### PR TITLE
feat(fabrika-cli): the six plan-epic ledger verbs

### DIFF
--- a/packages/fabrika-cli/src/exit-code-alignment.ts
+++ b/packages/fabrika-cli/src/exit-code-alignment.ts
@@ -98,6 +98,7 @@ export const ALIGNED_GROUPS: Readonly<Record<string, SharedSeats>> = {
 	build: BUILD_SEATS,
 	hook: HOOK_SEATS,
 	epic: BUILD_SEATS,
+	ledger: BUILD_SEATS,
 	plan: BUILD_SEATS,
 	triage: SHARED_SEATS,
 	review: SHARED_SEATS,

--- a/packages/fabrika-cli/src/exit-code-alignment.unit.test.ts
+++ b/packages/fabrika-cli/src/exit-code-alignment.unit.test.ts
@@ -11,6 +11,7 @@ import {
 	UNALIGNED_GROUPS,
 } from "./exit-code-alignment.ts";
 import * as hook from "./hook/codes.ts";
+import * as ledger from "./ledger/codes.ts";
 import * as plan from "./plan/codes.ts";
 import * as report from "./report/codes.ts";
 import * as review from "./review/codes.ts";
@@ -31,6 +32,7 @@ const TABLES: Readonly<Record<string, CodeTable>> = {
 	build,
 	epic,
 	hook,
+	ledger,
 	plan,
 	report,
 	review,

--- a/packages/fabrika-cli/src/ledger/child-body.ts
+++ b/packages/fabrika-cli/src/ledger/child-body.ts
@@ -1,0 +1,150 @@
+/**
+ * The child body: composed from what the author wrote, then validated through the gate's own readers.
+ *
+ * Every byte rule below is a v1 scar designed out, and the composition is a **normalization of the
+ * authored text**, never a re-rendering of it: the prose under `### What to build` is the author's and
+ * survives byte for byte. What the composer fixes is the shape the gate reads — the three field lines
+ * consecutive, one blank line before each `###` heading, no blank between `### Acceptance criteria`
+ * and its first bullet, a single trailing newline.
+ *
+ * `**Containment:**` is emitted **only** when the run's cycle-doc read is `present`. v1's documented
+ * spec template omitted the field entirely while its skill body required it, so an author following
+ * the template dropped it on every child and the tolerant read made "forgot" indistinguishable from
+ * "no cycle doc".
+ */
+
+import {
+	CONTAINMENT_FIELD,
+	type Containment,
+	fieldLines,
+	readChildStories,
+	readContainment,
+	STORIES_FIELD,
+} from "../plan/ledger.ts";
+import {read as readAcceptanceCriteria} from "../wire/acceptance-criteria.ts";
+import type {CycleDoc} from "./run.ts";
+
+const ACCEPTANCE_CRITERIA = "### Acceptance criteria";
+
+/** The three field-line spellings `fieldLines` recognises, matched here to drop or keep a whole line. */
+const fieldLineRe = (field: string): RegExp =>
+	new RegExp(
+		`^[ \\t]*(?:\\*\\*${field}:\\*\\*|\\*\\*${field}\\*\\*[ \\t]*:|${field}[ \\t]*:)`,
+		"i",
+	);
+
+const isFieldLine = (line: string): boolean =>
+	fieldLineRe("Stories").test(line) ||
+	fieldLineRe("TDD").test(line) ||
+	fieldLineRe(CONTAINMENT_FIELD).test(line);
+
+/**
+ * The authored text with the byte rules applied.
+ *
+ * Blank lines between consecutive field lines are dropped, every `###` heading is preceded by exactly
+ * one blank line, the acceptance-criteria heading is followed directly by its first item, and the
+ * result ends in exactly one newline.
+ */
+export const normalizeChildBody = (text: string, cycleDoc: CycleDoc): string => {
+	const dropContainment = cycleDoc !== "present";
+	const source = text
+		.replace(/\r\n/g, "\n")
+		.split("\n")
+		.map((line) => line.replace(/[ \t]+$/, ""))
+		.filter((line) => !(dropContainment && fieldLineRe(CONTAINMENT_FIELD).test(line)));
+
+	const collapsed: string[] = [];
+	for (const line of source) {
+		if (line === "" && (collapsed.at(-1) ?? "") === "") continue;
+		collapsed.push(line);
+	}
+	while ((collapsed[0] ?? "x") === "") collapsed.shift();
+	while (collapsed.length > 0 && (collapsed.at(-1) ?? "x") === "") collapsed.pop();
+
+	const out: string[] = [];
+	for (const [index, line] of collapsed.entries()) {
+		if (line === "") {
+			const before = out.at(-1) ?? "";
+			const after = collapsed[index + 1] ?? "";
+			if (isFieldLine(before) && isFieldLine(after)) continue;
+			if (before === ACCEPTANCE_CRITERIA) continue;
+			out.push(line);
+			continue;
+		}
+		if (line.startsWith("### ") && out.length > 0 && (out.at(-1) ?? "") !== "") out.push("");
+		out.push(line);
+	}
+	return `${out.join("\n")}\n`;
+};
+
+export interface ComposedChild {
+	readonly _tag: "Composed";
+	readonly body: string;
+	readonly stories: ReadonlyArray<number> | null;
+	readonly containment: Containment | null;
+	readonly criteria: number;
+}
+
+export type ChildBodyCheck = ComposedChild | {readonly _tag: "Bad"; readonly reason: string};
+
+const bad = (reason: string): ChildBodyCheck => ({_tag: "Bad", reason});
+
+export interface ChildBodyInput {
+	readonly text: string;
+	readonly cycleDoc: CycleDoc;
+	/** The `--type` label the child is born with; only `type:feature` owes a containment value. */
+	readonly type: string;
+}
+
+/**
+ * Compose and validate one child body.
+ *
+ * The readers are the gate's, imported: a body that composes here cannot fail the gate on grammar.
+ * `**Stories:**` carries bare integers or `none` and nothing else — v1 harvested every digit run in
+ * the value, so `1, 3 (see #4021)` silently claimed a story 4021 no epic declared.
+ */
+export const composeChildBody = (input: ChildBodyInput): ChildBodyCheck => {
+	const body = normalizeChildBody(input.text, input.cycleDoc);
+
+	for (const field of [STORIES_FIELD, "TDD", CONTAINMENT_FIELD]) {
+		const values = fieldLines(body, field);
+		if (values.length > 1) {
+			return bad(
+				`**${field}:** appears ${values.length} times — a child field line has one value, and the gate refuses a duplicate.`,
+			);
+		}
+	}
+
+	const storiesValue = fieldLines(body, STORIES_FIELD)[0];
+	const stories = readChildStories(storiesValue);
+	if (stories._tag === "NonConforming") {
+		return bad(
+			`**Stories:** value does not conform: "${stories.value}" — bare integers or "none".`,
+		);
+	}
+
+	const criteria = readAcceptanceCriteria(body);
+	if (criteria._tag !== "Found") {
+		return bad(
+			`acceptance criteria read as ${criteria._tag === "Absent" ? "absent" : "malformed"} — a child with no checkable criteria is not buildable.`,
+		);
+	}
+
+	const containmentValue = fieldLines(body, CONTAINMENT_FIELD)[0];
+	const containment = readContainment(containmentValue);
+	if (input.cycleDoc === "present" && input.type === "type:feature") {
+		if (containment !== "flag" && containment !== "exempt") {
+			return bad(
+				`type:feature child needs **Containment:** flag or exempt — got "${containmentValue ?? ""}", and the cycle doc is present.`,
+			);
+		}
+	}
+
+	return {
+		_tag: "Composed",
+		body,
+		stories: stories._tag === "Ids" ? stories.ids : null,
+		containment,
+		criteria: criteria.value.length,
+	};
+};

--- a/packages/fabrika-cli/src/ledger/child-body.unit.test.ts
+++ b/packages/fabrika-cli/src/ledger/child-body.unit.test.ts
@@ -1,0 +1,109 @@
+import {describe, expect, it} from "vitest";
+import {composeChildBody, normalizeChildBody} from "./child-body.ts";
+import {childBody} from "./fixtures.test-support.ts";
+
+const compose = (text: string, cycleDoc: "present" | "absent" | "unknown" = "present") =>
+	composeChildBody({text, cycleDoc, type: "type:feature"});
+
+describe("normalizeChildBody", () => {
+	it("makes the three field lines consecutive", () => {
+		const body = normalizeChildBody(
+			"**Stories:** 1\n\n**TDD:** yes\n\n**Containment:** flag\n\n### What to build\n\nx\n\n### Acceptance criteria\n- [ ] y\n",
+			"present",
+		);
+		expect(body.startsWith("**Stories:** 1\n**TDD:** yes\n**Containment:** flag\n\n")).toBe(true);
+	});
+
+	it("hugs the acceptance-criteria heading to its first item", () => {
+		const body = normalizeChildBody(
+			"**TDD:** yes\n\n### Acceptance criteria\n\n\n- [ ] y\n",
+			"absent",
+		);
+		expect(body).toContain("### Acceptance criteria\n- [ ] y");
+	});
+
+	it("puts exactly one blank line before each heading and ends in one newline", () => {
+		const body = normalizeChildBody(
+			"**TDD:** yes\n### What to build\nx\n\n\n### Acceptance criteria\n- [ ] y\n\n\n",
+			"absent",
+		);
+		expect(body).toBe("**TDD:** yes\n\n### What to build\nx\n\n### Acceptance criteria\n- [ ] y\n");
+	});
+
+	/**
+	 * The field is emitted only when the cycle doc is present. v1's template omitted it while its skill
+	 * body required it, so "forgot" and "no cycle doc" became indistinguishable.
+	 */
+	it("drops the containment line when the repo carries no cycle doc", () => {
+		expect(normalizeChildBody(childBody(), "absent")).not.toContain("**Containment:**");
+		expect(normalizeChildBody(childBody(), "present")).toContain("**Containment:**");
+	});
+});
+
+describe("composeChildBody", () => {
+	it("composes a conforming body and reports what the readers saw", () => {
+		expect(compose(childBody())).toMatchObject({
+			_tag: "Composed",
+			stories: [1, 2],
+			containment: "flag",
+			criteria: 1,
+		});
+	});
+
+	it('reads "none" as an explicit empty story claim', () => {
+		expect(compose(childBody({stories: "none"}))).toMatchObject({stories: []});
+	});
+
+	/** v1 harvested every digit run, so `1, 3 (see #4021)` silently claimed a story 4021. */
+	it("refuses a **Stories:** value that is not bare integers or none", () => {
+		expect(compose(childBody({stories: "1, 3 (see #4021)"}))).toEqual({
+			_tag: "Bad",
+			reason: '**Stories:** value does not conform: "1, 3 (see #4021)" — bare integers or "none".',
+		});
+	});
+
+	it("refuses a body with no acceptance criteria", () => {
+		expect(compose("**TDD:** yes\n\n### What to build\n\nx\n")).toMatchObject({
+			reason: expect.stringContaining("acceptance criteria read as absent"),
+		});
+	});
+
+	it("refuses a heading that reaches for the criteria block and misses", () => {
+		expect(compose("**TDD:** yes\n\n### Acceptance criteri\n- [ ] y\n")).toMatchObject({
+			reason: expect.stringContaining("acceptance criteria read as malformed"),
+		});
+	});
+
+	/** The gate's `MISSING_CONTAINMENT` treats `none` exactly as unset, so admitting it authors a defect. */
+	it("refuses a type:feature child whose containment is none while the cycle doc is present", () => {
+		expect(compose(childBody({containment: "none"}))).toMatchObject({
+			reason: expect.stringContaining("needs **Containment:** flag or exempt"),
+		});
+	});
+
+	it("refuses one whose containment line is missing entirely", () => {
+		expect(compose(childBody({containment: null}))).toMatchObject({
+			reason: expect.stringContaining("needs **Containment:** flag or exempt"),
+		});
+	});
+
+	it("asks nothing of containment when the cycle doc is absent", () => {
+		expect(compose(childBody({containment: null}), "absent")).toMatchObject({_tag: "Composed"});
+	});
+
+	it("asks nothing of containment on a child that is not a type:feature", () => {
+		expect(
+			composeChildBody({
+				text: childBody({containment: null}),
+				cycleDoc: "present",
+				type: "type:chore",
+			}),
+		).toMatchObject({_tag: "Composed"});
+	});
+
+	it("refuses a duplicated field line — the gate refuses it too", () => {
+		expect(compose(`**Stories:** 1\n${childBody()}`)).toMatchObject({
+			reason: expect.stringContaining("**Stories:** appears 2 times"),
+		});
+	});
+});

--- a/packages/fabrika-cli/src/ledger/child-verb.ts
+++ b/packages/fabrika-cli/src/ledger/child-verb.ts
@@ -1,0 +1,297 @@
+/**
+ * `ledger child` — mint one child with every birth attribute in one create, link it, re-read it,
+ * record it.
+ *
+ * **The manifest append sits before the link, deliberately.** A child recorded before its link is a
+ * child a successor can find and name, which is the whole of what the record buys — and it is enough,
+ * because the alternative is an issue that exists on GitHub and appears in no artifact this run
+ * produced. Under the reverse order a `23` leaves an issue that is absent from the manifest and can
+ * therefore be neither placed (`24`, dangling) nor retired (`10`, not a sub-issue) — created,
+ * unusable, and unreachable by every other verb in the group.
+ *
+ * `--ready-for` is required and has no default (#4780); `--ready-for human` requires `--assignee`
+ * (#4693) — the label is the routing signal, born-assignment is the enforced hold, and neither
+ * substitutes for the other. That pair is not merely a convention: the gate's floor reds
+ * `HELD_CHILD_UNASSIGNED` over the **whole epic**, so one held-and-unassigned child blocks every
+ * sibling.
+ */
+
+import {Effect, type FileSystem, type Path} from "effect";
+import type {ChildProcessSpawner} from "effect/unstable/process";
+import {readAuthored} from "../build/authored.ts";
+import {scannedLine} from "../build/target.ts";
+import {listLabels, listOpenMilestones} from "../io/issues.ts";
+import type {StdinRead} from "../io/stdin.ts";
+import {listSubIssues} from "../plan/github.ts";
+import {answer, refuse, type VerbOutcome} from "../verb.ts";
+import {composeChildBody} from "./child-body.ts";
+import {
+	BAD_SECTIONS,
+	LINK_UNPROVEN,
+	MANIFEST_UNWRITTEN,
+	OFF_VOCABULARY,
+	PRECONDITION_UNKNOWN,
+	READBACK_MISMATCH,
+	WRITE_UNKNOWN,
+} from "./codes.ts";
+import {createChildIssue, linkSubIssue, readChildBack} from "./github.ts";
+import {type LedgerMessages, type OpenOptions, openGround} from "./preconditions.ts";
+import type {ChildRecord} from "./run.ts";
+import {appendChild, loadManifest, loadRun, maskedLeakRefusal, rewriteChild} from "./run-io.ts";
+
+const VERB = "ledger child";
+
+/** The status every child is born carrying — the gate flips it, never a verb here. */
+const PLANNED = "status:planned";
+
+export const TYPES: ReadonlyArray<string> = [
+	"type:bug",
+	"type:feature",
+	"type:chore",
+	"type:decision",
+	"type:investigation",
+];
+
+/** `p3` is retired, not admitted (#4101, #2413). */
+export const PRIORITIES: ReadonlyArray<string> = ["p0", "p1", "p2"];
+
+export const AUDIENCES: ReadonlyArray<string> = ["human", "agent"];
+
+export const MESSAGES: LedgerMessages = {
+	verb: VERB,
+	notAnEpic: (epic) => `${VERB}: #${epic} is not a type:epic — refusing to mint a child of it.`,
+	unreadable: (what, reason) => `${VERB}: cannot read ${what}: ${reason} — nothing was created.`,
+	notAWorktree: `${VERB}: not in a linked worktree — the run manifest is unreachable.`,
+};
+
+export interface ChildOptions extends OpenOptions {
+	readonly title: string;
+	readonly type: string;
+	readonly priority: string;
+	/** Optional at the parser and refused here: an absent value is a decision nobody made (#4780). */
+	readonly readyFor: string | null;
+	readonly assignee: string | null;
+	readonly milestone: string | null;
+	readonly labels: ReadonlyArray<string>;
+	readonly stdin: Effect.Effect<StdinRead>;
+}
+
+export const runChild = (
+	options: ChildOptions,
+): Effect.Effect<
+	VerbOutcome,
+	never,
+	ChildProcessSpawner.ChildProcessSpawner | FileSystem.FileSystem | Path.Path
+> =>
+	Effect.gen(function* () {
+		if (options.readyFor === null) {
+			return refuse(
+				OFF_VOCABULARY,
+				`${VERB}: --ready-for is required — a child must never inherit its audience by omission (#4780).`,
+			);
+		}
+		if (!AUDIENCES.includes(options.readyFor)) {
+			return refuse(
+				OFF_VOCABULARY,
+				`${VERB}: --ready-for ${options.readyFor} is off the closed set (${AUDIENCES.join(", ")}).`,
+			);
+		}
+		if (options.readyFor === "human" && (options.assignee ?? "").trim() === "") {
+			return refuse(
+				OFF_VOCABULARY,
+				`${VERB}: --ready-for human requires --assignee — a held child is born assigned (#4693).`,
+			);
+		}
+		if (!TYPES.includes(options.type)) {
+			return refuse(
+				OFF_VOCABULARY,
+				`${VERB}: --type ${options.type} is off the closed set (${TYPES.join(", ")}).`,
+			);
+		}
+		if (!PRIORITIES.includes(options.priority)) {
+			return refuse(
+				OFF_VOCABULARY,
+				`${VERB}: --priority ${options.priority} is off the closed set (${PRIORITIES.join(", ")}).`,
+			);
+		}
+
+		const authored = readAuthored(
+			{
+				verb: VERB,
+				emptyMessage: `${VERB}: stdin held nothing — there is no child body to compose.`,
+				bareAtMessage: `${VERB}: the child body carries a bare @ path reference — it cannot be redacted.`,
+			},
+			yield* options.stdin,
+		);
+		if (authored._tag === "Refused") return authored.outcome;
+
+		const ground = yield* openGround(MESSAGES, options);
+		if (ground._tag === "Refused") return ground.outcome;
+		const {repo, epic, dir, notes} = ground;
+
+		const run = yield* loadRun(MESSAGES, dir, notes);
+		if (run._tag === "Refused") return run.outcome;
+
+		const composed = composeChildBody({
+			text: authored.text,
+			cycleDoc: run.value.cycleDoc,
+			type: options.type,
+		});
+		if (composed._tag === "Bad") return refuse(BAD_SECTIONS, `${VERB}: ${composed.reason}`, notes);
+
+		const leaked = maskedLeakRefusal(VERB, "child body", composed.body);
+		if (leaked !== null) return {...leaked, stderr: [...notes, ...leaked.stderr]};
+
+		const labels = [
+			options.type,
+			options.priority,
+			PLANNED,
+			`ready-for:${options.readyFor}`,
+			...options.labels,
+		];
+		const taxonomy = yield* listLabels(repo);
+		if (taxonomy._tag === "Failure") {
+			return refuse(
+				PRECONDITION_UNKNOWN,
+				MESSAGES.unreadable(`${repo}'s label taxonomy`, taxonomy.reason),
+				notes,
+			);
+		}
+		for (const label of labels) {
+			if (taxonomy.value.includes(label)) continue;
+			return refuse(
+				OFF_VOCABULARY,
+				`${VERB}: label "${label}" is absent from ${repo}'s taxonomy — refusing to create it (#4285).`,
+				notes,
+			);
+		}
+
+		let milestone: number | null = null;
+		if (options.milestone !== null) {
+			const milestones = yield* listOpenMilestones(repo);
+			if (milestones._tag === "Failure") {
+				return refuse(
+					PRECONDITION_UNKNOWN,
+					MESSAGES.unreadable(`${repo}'s open milestones`, milestones.reason),
+					notes,
+				);
+			}
+			const found = milestones.value.find((row) => row.title === options.milestone);
+			if (found === undefined) {
+				return refuse(
+					OFF_VOCABULARY,
+					`${VERB}: milestone "${options.milestone}" is not an open milestone of ${repo}.`,
+					notes,
+				);
+			}
+			milestone = found.number;
+		}
+
+		const assignees = options.assignee === null ? [] : [options.assignee];
+		const scanned = scannedLine(VERB, labels.length, "label", `taxonomy of ${repo} checked`);
+		const diagnostics = [...notes, scanned];
+
+		const created = yield* createChildIssue(repo, {
+			title: options.title,
+			body: composed.body,
+			labels,
+			milestone,
+			assignees,
+		});
+		if (created._tag === "Failure") {
+			return refuse(
+				WRITE_UNKNOWN,
+				`${VERB}: the create was attempted and its outcome could not be proven: ${created.reason} — UNKNOWN.`,
+				diagnostics,
+			);
+		}
+		const child = created.value;
+
+		const record: ChildRecord = {
+			number: child.number,
+			id: child.id,
+			title: options.title,
+			type: options.type,
+			priority: options.priority,
+			readyFor: options.readyFor,
+			stories: composed.stories,
+			containment: composed.containment,
+			linked: false,
+			mintedThisRun: true,
+		};
+		const recorded = yield* appendChild(dir, record);
+		if (recorded !== null) {
+			return refuse(
+				MANIFEST_UNWRITTEN,
+				`${VERB}: created #${child.number} and could not write the run manifest: ${recorded} — the child exists and this run holds no record of it.`,
+				diagnostics,
+			);
+		}
+
+		const unlinked = `${VERB}: created #${child.number} and could not prove the sub-issue link — the child exists, is recorded in the run manifest as linked:false, and is unlinked on GitHub.`;
+		const linked = yield* linkSubIssue(repo, epic.number, child.id);
+		if (linked._tag === "Failure") {
+			return refuse(LINK_UNPROVEN, unlinked, [...diagnostics, `${VERB}: ${linked.reason}.`]);
+		}
+
+		const observed = yield* readChildBack(repo, child.number);
+		if (observed._tag !== "Present") {
+			return refuse(
+				WRITE_UNKNOWN,
+				`${VERB}: created #${child.number} and could not re-read it — the outcome is UNKNOWN.`,
+				diagnostics,
+			);
+		}
+
+		const siblings = yield* listSubIssues(repo, epic.number);
+		if (siblings._tag === "Failure" || !siblings.value.includes(child.number)) {
+			return refuse(LINK_UNPROVEN, unlinked, [
+				...diagnostics,
+				`${VERB}: ${siblings._tag === "Failure" ? siblings.reason : `#${child.number} is not in #${epic.number}'s sub-issue list`}.`,
+			]);
+		}
+
+		const sentLabels = [...labels].sort();
+		const mismatch =
+			sentLabels.join(",") !== [...observed.value.labels].join(",") ||
+			[...assignees].sort().join(",") !== [...observed.value.assignees].join(",") ||
+			(options.milestone ?? null) !== observed.value.milestone;
+		if (mismatch) {
+			return refuse(
+				READBACK_MISMATCH,
+				`${VERB}: created #${child.number} and it does not read back as sent — it needs a human eye.`,
+				[
+					...diagnostics,
+					`${VERB}: sent labels ${sentLabels.join(", ")}; observed ${observed.value.labels.join(", ")}.`,
+				],
+			);
+		}
+
+		const manifest = yield* loadManifest(MESSAGES, dir, diagnostics);
+		if (manifest._tag === "Refused") return manifest.outcome;
+		const rewritten = yield* rewriteChild(dir, manifest.value, {...record, linked: true});
+		if (rewritten !== null) {
+			return refuse(
+				MANIFEST_UNWRITTEN,
+				`${VERB}: created #${child.number} and could not write the run manifest: ${rewritten} — the child exists and this run holds no record of it.`,
+				diagnostics,
+			);
+		}
+
+		return answer(
+			JSON.stringify({
+				answer: "minted",
+				epic: epic.number,
+				child: child.number,
+				linked: true,
+				observed: {
+					labels: observed.value.labels,
+					assignees: observed.value.assignees,
+					milestone: observed.value.milestone,
+				},
+				stories: composed.stories,
+				containment: composed.containment,
+			}),
+			diagnostics,
+		);
+	});

--- a/packages/fabrika-cli/src/ledger/child-verb.unit.test.ts
+++ b/packages/fabrika-cli/src/ledger/child-verb.unit.test.ts
@@ -1,0 +1,317 @@
+import {Effect, Layer} from "effect";
+import {describe, expect, it} from "vitest";
+import {LINKED} from "../build/fixtures.test-support.ts";
+import {errOut, fakeFs, fakeShell, okOut} from "../fakes.test-support.ts";
+import type {ExecResult} from "../io/exec.ts";
+import type {StdinRead} from "../io/stdin.ts";
+import {runChild} from "./child-verb.ts";
+import {
+	BAD_SECTIONS,
+	EMPTY_STDIN,
+	LEAKED_PATH,
+	LINK_UNPROVEN,
+	MANIFEST_UNWRITTEN,
+	OFF_VOCABULARY,
+	PRECONDITION_UNKNOWN,
+	READBACK_MISMATCH,
+	WRITE_UNKNOWN,
+} from "./codes.ts";
+import {bodyDigest} from "./digest.ts";
+import {
+	CLAIMED,
+	childBody,
+	childIssue,
+	DEFAULT_LABELS,
+	DIR,
+	env,
+	epic,
+	labelSet,
+	milestones,
+} from "./fixtures.test-support.ts";
+import {manifestPath, parseManifest, renderRunRecord, runJsonPath} from "./run.ts";
+
+const CREATE = /^gh api --method POST repos\/o\/r\/issues /;
+const LINK = /^gh api --method POST repos\/o\/r\/issues\/4300\/sub_issues/;
+const READBACK = /^gh api repos\/o\/r\/issues\/4301$/;
+const SUBS = /^gh api --paginate repos\/o\/r\/issues\/4300\/sub_issues/;
+const LABELS = /^gh api --paginate repos\/o\/r\/labels/;
+const MILESTONES = /^gh api --paginate repos\/o\/r\/milestones/;
+
+const MINTED_LABELS = ["type:feature", "p1", "status:planned", "ready-for:agent"];
+
+const RUN_JSON = (cycleDoc: "present" | "absent" | "unknown" = "present") =>
+	renderRunRecord({
+		epic: 4300,
+		run: "4300-c1a4d6f8",
+		mode: "fresh",
+		cycleDoc,
+		bodyDigest: bodyDigest("An epic brief about the moderation queue.\n"),
+	});
+
+const CREATED = okOut(JSON.stringify({number: 4301, id: 90210}));
+
+const HAPPY: ReadonlyArray<readonly [RegExp, ExecResult]> = [
+	[/^gh api repos\/o\/r\/issues\/4300$/, epic()],
+	[/^git rev-parse --path-format=absolute/, LINKED],
+	...CLAIMED,
+	[LABELS, labelSet(...DEFAULT_LABELS)],
+	[MILESTONES, milestones([44, "fabrika campaign"])],
+	[CREATE, CREATED],
+	[LINK, okOut("{}")],
+	[READBACK, childIssue({number: 4301, labels: MINTED_LABELS})],
+	[SUBS, okOut(JSON.stringify([{number: 4301, id: 90210}]))],
+];
+
+const options = {
+	number: 4300,
+	title: "queue view: fate loader",
+	type: "type:feature",
+	priority: "p1",
+	readyFor: "agent" as string | null,
+	assignee: null as string | null,
+	milestone: null as string | null,
+	labels: [] as ReadonlyArray<string>,
+	repo: null,
+	env,
+};
+
+const run = (
+	overrides: Partial<typeof options> = {},
+	script: ReadonlyArray<readonly [RegExp, ExecResult]> = HAPPY,
+	files: Readonly<Record<string, string | null>> = {[runJsonPath(DIR)]: RUN_JSON()},
+	body: string = childBody(),
+) => {
+	const shell = fakeShell(script);
+	const fs = fakeFs({files});
+	const stdin: Effect.Effect<StdinRead> = Effect.succeed({_tag: "Text", text: body});
+	return Effect.runPromise(
+		Effect.provide(
+			runChild({...options, ...overrides, stdin}),
+			Layer.mergeAll(shell.layer, fs.layer),
+		),
+	).then((outcome) => ({outcome, written: fs.written, calls: shell.calls}));
+};
+
+describe("runChild", () => {
+	it("mints, records, links, re-reads, and reports the OBSERVED result", async () => {
+		const {outcome, written} = await run();
+		expect(outcome.code).toBe(0);
+		expect(JSON.parse(outcome.stdout)).toEqual({
+			answer: "minted",
+			epic: 4300,
+			child: 4301,
+			linked: true,
+			observed: {labels: [...MINTED_LABELS].sort(), assignees: [], milestone: null},
+			stories: [1, 2],
+			containment: "flag",
+		});
+		expect(parseManifest(written.get(manifestPath(DIR)) ?? "")).toEqual([
+			{
+				number: 4301,
+				id: 90210,
+				title: "queue view: fate loader",
+				type: "type:feature",
+				priority: "p1",
+				readyFor: "agent",
+				stories: [1, 2],
+				containment: "flag",
+				linked: true,
+				mintedThisRun: true,
+			},
+		]);
+	});
+
+	/**
+	 * The whole reason the verb exists: v1's create hardcoded three labels with no pass-through and set
+	 * no milestone, so a fourth required label could only land by a follow-up PATCH — and that PATCH
+	 * opens a window in which the child exists with no `ready-for:` value at all.
+	 */
+	it("puts every birth attribute in the one POST", async () => {
+		const {calls} = await run({milestone: "fabrika campaign", labels: ["fabrika"]}, [
+			...HAPPY.filter(([pattern]) => pattern !== LABELS && pattern !== READBACK),
+			[LABELS, labelSet(...DEFAULT_LABELS, "fabrika")],
+			[
+				READBACK,
+				childIssue({
+					number: 4301,
+					labels: [...MINTED_LABELS, "fabrika"],
+					milestone: "fabrika campaign",
+				}),
+			],
+		]);
+		const create = calls.find((line) => CREATE.test(line)) ?? "";
+		for (const label of [...MINTED_LABELS, "fabrika"]) {
+			expect(create).toContain(`labels[]=${label}`);
+		}
+		expect(create).toContain("milestone=44");
+		expect(calls.filter((line) => line.startsWith("gh api --method PATCH")).length).toBe(0);
+	});
+
+	it("links on the child's id, not its number", async () => {
+		const {calls} = await run();
+		expect(calls.find((line) => LINK.test(line))).toContain("sub_issue_id=90210");
+	});
+
+	/** #4780: a child must never inherit its audience by omission. */
+	it("refuses an absent --ready-for before it reads anything", async () => {
+		const {outcome, calls} = await run({readyFor: null});
+		expect(outcome.code).toBe(OFF_VOCABULARY);
+		expect(outcome.stderr.at(-1)).toBe(
+			"ledger child: --ready-for is required — a child must never inherit its audience by omission (#4780).",
+		);
+		expect(calls).toEqual([]);
+	});
+
+	/** #4693: the label is the routing signal, born-assignment is the enforced hold. */
+	it("refuses --ready-for human without --assignee", async () => {
+		const {outcome} = await run({readyFor: "human"});
+		expect(outcome.code).toBe(OFF_VOCABULARY);
+		expect(outcome.stderr.at(-1)).toBe(
+			"ledger child: --ready-for human requires --assignee — a held child is born assigned (#4693).",
+		);
+	});
+
+	it("refuses a retired priority", async () => {
+		const {outcome} = await run({priority: "p3"});
+		expect(outcome.code).toBe(OFF_VOCABULARY);
+		expect(outcome.stderr.at(-1)).toContain("off the closed set (p0, p1, p2)");
+	});
+
+	/** #4285: `POST .../labels` CREATES an unknown label rather than rejecting it. */
+	it("refuses a label absent from the repo taxonomy rather than minting it", async () => {
+		const {outcome, calls} = await run({labels: ["not-a-label"]});
+		expect(outcome.code).toBe(OFF_VOCABULARY);
+		expect(outcome.stderr.at(-1)).toBe(
+			'ledger child: label "not-a-label" is absent from o/r\'s taxonomy — refusing to create it (#4285).',
+		);
+		expect(calls.some((line) => CREATE.test(line))).toBe(false);
+	});
+
+	it("refuses a milestone that is not open in the repo", async () => {
+		const {outcome} = await run({milestone: "Geçit"});
+		expect(outcome.code).toBe(OFF_VOCABULARY);
+		expect(outcome.stderr.at(-1)).toBe(
+			'ledger child: milestone "Geçit" is not an open milestone of o/r.',
+		);
+	});
+
+	it("refuses a body whose acceptance criteria are absent", async () => {
+		const {outcome} = await run({}, HAPPY, {[runJsonPath(DIR)]: RUN_JSON()}, "**TDD:** yes\n");
+		expect(outcome.code).toBe(BAD_SECTIONS);
+	});
+
+	it("refuses a type:feature child with no containment while the cycle doc is present", async () => {
+		const {outcome} = await run(
+			{},
+			HAPPY,
+			{[runJsonPath(DIR)]: RUN_JSON()},
+			childBody({containment: null}),
+		);
+		expect(outcome.code).toBe(BAD_SECTIONS);
+		expect(outcome.stderr.at(-1)).toContain("needs **Containment:** flag or exempt");
+	});
+
+	it("drops the containment line when the run's cycle-doc read is absent", async () => {
+		const {calls} = await run({}, HAPPY, {[runJsonPath(DIR)]: RUN_JSON("absent")});
+		const create = calls.find((line) => CREATE.test(line)) ?? "";
+		expect(create).not.toContain("**Containment:**");
+	});
+
+	it("refuses an empty pipe on its own code", async () => {
+		const {outcome} = await run({}, HAPPY, {[runJsonPath(DIR)]: RUN_JSON()}, "  \n");
+		expect(outcome.code).toBe(EMPTY_STDIN);
+	});
+
+	it("refuses a machine-local path in the child body", async () => {
+		const {outcome} = await run(
+			{},
+			HAPPY,
+			{[runJsonPath(DIR)]: RUN_JSON()},
+			childBody().replace("The queue view", "See /Users/someone/plan.md"),
+		);
+		expect(outcome.code).toBe(LEAKED_PATH);
+	});
+
+	it("refuses when a precondition read fails, and creates nothing", async () => {
+		const {outcome, calls} = await run({}, [
+			...HAPPY.filter(([pattern]) => pattern !== LABELS),
+			[LABELS, errOut("gh: Bad Gateway (HTTP 502)")],
+		]);
+		expect(outcome.code).toBe(PRECONDITION_UNKNOWN);
+		expect(calls.some((line) => CREATE.test(line))).toBe(false);
+	});
+
+	it("seats a create that could not be proven on 8", async () => {
+		const {outcome} = await run({}, [
+			...HAPPY.filter(([pattern]) => pattern !== CREATE),
+			[CREATE, errOut("gh: Bad Gateway (HTTP 502)")],
+		]);
+		expect(outcome.code).toBe(WRITE_UNKNOWN);
+	});
+
+	/**
+	 * The manifest append sits BEFORE the link: a `23` must leave a child a successor can find and
+	 * name. Under the reverse order the issue exists on GitHub, is absent from the manifest, and can
+	 * be neither placed nor retired.
+	 */
+	it("records the child before it links, so a 23 leaves a findable number", async () => {
+		const {outcome, written} = await run({}, [
+			...HAPPY.filter(([pattern]) => pattern !== LINK),
+			[LINK, errOut("gh: Unprocessable (HTTP 422)")],
+		]);
+		expect(outcome.code).toBe(LINK_UNPROVEN);
+		expect(outcome.stderr.at(-1)).toContain("recorded in the run manifest as linked:false");
+		expect(parseManifest(written.get(manifestPath(DIR)) ?? "")).toMatchObject([
+			{number: 4301, id: 90210, linked: false},
+		]);
+	});
+
+	it("seats an unprovable link on 23 even when the write itself returned", async () => {
+		const {outcome} = await run({}, [
+			...HAPPY.filter(([pattern]) => pattern !== SUBS),
+			[SUBS, okOut("[]")],
+		]);
+		expect(outcome.code).toBe(LINK_UNPROVEN);
+	});
+
+	it("seats a create it cannot re-read on 8", async () => {
+		const {outcome} = await run({}, [
+			...HAPPY.filter(([pattern]) => pattern !== READBACK),
+			[READBACK, errOut("gh: Bad Gateway (HTTP 502)")],
+		]);
+		expect(outcome.code).toBe(WRITE_UNKNOWN);
+	});
+
+	/** The observed labels decide, never the intent the write was issued with. */
+	it("refuses when the child does not read back as sent", async () => {
+		const {outcome} = await run({}, [
+			...HAPPY.filter(([pattern]) => pattern !== READBACK),
+			[READBACK, childIssue({number: 4301, labels: ["type:feature", "p1"]})],
+		]);
+		expect(outcome.code).toBe(READBACK_MISMATCH);
+	});
+
+	it("seats a manifest it could not write on 26, naming the number that now exists", async () => {
+		const shell = fakeShell(HAPPY);
+		const fs = fakeFs({
+			files: {[runJsonPath(DIR)]: RUN_JSON()},
+			unwritable: [manifestPath(DIR)],
+		});
+		const outcome = await Effect.runPromise(
+			Effect.provide(
+				runChild({
+					...options,
+					stdin: Effect.succeed({_tag: "Text", text: childBody()} as StdinRead),
+				}),
+				Layer.mergeAll(shell.layer, fs.layer),
+			),
+		);
+		expect(outcome.code).toBe(MANIFEST_UNWRITTEN);
+		expect(outcome.stderr.at(-1)).toContain("created #4301");
+	});
+
+	it("refuses when the run directory holds no run.json", async () => {
+		const {outcome} = await run({}, HAPPY, {});
+		expect(outcome.code).toBe(PRECONDITION_UNKNOWN);
+	});
+});

--- a/packages/fabrika-cli/src/ledger/codes.ts
+++ b/packages/fabrika-cli/src/ledger/codes.ts
@@ -1,0 +1,66 @@
+/**
+ * The one exit table the six `ledger` verbs allocate from.
+ *
+ * Three tiers, and the tier decides how a constant gets here rather than what it means:
+ *
+ * - `3`–`11` are `report`'s seats, reached through `build`'s re-exports so there is one hop, not two
+ *   tables to keep level. `ALIGNED_GROUPS` records the claim under `BUILD_SEATS` — *not*
+ *   `SHARED_SEATS`, which omits `BAD_SECTIONS`: three verbs here seat `4`, so under `SHARED_SEATS`
+ *   the checker would report `4` as a private code colliding with the base.
+ * - `12`–`19` are `build`'s, **re-exported verbatim**, because this group asserts the identical facts
+ *   (this process is in a linked worktree; this session holds this issue's claim) and a caller driving
+ *   both in one sweep must read one meaning for each. The re-export is selective and stops at `19`:
+ *   `13`, `14`, `16`, `17`, `18` and `19` are **never reached here** — this skill declares no
+ *   `--require-clean` flag, holds no lane branch, pushes nothing, runs no validation and derives no
+ *   readiness verdict — but carrying them keeps those seats occupied so a later verb here cannot
+ *   re-seat one.
+ * - `20`–`26` are this group's own. `build`'s `20`/`21` are deliberately **not** re-exported:
+ *   re-exporting `OUT_OF_FOCUS`/`AUDIENCE_NOT_AGENT` alongside these would put two names on one code in
+ *   one module, which `allocatedCodes` reports as drift. The rule this group follows, taken from
+ *   `plan/codes.ts` rather than re-derived: **import a code when two groups prove the same fact;
+ *   allocate freely when they do not.** No `build`, `epic` or `plan` verb can prove a fact about a
+ *   *plan being authored*, and an exit code is read off the command that produced it.
+ *
+ * `0`, `1`, `2` and `127` are reserved by the interface convention (`../verb.ts`, `../bin.ts`).
+ */
+
+export {
+	BAD_SECTIONS,
+	BARE_AT_PATH,
+	BLOCKED,
+	CLAIM_NOT_MINE,
+	DIRTY_TREE,
+	EMPTY_STDIN,
+	LEAKED_PATH,
+	NOT_A_WORKTREE,
+	OFF_VOCABULARY,
+	PRECONDITION_UNKNOWN,
+	READBACK_MISMATCH,
+	REF_NOT_MOVED,
+	UNSAFE_PUSH,
+	VALIDATION_RED,
+	WRITE_UNKNOWN,
+	WRONG_LANE,
+	ZERO_SCOPE,
+} from "../build/codes.ts";
+
+/** Proven: the worktree's base is behind `origin/main` — a plan derived here is derived on stale ground. */
+export const STALE_GROUND = 20;
+/** Proven: the epic body moved — the recomputed digest differs from `--body-digest`. */
+export const EPIC_MOVED = 21;
+/** Proven: the plan region is unresolvable — a duplicated anchor, or a mode the body contradicts. */
+export const REGION_UNRESOLVABLE = 22;
+/**
+ * Proven: the child was created and its sub-issue link could not be proven.
+ *
+ * Narrower and more useful than {@link WRITE_UNKNOWN} or {@link READBACK_MISMATCH}: the create is
+ * proven and the *link* is unknown, so a named child exists unlinked. Fusing it into `8` would leave a
+ * successor unable to tell "something may exist" from "#4302 exists and needs linking".
+ */
+export const LINK_UNPROVEN = 23;
+/** Proven: the declared topology is invalid — a cycle, a dangling ref, or an unplaced child. */
+export const TOPOLOGY_INVALID = 24;
+/** Proven: a document this verb must splice was never staged in this run. */
+export const NOT_STAGED = 25;
+/** Proven: a child was created and the run manifest could not record it. */
+export const MANIFEST_UNWRITTEN = 26;

--- a/packages/fabrika-cli/src/ledger/command.cli.test.ts
+++ b/packages/fabrika-cli/src/ledger/command.cli.test.ts
@@ -1,0 +1,64 @@
+/**
+ * The end-to-end half: `fabrika ledger` resolves, and so does every one of its six verbs.
+ *
+ * The reported defect was a group that answered `Unknown subcommand "ledger"` — a fact only a real
+ * process can settle, because the unit tests exercise the verbs directly and would pass against a
+ * group nobody registered.
+ */
+import {execFileSync} from "node:child_process";
+import {fileURLToPath} from "node:url";
+import {describe, expect, it} from "vitest";
+import {SUBPROCESS_TEST_TIMEOUT_MS} from "../test-budget.ts";
+
+const BIN = fileURLToPath(new URL("../bin.ts", import.meta.url));
+
+/** `FABRIKA_SKIP_INFER` pins the invocation to *this* copy rather than whatever the root pins. */
+const fabrika = (...args: ReadonlyArray<string>) => {
+	try {
+		return {
+			code: 0,
+			stdout: execFileSync(process.execPath, [BIN, ...args], {
+				encoding: "utf8",
+				env: {...process.env, FABRIKA_SKIP_INFER: "1"},
+				stdio: ["ignore", "pipe", "pipe"],
+			}),
+			stderr: "",
+		};
+	} catch (err) {
+		const failure = err as {status?: number; stdout?: string; stderr?: string};
+		return {code: failure.status ?? -1, stdout: failure.stdout ?? "", stderr: failure.stderr ?? ""};
+	}
+};
+
+describe("`fabrika ledger` is a registered group", {timeout: SUBPROCESS_TEST_TIMEOUT_MS}, () => {
+	it("resolves rather than answering Unknown subcommand", () => {
+		const run = fabrika("ledger");
+		expect(run.stderr).not.toMatch(/Unknown subcommand/);
+		expect(run.stdout).toContain("USAGE");
+	});
+
+	it("lists the group under the root index", () => {
+		expect(fabrika("--help").stdout).toMatch(/\bledger\b/);
+	});
+
+	it.each([
+		["open"],
+		["draft"],
+		["child"],
+		["topology"],
+		["write"],
+		["supersede"],
+	])("`ledger %s --help` exits 0 with its flags on stdout", (verb) => {
+		const run = fabrika("ledger", verb, "--help");
+		expect(run.code).toBe(0);
+		expect(run.stdout).toContain("USAGE");
+		expect(run.stderr).toBe("");
+	});
+
+	it("refuses an unknown verb in the group", () => {
+		const run = fabrika("ledger", "bogus");
+		expect(run.code).not.toBe(0);
+		expect(run.stderr).toMatch(/Unknown subcommand/);
+		expect(run.stdout).toBe("");
+	});
+});

--- a/packages/fabrika-cli/src/ledger/command.ts
+++ b/packages/fabrika-cli/src/ledger/command.ts
@@ -1,0 +1,233 @@
+/**
+ * The `ledger` verb group — `fabrika ledger <verb>`.
+ *
+ * The adapter and nothing else: it declares the flags (`--help` is the interface, so every flag carries
+ * a one-line description), runs the pure verb, and emits its outcome. Every decision lives in the
+ * `*-verb.ts` modules beside it, which is what makes each refusal testable without spawning a process.
+ *
+ * **Every leaf is declared with `leafCommand`, never a bare `Command.make`** — the bare form silently
+ * opts out of the excess-operand guard, which `../excess-operand.unit.test.ts` reds on.
+ *
+ * **`--ready-for` is optional at the parser and refused in the verb body.** A parser-required flag's
+ * absence is exit `1`, indistinguishable from a typo; an absent audience is a decision nobody made
+ * (#4780), which must be provable as `10`. `--body-digest`, `--child` and `--title` stay
+ * parser-required, because their absence is an ordinary usage error with no semantic content and their
+ * fail-open risk is a *wrong* value — which is `21` and `10` respectively, not a missing one.
+ */
+
+import {Effect, Option} from "effect";
+import {Argument, Command, Flag} from "effect/unstable/cli";
+import {leafCommand} from "../excess-operand.ts";
+import {readStdin} from "../io/stdin.ts";
+import type {VerbOutcome} from "../verb.ts";
+import {runChild} from "./child-verb.ts";
+import {runDraft} from "./draft-verb.ts";
+import {runOpen} from "./open-verb.ts";
+import {runSupersede} from "./supersede-verb.ts";
+import {runTopology} from "./topology-verb.ts";
+import {runWrite} from "./write-verb.ts";
+
+/** Write the outcome and exit on its code — stdout is the answer, everything else is stderr. */
+const emit = (outcome: VerbOutcome): Effect.Effect<void> =>
+	Effect.sync(() => {
+		for (const line of outcome.stderr) process.stderr.write(`${line}\n`);
+		if (outcome.stdout !== "") process.stdout.write(outcome.stdout);
+		process.exit(outcome.code);
+	});
+
+const repoFlag = Flag.string("repo").pipe(
+	Flag.optional,
+	Flag.withDescription(
+		"the target owner/name (default: $CLAUDE_PIPELINE_REPO, else $GITHUB_REPOSITORY, else the origin remote)",
+	),
+);
+
+const epicArg = Argument.integer("number").pipe(
+	Argument.withDescription("the epic this verb plans"),
+);
+
+const bodyDigestFlag = Flag.string("body-digest").pipe(
+	Flag.withDescription(
+		"the 12-lowercase-hex body digest `ledger open` printed; the verb recomputes it from the live body and refuses on 21 if the epic moved",
+	),
+);
+
+const stdin = Effect.sync(readStdin);
+
+const open = leafCommand(
+	"open",
+	{number: epicArg, repo: repoFlag},
+	Effect.fn(function* ({number, repo}) {
+		yield* emit(yield* runOpen({number, repo: Option.getOrNull(repo), env: process.env}));
+	}),
+).pipe(
+	Command.withDescription(
+		'Prove the ground fresh, allocate the run directory (keyed on the claim nonce, never the session), read the epic\'s existing children, probe the cycle doc, and rank duplicate candidates. Prints {"answer":"opened","epic":n,"run":"…","mode":"fresh|re-plan","bodyDigest":"…","dir":"…","children":[…],"cycleDoc":"present|absent|unknown","candidates":{"outcome":"candidates|none|indeterminate","items":[…]}}. Carry bodyDigest to `ledger draft` and `ledger write`. Exits 7 (the epic is proven absent or closed), 10 (not a type:epic), 11 (the epic, its sub-issue list, the backlog, the cycle-doc probe or the freshness probe could not be read), 12 (not in a linked worktree), 15 (this session does not hold the epic\'s claim), 20 (the base is proven behind origin/main), 22 (two or more "## Plan (plan-epic)" headings — the mode has no single meaning). Example: fabrika ledger open 4300',
+	),
+);
+
+const draft = leafCommand(
+	"draft",
+	{number: epicArg, bodyDigest: bodyDigestFlag, repo: repoFlag},
+	Effect.fn(function* ({number, bodyDigest, repo}) {
+		yield* emit(
+			yield* runDraft({
+				number,
+				bodyDigest,
+				repo: Option.getOrNull(repo),
+				env: process.env,
+				stdin,
+			}),
+		);
+	}),
+).pipe(
+	Command.withDescription(
+		'Validate the plan block on STDIN against the closed section set and the story grammar, then stage it in the run directory. Prints {"answer":"staged","epic":n,"document":"plan","sections":10,"stories":[…],"bytes":n}. It does not judge content — a "### Approach" reading TBD stages cleanly. Exits 3 (stdin held nothing), 4 (a required ### section is missing, duplicated or out of order; the block does not open with "## Plan (plan-epic)"; zero user stories; or story ids that are not contiguous from 1), 5 (machine-local path), 6 (bare @ reference), 7 (the epic is proven absent or closed), 10 (not a type:epic, or --body-digest is not 12 lowercase hex), 11 (a read failed — nothing was staged), 12 (not in a linked worktree), 15 (this session does not hold the claim), 21 (the epic body moved since open). Example: fabrika ledger draft 4300 --body-digest 8f2c1a90b4d7 < plan.md',
+	),
+);
+
+const child = leafCommand(
+	"child",
+	{
+		number: epicArg,
+		title: Flag.string("title").pipe(
+			Flag.withDescription("the child's title; it carries no type or priority prefix"),
+		),
+		type: Flag.string("type").pipe(
+			Flag.withDescription(
+				"the child's type label: type:bug | type:feature | type:chore | type:decision | type:investigation",
+			),
+		),
+		priority: Flag.string("priority").pipe(
+			Flag.withDescription(
+				"the child's priority label: p0 | p1 | p2 (p3 is retired, not admitted)",
+			),
+		),
+		readyFor: Flag.string("ready-for").pipe(
+			Flag.optional,
+			Flag.withDescription(
+				"the child's audience: human | agent. Optional at the parser and REFUSED on 10 when absent — a child never inherits its audience by omission (#4780)",
+			),
+		),
+		assignee: Flag.string("assignee").pipe(
+			Flag.optional,
+			Flag.withDescription(
+				"the login a held child is born assigned to; required with --ready-for human (#4693)",
+			),
+		),
+		milestone: Flag.string("milestone").pipe(
+			Flag.optional,
+			Flag.withDescription(
+				"the title of an open milestone; absent mints an unhomed child the repo's homing guard will red",
+			),
+		),
+		label: Flag.string("label").pipe(
+			Flag.atLeast(0),
+			Flag.withDescription(
+				"a further label applied in the same create call; repeatable, and every value must already exist in the repo taxonomy (#4285)",
+			),
+		),
+		repo: repoFlag,
+	},
+	Effect.fn(function* ({
+		number,
+		title,
+		type,
+		priority,
+		readyFor,
+		assignee,
+		milestone,
+		label,
+		repo,
+	}) {
+		yield* emit(
+			yield* runChild({
+				number,
+				title,
+				type,
+				priority,
+				readyFor: Option.getOrNull(readyFor),
+				assignee: Option.getOrNull(assignee),
+				milestone: Option.getOrNull(milestone),
+				labels: label,
+				repo: Option.getOrNull(repo),
+				env: process.env,
+				stdin,
+			}),
+		);
+	}),
+).pipe(
+	Command.withDescription(
+		'Mint one child with EVERY birth attribute in the one POST — title, body, every label, milestone and assignee — record it in the run manifest, link it as a native sub-issue, then re-read and report the OBSERVED result. Prints {"answer":"minted","epic":n,"child":n,"linked":true,"observed":{…},"stories":[…],"containment":"…"}. Exits 3 (stdin held nothing), 4 (the composed body\'s fields or sections do not parse: a malformed **Stories:** value, absent or malformed acceptance criteria, or a type:feature child whose **Containment:** is missing, unset or none while the cycle doc is present), 5 (machine-local path), 6 (bare @ reference), 7 (the epic is proven absent or closed), 8 (the create was attempted and no re-read could prove it — UNKNOWN), 9 (created and it does not read back as sent), 10 (a label, --type, --priority, --milestone or --ready-for off its closed vocabulary; --ready-for absent; --ready-for human without --assignee; or not a type:epic), 11 (a precondition read failed — NOTHING was created), 12 (not in a linked worktree), 15 (this session does not hold the claim), 23 (created and the sub-issue link could not be proven), 26 (created and the run manifest could not be written). Example: fabrika ledger child 4300 --title "queue view: fate loader" --type type:feature --priority p1 --ready-for agent < child.md',
+	),
+);
+
+const topology = leafCommand(
+	"topology",
+	{number: epicArg, repo: repoFlag},
+	Effect.fn(function* ({number, repo}) {
+		yield* emit(
+			yield* runTopology({number, repo: Option.getOrNull(repo), env: process.env, stdin}),
+		);
+	}),
+).pipe(
+	Command.withDescription(
+		'Validate the topology declared on STDIN — one "#<ref> phase <n> [requires #<a>, #<b>]" line per child, order-indifferent — against the run manifest, render the "## Dependencies" block, and parse it back through the shipped reader before staging it. Prints {"answer":"staged","epic":n,"document":"topology","phases":n,"children":n,"edges":[["#4303","#4301"]],"bytes":n}. It cannot see a shared-file conflict — whether two children in one phase write the same module is the skill\'s judgment (#3709). Exits 3 (stdin held nothing), 4 (a line does not parse), 7 (the epic is proven absent or closed, or the run manifest holds zero children), 10 (not a type:epic, or a phase is not a positive integer), 11 (a read failed — nothing was staged), 12 (not in a linked worktree), 15 (this session does not hold the claim), 24 (a cycle, a reference to a non-child, a manifest child placed nowhere, or a rendered block that does not parse back to the declared edges). Example: fabrika ledger topology 4300 < topo.txt',
+	),
+);
+
+const write = leafCommand(
+	"write",
+	{number: epicArg, bodyDigest: bodyDigestFlag, repo: repoFlag},
+	Effect.fn(function* ({number, bodyDigest, repo}) {
+		yield* emit(
+			yield* runWrite({number, bodyDigest, repo: Option.getOrNull(repo), env: process.env}),
+		);
+	}),
+).pipe(
+	Command.withDescription(
+		'Splice the staged plan and topology into the epic body in one PATCH, then re-read and compare the WHOLE normalized body. The plan region is resolved through the verb-written enrichment marker, never by position, and is never cut to end-of-file (#4879). mode is carried from `ledger open`, never re-derived. Prints {"answer":"written","epic":n,"mode":"…","bodyDigest":"…","newDigest":"…","planBytes":n,"topologyBytes":n,"verified":true}. Exits 7 (the epic is proven absent or closed), 8 (the PATCH was issued and could not be confirmed — UNKNOWN), 9 (written and it does not read back as composed), 10 (not a type:epic, or --body-digest is not 12 lowercase hex), 11 (a read failed — NOTHING was written), 12 (not in a linked worktree), 15 (this session does not hold the claim), 21 (the epic body moved since open), 22 (the plan region is unresolvable), 25 (plan.md or topology.md was never staged in this run). Example: fabrika ledger write 4300 --body-digest 8f2c1a90b4d7',
+	),
+);
+
+const supersede = leafCommand(
+	"supersede",
+	{
+		number: epicArg,
+		child: Flag.integer("child").pipe(Flag.withDescription("the child being retired")),
+		reason: Flag.string("reason").pipe(
+			Flag.withDescription("why it is retired; posted verbatim as the journal comment"),
+		),
+		repo: repoFlag,
+	},
+	Effect.fn(function* ({number, child: childNumber, reason, repo}) {
+		yield* emit(
+			yield* runSupersede({
+				number,
+				child: childNumber,
+				reason,
+				repo: Option.getOrNull(repo),
+				env: process.env,
+			}),
+		);
+	}),
+).pipe(
+	Command.withDescription(
+		'Retire a child the re-plan no longer contains: comment, unlink, close as not_planned — in that order, so a child is never closed while still linked — then re-read and prove it. Prints {"answer":"superseded","epic":n,"child":n,"comment":id,"unlinked":true,"state":"closed"}. Refuses a child that is not this epic\'s sub-issue, and one this run minted. Exits 5 (the reason carries a machine-local path), 6 (bare @ reference), 7 (the epic or the child is proven absent or closed), 8 (a leg was attempted and its outcome could not be proven), 9 (the legs landed and the child does not read back closed and unlinked), 10 (not a type:epic; --child is not a sub-issue of it; or --child was minted by this run), 11 (a precondition read failed — nothing was written), 12 (not in a linked worktree), 15 (this session does not hold the claim). Example: fabrika ledger supersede 4300 --child 4288 --reason "folded into the loader slice"',
+	),
+);
+
+export const ledgerCommand = Command.make("ledger").pipe(
+	Command.withSubcommands([
+		// One leaf per line, so concurrent slices append at distinct lines rather than all editing one.
+		open,
+		draft,
+		child,
+		topology,
+		write,
+		supersede,
+	]),
+	Command.withDescription(
+		"Author an epic's plan: open the run on proven-fresh ground, stage the plan block, mint each child born complete and linked, declare the dependency topology, and splice both into the epic body",
+	),
+);

--- a/packages/fabrika-cli/src/ledger/digest.ts
+++ b/packages/fabrika-cli/src/ledger/digest.ts
@@ -1,0 +1,32 @@
+/**
+ * The body digest: the first 12 lowercase hex of the SHA-256 of the epic's body, taken **after**
+ * `normalizeForReadback`.
+ *
+ * `ledger open` prints it; `ledger draft` and `ledger write` require it as `--body-digest`, re-read the
+ * live body, recompute, and refuse on `21` if it differs. The gap between deciding and writing is
+ * closed by re-deciding, not by trusting.
+ *
+ * **Normalizing before hashing is a scar fix, not tidiness (#4599).** v1's splice round-trip compared
+ * raw bytes while its only caller captured stdout through command substitution, which strips every
+ * trailing newline before the PATCH — so what GitHub stored was never what was emitted and the
+ * comparison was structurally unwinnable. Hashing the normalized form makes a trailing-newline round
+ * trip a match instead of a false `21` on every clean run.
+ *
+ * The digest covers the body text and nothing else. Unlike the sibling gate's scope digest it is
+ * deliberately *not* neutral to its own guarded write: `ledger write` is the run's last write, so
+ * neutrality would buy nothing and would require excluding the very bytes being verified.
+ */
+
+import {createHash} from "node:crypto";
+import {normalizeForReadback} from "../report/compose.ts";
+
+export const DIGEST_LENGTH = 12;
+
+/** 12 lowercase hex — the one shape `--body-digest` accepts, so a mistyped value refuses before any read. */
+export const BODY_DIGEST_RE = /^[0-9a-f]{12}$/;
+
+export const bodyDigest = (body: string): string =>
+	createHash("sha256")
+		.update(normalizeForReadback(body), "utf8")
+		.digest("hex")
+		.slice(0, DIGEST_LENGTH);

--- a/packages/fabrika-cli/src/ledger/draft-verb.ts
+++ b/packages/fabrika-cli/src/ledger/draft-verb.ts
@@ -1,0 +1,104 @@
+/**
+ * `ledger draft` — validate and stage the model-authored plan block.
+ *
+ * A total grammar check over a closed section set, and nothing more. Whether the plan is any *good* is
+ * irreducibly the skill's: a `### Approach` reading "TBD" stages cleanly. What this verb refuses is
+ * the class an author cannot see — v1's section set lived only in prose, so drift produced a `Corrupt`
+ * splice refusal much later with no statement of which section was wrong.
+ *
+ * The digest is compared against the `--body-digest` **flag** and nothing else. Falling back to the
+ * value recorded on `run.json` would compare the plan against itself and make the moved-epic check
+ * vacuous.
+ */
+
+import {Effect, type FileSystem, type Path} from "effect";
+import type {ChildProcessSpawner} from "effect/unstable/process";
+import {readAuthored} from "../build/authored.ts";
+import {scannedLine} from "../build/target.ts";
+import type {StdinRead} from "../io/stdin.ts";
+import {answer, refuse, type VerbOutcome} from "../verb.ts";
+import {BAD_SECTIONS, EPIC_MOVED, OFF_VOCABULARY, PRECONDITION_UNKNOWN} from "./codes.ts";
+import {BODY_DIGEST_RE, bodyDigest} from "./digest.ts";
+import {checkPlanBlock} from "./plan-block.ts";
+import {type LedgerMessages, type OpenOptions, openGround} from "./preconditions.ts";
+import {planPath} from "./run.ts";
+import {loadRun, maskedLeakRefusal, stage} from "./run-io.ts";
+
+const VERB = "ledger draft";
+
+export const MESSAGES: LedgerMessages = {
+	verb: VERB,
+	notAnEpic: (epic) => `${VERB}: #${epic} is not a type:epic — refusing to stage a plan for it.`,
+	unreadable: (what, reason) => `${VERB}: cannot read ${what}: ${reason} — nothing was staged.`,
+	notAWorktree: `${VERB}: not in a linked worktree — the run directory is unreachable.`,
+};
+
+export interface DraftOptions extends OpenOptions {
+	readonly bodyDigest: string;
+	readonly stdin: Effect.Effect<StdinRead>;
+}
+
+export const runDraft = (
+	options: DraftOptions,
+): Effect.Effect<
+	VerbOutcome,
+	never,
+	ChildProcessSpawner.ChildProcessSpawner | FileSystem.FileSystem | Path.Path
+> =>
+	Effect.gen(function* () {
+		if (!BODY_DIGEST_RE.test(options.bodyDigest)) {
+			return refuse(
+				OFF_VOCABULARY,
+				`${VERB}: --body-digest must be 12 lowercase hex — got "${options.bodyDigest}".`,
+			);
+		}
+
+		const authored = readAuthored(
+			{
+				verb: VERB,
+				emptyMessage: `${VERB}: stdin held nothing — there is no plan to stage.`,
+				bareAtMessage: `${VERB}: the plan text carries a bare @ path reference — it cannot be redacted.`,
+			},
+			yield* options.stdin,
+		);
+		if (authored._tag === "Refused") return authored.outcome;
+
+		const ground = yield* openGround(MESSAGES, options);
+		if (ground._tag === "Refused") return ground.outcome;
+		const {epic, dir, notes} = ground;
+
+		const run = yield* loadRun(MESSAGES, dir, notes);
+		if (run._tag === "Refused") return run.outcome;
+
+		const observed = bodyDigest(epic.body);
+		if (observed !== options.bodyDigest) {
+			return refuse(
+				EPIC_MOVED,
+				`${VERB}: the epic body moved since open (digest ${options.bodyDigest} → ${observed}) — re-open before staging.`,
+				notes,
+			);
+		}
+
+		const checked = checkPlanBlock(authored.text);
+		if (checked._tag === "Bad") return refuse(BAD_SECTIONS, `${VERB}: ${checked.reason}`, notes);
+
+		const leaked = maskedLeakRefusal(VERB, "plan text", authored.text);
+		if (leaked !== null) return {...leaked, stderr: [...notes, ...leaked.stderr]};
+
+		const failed = yield* stage(planPath(dir), authored.text);
+		if (failed !== null) {
+			return refuse(PRECONDITION_UNKNOWN, MESSAGES.unreadable(planPath(dir), failed), notes);
+		}
+
+		return answer(
+			JSON.stringify({
+				answer: "staged",
+				epic: epic.number,
+				document: "plan",
+				sections: checked.sections,
+				stories: checked.stories,
+				bytes: authored.bytes,
+			}),
+			[...notes, scannedLine(VERB, checked.sections, "plan section")],
+		);
+	});

--- a/packages/fabrika-cli/src/ledger/draft-verb.unit.test.ts
+++ b/packages/fabrika-cli/src/ledger/draft-verb.unit.test.ts
@@ -1,0 +1,186 @@
+import {Effect, Layer} from "effect";
+import {describe, expect, it} from "vitest";
+import {LINKED, PRIMARY} from "../build/fixtures.test-support.ts";
+import {fakeFs, fakeShell} from "../fakes.test-support.ts";
+import type {ExecResult} from "../io/exec.ts";
+import type {StdinRead} from "../io/stdin.ts";
+import {
+	BAD_SECTIONS,
+	BARE_AT_PATH,
+	EMPTY_STDIN,
+	EPIC_MOVED,
+	LEAKED_PATH,
+	NOT_A_WORKTREE,
+	OFF_VOCABULARY,
+	PRECONDITION_UNKNOWN,
+} from "./codes.ts";
+import {bodyDigest} from "./digest.ts";
+import {runDraft} from "./draft-verb.ts";
+import {CLAIMED, DIR, env, epic, planBlock} from "./fixtures.test-support.ts";
+import {planPath, renderRunRecord, runJsonPath} from "./run.ts";
+
+const EPIC_BODY = "An epic brief about the moderation queue.\n";
+const DIGEST = bodyDigest(EPIC_BODY);
+
+const GROUND: ReadonlyArray<readonly [RegExp, ExecResult]> = [
+	[/^gh api repos\/o\/r\/issues\/4300$/, epic()],
+	[/^git rev-parse --path-format=absolute/, LINKED],
+	...CLAIMED,
+];
+
+const RUN_JSON = renderRunRecord({
+	epic: 4300,
+	run: "4300-c1a4d6f8",
+	mode: "fresh",
+	cycleDoc: "present",
+	bodyDigest: DIGEST,
+});
+
+const text = (value: string): Effect.Effect<StdinRead> =>
+	Effect.succeed({_tag: "Text", text: value});
+
+const run = (
+	stdin: Effect.Effect<StdinRead>,
+	options: {
+		digest?: string;
+		script?: ReadonlyArray<readonly [RegExp, ExecResult]>;
+		files?: Readonly<Record<string, string | null>>;
+	} = {},
+) => {
+	const shell = fakeShell(options.script ?? GROUND);
+	const fs = fakeFs({files: options.files ?? {[runJsonPath(DIR)]: RUN_JSON}});
+	return Effect.runPromise(
+		Effect.provide(
+			runDraft({
+				number: 4300,
+				bodyDigest: options.digest ?? DIGEST,
+				repo: null,
+				env,
+				stdin,
+			}),
+			Layer.mergeAll(shell.layer, fs.layer),
+		),
+	).then((outcome) => ({outcome, written: fs.written}));
+};
+
+describe("runDraft", () => {
+	it("stages the plan and reports what it validated", async () => {
+		const block = planBlock();
+		const {outcome, written} = await run(text(block));
+		expect(outcome.code).toBe(0);
+		expect(JSON.parse(outcome.stdout)).toMatchObject({
+			answer: "staged",
+			epic: 4300,
+			document: "plan",
+			sections: 10,
+			stories: [1, 2],
+		});
+		expect(written.get(planPath(DIR))).toBe(block);
+	});
+
+	it("refuses a plan block off the section set", async () => {
+		const {outcome} = await run(text(planBlock({drop: "Approach"})));
+		expect(outcome.code).toBe(BAD_SECTIONS);
+		expect(outcome.stdout).toBe("");
+	});
+
+	it("refuses a plan declaring zero stories before it can reach the gate", async () => {
+		const {outcome} = await run(text(planBlock({stories: "- a bullet story"})));
+		expect(outcome.code).toBe(BAD_SECTIONS);
+		expect(outcome.stderr.at(-1)).toContain("zero user stories");
+	});
+
+	/** An unread pipe is UNKNOWN and seats on `1`; a read-but-empty one is a proven `3`. */
+	it("separates an empty pipe from an unread one", async () => {
+		const {outcome: empty} = await run(text("   \n"));
+		expect(empty.code).toBe(EMPTY_STDIN);
+		const {outcome: unread} = await run(
+			Effect.succeed({_tag: "Failed", reason: "EAGAIN"} as StdinRead),
+		);
+		expect(unread.code).toBe(1);
+	});
+
+	it("refuses a machine-local path, masked in the refusal", async () => {
+		const {outcome} = await run(
+			text(
+				planBlock().replace("Something true about this section.", "see /Users/someone/notes.md"),
+			),
+		);
+		expect(outcome.code).toBe(LEAKED_PATH);
+		expect(outcome.stderr.join("\n")).toContain("/Users/<redacted>");
+		expect(outcome.stderr.join("\n")).not.toContain("someone");
+	});
+
+	it("refuses a bare @ path reference on its own code", async () => {
+		const {outcome} = await run(text("@some/path/plan.md"));
+		expect(outcome.code).toBe(BARE_AT_PATH);
+	});
+
+	it("refuses a malformed --body-digest before any read", async () => {
+		const {outcome} = await run(text(planBlock()), {digest: "nope"});
+		expect(outcome.code).toBe(OFF_VOCABULARY);
+		expect(outcome.stderr.at(-1)).toBe(
+			'ledger draft: --body-digest must be 12 lowercase hex — got "nope".',
+		);
+	});
+
+	/** The gap between deciding and writing is closed by re-deciding, not by trusting. */
+	it("refuses when the epic body moved since open", async () => {
+		const {outcome, written} = await run(text(planBlock()), {digest: "0123456789ab"});
+		expect(outcome.code).toBe(EPIC_MOVED);
+		expect(written.size).toBe(0);
+	});
+
+	/** A run.json that is absent is UNKNOWN, never assumed fresh. */
+	it("refuses when the run directory holds no run.json", async () => {
+		const {outcome} = await run(text(planBlock()), {files: {}});
+		expect(outcome.code).toBe(PRECONDITION_UNKNOWN);
+	});
+
+	it("refuses an unparseable run.json for the same reason", async () => {
+		const {outcome} = await run(text(planBlock()), {files: {[runJsonPath(DIR)]: "{}"}});
+		expect(outcome.code).toBe(PRECONDITION_UNKNOWN);
+	});
+
+	it("refuses the primary checkout", async () => {
+		const {outcome} = await run(text(planBlock()), {
+			script: [
+				[/^gh api repos\/o\/r\/issues\/4300$/, epic()],
+				[/^git rev-parse --path-format=absolute/, PRIMARY],
+				...CLAIMED,
+			],
+		});
+		expect(outcome.code).toBe(NOT_A_WORKTREE);
+		expect(outcome.stderr.at(-1)).toBe(
+			"ledger draft: not in a linked worktree — the run directory is unreachable.",
+		);
+	});
+
+	it("refuses an issue that is not a type:epic", async () => {
+		const {outcome} = await run(text(planBlock()), {
+			script: [
+				[/^gh api repos\/o\/r\/issues\/4300$/, epic({labels: [{name: "type:chore"}]})],
+				[/^git rev-parse --path-format=absolute/, LINKED],
+				...CLAIMED,
+			],
+		});
+		expect(outcome.code).toBe(OFF_VOCABULARY);
+		expect(outcome.stderr.at(-1)).toBe(
+			"ledger draft: #4300 is not a type:epic — refusing to stage a plan for it.",
+		);
+	});
+
+	it("re-staging replaces the previous document", async () => {
+		const {written} = await run(text(planBlock()), {
+			files: {[runJsonPath(DIR)]: RUN_JSON, [planPath(DIR)]: "an older plan\n"},
+		});
+		expect(written.get(planPath(DIR))).toBe(planBlock());
+	});
+
+	it("stages a plan whose sections say nothing — content is the skill's judgment", async () => {
+		const {outcome} = await run(
+			text(planBlock().replace(/Something true about this section\./g, "TBD")),
+		);
+		expect(outcome.code).toBe(0);
+	});
+});

--- a/packages/fabrika-cli/src/ledger/fixtures.test-support.ts
+++ b/packages/fabrika-cli/src/ledger/fixtures.test-support.ts
@@ -1,0 +1,154 @@
+/**
+ * The canned `gh` and `git` responses the `ledger` verb tests script their spawner with.
+ *
+ * Shaped like the real payloads rather than like the parsers, so a parser that starts reading a
+ * different field still has to find it here — a fixture trimmed to exactly what the code reads today
+ * stops being able to catch tomorrow's misread. The sub-issue payload carries `id` alongside `number`
+ * for the same reason the link and unlink take it: it is the field the relation is keyed on.
+ */
+
+import {comments, LANE_UUID, marker, NONCE} from "../build/fixtures.test-support.ts";
+import {okOut} from "../fakes.test-support.ts";
+import type {ExecResult} from "../io/exec.ts";
+import {PLAN_SECTIONS} from "./plan-block.ts";
+import {runDir, runKey} from "./run.ts";
+
+export const EPIC = 4300;
+export const SESSION = "s-9f2e";
+export const REPO = "o/r";
+/** The tree root `LINKED` names — every run path in these tests hangs off it. */
+export const WORKTREE = "/repo/trees/lane-a";
+export const GIT_DIR = "/repo/.git/worktrees/lane-a";
+export const DIR = runDir(WORKTREE, runKey(EPIC, NONCE));
+export const EXCLUDE_PATH = `${GIT_DIR}/info/exclude`;
+
+export const env = {CLAUDE_PIPELINE_REPO: REPO, CLAUDE_CODE_SESSION_ID: SESSION} as Record<
+	string,
+	string | undefined
+>;
+
+export const epic = (overrides: Record<string, unknown> = {}): ExecResult =>
+	okOut(
+		JSON.stringify({
+			number: EPIC,
+			title: "The moderation queue epic",
+			body: "An epic brief about the moderation queue.\n",
+			state: "open",
+			labels: [{name: "type:epic"}, {name: "status:triaged"}],
+			html_url: "https://github.com/o/r/issues/4300",
+			milestone: null,
+			state_reason: null,
+			...overrides,
+		}),
+	);
+
+export interface SubIssueFixture {
+	readonly number: number;
+	readonly id?: number;
+	readonly title?: string;
+	readonly labels?: ReadonlyArray<string>;
+}
+
+export const subIssues = (...rows: ReadonlyArray<SubIssueFixture>): ExecResult =>
+	okOut(
+		JSON.stringify(
+			rows.map((row) => ({
+				number: row.number,
+				id: row.id ?? row.number * 1000,
+				title: row.title ?? `child ${row.number}`,
+				labels: (row.labels ?? ["type:feature", "p1"]).map((name) => ({name})),
+			})),
+		),
+	);
+
+export const childIssue = (options: {
+	number: number;
+	labels?: ReadonlyArray<string>;
+	assignees?: ReadonlyArray<string>;
+	milestone?: string | null;
+	state?: string;
+	stateReason?: string | null;
+	body?: string;
+}): ExecResult =>
+	okOut(
+		JSON.stringify({
+			number: options.number,
+			title: `child ${options.number}`,
+			body: options.body ?? "a child body\n",
+			state: options.state ?? "open",
+			state_reason: options.stateReason ?? null,
+			labels: (options.labels ?? []).map((name) => ({name})),
+			assignees: (options.assignees ?? []).map((login) => ({login})),
+			milestone: options.milestone == null ? null : {number: 44, title: options.milestone},
+			html_url: `https://github.com/o/r/issues/${options.number}`,
+		}),
+	);
+
+/** A plan block that clears the section set and the story grammar. */
+export const planBlock = (overrides: {stories?: string; drop?: string} = {}): string =>
+	[
+		"## Plan (plan-epic)",
+		"",
+		...PLAN_SECTIONS.filter((heading) => heading !== overrides.drop).flatMap((heading) => [
+			`### ${heading}`,
+			"",
+			heading === "User stories"
+				? (overrides.stories ??
+					"1. As a moderator, I want a queue.\n2. As a yazar, I want a receipt.")
+				: "Something true about this section.",
+			"",
+		]),
+	].join("\n");
+
+/** A child body that clears the field and criteria readers. */
+export const childBody = (
+	overrides: {stories?: string; containment?: string | null; criteria?: string} = {},
+): string =>
+	[
+		`**Stories:** ${overrides.stories ?? "1, 2"}`,
+		"**TDD:** yes",
+		...(overrides.containment === null
+			? []
+			: [`**Containment:** ${overrides.containment ?? "flag (default-off)"}`]),
+		"",
+		"### What to build",
+		"",
+		"The queue view, over the fate loader.",
+		"",
+		"### Acceptance criteria",
+		overrides.criteria ?? "- [ ] the queue view renders the ten most recent reports",
+		"",
+	].join("\n");
+
+export const labelSet = (...names: ReadonlyArray<string>): ExecResult =>
+	okOut(`${names.join("\n")}\n`);
+
+export const DEFAULT_LABELS: ReadonlyArray<string> = [
+	"type:feature",
+	"type:bug",
+	"type:chore",
+	"p0",
+	"p1",
+	"p2",
+	"status:planned",
+	"ready-for:agent",
+	"ready-for:human",
+];
+
+export const milestones = (...rows: ReadonlyArray<readonly [number, string]>): ExecResult =>
+	okOut(rows.map(([number, title]) => `${number}\t${title}`).join("\n"));
+
+/** `<number>\t<title>` rows, the shape both dedup sources are read in. */
+export const issueRows = (...rows: ReadonlyArray<readonly [number, string]>): ExecResult =>
+	okOut(rows.map(([number, title]) => `${number}\t${title}`).join("\n"));
+
+/** The claim on the epic, held by this session under the lane the run key is derived from. */
+export const CLAIMED: ReadonlyArray<readonly [RegExp, ExecResult]> = [
+	[
+		new RegExp(`^gh api --paginate repos/${REPO}/issues/${EPIC}/comments`),
+		comments({id: 1, body: marker(SESSION, LANE_UUID)}),
+	],
+	[new RegExp(`^gh api repos/${REPO}/collaborators/agent/permission`), okOut("write\n")],
+];
+
+export {NONCE};

--- a/packages/fabrika-cli/src/ledger/github.ts
+++ b/packages/fabrika-cli/src/ledger/github.ts
@@ -1,0 +1,248 @@
+/**
+ * The GitHub surface this group needs that no shipped module already makes.
+ *
+ * Two of these are genuinely new to fabrika, and they are the reason this file exists: **nothing
+ * shipped writes a sub-issue link.** `plan/github.ts`'s `listSubIssues` is the read half — imported
+ * and used as-is where numbers are enough — and the write half (`POST .../sub_issues`,
+ * `DELETE .../sub_issue`) is derived here. Both take the child's **database `id`, not its number**,
+ * which is the one shape v1 got right and is worth not rediscovering.
+ *
+ * The two readers below carry fields the shipped readers drop, which is the same justification
+ * `plan/github.ts` gives for `getChild` over `getIssue`: {@link listSubIssueEntries} carries the `id`
+ * the link and unlink take, and {@link readChildBack} carries labels, assignees **and** milestone
+ * together, which no shipped shape does — and a read-back that cannot see all three cannot prove the
+ * one create call landed every birth attribute.
+ *
+ * The package's two standing disciplines hold throughout: every list read pages in full, and a shape
+ * that is not what was asked for is a failure, never an empty result.
+ */
+
+import {Effect} from "effect";
+import {execCapture} from "../io/exec.ts";
+import {type Attempt, fail, ok, type Shell} from "../io/git.ts";
+import {
+	absent,
+	type Existence,
+	httpStatusOf,
+	type IssueRow,
+	pagedJson,
+	parseIssueRows,
+	present,
+	unknown,
+} from "../io/issues.ts";
+import {isRecord, parseJson} from "../io/json.ts";
+
+/** One existing child, with the id the sub-issue relation is keyed on. */
+export interface SubIssueEntry {
+	readonly number: number;
+	readonly id: number;
+	readonly title: string;
+	readonly labels: ReadonlyArray<string>;
+}
+
+const toSubIssueEntry = (value: unknown): SubIssueEntry | null => {
+	if (!isRecord(value) || typeof value.number !== "number" || typeof value.id !== "number") {
+		return null;
+	}
+	const names = Array.isArray(value.labels)
+		? value.labels.map((l) => (isRecord(l) && typeof l.name === "string" ? l.name : null))
+		: [];
+	if (names.includes(null)) return null;
+	return {
+		number: value.number,
+		id: value.id,
+		title: typeof value.title === "string" ? value.title : "",
+		labels: names as ReadonlyArray<string>,
+	};
+};
+
+/** The epic's children from the native sub-issue list, paginated in full, with their ids. */
+export const listSubIssueEntries = (
+	repo: string,
+	epic: number,
+): Shell<Attempt<ReadonlyArray<SubIssueEntry>>> =>
+	Effect.gen(function* () {
+		const r = yield* execCapture("gh", [
+			"api",
+			"--paginate",
+			`repos/${repo}/issues/${epic}/sub_issues?per_page=100`,
+		]);
+		if (!r.ok) return fail(r.reason);
+		const pages = pagedJson(r.stdout);
+		if (pages._tag === "Failure") return pages;
+		const entries: SubIssueEntry[] = [];
+		for (const page of pages.value) {
+			const parsed = parseJson(page);
+			if (!Array.isArray(parsed)) {
+				return fail("`gh api` exited 0 but its output is not a list of sub-issues");
+			}
+			for (const value of parsed) {
+				const entry = toSubIssueEntry(value);
+				if (entry === null) return fail("`gh api` exited 0 but one entry is not a sub-issue");
+				entries.push(entry);
+			}
+		}
+		return ok(entries);
+	});
+
+/**
+ * Every open issue in the repository, paged, pull requests filtered out — the dedup ranker's queue
+ * half.
+ *
+ * Unlike `openIssuesWithLabel` this one is deliberately **unscoped by label**: the question a planner
+ * asks is "does this work already exist anywhere in the open backlog", and a label-scoped read would
+ * answer a narrower one while looking like an answer to the wider.
+ */
+export const openBacklog = (repo: string): Shell<Attempt<ReadonlyArray<IssueRow>>> =>
+	Effect.gen(function* () {
+		const r = yield* execCapture("gh", [
+			"api",
+			"--paginate",
+			`repos/${repo}/issues?state=open&per_page=100`,
+			"--jq",
+			'.[] | select(.pull_request | not) | "\\(.number)\t\\(.title)"',
+		]);
+		if (!r.ok) return fail(r.reason);
+		const rows = parseIssueRows(r.stdout);
+		return rows === null
+			? fail("`gh api` exited 0 but its output is not a list of issue rows")
+			: ok(rows);
+	});
+
+export interface ChildCreate {
+	readonly title: string;
+	readonly body: string;
+	readonly labels: ReadonlyArray<string>;
+	/** The milestone **number** resolved from its title, or `null` for an unhomed child. */
+	readonly milestone: number | null;
+	readonly assignees: ReadonlyArray<string>;
+}
+
+export interface CreatedChild {
+	readonly number: number;
+	/** The database id — what the sub-issue link and unlink take. */
+	readonly id: number;
+}
+
+/**
+ * Create the child with **every birth attribute in the one call**.
+ *
+ * v1's create hardcoded exactly three `labels[]` with no pass-through and set no milestone, so a
+ * fourth required label could only be applied by a follow-up PATCH — and a follow-up PATCH opens a
+ * window in which the child exists with **no** `ready-for:` value, which is the fail-open shape the
+ * #4780 ruling forbids.
+ */
+export const createChildIssue = (repo: string, input: ChildCreate): Shell<Attempt<CreatedChild>> =>
+	Effect.gen(function* () {
+		const r = yield* execCapture("gh", [
+			"api",
+			"--method",
+			"POST",
+			`repos/${repo}/issues`,
+			"-f",
+			`title=${input.title}`,
+			"-f",
+			`body=${input.body}`,
+			...input.labels.flatMap((label) => ["-f", `labels[]=${label}`]),
+			...input.assignees.flatMap((login) => ["-f", `assignees[]=${login}`]),
+			...(input.milestone === null ? [] : ["-F", `milestone=${input.milestone}`]),
+		]);
+		if (!r.ok) return fail(r.reason);
+		const parsed = parseJson(r.stdout);
+		if (!isRecord(parsed) || typeof parsed.number !== "number" || typeof parsed.id !== "number") {
+			return fail("`gh api` exited 0 but its output is not a created issue");
+		}
+		return ok({number: parsed.number, id: parsed.id});
+	});
+
+/** Link a child to its epic. The relation takes the child's `id`, never its number. */
+export const linkSubIssue = (repo: string, epic: number, id: number): Shell<Attempt<void>> =>
+	Effect.gen(function* () {
+		const r = yield* execCapture("gh", [
+			"api",
+			"--method",
+			"POST",
+			`repos/${repo}/issues/${epic}/sub_issues`,
+			"-F",
+			`sub_issue_id=${id}`,
+		]);
+		return r.ok ? ok<void>(undefined) : fail(r.reason);
+	});
+
+/** Unlink a child from its epic — the same `id`-not-number shape the link uses. */
+export const unlinkSubIssue = (repo: string, epic: number, id: number): Shell<Attempt<void>> =>
+	Effect.gen(function* () {
+		const r = yield* execCapture("gh", [
+			"api",
+			"--method",
+			"DELETE",
+			`repos/${repo}/issues/${epic}/sub_issue`,
+			"-F",
+			`sub_issue_id=${id}`,
+		]);
+		return r.ok ? ok<void>(undefined) : fail(r.reason);
+	});
+
+/** Close a child as `not_planned` — the only close spelling a supersede may use. */
+export const closeAsNotPlanned = (repo: string, child: number): Shell<Attempt<void>> =>
+	Effect.gen(function* () {
+		const r = yield* execCapture("gh", [
+			"api",
+			"--method",
+			"PATCH",
+			`repos/${repo}/issues/${child}`,
+			"-f",
+			"state=closed",
+			"-f",
+			"state_reason=not_planned",
+		]);
+		return r.ok ? ok<void>(undefined) : fail(r.reason);
+	});
+
+/** What a create's read-back has to be able to see, so every birth attribute is provable. */
+export interface ChildReadback {
+	readonly number: number;
+	readonly labels: ReadonlyArray<string>;
+	readonly assignees: ReadonlyArray<string>;
+	readonly milestone: string | null;
+	readonly state: string;
+	readonly stateReason: string | null;
+	readonly body: string;
+}
+
+const toChildReadback = (value: unknown): ChildReadback | null => {
+	if (!isRecord(value) || typeof value.number !== "number") return null;
+	const names = Array.isArray(value.labels)
+		? value.labels.map((l) => (isRecord(l) && typeof l.name === "string" ? l.name : null))
+		: [];
+	if (names.includes(null)) return null;
+	const logins = Array.isArray(value.assignees)
+		? value.assignees.map((a) => (isRecord(a) && typeof a.login === "string" ? a.login : null))
+		: [];
+	if (logins.includes(null)) return null;
+	const milestone = value.milestone;
+	return {
+		number: value.number,
+		labels: (names as ReadonlyArray<string>).toSorted(),
+		assignees: (logins as ReadonlyArray<string>).toSorted(),
+		milestone: isRecord(milestone) && typeof milestone.title === "string" ? milestone.title : null,
+		state: typeof value.state === "string" ? value.state : "",
+		stateReason: typeof value.state_reason === "string" ? value.state_reason : null,
+		body: typeof value.body === "string" ? value.body : "",
+	};
+};
+
+/** One child re-read from the API. The create response's own echo is never evidence. */
+export const readChildBack = (repo: string, child: number): Shell<Existence<ChildReadback>> =>
+	Effect.gen(function* () {
+		const r = yield* execCapture("gh", ["api", `repos/${repo}/issues/${child}`]);
+		if (!r.ok) {
+			return httpStatusOf(r.reason) === 404
+				? absent<ChildReadback>()
+				: unknown<ChildReadback>(r.reason);
+		}
+		const payload = toChildReadback(parseJson(r.stdout));
+		return payload === null
+			? unknown<ChildReadback>("`gh api` exited 0 but its output is not an issue")
+			: present(payload);
+	});

--- a/packages/fabrika-cli/src/ledger/ground.ts
+++ b/packages/fabrika-cli/src/ledger/ground.ts
@@ -1,0 +1,30 @@
+/**
+ * The freshness proof: how far this worktree's HEAD sits behind `origin/main`.
+ *
+ * **The tree is stale by default until shown otherwise.** v1 planned against stale checkouts and
+ * minted phantom children (#3330), and the repo has no post-merge sync with any call site (#4167) — so
+ * there is no third arm here. A probe that *fails* is a failed read (`11`), never `20`: "I could not
+ * tell" is not "it is stale", and it is certainly not "it is fresh".
+ *
+ * The base is fetched before it is read, through the shipped `fetchAndResolve` — reading a stale local
+ * ref is the whole defect class.
+ */
+
+import {Effect} from "effect";
+import {execCapture} from "../io/exec.ts";
+import {type Attempt, fail, fetchAndResolve, ok, type Shell} from "../io/git.ts";
+
+export const BASE_REF = "origin/main";
+
+/** How many commits `base` carries that HEAD does not. `0` is a fresh tree. */
+export const commitsBehind = (base: string = BASE_REF): Shell<Attempt<number>> =>
+	Effect.gen(function* () {
+		const resolved = yield* fetchAndResolve(base);
+		if (resolved._tag === "Failure") return resolved;
+		const counted = yield* execCapture("git", ["rev-list", "--count", `HEAD..${resolved.value}`]);
+		if (!counted.ok) return fail(counted.reason);
+		const text = counted.stdout.trim();
+		return /^\d+$/.test(text)
+			? ok(Number.parseInt(text, 10))
+			: fail(`\`git rev-list --count\` exited 0 but printed "${text}", which is not a count`);
+	});

--- a/packages/fabrika-cli/src/ledger/open-verb.ts
+++ b/packages/fabrika-cli/src/ledger/open-verb.ts
@@ -1,0 +1,263 @@
+/**
+ * `ledger open` — prove the ground fresh, allocate the run, read what already exists, rank duplicate
+ * candidates.
+ *
+ * The run directory is created **here and nowhere else**; every later verb re-derives it from the
+ * claim nonce and refuses if it is gone. Three facts are decided once, here, and read off `run.json`
+ * afterwards rather than carried in anyone's head: the run's `mode`, the `cycleDoc` reading, and the
+ * body digest the two guarded verbs are held to.
+ *
+ * **A re-open is a resume, not a reset.** `runKey` comes from the claim nonce, which a re-open does not
+ * change, so this verb finds the previous attempt's files. It re-seeds `children.jsonl` from the live
+ * sub-issue list and **leaves `plan.md` and `topology.md` untouched** — re-staging either is `ledger
+ * draft`'s and `ledger topology`'s job, and silently discarding a staged document a caller has not
+ * replaced would lose authored work with no refusal to notice.
+ */
+
+import {Effect, FileSystem, Path} from "effect";
+import type {ChildProcessSpawner} from "effect/unstable/process";
+import {scannedLine} from "../build/target.ts";
+import {readTree} from "../build/worktree.ts";
+import {searchOpenIssues} from "../io/issues.ts";
+import {probeCycleDoc} from "../plan/github.ts";
+import {sectionCount} from "../plan/ledger.ts";
+import {rank, tokenize} from "../report/dedup.ts";
+import {answer, refuse, type VerbOutcome} from "../verb.ts";
+import {PRECONDITION_UNKNOWN, REGION_UNRESOLVABLE, STALE_GROUND} from "./codes.ts";
+import {bodyDigest} from "./digest.ts";
+import {listSubIssueEntries, openBacklog} from "./github.ts";
+import {commitsBehind} from "./ground.ts";
+import {PLAN_HEADING} from "./plan-block.ts";
+import {type LedgerMessages, type OpenOptions, openGround} from "./preconditions.ts";
+import {
+	type ChildRecord,
+	EXCLUDE_ENTRY,
+	manifestPath,
+	parseManifest,
+	renderManifest,
+	renderRunRecord,
+	runJsonPath,
+} from "./run.ts";
+
+const VERB = "ledger open";
+
+/** How many candidates the dedup rank prints. The advisory list is read by a human, not scanned. */
+const CANDIDATE_LIMIT = 20;
+
+export const MESSAGES: LedgerMessages = {
+	verb: VERB,
+	notAnEpic: (epic) => `${VERB}: #${epic} is not a type:epic — refusing to plan it.`,
+	unreadable: (what, reason) => `${VERB}: cannot read ${what}: ${reason} — the ground is UNKNOWN.`,
+	notAWorktree: `${VERB}: not in a linked worktree — refusing to plan from the primary checkout (#4934).`,
+};
+
+export const runOpen = (
+	options: OpenOptions,
+): Effect.Effect<
+	VerbOutcome,
+	never,
+	ChildProcessSpawner.ChildProcessSpawner | FileSystem.FileSystem | Path.Path
+> =>
+	Effect.gen(function* () {
+		const ground = yield* openGround(MESSAGES, options);
+		if (ground._tag === "Refused") return ground.outcome;
+		const {repo, epic, dir, notes} = ground;
+
+		const planAnchors = sectionCount(epic.body, "Plan (plan-epic)");
+		if (planAnchors > 1) {
+			return refuse(
+				REGION_UNRESOLVABLE,
+				`${VERB}: #${epic.number}'s body carries ${planAnchors} "${PLAN_HEADING}" headings — the plan mode has no single meaning.`,
+				notes,
+			);
+		}
+		const mode = planAnchors === 0 ? "fresh" : "re-plan";
+
+		const behind = yield* commitsBehind();
+		if (behind._tag === "Failure") {
+			return refuse(
+				PRECONDITION_UNKNOWN,
+				MESSAGES.unreadable("this tree's distance from origin/main", behind.reason),
+				notes,
+			);
+		}
+		if (behind.value > 0) {
+			return refuse(
+				STALE_GROUND,
+				`${VERB}: base is ${behind.value} commit(s) behind origin/main — a plan derived here is derived on stale ground (#3330).`,
+				notes,
+			);
+		}
+
+		const children = yield* listSubIssueEntries(repo, epic.number);
+		if (children._tag === "Failure") {
+			return refuse(
+				PRECONDITION_UNKNOWN,
+				MESSAGES.unreadable(`#${epic.number}'s sub-issue list`, children.reason),
+				notes,
+			);
+		}
+
+		const cycleDoc = yield* probeCycleDoc(repo);
+
+		const tokens = tokenize(epic.title);
+		const backlog = yield* openBacklog(repo);
+		if (backlog._tag === "Failure") {
+			return refuse(
+				PRECONDITION_UNKNOWN,
+				MESSAGES.unreadable(`${repo}'s open backlog`, backlog.reason),
+				notes,
+			);
+		}
+		const search = yield* searchOpenIssues(repo, tokens);
+		if (search._tag === "Failure") {
+			return refuse(
+				PRECONDITION_UNKNOWN,
+				MESSAGES.unreadable(`${repo}'s search index`, search.reason),
+				notes,
+			);
+		}
+		const ranked = rank({
+			tokens,
+			queue: backlog.value,
+			search: search.value,
+			limit: CANDIDATE_LIMIT,
+			label: "open backlog",
+			exclude: epic.number,
+		});
+
+		const fs = yield* FileSystem.FileSystem;
+		const previous = yield* readManifest(fs, manifestPath(dir));
+		const minted = new Set(
+			(previous ?? []).filter((record) => record.mintedThisRun).map((record) => record.number),
+		);
+		const seeded: ReadonlyArray<ChildRecord> = children.value.map((entry) => ({
+			number: entry.number,
+			id: entry.id,
+			title: entry.title,
+			type: entry.labels.find((label) => label.startsWith("type:")) ?? null,
+			priority: entry.labels.find((label) => /^p\d+$/.test(label)) ?? null,
+			readyFor: entry.labels.find((label) => label.startsWith("ready-for:")) ?? null,
+			stories: null,
+			containment: null,
+			linked: true,
+			mintedThisRun: minted.has(entry.number),
+		}));
+
+		const digest = bodyDigest(epic.body);
+		const wrote = yield* writeAll(fs, [
+			[
+				runJsonPath(dir),
+				renderRunRecord({
+					epic: epic.number,
+					run: ground.run,
+					mode,
+					cycleDoc,
+					bodyDigest: digest,
+				}),
+			],
+			[manifestPath(dir), renderManifest(seeded)],
+		]);
+		if (wrote !== null) {
+			return refuse(
+				PRECONDITION_UNKNOWN,
+				`${VERB}: cannot create the run directory ${dir}: ${wrote} — the run is UNKNOWN.`,
+				notes,
+			);
+		}
+
+		const excluded = yield* registerExclude(fs);
+		if (excluded !== null) {
+			return refuse(
+				PRECONDITION_UNKNOWN,
+				`${VERB}: cannot register ${EXCLUDE_ENTRY} in this tree's git exclude: ${excluded} — run state could reach the epic's PR.`,
+				notes,
+			);
+		}
+
+		return answer(
+			JSON.stringify({
+				answer: "opened",
+				epic: epic.number,
+				run: ground.run,
+				mode,
+				bodyDigest: digest,
+				dir,
+				children: children.value.map((entry) => ({
+					number: entry.number,
+					title: entry.title,
+					labels: entry.labels,
+				})),
+				cycleDoc,
+				candidates: {
+					outcome: ranked.outcome,
+					items: ranked.candidates.map((candidate) => ({
+						number: candidate.number,
+						title: candidate.title,
+						score: candidate.score,
+					})),
+				},
+			}),
+			[
+				...notes,
+				scannedLine(
+					VERB,
+					children.value.length,
+					"existing child",
+					`${backlog.value.length} open backlog issue(s) and ${search.value.length} search hit(s) ranked`,
+				),
+			],
+		);
+	});
+
+/** The previous attempt's manifest, or `null` when this run has none yet. */
+const readManifest = (
+	fs: FileSystem.FileSystem,
+	path: string,
+): Effect.Effect<ReadonlyArray<ChildRecord> | null> =>
+	fs.readFileString(path).pipe(
+		Effect.map(parseManifest),
+		Effect.catchTag("PlatformError", () => Effect.succeed(null)),
+	);
+
+/** Write every file, or the first reason one did not land. */
+const writeAll = (
+	fs: FileSystem.FileSystem,
+	files: ReadonlyArray<readonly [string, string]>,
+): Effect.Effect<string | null, never, Path.Path> =>
+	Effect.gen(function* () {
+		const path = yield* Path.Path;
+		for (const [target, text] of files) {
+			const failed = yield* fs.makeDirectory(path.dirname(target), {recursive: true}).pipe(
+				Effect.andThen(fs.writeFileString(target, text)),
+				Effect.as(null),
+				Effect.catchTag("PlatformError", (cause) => Effect.succeed(cause.message)),
+			);
+			if (failed !== null) return failed;
+		}
+		return null;
+	});
+
+/**
+ * Put the run directory behind the tree's own exclude file, so run state can never enter the epic's
+ * PR. The file is per-worktree and untracked, so the exclusion never enters a diff and never fights a
+ * `--require-clean` check.
+ */
+const registerExclude = (
+	fs: FileSystem.FileSystem,
+): Effect.Effect<string | null, never, ChildProcessSpawner.ChildProcessSpawner> =>
+	Effect.gen(function* () {
+		const tree = yield* readTree;
+		if (tree._tag === "Failure") return tree.reason;
+		const path = `${tree.value.gitDir}/info/exclude`;
+		const current = yield* fs
+			.readFileString(path)
+			.pipe(Effect.catchTag("PlatformError", () => Effect.succeed("")));
+		if (current.split("\n").some((line) => line.trim() === EXCLUDE_ENTRY)) return null;
+		const next = current === "" || current.endsWith("\n") ? current : `${current}\n`;
+		return yield* fs.makeDirectory(`${tree.value.gitDir}/info`, {recursive: true}).pipe(
+			Effect.andThen(fs.writeFileString(path, `${next}${EXCLUDE_ENTRY}\n`)),
+			Effect.as(null),
+			Effect.catchTag("PlatformError", (cause) => Effect.succeed(cause.message)),
+		);
+	});

--- a/packages/fabrika-cli/src/ledger/open-verb.unit.test.ts
+++ b/packages/fabrika-cli/src/ledger/open-verb.unit.test.ts
@@ -1,0 +1,251 @@
+import {Effect, Layer} from "effect";
+import {describe, expect, it} from "vitest";
+import {comments, LINKED, PRIMARY} from "../build/fixtures.test-support.ts";
+import {errOut, fakeFs, fakeShell, okOut} from "../fakes.test-support.ts";
+import type {ExecResult} from "../io/exec.ts";
+import {
+	CLAIM_NOT_MINE,
+	NOT_A_WORKTREE,
+	OFF_VOCABULARY,
+	PRECONDITION_UNKNOWN,
+	REGION_UNRESOLVABLE,
+	STALE_GROUND,
+	ZERO_SCOPE,
+} from "./codes.ts";
+import {
+	CLAIMED,
+	DIR,
+	EXCLUDE_PATH,
+	env,
+	epic,
+	issueRows,
+	subIssues,
+} from "./fixtures.test-support.ts";
+import {runOpen} from "./open-verb.ts";
+import {manifestPath, parseManifest, parseRunRecord, runJsonPath} from "./run.ts";
+
+const SHA = "03135b9188d2be6c0a4b7bd0b7a3ff9c53f0f2b1";
+
+const EPIC_READ = /^gh api repos\/o\/r\/issues\/4300$/;
+const TREE = /^git rev-parse --path-format=absolute/;
+const SUBS = /^gh api --paginate repos\/o\/r\/issues\/4300\/sub_issues/;
+const CYCLE = /^gh api repos\/o\/r\/contents\/product-development-cycle\.md$/;
+const BACKLOG = /^gh api --paginate repos\/o\/r\/issues\?state=open/;
+const SEARCH = /^gh api --paginate search\/issues/;
+const REV_LIST = /^git rev-list --count/;
+
+const GROUND: ReadonlyArray<readonly [RegExp, ExecResult]> = [
+	[/^git remote$/, okOut("origin\n")],
+	[/^git fetch --quiet origin main$/, okOut("")],
+	[/^git rev-parse --verify --quiet origin\/main/, okOut(`${SHA}\n`)],
+	[REV_LIST, okOut("0\n")],
+];
+
+const CLEAN: ReadonlyArray<readonly [RegExp, ExecResult]> = [
+	[EPIC_READ, epic()],
+	[TREE, LINKED],
+	...CLAIMED,
+	...GROUND,
+	[SUBS, subIssues()],
+	[CYCLE, okOut("{}")],
+	[BACKLOG, issueRows([4180, "queue view for reports"])],
+	[SEARCH, issueRows()],
+];
+
+const run = (
+	script: ReadonlyArray<readonly [RegExp, ExecResult]>,
+	files: Readonly<Record<string, string | null>> = {},
+) => {
+	const shell = fakeShell(script);
+	const fs = fakeFs({files});
+	return Effect.runPromise(
+		Effect.provide(runOpen({number: 4300, repo: null, env}), Layer.mergeAll(shell.layer, fs.layer)),
+	).then((outcome) => ({outcome, written: fs.written, calls: shell.calls}));
+};
+
+describe("runOpen", () => {
+	it("allocates the run, decides the mode, and prints the ground it proved", async () => {
+		const {outcome, written} = await run(CLEAN);
+		expect(outcome.code).toBe(0);
+		expect(JSON.parse(outcome.stdout)).toMatchObject({
+			answer: "opened",
+			epic: 4300,
+			run: "4300-c1a4d6f8",
+			mode: "fresh",
+			dir: DIR,
+			children: [],
+			cycleDoc: "present",
+			candidates: {outcome: "candidates"},
+		});
+		expect(JSON.parse(outcome.stdout).bodyDigest).toMatch(/^[0-9a-f]{12}$/);
+		expect(parseRunRecord(written.get(runJsonPath(DIR)) ?? "")).toMatchObject({
+			epic: 4300,
+			mode: "fresh",
+			cycleDoc: "present",
+		});
+	});
+
+	/**
+	 * The manifest is the epic's WHOLE child set, not this run's additions — which is what makes a
+	 * re-plan's topology check correct. Without the seed, a retained child is a dangling ref if named
+	 * and an orphan at the gate if omitted, with no third option.
+	 */
+	it("seeds the manifest with the epic's existing children, ids and all", async () => {
+		const {outcome, written} = await run([
+			...CLEAN.filter(([pattern]) => pattern !== SUBS),
+			[SUBS, subIssues({number: 4301, id: 90210, labels: ["type:feature", "p1"]})],
+		]);
+		expect(JSON.parse(outcome.stdout).children).toEqual([
+			{number: 4301, title: "child 4301", labels: ["type:feature", "p1"]},
+		]);
+		expect(parseManifest(written.get(manifestPath(DIR)) ?? "")).toEqual([
+			{
+				number: 4301,
+				id: 90210,
+				title: "child 4301",
+				type: "type:feature",
+				priority: "p1",
+				readyFor: null,
+				stories: null,
+				containment: null,
+				linked: true,
+				mintedThisRun: false,
+			},
+		]);
+	});
+
+	it("reads one plan heading as a re-plan", async () => {
+		const {outcome} = await run([
+			[EPIC_READ, epic({body: "brief\n\n## Plan (plan-epic)\n\n### Summary\n\nold\n"})],
+			...CLEAN.slice(1),
+		]);
+		expect(JSON.parse(outcome.stdout).mode).toBe("re-plan");
+	});
+
+	/** Two headings: the mode cannot be decided, and guessing is what corrupted epics in v1. */
+	it("refuses two plan headings rather than guessing the mode", async () => {
+		const {outcome} = await run([
+			[EPIC_READ, epic({body: "## Plan (plan-epic)\n\na\n\n## Plan (plan-epic)\n\nb\n"})],
+			...CLEAN.slice(1),
+		]);
+		expect(outcome.code).toBe(REGION_UNRESOLVABLE);
+		expect(outcome.stdout).toBe("");
+	});
+
+	it("registers the run root in this tree's git exclude", async () => {
+		const {written} = await run(CLEAN);
+		expect(written.get(EXCLUDE_PATH)).toBe(".fabrika-plan/\n");
+	});
+
+	it("keeps a staged plan across a re-open — a resume is not a reset", async () => {
+		const {written} = await run(CLEAN, {[`${DIR}/plan.md`]: "## Plan (plan-epic)\n"});
+		expect(written.has(`${DIR}/plan.md`)).toBe(false);
+	});
+
+	it("re-seeds a resumed run without forgetting which children it minted", async () => {
+		const {written} = await run(
+			[
+				...CLEAN.filter(([pattern]) => pattern !== SUBS),
+				[SUBS, subIssues({number: 4301, id: 90210})],
+			],
+			{
+				[manifestPath(DIR)]: `${JSON.stringify({
+					number: 4301,
+					id: 90210,
+					title: "child 4301",
+					linked: false,
+					mintedThisRun: true,
+				})}\n`,
+			},
+		);
+		expect(parseManifest(written.get(manifestPath(DIR)) ?? "")).toMatchObject([
+			{number: 4301, linked: true, mintedThisRun: true},
+		]);
+	});
+
+	it("refuses a base proven behind origin/main", async () => {
+		const {outcome} = await run([
+			...CLEAN.filter(([pattern]) => pattern !== REV_LIST),
+			[REV_LIST, okOut("47\n")],
+		]);
+		expect(outcome.code).toBe(STALE_GROUND);
+		expect(outcome.stderr.at(-1)).toBe(
+			"ledger open: base is 47 commit(s) behind origin/main — a plan derived here is derived on stale ground (#3330).",
+		);
+	});
+
+	/** "I could not tell" is not "it is stale", and it is certainly not "it is fresh". */
+	it("seats an unreadable freshness probe on 11, never on 20", async () => {
+		const {outcome} = await run([
+			...CLEAN.filter(([pattern]) => pattern !== REV_LIST),
+			[REV_LIST, errOut("fatal: bad revision")],
+		]);
+		expect(outcome.code).toBe(PRECONDITION_UNKNOWN);
+	});
+
+	it("refuses an issue that is not a type:epic", async () => {
+		const {outcome} = await run([
+			[EPIC_READ, epic({labels: [{name: "type:feature"}]})],
+			...CLEAN.slice(1),
+		]);
+		expect(outcome.code).toBe(OFF_VOCABULARY);
+		expect(outcome.stderr.at(-1)).toBe(
+			"ledger open: #4300 is not a type:epic — refusing to plan it.",
+		);
+	});
+
+	it("refuses a proven-absent epic on 7", async () => {
+		const {outcome} = await run([
+			[EPIC_READ, errOut("gh: Not Found (HTTP 404)")],
+			...CLEAN.slice(1),
+		]);
+		expect(outcome.code).toBe(ZERO_SCOPE);
+	});
+
+	it("refuses an unreadable epic on 11 — absence is decided by status, never by text", async () => {
+		const {outcome} = await run([
+			[EPIC_READ, errOut("gh: Bad Gateway (HTTP 502)")],
+			...CLEAN.slice(1),
+		]);
+		expect(outcome.code).toBe(PRECONDITION_UNKNOWN);
+	});
+
+	it("refuses the primary checkout", async () => {
+		const {outcome} = await run([[EPIC_READ, epic()], [TREE, PRIMARY], ...CLEAN.slice(2)]);
+		expect(outcome.code).toBe(NOT_A_WORKTREE);
+	});
+
+	it("refuses when this session does not hold the claim", async () => {
+		const {outcome} = await run([
+			[EPIC_READ, epic()],
+			[TREE, LINKED],
+			[
+				/^gh api --paginate repos\/o\/r\/issues\/4300\/comments/,
+				comments({id: 1, body: "nothing here"}),
+			],
+			...CLEAN.slice(4),
+		]);
+		expect(outcome.code).toBe(CLAIM_NOT_MINE);
+		expect(outcome.stderr.at(-1)).toBe("ledger open: this session does not hold #4300's claim.");
+	});
+
+	/** An unreachable index is `indeterminate`; only a read that ran and matched nothing is `none`. */
+	it("seats an unreadable backlog on 11 rather than a clean none", async () => {
+		const {outcome} = await run([
+			...CLEAN.filter(([pattern]) => pattern !== BACKLOG),
+			[BACKLOG, errOut("gh: Bad Gateway (HTTP 502)")],
+		]);
+		expect(outcome.code).toBe(PRECONDITION_UNKNOWN);
+		expect(outcome.stdout).toBe("");
+	});
+
+	it("ranks the open backlog and excludes the epic from its own candidates", async () => {
+		const {outcome} = await run([
+			...CLEAN.filter(([pattern]) => pattern !== BACKLOG),
+			[BACKLOG, issueRows([4300, "The moderation queue epic"], [4180, "moderation queue view"])],
+		]);
+		const {candidates} = JSON.parse(outcome.stdout);
+		expect(candidates.outcome).toBe("candidates");
+		expect(candidates.items.map((item: {number: number}) => item.number)).toEqual([4180]);
+	});
+});

--- a/packages/fabrika-cli/src/ledger/plan-block.ts
+++ b/packages/fabrika-cli/src/ledger/plan-block.ts
@@ -1,0 +1,112 @@
+/**
+ * The plan block's grammar: the closed section set and the story list, checked before anything is
+ * staged.
+ *
+ * The check is total over *shape* and says nothing about content — a `### Approach` reading "TBD"
+ * stages cleanly, and catching that is the skill's job, not a verb's. What it does catch is the class
+ * an author cannot see: `readEpicStories` collects ids only from ordered-list rows, so a
+ * `### User stories` section full of `-` bullets or `S1`-style labels parses as **zero stories** while
+ * looking complete. The gate's floor then reds `MISSING_STORIES_SECTION` over the whole epic — a
+ * planner writing a plan its own gate rejects, which is the failure this group exists to prevent.
+ *
+ * The section presence and duplication counts come from the gate's own `sectionCount`, so the composer
+ * is held to the reader it is composing for. Only the *ordering* is derived here, because no shipped
+ * reader answers it.
+ */
+
+import {readEpicStories, sectionCount, unfencedLines} from "../plan/ledger.ts";
+
+/** The line the block must open with. */
+export const PLAN_HEADING = "## Plan (plan-epic)";
+
+/** The closed section set: each present exactly once, in this order. */
+export const PLAN_SECTIONS: ReadonlyArray<string> = [
+	"Summary",
+	"Problem & who has it",
+	"What changes",
+	"User stories",
+	"Goal / non-goals",
+	"Resolved questions",
+	"Approach",
+	"Testing strategy",
+	"Task-split rationale",
+	"Vocabulary impact",
+];
+
+const ATX_HEADING = /^ {0,3}(#{1,6})[ \t]+(.*?)[ \t]*#*[ \t]*$/;
+
+const normalize = (text: string): string => text.toLowerCase().replace(/[^a-z0-9]/g, "");
+
+/** The `###` headings the block carries, in the order they appear, outside every fence. */
+const headingOrder = (text: string): ReadonlyArray<string> => {
+	const seen: string[] = [];
+	for (const {text: line} of unfencedLines(text)) {
+		const matched = ATX_HEADING.exec(line);
+		if (matched?.[1] === undefined || matched[2] === undefined) continue;
+		if (matched[1].length !== 3) continue;
+		seen.push(normalize(matched[2]));
+	}
+	return seen;
+};
+
+export type PlanBlockCheck =
+	| {
+			readonly _tag: "Ok";
+			readonly sections: number;
+			readonly stories: ReadonlyArray<number>;
+	  }
+	| {readonly _tag: "Bad"; readonly reason: string};
+
+const bad = (reason: string): PlanBlockCheck => ({_tag: "Bad", reason});
+
+/**
+ * Check the authored plan block. Every `Bad` names exactly one correctable thing, so a second attempt
+ * is a correction rather than a rewrite.
+ */
+export const checkPlanBlock = (text: string): PlanBlockCheck => {
+	const opening = text.split("\n").find((line) => line.trim() !== "");
+	if (opening?.trim() !== PLAN_HEADING) {
+		return bad(`the plan block does not open with "${PLAN_HEADING}".`);
+	}
+
+	const missing = PLAN_SECTIONS.filter((heading) => sectionCount(text, heading) === 0);
+	if (missing.length > 0) {
+		return bad(`the plan block is missing section(s): ${missing.join(", ")}.`);
+	}
+	for (const heading of PLAN_SECTIONS) {
+		const count = sectionCount(text, heading);
+		if (count > 1) {
+			return bad(
+				`the plan block carries ${count} "${heading}" sections — a plan with two of one section has no single meaning.`,
+			);
+		}
+	}
+
+	const wanted = PLAN_SECTIONS.map(normalize);
+	const seen = headingOrder(text).filter((key) => wanted.includes(key));
+	for (let i = 1; i < seen.length; i += 1) {
+		const previous = seen[i - 1];
+		const current = seen[i];
+		if (previous === undefined || current === undefined) continue;
+		if (wanted.indexOf(current) < wanted.indexOf(previous)) {
+			const label = (key: string) => PLAN_SECTIONS[wanted.indexOf(key)] ?? key;
+			return bad(
+				`the plan block's sections are out of order: "${label(current)}" appears after "${label(previous)}".`,
+			);
+		}
+	}
+
+	const stories = readEpicStories(text);
+	if (stories._tag === "MisNumbered") {
+		return bad(
+			`user stories are numbered ${stories.ids.join(", ")} — a story list must run from 1 with no gaps or repeats.`,
+		);
+	}
+	if (stories.ids.length === 0) {
+		return bad(
+			'the plan declares zero user stories — an ordered list is what carries them, and a bullet or an "S<n>" label parses as none.',
+		);
+	}
+
+	return {_tag: "Ok", sections: PLAN_SECTIONS.length, stories: stories.ids};
+};

--- a/packages/fabrika-cli/src/ledger/plan-block.unit.test.ts
+++ b/packages/fabrika-cli/src/ledger/plan-block.unit.test.ts
@@ -1,0 +1,76 @@
+import {describe, expect, it} from "vitest";
+import {planBlock} from "./fixtures.test-support.ts";
+import {checkPlanBlock, PLAN_SECTIONS} from "./plan-block.ts";
+
+describe("checkPlanBlock", () => {
+	it("passes a block carrying every section once, in order, with contiguous stories", () => {
+		expect(checkPlanBlock(planBlock())).toEqual({
+			_tag: "Ok",
+			sections: PLAN_SECTIONS.length,
+			stories: [1, 2],
+		});
+	});
+
+	it("names the missing sections rather than the first one", () => {
+		const checked = checkPlanBlock(planBlock({drop: "Approach"}));
+		expect(checked).toMatchObject({_tag: "Bad"});
+		expect(checked).toMatchObject({
+			reason: expect.stringContaining("missing section(s): Approach"),
+		});
+	});
+
+	it("refuses a block that does not open with the plan heading", () => {
+		const checked = checkPlanBlock(`## Plan\n\n${planBlock()}`);
+		expect(checked).toMatchObject({
+			reason: 'the plan block does not open with "## Plan (plan-epic)".',
+		});
+	});
+
+	it("refuses a duplicated section — two of one has no single meaning", () => {
+		const checked = checkPlanBlock(`${planBlock()}\n### Approach\n\nagain\n`);
+		expect(checked).toMatchObject({
+			reason: expect.stringContaining('carries 2 "Approach" sections'),
+		});
+	});
+
+	it("refuses sections that appear out of order", () => {
+		const reordered = planBlock()
+			.replace("### Approach\n\nSomething true about this section.\n\n", "")
+			.replace("### Summary", "### Approach\n\nSomething true about this section.\n\n### Summary");
+		expect(checkPlanBlock(reordered)).toMatchObject({
+			reason: expect.stringContaining("out of order"),
+		});
+	});
+
+	it("refuses a mis-numbered story list", () => {
+		const checked = checkPlanBlock(planBlock({stories: "1. one\n2. two\n4. four"}));
+		expect(checked).toMatchObject({
+			reason:
+				"user stories are numbered 1, 2, 4 — a story list must run from 1 with no gaps or repeats.",
+		});
+	});
+
+	/**
+	 * The trap the refusal is really for: `readEpicStories` collects ids only from ordered-list rows, so
+	 * a section full of bullets parses as zero stories while looking complete to its author, and the
+	 * gate's floor then reds `MISSING_STORIES_SECTION` over the whole epic.
+	 */
+	it("refuses a story section written as bullets — it parses as zero stories", () => {
+		const checked = checkPlanBlock(planBlock({stories: "- As a moderator, I want a queue."}));
+		expect(checked).toMatchObject({
+			reason: expect.stringContaining("the plan declares zero user stories"),
+		});
+	});
+
+	it("refuses an `S<n>`-labelled story list for the same reason", () => {
+		expect(checkPlanBlock(planBlock({stories: "S1. one\nS2. two"}))).toMatchObject({
+			reason: expect.stringContaining("zero user stories"),
+		});
+	});
+
+	it("does not judge content — a TBD section passes", () => {
+		expect(
+			checkPlanBlock(planBlock().replace("Something true about this section.", "TBD")),
+		).toMatchObject({_tag: "Ok"});
+	});
+});

--- a/packages/fabrika-cli/src/ledger/preconditions.ts
+++ b/packages/fabrika-cli/src/ledger/preconditions.ts
@@ -1,0 +1,128 @@
+/**
+ * The four preconditions every `ledger` verb runs before it answers, in one place so six copies cannot
+ * drift apart: resolve the repo, refuse a target that is not a `type:epic`, prove this process is in a
+ * linked worktree, and prove this session holds the epic's claim.
+ *
+ * The claim is the **`build` group's, reused as landed verbs** — no second lock is derived. v1's
+ * `epic-lock` is why: all five of its distinct outcomes collapsed onto exit `1`, it wrote the
+ * `status:planning` label *before* the claim comment so a failed claim left a held label with no owner,
+ * and its release re-found "our own" claim by session id, so a sibling lane's release retracted the
+ * holder's claim.
+ *
+ * The run directory is derived from the **claim nonce** here and nowhere else, which is what makes two
+ * parallel planning lanes of one session independent (#4516, #4544, #4500).
+ */
+
+import {Effect} from "effect";
+import type {ChildProcessSpawner} from "effect/unstable/process";
+import {requireClaim, requireSession} from "../build/claim.ts";
+import {nonceOf} from "../build/lane.ts";
+import {badNumber, openIssue, resolveTargetRepo} from "../build/target.ts";
+import {assertGround} from "../build/worktree.ts";
+import type {IssueRecord} from "../io/issues.ts";
+import {refuse, type VerbOutcome} from "../verb.ts";
+import {CLAIM_NOT_MINE, NOT_A_WORKTREE, OFF_VOCABULARY, PRECONDITION_UNKNOWN} from "./codes.ts";
+import {runDir, runKey} from "./run.ts";
+
+export const EPIC_LABEL = "type:epic";
+
+/** The per-verb halves of the shared refusals — the same facts, each verb's own wording. */
+export interface LedgerMessages {
+	readonly verb: string;
+	/** `<verb>: #<n> is not a type:epic — <tail>.` */
+	readonly notAnEpic: (epic: number) => string;
+	/** `<verb>: cannot read <what>: <reason> — <tail>.` */
+	readonly unreadable: (what: string, reason: string) => string;
+	/** `<verb>: not in a linked worktree — <tail>.` */
+	readonly notAWorktree: string;
+}
+
+export interface Ground {
+	readonly repo: string;
+	readonly epic: IssueRecord;
+	readonly worktreeRoot: string;
+	/** `<epic>-<claim-nonce>` — the run's name, and the leaf of its directory. */
+	readonly run: string;
+	readonly dir: string;
+	readonly notes: ReadonlyArray<string>;
+}
+
+export type Opened =
+	| {readonly _tag: "Refused"; readonly outcome: VerbOutcome}
+	| ({readonly _tag: "Ground"} & Ground);
+
+export interface OpenOptions {
+	readonly number: number;
+	readonly repo: string | null;
+	readonly env: Readonly<Record<string, string | undefined>>;
+}
+
+const refused = (outcome: VerbOutcome): Opened => ({_tag: "Refused", outcome});
+
+export const openGround = (
+	messages: LedgerMessages,
+	options: OpenOptions,
+): Effect.Effect<Opened, never, ChildProcessSpawner.ChildProcessSpawner> =>
+	Effect.gen(function* () {
+		const {verb} = messages;
+		const epicNumber = options.number;
+
+		const bad = badNumber(verb, "an issue number", epicNumber);
+		if (bad !== null) return refused(bad);
+
+		const session = requireSession(verb, options.env);
+		if (session._tag === "Refused") return refused(session.outcome);
+
+		const resolved = yield* resolveTargetRepo(verb, options.repo, options.env);
+		if (resolved._tag === "Refused") return refused(resolved.outcome);
+		const repo = resolved.repo;
+
+		const target = yield* openIssue(verb, repo, epicNumber, (reason) =>
+			messages.unreadable(`#${epicNumber}`, reason),
+		);
+		if (target._tag === "Refused") return refused(target.outcome);
+		if (!target.issue.labels.includes(EPIC_LABEL)) {
+			return refused(refuse(OFF_VOCABULARY, messages.notAnEpic(epicNumber)));
+		}
+
+		const tree = yield* assertGround(verb, false);
+		if (tree._tag === "Refused") {
+			return refused(refuse(NOT_A_WORKTREE, messages.notAWorktree, tree.outcome.stderr));
+		}
+
+		const held = yield* requireClaim(verb, repo, epicNumber, session.id);
+		if (held._tag === "Refused") {
+			const outcome = held.outcome;
+			return refused(
+				outcome.code === CLAIM_NOT_MINE
+					? refuse(
+							CLAIM_NOT_MINE,
+							`${verb}: this session does not hold #${epicNumber}'s claim.`,
+							outcome.stderr,
+						)
+					: outcome,
+			);
+		}
+
+		const nonce = nonceOf(held.marker.token);
+		if (nonce === null) {
+			return refused(
+				refuse(
+					PRECONDITION_UNKNOWN,
+					`${verb}: the claim on #${epicNumber} carries the token ${held.marker.token}, which yields no lane nonce — the run key is UNKNOWN.`,
+					held.notes,
+				),
+			);
+		}
+
+		const run = runKey(epicNumber, nonce);
+		return {
+			_tag: "Ground",
+			repo,
+			epic: target.issue,
+			worktreeRoot: tree.root,
+			run,
+			dir: runDir(tree.root, run),
+			notes: held.notes,
+		};
+	});

--- a/packages/fabrika-cli/src/ledger/region.ts
+++ b/packages/fabrika-cli/src/ledger/region.ts
@@ -1,0 +1,124 @@
+/**
+ * Where the plan goes in the epic body, resolved by anchors rather than by position.
+ *
+ * **Detection is the verb-written enrichment marker, never a position** (#4850, #4866): with the
+ * marker doing the detecting, appending the plan below the preserved brief envelope breaks no
+ * detector, so no layout inversion is needed. What the marker buys here is the *bound*: a
+ * `## Dependencies` heading that resolves **inside** the preserved brief is not this run's anchor, and
+ * cutting there is how v1 destroyed a body (#4879).
+ *
+ * **The region is never cut to end-of-file.** v1's replace branch sliced from the `## Dependencies`
+ * heading to EOF on the assumption that dependencies are the last section, destroying anything a human
+ * had appended below with no guard at all. This module resolves a bounded region and preserves every
+ * byte outside it.
+ */
+
+import {unfencedLines} from "../plan/ledger.ts";
+import {MARKER_RE} from "../triage/enrich.ts";
+import {PLAN_HEADING} from "./plan-block.ts";
+import type {PlanMode} from "./run.ts";
+
+export const DEPENDENCIES_HEADING = "## Dependencies";
+
+const PLAN_RE = /^##\s+Plan\s+\(plan-epic\)\s*$/;
+const DEPENDENCIES_RE = /^##\s+Dependencies\s*$/;
+const TOP_LEVEL_HEADING_RE = /^#{1,2}\s+/;
+
+/** 0-based indices into the body's lines, for the unfenced lines matching `pattern`. */
+const anchorsIn = (body: string, pattern: RegExp): ReadonlyArray<number> =>
+	unfencedLines(body)
+		.filter(({text}) => pattern.test(text.trim()))
+		.map(({line}) => line - 1);
+
+export type Splice =
+	| {readonly _tag: "Composed"; readonly body: string}
+	| {readonly _tag: "Unresolvable"; readonly reason: string};
+
+const unresolvable = (reason: string): Splice => ({_tag: "Unresolvable", reason});
+
+const headingCount = (epic: number, heading: string, count: number): string =>
+	`#${epic}'s body carries ${count} "${heading}" headings — the plan region has no single meaning.`;
+
+/** The `[start, end)` line span of the preserved brief envelope, or `null` when there is no marker. */
+const envelopeOf = (lines: ReadonlyArray<string>): {start: number; end: number} | null => {
+	const start = lines.findIndex((line) => MARKER_RE.test(line.trim()));
+	if (start === -1) return null;
+	const closing = lines.findIndex(
+		(line, index) => index > start && line.trim().toLowerCase() === "</details>",
+	);
+	return {start, end: closing === -1 ? start : closing};
+};
+
+export interface SpliceInput {
+	readonly epic: number;
+	readonly body: string;
+	readonly mode: PlanMode;
+	/** The staged plan block, opening with `## Plan (plan-epic)`. */
+	readonly plan: string;
+	/** The staged `## Dependencies` block. */
+	readonly topology: string;
+}
+
+const block = (text: string): string => text.replace(/\s+$/, "");
+
+/**
+ * Resolve the region and produce the whole new body.
+ *
+ * `mode` is carried from `ledger open`, never re-derived here: a `write` that recomputed it from the
+ * live body could disagree with the `open` that named the run, which is precisely how the
+ * mode-mismatch arm becomes unreachable and a first-time append silently overwrites a real plan.
+ */
+export const splicePlan = (input: SpliceInput): Splice => {
+	const lines = input.body.replace(/\r\n/g, "\n").split("\n");
+	const planAnchors = anchorsIn(input.body, PLAN_RE);
+	const composed = `${block(input.plan)}\n\n${block(input.topology)}\n`;
+
+	if (input.mode === "fresh") {
+		if (planAnchors.length > 0) {
+			return unresolvable(headingCount(input.epic, PLAN_HEADING, planAnchors.length));
+		}
+		return {_tag: "Composed", body: `${block(input.body)}\n\n${composed}`};
+	}
+
+	if (planAnchors.length === 0) {
+		return unresolvable(
+			`mode is re-plan and the body carries no "${PLAN_HEADING}" heading — the anchor drifted or was deleted.`,
+		);
+	}
+	if (planAnchors.length > 1) {
+		return unresolvable(headingCount(input.epic, PLAN_HEADING, planAnchors.length));
+	}
+
+	const dependencyAnchors = anchorsIn(input.body, DEPENDENCIES_RE);
+	if (dependencyAnchors.length !== 1) {
+		return unresolvable(headingCount(input.epic, DEPENDENCIES_HEADING, dependencyAnchors.length));
+	}
+
+	const start = planAnchors[0] as number;
+	const dependencies = dependencyAnchors[0] as number;
+	const envelope = envelopeOf(lines);
+	if (envelope !== null && dependencies > envelope.start && dependencies < envelope.end) {
+		return unresolvable(
+			`#${input.epic}'s "${DEPENDENCIES_HEADING}" heading resolves inside the preserved brief envelope — refusing to cut the region there (#4879).`,
+		);
+	}
+	if (dependencies < start) {
+		return unresolvable(
+			`#${input.epic}'s "${DEPENDENCIES_HEADING}" heading sits above its "${PLAN_HEADING}" heading — the plan region has no single meaning.`,
+		);
+	}
+
+	let end = lines.length;
+	for (let i = dependencies + 1; i < lines.length; i += 1) {
+		if (TOP_LEVEL_HEADING_RE.test((lines[i] ?? "").trim())) {
+			end = i;
+			break;
+		}
+	}
+
+	const before = lines.slice(0, start).join("\n").replace(/\s+$/, "");
+	const after = lines.slice(end).join("\n").replace(/^\n+/, "");
+	const head = before === "" ? "" : `${before}\n\n`;
+	const tail = after.trim() === "" ? "" : `\n${after}`;
+	return {_tag: "Composed", body: `${head}${composed}${tail}`};
+};

--- a/packages/fabrika-cli/src/ledger/region.unit.test.ts
+++ b/packages/fabrika-cli/src/ledger/region.unit.test.ts
@@ -1,0 +1,105 @@
+import {describe, expect, it} from "vitest";
+import {splicePlan} from "./region.ts";
+
+const PLAN = "## Plan (plan-epic)\n\n### Summary\n\nA plan.\n";
+const TOPOLOGY = "## Dependencies\n\n- phase 1: #4301\n";
+
+const splice = (body: string, mode: "fresh" | "re-plan") =>
+	splicePlan({epic: 4300, body, mode, plan: PLAN, topology: TOPOLOGY});
+
+const ENRICHED = [
+	"## Pitch",
+	"",
+	"A pitch.",
+	"",
+	"<!-- fabrika:enriched issue=4300 mode=wrap -->",
+	"<details>",
+	"<summary>Original brief (verbatim)</summary>",
+	"",
+	"The original brief.",
+	"",
+	"</details>",
+	"",
+].join("\n");
+
+describe("splicePlan on a fresh run", () => {
+	it("appends the plan and topology below the live bytes, which it does not touch", () => {
+		const spliced = splice(ENRICHED, "fresh");
+		expect(spliced).toMatchObject({_tag: "Composed"});
+		expect(spliced._tag === "Composed" && spliced.body).toBe(
+			`${ENRICHED.trimEnd()}\n\n${PLAN.trimEnd()}\n\n${TOPOLOGY.trimEnd()}\n`,
+		);
+	});
+
+	it("refuses when the body already carries a plan heading — the mode contradicts the body", () => {
+		expect(splice(`${ENRICHED}\n${PLAN}\n${TOPOLOGY}`, "fresh")).toEqual({
+			_tag: "Unresolvable",
+			reason:
+				'#4300\'s body carries 1 "## Plan (plan-epic)" headings — the plan region has no single meaning.',
+		});
+	});
+});
+
+describe("splicePlan on a re-plan", () => {
+	const PLANNED = `${ENRICHED}\n## Plan (plan-epic)\n\n### Summary\n\nAn older plan.\n\n## Dependencies\n\n- phase 1: #4288\n`;
+
+	it("replaces the bounded region and preserves every byte above it", () => {
+		const spliced = splice(PLANNED, "re-plan");
+		expect(spliced).toMatchObject({_tag: "Composed"});
+		const body = spliced._tag === "Composed" ? spliced.body : "";
+		expect(body.startsWith(ENRICHED.trimEnd())).toBe(true);
+		expect(body).toContain("A plan.");
+		expect(body).not.toContain("An older plan.");
+		expect(body).not.toContain("#4288");
+	});
+
+	/**
+	 * v1 sliced from the `## Dependencies` heading to EOF on the assumption that dependencies are the
+	 * last section, destroying anything a human had appended below with no guard at all.
+	 */
+	it("preserves a human's section below the dependencies block", () => {
+		const spliced = splice(`${PLANNED}\n## Notes\n\nA human wrote this.\n`, "re-plan");
+		expect(spliced._tag === "Composed" && spliced.body).toContain("A human wrote this.");
+	});
+
+	it("refuses when the plan anchor drifted or was deleted", () => {
+		expect(splice(ENRICHED, "re-plan")).toEqual({
+			_tag: "Unresolvable",
+			reason:
+				'mode is re-plan and the body carries no "## Plan (plan-epic)" heading — the anchor drifted or was deleted.',
+		});
+	});
+
+	/** #4879: cutting at a `## Dependencies` heading inside the preserved brief is how a body is destroyed. */
+	it("refuses a dependencies heading that resolves inside the preserved brief envelope", () => {
+		const trap = [
+			"## Pitch",
+			"",
+			"<!-- fabrika:enriched issue=4300 mode=wrap -->",
+			"<details>",
+			"<summary>Original brief (verbatim)</summary>",
+			"",
+			"## Dependencies",
+			"",
+			"- phase 1: #1",
+			"",
+			"</details>",
+			"",
+			"## Plan (plan-epic)",
+			"",
+			"### Summary",
+			"",
+			"An older plan.",
+			"",
+		].join("\n");
+		expect(splice(trap, "re-plan")).toMatchObject({
+			reason: expect.stringContaining("resolves inside the preserved brief envelope"),
+		});
+	});
+
+	it("refuses two plan headings", () => {
+		expect(splice(`${PLANNED}\n${PLAN}`, "re-plan")).toMatchObject({
+			reason: expect.stringContaining('carries 2 "## Plan (plan-epic)" headings'),
+		});
+	});
+});

--- a/packages/fabrika-cli/src/ledger/run-io.ts
+++ b/packages/fabrika-cli/src/ledger/run-io.ts
@@ -1,0 +1,164 @@
+/**
+ * Reading and writing the run directory — the one place the five later verbs touch it.
+ *
+ * Everything here refuses rather than defaults. A `run.json` that is absent or unparseable is `11`:
+ * the run is **UNKNOWN**, never assumed `fresh`. A manifest that will not parse is `11` too, never
+ * "this run has no children" — the two take opposite branches and only one of them is a fact.
+ *
+ * Stdin arrives through the imported three-way read, and its two empty arms never collapse: a
+ * non-blocking pipe throws `EAGAIN` before its producer writes, so swallowing that to `""` would make
+ * an unread pipe byte-identical to an empty one.
+ */
+
+import {Effect, FileSystem, Path} from "effect";
+import {renderLeaks, scanBody} from "../report/leaks.ts";
+import {refuse, type VerbOutcome} from "../verb.ts";
+import {LEAKED_PATH, PRECONDITION_UNKNOWN} from "./codes.ts";
+import type {LedgerMessages} from "./preconditions.ts";
+import {
+	type ChildRecord,
+	manifestPath,
+	parseManifest,
+	parseRunRecord,
+	type RunRecord,
+	renderChildRecord,
+	renderManifest,
+	runJsonPath,
+} from "./run.ts";
+
+export type Loaded<A> =
+	| {readonly _tag: "Refused"; readonly outcome: VerbOutcome}
+	| {readonly _tag: "Loaded"; readonly value: A};
+
+const refused = <A>(outcome: VerbOutcome): Loaded<A> => ({_tag: "Refused", outcome});
+
+/** Read a file, or the reason it could not be read — absence and a fault are one answer here. */
+const readText = (
+	fs: FileSystem.FileSystem,
+	path: string,
+): Effect.Effect<{text: string} | {reason: string}> =>
+	fs.readFileString(path).pipe(
+		Effect.map((text) => ({text})),
+		Effect.catchTag("PlatformError", (cause) => Effect.succeed({reason: cause.message})),
+	);
+
+/** `run.json`, or the `11` refusal. The run is UNKNOWN when it cannot be read or does not parse. */
+export const loadRun = (
+	messages: LedgerMessages,
+	dir: string,
+	notes: ReadonlyArray<string>,
+): Effect.Effect<Loaded<RunRecord>, never, FileSystem.FileSystem> =>
+	Effect.gen(function* () {
+		const fs = yield* FileSystem.FileSystem;
+		const path = runJsonPath(dir);
+		const read = yield* readText(fs, path);
+		if ("reason" in read) {
+			return refused<RunRecord>(
+				refuse(PRECONDITION_UNKNOWN, messages.unreadable(path, read.reason), notes),
+			);
+		}
+		const record = parseRunRecord(read.text);
+		return record === null
+			? refused<RunRecord>(
+					refuse(PRECONDITION_UNKNOWN, messages.unreadable(path, "it is not a run record"), notes),
+				)
+			: {_tag: "Loaded", value: record};
+	});
+
+/** `children.jsonl`, or the `11` refusal. An absent manifest is unreadable, not empty. */
+export const loadManifest = (
+	messages: LedgerMessages,
+	dir: string,
+	notes: ReadonlyArray<string>,
+): Effect.Effect<Loaded<ReadonlyArray<ChildRecord>>, never, FileSystem.FileSystem> =>
+	Effect.gen(function* () {
+		const fs = yield* FileSystem.FileSystem;
+		const path = manifestPath(dir);
+		const read = yield* readText(fs, path);
+		if ("reason" in read) {
+			return refused<ReadonlyArray<ChildRecord>>(
+				refuse(PRECONDITION_UNKNOWN, messages.unreadable(path, read.reason), notes),
+			);
+		}
+		const records = parseManifest(read.text);
+		return records === null
+			? refused<ReadonlyArray<ChildRecord>>(
+					refuse(
+						PRECONDITION_UNKNOWN,
+						messages.unreadable(path, "one of its lines is not a child record"),
+						notes,
+					),
+				)
+			: {_tag: "Loaded", value: records};
+	});
+
+/** A staged document's bytes, or `null` when this run never staged it. */
+export const loadStaged = (
+	path: string,
+): Effect.Effect<string | null, never, FileSystem.FileSystem> =>
+	Effect.gen(function* () {
+		const fs = yield* FileSystem.FileSystem;
+		const read = yield* readText(fs, path);
+		return "reason" in read ? null : read.text;
+	});
+
+/** Write a document into the run directory; the reason it did not land, or `null`. */
+export const stage = (
+	path: string,
+	text: string,
+): Effect.Effect<string | null, never, FileSystem.FileSystem | Path.Path> =>
+	Effect.gen(function* () {
+		const fs = yield* FileSystem.FileSystem;
+		const pathService = yield* Path.Path;
+		return yield* fs.makeDirectory(pathService.dirname(path), {recursive: true}).pipe(
+			Effect.andThen(fs.writeFileString(path, text)),
+			Effect.as(null),
+			Effect.catchTag("PlatformError", (cause) => Effect.succeed(cause.message)),
+		);
+	});
+
+/** Append one child record to the manifest; the reason it did not land, or `null`. */
+export const appendChild = (
+	dir: string,
+	record: ChildRecord,
+): Effect.Effect<string | null, never, FileSystem.FileSystem | Path.Path> =>
+	Effect.gen(function* () {
+		const fs = yield* FileSystem.FileSystem;
+		const path = manifestPath(dir);
+		const read = yield* readText(fs, path);
+		const current = "reason" in read ? "" : read.text;
+		const separator = current === "" || current.endsWith("\n") ? "" : "\n";
+		return yield* stage(path, `${current}${separator}${renderChildRecord(record)}\n`);
+	});
+
+/** Rewrite one child's manifest line — how a proven link becomes `linked: true`. */
+export const rewriteChild = (
+	dir: string,
+	records: ReadonlyArray<ChildRecord>,
+	replacement: ChildRecord,
+): Effect.Effect<string | null, never, FileSystem.FileSystem | Path.Path> =>
+	stage(
+		manifestPath(dir),
+		renderManifest(
+			records.map((record) => (record.number === replacement.number ? replacement : record)),
+		),
+	);
+
+/**
+ * The leak refusal over authored text, **masked**.
+ *
+ * The predicate is the shipped `report/leaks.ts` one, imported; only the wording is this group's — and
+ * the one substantive difference from `build/authored.ts`'s sibling is that the path is masked before
+ * it is printed. A refusal that quotes the raw path re-leaks it into the run log the refusal was
+ * written to keep it out of; masking through the same scanner is what keeps the two consistent.
+ */
+export const maskedLeakRefusal = (verb: string, what: string, text: string): VerbOutcome | null => {
+	const scan = scanBody(text);
+	const first = scan.leaks[0];
+	if (first === undefined) return null;
+	return refuse(
+		LEAKED_PATH,
+		`${verb}: the ${what} carries a machine-local path (${scanBody(first.text).redacted}).`,
+		renderLeaks(scan.leaks),
+	);
+};

--- a/packages/fabrika-cli/src/ledger/run.ts
+++ b/packages/fabrika-cli/src/ledger/run.ts
@@ -1,0 +1,145 @@
+/**
+ * The run directory: where a planning run keeps everything, so nothing survives only in a model's head.
+ *
+ * **The key is the claim nonce, never the session.** Every sibling subagent of one session shares
+ * `CLAUDE_CODE_SESSION_ID` (measured, #4500), so a session-keyed namespace collapses exactly the
+ * isolation two parallel planning lanes need (#4516, #4544). The shipped precedents are
+ * `build/scratch-verb.ts` and `epic/ledger.ts`.
+ *
+ * Four files, each named for what it holds, and between them they are the reason a compaction between
+ * minting and splicing loses nothing: `run.json` (the run's identity, decided once by `ledger open`),
+ * `plan.md` and `topology.md` (the staged documents `ledger write` splices), and `children.jsonl` (the
+ * epic's **whole** child set — seeded from the live sub-issue list, appended to as children are minted).
+ *
+ * A manifest line that does not parse fails the read. It never resolves to "this run has no children":
+ * an unreadable manifest and an empty one take opposite branches, and only one of them is a fact.
+ */
+
+import {isRecord, parseJson} from "../io/json.ts";
+
+/** The directory the run tree lives under, inside the epic's worktree. */
+export const RUN_ROOT = ".fabrika-plan";
+
+/**
+ * The one line `ledger open` appends to `.git/info/exclude`.
+ *
+ * That file is per-worktree and untracked, so the exclusion never enters a diff and never fights a
+ * `--require-clean` check — `epic/ledger.ts`'s `EXCLUDE_ENTRY` shape, applied to this group's root.
+ */
+export const EXCLUDE_ENTRY = `${RUN_ROOT}/`;
+
+/** The run key: `<epic>-<claim-nonce>`. */
+export const runKey = (epic: number, nonce: string): string => `${epic}-${nonce}`;
+
+/** The run's directory inside the epic worktree. */
+export const runDir = (worktreeRoot: string, key: string): string =>
+	`${worktreeRoot.replace(/\/+$/, "")}/${RUN_ROOT}/${key}`;
+
+export const runJsonPath = (dir: string): string => `${dir}/run.json`;
+export const planPath = (dir: string): string => `${dir}/plan.md`;
+export const topologyPath = (dir: string): string => `${dir}/topology.md`;
+export const manifestPath = (dir: string): string => `${dir}/children.jsonl`;
+
+/** How the run's plan region is resolved — decided once, by `ledger open`, and never re-derived. */
+export type PlanMode = "fresh" | "re-plan";
+
+/** Whether the repository carries the cycle doc — the third value is the point (`plan/github.ts`). */
+export type CycleDoc = "present" | "absent" | "unknown";
+
+/**
+ * `run.json` — what `ledger open` decided, read by every later verb.
+ *
+ * **`bodyDigest` is a record, never an input.** `draft` and `write` compare the live body against the
+ * `--body-digest` *flag* and nothing else; a verb that fell back to the recorded value when the flag
+ * was absent would compare the plan against itself and make the moved-epic check vacuous. The field is
+ * here so a successor reading the directory can see what scope the run was opened over.
+ */
+export interface RunRecord {
+	readonly epic: number;
+	readonly run: string;
+	readonly mode: PlanMode;
+	readonly cycleDoc: CycleDoc;
+	readonly bodyDigest: string;
+}
+
+export const renderRunRecord = (record: RunRecord): string => `${JSON.stringify(record)}\n`;
+
+const isMode = (value: unknown): value is PlanMode => value === "fresh" || value === "re-plan";
+
+const isCycleDoc = (value: unknown): value is CycleDoc =>
+	value === "present" || value === "absent" || value === "unknown";
+
+/** The record, or `null` when the bytes are not one — which every caller seats on `11`, never on a default. */
+export const parseRunRecord = (text: string): RunRecord | null => {
+	const value = parseJson(text);
+	if (!isRecord(value)) return null;
+	const {epic, run, mode, cycleDoc, bodyDigest} = value;
+	if (typeof epic !== "number" || typeof run !== "string" || typeof bodyDigest !== "string") {
+		return null;
+	}
+	return isMode(mode) && isCycleDoc(cycleDoc) ? {epic, run, mode, cycleDoc, bodyDigest} : null;
+};
+
+/**
+ * One line of `children.jsonl`.
+ *
+ * `id` is the database id the create response carries, and it is recorded because the sub-issue link
+ * and unlink both take it rather than the number. Without it on the manifest, `supersede` and any
+ * later link retry would have to re-read GitHub for a value the run already held.
+ */
+export interface ChildRecord {
+	readonly number: number;
+	readonly id: number;
+	readonly title: string;
+	readonly type: string | null;
+	readonly priority: string | null;
+	readonly readyFor: string | null;
+	readonly stories: ReadonlyArray<number> | null;
+	readonly containment: string | null;
+	readonly linked: boolean;
+	/** A child this run minted. `supersede` refuses one — a re-plan does not retire its own work. */
+	readonly mintedThisRun: boolean;
+}
+
+export const renderChildRecord = (record: ChildRecord): string => JSON.stringify(record);
+
+export const renderManifest = (records: ReadonlyArray<ChildRecord>): string =>
+	records.length === 0 ? "" : `${records.map(renderChildRecord).join("\n")}\n`;
+
+const stringOrNull = (value: unknown): string | null => (typeof value === "string" ? value : null);
+
+const parseChildRecord = (line: string): ChildRecord | null => {
+	const value = parseJson(line);
+	if (!isRecord(value)) return null;
+	const {number, id, title, stories, linked, mintedThisRun} = value;
+	if (typeof number !== "number" || typeof id !== "number") return null;
+	const ids = Array.isArray(stories)
+		? stories.every((s) => typeof s === "number")
+			? (stories as ReadonlyArray<number>)
+			: null
+		: null;
+	return {
+		number,
+		id,
+		title: typeof title === "string" ? title : "",
+		type: stringOrNull(value.type),
+		priority: stringOrNull(value.priority),
+		readyFor: stringOrNull(value.readyFor),
+		stories: Array.isArray(stories) ? ids : null,
+		containment: stringOrNull(value.containment),
+		linked: linked === true,
+		mintedThisRun: mintedThisRun === true,
+	};
+};
+
+/** Every recorded child, or `null` when any non-blank line is not a record. */
+export const parseManifest = (text: string): ReadonlyArray<ChildRecord> | null => {
+	const records: ChildRecord[] = [];
+	for (const line of text.split("\n")) {
+		if (line.trim() === "") continue;
+		const record = parseChildRecord(line);
+		if (record === null) return null;
+		records.push(record);
+	}
+	return records;
+};

--- a/packages/fabrika-cli/src/ledger/run.unit.test.ts
+++ b/packages/fabrika-cli/src/ledger/run.unit.test.ts
@@ -1,0 +1,83 @@
+import {describe, expect, it} from "vitest";
+import {
+	type ChildRecord,
+	EXCLUDE_ENTRY,
+	parseManifest,
+	parseRunRecord,
+	renderManifest,
+	renderRunRecord,
+	runDir,
+	runKey,
+} from "./run.ts";
+
+const CHILD: ChildRecord = {
+	number: 4301,
+	id: 90210,
+	title: "queue view",
+	type: "type:feature",
+	priority: "p1",
+	readyFor: "agent",
+	stories: [1, 2],
+	containment: "flag",
+	linked: true,
+	mintedThisRun: true,
+};
+
+describe("the run key", () => {
+	/** The key is the claim nonce, never the session: sibling subagents share the session id (#4500). */
+	it("is the epic and the claim nonce", () => {
+		expect(runKey(4300, "c1a4d6f8")).toBe("4300-c1a4d6f8");
+		expect(runDir("/w/", "4300-c1a4d6f8")).toBe("/w/.fabrika-plan/4300-c1a4d6f8");
+	});
+
+	it("excludes its own root from the tree", () => {
+		expect(EXCLUDE_ENTRY).toBe(".fabrika-plan/");
+	});
+});
+
+describe("run.json", () => {
+	it("round-trips", () => {
+		const record = {
+			epic: 4300,
+			run: "4300-c1a4d6f8",
+			mode: "fresh" as const,
+			cycleDoc: "present" as const,
+			bodyDigest: "8f2c1a90b4d7",
+		};
+		expect(parseRunRecord(renderRunRecord(record))).toEqual(record);
+	});
+
+	/** An unparseable record is UNKNOWN, never a default `fresh`. */
+	it("refuses a record whose mode is off its closed set", () => {
+		expect(
+			parseRunRecord('{"epic":1,"run":"x","mode":"maybe","cycleDoc":"present","bodyDigest":"a"}'),
+		).toBeNull();
+	});
+
+	it("refuses bytes that are not JSON at all", () => {
+		expect(parseRunRecord("not json")).toBeNull();
+	});
+});
+
+describe("children.jsonl", () => {
+	it("round-trips one record per line", () => {
+		expect(parseManifest(renderManifest([CHILD, {...CHILD, number: 4302, id: 90211}]))).toEqual([
+			CHILD,
+			{...CHILD, number: 4302, id: 90211},
+		]);
+	});
+
+	it("renders nothing for an empty child set, and reads it back as one", () => {
+		expect(renderManifest([])).toBe("");
+		expect(parseManifest("")).toEqual([]);
+	});
+
+	/** A line that will not parse fails the read; it never resolves to "this run has no children". */
+	it("refuses a manifest with one broken line", () => {
+		expect(parseManifest(`${renderManifest([CHILD])}not a record\n`)).toBeNull();
+	});
+
+	it("refuses a record with no id — the link and unlink are keyed on it", () => {
+		expect(parseManifest('{"number":4301,"title":"x"}\n')).toBeNull();
+	});
+});

--- a/packages/fabrika-cli/src/ledger/supersede-verb.ts
+++ b/packages/fabrika-cli/src/ledger/supersede-verb.ts
@@ -1,0 +1,167 @@
+/**
+ * `ledger supersede` — retire a child the re-plan no longer contains.
+ *
+ * Three legs in a fixed order — **comment, unlink, close** — then a re-read proving the child is
+ * `closed` with `state_reason` `not_planned` and no longer a sub-issue. The order is load-bearing:
+ * closing before unlinking leaves a closed issue still counted as a sub-issue, which the gate reads as
+ * a child in scope that can never carry a live assignee (#5026 names that residue as undecided for
+ * pre-existing children; this verb simply does not create more of it). The journal comment goes first
+ * so the reason survives even if a later leg fails.
+ *
+ * The two refusals are the guard v1's equivalent had none of: it "closed exactly the numbers you name"
+ * with no check at all. A child that is not this epic's is refused, and so is one **this run minted** —
+ * a child the current plan just created is not one the current plan supersedes, and letting that
+ * through is how a re-plan deletes its own work. A *retained* child is exactly what this verb is for,
+ * so the refusal narrows to the minted set rather than the whole manifest.
+ */
+
+import {Effect, type FileSystem} from "effect";
+import type {ChildProcessSpawner} from "effect/unstable/process";
+import {scannedLine} from "../build/target.ts";
+import {createComment} from "../io/issues.ts";
+import {isBareAtReference} from "../report/leaks.ts";
+import {answer, refuse, type VerbOutcome} from "../verb.ts";
+import {
+	BARE_AT_PATH,
+	OFF_VOCABULARY,
+	PRECONDITION_UNKNOWN,
+	READBACK_MISMATCH,
+	WRITE_UNKNOWN,
+	ZERO_SCOPE,
+} from "./codes.ts";
+import {closeAsNotPlanned, listSubIssueEntries, readChildBack, unlinkSubIssue} from "./github.ts";
+import {type LedgerMessages, type OpenOptions, openGround} from "./preconditions.ts";
+import {loadManifest, loadRun, maskedLeakRefusal} from "./run-io.ts";
+
+const VERB = "ledger supersede";
+
+export const MESSAGES: LedgerMessages = {
+	verb: VERB,
+	notAnEpic: (epic) => `${VERB}: #${epic} is not a type:epic.`,
+	unreadable: (what, reason) => `${VERB}: cannot read ${what}: ${reason} — nothing was written.`,
+	notAWorktree: `${VERB}: not in a linked worktree — the run manifest is unreachable.`,
+};
+
+export interface SupersedeOptions extends OpenOptions {
+	readonly child: number;
+	readonly reason: string;
+}
+
+export const runSupersede = (
+	options: SupersedeOptions,
+): Effect.Effect<
+	VerbOutcome,
+	never,
+	ChildProcessSpawner.ChildProcessSpawner | FileSystem.FileSystem
+> =>
+	Effect.gen(function* () {
+		if (isBareAtReference(options.reason)) {
+			return refuse(
+				BARE_AT_PATH,
+				`${VERB}: the reason carries a bare @ path reference — it cannot be redacted.`,
+			);
+		}
+		const leaked = maskedLeakRefusal(VERB, "reason", options.reason);
+		if (leaked !== null) return leaked;
+
+		const ground = yield* openGround(MESSAGES, options);
+		if (ground._tag === "Refused") return ground.outcome;
+		const {repo, epic, dir, notes} = ground;
+
+		const run = yield* loadRun(MESSAGES, dir, notes);
+		if (run._tag === "Refused") return run.outcome;
+
+		const manifest = yield* loadManifest(MESSAGES, dir, notes);
+		if (manifest._tag === "Refused") return manifest.outcome;
+		const recorded = manifest.value.find((record) => record.number === options.child);
+		if (recorded?.mintedThisRun === true) {
+			return refuse(
+				OFF_VOCABULARY,
+				`${VERB}: #${options.child} was minted by this run — refusing to supersede a child of the current plan.`,
+				notes,
+			);
+		}
+
+		const children = yield* listSubIssueEntries(repo, epic.number);
+		if (children._tag === "Failure") {
+			return refuse(
+				PRECONDITION_UNKNOWN,
+				MESSAGES.unreadable(`#${epic.number}'s sub-issue list`, children.reason),
+				notes,
+			);
+		}
+		const entry = children.value.find((row) => row.number === options.child);
+		if (entry === undefined) {
+			return refuse(
+				OFF_VOCABULARY,
+				`${VERB}: #${options.child} is not a sub-issue of #${epic.number}.`,
+				notes,
+			);
+		}
+
+		const before = yield* readChildBack(repo, options.child);
+		if (before._tag === "Absent" || (before._tag === "Present" && before.value.state !== "open")) {
+			return refuse(
+				ZERO_SCOPE,
+				`${VERB}: issue #${options.child} is proven absent or closed.`,
+				notes,
+			);
+		}
+		if (before._tag === "Unknown") {
+			return refuse(
+				PRECONDITION_UNKNOWN,
+				MESSAGES.unreadable(`#${options.child}`, before.reason),
+				notes,
+			);
+		}
+
+		const unproven = (legs: number, why: string): VerbOutcome =>
+			refuse(
+				WRITE_UNKNOWN,
+				`${VERB}: wrote ${legs} of 3 legs on #${options.child} and could not prove the rest — the child is UNKNOWN.`,
+				[...notes, `${VERB}: ${why}.`],
+			);
+
+		const journal = yield* createComment(
+			repo,
+			options.child,
+			`Superseded by re-plan of #${epic.number}: ${options.reason}.`,
+		);
+		if (journal._tag === "Failure") return unproven(0, journal.reason);
+
+		const unlinked = yield* unlinkSubIssue(repo, epic.number, entry.id);
+		if (unlinked._tag === "Failure") return unproven(1, unlinked.reason);
+
+		const closed = yield* closeAsNotPlanned(repo, options.child);
+		if (closed._tag === "Failure") return unproven(2, closed.reason);
+
+		const after = yield* readChildBack(repo, options.child);
+		if (after._tag !== "Present") return unproven(3, "the confirming read failed");
+		const siblings = yield* listSubIssueEntries(repo, epic.number);
+		if (siblings._tag === "Failure") return unproven(3, siblings.reason);
+
+		const stillLinked = siblings.value.some((row) => row.number === options.child);
+		if (
+			after.value.state !== "closed" ||
+			after.value.stateReason !== "not_planned" ||
+			stillLinked
+		) {
+			return refuse(
+				READBACK_MISMATCH,
+				`${VERB}: #${options.child} does not read back as closed and unlinked — it needs a human eye.`,
+				notes,
+			);
+		}
+
+		return answer(
+			JSON.stringify({
+				answer: "superseded",
+				epic: epic.number,
+				child: options.child,
+				comment: journal.value.id,
+				unlinked: true,
+				state: after.value.state,
+			}),
+			[...notes, scannedLine(VERB, 1, "retired child", `${children.value.length} linked before`)],
+		);
+	});

--- a/packages/fabrika-cli/src/ledger/supersede-verb.unit.test.ts
+++ b/packages/fabrika-cli/src/ledger/supersede-verb.unit.test.ts
@@ -1,0 +1,226 @@
+import {Effect, Layer} from "effect";
+import {describe, expect, it} from "vitest";
+import {LINKED} from "../build/fixtures.test-support.ts";
+import {errOut, fakeFs, fakeShell, okOut, once} from "../fakes.test-support.ts";
+import type {ExecResult} from "../io/exec.ts";
+import {
+	BARE_AT_PATH,
+	LEAKED_PATH,
+	OFF_VOCABULARY,
+	PRECONDITION_UNKNOWN,
+	READBACK_MISMATCH,
+	WRITE_UNKNOWN,
+	ZERO_SCOPE,
+} from "./codes.ts";
+import {bodyDigest} from "./digest.ts";
+import {CLAIMED, childIssue, DIR, env, epic, subIssues} from "./fixtures.test-support.ts";
+import {
+	type ChildRecord,
+	manifestPath,
+	renderManifest,
+	renderRunRecord,
+	runJsonPath,
+} from "./run.ts";
+import {runSupersede} from "./supersede-verb.ts";
+
+const SUBS = /^gh api --paginate repos\/o\/r\/issues\/4300\/sub_issues/;
+const CHILD = /^gh api repos\/o\/r\/issues\/4288$/;
+const COMMENT = /^gh api --method POST repos\/o\/r\/issues\/4288\/comments/;
+const UNLINK = /^gh api --method DELETE repos\/o\/r\/issues\/4300\/sub_issue /;
+const CLOSE = /^gh api --method PATCH repos\/o\/r\/issues\/4288/;
+
+const RUN_JSON = renderRunRecord({
+	epic: 4300,
+	run: "4300-c1a4d6f8",
+	mode: "re-plan",
+	cycleDoc: "present",
+	bodyDigest: bodyDigest("An epic brief about the moderation queue.\n"),
+});
+
+const record = (number: number, mintedThisRun: boolean): ChildRecord => ({
+	number,
+	id: number * 10,
+	title: `child ${number}`,
+	type: "type:feature",
+	priority: "p1",
+	readyFor: "agent",
+	stories: [1],
+	containment: "flag",
+	linked: true,
+	mintedThisRun,
+});
+
+const files = (...records: ReadonlyArray<ChildRecord>) => ({
+	[runJsonPath(DIR)]: RUN_JSON,
+	[manifestPath(DIR)]: renderManifest(records),
+});
+
+const COMMENTED = okOut(
+	JSON.stringify({id: 5230661234, html_url: "https://github.com/o/r/issues/4288#c"}),
+);
+
+/** The three legs and the reads around them; `once` lets each read differ before and after. */
+const happy = (
+	overrides: {
+		comment?: ExecResult;
+		unlink?: ExecResult;
+		close?: ExecResult;
+		after?: ExecResult;
+		afterSubs?: ExecResult;
+	} = {},
+): ReadonlyArray<readonly [RegExp, ExecResult]> => [
+	[/^gh api repos\/o\/r\/issues\/4300$/, epic()],
+	[/^git rev-parse --path-format=absolute/, LINKED],
+	...CLAIMED,
+	[once(SUBS), subIssues({number: 4288, id: 42880})],
+	[once(CHILD), childIssue({number: 4288})],
+	[COMMENT, overrides.comment ?? COMMENTED],
+	[UNLINK, overrides.unlink ?? okOut("{}")],
+	[CLOSE, overrides.close ?? okOut("{}")],
+	[
+		CHILD,
+		overrides.after ?? childIssue({number: 4288, state: "closed", stateReason: "not_planned"}),
+	],
+	[SUBS, overrides.afterSubs ?? okOut("[]")],
+];
+
+const run = (
+	script: ReadonlyArray<readonly [RegExp, ExecResult]> = happy(),
+	fsFiles: Readonly<Record<string, string | null>> = files(record(4288, false)),
+	options: {child?: number; reason?: string} = {},
+) => {
+	const shell = fakeShell(script);
+	const fs = fakeFs({files: fsFiles});
+	return Effect.runPromise(
+		Effect.provide(
+			runSupersede({
+				number: 4300,
+				child: options.child ?? 4288,
+				reason: options.reason ?? "folded into the loader slice",
+				repo: null,
+				env,
+			}),
+			Layer.mergeAll(shell.layer, fs.layer),
+		),
+	).then((outcome) => ({outcome, calls: shell.calls}));
+};
+
+describe("runSupersede", () => {
+	it("comments, unlinks, closes, and proves the result", async () => {
+		const {outcome} = await run();
+		expect(outcome.code).toBe(0);
+		expect(JSON.parse(outcome.stdout)).toEqual({
+			answer: "superseded",
+			epic: 4300,
+			child: 4288,
+			comment: 5230661234,
+			unlinked: true,
+			state: "closed",
+		});
+	});
+
+	/**
+	 * Closing before unlinking leaves a closed issue still counted as a sub-issue, which the gate reads
+	 * as a child in scope that can never carry a live assignee (#5026).
+	 */
+	it("unlinks before it closes, and journals before either", async () => {
+		const {calls} = await run();
+		const order = calls.filter(
+			(line) => COMMENT.test(line) || UNLINK.test(line) || CLOSE.test(line),
+		);
+		expect(
+			order.map((line) =>
+				COMMENT.test(line) ? "comment" : UNLINK.test(line) ? "unlink" : "close",
+			),
+		).toEqual(["comment", "unlink", "close"]);
+	});
+
+	it("unlinks on the child's id, not its number", async () => {
+		const {calls} = await run();
+		expect(calls.find((line) => UNLINK.test(line))).toContain("sub_issue_id=42880");
+	});
+
+	it("refuses a child this run minted — a re-plan does not retire its own work", async () => {
+		const {outcome, calls} = await run(happy(), files(record(4288, true)));
+		expect(outcome.code).toBe(OFF_VOCABULARY);
+		expect(outcome.stderr.at(-1)).toBe(
+			"ledger supersede: #4288 was minted by this run — refusing to supersede a child of the current plan.",
+		);
+		expect(calls.some((line) => COMMENT.test(line))).toBe(false);
+	});
+
+	it("refuses a child that is not this epic's sub-issue", async () => {
+		const {outcome} = await run(
+			[
+				[/^gh api repos\/o\/r\/issues\/4300$/, epic()],
+				[/^git rev-parse --path-format=absolute/, LINKED],
+				...CLAIMED,
+				[SUBS, subIssues({number: 4301, id: 43010})],
+			],
+			files(),
+		);
+		expect(outcome.code).toBe(OFF_VOCABULARY);
+		expect(outcome.stderr.at(-1)).toBe("ledger supersede: #4288 is not a sub-issue of #4300.");
+	});
+
+	it("refuses a child that is already closed", async () => {
+		const {outcome} = await run([
+			[/^gh api repos\/o\/r\/issues\/4300$/, epic()],
+			[/^git rev-parse --path-format=absolute/, LINKED],
+			...CLAIMED,
+			[SUBS, subIssues({number: 4288, id: 42880})],
+			[CHILD, childIssue({number: 4288, state: "closed"})],
+		]);
+		expect(outcome.code).toBe(ZERO_SCOPE);
+	});
+
+	it("refuses a reason carrying a machine-local path, masked", async () => {
+		const {outcome, calls} = await run(happy(), files(record(4288, false)), {
+			reason: "see /Users/someone/notes.md",
+		});
+		expect(outcome.code).toBe(LEAKED_PATH);
+		expect(outcome.stderr.join("\n")).toContain("/Users/<redacted>");
+		expect(calls).toEqual([]);
+	});
+
+	it("refuses a reason that is a bare @ path reference", async () => {
+		const {outcome} = await run(happy(), files(record(4288, false)), {reason: "@some/path.md"});
+		expect(outcome.code).toBe(BARE_AT_PATH);
+	});
+
+	/** The journal is posted first so the reason survives even if a later leg fails. */
+	it("reports how many legs landed when one could not be proven", async () => {
+		const {outcome} = await run(happy({unlink: errOut("gh: Bad Gateway (HTTP 502)")}));
+		expect(outcome.code).toBe(WRITE_UNKNOWN);
+		expect(outcome.stderr.at(-1)).toBe(
+			"ledger supersede: wrote 1 of 3 legs on #4288 and could not prove the rest — the child is UNKNOWN.",
+		);
+	});
+
+	it("refuses when the child does not read back closed", async () => {
+		const {outcome} = await run(happy({after: childIssue({number: 4288, state: "open"})}));
+		expect(outcome.code).toBe(READBACK_MISMATCH);
+	});
+
+	it("refuses when the child reads back closed for the wrong reason", async () => {
+		const {outcome} = await run(
+			happy({after: childIssue({number: 4288, state: "closed", stateReason: "completed"})}),
+		);
+		expect(outcome.code).toBe(READBACK_MISMATCH);
+	});
+
+	it("refuses when the child is still linked after the unlink", async () => {
+		const {outcome} = await run(happy({afterSubs: subIssues({number: 4288, id: 42880})}));
+		expect(outcome.code).toBe(READBACK_MISMATCH);
+	});
+
+	it("refuses when the sub-issue list could not be read", async () => {
+		const {outcome} = await run([
+			[/^gh api repos\/o\/r\/issues\/4300$/, epic()],
+			[/^git rev-parse --path-format=absolute/, LINKED],
+			...CLAIMED,
+			[SUBS, errOut("gh: Bad Gateway (HTTP 502)")],
+		]);
+		expect(outcome.code).toBe(PRECONDITION_UNKNOWN);
+	});
+});

--- a/packages/fabrika-cli/src/ledger/topology-doc.ts
+++ b/packages/fabrika-cli/src/ledger/topology-doc.ts
@@ -1,0 +1,248 @@
+/**
+ * The declared topology: a line grammar in, a `## Dependencies` block out, and the round trip that
+ * proves the two agree.
+ *
+ * **This module adds no second `## Dependencies` grammar.** It composes a block the shipped
+ * `build/dependencies.ts` parser reads back, and the composed block is parsed through that very parser
+ * before anything is staged. A block the gate's parser reads differently from how its author meant it
+ * is exactly the class of defect nobody notices until a build runs in the wrong order — v1 had no
+ * round-trip check at all, and the first time anyone learned the topology parsed differently than
+ * intended was when the gate derived the wrong defects.
+ *
+ * The cycle walk runs over the **union** of the declared `requires` edges and the edges the phase
+ * order implies, so a `requires` that contradicts its phases (a phase-1 child requiring a phase-2 one)
+ * surfaces as the cycle it is rather than staging cleanly.
+ */
+
+import {readTopology} from "../build/dependencies.ts";
+
+const LINE_RE = /^#(\d+)\s+phase\s+(\S+)(?:\s+requires\s+(.+))?$/i;
+const REF_RE = /^#(\d+)$/;
+
+export interface DeclaredLine {
+	readonly child: number;
+	readonly phase: number;
+	readonly requires: ReadonlyArray<number>;
+}
+
+export type LineParse =
+	| {readonly _tag: "Line"; readonly line: DeclaredLine}
+	/** The line does not match the grammar at all — a `4`. */
+	| {readonly _tag: "Unparseable"; readonly index: number; readonly text: string}
+	/** The line parses and a value is off its closed vocabulary — a `10`. */
+	| {readonly _tag: "OffVocabulary"; readonly phase: string};
+
+/** Parse one stdin line. Blank lines are the caller's to drop before this is reached. */
+export const parseLine = (text: string, index: number): LineParse => {
+	const matched = LINE_RE.exec(text.trim());
+	if (matched?.[1] === undefined || matched[2] === undefined) {
+		return {_tag: "Unparseable", index, text: text.trim()};
+	}
+	if (!/^\d+$/.test(matched[2]) || Number.parseInt(matched[2], 10) < 1) {
+		return {_tag: "OffVocabulary", phase: matched[2]};
+	}
+	const requires: number[] = [];
+	for (const raw of (matched[3] ?? "").split(",")) {
+		const part = raw.trim();
+		if (part === "") continue;
+		const ref = REF_RE.exec(part);
+		if (ref?.[1] === undefined) return {_tag: "Unparseable", index, text: text.trim()};
+		requires.push(Number.parseInt(ref[1], 10));
+	}
+	return {
+		_tag: "Line",
+		line: {
+			child: Number.parseInt(matched[1], 10),
+			phase: Number.parseInt(matched[2], 10),
+			requires,
+		},
+	};
+};
+
+/** `[dependent, prerequisite]` — `["#4303","#4301"]` reads *#4303 requires #4301*. */
+export type Edge = readonly [string, string];
+
+const ascending = (values: ReadonlyArray<number>): ReadonlyArray<number> =>
+	[...values].sort((a, b) => a - b);
+
+/** The block, in the grammar `build/dependencies.ts` reads: phase lines, then the `requires:` lines. */
+export const renderDependencies = (lines: ReadonlyArray<DeclaredLine>): string => {
+	const phases = [...new Set(lines.map((line) => line.phase))].sort((a, b) => a - b);
+	const rows: string[] = ["## Dependencies", ""];
+	for (const phase of phases) {
+		const members = ascending(
+			lines.filter((line) => line.phase === phase).map((line) => line.child),
+		);
+		rows.push(`- phase ${phase}: ${members.map((n) => `#${n}`).join(", ")}`);
+	}
+	for (const line of [...lines].sort((a, b) => a.child - b.child)) {
+		if (line.requires.length === 0) continue;
+		rows.push(
+			`- #${line.child} requires: ${ascending(line.requires)
+				.map((n) => `#${n}`)
+				.join(", ")}`,
+		);
+	}
+	// The trailing blank line keeps a later heading separated from the last row.
+	return `${rows.join("\n")}\n`;
+};
+
+/** The canonical serialization both sides of the round trip are compared through. */
+const canonical = (
+	phases: ReadonlyMap<number, ReadonlyArray<number>>,
+	requires: ReadonlyMap<number, ReadonlyArray<number>>,
+): string =>
+	[
+		[...phases.entries()]
+			.sort((a, b) => a[0] - b[0])
+			.map(([phase, members]) => `p${phase}:${ascending(members).join(",")}`)
+			.join(";"),
+		[...requires.entries()]
+			.sort((a, b) => a[0] - b[0])
+			.map(([subject, needs]) => `${subject}>${ascending(needs).join(",")}`)
+			.join(";"),
+	].join("|");
+
+const declaredCanonical = (lines: ReadonlyArray<DeclaredLine>): string => {
+	const phases = new Map<number, number[]>();
+	const requires = new Map<number, number[]>();
+	for (const line of lines) {
+		phases.set(line.phase, [...(phases.get(line.phase) ?? []), line.child]);
+		if (line.requires.length > 0) requires.set(line.child, [...line.requires]);
+	}
+	return canonical(phases, requires);
+};
+
+/** The same serialization, taken over what the shipped parser read back out of the rendered block. */
+const parsedCanonical = (block: string): string | null => {
+	const parsed = readTopology(block);
+	if (parsed._tag !== "Parsed") return null;
+	const phases = new Map<number, number[]>();
+	const requires = new Map<number, number[]>();
+	for (const edge of parsed.edges) {
+		if (edge._tag === "Phase") {
+			const members: number[] = [];
+			for (const ref of edge.members) {
+				if (ref._tag !== "Issue") return null;
+				members.push(ref.number);
+			}
+			phases.set(edge.phase, [...(phases.get(edge.phase) ?? []), ...members]);
+			continue;
+		}
+		if (edge.subject._tag !== "Issue") return null;
+		const needs: number[] = [];
+		for (const ref of edge.needs) {
+			if (ref._tag !== "Issue") return null;
+			needs.push(ref.number);
+		}
+		requires.set(edge.subject.number, [...(requires.get(edge.subject.number) ?? []), ...needs]);
+	}
+	return canonical(phases, requires);
+};
+
+/** The union graph: `requires` edges plus the edges the phase order implies. */
+const dependencyGraph = (
+	lines: ReadonlyArray<DeclaredLine>,
+): ReadonlyMap<number, ReadonlyArray<number>> => {
+	const graph = new Map<number, number[]>();
+	for (const line of lines) {
+		const earlier = lines.filter((other) => other.phase < line.phase).map((other) => other.child);
+		graph.set(line.child, [...new Set([...line.requires, ...earlier])]);
+	}
+	return graph;
+};
+
+/** The first cycle in the graph, as the ref path a refusal prints, or `null`. */
+export const findCycle = (lines: ReadonlyArray<DeclaredLine>): ReadonlyArray<number> | null => {
+	const graph = dependencyGraph(lines);
+	const state = new Map<number, "open" | "done">();
+	const stack: number[] = [];
+
+	const walk = (node: number): ReadonlyArray<number> | null => {
+		const seen = state.get(node);
+		if (seen === "done") return null;
+		if (seen === "open") return [...stack.slice(stack.indexOf(node)), node];
+		state.set(node, "open");
+		stack.push(node);
+		for (const next of graph.get(node) ?? []) {
+			const found = walk(next);
+			if (found !== null) return found;
+		}
+		stack.pop();
+		state.set(node, "done");
+		return null;
+	};
+
+	for (const line of lines) {
+		const found = walk(line.child);
+		if (found !== null) return found;
+	}
+	return null;
+};
+
+export type TopologyCheck =
+	| {
+			readonly _tag: "Ok";
+			readonly block: string;
+			readonly phases: number;
+			readonly edges: ReadonlyArray<Edge>;
+	  }
+	| {readonly _tag: "Invalid"; readonly reason: string};
+
+const invalid = (reason: string): TopologyCheck => ({_tag: "Invalid", reason});
+
+/**
+ * Validate the declared lines against the run manifest's child set, then render and prove the round
+ * trip.
+ *
+ * The manifest is the epic's **whole** child set, retained children included — which is what makes a
+ * `re-plan` placeable. A manifest child with no line is an unplaced child; a line naming a number that
+ * is not in the manifest is a dangling reference. Both are the same refusal, because both produce a
+ * block the gate reads as a broken epic.
+ */
+export const checkTopology = (
+	epic: number,
+	lines: ReadonlyArray<DeclaredLine>,
+	manifest: ReadonlyArray<number>,
+): TopologyCheck => {
+	const counts = new Map<number, number>();
+	for (const line of lines) counts.set(line.child, (counts.get(line.child) ?? 0) + 1);
+	for (const [child, count] of counts) {
+		if (count > 1) {
+			return invalid(`#${child} is declared ${count} times — a child sits in exactly one phase.`);
+		}
+	}
+
+	const known = new Set(manifest);
+	for (const line of lines) {
+		for (const ref of [line.child, ...line.requires]) {
+			if (!known.has(ref)) return invalid(`#${ref} is referenced but is not a child of #${epic}.`);
+		}
+	}
+	for (const child of manifest) {
+		if (!counts.has(child)) return invalid(`child #${child} is placed in no phase.`);
+	}
+
+	const cycle = findCycle(lines);
+	if (cycle !== null) {
+		return invalid(`cycle: ${cycle.map((n) => `#${n}`).join(" → ")}`);
+	}
+
+	const block = renderDependencies(lines);
+	if (parsedCanonical(block) !== declaredCanonical(lines)) {
+		return invalid(
+			"the rendered block does not parse back to the declared edges — refusing to stage it.",
+		);
+	}
+
+	const edges: Edge[] = [];
+	for (const line of [...lines].sort((a, b) => a.child - b.child)) {
+		for (const need of ascending(line.requires)) edges.push([`#${line.child}`, `#${need}`]);
+	}
+	return {
+		_tag: "Ok",
+		block,
+		phases: new Set(lines.map((line) => line.phase)).size,
+		edges,
+	};
+};

--- a/packages/fabrika-cli/src/ledger/topology-doc.unit.test.ts
+++ b/packages/fabrika-cli/src/ledger/topology-doc.unit.test.ts
@@ -1,0 +1,133 @@
+import {describe, expect, it} from "vitest";
+import {readTopology} from "../build/dependencies.ts";
+import {
+	checkTopology,
+	type DeclaredLine,
+	findCycle,
+	parseLine,
+	renderDependencies,
+} from "./topology-doc.ts";
+
+const line = (
+	child: number,
+	phase: number,
+	requires: ReadonlyArray<number> = [],
+): DeclaredLine => ({
+	child,
+	phase,
+	requires,
+});
+
+describe("parseLine", () => {
+	it("reads a bare phase line", () => {
+		expect(parseLine("#4301 phase 1", 1)).toEqual({_tag: "Line", line: line(4301, 1)});
+	});
+
+	it("reads a requires clause, single and comma-separated", () => {
+		expect(parseLine("#4303 phase 2 requires #4301", 1)).toEqual({
+			_tag: "Line",
+			line: line(4303, 2, [4301]),
+		});
+		expect(parseLine("#4303 phase 2 requires #4301, #4302", 1)).toEqual({
+			_tag: "Line",
+			line: line(4303, 2, [4301, 4302]),
+		});
+	});
+
+	it("refuses a line off the grammar", () => {
+		expect(parseLine("4301 in phase one", 7)).toEqual({
+			_tag: "Unparseable",
+			index: 7,
+			text: "4301 in phase one",
+		});
+	});
+
+	/** A phase off its closed vocabulary is a semantic refusal (`10`), not a malformed-flag `4`. */
+	it("separates a non-integer phase from an unparseable line", () => {
+		expect(parseLine("#4301 phase two", 1)).toEqual({_tag: "OffVocabulary", phase: "two"});
+		expect(parseLine("#4301 phase 0", 1)).toEqual({_tag: "OffVocabulary", phase: "0"});
+	});
+});
+
+describe("renderDependencies", () => {
+	it("renders phases ascending, members ascending, then the requires lines", () => {
+		expect(renderDependencies([line(4302, 1), line(4301, 1), line(4303, 2, [4301])])).toBe(
+			"## Dependencies\n\n- phase 1: #4301, #4302\n- phase 2: #4303\n- #4303 requires: #4301\n",
+		);
+	});
+
+	/**
+	 * The whole point of composing here rather than in the skill: the block the gate's parser reads is
+	 * the block this verb wrote, proven by parsing it back through that very parser.
+	 */
+	it("round-trips through the shipped `readTopology`", () => {
+		const parsed = readTopology(renderDependencies([line(4301, 1), line(4303, 2, [4301])]));
+		expect(parsed).toMatchObject({_tag: "Parsed"});
+		expect(parsed._tag === "Parsed" && parsed.edges).toEqual([
+			{_tag: "Phase", phase: 1, members: [{_tag: "Issue", number: 4301}]},
+			{_tag: "Phase", phase: 2, members: [{_tag: "Issue", number: 4303}]},
+			{
+				_tag: "Requires",
+				subject: {_tag: "Issue", number: 4303},
+				needs: [{_tag: "Issue", number: 4301}],
+			},
+		]);
+	});
+});
+
+describe("findCycle", () => {
+	it("finds a two-node cycle through requires edges", () => {
+		expect(findCycle([line(1, 1, [2]), line(2, 1, [1])])).toEqual([1, 2, 1]);
+	});
+
+	/** A requires that contradicts its phases is a cycle in the union graph, and says so. */
+	it("finds a cycle a backwards requires creates against the phase order", () => {
+		expect(findCycle([line(1, 1, [2]), line(2, 2)])).not.toBeNull();
+	});
+
+	it("finds none in a plain forward topology", () => {
+		expect(findCycle([line(1, 1), line(2, 2, [1])])).toBeNull();
+	});
+});
+
+describe("checkTopology", () => {
+	it("stages a topology that places every manifest child exactly once", () => {
+		expect(checkTopology(4300, [line(4301, 1), line(4303, 2, [4301])], [4301, 4303])).toMatchObject(
+			{
+				_tag: "Ok",
+				phases: 2,
+				edges: [["#4303", "#4301"]],
+			},
+		);
+	});
+
+	it("refuses a manifest child placed in no phase", () => {
+		expect(checkTopology(4300, [line(4301, 1)], [4301, 4302])).toEqual({
+			_tag: "Invalid",
+			reason: "child #4302 is placed in no phase.",
+		});
+	});
+
+	it("refuses a reference to something that is not a child", () => {
+		expect(checkTopology(4300, [line(4301, 1), line(4302, 2, [9999])], [4301, 4302])).toEqual({
+			_tag: "Invalid",
+			reason: "#9999 is referenced but is not a child of #4300.",
+		});
+	});
+
+	it("refuses a child declared twice", () => {
+		expect(checkTopology(4300, [line(4301, 1), line(4301, 2)], [4301])).toEqual({
+			_tag: "Invalid",
+			reason: "#4301 is declared 2 times — a child sits in exactly one phase.",
+		});
+	});
+
+	it("refuses a cycle and names its members", () => {
+		expect(
+			checkTopology(4300, [line(4301, 1, [4302]), line(4302, 1, [4301])], [4301, 4302]),
+		).toEqual({
+			_tag: "Invalid",
+			reason: "cycle: #4301 → #4302 → #4301",
+		});
+	});
+});

--- a/packages/fabrika-cli/src/ledger/topology-verb.ts
+++ b/packages/fabrika-cli/src/ledger/topology-verb.ts
@@ -1,0 +1,129 @@
+/**
+ * `ledger topology` — validate the declared edges against the recorded children and render the block.
+ *
+ * A total function from edges to a verdict: cycles, dangling refs and orphans are all decidable, and
+ * the verb decides them. **What it cannot see is a shared-file conflict** — whether two children in one
+ * phase write the same module is a judgment the skill carries (#3709), and the verb does not pretend
+ * otherwise.
+ *
+ * Zero scope reds on `7` rather than `24`, because nothing was validated: an empty manifest means the
+ * epic has no children at all, and rendering a topology over none would produce a block the gate reads
+ * as an epic every one of whose children is orphaned. A refused scope is not an invalid topology
+ * (ADR 0092).
+ */
+
+import {Effect, type FileSystem, type Path} from "effect";
+import type {ChildProcessSpawner} from "effect/unstable/process";
+import {readAuthored} from "../build/authored.ts";
+import {scannedLine} from "../build/target.ts";
+import type {StdinRead} from "../io/stdin.ts";
+import {answer, refuse, type VerbOutcome} from "../verb.ts";
+import {
+	BAD_SECTIONS,
+	OFF_VOCABULARY,
+	PRECONDITION_UNKNOWN,
+	TOPOLOGY_INVALID,
+	ZERO_SCOPE,
+} from "./codes.ts";
+import {type LedgerMessages, type OpenOptions, openGround} from "./preconditions.ts";
+import {topologyPath} from "./run.ts";
+import {loadManifest, loadRun, stage} from "./run-io.ts";
+import {checkTopology, type DeclaredLine, parseLine} from "./topology-doc.ts";
+
+const VERB = "ledger topology";
+
+export const MESSAGES: LedgerMessages = {
+	verb: VERB,
+	notAnEpic: (epic) =>
+		`${VERB}: #${epic} is not a type:epic — refusing to declare a topology for it.`,
+	unreadable: (what, reason) => `${VERB}: cannot read ${what}: ${reason} — nothing was staged.`,
+	notAWorktree: `${VERB}: not in a linked worktree — the run manifest is unreachable.`,
+};
+
+export interface TopologyOptions extends OpenOptions {
+	readonly stdin: Effect.Effect<StdinRead>;
+}
+
+export const runTopology = (
+	options: TopologyOptions,
+): Effect.Effect<
+	VerbOutcome,
+	never,
+	ChildProcessSpawner.ChildProcessSpawner | FileSystem.FileSystem | Path.Path
+> =>
+	Effect.gen(function* () {
+		const authored = readAuthored(
+			{
+				verb: VERB,
+				emptyMessage: `${VERB}: stdin held nothing — there is no topology to declare.`,
+				bareAtMessage: `${VERB}: the declared topology is a bare @ path reference — it cannot be redacted.`,
+			},
+			yield* options.stdin,
+		);
+		if (authored._tag === "Refused") return authored.outcome;
+
+		const ground = yield* openGround(MESSAGES, options);
+		if (ground._tag === "Refused") return ground.outcome;
+		const {epic, dir, notes} = ground;
+
+		const run = yield* loadRun(MESSAGES, dir, notes);
+		if (run._tag === "Refused") return run.outcome;
+
+		const manifest = yield* loadManifest(MESSAGES, dir, notes);
+		if (manifest._tag === "Refused") return manifest.outcome;
+		if (manifest.value.length === 0) {
+			return refuse(
+				ZERO_SCOPE,
+				`${VERB}: the run manifest holds zero children — refusing to render a topology over zero scope (ADR 0092).`,
+				notes,
+			);
+		}
+
+		const lines: DeclaredLine[] = [];
+		for (const [index, text] of authored.text.split("\n").entries()) {
+			if (text.trim() === "") continue;
+			const parsed = parseLine(text, index + 1);
+			if (parsed._tag === "Unparseable") {
+				return refuse(
+					BAD_SECTIONS,
+					`${VERB}: line ${parsed.index} does not parse: "${parsed.text}" — want "#<ref> phase <n> [requires #<a>]".`,
+					notes,
+				);
+			}
+			if (parsed._tag === "OffVocabulary") {
+				return refuse(
+					OFF_VOCABULARY,
+					`${VERB}: phase "${parsed.phase}" is not a positive integer.`,
+					notes,
+				);
+			}
+			lines.push(parsed.line);
+		}
+
+		const checked = checkTopology(
+			epic.number,
+			lines,
+			manifest.value.map((record) => record.number),
+		);
+		if (checked._tag === "Invalid") {
+			return refuse(TOPOLOGY_INVALID, `${VERB}: ${checked.reason}`, notes);
+		}
+
+		const failed = yield* stage(topologyPath(dir), checked.block);
+		if (failed !== null) {
+			return refuse(PRECONDITION_UNKNOWN, MESSAGES.unreadable(topologyPath(dir), failed), notes);
+		}
+
+		return answer(
+			JSON.stringify({
+				answer: "staged",
+				epic: epic.number,
+				document: "topology",
+				phases: checked.phases,
+				children: lines.length,
+				edges: checked.edges,
+				bytes: new TextEncoder().encode(checked.block).length,
+			}),
+			[...notes, scannedLine(VERB, manifest.value.length, "recorded child")],
+		);
+	});

--- a/packages/fabrika-cli/src/ledger/topology-verb.unit.test.ts
+++ b/packages/fabrika-cli/src/ledger/topology-verb.unit.test.ts
@@ -1,0 +1,171 @@
+import {Effect, Layer} from "effect";
+import {describe, expect, it} from "vitest";
+import {LINKED} from "../build/fixtures.test-support.ts";
+import {fakeFs, fakeShell} from "../fakes.test-support.ts";
+import type {ExecResult} from "../io/exec.ts";
+import type {StdinRead} from "../io/stdin.ts";
+import {
+	BAD_SECTIONS,
+	EMPTY_STDIN,
+	OFF_VOCABULARY,
+	PRECONDITION_UNKNOWN,
+	TOPOLOGY_INVALID,
+	ZERO_SCOPE,
+} from "./codes.ts";
+import {bodyDigest} from "./digest.ts";
+import {CLAIMED, DIR, env, epic} from "./fixtures.test-support.ts";
+import {
+	type ChildRecord,
+	manifestPath,
+	renderManifest,
+	renderRunRecord,
+	runJsonPath,
+	topologyPath,
+} from "./run.ts";
+import {runTopology} from "./topology-verb.ts";
+
+const GROUND: ReadonlyArray<readonly [RegExp, ExecResult]> = [
+	[/^gh api repos\/o\/r\/issues\/4300$/, epic()],
+	[/^git rev-parse --path-format=absolute/, LINKED],
+	...CLAIMED,
+];
+
+const RUN_JSON = renderRunRecord({
+	epic: 4300,
+	run: "4300-c1a4d6f8",
+	mode: "fresh",
+	cycleDoc: "present",
+	bodyDigest: bodyDigest("An epic brief about the moderation queue.\n"),
+});
+
+const record = (number: number, mintedThisRun = true): ChildRecord => ({
+	number,
+	id: number * 10,
+	title: `child ${number}`,
+	type: "type:feature",
+	priority: "p1",
+	readyFor: "agent",
+	stories: [1],
+	containment: "flag",
+	linked: true,
+	mintedThisRun,
+});
+
+const files = (...records: ReadonlyArray<ChildRecord>) => ({
+	[runJsonPath(DIR)]: RUN_JSON,
+	[manifestPath(DIR)]: renderManifest(records),
+});
+
+const run = (
+	stdinText: string,
+	fsFiles: Readonly<Record<string, string | null>> = files(record(4301), record(4303)),
+) => {
+	const shell = fakeShell(GROUND);
+	const fs = fakeFs({files: fsFiles});
+	const stdin: Effect.Effect<StdinRead> = Effect.succeed({_tag: "Text", text: stdinText});
+	return Effect.runPromise(
+		Effect.provide(
+			runTopology({number: 4300, repo: null, env, stdin}),
+			Layer.mergeAll(shell.layer, fs.layer),
+		),
+	).then((outcome) => ({outcome, written: fs.written}));
+};
+
+describe("runTopology", () => {
+	it("stages the rendered block and reports the edges it validated", async () => {
+		const {outcome, written} = await run("#4301 phase 1\n#4303 phase 2 requires #4301\n");
+		expect(outcome.code).toBe(0);
+		expect(JSON.parse(outcome.stdout)).toMatchObject({
+			answer: "staged",
+			epic: 4300,
+			document: "topology",
+			phases: 2,
+			children: 2,
+			edges: [["#4303", "#4301"]],
+		});
+		expect(written.get(topologyPath(DIR))).toBe(
+			"## Dependencies\n\n- phase 1: #4301\n- phase 2: #4303\n- #4303 requires: #4301\n",
+		);
+	});
+
+	it("is order-indifferent over its lines", async () => {
+		const {written: forwards} = await run("#4301 phase 1\n#4303 phase 2 requires #4301\n");
+		const {written: backwards} = await run("#4303 phase 2 requires #4301\n#4301 phase 1\n");
+		expect(backwards.get(topologyPath(DIR))).toBe(forwards.get(topologyPath(DIR)));
+	});
+
+	it("refuses a line off the grammar", async () => {
+		const {outcome} = await run("#4301 phase 1\n4303 in phase two\n");
+		expect(outcome.code).toBe(BAD_SECTIONS);
+		expect(outcome.stderr.at(-1)).toBe(
+			'ledger topology: line 2 does not parse: "4303 in phase two" — want "#<ref> phase <n> [requires #<a>]".',
+		);
+	});
+
+	/** A phase off its closed vocabulary is a semantic refusal, never a malformed-line `4`. */
+	it("refuses a phase that is not a positive integer", async () => {
+		const {outcome} = await run("#4301 phase 0\n");
+		expect(outcome.code).toBe(OFF_VOCABULARY);
+		expect(outcome.stderr.at(-1)).toBe('ledger topology: phase "0" is not a positive integer.');
+	});
+
+	it("refuses a manifest child placed in no phase", async () => {
+		const {outcome} = await run("#4301 phase 1\n");
+		expect(outcome.code).toBe(TOPOLOGY_INVALID);
+		expect(outcome.stderr.at(-1)).toBe("ledger topology: child #4303 is placed in no phase.");
+	});
+
+	it("refuses a reference that is not a child of this epic", async () => {
+		const {outcome} = await run("#4301 phase 1\n#4303 phase 2 requires #9999\n");
+		expect(outcome.code).toBe(TOPOLOGY_INVALID);
+		expect(outcome.stderr.at(-1)).toBe(
+			"ledger topology: #9999 is referenced but is not a child of #4300.",
+		);
+	});
+
+	it("refuses a cycle", async () => {
+		const {outcome} = await run("#4301 phase 1 requires #4303\n#4303 phase 1 requires #4301\n");
+		expect(outcome.code).toBe(TOPOLOGY_INVALID);
+		expect(outcome.stderr.at(-1)).toContain("cycle:");
+	});
+
+	/**
+	 * A retained child is in the manifest because `ledger open` seeded it, and that is what makes a
+	 * re-plan placeable — naming one is not a dangling ref and omitting one is not clean.
+	 */
+	it("places a retained child the same as one this run minted", async () => {
+		const {outcome} = await run(
+			"#4301 phase 1\n#4288 phase 1\n",
+			files(record(4301), record(4288, false)),
+		);
+		expect(outcome.code).toBe(0);
+	});
+
+	/** ADR 0092: an empty manifest is a refused scope, never a rendered empty topology. */
+	it("reds on zero scope rather than rendering a topology over no children", async () => {
+		const {outcome, written} = await run("#4301 phase 1\n", files());
+		expect(outcome.code).toBe(ZERO_SCOPE);
+		expect(outcome.stderr.at(-1)).toBe(
+			"ledger topology: the run manifest holds zero children — refusing to render a topology over zero scope (ADR 0092).",
+		);
+		expect(written.size).toBe(0);
+	});
+
+	it("refuses an empty pipe", async () => {
+		const {outcome} = await run("\n\n");
+		expect(outcome.code).toBe(EMPTY_STDIN);
+	});
+
+	it("refuses an unreadable manifest rather than reading it as no children", async () => {
+		const {outcome} = await run("#4301 phase 1\n", {[runJsonPath(DIR)]: RUN_JSON});
+		expect(outcome.code).toBe(PRECONDITION_UNKNOWN);
+	});
+
+	it("refuses a manifest line that does not parse", async () => {
+		const {outcome} = await run("#4301 phase 1\n", {
+			[runJsonPath(DIR)]: RUN_JSON,
+			[manifestPath(DIR)]: "not a record\n",
+		});
+		expect(outcome.code).toBe(PRECONDITION_UNKNOWN);
+	});
+});

--- a/packages/fabrika-cli/src/ledger/write-verb.ts
+++ b/packages/fabrika-cli/src/ledger/write-verb.ts
@@ -1,0 +1,147 @@
+/**
+ * `ledger write` — splice the staged plan and topology into the epic body, byte-verified.
+ *
+ * **`mode` is never re-derived here.** It was decided once by `ledger open`, and a `write` that
+ * recomputed it from the live body could disagree with the `open` that named the run — which is
+ * precisely how the mode-mismatch arm becomes unreachable and a first-time append silently overwrites
+ * a real plan.
+ *
+ * The comparison after the PATCH is over the **whole** normalized body, not a re-extraction of the
+ * region: v1 truncated an epic body to end-of-file whenever a `## Dependencies` heading appeared inside
+ * the preserved brief, and its round-trip check could not see it because both sides ran the same
+ * first-occurrence extractor (#4879). v1 also never checked the PATCH's exit status, so a rejected
+ * write, a failed read and a genuine race all printed "a racer clobbered it" — `8`, `9`, `21` and `22`
+ * are those four states separated. This verb attempts once and says so.
+ */
+
+import {Effect, type FileSystem} from "effect";
+import type {ChildProcessSpawner} from "effect/unstable/process";
+import {scannedLine} from "../build/target.ts";
+import {getIssue, patchIssueBody} from "../io/issues.ts";
+import {normalizeForReadback} from "../report/compose.ts";
+import {answer, refuse, type VerbOutcome} from "../verb.ts";
+import {
+	EPIC_MOVED,
+	NOT_STAGED,
+	OFF_VOCABULARY,
+	READBACK_MISMATCH,
+	REGION_UNRESOLVABLE,
+	WRITE_UNKNOWN,
+} from "./codes.ts";
+import {BODY_DIGEST_RE, bodyDigest} from "./digest.ts";
+import {type LedgerMessages, type OpenOptions, openGround} from "./preconditions.ts";
+import {splicePlan} from "./region.ts";
+import {planPath, topologyPath} from "./run.ts";
+import {loadRun, loadStaged} from "./run-io.ts";
+
+const VERB = "ledger write";
+
+export const MESSAGES: LedgerMessages = {
+	verb: VERB,
+	notAnEpic: (epic) => `${VERB}: #${epic} is not a type:epic — refusing to write a plan into it.`,
+	unreadable: (what, reason) => `${VERB}: cannot read ${what}: ${reason} — nothing was written.`,
+	notAWorktree: `${VERB}: not in a linked worktree — the staged documents are unreachable.`,
+};
+
+export interface WriteOptions extends OpenOptions {
+	readonly bodyDigest: string;
+}
+
+export const runWrite = (
+	options: WriteOptions,
+): Effect.Effect<
+	VerbOutcome,
+	never,
+	ChildProcessSpawner.ChildProcessSpawner | FileSystem.FileSystem
+> =>
+	Effect.gen(function* () {
+		if (!BODY_DIGEST_RE.test(options.bodyDigest)) {
+			return refuse(
+				OFF_VOCABULARY,
+				`${VERB}: --body-digest must be 12 lowercase hex — got "${options.bodyDigest}".`,
+			);
+		}
+
+		const ground = yield* openGround(MESSAGES, options);
+		if (ground._tag === "Refused") return ground.outcome;
+		const {repo, epic, dir, notes} = ground;
+
+		const run = yield* loadRun(MESSAGES, dir, notes);
+		if (run._tag === "Refused") return run.outcome;
+
+		const plan = yield* loadStaged(planPath(dir));
+		if (plan === null) {
+			return refuse(
+				NOT_STAGED,
+				`${VERB}: plan.md was never staged in this run — stage it before writing.`,
+				notes,
+			);
+		}
+		const topology = yield* loadStaged(topologyPath(dir));
+		if (topology === null) {
+			return refuse(
+				NOT_STAGED,
+				`${VERB}: topology.md was never staged in this run — stage it before writing.`,
+				notes,
+			);
+		}
+
+		const observed = bodyDigest(epic.body);
+		if (observed !== options.bodyDigest) {
+			return refuse(
+				EPIC_MOVED,
+				`${VERB}: the epic body moved since open (digest ${options.bodyDigest} → ${observed}) — re-open before writing.`,
+				notes,
+			);
+		}
+
+		const spliced = splicePlan({
+			epic: epic.number,
+			body: epic.body,
+			mode: run.value.mode,
+			plan,
+			topology,
+		});
+		if (spliced._tag === "Unresolvable") {
+			return refuse(REGION_UNRESOLVABLE, `${VERB}: ${spliced.reason}`, notes);
+		}
+
+		const patched = yield* patchIssueBody(repo, epic.number, spliced.body);
+		if (patched._tag === "Failure") {
+			return refuse(
+				WRITE_UNKNOWN,
+				`${VERB}: the PATCH was issued and could not be confirmed — the body is UNKNOWN.`,
+				[...notes, `${VERB}: ${patched.reason}.`],
+			);
+		}
+
+		const reread = yield* getIssue(repo, epic.number);
+		if (reread._tag !== "Present") {
+			return refuse(
+				WRITE_UNKNOWN,
+				`${VERB}: the PATCH was issued and could not be confirmed — the body is UNKNOWN.`,
+				notes,
+			);
+		}
+		if (normalizeForReadback(reread.value.body) !== normalizeForReadback(spliced.body)) {
+			return refuse(
+				READBACK_MISMATCH,
+				`${VERB}: the body was written and does not read back as composed — it needs a human eye.`,
+				notes,
+			);
+		}
+
+		return answer(
+			JSON.stringify({
+				answer: "written",
+				epic: epic.number,
+				mode: run.value.mode,
+				bodyDigest: options.bodyDigest,
+				newDigest: bodyDigest(reread.value.body),
+				planBytes: new TextEncoder().encode(plan).length,
+				topologyBytes: new TextEncoder().encode(topology).length,
+				verified: true,
+			}),
+			[...notes, scannedLine(VERB, 1, "epic body", `mode ${run.value.mode}`)],
+		);
+	});

--- a/packages/fabrika-cli/src/ledger/write-verb.unit.test.ts
+++ b/packages/fabrika-cli/src/ledger/write-verb.unit.test.ts
@@ -1,0 +1,174 @@
+import {Effect, Layer} from "effect";
+import {describe, expect, it} from "vitest";
+import {LINKED} from "../build/fixtures.test-support.ts";
+import {errOut, fakeFs, fakeShell, okOut, once} from "../fakes.test-support.ts";
+import type {ExecResult} from "../io/exec.ts";
+import {
+	EPIC_MOVED,
+	NOT_STAGED,
+	OFF_VOCABULARY,
+	PRECONDITION_UNKNOWN,
+	READBACK_MISMATCH,
+	REGION_UNRESOLVABLE,
+	WRITE_UNKNOWN,
+} from "./codes.ts";
+import {bodyDigest} from "./digest.ts";
+import {CLAIMED, DIR, env, epic} from "./fixtures.test-support.ts";
+import {planPath, renderRunRecord, runJsonPath, topologyPath} from "./run.ts";
+import {runWrite} from "./write-verb.ts";
+
+const EPIC_READ = /^gh api repos\/o\/r\/issues\/4300$/;
+const PATCH = /^gh api --method PATCH repos\/o\/r\/issues\/4300/;
+
+const BODY = "An epic brief about the moderation queue.\n";
+const DIGEST = bodyDigest(BODY);
+const PLAN = "## Plan (plan-epic)\n\n### Summary\n\nA plan.\n";
+const TOPOLOGY = "## Dependencies\n\n- phase 1: #4301\n";
+const SPLICED = `${BODY.trimEnd()}\n\n${PLAN.trimEnd()}\n\n${TOPOLOGY.trimEnd()}\n`;
+
+const runJson = (mode: "fresh" | "re-plan") =>
+	renderRunRecord({
+		epic: 4300,
+		run: "4300-c1a4d6f8",
+		mode,
+		cycleDoc: "present",
+		bodyDigest: DIGEST,
+	});
+
+const STAGED = {
+	[runJsonPath(DIR)]: runJson("fresh"),
+	[planPath(DIR)]: PLAN,
+	[topologyPath(DIR)]: TOPOLOGY,
+};
+
+/**
+ * The two body reads, in the order the write issues them — `once` lets the confirming read differ from
+ * the pre-write one. Built per call, because a spent `once` pattern would leak across tests.
+ */
+const happy = (
+	options: {before?: string; after?: string; patch?: ExecResult} = {},
+): ReadonlyArray<readonly [RegExp, ExecResult]> => [
+	[once(EPIC_READ), epic({body: options.before ?? BODY})],
+	[/^git rev-parse --path-format=absolute/, LINKED],
+	...CLAIMED,
+	[PATCH, options.patch ?? okOut("{}")],
+	[EPIC_READ, epic({body: options.after ?? SPLICED})],
+];
+
+const run = (
+	script: ReadonlyArray<readonly [RegExp, ExecResult]> = happy(),
+	files: Readonly<Record<string, string | null>> = STAGED,
+	digest: string = DIGEST,
+) => {
+	const shell = fakeShell(script);
+	const fs = fakeFs({files});
+	return Effect.runPromise(
+		Effect.provide(
+			runWrite({number: 4300, bodyDigest: digest, repo: null, env}),
+			Layer.mergeAll(shell.layer, fs.layer),
+		),
+	).then((outcome) => ({outcome, calls: shell.calls}));
+};
+
+describe("runWrite", () => {
+	it("splices both documents in one PATCH and proves the whole body read back", async () => {
+		const {outcome, calls} = await run();
+		expect(outcome.code).toBe(0);
+		expect(JSON.parse(outcome.stdout)).toMatchObject({
+			answer: "written",
+			epic: 4300,
+			mode: "fresh",
+			bodyDigest: DIGEST,
+			newDigest: bodyDigest(SPLICED),
+			verified: true,
+		});
+		// One PATCH, and only one. v1 looped three times over a body write whose every branch broke.
+		expect(calls.filter((line) => PATCH.test(line)).length).toBe(1);
+	});
+
+	it("names the document that was never staged", async () => {
+		const {outcome} = await run(happy(), {
+			[runJsonPath(DIR)]: runJson("fresh"),
+			[planPath(DIR)]: PLAN,
+		});
+		expect(outcome.code).toBe(NOT_STAGED);
+		expect(outcome.stderr.at(-1)).toBe(
+			"ledger write: topology.md was never staged in this run — stage it before writing.",
+		);
+	});
+
+	it("names the plan when that is the missing one", async () => {
+		const {outcome} = await run(happy(), {
+			[runJsonPath(DIR)]: runJson("fresh"),
+			[topologyPath(DIR)]: TOPOLOGY,
+		});
+		expect(outcome.stderr.at(-1)).toBe(
+			"ledger write: plan.md was never staged in this run — stage it before writing.",
+		);
+	});
+
+	it("refuses a body that moved since open, and writes nothing", async () => {
+		const {outcome, calls} = await run(happy(), STAGED, "0123456789ab");
+		expect(outcome.code).toBe(EPIC_MOVED);
+		expect(calls.some((line) => PATCH.test(line))).toBe(false);
+	});
+
+	it("refuses a malformed --body-digest before any read", async () => {
+		const {outcome, calls} = await run(happy(), STAGED, "NOPE");
+		expect(outcome.code).toBe(OFF_VOCABULARY);
+		expect(calls).toEqual([]);
+	});
+
+	/**
+	 * `mode` is carried from `ledger open`, never re-derived — which is what makes the disagreement
+	 * observable instead of letting a first-time append silently overwrite a real plan.
+	 */
+	it("refuses a re-plan whose body carries no plan anchor", async () => {
+		const {outcome, calls} = await run(happy(), {
+			...STAGED,
+			[runJsonPath(DIR)]: runJson("re-plan"),
+		});
+		expect(outcome.code).toBe(REGION_UNRESOLVABLE);
+		expect(outcome.stderr.at(-1)).toContain("the anchor drifted or was deleted");
+		expect(calls.some((line) => PATCH.test(line))).toBe(false);
+	});
+
+	it("refuses a fresh run whose body already carries a plan heading", async () => {
+		const body = `${BODY}\n${PLAN}`;
+		const {outcome} = await run(
+			[
+				[once(EPIC_READ), epic({body})],
+				[/^git rev-parse --path-format=absolute/, LINKED],
+				...CLAIMED,
+				[PATCH, okOut("{}")],
+				[EPIC_READ, epic({body})],
+			],
+			{...STAGED, [runJsonPath(DIR)]: runJson("fresh")},
+			bodyDigest(body),
+		);
+		expect(outcome.code).toBe(REGION_UNRESOLVABLE);
+	});
+
+	it("seats an unconfirmable PATCH on 8", async () => {
+		const {outcome} = await run(happy({patch: errOut("gh: Bad Gateway (HTTP 502)")}));
+		expect(outcome.code).toBe(WRITE_UNKNOWN);
+		expect(outcome.stdout).toBe("");
+	});
+
+	/** The comparison is over the WHOLE normalized body, not a re-extraction of the region (#4879). */
+	it("refuses a body that landed and does not read back as composed", async () => {
+		const {outcome} = await run([
+			[once(EPIC_READ), epic()],
+			[/^git rev-parse --path-format=absolute/, LINKED],
+			...CLAIMED,
+			[PATCH, okOut("{}")],
+			[EPIC_READ, epic({body: `${SPLICED}\nsomeone else wrote this\n`})],
+		]);
+		expect(outcome.code).toBe(READBACK_MISMATCH);
+	});
+
+	it("refuses when the run directory holds no run.json", async () => {
+		const {outcome} = await run(happy(), {[planPath(DIR)]: PLAN, [topologyPath(DIR)]: TOPOLOGY});
+		expect(outcome.code).toBe(PRECONDITION_UNKNOWN);
+	});
+});

--- a/packages/fabrika-cli/src/registry.ts
+++ b/packages/fabrika-cli/src/registry.ts
@@ -20,6 +20,7 @@ import {buildCommand} from "./build/command.ts";
 import {epicCommand} from "./epic/command.ts";
 import {evalCommand} from "./eval/command.ts";
 import {hookCommand} from "./hook/command.ts";
+import {ledgerCommand} from "./ledger/command.ts";
 import {planCommand} from "./plan/command.ts";
 import {reportCommand} from "./report/command.ts";
 import {reviewCommand} from "./review/command.ts";
@@ -40,6 +41,7 @@ export const registeredGroups: ReadonlyArray<VerbGroup> = [
 	epicCommand,
 	evalCommand,
 	hookCommand,
+	ledgerCommand,
 	planCommand,
 	reportCommand,
 	reviewCommand,


### PR DESCRIPTION
Fixes #5179

The `plan-epic` skill landed with a derived contract naming six verbs in a new `ledger` group, and
none of them existed — `fabrika ledger` answered `Unknown subcommand "ledger"`. The planning lane had
a gate (`fabrika plan check`) and nothing that could write the thing being judged, so `plan-epic` was
a document rather than a runnable skill. This is the whole group, in one PR, as the approved pitch
binds ("one agent, one PR", 1 cycle).

## What landed

`packages/fabrika-cli/src/ledger/`, registered in `registry.ts`, every leaf declared via
`leafCommand`:

| Verb | What it does |
|---|---|
| `ledger open` | proves the ground fresh against `origin/main`, allocates the run directory on the **claim nonce**, seeds the manifest from the epic's live sub-issue list, probes the cycle doc, ranks duplicate candidates |
| `ledger draft` | validates the plan block's closed section set and its ordered-list story grammar, leak-scans it, stages it |
| `ledger child` | mints one child with **every birth attribute in the one POST**, records it, links it as a native sub-issue, re-reads, and reports the observed result |
| `ledger topology` | validates the declared edges against the manifest, renders the `## Dependencies` block, and parses it back through the shipped reader before staging |
| `ledger write` | splices both staged documents in one PATCH and compares the **whole** normalized body |
| `ledger supersede` | comment, unlink, close as `not_planned` — in that order — then a confirming read |

Supporting modules are split so every refusal is testable without spawning a process: `codes.ts`,
`run.ts` (the run-directory model), `digest.ts`, `plan-block.ts`, `child-body.ts`, `topology-doc.ts`,
`region.ts`, `github.ts`, `ground.ts`, `preconditions.ts`, `run-io.ts`, `command.ts`.

## The load-bearing choices

- **Reuse by import, never a second copy.** `build/dependencies.ts`'s `readTopology`,
  `plan/ledger.ts`'s field readers, `wire/acceptance-criteria.ts`'s three-armed read,
  `report/leaks.ts`, `report/compose.ts`'s `normalizeForReadback`, `report/dedup.ts`'s ranker,
  `plan/github.ts`'s `listSubIssues` and `probeCycleDoc`, `build/claim.ts`'s `requireClaim`,
  `build/worktree.ts`'s `assertGround`, `build/target.ts`, `build/authored.ts`, `io/issues.ts`,
  `io/stdin.ts`. No second topology parser, ledger reader, leak predicate, dedup ranker or claim.
- **The sub-issue *write* half is genuinely new** and is keyed on the child's **database `id`**, not
  its number — `POST .../sub_issues` and `DELETE .../sub_issue`. The link is proven by re-listing the
  epic's sub-issues; a create that landed with an unprovable link seats `23`, and the manifest append
  sits **before** the link so that `23` leaves a number a successor can find.
- **Exit seats.** `3`–`11` re-exported from `build/codes.ts` (which re-exports `report`'s); `12`–`19`
  re-exported from `build` verbatim; `20`–`26` are this group's own. Registered as **`BUILD_SEATS`**
  in `exit-code-alignment.ts` because three verbs seat `4`. `build`'s `20`/`21` are deliberately not
  re-exported — two names on one code in one module is what `allocatedCodes` reports as drift.
- **Two verb endings only.** Exit 0 with a payload on stdout, or non-zero with empty stdout. No
  machine-readable refusal was added.
- **The gate is never second-guessed.** No verb flips `status:triaged`, derives a structural floor,
  homes a milestone, checks reachability, or loops a re-plan.

## Testing

Unit tests per verb and per pure module (`plan-block`, `child-body`, `topology-doc`, `region`, `run`),
covering each happy path and each declared refusal seat, plus a CLI test proving the group resolves
end to end. 148 new tests; the package's full suite is 2762 passing. `pnpm typecheck` and
`pnpm lint:worktree` are clean.

## Deviations

Four, each stated rather than absorbed.

1. **The rendered `## Dependencies` grammar follows the shipped parser, not the contract's
   illustration.** The contract illustrates `### Phase <n>` headings over `- #<ref> — <label>` rows,
   but `build/dependencies.ts`'s `readTopology` — the parser the same contract names, and the one
   `fabrika plan check` reads through — breaks at the first heading after `## Dependencies` and reads
   only `- phase <int>: <ref>…` / `- <ref> requires: <ref>…`. Rendering the illustration would make
   the contract's own round-trip clause refuse on `24` unconditionally. This PR renders the parser's
   grammar, which satisfies both the round-trip clause and the "adds no second `## Dependencies`
   grammar" clause. **Filed as a spec defect, not patched into the contract: #5220.**

2. **`ledger open` reads the epic's children in one paginated list rather than fanning out at
   concurrency 8.** The contract bounds a fan-out over per-child fetches; the sub-issue list payload
   already carries every field `children` reports (number, id, title, labels), so there is no fan-out
   to bound. The rule's purpose — "a rate-limit response must not abort the whole read" — is served
   more directly by not issuing N requests. No other verb fans out, as specified.

3. **Two readers were added here rather than imported**, both carrying a field the shipped reader
   drops — the same justification `plan/github.ts` gives for `getChild` over `getIssue`.
   `listSubIssueEntries` carries the `id` the link and unlink are keyed on (`listSubIssues` answers
   numbers only, and is still the import used to *prove* the link); `readChildBack` carries labels,
   assignees **and** milestone together, which no shipped shape does — and a read-back that cannot see
   all three cannot prove the one create call landed every birth attribute. `openBacklog` is likewise
   new because every shipped backlog read is label-scoped and the planner's question is not.

4. **Three refusal messages have no row in the contract's Errors tables**, each seated on a code the
   contract does declare: an out-of-order plan section (`4` — the exit table names the case, the
   Errors table has no row), a duplicated child field line (`4` — the gate refuses a duplicate, so
   composing one authors a defect), and a create call that failed outright (`8` — the table's `8` row
   covers only a failed *re-read*). All three are in the spec defect above (#5220).

## Fences respected

`claude-plugins/fabrika/skills/governance/` and `claude-plugins/fabrika/skills/front-door/` were read
only. Nothing under `claude-plugins/fabrika/skills/plan-epic/` was touched — spec disagreements were
filed, not patched. None of PR #5206's files were edited.
