### PR TITLE
docs(fabrika): specify adr sweep's ranking and add the derivable-example rule (#4735)

### DIFF
--- a/.decisions/0247-a-spec-example-value-is-derivable-or-absent.md
+++ b/.decisions/0247-a-spec-example-value-is-derivable-or-absent.md
@@ -1,0 +1,64 @@
+---
+id: 0247
+title: A contract spec's example value is derivable from the spec, or it is not printed
+status: accepted
+date: 2026-08-09
+tags: [fabrika, tooling, decisions]
+---
+
+# 0247 — A contract spec's example value is derivable from the spec, or it is not printed
+
+**What this decides:** A fabrika contract spec that shows a computed number in an example has to say
+how that number is computed. If it will not say, it shows no number. `adr sweep`'s shipped ranking is
+adopted as its spec rather than replaced.
+
+## Context
+
+fabrika's contract-spec format ([`cli-interface-convention.md`](../claude-plugins/fabrika/docs/cli-interface-convention.md)
+Part 2) is what an authoring session emits and a `write-code` agent builds from with no access to the
+session. Its completeness test was six checks, all of them *presence* tests: every flag has a
+default, every code has a trigger, every error has a message, every stdout shape has an example.
+
+The wave-0 pilot built six verbs from one spec ([#4725](https://github.com/kamp-us/phoenix/issues/4725) /
+[#4731](https://github.com/kamp-us/phoenix/pull/4731)). Five needed essentially no judgment. `adr
+sweep` was different: its whole ranking specification was one inventory cell ("deterministic — scan,
+score, sort") and one grounding line ("a lexical/rarity score over decision-bearing text"), and it
+printed two example scores anyway. What counts as decision-bearing text, the tokenizer, the
+stopwords, the rarity denominator, the tie-break and the rounding were all unstated, and each of them
+moves the number. The implementation scored the same corpus in the 70s–90s where the spec's examples
+were in the teens, and neither was wrong, because there was nothing to be wrong against
+([#4735](https://github.com/kamp-us/phoenix/issues/4735)).
+
+The spec's author omitted nothing the format asked for — no section and no check asks for a
+computation. That makes it a format defect, and seventeen further specs are due to be authored
+against the same doc (epic [#4650](https://github.com/kamp-us/phoenix/issues/4650)), so the same hole
+is available to every one of them.
+
+## Decision
+
+**A contract spec's completeness test gains a seventh check: every value an example prints is
+derivable from the spec, and a verb emitting a computed value either specifies the computation or
+prints no example value.**
+
+Specifying the computation means all of it — the inputs, the weighting, the tie-break, the rounding —
+at the precision at which two implementers reading only the spec produce the same digits. Where the
+value also depends on data the spec does not carry, the example names data a reader can hold fixed, a
+committed fixture rather than a live corpus that moves under it. A worked example that looks
+verifiable and is not is worse than no example: a reader treats the number as a contract.
+
+**`adr sweep`'s shipped ranking is ratified, not replaced.** The function in
+[`packages/fabrika-cli/src/adr/sweep.ts`](../packages/fabrika-cli/src/adr/sweep.ts) was written down
+into the spec verbatim rather than a second ranking being invented to displace it. It was the only
+complete statement of the ranking that existed, it is already the behaviour every caller sees, and a
+re-derivation would have re-opened a settled question to no benefit. From here the spec is the
+contract and the implementation is the bug if they ever diverge.
+
+## Consequences
+
+Authoring a verb that scores, ranks or otherwise computes a number now costs the author the whole
+function in prose. That is the cost the rule intends: it is the difference between a spec and a
+sketch, and it is paid once per verb instead of once per implementer.
+
+An example that binds a committed fixture stays reproducible for as long as the fixture is committed,
+so a reviewer can re-run it. `adr sweep` gains such a corpus under its skill's fixtures; a live
+`.decisions/` example would print numbers that are stale the next time a record lands.

--- a/claude-plugins/fabrika/docs/cli-interface-convention.md
+++ b/claude-plugins/fabrika/docs/cli-interface-convention.md
@@ -309,7 +309,7 @@ that test belongs in the skill, not the CLI.
 
 ### Completeness test
 
-A spec is complete when all six hold. Each is checkable by reading the spec alone, which is the
+A spec is complete when all seven hold. Each is checkable by reading the spec alone, which is the
 point: an implementer can tell an unfinished spec from a finished one before starting.
 
 1. Every flag has a type and, if optional, a default.
@@ -320,6 +320,19 @@ point: an implementer can tell an unfinished spec from a finished one before sta
 6. No clause defers to a v1 script, another skill's prose, or the authoring session. Deferral is the
    [#4638](https://github.com/kamp-us/phoenix/issues/4638) failure: the spec is the contract, so a
    spec that points elsewhere has not derived one.
+7. **Every value an example prints is derivable from the spec.** A verb that emits a computed value
+   specifies the computation — every input to it, down to the tie-break and the rounding — or prints
+   no example value. Where the value also depends on data outside the spec, the example names data a
+   reader can hold fixed, such as a committed fixture, rather than a corpus that moves under it.
+
+   Checks 1–6 are all *presence* tests, and a spec can pass every one of them while leaving its core
+   uninvented: `adr sweep` declared its flags, its shapes, its codes, its errors and its scope, and
+   printed two example scores derived from a ranking function the spec never gave. Two implementers
+   read that and ship two different verbs, each skill's judgment layer tuned against a ranking that
+   moves under it ([#4735](https://github.com/kamp-us/phoenix/issues/4735), ADR
+   [0247](../../../.decisions/0247-a-spec-example-value-is-derivable-or-absent.md)). An example that
+   *looks* verifiable and is not is worse than no example, because a reader treats the number as a
+   contract.
 
 ### Worked example
 

--- a/claude-plugins/fabrika/skills/adr/SKILL.md
+++ b/claude-plugins/fabrika/skills/adr/SKILL.md
@@ -56,8 +56,11 @@ None of its three outcomes is a clearance:
 - **`no-overlap`** — nothing mechanically adjacent was left to open, **never** that there is no
   contradiction: an ADR disagreeing with yours about what a label *means*, sharing no distinctive
   vocabulary, never appears at all. Read the domain by hand.
-- **`indeterminate`** — the run carries no information: your draft yielded no distinctive terms, or
-  the corpus is too small to rank rarity against. Say which, and read by hand regardless.
+- **`indeterminate`** — the run carries no information: your draft yielded no distinctive term — one
+  every live-accepted ADR carries is not distinctive — or the corpus is too small to rank rarity
+  against. Distinctiveness is a property of your draft against the corpus, not of what it overlaps,
+  so a draft whose vocabulary is entirely its own is maximally distinctive and lands on `no-overlap`
+  instead. Say which fired, and read by hand regardless.
 
 Resolve each real hit in step 4 — supersede where this ADR replaces it outright, amend-in-part where
 the rest still stands. Where you only refine your own earlier ADR's mechanics and its ruling holds,

--- a/claude-plugins/fabrika/skills/adr/contract.md
+++ b/claude-plugins/fabrika/skills/adr/contract.md
@@ -505,6 +505,72 @@ fabrika adr sweep --new 0240 [--dir <path>] [--limit <n>] [--json]
 | `--limit` | integer | no | `8` | how many shortlist entries to emit |
 | `--json` | boolean | no | `false` | emit the sweep result as one JSON object on **stdout** |
 
+**Ranking** — the score is a computation, and this is it. Two implementers who read this section
+compute the same number to the last printed digit; nothing below is left to judgment.
+
+1. **The corpus and the two populations.** Every `NNNN-slug.md` file under `--dir` is read, and that
+   count is `scanned`. The **live-accepted corpus** `L` is every scanned record whose frontmatter
+   `status:` is live (`accepted` or `amended-in-part …`, per the shared conventions), minus the
+   subject's own record when the subject sits in `--dir`. `N = |L|`. The **in-scope** set is `L`
+   minus every record whose id the subject already cites, a citation being any four-digit token
+   anywhere in the subject's file text. `L` is the rarity denominator **and** the population the
+   rarity floor of 10 counts — the whole live-accepted corpus, *before* citations are excluded. The
+   in-scope set is only what gets ranked, and it is what `inScope` reports.
+2. **Decision-bearing text**, taken the same way for the subject and for each record in `L`: the
+   frontmatter `title:`, the `**What this decides:**` gloss up to its first blank line, and the
+   `## Decision` section — frontmatter stripped, and nothing from `## Context` or `## Consequences`.
+   Those two narrate why a decision was taken and what it costs; two ADRs contradict each other in
+   what they *decide*, so ranking on decision text is what stops a shared war story scoring as a
+   shared ruling. A record with no `## Decision` heading contributes its whole body instead, so a
+   nonstandard record is rankable rather than silently invisible.
+3. **Tokenizer.** Lowercase the text, split it on every run of characters outside `[a-z0-9]`, and
+   keep the tokens of length ≥ 3 that are neither purely numeric (a bare number is an id, not a
+   term) nor a stopword. Each document's terms are a **set**: a term counts once per record however
+   often it occurs, so the score carries no term-frequency component.
+4. **Stopwords** — exactly this list, and nothing domain-specific. Repo jargon needs no list: a term
+   every record uses has a rarity weight near zero and contributes nothing on its own.
+
+   ```
+   a about above after again against all also although always am an and any are as at be because
+   been before being below between both but by can cannot could did do does doing done down during
+   each either else even ever every few for from further had has have having her here hers him his
+   how however if in instead into is it its itself just less let like made make makes many may
+   might more most much must never new no nor not now of off on once one only or other our out over
+   own per rather same shall she should since so some still such than that the their them then
+   there these they this those though through thus to too two under until up upon use used uses
+   using very was way we well were what when where whether which while who whom whose why will with
+   within without would yet you your
+   ```
+
+5. **Rarity.** `df(t)` is how many records of `L` carry term `t`. For each subject term `t` with
+   `df(t) < N`, the weight is `idf(t) = ln(N / max(df(t), 1))`. A term with `df(t) = N` is dropped:
+   carried by every record, it discriminates nothing. A term with `df(t) = 0` is kept at `ln(N)` —
+   maximally rare, scoring against nobody, which is what separates the two silent outcomes below.
+6. **Score.** Each in-scope record scores the sum of `idf(t)` over the subject terms it carries.
+   A record scoring `0` is dropped rather than shortlisted at zero.
+7. **Order and cut.** Descending score, ties broken by ascending numeric id; `--limit` then takes
+   the first `n` of that order.
+8. **Rounding.** A score is rounded to two decimals as `round(score × 100) / 100` (halves away from
+   zero) and printed with exactly two decimals, so `2.3` prints `2.30`.
+
+**This ratifies the shipped function rather than replacing it.**
+[`packages/fabrika-cli/src/adr/sweep.ts`](../../../../packages/fabrika-cli/src/adr/sweep.ts) already
+computes exactly the above; the spec was unspecified and the implementation was not, so the
+implementation is what got written down (ADR
+[0247](../../../../.decisions/0247-a-spec-example-value-is-derivable-or-absent.md)). Where the two
+ever disagree, this section is the contract and the implementation is the bug.
+
+**The three outcomes, disjoint by construction.**
+
+- **`indeterminate`** — the run carries no information: either `N` is below the rarity floor of 10,
+  or the subject yielded no distinctive term at all. **Distinctiveness is a property of the subject
+  against the corpus, never of its overlap**: a subject term is distinctive when at least one record
+  of `L` lacks it (`df(t) < N`). So a subject whose every term is *absent* from the corpus is
+  maximally distinctive and never lands here — it reaches `no-overlap`.
+- **`no-overlap`** — the subject had distinctive terms and no uncited live-accepted record shares
+  one, so every in-scope record scored `0`. Never read as a clearance.
+- **`shortlist`** — at least one in-scope record scored above `0`.
+
 **Output** — the first line is the outcome token alone: `shortlist`, `no-overlap` or `indeterminate`.
 On `shortlist`, one tab-separated line per entry follows — `<id>`, `<score>`, `<file>`, `<title>`.
 The reason for a `no-overlap` or `indeterminate`, and the scope line, go to stderr.
@@ -514,8 +580,21 @@ a caller must never read its own shortlist as a failed run — which is precisel
 `adr-sweep` makes by exiting `1` on the one case it was asked to produce.
 
 With `--json`, one object on stdout with keys `outcome` (the token), `entries` (an array of
-`{id, score, file, title}`, empty unless `outcome` is `shortlist`), `reason` (the explanatory string
-for `no-overlap` and `indeterminate`, else `null`), `scanned`, `inScope` and `cited`.
+`{id, score, file, title}`, empty unless `outcome` is `shortlist`), `reason` (the string below, or
+`null`), `scanned`, `inScope` and `cited`.
+
+**The `reason` string is fixed text, byte for byte** — a caller may grep it, so it is pinned to the
+same precision as every stderr message in the Errors table. `<N>` is the live-accepted count.
+
+| Outcome | `reason` |
+|---|---|
+| `indeterminate`, below the floor | `the live-accepted corpus holds <N> record(s), below the rarity floor of 10 — every term looks common, so a clean sweep here is degenerate rather than clean` |
+| `indeterminate`, no distinctive terms | `the subject yielded no distinctive terms against the live-accepted corpus — nothing to rank, so the run carries no information` |
+| `no-overlap` | `no uncited live-accepted record shares a distinctive term with the subject — this is not a clearance: an ADR that disagrees about what a label means shares no vocabulary and never appears here` |
+| `shortlist` | `null` |
+
+The same sentence is what reaches stderr on either channel, as `adr sweep: <reason>.` — the verb's
+prefix and a terminating period, and no other rewording.
 
 **Exit status**
 
@@ -538,22 +617,49 @@ for `no-overlap` and `indeterminate`, else `null`), `scanned`, `inScope` and `ci
 **Scope** — every live-accepted record under `--dir` that `--new` does not already cite. The scope
 line goes to stderr naming the corpus size and the in-scope count, because the outcome is only
 readable against them: `indeterminate` fires when the live-accepted corpus is below the rarity floor
-of 10, and a caller that cannot see the count cannot tell that from a clean sweep.
+of 10 — the floor counts that corpus, not the in-scope subset — and a caller that cannot see the
+count cannot tell that from a clean sweep.
 
 **Examples**
 
+A score is relative to the corpus it was computed against, so an example that prints one names a
+**committed** corpus rather than the live `.decisions/`, whose scores would be stale the next time a
+record lands (ADR [0247](../../../../.decisions/0247-a-spec-example-value-is-derivable-or-absent.md)).
+Both examples run against fixtures in this skill's tree and reproduce byte for byte; the scope line
+each writes to stderr is not shown.
+
 ```
-$ fabrika adr sweep --new 0240
+$ fabrika adr sweep --new claude-plugins/fabrika/skills/adr/evals/fixtures/0240-only-landed-adrs-may-be-cited.md --dir claude-plugins/fabrika/skills/adr/evals/fixtures/sweep-corpus
 shortlist
-0233	15.11	0233-decision-shell-enforcement-review-skill-criterion.md	New decision-computing shell is caught by a review-skill criterion row
-0160	13.46	0160-ref-transaction-guard-refuses-diverging-primary-main.md	A git reference-transaction guard refuses a diverging refs/heads/main ref-move
+0101	17.03	0101-citations-resolve-against-the-base-ref.md	A citation resolves against the fetched base ref, never the local working tree
+0103	11.74	0103-an-unmerged-pull-request-leaves-no-record.md	A pull request that never merges leaves no record behind
+0102	9.43	0102-a-reviewer-resolves-every-reference.md	A reviewer resolves every reference in the pull request under review
+0104	4.61	0104-superseded-records-keep-their-file.md	A superseded record keeps its file and gains a status line
+0107	2.30	0107-every-push-runs-the-test-suite.md	Every push runs the whole test suite
+0110	2.30	0110-diagnostics-go-to-stderr.md	Diagnostics go to stderr, answers to stdout
 $ echo $?
 0
 ```
 
+Four of that corpus's ten records — `0105`, `0106`, `0108`, `0109` — are absent, and the absence is
+the ranking working: each shares exactly one term with the subject, `decision`, which all ten records
+carry (`df = N`), so its weight is dropped and the record scores `0`. The tail is the arithmetic in
+the open: `0107` shares only `time` and `0110` only `lands`, each held by one record of ten, so both
+score `ln(10 / 1) = 2.302…` → `2.30` and tie, and the tie breaks toward the lower id.
+
 ```
 $ fabrika adr sweep --new 0240 --dir claude-plugins/fabrika/skills/adr/evals/fixtures/small-corpus
 indeterminate
+$ echo $?
+0
+```
+
+That corpus holds three live-accepted records, so it is below the rarity floor and the run is
+indeterminate rather than clean. With `--json` the same run carries the pinned `reason`:
+
+```
+$ fabrika adr sweep --new 0240 --dir claude-plugins/fabrika/skills/adr/evals/fixtures/small-corpus --json
+{"outcome":"indeterminate","entries":[],"reason":"the live-accepted corpus holds 3 record(s), below the rarity floor of 10 — every term looks common, so a clean sweep here is degenerate rather than clean","scanned":4,"inScope":3,"cited":0}
 $ echo $?
 0
 ```
@@ -567,6 +673,8 @@ $ echo $?
   three outcomes exit `0` here, and `--json` goes to stdout per rule 2. Read it as a list of mistakes
   already made, not as an implementation to copy.
 - The ranking is a lexical/rarity score over decision-bearing text, capped at 8, excluding the
-  subject's own citations. `indeterminate` fires when the subject yields no distinctive terms or the
-  live-accepted corpus is below the rarity floor of 10 — a small corpus makes every term look common,
-  so silence there is degenerate rather than clean.
+  subject's own citations — written out step by step under **Ranking** above, because the earlier
+  one-line gloss printed example scores nobody could re-derive from it
+  ([#4735](https://github.com/kamp-us/phoenix/issues/4735)).
+- ADR [0247](../../../../.decisions/0247-a-spec-example-value-is-derivable-or-absent.md) — an
+  example value is derivable or absent, and this verb's shipped ranking is ratified as the spec.

--- a/claude-plugins/fabrika/skills/adr/evals/fixtures/sweep-corpus/0101-citations-resolve-against-the-base-ref.md
+++ b/claude-plugins/fabrika/skills/adr/evals/fixtures/sweep-corpus/0101-citations-resolve-against-the-base-ref.md
@@ -1,0 +1,20 @@
+---
+id: 0101
+title: A citation resolves against the fetched base ref, never the local working tree
+status: accepted
+date: 2026-08-01
+tags: [decisions, gates]
+---
+
+# 0101 — A citation resolves against the fetched base ref, never the local working tree
+
+**What this decides:** Every citation is resolved against a freshly fetched base ref.
+
+## Context
+A reader who resolves a reference against their own tree sees a citation the base ref does not carry.
+
+## Decision
+**Every citation resolves against the fetched base ref; a local working tree is never the authority.**
+
+## Consequences
+One fetch per resolution.

--- a/claude-plugins/fabrika/skills/adr/evals/fixtures/sweep-corpus/0102-a-reviewer-resolves-every-reference.md
+++ b/claude-plugins/fabrika/skills/adr/evals/fixtures/sweep-corpus/0102-a-reviewer-resolves-every-reference.md
@@ -1,0 +1,20 @@
+---
+id: 0102
+title: A reviewer resolves every reference in the pull request under review
+status: accepted
+date: 2026-08-01
+tags: [gates, review]
+---
+
+# 0102 — A reviewer resolves every reference in the pull request under review
+
+**What this decides:** A reviewer follows each reference a pull request adds before approving it.
+
+## Context
+An unfollowed reference is a claim nobody checked.
+
+## Decision
+**A reviewer resolves every reference a pull request adds, and blocks the pull request on a dead one.**
+
+## Consequences
+Review costs one resolution per reference.

--- a/claude-plugins/fabrika/skills/adr/evals/fixtures/sweep-corpus/0103-an-unmerged-pull-request-leaves-no-record.md
+++ b/claude-plugins/fabrika/skills/adr/evals/fixtures/sweep-corpus/0103-an-unmerged-pull-request-leaves-no-record.md
@@ -1,0 +1,20 @@
+---
+id: 0103
+title: A pull request that never merges leaves no record behind
+status: accepted
+date: 2026-08-01
+tags: [decisions, pipeline]
+---
+
+# 0103 — A pull request that never merges leaves no record behind
+
+**What this decides:** Only a merged pull request contributes a record to the repository.
+
+## Context
+Work that lives in an open pull request may be closed instead of merged.
+
+## Decision
+**A record counts as landed only once its pull request merges onto the base branch.**
+
+## Consequences
+An author waits for the merge before depending on it.

--- a/claude-plugins/fabrika/skills/adr/evals/fixtures/sweep-corpus/0104-superseded-records-keep-their-file.md
+++ b/claude-plugins/fabrika/skills/adr/evals/fixtures/sweep-corpus/0104-superseded-records-keep-their-file.md
@@ -1,0 +1,20 @@
+---
+id: 0104
+title: A superseded record keeps its file and gains a status line
+status: accepted
+date: 2026-08-01
+tags: [decisions]
+---
+
+# 0104 — A superseded record keeps its file and gains a status line
+
+**What this decides:** Superseding a record edits its status line and deletes nothing.
+
+## Context
+A deleted record breaks every pointer into it.
+
+## Decision
+**A superseded record keeps its file; the supersession is recorded on the status line alone.**
+
+## Consequences
+The directory grows monotonically.

--- a/claude-plugins/fabrika/skills/adr/evals/fixtures/sweep-corpus/0105-one-decision-per-file.md
+++ b/claude-plugins/fabrika/skills/adr/evals/fixtures/sweep-corpus/0105-one-decision-per-file.md
@@ -1,0 +1,20 @@
+---
+id: 0105
+title: One decision per file, named by its number and a slug
+status: accepted
+date: 2026-08-01
+tags: [decisions]
+---
+
+# 0105 — One decision per file, named by its number and a slug
+
+**What this decides:** Each decision lives in its own numbered file.
+
+## Context
+Two decisions in one file cannot be superseded independently.
+
+## Decision
+**One decision per file, named `NNNN-slug.md`.**
+
+## Consequences
+More files, each independently addressable.

--- a/claude-plugins/fabrika/skills/adr/evals/fixtures/sweep-corpus/0106-formatting-is-tabs-at-a-hundred-columns.md
+++ b/claude-plugins/fabrika/skills/adr/evals/fixtures/sweep-corpus/0106-formatting-is-tabs-at-a-hundred-columns.md
@@ -1,0 +1,20 @@
+---
+id: 0106
+title: Source formatting is tabs at a hundred columns
+status: accepted
+date: 2026-08-01
+tags: [platform]
+---
+
+# 0106 — Source formatting is tabs at a hundred columns
+
+**What this decides:** One formatter setting for the whole repository.
+
+## Context
+Mixed indentation makes every diff noisy.
+
+## Decision
+**Tabs, wrapped at a hundred columns, formatter-enforced.**
+
+## Consequences
+One reformatting pass at adoption.

--- a/claude-plugins/fabrika/skills/adr/evals/fixtures/sweep-corpus/0107-every-push-runs-the-test-suite.md
+++ b/claude-plugins/fabrika/skills/adr/evals/fixtures/sweep-corpus/0107-every-push-runs-the-test-suite.md
@@ -1,0 +1,20 @@
+---
+id: 0107
+title: Every push runs the whole test suite
+status: accepted
+date: 2026-08-01
+tags: [platform]
+---
+
+# 0107 — Every push runs the whole test suite
+
+**What this decides:** Continuous integration runs everything, every time.
+
+## Context
+A partial run hides the failure it did not cover.
+
+## Decision
+**Every push runs the whole suite; no subset selection.**
+
+## Consequences
+Slower runs, no hidden gaps.

--- a/claude-plugins/fabrika/skills/adr/evals/fixtures/sweep-corpus/0108-migrations-are-hand-authored.md
+++ b/claude-plugins/fabrika/skills/adr/evals/fixtures/sweep-corpus/0108-migrations-are-hand-authored.md
@@ -1,0 +1,20 @@
+---
+id: 0108
+title: Database migrations are hand-authored and flat
+status: accepted
+date: 2026-08-01
+tags: [platform]
+---
+
+# 0108 — Database migrations are hand-authored and flat
+
+**What this decides:** Migrations are written by hand, numbered, and never regenerated.
+
+## Context
+A generated migration hides what it does to live data.
+
+## Decision
+**Migrations are hand-authored SQL in a flat numbered sequence.**
+
+## Consequences
+More typing, readable history.

--- a/claude-plugins/fabrika/skills/adr/evals/fixtures/sweep-corpus/0109-one-worker-serves-app-and-api.md
+++ b/claude-plugins/fabrika/skills/adr/evals/fixtures/sweep-corpus/0109-one-worker-serves-app-and-api.md
@@ -1,0 +1,20 @@
+---
+id: 0109
+title: One worker serves the single-page app and its API
+status: accepted
+date: 2026-08-01
+tags: [platform]
+---
+
+# 0109 — One worker serves the single-page app and its API
+
+**What this decides:** The static bundle and the API share one deployment.
+
+## Context
+Two deployments for one product doubles the configuration.
+
+## Decision
+**One worker serves both the static bundle and the API routes.**
+
+## Consequences
+One deploy, one origin.

--- a/claude-plugins/fabrika/skills/adr/evals/fixtures/sweep-corpus/0110-diagnostics-go-to-stderr.md
+++ b/claude-plugins/fabrika/skills/adr/evals/fixtures/sweep-corpus/0110-diagnostics-go-to-stderr.md
@@ -1,0 +1,20 @@
+---
+id: 0110
+title: Diagnostics go to stderr, answers to stdout
+status: accepted
+date: 2026-08-01
+tags: [platform]
+---
+
+# 0110 — Diagnostics go to stderr, answers to stdout
+
+**What this decides:** Only the answer lands on stdout.
+
+## Context
+Progress chatter mixed into the answer breaks every caller that parses it.
+
+## Decision
+**Stdout carries the answer; progress, warnings and scope lines go to stderr.**
+
+## Consequences
+Callers parse stdout with no filtering.


### PR DESCRIPTION
The `adr sweep` spec printed two example scores it never explained how to compute, so two implementers reading it would ship two different verbs. This writes the ranking function down — what text it reads, how it tokenizes, how it weighs rarity, how it breaks ties and rounds — and adopts the version already shipped in `packages/fabrika-cli/` rather than inventing a second one. The bigger half is the format fix: the contract-spec completeness test gains a seventh rule so the same hole cannot be re-authored into the seventeen specs still to be written.

Fixes #4735

## What changed

- **`claude-plugins/fabrika/docs/cli-interface-convention.md`** — completeness test grows rule 7: every value an example prints is derivable from the spec; a verb emitting a computed value specifies the computation or prints no value, and a value that also depends on outside data names data a reader can hold fixed. Checks 1–6 are all presence tests, which is how `adr sweep` passed every one of them with its core uninvented.
- **`claude-plugins/fabrika/skills/adr/contract.md`** — a new **Ranking** section for `adr sweep`: the two populations, decision-bearing text, the tokenizer, the stopword list verbatim, `idf(t) = ln(N / max(df(t), 1))` with the `df = N` drop, the score, the sort and tie-break, and the rounding. Plus: the ratification statement, the three outcomes stated disjointly, the `--json` `reason` strings pinned byte-for-byte, and the rarity-floor population named.
- **`claude-plugins/fabrika/skills/adr/evals/fixtures/sweep-corpus/`** — ten small records the shortlist example runs against, so its scores reproduce on a re-run instead of rotting the next time an ADR lands in `.decisions/`. The example's tail is arithmetic a reader can check: two records tie at `ln(10 / 1) = 2.30`.
- **`claude-plugins/fabrika/skills/adr/SKILL.md`** — the `indeterminate` bullet now says distinctiveness is a property of the draft against the corpus, so a draft whose vocabulary is all its own lands on `no-overlap` instead.
- **`.decisions/0247-a-spec-example-value-is-derivable-or-absent.md`** — the recorded decision behind both halves.

## Acceptance criteria

- Rule 7 in the completeness test — done.
- The ranking specified end to end — done (contract.md, **Ranking**).
- Shipped function ratified and example numbers regenerated from it — done; the example now runs against the committed fixture corpus.
- `indeterminate` / `no-overlap` boundary — done, in the contract and in `SKILL.md`.
- The rarity floor names its population (the live-accepted corpus, before citations are excluded) — done, in **Ranking** and in **Scope**.
- `--json` `reason` pinned byte-for-byte — done, one table row per outcome.
- Siblings #4736, #4737, #4738 untouched — this diff changes nothing they own.

## Deviations

- **Class: narrowed a suggested shape.** Said: the issue offered "specify the computation **or** drop the example scores". Did: specified the computation and kept a score example, moved onto a committed fixture corpus. Why: the shipped verb already computes a fixed function, so dropping the numbers would lose a real worked example for no gain; a fixture corpus makes the numbers verifiable forever, which a live `.decisions/` example cannot be. Disposition: no action needed.
- **Class: scope added beyond the literal ACs.** Said: the ACs name two documents. Did: also sharpened the same ambiguous `indeterminate` sentence in `claude-plugins/fabrika/skills/adr/SKILL.md`, and added the ten-record fixture corpus. Why: the skill carries the identical wording a caller reads at runtime, so fixing only the contract would have left the ambiguity live; the fixtures are what make the regenerated example reproducible. Disposition: for the reviewer to judge.
- **Class: recorded an ADR the ACs did not request.** Said: nothing about `.decisions/`. Did: added ADR 0247. Why: this is a `type:decision` issue, and write-code's type routing settles one with a recorded decision; both docs point at it rather than restating the why twice. Disposition: no action needed.