### PR TITLE
feat(fabrika-cli): make the governance verdict a floor ship gate raises from the diff (#5036)

### DIFF
--- a/claude-plugins/fabrika/skills/governance/SKILL.md
+++ b/claude-plugins/fabrika/skills/governance/SKILL.md
@@ -33,9 +33,10 @@ make that checkable:
 - **Fail-closed on absence.** The refusal belongs at the enqueue seam, not to a reviewer's good
   intentions: `governance` is a required namespace in `fabrika ship gate`'s conjunction, so a
   harness-touching diff carrying no current-head verdict is **named absent and refused there**. Zero
-  scope is itself a refusal (ADR 0092). **Until `ship`'s required-namespace vocabulary admits
-  `governance` this property is specified and not yet enforced** ([contract.md](contract.md), the
-  first shipped-surface change) — say so rather than relying on it.
+  scope is itself a refusal (ADR 0092). This is now enforced end to end: `ship`'s vocabulary admits
+  the namespace (#5206) and `ship gate` **raises the requirement from the diff itself**, so passing
+  `--require governance` is not the caller's choice to make (#5036) — see
+  [contract.md](contract.md), shipped-surface changes 1 and 1b.
 - **Independent of who reviewed.** The predicate consults neither which skill ran nor what it
   concluded, so a `review` PASS discharges nothing and a `review` run that forgot to fire you leaves
   the namespace required — the omission surfaces as a refusal rather than as silence.

--- a/claude-plugins/fabrika/skills/governance/contract.md
+++ b/claude-plugins/fabrika/skills/governance/contract.md
@@ -229,11 +229,11 @@ wrapper shape at `packages/fabrika-cli/src/review/authored.ts` and
 
 ### Three shipped-surface changes this group requires
 
-All three are additive; none changes how any existing marker, namespace or verdict reads. Each is a
-change to a surface this group does not own, so each names the file and the exact edit. **Two of the
-three have since landed**, via [#5206](https://github.com/kamp-us/phoenix/pull/5206) — they are kept
-here, in landed state, because they are still the surfaces this group's fail-closed property rests
-on. Change 3 is the only one still outstanding.
+All are additive; none changes how any existing marker, namespace or verdict reads. Each is a
+change to a surface this group does not own, so each names the file and the exact edit. **Changes 1
+and 2 landed** via [#5206](https://github.com/kamp-us/phoenix/pull/5206) and **1b** via #5036 — they
+are kept here, in landed state, because they are still the surfaces this group's fail-closed
+property rests on. Change 3 is the only one still outstanding.
 
 **1. `ship`'s required-namespace vocabulary must admit `governance` — without this the whole
 fail-closed property is decoration. LANDED (#5206).**
@@ -252,6 +252,24 @@ through the same `verdict-marker` format for every namespace, and the ADR 0058 k
 no notion of which skill posted one. **This is not a second answer to an enforced question** — the
 enqueue conjunction stays `ship gate`'s alone. It is that enforcer being taught one more namespace,
 which is the only shape in which a derived-required namespace can actually be required.
+
+**1b. …and requiring it must not be optional. LANDED (#5036).** Admitting the namespace left one
+hole: `--require` was caller-asserted, so a session that simply never passed
+`--require governance` shipped a governance-root diff with no governance verdict, and the gate
+called that `satisfied`. `packages/fabrika-cli/src/ship/gate-verb.ts` now reads the PR's own
+changed-file list and raises the required set from it (`requiredWithFloor`) through the **same**
+`touchesGovernanceRoot` predicate `governance scope` and `ship scope` use — one derivation, three
+readers. So the requirement is a property of the diff, not of what a session remembered to type.
+
+**The founder ruled this instead of a §CP row** ([veto on
+#5036](https://github.com/kamp-us/phoenix/issues/5036#issuecomment-5234614633), 2026-08-10):
+`claude-plugins/fabrika/**` gets **no** CODEOWNERS row and **no** §CP-boundary widening. The model
+is *machine gate plus human awareness, not a human click* — this floor blocks the enqueue, and the
+§CP digest readout (producer: this skill; display: the front door, #4952) carries every fabrika-tree
+landing to the founder. **Visibility after landing replaces blocking before it**, with the limit
+recorded rather than glossed: the readout makes a gate-weakening landing *visible*, not
+*impossible* (#5216 is one the machine chain missed). `.github/**` — CODEOWNERS included — and
+everything the existing §CP boundary already covers stay §CP, enforced server-side regardless.
 
 **2. The `verdict-marker` namespace class must admit `governance`. LANDED (#5206), with one
 residual.** `packages/fabrika-cli/src/wire/verdict-marker.ts` now declares

--- a/claude-plugins/fabrika/skills/ship/SKILL.md
+++ b/claude-plugins/fabrika/skills/ship/SKILL.md
@@ -57,11 +57,14 @@ fabrika ship gate 4321 --sha 03135b91 --require review-code --require review-ski
 ```
 
 `--require` is repeated verbatim from `scope`'s printed namespace set — the verb refuses a
-cleared answer that does not cover exactly that set (#4520). `blocked` naming a FAIL → route to
-repair (`build`) and stop. `blocked` naming absence → the namespace was never gated at this
-head; route to the gate that owns it — `review` for every `review-*` namespace, the `governance`
-skill for `governance` — and stop. Absence and staleness are refusals, never passes (#3944, ADR
-0058).
+cleared answer that does not cover exactly that set (#4520). It is a **floor, not a ceiling**: a
+diff touching `.decisions/`, `.claude/`, `.github/` or `claude-plugins/` gates on `governance`
+whether or not you passed it, because the verb re-derives that requirement from the diff itself
+(#5036) — so an `ns governance` line you did not ask for is the gate working, not a bug. `blocked`
+naming a FAIL → route to repair (`build`) and stop. `blocked` naming absence → the namespace was
+never gated at this head; route to the gate that owns it — `review` for every `review-*` namespace,
+the `governance` skill for `governance` — and stop. Absence and staleness are refusals, never
+passes (#3944, ADR 0058).
 
 ## 4 — CI at the head, and only at the head
 

--- a/claude-plugins/fabrika/skills/ship/contract.md
+++ b/claude-plugins/fabrika/skills/ship/contract.md
@@ -526,7 +526,7 @@ fabrika ship gate 4321 --sha 03135b91 --require review-code [--require review-do
 |---|---|---|---|---|
 | *(positional)* | integer | yes | — | the pull-request number |
 | `--sha` | string | yes | — | the head every verdict must bind to |
-| `--require` | string, repeatable | yes (≥1) | — | a required namespace; repeat the flag once per namespace, exactly as `ship scope` printed them |
+| `--require` | string, repeatable | yes (≥1) | — | a required namespace; repeat the flag once per namespace, exactly as `ship scope` printed them. A **floor the verb may raise**, never a ceiling (see the governance floor below) |
 | `--cp` | boolean | no | `false` | resolve §CP advisory carriers for the code namespace; pass iff `ship cp-approval` discharged |
 | `--repo` | string | no | resolved | the repository |
 | `--json` | boolean | no | `false` | emit the result object |
@@ -546,6 +546,26 @@ affirmative answer carries its own proof: before `satisfied` is printed, the ver
 namespace lines cover exactly the distinct required set — a plausible value with silently
 narrowed coverage is the defect's signature, so the assertion runs *before* the answer is
 believed, not after.
+
+**The `governance` requirement is the diff's floor, not the caller's option.** The verb reads the
+PR's changed-file list itself, and a diff with at least one path under `.decisions/`, `.claude/`,
+`.github/` or `claude-plugins/` gates on `governance` **whether or not `--require` named it** — the
+same predicate `ship scope` prints the namespace from, shared as code, so the two cannot disagree.
+Every other namespace stays caller-asserted; the floor only ever *adds*, so a diff under none of the
+four roots requires exactly what it required before. When the floor fires, a stderr notice names it.
+
+This is the whole ruling on #5036, and it is what a §CP row would otherwise have had to enforce.
+`claude-plugins/fabrika/**` is deliberately **not** control-plane — no CODEOWNERS row, no boundary
+widening ([founder veto, #5036](https://github.com/kamp-us/phoenix/issues/5036#issuecomment-5234614633),
+2026-08-10). The protection is this machine floor plus the §CP digest readout that carries every
+fabrika-tree landing to a human: **visibility after landing replaces blocking before it**, and the
+trade is explicit — the readout makes a gate-weakening landing *visible*, not *impossible* (#5216 is
+a live instance of the machine chain missing one). `.github/**`, CODEOWNERS included, and everything
+the existing §CP boundary already covers stay §CP, unchanged and enforced server-side regardless.
+
+The floor is `governance` only. Deriving the whole `review-*` set here would be a second answer to
+what `ship scope` already prints, and widening it is its own decision — recorded as considered, not
+silently taken.
 
 **In-force resolution, per namespace:** candidates are this namespace's verdict comments,
 head-bound first (a live-head-bound verdict strictly outranks recency — #4189), then ordered
@@ -576,10 +596,10 @@ answer this contract bans.
 
 | Code | Trigger |
 |---|---|
-| `7` | the PR is proven absent (404) or closed |
+| `7` | the PR is proven absent (404) or closed, or its diff has zero changed files — a conjunction over an empty diff proves nothing (ADR 0092) |
 | `10` | a `--require` value is not a known gateable namespace |
-| `11` | the comments, reviews, or ACL could not be read — the conjunction is UNKNOWN, never `blocked`, never `satisfied` |
-| `13` | the comment enumeration is provably short of the declared count, or the review read — for which the platform declares no count — never reached a terminal page |
+| `11` | the changed-file list, comments, reviews, or ACL could not be read — the conjunction is UNKNOWN, never `blocked`, never `satisfied` |
+| `13` | the changed-file or comment enumeration is provably short of the declared count, or the review read — for which the platform declares no count — never reached a terminal page |
 
 **Errors**
 
@@ -587,13 +607,17 @@ answer this contract bans.
 |---|---|---|
 | `ship gate: PR #<n> not found in <repo>.` | 7 | refusal |
 | `ship gate: PR #<n> is closed — nothing to gate.` | 7 | refusal |
+| `ship gate: PR #<n> has zero changed files — a conjunction over an empty diff proves nothing (ADR 0092).` | 7 | refusal |
 | `ship gate: --require <v> is not a gateable namespace (known: review-code, review-doc, review-skill, review-ui, governance).` | 10 | refusal |
 | `ship gate: cannot read <what> for #<n>: <reason> — the conjunction is UNKNOWN.` | 11 | refusal |
+| `ship gate: received <k> of <m> changed files — refusing to derive the required floor from a truncated read.` | 13 | refusal |
 | `ship gate: received <k> of <m> comments — refusing the partial resolution.` | 13 | refusal |
 | `ship gate: the review read never reached a terminal page — pagination is unexhausted, so the native-review fold would rest on a truncated set; refusing the partial resolution.` | 13 | refusal |
+| `ship gate: #<n>'s diff touches a governance root, so governance is required whether or not it was passed — the diff's floor, not the caller's option (#5036).` | 0 | notice |
 | `ship gate: #<n> carries a §CP advisory with a [FAIL] row — an invalid emission (ADR 0226); treated as fail, report it.` | 0 | notice |
 
-**Scope** — one PR's verdict comments (paginated, count-checked) and native reviews (paginated to
+**Scope** — one PR's changed-file list (paginated, count-checked — the floor may not rest on a
+truncated read), its verdict comments (paginated, count-checked) and native reviews (paginated to
 exhaustion), each candidate ACL-resolved. The verdict-marker and advisory grammars are the registered wire
 formats (`packages/fabrika-cli/src/wire/verdict-marker.ts`, `src/review/advisory.ts`) —
 imported, never re-parsed; a hand-rolled marker regex is the drift the registry ended.
@@ -615,8 +639,19 @@ $ echo $?
 0
 ```
 
+```
+$ fabrika ship gate 4323 --sha 7c31a0de --require review-skill
+ship gate: #4323's diff touches a governance root, so governance is required whether or not it was passed — the diff's floor, not the caller's option (#5036).
+gate	blocked	7c31a0de
+ns	review-skill	pass	marker
+ns	governance	absent	-
+```
+
 **Grounding**
 
+- #5036 — the governance floor. `--require` was caller-asserted end to end, so a fabrika-tree PR
+  shipped with no governance verdict simply by never passing the flag; the founder vetoed making
+  the tree §CP and ruled the machine floor instead.
 - #4520 — the repeated-flag collapse and the coverage assertion; both layers here.
 - #3944 / #3982 — the set-level absence check is not expressible as N separate reads; one verb
   owns the conjunction.

--- a/packages/fabrika-cli/src/ship/command.ts
+++ b/packages/fabrika-cli/src/ship/command.ts
@@ -93,7 +93,7 @@ const gate = leafCommand(
 		require: Flag.string("require").pipe(
 			Flag.atLeast(1),
 			Flag.withDescription(
-				"a required review namespace; repeat the flag once per namespace, exactly as `ship scope` printed them",
+				"a required review namespace; repeat the flag once per namespace, exactly as `ship scope` printed them. The set is a floor the verb may raise, never a ceiling: a governance-root diff requires `governance` whether or not it is passed (#5036)",
 			),
 		),
 		cp: Flag.boolean("cp").pipe(
@@ -111,7 +111,7 @@ const gate = leafCommand(
 	}),
 ).pipe(
 	Command.withDescription(
-		"Resolve the verdict conjunction over every required namespace at one head. First stdout line is `gate\\t<satisfied|blocked>\\t<sha>`, then one `ns\\t<namespace>\\t<pass|fail|absent|stale>\\t<marker|advisory|review-fold|->` line per required namespace, in the order required; `satisfied` iff every one reads pass, and the coverage of the required set is asserted before that word is printed (#4520). In-force resolution is head-bound-first then by write stamp (#4189/#4200), ACL-gated fail-closed (ADR 0055). Both `absent` and `stale` block (#3944). Exits 7 (PR proven absent or closed), 10 (a --require value is not a gateable namespace), 11 (comments, reviews or the ACL could not be read — the conjunction is UNKNOWN, never blocked and never satisfied), 13 (the comment enumeration is provably short of the declared count, or the review read — which the platform gives no count for — never reached a terminal page with no `next` link). Example: fabrika ship gate 4321 --sha 03135b91 --require review-code --require review-doc",
+		"Resolve the verdict conjunction over every required namespace at one head. First stdout line is `gate\\t<satisfied|blocked>\\t<sha>`, then one `ns\\t<namespace>\\t<pass|fail|absent|stale>\\t<marker|advisory|review-fold|->` line per required namespace, in the order required; `satisfied` iff every one reads pass, and the coverage of the required set is asserted before that word is printed (#4520). In-force resolution is head-bound-first then by write stamp (#4189/#4200), ACL-gated fail-closed (ADR 0055). Both `absent` and `stale` block (#3944). The required set is a floor the verb raises from the diff itself: a PR touching `.decisions/`, `.claude/`, `.github/` or `claude-plugins/` gates on `governance` whether or not --require named it, so no session can turn the requirement off by omission (#5036). Exits 7 (PR proven absent or closed, or the diff has zero changed files), 10 (a --require value is not a gateable namespace), 11 (the changed-file list, comments, reviews or the ACL could not be read — the conjunction is UNKNOWN, never blocked and never satisfied), 13 (the changed-file or comment enumeration is provably short of the declared count, or the review read — which the platform gives no count for — never reached a terminal page with no `next` link). Example: fabrika ship gate 4321 --sha 03135b91 --require review-code --require review-doc",
 	),
 );
 

--- a/packages/fabrika-cli/src/ship/gate-verb.ts
+++ b/packages/fabrika-cli/src/ship/gate-verb.ts
@@ -16,16 +16,18 @@
  * The one caller-asserted input is `--cp`, and it reaches **every** resolution in one run — v1
  * passed it to the gate and not the native fold, and a discharged FAIL stayed in force forever
  * (#4049). The fold living inside this verb is what makes that seam unrepresentable.
+ *
+ * `governance` is the one namespace the caller cannot decline: see {@link requiredWithFloor}.
  */
 import {Effect} from "effect";
 import type {ChildProcessSpawner} from "effect/unstable/process";
 import {type CommentRecord, listComments} from "../io/issues.ts";
-import {permissionFor} from "../io/pulls.ts";
+import {listPullFiles, permissionFor} from "../io/pulls.ts";
 import {readAdvisory} from "../review/advisory.ts";
-import {SHIP_NAMESPACES} from "../review/classes.ts";
+import {SHIP_NAMESPACES, touchesGovernanceRoot} from "../review/classes.ts";
 import {answer, refuse, type VerbOutcome} from "../verb.ts";
 import {read as readMarker} from "../wire/verdict-marker.ts";
-import {INCOMPLETE_SCAN, OFF_VOCABULARY, PRECONDITION_UNKNOWN} from "./codes.ts";
+import {INCOMPLETE_SCAN, OFF_VOCABULARY, PRECONDITION_UNKNOWN, ZERO_SCOPE} from "./codes.ts";
 import {listReviews, type ReviewRecord} from "./github.ts";
 import {
 	badNumber,
@@ -101,6 +103,28 @@ const candidateOf = (comment: CommentRecord, cp: boolean): Candidate | null => {
 };
 
 /**
+ * The set this verb gates on: the caller's namespaces, plus the floor the diff itself derives.
+ *
+ * `--require` was caller-asserted end to end — `ship scope` printed `governance` on a
+ * governance-root diff and the gate then believed whatever the session typed, so leaving the flag
+ * off turned the requirement off and a fabrika-tree PR shipped with no governance verdict at all
+ * (#5036). A namespace the diff derives is not the caller's to drop, so it is added here whether or
+ * not it was passed: the omission stops being discouraged and becomes unrepresentable.
+ *
+ * The floor is `governance` only. Deriving the `review-*` set here too would be a second answer to
+ * what `ship scope` already prints, and widening it is its own decision — the caller's assertion
+ * stands for those, unchanged.
+ */
+export const requiredWithFloor = (
+	requested: ReadonlyArray<string>,
+	files: ReadonlyArray<string>,
+): {readonly required: ReadonlyArray<string>; readonly floored: ReadonlyArray<string>} => {
+	const distinct = new Set(requested);
+	const floored = touchesGovernanceRoot(files) && !distinct.has("governance") ? ["governance"] : [];
+	return {required: [...distinct, ...floored], floored};
+};
+
+/**
  * The in-force verdict for one namespace: head-bound candidates first, then newest write stamp.
  *
  * Exported so the ordering is testable without a PR: the two rules interact, and "head-bound
@@ -148,14 +172,14 @@ export const runGate = (
 		const bound = inspectedSha(VERB, options.sha);
 		if (typeof bound !== "string") return bound;
 
-		const required = [...new Set(options.require)];
-		if (required.length === 0) {
+		const requested = [...new Set(options.require)];
+		if (requested.length === 0) {
 			return refuse(
 				OFF_VOCABULARY,
 				`${VERB}: --require is mandatory — a merge gated on zero namespaces is vacuously green (#2765).`,
 			);
 		}
-		const offVocabulary = required.find((name) => !SHIP_NAMESPACES.includes(name));
+		const offVocabulary = requested.find((name) => !SHIP_NAMESPACES.includes(name));
 		if (offVocabulary !== undefined) {
 			return refuse(
 				OFF_VOCABULARY,
@@ -177,13 +201,45 @@ export const runGate = (
 		if (target._tag === "Refused") return target.outcome;
 		const pull = target.pull;
 
-		const commented = yield* listComments(repo, pr);
-		if (commented._tag === "Failure") {
-			return refuse(PRECONDITION_UNKNOWN, unreadable("the comments", commented.reason));
+		const listed = yield* listPullFiles(repo, pr);
+		if (listed._tag === "Failure") {
+			return refuse(PRECONDITION_UNKNOWN, unreadable("the changed-file list", listed.reason));
 		}
 		const diagnostics = [
-			scannedLine(VERB, commented.value.length, "comment", `${pull.comments} declared`),
+			scannedLine(VERB, listed.value.length, "changed file", `${pull.changedFiles} declared`),
 		];
+		if (listed.value.length < pull.changedFiles) {
+			return refuse(
+				INCOMPLETE_SCAN,
+				`${VERB}: received ${listed.value.length} of ${pull.changedFiles} changed files — refusing to derive the required floor from a truncated read.`,
+				diagnostics,
+			);
+		}
+		if (listed.value.length === 0) {
+			return refuse(
+				ZERO_SCOPE,
+				`${VERB}: PR #${pr} has zero changed files — a conjunction over an empty diff proves nothing (ADR 0092).`,
+				diagnostics,
+			);
+		}
+		const {required, floored} = requiredWithFloor(requested, listed.value);
+		if (floored.length > 0) {
+			diagnostics.push(
+				`${VERB}: #${pr}'s diff touches a governance root, so governance is required whether or not it was passed — the diff's floor, not the caller's option (#5036).`,
+			);
+		}
+
+		const commented = yield* listComments(repo, pr);
+		if (commented._tag === "Failure") {
+			return refuse(
+				PRECONDITION_UNKNOWN,
+				unreadable("the comments", commented.reason),
+				diagnostics,
+			);
+		}
+		diagnostics.push(
+			scannedLine(VERB, commented.value.length, "comment", `${pull.comments} declared`),
+		);
 		if (commented.value.length < pull.comments) {
 			return refuse(
 				INCOMPLETE_SCAN,

--- a/packages/fabrika-cli/src/ship/gate-verb.unit.test.ts
+++ b/packages/fabrika-cli/src/ship/gate-verb.unit.test.ts
@@ -6,18 +6,28 @@ import {INCOMPLETE_SCAN, OFF_VOCABULARY, PRECONDITION_UNKNOWN, ZERO_SCOPE} from 
 import {
 	comments,
 	ENV,
+	files,
 	HEAD,
 	OTHER_HEAD,
 	pull,
 	reviews,
 	unexhaustedPage,
 } from "./fixtures.test-support.ts";
-import {inForce, runGate} from "./gate-verb.ts";
+import {inForce, requiredWithFloor, runGate} from "./gate-verb.ts";
 
 const PULL = /^gh api repos\/o\/r\/pulls\/4321$/;
+const FILES = /^gh api --paginate repos\/o\/r\/pulls\/4321\/files/;
 const COMMENTS = /^gh api --paginate repos\/o\/r\/issues\/4321\/comments/;
 const REVIEWS = /^gh api -i repos\/o\/r\/pulls\/4321\/reviews/;
 const ACL = /^gh api repos\/o\/r\/collaborators\/[^ ]+\/permission/;
+
+/** The default two-file diff, under no governance root — the floor stays off unless a test asks. */
+const ORDINARY = [FILES, files("apps/web/src/a.ts", "apps/web/src/b.ts")] as const;
+/** A fabrika-tree diff: `claude-plugins/` is one of the four governance roots. */
+const FABRIKA_TREE = [
+	FILES,
+	files("claude-plugins/fabrika/skills/ship/SKILL.md", "apps/web/src/b.ts"),
+] as const;
 
 const options = {
 	pr: 4321,
@@ -29,11 +39,17 @@ const options = {
 	env: ENV,
 };
 
+/**
+ * `ORDINARY` is appended, not prepended: `fakeShell` resolves on the FIRST matching pattern, so a
+ * test that scripts its own file list still wins and every other test reads an ordinary diff.
+ */
 const run = (
 	script: ReadonlyArray<readonly [RegExp, ExecResult]>,
 	overrides: Partial<typeof options> = {},
 ) =>
-	Effect.runPromise(Effect.provide(runGate({...options, ...overrides}), fakeShell(script).layer));
+	Effect.runPromise(
+		Effect.provide(runGate({...options, ...overrides}), fakeShell([...script, ORDINARY]).layer),
+	);
 
 const marker = (namespace: string, polarity: string, sha: string): string =>
 	`${namespace}: ${polarity} @ ${sha} — the clause`;
@@ -266,5 +282,125 @@ describe("runGate", () => {
 	it("refuses a closed PR on 7", async () => {
 		const out = await run([[PULL, pull({state: "closed"})]]);
 		expect(out.code).toBe(ZERO_SCOPE);
+	});
+
+	it("refuses a truncated changed-file read on 13 — the floor may not rest on it", async () => {
+		const out = await run([
+			[PULL, pull({changedFiles: 9})],
+			[FILES, files("claude-plugins/fabrika/skills/ship/SKILL.md")],
+		]);
+		expect(out.code).toBe(INCOMPLETE_SCAN);
+		expect(out.stdout).toBe("");
+	});
+
+	it("refuses a zero-file diff on 7 — a conjunction over an empty diff proves nothing", async () => {
+		const out = await run([
+			[PULL, pull({changedFiles: 0})],
+			[FILES, files()],
+		]);
+		expect(out.code).toBe(ZERO_SCOPE);
+	});
+});
+
+// The #5036 unit: `--require` was caller-asserted end to end, so a fabrika-tree PR shipped with no
+// governance verdict simply by never passing the flag. The floor is what makes that unrepresentable.
+describe("runGate — the governance floor (#5036)", () => {
+	it("requires governance on a fabrika-tree diff the caller never asked to gate on it", async () => {
+		const out = await run(
+			[
+				[PULL, pull({comments: 1})],
+				FABRIKA_TREE,
+				[COMMENTS, comments({id: 1, body: marker("review-skill", "PASS", HEAD)})],
+				[REVIEWS, reviews()],
+				[ACL, okOut("write")],
+			],
+			{require: ["review-skill"]},
+		);
+		expect(out.code).toBe(0);
+		expect(out.stdout).toBe(
+			[
+				`gate\tblocked\t${HEAD}`,
+				"ns\treview-skill\tpass\tmarker",
+				"ns\tgovernance\tabsent\t-",
+				"",
+			].join("\n"),
+		);
+		expect(
+			out.stderr.some((line) => line.includes("the diff's floor, not the caller's option")),
+		).toBe(true);
+	});
+
+	it("satisfies the floored namespace from a posted governance PASS", async () => {
+		const out = await run(
+			[
+				[PULL, pull({comments: 2})],
+				FABRIKA_TREE,
+				[
+					COMMENTS,
+					comments(
+						{id: 1, body: marker("review-skill", "PASS", HEAD)},
+						{id: 2, body: marker("governance", "PASS", HEAD)},
+					),
+				],
+				[REVIEWS, reviews()],
+				[ACL, okOut("write")],
+			],
+			{require: ["review-skill"]},
+		);
+		expect(out.stdout).toBe(
+			[
+				`gate\tsatisfied\t${HEAD}`,
+				"ns\treview-skill\tpass\tmarker",
+				"ns\tgovernance\tpass\tmarker",
+				"",
+			].join("\n"),
+		);
+	});
+
+	it("counts the floored namespace in --json `required`, so coverage cannot narrow silently", async () => {
+		const out = await run(
+			[[PULL, pull()], FABRIKA_TREE, [COMMENTS, comments()], [REVIEWS, reviews()]],
+			{require: ["review-skill"], json: true},
+		);
+		expect(JSON.parse(out.stdout)).toMatchObject({outcome: "blocked", required: 2});
+	});
+
+	it("leaves a diff under no governance root gated exactly as before", async () => {
+		const out = await run(
+			[
+				[PULL, pull({comments: 1})],
+				ORDINARY,
+				[COMMENTS, comments({id: 1, body: marker("review-code", "PASS", HEAD)})],
+				[REVIEWS, reviews()],
+				[ACL, okOut("write")],
+			],
+			{require: ["review-code"]},
+		);
+		expect(out.stdout).toBe(
+			[`gate\tsatisfied\t${HEAD}`, "ns\treview-code\tpass\tmarker", ""].join("\n"),
+		);
+	});
+});
+
+describe("requiredWithFloor", () => {
+	it("adds governance on a governance-root diff", () => {
+		const result = requiredWithFloor(
+			["review-skill"],
+			["claude-plugins/fabrika/skills/ship/SKILL.md"],
+		);
+		expect(result.required).toEqual(["review-skill", "governance"]);
+		expect(result.floored).toEqual(["governance"]);
+	});
+
+	it("adds nothing when the caller already asked for it — the floor never duplicates", () => {
+		const result = requiredWithFloor(["governance"], [".decisions/0001-a.md"]);
+		expect(result.required).toEqual(["governance"]);
+		expect(result.floored).toEqual([]);
+	});
+
+	it("leaves an ordinary diff's required set untouched", () => {
+		const result = requiredWithFloor(["review-code"], ["apps/web/src/a.ts"]);
+		expect(result.required).toEqual(["review-code"]);
+		expect(result.floored).toEqual([]);
 	});
 });


### PR DESCRIPTION
Fixes #5036

## What this builds

The [founder veto on #5036](https://github.com/kamp-us/phoenix/issues/5036#issuecomment-5234614633) (2026-08-10) reversed the earlier delegated ruling: `claude-plugins/fabrika/**` does **not** become §CP. This PR builds the revised unit — the machine gate, plus the model written down where the next reader finds it.

**The hole.** `ship scope` already emits the `governance` namespace for a governance-root diff (#5199) and `ship gate --require governance` is already satisfiable (#5206). But `--require` was caller-asserted end to end: a session that simply never passed `--require governance` shipped a fabrika-tree PR with no governance verdict at all, and the gate called that `satisfied`. The requirement was a discipline, not a gate.

**The fix.** `ship gate` now reads the PR's own changed-file list and raises the required set from it (`requiredWithFloor`), through the **same** `touchesGovernanceRoot` predicate `ship scope` and `governance scope` use — one derivation, three readers. The floor only ever *adds*: a diff under none of the four governance roots (`.decisions/`, `.claude/`, `.github/`, `claude-plugins/`) gates exactly as it did before. When the floor fires, a stderr notice names it. The floor is `governance` only — deriving the `review-*` set here too would be a second answer to what `ship scope` already prints, and that is recorded as considered, not silently taken.

The new file read is fail-closed like every other read in the group: unreadable → `11`, received-short-of-declared → `13`, zero changed files → `7` (ADR 0092).

## What this deliberately does NOT do

- **No CODEOWNERS row for `claude-plugins/fabrika/**`.** `.github/CODEOWNERS` is untouched by this diff.
- **No §CP-boundary widening.** `CONTROL_PLANE_RE` is untouched by this diff.
- `.github/**` (CODEOWNERS included) and everything the existing §CP boundary already covers stay §CP, enforced server-side regardless.

## The model, recorded

Both contracts now carry the ruling rather than just the mechanism: the protection is **machine gate plus human awareness, not a human click**. The floor blocks the enqueue; the §CP digest readout (producer: the `governance` skill; display: the front door, #4952) carries every fabrika-tree landing to a human. **Visibility after landing replaces blocking before it** — with the founder's own limit recorded rather than glossed: the readout makes a gate-weakening landing *visible*, not *impossible* (#5216 is one the machine chain missed).

## Files

- `packages/fabrika-cli/src/ship/gate-verb.ts` — the `requiredWithFloor` derivation, the count-checked changed-file read, the notice.
- `packages/fabrika-cli/src/ship/gate-verb.unit.test.ts` — the floor's three behaviours (fires unasked, is satisfiable by a posted PASS, counts in `--json required`), the unchanged-bar case, the two new refusals, and the pure unit.
- `packages/fabrika-cli/src/ship/command.ts` — the `--require` flag help and the verb description (the verb's own prose surface).
- `claude-plugins/fabrika/skills/ship/contract.md` — the floor, the exit/error tables, an example, the grounding, the ruling.
- `claude-plugins/fabrika/skills/ship/SKILL.md` — step 3: an `ns governance` line you did not ask for is the gate working.
- `claude-plugins/fabrika/skills/governance/contract.md` — shipped-surface change **1b**, and the model.
- `claude-plugins/fabrika/skills/governance/SKILL.md` — the "fail-closed on absence" bullet's stale caveat replaced by what is now actually enforced.

## Verification

- `pnpm vitest run` in `packages/fabrika-cli` — 195 files, 2789 tests, all green (26 in `gate-verb.unit.test.ts`, up from 17).
- `pnpm typecheck` — clean. `pnpm biome check` — clean.
- Rebased onto `origin/main` at `7d487fa9`; the diff is exactly the seven files above.
