### PR TITLE
docs(decisions): 0248 — the authoring session mints a contract's implementation ticket at handoff (#4749)

### DIFF
--- a/.decisions/0248-authoring-session-mints-the-implementation-ticket.md
+++ b/.decisions/0248-authoring-session-mints-the-implementation-ticket.md
@@ -1,0 +1,131 @@
+---
+id: 0248
+title: The authoring session mints a fabrika contract's implementation ticket at handoff, and review-skill checks it exists
+status: accepted
+date: 2026-08-10
+tags: [fabrika, pipeline, process]
+---
+
+# 0248 — The authoring session mints a fabrika contract's implementation ticket at handoff, and review-skill checks it exists
+
+**What this decides:** who turns a landed fabrika `contract.md` into an implementation ticket, at
+what moment, and what checks it happened. The answer is: **the authoring session, as part of its
+handoff, and the `review-skill` gate on the skill PR asserts the ticket exists and is named.**
+Nothing mints a ticket by machine — the session files it, triage prices it, the gate refuses a
+contract PR that arrives without one.
+
+## Context
+
+A fabrika authoring session's lane ends at the spec: it emits `SKILL.md` + `contract.md` and is
+forbidden from implementing the verbs it just specified (the
+[authoring-brief contract](../claude-plugins/fabrika/docs/authoring-brief-contract.md) field 6,
+[#4638](https://github.com/kamp-us/phoenix/issues/4638)). The build end is the crew's. Between them
+sat nothing: no actor, no moment, no artifact carrying the hand-off.
+
+That gap is not merely manual, it is **unowned**, and the only route into the build pool is an open
+issue — `write-code`'s picker selects on open + `status:triaged` + a priority label + a null
+assignee and reads nothing else
+(`claude-plugins/kampus-pipeline/skills/write-code/scripts/step1-candidate-pool.sh`). No issue means
+no build, with no other path. The failure reads as success: a green PR, a merged spec, a brief that
+auto-closes on `Fixes #<brief>`, and a skill on `main` whose verbs do not exist.
+
+Both early instances got a ticket by accident, from different actors on opposite sides of the merge
+that was supposedly the trigger: `adr`'s ([#4725](https://github.com/kamp-us/phoenix/issues/4725))
+2h14m *before* its contract merged, filed by an agent reading the open PR; `report`'s
+([#4748](https://github.com/kamp-us/phoenix/issues/4748)) 1h39m *after*, filed by an agent closing a
+brief. Two for two by noticing is a pattern, not a guarantee.
+
+The answer was then proven three times live, in one evening, before it was written down:
+`plan-epic`'s session → [#5179](https://github.com/kamp-us/phoenix/issues/5179), `governance`'s →
+[#5199](https://github.com/kamp-us/phoenix/issues/5199), `front-door`'s →
+[#5214](https://github.com/kamp-us/phoenix/issues/5214). Each handoff filed (or directly caused the
+filing of) its verbs ticket before the session closed, triage priced it, and the founder stamped it.
+The `front-door` skill PR's own `review-skill` verdict already asserted the linkage informally
+("#5214 costs no second lane"). This decision codifies exactly the behavior that was already
+working.
+
+## Decision
+
+### 1. The actor and the moment
+
+**The authoring session mints the implementation ticket, as part of its handoff.** The handoff is
+not complete until the ticket exists and the handoff names its number.
+
+The session is the right filer because it holds the context nobody else has: it just derived the
+verb inventory and ran the judgment/verb split, so it can name what is to be built without a second
+reader reconstructing it from the spec. The ticket carries, at minimum: the skill it serves, the
+repo-relative path of its `contract.md`, the verb inventory, and any sequencing dependency on the
+verb package existing.
+
+This does **not** move the lane's end. The session still does not implement its verbs, and a skill
+on `main` with unbuilt verbs is still an expected state. What is no longer permitted is a merged
+contract with **no ticket**, because that is the state that reads as done and is not.
+
+### 2. The check
+
+**The `review-skill` gate lists it as a criterion.** On a PR that adds or changes a fabrika
+`contract.md`, the gate asserts the implementation ticket exists, is open, and is named in the PR
+body or the handoff comment.
+
+Scope and zero-scope behavior (ADR [0092](0092-gates-fail-closed-on-zero-scope.md)): the check is
+selected off the PR's changed-file list. A diff carrying no
+`claude-plugins/fabrika/skills/*/contract.md` is out of scope and records PASS with that evidence —
+the check ran, it had nothing to assert. A file list that could not be read is **UNKNOWN and
+fails**, never "no contract touched".
+Unlike the sibling gap at [#4693](https://github.com/kamp-us/phoenix/issues/4693), scope is
+non-empty today: contracts are already on `main`.
+
+### 3. Nothing mints a ticket automatically
+
+A machine-minted ticket is un-sized, un-priced and un-homed work entering the board without passing
+triage — a second door into the build pool, the exact defect class the one-door ruling
+([#4637-C](https://github.com/kamp-us/phoenix/issues/4637)) fights. The mechanism's job is to
+**demand** the ticket, never to author one.
+
+## Why the teeth are a gate criterion and not a CI guard
+
+An earlier reading of this seam proposed a repo CI job that reds when a PR adds a `contract.md`
+without referencing an implementation issue. It was not taken, and the reason is what the check has
+to establish.
+
+The question is not "does the PR body contain an issue number" — a grep-shaped guard is satisfied by
+any number, including the brief's own `Fixes #<brief>` line, which is a **done-signal** and the exact
+opposite of a hand-off. The question is "does an open ticket exist that routes to *these* verbs" —
+a semantic read of the ticket against the contract the PR carries. `review-skill` already opens both
+the PR and its linked issues, already reads the contract text under review, and already performed
+this exact check informally on the `front-door` PR. Putting the assertion where the reader already
+is costs one listed criterion; a second CI job would re-derive a weaker version of the same answer
+and drift from it.
+
+So enforcement is **both** halves in the sense the seam needed — a documented obligation (the brief
+contract states the filing half) plus teeth (a listed, conjunctive gate criterion that fails the
+PR) — but the teeth are the gate, not a new fail-closed CI job. Teeth were not declined; they were
+placed at the only surface that can judge the ticket rather than count a number.
+
+## Rejected alternatives
+
+- **The wave epic carries an implementation child per skill up front.** Contradicts
+  [#4650](https://github.com/kamp-us/phoenix/issues/4650)'s ruled plan ("authoring briefs, not
+  code") and its non-goals, so it is an amendment to a p0 epic rather than a fix to this seam. It
+  also drops unassigned children into the `write-code` candidate pool — the second-door problem
+  tracked at #4693.
+- **Leave it to ambient noticing.** This is the status quo the seam documents: two of two tickets
+  filed because somebody happened to look. A rule that depends on remembering is the failure mode,
+  not the fix.
+- **Auto-mint on merge.** Ruled out above — an un-triaged ticket is a second door.
+
+## Consequences
+
+- The 17 briefs still open need **no edit**. A brief points at the authoring-brief contract rather
+  than paraphrasing it, so every session boots against the live doc and picks the filing obligation
+  up from field 6.
+- The two landed instances reconcile with nothing to re-file: `adr` (#4725) and `report` (#4748) are
+  both closed, so the rule is retroactively satisfied and this decision applies at authoring time
+  only.
+- The obligation is written in exactly two in-repo places — field 6 of the authoring-brief contract
+  (what the session owes) and `review-skill`'s rigor checklist (what the gate asserts). The
+  `/fabrika-skill-creator` wrapper's handoff step lives outside this repo's tree; it cites this
+  decision rather than restating the rule, so the two cannot drift.
+- The criterion belongs to **whichever skill is the live skill-class gate**. When fabrika's own
+  `review` skill takes that role from `claude-plugins/kampus-pipeline/skills/review-skill/`, it
+  carries this criterion with it; it is not a second, parallel check.

--- a/claude-plugins/fabrika/docs/authoring-brief-contract.md
+++ b/claude-plugins/fabrika/docs/authoring-brief-contract.md
@@ -133,6 +133,25 @@ needs. Implementing those verbs is downstream `write-code` work against that spe
 implements the contract from there", per the workflow ruling. A session that also implements its
 verbs has left its lane; a session that emits no contract spec has skipped its deliverable.
 
+**Who files the implementation ticket: this session, at handoff.** The lane ends at the spec, but
+the *hand-off* is the session's, and it is not complete until the implementation ticket exists and
+the handoff names its number
+([ADR 0248](../../../.decisions/0248-authoring-session-mints-the-implementation-ticket.md)). Nothing
+mints it by machine — a machine-minted ticket is un-sized, un-priced work entering the build pool
+without passing triage, which is the second door #4637-C closed. The session is the filer because it
+holds the context: it just derived the verb inventory and ran the split test, so it can name what is
+to be built without a second reader reconstructing it from the spec.
+
+The ticket carries, at minimum: the skill it serves, the repo-relative path of its `contract.md`,
+the verb inventory, and any sequencing dependency on the verb package existing. It goes through
+triage like any other issue; the session files it and stops.
+
+**It is checked, not merely asked for.** `review-skill` lists this as a criterion on a PR that adds
+or changes a `contract.md`: the implementation ticket must exist, be open, and be named in the PR
+body or the handoff comment. The brief's own `Fixes #<brief>` line does **not** satisfy it — that is
+a done-signal for the brief, not the hand-off. This is why "someone will file it" is not a plan: the
+seam has already failed twice by depending on somebody noticing (#4725, #4748).
+
 ## A brief is not write-code work
 
 A brief issue must never enter the `write-code` candidate pool. If it does, a coder agent picks it
@@ -197,7 +216,8 @@ point: a session can tell an unbootable brief from a bootable one before it star
 3. Every incident is a number **and** a one-line behavior; an empty list is written as empty.
 4. Every prior-art verb is named, with what it computes and — where known — what it gets wrong.
 5. Both convention docs are linked, and neither is summarised.
-6. The output contract is stated in the brief, not assumed.
+6. The output contract is stated in the brief, not assumed — including its filing half: the
+   handoff mints the implementation ticket and names its number.
 
 ## What a brief deliberately does not carry
 
@@ -262,4 +282,5 @@ Read these for semantics and scars; specify fabrika's own. Derive nothing for wo
 opening the PR (runbook step 5.5). Then one PR carrying `claude-plugins/fabrika/skills/adr/SKILL.md`
 and `claude-plugins/fabrika/skills/adr/contract.md`, with `Fixes #<this brief>` in the body and the
 review pass. The verbs the contract specifies are implemented downstream by `write-code`, against
-that spec. No skill enters fabrika by any other path (#4637-C).
+that spec — and this session's handoff files that implementation ticket and names its number in the
+PR body (ADR 0248). No skill enters fabrika by any other path (#4637-C).

--- a/claude-plugins/kampus-pipeline/skills/author-skill/SKILL.md
+++ b/claude-plugins/kampus-pipeline/skills/author-skill/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: author-skill
-description: "The authoring-side guide for writing a new kampus skill in the house idiom — the complement to the review-skill gate. Read it before you write a `skills/**/SKILL.md`. It covers the SKILL.md shape (frontmatter name/description contract, prose-first body), the house rules imported from the writing-craft manifest (no Python, no `sources/` tree, no second validator — review-skill already gates), how to author toward review-skill's four rigor checks so the gate passes on the first pass, the gate-skill house-style exemption, and the §CP destination re-check. Trigger on \"author a new skill\", \"write a kampus skill\", \"how do I add a skill\", \"what shape should this SKILL.md be\", \"run author-skill\", or whenever you are about to create or substantially rewrite a `skills/**` skill and need the house conventions. This is a reference guide, not a pipeline stage: it never picks issues, opens PRs, or merges — write-code does the building, review-skill does the gating, this tells you how to write the artifact in between."
+description: "The authoring-side guide for writing a new kampus skill in the house idiom — the complement to the review-skill gate. Read it before you write a `skills/**/SKILL.md`. It covers the SKILL.md shape (frontmatter name/description contract, prose-first body), the house rules imported from the writing-craft manifest (no Python, no `sources/` tree, no second validator — review-skill already gates), how to author toward review-skill's rigor checks so the gate passes on the first pass, the gate-skill house-style exemption, and the §CP destination re-check. Trigger on \"author a new skill\", \"write a kampus skill\", \"how do I add a skill\", \"what shape should this SKILL.md be\", \"run author-skill\", or whenever you are about to create or substantially rewrite a `skills/**` skill and need the house conventions. This is a reference guide, not a pipeline stage: it never picks issues, opens PRs, or merges — write-code does the building, review-skill does the gating, this tells you how to write the artifact in between."
 ---
 
 # author-skill
@@ -8,7 +8,7 @@ description: "The authoring-side guide for writing a new kampus skill in the hou
 You are about to write a **kampus skill** — a `SKILL.md` under `skills/**` that an agent
 loads and follows as a procedure. This guide is the authoring-side complement to
 [`review-skill`](../review-skill/SKILL.md): review-skill *gates* a skill PR against its
-issue's acceptance criteria plus four rigor checks; this tells you how to write the skill so
+issue's acceptance criteria plus the rigor checks; this tells you how to write the skill so
 it passes that gate on the first pass, in the house idiom. Read it before you create or
 substantially rewrite a `SKILL.md`.
 
@@ -67,10 +67,10 @@ malformed or vague one makes the skill silently unroutable. Write it as concrete
 conditions: what the skill is, then the phrases and situations it should fire on. This is
 also rigor check #2 (below), so getting it right here is getting it right for the gate.
 
-## Author toward review-skill's four rigor checks
+## Author toward review-skill's rigor checks
 
-review-skill verifies your PR against its issue's acceptance criteria **and** four rigor
-checks, conjunctively — any one failing fails the gate. Write to satisfy all four up front:
+review-skill verifies your PR against its issue's acceptance criteria **and** the rigor
+checks, conjunctively — any one failing fails the gate. Write to satisfy them up front:
 
 1. **Behavioral correctness.** Does the instruction *produce the intended behavior* when an
    agent follows it literally? Write concrete, ordered steps a fresh agent can execute
@@ -89,6 +89,12 @@ checks, conjunctively — any one failing fails the gate. Write to satisfy all f
    drop a SHA binding, remove a fail-closed assertion, loosen a denylist. This is the most
    serious verdict the gate lands; if you are editing a gate skill, name the invariant you
    are preserving and prove the edit keeps it.
+5. **Contract implementation ticket** — only if your PR carries a fabrika `contract.md`. The
+   contract specifies verbs nobody has built yet, and an open issue is the only route into the
+   build pool, so your handoff files that ticket and names its number in the PR body
+   (ADR [0248](https://github.com/kamp-us/phoenix/blob/main/.decisions/0248-authoring-session-mints-the-implementation-ticket.md)).
+   `Fixes #<brief>` does not count — it closes the brief, which is a done-signal, not the
+   hand-off. A PR with no fabrika `contract.md` is out of this check's scope.
 
 ## The gate-skill house-style exemption
 
@@ -149,5 +155,5 @@ Confirm `validate-skills.sh` passes locally. If your skill is a **pipeline stage
 step in the report → triage → … → ship-it flow), add a one-line row to the skills table in
 the plugin [`README.md`](../../README.md); an **ambient** skill (a guide or standalone tool,
 like this one) is discovered by the harness's `skills/*/SKILL.md` scan and needs no README
-row. Then hand the PR to `review-skill` — it gates the four rigor checks above; you do not
+row. Then hand the PR to `review-skill` — it gates the rigor checks above; you do not
 review your own skill.

--- a/claude-plugins/kampus-pipeline/skills/review-skill/SKILL.md
+++ b/claude-plugins/kampus-pipeline/skills/review-skill/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: review-skill
-description: Verify a skill PR against its linked issue's acceptance criteria — plus a skill-specific rigor checklist (behavioral correctness, trigger/description quality, cross-skill conflict/shadowing, gate-invariant preservation) — before it merges. The behavioral-artifact sibling of review-code/review-doc in the configured target repo's pipeline. Trigger on "review this skill PR", "review-skill #N", "gate the skill PR", "verify the skill on #N before merge", "run review-skill", "does this skill PR meet its acceptance criteria", or whenever you're asked to confirm a `skills/**` PR actually satisfies the issue it claims to close and does not weaken a gate. This is the skill-class verification stage of the issue-intake pipeline: it consumes the skill PRs `write-code` opens and verifies them one criterion at a time plus the four rigor checks, evidence-based from reading the diff (no test-running). Emits a namespaced, SHA-bound `review-skill: PASS @ <sha> — merge-ready` / `review-skill: FAIL @ <sha> — changes-requested` comment marker (never a native review — ADR 0058), upserted on the (PR, gate-namespace, head, run) key; for BLOCKING-set skill PRs (a gate-critical skill, or any `.claude`/`.github` path) it is advisory only; it never merges; it never emits a `review-code` or `review-doc` marker.
+description: Verify a skill PR against its linked issue's acceptance criteria — plus a skill-specific rigor checklist (behavioral correctness, trigger/description quality, cross-skill conflict/shadowing, gate-invariant preservation, and — on a fabrika contract PR — that the contract's implementation ticket exists and is named) — before it merges. The behavioral-artifact sibling of review-code/review-doc in the configured target repo's pipeline. Trigger on "review this skill PR", "review-skill #N", "gate the skill PR", "verify the skill on #N before merge", "run review-skill", "does this skill PR meet its acceptance criteria", or whenever you're asked to confirm a `skills/**` PR actually satisfies the issue it claims to close and does not weaken a gate. This is the skill-class verification stage of the issue-intake pipeline: it consumes the skill PRs `write-code` opens and verifies them one criterion at a time plus the rigor checks, evidence-based from reading the diff (no test-running). Emits a namespaced, SHA-bound `review-skill: PASS @ <sha> — merge-ready` / `review-skill: FAIL @ <sha> — changes-requested` comment marker (never a native review — ADR 0058), upserted on the (PR, gate-namespace, head, run) key; for BLOCKING-set skill PRs (a gate-critical skill, or any `.claude`/`.github` path) it is advisory only; it never merges; it never emits a `review-code` or `review-doc` marker.
 ---
 
 # review-skill
@@ -427,7 +427,8 @@ whether the skill is *well-formed and behaviorally sound* — the skill-class eq
 regardless of what the AC say**. A skill can satisfy its issue and still misfire, shadow
 another skill, or quietly weaken a gate. Each check is PASS / FAIL with diff evidence, and **a
 rigor FAIL fails the gate** the same as an AC FAIL — the overall verdict is conjunctive across
-*both* lists. These are the four checks the existing gates structurally miss (ADR 0073 §1):
+*both* lists. Checks 1–4 are the ones the existing gates structurally miss (ADR 0073 §1); check 5
+is scoped to fabrika contract PRs (ADR 0248):
 
 1. **Behavioral correctness.** Does the instruction *produce the intended agent behavior*,
    beyond "meets the issue's ACs"? Trace the changed steps as an agent would execute them: do
@@ -480,6 +481,25 @@ rigor FAIL fails the gate** the same as an AC FAIL — the overall verdict is co
    removed/softened line and the invariant it breaks. For a **non**-gate-critical skill PR
    (nothing in §CP), this check is "no gate invariant is in the diff's reach" — record it PASS
    with that evidence; the check still runs, it just has nothing to weaken.
+5. **Contract implementation ticket — scoped to fabrika contract PRs (ADR 0248).** A fabrika
+   authoring session's lane ends at the spec, so its `contract.md` specifies verbs nobody has built
+   yet, and the **only** route into the build pool is an open issue. The session owes that ticket at
+   handoff; you are what checks it. Scope this check off the PR's **changed-file list**:
+   - **In scope** — the diff adds or changes a `claude-plugins/fabrika/skills/*/contract.md`.
+     Assert an implementation ticket for **these** verbs **exists, is open, and is named** in the PR
+     body or the handoff comment, and read the ticket to confirm it routes to this contract (the
+     skill it serves + its verb inventory). A `Fixes #<brief>` line does **not** satisfy this: it
+     closes the authoring brief, which is a done-signal, not the hand-off. Neither does a bare issue
+     number that turns out to track something else. FAIL with the contract path + what the named
+     issue actually covers.
+   - **Out of scope** — the diff carries no such `contract.md`. Record PASS with that evidence; the
+     check ran and had nothing to assert.
+   - **File list unreadable** — UNKNOWN, and UNKNOWN **fails** (ADR 0092). Never read a file list
+     you could not fetch as "no contract touched."
+
+   You never file the ticket yourself and you never merge on its absence: a machine-minted ticket is
+   un-triaged work entering the build pool, the second door ADR 0248 refuses. Your job is to demand
+   it.
 
 Build the rigor findings into the same evidence shape as the AC table:
 
@@ -487,19 +507,20 @@ Build the rigor findings into the same evidence shape as the AC table:
 - [PASS] Behavioral correctness — the new Step R2 fold reads exactly the enumerated findings (skills/write-code/SKILL.md:619–636)
 - [FAIL] Gate-invariant preservation — diff drops the `@ <sha>` from ship-it's matcher (Step 2, line NNN) → SHA-staleness refusal no longer fires
 - [PASS] Cross-skill conflict — review-skill marker token is disjoint from review-code/review-doc (§VERDICT)
+- [PASS] Contract implementation ticket — out of scope, no fabrika `contract.md` in the diff's 8 files
 ```
 
 ---
 
 ## Step 4b — Specialist fan-out + route-don't-grade (ADR 0079)
 
-The AC checklist (Step 3) and the four rigor checks (Step 4) catch what the issue *named*
+The AC checklist (Step 3) and the rigor checks (Step 4) catch what the issue *named*
 and the four behavioral failures ADR 0073 enumerated; together they are still blind to a
 real, in-scope behavioral defect the issue's AC never named — a path through the changed
-instruction that misbehaves yet trips none of the four named rigor checks. This gate fans out
+instruction that misbehaves yet trips none of the named rigor checks. This gate fans out
 skill-class specialists to surface such a finding and **routes** it into the converging AC
 work-list, exactly as `review-code` does for code. **The fan-out is additive — it feeds
-*additional* findings into the route step; the four-check rigor checklist (Step 4), including
+*additional* findings into the route step; the rigor checklist (Step 4), including
 gate-invariant-preservation, is preserved in full, not replaced.**
 
 **This is one logic with four call sites — [`../shared/specialist-fan-out.md`](../shared/specialist-fan-out.md)
@@ -523,7 +544,7 @@ re-derive the route decision, the tag fields, or the fences here.** Only the *cl
   handle that the changed instruction leaves unspecified (an error branch with no described
   handling, a mode the description admits but no step covers).
 
-These extend, never replace, the four rigor checks. Each yields zero or more **findings** (a
+These extend, never replace, the rigor checks. Each yields zero or more **findings** (a
 concrete defect with its skill-text site) that feed the route step; the fan-out emits no
 verdict.
 
@@ -677,6 +698,7 @@ Verified PR #<PR> against the acceptance criteria of #<ISSUE> + the skill-rigor 
 - [PASS] Trigger / description quality — <evidence>
 - [PASS] Cross-skill conflict / shadowing — <evidence>
 - [PASS] Gate-invariant preservation — <evidence / "no gate invariant in diff's reach">
+- [PASS] Contract implementation ticket — <the named open ticket / "out of scope, no fabrika contract.md in the diff">
 
 Read the PR head (§HEAD): all skill text under review sourced from `<HEAD_SHA>` via
 `$REVIEW_WT/skills/...`, never the launched checkout's working copy.
@@ -746,6 +768,7 @@ Verified against #<ISSUE>'s acceptance criteria + the skill-rigor checklist — 
 - [PASS] Trigger / description quality — <evidence>
 - [PASS] Cross-skill conflict / shadowing — <evidence>
 - [PASS] Gate-invariant preservation — <evidence: invariants walked, none weakened>
+- [PASS] Contract implementation ticket — <the named open ticket / "out of scope, no fabrika contract.md in the diff">
 ```
 
 Upsert it the same way as the pass/fail paths — `mktemp` the verdict file (the PR number alone
@@ -863,7 +886,7 @@ cannot. See the shared contract for the full post-path enumeration proving no pa
 A single invocation gates one skill PR end to end: config-pin yourself to the base (mandatory,
 ADR 0052), classify blocking vs non-blocking via the canonical §CP set (Step 0), resolve the
 PR ↔ issue (Step 1), read the diff + the head's skill text from the isolated worktree (Step 2),
-verify each acceptance criterion (Step 3) and run the four-check skill-rigor checklist
+verify each acceptance criterion (Step 3) and run the skill-rigor checklist
 (Step 4), fan out the skill-class specialists and route their findings (Step 4b — in-scope
 appends an AC, out-of-scope to `report`, ADR 0079), then land the verdict — namespaced
 `review-skill: PASS` (non-blocking) or the canonical advisory line (blocking) on a full pass,

--- a/claude-plugins/kampus-pipeline/skills/write-code/SKILL.md
+++ b/claude-plugins/kampus-pipeline/skills/write-code/SKILL.md
@@ -1307,7 +1307,7 @@ skip for that surface, never a block.
 - **A skill** — a `skills/**/SKILL.md` or its supporting files → read
   [`../author-skill/SKILL.md`](../author-skill/SKILL.md) and write in the house idiom (the frontmatter
   `name`/`description` contract, the prose-first body, the imported writing-craft house rules) toward
-  `review-skill`'s four rigor checks, so the gate passes on the first pass.
+  `review-skill`'s rigor checks, so the gate passes on the first pass.
 
 This is a **self-check, not a gate — the split-role firewall holds** exactly as it does for
 Steps 4c/4d. Reading the writing-craft skills to shape your own prose before you push is the


### PR DESCRIPTION
Fixes #4749

Records the founder ruling on the spec-to-build seam (issue comment 2026-08-10T00:12:17Z, which supersedes the earlier 2026-08-02 comment's CI-guard shape) and writes it into the two in-repo surfaces that carry it.

## The decision

**The authoring session mints a fabrika contract's implementation ticket, as part of its handoff, and `review-skill` checks it exists.**

- **Actor + moment** — the authoring session, at handoff. The handoff is not complete until the ticket exists and names its number. The session is the filer because it just derived the verb inventory and ran the split test.
- **The check** — a listed `review-skill` rigor criterion, scoped to a PR that adds or changes a `claude-plugins/fabrika/skills/*/contract.md`: the ticket must exist, be open, be named in the PR body or handoff, and route to *these* verbs. `Fixes #<brief>` does not satisfy it — that closes the brief, which is a done-signal, not the hand-off.
- **Zero scope (ADR 0092)** — a diff with no fabrika `contract.md` is out of scope and records PASS with that evidence; an unreadable file list is UNKNOWN and **fails**, never "no contract touched."
- **Nothing auto-mints.** A machine-minted ticket is un-triaged work entering the build pool — the second door #4637-C closed. The mechanism demands the ticket, it never authors one.

Rejected on the record: minting implementation children on the epic up front (amends #4650's ruled briefs-only plan, and drops unassigned children into the coder pool), and leaving it to ambient noticing (the gap itself).

## Why the teeth are a gate criterion, not a new CI job

A grep-shaped CI guard answers "does the body contain an issue number" — satisfiable by the brief's own `Fixes #<brief>` line. The question that matters is "does an open ticket route to *these* verbs", which is a semantic read. `review-skill` already opens the PR, its linked issues and the contract text, and already did exactly this informally on the `front-door` PR (#5216). One listed criterion beats a second job that re-derives a weaker answer and drifts.

## Acceptance criteria

- [x] The choice is recorded as an ADR — `.decisions/0248-authoring-session-mints-the-implementation-ticket.md` (actor, moment, and what enforces it)
- [x] The brief contract's field 6 states the hand-off's *filing* half explicitly — a new "Who files the implementation ticket: this session, at handoff" clause under "Where the session's job ends", plus the completeness-test row and the worked example
- [x] The decision states whether enforcement is a guard, a documented obligation, or both — both: the documented obligation in the brief contract, the teeth as a conjunctive gate criterion; the ADR says why a CI guard was not the shape
- [x] Zero-scope behaviour stated (ADR 0092) — out-of-scope PASS with evidence, unreadable file list fails
- [x] Whether the 17 open briefs need changing — no. A brief points at the contract doc rather than paraphrasing it, so every session boots against the live doc
- [x] The two landed instances reconciled — `adr` (#4725) and `report` (#4748) are both closed; the rule is retroactively satisfied and applies at authoring time only
- [x] Nothing files an implementation ticket automatically without triage

## Files

| File | What changed |
|---|---|
| `.decisions/0248-authoring-session-mints-the-implementation-ticket.md` | new ADR |
| `claude-plugins/fabrika/docs/authoring-brief-contract.md` | field 6 gains the filing half; completeness test row 6; worked example |
| `claude-plugins/kampus-pipeline/skills/review-skill/SKILL.md` | rigor check 5 (scoped) + the two PASS verdict templates + count phrasing |
| `claude-plugins/kampus-pipeline/skills/author-skill/SKILL.md` | authoring-side mirror of check 5 + count phrasing |
| `claude-plugins/kampus-pipeline/skills/write-code/SKILL.md` | one count phrase ("four rigor checks" → "rigor checks") |

Three of the five are under `claude-plugins/kampus-pipeline/skills/`, so this PR is **§CP** and needs a `@kamp-us/control-plane` approval at head before `ship-it` can enqueue it. No CODEOWNERS row was added or widened, and nothing under `claude-plugins/fabrika/skills/` was touched.

## Checks run locally

- `validate-skills.sh` — OK, 30 skills valid
- `pipeline-cli decisions-index validate` — no duplicate or mismatched id (0247 is claimed by open PR #5230; 0248 re-checked free against `origin/main` and every open PR immediately before commit)
- `pipeline-cli gh-phoenix lint-skills` on the three edited skills — clean
- typecheck + changed-unit tests ran green on the push hook
