### PR TITLE
fix(divan): size the upvote button through the button size contract

### DIFF
--- a/apps/web/src/components/divan/Divan.css
+++ b/apps/web/src/components/divan/Divan.css
@@ -335,12 +335,21 @@
 	gap: 2px;
 }
 
+/* The square is set through the button's own size contract, not bare width/height: Manti applies
+   `min-height: var(--manti-button-height)` and Button.css a `min-width: var(--tap-min)` (36px), both
+   of which outrank a plain declaration — 28×28 rendered ≥36×30 until these were set (#5227). 28 is
+   under the 36px tap floor for the same reason the pano/sözlük vote buttons are: WCAG 2.5.8's 24px
+   target governs a dense vote control (#2166). */
 .kp-divan__upvote {
+	--manti-button-height: 28px;
+	--manti-button-padding-x: 0px;
 	display: inline-flex;
 	align-items: center;
 	justify-content: center;
+	min-width: 28px;
 	width: 28px;
 	height: 28px;
+	padding: 0;
 	border: 1px solid var(--border);
 	border-radius: var(--r-sm);
 	background: var(--surface);

--- a/apps/web/src/components/divan/Divan.css
+++ b/apps/web/src/components/divan/Divan.css
@@ -341,14 +341,15 @@
    under the 36px tap floor for the same reason the pano/sözlük vote buttons are: WCAG 2.5.8's 24px
    target governs a dense vote control (#2166). */
 .kp-divan__upvote {
-	--manti-button-height: 28px;
+	--vote-size: 28px;
+	--manti-button-height: var(--vote-size);
 	--manti-button-padding-x: 0px;
 	display: inline-flex;
 	align-items: center;
 	justify-content: center;
-	min-width: 28px;
-	width: 28px;
-	height: 28px;
+	min-width: var(--vote-size);
+	width: var(--vote-size);
+	height: var(--vote-size);
 	padding: 0;
 	border: 1px solid var(--border);
 	border-radius: var(--r-sm);

--- a/apps/web/src/components/ui/button-size-contract.unit.test.ts
+++ b/apps/web/src/components/ui/button-size-contract.unit.test.ts
@@ -1,0 +1,92 @@
+// A feature sheet cannot size a Manti button with bare `width`/`height`: Manti's own
+// `[data-scope=button][data-part=root]` sets `min-height: var(--manti-button-height)` and
+// Button.css sets `min-width: var(--tap-min)`, so both bare declarations lose and the control
+// silently renders at the floor instead of the declared box (#5227).
+import {readdirSync, readFileSync} from "node:fs";
+import {join, relative} from "node:path";
+import {describe, expect, it} from "vitest";
+
+const sourceRoot = join(import.meta.dirname, "../..");
+const buttonElementPattern = /<Button\b[^>]*>/gs;
+const classNamePattern = /className=(?:"([^"]*)"|\{`([^`]*)`\})/;
+
+function sourceFiles(directory: string, extension: string): string[] {
+	return readdirSync(directory, {withFileTypes: true}).flatMap((entry) => {
+		const path = join(directory, entry.name);
+
+		if (entry.isDirectory()) return sourceFiles(path, extension);
+		if (!entry.name.endsWith(extension) || entry.name.includes(".test.")) return [];
+
+		return [path];
+	});
+}
+
+/** Every static `kp-*` class a production `<Button>` carries. */
+function buttonClasses(): Set<string> {
+	const classes = new Set<string>();
+
+	for (const path of sourceFiles(sourceRoot, ".tsx")) {
+		for (const element of readFileSync(path, "utf8").matchAll(buttonElementPattern)) {
+			const match = classNamePattern.exec(element[0]);
+			const value = match?.[1] ?? match?.[2];
+			if (!value) continue;
+
+			for (const name of value.split(/\s+/)) {
+				if (name.startsWith("kp-")) classes.add(name);
+			}
+		}
+	}
+
+	return classes;
+}
+
+type Rule = {file: string; selector: string; body: string};
+
+function cssRules(): Rule[] {
+	return sourceFiles(sourceRoot, ".css").flatMap((path) =>
+		[...readFileSync(path, "utf8").matchAll(/([^{}]+)\{([^{}]*)\}/g)].map((rule) => ({
+			file: relative(sourceRoot, path),
+			selector: (rule[1] ?? "").replace(/\/\*[\s\S]*?\*\//g, "").trim(),
+			body: rule[2] ?? "",
+		})),
+	);
+}
+
+function declares(body: string, property: string): boolean {
+	return new RegExp(`(^|[;{\\s])${property}\\s*:`).test(body);
+}
+
+/** A fixed px box — the sizing that loses to the contract's floors. `100%`/`auto` is layout. */
+function declaresFixedBox(body: string): boolean {
+	return /(^|[;{\s])(width|height)\s*:\s*\d+px/.test(body);
+}
+
+/** The rule targets the button itself only when the class sits in the selector's last compound. */
+function targets(selector: string, className: string): boolean {
+	return selector
+		.split(",")
+		.some((part) => part.trim().split(/\s+/).at(-1)?.includes(`.${className}`) === true);
+}
+
+describe("Manti button size contract", () => {
+	const classes = buttonClasses();
+	const rules = cssRules();
+
+	it("scans a non-empty set of button classes and CSS rules", () => {
+		expect(classes.size).toBeGreaterThan(0);
+		expect(rules.length).toBeGreaterThan(0);
+	});
+
+	it("sizes a button through the size contract, never bare width/height", () => {
+		const offenders = rules
+			.filter((rule) => [...classes].some((name) => targets(rule.selector, name)))
+			.filter((rule) => declaresFixedBox(rule.body))
+			.filter(
+				(rule) =>
+					!declares(rule.body, "min-width") || !declares(rule.body, "--manti-button-height"),
+			)
+			.map((rule) => `${rule.file} :: ${rule.selector}`);
+
+		expect(offenders).toEqual([]);
+	});
+});

--- a/apps/web/src/components/ui/button-size-contract.unit.test.ts
+++ b/apps/web/src/components/ui/button-size-contract.unit.test.ts
@@ -56,9 +56,14 @@ function declares(body: string, property: string): boolean {
 	return new RegExp(`(^|[;{\\s])${property}\\s*:`).test(body);
 }
 
-/** A fixed px box — the sizing that loses to the contract's floors. `100%`/`auto` is layout. */
+/** A definite box — both axes at a fixed length. `100%`/`auto` is layout, not sizing. */
 function declaresFixedBox(body: string): boolean {
-	return /(^|[;{\s])(width|height)\s*:\s*\d+px/.test(body);
+	const definite = (axis: string) => {
+		const value = new RegExp(`(?:^|[;{\\s])${axis}\\s*:\\s*([^;]+)`).exec(body)?.[1]?.trim();
+		return value !== undefined && !/%|auto|inherit|content$/.test(value);
+	};
+
+	return definite("width") && definite("height");
 }
 
 /** The rule targets the button itself only when the class sits in the selector's last compound. */


### PR DESCRIPTION
The upvote button on the divan çaylak-detail page looked like a slightly squashed rectangle instead of the square it was meant to be, which also made its triangle icon read as undersized. The CSS did declare a 28×28 square, but two larger floors from the shared button styles quietly overrode it. This sets the size through the button's own contract so the declared box is the box that renders, and adds a test so the same override can't silently lose again.

Fixes #5227

## What changed

- `apps/web/src/components/divan/Divan.css` — `.kp-divan__upvote` now sets `--manti-button-height`, `--manti-button-padding-x`, `min-width` and `padding` alongside `width`/`height`, the same shape `.kp-pano-post__vote-btn` and `.kp-sozluk-definition__vote-btn` already use. Previously `min-width: var(--tap-min)` (36px, `Button.css:7`) and Manti's `min-height: var(--manti-button-height)` (30px at `size="sm"`) outranked the bare 28px declarations, so the control laid out at ≥36×30.
- `apps/web/src/components/ui/button-size-contract.unit.test.ts` — a source-scanning guard in the `manti-adoption.unit.test.ts` idiom: it collects every static `kp-*` class a production `<Button>` carries, and fails when a rule targeting one of those classes sets a fixed px `width`/`height` without also setting `min-width` and `--manti-button-height`. It carries a zero-scope assertion (ADR 0092) so an empty scan can't pass silently. Reverting the CSS fix makes it fail on `.kp-divan__upvote` — verified.

The icon is unchanged at 16px: ADR 0240 rules that an icon-only control (no visible label) stays at ≥16 whatever its host's height, so 12/14 is not available here. With the box now a true 28×28 the glyph fills it at the same ratio as the pano and sözlük vote buttons, which is where the "icon looks small" reading came from.

## Deviations

- **Class: scope of the AC / narrowed fix shape.** Said: AC 2 offered "satisfy the 36px `--tap-min` floor, or record the deviation with an explicit rationale", and the triage note called growing to 36px the low-risk default. Did: kept the 28px box and took the second branch — an inline note at the enforcement site citing WCAG 2.5.8's 24px target and the `#2166` precedent the two sibling vote buttons already run under. Why: the divan row is a dense vote control of the same class as the pano (24px) and sözlük (26px) vote buttons; growing only this one to 36px would make it the outlier among three sibling surfaces and change the row's rhythm, which is not what the issue reported. Disposition: for the reviewer to judge — if the design call is that all three should reach the tap floor, that is one change across three surfaces, not this one.
- **Class: verification weaker than the AC's letter.** Said: AC 1 asks for "measured computed `width == height` in the browser, not merely declared in CSS". Did: verified the box is square by CSS reasoning (every floor now equals 28px) plus the source-level guard test above; there is no computed-style or browser-metric test tier in this repo (no `getComputedStyle`/`toHaveCSS` precedent anywhere in `apps/web/tests`), and the divan surface is mod-gated so an e2e assertion would need an actor fixture. Why: adding a browser-metrics tier for one assertion is disproportionate to the fix. Disposition: for the reviewer to judge; the guard test enforces the invariant that made the box non-square, which is the part that can regress.