### PR TITLE
docs(decisions): 0249 — trigger coverage lives in the eval set, not a fourth ship-gate part (#4750)

### DIFF
--- a/.decisions/0249-skill-trigger-coverage-lives-in-the-eval-set.md
+++ b/.decisions/0249-skill-trigger-coverage-lives-in-the-eval-set.md
@@ -1,0 +1,122 @@
+---
+id: 0249
+title: a fabrika skill's trigger coverage is measured in its eval set, not as a fourth ship-gate part
+status: accepted
+date: 2026-08-09
+tags: [fabrika, skills, gates, evals]
+---
+
+# 0249 — a fabrika skill's trigger coverage is measured in its eval set, not as a fourth ship-gate part
+
+**What this decides:** where the number that says "this skill actually fires" lives. It lives in the
+skill's **eval set**, under the eval mechanics epic
+[#4649](https://github.com/kamp-us/phoenix/issues/4649) owns. The
+[fabrika skill-conventions](../claude-plugins/fabrika/docs/skill-conventions.md) §8 ship gate keeps
+exactly the three parts it was founder-ruled with — it gains no fourth part.
+
+## Context
+
+[#4750](https://github.com/kamp-us/phoenix/issues/4750) reported a real hole: a fabrika skill can
+pass every part of §8 and still almost never fire. §8's three parts are provenance (authored via
+`/skill-creator`), the CLI layer (the derived contract implemented with deterministic tests), and the
+behavioural layer (the eval set green at the ruled bar). None of the three measures whether the
+skill's `description` gets the skill invoked in the first place, and the eval sets on `main` grade
+**post-invocation** behaviour by construction — the harness supplies the invocation, so it cannot see
+a skill nobody ever calls. Under §3, a model-invoked skill pays a per-turn context load forever, so a
+skill that never fires is the worst cell in that trade and nothing on the board goes red.
+
+§8 also fences itself: *"Gates 1 and 2 are what this doc governs. Gate 3 is cited, never re-derived
+here"*, and of the bar's mechanics, *"This doc specifies none of that mechanics and must not grow
+it."* So writing a recall floor into §8 is the one repair §8 forbids itself, which is why this was a
+recorded choice rather than a build ticket.
+
+### The measurement, and what it refuted
+
+The filing session ran `/skill-creator`'s description optimizer over `/report` five times, each
+rewrite tuned specifically for triggering, three runs per query against a 20-query set (10
+should-fire, 10 near-miss). Recall stayed between 0% and 11% on every iteration; **precision held at
+100% on all five**, including the noun-sense trap. No should-fire query ever reached 2/3 under any
+description.
+
+That refutes the framing the issue arrived with. It is not a badly-worded description with a wording
+fix — no wording reached the bar. Two structural causes explain it. Filing an issue is a **one-step
+action** the model just performs, and `/skill-creator`'s own guidance says a one-step query may not
+trigger a skill however well the description matches. And the probe ran with a cwd outside this repo,
+so no project `CLAUDE.md` was loaded — while the behavioural eval's **baseline arm, with no skill at
+all, behaved correctly purely by reading `CLAUDE.md`'s intake contract**. For this class of skill the
+project's routing instruction is the trigger mechanism and the description is not.
+
+Carried as reported, not re-measured at this desk: the numbers above and the confound check that
+ruled out a competing `report` skill stealing the trigger are the filing session's results. The
+structural claim — that neither §8 nor the eval layer measures triggering — was verified
+independently of them.
+
+## Decision
+
+Ruled 2026-08-10 on [#4750](https://github.com/kamp-us/phoenix/issues/4750#issuecomment-5234575962)
+under the founder's standing trust ruling of 2026-08-09 (delegated judgment, founder live, veto
+open):
+
+1. **§8 keeps its three parts, unchanged.** No fourth ship-gate part, and
+   `claude-plugins/fabrika/docs/skill-conventions.md` is not edited by this decision. §8's
+   self-imposed prohibition on restating eval mechanics stays intact.
+2. **Trigger coverage is part of a skill's eval set.** The convention: a skill's eval set includes
+   trigger coverage. Because §8 part 3 already requires the eval set to be green at the bar, this
+   adds a *property to the eval set*, not a gate to the doc — one home for the number, which is what
+   the question asked for.
+3. **User-only skills are exempt, and the exemption is stated.** A skill with
+   `disable-model-invocation` has no `description` in model context, so there is nothing to trigger
+   and no trigger coverage is owed. Precedent set live: the `front-door` authoring session
+   ([#4952](https://github.com/kamp-us/phoenix/issues/4952)) skipped the description optimizer for
+   exactly that stated reason, and its gate accepted the deviation.
+4. **The convention is written down against the eval surface**, not here — a build ticket records
+   the trigger-coverage convention and the user-only exemption in the eval mechanics docs where
+   #4649's mechanics live.
+
+### What this supersedes
+
+An earlier ruling on the same issue (2026-08-02,
+[comment](https://github.com/kamp-us/phoenix/issues/4750#issuecomment-5157012773) and
+[comment](https://github.com/kamp-us/phoenix/issues/4750#issuecomment-5157061359)) split the gate in
+two and put a structural half — *"is there a routing path that reaches this skill in deployment?"* —
+into `skill-conventions.md` beside the sizing band, leaving only the measured half with #4649. **That
+split is superseded: nothing lands in §8.** Read the issue newest-comment-first; the 2026-08-02
+answer is on the page and is no longer the ruling.
+
+The evidence that split was built on is *not* superseded, and is carried here so it is not
+re-derived from zero.
+
+## Consequences
+
+**Nothing changes in the ship gate today.** §8 reads exactly as it did. The work is downstream, in
+#4649's mechanics, and this ADR is the record a stateless authoring session reads to know that the
+number is not a §8 bullet.
+
+**Three constraints the mechanics inherit**, established by the measurement above:
+
+- **Measure in deployment context.** A trigger score taken without the project's own routing
+  instructions loaded measures an environment the skill never ships into.
+- **Price one-step skills separately.** Where the model can simply do the task, no description
+  reaches a recall floor, and demanding one reds a working skill while pointing its author at prose
+  that is not the cause. The honest question for that class is whether a routing path reaches the
+  skill.
+- **Keep precision in the bar.** It was the half that held. A recall-only bar would have failed the
+  working half and missed that the discriminating half works.
+
+**The two skills already on `main` are not exempted by this ruling.** `/report` and `/adr` are both
+model-invoked, so the user-only exemption does not reach them, and the ruling states no grandfather
+clause. Their trigger coverage is therefore owed once #4649's mechanics exist. Whether that is a
+retro-measurement pass or an explicit grandfather is **not settled here** — it is carried as an open
+item on the build ticket rather than invented at this desk.
+
+**The cutover pointer is still a live hazard.** `CLAUDE.md`'s intake instruction routes by a
+path-pinned link that names v1's `report` skill, and the `/adr` instruction names no path at all
+while two skills answer to the name. Under this ruling that is no longer a §8 check, but it is still
+the mechanism the baseline arm proved is what actually fires a skill — so whatever retires v1's
+descriptions at cutover ([#4670](https://github.com/kamp-us/phoenix/issues/4670)) has to re-point
+those instructions, or a fabrika skill stays unreachable however its eval set scores.
+
+**Adjacent, deliberately not folded.** [#4482](https://github.com/kamp-us/phoenix/issues/4482) is the
+class of check that runs clean while structurally blind to what it is for, and it states that its
+instances stay separately owned. [#4701](https://github.com/kamp-us/phoenix/issues/4701) is a second
+§8-adjacent gate defect on the same doc. Neither is merged into this.


### PR DESCRIPTION
Fixes #4750

Records the ruling on #4750 as ADR `0249`. One added file, no other changes:

- `.decisions/0249-skill-trigger-coverage-lives-in-the-eval-set.md`

## The ruling this records

Per the newest comment on the issue (2026-08-10, founder-delegated judgment under the standing trust ruling of 2026-08-09, founder live with veto open):

- **The fabrika §8 ship gate keeps its three parts.** No fourth part. `claude-plugins/fabrika/docs/skill-conventions.md` is **not** edited by this PR, so §8's own prohibition on restating eval mechanics stays intact.
- **Trigger coverage is a property of a skill's eval set**, under the mechanics epic #4649 owns. Since §8 part 3 already requires a green eval set, this adds a property to the eval set rather than a gate to the doc — one home for the number.
- **User-only skills are exempt**, stated: with `disable-model-invocation` there is no description in model context, so there is nothing to trigger. Precedent set live by the `front-door` session (#4952), whose gate accepted the deviation.
- **The convention gets written against the eval surface**, not into §8 — a downstream build ticket, filed and linked in the progress comment.

## What is superseded, and why the ADR says so out loud

An earlier ruling on the same issue (2026-08-02) split the gate and sent a routing-path check into `skill-conventions.md` beside the sizing band. The newest comment reverses that: nothing lands in §8. The ADR records the reversal explicitly so a reader who scrolls the issue top-down does not act on the 2026-08-02 answer.

The *evidence* behind that earlier split is carried forward, not dropped — the five optimizer iterations (recall 0–11%, precision 100% throughout, no should-fire query ever reaching 2/3) and the baseline arm that behaved correctly with no skill at all by reading `CLAUDE.md`. That is what stops someone re-litigating a naive recall floor in a month, so the ADR keeps it as the three constraints #4649's mechanics inherit.

## Acceptance criteria

- [x] The ruling is recorded: §8 gains no triggering gate.
- [x] The single home for the number is named — the eval set / #4649's mechanics — and the user-only exemption is stated. No floors are invented here; the ruling named none, and the ADR does not fabricate them.
- [x] The two skills already on `main` are addressed: both are model-invoked, so the exemption does not reach them, and the ruling states no grandfather clause. The ADR records that their trigger coverage is owed once the mechanics exist and that retro-measure-vs-grandfather is **open**, carried on the build ticket rather than decided at this desk. **This departs from the criterion as written — disclosed as class 1 under `## Deviations` below.**
- [x] Written where a stateless authoring session reads it — an ADR in `.decisions/`.
- [x] No implementation lands here. Build ticket filed against the eval surface (linked in the progress comment on the issue).

## Deviations

Section added in repair round 1, answering the `deviation-disclosure` FAIL (review comment 5234901884). The class-1 entry below belongs to the **initial build**, not to this round; this round touched no file — PR body only, ADR text and number unchanged.

- **Class 1 — scope narrowing.** **Said:** #4750's AC3 asks that the two skills already on `main` (`/report` and `/adr`) be either **retro-measured before the next skill ships** or **explicitly grandfathered** — one of two named outcomes. **Did:** the ADR settles only the half the governing ruling settles — both skills are model-invoked, so the `disable-model-invocation` exemption does not reach them; the ruling states no grandfather clause; their trigger coverage is therefore **owed** once #4649's mechanics exist — and then records retro-measure-vs-grandfather as an **open** question rather than picking either named outcome. **Why:** the governing 2026-08-10 ruling does not decide the timing or the mechanism. Answering it at the coder's desk would manufacture founder doctrine inside an ADR, and a stateless later reader obeys an ADR as ruled — a worse artifact than a recorded open item. The residue is also genuinely downstream of eval mechanics that do not exist yet, so there is nothing to retro-measure against today. **Disposition:** follow-up #5239 (open, `status:needs-triage`) carries the question against the eval surface; a one-line founder amendment on #4750 can settle it without editing this ADR.
- **Class 2 — governing-ADR departure.** None. Step 4a's contradiction sweep found no accepted ADR ruling on any of the four questions, and this ADR neither narrows nor widens one; it is the first on this subject.
- **Class 3 — known defect left unfixed.** None. No adjacent or sibling defect was seen and skipped.
- **Class 4 — declined guidance.** None. No reviewer suggestion, reviewer-appended acceptance criterion, or triage instruction was declined; the only review finding to date is the one this round addresses.
- **Class 5 — guard or gate bypassed.** None. No `--no-verify` push, no skipped or disabled hook, no suppressed lint or type error, no widened allowlist. `pnpm lint:worktree` was a clean skip because the diff changes no biome-handled file — a no-op by scope, not a bypass.
- **Class 6 — pre-existing test or fixture changed.** None. The diff is one **added** file, +122/−0; no existing assertion was modified, weakened, or deleted.
- **Class 7 — out-of-scope change.** None. Exactly one file changed, `.decisions/0249-skill-trigger-coverage-lives-in-the-eval-set.md`, which is precisely what #4750 asks for. Nothing under `claude-plugins/**`, no CODEOWNERS or control-plane-pattern change.

## Notes for the gate

- Docs-only diff. `pnpm lint:worktree` is a clean skip (no biome-handled files changed).
- ADR number re-checked against `origin/main` (holds through `0247`) and every open PR (`0248` in #5235, `0237` in #4703, `0235` in #4614) immediately before commit.
- Fences respected: no edit under `claude-plugins/fabrika/skills/{wayfinding,prototyping,graduate,handoff}/`, none under `plan-epic/**`, no CODEOWNERS or control-plane-pattern change.
- **§CP by content (ADR 0164 / 0135).** `.decisions/**` carries no CODEOWNERS row, but `pipeline-cli guard-content-probe classify` returns `guard-touching [guard-vocabulary-match]` on the ADR body, so this PR is in the blocking set by content: it needs a `@kamp-us/control-plane` approval at the then-current head before `ship-it` enqueues it.
- **Closing keywords.** Exactly one plain-prose closing keyword in this body: `Fixes #4750` on line 1. No other `fix`/`close`/`resolve` variant precedes an issue reference — in particular no closing keyword is attached to #5239 anywhere in this body, so that follow-up stays open to carry the class-1 residue above.
