### PR TITLE
docs(fabrika): delete the dead line band from the sizing convention (#4701)

### DIFF
--- a/claude-plugins/fabrika/docs/authoring-brief-contract.md
+++ b/claude-plugins/fabrika/docs/authoring-brief-contract.md
@@ -127,6 +127,10 @@ Stated in the brief itself, so the session reads its own deliverable rather than
 - **Linked back to the brief issue** — `Fixes #<brief>` in the PR body, so the brief closes on merge
   and the authored artifact is traceable to the document it was authored from.
 - **No skill enters fabrika by any other path** ([#4637-C](https://github.com/kamp-us/phoenix/issues/4637)).
+- **No line target, and no sizing acceptance criterion.** Sizing is `skill-conventions.md` §2's
+  structural split — `SKILL.md` routes, `contract.md` carries the depth — which the gate judges case
+  by case; a number in a brief would be a second source of truth for a rule that deliberately has
+  none ([#4701](https://github.com/kamp-us/phoenix/issues/4701#issuecomment-5234580426)).
 
 **Where the session's job ends.** The PR carries the skill and the *specification* of the verbs it
 needs. Implementing those verbs is downstream `write-code` work against that spec — "the crew

--- a/claude-plugins/fabrika/docs/skill-conventions.md
+++ b/claude-plugins/fabrika/docs/skill-conventions.md
@@ -35,18 +35,24 @@ scripts rather than typed, tested verbs.
 
 ## 2. Sizing — the tiny wrapper
 
-**7–140 lines, median ~75.** A fabrika `SKILL.md` that runs past the band is not "thorough", it is
-un-split: the overflow is deterministic content that should have become a verb (§1) or reference
-that should have moved behind a pointer (§5).
+**`SKILL.md` is a routing and orientation surface; depth lives in `contract.md`.** The skill says
+what the thing is, when to fire it, and where each step's detail lives — the detail itself sits
+behind the pointer. **A `SKILL.md` that inlines what its contract owns is the defect**, and that is
+the same un-split failure §1 names: the overflow is deterministic content that should have become a
+verb, or reference that should have moved behind a pointer (§5).
 
-The band is not an aesthetic preference. It is the measured shape of the SOTA reference's 41
-skills, against which v1's own skills trend **300–600** lines (its `wayfinder` is 579). That gap is
-the discipline v1 lacked, stated as a number so it can be checked instead of felt.
+**There is no line count.** Concision is judged case by case against that split — never "how long is
+it", always "does this paragraph belong here or in the contract". A skill that has honoured the
+split is short as a consequence, not as a target, and shortness reached by deleting judgement is not
+conformance.
 
 Finer division is not free, and §3 is the ledger for what it costs.
 
-> Source: [#4644](https://github.com/kamp-us/phoenix/issues/4644) survey finding (measured across
-> the reference at `2ab9580`), adopt-list item 3.
+> Source: founder-delegated ruling on
+> [#4701](https://github.com/kamp-us/phoenix/issues/4701#issuecomment-5234580426), jointly with
+> [#5219](https://github.com/kamp-us/phoenix/issues/5219), deleting the prior 7–140 line band drawn
+> from the [#4644](https://github.com/kamp-us/phoenix/issues/4644) survey: it was unenforceable by
+> the ruled gate, which judges qualitatively, and violated by most of the landed corpus.
 
 ## 3. Invocation-axis economics
 

--- a/claude-plugins/fabrika/skills/review/rubrics/skill.md
+++ b/claude-plugins/fabrika/skills/review/rubrics/skill.md
@@ -29,8 +29,10 @@ is a finding even when each file reads well alone.
 ## 4 — fabrika conventions (skills under `claude-plugins/fabrika/`)
 
 Hold the skill to `claude-plugins/fabrika/docs/skill-conventions.md` — the two-layer split (a
-deterministic step in prose belongs in a verb), the 7–140 line band met by omission rather than
-deleted judgement, single-home facts, closed-vocabulary coordination, declared ingestion surface
+deterministic step in prose belongs in a verb), sizing as the routing/depth split rather than a
+line count — a `SKILL.md` that inlines what its `contract.md` owns is over-long however few lines it
+is, and shortness reached by deleting judgement is not conformance — single-home facts,
+closed-vocabulary coordination, declared ingestion surface
 and capability set — and its contract to `cli-interface-convention.md` Part 2's completeness
 test. A restated sibling behavior (rather than an imported module or a cited section) is drift
 waiting to happen; name it.


### PR DESCRIPTION
Fixes #4701

Implements the founder-delegated ruling on #4701 (comment 5234580426, 2026-08-10), which deletes the numeric line band from fabrika's sizing convention and replaces it with the structural principle the ruled gate can actually check.

## Why now

The band was doubly dead: **unenforceable by the ruled gate** (the upstream `skill-reviewer` judges qualitatively and states no line bound — this ticket's finding) and **violated by most of the landed corpus** (#5219's finding, 9 of 12 landed skills over the band). It was also actively producing contradictory verdicts: PR #5216 merged at 276 lines because its reviewer judged against the replacement principle, and PR #5233 was FAIL'd twenty minutes later at 285 lines because its reviewer quoted `skill-conventions.md:38`. Nine lines apart, opposite outcomes, decided by which source each reviewer read. This edit is what makes those two agree.

## The change

**`claude-plugins/fabrika/docs/skill-conventions.md` §2** — the `7–140 lines, median ~75` band and its `#4644`-survey justification are deleted. §2 now states the split: `SKILL.md` is a routing and orientation surface, depth lives in `contract.md`, and **a `SKILL.md` that inlines what its contract owns is the defect** — judged case by case, with no number. The one guard kept from the old text: shortness reached by deleting judgement is not conformance. The source blockquote now cites the ruling and records what was deleted and why, so the band's removal is traceable rather than a silent disappearance.

**`claude-plugins/fabrika/docs/authoring-brief-contract.md` field 6** — one bullet: a brief states no line target and no sizing acceptance criterion, because a number in a brief would be a second source of truth for a rule that deliberately has none. This is also the answer to the issue's last acceptance criterion (the 18 briefs carrying no sizing AC need none).

## One edit beyond the ruling's stated two files — flagged for your call

The ruling names its implementation as "one doc edit to §2 + a line in the authoring-brief contract's field 6". A grep found a **third** live citation of the deleted number: `claude-plugins/fabrika/skills/review/rubrics/skill.md:32` told fabrika's own skill reviewer to hold a skill to *"the 7–140 line band"*. Leaving it would keep a reviewer-facing surface pointing at a rule that no longer exists — the exact split-source failure this ruling exists to end. I rewrote that one clause to the routing/depth split. It adds no mechanism and no number; revert it if you read the ruling's file list as exhaustive.

No verb, no lint rule, no mechanical check was added — deliberately. The whole point of the ruling is that no number should be mechanically enforced.

## Not closed here

#5219 is consolidated into #4701 as the ruling home, and **stays open as the evidence record** — the ruling does not direct closing it, so nothing in this body closes it. It is referenced, not closed.

## Scope

- §CP status by live `.github/CODEOWNERS`: **not control-plane.** No row matches `claude-plugins/fabrika/**`; the only `claude-plugins/` rows are under `kampus-pipeline/`. Consistent with the founder veto on #5036. Nothing under `claude-plugins/kampus-pipeline/skills/` is touched.
- Fenced trees untouched: `wayfinding`, `prototyping`, `graduate`, `handoff`, `plan-epic`.
- Three files, docs only, no code and no config.

## Closing-keyword audit

Case-insensitive `(fix|close|resolve)[a-z]* +#[0-9]+` over this body — **one match**, the `Fixes #4701` on line 1, in plain prose and intended. Every other issue reference (#5219, #5216, #5233, #5036, #4644) is a bare `#N` with no closing keyword before it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
