### PR TITLE
docs(decisions): 0251 — fabrika pins shared wire formats, and owns their tests (#4892)

### DIFF
--- a/.decisions/0251-shared-formats-are-pinned-not-reimplemented.md
+++ b/.decisions/0251-shared-formats-are-pinned-not-reimplemented.md
@@ -119,14 +119,19 @@ module plus one row plus its narrative section — rather than half-built inside
 shape currently written out in `claude-plugins/fabrika/skills/triage/contract.md` moves into the
 module on that slice or a second one; it stays where it is until there is a module to hold it.
 
-**Remedy (c) is deferred, and [#4712](https://github.com/kamp-us/phoenix/issues/4712) is its
-decider.** #4892 offered a third remedy: make the envelope independent of any splicer's anchor set.
-This ADR deliberately does not take it. It changes the *failure mode* — a drift now reds a fixture
-test instead of breaking the seam quietly — and that is the property worth having. Whether the anchor
-relationship dissolves entirely depends on where fabrika's own `plan-epic` writes its plan, which is
-#4712's decision (live as Q5 on [#4890](https://github.com/kamp-us/phoenix/issues/4890), riding map
-[#4891](https://github.com/kamp-us/phoenix/issues/4891)). Taking (c) here would decide #4712's
-question from the wrong seat.
+**Remedy (c) is moot — [#4712](https://github.com/kamp-us/phoenix/issues/4712) already dissolved the
+coupling.** #4892 offered a third remedy: make the `--epic` envelope independent of any splicer's
+anchor set. There is nothing left to take. #4712 closed by shipping
+`claude-plugins/fabrika/skills/plan-epic/contract.md`, which rules that *the plan region is located
+by the enrichment marker, never by position*, and states the consequence outright — with the marker
+doing the detecting, appending the plan below the brief envelope breaks no detector, so **#4892's
+remedy (c) is thereby moot**. The contract left the write-up to this ADR rather than pre-empting it,
+so here it is, verified at the owner module rather than taken on the contract's word: detection is
+`MARKER_RE` in `packages/fabrika-cli/src/triage/enrich.ts`, a whole-line-anchored multiline pattern
+matched at its **first** occurrence, so the read asks nothing about where anything sits and no
+splicer anchor set can reach the answer. What remains between fabrika and `epic-splice` is the byte
+agreement this ADR pins with a fixture — a conformance obligation, not an anchor dependency — and it
+is the fixture, not a position argument, that turns a future drift into a red test.
 
 **[#4879](https://github.com/kamp-us/phoenix/issues/4879) is untouched.** It is a live destructive
 defect *in* v1's splicer, re-homed to `axis:pipeline-hardening` under the 2026-08-07 ruling. This ADR

--- a/.decisions/0251-shared-formats-are-pinned-not-reimplemented.md
+++ b/.decisions/0251-shared-formats-are-pinned-not-reimplemented.md
@@ -1,0 +1,173 @@
+---
+id: 0251
+title: fabrika pins a shared wire format rather than deriving it from v1, and owns the test that proves it
+status: accepted
+date: 2026-08-09
+tags: [fabrika, pipeline, contracts, wire]
+---
+
+# 0251 — fabrika pins a shared wire format rather than deriving it from v1, and owns the test that proves it
+
+**What this decides:** ADR [0238](0238-fabrika-reimplements-v1-never-calls-it.md)'s clean cut is
+about **calls**. A byte-level format two programs meet through on a GitHub artifact is not a call,
+and neither side can re-implement it — by definition both must agree on the same bytes. So the rule
+is **re-implement calls, pin formats**. The `triage enrich --epic` envelope is a wire format owned by
+fabrika's `wire` group, specified with a golden fixture; v1's `epic-splice` conforms by pinning that
+same fixture in a test of its own, never by an import. Test ownership follows format ownership: a
+test that asserts a fabrika property lives in fabrika's package.
+
+## Context
+
+[#4892](https://github.com/kamp-us/phoenix/issues/4892) reported, and re-verified at source, that
+fabrika's `--epic` envelope is coupled to v1 in two ways that "calls `pipeline-cli` nowhere" does not
+name.
+
+**The behavioural pin.** `claude-plugins/fabrika/skills/triage/contract.md` argued the envelope's
+survival from v1's implementation, citing `epic-splice.ts` line numbers at four sites. The shape of
+the argument was: `epic-splice` cuts only on `## Dependencies` and `## Plan (plan-epic)`, therefore
+fabrika's headings are bytes it can never touch. That is true today and true by accident. Grow v1's
+anchor set and fabrika's guarantee becomes false with nothing in fabrika to notice.
+
+**The test pin.** The block *the fabrika `--epic` envelope survives the splice* lives in
+`packages/pipeline-cli/src/tools/epic-splice/epic-splice.unit.test.ts`, and it carries more than
+assertions: fabrika's canonical envelope fixture and a re-implementation of fabrika's own detector
+sit there too, under a docblock claiming the fixture is the envelope *byte for byte*. Under the
+deletion test the repo uses as its yardstick, deleting v1 costs fabrika a guard fabrika never owned.
+
+**The copy has already drifted, which settles the question empirically.** The founder ruling on
+[#4866](https://github.com/kamp-us/phoenix/issues/4866) replaced the envelope's shape-based detector
+with a marker line, and `composeBody` in `packages/fabrika-cli/src/triage/enrich.ts` now writes
+`<!-- fabrika:enriched issue=<N> mode=<mode> -->` immediately above the preserved block. The v1
+fixture that claims to be the envelope byte for byte carries no marker line at all. Nothing red. The
+"byte for byte" claim in a docblock is exactly the sort of promise a comment cannot keep.
+
+**One un-sanctioned pin, not a class.** The same sweep found three citation sets from fabrika into
+`packages/pipeline-cli/`. `split-match.ts` is a scar read — a v1 defect fabrika designs out — and
+needs nothing. The `pitch-guard` set is a **deliberate** deferral to a CI-live gate, which ADR 0238
+already sanctions: *"Where a question is already decided by a gate, fabrika expects the answer and
+does not recompute it."* Only `epic-splice` is drift. A rule written here without saying so would
+read as banning the sanctioned deferral too.
+
+**What 0238 covers and what it does not.** Its binding constraint *"a spec clause that defers to one
+has derived nothing"* arguably already reaches the behavioural pin. It says nothing about **test
+ownership**, and nothing about the case where two programs must agree on bytes rather than one
+calling the other. Those two gaps are what this ADR fills.
+
+Ruled 2026-08-09 under the standing founder trust ruling and recorded on
+[#4892](https://github.com/kamp-us/phoenix/issues/4892#issuecomment-5234594233).
+
+## Decision
+
+**A byte-level format fabrika shares with any other program is a wire format fabrika owns, and every
+other side conforms to it by pinning a golden fixture in a test.**
+
+The `wire` group's charter line already says this — *own the byte-level formats two skills meet
+through on a GitHub artifact* — so the `--epic` envelope belongs to `wire` the same way the
+acceptance-criteria block and the verdict marker do, on the terms ADR
+[0241](0241-wire-formats-owned-by-schema-modules.md) sets: one owner schema module, one registry row,
+`emit` / `read` / `check`, a total read. What this adds to 0241 is the **fixture**: the envelope's
+canonical bytes are committed as a golden fixture beside the module and read verbatim (ADR
+[0180](0180-capture-real-runtime-artifact-before-coding.md)'s `readGoldenFixture`), so both sides of the seam assert
+against one artifact instead of two hand-copied ones.
+
+**The dependency direction flips.** fabrika stops arguing the envelope's survival from v1's source.
+v1's `epic-splice` test reads fabrika's fixture and asserts that splicing preserves it. That is a
+test-time file read, not an import and not a call, so it neither re-arms 0238 nor blocks v1's
+retirement: a v1 that goes away takes its own conformance test with it and leaves fabrika whole.
+When either side reworders the bytes, a fixture test reds on the side that reworded, instead of the
+seam breaking silently in production.
+
+**Test ownership follows format ownership.** A test asserting a *fabrika* property belongs in
+`packages/fabrika-cli/`. A test asserting *v1's splicer preserves what it is handed* belongs in
+`packages/pipeline-cli/` and is v1's own conformance obligation. The block at
+`epic-splice.unit.test.ts` is both of those things fused, so it splits along that line: the fixture
+and the detector go to fabrika, the preservation assertions stay with the splicer and read the
+fabrika fixture.
+
+**The gate-deferral carve-out is untouched and is not what this bans.** Where a question is already
+decided by a CI gate — `pitch-guard`, `homing-guard`, `cp-classify` — fabrika expects that gate's
+answer, designs its artifacts to satisfy it, and computes no second verdict (ADR 0238). Citing such a
+gate's source to explain *why* an artifact is shaped the way it is stays correct. The difference is
+authority: a gate is the authority on its own question, whereas `epic-splice` was never the authority
+on fabrika's envelope — fabrika is.
+
+**Binding constraints.**
+
+- A byte-level format fabrika shares with another program is a wire format: owner module, registry
+  row, and a committed golden fixture carrying the canonical bytes.
+- fabrika prose never grounds a property of its own format in another package's implementation or its
+  line numbers. It cites the owner module.
+- A test asserting a fabrika correctness property lives in `packages/fabrika-cli/`.
+- A non-fabrika side conforms by pinning fabrika's golden fixture in its own test — never by
+  importing fabrika code, and never the reverse.
+- Deferral to a CI gate's verdict remains sanctioned and is not a pin.
+
+**Banned.**
+
+- Citing another package's line numbers as the reason a fabrika format is safe.
+- A second hand-copied fixture standing in for the shared one.
+- An import edge in either direction between `fabrika-cli` and `pipeline-cli`.
+
+## Sequencing
+
+**The module, the fixture and the test split land as one follow-up slice, not here.** ADR 0241 stages
+a format with its first consumer; `triage enrich` has since landed
+([#4831](https://github.com/kamp-us/phoenix/issues/4831)), so that condition is already met and the
+slice is unblocked. This ADR is the ruling and the doc reconciliation; the code slice is filed as
+[#5249](https://github.com/kamp-us/phoenix/issues/5249) so the format lands as 0241 requires — one
+module plus one row plus its narrative section — rather than half-built inside a decision PR. The
+shape currently written out in `claude-plugins/fabrika/skills/triage/contract.md` moves into the
+module on that slice or a second one; it stays where it is until there is a module to hold it.
+
+**Remedy (c) is deferred, and [#4712](https://github.com/kamp-us/phoenix/issues/4712) is its
+decider.** #4892 offered a third remedy: make the envelope independent of any splicer's anchor set.
+This ADR deliberately does not take it. It changes the *failure mode* — a drift now reds a fixture
+test instead of breaking the seam quietly — and that is the property worth having. Whether the anchor
+relationship dissolves entirely depends on where fabrika's own `plan-epic` writes its plan, which is
+#4712's decision (live as Q5 on [#4890](https://github.com/kamp-us/phoenix/issues/4890), riding map
+[#4891](https://github.com/kamp-us/phoenix/issues/4891)). Taking (c) here would decide #4712's
+question from the wrong seat.
+
+**[#4879](https://github.com/kamp-us/phoenix/issues/4879) is untouched.** It is a live destructive
+defect *in* v1's splicer, re-homed to `axis:pipeline-hardening` under the 2026-08-07 ruling. This ADR
+is a dependency question *about* v1. The two are inverses and must not be merged.
+
+## Not decided here
+
+- **Whether v1 keeps its conformance test after v1-skill absorption.** Retiring
+  `packages/pipeline-cli/` is a separate and larger question ADR 0238's own Consequences already
+  fences off; the fixture pin is correct whether v1 lives or goes.
+- **Whether `epic-splice`'s anchor set may grow.** That is v1's call, and the fixture test is what
+  makes it a visible one rather than a silent break.
+
+## Consequences
+
+**Easier.** A format drift is a red test on the side that drifted, instead of a production seam that
+stopped holding. fabrika's contract stops citing another package's line numbers, so it stops rotting
+every time that file moves — the `:128-130` citation was already two lines stale when #4892 checked
+it. The deletion test passes in the direction it was failing: v1 can go without taking a fabrika
+guard with it.
+
+**Harder.** The envelope now costs a schema module, a fixture and a registry row rather than a
+paragraph, which is 0241's standing price and the reason formats land with their consumers. And the
+shape currently spelled out in `claude-plugins/fabrika/skills/triage/contract.md` has to move into
+that module when it lands — 0241 bans restating a wire format's shape in a skill body, and the
+contract is doing exactly that today. That migration is named in the follow-up slice; until the
+module exists there is nowhere to move it to, so the contract keeps the shape and stops resting its
+*argument* on v1.
+
+**Method lesson.** The couplings that survive a clean-cut rule are the ones the rule's noun does not
+cover. "Calls nowhere" was audited as calls and passed. Formats and tests are two more edge kinds,
+and both were carrying weight. A boundary rule should name the edge kinds it governs, not the one
+that prompted it.
+
+## Records
+
+Records the founder-delegated ruling on
+[#4892](https://github.com/kamp-us/phoenix/issues/4892#issuecomment-5234594233) and closes that
+issue. Extends ADR [0238](0238-fabrika-reimplements-v1-never-calls-it.md) — which stands unchanged on
+calls — and ADR [0241](0241-wire-formats-owned-by-schema-modules.md), whose ownership law this
+applies to a format whose second party is outside fabrika. The fabrika README's absent-list and
+`claude-plugins/fabrika/skills/triage/contract.md` are amended by the same change.
+
+No vocabulary impact: **wire format** is already coined in ADR 0241 and this decision applies it.

--- a/claude-plugins/fabrika/README.md
+++ b/claude-plugins/fabrika/README.md
@@ -54,3 +54,11 @@ directory was empty; it is harmless and can go with any later change.
 - **No dependency on v1.** fabrika calls `pipeline-cli` nowhere — not from a skill, not from a verb.
   Its own verbs live in `packages/fabrika-cli/`. v1 is a reference to read, never a runtime to call,
   because a fabrika that calls the old tree can never be the thing that replaces it.
+
+  The rule is **re-implement calls, pin formats** (ADR
+  [0251](../../.decisions/0251-shared-formats-are-pinned-not-reimplemented.md)). Where fabrika and
+  another program must agree on the same bytes on a GitHub artifact, neither side can re-implement
+  its way out: fabrika owns that wire format and commits its canonical bytes as a golden fixture, and
+  the other side conforms by pinning the fixture in a test of its own. Nothing about that is a call,
+  and it points the dependency at fabrika rather than away from it. Tests follow the same line — a
+  test asserting a fabrika property lives in `packages/fabrika-cli/`.

--- a/claude-plugins/fabrika/skills/triage/contract.md
+++ b/claude-plugins/fabrika/skills/triage/contract.md
@@ -11,7 +11,11 @@ that doc disagree, the doc wins and this spec is the bug.
 ([ADR 0238](../../../../.decisions/0238-fabrika-reimplements-v1-never-calls-it.md)). Every verb below
 is implemented from scratch here. v1's tools and its 18 `scripts/` were read for their semantics and
 their scars — each Grounding section names what the v1 counterpart gets wrong and what this spec does
-instead — but no clause defers to one, and none is invoked.
+instead — but no clause defers to one, and none is invoked. Two edges are sanctioned and are not
+calls: a CI gate stays the authority on its own question, so this spec expects `pitch-guard`'s answer
+rather than recomputing it; and where both programs must agree on the same bytes, fabrika owns the
+wire format and the other side conforms by pinning fabrika's golden fixture in a test (ADR
+[0251](../../../../.decisions/0251-shared-formats-are-pinned-not-reimplemented.md)).
 
 **Substrate.** These verbs are Effect CLI verbs on the `@effect/platform-node` seam already used by
 the sibling groups; GitHub access per
@@ -1012,10 +1016,13 @@ red), and this is the only verb in the group that writes a body. An earlier revi
 here at all, which left an epic **structurally unable to carry the section a CI guard fires on** at
 the very label `triage apply` writes.
 
-**Nothing this mode adds can reach the brief.** `plan-epic` splices around it: `epic-splice` anchors
-on the exact headings `## Dependencies` and `## Plan (plan-epic)` and preserves every other byte
-verbatim (`packages/pipeline-cli/src/tools/epic-splice/epic-splice.ts:48-51`), so neither heading
-above is an anchor it can cut on, and the wrapped original is untouched bytes either way. What
+**Nothing this mode adds can reach the brief.** A planner splices around the envelope: it anchors on
+the exact headings `## Dependencies` and `## Plan (plan-epic)` and preserves every other byte
+verbatim, so neither heading above is an anchor it can cut on, and the wrapped original is untouched
+bytes either way. That is an agreement rather than a coincidence — the envelope is a wire format
+fabrika owns, and a splicer conforms to it by pinning fabrika's golden fixture in a test of its own
+(ADR [0251](../../../../.decisions/0251-shared-formats-are-pinned-not-reimplemented.md)), so a
+reworded anchor set reds a test on the side that reworded. What
 `plan-epic` *does* change is where the wrap sits: `## Plan (plan-epic)` and `## Dependencies` both
 land **below** it, so this mode's envelope stops being terminal the moment the epic is planned. The
 re-enrich detector below tests position nowhere, in either mode, for exactly that reason; a re-enrich
@@ -1083,8 +1090,8 @@ mode's terminality-plus-`Original report (verbatim)` test, and `--epic`'s three 
 reasoning that produced them is not withdrawn: each was correct about its own mode, and the
 `--epic` rule's position-independence was itself the ruled fix to a real compounding bug
 ([#4850](https://github.com/kamp-us/phoenix/issues/4850)) — once `plan-epic` runs,
-`## Plan (plan-epic)` and `## Dependencies` sit *below* the wrap
-(`epic-splice.ts:128-130`; `plan-epic` Step 2 writes the plan "below the untouched brief"), so a
+`## Plan (plan-epic)` and `## Dependencies` sit *below* the wrap (`plan-epic` Step 2 writes the plan
+"below the untouched brief", and a first-time plan with no topology yet appends at end of body), so a
 terminality test stops matching on every planned epic. What the ruling settles is that **both** were
 mode-scoped and keyed on disjoint literals, so neither could recognise the other mode's envelope. A
 re-run in the other mode therefore fell through to "first enrichment ⇒ wrap" and nested the whole
@@ -1166,18 +1173,22 @@ cover it either (a paste that ends the body is terminal). The section named the 
 *"if it ever bites the answer is a marker the verb writes and a paste does not, never a weaker
 anchor"* — and this is that answer.
 
-The `--epic` anchors, which the legacy branch still uses as recognisers, were checked against the
-implementation rather than inherited: `epic-splice` cuts only on `## Dependencies` and
-`## Plan (plan-epic)` (`epic-splice.ts:48-51`), so `## Pitch` and `## Epic — awaiting plan` are bytes
-it can never touch, and they survive every plan and re-plan. The same holds of the marker: it is
-neither of those two headings, so `epic-splice` preserves it verbatim through every plan and re-plan.
+The `--epic` anchors, which the legacy branch still uses as recognisers, survive a plan because a
+splicer cuts only on `## Dependencies` and `## Plan (plan-epic)`: `## Pitch` and
+`## Epic — awaiting plan` are bytes it never touches, and so is the marker, which is neither of those
+two headings. That is the splicer's obligation to this format rather than a fact fabrika inherits —
+which side owes which is settled in ADR
+[0251](../../../../.decisions/0251-shared-formats-are-pinned-not-reimplemented.md).
 
-**That survival is pinned executably, not only argued.** `epic-splice`'s unit tests
-(`packages/pipeline-cli/src/tools/epic-splice/epic-splice.unit.test.ts`, the *fabrika `--epic`
-envelope survives the splice* block) run a real envelope through a first-time plan and a re-plan and
-assert that the `<details>` block stops being terminal, that the anchors still hold, that the wrapped
-original survives byte-for-byte, and that the summary line never doubles. The marker rule is pinned
-the same way on the verb's own side, in `packages/fabrika-cli/src/triage/enrich.unit.test.ts`, which
+**That survival is pinned executably, not only argued.** A splicer's unit tests run a real envelope
+through a first-time plan and a re-plan and assert that the `<details>` block stops being terminal,
+that the anchors still hold, that the wrapped original survives byte-for-byte, and that the summary
+line never doubles. Under ADR 0251 the envelope those tests run is fabrika's committed golden
+fixture, so a rewording here reds them; the block presently lives in
+`packages/pipeline-cli/src/tools/epic-splice/epic-splice.unit.test.ts` with a hand-copied envelope
+and is scheduled to split — fixture and detector to fabrika, preservation assertions to the splicer.
+The marker rule is pinned on the verb's own side, in
+`packages/fabrika-cli/src/triage/enrich.unit.test.ts`, which
 reproduces the **retired** detectors in-test as controls: the cross-mode re-run they miss is asserted
 to be recognised here, a pasted envelope bound to another issue is asserted to read as fresh, and a
 legacy body is asserted to be recognised, preserved and stamped. Change the rule and those tests go


### PR DESCRIPTION
fabrika's rule was "calls `pipeline-cli` nowhere". But the envelope fabrika writes on an epic and the splicer that plans that epic have to agree on the same bytes, and neither side can re-implement its way out of that. This records the founder-delegated ruling: fabrika owns those bytes as a wire format with a committed golden fixture, and the other side conforms by pinning that fixture in a test of its own. The rule, in one line, is re-implement calls, pin formats — and a test asserting a fabrika property lives in fabrika's package.

The evidence that this was already costing something: fabrika's envelope grew a `<!-- fabrika:enriched … -->` marker line under the #4866 ruling, and the copy of the envelope inside v1's test file — the one whose docblock says "byte for byte" — still has no marker. Nothing went red.

Fixes #4892

## What changed

- `.decisions/0251-shared-formats-are-pinned-not-reimplemented.md` — the ruling. Extends ADR 0238 (which stands unchanged on calls) and ADR 0241 (whose ownership law this applies to a format whose second party sits outside fabrika). Names the sanctioned gate-deferral carve-out — `pitch-guard`, `homing-guard`, `cp-classify` — explicitly, so the ruled class is not caught by the new rule.
- `claude-plugins/fabrika/README.md` — the absent-list's "no dependency on v1" bullet now says what the calls rule does not cover.
- `claude-plugins/fabrika/skills/triage/contract.md` — four sites stopped grounding the envelope's survival in `epic-splice.ts` line numbers (one of which was already two lines stale) and now cite the ruling instead. The observed behaviour is unchanged; what changed is which side owes it.

## Against the issue's acceptance criteria

- **Test ownership** — ruled in scope. A test asserting a fabrika correctness property lives in `packages/fabrika-cli/`; a test asserting v1's splicer preserves what it is handed stays with the splicer and reads fabrika's fixture.
- **The v1 test block** — recorded as splitting: fixture and detector to fabrika, preservation assertions to the splicer. Timing: `triage enrich` (#4831) has landed, so ADR 0241's staging condition is already met and the slice is unblocked. It is filed as #5249 rather than half-built inside a decision PR.
- **Remedy (c)** — taken as **moot**, with the reason recorded (repair round 1). #4712 closed by shipping `claude-plugins/fabrika/skills/plan-epic/contract.md`, which rules the plan region is located by the enrichment marker and never by position, states remedy (c) is thereby moot, and hands the write-up to this ADR. Verified at the owner module rather than on the contract's word: detection is `MARKER_RE` in `packages/fabrika-cli/src/triage/enrich.ts`, a whole-line-anchored multiline pattern matched at its first occurrence, so no splicer anchor set can reach the answer.
- **Docs** — both surfaces amended, above.
- **#4879** — untouched, and the ADR says why the two must not be merged.

## Deviations

- **Narrowed the delivered scope (class: narrowed fix-shape).** Said: the ticket's remedies (a)+(b) are "compatible, small, and hold regardless." Did: landed the recorded decision and the doc reconciliation, and filed the module + fixture + test split as #5249. Why: ADR 0241 requires a format to land as one owner module plus one registry row plus its narrative section, and `fabrika wire index` reds on a narrative section naming no registered format — so a half-built format inside a decision PR would red CI and violate 0241's own shape rule. Disposition: follow-up #5249 filed and named in the ADR, the PR body and the progress comment.
- **A judgement the ruling did not settle (class: decision made at my desk).** Said: the ruling covers ownership and conformance. Did: recorded remedy (c) as deferred rather than taken. Why: the ruling changes the failure mode (a drift now reds a fixture test) but does not dissolve the anchor relationship, and whether it dissolves depends on where fabrika's own `plan-epic` writes its plan. Disposition: deferred with #4712 named as decider, per the issue's own acceptance criterion; a **Not decided here** section in the ADR lists the two questions I left open and who settles them. *(Superseded in repair round 1 — see below. Left standing as the log of what round 0 shipped.)*
- **ADR number changed twice mid-run (class: mechanical).** Said: next free number was 0249. Did: renumbered to 0250 after rebasing onto `origin/main`, which had taken 0249 for `0249-skill-trigger-coverage-lives-in-the-eval-set.md`; then renumbered again to **0251**, because open PR #5250 — filed first and already at its gate — had taken 0250 while this lane was in flight. Why: two number collisions one step apart; the mid-flight recheck caught the first race but landed on a slot another open PR already held. Disposition: 0251 re-verified free immediately before the commit against `origin/main` (tops out at 0249) and against every open PR's `.decisions/` diff (only #5250/0250, #4703/0237, #4614/0235). Every in-repo reference was rewritten, `decisions-index validate` passes, and the already-filed #5249 carries a further dated amendment comment pointing at 0251.
- **Left `claude-plugins/fabrika/docs/wire-formats.md` alone (class: declined an adjacent change).** Said: a new format gets a narrative section there. Did: no edit. Why: `fabrika wire index` reds on a section naming no registered format, and the registry row lands with #5249. That page's own staging-rule section already says an unwritten format is not a missing one. Disposition: rides #5249.
- **The shape still lives in the contract (class: known residue).** ADR 0241 bans restating a wire format's shape in a skill body, and `triage/contract.md` spells the envelope out today. Why: there is no owner module to move it into until #5249 lands. Disposition: named in the ADR's Consequences and in #5249's scope.
- **(repair round 1) Reversed round 0's remedy-(c) deferral (class: departure from a governing decision, now discharged).** Said (round 0): remedy (c) is deferred and #4712 is its decider, "live as Q5 on #4890, riding map #4891." Did: took remedy (c) as **moot** and recorded why. Why: `claude-plugins/fabrika/skills/plan-epic/contract.md` — in this PR's own tree, landed on `main` in `b5465b6a` via #5178 — already rules remedy (c) moot and explicitly leaves the write-up to this ADR, so round 0 had two shipped records contradicting each other and the answer written nowhere. #4712 is closed (2026-08-09T21:50:05Z), and #4890/#4891/#4896 are all closed too, so the "live" pointer named three closed issues. Disposition: the ADR's `## Sequencing` now states the mootness, grounded at fabrika's own owner module (`enrich.ts`'s whole-line-anchored `MARKER_RE`, matched at first occurrence) rather than on the contract's word; the round-0 deviation entry above is marked superseded rather than rewritten.
- **(repair round 1) The head moved for a second reason (class: mechanical).** The lane's local branch ref was stale — it still pointed at the pre-renumber `0250` commit while the remote head was the `0251` commit — so this round reset the local ref to the pushed head `82f3707a` before editing, then rebased onto latest `origin/main` per the repair contract. Why: rebasing the stale ref would have silently un-done the renumber. Disposition: the pushed head therefore differs from `82f3707a` by both the fix commit and a fresher base; the ADR file, its frontmatter `id`, its H1 and every in-repo reference still read **0251**, and `origin/main` now holds `0250` (from #5250), so the slot is still uncontested.
