### PR TITLE
docs(decisions): 0256 — the kill audit keys on the not-planned close, not the label (#4921)

### DIFF
--- a/.decisions/0256-kill-audit-keys-on-the-not-planned-close.md
+++ b/.decisions/0256-kill-audit-keys-on-the-not-planned-close.md
@@ -1,0 +1,123 @@
+---
+id: 0256
+title: the kill audit keys on the not-planned close; `closed-by-triage` is provenance only
+status: accepted
+date: 2026-08-09
+tags: [triage, fabrika, audit, pipeline]
+---
+
+# 0256 — the kill audit keys on the not-planned close; `closed-by-triage` is provenance only
+
+**What this decides:** the maintainer's kill audit finds kills by the close itself — `state_reason=not_planned` — not by the `closed-by-triage` label. The label stays, but it now only says *who* executed the kill; it never says *whether* a kill happened.
+
+## Context
+
+The kill audit is the compensating control for the whole kill path: one query the maintainer runs so
+an over-close is caught and reopened cheaply. It queries the label
+(`claude-plugins/kampus-pipeline/skills/triage/scripts/audit-kills.sh:12`), and the protocol states
+the guarantee plainly — *"Apply `closed-by-triage` so every kill shows up in one query"*
+(`claude-plugins/kampus-pipeline/skills/triage/close-not-planned.md:28`) and *"The maintainer audits
+all kills with one query"* (`:46`).
+
+Both sentences rest on one premise: **every kill is a triage kill.** That premise is false, and it
+came apart the first time a non-triage actor performed a legitimate kill. In a single decision wave
+(2026-08-08), #4722 and #4715 were killed through triage and carry the label; #4720 was killed
+first-hand in a founder session, carries no label, and is invisible to the audit. Same wave, same
+authority, different visibility — purely by who ran the close.
+
+Stamping the label on #4720 would restore coverage by **falsifying provenance**: the label names an
+actor, and nothing downstream can tell a truthful marker from a courtesy one. An incomplete audit is
+recoverable; a wrong one is not. So the label's two jobs have to be separated rather than
+re-conflated: its *function* is coverage, its *name* asserts an actor.
+
+Three measurements decide the shape (#4921's triage, 2026-08-08, and #4291):
+
+- **The label has exactly one reader.** A repo-wide census returns nine sites; the only thing that
+  reads the label for anything is the audit query itself. No CI workflow, no `pipeline-cli` guard, no
+  projection consumes it. Changing the audit's key therefore breaks nothing downstream.
+- **The gap is ~451 issues, not one.** 106 closed issues carry `closed-by-triage`; the search index
+  reports ~547 closed as not planned. #4291 read a bounded week of that population: 70 unlabelled
+  not-planned closes, and for the 35 with no agent footer it read the last comment before each close
+  — all 35 carried a specific, issue-tailored reason, most naming an explicit human authorization.
+  Its conclusion is the one this ADR builds on: **the audit surface is blind while the audit
+  substance is intact.**
+- **The substance is the reason comment, not the label.** Every kill path — triage's and a founder
+  session's — leaves a reason comment before the close. That is what a maintainer actually reads when
+  judging whether a close was wrong.
+
+This is the same split ADR [0244](0244-live-stage-key-vs-recorded-provenance.md) already made in the
+eval corpus: a value used as a **live key** and the same value recorded as **provenance** are two
+things, and forcing one to serve both corrupts the recorded half. This ADR applies that split to the
+kill audit.
+
+## Decision
+
+**The kill audit's key is `state_reason=not_planned`, and `closed-by-triage` is demoted to a
+provenance stamp that records who executed a kill — never whether one happened.**
+
+**What the audit is an audit of.** Every not-planned close in the repository, whoever executed it —
+because the risk it guards against (an issue wrongly declared won't-be-done) does not depend on who
+ran the close.
+
+**The precision cost is paid with a window and a column, never an actor filter.** Re-keying widens
+the audit roughly five-fold (106 → ~547), and those rows are not noise: a sample of the most recently
+updated reads as genuine kills and supersessions performed outside the triage kill path. That is the
+population actually at risk, so it belongs in the audit. What makes it readable is **scope in time**
+— the audit reads every page of a bounded recent window (it is a periodic sweep, not a census) — and
+**provenance as a column**: each row shows whether it carries `closed-by-triage`, so a maintainer can
+still see triage's kills as a distinct set inside the honest total. Filtering by actor to keep the
+list short buys a short list that is wrong; a window buys a short list that is true.
+
+**`closed-by-triage` survives, as provenance only.** It is written by triage's own kill path and by
+nothing else. It is never applied to a close triage did not execute, never applied on another actor's
+behalf, and never retro-applied — #4720 stays bare, and the recorded reasoning for declining that
+stamp stands. No second marker is minted for founder or other actor classes; a new label per actor
+class only relocates the gap to the next actor nobody minted one for.
+
+**fabrika's `triage kill` keeps refusing when the label is absent (exit `7`), with a restated
+reason.** The behaviour is unchanged, but its rationale is no longer *"refusing a kill that would be
+invisible to the audit"* — under this key the kill is visible either way. It refuses because the kill
+would be **unattributable**: a triage kill that cannot carry its stamp is indistinguishable from a
+founder-session close, which is the confusion this ADR exists to remove. The verb gains **no** actor
+flag and **no** courtesy stamp for a human actor: a founder-session close does not run this verb and
+must not, and it is auditable through the key plus its reason comment.
+
+**Binding constraints.**
+- The audit query keys on `state_reason == not_planned`, reads every page, and is bounded by a time window.
+- Every audit row carries its provenance (labelled = triage's kill path; unlabelled = another actor).
+- `closed-by-triage` is written only by triage's own kill path.
+- Every kill, by any actor, carries a reason comment before the close — that is the audit's substance.
+
+**Banned.**
+- Keying the audit on an actor label, or on any actor at all.
+- Applying `closed-by-triage` to a close triage did not execute, including a retro-backfill.
+- Minting a second `closed-by-<actor>` marker per actor class.
+
+## Consequences
+
+- `close-not-planned.md:28` and `:46` are amended in this PR: the label's line now says what the
+  label records, and the audit line's "all kills" becomes a true claim about the ruled key.
+- `claude-plugins/fabrika/skills/triage/contract.md` records the ruling next to the kill verb, so the
+  spec and the refusal's rationale stop asserting the superseded premise.
+- **The audit query is not re-keyed in this PR.** The re-key travels with the same query's pagination
+  repair (#4928 — it already reads one unpaginated page of 30 against 106 kills, and under this key
+  it must read every page or the widening makes the blindness worse), together with the two shipped
+  message strings that still say "invisible to the audit". Per ADR
+  [0248](0248-authoring-session-mints-the-implementation-ticket.md) that implementation unit is
+  minted from this session rather than left implicit: **#5280**, which names #4928 as the same edit
+  site so the two land together instead of racing over one line.
+- #4291's `tracker close-not-planned` envelope keeps applying the label — it is the triage kill path,
+  so the stamp is truthful — but its acceptance criteria must not name the label as the audit's key.
+- Harder: a maintainer skims a wider list. Cheaper: no new marker, no migration of the 106 already
+  labelled kills, and no union query.
+
+## Records
+
+- Closes #4921.
+- Related: #4291 (the enforcement gap), #4928 (the audit query's pagination blindness), #4720 /
+  #4722 / #4715 (the wave that exposed this), ADR
+  [0159](0159-never-auto-close-signal-is-the-report-footer.md) (who may be closed at all), ADR
+  [0092](0092-gates-fail-closed-on-zero-scope.md) (the fail-closed refusal the verb's exit `7` is).
+- **No vocabulary impact.** The key-vs-provenance distinction this rests on is already named by ADR
+  [0244](0244-live-stage-key-vs-recorded-provenance.md); this ADR applies it to a second surface and
+  coins nothing.

--- a/claude-plugins/fabrika/skills/triage/contract.md
+++ b/claude-plugins/fabrika/skills/triage/contract.md
@@ -1723,6 +1723,20 @@ comments are live, re-running duplicates them". An earlier revision covered only
 read-back asserts `state` is `closed` **and** `state_reason` is `not_planned`, because a plain
 `closed` reads as "done", not "killed".
 
+**`closed-by-triage` is provenance, and the refusal on its absence stands for a different reason
+(ADR [0256](https://github.com/kamp-us/phoenix/blob/main/.decisions/0256-kill-audit-keys-on-the-not-planned-close.md)).**
+The kill audit's key is the not-planned close itself, so the label no longer carries coverage — it
+records that **triage** was the actor. The exit-`7` refusal on the label's absence is therefore
+**unchanged in behaviour and changed in rationale**: the kill would not be *invisible* (the close is
+the key), it would be **unattributable** — a triage kill that cannot carry its stamp is
+indistinguishable from a founder-session close, which is the confusion the label exists to prevent.
+Two consequences bind this verb. It gains **no** actor flag and **no** courtesy stamp: a non-triage
+actor's kill does not run this verb and must not carry the label, and it stays auditable through the
+close plus its reason comment. And the two shipped strings above that still read *"invisible to the
+audit"* (the exit-`7` refusal and the exit-`8` label-write failure) are reworded when the v1 audit
+query is re-keyed and paginated ([#4928](https://github.com/kamp-us/phoenix/issues/4928)) — the codes
+and the write order do not move.
+
 **Scope** — one issue with its body and author login, the repository's label set, plus the surviving
 issue when `--duplicate-of` is given.
 
@@ -1763,9 +1777,12 @@ $ fabrika triage kill 4312 --confirm --json < reason.md
   and computed it nowhere. The #4619 ruling narrows *who counts as human-filed*, not the protection:
   a footerless filing from a non-operator is as protected as it ever was.
 - v1 `audit-kills.sh` — the compensating control for the whole kill path — reads one unpaginated
-  page, so it goes blind past 30 kills with no truncation signal. This spec does not re-mint that
-  verb; the audit belongs to a board surface, and the fail-closed write order above is what makes a
-  kill auditable at the moment it happens.
+  page, so it goes blind past 30 kills with no truncation signal, and it keys on the label, so it
+  cannot see a kill any other actor executed (ADR
+  [0256](https://github.com/kamp-us/phoenix/blob/main/.decisions/0256-kill-audit-keys-on-the-not-planned-close.md)
+  re-keys it onto the close). This spec does not re-mint that verb; the audit belongs to a board
+  surface, and the fail-closed write order above is what makes a kill auditable at the moment it
+  happens.
 
 ---
 

--- a/claude-plugins/kampus-pipeline/skills/triage/close-not-planned.md
+++ b/claude-plugins/kampus-pipeline/skills/triage/close-not-planned.md
@@ -25,8 +25,12 @@ Every kill is auditable and reversible. Always:
    #33, which already tracks this hang" or "The function this references was removed in #30;
    no longer applicable"). One sentence of real reasoning, so the maintainer reviewing kills
    can judge it.
-3. Apply `closed-by-triage` so every kill shows up in one query.
-4. Close as **not planned** (state `closed`, reason `not_planned`).
+3. Apply `closed-by-triage` to record that **triage** executed this kill. The label is provenance,
+   not coverage — it says *who*, never *whether* (ADR
+   [0256](https://github.com/kamp-us/phoenix/blob/main/.decisions/0256-kill-audit-keys-on-the-not-planned-close.md)).
+   Never apply it to a close triage did not execute.
+4. Close as **not planned** (state `closed`, reason `not_planned`). This close is what makes the kill
+   auditable — see the audit below.
 
 ```bash
 # step 1 only when closing as a duplicate of #M. Both scripts resolve the SAME §SP per-run scratch
@@ -43,9 +47,18 @@ The scripts live in [`scripts/`](scripts/) alongside the rest of this skill's ex
 extraction contract and the `set -uo pipefail`-without-`-e` rationale are in
 [`SKILL.md` § The extracted scripts](./SKILL.md#the-extracted-scripts).
 
-The maintainer audits all kills with one query, so over-closing is caught and reopened
-cheaply:
+The maintainer's kill audit is an audit of **every not-planned close, whoever executed it** — the
+close is the audit's key, and `closed-by-triage` reads as a provenance column on the rows triage
+killed (ADR
+[0256](https://github.com/kamp-us/phoenix/blob/main/.decisions/0256-kill-audit-keys-on-the-not-planned-close.md)).
+That is what lets over-closing be caught and reopened cheaply whoever ran the close:
 
 ```bash
 "${CLAUDE_PLUGIN_ROOT:-claude-plugins/kampus-pipeline}/skills/triage/scripts/audit-kills.sh"
 ```
+
+**The script itself is not re-keyed yet**, so read its output for what it currently is: triage's own
+labelled kills, first page only. The re-key onto `state_reason=not_planned` travels with the same
+query's pagination repair ([#4928](https://github.com/kamp-us/phoenix/issues/4928)) — until then the
+audit under-reports in both directions ([#5280](https://github.com/kamp-us/phoenix/issues/5280) is
+the re-key).


### PR DESCRIPTION
The kill audit asked "which issues did triage close?" and called the answer "every kill". It isn't: a founder-session close is a real kill the audit cannot see, and stamping `closed-by-triage` on it would buy coverage by lying about who killed it. This rules the audit's key onto the close itself (`state_reason=not_planned`) and demotes the label to a provenance stamp — it says *who*, never *whether*.

ADR 0256 records the ruling. Alongside it, the two v1 prose claims that asserted the false premise are amended, and fabrika's kill-verb contract records why its exit-`7` refusal still stands (the reason changes from "invisible" to "unattributable", the behaviour does not).

Fixes #4921

## What landed

- `.decisions/0256-kill-audit-keys-on-the-not-planned-close.md` — the ruling: the key, what the audit is an audit *of* (every not-planned close, whoever ran it), the measured ~5x precision cost and how it is paid (a time window + a provenance column, never an actor filter), the label's survival as provenance only, and the kill verb's unchanged refusal with a restated reason.
- `claude-plugins/kampus-pipeline/skills/triage/close-not-planned.md` — `:28` now says the label records that *triage* was the actor; the audit paragraph now states what the audit is an audit of, and flags honestly that the script is not re-keyed yet.
- `claude-plugins/fabrika/skills/triage/contract.md` — the ruling next to `triage kill`: the refusal's restated rationale, no actor flag, no courtesy stamp, and the grounding note on `audit-kills.sh` updated.

Follow-up #5280 carries the implementation (re-key + the two shipped message strings), and names #4928 as the same edit site so the two land together instead of racing over one line.

## Acceptance criteria

- [x] A recorded decision names the audit's key and states in one sentence what it is an audit of.
- [x] The measured precision cost (106 labelled vs ~547 not-planned) is addressed, not deferred — the widening is the correct population; readability comes from a window and a provenance column.
- [x] The decision states `closed-by-triage` survives as provenance only.
- [x] `close-not-planned.md:28` / `:46` are amended so "every" and "all" are true claims.
- [x] The decision states the kill verb keeps refusing on the label's absence (exit `7`, behaviour unchanged, reason restated) and what it does when a human is the actor (nothing — that close does not run the verb and must not carry the stamp).
- [x] The ruling lands in `claude-plugins/fabrika/skills/triage/contract.md`; #4291 is cited so its `tracker close-not-planned` envelope is not built against a superseded key.
- [x] No label retro-applied to #4720.
- [x] No absolute, home-rooted, machine-local or sibling-repo path in any artifact.

## Deviations

- **Class: scope narrowed.** Said: the ruling names the audit's key. Did: ruled the key, but did **not** re-key `claude-plugins/kampus-pipeline/skills/triage/scripts/audit-kills.sh` in this PR. Why: that line is also #4928's edit site (the unpaginated read), the triage note explicitly kept the two apart, and under the new key an unpaginated read is strictly worse — the two changes must land as one edit. Disposition: follow-up #5280 filed, naming #4928 as the same site; `close-not-planned.md` says out loud that the script is not re-keyed yet, so no doc claims a key the code does not use.
- **Class: left a sibling defect.** Said: state whether the kill verb keeps refusing. Did: ruled that it does, with a restated reason, but left the two shipped strings in `packages/fabrika-cli/src/triage/kill-verb.ts` (and their mirrors in the contract's error table) reading "invisible to the audit". Why: changing a shipped message desynchronises the contract table, the code and its unit test unless all three move together, which belongs with the re-key rather than in a decision PR. Disposition: folded into #5280; the contract paragraph names the two strings so a reader is not misled meanwhile.
- **Class: added beyond the ask.** Said: make `:28` / `:46` true or amend them. Did: amended both **and** added an explicit "the script is not re-keyed yet" caveat the AC did not request. Why: without it the amended prose would describe a key the shipped script does not use — trading one false sentence for another. Disposition: no action needed; the caveat is removed by #5280.

## Contradiction sweep

Run (`adr/scripts/sweep-shortlist.sh`): 8 lexically adjacent live-accepted ADRs shortlisted (0215, 0252, 0241, 0219, 0208, 0246, 0239, 0245). Each opened; none rules on what the kill audit's key is or on what `closed-by-triage` means, so nothing is superseded or amended-in-part. The ADR cites 0244 (the key-vs-provenance split it applies), 0248, 0159 and 0092.
