### PR TITLE
fix(fabrika): refuse a build check diff no surface validates, never green it

### DIFF
--- a/claude-plugins/fabrika/skills/build/contract.md
+++ b/claude-plugins/fabrika/skills/build/contract.md
@@ -4,6 +4,8 @@
 
 **Amended 2026-08-09** — the campaign-scope admission term ([ADR 0245](../../../../.decisions/0245-campaign-scope-fence-binds-both-seams.md), [#5013](https://github.com/kamp-us/phoenix/issues/5013)): a new [admission test](#admission-test--scope-admission-and-the-audience-axis) section under shared conventions — scope admission composed with the pre-existing `ready-for:` audience axis, two named axes rather than one widened term — two codes (`20`, `21`) in the shared exit matrix, and the consuming clauses in `build pick` and `build claim`.
 
+**Amended 2026-08-10** — the third file class in `build check` ([#5229](https://github.com/kamp-us/phoenix/issues/5229)): a changed file matching neither the code nor the markdown pattern is now named rather than dropped out of both filters, so a diff nothing validates refuses on a new code (`22`) instead of greening, and a green over a partly-unvalidatable diff carries the files it did not cover.
+
 The verbs land in `packages/fabrika-cli/` under the `build` subcommand group, registered in
 `packages/fabrika-cli/src/registry.ts` like the shipped `adr`, `report`, `triage` and `wire`
 groups. The [CLI interface convention](../../docs/cli-interface-convention.md) governs every verb;
@@ -247,6 +249,7 @@ range, exactly as `triage/codes.ts` itself states for `adr`.
 | `19` | refused: the requested push is unsafe (detached HEAD, or a non-fast-forward without `--force-with-lease`) |
 | `20` | proven: not admitted on the scope axis, out of focus — the issue's home is not the declared milestone and no standing-lane label exempts it |
 | `21` | proven: not admitted on the audience axis, audience not agent — the issue's `ready-for:` label is not `ready-for:agent`, or is absent |
+| `22` | proven: every changed file falls outside all three surfaces' validators — there is nothing to run, so the verdict is a refusal, never a green |
 | `127` | the verb never ran at all (unresolved binary — the shell's code, not this process's) |
 
 **`7` versus `11` is the split the whole group rests on** (the `wire` group's `ABSENT` vs
@@ -981,8 +984,12 @@ fabrika build check --surface code
 | `--surface` | enum: `code` \| `prose` \| `plan` | yes | — | the surface whose validators run; the skill names it, this verb anchors it |
 
 **Output** — machine. On green, one JSON object:
-`{"verdict": "green", "surface": "code", "tree": "<abs tree root>", "ran": ["pnpm typecheck", "pnpm lint:worktree"]}`.
+`{"verdict": "green", "surface": "code", "tree": "<abs tree root>", "ran": ["pnpm typecheck", "pnpm lint:worktree"], "unvalidated": []}`.
 Red and unknown produce no stdout (`18` / `11`), diagnostics on stderr verbatim from the runners.
+
+`unvalidated` is always present and lists the changed files **this verdict does not cover** — the
+class no surface validates (`.yml`, `.sh`, `.sql`, `.css`, …). A non-empty list beside a green is the
+honest reading of a mixed diff, and the same line is repeated on stderr.
 
 Per surface:
 
@@ -1001,6 +1008,14 @@ The surface anchor: the verb diffs the branch against its base and refuses a sur
 match the diff (`--surface prose` over changed `.ts` files is `10`) — the skill's judgment is
 taken, then checked against the tree, never silently accepted.
 
+**Three file classes, because two cannot express "unvalidatable".** The anchor sorts each changed
+file into code, markdown, or **neither** — the third class is named, not an absence. A diff that is
+*wholly* the third class (only `.github/workflows/*.yml`, only `*.sh`) refuses on `22` under **every**
+surface: no validator covers those files, so any verdict would be a green over an unread tree. The
+remedy is to split the diff or extend a validator, never to rename the surface — widening the code
+pattern to swallow `.yml` was considered and rejected, because it would claim `pnpm typecheck`
+validated a shell script (#5229).
+
 Preconditions: a linked worktree (`12`), the lane's branch checked out (`14`).
 
 **Exit status** (beyond the universal four)
@@ -1014,6 +1029,7 @@ Preconditions: a linked worktree (`12`), the lane's branch checked out (`14`).
 | `14` | proven: the checked-out branch is not this lane's (lane-identity rule) |
 | `15` | proven: the lane's claim is held by another session |
 | `18` | proven red — the failing runner and its diagnostics are on stderr |
+| `22` | proven: no changed file falls in any surface's validators — nothing to run, never a green |
 
 **Errors**
 
@@ -1025,20 +1041,26 @@ Preconditions: a linked worktree (`12`), the lane's branch checked out (`14`).
 | `build check: --surface prose, but the diff is 14 .ts files — the surface is provably wrong.` | 10 | refusal |
 | `build check: the diff against <base> is empty — nothing to validate (ADR 0092).` | 7 | refusal |
 | `build check: red — <runner> failed; diagnostics above.` | 18 | refusal |
+| `build check: no surface validates any of the <n> changed file(s) (<files>) — there is nothing here to run, so the verdict is a refusal, never green.` | 22 | refusal |
 
 **Scope** — this tree's diff against the branch base. A zero-file diff is `7` — zero scope, never
-a green (ADR 0092).
+a green (ADR 0092). A diff no surface validates is `22` — the same rule one step further in: a file
+the verb cannot classify is a file it cannot check, and an unchecked file never counts toward a
+green. A green's `unvalidated` list is what keeps the partial case honest.
 
 **Example**
 
 ```
 $ fabrika build check --surface code
-{"verdict":"green","surface":"code","tree":"/private/var/folders/…/build-4312","ran":["pnpm typecheck","pnpm lint:worktree"]}
+{"verdict":"green","surface":"code","tree":"/private/var/folders/…/build-4312","ran":["pnpm typecheck","pnpm lint:worktree"],"unvalidated":["scripts/deploy.sh"]}
 ```
 
 **Grounding**
 
 - #4106 / #4887 — the cross-tree cache false green; cache bypass is the design, not an option.
+- #5229 — two extension patterns and no third class: a workflow-only diff greened under `--surface
+  prose` having opened no file, and refused under `--surface code` with a message pointing at the
+  branch that greened. `22` and `unvalidated` are the two halves of that fix.
 - v1's discipline was prose-only (`SKILL.md:895-935`, exact-CI-command mandate with no
   enforcement); here the command set is the verb's, not the agent's memory.
 - ADR 0092 — zero diff is a refusal, not a vacuous green.

--- a/packages/fabrika-cli/src/build/check-verb.ts
+++ b/packages/fabrika-cli/src/build/check-verb.ts
@@ -14,6 +14,9 @@
  * makes reading the issue, and a verb that guessed it from file extensions would be wrong exactly on
  * the mixed diffs where the answer matters. The verb takes the skill's answer and refuses one the diff
  * provably contradicts.
+ *
+ * **Green means "the validators ran and passed", never "I could not tell."** See {@link classifyDiff}
+ * for the third file class that keeps that distinction representable (#5229).
  */
 import {Effect, FileSystem} from "effect";
 import type {ChildProcessSpawner} from "effect/unstable/process";
@@ -21,7 +24,13 @@ import {execCapture} from "../io/exec.ts";
 import {scanBody} from "../report/leaks.ts";
 import {answer, refuse, type VerbOutcome} from "../verb.ts";
 import {requireSession} from "./claim.ts";
-import {OFF_VOCABULARY, PRECONDITION_UNKNOWN, VALIDATION_RED, ZERO_SCOPE} from "./codes.ts";
+import {
+	OFF_VOCABULARY,
+	PRECONDITION_UNKNOWN,
+	UNCLASSIFIED_DIFF,
+	VALIDATION_RED,
+	ZERO_SCOPE,
+} from "./codes.ts";
 import {predecessorsOf, readTopology, renderRef, sameRef} from "./dependencies.ts";
 import {changedFiles, mergeBase} from "./git.ts";
 import {defaultBranch} from "./github.ts";
@@ -49,10 +58,44 @@ export interface CheckOptions {
 	readonly env: Readonly<Record<string, string | undefined>>;
 }
 
+/**
+ * The changed files split three ways, with `unvalidated` the file class **no** surface validates.
+ *
+ * That third bucket is the point. Filtering with the two regexes and reading nothing off what fell
+ * out of both made "matched neither" an absence, and an absence cannot be refused: a `.yml`/`.sh`
+ * diff produced an empty markdown list, zero validator iterations and a green that had opened no
+ * file (#5229). Named, it is a state the verb can act on.
+ */
+export interface DiffClasses {
+	readonly code: ReadonlyArray<string>;
+	readonly markdown: ReadonlyArray<string>;
+	readonly unvalidated: ReadonlyArray<string>;
+}
+
+export const classifyDiff = (files: ReadonlyArray<string>): DiffClasses => ({
+	code: files.filter((f) => CODE_RE.test(f)),
+	markdown: files.filter((f) => MARKDOWN_RE.test(f)),
+	unvalidated: files.filter((f) => !CODE_RE.test(f) && !MARKDOWN_RE.test(f)),
+});
+
+/**
+ * Why no surface can validate this diff at all, or `null`.
+ *
+ * Checked **before** {@link surfaceMismatch}, so a wholly-unvalidatable diff refuses with the honest
+ * reason under every surface — including `code`, whose old "the diff changes no code file" was a true
+ * sentence pointing at the wrong remedy (it invites `--surface prose`, the branch that greened).
+ */
+export const unvalidatableDiff = (files: ReadonlyArray<string>): string | null => {
+	const {code, markdown, unvalidated} = classifyDiff(files);
+	if (code.length > 0 || markdown.length > 0) return null;
+	const shown = unvalidated.slice(0, 5).join(", ");
+	const rest = unvalidated.length > 5 ? `, +${unvalidated.length - 5} more` : "";
+	return `no surface validates any of the ${unvalidated.length} changed file(s) (${shown}${rest})`;
+};
+
 /** Why `--surface` provably contradicts the diff, or `null`. */
 export const surfaceMismatch = (surface: Surface, files: ReadonlyArray<string>): string | null => {
-	const code = files.filter((f) => CODE_RE.test(f));
-	const markdown = files.filter((f) => MARKDOWN_RE.test(f));
+	const {code, markdown} = classifyDiff(files);
 	if (surface === "prose" && code.length > 0) {
 		return `--surface prose, but the diff is ${code.length} ${code.length === 1 ? "code file" : "code files"}`;
 	}
@@ -192,10 +235,28 @@ export const runCheck = (
 				scope,
 			);
 		}
+		const unvalidatable = unvalidatableDiff(files);
+		if (unvalidatable !== null) {
+			return refuse(
+				UNCLASSIFIED_DIFF,
+				`${VERB}: ${unvalidatable} — there is nothing here to run, so the verdict is a refusal, never green.`,
+				scope,
+			);
+		}
 		const mismatch = surfaceMismatch(surface as Surface, files);
 		if (mismatch !== null) {
 			return refuse(OFF_VOCABULARY, `${VERB}: ${mismatch} — the surface is provably wrong.`, scope);
 		}
+		const {markdown, unvalidated} = classifyDiff(files);
+		// A green over a partly-unvalidatable diff has to carry what it skipped, on both channels:
+		// #5187 greened over 25 workflow files whose `ran` line was true and misleading at once (#5229).
+		const noted =
+			unvalidated.length === 0
+				? scope
+				: [
+						...scope,
+						`${VERB}: ${unvalidated.length} changed file(s) no surface validates — NOT covered by this verdict: ${unvalidated.join(", ")}.`,
+					];
 
 		if (surface === "code") {
 			const ran: string[] = [];
@@ -206,15 +267,17 @@ export const runCheck = (
 					return refuse(
 						VALIDATION_RED,
 						`${VERB}: red — ${runner.label} failed; diagnostics above.`,
-						[...scope, result.reason],
+						[...noted, result.reason],
 					);
 				}
 			}
-			return answer(JSON.stringify({verdict: "green", surface, tree: lane.root, ran}), scope);
+			return answer(
+				JSON.stringify({verdict: "green", surface, tree: lane.root, ran, unvalidated}),
+				noted,
+			);
 		}
 
 		const fs = yield* FileSystem.FileSystem;
-		const markdown = files.filter((file) => MARKDOWN_RE.test(file));
 		const defects: string[] = [];
 		for (const file of markdown) {
 			const path = `${lane.root}/${file}`;
@@ -243,7 +306,7 @@ export const runCheck = (
 			return refuse(
 				VALIDATION_RED,
 				`${VERB}: red — the ${surface} validators failed; diagnostics above.`,
-				[...scope, ...defects],
+				[...noted, ...defects],
 			);
 		}
 		return answer(
@@ -252,7 +315,8 @@ export const runCheck = (
 				surface,
 				tree: lane.root,
 				ran: [surface === "prose" ? "markdown link + leak scan" : "## Dependencies grammar"],
+				unvalidated,
 			}),
-			scope,
+			noted,
 		);
 	});

--- a/packages/fabrika-cli/src/build/check-verb.unit.test.ts
+++ b/packages/fabrika-cli/src/build/check-verb.unit.test.ts
@@ -2,10 +2,11 @@ import {Effect, Layer} from "effect";
 import {describe, expect, it} from "vitest";
 import {errOut, fakeFs, fakeShell, okOut} from "../fakes.test-support.ts";
 import type {ExecResult} from "../io/exec.ts";
-import {runCheck, surfaceMismatch} from "./check-verb.ts";
+import {classifyDiff, runCheck, surfaceMismatch} from "./check-verb.ts";
 import {
 	OFF_VOCABULARY,
 	PRECONDITION_UNKNOWN,
+	UNCLASSIFIED_DIFF,
 	VALIDATION_RED,
 	WRONG_LANE,
 	ZERO_SCOPE,
@@ -70,6 +71,22 @@ describe("surfaceMismatch — the anchor, not a second classifier", () => {
 	});
 });
 
+describe("classifyDiff — matched-neither is a bucket, not an absence", () => {
+	it("names the files no surface validates", () => {
+		expect(classifyDiff([".github/workflows/ci.yml", "scripts/x.sh", "a.ts", "R.md"])).toEqual({
+			code: ["a.ts"],
+			markdown: ["R.md"],
+			unvalidated: [".github/workflows/ci.yml", "scripts/x.sh"],
+		});
+	});
+
+	it("puts every file in exactly one bucket", () => {
+		const files = ["a.tsx", "b.mjs", "c.json", "d.md", "e.mdx", "f.sql", "g.css", "LICENSE"];
+		const {code, markdown, unvalidated} = classifyDiff(files);
+		expect([...code, ...markdown, ...unvalidated].sort()).toEqual([...files].sort());
+	});
+});
+
 describe("runCheck", () => {
 	it("runs the exact CI commands with the cache bypassed, and reports what ran", async () => {
 		const shell = fakeShell([
@@ -87,6 +104,7 @@ describe("runCheck", () => {
 			surface: "code",
 			tree: "/repo/trees/lane-a",
 			ran: ["pnpm typecheck --force", "pnpm lint:worktree"],
+			unvalidated: [],
 		});
 		expect(shell.calls).toContain("pnpm typecheck --force");
 	});
@@ -179,6 +197,59 @@ describe("runCheck", () => {
 		);
 		expect(out.code).toBe(0);
 		expect(JSON.parse(out.stdout).verdict).toBe("green");
+	});
+
+	// The #5229 regression: before the third bucket existed, this exact diff returned
+	// {"verdict":"green","surface":"prose","ran":["markdown link + leak scan"]} having opened no file.
+	const WORKFLOW_ONLY = okOut(".github/workflows/ship.yml\nclaude-plugins/x/foo.sh\n");
+
+	it("refuses a wholly-unvalidatable diff on 22 under --surface prose — the false green", async () => {
+		const out = await run([...LANE_OK, [DIFF, WORKFLOW_ONLY]], {surface: "prose"});
+		expect(out.code).toBe(UNCLASSIFIED_DIFF);
+		expect(out.stdout).toBe("");
+		expect(out.stderr.at(-1)).toBe(
+			"build check: no surface validates any of the 2 changed file(s) (.github/workflows/ship.yml, claude-plugins/x/foo.sh) — there is nothing here to run, so the verdict is a refusal, never green.",
+		);
+	});
+
+	it("refuses the same diff on 22 under --surface plan", async () => {
+		const out = await run([...LANE_OK, [DIFF, WORKFLOW_ONLY]], {surface: "plan"});
+		expect(out.code).toBe(UNCLASSIFIED_DIFF);
+	});
+
+	it("refuses the same diff on 22 under --surface code, naming the honest reason", async () => {
+		const shell = fakeShell([...LANE_OK, [DIFF, WORKFLOW_ONLY]]);
+		const out = await Effect.runPromise(
+			Effect.provide(runCheck(options), Layer.merge(shell.layer, fakeFs({}).layer)),
+		);
+		expect(out.code).toBe(UNCLASSIFIED_DIFF);
+		expect(out.stderr.at(-1)).toContain("no surface validates any of the 2 changed file(s)");
+		expect(out.stderr.at(-1)).not.toContain("changes no code file");
+		expect(shell.calls).not.toContain("pnpm typecheck --force");
+	});
+
+	it("discloses the unvalidated files on a partly-unvalidatable prose green (the #5187 shape)", async () => {
+		const out = await run(
+			[...LANE_OK, [DIFF, okOut("docs/guide.md\n.github/workflows/ship.yml\n")]],
+			{surface: "prose"},
+			{"/repo/trees/lane-a/docs/guide.md": "nothing to resolve here\n"},
+		);
+		expect(out.code).toBe(0);
+		const verdict = JSON.parse(out.stdout);
+		expect(verdict.verdict).toBe("green");
+		expect(verdict.unvalidated).toEqual([".github/workflows/ship.yml"]);
+		expect(out.stderr.some((line) => line.includes("NOT covered by this verdict"))).toBe(true);
+	});
+
+	it("discloses the unvalidated files on a partly-unvalidatable code green", async () => {
+		const out = await run([
+			...LANE_OK,
+			[DIFF, okOut("apps/web/src/App.tsx\nscripts/deploy.sh\n")],
+			[TYPECHECK, okOut("")],
+			[LINT, okOut("")],
+		]);
+		expect(out.code).toBe(0);
+		expect(JSON.parse(out.stdout).unvalidated).toEqual(["scripts/deploy.sh"]);
 	});
 
 	it("reds a plan diff whose Dependencies block does not parse", async () => {

--- a/packages/fabrika-cli/src/build/codes.ts
+++ b/packages/fabrika-cli/src/build/codes.ts
@@ -81,3 +81,12 @@ export const UNSAFE_PUSH = 19;
 export const OUT_OF_FOCUS = 20;
 /** Proven: not admitted on the **audience axis** — the `ready-for:` label is not agent, or absent (#4780). */
 export const AUDIENCE_NOT_AGENT = 21;
+/**
+ * Proven: every changed file falls outside all three surfaces' validators — nothing is checkable.
+ *
+ * A *proven* refusal like `20`/`21`, not a borrowed {@link PRECONDITION_UNKNOWN}: the diff read
+ * succeeded and the classification is complete, so the fact established is about the tree, not about
+ * a read that failed. Its own seat because the caller's remedy is unique — widen no surface, split
+ * the diff or extend a validator (#5229).
+ */
+export const UNCLASSIFIED_DIFF = 22;


### PR DESCRIPTION
Fixes #5229

`fabrika build check` sorted the changed-file list with two extension patterns and read
nothing off what matched neither, so "unclassifiable" was an **absence** rather than a
state — and an absence cannot be refused. A `.github/workflows/*.yml` + `*.sh` diff cleared
the zero-scope guard, produced an empty markdown list, ran the validator loop zero times and
returned `{"verdict":"green","surface":"prose","ran":["markdown link + leak scan"]}` having
opened no file. The mirror direction refused the same diff under `--surface code` with
"the diff changes no code file", which points at the branch that greens.

## The design question, settled: refuse, do not widen

The issue left the fork open. **Resolution: make "matched neither" a named class and refuse —
do not widen the code pattern.**

Widening `CODE_RE` to swallow `.yml`/`.sh` would make the verb *claim* `pnpm typecheck` and
`pnpm lint:worktree` validated a shell script. They do not: `lint:worktree` filters to
biome-handled extensions, so a widened pattern buys a green that is false in a new way rather
than silent in the old way. It also makes `--surface` guess at file classes, which
`contract.md` explicitly declined ("an anchor, not a second classifier").

The honest answer is that no validator covers those files, so no verdict can. The remedy for a
workflow-only lane is to split the diff or extend a validator — not to rename the surface.

**A new proven code (`22`), not `PRECONDITION_UNKNOWN` (`11`).** `11` means a read or a runner
failed and nothing is proven. Here the diff read succeeded and the classification is complete:
the fact is *about the tree*, so it belongs with the group's other proven refusals (`20`/`21`),
not with the unknowns.

## What changed

- **`classifyDiff`** splits the changed files three ways — `code` / `markdown` / `unvalidated`
  — and every file lands in exactly one bucket. `surfaceMismatch` now reads from it instead of
  re-filtering, so there is one classifier, not two.
- **A wholly unvalidatable diff refuses on `22` under every surface**, checked *before* the
  surface-mismatch test so `--surface code` also gets the honest reason instead of
  "changes no code file".
- **A partly unvalidatable diff still greens, but never bare.** The green JSON always carries
  `unvalidated: [...]` (the files this verdict does not cover), and the same line goes to
  stderr. That is the live PR #5187 / #5205 shape — 25 workflow files and 8 shell files whose
  `ran` field was true and misleading at the same time.

Green now means "the validators ran and passed". It never means "I could not tell".

## Regression coverage

`check-verb.unit.test.ts` gains the exact diff that used to read green: a
`.github/workflows/ship.yml` + `*.sh` diff under `--surface prose` now asserts exit `22` and
empty stdout. It fails against the old code, which returned `0` with a green verdict. Plus:
the same diff under `plan` and `code` (asserting the old "no code file" wording is gone and no
runner was spawned), both partial-green disclosure cases, and the bucket-partition property.

## Contract

`claude-plugins/fabrika/skills/build/contract.md` is amended so the contract and the source
agree: `22` in the shared exit matrix and in `build check`'s own exit + errors tables, the
`unvalidated` key in the output shape and the example, the three-file-classes paragraph under
the surface anchor (including why widening was rejected), and the scope note.

`packages/fabrika-cli/src/build/push-verb.ts` is untouched — that is #5222's scope.

## Verification

- `pnpm typecheck` — 31/31 tasks green.
- `pnpm lint:worktree` — clean.
- `pnpm vitest run` in `packages/fabrika-cli` — 2815 tests across 195 files, all passing.

## Deviations

- **Known defect left unfixed** — **Said:** #5229 asks that a green verdict never imply a file was
  validated when it was not. **Did:** only the *wholly*-unvalidatable diff is refused, and the
  partial disclosure covers only the third bucket. `--surface code` over a diff that also contains
  markdown (the pre-existing `["a.ts","README.md"]` case) still greens: the markdown lands in the
  `markdown` bucket, so it is neither scanned by the code runners nor listed in `unvalidated`.
  **Why:** it is a different shape from this ticket's — those files *have* a validator, just not the
  one this surface runs, so the fix is a design call (scan both classes, or list the unscanned
  class) that #5229 did not scope. Widening it here would have changed behavior no acceptance
  criterion asked for. **Disposition:** follow-up #5288 filed; disclosed here because §DEV class 3
  is owed whether or not a follow-up exists.

- **Known defect left unfixed (repair round 1)** — **Said:** a comment should describe the code it
  sits on. **Did:** `packages/fabrika-cli/src/build/codes.ts:7` still documents the group as adding
  its own `12`-`21`; this PR adds `22`, so that range is now stale, and the line is left as-is.
  **Why:** the reviewer recorded it as a non-blocking observation requiring no repair, and this
  repair round is body-only at head `5a6936ae` — touching the comment would move the head and
  invalidate the verified acceptance-criteria and run-evidence work already done against it.
  **Disposition:** for the reviewer to judge — fold into a follow-up, or into the next PR that
  touches this file.
