### PR TITLE
fix(fabrika): prove push containment on the force path, never on the lease alone

### DIFF
--- a/claude-plugins/fabrika/skills/build/SKILL.md
+++ b/claude-plugins/fabrika/skills/build/SKILL.md
@@ -174,7 +174,10 @@ UNKNOWN exit means the verdict state is unread — never "nothing to fix" (#4105
 on the same branch (`fabrika build tree --issue 4310`, then `fabrika build branch --resume
 4310`), re-validate
 with `fabrika build check --surface <yours>`, push with `fabrika build push --force-with-lease`,
-answer the findings in a `fabrika build note` naming each one addressed, release. A
+answer the findings in a `fabrika build note` naming each one addressed, release. Exit `23` on that
+push means your head **drops commits the PR already published** — `build branch --resume` again so
+you rebuild on the published head, never `--drop-remote-commits`, which is for a rewrite you
+actually intend (#5222). A
 review-appended acceptance criterion after round 2 is frozen — note it, do not chase it.
 
 ## Expectations you hold but never recompute

--- a/claude-plugins/fabrika/skills/build/contract.md
+++ b/claude-plugins/fabrika/skills/build/contract.md
@@ -250,6 +250,7 @@ range, exactly as `triage/codes.ts` itself states for `adr`.
 | `20` | proven: not admitted on the scope axis, out of focus — the issue's home is not the declared milestone and no standing-lane label exempts it |
 | `21` | proven: not admitted on the audience axis, audience not agent — the issue's `ready-for:` label is not `ready-for:agent`, or is absent |
 | `22` | proven: every changed file falls outside all three surfaces' validators — there is nothing to run, so the verdict is a refusal, never a green |
+| `23` | proven: the local head does not contain the published remote head — the push would drop its commits |
 | `127` | the verb never ran at all (unresolved binary — the shell's code, not this process's) |
 
 **`7` versus `11` is the split the whole group rests on** (the `wire` group's `ABSENT` vs
@@ -1074,7 +1075,7 @@ $ fabrika build check --surface code
 **Invocation**
 
 ```
-fabrika build push [--force-with-lease]
+fabrika build push [--force-with-lease] [--drop-remote-commits]
 ```
 
 **Inputs**
@@ -1082,6 +1083,7 @@ fabrika build push [--force-with-lease]
 | Flag | Type | Required | Default | Description |
 |---|---|---|---|---|
 | `--force-with-lease` | boolean | no | `false` | permit a non-fast-forward update of this lane's own branch (repair resubmission) |
+| `--drop-remote-commits` | boolean | no | `false` | publish a head that does **not** contain the published remote head — a deliberate history rewrite |
 
 **Output** — machine, **single-stream: the entire report is stdout**, and the last line is always
 exactly one of:
@@ -1109,6 +1111,28 @@ Refusals before any push (`19`): HEAD is detached; or the update is non-fast-for
 `--force` flag does not exist here, and there is no `--no-verify` (#4159: the ban is enforced by
 the flag not existing).
 
+**Containment is proven on every path, the force path included (`23`).** Whenever the target ref
+already exists, the local head must **contain** the SHA a live `git ls-remote` just read off it —
+`git merge-base --is-ancestor <remote head> <local head>`. On the plain path that is the
+fast-forward test and its failure is `19`; on the force path its failure is `23`, and a lane that
+means the rewrite says so with `--drop-remote-commits`, which publishes anyway and records the
+drop on stderr.
+
+`--force-with-lease` does not cover this and cannot: a lease compares the remote against what this
+clone last saw of it, so it defends the ref against **another** writer, never against **this**
+lane's own head having dropped the remote's commits — and a bare lease is "trivially defeated" by
+any `git fetch` the lane already ran (`git push`'s own documentation), which the repair path does.
+With the ancestry test formerly guarded by `!--force-with-lease`, the documented repair invocation
+had no containment evidence at all and the verb's success test (remote SHA equals the lane's own
+head) reported the drop as `MOVED` (#5222).
+
+The remote head must be **in this object database** for the ancestry test to mean anything, and a
+repair lane's published head may be a commit this clone has never held. So the verb probes for it
+and fetches `<remote>/<ref>` once if it is absent; if it is still absent, containment is **UNKNOWN**
+and the refusal is `11` — never `23`, which is a *proven* fact about two commits it holds. This is
+also why the read is a live `ls-remote` rather than a remote-tracking ref: a tracking ref a
+preceding fetch in the same lane already refreshed proves nothing about what is published.
+
 Preconditions: a linked worktree (`12`), the lane's branch (`14`).
 
 **Exit status** (beyond the universal four)
@@ -1116,12 +1140,13 @@ Preconditions: a linked worktree (`12`), the lane's branch (`14`).
 | Code | Trigger |
 |---|---|
 | `8` | the push was attempted but the remote ref could not be re-read — the outcome is UNKNOWN (the matrix's `8`: an attempted write whose outcome cannot be proven) |
-| `11` | the lane's claim could not be read — nothing was pushed |
+| `11` | the lane's claim could not be read, or the remote head could not be made readable so containment is UNKNOWN — nothing was pushed |
 | `12` | proven: not in a linked worktree |
 | `14` | proven: the checked-out branch is not this lane's (lane-identity rule) |
 | `15` | proven: the lane's claim is held by another session — nothing was pushed |
 | `17` | proven: the remote ref did not move |
 | `19` | refused before pushing: detached HEAD, or non-fast-forward without `--force-with-lease` |
+| `23` | proven: the local head does not contain the published remote head — the push would drop its commits |
 
 **Errors**
 
@@ -1129,6 +1154,8 @@ Preconditions: a linked worktree (`12`), the lane's branch (`14`).
 |---|---|---|
 | `build push: HEAD is detached — refusing to guess a branch.` | 19 | refusal |
 | `build push: non-fast-forward — pass --force-with-lease only for this lane's own repair resubmission.` | 19 | refusal |
+| `build push: the local head does not contain <remote>/<ref> (<sha>) — this push would DROP <commits>. Rebase onto the published head, or pass --drop-remote-commits to rewrite it deliberately.` | 23 | refusal |
+| `build push: cannot prove containment — <remote>/<ref> is at <sha>, which this checkout does not hold and could not fetch. Nothing was pushed.` | 11 | refusal |
 | `build push: the remote ref did not move (remote <sha> ≠ local <sha>).` | 17 | refusal |
 | `build push: pushed, but the remote ref could not be re-read: <reason> — the outcome is UNKNOWN.` | 8 | refusal |
 
@@ -1150,6 +1177,11 @@ PUSH-VERDICT: MOVED
   refusal removes the case instead of guarding it.
 - #4159 — `--no-verify` unenforceable as prose; here unrepresentable.
 - #4540 — `--force-with-lease` as the only force shape protects the remote against a stale local.
+- #5222 — the ancestry test was guarded by `!--force-with-lease`, so the repair path, which mandates
+  the lease, got no containment check; `23` and the explicit `--drop-remote-commits` escape close it.
+- #5263 — the same gap reproduced on v1 from a stale *local branch ref*: the rebase is clean, the
+  bare lease is defeated by the lane's own fetch, and the verdict is `MOVED`. Containment against a
+  live remote read is the only test that catches it.
 
 ---
 

--- a/packages/fabrika-cli/src/build/codes.ts
+++ b/packages/fabrika-cli/src/build/codes.ts
@@ -90,3 +90,16 @@ export const AUDIENCE_NOT_AGENT = 21;
  * the diff or extend a validator (#5229).
  */
 export const UNCLASSIFIED_DIFF = 22;
+/**
+ * Proven: the local head does not contain the published remote head — this push would drop commits.
+ *
+ * A *proven* refusal about the two commits, so it sits with `17`/`19`/`20`/`21` and never on
+ * {@link PRECONDITION_UNKNOWN}, which is reserved for a read that failed. Its own seat rather than
+ * `19`'s because the remedy differs: `19` says "pass the lease", this one says "rebase, or say you
+ * mean it" — collapsing them would make the fix instruction ambiguous (#5222).
+ *
+ * Overlapping `epic`'s own `23` is the same safe overlap `20`/`21` already rely on — the rule is
+ * `plan/codes.ts`'s: import a code when two groups prove the *same* fact, and an exit code is
+ * otherwise read off the command that produced it. No `epic` verb can prove a push's containment.
+ */
+export const HEAD_DROPS_REMOTE = 23;

--- a/packages/fabrika-cli/src/build/command.ts
+++ b/packages/fabrika-cli/src/build/command.ts
@@ -302,14 +302,26 @@ const push = leafCommand(
 				"permit a non-fast-forward update of this lane's own branch — repair resubmission only (default: false)",
 			),
 		),
+		dropRemoteCommits: Flag.boolean("drop-remote-commits").pipe(
+			Flag.withDescription(
+				"publish a head that does NOT contain the published remote head, dropping its commits — a deliberate history rewrite (default: false)",
+			),
+		),
 		repo: repoFlag,
 	},
-	Effect.fn(function* ({forceWithLease, repo}) {
-		yield* emit(yield* runPush({forceWithLease, repo: Option.getOrNull(repo), env: process.env}));
+	Effect.fn(function* ({dropRemoteCommits, forceWithLease, repo}) {
+		yield* emit(
+			yield* runPush({
+				forceWithLease,
+				dropRemoteCommits,
+				repo: Option.getOrNull(repo),
+				env: process.env,
+			}),
+		);
 	}),
 ).pipe(
 	Command.withDescription(
-		"Publish the lane's branch and INDEPENDENTLY confirm the remote ref moved, by reading it back with git ls-remote. The whole report is stdout, single-stream, so `tail -1` of stdout on exit 0 is always `PUSH-VERDICT: MOVED`. Exits 8 (pushed, but the remote ref could not be re-read — the outcome is UNKNOWN), 11 (the lane's claim could not be read — nothing was pushed), 12 (not in a linked worktree), 14 (the checked-out branch is not this lane's), 15 (the claim is held by another session), 17 (proven: the remote ref did not move), 19 (refused before pushing: detached HEAD, or non-fast-forward without --force-with-lease). Example: fabrika build push",
+		"Publish the lane's branch and INDEPENDENTLY confirm the remote ref moved, by reading it back with git ls-remote. The whole report is stdout, single-stream, so `tail -1` of stdout on exit 0 is always `PUSH-VERDICT: MOVED`. Before pushing, the local head must CONTAIN the published remote head — on the force path too, where --force-with-lease proves nothing about this lane's own dropped commits. Exits 8 (pushed, but the remote ref could not be re-read — the outcome is UNKNOWN), 11 (the lane's claim could not be read, or containment could not be proven — nothing was pushed), 12 (not in a linked worktree), 14 (the checked-out branch is not this lane's), 15 (the claim is held by another session), 17 (proven: the remote ref did not move), 19 (refused before pushing: detached HEAD, or non-fast-forward without --force-with-lease), 23 (proven: the local head drops the remote head's commits — rebase, or pass --drop-remote-commits). Example: fabrika build push",
 	),
 );
 

--- a/packages/fabrika-cli/src/build/git.ts
+++ b/packages/fabrika-cli/src/build/git.ts
@@ -17,9 +17,11 @@ import {execCapture} from "../io/exec.ts";
 import {
 	type Attempt,
 	fail,
+	fetchRef,
 	isObjectName,
 	ok,
 	remotes,
+	resolveCommit,
 	type Shell,
 	splitRemoteRef,
 } from "../io/git.ts";
@@ -105,6 +107,52 @@ export const remoteSha = (remote: string, ref: string): Shell<Attempt<string | n
 		return isObjectName(sha)
 			? ok(sha)
 			: fail(`\`git ls-remote\` printed "${first}", not a ref row`);
+	});
+
+/**
+ * Make `sha` readable from this object database, fetching `<remote>/<ref>` once if it is not, and
+ * answer whether it now is.
+ *
+ * {@link isAncestor} needs both commits present locally, and a repair lane's published head can be a
+ * commit this clone has never held. A missing object is UNKNOWN — never "not an ancestor" — so this
+ * answers presence and leaves the conclusion to the caller.
+ */
+export const ensureCommitPresent = (remote: string, ref: string, sha: string): Shell<boolean> =>
+	Effect.gen(function* () {
+		const present = (yield* resolveCommit(sha))._tag === "Ok";
+		if (present) return true;
+		yield* fetchRef(remote, ref);
+		return (yield* resolveCommit(sha))._tag === "Ok";
+	});
+
+/** How many dropped commits a refusal names before it truncates. */
+const DROPPED_SHOWN = 10;
+
+/**
+ * The commits reachable from `remoteHead` and not from `local` — exactly what a force push drops.
+ *
+ * Reported as text for a human to read in the refusal, so a failure to enumerate degrades to an empty
+ * list rather than to a second failure mode: the containment verdict is already proven by then.
+ */
+export const commitsDropped = (
+	local: string,
+	remoteHead: string,
+): Shell<{readonly lines: ReadonlyArray<string>; readonly truncated: boolean}> =>
+	Effect.gen(function* () {
+		const r = yield* execCapture("git", [
+			"log",
+			"--no-decorate",
+			"--format=%h %s",
+			`-n`,
+			`${DROPPED_SHOWN + 1}`,
+			`${local}..${remoteHead}`,
+		]);
+		if (!r.ok) return {lines: [], truncated: false};
+		const lines = r.stdout
+			.split("\n")
+			.map((l) => l.trim())
+			.filter((l) => l !== "");
+		return {lines: lines.slice(0, DROPPED_SHOWN), truncated: lines.length > DROPPED_SHOWN};
 	});
 
 /** Whether `ancestor` is reachable from `descendant` — the fast-forward test. */

--- a/packages/fabrika-cli/src/build/push-verb.ts
+++ b/packages/fabrika-cli/src/build/push-verb.ts
@@ -21,8 +21,22 @@ import type {ChildProcessSpawner} from "effect/unstable/process";
 import {currentBranch} from "../io/issues.ts";
 import {answer, refuse, type VerbOutcome} from "../verb.ts";
 import {requireSession} from "./claim.ts";
-import {PRECONDITION_UNKNOWN, REF_NOT_MOVED, UNSAFE_PUSH, WRITE_UNKNOWN} from "./codes.ts";
-import {headSha, isAncestor, push, remoteSha, upstreamOf} from "./git.ts";
+import {
+	HEAD_DROPS_REMOTE,
+	PRECONDITION_UNKNOWN,
+	REF_NOT_MOVED,
+	UNSAFE_PUSH,
+	WRITE_UNKNOWN,
+} from "./codes.ts";
+import {
+	commitsDropped,
+	ensureCommitPresent,
+	headSha,
+	isAncestor,
+	push,
+	remoteSha,
+	upstreamOf,
+} from "./git.ts";
 import {requireLane} from "./lane-guard.ts";
 import {resolveTargetRepo} from "./target.ts";
 
@@ -30,6 +44,8 @@ const VERB = "build push";
 
 export interface PushOptions {
 	readonly forceWithLease: boolean;
+	/** Publish a head that drops the remote's commits anyway — a deliberate rewrite, never a default. */
+	readonly dropRemoteCommits: boolean;
 	readonly repo: string | null;
 	readonly env: Readonly<Record<string, string | undefined>>;
 }
@@ -76,13 +92,45 @@ export const runPush = (
 				lane.notes,
 			);
 		}
-		if (before.value !== null && !options.forceWithLease) {
-			const fastForward = yield* isAncestor(before.value, local.value);
-			if (!fastForward) {
+		const notes = [...lane.notes];
+
+		// The containment test runs on BOTH paths, and that is the whole fix (#5222). It used to be
+		// guarded by `!forceWithLease`, so the repair path — which mandates the lease — got no
+		// containment evidence at all: `--force-with-lease` defends the ref against ANOTHER writer,
+		// never against this lane's own head having dropped the remote's commits, and a bare lease is
+		// refreshed by any fetch the lane already ran, so it cannot refuse the drop either. The verb's
+		// own success test (remote === local) then reported the drop as `MOVED`.
+		if (before.value !== null) {
+			if (!(yield* ensureCommitPresent(remote, ref, before.value))) {
+				return refuse(
+					PRECONDITION_UNKNOWN,
+					`${VERB}: cannot prove containment — ${remote}/${ref} is at ${before.value}, which this checkout does not hold and could not fetch. Nothing was pushed.`,
+					notes,
+				);
+			}
+			const contains = yield* isAncestor(before.value, local.value);
+			if (!contains && !options.forceWithLease) {
 				return refuse(
 					UNSAFE_PUSH,
 					`${VERB}: non-fast-forward — pass --force-with-lease only for this lane's own repair resubmission.`,
-					lane.notes,
+					notes,
+				);
+			}
+			if (!contains && !options.dropRemoteCommits) {
+				const dropped = yield* commitsDropped(local.value, before.value);
+				return refuse(
+					HEAD_DROPS_REMOTE,
+					`${VERB}: the local head does not contain ${remote}/${ref} (${before.value}) — this push would DROP ${
+						dropped.lines.length === 0
+							? "commits the remote holds and this head does not"
+							: `${dropped.lines.join("; ")}${dropped.truncated ? "; …" : ""}`
+					}. Rebase onto the published head, or pass --drop-remote-commits to rewrite it deliberately.`,
+					notes,
+				);
+			}
+			if (!contains) {
+				notes.push(
+					`${VERB}: --drop-remote-commits given — publishing a head that drops ${remote}/${ref} (${before.value}).`,
 				);
 			}
 		}
@@ -93,7 +141,7 @@ export const runPush = (
 			return refuse(
 				WRITE_UNKNOWN,
 				`${VERB}: pushed, but the remote ref could not be re-read: ${after.reason} — the outcome is UNKNOWN.`,
-				lane.notes,
+				notes,
 			);
 		}
 		if (after.value !== local.value) {
@@ -101,7 +149,7 @@ export const runPush = (
 				REF_NOT_MOVED,
 				`${VERB}: the remote ref did not move (remote ${after.value ?? "absent"} ≠ local ${local.value}).`,
 				[
-					...lane.notes,
+					...notes,
 					...(pushed._tag === "Failure" ? [`${VERB}: git push reported: ${pushed.reason}.`] : []),
 				],
 			);
@@ -112,6 +160,6 @@ export const runPush = (
 				`remote ref read back: ${after.value}`,
 				"PUSH-VERDICT: MOVED",
 			].join("\n"),
-			lane.notes,
+			notes,
 		);
 	});

--- a/packages/fabrika-cli/src/build/push-verb.unit.test.ts
+++ b/packages/fabrika-cli/src/build/push-verb.unit.test.ts
@@ -1,9 +1,10 @@
 import {Effect} from "effect";
 import {describe, expect, it} from "vitest";
-import {errOut, fakeShell, okOut} from "../fakes.test-support.ts";
+import {errOut, fakeShell, okOut, once} from "../fakes.test-support.ts";
 import type {ExecResult} from "../io/exec.ts";
 import {
 	CLAIM_NOT_MINE,
+	HEAD_DROPS_REMOTE,
 	PRECONDITION_UNKNOWN,
 	REF_NOT_MOVED,
 	UNSAFE_PUSH,
@@ -32,6 +33,9 @@ const UPSTREAM = /^git rev-parse --abbrev-ref --symbolic-full-name /;
 const LS_REMOTE = /^git ls-remote origin /;
 const PUSH = /^git push /;
 const ANCESTOR = /^git merge-base --is-ancestor /;
+const PRESENT = /^git rev-parse --verify --quiet /;
+const FETCH = /^git fetch /;
+const LOG = /^git log /;
 
 const LANE = `build/4312-editor-focus-loss-${NONCE}`;
 
@@ -43,10 +47,13 @@ const LANE_OK: ReadonlyArray<readonly [RegExp, ExecResult]> = [
 	[PERM, okOut("write\n")],
 	[HEAD_SHA, okOut(`${HEAD}\n`)],
 	[UPSTREAM, errOut("fatal: no upstream")],
+	// The remote head is in this object database, so the containment test has both commits.
+	[PRESENT, okOut(`${OLD_HEAD}\n`)],
 ];
 
 const options = {
 	forceWithLease: false,
+	dropRemoteCommits: false,
 	repo: null,
 	env: {CLAUDE_PIPELINE_REPO: "o/r", CLAUDE_CODE_SESSION_ID: "s-9f2e"} as Record<
 		string,
@@ -163,6 +170,7 @@ describe("runPush", () => {
 			[PERM, okOut("write\n")],
 			[HEAD_SHA, okOut(`${HEAD}\n`)],
 			[UPSTREAM, okOut("origin/umut/fix-focus\n")],
+			[PRESENT, okOut(`${HEAD}\n`)],
 			[/^git remote$/, okOut("origin\n")],
 			[LS_REMOTE, okOut(`${HEAD}\trefs/heads/umut/fix-focus\n`)],
 			[ANCESTOR, okOut("")],
@@ -171,6 +179,83 @@ describe("runPush", () => {
 		const out = await Effect.runPromise(Effect.provide(runPush(options), shell.layer));
 		expect(out.code).toBe(0);
 		expect(shell.calls).toContain("git push origin HEAD:refs/heads/umut/fix-focus");
+	});
+
+	// The repair path mandates --force-with-lease, and the lease is blind to THIS lane dropping the
+	// remote's own commits — so these four are the containment contract (#5222).
+	it("refuses on 23 when the force-path head does not contain the remote head, and pushes nothing", async () => {
+		const shell = fakeShell([
+			...LANE_OK,
+			[/^git remote$/, okOut("origin\n")],
+			[LS_REMOTE, okOut(`${OLD_HEAD}\trefs/heads/${LANE}\n`)],
+			[ANCESTOR, errOut("")],
+			[LOG, okOut("a1b2c3d restore the 20 workflow triggers\ne4f5a6b fix the focus loss\n")],
+			[PUSH, okOut("")],
+		]);
+		const out = await Effect.runPromise(
+			Effect.provide(runPush({...options, forceWithLease: true}), shell.layer),
+		);
+		expect(out.code).toBe(HEAD_DROPS_REMOTE);
+		expect(out.stdout).toBe("");
+		expect(shell.calls.some((line) => PUSH.test(line))).toBe(false);
+		const said = out.stderr.at(-1) ?? "";
+		expect(said).toContain(`does not contain origin/${LANE} (${OLD_HEAD})`);
+		expect(said).toContain("a1b2c3d restore the 20 workflow triggers");
+		expect(said).toContain("--drop-remote-commits");
+	});
+
+	it("publishes the dropping head only when --drop-remote-commits says so, and says it did", async () => {
+		const shell = fakeShell([
+			...LANE_OK,
+			[/^git remote$/, okOut("origin\n")],
+			[once(LS_REMOTE), okOut(`${OLD_HEAD}\trefs/heads/${LANE}\n`)],
+			[LS_REMOTE, okOut(`${HEAD}\trefs/heads/${LANE}\n`)],
+			[ANCESTOR, errOut("")],
+			[PUSH, okOut("")],
+		]);
+		const out = await Effect.runPromise(
+			Effect.provide(
+				runPush({...options, forceWithLease: true, dropRemoteCommits: true}),
+				shell.layer,
+			),
+		);
+		expect(out.code).toBe(0);
+		expect(out.stdout.trimEnd().split("\n").at(-1)).toBe("PUSH-VERDICT: MOVED");
+		expect(out.stderr.some((line) => line.includes("--drop-remote-commits given"))).toBe(true);
+	});
+
+	it("refuses on 11 when the remote head is unreadable locally — UNKNOWN, never 'not contained'", async () => {
+		const shell = fakeShell([
+			...LANE_OK.filter(([pattern]) => pattern !== PRESENT),
+			[/^git remote$/, okOut("origin\n")],
+			[LS_REMOTE, okOut(`${OLD_HEAD}\trefs/heads/${LANE}\n`)],
+			[PRESENT, errOut("")],
+			[FETCH, errOut("fatal: could not read from remote repository")],
+		]);
+		const out = await Effect.runPromise(
+			Effect.provide(runPush({...options, forceWithLease: true}), shell.layer),
+		);
+		expect(out.code).toBe(PRECONDITION_UNKNOWN);
+		expect(out.stdout).toBe("");
+		expect(shell.calls.some((line) => PUSH.test(line))).toBe(false);
+		expect(shell.calls.some((line) => FETCH.test(line))).toBe(true);
+		expect(out.stderr.at(-1)).toContain("cannot prove containment");
+	});
+
+	it("still pushes on the force path when the head DOES contain the remote head", async () => {
+		const out = await run(
+			[
+				...LANE_OK,
+				[/^git remote$/, okOut("origin\n")],
+				[once(LS_REMOTE), okOut(`${OLD_HEAD}\trefs/heads/${LANE}\n`)],
+				[LS_REMOTE, okOut(`${HEAD}\trefs/heads/${LANE}\n`)],
+				[ANCESTOR, okOut("")],
+				[PUSH, okOut("")],
+			],
+			{forceWithLease: true},
+		);
+		expect(out.code).toBe(0);
+		expect(out.stdout.trimEnd().split("\n").at(-1)).toBe("PUSH-VERDICT: MOVED");
 	});
 
 	it("refuses a branch that is not a lane branch on 14", async () => {


### PR DESCRIPTION
Fixes #5222

`fabrika build push` guarded its ancestry test with `if (before.value !== null && !options.forceWithLease)`
— so the one path that force-pushes, the repair path, was the one path with no containment
evidence at all. The documented repair invocation is `fabrika build push --force-with-lease`,
and on it the verb pushed whatever the lane's head happened to be, then declared success by
comparing the remote against that same head. A head that had dropped the PR's published
commits therefore reported `PUSH-VERDICT: MOVED`.

`--force-with-lease` does not close this and cannot. A lease compares the remote against what
*this clone last saw* of it: it defends the ref against **another** writer, never against this
lane's own head having dropped the remote's commits. A bare lease is also, per `git push`'s own
documentation, "trivially defeated" by anything that implicitly runs `git fetch` on the remote
being pushed to — which the repair path does before it rebases.

## What changed

- **The containment test runs on both paths.** Whenever the target ref already exists, the local
  head must contain the SHA a live `git ls-remote` just read off it. On the plain path that is
  the fast-forward test and its failure stays `19`; on the force path its failure is the new
  proven code **`23`**.
- **`--drop-remote-commits` is the explicit escape.** A deliberate history rewrite says so and
  publishes; the push then records on stderr that it dropped the published head. Silence is no
  longer a way to do it.
- **An unreadable remote head is UNKNOWN (`11`), never "not contained".** `git merge-base
  --is-ancestor` needs both commits locally, and a repair lane's published head can be a commit
  this clone has never held. The verb probes for it, fetches `<remote>/<ref>` once if absent, and
  refuses on `11` if it still cannot hold it — a *proven* code is reserved for a fact proven
  about two commits it has.
- **The read is live.** Containment is compared against `ls-remote`, not a remote-tracking ref a
  preceding fetch in the same lane may already have refreshed (the trigger recorded on #5222 from
  #5263).

`23` rather than widening `19`: the remedies differ. `19` says "pass the lease"; `23` says
"rebase onto the published head, or say you mean the rewrite". `22` is deliberately skipped — it
is allocated by the in-flight #5229 lane, and a gap costs nothing while a collision costs a
silent double meaning.

## Regression coverage

`push-verb.unit.test.ts` gains four cases, three of which fail against the pre-fix code
(measured: restoring the `&& !options.forceWithLease` guard and re-running gives 3 failed / 11
passed of 14):

- a `--force-with-lease` push whose head does not contain the remote head → exit `23`, empty
  stdout, no `git push` spawned, and the refusal names the dropped commits;
- the same push with `--drop-remote-commits` → publishes, and says on stderr that it dropped the
  remote head;
- a force push whose remote head is neither local nor fetchable → exit `11`, nothing pushed;
- a force push that *does* contain the remote head → still `PUSH-VERDICT: MOVED` (the guard adds
  no false refusal to the normal repair round).

## Contract

`claude-plugins/fabrika/skills/build/contract.md` carries `23` in the shared exit matrix and in
`build push`'s own exit + error tables, the `--drop-remote-commits` input row, the containment
paragraph (including why the lease cannot substitute and why an absent object is `11`), and the
grounding entries. `claude-plugins/fabrika/skills/build/SKILL.md`'s repair step now tells a lane
what a `23` means: re-`build branch --resume`, never `--drop-remote-commits`.

## Verification

- `pnpm typecheck` — 31/31 tasks green.
- `pnpm lint:worktree` — clean.
- `pnpm vitest run` in `packages/fabrika-cli` — 195 files, 2812 tests, all passing.

## Deviations

**Class 3 — acceptance criteria 3, 4 and one third of criterion 5 are deliberately not built
here.**

- **Said:** the issue body's acceptance criteria include `build check`'s surface classification
  ("stops being silently blind to unlisted file classes", "`--surface code` no longer refuses a
  workflow-only diff") and the two matching unit tests.
- **Did:** this PR touches only `packages/fabrika-cli/src/build/push-verb.ts` and its
  dependencies. `check-verb.ts` is untouched.
- **Why:** the intake desk's scope-boundary comment on #5222 (2026-08-10T00:37Z) split section 2
  of that body out to **#5229** and states it "stays in this body as context, not scope" —
  explicitly because a coder could otherwise read it as work to do. #5229 is open and in flight.
  Building it here would double-implement it.
- **Disposition:** owned by #5229; nothing further is owed from this lane. This disclosure is the
  record, not the follow-up filing.

No ADR was authored. The push verb's containment rule is a contract-level fix inside an existing
decision, not a new one; the pre-assigned `0260` is unused.
