### PR TITLE
fix(fabrika): plan-epic claims the epic with --purpose plan (#5217)

### DIFF
--- a/claude-plugins/fabrika/skills/plan-epic/SKILL.md
+++ b/claude-plugins/fabrika/skills/plan-epic/SKILL.md
@@ -49,9 +49,18 @@ A plan is only as good as the ground it was derived from (#3330). Claim first �
 `build`'s, reused, not a second lock:
 
 ```bash
-fabrika build claim 4300
+fabrika build claim 4300 --purpose plan
 fabrika build tree --require-clean
 ```
+
+`--purpose plan` is not optional here. The audience axis (`ready-for:agent`) asks whether an agent
+should pick the issue up to **build**, and an epic earns that label only *after* this skill has
+planned it and the gate has passed it — so fencing the planner on it is circular, and the founder
+ruled the fence binds build-purpose claims only
+([#5175](https://github.com/kamp-us/phoenix/issues/5175)). A `plan` claim is admitted without the
+label; the scope axis still binds, so an out-of-focus epic is still exit `20`. Never reach for
+`--override` to get past the audience axis — that is the fail-open convention the purpose exists to
+remove.
 
 Work in **the epic's worktree, never the primary checkout** (#4934, #4167): `12` and `13` end
 `STOPPED`. `build tree` is called **without** `--issue` — that flag proves the branch carries the
@@ -59,9 +68,11 @@ claim's nonce, and this skill cuts no branch.
 
 Done when the claim answers `won`. **Read these codes off `build claim`, whose numbers above `11`
 are its own group's:** `15` is a proven loss (`BACKED-OFF`); `7` is a proven-absent or closed epic
-(`EPIC-UNPLANNABLE`); `20` or `21` is a proven admission refusal (`EPIC-NOT-ADMITTED`) — report
-which axis, and do not route around it with an override. Any other non-zero ends `STOPPED` with no
-note: you hold no claim, and `build note` requires one.
+(`EPIC-UNPLANNABLE`); `20` is a proven admission refusal on the scope axis (`EPIC-NOT-ADMITTED`) —
+report the axis, and do not route around it with an override. Exit `21` is no longer reachable at
+this step, because a `plan` claim is not bound by the audience axis. Any other non-zero ends
+`STOPPED` with no note — including `10`, an off-enum `--purpose`, which refuses rather than falling
+back to `build`: you hold no claim, and `build note` requires one.
 
 ## 2 — Open the run
 
@@ -238,10 +249,10 @@ epic — so read each code off the command that produced it and never off this l
 - `GROUND-STALE` — `20` from `ledger open`: the worktree is proven behind `origin/main`. **A
   back-off, terminal here** — nothing read into a plan, nothing written, no children. Refreshing
   the tree is outside this skill's capabilities and is a fresh run.
-- `EPIC-NOT-ADMITTED` — `20` or `21` from **`build claim`**: proven not admitted on the scope or
-  audience axis. **A back-off**; nothing read, nothing written, no claim held. Report which axis.
-  Whether a planning claim should face the audience fence is open (#5175) — bypassing it with the
-  override is not your answer to give.
+- `EPIC-NOT-ADMITTED` — `20` from **`build claim`**: proven not admitted on the scope axis. **A
+  back-off**; nothing read, nothing written, no claim held. Name the axis. `21` is not among this
+  skill's codes: step 1 claims with `--purpose plan`, and the audience axis binds build-purpose
+  claims only (#5175). Bypassing the scope axis with the override is not your answer to give.
 - `CHILD-ORPHANED` — `23` or `26` from `ledger child`: a child was created and something after the
   create could not be proven. **A back-off holding a real artifact.** On `23` the link is unproven
   and the child is in the run manifest, so name it from there. On `26` the manifest write itself

--- a/claude-plugins/fabrika/skills/plan-epic/contract.md
+++ b/claude-plugins/fabrika/skills/plan-epic/contract.md
@@ -33,9 +33,15 @@ two never meet: no verb here reads or writes an `epic` run ledger.
 
 **What fabrika already ships, reused — never respecified.** The claim is the **`build` group's,
 reused as landed verbs** ([`build`'s contract](../build/contract.md)) — the cross-contract shape
-`build-ui` sanctioned: this skill claims the epic with `fabrika build claim`, proves its worktree
-with `fabrika build tree`, releases with `fabrika build release`, and posts a successor note with
-`fabrika build note`. **No second lock is derived**, and v1's `epic-lock` is why: all five of its
+`build-ui` sanctioned: this skill claims the epic with `fabrika build claim --purpose plan`, proves
+its worktree with `fabrika build tree`, releases with `fabrika build release`, and posts a successor
+note with `fabrika build note`. The purpose is part of the reuse, not a detail of it: `build claim`'s
+audience axis asks whether an agent should pick the issue up to *build*, and an epic earns
+`ready-for:agent` only after this skill has planned it and the gate has passed it, so a `plan` claim
+is admitted without it (founder ruling,
+[#5175](https://github.com/kamp-us/phoenix/issues/5175)). The scope axis is unchanged by the purpose,
+so `20` stays reachable and `21` does not, and `--override` stays the exception it was.
+**No second lock is derived**, and v1's `epic-lock` is why: all five of its
 distinct outcomes collapse onto exit `1`
 (`packages/pipeline-cli/src/tools/epic-lock/command.ts:26,43-47`), it `POST`s the
 `status:planning` label *before* the claim comment so a failed claim leaves a held label with no

--- a/packages/fabrika-cli/src/build/claim-purpose.data.unit.test.ts
+++ b/packages/fabrika-cli/src/build/claim-purpose.data.unit.test.ts
@@ -1,0 +1,69 @@
+/**
+ * The #5175 ruling, enforced against the skills instead of only written down (#5217).
+ *
+ * The planning and gating lanes are exempt from the `ready-for:agent` audience fence, and the
+ * sanctioned route is `--purpose`, never `--override`. Nothing types that: each lane's claim is a
+ * shell line inside a markdown skill, so `plan-epic` shipped a bare `fabrika build claim` for a
+ * whole release while `audienceAxisBinds` was already exempting `plan` — the CLI was right and the
+ * instruction the agent actually executes was wrong. These are data tests over the real skill files,
+ * so dropping the flag turns the suite red.
+ */
+import {readFileSync} from "node:fs";
+import {fileURLToPath} from "node:url";
+import {assert, describe, it} from "@effect/vitest";
+import {audienceAxisBinds, type ClaimPurpose} from "./scope-admission.ts";
+
+/** The skill directory of each exempt lane, and the purpose its claim must carry (#5175). */
+const EXEMPT_LANES: Readonly<Record<string, ClaimPurpose>> = {
+	"plan-epic": "plan",
+	"check-epic-plan": "gate",
+};
+
+const skillSource = (skill: string): string =>
+	readFileSync(
+		fileURLToPath(
+			new URL(`../../../../claude-plugins/fabrika/skills/${skill}/SKILL.md`, import.meta.url),
+		),
+		"utf8",
+	);
+
+/** Every `fabrika build claim` command line in a skill — the lines an agent actually runs. */
+const claimInvocations = (source: string): ReadonlyArray<string> =>
+	source.split("\n").filter((line) => line.trimStart().startsWith("fabrika build claim"));
+
+describe("exempt lanes claim with a purpose, never an override (#5175)", () => {
+	for (const [skill, purpose] of Object.entries(EXEMPT_LANES)) {
+		// A lane whose claim vanished proves nothing, so zero scope is a failure (ADR 0092).
+		it(`${skill} invokes build claim at least once`, () => {
+			assert.isAtLeast(
+				claimInvocations(skillSource(skill)).length,
+				1,
+				`${skill}/SKILL.md has no 'fabrika build claim' line — this test would pass vacuously`,
+			);
+		});
+
+		it(`${skill} claims with --purpose ${purpose}`, () => {
+			assert.isFalse(
+				audienceAxisBinds(purpose),
+				`${purpose} is bound by the audience axis, so ${skill} would still be fenced`,
+			);
+			for (const line of claimInvocations(skillSource(skill))) {
+				assert.include(
+					line,
+					`--purpose ${purpose}`,
+					`${skill}/SKILL.md claims without --purpose ${purpose}, so the audience fence binds it (#5175)`,
+				);
+			}
+		});
+
+		it(`${skill} reaches for no --override`, () => {
+			for (const line of claimInvocations(skillSource(skill))) {
+				assert.notInclude(
+					line,
+					"--override",
+					`${skill}/SKILL.md routes around admission with --override — the purpose is the sanctioned route`,
+				);
+			}
+		});
+	}
+});


### PR DESCRIPTION
Fixes #5217

## What this is

The #5175 ruling exempts the planning and gating lanes from `fabrika build claim`'s
`ready-for:agent` audience fence. PR #5218 (issue #5183) shipped the CLI half and flipped
`check-epic-plan` to `--purpose gate`, but carved `plan-epic` out because
`claude-plugins/fabrika/skills/plan-epic/**` was a concurrent lane's surface at the time. That
carve-out was recorded in #5218's `## Deviations`; this PR discharges it. #5179, the lane that
owned those files, has since closed.

Until now the shipped instruction issued a **default `build`-purpose** claim, so the fence refused
on exit `21` for any epic carrying no `ready-for:` label — nearly every open epic. The CLI was
already right; the instruction the agent actually executes was wrong.

## The change

`claude-plugins/fabrika/skills/plan-epic/SKILL.md`

- Step 1 claims `fabrika build claim 4300 --purpose plan`, in the same shape `check-epic-plan` uses
  for `gate`, with the reason stated once at the invocation: the audience axis asks whether an agent
  should pick the issue up to *build*, and an epic earns `ready-for:agent` only after this skill has
  planned it and the gate has passed it, so fencing the planner on it is circular (#5175).
- Step 1's exit-code prose: `20` stays a reachable scope-axis refusal; `21` is called out as no
  longer reachable under a `plan` claim; `10` (an off-enum `--purpose`) is named as a refusal that
  never falls back to `build`.
- The `EPIC-NOT-ADMITTED` terminal is now scope-axis only, and its "whether a planning claim should
  face the audience fence is open (#5175)" line is replaced by the ruling's answer.

`claude-plugins/fabrika/skills/plan-epic/contract.md`

- The "reused from `build`" passage names `fabrika build claim --purpose plan` and states *why* the
  purpose is part of the reuse — the founder ruling in #5175 — plus that the scope axis is unchanged,
  so `20` stays reachable and `21` does not.

`packages/fabrika-cli/src/build/claim-purpose.data.unit.test.ts` (new, test-only)

- A data test over the real skill files: for each exempt lane (`plan-epic` → `plan`,
  `check-epic-plan` → `gate`), every `fabrika build claim` command line carries its ruled purpose and
  none reaches for `--override`. It fails closed on zero invocations (ADR 0092), so a lane whose
  claim line vanished cannot pass vacuously, and it asserts `audienceAxisBinds(purpose) === false` so
  the prose and the CLI cannot drift apart silently.

No `--override` is introduced anywhere. No production `packages/fabrika-cli/` source changed.

## Regression proof

The new test **fails against the pre-fix skill**. Restoring step 1's bare
`fabrika build claim 4300` and re-running:

```
FAIL src/build/claim-purpose.data.unit.test.ts > plan-epic claims with --purpose plan
AssertionError: plan-epic/SKILL.md claims without --purpose plan, so the audience fence binds it
(#5175): expected 'fabrika build claim 4300' to include '--purpose plan'
```

With the fix in place: 6 passed. Full `packages/fabrika-cli` suite: 196 files / 2814 tests passed.
`pnpm typecheck` clean across all 31 workspace tasks. `pnpm lint:worktree` clean.

## Deviations

**Acceptance criterion 5 says "No change to `packages/fabrika-cli/` in this unit; the CLI half ships
in #5183/#5218." This PR adds one file under `packages/fabrika-cli/` anyway.** It is a test-only
file — a data test that reads the two skill markdown files — and it changes no CLI production source,
no verb, no exit code, and no runtime behaviour. The criterion's stated reason (the CLI half ships in
#5183/#5218) is untouched by it.

I made this call rather than shipping the prose bare because this defect *is* a prose-versus-CLI
drift: `audienceAxisBinds` already exempted `plan` while the skill's shell line did not, and nothing
in the repo could catch that. Without a test, the same drift can recur on the next skill edit. If the
reviewer holds AC 5 literally, the remedy is to delete that one file; the other four criteria stand
without it.

**Sequencing note, not a defect:** #5220 proposes a separate correction to this same
`contract.md`'s `## Dependencies` illustration (around line 200). This PR touches only the reuse
passage near the top of the file, so the two edits do not overlap — but they land in one file and
should not be merged blind against each other.

No other known-unfixed defect exists in this diff.

## Cross-references

- #5183 — the purpose axis; this PR discharges its ninth acceptance criterion (the `plan-epic` half).
- #5175 — the founder ruling that the audience fence binds build-purpose claims only.
- #5218 — the PR that shipped the CLI half and recorded this residual in its `## Deviations`.
