### PR TITLE
fix(fabrika-cli): scope the exit-code alignment guard to the shipped verb registry (#5213)

### DIFF
--- a/packages/fabrika-cli/src/eval/codes.ts
+++ b/packages/fabrika-cli/src/eval/codes.ts
@@ -1,0 +1,55 @@
+/**
+ * The one exit table every `eval` verb allocates from, so a code means one thing across the group.
+ *
+ * Before this table the group seated *every* refusal on `1` — a decoded-and-invalid manifest and a
+ * manifest that could not be read exited alike, so a caller reading `$?` could not tell a verdict
+ * the verb PROVED from a failure to invoke it (`../verb.ts`, #4208/#4219). What stays on `1` is
+ * exactly what the convention reserves it for: a usage error (a flag naming something that is not a
+ * stage, a surface, or an arm) and a read that failed before the verb could judge anything.
+ *
+ * The two shared seats are **imported from the base, never re-typed** — the discipline
+ * `../review-ui/codes.ts` states, and the reason `../exit-code-alignment.ts` can check them. `12`
+ * and up are this group's own.
+ *
+ * `0`, `1` and `127` are reserved by the interface convention (`../verb.ts`).
+ */
+
+import {
+	BAD_SECTIONS as REPORT_BAD_SECTIONS,
+	NO_TARGET as REPORT_NO_TARGET,
+} from "../report/codes.ts";
+
+/**
+ * A named artifact was read in full and does not conform: a corpus manifest, a runner-rows file, a
+ * `/skill-creator` eval set, a ruled-KEEP enumeration, or a provenance ledger.
+ *
+ * The base's section seat, widened to whole documents the same way `../review-ui/codes.ts` widens
+ * it. Deliberately not `1`: the bytes were in hand and the schema answered, so this is a fact about
+ * the artifact. A read that never produced bytes is the `1` above.
+ */
+export const MALFORMED_DOCUMENT = REPORT_BAD_SECTIONS;
+
+/**
+ * Zero scope, proven: the artifact decodes and carries no eval cases (ADR 0092).
+ *
+ * A suite that ran nothing and exited 0 is the vacuous pass the ADR forbids, so the emptiness is an
+ * outcome with its own seat rather than a green with a caveat on stderr.
+ */
+export const ZERO_SCOPE = REPORT_NO_TARGET;
+
+/**
+ * Proven: the ruled-KEEP enumeration decodes but breaks its own integrity rules.
+ *
+ * Its own seat rather than {@link MALFORMED_DOCUMENT} because the caller's remedy differs — the
+ * schema is satisfied, so no decoder change can help; a human has to reconcile the membership list.
+ */
+export const INTEGRITY_VIOLATION = 12;
+
+/**
+ * Proven: the suite completed and at least one planned run did not execute.
+ *
+ * Not a failed invocation — the runner ran, the ledger is on stdout, and this reports only that the
+ * evidence is incomplete. Whether the executed runs *passed* is the oracle's answer downstream, and
+ * never this code.
+ */
+export const RUNS_NOT_EXECUTED = 13;

--- a/packages/fabrika-cli/src/eval/command.ts
+++ b/packages/fabrika-cli/src/eval/command.ts
@@ -21,13 +21,16 @@
  * two-artifact join every consumer used to re-run by hand.
  *
  * Thin IO shell over the pure cores (the `token-spend` / `readme-guard` idiom): read the file,
- * decode, render. An unreadable path and a malformed/mismatched input both exit non-zero.
+ * decode, render. Every refusal seats on `./codes.ts` — an unreadable path exits `FAILED`, an
+ * outcome the verb proved exits on its own code.
  */
 import {Console, Crypto, Effect, FileSystem, Path, Result} from "effect";
 import * as Schema from "effect/Schema";
 import {Argument, Command, Flag} from "effect/unstable/cli";
 import {leafCommand} from "../excess-operand.ts";
 import {DEFAULT_SPEND_LEDGER_PATH, persistSpendRows} from "../spend/ledger.ts";
+import {FAILED} from "../verb.ts";
+import {INTEGRITY_VIOLATION, MALFORMED_DOCUMENT, RUNS_NOT_EXECUTED, ZERO_SCOPE} from "./codes.ts";
 import {decodeManifest, REVIEW_SURFACES, type ReviewSurface, STAGES} from "./corpus.ts";
 import {decodeIncidentProvenance} from "./incident-provenance.ts";
 import {
@@ -60,8 +63,6 @@ import {
 } from "./spawn.ts";
 import {claudeExecutor, claudeVersion, locateTranscript, readTranscript} from "./spawn-io.ts";
 
-const GATE_FAIL_EXIT_CODE = 1;
-
 // A named manifest path that could not be read — a hard error (exit 1), not a skip.
 class ManifestUnreadable extends Schema.TaggedErrorClass<ManifestUnreadable>()(
 	"ManifestUnreadable",
@@ -89,7 +90,7 @@ const check = leafCommand(
 				yield* Console.error(
 					`fabrika eval: ${manifest} is not a valid corpus manifest (${result.failure.reason}): ${result.failure.message}`,
 				);
-				return yield* Effect.sync(() => process.exit(GATE_FAIL_EXIT_CODE));
+				return yield* Effect.sync(() => process.exit(MALFORMED_DOCUMENT));
 			}
 			yield* Console.log(`fabrika eval: ${manifest} is a valid corpus manifest.`);
 		});
@@ -97,7 +98,7 @@ const check = leafCommand(
 			Effect.catchTag("ManifestUnreadable", (e) =>
 				Effect.gen(function* () {
 					yield* Console.error(`fabrika eval: cannot read manifest ${e.path}`);
-					return yield* Effect.sync(() => process.exit(GATE_FAIL_EXIT_CODE));
+					return yield* Effect.sync(() => process.exit(FAILED));
 				}),
 			),
 		);
@@ -173,7 +174,7 @@ const report = leafCommand(
 				yield* Console.error(
 					`fabrika eval: ${rows} is not a valid runner-rows file (${decoded.failure.reason}): ${decoded.failure.message}`,
 				);
-				return yield* Effect.sync(() => process.exit(GATE_FAIL_EXIT_CODE));
+				return yield* Effect.sync(() => process.exit(MALFORMED_DOCUMENT));
 			}
 
 			// A --baseline-stage that isn't one of the known stages is a user error, not a silent
@@ -188,19 +189,19 @@ const report = leafCommand(
 					yield* Console.error(
 						`fabrika eval: --baseline-stage '${stage}' is not a known stage (${STAGES.join(", ")})`,
 					);
-					return yield* Effect.sync(() => process.exit(GATE_FAIL_EXIT_CODE));
+					return yield* Effect.sync(() => process.exit(FAILED));
 				}
 				if (baselineSurface._tag === "Some" && stage !== "review") {
 					yield* Console.error(
 						`fabrika eval: --baseline-surface only applies to --baseline-stage review, not '${stage}'`,
 					);
-					return yield* Effect.sync(() => process.exit(GATE_FAIL_EXIT_CODE));
+					return yield* Effect.sync(() => process.exit(FAILED));
 				}
 				if (stage === "review" && baselineSurface._tag === "None") {
 					yield* Console.error(
 						`fabrika eval: --baseline-stage review needs --baseline-surface (${REVIEW_SURFACES.join(", ")}) — a review pass-rate is one grading regime, never an average of two`,
 					);
-					return yield* Effect.sync(() => process.exit(GATE_FAIL_EXIT_CODE));
+					return yield* Effect.sync(() => process.exit(FAILED));
 				}
 				const model = baselineModel._tag === "Some" ? baselineModel.value : null;
 				if (baselineSurface._tag === "Some") {
@@ -209,7 +210,7 @@ const report = leafCommand(
 						yield* Console.error(
 							`fabrika eval: --baseline-surface '${surface}' is not a known review surface (${REVIEW_SURFACES.join(", ")})`,
 						);
-						return yield* Effect.sync(() => process.exit(GATE_FAIL_EXIT_CODE));
+						return yield* Effect.sync(() => process.exit(FAILED));
 					}
 					baseline = {stage, surface, model};
 				} else {
@@ -226,7 +227,7 @@ const report = leafCommand(
 			Effect.catchTag("RowsUnreadable", (e) =>
 				Effect.gen(function* () {
 					yield* Console.error(`fabrika eval: cannot read runner-rows file ${e.path}`);
-					return yield* Effect.sync(() => process.exit(GATE_FAIL_EXIT_CODE));
+					return yield* Effect.sync(() => process.exit(FAILED));
 				}),
 			),
 		);
@@ -263,7 +264,7 @@ const cases = leafCommand(
 				yield* Console.error(
 					`fabrika eval: ${path} is not a valid skill eval set (${result.failure.reason}): ${result.failure.message}`,
 				);
-				return yield* Effect.sync(() => process.exit(GATE_FAIL_EXIT_CODE));
+				return yield* Effect.sync(() => process.exit(MALFORMED_DOCUMENT));
 			}
 			const set = result.success;
 			// A schema-valid set with zero cases would report green while checking nothing — the
@@ -272,7 +273,7 @@ const cases = leafCommand(
 				yield* Console.error(
 					`fabrika eval: ${path} is not a usable skill eval set (empty-set): it decodes, but carries zero eval cases (ADR 0092 — zero scope reds)`,
 				);
-				return yield* Effect.sync(() => process.exit(GATE_FAIL_EXIT_CODE));
+				return yield* Effect.sync(() => process.exit(ZERO_SCOPE));
 			}
 			const counts = tierCounts(set);
 			yield* Console.log(
@@ -288,7 +289,7 @@ const cases = leafCommand(
 			Effect.catchTag("EvalSetUnreadable", (e) =>
 				Effect.gen(function* () {
 					yield* Console.error(`fabrika eval: cannot read eval set ${e.path}`);
-					return yield* Effect.sync(() => process.exit(GATE_FAIL_EXIT_CODE));
+					return yield* Effect.sync(() => process.exit(FAILED));
 				}),
 			),
 		);
@@ -398,27 +399,27 @@ const runCommand = leafCommand(
 				yield* Console.error(
 					`fabrika eval: ${opts.path} is not a valid skill eval set (${decoded.failure.reason}): ${decoded.failure.message}`,
 				);
-				return yield* Effect.sync(() => process.exit(GATE_FAIL_EXIT_CODE));
+				return yield* Effect.sync(() => process.exit(MALFORMED_DOCUMENT));
 			}
 			const set = decoded.success;
 			if (set.cases.length === 0) {
 				yield* Console.error(
 					`fabrika eval: ${opts.path} carries zero eval cases — refusing to report a green suite that ran nothing (ADR 0092)`,
 				);
-				return yield* Effect.sync(() => process.exit(GATE_FAIL_EXIT_CODE));
+				return yield* Effect.sync(() => process.exit(ZERO_SCOPE));
 			}
 			if (!isStageName(opts.stage)) {
 				yield* Console.error(
 					`fabrika eval: --stage '${opts.stage}' is not a known stage (${STAGES.join(", ")})`,
 				);
-				return yield* Effect.sync(() => process.exit(GATE_FAIL_EXIT_CODE));
+				return yield* Effect.sync(() => process.exit(FAILED));
 			}
 			const arms = parseArms(opts.arms);
 			if (arms === null) {
 				yield* Console.error(
 					`fabrika eval: --arms '${opts.arms}' names something that is not an arm (${EVAL_ARMS.join(", ")})`,
 				);
-				return yield* Effect.sync(() => process.exit(GATE_FAIL_EXIT_CODE));
+				return yield* Effect.sync(() => process.exit(FAILED));
 			}
 
 			let jsonSchema: string | null = null;
@@ -488,14 +489,14 @@ const runCommand = leafCommand(
 				yield* Console.error(
 					`fabrika eval: ${ledger.summary.failed} of ${ledger.summary.planned} run(s) did not execute — ${JSON.stringify(ledger.summary.byFailure)}`,
 				);
-				return yield* Effect.sync(() => process.exit(GATE_FAIL_EXIT_CODE));
+				return yield* Effect.sync(() => process.exit(RUNS_NOT_EXECUTED));
 			}
 		});
 		yield* run.pipe(
 			Effect.catchTag("EvalSetUnreadable", (e) =>
 				Effect.gen(function* () {
 					yield* Console.error(`fabrika eval: cannot read ${e.path}`);
-					return yield* Effect.sync(() => process.exit(GATE_FAIL_EXIT_CODE));
+					return yield* Effect.sync(() => process.exit(FAILED));
 				}),
 			),
 		);
@@ -547,14 +548,14 @@ const keeps = leafCommand(
 				yield* Console.error(
 					`fabrika eval: ${opts.path} is not a valid ruled-KEEP enumeration (${decoded.failure.reason}): ${decoded.failure.message}`,
 				);
-				return yield* Effect.sync(() => process.exit(GATE_FAIL_EXIT_CODE));
+				return yield* Effect.sync(() => process.exit(MALFORMED_DOCUMENT));
 			}
 			const violations = ruledKeepsViolations(decoded.success);
 			if (violations.length > 0) {
 				yield* Console.error(
 					`fabrika eval: ${opts.path} decodes but breaks its own integrity rules:\n${violations.map((v) => `  - ${v}`).join("\n")}`,
 				);
-				return yield* Effect.sync(() => process.exit(GATE_FAIL_EXIT_CODE));
+				return yield* Effect.sync(() => process.exit(INTEGRITY_VIOLATION));
 			}
 
 			const ledgerPath =
@@ -570,7 +571,7 @@ const keeps = leafCommand(
 				yield* Console.error(
 					`fabrika eval: ${ledgerPath} is not a valid provenance ledger (${ledger.failure.reason}): ${ledger.failure.message}`,
 				);
-				return yield* Effect.sync(() => process.exit(GATE_FAIL_EXIT_CODE));
+				return yield* Effect.sync(() => process.exit(MALFORMED_DOCUMENT));
 			}
 
 			const covered = withCoverage(decoded.success, ledger.success);
@@ -582,7 +583,7 @@ const keeps = leafCommand(
 			Effect.catchTag("KeepsUnreadable", (e) =>
 				Effect.gen(function* () {
 					yield* Console.error(`fabrika eval: cannot read ${e.path}`);
-					return yield* Effect.sync(() => process.exit(GATE_FAIL_EXIT_CODE));
+					return yield* Effect.sync(() => process.exit(FAILED));
 				}),
 			),
 		);

--- a/packages/fabrika-cli/src/exit-code-alignment.ts
+++ b/packages/fabrika-cli/src/exit-code-alignment.ts
@@ -20,6 +20,13 @@
  * Not every group aligns. `wire` allocates `3`-`6` for entirely different facts and is right to —
  * see {@link UNALIGNED_GROUPS}, which lists it rather than omitting it, because an omission is
  * indistinguishable from a group nobody registered.
+ *
+ * **What the guard scans is the shipped verb registry, not the tables on disk (#5213).** Scoping
+ * the coverage check to directories that hold a `codes.ts` made the group with the loosest exit
+ * discipline the one it could not see: `eval` shipped no table, so it was absent from the scan and
+ * absent from both registries, and the check stayed green over it. A group is now checked because
+ * `registry.ts` ships it, so the only way to leave one unchecked is to not ship it at all —
+ * {@link coverageGaps} takes the registered names and reds on any it cannot classify.
  */
 
 import {existsSync, readdirSync, realpathSync} from "node:fs";
@@ -93,9 +100,20 @@ export const UI_SEATS: SharedSeats = (() => {
  */
 export const HOOK_SEATS: SharedSeats = {EMPTY_STDIN: "EMPTY_STDIN"};
 
+/**
+ * `eval`'s seats: two. Its verbs neither read stdin nor write anything, so most of the base's table
+ * is about facts they cannot establish; what they do establish is that a named JSON artifact is
+ * malformed, and that a decoded eval set carries nothing to run.
+ */
+export const EVAL_SEATS: SharedSeats = {
+	MALFORMED_DOCUMENT: "BAD_SECTIONS",
+	ZERO_SCOPE: "NO_TARGET",
+};
+
 /** The groups that align to {@link ALIGNMENT_BASE}, each with the seats it claims to share. */
 export const ALIGNED_GROUPS: Readonly<Record<string, SharedSeats>> = {
 	build: BUILD_SEATS,
+	eval: EVAL_SEATS,
 	hook: HOOK_SEATS,
 	epic: BUILD_SEATS,
 	ledger: BUILD_SEATS,
@@ -109,11 +127,90 @@ export const ALIGNED_GROUPS: Readonly<Record<string, SharedSeats>> = {
 
 /**
  * The groups that deliberately do **not** align, and the reason each is exempt. A group listed here
- * is a decision; a group listed nowhere is drift, which is what
- * {@link codeTableGroupsIn} exists to surface.
+ * is a decision; a group listed nowhere is drift, which is what {@link coverageGaps} exists to
+ * surface.
  */
 export const UNALIGNED_GROUPS: Readonly<Record<string, string>> = {
 	wire: "3-6 are ABSENT / MALFORMED / EMPTY_ARTIFACT / ARTIFACT_UNKNOWN — a different vocabulary about artifacts, not about writes",
+};
+
+/**
+ * The registered groups that ship no `<group>/codes.ts` at all, and the tracked reason each is
+ * still unchecked.
+ *
+ * This is an admission, not an exemption: neither entry is a decision that a group table is
+ * unwarranted, only a record that these two allocate their codes per-verb and nobody has re-seated
+ * them yet. Listing them is what lets {@link coverageGaps} treat *any other* untabled group as the
+ * failure it is, instead of the silence that hid `eval`.
+ */
+export const UNTABLED_GROUPS: Readonly<Record<string, string>> = {
+	adr: "allocates proven codes per-verb (relate-verb's NO_SUBJECT is 3, sweep-verb's is 4) rather than from a group table — #5294",
+	spend:
+		"allocates proven codes per-verb across read-verb and rollup-verb rather than from a group table — #5294",
+};
+
+/** Every group this module has an answer for, whichever of the three registries holds it. */
+export const classifiedGroups = (): ReadonlySet<string> =>
+	new Set([
+		ALIGNMENT_BASE,
+		...Object.keys(ALIGNED_GROUPS),
+		...Object.keys(UNALIGNED_GROUPS),
+		...Object.keys(UNTABLED_GROUPS),
+	]);
+
+/** What a scan of the shipped registry against this module's registries turned up. */
+export interface CoverageGaps {
+	/**
+	 * Groups classified nowhere here — shipped by the registry, carrying a table on disk, or both.
+	 * Non-empty means the guard is blind to one, which is the defect it exists to red on.
+	 */
+	readonly unclassified: readonly string[];
+	/** Groups classified here that the registry no longer ships — a stale registration. */
+	readonly unshipped: readonly string[];
+	/** Groups recorded as untabled that do ship a `codes.ts` — the record is out of date. */
+	readonly untabledWithTable: readonly string[];
+	/** Groups classified as base/aligned/unaligned that ship no `codes.ts` to check. */
+	readonly tableMissing: readonly string[];
+}
+
+/** A scan that had nothing to scan, so its all-clear would mean nothing (ADR 0092). */
+export class ZeroCoverageScope extends Error {}
+
+/**
+ * Every gap between what `registry.ts` ships and what this module classifies. Empty arrays are the
+ * covered state.
+ *
+ * Takes the registered names rather than importing the registry so this module stays loadable
+ * without constructing the whole CLI; the caller passes `registeredGroups.map((g) => g.name)`.
+ *
+ * Throws on an empty scan on either side. An all-clear derived from nothing is the vacuous pass ADR
+ * 0092 forbids, and it is the shape that would return here first: a registry that failed to load
+ * would report zero groups and therefore zero gaps.
+ */
+export const coverageGaps = (input: {
+	readonly registered: readonly string[];
+	readonly onDisk: readonly string[];
+}): CoverageGaps => {
+	if (input.registered.length === 0) {
+		throw new ZeroCoverageScope("no verb groups were registered — nothing to check (ADR 0092)");
+	}
+	if (input.onDisk.length === 0) {
+		throw new ZeroCoverageScope("no `<group>/codes.ts` was found on disk (ADR 0092)");
+	}
+
+	const registered = new Set(input.registered);
+	const onDisk = new Set(input.onDisk);
+	const classified = classifiedGroups();
+	const untabled = new Set(Object.keys(UNTABLED_GROUPS));
+
+	return {
+		unclassified: [...new Set([...input.registered, ...input.onDisk])]
+			.filter((name) => !classified.has(name))
+			.sort(),
+		unshipped: [...classified].filter((name) => !registered.has(name)).sort(),
+		untabledWithTable: [...untabled].filter((name) => onDisk.has(name)).sort(),
+		tableMissing: [...classified].filter((name) => !untabled.has(name) && !onDisk.has(name)).sort(),
+	};
 };
 
 /**
@@ -200,9 +297,10 @@ export const checkAlignment = (
 };
 
 /**
- * The `<group>/codes.ts` tables that actually exist on disk, so a new group is a registry failure
- * rather than an unchecked table. Paths resolve physically — a `..` folded across the repo's
- * `.claude/skills` symlink resolves somewhere else entirely.
+ * The `<group>/codes.ts` tables that actually exist on disk — one of {@link coverageGaps}'s two
+ * inputs, and on its own never the scan's scope: a group with no table is exactly what this read
+ * cannot see (#5213). Paths resolve physically — a `..` folded across the repo's `.claude/skills`
+ * symlink resolves somewhere else entirely.
  */
 export const codeTableGroupsIn = (srcDir: string): readonly string[] => {
 	const root = realpathSync(srcDir);

--- a/packages/fabrika-cli/src/exit-code-alignment.unit.test.ts
+++ b/packages/fabrika-cli/src/exit-code-alignment.unit.test.ts
@@ -2,17 +2,22 @@ import {fileURLToPath} from "node:url";
 import {describe, expect, it} from "vitest";
 import * as build from "./build/codes.ts";
 import * as epic from "./epic/codes.ts";
+import * as evalCodes from "./eval/codes.ts";
 import {
 	ALIGNED_GROUPS,
 	ALIGNMENT_BASE,
 	type CodeTable,
 	checkAlignment,
 	codeTableGroupsIn,
+	coverageGaps,
 	UNALIGNED_GROUPS,
+	UNTABLED_GROUPS,
+	ZeroCoverageScope,
 } from "./exit-code-alignment.ts";
 import * as hook from "./hook/codes.ts";
 import * as ledger from "./ledger/codes.ts";
 import * as plan from "./plan/codes.ts";
+import {registeredGroups} from "./registry.ts";
 import * as report from "./report/codes.ts";
 import * as review from "./review/codes.ts";
 import * as reviewUi from "./review-ui/codes.ts";
@@ -31,6 +36,7 @@ const SRC_DIR = fileURLToPath(new URL(".", import.meta.url));
 const TABLES: Readonly<Record<string, CodeTable>> = {
 	build,
 	epic,
+	eval: evalCodes,
 	hook,
 	ledger,
 	plan,
@@ -43,24 +49,80 @@ const TABLES: Readonly<Record<string, CodeTable>> = {
 	wire,
 };
 
-describe("every `<group>/codes.ts` in this package is accounted for", () => {
+describe("every verb group the CLI ships is accounted for", () => {
+	const shipped = registeredGroups.map((group) => group.name);
 	const onDisk = codeTableGroupsIn(SRC_DIR);
+	const gaps = () => coverageGaps({registered: shipped, onDisk});
 
-	it("finds tables at all — a scan over nothing is a failure, not a pass (ADR 0092)", () => {
+	it("finds groups and tables at all — a scan over nothing is a failure, not a pass (ADR 0092)", () => {
+		expect(shipped.length).toBeGreaterThan(0);
 		expect(onDisk.length).toBeGreaterThan(0);
 	});
 
-	it("classifies each one as the base, aligned, or deliberately unaligned", () => {
-		const registered = new Set([
+	it("classifies each as the base, aligned, deliberately unaligned, or recorded untabled", () => {
+		expect(gaps().unclassified).toEqual([]);
+	});
+
+	it("classifies nothing the CLI no longer ships", () => {
+		expect(gaps().unshipped).toEqual([]);
+	});
+
+	it("keeps the untabled record true in both directions", () => {
+		expect(gaps().untabledWithTable).toEqual([]);
+		expect(gaps().tableMissing).toEqual([]);
+	});
+
+	it("holds a module for each table on disk, so no checked group is checked against nothing", () => {
+		expect(Object.keys(TABLES).sort()).toEqual([...onDisk].sort());
+	});
+});
+
+/**
+ * The blindness itself, pinned (#5213). Scoping the scan to `codes.ts` files made a group that
+ * ships none unreachable by the check — so it could sit in no registry and the suite stayed green.
+ * These assert the property that removes it: scope comes from what is shipped, and an empty scan
+ * is a throw rather than an all-clear.
+ */
+describe("the coverage scan can see a group that ships no table", () => {
+	it("reports a shipped group with no table and no registration", () => {
+		expect(
+			coverageGaps({registered: [ALIGNMENT_BASE, "ghost"], onDisk: [ALIGNMENT_BASE]}),
+		).toMatchObject({unclassified: ["ghost"]});
+	});
+
+	it("reports a table on disk that no registry classifies", () => {
+		expect(
+			coverageGaps({registered: [ALIGNMENT_BASE], onDisk: [ALIGNMENT_BASE, "ghost"]}),
+		).toMatchObject({unclassified: ["ghost"]});
+	});
+
+	it("throws rather than reporting no gaps when there is nothing to scan (ADR 0092)", () => {
+		expect(() => coverageGaps({registered: [], onDisk: [ALIGNMENT_BASE]})).toThrow(
+			ZeroCoverageScope,
+		);
+		expect(() => coverageGaps({registered: [ALIGNMENT_BASE], onDisk: []})).toThrow(
+			ZeroCoverageScope,
+		);
+	});
+});
+
+/**
+ * The untabled record is an admission of a tracked gap, not a way to opt out of the guard: each
+ * entry must name a reason, and none may be a group that already carries a table.
+ */
+describe("the untabled groups are genuinely untabled", () => {
+	it("states a reason for each", () => {
+		expect(Object.keys(UNTABLED_GROUPS).length).toBeGreaterThan(0);
+		for (const reason of Object.values(UNTABLED_GROUPS)) expect(reason).not.toEqual("");
+	});
+
+	it("names no group that also appears in an alignment registry", () => {
+		const aligned = new Set([
 			ALIGNMENT_BASE,
 			...Object.keys(ALIGNED_GROUPS),
 			...Object.keys(UNALIGNED_GROUPS),
 		]);
-		expect([...onDisk].sort()).toEqual([...registered].sort());
-	});
-
-	it("holds a module for each, so no registered group is checked against nothing", () => {
-		expect(Object.keys(TABLES).sort()).toEqual([...onDisk].sort());
+		expect(Object.keys(UNTABLED_GROUPS).filter((name) => aligned.has(name))).toEqual([]);
 	});
 });
 


### PR DESCRIPTION
Fixes #5213

## What changed

Two defects, one root. The root was the guard's scope.

**The guard can now see a group that ships no table.** `codeTableGroupsIn` finds directories holding a `codes.ts`, and the coverage test used that as its *scope*. A group with no table was therefore not in the set being checked, so it could sit in no registry and the assertion stayed green — over the group with the loosest exit discipline in the package. Scope now comes from `registry.ts`: a group is checked because the CLI ships it. `coverageGaps` reports four gaps and the test reds on each:

- `unclassified` — a group shipped by the registry, or carrying a table on disk, that no registry here classifies. This is the blindness, pinned.
- `unshipped` — a registration for a group the CLI no longer ships.
- `untabledWithTable` / `tableMissing` — the untabled record gone stale in either direction.

It throws `ZeroCoverageScope` rather than reporting no gaps when either side of the scan is empty (ADR 0092) — a registry that failed to load would otherwise report zero groups and therefore zero gaps.

`UNTABLED_GROUPS` records `adr` and `spend` as the two remaining registered groups with no table, each with the reason it is still unchecked and a tracking issue. That is what lets the guard treat *any other* untabled group as a failure instead of silence.

**`eval` gets a table and its refusals get seated on it.** `packages/fabrika-cli/src/eval/codes.ts` imports `MALFORMED_DOCUMENT` and `ZERO_SCOPE` from the base rather than restating the numerals (the `review-ui` discipline), and adds `INTEGRITY_VIOLATION = 12` and `RUNS_NOT_EXECUTED = 13` on its own account. `eval` is registered in `ALIGNED_GROUPS`.

All 21 `process.exit` sites in `eval/command.ts` are re-seated. `GATE_FAIL_EXIT_CODE = 1` is gone:

- 6 → `MALFORMED_DOCUMENT` (a named JSON artifact read in full that does not conform)
- 2 → `ZERO_SCOPE` (an eval set that decodes and carries zero cases)
- 1 → `INTEGRITY_VIOLATION` (`keeps`: decodes, breaks its own integrity rules — its own seat because no decoder change helps)
- 1 → `RUNS_NOT_EXECUTED` (`run`: the suite completed, some planned runs did not execute)
- 11 → `FAILED` from `verb.ts` (six flag-value usage errors, and five catch-arms — `check`, `report`, `cases`, `run`, `keeps` — where the read failed before the verb could judge anything) — correctly still `1`, which is what the convention reserves it for

## The regression test fails against pre-fix code

Verified by removing `eval: EVAL_SEATS` from `ALIGNED_GROUPS` and re-running:

```
× classifies each as the base, aligned, deliberately unaligned, or recorded untabled
  AssertionError: expected [ 'eval' ] to deeply equal []
```

That is the acceptance criterion's own check. The old assertion could not produce it: with no `eval/codes.ts` on disk, `eval` was not in `onDisk`, so `onDisk == registered` held and the suite was green. Three further tests pin the property directly rather than the instance — a shipped group with no table and no registration is reported, a table on disk that no registry classifies is reported, and an empty scan throws instead of returning no gaps.

## Verification

- `pnpm typecheck` — 31/31 tasks pass
- `packages/fabrika-cli` suite — 195 files, 2825 tests pass
- `pnpm lint:worktree` — clean

## Deviations

- **`adr` and `spend` are recorded, not fixed.** Both allocate proven codes per-verb rather than from a group table, and `adr` already collides with itself (`relate-verb.ts` seats `NO_SUBJECT = 3`, `sweep-verb.ts` seats it `4`). The issue's triage note scoped them out; the change makes them visible in `UNTABLED_GROUPS` with a stated reason. Follow-up filed as #5294. Naming them "untabled" is an admission of a tracked gap, and the guard asserts each entry carries a reason and that none of them actually ships a table.
- **`eval/command.ts` still calls `process.exit` directly rather than returning `VerbOutcome`s through `verb.ts`'s `answer`/`refuse`.** The issue notes `eval` imports nothing from `verb.ts`; this imports `FAILED` and seats every refusal on a named constant, which is what the acceptance criteria ask for. Converting the five verbs to pure `VerbOutcome`-returning cores with a thin adapter is a larger refactor and is not in this diff.
- **No ADR.** This applies existing decisions (`verb.ts`'s reserved-code convention, ADR 0092's zero-scope rule) rather than making a new one.

