### PR TITLE
fix(fabrika): a readable-but-empty .decisions/ mints 0001 instead of exiting 5

### DIFF
--- a/claude-plugins/fabrika/skills/adr/SKILL.md
+++ b/claude-plugins/fabrika/skills/adr/SKILL.md
@@ -20,6 +20,12 @@ at `0150` while origin is at `0151` cannot mint a duplicate.
 **A non-zero exit is UNKNOWN, never "nothing reserved."** Re-run it. Falling back to the highest id
 on disk is what minted ADR 0198 from two lanes at once, and 0114 and 0123 before it (#3779).
 
+**An empty `.decisions/` is not one of those cases — it answers `0001` and exits 0.** A repo adopting
+fabrika has no records on day one, and that is a fact the verb reports, not a read it failed. Only a
+directory it could not read at all refuses (exit 6). If `.decisions/` does not exist yet, create it
+and re-run; a repo with no decision directory at all is a setup question for
+[front-door](../front-door/SKILL.md).
+
 ## 2 — Write the decision
 
 ```bash

--- a/claude-plugins/fabrika/skills/adr/contract.md
+++ b/claude-plugins/fabrika/skills/adr/contract.md
@@ -102,7 +102,11 @@ first-free would answer `0238`.
 | `1` | usage error, or the verb failed to run |
 | `3` | `--base` could not be fetched, so the merged set is UNKNOWN |
 | `4` | the open pull requests could not be enumerated, so the in-flight set is UNKNOWN |
-| `5` | `--dir` was read and held zero `NNNN-slug.md` records — zero scope |
+| `6` | `--dir` could not be read at the fetched `--base`, so the merged set is UNKNOWN |
+
+`5` is a **vacated** seat, not a free one: it meant "read and empty — refusing" until #5254 made that
+state an answer, and re-seating a new meaning on it would hand a caller pinned to the old reading a
+wrong answer under a familiar number.
 
 **Errors**
 
@@ -111,7 +115,7 @@ first-free would answer `0238`.
 | `adr next: cannot fetch <ref>: <reason> — the merged set is UNKNOWN. Re-run; do not answer from the local tree.` | 3 | refusal |
 | `adr next: cannot enumerate open pull requests in <repo>: <reason> — the in-flight set is UNKNOWN, never "nothing reserved". Re-run; do not fall back to the on-disk id.` | 4 | refusal |
 | `adr next: cannot read PR #<n>'s file list: <reason> — the in-flight set is INCOMPLETE, so it is UNKNOWN.` | 4 | refusal |
-| `adr next: scanned <dir> at <ref>, 0 decision records — refusing to answer (ADR 0092).` | 5 | refusal |
+| `adr next: cannot read <dir> at <ref>: <reason> — the merged set is UNKNOWN, never "0 records".` | 6 | refusal |
 | `adr next: <dir> holds a record with an unparseable id: <name>` | 1 | refusal |
 
 **Scope** — every `NNNN-slug.md` under `--dir` **as of the fetched `--base`**, plus every open pull
@@ -121,9 +125,11 @@ produced the answer.
 
 The two halves fail differently, and the difference is load-bearing:
 
-- **Zero records is a failed read, not an answer.** This repo always has decision records, so an
-  empty scan means the wrong directory or a broken read, and answering `0001` would collide with
-  every existing record.
+- **An empty merged set is a fact, and the answer is `0001`.** The read itself proves the directory:
+  the merged set is read as `git ls-tree <base-sha>:<dir>`, which fails outright when `<dir>` is not
+  in the tree, so a listing that comes back empty is a directory that **exists and holds nothing** —
+  a repo adopting fabrika on day one. Only a directory that could not be read is UNKNOWN, and that is
+  exit `6`. The two states never share a code (#5254).
 - **An empty in-flight set is a fact — but only on exit 0.** No open ADR pull request is a normal
   state. An in-flight set that could not be read is exit 4 and prints nothing on stdout, because a
   caller that reads an empty set as "nothing reserved" silently falls back to the on-disk id, which
@@ -139,6 +145,14 @@ $ fabrika adr next
 ```
 $ fabrika adr next --json
 {"id":"0240","mergedMax":"0236","inFlight":["0237","0239"],"baseRef":"origin/main","baseSha":"49a22902d1e0c7b3f5a8e4126b9d0f3c7a1e5b82"}
+```
+
+An adopting repo whose `.decisions/` exists and holds no records — the merged set is empty, no open
+pull request claims an id, so `max(∅ ∪ ∅) + 1` is the first id:
+
+```
+$ fabrika adr next
+0001
 ```
 
 ```
@@ -163,7 +177,11 @@ $ echo $?
   `max(union) + 1` answers `0238`. **The divergence is real and needs an ADR that amends 0074 rather
   than a spec that quietly outvotes it** — an implementer should not resolve this alone. Tracked on
   #3779.
-- ADR 0092 — zero scope reds; an empty record scan is a refusal, not `0001`.
+- ADR 0092 — zero scope reds **for a gate**, whose empty scan means it checked nothing. An allocator
+  is not a gate, and 0092's own Consequences ask a legitimately-empty scope to be made explicit
+  rather than refused. A repo adopting fabrika has an empty `.decisions/` by definition, and refusing
+  there left its first ADR unmintable on the documented path (#5254, against the #4776 ruling that
+  working in a foreign repo is a release criterion).
 - **The residual race is real and this verb does not close it.** Two authors between the same pair of
   invocations still collide. CI's `decisions-index validate` job reds the second-to-merge PR in
   CI, and the skill's step 6 re-check catches it for the caller's own id before the PR opens. A verb
@@ -330,7 +348,9 @@ were enumerated, and no one holds this id. It is never what a failed read prints
 | `1` | usage error, or the verb failed to run |
 | `3` | `--base` could not be fetched, so every state is UNKNOWN |
 | `4` | the open pull requests could not be enumerated, so `absent` cannot be distinguished from `in-flight` |
-| `5` | `--dir` was read and held zero `NNNN-slug.md` records — zero scope |
+| `6` | `--dir` could not be read at the fetched `--base`, so every state is UNKNOWN |
+
+`5` is vacated here for the same reason it is under `adr next`.
 
 **Errors**
 
@@ -338,13 +358,14 @@ were enumerated, and no one holds this id. It is never what a failed read prints
 |---|---|---|
 | `adr resolve: cannot fetch <ref>: <reason> — every state is UNKNOWN, never "absent".` | 3 | refusal |
 | `adr resolve: cannot enumerate open pull requests in <repo>: <reason> — "absent" is indistinguishable from "in-flight", so it is UNKNOWN.` | 4 | refusal |
-| `adr resolve: scanned <dir> at <ref>, 0 decision records — refusing to answer (ADR 0092).` | 5 | refusal |
+| `adr resolve: cannot read <dir> at <ref>: <reason> — every state is UNKNOWN, never "absent".` | 6 | refusal |
 | `adr resolve: id "<id>" is not four zero-padded digits.` | 1 | usage error |
 | `adr resolve: <dir> at <ref> holds two records for id <id>: <a>, <b>` | 1 | refusal |
 
 **Scope** — every `NNNN-slug.md` under `--dir` at the fetched `--base`, plus every open pull request
-in `--repo` that adds a `.decisions/NNNN-*.md` file. Zero records is a failed read and reds, for the
-same reason it does in `adr next`. The scope line goes to stderr, naming the base SHA and both counts.
+in `--repo` that adds a `.decisions/NNNN-*.md` file. Zero records is a fact and answers `absent` for
+every id no open pull request holds, for the same reason it answers in `adr next`. The scope line
+goes to stderr, naming the base SHA and both counts.
 
 **Examples**
 
@@ -383,7 +404,7 @@ $ echo $?
 - #1777 — a guessed slug is a dead link. A slug is not derivable from a title (0048 is
   `ship-it-merge-actor`, not `single-merge-authority`), so this verb prints the real filename and the
   caller uses it verbatim.
-- ADR 0092 — zero scope reds.
+- ADR 0092 — zero scope reds for a gate; see `adr next`'s Grounding for why this verb is not one.
 
 ---
 
@@ -604,7 +625,8 @@ prefix and a terminating period, and no other rewording.
 | `1` | usage error, or the verb failed to run |
 | `3` | the corpus could not be read, so the outcome is UNKNOWN |
 | `4` | `--new` names an id or path with no readable ADR |
-| `5` | `--dir` was read and held zero `NNNN-slug.md` records — zero scope |
+
+`5` is vacated here for the same reason it is under `adr next`.
 
 **Errors**
 
@@ -612,13 +634,19 @@ prefix and a terminating period, and no other rewording.
 |---|---|---|
 | `adr sweep: cannot read <dir>: <reason> — the outcome is UNKNOWN, never "no-overlap".` | 3 | refusal |
 | `adr sweep: no readable ADR for --new <value>.` | 4 | refusal |
-| `adr sweep: scanned <dir>, 0 decision records — refusing to answer (ADR 0092).` | 5 | refusal |
 
 **Scope** — every live-accepted record under `--dir` that `--new` does not already cite. The scope
 line goes to stderr naming the corpus size and the in-scope count, because the outcome is only
 readable against them: `indeterminate` fires when the live-accepted corpus is below the rarity floor
 of 10 — the floor counts that corpus, not the in-scope subset — and a caller that cannot see the
 count cannot tell that from a clean sweep.
+
+**A readable-but-empty `--dir` is that floor at its limit and answers `indeterminate`**, with the
+below-the-floor `reason` reading `0 record(s)`. It needs no case of its own: a corpus of nothing
+carries no information for the same reason a corpus of three does not. Only a corpus that could not
+be read is UNKNOWN, and that is exit `3`. Note `--new` still has to name a readable ADR — against an
+empty `--dir` an `NNNN` id form resolves to nothing and refuses `4`, so a fresh adopter passes the
+path to their draft.
 
 **Examples**
 
@@ -666,7 +694,7 @@ $ echo $?
 
 **Grounding**
 
-- ADR 0092 — zero scope reds.
+- ADR 0092 — zero scope reds for a gate; see `adr next`'s Grounding for why this verb is not one.
 - v1's `adr-sweep` is worth reading before implementing this, for two scars it already carries: it
   exits `1` whenever it *has* a shortlist (so a caller reads its informative case as a failure), and
   its `--json` payload goes to stderr leaving stdout empty (#4723). fabrika repeats neither — all

--- a/packages/fabrika-cli/src/adr/base-ref.ts
+++ b/packages/fabrika-cli/src/adr/base-ref.ts
@@ -4,8 +4,13 @@
  *
  * The halves fail differently and the difference is load-bearing:
  *
- * - **Zero merged records is a failed read, not an answer.** This repo always has decision records,
- *   so an empty scan means the wrong directory or a broken read (ADR 0092).
+ * - **An empty merged set is a fact, not a failed read.** The read itself proves the directory:
+ *   `git ls-tree <sha>:<dir>` fails outright when `<dir>` is not in the tree, so a listing that
+ *   comes back empty is a directory that exists and holds nothing — a repo adopting fabrika on day
+ *   one, whose first id is `0001`. Only `DirUnreadable` is UNKNOWN. ADR 0092's zero-scope refusal
+ *   governs *gates* scanning for violations, where an empty scan means nothing was checked; an
+ *   allocator's empty corpus is 0092's own "legitimately-empty scope", which it asks to be made
+ *   explicit rather than refused (#5254).
  * - **An empty in-flight set is a fact — but only on a successful read.** No open ADR pull request
  *   is a normal state; an in-flight set that could not be read is a refusal, because a caller that
  *   reads an empty set as "nothing reserved" falls back to the on-disk id, which is exactly the
@@ -20,7 +25,6 @@ import type {InFlightRecord, MergedRecord} from "./resolve.ts";
 export type MergedFailure =
 	| {readonly _tag: "FetchFailed"; readonly reason: string}
 	| {readonly _tag: "DirUnreadable"; readonly reason: string}
-	| {readonly _tag: "ZeroScope"; readonly sha: string}
 	| {readonly _tag: "UnparseableId"; readonly file: string};
 
 export interface MergedSet {
@@ -47,7 +51,6 @@ export const loadMerged = (base: string, dir: string): Shell<MergedOutcome> =>
 		const {records, unparseable} = partitionRecordNames(listed.value);
 		const bad = unparseable[0];
 		if (bad !== undefined) return {_tag: "Err", error: {_tag: "UnparseableId", file: bad}};
-		if (records.length === 0) return {_tag: "Err", error: {_tag: "ZeroScope", sha: resolved.value}};
 		return {
 			_tag: "Ok",
 			value: {

--- a/packages/fabrika-cli/src/adr/command.ts
+++ b/packages/fabrika-cli/src/adr/command.ts
@@ -66,7 +66,7 @@ const next = leafCommand(
 	}),
 ).pipe(
 	Command.withDescription(
-		"The next unused ADR id — max(fetched merged set ∪ open-PR claims) + 1. Prints `0240`; --json adds mergedMax/inFlight/baseSha. Exits 3 (base unfetchable), 4 (in-flight unknown), 5 (zero scope). Example: fabrika adr next",
+		"The next unused ADR id — max(fetched merged set ∪ open-PR claims) + 1. Prints `0240`; --json adds mergedMax/inFlight/baseSha. An empty-and-readable --dir is a fresh corpus and answers 0001. Exits 3 (base unfetchable), 4 (in-flight unknown), 6 (--dir unreadable). Example: fabrika adr next",
 	),
 );
 
@@ -138,7 +138,7 @@ const resolve = leafCommand(
 	}),
 ).pipe(
 	Command.withDescription(
-		"Resolve ids to their real filename and state against a fetched base ref — one `<state>\\t<file>\\t<detail>` line per id, state ∈ live|landed|in-flight|absent. Exits 3 (base unfetchable), 4 (in-flight unknown), 5 (zero scope). Example: fabrika adr resolve 0164 0023",
+		"Resolve ids to their real filename and state against a fetched base ref — one `<state>\\t<file>\\t<detail>` line per id, state ∈ live|landed|in-flight|absent. An empty-and-readable --dir answers absent. Exits 3 (base unfetchable), 4 (in-flight unknown), 6 (--dir unreadable). Example: fabrika adr resolve 0164 0023",
 	),
 );
 
@@ -190,7 +190,7 @@ const sweepCmd = leafCommand(
 	}),
 ).pipe(
 	Command.withDescription(
-		"Rank the uncited live-accepted ADRs this one may contradict. First stdout line is the outcome token — shortlist | no-overlap | indeterminate — and ALL THREE exit 0; a shortlist adds one `<id>\\t<score>\\t<file>\\t<title>` line per entry. Exits 3 (corpus unreadable), 4 (no readable --new), 5 (zero scope). Example: fabrika adr sweep --new 0240",
+		"Rank the uncited live-accepted ADRs this one may contradict. First stdout line is the outcome token — shortlist | no-overlap | indeterminate — and ALL THREE exit 0; a shortlist adds one `<id>\\t<score>\\t<file>\\t<title>` line per entry. An empty-and-readable --dir answers indeterminate. Exits 3 (corpus unreadable), 4 (no readable --new). Example: fabrika adr sweep --new 0240",
 	),
 );
 

--- a/packages/fabrika-cli/src/adr/next-verb.ts
+++ b/packages/fabrika-cli/src/adr/next-verb.ts
@@ -17,15 +17,16 @@ import {allocate} from "./next.ts";
 export const BASE_UNFETCHABLE = 3;
 /** The open pull requests could not be enumerated, so the in-flight set is UNKNOWN. */
 export const IN_FLIGHT_UNKNOWN = 4;
-/** `--dir` was read and held zero records — zero scope (ADR 0092). */
-export const ZERO_SCOPE = 5;
 /**
  * `--dir` could not be read at the fetched base ref, so the merged set is UNKNOWN.
  *
  * This is a proven outcome, so it takes a `3`+ code and not `1`: a caller that saw a refusal share
  * the failure-to-invoke code could not tell "the directory is not there at that ref" from "the verb
- * never ran" (#4208, #4219, #4736). `6` is the lowest code this verb's table had free — `3`, `4` and
- * `5` already carry other proven outcomes — and `resolve` seats the same state on the same number.
+ * never ran" (#4208, #4219, #4736). `resolve` seats the same state on the same number.
+ *
+ * `5` is a **vacated** seat across this group, not a free one: it meant "read and empty — refusing"
+ * until #5254 made that state an answer, and re-seating a new meaning on it would hand a caller
+ * pinned to the old reading a wrong answer under a familiar number.
  */
 export const DIR_UNREADABLE = 6;
 
@@ -67,13 +68,7 @@ export const runNext = (options: NextOptions): Shell<VerbOutcome> =>
 					`adr next: cannot read ${dir} at ${base}: ${e.reason} — the merged set is UNKNOWN, never "0 records".`,
 				);
 			}
-			if (e._tag === "UnparseableId") {
-				return refuse(FAILED, `adr next: ${dir} holds a record with an unparseable id: ${e.file}`);
-			}
-			return refuse(
-				ZERO_SCOPE,
-				`adr next: scanned ${dir} at ${base}, 0 decision records — refusing to answer (ADR 0092).`,
-			);
+			return refuse(FAILED, `adr next: ${dir} holds a record with an unparseable id: ${e.file}`);
 		}
 
 		const inFlight = yield* loadInFlight(repo, dir);

--- a/packages/fabrika-cli/src/adr/next-verb.unit.test.ts
+++ b/packages/fabrika-cli/src/adr/next-verb.unit.test.ts
@@ -1,13 +1,7 @@
 import {Effect} from "effect";
 import {describe, expect, it} from "vitest";
 import {errOut, fakeShell, okOut, tree} from "../fakes.test-support.ts";
-import {
-	BASE_UNFETCHABLE,
-	DIR_UNREADABLE,
-	IN_FLIGHT_UNKNOWN,
-	runNext,
-	ZERO_SCOPE,
-} from "./next-verb.ts";
+import {BASE_UNFETCHABLE, DIR_UNREADABLE, IN_FLIGHT_UNKNOWN, runNext} from "./next-verb.ts";
 
 const SHA = "49a22902d1e0c7b3f5a8e4126b9d0f3c7a1e5b82";
 
@@ -85,16 +79,27 @@ describe("runNext", () => {
 		expect(out.stdout).toBe("");
 	});
 
-	it("refuses on zero scope rather than answering 0001", async () => {
-		const out = await run([[/^git ls-tree/, okOut("")]]);
-		expect(out.code).toBe(ZERO_SCOPE);
-		expect(out.stdout).toBe("");
-		expect(out.stderr.at(-1)).toContain("ADR 0092");
+	// A fresh adopter's `.decisions/` is empty by definition, and `git ls-tree <sha>:<dir>` fails
+	// outright on a directory that is not in the tree — so an empty listing PROVES an existing,
+	// empty directory and mints `0001` (#5254).
+	it("answers 0001 on a readable-but-empty --dir, with no open PR claiming an id", async () => {
+		const out = await run([
+			[/^git ls-tree/, okOut("")],
+			[/^gh api --paginate repos\/[^ ]+\/pulls\?/, okOut("")],
+		]);
+		expect(out.code).toBe(0);
+		expect(out.stdout).toBe("0001\n");
+		expect(out.stderr.join("\n")).toContain("0 decision records");
 	});
 
-	// The two states below are both non-zero and must stay on different codes: an unreadable
-	// directory is a PROVEN refusal, so it may not share `1` with a verb that failed to run
-	// (#4208, #4219, #4736), and it may not be confused with the empty directory that answers 5.
+	it("unions an empty --dir with the in-flight set rather than restarting at 0001", async () => {
+		const out = await run([[/^git ls-tree/, okOut("")]]);
+		expect(out.code).toBe(0);
+		expect(out.stdout).toBe("0240\n");
+	});
+
+	// An unreadable directory is a PROVEN refusal, so it may not share `1` with a verb that failed
+	// to run (#4208, #4219, #4736), and it must stay distinct from the empty directory that answers.
 	it("refuses an unreadable --dir on its own proven code, not on 1", async () => {
 		const out = await run([[/^git ls-tree/, errOut("fatal: not a tree object")]]);
 		expect(out.code).toBe(DIR_UNREADABLE);
@@ -108,7 +113,8 @@ describe("runNext", () => {
 	it("keeps an unreadable --dir distinguishable from an empty one", async () => {
 		const unreadable = await run([[/^git ls-tree/, errOut("fatal: not a tree object")]]);
 		const empty = await run([[/^git ls-tree/, okOut("")]]);
-		expect(unreadable.code).not.toBe(empty.code);
+		expect(unreadable.code).toBe(DIR_UNREADABLE);
+		expect(empty.code).toBe(0);
 	});
 
 	it("refuses a record whose id cannot be parsed", async () => {

--- a/packages/fabrika-cli/src/adr/next.ts
+++ b/packages/fabrika-cli/src/adr/next.ts
@@ -31,9 +31,9 @@ export interface Allocation {
 /**
  * Allocate the next id from the merged set unioned with the in-flight set.
  *
- * Both inputs are required to be non-empty *facts*: the caller refuses on zero merged records
- * (ADR 0092) and refuses on an in-flight set it could not read, so an empty `inFlight` reaching
- * here means "no open ADR pull request", never "the read failed".
+ * Both inputs are *facts*: the caller refuses on any set it could not read, so an empty one reaching
+ * here means "nothing there", never "the read failed". Two empty sets are the fresh-adopter case and
+ * allocate `0001` (see `base-ref.ts`).
  */
 export const allocate = (
 	mergedIds: ReadonlyArray<string>,

--- a/packages/fabrika-cli/src/adr/records.unit.test.ts
+++ b/packages/fabrika-cli/src/adr/records.unit.test.ts
@@ -41,7 +41,7 @@ describe("partitionRecordNames", () => {
 		expect(unparseable).toEqual(["12-too-short.md"]);
 	});
 
-	it("is empty for an empty listing — zero scope is the caller's refusal, not a silent pass", () => {
+	it("is empty for an empty listing — the caller reads that as a fresh corpus", () => {
 		expect(partitionRecordNames([]).records).toEqual([]);
 	});
 });

--- a/packages/fabrika-cli/src/adr/resolve-verb.ts
+++ b/packages/fabrika-cli/src/adr/resolve-verb.ts
@@ -27,9 +27,7 @@ import {
 export const BASE_UNFETCHABLE = 3;
 /** The open pull requests could not be enumerated, so `absent` cannot be told from `in-flight`. */
 export const IN_FLIGHT_UNKNOWN = 4;
-/** `--dir` was read and held zero records — zero scope (ADR 0092). */
-export const ZERO_SCOPE = 5;
-/** `--dir` could not be read at the fetched base ref, so every state is UNKNOWN. See `next-verb.ts`'s `DIR_UNREADABLE` for why this is a `3`+ code and not `1`. */
+/** `--dir` could not be read at the fetched base ref, so every state is UNKNOWN. See `next-verb.ts`'s `DIR_UNREADABLE` for why this is a `3`+ code and not `1`, and why `5` stays vacated. */
 export const DIR_UNREADABLE = 6;
 
 export interface ResolveOptions {
@@ -77,16 +75,7 @@ export const runResolve = (options: ResolveOptions): Shell<VerbOutcome> =>
 					`adr resolve: cannot read ${dir} at ${base}: ${e.reason} — every state is UNKNOWN, never "absent".`,
 				);
 			}
-			if (e._tag === "UnparseableId") {
-				return refuse(
-					FAILED,
-					`adr resolve: ${dir} holds a record with an unparseable id: ${e.file}`,
-				);
-			}
-			return refuse(
-				ZERO_SCOPE,
-				`adr resolve: scanned ${dir} at ${base}, 0 decision records — refusing to answer (ADR 0092).`,
-			);
+			return refuse(FAILED, `adr resolve: ${dir} holds a record with an unparseable id: ${e.file}`);
 		}
 		const mergedSet = merged.value;
 

--- a/packages/fabrika-cli/src/adr/resolve-verb.unit.test.ts
+++ b/packages/fabrika-cli/src/adr/resolve-verb.unit.test.ts
@@ -1,13 +1,7 @@
 import {Effect} from "effect";
 import {describe, expect, it} from "vitest";
 import {errOut, fakeShell, okOut, record, tree} from "../fakes.test-support.ts";
-import {
-	BASE_UNFETCHABLE,
-	DIR_UNREADABLE,
-	IN_FLIGHT_UNKNOWN,
-	runResolve,
-	ZERO_SCOPE,
-} from "./resolve-verb.ts";
+import {BASE_UNFETCHABLE, DIR_UNREADABLE, IN_FLIGHT_UNKNOWN, runResolve} from "./resolve-verb.ts";
 
 const SHA = "49a22902d1e0c7b3f5a8e4126b9d0f3c7a1e5b82";
 const AMEND_LIST =
@@ -106,10 +100,22 @@ describe("runResolve", () => {
 		expect(out.stderr.at(-1)).toContain("indistinguishable from");
 	});
 
-	it("refuses on zero scope", async () => {
-		const out = await run([[/^git ls-tree/, okOut("")]]);
-		expect(out.code).toBe(ZERO_SCOPE);
-		expect(out.stdout).toBe("");
+	// An empty `.decisions/` is a fresh adopter's normal state, and nobody holds the id there —
+	// which is exactly what `absent` says (#5254).
+	it("answers absent against a readable-but-empty --dir", async () => {
+		const out = await run([
+			[/^git ls-tree/, okOut("")],
+			[/^gh api --paginate repos\/[^ ]+\/pulls\?/, okOut("")],
+		]);
+		expect(out.code).toBe(0);
+		expect(out.stdout).toBe("absent\t-\t-\n");
+		expect(out.stderr.join("\n")).toContain("0 decision records");
+	});
+
+	it("still reports an in-flight id against an empty --dir", async () => {
+		const out = await run([[/^git ls-tree/, okOut("")]], {ids: ["0239"]});
+		expect(out.code).toBe(0);
+		expect(out.stdout).toBe("in-flight\t0239-campaign-milestones.md\tPR #4711\n");
 	});
 
 	it("refuses an unreadable --dir on its own proven code, not on 1", async () => {
@@ -125,7 +131,8 @@ describe("runResolve", () => {
 	it("keeps an unreadable --dir distinguishable from an empty one", async () => {
 		const unreadable = await run([[/^git ls-tree/, errOut("fatal: not a tree object")]]);
 		const empty = await run([[/^git ls-tree/, okOut("")]]);
-		expect(unreadable.code).not.toBe(empty.code);
+		expect(unreadable.code).toBe(DIR_UNREADABLE);
+		expect(empty.code).toBe(0);
 	});
 
 	it("refuses an id that is not four zero-padded digits", async () => {

--- a/packages/fabrika-cli/src/adr/sweep-verb.ts
+++ b/packages/fabrika-cli/src/adr/sweep-verb.ts
@@ -4,6 +4,10 @@
  * **All three outcomes are answers and all three exit 0.** A caller must never read its own
  * shortlist as a failed run, which is precisely the mistake v1's `adr-sweep` makes by exiting 1 on
  * the one case it was asked to produce; and `--json` goes to **stdout**, not stderr (#4723).
+ *
+ * A readable-but-empty `--dir` is the rarity floor at its limit, so it answers `indeterminate` and
+ * needs no case of its own; only an unreadable corpus is UNKNOWN. `5` stays vacated — see
+ * `next-verb.ts`'s `DIR_UNREADABLE` (#5254).
  */
 import {Effect, type FileSystem, Result} from "effect";
 import {readDir, readFile} from "../io/fs.ts";
@@ -15,8 +19,6 @@ import {renderEntry, type SweepCandidate, sweep} from "./sweep.ts";
 export const CORPUS_UNREADABLE = 3;
 /** `--new` names an id or path with no readable ADR. */
 export const NO_SUBJECT = 4;
-/** `--dir` was read and held zero records — zero scope (ADR 0092). */
-export const ZERO_SCOPE = 5;
 
 export interface SweepOptions {
 	/** A four-digit id already in `--dir`, or a path to the draft file. */
@@ -41,12 +43,6 @@ export const runSweep = (
 			);
 		}
 		const {records} = partitionRecordNames(listing.success);
-		if (records.length === 0) {
-			return refuse(
-				ZERO_SCOPE,
-				`adr sweep: scanned ${root}, 0 decision records — refusing to answer (ADR 0092).`,
-			);
-		}
 
 		const corpus: SweepCandidate[] = [];
 		for (const file of records) {

--- a/packages/fabrika-cli/src/adr/sweep-verb.unit.test.ts
+++ b/packages/fabrika-cli/src/adr/sweep-verb.unit.test.ts
@@ -1,7 +1,7 @@
 import {Effect} from "effect";
 import {describe, expect, it} from "vitest";
 import {type FakeFs, fakeFs, record} from "../fakes.test-support.ts";
-import {CORPUS_UNREADABLE, NO_SUBJECT, runSweep, ZERO_SCOPE} from "./sweep-verb.ts";
+import {CORPUS_UNREADABLE, NO_SUBJECT, runSweep} from "./sweep-verb.ts";
 
 const dir = ".decisions";
 
@@ -89,11 +89,18 @@ describe("runSweep", () => {
 		expect(out.stdout).toBe("");
 	});
 
-	it("refuses on zero scope", async () => {
-		const out = await run(fakeFs({dirs: {[dir]: ["README.md"]}}));
-		expect(out.code).toBe(ZERO_SCOPE);
-		expect(out.stdout).toBe("");
-		expect(out.stderr.at(-1)).toContain("ADR 0092");
+	// A readable-but-empty corpus is the rarity floor at its limit, not a failed read — the fresh
+	// adopter sweeping their very first draft gets an answer (#5254).
+	it("answers indeterminate against a readable-but-empty --dir", async () => {
+		const io = fakeFs({
+			dirs: {[dir]: []},
+			files: {"drafts/0001-draft.md": record("0001", "proposed", "reticulate the splines")},
+		});
+		const out = await run(io, {new: "drafts/0001-draft.md"});
+		expect(out.code).toBe(0);
+		expect(out.stdout).toBe("indeterminate\n");
+		expect(out.stderr.join("\n")).toContain("rarity floor");
+		expect(out.stderr[0]).toContain("0 decision records");
 	});
 
 	it("refuses when --new names no readable ADR", async () => {


### PR DESCRIPTION
A repo adopting fabrika has an empty `.decisions/` on day one. `fabrika adr` treated that as a broken read and exited 5, so the adopter's first ADR could never be minted on the documented path — the skill says "a non-zero exit is UNKNOWN, re-run it", which on a permanently empty corpus is a loop with no way out. An empty directory that was read successfully is a fact, not a failure, so the three id-reading verbs now answer it: `adr next` mints `0001`, `adr resolve` reports `absent`, `adr sweep` reports `indeterminate`. Only a directory that could not be read at all still refuses.

The two states are told apart by the read itself, not by a heuristic. The merged set is read as `git ls-tree <base-sha>:<dir>`, which fails outright when the directory is not in the tree — so a listing that comes back empty proves a directory that exists and holds nothing, and a typo'd `--dir` still refuses on its own code (6 for `next`/`resolve`, 3 for `sweep`). Exit 5 is left vacated across the group rather than re-used, so a caller pinned to the old "5 means empty" reading can never be handed a different meaning under a familiar number.

Fixes #5254

## Deviations

**Class 3 (a decision the issue left to the lane).** Said: triage explicitly did not choose between "answer `0001` on a proven-empty-and-readable scan" and "refuse, but name the bootstrap route". Did: chose to answer. Why: ADR 0092's zero-scope refusal governs *gates*, whose empty scan means they checked nothing; an allocator is not a gate, and 0092's own Consequences ask a legitimately-empty scope to be made explicit rather than refused. Answering also removes the dead end instead of documenting a way around it, which is what #4776 (works in a foreign repo is a release criterion) asks for. Disposition: no action needed — the reasoning is written into `base-ref.ts` and the contract's Grounding sections so a later reader sees why the two directions are not symmetric.

**Class 3 (an AC's literal wording no longer fits the chosen direction).** Said: amended AC 1 asks the contract to "state `sweep`'s equivalent split (`3` vs `5`)". Did: stated `sweep`'s split as `3` (corpus unreadable) versus an **answer** — `indeterminate` — because choosing "answer" removes `5` from `sweep` entirely. Why: the AC's `3` vs `5` phrasing presumes the refuse branch; keeping a `5` row would contradict the fix. Disposition: for the reviewer to judge — the AC's intent (the two states must not share a code) is delivered, its literal numbering is not.

**Class 5 (adjacent defect left alone).** Said: #5294 records that the `adr` group collides with itself — `relate-verb.ts` `NO_SUBJECT = 3` against `sweep-verb.ts` `NO_SUBJECT = 4`. Did: left it untouched. Why: it is another lane's disclosed debt and out of this scope. This change does not touch either constant and does not worsen the collision; it vacates `5` in three verbs, and the note in `next-verb.ts` plus the contract says that seat stays vacated, so a later renumbering lane cannot read it as free space. Disposition: no action needed — #5294 owns it.

**Class 6 (tests changed that asserted the old behaviour).** Said: three unit tests asserted the exit-5 refusal (`refuses on zero scope` in `next-verb`, `resolve-verb`, `sweep-verb`). Did: replaced them with tests asserting the new answers, plus two that pin the empty-versus-unreadable split apart. Why: they asserted exactly the defect. Disposition: no action needed — the new tests were proven against the pre-fix logic (restored temporarily, 7 failures, all exit 5 where 0 is expected).

**Class 7 (no ADR).** Said: an ADR number was pre-assigned in case this warranted one. Did: wrote none. Why: triage's second pass already found the direction settled by ADR 0092's own Consequences, so there is no new decision to record. Disposition: no action needed — `0264` remains unused.