### PR TITLE
feat(fabrika): build the six status verbs the front-door contract derives (#5214)

### DIFF
--- a/packages/fabrika-cli/README.md
+++ b/packages/fabrika-cli/README.md
@@ -11,7 +11,8 @@ the `/review` contract specifies; `review-ui`, the three the `/review-ui` contra
 `ship`, the thirteen the `/ship` contract specifies; `eval`, the graded-corpus
 harness the fabrika eval layer measures itself with; `spend`, what one fabrika run cost in
 tokens; `wire`, which owns the byte-level formats two skills meet through on a GitHub
-artifact; and `hook`, which reads the envelope Claude Code writes to a hook's stdin — the group
+artifact; `status`, the six the `/fabrika` front door's contract specifies (what state the
+factory is in); and `hook`, which reads the envelope Claude Code writes to a hook's stdin — the group
 [fabrika's hook surface](../../claude-plugins/fabrika/hooks.json) declares against.
 `fabrika --help` lists them from the registry, so that index is never a second
 hand-maintained list.
@@ -564,6 +565,41 @@ Four things about it are load-bearing:
 The core is [`src/spend/rollup.ts`](./src/spend/rollup.ts), pure and total: it sums a
 `readSpendLedger` result over a resolved window and groups it three ways.
 [`src/spend/rollup-verb.ts`](./src/spend/rollup-verb.ts) is the IO around it.
+
+## The `status` group
+
+What state the factory is in — the six verbs
+[`front-door`](../../claude-plugins/fabrika/skills/front-door/SKILL.md) drives
+([#5214](https://github.com/kamp-us/phoenix/issues/5214), spec:
+[`contract.md`](../../claude-plugins/fabrika/skills/front-door/contract.md)).
+
+```
+status open                       # the composite four-field readout the skill injects
+status config                     # which declared repo surfaces exist here — the detection verb
+status menu                       # the landed skill roster, derived from the skills tree
+status readout                    # the landed-decision digest, as published
+status board                      # counts of the board's decided buckets
+status bootstrap readout-artifact # create one missing surface, then read it back
+```
+
+Three things about it are load-bearing:
+
+- **The three-state law.** Every field, row and bucket is a live value, a **proven negative**
+  (`empty` / `absent` / `missing` / `unprobeable` / `malformed`), or **`unknown`** with its reason —
+  and the third never renders as the second. An absent label is `unknown`, never `0`; an
+  unregistered decoder is `unknown`, never `absent`.
+- **`status open` is total.** It is injected before a session reads a token, and
+  [`src/verb.ts`](./src/verb.ts)'s `refuse()` hardcodes empty stdout — so a refusal would leave the
+  front door silent on exactly the cold start it exists for. Every source it cannot read becomes a
+  field state; its one refusal seat is a bad `--field`. It composes by **importing** the sibling
+  cores, never by spawning a verb and reading its exit code.
+- **`7` and `11` are the pair.** `7` is an **explicitly passed** `--skills-dir` proven absent; `11`
+  is a failed read. An *implicitly* resolved roster holding zero skills is neither — it is `empty`
+  at exit `0`.
+
+The roster resolves in three tiers — an explicit `--skills-dir`, the installed plugin's own skills
+tree, then `claude-plugins/fabrika/skills` in-repo — and prints which one served
+([`src/status/roster.ts`](./src/status/roster.ts)).
 
 ## The `ui` group
 

--- a/packages/fabrika-cli/src/exit-code-alignment.ts
+++ b/packages/fabrika-cli/src/exit-code-alignment.ts
@@ -104,6 +104,7 @@ export const ALIGNED_GROUPS: Readonly<Record<string, SharedSeats>> = {
 	review: SHARED_SEATS,
 	"review-ui": REVIEW_UI_SEATS,
 	ship: SHARED_SEATS,
+	status: SHARED_SEATS,
 	ui: UI_SEATS,
 };
 

--- a/packages/fabrika-cli/src/exit-code-alignment.unit.test.ts
+++ b/packages/fabrika-cli/src/exit-code-alignment.unit.test.ts
@@ -17,6 +17,7 @@ import * as report from "./report/codes.ts";
 import * as review from "./review/codes.ts";
 import * as reviewUi from "./review-ui/codes.ts";
 import * as ship from "./ship/codes.ts";
+import * as status from "./status/codes.ts";
 import * as triage from "./triage/codes.ts";
 import * as ui from "./ui/codes.ts";
 import * as wire from "./wire/codes.ts";
@@ -38,6 +39,7 @@ const TABLES: Readonly<Record<string, CodeTable>> = {
 	review,
 	"review-ui": reviewUi,
 	ship,
+	status,
 	triage,
 	ui,
 	wire,

--- a/packages/fabrika-cli/src/io/fs.ts
+++ b/packages/fabrika-cli/src/io/fs.ts
@@ -64,6 +64,24 @@ export const exists = (path: string): Effect.Effect<boolean, ReadFailed, FileSys
 	);
 
 /**
+ * Whether `path` is a directory.
+ *
+ * Separate from {@link exists} because "is there a file *under* this?" is not answerable by probing
+ * the child: on a non-directory parent the platform raises `ENOTDIR` rather than answering absent,
+ * so a caller enumerating a tree must ask about the entry itself. Like every read here, a probe that
+ * could not be performed FAILS; it never answers `false`.
+ */
+export const isDirectory = (
+	path: string,
+): Effect.Effect<boolean, ReadFailed, FileSystem.FileSystem> =>
+	Effect.gen(function* () {
+		const fs = yield* FileSystem.FileSystem;
+		return (yield* fs.stat(path)).type === "Directory";
+	}).pipe(
+		Effect.catchTag("PlatformError", (cause) => new ReadFailed({path, reason: cause.message})),
+	);
+
+/**
  * Append `text` to `path`, creating the file and its parent directory when they are absent.
  *
  * The `"a+"` open flag is the guarantee that matters: every write lands at the end of whatever is

--- a/packages/fabrika-cli/src/io/issues.ts
+++ b/packages/fabrika-cli/src/io/issues.ts
@@ -118,6 +118,32 @@ export const openIssuesWithLabel = (
 	});
 
 /**
+ * Open issues in `repo` whose title is **exactly** `title`, paged, pull requests filtered out.
+ *
+ * Matched over the issues endpoint rather than through the search index on purpose: search is
+ * eventually consistent and caps its result set, so a durable artifact created moments ago can read
+ * back as absent — and "absent" is the one answer an artifact lookup must never get wrong.
+ */
+export const openIssuesTitled = (
+	repo: string,
+	title: string,
+): Shell<Attempt<ReadonlyArray<IssueRow>>> =>
+	Effect.gen(function* () {
+		const r = yield* execCapture("gh", [
+			"api",
+			"--paginate",
+			`repos/${repo}/issues?state=open&per_page=100`,
+			"--jq",
+			'.[] | select(.pull_request | not) | "\\(.number)\t\\(.title)"',
+		]);
+		if (!r.ok) return fail(r.reason);
+		const rows = parseIssueRows(r.stdout);
+		return rows === null
+			? fail("`gh api` exited 0 but its output is not a list of issue rows")
+			: ok(rows.filter((row) => row.title === title));
+	});
+
+/**
  * The search index's open issues for `tokens`.
  *
  * GitHub AND-joins search terms, which is why the caller caps the token list — an over-long query
@@ -243,6 +269,60 @@ export const createIssue = (
 			return fail("`gh api` exited 0 but its output is not a created issue");
 		}
 		return ok({number: parsed.number, url: parsed.html_url});
+	});
+
+/**
+ * Create an issue carrying **no** label — the durable-artifact shape.
+ *
+ * Separate from {@link createIssue} rather than a nullable parameter: an artifact issue is not
+ * intake, and a stray label on it would put it in a queue something else drains.
+ */
+export const createUnlabelledIssue = (
+	repo: string,
+	title: string,
+	body: string,
+): Shell<Attempt<CreatedIssue>> =>
+	Effect.gen(function* () {
+		const r = yield* execCapture("gh", [
+			"api",
+			"--method",
+			"POST",
+			`repos/${repo}/issues`,
+			"-f",
+			`title=${title}`,
+			"-f",
+			`body=${body}`,
+		]);
+		if (!r.ok) return fail(r.reason);
+		const parsed = parseJson(r.stdout);
+		if (
+			!isRecord(parsed) ||
+			typeof parsed.number !== "number" ||
+			typeof parsed.html_url !== "string"
+		) {
+			return fail("`gh api` exited 0 but its output is not a created issue");
+		}
+		return ok({number: parsed.number, url: parsed.html_url});
+	});
+
+/** Create one repository label with GitHub's default colour and a description naming its creator. */
+export const createLabel = (
+	repo: string,
+	name: string,
+	description: string,
+): Shell<Attempt<void>> =>
+	Effect.gen(function* () {
+		const r = yield* execCapture("gh", [
+			"api",
+			"--method",
+			"POST",
+			`repos/${repo}/labels`,
+			"-f",
+			`name=${name}`,
+			"-f",
+			`description=${description}`,
+		]);
+		return r.ok ? ok(undefined) : fail(r.reason);
 	});
 
 export interface CreatedComment {

--- a/packages/fabrika-cli/src/registry.ts
+++ b/packages/fabrika-cli/src/registry.ts
@@ -27,6 +27,7 @@ import {reviewCommand} from "./review/command.ts";
 import {reviewUiCommand} from "./review-ui/command.ts";
 import {shipCommand} from "./ship/command.ts";
 import {spendCommand} from "./spend/command.ts";
+import {statusCommand} from "./status/command.ts";
 import {triageCommand} from "./triage/command.ts";
 import {uiCommand} from "./ui/command.ts";
 import {wireCommand} from "./wire/command.ts";
@@ -48,6 +49,7 @@ export const registeredGroups: ReadonlyArray<VerbGroup> = [
 	reviewUiCommand,
 	shipCommand,
 	spendCommand,
+	statusCommand,
 	triageCommand,
 	uiCommand,
 	wireCommand,

--- a/packages/fabrika-cli/src/status/board-verb.ts
+++ b/packages/fabrika-cli/src/status/board-verb.ts
@@ -1,0 +1,197 @@
+/**
+ * `status board` — counts of the board's decided buckets, each with its own freshness.
+ *
+ * **Counts only.** `fabrika build pick` and `build eligible` answer which issue is next and
+ * `build verdicts` / `ship gate` answer a pull request's state; a second answer here could
+ * contradict the verb that actually claims the work. There is no "banked" bucket either — what
+ * marks a pull request banked is an open decision (#4103).
+ *
+ * **An absent label renders `unknown`, never `0`.** A zero count means the label exists and nothing
+ * carries it; an absent label means the question was never askable — the #4060 shape, where a fresh
+ * repo would be told its queue is clear.
+ */
+import {Effect} from "effect";
+import {scannedLine} from "../build/target.ts";
+import type {Shell} from "../io/git.ts";
+import {openPullRequests} from "../io/github.ts";
+import {listLabels, openIssuesWithLabel} from "../io/issues.ts";
+import {PRIORITIES} from "../triage/facets.ts";
+import {answer, refuse, type VerbOutcome} from "../verb.ts";
+import {PRECONDITION_UNKNOWN} from "./codes.ts";
+import {type AsOf, asOfToken, detail, EMPTY_CELL, instant, noAsOf, readNow, row} from "./fields.ts";
+
+const VERB = "status board";
+
+/** The label whose absence makes a bucket unaskable, and the selector printed for it. */
+const labelBucket = (name: string, label: string) => ({
+	name,
+	label,
+	selector: `labels=${label}`,
+});
+
+/**
+ * The six buckets, each with the REST call that produces it — never GitHub search syntax, which
+ * caps at 1000 results and cannot back a count.
+ */
+export const BUCKETS = [
+	labelBucket("needs-triage", "status:needs-triage"),
+	labelBucket("triaged", "status:triaged"),
+	...PRIORITIES.map((priority) => labelBucket(priority, priority)),
+] as const;
+
+/** The pull-request bucket, read off `/pulls` rather than `/issues` — it counts PRs on purpose. */
+export const IN_FLIGHT = {name: "in-flight", selector: "pulls?state=open"} as const;
+
+export interface Bucket {
+	readonly name: string;
+	readonly count: number | null;
+	readonly selector: string;
+	readonly detail: string | null;
+	readonly asOf: AsOf;
+}
+
+export type BoardRead =
+	/** The repository could not be read at all — every bucket is UNKNOWN, so there is no readout. */
+	| {readonly _tag: "Failed"; readonly repo: string; readonly reason: string}
+	| {readonly _tag: "Read"; readonly repo: string; readonly buckets: ReadonlyArray<Bucket>};
+
+const unknownBucket = (name: string, selector: string, reason: string): Bucket => ({
+	name,
+	selector,
+	count: null,
+	detail: detail(reason),
+	asOf: noAsOf,
+});
+
+/**
+ * Read every bucket.
+ *
+ * The label set is read first because it is what separates the two negative answers: with it in
+ * hand a `0` is proven, and an absent label is reported as the unasked question it is. When the
+ * label read itself fails, every label bucket is UNKNOWN — a count taken without it could not be
+ * told apart from a proven zero.
+ */
+export const readBoard = (repo: string, now: () => Date): Shell<BoardRead> =>
+	Effect.gen(function* () {
+		const labels = yield* listLabels(repo);
+		const labelFailure = labels._tag === "Failure" ? labels.reason : null;
+		const known = labels._tag === "Ok" ? new Set(labels.value) : null;
+		const buckets: Bucket[] = [];
+
+		for (const bucket of BUCKETS) {
+			if (known === null) {
+				buckets.push(
+					unknownBucket(
+						bucket.name,
+						bucket.selector,
+						`${labelFailure ?? "unreadable"} — the label set is UNKNOWN`,
+					),
+				);
+				continue;
+			}
+			if (!known.has(bucket.label)) {
+				buckets.push(unknownBucket(bucket.name, bucket.selector, "label absent"));
+				continue;
+			}
+			const rows = yield* openIssuesWithLabel(repo, bucket.label);
+			if (rows._tag === "Failure") {
+				buckets.push(unknownBucket(bucket.name, bucket.selector, rows.reason));
+				continue;
+			}
+			buckets.push({
+				name: bucket.name,
+				selector: bucket.selector,
+				count: rows.value.length,
+				detail: null,
+				asOf: readNow(instant(now())),
+			});
+		}
+
+		const pulls = yield* openPullRequests(repo);
+		if (pulls._tag === "Failure") {
+			buckets.push(unknownBucket(IN_FLIGHT.name, IN_FLIGHT.selector, pulls.reason));
+		} else {
+			buckets.push({
+				name: IN_FLIGHT.name,
+				selector: IN_FLIGHT.selector,
+				count: pulls.value.length,
+				detail: null,
+				asOf: readNow(instant(now())),
+			});
+		}
+
+		return buckets.every((bucket) => bucket.count === null)
+			? ({
+					_tag: "Failed",
+					repo,
+					reason: labels._tag === "Failure" ? labels.reason : "every bucket read failed",
+				} as const)
+			: ({_tag: "Read", repo, buckets: ordered(buckets)} as const);
+	});
+
+/** The fixed print order: the two queue buckets, in-flight, then the priorities. */
+const ordered = (buckets: ReadonlyArray<Bucket>): ReadonlyArray<Bucket> => {
+	const order = ["needs-triage", "triaged", IN_FLIGHT.name, ...PRIORITIES];
+	return [...buckets].sort((a, b) => order.indexOf(a.name) - order.indexOf(b.name));
+};
+
+export type BoardState = "counted" | "unknown";
+
+export const boardState = (buckets: ReadonlyArray<Bucket>): BoardState =>
+	buckets.every((bucket) => bucket.count !== null) ? "counted" : "unknown";
+
+export interface BoardInput {
+	readonly read: BoardRead;
+	readonly json: boolean;
+}
+
+export const runBoard = ({read, json}: BoardInput): VerbOutcome => {
+	if (read._tag === "Failed") {
+		return refuse(
+			PRECONDITION_UNKNOWN,
+			`${VERB}: cannot read ${read.repo}: ${read.reason} — every bucket is UNKNOWN, never 0.`,
+		);
+	}
+	const state = boardState(read.buckets);
+	const unknown = read.buckets.filter((bucket) => bucket.count === null);
+	const counted = read.buckets.reduce((sum, bucket) => sum + (bucket.count ?? 0), 0);
+	const notice = scannedLine(
+		VERB,
+		counted,
+		"item",
+		`counted ${read.buckets.length} buckets over ${read.repo}, ${unknown.length} unknown (${
+			unknown.map((bucket) => bucket.name).join(",") || EMPTY_CELL
+		})`,
+	);
+
+	if (json) {
+		return answer(
+			`${JSON.stringify({
+				outcome: state,
+				buckets: read.buckets.map((bucket) => ({
+					name: bucket.name,
+					count: bucket.count,
+					selector: bucket.selector,
+					detail: bucket.detail,
+					asOf: bucket.asOf.at,
+					asOfKind: bucket.asOf.kind,
+				})),
+			})}\n`,
+			[notice],
+		);
+	}
+	const lines = [
+		row("board", state, String(read.buckets.length)),
+		...read.buckets.map((bucket) =>
+			row(
+				"bucket",
+				bucket.name,
+				bucket.count === null ? "unknown" : String(bucket.count),
+				bucket.selector,
+				bucket.detail ?? EMPTY_CELL,
+				asOfToken(bucket.asOf),
+			),
+		),
+	];
+	return answer(`${lines.join("\n")}\n`, [notice]);
+};

--- a/packages/fabrika-cli/src/status/bootstrap-verb.ts
+++ b/packages/fabrika-cli/src/status/bootstrap-verb.ts
@@ -1,0 +1,312 @@
+/**
+ * `status bootstrap` — create **one** missing repo surface from this group's own registry, and read
+ * it back.
+ *
+ * The content is the skill's judgement; the write, the collision guard and the read-back are this
+ * verb's. That split is why file content arrives on stdin: *"/fabrika shows what's missing, then
+ * runs the primitives to build the missing thing"* (#4952).
+ *
+ * **What this builds is fixed in {@link BUILDABLE_SURFACES}, never inferred from a declaration.** A
+ * row's disposition says what *the declaring skill* does when a surface is missing — `build-ui`
+ * declares `design-system-manifest.md` **fail-loud** *and* points at this verb — so reading
+ * `fail-loud` as "unbuildable" would make the most important onboarding surface unreachable.
+ *
+ * **`exists` is an exit-`0` answer, not a refusal.** A target already there is a proven fact the
+ * caller acts on, and a non-zero exit cannot carry it. Nothing is written and nothing is overwritten.
+ */
+import {Effect, type FileSystem, Path, Result} from "effect";
+import type {ChildProcessSpawner} from "effect/unstable/process";
+import {exists, readFile, writeFile} from "../io/fs.ts";
+import type {Attempt} from "../io/git.ts";
+import {createLabel, createUnlabelledIssue, listLabels, openIssuesTitled} from "../io/issues.ts";
+import type {StdinRead} from "../io/stdin.ts";
+import {normalizeForReadback} from "../report/compose.ts";
+import {isBareAtReference, renderLeaks, scanBody} from "../report/leaks.ts";
+import {PRIORITIES} from "../triage/facets.ts";
+import {answer, FAILED, refuse, type VerbOutcome} from "../verb.ts";
+import {
+	BARE_AT_PATH,
+	EMPTY_STDIN,
+	LEAKED_PATH,
+	NOT_BUILDABLE,
+	OFF_VOCABULARY,
+	PRECONDITION_UNKNOWN,
+	READBACK_MISMATCH,
+	WRITE_UNKNOWN,
+} from "./codes.ts";
+import {EMPTY_CELL, row} from "./fields.ts";
+import {ARTIFACT_TITLE} from "./readout-verb.ts";
+
+const VERB = "status bootstrap";
+
+/** The board label taxonomy this verb creates, in the order it reports them. */
+export const TAXONOMY: ReadonlyArray<string> = [
+	"status:needs-triage",
+	"status:triaged",
+	...PRIORITIES,
+];
+
+/** The description every created label carries, so its creator is on the record. */
+export const LABEL_DESCRIPTION = "created by fabrika status bootstrap label-taxonomy";
+
+/** The artifact issue's body, fixed here so no clause defers to another skill's prose. */
+export const ARTIFACT_BODY = `The durable home for the landed-decision digest. \`fabrika governance readout\` upserts a comment
+here; \`fabrika status readout\` displays it. This issue stays open and is not worked.`;
+
+export interface BuildableSurface {
+	readonly id: string;
+	readonly kind: "file" | "labels" | "issue";
+	/** The registry default write path, for a file surface. */
+	readonly defaultPath: string | null;
+	readonly needsStdin: boolean;
+}
+
+/** Four ids. A fifth is a change to this table, not a new rule. */
+export const BUILDABLE_SURFACES: ReadonlyArray<BuildableSurface> = [
+	{id: "design-manifest", kind: "file", defaultPath: "design-system-manifest.md", needsStdin: true},
+	{id: "roadmap-focus", kind: "file", defaultPath: "ROADMAP.md", needsStdin: true},
+	{id: "label-taxonomy", kind: "labels", defaultPath: null, needsStdin: false},
+	{id: "readout-artifact", kind: "issue", defaultPath: null, needsStdin: false},
+];
+
+export const findSurface = (id: string): BuildableSurface | undefined =>
+	BUILDABLE_SURFACES.find((surface) => surface.id === id);
+
+export const knownIds = (): string => BUILDABLE_SURFACES.map((surface) => surface.id).join(", ");
+
+export interface BootstrapInput {
+	readonly surfaceId: string;
+	readonly path: string | null;
+	readonly json: boolean;
+	readonly repoRoot: string;
+	/** The resolved target repo, or the failure that makes the two non-file surfaces unanswerable. */
+	readonly repo: Attempt<string>;
+	readonly stdin: Effect.Effect<StdinRead>;
+}
+
+type Requirements = FileSystem.FileSystem | Path.Path | ChildProcessSpawner.ChildProcessSpawner;
+
+const created = (surfaceId: string, target: string, json: boolean, notice: string): VerbOutcome => {
+	const stdout = json
+		? `${JSON.stringify({outcome: "created", surfaceId, target, readback: "ok"})}\n`
+		: `${row("bootstrap", "created", surfaceId, target, "ok")}\n`;
+	return answer(stdout, [notice]);
+};
+
+const already = (surfaceId: string, target: string, json: boolean): VerbOutcome => {
+	const stdout = json
+		? `${JSON.stringify({outcome: "exists", surfaceId, target, readback: EMPTY_CELL})}\n`
+		: `${row("bootstrap", "exists", surfaceId, target, EMPTY_CELL)}\n`;
+	return answer(stdout, [
+		`${VERB}: ${target} is already present for ${surfaceId} — nothing written.`,
+	]);
+};
+
+/** The stdin content, or the refusal its three variants owe. `Failed` is `1`; empty is `3`. */
+const contentOrRefusal = (read: StdinRead, surfaceId: string): string | VerbOutcome => {
+	if (read._tag === "Failed") {
+		return refuse(
+			FAILED,
+			`${VERB}: cannot read stdin: ${read.reason} — the content is UNKNOWN, never empty.`,
+		);
+	}
+	if (read._tag === "NoStdin" || read.text.trim() === "") {
+		return refuse(EMPTY_STDIN, `${VERB}: stdin held nothing — ${surfaceId} requires content.`);
+	}
+	const scan = scanBody(read.text);
+	if (isBareAtReference(read.text)) {
+		return refuse(
+			BARE_AT_PATH,
+			`${VERB}: the supplied content is a bare @ path reference — not redactable.`,
+		);
+	}
+	if (scan.leaks.length > 0) {
+		return refuse(
+			LEAKED_PATH,
+			`${VERB}: the supplied content carries a machine-local path: ${scan.leaks[0]?.class ?? ""}.`,
+			renderLeaks(scan.leaks),
+		);
+	}
+	return read.text;
+};
+
+const isOutcome = (value: string | VerbOutcome): value is VerbOutcome => typeof value !== "string";
+
+const UNRESOLVED_REPO = refuse(
+	FAILED,
+	`${VERB}: cannot resolve a target repo — set CLAUDE_PIPELINE_REPO, GITHUB_REPOSITORY, or pass --repo.`,
+);
+
+const buildFile = (
+	surface: BuildableSurface,
+	input: BootstrapInput,
+): Effect.Effect<VerbOutcome, never, Requirements> =>
+	Effect.gen(function* () {
+		const path = yield* Path.Path;
+		const relative = input.path ?? (surface.defaultPath as string);
+		const absolute = path.resolve(input.repoRoot, relative);
+		// Containment is checked on the RESOLVED path, so `../` cannot walk out of the repository.
+		if (absolute !== input.repoRoot && !absolute.startsWith(`${input.repoRoot}${path.sep}`)) {
+			return refuse(
+				OFF_VOCABULARY,
+				`${VERB}: --path ${relative} resolves outside the repository root.`,
+			);
+		}
+		const probe = yield* Effect.result(exists(absolute));
+		if (Result.isFailure(probe)) {
+			return refuse(
+				PRECONDITION_UNKNOWN,
+				`${VERB}: cannot probe ${relative}: ${probe.failure.reason} — nothing was written.`,
+			);
+		}
+		if (probe.success) return already(surface.id, relative, input.json);
+
+		const content = contentOrRefusal(yield* input.stdin, surface.id);
+		if (isOutcome(content)) return content;
+
+		const written = yield* Effect.result(writeFile(absolute, content));
+		if (Result.isFailure(written)) {
+			return refuse(
+				WRITE_UNKNOWN,
+				`${VERB}: writing ${relative} failed: ${written.failure.reason} — whether it landed is UNKNOWN. Re-read before retrying.`,
+			);
+		}
+		const back = yield* Effect.result(readFile(absolute));
+		if (Result.isFailure(back)) {
+			return refuse(
+				WRITE_UNKNOWN,
+				`${VERB}: wrote ${relative} and it could not be read back: ${back.failure.reason} — the outcome is UNKNOWN.`,
+			);
+		}
+		if (normalizeForReadback(back.success) !== normalizeForReadback(content)) {
+			return refuse(
+				READBACK_MISMATCH,
+				`${VERB}: wrote ${relative} and the read-back differs — the outcome is UNKNOWN.`,
+			);
+		}
+		return created(
+			surface.id,
+			relative,
+			input.json,
+			`${VERB}: created ${relative} for ${surface.id}, read-back conformed.`,
+		);
+	});
+
+/**
+ * **Partial existence is not existence.** `exists` requires every label in the set; where some are
+ * present the verb creates only the missing ones and reports `created` naming exactly what it
+ * created. This is the one surface holding many objects, so it is the one place the rule is stated.
+ */
+const buildLabels = (
+	surface: BuildableSurface,
+	input: BootstrapInput,
+): Effect.Effect<VerbOutcome, never, Requirements> =>
+	Effect.gen(function* () {
+		if (input.repo._tag === "Failure") return UNRESOLVED_REPO;
+		const repo = input.repo.value;
+
+		const before = yield* listLabels(repo);
+		if (before._tag === "Failure") {
+			return refuse(
+				PRECONDITION_UNKNOWN,
+				`${VERB}: cannot probe ${repo} labels: ${before.reason} — nothing was written.`,
+			);
+		}
+		const have = new Set(before.value);
+		const missing = TAXONOMY.filter((label) => !have.has(label));
+		if (missing.length === 0) return already(surface.id, TAXONOMY.join(","), input.json);
+
+		for (const label of missing) {
+			const write = yield* createLabel(repo, label, LABEL_DESCRIPTION);
+			if (write._tag === "Failure") {
+				return refuse(
+					WRITE_UNKNOWN,
+					`${VERB}: writing label ${label} failed: ${write.reason} — whether it landed is UNKNOWN. Re-read before retrying.`,
+				);
+			}
+		}
+		const after = yield* listLabels(repo);
+		if (after._tag === "Failure") {
+			return refuse(
+				WRITE_UNKNOWN,
+				`${VERB}: created ${missing.join(",")} and the label set could not be re-read: ${after.reason} — the outcome is UNKNOWN.`,
+			);
+		}
+		const stillMissing = TAXONOMY.filter((label) => !after.value.includes(label));
+		if (stillMissing.length > 0) {
+			return refuse(
+				READBACK_MISMATCH,
+				`${VERB}: wrote ${missing.join(",")} and the read-back differs — ${stillMissing.join(",")} is still absent.`,
+			);
+		}
+		return created(
+			surface.id,
+			missing.join(","),
+			input.json,
+			`${VERB}: created ${missing.join(",")} for ${surface.id}, read-back conformed.`,
+		);
+	});
+
+const buildArtifact = (
+	surface: BuildableSurface,
+	input: BootstrapInput,
+): Effect.Effect<VerbOutcome, never, Requirements> =>
+	Effect.gen(function* () {
+		if (input.repo._tag === "Failure") return UNRESOLVED_REPO;
+		const repo = input.repo.value;
+
+		const before = yield* openIssuesTitled(repo, ARTIFACT_TITLE);
+		if (before._tag === "Failure") {
+			return refuse(
+				PRECONDITION_UNKNOWN,
+				`${VERB}: cannot probe ${repo} for "${ARTIFACT_TITLE}": ${before.reason} — nothing was written.`,
+			);
+		}
+		const found = before.value[0];
+		if (found !== undefined) return already(surface.id, `${repo}#${found.number}`, input.json);
+
+		const write = yield* createUnlabelledIssue(repo, ARTIFACT_TITLE, ARTIFACT_BODY);
+		if (write._tag === "Failure") {
+			return refuse(
+				WRITE_UNKNOWN,
+				`${VERB}: writing the ${ARTIFACT_TITLE} issue failed: ${write.reason} — whether it landed is UNKNOWN. Re-read before retrying.`,
+			);
+		}
+		const target = `${repo}#${write.value.number}`;
+		const back = yield* openIssuesTitled(repo, ARTIFACT_TITLE);
+		if (back._tag === "Failure") {
+			return refuse(
+				WRITE_UNKNOWN,
+				`${VERB}: created ${target} and it could not be read back: ${back.reason} — the outcome is UNKNOWN.`,
+			);
+		}
+		if (!back.value.some((issue) => issue.number === write.value.number)) {
+			return refuse(
+				READBACK_MISMATCH,
+				`${VERB}: wrote ${target} and the read-back differs — it does not resolve open under that exact title.`,
+			);
+		}
+		return created(
+			surface.id,
+			target,
+			input.json,
+			`${VERB}: created ${target} for ${surface.id}, read-back conformed.`,
+		);
+	});
+
+/** One surface per invocation, deliberately: a partial write reported as success is #4557's shape. */
+export const runBootstrap = (
+	input: BootstrapInput,
+): Effect.Effect<VerbOutcome, never, Requirements> => {
+	const surface = findSurface(input.surfaceId);
+	if (surface === undefined) {
+		return Effect.succeed(
+			refuse(
+				NOT_BUILDABLE,
+				`${VERB}: "${input.surfaceId}" is not a buildable surface. Known: ${knownIds()}.`,
+			),
+		);
+	}
+	if (surface.kind === "file") return buildFile(surface, input);
+	return surface.kind === "labels" ? buildLabels(surface, input) : buildArtifact(surface, input);
+};

--- a/packages/fabrika-cli/src/status/codes.ts
+++ b/packages/fabrika-cli/src/status/codes.ts
@@ -1,0 +1,52 @@
+/**
+ * The one exit table all six `status` verbs allocate from, so a code means one thing across this
+ * group whichever verb produced it
+ * (`claude-plugins/fabrika/skills/front-door/contract.md`, "The shared exit taxonomy").
+ *
+ * Every shared seat is **imported** from `../report/codes.ts` rather than restated as a numeral —
+ * the discipline `../triage/codes.ts` and `../ui/codes.ts` state in full: an import makes a drift
+ * unrepresentable where a copied number makes it merely detectable.
+ *
+ * `0`, `1`, `2` and `127` are reserved by the interface convention (`../verb.ts`, `../bin.ts`).
+ *
+ * **`7` and `11` are this group's load-bearing pair.** `7` is a fact about a *caller-supplied* path
+ * — it was named explicitly and is not there. `11` is a *failed read*. An implicitly-resolved roster
+ * holding zero skills is neither: it is `empty` at exit `0`, a fact the caller acts on.
+ */
+
+import {
+	BARE_AT_PATH as REPORT_BARE_AT_PATH,
+	CLASSIFIED as REPORT_CLASSIFIED,
+	EMPTY_STDIN as REPORT_EMPTY_STDIN,
+	LEAKED_PATH as REPORT_LEAKED_PATH,
+	NO_TARGET as REPORT_NO_TARGET,
+	PRECONDITION_UNKNOWN as REPORT_PRECONDITION_UNKNOWN,
+	READBACK_MISMATCH as REPORT_READBACK_MISMATCH,
+	WRITE_UNKNOWN as REPORT_WRITE_UNKNOWN,
+} from "../report/codes.ts";
+
+/** Stdin was read and held nothing. A read that *failed* is `1` — the content is UNKNOWN. */
+export const EMPTY_STDIN = REPORT_EMPTY_STDIN;
+/** The authored content carries a machine-local path. */
+export const LEAKED_PATH = REPORT_LEAKED_PATH;
+/** The authored content is a bare `@` path reference — not redactable, so a second code. */
+export const BARE_AT_PATH = REPORT_BARE_AT_PATH;
+/** Zero scope: an **explicitly passed** `--skills-dir` is proven absent (ADR 0092). */
+export const ZERO_SCOPE = REPORT_NO_TARGET;
+/** The write itself failed — whether anything landed is UNKNOWN. Re-read before retrying. */
+export const WRITE_UNKNOWN = REPORT_WRITE_UNKNOWN;
+/** The write landed and the read-back does not match. The artifact exists and needs a human. */
+export const READBACK_MISMATCH = REPORT_READBACK_MISMATCH;
+/** A supplied value is off its closed vocabulary — an unknown `--field`, a non-integer issue. */
+export const OFF_VOCABULARY = REPORT_CLASSIFIED;
+/** A precondition read failed — nothing was written and the outcome is UNKNOWN. */
+export const PRECONDITION_UNKNOWN = REPORT_PRECONDITION_UNKNOWN;
+
+/** Refused: the surface named is not in `status bootstrap`'s buildable-surface registry. */
+export const NOT_BUILDABLE = 12;
+
+/**
+ * The aligned body-section seat, held empty: no verb here composes body sections, so the gap is
+ * registered rather than silently absent.
+ */
+export const DELIBERATE_GAP = 4;

--- a/packages/fabrika-cli/src/status/command.ts
+++ b/packages/fabrika-cli/src/status/command.ts
@@ -1,0 +1,315 @@
+/**
+ * The `status` verb group — `fabrika status <verb>`.
+ *
+ * The adapter and nothing else: it declares the flags, reads the world, runs the pure verb, and
+ * emits its outcome. Every decision lives in the `*-verb.ts` modules beside it, which is what makes
+ * each refusal testable without spawning a process.
+ *
+ * **Every leaf is declared with `leafCommand`, never a bare `Command.make`** — the bare form
+ * silently opts out of the excess-operand guard, which `../excess-operand.unit.test.ts` reds on.
+ */
+import {fileURLToPath} from "node:url";
+import {Effect, type FileSystem, Option, type Path} from "effect";
+import {Argument, Command, Flag} from "effect/unstable/cli";
+import {discoverRepoRoot} from "../delegate/root.ts";
+import {leafCommand} from "../excess-operand.ts";
+import type {Attempt} from "../io/git.ts";
+import {listLabels, resolveRepo} from "../io/issues.ts";
+import {readStdin} from "../io/stdin.ts";
+import type {VerbOutcome} from "../verb.ts";
+import {readBoard, runBoard} from "./board-verb.ts";
+import {runBootstrap} from "./bootstrap-verb.ts";
+import {labelSetOf, probeSurfaces, runConfig, type SurfaceRow} from "./config-verb.ts";
+import {instant, readNow} from "./fields.ts";
+import {runMenu} from "./menu-verb.ts";
+import {
+	badFieldRefusal,
+	boardField,
+	configField,
+	FIELDS,
+	type Field,
+	isFieldName,
+	menuField,
+	readoutField,
+	runOpen,
+} from "./open-verb.ts";
+import {badIssueRefusal, issueNumberOf, readReadout, runReadout} from "./readout-verb.ts";
+import {type RosterSources, readRoster} from "./roster.ts";
+
+/** Write the outcome and exit on its code — stdout is the answer, everything else is stderr. */
+const emit = (outcome: VerbOutcome): Effect.Effect<void> =>
+	Effect.sync(() => {
+		for (const line of outcome.stderr) process.stderr.write(`${line}\n`);
+		if (outcome.stdout !== "") process.stdout.write(outcome.stdout);
+		process.exit(outcome.code);
+	});
+
+const repoFlag = Flag.string("repo").pipe(
+	Flag.optional,
+	Flag.withDescription(
+		"the target owner/name (default: $CLAUDE_PIPELINE_REPO, else $GITHUB_REPOSITORY, else the origin remote)",
+	),
+);
+
+const skillsDirFlag = Flag.string("skills-dir").pipe(
+	Flag.optional,
+	Flag.withDescription(
+		"the roster root to read (default: the installed plugin's own skills tree, else claude-plugins/fabrika/skills beneath the repo root)",
+	),
+);
+
+const jsonFlag = Flag.boolean("json").pipe(
+	Flag.withDescription("emit the full result object on stdout instead of the line grammar"),
+);
+
+/** The roster sources this invocation resolves against — the module's own location and the cwd. */
+const rosterSources = (explicit: string | null): RosterSources => ({
+	explicit,
+	moduleDir: fileURLToPath(new URL(".", import.meta.url)),
+	cwd: process.cwd(),
+});
+
+/**
+ * The repository root a declared path is probed against, falling back to the cwd.
+ *
+ * The fallback is safe here and only here: a probe rooted at the cwd answers about *some* real
+ * directory, and every row it produces says which path it looked at. Nothing is reported present
+ * that was not found.
+ */
+const repositoryRoot: Effect.Effect<string, never, FileSystem.FileSystem | Path.Path> = Effect.gen(
+	function* () {
+		const found = yield* Effect.result(discoverRepoRoot(process.cwd()));
+		return found._tag === "Success" ? (found.success ?? process.cwd()) : process.cwd();
+	},
+);
+
+const resolveTarget = (explicit: string | null) => resolveRepo(explicit, process.env);
+
+const menu = leafCommand(
+	"menu",
+	{skillsDir: skillsDirFlag, json: jsonFlag},
+	Effect.fn(function* ({skillsDir, json}) {
+		const roster = yield* readRoster(rosterSources(Option.getOrNull(skillsDir)));
+		yield* emit(runMenu({roster, asOf: readNow(instant(new Date())), json}));
+	}),
+).pipe(
+	Command.withDescription(
+		"List the landed skill roster, derived from the installed plugin's skills tree rather than from a committed file. First stdout line is `menu\\t<ready|empty>\\t<count>\\t<as-of>`, then one `skill\\t<name>\\t<invocation>\\t<model|user>\\t<description>` line each. An implicitly-resolved roster holding zero skills is `empty` at exit 0. Exits 7 (an explicitly passed --skills-dir is proven absent), 11 (the resolved roster could not be read — UNKNOWN, never empty). Example: fabrika status menu",
+	),
+);
+
+const config = leafCommand(
+	"config",
+	{
+		skill: Flag.string("skill").pipe(Flag.optional),
+		skillsDir: skillsDirFlag,
+		repo: repoFlag,
+		json: jsonFlag,
+	},
+	Effect.fn(function* ({skill, skillsDir, repo, json}) {
+		const roster = yield* readRoster(rosterSources(Option.getOrNull(skillsDir)));
+		if (roster._tag !== "Resolved") {
+			yield* emit(runConfig({roster, surfaces: [], json}));
+			return;
+		}
+		const target = yield* resolveTarget(Option.getOrNull(repo));
+		const labels = target._tag === "Ok" ? yield* listLabels(target.value) : null;
+		const surfaces = yield* probeSurfaces({
+			roster,
+			only: Option.getOrNull(skill),
+			ctx: {
+				repoRoot: yield* repositoryRoot,
+				labels: labelSetOf(labels),
+				repoName: target._tag === "Ok" ? target.value : "the target repo",
+				asOf: readNow(instant(new Date())),
+			},
+		});
+		yield* emit(runConfig({roster, surfaces, json}));
+	}),
+).pipe(
+	Command.withDescription(
+		"Report which repo surfaces every landed skill declares it needs and whether each is present here — the detection verb (#4952). First stdout line is `config\\t<satisfied|gaps|unknown>\\t<declared>\\t<missing>\\t<undeclared>\\t<off-vocabulary>`, then one `surface\\t…` line per declared row. A skill with no `## Required repo files` section emits one `undeclared` row, never zero. Exits 7 (an explicitly passed --skills-dir is proven absent), 11 (the roster or a SKILL.md inside it could not be read — the declaration set is UNKNOWN). Example: fabrika status config",
+	),
+);
+
+const board = leafCommand(
+	"board",
+	{repo: repoFlag, json: jsonFlag},
+	Effect.fn(function* ({repo, json}) {
+		const target = yield* resolveTarget(Option.getOrNull(repo));
+		if (target._tag === "Failure") {
+			yield* emit(
+				runBoard({
+					read: {_tag: "Failed", repo: "the target repo", reason: target.reason},
+					json,
+				}),
+			);
+			return;
+		}
+		yield* emit(runBoard({read: yield* readBoard(target.value, () => new Date()), json}));
+	}),
+).pipe(
+	Command.withDescription(
+		"Count the board's decided buckets over named REST endpoints — needs-triage, triaged, in-flight and one per priority — each with its own freshness. An absent label renders `unknown` with detail `label absent`, never 0. First stdout line is `board\\t<counted|unknown>\\t<bucket-count>`, then one `bucket\\t…` line each. Exits 11 (the repository could not be read at all — every bucket is UNKNOWN). Example: fabrika status board",
+	),
+);
+
+const readout = leafCommand(
+	"readout",
+	{
+		issue: Argument.string("issue").pipe(
+			Argument.optional,
+			Argument.withDescription(
+				'the artifact issue number (default: $FABRIKA_GOVERNANCE_READOUT_ISSUE, else the single open issue titled exactly "Governance readout")',
+			),
+		),
+		repo: repoFlag,
+		json: jsonFlag,
+	},
+	Effect.fn(function* ({issue, repo, json}) {
+		const supplied = Option.getOrNull(issue);
+		const number = supplied === null ? null : issueNumberOf(supplied);
+		if (supplied !== null && number === null) {
+			yield* emit(badIssueRefusal(supplied));
+			return;
+		}
+		const target = yield* resolveTarget(Option.getOrNull(repo));
+		const read = yield* readReadout({
+			repo: target._tag === "Ok" ? target.value : "",
+			issue: number,
+			env: process.env,
+		});
+		yield* emit(runReadout({read, json}));
+	}),
+).pipe(
+	Command.withDescription(
+		"Display the landed-decision digest published in the durable artifact, decoded through the registered governance-digest wire format. This verb ranks nothing. First stdout line is `readout\\t<found|absent|malformed>\\t<row-count>\\t<source>\\t<as-of>`, then the digest's own rows. A closed or absent artifact is `absent` at exit 0. Exits 10 (the positional is not a positive issue number), 11 (the artifact could not be fetched, its updated_at was unreadable, or the format is not registered — UNKNOWN, never absent). Example: fabrika status readout",
+	),
+);
+
+const bootstrap = leafCommand(
+	"bootstrap",
+	{
+		surface: Argument.string("surface-id").pipe(
+			Argument.withDescription(
+				"one id from the buildable-surface registry: design-manifest, roadmap-focus, label-taxonomy, readout-artifact",
+			),
+		),
+		path: Flag.string("path").pipe(
+			Flag.optional,
+			Flag.withDescription(
+				"override the write path for a file surface; must resolve inside the repository root",
+			),
+		),
+		repo: repoFlag,
+		json: jsonFlag,
+	},
+	Effect.fn(function* ({surface, path, repo, json}) {
+		yield* emit(
+			yield* runBootstrap({
+				surfaceId: surface,
+				path: Option.getOrNull(path),
+				json,
+				repoRoot: yield* repositoryRoot,
+				repo: yield* resolveTarget(Option.getOrNull(repo)),
+				stdin: Effect.sync(readStdin),
+			}),
+		);
+	}),
+).pipe(
+	Command.withDescription(
+		"Create one missing repo surface from this group's own buildable-surface registry and read it back. The content of a file surface arrives on STDIN — the write, the collision guard and the read-back are this verb's; what the file says is the skill's. A target already present is `exists` at exit 0 and nothing is written. Stdout is the single line `bootstrap\\t<created|exists>\\t<surface-id>\\t<target>\\t<readback>`. Exits 3 (stdin held nothing), 5 (the content carries a machine-local path), 6 (the content is a bare @ path reference), 8 (the write failed — UNKNOWN), 9 (the read-back differs), 10 (--path resolves outside the repository root), 11 (the existence probe failed — nothing was written), 12 (the surface is not in the registry). Example: fabrika status bootstrap readout-artifact",
+	),
+);
+
+const open = leafCommand(
+	"open",
+	{
+		field: Flag.string("field").pipe(
+			Flag.optional,
+			Flag.withDescription(`render one field only: ${FIELDS.join(", ")}`),
+		),
+		repo: repoFlag,
+		skillsDir: skillsDirFlag,
+		json: jsonFlag,
+	},
+	Effect.fn(function* ({field, repo, skillsDir, json}) {
+		const only = Option.getOrNull(field);
+		if (only !== null && !isFieldName(only)) {
+			yield* emit(badFieldRefusal(only));
+			return;
+		}
+		const wanted = only === null ? FIELDS : [only];
+		const asOf = readNow(instant(new Date()));
+		const target: Attempt<string> = yield* resolveTarget(Option.getOrNull(repo));
+		const repoName = target._tag === "Ok" ? target.value : "unresolved";
+
+		const needsRoster = wanted.includes("menu") || wanted.includes("config");
+		const roster = needsRoster
+			? yield* readRoster(rosterSources(Option.getOrNull(skillsDir)))
+			: null;
+
+		const fields: Field[] = [];
+		let surfaces: ReadonlyArray<SurfaceRow> = [];
+		if (roster !== null && roster._tag === "Resolved" && wanted.includes("config")) {
+			const labels = target._tag === "Ok" ? yield* listLabels(target.value) : null;
+			surfaces = yield* probeSurfaces({
+				roster,
+				only: null,
+				ctx: {
+					repoRoot: yield* repositoryRoot,
+					labels: labelSetOf(labels),
+					repoName,
+					asOf,
+				},
+			});
+		}
+		for (const name of wanted) {
+			if (name === "menu" && roster !== null) fields.push(menuField(roster, asOf));
+			if (name === "config" && roster !== null) fields.push(configField(roster, surfaces, asOf));
+			if (name === "board") {
+				fields.push(
+					boardField(
+						target._tag === "Ok"
+							? yield* readBoard(target.value, () => new Date())
+							: {_tag: "Failed", repo: repoName, reason: target.reason},
+					),
+				);
+			}
+			if (name === "readout") {
+				fields.push(
+					readoutField(
+						target._tag === "Ok"
+							? yield* readReadout({repo: target.value, issue: null, env: process.env})
+							: {_tag: "Unfetchable", repo: repoName, issue: null, reason: target.reason},
+					),
+				);
+			}
+		}
+		const rosterScope =
+			roster === null
+				? "roster not read"
+				: `roster ${roster.display}${roster._tag === "Resolved" ? ` (${roster.tier})` : " (unresolved)"}`;
+		yield* emit(runOpen({fields, json, scope: `${rosterScope}; repo ${repoName}`}));
+	}),
+).pipe(
+	Command.withDescription(
+		"The composite front-door readout: four fields — menu, config, board, readout — each with its own state, source and freshness. Every unreadable source becomes a field state, so this verb has no zero-scope seat and no failed-read seat: it is injected before the session reads a token and a refusal would write zero bytes. First stdout line is `open\\t<field-count>`, then one `field\\t<name>\\t<state>\\t<detail>\\t<source>\\t<as-of>` line each. Exits 10 (--field is off the closed vocabulary). Example: fabrika status open",
+	),
+);
+
+export const statusCommand = Command.make("status").pipe(
+	Command.withSubcommands([
+		// One leaf per line, so concurrent slices append at distinct lines rather than all editing
+		// one. The comment is what keeps the formatter from collapsing the list back.
+		open,
+		config,
+		menu,
+		readout,
+		board,
+		bootstrap,
+	]),
+	Command.withDescription(
+		"Answer what state the factory is in — the composite front-door readout, the config-surface detection verb, the derived skill roster, the landed-decision digest, the board's bucket counts, and the one primitive that creates a missing surface",
+	),
+);

--- a/packages/fabrika-cli/src/status/config-verb.ts
+++ b/packages/fabrika-cli/src/status/config-verb.ts
@@ -1,0 +1,289 @@
+/**
+ * `status config` — which repo surfaces every landed skill declares it needs, and whether each is
+ * present here. The detection verb the founder ruled into existence in place of v1's `/doctor`
+ * skill (#4952, and the kill ruling #4722 that stands): machine-answerable, exit-coded, zero
+ * judgement.
+ *
+ * **`present` is the only state this verb can prove.** `missing` is a probe that ran and found
+ * nothing; `unprobeable` is a subject no probe settles; `unknown` is a probe that could not be
+ * performed. Rendering an unprobeable subject `present` off some file's existence is the false
+ * positive the four-state set exists to prevent, and scoring an undeclared skill clean is the
+ * fail-open of #4060.
+ */
+import {Effect, type FileSystem, type Path, Result} from "effect";
+import {exists} from "../io/fs.ts";
+import type {Attempt} from "../io/git.ts";
+import {answer, type VerbOutcome} from "../verb.ts";
+import {type AsOf, asOfToken, detail, EMPTY_CELL, row} from "./fields.ts";
+import {rosterRefusal} from "./menu-verb.ts";
+import {CANONICAL_DISPOSITIONS, type DeclaredRow, parseRequiredFiles} from "./required-files.ts";
+import type {RosterRead, RosterSkill} from "./roster.ts";
+
+const VERB = "status config";
+
+/** The declaration a skill with no `## Required repo files` section carries: nobody checked. */
+export const UNDECLARED = "undeclared";
+
+export type Presence = "present" | "missing" | "unprobeable" | "unknown";
+export type ConfigState = "satisfied" | "gaps" | "unknown";
+
+export interface SurfaceRow {
+	readonly skill: string;
+	readonly surfaceId: string;
+	readonly disposition: string;
+	readonly presence: Presence;
+	readonly consequence: string;
+	readonly detail: string;
+	readonly asOf: AsOf;
+}
+
+export interface ConfigCounts {
+	readonly declaredSkills: number;
+	readonly missing: number;
+	readonly undeclaredSkills: number;
+	readonly offVocabulary: number;
+	readonly unprobeable: number;
+	readonly probed: number;
+}
+
+/**
+ * The label set of the target repo, or the reason it is UNKNOWN.
+ *
+ * A label probe that could not be *performed* is not the same as a label that is not there, so an
+ * unresolvable repo renders every label row `unknown` rather than `missing`.
+ */
+export type LabelSet =
+	| {readonly _tag: "Known"; readonly labels: ReadonlySet<string>}
+	| {readonly _tag: "Unknown"; readonly reason: string};
+
+export const labelSetOf = (repo: Attempt<ReadonlyArray<string>> | null): LabelSet =>
+	repo === null
+		? {_tag: "Unknown", reason: "no repo resolved — the label probe could not be performed"}
+		: repo._tag === "Failure"
+			? {_tag: "Unknown", reason: repo.reason}
+			: {_tag: "Known", labels: new Set(repo.value)};
+
+/**
+ * Every row a skill declares — or the single `undeclared` row that a missing section is.
+ *
+ * Never zero rows: an absent declaration means nobody checked, which is #5049's own stated reason
+ * for requiring the section.
+ */
+export const declaredRowsOf = (skill: RosterSkill): ReadonlyArray<DeclaredRow> | null =>
+	parseRequiredFiles(skill.text);
+
+const undeclaredRow = (skill: string, asOf: AsOf): SurfaceRow => ({
+	skill,
+	surfaceId: EMPTY_CELL,
+	disposition: UNDECLARED,
+	presence: "unknown",
+	consequence: EMPTY_CELL,
+	detail: "no `## Required repo files` section",
+	asOf,
+});
+
+export interface ProbeContext {
+	/** The directory a declared path is resolved against — the invocation's repository root. */
+	readonly repoRoot: string;
+	readonly labels: LabelSet;
+	readonly repoName: string;
+	readonly asOf: AsOf;
+}
+
+/** Probe one declared row's subject. A probe that could not be performed is `unknown`, never `false`. */
+export const probeRow = (
+	skill: string,
+	declared: DeclaredRow,
+	ctx: ProbeContext,
+): Effect.Effect<SurfaceRow, never, FileSystem.FileSystem | Path.Path> =>
+	Effect.gen(function* () {
+		const base = {
+			skill,
+			surfaceId: declared.surfaceId,
+			disposition: declared.disposition,
+			consequence: detail(declared.consequence),
+			asOf: ctx.asOf,
+		};
+		if (declared.subject._tag === "Unprobeable") {
+			return {...base, presence: "unprobeable" as const, detail: detail(declared.subject.reason)};
+		}
+		if (declared.subject._tag === "Labels") {
+			if (ctx.labels._tag === "Unknown") {
+				return {...base, presence: "unknown" as const, detail: detail(ctx.labels.reason)};
+			}
+			const known = ctx.labels.labels;
+			const absent = declared.subject.labels.filter((label) => !known.has(label));
+			return absent.length === 0
+				? {
+						...base,
+						presence: "present" as const,
+						detail: detail(declared.subject.labels.join(",")),
+					}
+				: {
+						...base,
+						presence: "missing" as const,
+						detail: detail(`no label ${absent.join(",")} in ${ctx.repoName}`),
+					};
+		}
+		const declaredPath = declared.subject.path;
+		const probe = yield* Effect.result(exists(`${ctx.repoRoot}/${declaredPath}`));
+		if (Result.isFailure(probe)) {
+			return {...base, presence: "unknown" as const, detail: detail(probe.failure.reason)};
+		}
+		return probe.success
+			? {...base, presence: "present" as const, detail: declaredPath}
+			: {
+					...base,
+					presence: "missing" as const,
+					detail: detail(`no ${declaredPath} at the repo root`),
+				};
+	});
+
+export interface SurfacesInput {
+	readonly roster: Extract<RosterRead, {readonly _tag: "Resolved"}>;
+	/** `--skill`, when the caller narrowed the scope. */
+	readonly only: string | null;
+	readonly ctx: ProbeContext;
+}
+
+/** Every declared surface across the roster, ordered by skill then the row's order in its table. */
+export const probeSurfaces = ({
+	roster,
+	only,
+	ctx,
+}: SurfacesInput): Effect.Effect<
+	ReadonlyArray<SurfaceRow>,
+	never,
+	FileSystem.FileSystem | Path.Path
+> =>
+	Effect.gen(function* () {
+		const scoped =
+			only === null ? roster.skills : roster.skills.filter((skill) => skill.name === only);
+		if (only !== null && scoped.length === 0) {
+			return [{...undeclaredRow(only, ctx.asOf), detail: "not in the roster"}];
+		}
+		const out: SurfaceRow[] = [];
+		for (const skill of scoped) {
+			const declared = declaredRowsOf(skill);
+			if (declared === null || declared.length === 0) {
+				out.push(undeclaredRow(skill.name, ctx.asOf));
+				continue;
+			}
+			for (const one of declared) out.push(yield* probeRow(skill.name, one, ctx));
+		}
+		return out;
+	});
+
+/**
+ * The header counts.
+ *
+ * `<missing>` **deduplicates by id**, so a surface three skills declare counts once — while every
+ * declaring row still prints, so no declaration is hidden. Rows with no id token cannot dedupe
+ * against each other and each counts, which is the honest reading while landed skills carry none.
+ */
+export const countsOf = (surfaces: ReadonlyArray<SurfaceRow>): ConfigCounts => {
+	const declaring = new Set<string>();
+	const undeclaredSkills = new Set<string>();
+	const missingIds = new Set<string>();
+	let missingUnidentified = 0;
+	let offVocabulary = 0;
+	let unprobeable = 0;
+	let probed = 0;
+	for (const surface of surfaces) {
+		if (surface.disposition === UNDECLARED) {
+			undeclaredSkills.add(surface.skill);
+			continue;
+		}
+		declaring.add(surface.skill);
+		if (!CANONICAL_DISPOSITIONS.includes(surface.disposition)) offVocabulary += 1;
+		if (surface.presence === "unprobeable") unprobeable += 1;
+		if (surface.presence === "present" || surface.presence === "missing") probed += 1;
+		if (surface.presence !== "missing") continue;
+		if (surface.surfaceId === EMPTY_CELL) missingUnidentified += 1;
+		else missingIds.add(surface.surfaceId);
+	}
+	return {
+		declaredSkills: declaring.size,
+		missing: missingIds.size + missingUnidentified,
+		undeclaredSkills: undeclaredSkills.size,
+		offVocabulary,
+		unprobeable,
+		probed,
+	};
+};
+
+/**
+ * The header state.
+ *
+ * `satisfied` requires *proof* for every declared surface, which is why a row-level `unknown`
+ * lands under `gaps` alongside `missing`: an unperformed probe is not a present surface, and a
+ * detection verb that scored it clean would be the fail-open this verb exists to remove.
+ */
+export const configState = (
+	surfaces: ReadonlyArray<SurfaceRow>,
+	skillCount: number,
+): ConfigState => {
+	if (skillCount === 0) return "gaps";
+	return surfaces.every((s) => s.disposition !== UNDECLARED && s.presence === "present")
+		? "satisfied"
+		: "gaps";
+};
+
+export interface ConfigInput {
+	readonly roster: RosterRead;
+	readonly surfaces: ReadonlyArray<SurfaceRow>;
+	readonly json: boolean;
+}
+
+export const runConfig = ({roster, surfaces, json}: ConfigInput): VerbOutcome => {
+	if (roster._tag !== "Resolved") return rosterRefusal(VERB, roster);
+	const counts = countsOf(surfaces);
+	const state = configState(surfaces, roster.skills.length);
+	const notice = `${VERB}: roster ${roster.display} (${roster.tier}), ${roster.skills.length} skills, ${counts.declaredSkills} declaring, ${counts.undeclaredSkills} undeclared; probed ${counts.probed} surfaces, ${counts.unprobeable} unprobeable.`;
+
+	if (json) {
+		return answer(
+			`${JSON.stringify({
+				outcome: state,
+				declaredSkills: counts.declaredSkills,
+				missing: counts.missing,
+				undeclaredSkills: counts.undeclaredSkills,
+				offVocabulary: counts.offVocabulary,
+				surfaces: surfaces.map((s) => ({
+					skill: s.skill,
+					surfaceId: s.surfaceId,
+					disposition: s.disposition,
+					presence: s.presence,
+					consequence: s.consequence,
+					detail: s.detail,
+					asOf: s.asOf.at,
+					asOfKind: s.asOf.kind,
+				})),
+			})}\n`,
+			[notice],
+		);
+	}
+	const lines = [
+		row(
+			"config",
+			state,
+			String(counts.declaredSkills),
+			String(counts.missing),
+			String(counts.undeclaredSkills),
+			String(counts.offVocabulary),
+		),
+		...surfaces.map((s) =>
+			row(
+				"surface",
+				s.skill,
+				s.surfaceId,
+				s.disposition,
+				s.presence,
+				s.consequence,
+				s.detail,
+				asOfToken(s.asOf),
+			),
+		),
+	];
+	return answer(`${lines.join("\n")}\n`, [notice]);
+};

--- a/packages/fabrika-cli/src/status/fields.ts
+++ b/packages/fabrika-cli/src/status/fields.ts
@@ -1,0 +1,52 @@
+/**
+ * The line grammar every `status` verb shares: tab-separated rows whose every field is tab-free,
+ * and a freshness token that is printed rather than implied.
+ *
+ * A `<detail>` is prose in a machine channel, so it is stripped of tabs and newlines and clamped
+ * before it is ever joined into a row — prose describing a shape is not a shape, and a row whose
+ * detail carried a tab would parse as extra columns.
+ */
+
+/** The token an unestablished timestamp prints. It moves with the field's state, never alone. */
+export const UNKNOWN_AS_OF = "unknown";
+
+/** Where an `<as-of>` came from: this invocation's read, or the artifact's own last write. */
+export type AsOfKind = "read-now" | "artifact";
+
+/** A field's freshness: an instant with its provenance, or an unestablished one. */
+export interface AsOf {
+	readonly at: string | null;
+	readonly kind: AsOfKind | null;
+}
+
+export const readNow = (at: string): AsOf => ({at, kind: "read-now"});
+export const fromArtifact = (at: string): AsOf => ({at, kind: "artifact"});
+export const noAsOf: AsOf = {at: null, kind: null};
+
+export const asOfToken = (asOf: AsOf): string => asOf.at ?? UNKNOWN_AS_OF;
+
+/** An ISO-8601 UTC instant to the second — the grammar `<as-of>` declares. */
+export const instant = (date: Date): string => `${date.toISOString().slice(0, 19)}Z`;
+
+/**
+ * Prose fit for a tab-separated field: tabs and newlines collapsed to spaces, then clamped.
+ *
+ * Clamping is not cosmetic — the raw failed read is reproduced verbatim *before* it, so a truncated
+ * detail is still attributable to the read that produced it.
+ */
+export const oneLine = (text: string, max: number): string => {
+	const flat = text.replace(/[\t\r\n]+/g, " ").trim();
+	return flat.length <= max ? flat : flat.slice(0, max);
+};
+
+/** A `<detail>` field: 120 characters, the group-wide clamp. */
+export const detail = (text: string): string => oneLine(text, 120);
+
+/** A skill description: 200 characters, the roster's clamp. */
+export const description = (text: string): string => oneLine(text, 200);
+
+/** A row of tab-separated cells, each already tab-free. */
+export const row = (...cells: ReadonlyArray<string>): string => cells.join("\t");
+
+/** A dash stands in for a cell with no value — never an empty cell, which reads as a lost column. */
+export const EMPTY_CELL = "-";

--- a/packages/fabrika-cli/src/status/menu-verb.ts
+++ b/packages/fabrika-cli/src/status/menu-verb.ts
@@ -1,0 +1,78 @@
+/**
+ * `status menu` — the landed skill roster, derived from the installed plugin's skills tree.
+ *
+ * **The roster is derived, never stored.** No committed menu file and no generate step: the
+ * directory is the list, the same on-demand idiom ADR 0129 applies to the repo's decision records. A
+ * committed roster is a copy, and a copy rots.
+ *
+ * **The header has two states, not three.** `unknown` is a *composite* rendering — this verb refuses
+ * instead, because a caller invoking `menu` directly reads the exit status.
+ */
+import {answer, refuse, type VerbOutcome} from "../verb.ts";
+import {PRECONDITION_UNKNOWN, ZERO_SCOPE} from "./codes.ts";
+import {type AsOf, asOfToken, description, row} from "./fields.ts";
+import type {RosterRead} from "./roster.ts";
+
+const VERB = "status menu";
+
+export type MenuState = "ready" | "empty";
+
+export interface MenuInput {
+	readonly roster: RosterRead;
+	readonly asOf: AsOf;
+	readonly json: boolean;
+}
+
+export const menuState = (skillCount: number): MenuState => (skillCount === 0 ? "empty" : "ready");
+
+/** A roster read that did not resolve — the only two shapes that owe a refusal. */
+export type RosterUnresolved = Exclude<RosterRead, {readonly _tag: "Resolved"}>;
+
+/**
+ * The refusal an unresolved roster owes.
+ *
+ * Shared with `status config`, which seats the identical pair on the identical two codes: `7` is a
+ * fact about a caller-supplied path, `11` is a failed read, and folding them is the defect this
+ * group exists to prevent.
+ */
+export const rosterRefusal = (verb: string, roster: RosterUnresolved): VerbOutcome =>
+	roster._tag === "AbsentExplicit"
+		? refuse(
+				ZERO_SCOPE,
+				`${verb}: --skills-dir ${roster.display} is proven absent — refusing to answer (ADR 0092).`,
+			)
+		: refuse(
+				PRECONDITION_UNKNOWN,
+				`${verb}: cannot read ${roster.display}: ${roster.reason} — the roster is UNKNOWN, never empty.`,
+			);
+
+export const runMenu = ({roster, asOf, json}: MenuInput): VerbOutcome => {
+	if (roster._tag !== "Resolved") return rosterRefusal(VERB, roster);
+
+	const state = menuState(roster.skills.length);
+	const notice = `${VERB}: roster ${roster.display} (${roster.tier}), ${roster.skills.length} skills, ${roster.unreadableFrontmatter} unreadable frontmatter.`;
+	const rows = roster.skills.map((skill) => ({
+		name: skill.name,
+		invocation: skill.invocation,
+		invocationAxis: skill.invocationAxis,
+		description: description(skill.description),
+	}));
+
+	if (json) {
+		return answer(
+			`${JSON.stringify({
+				outcome: state,
+				count: rows.length,
+				asOf: asOf.at,
+				asOfKind: asOf.kind,
+				skills: rows,
+			})}\n`,
+			[notice],
+		);
+	}
+	const lines = [
+		row("menu", state, String(rows.length), asOfToken(asOf)),
+		...rows.map((r) => row("skill", r.name, r.invocation, r.invocationAxis, r.description)),
+	];
+	return answer(`${lines.join("\n")}\n`, [notice]);
+};

--- a/packages/fabrika-cli/src/status/open-verb.ts
+++ b/packages/fabrika-cli/src/status/open-verb.ts
@@ -1,0 +1,222 @@
+/**
+ * `status open` — the composite front-door readout: four fields, each with its own state, source
+ * and freshness.
+ *
+ * **This verb has no zero-scope seat and no failed-read seat at all.** It is the command the skill
+ * injects before the session reads a token, and `../verb.ts`'s `refuse()` hardcodes empty stdout —
+ * so a front door that refused would be silent on exactly the cold start it exists for. Every
+ * source it cannot read becomes a *field state*. Its only refusal is a bad `--field`.
+ *
+ * **It composes by importing the sibling verbs' pure cores, never by spawning a verb and reading
+ * its exit code.** A composite that mapped sibling exit codes would be the package's first
+ * cross-group code reader, which would turn every legitimate code reuse into a defect. The mapping
+ * from a core's outcome to a field state is the table below, stated rather than left to the
+ * implementer, because that mapping *is* the group's purpose: keeping proven-empty apart from
+ * unread.
+ *
+ * **No aggregate state, deliberately.** A roll-up over four independently-sourced fields would need
+ * a rule for "three fine, one unknown", and every such rule either hides the unknown or drowns the
+ * three.
+ */
+import {answer, refuse, type VerbOutcome} from "../verb.ts";
+import type {BoardRead} from "./board-verb.ts";
+import {boardState} from "./board-verb.ts";
+import {OFF_VOCABULARY} from "./codes.ts";
+import {configState, countsOf, type SurfaceRow} from "./config-verb.ts";
+import {type AsOf, asOfToken, detail, noAsOf, row} from "./fields.ts";
+import {menuState} from "./menu-verb.ts";
+import {type ReadoutRead, readingOf} from "./readout-verb.ts";
+import type {RosterRead} from "./roster.ts";
+
+const VERB = "status open";
+
+/** The closed `--field` vocabulary. Any other value is off-vocabulary. */
+export const FIELDS = ["menu", "config", "board", "readout"] as const;
+export type FieldName = (typeof FIELDS)[number];
+
+export interface Field {
+	readonly name: FieldName;
+	readonly state: string;
+	readonly detail: string;
+	readonly source: string;
+	readonly asOf: AsOf;
+}
+
+/** `unknown` is in every field's closed set — that is what makes this verb total. */
+export const UNKNOWN = "unknown";
+
+const rosterSource = (roster: RosterRead): string => roster.display;
+
+export const menuField = (roster: RosterRead, asOf: AsOf): Field =>
+	roster._tag === "Resolved"
+		? {
+				name: "menu",
+				state: menuState(roster.skills.length),
+				detail:
+					roster.skills.length === 0
+						? `no skills in ${roster.tier} roster`
+						: `${roster.skills.length} skills`,
+				source: rosterSource(roster),
+				asOf,
+			}
+		: {
+				name: "menu",
+				state: UNKNOWN,
+				detail: detail(
+					roster._tag === "Failed" ? roster.reason : "the named --skills-dir is not there",
+				),
+				source: rosterSource(roster),
+				asOf: noAsOf,
+			};
+
+/**
+ * The one row worth naming: a roster that resolved and holds **zero** skills is `gaps`, never
+ * `satisfied`. "Every declared surface is present" is vacuously true over zero surfaces, and
+ * rendering the fresh install this skill onboards as fine is the exact fail-open of #4060.
+ */
+export const configField = (
+	roster: RosterRead,
+	surfaces: ReadonlyArray<SurfaceRow>,
+	asOf: AsOf,
+): Field => {
+	if (roster._tag !== "Resolved") {
+		return {
+			name: "config",
+			state: UNKNOWN,
+			detail: detail(
+				roster._tag === "Failed" ? roster.reason : "the named --skills-dir is not there",
+			),
+			source: rosterSource(roster),
+			asOf: noAsOf,
+		};
+	}
+	if (roster.skills.length === 0) {
+		return {
+			name: "config",
+			state: "gaps",
+			detail: "empty roster — nothing declared, nothing proven",
+			source: roster.display,
+			asOf,
+		};
+	}
+	const counts = countsOf(surfaces);
+	return {
+		name: "config",
+		state: configState(surfaces, roster.skills.length),
+		detail: `${counts.declaredSkills} declared, ${counts.missing} missing, ${counts.undeclaredSkills} undeclared`,
+		source: roster.display,
+		asOf,
+	};
+};
+
+export const boardField = (read: BoardRead): Field => {
+	if (read._tag === "Failed") {
+		return {
+			name: "board",
+			state: UNKNOWN,
+			detail: detail(`${read.reason} — a failed read, not zero issues`),
+			source: read.repo,
+			asOf: noAsOf,
+		};
+	}
+	const state = boardState(read.buckets);
+	const first = read.buckets.find((bucket) => bucket.name === "needs-triage");
+	const second = read.buckets.find((bucket) => bucket.name === "triaged");
+	if (state === "counted") {
+		return {
+			name: "board",
+			state,
+			detail: `${first?.count ?? 0} needs-triage, ${second?.count ?? 0} triaged`,
+			source: read.repo,
+			asOf: read.buckets[0]?.asOf ?? noAsOf,
+		};
+	}
+	const unknown = read.buckets.filter((bucket) => bucket.count === null);
+	return {
+		name: "board",
+		state: UNKNOWN,
+		detail: detail(
+			`${unknown.map((bucket) => bucket.name).join(",")}: ${unknown[0]?.detail ?? "unreadable"}`,
+		),
+		source: read.repo,
+		asOf: noAsOf,
+	};
+};
+
+/**
+ * **A proven-absent artifact is `absent` inside the composite, never `unknown`** — an absence the
+ * repository proves is a fact. Only a failed *read* is `unknown`, which is why an unregistered
+ * decoder lands there: an unbuilt decoder proves nothing about whether a digest exists.
+ */
+export const readoutField = (read: ReadoutRead): Field => {
+	const reading = readingOf(read);
+	if (reading !== null) {
+		return {
+			name: "readout",
+			state: reading.state,
+			detail: reading.detail,
+			source: reading.source,
+			asOf: reading.asOf,
+		};
+	}
+	return {
+		name: "readout",
+		state: UNKNOWN,
+		detail: detail(
+			read._tag === "NoFormat"
+				? "the governance-digest format is not registered — a failed read, not an absent digest"
+				: read._tag === "Unfetchable"
+					? `${read.reason} — a failed read, not an absent digest`
+					: "the digest could not be read",
+		),
+		source:
+			read._tag === "Unfetchable" && read.issue !== null
+				? `${read.repo}#${read.issue}`
+				: read._tag === "NoFormat"
+					? "unknown"
+					: read.repo,
+		asOf: noAsOf,
+	};
+};
+
+export const isFieldName = (value: string): value is FieldName =>
+	(FIELDS as ReadonlyArray<string>).includes(value);
+
+/** The one refusal seat this verb has. */
+export const badFieldRefusal = (value: string): VerbOutcome =>
+	refuse(OFF_VOCABULARY, `${VERB}: --field "${value}" is not one of ${FIELDS.join(", ")}.`);
+
+export interface OpenInput {
+	readonly fields: ReadonlyArray<Field>;
+	readonly json: boolean;
+	/** The notice line's scope half — the roster, its tier and the repo the reads resolved to. */
+	readonly scope: string;
+}
+
+export const runOpen = ({fields, json, scope}: OpenInput): VerbOutcome => {
+	const unknown = fields.filter((field) => field.state === UNKNOWN).length;
+	const notice = `${VERB}: ${scope}; ${fields.length} field(s) rendered, ${unknown} unknown.`;
+	if (json) {
+		return answer(
+			`${JSON.stringify({
+				outcome: "open",
+				fields: fields.map((field) => ({
+					name: field.name,
+					state: field.state,
+					detail: field.detail,
+					source: field.source,
+					asOf: field.asOf.at,
+					asOfKind: field.asOf.kind,
+				})),
+			})}\n`,
+			[notice],
+		);
+	}
+	const lines = [
+		row("open", String(fields.length)),
+		...fields.map((field) =>
+			row("field", field.name, field.state, field.detail, field.source, asOfToken(field.asOf)),
+		),
+	];
+	return answer(`${lines.join("\n")}\n`, [notice]);
+};

--- a/packages/fabrika-cli/src/status/readout-verb.ts
+++ b/packages/fabrika-cli/src/status/readout-verb.ts
@@ -1,0 +1,242 @@
+/**
+ * `status readout` — the landed-decision digest as published in the durable artifact.
+ *
+ * The display half. The producer is `governance` (#4949); this verb ranks nothing and re-derives
+ * nothing — it decodes the registered `governance-digest` wire format and prints what it holds.
+ *
+ * **Four readings, and `absent` is only one of them.** `found`, `absent` and `malformed` are all
+ * facts about the repository at exit `0`; a failed fetch, an unreadable freshness stamp and an
+ * unregistered format are UNKNOWN at exit `11`. Collapsing any of the three into `absent` reports a
+ * proven negative over evidence never held — the hazard `../wire/codes.ts` names when it seats
+ * `ARTIFACT_UNKNOWN` deliberately apart from `ABSENT`.
+ *
+ * **`<as-of>` is the artifact comment's own `updated_at`, never the fetch time.** Printing the
+ * fetch time for a digest written three weeks ago claims a freshness nobody has (#3148, #3330,
+ * #4338).
+ */
+import {Effect} from "effect";
+import type {Shell} from "../io/git.ts";
+import {listComments, openIssuesTitled} from "../io/issues.ts";
+import {answer, FAILED, refuse, type VerbOutcome} from "../verb.ts";
+import {findFormat} from "../wire/registry.ts";
+import {OFF_VOCABULARY, PRECONDITION_UNKNOWN} from "./codes.ts";
+import {type AsOf, asOfToken, fromArtifact, noAsOf, row} from "./fields.ts";
+
+const VERB = "status readout";
+
+/** The registered wire format this verb decodes. Not registered yet — tracked at #5199. */
+export const DIGEST_FORMAT = "governance-digest";
+
+/** The heading the digest comment carries. */
+export const DIGEST_HEADING = "## Governance readout";
+
+/** The exact title of the durable artifact issue, when no explicit number is supplied. */
+export const ARTIFACT_TITLE = "Governance readout";
+
+/** The environment variable that names the artifact issue. Never a constant issue number. */
+export const ARTIFACT_ISSUE_ENV = "FABRIKA_GOVERNANCE_READOUT_ISSUE";
+
+export type ReadoutState = "found" | "absent" | "malformed";
+
+export type ReadoutRead =
+	/** The decoder does not exist, so nothing about the digest is knowable. */
+	| {readonly _tag: "NoFormat"}
+	/** No artifact resolved — a **proven** fact about the repository, and the caller bootstraps one. */
+	| {readonly _tag: "NoArtifact"; readonly repo: string}
+	/** The artifact could not be fetched, or its freshness could not be established. */
+	| {
+			readonly _tag: "Unfetchable";
+			readonly repo: string;
+			readonly issue: number | null;
+			readonly reason: string;
+	  }
+	| {
+			readonly _tag: "Fetched";
+			readonly repo: string;
+			readonly issue: number;
+			readonly scanned: number;
+			/** The most recently updated comment carrying the heading, or `null` when none does. */
+			readonly digest: {readonly body: string; readonly updatedAt: string} | null;
+	  };
+
+/** A positive integer, or `null` — the shape a supplied issue number must have. */
+export const issueNumberOf = (value: string): number | null =>
+	/^\d+$/.test(value.trim()) && Number.parseInt(value.trim(), 10) > 0
+		? Number.parseInt(value.trim(), 10)
+		: null;
+
+/**
+ * Which comment is the digest, stated so staleness cannot hide: the **most recently updated**
+ * comment carrying the heading, and that comment's conformance alone decides `found` vs `malformed`.
+ * Skipping a newer non-conforming publication in favour of an older valid one would render a stale
+ * digest as current.
+ */
+export const digestComment = <A extends {readonly body: string; readonly updatedAt: string}>(
+	comments: ReadonlyArray<A>,
+): A | null => {
+	const carrying = comments.filter((comment) =>
+		comment.body.split("\n").some((line) => line.trim() === DIGEST_HEADING),
+	);
+	return carrying.reduce<A | null>(
+		(newest, comment) =>
+			newest === null || comment.updatedAt > newest.updatedAt ? comment : newest,
+		null,
+	);
+};
+
+export interface ReadoutSources {
+	readonly repo: string;
+	/** The positional argument, already validated, or `null`. */
+	readonly issue: number | null;
+	readonly env: Readonly<Record<string, string | undefined>>;
+}
+
+/** Resolve the artifact and fetch it. The format check is the caller's first gate. */
+export const readReadout = ({repo, issue, env}: ReadoutSources): Shell<ReadoutRead> =>
+	Effect.gen(function* () {
+		if (findFormat(DIGEST_FORMAT) === undefined) return {_tag: "NoFormat"} as const;
+
+		const fromEnv = env[ARTIFACT_ISSUE_ENV];
+		let target = issue ?? (fromEnv === undefined ? null : issueNumberOf(fromEnv));
+		if (target === null) {
+			const titled = yield* openIssuesTitled(repo, ARTIFACT_TITLE);
+			if (titled._tag === "Failure") {
+				return {_tag: "Unfetchable", repo, issue: null, reason: titled.reason} as const;
+			}
+			// Several issues sharing the title is not a resolution: guessing which one is the digest
+			// would display somebody else's issue as the readout.
+			if (titled.value.length !== 1) return {_tag: "NoArtifact", repo} as const;
+			target = titled.value[0]?.number ?? null;
+			if (target === null) return {_tag: "NoArtifact", repo} as const;
+		}
+
+		const comments = yield* listComments(repo, target);
+		if (comments._tag === "Failure") {
+			return {_tag: "Unfetchable", repo, issue: target, reason: comments.reason} as const;
+		}
+		const digest = digestComment(comments.value);
+		if (digest !== null && digest.updatedAt === "") {
+			return {
+				_tag: "Unfetchable",
+				repo,
+				issue: target,
+				reason: "carries no readable updated_at — the digest's freshness is UNKNOWN",
+			} as const;
+		}
+		return {
+			_tag: "Fetched",
+			repo,
+			issue: target,
+			scanned: comments.value.length,
+			digest: digest === null ? null : {body: digest.body, updatedAt: digest.updatedAt},
+		} as const;
+	});
+
+/** The rendered reading: a state, its rows, its source and its freshness. */
+export interface ReadoutReading {
+	readonly state: ReadoutState;
+	readonly rows: ReadonlyArray<string>;
+	readonly source: string;
+	readonly asOf: AsOf;
+	readonly detail: string;
+}
+
+/** The refusal an UNKNOWN reading owes, or the reading itself. `null` state means exit `11`. */
+export const readingOf = (read: ReadoutRead): ReadoutReading | null => {
+	if (read._tag === "NoFormat" || read._tag === "Unfetchable") return null;
+	if (read._tag === "NoArtifact") {
+		return {
+			state: "absent",
+			rows: [],
+			source: read.repo,
+			asOf: noAsOf,
+			detail: "no readout artifact",
+		};
+	}
+	const source = `${read.repo}#${read.issue}`;
+	if (read.digest === null) {
+		return {
+			state: "absent",
+			rows: [],
+			source,
+			asOf: noAsOf,
+			detail: `no digest block in ${source}`,
+		};
+	}
+	const format = findFormat(DIGEST_FORMAT);
+	// Unreachable through `readReadout`, which returns `NoFormat` before any fetch.
+	if (format === undefined) return null;
+	const decoded = format.read(read.digest.body);
+	const asOf = fromArtifact(read.digest.updatedAt);
+	if (decoded._tag === "Found") {
+		return {
+			state: "found",
+			rows: decoded.value,
+			source,
+			asOf,
+			detail: `${decoded.value.length} rows`,
+		};
+	}
+	return decoded._tag === "Malformed"
+		? {state: "malformed", rows: [], source, asOf, detail: decoded.reason}
+		: {state: "absent", rows: [], source, asOf, detail: decoded.reason};
+};
+
+export interface ReadoutInput {
+	readonly read: ReadoutRead;
+	readonly json: boolean;
+}
+
+export const runReadout = ({read, json}: ReadoutInput): VerbOutcome => {
+	if (read._tag === "NoFormat") {
+		return refuse(
+			PRECONDITION_UNKNOWN,
+			`${VERB}: the ${DIGEST_FORMAT} format is not registered — the digest is UNKNOWN, never absent (#5199).`,
+		);
+	}
+	if (read._tag === "Unfetchable") {
+		const where = read.issue === null ? read.repo : `${read.repo}#${read.issue}`;
+		return refuse(
+			PRECONDITION_UNKNOWN,
+			`${VERB}: cannot fetch ${where}: ${read.reason} — the digest is UNKNOWN, never absent.`,
+		);
+	}
+	const reading = readingOf(read);
+	// Unreachable: the two UNKNOWN tags are handled above and every other tag yields a reading.
+	if (reading === null) return refuse(FAILED, `${VERB}: the reading could not be produced.`);
+
+	const notice =
+		read._tag === "NoArtifact"
+			? `${VERB}: no artifact — $${ARTIFACT_ISSUE_ENV} unset and no open issue in ${read.repo} titled exactly "${ARTIFACT_TITLE}". Run: fabrika status bootstrap readout-artifact`
+			: `${VERB}: read ${read.repo}#${read.issue}, ${read.scanned} comments scanned, digest ${reading.state}.`;
+
+	if (json) {
+		return answer(
+			`${JSON.stringify({
+				outcome: reading.state,
+				rows: reading.rows,
+				issue: read._tag === "Fetched" ? read.issue : null,
+				repo: read.repo,
+				asOf: reading.asOf.at,
+				asOfKind: reading.asOf.kind,
+				detail: reading.detail,
+			})}\n`,
+			[notice],
+		);
+	}
+	const lines = [
+		row(
+			"readout",
+			reading.state,
+			String(reading.rows.length),
+			reading.source,
+			asOfToken(reading.asOf),
+		),
+		...reading.rows,
+	];
+	return answer(`${lines.join("\n")}\n`, [notice]);
+};
+
+/** The usage refusal a non-integer positional owes. */
+export const badIssueRefusal = (value: string): VerbOutcome =>
+	refuse(OFF_VOCABULARY, `${VERB}: "${value}" is not a positive issue number.`);

--- a/packages/fabrika-cli/src/status/required-files.ts
+++ b/packages/fabrika-cli/src/status/required-files.ts
@@ -1,0 +1,141 @@
+/**
+ * The reader for every fabrika skill's `## Required repo files` table (#5049) — the declaration each
+ * skill makes about the repo surfaces it leans on.
+ *
+ * The table is **externally-authorable text**: fabrika installs into repos that are not phoenix
+ * (#4776), so this parser reports what it finds rather than refusing on it. Nothing is normalized,
+ * guessed at, or dropped — a dropped row is a declaration the reader will never know exists.
+ *
+ * **Parse by cell position, never by scanning the row for a bolded token.** The *second* cell is
+ * prose that may itself contain bolded words (`plan-epic` writes `` `POST …/labels` **creates** ``
+ * there, beside a third cell reading `**fail-loud**`), so a section-wide scan reports a disposition
+ * that is not one — as it did during the contract's own authoring.
+ */
+
+/** The three words every landed skill uses. A fourth is counted off-vocabulary, never refused. */
+export const CANONICAL_DISPOSITIONS: ReadonlyArray<string> = ["fail-loud", "degrade", "bootstrap"];
+
+/** The heading whose table this reads. */
+export const SECTION_HEADING = "## Required repo files";
+
+/**
+ * What a declared row's first cell names, and therefore what — if anything — can be probed.
+ *
+ * `Unprobeable` is a first-class outcome, not a parse failure: *"the `package.json` scripts
+ * `typecheck` and `lint:worktree`"* and *"a merge queue enabled on the base branch"* are real
+ * declarations no filesystem or label probe settles, and rendering them `present` off some file's
+ * existence is the false positive this state exists to prevent.
+ */
+export type Subject =
+	| {readonly _tag: "Path"; readonly path: string}
+	| {readonly _tag: "Labels"; readonly labels: ReadonlyArray<string>}
+	| {readonly _tag: "Unprobeable"; readonly reason: string};
+
+export interface DeclaredRow {
+	/** The `` `id:<slug>` `` token in the first cell, or `-`. No slug is ever derived from prose. */
+	readonly surfaceId: string;
+	readonly disposition: string;
+	/** The third cell after its bolded disposition — what the declaring skill says happens. */
+	readonly consequence: string;
+	readonly subject: Subject;
+}
+
+const ID_TOKEN = /`id:([a-z0-9-]+)`/;
+const BACKTICKED = /`([^`]+)`/g;
+/**
+ * The label grammar, closed on **fabrika's own** board facets rather than on any `word:word`.
+ *
+ * Left open, `lint:worktree` — a `package.json` script named in `build`'s table — reads as a label
+ * and the row reports a missing label that was never declared. The facets here are the ones this
+ * group itself creates and counts (`status bootstrap label-taxonomy`, `status board`'s buckets), so
+ * the set is fabrika's vocabulary, not a guess at the host repo's.
+ */
+const LABEL_TOKEN = /^(?:(?:status|type|ready-for):[a-z0-9._-]+|p\d+)$/;
+const PATH_TOKEN = /^[A-Za-z0-9._][A-Za-z0-9._/-]*$/;
+const SEPARATOR_CELL = /^:?-{3,}:?$/;
+
+const isPathToken = (token: string): boolean =>
+	PATH_TOKEN.test(token) && (token.includes("/") || /\.[A-Za-z0-9]+$/.test(token));
+
+/** The cells of one markdown table row, outer pipes dropped. */
+export const rowCells = (line: string): ReadonlyArray<string> => {
+	const trimmed = line.trim();
+	const inner = trimmed.replace(/^\|/, "").replace(/\|$/, "");
+	return inner.split("|").map((cell) => cell.trim());
+};
+
+/**
+ * What the first cell declares.
+ *
+ * The rule is positional and stated so two implementers cannot ship two answers: a cell naming any
+ * **label-shaped** token declares labels; otherwise a cell that *opens* with a backticked path
+ * declares that path; everything else is unprobeable. A path named mid-sentence is a qualifier on
+ * some other subject — *"the `package.json` scripts …"*, *"a dev server … `design-harness.json`'s
+ * `command`"* — and probing it would answer a question the row did not ask.
+ */
+export const classifySubject = (cell: string): Subject => {
+	const withoutId = cell.replace(ID_TOKEN, "").trim();
+	const tokens = [...withoutId.matchAll(BACKTICKED)].map((m) => m[1] ?? "");
+	const labels = tokens.filter((token) => LABEL_TOKEN.test(token));
+	if (labels.length > 0) return {_tag: "Labels", labels};
+	const opening = /^`([^`]+)`/.exec(withoutId);
+	if (opening?.[1] !== undefined && isPathToken(opening[1])) {
+		return {_tag: "Path", path: opening[1]};
+	}
+	return {
+		_tag: "Unprobeable",
+		reason: `declared subject is ${withoutId.replace(/`/g, "")} — not a path or a label`,
+	};
+};
+
+/** The disposition word and the consequence sentence behind it, off the third cell. */
+export const splitDisposition = (cell: string): {disposition: string; consequence: string} => {
+	const bolded = /^\*\*([^*]+)\*\*\s*(?:—|–|-|:)?\s*([\s\S]*)$/.exec(cell.trim());
+	if (bolded?.[1] === undefined) return {disposition: "-", consequence: cell.trim()};
+	return {disposition: bolded[1].trim(), consequence: (bolded[2] ?? "").trim()};
+};
+
+/** The lines of the `## Required repo files` section, or `null` when the skill declares none. */
+export const sectionOf = (text: string): ReadonlyArray<string> | null => {
+	const lines = text.split("\n");
+	const start = lines.findIndex((line) => line.trim() === SECTION_HEADING);
+	if (start === -1) return null;
+	const rest = lines.slice(start + 1);
+	const end = rest.findIndex((line) => /^#{1,2} /.test(line));
+	return end === -1 ? rest : rest.slice(0, end);
+};
+
+/**
+ * Every declared row, in table order — or `null` when the skill has no `## Required repo files`
+ * section at all, which the caller renders as one `undeclared` row and never as zero rows.
+ */
+export const parseRequiredFiles = (text: string): ReadonlyArray<DeclaredRow> | null => {
+	const section = sectionOf(text);
+	if (section === null) return null;
+	const tableLines = section.filter((line) => line.trim().startsWith("|"));
+	const body = tableLines.filter((line) => !rowCells(line).every((c) => SEPARATOR_CELL.test(c)));
+	// The header row is the table's first non-separator row; every row after it is a declaration.
+	const rows: DeclaredRow[] = [];
+	for (const line of body.slice(1)) {
+		const cells = rowCells(line);
+		const first = cells[0] ?? "";
+		const third = cells[2];
+		if (third === undefined) {
+			rows.push({
+				surfaceId: "-",
+				disposition: "-",
+				consequence: "-",
+				subject: {_tag: "Unprobeable", reason: "row does not carry three cells"},
+			});
+			continue;
+		}
+		const {disposition, consequence} = splitDisposition(third);
+		rows.push({
+			surfaceId: ID_TOKEN.exec(first)?.[1] ?? "-",
+			disposition,
+			consequence: consequence === "" ? "-" : consequence,
+			subject: classifySubject(first),
+		});
+	}
+	return rows;
+};

--- a/packages/fabrika-cli/src/status/required-files.unit.test.ts
+++ b/packages/fabrika-cli/src/status/required-files.unit.test.ts
@@ -1,0 +1,93 @@
+import {describe, expect, it} from "vitest";
+import {classifySubject, parseRequiredFiles, splitDisposition} from "./required-files.ts";
+
+const table = (rows: string): string =>
+	`# skill\n\n## Required repo files\n\n| Must exist | Why | When missing |\n| --- | --- | --- |\n${rows}\n\n## Next section\n`;
+
+describe("the `## Required repo files` reader", () => {
+	it("reports a skill with no section as null, so the caller can render `undeclared`", () => {
+		expect(parseRequiredFiles("# skill\n\nNo declarations here.\n")).toBeNull();
+	});
+
+	it("drops the header row and keeps every declaration", () => {
+		const rows = parseRequiredFiles(
+			table(
+				"| `ROADMAP.md` | why | **degrade** — it is inert |\n| `a.md` | why | **fail-loud** — stop |",
+			),
+		);
+		expect(rows?.map((r) => r.disposition)).toEqual(["degrade", "fail-loud"]);
+	});
+
+	it("keeps a row that does not carry three cells rather than dropping it", () => {
+		const rows = parseRequiredFiles(table("| only one cell |"));
+		expect(rows).toHaveLength(1);
+		expect(rows?.[0]?.subject).toEqual({
+			_tag: "Unprobeable",
+			reason: "row does not carry three cells",
+		});
+	});
+
+	it("reads the id token and never derives a slug from prose", () => {
+		const rows = parseRequiredFiles(
+			table("| `id:design-manifest` `x.md` | why | **degrade** — n |"),
+		);
+		expect(rows?.[0]?.surfaceId).toBe("design-manifest");
+		expect(
+			parseRequiredFiles(table("| The board label taxonomy | w | **degrade** — n |"))?.[0]
+				?.surfaceId,
+		).toBe("-");
+	});
+});
+
+describe("the disposition is read by cell position, never by scanning for a bolded token", () => {
+	it("takes the third cell's leading bolded word", () => {
+		expect(splitDisposition("**fail-loud** — the run stops").disposition).toBe("fail-loud");
+	});
+
+	it("reports an unrecognized word verbatim rather than refusing or normalizing it", () => {
+		expect(splitDisposition("**warn** — a fourth word").disposition).toBe("warn");
+	});
+
+	it("ignores a bolded word in the SECOND cell — the `**creates**` trap", () => {
+		const rows = parseRequiredFiles(
+			table("| `x.md` | `POST /labels` **creates** an unknown label | **fail-loud** — stop |"),
+		);
+		expect(rows?.[0]?.disposition).toBe("fail-loud");
+	});
+});
+
+describe("subject classification", () => {
+	it("reads a cell that OPENS with a backticked path as that path", () => {
+		expect(classifySubject("`ROADMAP.md` with a `## Focus` section")).toEqual({
+			_tag: "Path",
+			path: "ROADMAP.md",
+		});
+	});
+
+	it("reads the board taxonomy's tokens as labels", () => {
+		expect(
+			classifySubject("The board label taxonomy — `status:triaged`, `type:feature`, `p0`"),
+		).toEqual({_tag: "Labels", labels: ["status:triaged", "type:feature", "p0"]});
+	});
+
+	/**
+	 * The regression the contract names by example: this row must be `unprobeable`, and a
+	 * `word:word` label grammar reads `lint:worktree` as a label and reports a missing label the
+	 * table never declared.
+	 */
+	it("does NOT read a `package.json` script pair as a label", () => {
+		const subject = classifySubject("The `package.json` scripts `typecheck` and `lint:worktree`");
+		expect(subject._tag).toBe("Unprobeable");
+	});
+
+	it("does not probe a path named mid-sentence as a qualifier on some other subject", () => {
+		expect(
+			classifySubject("A dev server that actually comes ready — `design-harness.json`'s `command`")
+				._tag,
+		).toBe("Unprobeable");
+	});
+
+	it("has no probe for a subject that is neither a path nor a label", () => {
+		expect(classifySubject("A merge queue enabled on the base branch")._tag).toBe("Unprobeable");
+	});
+});

--- a/packages/fabrika-cli/src/status/roster.ts
+++ b/packages/fabrika-cli/src/status/roster.ts
@@ -1,0 +1,257 @@
+/**
+ * Where the skill roster lives, and what one `SKILL.md` says about itself.
+ *
+ * **The roster is the plugin's, not the target repo's.** fabrika installs into repos that are not
+ * phoenix (#4776), so defaulting to a repo-relative path would make `status menu` and
+ * `status config` empty on precisely the fresh repo this skill onboards. Resolution runs three
+ * tiers and prints which one served, so a caller can re-run the read instead of adopting the render.
+ *
+ * **A roster that resolves and holds zero skills is a fact, not a failure**; a roster that could not
+ * be read, or one `SKILL.md` inside it that could not be read, is UNKNOWN. A partial roster is not a
+ * roster — the false-absence class of #4105 and #4163.
+ */
+import {Effect, type FileSystem, Path, Result} from "effect";
+import {ancestors} from "../delegate/root.ts";
+import {exists, isDirectory, readDir, readFile} from "../io/fs.ts";
+
+/** Which of the three tiers served the roster. Printed, never assumed. */
+export type RosterTier = "explicit" | "plugin" | "repo";
+
+/** Who can reach a skill — the one routing fact a reader cannot infer from a description. */
+export type InvocationAxis = "model" | "user";
+
+/** The plugin-manifest directory that marks an installed fabrika plugin root. */
+export const PLUGIN_MANIFEST = ".claude-plugin/plugin.json";
+
+/** The in-repo development location of the roster, relative to the repository root. */
+export const IN_REPO_ROSTER = "claude-plugins/fabrika/skills";
+
+export interface RosterSkill {
+	readonly name: string;
+	readonly invocation: string;
+	readonly invocationAxis: InvocationAxis;
+	readonly description: string;
+	/** Whether the frontmatter parsed. A `false` row still ships — a dropped row is a false absence. */
+	readonly frontmatterReadable: boolean;
+	/** The whole `SKILL.md`, so `status config` parses its declarations without a second read. */
+	readonly text: string;
+}
+
+export type RosterRead =
+	| {
+			readonly _tag: "Resolved";
+			readonly path: string;
+			/** The path as printed — relative to its root, so no machine-local path reaches a reader. */
+			readonly display: string;
+			readonly tier: RosterTier;
+			readonly skills: ReadonlyArray<RosterSkill>;
+			readonly unreadableFrontmatter: number;
+	  }
+	/** An **explicitly passed** `--skills-dir` proven absent — a caller error, not a state of the world. */
+	| {readonly _tag: "AbsentExplicit"; readonly path: string; readonly display: string}
+	/** The roster, or one `SKILL.md` inside it, could not be read. The declaration set is UNKNOWN. */
+	| {
+			readonly _tag: "Failed";
+			readonly path: string;
+			readonly display: string;
+			readonly reason: string;
+	  };
+
+const FRONTMATTER = /^---\r?\n([\s\S]*?)\r?\n---(?:\r?\n|$)/;
+
+/**
+ * The `key: value` pairs of a `SKILL.md`'s frontmatter block, or `null` when there is none.
+ *
+ * Hand-read rather than parsed with a YAML dependency, matching this package's standing shape: the
+ * three keys read here — `name`, `description`, `disable-model-invocation` — are plain scalars, and
+ * a continuation line is folded into the value above it the way the block quotes them.
+ */
+export const parseFrontmatter = (text: string): ReadonlyMap<string, string> | null => {
+	const block = FRONTMATTER.exec(text);
+	if (block?.[1] === undefined) return null;
+	const fields = new Map<string, string>();
+	let current: string | null = null;
+	for (const line of block[1].split("\n")) {
+		const pair = /^([A-Za-z][A-Za-z0-9_-]*):\s?(.*)$/.exec(line);
+		if (pair?.[1] !== undefined) {
+			current = pair[1];
+			fields.set(current, (pair[2] ?? "").trim());
+			continue;
+		}
+		if (current !== null && line.trim() !== "") {
+			fields.set(current, `${fields.get(current) ?? ""} ${line.trim()}`.trim());
+		}
+	}
+	return fields;
+};
+
+/** One roster row from a `SKILL.md`'s bytes. Unparseable frontmatter yields a row that says so. */
+export const skillFrom = (name: string, text: string): RosterSkill => {
+	const fields = parseFrontmatter(text);
+	const declared = fields?.get("description");
+	return {
+		name,
+		invocation: `/fabrika:${name}`,
+		invocationAxis: fields?.get("disable-model-invocation") === "true" ? "user" : "model",
+		description: declared ?? "unknown (frontmatter unreadable)",
+		frontmatterReadable: declared !== undefined,
+		text,
+	};
+};
+
+/** The nearest ancestor of `from` for which `marker` resolves, or `null`. */
+const nearestAncestorWith = (
+	path: Path.Path,
+	from: string,
+	marker: string,
+): Effect.Effect<string | null, never, FileSystem.FileSystem> =>
+	Effect.gen(function* () {
+		for (const dir of ancestors(path, from)) {
+			const probe = yield* Effect.result(exists(path.join(dir, marker)));
+			if (Result.isSuccess(probe) && probe.success) return dir;
+		}
+		return null;
+	});
+
+export interface RosterSources {
+	/** `--skills-dir`, when the caller passed one. */
+	readonly explicit: string | null;
+	/** The directory of the running module — tier 2 walks up from here. */
+	readonly moduleDir: string;
+	/** The invocation directory — tier 3 walks up from here for the in-repo checkout. */
+	readonly cwd: string;
+}
+
+/**
+ * The roster path and the tier that served it, before anything is read out of it.
+ *
+ * `path` is absolute because the reads need it; `display` is what a reader ever sees. An absolute
+ * path printed into a session transcript is a machine-local path leak, and the front door prints
+ * this one on every cold start.
+ */
+export interface ResolvedRoster {
+	readonly path: string;
+	readonly display: string;
+	readonly tier: RosterTier;
+}
+
+export const resolveRosterPath = (
+	sources: RosterSources,
+): Effect.Effect<ResolvedRoster | null, never, FileSystem.FileSystem | Path.Path> =>
+	Effect.gen(function* () {
+		const path = yield* Path.Path;
+		if (sources.explicit !== null) {
+			return {path: sources.explicit, display: sources.explicit, tier: "explicit" as const};
+		}
+		const pluginRoot = yield* nearestAncestorWith(path, sources.moduleDir, PLUGIN_MANIFEST);
+		if (pluginRoot !== null) {
+			return {
+				path: path.join(pluginRoot, "skills"),
+				display: `${path.basename(pluginRoot)}/skills`,
+				tier: "plugin" as const,
+			};
+		}
+		const repoRoot = yield* nearestAncestorWith(path, sources.cwd, IN_REPO_ROSTER);
+		return repoRoot === null
+			? null
+			: {
+					path: path.join(repoRoot, IN_REPO_ROSTER),
+					display: IN_REPO_ROSTER,
+					tier: "repo" as const,
+				};
+	});
+
+/**
+ * Read the roster: resolve it, enumerate every directory holding a `SKILL.md`, and read each one.
+ *
+ * An unreadable directory or an unreadable `SKILL.md` FAILS rather than shortening the list, which
+ * is why `../io/fs.ts`'s `readDir`/`readFile` are typed to fail rather than to return `[]` / `""`.
+ */
+export const readRoster = (
+	sources: RosterSources,
+): Effect.Effect<RosterRead, never, FileSystem.FileSystem | Path.Path> =>
+	Effect.gen(function* () {
+		const path = yield* Path.Path;
+		const resolved = yield* resolveRosterPath(sources);
+		if (resolved === null) {
+			return {
+				_tag: "Failed",
+				path: IN_REPO_ROSTER,
+				display: IN_REPO_ROSTER,
+				reason: "no roster resolved — pass --skills-dir",
+			} as const;
+		}
+		const present = yield* Effect.result(exists(resolved.path));
+		if (Result.isFailure(present)) {
+			return {
+				_tag: "Failed",
+				path: resolved.path,
+				display: resolved.display,
+				reason: present.failure.reason,
+			} as const;
+		}
+		if (!present.success) {
+			return resolved.tier === "explicit"
+				? ({_tag: "AbsentExplicit", path: resolved.path, display: resolved.display} as const)
+				: ({
+						_tag: "Failed",
+						path: resolved.path,
+						display: resolved.display,
+						reason: "the resolved roster directory does not exist",
+					} as const);
+		}
+		const entries = yield* Effect.result(readDir(resolved.path));
+		if (Result.isFailure(entries)) {
+			return {
+				_tag: "Failed",
+				path: resolved.path,
+				display: resolved.display,
+				reason: entries.failure.reason,
+			} as const;
+		}
+		const skills: RosterSkill[] = [];
+		for (const name of [...entries.success].sort()) {
+			const dir = path.join(resolved.path, name);
+			// The entry's own type decides, not a probe of the child: a non-directory entry (a
+			// `.gitkeep`) makes the child probe raise ENOTDIR, which would read as a failed roster.
+			const isDir = yield* Effect.result(isDirectory(dir));
+			if (Result.isFailure(isDir)) {
+				return {
+					_tag: "Failed",
+					path: dir,
+					display: `${resolved.display}/${name}`,
+					reason: isDir.failure.reason,
+				} as const;
+			}
+			if (!isDir.success) continue;
+			const file = path.join(dir, "SKILL.md");
+			const there = yield* Effect.result(exists(file));
+			if (Result.isFailure(there)) {
+				return {
+					_tag: "Failed",
+					path: file,
+					display: `${resolved.display}/${name}/SKILL.md`,
+					reason: there.failure.reason,
+				} as const;
+			}
+			if (!there.success) continue;
+			const text = yield* Effect.result(readFile(file));
+			if (Result.isFailure(text)) {
+				return {
+					_tag: "Failed",
+					path: file,
+					display: `${resolved.display}/${name}/SKILL.md`,
+					reason: text.failure.reason,
+				} as const;
+			}
+			skills.push(skillFrom(name, text.success));
+		}
+		return {
+			_tag: "Resolved",
+			path: resolved.path,
+			display: resolved.display,
+			tier: resolved.tier,
+			skills,
+			unreadableFrontmatter: skills.filter((s) => !s.frontmatterReadable).length,
+		} as const;
+	});

--- a/packages/fabrika-cli/src/status/status.cli.test.ts
+++ b/packages/fabrika-cli/src/status/status.cli.test.ts
@@ -1,0 +1,67 @@
+/**
+ * The end-to-end half: the **exit status and the exact stdout bytes** a shell caller reads.
+ *
+ * Only a subprocess proves those, and each `it` costs one cold node+TS load of `bin.ts` — so spawn
+ * count is this file's cost (`.patterns/subprocess-test-budget.md`). Three spawns, each proving
+ * something no in-process test can: that the group is reachable through the real registry, that the
+ * injected `status open` form survives a real filesystem walk, and that a refusal writes **zero
+ * bytes** to a real stdout. Everything else is covered in-process by `./verbs.unit.test.ts`.
+ */
+import {execFileSync} from "node:child_process";
+import {fileURLToPath} from "node:url";
+import {describe, expect, it} from "vitest";
+import {SUBPROCESS_TEST_TIMEOUT_MS} from "../test-budget.ts";
+import {NOT_BUILDABLE, ZERO_SCOPE} from "./codes.ts";
+
+const BIN = fileURLToPath(new URL("../bin.ts", import.meta.url));
+
+interface Run {
+	readonly code: number;
+	readonly stdout: string;
+	readonly stderr: string;
+}
+
+/** `FABRIKA_SKIP_INFER` pins the invocation to this copy rather than whatever the repo root installs. */
+const fabrika = (args: ReadonlyArray<string>): Run => {
+	try {
+		const stdout = execFileSync(process.execPath, [BIN, ...args], {
+			encoding: "utf8",
+			env: {...process.env, FABRIKA_SKIP_INFER: "1"},
+			input: "",
+			stdio: ["pipe", "pipe", "pipe"],
+		});
+		return {code: 0, stdout, stderr: ""};
+	} catch (err) {
+		const failure = err as {status?: number; stdout?: string; stderr?: string};
+		return {code: failure.status ?? -1, stdout: failure.stdout ?? "", stderr: failure.stderr ?? ""};
+	}
+};
+
+describe("fabrika status, end to end", {timeout: SUBPROCESS_TEST_TIMEOUT_MS}, () => {
+	it("renders the roster off the resolved skills tree, exit 0", () => {
+		const run = fabrika(["status", "menu"]);
+		expect(run.code).toBe(0);
+		expect(run.stdout.split("\n")[0]).toMatch(/^menu\tready\t\d+\t\d{4}-\d{2}-\d{2}T/);
+		expect(run.stdout).toContain("skill\tfront-door\t/fabrika:front-door\tuser\t");
+	});
+
+	/**
+	 * The injected form's whole point: it passes no flags, so its one refusal seat is unreachable and
+	 * a source it cannot read becomes a field state. A refusal here would write zero bytes on exactly
+	 * the cold start the front door exists for.
+	 */
+	it("answers `status open --field menu` at exit 0 with a stated field state", () => {
+		const run = fabrika(["status", "open", "--field", "menu"]);
+		expect(run.code).toBe(0);
+		expect(run.stdout.split("\n")[0]).toBe("open\t1");
+		expect(run.stdout).toMatch(/^field\tmenu\t(ready|empty|unknown)\t/m);
+	});
+
+	it("refuses an unbuildable surface on 12 with NOTHING on stdout", () => {
+		const run = fabrika(["status", "bootstrap", "merge-queue"]);
+		expect(run.code).toBe(NOT_BUILDABLE);
+		expect(run.stdout).toBe("");
+		expect(run.stderr).toContain("is not a buildable surface");
+		expect(NOT_BUILDABLE).not.toBe(ZERO_SCOPE);
+	});
+});

--- a/packages/fabrika-cli/src/status/verbs.unit.test.ts
+++ b/packages/fabrika-cli/src/status/verbs.unit.test.ts
@@ -1,0 +1,291 @@
+/**
+ * The in-process half: every verb's outcome — its code, its stdout bytes and the state words it
+ * keeps apart — driven over scripted reads rather than a real filesystem or a real GitHub.
+ *
+ * The property under test throughout is the three-state law: a proven negative is an exit-`0` token,
+ * an unread source is `unknown`, and the two never collapse.
+ */
+import {describe, expect, it} from "vitest";
+import * as report from "../report/codes.ts";
+import {ANSWER} from "../verb.ts";
+import {type BoardRead, type Bucket, boardState, runBoard} from "./board-verb.ts";
+import {BUILDABLE_SURFACES, findSurface, knownIds} from "./bootstrap-verb.ts";
+import {NOT_BUILDABLE, PRECONDITION_UNKNOWN, ZERO_SCOPE} from "./codes.ts";
+import {configState, countsOf, runConfig, type SurfaceRow} from "./config-verb.ts";
+import {noAsOf, oneLine, readNow} from "./fields.ts";
+import {runMenu} from "./menu-verb.ts";
+import {
+	badFieldRefusal,
+	boardField,
+	configField,
+	menuField,
+	readoutField,
+	runOpen,
+} from "./open-verb.ts";
+import {digestComment, issueNumberOf, runReadout} from "./readout-verb.ts";
+import {parseFrontmatter, type RosterRead, type RosterSkill, skillFrom} from "./roster.ts";
+
+const AS_OF = readNow("2026-08-09T14:22:03Z");
+
+const skill = (name: string, text: string): RosterSkill => skillFrom(name, text);
+
+const resolvedRoster = (skills: ReadonlyArray<RosterSkill>): RosterRead => ({
+	_tag: "Resolved",
+	path: "/abs/claude-plugins/fabrika/skills",
+	display: "claude-plugins/fabrika/skills",
+	tier: "repo",
+	skills,
+	unreadableFrontmatter: skills.filter((s) => !s.frontmatterReadable).length,
+});
+
+const surface = (over: Partial<SurfaceRow>): SurfaceRow => ({
+	skill: "build",
+	surfaceId: "-",
+	disposition: "degrade",
+	presence: "present",
+	consequence: "-",
+	detail: "ROADMAP.md",
+	asOf: AS_OF,
+	...over,
+});
+
+describe("the roster row", () => {
+	it("reads the frontmatter's description and the invocation axis", () => {
+		const row = skill(
+			"front-door",
+			"---\nname: front-door\ndisable-model-invocation: true\ndescription: The front door.\n---\n",
+		);
+		expect(row.invocation).toBe("/fabrika:front-door");
+		expect(row.invocationAxis).toBe("user");
+		expect(row.description).toBe("The front door.");
+	});
+
+	it("defaults the axis to model when the flag is absent", () => {
+		expect(skill("build", "---\nname: build\ndescription: d\n---\n").invocationAxis).toBe("model");
+	});
+
+	/** A dropped row is a skill the reader will never know exists — the false absence of #4105. */
+	it("emits a row saying so when the frontmatter cannot be parsed, rather than dropping it", () => {
+		const row = skill("broken", "# no frontmatter at all\n");
+		expect(parseFrontmatter("# no frontmatter at all\n")).toBeNull();
+		expect(row.description).toBe("unknown (frontmatter unreadable)");
+		expect(row.frontmatterReadable).toBe(false);
+	});
+});
+
+describe("status menu", () => {
+	it("renders a resolved roster at exit 0, one line per skill", () => {
+		const out = runMenu({
+			roster: resolvedRoster([skill("build", "---\nname: build\ndescription: d\n---\n")]),
+			asOf: AS_OF,
+			json: false,
+		});
+		expect(out.code).toBe(ANSWER);
+		expect(out.stdout).toBe(
+			"menu\tready\t1\t2026-08-09T14:22:03Z\nskill\tbuild\t/fabrika:build\tmodel\td\n",
+		);
+	});
+
+	/** An implicitly-resolved roster holding zero skills is a FACT, not a refusal. */
+	it("renders an empty roster as `empty` at exit 0, never silence", () => {
+		const out = runMenu({roster: resolvedRoster([]), asOf: AS_OF, json: false});
+		expect(out.code).toBe(ANSWER);
+		expect(out.stdout).toBe("menu\tempty\t0\t2026-08-09T14:22:03Z\n");
+	});
+
+	it("seats an explicitly-passed absent path on 7 and an unreadable roster on 11 — never one code", () => {
+		const seven = runMenu({
+			roster: {_tag: "AbsentExplicit", path: "/nope", display: "/nope"},
+			asOf: AS_OF,
+			json: false,
+		});
+		const eleven = runMenu({
+			roster: {_tag: "Failed", path: "/x", display: "x", reason: "EACCES"},
+			asOf: AS_OF,
+			json: false,
+		});
+		expect(seven.code).toBe(ZERO_SCOPE);
+		expect(eleven.code).toBe(PRECONDITION_UNKNOWN);
+		expect(seven.code).not.toBe(eleven.code);
+		expect(seven.stdout).toBe("");
+		expect(eleven.stdout).toBe("");
+	});
+});
+
+describe("status config", () => {
+	it("is `gaps`, never `satisfied`, over a roster that holds zero skills", () => {
+		expect(configState([], 0)).toBe("gaps");
+	});
+
+	it("is `satisfied` only when every declared surface is proven present", () => {
+		expect(configState([surface({})], 1)).toBe("satisfied");
+		expect(configState([surface({presence: "unprobeable"})], 1)).toBe("gaps");
+		expect(configState([surface({presence: "unknown"})], 1)).toBe("gaps");
+		expect(configState([surface({disposition: "undeclared", presence: "unknown"})], 1)).toBe(
+			"gaps",
+		);
+	});
+
+	it("deduplicates the missing count by id while every declaring row still prints", () => {
+		const counts = countsOf([
+			surface({skill: "build", surfaceId: "taxonomy", presence: "missing"}),
+			surface({skill: "build-epic", surfaceId: "taxonomy", presence: "missing"}),
+			surface({skill: "review", surfaceId: "other", presence: "missing"}),
+		]);
+		expect(counts.missing).toBe(2);
+		expect(counts.declaredSkills).toBe(3);
+	});
+
+	it("counts a disposition off the canonical three under off-vocabulary rather than refusing", () => {
+		expect(countsOf([surface({disposition: "warn"})]).offVocabulary).toBe(1);
+	});
+
+	it("renders the header and one line per surface", () => {
+		const out = runConfig({
+			roster: resolvedRoster([skill("build", "---\nname: build\ndescription: d\n---\n")]),
+			surfaces: [surface({})],
+			json: false,
+		});
+		expect(out.code).toBe(ANSWER);
+		expect(out.stdout).toBe(
+			"config\tsatisfied\t1\t0\t0\t0\nsurface\tbuild\t-\tdegrade\tpresent\t-\tROADMAP.md\t2026-08-09T14:22:03Z\n",
+		);
+	});
+});
+
+describe("status board", () => {
+	const counted = (name: string, count: number): Bucket => ({
+		name,
+		count,
+		selector: `labels=${name}`,
+		detail: null,
+		asOf: AS_OF,
+	});
+	const absentLabel = (name: string): Bucket => ({
+		name,
+		count: null,
+		selector: `labels=${name}`,
+		detail: "label absent",
+		asOf: noAsOf,
+	});
+
+	/** A zero count means the label exists and nothing carries it; an absent label is unaskable. */
+	it("renders an absent label as `unknown`, never as 0", () => {
+		const read: BoardRead = {
+			_tag: "Read",
+			repo: "acme/storefront",
+			buckets: [absentLabel("needs-triage"), counted("in-flight", 0)],
+		};
+		expect(boardState(read.buckets)).toBe("unknown");
+		const out = runBoard({read, json: false});
+		expect(out.code).toBe(ANSWER);
+		expect(out.stdout).toContain(
+			"bucket\tneeds-triage\tunknown\tlabels=needs-triage\tlabel absent\tunknown",
+		);
+		expect(out.stdout).toContain("bucket\tin-flight\t0\t");
+	});
+
+	it("refuses on 11 when the repository could not be read at all", () => {
+		const out = runBoard({
+			read: {_tag: "Failed", repo: "acme/storefront", reason: "EAI_AGAIN"},
+			json: false,
+		});
+		expect(out.code).toBe(PRECONDITION_UNKNOWN);
+		expect(out.stdout).toBe("");
+		expect(out.stderr.join("\n")).toContain("never 0");
+	});
+});
+
+describe("status readout", () => {
+	it("takes the MOST RECENTLY UPDATED comment carrying the heading, so staleness cannot hide", () => {
+		const picked = digestComment([
+			{body: "## Governance readout\nold", updatedAt: "2026-08-01T00:00:00Z"},
+			{body: "## Governance readout\nnew", updatedAt: "2026-08-09T00:00:00Z"},
+			{body: "unrelated", updatedAt: "2026-08-10T00:00:00Z"},
+		]);
+		expect(picked?.body).toContain("new");
+	});
+
+	it("resolves no digest comment to null rather than to an empty one", () => {
+		expect(digestComment([{body: "unrelated", updatedAt: "2026-08-10T00:00:00Z"}])).toBeNull();
+	});
+
+	it("reads only a positive integer as an issue number", () => {
+		expect(issueNumberOf("9412")).toBe(9412);
+		expect(issueNumberOf("abc")).toBeNull();
+		expect(issueNumberOf("0")).toBeNull();
+		expect(issueNumberOf("-3")).toBeNull();
+	});
+
+	/** An unbuilt decoder is a failed read, not a proven-empty artifact (#5199). */
+	it("refuses on 11 with the unregistered-format reason, and never reports `absent`", () => {
+		const out = runReadout({read: {_tag: "NoFormat"}, json: false});
+		expect(out.code).toBe(PRECONDITION_UNKNOWN);
+		expect(out.stdout).toBe("");
+		expect(out.stderr.join("\n")).toContain("is not registered");
+		expect(out.stderr.join("\n")).toContain("never absent");
+	});
+
+	it("renders a proven-absent artifact as `absent` at exit 0 — a fact the caller acts on", () => {
+		const out = runReadout({read: {_tag: "NoArtifact", repo: "acme/storefront"}, json: false});
+		expect(out.code).toBe(ANSWER);
+		expect(out.stdout).toBe("readout\tabsent\t0\tacme/storefront\tunknown\n");
+	});
+});
+
+describe("status bootstrap", () => {
+	it("refuses an id outside the registry on 12, naming what IS buildable", () => {
+		expect(findSurface("merge-queue")).toBeUndefined();
+		expect(knownIds()).toBe("design-manifest, roadmap-focus, label-taxonomy, readout-artifact");
+	});
+
+	it("carries exactly four ids", () => {
+		expect(BUILDABLE_SURFACES).toHaveLength(4);
+		expect(NOT_BUILDABLE).toBe(12);
+	});
+});
+
+describe("status open is TOTAL — every unreadable source is a field state, never a refusal", () => {
+	it("renders four fields at exit 0 when EVERY source failed", () => {
+		const fields = [
+			menuField({_tag: "Failed", path: "/x", display: "x", reason: "EACCES"}, AS_OF),
+			configField({_tag: "Failed", path: "/x", display: "x", reason: "EACCES"}, [], AS_OF),
+			boardField({_tag: "Failed", repo: "acme/storefront", reason: "EAI_AGAIN"}),
+			readoutField({_tag: "NoFormat"}),
+		];
+		const out = runOpen({fields, json: false, scope: "roster x; repo acme/storefront"});
+		expect(out.code).toBe(ANSWER);
+		expect(out.stdout.split("\n")[0]).toBe("open\t4");
+		expect(out.stdout.split("\n").filter((l) => l.startsWith("field\t"))).toHaveLength(4);
+		for (const field of fields) expect(field.state).toBe("unknown");
+	});
+
+	it("renders a resolved-but-empty roster as `empty`/`gaps`, not `unknown` and not `satisfied`", () => {
+		expect(menuField(resolvedRoster([]), AS_OF).state).toBe("empty");
+		const config = configField(resolvedRoster([]), [], AS_OF);
+		expect(config.state).toBe("gaps");
+		expect(config.detail).toBe("empty roster — nothing declared, nothing proven");
+	});
+
+	it("has exactly one refusal seat, and it is the off-vocabulary `--field`", () => {
+		const out = badFieldRefusal("nope");
+		expect(out.code).toBe(report.CLASSIFIED);
+		expect(out.stdout).toBe("");
+	});
+
+	it("never prints an absolute machine-local path as a field's source", () => {
+		const source = menuField(resolvedRoster([]), AS_OF).source;
+		expect(source).toBe("claude-plugins/fabrika/skills");
+		expect(source.startsWith("/")).toBe(false);
+	});
+});
+
+describe("the tab-separated field discipline", () => {
+	it("strips tabs and newlines out of prose before it is joined into a row", () => {
+		expect(oneLine("a\tb\nc", 120)).toBe("a b c");
+	});
+
+	it("clamps after reproducing the raw text, so a truncated detail stays attributable", () => {
+		expect(oneLine("x".repeat(200), 120)).toHaveLength(120);
+	});
+});


### PR DESCRIPTION
Fixes #5214

The `front-door` contract specified six `status` verbs and none of them existed, so the
skill's injected `status open` had nothing behind it and every field fell back to UNKNOWN.
This builds the group — all six verbs plus the registration.

**Which side of the fork:** implement the six verbs, not correct the contract. The issue's
acceptance criteria name the six by verb, name the three registration edits, and name the
`codes.ts` exports — there is no ambiguity to resolve. The founder's `pitch-approved:`
comment (appetite 1 cycle) is the only ruling on the issue, and it approves the build.

Both stated blockers were re-checked live rather than taken from the body:

| Body claim | Live state |
|---|---|
| "the contract is not on `main` yet — PR #5216 is open" | **discharged** — #5216 merged 2026-08-10T00:39Z; the contract is on `main` |
| "`status readout` waits on #5199" | **still open** — #5199 is open, and `governance-digest` is not in `wire/registry.ts`. So `status readout` exits `11` with the unregistered-format reason, exactly as the contract and the acceptance criteria specify |

## What is here

Six verbs under `packages/fabrika-cli/src/status/`, each a pure core plus a thin adapter:

| Verb | What it answers |
|---|---|
| `open` | the composite four-field readout the skill injects |
| `config` | which declared repo surfaces exist here — the detection verb (#4952) |
| `menu` | the landed skill roster, derived from the skills tree |
| `readout` | the landed-decision digest, as published |
| `board` | counts of the board's decided buckets |
| `bootstrap` | create one missing surface from a fixed registry, then read it back |

Three properties carry the group's whole point:

- **The three-state law.** Every field, row and bucket is a live value, a **proven negative**
  (`empty` / `absent` / `missing` / `unprobeable` / `malformed`) or **`unknown`** with its
  reason — and the third never renders as the second. An absent label is `unknown` with
  detail `label absent`, never `0`. An unregistered decoder is `unknown`, never `absent`.
- **`status open` is total.** `verb.ts`'s `refuse()` hardcodes empty stdout, so a refusal
  would leave the front door silent on exactly the cold start it exists for. Every
  unreadable source becomes a *field state*; the one refusal seat is a bad `--field`. It
  composes by **importing** the sibling cores — it never spawns a verb and reads its exit
  code, which the contract bans by name.
- **`7` and `11` stay apart.** `7` is an *explicitly passed* `--skills-dir` proven absent;
  `11` is a failed read; an *implicitly* resolved roster holding zero skills is neither — it
  is `empty` at exit `0`.

Registered in all four places a new group with a `codes.ts` needs: `registry.ts`,
`ALIGNED_GROUPS` in `exit-code-alignment.ts`, and **both** the import line and the `TABLES`
row in `exit-code-alignment.unit.test.ts` (the on-disk-groups equality assertion is what
reds when only the first edit lands).

Shared substrate this needed, in files outside `src/status/`:

- `io/issues.ts` — `openIssuesTitled`, `createUnlabelledIssue`, `createLabel`.
- `io/fs.ts` — `isDirectory`. The entry's own type has to decide whether a roster entry is a
  skill directory: probing the child instead makes a non-directory entry (a `.gitkeep`)
  raise `ENOTDIR`, which reads as a **failed roster** rather than as an entry to skip.

## Evidence

- `pnpm typecheck` — clean, whole workspace (31 tasks).
- `pnpm test` in `packages/fabrika-cli` — 199 files, 2872 tests, all passing.
- `pnpm lint:worktree` — clean.
- Live run against this checkout: `status open` renders 4 fields at exit `0` with `readout`
  `unknown` (format unregistered); `status menu` renders 17 skills; `status readout` exits
  `11`; `status readout abc` exits `10`; `status bootstrap merge-queue` exits `12`;
  `status open --field nope` exits `10`.

**Two regression tests were proven to fail against pre-fix logic**, by restoring the defect
and re-running:

1. *"does NOT read a `package.json` script pair as a label"* — with the loose `word:word`
   label grammar restored, `lint:worktree` reads as a label and the row reports a missing
   label that no table declared. Restored → `1 failed | 11 passed`.
2. *"renders the roster off the resolved skills tree, exit 0"* — with the directory check
   removed, a `.gitkeep` in the skills tree makes the child probe raise `ENOTDIR` and the
   whole roster reads UNKNOWN. Restored → `1 failed | 2 passed`.

Both are defects that were actually present in this diff's own first draft, caught by
running the binary, and are now pinned.

## Deviations

Three, all real, none of them "filed a follow-up instead of doing it".

1. **The contract contradicts itself on id-less rows, and I followed its worked example
   rather than its sentence.** The surface-ids paragraph says a row with no `` `id:` `` token
   is reported *"with id `-` and presence `unknown`"*. Its own `status config` example, two
   paragraphs later, shows id-less rows with presence `present` / `missing` / `unprobeable`
   and a header of `config gaps 9 3 3 0`. The two cannot both hold: no landed skill carries
   id tokens yet (the contract says so itself), so the sentence would make **every row on
   today's tree `unknown`** and the example's counts unreachable. I implemented the example —
   an absent id yields `surfaceId` `-` and the probe still runs. This is a departure from one
   sentence of the spec the acceptance criteria point at, so it is disclosed here rather than
   resolved silently. Filed for the contract to be corrected either way — #5298 — which does
   **not** discharge this disclosure, it only records the spec bug.
2. **`status readout` gates on format registration *before* it resolves the repo**, which
   makes its exit-`1` unresolvable-repo seat and its `found` / `absent` / `malformed`
   readings unreachable **today**. The acceptance criterion is emphatic — *"exits `11` with
   the unregistered-format reason until the format is registered — it never reports the
   digest as absent"* — and any other ordering lets an unresolvable repo or an absent
   artifact answer first. The full read path (artifact resolution by env/exact title, the
   most-recently-updated digest comment, decode, artifact `updated_at` freshness) is
   implemented and unit-tested at the core, and goes live the moment #5199 registers the
   format. Until then only the `11` seat is reachable end to end, so the row grammar itself
   is **unproven against a real registered format**.
3. **The subject-classification rule is mine.** The contract fixes the *id* rule but leaves
   "which first cell is a path, which is labels, which is unprobeable" to the implementer,
   while naming five examples of each. The rule I shipped: a **label-shaped token anywhere**
   in the cell declares labels; otherwise a cell that **opens** with a backticked path
   declares that path; everything else is `unprobeable`. It reproduces every example the
   contract names in both directions. Two consequences worth naming rather than burying:
   - The label grammar is closed on **fabrika's own** board facets (`status:`, `type:`,
     `ready-for:`, `pN`) rather than any `word:word`, because otherwise `lint:worktree` — a
     `package.json` script in `build`'s table — reads as a label. That is a deliberate
     narrowing to fabrika's vocabulary, not to the host repo's.
   - A range written `` `p0`–`p2` `` probes `p0` and `p2` and **not** `p1`: no value is ever
     inferred from prose, which is the same rule that forbids deriving a slug from a cell.
     The row still reports what it literally names.
