### PR TITLE
fix(fabrika): scope build check's unvalidated list to the surface that ran (#5288)

### DIFF
--- a/claude-plugins/fabrika/skills/build/contract.md
+++ b/claude-plugins/fabrika/skills/build/contract.md
@@ -988,9 +988,17 @@ fabrika build check --surface code
 `{"verdict": "green", "surface": "code", "tree": "<abs tree root>", "ran": ["pnpm typecheck", "pnpm lint:worktree"], "unvalidated": []}`.
 Red and unknown produce no stdout (`18` / `11`), diagnostics on stderr verbatim from the runners.
 
-`unvalidated` is always present and lists the changed files **this verdict does not cover** — the
-class no surface validates (`.yml`, `.sh`, `.sql`, `.css`, …). A non-empty list beside a green is the
-honest reading of a mixed diff, and the same line is repeated on stderr.
+`unvalidated` is always present and lists the changed files **this verdict does not cover** —
+computed against *this* surface's validators, so it holds both the class no surface validates
+(`.yml`, `.sh`, `.sql`, `.css`, …) and the class another surface would have read. Markdown under
+`--surface code` is the common case, and its mirror is code under `--surface plan`. A non-empty list
+beside a green is the honest reading of a mixed diff, and the same line is repeated on stderr.
+
+The list is a **disclosure, not a second validator run**: `--surface code` names the markdown it
+skipped and does not scan it. Running the markdown validators there would make the surface guess at
+file classes, which the anchor exists to refuse — so the remedy for a mixed diff that needs its
+markdown read is a second run, not a wider surface. `unvalidated: []` therefore means every changed
+file was read by a validator that passed, and nothing weaker (#5288).
 
 Per surface:
 
@@ -1043,17 +1051,19 @@ Preconditions: a linked worktree (`12`), the lane's branch checked out (`14`).
 | `build check: the diff against <base> is empty — nothing to validate (ADR 0092).` | 7 | refusal |
 | `build check: red — <runner> failed; diagnostics above.` | 18 | refusal |
 | `build check: no surface validates any of the <n> changed file(s) (<files>) — there is nothing here to run, so the verdict is a refusal, never green.` | 22 | refusal |
+| `build check: <n> changed file(s) --surface <surface> does not validate — NOT covered by this verdict: <files>.` | 0 | scope note beside a green |
 
 **Scope** — this tree's diff against the branch base. A zero-file diff is `7` — zero scope, never
 a green (ADR 0092). A diff no surface validates is `22` — the same rule one step further in: a file
 the verb cannot classify is a file it cannot check, and an unchecked file never counts toward a
-green. A green's `unvalidated` list is what keeps the partial case honest.
+green. A green's `unvalidated` list is what keeps the partial case honest — and it is scoped to the
+surface that ran, so a file another surface would have read counts as uncovered here too.
 
 **Example**
 
 ```
 $ fabrika build check --surface code
-{"verdict":"green","surface":"code","tree":"/private/var/folders/…/build-4312","ran":["pnpm typecheck","pnpm lint:worktree"],"unvalidated":["scripts/deploy.sh"]}
+{"verdict":"green","surface":"code","tree":"/private/var/folders/…/build-4312","ran":["pnpm typecheck","pnpm lint:worktree"],"unvalidated":["README.md","scripts/deploy.sh"]}
 ```
 
 **Grounding**
@@ -1062,6 +1072,10 @@ $ fabrika build check --surface code
 - #5229 — two extension patterns and no third class: a workflow-only diff greened under `--surface
   prose` having opened no file, and refused under `--surface code` with a message pointing at the
   branch that greened. `22` and `unvalidated` are the two halves of that fix.
+- #5288 — `unvalidated` was computed from the third class alone, so `--surface code` over
+  `["a.ts", "README.md"]` greened with an empty list: the markdown had a validator, just not the one
+  that ran. Scoping the list to the surface closes it, and the mirrored `--surface plan` case, with
+  one rule.
 - v1's discipline was prose-only (`SKILL.md:895-935`, exact-CI-command mandate with no
   enforcement); here the command set is the verb's, not the agent's memory.
 - ADR 0092 — zero diff is a refusal, not a vacuous green.

--- a/packages/fabrika-cli/src/build/check-verb.ts
+++ b/packages/fabrika-cli/src/build/check-verb.ts
@@ -16,7 +16,8 @@
  * provably contradicts.
  *
  * **Green means "the validators ran and passed", never "I could not tell."** See {@link classifyDiff}
- * for the third file class that keeps that distinction representable (#5229).
+ * for the third file class that keeps that distinction representable (#5229), and
+ * {@link notCoveredBy} for the per-surface coverage the green's `unvalidated` list reports (#5288).
  */
 import {Effect, FileSystem} from "effect";
 import type {ChildProcessSpawner} from "effect/unstable/process";
@@ -59,24 +60,57 @@ export interface CheckOptions {
 }
 
 /**
- * The changed files split three ways, with `unvalidated` the file class **no** surface validates.
+ * The changed files split three ways, with `unvalidatable` the file class **no** surface validates.
  *
  * That third bucket is the point. Filtering with the two regexes and reading nothing off what fell
  * out of both made "matched neither" an absence, and an absence cannot be refused: a `.yml`/`.sh`
  * diff produced an empty markdown list, zero validator iterations and a green that had opened no
  * file (#5229). Named, it is a state the verb can act on.
+ *
+ * `unvalidatable` is a property of the **tree** — no surface covers these files. Whether *this* run
+ * covered a file is a narrower question, and {@link notCoveredBy} is the one that answers it; the two
+ * were the same word once, which is how a markdown file could sit outside a `--surface code` green's
+ * disclosure while the field's own documentation said it listed everything the verdict missed (#5288).
  */
 export interface DiffClasses {
 	readonly code: ReadonlyArray<string>;
 	readonly markdown: ReadonlyArray<string>;
-	readonly unvalidated: ReadonlyArray<string>;
+	readonly unvalidatable: ReadonlyArray<string>;
 }
 
 export const classifyDiff = (files: ReadonlyArray<string>): DiffClasses => ({
 	code: files.filter((f) => CODE_RE.test(f)),
 	markdown: files.filter((f) => MARKDOWN_RE.test(f)),
-	unvalidated: files.filter((f) => !CODE_RE.test(f) && !MARKDOWN_RE.test(f)),
+	unvalidatable: files.filter((f) => !CODE_RE.test(f) && !MARKDOWN_RE.test(f)),
 });
+
+/** The file classes each surface's validators actually open. `unvalidatable` is in no surface's. */
+const COVERS: Record<Surface, ReadonlyArray<keyof DiffClasses>> = {
+	code: ["code"],
+	prose: ["markdown"],
+	plan: ["markdown"],
+};
+
+/**
+ * The changed files this surface's validators do not read — what a green must disclose.
+ *
+ * A superset of the `unvalidatable` bucket, and the extra members are the whole point: `--surface
+ * code` ran typecheck and `lint:worktree` over a `["a.ts", "README.md"]` diff, neither of which reads
+ * markdown (`lint:worktree` filters `.md` out by extension), and greened with an empty disclosure —
+ * which affirmatively reads as "nothing uncovered". `--surface plan` did the same to code files.
+ * Reporting coverage per surface answers both with one rule instead of two (#5288).
+ *
+ * Disclosing is deliberately not validating: running the markdown validators under `--surface code`
+ * would make the surface guess at file classes, which the anchor exists to refuse.
+ */
+export const notCoveredBy = (
+	surface: Surface,
+	files: ReadonlyArray<string>,
+): ReadonlyArray<string> => {
+	const classes = classifyDiff(files);
+	const covered = new Set(COVERS[surface].flatMap((bucket) => classes[bucket]));
+	return files.filter((file) => !covered.has(file));
+};
 
 /**
  * Why no surface can validate this diff at all, or `null`.
@@ -86,11 +120,11 @@ export const classifyDiff = (files: ReadonlyArray<string>): DiffClasses => ({
  * sentence pointing at the wrong remedy (it invites `--surface prose`, the branch that greened).
  */
 export const unvalidatableDiff = (files: ReadonlyArray<string>): string | null => {
-	const {code, markdown, unvalidated} = classifyDiff(files);
+	const {code, markdown, unvalidatable} = classifyDiff(files);
 	if (code.length > 0 || markdown.length > 0) return null;
-	const shown = unvalidated.slice(0, 5).join(", ");
-	const rest = unvalidated.length > 5 ? `, +${unvalidated.length - 5} more` : "";
-	return `no surface validates any of the ${unvalidated.length} changed file(s) (${shown}${rest})`;
+	const shown = unvalidatable.slice(0, 5).join(", ");
+	const rest = unvalidatable.length > 5 ? `, +${unvalidatable.length - 5} more` : "";
+	return `no surface validates any of the ${unvalidatable.length} changed file(s) (${shown}${rest})`;
 };
 
 /** Why `--surface` provably contradicts the diff, or `null`. */
@@ -247,15 +281,17 @@ export const runCheck = (
 		if (mismatch !== null) {
 			return refuse(OFF_VOCABULARY, `${VERB}: ${mismatch} — the surface is provably wrong.`, scope);
 		}
-		const {markdown, unvalidated} = classifyDiff(files);
-		// A green over a partly-unvalidatable diff has to carry what it skipped, on both channels:
-		// #5187 greened over 25 workflow files whose `ran` line was true and misleading at once (#5229).
+		const {markdown} = classifyDiff(files);
+		// A partial green has to carry what it skipped, on both channels: #5187 greened over 25 workflow
+		// files whose `ran` line was true and misleading at once (#5229), and a `--surface code` green
+		// then did the same to markdown while reporting an empty list (#5288).
+		const unvalidated = notCoveredBy(surface as Surface, files);
 		const noted =
 			unvalidated.length === 0
 				? scope
 				: [
 						...scope,
-						`${VERB}: ${unvalidated.length} changed file(s) no surface validates — NOT covered by this verdict: ${unvalidated.join(", ")}.`,
+						`${VERB}: ${unvalidated.length} changed file(s) --surface ${surface} does not validate — NOT covered by this verdict: ${unvalidated.join(", ")}.`,
 					];
 
 		if (surface === "code") {

--- a/packages/fabrika-cli/src/build/check-verb.unit.test.ts
+++ b/packages/fabrika-cli/src/build/check-verb.unit.test.ts
@@ -2,7 +2,7 @@ import {Effect, Layer} from "effect";
 import {describe, expect, it} from "vitest";
 import {errOut, fakeFs, fakeShell, okOut} from "../fakes.test-support.ts";
 import type {ExecResult} from "../io/exec.ts";
-import {classifyDiff, runCheck, surfaceMismatch} from "./check-verb.ts";
+import {classifyDiff, notCoveredBy, runCheck, surfaceMismatch} from "./check-verb.ts";
 import {
 	OFF_VOCABULARY,
 	PRECONDITION_UNKNOWN,
@@ -76,14 +76,37 @@ describe("classifyDiff — matched-neither is a bucket, not an absence", () => {
 		expect(classifyDiff([".github/workflows/ci.yml", "scripts/x.sh", "a.ts", "R.md"])).toEqual({
 			code: ["a.ts"],
 			markdown: ["R.md"],
-			unvalidated: [".github/workflows/ci.yml", "scripts/x.sh"],
+			unvalidatable: [".github/workflows/ci.yml", "scripts/x.sh"],
 		});
 	});
 
 	it("puts every file in exactly one bucket", () => {
 		const files = ["a.tsx", "b.mjs", "c.json", "d.md", "e.mdx", "f.sql", "g.css", "LICENSE"];
-		const {code, markdown, unvalidated} = classifyDiff(files);
-		expect([...code, ...markdown, ...unvalidated].sort()).toEqual([...files].sort());
+		const {code, markdown, unvalidatable} = classifyDiff(files);
+		expect([...code, ...markdown, ...unvalidatable].sort()).toEqual([...files].sort());
+	});
+});
+
+describe("notCoveredBy — a green discloses what THIS surface did not read", () => {
+	it("names the markdown a code run skipped", () => {
+		expect(notCoveredBy("code", ["a.ts", "README.md"])).toEqual(["README.md"]);
+	});
+
+	it("names the code a plan run skipped — the symmetric case, same rule", () => {
+		expect(notCoveredBy("plan", ["a.ts", "plans/epic.md"])).toEqual(["a.ts"]);
+	});
+
+	it("is empty only when the surface read every changed file", () => {
+		expect(notCoveredBy("code", ["a.ts", "b.tsx"])).toEqual([]);
+		expect(notCoveredBy("prose", ["docs/a.md"])).toEqual([]);
+	});
+
+	it("still carries the class no surface validates", () => {
+		expect(notCoveredBy("code", ["a.ts", "scripts/deploy.sh"])).toEqual(["scripts/deploy.sh"]);
+	});
+
+	it("reports in diff order, so the list reads against the diff it came from", () => {
+		expect(notCoveredBy("code", ["R.md", "a.ts", "x.sh"])).toEqual(["R.md", "x.sh"]);
 	});
 });
 
@@ -250,6 +273,62 @@ describe("runCheck", () => {
 		]);
 		expect(out.code).toBe(0);
 		expect(JSON.parse(out.stdout).unvalidated).toEqual(["scripts/deploy.sh"]);
+	});
+
+	// The #5288 regression. README.md landed in the markdown bucket, so the green listed nothing — and
+	// an empty `unvalidated` reads as "nothing uncovered" over a file no runner opened (`lint:worktree`
+	// filters `.md` out by extension).
+	it("names the markdown a --surface code green did not read", async () => {
+		const out = await run(
+			[
+				...LANE_OK,
+				[DIFF, okOut("apps/web/src/App.tsx\nREADME.md\n")],
+				[TYPECHECK, okOut("")],
+				[LINT, okOut("")],
+			],
+			{},
+			{"/repo/trees/lane-a/README.md": "nothing to resolve here\n"},
+		);
+		expect(out.code).toBe(0);
+		expect(JSON.parse(out.stdout).unvalidated).toEqual(["README.md"]);
+		expect(out.stderr).toContain(
+			"build check: 1 changed file(s) --surface code does not validate — NOT covered by this verdict: README.md.",
+		);
+	});
+
+	it("names the code a --surface plan green did not read — same rule, mirrored", async () => {
+		const shell = fakeShell([...LANE_OK, [DIFF, okOut("apps/web/src/App.tsx\nplans/epic.md\n")]]);
+		const out = await Effect.runPromise(
+			Effect.provide(
+				runCheck({...options, surface: "plan"}),
+				Layer.merge(
+					shell.layer,
+					fakeFs({
+						files: {"/repo/trees/lane-a/plans/epic.md": "## Dependencies\n\n- phase 1: #12\n"},
+					}).layer,
+				),
+			),
+		);
+		expect(out.code).toBe(0);
+		expect(JSON.parse(out.stdout).unvalidated).toEqual(["apps/web/src/App.tsx"]);
+		expect(shell.calls).not.toContain("pnpm typecheck --force");
+	});
+
+	// Disclosing is not validating: --surface code names the markdown it skipped and stays green over
+	// content the prose validators would red. Widening the surface to scan it is the fix #5288 declined.
+	it("discloses the skipped markdown without scanning it", async () => {
+		const out = await run(
+			[
+				...LANE_OK,
+				[DIFF, okOut("apps/web/src/App.tsx\ndocs/guide.md\n")],
+				[TYPECHECK, okOut("")],
+				[LINT, okOut("")],
+			],
+			{},
+			{"/repo/trees/lane-a/docs/guide.md": "run it from /Users/someone/phoenix\n"},
+		);
+		expect(out.code).toBe(0);
+		expect(JSON.parse(out.stdout).unvalidated).toEqual(["docs/guide.md"]);
 	});
 
 	it("reds a plan diff whose Dependencies block does not parse", async () => {


### PR DESCRIPTION
`fabrika build check --surface code` returned green over a diff like `["a.ts", "README.md"]` while listing nothing as skipped. The markdown was classified, so it never tripped the unclassified-diff refusal, but no code runner reads markdown — `lint:worktree` filters `.md` out by extension — and an empty `unvalidated: []` affirmatively reads as "nothing uncovered". `--surface plan` did the same to code files. A green now lists every changed file this surface's validators did not read, so an empty list means the whole diff was checked and nothing weaker.

Fixes #5288

## The fork, and which side this takes

#5287's disclosure named two candidate directions — scan both classes, or list the unscanned class — and this takes the **second**: disclose, do not widen.

`--surface` is an anchor, not a classifier. Running the markdown validators under `--surface code` would make the surface guess at file classes, which the anchor exists to refuse, and it has no coherent mirror: covering the symmetric `--surface plan` case that way would mean `build check --surface plan` spawning `pnpm typecheck`. Acceptance criterion 2 asks for **one mechanism** across both cases, and per-surface disclosure is the only shape that gives one. Acceptance criterion 1 already permits either ("validated **or** explicitly named as not covered").

This is also what the field was documented to be. `contract.md` said `unvalidated` "lists the changed files **this verdict does not cover**" and then narrowed it to the third class; the implementation followed the narrowing. Scoping the computation to the surface makes the code match the sentence — no new key, no new exit code, no third vocabulary.

## What changed

- **`notCoveredBy(surface, files)`** reports the changed files this surface's validators do not open, off a small `COVERS` map. It is a superset of the third class, and the extra members are markdown under `code` and code under `plan` — one rule, both cases. `packages/fabrika-cli/src/build/check-verb.ts`.
- **The green's `unvalidated` and the stderr scope note both read from it.** The note names the surface now (`--surface code does not validate — NOT covered by this verdict: README.md`), because "no surface validates" is no longer true of everything in the list.
- **`DiffClasses.unvalidated` is renamed `unvalidatable`.** The tree-level fact (no surface covers this file, which drives exit `22`) and the per-verdict one shared a word, and that collision is how a markdown file sat outside the disclosure while the field's own docs said otherwise.
- **`contract.md`** is amended to match: the scoped meaning, the disclosure-is-not-validation rule and its remedy (a second run, not a wider surface), the new scope-note row, an example with both classes, and the #5288 grounding line.

Exit codes are untouched — no refusal is added, and `22` keeps its exact trigger.

## Regression coverage

Three `runCheck` tests pin the defect, and they were proven to fail against the pre-fix computation by restoring it (`const unvalidated = classifyDiff(files).unvalidatable;`) and re-running: all three failed with `expected [] to deeply equal [...]`, which is the defect's exact signature.

- `--surface code` over `["apps/web/src/App.tsx", "README.md"]` → green with `unvalidated: ["README.md"]` and the stderr line asserted verbatim.
- `--surface plan` over `["apps/web/src/App.tsx", "plans/epic.md"]` → green with `unvalidated: ["apps/web/src/App.tsx"]`, and `pnpm typecheck --force` asserted **not** spawned, so the mirrored case is disclosed rather than validated.
- A `--surface code` run stays green over markdown carrying a machine-local path — the prose validators would red it, which is what proves the file was named but not scanned.

Plus five `notCoveredBy` unit tests, including the empty-only-when-fully-read case and diff-order reporting.

## Verification

- `pnpm typecheck` — 31/31 tasks, **0 cached**, resolved against this worktree.
- `pnpm lint:worktree` — clean.
- `pnpm vitest run` in `packages/fabrika-cli` — 196 files, 2833 tests, all passing.

## Deviations

- **Reviewer-suggested alternative declined** — **Said:** triage's read on #5288 was that disclose-only "leaves mixed diffs permanently unscannable for leaks and dead links, so it is honest but not sufficient on its own." **Did:** shipped disclose-only anyway. **Why:** the gap triage names is real but it is a *different* defect — `surfaceMismatch` refuses `--surface prose` whenever the diff holds any code file, so a mixed diff has no runnable prose surface at all. That is a routing rule, not the disclosure bug this issue scopes, and fixing it here would change which surfaces a diff admits, which no acceptance criterion asks for. Acceptance criterion 2's "same mechanism" requirement also rules out the validate-both shape, since its mirror would have `--surface plan` running `pnpm typecheck`. **Disposition:** follow-up #5301 filed for the unscannable-mixed-diff routing; for the reviewer to judge whether it belongs in this PR instead.

- **Widened the fix shape** — **Said:** the issue asks that the skipped class be named. **Did:** also renamed the `DiffClasses` bucket `unvalidated` → `unvalidatable`, touching the exported interface #5287 landed hours ago. **Why:** leaving both the structural bucket and the per-verdict list called `unvalidated` in one file reproduces the exact confusion that produced this bug — a reader greps `classifyDiff().unvalidated` and concludes the JSON field means the same thing. **Disposition:** no action needed; contained to `check-verb.ts` and its test, no other consumer in the repo.

- **Known defect left unfixed** — **Said:** `packages/fabrika-cli/src/build/codes.ts:7` still documents the group as adding its own `12`-`21`, which is stale now that `22` and `23` are allocated; #5287 left it for the next lane touching that file. **Did:** left it. **Why:** this fix allocates no exit code, so `codes.ts` is not in the diff, and opening it solely for a comment would widen the reviewed surface past the issue. **Disposition:** for the reviewer to judge — still owned by the next PR that edits `codes.ts`.

- **No ADR** — **Said:** ADR `0265` was pre-assigned for this lane. **Did:** wrote none, leaving `0265` unused. **Why:** the change makes an existing documented contract true rather than deciding anything new; `contract.md` carries the reasoning at the surface it governs. **Disposition:** no action needed — `0265` is free for another lane.
