### PR TITLE
docs(fabrika): record the trigger-coverage convention + the user-only exemption on the eval surface (#5239)

### DIFF
--- a/packages/fabrika-cli/src/eval/README.md
+++ b/packages/fabrika-cli/src/eval/README.md
@@ -676,6 +676,51 @@ An unedited authoring-session output shape is committed under
 [`fixtures/skill-creator/`](./fixtures/skill-creator) and is what the unit tests decode, so "decodes
 with no edits" is checked against the real shape rather than asserted.
 
+### Trigger coverage is part of the eval set ([#4750](https://github.com/kamp-us/phoenix/issues/4750))
+
+An eval set grades what a skill does **once invoked**. Whether it is ever invoked is a separate
+question, and it is not rhetorical: measured on `/report`, precision held at 100% while recall stayed
+between 0% and 11% across five description rewrites, so a skill can be green here and still almost
+never fire.
+
+**The convention: a skill's eval set includes trigger coverage.** It is a property of the *set*, not
+a fourth part of the ship gate — §8 part 3 already requires the set to be green at the bar, so the
+number has exactly one home and it is this surface.
+[`skill-conventions.md`](../../../../claude-plugins/fabrika/docs/skill-conventions.md) §8 keeps the
+three parts it was founder-ruled with and restates none of this. Ruled 2026-08-10 on #4750 and
+recorded in [ADR
+0249](../../../../.decisions/0249-skill-trigger-coverage-lives-in-the-eval-set.md), which carries the
+full derivation; an earlier split that would have put a routing-path check into `skill-conventions.md`
+is superseded there.
+
+**User-only skills are exempt, and the exemption is stated.** A skill with `disable-model-invocation`
+puts no `description` into model context, so there is nothing to trigger and no trigger coverage is
+owed. The precedent is live, not hypothetical: the `front-door` authoring session
+([#4952](https://github.com/kamp-us/phoenix/issues/4952)) skipped the description optimizer for
+exactly that stated reason and its gate accepted the deviation.
+
+Three constraints come with the convention. They are stated here rather than left in ADR 0249 because
+dropping any one turns the number into a gate that reds a working skill:
+
+- **Measure in deployment context.** A trigger score taken without the project's own routing
+  instructions loaded measures an environment the skill never ships into. The behavioural eval's
+  baseline arm — no skill at all — behaved correctly purely by reading `CLAUDE.md`, so for that class
+  of skill the routing instruction is the trigger mechanism and the description is not.
+- **Price one-step skills separately.** Where the model can simply do the task itself, no description
+  reaches a recall floor — no should-fire query ever got above 1/3 under any of the five rewrites.
+  Demanding a recall number there reds a working skill and points its author at prose that is not the
+  cause; the honest question for that class is whether a routing path reaches the skill at all.
+- **Keep precision in the bar.** Precision is the half that held — 100% across all five iterations and
+  all ten near-miss queries, including the noun-sense trap. A recall-only bar would have failed the
+  working half while missing that the discriminating half works.
+
+**No check enforces this today, and `fabrika eval cases` is not it.** Trigger coverage adds no
+required field to the authored format above, which is still decoded exactly as a session emits it —
+this is the requirement an authoring session writes its set *against*, ahead of the mechanics that
+will measure it. The model-invoked skills already on `main` are not exempted by the ruling, and
+whether they are retro-measured or explicitly grandfathered is open on
+[#5245](https://github.com/kamp-us/phoenix/issues/5245) — not answered here.
+
 ## `fabrika eval run` — executing an eval set unattended (#4676)
 
 ```bash


### PR DESCRIPTION
Fixes #5239

Records the trigger-coverage convention and its user-only exemption on the eval-mechanics surface, so a fabrika skill's eval set is authored against a written requirement instead of a ruling that lived only in an issue comment.

## What the ruling actually says

The governing ruling is the **2026-08-10** comment on #4750 (founder-delegated judgment under the standing trust ruling of 2026-08-09; founder live, veto open), recorded as [ADR 0249](.decisions/0249-skill-trigger-coverage-lives-in-the-eval-set.md), which is on `main`:

- Triggering measurement lives in the **eval mechanics** (#4649's surface), **not** as a fourth §8 part. §8 keeps exactly its three founder-ruled parts.
- The convention: **a skill's eval set includes trigger coverage**, with a **stated exemption for user-only skills** whose description never enters model context — precedent set live by the `front-door` session (#4952), whose gate accepted the deviation for exactly that stated reason.
- The downstream build ticket records that convention in the eval mechanics docs. That is this PR.

An **earlier** ruling on the same issue (2026-08-02) split the gate and sent a structural "is there a routing path that reaches this skill in deployment?" check into `skill-conventions.md` beside the sizing band. ADR 0249 records that split as **superseded**. This PR follows the later ruling: nothing lands in `skill-conventions.md`.

The three constraints (deployment-context measurement, one-step skills priced separately, precision kept in the bar) come from the 2026-08-02 measurement evidence, which ADR 0249 explicitly carries forward as *not* superseded — so they are recorded here as constraints the mechanics inherit.

## What changed

One file, one added subsection, +45/−0:

- `packages/fabrika-cli/src/eval/README.md` — a new `### Trigger coverage is part of the eval set (#4750)` subsection at the end of `## Authored eval-set ingestion`, which is where the eval-set contract already lives.

It states, in one text: the convention as a property of the *set* (not a fourth gate part); the user-only exemption with its reason (`disable-model-invocation` puts no `description` in model context) and its live precedent (#4952); and the three constraints, each with the measurement that establishes it. It also states plainly that **no check enforces this today** and that `fabrika eval cases` is not it — trigger coverage adds no required field to the authored format, which is still decoded exactly as a session emits it.

## Acceptance criteria

- [x] The trigger-coverage requirement is stated on the eval-mechanics surface (`packages/fabrika-cli/src/eval/README.md`), as a property of a skill's eval set.
- [x] The user-only exemption is stated with its reason and its live precedent (#4952).
- [x] All three constraints are carried in the same text, not dropped as background.
- [x] `claude-plugins/fabrika/docs/skill-conventions.md` is unchanged — no fourth part, no restated number. The diff touches one file and it is not that one.
- [x] ADR `0249` is cited, and it is on `main` (PR #5238 merged before this branch was cut — the branch is off `origin/main` at `0dab074e`, and the ADR file resolves there).
- [x] The retro-measure-vs-grandfather question is **not** settled here. The text points at #5245 as open and answers nothing.

## Verification

- `tsgo -p tsconfig.json --noEmit` in `packages/fabrika-cli`, run directly and uncached in this worktree: clean. The diff is markdown-only, so no test is affected and none was added.
- Both new relative links resolve on disk from the file's own directory (`../../../../.decisions/0249-…`, `../../../../claude-plugins/fabrika/docs/skill-conventions.md`) — the `doc-links` gate's check.
- No new ADR was minted. Recording an existing ruling in docs needs none, and ADR 0249 already is the record.

## Deviations

1. **Class: departure from a repo convention (`CLAUDE.md` — "state a *why* once; collapse a docblock that re-derives an ADR's *why* to a pointer").** The three constraints and their measurement are stated here even though ADR 0249's Consequences section already states them, so the same *why* now exists in two places. This is deliberate and required: #5239's third acceptance criterion says all three constraints must be "carried in the same text, not dropped as background", and the ruling's own reasoning is that a mechanics surface which cites the constraints without stating them is how a number becomes unenforceable (#4701). The text mitigates the duplication by naming ADR 0249 as the surface carrying "the full derivation" rather than re-deriving it, and by keeping each constraint to its claim plus the measurement that establishes it. Flagged rather than silently taken, because it is a real convention departure and a reviewer should get to disagree with it.

2. **Class: the issue body's stated precondition was already discharged.** #5239 says "**Blocked on PR #5238** for the ADR citation only… do not cite an unmerged ADR." Verified live before writing: #5238 is merged and `.decisions/0249-skill-trigger-coverage-lives-in-the-eval-set.md` is on `origin/main`. So the citation is written, not deferred. No divergence from the ruling — only from the issue body's snapshot of the board at triage time.

3. **Class: choice of exact placement, within what the AC permits.** The AC allowed "`packages/fabrika-cli/src/eval/README.md`, or wherever #4649's owner places the eval-set contract". The subsection went under `## Authored eval-set ingestion` (#4674), which is the section that defines what an eval set *is* and what it must contain. If #4649's owner wants the eval-set contract stated elsewhere on that surface, this is a move, not a rewrite.

4. **Class: ruling-vs-body conflict.** None. #4750's governing ruling and #5239's body agree on every load-bearing point — the home (eval mechanics, not §8), the convention (a property of the eval set), the exemption (user-only, with the #4952 precedent), and the three constraints. The one place the issue body goes beyond the 2026-08-10 comment — the three constraints — is sourced from the same issue's 2026-08-02 evidence, which ADR 0249 carries forward explicitly as not superseded. No seam to pick a side on.

5. **Class: scope / lane.** None. One file, entirely inside the eval surface; nothing touched under `packages/fabrika-cli/src/build/**`, `claude-plugins/fabrika/skills/build/**`, `packages/fabrika-cli/src/status/**`, `exit-code-alignment.ts` or `registry.ts`.

6. **Class: skipped or bypassed check.** None. No check was skipped or overridden; the typecheck was run directly rather than through the turbo task specifically to avoid a cached cross-lane pass.

7. **Class: unstated behaviour change.** None. The diff adds prose only — no code, no schema, no new required field, and no guard.
