### PR TITLE
docs(decisions): 0270 — the calibration record is written at the hand-off, and the criterion asks for the record (#5279)

### DIFF
--- a/.decisions/0270-calibration-record-is-written-at-the-handoff.md
+++ b/.decisions/0270-calibration-record-is-written-at-the-handoff.md
@@ -1,0 +1,135 @@
+---
+id: 0270
+title: the calibration conjunct is discharged by a record written at the hand-off, and the criterion is reworded to the evidence class a reader can check
+status: accepted
+date: 2026-08-10
+tags: [fabrika, skills, briefs, review]
+---
+
+# 0270 — the calibration record is written at the hand-off, and the criterion asks for the record, not the act
+
+**What this decides:** how a fabrika authoring brief's calibration row is discharged. The authoring
+session writes down which calibration inputs it handed `skill-reviewer` **while it hands them over**
+(runbook step 5.5), and the acceptance criterion is worded to ask for exactly that record — not for
+the act behind it. This closes a **forgotten** record. It does not, and is not written to, close an
+**untrue** one.
+
+## Context
+
+Every fabrika authoring brief carries a criterion of the shape (verbatim from
+[#5020](https://github.com/kamp-us/phoenix/issues/5020)): *"`skill-reviewer` ran on the authored
+skill before the pull request opened, was handed `skill-conventions.md` and a landed sibling skill as
+calibration, its findings were addressed, and the PR records the review pass."* Four conjuncts; the
+second is the one at issue.
+
+Three facts, each checked against the durable record rather than recalled:
+
+- **The row fails on correct work.** PR [#5261](https://github.com/kamp-us/phoenix/pull/5261)
+  (`prototyping`) took `review-skill: FAIL @ 35c1db4c` on that single row out of nineteen. The
+  verdict's words: *"The calibration conjunct is recorded nowhere — not in the PR body, not in the
+  handoff comment on #5020, not in the diff."* The calibration had in fact happened. Nothing wrote it
+  down, so the row failed and the repair was a sentence added to the PR body afterwards.
+- **The row passes on a sentence.** PR [#5268](https://github.com/kamp-us/phoenix/pull/5268)
+  (`graduate`) passed the same row, and its verdict says why in its own words: *"this gate verifies
+  the written record; it cannot re-run the reviewer, because the authoring runbook emits no
+  calibration artifact."* Both landed siblings —
+  [#5233](https://github.com/kamp-us/phoenix/issues/5233),
+  [#5242](https://github.com/kamp-us/phoenix/issues/5242) — cleared it the same way: one sentence in
+  the PR body, no independent artifact.
+- **No artifact class exists to produce.** `skill-reviewer` is a generic upstream `plugin-dev` agent
+  invoked in-session, and nothing under `claude-plugins/fabrika/` records what it was handed. That is
+  [#4701](https://github.com/kamp-us/phoenix/issues/4701)'s own finding, and it is *why* the brief
+  made handing over the doc an explicit act in the first place.
+
+So the same criterion produced opposite outcomes on two sibling PRs, decided entirely by whether
+someone remembered to type a sentence. And there is a second defect underneath: the obligation lives
+**only** in the per-brief acceptance criteria. `authoring-brief-contract.md` field 6 — the contract
+those criteria derive from — requires only that `skill-reviewer` *run*, and says nothing about
+calibration. A session that boots from the brief alone reads the obligation as an unexplained row
+rather than as part of its output contract.
+
+One tension is worth naming, because it is the sharpest thing on the ticket and it is easy to
+overstate. `prototyping` is built on the scar that a self-report is not evidence
+([#4111](https://github.com/kamp-us/phoenix/issues/4111)), while its own calibration row can be
+discharged only by a self-report. That is an **asymmetry**, not a contradiction: the #4111-grounded
+criterion constrains the runtime artifact the authored skill produces, and this one constrains the
+authoring process one level up. What is genuinely wrong is that fabrika applied to its own gate a
+standard weaker than the one it ships — and never said so out loud.
+
+## Decision
+
+**1. The record is written at the hand-off, not reconstructed at PR time.** Runbook step 5.5 is
+already where `skill-reviewer` runs. The session names its calibration inputs in the PR body's review
+section **as it runs that pass** — the conventions doc, any other convention doc handed over, and
+which landed sibling skill. A note written while the act happens cannot be forgotten afterwards; a
+note owed at PR-open time can be, and was.
+
+**2. The criterion asks for the record.** Its wording becomes: *"the PR records which calibration
+inputs `skill-reviewer` was handed."* The old wording — *"was handed … as calibration"* — asserts a
+fact about the session, and no reader of the PR can check it. The new wording asks for the thing a
+reader can actually check, so a passing row means what it says.
+
+**3. Field 6 of the brief contract carries both.** The contract and the briefs derived from it now
+say the same thing, and a session booting from the brief alone reads the obligation there.
+
+**4. Briefs already minted keep their bytes; the gate reads them at this evidence class.** The open
+briefs carry the old wording, and a filed brief is amended, never rewritten. `review-skill` reads the
+old wording as asking for the same record this ADR names, so no board-wide edit is owed and no
+in-flight brief changes meaning.
+
+## What this closes, and what it does not
+
+Stated plainly, because the value of the row depends on it:
+
+- **Closed: a forgotten record.** Observed — once in the three sibling PRs, at the cost of a review
+  cycle and an after-the-fact body edit.
+- **Not closed: an untrue record.** A note written by the same session at the moment of the act is
+  still that session's unverified word. An earlier timestamp does not make it checkable. A reader of
+  a passing row learns that the session wrote down which inputs it handed over — nothing stronger.
+
+That is the honest reading of the row, and it is why conjunct 2 is reworded rather than left implying
+verification it cannot deliver.
+
+## Relationship to #4701's option 3 — left open, not subsumed
+
+[#4701](https://github.com/kamp-us/phoenix/issues/4701) offered a third option: *"a fabrika-side gate
+that reads `skill-conventions.md` is named and given the conformance job, or `skill-reviewer`'s
+invocation is required to be handed the doc."* Its ruling deleted the sizing line band and left that
+option unresolved. This decision does **not** resolve it. Verb-mediating the hand-off — so the record
+is written by something other than the session vouching for itself — is the only shape that would
+make the row independently checkable, and it is priced here rather than skipped: a verb plus a
+wrapped invocation, against roughly a one-in-three chance of one lost review cycle on the remaining
+briefs. Not worth building for the briefs that remain. It stays open under #4701 for whenever a
+fabrika-side conformance gate is built for other reasons, and this ADR is not a ruling against it.
+
+[#5290](https://github.com/kamp-us/phoenix/issues/5290) is the sibling one row over — the same shape
+of problem on criterion 10 (v1-surface coverage), with its own answer. Neither decision subsumes the
+other.
+
+## Consequences
+
+- A future fabrika authoring session has one more thing to write during step 5.5, and one fewer way
+  to lose a review cycle at the end of it.
+- A passing calibration row is now correctly readable as "the record exists", which is weaker than
+  what the old wording implied and is the truth.
+- If a fabrika-side conformance gate is ever built (#4701 option 3), this row is a natural first
+  consumer: the record becomes the gate's input instead of its only evidence.
+
+## Alternatives considered
+
+- **Drop the conjunct.** Rejected: it exists to close #4701's "nothing hands the reviewer the doc"
+  hole, and dropping it re-opens that hole while the calibration is still the only thing pointing a
+  generic upstream reviewer at fabrika's conventions.
+- **Verb-mediate the hand-off now.** Rejected on price for the remaining briefs; left open at #4701
+  rather than ruled against (above).
+- **Leave the wording and rely on authors remembering.** Rejected — that is the observed failure, and
+  it also leaves a passing row claiming more than a reader can check.
+
+## References
+
+- [#5279](https://github.com/kamp-us/phoenix/issues/5279) — the decision issue this ADR settles.
+- [#5261](https://github.com/kamp-us/phoenix/pull/5261) — the FAIL on this row; [#5268](https://github.com/kamp-us/phoenix/pull/5268) — the PASS, whose verdict states the gate verifies the record and cannot re-run the reviewer.
+- [#4701](https://github.com/kamp-us/phoenix/issues/4701) — nothing hands `skill-reviewer` the conventions doc; option 3 unresolved.
+- [#5290](https://github.com/kamp-us/phoenix/issues/5290) — the sibling criterion-10 decision.
+- [#4111](https://github.com/kamp-us/phoenix/issues/4111) — the "a self-report is not evidence" scar, cited as grounding rather than as a standing law.
+- [`claude-plugins/fabrika/docs/authoring-brief-contract.md`](../claude-plugins/fabrika/docs/authoring-brief-contract.md) field 6 — where the obligation now lives.

--- a/claude-plugins/fabrika/docs/authoring-brief-contract.md
+++ b/claude-plugins/fabrika/docs/authoring-brief-contract.md
@@ -122,6 +122,17 @@ Stated in the brief itself, so the session reads its own deliverable rather than
   restated as constraint 4 of the [decomposition-dispatch contract](https://github.com/kamp-us/phoenix/issues/4650#issuecomment-5150265328)).
   A session booting from the brief alone reads this here or not at all, so every brief states it —
   and because the gate is `skill-reviewer`, nothing waits on fabrika's own `/review-skill`.
+- **The calibration inputs are handed over, and the hand-off is written down as it happens.**
+  `skill-reviewer` is a generic upstream `plugin-dev` agent that applies its own rubric and is handed
+  fabrika's conventions by nothing ([#4701](https://github.com/kamp-us/phoenix/issues/4701)), so the
+  session hands it [`skill-conventions.md`](skill-conventions.md) and a landed sibling skill, and
+  **names those inputs in the PR body during step 5.5** rather than reconstructing them at PR-open
+  time. The acceptance criterion asks for the **record**, not the act — *"the PR records which
+  calibration inputs `skill-reviewer` was handed"* — because the record is what a reader can check;
+  that closes a forgotten hand-off, not an untrue one
+  ([ADR 0270](../../../.decisions/0270-calibration-record-is-written-at-the-handoff.md), where the
+  price of verb-mediating it instead is recorded). Briefs already minted carry the older *"was
+  handed … as calibration"* wording and are read at this same evidence class.
 - **One pull request**, carrying the authored `SKILL.md` **and** the derived contract spec
   (`contract.md` beside it, per the CLI interface convention's Part 2).
 - **Linked back to the brief issue** — `Fixes #<brief>` in the PR body, so the brief closes on merge
@@ -220,8 +231,9 @@ point: a session can tell an unbootable brief from a bootable one before it star
 3. Every incident is a number **and** a one-line behavior; an empty list is written as empty.
 4. Every prior-art verb is named, with what it computes and — where known — what it gets wrong.
 5. Both convention docs are linked, and neither is summarised.
-6. The output contract is stated in the brief, not assumed — including its filing half: the
-   handoff mints the implementation ticket and names its number.
+6. The output contract is stated in the brief, not assumed — including its filing half (the
+   handoff mints the implementation ticket and names its number) and its calibration half (the PR
+   records which inputs `skill-reviewer` was handed).
 
 ## What a brief deliberately does not carry
 


### PR DESCRIPTION
Fixes #5279

`type:decision`, so the deliverable is a recorded choice: **ADR 0270**, plus the one contract edit the acceptance criteria name by path.

## The question, and the answer

How is a fabrika brief's calibration conjunct discharged — *"`skill-reviewer` … was handed `skill-conventions.md` and a landed sibling skill as calibration"*?

**Answer: the authoring session writes the hand-off down while it happens (runbook step 5.5), and the criterion is reworded to ask for that record rather than for the act.**

The two halves are deliberate. Writing it at the hand-off closes the failure that actually cost a cycle — forgetting. Rewording it stops the row from claiming more than a reader can check.

## Why, from first-party evidence

- PR #5261 (`prototyping`) took `review-skill: FAIL @ 35c1db4c` on that one row out of nineteen; its verdict says *"The calibration conjunct is recorded nowhere."* The calibration had happened. The repair was a sentence added to the body afterwards.
- PR #5268 (`graduate`) **passed** the same row, and its verdict states why in its own words: *"this gate verifies the written record; it cannot re-run the reviewer, because the authoring runbook emits no calibration artifact."*
- Same criterion, opposite outcomes, decided by whether someone typed a sentence. #4701's finding is that nothing in fabrika hands the upstream `plugin-dev` reviewer the doc, so the record is the only evidence class available.
- Second defect, underneath: the obligation lives **only** in per-brief acceptance criteria. `authoring-brief-contract.md` field 6 required only that the reviewer *run*. The contract and the briefs derived from it disagreed. This PR closes that split.

## What the ADR is careful about

- It says plainly which failure mode it closes (a forgotten record) and which it does not (an untrue one). A note written at the moment of the act is still the session's own word with a better timestamp.
- The #4111 "a self-report is not evidence" tension is recorded as an **asymmetry**, not a contradiction — the two claims sit at different levels (runtime artifact vs authoring process).
- #4701's option 3 (verb-mediate the hand-off so something other than the session writes the record) is **priced and left open with a pointer**, not subsumed and not ruled against.
- #5290 is named as the sibling one row over (criterion 10); neither decision subsumes the other.
- Briefs already minted keep their bytes — the gate reads their older wording at this same evidence class. No board-wide rewrite.

## Acceptance criteria

| # | Criterion | Where |
|---|---|---|
| 1 | Names how the conjunct is discharged, from the stated option set | ADR `## Decision` 1–2 — write at step 5.5 + reword to the evidence class |
| 2 | States which failure mode it closes and which it does not | ADR `## What this closes, and what it does not` |
| 3 | Field 6 and the per-brief criterion wording say the same thing | `authoring-brief-contract.md` field 6 gains the calibration bullet, in the reworded form; ADR `## Decision` 4 rules how already-minted briefs read |
| 4 | Relationship to #4701's option 3 stated | ADR `## Relationship to #4701's option 3 — left open, not subsumed` |
| 5 | Readable from the brief alone | Field 6 is what briefs derive their output contract from; the completeness test's item 6 now names the calibration half beside the filing half |

## Deviations

- **The contract edit touches two places in the file, not one.** The criteria name field 6; I also extended the completeness test's item 6, which enumerates what field 6 owes. Leaving it would have made the completeness test silently disagree with the field it tests. *Disposition: for the reviewer to judge.*
- **`pnpm typecheck` replayed FULL TURBO from a different lane's worktree** (`agent-ad815d15…`), the known false-green (#4881/#4887). Not repaired here, and not load-bearing: the diff is two markdown files and zero TypeScript. Real, uncached signal did run — the pre-push hook executed the changed-scope unit suite in this lane: 288 files, 2424 tests, all passing. *Disposition: no action needed; the false-green itself is a separate lane's problem.*
- **`review-skill`'s wording is untouched.** The row's text lives in brief issue bodies and in the reviewer's reading of them, not in a file this PR can edit. ADR `## Decision` 4 is what makes the already-minted briefs read at the new evidence class. *Disposition: for the reviewer to judge.*
- **Control-plane:** `claude-plugins/fabrika/**` is not §CP by path, but `.decisions/**` classifies by **content** under ADR 0164, and this ADR names gates and criteria throughout. Expect a §CP merge-authority hold and a human control-plane approval. *Disposition: no action needed — flagged for the shipper.*
