### PR TITLE
fix(fabrika): build check scans a mixed code+markdown diff's prose (#5301)

### DIFF
--- a/claude-plugins/fabrika/skills/build/SKILL.md
+++ b/claude-plugins/fabrika/skills/build/SKILL.md
@@ -116,6 +116,10 @@ fabrika build check --surface code
 Loop construct → check until green. `red` rows name the diagnostics; fix them here, never in the
 primary.
 
+A green names the files it did not read in `unvalidated`. When that list holds a file class another
+surface validates — markdown beside your code, most often — run `build check` again at that surface;
+one run per class present is what leaves nothing in the diff unread (#5301).
+
 ## 5 — Push verified, open the PR through the guard
 
 ```bash

--- a/claude-plugins/fabrika/skills/build/contract.md
+++ b/claude-plugins/fabrika/skills/build/contract.md
@@ -69,7 +69,7 @@ second answer to a gated question can contradict the gate (interface convention 
 **Considered and not derived: a surface classifier.** Naming the surface (code / prose / plan) is
 a judgment the skill makes reading the issue; a verb that guessed it from file extensions would be
 wrong exactly on the mixed PRs where the answer matters. `build check` takes the skill's answer as
-`--surface` and validates it against the diff (a `--surface prose` run over changed `.ts` files
+`--surface` and validates it against the diff (a `--surface prose` run over a diff with no markdown
 refuses) — an anchor, not a second classifier.
 
 ## Shared conventions
@@ -997,8 +997,10 @@ beside a green is the honest reading of a mixed diff, and the same line is repea
 The list is a **disclosure, not a second validator run**: `--surface code` names the markdown it
 skipped and does not scan it. Running the markdown validators there would make the surface guess at
 file classes, which the anchor exists to refuse — so the remedy for a mixed diff that needs its
-markdown read is a second run, not a wider surface. `unvalidated: []` therefore means every changed
-file was read by a validator that passed, and nothing weaker (#5288).
+markdown read is a **second run at `--surface prose`**, which the anchor admits (#5301). Each run is
+green for what it read and names what it did not; between them nothing in the diff goes unread.
+`unvalidated: []` therefore means every changed file was read by a validator that passed, and
+nothing weaker (#5288).
 
 Per surface:
 
@@ -1013,17 +1015,26 @@ Per surface:
   (defined in `build eligible`): issue refs (`#<int>`) resolve to real issues, ledger-local refs
   (`C<int>`) resolve within the ledger, and no child is its own predecessor.
 
-The surface anchor: the verb diffs the branch against its base and refuses a surface that does not
-match the diff (`--surface prose` over changed `.ts` files is `10`) — the skill's judgment is
-taken, then checked against the tree, never silently accepted.
+The surface anchor: the verb diffs the branch against its base and refuses a surface whose own file
+class the diff does not contain (`--surface prose` over a diff with no markdown is `10`) — the
+skill's judgment is taken, then checked against the tree, never silently accepted.
+
+**The anchor refuses an absent class, never a present other one.** One rule holds for all three
+surfaces, so a mixed code+markdown diff is runnable under every one of them: `code` runs the CI
+commands and names the markdown, `prose` scans the markdown and names the code, `plan` checks the
+ledger grammar and names the code. `prose` used to refuse on the *presence* of a code file, which
+left the repo's most common diff shape — one `.ts` plus one `.md` — with no invocation that opened
+the markdown at all, so the leak scan and the link resolver never ran on it (#5301). The presence of
+another class is not a contradiction with the surface; it is exactly what `unvalidated` discloses.
 
 **Three file classes, because two cannot express "unvalidatable".** The anchor sorts each changed
 file into code, markdown, or **neither** — the third class is named, not an absence. A diff that is
 *wholly* the third class (only `.github/workflows/*.yml`, only `*.sh`) refuses on `22` under **every**
 surface: no validator covers those files, so any verdict would be a green over an unread tree. The
-remedy is to split the diff or extend a validator, never to rename the surface — widening the code
+remedy is to extend a validator to cover the class, never to rename the surface — widening the code
 pattern to swallow `.yml` was considered and rejected, because it would claim `pnpm typecheck`
-validated a shell script (#5229).
+validated a shell script (#5229). "Split the diff" is not offered as a remedy anywhere here: a lane
+cannot split a diff it has already written (#5301).
 
 Preconditions: a linked worktree (`12`), the lane's branch checked out (`14`).
 
@@ -1032,7 +1043,7 @@ Preconditions: a linked worktree (`12`), the lane's branch checked out (`14`).
 | Code | Trigger |
 |---|---|
 | `7` | the diff against the branch base is empty — nothing to validate, zero scope |
-| `10` | `--surface` is off-enum, or provably mismatches the diff |
+| `10` | `--surface` is off-enum, or the diff contains none of the file classes that surface's validators open |
 | `11` | a validator could not be executed, or the lane's claim could not be read — the verdict is UNKNOWN, never green |
 | `12` | proven: not in a linked worktree |
 | `14` | proven: the checked-out branch is not this lane's (lane-identity rule) |
@@ -1047,7 +1058,7 @@ Preconditions: a linked worktree (`12`), the lane's branch checked out (`14`).
 | `build check: <runner> could not be executed: <reason> — the verdict is UNKNOWN, never green.` | 11 | refusal |
 | `build check: cannot read the claim markers on #<n>: <reason> — the lane is UNKNOWN.` | 11 | refusal |
 | `build check: #<n> is held by <token>, not this session.` | 15 | refusal |
-| `build check: --surface prose, but the diff is 14 .ts files — the surface is provably wrong.` | 10 | refusal |
+| `build check: --surface prose, but the diff changes no markdown file — the surface is provably wrong.` | 10 | refusal |
 | `build check: the diff against <base> is empty — nothing to validate (ADR 0092).` | 7 | refusal |
 | `build check: red — <runner> failed; diagnostics above.` | 18 | refusal |
 | `build check: no surface validates any of the <n> changed file(s) (<files>) — there is nothing here to run, so the verdict is a refusal, never green.` | 22 | refusal |
@@ -1076,6 +1087,9 @@ $ fabrika build check --surface code
   `["a.ts", "README.md"]` greened with an empty list: the markdown had a validator, just not the one
   that ran. Scoping the list to the surface closes it, and the mirrored `--surface plan` case, with
   one rule.
+- #5301 — the disclosure was honest but there was still nowhere to send the markdown: `--surface
+  prose` refused whenever one code file was present, so a mixed diff's prose was unscannable under
+  every surface. The anchor now refuses an absent class rather than a present other one.
 - v1's discipline was prose-only (`SKILL.md:895-935`, exact-CI-command mandate with no
   enforcement); here the command set is the verb's, not the agent's memory.
 - ADR 0092 — zero diff is a refusal, not a vacuous green.

--- a/packages/fabrika-cli/src/build/check-verb.ts
+++ b/packages/fabrika-cli/src/build/check-verb.ts
@@ -127,19 +127,22 @@ export const unvalidatableDiff = (files: ReadonlyArray<string>): string | null =
 	return `no surface validates any of the ${unvalidatable.length} changed file(s) (${shown}${rest})`;
 };
 
-/** Why `--surface` provably contradicts the diff, or `null`. */
+/**
+ * Why `--surface` provably contradicts the diff, or `null`.
+ *
+ * One rule for all three surfaces, read straight off {@link COVERS}: a surface is refused when the
+ * diff holds **none** of the file classes its validators open. `prose` used to refuse on the
+ * *presence* of a code file instead, and that asymmetry left the repo's most common diff shape — one
+ * `.ts` plus one `.md` — with no invocation that opened the markdown at all: `code` never reads it,
+ * `plan` runs the wrong validator, and `prose` refused on `10`. The leak scan and the link resolver
+ * simply did not run (#5301). The presence of another class is not a contradiction; it is what
+ * `unvalidated` discloses.
+ */
 export const surfaceMismatch = (surface: Surface, files: ReadonlyArray<string>): string | null => {
-	const {code, markdown} = classifyDiff(files);
-	if (surface === "prose" && code.length > 0) {
-		return `--surface prose, but the diff is ${code.length} ${code.length === 1 ? "code file" : "code files"}`;
-	}
-	if (surface === "code" && code.length === 0) {
-		return "--surface code, but the diff changes no code file";
-	}
-	if (surface === "plan" && markdown.length === 0) {
-		return "--surface plan, but the diff changes no markdown file";
-	}
-	return null;
+	const classes = classifyDiff(files);
+	const covered = COVERS[surface].flatMap((bucket) => classes[bucket]);
+	if (covered.length > 0) return null;
+	return `--surface ${surface}, but the diff changes no ${COVERS[surface].join("/")} file`;
 };
 
 /** The machine-local paths a prose file carries, as defect lines. */

--- a/packages/fabrika-cli/src/build/check-verb.unit.test.ts
+++ b/packages/fabrika-cli/src/build/check-verb.unit.test.ts
@@ -2,7 +2,7 @@ import {Effect, Layer} from "effect";
 import {describe, expect, it} from "vitest";
 import {errOut, fakeFs, fakeShell, okOut} from "../fakes.test-support.ts";
 import type {ExecResult} from "../io/exec.ts";
-import {classifyDiff, notCoveredBy, runCheck, surfaceMismatch} from "./check-verb.ts";
+import {classifyDiff, notCoveredBy, runCheck, SURFACES, surfaceMismatch} from "./check-verb.ts";
 import {
 	OFF_VOCABULARY,
 	PRECONDITION_UNKNOWN,
@@ -58,16 +58,24 @@ const run = (
 	);
 
 describe("surfaceMismatch — the anchor, not a second classifier", () => {
-	it("refuses --surface prose over changed code files", () => {
-		expect(surfaceMismatch("prose", ["a.ts", "b.ts"])).toContain("2 code files");
+	it("refuses --surface prose over a diff with no markdown file", () => {
+		expect(surfaceMismatch("prose", ["a.ts", "b.ts"])).toContain("no markdown file");
 	});
 
 	it("refuses --surface code over a diff with no code file", () => {
 		expect(surfaceMismatch("code", ["README.md"])).toContain("no code file");
 	});
 
-	it("accepts a mixed diff under --surface code", () => {
-		expect(surfaceMismatch("code", ["a.ts", "README.md"])).toBeNull();
+	it("refuses --surface plan over a diff with no markdown file", () => {
+		expect(surfaceMismatch("plan", ["a.ts"])).toContain("no markdown file");
+	});
+
+	// #5301: the anchor refuses an ABSENT class, never a present other one — the asymmetry that left a
+	// mixed diff's markdown with no surface to run under.
+	it("accepts a mixed diff under every surface", () => {
+		for (const surface of SURFACES) {
+			expect(surfaceMismatch(surface, ["a.ts", "README.md"])).toBeNull();
+		}
 	});
 });
 
@@ -153,13 +161,13 @@ describe("runCheck", () => {
 		);
 	});
 
-	it("refuses a surface the diff provably contradicts on 10", async () => {
+	it("refuses --surface prose on 10 over a diff with no markdown at all", async () => {
 		const out = await run([...LANE_OK, [DIFF, okOut("apps/web/src/App.tsx\nsrc/x.ts\n")]], {
 			surface: "prose",
 		});
 		expect(out.code).toBe(OFF_VOCABULARY);
 		expect(out.stderr.at(-1)).toBe(
-			"build check: --surface prose, but the diff is 2 code files — the surface is provably wrong.",
+			"build check: --surface prose, but the diff changes no markdown file — the surface is provably wrong.",
 		);
 	});
 
@@ -364,5 +372,64 @@ describe("runCheck", () => {
 			},
 		);
 		expect(out.code).toBe(0);
+	});
+});
+
+// The #5301 regression, one leg per surface. `["a.ts", "README.md"]` is the repo's most common diff
+// shape, and it had no invocation that opened the markdown: `code` never reads it, `plan` runs the
+// grammar check, and `prose` refused on 10 because a code file was present. The leak scan and the
+// link resolver never ran over a mixed diff under any surface.
+describe("a mixed code+markdown diff — every surface has a runnable answer", () => {
+	const MIXED = okOut("apps/web/src/App.tsx\nREADME.md\n");
+
+	it("scans the markdown under --surface prose, reding on its machine-local path", async () => {
+		const out = await run(
+			[...LANE_OK, [DIFF, MIXED]],
+			{surface: "prose"},
+			{
+				"/repo/trees/lane-a/README.md": "run it from /Users/someone/phoenix\n",
+			},
+		);
+		expect(out.code).toBe(VALIDATION_RED);
+		expect(out.stderr.some((line) => line.includes("machine-local path"))).toBe(true);
+	});
+
+	it("greens under --surface prose, disclosing the code file it did not read", async () => {
+		const out = await run(
+			[...LANE_OK, [DIFF, MIXED]],
+			{surface: "prose"},
+			{
+				"/repo/trees/lane-a/README.md": "see [the contract](./other.md)\n",
+				"/repo/trees/lane-a/other.md": "here\n",
+			},
+		);
+		expect(out.code).toBe(0);
+		const verdict = JSON.parse(out.stdout);
+		expect(verdict.ran).toEqual(["markdown link + leak scan"]);
+		expect(verdict.unvalidated).toEqual(["apps/web/src/App.tsx"]);
+	});
+
+	it("runs the CI commands under --surface code, disclosing the markdown it did not read", async () => {
+		const out = await run([...LANE_OK, [DIFF, MIXED], [TYPECHECK, okOut("")], [LINT, okOut("")]], {
+			surface: "code",
+		});
+		expect(out.code).toBe(0);
+		const verdict = JSON.parse(out.stdout);
+		expect(verdict.ran).toEqual(["pnpm typecheck --force", "pnpm lint:worktree"]);
+		expect(verdict.unvalidated).toEqual(["README.md"]);
+	});
+
+	it("runs the grammar check under --surface plan, disclosing the code file", async () => {
+		const out = await run(
+			[...LANE_OK, [DIFF, MIXED]],
+			{surface: "plan"},
+			{
+				"/repo/trees/lane-a/README.md": "## Dependencies\n\n- phase 1: #12\n",
+			},
+		);
+		expect(out.code).toBe(0);
+		const verdict = JSON.parse(out.stdout);
+		expect(verdict.ran).toEqual(["## Dependencies grammar"]);
+		expect(verdict.unvalidated).toEqual(["apps/web/src/App.tsx"]);
 	});
 });


### PR DESCRIPTION
`fabrika build check` could not scan the prose in a diff that changes both code and markdown — the most common shape in this repo. `--surface prose` refused whenever one code file was present, `--surface code` never opens a `.md`, and `--surface plan` runs the ledger grammar check. So a lane touching one `.ts` and one doc could ship a machine-local path or a dead relative link with `build check` green. This makes the surface anchor refuse only what it always meant: a surface whose own file class the diff does not contain.

Fixes #5301

## What changed

- `surfaceMismatch` now reads one rule off `COVERS`: refuse when the diff holds **none** of the file classes this surface's validators open. `code` and `plan` already behaved that way; `prose` was the only surface that refused on the *presence* of another class. Deriving the rule from `COVERS` makes the asymmetry unrepresentable rather than fixing it by hand in one branch.
- A mixed diff is now runnable under all three surfaces: `code` runs the CI commands and names the markdown, `prose` runs the leak scan + relative-link resolver and names the code, `plan` runs the `## Dependencies` grammar and names the code. The `unvalidated` disclosure needed no change — it has been correct since #5288.
- `--surface prose` still refuses on exit `10` over a diff with no markdown at all (message now `--surface prose, but the diff changes no markdown file`).
- Unit coverage pins the mixed diff `["apps/web/src/App.tsx", "README.md"]` under every surface, including the leg that proves the leak scan actually runs (the markdown carrying a machine-local path reds on `18` rather than greening).
- `contract.md`: the surface-anchor section, the exit-code table's `10` row and the error message row, the mixed-diff remedy (a second run at `--surface prose`, which the anchor now admits), and a `#5301` grounding bullet. The "split the diff" remedy is gone — a lane cannot split a diff it has already written.
- `SKILL.md`: one sentence telling the lane to re-run `build check` at the surface that covers whatever the green's `unvalidated` list names.

## The design call

The issue left a real choice open: relax the `prose` mismatch, or keep the anchor strict on `prose` and add a fourth invocation / route per file class instead. I took the relax branch, for three reasons:

1. **It is the smaller, more honest model.** The anchor exists to refuse a surface the diff *provably contradicts*. A diff containing markdown does not contradict `--surface prose`; it just also contains something else. Refusing on the presence of another class was never the anchor's stated rule — it was `prose`'s alone.
2. **It introduces nothing.** No new exit code, no new surface, no second classifier, no per-file-class routing that would make the verb guess at surfaces (which the anchor exists to prevent). The disclosure that keeps a partial green honest already exists and already lists the right files.
3. **The alternatives cost more and buy less.** A fourth invocation adds a vocabulary item to a closed enum for a case the existing three already cover; routing per file class makes `build check` classify the diff itself, which `contract.md` explicitly considered and rejected.

Nothing gets weaker: a green under any surface still means "these validators ran and passed", and still names every changed file it did not read.

## Deviations

- **Class: narrowed a suggested fix-shape.** Said: the reporter suggested relaxing the `prose` mismatch to `markdown.length === 0`. Did: implemented the same behavior by deriving the rule from `COVERS` for all three surfaces instead of special-casing `prose`. Why: a per-surface branch is what produced the asymmetry; one derived rule cannot drift back into it. Disposition: no action needed — the behavior is exactly what the issue asked for.
- **Class: left a sibling defect for a follow-up.** Said: nothing. Did: left two defects in `check-verb.ts` untouched — the catch-all `PlatformError` skip that greens over an unread markdown file (`continue` on a read failure), and `COVERS` letting both `prose` and `plan` claim the `markdown` class while running disjoint validators. Why: both belong to #5304, which the issue says to sequence after this one rather than run in parallel. Disposition: #5304 owns them.
- **Class: touched a file outside the named acceptance criteria.** Said: the ACs name `check-verb.ts`, its unit test, and `contract.md`. Did: also added one sentence to `claude-plugins/fabrika/skills/build/SKILL.md`. Why: without it the new routing is inert — a lane has no instruction to run the second surface, so the markdown still goes unscanned in practice. Disposition: for the reviewer to judge; it is one sentence and cites #5301.
- **Class: deviated from a dispatch instruction.** Said: the dispatch asked for a `umut/`-prefixed branch. Did: the branch is `usirin/5301-...`, the prefix `build branch`'s successor derives from this checkout's `git config user.name`. Why: the skill mandates the derived prefix and every recent merged branch uses `usirin/`. Disposition: no action needed.
