### PR TITLE
fix(fabrika): build check's green tells the truth about what it read (#5304)

### DIFF
--- a/claude-plugins/fabrika/skills/build/SKILL.md
+++ b/claude-plugins/fabrika/skills/build/SKILL.md
@@ -117,8 +117,9 @@ Loop construct → check until green. `red` rows name the diagnostics; fix them 
 primary.
 
 A green names the files it did not read in `unvalidated`. When that list holds a file class another
-surface validates — markdown beside your code, most often — run `build check` again at that surface;
-one run per class present is what leaves nothing in the diff unread (#5301).
+surface validates, run `build check` again there: markdown beside your code — the common case — goes
+to `--surface prose`, or `--surface plan` if that markdown is an epic ledger, which runs the prose
+validators too. One run per class present is what leaves nothing in the diff unread (#5301, #5304).
 
 ## 5 — Push verified, open the PR through the guard
 

--- a/claude-plugins/fabrika/skills/build/contract.md
+++ b/claude-plugins/fabrika/skills/build/contract.md
@@ -997,10 +997,23 @@ beside a green is the honest reading of a mixed diff, and the same line is repea
 The list is a **disclosure, not a second validator run**: `--surface code` names the markdown it
 skipped and does not scan it. Running the markdown validators there would make the surface guess at
 file classes, which the anchor exists to refuse — so the remedy for a mixed diff that needs its
-markdown read is a **second run at `--surface prose`**, which the anchor admits (#5301). Each run is
-green for what it read and names what it did not; between them nothing in the diff goes unread.
-`unvalidated: []` therefore means every changed file was read by a validator that passed, and
-nothing weaker (#5288).
+markdown read is a **second run at a markdown surface**: `--surface prose`, or `--surface plan` when
+the markdown is an epic ledger, since `plan` runs the prose validators too. Either admits a mixed
+diff (#5301). Each run is green for what it read and names what it did not; between them nothing in
+the diff goes unread.
+
+`unvalidated: []` therefore means every changed file was read by **every** validator its class gets
+and all of them passed — nothing weaker (#5288), and true at the validator level rather than only at
+the file-open level (#5304). Two facts hold that promise up:
+
+- **A class one surface claims, it validates whole.** `prose` and `plan` both cover `markdown`, so
+  both run the leak scan and the link resolver; `plan` adds the `## Dependencies` grammar on top.
+  `plan` used to run the grammar *instead*, and greened a ledger with `unvalidated: []` while the
+  leak scan had never opened it.
+- **A file that cannot be read refuses.** Only a file the tree no longer holds — a deletion the diff
+  still counts — may be skipped, and only because absence is proven. Any other read fault (a
+  permission or IO error) is a read that did not execute, so it refuses on `11` naming the file. One
+  catch-all fused the two and skipped both.
 
 Per surface:
 
@@ -1011,9 +1024,11 @@ Per surface:
 - **prose** — changed markdown files: every relative link resolves against this tree; no
   machine-local path (the imported `leaks.ts` predicate); every fabrika-doc reference cited by id
   exists.
-- **plan** — the changed ledger's `## Dependencies` block parses under the canonical grammar
-  (defined in `build eligible`): issue refs (`#<int>`) resolve to real issues, ledger-local refs
-  (`C<int>`) resolve within the ledger, and no child is its own predecessor.
+- **plan** — everything `prose` runs, plus the changed ledger's `## Dependencies` block parsing
+  under the canonical grammar (defined in `build eligible`): issue refs (`#<int>`) resolve to real
+  issues, ledger-local refs (`C<int>`) resolve within the ledger, and no child is its own
+  predecessor. A ledger is markdown, so the markdown validators are its baseline and the grammar is
+  the specialization on top.
 
 The surface anchor: the verb diffs the branch against its base and refuses a surface whose own file
 class the diff does not contain (`--surface prose` over a diff with no markdown is `10`) — the
@@ -1044,7 +1059,7 @@ Preconditions: a linked worktree (`12`), the lane's branch checked out (`14`).
 |---|---|
 | `7` | the diff against the branch base is empty — nothing to validate, zero scope |
 | `10` | `--surface` is off-enum, or the diff contains none of the file classes that surface's validators open |
-| `11` | a validator could not be executed, or the lane's claim could not be read — the verdict is UNKNOWN, never green |
+| `11` | a validator could not be executed, a changed file could not be read for a reason other than absence, or the lane's claim could not be read — the verdict is UNKNOWN, never green |
 | `12` | proven: not in a linked worktree |
 | `14` | proven: the checked-out branch is not this lane's (lane-identity rule) |
 | `15` | proven: the lane's claim is held by another session |
@@ -1057,6 +1072,7 @@ Preconditions: a linked worktree (`12`), the lane's branch checked out (`14`).
 |---|---|---|
 | `build check: <runner> could not be executed: <reason> — the verdict is UNKNOWN, never green.` | 11 | refusal |
 | `build check: cannot read the claim markers on #<n>: <reason> — the lane is UNKNOWN.` | 11 | refusal |
+| `build check: cannot read <file> (<reason>) — it is in the diff and is not absent, so the verdict is UNKNOWN, never green.` | 11 | refusal |
 | `build check: #<n> is held by <token>, not this session.` | 15 | refusal |
 | `build check: --surface prose, but the diff changes no markdown file — the surface is provably wrong.` | 10 | refusal |
 | `build check: the diff against <base> is empty — nothing to validate (ADR 0092).` | 7 | refusal |
@@ -1090,6 +1106,10 @@ $ fabrika build check --surface code
 - #5301 — the disclosure was honest but there was still nowhere to send the markdown: `--surface
   prose` refused whenever one code file was present, so a mixed diff's prose was unscannable under
   every surface. The anchor now refuses an absent class rather than a present other one.
+- #5304 — the green's disclosure was true at the file-open level and false at the validator level: a
+  catch-all `PlatformError` skipped a file nothing could open, and `plan` claimed the whole `markdown`
+  class while running only the grammar. A read that did not execute now refuses on `11`, and a
+  surface that claims a class runs every validator that class gets.
 - v1's discipline was prose-only (`SKILL.md:895-935`, exact-CI-command mandate with no
   enforcement); here the command set is the verb's, not the agent's memory.
 - ADR 0092 — zero diff is a refusal, not a vacuous green.

--- a/packages/fabrika-cli/src/build/check-verb.ts
+++ b/packages/fabrika-cli/src/build/check-verb.ts
@@ -17,7 +17,8 @@
  *
  * **Green means "the validators ran and passed", never "I could not tell."** See {@link classifyDiff}
  * for the third file class that keeps that distinction representable (#5229), and
- * {@link notCoveredBy} for the per-surface coverage the green's `unvalidated` list reports (#5288).
+ * {@link notCoveredBy} for the per-surface coverage the green's `unvalidated` list reports (#5288),
+ * and {@link readMarkdown} for the file the verb could not open (#5304).
  */
 import {Effect, FileSystem} from "effect";
 import type {ChildProcessSpawner} from "effect/unstable/process";
@@ -84,12 +85,26 @@ export const classifyDiff = (files: ReadonlyArray<string>): DiffClasses => ({
 	unvalidatable: files.filter((f) => !CODE_RE.test(f) && !MARKDOWN_RE.test(f)),
 });
 
-/** The file classes each surface's validators actually open. `unvalidatable` is in no surface's. */
+/**
+ * The file classes each surface's validators actually open. `unvalidatable` is in no surface's.
+ *
+ * Two surfaces claiming one class is only sound while both run **every** validator that class gets.
+ * The markdown loop in {@link runCheck} is where that holds: it runs the leak scan and the link
+ * resolver over every markdown file whatever the surface, and adds {@link PLAN_GRAMMAR} on top.
+ * `plan` used to run the grammar *instead*, so a ledger greened with `unvalidated: []` while the
+ * leak scan had never opened it — a disclosure true at the file-open level and false at the
+ * validator level (#5304).
+ */
 const COVERS: Record<Surface, ReadonlyArray<keyof DiffClasses>> = {
 	code: ["code"],
 	prose: ["markdown"],
 	plan: ["markdown"],
 };
+
+/** Every markdown file gets these, under either markdown surface. */
+const MARKDOWN_SCAN = "markdown link + leak scan";
+/** `plan` runs this **on top of** {@link MARKDOWN_SCAN}; it is a specialization, not a substitute. */
+const PLAN_GRAMMAR = "## Dependencies grammar";
 
 /**
  * The changed files this surface's validators do not read — what a green must disclose.
@@ -214,6 +229,41 @@ const planDefects = (file: string, text: string): ReadonlyArray<string> => {
 	return defects;
 };
 
+/** A changed markdown file resolves three ways, and only the middle one is safe to skip. */
+type MarkdownRead =
+	| {readonly _tag: "Read"; readonly text: string}
+	| {readonly _tag: "Absent"}
+	| {readonly _tag: "Unreadable"; readonly reason: string};
+
+/**
+ * Read a changed markdown file, keeping "it is gone" apart from "I could not open it".
+ *
+ * Absence is the one fault a green may absorb: a file the diff lists and the tree no longer holds
+ * was deleted, and there is nothing left to validate. Every other fault is a read that did not
+ * execute, so it proves nothing and must refuse — the same 404-vs-5xx split `codes.ts` states for
+ * {@link ZERO_SCOPE} against {@link PRECONDITION_UNKNOWN}. One `catchTag("PlatformError")` fused
+ * them and skipped both, so a permission or IO fault dropped a file out of validation while
+ * `unvalidated` stayed empty (#5304).
+ *
+ * `reason._tag === "NotFound"` is the proof, not a guess: `@effect/platform-node-shared`'s
+ * `handleErrnoException` maps `ENOENT` to `NotFound` and `EACCES` to `PermissionDenied`, and
+ * effect's own `FileSystem.exists` narrows on this exact field.
+ */
+const readMarkdown = (
+	fs: FileSystem.FileSystem,
+	path: string,
+): Effect.Effect<MarkdownRead, never> =>
+	fs.readFileString(path).pipe(
+		Effect.map((text): MarkdownRead => ({_tag: "Read", text})),
+		Effect.catchTag("PlatformError", (error) =>
+			Effect.succeed<MarkdownRead>(
+				error.reason._tag === "NotFound"
+					? {_tag: "Absent"}
+					: {_tag: "Unreadable", reason: error.reason._tag},
+			),
+		),
+	);
+
 export const runCheck = (
 	options: CheckOptions,
 ): Effect.Effect<
@@ -320,18 +370,18 @@ export const runCheck = (
 		const defects: string[] = [];
 		for (const file of markdown) {
 			const path = `${lane.root}/${file}`;
-			const text = yield* fs.readFileString(path).pipe(
-				Effect.map((t) => ({ok: true, t}) as {ok: boolean; t: string}),
-				Effect.catchTag("PlatformError", () => Effect.succeed({ok: false, t: ""})),
-			);
-			if (!text.ok) continue; // a deleted file has nothing to validate; the diff still counted it.
-			if (surface !== "prose") {
-				defects.push(...planDefects(file, text.t));
-				continue;
+			const read = yield* readMarkdown(fs, path);
+			if (read._tag === "Absent") continue;
+			if (read._tag === "Unreadable") {
+				return refuse(
+					PRECONDITION_UNKNOWN,
+					`${VERB}: cannot read ${file} (${read.reason}) — it is in the diff and is not absent, so the verdict is UNKNOWN, never green.`,
+					noted,
+				);
 			}
-			defects.push(...leakDefects(file, text.t));
+			defects.push(...leakDefects(file, read.text));
 			const dir = path.slice(0, path.lastIndexOf("/"));
-			for (const target of linkTargets(text.t)) {
+			for (const target of linkTargets(read.text)) {
 				const absolute = normalizePath(
 					target.startsWith("/") ? `${lane.root}${target}` : `${dir}/${target}`,
 				);
@@ -340,6 +390,7 @@ export const runCheck = (
 					.pipe(Effect.catchTag("PlatformError", () => Effect.succeed(false)));
 				if (!there) defects.push(`${file} links to "${target}", which does not resolve`);
 			}
+			if (surface === "plan") defects.push(...planDefects(file, read.text));
 		}
 		if (defects.length > 0) {
 			return refuse(
@@ -353,7 +404,7 @@ export const runCheck = (
 				verdict: "green",
 				surface,
 				tree: lane.root,
-				ran: [surface === "prose" ? "markdown link + leak scan" : "## Dependencies grammar"],
+				ran: surface === "plan" ? [MARKDOWN_SCAN, PLAN_GRAMMAR] : [MARKDOWN_SCAN],
 				unvalidated,
 			}),
 			noted,

--- a/packages/fabrika-cli/src/build/check-verb.unit.test.ts
+++ b/packages/fabrika-cli/src/build/check-verb.unit.test.ts
@@ -49,11 +49,12 @@ const run = (
 	script: ReadonlyArray<readonly [RegExp, ExecResult]>,
 	overrides: Partial<typeof options> = {},
 	files: Record<string, string> = {},
+	unreadable: ReadonlyArray<string> = [],
 ) =>
 	Effect.runPromise(
 		Effect.provide(
 			runCheck({...options, ...overrides}),
-			Layer.merge(fakeShell(script).layer, fakeFs({files}).layer),
+			Layer.merge(fakeShell(script).layer, fakeFs({files, unreadable}).layer),
 		),
 	);
 
@@ -429,7 +430,85 @@ describe("a mixed code+markdown diff — every surface has a runnable answer", (
 		);
 		expect(out.code).toBe(0);
 		const verdict = JSON.parse(out.stdout);
-		expect(verdict.ran).toEqual(["## Dependencies grammar"]);
+		expect(verdict.ran).toEqual(["markdown link + leak scan", "## Dependencies grammar"]);
 		expect(verdict.unvalidated).toEqual(["apps/web/src/App.tsx"]);
+	});
+});
+
+// #5304, hole 1. `catchTag("PlatformError")` caught every platform fault and `continue` skipped the
+// file, so a permission or IO fault left `unvalidated` empty over a file nothing opened.
+describe("a changed markdown file the verb cannot open", () => {
+	const GUIDE = "/repo/trees/lane-a/docs/guide.md";
+
+	it("refuses on 11 under --surface prose, naming the file and the reason", async () => {
+		const out = await run([...LANE_OK, [DIFF, okOut("docs/guide.md\n")]], {surface: "prose"}, {}, [
+			GUIDE,
+		]);
+		expect(out.code).toBe(PRECONDITION_UNKNOWN);
+		expect(out.stdout).toBe("");
+		expect(out.stderr.at(-1)).toBe(
+			"build check: cannot read docs/guide.md (PermissionDenied) — it is in the diff and is not absent, so the verdict is UNKNOWN, never green.",
+		);
+	});
+
+	it("refuses on 11 under --surface plan too — the same read, the same polarity", async () => {
+		const out = await run([...LANE_OK, [DIFF, okOut("plans/epic.md\n")]], {surface: "plan"}, {}, [
+			"/repo/trees/lane-a/plans/epic.md",
+		]);
+		expect(out.code).toBe(PRECONDITION_UNKNOWN);
+		expect(out.stdout).toBe("");
+	});
+
+	it("still greens over a file the diff lists and the tree no longer holds", async () => {
+		const out = await run(
+			[...LANE_OK, [DIFF, okOut("docs/gone.md\ndocs/here.md\n")]],
+			{surface: "prose"},
+			{"/repo/trees/lane-a/docs/here.md": "nothing to resolve here\n"},
+		);
+		expect(out.code).toBe(0);
+		expect(JSON.parse(out.stdout).unvalidated).toEqual([]);
+	});
+});
+
+// #5304, hole 2. `prose` and `plan` both claim the `markdown` class; the claim is only true while
+// both run every validator that class gets, so `plan` runs the leak scan and the link resolver on
+// top of the grammar rather than instead of it.
+describe("--surface plan covers the markdown class it claims", () => {
+	it("reds a plan ledger carrying a machine-local path", async () => {
+		const out = await run(
+			[...LANE_OK, [DIFF, okOut("plans/epic.md\n")]],
+			{surface: "plan"},
+			{
+				"/repo/trees/lane-a/plans/epic.md":
+					"## Dependencies\n\n- phase 1: #12\n\nRun it from /Users/someone/phoenix\n",
+			},
+		);
+		expect(out.code).toBe(VALIDATION_RED);
+		expect(out.stderr.some((line) => line.includes("machine-local path"))).toBe(true);
+	});
+
+	it("reds a plan ledger whose relative link does not resolve", async () => {
+		const out = await run(
+			[...LANE_OK, [DIFF, okOut("plans/epic.md\n")]],
+			{surface: "plan"},
+			{
+				"/repo/trees/lane-a/plans/epic.md":
+					"## Dependencies\n\n- phase 1: #12\n\nsee [the brief](./missing.md)\n",
+			},
+		);
+		expect(out.code).toBe(VALIDATION_RED);
+		expect(out.stderr.some((line) => line.includes("does not resolve"))).toBe(true);
+	});
+
+	it("earns its empty unvalidated list — the green names both validators that ran", async () => {
+		const out = await run(
+			[...LANE_OK, [DIFF, okOut("plans/epic.md\n")]],
+			{surface: "plan"},
+			{"/repo/trees/lane-a/plans/epic.md": "## Dependencies\n\n- phase 1: #12\n"},
+		);
+		expect(out.code).toBe(0);
+		const verdict = JSON.parse(out.stdout);
+		expect(verdict.unvalidated).toEqual([]);
+		expect(verdict.ran).toEqual(["markdown link + leak scan", "## Dependencies grammar"]);
 	});
 });

--- a/packages/fabrika-cli/src/fakes.test-support.ts
+++ b/packages/fabrika-cli/src/fakes.test-support.ts
@@ -24,11 +24,28 @@ const notFound = (method: string, path: string) =>
 		}),
 	);
 
+const denied = (method: string, path: string) =>
+	Effect.fail(
+		PlatformError.systemError({
+			_tag: "PermissionDenied",
+			module: "FileSystem",
+			method,
+			pathOrDescriptor: path,
+		}),
+	);
+
 export interface FakeFsOptions {
 	/** Directory path → base names. An absent or `null` entry makes the directory unreadable. */
 	readonly dirs?: Readonly<Record<string, ReadonlyArray<string> | null>>;
-	/** File path → contents. An absent or `null` entry makes the file unreadable. */
+	/** File path → contents. An absent or `null` entry makes the file **absent** (`NotFound`). */
 	readonly files?: Readonly<Record<string, string | null>>;
+	/**
+	 * Paths whose read fails for a reason other than absence — `PermissionDenied`.
+	 *
+	 * Distinct from an absent file on purpose: a caller that folds the two together turns "I could
+	 * not open it" into "it was deleted", which is the fail-open direction (#5304).
+	 */
+	readonly unreadable?: ReadonlyArray<string>;
 	/** Paths whose writes fail. */
 	readonly unwritable?: ReadonlyArray<string>;
 	/** Paths whose existence check itself fails — distinct from a path that is absent. */
@@ -57,6 +74,7 @@ export const fakeFs = (options: FakeFsOptions): FakeFs => {
 					: Effect.succeed([...names]);
 			},
 			readFileString: (path: string) => {
+				if (options.unreadable?.includes(path) === true) return denied("readFileString", path);
 				const text = files[path];
 				return text === undefined || text === null
 					? notFound("readFileString", path)


### PR DESCRIPTION
`fabrika build check` prints `unvalidated: []` beside a green to say "nothing in this diff went unchecked". Two paths made that claim without earning it: a file whose read failed for any reason at all was silently skipped and never disclosed, and `--surface plan` claimed to cover markdown while running only the `## Dependencies` grammar — so a plan ledger greened with an empty list even though the machine-local-path leak scan had never opened it. Both are now closed: a read that could not execute refuses instead of greening, and a surface that claims a file class runs every validator that class gets.

Fixes #5304

## What changed

**Hole 1 — the catch-all read failure.** `readMarkdown` replaces the single
`catchTag("PlatformError")` that folded every read fault into a skip. Absence is the one fault a
green may absorb (a file the diff lists and the tree no longer holds was deleted, so there is
nothing left to validate), and it is now *proven* rather than assumed: `reason._tag === "NotFound"`.
Every other fault — a permission or IO error — is a read that did not execute, so it refuses on
`11` (`PRECONDITION_UNKNOWN`) naming the file and the reason.

The `NotFound` test is grounded in the dependency's source, not intuition:
`@effect/platform-node-shared`'s `handleErrnoException` maps `ENOENT` to `NotFound` and `EACCES` to
`PermissionDenied`, and effect's own `FileSystem.exists` narrows on this exact field.

**Hole 2 — two surfaces, one class, disjoint validators.** The leak scan and the relative-link
resolver now run over every changed markdown file under **either** markdown surface, and `plan`'s
`## Dependencies` grammar runs *on top of* them rather than instead. The markdown class has a
baseline every markdown file gets; `plan` is a specialization, not a substitute. `COVERS` is
therefore true as written and `unvalidated: []` is true at the validator level, not only at the
file-open level.

**Routing is untouched.** `COVERS` and `surfaceMismatch` are byte-identical, so #5301's rule — a
surface is refused when the diff holds none of the classes its validators open — still decides every
refusal. A mixed code+markdown diff still runs the prose validators, `--surface prose` still refuses
on `10` over a diff with no markdown, and `code`/`plan` refuse exactly where they did before. All
four of #5321's mixed-diff tests pass unchanged except one `ran` assertion (below).

**Docs.** `claude-plugins/fabrika/skills/build/contract.md` states what `unvalidated: []` promises
and the two facts that hold it up, updates the per-surface list, the `11` row and the error table,
and records #5304 in Grounding. `claude-plugins/fabrika/skills/build/SKILL.md`'s re-run sentence now
names the surface instead of saying "that surface" — the ambiguity #5321's reviewer flagged, which
this PR resolves by making `plan` a superset of `prose` over markdown.

## Verification

- `packages/fabrika-cli` — 2907 tests, all passing (`pnpm vitest run`).
- `pnpm typecheck` — 31 tasks, clean.
- `pnpm lint:worktree` — clean.
- `pipeline-cli leak-guard scan` over the five changed files — clean.

## Deviations

**Class: changed a test another PR pinned.** Said / #5321's mixed-diff test asserted
`verdict.ran === ["## Dependencies grammar"]` for `--surface plan`. Did / widened it to
`["markdown link + leak scan", "## Dependencies grammar"]`. Why / the fix is that `plan` now runs
the markdown validators, so the old value would be a false report of what ran — the assertion is
this issue's subject matter, not #5301's, whose acceptance criteria pin routing and the mixed-diff
coverage, neither of which moves. Its sibling assertion in the same test — `unvalidated`
`["apps/web/src/App.tsx"]` — is unchanged. Disposition / no action needed; the widened value is the
delivered behaviour.

**Class: picked one of two sanctioned fix directions.** Said / the issue left the direction open:
narrow `plan`'s coverage claim, or widen what `plan` runs. Did / widened what `plan` runs.
Why / narrowing would put a file `plan` did open and did grammar-check into the "NOT covered by this
verdict" list on every plan run, so `--surface plan` could never produce a clean green and the
disclosure would be noisy rather than useful; widening makes the existing claim true and gets plan
ledgers leak-scanned, which is a real safety gain. It also costs nothing on routing. Disposition /
no action needed.

**Class: behaviour change beyond the disclosure.** Said / this issue is about honesty, not routing.
Did / `--surface plan` can now red (exit `18`) on a machine-local path or a dead relative link in a
ledger, where it previously greened. Why / that is the widening above, and the red is a true one —
the same file reds under `--surface prose` today. Disposition / for the reviewer to judge; two tests
pin it.

**Class: touched a shared test helper.** Said / the issue names three files. Did / also added an
`unreadable` fault to `packages/fabrika-cli/src/fakes.test-support.ts`. Why / the fake filesystem
could only fail a read with `NotFound`, so the "unreadable but not deleted" case — the whole of hole
1 — was untestable without it. Disposition / no action needed; the option is additive and every
existing caller is unchanged.