### PR TITLE
docs(fabrika): render the plan-epic Dependencies block in the grammar its own parser reads (#5220)

### DIFF
--- a/claude-plugins/fabrika/skills/plan-epic/contract.md
+++ b/claude-plugins/fabrika/skills/plan-epic/contract.md
@@ -155,12 +155,9 @@ gate's reader is authoritative and this composer is held to it by the imported m
 
 ## Dependencies
 
-### Phase 1
-- #4301 — label schema bootstrap
-- #4302 — formats contract doc
-
-### Phase 2
-- #4303 — the queue view (requires: #4301)
+- phase 1: #4301, #4302
+- phase 2: #4303
+- #4303 requires: #4301
 ```
 
 **The plan region is located by the enrichment marker, never by position.** Detection is the
@@ -215,11 +212,19 @@ emitted **only** when the cycle-doc probe reads `present` — v1's documented sp
 the field entirely while its skill body required it, so an author following the template dropped
 it on every child and the tolerant read made "forgot" indistinguishable from "no cycle doc".
 
-**`## Dependencies` — the rendered block.** `### Phase <n>` headings in ascending order; one
-`- #<ref> — <label>` row per child, ascending within a phase; the separator is an **em dash**
-surrounded by single spaces; a `requires:` clause is parenthesized at end of line with
-comma-separated refs. The block ends with a trailing blank line so a later heading stays
-separated. The label text after the em dash is human-legible and not load-bearing.
+**`## Dependencies` — the rendered block.** Exactly the two line forms `readTopology` parses, and
+nothing else: one `- phase <n>: #<ref>[, #<ref>…]` row per phase, phases ascending and members
+ascending within a row, then one `- #<ref> requires: #<ref>[, #<ref>…]` row per child that declares
+a prerequisite, ascending by subject. There is no `###` heading inside the section, no label column
+and no parenthesized clause — `readTopology` breaks at the first heading of any level
+(`ANY_HEADING_RE`, `packages/fabrika-cli/src/build/dependencies.ts:47,84`), so a `### Phase <n>`
+line would end the scan on the line after `## Dependencies` and the block would read back as zero
+edges: a well-formed, plausible, always-wrong answer the gate then reads as an epic every one of
+whose children is orphaned. The block ends with a trailing blank line so a later heading stays
+separated. The illustrated block above is the round trip this grammar buys — pasted into
+`readTopology` it parses to the three edges it depicts (`phase 1: #4301, #4302`, `phase 2: #4303`,
+`#4303 requires: #4301`), never the empty set, which is what lets `ledger topology` stage instead of
+refusing on `24`.
 
 ## The body digest
 
@@ -597,6 +602,7 @@ splices.
 | `ledger draft: stdin held nothing — there is no plan to stage.` | 3 | refusal |
 | `ledger draft: the plan block is missing section(s): <list>.` | 4 | refusal |
 | `ledger draft: the plan block carries <k> "<heading>" sections — a plan with two of one section has no single meaning.` | 4 | refusal |
+| `ledger draft: the plan block's sections are out of order: "<current>" appears after "<previous>".` | 4 | refusal |
 | `ledger draft: the plan block does not open with "## Plan (plan-epic)".` | 4 | refusal |
 | `ledger draft: user stories are numbered <list> — a story list must run from 1 with no gaps or repeats.` | 4 | refusal |
 | `ledger draft: the plan declares zero user stories — an ordered list is what carries them, and a bullet or an "S<n>" label parses as none.` | 4 | refusal |
@@ -743,7 +749,7 @@ link, deliberately** — see step 5.
 | Code | Trigger |
 |---|---|
 | `3` | stdin was read and held nothing |
-| `4` | the composed body's fields or sections do not parse: a malformed `**Stories:**` value, an absent or malformed `### Acceptance criteria`, zero criteria, or a `type:feature` child whose `**Containment:**` is missing, unset or `none` while `cycleDoc` is `present` |
+| `4` | the composed body's fields or sections do not parse: a field line present more than once, a malformed `**Stories:**` value, an absent or malformed `### Acceptance criteria`, zero criteria, or a `type:feature` child whose `**Containment:**` is missing, unset or `none` while `cycleDoc` is `present` |
 | `5` | the composed body carries a machine-local path |
 | `6` | the composed body is a bare `@` path reference |
 | `7` | the epic is proven absent or closed |
@@ -761,6 +767,7 @@ link, deliberately** — see step 5.
 | Message (stderr) | Code | Kind |
 |---|---|---|
 | `ledger child: stdin held nothing — there is no child body to compose.` | 3 | refusal |
+| `ledger child: **<field>:** appears <k> times — a child field line has one value, and the gate refuses a duplicate.` | 4 | refusal |
 | `ledger child: **Stories:** value does not conform: "<v>" — bare integers or "none".` | 4 | refusal |
 | `ledger child: acceptance criteria read as <absent\|malformed> — a child with no checkable criteria is not buildable.` | 4 | refusal |
 | `ledger child: type:feature child needs **Containment:** flag or exempt — got "<v>", and the cycle doc is present.` | 4 | refusal |


### PR DESCRIPTION
Fixes #5220

## What was wrong

`claude-plugins/fabrika/skills/plan-epic/contract.md` illustrated — in **two** places — the `## Dependencies` block that `ledger topology` renders as `### Phase <n>` headings over `- #<ref> — <label>` rows with a parenthesized `requires:` clause. The parser the same contract names as that block's reader, `readTopology` in `packages/fabrika-cli/src/build/dependencies.ts`, cannot read that shape.

The parser's accepted grammar, quoted from source:

```ts
const HEADING_RE = /^##\s+Dependencies\s*$/;
const ANY_HEADING_RE = /^#{1,6}\s+/;
const PHASE_RE = /^-\s*phase\s+(\d+)\s*:\s*(.+)$/i;
const REQUIRES_RE = /^-\s*(\S+)\s+requires\s*:\s*(.+)$/i;
```

and the scan break, tested **before** either line form:

```ts
if (ANY_HEADING_RE.test(text)) break;
```

So a `### Phase 1` line ends the scan on the line immediately after `## Dependencies`.

## Which clause moved, and why that direction

The **illustration** moved; the round-trip clause and the no-second-grammar clause stayed. Three reasons, all grounded in shipped code rather than in which text reads nicer:

1. The parser is shipped and is the gate's own reader — `plan/load.ts` and `build eligible` both consume `readTopology`. Moving the round-trip clause instead would mean minting a second `## Dependencies` grammar, which the contract explicitly forbids one clause earlier.
2. The renderer that already implements this contract, `packages/fabrika-cli/src/ledger/topology-doc.ts` (`renderDependencies`), emits the parser's two line forms and proves the round trip through `readTopology` before staging. The illustration was the only surface still on the old shape.
3. Verified by running the real parser over both blocks:
   - old illustrated block → `{"_tag":"Parsed","edges":[]}` — a well-formed, plausible, always-wrong zero-edge answer
   - corrected block → three edges: `Phase 1 [#4301, #4302]`, `Phase 2 [#4303]`, `Requires #4303 → #4301`

## The diff

**Occurrence count: two.** Both sites named in the issue were the only two in the file (re-grepped after the edit — the remaining `phase` mentions are the `ledger topology` *stdin* declaration grammar, `#<ref> phase <n> [requires #<a>]`, which is a different, correct surface).

1. The illustration in "The ledger grammar this skill WRITES" — now the parser's two line forms.
2. The "`## Dependencies` — the rendered block" paragraph — now specifies those same two line forms, states the `ANY_HEADING_RE` break as the reason no `###` heading may appear inside the section, and records the round-trip fact (the illustrated block parses to three edges, never the empty set).

The *why* is stated once, in the rendered-block paragraph; the illustration is left bare rather than re-narrating it.

Also seats the two Errors rows the same document already owed, both quoted verbatim from the shipped messages:

- `ledger draft`'s out-of-order-section case — exit `4`'s trigger already claimed it (`plan-block.ts:94`).
- `ledger child`'s duplicated-field-line refusal (`child-body.ts:113`), plus the exit-`4` trigger row that omitted it.

## Acceptance criteria

- [x] The illustrated block renders in the two line forms `readTopology` parses — no `###` heading inside the section.
- [x] The rendered-block paragraph describes the same two line forms, with no `### Phase <n>` heading and no em-dash label row.
- [x] The illustrated block parses to the non-empty edge set it depicts — stated in the contract, and verified against the real parser (three edges, not `edges: []`).
- [x] The `ledger draft` Errors table carries the out-of-order-section row.
- [x] The `ledger child` Errors table carries the duplicated-field-line row.
- [x] No second `## Dependencies` grammar introduced — `packages/fabrika-cli/src/build/dependencies.ts` stays the single definition, and no code changed.

## Verification

- Docs-only diff; `pnpm lint:worktree` is a clean skip (no biome-handled files changed). No TypeScript changed, so no typecheck surface moved.
- The parser claims above were checked by executing `readTopology` on both block shapes, not read off the regexes by eye.

## Deviations

None. **(repair round 1)** Walked §DEV's seven classes against this PR's diff and none fired: the diff delivers every acceptance criterion in the shape #5220 asked for (no narrowing), contradicts no accepted ADR, leaves no seen defect unfixed, declines no triage or reviewer guidance, bypasses no guard or gate, changes no pre-existing test or fixture, and touches exactly the one file the issue names. The canonical Tier-M scan (`claude-plugins/kampus-pipeline/skills/shared/scripts/dev-tier-m.sh`) is clean at this head — 0 suppression/skip lines, 0 removed-assertion lines.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
