### PR TITLE
fix(pipeline): let iso_preflight answer under a `set -u` caller instead of aborting (#4591)

### DIFF
--- a/.patterns/skill-script-shell-shape.md
+++ b/.patterns/skill-script-shell-shape.md
@@ -79,6 +79,20 @@ them as history, not as a choice on offer:
 - **Why no options.** `set` in a sourced file runs in the *caller's* shell, so the options persist
   and change every subsequent command in that session — including commands the script's author
   never saw.
+- **A sourced file must default EVERY read, because it inherits options it did not choose.** Setting
+  no options is not the same as running without them: the caller's `set -u` is in force inside the
+  sourced body, so one undefaulted `$VAR` aborts the caller's shell *at the read* — before the
+  script's scope line, before any clause completes, before a refusal can name itself. The caller
+  then sees a reasonless non-zero, which is indistinguishable from the guard running and refusing,
+  and the state that fires it can be the ordinary one (`iso_preflight` read `$WORKTREE_ROOT` bare,
+  and that variable is unset on every local agent run, so its green branch was unreachable —
+  [#4591](https://github.com/kamp-us/phoenix/issues/4591)). Defaulting is not the fail-open it looks
+  like *provided the defaulted signal can only tighten the answer*: check that the variable appears
+  only in clauses that arm a refusal, and that the permissive branch rests on something else.
+- **Report an absent signal three ways, not two.** `${VAR:+set}` renders unset and exported-blank
+  identically, which erases the difference between "I checked and the answer is no" and "I could not
+  check". When a guard's conclusion turns on a signal, print `${VAR+d}${VAR:+v}`'s three cases so
+  the log says which one it saw.
 - **What ADR 0232 settled.** Sourcing a skill script at an agent's top-level command is banned
   (the harness's isolation verifier refuses `.` itself, by any path form), the sourced class
   converts to executed scripts, and *leave-state-in-the-caller's-shell* is retired as a design
@@ -219,6 +233,13 @@ grep -q "$needle" "${files[@]-}"
   [#4473](https://github.com/kamp-us/phoenix/pull/4473)).
 - `claude-plugins/kampus-pipeline/skills/validate-gate-path-drift.sh` — the `[ -f "$sh" ]`
   unmatched-glob idiom (rule 4).
+- `claude-plugins/kampus-pipeline/skills/shared/scripts/iso-preflight.sh` — the sourced-class
+  defaulting rule above. Pinned by
+  `claude-plugins/kampus-pipeline/skills/shared/scripts/iso-preflight-setu-proof.sh`, which stands
+  the guard up in a sandbox primary / linked-worktree / symlinked-primary matrix under a
+  `set -uo pipefail` sourcing caller across all three states of each signal, and asserts the guard
+  reached its answer rather than merely returning the expected status
+  ([#4591](https://github.com/kamp-us/phoenix/issues/4591)).
 - `claude-plugins/kampus-pipeline/lib/common.sh` — `kp_skill_shell_surfaces`, the
   surface resolver both cycle validators consume through `< <(…)` (rule 6). Pinned by
   `lib/common-test.sh`, which forces a partial `find` failure with an unreadable

--- a/claude-plugins/kampus-pipeline/skills/gh-issue-intake-formats.md
+++ b/claude-plugins/kampus-pipeline/skills/gh-issue-intake-formats.md
@@ -1765,6 +1765,22 @@ sibling (it *always* expects isolation and additionally must branch the session 
 refuses the standalone-on-primary case via its Non-isolated fallback); it is a deliberate,
 documented specialization of this same contract, not a fourth drifting copy.
 
+**Two facts about *how it answers*, which #4591 had to restore before either could be relied on.**
+The guard is sourced into callers that `set -u` (`review-code`/`review-trivial`'s
+`materialize-head.sh`) as well as callers that set no options (`ship-it`'s `step0-preflight.sh`), so
+**every read in it is defaulted** — an undefaulted one aborted the sourcing shell *at the read*,
+which is a reasonless non-zero from a guard that never ran and is indistinguishable from one that
+ran and refused. Defaulting cannot fail it open, because the two env signals only ever **arm** the
+refusal: the pass comes from `git-dir != common-dir`, which no env var can forge. And the scope line
+reports each signal **three ways** — a value, `empty(exported-blank)`, `UNSET(never-exported)` —
+because "I checked and this is not an isolated spawn" and "I could not check" are the same exit
+status but not the same claim. Re-derive both, plus the LOUD refusal and the standalone branch, over
+a sandbox primary/linked/symlinked matrix:
+
+```bash
+bash ./.claude/.pipeline/skills/shared/scripts/iso-preflight-setu-proof.sh
+```
+
 ---
 
 ## SHARED. The extracted shared scripts — executed by literal path, answers on stdout (epic #4435)

--- a/claude-plugins/kampus-pipeline/skills/shared/scripts/iso-preflight-setu-proof.sh
+++ b/claude-plugins/kampus-pipeline/skills/shared/scripts/iso-preflight-setu-proof.sh
@@ -1,0 +1,150 @@
+#!/usr/bin/env bash
+# Proof for #4591: `iso_preflight` ANSWERS under a `set -u` sourcing caller, on all three states of
+# each isolation signal, and still refuses everything it refused before.
+#
+# usage: bash ./claude-plugins/kampus-pipeline/skills/shared/scripts/iso-preflight-setu-proof.sh
+#        exit 0 ⇒ every case matched; exit 1 ⇒ at least one FAIL line above.
+#
+# It re-derives the claim instead of asserting it, the way `write-code/scripts/verify-fail-closed.sh`
+# does: a throwaway sandbox repo supplies a real PRIMARY checkout and a real LINKED worktree, and each
+# case runs the guard as `review-code/scripts/materialize-head.sh` runs it — sourced into a
+# `set -uo pipefail` shell — across `CLAUDE_CODE_AGENT` × `WORKTREE_ROOT` ∈ {unset, blank, value}.
+#
+# The two properties under test, and why each needs its own case:
+#   1. NO case may abort. An unbound-variable abort produced a reasonless non-zero with empty output,
+#      which is indistinguishable from a guard that ran and refused — so every case asserts that the
+#      scope line was printed, not merely that the status was expected.
+#   2. Defaulting must not fail the guard OPEN. The refusal cases pin that the LOUD ROUTED BLOCKER
+#      still fires on the primary checkout whenever isolation was expected, and the one green case is
+#      green on git plumbing (`git-dir != common-dir`), never on an env read.
+#
+# No EXIT trap (`.patterns/skill-script-shell-shape.md`; #4476, class #4479) — the sandbox is removed
+# on the single exit path at the bottom, which every case reaches because nothing here uses `-e`.
+# shellcheck disable=SC1007  # the house `CDPATH= cd --` idiom on the GUARD resolution below
+set -uo pipefail
+
+FAILS=0
+GUARD="$(CDPATH= cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)/iso-preflight.sh"
+[ -f "$GUARD" ] || { echo "FAIL: guard not found at $GUARD — refusing to prove nothing (ADR 0092)"; exit 1; }
+
+SANDBOX="$(mktemp -d)"
+if [ -z "$SANDBOX" ] || [ ! -d "$SANDBOX" ]; then
+	echo "FAIL: mktemp -d produced no sandbox — refusing to run against nothing (ADR 0092)"
+	exit 1
+fi
+
+# Physically-resolved, because the second half of this proof is precisely about logical-vs-physical
+# path resolution: on darwin `mktemp -d` hands back a /var path that is a symlink to /private/var, so
+# an unresolved sandbox would exercise only the symlinked case and never the plain one.
+SANDBOX="$(cd "$SANDBOX" && pwd -P)"
+PRIMARY="$SANDBOX/primary"
+LINKED="$SANDBOX/linked"
+git init -q "$PRIMARY" >/dev/null 2>&1
+git -C "$PRIMARY" -c user.email=proof@example.invalid -c user.name=iso-preflight-proof \
+	commit -q --allow-empty -m "sandbox base" >/dev/null 2>&1
+git -C "$PRIMARY" worktree add -q "$LINKED" -b proof-lane >/dev/null 2>&1
+ln -s "$PRIMARY" "$SANDBOX/via-link"
+if [ ! -d "$LINKED" ] || [ ! -L "$SANDBOX/via-link" ]; then
+	echo "FAIL: could not stand up a linked worktree + a symlinked path in the sandbox — the matrix would be half-blind"
+	rm -rf "$SANDBOX"
+	exit 1
+fi
+
+# run_case <label> <tree> <mode:sourced|executed> <env-state:unset|blank|reviewer> <want-status> <needle>
+# The needle is matched over stdout+stderr together: which stream a line lands on is the io-contract's
+# business (pinned elsewhere), while what this proof pins is that the guard SPOKE at all.
+run_case() {
+	local label="$1" tree="$2" mode="$3" state="$4" want="$5" needle="$6"
+	local envargs out err got
+	case "$state" in
+		unset) envargs=(-u CLAUDE_CODE_AGENT -u WORKTREE_ROOT) ;;
+		blank) envargs=(CLAUDE_CODE_AGENT= WORKTREE_ROOT=) ;;
+		# `-u` first: env stops reading options at the first NAME=VALUE, so a trailing `-u X` would be
+		# taken as the command to run.
+		reviewer) envargs=(-u WORKTREE_ROOT CLAUDE_CODE_AGENT=crew-reviewer) ;;
+		*) echo "FAIL [$label]: unknown env state '$state'"; FAILS=$((FAILS + 1)); return 0 ;;
+	esac
+	if [ "${#envargs[@]}" -eq 0 ]; then
+		echo "FAIL [$label]: empty env argument list — a bash 3.2 empty-array expansion would pass \`\` as a name"
+		FAILS=$((FAILS + 1))
+		return 0
+	fi
+	out="$SANDBOX/out.$$"
+	err="$SANDBOX/err.$$"
+	if [ "$mode" = sourced ]; then
+		# EXACTLY the materialize-head.sh shape: the caller owns `set -uo pipefail`, the guard is
+		# sourced into it, and the call is `iso_preflight <surface>`.
+		(cd "$tree" && env "${envargs[@]-}" bash -u -o pipefail \
+			-c '. "$1"; iso_preflight proof-surface' _ "$GUARD") >"$out" 2>"$err"
+	else
+		(cd "$tree" && env "${envargs[@]-}" bash "$GUARD" proof-surface) >"$out" 2>"$err"
+	fi
+	got=$?
+	if [ "$got" != "$want" ]; then
+		echo "FAIL [$label]: exit $got, wanted $want"
+		FAILS=$((FAILS + 1))
+	fi
+	# Property 1 — the guard SPOKE. An abort printed only bash's own `unbound variable` line, so an
+	# answer is proven by the scope line being present and that line being absent.
+	if ! grep -q 'proof-surface iso_preflight:' "$out" "$err"; then
+		echo "FAIL [$label]: no scope line — the guard did not reach its answer"
+		FAILS=$((FAILS + 1))
+	fi
+	if grep -q 'unbound variable' "$err"; then
+		echo "FAIL [$label]: aborted on an unbound variable — the #4591 defect is back"
+		FAILS=$((FAILS + 1))
+	fi
+	if ! grep -q "$needle" "$out" "$err"; then
+		echo "FAIL [$label]: expected text not found: $needle"
+		FAILS=$((FAILS + 1))
+	fi
+	rm -f "$out" "$err"
+}
+
+for MODE in sourced executed; do
+	# The green that was unreachable before: a real linked worktree with WORKTREE_ROOT unset. It is
+	# green on `git-dir != common-dir` alone, which is why the same case is green in all three env
+	# states below rather than only when the env cooperates.
+	run_case "$MODE/linked/unset" "$LINKED" "$MODE" unset 0 'CONFIRMED: LINKED worktree'
+	run_case "$MODE/linked/blank" "$LINKED" "$MODE" blank 0 'CONFIRMED: LINKED worktree'
+	run_case "$MODE/linked/reviewer" "$LINKED" "$MODE" reviewer 0 'CONFIRMED: LINKED worktree'
+
+	# The refusal is intact: isolation expected (reviewer agent-type) on the PRIMARY checkout still
+	# fails closed LOUD — and now prints its reason, which was the whole complaint.
+	run_case "$MODE/primary/reviewer" "$PRIMARY" "$MODE" reviewer 1 'ROUTED BLOCKER'
+
+	# ADR 0172's standalone branch, unchanged in policy and now reachable. Both env states proceed,
+	# and both name the absence they concluded from rather than claiming a check they did not make.
+	run_case "$MODE/primary/unset" "$PRIMARY" "$MODE" unset 0 'no isolation-expected evidence'
+	run_case "$MODE/primary/blank" "$PRIMARY" "$MODE" blank 0 'no isolation-expected evidence'
+
+	# The SAME primary checkout reached through a symlink. Both refusals below fired only after the
+	# two path sides were resolved the same way — before that, the symlinked primary compared unequal
+	# and the guard passed it as a linked worktree, which is a fail-OPEN in the exact state the guard
+	# exists to catch.
+	run_case "$MODE/symlinked-primary/reviewer" "$SANDBOX/via-link" "$MODE" reviewer 1 'ROUTED BLOCKER'
+	run_case "$MODE/symlinked-primary/unset" "$SANDBOX/via-link" "$MODE" unset 0 'no isolation-expected evidence'
+done
+
+# "I could not check" is distinguishable from "I checked": unset and exported-blank must not render
+# the same. The old scope line printed `${WORKTREE_ROOT:+set}` for both, which is how the first state
+# lost its voice.
+UNSET_LINE="$( (cd "$PRIMARY" && env -u CLAUDE_CODE_AGENT -u WORKTREE_ROOT bash "$GUARD" proof-surface) 2>/dev/null | head -1)"
+BLANK_LINE="$( (cd "$PRIMARY" && env CLAUDE_CODE_AGENT= WORKTREE_ROOT= bash "$GUARD" proof-surface) 2>/dev/null | head -1)"
+case "$UNSET_LINE" in
+	*'worktree-root=UNSET(never-exported)'*) ;;
+	*) echo "FAIL [observability]: an unset WORKTREE_ROOT did not report itself as UNSET"; FAILS=$((FAILS + 1)) ;;
+esac
+case "$BLANK_LINE" in
+	*'worktree-root=empty(exported-blank)'*) ;;
+	*) echo "FAIL [observability]: an exported-blank WORKTREE_ROOT did not report itself as blank"; FAILS=$((FAILS + 1)) ;;
+esac
+
+git -C "$PRIMARY" worktree remove --force "$LINKED" >/dev/null 2>&1
+rm -rf "$SANDBOX"
+
+if [ "$FAILS" -ne 0 ]; then
+	echo "iso-preflight-setu-proof: $FAILS assertion(s) FAILED"
+	exit 1
+fi
+echo "iso-preflight-setu-proof: OK — 16 sourced/executed cases + 2 observability assertions passed"

--- a/claude-plugins/kampus-pipeline/skills/shared/scripts/iso-preflight.sh
+++ b/claude-plugins/kampus-pipeline/skills/shared/scripts/iso-preflight.sh
@@ -4,18 +4,21 @@
 # remedy — stays in that contract's §RO-iso prose (ADR 0172, #2443/#2446/#3406); the per-clause
 # comments travelled with the shell.
 #
-# MECHANICAL MOVE. Every moved line is byte-identical to the fence it came from and sits at column 0,
-# so a reviewer can diff it against the deleted block directly. Verbification is phase 2 (#1929,
-# ADR 0228). Do not "improve" it here.
+# MECHANICAL MOVE, since amended once. Every line arrived byte-identical to the fence it came from;
+# #4591 then changed the reads (not the policy) so the guard can answer under a `set -u` caller —
+# see the function header. Verbification is still phase 2 (#1929, ADR 0228); nothing else here is
+# an invitation to "improve" it.
 #
 # DUAL-MODE (ADR 0232) — the why is `.patterns/skill-script-shell-shape.md` § The dual-mode shape.
 #   EXECUTED:  bash ./claude-plugins/kampus-pipeline/skills/shared/scripts/iso-preflight.sh <surface>
 #              stdout ⇒ the function's own scope line, then `ISO_PREFLIGHT=OK`; on a refusal the
 #              LOUD ROUTED BLOCKER lines go to stderr, stdout carries no `ISO_PREFLIGHT=OK`, and the
 #              exit status is 1. This guard's whole contract is that status — read it first.
-#   SOURCED:   the sanctioned in-script edge — `review-code/scripts/materialize-head.sh` and
-#              `ship-it/scripts/step0-preflight.sh` source this file for `iso_preflight`. Unchanged,
-#              including which stream each of its lines lands on.
+#   SOURCED:   the sanctioned in-script edge — `review-code`/`review-trivial`'s `materialize-head.sh`
+#              and `ship-it/scripts/step0-preflight.sh` source this file for `iso_preflight`. The
+#              stream split is unchanged: the scope line is the only stdout, every refusal and every
+#              narration line is stderr. What #4591 changed is that a `set -u` sourcing caller now
+#              gets the guard's ANSWER on all three env states instead of an unbound-variable abort.
 # No EXIT trap — under bash 3.2 a cleanup trap's last command becomes the script's status,
 # laundering a `set -u` abort into exit 0 (#4476, class #4479), which would silently disarm it.
 
@@ -25,13 +28,43 @@ if [ "${BASH_SOURCE[0]}" = "$0" ]; then set -uo pipefail; fi   # executed mode o
 # gate runs BEFORE its first head fetch / `git worktree add` (§RO). Reviewer/shipper sibling of
 # write-code's Step-4 wt_preflight (ADR 0172) — the SAME git-dir==common-dir detection, the SAME
 # isolation-expected fork. Read-only (git rev-parse only); safe to re-run.
+#
+# EVERY read below is defaulted — the sourced-class rule in `.patterns/skill-script-shell-shape.md`,
+# and the whole of #4591's fix. The check that rule asks you to make, made here: defaulting cannot
+# fail this guard OPEN, because the two env signals appear ONLY in clauses that RAISE `iso`, so they
+# can arm the refusal and never grant a pass — the pass comes from the env-independent
+# `git-dir != common-dir` plumbing (#3458), which no env read can forge.
 iso_preflight() {
-  local surface="$1" gitdir common iso=0
+  local surface="${1-}" gitdir common iso=0 agent wtroot agent_obs wtroot_obs
+  [ -n "$surface" ] || {
+    echo "iso_preflight FAILED (fail-closed): called with no <surface> argument — refusing to run an unnamed preflight." >&2; return 1; }
   gitdir="$(git rev-parse --absolute-git-dir 2>/dev/null)" || {
     echo "$surface iso_preflight FAILED (fail-closed): not inside a git repository — refusing to materialize a PR head." >&2; return 1; }
   common="$(git rev-parse --git-common-dir 2>/dev/null)"
   case "$common" in /*) ;; *) common="$(pwd)/$common" ;; esac   # normalize a relative `.git` (older git)
-  common="$(cd "$common" && pwd)"
+  # Resolve BOTH sides PHYSICALLY before comparing them, and refuse if either won't resolve. Measured
+  # on darwin: `--absolute-git-dir` answers physically (/var -> /private/var) while `cd … && pwd`
+  # answers logically, so a checkout reached through a symlinked path made the two differ ON THE
+  # PRIMARY TREE — the guard then read the primary as a linked worktree and passed, with neither the
+  # LOUD refusal nor the standalone note firing. That is a fail-OPEN, and an unresolvable `cd` was a
+  # second one (it left `common` empty, which never equals `gitdir`). `git-dir == common-dir` only
+  # means what §RO-iso says it means when both sides are the same kind of path (#4591).
+  gitdir="$(cd "$gitdir" 2>/dev/null && pwd -P)" || {
+    echo "$surface iso_preflight FAILED (fail-closed): git-dir does not resolve to a readable directory — refusing to compare an unresolvable path." >&2; return 1; }
+  common="$(cd "$common" 2>/dev/null && pwd -P)" || {
+    echo "$surface iso_preflight FAILED (fail-closed): git-common-dir does not resolve to a readable directory — refusing to compare an unresolvable path." >&2; return 1; }
+  # Three-way observability, resolved before any clause reads the values (the report-an-absent-signal
+  # -three-ways rule in `.patterns/skill-script-shell-shape.md`). Here that distinction decides
+  # whether the standalone branch below is a conclusion or a guess, which is why it is computed even
+  # though no clause branches on it.
+  agent="${CLAUDE_CODE_AGENT-}"
+  wtroot="${WORKTREE_ROOT-}"
+  case "${CLAUDE_CODE_AGENT+d}${agent:+v}" in
+    dv) agent_obs="$agent" ;;  d) agent_obs='empty(exported-blank)' ;;  *) agent_obs='UNSET(never-exported)' ;;
+  esac
+  case "${WORKTREE_ROOT+d}${wtroot:+v}" in
+    dv) wtroot_obs='set' ;;    d) wtroot_obs='empty(exported-blank)' ;; *) wtroot_obs='UNSET(never-exported)' ;;
+  esac
   # Isolation was EXPECTED when the run is under an isolation-asserting pipeline agent-type —
   # coder/reviewer/shipper all spawn isolation:worktree (agents/{coder,reviewer,shipper}.md) — read
   # from the harness-set $CLAUDE_CODE_AGENT (stable across an agent's Bash calls, unlike a shell
@@ -47,33 +80,34 @@ iso_preflight() {
   # the PRIMARY checkout (gitdir == common) is a broken/absent worktree whatever its inherited name,
   # and this clause arms regardless of the string. Do NOT hard-code an agent-type name to patch a
   # rename — the corroboration removes the coupling rather than relocating it (#3406, #2462).
-  case "$CLAUDE_CODE_AGENT" in *coder*|*reviewer*|*shipper*) iso=1 ;; esac
-  [ -n "$WORKTREE_ROOT" ] && iso=1
-  [ -n "$CLAUDE_CODE_AGENT" ] && [ "$gitdir" = "$common" ] && iso=1
-  echo "$surface iso_preflight: git-dir=$gitdir common-dir=$common cwd=$(pwd) isolation-expected=$iso (agent=${CLAUDE_CODE_AGENT:-unset} worktree-root=${WORKTREE_ROOT:+set})"
+  case "$agent" in *coder*|*reviewer*|*shipper*) iso=1 ;; esac
+  [ -n "$wtroot" ] && iso=1
+  [ -n "$agent" ] && [ "$gitdir" = "$common" ] && iso=1
+  echo "$surface iso_preflight: git-dir=$gitdir common-dir=$common cwd=$(pwd) isolation-expected=$iso (agent=$agent_obs worktree-root=$wtroot_obs)"
   if [ "$gitdir" = "$common" ]; then
     if [ "$iso" = 1 ]; then
-      echo "$surface iso_preflight FAILED (fail-closed, LOUD): worktree isolation was EXPECTED (agent=${CLAUDE_CODE_AGENT:-?}, worktree-root=${WORKTREE_ROOT:+set}) but this run is on the PRIMARY checkout (git-dir == common-dir) and \$WORKTREE_ROOT is unset." >&2
+      echo "$surface iso_preflight FAILED (fail-closed, LOUD): worktree isolation was EXPECTED (agent=$agent_obs, worktree-root=$wtroot_obs) but this run is on the PRIMARY checkout (git-dir == common-dir)." >&2
       echo "  Refusing to fetch / \`git worktree add\` the PR head here — the #2440 harness no-op left this $surface spawn in the shared primary checkout, and a head-materialization run there is the #2452/#2453 primary-checkout-detach surface. The \$WORKTREE_ROOT-keyed repo-side worktree-guard is disarmed by the same no-op, so THIS preflight is the only surviving layer." >&2
       echo "  Do NOT self-provision a worktree to route around it — that hides the harness failure and leaves the primary-corruption defense collapsed to one, invisibly (#2270)." >&2
-      echo "  ROUTED BLOCKER — surface UP to the operator/EM: 'harness worktree provisioning no-op'd for a $surface spawn (isolation expected, \$WORKTREE_ROOT unset); the out-of-repo harness half (#2440) needs attention. Do NOT blindly retry the same spawn.'" >&2
+      echo "  ROUTED BLOCKER — surface UP to the operator/EM: 'harness worktree provisioning no-op'd for a $surface spawn (isolation expected, worktree-root=$wtroot_obs); the out-of-repo harness half (#2440) needs attention. Do NOT blindly retry the same spawn.'" >&2
       return 1
     fi
     # isolation NOT expected ⇒ a genuine standalone run on the owner's primary checkout. This gate
     # never mutates the launched tree (§RO): it materializes the head ONLY into a throwaway worktree
     # / per-run ref, so operating from the primary checkout is safe here — proceed, no LOUD stop.
-    echo "$surface iso_preflight: standalone run on the primary checkout — proceeding read-only via the §RO throwaway-worktree / per-run-ref materialization (the launched tree is never mutated)." >&2
+    echo "$surface iso_preflight: no isolation-expected evidence (agent=$agent_obs worktree-root=$wtroot_obs) ⇒ read as a standalone run on the owner's primary checkout — proceeding read-only via the §RO throwaway-worktree / per-run-ref materialization (the launched tree is never mutated)." >&2
+    echo "  This is the ONE branch that concludes from an ABSENCE, so it names the absence rather than reporting a check it did not make: an isolation-asserting spawn whose env never reached this shell looks identical here. It stays a proceed because the branch is read-only by construction (ADR 0172), and the two env states are printed above so the difference is recoverable from the log." >&2
+  else
+    echo "$surface iso_preflight CONFIRMED: LINKED worktree (git-dir != common-dir) — isolation established from git plumbing ALONE, independent of \$CLAUDE_CODE_AGENT ($agent_obs) and \$WORKTREE_ROOT ($wtroot_obs). Neither env signal can manufacture this pass; they only ever ARM the refusal above, which is why defaulting their reads cannot fail this guard open (#4591)." >&2
   fi
+  return 0
 }
 
 if [ "${BASH_SOURCE[0]}" = "$0" ]; then
-  # The function reads $CLAUDE_CODE_AGENT and $WORKTREE_ROOT UNDEFAULTED, so under this mode's
-  # `set -u` an unset one aborts before the guard can answer at all. Bind each to its own current
-  # value — empty when unset — so the executed form evaluates exactly the branches a no-options
-  # sourced caller gets. The body stays untouched: the undefaulted reads under a sourced `set -u`
-  # caller are a separate pre-existing defect, filed rather than fixed from here.
-  CLAUDE_CODE_AGENT="${CLAUDE_CODE_AGENT-}"
-  WORKTREE_ROOT="${WORKTREE_ROOT-}"
-  iso_preflight "${1:?iso-preflight.sh: no <surface> argument — refusing to run an unnamed preflight}" || exit 1
+  # No pre-binding of $CLAUDE_CODE_AGENT / $WORKTREE_ROOT here any more. The function defaults every
+  # read itself (#4591), so both modes evaluate the same branches — and the pre-bind is now actively
+  # harmful: `VAR="${VAR-}"` DECLARES the variable, turning "never exported" into "exported blank"
+  # and erasing exactly the distinction the scope line was taught to report.
+  iso_preflight "${1-}" || exit 1
   echo "ISO_PREFLIGHT=OK"
 fi


### PR DESCRIPTION
Fixes #4591

`iso_preflight` (`claude-plugins/kampus-pipeline/skills/shared/scripts/iso-preflight.sh`, ADR 0172) is sourced into callers that `set -u` (`review-code` and `review-trivial`'s `materialize-head.sh`) and into one that sets no options (`ship-it`'s `step0-preflight.sh`). It read `$CLAUDE_CODE_AGENT` and `$WORKTREE_ROOT` **undefaulted**, so under the first kind the sourcing shell aborted at the read — before the scope line, before any isolation clause completed, before any refusal could name itself. The caller got a reasonless non-zero from a guard that never ran, and because `$WORKTREE_ROOT` is unset on every local agent run, a correctly isolated reviewer could never pass either.

## Why this is not "default the variables and move on"

The obvious fix is the dangerous one: a guard that returns a cheerful `0` because a variable defaulted to empty certifies isolation it never checked. So the defaults are only safe here because of a structural property, which is now stated at the site and re-derived by a committed proof:

- **The two env signals appear only in clauses that RAISE `iso`.** They arm the refusal; no clause reads them to grant a pass. The pass comes from `git-dir != common-dir` — git plumbing, which no env read can forge (the #3458 principle).
- **So an unset variable cannot produce a green.** What it produces now is the guard's own **reasoned answer**: on the primary checkout with isolation expected, the full LOUD ROUTED BLOCKER with its reason and exit 1 — the #2440 behaviour that was previously unreachable from a `set -u` caller because the abort happened first.
- **The success path asserts itself out loud** rather than falling through silently, naming the evidence it used and the two env states it did *not* use.

## "I could not check" now has a voice

Each signal is reported **three ways** — a value, `empty(exported-blank)`, `UNSET(never-exported)`. The old scope line printed `${VAR:+set}`, which renders unset and exported-blank identically, so *"I checked and this is not an isolated spawn"* and *"I could not check"* looked the same in the log.

That distinction lands on exactly one branch: standalone-on-the-primary-checkout. ADR 0172 sanctions that proceed (the branch is read-only by construction, and a human `/review-code` depends on it), so its **policy is unchanged** — but it is the one conclusion drawn from an *absence*, so it now names the absence instead of reporting a check it never made.

The executed-mode entry's `CLAUDE_CODE_AGENT="${CLAUDE_CODE_AGENT-}"` pre-binding is removed: the function defaults its own reads now, and the pre-bind actively *declared* the variable, converting "never exported" into "exported blank" and erasing the distinction the scope line exists to report.

## A second fail-open in the same function — flagged for scope

Found first-party while building the proof, and fixed here because the proof could not otherwise reach the primary-checkout cases at all (it would have had to route around a live bug, which is the silent-absorption failure this repo hates):

`git rev-parse --absolute-git-dir` answers **physically** — measured on darwin, it resolves `/var` to `/private/var` — while `cd "$common" && pwd` answers **logically**. A checkout reached through a symlinked path therefore compared *unequal* **on the primary tree**, and the guard read the primary as a linked worktree and **passed** it: neither the LOUD refusal nor the standalone note fired. An unresolvable `cd` was a second instance (it left `common` empty, which never equals `gitdir`, so it also passed). Both sides now resolve with `pwd -P`, and an unresolvable side refuses.

This is a different defect class from the undefaulted reads. Calling it out explicitly so the reviewer can rule on whether it belongs in this PR rather than discovering it in the diff.

## Accounting: every other undefaulted read in the script and its siblings

- **`iso-preflight.sh` — 4 occurrences, all fixed.** `$CLAUDE_CODE_AGENT` (2 sites: the agent-type `case`, the non-empty corroboration clause), `$WORKTREE_ROOT` (1 site), and `local surface="$1"` — the positional is the same class (an unnamed call aborted the caller instead of refusing), and is now a reasoned refusal. The already-defaulted `${VAR:-…}` / `${VAR:+…}` forms in the scope and refusal lines were never abort sites.
- **The other 18 scripts under `skills/shared/scripts/` — 0 occurrences.** Scanned every uppercase variable read that is not assigned in its own file. The apparent hits are all either comment prose, function-local values, or a **caller-contract** variable already guarded fail-closed with the correct idiom (`cp-guard-adr.sh`'s `[ -z "${CP_FILES+set}" ]` and `: "${CP_FILES?…}"`). No sibling reads an env var bare.

## Verification

`bash ./.claude/.pipeline/skills/shared/scripts/iso-preflight-setu-proof.sh` — a committed, reviewer-runnable proof that stands the guard up in a sandbox **primary / linked-worktree / symlinked-primary** matrix, **sourced** (the exact `materialize-head.sh` shape) and **executed**, across `{unset, exported-blank, value}` for each signal. 16 cases + 2 observability assertions. Every case asserts the guard **reached its answer** (scope line present, no `unbound variable`), not merely that the status matched — because an abort and a refusal are the same status and that is the whole complaint.

Three-way behaviour observed from this worktree, old (origin/main) vs new, sourced into `set -uo pipefail`:

| state | old | new |
|---|---|---|
| both unset | `line 50: CLAUDE_CODE_AGENT: unbound variable`, **exit 127**, no other output | scope line + `CONFIRMED: LINKED worktree`, **exit 0** |
| `CLAUDE_CODE_AGENT=crew-reviewer`, `WORKTREE_ROOT` set | scope line, exit 0 | scope line + `CONFIRMED`, exit 0 (unchanged) |
| both exported-blank | scope line reading `agent=unset worktree-root=`, exit 0 | scope line reading `agent=empty(exported-blank) worktree-root=empty(exported-blank)`, exit 0 |

Refusal reachability (sandbox primary checkout, `set -u` caller, `CLAUDE_CODE_AGENT=crew-reviewer`, `WORKTREE_ROOT` unset): **exit 1 with the full `ROUTED BLOCKER` text** — previously exit 127 with nothing.

No-options caller equivalence (the `ship-it` shape), old vs new across all three states: `0 / 0 / 0` both sides.

Also green: `pnpm typecheck` (31/31), `pnpm lint:worktree` (no biome-handled files), `shellcheck -S warning` on both scripts, `pipeline-cli trap-status-guard check` over the full 509-file corpus, `pipeline-cli gh-phoenix lint-skills` over the full corpus.

## Docs

- `.patterns/skill-script-shell-shape.md` — the sourced class documented that these files set no options, but not that they must survive a caller that does. Two rules added: default every read in a sourced file (with the check that keeps defaulting from being a fail-open), and report an absent signal three ways.
- `claude-plugins/kampus-pipeline/skills/gh-issue-intake-formats.md` §RO-iso — the contract now states both properties and points at the proof.

## Scope notes

- **Control plane.** The diff touches `claude-plugins/kampus-pipeline/skills/**`, so this needs a control-plane approval at head before it can be enqueued (ADR 0135). Expected; it banks rather than auto-ships.
- **Milestone.** This is milestone 37 under an M44 lock. The founder carved it out at 2026-08-10T08:41:30Z on #4591, narrowly: granted because this p0 blocks M44's own gates, not as a general p0 exemption.
