### PR TITLE
fix(fabrika): delete the browser-provisioning CI skip and cache the browser instead (#5169)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -460,7 +460,7 @@ jobs:
       # `@kampus/fabrika-cli`'s `postinstall` provisions chromium so no operator or agent ever
       # hand-runs a browser install (#5061), and pnpm runs a workspace member's `postinstall` on
       # EVERY `pnpm install --frozen-lockfile` — including "Already up to date" — so all five
-      # hosted-runner install jobs would each pay the ~130MB download. Restoring the browser dir
+      # hosted-runner install jobs would each pay the ~170MB download. Restoring the browser dir
       # BEFORE the install is what makes the script's presence check hit and skip, so the download
       # is paid once per cache key instead of once per job. Keyed on `pnpm-workspace.yaml` (which
       # carries the `@playwright/test` catalog pin) so a version bump re-downloads exactly once;
@@ -469,6 +469,11 @@ jobs:
       # pre-empted its own presence check and broke #5061's criterion (#5169). `e2e` needs none of
       # this: its container prebakes /ms-playwright and sets PLAYWRIGHT_BROWSERS_PATH, which the
       # script skips on one line earlier.
+      #
+      # This cache is INERT until #5343 is fixed: playwright 1.59.1 hangs in `extract-zip` after the
+      # bytes land, so nothing is ever extracted and the key saves an empty directory. It is kept
+      # rather than deferred because it is the mechanism the moment provisioning can succeed, and
+      # keeping it is what stops that becoming a per-job cost then.
       - name: Cache Playwright browsers
         uses: actions/cache@v4.2.3
         with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -457,6 +457,26 @@ jobs:
           node-version-file: package.json
           cache: pnpm
 
+      # `@kampus/fabrika-cli`'s `postinstall` provisions chromium so no operator or agent ever
+      # hand-runs a browser install (#5061), and pnpm runs a workspace member's `postinstall` on
+      # EVERY `pnpm install --frozen-lockfile` — including "Already up to date" — so all five
+      # hosted-runner install jobs would each pay the ~130MB download. Restoring the browser dir
+      # BEFORE the install is what makes the script's presence check hit and skip, so the download
+      # is paid once per cache key instead of once per job. Keyed on `pnpm-workspace.yaml` (which
+      # carries the `@playwright/test` catalog pin) so a version bump re-downloads exactly once;
+      # `restore-keys` falls back to the newest prior cache, which still satisfies the presence
+      # check whenever the pin didn't move. The script deliberately has no `CI` skip — that skip
+      # pre-empted its own presence check and broke #5061's criterion (#5169). `e2e` needs none of
+      # this: its container prebakes /ms-playwright and sets PLAYWRIGHT_BROWSERS_PATH, which the
+      # script skips on one line earlier.
+      - name: Cache Playwright browsers
+        uses: actions/cache@v4.2.3
+        with:
+          path: ~/.cache/ms-playwright
+          key: playwright-${{ runner.os }}-${{ hashFiles('pnpm-workspace.yaml') }}
+          restore-keys: |
+            playwright-${{ runner.os }}-
+
       - run: pnpm install --frozen-lockfile
 
       # `biome check` is lint + format in one pass (tabs/100-col/no-bracket-spacing).
@@ -510,6 +530,15 @@ jobs:
         with:
           node-version-file: package.json
           cache: pnpm
+
+      # See the `check` job's Playwright browser cache.
+      - name: Cache Playwright browsers
+        uses: actions/cache@v4.2.3
+        with:
+          path: ~/.cache/ms-playwright
+          key: playwright-${{ runner.os }}-${{ hashFiles('pnpm-workspace.yaml') }}
+          restore-keys: |
+            playwright-${{ runner.os }}-
 
       - run: pnpm install --frozen-lockfile
 
@@ -567,6 +596,15 @@ jobs:
           node-version-file: package.json
           cache: pnpm
 
+      # See the `check` job's Playwright browser cache.
+      - name: Cache Playwright browsers
+        uses: actions/cache@v4.2.3
+        with:
+          path: ~/.cache/ms-playwright
+          key: playwright-${{ runner.os }}-${{ hashFiles('pnpm-workspace.yaml') }}
+          restore-keys: |
+            playwright-${{ runner.os }}-
+
       - run: pnpm install --frozen-lockfile
 
       - run: pnpm --filter './packages/**' --filter @kampus/infra run test
@@ -587,6 +625,15 @@ jobs:
         with:
           node-version-file: package.json
           cache: pnpm
+
+      # See the `check` job's Playwright browser cache.
+      - name: Cache Playwright browsers
+        uses: actions/cache@v4.2.3
+        with:
+          path: ~/.cache/ms-playwright
+          key: playwright-${{ runner.os }}-${{ hashFiles('pnpm-workspace.yaml') }}
+          restore-keys: |
+            playwright-${{ runner.os }}-
 
       - run: pnpm install --frozen-lockfile
 
@@ -769,6 +816,15 @@ jobs:
         with:
           node-version-file: package.json
           cache: pnpm
+
+      # See the `check` job's Playwright browser cache.
+      - name: Cache Playwright browsers
+        uses: actions/cache@v4.2.3
+        with:
+          path: ~/.cache/ms-playwright
+          key: playwright-${{ runner.os }}-${{ hashFiles('pnpm-workspace.yaml') }}
+          restore-keys: |
+            playwright-${{ runner.os }}-
 
       - run: pnpm install --frozen-lockfile
 

--- a/packages/fabrika-cli/README.md
+++ b/packages/fabrika-cli/README.md
@@ -630,9 +630,12 @@ Four things about it are load-bearing:
 - **The headless browser is provisioned by installing the package.** `postinstall` runs
   [`scripts/provision-browser.mjs`](./scripts/provision-browser.mjs), so no operator and no agent
   ever runs a browser-install step by hand. It is best-effort and never fails the install; it skips
-  when the browser is already there, when `PLAYWRIGHT_BROWSERS_PATH` names a managed install, when
-  `CI` is set (CI images bake their own), or on `FABRIKA_SKIP_BROWSER_PROVISION=1`. A run that then
-  finds no browser exits `11` **carrying the exact remediation command** — never a silent skip.
+  when the browser is already there, when `PLAYWRIGHT_BROWSERS_PATH` names a managed install, or on
+  `FABRIKA_SKIP_BROWSER_PROVISION=1`. There is deliberately no `CI` skip: it pre-empted the presence
+  check, so it only ever fired on a CI image with *no* chromium — the one case the criterion has to
+  cover ([#5169](https://github.com/kamp-us/phoenix/issues/5169)). CI keeps the cost off the clock
+  with a `~/.cache/ms-playwright` cache restored before `pnpm install`, not with a skip. A run that
+  then finds no browser exits `11` **carrying the exact remediation command** — never a silent skip.
 - **Absence is answered three ways, never one.** A missing manifest is `12` (un-bootstrapped, route
   to front-door), a missing registry is `13` (the law is untyped, prose is the source), and an
   unreadable one is `11` (UNKNOWN) — the skill's prose fallback is legal only in the middle case.

--- a/packages/fabrika-cli/README.md
+++ b/packages/fabrika-cli/README.md
@@ -633,9 +633,13 @@ Four things about it are load-bearing:
   when the browser is already there, when `PLAYWRIGHT_BROWSERS_PATH` names a managed install, or on
   `FABRIKA_SKIP_BROWSER_PROVISION=1`. There is deliberately no `CI` skip: it pre-empted the presence
   check, so it only ever fired on a CI image with *no* chromium — the one case the criterion has to
-  cover ([#5169](https://github.com/kamp-us/phoenix/issues/5169)). CI keeps the cost off the clock
-  with a `~/.cache/ms-playwright` cache restored before `pnpm install`, not with a skip. A run that
-  then finds no browser exits `11` **carrying the exact remediation command** — never a silent skip.
+  cover ([#5169](https://github.com/kamp-us/phoenix/issues/5169)). CI keeps the repeat cost off the
+  clock with a `~/.cache/ms-playwright` cache restored before `pnpm install`, not with a skip. A run
+  that then finds no browser exits `11` **carrying the exact remediation command** — never a silent
+  skip. **Provisioning cannot currently succeed on a machine with no browser at all**: playwright
+  1.59.1 downloads the archive and then hangs unzipping it
+  ([#5343](https://github.com/kamp-us/phoenix/issues/5343)), so the install is bounded by a 120s
+  timeout and the `11` remediation path is what you land on.
 - **Absence is answered three ways, never one.** A missing manifest is `12` (un-bootstrapped, route
   to front-door), a missing registry is `13` (the law is untyped, prose is the source), and an
   unreadable one is `11` (UNKNOWN) — the skill's prose fallback is legal only in the middle case.

--- a/packages/fabrika-cli/scripts/provision-browser.mjs
+++ b/packages/fabrika-cli/scripts/provision-browser.mjs
@@ -17,8 +17,8 @@
  *
  * There is deliberately no `CI` skip (#5169): it fired *before* the presence check below, so it was
  * load-bearing only on a CI image with no chromium — exactly the case the criterion above must
- * cover. CI pays the download once per cache key, not once per job; see the browser cache in
- * `.github/workflows/ci.yml`.
+ * cover. CI keeps the repeat cost off the clock with a browser cache restored before the install
+ * (`.github/workflows/ci.yml`), not with a skip.
  */
 import {spawnSync} from "node:child_process";
 import {existsSync} from "node:fs";
@@ -41,9 +41,14 @@ try {
 }
 if (installed) skip("chromium is already provisioned");
 
+// 120s, not the 10 minutes this carried before, and the number is measured (#5169). The download
+// itself is ~2s for 173MB on both a GitHub hosted runner and a dev machine; what actually costs time
+// is playwright 1.59.1 hanging in `extract-zip` *after* the bytes land, which never recovers (#5343).
+// A timeout sized for a slow download therefore bought nothing and spent 10 minutes per install site
+// proving it. 120s is ~60x the measured download and caps a hung install at a bounded cost.
 const result = spawnSync("pnpm", ["exec", "playwright", "install", "chromium"], {
 	stdio: "inherit",
-	timeout: 10 * 60 * 1000,
+	timeout: 120 * 1000,
 });
 if (result.status !== 0) {
 	process.stderr.write(

--- a/packages/fabrika-cli/scripts/provision-browser.mjs
+++ b/packages/fabrika-cli/scripts/provision-browser.mjs
@@ -11,12 +11,14 @@
  * `pnpm install` for everyone over a capability only one verb needs, and the run-time story is
  * already fail-closed and actionable: `ui render` exits `11` naming the exact remediation command.
  *
- * Three skips, each a real provisioning state rather than a convenience:
+ * Two skips, each a real provisioning state rather than a convenience:
  *   - `FABRIKA_SKIP_BROWSER_PROVISION=1` — the explicit opt-out.
  *   - `PLAYWRIGHT_BROWSERS_PATH` set — a managed/prebaked install already owns the browsers.
- *   - `CI` set with no prebaked path — CI images bake their own browsers, and a ~130MB download in
- *     every job of every workflow is a cost no job asked for. The run-time `11` covers the case
- *     where a CI job really did need it.
+ *
+ * There is deliberately no `CI` skip (#5169): it fired *before* the presence check below, so it was
+ * load-bearing only on a CI image with no chromium — exactly the case the criterion above must
+ * cover. CI pays the download once per cache key, not once per job; see the browser cache in
+ * `.github/workflows/ci.yml`.
  */
 import {spawnSync} from "node:child_process";
 import {existsSync} from "node:fs";
@@ -29,7 +31,6 @@ const skip = (reason) => {
 if (process.env.FABRIKA_SKIP_BROWSER_PROVISION === "1") skip("FABRIKA_SKIP_BROWSER_PROVISION=1");
 if ((process.env.PLAYWRIGHT_BROWSERS_PATH ?? "") !== "")
 	skip("PLAYWRIGHT_BROWSERS_PATH names a managed install");
-if ((process.env.CI ?? "") !== "") skip("CI images prebake their browsers");
 
 let installed = false;
 try {


### PR DESCRIPTION
Fixes #5169

Both halves of the ruled work. Half 2's answer is not the one the ticket assumed, and the difference
is the substance of this PR.

## Half 1 — the `CI` skip is deleted

`packages/fabrika-cli/scripts/provision-browser.mjs` no longer carries
`if ((process.env.CI ?? "") !== "") skip("CI images prebake their browsers")`. The docblock's
three-skip list is now a two-skip list (`FABRIKA_SKIP_BROWSER_PROVISION=1`,
`PLAYWRIGHT_BROWSERS_PATH`) with a note on why the third is gone.
`packages/fabrika-cli/README.md` carried the same three-skip claim in prose and is corrected.

#5061's criterion is untouched. Option B was not taken.

## Half 2 — measured, and the premise was wrong

### The open triage question, answered by reproduction

Triage left open whether pnpm runs a workspace member's own `postinstall` in each CI install job.
Reproduced with the skip still in place, so the log names the skip that fired:

```
$ CI=1 pnpm install --frozen-lockfile
Lockfile is up to date, resolution step is skipped
Already up to date

packages/fabrika-cli postinstall$ node ./scripts/provision-browser.mjs
packages/fabrika-cli postinstall: fabrika: skipping headless-browser provisioning — CI images prebake their browsers.
```

**Yes** — it runs on every `pnpm install --frozen-lockfile`, including an "Already up to date" run.

### What deleting the skip actually costs — not a download

The ticket priced this at "~130MB per install site". That is wrong, and CI run
[31375020282](https://github.com/kamp-us/phoenix/actions/runs/31375020282) on this branch says so.
From the `validate skill frontmatter` job's log:

```
09:32:18.4  Downloading Chrome for Testing 147.0.7727.15 (playwright chromium v1217)
09:32:19.2  |                    |   0% of 170.4 MiB
09:32:20.0  |■■■■■■■■■■■■■■■■■■■■| 100% of 170.4 MiB
            <ten minutes of nothing>
09:42:17.8  fabrika: headless-browser provisioning did not complete; ...
```

170.4 MiB in **1.6 seconds**. The other 598 seconds are a hang, ended only by the script's own
10-minute spawn timeout. Two jobs hit 10m08s independently, to the second.

Diagnosed to the stage, not left as folklore. Run directly on darwin-arm64 — no pnpm wrapper, no
postinstall, just the CLI with playwright's install log on:

```
10:08:31.252 pw:install -- download complete, size: 173508376
10:08:31.252 pw:install SUCCESS downloading Chrome for Testing 147.0.7727.15
10:08:31.252 pw:install removing existing browser directory if any
10:08:31.253 pw:install extracting archive
            <nothing, indefinitely>
```

It stalls at **`extracting archive`** — playwright's bundled `extract-zip`, in
`oopDownloadBrowserMain.js`. Stalled, not slow: two `du` reads minutes apart both report 448 KB
across 39 files of a 173 MB archive, and `sample` shows every thread parked with no CPU. Same on
ubuntu-latest x64 and darwin-arm64, through `pnpm exec` and as a bare `node cli.js` — so it is the
library, not the platform or the invocation shape.

This is #522's "hangs deterministically on the hosted runner", still live in 1.59.1, now pinned to a
stage. Filed as #5343.

### Per-job cost, from the real run

| Job | Runner | Install step | What happened |
| --- | --- | --- | --- |
| `check` | `ubuntu-latest` | 10m08s | cache miss → download 1.6s → extraction hang → timeout |
| `unit` | `ubuntu-latest` | 10m08s | same |
| `packages-tests` | `ubuntu-latest` | 10m08s | same |
| `skills` | `ubuntu-latest` | 10m08s | same |
| `integration` | `ubuntu-latest` | 10m08s | same |
| `e2e` | `mcr.microsoft.com/playwright:v1.59.1-jammy` | **13s** | skipped one line earlier on `PLAYWRIGHT_BROWSERS_PATH` |

`e2e`'s 13 seconds is the prebaked-container path working exactly as designed, unchanged by this PR.

### The cost-avoidance answer

**The mechanism is a cache, and it is in place** — `actions/cache@v4.2.3` over
`~/.cache/ms-playwright`, restored **before** `pnpm install` in the five hosted-runner jobs (ordering
is the whole trick, since provisioning runs *during* the install), keyed on `pnpm-workspace.yaml`
(which carries the `@playwright/test` catalog pin) with a `restore-keys` prefix fallback. This
follows the `actions/cache@v4.2.3` turbo-cache precedent already in `integration`.

**But it is inert, and the recorded finding is why:** no mechanism can avoid this cost, because the
cost is not a download to cache. Nothing is ever extracted, so the key saves an empty directory and
can never hit — the run's own log confirms it (`Cache not found`, then `Cache saved` with a 1-second
post step). This is the "a finding is recorded naming each mechanism considered and why none of them
avoids the cost" branch of the AC, and it is recorded with evidence rather than asserted.

Mechanisms considered and rejected:

- **A browser cache** — kept, but inert until #5343. It is not deleted because it is the correct
  mechanism the moment provisioning can succeed, and it is what stops the cost being per-job then.
- **`playwright install --only-shell chromium`** (smaller archive) — rejected here: `ui render`'s
  presence check is `chromium.executablePath()`, so it changes the verb's runtime contract. Noted on
  #5343 as a workaround worth one run.
- **A dedicated provisioning job the five jobs `needs:`** — rejected: serializes the workflow behind
  one job, adds a job to the `ci-required` surface, and would hang in exactly the same place.
- **Setting `PLAYWRIGHT_BROWSERS_PATH` in CI** — rejected: no prebaked path exists on a hosted
  runner, and pointing it at an empty dir is the deleted `CI` skip wearing a different hat.

**So the timeout drops from 10 minutes to 120s.** It was sized for a slow download; a slow download
is not the failure mode. 120s is ~60x the measured transfer and caps a hung install at a bounded
cost instead of spending 8 more minutes per job proving the same hang. `pnpm install` stays
best-effort and still exits `0`.

### Regression guard (#522/#660)

No `playwright install` *step* is reintroduced on a hosted runner. The only install that can run is
the script's own `spawnSync`, now bounded tighter than before. `e2e` keeps its container and its
`timeout-minutes: 25`. No job timeout was raised.

## What this leaves open, stated plainly

#5061's criterion now holds **in form** — there is no CI-specific skip, and nobody is told to run a
browser install by hand. It does not hold **in fact** on a machine with no browser, because
provisioning cannot complete anywhere I could test it. That is a pre-existing defect this ticket
surfaced rather than one it introduced (the `CI` skip was hiding it in CI, and no fabrika CI job
renders UI today), and it is #5343. The residual cost until #5343 lifts is 120s per hosted-runner
install job.

`e2e` failed on this branch's first run at "Await preview URL + D1 id" — the deploy-side preview
never arrived inside its 10-minute budget. That step runs before any browser work and is unrelated
to this diff; `e2e`'s own install was 13s.

## Control-plane note

The diff touches `.github/workflows/ci.yml`, so this is **control-plane by path (ADR 0053)** and
banks for human approval rather than auto-shipping. Not routed around.

## Deviations

**Class: the fix shape changed once the measurement came back.**
- Said: delete the `CI` skip, then add a cache (or record that none exists) to avoid the ~130MB
  per-job download.
- Did: deleted the skip and added the cache, and *also* cut the script's spawn timeout from 10
  minutes to 120s — a change the issue does not ask for.
- Why: the issue's cost model was falsified by the first CI run. The download is 1.6s; the cost is a
  deterministic extraction hang. A 10-minute timeout sized for a slow download spends 50 minutes of
  CI per run learning nothing. Leaving it would have shipped a measured, avoidable regression.
- Disposition: no action needed; the rationale is at the line and in #5343.

**Class: an acceptance criterion cannot be satisfied as written, and is answered rather than met.**
- Said: "CI is green on the PR, including the `e2e` job, with no increase in job timeouts needed to
  accommodate a download", and "any install step that does run on a hosted runner is ... shown to
  complete in a real CI run".
- Did: no timeout was increased and no install step was added, but the provisioning run does **not**
  complete on a hosted runner — it cannot, at this playwright pin.
- Why: #5343. Making it complete is a dependency-level fix (a `pnpm patch` per ADR 0038, or a version
  move that must stay in lockstep with the `mcr.microsoft.com/playwright:v1.59.1-jammy` tag `e2e`
  matches), which is a different decision from the one ruled here.
- Disposition: for the reviewer and the founder to judge. The two live options are to accept 120s per
  hosted-runner job until #5343 lifts, or to hold this PR behind #5343. I did not pick between them,
  and I did not re-add the skip — Option B is off the table by the ruling.

**Class: a defect found while working, left for its own lane.**
- Said: nothing about the scratch namespace.
- Did: hit a cross-lane scratch-file collision mid-run (another lane's PR body overwrote mine at the
  same path). Verified this PR's posted body was mine; changed nothing.
- Why: it is a shared pipeline surface with other lanes live in the same tree.
- Disposition: filed as #5339.

`claude-plugins/kampus-pipeline/skills/shared/scripts/dev-tier-m.sh` was run against this PR and
returned: `## Deviations` section present; Tier-M scan — 0 suppression/skip lines, 0
removed-assertion lines. The entries above are disclosed on their own, not because the scan flagged
them.
