### PR TITLE
docs(fabrika): add the outcome-completeness check the six presence checks cannot see (#4736)

### DIFF
--- a/claude-plugins/fabrika/docs/cli-interface-convention.md
+++ b/claude-plugins/fabrika/docs/cli-interface-convention.md
@@ -310,7 +310,7 @@ that test belongs in the skill, not the CLI.
 
 ### Completeness test
 
-A spec is complete when all seven hold. Each is checkable by reading the spec alone, which is the
+A spec is complete when all eight hold. Each is checkable by reading the spec alone, which is the
 point: an implementer can tell an unfinished spec from a finished one before starting.
 
 1. Every flag has a type and, if optional, a default.
@@ -334,6 +334,24 @@ point: an implementer can tell an unfinished spec from a finished one before sta
    [0247](../../../.decisions/0247-a-spec-example-value-is-derivable-or-absent.md)). An example that
    *looks* verifiable and is not is worse than no example, because a reader treats the number as a
    contract.
+8. **Every outcome the verb can reach has a code.** Walk the verb's *states* and check each one names
+   a code. This is check 3 run backwards — 3 walks the codes and asks what produces each, so it can
+   only see what the spec already wrote down, and a state the spec never mentioned is invisible to it.
+
+   A reachable state no row names does not stay merely undocumented. It lands on `1`, which rule 3
+   reserves for a failure to invoke, so the spec's silence hands the caller a **proven** refusal it
+   cannot tell from a broken binary — or it pushes the implementer into minting a number the spec
+   never assigned, after which two implementations of one spec disagree about what that number means.
+   `adr next` and `adr resolve` were specified with a code for an unfetchable `--base` and a code for
+   a `--dir` that read empty, and none for the `--dir` that could not be read at all; the spec passed
+   checks 1–6, and the state shipped on `1`
+   ([#4736](https://github.com/kamp-us/phoenix/issues/4736) — the verdict-versus-invocation collision
+   of [#4208](https://github.com/kamp-us/phoenix/issues/4208) /
+   [#4219](https://github.com/kamp-us/phoenix/issues/4219)).
+
+   Checks 7 and 8 are the **outcome-completeness** pair, and they are the two directions the presence
+   tests cannot cover: 7 that the spec derives every value it prints, 8 that it names every outcome it
+   can reach.
 
 ### Worked example
 


### PR DESCRIPTION
fabrika's contract-spec format has a completeness test an author runs before handing a spec to a builder. Every check in it asks whether the spec wrote something down, so none of them can notice a state the spec never mentioned at all — which is how `adr next` and `adr resolve` shipped with no exit code for "the record directory could not be read", and the state landed on `1`, the code reserved for a binary that failed to run. This adds check 8: walk the verb's states and check each one names a code, which is check 3 run backwards.

Fixes #4736

## What this diff changes

`claude-plugins/fabrika/docs/cli-interface-convention.md` — one new check in Part 2's completeness test, plus the count in the sentence above it. Check 8 carries the #4736 case as its grounding and names checks 7 and 8 as the outcome-completeness pair the presence tests cannot cover.

## What was already delivered, and where

Five of the issue's six acceptance criteria were satisfied on `main` before this branch was cut, by the exit-table work that landed while #4736 sat in the queue. Verified at `main` `d173f56b`, not assumed:

| AC | State | Evidence |
|---|---|---|
| a code in `adr next`'s table for an unreadable `--dir`, distinct from the unfetchable base and the empty read | done | `claude-plugins/fabrika/skills/adr/contract.md` — `adr next` Exit status seats `11`, `17` is the unfetchable base, `5` is a vacated seat |
| the same in `adr resolve`'s table, stated in the spec | done | same file — `adr resolve` Exit status seats `11` |
| an Errors row per code, byte-for-byte, with stream and kind | done | both verbs' Errors tables carry the `cannot read <dir> at <ref>` row on stderr, kind refusal |
| `packages/fabrika-cli/` stops returning `1` for this state | done | `packages/fabrika-cli/src/adr/codes.ts` exports `DIR_UNREADABLE`; `next-verb.ts` and `resolve-verb.ts` refuse on it |
| a test proves the code for both verbs | done | `next-verb.unit.test.ts` and `resolve-verb.unit.test.ts` — "refuses an unreadable `--dir` on its own proven code, not on 1", plus a second test keeping it distinguishable from the empty directory |
| the outcome-completeness gap in the format's completeness test | **this diff** | check 8 |

`pnpm vitest run src/adr` in `packages/fabrika-cli`: 11 files, 128 tests, all green.

The sixth was the open one. #4735's amendment landed rule 7 — the derivable-example half — and its own closing note said the sibling defects stay independently resolvable, so the outcome-completeness half was never written and no reason for keeping it separate was recorded either. Check 8 is that half.

## Deviations

**Class: narrowed fix shape.**
- Said: the issue is filed against `claude-plugins/fabrika/skills/adr/contract.md` and asks for a spec change plus a code change in `packages/fabrika-cli/`.
- Did: changed neither. This diff touches only `claude-plugins/fabrika/docs/cli-interface-convention.md`.
- Why: both halves already landed on `main` — read at `d173f56b` rather than taken on trust, with the evidence in the table above. Re-doing them would either be a no-op or a second seating of a code that already means one thing across the group.
- Disposition: no action needed. The one criterion left is delivered here, so `Fixes` is honest at merge time — every criterion holds against `main` once this lands.

**Class: left a sibling defect for a follow-up.**
- Said: nothing about other specs.
- Did: `claude-plugins/fabrika/skills/handoff/contract.md` carries a "Self-test against the completeness test" section enumerating checks 1–7; check 8 leaves it a check short. Not updated here.
- Why: writing that line means judging whether `handoff`'s four verbs are outcome-complete. That is an authoring judgment on another skill's spec, outside the `adr` surface this lane was scoped to, and three other lanes are live in `packages/fabrika-cli`.
- Disposition: follow-up filed, #5338.

**Class: a proven refusal still sharing `1`, out of this issue's scope.**
- Said: the issue names the unreadable `--dir` state.
- Did: left two neighbours alone. `adr next: <dir> holds a record with an unparseable id: <name>` and `adr resolve: <dir> at <ref> holds two records for id <id>` are both proven refusals seated on `1` in the same tables, which is the same #4208 / #4219 collision one state over.
- Why: they are different states, and widening the diff to re-seat them would re-open a table that merged hours ago.
- Disposition: for the reviewer to judge; a follow-up is filed if it is wanted rather than minted unilaterally here.

`claude-plugins/kampus-pipeline/skills/shared/scripts/dev-tier-m.sh` was run against this PR and returned: `## Deviations` section present; Tier-M scan — 0 suppression/skip lines, 0 removed-assertion lines. The three entries above are disclosed on their own, not because the scan flagged them.
