### PR TITLE
feat(fabrika-cli): implement the wayfinding contract's map verbs

### DIFF
--- a/claude-plugins/fabrika/docs/wire-formats.md
+++ b/claude-plugins/fabrika/docs/wire-formats.md
@@ -40,6 +40,7 @@ does not exist yet — rather than missing; check the registry before assuming a
 | `acceptance-criteria` | [`packages/fabrika-cli/src/wire/acceptance-criteria.ts`](../../../packages/fabrika-cli/src/wire/acceptance-criteria.ts) | `triage`, `build-epic` | `build`, `review` |
 | `verdict-marker` | [`packages/fabrika-cli/src/wire/verdict-marker.ts`](../../../packages/fabrika-cli/src/wire/verdict-marker.ts) | `review`, `check-epic-plan` | `build`, `ship` |
 | `slice-handoff` | [`packages/fabrika-cli/src/wire/slice-handoff.ts`](../../../packages/fabrika-cli/src/wire/slice-handoff.ts) | `build-epic` | `build` |
+| `map-ticket` | [`packages/fabrika-cli/src/wire/map-ticket.ts`](../../../packages/fabrika-cli/src/wire/map-ticket.ts) | `map` | `map` |
 <!-- fabrika:wire-index:end -->
 
 ### `acceptance-criteria`
@@ -78,6 +79,20 @@ own words from someone else's. So the section set is closed and the rules text i
 module, and a brief carrying anything outside them reads as drifted rather than as a brief with
 extra advice. Its paths are machine-local by construction, which is also why a brief is consumed in
 session and never posted to a public surface.
+
+### `map-ticket`
+
+This is how a wayfinding frontier ticket says which map it belongs to. The load-bearing field is the
+map number, and it is load-bearing because the alternative already exists and is not trustworthy: a
+ticket is linked to its map by a native sub-issue edge, and **anyone with write access can add that
+edge to anything**. A reader that derived the frontier from edges alone would count a stranger's
+issue as one of the map's open questions, and it would look perfectly well-formed doing it. So the
+marker is the claim and the edge is only the link; a ticket whose marker names a different map is
+disregarded with the mismatch reported, not silently dropped and not silently counted.
+
+The nonce is the filing run's, not a session's, for the reason recorded at #5028 and #4516: a
+session id is pane-constant and shared across sibling subagents, so two lanes of one charting run
+would key onto one namespace and each would read the other's marker as its own.
 
 ## Adding a format
 

--- a/packages/fabrika-cli/README.md
+++ b/packages/fabrika-cli/README.md
@@ -8,7 +8,8 @@ contract specifies; `build`, the fourteen the `/build` contract specifies; `epic
 eight the `/build-epic` contract specifies; `plan`, the epic-plan gate's; `review`, the eight
 the `/review` contract specifies; `review-ui`, the three the `/review-ui` contract specifies
 (capture a PR's preview, emit the `review-ui` verdict, or post a typed blocker note);
-`ship`, the thirteen the `/ship` contract specifies; `eval`, the graded-corpus
+`ship`, the thirteen the `/ship` contract specifies; `map`, the eight the `/wayfinding`
+contract specifies (chart one destination's fog, and drain its frontier); `eval`, the graded-corpus
 harness the fabrika eval layer measures itself with; `spend`, what one fabrika run cost in
 tokens; `wire`, which owns the byte-level formats two skills meet through on a GitHub
 artifact; `status`, the six the `/fabrika` front door's contract specifies (what state the
@@ -353,6 +354,48 @@ lane verb does not.
   loop: a SHA is content-addressed, so an amend or rebase makes the old verdict `unbindable`
   against the new graph rather than quietly stale, and `status` re-derives every binding against
   the live graph on each read.
+
+## The `map` group
+
+Charting one destination's fog. The group implements
+[`claude-plugins/fabrika/skills/wayfinding/contract.md`](../../claude-plugins/fabrika/skills/wayfinding/contract.md).
+The map is a GitHub issue carrying `wayfinding:map`; its frontier is that issue's **sub-issues**,
+and the topology between them is GitHub's **native issue-dependency edges** — never prose in a body.
+
+| Verb | What it answers |
+|---|---|
+| `map open` | the map for a destination — minted or resumed, refusing one that is not fog |
+| `map read` | the whole state: five sections, one row per frontier ticket, the frontier token, the digest |
+| `map ticket` | one frontier ticket, filed and linked and edged and spliced onto the map, as one act |
+| `map lane` | a research lane on one ticket, claimed under this run's nonce |
+| `map finding` | a lane closed with an outcome from a closed set of three |
+| `map fork` | where a question is being answered instead — a `grilling` session or a `prototyping` spike |
+| `map record` | the lockstep: the answer under `## Decisions`, the row off the frontier, the ticket closed |
+| `map descope` | a rejected direction appended to the never-graduating out-of-scope section |
+
+- **A line's section is not its state.** State is resolved from the ticket's marker, its `state` on
+  GitHub and its edges; the body rows are re-rendered from that answer
+  ([`src/map/frontier.ts`](./src/map/frontier.ts)). v1 encoded state as which heading a bullet sat
+  under, in a body no shipped tool wrote, and then had to read "tolerantly" to cope with its own
+  drift.
+- **All four frontier tokens exit `0`.** `awaiting-founder`, `lanes-pending`, `clear` and `empty` are
+  four answers. A frontier holding open questions is the skill working, and seating it on a non-zero
+  code would make `[ $? -ne 0 ]` read "the fog is not cleared yet" as "the verb never ran".
+- **Every body write is a compare-and-set slice.** `--digest` guards the write and the write replaces
+  one section's bytes, so a concurrent edit to another section survives even when the guard admits
+  the write ([`src/map/body.ts`](./src/map/body.ts)).
+- **Lane traffic goes to the ticket, never to the map body.** `map finding` writes a comment and
+  releases the lane; only `map record` touches the body, so a parallel burndown sees one body write
+  per *resolution* rather than one per lane event.
+- **The lane key is the caller's run nonce**, eight lowercase hex, passed explicitly. A session id is
+  pane-constant and shared across sibling subagents, so two lanes of one run would key onto one
+  namespace and each would read the other's claim as its own.
+- **A `404` on a dependency read is a verdict about the issue, not about its edges**
+  ([`src/io/edges.ts`](./src/io/edges.ts)). Every edge read is preceded by an existence read, every
+  list pages, and an empty read that cannot be *proven* empty is `11` — never an empty frontier.
+- **`10` is a deliberate gap.** No `map` verb accepts a label flag or writes a classification, so the
+  base's `10` is unreachable here rather than merely unused
+  ([`src/map/codes.ts`](./src/map/codes.ts)).
 
 ## The `wire` group
 

--- a/packages/fabrika-cli/src/exit-code-alignment.ts
+++ b/packages/fabrika-cli/src/exit-code-alignment.ts
@@ -130,6 +130,19 @@ export const SPEND_SEATS: SharedSeats = {
 	INPUT_UNREADABLE: "PRECONDITION_UNKNOWN",
 };
 
+/**
+ * `map`'s seats: `build`'s nine minus the classification seat, under the base's own names.
+ *
+ * None of the shipped maps fits, which is why this one is written rather than reused: the eight-seat
+ * maps key on `ZERO_SCOPE` and `OFF_VOCABULARY`, `HOOK_SEATS` shares only the stdin seat, and `map`
+ * names `7` `NO_TARGET` and holds `10` as `DELIBERATE_GAP` — no `map` verb accepts a label flag or
+ * writes a classification, so the base's `10` is unreachable here and cannot be claimed at all.
+ */
+export const MAP_SEATS: SharedSeats = (() => {
+	const {OFF_VOCABULARY: _classified, ZERO_SCOPE: _zero, ...rest} = BUILD_SEATS;
+	return {...rest, NO_TARGET: "NO_TARGET"};
+})();
+
 /** The groups that align to {@link ALIGNMENT_BASE}, each with the seats it claims to share. */
 export const ALIGNED_GROUPS: Readonly<Record<string, SharedSeats>> = {
 	adr: ADR_SEATS,
@@ -138,6 +151,7 @@ export const ALIGNED_GROUPS: Readonly<Record<string, SharedSeats>> = {
 	hook: HOOK_SEATS,
 	epic: BUILD_SEATS,
 	ledger: BUILD_SEATS,
+	map: MAP_SEATS,
 	plan: BUILD_SEATS,
 	triage: SHARED_SEATS,
 	review: SHARED_SEATS,

--- a/packages/fabrika-cli/src/exit-code-alignment.unit.test.ts
+++ b/packages/fabrika-cli/src/exit-code-alignment.unit.test.ts
@@ -17,6 +17,7 @@ import {
 } from "./exit-code-alignment.ts";
 import * as hook from "./hook/codes.ts";
 import * as ledger from "./ledger/codes.ts";
+import * as map from "./map/codes.ts";
 import * as plan from "./plan/codes.ts";
 import {registeredGroups} from "./registry.ts";
 import * as report from "./report/codes.ts";
@@ -43,6 +44,7 @@ const TABLES: Readonly<Record<string, CodeTable>> = {
 	eval: evalCodes,
 	hook,
 	ledger,
+	map,
 	plan,
 	report,
 	review,

--- a/packages/fabrika-cli/src/io/edges.ts
+++ b/packages/fabrika-cli/src/io/edges.ts
@@ -101,7 +101,11 @@ export const addSubIssue = (repo: string, parent: number, childId: number): Shel
 	});
 
 /** Record that `issue` waits on the issue whose internal id is `blockerId`. */
-export const addBlockedBy = (repo: string, issue: number, blockerId: number): Shell<Attempt<void>> =>
+export const addBlockedBy = (
+	repo: string,
+	issue: number,
+	blockerId: number,
+): Shell<Attempt<void>> =>
 	Effect.gen(function* () {
 		const r = yield* execCapture("gh", [
 			"api",

--- a/packages/fabrika-cli/src/io/edges.ts
+++ b/packages/fabrika-cli/src/io/edges.ts
@@ -1,0 +1,115 @@
+/**
+ * GitHub's **native** relationship endpoints: the sub-issue link and the two issue-dependency
+ * lists. The frontier's topology is stored here rather than in a map body, so this is the one path
+ * to it — a second path is what let v1's prose topology drift from the graph it described.
+ *
+ * The `issues.ts` disciplines hold unchanged: `gh api` REST and never GraphQL, every list read paged,
+ * absent split from unreadable through {@link Existence}, and a shape that is not what was asked for
+ * treated as a failure rather than an empty result.
+ *
+ * <!-- anchor: 404-IS-A-VERDICT --> **A 404 on a dependency read is a verdict about the issue, not
+ * about its edges.** These endpoints answer `200 []` for a real issue with no edges and `404` for an
+ * issue that does not exist, so the two are distinguishable — but only if existence is established
+ * separately. A caller that read `[]` and reported "no blocking edges" without knowing the issue
+ * exists would print a proven negative over zero scope (ADR 0092, #4752), which is why every read
+ * here answers `Absent` on a 404 instead of an empty list.
+ *
+ * <!-- anchor: EDGE-BODY-TAKES-AN-INTERNAL-ID --> **Both POST bodies take the target's internal
+ * `id`, not its issue number**, and the sub-issue key is the singular `sub_issue_id`. Passing a
+ * number silently addresses a different issue, so the writes below take an id and the caller resolves
+ * it with `getIssue` rather than interpolating a number.
+ *
+ * **Pagination is load-bearing, not hygiene.** An unpaginated `blocked_by` read returns a plausible
+ * first page, so a frontier that "looks clear" at 30 edges would be reported clear with nothing
+ * marking it wrong — the fail-open direction.
+ */
+import {Effect} from "effect";
+import {execCapture} from "./exec.ts";
+import {type Attempt, fail, ok, type Shell} from "./git.ts";
+import {absent, type Existence, httpStatusOf, pagedJson, present, unknown} from "./issues.ts";
+import {isRecord, parseJson} from "./json.ts";
+
+/** The issue numbers in a paged list response, or the reason the bytes are not that. */
+const issueNumbers = (stdout: string): Attempt<ReadonlyArray<number>> => {
+	const pages = pagedJson(stdout);
+	if (pages._tag === "Failure") return pages;
+	const numbers: number[] = [];
+	for (const page of pages.value) {
+		const parsed = parseJson(page);
+		if (!Array.isArray(parsed)) return fail("`gh api` exited 0 but its output is not a list");
+		for (const value of parsed) {
+			if (!isRecord(value) || typeof value.number !== "number") {
+				return fail("`gh api` exited 0 but one entry carries no issue number");
+			}
+			numbers.push(value.number);
+		}
+	}
+	return ok(numbers);
+};
+
+const listRelation = (repo: string, path: string): Shell<Existence<ReadonlyArray<number>>> =>
+	Effect.gen(function* () {
+		const r = yield* execCapture("gh", ["api", "--paginate", `repos/${repo}/${path}?per_page=100`]);
+		if (!r.ok) {
+			return httpStatusOf(r.reason) === 404
+				? absent<ReadonlyArray<number>>()
+				: unknown<ReadonlyArray<number>>(r.reason);
+		}
+		const numbers = issueNumbers(r.stdout);
+		return numbers._tag === "Failure"
+			? unknown<ReadonlyArray<number>>(numbers.reason)
+			: present(numbers.value);
+	});
+
+/** The map's children. `200 []` is a proven-empty child set; a non-404 error is `Unknown`. */
+export const subIssues = (repo: string, parent: number): Shell<Existence<ReadonlyArray<number>>> =>
+	listRelation(repo, `issues/${parent}/sub_issues`);
+
+/** What a ticket waits on. */
+export const blockedBy = (repo: string, issue: number): Shell<Existence<ReadonlyArray<number>>> =>
+	listRelation(repo, `issues/${issue}/dependencies/blocked_by`);
+
+/** What a ticket gates. */
+export const blocking = (repo: string, issue: number): Shell<Existence<ReadonlyArray<number>>> =>
+	listRelation(repo, `issues/${issue}/dependencies/blocking`);
+
+/** The target's internal `id` — the value both POST bodies take, never the issue number. */
+export const internalId = (repo: string, issue: number): Shell<Existence<number>> =>
+	Effect.gen(function* () {
+		const r = yield* execCapture("gh", ["api", `repos/${repo}/issues/${issue}`, "--jq", ".id"]);
+		if (!r.ok) {
+			return httpStatusOf(r.reason) === 404 ? absent<number>() : unknown<number>(r.reason);
+		}
+		const id = r.stdout.trim();
+		return /^\d+$/.test(id)
+			? present(Number.parseInt(id, 10))
+			: unknown<number>("`gh api` exited 0 but named no internal id");
+	});
+
+/** Link `childId` under `parent` as a sub-issue. `-F` sends the integer the API requires. */
+export const addSubIssue = (repo: string, parent: number, childId: number): Shell<Attempt<void>> =>
+	Effect.gen(function* () {
+		const r = yield* execCapture("gh", [
+			"api",
+			"--method",
+			"POST",
+			`repos/${repo}/issues/${parent}/sub_issues`,
+			"-F",
+			`sub_issue_id=${childId}`,
+		]);
+		return r.ok ? ok(undefined) : fail(r.reason);
+	});
+
+/** Record that `issue` waits on the issue whose internal id is `blockerId`. */
+export const addBlockedBy = (repo: string, issue: number, blockerId: number): Shell<Attempt<void>> =>
+	Effect.gen(function* () {
+		const r = yield* execCapture("gh", [
+			"api",
+			"--method",
+			"POST",
+			`repos/${repo}/issues/${issue}/dependencies/blocked_by`,
+			"-F",
+			`issue_id=${blockerId}`,
+		]);
+		return r.ok ? ok(undefined) : fail(r.reason);
+	});

--- a/packages/fabrika-cli/src/io/issues.ts
+++ b/packages/fabrika-cli/src/io/issues.ts
@@ -169,6 +169,35 @@ export const searchOpenIssues = (
 			: ok(rows);
 	});
 
+/**
+ * The search index's issues for `tokens`, **open and closed**, paged.
+ *
+ * The sibling of {@link searchOpenIssues}, kept separate rather than parameterised because the two
+ * answer different questions and the wrong one is silently plausible: an open-only scan reports a
+ * question that was charted and closed as new, which is #4154/#4148's scar. A caller asking "has
+ * anyone answered this already?" needs the closed half; one asking "is there an open duplicate?" does
+ * not.
+ */
+export const searchIssues = (
+	repo: string,
+	tokens: ReadonlyArray<string>,
+): Shell<Attempt<ReadonlyArray<IssueRow>>> =>
+	Effect.gen(function* () {
+		const q = `repo:${repo} is:issue ${tokens.join(" ")}`;
+		const r = yield* execCapture("gh", [
+			"api",
+			"--paginate",
+			`search/issues?q=${encodeURIComponent(q)}&per_page=100`,
+			"--jq",
+			'.items[] | "\\(.number)\t\\(.title)"',
+		]);
+		if (!r.ok) return fail(r.reason);
+		const rows = parseIssueRows(r.stdout);
+		return rows === null
+			? fail("`gh api` exited 0 but its output is not a list of issue rows")
+			: ok(rows);
+	});
+
 export interface IssueRecord {
 	readonly number: number;
 	readonly title: string;
@@ -704,6 +733,28 @@ export const closeNotPlanned = (repo: string, issue: number): Shell<Attempt<void
 			"state=closed",
 			"-f",
 			"state_reason=not_planned",
+		]);
+		return r.ok ? ok(undefined) : fail(r.reason);
+	});
+
+/**
+ * Close an issue as `completed` — the close spelling for work that reached an answer.
+ *
+ * Separate from {@link closeNotPlanned} rather than a parameter: the two are opposite claims about
+ * the same issue, and a caller that could pass the wrong one silently records "we decided not to"
+ * over "we answered it".
+ */
+export const closeCompleted = (repo: string, issue: number): Shell<Attempt<void>> =>
+	Effect.gen(function* () {
+		const r = yield* execCapture("gh", [
+			"api",
+			"--method",
+			"PATCH",
+			`repos/${repo}/issues/${issue}`,
+			"-f",
+			"state=closed",
+			"-f",
+			"state_reason=completed",
 		]);
 		return r.ok ? ok(undefined) : fail(r.reason);
 	});

--- a/packages/fabrika-cli/src/map/body.ts
+++ b/packages/fabrika-cli/src/map/body.ts
@@ -1,0 +1,336 @@
+/**
+ * The map body: its five sections, the entries each holds, the compare-and-set digest over them, and
+ * the slice writes that change one section without touching the rest.
+ *
+ * Two properties this module exists to hold, both scars from v1's map:
+ *
+ * - **A line's section is not its state.** v1 encoded a ticket's state as which heading its bullet
+ *   sat under, in a body no shipped tool wrote, then read it back "tolerantly" to cope with its own
+ *   drift. Here the rows are a *rendering*: `../map/frontier.ts` resolves state from markers, issue
+ *   state and edges, and this module only composes and parses the bytes.
+ * - **A write is a slice, never a reconstruction.** {@link spliceSection} replaces the bytes of one
+ *   section and copies the rest verbatim, so a concurrent edit to another section survives even when
+ *   the digest guard admits the write.
+ *
+ * An **empty section is well-formed** and never refuses. A map at mint has an empty `## Decisions`,
+ * `## Frontier` and `## Out of scope`; a parser that refused one would make every freshly minted map
+ * unreadable by the next verb that touched it.
+ */
+
+import {createHash} from "node:crypto";
+
+/** The five headings, in the one order a map body may carry them. */
+export const SECTIONS = ["Destination", "Decisions", "Frontier", "Fog", "Out of scope"] as const;
+export type SectionName = (typeof SECTIONS)[number];
+
+/** What clears a frontier ticket. A fourth value is a drift, not a kind. */
+export const KINDS = ["research", "prototype", "decision"] as const;
+export type Kind = (typeof KINDS)[number];
+export const isKind = (value: string): value is Kind => (KINDS as readonly string[]).includes(value);
+
+/** One `## Frontier` row, as the body renders it. */
+export interface FrontierRow {
+	readonly ticket: number;
+	readonly kind: Kind;
+	readonly question: string;
+	/** The `grilling` session or `prototyping` spike the question was routed to, when it was. */
+	readonly forkedTo: number | null;
+}
+
+/** One `## Decisions` entry and the authority it cites. An entry citing neither does not parse. */
+export interface DecisionEntry {
+	readonly text: string;
+	readonly authority:
+		| {readonly _tag: "Ruled"; readonly session: number; readonly questionId: string}
+		| {readonly _tag: "Finding"; readonly ticket: number};
+}
+
+/** One `## Out of scope` entry. The section only ever grows, so these are never removed. */
+export interface OutOfScopeEntry {
+	readonly direction: string;
+	readonly reason: string;
+	readonly recordedAt: string;
+}
+
+/** A parsed map body, plus the raw bytes and section spans a slice write needs. */
+export interface MapBody {
+	readonly raw: string;
+	/** Each section's body bytes, headings excluded, in {@link SECTIONS} order. */
+	readonly sections: ReadonlyArray<string>;
+	/** `[start, end)` of each section's body inside {@link MapBody.raw}, in the same order. */
+	readonly spans: ReadonlyArray<readonly [number, number]>;
+	readonly destination: string;
+	readonly decisions: ReadonlyArray<DecisionEntry>;
+	readonly frontier: ReadonlyArray<FrontierRow>;
+	/**
+	 * How many non-blank lines `## Fog` holds.
+	 *
+	 * A count rather than a list because the section is free prose by contract: `map open` writes one
+	 * bullet per opening question, but a later session may write a paragraph, and a parser that
+	 * required bullets would refuse a body the spec permits.
+	 */
+	readonly fog: number;
+	readonly outOfScope: ReadonlyArray<OutOfScopeEntry>;
+}
+
+export type BodyRead =
+	| {readonly _tag: "Parsed"; readonly value: MapBody}
+	| {readonly _tag: "Malformed"; readonly reason: string};
+
+const HEADING = /^##[ \t]+(.+?)[ \t]*$/;
+
+/**
+ * The digest's normalisation: LF line endings, no trailing whitespace on any line, no leading or
+ * trailing blank lines. Applied per section body, which is what makes the digest survive a
+ * `normalizeForReadback` round trip byte-identically.
+ */
+export const normalizeSection = (text: string): string =>
+	text
+		.replace(/\r\n/g, "\n")
+		.split("\n")
+		.map((line) => line.replace(/[ \t]+$/, ""))
+		.join("\n")
+		.replace(/^\n+/, "")
+		.replace(/\n+$/, "");
+
+/**
+ * The compare-and-set token over the five section bodies, headings excluded.
+ *
+ * The exclusions are the invariant, not an optimisation: the digest must cover every byte a
+ * concurrent writer could move and no byte this group never touches. No verb rewrites a heading, so
+ * folding headings in would make another tool's heading-whitespace normalisation read as a lost
+ * update; issue metadata is out for the same reason — `map open` writes the label once and nothing
+ * else touches it.
+ */
+export const digestOf = (sections: ReadonlyArray<string>): string =>
+	createHash("sha256").update(sections.map(normalizeSection).join("\n")).digest("hex").slice(0, 12);
+
+const parseDecision = (entry: string): DecisionEntry | null => {
+	const ruled = /^([\s\S]*?)\s+—\s+ruled on #(\d+)\s+(R\d+\.\d+)$/.exec(entry);
+	if (ruled !== null) {
+		return {
+			text: (ruled[1] ?? "").trim(),
+			authority: {
+				_tag: "Ruled",
+				session: Number.parseInt(ruled[2] ?? "0", 10),
+				questionId: ruled[3] ?? "",
+			},
+		};
+	}
+	const finding = /^([\s\S]*?)\s+—\s+from #(\d+)$/.exec(entry);
+	if (finding === null) return null;
+	return {
+		text: (finding[1] ?? "").trim(),
+		authority: {_tag: "Finding", ticket: Number.parseInt(finding[2] ?? "0", 10)},
+	};
+};
+
+const parseFrontier = (entry: string): FrontierRow | null => {
+	const matched = /^#(\d+)\s+·\s+([a-z]+)\s+—\s+([\s\S]+)$/.exec(entry);
+	if (matched === null) return null;
+	const kind = matched[2] ?? "";
+	if (!isKind(kind)) return null;
+	const tail = matched[3] ?? "";
+	const forked = /^([\s\S]*?)\s+—\s+forked to #(\d+)$/.exec(tail);
+	return {
+		ticket: Number.parseInt(matched[1] ?? "0", 10),
+		kind,
+		question: (forked === null ? tail : (forked[1] ?? "")).trim(),
+		forkedTo: forked === null ? null : Number.parseInt(forked[2] ?? "0", 10),
+	};
+};
+
+const parseOutOfScope = (entry: string): OutOfScopeEntry | null => {
+	const matched = /^([\s\S]*?)\.\s+([\s\S]*?)\s+—\s+(\d{4}-\d{2}-\d{2})$/.exec(entry);
+	if (matched === null) return null;
+	const direction = (matched[1] ?? "").trim();
+	const reason = (matched[2] ?? "").trim();
+	if (direction === "" || reason === "") return null;
+	return {direction, reason, recordedAt: matched[3] ?? ""};
+};
+
+/**
+ * The `- ` entries of a section, each folded back onto one line with its continuation lines.
+ *
+ * Continuations are joined with a single space so an entry wrapped at the column limit parses the
+ * same as one written on a single line — a rejection on line wrapping would refuse the body the
+ * contract's own example shows.
+ */
+export const bulletEntries = (section: string): ReadonlyArray<string> | null => {
+	const entries: string[] = [];
+	for (const raw of normalizeSection(section).split("\n")) {
+		if (raw.trim() === "") continue;
+		const bullet = /^-[ \t]+(.*)$/.exec(raw);
+		if (bullet !== null) {
+			entries.push(bullet[1] ?? "");
+			continue;
+		}
+		const last = entries.length - 1;
+		if (last < 0 || !/^[ \t]/.test(raw)) return null;
+		entries[last] = `${entries[last] ?? ""} ${raw.trim()}`;
+	}
+	return entries;
+};
+
+/**
+ * Read a map body. Total: the five sections in order with every entry parsed, or the reason it is
+ * not that.
+ *
+ * The reason is carried rather than a bare `false` because every caller quotes it into a `4` refusal,
+ * and "the body does not parse" with no detail is a refusal nobody can act on.
+ */
+export const parseBody = (raw: string): BodyRead => {
+	const text = raw.replace(/\r\n/g, "\n");
+	const lines = text.split("\n");
+	const found: {name: string; bodyStart: number; headingStart: number}[] = [];
+	let offset = 0;
+	for (const line of lines) {
+		const heading = HEADING.exec(line);
+		if (heading !== null) {
+			found.push({
+				name: heading[1] ?? "",
+				headingStart: offset,
+				bodyStart: Math.min(offset + line.length + 1, text.length),
+			});
+		}
+		offset += line.length + 1;
+	}
+
+	const names = found.map((entry) => entry.name);
+	if (names.length !== SECTIONS.length || names.some((name, i) => name !== SECTIONS[i])) {
+		return {
+			_tag: "Malformed",
+			reason:
+				names.length === 0
+					? "the body carries no `## ` section heading at all"
+					: `the body carries [${names.join(", ")}] rather than the five sections in order [${SECTIONS.join(", ")}]`,
+		};
+	}
+
+	const spans = found.map(
+		(entry, i): readonly [number, number] => [
+			entry.bodyStart,
+			i + 1 < found.length ? (found[i + 1]?.headingStart ?? text.length) : text.length,
+		],
+	);
+	const sections = spans.map(([start, end]) => text.slice(start, end));
+
+	const decisionsRaw = bulletEntries(sections[1] ?? "");
+	if (decisionsRaw === null) {
+		return {_tag: "Malformed", reason: "a `## Decisions` line is neither an entry nor a continuation"};
+	}
+	const decisions: DecisionEntry[] = [];
+	for (const entry of decisionsRaw) {
+		const parsed = parseDecision(entry);
+		if (parsed === null) {
+			return {
+				_tag: "Malformed",
+				reason: `the decision "${entry}" cites no authority — expected "— ruled on #<session> R<round>.<n>" or "— from #<ticket>"`,
+			};
+		}
+		decisions.push(parsed);
+	}
+
+	const frontierRaw = bulletEntries(sections[2] ?? "");
+	if (frontierRaw === null) {
+		return {_tag: "Malformed", reason: "a `## Frontier` line is neither a row nor a continuation"};
+	}
+	const frontier: FrontierRow[] = [];
+	for (const entry of frontierRaw) {
+		const parsed = parseFrontier(entry);
+		if (parsed === null) {
+			return {
+				_tag: "Malformed",
+				reason: `the frontier row "${entry}" is not "#<n> · <${KINDS.join("|")}> — <question>"`,
+			};
+		}
+		frontier.push(parsed);
+	}
+
+	const outRaw = bulletEntries(sections[4] ?? "");
+	if (outRaw === null) {
+		return {_tag: "Malformed", reason: "an `## Out of scope` line is neither an entry nor a continuation"};
+	}
+	const outOfScope: OutOfScopeEntry[] = [];
+	for (const entry of outRaw) {
+		const parsed = parseOutOfScope(entry);
+		if (parsed === null) {
+			return {
+				_tag: "Malformed",
+				reason: `the out-of-scope entry "${entry}" is not "<direction>. <reason> — <YYYY-MM-DD>"`,
+			};
+		}
+		outOfScope.push(parsed);
+	}
+
+	return {
+		_tag: "Parsed",
+		value: {
+			raw: text,
+			sections,
+			spans,
+			destination: normalizeSection(sections[0] ?? ""),
+			decisions,
+			frontier,
+			fog: normalizeSection(sections[3] ?? "")
+				.split("\n")
+				.filter((line) => line.trim() !== "").length,
+			outOfScope,
+		},
+	};
+};
+
+/** The digest of a parsed body — the token every write guard compares against. */
+export const digestOfBody = (body: MapBody): string => digestOf(body.sections);
+
+/** One `## Frontier` row's bytes. */
+export const renderFrontierRow = (row: FrontierRow): string =>
+	`- #${row.ticket} · ${row.kind} — ${row.question}${row.forkedTo === null ? "" : ` — forked to #${row.forkedTo}`}`;
+
+/** One `## Decisions` entry's bytes, with the citation the verb composes rather than the caller. */
+export const renderDecision = (entry: DecisionEntry): string =>
+	entry.authority._tag === "Ruled"
+		? `- ${entry.text} — ruled on #${entry.authority.session} ${entry.authority.questionId}`
+		: `- ${entry.text} — from #${entry.authority.ticket}`;
+
+/** One `## Out of scope` entry's bytes. */
+export const renderOutOfScope = (entry: OutOfScopeEntry): string =>
+	`- ${entry.direction}. ${entry.reason} — ${entry.recordedAt}`;
+
+/**
+ * `body.raw` with one section's bytes replaced and every other byte copied verbatim.
+ *
+ * The surrounding blank lines are re-imposed rather than preserved so a section that was empty and a
+ * section that held entries render identically after the splice — otherwise the first write to an
+ * empty section would leave the heading glued to its first entry.
+ */
+export const spliceSection = (body: MapBody, section: SectionName, next: string): string => {
+	const index = SECTIONS.indexOf(section);
+	const span = body.spans[index];
+	if (span === undefined) return body.raw;
+	const trimmed = normalizeSection(next);
+	const isLast = index === SECTIONS.length - 1;
+	const replacement =
+		trimmed === "" ? (isLast ? "" : "\n") : isLast ? `${trimmed}\n` : `${trimmed}\n\n`;
+	return `${body.raw.slice(0, span[0])}${replacement}${body.raw.slice(span[1])}`;
+};
+
+/** The body `map open` mints: the destination, one fog bullet per question, three empty sections. */
+export const renderMintBody = (
+	destination: string,
+	questions: ReadonlyArray<string>,
+): string =>
+	[
+		"## Destination",
+		destination,
+		"",
+		"## Decisions",
+		"",
+		"## Frontier",
+		"",
+		"## Fog",
+		...questions.map((question) => `- ${question}`),
+		"",
+		"## Out of scope",
+		"",
+	].join("\n");

--- a/packages/fabrika-cli/src/map/body.ts
+++ b/packages/fabrika-cli/src/map/body.ts
@@ -26,7 +26,8 @@ export type SectionName = (typeof SECTIONS)[number];
 /** What clears a frontier ticket. A fourth value is a drift, not a kind. */
 export const KINDS = ["research", "prototype", "decision"] as const;
 export type Kind = (typeof KINDS)[number];
-export const isKind = (value: string): value is Kind => (KINDS as readonly string[]).includes(value);
+export const isKind = (value: string): value is Kind =>
+	(KINDS as readonly string[]).includes(value);
 
 /** One `## Frontier` row, as the body renders it. */
 export interface FrontierRow {
@@ -207,17 +208,18 @@ export const parseBody = (raw: string): BodyRead => {
 		};
 	}
 
-	const spans = found.map(
-		(entry, i): readonly [number, number] => [
-			entry.bodyStart,
-			i + 1 < found.length ? (found[i + 1]?.headingStart ?? text.length) : text.length,
-		],
-	);
+	const spans = found.map((entry, i): readonly [number, number] => [
+		entry.bodyStart,
+		i + 1 < found.length ? (found[i + 1]?.headingStart ?? text.length) : text.length,
+	]);
 	const sections = spans.map(([start, end]) => text.slice(start, end));
 
 	const decisionsRaw = bulletEntries(sections[1] ?? "");
 	if (decisionsRaw === null) {
-		return {_tag: "Malformed", reason: "a `## Decisions` line is neither an entry nor a continuation"};
+		return {
+			_tag: "Malformed",
+			reason: "a `## Decisions` line is neither an entry nor a continuation",
+		};
 	}
 	const decisions: DecisionEntry[] = [];
 	for (const entry of decisionsRaw) {
@@ -249,7 +251,10 @@ export const parseBody = (raw: string): BodyRead => {
 
 	const outRaw = bulletEntries(sections[4] ?? "");
 	if (outRaw === null) {
-		return {_tag: "Malformed", reason: "an `## Out of scope` line is neither an entry nor a continuation"};
+		return {
+			_tag: "Malformed",
+			reason: "an `## Out of scope` line is neither an entry nor a continuation",
+		};
 	}
 	const outOfScope: OutOfScopeEntry[] = [];
 	for (const entry of outRaw) {
@@ -316,10 +321,7 @@ export const spliceSection = (body: MapBody, section: SectionName, next: string)
 };
 
 /** The body `map open` mints: the destination, one fog bullet per question, three empty sections. */
-export const renderMintBody = (
-	destination: string,
-	questions: ReadonlyArray<string>,
-): string =>
+export const renderMintBody = (destination: string, questions: ReadonlyArray<string>): string =>
 	[
 		"## Destination",
 		destination,

--- a/packages/fabrika-cli/src/map/body.unit.test.ts
+++ b/packages/fabrika-cli/src/map/body.unit.test.ts
@@ -1,0 +1,168 @@
+import {describe, expect, it} from "vitest";
+import {normalizeForReadback} from "../report/compose.ts";
+import {
+	bulletEntries,
+	digestOf,
+	digestOfBody,
+	parseBody,
+	renderFrontierRow,
+	renderMintBody,
+	renderOutOfScope,
+	spliceSection,
+} from "./body.ts";
+import {MAP_BODY, MAP_BODY_WITH_REJECTION, parsed} from "./fixtures.test-support.ts";
+
+describe("parseBody", () => {
+	it("reads the five sections, their entries and the fog count", () => {
+		const body = parsed(MAP_BODY);
+		expect(body.destination).toBe("how moderation weight is earned");
+		expect(body.frontier).toEqual([
+			{
+				ticket: 9142,
+				kind: "research",
+				question: "which table carries the per-account weight column?",
+				forkedTo: null,
+			},
+		]);
+		expect(body.fog).toBe(1);
+		expect(body.decisions).toEqual([]);
+		expect(body.outOfScope).toEqual([]);
+	});
+
+	it("treats an empty section as well-formed — a freshly minted map must stay readable", () => {
+		const read = parseBody(renderMintBody("how weight is earned", []));
+		expect(read._tag).toBe("Parsed");
+	});
+
+	it("refuses a body whose sections are out of order, naming what it found", () => {
+		const read = parseBody(
+			"## Frontier\n\n## Destination\n\n## Decisions\n\n## Fog\n\n## Out of scope\n",
+		);
+		expect(read._tag).toBe("Malformed");
+		expect(read._tag === "Malformed" && read.reason).toContain("Frontier, Destination");
+	});
+
+	it("refuses a decision entry that cites no authority", () => {
+		const read = parseBody(
+			MAP_BODY.replace("## Decisions\n", "## Decisions\n- weight is earned per account\n"),
+		);
+		expect(read._tag === "Malformed" && read.reason).toContain("cites no authority");
+	});
+
+	it("reads both decision citations", () => {
+		const body = parsed(
+			MAP_BODY.replace(
+				"## Decisions\n",
+				"## Decisions\n- weight is earned per account — ruled on #9301 R2.3\n- the audit log records it — from #9146\n",
+			),
+		);
+		expect(body.decisions.map((entry) => entry.authority)).toEqual([
+			{_tag: "Ruled", session: 9301, questionId: "R2.3"},
+			{_tag: "Finding", ticket: 9146},
+		]);
+	});
+
+	it("reads a forked frontier row's route without folding it into the question", () => {
+		const body = parsed(
+			MAP_BODY.replace(
+				"- #9142 · research — which table carries the per-account weight column?",
+				"- #9144 · decision — does an invited çaylak start at 0 karma? — forked to #9301",
+			),
+		);
+		expect(body.frontier[0]).toEqual({
+			ticket: 9144,
+			kind: "decision",
+			question: "does an invited çaylak start at 0 karma?",
+			forkedTo: 9301,
+		});
+	});
+
+	it("refuses a frontier row whose kind is off the closed set", () => {
+		const read = parseBody(MAP_BODY.replace("· research —", "· investigation —"));
+		expect(read._tag === "Malformed" && read.reason).toContain("is not");
+	});
+
+	it("reads an out-of-scope entry and its date", () => {
+		expect(parsed(MAP_BODY_WITH_REJECTION).outOfScope).toEqual([
+			{
+				direction: "a per-topic weight multiplier",
+				reason: "It makes every moderation action's authority unreadable without a topic lookup",
+				recordedAt: "2026-06-29",
+			},
+		]);
+	});
+});
+
+describe("bulletEntries", () => {
+	it("folds a wrapped continuation back onto its entry", () => {
+		expect(bulletEntries("- one\n  and its tail\n- two")).toEqual(["one and its tail", "two"]);
+	});
+
+	it("refuses a line that is neither an entry nor a continuation", () => {
+		expect(bulletEntries("not a bullet")).toBeNull();
+	});
+});
+
+describe("digestOf", () => {
+	it("is twelve lowercase hex characters", () => {
+		expect(digestOfBody(parsed(MAP_BODY))).toMatch(/^[0-9a-f]{12}$/);
+	});
+
+	it("survives a normalizeForReadback round trip byte-identically", () => {
+		const before = digestOfBody(parsed(MAP_BODY));
+		const after = digestOfBody(parsed(`${normalizeForReadback(MAP_BODY)}\n`));
+		expect(after).toBe(before);
+	});
+
+	it("ignores a heading's trailing whitespace, which no verb writes", () => {
+		const spaced = MAP_BODY.replace("## Frontier", "## Frontier  ");
+		expect(digestOfBody(parsed(spaced))).toBe(digestOfBody(parsed(MAP_BODY)));
+	});
+
+	it("moves when any section body moves", () => {
+		expect(digestOf(["a", "", "", "", ""])).not.toBe(digestOf(["a", "b", "", "", ""]));
+	});
+});
+
+describe("spliceSection", () => {
+	it("changes one section and copies every other byte verbatim", () => {
+		const body = parsed(MAP_BODY);
+		const next = spliceSection(body, "Decisions", "- weight is earned per account — from #9146");
+		expect(next).toContain("- weight is earned per account — from #9146");
+		expect(next).toContain("- what clock does weight decay on?");
+		expect(parsed(next).frontier).toEqual(body.frontier);
+	});
+
+	it("re-imposes the blank line so a first write to an empty section stays parseable", () => {
+		const next = spliceSection(
+			parsed(MAP_BODY),
+			"Out of scope",
+			renderOutOfScope({
+				direction: "a per-topic weight multiplier",
+				reason: "it makes authority unreadable",
+				recordedAt: "2026-08-10",
+			}),
+		);
+		expect(parseBody(next)._tag).toBe("Parsed");
+		expect(parsed(next).outOfScope).toHaveLength(1);
+	});
+
+	it("empties a section without collapsing the body", () => {
+		const next = spliceSection(parsed(MAP_BODY), "Frontier", "");
+		expect(parsed(next).frontier).toEqual([]);
+		expect(parsed(next).fog).toBe(1);
+	});
+});
+
+describe("renderFrontierRow", () => {
+	it("round-trips through the parser", () => {
+		const row = {
+			ticket: 9144,
+			kind: "decision" as const,
+			question: "does it decay?",
+			forkedTo: 9301,
+		};
+		const next = spliceSection(parsed(MAP_BODY), "Frontier", renderFrontierRow(row));
+		expect(parsed(next).frontier).toEqual([row]);
+	});
+});

--- a/packages/fabrika-cli/src/map/codes.ts
+++ b/packages/fabrika-cli/src/map/codes.ts
@@ -1,0 +1,80 @@
+/**
+ * The one exit table all eight `map` verbs allocate from, so a code means one thing across this
+ * group whichever verb produced it (`claude-plugins/fabrika/skills/wayfinding/contract.md`).
+ *
+ * The overlap with `report` is **re-exported, never re-typed**: an aligning group imports the base's
+ * constant, so a drift is unrepresentable rather than merely detectable. This group shares eight
+ * seats over `3`-`9` and `11`, and adds `12`-`21` for facts about a map — its body guard, its
+ * frontier tickets, their edges, their lanes, and the two never-graduating refusals.
+ *
+ * Seat `10` is the one seat this group deliberately leaves empty. The base's `10` fires when a title
+ * or label carries a type or priority classification; no `map` verb accepts a label flag, none writes
+ * a classification label, and `map open` and `map ticket` compose their titles without classifying
+ * them — so the condition is unreachable rather than merely unused, and a second meaning seated here
+ * would collide with the base for no gain.
+ *
+ * `0`, `1`, `2` and `127` are reserved by the interface convention (`../verb.ts`, `../bin.ts`).
+ */
+
+import {
+	BAD_SECTIONS as REPORT_BAD_SECTIONS,
+	BARE_AT_PATH as REPORT_BARE_AT_PATH,
+	CLASSIFIED as REPORT_CLASSIFIED,
+	EMPTY_STDIN as REPORT_EMPTY_STDIN,
+	LEAKED_PATH as REPORT_LEAKED_PATH,
+	NO_TARGET as REPORT_NO_TARGET,
+	PRECONDITION_UNKNOWN as REPORT_PRECONDITION_UNKNOWN,
+	READBACK_MISMATCH as REPORT_READBACK_MISMATCH,
+	WRITE_UNKNOWN as REPORT_WRITE_UNKNOWN,
+} from "../report/codes.ts";
+
+/** The aligned classification seat, held empty — no `map` verb runs that check at all. */
+export const DELIBERATE_GAP = REPORT_CLASSIFIED;
+
+/** Stdin was read and held nothing. `map open` only — no other verb reads fd 0. */
+export const EMPTY_STDIN = REPORT_EMPTY_STDIN;
+/** A required section is missing, out of order, or holds an unparseable entry. */
+export const BAD_SECTIONS = REPORT_BAD_SECTIONS;
+/** The text carries a machine-local path. No `map` verb offers `--redact`, so this is unconditional. */
+export const LEAKED_PATH = REPORT_LEAKED_PATH;
+/** The text is a bare `@` path reference — not redactable, so a second code. */
+export const BARE_AT_PATH = REPORT_BARE_AT_PATH;
+/** Proven: the map issue, or the label a map is found by, does not exist. */
+export const NO_TARGET = REPORT_NO_TARGET;
+/** The write itself failed, so the outcome is **UNKNOWN** — deliberately not `1`. */
+export const WRITE_UNKNOWN = REPORT_WRITE_UNKNOWN;
+/** The write landed and the read-back differs. The artifact exists and needs a human. */
+export const READBACK_MISMATCH = REPORT_READBACK_MISMATCH;
+/** A precondition read failed, so nothing was written and no outcome is proven. */
+export const PRECONDITION_UNKNOWN = REPORT_PRECONDITION_UNKNOWN;
+
+/**
+ * Proven: the body moved since `--digest` was taken, so the write is refused.
+ *
+ * Its own seat rather than `9`: nothing was written here, where `9` means a write landed wrong.
+ */
+export const DIGEST_STALE = 12;
+/** Proven: the number names no frontier ticket of this map. */
+export const TICKET_UNKNOWN = 13;
+/** Proven: an edge target is not a ticket of this map, or the edge would close a cycle. */
+export const EDGE_UNRESOLVABLE = 14;
+/** Proven: the supplied nonce does not hold this ticket's lane. */
+export const LANE_NOT_MINE = 15;
+/** Proven: more than one open map matches the destination — which one is undecidable. */
+export const MAP_AMBIGUOUS = 16;
+/**
+ * Proven: no supplied line is stated as a question, so the destination carries no open question.
+ *
+ * Deliberately not {@link BAD_SECTIONS}: `4` says *fix the text*, this says *file it in intake
+ * instead*, and overloading an imported constant with a second meaning is the drift the import
+ * exists to stop.
+ */
+export const NOT_FOG = 17;
+/** Proven: the ticket already left the frontier — graduated or retired. */
+export const TICKET_RETIRED = 18;
+/** Proven: the destination or direction is already recorded out of scope. */
+export const ALREADY_DESCOPED = 19;
+/** Proven: the ticket's kind does not admit this verb. */
+export const KIND_MISMATCH = 20;
+/** Proven: the lane returned no answer, so there is nothing to record. */
+export const OUTCOME_UNRECORDABLE = 21;

--- a/packages/fabrika-cli/src/map/command.ts
+++ b/packages/fabrika-cli/src/map/command.ts
@@ -1,0 +1,334 @@
+/**
+ * The `map` verb group — `fabrika map <open|read|ticket|lane|finding|fork|record|descope>`, the
+ * `wayfinding` skill's half of the ideation layer.
+ *
+ * The adapter and nothing else: it declares the flags (`--help` is the interface, so every flag
+ * carries a one-line description), runs the pure verb, and emits its outcome. Every decision lives in
+ * the `*-verb.ts` modules beside it, which is what makes each refusal testable without spawning a
+ * process.
+ *
+ * **Every leaf is declared with `leafCommand`, never a bare `Command.make`** — the bare form silently
+ * opts out of the excess-operand guard, which `../excess-operand.unit.test.ts` reds on.
+ *
+ * **The answer channel is machine, unconditionally, so there is no `--json` flag.** v1's structured
+ * output was opt-in behind `--json` while the default was English prose, so the shape a skill
+ * captured by default was sentences.
+ *
+ * **`--kind` and `--outcome` are declared as strings and checked in the verb.** The check is the
+ * closed set's, and seating it in the verb is what lets the refusal name the whole vocabulary rather
+ * than emit the parser's generic message; it still exits `1`, which is where an off-vocabulary flag
+ * value belongs.
+ */
+
+import {randomBytes} from "node:crypto";
+import {Effect, Option} from "effect";
+import {Argument, Command, Flag} from "effect/unstable/cli";
+import {leafCommand} from "../excess-operand.ts";
+import {readStdin} from "../io/stdin.ts";
+import type {VerbOutcome} from "../verb.ts";
+import {KINDS} from "./body.ts";
+import {runDescope} from "./descope-verb.ts";
+import {runFinding} from "./finding-verb.ts";
+import {runFork} from "./fork-verb.ts";
+import {runLane} from "./lane-verb.ts";
+import {OUTCOMES} from "./markers.ts";
+import {runOpen} from "./open-verb.ts";
+import {runRead} from "./read-verb.ts";
+import {runRecord} from "./record-verb.ts";
+import {runTicket} from "./ticket-verb.ts";
+
+/** Write the outcome and exit on its code — stdout is the answer, everything else is stderr. */
+const emit = (outcome: VerbOutcome): Effect.Effect<void> =>
+	Effect.sync(() => {
+		for (const line of outcome.stderr) process.stderr.write(`${line}\n`);
+		if (outcome.stdout !== "") process.stdout.write(outcome.stdout);
+		process.exit(outcome.code);
+	});
+
+const repoFlag = Flag.string("repo").pipe(
+	Flag.optional,
+	Flag.withDescription(
+		"the target owner/name (default: $CLAUDE_PIPELINE_REPO, else $GITHUB_REPOSITORY, else the origin remote)",
+	),
+);
+
+const mapArg = Argument.integer("map").pipe(
+	Argument.withDescription("the map issue this verb acts on"),
+);
+
+const digestFlag = Flag.string("digest").pipe(
+	Flag.withDescription(
+		"the 12-lowercase-hex body digest `map read` printed; the write is refused with 12 if the body moved",
+	),
+);
+
+const ticketFlag = Flag.integer("ticket").pipe(
+	Flag.withDescription("the frontier ticket this verb acts on"),
+);
+
+const nonceFlag = Flag.string("nonce").pipe(
+	Flag.withDescription(
+		"this run's lane key, eight lowercase hex characters — generated once per run and passed explicitly, never inferred from the environment",
+	),
+);
+
+const open = leafCommand(
+	"open",
+	{
+		destination: Flag.string("destination").pipe(
+			Flag.withDescription(
+				"the fog to chart, as a short noun phrase; becomes the map's title and its `## Destination`",
+			),
+		),
+		repo: repoFlag,
+	},
+	Effect.fn(function* ({destination, repo}) {
+		yield* emit(
+			yield* runOpen({
+				destination,
+				repo: Option.getOrNull(repo),
+				env: process.env,
+				stdin: Effect.sync(readStdin),
+			}),
+		);
+	}),
+).pipe(
+	Command.withDescription(
+		'Mint or resume the map for a destination, reading the caller\'s open questions from STDIN one per line. Prints {"map":n,"created":bool,"destination":"…","questions":k,"answeredCandidates":[…],"digest":"…","scanned":{…}}. Exits 3 (stdin held no question), 4 (an existing map\'s body does not parse), 5/6 (machine-local path, bare @ reference), 7 (no wayfinding:map label), 8/9 (create or label write failed, read-back differs), 11 (the map search or a board read failed — nothing written), 16 (two or more open maps match), 17 (no supplied line is stated as a question), 19 (already recorded out of scope). Example: printf \'does a suspended account keep its weight?\\n\' | fabrika map open --destination "how moderation weight is earned"',
+	),
+);
+
+const read = leafCommand(
+	"read",
+	{map: mapArg, repo: repoFlag},
+	Effect.fn(function* ({map, repo}) {
+		yield* emit(yield* runRead({map, repo: Option.getOrNull(repo), env: process.env}));
+	}),
+).pipe(
+	Command.withDescription(
+		'The map\'s whole state: five sections, one row per frontier ticket with a closed-set state, the frontier token and the body digest. Prints {"map":n,"frontier":"awaiting-founder|lanes-pending|clear|empty","digest":"…","destination":"…","tickets":[…],"outOfScope":[…],"fog":k,"counts":{…},"disregarded":[…],"scanned":{…}} — all four frontier tokens exit 0. Exits 4 (the body does not hold the five sections in order), 7 (no such map), 11 (a child, edge or comment read failed — the frontier is UNKNOWN, never empty). Example: fabrika map read 9140',
+	),
+);
+
+const ticket = leafCommand(
+	"ticket",
+	{
+		map: mapArg,
+		digest: digestFlag,
+		kind: Flag.string("kind").pipe(
+			Flag.withDescription(`what clears this ticket: one of ${KINDS.join(", ")}`),
+		),
+		question: Flag.string("question").pipe(
+			Flag.withDescription("the open question, stated without answering it"),
+		),
+		blocks: Flag.integer("blocks").pipe(
+			Flag.atLeast(0),
+			Flag.withDescription(
+				"a ticket of this map that cannot proceed until this one clears; repeatable",
+			),
+		),
+		blockedBy: Flag.integer("blocked-by").pipe(
+			Flag.atLeast(0),
+			Flag.withDescription("a ticket of this map this one waits on; repeatable"),
+		),
+		repo: repoFlag,
+	},
+	Effect.fn(function* ({map, digest, kind, question, blocks, blockedBy, repo}) {
+		yield* emit(
+			yield* runTicket({
+				map,
+				digest,
+				kind,
+				question,
+				blocks,
+				blockedBy,
+				repo: Option.getOrNull(repo),
+				env: process.env,
+				nonce: () => randomBytes(4).toString("hex"),
+			}),
+		);
+	}),
+).pipe(
+	Command.withDescription(
+		'File a frontier ticket, link it as a sub-issue, set its blocking edges and splice its row onto the map — one act, preconditions resolved before anything is written. Prints {"map":n,"ticket":c,"kind":"…","blockedBy":[…],"blocking":[…],"digest":"…"}. Exits 4 (the map body does not parse), 5/6 (leak), 7 (no such map), 8/9 (a write failed, read-back differs), 11 (a precondition read failed), 12 (the body moved since --digest), 13 (an edge target is not a ticket of this map), 14 (the edge would cycle, or an id could not be resolved), 18 (an edge target already left the frontier), 19 (the question restates a rejected direction). Example: fabrika map ticket 9140 --digest a1b2c3d4e5f6 --kind research --question "does better-auth mint a single-use token without a new table?"',
+	),
+);
+
+const lane = leafCommand(
+	"lane",
+	{map: mapArg, ticket: ticketFlag, nonce: nonceFlag, repo: repoFlag},
+	Effect.fn(function* ({map, ticket: number, nonce, repo}) {
+		yield* emit(
+			yield* runLane({map, ticket: number, nonce, repo: Option.getOrNull(repo), env: process.env}),
+		);
+	}),
+).pipe(
+	Command.withDescription(
+		'Claim a research lane on one ticket, keyed on the run nonce. Prints {"map":n,"ticket":t,"nonce":"…","lane":"held|resumed"}. Exits 7 (no such map), 8/9 (the claim write failed, read-back differs), 11 (the comment read failed — whether a lane is held is UNKNOWN, never free), 13 (not a ticket of this map), 15 (another nonce holds the lane), 18 (the ticket already left the frontier), 20 (a decision ticket is routed, never researched). Example: fabrika map lane 9140 --ticket 9143 --nonce 7f3a9c21',
+	),
+);
+
+const finding = leafCommand(
+	"finding",
+	{
+		map: mapArg,
+		ticket: ticketFlag,
+		nonce: nonceFlag,
+		outcome: Flag.string("outcome").pipe(
+			Flag.withDescription(`what the lane established: one of ${OUTCOMES.join(", ")}`),
+		),
+		finding: Flag.string("finding").pipe(
+			Flag.optional,
+			Flag.withDescription(
+				"a path holding the finding; required with --outcome answered, optional otherwise",
+			),
+		),
+		repo: repoFlag,
+	},
+	Effect.fn(function* ({map, ticket: number, nonce, outcome, finding: path, repo}) {
+		yield* emit(
+			yield* runFinding({
+				map,
+				ticket: number,
+				nonce,
+				outcome,
+				finding: Option.getOrNull(path),
+				repo: Option.getOrNull(repo),
+				env: process.env,
+			}),
+		);
+	}),
+).pipe(
+	Command.withDescription(
+		'Close a lane with an outcome from a closed set, writing on the TICKET and never on the map body. Prints {"map":n,"ticket":t,"outcome":"…","comment":id,"lane":"released"}. Exits 4 (--outcome answered with no --finding, or an empty finding), 5/6 (leak), 7 (no such map), 8/9 (the comment write failed, read-back differs), 11 (a precondition read failed), 13 (not a ticket of this map), 15 (this nonce does not hold the lane), 18 (the ticket already left the frontier), 20 (a decision has no lane). Example: fabrika map finding 9140 --ticket 9143 --nonce 7f3a9c21 --outcome no-evidence',
+	),
+);
+
+const fork = leafCommand(
+	"fork",
+	{
+		map: mapArg,
+		digest: digestFlag,
+		ticket: ticketFlag,
+		session: Flag.integer("session").pipe(
+			Flag.optional,
+			Flag.withDescription(
+				"the grilling session issue the decision now lives in; admitted only for a decision ticket",
+			),
+		),
+		spike: Flag.integer("spike").pipe(
+			Flag.optional,
+			Flag.withDescription(
+				"the prototyping spike issue the empirical question now lives in; admitted only for a prototype ticket",
+			),
+		),
+		repo: repoFlag,
+	},
+	Effect.fn(function* ({map, digest, ticket: number, session, spike, repo}) {
+		yield* emit(
+			yield* runFork({
+				map,
+				digest,
+				ticket: number,
+				session: Option.getOrNull(session),
+				spike: Option.getOrNull(spike),
+				repo: Option.getOrNull(repo),
+				env: process.env,
+			}),
+		);
+	}),
+).pipe(
+	Command.withDescription(
+		'Record that a ticket\'s question is being answered elsewhere — a decision in a grilling session, an empirical question in a prototyping spike. Which flag is admitted is decided by the ticket\'s kind, not by the caller. Prints {"map":n,"ticket":t,"session|spike":s,"state":"forked","digest":"…"}. Exits 4 (the map body does not parse), 5/6 (leak), 7 (no such map), 8/9 (a write failed, read-back differs), 11 (a precondition read failed), 12 (the body moved), 13 (not a ticket of this map, or --session is not a grilling session), 18 (already left the frontier), 20 (the kind does not admit this route). Example: fabrika map fork 9140 --digest a1b2c3d4e5f6 --ticket 9144 --session 9301',
+	),
+);
+
+const record = leafCommand(
+	"record",
+	{
+		map: mapArg,
+		digest: digestFlag,
+		ticket: ticketFlag,
+		finding: Flag.string("finding").pipe(
+			Flag.withDescription("a path holding the answer, as it will read under `## Decisions`"),
+		),
+		ruledOn: Flag.integer("ruled-on").pipe(
+			Flag.optional,
+			Flag.withDescription("the grilling session the ruling was recorded in; required for a forked decision"),
+		),
+		spike: Flag.integer("spike").pipe(
+			Flag.optional,
+			Flag.withDescription("the prototyping spike whose captured decision this records; required for a forked prototype"),
+		),
+		questionId: Flag.string("question-id").pipe(
+			Flag.optional,
+			Flag.withDescription("the question id in that session, matching R<round>.<n>; required with --ruled-on"),
+		),
+		repo: repoFlag,
+	},
+	Effect.fn(function* ({map, digest, ticket: number, finding: path, ruledOn, spike, questionId, repo}) {
+		yield* emit(
+			yield* runRecord({
+				map,
+				digest,
+				ticket: number,
+				finding: path,
+				ruledOn: Option.getOrNull(ruledOn),
+				spike: Option.getOrNull(spike),
+				questionId: Option.getOrNull(questionId),
+				repo: Option.getOrNull(repo),
+				env: process.env,
+			}),
+		);
+	}),
+).pipe(
+	Command.withDescription(
+		'The lockstep: the answer lands under `## Decisions` and the ticket\'s row leaves `## Frontier` in ONE body write, then the sub-issue closes. Prints {"map":n,"ticket":t,"recorded":"— from #t","closed":true,"digest":"…"}. Exits 4 (the body does not parse, or --finding is empty), 5/6 (leak), 7 (no such map), 8/9 (a write failed, read-back differs), 11 (a precondition read failed — including a forked decision, whose ruling state only the grill reader may resolve), 12 (the body moved), 13 (not a ticket of this map, or its ruling does not read ruled), 18 (already left the frontier), 21 (the lane returned unreachable, so there is no answer to record). Example: fabrika map record 9140 --digest a1b2c3d4e5f6 --ticket 9143 --finding finding.md',
+	),
+);
+
+const descope = leafCommand(
+	"descope",
+	{
+		map: mapArg,
+		digest: digestFlag,
+		direction: Flag.string("direction").pipe(
+			Flag.withDescription("the rejected direction, as a short noun phrase"),
+		),
+		reason: Flag.string("reason").pipe(
+			Flag.withDescription("a path holding why it was rejected; quoted onto the map verbatim"),
+		),
+		ticket: Flag.integer("ticket").pipe(
+			Flag.optional,
+			Flag.withDescription(
+				"a frontier ticket this direction retires — the second exit off the frontier, for a question nobody can answer",
+			),
+		),
+		repo: repoFlag,
+	},
+	Effect.fn(function* ({map, digest, direction, reason, ticket: number, repo}) {
+		yield* emit(
+			yield* runDescope({
+				map,
+				digest,
+				direction,
+				reason,
+				ticket: Option.getOrNull(number),
+				repo: Option.getOrNull(repo),
+				env: process.env,
+				now: () => new Date(),
+			}),
+		);
+	}),
+).pipe(
+	Command.withDescription(
+		'Append a rejected direction and its reasoning to the never-graduating out-of-scope section, optionally retiring the frontier ticket that asked it. Prints {"map":n,"direction":"…","entries":k,"digest":"…"}. Exits 4 (the body does not parse, or --reason is empty), 5/6 (leak), 7 (no such map), 8/9 (the write failed, read-back differs or the section did not grow by exactly one), 11 (a precondition read failed), 12 (the body moved), 13 (--ticket is not a ticket of this map), 18 (--ticket already left the frontier), 19 (already out of scope). Example: fabrika map descope 9140 --digest a1b2c3d4e5f6 --direction "a per-topic weight multiplier" --reason reason.md',
+	),
+);
+
+export const mapCommand = Command.make("map").pipe(
+	Command.withSubcommands([open, read, ticket, lane, finding, fork, record, descope]),
+	Command.withDescription(
+		"Chart one destination's fog: mint the map, decompose it into frontier tickets with native dependency edges, run lanes under a run nonce, route decisions to grilling and empirical questions to prototyping, and record each answer in lockstep",
+	),
+);

--- a/packages/fabrika-cli/src/map/command.ts
+++ b/packages/fabrika-cli/src/map/command.ts
@@ -254,19 +254,34 @@ const record = leafCommand(
 		),
 		ruledOn: Flag.integer("ruled-on").pipe(
 			Flag.optional,
-			Flag.withDescription("the grilling session the ruling was recorded in; required for a forked decision"),
+			Flag.withDescription(
+				"the grilling session the ruling was recorded in; required for a forked decision",
+			),
 		),
 		spike: Flag.integer("spike").pipe(
 			Flag.optional,
-			Flag.withDescription("the prototyping spike whose captured decision this records; required for a forked prototype"),
+			Flag.withDescription(
+				"the prototyping spike whose captured decision this records; required for a forked prototype",
+			),
 		),
 		questionId: Flag.string("question-id").pipe(
 			Flag.optional,
-			Flag.withDescription("the question id in that session, matching R<round>.<n>; required with --ruled-on"),
+			Flag.withDescription(
+				"the question id in that session, matching R<round>.<n>; required with --ruled-on",
+			),
 		),
 		repo: repoFlag,
 	},
-	Effect.fn(function* ({map, digest, ticket: number, finding: path, ruledOn, spike, questionId, repo}) {
+	Effect.fn(function* ({
+		map,
+		digest,
+		ticket: number,
+		finding: path,
+		ruledOn,
+		spike,
+		questionId,
+		repo,
+	}) {
 		yield* emit(
 			yield* runRecord({
 				map,

--- a/packages/fabrika-cli/src/map/descope-verb.ts
+++ b/packages/fabrika-cli/src/map/descope-verb.ts
@@ -17,7 +17,7 @@
  * so without a retiring path it would hold the frontier forever and `graduate` could never run.
  */
 
-import {Effect, FileSystem} from "effect";
+import {Effect, type FileSystem} from "effect";
 import type {ChildProcessSpawner} from "effect/unstable/process";
 import {readFile} from "../io/fs.ts";
 import {closeCompleted, createComment, getIssue, patchIssueBody} from "../io/issues.ts";
@@ -26,19 +26,13 @@ import {appendOnly} from "../review/append.ts";
 import {answer, FAILED, refuse, type VerbOutcome} from "../verb.ts";
 import {
 	digestOf,
-	normalizeSection,
 	type OutOfScopeEntry,
 	parseBody,
 	renderFrontierRow,
 	renderOutOfScope,
 	spliceSection,
 } from "./body.ts";
-import {
-	ALREADY_DESCOPED,
-	BAD_SECTIONS,
-	READBACK_MISMATCH,
-	WRITE_UNKNOWN,
-} from "./codes.ts";
+import {ALREADY_DESCOPED, BAD_SECTIONS, READBACK_MISMATCH, WRITE_UNKNOWN} from "./codes.ts";
 import {
 	digestFresh,
 	leakFree,
@@ -80,7 +74,10 @@ export const runDescope = (
 	Effect.gen(function* () {
 		const direction = options.direction.trim();
 		if (direction === "") {
-			return refuse(FAILED, `${VERB}: --direction is empty — refusing to reject an unnamed direction.`);
+			return refuse(
+				FAILED,
+				`${VERB}: --direction is empty — refusing to reject an unnamed direction.`,
+			);
 		}
 
 		const read = yield* readFile(options.reason).pipe(
@@ -146,14 +143,25 @@ export const runDescope = (
 			reason: reason.replace(/\.$/, ""),
 			recordedAt: options.now().toISOString().slice(0, 10),
 		};
-		const previous = normalizeSection(found.value.body.sections[4] ?? "");
-		const composed = [...found.value.body.outOfScope.map(renderOutOfScope), renderOutOfScope(entry)]
-			.join("\n");
-		const fence = appendOnly(previous, composed);
-		if (fence._tag === "Violates") {
+		const priorEntries = found.value.body.outOfScope.map(renderOutOfScope);
+		const composed = [...priorEntries, renderOutOfScope(entry)].join("\n");
+		// The fence compares RENDERED entries, not the raw section bytes, and the empty case is its own
+		// arm: `appendOnly` counts lines, and an empty section splits to one empty line, so a first
+		// entry would read as "the composed section has 1 line, expected 2" and refuse the ordinary
+		// opening write.
+		const violation =
+			priorEntries.length === 0
+				? composed === renderOutOfScope(entry)
+					? null
+					: "the composed section is not exactly this one entry"
+				: (() => {
+						const fence = appendOnly(priorEntries.join("\n"), composed);
+						return fence._tag === "Violates" ? fence.reason : null;
+					})();
+		if (violation !== null) {
 			return refuse(
 				READBACK_MISMATCH,
-				`${VERB}: the composed out-of-scope section is not the old one plus this entry (${fence.reason}) — nothing was written.`,
+				`${VERB}: the composed out-of-scope section is not the old one plus this entry (${violation}) — nothing was written.`,
 			);
 		}
 

--- a/packages/fabrika-cli/src/map/descope-verb.ts
+++ b/packages/fabrika-cli/src/map/descope-verb.ts
@@ -1,0 +1,243 @@
+/**
+ * `map descope` — append a rejected direction and its reasoning to the never-graduating out-of-scope
+ * section, optionally retiring the frontier ticket that asked it.
+ *
+ * <!-- anchor: OUT-OF-SCOPE-NEVER-GRADUATES --> **This section is append-only and has no removal
+ * path, by construction: no verb in this group deletes from it.** Every other section empties as fog
+ * clears; this one is the map's memory of what was decided *against*, and an entry that can be
+ * removed is one the next session re-proposes. Reversing a rejection is a new decision under
+ * `## Decisions` naming the entry it overturns — both stay on the record.
+ *
+ * **The fence is checked, not assumed.** The composed section is validated with `appendOnly` and a
+ * re-parse that must hold every prior entry plus exactly one more; a write that would drop or mutate
+ * an existing entry refuses, because the read-back proves the body no longer holds what it held.
+ *
+ * <!-- anchor: EVERY-TICKET-HAS-AN-EXIT --> `--ticket` is the second exit off the frontier, and it is
+ * what keeps `clear` reachable: a question whose lane returned `unreachable` has no answer to record,
+ * so without a retiring path it would hold the frontier forever and `graduate` could never run.
+ */
+
+import {Effect, FileSystem} from "effect";
+import type {ChildProcessSpawner} from "effect/unstable/process";
+import {readFile} from "../io/fs.ts";
+import {closeCompleted, createComment, getIssue, patchIssueBody} from "../io/issues.ts";
+import {normalizeForReadback} from "../report/compose.ts";
+import {appendOnly} from "../review/append.ts";
+import {answer, FAILED, refuse, type VerbOutcome} from "../verb.ts";
+import {
+	digestOf,
+	normalizeSection,
+	type OutOfScopeEntry,
+	parseBody,
+	renderFrontierRow,
+	renderOutOfScope,
+	spliceSection,
+} from "./body.ts";
+import {
+	ALREADY_DESCOPED,
+	BAD_SECTIONS,
+	READBACK_MISMATCH,
+	WRITE_UNKNOWN,
+} from "./codes.ts";
+import {
+	digestFresh,
+	leakFree,
+	notTerminal,
+	requireMap,
+	requireTicket,
+	targetRepo,
+} from "./guards.ts";
+import {composeRetiredMarker} from "./markers.ts";
+import {namesSameThing} from "./open.ts";
+
+export interface DescopeOptions {
+	readonly map: number;
+	readonly digest: string;
+	readonly direction: string;
+	readonly reason: string;
+	/**
+	 * The frontier ticket this direction retires, when the rejection is also a ticket's exit.
+	 *
+	 * Optional, and named in the contract's exit table (`13`/`18`) and in `map record`'s refusal text
+	 * rather than in its Inputs table — see the spec-defect note on #5022.
+	 */
+	readonly ticket: number | null;
+	readonly repo: string | null;
+	readonly env: Readonly<Record<string, string | undefined>>;
+	/** Today, injected so an appended entry is byte-reproducible in a test. */
+	readonly now: () => Date;
+}
+
+const VERB = "map descope";
+
+export const runDescope = (
+	options: DescopeOptions,
+): Effect.Effect<
+	VerbOutcome,
+	never,
+	ChildProcessSpawner.ChildProcessSpawner | FileSystem.FileSystem
+> =>
+	Effect.gen(function* () {
+		const direction = options.direction.trim();
+		if (direction === "") {
+			return refuse(FAILED, `${VERB}: --direction is empty — refusing to reject an unnamed direction.`);
+		}
+
+		const read = yield* readFile(options.reason).pipe(
+			Effect.map((value) => ({ok: true as const, value})),
+			Effect.catchTag("fabrika-cli/ReadFailed", (cause) =>
+				Effect.succeed({ok: false as const, value: cause.reason}),
+			),
+		);
+		if (!read.ok) {
+			return refuse(
+				FAILED,
+				`${VERB}: could not read --reason ${options.reason}: ${read.value} — the reasoning is UNKNOWN, never empty.`,
+			);
+		}
+		// One line: the section's entries are one bullet each, so a multi-line reason is folded rather
+		// than allowed to split into entries the parser would read as separate rejections.
+		const reason = read.value.trim().replace(/\s*\n\s*/g, " ");
+		if (reason === "") {
+			return refuse(
+				BAD_SECTIONS,
+				`${VERB}: --reason ${options.reason} is empty — an out-of-scope entry with no reasoning is one the next session re-proposes.`,
+			);
+		}
+		const leaked = leakFree(VERB, "direction", direction) ?? leakFree(VERB, "reason", reason);
+		if (leaked !== null) return leaked;
+
+		const target = yield* targetRepo(VERB, options.repo, options.env);
+		if (target._tag === "Refused") return target.outcome;
+		const repo = target.value;
+
+		const found = yield* requireMap(VERB, repo, options.map);
+		if (found._tag === "Refused") return found.outcome;
+		const stale = digestFresh(VERB, options.map, found.value.body, options.digest);
+		if (stale !== null) return stale;
+
+		const already = found.value.body.outOfScope.find((entry) =>
+			namesSameThing(direction, entry.direction),
+		);
+		if (already !== undefined) {
+			return refuse(
+				ALREADY_DESCOPED,
+				`${VERB}: "${direction}" is already out of scope on #${options.map} (${already.recordedAt}) — nothing was written; the recorded reasoning stands.`,
+			);
+		}
+
+		let retiring: number | null = null;
+		if (options.ticket !== null) {
+			const resolved = yield* requireTicket(
+				VERB,
+				repo,
+				options.map,
+				found.value.body,
+				options.ticket,
+			);
+			if (resolved._tag === "Refused") return resolved.outcome;
+			const left = notTerminal(VERB, resolved.value.ticket, "there is nothing left to retire.");
+			if (left !== null) return left;
+			retiring = options.ticket;
+		}
+
+		const entry: OutOfScopeEntry = {
+			direction,
+			reason: reason.replace(/\.$/, ""),
+			recordedAt: options.now().toISOString().slice(0, 10),
+		};
+		const previous = normalizeSection(found.value.body.sections[4] ?? "");
+		const composed = [...found.value.body.outOfScope.map(renderOutOfScope), renderOutOfScope(entry)]
+			.join("\n");
+		const fence = appendOnly(previous, composed);
+		if (fence._tag === "Violates") {
+			return refuse(
+				READBACK_MISMATCH,
+				`${VERB}: the composed out-of-scope section is not the old one plus this entry (${fence.reason}) — nothing was written.`,
+			);
+		}
+
+		let next = spliceSection(found.value.body, "Out of scope", composed);
+		if (retiring !== null) {
+			const withEntry = parseBody(next);
+			if (withEntry._tag === "Malformed") {
+				return refuse(
+					BAD_SECTIONS,
+					`${VERB}: #${options.map}'s body stops parsing once the entry is appended (${withEntry.reason}) — nothing was written.`,
+				);
+			}
+			next = spliceSection(
+				withEntry.value,
+				"Frontier",
+				withEntry.value.frontier
+					.filter((row) => row.ticket !== retiring)
+					.map(renderFrontierRow)
+					.join("\n"),
+			);
+		}
+
+		const scope = `${VERB}: ${repo}, ${found.value.body.outOfScope.length} existing out-of-scope entry(ies)${retiring === null ? "" : `, retiring #${retiring}`}.`;
+		const written = yield* patchIssueBody(repo, options.map, next);
+		if (written._tag === "Failure") {
+			return refuse(
+				WRITE_UNKNOWN,
+				`${VERB}: could not write #${options.map}'s body: ${written.reason} — whether the rejection landed is UNKNOWN.`,
+				[scope],
+			);
+		}
+		const landed = yield* getIssue(repo, options.map);
+		if (
+			landed._tag !== "Present" ||
+			normalizeForReadback(landed.value.body) !== normalizeForReadback(next)
+		) {
+			return refuse(
+				READBACK_MISMATCH,
+				`${VERB}: wrote #${options.map}'s body and the read-back differs — the map needs fixing by hand.`,
+				[scope],
+			);
+		}
+		const reparsed = parseBody(landed.value.body);
+		if (
+			reparsed._tag === "Malformed" ||
+			reparsed.value.outOfScope.length !== found.value.body.outOfScope.length + 1
+		) {
+			return refuse(
+				READBACK_MISMATCH,
+				`${VERB}: wrote #${options.map}'s body and the out-of-scope section did not grow by exactly one entry — the map needs fixing by hand.`,
+				[scope],
+			);
+		}
+
+		if (retiring !== null) {
+			const marker = yield* createComment(
+				repo,
+				retiring,
+				composeRetiredMarker({map: options.map, ticket: retiring, direction}),
+			);
+			if (marker._tag === "Failure") {
+				return refuse(
+					WRITE_UNKNOWN,
+					`${VERB}: recorded the rejection on #${options.map} and the retire marker on #${retiring} did NOT land — the entry is on the map and the ticket is not retired.`,
+					[scope],
+				);
+			}
+			const closed = yield* closeCompleted(repo, retiring);
+			if (closed._tag === "Failure") {
+				return refuse(
+					WRITE_UNKNOWN,
+					`${VERB}: recorded the rejection on #${options.map} and the close of #${retiring} did NOT land — close #${retiring} by hand.`,
+					[scope],
+				);
+			}
+		}
+
+		return answer(
+			JSON.stringify({
+				map: options.map,
+				direction,
+				entries: reparsed.value.outOfScope.length,
+				digest: digestOf(reparsed.value.sections),
+			}),
+			[scope],
+		);
+	});

--- a/packages/fabrika-cli/src/map/descope-verb.unit.test.ts
+++ b/packages/fabrika-cli/src/map/descope-verb.unit.test.ts
@@ -1,0 +1,201 @@
+import {Effect, Layer} from "effect";
+import {describe, expect, it} from "vitest";
+import {fakeFs, fakeShell, okOut, once} from "../fakes.test-support.ts";
+import type {ExecResult} from "../io/exec.ts";
+import {renderOutOfScope, spliceSection} from "./body.ts";
+import {ALREADY_DESCOPED, BAD_SECTIONS, DIGEST_STALE, TICKET_UNKNOWN} from "./codes.ts";
+import {runDescope} from "./descope-verb.ts";
+import {
+	commentsJson,
+	digestFor,
+	issueJson,
+	MAP,
+	MAP_BODY,
+	MAP_BODY_WITH_REJECTION,
+	NONCE,
+	parsed,
+	REPO,
+	TICKET,
+} from "./fixtures.test-support.ts";
+import {composeTicketMarker} from "./markers.ts";
+
+const PERMISSION = /collaborators\/.*\/permission/;
+const CHILDREN = /issues\/9140\/sub_issues/;
+const TICKET_COMMENTS = /issues\/9142\/comments/;
+const POST_TICKET = /--method POST repos\/o\/r\/issues\/9142\/comments/;
+const EDGES = /issues\/9142\/dependencies\//;
+const TICKET_ISSUE = /issues\/9142$/;
+const MAP_ISSUE = /issues\/9140$/;
+const PATCH_MAP = /--method PATCH repos\/o\/r\/issues\/9140/;
+const PATCH_TICKET = /--method PATCH repos\/o\/r\/issues\/9142/;
+
+const REASON = "reason.md";
+const DIRECTION = "a per-topic weight multiplier";
+const WHY = "it makes every moderation action's authority unreadable without a topic lookup";
+
+const options = {
+	map: MAP,
+	digest: digestFor(MAP_BODY),
+	direction: DIRECTION,
+	reason: REASON,
+	ticket: null as number | null,
+	repo: null,
+	env: {CLAUDE_PIPELINE_REPO: REPO},
+	now: () => new Date("2026-08-10T00:00:00Z"),
+};
+
+const run = (
+	script: ReadonlyArray<readonly [RegExp, ExecResult]>,
+	over: Partial<typeof options> = {},
+	files: Readonly<Record<string, string | null>> = {[REASON]: `${WHY}\n`},
+) =>
+	Effect.runPromise(
+		Effect.provide(
+			runDescope({...options, ...over}),
+			Layer.merge(fakeShell(script).layer, fakeFs({files}).layer),
+		),
+	);
+
+const appended = spliceSection(
+	parsed(MAP_BODY),
+	"Out of scope",
+	renderOutOfScope({direction: DIRECTION, reason: WHY, recordedAt: "2026-08-10"}),
+);
+
+const mapOk = (body = MAP_BODY) =>
+	[MAP_ISSUE, okOut(issueJson({number: MAP, body, labels: ["wayfinding:map"]}))] as const;
+
+describe("runDescope", () => {
+	it("exits 4 on an empty reason — an entry with none is one the next session re-proposes", async () => {
+		const out = await run([], {}, {[REASON]: "  \n"});
+		expect(out.code).toBe(BAD_SECTIONS);
+		expect(out.stdout).toBe("");
+	});
+
+	it("exits 12 when the body moved since --digest", async () => {
+		const out = await run([mapOk()], {digest: "000000000000"});
+		expect(out.code).toBe(DIGEST_STALE);
+		expect(out.stdout).toBe("");
+	});
+
+	it("exits 19 when this direction is already out of scope — the recorded reasoning stands", async () => {
+		const out = await run([mapOk(MAP_BODY_WITH_REJECTION)], {
+			digest: digestFor(MAP_BODY_WITH_REJECTION),
+		});
+		expect(out.code).toBe(ALREADY_DESCOPED);
+		expect(out.stdout).toBe("");
+		expect(out.stderr.join("\n")).toContain("nothing was written");
+	});
+
+	it("exits 13 when --ticket is not a frontier ticket of this map", async () => {
+		const out = await run(
+			[
+				[PERMISSION, okOut("write")],
+				[CHILDREN, okOut(`[{"number":${TICKET}}]`)],
+				[
+					TICKET_COMMENTS,
+					okOut(
+						commentsJson([
+							{id: 1, body: composeTicketMarker({map: MAP, kind: "research", nonce: NONCE})},
+						]),
+					),
+				],
+				[EDGES, okOut("[]")],
+				[TICKET_ISSUE, okOut(issueJson({number: TICKET}))],
+				mapOk(),
+			],
+			{ticket: 9999},
+		);
+		expect(out.code).toBe(TICKET_UNKNOWN);
+		expect(out.stdout).toBe("");
+	});
+
+	it("exits 0 and reports the section's new size, which only ever grows", async () => {
+		const out = await run([
+			[PATCH_MAP, okOut("{}")],
+			[
+				once(MAP_ISSUE),
+				okOut(issueJson({number: MAP, body: MAP_BODY, labels: ["wayfinding:map"]})),
+			],
+			[MAP_ISSUE, okOut(issueJson({number: MAP, body: appended, labels: ["wayfinding:map"]}))],
+		]);
+		expect(out.code).toBe(0);
+		expect(JSON.parse(out.stdout)).toMatchObject({map: MAP, direction: DIRECTION, entries: 1});
+	});
+
+	it("appends rather than rewriting — every prior entry survives byte-identically", async () => {
+		const priorParsed = parsed(MAP_BODY_WITH_REJECTION);
+		const twoEntries = spliceSection(
+			priorParsed,
+			"Out of scope",
+			[
+				...priorParsed.outOfScope.map(renderOutOfScope),
+				renderOutOfScope({
+					direction: "importing the old forum's reputation score",
+					reason: "the old score counted post volume",
+					recordedAt: "2026-08-10",
+				}),
+			].join("\n"),
+		);
+		const shell = fakeShell([
+			[PATCH_MAP, okOut("{}")],
+			[
+				once(MAP_ISSUE),
+				okOut(issueJson({number: MAP, body: MAP_BODY_WITH_REJECTION, labels: ["wayfinding:map"]})),
+			],
+			[MAP_ISSUE, okOut(issueJson({number: MAP, body: twoEntries, labels: ["wayfinding:map"]}))],
+		]);
+		const out = await Effect.runPromise(
+			Effect.provide(
+				runDescope({
+					...options,
+					digest: digestFor(MAP_BODY_WITH_REJECTION),
+					direction: "importing the old forum's reputation score",
+				}),
+				Layer.merge(
+					shell.layer,
+					fakeFs({files: {[REASON]: "the old score counted post volume\n"}}).layer,
+				),
+			),
+		);
+		expect(out.code).toBe(0);
+		expect(JSON.parse(out.stdout).entries).toBe(2);
+		const patch = shell.calls.find((line) => line.includes("PATCH")) ?? "";
+		expect(patch).toContain("a per-topic weight multiplier");
+	});
+
+	it("retires the named ticket off the frontier and closes it", async () => {
+		const retired = spliceSection(parsed(appended), "Frontier", "");
+		const shell = fakeShell([
+			[POST_TICKET, okOut('{"id":3,"html_url":"u"}')],
+			[PATCH_TICKET, okOut("{}")],
+			[PATCH_MAP, okOut("{}")],
+			[PERMISSION, okOut("write")],
+			[CHILDREN, okOut(`[{"number":${TICKET}}]`)],
+			[
+				TICKET_COMMENTS,
+				okOut(
+					commentsJson([
+						{id: 1, body: composeTicketMarker({map: MAP, kind: "research", nonce: NONCE})},
+					]),
+				),
+			],
+			[EDGES, okOut("[]")],
+			[TICKET_ISSUE, okOut(issueJson({number: TICKET}))],
+			[
+				once(MAP_ISSUE),
+				okOut(issueJson({number: MAP, body: MAP_BODY, labels: ["wayfinding:map"]})),
+			],
+			[MAP_ISSUE, okOut(issueJson({number: MAP, body: retired, labels: ["wayfinding:map"]}))],
+		]);
+		const out = await Effect.runPromise(
+			Effect.provide(
+				runDescope({...options, ticket: TICKET}),
+				Layer.merge(shell.layer, fakeFs({files: {[REASON]: `${WHY}\n`}}).layer),
+			),
+		);
+		expect(out.code).toBe(0);
+		expect(shell.calls.some((line) => line.includes("map-retired:"))).toBe(true);
+		expect(shell.calls.some((line) => line.includes("state_reason=completed"))).toBe(true);
+	});
+});

--- a/packages/fabrika-cli/src/map/finding-verb.ts
+++ b/packages/fabrika-cli/src/map/finding-verb.ts
@@ -14,7 +14,7 @@
  * every lane shares (#3709).
  */
 
-import {Effect, FileSystem} from "effect";
+import {Effect, type FileSystem} from "effect";
 import type {ChildProcessSpawner} from "effect/unstable/process";
 import {readFile} from "../io/fs.ts";
 import {createComment, getComment} from "../io/issues.ts";
@@ -59,7 +59,10 @@ export const runFinding = (
 		}
 		const outcome = options.outcome.trim();
 		if (!isOutcome(outcome)) {
-			return refuse(FAILED, `${VERB}: --outcome "${outcome}" is not one of ${OUTCOMES.join(", ")}.`);
+			return refuse(
+				FAILED,
+				`${VERB}: --outcome "${outcome}" is not one of ${OUTCOMES.join(", ")}.`,
+			);
 		}
 		if (outcome === "answered" && options.finding === null) {
 			return refuse(
@@ -100,7 +103,13 @@ export const runFinding = (
 		const found = yield* requireMapForState(VERB, repo, options.map);
 		if (found._tag === "Refused") return found.outcome;
 
-		const resolved = yield* requireTicket(VERB, repo, options.map, found.value.body, options.ticket);
+		const resolved = yield* requireTicket(
+			VERB,
+			repo,
+			options.map,
+			found.value.body,
+			options.ticket,
+		);
 		if (resolved._tag === "Refused") return resolved.outcome;
 		const {ticket} = resolved.value;
 

--- a/packages/fabrika-cli/src/map/finding-verb.ts
+++ b/packages/fabrika-cli/src/map/finding-verb.ts
@@ -1,0 +1,160 @@
+/**
+ * `map finding` — close a lane with an outcome from a closed set.
+ *
+ * <!-- anchor: NOTHING-IS-NOT-EMPTY --> **The outcome vocabulary keeps three answers apart that an
+ * absence would collapse into one.** `answered` means the lane established the fact and the finding
+ * carries it. `no-evidence` means the lane looked and the evidence is not there — a **result**, and
+ * the finding, when given, records where it looked. `unreachable` means the lane could not look at
+ * all. A verb that accepted a silent empty finding would let all three arrive as one, which is
+ * exactly how a zero-files-read classifier ships a plausible answer (#4060). There is no fourth value
+ * and no default.
+ *
+ * This verb writes on the **ticket** and never touches the map body — that is `map record`,
+ * deliberately separate, so the lane traffic of a parallel burndown never contends on the one body
+ * every lane shares (#3709).
+ */
+
+import {Effect, FileSystem} from "effect";
+import type {ChildProcessSpawner} from "effect/unstable/process";
+import {readFile} from "../io/fs.ts";
+import {createComment, getComment} from "../io/issues.ts";
+import {normalizeForReadback} from "../report/compose.ts";
+import {answer, FAILED, refuse, type VerbOutcome} from "../verb.ts";
+import {
+	BAD_SECTIONS,
+	KIND_MISMATCH,
+	LANE_NOT_MINE,
+	READBACK_MISMATCH,
+	WRITE_UNKNOWN,
+} from "./codes.ts";
+import {leakFree, notTerminal, requireMapForState, requireTicket, targetRepo} from "./guards.ts";
+import {composeFindingMarker, isNonce, isOutcome, OUTCOMES} from "./markers.ts";
+
+export interface FindingOptions {
+	readonly map: number;
+	readonly ticket: number;
+	readonly nonce: string;
+	/** Validated here rather than at the parser, so an off-vocabulary outcome is `1` with a named set. */
+	readonly outcome: string;
+	readonly finding: string | null;
+	readonly repo: string | null;
+	readonly env: Readonly<Record<string, string | undefined>>;
+}
+
+const VERB = "map finding";
+
+export const runFinding = (
+	options: FindingOptions,
+): Effect.Effect<
+	VerbOutcome,
+	never,
+	ChildProcessSpawner.ChildProcessSpawner | FileSystem.FileSystem
+> =>
+	Effect.gen(function* () {
+		if (!isNonce(options.nonce)) {
+			return refuse(
+				FAILED,
+				`${VERB}: --nonce "${options.nonce}" is not eight lowercase hex characters.`,
+			);
+		}
+		const outcome = options.outcome.trim();
+		if (!isOutcome(outcome)) {
+			return refuse(FAILED, `${VERB}: --outcome "${outcome}" is not one of ${OUTCOMES.join(", ")}.`);
+		}
+		if (outcome === "answered" && options.finding === null) {
+			return refuse(
+				BAD_SECTIONS,
+				`${VERB}: --outcome answered requires --finding — an answered lane with no finding is indistinguishable from one that found nothing.`,
+			);
+		}
+
+		let text = "";
+		if (options.finding !== null) {
+			const read = yield* readFile(options.finding).pipe(
+				Effect.map((value) => ({ok: true as const, value})),
+				Effect.catchTag("fabrika-cli/ReadFailed", (cause) =>
+					Effect.succeed({ok: false as const, value: cause.reason}),
+				),
+			);
+			if (!read.ok) {
+				return refuse(
+					FAILED,
+					`${VERB}: could not read --finding ${options.finding}: ${read.value} — the finding is UNKNOWN, never empty.`,
+				);
+			}
+			if (read.value.trim() === "") {
+				return refuse(
+					BAD_SECTIONS,
+					`${VERB}: --finding ${options.finding} is empty — an empty finding is not an answer; use --outcome no-evidence.`,
+				);
+			}
+			text = read.value;
+			const leaked = leakFree(VERB, "finding", text);
+			if (leaked !== null) return leaked;
+		}
+
+		const target = yield* targetRepo(VERB, options.repo, options.env);
+		if (target._tag === "Refused") return target.outcome;
+		const repo = target.value;
+
+		const found = yield* requireMapForState(VERB, repo, options.map);
+		if (found._tag === "Refused") return found.outcome;
+
+		const resolved = yield* requireTicket(VERB, repo, options.map, found.value.body, options.ticket);
+		if (resolved._tag === "Refused") return resolved.outcome;
+		const {ticket} = resolved.value;
+
+		const left = notTerminal(VERB, ticket, "there is no lane left to close.");
+		if (left !== null) return left;
+		if (ticket.kind === "decision") {
+			return refuse(
+				KIND_MISMATCH,
+				`${VERB}: #${ticket.number} is a decision ticket — a decision has no lane.`,
+			);
+		}
+		if (ticket.state !== "lane-held" || ticket.nonce !== options.nonce) {
+			return refuse(
+				LANE_NOT_MINE,
+				`${VERB}: ${options.nonce} does not hold #${ticket.number}'s lane (${ticket.state === "lane-held" ? `held by ${ticket.nonce}` : `the ticket reads ${ticket.state}`}) — nothing was recorded.`,
+			);
+		}
+
+		const scope = `${VERB}: ${repo}, #${options.ticket}'s lane held by ${options.nonce}, ${new TextEncoder().encode(text).length} finding byte(s).`;
+		const marker = composeFindingMarker({
+			map: options.map,
+			ticket: options.ticket,
+			outcome,
+			nonce: options.nonce,
+		});
+		const body = text === "" ? `${marker}\n` : `${marker}\n\n${text}`;
+		const posted = yield* createComment(repo, options.ticket, body);
+		if (posted._tag === "Failure") {
+			return refuse(
+				WRITE_UNKNOWN,
+				`${VERB}: could not record the finding on #${options.ticket}: ${posted.reason} — whether the lane is released is UNKNOWN.`,
+				[scope],
+			);
+		}
+		const landed = yield* getComment(repo, posted.value.id);
+		if (
+			landed._tag === "Failure" ||
+			normalizeForReadback(landed.value) !== normalizeForReadback(body)
+		) {
+			return refuse(
+				READBACK_MISMATCH,
+				`${VERB}: recorded the finding on #${options.ticket} and the read-back differs — the comment exists and needs a human.`,
+				[scope],
+			);
+		}
+
+		return answer(
+			JSON.stringify({
+				map: options.map,
+				ticket: options.ticket,
+				outcome,
+				comment: posted.value.id,
+				lane: "released",
+			}),
+			[scope],
+		);
+	});

--- a/packages/fabrika-cli/src/map/finding-verb.unit.test.ts
+++ b/packages/fabrika-cli/src/map/finding-verb.unit.test.ts
@@ -1,0 +1,209 @@
+import {Effect, Layer} from "effect";
+import {describe, expect, it} from "vitest";
+import {errOut, fakeFs, fakeShell, okOut} from "../fakes.test-support.ts";
+import type {ExecResult} from "../io/exec.ts";
+import {
+	BAD_SECTIONS,
+	KIND_MISMATCH,
+	LANE_NOT_MINE,
+	LEAKED_PATH,
+	READBACK_MISMATCH,
+	WRITE_UNKNOWN,
+} from "./codes.ts";
+import {runFinding} from "./finding-verb.ts";
+import {
+	commentsJson,
+	issueJson,
+	MAP,
+	MAP_BODY,
+	NONCE,
+	REPO,
+	TICKET,
+} from "./fixtures.test-support.ts";
+import {composeFindingMarker, composeLaneMarker, composeTicketMarker} from "./markers.ts";
+
+const POST = /--method POST repos\/o\/r\/issues\/9142\/comments/;
+const GET_COMMENT = /issues\/comments\/\d+/;
+const PERMISSION = /collaborators\/.*\/permission/;
+const CHILDREN = /issues\/9140\/sub_issues/;
+const TICKET_COMMENTS = /issues\/9142\/comments/;
+const EDGES = /issues\/9142\/dependencies\//;
+const TICKET_ISSUE = /issues\/9142$/;
+const MAP_ISSUE = /issues\/9140$/;
+
+const FINDING_PATH = "finding.md";
+
+const options = {
+	map: MAP,
+	ticket: TICKET,
+	nonce: NONCE,
+	outcome: "no-evidence",
+	finding: null as string | null,
+	repo: null,
+	env: {CLAUDE_PIPELINE_REPO: REPO},
+};
+
+const run = (
+	script: ReadonlyArray<readonly [RegExp, ExecResult]>,
+	over: Partial<typeof options> = {},
+	files: Readonly<Record<string, string | null>> = {},
+) =>
+	Effect.runPromise(
+		Effect.provide(
+			runFinding({...options, ...over}),
+			Layer.merge(fakeShell(script).layer, fakeFs({files}).layer),
+		),
+	);
+
+const held = (nonce = NONCE) =>
+	[
+		[PERMISSION, okOut("write")],
+		[CHILDREN, okOut(`[{"number":${TICKET}}]`)],
+		[
+			TICKET_COMMENTS,
+			okOut(
+				commentsJson([
+					{id: 1, body: composeTicketMarker({map: MAP, kind: "research", nonce: NONCE})},
+					{id: 2, body: composeLaneMarker({map: MAP, ticket: TICKET, nonce})},
+				]),
+			),
+		],
+		[EDGES, okOut("[]")],
+		[TICKET_ISSUE, okOut(issueJson({number: TICKET, body: "which table?"}))],
+		[MAP_ISSUE, okOut(issueJson({number: MAP, body: MAP_BODY, labels: ["wayfinding:map"]}))],
+	] as const;
+
+describe("runFinding — the outcome vocabulary", () => {
+	it("exits 1 on an off-vocabulary outcome, naming the three", async () => {
+		const out = await run([], {outcome: "none"});
+		expect(out.code).toBe(1);
+		expect(out.stdout).toBe("");
+		expect(out.stderr.join("\n")).toContain("answered, no-evidence, unreachable");
+	});
+
+	it("exits 4 when --outcome answered arrives with no finding", async () => {
+		const out = await run([], {outcome: "answered"});
+		expect(out.code).toBe(BAD_SECTIONS);
+		expect(out.stdout).toBe("");
+		expect(out.stderr.join("\n")).toContain("indistinguishable from one that found nothing");
+	});
+
+	it("exits 4 on an empty finding file — an empty finding is not an answer", async () => {
+		const out = await run(
+			[],
+			{outcome: "answered", finding: FINDING_PATH},
+			{[FINDING_PATH]: "  \n"},
+		);
+		expect(out.code).toBe(BAD_SECTIONS);
+		expect(out.stderr.join("\n")).toContain("use --outcome no-evidence");
+	});
+
+	it("exits 1 on a finding file that cannot be read — the finding is UNKNOWN, never empty", async () => {
+		const out = await run([], {outcome: "answered", finding: FINDING_PATH}, {});
+		expect(out.code).toBe(1);
+		expect(out.stdout).toBe("");
+		expect(out.stderr.join("\n")).toContain("UNKNOWN, never empty");
+	});
+
+	it("exits 5 on a finding carrying a machine-local path", async () => {
+		const out = await run(
+			[],
+			{outcome: "answered", finding: FINDING_PATH},
+			{[FINDING_PATH]: "the evidence is in ~/notes/weight.md\n"},
+		);
+		expect(out.code).toBe(LEAKED_PATH);
+		expect(out.stdout).toBe("");
+	});
+});
+
+describe("runFinding — the lane", () => {
+	it("exits 0, records the outcome and releases the lane", async () => {
+		const body = `${composeFindingMarker({map: MAP, ticket: TICKET, outcome: "no-evidence", nonce: NONCE})}\n`;
+		const out = await run([
+			[POST, okOut('{"id":77,"html_url":"u"}')],
+			[GET_COMMENT, okOut(JSON.stringify({body}))],
+			...held(),
+		]);
+		expect(out.code).toBe(0);
+		expect(JSON.parse(out.stdout)).toEqual({
+			map: MAP,
+			ticket: TICKET,
+			outcome: "no-evidence",
+			comment: 77,
+			lane: "released",
+		});
+	});
+
+	it("exits 15 when a different nonce holds the lane", async () => {
+		const out = await run([...held("bbbbbbbb")]);
+		expect(out.code).toBe(LANE_NOT_MINE);
+		expect(out.stdout).toBe("");
+		expect(out.stderr.join("\n")).toContain("nothing was recorded");
+	});
+
+	it("exits 15 when no lane is held at all — the state is named rather than guessed", async () => {
+		const out = await run([
+			[PERMISSION, okOut("write")],
+			[CHILDREN, okOut(`[{"number":${TICKET}}]`)],
+			[
+				TICKET_COMMENTS,
+				okOut(
+					commentsJson([
+						{id: 1, body: composeTicketMarker({map: MAP, kind: "research", nonce: NONCE})},
+					]),
+				),
+			],
+			[EDGES, okOut("[]")],
+			[TICKET_ISSUE, okOut(issueJson({number: TICKET}))],
+			[MAP_ISSUE, okOut(issueJson({number: MAP, body: MAP_BODY, labels: ["wayfinding:map"]}))],
+		]);
+		expect(out.code).toBe(LANE_NOT_MINE);
+		expect(out.stderr.join("\n")).toContain("the ticket reads open");
+	});
+
+	it("exits 20 on a decision ticket — a decision has no lane", async () => {
+		const out = await run([
+			[PERMISSION, okOut("write")],
+			[CHILDREN, okOut(`[{"number":${TICKET}}]`)],
+			[
+				TICKET_COMMENTS,
+				okOut(
+					commentsJson([
+						{id: 1, body: composeTicketMarker({map: MAP, kind: "decision", nonce: NONCE})},
+					]),
+				),
+			],
+			[EDGES, okOut("[]")],
+			[TICKET_ISSUE, okOut(issueJson({number: TICKET}))],
+			[MAP_ISSUE, okOut(issueJson({number: MAP, body: MAP_BODY, labels: ["wayfinding:map"]}))],
+		]);
+		expect(out.code).toBe(KIND_MISMATCH);
+		expect(out.stdout).toBe("");
+	});
+
+	it("never touches the map body — lane traffic goes to the ticket", async () => {
+		const body = `${composeFindingMarker({map: MAP, ticket: TICKET, outcome: "no-evidence", nonce: NONCE})}\n`;
+		const shell = fakeShell([
+			[POST, okOut('{"id":77,"html_url":"u"}')],
+			[GET_COMMENT, okOut(JSON.stringify({body}))],
+			...held(),
+		]);
+		await Effect.runPromise(
+			Effect.provide(runFinding(options), Layer.merge(shell.layer, fakeFs({}).layer)),
+		);
+		expect(shell.calls.some((line) => line.includes("--method PATCH"))).toBe(false);
+	});
+
+	it("exits 8 when the comment write fails, and 9 when it does not read back", async () => {
+		const failed = await run([[POST, errOut("gh: Bad gateway (HTTP 502)")], ...held()]);
+		expect(failed.code).toBe(WRITE_UNKNOWN);
+		expect(failed.stdout).toBe("");
+		const drifted = await run([
+			[POST, okOut('{"id":77,"html_url":"u"}')],
+			[GET_COMMENT, okOut(JSON.stringify({body: "not the marker"}))],
+			...held(),
+		]);
+		expect(drifted.code).toBe(READBACK_MISMATCH);
+		expect(drifted.stdout).toBe("");
+	});
+});

--- a/packages/fabrika-cli/src/map/fixtures.test-support.ts
+++ b/packages/fabrika-cli/src/map/fixtures.test-support.ts
@@ -1,0 +1,77 @@
+/**
+ * The map bodies and `gh api` responses every `map` verb test is driven from.
+ *
+ * Shared so the eight verb suites assert against one canonical map rather than each inventing its
+ * own: a fixture per suite is how two tests come to disagree about what a well-formed body is, and
+ * the digest guard makes that disagreement invisible until a write refuses.
+ */
+
+import {digestOfBody, type MapBody, parseBody} from "./body.ts";
+
+export const REPO = "o/r";
+export const MAP = 9140;
+export const TICKET = 9142;
+export const NONCE = "7f3a9c21";
+
+/** A map with one open research ticket, no decisions, and nothing out of scope. */
+export const MAP_BODY = [
+	"## Destination",
+	"how moderation weight is earned",
+	"",
+	"## Decisions",
+	"",
+	"## Frontier",
+	"- #9142 · research — which table carries the per-account weight column?",
+	"",
+	"## Fog",
+	"- what clock does weight decay on?",
+	"",
+	"## Out of scope",
+	"",
+].join("\n");
+
+/** The same map with one rejected direction already recorded. */
+export const MAP_BODY_WITH_REJECTION = MAP_BODY.replace(
+	"## Out of scope\n",
+	"## Out of scope\n- a per-topic weight multiplier. It makes every moderation action's authority unreadable without a topic lookup — 2026-06-29\n",
+);
+
+export const parsed = (body: string): MapBody => {
+	const read = parseBody(body);
+	if (read._tag === "Malformed") throw new Error(`fixture does not parse: ${read.reason}`);
+	return read.value;
+};
+
+export const digestFor = (body: string): string => digestOfBody(parsed(body));
+
+export const issueJson = (input: {
+	readonly number: number;
+	readonly title?: string;
+	readonly body?: string;
+	readonly labels?: ReadonlyArray<string>;
+	readonly state?: string;
+}): string =>
+	JSON.stringify({
+		number: input.number,
+		title: input.title ?? `issue ${input.number}`,
+		body: input.body ?? "",
+		state: input.state ?? "open",
+		labels: (input.labels ?? []).map((name) => ({name})),
+		html_url: `https://github.com/${REPO}/issues/${input.number}`,
+		user: {login: "usirin"},
+		milestone: null,
+		state_reason: null,
+	});
+
+export const commentsJson = (
+	comments: ReadonlyArray<{readonly id: number; readonly body: string; readonly author?: string}>,
+): string =>
+	JSON.stringify(
+		comments.map((comment) => ({
+			id: comment.id,
+			body: comment.body,
+			user: {login: comment.author ?? "usirin"},
+			created_at: "2026-08-10T00:00:00Z",
+			updated_at: "2026-08-10T00:00:00Z",
+		})),
+	);

--- a/packages/fabrika-cli/src/map/fork-verb.ts
+++ b/packages/fabrika-cli/src/map/fork-verb.ts
@@ -25,13 +25,7 @@ import {
 	TICKET_UNKNOWN,
 	WRITE_UNKNOWN,
 } from "./codes.ts";
-import {
-	digestFresh,
-	notTerminal,
-	requireMap,
-	requireTicket,
-	targetRepo,
-} from "./guards.ts";
+import {digestFresh, notTerminal, requireMap, requireTicket, targetRepo} from "./guards.ts";
 import {composeForkMarker} from "./markers.ts";
 
 /** The label a `grilling` session issue carries. A plain label read, never a second reader. */
@@ -62,7 +56,13 @@ export const runFork = (
 		const stale = digestFresh(VERB, options.map, found.value.body, options.digest);
 		if (stale !== null) return stale;
 
-		const resolved = yield* requireTicket(VERB, repo, options.map, found.value.body, options.ticket);
+		const resolved = yield* requireTicket(
+			VERB,
+			repo,
+			options.map,
+			found.value.body,
+			options.ticket,
+		);
 		if (resolved._tag === "Refused") return resolved.outcome;
 		const {ticket} = resolved.value;
 
@@ -71,7 +71,8 @@ export const runFork = (
 
 		// Which flag is admitted is decided by the ticket's kind, not by the caller: `decision` takes
 		// `--session`, `prototype` takes `--spike`, and `research` takes neither — it is laned.
-		const wanted = ticket.kind === "decision" ? "session" : ticket.kind === "prototype" ? "spike" : null;
+		const wanted =
+			ticket.kind === "decision" ? "session" : ticket.kind === "prototype" ? "spike" : null;
 		const given =
 			options.session !== null && options.spike !== null
 				? "both"
@@ -148,7 +149,9 @@ export const runFork = (
 		if (guard !== null) return guard;
 
 		const rows = reread.value.body.frontier
-			.map((row) => renderFrontierRow(row.ticket === options.ticket ? {...row, forkedTo: routed} : row))
+			.map((row) =>
+				renderFrontierRow(row.ticket === options.ticket ? {...row, forkedTo: routed} : row),
+			)
 			.join("\n");
 		const next = spliceSection(reread.value.body, "Frontier", rows);
 		const written = yield* patchIssueBody(repo, options.map, next);

--- a/packages/fabrika-cli/src/map/fork-verb.ts
+++ b/packages/fabrika-cli/src/map/fork-verb.ts
@@ -1,0 +1,193 @@
+/**
+ * `map fork` — record that a ticket's question is being answered elsewhere.
+ *
+ * <!-- anchor: TWO-ROUTES-ONE-SHAPE --> A `decision` is answered in conversation and belongs to
+ * `grilling`; an **empirical** question — one only running throwaway code can settle — belongs to
+ * `prototyping`. This verb records *where* either is being answered and nothing about the answer. It
+ * is an invocation seam only: this group runs no spike and no verb in it writes code.
+ *
+ * <!-- anchor: RELAY-THE-RULING-NEVER-ASSERT-ONE --> **It records where the decision is being made;
+ * it never records the decision.** A ruling reaches `## Decisions` only through `map record` citing a
+ * `grilling` question id. Nothing here writes an authority claim and no flag accepts one — v1's whole
+ * given-grounding law reduced to an agent typing `(@founder)` after an entry that nothing verified.
+ */
+
+import {Effect} from "effect";
+import type {ChildProcessSpawner} from "effect/unstable/process";
+import {createComment, getComment, getIssue, patchIssueBody} from "../io/issues.ts";
+import {normalizeForReadback} from "../report/compose.ts";
+import {answer, refuse, type VerbOutcome} from "../verb.ts";
+import {digestOf, parseBody, renderFrontierRow, spliceSection} from "./body.ts";
+import {
+	KIND_MISMATCH,
+	PRECONDITION_UNKNOWN,
+	READBACK_MISMATCH,
+	TICKET_UNKNOWN,
+	WRITE_UNKNOWN,
+} from "./codes.ts";
+import {
+	digestFresh,
+	notTerminal,
+	requireMap,
+	requireTicket,
+	targetRepo,
+} from "./guards.ts";
+import {composeForkMarker} from "./markers.ts";
+
+/** The label a `grilling` session issue carries. A plain label read, never a second reader. */
+export const SESSION_LABEL = "grilling:session";
+
+export interface ForkOptions {
+	readonly map: number;
+	readonly digest: string;
+	readonly ticket: number;
+	readonly session: number | null;
+	readonly spike: number | null;
+	readonly repo: string | null;
+	readonly env: Readonly<Record<string, string | undefined>>;
+}
+
+const VERB = "map fork";
+
+export const runFork = (
+	options: ForkOptions,
+): Effect.Effect<VerbOutcome, never, ChildProcessSpawner.ChildProcessSpawner> =>
+	Effect.gen(function* () {
+		const target = yield* targetRepo(VERB, options.repo, options.env);
+		if (target._tag === "Refused") return target.outcome;
+		const repo = target.value;
+
+		const found = yield* requireMap(VERB, repo, options.map);
+		if (found._tag === "Refused") return found.outcome;
+		const stale = digestFresh(VERB, options.map, found.value.body, options.digest);
+		if (stale !== null) return stale;
+
+		const resolved = yield* requireTicket(VERB, repo, options.map, found.value.body, options.ticket);
+		if (resolved._tag === "Refused") return resolved.outcome;
+		const {ticket} = resolved.value;
+
+		const left = notTerminal(VERB, ticket, "a cleared question is not routed anywhere.");
+		if (left !== null) return left;
+
+		// Which flag is admitted is decided by the ticket's kind, not by the caller: `decision` takes
+		// `--session`, `prototype` takes `--spike`, and `research` takes neither — it is laned.
+		const wanted = ticket.kind === "decision" ? "session" : ticket.kind === "prototype" ? "spike" : null;
+		const given =
+			options.session !== null && options.spike !== null
+				? "both"
+				: options.session !== null
+					? "session"
+					: options.spike !== null
+						? "spike"
+						: "neither";
+		if (wanted === null) {
+			return refuse(
+				KIND_MISMATCH,
+				`${VERB}: #${ticket.number} is kind ${ticket.kind}, which is answered in a lane rather than routed — re-file it as a decision ticket or resolve it in a lane.`,
+			);
+		}
+		if (given !== wanted) {
+			return refuse(
+				KIND_MISMATCH,
+				`${VERB}: #${ticket.number} is kind ${ticket.kind}, which takes --${wanted}; ${given === "both" ? "both were given" : given === "neither" ? "neither was given" : `--${given} was given`}.`,
+			);
+		}
+		const route = wanted;
+		const routed = (route === "session" ? options.session : options.spike) as number;
+
+		const elsewhere = yield* getIssue(repo, routed);
+		if (elsewhere._tag === "Unknown") {
+			return refuse(
+				PRECONDITION_UNKNOWN,
+				`${VERB}: cannot read #${routed}: ${elsewhere.reason} — nothing was written and where the question is being answered is UNKNOWN.`,
+			);
+		}
+		if (elsewhere._tag === "Absent") {
+			return refuse(
+				TICKET_UNKNOWN,
+				`${VERB}: #${routed} does not exist — refusing to point a fork at an issue no run will read.`,
+			);
+		}
+		if (route === "session" && !elsewhere.value.labels.includes(SESSION_LABEL)) {
+			return refuse(
+				TICKET_UNKNOWN,
+				`${VERB}: #${routed} is not a grilling session — refusing to point a fork at an issue no grilling run will read.`,
+			);
+		}
+
+		const scope = `${VERB}: ${repo}, #${options.ticket} kind ${ticket.kind}, routed to #${routed}.`;
+		const markerBody = composeForkMarker({
+			map: options.map,
+			ticket: options.ticket,
+			route,
+			issue: routed,
+		});
+		const posted = yield* createComment(repo, options.ticket, markerBody);
+		if (posted._tag === "Failure") {
+			return refuse(
+				WRITE_UNKNOWN,
+				`${VERB}: could not record the fork on #${options.ticket}: ${posted.reason} — whether it is routed is UNKNOWN.`,
+				[scope],
+			);
+		}
+		const landedMarker = yield* getComment(repo, posted.value.id);
+		if (
+			landedMarker._tag === "Failure" ||
+			normalizeForReadback(landedMarker.value) !== normalizeForReadback(markerBody)
+		) {
+			return refuse(
+				READBACK_MISMATCH,
+				`${VERB}: recorded the fork on #${options.ticket} and the read-back differs — the comment exists and needs a human.`,
+				[scope],
+			);
+		}
+
+		const reread = yield* requireMap(VERB, repo, options.map);
+		if (reread._tag === "Refused") return reread.outcome;
+		const guard = digestFresh(VERB, options.map, reread.value.body, options.digest);
+		if (guard !== null) return guard;
+
+		const rows = reread.value.body.frontier
+			.map((row) => renderFrontierRow(row.ticket === options.ticket ? {...row, forkedTo: routed} : row))
+			.join("\n");
+		const next = spliceSection(reread.value.body, "Frontier", rows);
+		const written = yield* patchIssueBody(repo, options.map, next);
+		if (written._tag === "Failure") {
+			return refuse(
+				WRITE_UNKNOWN,
+				`${VERB}: recorded the fork on #${options.ticket} and the map body write did NOT land: ${written.reason} — the ticket is routed and the map does not say so.`,
+				[scope],
+			);
+		}
+
+		const landed = yield* getIssue(repo, options.map);
+		if (
+			landed._tag !== "Present" ||
+			normalizeForReadback(landed.value.body) !== normalizeForReadback(next)
+		) {
+			return refuse(
+				READBACK_MISMATCH,
+				`${VERB}: wrote #${options.map}'s body and the read-back differs — the map needs fixing by hand.`,
+				[scope],
+			);
+		}
+		const reparsed = parseBody(landed.value.body);
+		if (reparsed._tag === "Malformed") {
+			return refuse(
+				READBACK_MISMATCH,
+				`${VERB}: wrote #${options.map}'s body and it no longer parses (${reparsed.reason}) — the map needs fixing by hand.`,
+				[scope],
+			);
+		}
+
+		return answer(
+			JSON.stringify({
+				map: options.map,
+				ticket: options.ticket,
+				...(route === "session" ? {session: routed} : {spike: routed}),
+				state: "forked",
+				digest: digestOf(reparsed.value.sections),
+			}),
+			[scope],
+		);
+	});

--- a/packages/fabrika-cli/src/map/fork-verb.unit.test.ts
+++ b/packages/fabrika-cli/src/map/fork-verb.unit.test.ts
@@ -1,0 +1,162 @@
+import {Effect} from "effect";
+import {describe, expect, it} from "vitest";
+import {fakeShell, okOut, once} from "../fakes.test-support.ts";
+import type {ExecResult} from "../io/exec.ts";
+import {renderFrontierRow, spliceSection} from "./body.ts";
+import {DIGEST_STALE, KIND_MISMATCH, TICKET_UNKNOWN} from "./codes.ts";
+import {
+	commentsJson,
+	digestFor,
+	issueJson,
+	MAP,
+	MAP_BODY,
+	NONCE,
+	parsed,
+	REPO,
+	TICKET,
+} from "./fixtures.test-support.ts";
+import {runFork, SESSION_LABEL} from "./fork-verb.ts";
+import {composeForkMarker, composeTicketMarker} from "./markers.ts";
+
+const POST = /--method POST repos\/o\/r\/issues\/9142\/comments/;
+const GET_COMMENT = /issues\/comments\/\d+/;
+const PERMISSION = /collaborators\/.*\/permission/;
+const CHILDREN = /issues\/9140\/sub_issues/;
+const TICKET_COMMENTS = /issues\/9142\/comments/;
+const EDGES = /issues\/9142\/dependencies\//;
+const TICKET_ISSUE = /issues\/9142$/;
+const MAP_ISSUE = /issues\/9140$/;
+const SESSION_ISSUE = /issues\/9301$/;
+const PATCH = /--method PATCH repos\/o\/r\/issues\/9140/;
+
+const options = {
+	map: MAP,
+	digest: digestFor(MAP_BODY),
+	ticket: TICKET,
+	session: 9301 as number | null,
+	spike: null as number | null,
+	repo: null,
+	env: {CLAUDE_PIPELINE_REPO: REPO},
+};
+
+const run = (
+	script: ReadonlyArray<readonly [RegExp, ExecResult]>,
+	over: Partial<typeof options> = {},
+) => Effect.runPromise(Effect.provide(runFork({...options, ...over}), fakeShell(script).layer));
+
+const frontier = (kind: "research" | "prototype" | "decision") =>
+	[
+		[PERMISSION, okOut("write")],
+		[CHILDREN, okOut(`[{"number":${TICKET}}]`)],
+		[
+			TICKET_COMMENTS,
+			okOut(commentsJson([{id: 1, body: composeTicketMarker({map: MAP, kind, nonce: NONCE})}])),
+		],
+		[EDGES, okOut("[]")],
+		[
+			TICKET_ISSUE,
+			okOut(issueJson({number: TICKET, body: "does an invited çaylak start at 0 karma?"})),
+		],
+	] as const;
+
+const mapOk = [
+	MAP_ISSUE,
+	okOut(issueJson({number: MAP, body: MAP_BODY, labels: ["wayfinding:map"]})),
+] as const;
+
+const forked = spliceSection(
+	parsed(MAP_BODY),
+	"Frontier",
+	parsed(MAP_BODY)
+		.frontier.map((row) => renderFrontierRow({...row, forkedTo: 9301}))
+		.join("\n"),
+);
+
+describe("runFork", () => {
+	it("exits 12 when the body moved since --digest", async () => {
+		const out = await run([mapOk], {digest: "000000000000"});
+		expect(out.code).toBe(DIGEST_STALE);
+		expect(out.stdout).toBe("");
+	});
+
+	it("exits 20 on a research ticket, which is laned rather than routed", async () => {
+		const out = await run([...frontier("research"), mapOk]);
+		expect(out.code).toBe(KIND_MISMATCH);
+		expect(out.stdout).toBe("");
+		expect(out.stderr.join("\n")).toContain("resolve it in a lane");
+	});
+
+	it("exits 20 when the kind admits --spike and --session was given", async () => {
+		const out = await run([...frontier("prototype"), mapOk]);
+		expect(out.code).toBe(KIND_MISMATCH);
+		expect(out.stderr.join("\n")).toContain("takes --spike");
+	});
+
+	it("exits 20 when neither route flag was given", async () => {
+		const out = await run([...frontier("decision"), mapOk], {session: null});
+		expect(out.code).toBe(KIND_MISMATCH);
+		expect(out.stderr.join("\n")).toContain("neither was given");
+	});
+
+	it("exits 13 when --session is not a grilling session", async () => {
+		const out = await run([
+			[SESSION_ISSUE, okOut(issueJson({number: 9301}))],
+			...frontier("decision"),
+			mapOk,
+		]);
+		expect(out.code).toBe(TICKET_UNKNOWN);
+		expect(out.stdout).toBe("");
+		expect(out.stderr.join("\n")).toContain("no grilling run will read");
+	});
+
+	it("exits 0, marks the ticket and renders the route onto the row", async () => {
+		const marker = composeForkMarker({map: MAP, ticket: TICKET, route: "session", issue: 9301});
+		const out = await run([
+			[POST, okOut('{"id":9,"html_url":"u"}')],
+			[GET_COMMENT, okOut(JSON.stringify({body: marker}))],
+			[SESSION_ISSUE, okOut(issueJson({number: 9301, labels: [SESSION_LABEL]}))],
+			[PATCH, okOut("{}")],
+			...frontier("decision"),
+			[
+				once(MAP_ISSUE),
+				okOut(issueJson({number: MAP, body: MAP_BODY, labels: ["wayfinding:map"]})),
+			],
+			[
+				once(MAP_ISSUE),
+				okOut(issueJson({number: MAP, body: MAP_BODY, labels: ["wayfinding:map"]})),
+			],
+			[MAP_ISSUE, okOut(issueJson({number: MAP, body: forked, labels: ["wayfinding:map"]}))],
+		]);
+		expect(out.code).toBe(0);
+		expect(JSON.parse(out.stdout)).toMatchObject({
+			map: MAP,
+			ticket: TICKET,
+			session: 9301,
+			state: "forked",
+		});
+	});
+
+	it("records where the decision is being made and never the decision itself", async () => {
+		const marker = composeForkMarker({map: MAP, ticket: TICKET, route: "session", issue: 9301});
+		const shell = fakeShell([
+			[POST, okOut('{"id":9,"html_url":"u"}')],
+			[GET_COMMENT, okOut(JSON.stringify({body: marker}))],
+			[SESSION_ISSUE, okOut(issueJson({number: 9301, labels: [SESSION_LABEL]}))],
+			[PATCH, okOut("{}")],
+			...frontier("decision"),
+			[
+				once(MAP_ISSUE),
+				okOut(issueJson({number: MAP, body: MAP_BODY, labels: ["wayfinding:map"]})),
+			],
+			[
+				once(MAP_ISSUE),
+				okOut(issueJson({number: MAP, body: MAP_BODY, labels: ["wayfinding:map"]})),
+			],
+			[MAP_ISSUE, okOut(issueJson({number: MAP, body: forked, labels: ["wayfinding:map"]}))],
+		]);
+		await Effect.runPromise(Effect.provide(runFork(options), shell.layer));
+		const patch = shell.calls.find((line) => line.includes("--method PATCH")) ?? "";
+		expect(patch).not.toContain("## Decisions\n-");
+		expect(patch).toContain("forked to #9301");
+	});
+});

--- a/packages/fabrika-cli/src/map/frontier.ts
+++ b/packages/fabrika-cli/src/map/frontier.ts
@@ -22,12 +22,12 @@ import {permissionFor} from "../io/pulls.ts";
 import {type Kind, type MapBody, parseBody} from "./body.ts";
 import {
 	type Outcome,
+	reachesForTicketMarker,
 	readFindingMarker,
 	readForkMarker,
 	readLaneMarker,
 	readRetiredMarker,
 	readTicketMarker,
-	reachesForTicketMarker,
 } from "./markers.ts";
 
 /** The label a map is found by. `map open` applies it on mint; nothing else touches it. */
@@ -260,7 +260,8 @@ const resolveChild = (
 				value: {
 					ticket: child,
 					reason: "unauthorized" as const,
-					detail: "every map-ticket marker on this child is from an author with no write permission",
+					detail:
+						"every map-ticket marker on this child is from an author with no write permission",
 				},
 			};
 		}
@@ -382,7 +383,8 @@ export type FrontierToken = "awaiting-founder" | "lanes-pending" | "clear" | "em
 export const frontierToken = (tickets: ReadonlyArray<Ticket>): FrontierToken => {
 	if (tickets.length === 0) return "empty";
 	const awaiting = tickets.some(
-		(ticket) => ticket.kind === "decision" && (ticket.state === "open" || ticket.state === "forked"),
+		(ticket) =>
+			ticket.kind === "decision" && (ticket.state === "open" || ticket.state === "forked"),
 	);
 	if (awaiting) return "awaiting-founder";
 	return tickets.every((ticket) => isTerminal(ticket.state)) ? "clear" : "lanes-pending";

--- a/packages/fabrika-cli/src/map/frontier.ts
+++ b/packages/fabrika-cli/src/map/frontier.ts
@@ -1,0 +1,415 @@
+/**
+ * The composite read every `map` verb rests on: the map issue, its parsed body, its children, and
+ * each child's resolved frontier state.
+ *
+ * State is resolved from the ticket's markers, its own `state` on GitHub, and its native edges — the
+ * body's `## Frontier` rows are a rendering of this answer, never the record of it. An implementer
+ * who derives state by matching headings has rebuilt the v1 scar this module exists to remove.
+ *
+ * <!-- anchor: NEVER-PASS-ON-A-FAILED-READ --> **An empty read that cannot be proven empty is
+ * UNKNOWN.** v1's dangling-reference check disabled itself whenever the sub-issue read came back
+ * empty (`if (subIssues.length > 0)`), so a rate-limited call silently removed the check rather than
+ * refusing — the zero-scope pass ADR 0092 forbids. Here zero children is a **fact** only when the
+ * platform proved it with `200 []`; every other outcome is {@link FrontierRead.Unknown}.
+ */
+
+import {Effect} from "effect";
+import type {ChildProcessSpawner} from "effect/unstable/process";
+import {blockedBy, blocking, subIssues} from "../io/edges.ts";
+import type {Shell} from "../io/git.ts";
+import {type CommentRecord, getIssue, type IssueRecord, listComments} from "../io/issues.ts";
+import {permissionFor} from "../io/pulls.ts";
+import {type Kind, type MapBody, parseBody} from "./body.ts";
+import {
+	type Outcome,
+	readFindingMarker,
+	readForkMarker,
+	readLaneMarker,
+	readRetiredMarker,
+	readTicketMarker,
+	reachesForTicketMarker,
+} from "./markers.ts";
+
+/** The label a map is found by. `map open` applies it on mint; nothing else touches it. */
+export const MAP_LABEL = "wayfinding:map";
+
+/** The permissions that authorize a marker — the ADR 0055 `write+` set. */
+const AUTHORIZED = new Set(["admin", "maintain", "write"]);
+
+export type MapRead =
+	| {readonly _tag: "Map"; readonly issue: IssueRecord; readonly body: MapBody}
+	| {readonly _tag: "Absent"}
+	| {readonly _tag: "Malformed"; readonly reason: string}
+	| {readonly _tag: "Unknown"; readonly reason: string};
+
+/**
+ * The map issue and its parsed body, four ways.
+ *
+ * `Absent` covers a missing issue **and** one that does not carry {@link MAP_LABEL}: both mean *this
+ * number names no map*, which is the same `7` with the same remedy, and neither is a body defect.
+ */
+export const readMap = (repo: string, map: number): Shell<MapRead> =>
+	Effect.gen(function* () {
+		const issue = yield* getIssue(repo, map);
+		if (issue._tag === "Absent") return {_tag: "Absent" as const};
+		if (issue._tag === "Unknown") return {_tag: "Unknown" as const, reason: issue.reason};
+		if (!issue.value.labels.includes(MAP_LABEL)) return {_tag: "Absent" as const};
+		const parsed = parseBody(issue.value.body);
+		return parsed._tag === "Malformed"
+			? {_tag: "Malformed" as const, reason: parsed.reason}
+			: {_tag: "Map" as const, issue: issue.value, body: parsed.value};
+	});
+
+/** The six states a frontier ticket may hold. `graduated` and `retired` are terminal and always win. */
+export type TicketState = "open" | "lane-held" | "lane-closed" | "forked" | "graduated" | "retired";
+
+export interface Ticket {
+	readonly number: number;
+	readonly kind: Kind;
+	readonly question: string;
+	readonly state: TicketState;
+	readonly blockedBy: ReadonlyArray<number>;
+	readonly blocking: ReadonlyArray<number>;
+	/** Present when `state` is `lane-held`: the run nonce holding the lane. */
+	readonly nonce?: string;
+	/** Present when `state` is `forked` and `kind` is `decision`. */
+	readonly session?: number;
+	/** Present when `state` is `forked` and `kind` is `prototype`. */
+	readonly spike?: number;
+	/** Present when `state` is `lane-closed`. */
+	readonly outcome?: Outcome;
+	/** Present when `state` is `retired`: the out-of-scope direction it retired into. */
+	readonly retiredBy?: string;
+}
+
+/** A child this read did **not** count as a frontier ticket, and why. */
+export interface Disregarded {
+	readonly ticket: number;
+	readonly reason: "malformed" | "foreign-map" | "unauthorized";
+	readonly detail: string;
+}
+
+export interface Frontier {
+	readonly tickets: ReadonlyArray<Ticket>;
+	readonly disregarded: ReadonlyArray<Disregarded>;
+	readonly scanned: {
+		readonly children: number;
+		readonly edgeReads: number;
+		readonly comments: number;
+	};
+}
+
+export type FrontierRead =
+	| {readonly _tag: "Frontier"; readonly value: Frontier}
+	| {readonly _tag: "MapAbsent"}
+	| {readonly _tag: "Unknown"; readonly reason: string};
+
+/** Whether a ticket has left the frontier for good. */
+export const isTerminal = (state: TicketState): boolean =>
+	state === "graduated" || state === "retired";
+
+/** The ticket's question: the first non-blank line of its body, else its title. */
+const questionOf = (issue: IssueRecord): string => {
+	const line = issue.body.split("\n").find((l) => l.trim() !== "");
+	return (line ?? issue.title).trim();
+};
+
+interface MarkerScan {
+	readonly lane: {readonly nonce: string} | null;
+	readonly finding: {readonly outcome: Outcome; readonly nonce: string} | null;
+	readonly fork: {readonly route: "session" | "spike"; readonly issue: number} | null;
+	readonly retired: {readonly direction: string} | null;
+}
+
+/**
+ * The last marker of each kind on a ticket, in comment order.
+ *
+ * Last rather than first: a re-laned ticket carries an older `map-lane` and a newer one, and the
+ * lane that holds it now is the newer. Pairing is by ticket, so a finding always closes the lane
+ * that precedes it.
+ */
+export const scanTicketMarkers = (
+	map: number,
+	ticket: number,
+	comments: ReadonlyArray<CommentRecord>,
+): MarkerScan => {
+	let lane: MarkerScan["lane"] = null;
+	let finding: MarkerScan["finding"] = null;
+	let fork: MarkerScan["fork"] = null;
+	let retired: MarkerScan["retired"] = null;
+	for (const comment of comments) {
+		const laneMarker = readLaneMarker(comment.body);
+		if (laneMarker !== null && laneMarker.map === map && laneMarker.ticket === ticket) {
+			lane = {nonce: laneMarker.nonce};
+			finding = null;
+		}
+		const findingMarker = readFindingMarker(comment.body);
+		if (findingMarker !== null && findingMarker.map === map && findingMarker.ticket === ticket) {
+			finding = {outcome: findingMarker.outcome, nonce: findingMarker.nonce};
+		}
+		const forkMarker = readForkMarker(comment.body);
+		if (forkMarker !== null && forkMarker.map === map && forkMarker.ticket === ticket) {
+			fork = {route: forkMarker.route, issue: forkMarker.issue};
+		}
+		const retiredMarker = readRetiredMarker(comment.body);
+		if (retiredMarker !== null && retiredMarker.map === map && retiredMarker.ticket === ticket) {
+			retired = {direction: retiredMarker.direction};
+		}
+	}
+	return {lane, finding, fork, retired};
+};
+
+/**
+ * Whether the map's `## Decisions` already carries this ticket's answer.
+ *
+ * Two citations resolve to one ticket, because the contract's citation grammar has two forms and only
+ * one of them names a ticket: a research or spike finding cites `— from #<ticket>`, and a relayed
+ * ruling cites `— ruled on #<session>`, which names the session the fork pointed at. Matching the
+ * fork's session is what lets a decision ticket graduate at all; without it a forked ticket's answer
+ * could land on the map and the ticket would still read `forked` forever.
+ */
+export const decisionCites = (
+	body: MapBody,
+	ticket: number,
+	forkedSession: number | null,
+): boolean =>
+	body.decisions.some((entry) =>
+		entry.authority._tag === "Finding"
+			? entry.authority.ticket === ticket
+			: forkedSession !== null && entry.authority.session === forkedSession,
+	);
+
+const stateOf = (
+	closed: boolean,
+	markers: MarkerScan,
+	body: MapBody,
+	ticket: number,
+): TicketState => {
+	if (markers.retired !== null && closed) return "retired";
+	const forkedSession =
+		markers.fork !== null && markers.fork.route === "session" ? markers.fork.issue : null;
+	if (closed && decisionCites(body, ticket, forkedSession)) return "graduated";
+	if (markers.fork !== null) return "forked";
+	if (markers.finding !== null) return "lane-closed";
+	if (markers.lane !== null) return "lane-held";
+	return "open";
+};
+
+/** One resolved child, or the reason it is not counted as a ticket of this map. */
+type ChildOutcome =
+	| {readonly _tag: "Ticket"; readonly value: Ticket}
+	| {readonly _tag: "Disregarded"; readonly value: Disregarded}
+	| {readonly _tag: "Skip"}
+	| {readonly _tag: "Unknown"; readonly reason: string};
+
+const resolveChild = (
+	repo: string,
+	map: number,
+	body: MapBody,
+	child: number,
+	permissions: Map<string, string | null>,
+	counters: {comments: number; edgeReads: number},
+): Effect.Effect<ChildOutcome, never, ChildProcessSpawner.ChildProcessSpawner> =>
+	Effect.gen(function* () {
+		const issue = yield* getIssue(repo, child);
+		if (issue._tag === "Absent") {
+			return {
+				_tag: "Unknown" as const,
+				reason: `#${child} is listed as a child of #${map} and does not exist`,
+			};
+		}
+		if (issue._tag === "Unknown") return {_tag: "Unknown" as const, reason: issue.reason};
+
+		const listed = yield* listComments(repo, child);
+		if (listed._tag === "Failure") return {_tag: "Unknown" as const, reason: listed.reason};
+		counters.comments += listed.value.length;
+
+		const reaching = listed.value.find((comment) => reachesForTicketMarker(comment.body));
+		// A child with no `map-ticket:` comment at all reaches for nothing — an unmarked issue is not
+		// a frontier ticket and is not a ticket that "looks like" this map's, so it is neither counted
+		// nor disregarded. `map ticket`'s partial application leaves exactly this, and re-running it
+		// with the same question resumes rather than duplicating.
+		if (reaching === undefined) return {_tag: "Skip" as const};
+
+		// Content is not authority (ADR 0055): every marker this walk reads must come from a `write+`
+		// author, so a thread anyone can comment on cannot hand itself a lane or retire a ticket. A
+		// permission read that FAILS is UNKNOWN for the whole run, never a demotion — v1 demoted an
+		// authorized author on a transient read failure, which hands the lane to a later claimant on a
+		// network blip.
+		const authorized: CommentRecord[] = [];
+		for (const comment of listed.value) {
+			let permission = permissions.get(comment.author);
+			if (permission === undefined) {
+				const read = yield* permissionFor(repo, comment.author);
+				if (read._tag === "Unknown") {
+					return {
+						_tag: "Unknown" as const,
+						reason: `the repository permission of "${comment.author}" could not be read (${read.reason})`,
+					};
+				}
+				permission = read._tag === "Present" ? read.value : null;
+				permissions.set(comment.author, permission);
+			}
+			if (permission !== null && AUTHORIZED.has(permission)) authorized.push(comment);
+		}
+
+		const opening = authorized.find((comment) => reachesForTicketMarker(comment.body));
+		if (opening === undefined) {
+			return {
+				_tag: "Disregarded" as const,
+				value: {
+					ticket: child,
+					reason: "unauthorized" as const,
+					detail: "every map-ticket marker on this child is from an author with no write permission",
+				},
+			};
+		}
+
+		const marker = readTicketMarker(opening.body);
+		if (marker === null) {
+			return {
+				_tag: "Disregarded" as const,
+				value: {
+					ticket: child,
+					reason: "malformed" as const,
+					detail: "the map-ticket marker is not `map-ticket: #<map> · <kind> · <nonce>`",
+				},
+			};
+		}
+		if (marker.map !== map) {
+			return {
+				_tag: "Disregarded" as const,
+				value: {
+					ticket: child,
+					reason: "foreign-map" as const,
+					detail: `the map-ticket marker names map #${marker.map}, not #${map}`,
+				},
+			};
+		}
+
+		const waits = yield* blockedBy(repo, child);
+		counters.edgeReads += 1;
+		if (waits._tag !== "Present") {
+			return {
+				_tag: "Unknown" as const,
+				reason:
+					waits._tag === "Absent"
+						? `#${child}'s blocked_by list reports the issue does not exist`
+						: waits.reason,
+			};
+		}
+		const gates = yield* blocking(repo, child);
+		counters.edgeReads += 1;
+		if (gates._tag !== "Present") {
+			return {
+				_tag: "Unknown" as const,
+				reason:
+					gates._tag === "Absent"
+						? `#${child}'s blocking list reports the issue does not exist`
+						: gates.reason,
+			};
+		}
+
+		const markers = scanTicketMarkers(map, child, authorized);
+		const state = stateOf(issue.value.state === "closed", markers, body, child);
+		return {
+			_tag: "Ticket" as const,
+			value: {
+				number: child,
+				kind: marker.kind,
+				question: questionOf(issue.value),
+				state,
+				blockedBy: waits.value,
+				blocking: gates.value,
+				...(state === "lane-held" && markers.lane !== null ? {nonce: markers.lane.nonce} : {}),
+				...(state === "forked" && markers.fork?.route === "session"
+					? {session: markers.fork.issue}
+					: {}),
+				...(state === "forked" && markers.fork?.route === "spike"
+					? {spike: markers.fork.issue}
+					: {}),
+				...(state === "lane-closed" && markers.finding !== null
+					? {outcome: markers.finding.outcome}
+					: {}),
+				...(state === "retired" && markers.retired !== null
+					? {retiredBy: markers.retired.direction}
+					: {}),
+			},
+		};
+	});
+
+/**
+ * Every frontier ticket of `map`, with its state and edges resolved.
+ *
+ * The scan is sequential rather than concurrent on purpose: the ACL memo is what keeps a thread of
+ * markers from one author to one permission read, and a concurrent walk would race the memo into one
+ * lookup per child.
+ */
+export const readFrontier = (
+	repo: string,
+	map: number,
+	body: MapBody,
+): Effect.Effect<FrontierRead, never, ChildProcessSpawner.ChildProcessSpawner> =>
+	Effect.gen(function* () {
+		const children = yield* subIssues(repo, map);
+		if (children._tag === "Absent") return {_tag: "MapAbsent" as const};
+		if (children._tag === "Unknown") return {_tag: "Unknown" as const, reason: children.reason};
+
+		const permissions = new Map<string, string | null>();
+		const counters = {comments: 0, edgeReads: 0};
+		const tickets: Ticket[] = [];
+		const disregarded: Disregarded[] = [];
+		for (const child of children.value) {
+			const outcome = yield* resolveChild(repo, map, body, child, permissions, counters);
+			if (outcome._tag === "Unknown") return {_tag: "Unknown" as const, reason: outcome.reason};
+			if (outcome._tag === "Ticket") tickets.push(outcome.value);
+			if (outcome._tag === "Disregarded") disregarded.push(outcome.value);
+		}
+
+		return {
+			_tag: "Frontier" as const,
+			value: {
+				tickets,
+				disregarded,
+				scanned: {children: children.value.length, ...counters},
+			},
+		};
+	});
+
+/** The four answers a frontier may carry. All four are answers, and all four exit `0`. */
+export type FrontierToken = "awaiting-founder" | "lanes-pending" | "clear" | "empty";
+
+export const frontierToken = (tickets: ReadonlyArray<Ticket>): FrontierToken => {
+	if (tickets.length === 0) return "empty";
+	const awaiting = tickets.some(
+		(ticket) => ticket.kind === "decision" && (ticket.state === "open" || ticket.state === "forked"),
+	);
+	if (awaiting) return "awaiting-founder";
+	return tickets.every((ticket) => isTerminal(ticket.state)) ? "clear" : "lanes-pending";
+};
+
+/** `state → how many tickets hold it`, plus the derived `blocked` count. */
+export const counts = (tickets: ReadonlyArray<Ticket>): Readonly<Record<string, number>> => {
+	const unresolved = new Set(
+		tickets.filter((ticket) => !isTerminal(ticket.state)).map((ticket) => ticket.number),
+	);
+	const tally: Record<string, number> = {
+		open: 0,
+		"lane-held": 0,
+		"lane-closed": 0,
+		forked: 0,
+		graduated: 0,
+		retired: 0,
+		blocked: 0,
+	};
+	for (const ticket of tickets) {
+		tally[ticket.state] = (tally[ticket.state] ?? 0) + 1;
+		// Derived, never stored: a ticket can be both `open` and blocked, and collapsing the two would
+		// lose which. Whether a standalone issue may carry stored blockedness is open at #4840; this
+		// read takes no position on it.
+		if (ticket.blockedBy.some((number) => unresolved.has(number))) {
+			tally.blocked = (tally.blocked ?? 0) + 1;
+		}
+	}
+	return tally;
+};

--- a/packages/fabrika-cli/src/map/frontier.unit.test.ts
+++ b/packages/fabrika-cli/src/map/frontier.unit.test.ts
@@ -1,0 +1,138 @@
+import {describe, expect, it} from "vitest";
+import type {CommentRecord} from "../io/issues.ts";
+import {MAP_BODY, parsed} from "./fixtures.test-support.ts";
+import {
+	counts,
+	decisionCites,
+	frontierToken,
+	isTerminal,
+	scanTicketMarkers,
+	type Ticket,
+} from "./frontier.ts";
+import {
+	composeFindingMarker,
+	composeForkMarker,
+	composeLaneMarker,
+	composeRetiredMarker,
+} from "./markers.ts";
+
+const ticket = (over: Partial<Ticket> & Pick<Ticket, "state">): Ticket => ({
+	number: 9142,
+	kind: "research",
+	question: "which table carries the weight column?",
+	blockedBy: [],
+	blocking: [],
+	...over,
+});
+
+const comment = (id: number, body: string): CommentRecord => ({
+	id,
+	author: "usirin",
+	createdAt: "2026-08-10T00:00:00Z",
+	updatedAt: "2026-08-10T00:00:00Z",
+	body,
+});
+
+describe("frontierToken", () => {
+	it("is `empty` on zero tickets — a fact, and the ordinary state of a fresh map", () => {
+		expect(frontierToken([])).toBe("empty");
+	});
+
+	it("is `awaiting-founder` when a decision ticket is open or forked", () => {
+		expect(frontierToken([ticket({state: "open", kind: "decision"})])).toBe("awaiting-founder");
+		expect(frontierToken([ticket({state: "forked", kind: "decision"})])).toBe("awaiting-founder");
+	});
+
+	it("is `lanes-pending` for a prototype out at a spike — work in flight is not a question he owes", () => {
+		expect(frontierToken([ticket({state: "forked", kind: "prototype"})])).toBe("lanes-pending");
+	});
+
+	it("is `clear` only when every ticket is terminal", () => {
+		expect(
+			frontierToken([ticket({state: "graduated"}), ticket({number: 9143, state: "retired"})]),
+		).toBe("clear");
+		expect(
+			frontierToken([ticket({state: "graduated"}), ticket({number: 9143, state: "open"})]),
+		).toBe("lanes-pending");
+	});
+});
+
+describe("counts", () => {
+	it("tallies each state and derives `blocked` separately, so `open` and blocked both survive", () => {
+		const tally = counts([
+			ticket({number: 9142, state: "open"}),
+			ticket({number: 9143, state: "open", blockedBy: [9142]}),
+		]);
+		expect(tally.open).toBe(2);
+		expect(tally.blocked).toBe(1);
+	});
+
+	it("does not count a ticket blocked only by a terminal one", () => {
+		const tally = counts([
+			ticket({number: 9142, state: "graduated"}),
+			ticket({number: 9143, state: "open", blockedBy: [9142]}),
+		]);
+		expect(tally.blocked).toBe(0);
+	});
+});
+
+describe("isTerminal", () => {
+	it("is exactly graduated and retired", () => {
+		expect(["graduated", "retired"].every(isTerminal as (s: string) => boolean)).toBe(true);
+		expect(
+			["open", "lane-held", "lane-closed", "forked"].some(isTerminal as (s: string) => boolean),
+		).toBe(false);
+	});
+});
+
+describe("scanTicketMarkers", () => {
+	it("pairs a finding with the lane before it, and a re-lane clears the earlier finding", () => {
+		const scanned = scanTicketMarkers(9140, 9143, [
+			comment(1, composeLaneMarker({map: 9140, ticket: 9143, nonce: "aaaaaaaa"})),
+			comment(
+				2,
+				composeFindingMarker({map: 9140, ticket: 9143, outcome: "unreachable", nonce: "aaaaaaaa"}),
+			),
+			comment(3, composeLaneMarker({map: 9140, ticket: 9143, nonce: "bbbbbbbb"})),
+		]);
+		expect(scanned.lane).toEqual({nonce: "bbbbbbbb"});
+		expect(scanned.finding).toBeNull();
+	});
+
+	it("ignores markers naming another map, whatever the sub-issue edge says", () => {
+		const scanned = scanTicketMarkers(9140, 9143, [
+			comment(1, composeLaneMarker({map: 9999, ticket: 9143, nonce: "aaaaaaaa"})),
+		]);
+		expect(scanned.lane).toBeNull();
+	});
+
+	it("reads the fork route and the retirement direction", () => {
+		const scanned = scanTicketMarkers(9140, 9144, [
+			comment(1, composeForkMarker({map: 9140, ticket: 9144, route: "session", issue: 9301})),
+			comment(2, composeRetiredMarker({map: 9140, ticket: 9144, direction: "a decay curve"})),
+		]);
+		expect(scanned.fork).toEqual({route: "session", issue: 9301});
+		expect(scanned.retired).toEqual({direction: "a decay curve"});
+	});
+});
+
+describe("decisionCites", () => {
+	const body = parsed(
+		MAP_BODY.replace(
+			"## Decisions\n",
+			"## Decisions\n- the column is on the account row — from #9146\n- an invited çaylak starts at 0 — ruled on #9301 R2.3\n",
+		),
+	);
+
+	it("resolves a research finding by the ticket it names", () => {
+		expect(decisionCites(body, 9146, null)).toBe(true);
+		expect(decisionCites(body, 9142, null)).toBe(false);
+	});
+
+	it("resolves a relayed ruling by the session the fork pointed at", () => {
+		// A ruling cites the session, never the ticket, so this is the only way a forked decision
+		// ticket can ever graduate.
+		expect(decisionCites(body, 9144, 9301)).toBe(true);
+		expect(decisionCites(body, 9144, 9302)).toBe(false);
+	});
+});

--- a/packages/fabrika-cli/src/map/guards.ts
+++ b/packages/fabrika-cli/src/map/guards.ts
@@ -1,0 +1,197 @@
+/**
+ * The checks every `map` verb runs before it decides anything, factored here so eight verbs cannot
+ * disagree about what a leak is, what a missing map is, or what a stale digest is.
+ *
+ * Each returns the refusal itself rather than a boolean, so a caller cannot receive "this failed" and
+ * then compose a message that drifts from the code it seats.
+ */
+
+import {Effect} from "effect";
+import type {ChildProcessSpawner} from "effect/unstable/process";
+import {resolveRepo} from "../io/issues.ts";
+import {isBareAtReference, renderLeaks, scanBody} from "../report/leaks.ts";
+import {FAILED, refuse, type VerbOutcome} from "../verb.ts";
+import {digestOfBody, type MapBody} from "./body.ts";
+import {
+	BAD_SECTIONS,
+	BARE_AT_PATH,
+	DIGEST_STALE,
+	LEAKED_PATH,
+	NO_TARGET,
+	PRECONDITION_UNKNOWN,
+	TICKET_RETIRED,
+	TICKET_UNKNOWN,
+} from "./codes.ts";
+import {
+	type Frontier,
+	isTerminal,
+	type MapRead,
+	readFrontier,
+	readMap,
+	type Ticket,
+} from "./frontier.ts";
+
+export type Guarded<A> =
+	| {readonly _tag: "Ok"; readonly value: A}
+	| {readonly _tag: "Refused"; readonly outcome: VerbOutcome};
+
+const refused = (outcome: VerbOutcome): Guarded<never> => ({_tag: "Refused", outcome});
+
+/** The target repository, or the usage refusal that names both ways to supply it. */
+export const targetRepo = (
+	verb: string,
+	explicit: string | null,
+	env: Readonly<Record<string, string | undefined>>,
+): Effect.Effect<Guarded<string>, never, ChildProcessSpawner.ChildProcessSpawner> =>
+	Effect.gen(function* () {
+		const attempt = yield* resolveRepo(explicit, env);
+		return attempt._tag === "Ok"
+			? {_tag: "Ok" as const, value: attempt.value}
+			: refused(
+					refuse(
+						FAILED,
+						`${verb}: cannot resolve a target repo — pass --repo, or run inside a checkout whose origin remote resolves.`,
+					),
+				);
+	});
+
+/**
+ * Every text this group sends to GitHub is leak-scanned before the write — bodies, comments, and the
+ * issue titles `map open` and `map ticket` compose (#3086: the title is scanned, not only the body).
+ *
+ * **The base's `5` reads "…and `--redact` was not given"; no `map` verb offers `--redact`**, so here
+ * it fires on any machine-local path unconditionally. The condition narrows; the meaning does not.
+ */
+export const leakFree = (verb: string, what: string, text: string): VerbOutcome | null => {
+	if (isBareAtReference(text)) {
+		return refuse(
+			BARE_AT_PATH,
+			`${verb}: the ${what} is a bare "@" path reference — the text never arrived. Send the text itself.`,
+		);
+	}
+	const scan = scanBody(text);
+	return scan.leaks.length === 0
+		? null
+		: refuse(
+				LEAKED_PATH,
+				`${verb}: the ${what} carries ${scan.leaks.length} machine-local path(s) — refusing to post them to a public issue.`,
+				renderLeaks(scan.leaks),
+			);
+};
+
+/** The map issue and its parsed body, or the `7` / `4` / `11` refusal the read proved. */
+export const requireMap = (
+	verb: string,
+	repo: string,
+	map: number,
+): Effect.Effect<
+	Guarded<Extract<MapRead, {_tag: "Map"}>>,
+	never,
+	ChildProcessSpawner.ChildProcessSpawner
+> =>
+	Effect.gen(function* () {
+		const read = yield* readMap(repo, map);
+		if (read._tag === "Map") return {_tag: "Ok" as const, value: read};
+		if (read._tag === "Absent") {
+			return refused(refuse(NO_TARGET, `${verb}: #${map} does not exist, or is not a wayfinding map.`));
+		}
+		if (read._tag === "Malformed") {
+			return refused(
+				refuse(
+					BAD_SECTIONS,
+					`${verb}: #${map}'s body does not hold the five sections in order (${read.reason}) — refusing to act on a body this verb cannot read.`,
+				),
+			);
+		}
+		return refused(
+			refuse(
+				PRECONDITION_UNKNOWN,
+				`${verb}: cannot read #${map}: ${read.reason} — nothing was written and the map's state is UNKNOWN.`,
+			),
+		);
+	});
+
+/**
+ * The map, for a verb that never writes its body — `map lane` and `map finding`.
+ *
+ * Identical to {@link requireMap} except that an unparseable body is `11` rather than `4`. Those two
+ * verbs hold no `4` seat for the map body: they do not splice it, and what an unreadable body costs
+ * them is only that a ticket's `graduated` state cannot be proven — which is a precondition that
+ * could not be read, not a defect in a document they were asked to write.
+ */
+export const requireMapForState = (
+	verb: string,
+	repo: string,
+	map: number,
+): Effect.Effect<
+	Guarded<Extract<MapRead, {_tag: "Map"}>>,
+	never,
+	ChildProcessSpawner.ChildProcessSpawner
+> =>
+	Effect.gen(function* () {
+		const guarded = yield* requireMap(verb, repo, map);
+		if (guarded._tag === "Ok" || guarded.outcome.code !== BAD_SECTIONS) return guarded;
+		return refused(
+			refuse(
+				PRECONDITION_UNKNOWN,
+				`${verb}: #${map}'s body does not parse, so whether a ticket already graduated is UNKNOWN — nothing was written.`,
+			),
+		);
+	});
+
+/**
+ * One frontier ticket of this map, resolved against a fresh frontier read.
+ *
+ * A ticket that is not this map's is `13` and a frontier that could not be read is `11` — never an
+ * empty frontier, which would let a rate-limited read report a real ticket as unknown.
+ */
+export const requireTicket = (
+	verb: string,
+	repo: string,
+	map: number,
+	body: MapBody,
+	ticket: number,
+): Effect.Effect<
+	Guarded<{readonly ticket: Ticket; readonly frontier: Frontier}>,
+	never,
+	ChildProcessSpawner.ChildProcessSpawner
+> =>
+	Effect.gen(function* () {
+		const read = yield* readFrontier(repo, map, body);
+		if (read._tag !== "Frontier") {
+			return refused(
+				refuse(
+					PRECONDITION_UNKNOWN,
+					`${verb}: cannot read #${map}'s children: ${read._tag === "MapAbsent" ? "the map reports no child list" : read.reason} — nothing was written and the frontier is UNKNOWN, never empty.`,
+				),
+			);
+		}
+		const found = read.value.tickets.find((row) => row.number === ticket);
+		return found === undefined
+			? refused(
+					refuse(TICKET_UNKNOWN, `${verb}: #${ticket} is not a frontier ticket of map #${map}.`),
+				)
+			: {_tag: "Ok" as const, value: {ticket: found, frontier: read.value}};
+	});
+
+/** The `18` refusal a verb owes a ticket that already left the frontier. */
+export const notTerminal = (verb: string, ticket: Ticket, tail: string): VerbOutcome | null =>
+	isTerminal(ticket.state)
+		? refuse(TICKET_RETIRED, `${verb}: #${ticket.number} already left the frontier — ${tail}`)
+		: null;
+
+/** The compare-and-set guard: the body must still be the one `--digest` was taken from. */
+export const digestFresh = (
+	verb: string,
+	map: number,
+	body: MapBody,
+	supplied: string,
+): VerbOutcome | null => {
+	const current = digestOfBody(body);
+	return current === supplied
+		? null
+		: refuse(
+				DIGEST_STALE,
+				`${verb}: #${map}'s body moved since --digest ${supplied} (now ${current}) — nothing was written. Re-read and re-apply.`,
+			);
+};

--- a/packages/fabrika-cli/src/map/guards.ts
+++ b/packages/fabrika-cli/src/map/guards.ts
@@ -93,7 +93,9 @@ export const requireMap = (
 		const read = yield* readMap(repo, map);
 		if (read._tag === "Map") return {_tag: "Ok" as const, value: read};
 		if (read._tag === "Absent") {
-			return refused(refuse(NO_TARGET, `${verb}: #${map} does not exist, or is not a wayfinding map.`));
+			return refused(
+				refuse(NO_TARGET, `${verb}: #${map} does not exist, or is not a wayfinding map.`),
+			);
 		}
 		if (read._tag === "Malformed") {
 			return refused(

--- a/packages/fabrika-cli/src/map/lane-verb.ts
+++ b/packages/fabrika-cli/src/map/lane-verb.ts
@@ -1,0 +1,125 @@
+/**
+ * `map lane` — claim a research lane on one ticket, keyed on the run nonce, refusing a `decision`
+ * ticket.
+ *
+ * A compare-and-set on a marker under a closed-set kind guard. Re-running with the nonce that already
+ * holds the lane is `resumed`, not an error: a stateless re-dispatch of the same run must be able to
+ * prove it still owns the lane without a second claim.
+ *
+ * The five refusals stay five seats with five remedies, which is `epic-lock`'s scar designed out: it
+ * collapsed distinct refusals onto one code, so a caller could not tell an abandoned lock from a
+ * missing target. Here `15`, `13`, `18` and `11` say different true things.
+ */
+
+import {Effect} from "effect";
+import type {ChildProcessSpawner} from "effect/unstable/process";
+import {createComment, getComment} from "../io/issues.ts";
+import {normalizeForReadback} from "../report/compose.ts";
+import {answer, FAILED, refuse, type VerbOutcome} from "../verb.ts";
+import {KIND_MISMATCH, LANE_NOT_MINE, READBACK_MISMATCH, WRITE_UNKNOWN} from "./codes.ts";
+import {
+	notTerminal,
+	requireMapForState,
+	requireTicket,
+	targetRepo,
+} from "./guards.ts";
+import {composeLaneMarker, isNonce} from "./markers.ts";
+
+export interface LaneOptions {
+	readonly map: number;
+	readonly ticket: number;
+	readonly nonce: string;
+	readonly repo: string | null;
+	readonly env: Readonly<Record<string, string | undefined>>;
+}
+
+const VERB = "map lane";
+
+export const runLane = (
+	options: LaneOptions,
+): Effect.Effect<VerbOutcome, never, ChildProcessSpawner.ChildProcessSpawner> =>
+	Effect.gen(function* () {
+		if (!isNonce(options.nonce)) {
+			return refuse(
+				FAILED,
+				`${VERB}: --nonce "${options.nonce}" is not eight lowercase hex characters — a human-readable label two runs would collide on is not a lane key.`,
+			);
+		}
+
+		const target = yield* targetRepo(VERB, options.repo, options.env);
+		if (target._tag === "Refused") return target.outcome;
+		const repo = target.value;
+
+		const found = yield* requireMapForState(VERB, repo, options.map);
+		if (found._tag === "Refused") return found.outcome;
+
+		const resolved = yield* requireTicket(
+			VERB,
+			repo,
+			options.map,
+			found.value.body,
+			options.ticket,
+		);
+		if (resolved._tag === "Refused") return resolved.outcome;
+		const {ticket} = resolved.value;
+
+		const left = notTerminal(VERB, ticket, "there is nothing left to research.");
+		if (left !== null) return left;
+		if (ticket.kind === "decision") {
+			return refuse(
+				KIND_MISMATCH,
+				`${VERB}: #${ticket.number} is a decision ticket — it is the founder's to answer. Route it with map fork, never a lane.`,
+			);
+		}
+		if (ticket.state === "lane-held") {
+			return ticket.nonce === options.nonce
+				? answer(
+						JSON.stringify({
+							map: options.map,
+							ticket: options.ticket,
+							nonce: options.nonce,
+							lane: "resumed",
+						}),
+						[`${VERB}: ${repo}, #${options.ticket}'s lane already held by this nonce.`],
+					)
+				: refuse(
+						LANE_NOT_MINE,
+						`${VERB}: #${ticket.number}'s lane is held by ${ticket.nonce} — refusing to open a second lane on one ticket.`,
+					);
+		}
+
+		const scope = `${VERB}: ${repo}, #${options.ticket} resolved ${ticket.state}, lane free.`;
+		const body = composeLaneMarker({
+			map: options.map,
+			ticket: options.ticket,
+			nonce: options.nonce,
+		});
+		const posted = yield* createComment(repo, options.ticket, body);
+		if (posted._tag === "Failure") {
+			return refuse(
+				WRITE_UNKNOWN,
+				`${VERB}: could not post the lane claim on #${options.ticket}: ${posted.reason} — whether the lane is held is UNKNOWN.`,
+				[scope],
+			);
+		}
+		// The POST's own response is the server echoing the request; the lane is only held once the
+		// marker reads back, which is the read-back `epic-lock` never performed on its own stamp.
+		const landed = yield* getComment(repo, posted.value.id);
+		if (landed._tag === "Failure" || normalizeForReadback(landed.value) !== normalizeForReadback(body)) {
+			return refuse(
+				READBACK_MISMATCH,
+				`${VERB}: posted the lane claim on #${options.ticket} and the read-back differs — the comment exists and needs a human.`,
+				[scope],
+			);
+		}
+
+		return answer(
+			JSON.stringify({
+				map: options.map,
+				ticket: options.ticket,
+				nonce: options.nonce,
+				lane: "held",
+			}),
+			[scope],
+		);
+	});

--- a/packages/fabrika-cli/src/map/lane-verb.ts
+++ b/packages/fabrika-cli/src/map/lane-verb.ts
@@ -17,12 +17,7 @@ import {createComment, getComment} from "../io/issues.ts";
 import {normalizeForReadback} from "../report/compose.ts";
 import {answer, FAILED, refuse, type VerbOutcome} from "../verb.ts";
 import {KIND_MISMATCH, LANE_NOT_MINE, READBACK_MISMATCH, WRITE_UNKNOWN} from "./codes.ts";
-import {
-	notTerminal,
-	requireMapForState,
-	requireTicket,
-	targetRepo,
-} from "./guards.ts";
+import {notTerminal, requireMapForState, requireTicket, targetRepo} from "./guards.ts";
 import {composeLaneMarker, isNonce} from "./markers.ts";
 
 export interface LaneOptions {
@@ -105,7 +100,10 @@ export const runLane = (
 		// The POST's own response is the server echoing the request; the lane is only held once the
 		// marker reads back, which is the read-back `epic-lock` never performed on its own stamp.
 		const landed = yield* getComment(repo, posted.value.id);
-		if (landed._tag === "Failure" || normalizeForReadback(landed.value) !== normalizeForReadback(body)) {
+		if (
+			landed._tag === "Failure" ||
+			normalizeForReadback(landed.value) !== normalizeForReadback(body)
+		) {
 			return refuse(
 				READBACK_MISMATCH,
 				`${VERB}: posted the lane claim on #${options.ticket} and the read-back differs — the comment exists and needs a human.`,

--- a/packages/fabrika-cli/src/map/lane-verb.unit.test.ts
+++ b/packages/fabrika-cli/src/map/lane-verb.unit.test.ts
@@ -1,0 +1,169 @@
+import {Effect} from "effect";
+import {describe, expect, it} from "vitest";
+import {errOut, fakeShell, okOut} from "../fakes.test-support.ts";
+import type {ExecResult} from "../io/exec.ts";
+import {
+	KIND_MISMATCH,
+	LANE_NOT_MINE,
+	PRECONDITION_UNKNOWN,
+	READBACK_MISMATCH,
+	TICKET_RETIRED,
+	TICKET_UNKNOWN,
+	WRITE_UNKNOWN,
+} from "./codes.ts";
+import {
+	commentsJson,
+	issueJson,
+	MAP,
+	MAP_BODY,
+	NONCE,
+	REPO,
+	TICKET,
+} from "./fixtures.test-support.ts";
+import {runLane} from "./lane-verb.ts";
+import {composeLaneMarker, composeRetiredMarker, composeTicketMarker} from "./markers.ts";
+
+const POST = /--method POST repos\/o\/r\/issues\/9142\/comments/;
+const GET_COMMENT = /issues\/comments\/\d+/;
+const PERMISSION = /collaborators\/.*\/permission/;
+const CHILDREN = /issues\/9140\/sub_issues/;
+const TICKET_COMMENTS = /issues\/9142\/comments/;
+const EDGES = /issues\/9142\/dependencies\//;
+const TICKET_ISSUE = /issues\/9142$/;
+const MAP_ISSUE = /issues\/9140$/;
+
+const ticketMarker = (kind: "research" | "decision" | "prototype" = "research") =>
+	composeTicketMarker({map: MAP, kind, nonce: NONCE});
+
+const options = {
+	map: MAP,
+	ticket: TICKET,
+	nonce: NONCE,
+	repo: null,
+	env: {CLAUDE_PIPELINE_REPO: REPO},
+};
+
+const run = (
+	script: ReadonlyArray<readonly [RegExp, ExecResult]>,
+	over: Partial<typeof options> = {},
+) => Effect.runPromise(Effect.provide(runLane({...options, ...over}), fakeShell(script).layer));
+
+const frontier = (
+	comments: ReadonlyArray<{readonly id: number; readonly body: string}>,
+	ticketState = "open",
+) =>
+	[
+		[PERMISSION, okOut("write")],
+		[CHILDREN, okOut(`[{"number":${TICKET}}]`)],
+		[TICKET_COMMENTS, okOut(commentsJson(comments))],
+		[EDGES, okOut("[]")],
+		[TICKET_ISSUE, okOut(issueJson({number: TICKET, body: "which table?", state: ticketState}))],
+		[MAP_ISSUE, okOut(issueJson({number: MAP, body: MAP_BODY, labels: ["wayfinding:map"]}))],
+	] as const;
+
+describe("runLane", () => {
+	it("exits 1 on a lane key two runs would collide on, before any read", async () => {
+		const out = await run([], {nonce: "run-1"});
+		expect(out.code).toBe(1);
+		expect(out.stdout).toBe("");
+		expect(out.stderr.join("\n")).toContain("is not a lane key");
+	});
+
+	it("exits 0 and holds the lane when it is free", async () => {
+		const body = composeLaneMarker({map: MAP, ticket: TICKET, nonce: NONCE});
+		const out = await run([
+			[POST, okOut('{"id":7,"html_url":"u"}')],
+			[GET_COMMENT, okOut(JSON.stringify({body}))],
+			...frontier([{id: 1, body: ticketMarker()}]),
+		]);
+		expect(out.code).toBe(0);
+		expect(JSON.parse(out.stdout)).toEqual({
+			map: MAP,
+			ticket: TICKET,
+			nonce: NONCE,
+			lane: "held",
+		});
+	});
+
+	it("exits 0 with `resumed` when this nonce already holds it — a re-run is not an error", async () => {
+		const out = await run([
+			...frontier([
+				{id: 1, body: ticketMarker()},
+				{id: 2, body: composeLaneMarker({map: MAP, ticket: TICKET, nonce: NONCE})},
+			]),
+		]);
+		expect(out.code).toBe(0);
+		expect(JSON.parse(out.stdout).lane).toBe("resumed");
+	});
+
+	it("exits 15 when another nonce holds the lane", async () => {
+		const out = await run([
+			...frontier([
+				{id: 1, body: ticketMarker()},
+				{id: 2, body: composeLaneMarker({map: MAP, ticket: TICKET, nonce: "bbbbbbbb"})},
+			]),
+		]);
+		expect(out.code).toBe(LANE_NOT_MINE);
+		expect(out.stdout).toBe("");
+		expect(out.stderr.join("\n")).toContain("bbbbbbbb");
+	});
+
+	it("exits 20 on a decision ticket — it is routed, never researched", async () => {
+		const out = await run([...frontier([{id: 1, body: ticketMarker("decision")}])]);
+		expect(out.code).toBe(KIND_MISMATCH);
+		expect(out.stderr.join("\n")).toContain("Route it with map fork");
+	});
+
+	it("exits 18 on a ticket that already left the frontier", async () => {
+		const out = await run([
+			...frontier(
+				[
+					{id: 1, body: ticketMarker()},
+					{
+						id: 2,
+						body: composeRetiredMarker({map: MAP, ticket: TICKET, direction: "a decay curve"}),
+					},
+				],
+				"closed",
+			),
+		]);
+		expect(out.code).toBe(TICKET_RETIRED);
+		expect(out.stdout).toBe("");
+	});
+
+	it("exits 13 when the number is not a frontier ticket of this map", async () => {
+		const out = await run([...frontier([{id: 1, body: ticketMarker()}])], {ticket: 9999});
+		expect(out.code).toBe(TICKET_UNKNOWN);
+		expect(out.stdout).toBe("");
+	});
+
+	it("exits 11 when the comment read fails — whether a lane is held is UNKNOWN, never free", async () => {
+		const out = await run([
+			[TICKET_COMMENTS, errOut("gh: Bad gateway (HTTP 502)")],
+			...frontier([{id: 1, body: ticketMarker()}]).slice(3),
+			[PERMISSION, okOut("write")],
+			[CHILDREN, okOut(`[{"number":${TICKET}}]`)],
+		]);
+		expect(out.code).toBe(PRECONDITION_UNKNOWN);
+		expect(out.stdout).toBe("");
+	});
+
+	it("exits 8 when the claim write fails — whether the lane is held is UNKNOWN", async () => {
+		const out = await run([
+			[POST, errOut("gh: Bad gateway (HTTP 502)")],
+			...frontier([{id: 1, body: ticketMarker()}]),
+		]);
+		expect(out.code).toBe(WRITE_UNKNOWN);
+		expect(out.stdout).toBe("");
+	});
+
+	it("exits 9 when the posted marker does not read back — the stamp is verified, never assumed", async () => {
+		const out = await run([
+			[POST, okOut('{"id":7,"html_url":"u"}')],
+			[GET_COMMENT, okOut(JSON.stringify({body: "something else entirely"}))],
+			...frontier([{id: 1, body: ticketMarker()}]),
+		]);
+		expect(out.code).toBe(READBACK_MISMATCH);
+		expect(out.stdout).toBe("");
+	});
+});

--- a/packages/fabrika-cli/src/map/markers.ts
+++ b/packages/fabrika-cli/src/map/markers.ts
@@ -1,0 +1,158 @@
+/**
+ * The five one-line markers this group writes on a frontier ticket, and their readers.
+ *
+ * Ticket state lives in markers, issue state and native edges — never in a body row (see
+ * `./body.ts`). Each marker is composed here and nowhere else, so the grammar has one home and a
+ * reader cannot drift from a writer.
+ *
+ * **These are the group's own grammar, not `../build/claim.ts`'s.** That module's `composeMarker`
+ * hardcodes the `build-claim:` prefix, its `MARKER_RE` matches only that, and its `resolveOwnership`
+ * compares a **session** token. This group's lanes are keyed on a **run nonce**, so calling it would
+ * find zero markers on a frontier ticket and answer *unclaimed* on every call — a lane that can never
+ * see a sibling lane's claim, which is precisely the collision the nonce exists to prevent.
+ *
+ * <!-- anchor: LANE-KEY-IS-THE-RUN-NONCE --> The lane key is the caller's run nonce, never a session
+ * id and never a pid: `$CLAUDE_CODE_SESSION_ID` is pane-constant rather than per-run (#5028) and
+ * sibling subagents of one parent share it (#4516), so two lanes of one charting run would key onto
+ * one namespace and each would classify the other's claim as its own. Nothing here reads the
+ * environment — the nonce arrives as an argument.
+ */
+
+import {
+	emit as emitTicketMarker,
+	nonce as brandNonce,
+	read as readTicketFormat,
+	reaches,
+} from "../wire/map-ticket.ts";
+import type {Kind} from "./body.ts";
+
+/**
+ * The ticket marker is the one marker here that is a **registered wire format**, so its grammar lives
+ * in `../wire/map-ticket.ts` and this module only re-exports it. The other four are internal to this
+ * group: nothing outside it reads them, and a format nobody meets through is not a wire format.
+ */
+export {reaches as reachesForTicketMarker} from "../wire/map-ticket.ts";
+
+/** The lane key's grammar. A human-readable label two runs would collide on is not a nonce. */
+export const NONCE = /^[0-9a-f]{8}$/;
+export const isNonce = (value: string): boolean => NONCE.test(value);
+
+/** What a research lane established. There is no fourth value and no default. */
+export const OUTCOMES = ["answered", "no-evidence", "unreachable"] as const;
+export type Outcome = (typeof OUTCOMES)[number];
+export const isOutcome = (value: string): value is Outcome =>
+	(OUTCOMES as readonly string[]).includes(value);
+
+/** The ticket's identity marker: which map it belongs to, what clears it, and who filed it. */
+export interface TicketMarker {
+	readonly map: number;
+	readonly kind: Kind;
+	readonly nonce: string;
+}
+
+/** A lane claim on one ticket. */
+export interface LaneMarker {
+	readonly map: number;
+	readonly ticket: number;
+	readonly nonce: string;
+}
+
+/** A lane closing with what it established. */
+export interface FindingMarker {
+	readonly map: number;
+	readonly ticket: number;
+	readonly outcome: Outcome;
+	readonly nonce: string;
+}
+
+/** Where a question is being answered instead — a `grilling` session or a `prototyping` spike. */
+export interface ForkMarker {
+	readonly map: number;
+	readonly ticket: number;
+	readonly route: "session" | "spike";
+	readonly issue: number;
+}
+
+/** The ticket left the frontier into the out-of-scope section, and the direction it retired into. */
+export interface RetiredMarker {
+	readonly map: number;
+	readonly ticket: number;
+	readonly direction: string;
+}
+
+const first = (body: string): string => body.split("\n").find((line) => line.trim() !== "") ?? "";
+
+export const composeTicketMarker = (marker: TicketMarker): string => {
+	const key = brandNonce(marker.nonce);
+	// Unreachable through the callers, which all check `isNonce` first; composing an unbranded nonce
+	// would emit a marker this module's own reader refuses, so it throws rather than shipping bytes.
+	if (key === null) throw new Error(`"${marker.nonce}" is not a run nonce`);
+	return emitTicketMarker({map: marker.map, kind: marker.kind, nonce: key});
+};
+
+export const composeLaneMarker = (marker: LaneMarker): string =>
+	`map-lane: #${marker.map} · #${marker.ticket} · ${marker.nonce}`;
+
+export const composeFindingMarker = (marker: FindingMarker): string =>
+	`map-finding: #${marker.map} · #${marker.ticket} · ${marker.outcome} · ${marker.nonce}`;
+
+export const composeForkMarker = (marker: ForkMarker): string =>
+	`map-fork: #${marker.map} · #${marker.ticket} · ${marker.route} #${marker.issue}`;
+
+export const composeRetiredMarker = (marker: RetiredMarker): string =>
+	`map-retired: #${marker.map} · #${marker.ticket} · ${marker.direction}`;
+
+/** The ticket marker on a comment's first non-blank line, or `null` when it does not conform. */
+export const readTicketMarker = (body: string): TicketMarker | null => {
+	const result = readTicketFormat(body);
+	return result._tag === "Found" ? result.value : null;
+};
+
+export const readLaneMarker = (body: string): LaneMarker | null => {
+	const matched = /^map-lane:\s*#(\d+)\s*·\s*#(\d+)\s*·\s*([0-9a-f]+)\s*$/.exec(first(body).trim());
+	const nonce = matched?.[3] ?? "";
+	if (matched === null || !isNonce(nonce)) return null;
+	return {
+		map: Number.parseInt(matched[1] ?? "0", 10),
+		ticket: Number.parseInt(matched[2] ?? "0", 10),
+		nonce,
+	};
+};
+
+export const readFindingMarker = (body: string): FindingMarker | null => {
+	const matched = /^map-finding:\s*#(\d+)\s*·\s*#(\d+)\s*·\s*([a-z-]+)\s*·\s*([0-9a-f]+)\s*$/.exec(
+		first(body).trim(),
+	);
+	const outcome = matched?.[3] ?? "";
+	const nonce = matched?.[4] ?? "";
+	if (matched === null || !isOutcome(outcome) || !isNonce(nonce)) return null;
+	return {
+		map: Number.parseInt(matched[1] ?? "0", 10),
+		ticket: Number.parseInt(matched[2] ?? "0", 10),
+		outcome,
+		nonce,
+	};
+};
+
+export const readForkMarker = (body: string): ForkMarker | null => {
+	const matched = /^map-fork:\s*#(\d+)\s*·\s*#(\d+)\s*·\s*(session|spike)\s+#(\d+)\s*$/.exec(
+		first(body).trim(),
+	);
+	if (matched === null) return null;
+	return {
+		map: Number.parseInt(matched[1] ?? "0", 10),
+		ticket: Number.parseInt(matched[2] ?? "0", 10),
+		route: matched[3] === "spike" ? "spike" : "session",
+		issue: Number.parseInt(matched[4] ?? "0", 10),
+	};
+};
+
+export const readRetiredMarker = (body: string): RetiredMarker | null => {
+	const matched = /^map-retired:\s*#(\d+)\s*·\s*#(\d+)\s*·\s*(.+?)\s*$/.exec(first(body).trim());
+	if (matched === null) return null;
+	return {
+		map: Number.parseInt(matched[1] ?? "0", 10),
+		ticket: Number.parseInt(matched[2] ?? "0", 10),
+		direction: matched[3] ?? "",
+	};
+};

--- a/packages/fabrika-cli/src/map/markers.ts
+++ b/packages/fabrika-cli/src/map/markers.ts
@@ -19,10 +19,9 @@
  */
 
 import {
-	emit as emitTicketMarker,
 	nonce as brandNonce,
+	emit as emitTicketMarker,
 	read as readTicketFormat,
-	reaches,
 } from "../wire/map-ticket.ts";
 import type {Kind} from "./body.ts";
 

--- a/packages/fabrika-cli/src/map/markers.unit.test.ts
+++ b/packages/fabrika-cli/src/map/markers.unit.test.ts
@@ -1,0 +1,106 @@
+import {describe, expect, it} from "vitest";
+import {
+	composeFindingMarker,
+	composeForkMarker,
+	composeLaneMarker,
+	composeRetiredMarker,
+	composeTicketMarker,
+	isNonce,
+	isOutcome,
+	reachesForTicketMarker,
+	readFindingMarker,
+	readForkMarker,
+	readLaneMarker,
+	readRetiredMarker,
+	readTicketMarker,
+} from "./markers.ts";
+
+describe("the nonce grammar", () => {
+	it("admits eight lowercase hex characters and nothing else", () => {
+		expect(isNonce("7f3a9c21")).toBe(true);
+		// A human-readable label is exactly what two runs of one charting session would collide on.
+		expect(isNonce("run-1")).toBe(false);
+		expect(isNonce("7F3A9C21")).toBe(false);
+		expect(isNonce("7f3a9c2")).toBe(false);
+	});
+});
+
+describe("the outcome vocabulary", () => {
+	it("is closed at three, so an absent answer cannot arrive as a fourth", () => {
+		expect(["answered", "no-evidence", "unreachable"].every(isOutcome)).toBe(true);
+		expect(isOutcome("none")).toBe(false);
+		expect(isOutcome("")).toBe(false);
+	});
+});
+
+describe.each([
+	[
+		"ticket",
+		composeTicketMarker({map: 9140, kind: "research", nonce: "7f3a9c21"}),
+		(body: string) => readTicketMarker(body),
+		{map: 9140, kind: "research", nonce: "7f3a9c21"},
+	],
+	[
+		"lane",
+		composeLaneMarker({map: 9140, ticket: 9143, nonce: "7f3a9c21"}),
+		(body: string) => readLaneMarker(body),
+		{map: 9140, ticket: 9143, nonce: "7f3a9c21"},
+	],
+	[
+		"finding",
+		composeFindingMarker({map: 9140, ticket: 9143, outcome: "no-evidence", nonce: "7f3a9c21"}),
+		(body: string) => readFindingMarker(body),
+		{map: 9140, ticket: 9143, outcome: "no-evidence", nonce: "7f3a9c21"},
+	],
+	[
+		"fork",
+		composeForkMarker({map: 9140, ticket: 9144, route: "session", issue: 9301}),
+		(body: string) => readForkMarker(body),
+		{map: 9140, ticket: 9144, route: "session", issue: 9301},
+	],
+	[
+		"retired",
+		composeRetiredMarker({map: 9140, ticket: 9147, direction: "a decay curve nobody can predict"}),
+		(body: string) => readRetiredMarker(body),
+		{map: 9140, ticket: 9147, direction: "a decay curve nobody can predict"},
+	],
+])("the %s marker", (_name, composed, read, expected) => {
+	it("round-trips composed bytes back to its fields", () => {
+		expect(read(composed)).toEqual(expected);
+	});
+
+	it("is read off the first non-blank line only, so a quoted marker further down is not one", () => {
+		expect(read(`someone said:\n\n${composed}\n`)).toBeNull();
+	});
+
+	it("does not read another marker's bytes", () => {
+		expect(read("map-elsewhere: #9140 · nothing\n")).toBeNull();
+	});
+});
+
+describe("readTicketMarker", () => {
+	it("refuses an off-vocabulary kind rather than answering a plausible one", () => {
+		expect(readTicketMarker("map-ticket: #9140 · investigation · 7f3a9c21")).toBeNull();
+	});
+
+	it("refuses a lane key two runs would collide on", () => {
+		expect(readTicketMarker("map-ticket: #9140 · research · run-1")).toBeNull();
+	});
+
+	it("still REACHES for the format when it does not conform, so the child is disregarded not dropped", () => {
+		expect(reachesForTicketMarker("map-ticket: #9140 · investigation · 7f3a9c21")).toBe(true);
+		expect(reachesForTicketMarker("Picking this one up.")).toBe(false);
+	});
+});
+
+describe("composeTicketMarker", () => {
+	it("throws rather than emitting bytes its own reader would refuse", () => {
+		expect(() => composeTicketMarker({map: 9140, kind: "research", nonce: "run-1"})).toThrow();
+	});
+});
+
+describe("readFindingMarker", () => {
+	it("refuses an outcome off the closed set — the absent answer never arrives as a fourth", () => {
+		expect(readFindingMarker("map-finding: #9140 · #9143 · nothing-found · 7f3a9c21")).toBeNull();
+	});
+});

--- a/packages/fabrika-cli/src/map/open-verb.ts
+++ b/packages/fabrika-cli/src/map/open-verb.ts
@@ -1,0 +1,265 @@
+/**
+ * `map open` — mint or resume the map for a destination, refusing a destination that is not fog.
+ *
+ * The check order is local-first: everything decidable from the bytes on stdin runs before any
+ * network read, so a refusable input costs no API call and a refusal always names the cheapest
+ * correctable thing first.
+ *
+ * **Zero open maps is a fact, not a failed read** — the first map in a repository is the ordinary
+ * case. A search that could not complete is `11`, and nothing is written.
+ *
+ * **Write order, and what a partial application leaves.** The issue is created first, the label
+ * second. A failure between them leaves a map issue nobody can find, which is `8` with the number
+ * named on stderr so a human can finish it — the surviving half is inert rather than harmful. The
+ * reverse order is not available (a label cannot be applied to an issue that does not exist), which
+ * is why the orphan is named rather than prevented.
+ */
+
+import {Effect} from "effect";
+import type {ChildProcessSpawner} from "effect/unstable/process";
+import {
+	addLabels,
+	createUnlabelledIssue,
+	getIssue,
+	listLabels,
+	openIssuesWithLabel,
+	searchIssues,
+} from "../io/issues.ts";
+import type {StdinRead} from "../io/stdin.ts";
+import {normalizeForReadback} from "../report/compose.ts";
+import {tokenize} from "../report/dedup.ts";
+import {answer, FAILED, refuse, type VerbOutcome} from "../verb.ts";
+import {digestOfBody, type MapBody, parseBody, renderMintBody} from "./body.ts";
+import {
+	ALREADY_DESCOPED,
+	EMPTY_STDIN,
+	MAP_AMBIGUOUS,
+	NO_TARGET,
+	NOT_FOG,
+	PRECONDITION_UNKNOWN,
+	READBACK_MISMATCH,
+	WRITE_UNKNOWN,
+} from "./codes.ts";
+import {MAP_LABEL} from "./frontier.ts";
+import {leakFree, targetRepo} from "./guards.ts";
+import {
+	candidatesFor,
+	isQuestion,
+	linesOf,
+	mapTitle,
+	namesSameThing,
+	type QuestionCandidate,
+} from "./open.ts";
+
+export interface OpenOptions {
+	readonly destination: string;
+	readonly repo: string | null;
+	readonly env: Readonly<Record<string, string | undefined>>;
+	/** The fd-0 read, injected so the failed-read and TTY paths are testable without a descriptor. */
+	readonly stdin: Effect.Effect<StdinRead>;
+}
+
+interface OpenMap {
+	readonly number: number;
+	readonly body: MapBody;
+}
+
+const VERB = "map open";
+
+export const runOpen = (
+	options: OpenOptions,
+): Effect.Effect<VerbOutcome, never, ChildProcessSpawner.ChildProcessSpawner> =>
+	Effect.gen(function* () {
+		const destination = options.destination.trim();
+		if (destination === "") {
+			return refuse(FAILED, `${VERB}: --destination is empty — refusing to chart an unnamed fog.`);
+		}
+
+		const target = yield* targetRepo(VERB, options.repo, options.env);
+		if (target._tag === "Refused") return target.outcome;
+		const repo = target.value;
+
+		const read = yield* options.stdin;
+		if (read._tag === "Failed") {
+			return refuse(
+				FAILED,
+				`${VERB}: could not read stdin: ${read.reason} — the questions are UNKNOWN, never absent.`,
+			);
+		}
+		const lines = linesOf(read._tag === "NoStdin" ? "" : read.text);
+		if (lines.length === 0) {
+			return refuse(
+				EMPTY_STDIN,
+				`${VERB}: stdin was read and held no question — a destination with no open question is not fog.`,
+			);
+		}
+
+		const leaked = leakFree(VERB, "destination", destination) ?? leakFree(VERB, "question", lines.join("\n"));
+		if (leaked !== null) return leaked;
+
+		const questions = lines.filter(isQuestion);
+		if (questions.length === 0) {
+			return refuse(
+				NOT_FOG,
+				`${VERB}: none of the ${lines.length} supplied line(s) is stated as a question — a destination with no stated question is not fog. This belongs in intake, not on a map.`,
+			);
+		}
+
+		const labels = yield* listLabels(repo);
+		if (labels._tag === "Failure") {
+			return refuse(
+				PRECONDITION_UNKNOWN,
+				`${VERB}: cannot read the label set of ${repo}: ${labels.reason} — nothing was written and whether this destination is charted is UNKNOWN.`,
+			);
+		}
+		if (!labels.value.includes(MAP_LABEL)) {
+			return refuse(
+				NO_TARGET,
+				`${VERB}: the ${MAP_LABEL} label does not exist in ${repo} — refusing to open an unlabelled map no later run could find.`,
+			);
+		}
+
+		const listed = yield* openIssuesWithLabel(repo, MAP_LABEL);
+		if (listed._tag === "Failure") {
+			return refuse(
+				PRECONDITION_UNKNOWN,
+				`${VERB}: cannot search ${repo} for existing maps: ${listed.reason} — nothing was written and whether this destination is charted is UNKNOWN.`,
+			);
+		}
+
+		const maps: OpenMap[] = [];
+		for (const row of listed.value) {
+			const issue = yield* getIssue(repo, row.number);
+			if (issue._tag === "Unknown") {
+				return refuse(
+					PRECONDITION_UNKNOWN,
+					`${VERB}: cannot read map #${row.number}: ${issue.reason} — nothing was written and whether this destination is charted is UNKNOWN.`,
+				);
+			}
+			// A map that vanished between the list and the read is not a map this run must reconcile:
+			// the list is a snapshot, and an issue closed in that window is no longer open.
+			if (issue._tag === "Absent") continue;
+			const parsed = parseBody(issue.value.body);
+			if (parsed._tag === "Malformed") {
+				return refuse(
+					PRECONDITION_UNKNOWN,
+					`${VERB}: map #${row.number}'s body does not parse (${parsed.reason}) — nothing was written and whether this destination is charted is UNKNOWN.`,
+				);
+			}
+			maps.push({number: row.number, body: parsed.value});
+		}
+
+		for (const map of maps) {
+			const rejected = map.body.outOfScope.find((entry) =>
+				namesSameThing(destination, entry.direction),
+			);
+			if (rejected !== undefined) {
+				return refuse(
+					ALREADY_DESCOPED,
+					`${VERB}: this destination is recorded out of scope on map #${map.number} (${rejected.recordedAt}) — read the recorded reasoning before re-proposing it.`,
+				);
+			}
+		}
+
+		const charted = maps.filter((map) => namesSameThing(destination, map.body.destination));
+		if (charted.length > 1) {
+			return refuse(
+				MAP_AMBIGUOUS,
+				`${VERB}: ${charted.length} open maps match this destination (${charted.map((map) => `#${map.number}`).join(", ")}) — refusing to guess which; close or merge one.`,
+			);
+		}
+
+		const answeredCandidates: {
+			question: string;
+			candidates: ReadonlyArray<QuestionCandidate>;
+		}[] = [];
+		let candidateRows = 0;
+		for (const question of questions) {
+			const hits = yield* searchIssues(repo, tokenize(question));
+			if (hits._tag === "Failure") {
+				return refuse(
+					PRECONDITION_UNKNOWN,
+					`${VERB}: cannot read the board for "${question}": ${hits.reason} — nothing was written and whether it is already answered is UNKNOWN.`,
+				);
+			}
+			const candidates = candidatesFor(question, hits.value);
+			candidateRows += candidates.length;
+			if (candidates.length > 0) answeredCandidates.push({question, candidates});
+		}
+
+		const scope = `${VERB}: ${repo}, ${maps.length} open map(s) searched, ${lines.length} line(s) read, ${questions.length} stated as question(s), ${candidateRows} candidate(s) ranked.`;
+		const scanned = {maps: maps.length, candidates: candidateRows};
+
+		const resumed = charted[0];
+		if (resumed !== undefined) {
+			// The body is not touched at all on a resume: appending the supplied questions would
+			// duplicate fog a previous session already recorded, and this verb takes no `--digest`, so it
+			// holds no guard that would make a body write safe.
+			return answer(
+				JSON.stringify({
+					map: resumed.number,
+					created: false,
+					destination,
+					questions: questions.length,
+					answeredCandidates,
+					digest: digestOfBody(resumed.body),
+					scanned,
+				}),
+				[scope],
+			);
+		}
+
+		const body = renderMintBody(destination, questions);
+		const created = yield* createUnlabelledIssue(repo, mapTitle(destination), body);
+		if (created._tag === "Failure") {
+			return refuse(
+				WRITE_UNKNOWN,
+				`${VERB}: could not create the map in ${repo}: ${created.reason} — whether it landed is UNKNOWN. Re-run and read the refusal before filing again.`,
+				[scope],
+			);
+		}
+		const labelled = yield* addLabels(repo, created.value.number, [MAP_LABEL]);
+		if (labelled._tag === "Failure") {
+			return refuse(
+				WRITE_UNKNOWN,
+				`${VERB}: created #${created.value.number} and the label write did NOT land — the map exists and no later run can find it. Add ${MAP_LABEL} to #${created.value.number} by hand.`,
+				[scope],
+			);
+		}
+
+		// A create call's own response is the server echoing the request; a fresh read is the only
+		// evidence the map is on the board carrying its label.
+		const landed = yield* getIssue(repo, created.value.number);
+		let landedBody: MapBody | null = null;
+		let mismatch: string | null = null;
+		if (landed._tag === "Absent") mismatch = "the map is not readable after the create";
+		else if (landed._tag === "Unknown") mismatch = `the read-back itself failed: ${landed.reason}`;
+		else if (!landed.value.labels.includes(MAP_LABEL)) mismatch = `it does not carry ${MAP_LABEL}`;
+		else if (normalizeForReadback(landed.value.body) !== normalizeForReadback(body)) {
+			mismatch = "the landed body differs from what was composed";
+		} else {
+			const reparsed = parseBody(landed.value.body);
+			if (reparsed._tag === "Malformed") mismatch = `the landed body does not parse: ${reparsed.reason}`;
+			else landedBody = reparsed.value;
+		}
+		if (mismatch !== null || landedBody === null) {
+			return refuse(
+				READBACK_MISMATCH,
+					`${VERB}: created #${created.value.number} but the read-back is wrong: ${mismatch ?? "the landed body could not be re-parsed"}. The map exists and needs fixing by hand.`,
+				[scope],
+			);
+		}
+
+		return answer(
+			JSON.stringify({
+				map: created.value.number,
+				created: true,
+				destination,
+				questions: questions.length,
+				answeredCandidates,
+				digest: digestOfBody(landedBody),
+				scanned,
+			}),
+			[scope],
+		);
+	});

--- a/packages/fabrika-cli/src/map/open-verb.ts
+++ b/packages/fabrika-cli/src/map/open-verb.ts
@@ -94,7 +94,8 @@ export const runOpen = (
 			);
 		}
 
-		const leaked = leakFree(VERB, "destination", destination) ?? leakFree(VERB, "question", lines.join("\n"));
+		const leaked =
+			leakFree(VERB, "destination", destination) ?? leakFree(VERB, "question", lines.join("\n"));
 		if (leaked !== null) return leaked;
 
 		const questions = lines.filter(isQuestion);
@@ -239,13 +240,14 @@ export const runOpen = (
 			mismatch = "the landed body differs from what was composed";
 		} else {
 			const reparsed = parseBody(landed.value.body);
-			if (reparsed._tag === "Malformed") mismatch = `the landed body does not parse: ${reparsed.reason}`;
+			if (reparsed._tag === "Malformed")
+				mismatch = `the landed body does not parse: ${reparsed.reason}`;
 			else landedBody = reparsed.value;
 		}
 		if (mismatch !== null || landedBody === null) {
 			return refuse(
 				READBACK_MISMATCH,
-					`${VERB}: created #${created.value.number} but the read-back is wrong: ${mismatch ?? "the landed body could not be re-parsed"}. The map exists and needs fixing by hand.`,
+				`${VERB}: created #${created.value.number} but the read-back is wrong: ${mismatch ?? "the landed body could not be re-parsed"}. The map exists and needs fixing by hand.`,
 				[scope],
 			);
 		}

--- a/packages/fabrika-cli/src/map/open-verb.unit.test.ts
+++ b/packages/fabrika-cli/src/map/open-verb.unit.test.ts
@@ -1,0 +1,239 @@
+import {Effect} from "effect";
+import {describe, expect, it} from "vitest";
+import {errOut, fakeShell, okOut, once} from "../fakes.test-support.ts";
+import type {ExecResult} from "../io/exec.ts";
+import type {StdinRead} from "../io/stdin.ts";
+import {
+	ALREADY_DESCOPED,
+	BARE_AT_PATH,
+	EMPTY_STDIN,
+	LEAKED_PATH,
+	MAP_AMBIGUOUS,
+	NO_TARGET,
+	NOT_FOG,
+	PRECONDITION_UNKNOWN,
+	READBACK_MISMATCH,
+	WRITE_UNKNOWN,
+} from "./codes.ts";
+import {issueJson, MAP_BODY, MAP_BODY_WITH_REJECTION, REPO} from "./fixtures.test-support.ts";
+import {runOpen} from "./open-verb.ts";
+
+const LABELS = /repos\/o\/r\/labels/;
+const OPEN_MAPS = /issues\?state=open&labels=/;
+const SEARCH = /search\/issues/;
+const CREATE = /--method POST repos\/o\/r\/issues -f/;
+const ADD_LABEL = /--method POST repos\/o\/r\/issues\/9140\/labels/;
+const NEW_MAP = /issues\/9140$/;
+const EXISTING_MAP = /issues\/9200$/;
+
+const QUESTIONS = "does a suspended account keep its weight?\nwhat clock does weight decay on?\n";
+
+const run = (
+	script: ReadonlyArray<readonly [RegExp, ExecResult]>,
+	stdin: StdinRead = {_tag: "Text", text: QUESTIONS},
+	destination = "how moderation weight is earned",
+) =>
+	Effect.runPromise(
+		Effect.provide(
+			runOpen({
+				destination,
+				repo: null,
+				env: {CLAUDE_PIPELINE_REPO: REPO},
+				stdin: Effect.succeed(stdin),
+			}),
+			fakeShell(script).layer,
+		),
+	);
+
+const labelsOk = [LABELS, okOut("wayfinding:map\nstatus:needs-triage")] as const;
+const noMaps = [OPEN_MAPS, okOut("")] as const;
+const noHits = [SEARCH, okOut("")] as const;
+const minted = issueJson({number: 9140, body: "", labels: ["wayfinding:map"]});
+
+describe("runOpen — the checks before it mints", () => {
+	it("exits 3 with nothing on stdout when stdin held no question", async () => {
+		const out = await run([labelsOk], {_tag: "Text", text: "  \n\n"});
+		expect(out.code).toBe(EMPTY_STDIN);
+		expect(out.stdout).toBe("");
+		expect(out.stderr.join("\n")).toContain("is not fog");
+	});
+
+	it("exits 17 when nothing supplied is stated as a question — the checkable half of the fog test", async () => {
+		const out = await run([labelsOk], {_tag: "Text", text: "build the invite acceptance form\n"});
+		expect(out.code).toBe(NOT_FOG);
+		expect(out.stdout).toBe("");
+		expect(out.stderr.join("\n")).toContain("belongs in intake");
+	});
+
+	it("exits 5 on a machine-local path, unconditionally — no map verb offers --redact", async () => {
+		const out = await run([labelsOk], {_tag: "Text", text: "does ~/notes/weight.md say?\n"});
+		expect(out.code).toBe(LEAKED_PATH);
+		expect(out.stdout).toBe("");
+	});
+
+	it("exits 6 on a bare @ reference, which is not redactable", async () => {
+		const out = await run([labelsOk], {_tag: "Text", text: "@notes/weight.md"});
+		expect(out.code).toBe(BARE_AT_PATH);
+		expect(out.stdout).toBe("");
+	});
+
+	it("exits 7 when the wayfinding:map label does not exist", async () => {
+		const out = await run([[LABELS, okOut("status:needs-triage")]]);
+		expect(out.code).toBe(NO_TARGET);
+		expect(out.stderr.join("\n")).toContain("no later run could find");
+	});
+
+	it("exits 11 when the map search fails — nothing was written and charting is UNKNOWN", async () => {
+		const out = await run([labelsOk, [OPEN_MAPS, errOut("gh: Bad gateway (HTTP 502)")]]);
+		expect(out.code).toBe(PRECONDITION_UNKNOWN);
+		expect(out.stdout).toBe("");
+	});
+
+	it("exits 19 when the destination is already recorded out of scope", async () => {
+		const out = await run(
+			[
+				labelsOk,
+				[OPEN_MAPS, okOut("9200\twayfinding: something else")],
+				[
+					EXISTING_MAP,
+					okOut(
+						issueJson({number: 9200, body: MAP_BODY_WITH_REJECTION, labels: ["wayfinding:map"]}),
+					),
+				],
+			],
+			{_tag: "Text", text: QUESTIONS},
+			"a per-topic weight multiplier",
+		);
+		expect(out.code).toBe(ALREADY_DESCOPED);
+		expect(out.stderr.join("\n")).toContain("read the recorded reasoning");
+	});
+
+	it("exits 16 when two open maps match, refusing to guess which", async () => {
+		const body = okOut(issueJson({number: 9200, body: MAP_BODY, labels: ["wayfinding:map"]}));
+		const out = await run([
+			labelsOk,
+			[OPEN_MAPS, okOut("9200\twayfinding: a\n9201\twayfinding: b")],
+			[/issues\/9200$/, body],
+			[
+				/issues\/9201$/,
+				okOut(issueJson({number: 9201, body: MAP_BODY, labels: ["wayfinding:map"]})),
+			],
+		]);
+		expect(out.code).toBe(MAP_AMBIGUOUS);
+		expect(out.stderr.join("\n")).toContain("close or merge one");
+	});
+});
+
+describe("runOpen — minting and resuming", () => {
+	it("exits 9 when the landed body is not what was composed — the create's echo is not evidence", async () => {
+		const out = await run([
+			labelsOk,
+			noMaps,
+			noHits,
+			[CREATE, okOut('{"number":9140,"html_url":"https://github.com/o/r/issues/9140"}')],
+			[ADD_LABEL, okOut("{}")],
+			[NEW_MAP, okOut(minted)],
+		]);
+		expect(out.code).toBe(READBACK_MISMATCH);
+		expect(out.stdout).toBe("");
+	});
+
+	it("exits 0 on a mint whose read-back matches, reporting created:true and the digest", async () => {
+		const composed = [
+			"## Destination",
+			"how moderation weight is earned",
+			"",
+			"## Decisions",
+			"",
+			"## Frontier",
+			"",
+			"## Fog",
+			"- does a suspended account keep its weight?",
+			"- what clock does weight decay on?",
+			"",
+			"## Out of scope",
+			"",
+		].join("\n");
+		const out = await run([
+			labelsOk,
+			noMaps,
+			noHits,
+			[CREATE, okOut('{"number":9140,"html_url":"https://github.com/o/r/issues/9140"}')],
+			[ADD_LABEL, okOut("{}")],
+			[NEW_MAP, okOut(issueJson({number: 9140, body: composed, labels: ["wayfinding:map"]}))],
+		]);
+		expect(out.code).toBe(0);
+		const answer = JSON.parse(out.stdout);
+		expect(answer).toMatchObject({map: 9140, created: true, questions: 2});
+		expect(answer.digest).toMatch(/^[0-9a-f]{12}$/);
+		expect(answer.scanned).toEqual({maps: 0, candidates: 0});
+	});
+
+	it("exits 8 naming the number when the label write does not land — the survivor is inert", async () => {
+		const out = await run([
+			labelsOk,
+			noMaps,
+			noHits,
+			[CREATE, okOut('{"number":9140,"html_url":"https://github.com/o/r/issues/9140"}')],
+			[ADD_LABEL, errOut("gh: Bad gateway (HTTP 502)")],
+		]);
+		expect(out.code).toBe(WRITE_UNKNOWN);
+		expect(out.stdout).toBe("");
+		expect(out.stderr.join("\n")).toContain("Add wayfinding:map to #9140 by hand");
+	});
+
+	it("resumes an already-charted destination without touching its body", async () => {
+		const shell = fakeShell([
+			labelsOk,
+			[OPEN_MAPS, okOut("9200\twayfinding: how moderation weight is earned")],
+			[EXISTING_MAP, okOut(issueJson({number: 9200, body: MAP_BODY, labels: ["wayfinding:map"]}))],
+			noHits,
+		]);
+		const out = await Effect.runPromise(
+			Effect.provide(
+				runOpen({
+					destination: "how moderation weight is earned",
+					repo: null,
+					env: {CLAUDE_PIPELINE_REPO: REPO},
+					stdin: Effect.succeed({_tag: "Text", text: QUESTIONS} as StdinRead),
+				}),
+				shell.layer,
+			),
+		);
+		expect(out.code).toBe(0);
+		expect(JSON.parse(out.stdout)).toMatchObject({map: 9200, created: false, questions: 2});
+		expect(shell.calls.some((line) => line.includes("--method PATCH"))).toBe(false);
+	});
+
+	it("reports ranked candidates as evidence and charts every question anyway", async () => {
+		const composed = [
+			"## Destination",
+			"how moderation weight is earned",
+			"",
+			"## Decisions",
+			"",
+			"## Frontier",
+			"",
+			"## Fog",
+			"- does a suspended account keep its weight?",
+			"- what clock does weight decay on?",
+			"",
+			"## Out of scope",
+			"",
+		].join("\n");
+		const out = await run([
+			labelsOk,
+			noMaps,
+			[once(SEARCH), okOut("9098\tA suspended account keeps its moderation weight")],
+			[SEARCH, okOut("")],
+			[CREATE, okOut('{"number":9140,"html_url":"https://github.com/o/r/issues/9140"}')],
+			[ADD_LABEL, okOut("{}")],
+			[NEW_MAP, okOut(issueJson({number: 9140, body: composed, labels: ["wayfinding:map"]}))],
+		]);
+		expect(out.code).toBe(0);
+		const answer = JSON.parse(out.stdout);
+		expect(answer.questions).toBe(2);
+		expect(answer.answeredCandidates).toHaveLength(1);
+		expect(answer.answeredCandidates[0].candidates[0].issue).toBe(9098);
+	});
+});

--- a/packages/fabrika-cli/src/map/open.ts
+++ b/packages/fabrika-cli/src/map/open.ts
@@ -1,0 +1,114 @@
+/**
+ * `map open`'s pure half: what counts as a question, what the map's title reads as, and how a
+ * destination is ranked against what is already charted.
+ *
+ * <!-- anchor: THE-GATE-IS-EVIDENCE-NOT-VERDICT --> **This is the fog-or-ticket test's checkable
+ * half, and deliberately not the whole test.** Whether something is genuinely fog is a judgment the
+ * skill carries; what a verb can prove is that the caller enumerated questions, that nobody has
+ * charted or rejected this destination already. That is what makes a wrong classification catchable
+ * at the point it is made rather than well-formed and wrong (#4227) — the claim is bound to an
+ * enumerable artifact instead of to the caller's confidence. It is **not** a second answer to ADR
+ * 0203's fog-versus-buildable discriminator, which is seated at intake and expected here.
+ */
+
+import {rank, scoreTitle, TOKEN_FLOOR, tokenize} from "../report/dedup.ts";
+
+/** The prefix every map title carries, so the label and the title agree about what an issue is. */
+export const TITLE_PREFIX = "wayfinding: ";
+/** GitHub's practical title ceiling; the destination is cut to fit on a word boundary. */
+export const TITLE_LIMIT = 250;
+
+/**
+ * The interrogatives a question may open with, when it does not close with `?`.
+ *
+ * A closed set rather than a heuristic: this is a **grammar** check on the input document, which is
+ * what makes `17` provable. The verb is not deciding that the destination is a deliverable, it is
+ * reporting that nothing it was handed was *stated* as a question.
+ */
+const INTERROGATIVES = new Set([
+	"what",
+	"who",
+	"when",
+	"where",
+	"why",
+	"which",
+	"how",
+	"does",
+	"do",
+	"is",
+	"are",
+	"can",
+	"should",
+	"would",
+	"will",
+]);
+
+export const isQuestion = (line: string): boolean => {
+	const text = line.trim();
+	if (text === "") return false;
+	if (text.endsWith("?")) return true;
+	const first = text.split(/[^\p{L}\p{N}]+/u)[0] ?? "";
+	return INTERROGATIVES.has(first.toLowerCase());
+};
+
+/** The non-blank lines of stdin, in the order they arrived. */
+export const linesOf = (stdin: string): ReadonlyArray<string> =>
+	stdin
+		.split("\n")
+		.map((line) => line.trim())
+		.filter((line) => line !== "");
+
+/** Cut to `limit` characters on a word boundary, so a truncated title never ends mid-word. */
+export const truncateOnWordBoundary = (text: string, limit = TITLE_LIMIT): string => {
+	if (text.length <= limit) return text;
+	const cut = text.slice(0, limit);
+	const space = cut.lastIndexOf(" ");
+	return (space > 0 ? cut.slice(0, space) : cut).trimEnd();
+};
+
+/** The map's title: the destination verbatim, prefixed and truncated. */
+export const mapTitle = (destination: string): string =>
+	truncateOnWordBoundary(`${TITLE_PREFIX}${destination.trim()}`);
+
+/**
+ * Whether two short noun phrases name the same thing, by the shared dedup ranking.
+ *
+ * The floor is `dedup`'s own {@link TOKEN_FLOOR}: below it a phrase carries no information about
+ * *this* destination, so a match on one token is not a match at all.
+ */
+export const namesSameThing = (a: string, b: string): boolean => {
+	const tokens = tokenize(a);
+	return tokens.length >= TOKEN_FLOOR && scoreTitle(tokens, b) >= TOKEN_FLOOR;
+};
+
+export interface QuestionCandidate {
+	readonly issue: number;
+	readonly score: number;
+	readonly title: string;
+}
+
+/**
+ * The board rows that rank against one question.
+ *
+ * <!-- anchor: RANKING-IS-EVIDENCE-NOT-PROOF --> Advisory, and the caller never refuses on it.
+ * Title-token overlap can rank a question against an issue; it cannot prove the issue answers it, and
+ * seating a `NOT_FOG` refusal on a ranking would dress a stochastic judgment in a proven exit code.
+ */
+export const candidatesFor = (
+	question: string,
+	rows: ReadonlyArray<{readonly number: number; readonly title: string}>,
+	limit = 5,
+): ReadonlyArray<QuestionCandidate> =>
+	rank({
+		tokens: tokenize(question),
+		queue: [],
+		search: rows,
+		limit,
+		label: "board",
+	})
+		.candidates.filter((candidate) => candidate.score >= TOKEN_FLOOR)
+		.map((candidate) => ({
+			issue: candidate.number,
+			score: candidate.score,
+			title: candidate.title,
+		}));

--- a/packages/fabrika-cli/src/map/open.unit.test.ts
+++ b/packages/fabrika-cli/src/map/open.unit.test.ts
@@ -1,0 +1,85 @@
+import {describe, expect, it} from "vitest";
+import {
+	candidatesFor,
+	isQuestion,
+	linesOf,
+	mapTitle,
+	namesSameThing,
+	TITLE_LIMIT,
+	truncateOnWordBoundary,
+} from "./open.ts";
+
+describe("isQuestion", () => {
+	it("admits a line that closes with a question mark", () => {
+		expect(isQuestion("does a suspended account keep its weight?")).toBe(true);
+	});
+
+	it("admits a line that opens with an interrogative and closes without one", () => {
+		expect(isQuestion("what clock does weight decay on")).toBe(true);
+	});
+
+	it("refuses a line stated as a deliverable — the grammar is what makes 17 provable", () => {
+		expect(isQuestion("build the invite acceptance form")).toBe(false);
+		expect(isQuestion("")).toBe(false);
+	});
+
+	it("reads a Turkish opening word as prose rather than as an interrogative", () => {
+		expect(isQuestion("kefil sistemi kurulacak")).toBe(false);
+	});
+});
+
+describe("linesOf", () => {
+	it("keeps the arrival order and drops blank lines", () => {
+		expect(linesOf("one?\n\n  two?  \n")).toEqual(["one?", "two?"]);
+	});
+});
+
+describe("truncateOnWordBoundary", () => {
+	it("leaves a short string alone", () => {
+		expect(truncateOnWordBoundary("short", 20)).toBe("short");
+	});
+
+	it("never ends mid-word", () => {
+		expect(truncateOnWordBoundary("alpha beta gamma", 12)).toBe("alpha beta");
+	});
+});
+
+describe("mapTitle", () => {
+	it("prefixes the destination verbatim and fits the ceiling", () => {
+		expect(mapTitle("how moderation weight is earned")).toBe(
+			"wayfinding: how moderation weight is earned",
+		);
+		expect(mapTitle("weight ".repeat(80)).length).toBeLessThanOrEqual(TITLE_LIMIT);
+	});
+});
+
+describe("namesSameThing", () => {
+	it("matches two phrasings of one destination", () => {
+		expect(
+			namesSameThing("how moderation weight is earned", "how weight is earned by moderation"),
+		).toBe(true);
+	});
+
+	it("does not match on one shared token, which carries no information about this destination", () => {
+		expect(namesSameThing("moderation weight", "invite acceptance")).toBe(false);
+	});
+
+	it("refuses to answer yes below the token floor rather than matching everything", () => {
+		expect(namesSameThing("it", "it")).toBe(false);
+	});
+});
+
+describe("candidatesFor", () => {
+	it("reports the board rows that rank, with their scores", () => {
+		const candidates = candidatesFor("does weight inherit from a kefil?", [
+			{number: 9098, title: "Moderation weight is inherited from the kefil today"},
+			{number: 9099, title: "The invite acceptance form needs a spinner"},
+		]);
+		expect(candidates.map((candidate) => candidate.issue)).toEqual([9098]);
+		expect(candidates[0]?.score).toBeGreaterThan(1);
+	});
+
+	it("reports nothing rather than refusing — the ranking is evidence, never a proven answer", () => {
+		expect(candidatesFor("does weight inherit from a kefil?", [])).toEqual([]);
+	});
+});

--- a/packages/fabrika-cli/src/map/read-verb.ts
+++ b/packages/fabrika-cli/src/map/read-verb.ts
@@ -1,0 +1,71 @@
+/**
+ * `map read` — the parser: five sections, one row per frontier ticket with a closed-set state, the
+ * frontier token, and the body digest.
+ *
+ * <!-- anchor: READ-NEVER-REFUSES-ON-CONTENT --> **This verb never refuses on a ticket's content.** A
+ * ticket whose marker is malformed, or whose kind is off-vocabulary, is reported in `disregarded` at
+ * exit `0` — refusing would suppress the whole frontier over one bad comment and would let anyone
+ * with write access disable the verb by filing one. Its only refusals are a map that does not exist
+ * (`7`), a body that does not parse (`4`), and a read that could not complete (`11`).
+ *
+ * All four frontier tokens exit `0`. A frontier holding open questions is this skill working, and
+ * seating it on a non-zero code would make a caller's `[ $? -ne 0 ]` read "the fog is not cleared
+ * yet" as "the verb never ran".
+ */
+
+import {Effect} from "effect";
+import type {ChildProcessSpawner} from "effect/unstable/process";
+import {answer, refuse, type VerbOutcome} from "../verb.ts";
+import {digestOfBody} from "./body.ts";
+import {PRECONDITION_UNKNOWN} from "./codes.ts";
+import {counts, frontierToken, readFrontier} from "./frontier.ts";
+import {requireMap, targetRepo} from "./guards.ts";
+
+export interface ReadOptions {
+	readonly map: number;
+	readonly repo: string | null;
+	readonly env: Readonly<Record<string, string | undefined>>;
+}
+
+const VERB = "map read";
+
+export const runRead = (
+	options: ReadOptions,
+): Effect.Effect<VerbOutcome, never, ChildProcessSpawner.ChildProcessSpawner> =>
+	Effect.gen(function* () {
+		const target = yield* targetRepo(VERB, options.repo, options.env);
+		if (target._tag === "Refused") return target.outcome;
+		const repo = target.value;
+
+		const found = yield* requireMap(VERB, repo, options.map);
+		if (found._tag === "Refused") return found.outcome;
+		const {body} = found.value;
+
+		const frontier = yield* readFrontier(repo, options.map, body);
+		if (frontier._tag !== "Frontier") {
+			return refuse(
+				PRECONDITION_UNKNOWN,
+				frontier._tag === "MapAbsent"
+					? `${VERB}: cannot read #${options.map}'s children: the map reports no child list — the frontier is UNKNOWN, never empty.`
+					: `${VERB}: cannot read #${options.map}'s children: ${frontier.reason} — the frontier is UNKNOWN, never empty.`,
+			);
+		}
+		const {tickets, disregarded, scanned} = frontier.value;
+
+		const scope = `${VERB}: ${repo}, ${scanned.children} child(ren), ${scanned.edgeReads} edge read(s), ${scanned.comments} comment(s) scanned.`;
+		return answer(
+			JSON.stringify({
+				map: options.map,
+				frontier: frontierToken(tickets),
+				digest: digestOfBody(body),
+				destination: body.destination,
+				tickets,
+				outOfScope: body.outOfScope,
+				fog: body.fog,
+				counts: counts(tickets),
+				disregarded,
+				scanned,
+			}),
+			[scope],
+		);
+	});

--- a/packages/fabrika-cli/src/map/read-verb.unit.test.ts
+++ b/packages/fabrika-cli/src/map/read-verb.unit.test.ts
@@ -1,0 +1,178 @@
+import {Effect} from "effect";
+import {describe, expect, it} from "vitest";
+import {errOut, fakeShell, okOut} from "../fakes.test-support.ts";
+import type {ExecResult} from "../io/exec.ts";
+import {BAD_SECTIONS, NO_TARGET, PRECONDITION_UNKNOWN} from "./codes.ts";
+import {
+	commentsJson,
+	digestFor,
+	issueJson,
+	MAP,
+	MAP_BODY,
+	NONCE,
+	REPO,
+	TICKET,
+} from "./fixtures.test-support.ts";
+import {composeTicketMarker} from "./markers.ts";
+import {runRead} from "./read-verb.ts";
+
+const PERMISSION = /collaborators\/.*\/permission/;
+const CHILDREN = /issues\/9140\/sub_issues/;
+const TICKET_COMMENTS = /issues\/9142\/comments/;
+const BLOCKED_BY = /issues\/9142\/dependencies\/blocked_by/;
+const BLOCKING = /issues\/9142\/dependencies\/blocking/;
+const TICKET_ISSUE = /issues\/9142$/;
+const MAP_ISSUE = /issues\/9140$/;
+
+const run = (script: ReadonlyArray<readonly [RegExp, ExecResult]>) =>
+	Effect.runPromise(
+		Effect.provide(
+			runRead({map: MAP, repo: null, env: {CLAUDE_PIPELINE_REPO: REPO}}),
+			fakeShell(script).layer,
+		),
+	);
+
+const mapOk = [
+	MAP_ISSUE,
+	okOut(issueJson({number: MAP, body: MAP_BODY, labels: ["wayfinding:map"]})),
+] as const;
+const marker = composeTicketMarker({map: MAP, kind: "research", nonce: NONCE});
+const healthy = [
+	[PERMISSION, okOut("write")],
+	[CHILDREN, okOut(`[{"number":${TICKET}}]`)],
+	[TICKET_COMMENTS, okOut(commentsJson([{id: 1, body: marker}]))],
+	[BLOCKED_BY, okOut("[]")],
+	[BLOCKING, okOut("[]")],
+	[TICKET_ISSUE, okOut(issueJson({number: TICKET, body: "which table carries it?"}))],
+	mapOk,
+] as const;
+
+describe("runRead", () => {
+	it("exits 0 with the frontier token, the digest and one ticket row", async () => {
+		const out = await run([...healthy]);
+		expect(out.code).toBe(0);
+		const answer = JSON.parse(out.stdout);
+		expect(answer.frontier).toBe("lanes-pending");
+		expect(answer.digest).toBe(digestFor(MAP_BODY));
+		expect(answer.tickets).toEqual([
+			{
+				number: TICKET,
+				kind: "research",
+				question: "which table carries it?",
+				state: "open",
+				blockedBy: [],
+				blocking: [],
+			},
+		]);
+		expect(answer.counts.open).toBe(1);
+		expect(answer.scanned).toEqual({children: 1, edgeReads: 2, comments: 1});
+	});
+
+	it("exits 0 with `empty` on a proven-empty child set — zero children is a FACT", async () => {
+		const out = await run([[CHILDREN, okOut("[]")], mapOk]);
+		expect(out.code).toBe(0);
+		expect(JSON.parse(out.stdout).frontier).toBe("empty");
+	});
+
+	it("exits 11 with nothing on stdout when the child read fails — never an empty frontier", async () => {
+		const out = await run([[CHILDREN, errOut("gh: Bad gateway (HTTP 502)")], mapOk]);
+		expect(out.code).toBe(PRECONDITION_UNKNOWN);
+		expect(out.stdout).toBe("");
+		expect(out.stderr.join("\n")).toContain("the frontier is UNKNOWN, never empty");
+	});
+
+	it("exits 11 when a permission read fails — never a demotion that frees another run's lane", async () => {
+		const out = await run([
+			[PERMISSION, errOut("gh: Bad gateway (HTTP 502)")],
+			...healthy.slice(1),
+		]);
+		expect(out.code).toBe(PRECONDITION_UNKNOWN);
+		expect(out.stdout).toBe("");
+	});
+
+	it("exits 7 on an issue that is not a map, and on one that does not exist", async () => {
+		const unlabelled = await run([[MAP_ISSUE, okOut(issueJson({number: MAP, body: MAP_BODY}))]]);
+		expect(unlabelled.code).toBe(NO_TARGET);
+		expect(unlabelled.stdout).toBe("");
+		const missing = await run([[MAP_ISSUE, errOut("gh: Not Found (HTTP 404)")]]);
+		expect(missing.code).toBe(NO_TARGET);
+		expect(missing.stderr.join("\n")).toContain("is not a wayfinding map");
+	});
+
+	it("exits 4 on a body that does not hold the five sections in order", async () => {
+		const out = await run([
+			[
+				MAP_ISSUE,
+				okOut(issueJson({number: MAP, body: "## Frontier\n", labels: ["wayfinding:map"]})),
+			],
+		]);
+		expect(out.code).toBe(BAD_SECTIONS);
+		expect(out.stdout).toBe("");
+	});
+
+	it("disregards a malformed marker at exit 0 rather than suppressing the whole frontier", async () => {
+		const out = await run([
+			[PERMISSION, okOut("write")],
+			[CHILDREN, okOut(`[{"number":${TICKET}}]`)],
+			[
+				TICKET_COMMENTS,
+				okOut(commentsJson([{id: 1, body: "map-ticket: #9140 · investigation · 7f3a9c21"}])),
+			],
+			[TICKET_ISSUE, okOut(issueJson({number: TICKET}))],
+			mapOk,
+		]);
+		expect(out.code).toBe(0);
+		const answer = JSON.parse(out.stdout);
+		expect(answer.tickets).toEqual([]);
+		expect(answer.disregarded).toEqual([
+			{
+				ticket: TICKET,
+				reason: "malformed",
+				detail: "the map-ticket marker is not `map-ticket: #<map> · <kind> · <nonce>`",
+			},
+		]);
+	});
+
+	it("disregards a marker naming another map, so a stranger's issue is visible not counted", async () => {
+		const out = await run([
+			[PERMISSION, okOut("write")],
+			[CHILDREN, okOut(`[{"number":${TICKET}}]`)],
+			[
+				TICKET_COMMENTS,
+				okOut(
+					commentsJson([
+						{id: 1, body: composeTicketMarker({map: 9999, kind: "research", nonce: NONCE})},
+					]),
+				),
+			],
+			[TICKET_ISSUE, okOut(issueJson({number: TICKET}))],
+			mapOk,
+		]);
+		expect(JSON.parse(out.stdout).disregarded[0]).toMatchObject({reason: "foreign-map"});
+	});
+
+	it("disregards a marker from an author with no write permission", async () => {
+		const out = await run([
+			[PERMISSION, okOut("read")],
+			[CHILDREN, okOut(`[{"number":${TICKET}}]`)],
+			[TICKET_COMMENTS, okOut(commentsJson([{id: 1, body: marker, author: "stranger"}]))],
+			[TICKET_ISSUE, okOut(issueJson({number: TICKET}))],
+			mapOk,
+		]);
+		expect(JSON.parse(out.stdout).disregarded[0]).toMatchObject({reason: "unauthorized"});
+	});
+
+	it("counts an unmarked child as nothing at all — it is not a frontier ticket", async () => {
+		const out = await run([
+			[PERMISSION, okOut("write")],
+			[CHILDREN, okOut(`[{"number":${TICKET}}]`)],
+			[TICKET_COMMENTS, okOut(commentsJson([]))],
+			[TICKET_ISSUE, okOut(issueJson({number: TICKET}))],
+			mapOk,
+		]);
+		const answer = JSON.parse(out.stdout);
+		expect(answer.tickets).toEqual([]);
+		expect(answer.disregarded).toEqual([]);
+		expect(answer.frontier).toBe("empty");
+	});
+});

--- a/packages/fabrika-cli/src/map/record-verb.ts
+++ b/packages/fabrika-cli/src/map/record-verb.ts
@@ -15,7 +15,7 @@
  * UNKNOWN, never assumed `ruled`. The research and spike paths are unaffected.
  */
 
-import {Effect, FileSystem} from "effect";
+import {Effect, type FileSystem} from "effect";
 import type {ChildProcessSpawner} from "effect/unstable/process";
 import {readFile} from "../io/fs.ts";
 import {closeCompleted, getIssue, patchIssueBody} from "../io/issues.ts";
@@ -62,7 +62,10 @@ export const runRecord = (
 	ChildProcessSpawner.ChildProcessSpawner | FileSystem.FileSystem
 > =>
 	Effect.gen(function* () {
-		if (options.ruledOn !== null && (options.questionId === null || !QUESTION_ID.test(options.questionId))) {
+		if (
+			options.ruledOn !== null &&
+			(options.questionId === null || !QUESTION_ID.test(options.questionId))
+		) {
 			return refuse(
 				FAILED,
 				`${VERB}: --ruled-on requires --question-id matching R<round>.<n>; got "${options.questionId ?? ""}".`,
@@ -100,7 +103,13 @@ export const runRecord = (
 		const stale = digestFresh(VERB, options.map, found.value.body, options.digest);
 		if (stale !== null) return stale;
 
-		const resolved = yield* requireTicket(VERB, repo, options.map, found.value.body, options.ticket);
+		const resolved = yield* requireTicket(
+			VERB,
+			repo,
+			options.map,
+			found.value.body,
+			options.ticket,
+		);
 		if (resolved._tag === "Refused") return resolved.outcome;
 		const {ticket} = resolved.value;
 
@@ -114,7 +123,10 @@ export const runRecord = (
 			);
 		}
 
-		let entry: DecisionEntry = {text: finding, authority: {_tag: "Finding", ticket: options.ticket}};
+		let entry: DecisionEntry = {
+			text: finding,
+			authority: {_tag: "Finding", ticket: options.ticket},
+		};
 		if (ticket.state === "forked") {
 			if (ticket.kind === "decision") {
 				if (options.ruledOn === null) {

--- a/packages/fabrika-cli/src/map/record-verb.ts
+++ b/packages/fabrika-cli/src/map/record-verb.ts
@@ -1,0 +1,216 @@
+/**
+ * `map record` — the lockstep: the answer lands under `## Decisions`, the ticket's row leaves
+ * `## Frontier`, and the sub-issue closes.
+ *
+ * The two body edits are one PATCH and the close is second, ordered so the surviving half of a
+ * partial application is the visible-and-re-runnable one — an answer recorded against a still-open
+ * ticket — rather than the forbidden one, a closed ticket with no recorded answer.
+ *
+ * <!-- anchor: RELAY-GRILLINGS-STATE-NEVER-RECOMPUTE-IT --> **A forked decision ticket's ruling is
+ * read by importing the `grill` group's reader, never by re-deriving it here.** A ruling counts only
+ * when four clauses hold, and those clauses are `grill read`'s to resolve; a second implementation
+ * here would be a second answer to a question already enforced elsewhere, and the one that said
+ * `ruled` would win by being called. That group ships from #5023 and is not in the package yet, so
+ * until it lands this verb refuses a `forked` decision ticket with `11` — the ruling's state is
+ * UNKNOWN, never assumed `ruled`. The research and spike paths are unaffected.
+ */
+
+import {Effect, FileSystem} from "effect";
+import type {ChildProcessSpawner} from "effect/unstable/process";
+import {readFile} from "../io/fs.ts";
+import {closeCompleted, getIssue, patchIssueBody} from "../io/issues.ts";
+import {normalizeForReadback} from "../report/compose.ts";
+import {answer, FAILED, refuse, type VerbOutcome} from "../verb.ts";
+import {type DecisionEntry, digestOf, parseBody} from "./body.ts";
+import {
+	BAD_SECTIONS,
+	OUTCOME_UNRECORDABLE,
+	PRECONDITION_UNKNOWN,
+	READBACK_MISMATCH,
+	TICKET_UNKNOWN,
+	WRITE_UNKNOWN,
+} from "./codes.ts";
+import {
+	digestFresh,
+	leakFree,
+	notTerminal,
+	requireMap,
+	requireTicket,
+	targetRepo,
+} from "./guards.ts";
+import {applyRecord, QUESTION_ID} from "./record.ts";
+
+export interface RecordOptions {
+	readonly map: number;
+	readonly digest: string;
+	readonly ticket: number;
+	readonly finding: string;
+	readonly ruledOn: number | null;
+	readonly spike: number | null;
+	readonly questionId: string | null;
+	readonly repo: string | null;
+	readonly env: Readonly<Record<string, string | undefined>>;
+}
+
+const VERB = "map record";
+
+export const runRecord = (
+	options: RecordOptions,
+): Effect.Effect<
+	VerbOutcome,
+	never,
+	ChildProcessSpawner.ChildProcessSpawner | FileSystem.FileSystem
+> =>
+	Effect.gen(function* () {
+		if (options.ruledOn !== null && (options.questionId === null || !QUESTION_ID.test(options.questionId))) {
+			return refuse(
+				FAILED,
+				`${VERB}: --ruled-on requires --question-id matching R<round>.<n>; got "${options.questionId ?? ""}".`,
+			);
+		}
+
+		const read = yield* readFile(options.finding).pipe(
+			Effect.map((value) => ({ok: true as const, value})),
+			Effect.catchTag("fabrika-cli/ReadFailed", (cause) =>
+				Effect.succeed({ok: false as const, value: cause.reason}),
+			),
+		);
+		if (!read.ok) {
+			return refuse(
+				FAILED,
+				`${VERB}: could not read --finding ${options.finding}: ${read.value} — the answer is UNKNOWN, never empty.`,
+			);
+		}
+		const finding = read.value.trim();
+		if (finding === "") {
+			return refuse(
+				BAD_SECTIONS,
+				`${VERB}: --finding ${options.finding} is empty — an answer with no text is not an answer.`,
+			);
+		}
+		const leaked = leakFree(VERB, "finding", finding);
+		if (leaked !== null) return leaked;
+
+		const target = yield* targetRepo(VERB, options.repo, options.env);
+		if (target._tag === "Refused") return target.outcome;
+		const repo = target.value;
+
+		const found = yield* requireMap(VERB, repo, options.map);
+		if (found._tag === "Refused") return found.outcome;
+		const stale = digestFresh(VERB, options.map, found.value.body, options.digest);
+		if (stale !== null) return stale;
+
+		const resolved = yield* requireTicket(VERB, repo, options.map, found.value.body, options.ticket);
+		if (resolved._tag === "Refused") return resolved.outcome;
+		const {ticket} = resolved.value;
+
+		const left = notTerminal(VERB, ticket, "its answer is already on the map.");
+		if (left !== null) return left;
+
+		if (ticket.state === "lane-closed" && ticket.outcome === "unreachable") {
+			return refuse(
+				OUTCOME_UNRECORDABLE,
+				`${VERB}: #${ticket.number}'s lane returned unreachable — there is no answer to record. Re-lane it once the source is reachable, or retire it with map descope --ticket.`,
+			);
+		}
+
+		let entry: DecisionEntry = {text: finding, authority: {_tag: "Finding", ticket: options.ticket}};
+		if (ticket.state === "forked") {
+			if (ticket.kind === "decision") {
+				if (options.ruledOn === null) {
+					return refuse(
+						TICKET_UNKNOWN,
+						`${VERB}: #${ticket.number} is forked to #${ticket.session ?? 0} and --ruled-on was not given — a forked ticket's answer is the founder's, and it is recorded by citing his ruling, never by restating it.`,
+					);
+				}
+				return refuse(
+					PRECONDITION_UNKNOWN,
+					`${VERB}: #${options.ruledOn} ${options.questionId ?? ""} cannot be read — the grill question-state reader (#5023) has not landed, so whether it is ruled is UNKNOWN. Nothing was recorded.`,
+				);
+			}
+			if (options.spike === null) {
+				return refuse(
+					TICKET_UNKNOWN,
+					`${VERB}: #${ticket.number} is forked to spike #${ticket.spike ?? 0} and --spike was not given — the record cites the spike whose captured decision it carries.`,
+				);
+			}
+			const spike = yield* getIssue(repo, options.spike);
+			if (spike._tag === "Unknown") {
+				return refuse(
+					PRECONDITION_UNKNOWN,
+					`${VERB}: cannot read spike #${options.spike}: ${spike.reason} — nothing was recorded.`,
+				);
+			}
+			if (spike._tag === "Absent" || spike.value.state !== "closed") {
+				return refuse(
+					TICKET_UNKNOWN,
+					`${VERB}: spike #${options.spike} ${spike._tag === "Absent" ? "does not exist" : "is still open"} — a spike's captured decision is recorded once the spike is done.`,
+				);
+			}
+		} else if (options.ruledOn !== null && options.questionId !== null) {
+			entry = {
+				text: finding,
+				authority: {_tag: "Ruled", session: options.ruledOn, questionId: options.questionId},
+			};
+		}
+
+		const next = applyRecord(found.value.body, options.ticket, entry);
+		if (next === null) {
+			return refuse(
+				BAD_SECTIONS,
+				`${VERB}: #${options.map}'s body stops parsing once the row is removed — nothing was written.`,
+			);
+		}
+
+		const scope = `${VERB}: ${repo}, #${options.ticket} resolved ${ticket.state}, ${found.value.body.decisions.length} existing decision(s).`;
+		const written = yield* patchIssueBody(repo, options.map, next);
+		if (written._tag === "Failure") {
+			return refuse(
+				WRITE_UNKNOWN,
+				`${VERB}: could not write #${options.map}'s body: ${written.reason} — whether the answer landed is UNKNOWN and #${options.ticket} is still open.`,
+				[scope],
+			);
+		}
+		const landed = yield* getIssue(repo, options.map);
+		if (
+			landed._tag !== "Present" ||
+			normalizeForReadback(landed.value.body) !== normalizeForReadback(next)
+		) {
+			return refuse(
+				READBACK_MISMATCH,
+				`${VERB}: wrote #${options.map}'s body and the read-back differs — #${options.ticket} is still open and the map needs fixing by hand.`,
+				[scope],
+			);
+		}
+		const reparsed = parseBody(landed.value.body);
+		if (reparsed._tag === "Malformed") {
+			return refuse(
+				READBACK_MISMATCH,
+				`${VERB}: wrote #${options.map}'s body and it no longer parses (${reparsed.reason}) — the map needs fixing by hand.`,
+				[scope],
+			);
+		}
+
+		const closed = yield* closeCompleted(repo, options.ticket);
+		if (closed._tag === "Failure") {
+			return refuse(
+				WRITE_UNKNOWN,
+				`${VERB}: recorded the answer on #${options.map} and the close of #${options.ticket} did NOT land — the answer is on the map and the ticket is still open. Close #${options.ticket} by hand.`,
+				[scope],
+			);
+		}
+
+		return answer(
+			JSON.stringify({
+				map: options.map,
+				ticket: options.ticket,
+				recorded:
+					entry.authority._tag === "Ruled"
+						? `— ruled on #${entry.authority.session} ${entry.authority.questionId}`
+						: `— from #${entry.authority.ticket}`,
+				closed: true,
+				digest: digestOf(reparsed.value.sections),
+			}),
+			[scope],
+		);
+	});

--- a/packages/fabrika-cli/src/map/record-verb.unit.test.ts
+++ b/packages/fabrika-cli/src/map/record-verb.unit.test.ts
@@ -1,0 +1,226 @@
+import {Effect, Layer} from "effect";
+import {describe, expect, it} from "vitest";
+import {errOut, fakeFs, fakeShell, okOut, once} from "../fakes.test-support.ts";
+import type {ExecResult} from "../io/exec.ts";
+import {
+	BAD_SECTIONS,
+	OUTCOME_UNRECORDABLE,
+	PRECONDITION_UNKNOWN,
+	TICKET_UNKNOWN,
+	WRITE_UNKNOWN,
+} from "./codes.ts";
+import {
+	commentsJson,
+	digestFor,
+	issueJson,
+	MAP,
+	MAP_BODY,
+	NONCE,
+	parsed,
+	REPO,
+	TICKET,
+} from "./fixtures.test-support.ts";
+import {
+	composeFindingMarker,
+	composeForkMarker,
+	composeLaneMarker,
+	composeTicketMarker,
+} from "./markers.ts";
+import {applyRecord} from "./record.ts";
+import {runRecord} from "./record-verb.ts";
+
+const PERMISSION = /collaborators\/.*\/permission/;
+const CHILDREN = /issues\/9140\/sub_issues/;
+const TICKET_COMMENTS = /issues\/9142\/comments/;
+const EDGES = /issues\/9142\/dependencies\//;
+const TICKET_ISSUE = /issues\/9142$/;
+const MAP_ISSUE = /issues\/9140$/;
+const PATCH_MAP = /--method PATCH repos\/o\/r\/issues\/9140/;
+const PATCH_TICKET = /--method PATCH repos\/o\/r\/issues\/9142/;
+
+const FINDING = "finding.md";
+const ANSWER = "the weight column lives on the account row";
+
+const options = {
+	map: MAP,
+	digest: digestFor(MAP_BODY),
+	ticket: TICKET,
+	finding: FINDING,
+	ruledOn: null as number | null,
+	spike: null as number | null,
+	questionId: null as string | null,
+	repo: null,
+	env: {CLAUDE_PIPELINE_REPO: REPO},
+};
+
+const run = (
+	script: ReadonlyArray<readonly [RegExp, ExecResult]>,
+	over: Partial<typeof options> = {},
+	files: Readonly<Record<string, string | null>> = {[FINDING]: `${ANSWER}\n`},
+) =>
+	Effect.runPromise(
+		Effect.provide(
+			runRecord({...options, ...over}),
+			Layer.merge(fakeShell(script).layer, fakeFs({files}).layer),
+		),
+	);
+
+const ticketComments = (
+	extra: ReadonlyArray<{readonly id: number; readonly body: string}> = [],
+	kind: "research" | "decision" | "prototype" = "research",
+) => commentsJson([{id: 1, body: composeTicketMarker({map: MAP, kind, nonce: NONCE})}, ...extra]);
+
+const frontier = (comments: string) =>
+	[
+		[PERMISSION, okOut("write")],
+		[CHILDREN, okOut(`[{"number":${TICKET}}]`)],
+		[TICKET_COMMENTS, okOut(comments)],
+		[EDGES, okOut("[]")],
+		[TICKET_ISSUE, okOut(issueJson({number: TICKET, body: "which table carries it?"}))],
+	] as const;
+
+const laneClosed = (outcome: "answered" | "no-evidence" | "unreachable") =>
+	ticketComments([
+		{id: 2, body: composeLaneMarker({map: MAP, ticket: TICKET, nonce: NONCE})},
+		{id: 3, body: composeFindingMarker({map: MAP, ticket: TICKET, outcome, nonce: NONCE})},
+	]);
+
+const recorded = applyRecord(parsed(MAP_BODY), TICKET, {
+	text: ANSWER,
+	authority: {_tag: "Finding", ticket: TICKET},
+}) as string;
+
+describe("runRecord", () => {
+	it("exits 1 when --ruled-on arrives without a well-formed --question-id", async () => {
+		const out = await run([], {ruledOn: 9301, questionId: "2.3"});
+		expect(out.code).toBe(1);
+		expect(out.stdout).toBe("");
+	});
+
+	it("exits 4 on an empty finding", async () => {
+		const out = await run([], {}, {[FINDING]: "\n"});
+		expect(out.code).toBe(BAD_SECTIONS);
+		expect(out.stdout).toBe("");
+	});
+
+	it("exits 21 when the lane returned unreachable — there is no answer to record", async () => {
+		const out = await run([
+			...frontier(laneClosed("unreachable")),
+			[MAP_ISSUE, okOut(issueJson({number: MAP, body: MAP_BODY, labels: ["wayfinding:map"]}))],
+		]);
+		expect(out.code).toBe(OUTCOME_UNRECORDABLE);
+		expect(out.stdout).toBe("");
+		expect(out.stderr.join("\n")).toContain("map descope --ticket");
+	});
+
+	it("exits 13 when a forked decision arrives with no --ruled-on", async () => {
+		const out = await run([
+			...frontier(
+				ticketComments(
+					[
+						{
+							id: 2,
+							body: composeForkMarker({map: MAP, ticket: TICKET, route: "session", issue: 9301}),
+						},
+					],
+					"decision",
+				),
+			),
+			[MAP_ISSUE, okOut(issueJson({number: MAP, body: MAP_BODY, labels: ["wayfinding:map"]}))],
+		]);
+		expect(out.code).toBe(TICKET_UNKNOWN);
+		expect(out.stderr.join("\n")).toContain("never by restating it");
+	});
+
+	it("exits 11 on a forked decision until the grill reader lands — never assumed ruled", async () => {
+		const out = await run(
+			[
+				...frontier(
+					ticketComments(
+						[
+							{
+								id: 2,
+								body: composeForkMarker({map: MAP, ticket: TICKET, route: "session", issue: 9301}),
+							},
+						],
+						"decision",
+					),
+				),
+				[MAP_ISSUE, okOut(issueJson({number: MAP, body: MAP_BODY, labels: ["wayfinding:map"]}))],
+			],
+			{ruledOn: 9301, questionId: "R2.3"},
+		);
+		expect(out.code).toBe(PRECONDITION_UNKNOWN);
+		expect(out.stdout).toBe("");
+		expect(out.stderr.join("\n")).toContain("Nothing was recorded");
+	});
+
+	it("exits 0 on a research finding, moving the row and closing the ticket in that order", async () => {
+		const shell = fakeShell([
+			[PATCH_TICKET, okOut("{}")],
+			[PATCH_MAP, okOut("{}")],
+			...frontier(laneClosed("answered")),
+			[
+				once(MAP_ISSUE),
+				okOut(issueJson({number: MAP, body: MAP_BODY, labels: ["wayfinding:map"]})),
+			],
+			[MAP_ISSUE, okOut(issueJson({number: MAP, body: recorded, labels: ["wayfinding:map"]}))],
+		]);
+		const out = await Effect.runPromise(
+			Effect.provide(
+				runRecord(options),
+				Layer.merge(shell.layer, fakeFs({files: {[FINDING]: `${ANSWER}\n`}}).layer),
+			),
+		);
+		expect(out.code).toBe(0);
+		expect(JSON.parse(out.stdout)).toMatchObject({
+			map: MAP,
+			ticket: TICKET,
+			recorded: `— from #${TICKET}`,
+			closed: true,
+		});
+		const bodyAt = shell.calls.findIndex((line) => line.includes("PATCH repos/o/r/issues/9140"));
+		const closeAt = shell.calls.findIndex((line) => line.includes("state_reason=completed"));
+		// The close is second so the surviving half of a partial application is the re-runnable one.
+		expect(closeAt).toBeGreaterThan(bodyAt);
+	});
+
+	it("moves the answer and the row in ONE body PATCH, so the two cannot separate", async () => {
+		const shell = fakeShell([
+			[PATCH_TICKET, okOut("{}")],
+			[PATCH_MAP, okOut("{}")],
+			...frontier(laneClosed("answered")),
+			[
+				once(MAP_ISSUE),
+				okOut(issueJson({number: MAP, body: MAP_BODY, labels: ["wayfinding:map"]})),
+			],
+			[MAP_ISSUE, okOut(issueJson({number: MAP, body: recorded, labels: ["wayfinding:map"]}))],
+		]);
+		await Effect.runPromise(
+			Effect.provide(
+				runRecord(options),
+				Layer.merge(shell.layer, fakeFs({files: {[FINDING]: `${ANSWER}\n`}}).layer),
+			),
+		);
+		const patches = shell.calls.filter((line) => line.includes("PATCH repos/o/r/issues/9140"));
+		expect(patches).toHaveLength(1);
+		expect(patches[0]).toContain(`— from #${TICKET}`);
+		expect(patches[0]).not.toContain(`- #${TICKET} · research`);
+	});
+
+	it("exits 8 naming the ticket when the close does not land — the visible half is the survivor", async () => {
+		const out = await run([
+			[PATCH_TICKET, errOut("gh: Bad gateway (HTTP 502)")],
+			[PATCH_MAP, okOut("{}")],
+			...frontier(laneClosed("answered")),
+			[
+				once(MAP_ISSUE),
+				okOut(issueJson({number: MAP, body: MAP_BODY, labels: ["wayfinding:map"]})),
+			],
+			[MAP_ISSUE, okOut(issueJson({number: MAP, body: recorded, labels: ["wayfinding:map"]}))],
+		]);
+		expect(out.code).toBe(WRITE_UNKNOWN);
+		expect(out.stdout).toBe("");
+		expect(out.stderr.join("\n")).toContain(`Close #${TICKET} by hand`);
+	});
+});

--- a/packages/fabrika-cli/src/map/record.ts
+++ b/packages/fabrika-cli/src/map/record.ts
@@ -1,0 +1,51 @@
+/**
+ * `map record`'s pure half: the question id's grammar and the lockstep body edit.
+ *
+ * <!-- anchor: LOCKSTEP-IS-ONE-WRITE-THEN-ONE --> **The move is one body write, not two.** v1 spread
+ * the append, the row removal and the close across three unrelated acts with no transaction, so a
+ * failure between them produced exactly the state its own shape doc forbids — *the map is never left
+ * in a state where a resolved unknown has no recorded answer*. Folding the two body edits into one
+ * PATCH makes that state unrepresentable, which is why {@link applyRecord} returns one string rather
+ * than two writes.
+ */
+
+import {
+	type DecisionEntry,
+	type MapBody,
+	parseBody,
+	renderDecision,
+	renderFrontierRow,
+	spliceSection,
+} from "./body.ts";
+
+/** The question id inside a `grilling` session. */
+export const QUESTION_ID = /^R\d+\.\d+$/;
+
+/**
+ * The body with the answer appended under `## Decisions` and the ticket's row gone from
+ * `## Frontier` — one string, so the two cannot separate.
+ *
+ * `null` when the intermediate body no longer parses, which a caller seats as a refusal rather than
+ * writing bytes it cannot read back.
+ */
+export const applyRecord = (
+	body: MapBody,
+	ticket: number,
+	entry: DecisionEntry,
+): string | null => {
+	const withoutRow = spliceSection(
+		body,
+		"Frontier",
+		body.frontier
+			.filter((row) => row.ticket !== ticket)
+			.map(renderFrontierRow)
+			.join("\n"),
+	);
+	const reparsed = parseBody(withoutRow);
+	if (reparsed._tag === "Malformed") return null;
+	return spliceSection(
+		reparsed.value,
+		"Decisions",
+		[...reparsed.value.decisions.map(renderDecision), renderDecision(entry)].join("\n"),
+	);
+};

--- a/packages/fabrika-cli/src/map/record.ts
+++ b/packages/fabrika-cli/src/map/record.ts
@@ -28,11 +28,7 @@ export const QUESTION_ID = /^R\d+\.\d+$/;
  * `null` when the intermediate body no longer parses, which a caller seats as a refusal rather than
  * writing bytes it cannot read back.
  */
-export const applyRecord = (
-	body: MapBody,
-	ticket: number,
-	entry: DecisionEntry,
-): string | null => {
+export const applyRecord = (body: MapBody, ticket: number, entry: DecisionEntry): string | null => {
 	const withoutRow = spliceSection(
 		body,
 		"Frontier",

--- a/packages/fabrika-cli/src/map/record.unit.test.ts
+++ b/packages/fabrika-cli/src/map/record.unit.test.ts
@@ -1,0 +1,61 @@
+import {describe, expect, it} from "vitest";
+import {MAP_BODY, parsed} from "./fixtures.test-support.ts";
+import {applyRecord, QUESTION_ID} from "./record.ts";
+
+describe("QUESTION_ID", () => {
+	it("admits R<round>.<n> and nothing else", () => {
+		expect(QUESTION_ID.test("R2.3")).toBe(true);
+		expect(QUESTION_ID.test("2.3")).toBe(false);
+		expect(QUESTION_ID.test("R2")).toBe(false);
+	});
+});
+
+describe("applyRecord", () => {
+	it("appends the answer and removes the row in ONE string, so the two cannot separate", () => {
+		const next = applyRecord(parsed(MAP_BODY), 9142, {
+			text: "the weight column lives on the account row",
+			authority: {_tag: "Finding", ticket: 9142},
+		});
+		expect(next).not.toBeNull();
+		const body = parsed(next as string);
+		expect(body.frontier).toEqual([]);
+		expect(body.decisions).toEqual([
+			{
+				text: "the weight column lives on the account row",
+				authority: {_tag: "Finding", ticket: 9142},
+			},
+		]);
+	});
+
+	it("composes the citation itself, so an entry can never be recorded without one", () => {
+		const next = applyRecord(parsed(MAP_BODY), 9142, {
+			text: "an invited çaylak starts at 0 karma",
+			authority: {_tag: "Ruled", session: 9301, questionId: "R2.3"},
+		});
+		expect(next).toContain("— ruled on #9301 R2.3");
+	});
+
+	it("appends rather than rewriting, so a superseding answer leaves both on the record", () => {
+		const once = applyRecord(parsed(MAP_BODY), 9142, {
+			text: "first answer",
+			authority: {_tag: "Finding", ticket: 9142},
+		}) as string;
+		const twice = applyRecord(parsed(once), 9146, {
+			text: "second answer, replacing the first",
+			authority: {_tag: "Finding", ticket: 9146},
+		}) as string;
+		expect(parsed(twice).decisions.map((entry) => entry.text)).toEqual([
+			"first answer",
+			"second answer, replacing the first",
+		]);
+	});
+
+	it("leaves every other section's bytes alone", () => {
+		const next = applyRecord(parsed(MAP_BODY), 9142, {
+			text: "the weight column lives on the account row",
+			authority: {_tag: "Finding", ticket: 9142},
+		}) as string;
+		expect(next).toContain("- what clock does weight decay on?");
+		expect(parsed(next).destination).toBe("how moderation weight is earned");
+	});
+});

--- a/packages/fabrika-cli/src/map/ticket-verb.ts
+++ b/packages/fabrika-cli/src/map/ticket-verb.ts
@@ -23,14 +23,7 @@ import {addBlockedBy, addSubIssue, internalId} from "../io/edges.ts";
 import {createComment, createUnlabelledIssue, getIssue, patchIssueBody} from "../io/issues.ts";
 import {normalizeForReadback} from "../report/compose.ts";
 import {answer, FAILED, refuse, type VerbOutcome} from "../verb.ts";
-import {
-	digestOf,
-	isKind,
-	KINDS,
-	parseBody,
-	renderFrontierRow,
-	spliceSection,
-} from "./body.ts";
+import {digestOf, isKind, KINDS, parseBody, renderFrontierRow, spliceSection} from "./body.ts";
 import {
 	ALREADY_DESCOPED,
 	EDGE_UNRESOLVABLE,
@@ -74,14 +67,14 @@ export const runTicket = (
 	Effect.gen(function* () {
 		const question = options.question.trim();
 		if (question === "") {
-			return refuse(FAILED, `${VERB}: --question is empty — refusing to file a ticket asking nothing.`);
+			return refuse(
+				FAILED,
+				`${VERB}: --question is empty — refusing to file a ticket asking nothing.`,
+			);
 		}
 		const kind = options.kind.trim();
 		if (!isKind(kind)) {
-			return refuse(
-				FAILED,
-				`${VERB}: --kind "${kind}" is not one of ${KINDS.join(", ")}.`,
-			);
+			return refuse(FAILED, `${VERB}: --kind "${kind}" is not one of ${KINDS.join(", ")}.`);
 		}
 		const nonce = options.nonce();
 		if (!isNonce(nonce)) {
@@ -252,7 +245,10 @@ export const runTicket = (
 		}
 
 		const landed = yield* getIssue(repo, options.map);
-		if (landed._tag !== "Present" || normalizeForReadback(landed.value.body) !== normalizeForReadback(next)) {
+		if (
+			landed._tag !== "Present" ||
+			normalizeForReadback(landed.value.body) !== normalizeForReadback(next)
+		) {
 			return refuse(
 				READBACK_MISMATCH,
 				`${VERB}: wrote #${options.map}'s body and the read-back differs — the ticket #${child} exists and the map needs fixing by hand.`,

--- a/packages/fabrika-cli/src/map/ticket-verb.ts
+++ b/packages/fabrika-cli/src/map/ticket-verb.ts
@@ -1,0 +1,282 @@
+/**
+ * `map ticket` — file a frontier ticket, link it as a sub-issue, set its blocking edges, and splice
+ * its line onto the map, as one act.
+ *
+ * **Preconditions resolve before anything is written.** Every `--blocks` and `--blocked-by` target is
+ * existence-checked, confirmed to be a ticket of this map, and resolved to its internal id, and the
+ * cycle check runs — all before the create. That ordering is what makes `13`, `14`, `18` and `19`
+ * honestly mean *nothing was written*: an id that cannot be resolved is discovered while the frontier
+ * is still untouched, rather than after a ticket exists.
+ *
+ * **Write order, and what each partial application leaves.** Create the ticket, post its marker
+ * comment, link it as a sub-issue, set the edges, then splice the map body — in that order, with the
+ * body guard re-checked immediately before the splice. A failure after the create leaves an issue
+ * with no marker, which `map read` does not count as a ticket of this map, so it is inert rather than
+ * half-present and a re-run resumes it. The splice is last because it is the only write that can be
+ * lost to a concurrent writer, so it spends the shortest possible time between the guard and the
+ * write.
+ */
+
+import {Effect} from "effect";
+import type {ChildProcessSpawner} from "effect/unstable/process";
+import {addBlockedBy, addSubIssue, internalId} from "../io/edges.ts";
+import {createComment, createUnlabelledIssue, getIssue, patchIssueBody} from "../io/issues.ts";
+import {normalizeForReadback} from "../report/compose.ts";
+import {answer, FAILED, refuse, type VerbOutcome} from "../verb.ts";
+import {
+	digestOf,
+	isKind,
+	KINDS,
+	parseBody,
+	renderFrontierRow,
+	spliceSection,
+} from "./body.ts";
+import {
+	ALREADY_DESCOPED,
+	EDGE_UNRESOLVABLE,
+	PRECONDITION_UNKNOWN,
+	READBACK_MISMATCH,
+	TICKET_RETIRED,
+	TICKET_UNKNOWN,
+	WRITE_UNKNOWN,
+} from "./codes.ts";
+import {isTerminal, readFrontier, type Ticket} from "./frontier.ts";
+import {digestFresh, leakFree, requireMap, targetRepo} from "./guards.ts";
+import {composeTicketMarker, isNonce} from "./markers.ts";
+import {namesSameThing} from "./open.ts";
+import {cycleFrom, ticketBody, ticketTitle, waitsOnGraph} from "./ticket.ts";
+
+export interface TicketOptions {
+	readonly map: number;
+	readonly digest: string;
+	/** Validated here rather than at the parser, so an off-vocabulary kind is `1` with a named set. */
+	readonly kind: string;
+	readonly question: string;
+	readonly blocks: ReadonlyArray<number>;
+	readonly blockedBy: ReadonlyArray<number>;
+	readonly repo: string | null;
+	readonly env: Readonly<Record<string, string | undefined>>;
+	/**
+	 * This run's nonce, stamped into the ticket's marker.
+	 *
+	 * Injected rather than read from the environment, and injected rather than flagged: the contract's
+	 * input table for this verb declares no `--nonce`, so adding one would be a surface it does not
+	 * specify — see the spec-defect note on #5022. The production caller supplies four random bytes.
+	 */
+	readonly nonce: () => string;
+}
+
+const VERB = "map ticket";
+
+export const runTicket = (
+	options: TicketOptions,
+): Effect.Effect<VerbOutcome, never, ChildProcessSpawner.ChildProcessSpawner> =>
+	Effect.gen(function* () {
+		const question = options.question.trim();
+		if (question === "") {
+			return refuse(FAILED, `${VERB}: --question is empty — refusing to file a ticket asking nothing.`);
+		}
+		const kind = options.kind.trim();
+		if (!isKind(kind)) {
+			return refuse(
+				FAILED,
+				`${VERB}: --kind "${kind}" is not one of ${KINDS.join(", ")}.`,
+			);
+		}
+		const nonce = options.nonce();
+		if (!isNonce(nonce)) {
+			return refuse(FAILED, `${VERB}: "${nonce}" is not an eight-hex-character run nonce.`);
+		}
+
+		const target = yield* targetRepo(VERB, options.repo, options.env);
+		if (target._tag === "Refused") return target.outcome;
+		const repo = target.value;
+
+		const leaked = leakFree(VERB, "question", question);
+		if (leaked !== null) return leaked;
+
+		const found = yield* requireMap(VERB, repo, options.map);
+		if (found._tag === "Refused") return found.outcome;
+		const stale = digestFresh(VERB, options.map, found.value.body, options.digest);
+		if (stale !== null) return stale;
+
+		const rejected = found.value.body.outOfScope.find((entry) =>
+			namesSameThing(question, entry.direction),
+		);
+		if (rejected !== undefined) {
+			return refuse(
+				ALREADY_DESCOPED,
+				`${VERB}: "${question}" restates a direction recorded out of scope on #${options.map} (${rejected.recordedAt}) — nothing was written. Read the recorded reasoning before charting it.`,
+			);
+		}
+
+		const frontier = yield* readFrontier(repo, options.map, found.value.body);
+		if (frontier._tag !== "Frontier") {
+			return refuse(
+				PRECONDITION_UNKNOWN,
+				`${VERB}: cannot read #${options.map}'s children: ${frontier._tag === "MapAbsent" ? "the map reports no child list" : frontier.reason} — nothing was written.`,
+			);
+		}
+		const tickets = frontier.value.tickets;
+		const byNumber = new Map<number, Ticket>(tickets.map((ticket) => [ticket.number, ticket]));
+
+		for (const [flag, targets] of [
+			["--blocked-by", options.blockedBy],
+			["--blocks", options.blocks],
+		] as const) {
+			for (const number of targets) {
+				const ticket = byNumber.get(number);
+				if (ticket === undefined) {
+					return refuse(
+						TICKET_UNKNOWN,
+						`${VERB}: ${flag} ${number} is not a frontier ticket of map #${options.map}.`,
+					);
+				}
+				if (isTerminal(ticket.state)) {
+					return refuse(
+						TICKET_RETIRED,
+						`${VERB}: ${flag} ${number} already left the frontier — a cleared question cannot gate an open one.`,
+					);
+				}
+			}
+		}
+
+		const cycle = cycleFrom(waitsOnGraph(tickets), options.blockedBy, options.blocks);
+		if (cycle !== null) {
+			return refuse(
+				EDGE_UNRESOLVABLE,
+				`${VERB}: --blocks ${cycle.gates} would close a cycle (${cycle.gates} -> this ticket -> ${cycle.waitsOn} -> ${cycle.gates}) — refusing to make a frontier no run can drain.`,
+			);
+		}
+
+		// Resolved before the create so an unresolvable id refuses while the frontier is untouched.
+		const ids = new Map<number, number>();
+		for (const number of [...options.blockedBy, ...options.blocks]) {
+			if (ids.has(number)) continue;
+			const id = yield* internalId(repo, number);
+			if (id._tag !== "Present") {
+				return refuse(
+					EDGE_UNRESOLVABLE,
+					`${VERB}: cannot resolve ${number}'s internal id: ${id._tag === "Absent" ? "no such issue" : id.reason} — an edge POST takes the id, never the number. Resolved before the create, so nothing was written.`,
+				);
+			}
+			ids.set(number, id.value);
+		}
+
+		const scope = `${VERB}: ${repo}, ${tickets.length} existing ticket(s), ${options.blockedBy.length + options.blocks.length} edge target(s) resolved.`;
+
+		const created = yield* createUnlabelledIssue(
+			repo,
+			ticketTitle(question),
+			ticketBody(question, options.map),
+		);
+		if (created._tag === "Failure") {
+			return refuse(
+				WRITE_UNKNOWN,
+				`${VERB}: could not file the ticket in ${repo}: ${created.reason} — whether it landed is UNKNOWN.`,
+				[scope],
+			);
+		}
+		const child = created.value.number;
+
+		const marker = yield* createComment(
+			repo,
+			child,
+			composeTicketMarker({map: options.map, kind, nonce}),
+		);
+		if (marker._tag === "Failure") {
+			return refuse(
+				WRITE_UNKNOWN,
+				`${VERB}: filed #${child} and its marker comment did NOT land — the issue exists and is not a frontier ticket of #${options.map}. Re-run with the same question to resume.`,
+				[scope],
+			);
+		}
+
+		const childId = yield* internalId(repo, child);
+		if (childId._tag !== "Present") {
+			return refuse(
+				WRITE_UNKNOWN,
+				`${VERB}: filed #${child} and its internal id could not be resolved — the ticket exists and is not on the map. Link it before charting on.`,
+				[scope],
+			);
+		}
+		const linked = yield* addSubIssue(repo, options.map, childId.value);
+		if (linked._tag === "Failure") {
+			return refuse(
+				WRITE_UNKNOWN,
+				`${VERB}: filed #${child} and the sub-issue LINK to #${options.map} did NOT land — the ticket exists and is not on the map. Link it before charting on.`,
+				[scope],
+			);
+		}
+
+		for (const number of options.blockedBy) {
+			const edge = yield* addBlockedBy(repo, child, ids.get(number) as number);
+			if (edge._tag === "Failure") {
+				return refuse(
+					WRITE_UNKNOWN,
+					`${VERB}: linked #${child} and its --blocked-by ${number} edge did NOT land — the ticket is on the map with an incomplete topology.`,
+					[scope],
+				);
+			}
+		}
+		for (const number of options.blocks) {
+			const edge = yield* addBlockedBy(repo, number, childId.value);
+			if (edge._tag === "Failure") {
+				return refuse(
+					WRITE_UNKNOWN,
+					`${VERB}: linked #${child} and its --blocks ${number} edge did NOT land — the ticket is on the map with an incomplete topology.`,
+					[scope],
+				);
+			}
+		}
+
+		// Re-read and re-check the guard immediately before the splice: the reads above take time, and
+		// the body is the one surface a concurrent lane also writes.
+		const reread = yield* requireMap(VERB, repo, options.map);
+		if (reread._tag === "Refused") return reread.outcome;
+		const guard = digestFresh(VERB, options.map, reread.value.body, options.digest);
+		if (guard !== null) return guard;
+
+		const rows = [
+			...reread.value.body.frontier.map(renderFrontierRow),
+			renderFrontierRow({ticket: child, kind, question, forkedTo: null}),
+		].join("\n");
+		const next = spliceSection(reread.value.body, "Frontier", rows);
+		const written = yield* patchIssueBody(repo, options.map, next);
+		if (written._tag === "Failure") {
+			return refuse(
+				WRITE_UNKNOWN,
+				`${VERB}: filed and linked #${child} and the map body write did NOT land: ${written.reason} — the ticket is on the map and its row is not.`,
+				[scope],
+			);
+		}
+
+		const landed = yield* getIssue(repo, options.map);
+		if (landed._tag !== "Present" || normalizeForReadback(landed.value.body) !== normalizeForReadback(next)) {
+			return refuse(
+				READBACK_MISMATCH,
+				`${VERB}: wrote #${options.map}'s body and the read-back differs — the ticket #${child} exists and the map needs fixing by hand.`,
+				[scope],
+			);
+		}
+		const reparsed = parseBody(landed.value.body);
+		if (reparsed._tag === "Malformed") {
+			return refuse(
+				READBACK_MISMATCH,
+				`${VERB}: wrote #${options.map}'s body and it no longer parses (${reparsed.reason}) — the ticket #${child} exists and the map needs fixing by hand.`,
+				[scope],
+			);
+		}
+
+		return answer(
+			JSON.stringify({
+				map: options.map,
+				ticket: child,
+				kind,
+				blockedBy: options.blockedBy,
+				blocking: options.blocks,
+				digest: digestOf(reparsed.value.sections),
+			}),
+			[scope],
+		);
+	});

--- a/packages/fabrika-cli/src/map/ticket-verb.unit.test.ts
+++ b/packages/fabrika-cli/src/map/ticket-verb.unit.test.ts
@@ -1,0 +1,208 @@
+import {Effect} from "effect";
+import {describe, expect, it} from "vitest";
+import {errOut, fakeShell, okOut, once} from "../fakes.test-support.ts";
+import type {ExecResult} from "../io/exec.ts";
+import {parseBody, renderFrontierRow, spliceSection} from "./body.ts";
+import {
+	ALREADY_DESCOPED,
+	DIGEST_STALE,
+	EDGE_UNRESOLVABLE,
+	TICKET_UNKNOWN,
+	WRITE_UNKNOWN,
+} from "./codes.ts";
+import {
+	commentsJson,
+	digestFor,
+	issueJson,
+	MAP,
+	MAP_BODY,
+	MAP_BODY_WITH_REJECTION,
+	NONCE,
+	parsed,
+	REPO,
+	TICKET,
+} from "./fixtures.test-support.ts";
+import {composeTicketMarker} from "./markers.ts";
+import {runTicket} from "./ticket-verb.ts";
+
+const PERMISSION = /collaborators\/.*\/permission/;
+const CHILDREN = /issues\/9140\/sub_issues/;
+const TICKET_COMMENTS = /issues\/9142\/comments/;
+const EDGES = /issues\/9142\/dependencies\//;
+const TICKET_ISSUE = /issues\/9142$/;
+const MAP_ISSUE = /issues\/9140$/;
+const INTERNAL_ID = /issues\/\d+ --jq \.id/;
+const CREATE = /--method POST repos\/o\/r\/issues -f/;
+const POST_COMMENT = /--method POST repos\/o\/r\/issues\/9145\/comments/;
+const NEW_ID = /issues\/9145 --jq \.id/;
+const LINK = /sub_issues -F/;
+const PATCH = /--method PATCH repos\/o\/r\/issues\/9140/;
+
+const QUESTION = "does better-auth mint a single-use token without a new table?";
+
+const options = {
+	map: MAP,
+	digest: digestFor(MAP_BODY),
+	kind: "research",
+	question: QUESTION,
+	blocks: [] as ReadonlyArray<number>,
+	blockedBy: [] as ReadonlyArray<number>,
+	repo: null,
+	env: {CLAUDE_PIPELINE_REPO: REPO},
+	nonce: () => NONCE,
+};
+
+const run = (
+	script: ReadonlyArray<readonly [RegExp, ExecResult]>,
+	over: Partial<typeof options> = {},
+) => Effect.runPromise(Effect.provide(runTicket({...options, ...over}), fakeShell(script).layer));
+
+const mapOk = (body = MAP_BODY) =>
+	[MAP_ISSUE, okOut(issueJson({number: MAP, body, labels: ["wayfinding:map"]}))] as const;
+
+const frontier = [
+	[PERMISSION, okOut("write")],
+	[CHILDREN, okOut(`[{"number":${TICKET}}]`)],
+	[
+		TICKET_COMMENTS,
+		okOut(
+			commentsJson([
+				{id: 1, body: composeTicketMarker({map: MAP, kind: "research", nonce: NONCE})},
+			]),
+		),
+	],
+	[EDGES, okOut("[]")],
+	[TICKET_ISSUE, okOut(issueJson({number: TICKET, body: "which table carries it?"}))],
+] as const;
+
+/** The body a successful file leaves: the fixture's row plus the new ticket's. */
+const spliced = spliceSection(
+	parsed(MAP_BODY),
+	"Frontier",
+	[
+		...parsed(MAP_BODY).frontier.map(renderFrontierRow),
+		renderFrontierRow({ticket: 9145, kind: "research", question: QUESTION, forkedTo: null}),
+	].join("\n"),
+);
+
+describe("runTicket — the preconditions, all before anything is written", () => {
+	it("exits 1 on an off-vocabulary kind, naming the whole set", async () => {
+		const out = await run([], {kind: "investigation"});
+		expect(out.code).toBe(1);
+		expect(out.stdout).toBe("");
+		expect(out.stderr.join("\n")).toContain("research, prototype, decision");
+	});
+
+	it("exits 12 with nothing on stdout when the body moved since --digest", async () => {
+		const out = await run([mapOk()], {digest: "000000000000"});
+		expect(out.code).toBe(DIGEST_STALE);
+		expect(out.stdout).toBe("");
+		expect(out.stderr.join("\n")).toContain("nothing was written");
+	});
+
+	it("exits 19 when the question restates a direction already recorded out of scope", async () => {
+		const out = await run([mapOk(MAP_BODY_WITH_REJECTION)], {
+			digest: digestFor(MAP_BODY_WITH_REJECTION),
+			question: "a per-topic weight multiplier for moderation",
+		});
+		expect(out.code).toBe(ALREADY_DESCOPED);
+		expect(out.stderr.join("\n")).toContain("nothing was written");
+	});
+
+	it("exits 13 when an edge target is not a ticket of this map", async () => {
+		const out = await run([...frontier, mapOk()], {blockedBy: [9999]});
+		expect(out.code).toBe(TICKET_UNKNOWN);
+		expect(out.stdout).toBe("");
+	});
+
+	it("exits 14 on an edge that would close a cycle, naming the loop", async () => {
+		const out = await run([...frontier, mapOk()], {blockedBy: [TICKET], blocks: [TICKET]});
+		expect(out.code).toBe(EDGE_UNRESOLVABLE);
+		expect(out.stderr.join("\n")).toContain("no run can drain");
+	});
+
+	it("exits 14 when an edge target's internal id cannot be resolved, before the create", async () => {
+		const shell = fakeShell([
+			[INTERNAL_ID, errOut("gh: Bad gateway (HTTP 502)")],
+			...frontier,
+			mapOk(),
+		]);
+		const out = await Effect.runPromise(
+			Effect.provide(runTicket({...options, blockedBy: [TICKET]}), shell.layer),
+		);
+		expect(out.code).toBe(EDGE_UNRESOLVABLE);
+		expect(out.stderr.join("\n")).toContain("nothing was written");
+		expect(shell.calls.some((line) => line.includes("--method POST"))).toBe(false);
+	});
+});
+
+describe("runTicket — the write order", () => {
+	const created = [
+		CREATE,
+		okOut('{"number":9145,"html_url":"https://github.com/o/r/issues/9145"}'),
+	] as const;
+
+	it("exits 8 naming the number when the marker does not land — the issue is inert, not half-present", async () => {
+		const out = await run([
+			created,
+			[POST_COMMENT, errOut("gh: Bad gateway (HTTP 502)")],
+			...frontier,
+			mapOk(),
+		]);
+		expect(out.code).toBe(WRITE_UNKNOWN);
+		expect(out.stdout).toBe("");
+		expect(out.stderr.join("\n")).toContain("Re-run with the same question to resume");
+	});
+
+	it("exits 8 naming the number when the sub-issue link does not land", async () => {
+		const out = await run([
+			created,
+			[POST_COMMENT, okOut('{"id":1,"html_url":"u"}')],
+			[NEW_ID, okOut("55")],
+			[LINK, errOut("gh: Bad gateway (HTTP 502)")],
+			...frontier,
+			mapOk(),
+		]);
+		expect(out.code).toBe(WRITE_UNKNOWN);
+		expect(out.stderr.join("\n")).toContain("Link it before charting on");
+	});
+
+	it("exits 0 with the ticket, its edges and the map's NEW digest", async () => {
+		const shell = fakeShell([
+			created,
+			[POST_COMMENT, okOut('{"id":1,"html_url":"u"}')],
+			[NEW_ID, okOut("55")],
+			[LINK, okOut("{}")],
+			[PATCH, okOut("{}")],
+			...frontier,
+			[
+				once(MAP_ISSUE),
+				okOut(issueJson({number: MAP, body: MAP_BODY, labels: ["wayfinding:map"]})),
+			],
+			[
+				once(MAP_ISSUE),
+				okOut(issueJson({number: MAP, body: MAP_BODY, labels: ["wayfinding:map"]})),
+			],
+			[MAP_ISSUE, okOut(issueJson({number: MAP, body: spliced, labels: ["wayfinding:map"]}))],
+		]);
+		const out = await Effect.runPromise(Effect.provide(runTicket(options), shell.layer));
+		expect(out.code).toBe(0);
+		const answer = JSON.parse(out.stdout);
+		expect(answer).toMatchObject({map: MAP, ticket: 9145, kind: "research"});
+		expect(answer.digest).not.toBe(options.digest);
+		// The body write is last, so it spends the shortest time between the guard and the write.
+		const patchAt = shell.calls.findIndex((line) => line.includes("--method PATCH"));
+		const linkAt = shell.calls.findIndex((line) => line.includes("sub_issues -F"));
+		expect(patchAt).toBeGreaterThan(linkAt);
+	});
+
+	it("splices the row onto the map without disturbing the other sections", () => {
+		const body = parseBody(spliced);
+		expect(body._tag).toBe("Parsed");
+		expect(body._tag === "Parsed" && body.value.frontier.map((row) => row.ticket)).toEqual([
+			TICKET,
+			9145,
+		]);
+		expect(body._tag === "Parsed" && body.value.fog).toBe(1);
+	});
+});

--- a/packages/fabrika-cli/src/map/ticket.ts
+++ b/packages/fabrika-cli/src/map/ticket.ts
@@ -1,0 +1,55 @@
+/**
+ * `map ticket`'s pure half: the cycle check over the frontier's native edges, and the bytes the new
+ * ticket carries.
+ *
+ * The cycle check runs **before** anything is written. A frontier that closes a cycle is one no run
+ * can drain — every ticket in the loop waits on another — so the refusal has to land while the
+ * frontier is still untouched rather than after a ticket exists.
+ */
+
+import type {Ticket} from "./frontier.ts";
+import {truncateOnWordBoundary} from "./open.ts";
+
+/** `ticket → the tickets it waits on`, the direction a cycle is a loop in. */
+export type WaitsOn = ReadonlyMap<number, ReadonlyArray<number>>;
+
+export const waitsOnGraph = (tickets: ReadonlyArray<Ticket>): WaitsOn =>
+	new Map(tickets.map((ticket) => [ticket.number, ticket.blockedBy]));
+
+/** Whether `to` is reachable from `from` by following waits-on edges. */
+export const reaches = (graph: WaitsOn, from: number, to: number): boolean => {
+	const seen = new Set<number>();
+	const stack = [from];
+	while (stack.length > 0) {
+		const at = stack.pop() as number;
+		if (at === to) return true;
+		if (seen.has(at)) continue;
+		seen.add(at);
+		for (const next of graph.get(at) ?? []) stack.push(next);
+	}
+	return false;
+};
+
+/** A cycle the requested edges would close, named end to end, or `null` when they close none. */
+export const cycleFrom = (
+	graph: WaitsOn,
+	blockedByTargets: ReadonlyArray<number>,
+	blocksTargets: ReadonlyArray<number>,
+): {readonly waitsOn: number; readonly gates: number} | null => {
+	for (const waitsOn of blockedByTargets) {
+		for (const gates of blocksTargets) {
+			// The new ticket waits on `waitsOn` and gates `gates`, so `gates -> new -> waitsOn` already
+			// holds; a path from `waitsOn` back to `gates` — including the degenerate one where they are
+			// the same ticket — closes the loop.
+			if (waitsOn === gates || reaches(graph, waitsOn, gates)) return {waitsOn, gates};
+		}
+	}
+	return null;
+};
+
+/** The ticket's title: the question verbatim, truncated on a word boundary. */
+export const ticketTitle = (question: string): string => truncateOnWordBoundary(question.trim());
+
+/** The ticket's body: the question, then the line binding it to its map. */
+export const ticketBody = (question: string, map: number): string =>
+	`${question.trim()}\n\nCharted on #${map}.\n`;

--- a/packages/fabrika-cli/src/map/ticket.unit.test.ts
+++ b/packages/fabrika-cli/src/map/ticket.unit.test.ts
@@ -1,0 +1,55 @@
+import {describe, expect, it} from "vitest";
+import type {Ticket} from "./frontier.ts";
+import {cycleFrom, reaches, ticketBody, ticketTitle, waitsOnGraph} from "./ticket.ts";
+
+const ticket = (number: number, blockedBy: ReadonlyArray<number>): Ticket => ({
+	number,
+	kind: "research",
+	question: `question ${number}`,
+	state: "open",
+	blockedBy,
+	blocking: [],
+});
+
+/** 9143 waits on 9142; 9144 waits on 9143. */
+const graph = waitsOnGraph([ticket(9142, []), ticket(9143, [9142]), ticket(9144, [9143])]);
+
+describe("reaches", () => {
+	it("follows waits-on edges transitively", () => {
+		expect(reaches(graph, 9144, 9142)).toBe(true);
+		expect(reaches(graph, 9142, 9144)).toBe(false);
+	});
+
+	it("terminates on a graph that already holds a loop", () => {
+		const looped = waitsOnGraph([ticket(1, [2]), ticket(2, [1])]);
+		expect(reaches(looped, 1, 3)).toBe(false);
+	});
+});
+
+describe("cycleFrom", () => {
+	it("finds nothing when the new ticket only extends the chain", () => {
+		expect(cycleFrom(graph, [9144], [])).toBeNull();
+		expect(cycleFrom(graph, [], [9142])).toBeNull();
+	});
+
+	it("names the loop when the new ticket both waits on and gates the same chain", () => {
+		// new -> 9142 already, and 9144 -> new; 9144 reaches 9142, so the loop closes.
+		expect(cycleFrom(graph, [9144], [9142])).toEqual({waitsOn: 9144, gates: 9142});
+	});
+
+	it("catches the degenerate loop where one ticket is named on both sides", () => {
+		expect(cycleFrom(graph, [9142], [9142])).toEqual({waitsOn: 9142, gates: 9142});
+	});
+});
+
+describe("what the ticket carries", () => {
+	it("titles the ticket with the question verbatim", () => {
+		expect(ticketTitle("  does better-auth mint a single-use token?  ")).toBe(
+			"does better-auth mint a single-use token?",
+		);
+	});
+
+	it("binds the body to its map", () => {
+		expect(ticketBody("does it decay?", 9140)).toBe("does it decay?\n\nCharted on #9140.\n");
+	});
+});

--- a/packages/fabrika-cli/src/registry.ts
+++ b/packages/fabrika-cli/src/registry.ts
@@ -21,6 +21,7 @@ import {epicCommand} from "./epic/command.ts";
 import {evalCommand} from "./eval/command.ts";
 import {hookCommand} from "./hook/command.ts";
 import {ledgerCommand} from "./ledger/command.ts";
+import {mapCommand} from "./map/command.ts";
 import {planCommand} from "./plan/command.ts";
 import {reportCommand} from "./report/command.ts";
 import {reviewCommand} from "./review/command.ts";
@@ -43,6 +44,7 @@ export const registeredGroups: ReadonlyArray<VerbGroup> = [
 	evalCommand,
 	hookCommand,
 	ledgerCommand,
+	mapCommand,
 	planCommand,
 	reportCommand,
 	reviewCommand,

--- a/packages/fabrika-cli/src/wire/map-ticket.ts
+++ b/packages/fabrika-cli/src/wire/map-ticket.ts
@@ -1,0 +1,181 @@
+/**
+ * The `map-ticket` marker — the first line of a wayfinding frontier ticket's opening comment.
+ *
+ *     map-ticket: #9140 · research · 7f3a9c21
+ *
+ * Three fields: the **map** the ticket belongs to, the **kind** from a closed set, and the **run
+ * nonce** of the run that filed it. The map number is the load-bearing one: a ticket whose marker
+ * names a different map is not that map's ticket, whatever the sub-issue edge says — the edge can be
+ * added by anyone, and a reader that trusted the edge alone would count a stranger's issue as part of
+ * the frontier it reports.
+ *
+ * `read` is total and its three answers are the design (see `./format.ts`). The discrimination that
+ * carries the weight is **Absent vs Malformed**: bytes carrying no `map-ticket:` line at all are
+ * `Absent`; bytes carrying something recognisably *reaching* for one — an off-vocabulary kind, a
+ * nonce that is not eight hex characters, a missing field — are `Malformed`. `map read` reports a
+ * malformed marker in `disregarded` rather than dropping the child, so a ticket that *looks* like the
+ * map's is visible instead of silently absent.
+ */
+
+import type {NonEmptyReadonlyArray, WireEmit, WireRead, WireReadLines} from "./format.ts";
+
+declare const NONCE: unique symbol;
+
+/** A run's lane key: exactly eight lowercase hex characters. Branded so `Found` cannot carry `""`. */
+export type Nonce = string & {readonly [NONCE]: true};
+
+/** What clears a frontier ticket. A fourth token is not a kind — it is a drift. */
+export type TicketKind = "research" | "prototype" | "decision";
+
+export interface MapTicketMarker {
+	readonly map: number;
+	readonly kind: TicketKind;
+	readonly nonce: Nonce;
+}
+
+export type MapTicketRead = WireRead<MapTicketMarker>;
+
+export const KEY_PREFIX = "map-ticket:";
+const NONCE_RE = /^[0-9a-f]{8}$/;
+const KINDS: ReadonlyArray<TicketKind> = ["research", "prototype", "decision"];
+const MARKER = /^map-ticket:\s*#(\d+)\s*·\s*([^\s·]+)\s*·\s*([^\s·]+)\s*$/;
+
+export const nonce = (raw: string): Nonce | null => {
+	const value = raw.trim();
+	return NONCE_RE.test(value) ? (value as Nonce) : null;
+};
+
+export const isTicketKind = (value: string): value is TicketKind =>
+	(KINDS as ReadonlyArray<string>).includes(value);
+
+const firstNonBlankLine = (artifact: string): string | null =>
+	artifact.split("\n").find((line) => line.trim() !== "") ?? null;
+
+const malformed = (reason: string, evidence: string): MapTicketRead => ({
+	_tag: "Malformed",
+	reason,
+	evidence,
+});
+
+/** Whether the bytes reach for this format at all — the gate that keeps `Absent` off a real drift. */
+export const reaches = (artifact: string): boolean =>
+	(firstNonBlankLine(artifact) ?? "").trimStart().toLowerCase().startsWith(KEY_PREFIX);
+
+export const read = (artifact: string): MapTicketRead => {
+	const line = firstNonBlankLine(artifact);
+	if (line === null || !reaches(artifact)) {
+		return {
+			_tag: "Absent",
+			reason: 'the first non-blank line does not open with "map-ticket:" — no marker of this format',
+		};
+	}
+	const evidence = `first line: "${line.trim()}"`;
+	const matched = MARKER.exec(line.trim());
+	if (matched === null) {
+		return malformed(
+			'the marker is not "map-ticket: #<map> · <kind> · <nonce>" — a field is missing or the separator drifted',
+			evidence,
+		);
+	}
+	const kind = matched[2] ?? "";
+	if (!isTicketKind(kind)) {
+		return malformed(`"${kind}" is not a kind — expected ${KINDS.join(", ")}`, evidence);
+	}
+	const key = nonce(matched[3] ?? "");
+	if (key === null) {
+		return malformed(
+			`"${matched[3]}" is not a run nonce — expected exactly eight lowercase hex characters`,
+			evidence,
+		);
+	}
+	return {
+		_tag: "Found",
+		value: {map: Number.parseInt(matched[1] ?? "0", 10), kind, nonce: key},
+	};
+};
+
+/** Compose the marker's one line. Round-trips through {@link read}. */
+export const emit = (marker: MapTicketMarker): string =>
+	`map-ticket: #${marker.map} · ${marker.kind} · ${marker.nonce}`;
+
+export type MapTicketFields =
+	| {readonly _tag: "Fields"; readonly marker: MapTicketMarker}
+	| {readonly _tag: "Unusable"; readonly reason: string};
+
+const FIELD_LINE = /^([A-Za-z-]+)[ \t]*[:\t][ \t]*(.*)$/;
+const KEYS = ["map", "kind", "nonce"] as const;
+type FieldKey = (typeof KEYS)[number];
+
+const isFieldKey = (key: string): key is FieldKey => (KEYS as ReadonlyArray<string>).includes(key);
+
+/**
+ * Parse `emit`'s stdin into a marker: one `<key>: <value>` per line, in any order.
+ *
+ * Every rejection is a refusal rather than a default. A missing `map` that silently composed an
+ * unbound marker would attach the ticket to no map at all, and the emitted bytes would look perfectly
+ * well-formed.
+ */
+export const parseFields = (fields: string): MapTicketFields => {
+	const seen = new Map<FieldKey, string>();
+	for (const [index, raw] of fields.split("\n").entries()) {
+		const line = raw.trim();
+		if (line === "") continue;
+		const matched = FIELD_LINE.exec(line);
+		const key = matched?.[1]?.toLowerCase() ?? "";
+		if (matched === null || !isFieldKey(key)) {
+			return {
+				_tag: "Unusable",
+				reason: `line ${index + 1} is not a "<field>: <value>" line over ${KEYS.join(", ")}: "${line}"`,
+			};
+		}
+		if (seen.has(key)) {
+			return {
+				_tag: "Unusable",
+				reason: `"${key}" is given twice — which one is the field is undecidable`,
+			};
+		}
+		seen.set(key, matched[2] ?? "");
+	}
+
+	const missing = KEYS.filter((key) => (seen.get(key) ?? "").trim() === "");
+	if (missing.length > 0) {
+		return {_tag: "Unusable", reason: `no value for ${missing.join(", ")} — every field is required`};
+	}
+	const map = (seen.get("map") ?? "").trim().replace(/^#/, "");
+	if (!/^\d+$/.test(map)) {
+		return {_tag: "Unusable", reason: `"${seen.get("map")}" is not an issue number`};
+	}
+	const kind = (seen.get("kind") ?? "").trim();
+	if (!isTicketKind(kind)) {
+		return {_tag: "Unusable", reason: `"${kind}" is not a kind — expected ${KINDS.join(", ")}`};
+	}
+	const key = nonce(seen.get("nonce") ?? "");
+	if (key === null) {
+		return {
+			_tag: "Unusable",
+			reason: `"${seen.get("nonce")}" is not a run nonce — expected exactly eight lowercase hex characters`,
+		};
+	}
+	return {_tag: "Fields", marker: {map: Number.parseInt(map, 10), kind, nonce: key}};
+};
+
+/** One `<field>\t<value>` line per field — the `wire read` answer for this format. */
+export const renderMarker = (marker: MapTicketMarker): NonEmptyReadonlyArray<string> => [
+	`map\t${marker.map}`,
+	`kind\t${marker.kind}`,
+	`nonce\t${marker.nonce}`,
+];
+
+/** The registry row's byte-level `emit`, bound to this module's typed core. */
+export const emitFromFields = (fields: string): WireEmit => {
+	const parsed = parseFields(fields);
+	return parsed._tag === "Fields"
+		? {_tag: "Composed", bytes: `${emit(parsed.marker)}\n`}
+		: {_tag: "Unusable", reason: parsed.reason};
+};
+
+/** The registry row's byte-level `read`, bound to this module's typed core. */
+export const readToLines = (artifact: string): WireReadLines => {
+	const result = read(artifact);
+	return result._tag === "Found" ? {_tag: "Found", value: renderMarker(result.value)} : result;
+};

--- a/packages/fabrika-cli/src/wire/map-ticket.ts
+++ b/packages/fabrika-cli/src/wire/map-ticket.ts
@@ -66,7 +66,8 @@ export const read = (artifact: string): MapTicketRead => {
 	if (line === null || !reaches(artifact)) {
 		return {
 			_tag: "Absent",
-			reason: 'the first non-blank line does not open with "map-ticket:" — no marker of this format',
+			reason:
+				'the first non-blank line does not open with "map-ticket:" — no marker of this format',
 		};
 	}
 	const evidence = `first line: "${line.trim()}"`;
@@ -139,7 +140,10 @@ export const parseFields = (fields: string): MapTicketFields => {
 
 	const missing = KEYS.filter((key) => (seen.get(key) ?? "").trim() === "");
 	if (missing.length > 0) {
-		return {_tag: "Unusable", reason: `no value for ${missing.join(", ")} — every field is required`};
+		return {
+			_tag: "Unusable",
+			reason: `no value for ${missing.join(", ")} — every field is required`,
+		};
 	}
 	const map = (seen.get("map") ?? "").trim().replace(/^#/, "");
 	if (!/^\d+$/.test(map)) {

--- a/packages/fabrika-cli/src/wire/map-ticket.unit.test.ts
+++ b/packages/fabrika-cli/src/wire/map-ticket.unit.test.ts
@@ -1,0 +1,76 @@
+import {describe, expect, it} from "vitest";
+import {emit, emitFromFields, parseFields, read, readToLines} from "./map-ticket.ts";
+
+const marker = "map-ticket: #9140 · research · 7f3a9c21";
+
+describe("read", () => {
+	it("finds the marker's three fields", () => {
+		expect(read(`${marker}\n`)).toEqual({
+			_tag: "Found",
+			value: {map: 9140, kind: "research", nonce: "7f3a9c21"},
+		});
+	});
+
+	it("answers Absent for bytes that never reach for the format", () => {
+		expect(read("Picking this one up — will report back.\n")._tag).toBe("Absent");
+	});
+
+	it("answers Absent for an artifact with no non-blank line at all", () => {
+		expect(read("\n \n")._tag).toBe("Absent");
+	});
+
+	it.each([
+		["an off-vocabulary kind", "map-ticket: #9140 · investigation · 7f3a9c21"],
+		["a lane key two runs would collide on", "map-ticket: #9140 · research · run-1"],
+		["a missing map field", "map-ticket: research · 7f3a9c21"],
+		["a separator that drifted", "map-ticket: #9140 - research - 7f3a9c21"],
+	])("answers Malformed, not Absent, on %s", (_drift, artifact) => {
+		const result = read(`${artifact}\n`);
+		expect(result._tag).toBe("Malformed");
+		// The evidence is the offending bytes quoted back, so a reader can see what was judged.
+		expect(result._tag === "Malformed" && result.evidence).toContain(artifact);
+	});
+
+	it("does not read a marker quoted further down the body", () => {
+		expect(read(`Someone wrote:\n\n${marker}\n`)._tag).toBe("Absent");
+	});
+});
+
+describe("emit", () => {
+	it("round-trips through read", () => {
+		const composed = emit({map: 9140, kind: "decision", nonce: "0a1b2c3d" as never});
+		expect(read(composed)).toMatchObject({_tag: "Found"});
+	});
+});
+
+describe("parseFields", () => {
+	it("takes the fields in any order", () => {
+		expect(parseFields("nonce: 7f3a9c21\nkind: prototype\nmap: 9140")).toMatchObject({
+			_tag: "Fields",
+			marker: {map: 9140, kind: "prototype", nonce: "7f3a9c21"},
+		});
+	});
+
+	it("tolerates a leading # on the map field, which is how a human writes it", () => {
+		expect(parseFields("map: #9140\nkind: research\nnonce: 7f3a9c21")._tag).toBe("Fields");
+	});
+
+	it.each([
+		["a missing field", "kind: research\nnonce: 7f3a9c21"],
+		["a duplicated field", "map: 9140\nmap: 9141\nkind: research\nnonce: 7f3a9c21"],
+		["an unknown key", "map: 9140\nkind: research\nnonce: 7f3a9c21\nowner: someone"],
+		["an off-vocabulary kind", "map: 9140\nkind: investigation\nnonce: 7f3a9c21"],
+		["a bad nonce", "map: 9140\nkind: research\nnonce: run-1"],
+	])("refuses %s rather than composing a weaker marker", (_case, fields) => {
+		expect(emitFromFields(fields)._tag).toBe("Unusable");
+	});
+});
+
+describe("readToLines", () => {
+	it("renders one <field>\\t<value> line per field", () => {
+		expect(readToLines(`${marker}\n`)).toEqual({
+			_tag: "Found",
+			value: ["map\t9140", "kind\tresearch", "nonce\t7f3a9c21"],
+		});
+	});
+});

--- a/packages/fabrika-cli/src/wire/registry.ts
+++ b/packages/fabrika-cli/src/wire/registry.ts
@@ -20,6 +20,7 @@
  */
 import * as acceptanceCriteria from "./acceptance-criteria.ts";
 import {brandWitnesses, type WireFormat} from "./format.ts";
+import * as mapTicket from "./map-ticket.ts";
 import * as sliceHandoff from "./slice-handoff.ts";
 import * as verdictMarker from "./verdict-marker.ts";
 
@@ -136,6 +137,38 @@ export const registeredFormats: ReadonlyArray<WireFormat> = [
 			],
 		},
 		brands: brandWitnesses<sliceHandoff.SliceHandoff>({id: true, branch: true, base: true}),
+	},
+	{
+		key: "map-ticket",
+		purpose:
+			"the first line of a wayfinding frontier ticket's opening comment — the map it belongs to, what clears it, and the run nonce that filed it",
+		module: "packages/fabrika-cli/src/wire/map-ticket.ts",
+		producers: ["map"],
+		consumers: ["map"],
+		emit: mapTicket.emitFromFields,
+		read: mapTicket.readToLines,
+		fixtures: {
+			roundTrip: {
+				fields: "map: 9140\nkind: research\nnonce: 7f3a9c21\n",
+				values: ["9140", "research", "7f3a9c21"],
+			},
+			absent: "Picking this one up — will report back once the source read lands.\n",
+			malformed: [
+				{
+					drift: "the kind is off the closed set",
+					artifact: "map-ticket: #9140 · investigation · 7f3a9c21\n",
+				},
+				{
+					drift: "the lane key is a human-readable label two runs would collide on",
+					artifact: "map-ticket: #9140 · research · run-1\n",
+				},
+				{
+					drift: "the map field is missing, so the ticket names no map",
+					artifact: "map-ticket: research · 7f3a9c21\n",
+				},
+			],
+		},
+		brands: brandWitnesses<mapTicket.MapTicketMarker>({kind: true, nonce: true}),
 	},
 ];
 


### PR DESCRIPTION
Fixes #5022

Implements the `map` verb group in `packages/fabrika-cli/` against the landed
[`claude-plugins/fabrika/skills/wayfinding/contract.md`](claude-plugins/fabrika/skills/wayfinding/contract.md) —
all eight verbs the contract specifies, and no verb it does not.

## What landed

| Verb | Purpose |
|---|---|
| `map open` | mint or resume the map for a destination, refusing one that is not fog |
| `map read` | five sections, one row per frontier ticket, the frontier token, the body digest |
| `map ticket` | file a ticket, link it, set its edges, splice its row — one act |
| `map lane` | claim a research lane, keyed on the run nonce |
| `map finding` | close a lane with an outcome from a closed set of three |
| `map fork` | record where a question is being answered instead |
| `map record` | the lockstep: the answer under `## Decisions`, the row off the frontier, the ticket closed |
| `map descope` | append a rejected direction to the never-graduating out-of-scope section |

Module shape follows the group convention: pure cores (`body.ts`, `markers.ts`, `frontier.ts`,
`guards.ts`, `open.ts`, `ticket.ts`, `record.ts`) plus a thin `<verb>-verb.ts` entry each, assembled
by `src/map/command.ts`, with a `*.unit.test.ts` beside every one. Every verb is a pure function of
its dependencies — it computes an outcome and neither writes streams nor exits — so each refusal is
asserted by exit code and by the bytes on each channel without spawning a process.

Four properties the contract calls load-bearing, and where they live:

- **A line's section is not its state.** State resolves from the ticket's marker, its `state` on
  GitHub and its native edges; body rows are re-rendered from that answer
  (`packages/fabrika-cli/src/map/frontier.ts`).
- **A map read is bound to a current tree.** Every body write takes `--digest` and is a **slice**, so
  bytes outside the spliced section survive verbatim (`packages/fabrika-cli/src/map/body.ts`).
- **Concurrent lanes do not lose each other's writes.** Lane traffic writes to the ticket, never to
  the map body; only `map record` and `map descope` touch the body, each under the digest guard.
- **Zero scope is a first-class answer.** Zero open maps and zero children are facts only when the
  platform proved them; every unprovable empty read is `11`, never an empty frontier
  (`packages/fabrika-cli/src/io/edges.ts`).

## The exit table

One table per group in `packages/fabrika-cli/src/map/codes.ts`. `3`–`9` and `11` are **imported**
from `packages/fabrika-cli/src/report/codes.ts` — a drift is unrepresentable, not merely detectable.
`10` is held empty as `DELIBERATE_GAP` (no `map` verb accepts a label flag or writes a
classification, so the base's condition is unreachable here). `12`–`21` are the group's own and clear
the base's whole table.

| Code | Meaning |
|---|---|
| `0` | the answer is on stdout |
| `1` | usage error, or the verb failed to run |
| `127` | the verb never ran |
| `3` | `EMPTY_STDIN` |
| `4` | `BAD_SECTIONS` |
| `5` / `6` | `LEAKED_PATH` / `BARE_AT_PATH` |
| `7` | `NO_TARGET` |
| `8` / `9` | `WRITE_UNKNOWN` / `READBACK_MISMATCH` |
| `10` | `DELIBERATE_GAP` |
| `11` | `PRECONDITION_UNKNOWN` |
| `12` | `DIGEST_STALE` |
| `13` | `TICKET_UNKNOWN` |
| `14` | `EDGE_UNRESOLVABLE` |
| `15` | `LANE_NOT_MINE` |
| `16` | `MAP_AMBIGUOUS` |
| `17` | `NOT_FOG` |
| `18` | `TICKET_RETIRED` |
| `19` | `ALREADY_DESCOPED` |
| `20` | `KIND_MISMATCH` |
| `21` | `OUTCOME_UNRECORDABLE` |

The distinction the codebase keeps getting burned by is held open: `1` / `127` are *the call never
decided*, `8` is *a write was attempted and its outcome is UNKNOWN*, `11` is *a precondition read
failed and nothing was written*, and every proven verdict sits at `3` or above with **nothing on
stdout**.

## The four registration edits the contract names

1. `packages/fabrika-cli/src/registry.ts` — `mapCommand` registered; the group appears under
   `--help` by that alone.
2. `packages/fabrika-cli/src/exit-code-alignment.ts` — a new `MAP_SEATS` constant plus the `map` row
   in `ALIGNED_GROUPS`. None of the shipped seat maps fits: `map` names `7` `NO_TARGET` and holds
   `10`, so it can claim neither `ZERO_SCOPE` nor `OFF_VOCABULARY`.
3. `packages/fabrika-cli/src/exit-code-alignment.unit.test.ts` — the `map` row in `TABLES`.
4. The `map-ticket` wire format: `packages/fabrika-cli/src/wire/map-ticket.ts`, its
   `packages/fabrika-cli/src/wire/registry.ts` row, and its narrative section in
   `claude-plugins/fabrika/docs/wire-formats.md` (generated region regenerated with
   `fabrika wire index --write`).

`wire/verdict-marker.ts`'s `NAMESPACE`, its `NAMESPACE_PREFIXES` gate, `SHIP_NAMESPACES`,
`CLASS_NAMES` and `SHIP_CLASS_NAMES` are deliberately **not** widened: this group emits no verdict
marker and gates no merge.

## Green

`pnpm typecheck` (in-package) and `pnpm lint` clean; `pnpm test` 216 files / 3106 tests pass,
including 76 new tests across the `map` suites and the `map-ticket` format.

## Deviations

Not `None.` — `claude-plugins/kampus-pipeline/skills/shared/scripts/dev-tier-m.sh` on this PR
reports **1 suppression/skip line, 0 removed-assertion lines**. The one hit is a false positive and
is disclosed rather than swallowed:

- `packages/fabrika-cli/src/map/command.ts`, `process.exit(outcome.code);` — the scan's class-5
  alternation includes the bare token `xit(`, and `process.exit(` contains it. This is the byte-
  identical `emit` adapter every registered group already ships (`report`, `ledger`, `ship`, …); no
  test is skipped, no lint rule suppressed, no type error ignored. The diff adds no
  `biome-ignore`, no `eslint-disable`, no `@ts-expect-error`/`@ts-ignore`, and no `.skip(` /
  `.only(`.

What follows are **contract deviations** — clauses that proved
under-determined during implementation, resolved visibly rather than silently, per the ticket's own
instruction to surface them on the issue rather than patch the spec in code. Each is also filed on
#5022 as a comment.

1. **`map ticket` has no `--nonce` in the contract's Inputs table, yet its marker carries a run
   nonce.** Implemented as a nonce generated inside the verb (four random bytes, hex) and injected
   for tests, so the flag surface stays exactly what the contract declares. If the intent was an
   explicit `--nonce` matching `map lane`'s, that is a one-line change.
2. **`map descope --ticket` is named in the exit table (`13` / `18`) and in `map record`'s refusal
   text, but is absent from its Inputs table.** Implemented as an optional flag, since the
   `EVERY-TICKET-HAS-AN-EXIT` anchor makes it load-bearing for `clear` ever being reachable.
3. **A forked `decision` ticket cannot be proven `graduated` from the citation grammar alone.** The
   two admitted citations are `— ruled on #<session> <qid>` and `— from #<ticket>`; only the second
   names the ticket. So graduation for a forked decision is derived from a decision entry citing the
   **session the fork pointed at** (`decisionCites` in `packages/fabrika-cli/src/map/frontier.ts`).
   Without that, a forked ticket's answer could land on the map and the ticket would read `forked`
   forever.
4. **`map read`'s `fog` is a number over a section the contract calls free prose.** Implemented as
   the count of non-blank lines in `## Fog`, which equals the bullet count for the shape `map open`
   writes.
5. **`map lane` and `map finding` seat an unparseable map body on `11`, not `4`.** The shared matrix
   gives neither verb a `4` seat, and neither splices the body; what an unreadable body costs them is
   only that a ticket's `graduated` state cannot be proven, which is a precondition that could not be
   read.
6. **`map record` on a forked `decision` ticket refuses `11`.** This is the contract's own
   sequencing, not a deviation — the `grill` question-state reader ships from #5023 and re-deriving
   its four clauses here would be a second answer to a question enforced elsewhere. Recorded so a
   reviewer meets it as designed rather than as a gap.

## Shared-surface note for the concurrent lane (#5023)

Six files outside `src/map/` are touched, and #5023 will touch several of the same:
`src/registry.ts`, `src/exit-code-alignment.ts`, `src/exit-code-alignment.unit.test.ts`,
`src/wire/registry.ts`, `claude-plugins/fabrika/docs/wire-formats.md` (all four mandated by the
contract's registration burden), and `src/io/issues.ts`, which gains two small siblings —
`closeCompleted` (beside `closeNotPlanned`) and `searchIssues` (open **and** closed, beside
`searchOpenIssues`, because an open-only board scan reports a charted-and-closed question as new —
#4154 / #4148). The new native-relationship reads live in a **new** file,
`packages/fabrika-cli/src/io/edges.ts`, rather than as an append to `io/issues.ts`, precisely to keep
the shared-file surface small.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
