### PR TITLE
revert(ci): restore the browser-provisioning CI skip (#5169)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -457,31 +457,6 @@ jobs:
           node-version-file: package.json
           cache: pnpm
 
-      # `@kampus/fabrika-cli`'s `postinstall` provisions chromium so no operator or agent ever
-      # hand-runs a browser install (#5061), and pnpm runs a workspace member's `postinstall` on
-      # EVERY `pnpm install --frozen-lockfile` — including "Already up to date" — so all five
-      # hosted-runner install jobs would each pay the ~170MB download. Restoring the browser dir
-      # BEFORE the install is what makes the script's presence check hit and skip, so the download
-      # is paid once per cache key instead of once per job. Keyed on `pnpm-workspace.yaml` (which
-      # carries the `@playwright/test` catalog pin) so a version bump re-downloads exactly once;
-      # `restore-keys` falls back to the newest prior cache, which still satisfies the presence
-      # check whenever the pin didn't move. The script deliberately has no `CI` skip — that skip
-      # pre-empted its own presence check and broke #5061's criterion (#5169). `e2e` needs none of
-      # this: its container prebakes /ms-playwright and sets PLAYWRIGHT_BROWSERS_PATH, which the
-      # script skips on one line earlier.
-      #
-      # This cache is INERT until #5343 is fixed: playwright 1.59.1 hangs in `extract-zip` after the
-      # bytes land, so nothing is ever extracted and the key saves an empty directory. It is kept
-      # rather than deferred because it is the mechanism the moment provisioning can succeed, and
-      # keeping it is what stops that becoming a per-job cost then.
-      - name: Cache Playwright browsers
-        uses: actions/cache@v4.2.3
-        with:
-          path: ~/.cache/ms-playwright
-          key: playwright-${{ runner.os }}-${{ hashFiles('pnpm-workspace.yaml') }}
-          restore-keys: |
-            playwright-${{ runner.os }}-
-
       - run: pnpm install --frozen-lockfile
 
       # `biome check` is lint + format in one pass (tabs/100-col/no-bracket-spacing).
@@ -535,15 +510,6 @@ jobs:
         with:
           node-version-file: package.json
           cache: pnpm
-
-      # See the `check` job's Playwright browser cache.
-      - name: Cache Playwright browsers
-        uses: actions/cache@v4.2.3
-        with:
-          path: ~/.cache/ms-playwright
-          key: playwright-${{ runner.os }}-${{ hashFiles('pnpm-workspace.yaml') }}
-          restore-keys: |
-            playwright-${{ runner.os }}-
 
       - run: pnpm install --frozen-lockfile
 
@@ -601,15 +567,6 @@ jobs:
           node-version-file: package.json
           cache: pnpm
 
-      # See the `check` job's Playwright browser cache.
-      - name: Cache Playwright browsers
-        uses: actions/cache@v4.2.3
-        with:
-          path: ~/.cache/ms-playwright
-          key: playwright-${{ runner.os }}-${{ hashFiles('pnpm-workspace.yaml') }}
-          restore-keys: |
-            playwright-${{ runner.os }}-
-
       - run: pnpm install --frozen-lockfile
 
       - run: pnpm --filter './packages/**' --filter @kampus/infra run test
@@ -630,15 +587,6 @@ jobs:
         with:
           node-version-file: package.json
           cache: pnpm
-
-      # See the `check` job's Playwright browser cache.
-      - name: Cache Playwright browsers
-        uses: actions/cache@v4.2.3
-        with:
-          path: ~/.cache/ms-playwright
-          key: playwright-${{ runner.os }}-${{ hashFiles('pnpm-workspace.yaml') }}
-          restore-keys: |
-            playwright-${{ runner.os }}-
 
       - run: pnpm install --frozen-lockfile
 
@@ -821,15 +769,6 @@ jobs:
         with:
           node-version-file: package.json
           cache: pnpm
-
-      # See the `check` job's Playwright browser cache.
-      - name: Cache Playwright browsers
-        uses: actions/cache@v4.2.3
-        with:
-          path: ~/.cache/ms-playwright
-          key: playwright-${{ runner.os }}-${{ hashFiles('pnpm-workspace.yaml') }}
-          restore-keys: |
-            playwright-${{ runner.os }}-
 
       - run: pnpm install --frozen-lockfile
 

--- a/packages/fabrika-cli/README.md
+++ b/packages/fabrika-cli/README.md
@@ -709,16 +709,9 @@ Four things about it are load-bearing:
 - **The headless browser is provisioned by installing the package.** `postinstall` runs
   [`scripts/provision-browser.mjs`](./scripts/provision-browser.mjs), so no operator and no agent
   ever runs a browser-install step by hand. It is best-effort and never fails the install; it skips
-  when the browser is already there, when `PLAYWRIGHT_BROWSERS_PATH` names a managed install, or on
-  `FABRIKA_SKIP_BROWSER_PROVISION=1`. There is deliberately no `CI` skip: it pre-empted the presence
-  check, so it only ever fired on a CI image with *no* chromium — the one case the criterion has to
-  cover ([#5169](https://github.com/kamp-us/phoenix/issues/5169)). CI keeps the repeat cost off the
-  clock with a `~/.cache/ms-playwright` cache restored before `pnpm install`, not with a skip. A run
-  that then finds no browser exits `11` **carrying the exact remediation command** — never a silent
-  skip. **Provisioning cannot currently succeed on a machine with no browser at all**: playwright
-  1.59.1 downloads the archive and then hangs unzipping it
-  ([#5343](https://github.com/kamp-us/phoenix/issues/5343)), so the install is bounded by a 120s
-  timeout and the `11` remediation path is what you land on.
+  when the browser is already there, when `PLAYWRIGHT_BROWSERS_PATH` names a managed install, when
+  `CI` is set (CI images bake their own), or on `FABRIKA_SKIP_BROWSER_PROVISION=1`. A run that then
+  finds no browser exits `11` **carrying the exact remediation command** — never a silent skip.
 - **Absence is answered three ways, never one.** A missing manifest is `12` (un-bootstrapped, route
   to front-door), a missing registry is `13` (the law is untyped, prose is the source), and an
   unreadable one is `11` (UNKNOWN) — the skill's prose fallback is legal only in the middle case.

--- a/packages/fabrika-cli/scripts/provision-browser.mjs
+++ b/packages/fabrika-cli/scripts/provision-browser.mjs
@@ -11,14 +11,12 @@
  * `pnpm install` for everyone over a capability only one verb needs, and the run-time story is
  * already fail-closed and actionable: `ui render` exits `11` naming the exact remediation command.
  *
- * Two skips, each a real provisioning state rather than a convenience:
+ * Three skips, each a real provisioning state rather than a convenience:
  *   - `FABRIKA_SKIP_BROWSER_PROVISION=1` — the explicit opt-out.
  *   - `PLAYWRIGHT_BROWSERS_PATH` set — a managed/prebaked install already owns the browsers.
- *
- * There is deliberately no `CI` skip (#5169): it fired *before* the presence check below, so it was
- * load-bearing only on a CI image with no chromium — exactly the case the criterion above must
- * cover. CI keeps the repeat cost off the clock with a browser cache restored before the install
- * (`.github/workflows/ci.yml`), not with a skip.
+ *   - `CI` set with no prebaked path — CI images bake their own browsers, and a ~130MB download in
+ *     every job of every workflow is a cost no job asked for. The run-time `11` covers the case
+ *     where a CI job really did need it.
  */
 import {spawnSync} from "node:child_process";
 import {existsSync} from "node:fs";
@@ -31,6 +29,7 @@ const skip = (reason) => {
 if (process.env.FABRIKA_SKIP_BROWSER_PROVISION === "1") skip("FABRIKA_SKIP_BROWSER_PROVISION=1");
 if ((process.env.PLAYWRIGHT_BROWSERS_PATH ?? "") !== "")
 	skip("PLAYWRIGHT_BROWSERS_PATH names a managed install");
+if ((process.env.CI ?? "") !== "") skip("CI images prebake their browsers");
 
 let installed = false;
 try {
@@ -41,14 +40,9 @@ try {
 }
 if (installed) skip("chromium is already provisioned");
 
-// 120s, not the 10 minutes this carried before, and the number is measured (#5169). The download
-// itself is ~2s for 173MB on both a GitHub hosted runner and a dev machine; what actually costs time
-// is playwright 1.59.1 hanging in `extract-zip` *after* the bytes land, which never recovers (#5343).
-// A timeout sized for a slow download therefore bought nothing and spent 10 minutes per install site
-// proving it. 120s is ~60x the measured download and caps a hung install at a bounded cost.
 const result = spawnSync("pnpm", ["exec", "playwright", "install", "chromium"], {
 	stdio: "inherit",
-	timeout: 120 * 1000,
+	timeout: 10 * 60 * 1000,
 });
 if (result.status !== 0) {
 	process.stderr.write(


### PR DESCRIPTION
This reverts PR #5336 (merge commit `b2d33e64`), which landed on `main` against an explicit founder hold. It restores the three files that PR touched — `.github/workflows/ci.yml`, `packages/fabrika-cli/scripts/provision-browser.mjs`, `packages/fabrika-cli/README.md` — to exactly their pre-merge content. Nothing else changes.

Re: #5169

## Why revert

**The deleted `CI` skip was load-bearing.** A read-only investigation traced all six CI jobs. None of `check`, `unit`, `packages-tests`, `skills`, or `integration` ever launches a browser: they are static analysis, jsdom, bash validators, and HTTP against a deployed stack — no test in them reaches `chromium.launch`. `e2e` is the only job that needs chromium, and it already has it prebaked in the `mcr.microsoft.com/playwright:v1.59.1-jammy` container.

**A workspace member's `postinstall` fires in all six jobs.** This is grounded in pnpm 10.27.0's source — `runLifecycleHooksConcurrently` runs over workspace importers, and `onlyBuiltDependencies` is a different code path that governs *dependencies*, not workspace members — and confirmed by a live throwaway-workspace probe. That closes an unverified triage note the repo was carrying.

**So the net effect of the merged change was cost with no gate gained.** Five jobs each attempt a ~130MB chromium download that no test in them can use, on runners inside the `extract-zip` hang range of #5343. The cache added alongside the deletion does not remove that: it only changes how often the download is paid.

**The correct fix, for whoever picks this up:** scope browser provisioning to a job that actually needs a browser — if such a job exists — and when it does, a prebaked container beats a cache. #5343 stays open on its own merits; it is a real playwright defect independent of this revert.

This PR takes no position on #5169's original ruling. It restores the pre-merge state so the decision can be re-made outside a hold.

## Verification

- `git diff 889c26c3 HEAD` (the pre-merge parent) is **empty** — the branch tree is byte-identical to the state before `b2d33e64`.
- `git status` shows exactly three modified files, the same three `b2d33e64` touched.
- `pnpm typecheck` and `pnpm lint:worktree` are clean.

## Control-plane

This diff re-touches `.github/workflows/ci.yml`, so it is §CP by path and banks for a control-plane approval rather than auto-shipping. That is expected.

## Deviations

- **Scope narrowing (class 1)** — **Said:** #5169's `### What to build` asks for the `CI` skip to be deleted, which is what `b2d33e64` did. **Did:** this PR restores the skip, undoing that delivery. **Why:** the change merged against an explicit founder hold, and the evidence above shows the skip was load-bearing — five jobs pay a download no test can use. **Disposition:** for the reviewer to judge; #5169 stays open and a separate annotation on it records the re-decision. This PR deliberately carries `Re: #5169`, not a closing keyword, because the revert does not resolve that ticket.
