### PR TITLE
feat(fabrika): implement the prototyping contract's spike verbs (#5024)

### DIFF
--- a/packages/fabrika-cli/README.md
+++ b/packages/fabrika-cli/README.md
@@ -433,6 +433,48 @@ Four properties are worth knowing before you call them:
 This group records no merge-gating verdict and computes no second answer to control-plane
 membership, pitch approval or triage classification — each is already enforced at its own gate.
 
+## The `spike` group
+
+The contract is
+[`claude-plugins/fabrika/skills/prototyping/contract.md`](../../claude-plugins/fabrika/skills/prototyping/contract.md).
+A **spike** is one GitHub issue carrying the `prototyping:spike` label, bound to a throwaway
+workspace that lives under the OS temp root — **never inside the repository** — and keyed on a
+per-run nonce.
+
+| Verb | Answers |
+|---|---|
+| `spike open` | mints the spike issue and this run's workspace, and binds the two in a manifest |
+| `spike run` | executes one command in the workspace and appends an immutable evidence record |
+| `spike capture` | posts the decision plus the log's own run table, reads it back, and closes the spike |
+| `spike dispose` | proves the tree is unchanged and the capture still covers the log, removes the workspace, and proves it is gone |
+| `spike status` | one run's spike state, workspace presence and evidence count |
+
+Five properties are worth knowing before you call them:
+
+- **"Ran and answered no" and "could not run" are opposite answers.** `spike run` exits `0`
+  whatever the command returned — the command's own status rides in the payload as `commandExit`
+  — and exits `11` only when the command could not be executed at all. This is the one place in
+  the group where the exit code and the answer are deliberately about different things.
+- **The key is a per-run nonce, minted from a cryptographic source.** No verb reads
+  `CLAUDE_CODE_SESSION_ID` or any session variable, and no verb asks a caller to invent a value,
+  so two concurrent spikes cannot collide on a workspace ([#4544](https://github.com/kamp-us/phoenix/issues/4544)).
+- **Disposability is a property, not an intention.** `spike open` records a digest of
+  `git status --porcelain=v1 --untracked-files=all --ignored=matching`, and `spike dispose`
+  recomputes it *before* it removes or posts anything — so a leak refuses on `17` with the
+  workspace intact. `--ignored=matching` is load-bearing: a build cache or a `node_modules/` is
+  exactly where a prototype writes.
+- **A decision with no recorded run is a self-report.** `spike capture` reds on a log holding zero
+  runs (`14`, ADR [0092](../../.decisions/0092-gates-fail-closed-on-zero-scope.md)), and the
+  comment it posts transcribes each run's command and status rather than summarising them.
+- **`spike status` is near-total on purpose.** Its consumer is a session resuming cold, so an
+  absent workspace is a **fact** at exit `0` while the same absence is a refusal (`12`) in the
+  mutating verbs. The bound is still ADR 0092: an unparseable record is `4` and an unreadable
+  state is `11`.
+
+This group gates no merge, judges no pull request and emits no verdict, so it registers in no
+verdict namespace and no wire format — a `spike` marker there would be one `wire read` could never
+read back.
+
 ## The `wire` group
 
 A **wire format** is the byte-level agreement two skills meet through on a GitHub artifact —

--- a/packages/fabrika-cli/src/exit-code-alignment.ts
+++ b/packages/fabrika-cli/src/exit-code-alignment.ts
@@ -163,6 +163,28 @@ export const MAP_SEATS: SharedSeats = (() => {
 	return {...rest, NO_TARGET: "NO_TARGET"};
 })();
 
+/**
+ * `spike`'s seats: all nine, under this group's own names.
+ *
+ * The only group to claim the base's whole `3`-`11` table with no `DELIBERATE_GAP` — every seat is
+ * reached by some verb, which is what leaves `12`+ entirely to facts about a throwaway workspace.
+ * Two names differ deliberately: `MALFORMED_RECORD` reads the base's section fact over a whole
+ * on-disk record, and `READ_OR_EXEC_UNKNOWN` is a documented **superset** of the base's — it also
+ * covers a child process that could not be executed, which is an attempt rather than a read, and a
+ * number cannot say so on its own (see this module's header).
+ */
+export const SPIKE_SEATS: SharedSeats = {
+	EMPTY_STDIN: "EMPTY_STDIN",
+	MALFORMED_RECORD: "BAD_SECTIONS",
+	LEAKED_PATH: "LEAKED_PATH",
+	BARE_AT_PATH: "BARE_AT_PATH",
+	ZERO_SCOPE: "NO_TARGET",
+	WRITE_UNKNOWN: "WRITE_UNKNOWN",
+	READBACK_MISMATCH: "READBACK_MISMATCH",
+	OFF_VOCABULARY: "CLASSIFIED",
+	READ_OR_EXEC_UNKNOWN: "PRECONDITION_UNKNOWN",
+};
+
 /** The groups that align to {@link ALIGNMENT_BASE}, each with the seats it claims to share. */
 export const ALIGNED_GROUPS: Readonly<Record<string, SharedSeats>> = {
 	adr: ADR_SEATS,
@@ -179,6 +201,7 @@ export const ALIGNED_GROUPS: Readonly<Record<string, SharedSeats>> = {
 	"review-ui": REVIEW_UI_SEATS,
 	ship: SHARED_SEATS,
 	spend: SPEND_SEATS,
+	spike: SPIKE_SEATS,
 	status: SHARED_SEATS,
 	ui: UI_SEATS,
 };

--- a/packages/fabrika-cli/src/exit-code-alignment.unit.test.ts
+++ b/packages/fabrika-cli/src/exit-code-alignment.unit.test.ts
@@ -26,6 +26,7 @@ import * as review from "./review/codes.ts";
 import * as reviewUi from "./review-ui/codes.ts";
 import * as ship from "./ship/codes.ts";
 import * as spend from "./spend/codes.ts";
+import * as spike from "./spike/codes.ts";
 import * as status from "./status/codes.ts";
 import * as triage from "./triage/codes.ts";
 import * as ui from "./ui/codes.ts";
@@ -53,6 +54,7 @@ const TABLES: Readonly<Record<string, CodeTable>> = {
 	"review-ui": reviewUi,
 	ship,
 	spend,
+	spike,
 	status,
 	triage,
 	ui,

--- a/packages/fabrika-cli/src/fakes.test-support.ts
+++ b/packages/fabrika-cli/src/fakes.test-support.ts
@@ -52,6 +52,18 @@ export interface FakeFsOptions {
 	readonly unprobeable?: ReadonlyArray<string>;
 	/** Symlink path → the path it really is. Anything unlisted is its own real path. */
 	readonly real?: Readonly<Record<string, string>>;
+	/**
+	 * Directories that exist without holding a listed file — a workspace root, say.
+	 *
+	 * Separate from {@link FakeFsOptions.dirs}, which answers `readDirectory`: a caller asking
+	 * whether a directory is *there* is asking a different question from one asking what is in it,
+	 * and a fake that answered the first from the second would make an unlistable directory absent.
+	 */
+	readonly directories?: ReadonlyArray<string>;
+	/** Paths whose removal fails — distinct from a removal that lands and leaves the path behind. */
+	readonly unremovable?: ReadonlyArray<string>;
+	/** Paths a removal is scripted to NOT actually remove, so the re-probe has something to catch. */
+	readonly survivesRemoval?: ReadonlyArray<string>;
 }
 
 export interface FakeFs {
@@ -65,6 +77,8 @@ export const fakeFs = (options: FakeFsOptions): FakeFs => {
 	const dirs: Record<string, ReadonlyArray<string> | null> = {...options.dirs};
 	const files: Record<string, string | null> = {...options.files};
 	const written = new Map<string, string>();
+	const directories = new Set(options.directories ?? []);
+	const decoder = new TextDecoder();
 	const layer = Layer.merge(
 		FileSystem.layerNoop({
 			readDirectory: (path: string) => {
@@ -83,13 +97,43 @@ export const fakeFs = (options: FakeFsOptions): FakeFs => {
 			exists: (path: string) =>
 				options.unprobeable?.includes(path) === true
 					? notFound("exists", path)
-					: Effect.succeed(Object.hasOwn(files, path) && files[path] !== null),
-			makeDirectory: () => Effect.void,
+					: Effect.succeed(
+							(Object.hasOwn(files, path) && files[path] !== null) || directories.has(path),
+						),
+			makeDirectory: (path: string) => {
+				if (options.unwritable?.includes(path) === true) return notFound("makeDirectory", path);
+				directories.add(path);
+				return Effect.void;
+			},
 			realPath: (path: string) => Effect.succeed(options.real?.[path] ?? path),
-			writeFileString: (path: string, data: string) => {
+			remove: (path: string) => {
+				if (options.unremovable?.includes(path) === true) return denied("remove", path);
+				if (options.survivesRemoval?.includes(path) === true) return Effect.void;
+				directories.delete(path);
+				for (const key of Object.keys(files)) {
+					if (key === path || key.startsWith(`${path}/`)) delete files[key];
+				}
+				return Effect.void;
+			},
+			writeFileString: (
+				path: string,
+				data: string,
+				opts?: {readonly flag?: string | undefined},
+			) => {
 				if (options.unwritable?.includes(path) === true) return notFound("writeFileString", path);
-				files[path] = data;
-				written.set(path, data);
+				// An append flag appends here too, because a caller that appends and one that overwrites
+				// leave different bytes on disk and a fake that flattened them would hide the difference.
+				const appending = opts?.flag?.startsWith("a") === true;
+				const next = appending ? `${files[path] ?? ""}${data}` : data;
+				files[path] = next;
+				written.set(path, next);
+				return Effect.void;
+			},
+			writeFile: (path: string, data: Uint8Array) => {
+				if (options.unwritable?.includes(path) === true) return notFound("writeFile", path);
+				const text = decoder.decode(data);
+				files[path] = text;
+				written.set(path, text);
 				return Effect.void;
 			},
 		}),

--- a/packages/fabrika-cli/src/io/exec.ts
+++ b/packages/fabrika-cli/src/io/exec.ts
@@ -15,7 +15,7 @@
  * fault (`gh` absent from `PATH`) arrives as a `PlatformError` and folds into the same record, so
  * `E` is `never` and the status lives in `ok`.
  */
-import {Effect, Stream} from "effect";
+import {Duration, Effect, Stream} from "effect";
 import {ChildProcess, type ChildProcessSpawner} from "effect/unstable/process";
 
 export interface ExecResult {
@@ -34,6 +34,148 @@ const collect = (stream: Stream.Stream<Uint8Array, unknown>): Effect.Effect<stri
 	Stream.decodeText(stream).pipe(
 		Stream.mkString,
 		Effect.orElseSucceed(() => ""),
+	);
+
+/**
+ * What one **recorded** run of an arbitrary command produced — a second reading of this seam, for a
+ * caller that must tell "ran and answered no" from "could not run".
+ *
+ * `execCapture` above fuses those two: a non-zero exit and a spawn fault both arrive as `ok: false`,
+ * which is right for `git`/`gh` (a failed read is a failed read) and wrong for a prototype, where
+ * the command's own status **is** the observation. So the three outcomes are separate constructors
+ * here and the caller cannot collapse them by accident.
+ */
+export type ChildOutcome =
+	| {
+			readonly _tag: "Ran";
+			/** The child's own status, or `null` when it was killed at the timeout. */
+			readonly exitCode: number | null;
+			readonly timedOut: boolean;
+			readonly stdout: Uint8Array;
+			readonly stderr: Uint8Array;
+			/** Either stream reached the capture bound and the remainder was discarded. */
+			readonly truncated: boolean;
+	  }
+	| {readonly _tag: "Unstartable"; readonly reason: string};
+
+export interface ChildRequest {
+	readonly file: string;
+	readonly args: ReadonlyArray<string>;
+	readonly cwd: string;
+	/** The child's whole environment. Nothing is inherited: what is not here does not reach it. */
+	readonly env: Readonly<Record<string, string>>;
+	readonly timeoutSeconds: number;
+	/** Bytes captured per stream before capture stops and `truncated` is set. */
+	readonly captureBytes: number;
+}
+
+/** The seam a recording caller injects, so a timeout and an unstartable binary are both testable. */
+export type ChildRunner = (
+	request: ChildRequest,
+) => Effect.Effect<ChildOutcome, never, ChildProcessSpawner.ChildProcessSpawner>;
+
+const captureBounded = (
+	stream: Stream.Stream<Uint8Array, unknown>,
+	bound: number,
+): Effect.Effect<{readonly bytes: Uint8Array; readonly truncated: boolean}> =>
+	Effect.gen(function* () {
+		const parts: Uint8Array[] = [];
+		let total = 0;
+		let truncated = false;
+		yield* Stream.runForEach(stream, (chunk) =>
+			Effect.sync(() => {
+				const room = bound - total;
+				if (room <= 0) {
+					truncated = chunk.length > 0 || truncated;
+					return;
+				}
+				if (chunk.length > room) {
+					parts.push(chunk.subarray(0, room));
+					total = bound;
+					truncated = true;
+					return;
+				}
+				parts.push(chunk);
+				total += chunk.length;
+			}),
+		).pipe(Effect.orElseSucceed(() => undefined));
+		const bytes = new Uint8Array(total);
+		let at = 0;
+		for (const part of parts) {
+			bytes.set(part, at);
+			at += part.length;
+		}
+		return {bytes, truncated};
+	});
+
+/**
+ * Execute one command in `cwd` under exactly `env`, capturing both streams to a byte bound.
+ *
+ * `detached: true` puts the child in its own process group, which is what makes the timeout able to
+ * take its descendants with it: a prototype that spawns a dev server and hangs leaves the server
+ * running if only the direct child is signalled. The group kill is attempted first and the handle's
+ * own kill is the fallback, because a spawner that did not honour `detached` still has a child to
+ * signal.
+ */
+export const execRecord: ChildRunner = (request) =>
+	Effect.scoped(
+		Effect.gen(function* () {
+			const handle = yield* ChildProcess.make(request.file, [...request.args], {
+				cwd: request.cwd,
+				env: {...request.env},
+				extendEnv: false,
+				detached: true,
+			});
+			const killGroup: Effect.Effect<void> = Effect.try({
+				try: () => globalThis.process.kill(-handle.pid, "SIGKILL"),
+				catch: () => "the process group could not be signalled" as const,
+			}).pipe(
+				Effect.catchCause(() =>
+					handle.kill({killSignal: "SIGKILL"}).pipe(Effect.orElseSucceed(() => undefined)),
+				),
+				Effect.asVoid,
+			);
+			const streams = Effect.all(
+				[
+					captureBounded(handle.stdout, request.captureBytes),
+					captureBounded(handle.stderr, request.captureBytes),
+				],
+				{concurrency: "unbounded"},
+			);
+			const exit = handle.exitCode.pipe(
+				Effect.map((code): number | null => code),
+				Effect.orElseSucceed((): number | null => null),
+				Effect.timeoutOption(Duration.seconds(request.timeoutSeconds)),
+			);
+			const [captured, status] = yield* Effect.all([streams, exit], {concurrency: "unbounded"});
+			const [out, err] = captured;
+			if (status._tag === "None") {
+				yield* killGroup;
+				return {
+					_tag: "Ran" as const,
+					exitCode: null,
+					timedOut: true,
+					stdout: out.bytes,
+					stderr: err.bytes,
+					truncated: out.truncated || err.truncated,
+				};
+			}
+			return {
+				_tag: "Ran" as const,
+				exitCode: status.value,
+				timedOut: false,
+				stdout: out.bytes,
+				stderr: err.bytes,
+				truncated: out.truncated || err.truncated,
+			};
+		}),
+	).pipe(
+		Effect.catchTag("PlatformError", (cause) =>
+			Effect.succeed({
+				_tag: "Unstartable" as const,
+				reason: firstLine(cause.message) || `could not run ${request.file}`,
+			}),
+		),
 	);
 
 /** Run a command, capturing stdout; a non-zero exit and a spawn fault are both data, never a throw. */

--- a/packages/fabrika-cli/src/io/fs.ts
+++ b/packages/fabrika-cli/src/io/fs.ts
@@ -116,6 +116,84 @@ export const appendFile = (
 		Effect.catchTag("PlatformError", (cause) => new WriteFailed({path, reason: cause.message})),
 	);
 
+/**
+ * The physically resolved `path` — symlinks followed, `.` and `..` folded.
+ *
+ * Load-bearing for any containment test: on macOS `/tmp` is a symlink to `/private/tmp`, so a
+ * lexical prefix comparison and a resolved one give different answers about whether a path sits
+ * inside a tree.
+ */
+export const realPath = (path: string): Effect.Effect<string, ReadFailed, FileSystem.FileSystem> =>
+	Effect.gen(function* () {
+		const fs = yield* FileSystem.FileSystem;
+		return yield* fs.realPath(path);
+	}).pipe(
+		Effect.catchTag("PlatformError", (cause) => new ReadFailed({path, reason: cause.message})),
+	);
+
+/** Create `path` and any missing parent. Already-present is success, not an error. */
+export const makeDirectory = (
+	path: string,
+): Effect.Effect<void, WriteFailed, FileSystem.FileSystem> =>
+	Effect.gen(function* () {
+		const fs = yield* FileSystem.FileSystem;
+		yield* fs.makeDirectory(path, {recursive: true});
+	}).pipe(
+		Effect.catchTag("PlatformError", (cause) => new WriteFailed({path, reason: cause.message})),
+	);
+
+/**
+ * Remove `path` and everything under it.
+ *
+ * `force` makes an already-absent path a success: a caller that re-runs a disposal has nothing to
+ * remove and that is the goal state, not a fault. Whether the removal actually took is a separate
+ * question every caller must ask with {@link exists} — this call landing is not evidence the
+ * directory is gone.
+ */
+export const removeAll = (path: string): Effect.Effect<void, WriteFailed, FileSystem.FileSystem> =>
+	Effect.gen(function* () {
+		const fs = yield* FileSystem.FileSystem;
+		yield* fs.remove(path, {recursive: true, force: true});
+	}).pipe(
+		Effect.catchTag("PlatformError", (cause) => new WriteFailed({path, reason: cause.message})),
+	);
+
+/**
+ * Append `text` to `path` verbatim, creating the parent directory — for a line-oriented log whose
+ * **bytes** a digest is taken over.
+ *
+ * Deliberately not {@link appendFile}, which heals a missing final newline. That healing is right for
+ * a log a human reads and wrong for one a digest covers: it inserts a byte the digest would then
+ * account for, so two readers of the same appended record could compute two numbers. Here the
+ * caller's own grammar guarantees each write ends in `\n`, so there is nothing to heal.
+ */
+export const appendText = (
+	path: string,
+	text: string,
+): Effect.Effect<void, WriteFailed, FileSystem.FileSystem | Path.Path> =>
+	Effect.gen(function* () {
+		const fs = yield* FileSystem.FileSystem;
+		const pathService = yield* Path.Path;
+		yield* fs.makeDirectory(pathService.dirname(path), {recursive: true});
+		yield* fs.writeFileString(path, text, {flag: "a"});
+	}).pipe(
+		Effect.catchTag("PlatformError", (cause) => new WriteFailed({path, reason: cause.message})),
+	);
+
+/** Write raw bytes to `path`, creating its parent directory — for content a digest is taken over. */
+export const writeBytes = (
+	path: string,
+	data: Uint8Array,
+): Effect.Effect<void, WriteFailed, FileSystem.FileSystem | Path.Path> =>
+	Effect.gen(function* () {
+		const fs = yield* FileSystem.FileSystem;
+		const pathService = yield* Path.Path;
+		yield* fs.makeDirectory(pathService.dirname(path), {recursive: true});
+		yield* fs.writeFile(path, data);
+	}).pipe(
+		Effect.catchTag("PlatformError", (cause) => new WriteFailed({path, reason: cause.message})),
+	);
+
 /** Write `text` to `path`, creating its parent directory. */
 export const writeFile = (
 	path: string,

--- a/packages/fabrika-cli/src/io/git.ts
+++ b/packages/fabrika-cli/src/io/git.ts
@@ -202,6 +202,39 @@ export const listDir = (sha: string, dir: string): Shell<Attempt<ReadonlyArray<s
 		);
 	});
 
+/**
+ * The working tree's root, from the current directory.
+ *
+ * A directory that is not a repository fails rather than answering the current directory: a
+ * containment test taken against a guessed root is a test about nothing.
+ */
+export const repoRoot: Shell<Attempt<string>> = Effect.gen(function* () {
+	const r = yield* execCapture("git", ["rev-parse", "--show-toplevel"]);
+	if (!r.ok) return fail(r.reason);
+	const root = r.stdout.trim();
+	return root === "" ? fail("`git rev-parse --show-toplevel` named no root") : ok(root);
+});
+
+/**
+ * The working tree's whole status at `root`, ignored paths included.
+ *
+ * `--ignored=matching` is not the default invocation and is deliberate: a build cache, a
+ * `node_modules/`, a `.env` all land on ignored paths, so a status blind to them would report a
+ * tree as unchanged over exactly the writes a disposability check exists to find.
+ */
+export const treeStatus = (root: string): Shell<Attempt<string>> =>
+	Effect.gen(function* () {
+		const r = yield* execCapture("git", [
+			"-C",
+			root,
+			"status",
+			"--porcelain=v1",
+			"--untracked-files=all",
+			"--ignored=matching",
+		]);
+		return r.ok ? ok(r.stdout) : fail(r.reason);
+	});
+
 /** One file's contents at `sha`. */
 export const readFileAt = (sha: string, path: string): Shell<Attempt<string>> =>
 	Effect.gen(function* () {

--- a/packages/fabrika-cli/src/registry.ts
+++ b/packages/fabrika-cli/src/registry.ts
@@ -29,6 +29,7 @@ import {reviewCommand} from "./review/command.ts";
 import {reviewUiCommand} from "./review-ui/command.ts";
 import {shipCommand} from "./ship/command.ts";
 import {spendCommand} from "./spend/command.ts";
+import {spikeCommand} from "./spike/command.ts";
 import {statusCommand} from "./status/command.ts";
 import {triageCommand} from "./triage/command.ts";
 import {uiCommand} from "./ui/command.ts";
@@ -53,6 +54,7 @@ export const registeredGroups: ReadonlyArray<VerbGroup> = [
 	reviewUiCommand,
 	shipCommand,
 	spendCommand,
+	spikeCommand,
 	statusCommand,
 	triageCommand,
 	uiCommand,

--- a/packages/fabrika-cli/src/spike/bodies.ts
+++ b/packages/fabrika-cli/src/spike/bodies.ts
@@ -1,0 +1,176 @@
+/**
+ * The three composed bodies and the marker grammar three behaviours turn on — pure, so recognising a
+ * capture is mechanical rather than a prose instruction.
+ *
+ * **The issue body carries no marker.** A spike is found by its `prototyping:spike` label and its own
+ * number, so a marker there would be a second identity to keep in step with them. Only the two
+ * comments carry one, on their first line and nothing else.
+ *
+ * **The run table is transcribed, not summarised.** A reader sees each recorded run's command and
+ * status beside the claim rather than a hash standing in for them; the `evidenceDigest` is what
+ * proves the table matches the log.
+ *
+ * The body never carries the workspace path — that is the answer to #3086: the path is not scanned
+ * out of the body, it is never placed in it.
+ */
+
+import type {CommentRecord} from "../io/issues.ts";
+import type {EvidenceRecord, Kind} from "./workspace.ts";
+
+/** The label that makes a spike findable, countable and disposable as a class. */
+export const SPIKE_LABEL = "prototyping:spike";
+
+/** The longest a composed title may be, truncation mark included. */
+export const TITLE_LIMIT = 200;
+
+/** `spike: <question>`, truncated on a character boundary with a trailing `…` when longer. */
+export const spikeTitle = (question: string): string => {
+	const full = `spike: ${question.trim()}`;
+	const characters = [...full];
+	return characters.length <= TITLE_LIMIT
+		? full
+		: `${characters.slice(0, TITLE_LIMIT - 1).join("")}…`;
+};
+
+export interface IssueBodyFields {
+	readonly question: string;
+	readonly kind: Kind;
+	readonly nonce: string;
+	readonly ticket: number | null;
+}
+
+export const issueBody = (fields: IssueBodyFields): string =>
+	[
+		"## Question",
+		"",
+		fields.question.trim(),
+		"",
+		"## Shape",
+		"",
+		fields.kind,
+		"",
+		"## Run",
+		"",
+		fields.nonce,
+		"",
+		"## Came from",
+		"",
+		fields.ticket === null ? "standalone" : `#${fields.ticket}`,
+		"",
+	].join("\n");
+
+/** The capture marker's first line — the one string `spike dispose` and `spike capture` recognise. */
+export const captureMarker = (nonce: string, evidenceDigest: string): string =>
+	`<!-- fabrika:spike capture nonce=${nonce} evidenceDigest=${evidenceDigest} -->`;
+
+/** The forfeit marker's first line. It never satisfies the captured predicate — that is the point. */
+export const forfeitMarker = (nonce: string, runs: number): string =>
+	`<!-- fabrika:spike forfeit nonce=${nonce} runs=${runs} -->`;
+
+const CAPTURE_RE =
+	/^<!-- fabrika:spike capture nonce=([0-9a-f]{8}) evidenceDigest=([0-9a-f]{64}) -->$/;
+
+/** A recognised capture marker: which run it belongs to, and the log it was written over. */
+export interface CaptureMark {
+	readonly commentId: number;
+	readonly nonce: string;
+	readonly evidenceDigest: string;
+	readonly createdAt: string;
+}
+
+const markOf = (comment: CommentRecord): CaptureMark | null => {
+	const first = comment.body.split("\n")[0] ?? "";
+	const match = CAPTURE_RE.exec(first.trim());
+	return match?.[1] === undefined || match[2] === undefined
+		? null
+		: {
+				commentId: comment.id,
+				nonce: match[1],
+				evidenceDigest: match[2],
+				createdAt: comment.createdAt,
+			};
+};
+
+/**
+ * The **newest** capture marker carrying this run's nonce, or `null`.
+ *
+ * Matching on the nonce is what stops another run's marker answering for this one; taking the newest
+ * is what makes a staleness comparison single-valued once a supersede has happened. Ties on the
+ * creation stamp fall to the higher comment id, which is monotonic where a second-resolution
+ * timestamp is not.
+ */
+export const newestCapture = (
+	comments: ReadonlyArray<CommentRecord>,
+	nonce: string,
+): CaptureMark | null => {
+	let newest: CaptureMark | null = null;
+	for (const comment of comments) {
+		const mark = markOf(comment);
+		if (mark === null || mark.nonce !== nonce) continue;
+		if (
+			newest === null ||
+			mark.createdAt > newest.createdAt ||
+			(mark.createdAt === newest.createdAt && mark.commentId > newest.commentId)
+		) {
+			newest = mark;
+		}
+	}
+	return newest;
+};
+
+/** The run table, one row per evidence line, transcribed from the log rather than re-derived. */
+export const runTable = (records: ReadonlyArray<EvidenceRecord>): string =>
+	[
+		"| seq | command | exit | truncated |",
+		"| --- | --- | --- | --- |",
+		...records.map(
+			(record) =>
+				`| ${record.seq} | ${record.command.join(" ")} | ${
+					record.timedOut ? "timed out" : String(record.commandExit)
+				} | ${record.truncated} |`,
+		),
+	].join("\n");
+
+/** The capture comment: the marker line, a blank line, the decision verbatim, then the run table. */
+export const captureComment = (fields: {
+	readonly nonce: string;
+	readonly evidenceDigest: string;
+	readonly decision: string;
+	readonly records: ReadonlyArray<EvidenceRecord>;
+}): string =>
+	[
+		captureMarker(fields.nonce, fields.evidenceDigest),
+		"",
+		"## Decision",
+		"",
+		fields.decision.trim(),
+		"",
+		"## Runs",
+		"",
+		runTable(fields.records),
+		"",
+	].join("\n");
+
+/**
+ * The forfeit note: the question **read from the manifest** (`dispose` takes no `--question`), the
+ * same run table, and a closing line stating no decision was reached.
+ */
+export const forfeitNote = (fields: {
+	readonly nonce: string;
+	readonly question: string;
+	readonly records: ReadonlyArray<EvidenceRecord>;
+}): string =>
+	[
+		forfeitMarker(fields.nonce, fields.records.length),
+		"",
+		"## Abandoned",
+		"",
+		fields.question.trim(),
+		"",
+		"## Runs",
+		"",
+		runTable(fields.records),
+		"",
+		"No decision was reached; this spike was abandoned and its workspace disposed.",
+		"",
+	].join("\n");

--- a/packages/fabrika-cli/src/spike/bodies.unit.test.ts
+++ b/packages/fabrika-cli/src/spike/bodies.unit.test.ts
@@ -1,0 +1,129 @@
+import {describe, expect, it} from "vitest";
+import type {CommentRecord} from "../io/issues.ts";
+import {
+	captureComment,
+	captureMarker,
+	forfeitMarker,
+	forfeitNote,
+	issueBody,
+	newestCapture,
+	runTable,
+	SPIKE_LABEL,
+	spikeTitle,
+	TITLE_LIMIT,
+} from "./bodies.ts";
+import {evidenceRecord, NONCE, ONE_RUN_DIGEST, QUESTION} from "./fixtures.test-support.ts";
+
+const comment = (id: number, body: string, createdAt = "2026-08-10T00:00:00Z"): CommentRecord => ({
+	id,
+	author: "agent",
+	createdAt,
+	updatedAt: createdAt,
+	body,
+});
+
+describe("the composed title", () => {
+	it("names the question", () => {
+		expect(spikeTitle(QUESTION)).toBe(`spike: ${QUESTION}`);
+	});
+
+	it("truncates on a character boundary with a trailing ellipsis", () => {
+		const title = spikeTitle("é".repeat(400));
+		expect([...title]).toHaveLength(TITLE_LIMIT);
+		expect(title.endsWith("…")).toBe(true);
+	});
+});
+
+describe("the issue body carries the nonce and never the workspace path", () => {
+	const body = issueBody({question: QUESTION, kind: "logic", nonce: NONCE, ticket: 9140});
+
+	it("holds the four sections", () => {
+		expect(body).toContain("## Question");
+		expect(body).toContain("## Shape");
+		expect(body).toContain("## Run");
+		expect(body).toContain("## Came from");
+		expect(body).toContain("#9140");
+	});
+
+	it("names the nonce and no path (#3086)", () => {
+		expect(body).toContain(NONCE);
+		expect(body).not.toContain("fabrika-spike");
+	});
+
+	it("says standalone when no ticket is given", () => {
+		expect(issueBody({question: QUESTION, kind: "ui", nonce: NONCE, ticket: null})).toContain(
+			"standalone",
+		);
+	});
+
+	it("carries no marker — the label and the number are the identity", () => {
+		expect(body).not.toContain("<!-- fabrika:spike");
+		expect(SPIKE_LABEL).toBe("prototyping:spike");
+	});
+});
+
+describe("the capture predicate is mechanical", () => {
+	const mark = captureMarker(NONCE, ONE_RUN_DIGEST);
+
+	it("recognises this run's marker", () => {
+		expect(newestCapture([comment(1, `${mark}\n\n## Decision\n`)], NONCE)?.evidenceDigest).toBe(
+			ONE_RUN_DIGEST,
+		);
+	});
+
+	it("ignores another run's marker", () => {
+		expect(
+			newestCapture([comment(1, captureMarker("0badf00d", ONE_RUN_DIGEST))], NONCE),
+		).toBeNull();
+	});
+
+	it("never counts a forfeit marker — otherwise 15 would be bypassable by forfeiting twice", () => {
+		expect(newestCapture([comment(1, forfeitMarker(NONCE, 3))], NONCE)).toBeNull();
+	});
+
+	it("ignores a marker that is not the comment's first line", () => {
+		expect(newestCapture([comment(1, `a note\n${mark}`)], NONCE)).toBeNull();
+	});
+
+	it("takes the newest when more than one matches", () => {
+		const older = comment(1, captureMarker(NONCE, "a".repeat(64)), "2026-08-10T00:00:00Z");
+		const newer = comment(2, mark, "2026-08-10T01:00:00Z");
+		expect(newestCapture([newer, older], NONCE)?.commentId).toBe(2);
+	});
+});
+
+describe("the run table is transcribed, not summarised", () => {
+	it("holds one row per recorded run with its command and status", () => {
+		const table = runTable([evidenceRecord(1), evidenceRecord(2, {commandExit: 1})]);
+		expect(table).toContain("| 1 | printf no\\n | 0 | false |");
+		expect(table).toContain("| 2 | printf no\\n | 1 | false |");
+	});
+
+	it("names a timed-out run rather than printing a null exit", () => {
+		const table = runTable([evidenceRecord(1, {commandExit: null, timedOut: true})]);
+		expect(table).toContain("timed out");
+		expect(table).not.toContain("null");
+	});
+});
+
+describe("the two comments carry their marker on the first line and nothing else", () => {
+	it("composes the capture comment", () => {
+		const body = captureComment({
+			nonce: NONCE,
+			evidenceDigest: ONE_RUN_DIGEST,
+			decision: "A single-use token needs no new table.",
+			records: [evidenceRecord(1)],
+		});
+		expect(body.split("\n")[0]).toBe(captureMarker(NONCE, ONE_RUN_DIGEST));
+		expect(body).toContain("## Decision");
+		expect(body).toContain("## Runs");
+	});
+
+	it("composes the forfeit note from the manifest's question", () => {
+		const body = forfeitNote({nonce: NONCE, question: QUESTION, records: [evidenceRecord(1)]});
+		expect(body.split("\n")[0]).toBe(forfeitMarker(NONCE, 1));
+		expect(body).toContain("## Abandoned");
+		expect(body).toContain(QUESTION);
+		expect(body).toContain("No decision was reached");
+	});
+});

--- a/packages/fabrika-cli/src/spike/capture-verb.ts
+++ b/packages/fabrika-cli/src/spike/capture-verb.ts
@@ -1,0 +1,258 @@
+/**
+ * `spike capture` — post the decision plus the log's own run table, read it back, and close the spike.
+ *
+ * **Zero recorded runs reds** (`14`): "I ran nothing and it worked" is a pass this verb must never
+ * emit (ADR 0092), and it is the precondition the verb most exists for — a decision with no recorded
+ * run is a self-report, not evidence (#4111).
+ *
+ * **The ACL gate precedes every write on every path, the idempotent one included** (ADR 0055),
+ * because a close is a write and authority is checked before writes rather than around them. A
+ * permission read that fails is `11` — UNKNOWN, never a grant and never a demotion.
+ *
+ * **The re-entry story is the marker branch.** A marker whose digest equals the current one means the
+ * decision already covers the log, so nothing is posted and the stdin just read is **discarded** —
+ * re-wording a decision without recording a new run changes nothing, and a caller who meant to revise
+ * must run something first so the digest moves. A marker whose digest differs means runs were
+ * recorded after that decision, so a superseding comment is posted and the spike closes either way:
+ * that is what makes `spike dispose`'s `21` a detour rather than a trap.
+ */
+
+import {Effect} from "effect";
+import {closeCompleted, createComment, getComment, getIssue, listComments} from "../io/issues.ts";
+import {permissionFor, viewerLogin} from "../io/pulls.ts";
+import type {StdinRead} from "../io/stdin.ts";
+import {normalizeForReadback} from "../report/compose.ts";
+import {readAuthored} from "../review/authored.ts";
+import {answer, refuse, type VerbOutcome} from "../verb.ts";
+import {captureComment, newestCapture} from "./bodies.ts";
+import {
+	AUTHOR_UNAUTHORIZED,
+	NO_EVIDENCE,
+	READ_OR_EXEC_UNKNOWN,
+	READBACK_MISMATCH,
+	WORKSPACE_MISMATCH,
+	WRITE_UNKNOWN,
+	ZERO_SCOPE,
+} from "./codes.ts";
+import {
+	leakFree,
+	nonceGrammar,
+	readEvidence,
+	readManifest,
+	type SpikeEffect,
+	targetRepo,
+} from "./guards.ts";
+import {workspacePath} from "./workspace.ts";
+
+export interface CaptureOptions {
+	readonly spike: number;
+	readonly nonce: string;
+	readonly repo: string | null;
+	readonly env: Readonly<Record<string, string | undefined>>;
+	readonly tmpRoot: string;
+	/** The fd-0 read, injected so the failed-read and TTY paths are testable without a descriptor. */
+	readonly stdin: Effect.Effect<StdinRead>;
+}
+
+const VERB = "spike capture";
+
+/** The permissions that may record a decision on the record. */
+const AUTHORIZED = new Set(["admin", "maintain", "write"]);
+
+export const runCapture = (options: CaptureOptions): SpikeEffect<VerbOutcome> =>
+	Effect.gen(function* () {
+		const grammar = nonceGrammar(VERB, options.nonce, "");
+		if (grammar !== null) return grammar;
+
+		const read = yield* options.stdin;
+		const authored = readAuthored(
+			{
+				verb: VERB,
+				noun: "the decision",
+				emptyMessage: `${VERB}: stdin was read and held nothing — a spike with no decision has captured nothing.`,
+				bareAtMessage: `${VERB}: the decision is a bare @ path reference — write the decision, not a pointer to it.`,
+				leakCorrection: "Describe what the path was; do not paste it.",
+			},
+			read,
+		);
+		if (authored._tag === "Refused") return authored.outcome;
+		const leaked = leakFree(VERB, "decision", authored.text);
+		if (leaked !== null) return leaked;
+
+		const target = yield* targetRepo(VERB, options.repo, options.env);
+		if (target._tag === "Refused") return target.outcome;
+		const repo = target.value;
+
+		const workspace = workspacePath(options.tmpRoot, options.nonce);
+		const manifest = yield* readManifest(
+			VERB,
+			workspace,
+			options.nonce,
+			"the evidence a decision would rest on is gone.",
+		);
+		if (manifest._tag === "Refused") return manifest.outcome;
+		if (manifest.value.spike !== null && manifest.value.spike !== options.spike) {
+			return refuse(
+				WORKSPACE_MISMATCH,
+				`${VERB}: the manifest for nonce ${options.nonce} names spike #${manifest.value.spike}, not #${options.spike} — the evidence does not belong to this spike.`,
+			);
+		}
+
+		const evidence = yield* readEvidence(VERB, workspace);
+		if (evidence._tag === "Refused") return evidence.outcome;
+		if (evidence.value.records.length === 0 || evidence.value.digest === null) {
+			return refuse(
+				NO_EVIDENCE,
+				`${VERB}: the evidence log holds zero recorded runs — a decision with no recorded run is a self-report, not evidence (#4111). Run something through spike run, or dispose with --forfeit.`,
+			);
+		}
+		const evidenceDigest = evidence.value.digest;
+
+		const issue = yield* getIssue(repo, options.spike);
+		if (issue._tag === "Absent") {
+			return refuse(
+				ZERO_SCOPE,
+				`${VERB}: spike #${options.spike} is proven absent — nothing to capture onto; check the number.`,
+			);
+		}
+		if (issue._tag === "Unknown") {
+			return refuse(
+				READ_OR_EXEC_UNKNOWN,
+				`${VERB}: cannot read spike #${options.spike}: ${issue.reason} — nothing was posted, and authority is UNKNOWN, never granted.`,
+			);
+		}
+		const comments = yield* listComments(repo, options.spike);
+		if (comments._tag === "Failure") {
+			return refuse(
+				READ_OR_EXEC_UNKNOWN,
+				`${VERB}: cannot read the comments of spike #${options.spike}: ${comments.reason} — nothing was posted, and authority is UNKNOWN, never granted.`,
+			);
+		}
+
+		const login = yield* viewerLogin;
+		if (login._tag === "Failure") {
+			return refuse(
+				READ_OR_EXEC_UNKNOWN,
+				`${VERB}: cannot read the authenticated login: ${login.reason} — nothing was posted, and authority is UNKNOWN, never granted.`,
+			);
+		}
+		const permission = yield* permissionFor(repo, login.value);
+		if (permission._tag === "Unknown") {
+			return refuse(
+				READ_OR_EXEC_UNKNOWN,
+				`${VERB}: cannot read the repository permission of ${login.value}: ${permission.reason} — nothing was posted, and authority is UNKNOWN, never granted.`,
+			);
+		}
+		const held = permission._tag === "Absent" ? "no collaborator role" : permission.value;
+		if (permission._tag === "Absent" || !AUTHORIZED.has(permission.value)) {
+			return refuse(
+				AUTHOR_UNAUTHORIZED,
+				`${VERB}: ${login.value} holds ${held} on ${repo}, below write — a decision recorded here would carry no authority (ADR 0055).`,
+			);
+		}
+
+		const marker = newestCapture(comments.value, options.nonce);
+		const closed = issue.value.state === "closed";
+		const scope = `${VERB}: ${repo}, spike #${options.spike}, nonce ${options.nonce}, ${evidence.value.records.length} recorded run(s), ${comments.value.length} comment(s) scanned.`;
+
+		if (marker === null && closed) {
+			return refuse(
+				ZERO_SCOPE,
+				`${VERB}: spike #${options.spike} is closed and carries no capture marker for nonce ${options.nonce} — there is nothing to supersede. Open a new spike for a new question.`,
+				[scope],
+			);
+		}
+
+		if (marker !== null && marker.evidenceDigest === evidenceDigest) {
+			// The decision on the record already covers this exact log, so the bytes just read on stdin
+			// are discarded rather than posted a second time. The answer says so; the verb only ensures
+			// the close, which is what makes a re-run after a failed close safe.
+			const ensured = yield* ensureClosed(repo, options.spike, closed, marker.commentId, scope);
+			return (
+				ensured ??
+				answer(
+					JSON.stringify({
+						spike: options.spike,
+						nonce: options.nonce,
+						commentId: marker.commentId,
+						runs: evidence.value.records.length,
+						evidenceDigest,
+						state: "closed",
+						discardedStdin: true,
+					}),
+					[scope],
+				)
+			);
+		}
+
+		const body = captureComment({
+			nonce: options.nonce,
+			evidenceDigest,
+			decision: authored.text,
+			records: evidence.value.records,
+		});
+		const composed = leakFree(VERB, "composed capture comment", body);
+		if (composed !== null) return {...composed, stderr: [scope, ...composed.stderr]};
+
+		const posted = yield* createComment(repo, options.spike, body);
+		if (posted._tag === "Failure") {
+			return refuse(
+				WRITE_UNKNOWN,
+				`${VERB}: the comment post failed: ${posted.reason} — it may or may not have landed; read spike #${options.spike} before re-running.`,
+				[scope],
+			);
+		}
+		const back = yield* getComment(repo, posted.value.id);
+		if (
+			back._tag === "Failure" ||
+			normalizeForReadback(back.value) !== normalizeForReadback(body)
+		) {
+			return refuse(
+				READBACK_MISMATCH,
+				`${VERB}: the comment landed but does not read back as sent — it needs a human eye.`,
+				[scope],
+			);
+		}
+
+		const ensured = yield* ensureClosed(repo, options.spike, closed, posted.value.id, scope);
+		return (
+			ensured ??
+			answer(
+				JSON.stringify({
+					spike: options.spike,
+					nonce: options.nonce,
+					commentId: posted.value.id,
+					runs: evidence.value.records.length,
+					evidenceDigest,
+					state: "closed",
+					discardedStdin: false,
+				}),
+				[scope],
+			)
+		);
+	});
+
+/**
+ * Close the spike unless it is already closed, returning the refusal a failed close earns.
+ *
+ * The message states that the decision **did** land: a close that could not be proven leaves the
+ * record correct and only the state wrong, and a caller told otherwise would re-post.
+ */
+const ensureClosed = (
+	repo: string,
+	spike: number,
+	alreadyClosed: boolean,
+	commentId: number,
+	scope: string,
+): SpikeEffect<VerbOutcome | null> =>
+	Effect.gen(function* () {
+		if (alreadyClosed) return null;
+		const closed = yield* closeCompleted(repo, spike);
+		return closed._tag === "Failure"
+			? refuse(
+					WRITE_UNKNOWN,
+					`${VERB}: the decision landed as comment ${commentId} but the close failed: ${closed.reason} — the decision IS on the record; re-run to close.`,
+					[scope],
+				)
+			: null;
+	});

--- a/packages/fabrika-cli/src/spike/capture-verb.unit.test.ts
+++ b/packages/fabrika-cli/src/spike/capture-verb.unit.test.ts
@@ -1,0 +1,275 @@
+import {Effect, Layer} from "effect";
+import {describe, expect, it} from "vitest";
+import {errOut, type FakeFsOptions, fakeFs, fakeShell, okOut, once} from "../fakes.test-support.ts";
+import type {ExecResult} from "../io/exec.ts";
+import type {StdinRead} from "../io/stdin.ts";
+import {captureComment, captureMarker, forfeitMarker} from "./bodies.ts";
+import {runCapture} from "./capture-verb.ts";
+import {
+	AUTHOR_UNAUTHORIZED,
+	EMPTY_STDIN,
+	LEAKED_PATH,
+	NO_EVIDENCE,
+	NO_WORKSPACE,
+	READ_OR_EXEC_UNKNOWN,
+	READBACK_MISMATCH,
+	WORKSPACE_MISMATCH,
+	WRITE_UNKNOWN,
+	ZERO_SCOPE,
+} from "./codes.ts";
+import {
+	CLOSE,
+	COMMENTS,
+	commentsPayload,
+	ENV,
+	EVIDENCE,
+	evidenceRecord,
+	ISSUE,
+	issuePayload,
+	MANIFEST,
+	manifestText,
+	NONCE,
+	ONE_RUN,
+	ONE_RUN_DIGEST,
+	PERMISSION,
+	POST,
+	READBACK,
+	SPIKE,
+	TMP_ROOT,
+	VIEWER,
+	WORKSPACE,
+} from "./fixtures.test-support.ts";
+
+const DECISION = "A single-use token needs no new table — the verification record carries it.";
+const BODY = captureComment({
+	nonce: NONCE,
+	evidenceDigest: ONE_RUN_DIGEST,
+	decision: DECISION,
+	records: [evidenceRecord(1)],
+});
+
+const resident: FakeFsOptions = {
+	directories: [WORKSPACE],
+	files: {[MANIFEST]: manifestText(), [EVIDENCE]: ONE_RUN},
+};
+
+const options = {
+	spike: SPIKE,
+	nonce: NONCE,
+	repo: null as string | null,
+	env: ENV,
+	tmpRoot: TMP_ROOT,
+	stdin: Effect.succeed<StdinRead>({_tag: "Text", text: DECISION}),
+};
+
+const identity: ReadonlyArray<readonly [RegExp, ExecResult]> = [
+	[VIEWER, okOut("agent")],
+	[PERMISSION, okOut("write")],
+];
+
+const happy: ReadonlyArray<readonly [RegExp, ExecResult]> = [
+	...identity,
+	[ISSUE, okOut(issuePayload())],
+	[COMMENTS, okOut(commentsPayload([]))],
+	[POST, okOut(JSON.stringify({id: 512347, html_url: "https://example.test/#c"}))],
+	[READBACK, okOut(JSON.stringify({body: BODY}))],
+	[CLOSE, okOut("{}")],
+];
+
+const run = (
+	script: ReadonlyArray<readonly [RegExp, ExecResult]>,
+	overrides: Partial<typeof options> = {},
+	fs: FakeFsOptions = resident,
+) => {
+	const shell = fakeShell(script);
+	return Effect.runPromise(
+		Effect.provide(
+			runCapture({...options, ...overrides}),
+			Layer.merge(fakeFs(fs).layer, shell.layer),
+		),
+	).then((outcome) => ({outcome, calls: shell.calls}));
+};
+
+describe("runCapture records a decision the log grounds", () => {
+	it("posts, reads back, closes and answers", async () => {
+		const {outcome} = await run(happy);
+		expect(outcome.code).toBe(0);
+		expect(JSON.parse(outcome.stdout)).toEqual({
+			spike: SPIKE,
+			nonce: NONCE,
+			commentId: 512347,
+			runs: 1,
+			evidenceDigest: ONE_RUN_DIGEST,
+			state: "closed",
+			discardedStdin: false,
+		});
+	});
+
+	it("transcribes the run table beside the decision", async () => {
+		const {calls} = await run(happy);
+		const posted = calls.find((line) => POST.test(line)) ?? "";
+		expect(posted).toContain("## Runs");
+		expect(posted).toContain("printf");
+	});
+});
+
+describe("runCapture reds on zero scope — the precondition it most exists for", () => {
+	it("refuses a log with zero recorded runs on 14, naming both ways forward", async () => {
+		const {outcome, calls} = await run(
+			happy,
+			{},
+			{...resident, files: {[MANIFEST]: manifestText()}},
+		);
+		expect(outcome.code).toBe(NO_EVIDENCE);
+		expect(outcome.stdout).toBe("");
+		expect(outcome.stderr.join("\n")).toContain("spike run");
+		expect(outcome.stderr.join("\n")).toContain("--forfeit");
+		expect(calls.filter((line) => POST.test(line))).toHaveLength(0);
+	});
+});
+
+describe("runCapture refuses on the authored text before it reads anything", () => {
+	it("refuses empty stdin on 3", async () => {
+		const {outcome} = await run(happy, {
+			stdin: Effect.succeed<StdinRead>({_tag: "NoStdin", reason: "no pipe on fd 0"}),
+		});
+		expect(outcome.code).toBe(EMPTY_STDIN);
+	});
+
+	it("refuses a decision carrying a machine-local path on 5", async () => {
+		const {outcome} = await run(happy, {
+			stdin: Effect.succeed<StdinRead>({_tag: "Text", text: "it is under ~/code/thing.ts"}),
+		});
+		expect(outcome.code).toBe(LEAKED_PATH);
+		expect(outcome.stdout).toBe("");
+	});
+});
+
+describe("runCapture splits a proven absence from a failed read", () => {
+	it("seats a 404 on 7", async () => {
+		const {outcome} = await run([...identity, [ISSUE, errOut("gh: Not Found (HTTP 404)")]]);
+		expect(outcome.code).toBe(ZERO_SCOPE);
+		expect(outcome.stderr.join("\n")).toContain("proven absent");
+	});
+
+	it("seats any other read failure on 11", async () => {
+		const {outcome} = await run([...identity, [ISSUE, errOut("gh: Bad gateway (HTTP 502)")]]);
+		expect(outcome.code).toBe(READ_OR_EXEC_UNKNOWN);
+		expect(outcome.stderr.join("\n")).toContain("never granted");
+	});
+
+	it("seats an absent workspace on 12, not 7", async () => {
+		const {outcome} = await run(happy, {}, {});
+		expect(outcome.code).toBe(NO_WORKSPACE);
+	});
+
+	it("refuses a manifest naming another spike on 18", async () => {
+		const {outcome} = await run(
+			happy,
+			{},
+			{...resident, files: {...resident.files, [MANIFEST]: manifestText({spike: 9999})}},
+		);
+		expect(outcome.code).toBe(WORKSPACE_MISMATCH);
+	});
+});
+
+describe("the ACL gate precedes every write, on every path (ADR 0055)", () => {
+	it("refuses an author below write on 19", async () => {
+		const {outcome, calls} = await run([
+			[VIEWER, okOut("agent")],
+			[PERMISSION, okOut("read")],
+			[ISSUE, okOut(issuePayload())],
+			[COMMENTS, okOut(commentsPayload([]))],
+		]);
+		expect(outcome.code).toBe(AUTHOR_UNAUTHORIZED);
+		expect(calls.filter((line) => POST.test(line) || CLOSE.test(line))).toHaveLength(0);
+	});
+
+	it("seats a permission read that failed on 11 — UNKNOWN, never a grant", async () => {
+		const {outcome} = await run([
+			[VIEWER, okOut("agent")],
+			[PERMISSION, errOut("gh: Bad gateway (HTTP 502)")],
+			[ISSUE, okOut(issuePayload())],
+			[COMMENTS, okOut(commentsPayload([]))],
+		]);
+		expect(outcome.code).toBe(READ_OR_EXEC_UNKNOWN);
+	});
+});
+
+describe("runCapture's re-entry turns on the newest marker for this nonce", () => {
+	const marked = (digest: string, state = "open") =>
+		[
+			...identity,
+			[ISSUE, okOut(issuePayload({state}))],
+			[COMMENTS, okOut(commentsPayload([{id: 500, body: `${captureMarker(NONCE, digest)}\n`}]))],
+			[POST, okOut(JSON.stringify({id: 512348, html_url: "https://example.test/#c"}))],
+			[READBACK, okOut(JSON.stringify({body: BODY}))],
+			[CLOSE, okOut("{}")],
+		] as ReadonlyArray<readonly [RegExp, ExecResult]>;
+
+	it("posts nothing when the marker already covers this log, and says the stdin was discarded", async () => {
+		const {outcome, calls} = await run(marked(ONE_RUN_DIGEST));
+		expect(outcome.code).toBe(0);
+		expect(JSON.parse(outcome.stdout)).toMatchObject({commentId: 500, discardedStdin: true});
+		expect(calls.filter((line) => POST.test(line))).toHaveLength(0);
+	});
+
+	it("ensures the close even on that branch, so a re-run after a failed close is safe", async () => {
+		const {calls} = await run(marked(ONE_RUN_DIGEST));
+		expect(calls.filter((line) => CLOSE.test(line))).toHaveLength(1);
+	});
+
+	it("supersedes a marker whose digest differs, and closes either way", async () => {
+		const {outcome, calls} = await run(marked("a".repeat(64), "closed"));
+		expect(outcome.code).toBe(0);
+		expect(JSON.parse(outcome.stdout)).toMatchObject({commentId: 512348, discardedStdin: false});
+		expect(calls.filter((line) => POST.test(line))).toHaveLength(1);
+	});
+
+	it("refuses a closed spike carrying no marker for this nonce on 7", async () => {
+		const {outcome} = await run([
+			...identity,
+			[ISSUE, okOut(issuePayload({state: "closed"}))],
+			[COMMENTS, okOut(commentsPayload([{id: 500, body: forfeitMarker(NONCE, 1)}]))],
+		]);
+		expect(outcome.code).toBe(ZERO_SCOPE);
+		expect(outcome.stderr.join("\n")).toContain("nothing to supersede");
+	});
+});
+
+describe("runCapture proves the comment landed", () => {
+	it("seats an unproven post on 8", async () => {
+		const {outcome} = await run([
+			...identity,
+			[ISSUE, okOut(issuePayload())],
+			[COMMENTS, okOut(commentsPayload([]))],
+			[POST, errOut("gh: Bad gateway (HTTP 502)")],
+		]);
+		expect(outcome.code).toBe(WRITE_UNKNOWN);
+		expect(outcome.stderr.join("\n")).toContain("may or may not have landed");
+	});
+
+	it("seats a read-back that differs on 9", async () => {
+		const {outcome} = await run([
+			...identity,
+			[ISSUE, okOut(issuePayload())],
+			[COMMENTS, okOut(commentsPayload([]))],
+			[POST, okOut(JSON.stringify({id: 512347, html_url: "https://example.test/#c"}))],
+			[READBACK, okOut(JSON.stringify({body: "somebody edited it"}))],
+		]);
+		expect(outcome.code).toBe(READBACK_MISMATCH);
+	});
+
+	it("seats a failed close on 8 while saying the decision DID land", async () => {
+		const {outcome} = await run([
+			...identity,
+			[ISSUE, okOut(issuePayload())],
+			[COMMENTS, okOut(commentsPayload([]))],
+			[once(POST), okOut(JSON.stringify({id: 512347, html_url: "https://example.test/#c"}))],
+			[READBACK, okOut(JSON.stringify({body: BODY}))],
+			[CLOSE, errOut("gh: Bad gateway (HTTP 502)")],
+		]);
+		expect(outcome.code).toBe(WRITE_UNKNOWN);
+		expect(outcome.stderr.join("\n")).toContain("IS on the record");
+	});
+});

--- a/packages/fabrika-cli/src/spike/codes.ts
+++ b/packages/fabrika-cli/src/spike/codes.ts
@@ -1,0 +1,104 @@
+/**
+ * The one exit table all five `spike` verbs allocate from, so a code means one thing across this
+ * group whichever verb produced it (`claude-plugins/fabrika/skills/prototyping/contract.md`).
+ *
+ * The overlap with `report` is **re-exported, never re-typed**: an aligning group imports the base's
+ * constant, so a drift is unrepresentable rather than merely detectable. This group claims all nine
+ * seats over `3`-`11` — there is no `DELIBERATE_GAP` — and adds `12`-`21` for facts about a
+ * throwaway workspace: whether it exists, where it resolves, what it recorded, and whether it stayed
+ * thrown away.
+ *
+ * Three meanings on this table are one another's opposites and the whole group is built to keep them
+ * apart: `1`/`127` is *the call never decided*, {@link READ_OR_EXEC_UNKNOWN} is *a read or an
+ * execution failed and nothing was written*, and every code at `3` and above is something a verb
+ * **proved** — with nothing on stdout.
+ *
+ * `0`, `1`, `2` and `127` are reserved by the interface convention (`../verb.ts`, `../bin.ts`).
+ */
+
+import {
+	BAD_SECTIONS as REPORT_BAD_SECTIONS,
+	BARE_AT_PATH as REPORT_BARE_AT_PATH,
+	CLASSIFIED as REPORT_CLASSIFIED,
+	EMPTY_STDIN as REPORT_EMPTY_STDIN,
+	LEAKED_PATH as REPORT_LEAKED_PATH,
+	NO_TARGET as REPORT_NO_TARGET,
+	PRECONDITION_UNKNOWN as REPORT_PRECONDITION_UNKNOWN,
+	READBACK_MISMATCH as REPORT_READBACK_MISMATCH,
+	WRITE_UNKNOWN as REPORT_WRITE_UNKNOWN,
+} from "../report/codes.ts";
+
+/** Stdin was read and held nothing. `spike capture` only — the one verb that reads fd 0. */
+export const EMPTY_STDIN = REPORT_EMPTY_STDIN;
+/**
+ * A required document is missing, malformed, or out of place — here the workspace manifest or the
+ * evidence log exists and does not parse.
+ *
+ * Refused whole-file rather than per-field: a verb holding half a manifest would compare against a
+ * digest it cannot vouch for.
+ */
+export const MALFORMED_RECORD = REPORT_BAD_SECTIONS;
+/**
+ * The authored text carries a machine-local path.
+ *
+ * **A stated widening of the base seat, which reads "…and `--redact` was not given".** No `spike`
+ * verb offers `--redact`, so here the refusal fires unconditionally. The condition narrows; the
+ * meaning does not drift.
+ */
+export const LEAKED_PATH = REPORT_LEAKED_PATH;
+/** The authored text is a bare `@` path reference — not redactable, so a second code. */
+export const BARE_AT_PATH = REPORT_BARE_AT_PATH;
+/**
+ * Proven: the write target is absent — the spike issue, or the `prototyping:spike` label — or the
+ * spike is proven closed when the verb needed it open.
+ *
+ * Never fused with {@link READ_OR_EXEC_UNKNOWN}: a proven absence is a verdict, a failed read is a
+ * verdict about nothing, and no message in this group reads "does not exist, or is not readable".
+ */
+export const ZERO_SCOPE = REPORT_NO_TARGET;
+/** A write was attempted and its outcome could not be proven — UNKNOWN, deliberately not `1`. */
+export const WRITE_UNKNOWN = REPORT_WRITE_UNKNOWN;
+/** The write landed but the read-back does not match; the artifact exists and needs a human. */
+export const READBACK_MISMATCH = REPORT_READBACK_MISMATCH;
+/**
+ * A value off its closed vocabulary or naming grammar — an off-grammar `--nonce`, a `--kind` outside
+ * `logic`/`ui`, a malformed `--timeout` or `--env`.
+ *
+ * A semantic refusal on a *value*; a malformed *flag* stays `1`, which is the parser's.
+ */
+export const OFF_VOCABULARY = REPORT_CLASSIFIED;
+/**
+ * A required read or execution failed — no outcome is proven.
+ *
+ * **The name differs from the base's `PRECONDITION_UNKNOWN` deliberately.** The base covers a failed
+ * precondition *read*; this seat also covers a child process that could not be *executed*, which is
+ * an attempt rather than a read. `../exit-code-alignment.ts` records that a group's reading may be a
+ * documented superset and that a number cannot say so on its own; the name is where this one says it.
+ */
+export const READ_OR_EXEC_UNKNOWN = REPORT_PRECONDITION_UNKNOWN;
+
+/**
+ * Proven: no workspace exists for this nonce — never opened, or already disposed.
+ *
+ * Deliberately not {@link ZERO_SCOPE}: an absent workspace is a routable local state, not a
+ * statement about the issue.
+ */
+export const NO_WORKSPACE = 12;
+/** Proven: the resolved workspace path is inside the repository working tree — refused before any write. */
+export const WORKSPACE_IN_TREE = 13;
+/** Proven: the evidence log holds zero recorded runs — a decision here would be a self-report. */
+export const NO_EVIDENCE = 14;
+/** Proven: disposal was asked on a spike whose decision is not captured. */
+export const NOT_CAPTURED = 15;
+/** Proven: the workspace was removed and is still present on re-probe. */
+export const REMOVAL_UNPROVEN = 16;
+/** Proven: the working tree does not match what `spike open` recorded — the spike may have leaked. */
+export const TREE_MOVED = 17;
+/** Proven: the workspace for this nonce belongs to different work — another spike, question or kind. */
+export const WORKSPACE_MISMATCH = 18;
+/** Proven: the capture author does not hold `write` or better on the repository (ADR 0055). */
+export const AUTHOR_UNAUTHORIZED = 19;
+/** Proven: the spike issue landed and its manifest could not be completed to name it. */
+export const MANIFEST_INCOMPLETE = 20;
+/** Proven: the evidence log moved after the decision was captured — the capture no longer covers it. */
+export const CAPTURE_STALE = 21;

--- a/packages/fabrika-cli/src/spike/command.ts
+++ b/packages/fabrika-cli/src/spike/command.ts
@@ -1,0 +1,221 @@
+/**
+ * The `spike` verb group — `fabrika spike <open|run|capture|dispose|status>`, the `prototyping`
+ * skill's half of the ideation layer.
+ *
+ * The adapter and nothing else: it declares the flags (`--help` is the interface, so every flag
+ * carries a one-line description), reads the two machine facts this group does not derive — the OS
+ * temp root and a cryptographic random source — runs the pure verb, and emits its outcome. Every
+ * decision lives in the `*-verb.ts` modules beside it, which is what makes each refusal testable
+ * without spawning a process.
+ *
+ * **Every leaf is declared with `leafCommand`, never a bare `Command.make`** — the bare form silently
+ * opts out of the excess-operand guard, which `../excess-operand.unit.test.ts` reds on.
+ *
+ * **`--kind` is declared as a string and checked in the verb.** The check is the closed set's, and
+ * seating it in the verb is what lets the refusal name the whole vocabulary and seat it on `10`
+ * rather than emit the parser's generic message.
+ */
+
+import {randomBytes} from "node:crypto";
+import {tmpdir} from "node:os";
+import {Effect, Option} from "effect";
+import {Argument, Command, Flag} from "effect/unstable/cli";
+import {leafCommand} from "../excess-operand.ts";
+import {execRecord} from "../io/exec.ts";
+import {readStdin} from "../io/stdin.ts";
+import type {VerbOutcome} from "../verb.ts";
+import {runCapture} from "./capture-verb.ts";
+import {runDispose} from "./dispose-verb.ts";
+import {runOpen} from "./open-verb.ts";
+import {runRun} from "./run-verb.ts";
+import {runStatus} from "./status-verb.ts";
+import {KINDS} from "./workspace.ts";
+
+/** Write the outcome and exit on its code — stdout is the answer, everything else is stderr. */
+const emit = (outcome: VerbOutcome): Effect.Effect<void> =>
+	Effect.sync(() => {
+		for (const line of outcome.stderr) process.stderr.write(`${line}\n`);
+		if (outcome.stdout !== "") process.stdout.write(outcome.stdout);
+		process.exit(outcome.code);
+	});
+
+const repoFlag = Flag.string("repo").pipe(
+	Flag.optional,
+	Flag.withDescription(
+		"the target owner/name (default: $CLAUDE_PIPELINE_REPO, else $GITHUB_REPOSITORY, else the origin remote)",
+	),
+);
+
+const nonceFlag = Flag.string("nonce").pipe(
+	Flag.withDescription(
+		"this run's key, eight lowercase hex characters — minted by `spike open` and passed verbatim, never invented by a caller",
+	),
+);
+
+const open = leafCommand(
+	"open",
+	{
+		question: Flag.string("question").pipe(
+			Flag.withDescription(
+				"the one named question this spike answers; two questions is two spikes",
+			),
+		),
+		kind: Flag.string("kind").pipe(
+			Flag.withDescription(`the ruled artifact shape: one of ${KINDS.join(", ")}`),
+		),
+		ticket: Flag.integer("ticket").pipe(
+			Flag.optional,
+			Flag.withDescription(
+				"the issue this question came from, recorded as provenance and never read for instruction",
+			),
+		),
+		nonce: Flag.string("nonce").pipe(
+			Flag.optional,
+			Flag.withDescription(
+				"re-entry only: names an existing workspace to resume; supplying one with no workspace is 12",
+			),
+		),
+		repo: repoFlag,
+	},
+	Effect.fn(function* ({question, kind, ticket, nonce, repo}) {
+		yield* emit(
+			yield* runOpen({
+				question,
+				kind,
+				ticket: Option.getOrNull(ticket),
+				nonce: Option.getOrNull(nonce),
+				repo: Option.getOrNull(repo),
+				env: process.env,
+				tmpRoot: tmpdir(),
+				mintNonce: () => randomBytes(4).toString("hex"),
+			}),
+		);
+	}),
+).pipe(
+	Command.withDescription(
+		'Mint the spike issue for one question, allocate this run\'s workspace under a freshly minted nonce, and bind the two in a manifest. Prints {"spike":n,"nonce":"…","kind":"…","workspace":"…","treeDigest":"…"}. Exits 4 (a workspace exists and its manifest does not parse), 5/6 (machine-local path, bare @ reference), 7 (no prototyping:spike label), 8/9 (the create failed, the read-back differs), 10 (off-grammar --nonce or --kind), 11 (a root, the label set or the tree state could not be read — nothing was minted), 12 (--nonce names no workspace), 13 (the workspace resolves inside the repository), 18 (a workspace under a different question or kind), 20 (the spike landed and the manifest could not be completed). Example: fabrika spike open --question "does better-auth mint a single-use token without a new table?" --kind logic',
+	),
+);
+
+const run = leafCommand(
+	"run",
+	{
+		nonce: nonceFlag,
+		timeout: Flag.integer("timeout").pipe(
+			Flag.withDefault(300),
+			Flag.withDescription(
+				"seconds before the child's process group is killed; the run is still recorded, with timedOut true",
+			),
+		),
+		env: Flag.string("env").pipe(
+			Flag.atLeast(0),
+			Flag.withDescription(
+				"KEY=VALUE added to the child's scrubbed environment; repeatable, and a credential variable is refused rather than honoured",
+			),
+		),
+		command: Argument.string("command").pipe(
+			Argument.atLeast(1),
+			Argument.withDescription(
+				"the argv to execute after --, taken literally and never passed through a shell",
+			),
+		),
+	},
+	Effect.fn(function* ({nonce, timeout, env, command}) {
+		yield* emit(
+			yield* runRun({
+				nonce,
+				timeout,
+				env,
+				command,
+				parentEnv: process.env,
+				tmpRoot: tmpdir(),
+				spawn: execRecord,
+			}),
+		);
+	}),
+).pipe(
+	Command.withDescription(
+		'Execute one command in the workspace and append an immutable evidence record. Exit 0 means the command RAN and was recorded, whatever it returned — its own status rides in the payload as commandExit. Prints {"nonce":"…","seq":n,"command":[…],"commandExit":n,"timedOut":bool,"outBytes":n,"errBytes":n,"truncated":bool,"outSha256":"…","errSha256":"…"}. Exits 4 (the manifest or the log does not parse, or the log is not contiguous from 1), 10 (off-grammar --nonce, --timeout or --env), 11 (the command could NOT be executed — nothing was appended, and this is not an answer of no), 12 (no workspace for this nonce), 13 (the workspace resolves inside the repository). Example: fabrika spike run --nonce 7f3a9c21 -- node walkthrough.mjs',
+	),
+);
+
+const capture = leafCommand(
+	"capture",
+	{
+		spike: Argument.integer("spike").pipe(
+			Argument.withDescription("the spike issue the decision is captured on"),
+		),
+		nonce: nonceFlag,
+		repo: repoFlag,
+	},
+	Effect.fn(function* ({spike, nonce, repo}) {
+		yield* emit(
+			yield* runCapture({
+				spike,
+				nonce,
+				repo: Option.getOrNull(repo),
+				env: process.env,
+				tmpRoot: tmpdir(),
+				stdin: Effect.sync(readStdin),
+			}),
+		);
+	}),
+).pipe(
+	Command.withDescription(
+		'Post the decision read from STDIN plus the log\'s own run table, read it back, and close the spike. Prints {"spike":n,"nonce":"…","commentId":id,"runs":k,"evidenceDigest":"…","state":"closed","discardedStdin":bool}. Exits 3 (stdin held nothing), 4 (the manifest or the log does not parse), 5/6 (leak), 7 (the spike is absent, or closed with nothing to supersede), 8/9 (the post or the close was unproven, the read-back differs), 10 (off-grammar --nonce), 11 (a precondition read failed — nothing was posted), 12 (no workspace), 14 (zero recorded runs — a decision here would be a self-report), 18 (the manifest names another spike), 19 (the author holds below write). Example: fabrika spike capture 9310 --nonce 7f3a9c21 < decision.md',
+	),
+);
+
+const dispose = leafCommand(
+	"dispose",
+	{
+		nonce: nonceFlag,
+		forfeit: Flag.boolean("forfeit").pipe(
+			Flag.withDescription(
+				"abandon the spike without a decision: post a forfeit note naming the run count, close, then dispose; never bypasses the tree check",
+			),
+		),
+		repo: repoFlag,
+	},
+	Effect.fn(function* ({nonce, forfeit, repo}) {
+		yield* emit(
+			yield* runDispose({
+				nonce,
+				forfeit,
+				repo: Option.getOrNull(repo),
+				env: process.env,
+				tmpRoot: tmpdir(),
+			}),
+		);
+	}),
+).pipe(
+	Command.withDescription(
+		'Prove the repository tree is unchanged and the capture still covers the log, remove the workspace, and prove it is gone. Prints {"spike":n,"nonce":"…","workspace":"removed","treeMatched":true,"runs":k,"forfeited":bool}. Exits 4 (the manifest or the log does not parse), 5/6 (leak in the forfeit note), 7 (the spike is proven absent), 8/9 (the note post or the close was unproven, the read-back differs), 10 (off-grammar --nonce), 11 (a read failed — nothing was removed), 12 (no workspace), 15 (no captured decision and no --forfeit), 16 (removed and still present on re-probe), 17 (the tree moved since open — NOTHING was removed), 21 (the log moved after the capture). Example: fabrika spike dispose --nonce 7f3a9c21',
+	),
+);
+
+const status = leafCommand(
+	"status",
+	{nonce: nonceFlag, repo: repoFlag},
+	Effect.fn(function* ({nonce, repo}) {
+		yield* emit(
+			yield* runStatus({
+				nonce,
+				repo: Option.getOrNull(repo),
+				env: process.env,
+				tmpRoot: tmpdir(),
+			}),
+		);
+	}),
+).pipe(
+	Command.withDescription(
+		'One run\'s spike state, workspace presence and evidence count — near-total, because its consumer is a session resuming cold. An absent workspace is a FACT at exit 0. Prints {"nonce":"…","workspace":"present|absent","spike":n,"kind":"…","question":"…","spikeState":"open|closed|null","captured":bool,"runs":k,"lastCommandExit":n,"evidenceDigest":"…","treeMatched":bool}. Exits 4 (the manifest or the log exists and does not parse), 10 (off-grammar --nonce), 11 (the spike state, its comments or the tree state could not be read). Example: fabrika spike status --nonce 7f3a9c21',
+	),
+);
+
+export const spikeCommand = Command.make("spike").pipe(
+	Command.withSubcommands([open, run, capture, dispose, status]),
+	Command.withDescription(
+		"Settle one empirical question by building a throwaway: mint the spike and its workspace outside the repository, record every run as evidence, capture the decision on the issue, and prove the throwaway was thrown away",
+	),
+);

--- a/packages/fabrika-cli/src/spike/dispose-verb.ts
+++ b/packages/fabrika-cli/src/spike/dispose-verb.ts
@@ -1,0 +1,258 @@
+/**
+ * `spike dispose` — prove the repository tree is unchanged and the capture still covers the log,
+ * remove the workspace, and prove it is gone.
+ *
+ * This is the group's one **judging** verb: it judges whether the throwaway stayed thrown away, and
+ * its verdict rests on the digest comparison stated on stderr as the scope line. An absent manifest
+ * is `12` before any judgment is attempted, never a clean verdict over nothing.
+ *
+ * **The tree comparison runs first — before any state read and before any write.** That ordering is
+ * what keeps a `17`, the refusal this verb most exists for, from destroying the leak it just found
+ * (the #4111 shape). It does **not** make every non-zero exit write-free: `8`, `9` and `16` all sit
+ * past the `--forfeit` write or past the removal.
+ *
+ * **`--forfeit` relaxes neither `17` nor `21`.** Forfeiting is about the absence of a decision; those
+ * two are about whether the throwaway stayed thrown away and whether the record is current, and they
+ * are independent questions.
+ *
+ * **A manifest carrying `spike: null` skips the issue half entirely** — no `15`, no `21`, no forfeit,
+ * no GitHub read — leaving only the tree comparison and the removal, so the orphaned workspace a `20`
+ * leaves behind is always collectable.
+ */
+
+import {Effect} from "effect";
+import {exists, removeAll} from "../io/fs.ts";
+import {closeCompleted, createComment, getComment, getIssue, listComments} from "../io/issues.ts";
+import {normalizeForReadback} from "../report/compose.ts";
+import {answer, refuse, type VerbOutcome} from "../verb.ts";
+import {forfeitNote, newestCapture} from "./bodies.ts";
+import {
+	CAPTURE_STALE,
+	NOT_CAPTURED,
+	READ_OR_EXEC_UNKNOWN,
+	READBACK_MISMATCH,
+	REMOVAL_UNPROVEN,
+	TREE_MOVED,
+	WRITE_UNKNOWN,
+	ZERO_SCOPE,
+} from "./codes.ts";
+import {
+	leakFree,
+	nonceGrammar,
+	readEvidence,
+	readManifest,
+	readTree,
+	type SpikeEffect,
+	targetRepo,
+} from "./guards.ts";
+import {type EvidenceRecord, workspacePath} from "./workspace.ts";
+
+export interface DisposeOptions {
+	readonly nonce: string;
+	readonly forfeit: boolean;
+	readonly repo: string | null;
+	readonly env: Readonly<Record<string, string | undefined>>;
+	readonly tmpRoot: string;
+}
+
+const VERB = "spike dispose";
+
+export const runDispose = (options: DisposeOptions): SpikeEffect<VerbOutcome> =>
+	Effect.gen(function* () {
+		const grammar = nonceGrammar(VERB, options.nonce, "");
+		if (grammar !== null) return grammar;
+
+		const workspace = workspacePath(options.tmpRoot, options.nonce);
+		const manifest = yield* readManifest(
+			VERB,
+			workspace,
+			options.nonce,
+			"it was already disposed, or never opened.",
+		);
+		if (manifest._tag === "Refused") return manifest.outcome;
+
+		const tree = yield* readTree(VERB, manifest.value.treeRoot);
+		if (tree._tag === "Refused") return tree.outcome;
+		const scope = `${VERB}: nonce ${options.nonce}, tree ${manifest.value.treeRoot}, ${tree.value.lines.length} status line(s).`;
+		if (tree.value.digest !== manifest.value.treeDigest) {
+			return refuse(
+				TREE_MOVED,
+				`${VERB}: the working tree changed since the spike opened (${tree.value.lines.length} paths, first: ${first(tree.value.lines)}) — the workspace is intact and NOT removed.`,
+				[scope, ...tree.value.lines.map((line) => `${VERB}:   ${line}`)],
+			);
+		}
+
+		const evidence = yield* readEvidence(VERB, workspace);
+		if (evidence._tag === "Refused") return evidence.outcome;
+		const records = evidence.value.records;
+
+		let forfeited = false;
+		if (manifest.value.spike !== null) {
+			const issueHalf = yield* resolveIssueHalf({
+				spike: manifest.value.spike,
+				nonce: options.nonce,
+				forfeit: options.forfeit,
+				question: manifest.value.question,
+				records,
+				evidenceDigest: evidence.value.digest,
+				repo: options.repo,
+				env: options.env,
+				scope,
+			});
+			if (issueHalf._tag === "Refused") return issueHalf.outcome;
+			forfeited = issueHalf.forfeited;
+		}
+
+		const removed = yield* removeAll(workspace).pipe(
+			Effect.map((): string | null => null),
+			Effect.catchTag("fabrika-cli/WriteFailed", (failure) => Effect.succeed(failure.reason)),
+		);
+		if (removed !== null) {
+			return refuse(
+				REMOVAL_UNPROVEN,
+				`${VERB}: the workspace ${workspace} could not be removed: ${removed} — disposal is UNPROVEN, and this spike is not disposed.`,
+				[scope],
+			);
+		}
+		// A removal nobody checked is the self-report class again, one directory down.
+		const stillThere = yield* exists(workspace).pipe(Effect.orElseSucceed(() => true));
+		if (stillThere) {
+			return refuse(
+				REMOVAL_UNPROVEN,
+				`${VERB}: the workspace ${workspace} is still present after removal — disposal is UNPROVEN, and this spike is not disposed.`,
+				[scope],
+			);
+		}
+
+		return answer(
+			JSON.stringify({
+				spike: manifest.value.spike,
+				nonce: options.nonce,
+				workspace: "removed",
+				treeMatched: true,
+				runs: records.length,
+				forfeited,
+			}),
+			[scope],
+		);
+	});
+
+const first = (lines: ReadonlyArray<string>): string => lines[0] ?? "<none>";
+
+type IssueHalf =
+	| {readonly _tag: "Ok"; readonly forfeited: boolean}
+	| {readonly _tag: "Refused"; readonly outcome: VerbOutcome};
+
+const resolveIssueHalf = (input: {
+	readonly spike: number;
+	readonly nonce: string;
+	readonly forfeit: boolean;
+	readonly question: string;
+	readonly records: ReadonlyArray<EvidenceRecord>;
+	readonly evidenceDigest: string | null;
+	readonly repo: string | null;
+	readonly env: Readonly<Record<string, string | undefined>>;
+	readonly scope: string;
+}): SpikeEffect<IssueHalf> =>
+	Effect.gen(function* () {
+		const refused = (outcome: VerbOutcome): IssueHalf => ({_tag: "Refused", outcome});
+		const target = yield* targetRepo(VERB, input.repo, input.env);
+		if (target._tag === "Refused") return refused(target.outcome);
+		const repo = target.value;
+
+		const issue = yield* getIssue(repo, input.spike);
+		if (issue._tag === "Absent") {
+			return refused(
+				refuse(
+					ZERO_SCOPE,
+					`${VERB}: spike #${input.spike} is proven absent — there is nothing to forfeit to.`,
+					[input.scope],
+				),
+			);
+		}
+		if (issue._tag === "Unknown") {
+			return refused(
+				refuse(
+					READ_OR_EXEC_UNKNOWN,
+					`${VERB}: cannot read spike #${input.spike}: ${issue.reason} — nothing was removed.`,
+					[input.scope],
+				),
+			);
+		}
+		const comments = yield* listComments(repo, input.spike);
+		if (comments._tag === "Failure") {
+			return refused(
+				refuse(
+					READ_OR_EXEC_UNKNOWN,
+					`${VERB}: cannot read the comments of spike #${input.spike}: ${comments.reason} — nothing was removed.`,
+					[input.scope],
+				),
+			);
+		}
+
+		const marker = newestCapture(comments.value, input.nonce);
+		if (marker !== null && marker.evidenceDigest !== input.evidenceDigest) {
+			return refused(
+				refuse(
+					CAPTURE_STALE,
+					`${VERB}: the evidence log moved after the decision was captured (${input.records.length} runs now; the capture was written over evidenceDigest ${marker.evidenceDigest}) — re-run spike capture to supersede the stale decision, then dispose. If capture refuses on 19, someone holding write must run it. Nothing was removed.`,
+					[input.scope],
+				),
+			);
+		}
+		if (!input.forfeit && (marker === null || issue.value.state !== "closed")) {
+			return refused(
+				refuse(
+					NOT_CAPTURED,
+					`${VERB}: spike #${input.spike} carries no captured decision — disposing now destroys what a decision would rest on. Capture it, or pass --forfeit to abandon it on the record.`,
+					[input.scope],
+				),
+			);
+		}
+		if (!input.forfeit) return {_tag: "Ok", forfeited: false};
+
+		const body = forfeitNote({
+			nonce: input.nonce,
+			question: input.question,
+			records: input.records,
+		});
+		const leaked = leakFree(VERB, "composed forfeit note", body);
+		if (leaked !== null) return refused({...leaked, stderr: [input.scope, ...leaked.stderr]});
+
+		const posted = yield* createComment(repo, input.spike, body);
+		if (posted._tag === "Failure") {
+			return refused(
+				refuse(
+					WRITE_UNKNOWN,
+					`${VERB}: the forfeit note failed to post: ${posted.reason} — it may or may not have landed; read spike #${input.spike} before re-running. Nothing was removed.`,
+					[input.scope],
+				),
+			);
+		}
+		const back = yield* getComment(repo, posted.value.id);
+		if (
+			back._tag === "Failure" ||
+			normalizeForReadback(back.value) !== normalizeForReadback(body)
+		) {
+			return refused(
+				refuse(
+					READBACK_MISMATCH,
+					`${VERB}: the forfeit note landed but does not read back as sent — it needs a human eye. Nothing was removed.`,
+					[input.scope],
+				),
+			);
+		}
+		if (issue.value.state !== "closed") {
+			const closed = yield* closeCompleted(repo, input.spike);
+			if (closed._tag === "Failure") {
+				return refused(
+					refuse(
+						WRITE_UNKNOWN,
+						`${VERB}: the forfeit note landed as comment ${posted.value.id} but the close failed: ${closed.reason} — the note IS on the record; re-run to close. Nothing was removed.`,
+						[input.scope],
+					),
+				);
+			}
+		}
+		return {_tag: "Ok", forfeited: true};
+	});

--- a/packages/fabrika-cli/src/spike/dispose-verb.unit.test.ts
+++ b/packages/fabrika-cli/src/spike/dispose-verb.unit.test.ts
@@ -1,0 +1,233 @@
+import {Effect, Layer} from "effect";
+import {describe, expect, it} from "vitest";
+import {errOut, type FakeFsOptions, fakeFs, fakeShell, okOut} from "../fakes.test-support.ts";
+import type {ExecResult} from "../io/exec.ts";
+import {captureMarker, forfeitNote} from "./bodies.ts";
+import {
+	CAPTURE_STALE,
+	MALFORMED_RECORD,
+	NO_WORKSPACE,
+	NOT_CAPTURED,
+	READ_OR_EXEC_UNKNOWN,
+	REMOVAL_UNPROVEN,
+	TREE_MOVED,
+	WRITE_UNKNOWN,
+} from "./codes.ts";
+import {runDispose} from "./dispose-verb.ts";
+import {
+	CLOSE,
+	COMMENTS,
+	commentsPayload,
+	ENV,
+	EVIDENCE,
+	evidenceRecord,
+	ISSUE,
+	issuePayload,
+	MANIFEST,
+	manifestText,
+	NONCE,
+	ONE_RUN,
+	ONE_RUN_DIGEST,
+	POST,
+	QUESTION,
+	READBACK,
+	SPIKE,
+	STATUS,
+	TMP_ROOT,
+	WORKSPACE,
+} from "./fixtures.test-support.ts";
+
+const NOTE = forfeitNote({nonce: NONCE, question: QUESTION, records: [evidenceRecord(1)]});
+
+const resident: FakeFsOptions = {
+	directories: [WORKSPACE],
+	files: {[MANIFEST]: manifestText(), [EVIDENCE]: ONE_RUN},
+};
+
+const options = {
+	nonce: NONCE,
+	forfeit: false,
+	repo: null as string | null,
+	env: ENV,
+	tmpRoot: TMP_ROOT,
+};
+
+const CAPTURED = commentsPayload([{id: 500, body: `${captureMarker(NONCE, ONE_RUN_DIGEST)}\n`}]);
+
+const happy: ReadonlyArray<readonly [RegExp, ExecResult]> = [
+	[STATUS, okOut("")],
+	[ISSUE, okOut(issuePayload({state: "closed"}))],
+	[COMMENTS, okOut(CAPTURED)],
+];
+
+const run = (
+	script: ReadonlyArray<readonly [RegExp, ExecResult]>,
+	overrides: Partial<typeof options> = {},
+	fs: FakeFsOptions = resident,
+) => {
+	const shell = fakeShell(script);
+	return Effect.runPromise(
+		Effect.provide(
+			runDispose({...options, ...overrides}),
+			Layer.merge(fakeFs(fs).layer, shell.layer),
+		),
+	).then((outcome) => ({outcome, calls: shell.calls}));
+};
+
+describe("runDispose removes a captured spike's workspace and proves it is gone", () => {
+	it("answers the disposal with the tree it judged", async () => {
+		const {outcome} = await run(happy);
+		expect(outcome.code).toBe(0);
+		expect(JSON.parse(outcome.stdout)).toEqual({
+			spike: SPIKE,
+			nonce: NONCE,
+			workspace: "removed",
+			treeMatched: true,
+			runs: 1,
+			forfeited: false,
+		});
+	});
+
+	it("names no path in the answer — there is nothing left to point at", async () => {
+		const {outcome} = await run(happy);
+		expect(outcome.stdout).not.toContain(WORKSPACE);
+	});
+
+	it("seats a workspace still present on re-probe on 16", async () => {
+		const {outcome} = await run(happy, {}, {...resident, survivesRemoval: [WORKSPACE]});
+		expect(outcome.code).toBe(REMOVAL_UNPROVEN);
+		expect(outcome.stdout).toBe("");
+	});
+});
+
+describe("the tree comparison runs first, so a 17 never destroys the leak it found", () => {
+	const dirty = [
+		[STATUS, okOut("?? apps/web/src/probe.ts\n!! node_modules/\n")],
+		[ISSUE, okOut(issuePayload({state: "closed"}))],
+		[COMMENTS, okOut(CAPTURED)],
+	] as ReadonlyArray<readonly [RegExp, ExecResult]>;
+
+	it("refuses on 17 with the workspace intact and nothing posted", async () => {
+		const {outcome, calls} = await run(dirty, {forfeit: true});
+		expect(outcome.code).toBe(TREE_MOVED);
+		expect(outcome.stdout).toBe("");
+		expect(outcome.stderr.join("\n")).toContain("NOT removed");
+		expect(calls.filter((line) => POST.test(line))).toHaveLength(0);
+	});
+
+	it("enumerates every differing line, not only the first", async () => {
+		const {outcome} = await run(dirty);
+		expect(outcome.stderr.join("\n")).toContain("apps/web/src/probe.ts");
+		expect(outcome.stderr.join("\n")).toContain("node_modules/");
+	});
+
+	it("counts an ignored path — the check has no hole where prototypes write", async () => {
+		const {outcome} = await run([
+			[STATUS, okOut("!! dist/\n")],
+			[ISSUE, okOut(issuePayload({state: "closed"}))],
+			[COMMENTS, okOut(CAPTURED)],
+		]);
+		expect(outcome.code).toBe(TREE_MOVED);
+	});
+
+	it("seats an unreadable tree on 11 with nothing removed", async () => {
+		const {outcome} = await run([[STATUS, errOut("fatal: not a git repository")]]);
+		expect(outcome.code).toBe(READ_OR_EXEC_UNKNOWN);
+	});
+});
+
+describe("runDispose refuses to destroy what a decision would rest on", () => {
+	it("seats an uncaptured spike on 15, naming both ways forward", async () => {
+		const {outcome} = await run([
+			[STATUS, okOut("")],
+			[ISSUE, okOut(issuePayload())],
+			[COMMENTS, okOut(commentsPayload([]))],
+		]);
+		expect(outcome.code).toBe(NOT_CAPTURED);
+		expect(outcome.stderr.join("\n")).toContain("--forfeit");
+	});
+
+	it("seats a capture that no longer covers the log on 21, forfeit or not", async () => {
+		const stale = [
+			[STATUS, okOut("")],
+			[ISSUE, okOut(issuePayload({state: "closed"}))],
+			[COMMENTS, okOut(commentsPayload([{id: 500, body: captureMarker(NONCE, "a".repeat(64))}]))],
+		] as ReadonlyArray<readonly [RegExp, ExecResult]>;
+		expect((await run(stale)).outcome.code).toBe(CAPTURE_STALE);
+		const forfeited = await run(stale, {forfeit: true});
+		expect(forfeited.outcome.code).toBe(CAPTURE_STALE);
+		expect(forfeited.calls.filter((line) => POST.test(line))).toHaveLength(0);
+	});
+
+	it("names the human escalation a 19 on capture would force", async () => {
+		const {outcome} = await run([
+			[STATUS, okOut("")],
+			[ISSUE, okOut(issuePayload({state: "closed"}))],
+			[COMMENTS, okOut(commentsPayload([{id: 500, body: captureMarker(NONCE, "a".repeat(64))}]))],
+		]);
+		expect(outcome.stderr.join("\n")).toContain("someone holding write");
+	});
+
+	it("seats an absent workspace on 12", async () => {
+		const {outcome} = await run(happy, {}, {});
+		expect(outcome.code).toBe(NO_WORKSPACE);
+	});
+
+	it("seats a manifest that does not parse on 4", async () => {
+		const {outcome} = await run(happy, {}, {directories: [WORKSPACE], files: {[MANIFEST]: "{}\n"}});
+		expect(outcome.code).toBe(MALFORMED_RECORD);
+	});
+});
+
+describe("--forfeit abandons the spike on the record before disposing", () => {
+	const forfeitScript: ReadonlyArray<readonly [RegExp, ExecResult]> = [
+		[STATUS, okOut("")],
+		[ISSUE, okOut(issuePayload())],
+		[COMMENTS, okOut(commentsPayload([]))],
+		[POST, okOut(JSON.stringify({id: 700, html_url: "https://example.test/#c"}))],
+		[READBACK, okOut(JSON.stringify({body: NOTE}))],
+		[CLOSE, okOut("{}")],
+	];
+
+	it("posts the note, closes, disposes and says so", async () => {
+		const {outcome, calls} = await run(forfeitScript, {forfeit: true});
+		expect(outcome.code).toBe(0);
+		expect(JSON.parse(outcome.stdout).forfeited).toBe(true);
+		expect(calls.filter((line) => CLOSE.test(line))).toHaveLength(1);
+	});
+
+	it("reads the question from the manifest — dispose takes no --question", async () => {
+		const {calls} = await run(forfeitScript, {forfeit: true});
+		expect(calls.find((line) => POST.test(line))).toContain(QUESTION);
+	});
+
+	it("seats an unproven post on 8 with nothing removed", async () => {
+		const {outcome} = await run(
+			[
+				[STATUS, okOut("")],
+				[ISSUE, okOut(issuePayload())],
+				[COMMENTS, okOut(commentsPayload([]))],
+				[POST, errOut("gh: Bad gateway (HTTP 502)")],
+			],
+			{forfeit: true},
+		);
+		expect(outcome.code).toBe(WRITE_UNKNOWN);
+		expect(outcome.stderr.join("\n")).toContain("Nothing was removed");
+	});
+});
+
+describe("a provisional manifest skips the issue half entirely", () => {
+	it("disposes an orphaned workspace with no GitHub read at all", async () => {
+		const {outcome, calls} = await run(
+			[[STATUS, okOut("")]],
+			{},
+			{
+				directories: [WORKSPACE],
+				files: {[MANIFEST]: manifestText({spike: null})},
+			},
+		);
+		expect(outcome.code).toBe(0);
+		expect(JSON.parse(outcome.stdout)).toMatchObject({spike: null, runs: 0, forfeited: false});
+		expect(calls.filter((line) => line.startsWith("gh "))).toHaveLength(0);
+	});
+});

--- a/packages/fabrika-cli/src/spike/fixtures.test-support.ts
+++ b/packages/fabrika-cli/src/spike/fixtures.test-support.ts
@@ -1,0 +1,116 @@
+/**
+ * The fixtures every `spike` test drives from, so five verb suites agree about what a well-formed
+ * workspace, manifest, evidence log and spike issue look like — and a change to one of those shapes
+ * reds in one place rather than drifting across five.
+ */
+
+import type {EvidenceRecord, Manifest} from "./workspace.ts";
+import {
+	evidencePath,
+	manifestPath,
+	renderEvidenceLine,
+	renderManifest,
+	sha256OfText,
+	workspacePath,
+} from "./workspace.ts";
+
+export const REPO = "o/r";
+export const NONCE = "7f3a9c21";
+export const SPIKE = 9310;
+export const TREE_ROOT = "/repo";
+export const TMP_ROOT = "/tmp-root";
+export const QUESTION = "does a single-use token need a new table?";
+export const WORKSPACE = workspacePath(TMP_ROOT, NONCE);
+export const MANIFEST = manifestPath(WORKSPACE);
+export const EVIDENCE = evidencePath(WORKSPACE);
+export const CLEAN_TREE_DIGEST = sha256OfText("");
+
+export const ENV = {CLAUDE_PIPELINE_REPO: REPO} as Record<string, string | undefined>;
+
+export const manifest = (overrides: Partial<Manifest> = {}): Manifest => ({
+	spike: SPIKE,
+	nonce: NONCE,
+	kind: "logic",
+	question: QUESTION,
+	repo: REPO,
+	ticket: null,
+	treeDigest: CLEAN_TREE_DIGEST,
+	treeRoot: TREE_ROOT,
+	...overrides,
+});
+
+export const manifestText = (overrides: Partial<Manifest> = {}): string =>
+	renderManifest(manifest(overrides));
+
+export const evidenceRecord = (
+	seq: number,
+	overrides: Partial<EvidenceRecord> = {},
+): EvidenceRecord => ({
+	seq,
+	command: ["printf", "no\\n"],
+	commandExit: 0,
+	timedOut: false,
+	outBytes: 3,
+	errBytes: 0,
+	truncated: false,
+	outSha256: sha256OfText("no\n"),
+	errSha256: sha256OfText(""),
+	...overrides,
+});
+
+export const evidenceText = (records: ReadonlyArray<EvidenceRecord>): string =>
+	records.map(renderEvidenceLine).join("");
+
+/** The one-run log every capture/dispose test rests on, and the digest a marker must carry. */
+export const ONE_RUN = evidenceText([evidenceRecord(1)]);
+export const ONE_RUN_DIGEST = sha256OfText(ONE_RUN);
+
+export const issuePayload = (
+	overrides: {
+		readonly number?: number;
+		readonly title?: string;
+		readonly body?: string;
+		readonly state?: string;
+		readonly labels?: ReadonlyArray<string>;
+	} = {},
+): string =>
+	JSON.stringify({
+		number: overrides.number ?? SPIKE,
+		title: overrides.title ?? `spike: ${QUESTION}`,
+		body: overrides.body ?? "## Question\n",
+		state: overrides.state ?? "open",
+		labels: (overrides.labels ?? ["prototyping:spike"]).map((name) => ({name})),
+		html_url: `https://example.test/#${overrides.number ?? SPIKE}`,
+		user: {login: "agent"},
+	});
+
+export const commentsPayload = (
+	comments: ReadonlyArray<{
+		readonly id: number;
+		readonly body: string;
+		readonly createdAt?: string;
+	}>,
+): string =>
+	JSON.stringify(
+		comments.map((comment) => ({
+			id: comment.id,
+			body: comment.body,
+			created_at: comment.createdAt ?? "2026-08-10T00:00:00Z",
+			updated_at: comment.createdAt ?? "2026-08-10T00:00:00Z",
+			user: {login: "agent"},
+		})),
+	);
+
+/** The command lines the fake spawner is scripted on. */
+export const ROOT = /^git rev-parse --show-toplevel$/;
+export const STATUS = /^git -C \/repo status --porcelain=v1/;
+export const LABELS = /^gh api --paginate repos\/o\/r\/labels\?/;
+export const ISSUE = /^gh api repos\/o\/r\/issues\/9310$/;
+export const COMMENTS = /^gh api --paginate repos\/o\/r\/issues\/9310\/comments\?/;
+export const CREATE = /^gh api --method POST repos\/o\/r\/issues -f/;
+export const POST = /^gh api --method POST repos\/o\/r\/issues\/9310\/comments -f/;
+export const READBACK = /^gh api repos\/o\/r\/issues\/comments\/\d+$/;
+export const CLOSE = /^gh api --method PATCH repos\/o\/r\/issues\/9310 -f state=closed/;
+export const VIEWER = /^gh api user --jq \.login$/;
+export const PERMISSION = /^gh api repos\/o\/r\/collaborators\/agent\/permission/;
+export const OPEN_SPIKES = /^gh api --paginate repos\/o\/r\/issues\?state=open&labels=/;

--- a/packages/fabrika-cli/src/spike/guards.ts
+++ b/packages/fabrika-cli/src/spike/guards.ts
@@ -1,0 +1,235 @@
+/**
+ * The checks every `spike` verb runs before it decides anything, factored here so five verbs cannot
+ * disagree about what an off-grammar nonce is, what an absent workspace is, or what a leak is.
+ *
+ * Each returns the refusal itself rather than a boolean, so a caller cannot receive "this failed" and
+ * then compose a message that drifts from the code it seats.
+ *
+ * **Absence and unreadability are separated at every read here**, because that is the split the whole
+ * group rests on: an absent workspace is `12`, an absent evidence log is a *fact*, and a read that
+ * could not be performed is `11` with nothing written.
+ */
+
+import {Effect, type FileSystem, type Path} from "effect";
+import type {ChildProcessSpawner} from "effect/unstable/process";
+import {exists, readFile} from "../io/fs.ts";
+import {treeStatus} from "../io/git.ts";
+import {resolveRepo} from "../io/issues.ts";
+import {isBareAtReference, renderLeaks, scanBody} from "../report/leaks.ts";
+import {FAILED, refuse, type VerbOutcome} from "../verb.ts";
+import {
+	BARE_AT_PATH,
+	LEAKED_PATH,
+	MALFORMED_RECORD,
+	NO_WORKSPACE,
+	OFF_VOCABULARY,
+	READ_OR_EXEC_UNKNOWN,
+} from "./codes.ts";
+import {
+	differingStatusLines,
+	type EvidenceRecord,
+	evidenceDigestOf,
+	evidencePath,
+	isNonce,
+	type Manifest,
+	manifestPath,
+	parseEvidence,
+	parseManifest,
+	treeDigestOf,
+} from "./workspace.ts";
+
+export type Guarded<A> =
+	| {readonly _tag: "Ok"; readonly value: A}
+	| {readonly _tag: "Refused"; readonly outcome: VerbOutcome};
+
+export const ok = <A>(value: A): Guarded<A> => ({_tag: "Ok", value});
+export const refused = (outcome: VerbOutcome): Guarded<never> => ({_tag: "Refused", outcome});
+
+/** Anything in this module: it reads disk and shells out, so it needs both platform seams. */
+export type SpikeEffect<A> = Effect.Effect<
+	A,
+	never,
+	FileSystem.FileSystem | Path.Path | ChildProcessSpawner.ChildProcessSpawner
+>;
+
+/** The target repository, or the usage refusal that names both ways to supply it. */
+export const targetRepo = (
+	verb: string,
+	explicit: string | null,
+	env: Readonly<Record<string, string | undefined>>,
+): Effect.Effect<Guarded<string>, never, ChildProcessSpawner.ChildProcessSpawner> =>
+	Effect.gen(function* () {
+		const attempt = yield* resolveRepo(explicit, env);
+		return attempt._tag === "Ok"
+			? ok(attempt.value)
+			: refused(
+					refuse(
+						FAILED,
+						`${verb}: cannot resolve a target repo — pass --repo, or run inside a checkout whose origin remote resolves.`,
+					),
+				);
+	});
+
+/** The `10` a nonce that is not eight lowercase hex earns, in each verb's own words. */
+export const nonceGrammar = (verb: string, nonce: string, tail: string): VerbOutcome | null =>
+	isNonce(nonce)
+		? null
+		: refuse(
+				OFF_VOCABULARY,
+				`${verb}: --nonce "${nonce}" is not eight lowercase hex characters.${tail}`,
+			);
+
+/**
+ * Every text this group sends to GitHub is leak-scanned before the write.
+ *
+ * The recorded false positive is inherited rather than designed around: the scan flags a
+ * counter-example path quoted in prose (#3785), so a decision body that *quotes* a path refuses on
+ * `5`. The expectation is that a decision describes what a path was rather than pasting one — which
+ * is also what keeps a machine-local path out of a posted body in the first place.
+ */
+export const leakFree = (verb: string, what: string, text: string): VerbOutcome | null => {
+	if (isBareAtReference(text)) {
+		return refuse(
+			BARE_AT_PATH,
+			`${verb}: the ${what} is a bare @ path reference — write the text, not a pointer to it.`,
+		);
+	}
+	const scan = scanBody(text);
+	return scan.leaks.length === 0
+		? null
+		: refuse(
+				LEAKED_PATH,
+				`${verb}: the ${what} carries a machine-local path: ${scan.leaks[0]?.text ?? "<unnamed>"}.`,
+				renderLeaks(scan.leaks),
+			);
+};
+
+/** Whether a path is there — a probe that could not be performed is `11`, never "absent". */
+export const probe = (verb: string, what: string, path: string): SpikeEffect<Guarded<boolean>> =>
+	exists(path).pipe(
+		Effect.map(ok<boolean>),
+		Effect.catchTag("fabrika-cli/ReadFailed", (failure) =>
+			Effect.succeed(
+				refused(
+					refuse(
+						READ_OR_EXEC_UNKNOWN,
+						`${verb}: cannot read ${what}: ${failure.reason} — nothing was written and the state is UNKNOWN.`,
+					),
+				),
+			),
+		),
+	);
+
+/** The manifest for a nonce: `12` when the workspace is absent, `4` malformed, `11` unreadable. */
+export const readManifest = (
+	verb: string,
+	workspace: string,
+	nonce: string,
+	absentTail: string,
+): SpikeEffect<Guarded<Manifest>> =>
+	Effect.gen(function* () {
+		const present = yield* probe(verb, "the workspace", workspace);
+		if (present._tag === "Refused") return present;
+		if (!present.value) {
+			return refused(
+				refuse(NO_WORKSPACE, `${verb}: no workspace for nonce ${nonce} — ${absentTail}`),
+			);
+		}
+		const path = manifestPath(workspace);
+		const read = yield* readFile(path).pipe(
+			Effect.map((text) => ({_tag: "Text" as const, text})),
+			Effect.catchTag("fabrika-cli/ReadFailed", (failure) =>
+				Effect.succeed({_tag: "Failed" as const, reason: failure.reason}),
+			),
+		);
+		if (read._tag === "Failed") {
+			return refused(
+				refuse(
+					READ_OR_EXEC_UNKNOWN,
+					`${verb}: cannot read the manifest for nonce ${nonce}: ${read.reason} — nothing was written.`,
+				),
+			);
+		}
+		const manifest = parseManifest(read.text);
+		return manifest._tag === "Malformed"
+			? refused(
+					refuse(
+						MALFORMED_RECORD,
+						`${verb}: ${path} exists but does not satisfy the manifest schema: ${manifest.reason} — refusing the whole file.`,
+					),
+				)
+			: ok(manifest.value);
+	});
+
+/** The evidence log as it sits on disk, plus the digest taken over exactly those bytes. */
+export interface Evidence {
+	readonly records: ReadonlyArray<EvidenceRecord>;
+	/** The log's bytes as text, or `null` when the log was never written — a fact, not a failed read. */
+	readonly text: string | null;
+	/** `null` when the log was never written: a log that does not exist is not one that hashes empty. */
+	readonly digest: string | null;
+}
+
+/**
+ * The evidence log for a workspace.
+ *
+ * An **absent** log is a fact — zero runs, `seq` 1 for the next append — and is deliberately not the
+ * same value as an empty one: `digest` is `null` rather than the SHA-256 of zero bytes, so no caller
+ * can compare a never-written log against a marker and read the two as agreeing.
+ */
+export const readEvidence = (verb: string, workspace: string): SpikeEffect<Guarded<Evidence>> =>
+	Effect.gen(function* () {
+		const path = evidencePath(workspace);
+		const present = yield* probe(verb, "the evidence log", path);
+		if (present._tag === "Refused") return present;
+		if (!present.value) return ok<Evidence>({records: [], text: null, digest: null});
+		const read = yield* readFile(path).pipe(
+			Effect.map((text) => ({_tag: "Text" as const, text})),
+			Effect.catchTag("fabrika-cli/ReadFailed", (failure) =>
+				Effect.succeed({_tag: "Failed" as const, reason: failure.reason}),
+			),
+		);
+		if (read._tag === "Failed") {
+			return refused(
+				refuse(
+					READ_OR_EXEC_UNKNOWN,
+					`${verb}: cannot read the evidence log: ${read.reason} — the log is the evidence, so a log that cannot be read proves nothing.`,
+				),
+			);
+		}
+		const log = parseEvidence(read.text);
+		return log._tag === "Malformed"
+			? refused(
+					refuse(
+						MALFORMED_RECORD,
+						`${verb}: ${path} does not parse: ${log.reason} — the log is the evidence, so a log that cannot be read proves nothing.`,
+					),
+				)
+			: ok<Evidence>({
+					records: log.value,
+					text: read.text,
+					digest: evidenceDigestOf(read.text),
+				});
+	});
+
+/** The working tree's state at `root`, digested — and the sorted status lines a `17` enumerates. */
+export interface TreeState {
+	readonly digest: string;
+	readonly lines: ReadonlyArray<string>;
+}
+
+export const readTree = (verb: string, root: string): SpikeEffect<Guarded<TreeState>> =>
+	Effect.gen(function* () {
+		const status = yield* treeStatus(root);
+		return status._tag === "Failure"
+			? refused(
+					refuse(
+						READ_OR_EXEC_UNKNOWN,
+						`${verb}: cannot read the tree state at ${root}: ${status.reason} — an unreadable tree is UNKNOWN, never clean.`,
+					),
+				)
+			: ok<TreeState>({
+					digest: treeDigestOf(status.value),
+					lines: differingStatusLines(status.value),
+				});
+	});

--- a/packages/fabrika-cli/src/spike/open-verb.ts
+++ b/packages/fabrika-cli/src/spike/open-verb.ts
@@ -1,0 +1,357 @@
+/**
+ * `spike open` — mint the spike issue for one question, allocate this run's workspace under a freshly
+ * minted nonce, and bind the two in a manifest.
+ *
+ * Not a judging verb: it supplies an identity. Whether this question deserves a spike stays in the
+ * skill; what this verb proves is mechanical — the path is outside the tree, the label exists, the
+ * issue read back as sent, and the workspace names it.
+ *
+ * **Three ordering rules are load-bearing and none is incidental.** The in-tree refusal comes before
+ * any write, so a workspace inside the tree never becomes part of the thing the digest measures. The
+ * tree digest is taken before the workspace exists, for the same reason. And the workspace is created
+ * **before** the issue, so a half-applied run fails toward a local orphan directory `spike dispose`
+ * collects rather than toward a public issue nobody holds a nonce for.
+ *
+ * **An absent workspace is the normal first-run path, not a refusal** — which is why this verb seats
+ * `4` for a manifest that does not parse and never `12` for one that is not there, the asymmetry its
+ * sibling verbs invert.
+ */
+
+import {Effect} from "effect";
+import {exists, readFile, realPath, writeFile} from "../io/fs.ts";
+import {repoRoot, treeStatus} from "../io/git.ts";
+import {createIssue, getIssue, listLabels, openIssuesWithLabel} from "../io/issues.ts";
+import {normalizeForReadback} from "../report/compose.ts";
+import {answer, FAILED, refuse, type VerbOutcome} from "../verb.ts";
+import {issueBody, SPIKE_LABEL, spikeTitle} from "./bodies.ts";
+import {
+	MALFORMED_RECORD,
+	MANIFEST_INCOMPLETE,
+	NO_WORKSPACE,
+	OFF_VOCABULARY,
+	READ_OR_EXEC_UNKNOWN,
+	READBACK_MISMATCH,
+	WORKSPACE_IN_TREE,
+	WORKSPACE_MISMATCH,
+	WRITE_UNKNOWN,
+	ZERO_SCOPE,
+} from "./codes.ts";
+import {leakFree, nonceGrammar, type SpikeEffect, targetRepo} from "./guards.ts";
+import {
+	isInsideTree,
+	isKind,
+	isNonce,
+	KINDS,
+	type Kind,
+	type Manifest,
+	manifestPath,
+	parseManifest,
+	renderManifest,
+	treeDigestOf,
+	workspacePath,
+} from "./workspace.ts";
+
+export interface OpenOptions {
+	readonly question: string;
+	readonly kind: string;
+	readonly ticket: number | null;
+	/** Re-entry only: names an existing workspace to resume. A caller does not invent one. */
+	readonly nonce: string | null;
+	readonly repo: string | null;
+	readonly env: Readonly<Record<string, string | undefined>>;
+	/** The OS temp root — the one machine fact this group does not derive, read by the adapter. */
+	readonly tmpRoot: string;
+	/** The cryptographic source a fresh nonce is drawn from, injected so a test can pin the value. */
+	readonly mintNonce: () => string;
+}
+
+const VERB = "spike open";
+
+const answered = (manifest: Manifest, workspace: string, scope: string): VerbOutcome =>
+	answer(
+		JSON.stringify({
+			spike: manifest.spike,
+			nonce: manifest.nonce,
+			kind: manifest.kind,
+			workspace,
+			treeDigest: manifest.treeDigest,
+		}),
+		[scope],
+	);
+
+export const runOpen = (options: OpenOptions): SpikeEffect<VerbOutcome> =>
+	Effect.gen(function* () {
+		const question = options.question.trim();
+		if (question === "") {
+			return refuse(FAILED, `${VERB}: --question is empty — a spike answers one named question.`);
+		}
+		if (!isKind(options.kind)) {
+			return refuse(
+				OFF_VOCABULARY,
+				`${VERB}: --kind "${options.kind}" is not ${KINDS.join(" or ")} — those are the two ruled artifact shapes (#5017).`,
+			);
+		}
+		const kind: Kind = options.kind;
+		if (options.nonce !== null && !isNonce(options.nonce)) {
+			return (
+				nonceGrammar(
+					VERB,
+					options.nonce,
+					" Nonces are minted by this verb, not supplied, except to re-enter a run.",
+				) ?? refuse(FAILED, `${VERB}: --nonce could not be validated.`)
+			);
+		}
+
+		const target = yield* targetRepo(VERB, options.repo, options.env);
+		if (target._tag === "Refused") return target.outcome;
+		const repo = target.value;
+
+		const root = yield* repoRoot;
+		if (root._tag === "Failure") {
+			return refuse(
+				READ_OR_EXEC_UNKNOWN,
+				`${VERB}: cannot read the repository root: ${root.reason} — nothing was minted and no workspace exists.`,
+			);
+		}
+		// Serial on purpose: two local `realpath` calls, and the refusal below names whichever failed
+		// first, which a concurrent pair would make nondeterministic.
+		const resolved = yield* Effect.all([realPath(root.value), realPath(options.tmpRoot)], {
+			concurrency: 1,
+		}).pipe(
+			Effect.map(([treeRoot, tmpRoot]) => ({_tag: "Ok" as const, treeRoot, tmpRoot})),
+			Effect.catchTag("fabrika-cli/ReadFailed", (failure) =>
+				Effect.succeed({_tag: "Failed" as const, what: failure.path, reason: failure.reason}),
+			),
+		);
+		if (resolved._tag === "Failed") {
+			return refuse(
+				READ_OR_EXEC_UNKNOWN,
+				`${VERB}: cannot read ${resolved.what}: ${resolved.reason} — nothing was minted and no workspace exists.`,
+			);
+		}
+		const {treeRoot, tmpRoot} = resolved;
+
+		const nonce = options.nonce ?? options.mintNonce();
+		const workspace = workspacePath(tmpRoot, nonce);
+		if (isInsideTree(workspace, treeRoot)) {
+			return refuse(
+				WORKSPACE_IN_TREE,
+				`${VERB}: the workspace path ${workspace} resolves inside the repository at ${treeRoot} — a spike that lives in the tree is the defect this skill exists to prevent. Nothing was written.`,
+			);
+		}
+
+		const scope = `${VERB}: ${repo}, nonce ${nonce}, workspace ${workspace}, tree ${treeRoot}.`;
+
+		const present = yield* exists(workspace).pipe(
+			Effect.map((value) => ({_tag: "Ok" as const, value})),
+			Effect.catchTag("fabrika-cli/ReadFailed", (failure) =>
+				Effect.succeed({_tag: "Failed" as const, reason: failure.reason}),
+			),
+		);
+		if (present._tag === "Failed") {
+			return refuse(
+				READ_OR_EXEC_UNKNOWN,
+				`${VERB}: cannot read the workspace: ${present.reason} — nothing was minted and no workspace exists.`,
+			);
+		}
+		if (present.value) {
+			return yield* resumeExisting({repo, workspace, nonce, question, kind, scope});
+		}
+		if (options.nonce !== null) {
+			return refuse(
+				NO_WORKSPACE,
+				`${VERB}: --nonce ${nonce} names no workspace — omit it to mint a new run.`,
+			);
+		}
+
+		const labels = yield* listLabels(repo);
+		if (labels._tag === "Failure") {
+			return refuse(
+				READ_OR_EXEC_UNKNOWN,
+				`${VERB}: cannot read the label set of ${repo}: ${labels.reason} — nothing was minted and no workspace exists.`,
+			);
+		}
+		if (!labels.value.includes(SPIKE_LABEL)) {
+			return refuse(
+				ZERO_SCOPE,
+				`${VERB}: the repository has no ${SPIKE_LABEL} label — a spike minted without it is one no later run and no caller can find. Run /fabrika: front-door's bootstrap creates the board labels (#4952).`,
+			);
+		}
+
+		const status = yield* treeStatus(treeRoot);
+		if (status._tag === "Failure") {
+			return refuse(
+				READ_OR_EXEC_UNKNOWN,
+				`${VERB}: cannot read the tree state at ${treeRoot}: ${status.reason} — nothing was minted and no workspace exists.`,
+			);
+		}
+		const treeDigest = treeDigestOf(status.value);
+
+		const provisional: Manifest = {
+			spike: null,
+			nonce,
+			kind,
+			question,
+			repo,
+			ticket: options.ticket,
+			treeDigest,
+			treeRoot,
+		};
+		const staged = yield* writeManifest(workspace, provisional);
+		if (staged !== null) {
+			return refuse(
+				READ_OR_EXEC_UNKNOWN,
+				`${VERB}: cannot write the workspace at ${workspace}: ${staged} — nothing was minted.`,
+				[scope],
+			);
+		}
+
+		const title = spikeTitle(question);
+		const body = issueBody({question, kind, nonce, ticket: options.ticket});
+		const leaked = leakFree(VERB, "composed title", title) ?? leakFree(VERB, "composed body", body);
+		if (leaked !== null) return {...leaked, stderr: [scope, ...leaked.stderr]};
+
+		const created = yield* createIssue(repo, title, body, SPIKE_LABEL);
+		if (created._tag === "Failure") {
+			return refuse(
+				WRITE_UNKNOWN,
+				`${VERB}: the issue create failed: ${created.reason} — it may or may not have landed; read the board before re-running.`,
+				[scope],
+			);
+		}
+		const spike = created.value.number;
+
+		const landed = yield* getIssue(repo, spike);
+		if (landed._tag !== "Present") {
+			return refuse(
+				WRITE_UNKNOWN,
+				`${VERB}: the issue create failed: ${landed._tag === "Absent" ? `#${spike} is not readable after the create` : landed.reason} — it may or may not have landed; read the board before re-running.`,
+				[scope],
+			);
+		}
+		const wrong =
+			landed.value.title !== title
+				? "title"
+				: normalizeForReadback(landed.value.body) !== normalizeForReadback(body)
+					? "body"
+					: landed.value.labels.includes(SPIKE_LABEL)
+						? null
+						: "labels";
+		if (wrong !== null) {
+			return refuse(
+				READBACK_MISMATCH,
+				`${VERB}: the spike landed as #${spike} but its ${wrong} does not read back as sent — it needs a human eye.`,
+				[scope],
+			);
+		}
+
+		const completed: Manifest = {...provisional, spike};
+		const failure = yield* writeManifest(workspace, completed);
+		if (failure !== null) {
+			return refuse(
+				MANIFEST_INCOMPLETE,
+				`${VERB}: the spike landed as #${spike} but its manifest could not be completed: ${failure} — the issue exists and no workspace names it. Close #${spike}, or re-run with --nonce ${nonce}.`,
+				[scope],
+			);
+		}
+		return answered(completed, workspace, scope);
+	});
+
+const writeManifest = (workspace: string, manifest: Manifest): SpikeEffect<string | null> =>
+	writeFile(manifestPath(workspace), renderManifest(manifest)).pipe(
+		Effect.map((): string | null => null),
+		Effect.catchTag("fabrika-cli/WriteFailed", (failure) => Effect.succeed(failure.reason)),
+	);
+
+/**
+ * The re-entry branch: a workspace already exists for this nonce.
+ *
+ * Every path here either answers the existing manifest or refuses — a workspace that exists and
+ * holds different work is never written over, and a re-run after a network fault therefore mints no
+ * second issue.
+ */
+const resumeExisting = (input: {
+	readonly repo: string;
+	readonly workspace: string;
+	readonly nonce: string;
+	readonly question: string;
+	readonly kind: Kind;
+	readonly scope: string;
+}): SpikeEffect<VerbOutcome> =>
+	Effect.gen(function* () {
+		const path = manifestPath(input.workspace);
+		const read = yield* readFile(path).pipe(
+			Effect.map((text) => ({_tag: "Text" as const, text})),
+			Effect.catchTag("fabrika-cli/ReadFailed", (failure) =>
+				Effect.succeed({_tag: "Failed" as const, reason: failure.reason}),
+			),
+		);
+		if (read._tag === "Failed") {
+			return refuse(
+				READ_OR_EXEC_UNKNOWN,
+				`${VERB}: cannot read the manifest for nonce ${input.nonce}: ${read.reason} — nothing was minted.`,
+			);
+		}
+		const manifest = parseManifest(read.text);
+		if (manifest._tag === "Malformed") {
+			return refuse(
+				MALFORMED_RECORD,
+				`${VERB}: a workspace for nonce ${input.nonce} exists but its manifest does not parse: ${manifest.reason} — refusing the whole file; re-entry cannot be decided against half a manifest.`,
+			);
+		}
+		if (manifest.value.question !== input.question) {
+			return refuse(
+				WORKSPACE_MISMATCH,
+				`${VERB}: a workspace for nonce ${input.nonce} holds a different question — mint a new run rather than reusing it.`,
+			);
+		}
+		if (manifest.value.kind !== input.kind) {
+			return refuse(
+				WORKSPACE_MISMATCH,
+				`${VERB}: a workspace for nonce ${input.nonce} holds a different kind — mint a new run rather than reusing it.`,
+			);
+		}
+		if (manifest.value.spike !== null)
+			return answered(manifest.value, input.workspace, input.scope);
+
+		// A provisional manifest is a real, reachable state: the issue landed and the completing write
+		// did not (`20`). The way forward is to find that issue by the nonce its body carries, which is
+		// what makes `20`'s named recovery terminate instead of loop.
+		const listed = yield* openIssuesWithLabel(input.repo, SPIKE_LABEL);
+		if (listed._tag === "Failure") {
+			return refuse(
+				READ_OR_EXEC_UNKNOWN,
+				`${VERB}: cannot read the open ${SPIKE_LABEL} issues of ${input.repo}: ${listed.reason} — the manifest stays provisional and nothing was lost.`,
+			);
+		}
+		for (const row of listed.value) {
+			const issue = yield* getIssue(input.repo, row.number);
+			if (issue._tag === "Unknown") {
+				return refuse(
+					READ_OR_EXEC_UNKNOWN,
+					`${VERB}: cannot read spike #${row.number}: ${issue.reason} — the manifest stays provisional and nothing was lost.`,
+				);
+			}
+			if (issue._tag === "Absent") continue;
+			if (!issueBodyNames(issue.value.body, input.nonce)) continue;
+			const completed: Manifest = {...manifest.value, spike: row.number};
+			const failure = yield* writeManifest(input.workspace, completed);
+			return failure === null
+				? answered(completed, input.workspace, input.scope)
+				: refuse(
+						MANIFEST_INCOMPLETE,
+						`${VERB}: the spike landed as #${row.number} but its manifest could not be completed: ${failure} — the issue exists and no workspace names it. Close #${row.number}, or re-run with --nonce ${input.nonce}.`,
+					);
+		}
+		return refuse(
+			NO_WORKSPACE,
+			`${VERB}: --nonce ${input.nonce} names a workspace whose spike is not among the open ${SPIKE_LABEL} issues — the workspace names nothing. Omit --nonce to start over.`,
+		);
+	});
+
+/** Whether an issue body's `## Run` section names this nonce. */
+const issueBodyNames = (body: string, nonce: string): boolean =>
+	body
+		.split("\n")
+		.map((line) => line.trim())
+		.includes(nonce);

--- a/packages/fabrika-cli/src/spike/open-verb.unit.test.ts
+++ b/packages/fabrika-cli/src/spike/open-verb.unit.test.ts
@@ -1,0 +1,281 @@
+import {Effect, Layer} from "effect";
+import {describe, expect, it} from "vitest";
+import {errOut, type FakeFsOptions, fakeFs, fakeShell, okOut} from "../fakes.test-support.ts";
+import type {ExecResult} from "../io/exec.ts";
+import {issueBody, spikeTitle} from "./bodies.ts";
+import {
+	MALFORMED_RECORD,
+	MANIFEST_INCOMPLETE,
+	NO_WORKSPACE,
+	OFF_VOCABULARY,
+	READ_OR_EXEC_UNKNOWN,
+	READBACK_MISMATCH,
+	WORKSPACE_IN_TREE,
+	WORKSPACE_MISMATCH,
+	WRITE_UNKNOWN,
+	ZERO_SCOPE,
+} from "./codes.ts";
+import {
+	CLEAN_TREE_DIGEST,
+	CREATE,
+	ENV,
+	ISSUE,
+	issuePayload,
+	LABELS,
+	MANIFEST,
+	manifestText,
+	NONCE,
+	OPEN_SPIKES,
+	QUESTION,
+	ROOT,
+	SPIKE,
+	STATUS,
+	TMP_ROOT,
+	TREE_ROOT,
+	WORKSPACE,
+} from "./fixtures.test-support.ts";
+import {runOpen} from "./open-verb.ts";
+import {parseManifest} from "./workspace.ts";
+
+const BODY = issueBody({question: QUESTION, kind: "logic", nonce: NONCE, ticket: null});
+const TITLE = spikeTitle(QUESTION);
+
+const options = {
+	question: QUESTION,
+	kind: "logic",
+	ticket: null,
+	nonce: null as string | null,
+	repo: null as string | null,
+	env: ENV,
+	tmpRoot: TMP_ROOT,
+	mintNonce: () => NONCE,
+};
+
+const happy: ReadonlyArray<readonly [RegExp, ExecResult]> = [
+	[ROOT, okOut(`${TREE_ROOT}\n`)],
+	[LABELS, okOut("prototyping:spike\ntype:bug\n")],
+	[STATUS, okOut("")],
+	[CREATE, okOut(JSON.stringify({number: SPIKE, html_url: "https://example.test/#9310"}))],
+	[ISSUE, okOut(issuePayload({title: TITLE, body: BODY}))],
+];
+
+const run = (
+	script: ReadonlyArray<readonly [RegExp, ExecResult]>,
+	overrides: Partial<typeof options> = {},
+	fs: FakeFsOptions = {},
+) => {
+	const disk = fakeFs(fs);
+	const shell = fakeShell(script);
+	return Effect.runPromise(
+		Effect.provide(runOpen({...options, ...overrides}), Layer.merge(disk.layer, shell.layer)),
+	).then((outcome) => ({outcome, written: disk.written, calls: shell.calls}));
+};
+
+describe("runOpen mints a spike, its workspace and their binding", () => {
+	it("answers the issue number, the nonce, the workspace and the tree digest", async () => {
+		const {outcome} = await run(happy);
+		expect(outcome.code).toBe(0);
+		expect(JSON.parse(outcome.stdout)).toEqual({
+			spike: SPIKE,
+			nonce: NONCE,
+			kind: "logic",
+			workspace: WORKSPACE,
+			treeDigest: CLEAN_TREE_DIGEST,
+		});
+	});
+
+	it("creates the workspace BEFORE the issue, so a half-run leaves a collectable orphan", async () => {
+		const {written, calls} = await run(happy);
+		expect([...written.keys()]).toContain(MANIFEST);
+		expect(calls.filter((line) => CREATE.test(line))).toHaveLength(1);
+	});
+
+	it("sends the label in the create call itself, so there is no unlabelled window", async () => {
+		const {calls} = await run(happy);
+		expect(calls.find((line) => CREATE.test(line))).toContain("labels[]=prototyping:spike");
+	});
+
+	it("completes the manifest with the spike number", async () => {
+		const {written} = await run(happy);
+		const parsed = parseManifest(written.get(MANIFEST) ?? "");
+		expect(parsed._tag === "Parsed" ? parsed.value.spike : null).toBe(SPIKE);
+	});
+});
+
+describe("runOpen refuses before it writes anything", () => {
+	it("refuses an off-vocabulary --kind on 10", async () => {
+		const {outcome, written} = await run(happy, {kind: "prototype"});
+		expect(outcome.code).toBe(OFF_VOCABULARY);
+		expect(outcome.stdout).toBe("");
+		expect(written.size).toBe(0);
+	});
+
+	it("refuses an off-grammar --nonce on 10", async () => {
+		const {outcome, written} = await run(happy, {nonce: "run-1"});
+		expect(outcome.code).toBe(OFF_VOCABULARY);
+		expect(outcome.stderr.join("\n")).toContain("minted by this verb");
+		expect(written.size).toBe(0);
+	});
+
+	it("refuses a workspace inside the repository on 13, with nothing written", async () => {
+		const {outcome, written} = await run(happy, {tmpRoot: "/repo/tmp"});
+		expect(outcome.code).toBe(WORKSPACE_IN_TREE);
+		expect(outcome.stdout).toBe("");
+		expect(written.size).toBe(0);
+	});
+
+	it("refuses a proven-absent label on 7 and names the bootstrap", async () => {
+		const {outcome, written} = await run([
+			[ROOT, okOut(`${TREE_ROOT}\n`)],
+			[LABELS, okOut("type:bug\n")],
+		]);
+		expect(outcome.code).toBe(ZERO_SCOPE);
+		expect(outcome.stderr.join("\n")).toContain("front-door");
+		expect(written.size).toBe(0);
+	});
+
+	it("refuses an unreadable label set on 11 — never as a proven absence", async () => {
+		const {outcome} = await run([
+			[ROOT, okOut(`${TREE_ROOT}\n`)],
+			[LABELS, errOut("gh: Bad gateway (HTTP 502)")],
+		]);
+		expect(outcome.code).toBe(READ_OR_EXEC_UNKNOWN);
+		expect(outcome.stderr.join("\n")).not.toContain("front-door");
+	});
+
+	it("refuses an unreadable tree on 11 — an unreadable tree is never clean", async () => {
+		const {outcome, written} = await run([
+			[ROOT, okOut(`${TREE_ROOT}\n`)],
+			[LABELS, okOut("prototyping:spike\n")],
+			[STATUS, errOut("fatal: not a git repository")],
+		]);
+		expect(outcome.code).toBe(READ_OR_EXEC_UNKNOWN);
+		expect(written.size).toBe(0);
+	});
+
+	it("refuses --nonce naming no workspace on 12", async () => {
+		const {outcome} = await run(happy, {nonce: "0badf00d"});
+		expect(outcome.code).toBe(NO_WORKSPACE);
+		expect(outcome.stderr.join("\n")).toContain("omit it to mint a new run");
+	});
+});
+
+describe("runOpen re-enters an existing workspace rather than minting a second issue", () => {
+	const resident: FakeFsOptions = {directories: [WORKSPACE], files: {[MANIFEST]: manifestText()}};
+
+	it("answers the existing manifest and creates nothing", async () => {
+		const {outcome, calls} = await run(happy, {nonce: NONCE}, resident);
+		expect(outcome.code).toBe(0);
+		expect(JSON.parse(outcome.stdout).spike).toBe(SPIKE);
+		expect(calls.filter((line) => CREATE.test(line))).toHaveLength(0);
+	});
+
+	it("refuses a workspace holding a different question on 18", async () => {
+		const {outcome} = await run(
+			happy,
+			{nonce: NONCE, question: "something else entirely"},
+			resident,
+		);
+		expect(outcome.code).toBe(WORKSPACE_MISMATCH);
+	});
+
+	it("refuses a workspace holding a different kind on 18", async () => {
+		const {outcome} = await run(happy, {nonce: NONCE, kind: "ui"}, resident);
+		expect(outcome.code).toBe(WORKSPACE_MISMATCH);
+	});
+
+	it("refuses a manifest that does not parse on 4, whole-file", async () => {
+		const {outcome} = await run(
+			happy,
+			{nonce: NONCE},
+			{
+				directories: [WORKSPACE],
+				files: {[MANIFEST]: "{}\n"},
+			},
+		);
+		expect(outcome.code).toBe(MALFORMED_RECORD);
+		expect(outcome.stderr.join("\n")).toContain("refusing the whole file");
+	});
+
+	it("completes a provisional manifest from the open spike whose body names this nonce", async () => {
+		const {outcome, written} = await run(
+			[
+				[ROOT, okOut(`${TREE_ROOT}\n`)],
+				[OPEN_SPIKES, okOut(`${SPIKE}\t${TITLE}\n`)],
+				[ISSUE, okOut(issuePayload({title: TITLE, body: BODY}))],
+			],
+			{nonce: NONCE},
+			{directories: [WORKSPACE], files: {[MANIFEST]: manifestText({spike: null})}},
+		);
+		expect(outcome.code).toBe(0);
+		expect(JSON.parse(outcome.stdout).spike).toBe(SPIKE);
+		expect(parseManifest(written.get(MANIFEST) ?? "")).toMatchObject({
+			_tag: "Parsed",
+			value: {spike: SPIKE},
+		});
+	});
+
+	it("refuses an unreadable open-spike listing on 11, leaving the manifest provisional", async () => {
+		const {outcome, written} = await run(
+			[
+				[ROOT, okOut(`${TREE_ROOT}\n`)],
+				[OPEN_SPIKES, errOut("gh: Bad gateway (HTTP 502)")],
+			],
+			{nonce: NONCE},
+			{directories: [WORKSPACE], files: {[MANIFEST]: manifestText({spike: null})}},
+		);
+		expect(outcome.code).toBe(READ_OR_EXEC_UNKNOWN);
+		expect(written.size).toBe(0);
+	});
+});
+
+describe("runOpen proves the issue landed as sent", () => {
+	it("seats an unproven create on 8", async () => {
+		const {outcome} = await run([
+			[ROOT, okOut(`${TREE_ROOT}\n`)],
+			[LABELS, okOut("prototyping:spike\n")],
+			[STATUS, okOut("")],
+			[CREATE, errOut("gh: Bad gateway (HTTP 502)")],
+		]);
+		expect(outcome.code).toBe(WRITE_UNKNOWN);
+		expect(outcome.stderr.join("\n")).toContain("may or may not have landed");
+	});
+
+	it("seats a body that does not read back as sent on 9", async () => {
+		const {outcome} = await run([
+			...happy.filter(([pattern]) => pattern !== ISSUE),
+			[ISSUE, okOut(issuePayload({title: TITLE, body: "somebody edited it"}))],
+		]);
+		expect(outcome.code).toBe(READBACK_MISMATCH);
+		expect(outcome.stderr.join("\n")).toContain("body");
+	});
+
+	it("seats a label that did not land on 9", async () => {
+		const {outcome} = await run([
+			...happy.filter(([pattern]) => pattern !== ISSUE),
+			[ISSUE, okOut(issuePayload({title: TITLE, body: BODY, labels: []}))],
+		]);
+		expect(outcome.code).toBe(READBACK_MISMATCH);
+		expect(outcome.stderr.join("\n")).toContain("labels");
+	});
+
+	it("seats a manifest that could not be completed on 20, naming both halves", async () => {
+		const {outcome} = await run(
+			[
+				[ROOT, okOut(`${TREE_ROOT}\n`)],
+				[OPEN_SPIKES, okOut(`${SPIKE}\t${TITLE}\n`)],
+				[ISSUE, okOut(issuePayload({title: TITLE, body: BODY}))],
+			],
+			{nonce: NONCE},
+			{
+				directories: [WORKSPACE],
+				files: {[MANIFEST]: manifestText({spike: null})},
+				unwritable: [MANIFEST],
+			},
+		);
+		expect(outcome.code).toBe(MANIFEST_INCOMPLETE);
+		expect(outcome.stdout).toBe("");
+		expect(outcome.stderr.join("\n")).toContain(`#${SPIKE}`);
+		expect(outcome.stderr.join("\n")).toContain(`--nonce ${NONCE}`);
+	});
+});

--- a/packages/fabrika-cli/src/spike/run-verb.ts
+++ b/packages/fabrika-cli/src/spike/run-verb.ts
@@ -1,0 +1,213 @@
+/**
+ * `spike run` — execute one command in the workspace and append an immutable evidence record.
+ *
+ * **Exit `0` means the command was executed and recorded, not that it succeeded.** The command's own
+ * status rides in the payload as `commandExit`, where a caller reads it as data. This is the one
+ * place in the group where the exit code and the answer are deliberately about different things: a
+ * prototype that ran and answered **no** is `0` with a non-zero `commandExit`, and a prototype that
+ * could not run is `11` and answers nothing. Those are opposite answers, and the shipped helpers make
+ * the correct shape the only constructible one — `answer` hardcodes code `0`, so a payload carrying
+ * `commandExit` cannot ride a non-zero code.
+ *
+ * **An absent evidence log is a fact** (`seq` 1), not a failed read. This verb surveys nothing, so it
+ * has no zero-scope case at all.
+ *
+ * **The child's environment is built, never inherited.** It receives `PATH`, `HOME`, `LANG`,
+ * `LC_ALL`, `TZ` and `TMPDIR`, plus every `--env` pair, plus `SPIKE_WORKSPACE`. Everything else is
+ * dropped, and naming a credential variable explicitly in `--env` is refused rather than honoured —
+ * a prototype is throwaway code nobody reviewed, so handing it the token that can write to the board
+ * would make this the widest hole in fabrika rather than its most bounded execution point.
+ *
+ * **The captured bytes are what is stored.** Streams are written first and the record line last, so a
+ * record never names files that do not exist, and `outBytes` counts what was stored rather than what
+ * the child produced — past the bound nothing further is read, so a pre-truncation total is not
+ * knowable and no field claims to hold one.
+ */
+
+import {Effect} from "effect";
+import type {ChildRunner} from "../io/exec.ts";
+import {appendText, writeBytes} from "../io/fs.ts";
+import {answer, FAILED, refuse, type VerbOutcome} from "../verb.ts";
+import {OFF_VOCABULARY, READ_OR_EXEC_UNKNOWN, WORKSPACE_IN_TREE} from "./codes.ts";
+import {nonceGrammar, readEvidence, readManifest, type SpikeEffect} from "./guards.ts";
+import {
+	CAPTURE_BYTES,
+	captureErrPath,
+	captureOutPath,
+	type EvidenceRecord,
+	evidencePath,
+	isInsideTree,
+	renderEvidenceLine,
+	sha256Of,
+	workspacePath,
+} from "./workspace.ts";
+
+export interface RunOptions {
+	readonly nonce: string;
+	readonly timeout: number;
+	/** `KEY=VALUE` pairs added to the scrubbed environment. */
+	readonly env: ReadonlyArray<string>;
+	/** The literal argv after `--`, taken as-is and never passed through a shell. */
+	readonly command: ReadonlyArray<string>;
+	readonly parentEnv: Readonly<Record<string, string | undefined>>;
+	readonly tmpRoot: string;
+	/** The execution seam, injected so a timeout and an unstartable binary are both testable. */
+	readonly spawn: ChildRunner;
+}
+
+const VERB = "spike run";
+
+/** The only parent variables a child inherits. Everything else is dropped, credentials included. */
+export const PASSED_THROUGH = ["PATH", "HOME", "LANG", "LC_ALL", "TZ", "TMPDIR"] as const;
+
+const ENV_PAIR_RE = /^([A-Za-z_][A-Za-z0-9_]*)=([\s\S]*)$/;
+
+/**
+ * Whether a variable name may not be handed to a prototype.
+ *
+ * A **generic** shape check, never a named deny-list: the point is that a credential cannot reach a
+ * child by any name that looks like one, and a list of the tokens we happen to know about would go
+ * stale the first time a new one is minted.
+ */
+export const isCredentialName = (name: string): boolean =>
+	name === "GH_TOKEN" ||
+	name === "GITHUB_TOKEN" ||
+	name.endsWith("_TOKEN") ||
+	name.endsWith("_SECRET") ||
+	name.endsWith("_KEY");
+
+/** The child's whole environment, or the name of the `--env` pair that is refused. */
+export const childEnv = (input: {
+	readonly parentEnv: Readonly<Record<string, string | undefined>>;
+	readonly pairs: ReadonlyArray<string>;
+	readonly workspace: string;
+}):
+	| {readonly _tag: "Env"; readonly env: Record<string, string>}
+	| {readonly _tag: "Refused"; readonly pair: string} => {
+	const env: Record<string, string> = {};
+	for (const name of PASSED_THROUGH) {
+		const value = input.parentEnv[name];
+		if (value !== undefined) env[name] = value;
+	}
+	for (const pair of input.pairs) {
+		const match = ENV_PAIR_RE.exec(pair);
+		if (match?.[1] === undefined || match[2] === undefined || isCredentialName(match[1])) {
+			return {_tag: "Refused", pair};
+		}
+		env[match[1]] = match[2];
+	}
+	env.SPIKE_WORKSPACE = input.workspace;
+	return {_tag: "Env", env};
+};
+
+export const runRun = (options: RunOptions): SpikeEffect<VerbOutcome> =>
+	Effect.gen(function* () {
+		const grammar = nonceGrammar(VERB, options.nonce, "");
+		if (grammar !== null) return grammar;
+		if (options.command.length === 0) {
+			return refuse(
+				FAILED,
+				`${VERB}: no command was given after -- — there is nothing to run and nothing to record.`,
+			);
+		}
+		if (!Number.isInteger(options.timeout) || options.timeout <= 0) {
+			return refuse(
+				OFF_VOCABULARY,
+				`${VERB}: --timeout "${options.timeout}" is not a positive integer.`,
+			);
+		}
+
+		const workspace = workspacePath(options.tmpRoot, options.nonce);
+		const manifest = yield* readManifest(
+			VERB,
+			workspace,
+			options.nonce,
+			"open a spike first, or this run was already disposed.",
+		);
+		if (manifest._tag === "Refused") return manifest.outcome;
+		if (isInsideTree(workspace, manifest.value.treeRoot)) {
+			return refuse(
+				WORKSPACE_IN_TREE,
+				`${VERB}: the workspace ${workspace} resolves inside the repository at ${manifest.value.treeRoot} — refusing to execute against the tree.`,
+			);
+		}
+
+		const evidence = yield* readEvidence(VERB, workspace);
+		if (evidence._tag === "Refused") return evidence.outcome;
+		const seq = evidence.value.records.length + 1;
+
+		const built = childEnv({
+			parentEnv: options.parentEnv,
+			pairs: options.env,
+			workspace,
+		});
+		if (built._tag === "Refused") {
+			return refuse(
+				OFF_VOCABULARY,
+				`${VERB}: --env "${built.pair}" is not KEY=VALUE, or names a credential variable a prototype may not receive.`,
+			);
+		}
+
+		const scope = `${VERB}: nonce ${options.nonce}, run ${seq}, ${options.command.length} argv token(s), timeout ${options.timeout}s.`;
+		const file = options.command[0] ?? "";
+		const outcome = yield* options.spawn({
+			file,
+			args: options.command.slice(1),
+			cwd: workspace,
+			env: built.env,
+			timeoutSeconds: options.timeout,
+			captureBytes: CAPTURE_BYTES,
+		});
+		if (outcome._tag === "Unstartable") {
+			return refuse(
+				READ_OR_EXEC_UNKNOWN,
+				`${VERB}: the command could not be executed: ${outcome.reason} — nothing was recorded, and this is NOT an answer of no.`,
+				[scope],
+			);
+		}
+
+		const wroteOut = yield* writeCapture(captureOutPath(workspace, seq), outcome.stdout);
+		const wroteErr =
+			wroteOut === null
+				? yield* writeCapture(captureErrPath(workspace, seq), outcome.stderr)
+				: null;
+		const writeFailure = wroteOut ?? wroteErr;
+		if (writeFailure !== null) {
+			return refuse(
+				READ_OR_EXEC_UNKNOWN,
+				`${VERB}: cannot write the capture files for run ${seq}: ${writeFailure} — nothing was appended.`,
+				[scope],
+			);
+		}
+
+		const record: EvidenceRecord = {
+			seq,
+			command: [...options.command],
+			commandExit: outcome.exitCode,
+			timedOut: outcome.timedOut,
+			outBytes: outcome.stdout.length,
+			errBytes: outcome.stderr.length,
+			truncated: outcome.truncated,
+			outSha256: sha256Of(outcome.stdout),
+			errSha256: sha256Of(outcome.stderr),
+		};
+		const appended = yield* appendText(evidencePath(workspace), renderEvidenceLine(record)).pipe(
+			Effect.map((): string | null => null),
+			Effect.catchTag("fabrika-cli/WriteFailed", (failure) => Effect.succeed(failure.reason)),
+		);
+		if (appended !== null) {
+			return refuse(
+				READ_OR_EXEC_UNKNOWN,
+				`${VERB}: cannot write the capture files for run ${seq}: ${appended} — nothing was appended.`,
+				[scope],
+			);
+		}
+
+		return answer(JSON.stringify({nonce: options.nonce, ...record}), [scope]);
+	});
+
+const writeCapture = (path: string, bytes: Uint8Array): SpikeEffect<string | null> =>
+	writeBytes(path, bytes).pipe(
+		Effect.map((): string | null => null),
+		Effect.catchTag("fabrika-cli/WriteFailed", (failure) => Effect.succeed(failure.reason)),
+	);

--- a/packages/fabrika-cli/src/spike/run-verb.unit.test.ts
+++ b/packages/fabrika-cli/src/spike/run-verb.unit.test.ts
@@ -1,0 +1,234 @@
+import {Effect, Layer} from "effect";
+import {describe, expect, it} from "vitest";
+import {type FakeFsOptions, fakeFs, fakeShell} from "../fakes.test-support.ts";
+import type {ChildOutcome, ChildRequest, ChildRunner} from "../io/exec.ts";
+import {
+	MALFORMED_RECORD,
+	NO_WORKSPACE,
+	OFF_VOCABULARY,
+	READ_OR_EXEC_UNKNOWN,
+	WORKSPACE_IN_TREE,
+} from "./codes.ts";
+import {
+	EVIDENCE,
+	evidenceRecord,
+	evidenceText,
+	MANIFEST,
+	manifestText,
+	NONCE,
+	ONE_RUN,
+	TMP_ROOT,
+	WORKSPACE,
+} from "./fixtures.test-support.ts";
+import {childEnv, isCredentialName, runRun} from "./run-verb.ts";
+import {parseEvidence, sha256OfText} from "./workspace.ts";
+
+const bytes = (text: string): Uint8Array => new TextEncoder().encode(text);
+
+const ran = (overrides: Partial<Extract<ChildOutcome, {_tag: "Ran"}>> = {}): ChildOutcome => ({
+	_tag: "Ran",
+	exitCode: 0,
+	timedOut: false,
+	stdout: bytes("no\n"),
+	stderr: bytes(""),
+	truncated: false,
+	...overrides,
+});
+
+const resident: FakeFsOptions = {directories: [WORKSPACE], files: {[MANIFEST]: manifestText()}};
+
+const options = {
+	nonce: NONCE,
+	timeout: 300,
+	env: [] as ReadonlyArray<string>,
+	command: ["printf", "no\\n"] as ReadonlyArray<string>,
+	parentEnv: {PATH: "/usr/bin", GH_TOKEN: "secret", HOME: "/home/agent"} as Record<
+		string,
+		string | undefined
+	>,
+	tmpRoot: TMP_ROOT,
+	spawn: ((_request: ChildRequest) => Effect.succeed(ran())) as ChildRunner,
+};
+
+const run = (overrides: Partial<typeof options> = {}, fs: FakeFsOptions = resident) => {
+	const disk = fakeFs(fs);
+	const requests: ChildRequest[] = [];
+	const spawn = (request: ChildRequest) => {
+		requests.push(request);
+		return (overrides.spawn ?? options.spawn)(request);
+	};
+	return Effect.runPromise(
+		Effect.provide(
+			runRun({...options, ...overrides, spawn}),
+			Layer.merge(disk.layer, fakeShell([]).layer),
+		),
+	).then((outcome) => ({outcome, written: disk.written, requests}));
+};
+
+describe("runRun records what happened, whatever the command returned", () => {
+	it("answers the record and seats it on exit 0", async () => {
+		const {outcome} = await run();
+		expect(outcome.code).toBe(0);
+		expect(JSON.parse(outcome.stdout)).toEqual({
+			nonce: NONCE,
+			seq: 1,
+			command: ["printf", "no\\n"],
+			commandExit: 0,
+			timedOut: false,
+			outBytes: 3,
+			errBytes: 0,
+			truncated: false,
+			outSha256: sha256OfText("no\n"),
+			errSha256: sha256OfText(""),
+		});
+	});
+
+	it("keeps `ran and answered no` at exit 0 with the status in the payload", async () => {
+		const {outcome} = await run({spawn: () => Effect.succeed(ran({exitCode: 1}))});
+		expect(outcome.code).toBe(0);
+		expect(JSON.parse(outcome.stdout).commandExit).toBe(1);
+	});
+
+	it("records a run that hung rather than losing it", async () => {
+		const {outcome} = await run({
+			spawn: () => Effect.succeed(ran({exitCode: null, timedOut: true})),
+		});
+		expect(outcome.code).toBe(0);
+		expect(JSON.parse(outcome.stdout)).toMatchObject({commandExit: null, timedOut: true});
+	});
+
+	it("records the truncation rather than letting it be silent", async () => {
+		const {outcome} = await run({spawn: () => Effect.succeed(ran({truncated: true}))});
+		expect(JSON.parse(outcome.stdout).truncated).toBe(true);
+	});
+
+	it("writes the capture files BEFORE the record, so no record names a missing file", async () => {
+		const {written} = await run();
+		const paths = [...written.keys()];
+		expect(paths).toContain(`${WORKSPACE}/runs/1.out`);
+		expect(paths).toContain(`${WORKSPACE}/runs/1.err`);
+		expect(paths.indexOf(EVIDENCE)).toBeGreaterThan(paths.indexOf(`${WORKSPACE}/runs/1.err`));
+	});
+
+	it("derives seq from the line count of an existing log", async () => {
+		const {outcome} = await run({}, {...resident, files: {...resident.files, [EVIDENCE]: ONE_RUN}});
+		expect(JSON.parse(outcome.stdout).seq).toBe(2);
+	});
+
+	it("appends a line that parses back as the record it answered", async () => {
+		const {written} = await run();
+		const parsed = parseEvidence(written.get(EVIDENCE) ?? "");
+		expect(parsed).toEqual({_tag: "Parsed", value: [evidenceRecord(1)]});
+	});
+});
+
+describe("runRun never fuses `could not run` with `ran and answered no`", () => {
+	it("seats an unstartable command on 11 with nothing appended", async () => {
+		const {outcome, written} = await run({
+			spawn: () => Effect.succeed({_tag: "Unstartable" as const, reason: "ENOENT"}),
+		});
+		expect(outcome.code).toBe(READ_OR_EXEC_UNKNOWN);
+		expect(outcome.stdout).toBe("");
+		expect(outcome.stderr.join("\n")).toContain("NOT an answer of no");
+		expect(written.size).toBe(0);
+	});
+
+	it("seats a capture file that could not be written on 11 with nothing appended", async () => {
+		const {outcome, written} = await run(
+			{},
+			{...resident, unwritable: [`${WORKSPACE}/runs/1.out`]},
+		);
+		expect(outcome.code).toBe(READ_OR_EXEC_UNKNOWN);
+		expect(written.has(EVIDENCE)).toBe(false);
+	});
+});
+
+describe("runRun refuses on the workspace before it spawns anything", () => {
+	it("seats an absent workspace on 12", async () => {
+		const {outcome, requests} = await run({}, {});
+		expect(outcome.code).toBe(NO_WORKSPACE);
+		expect(requests).toHaveLength(0);
+	});
+
+	it("seats a manifest that does not parse on 4", async () => {
+		const {outcome} = await run({}, {directories: [WORKSPACE], files: {[MANIFEST]: "{}\n"}});
+		expect(outcome.code).toBe(MALFORMED_RECORD);
+	});
+
+	it("seats a log that does not parse on 4", async () => {
+		const {outcome} = await run(
+			{},
+			{...resident, files: {...resident.files, [EVIDENCE]: "nope\n"}},
+		);
+		expect(outcome.code).toBe(MALFORMED_RECORD);
+	});
+
+	it("seats a log whose seq values are not contiguous on 4", async () => {
+		const {outcome} = await run(
+			{},
+			{...resident, files: {...resident.files, [EVIDENCE]: evidenceText([evidenceRecord(2)])}},
+		);
+		expect(outcome.code).toBe(MALFORMED_RECORD);
+	});
+
+	it("seats a workspace that resolves inside the tree on 13", async () => {
+		const {outcome, requests} = await run(
+			{},
+			{
+				directories: [WORKSPACE],
+				files: {[MANIFEST]: manifestText({treeRoot: TMP_ROOT})},
+			},
+		);
+		expect(outcome.code).toBe(WORKSPACE_IN_TREE);
+		expect(requests).toHaveLength(0);
+	});
+
+	it("treats an absent log as a fact — seq 1, not a refusal", async () => {
+		const {outcome} = await run();
+		expect(outcome.code).toBe(0);
+		expect(JSON.parse(outcome.stdout).seq).toBe(1);
+	});
+});
+
+describe("runRun refuses off-vocabulary values on 10", () => {
+	it.each([
+		["a non-positive --timeout", {timeout: 0}],
+		["a malformed --env pair", {env: ["not-a-pair"]}],
+		["an --env pair naming a credential", {env: ["ACME_TOKEN=secret"]}],
+		["an off-grammar --nonce", {nonce: "run-1"}],
+	])("refuses %s", async (_case, override) => {
+		const {outcome, requests} = await run(override as Partial<typeof options>);
+		expect(outcome.code).toBe(OFF_VOCABULARY);
+		expect(outcome.stdout).toBe("");
+		expect(requests).toHaveLength(0);
+	});
+});
+
+describe("the child's environment is built, never inherited", () => {
+	it("passes through only the six named variables plus SPIKE_WORKSPACE", async () => {
+		const {requests} = await run();
+		expect(requests[0]?.env).toEqual({
+			PATH: "/usr/bin",
+			HOME: "/home/agent",
+			SPIKE_WORKSPACE: WORKSPACE,
+		});
+	});
+
+	it("runs the child in the workspace", async () => {
+		const {requests} = await run();
+		expect(requests[0]?.cwd).toBe(WORKSPACE);
+	});
+
+	it("classifies a credential by shape, never by a named list that goes stale", () => {
+		expect(isCredentialName("GH_TOKEN")).toBe(true);
+		expect(isCredentialName("SOME_FUTURE_SECRET")).toBe(true);
+		expect(isCredentialName("ANY_API_KEY")).toBe(true);
+		expect(isCredentialName("PATH")).toBe(false);
+	});
+
+	it("refuses a credential named explicitly rather than honouring it", () => {
+		expect(
+			childEnv({parentEnv: {}, pairs: ["GITHUB_TOKEN=x"], workspace: WORKSPACE}),
+		).toMatchObject({_tag: "Refused"});
+	});
+});

--- a/packages/fabrika-cli/src/spike/spike.cli.test.ts
+++ b/packages/fabrika-cli/src/spike/spike.cli.test.ts
@@ -1,0 +1,55 @@
+/**
+ * The end-to-end half: the **exit status and the bytes on each channel** a shell caller reads.
+ *
+ * Only a subprocess proves those, and each `it` costs one cold node+TS load of `bin.ts` — so spawn
+ * count is this file's cost (`.patterns/subprocess-test-budget.md`). Two spawns, both about facts no
+ * in-process test can establish: that the group is reachable by its registration alone, and that a
+ * refusal really does leave stdout empty across the process boundary. Everything else about these
+ * verbs is covered in-process by the `*-verb.unit.test.ts` files beside them.
+ */
+import {execFileSync} from "node:child_process";
+import {fileURLToPath} from "node:url";
+import {describe, expect, it} from "vitest";
+import {SUBPROCESS_TEST_TIMEOUT_MS} from "../test-budget.ts";
+import {OFF_VOCABULARY} from "./codes.ts";
+
+const BIN = fileURLToPath(new URL("../bin.ts", import.meta.url));
+
+interface Run {
+	readonly code: number;
+	readonly stdout: string;
+	readonly stderr: string;
+}
+
+/** `FABRIKA_SKIP_INFER` pins the invocation to this copy rather than whatever the repo root installs. */
+const fabrika = (args: ReadonlyArray<string>, stdin = ""): Run => {
+	try {
+		const stdout = execFileSync(process.execPath, [BIN, ...args], {
+			encoding: "utf8",
+			env: {...process.env, FABRIKA_SKIP_INFER: "1"},
+			input: stdin,
+			stdio: ["pipe", "pipe", "pipe"],
+		});
+		return {code: 0, stdout, stderr: ""};
+	} catch (err) {
+		const failure = err as {status?: number; stdout?: string; stderr?: string};
+		return {code: failure.status ?? -1, stdout: failure.stdout ?? "", stderr: failure.stderr ?? ""};
+	}
+};
+
+describe("fabrika spike, end to end", {timeout: SUBPROCESS_TEST_TIMEOUT_MS}, () => {
+	it("lists all five verbs under --help by its registration alone", () => {
+		const run = fabrika(["spike", "--help"]);
+		expect(run.code).toBe(0);
+		for (const verb of ["open", "run", "capture", "dispose", "status"]) {
+			expect(run.stdout).toContain(verb);
+		}
+	});
+
+	it("refuses an off-grammar nonce on its own code with NOTHING on stdout", () => {
+		const run = fabrika(["spike", "status", "--nonce", "run-1", "--repo", "o/r"]);
+		expect(run.code).toBe(OFF_VOCABULARY);
+		expect(run.stdout).toBe("");
+		expect(run.stderr).toContain('spike status: --nonce "run-1" is not eight lowercase hex');
+	});
+});

--- a/packages/fabrika-cli/src/spike/status-verb.ts
+++ b/packages/fabrika-cli/src/spike/status-verb.ts
@@ -1,0 +1,178 @@
+/**
+ * `spike status` — one run's spike state, workspace presence, and evidence count.
+ *
+ * **Deliberately near-total: it reports per-field state inside exit `0` rather than refusing**,
+ * because its consumer is a session resuming cold, and a resuming session that gets a refusal learns
+ * nothing about where it is. So an absent workspace is a **fact** here (`workspace: "absent"`, every
+ * workspace-derived field `null`) while the same absence is a refusal (`12`) in the mutating verbs —
+ * two consumers, two correct treatments, and the asymmetry is stated rather than left to be "fixed".
+ *
+ * **The bound on that near-totality is ADR 0092.** `4` and `11` still refuse: a workspace that cannot
+ * be described is not "absent", and an unreadable state rendered as a plausible default is exactly the
+ * failure that rule exists to prevent.
+ *
+ * An **absent `evidence.jsonl` under a present workspace** yields `runs: 0`, `lastCommandExit: null`
+ * and `evidenceDigest: null`, also a fact: a log that was never written is not a log that hashes to
+ * the empty string.
+ */
+
+import {Effect} from "effect";
+import {getIssue, listComments} from "../io/issues.ts";
+import {answer, refuse, type VerbOutcome} from "../verb.ts";
+import {newestCapture} from "./bodies.ts";
+import {READ_OR_EXEC_UNKNOWN} from "./codes.ts";
+import {
+	nonceGrammar,
+	probe,
+	readEvidence,
+	readManifest,
+	readTree,
+	type SpikeEffect,
+	targetRepo,
+} from "./guards.ts";
+import {workspacePath} from "./workspace.ts";
+
+export interface StatusOptions {
+	readonly nonce: string;
+	readonly repo: string | null;
+	readonly env: Readonly<Record<string, string | undefined>>;
+	readonly tmpRoot: string;
+}
+
+const VERB = "spike status";
+
+const ABSENT_FIELDS = {
+	workspace: "absent",
+	spike: null,
+	kind: null,
+	question: null,
+	spikeState: null,
+	captured: false,
+	runs: null,
+	lastCommandExit: null,
+	evidenceDigest: null,
+	treeMatched: null,
+} as const;
+
+export const runStatus = (options: StatusOptions): SpikeEffect<VerbOutcome> =>
+	Effect.gen(function* () {
+		const grammar = nonceGrammar(VERB, options.nonce, "");
+		if (grammar !== null) return grammar;
+
+		const workspace = workspacePath(options.tmpRoot, options.nonce);
+		const present = yield* probe(VERB, "the workspace", workspace);
+		if (present._tag === "Refused") return present.outcome;
+		const scope = `${VERB}: nonce ${options.nonce}, workspace ${present.value ? "present" : "absent"}.`;
+		if (!present.value) {
+			return answer(JSON.stringify({nonce: options.nonce, ...ABSENT_FIELDS}), [scope]);
+		}
+
+		const manifest = yield* readManifest(
+			VERB,
+			workspace,
+			options.nonce,
+			"it was disposed between the probe and the read.",
+		);
+		if (manifest._tag === "Refused") return manifest.outcome;
+		const evidence = yield* readEvidence(VERB, workspace);
+		if (evidence._tag === "Refused") return evidence.outcome;
+		const last = evidence.value.records[evidence.value.records.length - 1];
+
+		const tree = yield* readTree(VERB, manifest.value.treeRoot);
+		if (tree._tag === "Refused") return tree.outcome;
+
+		const state = yield* spikeState(manifest.value.spike, options);
+		if (state._tag === "Refused") return state.outcome;
+
+		return answer(
+			JSON.stringify({
+				nonce: options.nonce,
+				workspace: "present",
+				spike: manifest.value.spike,
+				kind: manifest.value.kind,
+				question: manifest.value.question,
+				spikeState: state.value.spikeState,
+				captured: state.value.captured,
+				runs: evidence.value.records.length,
+				lastCommandExit: last?.commandExit ?? null,
+				evidenceDigest: evidence.value.digest,
+				treeMatched: tree.value.digest === manifest.value.treeDigest,
+			}),
+			[scope, ...state.value.notes],
+		);
+	});
+
+interface SpikeState {
+	readonly spikeState: string | null;
+	readonly captured: boolean;
+	readonly notes: ReadonlyArray<string>;
+}
+
+type Resolved =
+	| {readonly _tag: "Ok"; readonly value: SpikeState}
+	| {readonly _tag: "Refused"; readonly outcome: VerbOutcome};
+
+/**
+ * The issue half of the answer.
+ *
+ * A **provisional** manifest names no spike, so there is nothing to read and `spikeState` is `null`.
+ * A spike that is **proven absent** is also reported as `null` rather than refused — this verb holds
+ * no `7` seat and its consumer cannot act on a refusal — but the stderr note says which of the two it
+ * was, so the proven case is never silently indistinguishable from "no spike named". A read that
+ * *failed* is `11`, as everywhere else in this group.
+ */
+const spikeState = (spike: number | null, options: StatusOptions): SpikeEffect<Resolved> =>
+	Effect.gen(function* () {
+		if (spike === null) {
+			return {
+				_tag: "Ok" as const,
+				value: {
+					spikeState: null,
+					captured: false,
+					notes: [`${VERB}: the manifest is provisional and names no spike.`],
+				},
+			};
+		}
+		const target = yield* targetRepo(VERB, options.repo, options.env);
+		if (target._tag === "Refused") return {_tag: "Refused" as const, outcome: target.outcome};
+		const repo = target.value;
+
+		const issue = yield* getIssue(repo, spike);
+		if (issue._tag === "Unknown") {
+			return {
+				_tag: "Refused" as const,
+				outcome: refuse(
+					READ_OR_EXEC_UNKNOWN,
+					`${VERB}: cannot read spike #${spike}: ${issue.reason} — the state is UNKNOWN, never reported as a default.`,
+				),
+			};
+		}
+		if (issue._tag === "Absent") {
+			return {
+				_tag: "Ok" as const,
+				value: {
+					spikeState: null,
+					captured: false,
+					notes: [`${VERB}: spike #${spike} is proven absent on ${repo}.`],
+				},
+			};
+		}
+		const comments = yield* listComments(repo, spike);
+		if (comments._tag === "Failure") {
+			return {
+				_tag: "Refused" as const,
+				outcome: refuse(
+					READ_OR_EXEC_UNKNOWN,
+					`${VERB}: cannot read the comments of spike #${spike}: ${comments.reason} — the state is UNKNOWN, never reported as a default.`,
+				),
+			};
+		}
+		return {
+			_tag: "Ok" as const,
+			value: {
+				spikeState: issue.value.state === "closed" ? "closed" : "open",
+				captured: newestCapture(comments.value, options.nonce) !== null,
+				notes: [`${VERB}: ${comments.value.length} comment(s) scanned on #${spike}.`],
+			},
+		};
+	});

--- a/packages/fabrika-cli/src/spike/status-verb.unit.test.ts
+++ b/packages/fabrika-cli/src/spike/status-verb.unit.test.ts
@@ -1,0 +1,181 @@
+import {Effect, Layer} from "effect";
+import {describe, expect, it} from "vitest";
+import {errOut, type FakeFsOptions, fakeFs, fakeShell, okOut} from "../fakes.test-support.ts";
+import type {ExecResult} from "../io/exec.ts";
+import {captureMarker} from "./bodies.ts";
+import {MALFORMED_RECORD, OFF_VOCABULARY, READ_OR_EXEC_UNKNOWN} from "./codes.ts";
+import {
+	COMMENTS,
+	commentsPayload,
+	ENV,
+	EVIDENCE,
+	ISSUE,
+	issuePayload,
+	MANIFEST,
+	manifestText,
+	NONCE,
+	ONE_RUN,
+	ONE_RUN_DIGEST,
+	QUESTION,
+	SPIKE,
+	STATUS,
+	TMP_ROOT,
+	WORKSPACE,
+} from "./fixtures.test-support.ts";
+import {runStatus} from "./status-verb.ts";
+
+const resident: FakeFsOptions = {
+	directories: [WORKSPACE],
+	files: {[MANIFEST]: manifestText(), [EVIDENCE]: ONE_RUN},
+};
+
+const options = {nonce: NONCE, repo: null as string | null, env: ENV, tmpRoot: TMP_ROOT};
+
+const happy: ReadonlyArray<readonly [RegExp, ExecResult]> = [
+	[STATUS, okOut("")],
+	[ISSUE, okOut(issuePayload())],
+	[COMMENTS, okOut(commentsPayload([]))],
+];
+
+const run = (
+	script: ReadonlyArray<readonly [RegExp, ExecResult]>,
+	overrides: Partial<typeof options> = {},
+	fs: FakeFsOptions = resident,
+) =>
+	Effect.runPromise(
+		Effect.provide(
+			runStatus({...options, ...overrides}),
+			Layer.merge(fakeFs(fs).layer, fakeShell(script).layer),
+		),
+	);
+
+describe("runStatus reports per-field state inside exit 0", () => {
+	it("answers the whole state of a live run", async () => {
+		const outcome = await run(happy);
+		expect(outcome.code).toBe(0);
+		expect(JSON.parse(outcome.stdout)).toEqual({
+			nonce: NONCE,
+			workspace: "present",
+			spike: SPIKE,
+			kind: "logic",
+			question: QUESTION,
+			spikeState: "open",
+			captured: false,
+			runs: 1,
+			lastCommandExit: 0,
+			evidenceDigest: ONE_RUN_DIGEST,
+			treeMatched: true,
+		});
+	});
+
+	it("reports an absent workspace as a FACT, every derived field null", async () => {
+		const outcome = await run([], {}, {});
+		expect(outcome.code).toBe(0);
+		expect(JSON.parse(outcome.stdout)).toEqual({
+			nonce: NONCE,
+			workspace: "absent",
+			spike: null,
+			kind: null,
+			question: null,
+			spikeState: null,
+			captured: false,
+			runs: null,
+			lastCommandExit: null,
+			evidenceDigest: null,
+			treeMatched: null,
+		});
+	});
+
+	it("distinguishes a log that was never written from one that hashes empty", async () => {
+		const outcome = await run(
+			happy,
+			{},
+			{directories: [WORKSPACE], files: {[MANIFEST]: manifestText()}},
+		);
+		expect(JSON.parse(outcome.stdout)).toMatchObject({
+			runs: 0,
+			lastCommandExit: null,
+			evidenceDigest: null,
+		});
+	});
+
+	it("reports a captured spike", async () => {
+		const outcome = await run([
+			[STATUS, okOut("")],
+			[ISSUE, okOut(issuePayload({state: "closed"}))],
+			[COMMENTS, okOut(commentsPayload([{id: 1, body: captureMarker(NONCE, ONE_RUN_DIGEST)}]))],
+		]);
+		expect(JSON.parse(outcome.stdout)).toMatchObject({spikeState: "closed", captured: true});
+	});
+
+	it("reports treeMatched as information, never as a verdict", async () => {
+		const outcome = await run([
+			[STATUS, okOut("?? probe.ts\n")],
+			[ISSUE, okOut(issuePayload())],
+			[COMMENTS, okOut(commentsPayload([]))],
+		]);
+		expect(outcome.code).toBe(0);
+		expect(JSON.parse(outcome.stdout).treeMatched).toBe(false);
+	});
+
+	it("reads no spike state at all from a provisional manifest", async () => {
+		const outcome = await run(
+			[[STATUS, okOut("")]],
+			{},
+			{
+				directories: [WORKSPACE],
+				files: {[MANIFEST]: manifestText({spike: null}), [EVIDENCE]: ONE_RUN},
+			},
+		);
+		expect(outcome.code).toBe(0);
+		expect(JSON.parse(outcome.stdout)).toMatchObject({spike: null, spikeState: null});
+	});
+});
+
+describe("the near-totality is bounded by ADR 0092", () => {
+	it("refuses a manifest that does not parse on 4 — that is not `absent`", async () => {
+		const outcome = await run(happy, {}, {directories: [WORKSPACE], files: {[MANIFEST]: "{}\n"}});
+		expect(outcome.code).toBe(MALFORMED_RECORD);
+		expect(outcome.stdout).toBe("");
+	});
+
+	it("refuses a log that does not parse on 4", async () => {
+		const outcome = await run(
+			happy,
+			{},
+			{...resident, files: {...resident.files, [EVIDENCE]: "nope\n"}},
+		);
+		expect(outcome.code).toBe(MALFORMED_RECORD);
+	});
+
+	it("refuses an unreadable spike state on 11 rather than reporting a default", async () => {
+		const outcome = await run([
+			[STATUS, okOut("")],
+			[ISSUE, errOut("gh: Bad gateway (HTTP 502)")],
+		]);
+		expect(outcome.code).toBe(READ_OR_EXEC_UNKNOWN);
+		expect(outcome.stdout).toBe("");
+	});
+
+	it("refuses an unreadable tree on 11", async () => {
+		const outcome = await run([[STATUS, errOut("fatal: not a git repository")]]);
+		expect(outcome.code).toBe(READ_OR_EXEC_UNKNOWN);
+	});
+
+	it("refuses an off-grammar nonce on 10", async () => {
+		const outcome = await run(happy, {nonce: "run-1"});
+		expect(outcome.code).toBe(OFF_VOCABULARY);
+	});
+});
+
+describe("a proven-absent spike is reported, never fused with an unreadable one", () => {
+	it("names it on stderr and leaves the state null at exit 0", async () => {
+		const outcome = await run([
+			[STATUS, okOut("")],
+			[ISSUE, errOut("gh: Not Found (HTTP 404)")],
+		]);
+		expect(outcome.code).toBe(0);
+		expect(JSON.parse(outcome.stdout).spikeState).toBeNull();
+		expect(outcome.stderr.join("\n")).toContain("proven absent");
+	});
+});

--- a/packages/fabrika-cli/src/spike/workspace.ts
+++ b/packages/fabrika-cli/src/spike/workspace.ts
@@ -1,0 +1,277 @@
+/**
+ * The workspace grammar, the two records that live in it, and the two digests taken over them —
+ * pure, so two implementers compute one number and a test can assert every violation without a disk.
+ *
+ * The path is keyed on the **nonce alone**: no session segment, no issue segment, no pid. Two
+ * concurrent spikes carry different minted nonces and therefore different directories, which is the
+ * whole of the collision answer (#4544, #4516, #3607, #5028).
+ *
+ * **Both digests are defined byte-exactly here** because they are compared across runs and across
+ * processes: `treeDigest` decides whether a throwaway stayed thrown away, and `evidenceDigest`
+ * decides whether a captured decision still covers the log. A digest whose input is "however this
+ * implementation happened to serialize it" cannot answer either question twice the same way.
+ */
+
+import {createHash} from "node:crypto";
+import {join, sep} from "node:path";
+
+/** The one directory segment under the OS temp root that every workspace sits beneath. */
+export const WORKSPACE_ROOT = "fabrika-spike";
+
+/** The capture bound per stream, in bytes. Past it capture stops and the record says `truncated`. */
+export const CAPTURE_BYTES = 1024 * 1024;
+
+/** The nonce grammar: eight lowercase hex, minted by `spike open` and an argument everywhere else. */
+export const NONCE_RE = /^[0-9a-f]{8}$/;
+
+export const isNonce = (value: string): boolean => NONCE_RE.test(value);
+
+/** The two ruled artifact shapes (#5017). */
+export const KINDS = ["logic", "ui"] as const;
+export type Kind = (typeof KINDS)[number];
+
+export const isKind = (value: string): value is Kind =>
+	(KINDS as ReadonlyArray<string>).includes(value);
+
+/** `<tmpRoot>/fabrika-spike/<nonce>`. Both callers pass a **physically resolved** temp root. */
+export const workspacePath = (tmpRoot: string, nonce: string): string =>
+	join(tmpRoot, WORKSPACE_ROOT, nonce);
+
+export const manifestPath = (workspace: string): string => join(workspace, "spike.json");
+export const evidencePath = (workspace: string): string => join(workspace, "evidence.jsonl");
+export const captureOutPath = (workspace: string, seq: number): string =>
+	join(workspace, "runs", `${seq}.out`);
+export const captureErrPath = (workspace: string, seq: number): string =>
+	join(workspace, "runs", `${seq}.err`);
+
+/**
+ * Whether the workspace resolves inside the repository working tree.
+ *
+ * Both arguments must already be **physically** resolved — symlinks followed, `.` and `..` folded.
+ * On macOS `/tmp` is a symlink to `/private/tmp`, so a lexical test gives a different answer than a
+ * resolved one, and a repository checked out under the temp root would pass a lexical test while
+ * sitting inside the very tree the digest measures.
+ */
+export const isInsideTree = (workspace: string, treeRoot: string): boolean =>
+	workspace === treeRoot || workspace.startsWith(`${treeRoot}${sep}`);
+
+/** The workspace manifest: written by `spike open`, never rewritten once it is completed. */
+export interface Manifest {
+	readonly spike: number | null;
+	readonly nonce: string;
+	readonly kind: Kind;
+	readonly question: string;
+	readonly repo: string;
+	readonly ticket: number | null;
+	readonly treeDigest: string;
+	readonly treeRoot: string;
+}
+
+/** The manifest's keys, in the order it is written. Extra or missing keys are both violations. */
+export const MANIFEST_KEYS: ReadonlyArray<keyof Manifest> = [
+	"spike",
+	"nonce",
+	"kind",
+	"question",
+	"repo",
+	"ticket",
+	"treeDigest",
+	"treeRoot",
+];
+
+export type Parsed<A> =
+	| {readonly _tag: "Parsed"; readonly value: A}
+	| {readonly _tag: "Malformed"; readonly reason: string};
+
+const malformed = <A>(reason: string): Parsed<A> => ({_tag: "Malformed", reason});
+const parsed = <A>(value: A): Parsed<A> => ({_tag: "Parsed", value});
+
+const DIGEST_RE = /^[0-9a-f]{64}$/;
+
+const asRecord = (text: string): Record<string, unknown> | null => {
+	try {
+		const value: unknown = JSON.parse(text);
+		return typeof value === "object" && value !== null && !Array.isArray(value)
+			? (value as Record<string, unknown>)
+			: null;
+	} catch {
+		return null;
+	}
+};
+
+/** The manifest, or the **first** violation — the whole file is refused either way. */
+export const parseManifest = (text: string): Parsed<Manifest> => {
+	const record = asRecord(text);
+	if (record === null) return malformed("it is not a JSON object");
+	for (const key of MANIFEST_KEYS) {
+		if (!Object.hasOwn(record, key)) return malformed(`the key "${key}" is missing`);
+	}
+	const extra = Object.keys(record).find(
+		(key) => !(MANIFEST_KEYS as ReadonlyArray<string>).includes(key),
+	);
+	if (extra !== undefined) return malformed(`it carries an unexpected key "${extra}"`);
+	const {spike, nonce, kind, question, repo, ticket, treeDigest, treeRoot} = record;
+	if (spike !== null && !Number.isInteger(spike))
+		return malformed('"spike" is not an integer or null');
+	if (typeof nonce !== "string" || !isNonce(nonce)) {
+		return malformed('"nonce" is not eight lowercase hex characters');
+	}
+	if (typeof kind !== "string" || !isKind(kind)) return malformed('"kind" is not logic or ui');
+	if (typeof question !== "string") return malformed('"question" is not a string');
+	if (typeof repo !== "string") return malformed('"repo" is not a string');
+	if (ticket !== null && !Number.isInteger(ticket)) {
+		return malformed('"ticket" is not an integer or null');
+	}
+	if (typeof treeDigest !== "string" || !DIGEST_RE.test(treeDigest)) {
+		return malformed('"treeDigest" is not 64 lowercase hex characters');
+	}
+	if (typeof treeRoot !== "string") return malformed('"treeRoot" is not a string');
+	return parsed({
+		spike: spike as number | null,
+		nonce,
+		kind,
+		question,
+		repo,
+		ticket: ticket as number | null,
+		treeDigest,
+		treeRoot,
+	});
+};
+
+/** The manifest as it is written: the keys in {@link MANIFEST_KEYS} order, one trailing newline. */
+export const renderManifest = (manifest: Manifest): string => {
+	const ordered: Record<string, unknown> = {};
+	for (const key of MANIFEST_KEYS) ordered[key] = manifest[key];
+	return `${JSON.stringify(ordered)}\n`;
+};
+
+/** One appended run record. The serialization is pinned: `evidenceDigest` is taken over these bytes. */
+export interface EvidenceRecord {
+	readonly seq: number;
+	readonly command: ReadonlyArray<string>;
+	readonly commandExit: number | null;
+	readonly timedOut: boolean;
+	readonly outBytes: number;
+	readonly errBytes: number;
+	readonly truncated: boolean;
+	readonly outSha256: string;
+	readonly errSha256: string;
+}
+
+/** The record's keys, in exactly the order every line is serialized in. */
+export const EVIDENCE_KEYS: ReadonlyArray<keyof EvidenceRecord> = [
+	"seq",
+	"command",
+	"commandExit",
+	"timedOut",
+	"outBytes",
+	"errBytes",
+	"truncated",
+	"outSha256",
+	"errSha256",
+];
+
+/** One line: the keys in order, no whitespace between tokens, a single `\n`. */
+export const renderEvidenceLine = (record: EvidenceRecord): string => {
+	const ordered: Record<string, unknown> = {};
+	for (const key of EVIDENCE_KEYS) ordered[key] = record[key];
+	return `${JSON.stringify(ordered)}\n`;
+};
+
+const parseEvidenceRecord = (value: Record<string, unknown>): Parsed<EvidenceRecord> => {
+	for (const key of EVIDENCE_KEYS) {
+		if (!Object.hasOwn(value, key)) return malformed(`the key "${key}" is missing`);
+	}
+	const {seq, command, commandExit, timedOut, outBytes, errBytes, truncated, outSha256, errSha256} =
+		value;
+	if (!Number.isInteger(seq) || (seq as number) < 1)
+		return malformed('"seq" is not a positive integer');
+	if (!Array.isArray(command) || command.some((part) => typeof part !== "string")) {
+		return malformed('"command" is not an array of strings');
+	}
+	if (commandExit !== null && !Number.isInteger(commandExit)) {
+		return malformed('"commandExit" is not an integer or null');
+	}
+	if (typeof timedOut !== "boolean") return malformed('"timedOut" is not a boolean');
+	if (!Number.isInteger(outBytes) || !Number.isInteger(errBytes)) {
+		return malformed('"outBytes" or "errBytes" is not an integer');
+	}
+	if (typeof truncated !== "boolean") return malformed('"truncated" is not a boolean');
+	if (typeof outSha256 !== "string" || !DIGEST_RE.test(outSha256)) {
+		return malformed('"outSha256" is not 64 lowercase hex characters');
+	}
+	if (typeof errSha256 !== "string" || !DIGEST_RE.test(errSha256)) {
+		return malformed('"errSha256" is not 64 lowercase hex characters');
+	}
+	return parsed({
+		seq: seq as number,
+		command: command as ReadonlyArray<string>,
+		commandExit: commandExit as number | null,
+		timedOut,
+		outBytes: outBytes as number,
+		errBytes: errBytes as number,
+		truncated,
+		outSha256,
+		errSha256,
+	});
+};
+
+/**
+ * The whole log, or the first violation.
+ *
+ * A file that is **absent** never reaches here: an absent log is `seq` 1 and a **fact**, while a log
+ * that exists and cannot be read is a refusal. The two are decided by the caller's probe, not by an
+ * empty string arriving here.
+ */
+export const parseEvidence = (text: string): Parsed<ReadonlyArray<EvidenceRecord>> => {
+	const lines = text.split("\n");
+	if (lines[lines.length - 1] === "") lines.pop();
+	const records: EvidenceRecord[] = [];
+	for (const [index, line] of lines.entries()) {
+		const record = asRecord(line);
+		if (record === null) return malformed(`line ${index + 1} does not parse`);
+		const one = parseEvidenceRecord(record);
+		if (one._tag === "Malformed") return malformed(`line ${index + 1}: ${one.reason}`);
+		if (one.value.seq !== index + 1) {
+			return malformed(
+				`line ${index + 1} carries seq ${one.value.seq} — the log is not contiguous from 1`,
+			);
+		}
+		records.push(one.value);
+	}
+	return parsed(records);
+};
+
+/** SHA-256 of `bytes`, as 64 lowercase hex. */
+export const sha256Of = (bytes: Uint8Array): string =>
+	createHash("sha256").update(bytes).digest("hex");
+
+/** SHA-256 of `text`'s UTF-8 bytes, as 64 lowercase hex. */
+export const sha256OfText = (text: string): string => sha256Of(new TextEncoder().encode(text));
+
+/** What zero bytes digest to — a clean tree's `treeDigest`, and an empty stream's. */
+export const EMPTY_SHA256 = sha256OfText("");
+
+/**
+ * `treeDigest` over `git status --porcelain=v1 --untracked-files=all --ignored=matching`'s output.
+ *
+ * Split on `\n`, drop the trailing empty element, sort byte-wise ascending, join with a `\n` after
+ * **each** line, and digest that text's UTF-8 bytes. An empty set therefore yields the empty string
+ * and digests to {@link EMPTY_SHA256}.
+ */
+export const treeDigestOf = (statusOutput: string): string => {
+	const lines = statusOutput.split("\n");
+	if (lines[lines.length - 1] === "") lines.pop();
+	const sorted = [...lines].sort((a, b) => (a < b ? -1 : a > b ? 1 : 0));
+	return sha256OfText(sorted.map((line) => `${line}\n`).join(""));
+};
+
+/** The status lines that differ between two readings of the same tree — what a `17` enumerates. */
+export const differingStatusLines = (statusOutput: string): ReadonlyArray<string> => {
+	const lines = statusOutput.split("\n");
+	if (lines[lines.length - 1] === "") lines.pop();
+	return [...lines].sort((a, b) => (a < b ? -1 : a > b ? 1 : 0));
+};
+
+/** `evidenceDigest` — the SHA-256 of `evidence.jsonl`'s bytes exactly as they sit on disk. */
+export const evidenceDigestOf = (logText: string): string => sha256OfText(logText);

--- a/packages/fabrika-cli/src/spike/workspace.unit.test.ts
+++ b/packages/fabrika-cli/src/spike/workspace.unit.test.ts
@@ -1,0 +1,115 @@
+import {describe, expect, it} from "vitest";
+import {
+	evidenceRecord,
+	manifest,
+	manifestText,
+	ONE_RUN,
+	ONE_RUN_DIGEST,
+} from "./fixtures.test-support.ts";
+import {
+	EMPTY_SHA256,
+	evidenceDigestOf,
+	isInsideTree,
+	isNonce,
+	parseEvidence,
+	parseManifest,
+	renderEvidenceLine,
+	renderManifest,
+	treeDigestOf,
+	workspacePath,
+} from "./workspace.ts";
+
+describe("the workspace path is keyed on the nonce alone", () => {
+	it("puts two concurrent runs in two directories", () => {
+		expect(workspacePath("/tmp", "7f3a9c21")).toBe("/tmp/fabrika-spike/7f3a9c21");
+		expect(workspacePath("/tmp", "0badf00d")).not.toBe(workspacePath("/tmp", "7f3a9c21"));
+	});
+
+	it("admits only eight lowercase hex as a nonce", () => {
+		expect(isNonce("7f3a9c21")).toBe(true);
+		expect(isNonce("7F3A9C21")).toBe(false);
+		expect(isNonce("run-1")).toBe(false);
+		expect(isNonce("7f3a9c2")).toBe(false);
+	});
+});
+
+describe("the in-tree test compares resolved paths", () => {
+	it("refuses a workspace at the tree root and under it", () => {
+		expect(isInsideTree("/repo", "/repo")).toBe(true);
+		expect(isInsideTree("/repo/tmp/fabrika-spike/7f3a9c21", "/repo")).toBe(true);
+	});
+
+	it("admits a sibling whose name merely starts with the root", () => {
+		expect(isInsideTree("/repo-two/fabrika-spike/7f3a9c21", "/repo")).toBe(false);
+	});
+});
+
+describe("the manifest is refused whole-file", () => {
+	it("round-trips a well-formed one", () => {
+		const parsed = parseManifest(manifestText());
+		expect(parsed).toEqual({_tag: "Parsed", value: manifest()});
+	});
+
+	it.each([
+		["a missing key", '{"nonce":"7f3a9c21"}'],
+		["an extra key", renderManifest(manifest()).replace(/}\n$/, ',"extra":1}\n')],
+		["an off-enum kind", manifestText().replace('"logic"', '"prototype"')],
+		["an off-grammar nonce", manifestText().replace('"7f3a9c21"', '"run-1"')],
+		["text that is not JSON", "not json\n"],
+	])("refuses %s", (_case, text) => {
+		expect(parseManifest(text)._tag).toBe("Malformed");
+	});
+
+	it("admits the provisional window, where the spike is null", () => {
+		expect(parseManifest(manifestText({spike: null}))._tag).toBe("Parsed");
+	});
+});
+
+describe("the evidence log is pinned, so its digest is reproducible", () => {
+	it("serializes the keys in one order with no whitespace", () => {
+		expect(renderEvidenceLine(evidenceRecord(1))).toBe(
+			`{"seq":1,"command":["printf","no\\\\n"],"commandExit":0,"timedOut":false,"outBytes":3,"errBytes":0,"truncated":false,"outSha256":"${evidenceRecord(1).outSha256}","errSha256":"${EMPTY_SHA256}"}\n`,
+		);
+	});
+
+	it("digests exactly the bytes on disk", () => {
+		expect(evidenceDigestOf(ONE_RUN)).toBe(ONE_RUN_DIGEST);
+	});
+
+	it("reads a two-line log", () => {
+		const text = [evidenceRecord(1), evidenceRecord(2)].map(renderEvidenceLine).join("");
+		const parsed = parseEvidence(text);
+		expect(parsed._tag).toBe("Parsed");
+		expect(parsed._tag === "Parsed" ? parsed.value.length : 0).toBe(2);
+	});
+
+	it.each([
+		["a line that does not parse", "not json\n"],
+		[
+			"seq values that are not contiguous from 1",
+			[evidenceRecord(1), evidenceRecord(3)].map(renderEvidenceLine).join(""),
+		],
+		["a missing key", '{"seq":1}\n'],
+	])("refuses %s", (_case, text) => {
+		expect(parseEvidence(text)._tag).toBe("Malformed");
+	});
+
+	it("reads an empty log as zero records — the caller decides absent versus empty", () => {
+		expect(parseEvidence("")).toEqual({_tag: "Parsed", value: []});
+	});
+});
+
+describe("treeDigest is defined so two implementers compute one number", () => {
+	it("digests a clean tree to the SHA-256 of zero bytes", () => {
+		expect(treeDigestOf("")).toBe(EMPTY_SHA256);
+		expect(EMPTY_SHA256).toBe("e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855");
+	});
+
+	it("sorts byte-wise, so line order out of git cannot move the digest", () => {
+		expect(treeDigestOf("?? b\n?? a\n")).toBe(treeDigestOf("?? a\n?? b\n"));
+	});
+
+	it("moves the moment one ignored path appears", () => {
+		expect(treeDigestOf("!! node_modules/\n")).not.toBe(EMPTY_SHA256);
+	});
+});


### PR DESCRIPTION
Fixes #5024

Implements the five verbs [`claude-plugins/fabrika/skills/prototyping/contract.md`](claude-plugins/fabrika/skills/prototyping/contract.md) specifies, as the `spike` group in `packages/fabrika-cli/src/spike/`.

| Verb | What it proves |
|---|---|
| `spike open` | the workspace path is outside the tree, the `prototyping:spike` label exists, the issue read back as sent, and the manifest names it |
| `spike run` | the command **was executed and recorded** — exit `0` whatever it returned — or, on `11`, that it could not be executed and nothing was appended |
| `spike capture` | the log holds at least one recorded run, the author holds `write`, and the posted comment reads back as sent |
| `spike dispose` | the tree matches what `open` recorded, the capture still covers the log, and the workspace is gone on re-probe |
| `spike status` | one run's state, near-total: an absent workspace is a fact at exit `0` |

## The exit table

`packages/fabrika-cli/src/spike/codes.ts` re-exports all nine of the base's seats under this group's own names — no `DELIBERATE_GAP` — and adds `12`–`21`.

| Code | Export | Meaning |
|---|---|---|
| `3` | `EMPTY_STDIN` | stdin was read and held nothing |
| `4` | `MALFORMED_RECORD` | the manifest or the evidence log exists and does not parse |
| `5` | `LEAKED_PATH` | the authored text carries a machine-local path |
| `6` | `BARE_AT_PATH` | the authored text is a bare `@` reference |
| `7` | `ZERO_SCOPE` | proven absent: the spike, or the label |
| `8` | `WRITE_UNKNOWN` | a write was attempted and its outcome is UNKNOWN |
| `9` | `READBACK_MISMATCH` | the write landed and does not read back as sent |
| `10` | `OFF_VOCABULARY` | a value off its closed vocabulary or grammar |
| `11` | `READ_OR_EXEC_UNKNOWN` | a required read **or execution** failed; nothing was written |
| `12`–`21` | `NO_WORKSPACE`, `WORKSPACE_IN_TREE`, `NO_EVIDENCE`, `NOT_CAPTURED`, `REMOVAL_UNPROVEN`, `TREE_MOVED`, `WORKSPACE_MISMATCH`, `AUTHOR_UNAUTHORIZED`, `MANIFEST_INCOMPLETE`, `CAPTURE_STALE` | facts about a throwaway workspace |

The three-way distinction the group is built around: `1`/`127` is *the call never decided*, `11` is *a read or an execution failed and nothing was written*, and every code at `3`+ is something a verb **proved**, with nothing on stdout.

`SPIKE_SEATS` registers in `src/exit-code-alignment.ts`'s `ALIGNED_GROUPS`, and `spike` joins that file's unit-test `TABLES` map. Two seat names differ from the base deliberately and say why in the module: `MALFORMED_RECORD` reads the base's section fact over a whole on-disk record, and `READ_OR_EXEC_UNKNOWN` is a documented **superset** — it also covers a child that could not be executed, which is an attempt rather than a read.

## Shared registration edits — all insertion-only

- `src/registry.ts` — one import line, one array row.
- `src/exit-code-alignment.ts` — the `SPIKE_SEATS` constant, one `ALIGNED_GROUPS` row.
- `src/exit-code-alignment.unit.test.ts` — one import line, one `TABLES` row.
- `README.md` — one new `## The spike group` section; no existing prose reflowed.

**No `src/wire/registry.ts` or `claude-plugins/fabrika/docs/wire-formats.md` edit.** The contract rules a wire format out explicitly: this group gates no merge, judges no pull request and emits no verdict, so a `spike` marker in that namespace would be one `wire read` could never read back. Its two HTML-comment markers live only in issue comments and enter no wire registry.

## The three io seams that grew

Each is an insertion into the existing module, so no second path to the same resource is opened.

- `io/exec.ts` — `execRecord`, a **recorded** child run: cwd, a built environment, a timeout that kills the child's process group, and per-stream capture to a 1 MiB bound. `execCapture` fuses a non-zero exit with a spawn fault, which is right for `git`/`gh` and wrong here, so the three outcomes are separate constructors.
- `io/fs.ts` — `realPath` (the in-tree test has to be physical: on macOS `/tmp` is a symlink), `makeDirectory`, `removeAll`, `writeBytes`, and `appendText`. `appendText` is deliberately not `appendFile`: the latter heals a missing final newline, which would insert a byte the evidence digest then covers.
- `io/git.ts` — `repoRoot`, and `treeStatus` with `--untracked-files=all --ignored=matching`.

`fakes.test-support.ts` gained `directories`, `unremovable` and `survivesRemoval` options plus `remove` / `writeFile` / append-flag handling — all additive; every existing caller's behaviour is unchanged.

## Verification

- `pnpm typecheck` (workspace, 31 tasks) green; `pnpm lint:worktree` clean.
- `pnpm vitest run` in `packages/fabrika-cli`: 233 files, 3429 tests pass — 133 of them new, across seven `spike` files plus one `spike.cli.test.ts` (two spawns: the group appears under `--help` by registration alone, and a refusal really leaves stdout empty across the process boundary).

## Deviations

The Tier-M scan reports **1 suppression/skip line, 0 removed-assertion lines**.

- **The one class-5 hit is a false positive.** The scan's bare `xit(` alternative matches inside `process.exit(outcome.code)` in `src/spike/command.ts`'s emit adapter. That adapter is byte-identical to the one every sibling group ships (`src/map/command.ts`, `src/grill/command.ts`): it is how a verb's outcome reaches the shell, not a skipped test. No `biome-ignore`, `eslint-disable`, `@ts-expect-error`, `.skip(`, `.only(` or `xdescribe(` appears anywhere in this diff.
- **No assertion was removed or weakened.** Every edit to an existing test file is an insertion.

Five clauses proved under-determined and are surfaced on #5024 rather than silently resolved; each took the conservative branch, and none patched the authored `SKILL.md` or `contract.md`:

1. **`spike capture`'s idempotent branch must "say" the stdin was discarded, but the answer's key set is fixed by the contract's example.** Added one boolean, `discardedStdin`, present on both posting and non-posting branches.
2. **The `21` message names `<m> at capture`, which nothing records.** The capture marker carries only `evidenceDigest`; only the *forfeit* marker carries a run count. The refusal names the digest the capture was written over instead.
3. **The contract does not say how a non-UTF-8 stream is stored.** Captures are written as raw bytes, verbatim, so `outSha256` is over exactly the bytes in `runs/<seq>.out`.
4. **`spike status` has no seat for a *proven-absent* spike issue.** It holds no `7`, and `spikeState`'s vocabulary has no member for it. Reported as `spikeState: null` at exit `0` with a stderr line naming it proven absent — never fused with the `11` unreadable case.
5. **`spike dispose`'s own exit table seats `4` for the manifest only.** The shared matrix's `4` covers the evidence log too, so a malformed log seats there rather than getting a new code.
