### PR TITLE
feat(fabrika): implement the governance contract's seven verbs (#5199)

### DIFF
--- a/claude-plugins/fabrika/docs/wire-formats.md
+++ b/claude-plugins/fabrika/docs/wire-formats.md
@@ -38,13 +38,14 @@ does not exist yet — rather than missing; check the registry before assuming a
 | Format | Owner module | Producers | Consumers |
 | --- | --- | --- | --- |
 | `acceptance-criteria` | [`packages/fabrika-cli/src/wire/acceptance-criteria.ts`](../../../packages/fabrika-cli/src/wire/acceptance-criteria.ts) | `triage`, `build-epic` | `build`, `review` |
-| `verdict-marker` | [`packages/fabrika-cli/src/wire/verdict-marker.ts`](../../../packages/fabrika-cli/src/wire/verdict-marker.ts) | `review`, `check-epic-plan` | `build`, `ship` |
+| `verdict-marker` | [`packages/fabrika-cli/src/wire/verdict-marker.ts`](../../../packages/fabrika-cli/src/wire/verdict-marker.ts) | `review`, `check-epic-plan`, `governance` | `build`, `ship` |
 | `slice-handoff` | [`packages/fabrika-cli/src/wire/slice-handoff.ts`](../../../packages/fabrika-cli/src/wire/slice-handoff.ts) | `build-epic` | `build` |
 | `map-ticket` | [`packages/fabrika-cli/src/wire/map-ticket.ts`](../../../packages/fabrika-cli/src/wire/map-ticket.ts) | `map` | `map` |
 | `grill-ruling` | [`packages/fabrika-cli/src/wire/grill-ruling.ts`](../../../packages/fabrika-cli/src/wire/grill-ruling.ts) | `grilling` | `grilling` |
 | `grill-answer` | [`packages/fabrika-cli/src/wire/grill-answer.ts`](../../../packages/fabrika-cli/src/wire/grill-answer.ts) | `grilling` | `grilling` |
 | `grill-supersede` | [`packages/fabrika-cli/src/wire/grill-supersede.ts`](../../../packages/fabrika-cli/src/wire/grill-supersede.ts) | `grilling` | `grilling` |
 | `handoff-pack` | [`packages/fabrika-cli/src/wire/handoff-pack.ts`](../../../packages/fabrika-cli/src/wire/handoff-pack.ts) | `handoff` | `handoff` |
+| `governance-digest` | [`packages/fabrika-cli/src/wire/governance-digest.ts`](../../../packages/fabrika-cli/src/wire/governance-digest.ts) | `governance` | `front-door` |
 <!-- fabrika:wire-index:end -->
 
 ### `acceptance-criteria`
@@ -146,6 +147,17 @@ artifact whose section set is open can steer its receiver past the artifact and 
 way to tell the format's own words from someone else's. Its digest is over the proven half's fields
 rather than over the comment text, and a reader recomputes it — a pack comment is editable by its
 author, so two printed copies of a number nobody recomputes can drift with nothing marking it.
+
+### `governance-digest`
+
+This is the periodic readout of the decision records that landed in a window — the non-blocking half
+of the ruling that retired the human gate on ADRs, so it carries no polarity and nothing about it can
+red. Each row is an id, one of three closed kinds (`tension`, `blast`, `routine`) and a one-line note,
+ranked highest consequence first. The note is a **pointer, not a directive**: the receiver re-fetches
+the record the id names and reads it there, which is what keeps a coordination artifact from steering
+whoever reads it, and it is why free prose is confined to that one field. The block is upserted onto a
+durable issue rather than appended, so a reader always finds exactly one current readout instead of a
+stream a timestamp has to decide between.
 
 ## Adding a format
 

--- a/packages/fabrika-cli/README.md
+++ b/packages/fabrika-cli/README.md
@@ -515,6 +515,50 @@ This group applies no label, closes nothing, opens no pull request, emits no ver
 pushes nothing. Nothing it records can block a merge — a session state that gated one would make
 every interrupted session a blocked one.
 
+## The `governance` group
+
+The contract is
+[`claude-plugins/fabrika/skills/governance/contract.md`](../../claude-plugins/fabrika/skills/governance/contract.md).
+The **governance namespace** is derived from a PR's diff — required when any changed path sits under
+one of four harness roots (`.decisions/`, `.claude/`, `.github/`, `claude-plugins/`) — and this group
+answers the mechanical half of the judgment a governance verdict rests on.
+
+| Verb | Answers |
+|---|---|
+| `governance scope` | whether the diff derives the namespace, over which roots, with the bound head, the `self` flag and the records in the diff |
+| `governance sweep` | the uncited live-`accepted` records whose domain a subject touches, ranked, for a subject in a bound commit or in the corpus |
+| `governance guards` | the anchored invariants the bound diff removes or modifies, and the guard-bearing files it touches |
+| `governance base` | this skill's own text at a PR's merge base — the self fence's bytes |
+| `governance post` | the single sanctioned emit of the `governance` namespace verdict |
+| `governance digest` | the decision records that landed in a window, with each landing commit and its anchor delta |
+| `governance readout` | the digest-publishing protocol: compose, upsert, read back |
+
+Five properties are worth knowing before you call them:
+
+- **This is not the §CP answer, and `governance scope` says so on stderr on every run.** fabrika's
+  §CP model is CODEOWNERS-only with no semantic detection, so a second answer here could contradict a
+  merge-gating verdict. What this derives is a separate namespace whose *verdict* is the skill's
+  judgment.
+- **Nothing is re-derived that already ships.** The root list and its predicate come from
+  [`review/classes.ts`](src/review/classes.ts) — one derivation, read by `ship scope`, `ship gate`'s
+  required-set floor and `governance scope` alike; the ranking core comes from
+  [`adr/sweep.ts`](src/adr/sweep.ts); the commit binding, the leak predicate and the read-back
+  normalizer are all imports.
+- **No outcome here is a clearance.** `sweep`'s `no-overlap` carries that sentence verbatim in its
+  `reason`, and `guards`'s `no-anchors-in-reach` is the mechanical floor reporting its own silence: a
+  guard weakened in prose carrying no anchor is invisible to the scan by construction.
+- **The anchor inventory lives in the guarded file.** An anchor is the `<!-- anchor: NAME -->` comment
+  a skill already carries, so the set cannot rot while the guards move — which is the whole design
+  difference from v1's hardcoded prose list inside the reviewing skill.
+- **The readout gates nothing.** `governance readout` writes one comment and nothing else: no label,
+  no PR, and no exit code meaning "the corpus is in a bad state", because a digest that could red
+  would be the human gate the [#4927](https://github.com/kamp-us/phoenix/issues/4927) ruling retired
+  under a new name.
+
+The group emits the `governance` namespace through the shipped
+[`verdict-marker`](src/wire/verdict-marker.ts) format and publishes its digest through
+[`governance-digest`](src/wire/governance-digest.ts).
+
 ## The `wire` group
 
 A **wire format** is the byte-level agreement two skills meet through on a GitHub artifact —

--- a/packages/fabrika-cli/src/exit-code-alignment.ts
+++ b/packages/fabrika-cli/src/exit-code-alignment.ts
@@ -198,11 +198,23 @@ export const SPIKE_SEATS: SharedSeats = {
 	READ_OR_EXEC_UNKNOWN: "PRECONDITION_UNKNOWN",
 };
 
+/**
+ * `governance`'s seats: the same eight `triage` and `review` claim, under the base's own readings.
+ *
+ * It reaches for {@link SHARED_SEATS} rather than a map of its own because every name and every
+ * reading matches — including `4`, which it holds as a `DELIBERATE_GAP` for the same reason `review`
+ * does: no verb here composes body sections. Its private band is `12`-`14`, and only `14` is
+ * genuinely its own — `12` and `13` are `review`'s constants, imported because this group proves the
+ * same two facts.
+ */
+export const GOVERNANCE_SEATS: SharedSeats = SHARED_SEATS;
+
 /** The groups that align to {@link ALIGNMENT_BASE}, each with the seats it claims to share. */
 export const ALIGNED_GROUPS: Readonly<Record<string, SharedSeats>> = {
 	adr: ADR_SEATS,
 	build: BUILD_SEATS,
 	eval: EVAL_SEATS,
+	governance: GOVERNANCE_SEATS,
 	hook: HOOK_SEATS,
 	epic: BUILD_SEATS,
 	grill: GRILL_SEATS,

--- a/packages/fabrika-cli/src/exit-code-alignment.unit.test.ts
+++ b/packages/fabrika-cli/src/exit-code-alignment.unit.test.ts
@@ -15,6 +15,7 @@ import {
 	UNTABLED_GROUPS,
 	ZeroCoverageScope,
 } from "./exit-code-alignment.ts";
+import * as governance from "./governance/codes.ts";
 import * as grill from "./grill/codes.ts";
 import * as handoff from "./handoff/codes.ts";
 import * as hook from "./hook/codes.ts";
@@ -45,6 +46,7 @@ const TABLES: Readonly<Record<string, CodeTable>> = {
 	build,
 	epic,
 	eval: evalCodes,
+	governance,
 	grill,
 	handoff,
 	hook,

--- a/packages/fabrika-cli/src/governance/anchors.ts
+++ b/packages/fabrika-cli/src/governance/anchors.ts
@@ -1,0 +1,117 @@
+/**
+ * The anchored-invariant scan, pure over a unified diff.
+ *
+ * An anchor is the `<!-- anchor: NAME -->` HTML comment fabrika skills already carry. The inventory
+ * therefore lives **in the guarded file**, which is the whole design difference from v1's gate check:
+ * that one kept a hardcoded prose list of what each gate promises, inside the reviewing skill, so the
+ * copy drifted from the guards silently and nothing checked it. Anchors cannot rot while the guards
+ * move, because they move with them.
+ *
+ * What this scan cannot see is stated rather than implied: a guard weakened in prose carrying no
+ * anchor is invisible here **by construction**. That is why the verb's third outcome is
+ * `no-anchors-in-reach` — the mechanical floor reporting its own silence — and never a clearance.
+ */
+
+const ANCHOR = /<!--\s*anchor:\s*([A-Z][A-Z0-9-]*)\s*-->/;
+const FILE_HEADER = /^diff --git a\/(.+?) b\/(.+)$/;
+const HUNK_HEADER = /^@@ -(\d+)(?:,\d+)? \+(\d+)(?:,\d+)? @@/;
+
+/** One anchored invariant the diff removes or changes. */
+export interface AnchorHit {
+	readonly kind: "removed" | "modified";
+	readonly name: string;
+	readonly file: string;
+	readonly line: number;
+}
+
+/** One side of the diff: the anchor's name, the text that followed it, and the line it sat on. */
+interface AnchorSighting {
+	readonly name: string;
+	readonly rest: string;
+	readonly line: number;
+}
+
+const sightingOf = (text: string, line: number): AnchorSighting | null => {
+	const matched = ANCHOR.exec(text);
+	if (matched?.[1] === undefined) return null;
+	return {name: matched[1], rest: text.slice(matched.index + matched[0].length).trim(), line};
+};
+
+/** How many anchors a file's bytes carry — the `anchors-in-reach` denominator, per file. */
+export const anchorsIn = (text: string): number =>
+	text.split("\n").filter((line) => ANCHOR.test(line)).length;
+
+/** The destination path of one `diff --git` header, or `null` when the line is not one. */
+export const changedFileOf = (line: string): string | null => FILE_HEADER.exec(line)?.[2] ?? null;
+
+/** How many files a unified diff carries — the completeness proof's numerator. */
+export const filesInDiff = (diff: string): number =>
+	diff.split("\n").filter((line) => FILE_HEADER.test(line)).length;
+
+/**
+ * Every anchored invariant the diff removes or modifies, in diff order.
+ *
+ * The pairing is by NAME within a file: a name on a removed line and on no added line is `removed`;
+ * a name on both sides whose following text differs is `modified`. A name on both sides with the
+ * same text moved and did not change, so it is neither — a scan that reported it would drown the
+ * two findings that matter in every reflow.
+ */
+export const scanAnchors = (diff: string): ReadonlyArray<AnchorHit> => {
+	const hits: AnchorHit[] = [];
+	let file: string | null = null;
+	let removed: AnchorSighting[] = [];
+	let added: AnchorSighting[] = [];
+	let oldLine = 0;
+	let newLine = 0;
+
+	const flush = (): void => {
+		if (file === null) return;
+		for (const gone of removed) {
+			const back = added.find((entry) => entry.name === gone.name);
+			if (back === undefined) {
+				hits.push({kind: "removed", name: gone.name, file, line: gone.line});
+			} else if (back.rest !== gone.rest) {
+				hits.push({kind: "modified", name: gone.name, file, line: back.line});
+			}
+		}
+		removed = [];
+		added = [];
+	};
+
+	for (const line of diff.split("\n")) {
+		const header = changedFileOf(line);
+		if (header !== null) {
+			flush();
+			file = header;
+			continue;
+		}
+		const hunk = HUNK_HEADER.exec(line);
+		if (hunk !== null) {
+			oldLine = Number(hunk[1] ?? "0");
+			newLine = Number(hunk[2] ?? "0");
+			continue;
+		}
+		if (file === null) continue;
+		if (line.startsWith("---") || line.startsWith("+++")) continue;
+		if (line.startsWith("-")) {
+			const seen = sightingOf(line.slice(1), oldLine);
+			if (seen !== null) removed.push(seen);
+			oldLine += 1;
+		} else if (line.startsWith("+")) {
+			const seen = sightingOf(line.slice(1), newLine);
+			if (seen !== null) added.push(seen);
+			newLine += 1;
+		} else if (line.startsWith(" ") || line === "") {
+			oldLine += 1;
+			newLine += 1;
+		}
+	}
+	flush();
+	return hits;
+};
+
+/** A changed file is guard-bearing iff it carries an anchor, or sits under `.github/workflows/`. */
+export const WORKFLOW_ROOT = ".github/workflows/";
+
+export const isGuardBearing = (path: string, anchors: number): boolean =>
+	anchors > 0 || path.startsWith(WORKFLOW_ROOT);

--- a/packages/fabrika-cli/src/governance/anchors.ts
+++ b/packages/fabrika-cli/src/governance/anchors.ts
@@ -15,6 +15,22 @@
 const ANCHOR = /<!--\s*anchor:\s*([A-Z][A-Z0-9-]*)\s*-->/;
 const FILE_HEADER = /^diff --git a\/(.+?) b\/(.+)$/;
 const HUNK_HEADER = /^@@ -(\d+)(?:,\d+)? \+(\d+)(?:,\d+)? @@/;
+const INLINE_CODE = /`[^`]*`/g;
+
+/**
+ * The line with its inline-code spans blanked out — an anchor tag inside backticks is *documentation
+ * of the pattern*, not an anchor. Without this the scan counts the governance skill's own sentence
+ * describing the tag as a twelfth anchor of eleven, which inflates the `anchors-in-reach` denominator
+ * and would report a phantom `modified` the day that sentence is reworded — both landing on the
+ * self-editing PR the fence exists for (#5199).
+ *
+ * The blanking is length-preserving on purpose: every index into the masked text is an index into the
+ * original, so a caller matches here and still slices the real bytes. Position, not line-start, is the
+ * discriminator — real anchors sit after a list bullet and after a heading too, so a line-start rule
+ * would drop genuine anchors, which is a worse defect than the one being fixed.
+ */
+const maskInlineCode = (text: string): string =>
+	text.replace(INLINE_CODE, (span) => " ".repeat(span.length));
 
 /** One anchored invariant the diff removes or changes. */
 export interface AnchorHit {
@@ -32,14 +48,14 @@ interface AnchorSighting {
 }
 
 const sightingOf = (text: string, line: number): AnchorSighting | null => {
-	const matched = ANCHOR.exec(text);
+	const matched = ANCHOR.exec(maskInlineCode(text));
 	if (matched?.[1] === undefined) return null;
 	return {name: matched[1], rest: text.slice(matched.index + matched[0].length).trim(), line};
 };
 
 /** How many anchors a file's bytes carry — the `anchors-in-reach` denominator, per file. */
 export const anchorsIn = (text: string): number =>
-	text.split("\n").filter((line) => ANCHOR.test(line)).length;
+	text.split("\n").filter((line) => ANCHOR.test(maskInlineCode(line))).length;
 
 /** The destination path of one `diff --git` header, or `null` when the line is not one. */
 export const changedFileOf = (line: string): string | null => FILE_HEADER.exec(line)?.[2] ?? null;

--- a/packages/fabrika-cli/src/governance/anchors.unit.test.ts
+++ b/packages/fabrika-cli/src/governance/anchors.unit.test.ts
@@ -1,0 +1,102 @@
+import {describe, expect, it} from "vitest";
+import {anchorsIn, filesInDiff, isGuardBearing, scanAnchors} from "./anchors.ts";
+
+const diff = (...lines: ReadonlyArray<string>): string => `${lines.join("\n")}\n`;
+
+const file = (path: string): ReadonlyArray<string> => [
+	`diff --git a/${path} b/${path}`,
+	`--- a/${path}`,
+	`+++ b/${path}`,
+	"@@ -10,3 +10,3 @@",
+];
+
+describe("scanAnchors", () => {
+	it("reports an anchor present on a removed line and on no added line as `removed`", () => {
+		const hits = scanAnchors(
+			diff(
+				...file("skills/review/SKILL.md"),
+				"-<!-- anchor: SHA-BOUND --> the verdict names its head",
+				" tail",
+			),
+		);
+		expect(hits).toEqual([
+			{kind: "removed", name: "SHA-BOUND", file: "skills/review/SKILL.md", line: 10},
+		]);
+	});
+
+	it("reports an anchor on both sides with different following text as `modified`", () => {
+		const hits = scanAnchors(
+			diff(
+				...file("skills/ship/SKILL.md"),
+				"-<!-- anchor: SHA-BOUND --> the verdict names its head",
+				"+<!-- anchor: SHA-BOUND --> the verdict may name a head",
+			),
+		);
+		expect(hits).toEqual([
+			{kind: "modified", name: "SHA-BOUND", file: "skills/ship/SKILL.md", line: 10},
+		]);
+	});
+
+	it("reports NOTHING for an anchor that only moved — a reflow is not a weakening", () => {
+		expect(
+			scanAnchors(
+				diff(
+					...file("skills/ship/SKILL.md"),
+					"-<!-- anchor: SHA-BOUND --> the verdict names its head",
+					"+<!-- anchor: SHA-BOUND --> the verdict names its head",
+				),
+			),
+		).toEqual([]);
+	});
+
+	it("keeps each file's anchors to that file — a name in two files is two questions", () => {
+		const hits = scanAnchors(
+			diff(
+				...file("a.md"),
+				"-<!-- anchor: G --> one",
+				...file("b.md"),
+				"-<!-- anchor: G --> two",
+				"+<!-- anchor: G --> two",
+			),
+		);
+		expect(hits).toEqual([{kind: "removed", name: "G", file: "a.md", line: 10}]);
+	});
+
+	it("finds nothing in a diff that carries no anchor at all", () => {
+		expect(scanAnchors(diff(...file("src/cart.ts"), "-const a = 1;", "+const a = 2;"))).toEqual([]);
+	});
+});
+
+describe("anchorsIn", () => {
+	it("counts the anchors a file's bytes carry", () => {
+		expect(anchorsIn("<!-- anchor: A -->\ntext\n<!-- anchor: B --> more\n")).toBe(2);
+	});
+
+	it("counts none in a file with no anchor, which is the `no-anchors-in-reach` floor", () => {
+		expect(anchorsIn("# a doc\n\nprose\n")).toBe(0);
+	});
+});
+
+describe("filesInDiff", () => {
+	it("counts the `diff --git` headers, which is the completeness proof's numerator", () => {
+		expect(filesInDiff(diff(...file("a.md"), "-x", ...file("b.md"), "+y"))).toBe(2);
+	});
+
+	it("counts zero over an empty diff rather than throwing", () => {
+		expect(filesInDiff("")).toBe(0);
+	});
+});
+
+describe("isGuardBearing", () => {
+	it("admits a file carrying an anchor", () => {
+		expect(isGuardBearing("skills/review/SKILL.md", 3)).toBe(true);
+	});
+
+	it("admits a workflow whether or not it carries one — the enforcement layer is the clause", () => {
+		expect(isGuardBearing(".github/workflows/ci.yml", 0)).toBe(true);
+	});
+
+	it("refuses everything else: `a file that looks important` is not a criterion", () => {
+		expect(isGuardBearing("src/very/important.ts", 0)).toBe(false);
+	});
+});

--- a/packages/fabrika-cli/src/governance/anchors.unit.test.ts
+++ b/packages/fabrika-cli/src/governance/anchors.unit.test.ts
@@ -1,5 +1,9 @@
+import {readFileSync} from "node:fs";
+import {fileURLToPath} from "node:url";
 import {describe, expect, it} from "vitest";
 import {anchorsIn, filesInDiff, isGuardBearing, scanAnchors} from "./anchors.ts";
+
+const GOVERNANCE_SKILL = "claude-plugins/fabrika/skills/governance/SKILL.md";
 
 const diff = (...lines: ReadonlyArray<string>): string => `${lines.join("\n")}\n`;
 
@@ -62,6 +66,18 @@ describe("scanAnchors", () => {
 		expect(hits).toEqual([{kind: "removed", name: "G", file: "a.md", line: 10}]);
 	});
 
+	it("reports NO phantom hit when the edited line only DESCRIBES the tag inside backticks", () => {
+		expect(
+			scanAnchors(
+				diff(
+					...file("skills/governance/SKILL.md"),
+					"-`guards` reports the `<!-- anchor: NAME -->` tags skills carry",
+					"+`guards` reports the `<!-- anchor: NAME -->` tags a skill carries",
+				),
+			),
+		).toEqual([]);
+	});
+
 	it("finds nothing in a diff that carries no anchor at all", () => {
 		expect(scanAnchors(diff(...file("src/cart.ts"), "-const a = 1;", "+const a = 2;"))).toEqual([]);
 	});
@@ -74,6 +90,22 @@ describe("anchorsIn", () => {
 
 	it("counts none in a file with no anchor, which is the `no-anchors-in-reach` floor", () => {
 		expect(anchorsIn("# a doc\n\nprose\n")).toBe(0);
+	});
+
+	it("does NOT count a tag inside backticks — a skill documenting the pattern is not an anchor", () => {
+		expect(anchorsIn("the `<!-- anchor: NAME -->` tags skills carry\n")).toBe(0);
+	});
+
+	it("counts an anchor after a bullet and after a heading — position is not the discriminator", () => {
+		expect(anchorsIn("- <!-- anchor: H1 --> a claim\n## Open <!-- anchor: Q1 -->\n")).toBe(2);
+	});
+
+	it("counts the governance skill's own eleven anchors, not the twelve a raw scan sees", () => {
+		const skill = readFileSync(
+			fileURLToPath(new URL(`../../../../${GOVERNANCE_SKILL}`, import.meta.url)),
+			"utf8",
+		);
+		expect(anchorsIn(skill)).toBe(11);
 	});
 });
 

--- a/packages/fabrika-cli/src/governance/authored.ts
+++ b/packages/fabrika-cli/src/governance/authored.ts
@@ -1,0 +1,78 @@
+/**
+ * The guard over **authored** text — the bytes this run just wrote — for `governance post` and
+ * `governance readout`.
+ *
+ * The predicates are the shipped `../report/leaks.ts` ones, imported; only the message text is this
+ * group's, because each refusal names one correctable thing in its own verb's words. A second leak
+ * predicate that drifts from the first is worse than either alone.
+ *
+ * Four outcomes, and the first two must never collapse: an **unread** pipe is UNKNOWN and seats on
+ * `1`, a **read-but-empty** one is a proven `3`. A body that IS a path is `6` rather than `5` because
+ * the fixes are opposite — the loop on a leak is *rewrite and resend*, and on a body that is a path
+ * that loop never terminates.
+ */
+
+import type {StdinRead} from "../io/stdin.ts";
+import {isBareAtReference, renderLeaks, scanBody} from "../report/leaks.ts";
+import {FAILED, refuse, type VerbOutcome} from "../verb.ts";
+import {BARE_AT_PATH, EMPTY_STDIN, LEAKED_PATH} from "./codes.ts";
+
+/** What one verb calls the text it is guarding, so each refusal reads as that verb's own. */
+export interface AuthoredSurface {
+	readonly verb: string;
+	/** The noun a `1` and a `5` refusal name, e.g. `the assembled comment`. */
+	readonly noun: string;
+	/** The whole `3` message — the contract states it per verb, so it is not composed here. */
+	readonly emptyMessage: string;
+	/** The whole `6` message, for the same reason. */
+	readonly bareAtMessage: string;
+	/** The correction a leak refusal ends with, e.g. `cite it repo-relative.` */
+	readonly leakCorrection: string;
+}
+
+export type Authored =
+	| {readonly _tag: "Refused"; readonly outcome: VerbOutcome}
+	| {readonly _tag: "Text"; readonly text: string; readonly bytes: number};
+
+export const readAuthored = (surface: AuthoredSurface, read: StdinRead): Authored => {
+	if (read._tag === "Failed") {
+		return {
+			_tag: "Refused",
+			outcome: refuse(
+				FAILED,
+				`${surface.verb}: could not read stdin: ${read.reason} — ${surface.noun} is UNKNOWN, never empty.`,
+			),
+		};
+	}
+	const text = read._tag === "NoStdin" ? "" : read.text;
+	const bytes = new TextEncoder().encode(text).length;
+	if (text.trim() === "") {
+		return {
+			_tag: "Refused",
+			outcome: refuse(EMPTY_STDIN, surface.emptyMessage, [
+				`${surface.verb}: stdin was read and held ${bytes} byte(s).`,
+			]),
+		};
+	}
+	if (isBareAtReference(text)) {
+		return {_tag: "Refused", outcome: refuse(BARE_AT_PATH, surface.bareAtMessage)};
+	}
+	return {_tag: "Text", text, bytes};
+};
+
+/**
+ * The leak refusal for `body`, or `null` when it carries no machine-local path.
+ *
+ * Run over the **composed** artifact rather than over raw stdin, so nothing a verb itself appends can
+ * escape the predicate.
+ */
+export const leakRefusal = (surface: AuthoredSurface, body: string): VerbOutcome | null => {
+	const scan = scanBody(body);
+	const first = scan.leaks[0];
+	if (first === undefined) return null;
+	return refuse(
+		LEAKED_PATH,
+		`${surface.verb}: ${surface.noun} carries a machine-local path at line ${first.line} (${first.class}) — ${surface.leakCorrection}`,
+		renderLeaks(scan.leaks),
+	);
+};

--- a/packages/fabrika-cli/src/governance/base-verb.ts
+++ b/packages/fabrika-cli/src/governance/base-verb.ts
@@ -1,0 +1,162 @@
+/**
+ * `governance base` — this skill's own text at the merge base of a PR that edits it.
+ *
+ * **The verb exists so the self fence is a pasteable literal.** The rule it serves — judge a
+ * self-editing PR by the merge-base revision of its own text (ADR 0052) — otherwise needs a merge-base
+ * SHA the model would have to compute and interpolate, which the harness's isolation verifier refuses.
+ * Resolving a merge base and reading named paths at it is mechanical; judging by them is not.
+ *
+ * **`--path` is fenced to this skill's own directory, and that directory is resolved, not hardcoded.**
+ * The fence is deliberate: a general "read any file at the merge base" verb would be a second way to
+ * load instructions out of a tree, which is what the whole no-checkout posture exists to prevent. And
+ * nothing is checked out here either — the bytes come from the object database.
+ *
+ * The `11` refusal never falls back to the head. A self fence that degrades to the head's rules on a
+ * failed read is a fence that opens exactly when it is being tested.
+ */
+import {Effect} from "effect";
+import type {ChildProcessSpawner} from "effect/unstable/process";
+import {listTreePaths, mergeBase, readFileAt} from "../io/git.ts";
+import {getPullRequest} from "../io/pulls.ts";
+import {badNumber, openPull, resolveTargetRepo} from "../review/target.ts";
+import {answer, refuse, type VerbOutcome} from "../verb.ts";
+import {OFF_VOCABULARY, PRECONDITION_UNKNOWN, STALE_HEAD, ZERO_SCOPE} from "./codes.ts";
+import {bindGovernanceHead} from "./head.ts";
+import {insideRoot, resolveSkillRoots} from "./skill-root.ts";
+
+const VERB = "governance base";
+
+/** The two files the self fence reads when the caller names none. */
+const DEFAULT_FILES = ["SKILL.md", "contract.md"];
+
+export interface BaseOptions {
+	readonly pr: number;
+	readonly path: ReadonlyArray<string>;
+	readonly repo: string | null;
+	readonly env: Readonly<Record<string, string | undefined>>;
+}
+
+const byteLength = (text: string): number => new TextEncoder().encode(text).length;
+
+export const runBase = (
+	options: BaseOptions,
+): Effect.Effect<VerbOutcome, never, ChildProcessSpawner.ChildProcessSpawner> =>
+	Effect.gen(function* () {
+		const {pr} = options;
+		const bad = badNumber(VERB, "a pull-request number", pr);
+		if (bad !== null) return bad;
+
+		const resolved = yield* resolveTargetRepo(VERB, options.repo, options.env);
+		if (resolved._tag === "Refused") return resolved.outcome;
+		const repo = resolved.repo;
+
+		const target = yield* openPull(VERB, repo, pr, {
+			requireOpen: true,
+			closedReason: "there is no base revision to judge by.",
+			requireFiles: false,
+			unknownMessage: (reason) =>
+				`${VERB}: cannot read PR #${pr} in ${repo}: ${reason} — the base rules are UNKNOWN; refusing to judge by the head's.`,
+		});
+		if (target._tag === "Refused") return target.outcome;
+
+		// This verb takes no `--sha`: it resolves the base itself, so the binding runs against the live
+		// head and the staleness check below is what pairs the two.
+		const bound = yield* bindGovernanceHead(
+			VERB,
+			"the merge base cannot be resolved, so the base rules are UNKNOWN.",
+			repo,
+			pr,
+			target.pull,
+			null,
+		);
+		if (bound._tag === "Refused") return bound.outcome;
+		const head = bound.head;
+
+		const base = yield* mergeBase(head.base, head.sha);
+		if (base._tag === "Failure") {
+			return refuse(
+				PRECONDITION_UNKNOWN,
+				`${VERB}: cannot resolve the merge base of #${pr}: ${base.reason} — the base rules are UNKNOWN; refusing to judge by the head's.`,
+			);
+		}
+
+		// A base paired with a head nobody judged is not a fence, so the head is re-read after the
+		// resolve rather than trusted from before it.
+		const after = yield* getPullRequest(repo, pr);
+		if (after._tag !== "Present") {
+			return refuse(
+				PRECONDITION_UNKNOWN,
+				`${VERB}: cannot re-read PR #${pr} in ${repo}: ${after._tag === "Unknown" ? after.reason : "it is no longer there"} — the base rules are UNKNOWN; refusing to judge by the head's.`,
+			);
+		}
+		if (after.value.headSha !== head.sha) {
+			return refuse(
+				STALE_HEAD,
+				`${VERB}: #${pr}'s head moved to ${after.value.headSha} while resolving — re-run.`,
+			);
+		}
+
+		const tree = yield* listTreePaths(base.value);
+		if (tree._tag === "Failure") {
+			return refuse(
+				PRECONDITION_UNKNOWN,
+				`${VERB}: cannot list the tree at merge base ${base.value}: ${tree.reason} — the base rules are UNKNOWN; refusing to judge by the head's.`,
+			);
+		}
+		const roots = resolveSkillRoots(tree.value);
+		if (roots._tag === "None") {
+			return refuse(
+				ZERO_SCOPE,
+				`${VERB}: no \`*/fabrika/skills/governance/SKILL.md\` at merge-base ${base.value} — this skill is not installed in the base revision, so there is no self fence to run.`,
+			);
+		}
+		if (roots._tag === "Many") {
+			return refuse(
+				PRECONDITION_UNKNOWN,
+				`${VERB}: ${roots.candidates.length} candidate skill roots at merge-base ${base.value} (${roots.candidates.join(", ")}) — which one is this skill is UNKNOWN; refusing to guess.`,
+			);
+		}
+		const root = roots.root;
+		const diagnostics = [
+			`${VERB}: resolved this skill's own directory to ${root} at merge-base ${base.value}.`,
+		];
+
+		const wanted =
+			options.path.length === 0 ? DEFAULT_FILES.map((name) => `${root}${name}`) : options.path;
+		for (const path of wanted) {
+			if (!insideRoot(root, path)) {
+				return refuse(
+					OFF_VOCABULARY,
+					`${VERB}: --path "${path}" is outside this skill's own directory (${root}) — this verb reads only this skill's own text.`,
+					diagnostics,
+				);
+			}
+		}
+
+		const present = new Set(tree.value);
+		const blocks: string[] = [];
+		for (const path of wanted) {
+			// Absence is PROVEN from the tree listing, so a path that is simply not there is skipped and
+			// a path that is there and will not read is `11` — the two are different facts.
+			if (!present.has(path)) continue;
+			const bytes = yield* readFileAt(base.value, path);
+			if (bytes._tag === "Failure") {
+				return refuse(
+					PRECONDITION_UNKNOWN,
+					`${VERB}: cannot read ${path} at ${base.value}: ${bytes.reason} — UNKNOWN.`,
+					diagnostics,
+				);
+			}
+			blocks.push(`file\t${path}\t${byteLength(bytes.value)}\n${bytes.value}`);
+		}
+		if (blocks.length === 0) {
+			return refuse(
+				ZERO_SCOPE,
+				`${VERB}: none of the requested paths exist at merge-base ${base.value} — there is no base revision to judge by.`,
+				diagnostics,
+			);
+		}
+
+		diagnostics.push(`${VERB}: merge base of #${pr} is ${base.value}.`);
+		return answer(`base\t${base.value}\t${blocks.length}\n${blocks.join("")}`, diagnostics);
+	});

--- a/packages/fabrika-cli/src/governance/base-verb.unit.test.ts
+++ b/packages/fabrika-cli/src/governance/base-verb.unit.test.ts
@@ -1,0 +1,152 @@
+import {Effect} from "effect";
+import {describe, expect, it} from "vitest";
+import {errOut, fakeShell, okOut, once} from "../fakes.test-support.ts";
+import type {ExecResult} from "../io/exec.ts";
+import {runBase} from "./base-verb.ts";
+import {OFF_VOCABULARY, PRECONDITION_UNKNOWN, STALE_HEAD, ZERO_SCOPE} from "./codes.ts";
+import {
+	binding,
+	HEAD,
+	pull,
+	SHOW_AT,
+	SKILL_ROOT,
+	TREE_AT,
+	treeOf,
+} from "./fixtures.test-support.ts";
+
+const PULL = /^gh api repos\/o\/r\/pulls\/4321$/;
+const MERGE_BASE = "8b1e0c4499ad72f635e0117a9bb2d3c058e7fa16";
+
+const options = {
+	pr: 4321,
+	path: [] as ReadonlyArray<string>,
+	repo: null,
+	env: {CLAUDE_PIPELINE_REPO: "o/r"} as Record<string, string | undefined>,
+};
+
+const run = (
+	script: ReadonlyArray<readonly [RegExp, ExecResult]>,
+	overrides: Partial<typeof options> = {},
+) =>
+	Effect.runPromise(Effect.provide(runBase({...options, ...overrides}), fakeShell(script).layer));
+
+const SKILL_BYTES = "---\nname: governance\n---\n\n# governance\n";
+const CONTRACT_BYTES = "# contract\n";
+
+const upTo = (
+	tree: ReadonlyArray<string> = [`${SKILL_ROOT}SKILL.md`, `${SKILL_ROOT}contract.md`],
+): ReadonlyArray<readonly [RegExp, ExecResult]> => [
+	[once(PULL), pull()],
+	...binding(),
+	[/^git merge-base /, okOut(`${MERGE_BASE}\n`)],
+	[PULL, pull()],
+	[TREE_AT(MERGE_BASE), treeOf(...tree)],
+];
+
+const happy: ReadonlyArray<readonly [RegExp, ExecResult]> = [
+	...upTo(),
+	[SHOW_AT(MERGE_BASE, `${SKILL_ROOT}SKILL.md`), okOut(SKILL_BYTES)],
+	[SHOW_AT(MERGE_BASE, `${SKILL_ROOT}contract.md`), okOut(CONTRACT_BYTES)],
+];
+
+describe("runBase", () => {
+	it("prints the merge base, then each file's header and its bytes back to back", async () => {
+		const out = await run(happy);
+		expect(out.code).toBe(0);
+		expect(out.stdout).toBe(
+			`base\t${MERGE_BASE}\t2\n` +
+				`file\t${SKILL_ROOT}SKILL.md\t${SKILL_BYTES.length}\n${SKILL_BYTES}` +
+				`file\t${SKILL_ROOT}contract.md\t${CONTRACT_BYTES.length}\n${CONTRACT_BYTES}`,
+		);
+	});
+
+	it("names the merge base and the resolved root on stderr", async () => {
+		const out = await run(happy);
+		expect(out.stderr).toContain(
+			`governance base: resolved this skill's own directory to ${SKILL_ROOT} at merge-base ${MERGE_BASE}.`,
+		);
+		expect(out.stderr.at(-1)).toBe(`governance base: merge base of #4321 is ${MERGE_BASE}.`);
+	});
+
+	it("refuses a --path outside the resolved root on 10 — this verb reads only its own text", async () => {
+		const out = await run(happy, {path: ["claude-plugins/fabrika/skills/review/SKILL.md"]});
+		expect(out.code).toBe(OFF_VOCABULARY);
+		expect(out.stdout).toBe("");
+		expect(out.stderr.at(-1)).toBe(
+			`governance base: --path "claude-plugins/fabrika/skills/review/SKILL.md" is outside this skill's own directory (${SKILL_ROOT}) — this verb reads only this skill's own text.`,
+		);
+	});
+
+	it("refuses a merge base with NO install on 7 — there is no self fence to run", async () => {
+		const out = await run(upTo(["src/cart.ts"]));
+		expect(out.code).toBe(ZERO_SCOPE);
+		expect(out.stderr.at(-1)).toContain("this skill is not installed in the base revision");
+	});
+
+	it("refuses TWO installs on 11 rather than picking one, naming both", async () => {
+		const out = await run(
+			upTo(["a/fabrika/skills/governance/SKILL.md", "b/fabrika/skills/governance/SKILL.md"]),
+		);
+		expect(out.code).toBe(PRECONDITION_UNKNOWN);
+		expect(out.stderr.at(-1)).toContain(
+			"a/fabrika/skills/governance/, b/fabrika/skills/governance/",
+		);
+		expect(out.stderr.at(-1)).toContain("refusing to guess");
+	});
+
+	it("refuses on 7 when the root resolves but no requested path exists at the base", async () => {
+		const out = await run(upTo([`${SKILL_ROOT}SKILL.md`]), {
+			path: [`${SKILL_ROOT}contract.md`],
+		});
+		expect(out.code).toBe(ZERO_SCOPE);
+		expect(out.stderr.at(-1)).toBe(
+			`governance base: none of the requested paths exist at merge-base ${MERGE_BASE} — there is no base revision to judge by.`,
+		);
+	});
+
+	it("refuses on 11 when a path is THERE and will not read — never a fallback to the head", async () => {
+		const out = await run([
+			...upTo(),
+			[SHOW_AT(MERGE_BASE, `${SKILL_ROOT}SKILL.md`), errOut("fatal: bad object")],
+		]);
+		expect(out.code).toBe(PRECONDITION_UNKNOWN);
+		expect(out.stdout).toBe("");
+	});
+
+	it("refuses on 12 when the head moved while the base was being resolved", async () => {
+		const moved = "0b1c2d3e4f5a6b7c8d9e0f1a2b3c4d5e6f708192";
+		const out = await run([
+			[once(PULL), pull()],
+			...binding(),
+			[/^git merge-base /, okOut(`${MERGE_BASE}\n`)],
+			[PULL, pull({head: moved})],
+		]);
+		expect(out.code).toBe(STALE_HEAD);
+		expect(out.stderr.at(-1)).toBe(
+			`governance base: #4321's head moved to ${moved} while resolving — re-run.`,
+		);
+	});
+
+	it("refuses an unresolvable merge base on 11", async () => {
+		const out = await run([
+			[once(PULL), pull()],
+			...binding(),
+			[/^git merge-base /, errOut("fatal: no merge base")],
+		]);
+		expect(out.code).toBe(PRECONDITION_UNKNOWN);
+		expect(out.stderr.at(-1)).toContain("refusing to judge by the head's");
+	});
+
+	it("refuses an absent PR on 7 and a non-PR number on 1", async () => {
+		expect((await run([[PULL, errOut("gh: Not Found (HTTP 404)")]])).code).toBe(ZERO_SCOPE);
+		expect((await run(happy, {pr: 0})).code).toBe(1);
+	});
+
+	it("reads the head it bound, so nothing is ever checked out", async () => {
+		const fake = fakeShell(happy);
+		await Effect.runPromise(Effect.provide(runBase(options), fake.layer));
+		expect(fake.calls.some((call) => call.startsWith("git checkout"))).toBe(false);
+		expect(fake.calls).toContain(`git ls-tree -r --name-only -z ${MERGE_BASE}`);
+		expect(fake.calls).toContain(`git rev-parse --verify --quiet ${HEAD}^{commit}`);
+	});
+});

--- a/packages/fabrika-cli/src/governance/codes.ts
+++ b/packages/fabrika-cli/src/governance/codes.ts
@@ -1,0 +1,90 @@
+/**
+ * The one exit table all seven `governance` verbs allocate from, so a code means one thing across
+ * this group whichever verb produced it
+ * (`claude-plugins/fabrika/skills/governance/contract.md`, the shared exit taxonomy).
+ *
+ * Every shared seat is **imported**, never restated as a numeral: a restated numeral is a second
+ * source that can drift silently, and an import cannot. Each import comes from the module that owns
+ * the meaning this group proves — `report` for the writing seats, `triage` for the off-vocabulary
+ * one (its `OFF_VOCABULARY` *is* `report`'s `CLASSIFIED`, so there is no numeric difference to hunt
+ * for; the name is where the reading is stated), and `review` for the two facts this group proves
+ * identically.
+ *
+ * Three readings on this table are one another's opposites, and keeping them apart is the whole
+ * point: `1`/`127` is *the call never decided*, {@link PRECONDITION_UNKNOWN} is *a precondition read
+ * failed and nothing was written*, {@link WRITE_UNKNOWN} is *a write was attempted and its outcome
+ * is UNKNOWN*, and every code at `3` and above is something a verb **proved** — with nothing on
+ * stdout (`../verb.ts`'s `refuse` hardcodes that).
+ *
+ * `0`, `1`, `2` and `127` are reserved by the interface convention (`../verb.ts`, `../bin.ts`).
+ */
+
+import {
+	BARE_AT_PATH as REPORT_BARE_AT_PATH,
+	EMPTY_STDIN as REPORT_EMPTY_STDIN,
+	LEAKED_PATH as REPORT_LEAKED_PATH,
+	NO_TARGET as REPORT_NO_TARGET,
+	PRECONDITION_UNKNOWN as REPORT_PRECONDITION_UNKNOWN,
+	READBACK_MISMATCH as REPORT_READBACK_MISMATCH,
+	WRITE_UNKNOWN as REPORT_WRITE_UNKNOWN,
+} from "../report/codes.ts";
+import {
+	INCOMPLETE_SCAN as REVIEW_INCOMPLETE_SCAN,
+	STALE_HEAD as REVIEW_STALE_HEAD,
+} from "../review/codes.ts";
+import {OFF_VOCABULARY as TRIAGE_OFF_VOCABULARY} from "../triage/codes.ts";
+
+/** Stdin was read and held nothing. `governance post` and `governance readout` only. */
+export const EMPTY_STDIN = REPORT_EMPTY_STDIN;
+/** The **authored** text carries a machine-local path. */
+export const LEAKED_PATH = REPORT_LEAKED_PATH;
+/** The **authored** text is a bare `@` path reference — not redactable, so a second code. */
+export const BARE_AT_PATH = REPORT_BARE_AT_PATH;
+/**
+ * Zero scope: the target is **proven absent (404)** or closed, the PR has zero changed files, the
+ * corpus holds zero decision records, the window holds zero landings, or the readout artifact is
+ * proven absent — a fail-closed refusal (ADR 0092).
+ *
+ * *Proven* is the operative word. A 404 is a fact about the repository; an unreachable GitHub is not
+ * a fact about anything and lands on {@link PRECONDITION_UNKNOWN}.
+ */
+export const ZERO_SCOPE = REPORT_NO_TARGET;
+/** The write itself failed — the outcome is **UNKNOWN**, deliberately not `1`. */
+export const WRITE_UNKNOWN = REPORT_WRITE_UNKNOWN;
+/** The write landed but the read-back does not match. The artifact exists and needs a human. */
+export const READBACK_MISMATCH = REPORT_READBACK_MISMATCH;
+/**
+ * A supplied value is off the closed vocabulary — a bad `--polarity`, a `--sha` that is not a head
+ * SHA, an unparseable `--since`, a `--record` that is not a four-digit id, a `--path` outside this
+ * skill's own resolved directory.
+ */
+export const OFF_VOCABULARY = TRIAGE_OFF_VOCABULARY;
+/** A precondition read failed — nothing was written and the outcome is UNKNOWN. */
+export const PRECONDITION_UNKNOWN = REPORT_PRECONDITION_UNKNOWN;
+
+/** Refused: the `--sha` given is not the PR's head — `review`'s seat, for the same proven fact. */
+export const STALE_HEAD = REVIEW_STALE_HEAD;
+/** Refused: the read completed and its scope is **provably incomplete** — `review`'s seat again. */
+export const INCOMPLETE_SCAN = REVIEW_INCOMPLETE_SCAN;
+
+/**
+ * Refused: this PR's diff derives **no** governance namespace.
+ *
+ * This group's one private seat, and deliberately **declared here rather than imported**. It is not
+ * {@link OFF_VOCABULARY}: that is a value off a closed vocabulary, a caller typo. This is a *proven
+ * fact about the PR* — the diff was read, bound and partitioned, and it derives no governance
+ * namespace. Folding them would make "you asked wrongly" and "this PR is not mine to judge" one
+ * number, and only the second is safe to treat as a clean skip. `review/codes.ts` seats its own `14`
+ * as `ACL_DENIED`; that is a different group's private band and carries no cross-group uniqueness
+ * obligation, so importing `14` from `review` beside `12` and `13` would silently take the wrong
+ * meaning (interface convention rule 3).
+ */
+export const NOT_HARNESS_TOUCHING = 14;
+
+/**
+ * The unallocated code: `report file`'s body-section seat, which no verb here performs.
+ *
+ * Registered rather than silently absent, so the gap is a decision the alignment check can read
+ * (`../exit-code-alignment.ts` excludes this export from a table's allocations).
+ */
+export const DELIBERATE_GAP = 4;

--- a/packages/fabrika-cli/src/governance/codes.unit.test.ts
+++ b/packages/fabrika-cli/src/governance/codes.unit.test.ts
@@ -1,0 +1,51 @@
+import {describe, expect, it} from "vitest";
+import * as report from "../report/codes.ts";
+import * as review from "../review/codes.ts";
+import * as triage from "../triage/codes.ts";
+import * as governance from "./codes.ts";
+
+/**
+ * The table's own laws, asserted here rather than left to the alignment guard.
+ *
+ * The alignment guard proves the shared seats sit on the base's numbers. What it cannot prove is the
+ * distinction this group's contract turns on — that "nothing was written", "a write was attempted and
+ * its outcome is unknown", and "the call never decided" are three different numbers.
+ */
+describe("the governance exit table", () => {
+	it("imports every shared seat rather than restating a numeral", () => {
+		expect(governance.EMPTY_STDIN).toBe(report.EMPTY_STDIN);
+		expect(governance.LEAKED_PATH).toBe(report.LEAKED_PATH);
+		expect(governance.BARE_AT_PATH).toBe(report.BARE_AT_PATH);
+		expect(governance.ZERO_SCOPE).toBe(report.NO_TARGET);
+		expect(governance.WRITE_UNKNOWN).toBe(report.WRITE_UNKNOWN);
+		expect(governance.READBACK_MISMATCH).toBe(report.READBACK_MISMATCH);
+		expect(governance.PRECONDITION_UNKNOWN).toBe(report.PRECONDITION_UNKNOWN);
+	});
+
+	it("takes the off-vocabulary seat from `triage`, where this group's reading is named", () => {
+		expect(governance.OFF_VOCABULARY).toBe(triage.OFF_VOCABULARY);
+	});
+
+	it("takes the two facts it proves identically from `review`", () => {
+		expect(governance.STALE_HEAD).toBe(review.STALE_HEAD);
+		expect(governance.INCOMPLETE_SCAN).toBe(review.INCOMPLETE_SCAN);
+	});
+
+	it("declares `14` locally — importing `review`'s would take ACL_DENIED's meaning silently", () => {
+		expect(governance.NOT_HARNESS_TOUCHING).toBe(14);
+		expect(review.ACL_DENIED).toBe(14);
+		// Same number, different meanings, in two private bands. The test is that this group DECLARED
+		// it: a re-export would make the two one binding and the wrong reading would ride along.
+		expect(governance.NOT_HARNESS_TOUCHING).not.toBe(governance.OFF_VOCABULARY);
+	});
+
+	it("keeps the three unknowns apart — nothing-written, write-unproven, and the reserved failure", () => {
+		const seats = [governance.PRECONDITION_UNKNOWN, governance.WRITE_UNKNOWN, 1, 127];
+		expect(new Set(seats).size).toBe(seats.length);
+	});
+
+	it("holds `4` as a registered gap, not a free slot", () => {
+		expect(governance.DELIBERATE_GAP).toBe(4);
+		expect(governance.DELIBERATE_GAP).toBe(report.BAD_SECTIONS);
+	});
+});

--- a/packages/fabrika-cli/src/governance/command.ts
+++ b/packages/fabrika-cli/src/governance/command.ts
@@ -1,0 +1,279 @@
+/**
+ * The `governance` verb group — `fabrika governance <scope|sweep|guards|base|post|digest|readout>`,
+ * the `governance` skill's machine half.
+ *
+ * The adapter and nothing else: it declares the flags (`--help` is the interface, so every flag
+ * carries a one-line description), reads the one machine fact this group does not derive — the wall
+ * clock — runs the pure verb, and emits its outcome. Every decision lives in the `*-verb.ts` modules
+ * beside it, which is what makes each refusal testable without spawning a process.
+ *
+ * **Every leaf is declared with `leafCommand`, never a bare `Command.make`** — the bare form silently
+ * opts out of the excess-operand guard, which `../excess-operand.unit.test.ts` reds on.
+ *
+ * **`--polarity` is declared as a string and checked in the verb.** The check is the closed set's, and
+ * seating it in the verb is what lets the refusal name the whole vocabulary and seat it on `10` rather
+ * than emit the parser's generic message.
+ */
+
+import {Effect, Option} from "effect";
+import {Argument, Command, Flag} from "effect/unstable/cli";
+import {leafCommand} from "../excess-operand.ts";
+import {readStdin} from "../io/stdin.ts";
+import type {VerbOutcome} from "../verb.ts";
+import {runBase} from "./base-verb.ts";
+import {runDigest} from "./digest-verb.ts";
+import {runGuards} from "./guards-verb.ts";
+import {runPost} from "./post-verb.ts";
+import {runReadout} from "./readout-verb.ts";
+import {runScope} from "./scope-verb.ts";
+import {runSweep} from "./sweep-verb.ts";
+
+/** Write the outcome and exit on its code — stdout is the answer, everything else is stderr. */
+const emit = (outcome: VerbOutcome): Effect.Effect<void> =>
+	Effect.sync(() => {
+		for (const line of outcome.stderr) process.stderr.write(`${line}\n`);
+		if (outcome.stdout !== "") process.stdout.write(outcome.stdout);
+		process.exit(outcome.code);
+	});
+
+const repoFlag = Flag.string("repo").pipe(
+	Flag.optional,
+	Flag.withDescription(
+		"the target owner/name (default: $CLAUDE_PIPELINE_REPO, else $GITHUB_REPOSITORY, else the origin remote)",
+	),
+);
+
+const shaFlag = Flag.string("sha").pipe(
+	Flag.optional,
+	Flag.withDescription(
+		"the head to read at; must be the PR's head, or the verb refuses on 12 rather than judging a tree the PR moved past",
+	),
+);
+
+const jsonFlag = Flag.boolean("json").pipe(
+	Flag.withDescription("emit the result object on stdout instead of the line grammar"),
+);
+
+const dirFlag = Flag.string("dir").pipe(
+	Flag.withDefault(".decisions"),
+	Flag.withDescription("the decision-record corpus to read"),
+);
+
+const prArgument = Argument.integer("pr").pipe(Argument.withDescription("the pull-request number"));
+
+const scope = leafCommand(
+	"scope",
+	{pr: prArgument, sha: shaFlag, repo: repoFlag, json: jsonFlag},
+	Effect.fn(function* ({pr, sha, repo, json}) {
+		yield* emit(
+			yield* runScope({
+				pr,
+				sha: Option.getOrNull(sha),
+				repo: Option.getOrNull(repo),
+				json,
+				env: process.env,
+			}),
+		);
+	}),
+).pipe(
+	Command.withDescription(
+		"Derive whether this PR's diff requires the governance namespace, over which of the four harness roots, at the bound head. Prints `governance\\t<required|not-required>\\t<head>`, then a `root` line per touched root, `self`, and a `record` line per decision record in the diff. This is NOT a §CP classification — §CP is CODEOWNERS' answer, and the verb says so on stderr every run. Exits 7 (the PR is absent, closed, or has zero changed files), 10 (--sha is not a head SHA), 11 (the PR or the commit binding could not be read — the derivation is UNKNOWN, never not-required), 12 (--sha is not the PR's head), 13 (the changed-file enumeration is provably short). Example: fabrika governance scope 4321",
+	),
+);
+
+const sweep = leafCommand(
+	"sweep",
+	{
+		pr: Argument.integer("pr").pipe(
+			Argument.optional,
+			Argument.withDescription(
+				"the pull-request the subject record lives in; required unless --landed is given",
+			),
+		),
+		record: Flag.string("record").pipe(
+			Flag.optional,
+			Flag.withDescription("the four-digit id of the decision record in that PR to sweep"),
+		),
+		landed: Flag.string("landed").pipe(
+			Flag.optional,
+			Flag.withDescription(
+				"sweep a record already in --dir instead of one in a PR — the digest-time mode; never combined with the positional",
+			),
+		),
+		sha: shaFlag,
+		dir: dirFlag,
+		limit: Flag.integer("limit").pipe(
+			Flag.withDefault(8),
+			Flag.withDescription("the maximum shortlist entries"),
+		),
+		repo: repoFlag,
+		json: jsonFlag,
+	},
+	Effect.fn(function* ({pr, record, landed, sha, dir, limit, repo, json}) {
+		yield* emit(
+			yield* runSweep({
+				pr: Option.getOrNull(pr),
+				record: Option.getOrNull(record),
+				landed: Option.getOrNull(landed),
+				sha: Option.getOrNull(sha),
+				dir,
+				limit,
+				repo: Option.getOrNull(repo),
+				json,
+				env: process.env,
+			}),
+		);
+	}),
+).pipe(
+	Command.withDescription(
+		"Rank the uncited live-accepted records whose decision domain the subject touches, reading the subject out of a bound commit or out of the corpus. All three outcomes — shortlist, no-overlap, indeterminate — exit 0 and none of them is a clearance. Exits 7 (--dir holds zero records, or the PR is absent or closed), 10 (a non-four-digit id, a --sha that is not a head SHA, a negative --limit, or both a PR and --landed), 11 (the subject or a corpus member could not be read — an incomplete corpus is UNKNOWN), 12 (--sha is not the PR's head), 13 (the changed-file list proving the record is in this PR is provably short). Example: fabrika governance sweep 4321 --record 0240",
+	),
+);
+
+const guards = leafCommand(
+	"guards",
+	{pr: prArgument, sha: shaFlag, repo: repoFlag, json: jsonFlag},
+	Effect.fn(function* ({pr, sha, repo, json}) {
+		yield* emit(
+			yield* runGuards({
+				pr,
+				sha: Option.getOrNull(sha),
+				repo: Option.getOrNull(repo),
+				json,
+				env: process.env,
+			}),
+		);
+	}),
+).pipe(
+	Command.withDescription(
+		"Scan the bound diff for anchored invariants it removes or modifies, and report the guard-bearing files it touches. Prints `guards\\t<hits|no-anchor-change|no-anchors-in-reach>\\t<anchors-in-reach>` then an `anchor` line per hit and a `guard-file` line per touched guard-bearing file. no-anchors-in-reach is the scan reporting its own silence, never a clearance. Exits 7 (the PR is absent, closed, or empty), 10 (--sha is not a head SHA), 11 (the diff could not be read — UNKNOWN, never no-anchor-change), 12 (--sha is not the PR's head), 13 (the diff is provably incomplete). Example: fabrika governance guards 4321",
+	),
+);
+
+const base = leafCommand(
+	"base",
+	{
+		pr: prArgument,
+		path: Flag.string("path").pipe(
+			Flag.atLeast(0),
+			Flag.withDescription(
+				"a repo-relative path inside this skill's own resolved directory to read at the merge base; repeatable, defaults to SKILL.md and contract.md",
+			),
+		),
+		repo: repoFlag,
+	},
+	Effect.fn(function* ({pr, path, repo}) {
+		yield* emit(yield* runBase({pr, path, repo: Option.getOrNull(repo), env: process.env}));
+	}),
+).pipe(
+	Command.withDescription(
+		"Read this skill's own text at the merge base of a PR that edits it — the self fence's bytes, as a pasteable literal. Prints `base\\t<merge-base>\\t<file-count>` then a `file\\t<path>\\t<byte-count>` header and that file's bytes per path; the byte count is the delimiter, there is no separator line. Exits 7 (the PR is absent or closed, the skill root resolved to zero matches, or every --path is absent at the merge base), 10 (a --path outside the resolved skill root), 11 (the merge base or a path could not be read, or the skill root resolved to more than one candidate), 12 (the head moved while the base was being resolved). Example: fabrika governance base 4321",
+	),
+);
+
+const post = leafCommand(
+	"post",
+	{
+		pr: prArgument,
+		polarity: Flag.string("polarity").pipe(
+			Flag.withDescription("PASS or FAIL — a third token is not a polarity"),
+		),
+		sha: Flag.string("sha").pipe(
+			Flag.withDescription("the head the reviewer actually inspected (7-40 lowercase hex)"),
+		),
+		clause: Flag.string("clause").pipe(
+			Flag.withDescription("the human clause; blank is not a clause"),
+		),
+		repo: repoFlag,
+		json: jsonFlag,
+	},
+	Effect.fn(function* ({pr, polarity, sha, clause, repo, json}) {
+		yield* emit(
+			yield* runPost({
+				pr,
+				polarity,
+				sha,
+				clause,
+				repo: Option.getOrNull(repo),
+				json,
+				env: process.env,
+				stdin: Effect.sync(readStdin),
+			}),
+		);
+	}),
+).pipe(
+	Command.withDescription(
+		'Post the governance verdict read from STDIN: compose through the verdict-marker format, re-resolve the head, re-derive the namespace at the bound commit, leak-scan, upsert one comment, read it back. The namespace is fixed — there is no --namespace, so this verb cannot be aimed at another gate\'s. Prints `posted\\tgovernance\\t<polarity>\\t<sha>\\t<created|edited>\\t<url>`. Exits 3 (stdin held nothing), 5/6 (a machine-local path, a bare @ reference), 7 (the PR is absent or closed), 8/9 (the write was unproven, the read-back differs), 10 (a bad --polarity, --sha or blank --clause), 11 (a precondition read failed — nothing was posted), 12 (the head moved past --sha), 14 (the diff derives no governance namespace). Example: fabrika governance post 4321 --polarity PASS --sha 03135b91 --clause "no contradiction, no weakening" < verdict.md',
+	),
+);
+
+const digest = leafCommand(
+	"digest",
+	{
+		since: Flag.string("since").pipe(
+			Flag.withDescription("the window's inclusive start, YYYY-MM-DD"),
+		),
+		until: Flag.string("until").pipe(
+			Flag.optional,
+			Flag.withDescription("the window's inclusive end, YYYY-MM-DD; defaults to today"),
+		),
+		dir: dirFlag,
+		base: Flag.string("base").pipe(
+			Flag.withDefault("origin/main"),
+			Flag.withDescription("the ref whose history is walked; fetched before the walk"),
+		),
+		json: jsonFlag,
+	},
+	Effect.fn(function* ({since, until, dir, base: ref, json}) {
+		yield* emit(
+			yield* runDigest({
+				since,
+				until: Option.getOrNull(until),
+				dir,
+				base: ref,
+				json,
+				now: Effect.sync(() => Date.now()),
+			}),
+		);
+	}),
+).pipe(
+	Command.withDescription(
+		"List the decision records that landed in a window, each with its status as written, its landing commit, and that commit's anchor delta. `none` is a PROVEN answer at exit 0 — the window was walked and nothing landed. This verb ranks nothing: tension and blast radius are judgment. Exits 7 (--dir is absent or holds zero records), 10 (a malformed date, or --until before --since), 11 (--base could not be fetched or a landing commit could not be read — UNKNOWN, never none), 13 (a shallow clone whose graft boundary falls inside the window). Example: fabrika governance digest --since 2026-08-02",
+	),
+);
+
+const readout = leafCommand(
+	"readout",
+	{
+		issue: Argument.integer("issue").pipe(
+			Argument.optional,
+			Argument.withDescription(
+				'the durable readout artifact\'s issue number; resolved from $FABRIKA_GOVERNANCE_READOUT_ISSUE, else the single open issue titled "Governance readout", when omitted',
+			),
+		),
+		repo: repoFlag,
+		json: jsonFlag,
+	},
+	Effect.fn(function* ({issue, repo, json}) {
+		yield* emit(
+			yield* runReadout({
+				issue: Option.getOrNull(issue),
+				repo: Option.getOrNull(repo),
+				json,
+				env: process.env,
+				stdin: Effect.sync(readStdin),
+			}),
+		);
+	}),
+).pipe(
+	Command.withDescription(
+		"Publish the ranked rows read from STDIN onto the durable readout artifact: compose through the governance-digest format, leak-scan, upsert the one comment, read it back in order. It gates nothing — there is no outcome here meaning the corpus is in a bad state. Prints `readout\\t<issue>\\t<rows>\\t<created|edited>\\t<url>`. Exits 3 (stdin held nothing), 5/6 (a machine-local path, a bare @ reference), 7 (the artifact is absent, closed, or unresolvable), 8/9 (the write was unproven, the read-back differs), 10 (a row's kind or id is off the vocabulary), 11 (the issue or its comments could not be read — nothing was written), 13 (the comment enumeration is provably short). Example: printf 'row\\t0240\\troutine\\tno tension found\\n' | fabrika governance readout 4952",
+	),
+);
+
+export const governanceCommand = Command.make("governance").pipe(
+	Command.withSubcommands([scope, sweep, guards, base, post, digest, readout]),
+	Command.withDescription(
+		"Keep the governance corpus honest: derive the namespace a diff requires, rank the records it may contradict, scan the anchored invariants it moves, read this skill's own text at the merge base, emit the one verdict, and publish the periodic non-blocking readout",
+	),
+);

--- a/packages/fabrika-cli/src/governance/digest-verb.ts
+++ b/packages/fabrika-cli/src/governance/digest-verb.ts
@@ -1,0 +1,207 @@
+/**
+ * `governance digest` — the decision records that landed in a window, each with its id, title,
+ * status, landing commit and the anchor delta of that commit's own diff.
+ *
+ * **`none` is a proven answer at exit 0** — the window was walked and nothing landed in it. Empty
+ * stdout would be byte-identical to a verb that never ran, which is v1's `adr-sweep.sh` scar.
+ *
+ * **The `status` field is reported, never interpreted.** Nine records on `main` read `proposed` while
+ * being enforced at a live gate (#4388), so a consumer that treats `proposed` as "not law" is reading
+ * a claim as an observation. The verb prints what is there and the skill judges what it means.
+ *
+ * **This verb ranks nothing.** Tension and blast radius are the two ruled ranking dimensions and both
+ * are judgment; a ranking verb would be a second judgement wearing a verb's clothes.
+ */
+import {Effect} from "effect";
+import type {ChildProcessSpawner} from "effect/unstable/process";
+import {idFromFile, isFourDigitId, statusOf, titleOf} from "../adr/records.ts";
+import {
+	commitDiff,
+	commitStatuses,
+	fetchAndResolve,
+	isShallowClone,
+	listTreePaths,
+	logCommitsTouching,
+	parentlessCommitDates,
+	readFileAt,
+} from "../io/git.ts";
+import {answer, refuse, type VerbOutcome} from "../verb.ts";
+import {scanAnchors} from "./anchors.ts";
+import {INCOMPLETE_SCAN, OFF_VOCABULARY, PRECONDITION_UNKNOWN, ZERO_SCOPE} from "./codes.ts";
+
+const VERB = "governance digest";
+
+const DAY = /^\d{4}-\d{2}-\d{2}$/;
+
+export interface DigestOptions {
+	readonly since: string;
+	readonly until: string | null;
+	readonly dir: string;
+	readonly base: string;
+	readonly json: boolean;
+	/** The wall clock `--until` defaults from — a port so a test can pin the window's open end. */
+	readonly now: Effect.Effect<number>;
+}
+
+/** One decision record that landed inside the window. */
+export interface Landing {
+	readonly id: string;
+	readonly status: string;
+	readonly commit: string;
+	readonly date: string;
+	readonly anchorsTouched: number;
+	readonly title: string;
+	readonly path: string;
+}
+
+export const runDigest = (
+	options: DigestOptions,
+): Effect.Effect<VerbOutcome, never, ChildProcessSpawner.ChildProcessSpawner> =>
+	Effect.gen(function* () {
+		const {json} = options;
+		if (!DAY.test(options.since)) {
+			return refuse(
+				OFF_VOCABULARY,
+				`${VERB}: --since "${options.since}" is not a YYYY-MM-DD date.`,
+			);
+		}
+		const until = options.until ?? new Date(yield* options.now).toISOString().slice(0, 10);
+		if (!DAY.test(until)) {
+			return refuse(OFF_VOCABULARY, `${VERB}: --until "${until}" is not a YYYY-MM-DD date.`);
+		}
+		if (until < options.since) {
+			return refuse(
+				OFF_VOCABULARY,
+				`${VERB}: --until ${until} precedes --since ${options.since} — an empty window is a usage error, not a result.`,
+			);
+		}
+		const dir = options.dir.replace(/\/+$/, "");
+
+		// The base is FETCHED before it is walked: a stale checkout is how withdrawn doctrine gets
+		// applied after its withdrawal (#4338) and how four seats declared a merged ADR nonexistent
+		// (#4163).
+		const base = yield* fetchAndResolve(options.base);
+		if (base._tag === "Failure") {
+			return refuse(
+				PRECONDITION_UNKNOWN,
+				`${VERB}: cannot fetch or resolve ${options.base}: ${base.reason} — what landed is UNKNOWN, never "none".`,
+			);
+		}
+
+		const shallow = yield* isShallowClone;
+		if (shallow._tag === "Failure") {
+			return refuse(
+				PRECONDITION_UNKNOWN,
+				`${VERB}: cannot tell whether this clone is shallow: ${shallow.reason} — what landed is UNKNOWN, never "none".`,
+			);
+		}
+		if (shallow.value) {
+			const boundary = yield* parentlessCommitDates(base.value);
+			if (boundary._tag === "Failure") {
+				return refuse(
+					PRECONDITION_UNKNOWN,
+					`${VERB}: cannot read this clone's graft boundary: ${boundary.reason} — what landed is UNKNOWN, never "none".`,
+				);
+			}
+			const inside = boundary.value.find((day) => day >= options.since && day <= until);
+			if (inside !== undefined) {
+				return refuse(
+					INCOMPLETE_SCAN,
+					`${VERB}: the history is shallow and its boundary at ${inside} falls inside the window — refusing a partial landing list (#3999's class).`,
+				);
+			}
+		}
+
+		const tree = yield* listTreePaths(base.value);
+		if (tree._tag === "Failure") {
+			return refuse(
+				PRECONDITION_UNKNOWN,
+				`${VERB}: cannot list ${dir} at ${base.value}: ${tree.reason} — what landed is UNKNOWN, never "none".`,
+			);
+		}
+		const corpus = tree.value.filter(
+			(path) => path.startsWith(`${dir}/`) && idFromFile(path.split("/").pop() ?? "") !== null,
+		);
+		if (corpus.length === 0) {
+			return refuse(
+				ZERO_SCOPE,
+				`${VERB}: scanned ${dir}, 0 decision records — refusing to answer (ADR 0092).`,
+			);
+		}
+
+		const commits = yield* logCommitsTouching(base.value, options.since, until, dir);
+		if (commits._tag === "Failure") {
+			return refuse(
+				PRECONDITION_UNKNOWN,
+				`${VERB}: cannot walk ${options.base}: ${commits.reason} — what landed is UNKNOWN, never "none".`,
+			);
+		}
+
+		const records: Landing[] = [];
+		for (const commit of commits.value) {
+			const touched = yield* commitStatuses(commit.sha, dir);
+			if (touched._tag === "Failure") {
+				return refuse(
+					PRECONDITION_UNKNOWN,
+					`${VERB}: cannot read landing commit ${commit.sha}: ${touched.reason} — the window is UNKNOWN.`,
+				);
+			}
+			const diff = yield* commitDiff(commit.sha);
+			if (diff._tag === "Failure") {
+				return refuse(
+					PRECONDITION_UNKNOWN,
+					`${VERB}: cannot read landing commit ${commit.sha}: ${diff.reason} — the window is UNKNOWN.`,
+				);
+			}
+			const anchorsTouched = scanAnchors(diff.value).length;
+			for (const entry of touched.value) {
+				const id = idFromFile(entry.path.split("/").pop() ?? "");
+				// A deletion has no frontmatter to read at this commit, and a lettered variant is not
+				// addressable by the four-digit id every sibling verb takes.
+				if (id === null || !isFourDigitId(id) || entry.status.startsWith("D")) continue;
+				const bytes = yield* readFileAt(commit.sha, entry.path);
+				if (bytes._tag === "Failure") {
+					return refuse(
+						PRECONDITION_UNKNOWN,
+						`${VERB}: cannot read landing commit ${commit.sha}: ${bytes.reason} — the window is UNKNOWN.`,
+					);
+				}
+				records.push({
+					id,
+					status: statusOf(bytes.value) ?? "",
+					commit: commit.sha.slice(0, 8),
+					date: commit.date,
+					anchorsTouched,
+					title: titleOf(bytes.value),
+					path: entry.path,
+				});
+			}
+		}
+
+		const diagnostics = [
+			`${VERB}: walked ${options.base} from ${options.since} to ${until}, ${commits.value.length} commits touching ${dir}.`,
+		];
+		const outcome = records.length === 0 ? "none" : "landed";
+		if (json) {
+			return answer(
+				JSON.stringify({
+					outcome,
+					count: records.length,
+					records,
+					window: {since: options.since, until},
+					base: options.base,
+				}),
+				diagnostics,
+			);
+		}
+		return answer(
+			[
+				`digest\t${outcome}\t${records.length}`,
+				...records.map(
+					(row) =>
+						`landed\t${row.id}\t${row.status}\t${row.commit}\t${row.date}\t${row.anchorsTouched}\t${row.title}`,
+				),
+			].join("\n"),
+			diagnostics,
+		);
+	});

--- a/packages/fabrika-cli/src/governance/digest-verb.unit.test.ts
+++ b/packages/fabrika-cli/src/governance/digest-verb.unit.test.ts
@@ -1,0 +1,179 @@
+import {Effect} from "effect";
+import {describe, expect, it} from "vitest";
+import {errOut, fakeShell, okOut, record} from "../fakes.test-support.ts";
+import type {ExecResult} from "../io/exec.ts";
+import {INCOMPLETE_SCAN, OFF_VOCABULARY, PRECONDITION_UNKNOWN, ZERO_SCOPE} from "./codes.ts";
+import {runDigest} from "./digest-verb.ts";
+
+const BASE_SHA = "0f1e2d3c4b5a69788796a5b4c3d2e1f009182736";
+const LANDING = "1f8e83b1aa04f7e2c9d8b1640a5c22e9f01b7d3c";
+const PATH = ".decisions/0240-only-landed-adrs-may-be-cited.md";
+
+const REMOTES = [/^git remote$/, okOut("origin\n")] as const;
+const FETCH = [/^git fetch --quiet origin main$/, okOut("")] as const;
+const RESOLVE = [
+	/^git rev-parse --verify --quiet origin\/main\^\{commit\}$/,
+	okOut(`${BASE_SHA}\n`),
+] as const;
+const SHALLOW = [/^git rev-parse --is-shallow-repository$/, okOut("false\n")] as const;
+const TREE = [
+	new RegExp(`^git ls-tree -r --name-only -z ${BASE_SHA}$`),
+	okOut(`${PATH}\0.decisions/0238-fabrika-reimplements-v1.md\0src/cart.ts\0`),
+] as const;
+const LOG = [
+	/^git log --reverse --format=%H%x09%cI /,
+	okOut(`${LANDING}\t2026-08-08T09:12:00Z\n`),
+] as const;
+const STATUSES = [
+	new RegExp(`^git show .* --name-status -z --format= ${LANDING} -- \\.decisions$`),
+	okOut(`A\0${PATH}\0`),
+] as const;
+const COMMIT_DIFF = [
+	new RegExp(`^git show .*--format= ${LANDING}$`),
+	okOut(
+		`diff --git a/skills/x.md b/skills/x.md\n--- a/skills/x.md\n+++ b/skills/x.md\n@@ -1,2 +1,2 @@\n-<!-- anchor: G --> one\n+<!-- anchor: G --> two\n`,
+	),
+] as const;
+const SHOW = [
+	new RegExp(`^git show ${LANDING}:\\.decisions/0240`),
+	okOut(record("0240", "accepted")),
+] as const;
+
+const options = {
+	since: "2026-08-02",
+	until: null as string | null,
+	dir: ".decisions",
+	base: "origin/main",
+	json: false,
+	now: Effect.succeed(Date.parse("2026-08-10T00:00:00Z")),
+};
+
+const run = (
+	script: ReadonlyArray<readonly [RegExp, ExecResult]>,
+	overrides: Partial<typeof options> = {},
+) =>
+	Effect.runPromise(Effect.provide(runDigest({...options, ...overrides}), fakeShell(script).layer));
+
+const happy: ReadonlyArray<readonly [RegExp, ExecResult]> = [
+	REMOTES,
+	FETCH,
+	RESOLVE,
+	SHALLOW,
+	TREE,
+	LOG,
+	STATUSES,
+	COMMIT_DIFF,
+	SHOW,
+];
+
+describe("runDigest", () => {
+	it("lists each landing with its status as written, commit, date and anchor delta", async () => {
+		const out = await run(happy);
+		expect(out.code).toBe(0);
+		expect(out.stdout).toBe(
+			[
+				"digest\tlanded\t1",
+				"landed\t0240\taccepted\t1f8e83b1\t2026-08-08\t1\tA decision about 0240",
+				"",
+			].join("\n"),
+		);
+	});
+
+	it("reports `status:` verbatim rather than interpreting it (#4388)", async () => {
+		const out = await run([...happy.slice(0, 8), [SHOW[0], okOut(record("0240", "proposed"))]]);
+		expect(out.stdout).toContain("\tproposed\t");
+	});
+
+	it("answers `none` at exit 0 over a walked window that carried nothing", async () => {
+		const out = await run([REMOTES, FETCH, RESOLVE, SHALLOW, TREE, [LOG[0], okOut("")]]);
+		expect(out.code).toBe(0);
+		expect(out.stdout).toBe("digest\tnone\t0\n");
+	});
+
+	it("emits the record with --json, naming the window it walked", async () => {
+		const out = await run(happy, {json: true, until: "2026-08-09"});
+		expect(JSON.parse(out.stdout)).toMatchObject({
+			outcome: "landed",
+			count: 1,
+			window: {since: "2026-08-02", until: "2026-08-09"},
+			base: "origin/main",
+		});
+	});
+
+	it("states the base, the window and the commit count on stderr", async () => {
+		const out = await run(happy, {until: "2026-08-09"});
+		expect(out.stderr.at(-1)).toBe(
+			"governance digest: walked origin/main from 2026-08-02 to 2026-08-09, 1 commits touching .decisions.",
+		);
+	});
+
+	it("FETCHES the base before it walks it — a stale checkout applies withdrawn doctrine", async () => {
+		const fake = fakeShell(happy);
+		await Effect.runPromise(Effect.provide(runDigest(options), fake.layer));
+		const fetched = fake.calls.indexOf("git fetch --quiet origin main");
+		const walked = fake.calls.findIndex((call) => call.startsWith("git log --reverse"));
+		expect(fetched).toBeGreaterThanOrEqual(0);
+		expect(fetched).toBeLessThan(walked);
+	});
+
+	it("refuses a malformed date, and a window that runs backwards, on 10", async () => {
+		expect((await run(happy, {since: "08/02/2026"})).code).toBe(OFF_VOCABULARY);
+		expect((await run(happy, {until: "2026-08-01"})).code).toBe(OFF_VOCABULARY);
+	});
+
+	it("refuses an unfetchable base on 11 — what landed is UNKNOWN, never `none`", async () => {
+		const out = await run([REMOTES, [FETCH[0], errOut("fatal: could not read from remote")]]);
+		expect(out.code).toBe(PRECONDITION_UNKNOWN);
+		expect(out.stderr.at(-1)).toContain('what landed is UNKNOWN, never "none"');
+	});
+
+	it("refuses a corpus with zero records on 7", async () => {
+		const out = await run([REMOTES, FETCH, RESOLVE, SHALLOW, [TREE[0], okOut("src/cart.ts\0")]]);
+		expect(out.code).toBe(ZERO_SCOPE);
+		expect(out.stderr.at(-1)).toBe(
+			"governance digest: scanned .decisions, 0 decision records — refusing to answer (ADR 0092).",
+		);
+	});
+
+	it("refuses a shallow clone whose boundary falls inside the window on 13", async () => {
+		const out = await run([
+			REMOTES,
+			FETCH,
+			RESOLVE,
+			[SHALLOW[0], okOut("true\n")],
+			[/^git log --max-parents=0 /, okOut("2026-08-05T00:00:00Z\n")],
+		]);
+		expect(out.code).toBe(INCOMPLETE_SCAN);
+		expect(out.stderr.at(-1)).toContain("refusing a partial landing list");
+	});
+
+	it("walks a shallow clone whose boundary predates the window", async () => {
+		const out = await run([
+			REMOTES,
+			FETCH,
+			RESOLVE,
+			[SHALLOW[0], okOut("true\n")],
+			[/^git log --max-parents=0 /, okOut("2026-01-01T00:00:00Z\n")],
+			TREE,
+			LOG,
+			STATUSES,
+			COMMIT_DIFF,
+			SHOW,
+		]);
+		expect(out.code).toBe(0);
+	});
+
+	it("refuses an unreadable landing commit on 11 rather than dropping it from the window", async () => {
+		const out = await run([
+			REMOTES,
+			FETCH,
+			RESOLVE,
+			SHALLOW,
+			TREE,
+			LOG,
+			[STATUSES[0], errOut("fatal: bad object")],
+		]);
+		expect(out.code).toBe(PRECONDITION_UNKNOWN);
+		expect(out.stderr.at(-1)).toContain("the window is UNKNOWN");
+	});
+});

--- a/packages/fabrika-cli/src/governance/fixtures.test-support.ts
+++ b/packages/fabrika-cli/src/governance/fixtures.test-support.ts
@@ -1,0 +1,56 @@
+/**
+ * The canned payloads the `governance` verb tests script their spawner with.
+ *
+ * The PR shape, the binding script and the head/base constants are **re-exported from the `review`
+ * group's fixtures** rather than copied: every verb here binds through the same `bindHead`, and two
+ * hand-written copies are two chances for a test to prove a binding the other group does not make.
+ * What is added below is only what this group reads that `review` does not — the `--name-status`
+ * stream and the tree listing.
+ */
+import {okOut} from "../fakes.test-support.ts";
+import type {ExecResult} from "../io/exec.ts";
+import {BASE, HEAD} from "../review/fixtures.test-support.ts";
+
+export {
+	BASE,
+	binding,
+	comments,
+	HEAD,
+	OLD_HEAD,
+	paths,
+	pull,
+} from "../review/fixtures.test-support.ts";
+
+const DIFF_FLAGS = "--no-ext-diff --no-color --find-renames --src-prefix=a/ --dst-prefix=b/";
+
+/** The bound status read: `git diff <flags> --name-status -z <base>...<head>`. */
+export const STATUS_AT = (base: string = BASE, head: string = HEAD): RegExp =>
+	new RegExp(`^git diff ${DIFF_FLAGS} --name-status -z ${base}\\.\\.\\.${head}$`);
+
+/** `--name-status -z` output: a status field then a path field, both NUL-terminated. */
+export const statuses = (...rows: ReadonlyArray<readonly [string, string]>): ExecResult =>
+	okOut(rows.map(([status, path]) => `${status}\0${path}\0`).join(""));
+
+/** The recursive tree read this group resolves a skill root and root presence from. */
+export const TREE_AT = (sha: string = HEAD): RegExp =>
+	new RegExp(`^git ls-tree -r --name-only -z ${sha}$`);
+
+export const treeOf = (...paths: ReadonlyArray<string>): ExecResult =>
+	okOut(paths.map((path) => `${path}\0`).join(""));
+
+/** One file's bytes at a commit. */
+export const SHOW_AT = (sha: string, path: string): RegExp =>
+	new RegExp(`^git show ${sha}:${path.replace(/[.*+?^${}()|[\]\\]/g, "\\$&")}$`);
+
+/** A tree that carries all four governance roots plus one install of this skill. */
+export const FULL_TREE: ReadonlyArray<string> = [
+	".decisions/0240-only-landed-adrs-may-be-cited.md",
+	".claude/settings.json",
+	".github/workflows/ci.yml",
+	"claude-plugins/fabrika/skills/governance/SKILL.md",
+	"claude-plugins/fabrika/skills/governance/contract.md",
+	"src/cart.ts",
+];
+
+/** The resolved skill root `FULL_TREE` yields. */
+export const SKILL_ROOT = "claude-plugins/fabrika/skills/governance/";

--- a/packages/fabrika-cli/src/governance/governance.cli.test.ts
+++ b/packages/fabrika-cli/src/governance/governance.cli.test.ts
@@ -1,0 +1,57 @@
+/**
+ * The end-to-end half: the **exit status and the bytes on each channel** a shell caller reads.
+ *
+ * Only a subprocess proves those, and each `it` costs one cold node+TS load of `bin.ts` — so spawn
+ * count is this file's cost (`.patterns/subprocess-test-budget.md`). Two spawns, both about facts no
+ * in-process test can establish: that the group is reachable by its registration alone, and that a
+ * refusal really does leave stdout empty across the process boundary. Everything else about these
+ * verbs is covered in-process by the `*-verb.unit.test.ts` files beside them.
+ */
+import {execFileSync} from "node:child_process";
+import {fileURLToPath} from "node:url";
+import {describe, expect, it} from "vitest";
+import {SUBPROCESS_TEST_TIMEOUT_MS} from "../test-budget.ts";
+import {OFF_VOCABULARY} from "./codes.ts";
+
+const BIN = fileURLToPath(new URL("../bin.ts", import.meta.url));
+
+interface Run {
+	readonly code: number;
+	readonly stdout: string;
+	readonly stderr: string;
+}
+
+/** `FABRIKA_SKIP_INFER` pins the invocation to this copy rather than whatever the repo root installs. */
+const fabrika = (args: ReadonlyArray<string>, stdin = ""): Run => {
+	try {
+		const stdout = execFileSync(process.execPath, [BIN, ...args], {
+			encoding: "utf8",
+			env: {...process.env, FABRIKA_SKIP_INFER: "1"},
+			input: stdin,
+			stdio: ["pipe", "pipe", "pipe"],
+		});
+		return {code: 0, stdout, stderr: ""};
+	} catch (err) {
+		const failure = err as {status?: number; stdout?: string; stderr?: string};
+		return {code: failure.status ?? -1, stdout: failure.stdout ?? "", stderr: failure.stderr ?? ""};
+	}
+};
+
+describe("fabrika governance, end to end", {timeout: SUBPROCESS_TEST_TIMEOUT_MS}, () => {
+	it("lists all seven verbs under --help by its registration alone", () => {
+		const run = fabrika(["governance", "--help"]);
+		expect(run.code).toBe(0);
+		for (const verb of ["scope", "sweep", "guards", "base", "post", "digest", "readout"]) {
+			expect(run.stdout).toContain(verb);
+		}
+	});
+
+	it("refuses an off-vocabulary date on its own code with NOTHING on stdout", () => {
+		const run = fabrika(["governance", "digest", "--since", "08/02/2026"]);
+		expect(run.code).toBe(OFF_VOCABULARY);
+		expect(run.stdout).toBe("");
+		expect(run.stderr).toContain(
+			'governance digest: --since "08/02/2026" is not a YYYY-MM-DD date.',
+		);
+	});
+});

--- a/packages/fabrika-cli/src/governance/guards-verb.ts
+++ b/packages/fabrika-cli/src/governance/guards-verb.ts
@@ -1,0 +1,139 @@
+/**
+ * `governance guards` — the anchored invariants the bound diff removes or modifies, and the
+ * guard-bearing files it touches.
+ *
+ * **The three outcomes are distinct facts and none is a clearance.** `hits` — an anchored invariant
+ * moved. `no-anchor-change` — anchors exist in the diff's reach and none moved. `no-anchors-in-reach`
+ * — the touched files carry no anchors at all, so this scan had nothing to look at. That third one is
+ * the mechanical floor reporting its own silence, not a statement that no guard was weakened: a guard
+ * weakened in prose carrying no anchor is invisible here by construction, and the skill's judgment is
+ * what covers it.
+ *
+ * A truncated diff is refused rather than scanned. An under-reported hit list reads as a
+ * checked-clean answer that was never checked (#3925's class).
+ */
+import {Effect} from "effect";
+import type {ChildProcessSpawner} from "effect/unstable/process";
+import {diffRange, diffRangeStatuses, readFileAt} from "../io/git.ts";
+import {badNumber, openPull, resolveTargetRepo} from "../review/target.ts";
+import {answer, refuse, type VerbOutcome} from "../verb.ts";
+import {anchorsIn, filesInDiff, isGuardBearing, scanAnchors} from "./anchors.ts";
+import {INCOMPLETE_SCAN, PRECONDITION_UNKNOWN} from "./codes.ts";
+import {bindGovernanceHead, boundLine} from "./head.ts";
+
+const VERB = "governance guards";
+
+const UNKNOWN_TAIL = "the diff cannot be bound to a commit, so what it shows is UNKNOWN.";
+
+export interface GuardsOptions {
+	readonly pr: number;
+	readonly sha: string | null;
+	readonly repo: string | null;
+	readonly json: boolean;
+	readonly env: Readonly<Record<string, string | undefined>>;
+}
+
+export const runGuards = (
+	options: GuardsOptions,
+): Effect.Effect<VerbOutcome, never, ChildProcessSpawner.ChildProcessSpawner> =>
+	Effect.gen(function* () {
+		const {pr, json} = options;
+		const bad = badNumber(VERB, "a pull-request number", pr);
+		if (bad !== null) return bad;
+
+		const resolved = yield* resolveTargetRepo(VERB, options.repo, options.env);
+		if (resolved._tag === "Refused") return resolved.outcome;
+		const repo = resolved.repo;
+
+		const target = yield* openPull(VERB, repo, pr, {
+			requireOpen: true,
+			closedReason: "nothing to scan.",
+			requireFiles: true,
+			emptyReason: "nothing to scan (ADR 0092).",
+			unknownMessage: (reason) =>
+				`${VERB}: cannot read PR #${pr} in ${repo}: ${reason} — UNKNOWN, never "nothing moved".`,
+		});
+		if (target._tag === "Refused") return target.outcome;
+
+		const bound = yield* bindGovernanceHead(VERB, UNKNOWN_TAIL, repo, pr, target.pull, options.sha);
+		if (bound._tag === "Refused") return bound.outcome;
+		const head = bound.head;
+		const diagnostics = [boundLine(VERB, head)];
+
+		const diff = yield* diffRange(head.base, head.sha);
+		if (diff._tag === "Failure") {
+			return refuse(
+				PRECONDITION_UNKNOWN,
+				`${VERB}: cannot read the diff for #${pr} at ${head.sha}: ${diff.reason} — UNKNOWN, never "nothing moved".`,
+				diagnostics,
+			);
+		}
+		const carried = filesInDiff(diff.value);
+		if (carried < target.pull.changedFiles) {
+			return refuse(
+				INCOMPLETE_SCAN,
+				`${VERB}: the diff at ${head.sha} carries ${carried} of #${pr}'s ${target.pull.changedFiles} declared files — refusing a partial anchor scan (#3925's class).`,
+				diagnostics,
+			);
+		}
+
+		const listed = yield* diffRangeStatuses(head.base, head.sha);
+		if (listed._tag === "Failure") {
+			return refuse(
+				PRECONDITION_UNKNOWN,
+				`${VERB}: cannot read the changed files of #${pr} at ${head.sha}: ${listed.reason} — UNKNOWN, never "nothing moved".`,
+				diagnostics,
+			);
+		}
+
+		// Anchors are counted at the bound commit rather than off the diff: `inReach` is how many
+		// anchored invariants EXIST in the files this diff touches, which is the denominator that makes
+		// "I scanned nothing and found nothing" unrenderable as a pass (ADR 0092).
+		const inTree: Array<{readonly path: string; readonly anchors: number}> = [];
+		for (const entry of listed.value) {
+			if (entry.status.startsWith("D")) continue;
+			const bytes = yield* readFileAt(head.sha, entry.path);
+			if (bytes._tag === "Failure") {
+				return refuse(
+					PRECONDITION_UNKNOWN,
+					`${VERB}: cannot read ${entry.path} at ${head.sha}: ${bytes.reason} — UNKNOWN, never "nothing moved".`,
+					diagnostics,
+				);
+			}
+			inTree.push({path: entry.path, anchors: anchorsIn(bytes.value)});
+		}
+
+		const hits = scanAnchors(diff.value);
+		const inReach = inTree.reduce((total, file) => total + file.anchors, 0);
+		const moved = new Set(hits.map((hit) => hit.file));
+		const guardFiles = inTree.filter(
+			(file) => isGuardBearing(file.path, file.anchors) && !moved.has(file.path),
+		);
+
+		const outcome =
+			hits.length > 0 ? "hits" : inReach === 0 ? "no-anchors-in-reach" : "no-anchor-change";
+		diagnostics.push(
+			`${VERB}: scanned ${listed.value.length} files, ${inReach} anchored invariants in reach.`,
+		);
+
+		if (json) {
+			return answer(
+				JSON.stringify({
+					outcome,
+					hits,
+					guardFiles: guardFiles.map((file) => ({path: file.path, anchors: file.anchors})),
+					inReach,
+					scanned: listed.value.length,
+				}),
+				diagnostics,
+			);
+		}
+		return answer(
+			[
+				`guards\t${outcome}\t${inReach}`,
+				...hits.map((hit) => `anchor\t${hit.kind}\t${hit.name}\t${hit.file}:${hit.line}`),
+				...guardFiles.map((file) => `guard-file\t${file.path}\t${file.anchors}`),
+			].join("\n"),
+			diagnostics,
+		);
+	});

--- a/packages/fabrika-cli/src/governance/guards-verb.unit.test.ts
+++ b/packages/fabrika-cli/src/governance/guards-verb.unit.test.ts
@@ -1,0 +1,163 @@
+import {Effect} from "effect";
+import {describe, expect, it} from "vitest";
+import {errOut, fakeShell, okOut} from "../fakes.test-support.ts";
+import type {ExecResult} from "../io/exec.ts";
+import {DIFF_AT} from "../review/fixtures.test-support.ts";
+import {INCOMPLETE_SCAN, PRECONDITION_UNKNOWN, STALE_HEAD, ZERO_SCOPE} from "./codes.ts";
+import {
+	binding,
+	HEAD,
+	OLD_HEAD,
+	pull,
+	SHOW_AT,
+	STATUS_AT,
+	statuses,
+} from "./fixtures.test-support.ts";
+import {runGuards} from "./guards-verb.ts";
+
+const PULL = /^gh api repos\/o\/r\/pulls\/4321$/;
+const SKILL = "claude-plugins/fabrika/skills/review/SKILL.md";
+
+const options = {
+	pr: 4321,
+	sha: null as string | null,
+	repo: null,
+	json: false,
+	env: {CLAUDE_PIPELINE_REPO: "o/r"} as Record<string, string | undefined>,
+};
+
+const run = (
+	script: ReadonlyArray<readonly [RegExp, ExecResult]>,
+	overrides: Partial<typeof options> = {},
+) =>
+	Effect.runPromise(Effect.provide(runGuards({...options, ...overrides}), fakeShell(script).layer));
+
+const diffOf = (path: string, ...body: ReadonlyArray<string>): string =>
+	[
+		`diff --git a/${path} b/${path}`,
+		`--- a/${path}`,
+		`+++ b/${path}`,
+		"@@ -12,2 +12,2 @@",
+		...body,
+		"",
+	].join("\n");
+
+const scripted = (
+	diff: string,
+	bytes: string,
+	path = SKILL,
+): ReadonlyArray<readonly [RegExp, ExecResult]> => [
+	[PULL, pull({changedFiles: 1})],
+	...binding(),
+	[DIFF_AT(), okOut(diff)],
+	[STATUS_AT(), statuses(["M", path])],
+	[SHOW_AT(HEAD, path), okOut(bytes)],
+];
+
+describe("runGuards", () => {
+	it("reports a modified anchor as a hit, with the file and line", async () => {
+		const out = await run(
+			scripted(
+				diffOf(
+					SKILL,
+					"-<!-- anchor: UNSEEN-NEVER-PLAUSIBLE --> an unseen surface is never plausible",
+					"+<!-- anchor: UNSEEN-NEVER-PLAUSIBLE --> an unseen surface may be plausible",
+				),
+				"<!-- anchor: UNSEEN-NEVER-PLAUSIBLE --> an unseen surface may be plausible\n",
+			),
+		);
+		expect(out.code).toBe(0);
+		expect(out.stdout).toBe(
+			[`guards\thits\t1`, `anchor\tmodified\tUNSEEN-NEVER-PLAUSIBLE\t${SKILL}:12`, ""].join("\n"),
+		);
+	});
+
+	it("answers `no-anchor-change` when anchors are in reach and none moved", async () => {
+		const out = await run(
+			scripted(diffOf(SKILL, "-prose", "+other prose"), "<!-- anchor: G --> g\n"),
+		);
+		expect(out.stdout).toBe(
+			[`guards\tno-anchor-change\t1`, `guard-file\t${SKILL}\t1`, ""].join("\n"),
+		);
+	});
+
+	it("answers `no-anchors-in-reach` when the touched files carry none — the floor's own silence", async () => {
+		const out = await run(
+			scripted(
+				diffOf("src/cart.ts", "-const a = 1;", "+const a = 2;"),
+				"const a = 2;\n",
+				"src/cart.ts",
+			),
+		);
+		expect(out.stdout).toBe(["guards\tno-anchors-in-reach\t0", ""].join("\n"));
+	});
+
+	it("lists a touched workflow as guard-bearing even with no anchor in it", async () => {
+		const path = ".github/workflows/ci.yml";
+		const out = await run(scripted(diffOf(path, "-  run: a", "+  run: b"), "jobs: {}\n", path));
+		expect(out.stdout).toContain(`guard-file\t${path}\t0`);
+	});
+
+	it("keeps a file whose anchor MOVED out of the guard-file list — it is already a hit", async () => {
+		const out = await run(
+			scripted(
+				diffOf(SKILL, "-<!-- anchor: G --> one", "+<!-- anchor: G --> two"),
+				"<!-- anchor: G --> two\n",
+			),
+		);
+		expect(out.stdout).not.toContain("guard-file");
+	});
+
+	it("states the scanned file count and the anchors in reach on stderr", async () => {
+		const out = await run(scripted(diffOf(SKILL, "-a", "+b"), "<!-- anchor: G --> g\n"));
+		expect(out.stderr.at(-1)).toBe(
+			"governance guards: scanned 1 files, 1 anchored invariants in reach.",
+		);
+	});
+
+	it("emits the record with --json", async () => {
+		const out = await run(scripted(diffOf(SKILL, "-<!-- anchor: G --> one"), "prose\n"), {
+			json: true,
+		});
+		expect(JSON.parse(out.stdout)).toMatchObject({
+			outcome: "hits",
+			hits: [{kind: "removed", name: "G", file: SKILL, line: 12}],
+			scanned: 1,
+		});
+	});
+
+	it("refuses an absent, closed, or empty PR on 7", async () => {
+		expect((await run([[PULL, errOut("gh: Not Found (HTTP 404)")]])).code).toBe(ZERO_SCOPE);
+		expect((await run([[PULL, pull({state: "closed"})]])).code).toBe(ZERO_SCOPE);
+		expect((await run([[PULL, pull({changedFiles: 0})]])).code).toBe(ZERO_SCOPE);
+	});
+
+	it("refuses an unreadable diff on 11 — UNKNOWN, never `nothing moved`", async () => {
+		const out = await run([
+			[PULL, pull({changedFiles: 1})],
+			...binding(),
+			[DIFF_AT(), errOut("fatal: bad revision")],
+		]);
+		expect(out.code).toBe(PRECONDITION_UNKNOWN);
+		expect(out.stderr.at(-1)).toContain('UNKNOWN, never "nothing moved"');
+	});
+
+	it("refuses a partial diff on 13 rather than scanning it", async () => {
+		const out = await run([
+			[PULL, pull({changedFiles: 4})],
+			...binding(),
+			[DIFF_AT(), okOut(diffOf(SKILL, "-a", "+b"))],
+		]);
+		expect(out.code).toBe(INCOMPLETE_SCAN);
+		expect(out.stdout).toBe("");
+		expect(out.stderr.at(-1)).toBe(
+			`governance guards: the diff at ${HEAD} carries 1 of #4321's 4 declared files — refusing a partial anchor scan (#3925's class).`,
+		);
+	});
+
+	it("refuses a --sha that is not the PR's head on 12", async () => {
+		expect((await run(scripted(diffOf(SKILL, "-a", "+b"), "x\n"), {sha: OLD_HEAD})).code).toBe(
+			STALE_HEAD,
+		);
+	});
+});

--- a/packages/fabrika-cli/src/governance/head.ts
+++ b/packages/fabrika-cli/src/governance/head.ts
@@ -1,0 +1,55 @@
+/**
+ * The commit binding every read in this group runs before it reads anything.
+ *
+ * The binding itself is **imported**, not restated: `../review/head.ts`'s `bindHead` already fetches
+ * `pull/<pr>/head`, refuses a `--sha` that is not the PR's head, and resolves both ends of the range
+ * out of the object database with nothing checked out. Re-deriving it here would be a second answer
+ * to a solved question — and the two would drift the first time one of them learned something.
+ *
+ * What this module adds is the **noun**. `bindHead`'s UNKNOWN refusal says "the artifact"; each verb
+ * here has to say what is unknown *to it*, because "the derivation is UNKNOWN" and "what the subject
+ * says is UNKNOWN" leave a reader free to guess differently. The rewrite is a fixed-substring swap on
+ * one message this module owns the shape of, so a change to `bindHead`'s wording surfaces as a failed
+ * unit test rather than as a silently un-rewritten refusal.
+ */
+import {Effect} from "effect";
+import type {ChildProcessSpawner} from "effect/unstable/process";
+import type {PullRecord} from "../io/pulls.ts";
+import {type Binding, bindHead, boundLine} from "../review/head.ts";
+import type {VerbOutcome} from "../verb.ts";
+import {PRECONDITION_UNKNOWN} from "./codes.ts";
+
+export type {Binding, BoundHead} from "../review/head.ts";
+export {boundLine};
+
+/** The tail `bindHead` writes, which each verb below replaces with its own. */
+const IMPORTED_TAIL = "the artifact cannot be bound to a commit, so what it shows is UNKNOWN.";
+
+/** Swap the imported tail for this verb's. A message that does not carry it is passed through. */
+export const withBindingNoun = (reason: string, tail: string): string =>
+	reason.endsWith(IMPORTED_TAIL) ? `${reason.slice(0, -IMPORTED_TAIL.length)}${tail}` : reason;
+
+/**
+ * Bind this run's read to one commit, phrasing the UNKNOWN refusal in this verb's own terms.
+ *
+ * `tail` is the clause after the em dash — e.g. `the file list cannot be bound to a commit, so the
+ * derivation is UNKNOWN.` Only the `11` arm is rewritten: the `10` and `12` arms already read as this
+ * group's contract states them, so touching them would be churn.
+ */
+export const bindGovernanceHead = (
+	verb: string,
+	tail: string,
+	repo: string,
+	pr: number,
+	pull: PullRecord,
+	asked: string | null,
+): Effect.Effect<Binding, never, ChildProcessSpawner.ChildProcessSpawner> =>
+	Effect.gen(function* () {
+		const bound = yield* bindHead(verb, repo, pr, pull, asked);
+		if (bound._tag !== "Refused" || bound.outcome.code !== PRECONDITION_UNKNOWN) return bound;
+		const outcome: VerbOutcome = {
+			...bound.outcome,
+			stderr: bound.outcome.stderr.map((line) => withBindingNoun(line, tail)),
+		};
+		return {_tag: "Refused" as const, outcome};
+	});

--- a/packages/fabrika-cli/src/governance/head.unit.test.ts
+++ b/packages/fabrika-cli/src/governance/head.unit.test.ts
@@ -1,0 +1,77 @@
+import {Effect} from "effect";
+import {describe, expect, it} from "vitest";
+import {fakeShell, okOut} from "../fakes.test-support.ts";
+import {PRECONDITION_UNKNOWN, STALE_HEAD} from "./codes.ts";
+import {binding, HEAD, OLD_HEAD} from "./fixtures.test-support.ts";
+import {bindGovernanceHead, withBindingNoun} from "./head.ts";
+
+const PULL_RECORD = {
+	number: 4321,
+	state: "open",
+	headSha: HEAD,
+	body: "",
+	changedFiles: 2,
+	comments: 0,
+	draft: false,
+	merged: false,
+	baseRef: "main",
+	autoMerge: false,
+	authorLogin: "usirin",
+};
+
+const TAIL = "the file list cannot be bound to a commit, so the derivation is UNKNOWN.";
+
+const bind = (
+	script: ReadonlyArray<readonly [RegExp, ReturnType<typeof okOut>]>,
+	asked: string | null = null,
+) =>
+	Effect.runPromise(
+		Effect.provide(
+			bindGovernanceHead("governance scope", TAIL, "o/r", 4321, PULL_RECORD, asked),
+			fakeShell(script).layer,
+		),
+	);
+
+describe("withBindingNoun", () => {
+	it("swaps the imported tail for this verb's", () => {
+		expect(
+			withBindingNoun(
+				"governance scope: no remote — the artifact cannot be bound to a commit, so what it shows is UNKNOWN.",
+				TAIL,
+			),
+		).toBe(`governance scope: no remote — ${TAIL}`);
+	});
+
+	it("passes through a message that does not carry the imported tail", () => {
+		expect(withBindingNoun("governance scope: something else.", TAIL)).toBe(
+			"governance scope: something else.",
+		);
+	});
+});
+
+describe("bindGovernanceHead", () => {
+	it("binds through the imported `bindHead` and reports both ends of the range", async () => {
+		const bound = await bind(binding());
+		expect(bound._tag).toBe("Bound");
+	});
+
+	it("re-phrases the 11 refusal in this verb's noun, so a reader is not left to guess", async () => {
+		const bound = await bind([
+			[/^git remote -v$/, okOut("origin\tgit@github.com:someone/else.git (fetch)\n")],
+		]);
+		expect(bound._tag).toBe("Refused");
+		if (bound._tag !== "Refused") return;
+		expect(bound.outcome.code).toBe(PRECONDITION_UNKNOWN);
+		expect(bound.outcome.stderr.at(-1)).toBe(
+			`governance scope: no git remote in this checkout serves o/r — ${TAIL}`,
+		);
+	});
+
+	it("leaves the 12 refusal exactly as the imported binding phrases it", async () => {
+		const bound = await bind(binding(), OLD_HEAD);
+		expect(bound._tag).toBe("Refused");
+		if (bound._tag !== "Refused") return;
+		expect(bound.outcome.code).toBe(STALE_HEAD);
+		expect(bound.outcome.stderr.at(-1)).toContain("re-scope at");
+	});
+});

--- a/packages/fabrika-cli/src/governance/post-verb.ts
+++ b/packages/fabrika-cli/src/governance/post-verb.ts
@@ -1,0 +1,278 @@
+/**
+ * `governance post` — the single sanctioned emit of the `governance` namespace verdict.
+ *
+ * Six steps, each gating the next: re-resolve the live head, re-derive the namespace requirement at
+ * the bound commit, compose the first line through the `verdict-marker` wire format, leak-scan the
+ * assembled comment, upsert one comment, and read it back unconditionally from live PR state.
+ *
+ * **The namespace is fixed.** There is no `--namespace` flag: this verb emits exactly one namespace,
+ * so it cannot be aimed anywhere else even by a confused caller. That is the disjointness guarantee
+ * made structural from the opposite direction to `review post`, which refuses a namespace outside its
+ * derived set.
+ *
+ * **There is no advisory carrier.** §CP is not this namespace's question, the governance verdict is
+ * never the §CP approval, and a carrier flag here would be a second §CP answer wearing an input's
+ * clothes.
+ *
+ * The `14` refusal is the fail-closed condition's write-seam half: absence of a verdict on a required
+ * diff is a refusal downstream, presence of one on a non-required diff is a refusal here. Both
+ * directions exist so the namespace means exactly one thing.
+ */
+import {Effect} from "effect";
+import type {ChildProcessSpawner} from "effect/unstable/process";
+import {diffRangePaths} from "../io/git.ts";
+import {createComment, getComment, listComments} from "../io/issues.ts";
+import {patchComment, viewerLogin} from "../io/pulls.ts";
+import type {StdinRead} from "../io/stdin.ts";
+import {normalizeForReadback} from "../report/compose.ts";
+import {GOVERNANCE_ROOTS, touchesGovernanceRoot} from "../review/classes.ts";
+import {badNumber, openPull, resolveTargetRepo, scannedLine} from "../review/target.ts";
+import {latestByWriteRecency} from "../review/write-recency.ts";
+import {answer, refuse, type VerbOutcome} from "../verb.ts";
+import {
+	emit as emitMarker,
+	headSha,
+	type Polarity,
+	read as readMarker,
+	clause as toClause,
+} from "../wire/verdict-marker.ts";
+import {type AuthoredSurface, leakRefusal, readAuthored} from "./authored.ts";
+import {
+	NOT_HARNESS_TOUCHING,
+	OFF_VOCABULARY,
+	PRECONDITION_UNKNOWN,
+	READBACK_MISMATCH,
+	STALE_HEAD,
+	WRITE_UNKNOWN,
+} from "./codes.ts";
+import {bindGovernanceHead, boundLine} from "./head.ts";
+
+const VERB = "governance post";
+
+/** The one namespace this verb emits. Not a flag, and not derivable from anything a caller passes. */
+export const NAMESPACE = "governance";
+
+const SURFACE: AuthoredSurface = {
+	verb: VERB,
+	noun: "the assembled comment",
+	emptyMessage: `${VERB}: no body on stdin — an empty verdict reads as UNGATED; pipe the verdict body in.`,
+	bareAtMessage: `${VERB}: the body is a bare "@" path reference — the body never arrived. Send its bytes on stdin.`,
+	leakCorrection: "cite it repo-relative or by class root.",
+};
+
+export interface PostOptions {
+	readonly pr: number;
+	readonly polarity: string;
+	readonly sha: string;
+	readonly clause: string;
+	readonly repo: string | null;
+	readonly json: boolean;
+	readonly env: Readonly<Record<string, string | undefined>>;
+	readonly stdin: Effect.Effect<StdinRead>;
+}
+
+/** Either side may be abbreviated, so the match is a prefix in whichever direction is shorter. */
+const prefixMatch = (a: string, b: string): boolean => a.startsWith(b) || b.startsWith(a);
+
+/** Whether a comment already carries this namespace's marker — the upsert's match key. */
+const carriesNamespace = (body: string): boolean => {
+	const parsed = readMarker(body);
+	return parsed._tag === "Found" && parsed.value.namespace === NAMESPACE;
+};
+
+/**
+ * Why the read-back does not show what was posted, or `null` when it does.
+ *
+ * Two assertions, and both are needed. The marker goes through the format's own `read`, so the four
+ * fields have to be the four that were composed; the whole comment is then compared through
+ * `normalizeForReadback` — a marker that parses proves nothing about the body under it, and the body
+ * is the verdict. That normalizer is imported rather than re-derived because its trailing-newline step
+ * is the one a re-derivation drops, and dropping it fires this refusal on every clean run.
+ */
+const mismatchOf = (
+	body: string,
+	posted: {readonly polarity: string; readonly sha: string; readonly clause: string},
+	composed: string,
+): string | null => {
+	const normalized = normalizeForReadback(body);
+	const parsed = readMarker(normalized);
+	if (parsed._tag !== "Found") return parsed.reason;
+	const marker = parsed.value;
+	if (marker.namespace !== NAMESPACE) return `namespace ${marker.namespace}, expected ${NAMESPACE}`;
+	if (marker.polarity !== posted.polarity) {
+		return `polarity ${marker.polarity}, expected ${posted.polarity}`;
+	}
+	if (marker.sha !== posted.sha) return `sha ${marker.sha}, expected ${posted.sha}`;
+	if (marker.clause !== posted.clause) {
+		return `clause "${marker.clause}", expected "${posted.clause}"`;
+	}
+	return normalized === normalizeForReadback(composed)
+		? null
+		: "the comment's bytes are not the ones that were sent";
+};
+
+const unreadable = (what: string, pr: number, reason: string): VerbOutcome =>
+	refuse(
+		PRECONDITION_UNKNOWN,
+		`${VERB}: cannot read ${what} for #${pr}: ${reason} — nothing was posted.`,
+	);
+
+export const runPost = (
+	options: PostOptions,
+): Effect.Effect<VerbOutcome, never, ChildProcessSpawner.ChildProcessSpawner> =>
+	Effect.gen(function* () {
+		const {pr, json} = options;
+		const bad = badNumber(VERB, "a pull-request number", pr);
+		if (bad !== null) return bad;
+
+		const polarity = options.polarity.toUpperCase();
+		if (polarity !== "PASS" && polarity !== "FAIL") {
+			return refuse(
+				OFF_VOCABULARY,
+				`${VERB}: --polarity must be PASS or FAIL — got "${options.polarity}". A third token is not a polarity.`,
+			);
+		}
+		const inspected = headSha(options.sha);
+		if (inspected === null) {
+			return refuse(
+				OFF_VOCABULARY,
+				`${VERB}: --sha "${options.sha}" is not a head SHA — expected 7–40 lowercase hex characters.`,
+			);
+		}
+		const clause = toClause(options.clause);
+		if (clause === null) {
+			return refuse(
+				OFF_VOCABULARY,
+				`${VERB}: --clause is blank — a verdict with no clause states nothing.`,
+			);
+		}
+
+		const resolved = yield* resolveTargetRepo(VERB, options.repo, options.env);
+		if (resolved._tag === "Refused") return resolved.outcome;
+		const repo = resolved.repo;
+
+		const authored = readAuthored(SURFACE, yield* options.stdin);
+		if (authored._tag === "Refused") return authored.outcome;
+
+		const target = yield* openPull(VERB, repo, pr, {
+			requireOpen: true,
+			closedReason: "a verdict on a closed PR gates nothing.",
+			requireFiles: false,
+			unknownMessage: (reason) =>
+				`${VERB}: cannot read the PR for #${pr}: ${reason} — nothing was posted.`,
+		});
+		if (target._tag === "Refused") return target.outcome;
+		const live = target.pull.headSha;
+
+		// Step 1 — the verdict binds the tree it was formed over, or it is re-reviewed, never re-bound.
+		if (!prefixMatch(live, inspected)) {
+			return refuse(
+				STALE_HEAD,
+				`${VERB}: the live head is ${live}, not ${inspected} — the tree you judged is gone; re-review at ${live} (ADR 0058).`,
+			);
+		}
+
+		// Step 2 — re-derive the requirement at the bound commit. The head check labels the tree; only
+		// the binding makes the derived answer provably that tree's (#5122).
+		const bound = yield* bindGovernanceHead(
+			VERB,
+			"the file list cannot be bound to a commit, so the derivation is UNKNOWN.",
+			repo,
+			pr,
+			target.pull,
+			options.sha,
+		);
+		if (bound._tag === "Refused") return bound.outcome;
+		const head = bound.head;
+		const listed = yield* diffRangePaths(head.base, head.sha);
+		if (listed._tag === "Failure") return unreadable("the changed-file list", pr, listed.reason);
+		const diagnostics = [
+			boundLine(VERB, head),
+			scannedLine(VERB, listed.value.length, "changed file"),
+		];
+		if (!touchesGovernanceRoot(listed.value)) {
+			return refuse(
+				NOT_HARNESS_TOUCHING,
+				`${VERB}: #${pr}'s diff touches no governance root (${GOVERNANCE_ROOTS.join(", ")}) — the namespace is not required here, and a verdict in it would attest a scope nobody derived.`,
+				diagnostics,
+			);
+		}
+
+		// Step 3 — compose through the wire format, never by hand (#3173).
+		const composed = `${emitMarker({
+			namespace: NAMESPACE,
+			polarity: polarity as Polarity,
+			sha: inspected,
+			clause,
+		})}\n${authored.text}`;
+
+		// Step 4 — the scan runs over the ASSEMBLED comment, so nothing this verb appended escapes it.
+		const leaked = leakRefusal(SURFACE, composed);
+		if (leaked !== null) return leaked;
+
+		// Step 5 — one namespace, one comment: a second marker stacked on line 2 is un-anchored,
+		// resolves the namespace empty, and fail-closes a substantively-passing PR.
+		const me = yield* viewerLogin;
+		if (me._tag === "Failure") return unreadable("the authenticated user", pr, me.reason);
+		const comments = yield* listComments(repo, pr);
+		if (comments._tag === "Failure") return unreadable("the comments", pr, comments.reason);
+		// The NEWEST match, by write recency — the same end of the order a resolver reads from. The list
+		// arrives oldest-first, so taking the first match edits the comment least likely to be in force
+		// and the edit lands where nobody reads (#5048).
+		const mine = latestByWriteRecency(
+			comments.value.filter(
+				(comment) => comment.author === me.value && carriesNamespace(comment.body),
+			),
+		);
+
+		let landed: {readonly id: number; readonly url: string} | null = null;
+		let failure: string | null = null;
+		if (mine === undefined) {
+			const created = yield* createComment(repo, pr, composed);
+			if (created._tag === "Failure") failure = created.reason;
+			else landed = {id: created.value.id, url: created.value.url};
+		} else {
+			const edited = yield* patchComment(repo, mine.id, composed);
+			if (edited._tag === "Failure") failure = edited.reason;
+			else landed = {id: mine.id, url: edited.value};
+		}
+		if (landed === null) {
+			return refuse(
+				WRITE_UNKNOWN,
+				`${VERB}: create/edit failed: ${failure ?? "unknown"} — UNKNOWN whether the verdict landed; re-read #${pr}'s comments before retrying.`,
+				diagnostics,
+			);
+		}
+		const upsert = mine === undefined ? "created" : "edited";
+
+		// Step 6 — read it back from live state. The write call's own echo is not evidence (#3173).
+		const back = yield* getComment(repo, landed.id);
+		const mismatch =
+			back._tag === "Failure"
+				? back.reason
+				: mismatchOf(back.value, {polarity, sha: inspected, clause}, composed);
+		if (mismatch !== null) {
+			return refuse(
+				READBACK_MISMATCH,
+				`${VERB}: posted, but the read-back does not yield this marker (${mismatch}) — the PR may carry a garbled verdict; inspect comment ${landed.id}.`,
+				diagnostics,
+			);
+		}
+
+		return json
+			? answer(
+					JSON.stringify({
+						outcome: "posted",
+						namespace: NAMESPACE,
+						polarity,
+						sha: inspected,
+						upsert,
+						commentUrl: landed.url,
+					}),
+					diagnostics,
+				)
+			: answer(
+					`posted\t${NAMESPACE}\t${polarity}\t${inspected}\t${upsert}\t${landed.url}`,
+					diagnostics,
+				);
+	});

--- a/packages/fabrika-cli/src/governance/post-verb.unit.test.ts
+++ b/packages/fabrika-cli/src/governance/post-verb.unit.test.ts
@@ -1,0 +1,184 @@
+import {Effect} from "effect";
+import {describe, expect, it} from "vitest";
+import {errOut, fakeShell, okOut, once} from "../fakes.test-support.ts";
+import type {ExecResult} from "../io/exec.ts";
+import type {StdinRead} from "../io/stdin.ts";
+import {PATHS_AT} from "../review/fixtures.test-support.ts";
+import {
+	BARE_AT_PATH,
+	EMPTY_STDIN,
+	LEAKED_PATH,
+	NOT_HARNESS_TOUCHING,
+	OFF_VOCABULARY,
+	PRECONDITION_UNKNOWN,
+	READBACK_MISMATCH,
+	STALE_HEAD,
+	WRITE_UNKNOWN,
+	ZERO_SCOPE,
+} from "./codes.ts";
+import {binding, comments, HEAD, OLD_HEAD, paths, pull} from "./fixtures.test-support.ts";
+import {runPost} from "./post-verb.ts";
+
+const PULL = /^gh api repos\/o\/r\/pulls\/4321$/;
+const VIEWER = /^gh api user --jq \.login$/;
+const COMMENTS = /^gh api --paginate repos\/o\/r\/issues\/4321\/comments/;
+const CREATE = /^gh api --method POST repos\/o\/r\/issues\/4321\/comments/;
+const PATCH = /^gh api --method PATCH repos\/o\/r\/issues\/comments\/77/;
+const READ_BACK = /^gh api repos\/o\/r\/issues\/comments\/(\d+)$/;
+
+const BODY = "The sweep found no contradiction; no anchored invariant is in reach.\n";
+const URL = "https://github.com/o/r/pull/4321#issuecomment-5154902211";
+
+const options = {
+	pr: 4321,
+	polarity: "PASS",
+	sha: HEAD,
+	clause: "no contradiction, no weakening",
+	repo: null,
+	json: false,
+	env: {CLAUDE_PIPELINE_REPO: "o/r"} as Record<string, string | undefined>,
+	stdin: Effect.succeed({_tag: "Text", text: BODY} as StdinRead),
+};
+
+const run = (
+	script: ReadonlyArray<readonly [RegExp, ExecResult]>,
+	overrides: Partial<typeof options> = {},
+) =>
+	Effect.runPromise(Effect.provide(runPost({...options, ...overrides}), fakeShell(script).layer));
+
+const composed = (body = BODY, sha = HEAD): string =>
+	`governance: PASS @ ${sha} — no contradiction, no weakening\n\n${body}`;
+
+const created = (id = 91): ExecResult => okOut(JSON.stringify({id, html_url: URL}));
+
+const governing = (
+	...extra: ReadonlyArray<readonly [RegExp, ExecResult]>
+): ReadonlyArray<readonly [RegExp, ExecResult]> => [
+	[PULL, pull()],
+	...binding(),
+	[PATHS_AT(), paths(".decisions/0240-x.md", "src/cart.ts")],
+	[VIEWER, okOut("kampus-bot\n")],
+	[COMMENTS, comments()],
+	...extra,
+];
+
+describe("runPost", () => {
+	it("composes the marker, upserts one comment, reads it back, and prints the line", async () => {
+		const out = await run(
+			governing([CREATE, created()], [READ_BACK, okOut(JSON.stringify({body: composed()}))]),
+		);
+		expect(out.code).toBe(0);
+		expect(out.stdout).toBe(`posted\tgovernance\tPASS\t${HEAD}\tcreated\t${URL}\n`);
+	});
+
+	it("edits the namespace's own comment rather than stacking a second one", async () => {
+		const out = await run([
+			[PULL, pull()],
+			...binding(),
+			[PATHS_AT(), paths(".decisions/0240-x.md", "src/cart.ts")],
+			[VIEWER, okOut("kampus-bot\n")],
+			[COMMENTS, comments({id: 77, body: composed("older\n")})],
+			[PATCH, okOut(JSON.stringify({html_url: URL}))],
+			[READ_BACK, okOut(JSON.stringify({body: composed()}))],
+		]);
+		expect(out.stdout).toContain("\tedited\t");
+	});
+
+	it("emits the record with --json, naming the fixed namespace", async () => {
+		const out = await run(
+			governing([CREATE, created()], [READ_BACK, okOut(JSON.stringify({body: composed()}))]),
+			{json: true},
+		);
+		expect(JSON.parse(out.stdout)).toMatchObject({
+			outcome: "posted",
+			namespace: "governance",
+			polarity: "PASS",
+			upsert: "created",
+		});
+	});
+
+	it("refuses on 14 when the diff derives NO governance root, and writes nothing", async () => {
+		const fake = fakeShell([
+			[PULL, pull()],
+			...binding(),
+			[PATHS_AT(), paths("src/cart.ts", "README.md")],
+		]);
+		const out = await Effect.runPromise(Effect.provide(runPost(options), fake.layer));
+		expect(out.code).toBe(NOT_HARNESS_TOUCHING);
+		expect(out.code).not.toBe(OFF_VOCABULARY);
+		expect(out.stdout).toBe("");
+		expect(out.stderr.at(-1)).toContain("a verdict in it would attest a scope nobody derived");
+		expect(fake.calls.some((call) => call.includes("--method POST"))).toBe(false);
+	});
+
+	it("refuses a stale --sha on 12 before it writes anything", async () => {
+		const out = await run(governing(), {sha: OLD_HEAD});
+		expect(out.code).toBe(STALE_HEAD);
+		expect(out.stderr.at(-1)).toContain("re-review at");
+	});
+
+	it("refuses a bad polarity, a bad sha and a blank clause on 10", async () => {
+		expect((await run(governing(), {polarity: "APPROVED"})).code).toBe(OFF_VOCABULARY);
+		expect((await run(governing(), {sha: "origin/main"})).code).toBe(OFF_VOCABULARY);
+		expect((await run(governing(), {clause: "   "})).code).toBe(OFF_VOCABULARY);
+	});
+
+	it("refuses an empty pipe on 3 and a bare @ body on 6", async () => {
+		const empty = await run(governing(), {stdin: Effect.succeed({_tag: "Text", text: "  "})});
+		expect(empty.code).toBe(EMPTY_STDIN);
+		const bare = await run(governing(), {
+			stdin: Effect.succeed({_tag: "Text", text: "@notes/verdict.md"}),
+		});
+		expect(bare.code).toBe(BARE_AT_PATH);
+	});
+
+	it("separates an UNREAD pipe from an empty one — 1, never 3", async () => {
+		const out = await run(governing(), {
+			stdin: Effect.succeed({_tag: "Failed", reason: "EAGAIN"}),
+		});
+		expect(out.code).toBe(1);
+		expect(out.code).not.toBe(EMPTY_STDIN);
+	});
+
+	it("refuses a machine-local path in the ASSEMBLED comment on 5", async () => {
+		const out = await run(governing(), {
+			stdin: Effect.succeed({_tag: "Text", text: "see ~/notes/verdict.md for the sweep\n"}),
+		});
+		expect(out.code).toBe(LEAKED_PATH);
+		expect(out.stdout).toBe("");
+	});
+
+	it("refuses an absent or closed PR on 7", async () => {
+		expect((await run([[PULL, errOut("gh: Not Found (HTTP 404)")]])).code).toBe(ZERO_SCOPE);
+		expect((await run([[PULL, pull({state: "closed"})]])).code).toBe(ZERO_SCOPE);
+	});
+
+	it("seats a failed write on 8, never on 1 — the outcome is UNKNOWN", async () => {
+		const out = await run(governing([CREATE, errOut("gh: Gateway timeout (HTTP 504)")]));
+		expect(out.code).toBe(WRITE_UNKNOWN);
+		expect(out.code).not.toBe(1);
+		expect(out.stderr.at(-1)).toContain("UNKNOWN whether the verdict landed");
+	});
+
+	it("seats a read-back that does not carry the marker on 9", async () => {
+		const out = await run(
+			governing([CREATE, created()], [READ_BACK, okOut(JSON.stringify({body: "thanks!\n"}))]),
+		);
+		expect(out.code).toBe(READBACK_MISMATCH);
+		expect(out.stderr.at(-1)).toContain("inspect comment 91");
+	});
+
+	it("seats an unreadable precondition on 11 — nothing was posted", async () => {
+		const out = await run([[PULL, errOut("gh: Bad gateway (HTTP 502)")]]);
+		expect(out.code).toBe(PRECONDITION_UNKNOWN);
+		expect(out.stderr.at(-1)).toContain("nothing was posted");
+	});
+
+	it("re-reads the comment from live state — the write call's own echo is not evidence", async () => {
+		const fake = fakeShell(
+			governing([once(CREATE), created()], [READ_BACK, okOut(JSON.stringify({body: composed()}))]),
+		);
+		await Effect.runPromise(Effect.provide(runPost(options), fake.layer));
+		expect(fake.calls).toContain("gh api repos/o/r/issues/comments/91");
+	});
+});

--- a/packages/fabrika-cli/src/governance/readout-verb.ts
+++ b/packages/fabrika-cli/src/governance/readout-verb.ts
@@ -1,0 +1,257 @@
+/**
+ * `governance readout` — compose the ranked rows through the `governance-digest` wire format, upsert
+ * them into the durable artifact, and read them back.
+ *
+ * **Non-blocking by construction.** This verb writes a comment and nothing else. It sets no label,
+ * touches no PR, and has no exit code meaning "the corpus is in a bad state" — a digest that could red
+ * would be the human gate the #4927 ruling retired, wearing a new name. Every outcome here is either
+ * "the readout landed" or "the readout did not land".
+ *
+ * **The artifact issue is resolved, never a constant.** `$FABRIKA_GOVERNANCE_READOUT_ISSUE`, else the
+ * single open issue titled exactly `Governance readout`, else a refusal naming both lookups — a
+ * guessed number would publish the digest onto somebody else's issue.
+ */
+import {Effect} from "effect";
+import type {ChildProcessSpawner} from "effect/unstable/process";
+import {createComment, getComment, getIssue, listComments, openIssuesTitled} from "../io/issues.ts";
+import {patchComment, viewerLogin} from "../io/pulls.ts";
+import type {StdinRead} from "../io/stdin.ts";
+import {normalizeForReadback} from "../report/compose.ts";
+import {resolveTargetRepo} from "../review/target.ts";
+import {latestByWriteRecency} from "../review/write-recency.ts";
+import {answer, refuse, type VerbOutcome} from "../verb.ts";
+import {
+	emitFromFields,
+	parseFields,
+	read as readDigest,
+	renderRows,
+} from "../wire/governance-digest.ts";
+import {type AuthoredSurface, leakRefusal, readAuthored} from "./authored.ts";
+import {
+	INCOMPLETE_SCAN,
+	OFF_VOCABULARY,
+	PRECONDITION_UNKNOWN,
+	READBACK_MISMATCH,
+	WRITE_UNKNOWN,
+	ZERO_SCOPE,
+} from "./codes.ts";
+
+const VERB = "governance readout";
+
+/** The title the artifact issue carries when no number and no env var name it. */
+export const ARTIFACT_TITLE = "Governance readout";
+export const ARTIFACT_ENV = "FABRIKA_GOVERNANCE_READOUT_ISSUE";
+
+const SURFACE: AuthoredSurface = {
+	verb: VERB,
+	noun: "the assembled body",
+	emptyMessage: `${VERB}: no rows on stdin — an empty readout is not a readout.`,
+	bareAtMessage: `${VERB}: the body is a bare "@" path reference — the rows never arrived. Send them on stdin.`,
+	leakCorrection: "cite it repo-relative.",
+};
+
+export interface ReadoutOptions {
+	/** The artifact issue, or `null` to resolve it from the environment and then from the title. */
+	readonly issue: number | null;
+	readonly repo: string | null;
+	readonly json: boolean;
+	readonly env: Readonly<Record<string, string | undefined>>;
+	readonly stdin: Effect.Effect<StdinRead>;
+}
+
+type Artifact =
+	| {readonly _tag: "Refused"; readonly outcome: VerbOutcome}
+	| {readonly _tag: "Issue"; readonly issue: number};
+
+const resolveArtifact = (
+	repo: string,
+	explicit: number | null,
+	env: Readonly<Record<string, string | undefined>>,
+): Effect.Effect<Artifact, never, ChildProcessSpawner.ChildProcessSpawner> =>
+	Effect.gen(function* () {
+		if (explicit !== null) return {_tag: "Issue" as const, issue: explicit};
+		const named = (env[ARTIFACT_ENV] ?? "").trim();
+		if (named !== "") {
+			const parsed = Number.parseInt(named, 10);
+			return Number.isInteger(parsed) && parsed > 0
+				? {_tag: "Issue" as const, issue: parsed}
+				: {
+						_tag: "Refused" as const,
+						outcome: refuse(
+							OFF_VOCABULARY,
+							`${VERB}: $${ARTIFACT_ENV} is "${named}", which is not an issue number.`,
+						),
+					};
+		}
+		const titled = yield* openIssuesTitled(repo, ARTIFACT_TITLE);
+		if (titled._tag === "Failure") {
+			return {
+				_tag: "Refused" as const,
+				outcome: refuse(
+					PRECONDITION_UNKNOWN,
+					`${VERB}: cannot search ${repo} for an open issue titled "${ARTIFACT_TITLE}": ${titled.reason} — nothing was written.`,
+				),
+			};
+		}
+		const only = titled.value[0];
+		if (only === undefined || titled.value.length > 1) {
+			return {
+				_tag: "Refused" as const,
+				outcome: refuse(
+					ZERO_SCOPE,
+					`${VERB}: no artifact issue given, \`$${ARTIFACT_ENV}\` is unset, and ${repo} has ${only === undefined ? "no" : `${titled.value.length}`} open issue${only === undefined ? "" : "s"} titled "${ARTIFACT_TITLE}" — refusing to guess where the digest lands.`,
+				),
+			};
+		}
+		return {_tag: "Issue" as const, issue: only.number};
+	});
+
+/**
+ * Why the read-back does not show the same rows in the same order, or `null` when it does.
+ *
+ * The rows go through the format's own `read` and are compared **in order** — a digest is ranked, so
+ * a set comparison would pass a readout whose ranking the write reversed. The whole body is then
+ * compared through the imported `normalizeForReadback`, whose trailing-newline step is the one a
+ * re-derivation drops.
+ */
+const mismatchOf = (
+	body: string,
+	expected: ReadonlyArray<string>,
+	composed: string,
+): string | null => {
+	const normalized = normalizeForReadback(body);
+	const parsed = readDigest(normalized);
+	if (parsed._tag !== "Found") return parsed.reason;
+	const got = renderRows(parsed.value);
+	if (got.length !== expected.length) {
+		return `read back ${got.length} row(s), expected ${expected.length}`;
+	}
+	for (const [index, row] of expected.entries()) {
+		if (got[index] !== row)
+			return `row ${index + 1} read back as "${got[index]}", expected "${row}"`;
+	}
+	return normalized === normalizeForReadback(composed)
+		? null
+		: "the comment's bytes are not the ones that were sent";
+};
+
+export const runReadout = (
+	options: ReadoutOptions,
+): Effect.Effect<VerbOutcome, never, ChildProcessSpawner.ChildProcessSpawner> =>
+	Effect.gen(function* () {
+		const {json} = options;
+		const resolved = yield* resolveTargetRepo(VERB, options.repo, options.env);
+		if (resolved._tag === "Refused") return resolved.outcome;
+		const repo = resolved.repo;
+
+		const authored = readAuthored(SURFACE, yield* options.stdin);
+		if (authored._tag === "Refused") return authored.outcome;
+
+		// The rows are parsed BEFORE the artifact is resolved: an off-vocabulary kind is the caller's
+		// to fix, and reaching GitHub first would make a bad row's refusal depend on the network.
+		const rows = parseFields(authored.text);
+		if (rows._tag === "Unusable") {
+			return refuse(OFF_VOCABULARY, `${VERB}: ${rows.reason}.`);
+		}
+		const composed = emitFromFields(authored.text);
+		if (composed._tag === "Unusable") {
+			return refuse(OFF_VOCABULARY, `${VERB}: ${composed.reason}.`);
+		}
+		const body = composed.bytes;
+
+		const leaked = leakRefusal(SURFACE, body);
+		if (leaked !== null) return leaked;
+
+		const artifact = yield* resolveArtifact(repo, options.issue, options.env);
+		if (artifact._tag === "Refused") return artifact.outcome;
+		const issue = artifact.issue;
+
+		const found = yield* getIssue(repo, issue);
+		if (found._tag === "Absent") {
+			return refuse(
+				ZERO_SCOPE,
+				`${VERB}: issue #${issue} not found in ${repo} — the readout artifact is absent; front-door creates it (#4952).`,
+			);
+		}
+		if (found._tag === "Unknown") {
+			return refuse(
+				PRECONDITION_UNKNOWN,
+				`${VERB}: cannot read #${issue}: ${found.reason} — nothing was written.`,
+			);
+		}
+		if (found.value.state !== "open") {
+			return refuse(
+				ZERO_SCOPE,
+				`${VERB}: issue #${issue} is closed — a readout nobody reads is not a readout.`,
+			);
+		}
+
+		const me = yield* viewerLogin;
+		if (me._tag === "Failure") {
+			return refuse(
+				PRECONDITION_UNKNOWN,
+				`${VERB}: cannot read the authenticated user: ${me.reason} — nothing was written.`,
+			);
+		}
+		const comments = yield* listComments(repo, issue);
+		if (comments._tag === "Failure") {
+			return refuse(
+				PRECONDITION_UNKNOWN,
+				`${VERB}: cannot read #${issue}: ${comments.reason} — nothing was written.`,
+			);
+		}
+		if (comments.value.length < found.value.comments) {
+			return refuse(
+				INCOMPLETE_SCAN,
+				`${VERB}: received ${comments.value.length} of ${found.value.comments} comments on #${issue} — refusing to upsert against a partial sweep.`,
+			);
+		}
+		const mine = latestByWriteRecency(
+			comments.value.filter(
+				(comment) => comment.author === me.value && readDigest(comment.body)._tag === "Found",
+			),
+		);
+
+		let landed: {readonly id: number; readonly url: string} | null = null;
+		let failure: string | null = null;
+		if (mine === undefined) {
+			const created = yield* createComment(repo, issue, body);
+			if (created._tag === "Failure") failure = created.reason;
+			else landed = {id: created.value.id, url: created.value.url};
+		} else {
+			const edited = yield* patchComment(repo, mine.id, body);
+			if (edited._tag === "Failure") failure = edited.reason;
+			else landed = {id: mine.id, url: edited.value};
+		}
+		if (landed === null) {
+			return refuse(
+				WRITE_UNKNOWN,
+				`${VERB}: create/edit failed: ${failure ?? "unknown"} — UNKNOWN whether the readout landed; re-read #${issue} before retrying.`,
+			);
+		}
+		const upsert = mine === undefined ? "created" : "edited";
+
+		const back = yield* getComment(repo, landed.id);
+		const mismatch =
+			back._tag === "Failure" ? back.reason : mismatchOf(back.value, renderRows(rows.rows), body);
+		if (mismatch !== null) {
+			return refuse(
+				READBACK_MISMATCH,
+				`${VERB}: landed, but the read-back does not yield the same rows (${mismatch}) — inspect comment ${landed.id}.`,
+			);
+		}
+
+		const diagnostics = [`${VERB}: upserted ${rows.rows.length} row(s) onto #${issue}.`];
+		return json
+			? answer(
+					JSON.stringify({
+						outcome: "readout",
+						issue,
+						rows: rows.rows.length,
+						upsert,
+						commentUrl: landed.url,
+					}),
+					diagnostics,
+				)
+			: answer(`readout\t${issue}\t${rows.rows.length}\t${upsert}\t${landed.url}`, diagnostics);
+	});

--- a/packages/fabrika-cli/src/governance/readout-verb.unit.test.ts
+++ b/packages/fabrika-cli/src/governance/readout-verb.unit.test.ts
@@ -1,0 +1,214 @@
+import {Effect} from "effect";
+import {describe, expect, it} from "vitest";
+import {errOut, fakeShell, okOut, once} from "../fakes.test-support.ts";
+import type {ExecResult} from "../io/exec.ts";
+import type {StdinRead} from "../io/stdin.ts";
+import {emit, parseFields} from "../wire/governance-digest.ts";
+import {
+	BARE_AT_PATH,
+	EMPTY_STDIN,
+	INCOMPLETE_SCAN,
+	LEAKED_PATH,
+	OFF_VOCABULARY,
+	PRECONDITION_UNKNOWN,
+	READBACK_MISMATCH,
+	WRITE_UNKNOWN,
+	ZERO_SCOPE,
+} from "./codes.ts";
+import {comments} from "./fixtures.test-support.ts";
+import {ARTIFACT_ENV, runReadout} from "./readout-verb.ts";
+
+const ISSUE = /^gh api repos\/o\/r\/issues\/4952$/;
+const TITLED = /^gh api --paginate repos\/o\/r\/issues\?state=open/;
+const VIEWER = /^gh api user --jq \.login$/;
+const COMMENTS = /^gh api --paginate repos\/o\/r\/issues\/4952\/comments/;
+const CREATE = /^gh api --method POST repos\/o\/r\/issues\/4952\/comments/;
+const READ_BACK = /^gh api repos\/o\/r\/issues\/comments\/(\d+)$/;
+
+const URL = "https://github.com/o/r/issues/4952#issuecomment-5229900001";
+const ROWS = "row\t0240\ttension\tsits against ADR 0058\nrow\t0238\troutine\tno tension found\n";
+
+const composed = (rows = ROWS): string => {
+	const parsed = parseFields(rows);
+	if (parsed._tag !== "Fields") throw new Error("fixture rows do not parse");
+	return emit(parsed.rows);
+};
+
+const issue = (state = "open", count = 0): ExecResult =>
+	okOut(
+		JSON.stringify({
+			number: 4952,
+			title: "Governance readout",
+			body: "",
+			state,
+			labels: [],
+			html_url: "https://example.test/issues/4952",
+			comments: count,
+		}),
+	);
+
+const options = {
+	issue: 4952 as number | null,
+	repo: null,
+	json: false,
+	env: {CLAUDE_PIPELINE_REPO: "o/r"} as Record<string, string | undefined>,
+	stdin: Effect.succeed({_tag: "Text", text: ROWS} as StdinRead),
+};
+
+const run = (
+	script: ReadonlyArray<readonly [RegExp, ExecResult]>,
+	overrides: Partial<typeof options> = {},
+) =>
+	Effect.runPromise(
+		Effect.provide(runReadout({...options, ...overrides}), fakeShell(script).layer),
+	);
+
+const happy = (
+	...extra: ReadonlyArray<readonly [RegExp, ExecResult]>
+): ReadonlyArray<readonly [RegExp, ExecResult]> => [
+	[ISSUE, issue()],
+	[VIEWER, okOut("kampus-bot\n")],
+	[COMMENTS, comments()],
+	...extra,
+];
+
+const landed = (id = 55): ExecResult => okOut(JSON.stringify({id, html_url: URL}));
+
+describe("runReadout", () => {
+	it("upserts the block and prints the issue, row count and outcome", async () => {
+		const out = await run(
+			happy([CREATE, landed()], [READ_BACK, okOut(JSON.stringify({body: composed()}))]),
+		);
+		expect(out.code).toBe(0);
+		expect(out.stdout).toBe(`readout\t4952\t2\tcreated\t${URL}\n`);
+	});
+
+	it("emits the record with --json", async () => {
+		const out = await run(
+			happy([CREATE, landed()], [READ_BACK, okOut(JSON.stringify({body: composed()}))]),
+			{json: true},
+		);
+		expect(JSON.parse(out.stdout)).toMatchObject({outcome: "readout", issue: 4952, rows: 2});
+	});
+
+	it("resolves the artifact from the environment when no number is passed", async () => {
+		const out = await run(
+			happy([CREATE, landed()], [READ_BACK, okOut(JSON.stringify({body: composed()}))]),
+			{issue: null, env: {CLAUDE_PIPELINE_REPO: "o/r", [ARTIFACT_ENV]: "4952"}},
+		);
+		expect(out.code).toBe(0);
+	});
+
+	it("resolves it from the single open issue with the exact title when the env is unset", async () => {
+		const out = await run(
+			[
+				[TITLED, okOut("4952\tGovernance readout\n")],
+				...happy([CREATE, landed()], [READ_BACK, okOut(JSON.stringify({body: composed()}))]),
+			],
+			{issue: null},
+		);
+		expect(out.code).toBe(0);
+	});
+
+	it("refuses to GUESS when neither lookup resolves one — 7, naming both", async () => {
+		const out = await run([[TITLED, okOut("")]], {issue: null});
+		expect(out.code).toBe(ZERO_SCOPE);
+		expect(out.stderr.at(-1)).toContain("refusing to guess where the digest lands");
+		expect(out.stderr.at(-1)).toContain(ARTIFACT_ENV);
+	});
+
+	it("refuses when two issues carry the title, rather than picking one", async () => {
+		const out = await run(
+			[[TITLED, okOut("4952\tGovernance readout\n5001\tGovernance readout\n")]],
+			{
+				issue: null,
+			},
+		);
+		expect(out.code).toBe(ZERO_SCOPE);
+	});
+
+	it("refuses an off-vocabulary kind and a non-four-digit id on 10, before touching GitHub", async () => {
+		const fake = fakeShell([]);
+		const out = await Effect.runPromise(
+			Effect.provide(
+				runReadout({
+					...options,
+					stdin: Effect.succeed({_tag: "Text", text: "row\t0240\turgent\tnote\n"}),
+				}),
+				fake.layer,
+			),
+		);
+		expect(out.code).toBe(OFF_VOCABULARY);
+		expect(fake.calls).toEqual([]);
+		expect(
+			(await run(happy(), {stdin: Effect.succeed({_tag: "Text", text: "row\t240\troutine\tn\n"})}))
+				.code,
+		).toBe(OFF_VOCABULARY);
+	});
+
+	it("refuses an empty pipe on 3 and a bare @ body on 6", async () => {
+		expect((await run(happy(), {stdin: Effect.succeed({_tag: "Text", text: " "})})).code).toBe(
+			EMPTY_STDIN,
+		);
+		expect(
+			(await run(happy(), {stdin: Effect.succeed({_tag: "Text", text: "@run/rows.txt"})})).code,
+		).toBe(BARE_AT_PATH);
+	});
+
+	it("refuses a machine-local path in a note on 5", async () => {
+		const out = await run(happy(), {
+			stdin: Effect.succeed({_tag: "Text", text: "row\t0240\troutine\tsee ~/notes/x.md\n"}),
+		});
+		expect(out.code).toBe(LEAKED_PATH);
+	});
+
+	it("refuses an absent or closed artifact on 7", async () => {
+		expect((await run([[ISSUE, errOut("gh: Not Found (HTTP 404)")]])).code).toBe(ZERO_SCOPE);
+		expect((await run([[ISSUE, issue("closed")]])).code).toBe(ZERO_SCOPE);
+	});
+
+	it("separates an unreadable artifact from an absent one — 11, never 7", async () => {
+		const out = await run([[ISSUE, errOut("gh: Bad gateway (HTTP 502)")]]);
+		expect(out.code).toBe(PRECONDITION_UNKNOWN);
+		expect(out.stderr.at(-1)).toContain("nothing was written");
+	});
+
+	it("refuses a partial comment sweep on 13 — the upsert target would be unknown", async () => {
+		const out = await run([
+			[ISSUE, issue("open", 9)],
+			[VIEWER, okOut("kampus-bot\n")],
+			[COMMENTS, comments()],
+		]);
+		expect(out.code).toBe(INCOMPLETE_SCAN);
+		expect(out.stderr.at(-1)).toBe(
+			"governance readout: received 0 of 9 comments on #4952 — refusing to upsert against a partial sweep.",
+		);
+	});
+
+	it("seats a failed write on 8 and a read-back that lost the rows on 9", async () => {
+		expect((await run(happy([CREATE, errOut("gh: Gateway timeout")]))).code).toBe(WRITE_UNKNOWN);
+		const stale = await run(
+			happy([CREATE, landed()], [READ_BACK, okOut(JSON.stringify({body: "thanks\n"}))]),
+		);
+		expect(stale.code).toBe(READBACK_MISMATCH);
+	});
+
+	it("refuses a read-back whose rows came back in a DIFFERENT order — a digest is ranked", async () => {
+		const reversed = composed(
+			"row\t0238\troutine\tno tension found\nrow\t0240\ttension\tsits against ADR 0058\n",
+		);
+		const out = await run(
+			happy([CREATE, landed()], [READ_BACK, okOut(JSON.stringify({body: reversed}))]),
+		);
+		expect(out.code).toBe(READBACK_MISMATCH);
+		expect(out.stderr.at(-1)).toContain("row 1 read back as");
+	});
+
+	it("re-reads from live state — the write call's own echo is not evidence", async () => {
+		const fake = fakeShell(
+			happy([once(CREATE), landed()], [READ_BACK, okOut(JSON.stringify({body: composed()}))]),
+		);
+		await Effect.runPromise(Effect.provide(runReadout(options), fake.layer));
+		expect(fake.calls).toContain("gh api repos/o/r/issues/comments/55");
+	});
+});

--- a/packages/fabrika-cli/src/governance/roots.ts
+++ b/packages/fabrika-cli/src/governance/roots.ts
@@ -1,0 +1,91 @@
+/**
+ * The governance-namespace derivation, as a pure function of one bound commit's changed paths.
+ *
+ * The root set is **not declared here**. `GOVERNANCE_ROOTS` and `touchesGovernanceRoot` live in
+ * `../review/classes.ts`, where `ship scope` and `ship gate`'s required-set floor already read them,
+ * and this module imports both — one derivation, three readers. Two derivations of one namespace are
+ * two answers to one question (#4730), and the two would disagree the first time a fifth root landed
+ * in only one of them.
+ *
+ * The directory is the unit of coverage, not the file type: an enumerated skill-dir list plus an
+ * any-depth `*.sh` clause is what left a non-`.sh` file beside a gated script proven-ordinary in v1.
+ */
+
+import {idFromFile, isFourDigitId} from "../adr/records.ts";
+import type {ChangedPath} from "../io/git.ts";
+import {GOVERNANCE_ROOTS, touchesGovernanceRoot} from "../review/classes.ts";
+
+/** One root and how many of the diff's paths sit under it. Only roots the diff touches are reported. */
+export interface RootTally {
+	readonly name: string;
+	readonly files: number;
+}
+
+/** A decision record the diff carries, and what the diff does to it. */
+export interface RecordChange {
+	readonly id: string;
+	readonly change: "added" | "modified" | "deleted";
+	readonly path: string;
+}
+
+export interface ScopeResult {
+	readonly required: boolean;
+	readonly roots: ReadonlyArray<RootTally>;
+	readonly self: boolean;
+	readonly records: ReadonlyArray<RecordChange>;
+	readonly scanned: number;
+}
+
+/**
+ * git's change letter as this group's vocabulary.
+ *
+ * `deleted` is in the vocabulary because removing a decision record is itself a governance event —
+ * the one change to the corpus an added/modified pair cannot express at all. A rename lands on
+ * `added` because its `path` is the destination: the record now exists there and did not before.
+ */
+export const changeOf = (status: string): RecordChange["change"] => {
+	if (status.startsWith("D")) return "deleted";
+	if (status.startsWith("A") || status.startsWith("R") || status.startsWith("C")) return "added";
+	return "modified";
+};
+
+/** The four-digit-addressable decision records among the changed paths, in path order. */
+export const recordsIn = (changed: ReadonlyArray<ChangedPath>): ReadonlyArray<RecordChange> => {
+	const out: RecordChange[] = [];
+	for (const entry of changed) {
+		const base = entry.path.split("/").pop() ?? "";
+		const id = idFromFile(base);
+		// A lettered variant (`0034a`) is a real record the corpus carries, but it is not addressable
+		// by the four-digit `--record` these verbs take, so reporting it would name an id no sibling
+		// verb accepts.
+		if (id === null || !isFourDigitId(id)) continue;
+		out.push({id, change: changeOf(entry.status), path: entry.path});
+	}
+	return out;
+};
+
+/**
+ * Derive the namespace over one bound commit's changed paths.
+ *
+ * `skillRoots` is what the `<anything>/fabrika/skills/governance/SKILL.md` resolution found at the commit —
+ * possibly none, possibly several. `self` is true when any changed path lies under **any** of them,
+ * which is the conservative direction: an ambiguous install flags the self fence rather than
+ * skipping it, and the fence is what stops a self-editing PR being judged by its own new rules
+ * (ADR 0052).
+ */
+export const deriveScope = (
+	changed: ReadonlyArray<ChangedPath>,
+	skillRoots: ReadonlyArray<string>,
+): ScopeResult => {
+	const paths = changed.map((entry) => entry.path);
+	return {
+		required: touchesGovernanceRoot(paths),
+		roots: GOVERNANCE_ROOTS.map((name) => ({
+			name,
+			files: paths.filter((path) => path.startsWith(name)).length,
+		})).filter((tally) => tally.files > 0),
+		self: paths.some((path) => skillRoots.some((root) => path.startsWith(root))),
+		records: recordsIn(changed),
+		scanned: paths.length,
+	};
+};

--- a/packages/fabrika-cli/src/governance/roots.unit.test.ts
+++ b/packages/fabrika-cli/src/governance/roots.unit.test.ts
@@ -1,0 +1,90 @@
+import {describe, expect, it} from "vitest";
+import {GOVERNANCE_ROOTS} from "../review/classes.ts";
+import {changeOf, deriveScope, recordsIn} from "./roots.ts";
+
+const changed = (...rows: ReadonlyArray<readonly [string, string]>) =>
+	rows.map(([status, path]) => ({status, path}));
+
+describe("changeOf", () => {
+	it("maps git's letters onto the three-word vocabulary", () => {
+		expect(changeOf("A")).toBe("added");
+		expect(changeOf("M")).toBe("modified");
+		expect(changeOf("D")).toBe("deleted");
+	});
+
+	it("reads a rename as `added` — its path is the destination, which did not exist before", () => {
+		expect(changeOf("R100")).toBe("added");
+		expect(changeOf("C85")).toBe("added");
+	});
+});
+
+describe("recordsIn", () => {
+	it("names each four-digit record the diff carries, with what the diff does to it", () => {
+		expect(
+			recordsIn(
+				changed(["A", ".decisions/0240-only-landed-adrs-may-be-cited.md"], ["M", "src/a.ts"]),
+			),
+		).toEqual([
+			{id: "0240", change: "added", path: ".decisions/0240-only-landed-adrs-may-be-cited.md"},
+		]);
+	});
+
+	it("reports a deleted record — the one corpus change added/modified cannot express", () => {
+		expect(recordsIn(changed(["D", ".decisions/0099-gone.md"]))[0]?.change).toBe("deleted");
+	});
+
+	it("skips a lettered variant, which no sibling verb's four-digit `--record` addresses", () => {
+		expect(recordsIn(changed(["M", ".decisions/0034a-live-fan-out-options.md"]))).toEqual([]);
+	});
+});
+
+describe("deriveScope", () => {
+	it("requires the namespace when any path is under any root, and tallies only touched roots", () => {
+		const result = deriveScope(
+			changed(
+				["A", ".decisions/0240-x.md"],
+				["M", "claude-plugins/fabrika/skills/review/SKILL.md"],
+				["M", "src/a.ts"],
+			),
+			[],
+		);
+		expect(result.required).toBe(true);
+		expect(result.roots).toEqual([
+			{name: ".decisions/", files: 1},
+			{name: "claude-plugins/", files: 1},
+		]);
+		expect(result.scanned).toBe(3);
+	});
+
+	it("does not require it for a diff under no root", () => {
+		expect(deriveScope(changed(["M", "src/a.ts"]), []).required).toBe(false);
+	});
+
+	it("reads the root list from `review/classes.ts` rather than a second copy", () => {
+		const each = GOVERNANCE_ROOTS.map(
+			(root) => deriveScope(changed(["M", `${root}x`]), []).required,
+		);
+		expect(each).toEqual(GOVERNANCE_ROOTS.map(() => true));
+	});
+
+	it("sets `self` when a changed path is under the resolved skill root", () => {
+		const root = "claude-plugins/fabrika/skills/governance/";
+		expect(deriveScope(changed(["M", `${root}SKILL.md`]), [root]).self).toBe(true);
+		expect(
+			deriveScope(changed(["M", "claude-plugins/fabrika/skills/review/SKILL.md"]), [root]).self,
+		).toBe(false);
+	});
+
+	it("flags `self` under an AMBIGUOUS install rather than skipping the fence", () => {
+		const roots = ["a/fabrika/skills/governance/", "b/fabrika/skills/governance/"];
+		expect(deriveScope(changed(["M", "b/fabrika/skills/governance/SKILL.md"]), roots).self).toBe(
+			true,
+		);
+	});
+
+	it("leaves `self` false when no install resolved — there is nothing to be under", () => {
+		expect(
+			deriveScope(changed(["M", "claude-plugins/fabrika/skills/governance/SKILL.md"]), []).self,
+		).toBe(false);
+	});
+});

--- a/packages/fabrika-cli/src/governance/scope-verb.ts
+++ b/packages/fabrika-cli/src/governance/scope-verb.ts
@@ -1,0 +1,146 @@
+/**
+ * `governance scope` — whether a PR's diff derives the governance namespace, over which harness
+ * roots, with the bound head, the `self` flag, and the decision records the diff touches.
+ *
+ * **This is not the §CP answer, and the verb says so on stderr on every run.** fabrika's §CP model is
+ * CODEOWNERS-only with no semantic detection; a second answer here could contradict a merge-gating
+ * verdict. What this derives is a *separate* namespace whose verdict is the skill's judgment.
+ *
+ * Zero changed files is a refusal, never `not-required`: the whole value of a `not-required` answer is
+ * that it was computed over everything (v1's `class-probe` read 0 files and classified `has-code` at
+ * exit 0 — #4060). The file list is read at the **bound commit** and the head printed is that same
+ * commit, because the list is the derivation's only input (#5117).
+ */
+import {Effect} from "effect";
+import type {ChildProcessSpawner} from "effect/unstable/process";
+import {diffRangeStatuses, listTreePaths} from "../io/git.ts";
+import {GOVERNANCE_ROOTS} from "../review/classes.ts";
+import {badNumber, openPull, resolveTargetRepo} from "../review/target.ts";
+import {answer, refuse, type VerbOutcome} from "../verb.ts";
+import {INCOMPLETE_SCAN, PRECONDITION_UNKNOWN} from "./codes.ts";
+import {bindGovernanceHead, boundLine} from "./head.ts";
+import {deriveScope} from "./roots.ts";
+import {skillRootsIn} from "./skill-root.ts";
+
+const VERB = "governance scope";
+
+/** Printed on every run, answer or refusal — the boundary this verb is most likely to be read across. */
+export const NOT_CP_NOTICE = `${VERB}: this is the governance-namespace derivation, not a §CP classification — §CP is CODEOWNERS' answer.`;
+
+const UNKNOWN_TAIL = "the file list cannot be bound to a commit, so the derivation is UNKNOWN.";
+
+/** The §CP boundary notice rides on refusals too — the reading it corrects is likeliest on one. */
+const withNotice = (outcome: VerbOutcome): VerbOutcome => ({
+	...outcome,
+	stderr: [...outcome.stderr, NOT_CP_NOTICE],
+});
+
+export interface ScopeOptions {
+	readonly pr: number;
+	/** The head the caller scoped. `null` binds to the PR's live head instead of asserting one. */
+	readonly sha: string | null;
+	readonly repo: string | null;
+	readonly json: boolean;
+	readonly env: Readonly<Record<string, string | undefined>>;
+}
+
+export const runScope = (
+	options: ScopeOptions,
+): Effect.Effect<VerbOutcome, never, ChildProcessSpawner.ChildProcessSpawner> =>
+	Effect.gen(function* () {
+		const {pr, json} = options;
+		const bad = badNumber(VERB, "a pull-request number", pr);
+		if (bad !== null) return bad;
+
+		const resolved = yield* resolveTargetRepo(VERB, options.repo, options.env);
+		if (resolved._tag === "Refused") return resolved.outcome;
+		const repo = resolved.repo;
+
+		const target = yield* openPull(VERB, repo, pr, {
+			requireOpen: true,
+			closedReason: "nothing to derive.",
+			requireFiles: true,
+			emptyReason: "refusing to derive over an empty diff (ADR 0092).",
+			unknownMessage: (reason) =>
+				`${VERB}: cannot read PR #${pr} in ${repo}: ${reason} — whether the namespace is required is UNKNOWN, never "not-required".`,
+		});
+		if (target._tag === "Refused") return withNotice(target.outcome);
+		const pull = target.pull;
+
+		const bound = yield* bindGovernanceHead(VERB, UNKNOWN_TAIL, repo, pr, pull, options.sha);
+		if (bound._tag === "Refused") return withNotice(bound.outcome);
+		const head = bound.head;
+
+		const listed = yield* diffRangeStatuses(head.base, head.sha);
+		if (listed._tag === "Failure") {
+			return withNotice(
+				refuse(
+					PRECONDITION_UNKNOWN,
+					`${VERB}: cannot read the changed files of #${pr} at ${head.sha}: ${listed.reason} — ${UNKNOWN_TAIL}`,
+				),
+			);
+		}
+		const changed = listed.value;
+		if (changed.length < pull.changedFiles) {
+			// The contract seats a short read on `13` explicitly, and this stays the fail-closed
+			// direction even where git and GitHub legitimately disagree — git pairs a rename into one
+			// path where GitHub counts two (#5154), so a rename-only PR refuses here rather than
+			// deriving from a list it cannot prove complete.
+			return withNotice(
+				refuse(
+					INCOMPLETE_SCAN,
+					`${VERB}: ${head.sha} carries ${changed.length} of the ${pull.changedFiles} files #${pr} declares — refusing to derive from a short read (#3999).`,
+					[boundLine(VERB, head)],
+				),
+			);
+		}
+
+		const tree = yield* listTreePaths(head.sha);
+		if (tree._tag === "Failure") {
+			return withNotice(
+				refuse(
+					PRECONDITION_UNKNOWN,
+					`${VERB}: cannot list the tree at ${head.sha}: ${tree.reason} — ${UNKNOWN_TAIL}`,
+				),
+			);
+		}
+
+		const result = deriveScope(changed, skillRootsIn(tree.value));
+		const present = GOVERNANCE_ROOTS.filter((root) =>
+			tree.value.some((path) => path.startsWith(root)),
+		);
+		const diagnostics = [
+			boundLine(VERB, head),
+			...GOVERNANCE_ROOTS.filter((root) => !present.includes(root)).map(
+				(root) =>
+					`${VERB}: root ${root} is absent in this repository — the derivation covered ${present.length} of ${GOVERNANCE_ROOTS.length} roots.`,
+			),
+			`${VERB}: partitioned ${changed.length} of the ${pull.changedFiles} declared changed files at ${head.sha} across ${GOVERNANCE_ROOTS.length} roots.`,
+			NOT_CP_NOTICE,
+		];
+
+		const outcome = result.required ? "required" : "not-required";
+		if (json) {
+			return answer(
+				JSON.stringify({
+					outcome,
+					head: head.sha,
+					roots: result.roots.map((tally) => ({name: tally.name, files: tally.files})),
+					self: result.self,
+					base: head.base,
+					records: result.records,
+					scanned: result.scanned,
+				}),
+				diagnostics,
+			);
+		}
+		return answer(
+			[
+				`governance\t${outcome}\t${head.sha}`,
+				...result.roots.map((tally) => `root\t${tally.name}\t${tally.files}`),
+				`self\t${result.self}`,
+				...result.records.map((row) => `record\t${row.id}\t${row.change}\t${row.path}`),
+			].join("\n"),
+			diagnostics,
+		);
+	});

--- a/packages/fabrika-cli/src/governance/scope-verb.unit.test.ts
+++ b/packages/fabrika-cli/src/governance/scope-verb.unit.test.ts
@@ -1,0 +1,178 @@
+import {Effect} from "effect";
+import {describe, expect, it} from "vitest";
+import {errOut, fakeShell, okOut} from "../fakes.test-support.ts";
+import type {ExecResult} from "../io/exec.ts";
+import {
+	INCOMPLETE_SCAN,
+	OFF_VOCABULARY,
+	PRECONDITION_UNKNOWN,
+	STALE_HEAD,
+	ZERO_SCOPE,
+} from "./codes.ts";
+import {
+	BASE,
+	binding,
+	FULL_TREE,
+	HEAD,
+	OLD_HEAD,
+	pull,
+	STATUS_AT,
+	statuses,
+	TREE_AT,
+	treeOf,
+} from "./fixtures.test-support.ts";
+import {NOT_CP_NOTICE, runScope} from "./scope-verb.ts";
+
+const PULL = /^gh api repos\/o\/r\/pulls\/4321$/;
+
+const options = {
+	pr: 4321,
+	sha: null as string | null,
+	repo: null,
+	json: false,
+	env: {CLAUDE_PIPELINE_REPO: "o/r"} as Record<string, string | undefined>,
+};
+
+const run = (
+	script: ReadonlyArray<readonly [RegExp, ExecResult]>,
+	overrides: Partial<typeof options> = {},
+) =>
+	Effect.runPromise(Effect.provide(runScope({...options, ...overrides}), fakeShell(script).layer));
+
+const happy = (
+	...rows: ReadonlyArray<readonly [string, string]>
+): ReadonlyArray<readonly [RegExp, ExecResult]> => [
+	[PULL, pull({changedFiles: rows.length})],
+	...binding(),
+	[STATUS_AT(), statuses(...rows)],
+	[TREE_AT(), treeOf(...FULL_TREE)],
+];
+
+const GOVERNING = happy(
+	["A", ".decisions/0240-only-landed-adrs-may-be-cited.md"],
+	["M", "claude-plugins/fabrika/skills/review/SKILL.md"],
+);
+
+describe("runScope", () => {
+	it("prints the outcome, the head, each touched root, `self`, and each record", async () => {
+		const out = await run(GOVERNING);
+		expect(out.code).toBe(0);
+		expect(out.stdout).toBe(
+			[
+				`governance\trequired\t${HEAD}`,
+				"root\t.decisions/\t1",
+				"root\tclaude-plugins/\t1",
+				"self\tfalse",
+				"record\t0240\tadded\t.decisions/0240-only-landed-adrs-may-be-cited.md",
+				"",
+			].join("\n"),
+		);
+	});
+
+	it("answers `not-required` for a diff under no root — a computed answer, not a silence", async () => {
+		const out = await run(happy(["M", "src/cart.ts"]));
+		expect(out.code).toBe(0);
+		expect(out.stdout.split("\n")[0]).toBe(`governance\tnot-required\t${HEAD}`);
+	});
+
+	it("sets `self` on this skill's own diff, which derives its own namespace by construction", async () => {
+		const out = await run(happy(["M", "claude-plugins/fabrika/skills/governance/SKILL.md"]));
+		expect(out.stdout).toContain("self\ttrue");
+	});
+
+	it("emits the record with --json, carrying the base the range was read across", async () => {
+		const out = await run(GOVERNING, {json: true});
+		expect(JSON.parse(out.stdout)).toMatchObject({
+			outcome: "required",
+			head: HEAD,
+			base: BASE,
+			self: false,
+			scanned: 2,
+			records: [{id: "0240", change: "added"}],
+		});
+	});
+
+	it("says on stderr, on every run, that this is not the §CP answer", async () => {
+		expect((await run(GOVERNING)).stderr).toContain(NOT_CP_NOTICE);
+		expect((await run([[PULL, errOut("gh: Not Found (HTTP 404)")]])).stderr).toContain(
+			NOT_CP_NOTICE,
+		);
+	});
+
+	it("reports the commit it bound to and what it partitioned", async () => {
+		const out = await run(GOVERNING);
+		expect(out.stderr[0]).toBe(
+			`governance scope: bound to ${HEAD} (base ${BASE}) — read from the object database, nothing checked out.`,
+		);
+		expect(out.stderr).toContain(
+			`governance scope: partitioned 2 of the 2 declared changed files at ${HEAD} across 4 roots.`,
+		);
+	});
+
+	it("names a root that is absent in this repository rather than counting it silently", async () => {
+		const out = await run([
+			[PULL, pull({changedFiles: 1})],
+			...binding(),
+			[STATUS_AT(), statuses(["M", ".decisions/0240-x.md"])],
+			[TREE_AT(), treeOf(".decisions/0240-x.md", "src/cart.ts")],
+		]);
+		expect(out.stderr).toContain(
+			"governance scope: root .claude/ is absent in this repository — the derivation covered 1 of 4 roots.",
+		);
+	});
+
+	it("refuses a PR proven absent on 7", async () => {
+		const out = await run([[PULL, errOut("gh: Not Found (HTTP 404)")]]);
+		expect(out.code).toBe(ZERO_SCOPE);
+		expect(out.stdout).toBe("");
+	});
+
+	it("refuses a closed PR, and a zero-file PR, on 7 — never `not-required`", async () => {
+		expect((await run([[PULL, pull({state: "closed"})]])).code).toBe(ZERO_SCOPE);
+		const empty = await run([[PULL, pull({changedFiles: 0})]]);
+		expect(empty.code).toBe(ZERO_SCOPE);
+		expect(empty.stderr.at(-2)).toContain("refusing to derive over an empty diff");
+	});
+
+	it("separates an UNREADABLE PR from an absent one — 11, never 7", async () => {
+		const out = await run([[PULL, errOut("gh: Bad gateway (HTTP 502)")]]);
+		expect(out.code).toBe(PRECONDITION_UNKNOWN);
+		expect(out.code).not.toBe(ZERO_SCOPE);
+		expect(out.stderr.at(-2)).toContain('is UNKNOWN, never "not-required"');
+	});
+
+	it("phrases the binding failure in this verb's own noun", async () => {
+		const out = await run([
+			[PULL, pull()],
+			[/^git remote -v$/, okOut("origin\tgit@github.com:someone/else.git (fetch)\n")],
+		]);
+		expect(out.code).toBe(PRECONDITION_UNKNOWN);
+		expect(out.stderr.at(-2)).toBe(
+			"governance scope: no git remote in this checkout serves o/r — the file list cannot be bound to a commit, so the derivation is UNKNOWN.",
+		);
+	});
+
+	it("refuses a short changed-file read on 13, distinct from 11 and 7", async () => {
+		const out = await run([
+			[PULL, pull({changedFiles: 9})],
+			...binding(),
+			[STATUS_AT(), statuses(["M", "src/cart.ts"])],
+		]);
+		expect(out.code).toBe(INCOMPLETE_SCAN);
+		expect(out.code).not.toBe(PRECONDITION_UNKNOWN);
+		expect(out.stdout).toBe("");
+		expect(out.stderr.at(-2)).toBe(
+			`governance scope: ${HEAD} carries 1 of the 9 files #4321 declares — refusing to derive from a short read (#3999).`,
+		);
+	});
+
+	it("refuses a --sha that is not the PR's head on 12, and a malformed one on 10", async () => {
+		expect((await run(GOVERNING, {sha: OLD_HEAD})).code).toBe(STALE_HEAD);
+		expect((await run(GOVERNING, {sha: "origin/main"})).code).toBe(OFF_VOCABULARY);
+	});
+
+	it("refuses a non-PR number, and an unresolvable repo, on 1", async () => {
+		expect((await run(GOVERNING, {pr: 0})).code).toBe(1);
+		expect((await run(GOVERNING, {env: {}})).code).toBe(1);
+	});
+});

--- a/packages/fabrika-cli/src/governance/skill-root.ts
+++ b/packages/fabrika-cli/src/governance/skill-root.ts
@@ -1,0 +1,39 @@
+/**
+ * Where this skill's own text lives, resolved out of a commit's tree rather than hardcoded.
+ *
+ * The pattern carries the **plugin segment** deliberately: a bare `<anything>/skills/governance/` also matches
+ * a repo-root `skills/` tree and a symlinked v1 tree, and either would serve the wrong bytes as "this
+ * skill's own text". A literal `claude-plugins/fabrika/` fence is the other failure — this skill ships
+ * to other repositories, where that path does not exist and the self fence would refuse everywhere.
+ *
+ * Three outcomes, and the two failures are not the same fact: **zero** matches means there is no self
+ * fence to run at this commit, **more than one** means which install is "this skill" is genuinely
+ * unknown. Picking one would be a coin flip the caller cannot see.
+ */
+
+/** The tracked path that identifies an install: `<anything>/fabrika/skills/governance/SKILL.md`. */
+const SKILL_FILE = /(^|\/)fabrika\/skills\/governance\/SKILL\.md$/;
+
+export type SkillRoots =
+	| {readonly _tag: "One"; readonly root: string}
+	| {readonly _tag: "None"}
+	| {readonly _tag: "Many"; readonly candidates: ReadonlyArray<string>};
+
+/** Every install's root directory, trailing slash included, sorted so two runs answer alike. */
+export const skillRootsIn = (paths: ReadonlyArray<string>): ReadonlyArray<string> =>
+	[
+		...new Set(
+			paths.filter((path) => SKILL_FILE.test(path)).map((path) => path.replace(/SKILL\.md$/, "")),
+		),
+	].sort();
+
+export const resolveSkillRoots = (paths: ReadonlyArray<string>): SkillRoots => {
+	const roots = skillRootsIn(paths);
+	const only = roots[0];
+	if (only === undefined) return {_tag: "None"};
+	return roots.length === 1 ? {_tag: "One", root: only} : {_tag: "Many", candidates: roots};
+};
+
+/** Whether `path` lies inside the resolved root — the `--path` fence `governance base` applies. */
+export const insideRoot = (root: string, path: string): boolean =>
+	path.startsWith(root) && path !== root;

--- a/packages/fabrika-cli/src/governance/skill-root.unit.test.ts
+++ b/packages/fabrika-cli/src/governance/skill-root.unit.test.ts
@@ -1,0 +1,56 @@
+import {describe, expect, it} from "vitest";
+import {insideRoot, resolveSkillRoots, skillRootsIn} from "./skill-root.ts";
+
+describe("resolveSkillRoots", () => {
+	it("resolves the one install and returns its directory", () => {
+		expect(
+			resolveSkillRoots([
+				"claude-plugins/fabrika/skills/governance/SKILL.md",
+				"claude-plugins/fabrika/skills/review/SKILL.md",
+			]),
+		).toEqual({_tag: "One", root: "claude-plugins/fabrika/skills/governance/"});
+	});
+
+	it("does NOT match a repo-root `skills/` tree — the plugin segment is part of the pattern", () => {
+		expect(resolveSkillRoots(["skills/governance/SKILL.md"])).toEqual({_tag: "None"});
+	});
+
+	it("matches an install at any depth, so a foreign repo's layout still resolves", () => {
+		expect(resolveSkillRoots(["vendor/plugins/fabrika/skills/governance/SKILL.md"])).toEqual({
+			_tag: "One",
+			root: "vendor/plugins/fabrika/skills/governance/",
+		});
+	});
+
+	it("names every candidate when two installs are present rather than picking one", () => {
+		const roots = resolveSkillRoots([
+			"b/fabrika/skills/governance/SKILL.md",
+			"a/fabrika/skills/governance/SKILL.md",
+		]);
+		expect(roots).toEqual({
+			_tag: "Many",
+			candidates: ["a/fabrika/skills/governance/", "b/fabrika/skills/governance/"],
+		});
+	});
+
+	it("answers None over an empty tree, which is a fact and not an error", () => {
+		expect(resolveSkillRoots([])).toEqual({_tag: "None"});
+		expect(skillRootsIn([])).toEqual([]);
+	});
+});
+
+describe("insideRoot", () => {
+	const root = "claude-plugins/fabrika/skills/governance/";
+
+	it("admits a path under the root", () => {
+		expect(insideRoot(root, `${root}contract.md`)).toBe(true);
+	});
+
+	it("refuses a sibling skill's text, which is what the fence exists for", () => {
+		expect(insideRoot(root, "claude-plugins/fabrika/skills/review/SKILL.md")).toBe(false);
+	});
+
+	it("refuses the root itself — a directory carries no bytes to read", () => {
+		expect(insideRoot(root, root)).toBe(false);
+	});
+});

--- a/packages/fabrika-cli/src/governance/sweep-verb.ts
+++ b/packages/fabrika-cli/src/governance/sweep-verb.ts
@@ -1,0 +1,216 @@
+/**
+ * `governance sweep` — the uncited live-`accepted` records whose decision domain a subject touches,
+ * ranked, for a subject read out of a bound commit (`--record`) or out of the corpus (`--landed`).
+ *
+ * **The ranking core is imported, never restated.** `decisionBearingText`, `tokenize`, the idf scoring,
+ * `RARITY_FLOOR` and `DEFAULT_LIMIT` all come from `../adr/sweep.ts`. A second lexical sweep would be a
+ * rival answer to a solved question, and two runs of the two verbs over the same bytes would stop
+ * agreeing by construction. What this verb owns is the **subject acquisition**: `adr sweep` can only
+ * read a local draft, and a review-time or digest-time subject lives in a commit.
+ *
+ * All three outcomes exit 0 and all three are answers — and none of them is a clearance. A record that
+ * disagrees with the subject about what a *label means* shares no distinctive vocabulary and never
+ * appears here at all, which is why `no-overlap` carries that sentence in `reason` verbatim.
+ */
+import {Effect, type FileSystem, Result} from "effect";
+import type {ChildProcessSpawner} from "effect/unstable/process";
+import {idFromFile, isFourDigitId, partitionRecordNames} from "../adr/records.ts";
+import {renderEntry, type SweepCandidate, sweep} from "../adr/sweep.ts";
+import {readDir, readFile} from "../io/fs.ts";
+import {diffRangeStatuses, readFileAt} from "../io/git.ts";
+import {badNumber, openPull, resolveTargetRepo} from "../review/target.ts";
+import {answer, refuse, type VerbOutcome} from "../verb.ts";
+import {INCOMPLETE_SCAN, OFF_VOCABULARY, PRECONDITION_UNKNOWN, ZERO_SCOPE} from "./codes.ts";
+import {bindGovernanceHead, boundLine} from "./head.ts";
+
+const VERB = "governance sweep";
+
+const UNKNOWN_TAIL = "the subject cannot be bound to a commit, so what it says is UNKNOWN.";
+
+export interface SweepOptions {
+	/** The PR the subject record lives in. `null` with `--landed` is the corpus mode. */
+	readonly pr: number | null;
+	readonly record: string | null;
+	readonly landed: string | null;
+	readonly sha: string | null;
+	readonly dir: string;
+	readonly limit: number;
+	readonly repo: string | null;
+	readonly json: boolean;
+	readonly env: Readonly<Record<string, string | undefined>>;
+}
+
+/** Every record in the corpus, or the refusal its unreadability seats. */
+type Corpus =
+	| {readonly _tag: "Refused"; readonly outcome: VerbOutcome}
+	| {readonly _tag: "Corpus"; readonly records: ReadonlyArray<SweepCandidate>};
+
+const readCorpus = (dir: string): Effect.Effect<Corpus, never, FileSystem.FileSystem> =>
+	Effect.gen(function* () {
+		const root = dir.replace(/\/+$/, "");
+		const listing = yield* Effect.result(readDir(root));
+		if (Result.isFailure(listing)) {
+			return {
+				_tag: "Refused" as const,
+				outcome: refuse(
+					PRECONDITION_UNKNOWN,
+					`${VERB}: cannot read ${root}: the directory could not be listed — an incomplete corpus is UNKNOWN, never "no-overlap".`,
+				),
+			};
+		}
+		const {records} = partitionRecordNames(listing.success);
+		if (records.length === 0) {
+			return {
+				_tag: "Refused" as const,
+				outcome: refuse(
+					ZERO_SCOPE,
+					`${VERB}: scanned ${root}, 0 decision records — refusing to answer (ADR 0092).`,
+				),
+			};
+		}
+		const corpus: SweepCandidate[] = [];
+		for (const file of records) {
+			const text = yield* Effect.result(readFile(`${root}/${file}`));
+			// One unreadable member makes the corpus INCOMPLETE, and an incomplete corpus is UNKNOWN —
+			// ranking against the rest would answer `no-overlap` over a corpus nobody scanned.
+			if (Result.isFailure(text)) {
+				return {
+					_tag: "Refused" as const,
+					outcome: refuse(
+						PRECONDITION_UNKNOWN,
+						`${VERB}: cannot read ${root}/${file}: the file could not be read — an incomplete corpus is UNKNOWN, never "no-overlap".`,
+					),
+				};
+			}
+			corpus.push({id: idFromFile(file) ?? file, file, text: text.success});
+		}
+		return {_tag: "Corpus" as const, records: corpus};
+	});
+
+export const runSweep = (
+	options: SweepOptions,
+): Effect.Effect<
+	VerbOutcome,
+	never,
+	ChildProcessSpawner.ChildProcessSpawner | FileSystem.FileSystem
+> =>
+	Effect.gen(function* () {
+		const {pr, landed, json} = options;
+		if ((pr === null) === (landed === null)) {
+			return refuse(OFF_VOCABULARY, `${VERB}: pass a PR with --record, or --landed, never both.`);
+		}
+		if (options.limit < 0) {
+			return refuse(
+				OFF_VOCABULARY,
+				`${VERB}: --limit ${options.limit} is negative — a shortlist cannot be shorter than empty.`,
+			);
+		}
+		const subjectId = landed ?? options.record;
+		if (subjectId === null || !isFourDigitId(subjectId)) {
+			return refuse(
+				OFF_VOCABULARY,
+				`${VERB}: --${landed === null ? "record" : "landed"} "${subjectId ?? ""}" is not a four-digit decision id.`,
+			);
+		}
+
+		const root = options.dir.replace(/\/+$/, "");
+		const corpus = yield* readCorpus(options.dir);
+		if (corpus._tag === "Refused") return corpus.outcome;
+
+		const diagnostics: string[] = [];
+		let subjectText: string;
+		if (pr === null) {
+			const member = corpus.records.find((entry) => entry.id === subjectId);
+			if (member === undefined) {
+				return refuse(
+					PRECONDITION_UNKNOWN,
+					`${VERB}: ${root} carries no decision record ${subjectId} — nothing to sweep.`,
+				);
+			}
+			subjectText = member.text;
+		} else {
+			const bad = badNumber(VERB, "a pull-request number", pr);
+			if (bad !== null) return bad;
+			const resolved = yield* resolveTargetRepo(VERB, options.repo, options.env);
+			if (resolved._tag === "Refused") return resolved.outcome;
+			const repo = resolved.repo;
+
+			const target = yield* openPull(VERB, repo, pr, {
+				requireOpen: true,
+				closedReason: "nothing to sweep.",
+				requireFiles: true,
+				emptyReason: "refusing to sweep over an empty diff (ADR 0092).",
+				unknownMessage: (reason) =>
+					`${VERB}: cannot read PR #${pr} in ${repo}: ${reason} — what the subject says is UNKNOWN.`,
+			});
+			if (target._tag === "Refused") return target.outcome;
+
+			const bound = yield* bindGovernanceHead(
+				VERB,
+				UNKNOWN_TAIL,
+				repo,
+				pr,
+				target.pull,
+				options.sha,
+			);
+			if (bound._tag === "Refused") return bound.outcome;
+			const head = bound.head;
+			diagnostics.push(boundLine(VERB, head));
+
+			const listed = yield* diffRangeStatuses(head.base, head.sha);
+			if (listed._tag === "Failure") {
+				return refuse(
+					PRECONDITION_UNKNOWN,
+					`${VERB}: cannot read the changed files of #${pr} at ${head.sha}: ${listed.reason} — ${UNKNOWN_TAIL}`,
+				);
+			}
+			if (listed.value.length < target.pull.changedFiles) {
+				return refuse(
+					INCOMPLETE_SCAN,
+					`${VERB}: ${head.sha} carries ${listed.value.length} of the ${target.pull.changedFiles} files #${pr} declares — refusing to prove ${subjectId} is in this PR from a short read (#3999).`,
+					diagnostics,
+				);
+			}
+			const carried = listed.value.find(
+				(entry) => idFromFile(entry.path.split("/").pop() ?? "") === subjectId,
+			);
+			if (carried === undefined) {
+				return refuse(
+					PRECONDITION_UNKNOWN,
+					`${VERB}: #${pr} at ${head.sha} carries no decision record ${subjectId} — nothing to sweep.`,
+					diagnostics,
+				);
+			}
+			const bytes = yield* readFileAt(head.sha, carried.path);
+			if (bytes._tag === "Failure") {
+				return refuse(
+					PRECONDITION_UNKNOWN,
+					`${VERB}: cannot read ${carried.path} at ${head.sha}: ${bytes.reason} — ${UNKNOWN_TAIL}`,
+					diagnostics,
+				);
+			}
+			subjectText = bytes.value;
+		}
+
+		const result = sweep({id: subjectId, text: subjectText}, corpus.records, options.limit);
+		diagnostics.push(
+			`${VERB}: ranked ${result.inScope} uncited live-accepted records of ${result.scanned} in scope.`,
+		);
+		if (result.reason !== null) diagnostics.push(`${VERB}: ${result.reason}.`);
+
+		if (json) {
+			return answer(
+				JSON.stringify({
+					outcome: result.outcome,
+					subject: subjectId,
+					entries: result.entries,
+					reason: result.reason,
+					scanned: result.scanned,
+					inScope: result.inScope,
+					cited: result.cited,
+				}),
+				diagnostics,
+			);
+		}
+		return answer([result.outcome, ...result.entries.map(renderEntry)].join("\n"), diagnostics);
+	});

--- a/packages/fabrika-cli/src/governance/sweep-verb.unit.test.ts
+++ b/packages/fabrika-cli/src/governance/sweep-verb.unit.test.ts
@@ -1,0 +1,180 @@
+import {Effect, Layer} from "effect";
+import {describe, expect, it} from "vitest";
+import {errOut, fakeFs, fakeShell, okOut, record} from "../fakes.test-support.ts";
+import type {ExecResult} from "../io/exec.ts";
+import {INCOMPLETE_SCAN, OFF_VOCABULARY, PRECONDITION_UNKNOWN, ZERO_SCOPE} from "./codes.ts";
+import {binding, HEAD, pull, SHOW_AT, STATUS_AT, statuses} from "./fixtures.test-support.ts";
+import {runSweep} from "./sweep-verb.ts";
+
+const PULL = /^gh api repos\/o\/r\/pulls\/4321$/;
+const DIR = ".decisions";
+const SUBJECT_PATH = ".decisions/0240-only-landed-adrs-may-be-cited.md";
+
+/** Twelve members, so the corpus clears the imported rarity floor of ten. */
+const names = Array.from({length: 12}, (_, i) => `${String(i + 1).padStart(4, "0")}-a-decision.md`);
+
+const corpusFiles = (): Record<string, string> =>
+	Object.fromEntries(
+		names.map((name, i) => [
+			`${DIR}/${name}`,
+			record(
+				name.slice(0, 4),
+				"accepted",
+				i === 0 ? "Verdicts bind a head sha immutably." : "Unrelated.",
+			),
+		]),
+	);
+
+const options = {
+	pr: null as number | null,
+	record: null as string | null,
+	landed: null as string | null,
+	sha: null as string | null,
+	dir: DIR,
+	limit: 8,
+	repo: null,
+	json: false,
+	env: {CLAUDE_PIPELINE_REPO: "o/r"} as Record<string, string | undefined>,
+};
+
+const run = (
+	script: ReadonlyArray<readonly [RegExp, ExecResult]>,
+	overrides: Partial<typeof options> = {},
+	fs = fakeFs({dirs: {[DIR]: names}, files: corpusFiles()}),
+) =>
+	Effect.runPromise(
+		Effect.provide(
+			runSweep({...options, ...overrides}),
+			Layer.merge(fakeShell(script).layer, fs.layer),
+		),
+	);
+
+describe("runSweep in --landed mode", () => {
+	it("ranks the corpus against a record already in --dir and exits 0", async () => {
+		const out = await run([], {landed: "0001"});
+		expect(out.code).toBe(0);
+		expect(out.stdout.split("\n")[0]).toMatch(/^(shortlist|no-overlap)$/);
+	});
+
+	it("carries the not-a-clearance sentence on the no-overlap arm's `reason`", async () => {
+		const out = await run([], {landed: "0002", json: true});
+		const parsed = JSON.parse(out.stdout);
+		if (parsed.outcome === "no-overlap") {
+			expect(parsed.reason).toContain("this is not a clearance");
+		}
+		expect(parsed.subject).toBe("0002");
+	});
+
+	it("answers `indeterminate` at exit 0 below the imported rarity floor", async () => {
+		const small = ["0001-a.md", "0002-b.md"];
+		const out = await run(
+			[],
+			{landed: "0001"},
+			fakeFs({
+				dirs: {[DIR]: small},
+				files: {
+					[`${DIR}/0001-a.md`]: record("0001", "accepted"),
+					[`${DIR}/0002-b.md`]: record("0002", "accepted"),
+				},
+			}),
+		);
+		expect(out.code).toBe(0);
+		expect(out.stdout.trim()).toBe("indeterminate");
+	});
+
+	it("refuses a zero-record corpus on 7 rather than answering no-overlap over nothing", async () => {
+		const out = await run([], {landed: "0001"}, fakeFs({dirs: {[DIR]: []}}));
+		expect(out.code).toBe(ZERO_SCOPE);
+		expect(out.stderr.at(-1)).toBe(
+			"governance sweep: scanned .decisions, 0 decision records — refusing to answer (ADR 0092).",
+		);
+	});
+
+	it("refuses an UNREADABLE member on 11 — an incomplete corpus is UNKNOWN", async () => {
+		const out = await run(
+			[],
+			{landed: "0001"},
+			fakeFs({
+				dirs: {[DIR]: names},
+				files: corpusFiles(),
+				unreadable: [`${DIR}/${names[3]}`],
+			}),
+		);
+		expect(out.code).toBe(PRECONDITION_UNKNOWN);
+		expect(out.code).not.toBe(ZERO_SCOPE);
+		expect(out.stderr.at(-1)).toContain('an incomplete corpus is UNKNOWN, never "no-overlap"');
+	});
+
+	it("refuses an unlistable --dir on 11, distinct from an empty one", async () => {
+		const out = await run([], {landed: "0001"}, fakeFs({}));
+		expect(out.code).toBe(PRECONDITION_UNKNOWN);
+	});
+
+	it("refuses a --landed id the corpus does not carry on 11", async () => {
+		const out = await run([], {landed: "9999"});
+		expect(out.code).toBe(PRECONDITION_UNKNOWN);
+		expect(out.stderr.at(-1)).toContain("carries no decision record 9999");
+	});
+});
+
+describe("runSweep in --record mode", () => {
+	const scripted: ReadonlyArray<readonly [RegExp, ExecResult]> = [
+		[PULL, pull({changedFiles: 1})],
+		...binding(),
+		[STATUS_AT(), statuses(["A", SUBJECT_PATH])],
+		[
+			SHOW_AT(HEAD, SUBJECT_PATH),
+			okOut(record("0240", "proposed", "Only landed ADRs may be cited.")),
+		],
+	];
+
+	it("reads the subject at the BOUND commit and ranks against the corpus", async () => {
+		const out = await run(scripted, {pr: 4321, record: "0240"});
+		expect(out.code).toBe(0);
+		expect(out.stderr[0]).toContain(`bound to ${HEAD}`);
+	});
+
+	it("refuses when the bound commit carries no such record on 11", async () => {
+		const out = await run(
+			[[PULL, pull({changedFiles: 1})], ...binding(), [STATUS_AT(), statuses(["M", "src/a.ts"])]],
+			{pr: 4321, record: "0240"},
+		);
+		expect(out.code).toBe(PRECONDITION_UNKNOWN);
+		expect(out.stderr.at(-1)).toContain("carries no decision record 0240");
+	});
+
+	it("refuses a short changed-file read on 13", async () => {
+		const out = await run(
+			[[PULL, pull({changedFiles: 9})], ...binding(), [STATUS_AT(), statuses(["A", SUBJECT_PATH])]],
+			{pr: 4321, record: "0240"},
+		);
+		expect(out.code).toBe(INCOMPLETE_SCAN);
+		expect(out.stderr.at(-1)).toContain("refusing to prove 0240 is in this PR from a short read");
+	});
+
+	it("refuses an absent PR on 7", async () => {
+		const out = await run([[PULL, errOut("gh: Not Found (HTTP 404)")]], {pr: 4321, record: "0240"});
+		expect(out.code).toBe(ZERO_SCOPE);
+	});
+});
+
+describe("runSweep's usage fence", () => {
+	it("refuses both a PR and --landed, and neither, on 10", async () => {
+		expect((await run([], {pr: 4321, record: "0240", landed: "0240"})).code).toBe(OFF_VOCABULARY);
+		expect((await run([], {})).code).toBe(OFF_VOCABULARY);
+	});
+
+	it("refuses a non-four-digit id on 10", async () => {
+		const out = await run([], {landed: "240"});
+		expect(out.code).toBe(OFF_VOCABULARY);
+		expect(out.stderr.at(-1)).toBe(
+			'governance sweep: --landed "240" is not a four-digit decision id.',
+		);
+	});
+
+	it("refuses a negative --limit on 10", async () => {
+		const out = await run([], {landed: "0001", limit: -1});
+		expect(out.code).toBe(OFF_VOCABULARY);
+		expect(out.stderr.at(-1)).toContain("a shortlist cannot be shorter than empty");
+	});
+});

--- a/packages/fabrika-cli/src/io/git.ts
+++ b/packages/fabrika-cli/src/io/git.ts
@@ -241,3 +241,175 @@ export const readFileAt = (sha: string, path: string): Shell<Attempt<string>> =>
 		const r = yield* execCapture("git", ["show", `${sha}:${path}`]);
 		return r.ok ? ok(r.stdout) : fail(r.reason);
 	});
+
+// ---------------------------------------------------------------------------------------------
+// The `governance` group's reads, appended as one block so a later verb slice extends the file here
+// rather than colliding with the range reads above (#5199).
+// ---------------------------------------------------------------------------------------------
+
+/** One changed path and the single letter git gives its change. */
+export interface ChangedPath {
+	/** `A`, `M`, `D`, `R<score>`, `C<score>`, `T` — git's own letter, never normalized here. */
+	readonly status: string;
+	/** For a rename or copy this is the **destination**, which is the path that now exists. */
+	readonly path: string;
+}
+
+/**
+ * Split a NUL-separated `--name-status` stream into rows.
+ *
+ * A rename or copy emits three fields (`R100`, source, destination) where every other change emits
+ * two, so the walk is stateful rather than a chunk-of-two. Getting that wrong shifts every later row
+ * by one field, which reads back as a well-formed change list naming the wrong paths.
+ */
+export const parseNameStatus = (stdout: string): ReadonlyArray<ChangedPath> => {
+	const fields = stdout.split("\0").filter((f) => f !== "");
+	const rows: ChangedPath[] = [];
+	for (let i = 0; i < fields.length; ) {
+		const status = fields[i] ?? "";
+		const renamed = status.startsWith("R") || status.startsWith("C");
+		const path = fields[i + (renamed ? 2 : 1)];
+		if (path === undefined) break;
+		rows.push({status, path});
+		i += renamed ? 3 : 2;
+	}
+	return rows;
+};
+
+/** The changed paths of `base...head` with their change letters. */
+export const diffRangeStatuses = (
+	base: string,
+	head: string,
+): Shell<Attempt<ReadonlyArray<ChangedPath>>> =>
+	Effect.gen(function* () {
+		const r = yield* execCapture("git", [
+			"diff",
+			...DIFF_FLAGS,
+			"--name-status",
+			"-z",
+			`${base}...${head}`,
+		]);
+		return r.ok ? ok(parseNameStatus(r.stdout)) : fail(r.reason);
+	});
+
+/** Every tracked path at `sha`, recursively — how a fenced skill root is resolved without a checkout. */
+export const listTreePaths = (sha: string): Shell<Attempt<ReadonlyArray<string>>> =>
+	Effect.gen(function* () {
+		const r = yield* execCapture("git", ["ls-tree", "-r", "--name-only", "-z", sha]);
+		return r.ok ? ok(r.stdout.split("\0").filter((p) => p !== "")) : fail(r.reason);
+	});
+
+/** The merge base of two commits, as a full object name. */
+export const mergeBase = (a: string, b: string): Shell<Attempt<string>> =>
+	Effect.gen(function* () {
+		const r = yield* execCapture("git", ["merge-base", a, b]);
+		if (!r.ok) return fail(r.reason);
+		const sha = r.stdout.trim();
+		return isObjectName(sha) ? ok(sha) : fail(`git named no merge base (got "${sha}")`);
+	});
+
+/** One commit on the walked ref: its object name and its committer date. */
+export interface CommitRow {
+	readonly sha: string;
+	/** `YYYY-MM-DD`, taken from the committer date in UTC. */
+	readonly date: string;
+}
+
+/**
+ * The UTC calendar day of a strict-ISO instant, or `null` when it is not one.
+ *
+ * git's `%cI` carries the committer's own offset, so the day is read after normalizing to UTC — a
+ * `--date=…-local` format would answer differently on two machines and make one window enumerate
+ * two different sets.
+ */
+export const utcDayOf = (iso: string): string | null => {
+	const at = Date.parse(iso.trim());
+	return Number.isNaN(at) ? null : (new Date(at).toISOString().slice(0, 10) ?? null);
+};
+
+/**
+ * The commits on `ref` inside an inclusive `YYYY-MM-DD` window that touch `dir`, oldest first.
+ *
+ * The bounds are stamped `Z` on purpose: bare dates make git read the caller's local zone, so the
+ * same window would enumerate different commits on two machines.
+ */
+export const logCommitsTouching = (
+	ref: string,
+	since: string,
+	until: string,
+	dir: string,
+): Shell<Attempt<ReadonlyArray<CommitRow>>> =>
+	Effect.gen(function* () {
+		const r = yield* execCapture("git", [
+			"log",
+			"--reverse",
+			"--format=%H%x09%cI",
+			`--since=${since}T00:00:00Z`,
+			`--until=${until}T23:59:59Z`,
+			ref,
+			"--",
+			dir,
+		]);
+		if (!r.ok) return fail(r.reason);
+		const rows: CommitRow[] = [];
+		for (const line of r.stdout.split("\n")) {
+			if (line.trim() === "") continue;
+			const [sha, stamp] = line.split("\t");
+			const date = stamp === undefined ? null : utcDayOf(stamp);
+			if (sha === undefined || date === null) return fail(`unreadable log line "${line}"`);
+			rows.push({sha, date});
+		}
+		return ok(rows);
+	});
+
+/** The paths one commit changes under `dir`, with their change letters. */
+export const commitStatuses = (
+	sha: string,
+	dir: string,
+): Shell<Attempt<ReadonlyArray<ChangedPath>>> =>
+	Effect.gen(function* () {
+		const r = yield* execCapture("git", [
+			"show",
+			...DIFF_FLAGS,
+			"--name-status",
+			"-z",
+			"--format=",
+			sha,
+			"--",
+			dir,
+		]);
+		return r.ok ? ok(parseNameStatus(r.stdout)) : fail(r.reason);
+	});
+
+/** One commit's own unified diff, under the same config-proof flags every range read uses. */
+export const commitDiff = (sha: string): Shell<Attempt<string>> =>
+	Effect.gen(function* () {
+		const r = yield* execCapture("git", ["show", ...DIFF_FLAGS, "--format=", sha]);
+		return r.ok ? ok(r.stdout) : fail(r.reason);
+	});
+
+/** Whether this clone is shallow — the precondition a window walk's completeness rests on. */
+export const isShallowClone: Shell<Attempt<boolean>> = Effect.gen(function* () {
+	const r = yield* execCapture("git", ["rev-parse", "--is-shallow-repository"]);
+	return r.ok ? ok(r.stdout.trim() === "true") : fail(r.reason);
+});
+
+/**
+ * The dates of `ref`'s parentless commits, in UTC `YYYY-MM-DD`.
+ *
+ * In a shallow clone the graft boundary *is* a parentless commit, so these are the dates a window
+ * has to clear to be provably complete.
+ */
+export const parentlessCommitDates = (ref: string): Shell<Attempt<ReadonlyArray<string>>> =>
+	Effect.gen(function* () {
+		const r = yield* execCapture("git", ["log", "--max-parents=0", "--format=%cI", ref]);
+		if (!r.ok) return fail(r.reason);
+		const days: string[] = [];
+		for (const line of r.stdout.split("\n")) {
+			if (line.trim() === "") continue;
+			const day = utcDayOf(line);
+			if (day === null) return fail(`unreadable boundary date "${line.trim()}"`);
+			days.push(day);
+		}
+		return ok(days);
+	});

--- a/packages/fabrika-cli/src/io/issues.ts
+++ b/packages/fabrika-cli/src/io/issues.ts
@@ -222,6 +222,14 @@ export interface IssueRecord {
 	readonly milestone: number | null;
 	/** `completed` / `not_planned` on a closed issue, `null` otherwise. A kill's read-back reads it. */
 	readonly stateReason: string | null;
+	/**
+	 * Issue comments, as the platform counts them — the denominator a completeness proof divides by.
+	 *
+	 * `0` when the payload carried none, which is the same fail-closed direction the rest of this
+	 * record takes: a caller comparing an enumeration against it then proves nothing rather than
+	 * proving a short read from a count that was never there.
+	 */
+	readonly comments: number;
 }
 
 const toIssueRecord = (value: unknown): IssueRecord | null => {
@@ -245,6 +253,7 @@ const toIssueRecord = (value: unknown): IssueRecord | null => {
 		milestone:
 			isRecord(milestone) && typeof milestone.number === "number" ? milestone.number : null,
 		stateReason: typeof state_reason === "string" ? state_reason : null,
+		comments: typeof value.comments === "number" ? value.comments : 0,
 	};
 };
 

--- a/packages/fabrika-cli/src/registry.ts
+++ b/packages/fabrika-cli/src/registry.ts
@@ -19,6 +19,7 @@ import {adrCommand} from "./adr/command.ts";
 import {buildCommand} from "./build/command.ts";
 import {epicCommand} from "./epic/command.ts";
 import {evalCommand} from "./eval/command.ts";
+import {governanceCommand} from "./governance/command.ts";
 import {grillCommand} from "./grill/command.ts";
 import {handoffCommand} from "./handoff/command.ts";
 import {hookCommand} from "./hook/command.ts";
@@ -45,6 +46,7 @@ export const registeredGroups: ReadonlyArray<VerbGroup> = [
 	buildCommand,
 	epicCommand,
 	evalCommand,
+	governanceCommand,
 	grillCommand,
 	handoffCommand,
 	hookCommand,

--- a/packages/fabrika-cli/src/wire/governance-digest.ts
+++ b/packages/fabrika-cli/src/wire/governance-digest.ts
@@ -1,0 +1,199 @@
+/**
+ * The governance digest — the ranked table of decision records that landed in a window, carried on
+ * the durable readout issue.
+ *
+ *     ## Governance readout
+ *
+ *     ```governance-digest
+ *     row	0398	tension	sits against ADR 0173 on whether a pending check blocks admission
+ *     ```
+ *
+ * Producer `governance readout`, consumer the front door. Three fields per row: the decision id, one
+ * of three **closed** kinds, and a one-line note.
+ *
+ * **The note is a pointer, never a directive.** A receiver re-fetches the record the id names and
+ * reads it there, which is what keeps a coordination artifact from steering whoever reads it — so the
+ * vocabulary is closed and free prose is confined to that one field.
+ *
+ * **The digest gates nothing.** There is no polarity here and no code that means "the corpus is in a
+ * bad state": a digest that could red would be the human gate the #4927 ruling retired, wearing a new
+ * name.
+ */
+
+import type {NonEmptyReadonlyArray, WireEmit, WireRead, WireReadLines} from "./format.ts";
+
+declare const RECORD_ID: unique symbol;
+declare const NOTE: unique symbol;
+
+/** A four-digit decision id. Branded so a `Found` cannot carry `""` or a half-written id. */
+export type RecordId = string & {readonly [RECORD_ID]: true};
+/** The one-line note. Branded for the same reason: a blank note points at nothing. */
+export type Note = string & {readonly [NOTE]: true};
+
+/** What the row says about the record. A fourth token is not a kind — it is a drift. */
+export type DigestKind = "tension" | "blast" | "routine";
+
+export interface DigestRow {
+	readonly id: RecordId;
+	readonly kind: DigestKind;
+	readonly note: Note;
+}
+
+export type GovernanceDigest = NonEmptyReadonlyArray<DigestRow>;
+export type GovernanceDigestRead = WireRead<GovernanceDigest>;
+
+/** The `--format` key, the fence's info string, and the heading the block sits under. */
+export const KEY = "governance-digest";
+export const HEADING = "## Governance readout";
+/** The row grammar's leading token, which is also what `governance readout` reads off stdin. */
+export const ROW = "row";
+
+export const KINDS: ReadonlyArray<DigestKind> = ["tension", "blast", "routine"];
+
+const HEADING_ANY_LEVEL = /^#{1,6}[ \t]+Governance readout[ \t]*$/i;
+const FENCE_OPEN = new RegExp(`^\`{3,}[ \t]*${KEY}[ \t]*$`);
+const FENCE_CLOSE = /^`{3,}[ \t]*$/;
+const FOUR_DIGITS = /^\d{4}$/;
+
+export const recordId = (raw: string): RecordId | null =>
+	FOUR_DIGITS.test(raw.trim()) ? (raw.trim() as RecordId) : null;
+
+export const note = (raw: string): Note | null => {
+	const value = raw.trim();
+	return value === "" ? null : (value as Note);
+};
+
+export const digestKind = (raw: string): DigestKind | null => {
+	const value = raw.trim().toLowerCase();
+	return KINDS.find((kind) => kind === value) ?? null;
+};
+
+const malformed = (reason: string, evidence: string): GovernanceDigestRead => ({
+	_tag: "Malformed",
+	reason,
+	evidence,
+});
+
+/** One `row\t<id>\t<kind>\t<note>` line as a row, or the reason it is not one. */
+export const parseRow = (line: string): DigestRow | string => {
+	const fields = line.split("\t");
+	if (fields[0]?.trim() !== ROW) {
+		return `"${line.trim()}" does not open with the "${ROW}" token — every digest line is a row`;
+	}
+	if (fields.length !== 4) {
+		return `a row carries exactly ${ROW}, id, kind and note — this one carries ${fields.length} field(s)`;
+	}
+	const id = recordId(fields[1] ?? "");
+	if (id === null) return `"${(fields[1] ?? "").trim()}" is not a four-digit decision id`;
+	const kind = digestKind(fields[2] ?? "");
+	if (kind === null) {
+		return `"${(fields[2] ?? "").trim()}" is outside ${KINDS.join("/")}`;
+	}
+	const text = note(fields[3] ?? "");
+	if (text === null) return `row ${id} carries no note — the field that says why the row is here`;
+	return {id, kind, note: text};
+};
+
+/**
+ * Read the digest out of an artifact. Total: `Found` | `Absent` | `Malformed`.
+ *
+ * A drifted heading level is `Malformed` rather than `Absent`, which is the discrimination that
+ * carries the weight: an artifact plainly reaching for this block and missing must never read back as
+ * "this issue carries no readout", because that is the answer a receiver acts on by doing nothing.
+ */
+export const read = (artifact: string): GovernanceDigestRead => {
+	const lines = artifact.split("\n");
+	const headingAt = lines.findIndex((line) => HEADING_ANY_LEVEL.test(line));
+	const fenceAt = lines.findIndex((line) => FENCE_OPEN.test(line));
+	if (headingAt === -1 && fenceAt === -1) {
+		return {
+			_tag: "Absent",
+			reason: `the artifact carries no "${HEADING}" heading over a \`${KEY}\` fence — no block of this format`,
+		};
+	}
+	if (headingAt === -1) {
+		return malformed(
+			`the \`${KEY}\` fence sits under no "${HEADING}" heading`,
+			`line ${fenceAt + 1}: "${(lines[fenceAt] ?? "").trim()}"`,
+		);
+	}
+	const heading = lines[headingAt] ?? "";
+	if (heading.trim() !== HEADING) {
+		return malformed(
+			`the heading is "${heading.trim()}", not "${HEADING}" — the level and spelling are the block's anchor`,
+			`line ${headingAt + 1}: "${heading.trim()}"`,
+		);
+	}
+	if (fenceAt === -1 || fenceAt < headingAt) {
+		return malformed(
+			`the "${HEADING}" heading is present with no \`${KEY}\` fence under it`,
+			`line ${headingAt + 1}: "${heading.trim()}"`,
+		);
+	}
+
+	const rows: DigestRow[] = [];
+	for (let i = fenceAt + 1; i < lines.length; i += 1) {
+		const line = lines[i] ?? "";
+		if (FENCE_CLOSE.test(line)) break;
+		if (line.trim() === "") continue;
+		const parsed = parseRow(line);
+		if (typeof parsed === "string") return malformed(parsed, `line ${i + 1}: "${line.trim()}"`);
+		rows.push(parsed);
+	}
+	const [first, ...rest] = rows;
+	if (first === undefined) {
+		return malformed(
+			`the \`${KEY}\` fence holds no row — an empty digest is not a digest`,
+			`line ${fenceAt + 1}: "${(lines[fenceAt] ?? "").trim()}"`,
+		);
+	}
+	return {_tag: "Found", value: [first, ...rest]};
+};
+
+export const emitRow = (row: DigestRow): string => `${ROW}\t${row.id}\t${row.kind}\t${row.note}`;
+
+/** Compose the whole block. Round-trips through {@link read}. */
+export const emit = (rows: GovernanceDigest): string =>
+	`${HEADING}\n\n\`\`\`${KEY}\n${rows.map(emitRow).join("\n")}\n\`\`\`\n`;
+
+/** One row line per row — read output that pipes straight back into {@link emitFromFields}. */
+export const renderRows = (rows: GovernanceDigest): NonEmptyReadonlyArray<string> => {
+	const [first, ...rest] = rows.map(emitRow);
+	if (first === undefined) throw new Error("a non-empty row list rendered no lines");
+	return [first, ...rest];
+};
+
+export type DigestFields =
+	| {readonly _tag: "Fields"; readonly rows: GovernanceDigest}
+	| {readonly _tag: "Unusable"; readonly reason: string};
+
+/** Parse `emit`'s stdin: one `row\t<id>\t<kind>\t<note>` per line, in the order they are ranked. */
+export const parseFields = (fields: string): DigestFields => {
+	const lines = fields.split("\n").filter((line) => line.trim() !== "");
+	const rows: DigestRow[] = [];
+	for (const [index, line] of lines.entries()) {
+		const parsed = parseRow(line);
+		if (typeof parsed === "string") {
+			return {_tag: "Unusable", reason: `line ${index + 1}: ${parsed}`};
+		}
+		rows.push(parsed);
+	}
+	const [first, ...rest] = rows;
+	return first === undefined
+		? {_tag: "Unusable", reason: "no rows were given — an empty readout is not a readout"}
+		: {_tag: "Fields", rows: [first, ...rest]};
+};
+
+/** The registry row's byte-level `emit`, bound to this module's typed core. */
+export const emitFromFields = (fields: string): WireEmit => {
+	const parsed = parseFields(fields);
+	return parsed._tag === "Fields"
+		? {_tag: "Composed", bytes: emit(parsed.rows)}
+		: {_tag: "Unusable", reason: parsed.reason};
+};
+
+/** The registry row's byte-level `read`, bound to this module's typed core. */
+export const readToLines = (artifact: string): WireReadLines => {
+	const result = read(artifact);
+	return result._tag === "Found" ? {_tag: "Found", value: renderRows(result.value)} : result;
+};

--- a/packages/fabrika-cli/src/wire/governance-digest.unit.test.ts
+++ b/packages/fabrika-cli/src/wire/governance-digest.unit.test.ts
@@ -1,0 +1,98 @@
+import {describe, expect, it} from "vitest";
+import {
+	emit,
+	emitFromFields,
+	HEADING,
+	KINDS,
+	parseFields,
+	read,
+	readToLines,
+} from "./governance-digest.ts";
+
+const artifact = (...rows: ReadonlyArray<string>): string =>
+	`${HEADING}\n\n\`\`\`governance-digest\n${rows.join("\n")}\n\`\`\`\n`;
+
+const ROW = "row\t0398\ttension\tsits against ADR 0173 on whether a pending check blocks admission";
+
+describe("read", () => {
+	it("finds the rows in file order", () => {
+		const result = read(artifact(ROW, "row\t0396\troutine\tno tension found"));
+		expect(result).toMatchObject({
+			_tag: "Found",
+			value: [
+				{id: "0398", kind: "tension"},
+				{id: "0396", kind: "routine"},
+			],
+		});
+	});
+
+	it("admits every kind in the closed set and nothing else", () => {
+		for (const kind of KINDS) {
+			expect(read(artifact(`row\t0398\t${kind}\tnote`))._tag).toBe("Found");
+		}
+		expect(read(artifact("row\t0398\turgent\tnote"))._tag).toBe("Malformed");
+	});
+
+	it("is Absent over an artifact that reaches for nothing", () => {
+		expect(read("Nothing landed this week, as far as I can tell.\n")).toMatchObject({
+			_tag: "Absent",
+		});
+	});
+
+	it("is MALFORMED, never Absent, on a drifted heading level", () => {
+		const drifted = artifact(ROW).replace(HEADING, "### Governance readout");
+		expect(read(drifted)).toMatchObject({_tag: "Malformed"});
+	});
+
+	it("is Malformed on a fence holding prose instead of rows", () => {
+		expect(read(artifact("Nothing much landed."))).toMatchObject({_tag: "Malformed"});
+	});
+
+	it("is Malformed on a fence under no heading, and a heading over no fence", () => {
+		expect(read(`\`\`\`governance-digest\n${ROW}\n\`\`\`\n`)).toMatchObject({_tag: "Malformed"});
+		expect(read(`${HEADING}\n\nnothing here\n`)).toMatchObject({_tag: "Malformed"});
+	});
+
+	it("is Malformed on a non-four-digit id and on a fourth field", () => {
+		expect(read(artifact("row\t398\troutine\tnote"))).toMatchObject({_tag: "Malformed"});
+		expect(read(artifact("row\t0398\troutine\tnote\tmore"))).toMatchObject({_tag: "Malformed"});
+	});
+
+	it("is Malformed on a fence with no row at all — an empty digest is not a digest", () => {
+		expect(read(`${HEADING}\n\n\`\`\`governance-digest\n\`\`\`\n`)).toMatchObject({
+			_tag: "Malformed",
+		});
+	});
+
+	it("names which line drifted, so a broken artifact points at itself", () => {
+		const result = read(artifact(ROW, "row\t0396\tsomething\tnote"));
+		expect(result).toMatchObject({_tag: "Malformed", evidence: expect.stringContaining("line 5")});
+	});
+});
+
+describe("emit", () => {
+	it("round-trips through read", () => {
+		const parsed = parseFields(`${ROW}\nrow\t0396\troutine\tno tension found\n`);
+		expect(parsed._tag).toBe("Fields");
+		if (parsed._tag !== "Fields") return;
+		expect(read(emit(parsed.rows))).toMatchObject({_tag: "Found"});
+	});
+
+	it("refuses to compose from no rows rather than emitting an empty block", () => {
+		expect(emitFromFields("\n  \n")).toMatchObject({_tag: "Unusable"});
+	});
+
+	it("refuses an off-vocabulary kind at compose time, naming the line", () => {
+		expect(emitFromFields("row\t0398\turgent\tnote")).toMatchObject({
+			_tag: "Unusable",
+			reason: expect.stringContaining("line 1"),
+		});
+	});
+
+	it("pipes its own read output straight back into emit", () => {
+		const back = readToLines(artifact(ROW));
+		expect(back._tag).toBe("Found");
+		if (back._tag !== "Found") return;
+		expect(emitFromFields(back.value.join("\n"))).toMatchObject({_tag: "Composed"});
+	});
+});

--- a/packages/fabrika-cli/src/wire/registry.ts
+++ b/packages/fabrika-cli/src/wire/registry.ts
@@ -20,6 +20,7 @@
  */
 import * as acceptanceCriteria from "./acceptance-criteria.ts";
 import {brandWitnesses, type WireFormat} from "./format.ts";
+import * as governanceDigest from "./governance-digest.ts";
 import * as grillAnswer from "./grill-answer.ts";
 import * as grillRuling from "./grill-ruling.ts";
 import * as grillSupersede from "./grill-supersede.ts";
@@ -66,7 +67,7 @@ export const registeredFormats: ReadonlyArray<WireFormat> = [
 		purpose:
 			"the SHA-bound first line of a gate's verdict comment on a PR — namespace, polarity, the head the reviewer inspected, and the human clause",
 		module: "packages/fabrika-cli/src/wire/verdict-marker.ts",
-		producers: ["review", "check-epic-plan"],
+		producers: ["review", "check-epic-plan", "governance"],
 		consumers: ["build", "ship"],
 		emit: verdictMarker.emitFromFields,
 		read: verdictMarker.readToLines,
@@ -88,6 +89,10 @@ export const registeredFormats: ReadonlyArray<WireFormat> = [
 				{
 					drift: "the polarity is not PASS or FAIL",
 					artifact: "review-code: APPROVED @ 03135b91 — merge-ready\n",
+				},
+				{
+					drift: "the governance namespace is not kebab-case",
+					artifact: "governance_digest: PASS @ 03135b91 — no contradiction, no weakening\n",
 				},
 			],
 		},
@@ -338,6 +343,63 @@ export const registeredFormats: ReadonlyArray<WireFormat> = [
 			sealedAt: true,
 			groundDigest: true,
 		}),
+	},
+	{
+		key: "governance-digest",
+		purpose:
+			"the periodic, non-blocking readout of the decision records that landed in a window — each row an id, one of three closed kinds, and a one-line pointer note",
+		module: "packages/fabrika-cli/src/wire/governance-digest.ts",
+		producers: ["governance"],
+		consumers: ["front-door"],
+		emit: governanceDigest.emitFromFields,
+		read: governanceDigest.readToLines,
+		fixtures: {
+			roundTrip: {
+				fields: [
+					"row\t0398\ttension\tsits against ADR 0173 on whether a pending required check blocks admission",
+					"row\t0401\tblast\tevery cache key in the system gains a tenant component",
+					"row\t0396\troutine\tno tension found",
+				].join("\n"),
+				values: [
+					"0398",
+					"tension",
+					"sits against ADR 0173 on whether a pending required check blocks admission",
+					"0401",
+					"blast",
+					"0396",
+					"routine",
+				],
+			},
+			absent: "Reading through the landings now — nothing here reaches for the block.\n",
+			malformed: [
+				{
+					drift: "the heading level drifted",
+					artifact:
+						"### Governance readout\n\n```governance-digest\nrow\t0398\troutine\tno tension found\n```\n",
+				},
+				{
+					drift: "the fence holds prose instead of rows",
+					artifact:
+						"## Governance readout\n\n```governance-digest\nNothing much landed this week.\n```\n",
+				},
+				{
+					drift: "a row's kind is off the closed set",
+					artifact:
+						"## Governance readout\n\n```governance-digest\nrow\t0398\turgent\tsits against ADR 0173\n```\n",
+				},
+				{
+					drift: "a row's id is not a four-digit decision id",
+					artifact:
+						"## Governance readout\n\n```governance-digest\nrow\t398\troutine\tno tension found\n```\n",
+				},
+				{
+					drift: "a row carries a fourth field",
+					artifact:
+						"## Governance readout\n\n```governance-digest\nrow\t0398\troutine\tno tension found\tand more\n```\n",
+				},
+			],
+		},
+		brands: brandWitnesses<governanceDigest.DigestRow>({id: true, kind: true, note: true}),
 	},
 ];
 


### PR DESCRIPTION
Fixes #5199

Builds `packages/fabrika-cli/src/governance/` — all seven verbs
`claude-plugins/fabrika/skills/governance/contract.md` derives — plus the one shipped-surface change
the contract still lists as outstanding.

## What the contract actually asked for, checked first-party against `main`

The issue body was written on 2026-08-09 and says "0 of 7 verbs and 0 of 3 surface changes". Two of
the three surface changes landed in the meantime, and the contract on `main` records it. Re-derived
against `origin/main` at `1baa7d02`:

| Piece | State before this PR |
|---|---|
| the seven verbs | **absent** — no `packages/fabrika-cli/src/governance/` at all, so **0 of 7 shipped** |
| change 1 — `SHIP_NAMESPACES` admits `governance` | **landed** (#5206), plus **1b** `requiredWithFloor` (#5036) |
| change 2 — the `verdict-marker` namespace class admits `governance` | **landed** (#5206); its stated residual is the registry fixtures |
| change 3 — a registered `governance-digest` wire format | **absent** — built here |

So this PR adds **seven verbs and one surface change**, and re-derives none of the two that landed.

## The verbs

| Verb | Answers |
|---|---|
| `governance scope` | whether the diff derives the namespace, over which of the four roots, at the bound head, with `self` and the records in the diff |
| `governance sweep` | the uncited live-`accepted` records whose domain a subject touches, ranked — subject from a bound commit (`--record`) or the corpus (`--landed`) |
| `governance guards` | the anchored invariants the bound diff removes or modifies, plus the guard-bearing files it touches |
| `governance base` | this skill's own text at a PR's merge base — the self fence's bytes |
| `governance post` | the single sanctioned emit of the `governance` namespace verdict |
| `governance digest` | the decision records that landed in a window, with each landing commit and its anchor delta |
| `governance readout` | compose the ranked rows, upsert the durable artifact, read them back |

**Nothing already solved is re-derived.** `GOVERNANCE_ROOTS` / `touchesGovernanceRoot` are imported
from `review/classes.ts` — one derivation, read by `ship scope`, `ship gate`'s required-set floor and
`governance scope` alike. The ranking core (`decisionBearingText`, `tokenize`, the idf scoring,
`RARITY_FLOOR`) is imported from `adr/sweep.ts`; `governance sweep` owns only the subject
acquisition. `bindHead` comes from `review/head.ts`, the leak predicate from `report/leaks.ts`, and
`normalizeForReadback` from `report/compose.ts`.

## The exit table

`packages/fabrika-cli/src/governance/codes.ts` imports every shared seat under an alias and restates
no numeral. `GOVERNANCE_SEATS` in `exit-code-alignment.ts` is `SHARED_SEATS` — every name and every
reading matches the base's.

| Seat | Source | Reading |
|---|---|---|
| `3` `5` `6` `7` `8` `9` `11` | `report/codes.ts` | `EMPTY_STDIN`, `LEAKED_PATH`, `BARE_AT_PATH`, `NO_TARGET` → `ZERO_SCOPE`, `WRITE_UNKNOWN`, `READBACK_MISMATCH`, `PRECONDITION_UNKNOWN` |
| `10` | `triage/codes.ts` | `OFF_VOCABULARY` — imported from `triage` because that is where this group's reading is named |
| `12` `13` | `review/codes.ts` | `STALE_HEAD`, `INCOMPLETE_SCAN` — this group proves the same two facts |
| `4` | declared locally | `DELIBERATE_GAP` — no verb here composes body sections, so the gap is registered rather than silently absent |
| `14` | declared locally | `NOT_HARNESS_TOUCHING` |

**No seat was re-used and no VACATED seat re-seated.** `14` is declared, deliberately **not**
imported: `review/codes.ts` seats its own `14` as `ACL_DENIED`, a different group's private band, so
an import beside `12` and `13` would take the wrong meaning silently. `codes.unit.test.ts` pins that
and pins the three-way distinction the group turns on — `1`/`127` never decided, `11` a precondition
read failed with nothing written, `8` a write attempted with an UNKNOWN outcome — and every proven
verdict at `3`+ leaves stdout empty by construction (`verb.ts`'s `refuse` hardcodes it).

## Shared registration files — every edit an insertion

Three other lanes are on these files, so each edit is an append at the end of an existing array,
record or section. `git diff --cached --numstat` on every shared file:

```
13	1	claude-plugins/fabrika/docs/wire-formats.md
44	0	packages/fabrika-cli/README.md
12	0	packages/fabrika-cli/src/exit-code-alignment.ts
2	0	packages/fabrika-cli/src/exit-code-alignment.unit.test.ts
172	0	packages/fabrika-cli/src/io/git.ts
9	0	packages/fabrika-cli/src/io/issues.ts
2	0	packages/fabrika-cli/src/registry.ts
63	1	packages/fabrika-cli/src/wire/registry.ts
```

The two deleted lines are one edit, disclosed rather than hidden: `governance` was appended to the
**existing** `verdict-marker` row's `producers` array, which this group now genuinely produces, and
the wire-formats table row is that same change re-rendered. Both are in-place appends to a list — no
content removed. Every other shared file is strictly insertion-only. The doc region was regenerated
with `fabrika wire index --write`, never hand-merged; the `README.md` change adds a
`## The governance group` section ahead of `## The wire group` and reflows nothing.

`io/issues.ts` gained a `comments` field on `IssueRecord`, read off `value.comments` rather than
through the existing destructure so the addition stays a pure insertion. It is what makes
`governance readout`'s `13` seat provable — without a declared count there is no denominator, and a
completeness refusal over no denominator proves nothing.

## Deviations

The Tier-M scan is reported below; this section states what it found and the three judgment calls
that are not the scan's to make.

**Tier-M scan, one hit, a known false positive.** The scan's bare `xit(` alternative matches inside
`process.exit(outcome.code)` in `src/governance/command.ts`'s emit adapter. That line is
byte-identical to the same line in every sibling group's `command.ts` (`spike`, `grill`, `map`,
`review`, `ship`). No test is skipped, no suppression is added, and no assertion is removed anywhere
in this diff.

**A behaviour the contract specifies that is UNREACHABLE as ordered, proven by execution.** The
contract's change-2 residual asks for `governance` fixture rows on the `verdict-marker` registry row
so `wire/conformance.ts` drives a governance arm. A **round-trip** governance arm is not
representable: `WireFixtures.roundTrip` (`src/wire/format.ts`) is a single `WireRoundTripFixture`,
not a list, so a second round-trip fixture cannot be added without changing that type — and changing
it would touch every registered row. Proven by execution rather than asserted: adding a second
`roundTrip` key to the row is `TS1117` (duplicate property), and replacing the existing
`review-code` round-trip would delete the coverage it stands for. This PR therefore lands the half
that IS representable — `governance` appended to `producers`, and a governance malformed fixture
whose namespace is not kebab-case — and leaves the round-trip arm to whoever decides whether
`WireFixtures` should carry a list. Surfaced on #5199 rather than patched over.

**Two places the contract is under-determined; the conservative branch was taken in both, and both
are surfaced on #5199 rather than invented over.**

1. *`self` under an ambiguous skill-root resolution.* `governance base` states all three arms —
   one root, zero (`7`), more than one (`11`) — but `governance scope`'s `self` flag is specified only
   as "true when any changed path is under the resolved skill root", with no arm for zero or several.
   Taken conservatively: `self` is true when a path is under **any** candidate root, so an ambiguous
   install flags the self fence rather than skipping it, and zero candidates leaves `self` false
   because there is nothing to be under. `roots.unit.test.ts` pins both.
2. *`governance scope`'s `13` versus the #5154 finding.* The contract seats a short changed-file read
   on `13` explicitly ("received < declared count"). #5154 established that git and GitHub
   legitimately disagree on that count — git pairs a rename into one `--name-only` path where GitHub
   counts two — which is why `review scope` reports the disagreement and never refuses on it. The
   contract wins here and the refusal is implemented as written, because it is the fail-closed
   direction (a rename-only PR refuses rather than deriving from a list it cannot prove complete);
   the tension is noted at the check site and on #5199.

**Two wording supersets, stated so a reviewer diffing against the contract is not surprised.** The
`12` refusal `governance scope` emits is `bindHead`'s, which adds "the tree you scoped is not the one
under review" before the contract's "re-scope at `<live>` (ADR 0058)" — a superset of the specified
text, taken by importing the binding rather than re-deriving it. The `11` binding refusal is
re-phrased into each verb's own noun by `governance/head.ts`'s `withBindingNoun`, which is unit-tested
in both directions so a change to `bindHead`'s wording reds a test rather than silently passing the
imported noun through.

**(repair round 1)** *The known defect this diff shipped undisclosed — now fixed, disclosed, and
pinned.* #5199 carried a warning from the #5206 lane that `governance guards` would read its own
`SKILL.md` prose as a twelfth anchor and wanted one exclusion line at implementation time. The
initial diff took neither remedy and said nothing here; the gate reproduced it by execution
(`anchorsIn` returned 12 over a file carrying 11 anchors). Fixed in `src/governance/anchors.ts`:
inline-code spans are blanked before the anchor regex runs, in `anchorsIn` (the `anchors-in-reach`
denominator) and in `sightingOf` (so `scanAnchors` cannot report a phantom `modified` when that
sentence is reworded). The blanking is length-preserving, so indices into the masked text are
indices into the original and the `modified` comparison still slices the real bytes — unchanged
behaviour for every real anchor. **Executed proof:** `anchorsIn` over
`claude-plugins/fabrika/skills/governance/SKILL.md` now returns **11** — lines 14, 27, 47, 77, 90,
97, 116, 149, 166, 214, 242 — with line 117 (the sentence documenting the tag) excluded. **Why this
shape and not the obvious one:** a "an anchor must open its line" rule would under-count, because
real anchors sit after a list bullet (`- <!-- anchor: H1 -->`) and after a heading
(`## Open questions <!-- anchor: OPEN-QUESTIONS -->`); a corpus sweep found the only backticked
anchor tags are the two that *document* the pattern, and no real anchor inside backticks. Pinned by
four new unit tests, including one over the real skill file.

**(repair round 1)** *Rebased onto latest `origin/main`, which had landed the `handoff-pack` wire
format (#5350).* Three textual conflicts, each "both sides appended", resolved by keeping both
sides: `wire/registry.ts`, the generated `docs/wire-formats.md`, and `fabrika-cli/README.md`.
`fabrika wire index --write` re-run afterwards reports `index written 9 9` with zero diff. The
zero-deletion property is intact: the only lines removed against `origin/main` remain the one
disclosed `verdict-marker` `producers` line and its re-rendered doc row.

## Checks

- `pnpm typecheck` (workspace, turbo) — 31/31 green. The in-package `tsgo -p tsconfig.json` was run
  from `packages/fabrika-cli`, never from the repo root (#5312).
- `pnpm vitest run` in `packages/fabrika-cli` — 247 files, 3589 tests, all green (148 of them new).
- `pnpm lint:worktree` — clean.
- *(repair round 1, re-run at the rebased head)* in-package `tsgo -p tsconfig.json` clean;
  `pnpm vitest run` in `packages/fabrika-cli` — 257 files, 3694 tests, all green;
  `pnpm lint:worktree` clean; `fabrika wire index --write` zero diff.

