### PR TITLE
feat(fabrika): implement the write-pattern contract's five pattern verbs (#5332)

### DIFF
--- a/packages/fabrika-cli/README.md
+++ b/packages/fabrika-cli/README.md
@@ -606,6 +606,56 @@ The group emits the `governance` namespace through the shipped
 [`verdict-marker`](src/wire/verdict-marker.ts) format and publishes its digest through
 [`governance-digest`](src/wire/governance-digest.ts).
 
+## The `pattern` group
+
+The contract is the `write-pattern` skill's derived CLI contract, landing with
+[PR #5333](https://github.com/kamp-us/phoenix/pull/5333) at
+`claude-plugins/fabrika/skills/write-pattern/contract.md`. A **pattern doc** is one flat
+`<slug>.md` under a doc directory (`.patterns` by default), registered by one row in that
+directory's `index.md`.
+
+| Verb | Answers |
+|---|---|
+| `pattern corpus` | the library at a base ref: every doc, its registration, its section, its last-touching commit |
+| `pattern drift` | whether the in-repo source a doc cites moved since the doc was last written |
+| `pattern anchor` | whether the dependency version a doc declares still matches what the workspace pins |
+| `pattern new` | scaffolds `<dir>/<slug>.md` from the canonical template |
+| `pattern register` | inserts the doc's row into `<dir>/index.md` under a named section |
+
+Five properties are worth knowing before you call them:
+
+- **Every outcome exits `0`, including the empty ones.** `corpus` answers `absent` for a directory
+  that is not in the tree and `none` for one that is and holds nothing; `drift` answers
+  `unanchored`; `anchor` answers `unanchored`. Exit `7` is deliberately unseated — no verb here
+  judges over a corpus, so none has a vacuous pass to prevent, and refusing on an empty library
+  would leave a repo adopting fabrika unable to write its first pattern doc
+  ([#5254](https://github.com/kamp-us/phoenix/issues/5254)).
+- **`unanchored` is not a clearance.** It says the doc cites nothing the verb can follow, so drift
+  there is *unanswerable* — read the source by hand. Reporting it as `current` would be a clean pass
+  over nothing, the shape ADR [0092](../../.decisions/0092-gates-fail-closed-on-zero-scope.md)
+  forbids; the group says so in vocabulary rather than in an exit code, because a verb that refused
+  would break the pipe its answer crosses.
+- **Registration is three-valued.** `unknown` — the index is absent, or holds no markdown table —
+  is its own value, because rendering it as `unregistered` would report a defect the verb never
+  proved and send a caller to add rows to a file that cannot hold them. A doc counts as registered
+  only when a table row's **first cell** links its filename; a mention in prose is not a
+  registration.
+- **An unresolved citation is counted, never a finding.** Pattern prose legitimately cites external
+  dependency source trees, and such a path is indistinguishable from a deleted in-repo one by
+  resolution alone. `drift` names each on stderr and excludes it from the moved set, inheriting
+  `pointer-guard`'s `.patterns/**` exclusion rather than repeating the false positive it escaped.
+- **`register` proves its diff before it writes.** The index is hand-curated, carries prose between
+  its tables, and is edited by lanes this verb cannot see, so an insertion that changed any line
+  beyond the new row aborts on `14` with nothing written — and the row is read back after.
+
+The two reads are deliberately different: `corpus`, `drift` and `anchor` read at a fetched `--base`,
+because the question they answer is what the repository already holds; `new` and `register` write the
+**working tree**. A doc created by `new` is therefore invisible to `corpus` until it is committed.
+
+This group is an authoring surface: it emits no verdict marker, joins no gate or ship namespace,
+registers no wire format, needs no repository token and writes to no board surface. A `.patterns/*.md`
+diff gates on the doc review namespace like any other doc change.
+
 ## The `wire` group
 
 A **wire format** is the byte-level agreement two skills meet through on a GitHub artifact —

--- a/packages/fabrika-cli/src/exit-code-alignment.ts
+++ b/packages/fabrika-cli/src/exit-code-alignment.ts
@@ -223,6 +223,24 @@ export const SPIKE_SEATS: SharedSeats = {
  */
 export const GOVERNANCE_SEATS: SharedSeats = SHARED_SEATS;
 
+/**
+ * `pattern`'s seats: four, the narrowest claim of any aligning group.
+ *
+ * Its verbs read a doc library and write two files, so most of the base's table is about facts they
+ * cannot establish. What they do establish is the four that mean the same thing wherever they are
+ * proven — a failed write, a mismatched read-back, an off-vocabulary value, a precondition that could
+ * not be read. `7` is deliberately **not** claimed and not held as a gap: no verb here judges over a
+ * corpus, so it has no vacuous pass to prevent, and an empty or absent doc directory is a fact it
+ * reports at exit `0` (#5254). The seats are imported from `build`, which re-exports the base's
+ * values unchanged and already carries `OFF_VOCABULARY` under that name.
+ */
+export const PATTERN_SEATS: SharedSeats = {
+	WRITE_UNKNOWN: "WRITE_UNKNOWN",
+	READBACK_MISMATCH: "READBACK_MISMATCH",
+	OFF_VOCABULARY: "CLASSIFIED",
+	PRECONDITION_UNKNOWN: "PRECONDITION_UNKNOWN",
+};
+
 /** The groups that align to {@link ALIGNMENT_BASE}, each with the seats it claims to share. */
 export const ALIGNED_GROUPS: Readonly<Record<string, SharedSeats>> = {
 	adr: ADR_SEATS,
@@ -236,6 +254,7 @@ export const ALIGNED_GROUPS: Readonly<Record<string, SharedSeats>> = {
 	handoff: HANDOFF_SEATS,
 	ledger: BUILD_SEATS,
 	map: MAP_SEATS,
+	pattern: PATTERN_SEATS,
 	plan: BUILD_SEATS,
 	triage: SHARED_SEATS,
 	review: SHARED_SEATS,

--- a/packages/fabrika-cli/src/exit-code-alignment.unit.test.ts
+++ b/packages/fabrika-cli/src/exit-code-alignment.unit.test.ts
@@ -22,6 +22,7 @@ import * as handoff from "./handoff/codes.ts";
 import * as hook from "./hook/codes.ts";
 import * as ledger from "./ledger/codes.ts";
 import * as map from "./map/codes.ts";
+import * as pattern from "./pattern/codes.ts";
 import * as plan from "./plan/codes.ts";
 import {registeredGroups} from "./registry.ts";
 import * as report from "./report/codes.ts";
@@ -54,6 +55,7 @@ const TABLES: Readonly<Record<string, CodeTable>> = {
 	hook,
 	ledger,
 	map,
+	pattern,
 	plan,
 	report,
 	review,

--- a/packages/fabrika-cli/src/pattern/anchor-verb.ts
+++ b/packages/fabrika-cli/src/pattern/anchor-verb.ts
@@ -1,0 +1,180 @@
+/**
+ * `pattern anchor` — whether the dependency version a doc declares still matches what the workspace
+ * pins.
+ *
+ * A separate verb rather than a mode of `pattern drift` because the git half and the dependency half
+ * go stale independently. **An unreadable manifest is UNKNOWN and never `unpinned`:** the two are one
+ * keystroke apart in consequence — `unpinned` says the repo does not carry this dependency, and a
+ * failed read says nothing at all. A manifest that is genuinely absent, or that parses and carries no
+ * `catalog:` map, is the degrade path instead: every declaration reports `unpinned` at exit `0` with
+ * the absence named on stderr.
+ */
+import {Effect, type FileSystem, Result} from "effect";
+import type {ChildProcessSpawner} from "effect/unstable/process";
+import {exists} from "../io/fs.ts";
+import {fetchAndResolve, readFileAt} from "../io/git.ts";
+import {answer, FAILED, refuse, type VerbOutcome} from "../verb.ts";
+import {
+	type AnchorOutcome,
+	anchorOutcome,
+	type Declaration,
+	declarationLinesIn,
+	parseCatalog,
+	resolveDeclarations,
+} from "./anchor.ts";
+import {DOC_ABSENT, PRECONDITION_UNKNOWN} from "./codes.ts";
+import {isKebabCase} from "./doc.ts";
+import {pathPresentAt} from "./git.ts";
+
+export interface AnchorOptions {
+	readonly slug: string;
+	readonly dir: string;
+	readonly manifest: string;
+	readonly base: string;
+	readonly json: boolean;
+}
+
+const count = (declarations: ReadonlyArray<Declaration>, state: Declaration["state"]): number =>
+	declarations.filter((d) => d.state === state).length;
+
+const emit = (
+	options: AnchorOptions,
+	outcome: AnchorOutcome,
+	declarations: ReadonlyArray<Declaration>,
+	sha: string,
+): string => {
+	const moved = count(declarations, "moved");
+	const unpinned = count(declarations, "unpinned");
+	const malformed = count(declarations, "malformed");
+	if (options.json) {
+		return JSON.stringify({
+			outcome,
+			declared: declarations.length,
+			moved,
+			unpinned,
+			malformed,
+			packages: declarations.map((d) => ({
+				package: d.package,
+				declaredVersion: d.declaredVersion,
+				pinnedVersion: d.pinnedVersion,
+				state: d.state,
+			})),
+			manifest: options.manifest,
+			baseRef: options.base,
+			baseSha: sha,
+		});
+	}
+	return [
+		["anchor", outcome, declarations.length, moved, unpinned, malformed].join("\t"),
+		...declarations.map((d) =>
+			["pkg", d.package, d.declaredVersion ?? "-", d.pinnedVersion ?? "-", d.state].join("\t"),
+		),
+	].join("\n");
+};
+
+export const runAnchor = (
+	options: AnchorOptions,
+): Effect.Effect<
+	VerbOutcome,
+	never,
+	FileSystem.FileSystem | ChildProcessSpawner.ChildProcessSpawner
+> =>
+	Effect.gen(function* () {
+		const {slug, dir, manifest, base} = options;
+		if (!isKebabCase(slug)) {
+			return refuse(
+				FAILED,
+				`pattern anchor: slug "${slug}" is not kebab-case (lowercase letters, digits and single hyphens).`,
+			);
+		}
+
+		const resolved = yield* fetchAndResolve(base);
+		if (resolved._tag === "Failure") {
+			return refuse(
+				PRECONDITION_UNKNOWN,
+				`pattern anchor: cannot fetch ${base}: ${resolved.reason} — the outcome is UNKNOWN, never "matched".`,
+			);
+		}
+		const sha = resolved.value;
+		const path = `${dir}/${slug}.md`;
+
+		const atBase = yield* pathPresentAt(sha, path);
+		if (atBase._tag === "Failure") {
+			return refuse(
+				PRECONDITION_UNKNOWN,
+				`pattern anchor: cannot read ${path} at ${base}: ${atBase.reason} — the outcome is UNKNOWN, never "matched".`,
+			);
+		}
+
+		if (!atBase.value) {
+			const inTree = yield* Effect.result(exists(path));
+			if (Result.isFailure(inTree)) {
+				return refuse(
+					PRECONDITION_UNKNOWN,
+					`pattern anchor: cannot read ${path}: ${inTree.failure.reason} — the outcome is UNKNOWN, never "matched".`,
+				);
+			}
+			if (!inTree.success) {
+				return refuse(
+					DOC_ABSENT,
+					`pattern anchor: no doc for slug "${slug}" under ${dir}, in the working tree or at ${base}.`,
+				);
+			}
+			// `unborn` mirrors `pattern drift` deliberately: the skill runs the two back to back, so one
+			// tree state must not produce two different verdicts.
+			return answer(emit(options, "unborn", [], sha), [
+				`pattern anchor: ${path} is in the working tree and absent at ${sha} — unborn, the same outcome pattern drift reports.`,
+			]);
+		}
+
+		const text = yield* readFileAt(sha, path);
+		if (text._tag === "Failure") {
+			return refuse(
+				PRECONDITION_UNKNOWN,
+				`pattern anchor: cannot read ${path} at ${base}: ${text.reason} — the outcome is UNKNOWN, never "matched".`,
+			);
+		}
+
+		const manifestPresent = yield* pathPresentAt(sha, manifest);
+		if (manifestPresent._tag === "Failure") {
+			return refuse(
+				PRECONDITION_UNKNOWN,
+				`pattern anchor: cannot read ${manifest} at ${base}: ${manifestPresent.reason} — every pin is UNKNOWN, never "unpinned".`,
+			);
+		}
+
+		let catalog: Readonly<Record<string, string>> | null = null;
+		let degraded: string | null = null;
+		if (!manifestPresent.value) {
+			degraded = `${manifest} is absent at ${sha}`;
+		} else {
+			const manifestText = yield* readFileAt(sha, manifest);
+			if (manifestText._tag === "Failure") {
+				return refuse(
+					PRECONDITION_UNKNOWN,
+					`pattern anchor: cannot read ${manifest} at ${base}: ${manifestText.reason} — every pin is UNKNOWN, never "unpinned".`,
+				);
+			}
+			const parsed = parseCatalog(manifestText.value);
+			if (parsed._tag === "Unparseable") {
+				return refuse(
+					PRECONDITION_UNKNOWN,
+					`pattern anchor: ${manifest} at ${base} does not parse as YAML: ${parsed.reason} — every pin is UNKNOWN, never "unpinned".`,
+				);
+			}
+			if (parsed.catalog === null) degraded = `${manifest} at ${sha} carries no catalog: map`;
+			else catalog = parsed.catalog;
+		}
+
+		const declarations = resolveDeclarations(declarationLinesIn(text.value), catalog);
+		const outcome = anchorOutcome(declarations);
+		const scope = [
+			`pattern anchor: read ${path} at ${sha} against ${manifest}; ${declarations.length} declared, ${count(declarations, "moved")} moved, ${count(declarations, "unpinned")} unpinned, ${count(declarations, "malformed")} malformed.`,
+			...(degraded === null
+				? []
+				: [
+						`pattern anchor: ${degraded} — every declaration reports "unpinned", which is a fact about this repository rather than a failed read.`,
+					]),
+		];
+		return answer(emit(options, outcome, declarations, sha), scope);
+	});

--- a/packages/fabrika-cli/src/pattern/anchor-verb.unit.test.ts
+++ b/packages/fabrika-cli/src/pattern/anchor-verb.unit.test.ts
@@ -1,0 +1,147 @@
+import {Effect, Layer} from "effect";
+import {describe, expect, it} from "vitest";
+import {errOut, fakeFs, fakeShell, okOut} from "../fakes.test-support.ts";
+import {runAnchor} from "./anchor-verb.ts";
+import {DOC_ABSENT, PRECONDITION_UNKNOWN} from "./codes.ts";
+import {ANCHORED_DOC, FIXTURE_MANIFEST, FIXTURES, PLAIN_DOC} from "./fixtures.test-support.ts";
+
+const SHA = "49a22902d1e0c7b3f5a8e4126b9d0f3c7a1e5b82";
+const DIR = `${FIXTURES}/anchored`;
+const MANIFEST = `${DIR}/workspace.yaml`;
+
+type Script = ReadonlyArray<readonly [RegExp, ReturnType<typeof okOut>]>;
+
+const shell = (overrides: Script = [], slug = "worker-queue-retry") =>
+	fakeShell([
+		...overrides,
+		[/^git remote$/, okOut("origin\n")],
+		[/^git fetch/, okOut("")],
+		[/^git rev-parse/, okOut(`${SHA}\n`)],
+		[/^git ls-tree --name-only \w+ -- \S+\.md$/, okOut(`${DIR}/${slug}.md\n`)],
+		[/^git ls-tree --name-only \w+ -- \S+\.yaml$/, okOut(`${MANIFEST}\n`)],
+		[/^git show \w+:\S+\.yaml$/, okOut(FIXTURE_MANIFEST)],
+		[/^git show \w+:\S+plain-doc\.md$/, okOut(PLAIN_DOC)],
+		[/^git show \w+:/, okOut(ANCHORED_DOC)],
+	]);
+
+const options = {
+	slug: "worker-queue-retry",
+	dir: DIR,
+	manifest: MANIFEST,
+	base: "origin/main",
+	json: false,
+};
+
+const run = (
+	overrides: Script = [],
+	opts: Partial<typeof options> = {},
+	files: Readonly<Record<string, string | null>> = {},
+) =>
+	Effect.runPromise(
+		Effect.provide(
+			runAnchor({...options, ...opts}),
+			Layer.merge(shell(overrides, opts.slug ?? options.slug).layer, fakeFs({files}).layer),
+		),
+	);
+
+describe("runAnchor", () => {
+	// The contract's first worked example, byte for byte.
+	it("reports one moved and one unpinned declaration at exit 0", async () => {
+		const out = await run();
+		expect(out.code).toBe(0);
+		expect(out.stdout).toBe(
+			[
+				"anchor\tmoved\t2\t1\t1\t0",
+				"pkg\tacme-queue\t4.1.0\t4.2.0\tmoved",
+				"pkg\t@acme/retry\t2.0.0\t-\tunpinned",
+				"",
+			].join("\n"),
+		);
+	});
+
+	// The contract's second worked example. `unanchored` is a FACT, not a fault: most pattern docs
+	// describe in-repo shapes and are anchored to no dependency at all.
+	it("answers `unanchored` for a doc that declares nothing", async () => {
+		const out = await run([], {slug: "plain-doc"});
+		expect(out.code).toBe(0);
+		expect(out.stdout).toBe("anchor\tunanchored\t0\t0\t0\t0\n");
+	});
+
+	// The contract's third worked example.
+	it("carries the whole record through --json", async () => {
+		const out = await run([], {json: true});
+		expect(out.stdout).toBe(
+			`{"outcome":"moved","declared":2,"moved":1,"unpinned":1,"malformed":0,"packages":[{"package":"acme-queue","declaredVersion":"4.1.0","pinnedVersion":"4.2.0","state":"moved"},{"package":"@acme/retry","declaredVersion":"2.0.0","pinnedVersion":null,"state":"unpinned"}],"manifest":"${MANIFEST}","baseRef":"origin/main","baseSha":"${SHA}"}\n`,
+		);
+	});
+
+	// The header is always `<moved> + <unpinned> + <malformed> + <matched>`, so a reader can check it
+	// against itself; counting only the well-formed lines would hide what the verb exists to surface.
+	it("counts a near-miss line as malformed rather than as absent", async () => {
+		const out = await run([
+			[
+				/^git show \w+:\S+\.md$/,
+				okOut(
+					"# Doc\n\n> Derived from the in-repo source plus `acme-queue@4.1.0` where it counts\n",
+				),
+			],
+		]);
+		expect(out.code).toBe(0);
+		expect(out.stdout.split("\n")[0]).toBe("anchor\tmalformed\t1\t0\t0\t1");
+		expect(out.stdout.split("\n")[1]).toBe(
+			"pkg\tthe in-repo source plus `acme-queue@4.1.0` where it counts\t-\t-\tmalformed",
+		);
+	});
+
+	// An unreadable manifest is UNKNOWN and never `unpinned` — a 404 is a verdict, a 5xx is a verdict
+	// about nothing.
+	it("refuses a manifest read that failed", async () => {
+		const out = await run([[/^git show \w+:\S+\.yaml$/, errOut("fatal: bad object")]]);
+		expect(out.code).toBe(PRECONDITION_UNKNOWN);
+		expect(out.stdout).toBe("");
+		expect(out.stderr.at(-1)).toContain('every pin is UNKNOWN, never "unpinned"');
+	});
+
+	it("refuses a manifest that does not parse as YAML", async () => {
+		const out = await run([[/^git show \w+:\S+\.yaml$/, okOut("catalog:\n\tacme-queue: 4.2.0\n")]]);
+		expect(out.code).toBe(PRECONDITION_UNKNOWN);
+		expect(out.stderr.at(-1)).toContain("does not parse as YAML");
+	});
+
+	// The degrade path: a repo that pins nothing centrally is a fact about that repo, not a failure.
+	it("degrades to `unpinned` at exit 0 when the manifest is absent, and says so on stderr", async () => {
+		const out = await run([[/^git ls-tree --name-only \w+ -- \S+\.yaml$/, okOut("")]]);
+		expect(out.code).toBe(0);
+		expect(out.stdout.split("\n")[0]).toBe("anchor\tunpinned\t2\t0\t2\t0");
+		expect(out.stderr.join("\n")).toContain("is absent at");
+	});
+
+	it("degrades the same way for a manifest that parses and carries no catalog map", async () => {
+		const out = await run([[/^git show \w+:\S+\.yaml$/, okOut("packages:\n  - packages/*\n")]]);
+		expect(out.code).toBe(0);
+		expect(out.stdout.split("\n")[0]).toBe("anchor\tunpinned\t2\t0\t2\t0");
+		expect(out.stderr.join("\n")).toContain("carries no catalog: map");
+	});
+
+	// `unborn` mirrors `pattern drift` deliberately: one tree state must not produce two verdicts.
+	it("answers `unborn` for a doc in the working tree and absent at the base", async () => {
+		const out = await run(
+			[[/^git ls-tree --name-only \w+ -- \S+\.md$/, okOut("")]],
+			{},
+			{
+				[`${DIR}/worker-queue-retry.md`]: "# New\n",
+			},
+		);
+		expect(out.code).toBe(0);
+		expect(out.stdout).toBe("anchor\tunborn\t0\t0\t0\t0\n");
+	});
+
+	it("refuses a slug with no doc anywhere on the same code pattern drift uses", async () => {
+		const out = await run([[/^git ls-tree --name-only \w+ -- \S+\.md$/, okOut("")]], {
+			slug: "no-such-doc",
+		});
+		expect(out.code).toBe(DOC_ABSENT);
+		expect(out.stdout).toBe("");
+		expect(out.stderr.at(-1)).toContain('no doc for slug "no-such-doc"');
+	});
+});

--- a/packages/fabrika-cli/src/pattern/anchor.ts
+++ b/packages/fabrika-cli/src/pattern/anchor.ts
@@ -1,0 +1,132 @@
+/**
+ * What a doc declares it is derived from, against what the workspace actually pins.
+ *
+ * **A line that opens `> Derived from ` and does not match the grammar in full is `malformed`, not a
+ * non-declaration.** This is the load-bearing half. Treating a near miss as absent would answer
+ * `unanchored` — *"this doc claims no dependency anchor"* — for a doc that visibly claims one, which
+ * is a fail-open false negative. Counting it as malformed makes the verb say *"something here
+ * declares an anchor I could not parse"*, which is true and actionable — the same discipline
+ * `./drift.ts` applies to an unresolved path.
+ */
+import {ANCHOR_DECLARATION, ANCHOR_PREFIX, splitAnchorToken} from "./doc.ts";
+
+export type DeclarationState = "matched" | "moved" | "unpinned" | "malformed";
+
+export interface Declaration {
+	/** The package name, or — on a malformed line — the line's text after the prefix, clamped. */
+	readonly package: string;
+	/** `null` on a malformed line: no `<pkg>@<version>` token could be split out of it. */
+	readonly declaredVersion: string | null;
+	/** `null` when the package is not a catalog key, and on a malformed line. */
+	readonly pinnedVersion: string | null;
+	readonly state: DeclarationState;
+}
+
+export type AnchorOutcome = DeclarationState | "unanchored" | "unborn";
+
+/** Enough of the line to find it, with nothing that could break the one-line grammar. */
+const echoOf = (line: string): string =>
+	line
+		.slice(ANCHOR_PREFIX.length)
+		.replace(/[\t\n\r]+/g, " ")
+		.slice(0, 120);
+
+/** Every line claiming an anchor, in document order — parsed or not. */
+export const declarationLinesIn = (text: string): ReadonlyArray<string> =>
+	text.split("\n").filter((line) => line.startsWith(ANCHOR_PREFIX));
+
+export type CatalogRead =
+	| {readonly _tag: "Ok"; readonly catalog: Readonly<Record<string, string>> | null}
+	| {readonly _tag: "Unparseable"; readonly reason: string};
+
+/**
+ * The manifest's top-level `catalog:` map.
+ *
+ * `catalog: null` is the **degrade** path, not a failure: a repo that pins nothing centrally is a
+ * fact about that repo, so every declaration reports `unpinned` at exit `0`. Only a manifest that
+ * does not parse is UNKNOWN — the `7`/`11` split, applied to a file: a missing key is a verdict, an
+ * unreadable document is a verdict about nothing.
+ */
+export const parseCatalog = (text: string): CatalogRead => {
+	const lines = text.split("\n");
+	for (const [at, line] of lines.entries()) {
+		if (/^[ ]*\t/.test(line)) {
+			return {_tag: "Unparseable", reason: `line ${at + 1} indents with a tab, which YAML forbids`};
+		}
+	}
+	const start = lines.findIndex((line) => /^catalog:\s*(#.*)?$/.test(line));
+	if (start === -1) return {_tag: "Ok", catalog: null};
+
+	const catalog: Record<string, string> = {};
+	for (let at = start + 1; at < lines.length; at += 1) {
+		const line = lines[at] ?? "";
+		if (line.trim() === "" || /^\s*#/.test(line)) continue;
+		if (!/^\s/.test(line)) break;
+		const m = /^\s+(.+?)\s*:\s*(.*?)\s*$/.exec(line);
+		if (m?.[1] === undefined || m[2] === undefined) {
+			return {
+				_tag: "Unparseable",
+				reason: `line ${at + 1} sits under catalog: and is not a key/value pair`,
+			};
+		}
+		catalog[m[1].replace(/^['"]|['"]$/g, "")] = m[2].replace(/^['"]|['"]$/g, "");
+	}
+	return {_tag: "Ok", catalog};
+};
+
+/**
+ * Resolve each declaration against the pins.
+ *
+ * The version comparison is **byte for byte**, with no semver interpretation: a doc's anchor records
+ * the version its author actually read, and accepting a range would silently bless a version nobody
+ * checked — the whole failure the line exists to catch.
+ */
+export const resolveDeclarations = (
+	lines: ReadonlyArray<string>,
+	catalog: Readonly<Record<string, string>> | null,
+): ReadonlyArray<Declaration> =>
+	lines.map((line): Declaration => {
+		const token = ANCHOR_DECLARATION.exec(line)?.[1];
+		const split = token === undefined ? null : splitAnchorToken(token);
+		if (split === null) {
+			return {
+				package: echoOf(line),
+				declaredVersion: null,
+				pinnedVersion: null,
+				state: "malformed",
+			};
+		}
+		const pinned = catalog?.[split.pkg];
+		if (pinned === undefined) {
+			return {
+				package: split.pkg,
+				declaredVersion: split.version,
+				pinnedVersion: null,
+				state: "unpinned",
+			};
+		}
+		return {
+			package: split.pkg,
+			declaredVersion: split.version,
+			pinnedVersion: pinned,
+			state: pinned === split.version ? "matched" : "moved",
+		};
+	});
+
+/**
+ * The outcome, by the contract's precedence: `moved`, then `malformed`, then `unpinned`, then
+ * `matched`, then `unanchored`.
+ *
+ * **`malformed` does not fold into `unpinned`.** They ask opposite things of a caller: `unpinned`
+ * says this repo no longer carries the dependency, which is a question about whether the doc still
+ * applies at all; `malformed` says the anchor line is mistyped, which is a one-line repair. And
+ * `unanchored` fires only when the doc carries no claiming line at all — not merely when none
+ * parsed, which is what keeps a near miss from reading as clean.
+ */
+export const anchorOutcome = (declarations: ReadonlyArray<Declaration>): AnchorOutcome => {
+	if (declarations.length === 0) return "unanchored";
+	if (declarations.some((d) => d.state === "moved")) return "moved";
+	if (declarations.some((d) => d.state === "malformed")) return "malformed";
+	if (declarations.some((d) => d.state === "unpinned")) return "unpinned";
+	return "matched";
+};

--- a/packages/fabrika-cli/src/pattern/anchor.unit.test.ts
+++ b/packages/fabrika-cli/src/pattern/anchor.unit.test.ts
@@ -1,0 +1,120 @@
+import {describe, expect, it} from "vitest";
+import {anchorOutcome, declarationLinesIn, parseCatalog, resolveDeclarations} from "./anchor.ts";
+
+const CATALOG = {"acme-queue": "4.2.0", "@nkzw/fate": "1.3.1"};
+
+const declared = (...lines: ReadonlyArray<string>) => resolveDeclarations(lines, CATALOG);
+
+describe("declarationLinesIn", () => {
+	// The load-bearing half: a line that OPENS the prefix and does not match in full is still a
+	// declaration. Treating it as absent would answer `unanchored` for a doc that visibly claims an
+	// anchor — a fail-open false negative.
+	it("takes every line claiming an anchor, parsed or not", () => {
+		expect(
+			declarationLinesIn(`# Doc
+
+> Derived from \`acme-queue@4.1.0\` — re-verify on pin bump.
+
+> Derived from the in-repo source plus \`acme-queue@4.1.0\` where the lib is implicated.
+
+Not a declaration: > Derived from something.
+`),
+		).toEqual([
+			"> Derived from `acme-queue@4.1.0` — re-verify on pin bump.",
+			"> Derived from the in-repo source plus `acme-queue@4.1.0` where the lib is implicated.",
+		]);
+	});
+});
+
+describe("parseCatalog", () => {
+	it("reads the top-level catalog map, unquoting scoped keys", () => {
+		expect(
+			parseCatalog(`packages:
+  - packages/*
+
+catalog:
+  # a comment
+  'acme-queue': 4.2.0
+  "@nkzw/fate": 1.3.1
+
+onlyBuiltDependencies:
+  - x
+`),
+		).toEqual({_tag: "Ok", catalog: {"acme-queue": "4.2.0", "@nkzw/fate": "1.3.1"}});
+	});
+
+	// The degrade path, not a failure: a repo that pins nothing centrally is a fact about that repo.
+	it("answers a null catalog for a manifest that parses and carries none", () => {
+		expect(parseCatalog("packages:\n  - packages/*\n")).toEqual({_tag: "Ok", catalog: null});
+	});
+
+	// An unreadable manifest is UNKNOWN and never `unpinned` — a 404 is a verdict, a 5xx is a verdict
+	// about nothing.
+	it("refuses a manifest indented with a tab, which YAML forbids", () => {
+		expect(parseCatalog("catalog:\n\tacme-queue: 4.2.0\n")._tag).toBe("Unparseable");
+	});
+
+	it("refuses a catalog entry that is not a key/value pair", () => {
+		expect(parseCatalog("catalog:\n  - acme-queue\n")._tag).toBe("Unparseable");
+	});
+});
+
+describe("resolveDeclarations", () => {
+	it("compares byte for byte, with no semver interpretation", () => {
+		expect(declared("> Derived from `acme-queue@^4.2.0` — re-verify on pin bump.")).toEqual([
+			{package: "acme-queue", declaredVersion: "^4.2.0", pinnedVersion: "4.2.0", state: "moved"},
+		]);
+	});
+
+	it("matches an exact pin and reports an absent key as unpinned", () => {
+		expect(
+			declared(
+				"> Derived from `acme-queue@4.2.0` — re-verify on pin bump.",
+				"> Derived from `@acme/retry@2.0.0` — re-verify on pin bump.",
+			),
+		).toEqual([
+			{package: "acme-queue", declaredVersion: "4.2.0", pinnedVersion: "4.2.0", state: "matched"},
+			{package: "@acme/retry", declaredVersion: "2.0.0", pinnedVersion: null, state: "unpinned"},
+		]);
+	});
+
+	it("echoes a malformed line's text, clamped, with both version fields empty", () => {
+		const [only] = declared("> Derived from the in-repo source plus `acme-queue@4.1.0` where …");
+		expect(only).toMatchObject({state: "malformed", declaredVersion: null, pinnedVersion: null});
+		expect(only?.package).toBe("the in-repo source plus `acme-queue@4.1.0` where …");
+	});
+
+	it("reports every declaration unpinned against a repo that pins nothing centrally", () => {
+		expect(
+			resolveDeclarations(["> Derived from `acme-queue@4.2.0` — re-verify on pin bump."], null),
+		).toMatchObject([{state: "unpinned", pinnedVersion: null}]);
+	});
+});
+
+describe("anchorOutcome", () => {
+	const decl = (state: "matched" | "moved" | "unpinned" | "malformed") => ({
+		package: "p",
+		declaredVersion: "1",
+		pinnedVersion: null,
+		state,
+	});
+
+	it("follows the contract's precedence: moved, malformed, unpinned, matched", () => {
+		expect(anchorOutcome([decl("matched"), decl("moved"), decl("malformed")])).toBe("moved");
+		expect(anchorOutcome([decl("matched"), decl("malformed"), decl("unpinned")])).toBe("malformed");
+		expect(anchorOutcome([decl("matched"), decl("unpinned")])).toBe("unpinned");
+		expect(anchorOutcome([decl("matched")])).toBe("matched");
+	});
+
+	// `malformed` never folds into `unpinned`: one says the repo dropped the dependency, the other
+	// says the line is mistyped, and the remedies are opposite.
+	it("keeps malformed above unpinned rather than folding them", () => {
+		expect(anchorOutcome([decl("unpinned"), decl("malformed")])).toBe("malformed");
+	});
+
+	// `unanchored` fires only when the doc carries NO claiming line — not merely when none parsed.
+	it("is `unanchored` only for a doc that declares nothing at all", () => {
+		expect(anchorOutcome([])).toBe("unanchored");
+		expect(anchorOutcome([decl("malformed")])).not.toBe("unanchored");
+	});
+});

--- a/packages/fabrika-cli/src/pattern/codes.ts
+++ b/packages/fabrika-cli/src/pattern/codes.ts
@@ -1,0 +1,59 @@
+/**
+ * The one exit table all five `pattern` verbs allocate from, so a code means one thing across this
+ * group whichever verb produced it (`claude-plugins/fabrika/skills/write-pattern/contract.md`).
+ *
+ * **The overlap with the base is imported, never restated** — the discipline `../build/codes.ts`
+ * states in full: an aligning group imports the base's constant, so a drift is unrepresentable
+ * rather than merely detectable. The four seats come from `build` rather than from `report`
+ * directly because `build` re-exports the base's values unchanged and already carries
+ * `OFF_VOCABULARY`, which `report` seats as `CLASSIFIED`; the value is the base's either way.
+ *
+ * This group shares four seats over `8`-`11` and adds `12`-`16` for facts about a doc, an index and
+ * a one-row edit. `3`-`7` are deliberate gaps, each for a stated reason: no verb reads stdin (`3`),
+ * none validates a doc's heading grammar (`4`), the repo's leak gate is the authority over
+ * `.patterns/` (`5`), nothing composes a body from authored input (`6`) — and `7` `ZERO_SCOPE`
+ * stays unseated because no verb here judges over a corpus, so none has a vacuous pass to prevent.
+ * An empty or absent doc directory is a **fact** this group reports at exit `0`; refusing there
+ * would leave a repo adopting fabrika unable to write its first pattern doc (#5254).
+ *
+ * `0`, `1`, `2` and `127` are reserved by the interface convention (`../verb.ts`, `../bin.ts`).
+ */
+
+import {
+	OFF_VOCABULARY as BUILD_OFF_VOCABULARY,
+	PRECONDITION_UNKNOWN as BUILD_PRECONDITION_UNKNOWN,
+	READBACK_MISMATCH as BUILD_READBACK_MISMATCH,
+	WRITE_UNKNOWN as BUILD_WRITE_UNKNOWN,
+} from "../build/codes.ts";
+
+/** The write itself failed, so whether anything landed is UNKNOWN — deliberately not `1`. */
+export const WRITE_UNKNOWN = BUILD_WRITE_UNKNOWN;
+/** The write landed and the read-back does not match; the artifact exists and needs a human. */
+export const READBACK_MISMATCH = BUILD_READBACK_MISMATCH;
+/** A value is outside a closed set this group validates against — here, the index's section names. */
+export const OFF_VOCABULARY = BUILD_OFF_VOCABULARY;
+/** A precondition read failed, so nothing was written and no outcome is proven. */
+export const PRECONDITION_UNKNOWN = BUILD_PRECONDITION_UNKNOWN;
+
+/** Proven: the named slug has no doc file. */
+export const DOC_ABSENT = 12;
+/** Proven: the target path already exists — refused, never overwritten. */
+export const ALREADY_EXISTS = 13;
+/**
+ * The edit would have changed a line beyond the one row — aborted before writing.
+ *
+ * The load-bearing seat of the group. `.patterns/index.md` is hand-curated, carries prose between
+ * its tables, and is edited by lanes `pattern register` cannot see, so an insertion that reflowed a
+ * table or rewrote a neighbouring row would destroy work with no diff small enough to notice.
+ */
+export const MULTI_LINE_DIFF = 14;
+/** Proven: the index is absent, or holds no parseable table. */
+export const INDEX_UNPARSEABLE = 15;
+/**
+ * Proven: the named section matches more than one heading.
+ *
+ * Its own seat rather than {@link OFF_VOCABULARY}'s because the remedy differs: `10` says the flag
+ * names a section that is not there, and this says the flag is right and the index needs
+ * disambiguating.
+ */
+export const SECTION_AMBIGUOUS = 16;

--- a/packages/fabrika-cli/src/pattern/codes.unit.test.ts
+++ b/packages/fabrika-cli/src/pattern/codes.unit.test.ts
@@ -1,0 +1,69 @@
+import {fileURLToPath} from "node:url";
+import {describe, expect, it} from "vitest";
+import {allocatedCodes, verbLocalCodesIn} from "../exit-code-alignment.ts";
+import * as report from "../report/codes.ts";
+import * as codes from "./codes.ts";
+
+const GROUP_DIR = fileURLToPath(new URL(".", import.meta.url));
+
+describe("the `pattern` group allocates from one table", () => {
+	// `adr` shipped a `NO_SUBJECT` in two verb files on two numbers (#5294). An imported and a
+	// declared export are indistinguishable once a module is loaded, so this reads the source.
+	it("leaves no verb module seating a code of its own", () => {
+		expect(verbLocalCodesIn(GROUP_DIR)).toEqual([]);
+	});
+
+	it("finds codes at all, so no assertion below passes over an empty table (ADR 0092)", () => {
+		expect(allocatedCodes(codes).size).toBeGreaterThan(0);
+	});
+
+	it("seats one meaning on each number", () => {
+		expect([...allocatedCodes(codes)].filter(([, names]) => names.length > 1)).toEqual([]);
+	});
+
+	it("keeps every code in the band a verb owns for outcomes it proved", () => {
+		for (const code of allocatedCodes(codes).keys()) expect(code).toBeGreaterThanOrEqual(3);
+	});
+});
+
+/**
+ * The five gaps, each pinned to the reason it is a gap rather than an oversight — and `7` above all.
+ * No verb here judges over a corpus, so none has a vacuous pass to prevent: an empty or absent doc
+ * directory is a fact reported at exit `0`, and refusing there would leave a repo adopting fabrika
+ * unable to write its first pattern doc on the documented path (#5254).
+ */
+describe("the deliberate gaps stay gaps", () => {
+	it("seats nothing on 3 through 7", () => {
+		for (const code of [3, 4, 5, 6, 7]) expect(allocatedCodes(codes).has(code)).toBe(false);
+	});
+
+	it("in particular never seats 7, the zero-scope refusal", () => {
+		expect(Object.values(codes)).not.toContain(7);
+	});
+});
+
+/**
+ * The four shared seats, verified as **the base's own values** rather than as numerals. The import
+ * is what makes a drift unrepresentable; this asserts the claim the import is making.
+ */
+describe("the shared seats are the base's", () => {
+	it("carries the base's number for each meaning it shares", () => {
+		expect(codes.WRITE_UNKNOWN).toBe(report.WRITE_UNKNOWN);
+		expect(codes.READBACK_MISMATCH).toBe(report.READBACK_MISMATCH);
+		expect(codes.OFF_VOCABULARY).toBe(report.CLASSIFIED);
+		expect(codes.PRECONDITION_UNKNOWN).toBe(report.PRECONDITION_UNKNOWN);
+	});
+
+	it("clears the base's whole table with every code it adds on its own account", () => {
+		const occupied = allocatedCodes(report);
+		for (const code of [
+			codes.DOC_ABSENT,
+			codes.ALREADY_EXISTS,
+			codes.MULTI_LINE_DIFF,
+			codes.INDEX_UNPARSEABLE,
+			codes.SECTION_AMBIGUOUS,
+		]) {
+			expect(occupied.has(code)).toBe(false);
+		}
+	});
+});

--- a/packages/fabrika-cli/src/pattern/command.ts
+++ b/packages/fabrika-cli/src/pattern/command.ts
@@ -1,0 +1,167 @@
+/**
+ * The `pattern` verb group — `fabrika pattern <corpus|drift|anchor|new|register>`, the
+ * `write-pattern` skill's mechanical half.
+ *
+ * The adapter and nothing else: it declares the flags (`--help` is the interface, so every flag
+ * carries a one-line description), runs the pure verb, and emits its outcome. Every decision lives in
+ * the `*-verb.ts` modules beside it, which is what makes each refusal testable without spawning a
+ * process.
+ *
+ * **Every leaf is declared with `leafCommand`, never a bare `Command.make`** — the bare form silently
+ * opts out of the excess-operand guard, which `../excess-operand.unit.test.ts` reds on.
+ */
+
+import {Effect, Option} from "effect";
+import {Argument, Command, Flag} from "effect/unstable/cli";
+import {leafCommand} from "../excess-operand.ts";
+import type {VerbOutcome} from "../verb.ts";
+import {runAnchor} from "./anchor-verb.ts";
+import {runCorpus} from "./corpus-verb.ts";
+import {runDrift} from "./drift-verb.ts";
+import {runNew} from "./new-verb.ts";
+import {runRegister} from "./register-verb.ts";
+
+/** Write the outcome and exit on its code — stdout is the answer, everything else is stderr. */
+const emit = (outcome: VerbOutcome): Effect.Effect<void> =>
+	Effect.sync(() => {
+		for (const line of outcome.stderr) process.stderr.write(`${line}\n`);
+		if (outcome.stdout !== "") process.stdout.write(outcome.stdout);
+		process.exit(outcome.code);
+	});
+
+const dirFlag = Flag.string("dir").pipe(
+	Flag.withDefault(".patterns"),
+	Flag.withDescription("the directory of flat <slug>.md pattern docs (default: .patterns)"),
+);
+
+const baseFlag = Flag.string("base").pipe(
+	Flag.withDefault("origin/main"),
+	Flag.withDescription(
+		"the base ref the corpus is read at, fetched before it is read (default: origin/main)",
+	),
+);
+
+const jsonFlag = Flag.boolean("json").pipe(
+	Flag.withDescription("emit one JSON object on stdout instead of the line grammar"),
+);
+
+const slugArgument = Argument.string("slug").pipe(
+	Argument.withDescription("the doc's basename without .md, kebab-case"),
+);
+
+const corpus = leafCommand(
+	"corpus",
+	{dir: dirFlag, base: baseFlag, json: jsonFlag},
+	Effect.fn(function* ({dir, base, json}) {
+		yield* emit(yield* runCorpus({dir, base, json}));
+	}),
+).pipe(
+	Command.withDescription(
+		'The library at a base ref: every doc, its index registration, its section and its last-touching commit. Prints `corpus <library|none|absent> <docs> <unregistered> <unknown> <dangling>` then one `doc` line per doc and one `dangling` line per index row pointing outside the corpus — all three outcomes at exit 0, because an empty or absent library is a fact a repo adopting fabrika must be able to act on. Exits 11 (the base could not be fetched, or a tree or history read failed — UNKNOWN, never "none"). Example: fabrika pattern corpus --dir .patterns',
+	),
+);
+
+const drift = leafCommand(
+	"drift",
+	{slug: slugArgument, dir: dirFlag, base: baseFlag, json: jsonFlag},
+	Effect.fn(function* ({slug, dir, base, json}) {
+		yield* emit(yield* runDrift({slug, dir, base, json}));
+	}),
+).pipe(
+	Command.withDescription(
+		'Whether the in-repo source a doc cites moved since the doc was last written. Prints `drift <drifted|current|unanchored|unborn> <anchor-sha> <cited> <in-repo> <unresolved> <moved>` then one `path` line per moved path — all four outcomes at exit 0. `unanchored` is not a clearance: it says the doc cites nothing this verb can follow. Exits 11 (a fetch, tree or history read failed — UNKNOWN, never "current"), 12 (no doc for the slug, in the working tree or at the base). Example: fabrika pattern drift worker-queue-retry',
+	),
+);
+
+const anchor = leafCommand(
+	"anchor",
+	{
+		slug: slugArgument,
+		dir: dirFlag,
+		manifest: Flag.string("manifest").pipe(
+			Flag.withDefault("pnpm-workspace.yaml"),
+			Flag.withDescription(
+				"the workspace manifest whose catalog: map holds the live pins (default: pnpm-workspace.yaml)",
+			),
+		),
+		base: baseFlag,
+		json: jsonFlag,
+	},
+	Effect.fn(function* ({slug, dir, manifest, base, json}) {
+		yield* emit(yield* runAnchor({slug, dir, manifest, base, json}));
+	}),
+).pipe(
+	Command.withDescription(
+		'Whether the dependency version a doc declares still matches what the workspace pins, compared byte for byte with no semver interpretation. Prints `anchor <matched|moved|malformed|unpinned|unanchored|unborn> <declared> <moved> <unpinned> <malformed>` then one `pkg` line per declaration — every outcome at exit 0. A line that claims an anchor and does not parse is `malformed`, never absent. Exits 11 (the base could not be fetched, or the doc or manifest could not be read — every pin is UNKNOWN, never "unpinned"), 12 (no doc for the slug). Example: fabrika pattern anchor worker-queue-retry',
+	),
+);
+
+const create = leafCommand(
+	"new",
+	{
+		slug: slugArgument,
+		dir: dirFlag,
+		title: Flag.string("title").pipe(
+			Flag.optional,
+			Flag.withDescription(
+				"the H1 text (default: the slug with hyphens as spaces and the first character upper-cased)",
+			),
+		),
+		anchor: Flag.string("anchor").pipe(
+			Flag.optional,
+			Flag.withDescription(
+				"a <pkg>@<version> this doc is derived from; adds the anchor line pattern anchor reads",
+			),
+		),
+		json: jsonFlag,
+	},
+	Effect.fn(function* ({slug, dir, title, anchor: anchorToken, json}) {
+		yield* emit(
+			yield* runNew({
+				slug,
+				dir,
+				title: Option.getOrNull(title),
+				anchor: Option.getOrNull(anchorToken),
+				json,
+			}),
+		);
+	}),
+).pipe(
+	Command.withDescription(
+		"Scaffold <dir>/<slug>.md from the canonical template, creating <dir> when it is absent. Prints the path written. Writes exactly one file and never edits another — the index row is pattern register's. Exits 8 (the write failed, so whether anything landed is UNKNOWN), 13 (the target already exists — refused, never overwritten). Example: fabrika pattern new worker-queue-retry --anchor acme-queue@4.2.0",
+	),
+);
+
+const register = leafCommand(
+	"register",
+	{
+		slug: slugArgument,
+		section: Flag.string("section").pipe(
+			Flag.withDescription(
+				"the exact heading text, without leading #, of the index section the row goes under",
+			),
+		),
+		topic: Flag.string("topic").pipe(
+			Flag.withDescription("the row's second cell: what the doc covers"),
+		),
+		readWhen: Flag.string("read-when").pipe(
+			Flag.withDescription("the row's third cell: when a reader should open it"),
+		),
+		dir: dirFlag,
+		json: jsonFlag,
+	},
+	Effect.fn(function* ({slug, section, topic, readWhen, dir, json}) {
+		yield* emit(yield* runRegister({slug, section, topic, readWhen, dir, json}));
+	}),
+).pipe(
+	Command.withDescription(
+		'Insert the doc\'s row into <dir>/index.md under a named section, proving the edit changed no other line before it writes and reading the row back after. Prints `<inserted|already> <path> <section>`. Exits 8/9 (the write failed, the read-back does not carry the row), 10 (no such section — every section carrying a table is named), 12 (no doc to point the row at), 14 (the edit would have changed a line beyond the new row), 15 (the index is absent or holds no parseable table), 16 (the section name matches more than one heading). Example: fabrika pattern register worker-queue-retry --section "Index — Effect domain layer" --topic "Retry and backoff" --read-when "Adding a queue consumer"',
+	),
+);
+
+export const patternCommand = Command.make("pattern").pipe(
+	Command.withSubcommands([corpus, drift, anchor, create, register]),
+	Command.withDescription(
+		"Read and write the pattern library: the corpus at a base ref, whether a doc's cited source or declared dependency pin moved, and the two writes that scaffold a doc and register its row",
+	),
+);

--- a/packages/fabrika-cli/src/pattern/corpus-verb.ts
+++ b/packages/fabrika-cli/src/pattern/corpus-verb.ts
@@ -1,0 +1,171 @@
+/**
+ * `pattern corpus` — the library at a base ref: every doc, its registration, its section and its
+ * last-touching commit.
+ *
+ * **Zero scope is an answer here, and the presence probe is what makes that safe.** The directory is
+ * proven present by a pathspec read that exits `0` either way, so an empty listing is a directory
+ * that exists and holds nothing rather than a directory nobody could find — precisely the
+ * distinction `decisions-index next` does not make when it computes `max + 1` over an empty entry
+ * set and hands a mis-rooted checkout `0001`.
+ */
+import {Effect} from "effect";
+import {fetchAndResolve, listDir, readFileAt, type Shell} from "../io/git.ts";
+import {answer, refuse, type VerbOutcome} from "../verb.ts";
+import {PRECONDITION_UNKNOWN} from "./codes.ts";
+import {type CorpusMember, type CorpusReading, readCorpus} from "./corpus.ts";
+import {lastCommitTouching, pathPresentAt} from "./git.ts";
+import {type ParsedIndex, parseIndex} from "./index-table.ts";
+
+export interface CorpusOptions {
+	readonly dir: string;
+	readonly base: string;
+	readonly json: boolean;
+}
+
+interface Entry extends CorpusMember {
+	readonly lastSha: string;
+	readonly lastDate: string;
+}
+
+const empty = (
+	options: CorpusOptions,
+	reading: CorpusReading,
+	sha: string,
+	extra: ReadonlyArray<string>,
+): VerbOutcome =>
+	answer(
+		options.json
+			? JSON.stringify({
+					outcome: reading.outcome,
+					docs: 0,
+					unregistered: 0,
+					unknown: 0,
+					dangling: 0,
+					entries: [],
+					danglingRows: [],
+					baseRef: options.base,
+					baseSha: sha,
+				})
+			: ["corpus", reading.outcome, 0, 0, 0, 0].join("\t"),
+		extra,
+	);
+
+export const runCorpus = (options: CorpusOptions): Shell<VerbOutcome> =>
+	Effect.gen(function* () {
+		const {dir, base, json} = options;
+
+		const resolved = yield* fetchAndResolve(base);
+		if (resolved._tag === "Failure") {
+			return refuse(
+				PRECONDITION_UNKNOWN,
+				`pattern corpus: cannot fetch ${base}: ${resolved.reason} — the corpus is UNKNOWN, never "none".`,
+			);
+		}
+		const sha = resolved.value;
+		const unreadable = (path: string, reason: string) =>
+			refuse(
+				PRECONDITION_UNKNOWN,
+				`pattern corpus: cannot read ${path} at ${base}: ${reason} — UNKNOWN, never "absent".`,
+			);
+
+		const present = yield* pathPresentAt(sha, dir);
+		if (present._tag === "Failure") return unreadable(dir, present.reason);
+		if (!present.value) {
+			const reading = readCorpus({present: false, names: [], index: null});
+			return empty(options, reading, sha, [
+				`pattern corpus: ${dir} is not in the tree at ${sha} — this repository has no pattern library yet.`,
+			]);
+		}
+
+		const listed = yield* listDir(sha, dir);
+		if (listed._tag === "Failure") return unreadable(dir, listed.reason);
+
+		const indexPath = `${dir}/index.md`;
+		let index: ParsedIndex | null = null;
+		let indexNote: string | null = null;
+		if (listed.value.includes("index.md")) {
+			const text = yield* readFileAt(sha, indexPath);
+			if (text._tag === "Failure") return unreadable(indexPath, text.reason);
+			const parsed = parseIndex(text.value);
+			if (parsed.hasTable) index = parsed;
+			else indexNote = `${indexPath} holds no markdown table`;
+		} else {
+			indexNote = `${indexPath} is absent at ${sha}`;
+		}
+
+		const reading = readCorpus({present: true, names: listed.value, index});
+		if (reading.outcome === "none") {
+			return empty(options, reading, sha, [
+				`pattern corpus: ${dir} at ${sha} holds no pattern doc — the library exists and is empty.`,
+			]);
+		}
+
+		const entries: Entry[] = [];
+		for (const member of reading.members) {
+			const path = `${dir}/${member.slug}.md`;
+			const last = yield* lastCommitTouching(sha, path);
+			if (last._tag === "Failure") {
+				return refuse(
+					PRECONDITION_UNKNOWN,
+					`pattern corpus: cannot read the history of ${path}: ${last.reason} — UNKNOWN, never a missing commit.`,
+				);
+			}
+			if (last.value === null) {
+				return refuse(
+					PRECONDITION_UNKNOWN,
+					`pattern corpus: cannot read the history of ${path}: no commit touches it at or before ${sha} — UNKNOWN, never a missing commit.`,
+				);
+			}
+			entries.push({...member, lastSha: last.value.sha, lastDate: last.value.date});
+		}
+
+		const scope = [
+			`pattern corpus: scanned ${dir} at ${sha}; ${entries.length} doc(s), ${reading.unregistered} unregistered, ${reading.unknown} unknown, ${reading.dangling.length} dangling index row(s).`,
+			...(indexNote === null
+				? []
+				: [
+						`pattern corpus: ${indexNote} — every doc's registration is reported "unknown" rather than "unregistered", which this run did not prove.`,
+					]),
+		];
+
+		if (json) {
+			return answer(
+				JSON.stringify({
+					outcome: reading.outcome,
+					docs: entries.length,
+					unregistered: reading.unregistered,
+					unknown: reading.unknown,
+					dangling: reading.dangling.length,
+					entries: entries.map((e) => ({
+						slug: e.slug,
+						registration: e.registration,
+						section: e.section,
+						lastSha: e.lastSha,
+						lastDate: e.lastDate,
+					})),
+					danglingRows: reading.dangling.map((d) => ({target: d.target, section: d.section})),
+					baseRef: base,
+					baseSha: sha,
+				}),
+				scope,
+			);
+		}
+
+		return answer(
+			[
+				[
+					"corpus",
+					reading.outcome,
+					entries.length,
+					reading.unregistered,
+					reading.unknown,
+					reading.dangling.length,
+				].join("\t"),
+				...entries.map((e) =>
+					["doc", e.slug, e.registration, e.section, e.lastSha, e.lastDate].join("\t"),
+				),
+				...reading.dangling.map((d) => ["dangling", d.target, d.section].join("\t")),
+			].join("\n"),
+			scope,
+		);
+	});

--- a/packages/fabrika-cli/src/pattern/corpus-verb.unit.test.ts
+++ b/packages/fabrika-cli/src/pattern/corpus-verb.unit.test.ts
@@ -1,0 +1,142 @@
+import {Effect} from "effect";
+import {describe, expect, it} from "vitest";
+import {errOut, fakeShell, okOut, tree} from "../fakes.test-support.ts";
+import {PRECONDITION_UNKNOWN} from "./codes.ts";
+import {runCorpus} from "./corpus-verb.ts";
+import {FIXTURES} from "./fixtures.test-support.ts";
+
+const SHA = "49a22902d1e0c7b3f5a8e4126b9d0f3c7a1e5b82";
+const DOC_SHA = "c18bd103ce24cda98aed690cbbec2669f46f98f8";
+
+const INDEX = `# Patterns
+
+## Index — services
+
+| Doc | Topic | Read when |
+|---|---|---|
+| [registered.md](./registered.md) | x | y |
+| [gone.md](./gone.md) | x | y |
+`;
+
+type Script = ReadonlyArray<readonly [RegExp, ReturnType<typeof okOut>]>;
+
+const base = (overrides: Script = [], dir = ".patterns") =>
+	fakeShell([
+		...overrides,
+		[/^git remote$/, okOut("origin\n")],
+		[/^git fetch/, okOut("")],
+		[/^git rev-parse/, okOut(`${SHA}\n`)],
+		[/^git ls-tree --name-only \w+ --/, okOut(`${dir}\n`)],
+		[/^git ls-tree --name-only \w+:/, okOut(tree("index.md", "registered.md", "orphan.md"))],
+		[/^git show \w+:.*index\.md$/, okOut(INDEX)],
+		[/^git log -1/, okOut(`${DOC_SHA}\t2026-08-09\n`)],
+	]);
+
+const options = {dir: ".patterns", base: "origin/main", json: false};
+
+const run = (overrides: Script = [], opts: Partial<typeof options> = {}) =>
+	Effect.runPromise(
+		Effect.provide(
+			runCorpus({...options, ...opts}),
+			base(overrides, opts.dir ?? options.dir).layer,
+		),
+	);
+
+describe("runCorpus", () => {
+	it("emits the header, then a doc line per doc, then a dangling line per orphaned row", async () => {
+		const out = await run();
+		expect(out.code).toBe(0);
+		expect(out.stdout).toBe(
+			[
+				"corpus\tlibrary\t2\t1\t0\t1",
+				`doc\torphan\tunregistered\t-\t${DOC_SHA}\t2026-08-09`,
+				`doc\tregistered\tregistered\tIndex — services\t${DOC_SHA}\t2026-08-09`,
+				"dangling\t./gone.md\tIndex — services",
+				"",
+			].join("\n"),
+		);
+	});
+
+	// The contract's first worked example, byte for byte.
+	it("answers `none` at exit 0 for a library that exists and is empty", async () => {
+		const out = await run([[/^git ls-tree --name-only \w+:/, okOut(tree("index.md"))]], {
+			dir: `${FIXTURES}/empty-library`,
+		});
+		expect(out.code).toBe(0);
+		expect(out.stdout).toBe("corpus\tnone\t0\t0\t0\t0\n");
+	});
+
+	// The contract's second worked example. `no-library` is deliberately not a committed directory —
+	// it is the absent path, and a fixture that existed could not demonstrate this outcome.
+	it("answers `absent` at exit 0 when --dir is not in the tree", async () => {
+		const out = await run([[/^git ls-tree --name-only \w+ --/, okOut("")]], {
+			dir: `${FIXTURES}/no-library`,
+		});
+		expect(out.code).toBe(0);
+		expect(out.stdout).toBe("corpus\tabsent\t0\t0\t0\t0\n");
+	});
+
+	// The contract's third worked example.
+	it("carries the same empty answer through --json", async () => {
+		const out = await run([[/^git ls-tree --name-only \w+:/, okOut(tree("index.md"))]], {
+			dir: `${FIXTURES}/empty-library`,
+			json: true,
+		});
+		expect(out.stdout).toBe(
+			`{"outcome":"none","docs":0,"unregistered":0,"unknown":0,"dangling":0,"entries":[],"danglingRows":[],"baseRef":"origin/main","baseSha":"${SHA}"}\n`,
+		);
+	});
+
+	// An unreadable directory and an absent one take opposite branches, so they may never fuse.
+	it("refuses an unfetchable base — the corpus is UNKNOWN, never `none`", async () => {
+		const out = await run([[/^git fetch/, errOut("fatal: couldn't find remote ref nope")]]);
+		expect(out.code).toBe(PRECONDITION_UNKNOWN);
+		expect(out.stdout).toBe("");
+		expect(out.stderr.at(-1)).toBe(
+			'pattern corpus: cannot fetch origin/main: fatal: couldn\'t find remote ref nope — the corpus is UNKNOWN, never "none".',
+		);
+	});
+
+	it("refuses a tree read that FAILED, and never reads that as `absent`", async () => {
+		const out = await run([
+			[/^git ls-tree --name-only \w+ --/, errOut("fatal: not a tree object")],
+		]);
+		expect(out.code).toBe(PRECONDITION_UNKNOWN);
+		expect(out.stdout).toBe("");
+		expect(out.stderr.at(-1)).toContain('UNKNOWN, never "absent"');
+	});
+
+	it("refuses a history read it could not perform, never a missing commit", async () => {
+		const out = await run([[/^git log -1/, errOut("fatal: bad revision")]]);
+		expect(out.code).toBe(PRECONDITION_UNKNOWN);
+		expect(out.stdout).toBe("");
+		expect(out.stderr.at(-1)).toContain("UNKNOWN, never a missing commit");
+	});
+
+	// Rendering an unknowable registration as `unregistered` would report a defect this verb never
+	// proved, and send a caller to add rows to a file that cannot hold them.
+	it("reports every registration `unknown` when the index holds no table, with a note on stderr", async () => {
+		const out = await run([[/^git show \w+:.*index\.md$/, okOut("# Patterns\n\nNothing yet.\n")]]);
+		expect(out.code).toBe(0);
+		expect(out.stdout).toContain(`doc\torphan\tunknown\t-\t${DOC_SHA}`);
+		expect(out.stdout.split("\n")[0]).toBe("corpus\tlibrary\t2\t0\t2\t0");
+		expect(out.stderr.join("\n")).toContain('"unknown" rather than "unregistered"');
+	});
+
+	it("reports the same when the index is absent altogether", async () => {
+		const out = await run([
+			[/^git ls-tree --name-only \w+:/, okOut(tree("registered.md", "orphan.md"))],
+		]);
+		expect(out.code).toBe(0);
+		expect(out.stdout.split("\n")[0]).toBe("corpus\tlibrary\t2\t0\t2\t0");
+	});
+
+	it("fetches the base BEFORE it reads the tree", async () => {
+		const shell = base();
+		await Effect.runPromise(Effect.provide(runCorpus(options), shell.layer));
+		const fetched = shell.calls.findIndex((c) => c.startsWith("git fetch"));
+		const listed = shell.calls.findIndex((c) => c.startsWith("git ls-tree"));
+		expect(fetched).toBeGreaterThanOrEqual(0);
+		expect(fetched).toBeLessThan(listed);
+	});
+});

--- a/packages/fabrika-cli/src/pattern/corpus.ts
+++ b/packages/fabrika-cli/src/pattern/corpus.ts
@@ -1,0 +1,112 @@
+/**
+ * The corpus as a fact about a tree: which docs are there, how each is registered, and which index
+ * rows point at nothing this directory holds.
+ *
+ * **Registration is three-valued, and the third value is what keeps a false negative out.**
+ * `unknown` means registration could not be determined at all — the index is absent, or holds no
+ * markdown table. Rendering that as `unregistered` would report a defect this verb never proved, and
+ * would send a caller to add rows to a file that cannot hold them.
+ */
+import type {ParsedIndex} from "./index-table.ts";
+
+export type Registration = "registered" | "unregistered" | "unknown";
+
+/**
+ * `absent` — the directory is not in the tree. `none` — it is, and holds no doc. `library` — it
+ * holds at least one. All three are facts at exit `0`: the two empty ones are the adopting-repo
+ * case, and refusing there would leave a repo unable to write its first pattern doc.
+ */
+export type CorpusOutcome = "library" | "none" | "absent";
+
+/** One doc, before its history is read. */
+export interface CorpusMember {
+	readonly slug: string;
+	readonly registration: Registration;
+	/** The exact heading its row sits under, or `-` when the registration is not `registered`. */
+	readonly section: string;
+}
+
+/** An index row whose first cell links a target that is not a doc in the directory. */
+export interface DanglingRow {
+	readonly target: string;
+	readonly section: string;
+}
+
+/**
+ * The doc slugs among a directory listing, sorted ascending byte-wise.
+ *
+ * `index.md` is the registry rather than a member of the corpus, so it is excluded — v1's
+ * `list-pattern-docs.sh` listed it as a pattern doc.
+ */
+export const docSlugs = (names: ReadonlyArray<string>): ReadonlyArray<string> =>
+	names
+		.filter((n) => n.endsWith(".md") && n !== "index.md")
+		.map((n) => n.slice(0, -".md".length))
+		.sort();
+
+export interface CorpusReading {
+	readonly outcome: CorpusOutcome;
+	readonly members: ReadonlyArray<CorpusMember>;
+	readonly dangling: ReadonlyArray<DanglingRow>;
+	readonly unregistered: number;
+	readonly unknown: number;
+}
+
+/**
+ * Fold the directory listing and the index into the corpus reading.
+ *
+ * `index` is `null` when the index is absent or holds no parseable table — the `unknown` case. It
+ * yields **no** dangling rows for the same reason it yields no registrations: nothing was parsed, so
+ * nothing was proven either way.
+ */
+export const readCorpus = (input: {
+	readonly present: boolean;
+	readonly names: ReadonlyArray<string>;
+	readonly index: ParsedIndex | null;
+}): CorpusReading => {
+	if (!input.present) {
+		return {outcome: "absent", members: [], dangling: [], unregistered: 0, unknown: 0};
+	}
+	const slugs = docSlugs(input.names);
+	if (slugs.length === 0) {
+		return {outcome: "none", members: [], dangling: [], unregistered: 0, unknown: 0};
+	}
+
+	const {index} = input;
+	if (index === null) {
+		return {
+			outcome: "library",
+			members: slugs.map((slug) => ({slug, registration: "unknown" as const, section: "-"})),
+			dangling: [],
+			unregistered: 0,
+			unknown: slugs.length,
+		};
+	}
+
+	const docNames = new Set(slugs.map((slug) => `${slug}.md`));
+	const sectionOf = new Map<string, string>();
+	for (const row of index.rows) {
+		if (row.member !== null && docNames.has(row.member) && !sectionOf.has(row.member)) {
+			sectionOf.set(row.member, row.section);
+		}
+	}
+
+	const members = slugs.map((slug): CorpusMember => {
+		const section = sectionOf.get(`${slug}.md`);
+		return section === undefined
+			? {slug, registration: "unregistered", section: "-"}
+			: {slug, registration: "registered", section};
+	});
+
+	const dangling = index.rows
+		.filter((row) => row.target !== null && (row.member === null || !docNames.has(row.member)))
+		.map((row): DanglingRow => ({target: row.target ?? "", section: row.section}));
+
+	return {
+		outcome: "library",
+		members,
+		dangling,
+		unregistered: members.filter((m) => m.registration === "unregistered").length,
+		unknown: 0,
+	};
+};

--- a/packages/fabrika-cli/src/pattern/corpus.unit.test.ts
+++ b/packages/fabrika-cli/src/pattern/corpus.unit.test.ts
@@ -1,0 +1,72 @@
+import {describe, expect, it} from "vitest";
+import {docSlugs, readCorpus} from "./corpus.ts";
+import {parseIndex} from "./index-table.ts";
+
+const INDEX = `# Patterns
+
+## Index — services
+
+| Doc | Topic | Read when |
+|---|---|---|
+| [registered.md](./registered.md) | x | y |
+| [gone.md](./gone.md) | x | y |
+| [../.decisions/0001-a.md](../.decisions/0001-a.md) | x | y |
+`;
+
+describe("docSlugs", () => {
+	// v1's `list-pattern-docs.sh` listed `index.md` as a pattern doc. It is the registry, not a member.
+	it("excludes index.md and sorts ascending", () => {
+		expect(docSlugs(["b.md", "index.md", "a.md", "notes.txt"])).toEqual(["a", "b"]);
+	});
+});
+
+describe("readCorpus", () => {
+	it("answers `absent` with no docs when the directory is not in the tree", () => {
+		expect(readCorpus({present: false, names: [], index: null})).toMatchObject({
+			outcome: "absent",
+			members: [],
+		});
+	});
+
+	it("answers `none` for a directory holding only its index", () => {
+		expect(readCorpus({present: true, names: ["index.md"], index: null})).toMatchObject({
+			outcome: "none",
+			members: [],
+		});
+	});
+
+	// `unknown` is the third value, and it is what keeps a false negative out: rendering an
+	// unknowable registration as `unregistered` would report a defect this verb never proved.
+	it("reports every registration `unknown` when the index parsed to no table", () => {
+		const reading = readCorpus({present: true, names: ["a.md", "b.md"], index: null});
+		expect(reading.members.map((m) => m.registration)).toEqual(["unknown", "unknown"]);
+		expect(reading.unknown).toBe(2);
+		expect(reading.unregistered).toBe(0);
+		expect(reading.dangling).toEqual([]);
+	});
+
+	it("splits registered from unregistered and carries the registered doc's section", () => {
+		const reading = readCorpus({
+			present: true,
+			names: ["registered.md", "orphan.md", "index.md"],
+			index: parseIndex(INDEX),
+		});
+		expect(reading.members).toEqual([
+			{slug: "orphan", registration: "unregistered", section: "-"},
+			{slug: "registered", registration: "registered", section: "Index — services"},
+		]);
+		expect(reading.unregistered).toBe(1);
+	});
+
+	it("reports a row pointing outside the corpus as dangling, in document order", () => {
+		const reading = readCorpus({
+			present: true,
+			names: ["registered.md"],
+			index: parseIndex(INDEX),
+		});
+		expect(reading.dangling).toEqual([
+			{target: "./gone.md", section: "Index — services"},
+			{target: "../.decisions/0001-a.md", section: "Index — services"},
+		]);
+	});
+});

--- a/packages/fabrika-cli/src/pattern/doc.ts
+++ b/packages/fabrika-cli/src/pattern/doc.ts
@@ -1,0 +1,72 @@
+/**
+ * The doc-level primitives three verbs share: the slug rule, the title derivation, the canonical
+ * template `pattern new` writes, and the anchor line `pattern anchor` reads.
+ *
+ * The anchor line's bytes live here **once**, so the writer and the reader of that line cannot
+ * disagree: {@link anchorLine} composes it and {@link ANCHOR_DECLARATION} parses it, and
+ * {@link splitAnchorToken} is the one split rule both `--anchor` validation and the read apply.
+ */
+
+/** A slug is lowercase letters, digits and single hyphens — no leading, trailing or doubled hyphen. */
+export const isKebabCase = (slug: string): boolean => /^[a-z0-9]+(-[a-z0-9]+)*$/.test(slug);
+
+/**
+ * The H1 text a bare slug derives: hyphens become spaces, the first character upper-cases.
+ *
+ * No acronym or digit special-casing. A doc wanting `Fate (Effect) server` passes `--title`; a
+ * derivation that guessed at capitalisation would be wrong in a way no caller could predict.
+ */
+export const titleFrom = (slug: string): string =>
+	slug.replace(/-/g, " ").replace(/^./, (c) => c.toUpperCase());
+
+/**
+ * A `<pkg>@<version>` split at its **LAST** `@`, or `null`.
+ *
+ * The last rather than the first is what makes a scoped package work: `@nkzw/fate@1.3.1` yields
+ * `@nkzw/fate` and `1.3.1`, where a first-`@` split would yield an empty package name.
+ */
+export const splitAnchorToken = (
+	token: string,
+): {readonly pkg: string; readonly version: string} | null => {
+	const at = token.lastIndexOf("@");
+	if (at <= 0) return null;
+	const pkg = token.slice(0, at);
+	const version = token.slice(at + 1);
+	return pkg === "" || version === "" ? null : {pkg, version};
+};
+
+/** The strict grammar of an anchor declaration. The em-dash is literal. */
+export const ANCHOR_DECLARATION = /^> Derived from `([^`]+)` — re-verify on pin bump\.$/;
+
+/** The prefix a line opens with to *claim* an anchor, whether or not it then parses. */
+export const ANCHOR_PREFIX = "> Derived from ";
+
+/** The one composition of the anchor line, so the template and the parser share its bytes. */
+export const anchorLine = (token: string): string =>
+	`${ANCHOR_PREFIX}\`${token}\` — re-verify on pin bump.`;
+
+const TEMPLATE_BODY = `<One sentence: what shape this describes, and where in the tree it applies.>
+
+## The shape
+
+<The pattern itself, with a fenced example lifted from a test or a real call site.>
+
+## When this applies
+
+<The two or more places it is used, by path, and the boundary where it stops applying.>
+
+## Why it is not obvious
+
+<What a reader would otherwise invent, and why that version is worse.>
+`;
+
+/**
+ * The canonical pattern doc, ready to write.
+ *
+ * The three body headings mirror the admission bar the skill applies — used in 2+ places,
+ * non-obvious, a future agent would invent worse — so a doc that cannot fill them is a doc that did
+ * not clear the bar. It is a **starting shape and not a validated grammar**: nothing here or at any
+ * gate checks a pattern doc's headings, which is why `4` is a deliberate gap in `codes.ts`.
+ */
+export const docTemplate = (title: string, anchorToken: string | null): string =>
+	`# ${title}\n\n${TEMPLATE_BODY}${anchorToken === null ? "" : `\n${anchorLine(anchorToken)}\n`}`;

--- a/packages/fabrika-cli/src/pattern/doc.unit.test.ts
+++ b/packages/fabrika-cli/src/pattern/doc.unit.test.ts
@@ -1,0 +1,75 @@
+import {describe, expect, it} from "vitest";
+import {
+	ANCHOR_DECLARATION,
+	anchorLine,
+	docTemplate,
+	isKebabCase,
+	splitAnchorToken,
+	titleFrom,
+} from "./doc.ts";
+
+describe("isKebabCase", () => {
+	it("admits lowercase letters, digits and single hyphens", () => {
+		for (const slug of ["worker-queue-retry", "fate", "d1-batch-2"]) {
+			expect(isKebabCase(slug)).toBe(true);
+		}
+	});
+
+	it("refuses upper case, doubled hyphens and edge hyphens", () => {
+		for (const slug of ["Worker-Queue", "a--b", "-a", "a-", "a_b", "a b", ""]) {
+			expect(isKebabCase(slug)).toBe(false);
+		}
+	});
+});
+
+describe("titleFrom", () => {
+	it("upper-cases only the first character and special-cases nothing else", () => {
+		expect(titleFrom("worker-queue-retry")).toBe("Worker queue retry");
+		expect(titleFrom("fate-effect-server")).toBe("Fate effect server");
+		expect(titleFrom("d1-batch")).toBe("D1 batch");
+	});
+});
+
+describe("splitAnchorToken", () => {
+	// Splitting at the LAST `@` is what makes a scoped package work; a first-`@` split yields an
+	// empty package name and would make every scoped anchor malformed.
+	it("splits a scoped package at its last @", () => {
+		expect(splitAnchorToken("@nkzw/fate@1.3.1")).toEqual({pkg: "@nkzw/fate", version: "1.3.1"});
+	});
+
+	it("splits an unscoped package", () => {
+		expect(splitAnchorToken("acme-queue@4.2.0")).toEqual({pkg: "acme-queue", version: "4.2.0"});
+	});
+
+	it("refuses a token with no @, or with an empty half", () => {
+		for (const token of ["acme-queue", "@scope/only", "acme-queue@", ""]) {
+			expect(splitAnchorToken(token)).toBeNull();
+		}
+	});
+});
+
+describe("the anchor line is composed and parsed from one home", () => {
+	it("round-trips every token the writer accepts", () => {
+		for (const token of ["acme-queue@4.2.0", "@nkzw/fate@1.3.1"]) {
+			expect(ANCHOR_DECLARATION.exec(anchorLine(token))?.[1]).toBe(token);
+		}
+	});
+});
+
+describe("docTemplate", () => {
+	it("writes the four headings and nothing else without --anchor", () => {
+		const text = docTemplate("Worker queue retry", null);
+		expect(text.startsWith("# Worker queue retry\n\n")).toBe(true);
+		expect(text).toContain("## The shape");
+		expect(text).toContain("## When this applies");
+		expect(text).toContain("## Why it is not obvious");
+		expect(text).not.toContain("Derived from");
+	});
+
+	it("appends the anchor line in the exact bytes pattern anchor parses", () => {
+		const text = docTemplate("Worker queue retry", "acme-queue@4.2.0");
+		const line = text.trimEnd().split("\n").at(-1) ?? "";
+		expect(line).toBe("> Derived from `acme-queue@4.2.0` — re-verify on pin bump.");
+		expect(ANCHOR_DECLARATION.test(line)).toBe(true);
+	});
+});

--- a/packages/fabrika-cli/src/pattern/drift-verb.ts
+++ b/packages/fabrika-cli/src/pattern/drift-verb.ts
@@ -1,0 +1,203 @@
+/**
+ * `pattern drift` — whether the in-repo source a doc cites moved since the doc was last written.
+ *
+ * The paths are derived from the doc and **resolved before they are used**, so a pathspec that
+ * matches nothing can never read as a clean answer: a doc whose paths all fail to resolve lands on
+ * `unanchored`. v1's script took its source directories as caller-supplied arguments and ran
+ * `git diff --name-status <last>..HEAD -- "$@"`, which exits `0` with empty output both when nothing
+ * changed and when the pathspec matched nothing — so a typo read as "nothing drifted", over a path
+ * set the doc was never consulted about.
+ */
+import {Effect, type FileSystem, Result} from "effect";
+import type {ChildProcessSpawner} from "effect/unstable/process";
+import {exists} from "../io/fs.ts";
+import {fetchAndResolve, readFileAt} from "../io/git.ts";
+import {answer, FAILED, refuse, type VerbOutcome} from "../verb.ts";
+import {DOC_ABSENT, PRECONDITION_UNKNOWN} from "./codes.ts";
+import {isKebabCase} from "./doc.ts";
+import {candidateTokens, type DriftOutcome, driftOutcome, isRepoPath} from "./drift.ts";
+import {
+	type Commit,
+	commitsTouchingRange,
+	lastCommitTouching,
+	pathPresentAt,
+	presentPathsAt,
+	topLevelEntriesAt,
+} from "./git.ts";
+
+export interface DriftOptions {
+	readonly slug: string;
+	readonly dir: string;
+	readonly base: string;
+	readonly json: boolean;
+}
+
+interface MovedPath {
+	readonly path: string;
+	readonly commits: number;
+	readonly lastSha: string;
+	readonly lastDate: string;
+}
+
+interface Reading {
+	readonly outcome: DriftOutcome;
+	readonly anchorSha: string;
+	readonly cited: number;
+	readonly inRepo: number;
+	readonly unresolved: ReadonlyArray<string>;
+	readonly paths: ReadonlyArray<MovedPath>;
+}
+
+const emit = (options: DriftOptions, reading: Reading, sha: string): string =>
+	options.json
+		? JSON.stringify({
+				outcome: reading.outcome,
+				anchorSha: reading.anchorSha,
+				cited: reading.cited,
+				inRepo: reading.inRepo,
+				unresolved: reading.unresolved.length,
+				moved: reading.paths.length,
+				paths: reading.paths,
+				unresolvedPaths: reading.unresolved,
+				baseRef: options.base,
+				baseSha: sha,
+			})
+		: [
+				[
+					"drift",
+					reading.outcome,
+					reading.anchorSha,
+					reading.cited,
+					reading.inRepo,
+					reading.unresolved.length,
+					reading.paths.length,
+				].join("\t"),
+				...reading.paths.map((p) => ["path", p.path, p.commits, p.lastSha, p.lastDate].join("\t")),
+			].join("\n");
+
+export const runDrift = (
+	options: DriftOptions,
+): Effect.Effect<
+	VerbOutcome,
+	never,
+	FileSystem.FileSystem | ChildProcessSpawner.ChildProcessSpawner
+> =>
+	Effect.gen(function* () {
+		const {slug, dir, base} = options;
+		if (!isKebabCase(slug)) {
+			return refuse(
+				FAILED,
+				`pattern drift: slug "${slug}" is not kebab-case (lowercase letters, digits and single hyphens).`,
+			);
+		}
+
+		const resolved = yield* fetchAndResolve(base);
+		if (resolved._tag === "Failure") {
+			return refuse(
+				PRECONDITION_UNKNOWN,
+				`pattern drift: cannot fetch ${base}: ${resolved.reason} — the outcome is UNKNOWN, never "current".`,
+			);
+		}
+		const sha = resolved.value;
+		const path = `${dir}/${slug}.md`;
+		const unknown = (what: string, reason: string) =>
+			refuse(
+				PRECONDITION_UNKNOWN,
+				`pattern drift: cannot read ${what}: ${reason} — the outcome is UNKNOWN, never "current".`,
+			);
+
+		const atBase = yield* pathPresentAt(sha, path);
+		if (atBase._tag === "Failure") return unknown(`${path} at ${base}`, atBase.reason);
+
+		if (!atBase.value) {
+			const inTree = yield* Effect.result(exists(path));
+			if (Result.isFailure(inTree)) return unknown(path, inTree.failure.reason);
+			if (!inTree.success) {
+				return refuse(
+					DOC_ABSENT,
+					`pattern drift: no doc for slug "${slug}" under ${dir}, in the working tree or at ${base}.`,
+				);
+			}
+			const reading: Reading = {
+				outcome: "unborn",
+				anchorSha: "-",
+				cited: 0,
+				inRepo: 0,
+				unresolved: [],
+				paths: [],
+			};
+			return answer(emit(options, reading, sha), [
+				`pattern drift: ${path} is in the working tree and absent at ${sha} — it has never been committed, so there is no anchor to measure from.`,
+			]);
+		}
+
+		const text = yield* readFileAt(sha, path);
+		if (text._tag === "Failure") return unknown(`${path} at ${base}`, text.reason);
+
+		const topLevel = yield* topLevelEntriesAt(sha);
+		if (topLevel._tag === "Failure") return unknown(`the tree at ${base}`, topLevel.reason);
+
+		const cited = candidateTokens(text.value).filter((t) => isRepoPath(t, topLevel.value));
+		const resolvedPaths = yield* presentPathsAt(sha, cited);
+		if (resolvedPaths._tag === "Failure") {
+			return unknown(`the tree at ${base}`, resolvedPaths.reason);
+		}
+		const inRepo = cited.filter((p) => resolvedPaths.value.has(p)).sort();
+		const unresolved = cited.filter((p) => !resolvedPaths.value.has(p)).sort();
+
+		const scope = (reading: Reading, anchor: string) =>
+			[
+				`pattern drift: read ${path} at ${sha}, anchor ${anchor}; ${reading.cited} cited, ${reading.inRepo} in-repo, ${unresolved.length} unresolved, ${reading.paths.length} moved.`,
+				...(unresolved.length === 0
+					? []
+					: [
+							`pattern drift: unresolved candidates, counted and never treated as findings: ${unresolved.join(", ")}.`,
+						]),
+			] as ReadonlyArray<string>;
+
+		if (inRepo.length === 0) {
+			const reading: Reading = {
+				outcome: "unanchored",
+				anchorSha: "-",
+				cited: cited.length,
+				inRepo: 0,
+				unresolved,
+				paths: [],
+			};
+			return answer(emit(options, reading, sha), scope(reading, "-"));
+		}
+
+		const anchor = yield* lastCommitTouching(sha, path);
+		if (anchor._tag === "Failure") return unknown(`the history of ${path}`, anchor.reason);
+		if (anchor.value === null) {
+			return unknown(
+				`the history of ${path}`,
+				`no commit touches it at or before ${sha}, though the path is in that tree`,
+			);
+		}
+		const anchorSha = anchor.value.sha;
+
+		const moved: MovedPath[] = [];
+		for (const cite of inRepo) {
+			const commits = yield* commitsTouchingRange(anchorSha, sha, cite);
+			if (commits._tag === "Failure") return unknown(`the history of ${cite}`, commits.reason);
+			const newest: Commit | undefined = commits.value[0];
+			if (newest === undefined) continue;
+			moved.push({
+				path: cite,
+				commits: commits.value.length,
+				lastSha: newest.sha,
+				lastDate: newest.date,
+			});
+		}
+
+		const reading: Reading = {
+			outcome: driftOutcome({inRepo: inRepo.length, moved: moved.length}),
+			anchorSha,
+			cited: cited.length,
+			inRepo: inRepo.length,
+			unresolved,
+			paths: moved,
+		};
+		return answer(emit(options, reading, sha), scope(reading, anchorSha));
+	});

--- a/packages/fabrika-cli/src/pattern/drift-verb.unit.test.ts
+++ b/packages/fabrika-cli/src/pattern/drift-verb.unit.test.ts
@@ -1,0 +1,169 @@
+import {Effect, Layer} from "effect";
+import {describe, expect, it} from "vitest";
+import {errOut, fakeFs, fakeShell, okOut} from "../fakes.test-support.ts";
+import {DOC_ABSENT, PRECONDITION_UNKNOWN} from "./codes.ts";
+import {runDrift} from "./drift-verb.ts";
+import {FIXTURES, UNANCHORED_DOC} from "./fixtures.test-support.ts";
+
+const SHA = "49a22902d1e0c7b3f5a8e4126b9d0f3c7a1e5b82";
+const ANCHOR = "7b1c0e4f2a9d6b83c5417e0af2d9b6c3e81547aa";
+const MOVED = "aa4712e0af2d9b6c35417e83c5b6d9a2f4e0c1b7";
+
+/**
+ * Four candidates survive the repo-path filter and two of them resolve — the split the header
+ * reports. `retry.ts` is ambiguous shorthand and never reaches the filter at all; the two
+ * `packages/`-rooted misses are the *unresolved* half, which is counted and never treated as drift.
+ */
+const DOC = `# Worker queue retry
+
+The shape lives in \`packages/fabrika-cli/src/bin.ts\` and [the router](apps/web/worker/router.ts),
+alongside \`packages/effect/src/Effect.ts\`, \`packages/fate/src/server/live.ts\` and the bare
+\`retry.ts\`.
+`;
+
+const TOP_LEVEL = "packages\napps\n.patterns\nREADME.md\n";
+
+type Script = ReadonlyArray<readonly [RegExp, ReturnType<typeof okOut>]>;
+
+const shell = (overrides: Script = []) =>
+	fakeShell([
+		...overrides,
+		[/^git remote$/, okOut("origin\n")],
+		[/^git fetch/, okOut("")],
+		[/^git rev-parse/, okOut(`${SHA}\n`)],
+		[
+			/^git ls-tree --name-only \w+ -- \.patterns\/worker-queue-retry\.md$/,
+			okOut(".patterns/worker-queue-retry.md\n"),
+		],
+		[/^git ls-tree --name-only \w+:$/, okOut(TOP_LEVEL)],
+		[
+			/^git ls-tree --name-only \w+ --/,
+			okOut("packages/fabrika-cli/src/bin.ts\napps/web/worker/router.ts\n"),
+		],
+		[/^git show \w+:/, okOut(DOC)],
+		[/^git log -1/, okOut(`${ANCHOR}\t2026-07-01\n`)],
+		[/^git log --format=[^ ]+ \w+\.\.\w+ -- packages/, okOut(`${MOVED}\t2026-08-01\n`)],
+		[/^git log --format=/, okOut("")],
+	]);
+
+const options = {slug: "worker-queue-retry", dir: ".patterns", base: "origin/main", json: false};
+
+const run = (
+	overrides: Script = [],
+	opts: Partial<typeof options> = {},
+	files: Readonly<Record<string, string | null>> = {},
+) =>
+	Effect.runPromise(
+		Effect.provide(
+			runDrift({...options, ...opts}),
+			Layer.merge(shell(overrides).layer, fakeFs({files}).layer),
+		),
+	);
+
+describe("runDrift", () => {
+	it("counts the followable paths, lists only the moved ones, and leaves the rest to the header", async () => {
+		const out = await run();
+		expect(out.code).toBe(0);
+		expect(out.stdout).toBe(
+			[
+				`drift\tdrifted\t${ANCHOR}\t4\t2\t2\t1`,
+				`path\tpackages/fabrika-cli/src/bin.ts\t1\t${MOVED}\t2026-08-01`,
+				"",
+			].join("\n"),
+		);
+	});
+
+	// An unresolved candidate is counted and named, never treated as a finding: pattern prose cites
+	// external dependency source trees, and such a path is indistinguishable from a deleted in-repo
+	// one by resolution alone.
+	it("names every unresolved candidate on stderr rather than reporting it as drift", async () => {
+		const out = await run([
+			[/^git ls-tree --name-only \w+ -- packages/, okOut("")],
+			[/^git ls-tree --name-only \w+ -- \.patterns/, okOut(".patterns/worker-queue-retry.md\n")],
+		]);
+		expect(out.stdout.split("\t")[1]).toBe("unanchored");
+		expect(out.stderr.join("\n")).toContain("never treated as findings");
+	});
+
+	it("is `current`, not `drifted`, when nothing in the range touched a cited path", async () => {
+		const out = await run([[/^git log --format=/, okOut("")]]);
+		expect(out.code).toBe(0);
+		expect(out.stdout).toBe(`drift\tcurrent\t${ANCHOR}\t4\t2\t2\t0\n`);
+	});
+
+	// The contract's worked example, byte for byte, over the unanchored-doc fixture's own text.
+	it("answers `unanchored` with a `-` anchor for a doc citing nothing it can follow", async () => {
+		const out = await run(
+			[
+				[/^git show \w+:/, okOut(UNANCHORED_DOC)],
+				[
+					/^git ls-tree --name-only \w+ -- \S/,
+					okOut(`${FIXTURES}/unanchored-doc/worker-queue-retry.md\n`),
+				],
+			],
+			{dir: `${FIXTURES}/unanchored-doc`},
+		);
+		expect(out.code).toBe(0);
+		expect(out.stdout).toBe("drift\tunanchored\t-\t0\t0\t0\t0\n");
+	});
+
+	it("carries that same answer through --json", async () => {
+		const out = await run(
+			[
+				[/^git show \w+:/, okOut(UNANCHORED_DOC)],
+				[
+					/^git ls-tree --name-only \w+ -- \S/,
+					okOut(`${FIXTURES}/unanchored-doc/worker-queue-retry.md\n`),
+				],
+			],
+			{dir: `${FIXTURES}/unanchored-doc`, json: true},
+		);
+		expect(out.stdout).toBe(
+			`{"outcome":"unanchored","anchorSha":"-","cited":0,"inRepo":0,"unresolved":0,"moved":0,"paths":[],"unresolvedPaths":[],"baseRef":"origin/main","baseSha":"${SHA}"}\n`,
+		);
+	});
+
+	// The contract's third worked example.
+	it("refuses a slug with no doc in the working tree and none at the base", async () => {
+		const out = await run([[/^git ls-tree --name-only \w+ --/, okOut("")]], {slug: "no-such-doc"});
+		expect(out.code).toBe(DOC_ABSENT);
+		expect(out.stdout).toBe("");
+		expect(out.stderr.at(-1)).toBe(
+			'pattern drift: no doc for slug "no-such-doc" under .patterns, in the working tree or at origin/main.',
+		);
+	});
+
+	// An uncommitted doc is the bootstrap case, not an empty diff — and `pattern anchor` answers the
+	// same token on the same tree state, because the skill runs the two back to back.
+	it("answers `unborn` for a doc present in the working tree and absent at the base", async () => {
+		const out = await run(
+			[[/^git ls-tree --name-only \w+ --/, okOut("")]],
+			{},
+			{
+				".patterns/worker-queue-retry.md": "# New\n",
+			},
+		);
+		expect(out.code).toBe(0);
+		expect(out.stdout).toBe("drift\tunborn\t-\t0\t0\t0\t0\n");
+	});
+
+	it("refuses an unfetchable base — the outcome is UNKNOWN, never `current`", async () => {
+		const out = await run([[/^git fetch/, errOut("fatal: couldn't find remote ref nope")]]);
+		expect(out.code).toBe(PRECONDITION_UNKNOWN);
+		expect(out.stdout).toBe("");
+		expect(out.stderr.at(-1)).toContain('UNKNOWN, never "current"');
+	});
+
+	it("refuses a history read it could not perform", async () => {
+		const out = await run([[/^git log --format=/, errOut("fatal: bad revision")]]);
+		expect(out.code).toBe(PRECONDITION_UNKNOWN);
+		expect(out.stdout).toBe("");
+	});
+
+	it("refuses a slug that is not kebab-case on 1, the usage seat", async () => {
+		const out = await run([], {slug: "Worker_Queue"});
+		expect(out.code).toBe(1);
+		expect(out.stdout).toBe("");
+		expect(out.stderr.at(-1)).toContain("is not kebab-case");
+	});
+});

--- a/packages/fabrika-cli/src/pattern/drift.ts
+++ b/packages/fabrika-cli/src/pattern/drift.ts
@@ -1,0 +1,63 @@
+/**
+ * Which in-repo paths a doc cites, and what the citation set means once each has been followed.
+ *
+ * **An unresolved candidate is never drift, and never a finding.** Pattern prose legitimately cites
+ * external dependency source trees, and such a path is indistinguishable from a deleted in-repo path
+ * by resolution alone — the irreducible false-positive source that made `pipeline-guard` exclude
+ * `.patterns/**` outright. Candidates that do not resolve are counted, named on stderr, and excluded
+ * from the moved set and from the outcome. This inherits that avoidance rather than repeating the
+ * defect.
+ */
+
+/** Characters that make a token a glob, a template or prose furniture rather than a path. */
+const AMBIGUOUS = /[*?{}[\]!()<>$|]/;
+
+const SCHEME = /^[a-zA-Z][a-zA-Z0-9+.-]*:/;
+
+/**
+ * Every backticked span and every markdown link target in `text`, as whitespace-free tokens.
+ *
+ * A span carrying whitespace is not one token, so it is not a candidate — which is also what keeps
+ * a fenced block's contents from arriving here as a path.
+ */
+export const candidateTokens = (text: string): ReadonlyArray<string> => {
+	const found: string[] = [];
+	const push = (raw: string | undefined) => {
+		if (raw === undefined) return;
+		const token = raw.trim();
+		if (token !== "" && !/\s/.test(token) && !found.includes(token)) found.push(token);
+	};
+	for (const m of text.matchAll(/`([^`]+)`/g)) push(m[1]);
+	for (const m of text.matchAll(/\[[^\]]*\]\(([^)]+)\)/g)) push(m[1]);
+	return found;
+};
+
+/**
+ * Whether a candidate is an unambiguous repo-root-relative path.
+ *
+ * The top-level segment set is **read from the tree**, never hardcoded, so the verb works in a repo
+ * whose layout is not this one. A bare basename and an app-relative fragment are ambiguous shorthand
+ * and are left alone — precision over recall, at the stated cost of missing a partial pointer.
+ */
+export const isRepoPath = (token: string, topLevel: ReadonlySet<string>): boolean => {
+	if (AMBIGUOUS.test(token) || SCHEME.test(token)) return false;
+	const first = token.split("/")[0];
+	return first !== undefined && first !== "" && topLevel.has(first);
+};
+
+/** `unborn` per the doc's tree state, then the moved set, then whether anything was followed. */
+export type DriftOutcome = "drifted" | "current" | "unanchored" | "unborn";
+
+/**
+ * **`unanchored` is not a clearance.** It says the doc cites nothing this verb can follow, so drift
+ * is *unanswerable* — read the source by hand. Reporting it as `current` would be a clean pass over
+ * nothing, which is the shape ADR 0092 exists to forbid; the group expresses that in vocabulary
+ * rather than in an exit code, because a verb that refused would break the pipe its answer crosses.
+ */
+export const driftOutcome = (input: {
+	readonly inRepo: number;
+	readonly moved: number;
+}): Exclude<DriftOutcome, "unborn"> => {
+	if (input.inRepo === 0) return "unanchored";
+	return input.moved > 0 ? "drifted" : "current";
+};

--- a/packages/fabrika-cli/src/pattern/drift.unit.test.ts
+++ b/packages/fabrika-cli/src/pattern/drift.unit.test.ts
@@ -1,0 +1,56 @@
+import {describe, expect, it} from "vitest";
+import {candidateTokens, driftOutcome, isRepoPath} from "./drift.ts";
+
+const TOP_LEVEL = new Set(["packages", "apps", ".patterns", "README.md"]);
+
+describe("candidateTokens", () => {
+	it("takes backticked spans and markdown link targets, once each", () => {
+		expect(
+			candidateTokens("see `packages/a.ts` and [b](apps/b.ts) and `packages/a.ts` again"),
+		).toEqual(["packages/a.ts", "apps/b.ts"]);
+	});
+
+	// A candidate is ONE whitespace-free token — which is also what keeps a fenced block's contents
+	// and an ordinary backticked phrase from arriving here as paths.
+	it("drops a span carrying whitespace", () => {
+		expect(candidateTokens("`pattern drift` and `a b`")).toEqual([]);
+	});
+});
+
+describe("isRepoPath", () => {
+	it("admits a token whose first segment is a top-level entry of the tree", () => {
+		expect(isRepoPath("packages/fabrika-cli/src/bin.ts", TOP_LEVEL)).toBe(true);
+		expect(isRepoPath("README.md", TOP_LEVEL)).toBe(true);
+	});
+
+	// Precision over recall, at the stated cost of missing a partial pointer: a bare basename and an
+	// app-relative fragment are ambiguous shorthand, so they are left alone rather than guessed at.
+	it("leaves a bare basename and an app-relative fragment alone", () => {
+		expect(isRepoPath("retry.ts", TOP_LEVEL)).toBe(false);
+		expect(isRepoPath("worker/queue/retry.ts", TOP_LEVEL)).toBe(false);
+	});
+
+	it("drops a glob, a template and a scheme", () => {
+		for (const token of ["packages/**/*.test.ts", "packages/{a,b}.ts", "https://example.com"]) {
+			expect(isRepoPath(token, TOP_LEVEL)).toBe(false);
+		}
+	});
+
+	it("keys on the tree's own top level, so a repo with another layout still answers", () => {
+		expect(isRepoPath("lib/x.ts", TOP_LEVEL)).toBe(false);
+		expect(isRepoPath("lib/x.ts", new Set(["lib"]))).toBe(true);
+	});
+});
+
+describe("driftOutcome", () => {
+	it("is `drifted` when anything moved and `current` when nothing did", () => {
+		expect(driftOutcome({inRepo: 3, moved: 1})).toBe("drifted");
+		expect(driftOutcome({inRepo: 3, moved: 0})).toBe("current");
+	});
+
+	// `unanchored` is NOT a clearance. Reporting it as `current` would be a clean pass over nothing,
+	// which is the shape ADR 0092 exists to forbid.
+	it("is `unanchored`, never `current`, when nothing was followed", () => {
+		expect(driftOutcome({inRepo: 0, moved: 0})).toBe("unanchored");
+	});
+});

--- a/packages/fabrika-cli/src/pattern/fixtures.test-support.ts
+++ b/packages/fabrika-cli/src/pattern/fixtures.test-support.ts
@@ -1,0 +1,74 @@
+/**
+ * The fixture bytes the contract's worked examples are stated against, scripted onto the git seam.
+ *
+ * The examples name fixtures committed in the skill's own tree, and the read-at-`--base` rule
+ * applies to them like anything else — so what a verb actually sees is `git show <sha>:<path>`
+ * output. Scripting **those bytes** reproduces the examples through the same seam production uses,
+ * and it does so without a checkout: a test that shelled out to a real repository would be asserting
+ * against that repository's history rather than against the spec.
+ */
+
+/** `.../fixtures/anchored/worker-queue-retry.md` — two declarations, one moved, one unpinned. */
+export const ANCHORED_DOC = `# Worker queue retry
+
+The fixture behind \`pattern anchor\`'s \`moved\` outcome. It declares two anchors: one whose package the
+fixture manifest pins at a different version, and one the manifest does not carry at all.
+
+> Derived from \`acme-queue@4.1.0\` — re-verify on pin bump.
+
+> Derived from \`@acme/retry@2.0.0\` — re-verify on pin bump.
+`;
+
+/** `.../fixtures/anchored/plain-doc.md` — a doc that claims no anchor at all. */
+export const PLAIN_DOC = `# Plain doc
+
+A doc carrying no anchor declaration, so \`pattern anchor\` answers \`unanchored\`.
+`;
+
+/** `.../fixtures/anchored/workspace.yaml` — pins `acme-queue`, carries no `@acme/retry`. */
+export const FIXTURE_MANIFEST = `# Fixture manifest for \`pattern anchor\`'s examples. Not a real workspace.
+catalog:
+  acme-queue: 4.2.0
+  acme-telemetry: 9.9.1
+`;
+
+/** `.../fixtures/unanchored-doc/worker-queue-retry.md` — every pointer deliberately unfollowable. */
+export const UNANCHORED_DOC = `# Worker queue retry
+
+The fixture behind \`pattern drift\`'s \`unanchored\` outcome: a doc that cites no repo-root-relative
+path this verb can follow, so drift here is unanswerable rather than clean.
+
+Every pointer below is deliberately unfollowable — a bare basename, an app-relative fragment, and a
+glob — which is exactly the ambiguous shorthand the derivation leaves alone.
+
+- \`retry.ts\`
+- \`worker/queue/retry.ts\`
+- \`src/**/*.test.ts\`
+`;
+
+/** `.../fixtures/three-sections/index.md` — three sections, so the `present:` list is exact. */
+export const THREE_SECTIONS_INDEX = `# Patterns
+
+A three-section index fixture, so \`pattern register\`'s refusal example prints an exact list.
+
+## Index — services
+
+| Doc | Topic | Read when |
+|---|---|---|
+| [cache-invalidation.md](./cache-invalidation.md) | Cache keys and invalidation order | Touching a cached read |
+
+## Index — edge
+
+| Doc | Topic | Read when |
+|---|---|---|
+| [edge-session-cookies.md](./edge-session-cookies.md) | Session cookie parse and re-issue | Changing session handling |
+
+## Index — observability
+
+| Doc | Topic | Read when |
+|---|---|---|
+| [tracing-span-names.md](./tracing-span-names.md) | Span naming convention | Naming a new span |
+`;
+
+/** The three fixture directory paths the contract's examples pass to `--dir`. */
+export const FIXTURES = "claude-plugins/fabrika/skills/write-pattern/evals/fixtures";

--- a/packages/fabrika-cli/src/pattern/fixtures.test-support.ts
+++ b/packages/fabrika-cli/src/pattern/fixtures.test-support.ts
@@ -22,7 +22,8 @@ fixture manifest pins at a different version, and one the manifest does not carr
 /** `.../fixtures/anchored/plain-doc.md` — a doc that claims no anchor at all. */
 export const PLAIN_DOC = `# Plain doc
 
-A doc carrying no anchor declaration, so \`pattern anchor\` answers \`unanchored\`.
+The fixture behind \`pattern anchor\`'s \`unanchored\` outcome: a doc that declares no dependency anchor
+at all, which is the common case and a fact rather than a fault.
 `;
 
 /** `.../fixtures/anchored/workspace.yaml` — pins `acme-queue`, carries no `@acme/retry`. */

--- a/packages/fabrika-cli/src/pattern/git.ts
+++ b/packages/fabrika-cli/src/pattern/git.ts
@@ -1,0 +1,96 @@
+/**
+ * The four git reads this group needs beyond `../io/git.ts`'s — presence in a tree, and history over
+ * a path.
+ *
+ * **Presence is probed with a pathspec, never with a read that fails on absence.** `git ls-tree
+ * --name-only <sha> -- <path>` exits `0` whether or not the path is there and prints it only when it
+ * is, so "not in the tree" is a *fact* and a non-zero exit is a *failed read*. That split is what
+ * lets `pattern corpus` answer `absent` at exit `0` while still refusing `11` on a read it could not
+ * perform — the two would be one answer if absence were inferred from a failure.
+ */
+import {Effect} from "effect";
+import {execCapture} from "../io/exec.ts";
+import {type Attempt, fail, ok, type Shell} from "../io/git.ts";
+
+/** One commit, as this group reports it: the full object name and the author date. */
+export interface Commit {
+	readonly sha: string;
+	/** The author date as `YYYY-MM-DD`. */
+	readonly date: string;
+}
+
+const parseCommits = (stdout: string): ReadonlyArray<Commit> =>
+	stdout
+		.split("\n")
+		.map((line) => line.trim())
+		.filter((line) => line !== "")
+		.flatMap((line) => {
+			const [sha, date] = line.split("\t");
+			return sha === undefined || date === undefined ? [] : [{sha, date}];
+		});
+
+/** The subset of `paths` present in the tree at `sha`. An empty input spawns nothing. */
+export const presentPathsAt = (
+	sha: string,
+	paths: ReadonlyArray<string>,
+): Shell<Attempt<ReadonlySet<string>>> =>
+	Effect.gen(function* () {
+		if (paths.length === 0) return ok<ReadonlySet<string>>(new Set());
+		const r = yield* execCapture("git", ["ls-tree", "--name-only", sha, "--", ...paths]);
+		if (!r.ok) return fail(r.reason);
+		return ok<ReadonlySet<string>>(
+			new Set(
+				r.stdout
+					.split("\n")
+					.map((p) => p.trim())
+					.filter((p) => p !== ""),
+			),
+		);
+	});
+
+/** Whether one path is present in the tree at `sha`. */
+export const pathPresentAt = (sha: string, path: string): Shell<Attempt<boolean>> =>
+	Effect.gen(function* () {
+		const present = yield* presentPathsAt(sha, [path]);
+		return present._tag === "Failure" ? present : ok(present.value.has(path));
+	});
+
+/** The top-level entries of the tree at `sha` — the segment set a cited path must open with. */
+export const topLevelEntriesAt = (sha: string): Shell<Attempt<ReadonlySet<string>>> =>
+	Effect.gen(function* () {
+		const r = yield* execCapture("git", ["ls-tree", "--name-only", `${sha}:`]);
+		if (!r.ok) return fail(r.reason);
+		return ok<ReadonlySet<string>>(
+			new Set(
+				r.stdout
+					.split("\n")
+					.map((p) => p.trim())
+					.filter((p) => p !== ""),
+			),
+		);
+	});
+
+/** The last commit touching `path` at or before `sha`, or `null` when none does. */
+export const lastCommitTouching = (sha: string, path: string): Shell<Attempt<Commit | null>> =>
+	Effect.gen(function* () {
+		const r = yield* execCapture("git", ["log", "-1", "--format=%H%x09%as", sha, "--", path]);
+		if (!r.ok) return fail(r.reason);
+		return ok(parseCommits(r.stdout)[0] ?? null);
+	});
+
+/** Every commit touching `path` in the range *(anchor, base]*, newest first. */
+export const commitsTouchingRange = (
+	anchor: string,
+	base: string,
+	path: string,
+): Shell<Attempt<ReadonlyArray<Commit>>> =>
+	Effect.gen(function* () {
+		const r = yield* execCapture("git", [
+			"log",
+			"--format=%H%x09%as",
+			`${anchor}..${base}`,
+			"--",
+			path,
+		]);
+		return r.ok ? ok(parseCommits(r.stdout)) : fail(r.reason);
+	});

--- a/packages/fabrika-cli/src/pattern/git.unit.test.ts
+++ b/packages/fabrika-cli/src/pattern/git.unit.test.ts
@@ -1,0 +1,111 @@
+import {Effect} from "effect";
+import {describe, expect, it} from "vitest";
+import {errOut, fakeShell, okOut} from "../fakes.test-support.ts";
+import type {Shell} from "../io/git.ts";
+import {
+	commitsTouchingRange,
+	lastCommitTouching,
+	pathPresentAt,
+	presentPathsAt,
+	topLevelEntriesAt,
+} from "./git.ts";
+
+const SHA = "49a22902d1e0c7b3f5a8e4126b9d0f3c7a1e5b82";
+const OTHER = "aa4712e0af2d9b6c35417e83c5b6d9a2f4e0c1b7";
+
+const run = <A>(
+	effect: Shell<A>,
+	script: ReadonlyArray<readonly [RegExp, ReturnType<typeof okOut>]>,
+): Promise<A> => Effect.runPromise(Effect.provide(effect, fakeShell(script).layer));
+
+/**
+ * The split the whole group rests on: `git ls-tree … -- <path>` exits `0` either way, so an empty
+ * listing is a path that is NOT there and a non-zero exit is a read that failed. If these two ever
+ * fused, `pattern corpus` would answer `absent` for a tree it could not read.
+ */
+describe("presence is a fact, and a failed read is not", () => {
+	it("reads an empty listing as absent, at Ok rather than Failure", async () => {
+		const out = await run(pathPresentAt(SHA, "no/such/dir"), [[/^git ls-tree/, okOut("")]]);
+		expect(out).toEqual({_tag: "Ok", value: false});
+	});
+
+	it("reads the path echoed back as present", async () => {
+		const out = await run(pathPresentAt(SHA, ".patterns"), [
+			[/^git ls-tree/, okOut(".patterns\n")],
+		]);
+		expect(out).toEqual({_tag: "Ok", value: true});
+	});
+
+	it("reads a non-zero exit as a FAILURE, never as absence", async () => {
+		const out = await run(pathPresentAt(SHA, ".patterns"), [
+			[/^git ls-tree/, errOut("fatal: not a tree object")],
+		]);
+		expect(out).toMatchObject({_tag: "Failure"});
+	});
+
+	// An empty pathspec list would make `git ls-tree <sha> --` list the whole root tree, which would
+	// report every top-level entry as a resolved citation.
+	it("spawns nothing for an empty path set", async () => {
+		const shell = fakeShell([]);
+		const out = await Effect.runPromise(Effect.provide(presentPathsAt(SHA, []), shell.layer));
+		expect(out).toEqual({_tag: "Ok", value: new Set()});
+		expect(shell.calls).toEqual([]);
+	});
+
+	it("returns the resolved subset of a mixed set", async () => {
+		const out = await run(presentPathsAt(SHA, ["apps/a.ts", "gone/b.ts"]), [
+			[/^git ls-tree/, okOut("apps/a.ts\n")],
+		]);
+		expect(out).toEqual({_tag: "Ok", value: new Set(["apps/a.ts"])});
+	});
+});
+
+describe("history reads", () => {
+	it("parses the sha and the author date off one log line", async () => {
+		const out = await run(lastCommitTouching(SHA, ".patterns/a.md"), [
+			[/^git log/, okOut(`${OTHER}\t2026-08-01\n`)],
+		]);
+		expect(out).toEqual({_tag: "Ok", value: {sha: OTHER, date: "2026-08-01"}});
+	});
+
+	// A path with no commit at or before the base is a fact the caller decides on; it is not a
+	// failure, and it is not a commit.
+	it("answers null for a path no commit touches, and Failure for a read that broke", async () => {
+		expect(await run(lastCommitTouching(SHA, "x"), [[/^git log/, okOut("")]])).toEqual({
+			_tag: "Ok",
+			value: null,
+		});
+		expect(
+			await run(lastCommitTouching(SHA, "x"), [[/^git log/, errOut("fatal: bad revision")]]),
+		).toMatchObject({_tag: "Failure"});
+	});
+
+	it("counts every commit in the range, newest first", async () => {
+		const out = await run(commitsTouchingRange(OTHER, SHA, "apps/a.ts"), [
+			[/^git log/, okOut(`${SHA}\t2026-08-05\n${OTHER}\t2026-08-01\n`)],
+		]);
+		expect(out).toEqual({
+			_tag: "Ok",
+			value: [
+				{sha: SHA, date: "2026-08-05"},
+				{sha: OTHER, date: "2026-08-01"},
+			],
+		});
+	});
+
+	it("drops a log line that does not carry both fields rather than half-reading it", async () => {
+		const out = await run(commitsTouchingRange(OTHER, SHA, "apps/a.ts"), [
+			[/^git log/, okOut("just-a-sha\n")],
+		]);
+		expect(out).toEqual({_tag: "Ok", value: []});
+	});
+});
+
+describe("topLevelEntriesAt", () => {
+	it("reads the root tree's entries as the segment set a cited path must open with", async () => {
+		const out = await run(topLevelEntriesAt(SHA), [
+			[/^git ls-tree/, okOut("apps\npackages\nREADME.md\n")],
+		]);
+		expect(out).toEqual({_tag: "Ok", value: new Set(["apps", "packages", "README.md"])});
+	});
+});

--- a/packages/fabrika-cli/src/pattern/index-table.ts
+++ b/packages/fabrika-cli/src/pattern/index-table.ts
@@ -1,0 +1,147 @@
+/**
+ * The index `pattern corpus` reads and `pattern register` edits, parsed once.
+ *
+ * **Row parsing is positional, never a region scan.** A doc counts as registered only when a
+ * markdown table row's FIRST cell links its filename; a mention anywhere else — a sentence of
+ * prose, a reading-order note, a second cell — is not a registration. v1's check was
+ * `grep -n "$NAME.md" index.md`: unanchored, whole-file, and with `.` as a regex any-char, so prose
+ * passed as a row.
+ */
+
+/** A cell's escapes undone, so a row's text round-trips through {@link composeRow}. */
+const unescapeCell = (cell: string): string => cell.replace(/\\\|/g, "|").trim();
+
+/** The cells of a table row, or `null` when the line is not one. */
+export const rowCells = (line: string): ReadonlyArray<string> | null => {
+	const trimmed = line.trim();
+	if (!trimmed.startsWith("|")) return null;
+	const inner = trimmed.replace(/^\|/, "").replace(/\|$/, "");
+	return inner.split(/(?<!\\)\|/).map(unescapeCell);
+};
+
+/** A table's `|---|---|` delimiter — what makes the lines around it a table rather than prose. */
+export const isDelimiterRow = (line: string): boolean => {
+	const cells = rowCells(line);
+	return cells !== null && cells.length > 0 && cells.every((c) => /^:?-{3,}:?$/.test(c));
+};
+
+/** The first markdown link target in a cell, verbatim, or `null`. */
+export const linkTarget = (cell: string): string | null =>
+	/\[[^\]]*\]\(([^)]+)\)/.exec(cell)?.[1]?.trim() ?? null;
+
+/**
+ * A link target read as a **member name of the doc directory**, or `null` when it names something
+ * else.
+ *
+ * A target carrying a directory component, a scheme, or an anchor onto another file is not a member
+ * — which is the whole point of the `dangling` line: an ADR, a doc in a subdirectory or a file
+ * outside `--dir` resolves perfectly well and is still not a member of this corpus.
+ */
+export const memberName = (target: string): string | null => {
+	const path = target.split("#")[0]?.split("?")[0] ?? "";
+	const bare = path.startsWith("./") ? path.slice(2) : path;
+	return bare === "" || bare.includes("/") || bare.includes(":") ? null : bare;
+};
+
+export interface IndexRow {
+	/** 0-based line index, so an insertion can be placed without re-finding the row. */
+	readonly line: number;
+	/** The first cell's link target, verbatim, or `null` when the cell links nothing. */
+	readonly target: string | null;
+	/** The target read as a member of the doc directory, or `null`. */
+	readonly member: string | null;
+	/** The enclosing heading's text, or `-` when the row sits above the first heading. */
+	readonly section: string;
+}
+
+export interface IndexSection {
+	/** The heading text, leading `#` characters and surrounding whitespace stripped. */
+	readonly heading: string;
+	readonly headingLine: number;
+	/** Every table row under it, in document order. */
+	readonly rows: ReadonlyArray<IndexRow>;
+	/** Where an insertion goes: the last table row's line, or `null` when the section has no table. */
+	readonly lastRowLine: number | null;
+	readonly hasTable: boolean;
+}
+
+export interface ParsedIndex {
+	readonly sections: ReadonlyArray<IndexSection>;
+	/** Every table row anywhere in the document, in document order. */
+	readonly rows: ReadonlyArray<IndexRow>;
+	/** Whether any table was found at all — the `15` question. */
+	readonly hasTable: boolean;
+}
+
+/** The section heading text of a `#`-prefixed line, or `null`. */
+const headingTextOf = (line: string): string | null => {
+	const m = /^\s{0,3}(#{1,6})\s+(.*)$/.exec(line);
+	return m?.[2] === undefined ? null : m[2].replace(/\s+#*\s*$/, "").trim();
+};
+
+export const parseIndex = (text: string): ParsedIndex => {
+	const lines = text.split("\n");
+	const sections: IndexSection[] = [];
+	const rows: IndexRow[] = [];
+
+	let heading = "-";
+	let headingLine = -1;
+	let current: IndexRow[] = [];
+	let currentHasTable = false;
+
+	const close = () => {
+		if (headingLine === -1 && current.length === 0 && !currentHasTable) return;
+		sections.push({
+			heading,
+			headingLine,
+			rows: current,
+			lastRowLine: current.at(-1)?.line ?? null,
+			hasTable: currentHasTable,
+		});
+	};
+
+	for (const [at, line] of lines.entries()) {
+		const head = headingTextOf(line);
+		if (head !== null) {
+			close();
+			heading = head;
+			headingLine = at;
+			current = [];
+			currentHasTable = false;
+			continue;
+		}
+		if (isDelimiterRow(line)) {
+			currentHasTable = true;
+			continue;
+		}
+		const cells = rowCells(line);
+		if (cells === null) continue;
+		const target = linkTarget(cells[0] ?? "");
+		const row: IndexRow = {
+			line: at,
+			target,
+			member: target === null ? null : memberName(target),
+			section: heading,
+		};
+		current.push(row);
+		rows.push(row);
+	}
+	close();
+
+	return {sections, rows, hasTable: sections.some((s) => s.hasTable)};
+};
+
+/** Every section that carries a table, in document order — the set `--section` may name. */
+export const tableSections = (index: ParsedIndex): ReadonlyArray<string> =>
+	index.sections.filter((s) => s.hasTable && s.headingLine !== -1).map((s) => s.heading);
+
+/** A cell's tabs and newlines stripped and its pipes escaped, so one row stays one line. */
+export const cellText = (value: string): string =>
+	value
+		.replace(/[\t\n\r]+/g, " ")
+		.replace(/\|/g, "\\|")
+		.trim();
+
+/** The row's bytes: a link to the doc, then the two authored cells. */
+export const composeRow = (slug: string, topic: string, readWhen: string): string =>
+	`| [${slug}.md](./${slug}.md) | ${cellText(topic)} | ${cellText(readWhen)} |`;

--- a/packages/fabrika-cli/src/pattern/index-table.ts
+++ b/packages/fabrika-cli/src/pattern/index-table.ts
@@ -8,15 +8,37 @@
  * passed as a row.
  */
 
-/** A cell's escapes undone, so a row's text round-trips through {@link composeRow}. */
-const unescapeCell = (cell: string): string => cell.replace(/\\\|/g, "|").trim();
-
-/** The cells of a table row, or `null` when the line is not one. */
+/**
+ * The cells of a table row, or `null` when the line is not one.
+ *
+ * The scan consumes `\|` and `\\` in a single left-to-right pass, which is what makes it the exact
+ * inverse of {@link cellText}. Honouring only `\|` fuses a cell whose own text ends in a backslash
+ * with the delimiter after it, so the value smuggles in a column separator the escape believed it
+ * had neutralized (#5364).
+ */
 export const rowCells = (line: string): ReadonlyArray<string> | null => {
-	const trimmed = line.trim();
-	if (!trimmed.startsWith("|")) return null;
-	const inner = trimmed.replace(/^\|/, "").replace(/\|$/, "");
-	return inner.split(/(?<!\\)\|/).map(unescapeCell);
+	let text = line.trim();
+	if (!text.startsWith("|")) return null;
+	text = text.slice(1);
+	if (text.endsWith("|") && !text.endsWith("\\|")) text = text.slice(0, -1);
+	const cells: string[] = [];
+	let cell = "";
+	for (let i = 0; i < text.length; i += 1) {
+		const ch = text[i] as string;
+		if (ch === "\\" && (text[i + 1] === "|" || text[i + 1] === "\\")) {
+			cell += text[i + 1] as string;
+			i += 1;
+			continue;
+		}
+		if (ch === "|") {
+			cells.push(cell.trim());
+			cell = "";
+			continue;
+		}
+		cell += ch;
+	}
+	cells.push(cell.trim());
+	return cells;
 };
 
 /** A table's `|---|---|` delimiter — what makes the lines around it a table rather than prose. */
@@ -135,12 +157,21 @@ export const parseIndex = (text: string): ParsedIndex => {
 export const tableSections = (index: ParsedIndex): ReadonlyArray<string> =>
 	index.sections.filter((s) => s.hasTable && s.headingLine !== -1).map((s) => s.heading);
 
-/** A cell's tabs and newlines stripped and its pipes escaped, so one row stays one line. */
+/**
+ * A cell's tabs and newlines flattened and its escapes written, so one row stays one line and a
+ * value cannot grow a column.
+ *
+ * **The backslash is escaped FIRST, and that order is the whole correctness of the pair.** Escaping
+ * only `|` leaves the encoding ambiguous — a cell ending in `\` renders as `…\ |`, and its own
+ * trailing backslash then reads as escaping the delimiter that follows. {@link rowCells} is the
+ * exact inverse and unescapes both.
+ */
 export const cellText = (value: string): string =>
 	value
 		.replace(/[\t\n\r]+/g, " ")
-		.replace(/\|/g, "\\|")
-		.trim();
+		.trim()
+		.replace(/\\/g, "\\\\")
+		.replace(/\|/g, "\\|");
 
 /** The row's bytes: a link to the doc, then the two authored cells. */
 export const composeRow = (slug: string, topic: string, readWhen: string): string =>

--- a/packages/fabrika-cli/src/pattern/index-table.unit.test.ts
+++ b/packages/fabrika-cli/src/pattern/index-table.unit.test.ts
@@ -1,0 +1,145 @@
+import {describe, expect, it} from "vitest";
+import {
+	cellText,
+	composeRow,
+	isDelimiterRow,
+	linkTarget,
+	memberName,
+	parseIndex,
+	rowCells,
+	tableSections,
+} from "./index-table.ts";
+
+const INDEX = `# Patterns
+
+A three-section index fixture.
+
+## Index — services
+
+| Doc | Topic | Read when |
+|---|---|---|
+| [cache-invalidation.md](./cache-invalidation.md) | Cache keys | Touching a cached read |
+
+## Index — edge
+
+| Doc | Topic | Read when |
+|---|---|---|
+| [edge-session-cookies.md](./edge-session-cookies.md) | Session cookies | Changing session handling |
+
+## Index — observability
+
+| Doc | Topic | Read when |
+|---|---|---|
+| [tracing-span-names.md](./tracing-span-names.md) | Span naming | Naming a new span |
+`;
+
+describe("rowCells", () => {
+	it("splits a row and unescapes its pipes", () => {
+		expect(rowCells("| a | b\\|c | d |")).toEqual(["a", "b|c", "d"]);
+	});
+
+	it("is null for a line that is not a row", () => {
+		expect(rowCells("just prose")).toBeNull();
+		expect(rowCells("## Index — services")).toBeNull();
+	});
+});
+
+describe("isDelimiterRow", () => {
+	it("recognises the alignment forms", () => {
+		for (const line of ["|---|---|", "| --- | :---: |", "|:---|---:|"]) {
+			expect(isDelimiterRow(line)).toBe(true);
+		}
+	});
+
+	it("is false for a content row", () => {
+		expect(isDelimiterRow("| [a.md](./a.md) | x | y |")).toBe(false);
+	});
+});
+
+describe("memberName", () => {
+	it("reads a bare or dot-slash target as a member", () => {
+		expect(memberName("./cache-invalidation.md")).toBe("cache-invalidation.md");
+		expect(memberName("cache-invalidation.md")).toBe("cache-invalidation.md");
+	});
+
+	// A target that resolves perfectly well — an ADR, a doc in a subdirectory — is still not a MEMBER
+	// of this corpus. The question is membership, not reachability, which is why this is not a link
+	// check and does not overlap the link gate.
+	it("is null for anything carrying a directory component or a scheme", () => {
+		for (const target of [
+			"../.decisions/0001-x.md",
+			"sub/foo.md",
+			"https://example.com/a.md",
+			"",
+		]) {
+			expect(memberName(target)).toBeNull();
+		}
+	});
+});
+
+describe("linkTarget", () => {
+	it("reads the first markdown link's target", () => {
+		expect(linkTarget("[a.md](./a.md)")).toBe("./a.md");
+	});
+
+	it("is null when the cell links nothing — a header cell is not a registration", () => {
+		expect(linkTarget("Doc")).toBeNull();
+	});
+});
+
+describe("parseIndex", () => {
+	const index = parseIndex(INDEX);
+
+	it("names every section carrying a table, in document order", () => {
+		expect(tableSections(index)).toEqual([
+			"Index — services",
+			"Index — edge",
+			"Index — observability",
+		]);
+	});
+
+	it("binds each content row to its enclosing heading", () => {
+		expect(index.rows.filter((r) => r.member !== null).map((r) => [r.member, r.section])).toEqual([
+			["cache-invalidation.md", "Index — services"],
+			["edge-session-cookies.md", "Index — edge"],
+			["tracing-span-names.md", "Index — observability"],
+		]);
+	});
+
+	// v1's check was `grep -n "$NAME.md" index.md`: unanchored, whole-file, and with `.` as a regex
+	// any-char, so a mention in prose passed as a row. Registration is a table row's FIRST cell.
+	it("does not read a prose mention, or a second cell, as a registration", () => {
+		const parsed = parseIndex(`## Index — services
+
+See worker-queue-retry.md for the retry shape.
+
+| Doc | Topic | Read when |
+|---|---|---|
+| [a.md](./a.md) | see [worker-queue-retry.md](./worker-queue-retry.md) | x |
+`);
+		expect(parsed.rows.map((r) => r.member)).toEqual([null, "a.md"]);
+	});
+
+	it("reports no table for a document that holds none", () => {
+		expect(parseIndex("# Patterns\n\nNothing here yet.\n").hasTable).toBe(false);
+	});
+});
+
+describe("composeRow", () => {
+	it("escapes pipes and flattens tabs so one row stays one line", () => {
+		expect(composeRow("a-b", "x | y", "line\tone")).toBe(
+			"| [a-b.md](./a-b.md) | x \\| y | line one |",
+		);
+	});
+
+	it("round-trips through the parser it is written for", () => {
+		const row = composeRow("a-b", "topic", "read when");
+		expect(rowCells(row)).toEqual(["[a-b.md](./a-b.md)", "topic", "read when"]);
+	});
+});
+
+describe("cellText", () => {
+	it("strips newlines as well as tabs", () => {
+		expect(cellText("a\nb")).toBe("a b");
+	});
+});

--- a/packages/fabrika-cli/src/pattern/index-table.unit.test.ts
+++ b/packages/fabrika-cli/src/pattern/index-table.unit.test.ts
@@ -142,4 +142,32 @@ describe("cellText", () => {
 	it("strips newlines as well as tabs", () => {
 		expect(cellText("a\nb")).toBe("a b");
 	});
+
+	it("escapes the backslash before the pipe, so the escape character cannot be forged", () => {
+		expect(cellText("a\\|b")).toBe("a\\\\\\|b");
+	});
+
+	/**
+	 * `cellText` and `rowCells` are an exact inverse pair, and the backslash arm is what makes that
+	 * true: escaping only `|` would let a cell ending in `\` read as escaping the delimiter after
+	 * it, which is a value smuggling in a column separator (#5364). Every case here renders a
+	 * three-cell row that must still split into exactly three cells.
+	 */
+	it.each([
+		"plain",
+		"",
+		"a | b",
+		"ends with a backslash \\",
+		"\\",
+		"|",
+		"double \\\\ backslash",
+		"already escaped \\| pipe",
+		"escaped backslash then pipe \\\\|",
+		"escaped pipe then backslash \\|\\",
+		"trailing bare pipe |",
+		"\\|",
+	])("round-trips %j through cellText and rowCells", (value) => {
+		const row = composeRow("a-b", value, "read when");
+		expect(rowCells(row)).toEqual(["[a-b.md](./a-b.md)", value.trim(), "read when"]);
+	});
 });

--- a/packages/fabrika-cli/src/pattern/new-verb.ts
+++ b/packages/fabrika-cli/src/pattern/new-verb.ts
@@ -1,0 +1,66 @@
+/**
+ * `pattern new` — scaffold one doc from the canonical template.
+ *
+ * Not a judging verb: it writes exactly one file and never edits another. The index row is
+ * `pattern register`'s, and separating them is what lets a doc land in a repo whose index is
+ * missing. Creating `--dir` when it is absent is the bootstrap half of the same rule — a repo
+ * adopting fabrika has no `.patterns/`, and its first doc has to be writable on the documented path.
+ */
+import {Effect, type FileSystem, type Path, Result} from "effect";
+import {exists, writeFile} from "../io/fs.ts";
+import {answer, FAILED, refuse, type VerbOutcome} from "../verb.ts";
+import {ALREADY_EXISTS, PRECONDITION_UNKNOWN, WRITE_UNKNOWN} from "./codes.ts";
+import {docTemplate, isKebabCase, splitAnchorToken, titleFrom} from "./doc.ts";
+
+export interface NewOptions {
+	readonly slug: string;
+	readonly dir: string;
+	readonly title: string | null;
+	readonly anchor: string | null;
+	readonly json: boolean;
+}
+
+export const runNew = (
+	options: NewOptions,
+): Effect.Effect<VerbOutcome, never, FileSystem.FileSystem | Path.Path> =>
+	Effect.gen(function* () {
+		const {slug, dir, anchor, json} = options;
+		if (!isKebabCase(slug)) {
+			return refuse(
+				FAILED,
+				`pattern new: slug "${slug}" is not kebab-case (lowercase letters, digits and single hyphens).`,
+			);
+		}
+		// Validated by `pattern anchor`'s own split rule, so the writer and the reader of the anchor
+		// line accept exactly the same strings.
+		if (anchor !== null && splitAnchorToken(anchor) === null) {
+			return refuse(FAILED, `pattern new: --anchor "${anchor}" is not <pkg>@<version>.`);
+		}
+
+		const path = `${dir.replace(/\/+$/, "")}/${slug}.md`;
+		const present = yield* Effect.result(exists(path));
+		// A probe that could not RUN is not "absent": answering absent here would license a write over
+		// a doc this verb never managed to look at.
+		if (Result.isFailure(present)) {
+			return refuse(
+				PRECONDITION_UNKNOWN,
+				`pattern new: cannot check ${path}: ${present.failure.reason} — nothing was written.`,
+			);
+		}
+		if (present.success) {
+			return refuse(ALREADY_EXISTS, `pattern new: ${path} already exists — refusing to overwrite.`);
+		}
+
+		const title = options.title ?? titleFrom(slug);
+		const written = yield* Effect.result(writeFile(path, docTemplate(title, anchor)));
+		if (Result.isFailure(written)) {
+			return refuse(
+				WRITE_UNKNOWN,
+				`pattern new: cannot write ${path}: ${written.failure.reason} — whether anything landed is UNKNOWN.`,
+			);
+		}
+
+		return answer(json ? JSON.stringify({path, slug, title, anchored: anchor}) : path, [
+			`pattern new: wrote ${path}${anchor === null ? "" : ` with the anchor line for ${anchor}`}; the index row is pattern register's.`,
+		]);
+	});

--- a/packages/fabrika-cli/src/pattern/new-verb.unit.test.ts
+++ b/packages/fabrika-cli/src/pattern/new-verb.unit.test.ts
@@ -1,0 +1,107 @@
+import {Effect} from "effect";
+import {describe, expect, it} from "vitest";
+import {type FakeFsOptions, fakeFs} from "../fakes.test-support.ts";
+import {ALREADY_EXISTS, PRECONDITION_UNKNOWN, WRITE_UNKNOWN} from "./codes.ts";
+import {ANCHOR_DECLARATION} from "./doc.ts";
+import {type NewOptions, runNew} from "./new-verb.ts";
+
+const options: NewOptions = {
+	slug: "worker-queue-retry",
+	dir: ".patterns",
+	title: null,
+	anchor: null,
+	json: false,
+};
+
+const run = (opts: Partial<typeof options> = {}, fs: FakeFsOptions = {}) => {
+	const fake = fakeFs(fs);
+	return Effect.runPromise(Effect.provide(runNew({...options, ...opts}), fake.layer)).then(
+		(outcome) => ({outcome, written: fake.written}),
+	);
+};
+
+describe("runNew", () => {
+	// The contract's first worked example.
+	it("answers the path written and nothing else", async () => {
+		const {outcome, written} = await run();
+		expect(outcome.code).toBe(0);
+		expect(outcome.stdout).toBe(".patterns/worker-queue-retry.md\n");
+		expect(
+			written.get(".patterns/worker-queue-retry.md")?.startsWith("# Worker queue retry\n"),
+		).toBe(true);
+	});
+
+	// The contract's second worked example.
+	it("refuses to overwrite an existing doc", async () => {
+		const {outcome, written} = await run(
+			{},
+			{files: {".patterns/worker-queue-retry.md": "# Already here\n"}},
+		);
+		expect(outcome.code).toBe(ALREADY_EXISTS);
+		expect(outcome.stdout).toBe("");
+		expect(outcome.stderr.at(-1)).toBe(
+			"pattern new: .patterns/worker-queue-retry.md already exists — refusing to overwrite.",
+		);
+		expect(written.size).toBe(0);
+	});
+
+	// The contract's third and fourth worked examples.
+	it("carries the write record through --json, with and without an anchor", async () => {
+		expect((await run({json: true})).outcome.stdout).toBe(
+			'{"path":".patterns/worker-queue-retry.md","slug":"worker-queue-retry","title":"Worker queue retry","anchored":null}\n',
+		);
+		expect((await run({json: true, anchor: "acme-queue@4.2.0"})).outcome.stdout).toBe(
+			'{"path":".patterns/worker-queue-retry.md","slug":"worker-queue-retry","title":"Worker queue retry","anchored":"acme-queue@4.2.0"}\n',
+		);
+	});
+
+	it("writes the anchor line in the exact bytes pattern anchor parses", async () => {
+		const {written} = await run({anchor: "@nkzw/fate@1.3.1"});
+		const line = (written.get(".patterns/worker-queue-retry.md") ?? "")
+			.trimEnd()
+			.split("\n")
+			.at(-1);
+		expect(ANCHOR_DECLARATION.exec(line ?? "")?.[1]).toBe("@nkzw/fate@1.3.1");
+	});
+
+	// The writer and the reader of that line accept exactly the same strings.
+	it("refuses an --anchor that is not <pkg>@<version> as a usage error", async () => {
+		const {outcome, written} = await run({anchor: "acme-queue"});
+		expect(outcome.code).toBe(1);
+		expect(outcome.stderr.at(-1)).toBe(
+			'pattern new: --anchor "acme-queue" is not <pkg>@<version>.',
+		);
+		expect(written.size).toBe(0);
+	});
+
+	it("refuses a slug that is not kebab-case", async () => {
+		const {outcome} = await run({slug: "Worker Queue"});
+		expect(outcome.code).toBe(1);
+		expect(outcome.stdout).toBe("");
+	});
+
+	// A failed write is UNKNOWN, deliberately not 1: whether anything landed is exactly what a caller
+	// cannot tell, and seating it on 1 would fuse it with a broken binary.
+	it("reports a failed write as UNKNOWN rather than as a usage error", async () => {
+		const {outcome} = await run({}, {unwritable: [".patterns/worker-queue-retry.md"]});
+		expect(outcome.code).toBe(WRITE_UNKNOWN);
+		expect(outcome.code).not.toBe(1);
+		expect(outcome.stdout).toBe("");
+		expect(outcome.stderr.at(-1)).toContain("whether anything landed is UNKNOWN");
+	});
+
+	// A probe that could not RUN is not "absent": answering absent would license a write over a doc
+	// this verb never managed to look at.
+	it("refuses a probe it could not perform, and writes nothing", async () => {
+		const {outcome, written} = await run({}, {unprobeable: [".patterns/worker-queue-retry.md"]});
+		expect(outcome.code).toBe(PRECONDITION_UNKNOWN);
+		expect(written.size).toBe(0);
+	});
+
+	it("takes --title verbatim over the derivation", async () => {
+		const {written} = await run({title: "Fate (Effect) server"});
+		expect(
+			written.get(".patterns/worker-queue-retry.md")?.startsWith("# Fate (Effect) server\n"),
+		).toBe(true);
+	});
+});

--- a/packages/fabrika-cli/src/pattern/pattern.cli.test.ts
+++ b/packages/fabrika-cli/src/pattern/pattern.cli.test.ts
@@ -1,0 +1,52 @@
+/**
+ * The end-to-end half: the **exit status and the bytes on each channel** a shell caller reads.
+ *
+ * Only a subprocess proves those, and each `it` costs one cold node+TS load of `bin.ts` — so spawn
+ * count is this file's cost (`.patterns/subprocess-test-budget.md`). Two spawns, both about facts no
+ * in-process test can establish: that the group is reachable by its registration alone, and that a
+ * refusal really does leave stdout empty across the process boundary.
+ */
+import {execFileSync} from "node:child_process";
+import {fileURLToPath} from "node:url";
+import {describe, expect, it} from "vitest";
+import {SUBPROCESS_TEST_TIMEOUT_MS} from "../test-budget.ts";
+
+const BIN = fileURLToPath(new URL("../bin.ts", import.meta.url));
+
+interface Run {
+	readonly code: number;
+	readonly stdout: string;
+	readonly stderr: string;
+}
+
+/** `FABRIKA_SKIP_INFER` pins the invocation to this copy rather than whatever the repo root installs. */
+const fabrika = (args: ReadonlyArray<string>): Run => {
+	try {
+		const stdout = execFileSync(process.execPath, [BIN, ...args], {
+			encoding: "utf8",
+			env: {...process.env, FABRIKA_SKIP_INFER: "1"},
+			stdio: ["pipe", "pipe", "pipe"],
+		});
+		return {code: 0, stdout, stderr: ""};
+	} catch (err) {
+		const failure = err as {status?: number; stdout?: string; stderr?: string};
+		return {code: failure.status ?? -1, stdout: failure.stdout ?? "", stderr: failure.stderr ?? ""};
+	}
+};
+
+describe("fabrika pattern, end to end", {timeout: SUBPROCESS_TEST_TIMEOUT_MS}, () => {
+	it("lists all five verbs under --help by its registration alone", () => {
+		const run = fabrika(["pattern", "--help"]);
+		expect(run.code).toBe(0);
+		for (const verb of ["corpus", "drift", "anchor", "new", "register"]) {
+			expect(run.stdout).toContain(verb);
+		}
+	});
+
+	it("refuses a non-kebab-case slug on the usage seat with NOTHING on stdout", () => {
+		const run = fabrika(["pattern", "new", "Worker_Queue"]);
+		expect(run.code).toBe(1);
+		expect(run.stdout).toBe("");
+		expect(run.stderr).toContain("is not kebab-case");
+	});
+});

--- a/packages/fabrika-cli/src/pattern/register-verb.ts
+++ b/packages/fabrika-cli/src/pattern/register-verb.ts
@@ -1,0 +1,161 @@
+/**
+ * `pattern register` — the doc's row inserted into `<dir>/index.md` under a named section.
+ *
+ * It reads the index **from the working tree**, not from a base ref: this verb edits the tree, so it
+ * must read what it is about to write. That is the deliberate half of the group's two-reads split —
+ * `corpus`, `drift` and `anchor` answer what the repository already holds, `new` and `register`
+ * write what it is about to.
+ */
+import {Effect, type FileSystem, type Path, Result} from "effect";
+import {exists, readFile, writeFile} from "../io/fs.ts";
+import {answer, FAILED, refuse, type VerbOutcome} from "../verb.ts";
+import {
+	DOC_ABSENT,
+	INDEX_UNPARSEABLE,
+	MULTI_LINE_DIFF,
+	OFF_VOCABULARY,
+	PRECONDITION_UNKNOWN,
+	READBACK_MISMATCH,
+	SECTION_AMBIGUOUS,
+	WRITE_UNKNOWN,
+} from "./codes.ts";
+import {isKebabCase} from "./doc.ts";
+import {insertRow, readBackCarries} from "./register.ts";
+
+export interface RegisterOptions {
+	readonly slug: string;
+	readonly section: string;
+	readonly topic: string;
+	readonly readWhen: string;
+	readonly dir: string;
+	readonly json: boolean;
+}
+
+export const runRegister = (
+	options: RegisterOptions,
+): Effect.Effect<VerbOutcome, never, FileSystem.FileSystem | Path.Path> =>
+	Effect.gen(function* () {
+		const {slug, section, dir, json} = options;
+		if (!isKebabCase(slug)) {
+			return refuse(
+				FAILED,
+				`pattern register: slug "${slug}" is not kebab-case (lowercase letters, digits and single hyphens).`,
+			);
+		}
+
+		const root = dir.replace(/\/+$/, "");
+		const indexPath = `${root}/index.md`;
+		const docPath = `${root}/${slug}.md`;
+		// The two refusals name the doc as written and unregistered on purpose: `new` and `register`
+		// are separable precisely so a doc can land in a repo whose index is missing.
+		const unparseable = (why: string) =>
+			refuse(
+				INDEX_UNPARSEABLE,
+				`pattern register: ${indexPath} ${why} — the doc at ${docPath} is written and unregistered; front-door bootstraps the index.`,
+			);
+
+		const indexThere = yield* Effect.result(exists(indexPath));
+		if (Result.isFailure(indexThere)) {
+			return refuse(
+				PRECONDITION_UNKNOWN,
+				`pattern register: cannot check ${indexPath}: ${indexThere.failure.reason} — nothing was written.`,
+			);
+		}
+		if (!indexThere.success) return unparseable("is absent");
+
+		const indexText = yield* Effect.result(readFile(indexPath));
+		if (Result.isFailure(indexText)) {
+			return refuse(
+				PRECONDITION_UNKNOWN,
+				`pattern register: cannot read ${indexPath}: ${indexText.failure.reason} — nothing was written.`,
+			);
+		}
+
+		const docThere = yield* Effect.result(exists(docPath));
+		if (Result.isFailure(docThere)) {
+			return refuse(
+				PRECONDITION_UNKNOWN,
+				`pattern register: cannot check ${docPath}: ${docThere.failure.reason} — nothing was written.`,
+			);
+		}
+		if (!docThere.success) {
+			return refuse(
+				DOC_ABSENT,
+				`pattern register: no doc at ${docPath} — refusing to register a row pointing at nothing.`,
+			);
+		}
+
+		const outcome = insertRow(indexText.success, {
+			slug,
+			section,
+			topic: options.topic,
+			readWhen: options.readWhen,
+		});
+
+		if (outcome._tag === "NoTable") return unparseable("holds no parseable markdown table");
+		if (outcome._tag === "NoSection") {
+			// Never truncated: a caller correcting a flag needs the whole set, so the next invocation is
+			// a correction rather than a guess.
+			return refuse(
+				OFF_VOCABULARY,
+				`pattern register: no section "${section}" in ${indexPath} (present: ${outcome.present.join(", ")}).`,
+			);
+		}
+		if (outcome._tag === "Ambiguous") {
+			return refuse(
+				SECTION_AMBIGUOUS,
+				`pattern register: "${section}" matches ${outcome.count} headings in ${indexPath} — ambiguous, nothing written.`,
+			);
+		}
+		if (outcome._tag === "MultiLine") {
+			return refuse(
+				MULTI_LINE_DIFF,
+				`pattern register: insertion would have changed ${outcome.beyond} line(s) beyond the new row — aborted, nothing written.`,
+			);
+		}
+		if (outcome._tag === "Already") {
+			return answer(
+				json
+					? JSON.stringify({
+							outcome: "already",
+							path: indexPath,
+							slug,
+							section: outcome.section,
+							row: null,
+						})
+					: ["already", indexPath, outcome.section].join("\t"),
+				[`pattern register: ${indexPath} already links ${slug}.md — registering twice is a no-op.`],
+			);
+		}
+
+		const written = yield* Effect.result(writeFile(indexPath, outcome.text));
+		if (Result.isFailure(written)) {
+			return refuse(
+				WRITE_UNKNOWN,
+				`pattern register: cannot write ${indexPath}: ${written.failure.reason} — whether anything landed is UNKNOWN.`,
+			);
+		}
+
+		const back = yield* Effect.result(readFile(indexPath));
+		if (Result.isFailure(back) || !readBackCarries(back.success, slug, outcome.section)) {
+			return refuse(
+				READBACK_MISMATCH,
+				`pattern register: ${indexPath} was written and the read-back does not carry the row — the file needs a human.`,
+			);
+		}
+
+		return answer(
+			json
+				? JSON.stringify({
+						outcome: "inserted",
+						path: indexPath,
+						slug,
+						section: outcome.section,
+						row: outcome.row,
+					})
+				: ["inserted", indexPath, outcome.section].join("\t"),
+			[
+				`pattern register: inserted one row under "${outcome.section}" in ${indexPath}, proven to change no other line.`,
+			],
+		);
+	});

--- a/packages/fabrika-cli/src/pattern/register-verb.unit.test.ts
+++ b/packages/fabrika-cli/src/pattern/register-verb.unit.test.ts
@@ -1,0 +1,180 @@
+import {Effect} from "effect";
+import {describe, expect, it} from "vitest";
+import {type FakeFsOptions, fakeFs} from "../fakes.test-support.ts";
+import {
+	DOC_ABSENT,
+	INDEX_UNPARSEABLE,
+	OFF_VOCABULARY,
+	READBACK_MISMATCH,
+	SECTION_AMBIGUOUS,
+	WRITE_UNKNOWN,
+} from "./codes.ts";
+import {FIXTURES, THREE_SECTIONS_INDEX} from "./fixtures.test-support.ts";
+import {readBackCarries} from "./register.ts";
+import {runRegister} from "./register-verb.ts";
+
+const DIR = `${FIXTURES}/three-sections`;
+const INDEX = `${DIR}/index.md`;
+
+const options = {
+	slug: "cache-invalidation",
+	section: "Index — services",
+	topic: "Cache keys and invalidation order",
+	readWhen: "Touching a cached read",
+	dir: DIR,
+	json: false,
+};
+
+const tree = (extra: Readonly<Record<string, string | null>> = {}): FakeFsOptions => ({
+	files: {
+		[INDEX]: THREE_SECTIONS_INDEX,
+		[`${DIR}/cache-invalidation.md`]: "# Cache invalidation\n",
+		[`${DIR}/worker-queue-retry.md`]: "# Worker queue retry\n",
+		...extra,
+	},
+});
+
+const run = (opts: Partial<typeof options> = {}, fs: FakeFsOptions = tree()) => {
+	const fake = fakeFs(fs);
+	return Effect.runPromise(Effect.provide(runRegister({...options, ...opts}), fake.layer)).then(
+		(outcome) => ({outcome, written: fake.written}),
+	);
+};
+
+describe("runRegister", () => {
+	it("inserts one row under the named section and proves nothing else moved", async () => {
+		const {outcome, written} = await run({slug: "worker-queue-retry"});
+		expect(outcome.code).toBe(0);
+		expect(outcome.stdout).toBe(`inserted\t${INDEX}\tIndex — services\n`);
+		const after = written.get(INDEX) ?? "";
+		expect(after.split("\n").length).toBe(THREE_SECTIONS_INDEX.split("\n").length + 1);
+		expect(after).toContain(
+			"| [worker-queue-retry.md](./worker-queue-retry.md) | Cache keys and invalidation order | Touching a cached read |",
+		);
+		// The two tables this verb did not name survive verbatim.
+		expect(after).toContain(
+			"| [tracing-span-names.md](./tracing-span-names.md) | Span naming convention | Naming a new span |",
+		);
+	});
+
+	// The contract's second worked example, byte for byte. The `present:` list is EVERY section
+	// carrying a table, in document order, never truncated — a caller correcting a flag needs the
+	// whole set, so its next invocation is a correction rather than a guess.
+	it("names every section carrying a table when --section matches none", async () => {
+		const {outcome, written} = await run({
+			section: "Nonexistent Section",
+			topic: "x",
+			readWhen: "y",
+		});
+		expect(outcome.code).toBe(OFF_VOCABULARY);
+		expect(outcome.stdout).toBe("");
+		expect(outcome.stderr.at(-1)).toBe(
+			`pattern register: no section "Nonexistent Section" in ${INDEX} (present: Index — services, Index — edge, Index — observability).`,
+		);
+		expect(written.size).toBe(0);
+	});
+
+	// The contract's third worked example. Registering twice is a no-op, not an error.
+	it("answers `already` at exit 0 without writing when the row is there", async () => {
+		const {outcome, written} = await run();
+		expect(outcome.code).toBe(0);
+		expect(outcome.stdout).toBe(`already\t${INDEX}\tIndex — services\n`);
+		expect(written.size).toBe(0);
+	});
+
+	// The flag is right and the index is what needs disambiguating, so it is a different code from 10.
+	it("refuses a section name matching more than one heading", async () => {
+		const doubled = `${THREE_SECTIONS_INDEX}\n## Index — services\n\n| Doc | Topic | Read when |\n|---|---|---|\n| [x.md](./x.md) | a | b |\n`;
+		const {outcome, written} = await run({slug: "worker-queue-retry"}, tree({[INDEX]: doubled}));
+		expect(outcome.code).toBe(SECTION_AMBIGUOUS);
+		expect(outcome.stderr.at(-1)).toContain("matches 2 headings");
+		expect(written.size).toBe(0);
+	});
+
+	// The doc lands even when the index cannot take its row — which is why `new` and `register` are
+	// separable in the first place.
+	it("refuses an absent index while naming the doc as written and unregistered", async () => {
+		const {outcome} = await run({slug: "worker-queue-retry"}, tree({[INDEX]: null}));
+		expect(outcome.code).toBe(INDEX_UNPARSEABLE);
+		expect(outcome.stderr.at(-1)).toBe(
+			`pattern register: ${INDEX} is absent — the doc at ${DIR}/worker-queue-retry.md is written and unregistered; front-door bootstraps the index.`,
+		);
+	});
+
+	it("refuses an index holding no parseable table on the same code", async () => {
+		const {outcome} = await run(
+			{slug: "worker-queue-retry"},
+			tree({[INDEX]: "# Patterns\n\nNothing yet.\n"}),
+		);
+		expect(outcome.code).toBe(INDEX_UNPARSEABLE);
+		expect(outcome.stderr.at(-1)).toContain("holds no parseable markdown table");
+	});
+
+	// A row pointing at a file that does not exist is a dead link a link gate reds later and a reader
+	// hits sooner, so the target is proven first.
+	it("refuses to register a row pointing at nothing", async () => {
+		const {outcome, written} = await run(
+			{slug: "worker-queue-retry"},
+			tree({
+				[`${DIR}/worker-queue-retry.md`]: null,
+			}),
+		);
+		expect(outcome.code).toBe(DOC_ABSENT);
+		expect(outcome.stderr.at(-1)).toBe(
+			`pattern register: no doc at ${DIR}/worker-queue-retry.md — refusing to register a row pointing at nothing.`,
+		);
+		expect(written.size).toBe(0);
+	});
+
+	it("reports a failed write as UNKNOWN rather than as a usage error", async () => {
+		const {outcome} = await run(
+			{slug: "worker-queue-retry"},
+			{
+				...tree(),
+				unwritable: [INDEX],
+			},
+		);
+		expect(outcome.code).toBe(WRITE_UNKNOWN);
+		expect(outcome.code).not.toBe(1);
+		expect(outcome.stdout).toBe("");
+	});
+
+	it("emits the same facts through --json", async () => {
+		const {outcome} = await run({slug: "worker-queue-retry", json: true});
+		expect(JSON.parse(outcome.stdout)).toEqual({
+			outcome: "inserted",
+			path: INDEX,
+			slug: "worker-queue-retry",
+			section: "Index — services",
+			row: "| [worker-queue-retry.md](./worker-queue-retry.md) | Cache keys and invalidation order | Touching a cached read |",
+		});
+	});
+
+	it("refuses a slug that is not kebab-case", async () => {
+		const {outcome, written} = await run({slug: "Worker Queue"});
+		expect(outcome.code).toBe(1);
+		expect(written.size).toBe(0);
+	});
+});
+
+/**
+ * The read-back's own predicate, asserted directly.
+ *
+ * `fakeFs` stores exactly what it is handed, so a write that lands somewhere else cannot be scripted
+ * through it — the state the `9` branch fires on is unreachable at this seam. The property is
+ * therefore asserted where it IS decidable: over {@link readBackCarries}, the predicate the branch
+ * consults, plus the seat's distinctness from the write's. A write that landed and does not match is
+ * an artifact that exists and needs a human, which is neither a success nor a failed write.
+ */
+describe("the read-back is not decorative", () => {
+	it("is false for a row that is not under the section it claims", () => {
+		expect(readBackCarries(THREE_SECTIONS_INDEX, "cache-invalidation", "Index — edge")).toBe(false);
+		expect(readBackCarries(THREE_SECTIONS_INDEX, "cache-invalidation", "Index — services")).toBe(
+			true,
+		);
+	});
+
+	it("seats a mismatch on its own code, never on the write's", () => {
+		expect(READBACK_MISMATCH).not.toBe(WRITE_UNKNOWN);
+	});
+});

--- a/packages/fabrika-cli/src/pattern/register.ts
+++ b/packages/fabrika-cli/src/pattern/register.ts
@@ -1,0 +1,96 @@
+/**
+ * One row inserted into a hand-curated index, and the proof that nothing else moved.
+ *
+ * **The diff fence is the load-bearing step, and it exists because of who else edits this file.**
+ * `.patterns/index.md` carries prose between its tables and is edited by lanes this verb cannot see,
+ * so an insertion that reflowed a table, normalised a pipe or rewrote a neighbouring row would
+ * destroy work with no diff small enough for a reviewer to notice. {@link linesChangedBeyond} makes
+ * that rule mechanical rather than remembered.
+ */
+import {composeRow, type ParsedIndex, parseIndex, tableSections} from "./index-table.ts";
+
+export type InsertOutcome =
+	| {
+			readonly _tag: "Inserted";
+			readonly text: string;
+			readonly row: string;
+			readonly section: string;
+	  }
+	/** A row already links the doc. Registering twice is a no-op, not an error. */
+	| {readonly _tag: "Already"; readonly section: string}
+	| {readonly _tag: "NoTable"}
+	| {readonly _tag: "NoSection"; readonly present: ReadonlyArray<string>}
+	| {readonly _tag: "Ambiguous"; readonly count: number}
+	| {readonly _tag: "MultiLine"; readonly beyond: number};
+
+export interface InsertRequest {
+	readonly slug: string;
+	readonly section: string;
+	readonly topic: string;
+	readonly readWhen: string;
+}
+
+/**
+ * How many lines the edit changed **beyond** the one row it claims to have added.
+ *
+ * The check is over the whole file, both directions: a length delta other than `+1`, or any line
+ * outside the inserted position that does not survive byte-identically, counts here. `0` is the only
+ * value that licenses a write.
+ */
+export const linesChangedBeyond = (before: string, after: string, insertedAt: number): number => {
+	const from = before.split("\n");
+	const to = after.split("\n");
+	if (to.length !== from.length + 1) return Math.abs(to.length - from.length - 1) + from.length;
+	const without = [...to.slice(0, insertedAt), ...to.slice(insertedAt + 1)];
+	let beyond = 0;
+	for (const [at, line] of from.entries()) if (without[at] !== line) beyond += 1;
+	return beyond;
+};
+
+/** Where a section's insertion goes: after its last table row, before the next heading. */
+const insertionPoint = (index: ParsedIndex, headingLine: number): number | null => {
+	const section = index.sections.find((s) => s.headingLine === headingLine);
+	return section?.lastRowLine === undefined || section.lastRowLine === null
+		? null
+		: section.lastRowLine + 1;
+};
+
+/**
+ * Insert the row, in the contract's order: parse, locate, no-op, insert, prove.
+ *
+ * The doc's own existence is **not** checked here — it is a filesystem fact the verb proves before
+ * calling, so that a row pointing at nothing is refused before any of this runs.
+ */
+export const insertRow = (text: string, request: InsertRequest): InsertOutcome => {
+	const index = parseIndex(text);
+	if (!index.hasTable) return {_tag: "NoTable"};
+
+	const matches = index.sections.filter(
+		(s) => s.headingLine !== -1 && s.heading === request.section,
+	);
+	if (matches.length === 0) return {_tag: "NoSection", present: tableSections(index)};
+	if (matches.length > 1) return {_tag: "Ambiguous", count: matches.length};
+
+	const existing = index.rows.find((row) => row.member === `${request.slug}.md`);
+	if (existing !== undefined) return {_tag: "Already", section: existing.section};
+
+	const heading = matches[0];
+	if (heading === undefined) return {_tag: "NoSection", present: tableSections(index)};
+	const at = insertionPoint(index, heading.headingLine);
+	if (at === null) return {_tag: "NoSection", present: tableSections(index)};
+
+	const row = composeRow(request.slug, request.topic, request.readWhen);
+	const lines = text.split("\n");
+	const next = [...lines.slice(0, at), row, ...lines.slice(at)].join("\n");
+
+	const beyond = linesChangedBeyond(text, next, at);
+	if (beyond > 0) return {_tag: "MultiLine", beyond};
+
+	return {_tag: "Inserted", text: next, row, section: heading.heading};
+};
+
+/** Whether a written-back index carries the row under the section, parsed to the same cells. */
+export const readBackCarries = (text: string, slug: string, section: string): boolean => {
+	const index = parseIndex(text);
+	return index.rows.some((row) => row.member === `${slug}.md` && row.section === section);
+};

--- a/packages/fabrika-cli/src/pattern/register.unit.test.ts
+++ b/packages/fabrika-cli/src/pattern/register.unit.test.ts
@@ -1,0 +1,99 @@
+import {describe, expect, it} from "vitest";
+import {insertRow, linesChangedBeyond, readBackCarries} from "./register.ts";
+
+const INDEX = `# Patterns
+
+Prose between the tables, which no insertion may touch.
+
+## Index — services
+
+| Doc | Topic | Read when |
+|---|---|---|
+| [cache-invalidation.md](./cache-invalidation.md) | Cache keys | Touching a cached read |
+
+## Index — edge
+
+| Doc | Topic | Read when |
+|---|---|---|
+| [edge-session-cookies.md](./edge-session-cookies.md) | Session cookies | Changing session handling |
+`;
+
+const request = {
+	slug: "worker-queue-retry",
+	section: "Index — services",
+	topic: "Retry and backoff",
+	readWhen: "Adding a queue consumer",
+};
+
+describe("linesChangedBeyond", () => {
+	it("is 0 for an insertion that adds exactly one line", () => {
+		expect(linesChangedBeyond("a\nb\nc", "a\nNEW\nb\nc", 1)).toBe(0);
+	});
+
+	it("counts a neighbouring line that was rewritten alongside the insertion", () => {
+		expect(linesChangedBeyond("a\nb\nc", "a\nNEW\nB\nc", 1)).toBe(1);
+	});
+
+	it("counts a deletion, which is not an insertion at all", () => {
+		expect(linesChangedBeyond("a\nb\nc", "a\nNEW\nc", 1)).toBeGreaterThan(0);
+	});
+});
+
+describe("insertRow", () => {
+	it("inserts after the section's last row and leaves every other line byte-identical", () => {
+		const out = insertRow(INDEX, request);
+		if (out._tag !== "Inserted") throw new Error(`expected Inserted, got ${out._tag}`);
+		expect(out.section).toBe("Index — services");
+		expect(out.row).toBe(
+			"| [worker-queue-retry.md](./worker-queue-retry.md) | Retry and backoff | Adding a queue consumer |",
+		);
+		// The prose and the second table survive verbatim: only one line was added.
+		expect(out.text.split("\n").length).toBe(INDEX.split("\n").length + 1);
+		expect(out.text).toContain("Prose between the tables, which no insertion may touch.");
+		expect(out.text).toContain(
+			"| [edge-session-cookies.md](./edge-session-cookies.md) | Session cookies | Changing session handling |",
+		);
+	});
+
+	it("places the row under the NAMED section, not the first one", () => {
+		const out = insertRow(INDEX, {...request, section: "Index — edge"});
+		if (out._tag !== "Inserted") throw new Error(`expected Inserted, got ${out._tag}`);
+		expect(readBackCarries(out.text, "worker-queue-retry", "Index — edge")).toBe(true);
+		expect(readBackCarries(out.text, "worker-queue-retry", "Index — services")).toBe(false);
+	});
+
+	it("is a no-op when a row already links the doc — registering twice is not an error", () => {
+		expect(insertRow(INDEX, {...request, slug: "cache-invalidation"})).toEqual({
+			_tag: "Already",
+			section: "Index — services",
+		});
+	});
+
+	// Never truncated: a caller correcting a flag needs the whole set, so the next invocation is a
+	// correction rather than a guess.
+	it("names every section carrying a table when the flag names none of them", () => {
+		expect(insertRow(INDEX, {...request, section: "Nonexistent Section"})).toEqual({
+			_tag: "NoSection",
+			present: ["Index — services", "Index — edge"],
+		});
+	});
+
+	// A different fact with a different remedy: the flag is right and the index needs disambiguating.
+	it("refuses an ambiguous section rather than picking one", () => {
+		const doubled = `${INDEX}\n## Index — services\n\n| Doc | Topic | Read when |\n|---|---|---|\n| [x.md](./x.md) | a | b |\n`;
+		expect(insertRow(doubled, request)).toEqual({_tag: "Ambiguous", count: 2});
+	});
+
+	it("reports a document holding no table rather than inventing one", () => {
+		expect(insertRow("# Patterns\n\nNothing yet.\n", request)).toEqual({_tag: "NoTable"});
+	});
+});
+
+describe("readBackCarries", () => {
+	it("is false when the row landed under another section", () => {
+		const out = insertRow(INDEX, request);
+		if (out._tag !== "Inserted") throw new Error(`expected Inserted, got ${out._tag}`);
+		expect(readBackCarries(out.text, "worker-queue-retry", "Index — services")).toBe(true);
+		expect(readBackCarries(out.text, "no-such-doc", "Index — services")).toBe(false);
+	});
+});

--- a/packages/fabrika-cli/src/registry.ts
+++ b/packages/fabrika-cli/src/registry.ts
@@ -26,6 +26,7 @@ import {handoffCommand} from "./handoff/command.ts";
 import {hookCommand} from "./hook/command.ts";
 import {ledgerCommand} from "./ledger/command.ts";
 import {mapCommand} from "./map/command.ts";
+import {patternCommand} from "./pattern/command.ts";
 import {planCommand} from "./plan/command.ts";
 import {reportCommand} from "./report/command.ts";
 import {reviewCommand} from "./review/command.ts";
@@ -54,6 +55,7 @@ export const registeredGroups: ReadonlyArray<VerbGroup> = [
 	hookCommand,
 	ledgerCommand,
 	mapCommand,
+	patternCommand,
 	planCommand,
 	reportCommand,
 	reviewCommand,


### PR DESCRIPTION
Fixes #5332

Builds the `pattern` verb group the `write-pattern` skill's derived CLI contract specifies —
`corpus`, `drift`, `anchor`, `new`, `register` — plus `pattern/codes.ts` and the two registration
rows the coverage guard needs.

## What landed

`packages/fabrika-cli/src/pattern/`, in the shape the five sibling groups that landed today use: a
pure core per concern with a `*.unit.test.ts` beside it, a thin `<verb>-verb.ts` entry per verb, one
`command.ts` adapter whose leaves are all `leafCommand`, and one group exit table.

| Verb | Answers |
|---|---|
| `pattern corpus` | the library at a base ref: every doc, its registration, its section, its last-touching commit |
| `pattern drift` | whether the in-repo source a doc cites moved since the doc was last written |
| `pattern anchor` | whether the dependency version a doc declares still matches what the workspace pins |
| `pattern new` | scaffolds `<dir>/<slug>.md` from the canonical template |
| `pattern register` | inserts the doc's row into `<dir>/index.md` under a named section |

Four properties the diff is built around:

- **Presence is probed, never inferred from a failure.** `git ls-tree --name-only <sha> -- <path>`
  exits `0` whether or not the path is there, so `corpus` can answer `absent` at exit `0` *and*
  still refuse `11` on a read it could not perform. `src/pattern/git.unit.test.ts` pins both
  directions.
- **Every outcome exits `0`, and `7` stays unseated.** No verb here judges over a corpus, so none
  has a vacuous pass to prevent; an empty or absent doc directory is a fact, and refusing there
  would leave a repo adopting fabrika unable to write its first pattern doc (#5254).
- **`unanchored` is expressed in vocabulary, not in an exit code.** It says the doc cites nothing
  the verb can follow — unanswerable, not clean. A verb that refused would break the pipe its
  answer crosses.
- **`register` proves its diff before it writes.** Any change beyond the inserted row aborts on
  `14` with nothing written, and the row is read back after.

## Exit table

The four shared seats are **imported** from `build/codes.ts` under aliases — never restated as
numerals — so a drift is unrepresentable rather than merely detectable. `12`–`16` are the group's
own facts.

| Code | Constant | Source | Meaning |
|---|---|---|---|
| `8` | `WRITE_UNKNOWN` | imported | the write failed, so whether anything landed is UNKNOWN |
| `9` | `READBACK_MISMATCH` | imported | the write landed and the read-back does not match |
| `10` | `OFF_VOCABULARY` | imported (base's `CLASSIFIED`) | a value outside a closed set — here, the index's section names |
| `11` | `PRECONDITION_UNKNOWN` | imported | a precondition read failed, nothing was written |
| `12` | `DOC_ABSENT` | private | proven: the named slug has no doc file |
| `13` | `ALREADY_EXISTS` | private | proven: the target path already exists — refused, never overwritten |
| `14` | `MULTI_LINE_DIFF` | private | the edit would have changed a line beyond the one row |
| `15` | `INDEX_UNPARSEABLE` | private | proven: the index is absent, or holds no parseable table |
| `16` | `SECTION_AMBIGUOUS` | private | proven: the section name matches more than one heading |

`3`–`7` are deliberate gaps, each for the reason the contract states; `7` above all. `1` and `127`
keep their reserved meaning — the call never decided. Every proven verdict is `3`+ with empty stdout
(`refuse()` hardcodes that, so a non-zero exit carrying a payload is not constructible).

`src/pattern/codes.unit.test.ts` asserts the shared seats **against the base's own exports** rather
than against numerals, asserts the five private codes clear the base's whole table, asserts no verb
module seats a code of its own (#5294), and asserts `3`–`7` stay empty.

## Shared registration files — every edit a pure insertion

`git diff --numstat` over the four shared files, **zero deleted lines** across all of them:

```
50	0	packages/fabrika-cli/README.md
19	0	packages/fabrika-cli/src/exit-code-alignment.ts
2	0	packages/fabrika-cli/src/exit-code-alignment.unit.test.ts
2	0	packages/fabrika-cli/src/registry.ts
```

- `src/registry.ts` — one import, one array entry, both alphabetical.
- `src/exit-code-alignment.ts` — `PATTERN_SEATS` (four seats) plus one `ALIGNED_GROUPS` row.
- `src/exit-code-alignment.unit.test.ts` — one import, one `TABLES` row.
- `README.md` — a new `## The pattern group` section inserted ahead of `## The wire group`. No
  existing prose reflowed or rewritten.
- **No wire format is registered**, because the contract rules one out: the group emits no verdict
  marker, joins no gate or ship namespace, needs no repository token and writes to no board surface.
  `fabrika wire index --write` was run anyway to prove the generated region is untouched — it
  reported `index written 8 8` and left a **zero diff**.

## Verification

- `pnpm typecheck` **in-package** (`packages/fabrika-cli`, never `tsgo -p tsconfig.json` from the
  repo root — #5312): clean.
- `pnpm test` in-package: 257 files, 3670 tests, all passing. 121 of them are this group's.
- `pnpm biome check --write` over every touched path.
- The contract's worked examples are reproduced byte for byte in the verb tests — see the first
  Deviation for how, and for the one thing that could not be executed.
- **(repair round 1)** Re-run after the rebase onto `d4f7a708`: in-package `pnpm typecheck` clean,
  in-package `pnpm test` **271 files, 3834 tests, all passing**, `pnpm lint:worktree` clean. The
  counts above rose because `governance` (#5351) and `write-pattern` (#5333) landed underneath this
  branch; they are left standing as what round 0 measured.

## Deviations

**1. The contract is not on `main`, and this was built against PR #5333's head.** The dispatch brief
called it "the landed pattern contract"; it is not landed. `claude-plugins/fabrika/skills/write-pattern/`
does not exist on `origin/main` — the skill, the contract and its fixtures live only on the open,
un-gated PR #5333 (head `b447e0f8`). Issue #5332 says so itself and sequences this work behind that
merge. This diff was built against that head and touches **no** file PR #5333 touches, so the two
cannot conflict in either merge order. Surfaced as a comment on #5332 rather than resolved here.

**2. The "reproduce byte-for-byte against the committed fixtures" criterion is UNREACHABLE today,
and that is proven by execution, not asserted.** The fixture files are not in any tree this branch
can read:

```
$ git show origin/main:claude-plugins/fabrika/skills/write-pattern/evals/fixtures/anchored/workspace.yaml
fatal: path '.../workspace.yaml' does not exist in 'origin/main'
```

The conservative branch was taken: the fixtures' **bytes** are committed to
`src/pattern/fixtures.test-support.ts` (lifted verbatim from PR #5333's head) and scripted onto the
same `git show` seam production reads, so all eleven worked examples are asserted byte for byte
through the real code path — the `corpus` `none`/`absent`/`--json` trio, the `drift` `unanchored`
pair and its `12` refusal, the `anchor` `moved`/`unanchored`/`--json` trio, the four `new` examples
and the three `register` examples. What is *not* done is a run against the committed fixture files
on disk; that becomes possible once #5333 merges. The fixtures were **not** copied into this branch,
which would duplicate PR #5333's own files.

> **Two claims in the entry above are false and are corrected by Deviation 11 (repair round 1) —
> read that before relying on this one.** "lifted verbatim from PR #5333's head" was not true of
> `PLAIN_DOC`, and "eleven worked examples" undercounts the sixteen the same sentence enumerates.
> The entry is left standing unedited because `## Deviations` is this PR's whole-life log.

**3. The README cites the contract by PR URL, not by a relative markdown link.** Every sibling group
links its contract relatively. A relative link to a file that is not yet on `main` reds the
`doc-links` job (`lychee --offline`, fail-closed on zero scope), so the section names the in-repo
path in backticks and links PR #5333 instead — `--offline` does not resolve remote URLs. Worth
linkifying in a follow-up once #5333 lands.

**4. Four refusal messages the contract's exit tables imply but its Errors tables do not spell out.**
`pattern drift`'s and `pattern anchor`'s exit tables both list `11` for "the tree could not be read",
and `pattern new` / `pattern register` can both fail an existence probe; none of those four has a
message row. Each is emitted in the shape of the neighbouring rows the contract *does* give
(`… — the outcome is UNKNOWN, never "current".` / `… never "matched".` / `… — nothing was
written.`). No new exit code was invented: `11` is the shared matrix's, which the contract states is
group-wide.

**5. `pattern register`'s `present:` list is every section carrying a table.** The contract's prose
says "names every section heading that does exist"; its own worked example prints exactly the three
heading-with-table sections and omits the `# Patterns` H1. The example was treated as the binding
reading. Not truncated, in document order.

**6. `already` reports the section the existing row actually sits under**, which the contract leaves
open (its example passes the same section the row is already in, so both readings print the same
bytes). The existing row's section is the more informative of the two, and the `--section` mismatch
case is already refused on `10` at the earlier step.

**7. `parseCatalog` is a bounded top-level scanner, not a general YAML parser.** The package's deps
are `catalog:`-pinned and carry no YAML library, and adding one for a `catalog:` map read would be a
new dependency for a fixed-shape read. It resolves the top-level `catalog:` block's `key: value`
entries (quotes stripped) and refuses — `11`, UNKNOWN, never `unpinned` — on tab indentation (which
YAML forbids) and on a catalog entry that is not a key/value pair. A manifest that is absent, or
that parses and carries no `catalog:` map, is the degrade path at exit `0` as specified.

**8. Tier-M, class 5 — one hit, and it is the known false positive.** The scan's bare `xit(`
alternative matches inside `process.exit(outcome.code)` in `src/pattern/command.ts`. That line is
the group's emit adapter and is byte-identical to the same line in every sibling group's
`command.ts`. It is not a skipped test: this branch adds **no** `.skip(`, `.only(`, `xit(`,
`xdescribe(`, `biome-ignore`, `eslint-disable`, `@ts-expect-error` or `@ts-ignore`. Class 6 is
clean — no assertion line is removed anywhere in the diff, and no test file is deleted.

**9. `pattern register`'s `9 READBACK_MISMATCH` branch is asserted at its predicate, not through the
filesystem seam.** `fakeFs` stores exactly the bytes it is handed, so "the write landed somewhere
else" is not a state that seam can be put into — the branch is unreachable through it by
construction. `readBackCarries` (the predicate the branch consults) is asserted directly in both
directions, and the seat's distinctness from `8` is asserted, with the limitation stated in the test
file rather than left for a reader to discover.

**10. `pattern drift` extracts candidates from fenced code blocks too.** The contract says "every
backticked span" with no fence carve-out, so that is what is implemented. It is harmless in
practice: a candidate must be one whitespace-free token, must open with a top-level segment read
from the tree, and an unresolved one is never a finding — three filters a fence's contents almost
never clear. Called out because it is a literal reading of a line that could have meant inline spans
only.

**11. (repair round 1) Deviation 2 stated a false provenance, and one committed constant really was
wrong.** `PLAIN_DOC` was **93 bytes written from memory**, not the **179 bytes** of
`claude-plugins/fabrika/skills/write-pattern/evals/fixtures/anchored/plain-doc.md`. So "lifted
verbatim from PR #5333's head" was true of four constants and false of the fifth, and the section a
reader trusts most would have carried them past the defect. Nothing caught it because nothing could:
`pattern anchor` answers `unanchored` against either text, so the worked example passed while
asserting bytes the fixture never held — silent by construction. `PLAIN_DOC` now carries the real
bytes.

All five constants were then re-verified **byte-for-byte, by execution rather than by eye**: each
was compared as a `Buffer` against `git show <sha>:<path>` output at PR #5333's head `244590eb`,
asserting equal length **and** equal SHA-256 — `ANCHORED_DOC` 339B, `PLAIN_DOC` 179B,
`FIXTURE_MANIFEST` 127B, `UNANCHORED_DOC` 439B, `THREE_SECTIONS_INDEX` 637B, five of five equal, and
the same five equal again at `origin/main`.

Deviation 2's count is also wrong in the same paragraph: it says "eleven worked examples" and then
enumerates 3+3+3+4+3 = **sixteen**. Sixteen is the correct number.

**How the copy gets reconciled: PR #5333 has now merged** (`d4f7a708`, 2026-08-10T19:07:35Z — 25
seconds after the FAIL verdict was written), and this branch is rebased onto it, so the fixture files
are in this tree and the byte-for-byte criterion is reachable against the real files for the first
time. Re-pointing these tests at those files and deleting the copy is the change that removes the
silent-drift surface for good; it is deliberately **not** taken in this round, which is scoped to the
verdict's two `[FAIL]` rows, and is left as the follow-up the verdict asked for. Until it lands, the
committed copy is unguarded duplication — the honest statement of its status, replacing the
"UNREACHABLE today" framing that was true when Deviation 2 was written and is not true now.

**12. (repair round 1) Rebased onto `d4f7a708` and resolved a two-lane conflict as a union.** The PR
was `CONFLICTING`/`DIRTY`: `governance` (#5199 / PR #5351) and `write-pattern` (PR #5333) both landed
after this branch point, and `governance` appended to the same four shared registration files. Both
lanes are pure insertions, so both sides were kept whole — `GOVERNANCE_SEATS` and `PATTERN_SEATS`
both present in `exit-code-alignment.ts`, both rows in `ALIGNED_GROUPS`, both in `registry.ts` and in
the test `TABLES` map, both README sections. `git diff --numstat origin/main...HEAD` over the four
shared files is again `50/0`, `19/0`, `2/0`, `2/0` — **zero deleted lines**, unchanged from round 0,
which is the proof nothing from either lane was dropped. A dropped registration compiles fine and
fails silently, so it is asserted rather than eyeballed: `fabrika --help` lists both groups and
`ALIGNED_GROUPS` has 20 rows including both.

**13. (repair round 1) Three findings the verdict raised were deliberately not fixed here.**
`parseCatalog`'s two wrong-answer shapes (an inline flow map answering `unpinned` when the truth is
`moved`; a nested sub-map answering `moved` with an empty pin when the truth is `unpinned`) and
`register`'s read-back-failure message are real but were ruled non-blocking, and the README's
contract link is now relinkable since #5333 landed. All three are being filed as their own tickets
rather than widened into this repair round.




**14. (repair round 2) The CodeQL escaping finding was fixed rather than carried as a nit, and the
splitter had to move with the escaper.** Round 1 recorded the finding on
`packages/fabrika-cli/src/pattern/index-table.ts:142` (*Incomplete string escaping or encoding*) as
non-blocking prose and discharged it in neither artifact the merge-ready guard reads — so `CodeQL`
and `check no unaccounted unresolved review thread reaches merge-ready` were both red at `6389056`
and the guard correctly held the PR. The finding is real: `cellText` escaped `|` but not `\`, so a
cell carrying a backslash-pipe sequence emitted an unescaped pipe and a three-cell row rendered as
**four**.

The fix is a **port, not a second derivation**. `escapeCell` / `splitCells` in
`packages/fabrika-cli/src/glossary/register.ts` (landed by PR #5357) is the proven implementation of
the identical bug in the identical class, so its shape was taken verbatim: escape `\` → `\\`
**first**, then `|` → `\|`, with the splitter consuming both arms in one left-to-right pass so it is
the exact inverse.

**The deviation worth naming is that `rowCells` changed too, which is more than the finding
literally asked for.** CodeQL flagged only the escaper. But the old splitter's `split(/(?<!\\)\|/)`
lookbehind *mirrored* the escaper's bug, so the pair round-tripped **itself** while a markdown
renderer disagreed — fixing only `cellText` would have broken that self-consistency and produced
rows the CLI could no longer read back. The old splitter was independently wrong on a hand-authored
`| a\\ | b | c |`, returning the first cell as `a\\` where the correct unescape is `a\`. Both sides
therefore moved, and the local `unescapeCell` helper is gone (subsumed by the pass).

**Proof is by execution, and deliberately not through the splitter alone** — that is exactly what
let the old pair look correct. Twelve adversarial cells are asserted through compose → split:
trailing backslash, lone backslash, doubled backslash, escaped-pipe-then-backslash,
escaped-backslash-then-pipe, pre-escaped `\|`, `\\|`, pipe-only, trailing bare pipe, embedded pipe,
the empty cell, and plain. **12/12 round-trip, zero failures.** Against the pre-fix pair, the cell
`escaped pipe then backslash \|\` composed a row that renders as **4 cells** by GFM's
odd-backslash-run rule and renders as **3** after the fix.

**15. (repair round 2) This round was opened by red CI checks, not by a gate FAIL marker.** All three
verdict namespaces resolve clean at the prior head (`CODE_FAIL=0`, `DOC_FAIL=0`, `SKILL_FAIL=0`), so
the skill's Step R1 would read this PR as "nothing to repair". The two reds were verified first-party
against `GET /commits/<sha>/check-runs` before any edit was made. Recorded because the repair
protocol's normal trigger did not fire and a reader checking the marker stream will find no FAIL to
explain this round.

**16. (repair round 2) The share-vs-duplicate question is left open on purpose.** Two modules now
implement the same escape rule with two copies of the same code. #5364 tracks both this defect and
that divergence; this round closes the defect half only. Collapsing the two onto one shared helper
changes a shipped module (`glossary`) that this issue's no-gos put out of scope, so it is a triage
call, not a repair-round call. Nothing else moved this round: the five fixture-byte constants, the
exit table, the `11` seating on `new` / `register` and the fixture-bytes strategy all stand
untouched, and `parseCatalog` (#5361), the README's contract link and re-pointing the fixtures at the
real files (#5362) remain out of scope. Two files changed, both under
`packages/fabrika-cli/src/pattern/`.
