### PR TITLE
feat(fabrika): implement the six `glossary` verbs and register the group (#5322)

### DIFF
--- a/packages/fabrika-cli/README.md
+++ b/packages/fabrika-cli/README.md
@@ -515,6 +515,53 @@ This group applies no label, closes nothing, opens no pull request, emits no ver
 pushes nothing. Nothing it records can block a merge — a session state that gated one would make
 every interrupted session a blocked one.
 
+## The `glossary` group
+
+The contract is
+[`claude-plugins/fabrika/skills/glossary/contract.md`](../../claude-plugins/fabrika/skills/glossary/contract.md).
+A **register** is one of the two markdown files the repo's canonical vocabulary lives in —
+`.glossary/TERMS.md` for the domain nouns and `.glossary/LANGUAGE.md` for the architecture
+vocabulary — and every verb here resolves it against the **target** repo's root, never against the
+installed plugin.
+
+| Verb | Answers |
+|---|---|
+| `glossary init` | creates a register that does not exist, so a fresh repo is not a dead end |
+| `glossary drift` | the surfaces that moved since a register last changed, and the candidate coinages in them |
+| `glossary lookup` | whether a term is already declared, and what overlaps it |
+| `glossary sections` | the live section names of a register, and each one's row count |
+| `glossary add` | inserts or replaces one row, alphabetically placed and byte-preserving elsewhere |
+| `glossary check` | row-shape, duplicate-key, cross-register, ordering and citation-liveness defects |
+
+Five properties are worth knowing before you call them:
+
+- **Absent and present-and-empty are different facts and never share a code.** An absent register
+  is `bootstrap` on exit `0` — day one in an adopting repo
+  ([#4776](https://github.com/kamp-us/phoenix/issues/4776)) — while a register that is present and
+  holds zero rows reds `check` on `7`, because a scan of nothing must never report `clean`
+  (ADR [0092](../../.decisions/0092-gates-fail-closed-on-zero-scope.md)). A register that could not
+  be *read* is `11` throughout.
+- **The whole first cell is one key.** `Database (tag)` and `tag` are different terms that
+  *overlap*; a parenthetical is a disambiguating qualifier, not an alias, and splitting one produced
+  three false duplicates the last time it was tried
+  ([#4206](https://github.com/kamp-us/phoenix/issues/4206)). `lookup` reports the overlap and leaves
+  the judgement to the skill.
+- **`add` changes one line and proves it.** It asserts the composed text differs from the original in
+  exactly its own splice before writing (`15` aborts with nothing written), then re-reads the row
+  that landed and refuses on `9` when it is not what was composed — a different fact from a write
+  that failed, which is `8`.
+- **Suppression is equality on the normalized key.** v1 suppressed a drift candidate when a declared
+  term contained it *or* it contained a declared term, which against a 226-row register measured
+  about 10% precision ([#4481](https://github.com/kamp-us/phoenix/issues/4481)). And the tokenizer is
+  Unicode-classed rather than ASCII, so the Turkish product nouns the glossary exists for are visible
+  at all.
+- **Two defect classes are deliberately not computed.** Machine-local paths in a register and dead
+  internal links are each decided by a merge-blocking gate, so `check` states the expectation and
+  leaves the verdict where it is enforced — a second answer could report `clean` while the gate reds.
+  Exit seats `5` and `6` are held empty for exactly that reason rather than left unallocated.
+
+This group reaches no network and touches no GitHub artifact: every read is the local tree. It gates
+no merge and emits no verdict, so it registers in no verdict namespace and no wire format.
 ## The `governance` group
 
 The contract is

--- a/packages/fabrika-cli/src/adr/sweep.ts
+++ b/packages/fabrika-cli/src/adr/sweep.ts
@@ -53,8 +53,12 @@ export interface SweepResult {
 /**
  * A plain English stopword list. Repo-generic jargon needs no list — a term every record uses
  * has an inverse document frequency near zero and contributes nothing to a score on its own.
+ *
+ * Exported because `../glossary/candidates.ts` filters against the same set: two term-extraction
+ * surfaces that each carried their own copy would drift apart. It imports **this and nothing else**
+ * — {@link tokenize} beside it is ASCII-only, which is the defect the drift verb exists to avoid.
  */
-const STOPWORDS = new Set(
+export const STOPWORDS = new Set(
 	`a about above after again against all also although always am an and any are as at be because
 	been before being below between both but by can cannot could did do does doing done down during
 	each either else even ever every few for from further had has have having her here hers him his

--- a/packages/fabrika-cli/src/exit-code-alignment.ts
+++ b/packages/fabrika-cli/src/exit-code-alignment.ts
@@ -127,6 +127,20 @@ export const GRILL_SEATS: SharedSeats = {
 export const HANDOFF_SEATS: SharedSeats = GRILL_SEATS;
 
 /**
+ * `glossary`'s seats: `build`'s nine minus the two leak seats.
+ *
+ * The group deliberately claims neither `5` nor `6`: machine-local paths in a register are decided by
+ * the merge-blocking leak gate over changed markdown, and dead internal links by the repo-wide link
+ * gate, and a second answer here could report clean while one of those reds. `5` carries
+ * {@link GAP_EXPORT} in the group's table and `6` is held by prose alone, so the private-code check
+ * reads both as occupied by the base.
+ */
+export const GLOSSARY_SEATS: SharedSeats = (() => {
+	const {LEAKED_PATH: _leak, BARE_AT_PATH: _bare, ...rest} = BUILD_SEATS;
+	return rest;
+})();
+
+/**
  * `hook`'s seats: one. It shares only `EMPTY_STDIN` — the same fact, an fd 0 read that held nothing
  * — and everything else it speaks is about a harness envelope rather than about a write, so its two
  * private codes sit above the base's whole table instead of claiming a seat in it.
@@ -217,6 +231,7 @@ export const ALIGNED_GROUPS: Readonly<Record<string, SharedSeats>> = {
 	governance: GOVERNANCE_SEATS,
 	hook: HOOK_SEATS,
 	epic: BUILD_SEATS,
+	glossary: GLOSSARY_SEATS,
 	grill: GRILL_SEATS,
 	handoff: HANDOFF_SEATS,
 	ledger: BUILD_SEATS,

--- a/packages/fabrika-cli/src/exit-code-alignment.unit.test.ts
+++ b/packages/fabrika-cli/src/exit-code-alignment.unit.test.ts
@@ -15,6 +15,7 @@ import {
 	UNTABLED_GROUPS,
 	ZeroCoverageScope,
 } from "./exit-code-alignment.ts";
+import * as glossary from "./glossary/codes.ts";
 import * as governance from "./governance/codes.ts";
 import * as grill from "./grill/codes.ts";
 import * as handoff from "./handoff/codes.ts";
@@ -46,6 +47,7 @@ const TABLES: Readonly<Record<string, CodeTable>> = {
 	build,
 	epic,
 	eval: evalCodes,
+	glossary,
 	governance,
 	grill,
 	handoff,

--- a/packages/fabrika-cli/src/glossary/add-verb.ts
+++ b/packages/fabrika-cli/src/glossary/add-verb.ts
@@ -1,0 +1,269 @@
+/**
+ * `glossary add` — insert or replace one row, alphabetically placed, byte-preserving elsewhere.
+ *
+ * Three properties carry this verb, and each is a mechanism rather than an intention: the one-row
+ * assertion aborts before the write when the composed text differs anywhere but the target splice
+ * (`15`), the read-back re-parses the row that landed and refuses when it is not what was composed
+ * (`9`, a different fact from a write that failed, `8`), and `--replace` on an absent term refuses
+ * (`12`) rather than adding — a caller whose belief about the register is wrong should learn that
+ * instead of having it hidden.
+ */
+import {Effect, Path, Result} from "effect";
+import {readFile, writeFile} from "../io/fs.ts";
+import type {StdinRead} from "../io/stdin.ts";
+import {answer, refuse, type VerbOutcome} from "../verb.ts";
+import {
+	EDIT_BEYOND_ROW,
+	EMPTY_STDIN,
+	PRECONDITION_UNKNOWN,
+	READBACK_MISMATCH,
+	ROW_SHAPE_INVALID,
+	SECTION_ABSENT,
+	TERM_COLLISION,
+	WRITE_UNKNOWN,
+} from "./codes.ts";
+import {appendIndex, linesChangedBeyond, newSectionBlock, placeRow, type Splice} from "./edit.ts";
+import {
+	type GlossaryEffect,
+	type Guarded,
+	ok,
+	readRegister,
+	refused,
+	registerFilesIn,
+	resolveDir,
+	selectRegisters,
+} from "./guards.ts";
+import {escapeCell, flattenCell, normalizeKey, parseRegister, renderRow} from "./register.ts";
+
+const VERB = "glossary add";
+
+export interface AddOptions {
+	readonly term: string;
+	readonly register: string;
+	readonly section: string;
+	readonly definitionFile: string;
+	readonly notFile: string | null;
+	readonly replace: boolean;
+	readonly createSection: boolean;
+	readonly dir: string;
+	readonly json: boolean;
+	readonly cwd: string;
+	readonly stdin: Effect.Effect<StdinRead>;
+}
+
+const messages = (section: string) => ({
+	unreadable: (path: string, reason: string) =>
+		`${VERB}: cannot read ${path}: ${reason} — nothing was written.`,
+	malformed: (path: string, _reason: string) =>
+		`${VERB}: ${path} has no parseable table under "${section}" — the insertion point is UNKNOWN, nothing written.`,
+});
+
+/** The definition or `Not` cell's source text: a file, or fd 0 when the source is `-`. */
+const readSource = (
+	source: string,
+	cwd: string,
+	stdin: Effect.Effect<StdinRead>,
+	flag: string,
+): GlossaryEffect<Guarded<string>> =>
+	Effect.gen(function* () {
+		if (source === "-") {
+			const read = yield* stdin;
+			if (read._tag === "Failed") {
+				return refused(
+					refuse(
+						PRECONDITION_UNKNOWN,
+						`${VERB}: cannot read ${flag} -: ${read.reason} — nothing was written.`,
+					),
+				);
+			}
+			// A TTY carried nothing to read, which is the same fact as a pipe that arrived empty: the
+			// caller asked for a definition on fd 0 and supplied none.
+			if (read._tag === "NoStdin")
+				return refused(refuse(EMPTY_STDIN, `${VERB}: stdin held nothing.`));
+			if (flattenCell(read.text) === "") {
+				return refused(refuse(EMPTY_STDIN, `${VERB}: stdin held nothing.`));
+			}
+			return ok(read.text);
+		}
+		const pathService = yield* Path.Path;
+		const text = yield* Effect.result(readFile(pathService.resolve(cwd, source)));
+		return Result.isFailure(text)
+			? refused(
+					refuse(
+						PRECONDITION_UNKNOWN,
+						`${VERB}: cannot read ${flag} ${source}: ${text.failure.reason} — nothing was written.`,
+					),
+				)
+			: ok(text.success);
+	});
+
+export const runAdd = (options: AddOptions): GlossaryEffect<VerbOutcome> =>
+	Effect.gen(function* () {
+		const selected = selectRegisters(VERB, options.register, {
+			allowed: false,
+			refusal: `${VERB}: --register both is not writable — a term belongs to one register.`,
+		});
+		if (selected._tag === "Refused") return selected.outcome;
+		const register = selected.value[0] as "terms" | "language";
+
+		const dir = yield* resolveDir(VERB, options.cwd, options.dir);
+		if (dir._tag === "Refused") return dir.outcome;
+		const pathService = yield* Path.Path;
+		const file = registerFilesIn(dir.value, [register], pathService)[0];
+		if (file === undefined) return refuse(PRECONDITION_UNKNOWN, `${VERB}: no register resolved.`);
+
+		const state = yield* readRegister(file, messages(options.section));
+		if (state._tag === "Refused") return state.outcome;
+		if (state.value._tag === "Absent") {
+			return refuse(
+				PRECONDITION_UNKNOWN,
+				`${VERB}: cannot read ${file.display}: the register does not exist — nothing was written. Run "fabrika glossary init --register ${register}" first.`,
+			);
+		}
+		const {text, parsed} = state.value;
+
+		const section = parsed.sections.find((candidate) => candidate.name === options.section);
+		if (section === undefined && !(options.createSection && !options.replace)) {
+			return refuse(
+				SECTION_ABSENT,
+				`${VERB}: "${options.section}" is not a section of ${file.display} — run "fabrika glossary sections" for the live list.`,
+			);
+		}
+
+		const definition = yield* readSource(
+			options.definitionFile,
+			options.cwd,
+			options.stdin,
+			"--definition-file",
+		);
+		if (definition._tag === "Refused") return definition.outcome;
+		let notCell = "";
+		if (options.notFile !== null) {
+			const not = yield* readSource(options.notFile, options.cwd, options.stdin, "--not-file");
+			if (not._tag === "Refused") return not.outcome;
+			notCell = flattenCell(not.value);
+		}
+
+		const plain = [flattenCell(options.term), flattenCell(definition.value), notCell] as const;
+		if (plain[1] === "") {
+			return refuse(
+				ROW_SHAPE_INVALID,
+				`${VERB}: the definition is empty after normalization — refusing to write a blank row.`,
+			);
+		}
+		if (plain[0] === "") {
+			return refuse(
+				ROW_SHAPE_INVALID,
+				`${VERB}: the term is empty after normalization — refusing to write a blank row.`,
+			);
+		}
+		const rowText = renderRow(plain.map(escapeCell));
+
+		const key = normalizeKey(plain[0]);
+		const declared = parsed.rows.find((row) => row.key === key);
+		if (declared !== undefined && !options.replace) {
+			return refuse(
+				TERM_COLLISION,
+				`${VERB}: ${plain[0]} is already declared in ${register} under "${declared.section}" — pass --replace to rewrite it.`,
+			);
+		}
+		if (declared === undefined && options.replace) {
+			return refuse(
+				TERM_COLLISION,
+				`${VERB}: --replace was given and ${plain[0]} is not declared in ${register} — refusing to rewrite a row that does not exist.`,
+			);
+		}
+
+		const lines = text.split("\n");
+		const scope: string[] = [`${VERB}: ${file.display} — ${parsed.rows.length} row(s) read.`];
+		let splice: Splice;
+		let reportLine: number;
+		let reportSection: string;
+		let action: "added" | "replaced";
+
+		if (declared !== undefined) {
+			splice = {at: declared.line - 1, added: 1, replaced: 1};
+			reportLine = declared.line;
+			reportSection = declared.section;
+			action = "replaced";
+		} else if (section !== undefined) {
+			if (section.separatorLine === null) {
+				return refuse(
+					ROW_SHAPE_INVALID,
+					`${VERB}: ${file.display} has no parseable table under "${options.section}" — the insertion point is UNKNOWN, nothing written.`,
+					scope,
+				);
+			}
+			const placement = placeRow(section, key);
+			if (placement.unsorted) {
+				scope.push(
+					`${VERB}: section "${section.name}" is not in ascending key order — the row was placed to keep it ordered against its neighbours, and nothing else was moved.`,
+				);
+			}
+			splice = {at: placement.index, added: 1, replaced: 0};
+			reportLine = placement.index + 1;
+			reportSection = section.name;
+			action = "added";
+		} else {
+			const at = appendIndex(lines);
+			splice = {at, added: newSectionBlock(options.section, rowText).length, replaced: 0};
+			reportLine = at + 5;
+			reportSection = options.section;
+			action = "added";
+		}
+
+		const inserted =
+			splice.added === 1 ? [rowText] : [...newSectionBlock(options.section, rowText)];
+		const next = [
+			...lines.slice(0, splice.at),
+			...inserted,
+			...lines.slice(splice.at + splice.replaced),
+		];
+
+		const beyond = linesChangedBeyond(lines, next, splice);
+		if (beyond !== 0) {
+			return refuse(
+				EDIT_BEYOND_ROW,
+				`${VERB}: the edit would have changed ${beyond} line(s) beyond the target row — aborted, nothing written.`,
+				scope,
+			);
+		}
+
+		const nextText = next.join("\n");
+		const written = yield* Effect.result(writeFile(file.path, nextText));
+		if (Result.isFailure(written)) {
+			return refuse(
+				WRITE_UNKNOWN,
+				`${VERB}: cannot write ${file.display}: ${written.failure.reason} — the register's state is UNKNOWN, re-read it before retrying.`,
+				scope,
+			);
+		}
+
+		const readBack = yield* Effect.result(readFile(file.path));
+		const landed =
+			Result.isSuccess(readBack) && parseRegister(readBack.success)._tag === "Parsed"
+				? readBack.success.split("\n")[reportLine - 1]
+				: undefined;
+		if (landed !== rowText) {
+			return refuse(
+				READBACK_MISMATCH,
+				`${VERB}: wrote ${file.display} and the read-back differs at line ${reportLine} — the register may be inconsistent.`,
+				scope,
+			);
+		}
+
+		if (options.json) {
+			return answer(
+				JSON.stringify({
+					action,
+					path: file.display,
+					section: reportSection,
+					line: reportLine,
+					term: plain[0],
+					normalized: key,
+				}),
+				scope,
+			);
+		}
+		return answer(`${action}\t${file.display}\t${reportSection}\t${reportLine}`, scope);
+	});

--- a/packages/fabrika-cli/src/glossary/add-verb.unit.test.ts
+++ b/packages/fabrika-cli/src/glossary/add-verb.unit.test.ts
@@ -1,0 +1,212 @@
+import {Effect} from "effect";
+import {describe, expect, it} from "vitest";
+import {type FakeFs, fakeFs} from "../fakes.test-support.ts";
+import type {StdinRead} from "../io/stdin.ts";
+import {runAdd} from "./add-verb.ts";
+import {
+	EDIT_BEYOND_ROW,
+	EMPTY_STDIN,
+	OFF_VOCABULARY,
+	PRECONDITION_UNKNOWN,
+	ROW_SHAPE_INVALID,
+	SECTION_ABSENT,
+	TERM_COLLISION,
+	WRITE_UNKNOWN,
+} from "./codes.ts";
+import {DIR, REPO, TERMS, TERMS_PATH} from "./fixtures.test-support.ts";
+
+const piped = (text: string): Effect.Effect<StdinRead> =>
+	Effect.succeed({_tag: "Text" as const, text});
+
+const options = {
+	term: "capture ledger",
+	register: "terms",
+	section: "Products (domains)",
+	definitionFile: "-",
+	notFile: null as string | null,
+	replace: false,
+	createSection: false,
+	dir: DIR,
+	json: false,
+	cwd: REPO,
+	stdin: piped("The append-only record of one capture run."),
+};
+
+const run = (fs: FakeFs, overrides: Partial<typeof options> = {}) =>
+	Effect.runPromise(Effect.provide(runAdd({...options, ...overrides}), fs.layer));
+
+const populated = () => fakeFs({files: {[TERMS_PATH]: TERMS}});
+
+describe("runAdd", () => {
+	it("inserts the row in its section's alphabetical place and reports the line", async () => {
+		const io = populated();
+		const out = await run(io);
+		expect(out.code).toBe(0);
+		expect(out.stdout).toBe(`added\t${DIR}/TERMS.md\tProducts (domains)\t16\n`);
+		expect((io.written.get(TERMS_PATH) ?? "").split("\n")[15]).toBe(
+			"| capture ledger | The append-only record of one capture run. | |",
+		);
+	});
+
+	it("moves nothing else — every other line survives byte for byte", async () => {
+		const io = populated();
+		await run(io);
+		const after = (io.written.get(TERMS_PATH) ?? "").split("\n");
+		const before = TERMS.split("\n");
+		expect([...after.slice(0, 15), ...after.slice(16)]).toEqual(before);
+	});
+
+	it("escapes a pipe and flattens a newline, so the row stays one line", async () => {
+		const io = populated();
+		await run(io, {stdin: piped("one | two\nthree")});
+		expect((io.written.get(TERMS_PATH) ?? "").split("\n")[15]).toBe(
+			"| capture ledger | one \\| two three | |",
+		);
+	});
+
+	it("writes the Not cell when --not-file names one", async () => {
+		const io = fakeFs({files: {[TERMS_PATH]: TERMS, "/repo/not.txt": "an evidence log"}});
+		await run(io, {notFile: "not.txt"});
+		expect((io.written.get(TERMS_PATH) ?? "").split("\n")[15]).toContain("| an evidence log |");
+	});
+
+	it("refuses a term already declared, naming the section it sits in", async () => {
+		const out = await run(populated(), {term: "pano", section: "Core / shape"});
+		expect(out.code).toBe(TERM_COLLISION);
+		expect(out.stdout).toBe("");
+		expect(out.stderr.at(-1)).toBe(
+			'glossary add: pano is already declared in terms under "Core / shape" — pass --replace to rewrite it.',
+		);
+	});
+
+	it("rewrites the declared row under --replace and reports its line", async () => {
+		const io = populated();
+		const out = await run(io, {
+			term: "pano",
+			section: "Core / shape",
+			replace: true,
+			stdin: piped("The board product."),
+		});
+		expect(out.stdout).toBe(`replaced\t${DIR}/TERMS.md\tCore / shape\t9\n`);
+		expect((io.written.get(TERMS_PATH) ?? "").split("\n")[8]).toBe(
+			"| pano | The board product. | |",
+		);
+	});
+
+	// The flag asks to rewrite a specific row; adding anyway would hide a wrong belief about the file.
+	it("refuses --replace on a term that is not declared", async () => {
+		const out = await run(populated(), {replace: true});
+		expect(out.code).toBe(TERM_COLLISION);
+		expect(out.stderr.at(-1)).toContain("refusing to rewrite a row that does not exist");
+	});
+
+	it("refuses a --section that names no heading, and points at the live list", async () => {
+		const out = await run(populated(), {section: "Nowhere"});
+		expect(out.code).toBe(SECTION_ABSENT);
+		expect(out.stderr.at(-1)).toBe(
+			`glossary add: "Nowhere" is not a section of ${DIR}/TERMS.md — run "fabrika glossary sections" for the live list.`,
+		);
+	});
+
+	it("appends exactly five lines under --create-section, and reorders nothing", async () => {
+		const io = populated();
+		const out = await run(io, {section: "fabrika skill nouns", createSection: true});
+		expect(out.stdout).toBe(`added\t${DIR}/TERMS.md\tfabrika skill nouns\t29\n`);
+		const after = (io.written.get(TERMS_PATH) ?? "").split("\n");
+		expect(after.slice(0, 24)).toEqual(TERMS.split("\n").slice(0, 24));
+		expect(after.slice(24, 29)).toEqual([
+			"",
+			"## fabrika skill nouns",
+			"| Term | Definition | Not |",
+			"|---|---|---|",
+			"| capture ledger | The append-only record of one capture run. | |",
+		]);
+	});
+
+	it("refuses a definition that is empty after normalization", async () => {
+		const out = await run(populated(), {stdin: piped("  \n ")});
+		expect(out.code).toBe(EMPTY_STDIN);
+	});
+
+	it("refuses a definition file that is empty after normalization", async () => {
+		const io = fakeFs({files: {[TERMS_PATH]: TERMS, "/repo/def.txt": "   \n"}});
+		const out = await run(io, {definitionFile: "def.txt"});
+		expect(out.code).toBe(ROW_SHAPE_INVALID);
+		expect(out.stderr.at(-1)).toBe(
+			"glossary add: the definition is empty after normalization — refusing to write a blank row.",
+		);
+	});
+
+	it("refuses stdin that held nothing", async () => {
+		const out = await run(populated(), {
+			stdin: Effect.succeed({_tag: "NoStdin" as const, reason: "fd 0 is a TTY"}),
+		});
+		expect(out.code).toBe(EMPTY_STDIN);
+		expect(out.stderr.at(-1)).toBe("glossary add: stdin held nothing.");
+	});
+
+	it("refuses a stdin READ that failed as UNKNOWN, never as empty", async () => {
+		const out = await run(populated(), {
+			stdin: Effect.succeed({_tag: "Failed" as const, reason: "EAGAIN"}),
+		});
+		expect(out.code).toBe(PRECONDITION_UNKNOWN);
+	});
+
+	it("refuses --register both — a term belongs to one register", async () => {
+		const out = await run(populated(), {register: "both"});
+		expect(out.code).toBe(OFF_VOCABULARY);
+		expect(out.stderr.at(-1)).toBe(
+			"glossary add: --register both is not writable — a term belongs to one register.",
+		);
+	});
+
+	it("refuses an absent register and names the verb that creates one", async () => {
+		const out = await run(fakeFs({files: {}}));
+		expect(out.code).toBe(PRECONDITION_UNKNOWN);
+		expect(out.stderr.at(-1)).toContain("fabrika glossary init");
+	});
+
+	it("reports a failed write as UNKNOWN, and writes nothing", async () => {
+		const io = fakeFs({files: {[TERMS_PATH]: TERMS}, unwritable: [TERMS_PATH]});
+		const out = await run(io);
+		expect(out.code).toBe(WRITE_UNKNOWN);
+		expect(io.written.size).toBe(0);
+	});
+
+	it("emits the edit record as JSON", async () => {
+		const out = await run(populated(), {json: true});
+		expect(JSON.parse(out.stdout)).toEqual({
+			action: "added",
+			path: `${DIR}/TERMS.md`,
+			section: "Products (domains)",
+			line: 16,
+			term: "capture ledger",
+			normalized: "capture ledger",
+		});
+	});
+
+	it("names an unsorted section on stderr and still places the row against its neighbours", async () => {
+		const unsorted = `## Products (domains)
+
+| Term | Definition | Not |
+|---|---|---|
+| sozluk | x | |
+| depo | y | |
+`;
+		const out = await run(fakeFs({files: {[TERMS_PATH]: unsorted}}));
+		expect(out.code).toBe(0);
+		expect(out.stderr.join("\n")).toContain("is not in ascending key order");
+	});
+});
+
+/**
+ * `15` is unreachable through the shipped composer, which only ever splices the lines it named —
+ * `edit.unit.test.ts` proves the assertion itself catches a re-sort. Pinned here so the code is not
+ * mistaken for dead: it is the guard that makes that property hold.
+ */
+describe("the one-row assertion", () => {
+	it("is not reached by any ordinary add", async () => {
+		const out = await run(populated());
+		expect(out.code).not.toBe(EDIT_BEYOND_ROW);
+	});
+});

--- a/packages/fabrika-cli/src/glossary/candidates.ts
+++ b/packages/fabrika-cli/src/glossary/candidates.ts
@@ -1,0 +1,111 @@
+/**
+ * `glossary drift`'s candidate extraction, stated deterministically so two implementers agree.
+ *
+ * Two v1 scars are designed out here rather than inherited. Its tokenizer was `/\b[a-z][a-z-]+\b/g`,
+ * which excludes uppercase and all non-ASCII, so every Turkish product noun the glossary exists for
+ * was structurally invisible (#4481) — {@link tokenize} splits on Unicode letter classes instead.
+ * And it suppressed a candidate when a declared term contained it **or** it contained a declared
+ * term, which against a 226-row register inverts the stated recall bias to about 10% measured
+ * precision — suppression here is equality on the normalized key, never containment in either
+ * direction.
+ */
+import {STOPWORDS} from "../adr/sweep.ts";
+import {normalizeKey} from "./register.ts";
+
+/** One commit's decision-bearing text. `files` is resolved separately, only where it is needed. */
+export interface CommitText {
+	readonly sha: string;
+	readonly subject: string;
+	readonly body: string;
+}
+
+export interface Candidate {
+	readonly phrase: string;
+	/** Distinct commits in the range whose subject or body contains the phrase. */
+	readonly hits: number;
+	/** The earliest commit contributing a hit — whose first changed file is the reported surface. */
+	readonly firstCommit: string;
+}
+
+/** Tokens are runs of Unicode letters, digits, `-` and `_`; everything else is a separator. */
+export const tokenize = (text: string): ReadonlyArray<string> =>
+	text.match(/[\p{L}\p{N}\-_]+/gu) ?? [];
+
+const QUOTED = /"([^"\n]+)"/g;
+const BACKTICKED = /`([^`\n]+)`/g;
+
+/** N-grams of `n` consecutive tokens of a single line. */
+const ngrams = (tokens: ReadonlyArray<string>, n: number): ReadonlyArray<string> => {
+	const out: string[] = [];
+	for (let i = 0; i + n <= tokens.length; i += 1) out.push(tokens.slice(i, i + n).join(" "));
+	return out;
+};
+
+/** Every double-quoted or backticked span of the whole text, plus the subject's 2- and 3-grams. */
+export const phrasesOf = (commit: CommitText): ReadonlyArray<string> => {
+	const text = `${commit.subject}\n${commit.body}`;
+	const spans = [...text.matchAll(QUOTED), ...text.matchAll(BACKTICKED)].map(
+		(match) => match[1] as string,
+	);
+	const subjectTokens = tokenize(commit.subject);
+	return [...spans, ...ngrams(subjectTokens, 2), ...ngrams(subjectTokens, 3)];
+};
+
+/**
+ * Whether a phrase survives the filter: it is not all stopwords, and every token shorter than three
+ * characters is itself a declared key.
+ */
+export const survivesFilter = (phrase: string, declared: ReadonlySet<string>): boolean => {
+	const tokens = tokenize(phrase);
+	if (tokens.length === 0) return false;
+	if (tokens.every((token) => STOPWORDS.has(token.toLocaleLowerCase()))) return false;
+	return tokens.every((token) => token.length >= 3 || declared.has(normalizeKey(token)));
+};
+
+const encoder = new TextEncoder();
+
+/** Byte-wise ascending, so the tie-break does not depend on a locale. */
+export const compareBytes = (a: string, b: string): number => {
+	const left = encoder.encode(a);
+	const right = encoder.encode(b);
+	for (let i = 0; i < Math.min(left.length, right.length); i += 1) {
+		const diff = (left[i] as number) - (right[i] as number);
+		if (diff !== 0) return diff;
+	}
+	return left.length - right.length;
+};
+
+/**
+ * The surviving candidates over `commits` (oldest first), highest-ranked first.
+ *
+ * Suppression is **equality on the normalized key**: a phrase whose key is already declared is
+ * dropped, and nothing else is.
+ */
+export const rankCandidates = (
+	commits: ReadonlyArray<CommitText>,
+	declared: ReadonlySet<string>,
+	limit: number,
+): ReadonlyArray<Candidate> => {
+	const phrases = new Set<string>();
+	for (const commit of commits) {
+		for (const phrase of phrasesOf(commit)) {
+			if (!survivesFilter(phrase, declared)) continue;
+			if (declared.has(normalizeKey(phrase))) continue;
+			phrases.add(phrase);
+		}
+	}
+
+	const candidates: Candidate[] = [];
+	for (const phrase of phrases) {
+		const hitting = commits.filter(
+			(commit) => commit.subject.includes(phrase) || commit.body.includes(phrase),
+		);
+		const first = hitting[0];
+		if (first === undefined) continue;
+		candidates.push({phrase, hits: hitting.length, firstCommit: first.sha});
+	}
+
+	return candidates
+		.sort((a, b) => (b.hits !== a.hits ? b.hits - a.hits : compareBytes(a.phrase, b.phrase)))
+		.slice(0, Math.max(limit, 0));
+};

--- a/packages/fabrika-cli/src/glossary/candidates.unit.test.ts
+++ b/packages/fabrika-cli/src/glossary/candidates.unit.test.ts
@@ -1,0 +1,108 @@
+import {describe, expect, it} from "vitest";
+import {compareBytes, phrasesOf, rankCandidates, survivesFilter, tokenize} from "./candidates.ts";
+
+const commit = (sha: string, subject: string, body = "") => ({sha, subject, body});
+
+describe("tokenize", () => {
+	// v1's tokenizer was `/\b[a-z][a-z-]+\b/g`, so every Turkish product noun was invisible (#4481).
+	it("keeps Unicode letters, so a Turkish noun is a token", () => {
+		expect(tokenize("sözlük ve geçit")).toEqual(["sözlük", "ve", "geçit"]);
+	});
+
+	it("keeps hyphens and underscores inside a token and splits on everything else", () => {
+		expect(tokenize("front-door, capture_ledger (v2)")).toEqual([
+			"front-door",
+			"capture_ledger",
+			"v2",
+		]);
+	});
+});
+
+describe("phrasesOf", () => {
+	it("takes every quoted and backticked span, from the subject and the body", () => {
+		const phrases = phrasesOf(commit("a", 'add "front door" routing', "see `capture ledger`"));
+		expect(phrases).toContain("front door");
+		expect(phrases).toContain("capture ledger");
+	});
+
+	it("takes the subject's 2- and 3-grams, and not the body's", () => {
+		const phrases = phrasesOf(commit("a", "add capture ledger", "body words here"));
+		expect(phrases).toContain("add capture");
+		expect(phrases).toContain("add capture ledger");
+		expect(phrases).not.toContain("body words");
+	});
+});
+
+describe("survivesFilter", () => {
+	it("drops a phrase whose every token is a stopword", () => {
+		expect(survivesFilter("and the", new Set())).toBe(false);
+	});
+
+	it("drops a phrase carrying a short token that is not itself declared", () => {
+		expect(survivesFilter("do the thing", new Set())).toBe(false);
+	});
+
+	it("keeps a short token that IS a declared key", () => {
+		expect(survivesFilter("do the thing", new Set(["do"]))).toBe(true);
+	});
+});
+
+describe("rankCandidates", () => {
+	const declared = new Set(["capture ledger"]);
+
+	/**
+	 * The measured v1 defect: it suppressed a candidate when a declared term contained it **or** it
+	 * contained a declared term, which against a 226-row register left about 10% precision (#4481).
+	 * Suppression here is equality on the normalized key and nothing else.
+	 */
+	it("suppresses only an exact key match, never a containment in either direction", () => {
+		const ranked = rankCandidates(
+			[commit("a", 'add "capture ledger" and "capture ledger rotation"')],
+			declared,
+			40,
+		);
+		expect(ranked.map((candidate) => candidate.phrase)).toContain("capture ledger rotation");
+		expect(ranked.map((candidate) => candidate.phrase)).not.toContain("capture ledger");
+	});
+
+	it("orders by hits descending, then by the phrase byte-wise", () => {
+		const ranked = rankCandidates(
+			[
+				commit("a", 'add "retry budget"'),
+				commit("b", 'tune "retry budget"'),
+				commit("c", 'add "zebra crossing" and "alpha channel"'),
+			],
+			new Set(),
+			40,
+		);
+		expect(ranked[0]?.phrase).toBe("retry budget");
+		expect(ranked[0]?.hits).toBe(2);
+		const rest = ranked.slice(1).map((candidate) => candidate.phrase);
+		expect(rest.indexOf("alpha channel")).toBeLessThan(rest.indexOf("zebra crossing"));
+	});
+
+	it("names the EARLIEST contributing commit, which is where the surface is read from", () => {
+		const ranked = rankCandidates(
+			[commit("older", 'add "retry budget"'), commit("newer", 'tune "retry budget"')],
+			new Set(),
+			40,
+		);
+		expect(ranked[0]?.firstCommit).toBe("older");
+	});
+
+	it("honours --limit", () => {
+		const ranked = rankCandidates(
+			[commit("a", "add capture ledger rotation policy")],
+			new Set(),
+			2,
+		);
+		expect(ranked).toHaveLength(2);
+	});
+});
+
+describe("compareBytes", () => {
+	it("orders by UTF-8 bytes rather than by a locale", () => {
+		expect(compareBytes("a", "b")).toBeLessThan(0);
+		expect(compareBytes("z", "ö")).toBeLessThan(0);
+	});
+});

--- a/packages/fabrika-cli/src/glossary/check-verb.ts
+++ b/packages/fabrika-cli/src/glossary/check-verb.ts
@@ -1,0 +1,180 @@
+/**
+ * `glossary check` — row-shape, duplicate-key, ordering and citation-liveness defects.
+ *
+ * **All three outcomes exit 0**, because the outcome is this verb's own verdict: a caller must never
+ * read its own finding list as a failed run, which is the mistake v1's `adr-sweep` made by exiting
+ * non-zero on the one case it was asked to produce (#4723).
+ *
+ * **Zero scope is a red, with one carved-out exception.** A register present and holding zero rows is
+ * `7` — a check that scanned nothing must never report `clean` (ADR 0092). An *absent* register is
+ * `bootstrap` on exit `0`: refusing there would leave a fresh repo unable to run the skill at all
+ * (#4776).
+ *
+ * Two defect classes are deliberately not computed here — machine-local paths and dead internal links
+ * — because a merge-blocking gate already decides each, and a second answer could contradict it.
+ */
+import {Effect, Path, Result} from "effect";
+import {idFromFile, isLive, statusOf} from "../adr/records.ts";
+import {readDir, readFile} from "../io/fs.ts";
+import {answer, refuse, type VerbOutcome} from "../verb.ts";
+import {ZERO_SCOPE} from "./codes.ts";
+import {
+	type CitationState,
+	citationsOf,
+	findDefects,
+	type RegisterRows,
+	renderFinding,
+} from "./findings.ts";
+import {
+	type GlossaryEffect,
+	readRegister,
+	registerFilesIn,
+	resolveDir,
+	selectRegisters,
+} from "./guards.ts";
+
+const VERB = "glossary check";
+
+export interface CheckOptions {
+	readonly register: string;
+	readonly dir: string;
+	readonly decisions: string;
+	readonly json: boolean;
+	readonly cwd: string;
+}
+
+const messages = {
+	unreadable: (path: string, reason: string) =>
+		`${VERB}: cannot read ${path}: ${reason} — the outcome is UNKNOWN, never "clean".`,
+	malformed: (path: string, reason: string) =>
+		`${VERB}: ${path} has no parseable term table (${reason}) — the outcome is UNKNOWN.`,
+};
+
+/** Every cited id resolved against `--decisions`, or the reason the corpus could not be read. */
+const resolveCitations = (
+	decisionsPath: string,
+	wanted: ReadonlySet<string>,
+): GlossaryEffect<{
+	readonly states: ReadonlyMap<string, CitationState>;
+	readonly unverified: string | null;
+}> =>
+	Effect.gen(function* () {
+		const states = new Map<string, CitationState>();
+		if (wanted.size === 0) return {states, unverified: null};
+
+		const listing = yield* Effect.result(readDir(decisionsPath));
+		if (Result.isFailure(listing)) return {states, unverified: listing.failure.reason};
+
+		const byId = new Map<string, string>();
+		for (const name of listing.success) {
+			const id = idFromFile(name);
+			if (id !== null && !byId.has(id)) byId.set(id, name);
+		}
+		for (const id of wanted) {
+			const name = byId.get(id);
+			if (name === undefined) {
+				states.set(id, {_tag: "Dead"});
+				continue;
+			}
+			const text = yield* Effect.result(readFile(`${decisionsPath}/${name}`));
+			if (Result.isFailure(text)) {
+				return {states, unverified: `${name} could not be read: ${text.failure.reason}`};
+			}
+			const status = statusOf(text.success) ?? "";
+			states.set(id, isLive(status) ? {_tag: "Live"} : {_tag: "Superseded", status});
+		}
+		return {states, unverified: null};
+	});
+
+export const runCheck = (options: CheckOptions): GlossaryEffect<VerbOutcome> =>
+	Effect.gen(function* () {
+		const selected = selectRegisters(VERB, options.register, {allowed: true, refusal: ""});
+		if (selected._tag === "Refused") return selected.outcome;
+
+		const dir = yield* resolveDir(VERB, options.cwd, options.dir);
+		if (dir._tag === "Refused") return dir.outcome;
+		const pathService = yield* Path.Path;
+		const files = registerFilesIn(dir.value, selected.value, pathService);
+
+		const present: RegisterRows[] = [];
+		const scope: string[] = [];
+		let firstAbsent: string | null = null;
+		for (const file of files) {
+			const state = yield* readRegister(file, messages);
+			if (state._tag === "Refused") return state.outcome;
+			if (state.value._tag === "Absent") {
+				if (firstAbsent === null) firstAbsent = file.display;
+				scope.push(`${VERB}: ${file.display} — absent.`);
+				continue;
+			}
+			const rows = state.value.parsed.rows;
+			if (rows.length === 0) {
+				return refuse(
+					ZERO_SCOPE,
+					`${VERB}: ${file.display} holds 0 rows — refusing to report a clean scan of an empty register (ADR 0092).`,
+					scope,
+				);
+			}
+			present.push({register: file.name, rows});
+			scope.push(`${VERB}: ${file.display} — ${rows.length} row(s).`);
+		}
+
+		if (present.length === 0) {
+			const reason = `no register at ${firstAbsent ?? dir.value.display} — nothing to check yet, which is bootstrap, not clean`;
+			const diagnostics = [...scope, `${VERB}: ${reason}.`];
+			return options.json
+				? answer(
+						JSON.stringify({
+							outcome: "bootstrap",
+							findings: [],
+							reason,
+							scannedRows: 0,
+							scannedRegisters: 0,
+							citationsResolved: 0,
+						}),
+						diagnostics,
+					)
+				: answer("bootstrap", diagnostics);
+		}
+
+		const wanted = new Set(
+			present.flatMap(({rows}) => rows.flatMap((row) => [...citationsOf(row)])),
+		);
+		const decisionsPath = pathService.resolve(
+			dir.value.root,
+			options.decisions.replace(/\/+$/, ""),
+		);
+		const citations = yield* resolveCitations(decisionsPath, wanted);
+		scope.push(
+			`${VERB}: ${citations.states.size} of ${wanted.size} citation(s) resolved under ${options.decisions}.`,
+		);
+
+		const findings = findDefects({
+			registers: present,
+			citations: citations.states,
+			citationsUnverified: citations.unverified,
+			decisionsDir: options.decisions,
+		});
+		const scannedRows = present.reduce((total, entry) => total + entry.rows.length, 0);
+		const outcome = findings.length === 0 ? "clean" : "defects";
+		const reason =
+			outcome === "clean"
+				? `checked ${scannedRows} row(s) across ${present.length} register(s); no defect found`
+				: null;
+		const diagnostics = reason === null ? scope : [...scope, `${VERB}: ${reason}.`];
+
+		if (options.json) {
+			return answer(
+				JSON.stringify({
+					outcome,
+					findings,
+					reason,
+					scannedRows,
+					scannedRegisters: present.length,
+					citationsResolved: citations.states.size,
+				}),
+				diagnostics,
+			);
+		}
+		return answer([outcome, ...findings.map(renderFinding)].join("\n"), diagnostics);
+	});

--- a/packages/fabrika-cli/src/glossary/check-verb.unit.test.ts
+++ b/packages/fabrika-cli/src/glossary/check-verb.unit.test.ts
@@ -1,0 +1,132 @@
+import {Effect} from "effect";
+import {describe, expect, it} from "vitest";
+import {type FakeFs, fakeFs, record} from "../fakes.test-support.ts";
+import {runCheck} from "./check-verb.ts";
+import {BAD_SECTIONS, OFF_VOCABULARY, PRECONDITION_UNKNOWN, ZERO_SCOPE} from "./codes.ts";
+import {
+	DIR,
+	LANGUAGE_NO_ROWS,
+	LANGUAGE_PATH,
+	REPO,
+	TERMS,
+	TERMS_CLEAN,
+	TERMS_PATH,
+} from "./fixtures.test-support.ts";
+
+const DECISIONS = "/repo/.decisions";
+
+const options = {register: "terms", dir: DIR, decisions: ".decisions", json: false, cwd: REPO};
+
+const run = (fs: FakeFs, overrides: Partial<typeof options> = {}) =>
+	Effect.runPromise(Effect.provide(runCheck({...options, ...overrides}), fs.layer));
+
+const withDecisions = (files: Record<string, string | null>, names: ReadonlyArray<string>) =>
+	fakeFs({dirs: {[DECISIONS]: [...names]}, files});
+
+const corpus = () =>
+	withDecisions(
+		{
+			[TERMS_PATH]: TERMS,
+			[`${DECISIONS}/0044-imge.md`]: record("0044", "superseded by [0144](0144-depo.md)"),
+			[`${DECISIONS}/0144-depo.md`]: record("0144", "accepted"),
+		},
+		["0044-imge.md", "0144-depo.md"],
+	);
+
+describe("runCheck", () => {
+	it("exits 0 WITH its findings — the informative case is not a failure (#4723)", async () => {
+		const out = await run(corpus());
+		expect(out.code).toBe(0);
+		expect(out.stdout.split("\n")[0]).toBe("defects");
+		expect(out.stdout).toContain(
+			'duplicate-key\tterms\tProducts (domains)\tpano\talso declared in "Core / shape"',
+		);
+		expect(out.stdout).toContain(
+			'citation-superseded\tterms\tCore / shape\tworker\tcites 0044, status "superseded by [0144](0144-depo.md)"',
+		);
+	});
+
+	it("decides liveness by the imported predicate, so amended-in-part is not a defect", async () => {
+		const io = withDecisions(
+			{
+				[TERMS_PATH]: TERMS_CLEAN.replace("The internal asset store.", "Cites 0044."),
+				[`${DECISIONS}/0044-imge.md`]: record("0044", "amended-in-part by [0144](0144-depo.md)"),
+			},
+			["0044-imge.md"],
+		);
+		const out = await run(io);
+		expect(out.stdout.split("\n")[0]).toBe("clean");
+	});
+
+	it("exits 0 on clean, with the pinned reason on stderr", async () => {
+		const out = await run(fakeFs({files: {[TERMS_PATH]: TERMS_CLEAN}}));
+		expect(out.code).toBe(0);
+		expect(out.stdout).toBe("clean\n");
+		expect(out.stderr.at(-1)).toBe(
+			"glossary check: checked 2 row(s) across 1 register(s); no defect found.",
+		);
+	});
+
+	it("exits 0 on bootstrap for an absent register", async () => {
+		const out = await run(fakeFs({files: {}}));
+		expect(out.code).toBe(0);
+		expect(out.stdout).toBe("bootstrap\n");
+		expect(out.stderr.at(-1)).toContain("bootstrap, not clean");
+	});
+
+	// Present-and-empty and absent are different facts and never share a code (ADR 0092).
+	it("reds on a register that is present and holds zero rows", async () => {
+		const out = await run(fakeFs({files: {[TERMS_PATH]: LANGUAGE_NO_ROWS}}));
+		expect(out.code).toBe(ZERO_SCOPE);
+		expect(out.stdout).toBe("");
+		expect(out.stderr.at(-1)).toBe(
+			`glossary check: ${DIR}/TERMS.md holds 0 rows — refusing to report a clean scan of an empty register (ADR 0092).`,
+		);
+	});
+
+	it("reports an unresolved decision corpus rather than reporting clean over it", async () => {
+		const out = await run(fakeFs({files: {[TERMS_PATH]: TERMS}}));
+		expect(out.code).toBe(0);
+		expect(out.stdout).toContain("citations-unverified\t-\t-\t-\tcannot read .decisions:");
+		expect(out.stdout.split("\n")[0]).toBe("defects");
+	});
+
+	it("refuses an unreadable register — the outcome is UNKNOWN, never clean", async () => {
+		const out = await run(fakeFs({files: {[TERMS_PATH]: TERMS}, unreadable: [TERMS_PATH]}));
+		expect(out.code).toBe(PRECONDITION_UNKNOWN);
+		expect(out.stdout).toBe("");
+		expect(out.stderr.at(-1)).toContain('never "clean"');
+	});
+
+	it("refuses a malformed term table", async () => {
+		const out = await run(
+			fakeFs({files: {[TERMS_PATH]: "## S\n\n| Term | Definition | Not |\n| pano | x | |\n"}}),
+		);
+		expect(out.code).toBe(BAD_SECTIONS);
+	});
+
+	it("refuses an off-enum --register", async () => {
+		const out = await run(fakeFs({files: {}}), {register: "sozluk"});
+		expect(out.code).toBe(OFF_VOCABULARY);
+	});
+
+	it("reports a key declared in both registers under --register both", async () => {
+		const out = await run(
+			fakeFs({files: {[TERMS_PATH]: TERMS_CLEAN, [LANGUAGE_PATH]: TERMS_CLEAN}}),
+			{register: "both"},
+		);
+		expect(out.stdout).toContain("cross-register\tlanguage");
+	});
+
+	it("carries the counts the outcome is only readable against, in --json", async () => {
+		const out = await run(fakeFs({files: {[TERMS_PATH]: TERMS_CLEAN}}), {json: true});
+		expect(JSON.parse(out.stdout)).toEqual({
+			outcome: "clean",
+			findings: [],
+			reason: "checked 2 row(s) across 1 register(s); no defect found",
+			scannedRows: 2,
+			scannedRegisters: 1,
+			citationsResolved: 0,
+		});
+	});
+});

--- a/packages/fabrika-cli/src/glossary/codes.ts
+++ b/packages/fabrika-cli/src/glossary/codes.ts
@@ -1,0 +1,69 @@
+/**
+ * The one exit table all six `glossary` verbs allocate from, so a code means one thing across this
+ * group whichever verb produced it (`claude-plugins/fabrika/skills/glossary/contract.md`).
+ *
+ * The overlap with `report` is **imported, never re-typed**: an aligning group takes the base's
+ * constant, so a drift is unrepresentable rather than merely detectable.
+ *
+ * Three meanings on this table are one another's opposites and the whole group is built to keep them
+ * apart: `1`/`127` is *the call never decided*, {@link PRECONDITION_UNKNOWN} is *a precondition read
+ * failed and nothing was written*, and {@link WRITE_UNKNOWN} is *a write was attempted and its
+ * outcome is UNKNOWN*. Everything at `3` and above is something a verb **proved** — with nothing on
+ * stdout.
+ *
+ * `0`, `1`, `2` and `127` are reserved by the interface convention (`../verb.ts`, `../bin.ts`).
+ */
+
+import {
+	BAD_SECTIONS as REPORT_BAD_SECTIONS,
+	CLASSIFIED as REPORT_CLASSIFIED,
+	EMPTY_STDIN as REPORT_EMPTY_STDIN,
+	NO_TARGET as REPORT_NO_TARGET,
+	PRECONDITION_UNKNOWN as REPORT_PRECONDITION_UNKNOWN,
+	READBACK_MISMATCH as REPORT_READBACK_MISMATCH,
+	WRITE_UNKNOWN as REPORT_WRITE_UNKNOWN,
+} from "../report/codes.ts";
+
+/** Stdin was read and held nothing. `glossary add --definition-file -` only — the one fd 0 read. */
+export const EMPTY_STDIN = REPORT_EMPTY_STDIN;
+/**
+ * The register was read and a structure this verb needs — its term table, or its headings — is
+ * unusable.
+ *
+ * A register with **no** term table at all is zero rows, never this: absence is `bootstrap` and an
+ * empty table is the verb's zero-row behaviour. Only a table that exists and is malformed lands here.
+ */
+export const BAD_SECTIONS = REPORT_BAD_SECTIONS;
+/**
+ * Held empty. Machine-local paths in a register are decided by the merge-blocking leak gate over
+ * changed markdown, and a second answer here could report clean while that gate reds.
+ *
+ * `6` is held empty for the same reason — dead internal links belong to the repo-wide link gate — and
+ * carries no export at all, because `../exit-code-alignment.ts` matches this one exact name and a
+ * second export of it would not compile while a renamed one would read as an allocation.
+ */
+export const DELIBERATE_GAP = 5;
+/** Proven: a judging verb scanned nothing it could judge (ADR 0092). */
+export const ZERO_SCOPE = REPORT_NO_TARGET;
+/** A register write was attempted and its outcome could not be proven — UNKNOWN, deliberately not `1`. */
+export const WRITE_UNKNOWN = REPORT_WRITE_UNKNOWN;
+/** The write landed and the re-read differs from what was composed; the register needs a human. */
+export const READBACK_MISMATCH = REPORT_READBACK_MISMATCH;
+/**
+ * A closed-enum flag carried an off-enum value — `--register` outside its vocabulary, or `both` where
+ * a verb writes and a term has exactly one register.
+ *
+ * A semantic refusal on a *value*; a malformed *flag* stays `1`, which is the parser's.
+ */
+export const OFF_VOCABULARY = REPORT_CLASSIFIED;
+/** A precondition read failed; nothing was written and no outcome is proven. */
+export const PRECONDITION_UNKNOWN = REPORT_PRECONDITION_UNKNOWN;
+
+/** Proven: the term is already declared and `--replace` was not given — `add` refused. */
+export const TERM_COLLISION = 12;
+/** Proven: `--section` names no heading in the register. */
+export const SECTION_ABSENT = 13;
+/** Proven: the composed row cannot be a well-formed table row. */
+export const ROW_SHAPE_INVALID = 14;
+/** Proven: the edit would have changed a line outside the target row — aborted, nothing written. */
+export const EDIT_BEYOND_ROW = 15;

--- a/packages/fabrika-cli/src/glossary/command.ts
+++ b/packages/fabrika-cli/src/glossary/command.ts
@@ -1,0 +1,224 @@
+/**
+ * The `glossary` verb group — `fabrika glossary <init|drift|lookup|sections|add|check>`, the
+ * `glossary` skill's half of register maintenance.
+ *
+ * The adapter and nothing else: it declares the flags (`--help` is the interface, so every flag
+ * carries a one-line description), reads the one machine fact this group does not derive — the
+ * process's working directory — runs the pure verb, and emits its outcome. Every decision lives in
+ * the `*-verb.ts` modules beside it, which is what makes each refusal testable without spawning a
+ * process.
+ *
+ * **Every leaf is declared with `leafCommand`, never a bare `Command.make`** — the bare form silently
+ * opts out of the excess-operand guard, which `../excess-operand.unit.test.ts` reds on.
+ *
+ * **`--register` is declared as a string and checked in the verb.** The check is the closed set's,
+ * and seating it in the verb is what lets the refusal name the whole vocabulary and seat it on `10`
+ * rather than emit the parser's generic message.
+ */
+
+import {Effect, Option} from "effect";
+import {Argument, Command, Flag} from "effect/unstable/cli";
+import {leafCommand} from "../excess-operand.ts";
+import {readStdin} from "../io/stdin.ts";
+import type {VerbOutcome} from "../verb.ts";
+import {runAdd} from "./add-verb.ts";
+import {runCheck} from "./check-verb.ts";
+import {runDrift} from "./drift-verb.ts";
+import {runInit} from "./init-verb.ts";
+import {runLookup} from "./lookup-verb.ts";
+import {runSections} from "./sections-verb.ts";
+
+/** Write the outcome and exit on its code — stdout is the answer, everything else is stderr. */
+const emit = (outcome: VerbOutcome): Effect.Effect<void> =>
+	Effect.sync(() => {
+		for (const line of outcome.stderr) process.stderr.write(`${line}\n`);
+		if (outcome.stdout !== "") process.stdout.write(outcome.stdout);
+		process.exit(outcome.code);
+	});
+
+const dirFlag = Flag.string("dir").pipe(
+	Flag.withDefault(".glossary"),
+	Flag.withDescription(
+		"the directory holding the registers, resolved against the target repo root",
+	),
+);
+
+const jsonFlag = Flag.boolean("json").pipe(
+	Flag.withDescription("emit the JSON shape on stdout instead of the line grammar"),
+);
+
+const registerFlag = (fallback: string, vocabulary: string) =>
+	Flag.string("register").pipe(
+		Flag.withDefault(fallback),
+		Flag.withDescription(`which register to resolve against: one of ${vocabulary}`),
+	);
+
+const init = leafCommand(
+	"init",
+	{
+		register: Flag.string("register").pipe(
+			Flag.withDescription("which register to create: terms or language; both is refused"),
+		),
+		dir: dirFlag,
+		json: jsonFlag,
+	},
+	Effect.fn(function* ({register, dir, json}) {
+		yield* emit(yield* runInit({register, dir, json, cwd: process.cwd()}));
+	}),
+).pipe(
+	Command.withDescription(
+		"Create a register file that does not exist, so a fresh repo is not a dead end. Prints `created\\t<path>`, or the JSON object {action, path, register}. Exits 8 (the write failed, the outcome is UNKNOWN), 9 (written and the read-back does not match the template), 10 (--register both, or an off-enum value), 11 (a precondition read failed, nothing was written), 12 (the register already exists — refused, never overwritten). Example: fabrika glossary init --register terms",
+	),
+);
+
+const drift = leafCommand(
+	"drift",
+	{
+		register: registerFlag("terms", "terms, language, both"),
+		dir: dirFlag,
+		paths: Flag.string("paths").pipe(
+			Flag.withDefault(""),
+			Flag.withDescription(
+				"comma-separated pathspecs to diff; the default is every tracked path, never a fixed layout",
+			),
+		),
+		limit: Flag.integer("limit").pipe(
+			Flag.withDefault(40),
+			Flag.withDescription("how many candidates to emit, highest-ranked first"),
+		),
+		json: jsonFlag,
+	},
+	Effect.fn(function* ({register, dir, paths, limit, json}) {
+		yield* emit(yield* runDrift({register, dir, paths, limit, json, cwd: process.cwd()}));
+	}),
+).pipe(
+	Command.withDescription(
+		"The surfaces that moved since the register last changed, and the candidate coinages in them. Prints `drift`, `clean` or `bootstrap` on the first line — all three on exit 0 — then one `<phrase>\\t<hits>\\t<first-surface>` line per candidate. Exits 4 (the table structure is unparseable, so the declared set is UNKNOWN), 7 (--paths matched 0 tracked files), 10 (off-enum --register), 11 (--dir could not be read, or the range could not be computed). Example: fabrika glossary drift --register terms",
+	),
+);
+
+const lookup = leafCommand(
+	"lookup",
+	{
+		terms: Argument.string("term").pipe(
+			Argument.atLeast(0),
+			Argument.withDescription("the terms to resolve against the register(s), one line each"),
+		),
+		register: registerFlag("both", "terms, language, both"),
+		dir: dirFlag,
+		json: jsonFlag,
+	},
+	Effect.fn(function* ({terms, register, dir, json}) {
+		yield* emit(yield* runLookup({terms, register, dir, json, cwd: process.cwd()}));
+	}),
+).pipe(
+	Command.withDescription(
+		'Whether a term is already declared, and what overlaps it. Prints one `<state>\\t<register>\\t<section>\\t<matched>` line per term, in argument order — `declared`, `collision` and `absent` are all answers on exit 0. Exits 1 (no term given), 4 (a selected register has no parseable term table), 10 (off-enum --register), 11 (a selected register could not be read, so every state is UNKNOWN). Example: fabrika glossary lookup "front door" --register both',
+	),
+);
+
+const sections = leafCommand(
+	"sections",
+	{register: registerFlag("terms", "terms, language, both"), dir: dirFlag, json: jsonFlag},
+	Effect.fn(function* ({register, dir, json}) {
+		yield* emit(yield* runSections({register, dir, json, cwd: process.cwd()}));
+	}),
+).pipe(
+	Command.withDescription(
+		'The live section names of a register, so a caller reads them rather than recalling a list that rots. Prints one `<register>\\t<section>\\t<rows>` line per section in file order, or the single line `-\\tbootstrap\\t0` for a register that is absent or has no heading yet. Exits 4 (table rows under no "## " heading), 10 (off-enum --register), 11 (the register could not be read). Example: fabrika glossary sections --register terms',
+	),
+);
+
+const add = leafCommand(
+	"add",
+	{
+		term: Argument.string("term").pipe(
+			Argument.withDescription("the term, written into the row's first cell verbatim"),
+		),
+		register: Flag.string("register").pipe(
+			Flag.withDescription("which register to write: terms or language; both is refused"),
+		),
+		section: Flag.string("section").pipe(
+			Flag.withDescription(
+				"the section heading to insert under, matched verbatim against the live headings",
+			),
+		),
+		definitionFile: Flag.string("definition-file").pipe(
+			Flag.withDescription("the file holding the definition cell, or - for stdin"),
+		),
+		notFile: Flag.string("not-file").pipe(
+			Flag.optional,
+			Flag.withDescription("a file holding the Not cell; omitted means an empty third cell"),
+		),
+		replace: Flag.boolean("replace").pipe(
+			Flag.withDescription(
+				"rewrite the existing row for this term instead of refusing on collision",
+			),
+		),
+		createSection: Flag.boolean("create-section").pipe(
+			Flag.withDescription("create --section at the end of the register when it does not exist"),
+		),
+		dir: dirFlag,
+		json: jsonFlag,
+	},
+	Effect.fn(function* ({
+		term,
+		register,
+		section,
+		definitionFile,
+		notFile,
+		replace,
+		createSection,
+		dir,
+		json,
+	}) {
+		yield* emit(
+			yield* runAdd({
+				term,
+				register,
+				section,
+				definitionFile,
+				notFile: Option.getOrNull(notFile),
+				replace,
+				createSection,
+				dir,
+				json,
+				cwd: process.cwd(),
+				stdin: Effect.sync(readStdin),
+			}),
+		);
+	}),
+).pipe(
+	Command.withDescription(
+		'Insert or replace one row, alphabetically placed and byte-preserving everywhere else. Prints `<action>\\t<path>\\t<section>\\t<line>`. Exits 3 (stdin held nothing), 4 (no parseable table under --section), 8/9 (the write failed, the read-back differs), 10 (--register both or an off-enum value), 11 (a precondition read failed — nothing was written), 12 (already declared without --replace, or --replace on an absent term), 13 (--section names no heading), 14 (the composed row cannot be a well-formed table row), 15 (the edit would have changed a line outside the target row — aborted). Example: printf \'The board product.\' | fabrika glossary add "pano" --register terms --section "Core / shape" --definition-file -',
+	),
+);
+
+const check = leafCommand(
+	"check",
+	{
+		register: registerFlag("both", "terms, language, both"),
+		dir: dirFlag,
+		decisions: Flag.string("decisions").pipe(
+			Flag.withDefault(".decisions"),
+			Flag.withDescription(
+				"the decision-record directory a row's four-digit citations resolve against",
+			),
+		),
+		json: jsonFlag,
+	},
+	Effect.fn(function* ({register, dir, decisions, json}) {
+		yield* emit(yield* runCheck({register, dir, decisions, json, cwd: process.cwd()}));
+	}),
+).pipe(
+	Command.withDescription(
+		"Row-shape, duplicate-key, cross-register, ordering and citation-liveness defects in a register. Prints `clean`, `defects` or `bootstrap` on the first line — all three on exit 0 — then one `<kind>\\t<register>\\t<section>\\t<term>\\t<detail>` line per finding. Machine-local paths and dead links are deliberately not computed: a merge-blocking gate already decides each. Exits 4 (no parseable term table), 7 (a selected register is present and holds 0 rows), 10 (off-enum --register), 11 (a selected register could not be read). Example: fabrika glossary check --register both",
+	),
+);
+
+export const glossaryCommand = Command.make("glossary").pipe(
+	Command.withSubcommands([init, drift, lookup, sections, add, check]),
+	Command.withDescription(
+		"Maintain the repo's canonical vocabulary registers: what is already declared, what moved since one last changed, where a row goes, and which rows have gone stale",
+	),
+);

--- a/packages/fabrika-cli/src/glossary/contract-examples.test.ts
+++ b/packages/fabrika-cli/src/glossary/contract-examples.test.ts
@@ -1,0 +1,165 @@
+/**
+ * The contract's worked examples, reproduced byte for byte against the **committed** fixtures under
+ * `claude-plugins/fabrika/skills/glossary/evals/fixtures/`.
+ *
+ * In-process rather than through a subprocess: what is under test is the bytes each verb produces
+ * over a corpus that does not move, and a spawn per example would buy nothing but cost a cold
+ * node+TS load each (`.patterns/subprocess-test-budget.md`). The end-to-end facts a subprocess is
+ * the only witness for live in `glossary.cli.test.ts`.
+ *
+ * The reads are the real filesystem through `NodeServices.layer` — the same layer `run.ts` provides
+ * — so a fixture that moves reds here instead of drifting away from the document that pins it.
+ */
+import {copyFileSync, mkdtempSync, readFileSync, rmSync} from "node:fs";
+import {tmpdir} from "node:os";
+import {join} from "node:path";
+import {fileURLToPath} from "node:url";
+import {NodeServices} from "@effect/platform-node";
+import {Effect} from "effect";
+import {describe, expect, it} from "vitest";
+import {runAdd} from "./add-verb.ts";
+import {runCheck} from "./check-verb.ts";
+import {TERM_COLLISION, ZERO_SCOPE} from "./codes.ts";
+import {runDrift} from "./drift-verb.ts";
+import {runInit} from "./init-verb.ts";
+import {runLookup} from "./lookup-verb.ts";
+import {runSections} from "./sections-verb.ts";
+
+/** The two fixture directories, repo-relative exactly as the contract's examples spell them. */
+const REGISTERS = "claude-plugins/fabrika/skills/glossary/evals/fixtures/registers";
+const DECISIONS = "claude-plugins/fabrika/skills/glossary/evals/fixtures/decisions";
+const EMPTY = "claude-plugins/fabrika/skills/glossary/evals/fixtures/empty";
+
+/**
+ * The verbs resolve a relative `--dir` against the target repo's root, so the package directory is a
+ * fine cwd — the root walk finds the same place from anywhere inside the checkout.
+ */
+const cwd = process.cwd();
+/** The checkout root, for the one test that copies a fixture before writing to it. */
+const REPO_ROOT = fileURLToPath(new URL("../../../../", import.meta.url));
+
+const run = <A>(effect: Effect.Effect<A, never, NodeServices.NodeServices>) =>
+	Effect.runPromise(Effect.provide(effect, NodeServices.layer));
+
+describe("glossary sections, against the committed fixture register", () => {
+	it("names the three sections and their row counts", async () => {
+		const out = await run(runSections({register: "terms", dir: REGISTERS, json: false, cwd}));
+		expect(out.code).toBe(0);
+		expect(out.stdout).toBe(
+			"terms\tCore / shape\t2\nterms\tProducts (domains)\t3\nterms\tIndexing\t1\n",
+		);
+	});
+});
+
+describe("glossary lookup, against the committed fixture register", () => {
+	const lookup = (terms: ReadonlyArray<string>) =>
+		run(runLookup({terms, register: "terms", dir: REGISTERS, json: false, cwd}));
+
+	it("reports the first `pano` row, leaving the duplication to `check`", async () => {
+		expect((await lookup(["pano"])).stdout).toBe("declared\tterms\tCore / shape\tpano\n");
+	});
+
+	it("reports `tag` as overlapping `Database (tag)`, never as declared", async () => {
+		expect((await lookup(["tag"])).stdout).toBe("collision\tterms\tIndexing\tDatabase (tag)\n");
+	});
+
+	it("answers one line per term, in argument order", async () => {
+		expect((await lookup(["depo", "capture ledger"])).stdout).toBe(
+			"declared\tterms\tProducts (domains)\tdepo\nabsent\t-\t-\t-\n",
+		);
+	});
+});
+
+describe("glossary check, against the committed fixture register and decisions", () => {
+	it("finds exactly the two planted defects, on exit 0", async () => {
+		const out = await run(
+			runCheck({
+				register: "terms",
+				dir: REGISTERS,
+				decisions: DECISIONS,
+				json: false,
+				cwd,
+			}),
+		);
+		expect(out.code).toBe(0);
+		expect(out.stdout).toBe(
+			`defects
+duplicate-key\tterms\tProducts (domains)\tpano\talso declared in "Core / shape"
+citation-superseded\tterms\tCore / shape\tworker\tcites 0044, status "superseded by [0144](0144-depo-internal-asset-store.md)"
+`,
+		);
+	});
+
+	/**
+	 * The fixture's `LANGUAGE.md` is present and holds no table, so `--register both` — the verb's own
+	 * default — reds on zero scope over it while `--register terms` answers. Present-and-empty and
+	 * absent are different facts and never share a code (ADR 0092).
+	 */
+	it("reds on the present-and-empty LANGUAGE register under --register both", async () => {
+		const out = await run(
+			runCheck({register: "both", dir: REGISTERS, decisions: DECISIONS, json: false, cwd}),
+		);
+		expect(out.code).toBe(ZERO_SCOPE);
+		expect(out.stdout).toBe("");
+	});
+});
+
+describe("glossary drift, against the committed fixtures", () => {
+	it("answers bootstrap for a readable directory holding no register", async () => {
+		const out = await run(
+			runDrift({register: "terms", dir: EMPTY, paths: "", limit: 40, json: false, cwd}),
+		);
+		expect(out.code).toBe(0);
+		expect(out.stdout).toBe("bootstrap\n");
+	});
+});
+
+/**
+ * `add` writes, so it runs against a **copy** of the fixture in a temp directory — the committed
+ * corpus every example above resolves against must not move. The line number is the derivable half
+ * of the contract's example and is what this pins.
+ */
+describe("glossary add, against a copy of the committed fixture register", () => {
+	it("places `capture ledger` as the first row of Products (domains) — line 18", async () => {
+		const dir = mkdtempSync(join(tmpdir(), "fabrika-glossary-"));
+		copyFileSync(join(REPO_ROOT, REGISTERS, "TERMS.md"), join(dir, "TERMS.md"));
+		const before = readFileSync(join(dir, "TERMS.md"), "utf8");
+
+		const out = await run(
+			runAdd({
+				term: "capture ledger",
+				register: "terms",
+				section: "Products (domains)",
+				definitionFile: "-",
+				notFile: null,
+				replace: false,
+				createSection: false,
+				dir,
+				json: false,
+				cwd,
+				stdin: Effect.succeed({
+					_tag: "Text" as const,
+					text: "The append-only record of one capture run.",
+				}),
+			}),
+		);
+		expect(out.code).toBe(0);
+		expect(out.stdout).toBe(`added\t${dir}/TERMS.md\tProducts (domains)\t18\n`);
+
+		const after = readFileSync(join(dir, "TERMS.md"), "utf8").split("\n");
+		expect(after[17]).toBe("| capture ledger | The append-only record of one capture run. | |");
+		expect([...after.slice(0, 17), ...after.slice(18)]).toEqual(before.split("\n"));
+		rmSync(dir, {recursive: true, force: true});
+	});
+});
+
+describe("glossary init, against the committed fixture register", () => {
+	it("refuses to overwrite the register that is already there", async () => {
+		const out = await run(runInit({register: "terms", dir: REGISTERS, json: false, cwd}));
+		expect(out.code).toBe(TERM_COLLISION);
+		expect(out.stdout).toBe("");
+		expect(out.stderr.at(-1)).toBe(
+			`glossary init: ${REGISTERS}/TERMS.md already exists — refusing to overwrite a register.`,
+		);
+	});
+});

--- a/packages/fabrika-cli/src/glossary/drift-verb.ts
+++ b/packages/fabrika-cli/src/glossary/drift-verb.ts
@@ -1,0 +1,218 @@
+/**
+ * `glossary drift` — the surfaces that moved since a register last changed, and the candidate
+ * coinages in them.
+ *
+ * **The three outcomes are disjoint by construction, and all three exit 0.** `bootstrap` is reachable
+ * only from a directory that was *read* and holds no register (or one with zero rows); `clean` means
+ * the range was computed and every candidate was suppressed; `drift` means one survived. A `--dir`
+ * that could not be read is `11`, and a `--paths` matching nothing is `7` — answering `clean` there
+ * is exactly how v1 reported "no drift" forever against a layout the repo did not have (#4776).
+ *
+ * This verb reports; it never reds a merge (ADR 0128).
+ */
+
+import type {FileSystem} from "effect";
+import {Effect, Path} from "effect";
+import type {ChildProcessSpawner} from "effect/unstable/process";
+import {answer, refuse, type VerbOutcome} from "../verb.ts";
+import {type Candidate, rankCandidates} from "./candidates.ts";
+import {PRECONDITION_UNKNOWN, ZERO_SCOPE} from "./codes.ts";
+import {readRegister, registerFilesIn, resolveDir, selectRegisters} from "./guards.ts";
+import {commitsSince, filesChangedBy, lastCommitTouching, trackedFiles} from "./history.ts";
+import type {Row} from "./register.ts";
+
+const VERB = "glossary drift";
+
+export interface DriftOptions {
+	readonly register: string;
+	readonly dir: string;
+	/** Comma-separated pathspecs; empty means the whole tree, never a fixed layout. */
+	readonly paths: string;
+	readonly limit: number;
+	readonly json: boolean;
+	readonly cwd: string;
+}
+
+/** This verb reads disk and shells out, so it needs both platform seams. */
+type DriftEffect<A> = Effect.Effect<
+	A,
+	never,
+	FileSystem.FileSystem | Path.Path | ChildProcessSpawner.ChildProcessSpawner
+>;
+
+const messages = {
+	unreadable: (path: string, reason: string) =>
+		`${VERB}: cannot read ${path}: ${reason} — the declared set is UNKNOWN, never "0 declared".`,
+	malformed: (path: string, _reason: string) =>
+		`${VERB}: ${path} has no parseable term table — the declared set is UNKNOWN.`,
+};
+
+interface Live {
+	readonly display: string;
+	readonly path: string;
+	readonly rows: ReadonlyArray<Row>;
+}
+
+export const runDrift = (options: DriftOptions): DriftEffect<VerbOutcome> =>
+	Effect.gen(function* () {
+		const selected = selectRegisters(VERB, options.register, {allowed: true, refusal: ""});
+		if (selected._tag === "Refused") return selected.outcome;
+
+		const dir = yield* resolveDir(VERB, options.cwd, options.dir);
+		if (dir._tag === "Refused") return dir.outcome;
+		const files = registerFilesIn(dir.value, selected.value, yield* Path.Path);
+
+		const live: Live[] = [];
+		let bootstrapReason: string | null = null;
+		for (const file of files) {
+			const state = yield* readRegister(file, messages);
+			if (state._tag === "Refused") return state.outcome;
+			if (state.value._tag === "Absent") {
+				bootstrapReason ??= `no register at ${file.display} — this repo has not adopted one yet, which is bootstrap, not empty drift`;
+				continue;
+			}
+			if (state.value.parsed.rows.length === 0) {
+				bootstrapReason ??= `the register at ${file.display} parsed to 0 rows — bootstrap, not empty drift`;
+				continue;
+			}
+			live.push({display: file.display, path: file.path, rows: state.value.parsed.rows});
+		}
+
+		if (live.length === 0) {
+			const reason =
+				bootstrapReason ??
+				`no register at ${dir.value.display} — this repo has not adopted one yet, which is bootstrap, not empty drift`;
+			return emit(
+				{outcome: "bootstrap", candidates: [], reason, sinceCommit: null, scannedCommits: 0},
+				0,
+				options.json,
+				[`${VERB}: ${reason}.`],
+			);
+		}
+
+		const declared = new Set(live.flatMap((register) => register.rows.map((row) => row.key)));
+
+		const pathspecs = options.paths
+			.split(",")
+			.map((spec) => spec.trim())
+			.filter((spec) => spec !== "");
+		if (pathspecs.length > 0) {
+			const tracked = yield* trackedFiles(pathspecs);
+			if (tracked._tag === "Failure") {
+				return refuse(
+					PRECONDITION_UNKNOWN,
+					`${VERB}: cannot list the tracked files matching --paths ${options.paths}: ${tracked.reason} — the range is UNKNOWN.`,
+				);
+			}
+			if (tracked.value.length === 0) {
+				return refuse(
+					ZERO_SCOPE,
+					`${VERB}: --paths ${options.paths} matched 0 tracked files — refusing to report a clean sweep of nothing (ADR 0092).`,
+				);
+			}
+		}
+
+		// With two registers the range starts at the OLDER of their last changes, so nothing that moved
+		// since either one last changed falls outside the sweep — this list is recall-biased by design.
+		let since: {sha: string; when: number} | null = null;
+		for (const register of live) {
+			const stamp = yield* lastCommitTouching(register.path);
+			if (stamp._tag === "Failure") {
+				return refuse(
+					PRECONDITION_UNKNOWN,
+					`${VERB}: cannot resolve the commit that last changed ${register.display}: ${stamp.reason} — the range is UNKNOWN, never "never committed".`,
+				);
+			}
+			if (since === null || stamp.value.when < since.when) since = stamp.value;
+		}
+		const sinceCommit = (since as {sha: string; when: number}).sha;
+
+		const commits = yield* commitsSince(sinceCommit, pathspecs);
+		if (commits._tag === "Failure") {
+			return refuse(
+				PRECONDITION_UNKNOWN,
+				`${VERB}: cannot read the commit range ${sinceCommit}..HEAD: ${commits.reason} — the range is UNKNOWN.`,
+			);
+		}
+
+		const scope = `${VERB}: swept ${commits.value.length} commit(s) since ${sinceCommit} against ${declared.size} declared key(s).`;
+		const ranked = rankCandidates(commits.value, declared, options.limit);
+		if (ranked.length === 0) {
+			const reason = `swept ${commits.value.length} commit(s) since ${sinceCommit}; every candidate was already declared — this is a clean sweep, not an unread range`;
+			return emit(
+				{
+					outcome: "clean",
+					candidates: [],
+					reason,
+					sinceCommit,
+					scannedCommits: commits.value.length,
+				},
+				declared.size,
+				options.json,
+				[scope, `${VERB}: ${reason}.`],
+			);
+		}
+
+		const surfaces: {phrase: string; hits: number; firstSurface: string}[] = [];
+		const cache = new Map<string, string>();
+		for (const candidate of ranked) {
+			surfaces.push({
+				phrase: candidate.phrase,
+				hits: candidate.hits,
+				firstSurface: yield* firstSurfaceOf(candidate, cache),
+			});
+		}
+		return emit(
+			{
+				outcome: "drift",
+				candidates: surfaces,
+				reason: null,
+				sinceCommit,
+				scannedCommits: commits.value.length,
+			},
+			declared.size,
+			options.json,
+			[scope],
+		);
+	});
+
+/** The first file the earliest contributing commit changed. An unreadable commit reports `-`. */
+const firstSurfaceOf = (candidate: Candidate, cache: Map<string, string>): DriftEffect<string> =>
+	Effect.gen(function* () {
+		const known = cache.get(candidate.firstCommit);
+		if (known !== undefined) return known;
+		const changed = yield* filesChangedBy(candidate.firstCommit);
+		const surface = changed._tag === "Failure" ? "-" : (changed.value[0] ?? "-");
+		cache.set(candidate.firstCommit, surface);
+		return surface;
+	});
+
+interface DriftResult {
+	readonly outcome: string;
+	readonly candidates: ReadonlyArray<{
+		readonly phrase: string;
+		readonly hits: number;
+		readonly firstSurface: string;
+	}>;
+	readonly reason: string | null;
+	readonly sinceCommit: string | null;
+	readonly scannedCommits: number;
+}
+
+const emit = (
+	result: DriftResult,
+	declaredKeys: number,
+	json: boolean,
+	diagnostics: ReadonlyArray<string>,
+): VerbOutcome =>
+	json
+		? answer(JSON.stringify({...result, declaredKeys}), diagnostics)
+		: answer(
+				[
+					result.outcome,
+					...result.candidates.map(
+						(candidate) => `${candidate.phrase}\t${candidate.hits}\t${candidate.firstSurface}`,
+					),
+				].join("\n"),
+				diagnostics,
+			);

--- a/packages/fabrika-cli/src/glossary/drift-verb.unit.test.ts
+++ b/packages/fabrika-cli/src/glossary/drift-verb.unit.test.ts
@@ -1,0 +1,166 @@
+import {Effect, Layer} from "effect";
+import {describe, expect, it} from "vitest";
+import {errOut, type FakeFs, fakeFs, fakeShell, okOut} from "../fakes.test-support.ts";
+import {OFF_VOCABULARY, PRECONDITION_UNKNOWN, ZERO_SCOPE} from "./codes.ts";
+import {runDrift} from "./drift-verb.ts";
+import {DIR, LANGUAGE_NO_ROWS, REPO, TERMS, TERMS_PATH} from "./fixtures.test-support.ts";
+
+const FIELD = "\u001f";
+const RECORD = "\u001e";
+
+const commit = (sha: string, subject: string, body = "") =>
+	`${sha}${FIELD}${subject}${FIELD}${body}${RECORD}`;
+
+const options = {register: "terms", dir: DIR, paths: "", limit: 40, json: false, cwd: REPO};
+
+const shell = (
+	log: string,
+	extra: ReadonlyArray<readonly [RegExp, ReturnType<typeof okOut>]> = [],
+) =>
+	fakeShell([
+		[/git log -n 1 --format=%H %ct/, okOut("abc1234 1700000000\n")],
+		[/git ls-files/, okOut("apps/web/src/index.ts\n")],
+		[/git show --name-only/, okOut("src/capture/ledger.ts\napps/web/x.ts\n")],
+		[/git log --reverse/, okOut(log)],
+		...extra,
+	]);
+
+const run = (
+	fs: FakeFs,
+	sh: ReturnType<typeof fakeShell>,
+	overrides: Partial<typeof options> = {},
+) =>
+	Effect.runPromise(
+		Effect.provide(runDrift({...options, ...overrides}), Layer.merge(fs.layer, sh.layer)),
+	);
+
+const populated = () =>
+	fakeFs({dirs: {"/repo/.glossary": ["TERMS.md"]}, files: {[TERMS_PATH]: TERMS}});
+
+describe("runDrift", () => {
+	it("answers drift with one tab-separated line per candidate", async () => {
+		const out = await run(populated(), shell(commit("aaa", 'add "capture ledger" to the worker')));
+		expect(out.code).toBe(0);
+		const lines = out.stdout.split("\n").filter((line) => line !== "");
+		expect(lines[0]).toBe("drift");
+		expect(lines).toContain("capture ledger\t1\tsrc/capture/ledger.ts");
+	});
+
+	it("suppresses a candidate whose normalized key is already declared", async () => {
+		const out = await run(populated(), shell(commit("aaa", 'add "depo" and "pano"')));
+		expect(out.stdout.split("\n")[0]).toBe("clean");
+	});
+
+	it("answers clean with the pinned reason, so `no drift` is not silence", async () => {
+		const out = await run(populated(), shell(""));
+		expect(out.code).toBe(0);
+		expect(out.stdout).toBe("clean\n");
+		expect(out.stderr.at(-1)).toBe(
+			"glossary drift: swept 0 commit(s) since abc1234; every candidate was already declared — this is a clean sweep, not an unread range.",
+		);
+	});
+
+	it("answers bootstrap for a --dir that was read and holds no register", async () => {
+		const out = await run(fakeFs({dirs: {"/repo/.glossary": []}, files: {}}), shell(""));
+		expect(out.code).toBe(0);
+		expect(out.stdout).toBe("bootstrap\n");
+		expect(out.stderr.at(-1)).toContain("which is bootstrap, not empty drift");
+	});
+
+	it("answers bootstrap for a register that parses to zero rows", async () => {
+		const io = fakeFs({
+			dirs: {"/repo/.glossary": ["TERMS.md"]},
+			files: {[TERMS_PATH]: LANGUAGE_NO_ROWS},
+		});
+		const out = await run(io, shell(""));
+		expect(out.stdout).toBe("bootstrap\n");
+		expect(out.stderr.at(-1)).toContain("parsed to 0 rows — bootstrap, not empty drift");
+	});
+
+	// v1 defaulted the pathspec to a literal `apps packages`, so a repo with another layout got a
+	// permanently empty diff that read as "no drift" (#4776). A pathspec matching nothing is a red.
+	it("reds on a --paths that matched 0 tracked files, rather than reporting clean", async () => {
+		const out = await run(
+			populated(),
+			fakeShell([
+				[/git ls-files/, okOut("")],
+				[/git log -n 1/, okOut("abc1234 1700000000\n")],
+			]),
+			{paths: "no/such/dir"},
+		);
+		expect(out.code).toBe(ZERO_SCOPE);
+		expect(out.stdout).toBe("");
+		expect(out.stderr.at(-1)).toBe(
+			"glossary drift: --paths no/such/dir matched 0 tracked files — refusing to report a clean sweep of nothing (ADR 0092).",
+		);
+	});
+
+	it("refuses an unreadable --dir — the declared set is UNKNOWN, never `0 declared`", async () => {
+		const out = await run(fakeFs({dirs: {}, files: {}, unprobeable: [TERMS_PATH]}), shell(""));
+		expect(out.code).toBe(PRECONDITION_UNKNOWN);
+		expect(out.stdout).toBe("");
+		expect(out.stderr.at(-1)).toContain('never "0 declared"');
+	});
+
+	/**
+	 * v1 captured the last commit without checking the status, then read an empty capture as "never
+	 * committed" and reported bootstrap — which a shallow clone reproduces on a register that IS
+	 * committed. An unresolvable range is UNKNOWN here.
+	 */
+	it("refuses an unresolvable range rather than calling it never committed", async () => {
+		const out = await run(
+			populated(),
+			fakeShell([
+				[/git log -n 1/, okOut("")],
+				[/git ls-files/, okOut("x\n")],
+			]),
+		);
+		expect(out.code).toBe(PRECONDITION_UNKNOWN);
+		expect(out.stdout).toBe("");
+		expect(out.stderr.at(-1)).toContain('never "never committed"');
+	});
+
+	it("refuses a commit-range read that failed", async () => {
+		const out = await run(
+			populated(),
+			fakeShell([
+				[/git log -n 1/, okOut("abc1234 1700000000\n")],
+				[/git log --reverse/, errOut("fatal: bad revision")],
+			]),
+		);
+		expect(out.code).toBe(PRECONDITION_UNKNOWN);
+	});
+
+	it("refuses an off-enum --register", async () => {
+		const out = await run(populated(), shell(""), {register: "sozluk"});
+		expect(out.code).toBe(OFF_VOCABULARY);
+	});
+
+	it("carries the counts the outcome is only readable against, in --json", async () => {
+		const out = await run(populated(), shell(""), {json: true});
+		expect(JSON.parse(out.stdout)).toEqual({
+			outcome: "clean",
+			candidates: [],
+			reason:
+				"swept 0 commit(s) since abc1234; every candidate was already declared — this is a clean sweep, not an unread range",
+			sinceCommit: "abc1234",
+			scannedCommits: 0,
+			declaredKeys: 5,
+		});
+	});
+
+	it("counts distinct KEYS rather than rows, so a planted duplicate collapses", async () => {
+		const out = await run(populated(), shell(""), {json: true});
+		// The fixture's six rows carry five distinct keys — `pano` is declared twice.
+		expect(JSON.parse(out.stdout).declaredKeys).toBe(5);
+	});
+
+	it("honours --limit", async () => {
+		const out = await run(
+			populated(),
+			shell(commit("aaa", "add capture ledger rotation policy today")),
+			{limit: 2},
+		);
+		expect(out.stdout.split("\n").filter((line) => line !== "")).toHaveLength(3);
+	});
+});

--- a/packages/fabrika-cli/src/glossary/edit.ts
+++ b/packages/fabrika-cli/src/glossary/edit.ts
@@ -1,0 +1,100 @@
+/**
+ * Where a row goes, and the assertion that nothing else moved.
+ *
+ * The one-row invariant is what makes "change only the affected rows, do not re-sort the file" a
+ * mechanism rather than a hope: the verb composes the new text, asks {@link linesChangedBeyond}
+ * whether the result differs from the original anywhere but the target splice, and aborts the write
+ * when it does. It is the `adr supersede` idiom reseated on this group's `15`.
+ */
+import {compareKeys} from "./findings.ts";
+import type {Section} from "./register.ts";
+
+/** The splice a verb intends: remove `replaced` lines at `at`, insert `added` of its own. */
+export interface Splice {
+	/** 0-based line index. */
+	readonly at: number;
+	readonly added: number;
+	readonly replaced: number;
+}
+
+/**
+ * How many lines the edit touched **outside** its intended splice. `0` is the invariant holding.
+ *
+ * The expectation is rebuilt from `after`'s own inserted slice, so the only thing being compared is
+ * whether everything around the splice survived byte for byte.
+ */
+export const linesChangedBeyond = (
+	before: ReadonlyArray<string>,
+	after: ReadonlyArray<string>,
+	splice: Splice,
+): number => {
+	const expected = [
+		...before.slice(0, splice.at),
+		...after.slice(splice.at, splice.at + splice.added),
+		...before.slice(splice.at + splice.replaced),
+	];
+	let changed = Math.abs(expected.length - after.length);
+	for (let i = 0; i < Math.min(expected.length, after.length); i += 1) {
+		if (expected[i] !== after[i]) changed += 1;
+	}
+	return changed;
+};
+
+export interface Placement {
+	/** 0-based index the new row's line is inserted at. */
+	readonly index: number;
+	/** True when the section's existing rows were not already in ascending key order. */
+	readonly unsorted: boolean;
+}
+
+/**
+ * Where a row with `key` belongs in `section`.
+ *
+ * The rows are placed in ascending key order. Where the section's existing rows are **not** already
+ * sorted, the row takes the first position that keeps it ordered against its immediate neighbours —
+ * the verb never re-sorts rows it was not asked to write.
+ */
+export const placeRow = (section: Section, key: string): Placement => {
+	const keys = section.rows.map((row) => row.key);
+	const unsorted = keys.some(
+		(current, index) => index > 0 && compareKeys(keys[index - 1] as string, current) > 0,
+	);
+	if (section.rows.length === 0) {
+		return {index: section.separatorLine ?? 0, unsorted: false};
+	}
+
+	for (let i = 0; i <= keys.length; i += 1) {
+		const before = i === 0 || compareKeys(keys[i - 1] as string, key) <= 0;
+		const after = i === keys.length || compareKeys(key, keys[i] as string) <= 0;
+		if (before && after) return {index: lineIndexAt(section, i), unsorted};
+	}
+	const firstGreater = keys.findIndex((existing) => compareKeys(key, existing) < 0);
+	return {
+		index: lineIndexAt(section, firstGreater === -1 ? keys.length : firstGreater),
+		unsorted,
+	};
+};
+
+/** The 0-based line index row slot `i` occupies — one past the last row when `i` is the end. */
+const lineIndexAt = (section: Section, i: number): number => {
+	const at = section.rows[i];
+	if (at !== undefined) return at.line - 1;
+	const last = section.rows[section.rows.length - 1];
+	return last === undefined ? (section.separatorLine ?? 0) : last.line;
+};
+
+/** The five lines `--create-section` appends: a blank line, the heading, the two table rows, the row. */
+export const newSectionBlock = (section: string, row: string): ReadonlyArray<string> => [
+	"",
+	`## ${section}`,
+	"| Term | Definition | Not |",
+	"|---|---|---|",
+	row,
+];
+
+/**
+ * Where a new section's block is appended: past the last line of content, before a trailing empty
+ * element that a file ending in a newline splits into.
+ */
+export const appendIndex = (lines: ReadonlyArray<string>): number =>
+	lines.length > 0 && lines[lines.length - 1] === "" ? lines.length - 1 : lines.length;

--- a/packages/fabrika-cli/src/glossary/edit.unit.test.ts
+++ b/packages/fabrika-cli/src/glossary/edit.unit.test.ts
@@ -1,0 +1,118 @@
+import {describe, expect, it} from "vitest";
+import {appendIndex, linesChangedBeyond, newSectionBlock, placeRow} from "./edit.ts";
+import {parseRegister, type Section} from "./register.ts";
+
+const register = `# fixture
+
+## Products
+
+| Term | Definition | Not |
+|---|---|---|
+| depo | The internal asset store. | |
+| pano | The board product. | |
+| sozluk | The dictionary product. | |
+`;
+
+const sectionOf = (text: string, name: string): Section => {
+	const parsed = parseRegister(text);
+	if (parsed._tag !== "Parsed") throw new Error("fixture does not parse");
+	const found = parsed.value.sections.find((section) => section.name === name);
+	if (found === undefined) throw new Error(`no section ${name}`);
+	return found;
+};
+
+describe("placeRow", () => {
+	const products = sectionOf(register, "Products");
+
+	it("places a key before the first row that sorts after it", () => {
+		expect(placeRow(products, "capture ledger").index).toBe(6);
+	});
+
+	it("places a key that sorts last one past the final row", () => {
+		expect(placeRow(products, "worker").index).toBe(9);
+	});
+
+	it("reports a sorted section as sorted", () => {
+		expect(placeRow(products, "capture ledger").unsorted).toBe(false);
+	});
+
+	it("names an unsorted section and still places the row against its neighbours", () => {
+		const unsorted = sectionOf(
+			`## Products
+
+| Term | Definition | Not |
+|---|---|---|
+| sozluk | x | |
+| depo | y | |
+`,
+			"Products",
+		);
+		const placement = placeRow(unsorted, "pano");
+		expect(placement.unsorted).toBe(true);
+		// The first slot that holds against its neighbours — `pano` sorts before `sozluk`, and the
+		// rows below it are left exactly where they were.
+		expect(placement.index).toBe(4);
+	});
+
+	it("places the first row of a table that has a header and no rows yet", () => {
+		const empty = sectionOf(
+			`## Products
+
+| Term | Definition | Not |
+|---|---|---|
+`,
+			"Products",
+		);
+		expect(placeRow(empty, "depo").index).toBe(4);
+	});
+});
+
+describe("linesChangedBeyond", () => {
+	const before = register.split("\n");
+
+	it("is 0 for a single inserted row", () => {
+		const after = [...before.slice(0, 6), "| capture ledger | x | |", ...before.slice(6)];
+		expect(linesChangedBeyond(before, after, {at: 6, added: 1, replaced: 0})).toBe(0);
+	});
+
+	it("is 0 for a single rewritten row", () => {
+		const after = [...before];
+		after[7] = "| pano | The board product, redefined. | |";
+		expect(linesChangedBeyond(before, after, {at: 7, added: 1, replaced: 1})).toBe(0);
+	});
+
+	it("is 0 for the five lines --create-section appends", () => {
+		const at = appendIndex(before);
+		const block = newSectionBlock("Indexing", "| tag | x | |");
+		const after = [...before.slice(0, at), ...block, ...before.slice(at)];
+		expect(linesChangedBeyond(before, after, {at, added: block.length, replaced: 0})).toBe(0);
+	});
+
+	/**
+	 * The defect the assertion exists to abort: a write that also re-sorts the section it touched. It
+	 * is what makes "change only the affected rows" a mechanism rather than a hope.
+	 */
+	it("counts every line a re-sort moved, which is what aborts the write on 15", () => {
+		const after = [
+			...before.slice(0, 6),
+			"| capture ledger | x | |",
+			"| sozluk | The dictionary product. | |",
+			"| pano | The board product. | |",
+			"| depo | The internal asset store. | |",
+			...before.slice(9),
+		];
+		expect(linesChangedBeyond(before, after, {at: 6, added: 1, replaced: 0})).toBeGreaterThan(0);
+	});
+
+	it("counts a trailing truncation the splice did not ask for", () => {
+		const after = [...before.slice(0, 6), "| capture ledger | x | |", ...before.slice(6, -2)];
+		expect(linesChangedBeyond(before, after, {at: 6, added: 1, replaced: 0})).toBeGreaterThan(0);
+	});
+});
+
+describe("appendIndex", () => {
+	it("appends before the empty element a trailing newline splits into", () => {
+		expect(appendIndex(["a", "b", ""])).toBe(2);
+		expect(appendIndex(["a", "b"])).toBe(2);
+	});
+});

--- a/packages/fabrika-cli/src/glossary/findings.ts
+++ b/packages/fabrika-cli/src/glossary/findings.ts
@@ -1,0 +1,188 @@
+/**
+ * What `glossary check` looks for, as a pure function of parsed rows plus resolved citations.
+ *
+ * Each `kind` is a decidable predicate over the file; what to *do* about one is the skill's. The
+ * `detail` text is fixed per kind because a caller may grep it.
+ */
+import type {RegisterName, Row} from "./register.ts";
+
+export type FindingKind =
+	| "row-shape"
+	| "duplicate-key"
+	| "cross-register"
+	| "out-of-order"
+	| "citation-dead"
+	| "citation-superseded"
+	| "citations-unverified";
+
+/** The closed set, in the order findings are emitted. */
+export const KINDS: ReadonlyArray<FindingKind> = [
+	"row-shape",
+	"duplicate-key",
+	"cross-register",
+	"out-of-order",
+	"citation-dead",
+	"citation-superseded",
+	"citations-unverified",
+];
+
+export interface Finding {
+	readonly kind: FindingKind;
+	readonly register: string;
+	readonly section: string;
+	readonly term: string;
+	readonly detail: string;
+}
+
+export interface RegisterRows {
+	readonly register: RegisterName;
+	readonly rows: ReadonlyArray<Row>;
+}
+
+/** What a cited decision id resolved to. `Dead` is proven absence, never a failed read. */
+export type CitationState =
+	| {readonly _tag: "Live"}
+	| {readonly _tag: "Dead"}
+	| {readonly _tag: "Superseded"; readonly status: string};
+
+const CITATION = /\b(\d{4})\b/g;
+
+/** The four-digit ids a row cites — cells 2 and 3 only, never the term itself. */
+export const citationsOf = (row: Row): ReadonlyArray<string> => {
+	const text = [row.cells[1] ?? "", row.cells[2] ?? ""].join(" ");
+	return [...text.matchAll(CITATION)].map((match) => match[1] as string);
+};
+
+const collator = new Intl.Collator("en", {sensitivity: "base"});
+
+/** Ascending `normalizeKey` order — the order `add` places a row into and `check` reports against. */
+export const compareKeys = (a: string, b: string): number => collator.compare(a, b);
+
+const rowShape = (register: string, row: Row): Finding | null => {
+	if (row.cells.length !== 3) {
+		return {
+			kind: "row-shape",
+			register,
+			section: row.section,
+			term: row.term,
+			detail: `expected 3 cells, found ${row.cells.length}`,
+		};
+	}
+	// The third cell — `Not` — is legitimately empty on most rows, so only 1 and 2 are required.
+	for (const index of [0, 1]) {
+		if ((row.cells[index] ?? "") === "") {
+			return {
+				kind: "row-shape",
+				register,
+				section: row.section,
+				term: row.term,
+				detail: `cell ${index + 1} is empty`,
+			};
+		}
+	}
+	return null;
+};
+
+export interface DefectInput {
+	readonly registers: ReadonlyArray<RegisterRows>;
+	/** Cited id → what it resolved to. Absent from the map means it was never resolved. */
+	readonly citations: ReadonlyMap<string, CitationState>;
+	/** The reason `--decisions` could not be read, or `null` when it was. */
+	readonly citationsUnverified: string | null;
+	readonly decisionsDir: string;
+}
+
+export const findDefects = (input: DefectInput): ReadonlyArray<Finding> => {
+	const findings: Finding[] = [];
+
+	for (const {register, rows} of input.registers) {
+		const seen = new Map<string, Row>();
+		for (const row of rows) {
+			const shape = rowShape(register, row);
+			if (shape !== null) findings.push(shape);
+
+			const earlier = seen.get(row.key);
+			if (earlier === undefined) seen.set(row.key, row);
+			else {
+				findings.push({
+					kind: "duplicate-key",
+					register,
+					section: row.section,
+					term: row.term,
+					detail: `also declared in "${earlier.section}"`,
+				});
+			}
+		}
+
+		for (const [index, row] of rows.entries()) {
+			const previous = rows[index - 1];
+			if (previous === undefined || previous.section !== row.section) continue;
+			if (compareKeys(previous.key, row.key) <= 0) continue;
+			findings.push({
+				kind: "out-of-order",
+				register,
+				section: row.section,
+				term: row.term,
+				detail: `sorts before "${previous.term}"`,
+			});
+		}
+	}
+
+	const [first, second] = input.registers;
+	if (first !== undefined && second !== undefined) {
+		const earlier = new Map(first.rows.map((row) => [row.key, row] as const));
+		for (const row of second.rows) {
+			const twin = earlier.get(row.key);
+			if (twin === undefined) continue;
+			findings.push({
+				kind: "cross-register",
+				register: second.register,
+				section: row.section,
+				term: row.term,
+				detail: `also declared in ${first.register} under "${twin.section}"`,
+			});
+		}
+	}
+
+	for (const {register, rows} of input.registers) {
+		for (const row of rows) {
+			for (const id of citationsOf(row)) {
+				const state = input.citations.get(id);
+				if (state === undefined || state._tag === "Live") continue;
+				findings.push(
+					state._tag === "Dead"
+						? {
+								kind: "citation-dead",
+								register,
+								section: row.section,
+								term: row.term,
+								detail: `cites ${id}, no record under ${input.decisionsDir}`,
+							}
+						: {
+								kind: "citation-superseded",
+								register,
+								section: row.section,
+								term: row.term,
+								detail: `cites ${id}, status "${state.status}"`,
+							},
+				);
+			}
+		}
+	}
+
+	if (input.citationsUnverified !== null) {
+		findings.push({
+			kind: "citations-unverified",
+			register: "-",
+			section: "-",
+			term: "-",
+			detail: `cannot read ${input.decisionsDir}: ${input.citationsUnverified}`,
+		});
+	}
+
+	return [...findings].sort((a, b) => KINDS.indexOf(a.kind) - KINDS.indexOf(b.kind));
+};
+
+/** The line grammar for one finding: `<kind>\t<register>\t<section>\t<term>\t<detail>`. */
+export const renderFinding = (finding: Finding): string =>
+	[finding.kind, finding.register, finding.section, finding.term, finding.detail].join("\t");

--- a/packages/fabrika-cli/src/glossary/findings.unit.test.ts
+++ b/packages/fabrika-cli/src/glossary/findings.unit.test.ts
@@ -1,0 +1,190 @@
+import {describe, expect, it} from "vitest";
+import {citationsOf, findDefects, type RegisterRows, renderFinding} from "./findings.ts";
+import {parseRegister, type Row} from "./register.ts";
+
+const rowsOf = (text: string): ReadonlyArray<Row> => {
+	const parsed = parseRegister(text);
+	if (parsed._tag !== "Parsed") throw new Error("fixture does not parse");
+	return parsed.value.rows;
+};
+
+const terms = (text: string): RegisterRows => ({register: "terms", rows: rowsOf(text)});
+
+const noCitations = {
+	citations: new Map(),
+	citationsUnverified: null,
+	decisionsDir: ".decisions",
+};
+
+describe("citationsOf", () => {
+	it("reads four-digit ids out of cells 2 and 3, never the term", () => {
+		const row = rowsOf(`## S
+
+| Term | Definition | Not |
+|---|---|---|
+| 0044 | Cites 0144. | see 0246 |
+`)[0] as Row;
+		expect(citationsOf(row)).toEqual(["0144", "0246"]);
+	});
+});
+
+describe("findDefects", () => {
+	it("reports a short row and an empty required cell, and never an empty Not cell", () => {
+		const findings = findDefects({
+			registers: [
+				terms(`## S
+
+| Term | Definition | Not |
+|---|---|---|
+| pano | The board. | |
+| depo | |
+| | x | |
+`),
+			],
+			...noCitations,
+		});
+		expect(
+			findings.filter((finding) => finding.kind === "row-shape").map((finding) => finding.detail),
+		).toEqual(["expected 3 cells, found 2", "cell 1 is empty"]);
+	});
+
+	it("reports a duplicate key against the LATER row, naming the earlier section", () => {
+		const findings = findDefects({
+			registers: [
+				terms(`## Core / shape
+
+| Term | Definition | Not |
+|---|---|---|
+| pano | The board. | |
+
+## Products (domains)
+
+| Term | Definition | Not |
+|---|---|---|
+| pano | The board again. | |
+`),
+			],
+			...noCitations,
+		});
+		expect(findings).toEqual([
+			{
+				kind: "duplicate-key",
+				register: "terms",
+				section: "Products (domains)",
+				term: "pano",
+				detail: 'also declared in "Core / shape"',
+			},
+		]);
+	});
+
+	// One term, one register, one row (#4465).
+	it("reports a key declared in both registers as cross-register", () => {
+		const table = `## S
+
+| Term | Definition | Not |
+|---|---|---|
+| seam | A boundary. | |
+`;
+		const findings = findDefects({
+			registers: [terms(table), {register: "language", rows: rowsOf(table)}],
+			...noCitations,
+		});
+		expect(findings.map((finding) => finding.kind)).toEqual(["cross-register"]);
+		expect(findings[0]?.detail).toBe('also declared in terms under "S"');
+	});
+
+	it("reports a row that sorts before the row above it, within its section", () => {
+		const findings = findDefects({
+			registers: [
+				terms(`## S
+
+| Term | Definition | Not |
+|---|---|---|
+| sozluk | x | |
+| depo | y | |
+`),
+			],
+			...noCitations,
+		});
+		expect(findings[0]).toMatchObject({kind: "out-of-order", detail: 'sorts before "sozluk"'});
+	});
+
+	it("separates a citation with no record from one whose record is not live", () => {
+		const findings = findDefects({
+			registers: [
+				terms(`## S
+
+| Term | Definition | Not |
+|---|---|---|
+| depo | Cites 0044 and 9999. | |
+`),
+			],
+			citations: new Map([
+				["0044", {_tag: "Superseded" as const, status: "superseded by [0144](0144-x.md)"}],
+				["9999", {_tag: "Dead" as const}],
+			]),
+			citationsUnverified: null,
+			decisionsDir: ".decisions",
+		});
+		expect(findings.map((finding) => finding.detail)).toEqual([
+			"cites 9999, no record under .decisions",
+			'cites 0044, status "superseded by [0144](0144-x.md)"',
+		]);
+	});
+
+	it("reports an unresolved decision corpus rather than reporting clean over it", () => {
+		const findings = findDefects({
+			registers: [
+				terms(`## S
+
+| Term | Definition | Not |
+|---|---|---|
+| depo | Cites 0044. | |
+`),
+			],
+			citations: new Map(),
+			citationsUnverified: "ENOENT",
+			decisionsDir: ".decisions",
+		});
+		expect(findings).toEqual([
+			{
+				kind: "citations-unverified",
+				register: "-",
+				section: "-",
+				term: "-",
+				detail: "cannot read .decisions: ENOENT",
+			},
+		]);
+	});
+
+	it("finds nothing in a clean register", () => {
+		expect(
+			findDefects({
+				registers: [
+					terms(`## S
+
+| Term | Definition | Not |
+|---|---|---|
+| depo | The internal asset store. | |
+| pano | The board product. | |
+`),
+				],
+				...noCitations,
+			}),
+		).toEqual([]);
+	});
+});
+
+describe("renderFinding", () => {
+	it("is five tab-separated columns", () => {
+		expect(
+			renderFinding({
+				kind: "duplicate-key",
+				register: "terms",
+				section: "Products (domains)",
+				term: "pano",
+				detail: 'also declared in "Core / shape"',
+			}),
+		).toBe('duplicate-key\tterms\tProducts (domains)\tpano\talso declared in "Core / shape"');
+	});
+});

--- a/packages/fabrika-cli/src/glossary/fixtures.test-support.ts
+++ b/packages/fabrika-cli/src/glossary/fixtures.test-support.ts
@@ -1,0 +1,57 @@
+/**
+ * The in-memory corpus the `glossary` verb tests resolve against.
+ *
+ * Deliberately **not** a copy of the committed fixture register under
+ * `claude-plugins/fabrika/skills/glossary/evals/fixtures/` — that one is read for real by
+ * `contract-examples.test.ts`, and a second copy here would be free to drift from the bytes the
+ * contract's examples are pinned to.
+ */
+
+export const REPO = "/repo";
+export const DIR = ".glossary";
+export const TERMS_PATH = "/repo/.glossary/TERMS.md";
+export const LANGUAGE_PATH = "/repo/.glossary/LANGUAGE.md";
+
+/** Two sections, five rows, one planted duplicate key and one citation to resolve. */
+export const TERMS = `# repo domain vocabulary (TERMS)
+
+Prose that mentions #3227). as a bare hash, which is not a heading.
+
+## Core / shape
+
+| Term | Definition | Not |
+|---|---|---|
+| pano | The board product. | |
+| worker | The edge worker. Cites 0044. | "server" |
+
+## Products (domains)
+
+| Term | Definition | Not |
+|---|---|---|
+| depo | The internal asset store. | the public image product |
+| pano | The board product, declared a second time. | |
+| sozluk | The dictionary product. | "dictionary" |
+
+## Indexing
+
+| Term | Definition | Not |
+|---|---|---|
+| Database (tag) | The row-version marker. | a user-applied label |
+`;
+
+/** A register that exists, holds prose, and has no table — zero rows, never malformed. */
+export const LANGUAGE_NO_ROWS = `# repo architecture vocabulary (LANGUAGE)
+
+This file exists and holds no term table.
+`;
+
+/** One clean section, so `check` can reach `clean` rather than only `defects`. */
+export const TERMS_CLEAN = `# repo domain vocabulary (TERMS)
+
+## Products (domains)
+
+| Term | Definition | Not |
+|---|---|---|
+| depo | The internal asset store. | |
+| sozluk | The dictionary product. | |
+`;

--- a/packages/fabrika-cli/src/glossary/glossary.cli.test.ts
+++ b/packages/fabrika-cli/src/glossary/glossary.cli.test.ts
@@ -1,0 +1,64 @@
+/**
+ * The end-to-end half: the **exit status and the bytes on each channel** a shell caller reads.
+ *
+ * Only a subprocess proves those, and each `it` costs one cold node+TS load of `bin.ts` — so spawn
+ * count is this file's cost (`.patterns/subprocess-test-budget.md`). Three spawns, each about a fact
+ * no in-process test can establish: that the group is reachable by its registration alone, that a
+ * refusal really does leave stdout empty across the process boundary, and that the answer channel
+ * carries the answer and nothing else. Everything else about these verbs is covered in-process by
+ * the `*-verb.unit.test.ts` files and by `contract-examples.test.ts`.
+ */
+import {spawnSync} from "node:child_process";
+import {fileURLToPath} from "node:url";
+import {describe, expect, it} from "vitest";
+import {SUBPROCESS_TEST_TIMEOUT_MS} from "../test-budget.ts";
+import {ZERO_SCOPE} from "./codes.ts";
+
+const BIN = fileURLToPath(new URL("../bin.ts", import.meta.url));
+const REGISTERS = "claude-plugins/fabrika/skills/glossary/evals/fixtures/registers";
+
+interface Run {
+	readonly code: number;
+	readonly stdout: string;
+	readonly stderr: string;
+}
+
+/**
+ * `FABRIKA_SKIP_INFER` pins the invocation to this copy rather than whatever the repo root installs.
+ *
+ * `spawnSync` rather than `execFileSync`: the channel split is what these tests are about, and
+ * `execFileSync` hands back stderr only on the throwing path — so an assertion about stderr on a
+ * successful run would be asserting against a string the helper made up.
+ */
+const fabrika = (args: ReadonlyArray<string>, stdin = ""): Run => {
+	const run = spawnSync(process.execPath, [BIN, ...args], {
+		encoding: "utf8",
+		env: {...process.env, FABRIKA_SKIP_INFER: "1"},
+		input: stdin,
+	});
+	return {code: run.status ?? -1, stdout: run.stdout ?? "", stderr: run.stderr ?? ""};
+};
+
+describe("fabrika glossary, end to end", {timeout: SUBPROCESS_TEST_TIMEOUT_MS}, () => {
+	it("lists all six verbs under --help by its registration alone", () => {
+		const run = fabrika(["glossary", "--help"]);
+		expect(run.code).toBe(0);
+		for (const verb of ["init", "drift", "lookup", "sections", "add", "check"]) {
+			expect(run.stdout).toContain(verb);
+		}
+	});
+
+	it("puts the answer on stdout and the scope line on stderr", () => {
+		const run = fabrika(["glossary", "lookup", "tag", "--register", "terms", "--dir", REGISTERS]);
+		expect(run.code).toBe(0);
+		expect(run.stdout).toBe("collision\tterms\tIndexing\tDatabase (tag)\n");
+		expect(run.stderr).toContain("6 row(s)");
+	});
+
+	it("refuses a pathspec that matched nothing on its own code, with NOTHING on stdout", () => {
+		const run = fabrika(["glossary", "drift", "--paths", "no/such/dir"]);
+		expect(run.code).toBe(ZERO_SCOPE);
+		expect(run.stdout).toBe("");
+		expect(run.stderr).toContain("matched 0 tracked files");
+	});
+});

--- a/packages/fabrika-cli/src/glossary/guards.ts
+++ b/packages/fabrika-cli/src/glossary/guards.ts
@@ -1,0 +1,157 @@
+/**
+ * The reads and enum checks every `glossary` verb runs before it decides anything, factored here so
+ * six verbs cannot disagree about what an absent register is, what an unreadable one is, or which
+ * values `--register` admits.
+ *
+ * **Absent and unreadable are separated at every read**, because that split is what the whole group
+ * rests on: an absent register is `bootstrap` — a fact about an adopting repo (#4776) — and a
+ * register that exists and could not be read is `11`, UNKNOWN, with nothing answered.
+ */
+
+import {Effect, type FileSystem, Path, Result} from "effect";
+import {discoverRepoRoot} from "../delegate/root.ts";
+import {exists, readFile} from "../io/fs.ts";
+import {refuse, type VerbOutcome} from "../verb.ts";
+import {BAD_SECTIONS, OFF_VOCABULARY, PRECONDITION_UNKNOWN} from "./codes.ts";
+import {
+	BOTH,
+	type ParsedRegister,
+	parseRegister,
+	REGISTER_FILE,
+	type RegisterName,
+} from "./register.ts";
+
+export type Guarded<A> =
+	| {readonly _tag: "Ok"; readonly value: A}
+	| {readonly _tag: "Refused"; readonly outcome: VerbOutcome};
+
+export const ok = <A>(value: A): Guarded<A> => ({_tag: "Ok", value});
+export const refused = (outcome: VerbOutcome): Guarded<never> => ({_tag: "Refused", outcome});
+
+/** Anything in this module: it reads disk, so the two platform seams are its only requirement. */
+export type GlossaryEffect<A> = Effect.Effect<A, never, FileSystem.FileSystem | Path.Path>;
+
+/**
+ * The registers `--register` selects, or the `10` an off-enum value earns.
+ *
+ * `both` is admissible only for the reading verbs. A verb that *writes* refuses it, because a term
+ * belongs to one register and creating or editing two from one ambiguous call is the defect.
+ */
+export const selectRegisters = (
+	verb: string,
+	value: string,
+	both: {readonly allowed: boolean; readonly refusal: string},
+): Guarded<ReadonlyArray<RegisterName>> => {
+	if (value === "terms" || value === "language") return ok([value]);
+	if (value === "both") {
+		return both.allowed ? ok(BOTH) : refused(refuse(OFF_VOCABULARY, both.refusal));
+	}
+	const vocabulary = both.allowed ? "terms, language, both" : "terms, language";
+	return refused(
+		refuse(OFF_VOCABULARY, `${verb}: --register "${value}" is not one of ${vocabulary}.`),
+	);
+};
+
+/** A register's two paths: the one a caller sees, and the one this process reads. */
+export interface RegisterFile {
+	readonly name: RegisterName;
+	/** `<--dir>/<FILE>` exactly as the caller spelled `--dir` — what every message and answer prints. */
+	readonly display: string;
+	/** The same file resolved against the target repo's root, which is what actually gets read. */
+	readonly path: string;
+}
+
+export interface RegisterDir {
+	readonly display: string;
+	readonly path: string;
+	readonly root: string;
+}
+
+/**
+ * `--dir` resolved against the target repo's root.
+ *
+ * The register belongs to the *target repo*, so a relative `--dir` is resolved against its root
+ * rather than against whatever directory the process was launched from. A root that could not be
+ * probed is `11`: an unreadable ancestor answered as "no repo" would silently relocate every read.
+ */
+export const resolveDir = (
+	verb: string,
+	cwd: string,
+	dir: string,
+): GlossaryEffect<Guarded<RegisterDir>> =>
+	Effect.gen(function* () {
+		const pathService = yield* Path.Path;
+		const display = dir.replace(/\/+$/, "");
+		const root = yield* Effect.result(discoverRepoRoot(cwd));
+		if (Result.isFailure(root)) {
+			return refused(
+				refuse(
+					PRECONDITION_UNKNOWN,
+					`${verb}: cannot resolve the repository root from ${cwd}: ${root.failure.reason} — nothing was read.`,
+				),
+			);
+		}
+		return ok<RegisterDir>({
+			display,
+			path: pathService.resolve(root.success ?? cwd, display),
+			root: root.success ?? cwd,
+		});
+	});
+
+export const registerFilesIn = (
+	dir: RegisterDir,
+	names: ReadonlyArray<RegisterName>,
+	pathService: Path.Path,
+): ReadonlyArray<RegisterFile> =>
+	names.map((name) => ({
+		name,
+		display: `${dir.display}/${REGISTER_FILE[name]}`,
+		path: pathService.join(dir.path, REGISTER_FILE[name]),
+	}));
+
+export type RegisterState =
+	| {readonly _tag: "Absent"; readonly file: RegisterFile}
+	| {
+			readonly _tag: "Present";
+			readonly file: RegisterFile;
+			readonly text: string;
+			readonly parsed: ParsedRegister;
+	  };
+
+/** How a verb words the two refusals a register read can produce. */
+export interface ReadMessages {
+	readonly unreadable: (path: string, reason: string) => string;
+	readonly malformed: (path: string, reason: string) => string;
+}
+
+/**
+ * One register as it sits on disk.
+ *
+ * Absence is an **answer** the caller routes on; only a file that exists and cannot be read, or a
+ * table that exists and cannot be resolved, refuses here.
+ */
+export const readRegister = (
+	file: RegisterFile,
+	messages: ReadMessages,
+): GlossaryEffect<Guarded<RegisterState>> =>
+	Effect.gen(function* () {
+		const present = yield* Effect.result(exists(file.path));
+		if (Result.isFailure(present)) {
+			return refused(
+				refuse(PRECONDITION_UNKNOWN, messages.unreadable(file.display, present.failure.reason)),
+			);
+		}
+		if (!present.success) return ok<RegisterState>({_tag: "Absent", file});
+
+		const text = yield* Effect.result(readFile(file.path));
+		if (Result.isFailure(text)) {
+			return refused(
+				refuse(PRECONDITION_UNKNOWN, messages.unreadable(file.display, text.failure.reason)),
+			);
+		}
+		const parsed = parseRegister(text.success);
+		if (parsed._tag === "Malformed") {
+			return refused(refuse(BAD_SECTIONS, messages.malformed(file.display, parsed.reason)));
+		}
+		return ok<RegisterState>({_tag: "Present", file, text: text.success, parsed: parsed.value});
+	});

--- a/packages/fabrika-cli/src/glossary/history.ts
+++ b/packages/fabrika-cli/src/glossary/history.ts
@@ -1,0 +1,90 @@
+/**
+ * The commit-range reads `glossary drift` bounds itself by.
+ *
+ * v1's `glossary-drift.sh` captured the last commit into a variable without checking the status, then
+ * read an empty variable as "never committed" and reported bootstrap — which a shallow clone
+ * reproduces on a register that *is* committed, sending a caller to regenerate a populated file.
+ * Every read here returns an {@link Attempt}, and an empty answer where a commit was expected is a
+ * `Failure`, never a fact.
+ */
+import {Effect} from "effect";
+import {execCapture} from "../io/exec.ts";
+import {type Attempt, fail, ok, type Shell} from "../io/git.ts";
+import type {CommitText} from "./candidates.ts";
+
+/** Field and record separators git will not find inside a subject or a body. */
+const FIELD = "\u001f";
+const RECORD = "\u001e";
+/** The same two, spelled the way `git log --format` names a raw byte. */
+const FORMAT = "--format=%H%x1f%s%x1f%b%x1e";
+
+const pathspec = (paths: ReadonlyArray<string>): ReadonlyArray<string> =>
+	paths.length === 0 ? [] : ["--", ...paths];
+
+/** A commit and when it was committed — the second field is what orders two registers' last changes. */
+export interface CommitStamp {
+	readonly sha: string;
+	readonly when: number;
+}
+
+/** The newest commit that touched `path`. An empty answer is UNKNOWN, never "never committed". */
+export const lastCommitTouching = (path: string): Shell<Attempt<CommitStamp>> =>
+	Effect.gen(function* () {
+		const run = yield* execCapture("git", ["log", "-n", "1", "--format=%H %ct", "--", path]);
+		if (!run.ok) return fail(run.reason);
+		const [sha, when] = run.stdout.trim().split(" ");
+		return sha === undefined || sha === ""
+			? fail("git named no commit touching it")
+			: ok({sha, when: Number.parseInt(when ?? "0", 10)});
+	});
+
+/** The tracked files `paths` matches. Zero matches is an answer the caller reds on (ADR 0092). */
+export const trackedFiles = (paths: ReadonlyArray<string>): Shell<Attempt<ReadonlyArray<string>>> =>
+	Effect.gen(function* () {
+		const run = yield* execCapture("git", ["ls-files", ...pathspec(paths)]);
+		return run.ok
+			? ok(
+					run.stdout
+						.split("\n")
+						.map((line) => line.trim())
+						.filter((line) => line !== ""),
+				)
+			: fail(run.reason);
+	});
+
+/** Every commit in `<since>..HEAD` touching `paths`, oldest first. */
+export const commitsSince = (
+	since: string,
+	paths: ReadonlyArray<string>,
+): Shell<Attempt<ReadonlyArray<CommitText>>> =>
+	Effect.gen(function* () {
+		const run = yield* execCapture("git", [
+			"log",
+			"--reverse",
+			FORMAT,
+			`${since}..HEAD`,
+			...pathspec(paths),
+		]);
+		if (!run.ok) return fail(run.reason);
+		const commits: CommitText[] = [];
+		for (const record of run.stdout.split(RECORD)) {
+			const [sha, subject, body] = record.replace(/^\s+/, "").split(FIELD);
+			if (sha === undefined || sha.trim() === "") continue;
+			commits.push({sha: sha.trim(), subject: subject ?? "", body: body ?? ""});
+		}
+		return ok(commits);
+	});
+
+/** The files one commit changed, in `git diff --name-only` order. */
+export const filesChangedBy = (sha: string): Shell<Attempt<ReadonlyArray<string>>> =>
+	Effect.gen(function* () {
+		const run = yield* execCapture("git", ["show", "--name-only", "--format=", sha]);
+		return run.ok
+			? ok(
+					run.stdout
+						.split("\n")
+						.map((line) => line.trim())
+						.filter((line) => line !== ""),
+				)
+			: fail(run.reason);
+	});

--- a/packages/fabrika-cli/src/glossary/init-verb.ts
+++ b/packages/fabrika-cli/src/glossary/init-verb.ts
@@ -1,0 +1,81 @@
+/**
+ * `glossary init` — create a register file that does not exist, so a fresh repo is not a dead end.
+ *
+ * Without it `bootstrap` is a state the skill can reach and never leave: `add` matches `--section`
+ * against live headings, and a file that is not there has none (#4776).
+ *
+ * The refusal on an existing register is `adr new`'s idiom reseated on this group's `12` — a register
+ * is the one artefact whose accidental overwrite destroys the most work.
+ */
+import {Effect, Path, Result} from "effect";
+import {exists, readFile, writeFile} from "../io/fs.ts";
+import {answer, refuse, type VerbOutcome} from "../verb.ts";
+import {PRECONDITION_UNKNOWN, READBACK_MISMATCH, TERM_COLLISION, WRITE_UNKNOWN} from "./codes.ts";
+import {type GlossaryEffect, registerFilesIn, resolveDir, selectRegisters} from "./guards.ts";
+import {registerTemplate} from "./template.ts";
+
+const VERB = "glossary init";
+
+export interface InitOptions {
+	readonly register: string;
+	readonly dir: string;
+	readonly json: boolean;
+	readonly cwd: string;
+}
+
+export const runInit = (options: InitOptions): GlossaryEffect<VerbOutcome> =>
+	Effect.gen(function* () {
+		const selected = selectRegisters(VERB, options.register, {
+			allowed: false,
+			refusal: `${VERB}: --register both is not creatable — create each register explicitly.`,
+		});
+		if (selected._tag === "Refused") return selected.outcome;
+		const register = selected.value[0] as "terms" | "language";
+
+		const dir = yield* resolveDir(VERB, options.cwd, options.dir);
+		if (dir._tag === "Refused") return dir.outcome;
+		const pathService = yield* Path.Path;
+		const file = registerFilesIn(dir.value, [register], pathService)[0] as {
+			readonly display: string;
+			readonly path: string;
+		};
+
+		const present = yield* Effect.result(exists(file.path));
+		// A probe that could not be performed is UNKNOWN, never "absent" — answering absent here would
+		// license a write over a register this process never managed to look at.
+		if (Result.isFailure(present)) {
+			return refuse(
+				PRECONDITION_UNKNOWN,
+				`${VERB}: cannot read ${file.display}: ${present.failure.reason} — nothing was written.`,
+			);
+		}
+		if (present.success) {
+			return refuse(
+				TERM_COLLISION,
+				`${VERB}: ${file.display} already exists — refusing to overwrite a register.`,
+			);
+		}
+
+		const template = registerTemplate(pathService.basename(dir.value.root), register);
+		const written = yield* Effect.result(writeFile(file.path, template));
+		if (Result.isFailure(written)) {
+			return refuse(
+				WRITE_UNKNOWN,
+				`${VERB}: cannot write ${file.display}: ${written.failure.reason} — the outcome is UNKNOWN.`,
+			);
+		}
+
+		const readBack = yield* Effect.result(readFile(file.path));
+		if (Result.isFailure(readBack) || readBack.success !== template) {
+			return refuse(
+				READBACK_MISMATCH,
+				`${VERB}: wrote ${file.display} and the read-back does not match the template.`,
+			);
+		}
+
+		const scope = [`${VERB}: created ${file.display} for register ${register}.`];
+		if (options.json) {
+			return answer(JSON.stringify({action: "created", path: file.display, register}), scope);
+		}
+		return answer(`created\t${file.display}`, scope);
+	});

--- a/packages/fabrika-cli/src/glossary/init-verb.unit.test.ts
+++ b/packages/fabrika-cli/src/glossary/init-verb.unit.test.ts
@@ -1,0 +1,93 @@
+import {Effect} from "effect";
+import {describe, expect, it} from "vitest";
+import {type FakeFs, fakeFs} from "../fakes.test-support.ts";
+import {OFF_VOCABULARY, PRECONDITION_UNKNOWN, TERM_COLLISION, WRITE_UNKNOWN} from "./codes.ts";
+import {DIR, LANGUAGE_PATH, REPO, TERMS, TERMS_PATH} from "./fixtures.test-support.ts";
+import {runInit} from "./init-verb.ts";
+import {registerTemplate} from "./template.ts";
+
+const options = {register: "terms", dir: DIR, json: false, cwd: REPO};
+
+const run = (fs: FakeFs, overrides: Partial<typeof options> = {}) =>
+	Effect.runPromise(Effect.provide(runInit({...options, ...overrides}), fs.layer));
+
+describe("runInit", () => {
+	it("writes the template and reports the path it created", async () => {
+		const io = fakeFs({files: {}});
+		const out = await run(io);
+		expect(out.code).toBe(0);
+		expect(out.stdout).toBe(`created\t${DIR}/TERMS.md\n`);
+		expect(io.written.get(TERMS_PATH)).toBe(registerTemplate("repo", "terms"));
+	});
+
+	it("names the target repo's own directory in the H1, not a hardcoded one", async () => {
+		const io = fakeFs({files: {}});
+		await run(io, {cwd: "/somewhere/other-repo"});
+		expect(io.written.get("/somewhere/other-repo/.glossary/TERMS.md")).toContain(
+			"# other-repo domain vocabulary (TERMS)",
+		);
+	});
+
+	it("scaffolds no section — an empty one invites filler", async () => {
+		const io = fakeFs({files: {}});
+		await run(io);
+		expect(io.written.get(TERMS_PATH)).not.toContain("\n## ");
+	});
+
+	it("writes the LANGUAGE register under its own heading", async () => {
+		const io = fakeFs({files: {}});
+		const out = await run(io, {register: "language"});
+		expect(out.stdout).toBe(`created\t${DIR}/LANGUAGE.md\n`);
+		expect(io.written.get(LANGUAGE_PATH)).toContain("# repo architecture vocabulary (LANGUAGE)");
+	});
+
+	it("refuses to overwrite an existing register", async () => {
+		const out = await run(fakeFs({files: {[TERMS_PATH]: TERMS}}));
+		expect(out.code).toBe(TERM_COLLISION);
+		expect(out.stdout).toBe("");
+		expect(out.stderr.at(-1)).toBe(
+			`glossary init: ${DIR}/TERMS.md already exists — refusing to overwrite a register.`,
+		);
+	});
+
+	it("refuses --register both — the two are never created by one ambiguous call", async () => {
+		const out = await run(fakeFs({files: {}}), {register: "both"});
+		expect(out.code).toBe(OFF_VOCABULARY);
+		expect(out.stderr.at(-1)).toBe(
+			"glossary init: --register both is not creatable — create each register explicitly.",
+		);
+	});
+
+	it("refuses an off-enum --register", async () => {
+		const out = await run(fakeFs({files: {}}), {register: "sozluk"});
+		expect(out.code).toBe(OFF_VOCABULARY);
+		expect(out.stderr.at(-1)).toBe(
+			'glossary init: --register "sozluk" is not one of terms, language.',
+		);
+	});
+
+	it("reports a failed write as UNKNOWN, never as created", async () => {
+		const io = fakeFs({files: {}, unwritable: [TERMS_PATH]});
+		const out = await run(io);
+		expect(out.code).toBe(WRITE_UNKNOWN);
+		expect(out.stdout).toBe("");
+		expect(io.written.size).toBe(0);
+	});
+
+	// A probe that could not be performed is UNKNOWN, never "absent" — answering absent would license
+	// a write over a register this process never managed to look at.
+	it("refuses when the existence probe itself fails", async () => {
+		const out = await run(fakeFs({files: {}, unprobeable: [TERMS_PATH]}));
+		expect(out.code).toBe(PRECONDITION_UNKNOWN);
+		expect(out.stdout).toBe("");
+	});
+
+	it("emits the creation record as JSON", async () => {
+		const out = await run(fakeFs({files: {}}), {json: true});
+		expect(JSON.parse(out.stdout)).toEqual({
+			action: "created",
+			path: `${DIR}/TERMS.md`,
+			register: "terms",
+		});
+	});
+});

--- a/packages/fabrika-cli/src/glossary/lookup-verb.ts
+++ b/packages/fabrika-cli/src/glossary/lookup-verb.ts
@@ -1,0 +1,118 @@
+/**
+ * `glossary lookup` — whether a term is already declared, and what overlaps it.
+ *
+ * **All three states are answers on exit 0.** `absent` means *proven absent against a register that
+ * was read* — never what a failed read prints, which is `11`.
+ *
+ * `declared` beats `collision` beats `absent`, and TERMS is searched before LANGUAGE, so a term
+ * declared in both is reported once as `declared` in TERMS. That duplication is a defect
+ * `glossary check` reports as `cross-register` (#4465); reporting it twice here would make one term
+ * look like two.
+ */
+import {Effect, Path} from "effect";
+import {answer, FAILED, refuse, type VerbOutcome} from "../verb.ts";
+import {
+	type GlossaryEffect,
+	readRegister,
+	registerFilesIn,
+	resolveDir,
+	selectRegisters,
+} from "./guards.ts";
+import {normalizeKey, overlaps, type Row} from "./register.ts";
+
+const VERB = "glossary lookup";
+
+export interface LookupOptions {
+	readonly terms: ReadonlyArray<string>;
+	readonly register: string;
+	readonly dir: string;
+	readonly json: boolean;
+	readonly cwd: string;
+}
+
+interface Resolution {
+	readonly term: string;
+	readonly normalized: string;
+	readonly state: "declared" | "collision" | "absent";
+	readonly register: string | null;
+	readonly section: string | null;
+	readonly matched: ReadonlyArray<string>;
+}
+
+/** A row plus which register holds it, so file order across `both` stays one sequence. */
+interface Declared {
+	readonly row: Row;
+	readonly register: string;
+}
+
+const messages = {
+	unreadable: (path: string, reason: string) =>
+		`${VERB}: cannot read ${path}: ${reason} — every state is UNKNOWN, never "absent".`,
+	malformed: (path: string, reason: string) =>
+		`${VERB}: ${path} has no parseable term table (${reason}) — membership is UNKNOWN, never "absent".`,
+};
+
+const resolve = (term: string, corpus: ReadonlyArray<Declared>): Resolution => {
+	const normalized = normalizeKey(term);
+	const exact = corpus.find((entry) => entry.row.key === normalized);
+	if (exact !== undefined) {
+		return {
+			term,
+			normalized,
+			state: "declared",
+			register: exact.register,
+			section: exact.row.section,
+			matched: [exact.row.term],
+		};
+	}
+	const overlapping = corpus.filter((entry) => overlaps(entry.row.key, normalized));
+	const first = overlapping[0];
+	if (first === undefined) {
+		return {term, normalized, state: "absent", register: null, section: null, matched: []};
+	}
+	return {
+		term,
+		normalized,
+		state: "collision",
+		register: first.register,
+		section: first.row.section,
+		matched: overlapping.map((entry) => entry.row.term),
+	};
+};
+
+const renderLine = (resolution: Resolution): string =>
+	[
+		resolution.state,
+		resolution.register ?? "-",
+		resolution.section ?? "-",
+		resolution.matched.length === 0 ? "-" : resolution.matched.join(", "),
+	].join("\t");
+
+export const runLookup = (options: LookupOptions): GlossaryEffect<VerbOutcome> =>
+	Effect.gen(function* () {
+		if (options.terms.length === 0) return refuse(FAILED, `${VERB}: no term given.`);
+
+		const selected = selectRegisters(VERB, options.register, {allowed: true, refusal: ""});
+		if (selected._tag === "Refused") return selected.outcome;
+
+		const dir = yield* resolveDir(VERB, options.cwd, options.dir);
+		if (dir._tag === "Refused") return dir.outcome;
+		const files = registerFilesIn(dir.value, selected.value, yield* Path.Path);
+
+		const corpus: Declared[] = [];
+		const scope: string[] = [];
+		for (const file of files) {
+			const state = yield* readRegister(file, messages);
+			if (state._tag === "Refused") return state.outcome;
+			if (state.value._tag === "Absent") {
+				scope.push(`${VERB}: ${file.display} — absent, contributing 0 row(s).`);
+				continue;
+			}
+			for (const row of state.value.parsed.rows) corpus.push({row, register: file.name});
+			scope.push(`${VERB}: ${file.display} — ${state.value.parsed.rows.length} row(s).`);
+		}
+
+		const resolutions = options.terms.map((term) => resolve(term, corpus));
+		if (options.json) return answer(JSON.stringify(resolutions), scope);
+		return answer(resolutions.map(renderLine).join("\n"), scope);
+	});

--- a/packages/fabrika-cli/src/glossary/lookup-verb.unit.test.ts
+++ b/packages/fabrika-cli/src/glossary/lookup-verb.unit.test.ts
@@ -1,0 +1,131 @@
+import {Effect} from "effect";
+import {describe, expect, it} from "vitest";
+import {type FakeFs, fakeFs} from "../fakes.test-support.ts";
+import {FAILED} from "../verb.ts";
+import {BAD_SECTIONS, OFF_VOCABULARY, PRECONDITION_UNKNOWN} from "./codes.ts";
+import {DIR, LANGUAGE_PATH, REPO, TERMS, TERMS_PATH} from "./fixtures.test-support.ts";
+import {runLookup} from "./lookup-verb.ts";
+
+const options = {terms: ["pano"], register: "terms", dir: DIR, json: false, cwd: REPO};
+
+const run = (fs: FakeFs, overrides: Partial<typeof options> = {}) =>
+	Effect.runPromise(Effect.provide(runLookup({...options, ...overrides}), fs.layer));
+
+const populated = () => fakeFs({files: {[TERMS_PATH]: TERMS}});
+
+describe("runLookup", () => {
+	it("answers declared with the first matching row's section and cell", async () => {
+		const out = await run(populated());
+		expect(out.code).toBe(0);
+		expect(out.stdout).toBe("declared\tterms\tCore / shape\tpano\n");
+	});
+
+	// A parenthetical is a disambiguating qualifier, not an alias — the v1 split produced three
+	// false duplicates (#4206), so `tag` overlaps `Database (tag)` rather than equalling it.
+	it("answers collision for a whole-word overlap, not declared", async () => {
+		const out = await run(populated(), {terms: ["tag"]});
+		expect(out.stdout).toBe("collision\tterms\tIndexing\tDatabase (tag)\n");
+	});
+
+	// The normalization folds a hyphen to a SPACE (contract §normalization step 3), which is what
+	// makes `front-door` and `front door` one key — the #4481 defect. It follows that `de-po`
+	// normalizes to `de po`, which is NOT `depo`: the contract's own `de-po` → `depo` example is
+	// unreachable under the algorithm the same document fixes. Pinned in both directions so the
+	// divergence is a measured fact rather than a reading.
+	it("folds a hyphen to a space, so `front-door` and `front door` are one key", async () => {
+		const io = fakeFs({
+			files: {
+				[TERMS_PATH]: `## S
+
+| Term | Definition | Not |
+|---|---|---|
+| front-door | The entry surface. | |
+`,
+			},
+		});
+		const out = await run(io, {terms: ["front door"]});
+		expect(out.stdout).toBe("declared\tterms\tS\tfront-door\n");
+	});
+
+	it("does not fold a hyphen AWAY, so `de-po` does not reach `depo`", async () => {
+		const out = await run(populated(), {terms: ["de-po"]});
+		expect(out.stdout).toBe("absent\t-\t-\t-\n");
+	});
+
+	it("answers absent as a proven fact against a register that was read", async () => {
+		const out = await run(populated(), {terms: ["capture ledger"]});
+		expect(out.code).toBe(0);
+		expect(out.stdout).toBe("absent\t-\t-\t-\n");
+	});
+
+	it("answers one line per term, in argument order", async () => {
+		const out = await run(populated(), {terms: ["depo", "capture ledger"]});
+		expect(out.stdout).toBe("declared\tterms\tProducts (domains)\tdepo\nabsent\t-\t-\t-\n");
+	});
+
+	it("answers absent for every term against a register that exists and holds no rows", async () => {
+		const out = await run(fakeFs({files: {[TERMS_PATH]: "# empty\n\nNo table.\n"}}));
+		expect(out.code).toBe(0);
+		expect(out.stdout).toBe("absent\t-\t-\t-\n");
+	});
+
+	it("reports a term declared in BOTH registers once, as declared in TERMS", async () => {
+		const out = await run(fakeFs({files: {[TERMS_PATH]: TERMS, [LANGUAGE_PATH]: TERMS}}), {
+			register: "both",
+		});
+		expect(out.stdout).toBe("declared\tterms\tCore / shape\tpano\n");
+	});
+
+	it("refuses an unreadable register — every state is UNKNOWN, never absent", async () => {
+		const out = await run(fakeFs({files: {[TERMS_PATH]: TERMS}, unreadable: [TERMS_PATH]}));
+		expect(out.code).toBe(PRECONDITION_UNKNOWN);
+		expect(out.stdout).toBe("");
+		expect(out.stderr.at(-1)).toContain('never "absent"');
+	});
+
+	it("refuses a malformed term table — membership is UNKNOWN, never absent", async () => {
+		const out = await run(
+			fakeFs({files: {[TERMS_PATH]: "## S\n\n| Term | Definition | Not |\n| pano | x | |\n"}}),
+		);
+		expect(out.code).toBe(BAD_SECTIONS);
+		expect(out.stdout).toBe("");
+	});
+
+	it("refuses an off-enum --register", async () => {
+		const out = await run(populated(), {register: "sozluk"});
+		expect(out.code).toBe(OFF_VOCABULARY);
+	});
+
+	it("refuses with no term given", async () => {
+		const out = await run(populated(), {terms: []});
+		expect(out.code).toBe(FAILED);
+		expect(out.stderr.at(-1)).toBe("glossary lookup: no term given.");
+	});
+
+	it("names the row count per register on stderr", async () => {
+		const out = await run(populated());
+		expect(out.stderr[0]).toContain("6 row(s)");
+	});
+
+	it("emits a JSON array so one term and many parse identically", async () => {
+		const out = await run(populated(), {terms: ["pano", "capture ledger"], json: true});
+		expect(JSON.parse(out.stdout)).toEqual([
+			{
+				term: "pano",
+				normalized: "pano",
+				state: "declared",
+				register: "terms",
+				section: "Core / shape",
+				matched: ["pano"],
+			},
+			{
+				term: "capture ledger",
+				normalized: "capture ledger",
+				state: "absent",
+				register: null,
+				section: null,
+				matched: [],
+			},
+		]);
+	});
+});

--- a/packages/fabrika-cli/src/glossary/register.ts
+++ b/packages/fabrika-cli/src/glossary/register.ts
@@ -1,0 +1,238 @@
+/**
+ * What a register file *is*, as data: its sections, its rows, and the one comparison key every verb
+ * in the group compares by.
+ *
+ * The whole first cell is one key. Splitting a parenthetical into an alias is the defect that
+ * produced three false duplicates the last time it was attempted (#4206) — a parenthetical in this
+ * corpus is a disambiguating qualifier, not a synonym — so `tag` and `Database (tag)` are different
+ * terms that *overlap*, and resolving that overlap is the skill's judgement, not this module's.
+ */
+
+/** The two registers, and the file each is stored in under `--dir`. */
+export type RegisterName = "terms" | "language";
+
+export const REGISTER_FILE: Readonly<Record<RegisterName, string>> = {
+	terms: "TERMS.md",
+	language: "LANGUAGE.md",
+};
+
+/** `both` means TERMS first, then LANGUAGE, in that order everywhere. */
+export const BOTH: ReadonlyArray<RegisterName> = ["terms", "language"];
+
+/**
+ * The comparison key for a first cell.
+ *
+ * Lowercasing is `toLocaleLowerCase`, which is Unicode-aware rather than `[a-z]`-restricted: `Sözlük`
+ * and `sözlük` are one key, and `Geçit` is not silently dropped the way v1's ASCII tokenizer dropped
+ * every Turkish product noun (#4481).
+ */
+export const normalizeKey = (cell: string): string =>
+	cell
+		.replace(/^[`*_]+/, "")
+		.replace(/[`*_]+$/, "")
+		.toLocaleLowerCase()
+		.replace(/[-_\s]+/g, " ")
+		.trim();
+
+const WORD = /[\p{L}\p{N}_]/u;
+
+const isWord = (ch: string | undefined): boolean => ch !== undefined && WORD.test(ch);
+
+/** A `\b`-style boundary at `at`: the characters either side differ in word-ness. */
+const isBoundary = (text: string, at: number): boolean => isWord(text[at - 1]) !== isWord(text[at]);
+
+const containsWholeWord = (haystack: string, needle: string): boolean => {
+	if (needle === "") return false;
+	for (let from = 0; ; ) {
+		const at = haystack.indexOf(needle, from);
+		if (at === -1) return false;
+		if (isBoundary(haystack, at) && isBoundary(haystack, at + needle.length)) return true;
+		from = at + 1;
+	}
+};
+
+/**
+ * Whether two normalized keys overlap: they differ, and one contains the other as a whole-word span.
+ *
+ * `front door` overlaps `front door detection`; it does not overlap `storefront doorway`.
+ */
+export const overlaps = (a: string, b: string): boolean =>
+	a !== b && (containsWholeWord(a, b) || containsWholeWord(b, a));
+
+export interface Row {
+	/** The first cell verbatim, as the file spells it. */
+	readonly term: string;
+	readonly key: string;
+	readonly cells: ReadonlyArray<string>;
+	readonly section: string;
+	/** 1-based line number in the file. */
+	readonly line: number;
+}
+
+export interface Section {
+	readonly name: string;
+	/** 1-based line of the `## ` heading. */
+	readonly headingLine: number;
+	/**
+	 * 1-based line of the first table's separator row, or `null` when the section holds no table.
+	 *
+	 * It is what makes an insertion point exist for a section whose table has a header and no data
+	 * rows yet — a state `rows` alone cannot tell apart from a section with no table at all.
+	 */
+	readonly separatorLine: number | null;
+	readonly rows: ReadonlyArray<Row>;
+}
+
+export interface ParsedRegister {
+	readonly sections: ReadonlyArray<Section>;
+	/** Every row in file order, whichever section holds it. */
+	readonly rows: ReadonlyArray<Row>;
+	/** Rows that sit under no `## ` heading — what makes `sections` unable to place content. */
+	readonly orphanRows: number;
+	readonly headings: number;
+}
+
+export type ParseResult =
+	| {readonly _tag: "Parsed"; readonly value: ParsedRegister}
+	| {readonly _tag: "Malformed"; readonly reason: string};
+
+/**
+ * A heading the section list is read from. The space after the hashes is required by the markdown
+ * spec and is load-bearing: `TERMS.md` carries a prose line beginning `#3227).`, and a scan for `^#`
+ * reports it as a phantom section.
+ */
+const SECTION_HEADING = /^##[ \t]+(\S.*)$/;
+/** An H1 or H2 — either closes the current section's table. */
+const ANY_HEADING = /^#{1,2}[ \t]+\S/;
+
+const isTableLine = (line: string): boolean => line.trim().startsWith("|");
+
+/** Split a table row into cells, honouring `\|` as a literal pipe rather than a delimiter. */
+export const splitCells = (line: string): ReadonlyArray<string> => {
+	let text = line.trim();
+	if (text.startsWith("|")) text = text.slice(1);
+	if (text.endsWith("|") && !text.endsWith("\\|")) text = text.slice(0, -1);
+	const cells: string[] = [];
+	let cell = "";
+	for (let i = 0; i < text.length; i += 1) {
+		const ch = text[i] as string;
+		if (ch === "\\" && text[i + 1] === "|") {
+			cell += "|";
+			i += 1;
+			continue;
+		}
+		if (ch === "|") {
+			cells.push(cell.trim());
+			cell = "";
+			continue;
+		}
+		cell += ch;
+	}
+	cells.push(cell.trim());
+	return cells;
+};
+
+/** `|---|---|---|` and its `:---:` variants — the row that makes the line above it a header. */
+export const isSeparatorRow = (line: string): boolean => {
+	if (!isTableLine(line)) return false;
+	const cells = splitCells(line);
+	return cells.length > 0 && cells.every((cell) => /^:?-{3,}:?$/.test(cell));
+};
+
+/**
+ * A register's sections and rows.
+ *
+ * `Malformed` is reserved for a table that **exists and cannot be resolved** — today that is a header
+ * row with no separator under it. A file with no table at all parses to zero rows, which is a fact
+ * about an adopting repo rather than a defect.
+ */
+export const parseRegister = (text: string): ParseResult => {
+	const lines = text.split("\n");
+	const sections: Section[] = [];
+	const rows: Row[] = [];
+	let current: {
+		name: string;
+		headingLine: number;
+		separatorLine: number | null;
+		rows: Row[];
+	} | null = null;
+	let orphanRows = 0;
+	let headings = 0;
+	let inTable = false;
+
+	for (let i = 0; i < lines.length; i += 1) {
+		const line = lines[i] as string;
+		const heading = SECTION_HEADING.exec(line);
+		if (heading !== null) {
+			if (current !== null) sections.push({...current, rows: current.rows});
+			headings += 1;
+			current = {
+				name: (heading[1] as string).trim(),
+				headingLine: i + 1,
+				separatorLine: null,
+				rows: [],
+			};
+			inTable = false;
+			continue;
+		}
+		if (ANY_HEADING.test(line)) {
+			if (current !== null) sections.push({...current, rows: current.rows});
+			current = null;
+			inTable = false;
+			continue;
+		}
+		if (!isTableLine(line)) {
+			if (line.trim() === "") inTable = false;
+			continue;
+		}
+		if (!inTable) {
+			// The first `|` line of a table is its header row, and a header with no separator under it
+			// is a table whose columns cannot be resolved — the one shape this parser calls malformed.
+			const next = lines[i + 1];
+			if (next === undefined || !isSeparatorRow(next)) {
+				return {
+					_tag: "Malformed",
+					reason: `the table header row at line ${i + 1} is not followed by a separator row`,
+				};
+			}
+			inTable = true;
+			if (current !== null && current.separatorLine === null) current.separatorLine = i + 2;
+			i += 1;
+			continue;
+		}
+		const cells = splitCells(line);
+		const term = cells[0] ?? "";
+		const row: Row = {
+			term,
+			key: normalizeKey(term),
+			cells,
+			section: current?.name ?? "",
+			line: i + 1,
+		};
+		rows.push(row);
+		if (current === null) orphanRows += 1;
+		else current.rows.push(row);
+	}
+	if (current !== null) sections.push({...current, rows: current.rows});
+
+	return {_tag: "Parsed", value: {sections, rows, orphanRows, headings}};
+};
+
+/**
+ * A cell's text as one table cell: newlines become single spaces, and a literal `|` is escaped, so a
+ * row stays one line and cannot grow a column.
+ */
+export const flattenCell = (text: string): string => text.replace(/\r\n|\r|\n/g, " ").trim();
+
+/** A literal `|` written so it stays content: the one character that could otherwise grow a column. */
+export const escapeCell = (text: string): string => text.replace(/\|/g, "\\|");
+
+export const normalizeCell = (text: string): string => escapeCell(flattenCell(text));
+
+/** A row's bytes. An empty cell renders as `| |`, which is how the corpus already spells one. */
+export const renderRow = (cells: ReadonlyArray<string>): string =>
+	`|${cells.map((cell) => (cell === "" ? " " : ` ${cell} `)).join("|")}|`;
+
+/** The distinct normalized keys a row set declares — what a caller counts instead of rows. */
+export const declaredKeys = (rows: ReadonlyArray<Row>): ReadonlySet<string> =>
+	new Set(rows.map((row) => row.key));

--- a/packages/fabrika-cli/src/glossary/register.ts
+++ b/packages/fabrika-cli/src/glossary/register.ts
@@ -107,7 +107,14 @@ const ANY_HEADING = /^#{1,2}[ \t]+\S/;
 
 const isTableLine = (line: string): boolean => line.trim().startsWith("|");
 
-/** Split a table row into cells, honouring `\|` as a literal pipe rather than a delimiter. */
+/**
+ * Split a table row into cells, honouring `\|` as a literal pipe and `\\` as a literal backslash.
+ *
+ * The backslash arm is the half that makes this the exact inverse of {@link escapeCell}. Without it
+ * the escape is incomplete in the classic direction: a cell whose own text ends in a backslash would
+ * fuse with the delimiter that follows it, so a value could smuggle in a column separator that
+ * `escapeCell` believed it had neutralized.
+ */
 export const splitCells = (line: string): ReadonlyArray<string> => {
 	let text = line.trim();
 	if (text.startsWith("|")) text = text.slice(1);
@@ -116,8 +123,8 @@ export const splitCells = (line: string): ReadonlyArray<string> => {
 	let cell = "";
 	for (let i = 0; i < text.length; i += 1) {
 		const ch = text[i] as string;
-		if (ch === "\\" && text[i + 1] === "|") {
-			cell += "|";
+		if (ch === "\\" && (text[i + 1] === "|" || text[i + 1] === "\\")) {
+			cell += text[i + 1] as string;
 			i += 1;
 			continue;
 		}
@@ -218,14 +225,20 @@ export const parseRegister = (text: string): ParseResult => {
 	return {_tag: "Parsed", value: {sections, rows, orphanRows, headings}};
 };
 
-/**
- * A cell's text as one table cell: newlines become single spaces, and a literal `|` is escaped, so a
- * row stays one line and cannot grow a column.
- */
+/** A cell's text as one line: newlines become single spaces, so a row cannot grow a line. */
 export const flattenCell = (text: string): string => text.replace(/\r\n|\r|\n/g, " ").trim();
 
-/** A literal `|` written so it stays content: the one character that could otherwise grow a column. */
-export const escapeCell = (text: string): string => text.replace(/\|/g, "\\|");
+/**
+ * A cell's text written so it stays content: `|` cannot grow a column, and the escape character
+ * itself cannot be forged.
+ *
+ * **The backslash is escaped FIRST, and that order is the whole correctness of the pair.** Escaping
+ * only `|` leaves the encoding ambiguous — a cell ending in `\` would render as `…\ |`, and its own
+ * trailing backslash would then read as escaping the delimiter that follows. `splitCells` is the
+ * exact inverse and unescapes both.
+ */
+export const escapeCell = (text: string): string =>
+	text.replace(/\\/g, "\\\\").replace(/\|/g, "\\|");
 
 export const normalizeCell = (text: string): string => escapeCell(flattenCell(text));
 

--- a/packages/fabrika-cli/src/glossary/register.unit.test.ts
+++ b/packages/fabrika-cli/src/glossary/register.unit.test.ts
@@ -1,0 +1,139 @@
+import {describe, expect, it} from "vitest";
+import {
+	normalizeCell,
+	normalizeKey,
+	overlaps,
+	parseRegister,
+	renderRow,
+	splitCells,
+} from "./register.ts";
+
+const fixture = `# fixture domain vocabulary (TERMS)
+
+Prose that mentions #3227). as a bare hash, which is not a heading.
+
+## Core / shape
+
+| Term | Definition | Not |
+|---|---|---|
+| pano | The board product. | |
+| worker | The edge worker. Cites 0044. | "server" |
+
+## Indexing
+
+| Term | Definition | Not |
+|---|---|---|
+| Database (tag) | The row-version marker. | a user-applied label |
+`;
+
+describe("normalizeKey", () => {
+	it("folds case with a Unicode-aware lowercase, so Turkish nouns are not dropped (#4481)", () => {
+		expect(normalizeKey("Sözlük")).toBe("sözlük");
+		expect(normalizeKey("Geçit")).toBe("geçit");
+	});
+
+	it("folds hyphens, underscores and whitespace runs to one space", () => {
+		expect(normalizeKey("front-door")).toBe("front door");
+		expect(normalizeKey("front_door")).toBe("front door");
+		expect(normalizeKey("  front   door  ")).toBe("front door");
+	});
+
+	it("strips a surrounding run of backticks, asterisks and underscores", () => {
+		expect(normalizeKey("`depo`")).toBe("depo");
+		expect(normalizeKey("**depo**")).toBe("depo");
+	});
+
+	// The v1 alias-splitting produced three false duplicates; a parenthetical is a qualifier (#4206).
+	it("keeps the whole cell as one key — no split on a parenthesis, slash or comma", () => {
+		expect(normalizeKey("Database (tag)")).toBe("database (tag)");
+		expect(normalizeKey("sözlük (sozluk)")).toBe("sözlük (sozluk)");
+		expect(normalizeKey("Database (tag)")).not.toBe(normalizeKey("tag"));
+	});
+});
+
+describe("overlaps", () => {
+	it("matches a whole-word span in either direction", () => {
+		expect(overlaps("front door detection", "front door")).toBe(true);
+		expect(overlaps("front door", "front door detection")).toBe(true);
+		expect(overlaps("database (tag)", "tag")).toBe(true);
+	});
+
+	it("does not match a span that begins or ends mid-word", () => {
+		expect(overlaps("storefront doorway", "front door")).toBe(false);
+	});
+
+	it("is false for equal keys — that is `declared`, not a collision", () => {
+		expect(overlaps("pano", "pano")).toBe(false);
+	});
+});
+
+describe("splitCells", () => {
+	it("splits on unescaped pipes and unescapes the rest", () => {
+		expect(splitCells("| a | b\\|c | |")).toEqual(["a", "b|c", ""]);
+	});
+});
+
+describe("renderRow", () => {
+	it("spells an empty cell the way the corpus already does", () => {
+		expect(renderRow(["pano", "The board product.", ""])).toBe("| pano | The board product. | |");
+	});
+});
+
+describe("normalizeCell", () => {
+	it("flattens newlines to spaces and escapes a literal pipe", () => {
+		expect(normalizeCell("one\ntwo | three\n")).toBe("one two \\| three");
+	});
+});
+
+describe("parseRegister", () => {
+	const parsed = parseRegister(fixture);
+	const value = parsed._tag === "Parsed" ? parsed.value : null;
+
+	it("reads only `^## ` headings, so a prose line beginning `#3227).` is not a phantom section", () => {
+		expect(value?.sections.map((section) => section.name)).toEqual(["Core / shape", "Indexing"]);
+	});
+
+	it("counts a section's data rows, excluding the header and separator rows", () => {
+		expect(value?.sections.map((section) => section.rows.length)).toEqual([2, 1]);
+	});
+
+	it("records each row's 1-based line and its normalized key", () => {
+		const first = value?.sections[0]?.rows[0];
+		expect(first?.line).toBe(9);
+		expect(first?.key).toBe("pano");
+	});
+
+	it("records the separator line, which is the insertion point for an empty table", () => {
+		expect(value?.sections[0]?.separatorLine).toBe(8);
+	});
+
+	it("parses a register with prose and no table to zero rows — a fact, never malformed", () => {
+		const empty = parseRegister("# fixture register with no rows\n\nNo table here.\n");
+		expect(empty._tag).toBe("Parsed");
+		expect(empty._tag === "Parsed" ? empty.value.rows.length : -1).toBe(0);
+	});
+
+	it("refuses a header row with no separator under it — the one malformed shape", () => {
+		const broken = parseRegister("## S\n\n| Term | Definition | Not |\n| pano | x | |\n");
+		expect(broken._tag).toBe("Malformed");
+	});
+
+	/**
+	 * The contract names a second `4` trigger — "rows whose cell count the parser cannot resolve" —
+	 * that this parser cannot reach: splitting on unescaped pipes resolves a count for every line,
+	 * so a short row is a `row-shape` FINDING at exit 0, never a refusal. Pinned so the divergence
+	 * is visible rather than inferred.
+	 */
+	it("resolves a cell count for a short row instead of refusing", () => {
+		const short = parseRegister(
+			"## S\n\n| Term | Definition | Not |\n|---|---|---|\n| pano | x |\n",
+		);
+		expect(short._tag).toBe("Parsed");
+		expect(short._tag === "Parsed" ? short.value.rows[0]?.cells.length : -1).toBe(2);
+	});
+
+	it("counts rows that sit under no heading, which is what `sections` cannot place", () => {
+		const orphan = parseRegister("| Term | Definition | Not |\n|---|---|---|\n| pano | x | |\n");
+		expect(orphan._tag === "Parsed" ? orphan.value.orphanRows : -1).toBe(1);
+	});
+});

--- a/packages/fabrika-cli/src/glossary/register.unit.test.ts
+++ b/packages/fabrika-cli/src/glossary/register.unit.test.ts
@@ -1,5 +1,6 @@
 import {describe, expect, it} from "vitest";
 import {
+	escapeCell,
 	normalizeCell,
 	normalizeKey,
 	overlaps,
@@ -70,6 +71,21 @@ describe("overlaps", () => {
 describe("splitCells", () => {
 	it("splits on unescaped pipes and unescapes the rest", () => {
 		expect(splitCells("| a | b\\|c | |")).toEqual(["a", "b|c", ""]);
+	});
+
+	/**
+	 * `escapeCell` and `splitCells` are an exact inverse pair, and the backslash arm is what makes
+	 * that true: escaping only `|` would let a cell ending in `\` read as escaping the delimiter
+	 * after it, which is a value smuggling in a column separator.
+	 */
+	it.each([
+		"plain",
+		"a | b",
+		"ends with a backslash \\",
+		"already escaped \\| pipe",
+		"double \\\\ backslash",
+	])("round-trips %j through escape and split", (value) => {
+		expect(splitCells(renderRow([escapeCell(value), "x", ""]))).toEqual([value, "x", ""]);
 	});
 });
 

--- a/packages/fabrika-cli/src/glossary/sections-verb.ts
+++ b/packages/fabrika-cli/src/glossary/sections-verb.ts
@@ -1,0 +1,91 @@
+/**
+ * `glossary sections` — the live section names of a register.
+ *
+ * **There is no exit-0-with-empty-stdout path.** A register that is absent, or present with no
+ * heading, prints `-\tbootstrap\t0`, because an answer that prints nothing is byte-identical to a
+ * verb that never ran (interface convention rule 2).
+ */
+import {Effect, Path} from "effect";
+import {answer, refuse, type VerbOutcome} from "../verb.ts";
+import {BAD_SECTIONS} from "./codes.ts";
+import {
+	type GlossaryEffect,
+	type RegisterFile,
+	readRegister,
+	registerFilesIn,
+	resolveDir,
+	selectRegisters,
+} from "./guards.ts";
+
+const VERB = "glossary sections";
+
+export interface SectionsOptions {
+	readonly register: string;
+	readonly dir: string;
+	readonly json: boolean;
+	readonly cwd: string;
+}
+
+interface SectionLine {
+	readonly register: string;
+	readonly section: string;
+	readonly rows: number;
+}
+
+const BOOTSTRAP: SectionLine = {register: "-", section: "bootstrap", rows: 0};
+
+const messages = {
+	unreadable: (path: string, reason: string) =>
+		`${VERB}: cannot read ${path}: ${reason} — the section list is UNKNOWN, never empty.`,
+	malformed: (path: string, reason: string) =>
+		`${VERB}: ${path} has no parseable term table (${reason}) — the section list is UNKNOWN.`,
+};
+
+const scopeLine = (file: RegisterFile, bytes: number, state: string): string =>
+	`${VERB}: ${file.display} — ${bytes} byte(s), ${state}.`;
+
+export const runSections = (options: SectionsOptions): GlossaryEffect<VerbOutcome> =>
+	Effect.gen(function* () {
+		const selected = selectRegisters(VERB, options.register, {allowed: true, refusal: ""});
+		if (selected._tag === "Refused") return selected.outcome;
+
+		const dir = yield* resolveDir(VERB, options.cwd, options.dir);
+		if (dir._tag === "Refused") return dir.outcome;
+		const files = registerFilesIn(dir.value, selected.value, yield* Path.Path);
+
+		const lines: SectionLine[] = [];
+		const scope: string[] = [];
+		for (const file of files) {
+			const state = yield* readRegister(file, messages);
+			if (state._tag === "Refused") return state.outcome;
+			if (state.value._tag === "Absent") {
+				scope.push(scopeLine(file, 0, "absent"));
+				lines.push(BOOTSTRAP);
+				continue;
+			}
+			const {text, parsed} = state.value;
+			scope.push(scopeLine(file, new TextEncoder().encode(text).length, "present"));
+			if (parsed.headings === 0) {
+				// Content the verb can see and cannot place under any section — distinct from a register
+				// that simply has no sections yet, which is an adopting repo's day one.
+				if (parsed.rows.length > 0) {
+					return refuse(
+						BAD_SECTIONS,
+						`${VERB}: ${file.display} carries ${parsed.rows.length} table row(s) under no "## " heading — the section list is UNKNOWN.`,
+						scope,
+					);
+				}
+				lines.push(BOOTSTRAP);
+				continue;
+			}
+			for (const section of parsed.sections) {
+				lines.push({register: file.name, section: section.name, rows: section.rows.length});
+			}
+		}
+
+		if (options.json) return answer(JSON.stringify(lines), scope);
+		return answer(
+			lines.map((line) => `${line.register}\t${line.section}\t${line.rows}`).join("\n"),
+			scope,
+		);
+	});

--- a/packages/fabrika-cli/src/glossary/sections-verb.unit.test.ts
+++ b/packages/fabrika-cli/src/glossary/sections-verb.unit.test.ts
@@ -1,0 +1,99 @@
+import {Effect} from "effect";
+import {describe, expect, it} from "vitest";
+import {type FakeFs, fakeFs} from "../fakes.test-support.ts";
+import {BAD_SECTIONS, OFF_VOCABULARY, PRECONDITION_UNKNOWN} from "./codes.ts";
+import {
+	DIR,
+	LANGUAGE_NO_ROWS,
+	LANGUAGE_PATH,
+	REPO,
+	TERMS,
+	TERMS_PATH,
+} from "./fixtures.test-support.ts";
+import {runSections} from "./sections-verb.ts";
+
+const options = {register: "terms", dir: DIR, json: false, cwd: REPO};
+
+const run = (fs: FakeFs, overrides: Partial<typeof options> = {}) =>
+	Effect.runPromise(Effect.provide(runSections({...options, ...overrides}), fs.layer));
+
+describe("runSections", () => {
+	it("names each section and its data-row count, in file order", async () => {
+		const out = await run(fakeFs({files: {[TERMS_PATH]: TERMS}}));
+		expect(out.code).toBe(0);
+		expect(out.stdout).toBe(
+			"terms\tCore / shape\t2\nterms\tProducts (domains)\t3\nterms\tIndexing\t1\n",
+		);
+	});
+
+	// A `^#` scan counts the prose line beginning `#3227).` as a section; the required space does not.
+	it("does not report a prose line beginning with a hash as a section", async () => {
+		const out = await run(fakeFs({files: {[TERMS_PATH]: TERMS}}));
+		expect(out.stdout).not.toContain("3227");
+	});
+
+	it("answers the bootstrap line for an absent register — never empty stdout", async () => {
+		const out = await run(fakeFs({files: {}}));
+		expect(out.code).toBe(0);
+		expect(out.stdout).toBe("-\tbootstrap\t0\n");
+	});
+
+	it("answers the bootstrap line for a register with prose and no heading", async () => {
+		const out = await run(fakeFs({files: {[TERMS_PATH]: LANGUAGE_NO_ROWS}}));
+		expect(out.code).toBe(0);
+		expect(out.stdout).toBe("-\tbootstrap\t0\n");
+	});
+
+	it("refuses when rows exist under no heading — content it can see and cannot place", async () => {
+		const out = await run(
+			fakeFs({
+				files: {[TERMS_PATH]: "| Term | Definition | Not |\n|---|---|---|\n| pano | x | |\n"},
+			}),
+		);
+		expect(out.code).toBe(BAD_SECTIONS);
+		expect(out.stdout).toBe("");
+		expect(out.stderr.at(-1)).toContain('carries 1 table row(s) under no "## " heading');
+	});
+
+	it("refuses an unreadable register — UNKNOWN, never empty", async () => {
+		const out = await run(fakeFs({files: {[TERMS_PATH]: TERMS}, unreadable: [TERMS_PATH]}));
+		expect(out.code).toBe(PRECONDITION_UNKNOWN);
+		expect(out.stdout).toBe("");
+		expect(out.stderr.at(-1)).toContain("never empty");
+	});
+
+	it("refuses an off-enum --register", async () => {
+		const out = await run(fakeFs({files: {}}), {register: "glossary"});
+		expect(out.code).toBe(OFF_VOCABULARY);
+		expect(out.stderr.at(-1)).toBe(
+			'glossary sections: --register "glossary" is not one of terms, language, both.',
+		);
+	});
+
+	it("answers both registers, and one absent register never fails the other", async () => {
+		const out = await run(fakeFs({files: {[TERMS_PATH]: TERMS}}), {register: "both"});
+		expect(out.code).toBe(0);
+		expect(out.stdout.split("\n").filter((line) => line !== "")).toHaveLength(4);
+		expect(out.stdout).toContain("-\tbootstrap\t0");
+	});
+
+	it("names each register and its byte length on stderr", async () => {
+		const out = await run(
+			fakeFs({files: {[TERMS_PATH]: TERMS, [LANGUAGE_PATH]: LANGUAGE_NO_ROWS}}),
+			{register: "both"},
+		);
+		expect(out.stderr[0]).toContain(
+			`${DIR}/TERMS.md — ${new TextEncoder().encode(TERMS).length} byte(s)`,
+		);
+		expect(out.stderr[1]).toContain(`${DIR}/LANGUAGE.md`);
+	});
+
+	it("emits the JSON array on stdout", async () => {
+		const out = await run(fakeFs({files: {[TERMS_PATH]: TERMS}}), {json: true});
+		expect(JSON.parse(out.stdout)).toEqual([
+			{register: "terms", section: "Core / shape", rows: 2},
+			{register: "terms", section: "Products (domains)", rows: 3},
+			{register: "terms", section: "Indexing", rows: 1},
+		]);
+	});
+});

--- a/packages/fabrika-cli/src/glossary/template.ts
+++ b/packages/fabrika-cli/src/glossary/template.ts
@@ -1,0 +1,23 @@
+/**
+ * The bytes `glossary init` writes.
+ *
+ * **No section is scaffolded.** An empty section invites filler; `add --create-section` writes the
+ * first one together with the row that justifies it.
+ */
+import type {RegisterName} from "./register.ts";
+
+/** The register file a fresh repo starts from, for the repo directory named `repo`. */
+export const registerTemplate = (repo: string, register: RegisterName): string =>
+	register === "terms"
+		? `# ${repo} domain vocabulary (TERMS)
+
+The repo-owned vocabulary spine. One row per term: the canonical definition, and where a name has
+drifted, what the term is **not**. When the code and this file disagree, the code is authoritative
+and this file is the doc to fix.
+`
+		: `# ${repo} architecture vocabulary (LANGUAGE)
+
+The repo-owned architecture vocabulary. One row per term: the canonical definition, and where a name
+has drifted, what the term is **not**. When the code and this file disagree, the code is
+authoritative and this file is the doc to fix.
+`;

--- a/packages/fabrika-cli/src/registry.ts
+++ b/packages/fabrika-cli/src/registry.ts
@@ -19,6 +19,7 @@ import {adrCommand} from "./adr/command.ts";
 import {buildCommand} from "./build/command.ts";
 import {epicCommand} from "./epic/command.ts";
 import {evalCommand} from "./eval/command.ts";
+import {glossaryCommand} from "./glossary/command.ts";
 import {governanceCommand} from "./governance/command.ts";
 import {grillCommand} from "./grill/command.ts";
 import {handoffCommand} from "./handoff/command.ts";
@@ -46,6 +47,7 @@ export const registeredGroups: ReadonlyArray<VerbGroup> = [
 	buildCommand,
 	epicCommand,
 	evalCommand,
+	glossaryCommand,
 	governanceCommand,
 	grillCommand,
 	handoffCommand,


### PR DESCRIPTION
The `/glossary` skill landed with a 933-line derived contract and none of the six verbs it calls
existed, so every step of the skill ran a command that exits `127`. This builds all six —
`init`, `drift`, `lookup`, `sections`, `add`, `check` — registers the group, and pins the
contract's worked examples against the committed fixtures so the document and the code cannot
drift apart quietly.

Fixes #5322

## What changed

New group at `packages/fabrika-cli/src/glossary/`: a pure core plus a thin `*-verb.ts` entry per
verb, a `*.unit.test.ts` beside each, and one `codes.ts` every verb allocates from.

| Module | What it owns |
|---|---|
| `register.ts` | the register as data — sections, rows, `normalizeKey`, whole-word overlap, cell escaping |
| `edit.ts` | placement, the one-row assertion, the `--create-section` block |
| `findings.ts` | the seven `check` defect kinds and their fixed `detail` text |
| `candidates.ts` | `drift`'s Unicode-classed extraction, filter and equality-only suppression |
| `history.ts` | the commit-range reads, where an empty answer is a `Failure` and never a fact |
| `guards.ts` | the `--register` enum, `--dir` resolution, and the absent / unreadable / malformed split |

Registration, each a **pure insertion** (see the proof below): `registry.ts`, `GLOSSARY_SEATS` +
`ALIGNED_GROUPS` in `exit-code-alignment.ts`, the `TABLES` map in its unit test, and a README
section. No wire format is registered — the contract calls for none, and the group emits no verdict
two skills meet through.

One shipped module changes as the contract orders: `STOPWORDS` in `packages/fabrika-cli/src/adr/sweep.ts`
becomes exported so the two term-extraction surfaces cannot drift apart. That module's `tokenize` is
**not** imported — it splits on `[^a-z0-9]+`, which is the ASCII-only defect `drift` exists to avoid.

## The exit table

Shared meanings are **imported** from `report/codes.ts` under an alias; no shared numeral is restated
anywhere in the group.

| Code | Export | Source |
|---|---|---|
| `3` | `EMPTY_STDIN` | import (`EMPTY_STDIN`) |
| `4` | `BAD_SECTIONS` | import (`BAD_SECTIONS`) |
| `5` | `DELIBERATE_GAP` | held empty — leak detection is the merge gate's |
| `6` | *(none)* | held empty by prose alone; no export, no `DELIBERATE_GAP_2` |
| `7` | `ZERO_SCOPE` | import (`NO_TARGET`) |
| `8` | `WRITE_UNKNOWN` | import (`WRITE_UNKNOWN`) |
| `9` | `READBACK_MISMATCH` | import (`READBACK_MISMATCH`) |
| `10` | `OFF_VOCABULARY` | import (`CLASSIFIED`) |
| `11` | `PRECONDITION_UNKNOWN` | import (`PRECONDITION_UNKNOWN`) |
| `12` | `TERM_COLLISION` | group-local |
| `13` | `SECTION_ABSENT` | group-local |
| `14` | `ROW_SHAPE_INVALID` | group-local |
| `15` | `EDIT_BEYOND_ROW` | group-local |

`GLOSSARY_SEATS` is `BUILD_SEATS` minus `LEAKED_PATH`/`BARE_AT_PATH`, derived from the shipped map
rather than retyped. No seat was re-seated: `5` and `6` are the base's and stay unclaimed here.

The three-way split holds: `1`/`127` is the call never deciding, `11` is a precondition read that
failed with nothing written, `8` is a write attempted whose outcome is UNKNOWN — and every proven
verdict at `3`+ leaves stdout empty (`refuse()` hardcodes that).

## Insertion-only proof for the shared files

`git diff --numstat` against the merge base, added/deleted per file:

```
47  0  packages/fabrika-cli/README.md
15  0  packages/fabrika-cli/src/exit-code-alignment.ts
 2  0  packages/fabrika-cli/src/exit-code-alignment.unit.test.ts
 2  0  packages/fabrika-cli/src/registry.ts
 5  1  packages/fabrika-cli/src/adr/sweep.ts
```

Deletions summed over the four registration files: **0**. The README section is added whole; no
existing prose is reflowed or rewritten. The single deletion in the whole diff is `adr/sweep.ts`'s
`const STOPWORDS =` line becoming `export const STOPWORDS =` — the one-line change to a shipped
module the contract explicitly requires, called out here rather than hidden inside the total.

## Tests

`pnpm typecheck` in-package (`tsgo -p tsconfig.json` from `packages/fabrika-cli/`) is clean, and the
whole package suite passes — 269 files, 3843 tests. Coverage is three tiers:

- **Unit**, in process over `fakeFs`/`fakeShell`: one `*.unit.test.ts` per verb plus the four pure
  modules, covering every refusal each verb can produce.
- **`contract-examples.test.ts`**, in process over the real filesystem through `NodeServices.layer`:
  the contract's worked examples reproduced **byte for byte** against the committed fixtures under
  `claude-plugins/fabrika/skills/glossary/evals/fixtures/`, including `check`'s two planted defects
  and `add`'s derived line 18 (against a temp copy, so the committed corpus does not move).
- **`glossary.cli.test.ts`**, three subprocess spawns for the facts only a process boundary proves:
  reachability by registration alone, the stdout/stderr split, and a refusal leaving stdout empty.

## Deviations

Nine, plus one disclosed scan hit. Every one is a place the contract is silent or self-inconsistent;
none is an invention over a clause that decided.

**1 — the contract's `de-po` → `depo` example is UNREACHABLE, proven by execution.** Normalization
step 3 says "replace every run of `-`, `_` or whitespace with a **single space**", and the #4481
grounding gives the reason: a declared `front-door` must suppress `front door`. Under that rule
`de-po` normalizes to `de po`, which is not `depo` — so the `lookup` example that prints
`declared	terms	Products (domains)	depo` cannot happen. The conservative branch was taken: the
**stated algorithm** is implemented (the one #4481 fixes), and both directions are pinned in
`lookup-verb.unit.test.ts` — `front-door` ↔ `front door` resolve as one key, and `de-po` answers
`absent`. Surfaced on #5322 rather than patched into the contract.

**2 — exit `4`'s second stated trigger is unreachable in this parser.** The contract names two: "a
header row without a separator" and "rows whose cell count the parser cannot resolve". Splitting on
unescaped `|` resolves a count for **every** line, so a short row is a `row-shape` *finding* at exit
0, not a refusal — which is also what the `row-shape` detail text (`expected 3 cells, found <n>`)
requires. `4` therefore fires only on the header-without-separator case. Pinned in
`register.unit.test.ts`.

**3 — `init` seats a failed existence probe on `11`, which its per-verb table does not list.** The
table gives `0/8/9/10/12`. A probe that could not be *performed* is neither "already exists" (`12`,
a lie), nor a failed write (`8`, nothing was attempted). `11` is the group's own seat for exactly
this and is not a new number. Answering "absent" instead would license a write over a register the
process never managed to look at.

**4 — `init`'s read-back arm covers a read that *failed*, not only one that differs.** Both mean the
write landed and cannot be proven correct, which is `9`'s meaning; the pinned message is unchanged.

**5 — `drift --register both` is under-determined and takes the recall-biased branch.** The contract
bounds the range by "the resolved register file", singular, while `--register` admits `both`. Here
the declared set is the **union** of the present registers' keys and the range starts at the
**older** of their last-change commits, so nothing that moved since either register changed falls
outside a list the skill already treats as recall-biased. `bootstrap` fires only when no selected
register contributes rows.

**6 — `citations-unverified` is emitted once per run, with `-` in the register/section/term
columns.** The contract fixes the kind and its `detail` but not which row it is reported against; it
is a fact about the corpus, not about any row. An individual record that exists and cannot be read
lands here too, with the file name in the reason.

**7 — `lookup --json` uses `null` where the line grammar prints `-`.** The line grammar's `-` is
pinned and is emitted verbatim; the JSON shape's `register`/`section` for an `absent` term are not,
and `null` is what a JSON consumer can branch on. `matched` is `[]`, matching the declared array
shape.

**8 — `duplicate-key` is scoped within a register.** The contract says "two rows in the selected
registers" and then gives `cross-register` its own kind for the same key in TERMS and LANGUAGE.
Scoping `duplicate-key` per register is what stops one defect being reported twice under two names.

**9 — two `add` orderings the precedence list does not reach.** `--replace` rewrites the row where
it actually lives and reports **that** row's section (`--section` is still validated first, so a
bad one is `13`). And where a register's table structure is unresolvable *globally*, its sections
cannot be enumerated at all, so `4` precedes `13` in that one case; wherever the register parses,
the precedence is exactly as ordered.

**Disclosed scan hit — `dev-tier-m.sh` class 5, one line, a known false positive.** The scan's bare
`xit(` alternative matches inside `process.exit(outcome.code)` in `src/glossary/command.ts`'s emit
adapter. That line is byte-identical to the same adapter in ~19 sibling verb groups; it is not a
skipped test and there is nothing to suppress. Class 6 (removed assertions) is zero — this diff
removes no test line at all.

**Two codes not reachable from a test, stated rather than left to be noticed.** `15` cannot be
produced by the shipped composer, which only ever splices the lines it named — so `edit.unit.test.ts`
proves the assertion itself catches a re-sort and a truncation, which is the property that makes the
guard load-bearing rather than dead. `9` on `add` needs a filesystem that returns bytes other than
the ones written, which the in-memory fake cannot express; the arm is a straight comparison against
the composed row.

## Amendment — the CodeQL thread on `register.ts` is fixed, not waved through

CodeQL flagged `escapeCell` as an incomplete sanitization, and it was right. Escaping `|` without
escaping the escape character left the encoding ambiguous: a cell whose own text ends in a backslash
rendered as `…\ |`, and that trailing backslash then read as escaping the delimiter after it — a
value able to smuggle in the column separator the escape believed it had neutralized.

The second commit makes the pair an exact inverse: `escapeCell` escapes `\` first, `splitCells`
unescapes both arms, and a round-trip table covers the plain, embedded-pipe, trailing-backslash,
pre-escaped-pipe and double-backslash cases. Real corpora are unaffected — a lone backslash before a
non-delimiter still reads as itself.
