### PR TITLE
fix(fabrika): seat exit 11 in write-pattern's two writing verbs (#5355)

### DIFF
--- a/claude-plugins/fabrika/skills/write-pattern/contract.md
+++ b/claude-plugins/fabrika/skills/write-pattern/contract.md
@@ -689,6 +689,7 @@ retroactively would fail in every repo that is not this one.
 | Code | Trigger |
 |---|---|
 | `8` | the file could not be written, so whether anything landed is UNKNOWN |
+| `11` | the target-path existence check itself failed, so whether `<path>` exists is UNKNOWN — never read as absent, and never `13`, which is proven |
 | `13` | the target path already exists — refused, never overwritten |
 
 **Errors**
@@ -696,6 +697,7 @@ retroactively would fail in every repo that is not this one.
 | Message (stderr) | Code | Kind |
 |---|---|---|
 | `pattern new: <path> already exists — refusing to overwrite.` | 13 | refusal |
+| `pattern new: cannot determine whether <path> exists: <reason> — UNKNOWN, never "absent"; nothing written.` | 11 | refusal |
 | `pattern new: slug "<slug>" is not kebab-case (lowercase letters, digits and single hyphens).` | 1 | usage error |
 | `pattern new: --anchor "<value>" is not <pkg>@<version>.` | 1 | usage error |
 | `pattern new: cannot write <path>: <reason> — whether anything landed is UNKNOWN.` | 8 | refusal |
@@ -811,6 +813,7 @@ mechanical rather than remembered, and it is the deterministic test the implemen
 | `12` | `<dir>/<slug>.md` does not exist — refusing to write a row pointing at nothing |
 | `14` | the edit would have changed a line beyond the inserted row — aborted, nothing written |
 | `15` | the index is absent, or holds no parseable markdown table |
+| `11` | `<dir>/index.md` (step 1) or `<dir>/<slug>.md` (step 2) could not be read at all, so the precondition is UNKNOWN — never `15` or `12`, which are proven facts |
 
 **Errors**
 
@@ -819,6 +822,7 @@ mechanical rather than remembered, and it is the deterministic test the implemen
 | `pattern register: <dir>/index.md is absent — the doc at <dir>/<slug>.md is written and unregistered; front-door bootstraps the index.` | 15 | refusal |
 | `pattern register: <dir>/index.md holds no parseable markdown table — the doc at <dir>/<slug>.md is written and unregistered; front-door bootstraps the index.` | 15 | refusal |
 | `pattern register: no doc at <dir>/<slug>.md — refusing to register a row pointing at nothing.` | 12 | refusal |
+| `pattern register: cannot read <path>: <reason> — UNKNOWN, never "absent"; nothing written.` | 11 | refusal |
 | `pattern register: slug "<slug>" is not kebab-case (lowercase letters, digits and single hyphens).` | 1 | usage error |
 | `pattern register: no section "<section>" in <dir>/index.md (present: <a>, <b>, …).` | 10 | refusal |
 | `pattern register: "<section>" matches <n> headings in <dir>/index.md — ambiguous, nothing written.` | 16 | refusal |

--- a/claude-plugins/fabrika/skills/write-pattern/contract.md
+++ b/claude-plugins/fabrika/skills/write-pattern/contract.md
@@ -697,7 +697,7 @@ retroactively would fail in every repo that is not this one.
 | Message (stderr) | Code | Kind |
 |---|---|---|
 | `pattern new: <path> already exists — refusing to overwrite.` | 13 | refusal |
-| `pattern new: cannot determine whether <path> exists: <reason> — UNKNOWN, never "absent"; nothing written.` | 11 | refusal |
+| `pattern new: cannot check <path>: <reason> — nothing was written.` | 11 | refusal |
 | `pattern new: slug "<slug>" is not kebab-case (lowercase letters, digits and single hyphens).` | 1 | usage error |
 | `pattern new: --anchor "<value>" is not <pkg>@<version>.` | 1 | usage error |
 | `pattern new: cannot write <path>: <reason> — whether anything landed is UNKNOWN.` | 8 | refusal |
@@ -822,7 +822,9 @@ mechanical rather than remembered, and it is the deterministic test the implemen
 | `pattern register: <dir>/index.md is absent — the doc at <dir>/<slug>.md is written and unregistered; front-door bootstraps the index.` | 15 | refusal |
 | `pattern register: <dir>/index.md holds no parseable markdown table — the doc at <dir>/<slug>.md is written and unregistered; front-door bootstraps the index.` | 15 | refusal |
 | `pattern register: no doc at <dir>/<slug>.md — refusing to register a row pointing at nothing.` | 12 | refusal |
-| `pattern register: cannot read <path>: <reason> — UNKNOWN, never "absent"; nothing written.` | 11 | refusal |
+| `pattern register: cannot check <dir>/index.md: <reason> — nothing was written.` | 11 | refusal |
+| `pattern register: cannot read <dir>/index.md: <reason> — nothing was written.` | 11 | refusal |
+| `pattern register: cannot check <dir>/<slug>.md: <reason> — nothing was written.` | 11 | refusal |
 | `pattern register: slug "<slug>" is not kebab-case (lowercase letters, digits and single hyphens).` | 1 | usage error |
 | `pattern register: no section "<section>" in <dir>/index.md (present: <a>, <b>, …).` | 10 | refusal |
 | `pattern register: "<section>" matches <n> headings in <dir>/index.md — ambiguous, nothing written.` | 16 | refusal |


### PR DESCRIPTION
The `write-pattern` CLI contract already defines exit `11` for "a precondition read failed", and three of its five verbs use it. The two verbs that write files — `pattern new` and `pattern register` — did not, so a read that *errored* fell through to exit `1`, the code this repo reserves for "the call never ran". This adds the missing seat to both verbs so a failed read is told apart from a call that never happened.

Six table rows, no code change: one **Exit status** row per verb, plus one **Errors** row per exit-`11` site in the shipped verb (one for `pattern new`, three for `pattern register`), reusing the shared matrix's existing `11 PRECONDITION_UNKNOWN`.

- `pattern new` — `11` when the target-path existence check itself fails, so existence is neither proven nor disproven (distinct from `13`, which is proven).
- `pattern register` — `11` at each of its three precondition reads: the `<dir>/index.md` existence check, the `<dir>/index.md` read, and the `<dir>/<slug>.md` existence check (distinct from `15` and `12`, which are proven facts).

Message wording is quoted verbatim from the shipped verbs (`packages/fabrika-cli/src/pattern/{new,register}-verb.ts`) — `pattern <verb>: cannot check|read <path>: <reason> — nothing was written.` No new exit code is minted, nothing is renumbered, exit `7` (`ZERO_SCOPE`) stays unseated, codes `3`–`6` stay deliberate gaps, and the shared matrix, the seat map, and the three verbs that already seat `11` are untouched.

Same defect and same shape as #4736 in the sibling `adr` contract; belongs to the #4208 collision (a failed read is not a call that never ran).

Fixes #5355

## Deviations

- **Scope narrowing / different shape** **(repair round 1)** — **Said:** #5355's *What the fix is*
  asks for "four rows total, two per verb", and AC2/AC4 ask for the stderr row "in the group's
  existing refusal wording, naming the outcome as UNKNOWN". **Did:** six rows — `pattern register`
  gets three Errors rows, one per exit-`11` site in the shipped verb — and the wording is quoted
  verbatim from `packages/fabrika-cli/src/pattern/{new,register}-verb.ts` (`— nothing was written.`),
  which carries no `UNKNOWN` token. **Why:** #5355 was filed before #5332 shipped, so its suggested
  wording is a guess at bytes that now exist; an Errors table that does not match what the binary
  prints is the defect the round-1 review FAILed on. **Disposition:** no action needed — reviewer-
  directed in the `review-skill: FAIL @ 04353efb` verdict; the seat-level UNKNOWN semantics AC2 wants
  are carried by the Exit status rows, and no code change is implied.
