### PR TITLE
fix(fabrika-cli): give every leaf verb a scannable help list row

### DIFF
--- a/claude-plugins/fabrika/docs/cli-interface-convention.md
+++ b/claude-plugins/fabrika/docs/cli-interface-convention.md
@@ -28,10 +28,29 @@ discoverability is first-class), sharpened by the [#4635](https://github.com/kam
 survey of the v1 CLI, which found root help lists every tool with a purpose and a citation while
 per-tool help documents subcommands and exit codes inline.
 
-- Every verb, every subcommand, and every flag carries a one-line description. A flag with no
-  description is an undocumented input.
+- Every verb, every subcommand, and every flag carries a description. A flag with no description is
+  an undocumented input.
+- **Two audiences read a verb's help, so a verb declares two descriptions, not one.** The parent
+  group's `SUBCOMMANDS` list is scanned by a human choosing a verb; the verb's own `DESCRIPTION`
+  block is read by whoever is about to call it. They want opposite things, and one string cannot be
+  both:
+  - the **short** description (`Command.withShortDescription`) is the list row — **one sentence**
+    saying what the verb answers, no output shape, no exit codes, no example. The renderer neither
+    wraps nor truncates it, so it must fit one terminal line beside the padded name column; the
+    budget and the checks are `packages/fabrika-cli/src/short-description.ts`, asserted for every
+    registered leaf by `short-description.unit.test.ts`.
+  - the **long** description (`Command.withDescription`) is the verb-level contract below.
+
+  Reusing the long form as the list row is the defect this split fixes: `fabrika ship --help` emitted
+  rows of 1171, 1043 and 1029 characters as single unwrapped lines, so a wrapped continuation was
+  indistinguishable from the next verb's row and the founder could not read the output at all
+  ([#5208](https://github.com/kamp-us/phoenix/issues/5208)). `withShortDescription` **adds** a field
+  and the renderer falls back to `description` when it is absent, so nothing is truncated and the
+  contract below is untouched.
 - `--help` states, for the verb: what it answers, its output **shape** (rule 2), its exit codes
-  (rule 3), and at least one example (rule 5).
+  (rule 3), and at least one example (rule 5). This is the **long** description's job — the "one
+  line" rule above governs the list row, not this block, and the two stop contradicting each other
+  once they are separate strings.
 - The index of verbs is **derived from the registry**, never hand-maintained. v1's
   `pipeline-cli commands compact` is the working precedent: it reads name + description off the same
   `Command` objects the router dispatches on, so a new verb appears automatically and a verb shipped

--- a/packages/fabrika-cli/src/adr/command.ts
+++ b/packages/fabrika-cli/src/adr/command.ts
@@ -65,6 +65,7 @@ const next = leafCommand(
 		yield* emit(yield* runNext({dir, base, repo: Option.getOrNull(repo), json}));
 	}),
 ).pipe(
+	Command.withShortDescription("The next unused ADR id, merged set and open-PR claims folded."),
 	Command.withDescription(
 		"The next unused ADR id — max(fetched merged set ∪ open-PR claims) + 1. Prints `0240`; --json adds mergedMax/inFlight/baseSha. An empty-and-readable --dir is a fresh corpus and answers 0001. Exits 11 (--dir unreadable), 17 (base unfetchable), 18 (in-flight unknown). Example: fabrika adr next",
 	),
@@ -119,6 +120,7 @@ const newCmd = leafCommand(
 		);
 	}),
 ).pipe(
+	Command.withShortDescription("Scaffold a new ADR file from the canonical template."),
 	Command.withDescription(
 		"Scaffold .decisions/NNNN-slug.md from the canonical template. Prints the path written. Exits 12 (path exists — never overwritten); a bad id or slug is a usage error and exits 1. Example: fabrika adr new 0240 only-landed-adrs-may-be-cited",
 	),
@@ -137,6 +139,7 @@ const resolve = leafCommand(
 		yield* emit(yield* runResolve({ids, dir, base, repo: Option.getOrNull(repo), json}));
 	}),
 ).pipe(
+	Command.withShortDescription("Resolve ADR ids to their real filename and state at a base ref."),
 	Command.withDescription(
 		"Resolve ids to their real filename and state against a fetched base ref — one `<state>\\t<file>\\t<detail>` line per id, state ∈ live|landed|in-flight|absent. An empty-and-readable --dir answers absent. Exits 11 (--dir unreadable), 17 (base unfetchable), 18 (in-flight unknown). Example: fabrika adr resolve 0164 0023",
 	),
@@ -153,6 +156,7 @@ const supersede = leafCommand(
 		yield* emit(yield* runRelate({relationship: "supersede", id, by, dir, json}));
 	}),
 ).pipe(
+	Command.withShortDescription("Mark an older ADR superseded by this one."),
 	Command.withDescription(
 		"Rewrite an older ADR's status: line to `superseded by [NNNN](NNNN-slug.md)` — that line and nothing else. Prints `<path>\\t<new status>`. Exits 7 (no such id), 13 (no --by record), 14 (no single status: line), 15 (diff touched another line — nothing written), 16 (already superseded). Example: fabrika adr supersede 0126 --by 0240",
 	),
@@ -165,6 +169,7 @@ const amendInPart = leafCommand(
 		yield* emit(yield* runRelate({relationship: "amend-in-part", id, by, dir, json}));
 	}),
 ).pipe(
+	Command.withShortDescription("Add this ADR to an older one's amended-in-part list."),
 	Command.withDescription(
 		"Append this ADR to an older one's `amended-in-part by` list, in id order, preserving the links already there. Prints `<path>\\t<new status>`. Same exit codes as supersede. Example: fabrika adr amend-in-part 0023 --by 0240",
 	),
@@ -189,6 +194,7 @@ const sweepCmd = leafCommand(
 		yield* emit(yield* runSweep({new: subject, dir, limit, json}));
 	}),
 ).pipe(
+	Command.withShortDescription("Rank the live ADRs this one may contradict."),
 	Command.withDescription(
 		"Rank the uncited live-accepted ADRs this one may contradict. First stdout line is the outcome token — shortlist | no-overlap | indeterminate — and ALL THREE exit 0; a shortlist adds one `<id>\\t<score>\\t<file>\\t<title>` line per entry. An empty-and-readable --dir answers indeterminate. Exits 7 (no readable --new), 11 (corpus unreadable). Example: fabrika adr sweep --new 0240",
 	),

--- a/packages/fabrika-cli/src/build/command.ts
+++ b/packages/fabrika-cli/src/build/command.ts
@@ -84,6 +84,7 @@ const tree = leafCommand(
 		);
 	}),
 ).pipe(
+	Command.withShortDescription("Prove the ground is a linked worktree, clean and this lane's."),
 	Command.withDescription(
 		"Prove the ground: a linked worktree, optionally clean, optionally this lane's. Prints the tree root's absolute path on stdout. Verifies and NEVER provisions — it creates, locks, unlocks and removes nothing (the spawner owns the tree's lifecycle). Exits 11 (with --issue: the claim state could not be read — the lane is UNKNOWN), 12 (proven: not in a linked worktree), 13 (proven: uncommitted changes at a --require-clean open), 14 (proven: the checked-out branch does not carry this claim's nonce), 15 (proven: the claim on --issue is foreign). Example: fabrika build tree --require-clean",
 	),
@@ -102,6 +103,7 @@ const pick = leafCommand(
 		yield* emit(yield* runPick({repo: Option.getOrNull(repo), limit, env: process.env}));
 	}),
 ).pipe(
+	Command.withShortDescription("The ranked pool of issues this lane may pick up."),
 	Command.withDescription(
 		'The ranked candidate pool: status:triaged + unassigned + admitted by the shared admission test (scope axis against the ROADMAP.md "## Focus" declaration, audience axis on ready-for:agent), every bucket paginated in full. Prints {"pool":[…],"excluded":[{"number","home","reason"}],"scanned":{"p0":n,"p1":n,"p2":n},"focus":{…}}; each excluded issue names which axis refused it, and an empty pool is a fact on exit 0, readable against the scanned counts. Exits 1 (--limit is not a positive integer), 4 (the "## Focus" declaration reads but does not parse — never read as "no focus"), 11 (any bucket read failed or came back truncated, or the declaration could not be read — the pool is UNKNOWN, never partial and never unfiltered). Example: fabrika build pick --limit 5',
 	),
@@ -114,6 +116,7 @@ const eligible = leafCommand(
 		yield* emit(yield* runEligible({number, repo: Option.getOrNull(repo), env: process.env}));
 	}),
 ).pipe(
+	Command.withShortDescription("Whether one issue's dependency gate is open."),
 	Command.withDescription(
 		'One issue\'s dependency gate, derived from the parent ledger\'s "## Dependencies" topology and never read off a label. Prints {"answer":"eligible","number":n,"parent":n|null}; blocked and unknown print nothing. Every predecessor is read before the answer is seated, so the verdict does not depend on the order the topology lists them in, and a predecessor that could not be read is named on stderr as its own row rather than counted closed. Exits 4 (the parent\'s "## Dependencies" block is absent or unparseable — "no parseable edges" is never "no edges"), 7 (the issue is proven absent or closed), 11 (the issue, parent or a predecessor could not be read, with nothing proven open — UNKNOWN, never "eligible"), 16 (proven blocked — EVERY open edge is named on stderr, alongside any predecessor that could not be read). Example: fabrika build eligible 4312',
 	),
@@ -163,6 +166,7 @@ const claim = leafCommand(
 		);
 	}),
 ).pipe(
+	Command.withShortDescription("Race the claim marker on an issue and win it or name the winner."),
 	Command.withDescription(
 		`Race the earliest AUTHORIZED claim marker on an issue: post this session's token (build:<CLAUDE_CODE_SESSION_ID>:<uuid>), re-read, and win or name the winner. Authorization is the author's repository permission (ADR 0055) — marker text confers nothing. The admission test runs FIRST, before any marker is written, so a refused claim leaves no trace to retract. --purpose says why this lane claims (${CLAIM_PURPOSES.join(" | ")}, default ${DEFAULT_CLAIM_PURPOSE}): the audience axis (${READY_FOR_AGENT}) binds a build claim only, because an epic earns that label AFTER it is planned and gated (#5175); the scope axis binds every purpose, and an off-enum --purpose refuses on 10 rather than falling back. --override "<reason>" admits a proven refusal and REQUIRES --override-lane "<lane>"; both are recorded on the marker, and an UNKNOWN admission is never overridable. Prints {"answer":"won","number":n,"token":"…","purpose":"…"}, plus "override":{"lane","reason"} when one was used. A lost race retracts this run's own marker and exits 15, never 0; an unset CLAUDE_CODE_SESSION_ID, an empty --override reason, an --override with no lane, or an --override-lane with no override, is 1. Exits 7 (issue proven absent or closed), 8 (the marker write failed — UNKNOWN; run confirm), 9 (the marker landed but does not read back), 10 (--purpose is off-enum), 15 (proven lost), and from the admission test: ${admissionExits}. Example: fabrika build claim 4312 --purpose gate`,
 	),
@@ -175,6 +179,7 @@ const confirm = leafCommand(
 		yield* emit(yield* runConfirm({number, repo: Option.getOrNull(repo), env: process.env}));
 	}),
 ).pipe(
+	Command.withShortDescription("Re-prove this session still holds the claim."),
 	Command.withDescription(
 		'Re-prove this session still holds the claim, before a mutation. Prints {"answer":"mine","number":n,"token":"…"}. Exits 1 (CLAUDE_CODE_SESSION_ID unset), 7 (issue proven absent or closed), 11 (the marker set could not be read — UNKNOWN, never "unclaimed"), 15 (proven: held by another session, or no claim exists — the detail is on stderr). Example: fabrika build confirm 4312',
 	),
@@ -187,6 +192,7 @@ const release = leafCommand(
 		yield* emit(yield* runRelease({number, repo: Option.getOrNull(repo), env: process.env}));
 	}),
 ).pipe(
+	Command.withShortDescription("Retract this session's own claim marker."),
 	Command.withDescription(
 		'Retract this session\'s OWN claim marker, and only its own. Prints {"answer":"released","number":n}. Exits 1 (CLAUDE_CODE_SESSION_ID unset), 7 (issue proven absent or closed), 8 (the retraction failed — UNKNOWN), 11 (the marker set could not be read), 15 (this session holds no claim — refusing to release another lane\'s). Example: fabrika build release 4312',
 	),
@@ -199,6 +205,7 @@ const issue = leafCommand(
 		yield* emit(yield* runIssue({number, repo: Option.getOrNull(repo), env: process.env}));
 	}),
 ).pipe(
+	Command.withShortDescription("The claimed issue's body and acceptance criteria."),
 	Command.withDescription(
 		'The claimed issue\'s body and acceptance criteria, through the content gate. Prints one JSON object with number, title, state, labels, body and criteria; criteria.state is found | absent | malformed — three facts the imported wire read keeps apart, so a drifted heading never reads as "no acceptance criteria". Exits 7 (issue proven absent or closed), 11 (the issue could not be read — its content is UNKNOWN). Example: fabrika build issue 4312',
 	),
@@ -240,6 +247,7 @@ const branch = leafCommand(
 		);
 	}),
 ).pipe(
+	Command.withShortDescription("Cut or resume the lane's branch off a freshly fetched base."),
 	Command.withDescription(
 		"Cut (or resume) the lane's nonce branch off a FRESHLY FETCHED base, never a stale local ref. Prints the checked-out branch name: build/<number>-<slug>-<nonce> in create mode, build/pr-<pr>-<nonce> in resume mode, where <nonce> is the first 8 hex of the current claim token's UUID. The branch name IS the lane record — there is no stamp file. Exits 7 (--resume's PR is proven absent, closed or merged), 10 (--slug is not kebab-case, exceeds 5 words, or is flag-shaped), 11 (the fetch failed, or the claim state could not be read), 12 (proven: not in a linked worktree), 15 (proven: the claim is foreign). Example: fabrika build branch 4312 --slug editor-focus-loss",
 	),
@@ -266,6 +274,7 @@ const scratch = leafCommand(
 		);
 	}),
 ).pipe(
+	Command.withShortDescription("The per-lane scratch directory path."),
 	Command.withDescription(
 		"The per-lane scratch path, allocated fail-closed: <temp root>/fabrika-build/<session-id>/<issue>-<claim-nonce>/<slug>, one absolute path on stdout, the directory created if absent. The claim nonce is what keys the namespace per LANE rather than per session, so two lanes of one session cannot clobber each other. The printed path is machine-local and must never reach a posted artifact. Exits 1 (the directory could not be created, or CLAUDE_CODE_SESSION_ID is unset), 10 (--slug carries a path separator or is not kebab-case), 11 (the claim state could not be read), 15 (proven: the claim is foreign). Example: fabrika build scratch 4312 --slug notes",
 	),
@@ -285,6 +294,9 @@ const check = leafCommand(
 		yield* emit(yield* runCheck({surface, repo: Option.getOrNull(repo), env: process.env}));
 	}),
 ).pipe(
+	Command.withShortDescription(
+		"Run this surface's validators here, with the build cache bypassed.",
+	),
 	Command.withDescription(
 		'Run this surface\'s validators in this tree, with the build cache BYPASSED — a cache hit from another worktree has returned another tree\'s green. Prints {"verdict":"green","surface":"…","tree":"…","ran":[…]}; red and unknown print nothing. This verb predicts; ci.yml decides, and supersedes it where they disagree. Exits 7 (the diff against the base is empty — zero scope, ADR 0092), 10 (--surface is off-enum or provably mismatches the diff), 11 (a validator could not be executed, or the lane\'s claim could not be read — UNKNOWN, never green), 12 (not in a linked worktree), 14 (the checked-out branch is not this lane\'s), 15 (the lane\'s claim is held by another session), 18 (proven red). Example: fabrika build check --surface code',
 	),
@@ -320,6 +332,7 @@ const push = leafCommand(
 		);
 	}),
 ).pipe(
+	Command.withShortDescription("Push the lane's branch and confirm the remote ref moved."),
 	Command.withDescription(
 		"Publish the lane's branch and INDEPENDENTLY confirm the remote ref moved, by reading it back with git ls-remote. The whole report is stdout, single-stream, so `tail -1` of stdout on exit 0 is always `PUSH-VERDICT: MOVED`. Before pushing, the local head must CONTAIN the published remote head — on the force path too, where --force-with-lease proves nothing about this lane's own dropped commits. Exits 8 (pushed, but the remote ref could not be re-read — the outcome is UNKNOWN), 11 (the lane's claim could not be read, or containment could not be proven — nothing was pushed), 12 (not in a linked worktree), 14 (the checked-out branch is not this lane's), 15 (the claim is held by another session), 17 (proven: the remote ref did not move), 19 (refused before pushing: detached HEAD, or non-fast-forward without --force-with-lease), 23 (proven: the local head drops the remote head's commits — rebase, or pass --drop-remote-commits). Example: fabrika build push",
 	),
@@ -348,6 +361,7 @@ const pr = leafCommand(
 		);
 	}),
 ).pipe(
+	Command.withShortDescription("Open the PR from the body on stdin, guarded and read back."),
 	Command.withDescription(
 		'Open the PR from the body on STDIN, refusing the known defect shapes before any write, with a read-back through normalizeForReadback. Prints {"answer":"opened",…}, or {"answer":"existing",…} on exit 0 when this head branch already has an open PR — an idempotent re-run is an answer, not a duplicate. Exits 3 (stdin held nothing), 4 ("## Deviations" missing or empty, or the closing-keyword line is absent, duplicated, mistargeted, or contradicts --partial), 5 (machine-local path), 6 (bare @ reference), 7 (issue proven absent or closed), 8 (the create failed — UNKNOWN; re-run), 9 (landed but does not read back), 10 (the body asserts a control-plane, type or priority classification — those verdicts are the gate\'s and triage\'s), 11 (a precondition read failed), 12 (not in a linked worktree), 14 (the head branch is not this lane\'s), 15 (this session does not hold the claim). Example: fabrika build pr 4312 < body.md',
 	),
@@ -372,6 +386,7 @@ const note = leafCommand(
 		);
 	}),
 ).pipe(
+	Command.withShortDescription("Post the progress or handoff note on stdin."),
 	Command.withDescription(
 		'Post the progress or handoff note on STDIN, leak-guarded and read back. When the number resolves to a PR the note is stamped with that PR\'s head SHA at post time, so a reader can see a note predates a later push. Runs ONLY the posting guards — never the tree assertions — so a stop-report stays postable from a refused tree. Prints {"answer":"posted","number":n,"commentId":n,"head":"…"|null}. Exits 3 (stdin held nothing), 5 (machine-local path), 6 (bare @ reference), 7 (target proven absent or closed), 8 (the write failed — UNKNOWN), 9 (posted but does not read back), 11 (a precondition read failed), 15 (this session does not hold the claim). Example: fabrika build note 4310 < round-2.md',
 	),
@@ -389,6 +404,7 @@ const verdicts = leafCommand(
 		yield* emit(yield* runVerdicts({pr: number, repo: Option.getOrNull(repo), env: process.env}));
 	}),
 ).pipe(
+	Command.withShortDescription("The latest gate verdict per namespace at a PR's live head."),
 	Command.withDescription(
 		'The paginated, current-head, per-gate verdict fold on a PR: every comment and every review, the latest marker per gate namespace bound to the live head, native reviews as their OWN row kind (never coerced), the 120-second FAIL round count, capReached, and the criteria frozen after round 2. Prints one JSON object with head, rows, rounds, capReached and frozenCriteria; {"rows":[]} on exit 0 is a proven "no verdicts", readable against the scope line. A stale marker prints as stale, never dropped. Exits 7 (PR proven absent or closed), 11 (the head, any comment page or any review page could not be read — UNKNOWN, never "none"). Example: fabrika build verdicts --pr 4310',
 	),

--- a/packages/fabrika-cli/src/epic/command.ts
+++ b/packages/fabrika-cli/src/epic/command.ts
@@ -66,6 +66,7 @@ const open = leafCommand(
 		);
 	}),
 ).pipe(
+	Command.withShortDescription("Open or resume an epic run and print its state."),
 	Command.withDescription(
 		'Open or resume the run: parse the epic\'s slice topology, create the nonce-keyed run ledger if absent, print run state. Prints {"answer":"opened","epic":n,"run":"<epic>-<nonce>","slices":[…],"order":[…],"resumed":false}; a ledger already at this key answers "resumed":true and the run picks up where it left off. Runs the tree and claim assertions only — never the lane branch, because this verb precedes `fabrika build branch`. Exits 4 (no parseable planned ledger or "## Dependencies" block — "no parseable slices" is never "no slices"), 7 (the epic or a named child is proven absent or closed), 10 (the issue is not a type:epic), 11 (the epic, a child or the ledger path could not be read or created), 12 (not in a linked worktree), 15 (this session does not hold the epic\'s claim), 21 (a ledger exists at this key and holds unnameable state). Example: fabrika epic open 4300',
 	),
@@ -78,6 +79,7 @@ const next = leafCommand(
 		yield* emit(yield* runNext({number, env: process.env}));
 	}),
 ).pipe(
+	Command.withShortDescription("The one next action for this run."),
 	Command.withDescription(
 		`The state relay: ledger + git graph folded into exactly one next action. Prints one JSON object whose "action" is dispatch-slice | evaluate-slice | retry-slice | escalate-slice | open-pr | done | halted. Reads no GitHub beyond the lane guard, spawns nothing, judges nothing. The two retry breakers are its arithmetic and are never summed: the fail axis caps at ${FAIL_AXIS_CAP}, the dead axis at ${DEAD_AXIS_CAP}; escalate-slice is an ANSWER on exit 0, not the 23 refusal. Exits 11 (the ledger or the graph could not be read), 12/14/15 (the lane guard's refusals), 20 (no ledger at this run's key — run "fabrika epic open <n>" first), 21 (the ledger holds unnameable state). Example: fabrika epic next 4300`,
 	),
@@ -113,6 +115,7 @@ const record = leafCommand(
 		);
 	}),
 ).pipe(
+	Command.withShortDescription("Append one event to the run ledger."),
 	Command.withDescription(
 		'Append one closed-vocabulary event to the run ledger, append-only, and read the tail back. Prints {"answer":"recorded","seq":n,"event":"…","slice":"…"}. The HEAD SHA is SELF-CAPTURED into slice-dispatched and slice-landed — a caller-supplied SHA would reopen the self-report hole this group closes — so the answer omits it and the read-back proves it from the artifact. Exits 8 (the append could not be proven — UNKNOWN), 9 (the tail does not read back), 10 (--event off-enum, --slice unknown to the run, or the event contradicts derived state), 11 (a required read failed), 12/14/15 (the lane guard\'s refusals), 20 (no ledger at this run\'s key), 21 (unnameable ledger state), 23 (the slice\'s breaker is at cap — only breaker-tripped or run-halted). Example: fabrika epic record 4300 --event slice-dispatched --slice C2',
 	),
@@ -143,6 +146,7 @@ const brief = leafCommand(
 		);
 	}),
 ).pipe(
+	Command.withShortDescription("The dispatch brief for one slice."),
 	Command.withDescription(
 		"The dispatch brief for one slice, emitted through the registered slice-handoff wire format: ## Slice (the child's acceptance criteria verbatim), ## Ground (worktree, branch, base SHA, the per-slice handoff path), ## Rules (byte-fixed text the format owns), and ## Fix-First with --retry. The document is NOT leak-scanned — ## Ground carries machine-local paths by construction, so a brief is consumed in-session and never posted. Exits 4 (the child's acceptance criteria are absent or malformed — no criterion is invented), 7 (the child issue is proven absent or closed), 10 (--slice unknown to this run, or --retry with no FAIL verdict on record), 11 (the ledger, the child issue or the git base could not be read), 12/14/15 (the lane guard's refusals), 20 (no ledger at this run's key), 21 (unnameable ledger state), 23 (the slice's breaker is at cap — escalate, do not dispatch). Example: fabrika epic brief 4300 --slice C2",
 	),
@@ -155,6 +159,7 @@ const landed = leafCommand(
 		yield* emit(yield* runLanded({number, slice, env: process.env}));
 	}),
 ).pipe(
+	Command.withShortDescription("Prove a slice's commit landed, from the git graph alone."),
 	Command.withDescription(
 		'Prove a slice\'s commit landed, from the git graph alone and NEVER from a subagent\'s report: HEAD moved since the slice\'s opening SHA, the old tip is an ancestor of the new HEAD, the tree is clean, and the commit is non-empty. Prints {"answer":"landed","slice":"…","commit":"…","parent":"…","files":n}. Exits 7 (the new commit changes zero files), 10 (the old tip is not an ancestor — history was rewritten under the run; a human decides), 11 (the ledger or git state could not be read), 12/14/15 (the lane guard\'s refusals), 13 (proven: the tree is dirty beside the new commit), 20 (no ledger at this run\'s key), 21 (unnameable ledger state), 22 (proven: HEAD is unchanged since the slice opened — a dead dispatch, distinct from a failed slice). Example: fabrika epic landed 4300 --slice C2',
 	),
@@ -172,6 +177,7 @@ const sliceDiff = leafCommand(
 		yield* emit(yield* runSliceDiff({number, commit}));
 	}),
 ).pipe(
+	Command.withShortDescription("The unpushed slice commit's diff against its first parent."),
 	Command.withDescription(
 		"The unpushed commit's unified diff against its first parent, served from the local object store exactly as git show gives it — no push, no CI dependency, no draft PR. Completeness is the object store's: a commit that resolves serves in full or the read fails. Runs the TREE assertion only — an evaluator holds no claim, it reads. Exits 7 (the diff is empty — nothing to review, ADR 0092), 10 (--commit is not 7–40 lowercase hex), 11 (the git read failed), 12 (proven: not in a linked worktree), 24 (proven: the commit is not in this branch's local graph). Example: fabrika epic slice-diff 4300 --commit 8c1f2a9d",
 	),
@@ -203,6 +209,7 @@ const verdict = leafCommand(
 		);
 	}),
 ).pipe(
+	Command.withShortDescription("Record one slice verdict, bound to its commit SHA."),
 	Command.withDescription(
 		'Record one slice verdict from the body on STDIN, bound to the commit SHA in the local graph — content-addressed, so any amend or rebase makes the old verdict unbindable rather than stale. Prints {"answer":"recorded","slice":"…","polarity":"PASS","commit":"…","seq":n}. The recorded marker is composed by the shared verdict-marker format under the namespace slice:<id>, its clause the body\'s first line, which is what next injects as Fix-First. Exits 3 (stdin held nothing), 8 (the append could not be proven), 9 (the tail does not read back), 10 (polarity off-enum, or --commit is not the slice\'s landed commit), 11 (a required read failed), 12/14/15 (the lane guard\'s refusals), 20 (no ledger at this run\'s key), 21 (unnameable ledger state), 23 (the slice\'s breaker is at cap), 24 (the commit is not in the local graph). Example: fabrika epic verdict 4300 --slice C2 --commit 8c1f2a9d --polarity FAIL < findings.md',
 	),
@@ -215,6 +222,7 @@ const status = leafCommand(
 		yield* emit(yield* runStatus({number, env: process.env}));
 	}),
 ).pipe(
+	Command.withShortDescription("The whole run folded from the ledger and the live graph."),
 	Command.withDescription(
 		"The whole run folded, derived fresh from the ledger and the live graph: per-slice state (pending | dispatched | landed | passed | retrying | escalated | dead-dispatch), each verdict four-valued against the graph (current | fail | none | unbindable — an unbindable verdict is surfaced, never dropped and never rendered as current), both per-slice counters, and the run counters. This fold is the handoff artifact: a successor session resumes from it and the ledger, not from anyone's narrative. Exits 11, 12/14/15, 20, 21 — triggers exactly as in `fabrika epic next`. Example: fabrika epic status 4300",
 	),

--- a/packages/fabrika-cli/src/eval/command.ts
+++ b/packages/fabrika-cli/src/eval/command.ts
@@ -104,6 +104,7 @@ const check = leafCommand(
 		);
 	}),
 ).pipe(
+	Command.withShortDescription("Validate a corpus manifest against the schema."),
 	Command.withDescription(
 		"Validate a corpus manifest file against the schema (exit non-zero on a bad one)",
 	),
@@ -233,6 +234,7 @@ const report = leafCommand(
 		);
 	}),
 ).pipe(
+	Command.withShortDescription("Render the graded two-axis eval scorecard."),
 	Command.withDescription(
 		"Render the graded two-axis scorecard (pass-rate + token spend + churn cost per stage×model) — evidence for #1576, not a recommendation",
 	),
@@ -295,6 +297,7 @@ const cases = leafCommand(
 		);
 	}),
 ).pipe(
+	Command.withShortDescription("Validate an eval set and print each case's execution tier."),
 	Command.withDescription(
 		"Validate a /skill-creator-authored eval set and print each case's derived execution tier (exit non-zero with a named reason on a bad one)",
 	),
@@ -502,6 +505,7 @@ const runCommand = leafCommand(
 		);
 	}),
 ).pipe(
+	Command.withShortDescription("Execute a skill's eval set unattended, both arms."),
 	Command.withDescription(
 		"Execute a skill's eval set unattended (both arms) and emit the capture manifest the existing collector consumes — for an operator's shell or a review-skill spawn, never a CI job (#4676)",
 	),
@@ -589,6 +593,7 @@ const keeps = leafCommand(
 		);
 	}),
 ).pipe(
+	Command.withShortDescription("Print the ruled KEEP corpus of eval feedstock."),
 	Command.withDescription(
 		"Print the ruled KEEP corpus — the committed enumeration of the fabrika eval feedstock, with each row's derivation and the eval cases that pin it (#4823)",
 	),

--- a/packages/fabrika-cli/src/glossary/command.ts
+++ b/packages/fabrika-cli/src/glossary/command.ts
@@ -66,6 +66,7 @@ const init = leafCommand(
 		yield* emit(yield* runInit({register, dir, json, cwd: process.cwd()}));
 	}),
 ).pipe(
+	Command.withShortDescription("Create a register file that does not exist yet."),
 	Command.withDescription(
 		"Create a register file that does not exist, so a fresh repo is not a dead end. Prints `created\\t<path>`, or the JSON object {action, path, register}. Exits 8 (the write failed, the outcome is UNKNOWN), 9 (written and the read-back does not match the template), 10 (--register both, or an off-enum value), 11 (a precondition read failed, nothing was written), 12 (the register already exists — refused, never overwritten). Example: fabrika glossary init --register terms",
 	),
@@ -92,6 +93,7 @@ const drift = leafCommand(
 		yield* emit(yield* runDrift({register, dir, paths, limit, json, cwd: process.cwd()}));
 	}),
 ).pipe(
+	Command.withShortDescription("The surfaces that moved since the register last changed."),
 	Command.withDescription(
 		"The surfaces that moved since the register last changed, and the candidate coinages in them. Prints `drift`, `clean` or `bootstrap` on the first line — all three on exit 0 — then one `<phrase>\\t<hits>\\t<first-surface>` line per candidate. Exits 4 (the table structure is unparseable, so the declared set is UNKNOWN), 7 (--paths matched 0 tracked files), 10 (off-enum --register), 11 (--dir could not be read, or the range could not be computed). Example: fabrika glossary drift --register terms",
 	),
@@ -112,6 +114,7 @@ const lookup = leafCommand(
 		yield* emit(yield* runLookup({terms, register, dir, json, cwd: process.cwd()}));
 	}),
 ).pipe(
+	Command.withShortDescription("Whether a term is already declared, and what overlaps it."),
 	Command.withDescription(
 		'Whether a term is already declared, and what overlaps it. Prints one `<state>\\t<register>\\t<section>\\t<matched>` line per term, in argument order — `declared`, `collision` and `absent` are all answers on exit 0. Exits 1 (no term given), 4 (a selected register has no parseable term table), 10 (off-enum --register), 11 (a selected register could not be read, so every state is UNKNOWN). Example: fabrika glossary lookup "front door" --register both',
 	),
@@ -124,6 +127,7 @@ const sections = leafCommand(
 		yield* emit(yield* runSections({register, dir, json, cwd: process.cwd()}));
 	}),
 ).pipe(
+	Command.withShortDescription("The live section names of a register."),
 	Command.withDescription(
 		'The live section names of a register, so a caller reads them rather than recalling a list that rots. Prints one `<register>\\t<section>\\t<rows>` line per section in file order, or the single line `-\\tbootstrap\\t0` for a register that is absent or has no heading yet. Exits 4 (table rows under no "## " heading), 10 (off-enum --register), 11 (the register could not be read). Example: fabrika glossary sections --register terms',
 	),
@@ -189,6 +193,7 @@ const add = leafCommand(
 		);
 	}),
 ).pipe(
+	Command.withShortDescription("Insert or replace one row, alphabetically placed."),
 	Command.withDescription(
 		'Insert or replace one row, alphabetically placed and byte-preserving everywhere else. Prints `<action>\\t<path>\\t<section>\\t<line>`. Exits 3 (stdin held nothing), 4 (no parseable table under --section), 8/9 (the write failed, the read-back differs), 10 (--register both or an off-enum value), 11 (a precondition read failed — nothing was written), 12 (already declared without --replace, or --replace on an absent term), 13 (--section names no heading), 14 (the composed row cannot be a well-formed table row), 15 (the edit would have changed a line outside the target row — aborted). Example: printf \'The board product.\' | fabrika glossary add "pano" --register terms --section "Core / shape" --definition-file -',
 	),
@@ -211,6 +216,9 @@ const check = leafCommand(
 		yield* emit(yield* runCheck({register, dir, decisions, json, cwd: process.cwd()}));
 	}),
 ).pipe(
+	Command.withShortDescription(
+		"The shape, duplicate, ordering and citation defects in a register.",
+	),
 	Command.withDescription(
 		"Row-shape, duplicate-key, cross-register, ordering and citation-liveness defects in a register. Prints `clean`, `defects` or `bootstrap` on the first line — all three on exit 0 — then one `<kind>\\t<register>\\t<section>\\t<term>\\t<detail>` line per finding. Machine-local paths and dead links are deliberately not computed: a merge-blocking gate already decides each. Exits 4 (no parseable term table), 7 (a selected register is present and holds 0 rows), 10 (off-enum --register), 11 (a selected register could not be read). Example: fabrika glossary check --register both",
 	),

--- a/packages/fabrika-cli/src/governance/command.ts
+++ b/packages/fabrika-cli/src/governance/command.ts
@@ -76,6 +76,7 @@ const scope = leafCommand(
 		);
 	}),
 ).pipe(
+	Command.withShortDescription("Whether this PR's diff requires the governance namespace."),
 	Command.withDescription(
 		"Derive whether this PR's diff requires the governance namespace, over which of the four harness roots, at the bound head. Prints `governance\\t<required|not-required>\\t<head>`, then a `root` line per touched root, `self`, and a `record` line per decision record in the diff. This is NOT a §CP classification — §CP is CODEOWNERS' answer, and the verb says so on stderr every run. Exits 7 (the PR is absent, closed, or has zero changed files), 10 (--sha is not a head SHA), 11 (the PR or the commit binding could not be read — the derivation is UNKNOWN, never not-required), 12 (--sha is not the PR's head), 13 (the changed-file enumeration is provably short). Example: fabrika governance scope 4321",
 	),
@@ -125,6 +126,7 @@ const sweep = leafCommand(
 		);
 	}),
 ).pipe(
+	Command.withShortDescription("Rank the live records whose domain this subject touches."),
 	Command.withDescription(
 		"Rank the uncited live-accepted records whose decision domain the subject touches, reading the subject out of a bound commit or out of the corpus. All three outcomes — shortlist, no-overlap, indeterminate — exit 0 and none of them is a clearance. Exits 7 (--dir holds zero records, or the PR is absent or closed), 10 (a non-four-digit id, a --sha that is not a head SHA, a negative --limit, or both a PR and --landed), 11 (the subject or a corpus member could not be read — an incomplete corpus is UNKNOWN), 12 (--sha is not the PR's head), 13 (the changed-file list proving the record is in this PR is provably short). Example: fabrika governance sweep 4321 --record 0240",
 	),
@@ -145,6 +147,7 @@ const guards = leafCommand(
 		);
 	}),
 ).pipe(
+	Command.withShortDescription("The anchored invariants this diff removes or modifies."),
 	Command.withDescription(
 		"Scan the bound diff for anchored invariants it removes or modifies, and report the guard-bearing files it touches. Prints `guards\\t<hits|no-anchor-change|no-anchors-in-reach>\\t<anchors-in-reach>` then an `anchor` line per hit and a `guard-file` line per touched guard-bearing file. no-anchors-in-reach is the scan reporting its own silence, never a clearance. Exits 7 (the PR is absent, closed, or empty), 10 (--sha is not a head SHA), 11 (the diff could not be read — UNKNOWN, never no-anchor-change), 12 (--sha is not the PR's head), 13 (the diff is provably incomplete). Example: fabrika governance guards 4321",
 	),
@@ -166,6 +169,7 @@ const base = leafCommand(
 		yield* emit(yield* runBase({pr, path, repo: Option.getOrNull(repo), env: process.env}));
 	}),
 ).pipe(
+	Command.withShortDescription("This skill's own text at a PR's merge base."),
 	Command.withDescription(
 		"Read this skill's own text at the merge base of a PR that edits it — the self fence's bytes, as a pasteable literal. Prints `base\\t<merge-base>\\t<file-count>` then a `file\\t<path>\\t<byte-count>` header and that file's bytes per path; the byte count is the delimiter, there is no separator line. Exits 7 (the PR is absent or closed, the skill root resolved to zero matches, or every --path is absent at the merge base), 10 (a --path outside the resolved skill root), 11 (the merge base or a path could not be read, or the skill root resolved to more than one candidate), 12 (the head moved while the base was being resolved). Example: fabrika governance base 4321",
 	),
@@ -202,6 +206,7 @@ const post = leafCommand(
 		);
 	}),
 ).pipe(
+	Command.withShortDescription("Post the governance verdict on stdin as one comment."),
 	Command.withDescription(
 		'Post the governance verdict read from STDIN: compose through the verdict-marker format, re-resolve the head, re-derive the namespace at the bound commit, leak-scan, upsert one comment, read it back. The namespace is fixed — there is no --namespace, so this verb cannot be aimed at another gate\'s. Prints `posted\\tgovernance\\t<polarity>\\t<sha>\\t<created|edited>\\t<url>`. Exits 3 (stdin held nothing), 5/6 (a machine-local path, a bare @ reference), 7 (the PR is absent or closed), 8/9 (the write was unproven, the read-back differs), 10 (a bad --polarity, --sha or blank --clause), 11 (a precondition read failed — nothing was posted), 12 (the head moved past --sha), 14 (the diff derives no governance namespace). Example: fabrika governance post 4321 --polarity PASS --sha 03135b91 --clause "no contradiction, no weakening" < verdict.md',
 	),
@@ -237,6 +242,7 @@ const digest = leafCommand(
 		);
 	}),
 ).pipe(
+	Command.withShortDescription("The decision records that landed in a window."),
 	Command.withDescription(
 		"List the decision records that landed in a window, each with its status as written, its landing commit, and that commit's anchor delta. `none` is a PROVEN answer at exit 0 — the window was walked and nothing landed. This verb ranks nothing: tension and blast radius are judgment. Exits 7 (--dir is absent or holds zero records), 10 (a malformed date, or --until before --since), 11 (--base could not be fetched or a landing commit could not be read — UNKNOWN, never none), 13 (a shallow clone whose graft boundary falls inside the window). Example: fabrika governance digest --since 2026-08-02",
 	),
@@ -266,6 +272,7 @@ const readout = leafCommand(
 		);
 	}),
 ).pipe(
+	Command.withShortDescription("Publish the ranked rows on stdin to the durable readout."),
 	Command.withDescription(
 		"Publish the ranked rows read from STDIN onto the durable readout artifact: compose through the governance-digest format, leak-scan, upsert the one comment, read it back in order. It gates nothing — there is no outcome here meaning the corpus is in a bad state. Prints `readout\\t<issue>\\t<rows>\\t<created|edited>\\t<url>`. Exits 3 (stdin held nothing), 5/6 (a machine-local path, a bare @ reference), 7 (the artifact is absent, closed, or unresolvable), 8/9 (the write was unproven, the read-back differs), 10 (a row's kind or id is off the vocabulary), 11 (the issue or its comments could not be read — nothing was written), 13 (the comment enumeration is provably short). Example: printf 'row\\t0240\\troutine\\tno tension found\\n' | fabrika governance readout 4952",
 	),

--- a/packages/fabrika-cli/src/grill/command.ts
+++ b/packages/fabrika-cli/src/grill/command.ts
@@ -77,6 +77,7 @@ const open = leafCommand(
 		yield* emit(yield* runOpen({topic, repo: Option.getOrNull(repo), env: process.env}));
 	}),
 ).pipe(
+	Command.withShortDescription("Open, or resume, the session issue for a topic."),
 	Command.withDescription(
 		'Open, or resume, the session issue for a topic. Prints {"session":n,"topic":"…","created":true|false,"url":"…"}. Topic matching is exact under NFC + case folding + whitespace collapse, never fuzzy. Exits 5 (machine-local path in --topic), 6 (bare @ reference), 7 (the grilling:session label does not exist), 8 (the create or the label write failed — UNKNOWN), 9 (read-back mismatch), 11 (the search could not complete, so "none" is unproven), 16 (more than one open session matches). Example: fabrika grill open --topic "sozluk moderation model"',
 	),
@@ -107,6 +108,7 @@ const round = leafCommand(
 		);
 	}),
 ).pipe(
+	Command.withShortDescription("Validate one round of questions on stdin and post it."),
 	Command.withDescription(
 		'Validate one round read from STDIN against the grammar, post it, and print {"session":n,"round":n,"digest":"…","questions":[…],"supersedes":[…],"comment":n,"supersedeComment":n|null}. The round number is derived, never supplied. Exits 3 (empty stdin), 4 (grammar), 5 (machine-local path), 6 (bare @ reference), 7 (no such session), 8 (a write failed — UNKNOWN), 9 (read-back mismatch), 11 (the existing rounds could not be read), 13 (--supersedes names no question), 14 (the round holding a superseded question could not be digested), 18 (already superseded). Example: fabrika grill round 9412 --supersedes R1.4 < round.md',
 	),
@@ -136,6 +138,7 @@ const answerCmd = leafCommand(
 		);
 	}),
 ).pipe(
+	Command.withShortDescription("Record an agent-established answer to a fact question."),
 	Command.withDescription(
 		'Record an agent-established answer to a fact question. Prints {"session":n,"question":"R2.1","kind":"fact","comment":n,"recordedAs":"agent"}. Exits 4 (--finding is empty), 5 (machine-local path), 6 (bare @ reference), 7 (no such session), 8 (the write failed — UNKNOWN), 9 (read-back mismatch), 11 (the rounds could not be read), 13 (the id names no question), 14 (the round could not be digested), 17 (the id is a decision question), 18 (superseded). Example: fabrika grill answer 9412 R2.1 --finding finding.md',
 	),
@@ -167,6 +170,7 @@ const rule = leafCommand(
 		);
 	}),
 ).pipe(
+	Command.withShortDescription("Record a founder ruling, with its verbatim authorization."),
 	Command.withDescription(
 		'Record a founder ruling, refusing without a verbatim dated authorization. Writes the authorization comment FIRST and the marker second, then prints {"session":n,"question":"R2.3","digest":"…","authorization":n,"marker":n,"resolvesTo":"ruled"}. Exits 5 (machine-local path), 6 (bare @ reference), 7 (no such session), 8 (a write failed — UNKNOWN), 9 (read-back mismatch), 11 (a precondition read failed), 12 (the invoking token is below write), 13 (the id names no question), 14 (the round could not be digested), 15 (--authorization missing, empty or undated), 17 (the id is a fact question), 18 (superseded). Example: fabrika grill rule 9412 R2.3 --authorization authorization.md',
 	),
@@ -179,6 +183,7 @@ const read = leafCommand(
 		yield* emit(yield* runRead({session, repo: Option.getOrNull(repo), env: process.env}));
 	}),
 ).pipe(
+	Command.withShortDescription("The whole session state and its frontier."),
 	Command.withDescription(
 		'Read the whole session state: {"session":n,"frontier":"awaiting-founder|facts-pending|clear|empty","questions":[…],"disregarded":[…],"counts":{…},"scanned":{…}}. All four frontier tokens exit 0 — an open frontier is this skill working. Never refuses on marker content: a malformed, unauthorized or unbindable marker is a disregarded row at exit 0. Exits 7 (no such session), 11 (a comment or permission read could not complete, so every state is UNKNOWN). Example: fabrika grill read 9412',
 	),

--- a/packages/fabrika-cli/src/handoff/command.ts
+++ b/packages/fabrika-cli/src/handoff/command.ts
@@ -72,6 +72,7 @@ const capture = leafCommand(
 		);
 	}),
 ).pipe(
+	Command.withShortDescription("Derive the ground state: branch, head, tree, issue and PR."),
 	Command.withDescription(
 		'Derive the ground state — branch, head, reachability, tree, base, issue and pull-request state — as one JSON object, writing nothing and reading no comments. Prints {"issue":n,"repo":"…","capturedAt":"…","git":{…},"board":{…},"groundDigest":"…"}. Exits 7 (no such issue), 11 (a git or board read failed — the ground is UNKNOWN, never clean). Example: fabrika handoff capture --issue 5021',
 	),
@@ -105,6 +106,7 @@ const take = leafCommand(
 		);
 	}),
 ).pipe(
+	Command.withShortDescription("Compose, post and read back the sealed handoff pack."),
 	Command.withDescription(
 		'Compose the pack from the four asserted sections on STDIN plus a fresh capture, leak-scan it, post it as one marker-bearing comment, and read it back. Prints {"issue":n,"packComment":c,"packNonce":"…","sealedAt":"…","groundDigest":"…","reachable":"…","supersedes":c|null}. Exits 3 (stdin held nothing), 4 (a section is missing, out of order, empty, or content sits outside the closed set), 5/6 (machine-local path, bare @ reference), 7 (no such issue), 8/9 (the comment write failed, read-back differs), 11 (the capture or a precondition read failed — nothing written), 12 (the work is unreachable by a successor and --declare-unreachable was not given). Example: printf \'## Intent\\nWiden the fanout guard.\\n\\n## Established\\nA failing case is committed.\\n\\n## Next act\\nFollow one level of helper call.\\n\\n## Unsure\\nWhether one level is enough.\\n\' | fabrika handoff take --issue 5021 --nonce 7f3a9c21',
 	),
@@ -124,6 +126,7 @@ const read = leafCommand(
 		);
 	}),
 ).pipe(
+	Command.withShortDescription("Resolve the latest sealed pack and report its drift."),
 	Command.withDescription(
 		'Resolve the latest sealed pack, parse its two halves, re-derive the ground against the PACKED branch, and report the drift field by field. Prints {"issue":n,"pack":"none|sealed|claimed","packComment":…,"packNonce":…,"sealedAt":…,"author":…,"asserted":…,"ground":{"packed":"…"},"drift":{"packedBranch":"resolves|gone|unknown","state":"none|moved|unknown","fields":[…]},"heldBy":…,"disregarded":[…],"scanned":{…}} — all three pack tokens exit 0. Exits 7 (no such issue), 11 (a comment read, a permission read or the live re-derivation failed), 14 (the latest sealed pack does not parse, or its groundDigest disagrees with the fields it labels). Example: fabrika handoff read --issue 5021',
 	),
@@ -144,6 +147,7 @@ const claim = leafCommand(
 		);
 	}),
 ).pipe(
+	Command.withShortDescription("Claim the latest sealed pack for this run."),
 	Command.withDescription(
 		'Claim the latest sealed pack, keyed on the run nonce. Prints {"issue":n,"packComment":c,"claimNonce":"…","claim":"held|resumed","claimedAt":"…","claimComment":c}. Exits 7 (no such issue), 8/9 (the claim write failed, read-back differs), 11 (a comment or permission read failed — nothing written), 13 (no sealed pack to claim), 14 (the latest pack does not parse), 15 (another nonce holds it). Example: fabrika handoff claim --issue 5021 --nonce 4b8e2f01',
 	),

--- a/packages/fabrika-cli/src/hook/command.ts
+++ b/packages/fabrika-cli/src/hook/command.ts
@@ -36,6 +36,7 @@ const check = leafCommand(
 		yield* emitOutcome(yield* runCheck({json, stdin: Effect.sync(readStdin)}));
 	}),
 ).pipe(
+	Command.withShortDescription("Whether the hook envelope on stdin is one fabrika can read."),
 	Command.withDescription(
 		"Say whether the harness hook envelope on STDIN is one fabrika can read. Stdout is the single line `conforms\\t<hook_event_name>\\t<field-count>`. The bytes judged are on stderr on every path. Exits 3 (stdin was read and held nothing), 12 (bytes arrived and are provably not a hook envelope), 13 (fd 0 could not be read — UNKNOWN, never malformed). Example: fabrika hook check",
 	),
@@ -55,6 +56,7 @@ const spawn = leafCommand(
 		);
 	}),
 ).pipe(
+	Command.withShortDescription("Whether the spawn on stdin may use the model it asked for."),
 	Command.withDescription(
 		"Decide whether the subagent spawn on STDIN may run on the model it asked for. Stdout is the PreToolUse permission-decision object, whose systemMessage names the allowlist, the requested model, its canonical id and the resolved pin. An off-allowlist model is denied (ADR 0092). Exits 3 (stdin held nothing), 12 (not a hook envelope), 13 (fd 0 unreadable — UNKNOWN), 14 (a harness event this verb does not judge). Example: fabrika hook spawn",
 	),
@@ -67,6 +69,7 @@ const codes = leafCommand(
 		yield* emitOutcome(runCodes({json}));
 	}),
 ).pipe(
+	Command.withShortDescription("Print the exit taxonomy this group allocates from."),
 	Command.withDescription(
 		"Print the exit taxonomy every verb in this group allocates from. Stdout is one `<code>\\t<meaning>` line per code. Reads nothing and always exits 0. Example: fabrika hook codes",
 	),

--- a/packages/fabrika-cli/src/ledger/command.ts
+++ b/packages/fabrika-cli/src/ledger/command.ts
@@ -61,6 +61,7 @@ const open = leafCommand(
 		yield* emit(yield* runOpen({number, repo: Option.getOrNull(repo), env: process.env}));
 	}),
 ).pipe(
+	Command.withShortDescription("Prove the ground and open the plan run for an epic."),
 	Command.withDescription(
 		'Prove the ground fresh, allocate the run directory (keyed on the claim nonce, never the session), read the epic\'s existing children, probe the cycle doc, and rank duplicate candidates. Prints {"answer":"opened","epic":n,"run":"…","mode":"fresh|re-plan","bodyDigest":"…","dir":"…","children":[…],"cycleDoc":"present|absent|unknown","candidates":{"outcome":"candidates|none|indeterminate","items":[…]}}. Carry bodyDigest to `ledger draft` and `ledger write`. Exits 7 (the epic is proven absent or closed), 10 (not a type:epic), 11 (the epic, its sub-issue list, the backlog, the cycle-doc probe or the freshness probe could not be read), 12 (not in a linked worktree), 15 (this session does not hold the epic\'s claim), 20 (the base is proven behind origin/main), 22 (two or more "## Plan (plan-epic)" headings — the mode has no single meaning). Example: fabrika ledger open 4300',
 	),
@@ -81,6 +82,7 @@ const draft = leafCommand(
 		);
 	}),
 ).pipe(
+	Command.withShortDescription("Validate the plan block on stdin and stage it."),
 	Command.withDescription(
 		'Validate the plan block on STDIN against the closed section set and the story grammar, then stage it in the run directory. Prints {"answer":"staged","epic":n,"document":"plan","sections":10,"stories":[…],"bytes":n}. It does not judge content — a "### Approach" reading TBD stages cleanly. Exits 3 (stdin held nothing), 4 (a required ### section is missing, duplicated or out of order; the block does not open with "## Plan (plan-epic)"; zero user stories; or story ids that are not contiguous from 1), 5 (machine-local path), 6 (bare @ reference), 7 (the epic is proven absent or closed), 10 (not a type:epic, or --body-digest is not 12 lowercase hex), 11 (a read failed — nothing was staged), 12 (not in a linked worktree), 15 (this session does not hold the claim), 21 (the epic body moved since open). Example: fabrika ledger draft 4300 --body-digest 8f2c1a90b4d7 < plan.md',
 	),
@@ -157,6 +159,7 @@ const child = leafCommand(
 		);
 	}),
 ).pipe(
+	Command.withShortDescription("Mint one child issue with every birth attribute at once."),
 	Command.withDescription(
 		'Mint one child with EVERY birth attribute in the one POST — title, body, every label, milestone and assignee — record it in the run manifest, link it as a native sub-issue, then re-read and report the OBSERVED result. Prints {"answer":"minted","epic":n,"child":n,"linked":true,"observed":{…},"stories":[…],"containment":"…"}. Exits 3 (stdin held nothing), 4 (the composed body\'s fields or sections do not parse: a malformed **Stories:** value, absent or malformed acceptance criteria, or a type:feature child whose **Containment:** is missing, unset or none while the cycle doc is present), 5 (machine-local path), 6 (bare @ reference), 7 (the epic is proven absent or closed), 8 (the create was attempted and no re-read could prove it — UNKNOWN), 9 (created and it does not read back as sent), 10 (a label, --type, --priority, --milestone or --ready-for off its closed vocabulary; --ready-for absent; --ready-for human without --assignee; or not a type:epic), 11 (a precondition read failed — NOTHING was created), 12 (not in a linked worktree), 15 (this session does not hold the claim), 23 (created and the sub-issue link could not be proven), 26 (created and the run manifest could not be written). Example: fabrika ledger child 4300 --title "queue view: fate loader" --type type:feature --priority p1 --ready-for agent < child.md',
 	),
@@ -171,6 +174,7 @@ const topology = leafCommand(
 		);
 	}),
 ).pipe(
+	Command.withShortDescription("Validate the declared topology and render its Dependencies block."),
 	Command.withDescription(
 		'Validate the topology declared on STDIN — one "#<ref> phase <n> [requires #<a>, #<b>]" line per child, order-indifferent — against the run manifest, render the "## Dependencies" block, and parse it back through the shipped reader before staging it. Prints {"answer":"staged","epic":n,"document":"topology","phases":n,"children":n,"edges":[["#4303","#4301"]],"bytes":n}. It cannot see a shared-file conflict — whether two children in one phase write the same module is the skill\'s judgment (#3709). Exits 3 (stdin held nothing), 4 (a line does not parse), 7 (the epic is proven absent or closed, or the run manifest holds zero children), 10 (not a type:epic, or a phase is not a positive integer), 11 (a read failed — nothing was staged), 12 (not in a linked worktree), 15 (this session does not hold the claim), 24 (a cycle, a reference to a non-child, a manifest child placed nowhere, or a rendered block that does not parse back to the declared edges). Example: fabrika ledger topology 4300 < topo.txt',
 	),
@@ -185,6 +189,7 @@ const write = leafCommand(
 		);
 	}),
 ).pipe(
+	Command.withShortDescription("Splice the staged plan and topology into the epic body."),
 	Command.withDescription(
 		'Splice the staged plan and topology into the epic body in one PATCH, then re-read and compare the WHOLE normalized body. The plan region is resolved through the verb-written enrichment marker, never by position, and is never cut to end-of-file (#4879). mode is carried from `ledger open`, never re-derived. Prints {"answer":"written","epic":n,"mode":"…","bodyDigest":"…","newDigest":"…","planBytes":n,"topologyBytes":n,"verified":true}. Exits 7 (the epic is proven absent or closed), 8 (the PATCH was issued and could not be confirmed — UNKNOWN), 9 (written and it does not read back as composed), 10 (not a type:epic, or --body-digest is not 12 lowercase hex), 11 (a read failed — NOTHING was written), 12 (not in a linked worktree), 15 (this session does not hold the claim), 21 (the epic body moved since open), 22 (the plan region is unresolvable), 25 (plan.md or topology.md was never staged in this run). Example: fabrika ledger write 4300 --body-digest 8f2c1a90b4d7',
 	),
@@ -212,6 +217,7 @@ const supersede = leafCommand(
 		);
 	}),
 ).pipe(
+	Command.withShortDescription("Retire a child the re-plan no longer contains."),
 	Command.withDescription(
 		'Retire a child the re-plan no longer contains: comment, unlink, close as not_planned — in that order, so a child is never closed while still linked — then re-read and prove it. Prints {"answer":"superseded","epic":n,"child":n,"comment":id,"unlinked":true,"state":"closed"}. Refuses a child that is not this epic\'s sub-issue, and one this run minted. Exits 5 (the reason carries a machine-local path), 6 (bare @ reference), 7 (the epic or the child is proven absent or closed), 8 (a leg was attempted and its outcome could not be proven), 9 (the legs landed and the child does not read back closed and unlinked), 10 (not a type:epic; --child is not a sub-issue of it; or --child was minted by this run), 11 (a precondition read failed — nothing was written), 12 (not in a linked worktree), 15 (this session does not hold the claim). Example: fabrika ledger supersede 4300 --child 4288 --reason "folded into the loader slice"',
 	),

--- a/packages/fabrika-cli/src/map/command.ts
+++ b/packages/fabrika-cli/src/map/command.ts
@@ -93,6 +93,7 @@ const open = leafCommand(
 		);
 	}),
 ).pipe(
+	Command.withShortDescription("Mint or resume the map for a destination."),
 	Command.withDescription(
 		'Mint or resume the map for a destination, reading the caller\'s open questions from STDIN one per line. Prints {"map":n,"created":bool,"destination":"…","questions":k,"answeredCandidates":[…],"digest":"…","scanned":{…}}. Exits 3 (stdin held no question), 4 (an existing map\'s body does not parse), 5/6 (machine-local path, bare @ reference), 7 (no wayfinding:map label), 8/9 (create or label write failed, read-back differs), 11 (the map search or a board read failed — nothing written), 16 (two or more open maps match), 17 (no supplied line is stated as a question), 19 (already recorded out of scope). Example: printf \'does a suspended account keep its weight?\\n\' | fabrika map open --destination "how moderation weight is earned"',
 	),
@@ -105,6 +106,7 @@ const read = leafCommand(
 		yield* emit(yield* runRead({map, repo: Option.getOrNull(repo), env: process.env}));
 	}),
 ).pipe(
+	Command.withShortDescription("The map's whole state, section by section."),
 	Command.withDescription(
 		'The map\'s whole state: five sections, one row per frontier ticket with a closed-set state, the frontier token and the body digest. Prints {"map":n,"frontier":"awaiting-founder|lanes-pending|clear|empty","digest":"…","destination":"…","tickets":[…],"outOfScope":[…],"fog":k,"counts":{…},"disregarded":[…],"scanned":{…}} — all four frontier tokens exit 0. Exits 4 (the body does not hold the five sections in order), 7 (no such map), 11 (a child, edge or comment read failed — the frontier is UNKNOWN, never empty). Example: fabrika map read 9140',
 	),
@@ -149,6 +151,7 @@ const ticket = leafCommand(
 		);
 	}),
 ).pipe(
+	Command.withShortDescription("File a frontier ticket and splice its row onto the map."),
 	Command.withDescription(
 		'File a frontier ticket, link it as a sub-issue, set its blocking edges and splice its row onto the map — one act, preconditions resolved before anything is written. Prints {"map":n,"ticket":c,"kind":"…","blockedBy":[…],"blocking":[…],"digest":"…"}. Exits 4 (the map body does not parse), 5/6 (leak), 7 (no such map), 8/9 (a write failed, read-back differs), 11 (a precondition read failed), 12 (the body moved since --digest), 13 (an edge target is not a ticket of this map), 14 (the edge would cycle, or an id could not be resolved), 18 (an edge target already left the frontier), 19 (the question restates a rejected direction). Example: fabrika map ticket 9140 --digest a1b2c3d4e5f6 --kind research --question "does better-auth mint a single-use token without a new table?"',
 	),
@@ -163,6 +166,7 @@ const lane = leafCommand(
 		);
 	}),
 ).pipe(
+	Command.withShortDescription("Claim a research lane on one ticket."),
 	Command.withDescription(
 		'Claim a research lane on one ticket, keyed on the run nonce. Prints {"map":n,"ticket":t,"nonce":"…","lane":"held|resumed"}. Exits 7 (no such map), 8/9 (the claim write failed, read-back differs), 11 (the comment read failed — whether a lane is held is UNKNOWN, never free), 13 (not a ticket of this map), 15 (another nonce holds the lane), 18 (the ticket already left the frontier), 20 (a decision ticket is routed, never researched). Example: fabrika map lane 9140 --ticket 9143 --nonce 7f3a9c21',
 	),
@@ -199,6 +203,7 @@ const finding = leafCommand(
 		);
 	}),
 ).pipe(
+	Command.withShortDescription("Close a lane with an outcome, writing on the ticket."),
 	Command.withDescription(
 		'Close a lane with an outcome from a closed set, writing on the TICKET and never on the map body. Prints {"map":n,"ticket":t,"outcome":"…","comment":id,"lane":"released"}. Exits 4 (--outcome answered with no --finding, or an empty finding), 5/6 (leak), 7 (no such map), 8/9 (the comment write failed, read-back differs), 11 (a precondition read failed), 13 (not a ticket of this map), 15 (this nonce does not hold the lane), 18 (the ticket already left the frontier), 20 (a decision has no lane). Example: fabrika map finding 9140 --ticket 9143 --nonce 7f3a9c21 --outcome no-evidence',
 	),
@@ -238,6 +243,7 @@ const fork = leafCommand(
 		);
 	}),
 ).pipe(
+	Command.withShortDescription("Record that a ticket's question is being answered elsewhere."),
 	Command.withDescription(
 		'Record that a ticket\'s question is being answered elsewhere — a decision in a grilling session, an empirical question in a prototyping spike. Which flag is admitted is decided by the ticket\'s kind, not by the caller. Prints {"map":n,"ticket":t,"session|spike":s,"state":"forked","digest":"…"}. Exits 4 (the map body does not parse), 5/6 (leak), 7 (no such map), 8/9 (a write failed, read-back differs), 11 (a precondition read failed), 12 (the body moved), 13 (not a ticket of this map, or --session is not a grilling session), 18 (already left the frontier), 20 (the kind does not admit this route). Example: fabrika map fork 9140 --digest a1b2c3d4e5f6 --ticket 9144 --session 9301',
 	),
@@ -297,6 +303,7 @@ const record = leafCommand(
 		);
 	}),
 ).pipe(
+	Command.withShortDescription("Land the answer and retire the ticket in one write."),
 	Command.withDescription(
 		'The lockstep: the answer lands under `## Decisions` and the ticket\'s row leaves `## Frontier` in ONE body write, then the sub-issue closes. Prints {"map":n,"ticket":t,"recorded":"— from #t","closed":true,"digest":"…"}. Exits 4 (the body does not parse, or --finding is empty), 5/6 (leak), 7 (no such map), 8/9 (a write failed, read-back differs), 11 (a precondition read failed — including a forked decision, whose ruling state only the grill reader may resolve), 12 (the body moved), 13 (not a ticket of this map, or its ruling does not read ruled), 18 (already left the frontier), 21 (the lane returned unreachable, so there is no answer to record). Example: fabrika map record 9140 --digest a1b2c3d4e5f6 --ticket 9143 --finding finding.md',
 	),
@@ -336,6 +343,7 @@ const descope = leafCommand(
 		);
 	}),
 ).pipe(
+	Command.withShortDescription("Append a rejected direction to the out-of-scope section."),
 	Command.withDescription(
 		'Append a rejected direction and its reasoning to the never-graduating out-of-scope section, optionally retiring the frontier ticket that asked it. Prints {"map":n,"direction":"…","entries":k,"digest":"…"}. Exits 4 (the body does not parse, or --reason is empty), 5/6 (leak), 7 (no such map), 8/9 (the write failed, read-back differs or the section did not grow by exactly one), 11 (a precondition read failed), 12 (the body moved), 13 (--ticket is not a ticket of this map), 18 (--ticket already left the frontier), 19 (already out of scope). Example: fabrika map descope 9140 --digest a1b2c3d4e5f6 --direction "a per-topic weight multiplier" --reason reason.md',
 	),

--- a/packages/fabrika-cli/src/pattern/command.ts
+++ b/packages/fabrika-cli/src/pattern/command.ts
@@ -56,6 +56,7 @@ const corpus = leafCommand(
 		yield* emit(yield* runCorpus({dir, base, json}));
 	}),
 ).pipe(
+	Command.withShortDescription("Every pattern doc at a base ref, with its registration."),
 	Command.withDescription(
 		'The library at a base ref: every doc, its index registration, its section and its last-touching commit. Prints `corpus <library|none|absent> <docs> <unregistered> <unknown> <dangling>` then one `doc` line per doc and one `dangling` line per index row pointing outside the corpus — all three outcomes at exit 0, because an empty or absent library is a fact a repo adopting fabrika must be able to act on. Exits 11 (the base could not be fetched, or a tree or history read failed — UNKNOWN, never "none"). Example: fabrika pattern corpus --dir .patterns',
 	),
@@ -68,6 +69,7 @@ const drift = leafCommand(
 		yield* emit(yield* runDrift({slug, dir, base, json}));
 	}),
 ).pipe(
+	Command.withShortDescription("Whether the in-repo source a doc cites has moved."),
 	Command.withDescription(
 		'Whether the in-repo source a doc cites moved since the doc was last written. Prints `drift <drifted|current|unanchored|unborn> <anchor-sha> <cited> <in-repo> <unresolved> <moved>` then one `path` line per moved path — all four outcomes at exit 0. `unanchored` is not a clearance: it says the doc cites nothing this verb can follow. Exits 11 (a fetch, tree or history read failed — UNKNOWN, never "current"), 12 (no doc for the slug, in the working tree or at the base). Example: fabrika pattern drift worker-queue-retry',
 	),
@@ -91,6 +93,7 @@ const anchor = leafCommand(
 		yield* emit(yield* runAnchor({slug, dir, manifest, base, json}));
 	}),
 ).pipe(
+	Command.withShortDescription("Whether the dependency version a doc declares still matches."),
 	Command.withDescription(
 		'Whether the dependency version a doc declares still matches what the workspace pins, compared byte for byte with no semver interpretation. Prints `anchor <matched|moved|malformed|unpinned|unanchored|unborn> <declared> <moved> <unpinned> <malformed>` then one `pkg` line per declaration — every outcome at exit 0. A line that claims an anchor and does not parse is `malformed`, never absent. Exits 11 (the base could not be fetched, or the doc or manifest could not be read — every pin is UNKNOWN, never "unpinned"), 12 (no doc for the slug). Example: fabrika pattern anchor worker-queue-retry',
 	),
@@ -127,6 +130,7 @@ const create = leafCommand(
 		);
 	}),
 ).pipe(
+	Command.withShortDescription("Scaffold a new pattern doc from the canonical template."),
 	Command.withDescription(
 		"Scaffold <dir>/<slug>.md from the canonical template, creating <dir> when it is absent. Prints the path written. Writes exactly one file and never edits another — the index row is pattern register's. Exits 8 (the write failed, so whether anything landed is UNKNOWN), 13 (the target already exists — refused, never overwritten). Example: fabrika pattern new worker-queue-retry --anchor acme-queue@4.2.0",
 	),
@@ -154,6 +158,7 @@ const register = leafCommand(
 		yield* emit(yield* runRegister({slug, section, topic, readWhen, dir, json}));
 	}),
 ).pipe(
+	Command.withShortDescription("Insert the doc's row into the index under a named section."),
 	Command.withDescription(
 		'Insert the doc\'s row into <dir>/index.md under a named section, proving the edit changed no other line before it writes and reading the row back after. Prints `<inserted|already> <path> <section>`. Exits 8/9 (the write failed, the read-back does not carry the row), 10 (no such section — every section carrying a table is named), 12 (no doc to point the row at), 14 (the edit would have changed a line beyond the new row), 15 (the index is absent or holds no parseable table), 16 (the section name matches more than one heading). Example: fabrika pattern register worker-queue-retry --section "Index — Effect domain layer" --topic "Retry and backoff" --read-when "Adding a queue consumer"',
 	),

--- a/packages/fabrika-cli/src/plan/command.ts
+++ b/packages/fabrika-cli/src/plan/command.ts
@@ -55,6 +55,7 @@ const read = leafCommand(
 		yield* emit(yield* runRead({number, repo: Option.getOrNull(repo), env: process.env}));
 	}),
 ).pipe(
+	Command.withShortDescription("The epic, its children and its parsed ledger."),
 	Command.withDescription(
 		'Fetch the epic and its native sub-issue children, parse the ledger, and print it as one object: {"answer":"read","epic":n,"children":[…],"epicStories":[…],"cycleDoc":"present|absent|unknown","topology":{…},"digest":"…"}. Fetch and registered parses only — no judgment. Each child carries the three-state assignee slot (assigneesObserved false and assignees null when the payload carried no assignees key), the acceptance-criteria token uncollapsed, and its **Stories:**/**Containment:** fields. Exits 4 (a ledger section or field line appears twice, the ## Dependencies block is unparseable, or a non-empty ### User stories list is not contiguous from 1), 7 (the epic is proven absent or closed, or it has zero sub-issue children), 10 (the issue is not a type:epic), 11 (the epic, the sub-issue list or a child could not be read). Example: fabrika plan read 4300',
 	),
@@ -67,6 +68,7 @@ const check = leafCommand(
 		yield* emit(yield* runCheck({number, repo: Option.getOrNull(repo), env: process.env}));
 	}),
 ).pipe(
+	Command.withShortDescription("The deterministic floor over the thirteen hard defect types."),
 	Command.withDescription(
 		'The deterministic floor over the thirteen hard defect types — the whole pass/fail decision. BOTH arms exit 0 and the discriminator is the "answer" state word (clean | defective); a defective floor is this verb\'s answer, never its refusal, and the guard against acting on one lives at `plan flip`\'s own re-gate. "skipped" names a class that could not be derived (today only MISSING_CONTAINMENT, and only when the cycle-doc probe failed) — it never makes the floor clean by omission. Exits 4 (the ledger grammar refused), 7 (zero scope), 10 (the issue is not a type:epic), 11 (a read the floor depends on failed — the floor is UNKNOWN, not clean). Example: fabrika plan check 4300',
 	),
@@ -79,6 +81,7 @@ const flip = leafCommand(
 		yield* emit(yield* runFlip({number, digest, repo: Option.getOrNull(repo), env: process.env}));
 	}),
 ).pipe(
+	Command.withShortDescription("Flip every planned child to triaged, re-gating first."),
 	Command.withDescription(
 		'Flip every status:planned child to status:triaged, re-gating first, and report the OBSERVED result per child — flipped | already | unchanged | not-planned, read back from GitHub, never asserted from intent. status:triaged is added before status:planned is removed, always, so a child caught mid-write still carries a status: label. Zero planned children is an answer with terminal "nothing-to-flip", not a refusal. Exits 4 (the grammar refused during the re-gate), 7 (zero children), 8 (a write was attempted and no re-read could prove its outcome), 10 (not a type:epic, or --digest is not 12 lowercase hex), 11 (a read failed — nothing was written), 15 (this session does not hold the epic\'s claim), 20 (the re-gate derived hard defects), 21 (the plan moved since the check), 22 (at least one child is unchanged — the refs are on stderr), 23 (a label the flip must write is absent from the repo taxonomy — refused, never created, #4285). Example: fabrika plan flip 4300 --digest 4d90e1bb27ac',
 	),
@@ -110,6 +113,7 @@ const verdict = leafCommand(
 		);
 	}),
 ).pipe(
+	Command.withShortDescription("Post the plan gate's verdict, bound to the scope digest."),
 	Command.withDescription(
 		'Post the gate\'s verdict comment, bound to the scope digest, and read it back. Prints {"answer":"posted","epic":n,"polarity":"PASS","digest":"…","skipped":[],"comment":id,"caveats":k}. The polarity is DERIVED by re-running the floor — a caller never supplies it. Optional stdin carries advisory caveats, one per line, "caveat: <kind> #<ref> — <text>", over the closed set ac-not-checkable | brief-fidelity | slice-too-broad | dependency-implied-not-declared; an empty stdin is an ordinary answer. Exits 4 (the grammar refused), 5/6 (the authored caveats carry a machine-local path, or are a bare @ path reference), 7 (zero children), 8 (posted and unprovable — UNKNOWN), 9 (posted but the read-back does not match), 10 (--digest malformed, not a type:epic, --polarity disagrees with the derived floor, an off-set caveat kind, or a caveat naming a ref outside the scanned set), 11 (a read failed — nothing was posted), 15 (this session does not hold the epic\'s claim), 21 (the plan moved since the check). Example: fabrika plan verdict 4300 --digest 4d90e1bb27ac < caveats.md',
 	),

--- a/packages/fabrika-cli/src/report/command.ts
+++ b/packages/fabrika-cli/src/report/command.ts
@@ -87,6 +87,7 @@ const dedup = leafCommand(
 		);
 	}),
 ).pipe(
+	Command.withShortDescription("Rank the open issues that may already cover an observation."),
 	Command.withDescription(
 		'Rank the open issues that may already cover an observation. First stdout line is the outcome token — candidates | none | indeterminate — and ALL THREE exit 0; a candidates list adds one `<number>\\t<source>\\t<score>\\t<title>` line per entry. Exits 3 (queue unreadable), 4 (search index unreadable), 7 (--label does not exist, so the queue half would scan nothing). Example: fabrika report dedup --query "retry helper swallows the abort reason" --exclude 4312',
 	),
@@ -123,6 +124,7 @@ const fileCmd = leafCommand(
 		);
 	}),
 ).pipe(
+	Command.withShortDescription("Compose and file the intake issue from the sections on stdin."),
 	Command.withDescription(
 		'Compose the intake issue from the six sections on STDIN, guard it, create it, and read back what landed. Prints `<number>\\t<url>`. Exits 3 (empty stdin), 4 (bad sections), 5 (machine-local path), 6 (bare @ reference), 7 (no such label), 8 (create failed — UNKNOWN), 9 (read-back mismatch), 10 (title or label classifies), 11 (label set unreadable). Example: fabrika report file --title "Retry helper swallows the abort reason" < body.md',
 	),
@@ -149,6 +151,7 @@ const note = leafCommand(
 		);
 	}),
 ).pipe(
+	Command.withShortDescription("Add a note from stdin to an existing issue."),
 	Command.withDescription(
 		"Add a note from STDIN to an existing issue over the same guarded path, then read the comment back. Prints `<comment-id>\\t<url>`. Exits 3 (empty stdin), 5 (machine-local path), 6 (bare @ reference), 7 (no such issue), 8 (post failed — UNKNOWN), 9 (read-back mismatch), 11 (issue unreadable). Example: fabrika report note --issue 4312 < note.md",
 	),

--- a/packages/fabrika-cli/src/review-ui/command.ts
+++ b/packages/fabrika-cli/src/review-ui/command.ts
@@ -85,6 +85,7 @@ const render = leafCommand(
 		);
 	}),
 ).pipe(
+	Command.withShortDescription("Capture the named surfaces from a PR's preview deployment."),
 	Command.withDescription(
 		"Capture the named surfaces from a PR's announced preview deployment at the inspected head, one validated PNG per surface, and write the set manifest. Prints one JSON object: the set, the PR, the head, the preview URL, and one capture record per surface (path, dimensions, sha256, page errors); every surface's outcome is enumerated on stderr. Full success is the only exit 0. Exits 1 (zero --surface operands), 7 (PR absent or closed), 10 (--out is not kebab-case, or a --surface carries the reserved :state suffix), 11 (a read failed, the preview comment is malformed or names several apps, or a capture's validity is undeterminable), 12 (the preview deploys a head that is not the PR's live head — stale preview), 13 (a surface threw during render), 14 (a surface is unreachable), 15 (a capture is invalid), 16 (no preview-deploy comment — the CANT-SEE route). Example: fabrika review-ui render --pr 4321 --out judged --surface /pano",
 	),
@@ -137,6 +138,7 @@ const post = leafCommand(
 		);
 	}),
 ).pipe(
+	Command.withShortDescription("Post the review-ui verdict on stdin as one comment."),
 	Command.withDescription(
 		'Post the review-ui verdict on STDIN as ONE comment for this namespace — re-resolve the live head, read the evidence set through its manifest, re-validate every capture, verify-upload every capture BEFORE anything posts, compose the first line through the `verdict-marker` wire format, leak-scan, upsert, and read it back from live state. There is no --namespace: this group emits review-ui and nothing else. Prints one JSON object. Exits 3 (empty stdin), 4 (the evidence set has no readable manifest.json, or design-harness.json violates its schema), 5 (machine-local path in the assembled comment), 6 (bare @ reference), 7 (PR absent or closed), 8 (the create/edit failed — UNKNOWN), 9 (read-back does not yield this marker), 10 (bad --polarity or --carrier, or advisory with FAIL), 11 (a precondition read failed — nothing uploaded or posted), 12 (the live head moved past --sha, or the set was rendered at another head), 15 (a capture fails its manifest sha), 17 (an evidence upload or its verification failed — nothing was posted). Example: fabrika review-ui post 4321 --polarity FAIL --sha 03135b91 --clause "changes-requested" --evidence judged < verdict.md',
 	),
@@ -156,6 +158,7 @@ const note = leafCommand(
 		);
 	}),
 ).pipe(
+	Command.withShortDescription("Post a blocker note when the surfaces cannot be seen."),
 	Command.withDescription(
 		"Post the blocker note on STDIN as one new comment — the typed non-verdict write for a proven can't-see or escalation state. Append-only (a dated fact is never edited in place), leak-scanned, and read back. A body whose first line parses as a verdict marker or an advisory carrier is refused: a verdict goes through review-ui post. Prints one JSON object. Exits 3 (empty stdin), 5 (machine-local path), 6 (bare @ reference), 7 (PR absent or closed), 8 (the post failed — UNKNOWN), 9 (the comment does not read back as sent), 10 (the body is verdict-shaped), 11 (a precondition read failed — nothing was posted). Example: fabrika review-ui note 4321 < blocker.md",
 	),

--- a/packages/fabrika-cli/src/review/command.ts
+++ b/packages/fabrika-cli/src/review/command.ts
@@ -80,6 +80,7 @@ const scope = leafCommand(
 		);
 	}),
 ).pipe(
+	Command.withShortDescription("A PR's artifact classes, head, linked issue and flags."),
 	Command.withDescription(
 		"Partition a PR's changed files into the code / doc / skill artifact classes and report its head SHA, linked issue and self / harness flags. The file list is read out of the object database at the bound commit, so the printed head and the partitioned files are the same tree. First stdout line is `scoped\\t<head-sha>\\t<issue>`, then one `class\\t<name>\\t<files>` line per present class and the two flag lines; the bound commit and the scanned count are on stderr. Exits 7 (PR absent, closed, or zero changed files — ADR 0092, #4060), 10 (--sha is not a head SHA), 11 (the PR could not be read, or the commit could not be bound — the scope is UNKNOWN), 12 (--sha is not the PR's head — re-scope, never re-bind), 13 (the commit carries fewer files than the PR declares). Example: fabrika review scope 4321 --sha 03135b91",
 	),
@@ -99,6 +100,7 @@ const diff = leafCommand(
 		);
 	}),
 ).pipe(
+	Command.withShortDescription("Serve a PR's unified diff at the bound commit."),
 	Command.withDescription(
 		"Serve a PR's unified diff bytes on stdout, read out of the object database at the bound commit and refusing a truncated one rather than passing it through as the whole. Nothing is checked out. No --json: the diff is the object. Exits 7 (PR absent, closed, or zero changed files), 10 (--sha is not a head SHA), 11 (the diff could not be read, or the commit could not be bound — UNKNOWN), 12 (--sha is not the PR's head — re-review, never re-bind), 13 (the diff carries fewer files than the PR declares — #3925's class). Example: fabrika review diff 4321 --sha 03135b91",
 	),
@@ -117,6 +119,7 @@ const criteria = leafCommand(
 		yield* emit(yield* runCriteria({issue, repo: Option.getOrNull(repo), json, env: process.env}));
 	}),
 ).pipe(
+	Command.withShortDescription("Read an issue's acceptance-criteria block."),
 	Command.withDescription(
 		"Read an issue's acceptance-criteria block through the registered `acceptance-criteria` wire format — no second parser. First stdout line is `criteria\\t<count>`, then one `<checked|open>\\t<text>` line per criterion. A closed issue is read anyway, with a notice on stderr. Exits 7 (issue absent, or the block is proven absent or malformed — the two are distinguished on stderr, never invented around), 11 (the issue could not be read — whether a block exists is UNKNOWN). Example: fabrika review criteria 4287",
 	),
@@ -147,6 +150,7 @@ const ci = leafCommand(
 		);
 	}),
 ).pipe(
+	Command.withShortDescription("Roll up the live check runs at a head, fail-closed."),
 	Command.withDescription(
 		"Enumerate the live check runs at a head and roll them up green / red / pending, fail-closed on the ambiguous rows — a cancelled or unrecognised conclusion is red, never green. First stdout line is `ci\\t<sha>\\t<rollup>`, then `check\\t<count>` and one `<name>\\t<status>` line per run. Exits 7 (PR or --sha proven absent, or zero check runs declared — ADR 0092), 11 (the enumeration failed — CI state is UNKNOWN, never green), 13 (received fewer runs than declared — #3999). Example: fabrika review ci 4321 --sha 03135b91",
 	),
@@ -159,6 +163,7 @@ const verdicts = leafCommand(
 		yield* emit(yield* runVerdicts({pr, repo: Option.getOrNull(repo), json, env: process.env}));
 	}),
 ).pipe(
+	Command.withShortDescription("Every verdict marker on a PR, bound to the live head."),
 	Command.withDescription(
 		"Sweep every verdict marker on a PR and bind each to the live head as one of three outcomes — current / stale / unbindable, never folded (ADR 0058). First stdout line is `verdicts\\t<live-head>\\t<count>`; a count of 0 is a proven answer. Then one `<namespace>\\t<polarity>\\t<sha>\\t<binding>\\t<comment-id>` line per marker, newest first; a marker that fails the format prints as a `malformed` row rather than being dropped. An unresolvable head prints unbindable on every row. Exits 7 (PR proven absent), 11 (the comment list could not be read — never zero), 13 (the sweep is provably short). Example: fabrika review verdicts 4321",
 	),
@@ -179,6 +184,7 @@ const deviations = leafCommand(
 		);
 	}),
 ).pipe(
+	Command.withShortDescription("The PR body's Deviations state, entries and token scan."),
 	Command.withDescription(
 		"Report the PR body's `## Deviations` state — found | none-declared | absent | malformed, three distinct facts — with its entries and the Tier-M token scan over the diff at the bound commit. First stdout line is `deviations\\t<state>`, then one `entry\\t<class-label-or-->\\t<first-line-of-Said>` line per entry and one `tier-m\\t<kind>\\t<file>:<line>\\t<token>` line per hit. Exits 7 (PR proven absent), 10 (--sha is not a head SHA), 11 (the body or diff could not be read, or the commit could not be bound — the disclosure state is UNKNOWN, never `none`), 12 (--sha is not the PR's head — re-scope, never re-bind), 13 (a partial diff must not print a partial scan beside a disclosure claim). Example: fabrika review deviations 4321 --sha 03135b91",
 	),
@@ -236,6 +242,7 @@ const post = leafCommand(
 		);
 	}),
 ).pipe(
+	Command.withShortDescription("Post the verdict on stdin as this namespace's one comment."),
 	Command.withDescription(
 		'Post the verdict on STDIN as ONE comment for this namespace — re-resolve the live head, recompute the class set at the bound commit, compose the first line through the `verdict-marker` wire format, leak-scan the assembled comment, upsert, and read it back from live state. Prints `posted\\t<namespace>\\t<polarity>\\t<sha>\\t<created|edited>\\t<comment-url>`. Exits 3 (empty stdin — an empty verdict reads as UNGATED), 5 (machine-local path in the assembled comment), 6 (bare @ reference), 7 (PR absent or closed), 8 (the create/edit failed — UNKNOWN), 9 (read-back does not yield this marker), 10 (namespace this diff did not derive, bad polarity, or advisory with FAIL), 11 (a precondition read failed, or the commit could not be bound — nothing was posted), 12 (the live head moved past --sha — re-review, never re-bind). Example: fabrika review post 4321 --namespace review-doc --polarity PASS --sha 03135b91 --clause "guide matches shipped behavior" < verdict.md',
 	),
@@ -275,6 +282,7 @@ const appendCriterion = leafCommand(
 		);
 	}),
 ).pipe(
+	Command.withShortDescription("Append one reviewer-authored acceptance criterion."),
 	Command.withDescription(
 		"Append one reviewer-authored acceptance criterion from STDIN under ADR 0079's four fences — ACL-gated fail-closed, append-only, provenance-tagged, frozen at round 3. Prints `appended\\t<issue>\\t<rows-after>`, or `escalated-frozen\\t<issue>\\t<round>` at the freeze; both are proven answers at exit 0. Exits 3 (empty stdin), 5 (machine-local path), 6 (bare @ reference), 7 (issue absent or closed, or no conforming acceptance-criteria block), 8 (the PATCH or the escalation comment failed — UNKNOWN), 9 (read-back does not show the prior rows plus this one), 11 (a precondition read failed), 14 (token below write or the ACL lookup failed — ADR 0055), 15 (the write would drop or mutate an existing row). Example: printf 'a regression test covers qty > 1' | fabrika review append-criterion 4287 --pr 4321 --round 1",
 	),

--- a/packages/fabrika-cli/src/ship/command.ts
+++ b/packages/fabrika-cli/src/ship/command.ts
@@ -64,6 +64,7 @@ const scope = leafCommand(
 		yield* emit(yield* runScope({pr, repo: Option.getOrNull(repo), json, env: process.env}));
 	}),
 ).pipe(
+	Command.withShortDescription("A PR's head, lifecycle, linked issue, classes and CP state."),
 	Command.withDescription(
 		"Report one PR's head, lifecycle state, linked issue, artifact classes with the review namespaces they require, and the four-state §CP classification derived from .github/CODEOWNERS at the base branch. First stdout line is `scoped\\t<head>\\t<open|draft|merged|closed>\\t<fixes:n|part-of:n|->`, then one `class\\t<name>\\t<files>` line per present class, one `namespace\\t<ns>` line per required namespace, `cp\\t<state>` and `files\\t<n>`. A merged, draft or closed PR is an ANSWER, not a refusal. Exits 7 (PR proven absent, zero changed files, or a non-empty diff deriving zero namespaces — a vacuous conjunction, #2765), 11 (the PR, its file list or the §CP boundary could not be read — the scope is UNKNOWN), 13 (the file list is provably short of the declared count). Example: fabrika ship scope 4321",
 	),
@@ -78,6 +79,7 @@ const cpApproval = leafCommand(
 		);
 	}),
 ).pipe(
+	Command.withShortDescription("Whether the control-plane approval is discharged at a head."),
 	Command.withDescription(
 		"Discharge the ADR 0175 §CP cardinality table at one head: `cp-approval\\t<discharge|stop|n/a>\\t<mechanism>`. The roster is the control-plane team parsed off .github/CODEOWNERS, read fresh; every discharge signal is head-bound, so a stale approval on a superseded head never counts (#3769). A failed read is UNRESOLVED, never `stop` and never `awaiting-approval` (#4223). A stderr notice fires when the banked head is behind the base, so the approval is not spent on a head that must move (#4477). Exits 7 (PR proven absent or closed), 11 (the boundary, roster, reviews, markers or live head could not be read), 13 (the comment enumeration is provably short of the declared count, or the review read — which the platform gives no count for — never reached a terminal page with no `next` link). Example: fabrika ship cp-approval 4321 --sha 03135b91",
 	),
@@ -110,6 +112,7 @@ const gate = leafCommand(
 		);
 	}),
 ).pipe(
+	Command.withShortDescription("The verdict conjunction over every required namespace."),
 	Command.withDescription(
 		"Resolve the verdict conjunction over every required namespace at one head. First stdout line is `gate\\t<satisfied|blocked>\\t<sha>`, then one `ns\\t<namespace>\\t<pass|fail|absent|stale>\\t<marker|advisory|review-fold|->` line per required namespace, in the order required; `satisfied` iff every one reads pass, and the coverage of the required set is asserted before that word is printed (#4520). In-force resolution is head-bound-first then by write stamp (#4189/#4200), ACL-gated fail-closed (ADR 0055). Both `absent` and `stale` block (#3944). The required set is a floor the verb raises from the diff itself: a PR touching `.decisions/`, `.claude/`, `.github/` or `claude-plugins/` gates on `governance` whether or not --require named it, so no session can turn the requirement off by omission (#5036). Exits 7 (PR proven absent or closed, or the diff has zero changed files), 10 (a --require value is not a gateable namespace), 11 (the changed-file list, comments, reviews or the ACL could not be read — the conjunction is UNKNOWN, never blocked and never satisfied), 13 (the changed-file or comment enumeration is provably short of the declared count, or the review read — which the platform gives no count for — never reached a terminal page with no `next` link). Example: fabrika ship gate 4321 --sha 03135b91 --require review-code --require review-doc",
 	),
@@ -165,6 +168,7 @@ const checks = leafCommand(
 		);
 	}),
 ).pipe(
+	Command.withShortDescription("Roll up the head CI, latest run per context."),
 	Command.withDescription(
 		"Roll up the head CI from REST check-runs, latest-per-context. First stdout line is `checks\\t<sha>\\t<green|red|pending|wedged|no-runs>`, then `run\\t<count>`, one `<name>\\t<status>\\t<gating|informational>` line per run, and `facts\\tworkflows:<n>\\truns:<n>` — the zero-checkset discriminators. With --wait a `settle\\t<settled|budget-exhausted|head-moved>` line leads the emission. The rollup is fail-closed on the ambiguous rows and the informational carve-out is ADR 0061's denylist; a wedge is diagnosed and named, and the cancel-and-rerun lever stays an operator's (#3999). Exits 7 (PR or --sha proven absent), 11 (the check-run or workflow read failed — CI state is UNKNOWN, never green), 13 (entries received < declared). Example: fabrika ship checks 4321 --sha 03135b91 --wait",
 	),
@@ -179,6 +183,7 @@ const evidence = leafCommand(
 		);
 	}),
 ).pipe(
+	Command.withShortDescription("Read the SHA-bound run-evidence bundle."),
 	Command.withDescription(
 		"Read the SHA-bound run-evidence bundle as five states. First stdout line is `evidence\\t<present|pending|failed|absent|unknown>\\t<sha>`, then `lookup\\trun:<id|->\\tartifact:<id|->\\tstatus:<status|->` — the evidence that makes the claim falsifiable — then one `check\\t<name>\\t<status>` line per manifest entry. `failed` is a bundle that binds this head and attests a failing run; `unknown` means the opposite — the answer cannot bind this head. Pending is not absent (#3913): a completed run with zero artifacts reads `pending` within 120s of its `completed_at` against the local clock and `absent` outside it. A failed read is not absent either (#3716), and the fetched artifact's zip magic number is checked before anything parses it. Exits 7 (PR or --sha proven absent), 11 (the run list, artifact list or artifact content could not be read after retries), 13 (a run or artifact enumeration is provably short). Example: fabrika ship evidence 4321 --sha 03135b91",
 	),
@@ -191,6 +196,7 @@ const threads = leafCommand(
 		yield* emit(yield* runThreads({pr, repo: Option.getOrNull(repo), json, env: process.env}));
 	}),
 ).pipe(
+	Command.withShortDescription("Every unresolved review thread with its class facts."),
 	Command.withDescription(
 		"List every unresolved review thread with its class facts, both pagination layers count-proved. First stdout line is `threads\\t<count>` — 0 is a proven answer — then one `thread\\t<id>\\t<bot|human>\\t<path:line|pr-level>\\t<author>\\t<excerpt>` line each. A thread is `bot` only when EVERY comment author is a GraphQL Bot; everything else is human by construction, with no login-suffix inference and no allowlist. This is the sanctioned GraphQL exception — thread resolution state has no REST equivalent. Exits 7 (PR proven absent), 11 (the thread read failed or fails shape validation — UNKNOWN, never zero), 13 (a thread or comment enumeration is provably short). Example: fabrika ship threads 4321",
 	),
@@ -219,6 +225,7 @@ const resolve = leafCommand(
 		);
 	}),
 ).pipe(
+	Command.withShortDescription("Resolve one bot-classed review thread with a rationale."),
 	Command.withDescription(
 		"Resolve ONE bot-classed review thread: re-derive its live state and class, leak-scan the rationale on STDIN, post the rationale as a reply, fire the resolve mutation, and read both back. Prints `resolved\\t<thread-id>\\t<comment-url>`. The rationale arrives on stdin only — a path flag is how a machine-local path reaches a public surface while the poster reads success. Exits 3 (no rationale — a silent resolve is unauditable), 5 (machine-local path in the rationale), 6 (bare @ reference), 7 (PR or thread proven absent), 8 (the reply, the mutation or the confirming re-read failed — UNKNOWN what landed), 9 (the read-back does not show it resolved with the rationale), 11 (the thread's state could not be re-derived — nothing was written), 16 (proven: already resolved, or not positively bot-classed — a human objection is theirs to resolve). Example: fabrika ship resolve 4321 --thread PRRT_kwDOLxx1 < rationale.md",
 	),
@@ -231,6 +238,7 @@ const enqueue = leafCommand(
 		yield* emit(yield* runEnqueue({pr, sha, repo: Option.getOrNull(repo), json, env: process.env}));
 	}),
 ).pipe(
+	Command.withShortDescription("Arm the merge queue at a pinned head and prove it landed."),
 	Command.withDescription(
 		"Arm the merge queue's auto-merge at a pinned head and prove the arm landed. Prints `enqueued\\t<sha>\\t<queued|settling>` — `settling` is the normal race, not a failure. There is NO merge-method flag by construction: the queue owns the method, and a method flag alongside the arm silently no-ops the enqueue at exit 0. `auto_merge: null` post-enqueue is expected and is never read as a jam. Before the arm, a DEFINITE `mergeable_state` is asserted: `mergeable` is computed lazily so an indefinite value is polled, and if it is still indefinite it is UNKNOWN and refuses — GitHub accepts the arm on a conflicted PR under a queue-governed base, so nothing else stands between `dirty` and a parked intent. Exits 7 (PR proven absent, closed or already merged), 8 (the arm or its confirming read-back failed — whether an intent is parked is UNKNOWN, so run `fabrika ship disarm --site refuse` before stopping), 11 (the live head or the mergeability could not be read, or mergeability stayed indefinite — nothing was armed), 12 (the live head moved past --sha — refusing to arm a tree nobody verified). Example: fabrika ship enqueue 4321 --sha 03135b91",
 	),
@@ -264,6 +272,7 @@ const reconcile = leafCommand(
 		);
 	}),
 ).pipe(
+	Command.withShortDescription("Watch a queued PR to a terminal classification."),
 	Command.withDescription(
 		"Watch a queued PR to a terminal classification. Prints `reconcile\\t<landed|ejected|unresolved|parked>\\t<polls-used>\\t<horizon-seconds>` — all four are proven answers at exit 0, so no loop shape around this verb can launder an ejection into a success (#4557). `landed` on merged:true or a base-branch squash whose subject ENDS with `(#<pr>)`; `ejected` only on a removal NOT paired with a merge (#4155); `unresolved` means still-queued at the horizon, the expected outcome of a healthy long dwell; `parked` means the arm never entered a queue on a queue-governed base. Exits 7 (PR proven absent), 11 (every poll failed to read — UNKNOWN, distinct from `unresolved`), 13 (the timeline read — which the platform gives no count for — never reached a terminal page with no `next` link). Example: fabrika ship reconcile 4321",
 	),
@@ -285,6 +294,7 @@ const disarm = leafCommand(
 		yield* emit(yield* runDisarm({pr, site, repo: Option.getOrNull(repo), json, env: process.env}));
 	}),
 ).pipe(
+	Command.withShortDescription("Clear or deliberately keep a parked merge intent."),
 	Command.withDescription(
 		"Clear or deliberately keep a parked merge intent at one ADR 0198 lifecycle site. Prints `disarm\\t<kept|disarmed>\\t<site>\\t<reason>`, where kept reasons are the closed set merged | live-queued | not-armed | pre-queue-regime and the disarmed reason is `cleared`, proven by re-reading auto_merge after the write — the disable call's own exit status fuses failure with nothing-armed and is never trusted. An unreadable armed-state reads armed and an unreadable queue regime reads queue-governed; a live queue entry is never disturbed. There is no 7 seat: a disarm aimed at a merged or absent PR answers `kept`. Exits 8 (the re-read cannot confirm the intent is clear — report `merge intent: NOT cleared`), 10 (--site is not one of the four sites), 11 (the armed-state read failed before any write). Example: fabrika ship disarm 4321 --site preflight",
 	),
@@ -297,6 +307,7 @@ const nudge = leafCommand(
 		yield* emit(yield* runNudge({pr, sha, repo: Option.getOrNull(repo), json, env: process.env}));
 	}),
 ).pipe(
+	Command.withShortDescription("Remedy a dropped CI trigger by close then reopen, once."),
 	Command.withDescription(
 		"Remedy a dropped CI trigger by close→reopen, at most once per head, after re-deriving the precondition itself. Prints `nudged\\t<sha>`. The verb trusts nothing it was told: zero check runs, zero commit statuses, at least one workflow and an open PR are all re-read here, because a mis-dispatched nudge once close→reopened a live green head (#4816). The head ref is untouched by construction, so SHA-bound verdicts survive. Exits 7 (PR proven absent), 8 (the close failed — nothing changed state), 11 (a precondition read failed — nothing was proven, nothing touched), 12 (the live head moved past --sha), 13 (the timeline read never reached a terminal page with no `next` link — the platform gives no count for it, and an unexhausted history must not license a second nudge), 16 (proven not in the dropped-trigger state, or this head was already nudged), 17 (THE CLOSE LANDED AND THE REOPEN IS UNCONFIRMED — the PR may be closed; reopen it by hand now). Example: fabrika ship nudge 4322 --sha 9fe12ab0",
 	),
@@ -317,6 +328,7 @@ const note = leafCommand(
 		);
 	}),
 ).pipe(
+	Command.withShortDescription("Post the durable stop-path note on stdin to the PR."),
 	Command.withDescription(
 		"Post the durable stop-path note on STDIN as a new PR comment, leak-scanned and read back. Prints `noted\\t<comment-url>`. Stop-path notes are a history, not a state — each run's refusal is its own record — and a note on a closed or merged PR is legal, because refusals happen at every lifecycle stage and the durable record is the point (#1928). Exits 3 (no body on stdin — a silent stop is the defect), 5 (machine-local path), 6 (bare @ reference), 7 (PR proven absent), 8 (the create or its confirming re-read failed — UNKNOWN whether it landed), 9 (it landed and the read-back does not match), 11 (the PR could not be read — nothing was posted). Example: fabrika ship note 4322 < stop.md",
 	),
@@ -329,6 +341,7 @@ const release = leafCommand(
 		yield* emit(yield* runRelease({pr, repo: Option.getOrNull(repo), json, env: process.env}));
 	}),
 ).pipe(
+	Command.withShortDescription("Detect a dark ship and queue its issue for release."),
 	Command.withDescription(
 		"Detect a dark ship over the PR itself and queue its linked issue for release. Prints `release\\t<queued|n/a|no-issue>\\t<flag-key|->`. Three ground-truth signals, any one sufficient: the diff adds a flag declaration, the body carries a `Flag:` line, or the body names a key declared in the registry at the base branch inside a gating-context line. The linked issue's inherited `Containment:` stamp is NEVER read — it describes the epic, not this PR (#1257). `no-issue` is its own answer, never folded into n/a: a dark ship the release queue cannot see is the hazard this prevents. Agents deploy, humans release — this ends at the label (ADR 0083). Exits 7 (PR proven absent), 8 (the label write or its re-read failed — escalate), 9 (it landed and the read-back does not show it), 11 (the diff, body, registry or linked issue could not be read — dark-ship-ness is UNKNOWN, never n/a), 13 (the changed-file enumeration is provably short). Example: fabrika ship release 4321",
 	),

--- a/packages/fabrika-cli/src/short-description.ts
+++ b/packages/fabrika-cli/src/short-description.ts
@@ -1,0 +1,45 @@
+/**
+ * The rule for a leaf verb's short list-row description — one string, mechanically checkable.
+ *
+ * Effect's help renderer reads one description for two audiences: the parent group's `SUBCOMMANDS`
+ * row and the verb's own `DESCRIPTION` block. The convention
+ * (`claude-plugins/fabrika/docs/cli-interface-convention.md` §1) makes the block the full contract —
+ * shape, exit codes, an example — so reusing it as the list row emitted rows over a thousand
+ * characters, unwrapped and untruncated (#5208). `Command.withShortDescription` adds the row's own
+ * string without touching the contract, and this module is what keeps it a row.
+ *
+ * The budget is derived from the renderer, not chosen: `renderTable` (`effect@4.0.0-beta.92`,
+ * `src/unstable/cli/CliOutput.ts`) prefixes two spaces and pads the name column to
+ * `min(longestName + 4, 20)`, so the right column starts at column 22 and 78 columns are left at a
+ * 100-column terminal. 72 keeps a margin for a longer verb name landing later.
+ */
+export const SHORT_DESCRIPTION_BUDGET = 72;
+
+/**
+ * Every way a short description fails the rule, named — an empty list is the pass.
+ *
+ * Reported as a list rather than a boolean so the test that reds tells the author which rule broke.
+ */
+export const shortDescriptionDefects = (text: string | undefined): ReadonlyArray<string> => {
+	if (text === undefined || text.trim() === "")
+		return ["absent — the verb declares no short description"];
+	const defects: Array<string> = [];
+	if (text.length > SHORT_DESCRIPTION_BUDGET) {
+		defects.push(
+			`${text.length} characters, over the ${SHORT_DESCRIPTION_BUDGET}-character budget`,
+		);
+	}
+	if (/\bexits?\s+\d/i.test(text) || /\bexit code/i.test(text)) {
+		defects.push("names an exit code — those belong in the verb's own --help");
+	}
+	if (/stdout/i.test(text) || text.includes("\t") || text.includes("\\t")) {
+		defects.push("states the stdout grammar — that belongs in the verb's own --help");
+	}
+	if (/example:/i.test(text)) {
+		defects.push("carries an example — that belongs in the verb's own --help");
+	}
+	if (/[.!?]\s/.test(text)) defects.push("is more than one sentence");
+	if (!text.endsWith(".")) defects.push("does not end in a full stop");
+	if (text.includes("\n")) defects.push("spans more than one line");
+	return defects;
+};

--- a/packages/fabrika-cli/src/short-description.unit.test.ts
+++ b/packages/fabrika-cli/src/short-description.unit.test.ts
@@ -1,0 +1,76 @@
+import {describe, expect, it} from "vitest";
+import {registeredGroups} from "./registry.ts";
+import {SHORT_DESCRIPTION_BUDGET, shortDescriptionDefects} from "./short-description.ts";
+import type {CommandNode} from "./unknown-subcommand.ts";
+
+describe("shortDescriptionDefects", () => {
+	it("passes a one-sentence line inside the budget", () => {
+		expect(shortDescriptionDefects("Rank the live ADRs this one may contradict.")).toEqual([]);
+	});
+
+	it("names an absent line rather than passing it", () => {
+		expect(shortDescriptionDefects(undefined)).toHaveLength(1);
+		expect(shortDescriptionDefects("   ")).toHaveLength(1);
+	});
+
+	it("reds on the contract material the verb's own --help owns", () => {
+		expect(shortDescriptionDefects("Do a thing. Exits 3 when absent.").length).toBeGreaterThan(0);
+		expect(shortDescriptionDefects("Stdout is one line per code.").length).toBeGreaterThan(0);
+		expect(
+			shortDescriptionDefects("Do a thing, Example: fabrika adr next.").length,
+		).toBeGreaterThan(0);
+	});
+
+	it("reds on a line over the budget", () => {
+		expect(shortDescriptionDefects(`${"x".repeat(SHORT_DESCRIPTION_BUDGET)}.`)).toEqual([
+			`${SHORT_DESCRIPTION_BUDGET + 1} characters, over the ${SHORT_DESCRIPTION_BUDGET}-character budget`,
+		]);
+	});
+});
+
+/**
+ * The coverage guard: a leaf shipped with no short description silently falls back to its full
+ * contract paragraph in the group's `SUBCOMMANDS` list, which is the defect back again on the next
+ * verb (#5208). Reds instead.
+ *
+ * It reads `shortDescription` off the `Command`'s runtime shape — the same deliberately-confined
+ * idiom `./excess-operand.unit.test.ts` uses, a plain widening assignment and never a cast, so a
+ * rename upstream reds here at build time rather than leaving the assertion vacuous.
+ */
+describe("every registered leaf verb carries a short list-row description", () => {
+	interface DescribedCommand extends Omit<CommandNode, "subcommands"> {
+		readonly description?: string | undefined;
+		readonly shortDescription?: string | undefined;
+		readonly subcommands: ReadonlyArray<{readonly commands: ReadonlyArray<DescribedCommand>}>;
+	}
+
+	const leaves = (
+		node: DescribedCommand,
+		prefix: ReadonlyArray<string>,
+	): ReadonlyArray<readonly [string, DescribedCommand]> => {
+		const path = [...prefix, node.name];
+		const children = node.subcommands.flatMap((group) => group.commands);
+		if (children.length === 0) return [[path.join(" "), node]];
+		return children.flatMap((child) => leaves(child, path));
+	};
+
+	const groups: ReadonlyArray<DescribedCommand> = registeredGroups;
+	const verbs = groups.flatMap((group) => leaves(group, ["fabrika"]));
+
+	it("finds leaf verbs at all — fail closed on zero scope (ADR 0092)", () => {
+		expect(verbs.length).toBeGreaterThan(0);
+	});
+
+	it.each(
+		verbs.map(([label, verb]) => [label, verb] as const),
+	)("`%s` lists as one scannable line", (_label, verb) => {
+		expect(shortDescriptionDefects(verb.shortDescription)).toEqual([]);
+	});
+
+	it.each(
+		verbs.map(([label, verb]) => [label, verb] as const),
+	)("`%s` keeps its full contract in the long description", (_label, verb) => {
+		expect(verb.description ?? "").not.toBe("");
+		expect((verb.description ?? "").length).toBeGreaterThan((verb.shortDescription ?? "").length);
+	});
+});

--- a/packages/fabrika-cli/src/spend/command.ts
+++ b/packages/fabrika-cli/src/spend/command.ts
@@ -36,6 +36,7 @@ const read = leafCommand(
 		yield* emit(yield* runRead({transcript, json}));
 	}),
 ).pipe(
+	Command.withShortDescription("One run's billed token spend, from its transcript."),
 	Command.withDescription(
 		"One run's billed token spend, reconstructed from its transcript (ADR 0112 §2). First stdout line is `spend\\t<billed>\\t<assistantTurns>`, then one `<field>\\t<value>` line each for input, cacheCreate, cacheRead, output, exCacheRead and model — the cache-read share stays its own number because it is the context-bloat signal. --json emits the same eight fields as an object. Exits 7 (no transcript at that path — a proven absence), 11 (the transcript could not be read, or its absence could not be established — the spend is UNKNOWN, never zero), 12 (read in full and carrying zero billed assistant turns — a well-formed zero, not a measured spend). No threshold, no budget flag, and no exit code that varies with a spend magnitude. Example: fabrika spend read agent-3f9c1d2b.jsonl",
 	),
@@ -79,6 +80,7 @@ const rollup = leafCommand(
 		);
 	}),
 ).pipe(
+	Command.withShortDescription("What fabrika's runs cost, from the durable spend ledger."),
 	Command.withDescription(
 		"What fabrika's runs cost, summed out of the durable spend ledger — the one command that answers it from persisted data, spawning nothing and re-parsing no transcript. stdout is one record per line, first field naming the kind: billed, exCacheRead, assistantTurns, runs, measuredRuns, then skipped/skippedMalformed/skippedNewerVersion/undatedRows, then one `day`, `skill` and `stage-arm` line per bucket. The skipped counts ride on the answer so a partially-unreadable ledger can never present as a quietly smaller total, and they are split because a malformed line is data loss while a newer-version line means upgrade this CLI. --since/--until bound the window (inclusive; a bare YYYY-MM-DD widens to the whole UTC day), --json emits the same answer as an object. Exits 7 (no ledger there — nothing recorded yet), 11 (the ledger could not be read — the spend is UNKNOWN, never zero), 12 (read in full, no rows at all), 13 (rows exist but this window selects none). No threshold, no budget flag, and no exit code that varies with a spend magnitude. Example: fabrika spend rollup --since 2026-08-01",
 	),

--- a/packages/fabrika-cli/src/spike/command.ts
+++ b/packages/fabrika-cli/src/spike/command.ts
@@ -92,6 +92,7 @@ const open = leafCommand(
 		);
 	}),
 ).pipe(
+	Command.withShortDescription("Mint the spike issue and workspace for one question."),
 	Command.withDescription(
 		'Mint the spike issue for one question, allocate this run\'s workspace under a freshly minted nonce, and bind the two in a manifest. Prints {"spike":n,"nonce":"…","kind":"…","workspace":"…","treeDigest":"…"}. Exits 4 (a workspace exists and its manifest does not parse), 5/6 (machine-local path, bare @ reference), 7 (no prototyping:spike label), 8/9 (the create failed, the read-back differs), 10 (off-grammar --nonce or --kind), 11 (a root, the label set or the tree state could not be read — nothing was minted), 12 (--nonce names no workspace), 13 (the workspace resolves inside the repository), 18 (a workspace under a different question or kind), 20 (the spike landed and the manifest could not be completed). Example: fabrika spike open --question "does better-auth mint a single-use token without a new table?" --kind logic',
 	),
@@ -134,6 +135,7 @@ const run = leafCommand(
 		);
 	}),
 ).pipe(
+	Command.withShortDescription("Execute one command in the workspace and log the evidence."),
 	Command.withDescription(
 		'Execute one command in the workspace and append an immutable evidence record. Exit 0 means the command RAN and was recorded, whatever it returned — its own status rides in the payload as commandExit. Prints {"nonce":"…","seq":n,"command":[…],"commandExit":n,"timedOut":bool,"outBytes":n,"errBytes":n,"truncated":bool,"outSha256":"…","errSha256":"…"}. Exits 4 (the manifest or the log does not parse, or the log is not contiguous from 1), 10 (off-grammar --nonce, --timeout or --env), 11 (the command could NOT be executed — nothing was appended, and this is not an answer of no), 12 (no workspace for this nonce), 13 (the workspace resolves inside the repository). Example: fabrika spike run --nonce 7f3a9c21 -- node walkthrough.mjs',
 	),
@@ -161,6 +163,7 @@ const capture = leafCommand(
 		);
 	}),
 ).pipe(
+	Command.withShortDescription("Post the decision on stdin with the run table, then close."),
 	Command.withDescription(
 		'Post the decision read from STDIN plus the log\'s own run table, read it back, and close the spike. Prints {"spike":n,"nonce":"…","commentId":id,"runs":k,"evidenceDigest":"…","state":"closed","discardedStdin":bool}. Exits 3 (stdin held nothing), 4 (the manifest or the log does not parse), 5/6 (leak), 7 (the spike is absent, or closed with nothing to supersede), 8/9 (the post or the close was unproven, the read-back differs), 10 (off-grammar --nonce), 11 (a precondition read failed — nothing was posted), 12 (no workspace), 14 (zero recorded runs — a decision here would be a self-report), 18 (the manifest names another spike), 19 (the author holds below write). Example: fabrika spike capture 9310 --nonce 7f3a9c21 < decision.md',
 	),
@@ -189,6 +192,7 @@ const dispose = leafCommand(
 		);
 	}),
 ).pipe(
+	Command.withShortDescription("Remove the workspace and prove the tree is unchanged."),
 	Command.withDescription(
 		'Prove the repository tree is unchanged and the capture still covers the log, remove the workspace, and prove it is gone. Prints {"spike":n,"nonce":"…","workspace":"removed","treeMatched":true,"runs":k,"forfeited":bool}. Exits 4 (the manifest or the log does not parse), 5/6 (leak in the forfeit note), 7 (the spike is proven absent), 8/9 (the note post or the close was unproven, the read-back differs), 10 (off-grammar --nonce), 11 (a read failed — nothing was removed), 12 (no workspace), 15 (no captured decision and no --forfeit), 16 (removed and still present on re-probe), 17 (the tree moved since open — NOTHING was removed), 21 (the log moved after the capture). Example: fabrika spike dispose --nonce 7f3a9c21',
 	),
@@ -208,6 +212,7 @@ const status = leafCommand(
 		);
 	}),
 ).pipe(
+	Command.withShortDescription("One run's spike state, workspace and evidence count."),
 	Command.withDescription(
 		'One run\'s spike state, workspace presence and evidence count — near-total, because its consumer is a session resuming cold. An absent workspace is a FACT at exit 0. Prints {"nonce":"…","workspace":"present|absent","spike":n,"kind":"…","question":"…","spikeState":"open|closed|null","captured":bool,"runs":k,"lastCommandExit":n,"evidenceDigest":"…","treeMatched":bool}. Exits 4 (the manifest or the log exists and does not parse), 10 (off-grammar --nonce), 11 (the spike state, its comments or the tree state could not be read). Example: fabrika spike status --nonce 7f3a9c21',
 	),

--- a/packages/fabrika-cli/src/status/command.ts
+++ b/packages/fabrika-cli/src/status/command.ts
@@ -93,6 +93,7 @@ const menu = leafCommand(
 		yield* emit(runMenu({roster, asOf: readNow(instant(new Date())), json}));
 	}),
 ).pipe(
+	Command.withShortDescription("The landed skill roster, derived from the installed plugin."),
 	Command.withDescription(
 		"List the landed skill roster, derived from the installed plugin's skills tree rather than from a committed file. First stdout line is `menu\\t<ready|empty>\\t<count>\\t<as-of>`, then one `skill\\t<name>\\t<invocation>\\t<model|user>\\t<description>` line each. An implicitly-resolved roster holding zero skills is `empty` at exit 0. Exits 7 (an explicitly passed --skills-dir is proven absent), 11 (the resolved roster could not be read — UNKNOWN, never empty). Example: fabrika status menu",
 	),
@@ -127,6 +128,7 @@ const config = leafCommand(
 		yield* emit(runConfig({roster, surfaces, json}));
 	}),
 ).pipe(
+	Command.withShortDescription("Which repo surfaces the landed skills need, and which exist."),
 	Command.withDescription(
 		"Report which repo surfaces every landed skill declares it needs and whether each is present here — the detection verb (#4952). First stdout line is `config\\t<satisfied|gaps|unknown>\\t<declared>\\t<missing>\\t<undeclared>\\t<off-vocabulary>`, then one `surface\\t…` line per declared row. A skill with no `## Required repo files` section emits one `undeclared` row, never zero. Exits 7 (an explicitly passed --skills-dir is proven absent), 11 (the roster or a SKILL.md inside it could not be read — the declaration set is UNKNOWN). Example: fabrika status config",
 	),
@@ -149,6 +151,7 @@ const board = leafCommand(
 		yield* emit(runBoard({read: yield* readBoard(target.value, () => new Date()), json}));
 	}),
 ).pipe(
+	Command.withShortDescription("The board's decided buckets, each with its own freshness."),
 	Command.withDescription(
 		"Count the board's decided buckets over named REST endpoints — needs-triage, triaged, in-flight and one per priority — each with its own freshness. An absent label renders `unknown` with detail `label absent`, never 0. First stdout line is `board\\t<counted|unknown>\\t<bucket-count>`, then one `bucket\\t…` line each. Exits 11 (the repository could not be read at all — every bucket is UNKNOWN). Example: fabrika status board",
 	),
@@ -182,6 +185,7 @@ const readout = leafCommand(
 		yield* emit(runReadout({read, json}));
 	}),
 ).pipe(
+	Command.withShortDescription("The landed-decision digest from the durable artifact."),
 	Command.withDescription(
 		"Display the landed-decision digest published in the durable artifact, decoded through the registered governance-digest wire format. This verb ranks nothing. First stdout line is `readout\\t<found|absent|malformed>\\t<row-count>\\t<source>\\t<as-of>`, then the digest's own rows. A closed or absent artifact is `absent` at exit 0. Exits 10 (the positional is not a positive issue number), 11 (the artifact could not be fetched, its updated_at was unreadable, or the format is not registered — UNKNOWN, never absent). Example: fabrika status readout",
 	),
@@ -217,6 +221,7 @@ const bootstrap = leafCommand(
 		);
 	}),
 ).pipe(
+	Command.withShortDescription("Create one missing repo surface and read it back."),
 	Command.withDescription(
 		"Create one missing repo surface from this group's own buildable-surface registry and read it back. The content of a file surface arrives on STDIN — the write, the collision guard and the read-back are this verb's; what the file says is the skill's. A target already present is `exists` at exit 0 and nothing is written. Stdout is the single line `bootstrap\\t<created|exists>\\t<surface-id>\\t<target>\\t<readback>`. Exits 3 (stdin held nothing), 5 (the content carries a machine-local path), 6 (the content is a bare @ path reference), 8 (the write failed — UNKNOWN), 9 (the read-back differs), 10 (--path resolves outside the repository root), 11 (the existence probe failed — nothing was written), 12 (the surface is not in the registry). Example: fabrika status bootstrap readout-artifact",
 	),
@@ -293,6 +298,7 @@ const open = leafCommand(
 		yield* emit(runOpen({fields, json, scope: `${rosterScope}; repo ${repoName}`}));
 	}),
 ).pipe(
+	Command.withShortDescription("The composite front-door readout: menu, config, board, readout."),
 	Command.withDescription(
 		"The composite front-door readout: four fields — menu, config, board, readout — each with its own state, source and freshness. Every unreadable source becomes a field state, so this verb has no zero-scope seat and no failed-read seat: it is injected before the session reads a token and a refusal would write zero bytes. First stdout line is `open\\t<field-count>`, then one `field\\t<name>\\t<state>\\t<detail>\\t<source>\\t<as-of>` line each. Exits 10 (--field is off the closed vocabulary). Example: fabrika status open",
 	),

--- a/packages/fabrika-cli/src/triage/command.ts
+++ b/packages/fabrika-cli/src/triage/command.ts
@@ -64,6 +64,7 @@ const codes = leafCommand(
 		yield* emit(runCodes({json}));
 	}),
 ).pipe(
+	Command.withShortDescription("Print the exit taxonomy this group allocates from."),
 	Command.withDescription(
 		"Print the exit taxonomy every verb in this group allocates from, one `<code>\\t<meaning>` line per code. Reads nothing and always exits 0. Example: fabrika triage codes",
 	),
@@ -106,6 +107,7 @@ const kill = leafCommand(
 		);
 	}),
 ).pipe(
+	Command.withShortDescription("Close an agent-filed issue not-planned, with a reason."),
 	Command.withDescription(
 		"Close an agent-filed issue not-planned over four gated writes — the optional redacted duplicate fold, the reason from STDIN, the closed-by-triage label, then the close — and read back that it says not_planned. Prints `killed\\t<number>\\t<foldedInto|none>`. Exits 3 (empty stdin), 5 (machine-local path in the reason), 6 (bare @ reference), 7 (issue absent or closed, duplicate absent or closed, or no closed-by-triage label), 8 (a write failed — UNKNOWN), 9 (read-back is not a not-planned close), 11 (a precondition read failed), 12 (human-filed — no agent footer and no operator author, see $FABRIKA_OPERATOR_ACCOUNTS), 13 (unconfirmed). Example: fabrika triage kill 4312 --confirm --duplicate-of 4290 < reason.md",
 	),
@@ -143,6 +145,7 @@ const split = leafCommand(
 		);
 	}),
 ).pipe(
+	Command.withShortDescription("Create one child of a bundled report, exactly once."),
 	Command.withDescription(
 		'Create one child of a bundled report from the body on STDIN, exactly once, and cross-link the parent. Prints `<created|reused>\\t<number>\\t<url>`; both outcomes exit 0. Exits 3 (empty stdin), 5 (machine-local path), 6 (bare @ reference), 7 (parent absent, or the queue label does not exist), 8 (create failed — UNKNOWN), 9 (read-back mismatch), 11 (a precondition read failed — never a silent create). Example: fabrika triage split 4312 --title "Editor loses focus after save" < child.md',
 	),
@@ -200,6 +203,7 @@ const apply = leafCommand(
 		);
 	}),
 ).pipe(
+	Command.withShortDescription("Stamp the whole triaged transition as one reconcile."),
 	Command.withDescription(
 		"Stamp the whole triaged transition — type, priority, audience, status and home — as ONE owned-facet reconcile, then read the end state back positively. Exactly one of --home / --lane. Prints `triaged\\t<n>\\t<type>\\t<priority>\\t<ready-for>\\t<home>`. Exits 7 (no such issue, or a label this run would write does not exist), 8 (a write failed — UNKNOWN), 9 (read-back mismatch), 10 (off-vocabulary value, or a non-open milestone), 11 (a precondition read failed). Example: fabrika triage apply 4312 --type bug --priority p2 --ready-for agent --home 47",
 	),
@@ -220,6 +224,7 @@ const park = leafCommand(
 		);
 	}),
 ).pipe(
+	Command.withShortDescription("Demote an issue to needs-info with the questions on stdin."),
 	Command.withDescription(
 		"Demote an issue to status:needs-info with the questions on STDIN, clearing every priced facet — type, priority, audience, lane and milestone. The comment is posted BEFORE the labels move. Prints `parked\\t<n>\\t<comment-url>`. Exits 3 (empty stdin), 5 (machine-local path), 6 (bare @ reference), 7 (no such issue, or status:needs-info does not exist), 8 (a write failed — UNKNOWN), 9 (read-back mismatch), 11 (a precondition read failed). Example: fabrika triage park 4290 < questions.md",
 	),
@@ -251,6 +256,7 @@ const claim = leafCommand(
 		);
 	}),
 ).pipe(
+	Command.withShortDescription("Take a session-scoped claim on one issue."),
 	Command.withDescription(
 		'Take a session-scoped claim on one issue, proven by re-reading the markers back. Prints `won` or `lost\\t<holder-session-id>` — both are proven answers and both exit 0. Exits 1 (CLAUDE_CODE_SESSION_ID unset), 7 (no such issue, or it is closed), 8 (marker POST failed — UNKNOWN), 9 (marker absent on read-back, or a conceded marker could not be deleted), 11 (the issue or its comments could not be read — never "won"). Example: fabrika triage claim 4312',
 	),
@@ -285,6 +291,7 @@ const queue = leafCommand(
 		);
 	}),
 ).pipe(
+	Command.withShortDescription("The claimable intake queue, oldest first."),
 	Command.withDescription(
 		"List the claimable intake queue, oldest first. First stdout line is the outcome token — queued | empty — and a queued list adds one `<number>\\t<age-days>\\t<title>` line per issue; the scanned count is on stderr. Exits 7 (--label does not exist, so the queue would scan nothing), 11 (the queue read failed — UNKNOWN, never `empty`). Example: fabrika triage queue --limit 20",
 	),
@@ -303,6 +310,7 @@ const provenance = leafCommand(
 		);
 	}),
 ).pipe(
+	Command.withShortDescription("Whether an issue was reported by an agent or a human."),
 	Command.withDescription(
 		"Say whether an issue was reported by an agent or typed by a human. Two agent signals: the anchored `Filed by an agent` footer (ADR 0159), or an author in the operator set named by $FABRIKA_OPERATOR_ACCOUNTS — an operator's own filing is agent-reported footer or not (#4619 ruling). Prints `agent` or `human`; with no operator set configured this is the footer-only rule, a footerless non-operator filing answers `human`, an empty body answers `human` fail-closed, an unreadable one refuses. Exits 7 (issue proven absent), 11 (unreadable — the provenance is UNKNOWN, never `human`). Example: fabrika triage provenance 4312",
 	),
@@ -324,6 +332,7 @@ const homes = leafCommand(
 		yield* emit(yield* runHomes({roadmap, repo: Option.getOrNull(repo), json, env: process.env}));
 	}),
 ).pipe(
+	Command.withShortDescription("The assignable homes: open milestones and standing lanes."),
 	Command.withDescription(
 		"List the assignable homes: every OPEN milestone joined to its roadmap arc/campaign row by `#<number>`, plus the two standing lanes. First stdout line is `homes`, then one `<kind>\\t<key>\\t<label>` line per candidate. Exits 7 (zero open milestones, or the roadmap parsed to 0 arc rows), 11 (the milestone list or the roadmap could not be read). Example: fabrika triage homes",
 	),
@@ -359,6 +368,7 @@ const enrich = leafCommand(
 		);
 	}),
 ).pipe(
+	Command.withShortDescription("Replace an issue body with the rewrite on stdin."),
 	Command.withDescription(
 		"Replace an issue body with the rewrite on STDIN above the preserved, leak-redacted original — or with --epic, a pitch above the original under a fixed header. A prior enrichment is recognised by the marker this verb writes, bound to this issue number, so a re-run in EITHER mode replaces the authored region instead of nesting a second envelope. Prints `enriched\\t<number>\\t<redactions>`. Exits 3 (empty stdin), 5 (machine-local path in the authored text), 6 (bare @ reference), 7 (issue absent, or its body is empty — no original to preserve), 8 (the PATCH failed — UNKNOWN), 9 (read-back mismatch), 11 (the issue could not be read). Example: fabrika triage enrich 4312 < enriched.md",
 	),

--- a/packages/fabrika-cli/src/ui/command.ts
+++ b/packages/fabrika-cli/src/ui/command.ts
@@ -45,6 +45,7 @@ const manifest = leafCommand(
 		yield* emit(yield* runManifest());
 	}),
 ).pipe(
+	Command.withShortDescription("This repo's design surfaces, as presence and paths."),
 	Command.withDescription(
 		'Resolve this repo\'s design surfaces by convention — manifest, prohibition registry, component inventory, golden pointer, render harness — as presence and paths, never a judgment. Prints {"manifest","registry","inventory","goldenPointer","harness","lawSource"}, each path repo-root-relative or null, with lawSource "registry" or "manifest-prose". Exits 11 (the repo root or a convention path could not be probed — presence is UNKNOWN, never "absent"), 12 (proven: no design manifest — the repo is un-bootstrapped; route to front-door). Example: fabrika ui manifest',
 	),
@@ -57,6 +58,7 @@ const law = leafCommand(
 		yield* emit(yield* runLaw());
 	}),
 ).pipe(
+	Command.withShortDescription("The typed prohibition registry, in file order."),
 	Command.withDescription(
 		'The typed prohibition registry, schema-validated whole-file, rows in file order. Prints {"lawSource":"registry","rows":[…]}; there is no empty answer, because a law file that names no law is malformed rather than minimal. Exits 4 (the registry exists but violates the schema — missing/extra field, duplicate id, off-enum value, zero rows, unparseable JSON; the whole file is refused), 11 (the registry could not be read — the law is UNKNOWN, never "untyped"), 12 (proven: no design manifest), 13 (proven: manifest present, no registry — the law is untyped and the manifest\'s prose is the source). Example: fabrika ui law',
 	),
@@ -97,6 +99,7 @@ const render = leafCommand(
 		);
 	}),
 ).pipe(
+	Command.withShortDescription("Render the named surfaces here and capture one PNG each."),
 	Command.withDescription(
 		'Render the named surfaces in this tree and capture one VALIDATED PNG per surface, into <set>/ under the lane scratch dir, plus a <set>/manifest.json byte-identical to the stdout JSON. Prints {"set","captures":[{"surface","path","width","height","sha256","firstRender"}]} and exits 0 only when EVERY requested surface captured and validated. Emits no verdict, no score and no layout opinion. Exits 4 (design-harness.json violates its schema), 10 (--out is not kebab-case, or a --surface carries the reserved :state suffix), 11 (the harness never became ready, or a capture\'s validity could not be determined — UNKNOWN), 14 (proven: a surface threw during render), 15 (proven: a surface is unreachable), 16 (proven: a capture is invalid), 18 (proven: the lane precondition failed), 19 (proven: no design-harness.json). Example: fabrika ui render --out after --surface /pano',
 	),
@@ -127,6 +130,7 @@ const golden = leafCommand(
 		);
 	}),
 ).pipe(
+	Command.withShortDescription("Diff a candidate surface against its blessed golden."),
 	Command.withDescription(
 		'Resolve a surface\'s blessed golden and diff a candidate against it — signal, never verdict. Prints {"surface","blessed","golden","diff"}; an unblessed surface is a FACT on exit 0, but only after a pointer read that succeeded. The diff is the contract\'s number: a pixel differs above a per-channel delta of 10, magnitude is differing/total rounded to 3 decimals, regions are 8-connected boxes merged under 16px, largest first, capped at 20; a dimension mismatch is {"magnitude":1,"regions":[],"dimensionMismatch":true}. Exits 4 (the pointer exists but does not parse — never read as an empty blessed set), 11 (the pointer read, the bytes fetch or their hash check failed — blessing is UNKNOWN), 16 (proven: the candidate is invalid). Example: fabrika ui golden --surface /pano --candidate /…/after/pano.png',
 	),
@@ -162,6 +166,7 @@ const evidence = leafCommand(
 		);
 	}),
 ).pipe(
+	Command.withShortDescription("Upload the before/after captures and post them on the PR."),
 	Command.withDescription(
 		'Upload the before/after captures, verify EVERY upload, post one head-SHA-bound PR comment, and read it back. Prints {"answer":"attached","pr","commentId","head","surfaces"}. Evidence is all-or-nothing: one failed upload or verification is 17 with nothing posted. Exits 4 (an after-surface has no before and no firstRender mark, a set is missing its manifest.json, or design-harness.json violates its schema), 5 (the comment carries a machine-local path), 6 (the comment is a bare @ path reference), 7 (the PR is proven absent, closed or merged), 8 (the post failed — it may or may not have landed), 9 (the comment landed but does not read back as sent), 11 (a precondition read failed — nothing was uploaded or posted), 16 (proven: a capture is invalid or no longer matches its manifest sha), 17 (proven: an upload or its verification failed), 18 (proven: the lane precondition failed). Example: fabrika ui evidence --pr 4318 --before before --after after',
 	),

--- a/packages/fabrika-cli/src/wire/command.ts
+++ b/packages/fabrika-cli/src/wire/command.ts
@@ -55,6 +55,7 @@ const codes = leafCommand(
 		yield* emitOutcome(runCodes({json}));
 	}),
 ).pipe(
+	Command.withShortDescription("Print the exit taxonomy this group allocates from."),
 	Command.withDescription(
 		"Print the exit taxonomy every verb in this group allocates from. Stdout is one `<code>\\t<meaning>` line per code. Reads nothing and always exits 0. Example: fabrika wire codes",
 	),
@@ -67,6 +68,7 @@ const formats = leafCommand(
 		yield* emitOutcome(runFormats({json}));
 	}),
 ).pipe(
+	Command.withShortDescription("List the registered wire formats, from the registry."),
 	Command.withDescription(
 		"List the registered wire formats, derived from the registry rather than from a hand-written list. First stdout line is `formats\\t<n>`, then one `<key>\\t<purpose>\\t<producers>\\t<consumers>` line per format. Exits 7 (no format is registered — a listing over zero rows is not an answer). Example: fabrika wire formats",
 	),
@@ -79,6 +81,7 @@ const emit = leafCommand(
 		yield* emitOutcome(yield* runEmit({format, json, stdin: Effect.sync(readStdin)}));
 	}),
 ).pipe(
+	Command.withShortDescription("Compose a format's bytes from the fields on stdin."),
 	Command.withDescription(
 		"Compose a format's bytes from the fields on STDIN — for acceptance-criteria, one criterion per line, optionally prefixed `[x]` or `[ ]`. The composed block is the stdout answer and round-trips through `wire read`. Exits 5 (stdin was read and held nothing), 6 (stdin could not be read — UNKNOWN), 7 (--format names no registered format), 8 (the fields hold no usable criterion). Example: fabrika wire emit --format acceptance-criteria < criteria.txt",
 	),
@@ -91,6 +94,7 @@ const read = leafCommand(
 		yield* emitOutcome(yield* runRead({format, json, stdin: Effect.sync(readStdin)}));
 	}),
 ).pipe(
+	Command.withShortDescription("Read a format's block out of the artifact on stdin."),
 	Command.withDescription(
 		"Read a format's block out of the artifact on STDIN and print its fields. The read is total: `found` is the only outcome on stdout, and it never carries zero fields. First stdout line is `found\\t<format>\\t<count>`, then one field line each. Exits 3 (proven absent — nothing in the artifact reaches for the block), 4 (present and malformed — the reason and the offending bytes are on stderr), 5 (stdin was read and held nothing), 6 (the artifact could not be read — UNKNOWN, never absent), 7 (--format names no registered format). Example: fabrika wire read --format acceptance-criteria < issue-body.md",
 	),
@@ -103,6 +107,7 @@ const check = leafCommand(
 		yield* emitOutcome(yield* runCheck({format, json, stdin: Effect.sync(readStdin)}));
 	}),
 ).pipe(
+	Command.withShortDescription("Whether the artifact on stdin carries a conforming block."),
 	Command.withDescription(
 		"Say whether the artifact on STDIN carries a conforming block for this format, without printing its fields. The scope judged — lines, bytes and format — is on stderr on every path, so a verdict is never reported over unstated scope. Stdout is the single line `conforms\\t<format>\\t<count>`. Exits 3 (proven absent), 4 (present and malformed), 5 (stdin was read and held nothing), 6 (the artifact could not be read — UNKNOWN), 7 (--format names no registered format — zero scope, never a vacuous pass). Example: fabrika wire check --format acceptance-criteria < issue-body.md",
 	),
@@ -154,6 +159,7 @@ const index = leafCommand(
 		);
 	}),
 ).pipe(
+	Command.withShortDescription("Reconcile the wire-formats index doc with the registry."),
 	Command.withDescription(
 		"Reconcile the wire-formats index doc with the registry — and, with --write, render its generated region from the registry rather than by hand. Stdout is the single line `index\\t<agrees|written>\\t<registered>\\t<documented>`. Exits 4 (the index and the registry disagree — a registered format with no section, a section for no registered format, or a stale generated region), 6 (the doc could not be read or written — UNKNOWN, never a disagreement), 7 (zero scope: an empty registry, an empty doc, no generated region, or no format sections — never a vacuous pass). Example: fabrika wire index --write",
 	),


### PR DESCRIPTION
`fabrika ship --help` printed verb rows over a thousand characters long, so the terminal wrapped them into a wall of text and you could not tell where one verb ended and the next began. Effect's help renderer was reusing each verb's full contract — output shape, exit codes, an example — as its one-line entry in the parent group's list.

Every leaf verb now declares a second, short description: one sentence saying what it answers. That is what the group list shows. The full contract is untouched and still prints on `fabrika <group> <verb> --help`.

## What changed

- All 142 leaf verbs across the 23 groups gained a `Command.withShortDescription` one-liner. The combinator is published by the pinned `effect@4.0.0-beta.92`, and the renderer already falls back to the long description when it is absent — so nothing is truncated and no existing string moved.
- `packages/fabrika-cli/src/short-description.ts` holds the rule: a 72-character budget derived from the renderer's own column math (`renderTable` pads the name column to `min(longest + 4, 20)` after a two-space indent, leaving 78 columns at a 100-column terminal), plus the checks that a short line is one sentence with no exit code, no stdout grammar and no example.
- `packages/fabrika-cli/src/short-description.unit.test.ts` runs that rule over every registered leaf, walking the same runtime `Command` tree `excess-operand.unit.test.ts` walks, and fails closed on zero scope. A verb shipped without a short line reds.
- `claude-plugins/fabrika/docs/cli-interface-convention.md` §1 now names the two audiences explicitly, so its "one-line description" rule and its "help states shape + exit codes + example" rule stop reading as contradictory.

Verified: every group's `SUBCOMMANDS` block renders with zero rows over 100 columns; `packages/fabrika-cli/src/wire/help.unit.test.ts` passes unchanged; `pnpm typecheck`, `pnpm lint:worktree` and the full 4290-test `fabrika-cli` suite are green.

Fixes #5208

## Deviations

- **Scope larger than the issue estimated.** Said: "~90 leaf verbs" across 14 files. Did: 142 leaf verbs across 23 files. Why: the CLI grew since the issue was written; the acceptance criterion is "every leaf verb", so the real count governs. Disposition: no action needed.
- **One PR, not sliced per group.** Said: "slicing the PR per group is fine and expected". Did: all 23 groups in one diff. Why: the change is one mechanical insertion per verb with a single shared rule module and a single test, so slicing would have shipped the guard before most of the verbs it guards. Disposition: no action needed — for the reviewer to judge whether the diff size is workable.
- **The character budget is my call.** Said: "over a fixed character budget". Did: 72, derived from the renderer's column math with margin for a longer verb name landing later. Why: the issue fixed the shape of the rule, not the number. Disposition: for the reviewer to judge; the derivation is stated in the module docblock.