### PR TITLE
fix(ci): bump playwright to 1.62.1 so the browser install stops hanging

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -885,11 +885,13 @@ jobs:
     timeout-minutes: 25
     # Run in the Playwright-maintained image: chromium + headless-shell + ffmpeg
     # and all system deps are PREBAKED at /ms-playwright (PLAYWRIGHT_BROWSERS_PATH
-    # is set in the image), so there's no `playwright install` download — which
-    # hangs deterministically on the hosted runner (#522). Tag MUST match the
-    # locked @playwright/test version (1.59.1) or the browsers won't match.
+    # is set in the image), so there's no `playwright install` download to pay for
+    # in this job at all (it hung deterministically at 1.59.1 — #522/#5343, fixed by
+    # the bump below, but a ~170MB download per run is still cost this job doesn't
+    # need). Tag MUST match the locked @playwright/test version (1.62.1) or the
+    # browsers won't match.
     container:
-      image: mcr.microsoft.com/playwright:v1.59.1-jammy
+      image: mcr.microsoft.com/playwright:v1.62.1-jammy
     permissions:
       contents: read
       pull-requests: read # read the sticky preview-deploy comment for URL + D1 id

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -61,8 +61,8 @@ catalogs:
       specifier: 1.3.1
       version: 1.3.1
     '@playwright/test':
-      specifier: ^1.59.1
-      version: 1.59.1
+      specifier: ^1.62.1
+      version: 1.62.1
     '@sentry/cloudflare':
       specifier: 10.62.0
       version: 10.62.0
@@ -346,7 +346,7 @@ importers:
         version: link:../../packages/founder-seed
       '@playwright/test':
         specifier: 'catalog:'
-        version: 1.59.1
+        version: 1.62.1
       '@testing-library/dom':
         specifier: 'catalog:'
         version: 10.4.1
@@ -873,7 +873,7 @@ importers:
         version: 4.0.0-beta.92(effect@4.0.0-beta.92(patch_hash=ed3008c54709e9cf624df2b898d592f905c570fc0a673eeaadf06ce377caac89))(ioredis@5.10.1)
       '@playwright/test':
         specifier: 'catalog:'
-        version: 1.59.1
+        version: 1.62.1
       effect:
         specifier: 'catalog:'
         version: 4.0.0-beta.92(patch_hash=ed3008c54709e9cf624df2b898d592f905c570fc0a673eeaadf06ce377caac89)
@@ -1052,7 +1052,7 @@ importers:
         version: link:../fabrika-cli
       '@playwright/test':
         specifier: 'catalog:'
-        version: 1.59.1
+        version: 1.62.1
       effect:
         specifier: 'catalog:'
         version: 4.0.0-beta.92(patch_hash=ed3008c54709e9cf624df2b898d592f905c570fc0a673eeaadf06ce377caac89)
@@ -2422,9 +2422,9 @@ packages:
   '@oxc-project/types@0.139.0':
     resolution: {integrity: sha512-r9gHphtCs+1M7J0pw6Sn/hh/Wpa/iQrOOkrNAlVLF/gHq+/CJmHIWKKUUhdWjcD6CIa8idarspCsASiXCXvFUw==}
 
-  '@playwright/test@1.59.1':
-    resolution: {integrity: sha512-PG6q63nQg5c9rIi4/Z5lR5IVF7yU5MqmKaPOe0HSc0O2cX1fPi96sUQu5j7eo4gKCkB2AnNGoWt7y4/Xx3Kcqg==}
-    engines: {node: '>=18'}
+  '@playwright/test@1.62.1':
+    resolution: {integrity: sha512-DTcUc8qii+cpHvtOwggMtBRMjKZHXYWdw8syRYu2vtzuq4Wxphqq4NfCs5Zt44L6mA8rfDfj+PHnxFc/FeK6mQ==}
+    engines: {node: '>=20'}
     hasBin: true
 
   '@rolldown/binding-android-arm64@1.0.1':
@@ -4322,14 +4322,14 @@ packages:
     resolution: {integrity: sha512-RvwwcruNjI1ncT5xRakeyS9Lf8lcItv34KD+aif+VH9kduAyfYBipGh12274xtenIPZ119/R9BdTBa8gAwSh0A==}
     engines: {node: '>=12'}
 
-  playwright-core@1.59.1:
-    resolution: {integrity: sha512-HBV/RJg81z5BiiZ9yPzIiClYV/QMsDCKUyogwH9p3MCP6IYjUFu/MActgYAvK0oWyV9NlwM3GLBjADyWgydVyg==}
-    engines: {node: '>=18'}
+  playwright-core@1.62.1:
+    resolution: {integrity: sha512-wPYSwEBJY9GHraISXqyqtx0na0LpO3XEX7jNDhntbex7tzUS7kLnZsOlFruFJB4Hi/rhDMjXGqHewDZ68nYZVw==}
+    engines: {node: '>=20'}
     hasBin: true
 
-  playwright@1.59.1:
-    resolution: {integrity: sha512-C8oWjPR3F81yljW9o5OxcWzfh6avkVwDD2VYdwIGqTkl+OGFISgypqzfu7dOe4QNLL2aqcWBmI3PMtLIK233lw==}
-    engines: {node: '>=18'}
+  playwright@1.62.1:
+    resolution: {integrity: sha512-0M+L3LAD8/nm554LOla9Ayx0j0tmFZ0FBcoQ7F1VuVHpM/XpiC8RcDzBQB8W5+hA8L22THxELzeF+2WcUzvcLg==}
+    engines: {node: '>=20'}
     hasBin: true
 
   postcss@8.5.22:
@@ -5956,9 +5956,9 @@ snapshots:
 
   '@oxc-project/types@0.139.0': {}
 
-  '@playwright/test@1.59.1':
+  '@playwright/test@1.62.1':
     dependencies:
-      playwright: 1.59.1
+      playwright: 1.62.1
 
   '@rolldown/binding-android-arm64@1.0.1':
     optional: true
@@ -7920,11 +7920,11 @@ snapshots:
 
   picomatch@4.0.5: {}
 
-  playwright-core@1.59.1: {}
+  playwright-core@1.62.1: {}
 
-  playwright@1.59.1:
+  playwright@1.62.1:
     dependencies:
-      playwright-core: 1.59.1
+      playwright-core: 1.62.1
     optionalDependencies:
       fsevents: 2.3.2
 

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -28,7 +28,7 @@ catalog:
   '@manti-ui/react': 0.9.0
   '@manti-ui/styles': 0.9.0
   '@nkzw/fate': 1.3.1
-  '@playwright/test': ^1.59.1
+  '@playwright/test': ^1.62.1
   '@sentry/cloudflare': 10.62.0
   '@sentry/effect': 10.62.0
   '@sentry/react': 10.62.0


### PR DESCRIPTION
Playwright 1.59.1 downloads the browser archive fine and then parks forever in its bundled zip extractor under the repo's pinned Node 26.2.0, so a machine without a prebaked browser never gets one. Triage had already isolated the variable (the Node major) and shown that 1.62.1 extracts fine on the same Node, so this is a version bump, not an investigation. The catalog moves to `^1.62.1` and the `e2e` job's container tag moves to `v1.62.1-jammy` in lockstep, because the image's prebaked browsers have to match the locked client.

Fixes #5343

## What changed

- `pnpm-workspace.yaml` — `@playwright/test` catalog entry `^1.59.1` -> `^1.62.1`. Every consumer (`apps/web`, `packages/fabrika-cli`, `packages/local-render`) already reads `catalog:`, so nothing else moves.
- `pnpm-lock.yaml` — regenerated; the diff is playwright-only (`@playwright/test`, `playwright`, `playwright-core` 1.59.1 -> 1.62.1).
- `.github/workflows/ci.yml` — `e2e` container `mcr.microsoft.com/playwright:v1.59.1-jammy` -> `v1.62.1-jammy`, and the comment above it now says the hang was a 1.59.1 defect that this bump fixes, rather than stating it in the present tense.

## Evidence (real runs, darwin-arm64, Node 26.2.0 — the repo's `volta.node` pin)

**Cold `playwright install chromium` into an empty `PLAYWRIGHT_BROWSERS_PATH`, `DEBUG=pw:install`:** exit 0 in about 8 seconds. `extracting archive` is followed one second later by `fixing permissions` and `SUCCESS installing` — the exact line the 1.59.1 runs parked on forever. 568 MB landed (`chromium-1234`, `chromium_headless_shell-1234`, `ffmpeg-1011`).

**`packages/fabrika-cli/scripts/provision-browser.mjs` end to end, no `PLAYWRIGHT_BROWSERS_PATH`, no `CI`, no skip flag, and no `chromium-1234` in the default cache:** exit 0 in 11 seconds, both browsers downloaded and extracted into the default cache. That is well inside the script's spawn timeout, so the run-time exit-`11` remediation path is no longer where a cold machine ends up.

**Guards:** `pipeline-cli catalog-guard check` green (29 manifests, all `catalog:`/`workspace:`), `pnpm typecheck` green (31/31), `pnpm lint:worktree` a clean skip (no biome-handled files changed).

**CI:** the diff touches `pnpm-lock.yaml` and `.github/workflows/ci.yml`, both of which trip the `e2e` path filter, so this PR runs the `e2e` suite inside the new container. No job timeout was raised.

## Finding: the browser cache the issue asks about does not exist on `main`

One acceptance criterion asks for the `.github/workflows/ci.yml` browser cache to be shown saving and hitting, or for a finding explaining why it cannot. There is no browser cache step in `ci.yml` on `main` — the only `ms-playwright` mention is a comment. The cache is introduced on #5169's branch, together with the removal of `provision-browser.mjs`'s `CI` skip. Until that lands, no CI job extracts a browser at all (`e2e` uses the prebaked image; every other job hits the `CI` skip), so there is nothing here to save or hit. This bump is what makes that cache able to work once #5169 lands; proving the save/hit belongs to #5169's PR, where the cache actually exists.

## Deviations

- **Class: narrowed a suggested fix-shape.** Said: the issue leaves the lowest fixed playwright version open and notes 1.60.0/1.61.x were never tested. Did: bumped straight to 1.62.1, the version triage verified first-hand, without bisecting for a smaller move. Why: an unverified smaller bump would trade a proven fix for a guess, and 1.62.1 is `latest` with a matching `-jammy` image. Disposition: no action needed — the issue explicitly says the smallest-possible-move question only needs answering if the implementer wants it.
- **Class: acceptance criterion discharged by a finding rather than a demonstration.** Said: show the CI browser cache saving and hitting. Did: recorded the finding above instead. Why: the cache does not exist on `main`. Disposition: the issue's own criterion sanctions this fork; the demonstration belongs to #5169.
- **Class: a pre-existing test failure I did not fix.** Said: nothing. Did: the first pre-push hook run reported one failing unit test in the fate-live suite (a `Post:post-clobber` case) out of 2424; a re-run of the same command found no changed test files and the second push was clean. Why: the diff touches no `apps/web` code, so this is unrelated flake, not a regression from the bump. Disposition: for the reviewer to judge — flagged here rather than silently swallowed.