### PR TITLE
fix(fabrika): walk check 8 in handoff/contract.md's completeness self-test

### DIFF
--- a/claude-plugins/fabrika/skills/handoff/contract.md
+++ b/claude-plugins/fabrika/skills/handoff/contract.md
@@ -1006,6 +1006,51 @@ no `origin`, which degrades rather than blocks.
    sixteen of those nineteen that a successor can observe (see *What `read` re-derives*). Nonces,
    comment ids and SHAs are declared in the header as grammar-conforming
    placeholders, which is the *no example value* branch of the rule rather than a claimed derivation.
+8. **Every outcome the verb can reach has a code** — walked below one verb at a time, over *states*
+   rather than over codes, because check 3 can only see what the tables already wrote down. The
+   universal seats are reachable from all four and are named once here instead of in every row: `1`
+   for a usage error or a verb that failed to run, `2` for an implementation that could not be
+   resolved, `127` for a verb that never ran. The walk was re-run against the shipped verbs
+   ([`src/handoff/`](../../../../packages/fabrika-cli/src/handoff/), #5025), so the codes below are
+   the ones the group actually seats rather than the ones this spec once intended.
+
+   - **`capture`.** The ground derived is `0` — `git.upstream: null`, `git.reachable: "unknown"` and
+     `board.pull: null` are values *inside* that answer, not outcomes of their own. The issue proven
+     absent is `7`. The default-branch read, any `git` read, and the pull-request or check-run read
+     failing are `11` each. A target repo that neither `--repo` nor the environment resolves is `1`:
+     nothing was read, so nothing was proven. The verb writes nothing, so no write, read-back or pack
+     state is reachable from it at all.
+   - **`take`.** A `--nonce` outside `^[0-9a-f]{8}$` is `1`. An fd 0 read that **failed** is `1` and
+     says the body is UNKNOWN — the base seats a failed read there in as many words
+     ([`src/report/codes.ts`](../../../../packages/fabrika-cli/src/report/codes.ts)) — while a pipe
+     that held nothing and a TTY with nothing piped in are both `3`. A section missing, out of order
+     or empty, and content outside the closed set, are `4`. A bare `@` reference is `6` and a
+     machine-local path is `5`, whichever half carried it. An unresolvable repo is `1`; the issue
+     absent is `7` and its read failing is `11`. The default-branch read, the capture, and the comment
+     page `supersedes` rests on are `11` when any fails. Work unreachable without
+     `--declare-unreachable` is `12`, whichever of the four messages prints. The comment write failing
+     is `8`, and the read-back **differing or not completing** is `9`. The pack sealed is `0`.
+   - **`read`.** An unresolvable repo is `1`; the issue absent is `7` and its read failing is `11`. A
+     comment page, a permission read, the packed branch resolving to neither a commit nor a proven
+     absence, and the live re-derivation are `11` when any fails. The latest pack failing to parse, or
+     its `groundDigest` disagreeing with the fields it labels, is `14`. All three `pack` tokens are
+     `0`, and everything the answer distinguishes below them — `drift.packedBranch`, `drift.state`,
+     each field's own state, each `disregarded` reason — is a closed-set value inside one answer
+     rather than a further outcome. One consequence worth stating: `packedBranch: "unknown"` is
+     refused as `11` before an answer is composed, so it is a member of that closed set the JSON never
+     prints.
+   - **`claim`.** A `--nonce` outside the grammar is `1`, and so is an unresolvable repo. The issue
+     absent is `7` and its read failing is `11`; a comment page or a permission read that did not
+     complete is `11`. No sealed pack is `13`, a malformed latest pack is `14`, and a pack another
+     nonce holds is `15`. A pack **this** nonce already holds is `0` (`resumed`, and no second comment
+     is posted). The write failing is `8`, its read-back differing or not completing is `9`, and the
+     claim landing and reading back is `0` (`held`).
+
+   The walk finds no reachable state without a code, so nothing is added to the matrix. What it adds
+   is the two states that seat on the universal `1` and were written down nowhere: a target repo that
+   does not resolve, and an fd 0 read that failed. Both are *the verb failed to run* rather than an
+   outcome the verb proved, which is why `1` is the right seat and why naming them is the whole point
+   of check 8 — a state the spec never mentions is exactly the one check 3 cannot see.
 
 **Every value a later verb needs arrives as an argument.** `--nonce` is authored by the caller and
 passed to `take` and `claim`, never inferred; `--issue` addresses every verb; `--base` is threaded


### PR DESCRIPTION
The `handoff` CLI contract ends with a self-test that walks the completeness test one check at a time. That test grew an eighth check — *every outcome the verb can reach has a code* — and the self-test still stopped at seven, so it claimed completeness against a test it did not finish. This adds the missing item: a walk of every state `capture`, `take`, `read` and `claim` can reach, and the exit code each one seats.

The walk found no reachable state without a code, so the exit matrix is unchanged. What it did surface is two states nothing had written down — a target repo that does not resolve, and an fd 0 read that failed — both of which correctly land on `1` (*the verb failed to run*), and both of which are now named instead of left implicit.

Fixes #5338

## What changed

- `claude-plugins/fabrika/skills/handoff/contract.md` → `## Self-test against the completeness test` gains item **8**, one sub-bullet per verb naming its reachable states and the code each seats.

## How the walk was grounded

The four verbs shipped after this contract was written (#5025, `packages/fabrika-cli/src/handoff/`), so every state below was read off the implementation rather than inferred from the spec: `capture-verb.ts`, `take-verb.ts`, `read-verb.ts`, `claim-verb.ts`, `guards.ts`, `packs.ts`, plus `src/report/codes.ts` for the base seats and `src/verb.ts` for the reserved ones.

Three facts the walk pinned down that the prose had left ambiguous:

- A **failed** stdin read is `1`, not `3` — `src/report/codes.ts` rules it there in as many words, and `take-verb.ts` follows it. An empty pipe and a TTY with nothing piped in are both `3`.
- A read-back that **could not be performed** seats on `9` alongside one that differs, in both `take` and `claim`.
- `drift.packedBranch: "unknown"` is refused as `11` before an answer is composed, so it is a member of that closed set the JSON never prints.

## Acceptance criteria

- [x] The section carries a check-8 item, so it walks all eight checks.
- [x] The item names, per verb, the states reached and the code each seats — not a bare "all outcomes have codes".
- [x] No reachable state was found without a code, so `### The shared exit matrix` and the per-verb Errors/Exit-status tables are untouched.
- [x] Grepped at fix time: `Self-test against the completeness test` matches exactly one file under `claude-plugins/`.

## Deviations

**Class: narrowed the fix shape.** Said: the issue allowed for outcome (2), a reachable state with no code, which would grow the exit matrix. Did: the walk found no such state, so no code was added and no table changed. Why: inventing a code where the shipped verbs already seat every state would put the spec ahead of the implementation, which is the drift this campaign is closing. Disposition: no action needed — outcome (1) of the two the issue named.

**Class: left a sibling defect for a follow-up.** Said: nothing about the contract's other claims. Did: while grounding the walk I noticed two places where the contract describes behaviour the shipped verbs do not have — the `--repo` default is documented as the `origin` remote only, where `command.ts` resolves `$CLAUDE_PIPELINE_REPO`, then `$GITHUB_REPOSITORY`, then `origin`; and `drift.packedBranch` is called a closed set of three where `unknown` never reaches stdout. Why: both sit outside this issue's acceptance criteria, which scope the diff to the self-test section. Disposition: the second is stated inside the new check-8 item so it is not lost; both are filed as a follow-up (see the progress comment on #5338).