### PR TITLE
fix(fabrika): seat `report dedup`'s two exit codes in the group table (#5296)

### DIFF
--- a/claude-plugins/fabrika/docs/cli-interface-convention.md
+++ b/claude-plugins/fabrika/docs/cli-interface-convention.md
@@ -134,8 +134,9 @@ exit taxonomy, and the verdict-vs-invocation rule proven in v1 at
   - **Per verb, no shared table** — the `3`+ row above read literally. Permitted, and today shipped
     nowhere: `adr` was the standing example until its five verbs seated `NO_SUBJECT` on two numbers
     and `3` on four meanings, which is what the shape costs when a group's verbs *do* share refusal
-    meanings (#5294). What survives of it is `report dedup`, whose two codes sit outside its group's
-    table — the residue tracked by #5296.
+    meanings (#5294). `report dedup` was the last residue and is gone too: its two codes moved into
+    the group table, and a check over every verb file now reds on the shape
+    ([#5296](https://github.com/kamp-us/phoenix/issues/5296)).
   - **Per group, one shared table** — `report`, `triage`, `review`, `adr`, `spend` and `wire` each ship a
     `<group>/codes.ts` that every verb in the group allocates from, so a code means one thing across
     the group whichever verb produced it. That is a **tightening** a group chooses, not a further

--- a/claude-plugins/fabrika/skills/report/contract.md
+++ b/claude-plugins/fabrika/skills/report/contract.md
@@ -241,10 +241,15 @@ server-side on title *or* body, so it is kept regardless.
 |---|---|
 | `0` | an outcome token was produced on stdout |
 | `1` | usage error, the target repo could not be resolved, or the verb failed to run |
-| `3` | the intake queue could not be read, so the outcome is UNKNOWN |
-| `4` | the search index could not be read, so the outcome is UNKNOWN |
+| `7` | `--label` does not exist in `--repo`, so the queue half would scan nothing |
+| `27` | the intake queue could not be read, so the outcome is UNKNOWN |
+| `28` | the search index could not be read, so the outcome is UNKNOWN |
 
-**When both reads fail, exit `3`.** The queue is the load-bearing half — it is the one that catches
+`27` and `28` sit above the writing verbs' `3`-`11` band because they are this group's codes too, and
+a code means one thing per group: `3` is an empty stdin and `4` is a bad section set, whichever verb
+produced them ([#5296](https://github.com/kamp-us/phoenix/issues/5296)).
+
+**When both reads fail, exit `27`.** The queue is the load-bearing half — it is the one that catches
 an issue filed seconds ago — so its failure is the one reported, and the stderr line names both
 failures so neither is hidden by the precedence.
 
@@ -252,17 +257,23 @@ failures so neither is hidden by the precedence.
 
 | Message (stderr) | Code | Kind |
 |---|---|---|
-| `report dedup: cannot read the <label> queue in <repo>: <reason> — the outcome is UNKNOWN, never "none".` | 3 | refusal |
-| `report dedup: cannot read the search index for <repo>: <reason> — the outcome is UNKNOWN, never "none".` | 4 | refusal |
+| `report dedup: cannot read the label set of <repo>: <reason> — whether the <label> queue exists is UNKNOWN, and so is the outcome.` | 27 | refusal |
+| `report dedup: cannot read the <label> queue in <repo>: <reason> — the outcome is UNKNOWN, never "none".` | 27 | refusal |
+| `report dedup: cannot read the search index for <repo>: <reason> — the outcome is UNKNOWN, never "none".` | 28 | refusal |
+| `report dedup: <repo> has no "<label>" label — the queue half would scan nothing, so the outcome is UNKNOWN, never "none". Create the label, or pass the one this repo uses.` | 7 | refusal |
 | `report dedup: --query is empty.` | 1 | usage error |
+| `report dedup: --limit <n> is negative.` | 1 | usage error |
 | `report dedup: cannot resolve a target repo — set CLAUDE_PIPELINE_REPO, or run inside a checkout whose origin remote resolves.` | 1 | refusal |
+
+When the queue read fails and the search read fails together, the queue line carries
+` (the search index also failed: <reason>)` before its em dash.
 
 **Scope** — this verb **supplies an input; it does not judge**, so an empty result is a fact rather
 than a failed read, and it says so here once. The two halves are read for different reasons: the
 label queue is read-after-write consistent and catches an issue filed seconds ago, while the search
 index is eventually consistent — it lags fresh issues but reaches older open issues that have
 already left the queue. An empty intake queue is a normal state, so `none` at exit 0 is an answer;
-a queue or index that could not be read is exit 3 or 4 with **nothing** on stdout. The scope line
+a queue or index that could not be read is exit 27 or 28 with **nothing** on stdout. The scope line
 goes to stderr on every run, naming both source counts, the tokens actually used, and whether the
 list was truncated.
 
@@ -294,10 +305,13 @@ $ fabrika report dedup --query "retry helper abort reason" --json
 
 ```
 $ fabrika report dedup --query "retry helper abort reason" --repo kamp-us/nonexistent
-report dedup: cannot read the status:needs-triage queue in kamp-us/nonexistent: HTTP 404 — the outcome is UNKNOWN, never "none".
+report dedup: cannot read the label set of kamp-us/nonexistent: HTTP 404 — whether the status:needs-triage queue exists is UNKNOWN, and so is the outcome.
 $ echo $?
-3
+27
 ```
+
+The label-set read runs before either source read, so it is the one an unreachable repo fails on —
+the queue message needs a repo whose labels *did* read.
 
 **Grounding**
 

--- a/claude-plugins/fabrika/skills/review/contract.md
+++ b/claude-plugins/fabrika/skills/review/contract.md
@@ -109,8 +109,7 @@ Stated once rather than repeated per block.
 ### The shared exit taxonomy
 
 All eight verbs allocate from one internal table, so a code means one thing across *this group*.
-Repo-wide the same number does not — `wire`'s `3`–`8` are its own, and `report dedup`'s `3`/`4` are
-*queue unreadable* / *search index unreadable* (#5296) — but where this group's codes overlap
+Repo-wide the same number does not — `wire`'s `3`–`8` are its own — but where this group's codes overlap
 **`report`'s and `triage`'s writing verbs** (`3`, `5`, `6`,
 `7`, `8`, `9`, `11`) they match them deliberately, code for code, read from the **shipped
 package** (`packages/fabrika-cli/src/report/codes.ts`, `src/triage/codes.ts`), never from a

--- a/claude-plugins/fabrika/skills/triage/contract.md
+++ b/claude-plugins/fabrika/skills/triage/contract.md
@@ -131,16 +131,16 @@ Stated once rather than repeated per block.
 
 **All nine verbs allocate from one internal table**, so a code means one thing across *this group*.
 That is a property of this group and not of `fabrika`, and the difference matters to anyone driving
-more than one group: **repo-wide the same number does not mean the same thing.** Inside `report`
-itself, `dedup`'s `3` is *the queue could not be read* while `file`'s and `note`'s `3` is *stdin was
-read and held nothing* — one group, one number, two meanings (#5296).
+more than one group: **repo-wide the same number does not mean the same thing.** `wire`'s `3` is
+*the format's block is provably not in the artifact*, where `report`'s and this group's is *stdin was
+read and held nothing*.
 
 Where this group's codes overlap **`report`'s two writing verbs** (`3`, `5`, `6`, `7`, `8`, `9`,
 `10`, `11`) they match them **deliberately**, code for code, so a caller driving `report` and `triage`
-in one sweep reads one meaning. `report dedup` does not participate in it — the one cross-group
-difference a caller of both will actually hit is `dedup`'s
-`3` = *queue unreadable* / `4` = *search index unreadable*. This spec calls `dedup` (the `--exclude`
-extension below), so that difference is named here rather than left to be discovered at a call site.
+in one sweep reads one meaning. This spec calls `report dedup` (the `--exclude` extension below), and
+that verb reads from the same `report` table: `7` when `--label` is absent, `27`/`28` when the queue
+or the search index could not be read
+([#5296](https://github.com/kamp-us/phoenix/issues/5296)).
 
 | Code | Meaning | queue | claim | prov | homes | split | enrich | apply | park | kill |
 |---|---|:--:|:--:|:--:|:--:|:--:|:--:|:--:|:--:|:--:|
@@ -1806,12 +1806,11 @@ fabrika report dedup --query "sozluk definition editor loses focus" --exclude 43
 Everything else — the tokenizer, the two sources, the three outcome tokens — is unchanged from the
 implemented verb at `packages/fabrika-cli/src/report/dedup.ts` and its verb wrapper
 `dedup-verb.ts`. **This change adds no exit code, no error, and no output shape**: `candidates`,
-`none` and `indeterminate` all still exit 0, and the existing `1` / `3` / `4` / `7` are untouched.
+`none` and `indeterminate` all still exit 0, and the existing `1` / `7` / `27` / `28` are untouched.
 
-**`dedup`'s codes are its own, and they do not follow this group's table.** Its `3` is *the queue
-could not be read* and its `4` is *the search index could not be read* — the one cross-group
-difference named in the shared taxonomy above. A caller invoking `triage` verbs and this one in the
-same sweep reads them from two tables, deliberately: this extension does not renumber a shipped verb.
+**`dedup`'s codes come from the `report` table, not this group's.** `7` is a missing `--label`, and
+`27`/`28` are the queue and the search index read failing — numbers no `triage` verb speaks, so a
+caller invoking both in one sweep never has to ask which table a code came from.
 
 **Behaviour.** The excluded number is filtered from both the queue half and the search half **after**
 retrieval and **before** scoring and the cap, so excluding an issue never changes the rank order of

--- a/packages/fabrika-cli/README.md
+++ b/packages/fabrika-cli/README.md
@@ -232,8 +232,10 @@ Three properties of that substrate are worth knowing before the verbs arrive:
 - **All nine verbs allocate from one table** ([`src/triage/codes.ts`](./src/triage/codes.ts)),
   so a code means one thing across this group. Where it overlaps the two `report` writing
   verbs — `3`, `5`, `6`, `7`, `8`, `9`, `10`, `11` — the meanings match **code for code**, so
-  a caller driving both groups in one sweep reads one meaning. That alignment does not extend
-  repo-wide: `report dedup`'s own `3`/`4` are *queue unreadable* / *search index unreadable*
+  a caller driving both groups in one sweep reads one meaning. `report dedup` used to break that
+  inside its own group, seating *queue unreadable* / *search index unreadable* on `3`/`4` from a verb
+  file the alignment check could not see; they are `27`/`28` in the group table now, and a check over
+  every verb file keeps the next one from hiding the same way
   ([#5296](https://github.com/kamp-us/phoenix/issues/5296)).
 - **`4` is a deliberate gap.** It once fused "the target issue is proven absent" with "the
   target issue could not be read". `7` and `11` took the halves, and the slot is left

--- a/packages/fabrika-cli/src/exit-code-alignment.ts
+++ b/packages/fabrika-cli/src/exit-code-alignment.ts
@@ -475,3 +475,63 @@ export const verbLocalCodesIn = (groupDir: string): readonly string[] => {
 		)
 		.sort();
 };
+
+/** What a scan for verb-seated exit codes read, and what it found. Empty `seated` is the goal state. */
+export interface VerbSeatScan {
+	/** `*-verb.ts` files actually read. Zero proves nothing and is a throw, never an all-clear. */
+	readonly scanned: number;
+	/** `<group>/<file>: <operand>` for each `refuse(...)` whose code the file seats itself. */
+	readonly seated: readonly string[];
+}
+
+/** `refuse(<code>` — the first argument, across the line break the formatter puts after the paren. */
+const REFUSE_CODE = /\brefuse\(\s*([A-Za-z_$][\w$]*|\d+)/g;
+
+/** A numeric `const` the file declares, exported or not — the shape a verb-seated code takes. */
+const LOCAL_NUMBER = /^(?:export )?const ([A-Za-z_$][\w$]*)\s*=\s*-?\d/gm;
+
+/**
+ * Every exit code a verb file seats **itself** rather than naming from its group's table, over the
+ * groups that ship a table. That is `report dedup`'s defect: two codes declared in `dedup-verb.ts`,
+ * invisible to {@link checkAlignment} because it reads the table's module namespace, and colliding
+ * with the base's own `3` and `4` for two years of nobody reading both files at once (#5296).
+ *
+ * A code is seated here when `refuse(...)` is handed a numeric literal, or a name the same file
+ * declares as a number. That is deliberately narrower than {@link verbLocalCodesIn}'s shape-only
+ * read, which cannot be the repo-wide check: `review`'s `FREEZE_ROUND` and `triage`'s
+ * `DEFAULT_TTL_MINUTES` are numeric constants a verb file is entitled to declare, and only their use
+ * as an exit code would make them a seat. Reading the source is still the only way — an import and a
+ * declaration are the same export once the module is loaded.
+ *
+ * Throws on a scan that read no verb file. An all-clear over nothing is the vacuous pass ADR 0092
+ * forbids, and it is the shape a mistyped source root would produce first.
+ */
+export const verbSeatedExitCodes = (srcDir: string, groups: readonly string[]): VerbSeatScan => {
+	if (groups.length === 0) {
+		throw new ZeroCoverageScope("no verb group was named — nothing to scan (ADR 0092)");
+	}
+
+	const root = realpathSync(srcDir);
+	const seated = new Set<string>();
+	let scanned = 0;
+
+	for (const group of groups) {
+		const dir = join(root, group);
+		for (const file of readdirSync(dir).filter((name) => name.endsWith("-verb.ts"))) {
+			scanned += 1;
+			const source = readFileSync(join(dir, file), "utf8");
+			const local = new Set([...source.matchAll(LOCAL_NUMBER)].map((match) => match[1]));
+			for (const [, operand] of source.matchAll(REFUSE_CODE)) {
+				if (operand === undefined) continue;
+				if (/^\d+$/.test(operand) || local.has(operand)) seated.add(`${group}/${file}: ${operand}`);
+			}
+		}
+	}
+
+	if (scanned === 0) {
+		throw new ZeroCoverageScope(
+			`no *-verb.ts was found under ${srcDir} — nothing to scan (ADR 0092)`,
+		);
+	}
+	return {scanned, seated: [...seated].sort()};
+};

--- a/packages/fabrika-cli/src/exit-code-alignment.unit.test.ts
+++ b/packages/fabrika-cli/src/exit-code-alignment.unit.test.ts
@@ -1,3 +1,6 @@
+import {mkdirSync, mkdtempSync, writeFileSync} from "node:fs";
+import {tmpdir} from "node:os";
+import {join} from "node:path";
 import {fileURLToPath} from "node:url";
 import {describe, expect, it} from "vitest";
 import * as adr from "./adr/codes.ts";
@@ -13,6 +16,7 @@ import {
 	coverageGaps,
 	UNALIGNED_GROUPS,
 	UNTABLED_GROUPS,
+	verbSeatedExitCodes,
 	ZeroCoverageScope,
 } from "./exit-code-alignment.ts";
 import * as glossary from "./glossary/codes.ts";
@@ -143,6 +147,60 @@ describe("the untabled groups are genuinely untabled", () => {
 			...Object.keys(UNALIGNED_GROUPS),
 		]);
 		expect(Object.keys(UNTABLED_GROUPS).filter((name) => aligned.has(name))).toEqual([]);
+	});
+});
+
+/**
+ * The per-verb seat, pinned (#5296). `checkAlignment` reads a table's module namespace, so a code a
+ * verb file declares for itself is invisible to it — which is how the base group came to seat two
+ * meanings on `3` and two on `4` inside its own table.
+ */
+describe("no verb file seats an exit code its group's table does not", () => {
+	const onDisk = codeTableGroupsIn(SRC_DIR);
+
+	/** A throwaway source root: `<group>/codes.ts` plus whatever verb files a case needs. */
+	const stub = (verbs: Readonly<Record<string, string>>): string => {
+		const root = mkdtempSync(join(tmpdir(), "verb-seat-"));
+		mkdirSync(join(root, "ghost"));
+		writeFileSync(join(root, "ghost", "codes.ts"), "export const ZERO_SCOPE = 7;\n");
+		for (const [name, source] of Object.entries(verbs))
+			writeFileSync(join(root, "ghost", name), source);
+		return root;
+	};
+
+	it("reads verb files at all — a scan over nothing is a failure, not a pass (ADR 0092)", () => {
+		expect(verbSeatedExitCodes(SRC_DIR, onDisk).scanned).toBeGreaterThan(0);
+	});
+
+	it("finds none in any group that ships a table", () => {
+		expect(verbSeatedExitCodes(SRC_DIR, onDisk).seated).toEqual([]);
+	});
+
+	it("reds on a constant a verb file declares and refuses with", () => {
+		const root = stub({
+			"thing-verb.ts": "export const QUEUE_UNREADABLE = 3;\nrefuse(QUEUE_UNREADABLE, 'nope');\n",
+		});
+		expect(verbSeatedExitCodes(root, ["ghost"]).seated).toEqual([
+			"ghost/thing-verb.ts: QUEUE_UNREADABLE",
+		]);
+	});
+
+	it("reds on a bare number handed straight to `refuse`", () => {
+		const root = stub({"thing-verb.ts": "refuse(12, 'nope');\n"});
+		expect(verbSeatedExitCodes(root, ["ghost"]).seated).toEqual(["ghost/thing-verb.ts: 12"]);
+	});
+
+	it("passes a numeric constant the file never refuses with — a round count is not a seat", () => {
+		const root = stub({
+			"thing-verb.ts":
+				"const FREEZE_ROUND = 3;\nif (round >= FREEZE_ROUND) refuse(ZERO_SCOPE, 'x');\n",
+		});
+		expect(verbSeatedExitCodes(root, ["ghost"]).seated).toEqual([]);
+	});
+
+	it("throws rather than reporting none when there is nothing to scan (ADR 0092)", () => {
+		expect(() => verbSeatedExitCodes(SRC_DIR, [])).toThrow(ZeroCoverageScope);
+		expect(() => verbSeatedExitCodes(stub({}), ["ghost"])).toThrow(ZeroCoverageScope);
 	});
 });
 

--- a/packages/fabrika-cli/src/report/codes.ts
+++ b/packages/fabrika-cli/src/report/codes.ts
@@ -43,3 +43,15 @@ export const CLASSIFIED = 10;
  * `1`, which would fuse an unreachable GitHub with a bad flag.
  */
 export const PRECONDITION_UNKNOWN = 11;
+/**
+ * The intake queue could not be read, so the outcome is UNKNOWN. `report dedup` only.
+ *
+ * Seated here rather than in `dedup-verb.ts`, where it sat on `3` and meant a second thing the group
+ * already spoke for (#5296). The number is the jump it looks like: `12`-`26` are densely allocated as
+ * *private* codes by the groups that align to this table, and a base seat inside that range reds
+ * every group holding it — so `27` is the lowest number that collides with nothing. The band beyond
+ * is not reserved; the alignment check is what keeps a later group off these two.
+ */
+export const QUEUE_UNREADABLE = 27;
+/** The search index could not be read, so the outcome is UNKNOWN. `report dedup` only. */
+export const SEARCH_UNREADABLE = 28;

--- a/packages/fabrika-cli/src/report/command.ts
+++ b/packages/fabrika-cli/src/report/command.ts
@@ -89,7 +89,7 @@ const dedup = leafCommand(
 ).pipe(
 	Command.withShortDescription("Rank the open issues that may already cover an observation."),
 	Command.withDescription(
-		'Rank the open issues that may already cover an observation. First stdout line is the outcome token — candidates | none | indeterminate — and ALL THREE exit 0; a candidates list adds one `<number>\\t<source>\\t<score>\\t<title>` line per entry. Exits 3 (queue unreadable), 4 (search index unreadable), 7 (--label does not exist, so the queue half would scan nothing). Example: fabrika report dedup --query "retry helper swallows the abort reason" --exclude 4312',
+		'Rank the open issues that may already cover an observation. First stdout line is the outcome token — candidates | none | indeterminate — and ALL THREE exit 0; a candidates list adds one `<number>\\t<source>\\t<score>\\t<title>` line per entry. Exits 7 (--label does not exist, so the queue half would scan nothing), 27 (queue unreadable), 28 (search index unreadable). Example: fabrika report dedup --query "retry helper swallows the abort reason" --exclude 4312',
 	),
 );
 

--- a/packages/fabrika-cli/src/report/dedup-verb.ts
+++ b/packages/fabrika-cli/src/report/dedup-verb.ts
@@ -14,18 +14,14 @@ import {Effect} from "effect";
 import type {ChildProcessSpawner} from "effect/unstable/process";
 import {listLabels, openIssuesWithLabel, resolveRepo, searchOpenIssues} from "../io/issues.ts";
 import {answer, FAILED, refuse, type VerbOutcome} from "../verb.ts";
-import {NO_TARGET} from "./codes.ts";
+import {NO_TARGET, QUEUE_UNREADABLE, SEARCH_UNREADABLE} from "./codes.ts";
 import {rank, renderCandidate, tokenize} from "./dedup.ts";
 
-/** The intake queue could not be read, so the outcome is UNKNOWN. */
-export const QUEUE_UNREADABLE = 3;
-/** The search index could not be read, so the outcome is UNKNOWN. */
-export const SEARCH_UNREADABLE = 4;
 /**
  * `--label` does not exist in `--repo`, so the queue half has **no scope** — and a scope of zero
  * cannot produce a proven negative.
  *
- * Not in the contract's exit table, and reported as a spec defect on #4752: a missing label is not
+ * Reported as a spec defect on #4752: a missing label is not
  * a transport error, so `GET /issues?labels=<missing>` answers HTTP 200 with `[]` and never reaches
  * {@link QUEUE_UNREADABLE}. It lands on the success path, where an empty queue is read as a fact,
  * and the verb prints `none` — a proven negative over nothing scanned, which ADR 0092 forbids. The

--- a/packages/fabrika-cli/src/report/dedup-verb.unit.test.ts
+++ b/packages/fabrika-cli/src/report/dedup-verb.unit.test.ts
@@ -1,8 +1,8 @@
 import {Effect} from "effect";
 import {describe, expect, it} from "vitest";
 import {errOut, fakeShell, okOut} from "../fakes.test-support.ts";
-import {NO_TARGET} from "./codes.ts";
-import {QUEUE_UNREADABLE, runDedup, SEARCH_UNREADABLE} from "./dedup-verb.ts";
+import {NO_TARGET, QUEUE_UNREADABLE, SEARCH_UNREADABLE} from "./codes.ts";
+import {runDedup} from "./dedup-verb.ts";
 
 const LABELS = /repos\/o\/r\/labels/;
 const QUEUE = /repos\/o\/r\/issues\?state=open/;

--- a/packages/fabrika-cli/src/triage/codes.ts
+++ b/packages/fabrika-cli/src/triage/codes.ts
@@ -12,8 +12,8 @@
  * `triage` in one sweep reads one meaning and a drift between the two is unrepresentable rather than
  * merely detectable (`../review/codes.ts` set the precedent; `../exit-code-alignment.ts` owns the
  * policy and checks the direction an import cannot cover — that the codes added below clear
- * `report`'s whole table). That alignment does **not** extend repo-wide: `report dedup`'s own
- * `3`/`4` are *queue unreadable* / *search index unreadable* (#5296).
+ * `report`'s whole table). That alignment does **not** extend repo-wide: `wire` allocates `3`-`6`
+ * for facts about an artifact, so its `3` is *the format's block is provably not in it*.
  *
  * **`4` is a deliberate gap, not a free slot.** It once held "the target issue does not exist, or is
  * not readable" — a proven fact and an unknown fused into one code. {@link ZERO_SCOPE} and


### PR DESCRIPTION
`report dedup` had two of its own exit codes written into `dedup-verb.ts` on `3` and `4` — the same two numbers `report file` and `report note` already use for "stdin was empty" and "a section is missing". So inside one group a caller reading `$?` got two answers per number. The alignment checker could not see it, because it reads a table's exports and a constant in a verb file is not one of them.

The two codes move into `report/codes.ts` on `27`/`28`, and a new check reads every verb file in every group that ships a table and reds when one seats an exit code itself. The docs that quoted `3`/`4` move with them.

## What changed

- `packages/fabrika-cli/src/report/codes.ts` seats `QUEUE_UNREADABLE = 27` and `SEARCH_UNREADABLE = 28`; `dedup-verb.ts` imports them the way it already imports `NO_TARGET`. `27`/`28` are the lowest pair free of both the base's `3`-`11` band and every aligning group's private codes (`12`-`26` are densely allocated — `ledger` reaches `26`), so `checkAlignment` stays green for all 21 entries in `ALIGNED_GROUPS`.
- `exit-code-alignment.ts` gains `verbSeatedExitCodes(srcDir, groups)`: for each `*-verb.ts` in a tabled group it flags a `refuse(...)` handed a numeric literal, or a name the same file declares as a number. It reports what it scanned and throws `ZeroCoverageScope` on a scan that read no verb file (ADR 0092).
- The detection is deliberately narrower than the existing `verbLocalCodesIn`, which matches any numeric `export const`. That shape cannot be the repo-wide check: `review`'s `FREEZE_ROUND` and `triage`'s `DEFAULT_TTL_MINUTES` are numeric constants a verb file is entitled to declare, and only their use as an exit code makes them a seat.
- Tests: three seeded cases in `exit-code-alignment.unit.test.ts` prove the check reds on a declared-and-refused constant and on a bare number, passes a numeric constant the file never refuses with, and throws on an empty scan. `dedup-verb.unit.test.ts` now imports both codes by name from `./codes.ts`.
- Docs: the `report dedup` help string, the exit + error tables in `claude-plugins/fabrika/skills/report/contract.md`, and the note in `packages/fabrika-cli/README.md`.

## Deviations

**Class: scope narrowed / widened beyond the stated ACs.**
Said: the ACs name three documented surfaces to move. Did: also corrected four more that asserted the old numbers or the defect as standing — `packages/fabrika-cli/src/triage/codes.ts`, `claude-plugins/fabrika/skills/review/contract.md`, two passages in `claude-plugins/fabrika/skills/triage/contract.md`, and `claude-plugins/fabrika/docs/cli-interface-convention.md` (which tracked `report dedup` as "the residue tracked by #5296"). Why: each one names `dedup`'s `3`/`4` as the one cross-group difference a caller will hit; after this change that sentence is false everywhere it appears. Disposition: no action needed — leaving them would ship a fixed defect with five docs still describing it.

**Class: corrected a document beyond renumbering.**
Said: move the exit-table rows. Did: also grounded the `report dedup` error table and its worked example against the shipped verb. Three rows were missing (`7` for an absent `--label`, the label-set read failing at what is now `27`, and `--limit` negative), and the failure example quoted the queue-read message for an unreachable repo — but `listLabels` runs first, so that repo fails on the label-set read and emits a different line. Why: the dispatch required every row to quote bytes the code actually emits. Disposition: no action needed; the rows now match `dedup-verb.ts` verbatim.

**Class: left a sibling observation for later.**
Said: nothing. Did: noted but did not change that `27`/`28` sit above the aligning groups' private band, so a group extending past `26` will collide with the base. Why: the alignment check reds on exactly that, loudly, and reserving a distant band would be an arbitrary choice no rule protects. Disposition: for the reviewer to judge.

Fixes #5296