### PR TITLE
fix(fabrika): refuse a catalog `pattern anchor` cannot read, instead of answering

### DIFF
--- a/claude-plugins/fabrika/skills/write-pattern/contract.md
+++ b/claude-plugins/fabrika/skills/write-pattern/contract.md
@@ -505,8 +505,16 @@ fabrika pattern anchor worker-queue-retry [--dir <path>] [--manifest <path>] [--
    yields `@nkzw/fate` and `1.3.1`, where a first-`@` split would yield an empty package name. A token
    with no `@`, or whose split yields an empty half, is reported `malformed` and counted, never
    guessed at.
-3. **Resolve the pin.** Look `<package>` up as a key of the manifest's top-level `catalog:` map. A key
-   that is absent is `unpinned`.
+3. **Resolve the pin.** Look `<package>` up as a key of the manifest's top-level `catalog:` map, read
+   as a block map of scalar pins. A key that is absent is `unpinned`.
+
+   **A catalog that is there and could not be read is exit `11`, never `unpinned`.** Three shapes are
+   outside what this reader comprehends — a flow map (`catalog: {…}`), a nested sub-map under a key,
+   and a named-catalog `catalogs:` block — and each of them parses as YAML, so none can be told apart
+   from a real read by parse success alone. Answering anyway produced two confident wrong answers:
+   the flow map and `catalogs:` both read as *no catalog at all* (`unpinned` for every declaration),
+   and the sub-map pinned its key to the empty string, which compares unequal to every declared
+   version and reported `moved` against a pin nobody wrote (#5361). All three refuse instead.
 4. **Compare.** `<version>` against the pinned value, **byte for byte**, with no semver
    interpretation. A doc's anchor records the version its author actually read; accepting a range
    would silently bless a version nobody checked, which is the whole failure the line exists to catch.
@@ -570,14 +578,16 @@ With `--json`, one object with keys `outcome`, `declared`, `moved`, `unpinned`, 
 |---|---|---|
 | `pattern anchor: cannot fetch <ref>: <reason> — the outcome is UNKNOWN, never "matched".` | 11 | refusal |
 | `pattern anchor: cannot read <manifest> at <ref>: <reason> — every pin is UNKNOWN, never "unpinned".` | 11 | refusal |
-| `pattern anchor: <manifest> at <ref> does not parse as YAML: <reason> — every pin is UNKNOWN, never "unpinned".` | 11 | refusal |
+| `pattern anchor: cannot read the catalog in <manifest> at <ref>: <reason> — every pin is UNKNOWN, never "unpinned".` | 11 | refusal |
 | `pattern anchor: no doc for slug "<slug>" under <dir>, in the working tree or at <ref>.` | 12 | refusal |
 | `pattern anchor: slug "<slug>" is not kebab-case (lowercase letters, digits and single hyphens).` | 1 | usage error |
 
-**A manifest that reads but does not parse is UNKNOWN too** (exit `11`), for the same reason. A
-manifest that parses and carries **no `catalog:` map** is the degrade path instead: every declaration
-reports `unpinned` at exit `0` with the absence named on stderr, because a repo that pins nothing
-centrally is a fact about that repo rather than a failed read.
+**A manifest that reads but whose catalog this verb could not read is UNKNOWN too** (exit `11`), for
+the same reason — including the three comprehensible-YAML shapes in step 3. A manifest that carries
+**no `catalog:` key at all** is the degrade path instead: every declaration reports `unpinned` at exit
+`0` with the absence named on stderr, because a repo that pins nothing centrally is a fact about that
+repo rather than a failed read. The two are not interchangeable: the degrade line names an absence,
+so it is never printed for a manifest that does carry a catalog.
 
 **An unreadable manifest is UNKNOWN and never `unpinned`.** The two are one keystroke apart in
 consequence: `unpinned` says the repo does not carry this dependency, and a failed read says nothing

--- a/packages/fabrika-cli/src/pattern/anchor-verb.ts
+++ b/packages/fabrika-cli/src/pattern/anchor-verb.ts
@@ -5,9 +5,10 @@
  * A separate verb rather than a mode of `pattern drift` because the git half and the dependency half
  * go stale independently. **An unreadable manifest is UNKNOWN and never `unpinned`:** the two are one
  * keystroke apart in consequence — `unpinned` says the repo does not carry this dependency, and a
- * failed read says nothing at all. A manifest that is genuinely absent, or that parses and carries no
- * `catalog:` map, is the degrade path instead: every declaration reports `unpinned` at exit `0` with
- * the absence named on stderr.
+ * failed read says nothing at all. A manifest that is genuinely absent, or that carries no `catalog:`
+ * key at all, is the degrade path instead: every declaration reports `unpinned` at exit `0` with the
+ * absence named on stderr. A manifest that *does* carry a catalog this reader cannot comprehend is
+ * UNKNOWN, never that degrade path — see `parseCatalog`.
  */
 import {Effect, type FileSystem, Result} from "effect";
 import type {ChildProcessSpawner} from "effect/unstable/process";
@@ -159,7 +160,7 @@ export const runAnchor = (
 			if (parsed._tag === "Unparseable") {
 				return refuse(
 					PRECONDITION_UNKNOWN,
-					`pattern anchor: ${manifest} at ${base} does not parse as YAML: ${parsed.reason} — every pin is UNKNOWN, never "unpinned".`,
+					`pattern anchor: cannot read the catalog in ${manifest} at ${base}: ${parsed.reason} — every pin is UNKNOWN, never "unpinned".`,
 				);
 			}
 			if (parsed.catalog === null) degraded = `${manifest} at ${sha} carries no catalog: map`;

--- a/packages/fabrika-cli/src/pattern/anchor-verb.unit.test.ts
+++ b/packages/fabrika-cli/src/pattern/anchor-verb.unit.test.ts
@@ -105,7 +105,33 @@ describe("runAnchor", () => {
 	it("refuses a manifest that does not parse as YAML", async () => {
 		const out = await run([[/^git show \w+:\S+\.yaml$/, okOut("catalog:\n\tacme-queue: 4.2.0\n")]]);
 		expect(out.code).toBe(PRECONDITION_UNKNOWN);
-		expect(out.stderr.at(-1)).toContain("does not parse as YAML");
+		expect(out.stderr.at(-1)).toContain("indents with a tab");
+	});
+
+	// #5361's three shapes, at the exit code a caller actually reads. Each parses as YAML and each
+	// carries a catalog the reader does not comprehend, so the verb refuses instead of answering —
+	// and in particular never claims the manifest "carries no catalog: map".
+	const manifest = (yaml: string): Script => [[/^git show \w+:\S+\.yaml$/, okOut(yaml)]];
+
+	it("refuses an inline flow map instead of answering `unpinned`", async () => {
+		const out = await run(manifest("catalog: {acme-queue: 4.2.0}\n"));
+		expect(out.code).toBe(PRECONDITION_UNKNOWN);
+		expect(out.stdout).toBe("");
+		expect(out.stderr.join("\n")).not.toContain("carries no catalog: map");
+	});
+
+	it("refuses a nested sub-map instead of answering `moved` against an empty pin", async () => {
+		const out = await run(manifest("catalog:\n  acme-queue:\n    version: 4.2.0\n"));
+		expect(out.code).toBe(PRECONDITION_UNKNOWN);
+		expect(out.stdout).toBe("");
+		expect(out.stderr.at(-1)).toContain("pins no version");
+	});
+
+	it("refuses a named-catalog block instead of reading it as no catalog at all", async () => {
+		const out = await run(manifest("catalogs:\n  default:\n    acme-queue: 4.2.0\n"));
+		expect(out.code).toBe(PRECONDITION_UNKNOWN);
+		expect(out.stdout).toBe("");
+		expect(out.stderr.join("\n")).not.toContain("carries no catalog: map");
 	});
 
 	// The degrade path: a repo that pins nothing centrally is a fact about that repo, not a failure.

--- a/packages/fabrika-cli/src/pattern/anchor.ts
+++ b/packages/fabrika-cli/src/pattern/anchor.ts
@@ -37,15 +37,26 @@ export const declarationLinesIn = (text: string): ReadonlyArray<string> =>
 
 export type CatalogRead =
 	| {readonly _tag: "Ok"; readonly catalog: Readonly<Record<string, string>> | null}
+	/** The reader could not comprehend the manifest's catalog — UNKNOWN, never a pin and never `null`. */
 	| {readonly _tag: "Unparseable"; readonly reason: string};
 
+/** Enough of an offending line to find it, on one line and clamped. */
+const lineEcho = (line: string): string =>
+	line
+		.trim()
+		.replace(/[\t\n\r]+/g, " ")
+		.slice(0, 80);
+
 /**
- * The manifest's top-level `catalog:` map.
+ * The manifest's top-level `catalog:` map, as a block map of scalar pins.
  *
  * `catalog: null` is the **degrade** path, not a failure: a repo that pins nothing centrally is a
- * fact about that repo, so every declaration reports `unpinned` at exit `0`. Only a manifest that
- * does not parse is UNKNOWN — the `7`/`11` split, applied to a file: a missing key is a verdict, an
- * unreadable document is a verdict about nothing.
+ * fact about that repo, so every declaration reports `unpinned` at exit `0`. Every other shape this
+ * reader cannot comprehend — a flow map (`catalog: {…}`), a nested sub-map under a key, a
+ * named-catalog `catalogs:` block — is UNKNOWN, **not** the degrade path: it is a map that is there
+ * and was not read, so answering `unpinned` would be a confident wrong answer where the caller
+ * deserves a refusal (#5361). The `7`/`11` split, applied to a file: a missing key is a verdict, a
+ * document this reader could not read is a verdict about nothing.
  */
 export const parseCatalog = (text: string): CatalogRead => {
 	const lines = text.split("\n");
@@ -54,8 +65,22 @@ export const parseCatalog = (text: string): CatalogRead => {
 			return {_tag: "Unparseable", reason: `line ${at + 1} indents with a tab, which YAML forbids`};
 		}
 	}
-	const start = lines.findIndex((line) => /^catalog:\s*(#.*)?$/.test(line));
+	const named = lines.findIndex((line) => /^catalogs:/.test(line));
+	if (named !== -1) {
+		return {
+			_tag: "Unparseable",
+			reason: `line ${named + 1} opens a named-catalog "catalogs:" block, which this reader does not interpret`,
+		};
+	}
+	const start = lines.findIndex((line) => /^catalog:/.test(line));
 	if (start === -1) return {_tag: "Ok", catalog: null};
+	const header = lines[start] ?? "";
+	if (!/^catalog:\s*(#.*)?$/.test(header)) {
+		return {
+			_tag: "Unparseable",
+			reason: `line ${start + 1} carries "catalog:" with inline content (\`${lineEcho(header)}\`), which this reader does not interpret`,
+		};
+	}
 
 	const catalog: Record<string, string> = {};
 	for (let at = start + 1; at < lines.length; at += 1) {
@@ -69,7 +94,17 @@ export const parseCatalog = (text: string): CatalogRead => {
 				reason: `line ${at + 1} sits under catalog: and is not a key/value pair`,
 			};
 		}
-		catalog[m[1].replace(/^['"]|['"]$/g, "")] = m[2].replace(/^['"]|['"]$/g, "");
+		const version = m[2].replace(/^['"]|['"]$/g, "");
+		// An empty value heads a nested sub-map, whose children then land as sibling keys; a `{`/`[`
+		// value is a flow collection. Either way the key's pin is not this line, and storing "" would
+		// compare unequal to every declared version and report `moved` against a pin nobody wrote.
+		if (version === "" || version.startsWith("{") || version.startsWith("[")) {
+			return {
+				_tag: "Unparseable",
+				reason: `line ${at + 1} sits under catalog: and pins no version (\`${lineEcho(line)}\`)`,
+			};
+		}
+		catalog[m[1].replace(/^['"]|['"]$/g, "")] = version;
 	}
 	return {_tag: "Ok", catalog};
 };

--- a/packages/fabrika-cli/src/pattern/anchor.unit.test.ts
+++ b/packages/fabrika-cli/src/pattern/anchor.unit.test.ts
@@ -57,6 +57,42 @@ onlyBuiltDependencies:
 	it("refuses a catalog entry that is not a key/value pair", () => {
 		expect(parseCatalog("catalog:\n  - acme-queue\n")._tag).toBe("Unparseable");
 	});
+
+	// The three shapes of #5361: each one parses as YAML, none of them is read, and answering
+	// `catalog: null` or an empty-string pin would be a confident wrong answer rather than a refusal.
+	it("refuses an inline flow map rather than reading it as no catalog at all", () => {
+		expect(parseCatalog("catalog: {acme-queue: 4.2.0}\n")).toMatchObject({
+			_tag: "Unparseable",
+			reason: expect.stringContaining("inline content"),
+		});
+	});
+
+	it("refuses a nested sub-map rather than pinning the key to an empty string", () => {
+		expect(parseCatalog("catalog:\n  acme-queue:\n    version: 4.2.0\n")).toMatchObject({
+			_tag: "Unparseable",
+			reason: expect.stringContaining("pins no version"),
+		});
+	});
+
+	it("refuses an entry whose value is a flow collection", () => {
+		expect(parseCatalog("catalog:\n  acme-queue: {version: 4.2.0}\n")._tag).toBe("Unparseable");
+	});
+
+	it("refuses a named-catalog block rather than reading it as no catalog at all", () => {
+		expect(parseCatalog("catalogs:\n  default:\n    acme-queue: 4.2.0\n")).toMatchObject({
+			_tag: "Unparseable",
+			reason: expect.stringContaining("catalogs:"),
+		});
+	});
+
+	// Reading only the flat half of a manifest that also names catalogs would report `unpinned` for
+	// every package pinned through the named half — the same confident wrong answer, one level in.
+	it("refuses a manifest that carries both a flat catalog and a named-catalog block", () => {
+		expect(
+			parseCatalog("catalog:\n  acme-queue: 4.2.0\n\ncatalogs:\n  legacy:\n    acme-queue: 3.0.0\n")
+				._tag,
+		).toBe("Unparseable");
+	});
 });
 
 describe("resolveDeclarations", () => {


### PR DESCRIPTION
`fabrika pattern anchor` reads a workspace manifest's `catalog:` map to tell a pattern author whether a doc's `> Derived from ...` line has gone stale. On three manifest shapes it does not actually read, it answered anyway: a flow map (`catalog: {…}`) and a named-catalog `catalogs:` block both looked like "this repo pins nothing", and a nested sub-map pinned a package to the empty string, which then compares unequal to every declared version and reports `moved` against a pin nobody wrote.

All three parse fine as YAML, so parse success alone cannot tell a real read from a misread. Each one now refuses at exit `11 PRECONDITION_UNKNOWN` instead of handing the author a confident wrong answer. The two honest degrade paths are untouched: a flat `catalog:` map still reads, and a manifest with no `catalog:` key at all still reports every declaration `unpinned` at exit 0.

Fixes #5361

## What changed

- `packages/fabrika-cli/src/pattern/anchor.ts` — `parseCatalog` now returns `Unparseable` for a top-level `catalogs:` block, for a `catalog:` line carrying inline content, and for an entry whose value pins no version (an empty value heads a nested sub-map; a `{`/`[` value is a flow collection). The docblock states the widened invariant once, at the function it governs.
- `packages/fabrika-cli/src/pattern/anchor-verb.ts` — the refusal message is now `cannot read the catalog in <manifest> at <ref>: <reason>`; `does not parse as YAML` was no longer true of every case it covers. `runAnchor` already mapped `Unparseable` to `11`, so no new exit path was added.
- Tests — five `parseCatalog` cases and three `runAnchor` exit-code cases, one per shape, alongside the existing flat-catalog case. The `runAnchor` cases also assert `carries no catalog: map` is not printed for a manifest that does carry a catalog.
- `claude-plugins/fabrika/skills/write-pattern/contract.md` — the verb's spec: step 3 now states the refusal and why, and the error table carries the new message.

## Notes for the reviewer

- **No `pnpm-workspace.yaml` or lockfile change**, so this does not touch the surface PRs #5370 and #5374 are moving.
- On the issue's open question — read `catalogs:` or refuse it — this refuses. Reading only the flat half of a manifest that also names catalogs would report `unpinned` for every package pinned through the named half, which is the same wrong answer one level in; and merging named catalogs into one flat map loses the distinction when two of them pin the same package differently. A test covers the both-blocks-present manifest.
- The full `packages/fabrika-cli` suite (4298 tests), `pnpm typecheck` and `pnpm lint:worktree` are green.

## Deviations

1. **Scope — one extra refusal beyond the three reported shapes.** Said: refuse the flow map, the nested sub-map, and `catalogs:`. Did: also refuse a *per-entry* flow collection (`  acme-queue: {version: 4.2.0}`). Why: it is the same defect one level down and falls out of the same value check that catches the sub-map — leaving it in would have shipped a fourth confident wrong answer next to three fixes. Disposition: no action needed; covered by a test.
2. **Changed an existing test's assertion.** Said: nothing about the existing suite. Did: `refuses a manifest that does not parse as YAML` now asserts the stderr contains `indents with a tab` rather than `does not parse as YAML`, because the verb's message changed. Why: the old message claimed a YAML parse failure for cases that parse. Disposition: no action needed — the case still asserts the same tab manifest at the same exit code.
3. **Touched a skill-owned doc.** Said: fix the parser. Did: also updated `claude-plugins/fabrika/skills/write-pattern/contract.md`, the verb's written spec. Why: leaving the contract stating the old error message and the old degrade rule would make the spec wrong the moment this merged. Disposition: for the reviewer to judge whether this pulls the PR under a CODEOWNERS path.