### PR TITLE
fix(fabrika-cli): read the pattern fixture bytes from the fixtures, never copy them

### DIFF
--- a/packages/fabrika-cli/README.md
+++ b/packages/fabrika-cli/README.md
@@ -610,11 +610,10 @@ The group emits the `governance` namespace through the shipped
 
 ## The `pattern` group
 
-The contract is the `write-pattern` skill's derived CLI contract, landing with
-[PR #5333](https://github.com/kamp-us/phoenix/pull/5333) at
-`claude-plugins/fabrika/skills/write-pattern/contract.md`. A **pattern doc** is one flat
-`<slug>.md` under a doc directory (`.patterns` by default), registered by one row in that
-directory's `index.md`.
+The contract these five implement is
+[`claude-plugins/fabrika/skills/write-pattern/contract.md`](../../claude-plugins/fabrika/skills/write-pattern/contract.md).
+A **pattern doc** is one flat `<slug>.md` under a doc directory (`.patterns` by default),
+registered by one row in that directory's `index.md`.
 
 | Verb | Answers |
 |---|---|

--- a/packages/fabrika-cli/src/pattern/fixtures.test-support.ts
+++ b/packages/fabrika-cli/src/pattern/fixtures.test-support.ts
@@ -6,70 +6,50 @@
  * output. Scripting **those bytes** reproduces the examples through the same seam production uses,
  * and it does so without a checkout: a test that shelled out to a real repository would be asserting
  * against that repository's history rather than against the spec.
+ *
+ * The bytes are read FROM the fixture files, never copied beside them (#5362). A copy is a fact that
+ * goes stale without telling anyone — `PLAIN_DOC` shipped 93 bytes against a 179-byte file and
+ * nothing red — so the file on disk is the one source, and a fixture that moved or emptied fails the
+ * read loudly rather than scripting the seam with nothing.
+ *
+ * What each fixture is for is stated in the fixture's own opening prose; read the file rather than a
+ * gloss of it here.
  */
-
-/** `.../fixtures/anchored/worker-queue-retry.md` — two declarations, one moved, one unpinned. */
-export const ANCHORED_DOC = `# Worker queue retry
-
-The fixture behind \`pattern anchor\`'s \`moved\` outcome. It declares two anchors: one whose package the
-fixture manifest pins at a different version, and one the manifest does not carry at all.
-
-> Derived from \`acme-queue@4.1.0\` — re-verify on pin bump.
-
-> Derived from \`@acme/retry@2.0.0\` — re-verify on pin bump.
-`;
-
-/** `.../fixtures/anchored/plain-doc.md` — a doc that claims no anchor at all. */
-export const PLAIN_DOC = `# Plain doc
-
-The fixture behind \`pattern anchor\`'s \`unanchored\` outcome: a doc that declares no dependency anchor
-at all, which is the common case and a fact rather than a fault.
-`;
-
-/** `.../fixtures/anchored/workspace.yaml` — pins `acme-queue`, carries no `@acme/retry`. */
-export const FIXTURE_MANIFEST = `# Fixture manifest for \`pattern anchor\`'s examples. Not a real workspace.
-catalog:
-  acme-queue: 4.2.0
-  acme-telemetry: 9.9.1
-`;
-
-/** `.../fixtures/unanchored-doc/worker-queue-retry.md` — every pointer deliberately unfollowable. */
-export const UNANCHORED_DOC = `# Worker queue retry
-
-The fixture behind \`pattern drift\`'s \`unanchored\` outcome: a doc that cites no repo-root-relative
-path this verb can follow, so drift here is unanswerable rather than clean.
-
-Every pointer below is deliberately unfollowable — a bare basename, an app-relative fragment, and a
-glob — which is exactly the ambiguous shorthand the derivation leaves alone.
-
-- \`retry.ts\`
-- \`worker/queue/retry.ts\`
-- \`src/**/*.test.ts\`
-`;
-
-/** `.../fixtures/three-sections/index.md` — three sections, so the `present:` list is exact. */
-export const THREE_SECTIONS_INDEX = `# Patterns
-
-A three-section index fixture, so \`pattern register\`'s refusal example prints an exact list.
-
-## Index — services
-
-| Doc | Topic | Read when |
-|---|---|---|
-| [cache-invalidation.md](./cache-invalidation.md) | Cache keys and invalidation order | Touching a cached read |
-
-## Index — edge
-
-| Doc | Topic | Read when |
-|---|---|---|
-| [edge-session-cookies.md](./edge-session-cookies.md) | Session cookie parse and re-issue | Changing session handling |
-
-## Index — observability
-
-| Doc | Topic | Read when |
-|---|---|---|
-| [tracing-span-names.md](./tracing-span-names.md) | Span naming convention | Naming a new span |
-`;
+import {readFileSync} from "node:fs";
+import {fileURLToPath} from "node:url";
 
 /** The three fixture directory paths the contract's examples pass to `--dir`. */
 export const FIXTURES = "claude-plugins/fabrika/skills/write-pattern/evals/fixtures";
+
+/**
+ * An empty read is a failed read, never fixture bytes — `""` scripted onto the seam satisfies every
+ * assertion vacuously (ADR 0092). Kept separate from the read so the refusal is provable without an
+ * empty file in the tree.
+ */
+export const nonEmptyFixture = (relativePath: string, bytes: string): string => {
+	if (bytes.trim() === "") {
+		throw new Error(
+			`fixture ${FIXTURES}/${relativePath} read as empty — refusing to script the git seam with nothing`,
+		);
+	}
+	return bytes;
+};
+
+/**
+ * Resolved from this module rather than from the process cwd, the way the `wire` group resolves its
+ * committed index doc — the fixtures live in the checkout this file ships in, wherever vitest ran.
+ */
+export const fixtureBytes = (relativePath: string): string =>
+	nonEmptyFixture(
+		relativePath,
+		readFileSync(
+			fileURLToPath(new URL(`../../../../${FIXTURES}/${relativePath}`, import.meta.url)),
+			"utf8",
+		),
+	);
+
+export const ANCHORED_DOC = fixtureBytes("anchored/worker-queue-retry.md");
+export const PLAIN_DOC = fixtureBytes("anchored/plain-doc.md");
+export const FIXTURE_MANIFEST = fixtureBytes("anchored/workspace.yaml");
+export const UNANCHORED_DOC = fixtureBytes("unanchored-doc/worker-queue-retry.md");
+export const THREE_SECTIONS_INDEX = fixtureBytes("three-sections/index.md");

--- a/packages/fabrika-cli/src/pattern/fixtures.test-support.unit.test.ts
+++ b/packages/fabrika-cli/src/pattern/fixtures.test-support.unit.test.ts
@@ -1,0 +1,65 @@
+/**
+ * The binding, proven: this file is what makes the scripted bytes a *read* of the fixtures rather
+ * than a copy of them.
+ *
+ * A copy passes every test that consumes it, which is why the 93-versus-179-byte `PLAIN_DOC` drift
+ * lived unnoticed (#5362). So each case below induces a mismatch and asserts it reds: bytes that
+ * disagree with the file, a fixture that moved, and a fixture that reads as nothing.
+ */
+import {readFileSync} from "node:fs";
+import {fileURLToPath} from "node:url";
+import {describe, expect, it} from "vitest";
+import {
+	ANCHORED_DOC,
+	FIXTURE_MANIFEST,
+	FIXTURES,
+	fixtureBytes,
+	nonEmptyFixture,
+	PLAIN_DOC,
+	THREE_SECTIONS_INDEX,
+	UNANCHORED_DOC,
+} from "./fixtures.test-support.ts";
+
+/** The second reader — a plain read of the same file, so the assertion is not the code restated. */
+const onDisk = (relativePath: string): string =>
+	readFileSync(
+		fileURLToPath(new URL(`../../../../${FIXTURES}/${relativePath}`, import.meta.url)),
+		"utf8",
+	);
+
+const BOUND = [
+	["anchored/worker-queue-retry.md", ANCHORED_DOC],
+	["anchored/plain-doc.md", PLAIN_DOC],
+	["anchored/workspace.yaml", FIXTURE_MANIFEST],
+	["unanchored-doc/worker-queue-retry.md", UNANCHORED_DOC],
+	["three-sections/index.md", THREE_SECTIONS_INDEX],
+] as const;
+
+/**
+ * This block reds for one edit and says so plainly: a constant that stops being a read and goes back
+ * to being a literal that drifted. Fixture *content* drift cannot reach it any more — the constants
+ * follow the file — and a fixture that moves or empties reds louder still, at import.
+ */
+describe("every scripted constant is its fixture file, byte for byte", () => {
+	it.each(BOUND)("%s", (relativePath, scripted) => {
+		const real = onDisk(relativePath);
+		expect(scripted.length).toBe(real.length);
+		expect(scripted).toBe(real);
+	});
+});
+
+describe("the binding bites — an induced mismatch reds", () => {
+	it("reds when the scripted bytes and the file diverge by a single byte", () => {
+		expect(() => expect(`${PLAIN_DOC} `).toBe(onDisk("anchored/plain-doc.md"))).toThrow();
+	});
+
+	it("refuses a fixture that moved out from under the examples", () => {
+		// Rehearsed against the real tree: moving `plain-doc.md` away reds every file that imports
+		// these constants, at import, rather than scripting the seam with a stale copy.
+		expect(() => fixtureBytes("anchored/moved-away.md")).toThrow(/ENOENT/);
+	});
+
+	it("refuses a fixture that reads as empty rather than scripting the seam with nothing", () => {
+		expect(() => nonEmptyFixture("anchored/plain-doc.md", "\n")).toThrow(/read as empty/);
+	});
+});


### PR DESCRIPTION
The `fabrika pattern` tests fed their worked examples five chunks of fixture text that had been
typed out by hand, because the real fixture files were not on `main` yet. They are now, and one of
those chunks was already wrong (93 bytes where the file has 179) with nothing to catch it. This PR
makes the tests read the fixture files instead, so a fixture that changes, moves, or empties can no
longer diverge from what the examples claim.

Fixes #5362

## What changed

- `packages/fabrika-cli/src/pattern/fixtures.test-support.ts` — the five constants are now reads of
  `claude-plugins/fabrika/skills/write-pattern/evals/fixtures/`, resolved from the module (the
  `wire` group's committed-doc idiom) rather than from the process cwd. An empty read is refused
  rather than scripted onto the seam (ADR 0092), and a missing file throws at import.
- `packages/fabrika-cli/src/pattern/fixtures.test-support.unit.test.ts` — new. Asserts each constant
  is byte-identical to its file, and that the binding bites: a fixture that moved, a fixture that
  reads as empty, and a one-byte divergence each red.
- `packages/fabrika-cli/README.md` — the `pattern` section cites
  `claude-plugins/fabrika/skills/write-pattern/contract.md` by relative link, in the same shape as
  the other group sections, replacing the PR-URL workaround.

The `git show <ref>:<path>` seam is untouched: the same bytes still reach it through the same
scripted-command table, they are just no longer written by hand. No test shells out to a live
checkout.

## Verification

- `pnpm vitest run` in `packages/fabrika-cli`: 285 files / 4304 tests pass, `pattern.cli.test.ts`
  included.
- `pnpm typecheck`: 31/31 tasks green. `pnpm lint:worktree`: clean.
- Binding rehearsed against the real tree: moving `anchored/plain-doc.md` away reds both
  `fixtures.test-support.unit.test.ts` and `anchor-verb.unit.test.ts` with `ENOENT` at import
  (before this change they passed regardless). Appending a byte to that fixture now flows straight
  through to every consumer instead of drifting from a copy.

## Deviations

- **Class: narrowed a suggested fix-shape.** Said: the issue offered either reading from disk or
  keeping the constants plus a byte-equality test. Did: read from disk, and kept a byte-equality
  test alongside. Why: the disk read removes the drift class outright; the equality test stays as a
  regression guard against a future edit re-inlining a literal. Disposition: no action needed — the
  test file names, in a comment, the one edit that block can red for, so it is not read as a check
  that cannot fail.
- **Class: judgment call on what "reds on an induced mismatch" means here.** Said: AC2 asks for a
  test that reds on an induced mismatch. Did: with the bytes read from the file, content drift is
  unrepresentable, so the induced mismatches proven are the ones that remain — a fixture that moved
  (rehearsed live against the real tree), a fixture that reads as empty, and a one-byte divergence
  in the comparison itself. Disposition: for the reviewer to judge.