### PR TITLE
fix(fabrika): decouple a status config row's presence from its id token

### DIFF
--- a/claude-plugins/fabrika/skills/front-door/contract.md
+++ b/claude-plugins/fabrika/skills/front-door/contract.md
@@ -467,8 +467,12 @@ skill's own text states *"it is the same table in every fabrika skill, so one re
 them."* This verb is that reader.
 
 <a id="surface-ids"></a>**Surface ids are declared, never inferred.** A row's id is the
-`` `id:<slug>` `` token in its first cell; `<slug>` is `[a-z0-9-]+`. A row with no id token is
-reported with id `-` and presence `unknown`, detail `row carries no id: token`. **No slug is derived
+`` `id:<slug>` `` token in its first cell; `<slug>` is `[a-z0-9-]+`. A row with no id token reports
+id `-`, and that is the whole of what an absent id decides: **the id column and `<presence>` are
+independent**. The probe still runs, so an id-less row's `<presence>` and `<detail>` carry what the
+probe proved, exactly as on a row that has an id. Coupling the two would report every row on the
+current tree `unknown` — no landed skill carries an id token — leaving a detection verb that names
+no gap it can act on, and making the example below unproducible (#5298). **No slug is derived
 from prose** — a rule that kebab-cased a cell would turn "The board label taxonomy — `status:triaged`,
 …" into `the-board-label-taxonomy`, two implementers would ship two id sets, and a reworded cell
 would silently break every documented invocation. The ids this group itself needs are fixed in
@@ -533,9 +537,11 @@ in this state today (`adr`, `report`, `triage`), so it is the common path, not a
 `--skill` naming something not in the roster emits the same shape with detail `not in the roster`.
 
 The header is `satisfied` only when every declared surface is `present` **and** no skill is
-`undeclared` **and** nothing is `unprobeable`; `gaps` when anything is `missing`, `undeclared` or
-`unprobeable`; `unknown` when the roster itself could not be read. **`gaps` and `unknown` are
-different answers** — the first is proven.
+`undeclared` **and** nothing is `unprobeable` **and** nothing is `unknown`; `gaps` when anything is
+`missing`, `undeclared`, `unprobeable` or `unknown`; `unknown` when the roster itself could not be
+read. A row set that is entirely `unknown` is `gaps` by that rule: an unperformed probe is not a
+present surface, and scoring it clean is the fail-open this verb exists to remove. **`gaps` and
+`unknown` are different answers** — the first is proven.
 
 <a id="multiply-declared"></a>**One surface declared by several skills** — the label taxonomy is
 declared by `build`, `build-epic` and this skill — emits **one row per declaring skill**, so no

--- a/packages/fabrika-cli/src/status/required-files.unit.test.ts
+++ b/packages/fabrika-cli/src/status/required-files.unit.test.ts
@@ -37,6 +37,13 @@ describe("the `## Required repo files` reader", () => {
 				?.surfaceId,
 		).toBe("-");
 	});
+
+	// #5298: an absent id token sets the id column and decides nothing else.
+	it("still classifies the subject of a row with no id token, so its presence stays the probe's answer", () => {
+		const rows = parseRequiredFiles(table("| `ROADMAP.md` | why | **degrade** — n |"));
+		expect(rows?.[0]?.surfaceId).toBe("-");
+		expect(rows?.[0]?.subject).toEqual({_tag: "Path", path: "ROADMAP.md"});
+	});
 });
 
 describe("the disposition is read by cell position, never by scanning for a bolded token", () => {


### PR DESCRIPTION
The fabrika front-door contract said one thing about `status config` rows and showed another. One sentence claimed a `## Required repo files` row with no `id:<slug>` token is reported with presence `unknown`; the worked example two paragraphs later printed id-less rows as `present`, `missing` and `unprobeable`. Since no landed skill carries an id token yet, the sentence reading would make every row on the tree `unknown` — a detection verb that names no gap it can act on.

The shipped code settles it: the parser sets an id-less row's id to `-` and nothing else, and the verb probes the row either way, so presence is whatever the probe proved. The contract now says that, and the header rule now says what an `unknown` presence contributes.

Fixes #5298

## What changed

- `claude-plugins/fabrika/skills/front-door/contract.md`
  - The `Surface ids are declared, never inferred` paragraph: an absent id token sets the id column to `-` and decides nothing else — the id column and `<presence>` are independent, and the probe still runs. The `no slug is derived from prose` half is untouched.
  - The header-state rule: `satisfied` now also requires nothing `unknown`, and `gaps` fires on `unknown` alongside `missing` / `undeclared` / `unprobeable`, so a row set that is entirely `unknown` has one defined header state.
- `packages/fabrika-cli/src/status/required-files.unit.test.ts` — one test locking the corrected rule at its seat: a row with no id token still classifies its subject, so its presence stays the probe's answer.

## How the code settled the reading

- `packages/fabrika-cli/src/status/required-files.ts` — `surfaceId: ID_TOKEN.exec(first)?.[1] ?? \"-\"`; the subject is classified from the same cell regardless, so an absent id never makes a row unprobeable.
- `packages/fabrika-cli/src/status/config-verb.ts` — `probeRow` takes `declared.surfaceId` as-is and derives presence from the probe alone; no branch keys on the id. `configState` returns `satisfied` only when every row is declared and `present`, so `unknown` lands in `gaps`.
- Live run of `fabrika status config` on this tree: header `config gaps 17 3 4 1`, with id-less rows printing `present`, `missing` and `unprobeable` — the example reading, unchanged.

No behavior change: `config-verb.ts` already conformed, so the deviation disclosed in #5299 is discharged by the text, not by a code edit.

## Checks

- `pnpm typecheck` — 31/31 green
- `pnpm lint:worktree` — clean
- `pnpm test` in `packages/fabrika-cli` — 4312 passed

## Deviations

- **Narrowed the fix-shape the issue offered.** Said: the acceptance criteria allowed the corrected paragraph to keep the `row carries no id: token` detail (\"may carry\"). Did: dropped that detail string entirely. Why: the shipped verb never emits it — an id-less row's `<detail>` carries the probe evidence (a path, a label list, a reason) exactly like every other row, so keeping it would restate a second untrue thing about the verb. Disposition: no action needed; the criterion made it optional.
- **Left an adjacent contradiction in the same section unfixed.** Said: the acceptance criteria scope the edit to the id/presence coupling and the `unknown` header state. Did: did not touch the clause reading `unknown` when the roster itself could not be read. Why: the code refuses on an unreadable roster (exit `11`, or `7` on an explicitly-passed absent path) and `configState` never returns `unknown`, so that header state looks unreachable in the machine line — a third contradiction, adjacent but outside this issue's criteria, and fixing it would need a ruling on whether the state or the refusal is the intended shape. Disposition: for the reviewer to judge; not filed as a follow-up because this lane's claim authorizes writes to #5298 and this PR only.
- **Added a test the issue did not ask for.** Said: the deliverable is a documentation edit with no runtime behavior change. Did: added one parser unit test. Why: the corrected rule is otherwise unguarded — nothing would fail if a future edit coupled presence to the id again. Disposition: no action needed.