### PR TITLE
fix(fabrika): seat adr next/resolve's five proven refusals in the group table (#5340)

### DIFF
--- a/claude-plugins/fabrika/skills/adr/contract.md
+++ b/claude-plugins/fabrika/skills/adr/contract.md
@@ -76,6 +76,9 @@ Every verb below obeys these; they are stated once rather than repeated per bloc
   | `16` | `<id>` is already `superseded by …` | | | | ✓ | |
   | `17` | `--base` could not be fetched, so the merged set is UNKNOWN | ✓ | ✓ | | | |
   | `18` | the open pull requests could not be enumerated | ✓ | ✓ | | | |
+  | `19` | a record under `--dir` has a filename with no readable id | ✓ | ✓ | | | |
+  | `20` | two records under `--dir` claim one id | | ✓ | | | |
+  | `21` | `--repo` was not given and the `origin` remote could not be read | ✓ | ✓ | | | |
 
   `7` and `11` are the two seats this group shares with `report`'s table, code for code, so a caller
   driving both reads one meaning: the target is not there, and the read that would have proven it
@@ -128,6 +131,8 @@ first-free would answer `0238`.
 | `11` | `--dir` could not be read at the fetched `--base`, so the merged set is UNKNOWN |
 | `17` | `--base` could not be fetched, so the merged set is UNKNOWN |
 | `18` | the open pull requests could not be enumerated, so the in-flight set is UNKNOWN |
+| `19` | a record under `--dir` has a filename with no readable id |
+| `21` | `--repo` was not given and the `origin` remote could not be read, so the in-flight set is UNKNOWN |
 
 **Errors**
 
@@ -137,7 +142,8 @@ first-free would answer `0238`.
 | `adr next: cannot enumerate open pull requests in <repo>: <reason> — the in-flight set is UNKNOWN, never "nothing reserved". Re-run; do not fall back to the on-disk id.` | 18 | refusal |
 | `adr next: cannot read PR #<n>'s file list: <reason> — the in-flight set is INCOMPLETE, so it is UNKNOWN.` | 18 | refusal |
 | `adr next: cannot read <dir> at <ref>: <reason> — the merged set is UNKNOWN, never "0 records".` | 11 | refusal |
-| `adr next: <dir> holds a record with an unparseable id: <name>` | 1 | refusal |
+| `adr next: <dir> holds a record with an unparseable id: <name>` | 19 | refusal |
+| `adr next: cannot resolve --repo from the origin remote: <reason> — the in-flight set is UNKNOWN.` | 21 | refusal |
 
 **Scope** — every `NNNN-slug.md` under `--dir` **as of the fetched `--base`**, plus every open pull
 request in `--repo` that *adds* a `.decisions/NNNN-*.md` file. The scope line goes to stderr on every
@@ -369,6 +375,9 @@ were enumerated, and no one holds this id. It is never what a failed read prints
 | `11` | `--dir` could not be read at the fetched `--base`, so every state is UNKNOWN |
 | `17` | `--base` could not be fetched, so every state is UNKNOWN |
 | `18` | the open pull requests could not be enumerated, so `absent` cannot be distinguished from `in-flight` |
+| `19` | a record under `--dir` has a filename with no readable id |
+| `20` | two records under `--dir` claim one id, so every state over it would be arbitrary |
+| `21` | `--repo` was not given and the `origin` remote could not be read, so `absent` cannot be distinguished from `in-flight` |
 
 `5` is vacated here for the group-wide reason above; no verb re-seats it.
 
@@ -379,8 +388,11 @@ were enumerated, and no one holds this id. It is never what a failed read prints
 | `adr resolve: cannot fetch <ref>: <reason> — every state is UNKNOWN, never "absent".` | 17 | refusal |
 | `adr resolve: cannot enumerate open pull requests in <repo>: <reason> — "absent" is indistinguishable from "in-flight", so it is UNKNOWN.` | 18 | refusal |
 | `adr resolve: cannot read <dir> at <ref>: <reason> — every state is UNKNOWN, never "absent".` | 11 | refusal |
+| `adr resolve: cannot read <dir>/<file> at <sha> — every state is UNKNOWN, never "absent".` | 11 | refusal |
 | `adr resolve: id "<id>" is not four zero-padded digits.` | 1 | usage error |
-| `adr resolve: <dir> at <ref> holds two records for id <id>: <a>, <b>` | 1 | refusal |
+| `adr resolve: <dir> at <ref> holds two records for id <id>: <a>, <b>` | 20 | refusal |
+| `adr resolve: <dir> holds a record with an unparseable id: <name>` | 19 | refusal |
+| `adr resolve: cannot resolve --repo from the origin remote: <reason> — "absent" is indistinguishable from "in-flight", so it is UNKNOWN.` | 21 | refusal |
 
 **Scope** — every `NNNN-slug.md` under `--dir` at the fetched `--base`, plus every open pull request
 in `--repo` that adds a `.decisions/NNNN-*.md` file. Zero records is a fact and answers `absent` for

--- a/packages/fabrika-cli/src/adr/codes.ts
+++ b/packages/fabrika-cli/src/adr/codes.ts
@@ -63,3 +63,29 @@ export const ALREADY_SUPERSEDED = 16;
 export const BASE_UNFETCHABLE = 17;
 /** The open pull requests could not be enumerated, so the in-flight set is UNKNOWN. */
 export const IN_FLIGHT_UNKNOWN = 18;
+
+/**
+ * A record under `--dir` has a filename this group cannot read an id from.
+ *
+ * One seat for `adr next` and `adr resolve` on {@link DIR_UNREADABLE}'s precedent: both say the same
+ * thing about the same directory, and the caller's remedy is the filename either way. A seat per verb
+ * would make the remedy look like it depended on which verb happened to find it.
+ */
+export const UNPARSEABLE_RECORD_ID = 19;
+
+/**
+ * Two records under `--dir` claim one id, so every answer over that id would be arbitrary.
+ *
+ * `adr resolve` proves this at two call sites — over the whole listing, and again over the records it
+ * read statuses for — and they are one fact, so they share the seat.
+ */
+export const DUPLICATE_ID = 20;
+
+/**
+ * `--repo` was not given and the `origin` remote could not be read, so the in-flight set is UNKNOWN.
+ *
+ * Its own seat rather than {@link DIR_UNREADABLE}'s for that seat's own stated reason: this reads
+ * something else — the git remote — and it is the precondition of the in-flight half, not of the
+ * record directory. Not `1`, which would fuse a missing remote with a bad flag.
+ */
+export const ORIGIN_REPO_UNRESOLVABLE = 21;

--- a/packages/fabrika-cli/src/adr/command.ts
+++ b/packages/fabrika-cli/src/adr/command.ts
@@ -67,7 +67,7 @@ const next = leafCommand(
 ).pipe(
 	Command.withShortDescription("The next unused ADR id, merged set and open-PR claims folded."),
 	Command.withDescription(
-		"The next unused ADR id — max(fetched merged set ∪ open-PR claims) + 1. Prints `0240`; --json adds mergedMax/inFlight/baseSha. An empty-and-readable --dir is a fresh corpus and answers 0001. Exits 11 (--dir unreadable), 17 (base unfetchable), 18 (in-flight unknown). Example: fabrika adr next",
+		"The next unused ADR id — max(fetched merged set ∪ open-PR claims) + 1. Prints `0240`; --json adds mergedMax/inFlight/baseSha. An empty-and-readable --dir is a fresh corpus and answers 0001. Exits 11 (--dir unreadable), 17 (base unfetchable), 18 (in-flight unknown), 19 (a record filename with no readable id), 21 (origin remote unresolvable). Example: fabrika adr next",
 	),
 );
 
@@ -141,7 +141,7 @@ const resolve = leafCommand(
 ).pipe(
 	Command.withShortDescription("Resolve ADR ids to their real filename and state at a base ref."),
 	Command.withDescription(
-		"Resolve ids to their real filename and state against a fetched base ref — one `<state>\\t<file>\\t<detail>` line per id, state ∈ live|landed|in-flight|absent. An empty-and-readable --dir answers absent. Exits 11 (--dir unreadable), 17 (base unfetchable), 18 (in-flight unknown). Example: fabrika adr resolve 0164 0023",
+		"Resolve ids to their real filename and state against a fetched base ref — one `<state>\\t<file>\\t<detail>` line per id, state ∈ live|landed|in-flight|absent. An empty-and-readable --dir answers absent. Exits 11 (--dir or one of its records unreadable), 17 (base unfetchable), 18 (in-flight unknown), 19 (a record filename with no readable id), 20 (two records for one id), 21 (origin remote unresolvable). Example: fabrika adr resolve 0164 0023",
 	),
 );
 

--- a/packages/fabrika-cli/src/adr/next-verb.ts
+++ b/packages/fabrika-cli/src/adr/next-verb.ts
@@ -9,9 +9,15 @@
  */
 import {Effect} from "effect";
 import {originRepo, type Shell} from "../io/git.ts";
-import {answer, FAILED, refuse, type VerbOutcome} from "../verb.ts";
+import {answer, refuse, type VerbOutcome} from "../verb.ts";
 import {loadInFlight, loadMerged} from "./base-ref.ts";
-import {BASE_UNFETCHABLE, DIR_UNREADABLE, IN_FLIGHT_UNKNOWN} from "./codes.ts";
+import {
+	BASE_UNFETCHABLE,
+	DIR_UNREADABLE,
+	IN_FLIGHT_UNKNOWN,
+	ORIGIN_REPO_UNRESOLVABLE,
+	UNPARSEABLE_RECORD_ID,
+} from "./codes.ts";
 import {allocate} from "./next.ts";
 
 export interface NextOptions {
@@ -30,8 +36,8 @@ export const runNext = (options: NextOptions): Shell<VerbOutcome> =>
 			const resolved = yield* originRepo;
 			if (resolved._tag === "Failure") {
 				return refuse(
-					FAILED,
-					`adr next: cannot resolve --repo from the origin remote: ${resolved.reason}`,
+					ORIGIN_REPO_UNRESOLVABLE,
+					`adr next: cannot resolve --repo from the origin remote: ${resolved.reason} — the in-flight set is UNKNOWN.`,
 				);
 			}
 			repo = resolved.value;
@@ -52,7 +58,10 @@ export const runNext = (options: NextOptions): Shell<VerbOutcome> =>
 					`adr next: cannot read ${dir} at ${base}: ${e.reason} — the merged set is UNKNOWN, never "0 records".`,
 				);
 			}
-			return refuse(FAILED, `adr next: ${dir} holds a record with an unparseable id: ${e.file}`);
+			return refuse(
+				UNPARSEABLE_RECORD_ID,
+				`adr next: ${dir} holds a record with an unparseable id: ${e.file}`,
+			);
 		}
 
 		const inFlight = yield* loadInFlight(repo, dir);

--- a/packages/fabrika-cli/src/adr/next-verb.unit.test.ts
+++ b/packages/fabrika-cli/src/adr/next-verb.unit.test.ts
@@ -1,7 +1,13 @@
 import {Effect} from "effect";
 import {describe, expect, it} from "vitest";
 import {errOut, fakeShell, okOut, tree} from "../fakes.test-support.ts";
-import {BASE_UNFETCHABLE, DIR_UNREADABLE, IN_FLIGHT_UNKNOWN} from "./codes.ts";
+import {
+	BASE_UNFETCHABLE,
+	DIR_UNREADABLE,
+	IN_FLIGHT_UNKNOWN,
+	ORIGIN_REPO_UNRESOLVABLE,
+	UNPARSEABLE_RECORD_ID,
+} from "./codes.ts";
 import {runNext} from "./next-verb.ts";
 
 const SHA = "49a22902d1e0c7b3f5a8e4126b9d0f3c7a1e5b82";
@@ -118,10 +124,22 @@ describe("runNext", () => {
 		expect(empty.code).toBe(0);
 	});
 
-	it("refuses a record whose id cannot be parsed", async () => {
+	it("refuses a record whose id cannot be parsed, on its own proven code", async () => {
 		const out = await run([[/^git ls-tree/, okOut(tree("0234-a.md", "12-bad.md"))]]);
-		expect(out.code).toBe(1);
+		expect(out.code).toBe(UNPARSEABLE_RECORD_ID);
+		expect(out.code).not.toBe(1);
+		expect(out.stdout).toBe("");
 		expect(out.stderr.at(-1)).toContain("unparseable id: 12-bad.md");
+	});
+
+	it("refuses an unresolvable origin remote on its own proven code, not on 1", async () => {
+		const out = await run([
+			[/^git remote get-url origin$/, errOut("fatal: No such remote 'origin'")],
+		]);
+		expect(out.code).toBe(ORIGIN_REPO_UNRESOLVABLE);
+		expect(out.code).not.toBe(1);
+		expect(out.stdout).toBe("");
+		expect(out.stderr.at(-1)).toContain("cannot resolve --repo from the origin remote");
 	});
 
 	it("refuses when git resolves the base to something that is not an object name", async () => {

--- a/packages/fabrika-cli/src/adr/resolve-verb.ts
+++ b/packages/fabrika-cli/src/adr/resolve-verb.ts
@@ -14,7 +14,14 @@ import {Effect} from "effect";
 import {originRepo, type Shell} from "../io/git.ts";
 import {answer, FAILED, refuse, type VerbOutcome} from "../verb.ts";
 import {loadInFlight, loadMerged, readMergedRecord} from "./base-ref.ts";
-import {BASE_UNFETCHABLE, DIR_UNREADABLE, IN_FLIGHT_UNKNOWN} from "./codes.ts";
+import {
+	BASE_UNFETCHABLE,
+	DIR_UNREADABLE,
+	DUPLICATE_ID,
+	IN_FLIGHT_UNKNOWN,
+	ORIGIN_REPO_UNRESOLVABLE,
+	UNPARSEABLE_RECORD_ID,
+} from "./codes.ts";
 import {isFourDigitId} from "./records.ts";
 import {
 	indexInFlight,
@@ -47,8 +54,8 @@ export const runResolve = (options: ResolveOptions): Shell<VerbOutcome> =>
 			const resolved = yield* originRepo;
 			if (resolved._tag === "Failure") {
 				return refuse(
-					FAILED,
-					`adr resolve: cannot resolve --repo from the origin remote: ${resolved.reason}`,
+					ORIGIN_REPO_UNRESOLVABLE,
+					`adr resolve: cannot resolve --repo from the origin remote: ${resolved.reason} — "absent" is indistinguishable from "in-flight", so it is UNKNOWN.`,
 				);
 			}
 			repo = resolved.value;
@@ -69,7 +76,10 @@ export const runResolve = (options: ResolveOptions): Shell<VerbOutcome> =>
 					`adr resolve: cannot read ${dir} at ${base}: ${e.reason} — every state is UNKNOWN, never "absent".`,
 				);
 			}
-			return refuse(FAILED, `adr resolve: ${dir} holds a record with an unparseable id: ${e.file}`);
+			return refuse(
+				UNPARSEABLE_RECORD_ID,
+				`adr resolve: ${dir} holds a record with an unparseable id: ${e.file}`,
+			);
 		}
 		const mergedSet = merged.value;
 
@@ -83,7 +93,7 @@ export const runResolve = (options: ResolveOptions): Shell<VerbOutcome> =>
 		if ("duplicate" in duplicates) {
 			const {id, files} = duplicates.duplicate;
 			return refuse(
-				FAILED,
+				DUPLICATE_ID,
 				`adr resolve: ${dir} at ${base} holds two records for id ${id}: ${files[0]}, ${files[1]}`,
 			);
 		}
@@ -98,7 +108,10 @@ export const runResolve = (options: ResolveOptions): Shell<VerbOutcome> =>
 			}
 			const record = yield* readMergedRecord(mergedSet.sha, dir, file, id);
 			if (record === null) {
-				return refuse(FAILED, `adr resolve: cannot read ${dir}/${file} at ${mergedSet.sha}`);
+				return refuse(
+					DIR_UNREADABLE,
+					`adr resolve: cannot read ${dir}/${file} at ${mergedSet.sha} — every state is UNKNOWN, never "absent".`,
+				);
 			}
 			records.push(record);
 		}
@@ -107,7 +120,7 @@ export const runResolve = (options: ResolveOptions): Shell<VerbOutcome> =>
 		if ("duplicate" in indexed) {
 			const {id, files} = indexed.duplicate;
 			return refuse(
-				FAILED,
+				DUPLICATE_ID,
 				`adr resolve: ${dir} at ${base} holds two records for id ${id}: ${files[0]}, ${files[1]}`,
 			);
 		}

--- a/packages/fabrika-cli/src/adr/resolve-verb.unit.test.ts
+++ b/packages/fabrika-cli/src/adr/resolve-verb.unit.test.ts
@@ -1,7 +1,14 @@
 import {Effect} from "effect";
 import {describe, expect, it} from "vitest";
 import {errOut, fakeShell, okOut, record, tree} from "../fakes.test-support.ts";
-import {BASE_UNFETCHABLE, DIR_UNREADABLE, IN_FLIGHT_UNKNOWN} from "./codes.ts";
+import {
+	BASE_UNFETCHABLE,
+	DIR_UNREADABLE,
+	DUPLICATE_ID,
+	IN_FLIGHT_UNKNOWN,
+	ORIGIN_REPO_UNRESOLVABLE,
+	UNPARSEABLE_RECORD_ID,
+} from "./codes.ts";
 import {runResolve} from "./resolve-verb.ts";
 
 const SHA = "49a22902d1e0c7b3f5a8e4126b9d0f3c7a1e5b82";
@@ -142,15 +149,48 @@ describe("runResolve", () => {
 		expect(out.stderr.at(-1)).toBe('adr resolve: id "0034a" is not four zero-padded digits.');
 	});
 
-	it("refuses when a requested record cannot be read at the base ref", async () => {
+	// The existing seat, not a new one — see `DIR_UNREADABLE`'s docblock in `codes.ts`.
+	it("refuses a requested record it cannot read on the directory seat, not on 1", async () => {
 		const out = await run([[/show .*0164-guard\.md$/, errOut("fatal: path does not exist")]]);
-		expect(out.code).toBe(1);
+		expect(out.code).toBe(DIR_UNREADABLE);
+		expect(out.code).not.toBe(1);
 		expect(out.stdout).toBe("");
+		expect(out.stderr.at(-1)).toContain("cannot read .decisions/0164-guard.md");
 	});
 
-	it("refuses two records claiming one id rather than picking one", async () => {
+	it("refuses two records claiming one id on its own proven code, not on 1", async () => {
 		const out = await run([[/^git ls-tree/, okOut(tree("0164-a.md", "0164-b.md"))]]);
-		expect(out.code).toBe(1);
+		expect(out.code).toBe(DUPLICATE_ID);
+		expect(out.code).not.toBe(1);
+		expect(out.stdout).toBe("");
 		expect(out.stderr.at(-1)).toContain("holds two records for id 0164");
+	});
+
+	it("refuses a record whose id cannot be parsed on its own proven code, not on 1", async () => {
+		const out = await run([[/^git ls-tree/, okOut(tree("0164-guard.md", "12-bad.md"))]]);
+		expect(out.code).toBe(UNPARSEABLE_RECORD_ID);
+		expect(out.code).not.toBe(1);
+		expect(out.stdout).toBe("");
+		expect(out.stderr.at(-1)).toContain("unparseable id: 12-bad.md");
+	});
+
+	it("refuses an unresolvable origin remote on its own proven code, not on 1", async () => {
+		const out = await run([
+			[/^git remote get-url origin$/, errOut("fatal: No such remote 'origin'")],
+		]);
+		expect(out.code).toBe(ORIGIN_REPO_UNRESOLVABLE);
+		expect(out.code).not.toBe(1);
+		expect(out.stdout).toBe("");
+		expect(out.stderr.at(-1)).toContain("cannot resolve --repo from the origin remote");
+	});
+
+	// The three states this verb used to fuse onto `1` — a caller that branches on the status can now
+	// tell a malformed filename from a duplicated id from a bad argument.
+	it("keeps the unparseable, duplicate and usage refusals on three different codes", async () => {
+		const unparseable = await run([[/^git ls-tree/, okOut(tree("0164-guard.md", "12-bad.md"))]]);
+		const duplicate = await run([[/^git ls-tree/, okOut(tree("0164-a.md", "0164-b.md"))]]);
+		const usage = await run([], {ids: ["0034a"]});
+		expect(new Set([unparseable.code, duplicate.code, usage.code]).size).toBe(3);
+		expect(usage.code).toBe(1);
 	});
 });


### PR DESCRIPTION
`fabrika adr next` and `fabrika adr resolve` had five refusals that exit `1` — the same code the interface reserves for "you passed a bad flag, or the verb never ran". So a caller checking the status could not tell "a file in `.decisions/` has a malformed name" from "the CLI is broken", and the two have completely different fixes. Each of those five states now returns a code of its own, allocated from the `adr` group's one exit table.

Nothing that scripts these verbs branches on a specific number today — the `adr` skill states only the coarse "a non-zero exit is UNKNOWN" rule — so no caller can mis-branch on the re-seat. Re-verified against `origin/main` at `bfd12d65`.

## What changed

Three new seats in `packages/fabrika-cli/src/adr/codes.ts`, from the group's private band:

| Seat | Code | States it covers |
|---|---|---|
| `UNPARSEABLE_RECORD_ID` | `19` | `adr next` and `adr resolve`, a record filename with no readable id |
| `DUPLICATE_ID` | `20` | `adr resolve`, both call sites of "two records for one id" |
| `ORIGIN_REPO_UNRESOLVABLE` | `21` | `adr next` and `adr resolve`, `--repo` unset and the `origin` remote unreadable |

A fourth state takes an **existing** seat: `adr resolve`'s `cannot read <dir>/<file>` moves to `DIR_UNREADABLE` (`11`), whose docblock already says a listing that failed and a member that could not be read are one fact to a caller. The usage error at `resolve-verb.ts` (`id "<id>" is not four zero-padded digits`) stays on `1`, per the `codes.ts` docblock.

`19`, `20` and `21` were verified free at `origin/main` rather than taken from the issue body: the base table (`report/codes.ts`) occupies `3`-`11`, `27` and `28`, and `adr`'s own band runs `12`-`18`. `5` stays vacated.

## The one open question, decided: one shared seat, not one per verb

`adr next` and `adr resolve` say the **same thing about the same directory** when a record's filename has no readable id, and the caller's remedy is the filename either way. That is exactly the argument `DIR_UNREADABLE`'s docblock already makes for sharing a seat across the two verbs, so `UNPARSEABLE_RECORD_ID` is one seat. A seat per verb would suggest the remedy depends on which verb happened to find the bad file, which it does not.

`ORIGIN_REPO_UNRESOLVABLE` gets its own seat rather than folding into `DIR_UNREADABLE` for that seat's own stated reason: it reads something else — the git remote — and it is the precondition of the in-flight half, not of the record directory.

## Also moved

- `claude-plugins/fabrika/skills/adr/contract.md` — the group table plus both verbs' exit-status and error tables.
- `packages/fabrika-cli/src/adr/command.ts` — the `--help` exit lists for `next` and `resolve`.
- Unit tests in `next-verb.unit.test.ts` and `resolve-verb.unit.test.ts` import every constant **by name**, and one test asserts the unparseable, duplicate and usage refusals land on three distinct codes.

The `exit-code-alignment` suite stays green: `19`-`21` collide with neither the base table nor `adr`'s existing seats.

Fixes #5340

## Deviations

- **Branch prefix.** Said: the dispatch asked for a `umut/` branch prefix. Did: the branch is `usirin/seat-adr-proven-refusals-5340-…`. Why: `write-code` Step 4 derives the prefix from this checkout's `git config user.name` and explicitly forbids a hardcoded literal; the identity here is `usirin`. Disposition: no action needed.
- **Out-of-lane refusals left alone.** Said: the triage note records the same shape in `adr new`, `adr supersede`/`amend-in-part`, and `adr sweep`, and asks that this issue not widen to cover them. Did: left them on `1`, untouched. Disposition: for a separate issue, as the triage note directs.
- **The second duplicate-id call site is not separately exercised.** Said: an AC asks for a unit test per newly seated state. Did: `DUPLICATE_ID` is asserted through the first call site; the second re-check runs over the same id set and is defensive, so no fixture reaches it without contriving one. Both sites name the constant. Disposition: for the reviewer to judge.
- **Refusal messages gained a consequence clause.** Said: the issue asked only for the codes to move. Did: the two `--repo`-from-origin messages and the `cannot read <dir>/<file>` message now end with what is UNKNOWN, matching the sibling refusals in the same verbs. Disposition: no action needed; the contract's error tables carry the new text.
