### PR TITLE
feat(fabrika): the graded axis at five runs, a median, and a head-bound eval record (#4678)

### DIFF
--- a/claude-plugins/fabrika/docs/wire-formats.md
+++ b/claude-plugins/fabrika/docs/wire-formats.md
@@ -39,6 +39,7 @@ does not exist yet — rather than missing; check the registry before assuming a
 | --- | --- | --- | --- |
 | `acceptance-criteria` | [`packages/fabrika-cli/src/wire/acceptance-criteria.ts`](../../../packages/fabrika-cli/src/wire/acceptance-criteria.ts) | `triage`, `build-epic` | `build`, `review` |
 | `verdict-marker` | [`packages/fabrika-cli/src/wire/verdict-marker.ts`](../../../packages/fabrika-cli/src/wire/verdict-marker.ts) | `review`, `check-epic-plan`, `governance` | `build`, `ship` |
+| `eval-record` | [`packages/fabrika-cli/src/wire/eval-record.ts`](../../../packages/fabrika-cli/src/wire/eval-record.ts) | `review` | `ship` |
 | `slice-handoff` | [`packages/fabrika-cli/src/wire/slice-handoff.ts`](../../../packages/fabrika-cli/src/wire/slice-handoff.ts) | `build-epic` | `build` |
 | `map-ticket` | [`packages/fabrika-cli/src/wire/map-ticket.ts`](../../../packages/fabrika-cli/src/wire/map-ticket.ts) | `map` | `map` |
 | `grill-ruling` | [`packages/fabrika-cli/src/wire/grill-ruling.ts`](../../../packages/fabrika-cli/src/wire/grill-ruling.ts) | `grilling` | `grilling` |
@@ -72,6 +73,24 @@ moved is stale rather than passing. Drift costs both directions: a marker the re
 recognise makes a reviewed PR look unreviewed and stalls it, while one whose binding is lost would
 let a stale approval carry an unreviewed tree through a merge. The module owns the composing and the
 reading, including the staleness question; the skills keep the judgement of when to flip a verdict.
+
+### `eval-record`
+
+This is the measurement a graded review run leaves behind on the PR it graded. `review` runs a
+changed skill's graded eval cases five times each, takes the median, and posts one record per
+`(head, cell)`; a later merge gate reads it back, and a later scorecard aggregates it into a series.
+The record exists because the grading no longer returns into the job that needs the answer — running
+a model in CI costs credits the CI provider does not have, so the run happens where a model is
+already being paid for and leaves its answer bound to the exact commit it measured.
+
+Two things about the agreement are deliberate and easy to undo by accident. Its outcome token is
+`RECORDED` or `UNRECORDABLE` and never a pass/fail polarity: a polarity would have to mean *pass
+against what*, and the only candidate is the merge bar, which belongs to the gate and not to the
+measurement. And every aggregate it carries is re-derived from the numbers beside it when it is read
+— the pass rate against its own denominator, each case's dispersion against its own run counts — so
+a record cannot publish a figure its own contents contradict. A run that produced no measurement at
+all says so rather than reporting a zero, because a zero somebody measured and a zero nobody measured
+are the two facts the reader most needs to keep apart.
 
 ### `slice-handoff`
 

--- a/claude-plugins/fabrika/docs/wire-formats.md
+++ b/claude-plugins/fabrika/docs/wire-formats.md
@@ -87,8 +87,11 @@ Two things about the agreement are deliberate and easy to undo by accident. Its 
 `RECORDED` or `UNRECORDABLE` and never a pass/fail polarity: a polarity would have to mean *pass
 against what*, and the only candidate is the merge bar, which belongs to the gate and not to the
 measurement. And every aggregate it carries is re-derived from the numbers beside it when it is read
-— the pass rate against its own denominator, each case's dispersion against its own run counts — so
-a record cannot publish a figure its own contents contradict. A run that produced no measurement at
+— each case's dispersion against its own run counts, and the cell's graded, passing and unmeasured
+case counts against the case blocks themselves, with the pass rate against that denominator — so a
+record cannot publish a figure its own contents contradict, at either level. A record claiming ten
+graded cases over two case blocks, or over none at all, is refused rather than read back. A run that
+produced no measurement at
 all says so rather than reporting a zero, because a zero somebody measured and a zero nobody measured
 are the two facts the reader most needs to keep apart.
 

--- a/claude-plugins/fabrika/skills/review/SKILL.md
+++ b/claude-plugins/fabrika/skills/review/SKILL.md
@@ -81,11 +81,18 @@ fabrika eval graded claude-plugins/fabrika/skills/<name>/evals/evals.json \
 ```
 
 Each graded case runs five times and the median is its verdict; the verb prints an **eval record**
-bound to the head you scoped, which you post as its own PR comment. **This stage is the only place
-the graded path runs.** Model-in-the-loop execution never runs in CI, on a **cost** constraint — no
-credits for model runs inside the CI provider — recorded as a cost constraint, not a principle. You
-are already spawning a model, so the graded axis rides a cost already being paid; a later CI job
-verifies the record rather than reproducing it.
+bound to the head you scoped, which you post as its own PR comment.
+
+<!-- anchor: GRADED-COST-IS-TEN-SPAWNS-PER-CASE --> **Budget it at ten model spawns per graded
+case** — five runs, each a candidate against the skill *plus* a grader against its output — at a
+default 15-minute timeout each. A four-case eval set is forty spawns. The run count is not a flag:
+five is the ruled count (#4637 ruling 4), and a record produced at fewer runs is indistinguishable
+from a ruled one at the gate.
+
+**This stage is the only place the graded path runs.** Model-in-the-loop execution never runs in CI,
+on a **cost** constraint — no credits for model runs inside the CI provider — recorded as a cost
+constraint, not a principle. You are already spawning a model, so the graded axis rides a cost
+already being paid; a later CI job verifies the record rather than reproducing it.
 
 <!-- anchor: RECORD-IS-A-MEASUREMENT-NOT-A-VERDICT --> The record is a **measurement, not a
 judgement**: its token is `RECORDED` or `UNRECORDABLE`, never a polarity, and the 90% bar it would be
@@ -93,7 +100,10 @@ judged against is the merge gate's, not yours. So it neither grants nor blocks y
 verdict. Post it on **every** outcome — a below-bar run records its below-bar number, because a
 failing run that wrote nothing reaches the verifier as *missing* and reddens for the wrong reason.
 `UNRECORDABLE` is the run that measured nothing at all: read it as UNKNOWN and say so, never as a
-zero.
+zero. **That includes the runs that never reached a case** — an eval set you could not read, one that
+does not conform, one with no graded case. Each of those prints an `UNRECORDABLE` record naming which
+it was, and you post it like any other: an unposted record reaches the merge gate as *missing*, which
+is indistinguishable from a review that never ran the axis.
 
 ## 4 — Fan out, then route — never grade severity
 
@@ -187,7 +197,7 @@ the surface and files the gap. No row here dead-ends on a bare error.
 | The linked issue's `### Acceptance criteria` block | `review criteria` grades against it, and nothing else is the contract | **fail-loud** — `review criteria` exits `7` naming the issue and the wire reason (`absent` vs `malformed`), no criterion is invented, and the run points at front-door. |
 | The PR body's `## Deviations` section | `review deviations` matches the disclosure against the bound commit's Tier-M scan | **fail-loud** — on a PR that owes the section, `absent` is malformed and fails the verdict closed; the run names the missing `## Deviations` heading and points at front-door. |
 | A git remote in this checkout whose URL names the repo under review | `review scope`, `review diff`, `review deviations` and `review post`'s namespace recompute fetch `pull/<pr>/head` and read the artifact out of the object database, so the bytes are provably the bound commit's ([`contract.md`](contract.md), the read verbs' commit binding) | **fail-loud** — every one of them exits `11` naming the repo no remote serves; the artifact cannot be tied to a commit, so what it shows is UNKNOWN and no unbound fallback is taken. |
-| The changed skill's `evals/evals.json` | `eval graded` runs its graded cases five times each so the PR carries a head-bound measurement of the skill it changed (step 3a) | **degrade** — `eval graded` exits `7` naming the set it could not read or the absence of any graded case, and the run says so in the `review-skill` verdict body as an unmeasured change. No number is invented, and the verdict is still emitted on what the rubric *could* see. |
+| The changed skill's `evals/evals.json` | `eval graded` runs its graded cases five times each so the PR carries a head-bound measurement of the skill it changed (step 3a) | **degrade**, on three distinguishable exits — `7` the set conforms and carries no graded case, `4` it decodes and does not conform, `1` it could not be read at all. All three still print an `UNRECORDABLE` record naming which one it was: **post it**, so the merge gate reads a broken eval set rather than an absent one. `7` and `4` are facts about the *set*, so say so in the `review-skill` verdict body as an unmeasured change; `1` is also the code for "the verb failed to run", so report it as the axis not running rather than as a fact about the skill. No number is invented on any of the three, and the verdict is still emitted on what the rubric *could* see. |
 | A CI check rollup at the head — `.github/workflows/` | `review ci` is the code class's execution evidence; this skill re-runs no check itself | **fail-loud** — zero declared check runs is exit `7`, refusing green over an empty enumeration (ADR 0092), and an unreadable enumeration is `11`, UNKNOWN, never green; the run names `.github/workflows/` and points at front-door. |
 
 ## Eval enumeration (leaf-rule obligation)

--- a/claude-plugins/fabrika/skills/review/SKILL.md
+++ b/claude-plugins/fabrika/skills/review/SKILL.md
@@ -72,6 +72,29 @@ No class checks out the head: content arrives through the verbs as bytes, so the
 instructions are never loaded to judge the PR. Every namespace's verdict is **comment-only** — v1's
 code-namespace native-APPROVE is deliberately not carried (ADR 0058 rule 4).
 
+## 3a — Skill class only: run the changed skill's graded cases and record the number
+
+```bash
+fabrika eval graded claude-plugins/fabrika/skills/<name>/evals/evals.json \
+  --stage review --surface skill --model <model> \
+  --plugin-dir claude-plugins/fabrika --sha 03135b91
+```
+
+Each graded case runs five times and the median is its verdict; the verb prints an **eval record**
+bound to the head you scoped, which you post as its own PR comment. **This stage is the only place
+the graded path runs.** Model-in-the-loop execution never runs in CI, on a **cost** constraint — no
+credits for model runs inside the CI provider — recorded as a cost constraint, not a principle. You
+are already spawning a model, so the graded axis rides a cost already being paid; a later CI job
+verifies the record rather than reproducing it.
+
+<!-- anchor: RECORD-IS-A-MEASUREMENT-NOT-A-VERDICT --> The record is a **measurement, not a
+judgement**: its token is `RECORDED` or `UNRECORDABLE`, never a polarity, and the 90% bar it would be
+judged against is the merge gate's, not yours. So it neither grants nor blocks your `review-skill`
+verdict. Post it on **every** outcome — a below-bar run records its below-bar number, because a
+failing run that wrote nothing reaches the verifier as *missing* and reddens for the wrong reason.
+`UNRECORDABLE` is the run that measured nothing at all: read it as UNKNOWN and say so, never as a
+zero.
+
 ## 4 — Fan out, then route — never grade severity
 
 Sweep the loaded diff on silent-failure, type-design and test-gap as checklist lines in this same
@@ -164,6 +187,7 @@ the surface and files the gap. No row here dead-ends on a bare error.
 | The linked issue's `### Acceptance criteria` block | `review criteria` grades against it, and nothing else is the contract | **fail-loud** — `review criteria` exits `7` naming the issue and the wire reason (`absent` vs `malformed`), no criterion is invented, and the run points at front-door. |
 | The PR body's `## Deviations` section | `review deviations` matches the disclosure against the bound commit's Tier-M scan | **fail-loud** — on a PR that owes the section, `absent` is malformed and fails the verdict closed; the run names the missing `## Deviations` heading and points at front-door. |
 | A git remote in this checkout whose URL names the repo under review | `review scope`, `review diff`, `review deviations` and `review post`'s namespace recompute fetch `pull/<pr>/head` and read the artifact out of the object database, so the bytes are provably the bound commit's ([`contract.md`](contract.md), the read verbs' commit binding) | **fail-loud** — every one of them exits `11` naming the repo no remote serves; the artifact cannot be tied to a commit, so what it shows is UNKNOWN and no unbound fallback is taken. |
+| The changed skill's `evals/evals.json` | `eval graded` runs its graded cases five times each so the PR carries a head-bound measurement of the skill it changed (step 3a) | **degrade** — `eval graded` exits `7` naming the set it could not read or the absence of any graded case, and the run says so in the `review-skill` verdict body as an unmeasured change. No number is invented, and the verdict is still emitted on what the rubric *could* see. |
 | A CI check rollup at the head — `.github/workflows/` | `review ci` is the code class's execution evidence; this skill re-runs no check itself | **fail-loud** — zero declared check runs is exit `7`, refusing green over an empty enumeration (ADR 0092), and an unreadable enumeration is `11`, UNKNOWN, never green; the run names `.github/workflows/` and points at front-door. |
 
 ## Eval enumeration (leaf-rule obligation)

--- a/packages/fabrika-cli/src/eval/README.md
+++ b/packages/fabrika-cli/src/eval/README.md
@@ -853,6 +853,74 @@ the only file in the module that imports `node:child_process`. The reversal that
 module could previously not spawn anything) and its bounds are recorded in [ADR
 0236](../../../../.decisions/0236-eval-harness-gains-a-spawning-shell.md).
 
+## The graded axis ([#4678](https://github.com/kamp-us/phoenix/issues/4678))
+
+The model-bearing half of the eval layer, and the seam `deterministic-tier.ts` defers to. A case with
+even one judgment assertion cannot be read off an exit status, so it runs **five times** and takes the
+**median** (founder ruling 4 on [#4637](https://github.com/kamp-us/phoenix/issues/4637)).
+
+```bash
+fabrika eval graded <evals.json> \
+  --stage review --surface skill --model <model> \
+  --plugin-dir <the changed skill's plugin dir> --sha <the head under review> \
+  [--runs 5] [--harness <version>] [--timeout-ms 900000] [--out record.md]
+```
+
+`graded-axis.ts` is the **pure** core — the protocol, the median, the record construction — driven by
+the unit tier through a stubbed grader, so no unit test spends a cent. The verb is its only IO, and it
+starts no process of its own: it reuses `spawn-io.ts`'s executor, which stays the module's single
+process boundary.
+
+### The grading is reused, not invented
+
+Each run is two invocations: the case's own prompt against the candidate skill, then a **grader**
+handed that output plus the case's authored `expected_output` and `expectations` **verbatim**
+(`composeGraderPrompt`). No rubric is declared here, so the judgment a case receives in a review is
+the judgment its authoring session defined. A unit test holds that open: it strips the case's own text
+and the fixed instruction block out of a composed prompt and asserts nothing is left.
+
+### What the median throws away is kept
+
+- **`dispersion`** is `min(passed, runs − passed)` (ADR
+  [0252](../../../../.decisions/0252-grading-chain-dispersion-and-decline-criterion.md) §1), and the
+  five per-run verdicts ride beside it, so a 3-of-5 pass is legible as a different fact from a 5-of-5
+  one. It is recorded and read; it gates nothing.
+- **An even split resolves down.** At five runs the tie never arises, but the function is total over
+  any run count and a half-failing set has not shown the case passes — rounding a tie up would be the
+  median quietly defaulting to a pass.
+- **A run that returns no verdict is a `NoVerdict`** over four reasons — `no-output`, `unparseable`,
+  `timed-out`, `invocation-failed` (ADR
+  [0253](../../../../.decisions/0253-eval-record-is-an-eval-namespaced-pr-comment.md) §4). It stays in
+  `runs`, never counts in `passed`, is counted in `noVerdict`, and is **never retried inside the
+  five**: a retry replaces a measurement with a re-measurement and silently changes what the median
+  measured. A case whose every run returned no verdict is `unmeasured` — absent from both sides of the
+  pass rate, because counting it as a failure publishes a number nobody took.
+
+### One aggregation path, one cell spelling
+
+Graded rows are `EvalRow`s and fold through `summarizeEvalRows` — the same aggregator the
+deterministic tier uses — rather than a second one. `gradedCellAggregate` returns
+`gradedRuns` / `passedRuns` / `passRate` typed as a `Pick` of `ScorecardCell`, so the scorecard
+spelling is bound by the compiler rather than by convention. One graded **case** is one graded run at
+cell level; the five executions behind it live in the case block.
+
+### Where it runs, and what it leaves behind
+
+Its supported sites are an operator's shell and the **`review` stage** on a PR that changes a skill
+(`claude-plugins/fabrika/skills/review/SKILL.md` step 3a). **No CI workflow invokes it**, for
+`run`'s reason: the founder ruling on epic [#4649](https://github.com/kamp-us/phoenix/issues/4649)
+removed model-in-the-loop execution from CI on a **cost** constraint — there are no credits for model
+runs inside the CI provider — recorded as a cost constraint, *not a principle*, so a future reader
+knows what would have to change to revisit it. A unit test reds if any workflow ever calls it.
+
+Because the answer no longer returns into a CI job, it is **left behind**: `buildEvalRecord` composes
+the head-bound eval record (`../wire/eval-record.ts`, ADR 0253) the review posts as a PR comment, and
+CI's later leg ([#4681](https://github.com/kamp-us/phoenix/issues/4681)) verifies that record instead
+of reproducing the run. A record is emitted on **every** outcome, so `missing`, `stale`, `below-bar`
+and `unrecordable` stay four distinguishable states for that verifier. The exit code says only whether
+a measurement exists — a below-bar rate exits `0`, because whether a rate clears the ruled bar is
+#4681's judgement and appears nowhere in this module.
+
 ## The fabrika incident corpus ([#4675](https://github.com/kamp-us/phoenix/issues/4675))
 
 `incident-corpus/` is a **second, separate** body of ground truth, and the name matters: the
@@ -919,5 +987,10 @@ against it, not against the issue bodies, which still leave all three values unn
 separate `type:decision` — the harness supplies the graded evidence, the human decides.
 
 **The tier protocols.** `run` executes and collects; it does not implement the deterministic tier's
-mechanical checks (#4677) or the graded tier's 5-run median (#4678), and it renders no scorecard
-series (#4680).
+mechanical checks (#4677) or the graded tier's 5-run median (`graded-axis.ts`, documented above), and
+it renders no scorecard series (#4680).
+
+**Committing a scorecard, and the merge bar.** The graded axis emits a per-run PR comment and
+nothing else: aggregating those records into the committed scorecard series is
+[#4680](https://github.com/kamp-us/phoenix/issues/4680), and reading a rate against the ruled 90% bar
+is [#4681](https://github.com/kamp-us/phoenix/issues/4681). Neither number is judged here.

--- a/packages/fabrika-cli/src/eval/README.md
+++ b/packages/fabrika-cli/src/eval/README.md
@@ -863,7 +863,7 @@ even one judgment assertion cannot be read off an exit status, so it runs **five
 fabrika eval graded <evals.json> \
   --stage review --surface skill --model <model> \
   --plugin-dir <the changed skill's plugin dir> --sha <the head under review> \
-  [--runs 5] [--harness <version>] [--timeout-ms 900000] [--out record.md]
+  [--harness <version>] [--timeout-ms 900000] [--out record.md]
 ```
 
 `graded-axis.ts` is the **pure** core — the protocol, the median, the record construction — driven by
@@ -875,7 +875,11 @@ process boundary.
 
 Each run is two invocations: the case's own prompt against the candidate skill, then a **grader**
 handed that output plus the case's authored `expected_output` and `expectations` **verbatim**
-(`composeGraderPrompt`). No rubric is declared here, so the judgment a case receives in a review is
+(`composeGraderPrompt`). So the ruled five runs cost **ten model spawns per graded case**, at a
+default 15-minute timeout each — and the count is deliberately **not a flag** on the verb: a record
+produced at fewer runs carries the same token, clause and rate as a ruled one, so no consumer could
+tell. `runGradedAxis`'s `runs` parameter stays for the unit tier, which drives 2-, 3- and 4-run sets
+to make the even-split rule testable. No rubric is declared here, so the judgment a case receives in a review is
 the judgment its authoring session defined. A unit test holds that open: it strips the case's own text
 and the fixed instruction block out of a composed prompt and asserts nothing is left.
 
@@ -917,7 +921,13 @@ Because the answer no longer returns into a CI job, it is **left behind**: `buil
 the head-bound eval record (`../wire/eval-record.ts`, ADR 0253) the review posts as a PR comment, and
 CI's later leg ([#4681](https://github.com/kamp-us/phoenix/issues/4681)) verifies that record instead
 of reproducing the run. A record is emitted on **every** outcome, so `missing`, `stale`, `below-bar`
-and `unrecordable` stay four distinguishable states for that verifier. The exit code says only whether
+and `unrecordable` stay four distinguishable states for that verifier — **including the runs that
+never reached a case**: an unreadable set (exit `1`), one that does not conform (`4`) and one with no
+graded case (`7`) each emit an `UNRECORDABLE` record whose clause names which it was, on the founder
+ruling at [#4678 comment 5247447078](https://github.com/kamp-us/phoenix/issues/4678#issuecomment-5247447078)
+(explicit beats implicit for error cases). Silence there would reach #4681 as `missing`, byte-identical
+to a review that never ran the axis. A bad `--stage`/`--surface` is the operator's own mistake, not a
+fact about the set, so it is validated first and records nothing. The exit code says only whether
 a measurement exists — a below-bar rate exits `0`, because whether a rate clears the ruled bar is
 #4681's judgement and appears nowhere in this module.
 
@@ -980,6 +990,13 @@ against it, not against the issue bodies, which still leave all three values unn
 - **Two spellings, two levels, on purpose.** The cell aggregate is `gradedRuns` / `passedRuns` /
   `passRate`, matching `ScorecardCell`; the per-case block is `runs` / `passed` / `dispersion`,
   matching ADR 0252 §1.
+- **`unmeasuredCases` rides beside the cell aggregate**, because it is the one fact that aggregate
+  cannot express: a cell that graded three of four cases reports `3/3 = 1.0`, and without the field
+  #4680's committed row hides the case that never ran.
+- **Both levels are re-derived on read.** `read` refuses a record whose `gradedRuns` / `passedRuns` /
+  `unmeasuredCases` disagree with its own case blocks, exactly as it refuses a `dispersion` that
+  disagrees with its own run counts — so a claim of ten graded cases over two blocks, or over none,
+  is `Malformed` rather than a plausible measurement nobody took.
 
 ## Out of scope
 

--- a/packages/fabrika-cli/src/eval/codes.ts
+++ b/packages/fabrika-cli/src/eval/codes.ts
@@ -53,3 +53,14 @@ export const INTEGRITY_VIOLATION = 12;
  * never this code.
  */
 export const RUNS_NOT_EXECUTED = 13;
+
+/**
+ * Proven: the graded axis ran and produced no measurement at all — every run of every case returned
+ * no verdict, so the record it emitted is `UNRECORDABLE`.
+ *
+ * Its own seat, and deliberately not a failure of the verb: the record is on stdout and is meant to
+ * be posted. This says only that there is no number in it, which the merge gate must be able to tell
+ * apart from a below-bar number (ADR 0253 §2). A below-bar run exits `0` — whether a rate clears the
+ * ruled bar is #4681's judgement and never this verb's.
+ */
+export const NO_MEASUREMENT = 14;

--- a/packages/fabrika-cli/src/eval/command.ts
+++ b/packages/fabrika-cli/src/eval/command.ts
@@ -1,14 +1,15 @@
 /**
- * The `eval` verb group — `fabrika eval check|report|cases|run|keeps`.
+ * The `eval` verb group — `fabrika eval check|report|cases|run|graded|keeps`.
  *
  * The graded-corpus apparatus for adjudicating a stochastic model swap per stage (epic
- * #1842), plus the ingestion of `/skill-creator`-authored eval sets (epic #4649). Five live
+ * #1842), plus the ingestion of `/skill-creator`-authored eval sets (epic #4649). Six live
  * surfaces:
  *
  *   fabrika eval check <manifest>   # decode a corpus manifest; exit non-zero on a bad one
  *   fabrika eval report <rows>      # the graded two-axis scorecard over runner rows
  *   fabrika eval cases <path>       # decode an authored eval set; exit non-zero on a bad one
  *   fabrika eval run <path>         # execute an eval set unattended, emit the capture manifest
+ *   fabrika eval graded <path>      # five runs per graded case, the median, and the head-bound record
  *   fabrika eval keeps <path>       # print the ruled KEEP corpus and what already pins each row
  *
  * `check` (issue #1848) validates the on-disk corpus format. `report` (issue #1853) is the
@@ -17,7 +18,9 @@
  * cost — as a human table (default) or stable JSON (`--json`), the evidence the model-tiering
  * decision (#1576) consumes. It presents measurement, never a recommendation. `cases` (issue
  * #4674) validates a `/skill-creator` `evals/evals.json` and prints the tier each case derives to.
- * `keeps` (issue #4823) prints the ruled KEEP corpus — the enumeration that replaced the
+ * `graded` (issue #4678) is the judgment tier: it runs each graded case five times through the
+ * grader the case's authoring session defined, takes the median, and emits the head-bound eval
+ * record. `keeps` (issue #4823) prints the ruled KEEP corpus — the enumeration that replaced the
  * two-artifact join every consumer used to re-run by hand.
  *
  * Thin IO shell over the pure cores (the `token-spend` / `readme-guard` idiom): read the file,
@@ -30,8 +33,26 @@ import {Argument, Command, Flag} from "effect/unstable/cli";
 import {leafCommand} from "../excess-operand.ts";
 import {DEFAULT_SPEND_LEDGER_PATH, persistSpendRows} from "../spend/ledger.ts";
 import {FAILED} from "../verb.ts";
-import {INTEGRITY_VIOLATION, MALFORMED_DOCUMENT, RUNS_NOT_EXECUTED, ZERO_SCOPE} from "./codes.ts";
+import {VERSION} from "../version.ts";
+import {emit as emitEvalRecord} from "../wire/eval-record.ts";
+import {
+	INTEGRITY_VIOLATION,
+	MALFORMED_DOCUMENT,
+	NO_MEASUREMENT,
+	RUNS_NOT_EXECUTED,
+	ZERO_SCOPE,
+} from "./codes.ts";
 import {decodeManifest, REVIEW_SURFACES, type ReviewSurface, STAGES} from "./corpus.ts";
+import {
+	buildEvalRecord,
+	candidateOutputOf,
+	composeGraderPrompt,
+	GRADED_RUNS,
+	gradableCase,
+	graderResponseOf,
+	readGraderVerdict,
+	runGradedAxis,
+} from "./graded-axis.ts";
 import {decodeIncidentProvenance} from "./incident-provenance.ts";
 import {
 	type BaselineKey,
@@ -511,6 +532,203 @@ const runCommand = leafCommand(
 	),
 );
 
+const surfaceFlag = Flag.string("surface").pipe(
+	Flag.optional,
+	Flag.withDescription(
+		`the review surface being graded, required with --stage review (one of: ${REVIEW_SURFACES.join(", ")}) — a pass rate measures one grading regime`,
+	),
+);
+
+const shaFlag = Flag.string("sha").pipe(
+	Flag.withDescription(
+		"the head commit the review ran against — the record is bound to it, and a record bound to nothing attests no tree",
+	),
+);
+
+const harnessFlag = Flag.string("harness").pipe(
+	Flag.withDefault(VERSION),
+	Flag.withDescription(
+		`the harness version the measurement is pinned to (#4637 ruling 4; default: ${VERSION})`,
+	),
+);
+
+const runsFlag = Flag.integer("runs").pipe(
+	Flag.withDefault(GRADED_RUNS),
+	Flag.withDescription(
+		`how many times each graded case is executed before the median is taken (default: ${GRADED_RUNS}, the ruled count)`,
+	),
+);
+
+const recordOutFlag = Flag.string("out").pipe(
+	Flag.optional,
+	Flag.withDescription("also write the record's bytes here; they always go to stdout"),
+);
+
+/**
+ * `graded` — run a skill's graded cases five times each, take the median, and emit the head-bound
+ * eval record (#4678).
+ *
+ * Its supported invocation sites are an operator's shell and the `review` stage on a PR that changes
+ * a skill. **No CI workflow invokes it**, for `run`'s reason above: the founder ruling on #4649
+ * removed model-in-the-loop execution from CI on a **cost** constraint — no credits for model runs
+ * inside the CI provider — recorded as a cost constraint and not a principle, so a future reader
+ * knows what would have to change to revisit it. CI's leg is #4681, which verifies that the record
+ * exists, is bound to the head, and clears the bar; it runs no model.
+ *
+ * The exit code reports **whether a measurement exists**, never whether it was good. A below-bar
+ * rate exits `0` with its number in the record, because the ruled bar is #4681's judgement.
+ */
+const graded = leafCommand(
+	"graded",
+	{
+		path: evalSetArg,
+		stage: stageFlag,
+		surface: surfaceFlag,
+		model: modelFlag,
+		pluginDir: pluginDirFlag,
+		sha: shaFlag,
+		harness: harnessFlag,
+		runs: runsFlag,
+		timeoutMs: timeoutFlag,
+		out: recordOutFlag,
+	},
+	Effect.fn(function* (opts) {
+		const run = Effect.gen(function* () {
+			const fs = yield* FileSystem.FileSystem;
+			const text = yield* Effect.mapError(
+				fs.readFileString(opts.path),
+				() => new EvalSetUnreadable({path: opts.path}),
+			);
+			const decoded = decodeSkillEvalSet(text);
+			if (Result.isFailure(decoded)) {
+				yield* Console.error(
+					`fabrika eval: ${opts.path} is not a valid skill eval set (${decoded.failure.reason}): ${decoded.failure.message}`,
+				);
+				return yield* Effect.sync(() => process.exit(MALFORMED_DOCUMENT));
+			}
+			if (!isStageName(opts.stage)) {
+				yield* Console.error(
+					`fabrika eval: --stage '${opts.stage}' is not a known stage (${STAGES.join(", ")})`,
+				);
+				return yield* Effect.sync(() => process.exit(FAILED));
+			}
+			let surface: ReviewSurface | null = null;
+			if (opts.surface._tag === "Some") {
+				if (!isReviewSurface(opts.surface.value)) {
+					yield* Console.error(
+						`fabrika eval: --surface '${opts.surface.value}' is not a known review surface (${REVIEW_SURFACES.join(", ")})`,
+					);
+					return yield* Effect.sync(() => process.exit(FAILED));
+				}
+				surface = opts.surface.value;
+			}
+			if (opts.stage === "review" && surface === null) {
+				yield* Console.error(
+					"fabrika eval: --stage review needs --surface — a review pass rate is one grading regime, never an average of two (ADR 0243 §4)",
+				);
+				return yield* Effect.sync(() => process.exit(FAILED));
+			}
+
+			const cases = decoded.success.cases
+				.filter((evalCase) => evalCase.tier === "graded")
+				.map(gradableCase);
+			// A set with no graded case has nothing for this axis to measure. Reporting a green over it
+			// is the zero-scope pass ADR 0092 forbids; reporting an UNRECORDABLE record would claim a
+			// measurement was attempted and died, which is a different and untrue fact.
+			if (cases.length === 0) {
+				yield* Console.error(
+					`fabrika eval: ${opts.path} carries no graded case — the graded axis measured nothing (ADR 0092)`,
+				);
+				return yield* Effect.sync(() => process.exit(ZERO_SCOPE));
+			}
+
+			const crypto = yield* Crypto.Crypto;
+			const executor = claudeExecutor({timeoutMs: opts.timeoutMs});
+			const invoke = (
+				evalCase: ReturnType<typeof gradableCase>,
+				prompt: string,
+				pluginDir: string | null,
+			) =>
+				Effect.gen(function* () {
+					const sessionId = yield* Effect.orDie(crypto.randomUUIDv4);
+					return yield* executor({
+						caseId: evalCase.id,
+						tier: "graded",
+						arm: "with-skill",
+						sessionId,
+						prompt,
+						model: opts.model,
+						pluginDir,
+						jsonSchema: null,
+					});
+				});
+
+			const results = yield* runGradedAxis({
+				cases,
+				runs: opts.runs,
+				runOnce: ({evalCase}) =>
+					Effect.gen(function* () {
+						const candidate = candidateOutputOf(
+							yield* invoke(evalCase, evalCase.prompt, opts.pluginDir),
+						);
+						if (candidate._tag !== "Output") return candidate;
+						// The grader loads no plugin: it judges what the candidate produced against the
+						// authored expectations, and running the skill again inside the grader would make
+						// the judgement depend on a second execution nobody scored.
+						return readGraderVerdict(
+							graderResponseOf(
+								yield* invoke(
+									evalCase,
+									composeGraderPrompt({evalCase, candidateOutput: candidate.text}),
+									null,
+								),
+							),
+						);
+					}),
+			});
+
+			const built = buildEvalRecord({
+				sha: opts.sha,
+				recordedAt: new Date().toISOString(),
+				cell: {stage: opts.stage, surface, model: opts.model},
+				pins: {
+					model: opts.model,
+					cli: (yield* claudeVersion()) ?? "unknown",
+					harness: opts.harness,
+				},
+				results,
+			});
+			if (built._tag === "Unusable") {
+				yield* Console.error(`fabrika eval: cannot record this run — ${built.reason}`);
+				return yield* Effect.sync(() => process.exit(FAILED));
+			}
+
+			const bytes = emitEvalRecord(built.record);
+			if (opts.out._tag === "Some") yield* fs.writeFileString(opts.out.value, bytes);
+			yield* Console.log(bytes);
+			if (built.record.outcome === "UNRECORDABLE") {
+				yield* Console.error(
+					`fabrika eval: every run of all ${results.length} graded case(s) returned no verdict — the record is UNRECORDABLE, which is not a below-bar number`,
+				);
+				return yield* Effect.sync(() => process.exit(NO_MEASUREMENT));
+			}
+		});
+		yield* run.pipe(
+			Effect.catchTag("EvalSetUnreadable", (e) =>
+				Effect.gen(function* () {
+					yield* Console.error(`fabrika eval: cannot read ${e.path}`);
+					return yield* Effect.sync(() => process.exit(FAILED));
+				}),
+			),
+		);
+	}),
+).pipe(
+	Command.withShortDescription("Run a skill's graded cases five times and record the median."),
+	Command.withDescription(
+		"Run each graded case five times through the authored grader, take the median, and emit the head-bound eval record — for an operator's shell or a review-stage spawn, never a CI job (#4678)",
+	),
+);
+
 // A named enumeration/ledger path that could not be read — a hard error (exit 1), not a skip.
 class KeepsUnreadable extends Schema.TaggedErrorClass<KeepsUnreadable>()("KeepsUnreadable", {
 	path: Schema.String,
@@ -600,8 +818,8 @@ const keeps = leafCommand(
 );
 
 export const evalCommand = Command.make("eval").pipe(
-	Command.withSubcommands([check, report, cases, runCommand, keeps]),
+	Command.withSubcommands([check, report, cases, runCommand, graded, keeps]),
 	Command.withDescription(
-		"Graded per-stage corpus + scorecard + authored-eval-set ingestion + the unattended runner + the ruled KEEP enumeration (#1848, #1853, #4674, #4676, #4823)",
+		"Graded per-stage corpus + scorecard + authored-eval-set ingestion + the unattended runner + the five-run graded axis + the ruled KEEP enumeration (#1848, #1853, #4674, #4676, #4678, #4823)",
 	),
 );

--- a/packages/fabrika-cli/src/eval/command.ts
+++ b/packages/fabrika-cli/src/eval/command.ts
@@ -47,7 +47,6 @@ import {
 	buildEvalRecord,
 	candidateOutputOf,
 	composeGraderPrompt,
-	GRADED_RUNS,
 	gradableCase,
 	graderResponseOf,
 	readGraderVerdict,
@@ -552,13 +551,6 @@ const harnessFlag = Flag.string("harness").pipe(
 	),
 );
 
-const runsFlag = Flag.integer("runs").pipe(
-	Flag.withDefault(GRADED_RUNS),
-	Flag.withDescription(
-		`how many times each graded case is executed before the median is taken (default: ${GRADED_RUNS}, the ruled count)`,
-	),
-);
-
 const recordOutFlag = Flag.string("out").pipe(
 	Flag.optional,
 	Flag.withDescription("also write the record's bytes here; they always go to stdout"),
@@ -577,6 +569,12 @@ const recordOutFlag = Flag.string("out").pipe(
  *
  * The exit code reports **whether a measurement exists**, never whether it was good. A below-bar
  * rate exits `0` with its number in the record, because the ruled bar is #4681's judgement.
+ *
+ * **The run count is not a flag.** Five is the ruled count (#4637 ruling 4), and a record produced at
+ * one run is indistinguishable at the gate from one produced at five — same token, same clause shape,
+ * same rate — so a flag would make the ruled protocol optional at no cost to the record, under the
+ * exact cost pressure that makes cutting it tempting. `runGradedAxis`'s `runs` parameter stays for the
+ * unit tier; re-adding a flag needs #4681 asserting `every case.runs === GRADED_RUNS` first.
  */
 const graded = leafCommand(
 	"graded",
@@ -588,24 +586,15 @@ const graded = leafCommand(
 		pluginDir: pluginDirFlag,
 		sha: shaFlag,
 		harness: harnessFlag,
-		runs: runsFlag,
 		timeoutMs: timeoutFlag,
 		out: recordOutFlag,
 	},
 	Effect.fn(function* (opts) {
 		const run = Effect.gen(function* () {
 			const fs = yield* FileSystem.FileSystem;
-			const text = yield* Effect.mapError(
-				fs.readFileString(opts.path),
-				() => new EvalSetUnreadable({path: opts.path}),
-			);
-			const decoded = decodeSkillEvalSet(text);
-			if (Result.isFailure(decoded)) {
-				yield* Console.error(
-					`fabrika eval: ${opts.path} is not a valid skill eval set (${decoded.failure.reason}): ${decoded.failure.message}`,
-				);
-				return yield* Effect.sync(() => process.exit(MALFORMED_DOCUMENT));
-			}
+			// The invocation is validated *before* the set is read, so the two kinds of failure stay
+			// apart: a bad --stage/--surface is the operator's own mistake and records nothing, while
+			// every refusal below is a fact about the eval set and therefore leaves a record.
 			if (!isStageName(opts.stage)) {
 				yield* Console.error(
 					`fabrika eval: --stage '${opts.stage}' is not a known stage (${STAGES.join(", ")})`,
@@ -629,17 +618,59 @@ const graded = leafCommand(
 				return yield* Effect.sync(() => process.exit(FAILED));
 			}
 
+			const cli = (yield* claudeVersion()) ?? "unknown";
+			const pins = {model: opts.model, cli, harness: opts.harness};
+			const cell = {stage: opts.stage, surface, model: opts.model};
+			/**
+			 * Emit the `UNRECORDABLE` record for a run that never reached a case, then exit on `code`.
+			 *
+			 * Founder ruling (#4678 comment 5247447078): a set that could not be read, one that does not
+			 * conform, and one carrying no graded case each emit an **explicit** record naming which it
+			 * was. Silence reaches #4681 as `missing`, which is byte-identical to a review that never ran
+			 * the axis — the exact ambiguity ADR 0253 Amendment 1 exists to remove. The exit code is
+			 * unchanged, so a caller still tells the three apart without parsing the record.
+			 */
+			const recordNoMeasurement = (noMeasurement: string, code: number) =>
+				Effect.gen(function* () {
+					const built = buildEvalRecord({
+						sha: opts.sha,
+						recordedAt: new Date().toISOString(),
+						cell,
+						pins,
+						results: [],
+						noMeasurement,
+					});
+					if (built._tag === "Unusable") {
+						yield* Console.error(`fabrika eval: cannot record this run — ${built.reason}`);
+						return yield* Effect.sync(() => process.exit(FAILED));
+					}
+					const bytes = emitEvalRecord(built.record);
+					if (opts.out._tag === "Some") yield* fs.writeFileString(opts.out.value, bytes);
+					yield* Console.log(bytes);
+					yield* Console.error(`fabrika eval: ${noMeasurement} — recorded UNRECORDABLE`);
+					return yield* Effect.sync(() => process.exit(code));
+				});
+
+			const read = yield* Effect.result(fs.readFileString(opts.path));
+			if (Result.isFailure(read)) {
+				return yield* recordNoMeasurement(`${opts.path} could not be read`, FAILED);
+			}
+			const decoded = decodeSkillEvalSet(read.success);
+			if (Result.isFailure(decoded)) {
+				return yield* recordNoMeasurement(
+					`${opts.path} is not a valid skill eval set (${decoded.failure.reason}): ${decoded.failure.message}`,
+					MALFORMED_DOCUMENT,
+				);
+			}
+
 			const cases = decoded.success.cases
 				.filter((evalCase) => evalCase.tier === "graded")
 				.map(gradableCase);
-			// A set with no graded case has nothing for this axis to measure. Reporting a green over it
-			// is the zero-scope pass ADR 0092 forbids; reporting an UNRECORDABLE record would claim a
-			// measurement was attempted and died, which is a different and untrue fact.
+			// A set with no graded case has nothing for this axis to measure, so reporting a green over
+			// it is the zero-scope pass ADR 0092 forbids. It records rather than exits silent, for
+			// `recordNoMeasurement`'s reason.
 			if (cases.length === 0) {
-				yield* Console.error(
-					`fabrika eval: ${opts.path} carries no graded case — the graded axis measured nothing (ADR 0092)`,
-				);
-				return yield* Effect.sync(() => process.exit(ZERO_SCOPE));
+				return yield* recordNoMeasurement(`${opts.path} carries no graded case`, ZERO_SCOPE);
 			}
 
 			const crypto = yield* Crypto.Crypto;
@@ -665,7 +696,6 @@ const graded = leafCommand(
 
 			const results = yield* runGradedAxis({
 				cases,
-				runs: opts.runs,
 				runOnce: ({evalCase}) =>
 					Effect.gen(function* () {
 						const candidate = candidateOutputOf(
@@ -690,12 +720,8 @@ const graded = leafCommand(
 			const built = buildEvalRecord({
 				sha: opts.sha,
 				recordedAt: new Date().toISOString(),
-				cell: {stage: opts.stage, surface, model: opts.model},
-				pins: {
-					model: opts.model,
-					cli: (yield* claudeVersion()) ?? "unknown",
-					harness: opts.harness,
-				},
+				cell,
+				pins,
 				results,
 			});
 			if (built._tag === "Unusable") {
@@ -713,14 +739,7 @@ const graded = leafCommand(
 				return yield* Effect.sync(() => process.exit(NO_MEASUREMENT));
 			}
 		});
-		yield* run.pipe(
-			Effect.catchTag("EvalSetUnreadable", (e) =>
-				Effect.gen(function* () {
-					yield* Console.error(`fabrika eval: cannot read ${e.path}`);
-					return yield* Effect.sync(() => process.exit(FAILED));
-				}),
-			),
-		);
+		yield* run;
 	}),
 ).pipe(
 	Command.withShortDescription("Run a skill's graded cases five times and record the median."),

--- a/packages/fabrika-cli/src/eval/graded-axis.ts
+++ b/packages/fabrika-cli/src/eval/graded-axis.ts
@@ -1,0 +1,405 @@
+/**
+ * The graded axis — the reused grader-agent judgment path at five runs and a median (issue #4678,
+ * epic #4649).
+ *
+ * The deterministic tier (`deterministic-tier.ts`) runs a mechanically-checkable case once. A case
+ * carrying even one judgment assertion cannot be read off an exit status, so it comes here: the case
+ * is executed **five times**, each execution is judged by the grader-agent pattern the authoring
+ * tool already uses, and the case's verdict is the **median** of those five (founder ruling 4 on
+ * #4637).
+ *
+ * **No rubric is invented here.** The grader is handed the case's own authored `expected_output` and
+ * `expectations` verbatim ({@link composeGraderPrompt}), so the judgment a case receives in a review
+ * is the judgment its authoring session defined. This module owns the protocol around that pattern —
+ * five runs, the median, what a dead invocation counts as — and nothing about what "good" means.
+ *
+ * Two arithmetic definitions come from ADR 0252 §1 and are not re-derived: `dispersion` is the
+ * minority-verdict count, and the per-run verdicts are retained beside it so a reader re-derives the
+ * aggregate instead of trusting it. The shape of what the run leaves behind is ADR 0253's
+ * (`../wire/eval-record.ts`).
+ *
+ * This module is **pure**: the executions arrive through the {@link RunOnce} seam, so the unit tier
+ * drives the whole protocol against a stubbed grader and no unit test spends a cent.
+ */
+import {Effect} from "effect";
+import {
+	dispersionOf,
+	type EvalCaseBlock,
+	type EvalRecord,
+	type EvalRecordCell,
+	type EvalRecordPins,
+	recordedAt as makeRecordedAt,
+	roundRate,
+} from "../wire/eval-record.ts";
+import {headSha, clause as makeClause} from "../wire/verdict-marker.ts";
+import type {AssertionOutcome, EvalRow} from "./deterministic-tier.ts";
+import type {ScorecardCell} from "./report.ts";
+import {decodeHeadlessResult, type ExecutorResult} from "./spawn.ts";
+
+/** Founder ruling 4 on #4637: five runs and take the median for a judgment eval. */
+export const GRADED_RUNS = 5;
+
+/**
+ * Why a grader invocation produced no verdict (ADR 0253 §4).
+ *
+ * Four rather than one because they are four different repairs: a grader that answered nothing, one
+ * whose answer could not be read, one that never came back, and one that never ran.
+ */
+export const NO_VERDICT_REASONS = [
+	"no-output",
+	"unparseable",
+	"timed-out",
+	"invocation-failed",
+] as const;
+
+export type NoVerdictReason = (typeof NO_VERDICT_REASONS)[number];
+
+/** One run's answer. `NoVerdict` is a typed outcome, never an absent value and never a pass. */
+export type RunVerdict =
+	| {readonly _tag: "Verdict"; readonly passed: boolean}
+	| {readonly _tag: "NoVerdict"; readonly reason: NoVerdictReason};
+
+/** What the grader invocation produced, as a value — the shape {@link readGraderVerdict} judges. */
+export type GraderResponse =
+	| {readonly _tag: "Returned"; readonly text: string}
+	| {readonly _tag: "TimedOut"}
+	| {readonly _tag: "InvocationFailed"; readonly detail: string};
+
+/** The one line the grader is asked to end on. Reading it is not a rubric — the rubric is authored. */
+const VERDICT_LINE = /^\s*VERDICT:\s*(PASS|FAIL)\s*$/i;
+
+/**
+ * Read a grader response into a run verdict. Total, and never defaults to a pass.
+ *
+ * The last conforming line wins: a grader that reasons aloud before answering mentions `PASS` and
+ * `FAIL` on the way, so the first match is the wrong one to trust.
+ */
+export const readGraderVerdict = (response: GraderResponse): RunVerdict => {
+	if (response._tag === "TimedOut") return {_tag: "NoVerdict", reason: "timed-out"};
+	if (response._tag === "InvocationFailed") {
+		return {_tag: "NoVerdict", reason: "invocation-failed"};
+	}
+	if (response.text.trim() === "") return {_tag: "NoVerdict", reason: "no-output"};
+	const lines = response.text.split("\n");
+	for (let i = lines.length - 1; i >= 0; i -= 1) {
+		const matched = VERDICT_LINE.exec(lines[i] ?? "");
+		if (matched?.[1] !== undefined) {
+			return {_tag: "Verdict", passed: matched[1].toUpperCase() === "PASS"};
+		}
+	}
+	return {_tag: "NoVerdict", reason: "unparseable"};
+};
+
+/**
+ * What the executor observed, read as a grader response.
+ *
+ * The mapping is the whole reason the four `NoVerdict` reasons are four: a wedged grader, one that
+ * never started, and one that answered nothing are three different repairs, and the executor already
+ * tells them apart. Folding them here would throw that away at the last step.
+ */
+export const graderResponseOf = (result: ExecutorResult): GraderResponse => {
+	if (result._tag === "TimedOut") return {_tag: "TimedOut"};
+	if (result._tag === "SpawnFailed") return {_tag: "InvocationFailed", detail: result.detail};
+	const decoded = decodeHeadlessResult(result.stdout);
+	// An undecodable payload is not silence: the invocation returned bytes nobody can read, which is
+	// `unparseable` once `readGraderVerdict` looks for a verdict line in them.
+	return {_tag: "Returned", text: decoded === null ? result.stdout : decoded.text};
+};
+
+/**
+ * The candidate run's output, or why the run produced none.
+ *
+ * A candidate that died is a run with no verdict for the *same* reason a dead grader is: nothing was
+ * judged. Scoring it as a fail would blame the skill for the harness (ADR 0253 §4).
+ */
+export const candidateOutputOf = (
+	result: ExecutorResult,
+): {readonly _tag: "Output"; readonly text: string} | RunVerdict => {
+	if (result._tag === "TimedOut") return {_tag: "NoVerdict", reason: "timed-out"};
+	if (result._tag === "SpawnFailed") return {_tag: "NoVerdict", reason: "invocation-failed"};
+	const text = decodeHeadlessResult(result.stdout)?.text ?? "";
+	return text.trim() === "" ? {_tag: "NoVerdict", reason: "no-output"} : {_tag: "Output", text};
+};
+
+/** One run's token as the eval record carries it, in run order. */
+export const perRunToken = (verdict: RunVerdict): string =>
+	verdict._tag === "Verdict" ? (verdict.passed ? "pass" : "fail") : `no-verdict:${verdict.reason}`;
+
+/**
+ * The case a graded run is driven from — read structurally, so this module adds no field to the
+ * authored `/skill-creator` format and depends on none of the ingestion module's other fields.
+ */
+export interface GradableCase {
+	readonly id: number;
+	readonly prompt: string;
+	/** The authored `expected_output`, verbatim. `null` when the case declares none. */
+	readonly expectedOutput: string | null;
+	/** The authored judgment assertions, verbatim. This is the rubric, and the only one. */
+	readonly expectations: ReadonlyArray<string>;
+}
+
+/**
+ * A decoded eval case as this module reads it: the authored prompt, expected output and assertion
+ * texts, and nothing else. Every assertion is handed to the grader — a graded case's mechanical
+ * assertions are part of the standard its author wrote, not a separate tier to drop here.
+ */
+export const gradableCase = (evalCase: {
+	readonly id: number;
+	readonly prompt: string;
+	readonly expectedOutput: string | null;
+	readonly assertions: ReadonlyArray<{readonly text: string}>;
+}): GradableCase => ({
+	id: evalCase.id,
+	prompt: evalCase.prompt,
+	expectedOutput: evalCase.expectedOutput,
+	expectations: evalCase.assertions.map((assertion) => assertion.text),
+});
+
+/**
+ * The fixed instructions {@link composeGraderPrompt} adds around the authored text.
+ *
+ * Exported so a test can assert that everything *else* in a composed prompt came from the case: the
+ * "no second rubric" property is checkable rather than asserted, which is what keeps a future edit
+ * from smuggling a criterion in here.
+ */
+export const GRADER_INSTRUCTIONS = [
+	"You are grading one eval case. The expectations below were written by the skill's authoring",
+	"session and are the whole standard — apply them as written, add none of your own, and drop none.",
+	"Answer on a final line of exactly `VERDICT: PASS` or `VERDICT: FAIL`, and nothing after it.",
+] as const;
+
+const section = (heading: string, body: string): string => `## ${heading}\n${body}`;
+
+/** Compose the grader's prompt: the fixed instructions, then the case's own authored text. */
+export const composeGraderPrompt = (args: {
+	readonly evalCase: GradableCase;
+	readonly candidateOutput: string;
+}): string => {
+	const {evalCase, candidateOutput} = args;
+	return [
+		GRADER_INSTRUCTIONS.join("\n"),
+		"",
+		section("Prompt the skill was given", evalCase.prompt),
+		"",
+		section("What the skill produced", candidateOutput),
+		...(evalCase.expectedOutput === null
+			? []
+			: ["", section("Expected output, as authored", evalCase.expectedOutput)]),
+		"",
+		section(
+			"Expectations, as authored",
+			evalCase.expectations.map((text) => `- ${text}`).join("\n"),
+		),
+	].join("\n");
+};
+
+/** A case's median verdict. `unmeasured` is the case whose every run returned no verdict. */
+export type CaseVerdict = "pass" | "fail" | "unmeasured";
+
+/** One graded case's five runs, retained rather than collapsed into the median (#4678). */
+export interface GradedCaseResult {
+	readonly caseId: number;
+	readonly verdict: CaseVerdict;
+	readonly runs: number;
+	readonly passed: number;
+	readonly noVerdict: number;
+	readonly dispersion: number;
+	readonly perRun: ReadonlyArray<string>;
+}
+
+/**
+ * The median over an odd or even set of binary verdicts, with a `NoVerdict` on the non-pass side.
+ *
+ * Sorting `fail < pass` and taking the **lower** middle element is what makes an even split resolve
+ * to `fail`: a set that is half failing has not shown the case passes, and the alternative — rounding
+ * a tie up — would be the median quietly defaulting to a pass, which is the direction this whole
+ * module refuses. At the ruled five runs the tie never arises; the rule is stated because the
+ * function is total over any run count.
+ */
+export const medianVerdict = (verdicts: ReadonlyArray<RunVerdict>): CaseVerdict => {
+	if (verdicts.length === 0) return "unmeasured";
+	if (verdicts.every((verdict) => verdict._tag === "NoVerdict")) return "unmeasured";
+	const passed = verdicts.filter((verdict) => verdict._tag === "Verdict" && verdict.passed).length;
+	// The lower middle index of the sorted set: with `fail` sorting first, the element at
+	// `floor((n-1)/2)` is `pass` exactly when the passes fill the upper half and one more.
+	return passed > Math.floor(verdicts.length / 2) ? "pass" : "fail";
+};
+
+/** Fold one case's runs into its retained result — the median plus everything the median throws away. */
+export const gradeCase = (
+	caseId: number,
+	verdicts: ReadonlyArray<RunVerdict>,
+): GradedCaseResult => {
+	const passed = verdicts.filter((verdict) => verdict._tag === "Verdict" && verdict.passed).length;
+	const noVerdict = verdicts.filter((verdict) => verdict._tag === "NoVerdict").length;
+	return {
+		caseId,
+		verdict: medianVerdict(verdicts),
+		runs: verdicts.length,
+		passed,
+		noVerdict,
+		dispersion: dispersionOf(verdicts.length, passed),
+		perRun: verdicts.map(perRunToken),
+	};
+};
+
+/**
+ * Execute one run of one case and judge it. The module's only seam, and the only path to a model.
+ *
+ * `R` is the platform requirement the *implementation* carries — the spawning shell's services, or
+ * `never` for a stub — so this core names no platform service and a unit test drives the whole
+ * protocol offline.
+ */
+export type RunOnce<R = never> = (args: {
+	readonly evalCase: GradableCase;
+	/** 1-based, so a log or a stub can name which of the five it is. */
+	readonly run: number;
+}) => Effect.Effect<RunVerdict, never, R>;
+
+/**
+ * Run every case `runs` times and fold each into its median.
+ *
+ * **A `NoVerdict` is never retried inside the block.** A retry replaces a measurement with a
+ * re-measurement and silently changes what the median measured, so the count is fixed and a dead
+ * invocation is carried into the record instead (ADR 0253 §4). Any retry policy belongs around the
+ * whole five-run block, recorded as such.
+ */
+export const runGradedAxis = <R>(args: {
+	readonly cases: ReadonlyArray<GradableCase>;
+	readonly runOnce: RunOnce<R>;
+	readonly runs?: number;
+}): Effect.Effect<ReadonlyArray<GradedCaseResult>, never, R> =>
+	Effect.gen(function* () {
+		const runs = args.runs ?? GRADED_RUNS;
+		const results: Array<GradedCaseResult> = [];
+		for (const evalCase of args.cases) {
+			const verdicts: Array<RunVerdict> = [];
+			for (let run = 1; run <= runs; run += 1) {
+				verdicts.push(yield* args.runOnce({evalCase, run}));
+			}
+			results.push(gradeCase(evalCase.id, verdicts));
+		}
+		return results;
+	});
+
+/**
+ * A graded case as an `EvalRow`, so graded rows fold through `summarizeEvalRows` — **the** aggregator
+ * both tiers share — rather than through a second path.
+ *
+ * The grader answers per case, not per assertion, so every judged assertion carries the case's own
+ * verdict and says so on a non-pass. Inventing a per-assertion answer the grader never gave would be
+ * exactly the fabricated detail the eval layer exists to keep out.
+ */
+export const toEvalRow = (result: GradedCaseResult, evalCase: GradableCase): EvalRow => {
+	const outcome =
+		result.verdict === "pass" ? "pass" : result.verdict === "fail" ? "fail" : "uncheckable";
+	const detail =
+		result.verdict === "pass"
+			? null
+			: result.verdict === "fail"
+				? `the median of ${result.runs} run(s) is fail (${result.passed} passed, ${result.noVerdict} returned no verdict)`
+				: `every one of ${result.runs} run(s) returned no verdict (${result.perRun.join(", ")})`;
+	const assertions: ReadonlyArray<AssertionOutcome> = evalCase.expectations.map((text) => ({
+		text,
+		cue: null,
+		status: outcome === "pass" ? "pass" : outcome === "fail" ? "fail" : "uncheckable",
+		detail: outcome === "pass" ? null : detail,
+	}));
+	return {caseId: result.caseId, tier: "graded", outcome, runs: result.runs, assertions, detail};
+};
+
+/**
+ * The cell aggregate, spelled as `ScorecardCell` so #4680 commits a scorecard row without renaming
+ * anything (ADR 0253 §5). One graded **case** is one graded run at cell level; the five executions
+ * behind it live in the case block.
+ *
+ * An `unmeasured` case is absent from both sides. It measured nothing, so counting it as a failure
+ * would publish a number nobody took — the `0.0`-over-no-measurement the record's `UNRECORDABLE`
+ * token exists to keep distinguishable (ADR 0253 §2).
+ */
+export const gradedCellAggregate = (
+	results: ReadonlyArray<GradedCaseResult>,
+): Pick<ScorecardCell, "gradedRuns" | "passedRuns" | "passRate"> => {
+	const graded = results.filter((result) => result.verdict !== "unmeasured");
+	const passedRuns = graded.filter((result) => result.verdict === "pass").length;
+	return {
+		gradedRuns: graded.length,
+		passedRuns,
+		passRate: graded.length === 0 ? 0 : roundRate(passedRuns / graded.length),
+	};
+};
+
+const caseBlock = (result: GradedCaseResult): EvalCaseBlock => ({
+	caseId: result.caseId,
+	verdict: result.verdict,
+	runs: result.runs,
+	passed: result.passed,
+	noVerdict: result.noVerdict,
+	dispersion: result.dispersion,
+	perRun: result.perRun,
+});
+
+export type EvalRecordBuild =
+	| {readonly _tag: "Record"; readonly record: EvalRecord}
+	| {readonly _tag: "Unusable"; readonly reason: string};
+
+/**
+ * Build the head-bound eval record for one cell's graded results.
+ *
+ * **A record is produced on every outcome.** A below-bar run records its below-bar number, and a run
+ * where nothing could be measured records `UNRECORDABLE` — because a failing run that wrote nothing
+ * would reach the verifier as `missing`, reddening for the wrong reason and destroying the number
+ * #4680's trend reads. `missing`, `stale`, `below-bar` and `unrecordable` stay four distinguishable
+ * states, and none of them is judged here: the 90% bar is #4681's and appears nowhere in this module.
+ */
+export const buildEvalRecord = (args: {
+	readonly sha: string;
+	readonly recordedAt: string;
+	readonly cell: EvalRecordCell;
+	readonly pins: EvalRecordPins;
+	readonly results: ReadonlyArray<GradedCaseResult>;
+}): EvalRecordBuild => {
+	const sha = headSha(args.sha);
+	if (sha === null) {
+		return {
+			_tag: "Unusable",
+			reason: `"${args.sha}" is not a head SHA — an unbound measurement attests no tree`,
+		};
+	}
+	const at = makeRecordedAt(args.recordedAt);
+	if (at === null) {
+		return {
+			_tag: "Unusable",
+			reason: `"${args.recordedAt}" is not an ISO-8601 UTC instant with a trailing Z`,
+		};
+	}
+	const aggregate = gradedCellAggregate(args.results);
+	const unmeasured = args.results.length - aggregate.gradedRuns;
+	const surface = args.cell.surface === null ? "—" : args.cell.surface;
+	const outcome = aggregate.gradedRuns === 0 ? "UNRECORDABLE" : "RECORDED";
+	const text = makeClause(
+		outcome === "RECORDED"
+			? `${args.cell.stage}/${surface} ${aggregate.passRate} (${aggregate.passedRuns}/${aggregate.gradedRuns} cases, ${unmeasured} unmeasured)`
+			: `${args.cell.stage}/${surface} no measurement — ${unmeasured} case(s) returned no verdict`,
+	);
+	if (text === null) {
+		// Unreachable: every branch above composes a non-blank clause from literals.
+		return {_tag: "Unusable", reason: "the composed clause is blank"};
+	}
+	return {
+		_tag: "Record",
+		record: {
+			outcome,
+			sha,
+			clause: text,
+			payload: {
+				sha,
+				recordedAt: at,
+				cell: args.cell,
+				pins: args.pins,
+				...aggregate,
+				cases: args.results.map(caseBlock),
+			},
+		},
+	};
+};

--- a/packages/fabrika-cli/src/eval/graded-axis.ts
+++ b/packages/fabrika-cli/src/eval/graded-axis.ts
@@ -351,6 +351,12 @@ export type EvalRecordBuild =
  * would reach the verifier as `missing`, reddening for the wrong reason and destroying the number
  * #4680's trend reads. `missing`, `stale`, `below-bar` and `unrecordable` stay four distinguishable
  * states, and none of them is judged here: the 90% bar is #4681's and appears nowhere in this module.
+ *
+ * That extends to the runs that never reached a case: an eval set that could not be read, one that
+ * does not conform, and one carrying no graded case each record `UNRECORDABLE` naming *which* of
+ * them it was, via `noMeasurement` (founder ruling, #4678 comment 5247447078 — explicit beats
+ * implicit for error cases). Silence there would reach #4681 as `missing`, indistinguishable from a
+ * review that never ran the axis at all.
  */
 export const buildEvalRecord = (args: {
 	readonly sha: string;
@@ -358,6 +364,8 @@ export const buildEvalRecord = (args: {
 	readonly cell: EvalRecordCell;
 	readonly pins: EvalRecordPins;
 	readonly results: ReadonlyArray<GradedCaseResult>;
+	/** Why nothing was measured, when the axis never reached a case. Only read on `UNRECORDABLE`. */
+	readonly noMeasurement?: string;
 }): EvalRecordBuild => {
 	const sha = headSha(args.sha);
 	if (sha === null) {
@@ -380,7 +388,7 @@ export const buildEvalRecord = (args: {
 	const text = makeClause(
 		outcome === "RECORDED"
 			? `${args.cell.stage}/${surface} ${aggregate.passRate} (${aggregate.passedRuns}/${aggregate.gradedRuns} cases, ${unmeasured} unmeasured)`
-			: `${args.cell.stage}/${surface} no measurement — ${unmeasured} case(s) returned no verdict`,
+			: `${args.cell.stage}/${surface} no measurement — ${args.noMeasurement ?? `${unmeasured} case(s) returned no verdict`}`,
 	);
 	if (text === null) {
 		// Unreachable: every branch above composes a non-blank clause from literals.
@@ -398,6 +406,7 @@ export const buildEvalRecord = (args: {
 				cell: args.cell,
 				pins: args.pins,
 				...aggregate,
+				unmeasuredCases: unmeasured,
 				cases: args.results.map(caseBlock),
 			},
 		},

--- a/packages/fabrika-cli/src/eval/graded-axis.unit.test.ts
+++ b/packages/fabrika-cli/src/eval/graded-axis.unit.test.ts
@@ -267,6 +267,25 @@ describe("the record is head-bound and written on every outcome", () => {
 		expect(built.record.clause).toContain("no measurement");
 	});
 
+	// The founder ruling on #4678 (comment 5247447078): a run that never reached a case still records,
+	// naming which failure it was, so #4681 can tell a broken eval set from a review that never ran.
+	it("records UNRECORDABLE naming why, for a run that never reached a case", () => {
+		const built = buildEvalRecord({
+			sha: HEAD,
+			recordedAt: "2026-08-10T04:08:00Z",
+			cell,
+			pins,
+			results: [],
+			noMeasurement: "evals.json carries no graded case",
+		});
+		expect(built._tag).toBe("Record");
+		if (built._tag !== "Record") return;
+		expect(built.record.outcome).toBe("UNRECORDABLE");
+		expect(built.record.payload.gradedRuns).toBe(0);
+		expect(built.record.payload.cases).toEqual([]);
+		expect(built.record.clause).toContain("carries no graded case");
+	});
+
 	it("refuses to build a record bound to something that is not a head", () => {
 		const built = buildEvalRecord({
 			sha: "HEAD~1",

--- a/packages/fabrika-cli/src/eval/graded-axis.unit.test.ts
+++ b/packages/fabrika-cli/src/eval/graded-axis.unit.test.ts
@@ -1,0 +1,298 @@
+/**
+ * The graded axis's own tier, driven entirely through a **stubbed grader** — no unit test here
+ * spawns a model or spends a cent.
+ *
+ * The assertions that carry the design are the ones about what the median throws away and what a
+ * dead invocation counts as: an even split resolves down, an all-fail set is a fail rather than an
+ * absence, a run that returned no verdict stays in the denominator and never lands on the passing
+ * side, and a case where every run died is `unmeasured` rather than a `0.0` nobody measured.
+ */
+import {Effect} from "effect";
+import {describe, expect, it} from "vitest";
+import {emit as emitRecord, read} from "../wire/eval-record.ts";
+import {summarizeEvalRows} from "./deterministic-tier.ts";
+import {
+	buildEvalRecord,
+	composeGraderPrompt,
+	GRADED_RUNS,
+	GRADER_INSTRUCTIONS,
+	type GradableCase,
+	gradeCase,
+	gradedCellAggregate,
+	medianVerdict,
+	perRunToken,
+	type RunVerdict,
+	readGraderVerdict,
+	runGradedAxis,
+	toEvalRow,
+} from "./graded-axis.ts";
+
+const HEAD = "03135b91e7d4a2c6f1b8093a5c4d2e1f6a7b8c9d";
+
+const pass: RunVerdict = {_tag: "Verdict", passed: true};
+const fail: RunVerdict = {_tag: "Verdict", passed: false};
+const dead = (reason: "no-output" | "timed-out"): RunVerdict => ({_tag: "NoVerdict", reason});
+
+const caseOf = (id: number, over: Partial<GradableCase> = {}): GradableCase => ({
+	id,
+	prompt: "File a report for the guard that reds on zero scope.",
+	expectedOutput: "One issue, tagged needs-triage.",
+	expectations: ["it files exactly one issue", "the issue carries no priority label"],
+	...over,
+});
+
+/** A grader stub: hands back a scripted verdict per (case, run) and counts what it was asked. */
+const scriptedGrader = (script: ReadonlyArray<RunVerdict>) => {
+	const calls: Array<{caseId: number; run: number}> = [];
+	return {
+		calls,
+		runOnce: ({evalCase, run}: {evalCase: GradableCase; run: number}) => {
+			calls.push({caseId: evalCase.id, run});
+			return Effect.succeed(script[(run - 1) % script.length] ?? fail);
+		},
+	};
+};
+
+describe("the median over a case's runs", () => {
+	it("is the majority at the ruled five runs", () => {
+		expect(medianVerdict([pass, pass, pass, fail, fail])).toBe("pass");
+		expect(medianVerdict([pass, pass, fail, fail, fail])).toBe("fail");
+	});
+
+	it("resolves an even split down — a half-failing set has not shown the case passes", () => {
+		expect(medianVerdict([pass, fail])).toBe("fail");
+		expect(medianVerdict([pass, pass, fail, fail])).toBe("fail");
+	});
+
+	it("is a fail over an all-fail set, never an absence", () => {
+		const result = gradeCase(7, [fail, fail, fail, fail, fail]);
+		expect(result.verdict).toBe("fail");
+		expect(result.passed).toBe(0);
+		expect(result.dispersion).toBe(0);
+	});
+
+	it("is unmeasured only when every run returned no verdict", () => {
+		expect(medianVerdict([dead("timed-out"), dead("no-output")])).toBe("unmeasured");
+		expect(medianVerdict([dead("timed-out"), pass])).toBe("fail");
+		expect(medianVerdict([])).toBe("unmeasured");
+	});
+});
+
+describe("a run that returns no verdict is typed and counted", () => {
+	it("reads each of the four reasons off what the grader did", () => {
+		expect(readGraderVerdict({_tag: "TimedOut"})).toEqual({
+			_tag: "NoVerdict",
+			reason: "timed-out",
+		});
+		expect(readGraderVerdict({_tag: "InvocationFailed", detail: "spawn"})).toEqual({
+			_tag: "NoVerdict",
+			reason: "invocation-failed",
+		});
+		expect(readGraderVerdict({_tag: "Returned", text: "  \n "})).toEqual({
+			_tag: "NoVerdict",
+			reason: "no-output",
+		});
+		expect(readGraderVerdict({_tag: "Returned", text: "I think it's fine, honestly."})).toEqual({
+			_tag: "NoVerdict",
+			reason: "unparseable",
+		});
+	});
+
+	it("takes the last verdict line, so reasoning that mentions PASS on the way does not win", () => {
+		const text =
+			"It could be a PASS if you squint.\nBut the second expectation fails.\nVERDICT: FAIL";
+		expect(readGraderVerdict({_tag: "Returned", text})).toEqual({_tag: "Verdict", passed: false});
+	});
+
+	it("stays in the denominator, never counts as passed, and is counted on its own", () => {
+		const result = gradeCase(3, [pass, fail, pass, dead("timed-out"), pass]);
+		expect(result.runs).toBe(5);
+		expect(result.passed).toBe(3);
+		expect(result.noVerdict).toBe(1);
+		expect(result.dispersion).toBe(2);
+		expect(result.perRun).toEqual(["pass", "fail", "pass", "no-verdict:timed-out", "pass"]);
+	});
+
+	it("makes a 3-of-5 with two dead invocations legible as a different fact from a 3-of-5 with two fails", () => {
+		const honest = gradeCase(1, [pass, pass, pass, fail, fail]);
+		const dying = gradeCase(1, [pass, pass, pass, dead("no-output"), dead("timed-out")]);
+		expect(honest.verdict).toBe(dying.verdict);
+		expect(honest.noVerdict).toBe(0);
+		expect(dying.noVerdict).toBe(2);
+	});
+
+	it("spells every reason on the per-run token", () => {
+		expect(perRunToken({_tag: "NoVerdict", reason: "unparseable"})).toBe("no-verdict:unparseable");
+	});
+});
+
+describe("the five-run protocol", () => {
+	it("runs each case exactly five times and never retries a dead invocation inside the block", () => {
+		const grader = scriptedGrader([pass, dead("timed-out"), pass, fail, pass]);
+		const results = Effect.runSync(
+			runGradedAxis({cases: [caseOf(11), caseOf(12)], runOnce: grader.runOnce}),
+		);
+		expect(grader.calls.length).toBe(2 * GRADED_RUNS);
+		expect(grader.calls.filter((call) => call.caseId === 11).map((call) => call.run)).toEqual([
+			1, 2, 3, 4, 5,
+		]);
+		expect(results.map((result) => result.verdict)).toEqual(["pass", "pass"]);
+		expect(results[0]?.noVerdict).toBe(1);
+	});
+});
+
+describe("the grader is the authoring session's, not a second rubric", () => {
+	const prompt = composeGraderPrompt({
+		evalCase: caseOf(1),
+		candidateOutput: "Filed #9001 with status:needs-triage.",
+	});
+
+	it("carries every authored expectation verbatim", () => {
+		for (const expectation of caseOf(1).expectations) {
+			expect(prompt).toContain(expectation);
+		}
+		expect(prompt).toContain("One issue, tagged needs-triage.");
+	});
+
+	it("adds no criterion of its own — everything not from the case is the fixed instruction block", () => {
+		const authored = [
+			...caseOf(1).expectations,
+			caseOf(1).prompt,
+			caseOf(1).expectedOutput ?? "",
+			"Filed #9001 with status:needs-triage.",
+		];
+		const leftover = prompt
+			.split("\n")
+			.map((line) => line.replace(/^[-#]+\s*/, "").trim())
+			.filter((line) => line !== "")
+			.filter((line) => !authored.includes(line))
+			.filter((line) => !GRADER_INSTRUCTIONS.includes(line as (typeof GRADER_INSTRUCTIONS)[number]))
+			// The section headings are structure, not standard: they name where each authored block
+			// came from and state no expectation of their own.
+			.filter((line) => !line.startsWith("Prompt the skill"))
+			.filter((line) => !line.startsWith("What the skill produced"))
+			.filter((line) => !line.startsWith("Expected output"))
+			.filter((line) => !line.startsWith("Expectations"));
+		expect(leftover).toEqual([]);
+	});
+});
+
+describe("graded rows fold through the one aggregator both tiers share", () => {
+	it("emits an EvalRow summarizeEvalRows counts under the graded tier", () => {
+		const rows = [
+			toEvalRow(gradeCase(11, [pass, pass, pass, fail, fail]), caseOf(11)),
+			toEvalRow(gradeCase(12, [fail, fail, fail, fail, fail]), caseOf(12)),
+		];
+		const summary = summarizeEvalRows(rows);
+		expect(summary.byTier.graded.cases).toBe(2);
+		expect(summary.byTier.graded.passed).toBe(1);
+		expect(summary.verdict).toBe("red");
+		expect(rows[0]?.runs).toBe(5);
+	});
+
+	it("reports an all-dead case as uncheckable, so the suite reds rather than scoring a zero", () => {
+		const row = toEvalRow(
+			gradeCase(13, [dead("timed-out"), dead("timed-out"), dead("no-output")]),
+			caseOf(13),
+		);
+		expect(row.outcome).toBe("uncheckable");
+		expect(summarizeEvalRows([row]).verdict).toBe("red");
+	});
+});
+
+describe("the cell aggregate is spelled as a scorecard cell", () => {
+	it("computes the pass rate over graded cases and excludes the unmeasured ones", () => {
+		const results = [
+			gradeCase(11, [pass, pass, pass, fail, fail]),
+			gradeCase(12, [fail, fail, fail, fail, fail]),
+			gradeCase(13, [dead("timed-out"), dead("timed-out"), dead("timed-out")]),
+		];
+		expect(gradedCellAggregate(results)).toEqual({
+			gradedRuns: 2,
+			passedRuns: 1,
+			passRate: 0.5,
+		});
+	});
+});
+
+describe("the record is head-bound and written on every outcome", () => {
+	const pins = {model: "claude-opus-4-6", cli: "2.1.220", harness: "fabrika 0.1.0"};
+	const cell = {stage: "review", surface: "skill", model: "claude-opus-4-6"};
+
+	it("binds the payload and the marker to the head the run was measured at", () => {
+		const built = buildEvalRecord({
+			sha: HEAD,
+			recordedAt: "2026-08-10T04:08:00Z",
+			cell,
+			pins,
+			results: [gradeCase(11, [pass, pass, pass, fail, fail])],
+		});
+		expect(built._tag).toBe("Record");
+		if (built._tag !== "Record") return;
+		expect(built.record.sha).toBe(HEAD);
+		expect(built.record.payload.sha).toBe(HEAD);
+		expect(built.record.payload.pins).toEqual(pins);
+		expect(built.record.payload.cases[0]?.perRun).toEqual(["pass", "pass", "pass", "fail", "fail"]);
+	});
+
+	it("records a below-bar number rather than withholding the record", () => {
+		const built = buildEvalRecord({
+			sha: HEAD,
+			recordedAt: "2026-08-10T04:08:00Z",
+			cell,
+			pins,
+			results: [
+				gradeCase(11, [fail, fail, fail, fail, fail]),
+				gradeCase(12, [fail, fail, fail, fail, fail]),
+			],
+		});
+		expect(built._tag).toBe("Record");
+		if (built._tag !== "Record") return;
+		expect(built.record.outcome).toBe("RECORDED");
+		expect(built.record.payload.passRate).toBe(0);
+	});
+
+	it("records UNRECORDABLE when nothing could be measured — never a 0.0 rate", () => {
+		const built = buildEvalRecord({
+			sha: HEAD,
+			recordedAt: "2026-08-10T04:08:00Z",
+			cell,
+			pins,
+			results: [gradeCase(11, [dead("timed-out"), dead("no-output"), dead("timed-out")])],
+		});
+		expect(built._tag).toBe("Record");
+		if (built._tag !== "Record") return;
+		expect(built.record.outcome).toBe("UNRECORDABLE");
+		expect(built.record.payload.gradedRuns).toBe(0);
+		expect(built.record.clause).toContain("no measurement");
+	});
+
+	it("refuses to build a record bound to something that is not a head", () => {
+		const built = buildEvalRecord({
+			sha: "HEAD~1",
+			recordedAt: "2026-08-10T04:08:00Z",
+			cell,
+			pins,
+			results: [gradeCase(11, [pass, pass, pass, fail, fail])],
+		});
+		expect(built._tag).toBe("Unusable");
+	});
+
+	it("produces bytes the registered wire format reads back", () => {
+		const built = buildEvalRecord({
+			sha: HEAD,
+			recordedAt: "2026-08-10T04:08:00Z",
+			cell,
+			pins,
+			results: [
+				gradeCase(11, [pass, pass, pass, pass, fail]),
+				gradeCase(12, [pass, fail, pass, dead("timed-out"), pass]),
+			],
+		});
+		if (built._tag !== "Record") throw new Error("the record did not build");
+		const roundTripped = read(emitRecord(built.record));
+		expect(roundTripped._tag).toBe("Found");
+		if (roundTripped._tag !== "Found") return;
+		expect(roundTripped.value.payload.cases.map((block) => block.dispersion)).toEqual([1, 2]);
+	});
+});

--- a/packages/fabrika-cli/src/eval/spawn.unit.test.ts
+++ b/packages/fabrika-cli/src/eval/spawn.unit.test.ts
@@ -828,13 +828,14 @@ describe("no CI workflow invokes the model-spawning runner (#4649 ruling)", () =
 		assert.isAbove(readdirSync(workflows).filter((f) => f.endsWith(".yml")).length, 0);
 	});
 
-	// Both spellings, so the ruling survives the rename: v1's `eval-harness run` and fabrika's
-	// `eval run` are the same forbidden invocation, and a workflow written against either reds.
-	it("no workflow calls the runner under either verb name", () => {
+	// Every spelling, so the ruling survives a rename: v1's `eval-harness run`, fabrika's `eval run`,
+	// and the graded axis's `eval graded` (#4678) are the same forbidden invocation, and a workflow
+	// written against any of them reds.
+	it("no workflow calls a model-spawning verb under any of its names", () => {
 		const offenders = readdirSync(workflows)
 			.filter((f) => f.endsWith(".yml") || f.endsWith(".yaml"))
 			.filter((f) =>
-				/(eval-harness|fabrika(-cli)?\s+eval)\s+run\b/.test(
+				/(eval-harness|fabrika(-cli)?\s+eval)\s+(run|graded)\b/.test(
 					readFileSync(join(workflows, f), "utf8"),
 				),
 			);

--- a/packages/fabrika-cli/src/wire/eval-record.ts
+++ b/packages/fabrika-cli/src/wire/eval-record.ts
@@ -2,11 +2,17 @@
  * The `eval-record` document — what one graded review run leaves behind, bound to the head it ran
  * against.
  *
- *     eval: RECORDED @ 03135b91 — review/skill 0.95 (19/20 runs, dispersion 1)
+ *     eval: RECORDED @ 03135b91 — review/skill 0.95 (19/20 cases, 1 unmeasured)
  *
  *     ```json
  *     { "sha": …, "recordedAt": …, "cell": …, "pins": …, "gradedRuns": …, "cases": [ … ] }
  *     ```
+ *
+ * The clause counts **cases, not invocations** — one graded case is one graded run at cell level, and
+ * the five executions behind it live in its case block. Counting invocations would double-count
+ * variance: a flaky 3-of-5 case would contribute three wins instead of one pass, which is what taking
+ * a median was for. Ruled on #5258; ADR 0253 §5's `19/20 runs` example is wrong and is corrected
+ * there, not here.
  *
  * ADR 0253 fixes every choice here — the `eval` root, the `RECORDED | UNRECORDABLE` token instead of
  * a polarity, the PR-comment home, and the field inventory. Two of its rules are the ones a future
@@ -16,8 +22,10 @@
  *   only candidate is the 90% bar that belongs to the merge gate (#4681). A marker spelled with one
  *   is `Malformed`, so the bar cannot re-enter through the record.
  * - **A stored aggregate whose inputs are absent is a number nobody can check** (ADR 0252 §1). Every
- *   aggregate here is re-derived from the fields beside it and refused when it disagrees, so a record
- *   cannot publish a `dispersion` or a `passRate` its own case blocks contradict.
+ *   aggregate here is re-derived from the fields beside it and refused when it disagrees — the case
+ *   block's `dispersion` from its own run counts, and the cell's `gradedRuns` / `passedRuns` /
+ *   `unmeasuredCases` / `passRate` from the case blocks themselves. So a record cannot publish a
+ *   figure its own contents contradict, in either direction.
  *
  * The head binding is **reused, not re-invented**: `HeadSha`, `Clause` and `bindToHead` come from
  * `./verdict-marker.ts`, so there is one notion of "bound to a head" in the package. What is new is
@@ -26,7 +34,14 @@
  */
 
 import type {NonEmptyReadonlyArray, WireEmit, WireRead, WireReadLines} from "./format.ts";
-import {CLAUSE_SEPARATOR, type Clause, clause, type HeadSha, headSha} from "./verdict-marker.ts";
+import {
+	CLAUSE_SEPARATOR,
+	type Clause,
+	clause,
+	type HeadSha,
+	headSha,
+	sameHead,
+} from "./verdict-marker.ts";
 
 declare const RECORDED_AT: unique symbol;
 
@@ -92,6 +107,10 @@ export interface EvalCaseBlock {
  * The two levels use two spellings on purpose (ADR 0253 §5): `gradedRuns` / `passedRuns` / `passRate`
  * are the *cell* aggregate and match `ScorecardCell`, so #4680 commits a row without renaming
  * anything; `runs` / `passed` / `dispersion` are the *case* block and match ADR 0252 §1.
+ *
+ * `unmeasuredCases` is carried as its own integer rather than left to prose, because it is the one
+ * fact `gradedRuns` / `passedRuns` cannot express: a cell that graded three of four cases reports
+ * `3/3 = 1.0`, and without this field the committed row (#4680) hides the case that never ran.
  */
 export interface EvalRecordPayload {
 	readonly sha: HeadSha;
@@ -100,6 +119,7 @@ export interface EvalRecordPayload {
 	readonly pins: EvalRecordPins;
 	readonly gradedRuns: number;
 	readonly passedRuns: number;
+	readonly unmeasuredCases: number;
 	readonly passRate: number;
 	readonly cases: ReadonlyArray<EvalCaseBlock>;
 }
@@ -229,7 +249,7 @@ const readPayload = (text: string, outcome: EvalOutcome, markerSha: HeadSha): Pa
 
 	const sha = headSha(stringField(parsed, "sha") ?? "");
 	if (sha === null) return {_tag: "No", reason: "the payload names no head SHA"};
-	if (!sha.startsWith(markerSha) && !markerSha.startsWith(sha)) {
+	if (!sameHead(sha, markerSha)) {
 		return {
 			_tag: "No",
 			reason: `the payload is bound to ${sha} and the marker to ${markerSha} — one record, one head`,
@@ -269,9 +289,13 @@ const readPayload = (text: string, outcome: EvalOutcome, markerSha: HeadSha): Pa
 
 	const gradedRuns = numberField(parsed, "gradedRuns");
 	const passedRuns = numberField(parsed, "passedRuns");
+	const unmeasuredCases = numberField(parsed, "unmeasuredCases");
 	const passRate = numberField(parsed, "passRate");
-	if (gradedRuns === null || passedRuns === null || passRate === null) {
-		return {_tag: "No", reason: "the payload is missing one of gradedRuns, passedRuns, passRate"};
+	if (gradedRuns === null || passedRuns === null || unmeasuredCases === null || passRate === null) {
+		return {
+			_tag: "No",
+			reason: "the payload is missing one of gradedRuns, passedRuns, unmeasuredCases, passRate",
+		};
 	}
 	const casesRaw = parsed.cases;
 	if (!Array.isArray(casesRaw)) return {_tag: "No", reason: "the payload carries no cases array"};
@@ -280,6 +304,31 @@ const readPayload = (text: string, outcome: EvalOutcome, markerSha: HeadSha): Pa
 		const block = readCaseBlock(raw, index);
 		if (typeof block === "string") return {_tag: "No", reason: block};
 		cases.push(block);
+	}
+
+	// The cell aggregate is re-derived from the case blocks, exactly as `readCaseBlock` re-derives a
+	// case's dispersion from its runs. Without this the cell half of the promise above was false: a
+	// record claiming 10/10 over blocks summing to 1/2 — or over an EMPTY `cases` array — read back
+	// Found, publishing a measurement nobody took as if it had been checked (review-code on #5401).
+	const gradedCases = cases.filter((block) => block.verdict !== "unmeasured");
+	const derivedPassed = gradedCases.filter((block) => block.verdict === "pass").length;
+	if (gradedRuns !== gradedCases.length) {
+		return {
+			_tag: "No",
+			reason: `gradedRuns is ${gradedRuns}; the case blocks carry ${gradedCases.length} graded case(s)`,
+		};
+	}
+	if (passedRuns !== derivedPassed) {
+		return {
+			_tag: "No",
+			reason: `passedRuns is ${passedRuns}; the case blocks carry ${derivedPassed} passing case(s)`,
+		};
+	}
+	if (unmeasuredCases !== cases.length - gradedCases.length) {
+		return {
+			_tag: "No",
+			reason: `unmeasuredCases is ${unmeasuredCases}; the case blocks carry ${cases.length - gradedCases.length}`,
+		};
 	}
 
 	// The token and the denominator are one fact: `RECORDED` over nothing is the vacuous green ADR
@@ -310,6 +359,7 @@ const readPayload = (text: string, outcome: EvalOutcome, markerSha: HeadSha): Pa
 			pins: {model: pinModel, cli: pinCli, harness: pinHarness},
 			gradedRuns,
 			passedRuns,
+			unmeasuredCases,
 			passRate,
 			cases,
 		},
@@ -420,7 +470,7 @@ export const renderRecord = (record: EvalRecord): NonEmptyReadonlyArray<string> 
 	`recordedAt\t${record.payload.recordedAt}`,
 	`cell\t${record.payload.cell.stage}\t${record.payload.cell.surface ?? ""}\t${record.payload.cell.model}`,
 	`pins\t${record.payload.pins.model}\t${record.payload.pins.cli}\t${record.payload.pins.harness}`,
-	`rate\t${record.payload.passedRuns}/${record.payload.gradedRuns}\t${record.payload.passRate}`,
+	`rate\t${record.payload.passedRuns}/${record.payload.gradedRuns}\t${record.payload.passRate}\tunmeasured ${record.payload.unmeasuredCases}`,
 	...record.payload.cases.map(
 		(block) =>
 			`case\t${block.caseId}\t${block.verdict}\t${block.passed}/${block.runs}\tnoVerdict ${block.noVerdict}\tdispersion ${block.dispersion}\t${block.perRun.join(",")}`,

--- a/packages/fabrika-cli/src/wire/eval-record.ts
+++ b/packages/fabrika-cli/src/wire/eval-record.ts
@@ -1,0 +1,491 @@
+/**
+ * The `eval-record` document — what one graded review run leaves behind, bound to the head it ran
+ * against.
+ *
+ *     eval: RECORDED @ 03135b91 — review/skill 0.95 (19/20 runs, dispersion 1)
+ *
+ *     ```json
+ *     { "sha": …, "recordedAt": …, "cell": …, "pins": …, "gradedRuns": …, "cases": [ … ] }
+ *     ```
+ *
+ * ADR 0253 fixes every choice here — the `eval` root, the `RECORDED | UNRECORDABLE` token instead of
+ * a polarity, the PR-comment home, and the field inventory. Two of its rules are the ones a future
+ * editor is most likely to undo, so they are enforced by {@link read} rather than trusted:
+ *
+ * - **The token is not a polarity.** `PASS`/`FAIL` would have to mean *pass against what*, and the
+ *   only candidate is the 90% bar that belongs to the merge gate (#4681). A marker spelled with one
+ *   is `Malformed`, so the bar cannot re-enter through the record.
+ * - **A stored aggregate whose inputs are absent is a number nobody can check** (ADR 0252 §1). Every
+ *   aggregate here is re-derived from the fields beside it and refused when it disagrees, so a record
+ *   cannot publish a `dispersion` or a `passRate` its own case blocks contradict.
+ *
+ * The head binding is **reused, not re-invented**: `HeadSha`, `Clause` and `bindToHead` come from
+ * `./verdict-marker.ts`, so there is one notion of "bound to a head" in the package. What is new is
+ * the payload beneath the line, which is why this is a sibling module rather than a widening of that
+ * one (ADR 0241).
+ */
+
+import type {NonEmptyReadonlyArray, WireEmit, WireRead, WireReadLines} from "./format.ts";
+import {CLAUSE_SEPARATOR, type Clause, clause, type HeadSha, headSha} from "./verdict-marker.ts";
+
+declare const RECORDED_AT: unique symbol;
+
+/** An ISO-8601 UTC instant with a trailing `Z`. Branded so `Found` cannot carry `"this morning"`. */
+export type RecordedAt = string & {readonly [RECORDED_AT]: true};
+
+const RECORDED_AT_RE = /^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}(?:\.\d+)?Z$/;
+
+export const recordedAt = (raw: string): RecordedAt | null => {
+	const value = raw.trim();
+	return RECORDED_AT_RE.test(value) ? (value as RecordedAt) : null;
+};
+
+/** The marker's namespace — a root of its own, never a `review-*` member (ADR 0253 §1). */
+export const EVAL_NAMESPACE = "eval";
+
+/**
+ * Whether a measurement exists, not whether it was any good.
+ *
+ * `RECORDED` carries whatever number the run produced, below-bar included. `UNRECORDABLE` is the run
+ * that produced no measurement at all — never folded into a `0.0` rate, which would publish a
+ * measurement nobody took (ADR 0092).
+ */
+export type EvalOutcome = "RECORDED" | "UNRECORDABLE";
+
+export const EVAL_OUTCOMES = ["RECORDED", "UNRECORDABLE"] as const;
+
+/** A case's median verdict. `unmeasured` is the case whose every run returned no verdict. */
+export type CaseVerdict = "pass" | "fail" | "unmeasured";
+
+const CASE_VERDICTS: ReadonlyArray<string> = ["pass", "fail", "unmeasured"];
+
+/** The `(stage × surface × model)` cell one record measures — ADR 0243 §4's key, unchanged. */
+export interface EvalRecordCell {
+	readonly stage: string;
+	/** The review surface whose grader produced the rows; `null` on every non-`review` stage. */
+	readonly surface: string | null;
+	readonly model: string;
+}
+
+/** #4637 ruling 4's model + CLI + harness triple, carried on every record. */
+export interface EvalRecordPins {
+	readonly model: string;
+	readonly cli: string;
+	readonly harness: string;
+}
+
+/** One graded case's five runs, spelled as ADR 0252 §1 defines them. */
+export interface EvalCaseBlock {
+	readonly caseId: number;
+	readonly verdict: CaseVerdict;
+	readonly runs: number;
+	readonly passed: number;
+	readonly noVerdict: number;
+	readonly dispersion: number;
+	/** One token per run, in run order: `pass`, `fail`, or `no-verdict:<reason>`. */
+	readonly perRun: ReadonlyArray<string>;
+}
+
+/**
+ * The record's payload.
+ *
+ * The two levels use two spellings on purpose (ADR 0253 §5): `gradedRuns` / `passedRuns` / `passRate`
+ * are the *cell* aggregate and match `ScorecardCell`, so #4680 commits a row without renaming
+ * anything; `runs` / `passed` / `dispersion` are the *case* block and match ADR 0252 §1.
+ */
+export interface EvalRecordPayload {
+	readonly sha: HeadSha;
+	readonly recordedAt: RecordedAt;
+	readonly cell: EvalRecordCell;
+	readonly pins: EvalRecordPins;
+	readonly gradedRuns: number;
+	readonly passedRuns: number;
+	readonly passRate: number;
+	readonly cases: ReadonlyArray<EvalCaseBlock>;
+}
+
+export interface EvalRecord {
+	readonly outcome: EvalOutcome;
+	readonly sha: HeadSha;
+	readonly clause: Clause;
+	readonly payload: EvalRecordPayload;
+}
+
+export type EvalRecordRead = WireRead<EvalRecord>;
+
+/** `dispersion` is the minority-verdict count over a case's runs (ADR 0252 §1). */
+export const dispersionOf = (runs: number, passed: number): number =>
+	Math.min(passed, runs - passed);
+
+/** The rate as the record stores it: four decimal places, the precision ADR 0252 §3 settles on. */
+export const roundRate = (rate: number): number => Math.round(rate * 10_000) / 10_000;
+
+const MARKER_LINE = /^\s*(\*{0,2})\s*([A-Za-z0-9_-]+)\s*:\s*(.*)$/;
+const SEPARATOR = /^(?:—|–|--|-)\s*/;
+
+const firstNonBlankLine = (artifact: string): string | null =>
+	artifact.split("\n").find((line) => line.trim() !== "") ?? null;
+
+const malformed = (reason: string, evidence: string): EvalRecordRead => ({
+	_tag: "Malformed",
+	reason,
+	evidence,
+});
+
+const takeToken = (rest: string): {readonly token: string; readonly after: string} => {
+	const trimmed = rest.trimStart();
+	const end = trimmed.search(/\s/);
+	return end === -1
+		? {token: trimmed, after: ""}
+		: {token: trimmed.slice(0, end), after: trimmed.slice(end)};
+};
+
+const outcomeOf = (token: string): EvalOutcome | null => {
+	const value = token.toUpperCase();
+	return value === "RECORDED" || value === "UNRECORDABLE" ? value : null;
+};
+
+/** Compose the record: the marker line, then the payload as one fenced JSON object. */
+export const emit = (record: EvalRecord): string =>
+	[
+		`${EVAL_NAMESPACE}: ${record.outcome} @ ${record.sha} ${CLAUSE_SEPARATOR} ${record.clause}`,
+		"",
+		"```json",
+		`${JSON.stringify(record.payload, null, 2)}`,
+		"```",
+		"",
+	].join("\n");
+
+type PayloadRead =
+	| {readonly _tag: "Payload"; readonly payload: EvalRecordPayload}
+	| {readonly _tag: "No"; readonly reason: string};
+
+const isRecordObject = (value: unknown): value is Record<string, unknown> =>
+	typeof value === "object" && value !== null && !Array.isArray(value);
+
+const stringField = (source: Record<string, unknown>, key: string): string | null => {
+	const value = source[key];
+	return typeof value === "string" ? value : null;
+};
+
+const numberField = (source: Record<string, unknown>, key: string): number | null => {
+	const value = source[key];
+	return typeof value === "number" && Number.isFinite(value) ? value : null;
+};
+
+const readCaseBlock = (raw: unknown, index: number): EvalCaseBlock | string => {
+	if (!isRecordObject(raw)) return `case block ${index} is not an object`;
+	const caseId = numberField(raw, "caseId");
+	if (caseId === null || !Number.isInteger(caseId)) {
+		return `case block ${index} carries no integer caseId`;
+	}
+	const verdict = stringField(raw, "verdict");
+	if (verdict === null || !CASE_VERDICTS.includes(verdict)) {
+		return `case ${caseId}'s verdict is "${verdict}" — expected ${CASE_VERDICTS.join(", ")}`;
+	}
+	const runs = numberField(raw, "runs");
+	const passed = numberField(raw, "passed");
+	const noVerdict = numberField(raw, "noVerdict");
+	const dispersion = numberField(raw, "dispersion");
+	if (runs === null || passed === null || noVerdict === null || dispersion === null) {
+		return `case ${caseId} is missing one of runs, passed, noVerdict, dispersion`;
+	}
+	const perRun = raw.perRun;
+	if (!Array.isArray(perRun) || perRun.some((token) => typeof token !== "string")) {
+		return `case ${caseId} carries no per-run token list`;
+	}
+	if (perRun.length !== runs) {
+		return `case ${caseId} reports ${runs} run(s) and carries ${perRun.length} per-run token(s)`;
+	}
+	// Both aggregates are re-derived rather than trusted: a stored number whose inputs are right
+	// there and disagree is worse than an absent one, because it reads as checked (ADR 0252 §1).
+	if (dispersion !== dispersionOf(runs, passed)) {
+		return `case ${caseId}'s dispersion is ${dispersion}; min(${passed}, ${runs} − ${passed}) is ${dispersionOf(runs, passed)}`;
+	}
+	// A run that returned no verdict stays in `runs` and never counts as passed (ADR 0253 §4), so
+	// this bound is what forbids a record that quietly moved a dead invocation onto the passing side.
+	if (passed + noVerdict > runs) {
+		return `case ${caseId} reports ${passed} passed + ${noVerdict} no-verdict over ${runs} run(s)`;
+	}
+	return {
+		caseId,
+		verdict: verdict as CaseVerdict,
+		runs,
+		passed,
+		noVerdict,
+		dispersion,
+		perRun: perRun as ReadonlyArray<string>,
+	};
+};
+
+const readPayload = (text: string, outcome: EvalOutcome, markerSha: HeadSha): PayloadRead => {
+	let parsed: unknown;
+	try {
+		parsed = JSON.parse(text);
+	} catch {
+		return {_tag: "No", reason: "the payload fence does not hold JSON"};
+	}
+	if (!isRecordObject(parsed)) return {_tag: "No", reason: "the payload is not one JSON object"};
+
+	const sha = headSha(stringField(parsed, "sha") ?? "");
+	if (sha === null) return {_tag: "No", reason: "the payload names no head SHA"};
+	if (!sha.startsWith(markerSha) && !markerSha.startsWith(sha)) {
+		return {
+			_tag: "No",
+			reason: `the payload is bound to ${sha} and the marker to ${markerSha} — one record, one head`,
+		};
+	}
+	const at = recordedAt(stringField(parsed, "recordedAt") ?? "");
+	if (at === null) {
+		return {_tag: "No", reason: "recordedAt is not an ISO-8601 UTC instant with a trailing Z"};
+	}
+
+	const cellRaw = parsed.cell;
+	if (!isRecordObject(cellRaw)) return {_tag: "No", reason: "the payload carries no cell object"};
+	const stage = stringField(cellRaw, "stage");
+	const model = stringField(cellRaw, "model");
+	if (stage === null || stage.trim() === "" || model === null || model.trim() === "") {
+		return {
+			_tag: "No",
+			reason: "the cell names no stage and model — a pass rate measures one cell",
+		};
+	}
+	const surfaceRaw = cellRaw.surface;
+	if (surfaceRaw !== null && typeof surfaceRaw !== "string") {
+		return {_tag: "No", reason: "the cell's surface is neither a string nor null"};
+	}
+
+	const pinsRaw = parsed.pins;
+	if (!isRecordObject(pinsRaw)) return {_tag: "No", reason: "the payload carries no pins object"};
+	const pinModel = stringField(pinsRaw, "model");
+	const pinCli = stringField(pinsRaw, "cli");
+	const pinHarness = stringField(pinsRaw, "harness");
+	if (pinModel === null || pinCli === null || pinHarness === null) {
+		return {
+			_tag: "No",
+			reason: "pins must name the model, the CLI and the harness (#4637 ruling 4)",
+		};
+	}
+
+	const gradedRuns = numberField(parsed, "gradedRuns");
+	const passedRuns = numberField(parsed, "passedRuns");
+	const passRate = numberField(parsed, "passRate");
+	if (gradedRuns === null || passedRuns === null || passRate === null) {
+		return {_tag: "No", reason: "the payload is missing one of gradedRuns, passedRuns, passRate"};
+	}
+	const casesRaw = parsed.cases;
+	if (!Array.isArray(casesRaw)) return {_tag: "No", reason: "the payload carries no cases array"};
+	const cases: Array<EvalCaseBlock> = [];
+	for (const [index, raw] of casesRaw.entries()) {
+		const block = readCaseBlock(raw, index);
+		if (typeof block === "string") return {_tag: "No", reason: block};
+		cases.push(block);
+	}
+
+	// The token and the denominator are one fact: `RECORDED` over nothing is the vacuous green ADR
+	// 0092 forbids, and `UNRECORDABLE` over a real denominator hides a measurement that exists.
+	if (outcome === "RECORDED" && gradedRuns === 0) {
+		return {_tag: "No", reason: "a RECORDED record over zero graded runs measures nothing"};
+	}
+	if (outcome === "UNRECORDABLE" && gradedRuns !== 0) {
+		return {
+			_tag: "No",
+			reason: `an UNRECORDABLE record reports ${gradedRuns} graded run(s) — that is a measurement`,
+		};
+	}
+	const derived = gradedRuns === 0 ? 0 : roundRate(passedRuns / gradedRuns);
+	if (roundRate(passRate) !== derived) {
+		return {
+			_tag: "No",
+			reason: `passRate is ${passRate}; ${passedRuns}/${gradedRuns} is ${derived}`,
+		};
+	}
+
+	return {
+		_tag: "Payload",
+		payload: {
+			sha,
+			recordedAt: at,
+			cell: {stage, surface: surfaceRaw ?? null, model},
+			pins: {model: pinModel, cli: pinCli, harness: pinHarness},
+			gradedRuns,
+			passedRuns,
+			passRate,
+			cases,
+		},
+	};
+};
+
+const fencedPayload = (
+	lines: ReadonlyArray<string>,
+):
+	| {readonly _tag: "Json"; readonly text: string}
+	| {readonly _tag: "No"; readonly reason: string} => {
+	const open = lines.findIndex((line) => line.trim().startsWith("```"));
+	if (open === -1) return {_tag: "No", reason: "the record carries no fenced JSON payload"};
+	const close = lines.findIndex((line, index) => index > open && line.trim() === "```");
+	if (close === -1) return {_tag: "No", reason: "the payload fence is never closed"};
+	return {
+		_tag: "Json",
+		text: lines
+			.slice(open + 1, close)
+			.join("\n")
+			.trim(),
+	};
+};
+
+/**
+ * Read an eval record out of a comment body. Total: `Found` | `Absent` | `Malformed`.
+ *
+ * The walk is stepwise for `verdict-marker.ts`'s reason — a single alternation would collapse "the
+ * token is a polarity" and "the payload disagrees with its own case blocks" into one non-match, and
+ * naming which half drifted is the whole value of the refusal.
+ */
+export const read = (artifact: string): EvalRecordRead => {
+	const line = firstNonBlankLine(artifact);
+	if (line === null) {
+		return {_tag: "Absent", reason: "the artifact holds no non-blank line to carry a record"};
+	}
+	const matched = MARKER_LINE.exec(line);
+	const namespace = matched?.[2]?.toLowerCase() ?? "";
+	if (matched === null || !namespace.startsWith(EVAL_NAMESPACE)) {
+		return {
+			_tag: "Absent",
+			reason: 'the first line does not open with an "eval:" namespace — no record of this format',
+		};
+	}
+	const evidence = `first line: "${line.trim()}"`;
+	if (namespace !== EVAL_NAMESPACE) {
+		return malformed(
+			`the namespace "${namespace}" is not the "eval" root — an eval record never wears a gate's namespace (ADR 0253 §1)`,
+			evidence,
+		);
+	}
+
+	const emphasis = matched[1] ?? "";
+	const {token: outcomeToken, after: afterOutcome} = takeToken(matched[3] ?? "");
+	if (outcomeToken === "") {
+		return malformed(
+			`"${EVAL_NAMESPACE}:" carries no outcome — expected ${EVAL_OUTCOMES.join(" or ")}`,
+			evidence,
+		);
+	}
+	const outcome = outcomeOf(outcomeToken);
+	if (outcome === null) {
+		return malformed(
+			`"${outcomeToken}" is not an eval outcome — expected ${EVAL_OUTCOMES.join(" or ")}; a record carries no PASS/FAIL polarity, because the bar it would judge against belongs to the merge gate`,
+			evidence,
+		);
+	}
+
+	const bound = afterOutcome.trimStart();
+	if (!bound.startsWith("@")) {
+		return malformed(
+			`the ${outcome} record is bound to no head SHA — a measurement with no "@ <sha>" attests no tree`,
+			evidence,
+		);
+	}
+	const {token: shaToken, after: afterSha} = takeToken(bound.slice(1));
+	const sha = headSha(shaToken);
+	if (sha === null) {
+		return malformed(`"${shaToken}" is not a head SHA — expected 7–40 hex characters`, evidence);
+	}
+
+	const tail = afterSha.trim();
+	const unemphasized =
+		emphasis !== "" && tail.endsWith(emphasis) ? tail.slice(0, -emphasis.length) : tail;
+	const text = clause(unemphasized.replace(SEPARATOR, ""));
+	if (text === null) {
+		return malformed(
+			"the record carries no trailing clause — the one field that says what the measurement means to a human",
+			evidence,
+		);
+	}
+
+	const lines = artifact.split("\n");
+	const markerAt = lines.findIndex((raw) => raw.trim() === line.trim());
+	const fenced = fencedPayload(lines.slice(markerAt + 1));
+	if (fenced._tag === "No") return malformed(fenced.reason, evidence);
+	const payload = readPayload(fenced.text, outcome, sha);
+	if (payload._tag === "No") return malformed(payload.reason, evidence);
+
+	return {_tag: "Found", value: {outcome, sha, clause: text, payload: payload.payload}};
+};
+
+/** One `<field>\t<value>` line per field — the `wire read` answer for this format. */
+export const renderRecord = (record: EvalRecord): NonEmptyReadonlyArray<string> => [
+	`outcome\t${record.outcome}`,
+	`sha\t${record.sha}`,
+	`clause\t${record.clause}`,
+	`recordedAt\t${record.payload.recordedAt}`,
+	`cell\t${record.payload.cell.stage}\t${record.payload.cell.surface ?? ""}\t${record.payload.cell.model}`,
+	`pins\t${record.payload.pins.model}\t${record.payload.pins.cli}\t${record.payload.pins.harness}`,
+	`rate\t${record.payload.passedRuns}/${record.payload.gradedRuns}\t${record.payload.passRate}`,
+	...record.payload.cases.map(
+		(block) =>
+			`case\t${block.caseId}\t${block.verdict}\t${block.passed}/${block.runs}\tnoVerdict ${block.noVerdict}\tdispersion ${block.dispersion}\t${block.perRun.join(",")}`,
+	),
+];
+
+export type EvalRecordFields =
+	| {readonly _tag: "Fields"; readonly record: EvalRecord}
+	| {readonly _tag: "Unusable"; readonly reason: string};
+
+const FIELD = /^([a-zA-Z]+):\s*(.*)$/;
+
+/**
+ * Parse `emit`'s stdin: `outcome` / `sha` / `clause` one per line, then `payload:` whose block runs
+ * to the end and holds the JSON object.
+ *
+ * Every rejection is a refusal rather than a default, for `verdict-marker.ts`'s reason: a record
+ * composed with a field silently missing looks perfectly well-formed to whoever reads it back.
+ */
+export const parseFields = (fields: string): EvalRecordFields => {
+	const values = new Map<string, string>();
+	const payloadLines: Array<string> = [];
+	let inPayload = false;
+	for (const [index, raw] of fields.split("\n").entries()) {
+		if (inPayload) {
+			payloadLines.push(raw);
+			continue;
+		}
+		const line = raw.trim();
+		if (line === "") continue;
+		const field = FIELD.exec(line);
+		if (field?.[1] === undefined) {
+			return {_tag: "Unusable", reason: `line ${index + 1} is not a "<field>: <value>" line`};
+		}
+		if (field[1] === "payload") {
+			inPayload = true;
+			continue;
+		}
+		values.set(field[1], field[2] ?? "");
+	}
+
+	const outcome = outcomeOf((values.get("outcome") ?? "").trim());
+	if (outcome === null) {
+		return {_tag: "Unusable", reason: `no outcome — expected ${EVAL_OUTCOMES.join(" or ")}`};
+	}
+	const sha = headSha(values.get("sha") ?? "");
+	if (sha === null) return {_tag: "Unusable", reason: "no 7–40 hex head SHA"};
+	const text = clause(values.get("clause") ?? "");
+	if (text === null) return {_tag: "Unusable", reason: "the trailing clause is blank"};
+	const payload = readPayload(payloadLines.join("\n").trim(), outcome, sha);
+	if (payload._tag === "No") return {_tag: "Unusable", reason: `payload: ${payload.reason}`};
+
+	return {_tag: "Fields", record: {outcome, sha, clause: text, payload: payload.payload}};
+};
+
+/** The registry row's byte-level `emit`, bound to this module's typed core. */
+export const emitFromFields = (fields: string): WireEmit => {
+	const parsed = parseFields(fields);
+	return parsed._tag === "Fields"
+		? {_tag: "Composed", bytes: emit(parsed.record)}
+		: {_tag: "Unusable", reason: parsed.reason};
+};
+
+/** The registry row's byte-level `read`, bound to this module's typed core. */
+export const readToLines = (artifact: string): WireReadLines => {
+	const result = read(artifact);
+	return result._tag === "Found" ? {_tag: "Found", value: renderRecord(result.value)} : result;
+};

--- a/packages/fabrika-cli/src/wire/eval-record.unit.test.ts
+++ b/packages/fabrika-cli/src/wire/eval-record.unit.test.ts
@@ -50,6 +50,7 @@ const RECORD: EvalRecord = {
 		pins: {model: "claude-opus-4-6", cli: "2.1.220", harness: "fabrika 0.1.0"},
 		gradedRuns: 2,
 		passedRuns: 1,
+		unmeasuredCases: 0,
 		passRate: 0.5,
 		cases: [
 			{
@@ -82,6 +83,28 @@ const refusal = (artifact: string): {tag: string; reason: string} => {
 const withPayload = (payload: unknown, marker = `eval: RECORDED @ ${HEAD} — a clause`): string =>
 	`${marker}\n\n\`\`\`json\n${JSON.stringify(payload)}\n\`\`\`\n`;
 
+/** One passing and one failing case — the honest cell aggregate is `1/2 = 0.5`, 0 unmeasured. */
+const TWO_CASES = [
+	{
+		caseId: 1,
+		verdict: "pass",
+		runs: 5,
+		passed: 4,
+		noVerdict: 0,
+		dispersion: 1,
+		perRun: ["pass", "pass", "fail", "pass", "pass"],
+	},
+	{
+		caseId: 2,
+		verdict: "fail",
+		runs: 5,
+		passed: 0,
+		noVerdict: 0,
+		dispersion: 0,
+		perRun: ["fail", "fail", "fail", "fail", "fail"],
+	},
+];
+
 const payloadOf = (over: Record<string, unknown> = {}): Record<string, unknown> => ({
 	sha: HEAD,
 	recordedAt: "2026-08-10T04:08:00Z",
@@ -89,6 +112,7 @@ const payloadOf = (over: Record<string, unknown> = {}): Record<string, unknown> 
 	pins: {model: "m", cli: "c", harness: "h"},
 	gradedRuns: 1,
 	passedRuns: 1,
+	unmeasuredCases: 0,
 	passRate: 1,
 	cases: [
 		{
@@ -178,9 +202,45 @@ describe("a record that drifted is Malformed — never a measurement nobody took
 	});
 
 	it("refuses a pass rate its own denominator contradicts", () => {
-		const {tag, reason} = refusal(withPayload(payloadOf({gradedRuns: 2, passedRuns: 1})));
+		const {tag, reason} = refusal(
+			withPayload(payloadOf({gradedRuns: 2, passedRuns: 1, passRate: 1, cases: TWO_CASES})),
+		);
 		expect(tag).toBe("Malformed");
 		expect(reason).toContain("passRate");
+	});
+
+	// The cell half of the re-derivation promise. Both of these read back `Found` before the fix that
+	// added it, publishing a figure the record's own case blocks contradict (review-code on #5401).
+	it("refuses a cell aggregate its own case blocks contradict", () => {
+		const {tag, reason} = refusal(
+			withPayload(payloadOf({gradedRuns: 10, passedRuns: 10, passRate: 1, cases: TWO_CASES})),
+		);
+		expect(tag).toBe("Malformed");
+		expect(reason).toContain("gradedRuns");
+	});
+
+	it("refuses graded cases claimed over an empty cases array", () => {
+		const {tag, reason} = refusal(
+			withPayload(payloadOf({gradedRuns: 10, passedRuns: 10, passRate: 1, cases: []})),
+		);
+		expect(tag).toBe("Malformed");
+		expect(reason).toContain("0 graded case(s)");
+	});
+
+	it("refuses an unmeasuredCases count the case blocks contradict", () => {
+		const {tag, reason} = refusal(
+			withPayload(
+				payloadOf({
+					gradedRuns: 2,
+					passedRuns: 1,
+					passRate: 0.5,
+					unmeasuredCases: 1,
+					cases: TWO_CASES,
+				}),
+			),
+		);
+		expect(tag).toBe("Malformed");
+		expect(reason).toContain("unmeasuredCases");
 	});
 
 	it("refuses a case whose passed and no-verdict counts exceed its runs", () => {
@@ -230,6 +290,7 @@ describe("RECORDED and UNRECORDABLE are about whether a measurement exists", () 
 				payloadOf({
 					gradedRuns: 0,
 					passedRuns: 0,
+					unmeasuredCases: 1,
 					passRate: 0,
 					cases: [
 						{
@@ -260,7 +321,7 @@ describe("RECORDED and UNRECORDABLE are about whether a measurement exists", () 
 
 	it("accepts a below-bar rate — the bar belongs to the merge gate, not the record", () => {
 		const result = read(
-			withPayload(payloadOf({gradedRuns: 10, passedRuns: 1, passRate: 0.1, cases: []})),
+			withPayload(payloadOf({gradedRuns: 2, passedRuns: 1, passRate: 0.5, cases: TWO_CASES})),
 		);
 		expect(result._tag).toBe("Found");
 	});

--- a/packages/fabrika-cli/src/wire/eval-record.unit.test.ts
+++ b/packages/fabrika-cli/src/wire/eval-record.unit.test.ts
@@ -1,0 +1,297 @@
+/**
+ * The eval record's own tier: the outcome token, the head binding, and the aggregates the read
+ * re-derives instead of trusting.
+ *
+ * The assertions that carry the design are the refusals. Each one feeds bytes a lenient reader would
+ * answer `Found` for — a gate polarity where the outcome belongs, a payload bound to a different
+ * head, a `dispersion` its own run counts contradict — because the failure this module removes is
+ * not a crash, it is a *plausible* measurement.
+ */
+import {describe, expect, it} from "vitest";
+import {
+	dispersionOf,
+	type EvalRecord,
+	emit,
+	emitFromFields,
+	read,
+	readToLines,
+	recordedAt,
+	renderRecord,
+	roundRate,
+} from "./eval-record.ts";
+import {bindToHead, clause, headSha, type VerdictMarker} from "./verdict-marker.ts";
+
+const HEAD = "03135b91e7d4a2c6f1b8093a5c4d2e1f6a7b8c9d";
+
+const sha = (raw: string) => {
+	const value = headSha(raw);
+	if (value === null) throw new Error(`fixture is not a head SHA: ${raw}`);
+	return value;
+};
+const text = (raw: string) => {
+	const value = clause(raw);
+	if (value === null) throw new Error("fixture clause is blank");
+	return value;
+};
+const at = (raw: string) => {
+	const value = recordedAt(raw);
+	if (value === null) throw new Error(`fixture is not an instant: ${raw}`);
+	return value;
+};
+
+const RECORD: EvalRecord = {
+	outcome: "RECORDED",
+	sha: sha(HEAD),
+	clause: text("review/skill 0.5 (1/2 cases, 0 unmeasured)"),
+	payload: {
+		sha: sha(HEAD),
+		recordedAt: at("2026-08-10T04:08:00Z"),
+		cell: {stage: "review", surface: "skill", model: "claude-opus-4-6"},
+		pins: {model: "claude-opus-4-6", cli: "2.1.220", harness: "fabrika 0.1.0"},
+		gradedRuns: 2,
+		passedRuns: 1,
+		passRate: 0.5,
+		cases: [
+			{
+				caseId: 11,
+				verdict: "pass",
+				runs: 5,
+				passed: 3,
+				noVerdict: 1,
+				dispersion: 2,
+				perRun: ["pass", "fail", "pass", "no-verdict:timed-out", "pass"],
+			},
+			{
+				caseId: 12,
+				verdict: "fail",
+				runs: 5,
+				passed: 0,
+				noVerdict: 0,
+				dispersion: 0,
+				perRun: ["fail", "fail", "fail", "fail", "fail"],
+			},
+		],
+	},
+};
+
+const refusal = (artifact: string): {tag: string; reason: string} => {
+	const result = read(artifact);
+	return {tag: result._tag, reason: result._tag === "Found" ? "" : result.reason};
+};
+
+const withPayload = (payload: unknown, marker = `eval: RECORDED @ ${HEAD} — a clause`): string =>
+	`${marker}\n\n\`\`\`json\n${JSON.stringify(payload)}\n\`\`\`\n`;
+
+const payloadOf = (over: Record<string, unknown> = {}): Record<string, unknown> => ({
+	sha: HEAD,
+	recordedAt: "2026-08-10T04:08:00Z",
+	cell: {stage: "review", surface: "skill", model: "m"},
+	pins: {model: "m", cli: "c", harness: "h"},
+	gradedRuns: 1,
+	passedRuns: 1,
+	passRate: 1,
+	cases: [
+		{
+			caseId: 1,
+			verdict: "pass",
+			runs: 5,
+			passed: 4,
+			noVerdict: 0,
+			dispersion: 1,
+			perRun: ["pass", "pass", "fail", "pass", "pass"],
+		},
+	],
+	...over,
+});
+
+describe("the record round-trips", () => {
+	it("emits a marker line the read answers Found on, with the payload intact", () => {
+		const result = read(emit(RECORD));
+		expect(result._tag).toBe("Found");
+		if (result._tag !== "Found") return;
+		expect(result.value).toEqual(RECORD);
+	});
+
+	it("survives the fields adapter the registry row calls", () => {
+		const composed = emitFromFields(
+			[
+				"outcome: RECORDED",
+				`sha: ${HEAD}`,
+				"clause: review/skill 0.5 (1/2 cases, 0 unmeasured)",
+				"payload:",
+				JSON.stringify(RECORD.payload),
+			].join("\n"),
+		);
+		expect(composed._tag).toBe("Composed");
+		if (composed._tag !== "Composed") return;
+		expect(readToLines(composed.bytes)).toEqual({_tag: "Found", value: renderRecord(RECORD)});
+	});
+});
+
+describe("bytes that are not a record read Absent, never Malformed", () => {
+	it.each([
+		["empty bytes", ""],
+		["an ordinary comment", "Looks good to me, shipping it.\n"],
+		["a gate verdict in its own namespace", `review-skill: PASS @ ${HEAD} — merge-ready\n`],
+	])("%s", (_case, artifact) => {
+		expect(read(artifact)._tag).toBe("Absent");
+	});
+});
+
+describe("a record that drifted is Malformed — never a measurement nobody took", () => {
+	it("refuses a gate polarity where the outcome token belongs", () => {
+		const {tag, reason} = refusal(`eval: PASS @ ${HEAD} — a clause\n`);
+		expect(tag).toBe("Malformed");
+		expect(reason).toContain("RECORDED");
+	});
+
+	it("refuses a record bound to no head", () => {
+		expect(refusal("eval: RECORDED — a clause\n").tag).toBe("Malformed");
+	});
+
+	it("refuses a payload bound to a different head than the marker", () => {
+		const {tag, reason} = refusal(withPayload(payloadOf({sha: "aaaaaaa"})));
+		expect(tag).toBe("Malformed");
+		expect(reason).toContain("one record, one head");
+	});
+
+	it("refuses a dispersion its own run counts contradict", () => {
+		const {tag, reason} = refusal(
+			withPayload(
+				payloadOf({
+					cases: [
+						{
+							caseId: 1,
+							verdict: "pass",
+							runs: 5,
+							passed: 4,
+							noVerdict: 0,
+							dispersion: 0,
+							perRun: ["pass", "pass", "fail", "pass", "pass"],
+						},
+					],
+				}),
+			),
+		);
+		expect(tag).toBe("Malformed");
+		expect(reason).toContain("dispersion");
+	});
+
+	it("refuses a pass rate its own denominator contradicts", () => {
+		const {tag, reason} = refusal(withPayload(payloadOf({gradedRuns: 2, passedRuns: 1})));
+		expect(tag).toBe("Malformed");
+		expect(reason).toContain("passRate");
+	});
+
+	it("refuses a case whose passed and no-verdict counts exceed its runs", () => {
+		const {tag} = refusal(
+			withPayload(
+				payloadOf({
+					cases: [
+						{
+							caseId: 1,
+							verdict: "pass",
+							runs: 5,
+							passed: 4,
+							noVerdict: 3,
+							dispersion: 1,
+							perRun: ["pass", "pass", "fail", "pass", "pass"],
+						},
+					],
+				}),
+			),
+		);
+		expect(tag).toBe("Malformed");
+	});
+
+	it("refuses a record with no pins — the model/CLI/harness triple is required", () => {
+		const {tag, reason} = refusal(withPayload(payloadOf({pins: {model: "m", cli: "c"}})));
+		expect(tag).toBe("Malformed");
+		expect(reason).toContain("pins");
+	});
+
+	it("refuses a namespace that reaches for eval and is not the eval root", () => {
+		expect(refusal(`eval-skill: RECORDED @ ${HEAD} — a clause\n`).tag).toBe("Malformed");
+	});
+});
+
+describe("RECORDED and UNRECORDABLE are about whether a measurement exists", () => {
+	it("refuses RECORDED over zero graded runs — that is a green over nothing", () => {
+		const {tag, reason} = refusal(
+			withPayload(payloadOf({gradedRuns: 0, passedRuns: 0, passRate: 0, cases: []})),
+		);
+		expect(tag).toBe("Malformed");
+		expect(reason).toContain("measures nothing");
+	});
+
+	it("accepts UNRECORDABLE over zero graded runs, with its case blocks retained", () => {
+		const result = read(
+			withPayload(
+				payloadOf({
+					gradedRuns: 0,
+					passedRuns: 0,
+					passRate: 0,
+					cases: [
+						{
+							caseId: 1,
+							verdict: "unmeasured",
+							runs: 5,
+							passed: 0,
+							noVerdict: 5,
+							dispersion: 0,
+							perRun: [
+								"no-verdict:timed-out",
+								"no-verdict:timed-out",
+								"no-verdict:no-output",
+								"no-verdict:unparseable",
+								"no-verdict:invocation-failed",
+							],
+						},
+					],
+				}),
+				`eval: UNRECORDABLE @ ${HEAD} — nothing measured`,
+			),
+		);
+		expect(result._tag).toBe("Found");
+		if (result._tag !== "Found") return;
+		expect(result.value.outcome).toBe("UNRECORDABLE");
+		expect(result.value.payload.cases[0]?.noVerdict).toBe(5);
+	});
+
+	it("accepts a below-bar rate — the bar belongs to the merge gate, not the record", () => {
+		const result = read(
+			withPayload(payloadOf({gradedRuns: 10, passedRuns: 1, passRate: 0.1, cases: []})),
+		);
+		expect(result._tag).toBe("Found");
+	});
+});
+
+describe("the binding is the verdict marker's, reused", () => {
+	it("answers Current for the head it was measured at and Stale for one that moved", () => {
+		const found = read(emit(RECORD));
+		if (found._tag !== "Found") throw new Error("fixture did not read back");
+		const marker: VerdictMarker = {
+			namespace: "eval",
+			polarity: "PASS",
+			sha: found.value.sha,
+			clause: found.value.clause,
+		};
+		expect(bindToHead(marker, HEAD)._tag).toBe("Current");
+		expect(bindToHead(marker, "b91e7d4a2c6f1b8093a5c4d2e1f6a7b8c9d03135")._tag).toBe("Stale");
+		expect(bindToHead(marker, "not-a-sha")._tag).toBe("Unbindable");
+	});
+});
+
+describe("the arithmetic the payload carries", () => {
+	it("dispersion is the minority-verdict count over the runs (ADR 0252 §1)", () => {
+		expect(dispersionOf(5, 5)).toBe(0);
+		expect(dispersionOf(5, 4)).toBe(1);
+		expect(dispersionOf(5, 3)).toBe(2);
+		expect(dispersionOf(5, 0)).toBe(0);
+	});
+
+	it("rates are stored at four decimal places", () => {
+		expect(roundRate(2 / 3)).toBe(0.6667);
+		expect(roundRate(19 / 20)).toBe(0.95);
+	});
+});

--- a/packages/fabrika-cli/src/wire/registry.ts
+++ b/packages/fabrika-cli/src/wire/registry.ts
@@ -19,6 +19,7 @@
  * registered without them — which is what makes the totality law inherited rather than re-written.
  */
 import * as acceptanceCriteria from "./acceptance-criteria.ts";
+import * as evalRecord from "./eval-record.ts";
 import {brandWitnesses, type WireFormat} from "./format.ts";
 import * as governanceDigest from "./governance-digest.ts";
 import * as grillAnswer from "./grill-answer.ts";
@@ -97,6 +98,59 @@ export const registeredFormats: ReadonlyArray<WireFormat> = [
 			],
 		},
 		brands: brandWitnesses<verdictMarker.VerdictMarker>({sha: true, clause: true, polarity: true}),
+	},
+	{
+		key: "eval-record",
+		purpose:
+			"the head-bound measurement a graded review run leaves on a PR — one cell's pass rate, its per-run verdicts and dispersion, and the model/CLI/harness it was measured at",
+		module: "packages/fabrika-cli/src/wire/eval-record.ts",
+		producers: ["review"],
+		consumers: ["ship"],
+		emit: evalRecord.emitFromFields,
+		read: evalRecord.readToLines,
+		fixtures: {
+			roundTrip: {
+				fields: [
+					"outcome: RECORDED",
+					"sha: 03135b91",
+					"clause: review/skill 0.6667 (2/3 cases, 0 unmeasured)",
+					"payload:",
+					'{"sha":"03135b91","recordedAt":"2026-08-10T04:08:00Z","cell":{"stage":"review","surface":"skill","model":"claude-opus-4-6"},"pins":{"model":"claude-opus-4-6","cli":"2.1.220","harness":"fabrika 0.1.0"},"gradedRuns":3,"passedRuns":2,"passRate":0.6667,"cases":[{"caseId":11,"verdict":"pass","runs":5,"passed":4,"noVerdict":0,"dispersion":1,"perRun":["pass","pass","fail","pass","pass"]},{"caseId":12,"verdict":"pass","runs":5,"passed":3,"noVerdict":1,"dispersion":2,"perRun":["pass","fail","pass","no-verdict:timed-out","pass"]},{"caseId":13,"verdict":"fail","runs":5,"passed":1,"noVerdict":0,"dispersion":1,"perRun":["fail","fail","pass","fail","fail"]}]}',
+				].join("\n"),
+				values: [
+					"RECORDED",
+					"03135b91",
+					"review/skill 0.6667 (2/3 cases, 0 unmeasured)",
+					"2026-08-10T04:08:00Z",
+					"claude-opus-4-6",
+					"2.1.220",
+					"fabrika 0.1.0",
+					"no-verdict:timed-out",
+				],
+			},
+			absent: "Ran the set locally and it looked fine to me — no notes.\n",
+			malformed: [
+				{
+					drift: "the outcome is spelled as a gate polarity",
+					artifact: "eval: PASS @ 03135b91 — review/skill 0.95\n",
+				},
+				{
+					drift: "the record carries no payload, so its number cannot be read",
+					artifact: "eval: RECORDED @ 03135b91 — review/skill 0.95\n",
+				},
+				{
+					drift: "a case's stored dispersion disagrees with the runs beside it",
+					artifact:
+						'eval: RECORDED @ 03135b91 — review/skill 1\n\n```json\n{"sha":"03135b91","recordedAt":"2026-08-10T04:08:00Z","cell":{"stage":"review","surface":"skill","model":"m"},"pins":{"model":"m","cli":"c","harness":"h"},"gradedRuns":1,"passedRuns":1,"passRate":1,"cases":[{"caseId":1,"verdict":"pass","runs":5,"passed":3,"noVerdict":0,"dispersion":0,"perRun":["pass","pass","pass","fail","fail"]}]}\n```\n',
+				},
+				{
+					drift: "an UNRECORDABLE record reports a real denominator",
+					artifact:
+						'eval: UNRECORDABLE @ 03135b91 — nothing measured\n\n```json\n{"sha":"03135b91","recordedAt":"2026-08-10T04:08:00Z","cell":{"stage":"review","surface":"skill","model":"m"},"pins":{"model":"m","cli":"c","harness":"h"},"gradedRuns":1,"passedRuns":1,"passRate":1,"cases":[]}\n```\n',
+				},
+			],
+		},
+		brands: brandWitnesses<evalRecord.EvalRecord>({outcome: true, sha: true, clause: true}),
 	},
 	{
 		key: "slice-handoff",

--- a/packages/fabrika-cli/src/wire/registry.ts
+++ b/packages/fabrika-cli/src/wire/registry.ts
@@ -115,7 +115,7 @@ export const registeredFormats: ReadonlyArray<WireFormat> = [
 					"sha: 03135b91",
 					"clause: review/skill 0.6667 (2/3 cases, 0 unmeasured)",
 					"payload:",
-					'{"sha":"03135b91","recordedAt":"2026-08-10T04:08:00Z","cell":{"stage":"review","surface":"skill","model":"claude-opus-4-6"},"pins":{"model":"claude-opus-4-6","cli":"2.1.220","harness":"fabrika 0.1.0"},"gradedRuns":3,"passedRuns":2,"passRate":0.6667,"cases":[{"caseId":11,"verdict":"pass","runs":5,"passed":4,"noVerdict":0,"dispersion":1,"perRun":["pass","pass","fail","pass","pass"]},{"caseId":12,"verdict":"pass","runs":5,"passed":3,"noVerdict":1,"dispersion":2,"perRun":["pass","fail","pass","no-verdict:timed-out","pass"]},{"caseId":13,"verdict":"fail","runs":5,"passed":1,"noVerdict":0,"dispersion":1,"perRun":["fail","fail","pass","fail","fail"]}]}',
+					'{"sha":"03135b91","recordedAt":"2026-08-10T04:08:00Z","cell":{"stage":"review","surface":"skill","model":"claude-opus-4-6"},"pins":{"model":"claude-opus-4-6","cli":"2.1.220","harness":"fabrika 0.1.0"},"gradedRuns":3,"passedRuns":2,"unmeasuredCases":0,"passRate":0.6667,"cases":[{"caseId":11,"verdict":"pass","runs":5,"passed":4,"noVerdict":0,"dispersion":1,"perRun":["pass","pass","fail","pass","pass"]},{"caseId":12,"verdict":"pass","runs":5,"passed":3,"noVerdict":1,"dispersion":2,"perRun":["pass","fail","pass","no-verdict:timed-out","pass"]},{"caseId":13,"verdict":"fail","runs":5,"passed":1,"noVerdict":0,"dispersion":1,"perRun":["fail","fail","pass","fail","fail"]}]}',
 				].join("\n"),
 				values: [
 					"RECORDED",
@@ -141,12 +141,22 @@ export const registeredFormats: ReadonlyArray<WireFormat> = [
 				{
 					drift: "a case's stored dispersion disagrees with the runs beside it",
 					artifact:
-						'eval: RECORDED @ 03135b91 — review/skill 1\n\n```json\n{"sha":"03135b91","recordedAt":"2026-08-10T04:08:00Z","cell":{"stage":"review","surface":"skill","model":"m"},"pins":{"model":"m","cli":"c","harness":"h"},"gradedRuns":1,"passedRuns":1,"passRate":1,"cases":[{"caseId":1,"verdict":"pass","runs":5,"passed":3,"noVerdict":0,"dispersion":0,"perRun":["pass","pass","pass","fail","fail"]}]}\n```\n',
+						'eval: RECORDED @ 03135b91 — review/skill 1\n\n```json\n{"sha":"03135b91","recordedAt":"2026-08-10T04:08:00Z","cell":{"stage":"review","surface":"skill","model":"m"},"pins":{"model":"m","cli":"c","harness":"h"},"gradedRuns":1,"passedRuns":1,"unmeasuredCases":0,"passRate":1,"cases":[{"caseId":1,"verdict":"pass","runs":5,"passed":3,"noVerdict":0,"dispersion":0,"perRun":["pass","pass","pass","fail","fail"]}]}\n```\n',
+				},
+				{
+					drift: "the cell aggregate disagrees with the case blocks it is drawn from",
+					artifact:
+						'eval: RECORDED @ 03135b91 — review/skill 1\n\n```json\n{"sha":"03135b91","recordedAt":"2026-08-10T04:08:00Z","cell":{"stage":"review","surface":"skill","model":"m"},"pins":{"model":"m","cli":"c","harness":"h"},"gradedRuns":10,"passedRuns":10,"unmeasuredCases":0,"passRate":1,"cases":[{"caseId":1,"verdict":"pass","runs":5,"passed":4,"noVerdict":0,"dispersion":1,"perRun":["pass","pass","fail","pass","pass"]}]}\n```\n',
+				},
+				{
+					drift: "graded cases are claimed over an empty cases array",
+					artifact:
+						'eval: RECORDED @ 03135b91 — review/skill 1\n\n```json\n{"sha":"03135b91","recordedAt":"2026-08-10T04:08:00Z","cell":{"stage":"review","surface":"skill","model":"m"},"pins":{"model":"m","cli":"c","harness":"h"},"gradedRuns":10,"passedRuns":10,"unmeasuredCases":0,"passRate":1,"cases":[]}\n```\n',
 				},
 				{
 					drift: "an UNRECORDABLE record reports a real denominator",
 					artifact:
-						'eval: UNRECORDABLE @ 03135b91 — nothing measured\n\n```json\n{"sha":"03135b91","recordedAt":"2026-08-10T04:08:00Z","cell":{"stage":"review","surface":"skill","model":"m"},"pins":{"model":"m","cli":"c","harness":"h"},"gradedRuns":1,"passedRuns":1,"passRate":1,"cases":[]}\n```\n',
+						'eval: UNRECORDABLE @ 03135b91 — nothing measured\n\n```json\n{"sha":"03135b91","recordedAt":"2026-08-10T04:08:00Z","cell":{"stage":"review","surface":"skill","model":"m"},"pins":{"model":"m","cli":"c","harness":"h"},"gradedRuns":1,"passedRuns":1,"unmeasuredCases":0,"passRate":1,"cases":[{"caseId":1,"verdict":"pass","runs":5,"passed":4,"noVerdict":0,"dispersion":1,"perRun":["pass","pass","fail","pass","pass"]}]}\n```\n',
 				},
 			],
 		},

--- a/packages/fabrika-cli/src/wire/verdict-marker.ts
+++ b/packages/fabrika-cli/src/wire/verdict-marker.ts
@@ -223,7 +223,15 @@ export type Binding =
 	| {readonly _tag: "Stale"; readonly markerSha: HeadSha; readonly head: HeadSha}
 	| {readonly _tag: "Unbindable"; readonly reason: string};
 
-/** Either side may be abbreviated, so the match is a prefix in whichever direction is shorter. */
+/**
+ * Whether two head SHAs name the same commit. Either side may be abbreviated, so the match is a
+ * prefix in whichever direction is shorter.
+ *
+ * Exported because {@link bindToHead} is not the only caller: `eval-record.ts` asks the same question
+ * of a payload against its own marker line. One copy, so the prefix rule cannot drift between them.
+ */
+export const sameHead = (a: HeadSha, b: HeadSha): boolean => a.startsWith(b) || b.startsWith(a);
+
 export const bindToHead = (marker: VerdictMarker, head: string): Binding => {
 	const resolved = headSha(head);
 	if (resolved === null) {
@@ -232,8 +240,7 @@ export const bindToHead = (marker: VerdictMarker, head: string): Binding => {
 			reason: `"${head.trim()}" is not a head SHA — the marker's binding cannot be judged`,
 		};
 	}
-	const current = marker.sha.startsWith(resolved) || resolved.startsWith(marker.sha);
-	return current
+	return sameHead(marker.sha, resolved)
 		? {_tag: "Current", sha: marker.sha}
 		: {_tag: "Stale", markerSha: marker.sha, head: resolved};
 };


### PR DESCRIPTION
A skill's judgment eval cases now actually get measured. Each graded case runs five times, the median is its verdict, and the result is left on the PR bound to the exact commit the review graded — so a later job can verify a number instead of re-running a model to get one. Nothing here judges that number against the 90% bar; that stays the merge gate's job.

Fixes #4678

## What landed

**`packages/fabrika-cli/src/eval/graded-axis.ts`** — the pure protocol. Five runs, the median, ADR 0252's `dispersion = min(passed, runs − passed)` with the five per-run verdicts kept beside it, and ADR 0253's four-reason `NoVerdict`. It imports nothing spawnable: the executions arrive through a `RunOnce` seam, so the whole protocol is driven in the unit tier by a stubbed grader and no unit test spends a cent.

**The grading is reused, not invented.** Each run is two invocations — the case's prompt against the candidate skill, then a grader handed that output plus the case's own authored `expected_output` and `expectations` **verbatim**. No rubric is declared in this package. A test holds that open: it strips the case's own text and the fixed instruction block out of a composed prompt and asserts nothing is left over.

**`packages/fabrika-cli/src/wire/eval-record.ts` + one registry row** — the record, on ADR 0241's terms (a sibling schema module, a total `Found`/`Absent`/`Malformed` read, no widening of `verdict-marker.ts`).

**`fabrika eval graded`** — the invocation surface, wired into fabrika's `review` stage at step 3a for a diff that changes a skill. No CI workflow reaches it; the unit test that has held that line since #4676 now covers this verb too.

## The shape the two downstream tickets get

Both #4680 and #4681 consume this, so here is what settled and why.

**It is a PR comment, one per `(head, cell)`, never a committed file** (ADR 0253 §3). Committing it would move the head it binds to.

**The head binding is reused, not re-invented.** `HeadSha`, `Clause` and `bindToHead` are imported from `verdict-marker.ts`, so there is exactly one notion of "bound to a head" in the package and `Current | Stale | Unbindable` resolves identically. What is new is the payload below the line — which is the whole reason it is a sibling module rather than a fourth branch inside the marker.

**The first line is the §VERDICT grammar in shape and field order, with one deliberate departure:** the second token is `RECORDED | UNRECORDABLE`, not a polarity. A polarity would have to mean *pass against what*, and the only candidate is the bar that belongs to #4681 — so spelling it that way would smuggle the gate into the module that must not hold it, and would make "the number is bad" indistinguishable from "the run died". A record spelled with `PASS` is `Malformed`.

**Two field spellings, on purpose** (ADR 0253 §5). The cell aggregate is `gradedRuns` / `passedRuns` / `passRate`, typed as a `Pick` of `ScorecardCell` so the compiler — not a convention — keeps #4680's committed row from needing a rename. The case block is `runs` / `passed` / `noVerdict` / `dispersion` / `perRun`, matching ADR 0252 §1. One graded **case** is one graded run at cell level; the five executions behind it live in the case block.

**Every aggregate is re-derived on read, never trusted.** A record whose `dispersion` disagrees with its own run counts, or whose `passRate` disagrees with its own denominator, reads `Malformed`. #4681 gets a comparison, not a leap of faith.

**Four states stay distinguishable**, which is what the record exists for: `missing` (no record at this PR), `stale` (bound to a head that moved), `below-bar` (a `RECORDED` record whose rate is low), `unrecordable` (nothing was measured). A record is emitted on **every** outcome — a below-bar run records its below-bar number, because a failing run that wrote nothing would arrive at the verifier as *missing* and redden for the wrong reason.

## The two calls a reader is most likely to want justified

**A run that returns no verdict never becomes a pass and never leaves the denominator.** It stays in `runs`, is counted in `noVerdict`, and sits on the non-pass side of the median — so a 3-of-5 with two dead invocations reads as a different fact from a 3-of-5 with two honest fails. It is **not retried inside the five**: a retry replaces a measurement with a re-measurement and silently changes what the median measured.

**A case whose every run died is `unmeasured`, not a zero.** It is absent from both sides of the pass rate, and a set where every case is unmeasured records `UNRECORDABLE`. Folding it into `0.0` would publish a measurement nobody took.

## Deviations

**Class: departure from the issue's stated shape.**
Said: the issue body's Amendment 1 names v1's `review-skill` as the invoker and points at v1's `claude-plugins/kampus-pipeline/skills/shared/gate-verdict-contract.md` for the head-bound shape.
Did: wired it into **fabrika's** `review` skill and bound it to **fabrika's** `packages/fabrika-cli/src/wire/verdict-marker.ts`.
Why: ADR 0238 forbids a fabrika skill or verb reaching into v1, and the issue's own Amendment 2 flagged both references as unauthorized violations awaiting a ruling.
Disposition: ruled — founder, on #4678 comment 5247154027 ("everything should be using fabrika's review, we have a rule for not using any v1 tech"). ADR 0253's Context already read it this way.

**Class: a value the spec left undefined.**
Said: ADR 0253 §4 defines `UNRECORDABLE` for the case where all five runs return no verdict, and the payload's case-block `verdict` field is only ever shown as `"pass"`.
Did: added a third per-case verdict, `unmeasured`, and made the record's token `UNRECORDABLE` only when *every* case is unmeasured.
Why: over a multi-case set the ADR's rule has no per-case spelling. Without a third state a dead case scores `fail` and drags a real rate down with a measurement nobody took, which is the `0.0`-over-nothing the same ADR bans.
Disposition: for the reviewer to judge. If it should instead be spelled on the record only, the change is local to `gradedCellAggregate` and the case block's verdict union.

**Class: a rule stated where none existed.**
Said: nothing anywhere says what the median of an *even* run count is.
Did: sorted `fail < pass` and took the lower middle, so an even split resolves to `fail`, and documented + tested it.
Why: at the ruled five runs the tie cannot arise, but the function is total over any count and rounding a tie up would be the median quietly defaulting to a pass.
Disposition: no action needed — stated at the function and covered by a test.

**Class: a surface the issue did not ask for.**
Said: the acceptance criteria describe a module, not a command.
Did: added `fabrika eval graded` and a new exit seat, `NO_MEASUREMENT = 14`, in the `eval` group's private band.
Why: "invoked by the review stage" needs something to invoke. The exit code says only whether a measurement exists — a below-bar rate exits `0`, because whether a rate clears the bar is #4681's judgement.
Disposition: no action needed.

**Class: a convention introduced, which could be misread as a rubric.**
Said: no second rubric mechanism is introduced.
Did: the grader is asked to end on a line of exactly `VERDICT: PASS` or `VERDICT: FAIL`, and the reader takes the **last** such line.
Why: that is a response format, not a standard — the standard is the authored expectations, quoted into the prompt unchanged. The last-line rule exists because a grader that reasons aloud mentions both words on the way.
Disposition: no action needed; named here because a reader could reasonably want to check it.

**Class: a default that could be read as weakening a ruling.**
Said: five runs, ruled.
Did: `--runs` defaults to `GRADED_RUNS = 5` and accepts another value.
Why: an operator smoke-testing the path should not have to pay for five runs; the ruled count is what every unattended invocation gets.
Disposition: for the reviewer to judge — if the flag should not exist, deleting it is a one-line change and the core already defaults.

**Class: scope deliberately left.**
Said: out of scope are the 90% bar, the trend co-gate, and scorecard commitment.
Did: none of them. The pass rate is computed and recorded; nothing compares it to anything.
Disposition: no action needed — #4680 and #4681 own them, and this PR names neither number.

**(repair round 1) Class: a pre-existing test changed because the fix contradicts it.**
Said: `eval-record.unit.test.ts`'s "accepts a below-bar rate" fed `{gradedRuns: 10, passedRuns: 1, cases: []}` and asserted `Found`.
Did: rewrote it to make the same point with case blocks that support the rate, and turned the old shape into a `Malformed` probe. The registry's "UNRECORDABLE reports a real denominator" fixture likewise gained a case block, so it still exercises the token/denominator check rather than the new derivation.
Why: those payloads *were* the hole — the reviewer proved a record can publish a figure its own contents contradict, so a test asserting `Found` over them enshrined it.
Disposition: no action needed — flagged because a reviewer should see a green test was deliberately inverted.

**(repair round 1) Class: a payload field added mid-life.**
Said: the record's field inventory was fixed by ADR 0253.
Did: added a required `unmeasuredCases` integer to the payload.
Why: the reviewer's condition on accepting the `unmeasured` per-case verdict — without it, #4680 commits a `3/3 = 1.0` row that hides a case which never ran.
Disposition: for the reviewer to judge whether ADR 0253's inventory needs the same amendment; the field is checkable by the same walk that re-derives the rest.

**(repair round 1) Class: a flag removed that the previous round shipped.**
Said: round 0's own deviations offered `--runs` for the reviewer to judge.
Did: deleted `runsFlag` from the `graded` verb; `runGradedAxis({runs?})` stays for the unit tier.
Why: the reviewer ruled it — reject as a CLI flag, accept as a core parameter — because a record made at one run is indistinguishable from a ruled five at the gate.
Disposition: no action needed; re-adding the flag is gated on #4681 asserting `every case.runs === GRADED_RUNS`.

**(repair round 1) Class: behavior changed beyond the FAIL list, on a founder ruling landed mid-round.**
Said: the reviewer's priority-6 finding left the no-record-on-a-broken-set gap as a flagged question, not a defect.
Did: an unreadable / nonconforming / no-graded-case eval set now emits an explicit `UNRECORDABLE` record naming which it was, on its unchanged exit code (1 / 4 / 7). `--stage`/`--surface` validation moved ahead of the file read, so an operator's own bad invocation still records nothing.
Why: the founder ruled it on [#4678 comment 5247447078](https://github.com/kamp-us/phoenix/issues/4678#issuecomment-5247447078) — explicit beats implicit for error cases, and silence reaches #4681 as `missing`.
Disposition: no action needed; stays inside `RECORDED | UNRECORDABLE`, no polarity and no bar.