### PR TITLE
feat(fabrika): the eval post verb — one record, one PR comment per (head, cell) (#5411)

### DIFF
--- a/packages/fabrika-cli/src/eval/codes.ts
+++ b/packages/fabrika-cli/src/eval/codes.ts
@@ -7,7 +7,7 @@
  * exactly what the convention reserves it for: a usage error (a flag naming something that is not a
  * stage, a surface, or an arm) and a read that failed before the verb could judge anything.
  *
- * The two shared seats are **imported from the base, never re-typed** — the discipline
+ * The shared seats are **imported from the base, never re-typed** — the discipline
  * `../review-ui/codes.ts` states, and the reason `../exit-code-alignment.ts` can check them. `12`
  * and up are this group's own.
  *
@@ -16,7 +16,13 @@
 
 import {
 	BAD_SECTIONS as REPORT_BAD_SECTIONS,
+	BARE_AT_PATH as REPORT_BARE_AT_PATH,
+	EMPTY_STDIN as REPORT_EMPTY_STDIN,
+	LEAKED_PATH as REPORT_LEAKED_PATH,
 	NO_TARGET as REPORT_NO_TARGET,
+	PRECONDITION_UNKNOWN as REPORT_PRECONDITION_UNKNOWN,
+	READBACK_MISMATCH as REPORT_READBACK_MISMATCH,
+	WRITE_UNKNOWN as REPORT_WRITE_UNKNOWN,
 } from "../report/codes.ts";
 
 /**
@@ -36,6 +42,21 @@ export const MALFORMED_DOCUMENT = REPORT_BAD_SECTIONS;
  * outcome with its own seat rather than a green with a caveat on stderr.
  */
 export const ZERO_SCOPE = REPORT_NO_TARGET;
+
+/**
+ * The write-path seats, imported from the base with its meanings unchanged (`eval post`, #5411).
+ *
+ * They arrive as a block because they arrived with one verb: until `post` the group neither read
+ * stdin nor wrote anything, so every fact these name was unreachable here. Each keeps the base's
+ * name as well as its number, which is what lets `../exit-code-alignment.ts` record the claim that
+ * the two meanings are one rather than merely that the two numbers match.
+ */
+export const EMPTY_STDIN = REPORT_EMPTY_STDIN;
+export const LEAKED_PATH = REPORT_LEAKED_PATH;
+export const BARE_AT_PATH = REPORT_BARE_AT_PATH;
+export const WRITE_UNKNOWN = REPORT_WRITE_UNKNOWN;
+export const READBACK_MISMATCH = REPORT_READBACK_MISMATCH;
+export const PRECONDITION_UNKNOWN = REPORT_PRECONDITION_UNKNOWN;
 
 /**
  * Proven: the ruled-KEEP enumeration decodes but breaks its own integrity rules.
@@ -93,3 +114,30 @@ export const BASELINE_INCOMPARABLE = 16;
  * is a precondition of the artifact, not a field a writer may leave out (#4637 ruling 4).
  */
 export const NOT_COMMITTABLE = 17;
+
+/**
+ * Proven: the record's `sha` is not the PR's live head, so the tree it measured is gone.
+ *
+ * A measurement is re-run at the new head, never re-bound to it — re-binding would publish a number
+ * taken over one tree as if it had been taken over another. `../review/codes.ts` seats the same fact
+ * on `12`; this group's `12` is {@link INTEGRITY_VIOLATION}, so cross-group divergence above `11` is
+ * the doctrine and the refusal is re-seated here rather than imported (ADR 0253).
+ */
+export const STALE_HEAD = 18;
+
+/**
+ * Proven: the comment enumeration is short of the count the platform declared.
+ *
+ * Its own seat because the upsert's match is then *unprovable* rather than negative: a sweep that
+ * missed the comment this record owes an edit to would create a second one, and two comments on one
+ * `(head, cell)` is exactly what ADR 0253's key forbids.
+ */
+export const INCOMPLETE_SCAN = 19;
+
+/**
+ * Proven: the pull request is absent (404) or closed, so a record has no home there.
+ *
+ * Deliberately not {@link ZERO_SCOPE}: this group widened `7` to *the eval set carries zero cases*,
+ * and one number may not carry two facts inside one group.
+ */
+export const TARGET_ABSENT = 20;

--- a/packages/fabrika-cli/src/eval/command.ts
+++ b/packages/fabrika-cli/src/eval/command.ts
@@ -12,6 +12,7 @@
  *   fabrika eval graded <path>      # five runs per graded case, the median, and the head-bound record
  *   fabrika eval keeps <path>       # print the ruled KEEP corpus and what already pins each row
  *   fabrika eval baseline …         # record the v1 cost baseline, and answer the phase-1 ceiling
+ *   fabrika eval post <pr>          # commit one head-bound record onto a PR, upserted per (head, cell)
  *
  * `check` (issue #1848) validates the on-disk corpus format. `report` (issue #1853) is the
  * top of the vertical slice: it reads the runner's graded `{entry, grade, spend}` rows and
@@ -33,13 +34,14 @@ import {Console, Crypto, Effect, FileSystem, Path, Result} from "effect";
 import * as Schema from "effect/Schema";
 import {Argument, Command, Flag} from "effect/unstable/cli";
 import {leafCommand} from "../excess-operand.ts";
+import {readStdin} from "../io/stdin.ts";
 import {
 	DEFAULT_SPEND_LEDGER_PATH,
 	type LedgerRow,
 	persistSpendRows,
 	readSpendLedger,
 } from "../spend/ledger.ts";
-import {FAILED} from "../verb.ts";
+import {FAILED, type VerbOutcome} from "../verb.ts";
 import {VERSION} from "../version.ts";
 import {
 	type EvalRecord,
@@ -87,6 +89,7 @@ import {
 } from "./graded-axis.ts";
 import {decodeIncidentProvenance} from "./incident-provenance.ts";
 import {churnToJson, compareToSeries, renderChurn} from "./model-churn.ts";
+import {runPost} from "./post-verb.ts";
 import {
 	type BaselineKey,
 	buildScorecard,
@@ -1561,6 +1564,62 @@ const churn = leafCommand(
 	),
 );
 
+/** Write the outcome and exit on its code — stdout is the answer, everything else is stderr. */
+const emit = (outcome: VerbOutcome): Effect.Effect<void> =>
+	Effect.sync(() => {
+		for (const line of outcome.stderr) process.stderr.write(`${line}\n`);
+		if (outcome.stdout !== "") process.stdout.write(outcome.stdout);
+		process.exit(outcome.code);
+	});
+
+const repoFlag = Flag.string("repo").pipe(
+	Flag.optional,
+	Flag.withDescription(
+		"the target owner/name (default: $CLAUDE_PIPELINE_REPO, else $GITHUB_REPOSITORY, else the origin remote)",
+	),
+);
+
+const resultJsonFlag = Flag.boolean("json").pipe(
+	Flag.withDescription("emit the result object on stdout instead of the line grammar"),
+);
+
+/**
+ * `post` — commit one head-bound eval record onto a PR as a comment (#5411).
+ *
+ * The record arrives on **stdin only** — no `--body`, no `--body-file`, and no `--sha` or `--cell`
+ * either. A path flag is how a machine-local path reaches a public surface while the poster reads
+ * success, and a flag repeating a payload field is a second home the two can drift between: the
+ * record is already a self-contained artifact carrying every value this verb needs.
+ */
+const post = leafCommand(
+	"post",
+	{
+		pr: Argument.integer("pr").pipe(
+			Argument.withDescription("the pull request the record lands on"),
+		),
+		repo: repoFlag,
+		json: resultJsonFlag,
+	},
+	Effect.fn(function* ({pr, repo, json}) {
+		yield* emit(
+			yield* runPost({
+				pr,
+				repo: repo._tag === "Some" ? repo.value : null,
+				json,
+				env: process.env,
+				stdin: Effect.sync(readStdin),
+			}),
+		);
+	}),
+).pipe(
+	Command.withShortDescription(
+		"Post the eval record on stdin onto a PR, upserted per (head, cell).",
+	),
+	Command.withDescription(
+		"Post the head-bound eval record on STDIN as ONE comment per (head, cell) — read stdin through the `eval-record` wire format, resolve the PR, compare the record's sha against the live head, leak-scan the bytes, sweep the comments count-checked, upsert, and read the comment back from live PR state. Prints `posted\\t<RECORDED|UNRECORDABLE>\\t<sha>\\t<cell>\\t<created|edited>\\t<comment-url>`. Exits 3 (empty stdin), 4 (stdin does not read as an eval record), 5 (machine-local path in the record), 6 (bare @ reference), 8 (the create/edit failed — UNKNOWN), 9 (the read-back does not yield this record), 11 (a precondition read failed — nothing was posted), 18 (the record's sha is not the PR's live head — re-run the suite, never re-bind), 19 (the comment sweep is provably short), 20 (the PR is absent or closed). Example: fabrika eval graded evals.json --stage triage --model <model> --plugin-dir claude-plugins/fabrika --sha 03135b91 | fabrika eval post 9041",
+	),
+);
+
 export const evalCommand = Command.make("eval").pipe(
 	Command.withSubcommands([
 		check,
@@ -1573,8 +1632,9 @@ export const evalCommand = Command.make("eval").pipe(
 		scorecard,
 		trend,
 		churn,
+		post,
 	]),
 	Command.withDescription(
-		"Graded per-stage corpus + scorecard + authored-eval-set ingestion + the unattended runner + the five-run graded axis + the ruled KEEP enumeration + the v1 cost baseline + the committed scorecard series, its trend co-gate and the model-churn re-run (#1848, #1853, #4674, #4676, #4678, #4823, #4679, #4680)",
+		"Graded per-stage corpus + scorecard + authored-eval-set ingestion + the unattended runner + the five-run graded axis + the ruled KEEP enumeration + the v1 cost baseline + the committed scorecard series, its trend co-gate, the model-churn re-run and the record emit (#1848, #1853, #4674, #4676, #4678, #4823, #4679, #4680, #5411)",
 	),
 );

--- a/packages/fabrika-cli/src/eval/post-verb.ts
+++ b/packages/fabrika-cli/src/eval/post-verb.ts
@@ -1,0 +1,270 @@
+/**
+ * `eval post` — the single sanctioned path from an eval record to a PR comment.
+ *
+ * Seven steps, each gating the next: read stdin through the registered format, resolve the PR,
+ * compare the record's head against the live one, leak-scan the bytes, sweep the comments
+ * count-checked, upsert on `(head, cell)`, and read the comment back from live PR state.
+ *
+ * The record is posted **exactly as it arrived**. Nothing here composes, normalises or recomputes a
+ * field — the score is passed-cases over graded-cases and `wire/eval-record.ts` already re-derives
+ * every aggregate from the case blocks beside it (#5258), so a second derivation here could only
+ * disagree with the one artifact both sides read. A record whose suite produced no measurement is
+ * `UNRECORDABLE` and posts like any other: an explicit failed record beats silence, which reaches a
+ * gate as byte-identical to a run that never happened (founder ruling, #4678).
+ *
+ * Every step is a scar. #3173's hand-rolled `gh api` emit posted garbage and self-reported success,
+ * which is why the read-back re-fetches instead of trusting the write call's echo. The `18` refusal
+ * is the stale-head class at the write seam. And the `19` refusal is what keeps a short sweep from
+ * creating a second comment where an edit was owed — two comments on one `(head, cell)` is exactly
+ * what ADR 0253's key forbids.
+ */
+import {Effect} from "effect";
+import type {ChildProcessSpawner} from "effect/unstable/process";
+import {
+	type CommentRecord,
+	createComment,
+	getComment,
+	listComments,
+	resolveRepo,
+} from "../io/issues.ts";
+import {getPullRequest, patchComment} from "../io/pulls.ts";
+import type {StdinRead} from "../io/stdin.ts";
+import {normalizeForReadback} from "../report/compose.ts";
+import {isBareAtReference, renderLeaks, scanBody} from "../report/leaks.ts";
+import {answer, FAILED, refuse, type VerbOutcome} from "../verb.ts";
+import {type EvalRecord, type EvalRecordCell, read as readRecord} from "../wire/eval-record.ts";
+import {headSha, sameHead} from "../wire/verdict-marker.ts";
+import {
+	BARE_AT_PATH,
+	EMPTY_STDIN,
+	INCOMPLETE_SCAN,
+	LEAKED_PATH,
+	MALFORMED_DOCUMENT,
+	PRECONDITION_UNKNOWN,
+	READBACK_MISMATCH,
+	STALE_HEAD,
+	TARGET_ABSENT,
+	WRITE_UNKNOWN,
+} from "./codes.ts";
+
+const VERB = "eval post";
+
+export interface PostOptions {
+	readonly pr: number;
+	readonly repo: string | null;
+	readonly json: boolean;
+	readonly env: Readonly<Record<string, string | undefined>>;
+	readonly stdin: Effect.Effect<StdinRead>;
+}
+
+/** The cell as the answer line spells it: `<stage>` or `<stage>/<surface>`. */
+const cellLabel = (cell: EvalRecordCell): string =>
+	cell.surface === null || cell.surface === "" ? cell.stage : `${cell.stage}/${cell.surface}`;
+
+/** ADR 0243 §4's key in full — a model swap is a different cell, not a newer reading of this one. */
+const sameCell = (a: EvalRecordCell, b: EvalRecordCell): boolean =>
+	a.stage === b.stage && a.surface === b.surface && a.model === b.model;
+
+const scannedLine = (scanned: number): string =>
+	`${VERB}: scanned ${scanned} comment${scanned === 1 ? "" : "s"}.`;
+
+/**
+ * Why the read-back does not show what was posted, or `null` when it does.
+ *
+ * Both halves are needed. The **fields** go through the format's own `read`, which is what proves the
+ * comment carries *this* record rather than some record; the **whole body** is then compared against
+ * the bytes that were sent, because a marker line that parses says nothing about the payload under
+ * it. `normalizeForReadback` is imported rather than re-derived for one specific reason: its
+ * trailing-newline step is the one a re-derivation drops, and dropping it fires `9` on clean runs.
+ */
+const mismatchOf = (body: string, record: EvalRecord, sent: string): string | null => {
+	const normalized = normalizeForReadback(body);
+	const parsed = readRecord(normalized);
+	if (parsed._tag !== "Found") return parsed.reason;
+	const back = parsed.value;
+	if (!sameHead(back.sha, record.sha)) return `sha ${back.sha}, expected ${record.sha}`;
+	if (back.outcome !== record.outcome) return `token ${back.outcome}, expected ${record.outcome}`;
+	if (!sameCell(back.payload.cell, record.payload.cell)) {
+		return `cell ${cellLabel(back.payload.cell)} on ${back.payload.cell.model}, expected ${cellLabel(record.payload.cell)} on ${record.payload.cell.model}`;
+	}
+	return normalized === normalizeForReadback(sent)
+		? null
+		: "the comment's bytes are not the ones that were sent";
+};
+
+export const runPost = (
+	options: PostOptions,
+): Effect.Effect<VerbOutcome, never, ChildProcessSpawner.ChildProcessSpawner> =>
+	Effect.gen(function* () {
+		const {pr, json} = options;
+		if (!Number.isInteger(pr) || pr <= 0) {
+			return refuse(FAILED, `${VERB}: ${pr} is not a pull-request number.`);
+		}
+
+		// Step 1 — the record arrives through the registered format, and an unread pipe is never empty.
+		const read = yield* options.stdin;
+		if (read._tag === "Failed") {
+			return refuse(
+				FAILED,
+				`${VERB}: could not read stdin: ${read.reason} — the record is UNKNOWN, never empty.`,
+			);
+		}
+		const bytes = read._tag === "NoStdin" ? "" : read.text;
+		if (bytes.trim() === "") {
+			return refuse(
+				EMPTY_STDIN,
+				`${VERB}: no record on stdin — pipe the bytes eval graded emitted.`,
+				[`${VERB}: stdin was read and held ${new TextEncoder().encode(bytes).length} byte(s).`],
+			);
+		}
+		if (isBareAtReference(bytes)) {
+			return refuse(
+				BARE_AT_PATH,
+				`${VERB}: the body is a bare "@" path reference — the record never arrived. Pipe its bytes on stdin.`,
+			);
+		}
+		const parsed = readRecord(bytes);
+		if (parsed._tag !== "Found") {
+			return refuse(
+				MALFORMED_DOCUMENT,
+				`${VERB}: stdin does not read as an eval record (absent or malformed: ${parsed.reason}) — post the emitted bytes, never a hand-assembled comment.`,
+			);
+		}
+		const record = parsed.value;
+
+		const target = yield* resolveRepo(options.repo, options.env);
+		if (target._tag === "Failure") {
+			return refuse(
+				FAILED,
+				`${VERB}: cannot resolve a target repo — set CLAUDE_PIPELINE_REPO, or run inside a checkout whose origin remote resolves.`,
+			);
+		}
+		const repo = target.value;
+		const unreadable = (what: string, reason: string): VerbOutcome =>
+			refuse(
+				PRECONDITION_UNKNOWN,
+				`${VERB}: cannot read ${what} for #${pr}: ${reason} — nothing was posted.`,
+			);
+
+		// Step 2 — a 404 and an unreachable GitHub are different facts, and only the first is proven.
+		const found = yield* getPullRequest(repo, pr);
+		if (found._tag === "Absent") {
+			return refuse(TARGET_ABSENT, `${VERB}: PR #${pr} not found in ${repo}.`);
+		}
+		if (found._tag === "Unknown") return unreadable("the PR", found.reason);
+		const pull = found.value;
+		if (pull.state !== "open") {
+			return refuse(
+				TARGET_ABSENT,
+				`${VERB}: PR #${pr} is closed — a record there enters no series; post on the PR that carries this head.`,
+			);
+		}
+
+		// Step 3 — the record measured a tree; if the PR has left it, the suite is re-run, never re-bound.
+		const live = headSha(pull.headSha);
+		if (live === null) {
+			return unreadable("the live head", `"${pull.headSha.trim()}" is not a head SHA`);
+		}
+		if (!sameHead(record.sha, live)) {
+			return refuse(
+				STALE_HEAD,
+				`${VERB}: PR #${pr}'s head is ${live}, not ${record.sha} — the tree this record measured is gone; re-run the suite at ${live}, never re-bind (ADR 0253).`,
+			);
+		}
+
+		// Step 4 — the scan runs over the bytes that will be posted, so nothing reaches the PR unscanned.
+		const scan = scanBody(bytes);
+		const leak = scan.leaks[0];
+		if (leak !== undefined) {
+			return refuse(
+				LEAKED_PATH,
+				`${VERB}: the record carries a machine-local path at line ${leak.line} (${leak.class}) — a transcriptPath is machine-local and perishable; strip it (ADR 0273).`,
+				renderLeaks(scan.leaks),
+			);
+		}
+
+		// Step 5 — the sweep is the upsert's evidence, so a provably short one refuses rather than creates.
+		const listed = yield* listComments(repo, pr);
+		if (listed._tag === "Failure") return unreadable("the comments", listed.reason);
+		const swept = listed.value;
+		if (swept.length < pull.comments) {
+			return refuse(
+				INCOMPLETE_SCAN,
+				`${VERB}: received ${swept.length} of ${pull.comments} declared comments on #${pr} — refusing the partial sweep; a blind create could shadow the edit this record owes.`,
+			);
+		}
+
+		const notices: Array<string> = [];
+		const matches: Array<CommentRecord> = [];
+		for (const comment of swept) {
+			const carried = readRecord(comment.body);
+			// A comment that reaches for the format and fails it is named rather than dropped: it may be
+			// the very comment this record owes an edit to, garbled, and a silent skip would duplicate it.
+			if (carried._tag === "Malformed") {
+				notices.push(
+					`${VERB}: comment ${comment.id} reaches for the eval-record format and fails it: ${carried.reason}.`,
+				);
+				continue;
+			}
+			if (carried._tag !== "Found") continue;
+			if (
+				sameHead(carried.value.sha, record.sha) &&
+				sameCell(carried.value.payload.cell, record.payload.cell)
+			) {
+				matches.push(comment);
+			}
+		}
+		const diagnostics = [scannedLine(swept.length), ...notices];
+
+		// Step 6 — one comment per `(head, cell)` (ADR 0253), the newest in force. The list arrives
+		// oldest-first, so the last match is the one a reader would be looking at.
+		const held = matches.at(-1);
+		let landed: {readonly id: number; readonly url: string} | null = null;
+		let failure: string | null = null;
+		if (held === undefined) {
+			const created = yield* createComment(repo, pr, bytes);
+			if (created._tag === "Failure") failure = created.reason;
+			else landed = {id: created.value.id, url: created.value.url};
+		} else {
+			const edited = yield* patchComment(repo, held.id, bytes);
+			if (edited._tag === "Failure") failure = edited.reason;
+			else landed = {id: held.id, url: edited.value};
+		}
+		if (landed === null) {
+			return refuse(
+				WRITE_UNKNOWN,
+				`${VERB}: create/edit failed: ${failure ?? "unknown"} — UNKNOWN whether the record landed; sweep the PR's comments before retrying.`,
+				diagnostics,
+			);
+		}
+		const upsert = held === undefined ? "created" : "edited";
+
+		// Step 7 — read it back from live state. The write call's own echo is not evidence (#3173).
+		const back = yield* getComment(repo, landed.id);
+		const mismatch = back._tag === "Failure" ? back.reason : mismatchOf(back.value, record, bytes);
+		if (mismatch !== null) {
+			return refuse(
+				READBACK_MISMATCH,
+				`${VERB}: posted, but the read-back does not yield this record (${mismatch}) — the PR may carry a garbled record; inspect comment ${landed.id} before re-running, since a garbled comment does not match the upsert key.`,
+				diagnostics,
+			);
+		}
+
+		return json
+			? answer(
+					JSON.stringify({
+						outcome: "posted",
+						token: record.outcome,
+						sha: record.sha,
+						cell: record.payload.cell,
+						upsert,
+						commentUrl: landed.url,
+						scanned: swept.length,
+					}),
+					diagnostics,
+				)
+			: answer(
+					`posted\t${record.outcome}\t${record.sha}\t${cellLabel(record.payload.cell)}\t${upsert}\t${landed.url}`,
+					diagnostics,
+				);
+	});

--- a/packages/fabrika-cli/src/eval/post-verb.unit.test.ts
+++ b/packages/fabrika-cli/src/eval/post-verb.unit.test.ts
@@ -1,0 +1,411 @@
+import {Effect} from "effect";
+import {describe, expect, it} from "vitest";
+import {errOut, fakeShell, okOut} from "../fakes.test-support.ts";
+import type {ExecResult} from "../io/exec.ts";
+import type {StdinRead} from "../io/stdin.ts";
+import {
+	BARE_AT_PATH,
+	EMPTY_STDIN,
+	INCOMPLETE_SCAN,
+	LEAKED_PATH,
+	MALFORMED_DOCUMENT,
+	PRECONDITION_UNKNOWN,
+	READBACK_MISMATCH,
+	STALE_HEAD,
+	TARGET_ABSENT,
+	WRITE_UNKNOWN,
+} from "./codes.ts";
+import {runPost} from "./post-verb.ts";
+
+const HEAD = "03135b91aa04f7e2c9d8b1640a5c22e9f01b7d3c";
+const OTHER_HEAD = "7be402c1d3e5f60718293a4b5c6d7e8f90a1b2c3";
+const URL = "https://example.test/pull/9041#issuecomment-9100000001";
+
+const PULL = /^gh api repos\/o\/r\/pulls\/9041$/;
+const COMMENTS = /^gh api --paginate repos\/o\/r\/issues\/9041\/comments/;
+const CREATE = /^gh api --method POST repos\/o\/r\/issues\/9041\/comments /;
+const PATCH = /^gh api --method PATCH repos\/o\/r\/issues\/comments\/\d+ /;
+const READBACK = /^gh api repos\/o\/r\/issues\/comments\/\d+$/;
+
+interface Cell {
+	readonly stage: string;
+	readonly surface: string | null;
+	readonly model: string;
+}
+
+const CELL: Cell = {stage: "review", surface: "skill", model: "claude-opus-4-6"};
+
+/**
+ * A conforming record's bytes, as `eval graded` emits them.
+ *
+ * Composed here rather than through the format's `emit` so the tests own the *bytes* — the artifact
+ * this verb posts verbatim — instead of asserting a round trip against the composer that produced it.
+ */
+const recordBytes = (
+	shape: {
+		readonly sha?: string;
+		readonly cell?: Cell;
+		readonly outcome?: "RECORDED" | "UNRECORDABLE";
+		readonly extraLine?: string;
+	} = {},
+): string => {
+	const sha = shape.sha ?? HEAD;
+	const cell = shape.cell ?? CELL;
+	const outcome = shape.outcome ?? "RECORDED";
+	const measured = outcome === "RECORDED";
+	const payload = {
+		sha,
+		recordedAt: "2026-08-11T06:30:00Z",
+		cell,
+		pins: {model: cell.model, cli: "2.1.9", harness: "0.1.0"},
+		gradedRuns: measured ? 1 : 0,
+		passedRuns: measured ? 1 : 0,
+		unmeasuredCases: measured ? 0 : 1,
+		passRate: measured ? 1 : 0,
+		cases: [
+			measured
+				? {
+						caseId: 1,
+						verdict: "pass",
+						runs: 5,
+						passed: 5,
+						noVerdict: 0,
+						dispersion: 0,
+						perRun: ["pass", "pass", "pass", "pass", "pass"],
+					}
+				: {
+						caseId: 1,
+						verdict: "unmeasured",
+						runs: 5,
+						passed: 0,
+						noVerdict: 5,
+						dispersion: 0,
+						perRun: Array.from({length: 5}, () => "no-verdict:grader-silent"),
+					},
+		],
+	};
+	const clause = measured ? "review/skill 1.0 (1/1 cases)" : "review/skill no measurement";
+	return [
+		`eval: ${outcome} @ ${sha} — ${clause}`,
+		"",
+		...(shape.extraLine === undefined ? [] : [shape.extraLine, ""]),
+		"```json",
+		JSON.stringify(payload, null, 2),
+		"```",
+		"",
+	].join("\n");
+};
+
+const RECORD = recordBytes();
+
+const pull = (
+	shape: {readonly state?: string; readonly head?: string; readonly comments?: number} = {},
+): ExecResult =>
+	okOut(
+		JSON.stringify({
+			number: 9041,
+			state: shape.state ?? "open",
+			head: {sha: shape.head ?? HEAD},
+			base: {ref: "main"},
+			body: "does a thing",
+			changed_files: 2,
+			comments: shape.comments ?? 0,
+		}),
+	);
+
+const comments = (
+	...rows: ReadonlyArray<{id: number; body: string; author?: string}>
+): ExecResult =>
+	okOut(
+		JSON.stringify(
+			rows.map((row) => ({
+				id: row.id,
+				user: {login: row.author ?? "kampus-bot"},
+				created_at: "2026-08-11T00:00:00Z",
+				updated_at: "2026-08-11T00:00:00Z",
+				body: row.body,
+			})),
+		),
+	);
+
+const created = okOut(JSON.stringify({id: 9100000001, html_url: URL}));
+
+const options = {
+	pr: 9041,
+	repo: null,
+	json: false,
+	env: {CLAUDE_PIPELINE_REPO: "o/r"} as Record<string, string | undefined>,
+	stdin: Effect.succeed<StdinRead>({_tag: "Text", text: RECORD}),
+};
+
+const happy = (): ReadonlyArray<readonly [RegExp, ExecResult]> => [
+	[PULL, pull()],
+	[COMMENTS, comments()],
+	[CREATE, created],
+	[READBACK, okOut(JSON.stringify({body: RECORD}))],
+];
+
+const run = (
+	script: ReadonlyArray<readonly [RegExp, ExecResult]>,
+	overrides: Partial<typeof options> = {},
+) =>
+	Effect.runPromise(Effect.provide(runPost({...options, ...overrides}), fakeShell(script).layer));
+
+const piped = (text: string): Partial<typeof options> => ({
+	stdin: Effect.succeed<StdinRead>({_tag: "Text", text}),
+});
+
+describe("runPost", () => {
+	it("posts the record and says whether it created or edited", async () => {
+		const out = await run(happy());
+		expect(out.code).toBe(0);
+		expect(out.stdout).toBe(`posted\tRECORDED\t${HEAD}\treview/skill\tcreated\t${URL}\n`);
+	});
+
+	it("names a stage-only cell without a trailing slash", async () => {
+		const bytes = recordBytes({cell: {stage: "triage", surface: null, model: CELL.model}});
+		const out = await run(
+			[
+				[PULL, pull()],
+				[COMMENTS, comments()],
+				[CREATE, created],
+				[READBACK, okOut(JSON.stringify({body: bytes}))],
+			],
+			piped(bytes),
+		);
+		expect(out.stdout).toBe(`posted\tRECORDED\t${HEAD}\ttriage\tcreated\t${URL}\n`);
+	});
+
+	it("emits the result object under --json, with the scanned count", async () => {
+		const out = await run(
+			[
+				[PULL, pull({comments: 1})],
+				[COMMENTS, comments({id: 7, body: "a plain comment"})],
+				[CREATE, created],
+				[READBACK, okOut(JSON.stringify({body: RECORD}))],
+			],
+			{json: true},
+		);
+		expect(out.code).toBe(0);
+		expect(JSON.parse(out.stdout)).toEqual({
+			outcome: "posted",
+			token: "RECORDED",
+			sha: HEAD,
+			cell: CELL,
+			upsert: "created",
+			commentUrl: URL,
+			scanned: 1,
+		});
+	});
+
+	it("posts the record's bytes verbatim — no re-derived score, no re-composed body", async () => {
+		const shell = fakeShell(happy());
+		await Effect.runPromise(Effect.provide(runPost(options), shell.layer));
+		const write = shell.calls.find((call) => CREATE.test(call)) ?? "";
+		expect(write.slice(write.indexOf("body=") + "body=".length)).toBe(RECORD);
+	});
+
+	it("edits this (head, cell)'s existing comment instead of stacking a second one", async () => {
+		const shell = fakeShell([
+			[PULL, pull({comments: 1})],
+			[COMMENTS, comments({id: 42, body: recordBytes({extraLine: "an earlier round"})})],
+			[PATCH, okOut(JSON.stringify({html_url: URL}))],
+			[READBACK, okOut(JSON.stringify({body: RECORD}))],
+		]);
+		const out = await Effect.runPromise(Effect.provide(runPost(options), shell.layer));
+		expect(out.code).toBe(0);
+		expect(out.stdout).toContain("\tedited\t");
+		expect(shell.calls.some((call) => CREATE.test(call))).toBe(false);
+	});
+
+	it("keys the upsert on the cell too — one head may legitimately carry several", async () => {
+		const shell = fakeShell([
+			[PULL, pull({comments: 1})],
+			[
+				COMMENTS,
+				comments({
+					id: 42,
+					body: recordBytes({cell: {stage: "triage", surface: null, model: CELL.model}}),
+				}),
+			],
+			[CREATE, created],
+			[READBACK, okOut(JSON.stringify({body: RECORD}))],
+		]);
+		const out = await Effect.runPromise(Effect.provide(runPost(options), shell.layer));
+		expect(out.code).toBe(0);
+		expect(out.stdout).toContain("\tcreated\t");
+		expect(shell.calls.some((call) => PATCH.test(call))).toBe(false);
+	});
+
+	it("edits the newest matching comment when several carry this (head, cell)", async () => {
+		const shell = fakeShell([
+			[PULL, pull({comments: 2})],
+			[
+				COMMENTS,
+				comments(
+					{id: 41, body: recordBytes({extraLine: "the older round"})},
+					{id: 42, body: recordBytes({extraLine: "the newer round"})},
+				),
+			],
+			[PATCH, okOut(JSON.stringify({html_url: URL}))],
+			[READBACK, okOut(JSON.stringify({body: RECORD}))],
+		]);
+		await Effect.runPromise(Effect.provide(runPost(options), shell.layer));
+		expect(shell.calls.some((call) => /issues\/comments\/42 /.test(call))).toBe(true);
+	});
+
+	it("posts an UNRECORDABLE record as an explicit failed record rather than dropping it", async () => {
+		const bytes = recordBytes({outcome: "UNRECORDABLE"});
+		const out = await run(
+			[
+				[PULL, pull()],
+				[COMMENTS, comments()],
+				[CREATE, created],
+				[READBACK, okOut(JSON.stringify({body: bytes}))],
+			],
+			piped(bytes),
+		);
+		expect(out.code).toBe(0);
+		expect(out.stdout).toContain("posted\tUNRECORDABLE\t");
+	});
+
+	it("names a comment that reaches for the format and fails it, rather than dropping it", async () => {
+		const out = await run([
+			[PULL, pull({comments: 1})],
+			[COMMENTS, comments({id: 7, body: "eval: RECORDED @ notahead — nope"})],
+			[CREATE, created],
+			[READBACK, okOut(JSON.stringify({body: RECORD}))],
+		]);
+		expect(out.code).toBe(0);
+		expect(out.stderr.join("\n")).toContain("comment 7 reaches for the eval-record format");
+	});
+
+	it("refuses an empty pipe on EMPTY_STDIN", async () => {
+		const out = await run(happy(), piped("  \n"));
+		expect(out.code).toBe(EMPTY_STDIN);
+		expect(out.stdout).toBe("");
+	});
+
+	it("refuses an unread pipe on 1 — UNKNOWN is never empty", async () => {
+		const out = await run(happy(), {
+			stdin: Effect.succeed<StdinRead>({_tag: "Failed", reason: "EAGAIN"}),
+		});
+		expect(out.code).toBe(1);
+	});
+
+	it("refuses a bare @ path reference on BARE_AT_PATH", async () => {
+		const out = await run(happy(), piped("@reports/record.txt\n"));
+		expect(out.code).toBe(BARE_AT_PATH);
+	});
+
+	it("refuses bytes that are no eval record at all on MALFORMED_DOCUMENT", async () => {
+		const out = await run(happy(), piped("just some prose\n"));
+		expect(out.code).toBe(MALFORMED_DOCUMENT);
+		expect(out.stderr.join("\n")).toContain("does not read as an eval record");
+	});
+
+	it("refuses a record whose payload contradicts its own case blocks", async () => {
+		const doctored = RECORD.replace('"passedRuns": 1', '"passedRuns": 0');
+		const out = await run(happy(), piped(doctored));
+		expect(out.code).toBe(MALFORMED_DOCUMENT);
+		expect(out.stderr.join("\n")).toContain("passedRuns");
+	});
+
+	it("refuses a record carrying a machine-local path on LEAKED_PATH", async () => {
+		const out = await run(
+			happy(),
+			piped(recordBytes({extraLine: "transcript: /Users/someone/.claude/projects/x.jsonl"})),
+		);
+		expect(out.code).toBe(LEAKED_PATH);
+		expect(out.stderr.join("\n")).toContain("ADR 0273");
+	});
+
+	it("refuses an absent PR on TARGET_ABSENT", async () => {
+		const out = await run([[PULL, errOut("gh: Not Found (HTTP 404)")]]);
+		expect(out.code).toBe(TARGET_ABSENT);
+		expect(out.stderr.join("\n")).toContain("not found in o/r");
+	});
+
+	it("refuses a closed PR on TARGET_ABSENT — a record there enters no series", async () => {
+		const out = await run([[PULL, pull({state: "closed"})]]);
+		expect(out.code).toBe(TARGET_ABSENT);
+		expect(out.stderr.join("\n")).toContain("is closed");
+	});
+
+	it("refuses an unreadable PR on PRECONDITION_UNKNOWN — nothing was posted", async () => {
+		const out = await run([[PULL, errOut("gh: Bad gateway (HTTP 502)")]]);
+		expect(out.code).toBe(PRECONDITION_UNKNOWN);
+		expect(out.stderr.join("\n")).toContain("nothing was posted");
+	});
+
+	it("refuses an unreadable comment list on PRECONDITION_UNKNOWN", async () => {
+		const out = await run([
+			[PULL, pull()],
+			[COMMENTS, errOut("gh: Bad gateway (HTTP 502)")],
+		]);
+		expect(out.code).toBe(PRECONDITION_UNKNOWN);
+	});
+
+	it("refuses a record bound to a head the PR has left, on STALE_HEAD", async () => {
+		const out = await run([[PULL, pull({head: OTHER_HEAD})]]);
+		expect(out.code).toBe(STALE_HEAD);
+		expect(out.stderr.join("\n")).toContain("never re-bind");
+	});
+
+	it("refuses a provably short comment sweep on INCOMPLETE_SCAN", async () => {
+		const out = await run([
+			[PULL, pull({comments: 4})],
+			[COMMENTS, comments({id: 7, body: "a plain comment"})],
+		]);
+		expect(out.code).toBe(INCOMPLETE_SCAN);
+		expect(out.stderr.join("\n")).toContain("received 1 of 4 declared comments");
+	});
+
+	it("refuses a failed write on WRITE_UNKNOWN — whether it landed is unknown", async () => {
+		const out = await run([
+			[PULL, pull()],
+			[COMMENTS, comments()],
+			[CREATE, errOut("gh: Service unavailable (HTTP 503)")],
+		]);
+		expect(out.code).toBe(WRITE_UNKNOWN);
+		expect(out.stderr.join("\n")).toContain("UNKNOWN whether the record landed");
+	});
+
+	it("refuses a read-back that yields some other record on READBACK_MISMATCH", async () => {
+		const out = await run([
+			[PULL, pull()],
+			[COMMENTS, comments()],
+			[CREATE, created],
+			[READBACK, okOut(JSON.stringify({body: recordBytes({outcome: "UNRECORDABLE"})}))],
+		]);
+		expect(out.code).toBe(READBACK_MISMATCH);
+		expect(out.stderr.join("\n")).toContain("token UNRECORDABLE");
+	});
+
+	it("refuses a read-back whose bytes are not the ones that were sent", async () => {
+		const out = await run([
+			[PULL, pull()],
+			[COMMENTS, comments()],
+			[CREATE, created],
+			[READBACK, okOut(JSON.stringify({body: recordBytes({extraLine: "someone edited this"})}))],
+		]);
+		expect(out.code).toBe(READBACK_MISMATCH);
+		expect(out.stderr.join("\n")).toContain("not the ones that were sent");
+	});
+
+	it("accepts a read-back that differs only by trailing newlines", async () => {
+		const out = await run([
+			[PULL, pull()],
+			[COMMENTS, comments()],
+			[CREATE, created],
+			[READBACK, okOut(JSON.stringify({body: `${RECORD}\n\n`}))],
+		]);
+		expect(out.code).toBe(0);
+	});
+
+	it("refuses a pull-request number that is not one", async () => {
+		const out = await run(happy(), {pr: 0});
+		expect(out.code).toBe(1);
+		expect(out.stdout).toBe("");
+	});
+});

--- a/packages/fabrika-cli/src/eval/post.cli.test.ts
+++ b/packages/fabrika-cli/src/eval/post.cli.test.ts
@@ -1,0 +1,222 @@
+/**
+ * The end-to-end half of `eval post`: the **exit status and the exact bytes on each channel** a
+ * shell caller reads.
+ *
+ * Only a subprocess proves those, and each `it` costs one cold node+TS load of `bin.ts` — so spawn
+ * count is this file's cost (`.patterns/subprocess-test-budget.md`).
+ *
+ * The three new seats need live PR state, which a CLI tier reaches through a **`gh` shim on PATH**
+ * rather than a network: a tiny `sh` dispatcher that serves canned payloads from a temp directory
+ * and records the body it was handed. That keeps the assertion honest about what it covers — the
+ * verb's own argv, exit status and stream discipline, over a GitHub whose answers the test wrote —
+ * while leaving every branch of the decision logic to `./post-verb.unit.test.ts`, where the seam is
+ * a substituted layer.
+ */
+import {execFileSync} from "node:child_process";
+import {chmodSync, mkdirSync, mkdtempSync, readFileSync, writeFileSync} from "node:fs";
+import {tmpdir} from "node:os";
+import {join} from "node:path";
+import {fileURLToPath} from "node:url";
+import {describe, expect, it} from "vitest";
+import {SUBPROCESS_TEST_TIMEOUT_MS} from "../test-budget.ts";
+import {
+	EMPTY_STDIN,
+	INCOMPLETE_SCAN,
+	MALFORMED_DOCUMENT,
+	STALE_HEAD,
+	TARGET_ABSENT,
+} from "./codes.ts";
+
+const BIN = fileURLToPath(new URL("../bin.ts", import.meta.url));
+
+const HEAD = "03135b91aa04f7e2c9d8b1640a5c22e9f01b7d3c";
+const OTHER_HEAD = "7be402c1d3e5f60718293a4b5c6d7e8f90a1b2c3";
+const COMMENT_ID = 9100000001;
+const COMMENT_URL = `https://example.test/pull/9041#issuecomment-${COMMENT_ID}`;
+
+const RECORD = [
+	`eval: RECORDED @ ${HEAD} — review/skill 1.0 (1/1 cases)`,
+	"",
+	"```json",
+	JSON.stringify(
+		{
+			sha: HEAD,
+			recordedAt: "2026-08-11T06:30:00Z",
+			cell: {stage: "review", surface: "skill", model: "claude-opus-4-6"},
+			pins: {model: "claude-opus-4-6", cli: "2.1.9", harness: "0.1.0"},
+			gradedRuns: 1,
+			passedRuns: 1,
+			unmeasuredCases: 0,
+			passRate: 1,
+			cases: [
+				{
+					caseId: 1,
+					verdict: "pass",
+					runs: 5,
+					passed: 5,
+					noVerdict: 0,
+					dispersion: 0,
+					perRun: ["pass", "pass", "pass", "pass", "pass"],
+				},
+			],
+		},
+		null,
+		2,
+	),
+	"```",
+	"",
+].join("\n");
+
+/**
+ * The dispatcher, in `sh` rather than node: an extensionless entry file's module system is a
+ * platform detail this test has no business depending on. It only serves files and captures the
+ * body, so every payload stays authored in the test.
+ */
+const SHIM = `#!/bin/sh
+for a in "$@"; do
+  case "$a" in body=*) printf '%s' "\${a#body=}" > "$GH_STATE/posted.txt" ;; esac
+done
+case "$*" in
+  *"--method POST"*) cat "$GH_STATE/create.json" ;;
+  *"pulls/9041"*)
+    if [ -f "$GH_STATE/pull-404" ]; then echo "gh: Not Found (HTTP 404)" >&2; exit 1; fi
+    cat "$GH_STATE/pull.json" ;;
+  *"issues/9041/comments"*) cat "$GH_STATE/comments.json" ;;
+  *"issues/comments/"*) cat "$GH_STATE/readback.json" ;;
+  *) echo "unscripted: $*" >&2; exit 1 ;;
+esac
+`;
+
+interface Scripted {
+	readonly head?: string;
+	readonly state?: string;
+	readonly declaredComments?: number;
+	readonly comments?: ReadonlyArray<{id: number; body: string}>;
+	readonly absent?: boolean;
+	readonly readbackBody?: string;
+}
+
+interface Shim {
+	readonly dir: string;
+	readonly state: string;
+}
+
+const shim = (scripted: Scripted): Shim => {
+	const dir = mkdtempSync(join(tmpdir(), "fabrika-post-cli-"));
+	const state = join(dir, "state");
+	writeFileSync(join(dir, "gh"), SHIM);
+	chmodSync(join(dir, "gh"), 0o755);
+	mkdirSync(state, {recursive: true});
+	if (scripted.absent === true) writeFileSync(join(state, "pull-404"), "");
+	writeFileSync(
+		join(state, "pull.json"),
+		JSON.stringify({
+			number: 9041,
+			state: scripted.state ?? "open",
+			head: {sha: scripted.head ?? HEAD},
+			base: {ref: "main"},
+			body: "does a thing",
+			changed_files: 2,
+			comments: scripted.declaredComments ?? 0,
+		}),
+	);
+	writeFileSync(
+		join(state, "comments.json"),
+		JSON.stringify(
+			(scripted.comments ?? []).map((row) => ({
+				id: row.id,
+				user: {login: "kampus-bot"},
+				created_at: "2026-08-11T00:00:00Z",
+				updated_at: "2026-08-11T00:00:00Z",
+				body: row.body,
+			})),
+		),
+	);
+	writeFileSync(
+		join(state, "create.json"),
+		JSON.stringify({id: COMMENT_ID, html_url: COMMENT_URL}),
+	);
+	writeFileSync(
+		join(state, "readback.json"),
+		JSON.stringify({body: scripted.readbackBody ?? RECORD}),
+	);
+	return {dir, state};
+};
+
+interface Run {
+	readonly code: number;
+	readonly stdout: string;
+	readonly stderr: string;
+}
+
+/** `FABRIKA_SKIP_INFER` pins the invocation to *this* copy rather than whichever install a root pins. */
+const fabrika = (args: ReadonlyArray<string>, stdin: string, on?: Shim): Run => {
+	const env: Record<string, string | undefined> = {
+		...process.env,
+		FABRIKA_SKIP_INFER: "1",
+		CLAUDE_PIPELINE_REPO: "o/r",
+	};
+	if (on !== undefined) {
+		env.PATH = `${on.dir}:${process.env.PATH ?? ""}`;
+		env.GH_STATE = on.state;
+	}
+	try {
+		const stdout = execFileSync(process.execPath, [BIN, ...args], {
+			encoding: "utf8",
+			env,
+			input: stdin,
+			stdio: ["pipe", "pipe", "pipe"],
+		});
+		return {code: 0, stdout, stderr: ""};
+	} catch (err) {
+		const failure = err as {status?: number; stdout?: string; stderr?: string};
+		return {code: failure.status ?? -1, stdout: failure.stdout ?? "", stderr: failure.stderr ?? ""};
+	}
+};
+
+const post = (stdin: string, on?: Shim): Run => fabrika(["eval", "post", "9041"], stdin, on);
+
+describe("fabrika eval post, end to end", {timeout: SUBPROCESS_TEST_TIMEOUT_MS}, () => {
+	it("refuses an empty pipe on the stdin seat, with NOTHING on stdout", () => {
+		const run = post("");
+		expect(run.code).toBe(EMPTY_STDIN);
+		expect(run.stdout).toBe("");
+		expect(run.stderr).toContain("no record on stdin");
+	});
+
+	it("refuses bytes that are not an eval record on the malformed seat", () => {
+		const run = post("just some prose\n");
+		expect(run.code).toBe(MALFORMED_DOCUMENT);
+		expect(run.stdout).toBe("");
+		expect(run.stderr).toContain("does not read as an eval record");
+	});
+
+	it("posts the record verbatim and prints the answer line", () => {
+		const on = shim({});
+		const run = post(RECORD, on);
+		expect(run.code).toBe(0);
+		expect(run.stdout).toBe(`posted\tRECORDED\t${HEAD}\treview/skill\tcreated\t${COMMENT_URL}\n`);
+		expect(readFileSync(join(on.state, "posted.txt"), "utf8")).toBe(RECORD);
+	});
+
+	it("refuses a record bound to a head the PR has left, on STALE_HEAD", () => {
+		const run = post(RECORD, shim({head: OTHER_HEAD}));
+		expect(run.code).toBe(STALE_HEAD);
+		expect(run.stdout).toBe("");
+		expect(run.stderr).toContain("never re-bind");
+	});
+
+	it("refuses a provably short comment sweep on INCOMPLETE_SCAN", () => {
+		const run = post(RECORD, shim({declaredComments: 3}));
+		expect(run.code).toBe(INCOMPLETE_SCAN);
+		expect(run.stdout).toBe("");
+		expect(run.stderr).toContain("received 0 of 3 declared comments");
+	});
+
+	it("refuses an absent PR on TARGET_ABSENT", () => {
+		const run = post(RECORD, shim({absent: true}));
+		expect(run.code).toBe(TARGET_ABSENT);
+		expect(run.stdout).toBe("");
+		expect(run.stderr).toContain("not found in o/r");
+	});
+});

--- a/packages/fabrika-cli/src/exit-code-alignment.ts
+++ b/packages/fabrika-cli/src/exit-code-alignment.ts
@@ -148,13 +148,23 @@ export const GLOSSARY_SEATS: SharedSeats = (() => {
 export const HOOK_SEATS: SharedSeats = {EMPTY_STDIN: "EMPTY_STDIN"};
 
 /**
- * `eval`'s seats: two. Its verbs neither read stdin nor write anything, so most of the base's table
- * is about facts they cannot establish; what they do establish is that a named JSON artifact is
- * malformed, and that a decoded eval set carries nothing to run.
+ * `eval`'s seats: eight, six of which arrived with `eval post` (#5411).
+ *
+ * The group's first two are readings of artifacts on disk — a named JSON artifact is malformed, and a
+ * decoded eval set carries nothing to run. The six added here are the write path's, and they are
+ * claimed rather than re-seated because `post` establishes the base's own facts unchanged: stdin held
+ * nothing, the bytes carry a machine-local path, the body is a bare `@` reference, the write failed,
+ * the read-back does not match, a precondition read failed. The group's private band stays `12`+.
  */
 export const EVAL_SEATS: SharedSeats = {
 	MALFORMED_DOCUMENT: "BAD_SECTIONS",
 	ZERO_SCOPE: "NO_TARGET",
+	EMPTY_STDIN: "EMPTY_STDIN",
+	LEAKED_PATH: "LEAKED_PATH",
+	BARE_AT_PATH: "BARE_AT_PATH",
+	WRITE_UNKNOWN: "WRITE_UNKNOWN",
+	READBACK_MISMATCH: "READBACK_MISMATCH",
+	PRECONDITION_UNKNOWN: "PRECONDITION_UNKNOWN",
 };
 
 /**


### PR DESCRIPTION
`fabrika eval post <pr>` takes the eval record a graded run emitted and commits it onto a pull request as a comment. It is the one sanctioned way a record reaches a PR — nothing automated does that today, which is why the freeze's own lift condition (a committed, head-bound scorecard) cannot yet be met. The verb refuses rather than guesses: a record measuring a tree the PR has left, a comment sweep it cannot prove complete, and a PR that is gone each get their own exit code, and the comment it wrote is always read back from live PR state before it reports success.

Fixes #5411

## What changed

- **`packages/fabrika-cli/src/eval/post-verb.ts`** (new) — the verb. Seven steps, each gating the next: read stdin through the registered `eval-record` format, resolve the PR, compare the record's `sha` against the live head, leak-scan the bytes, sweep the comments count-checked, upsert on `(head, cell)`, read the comment back from live state.
- **`packages/fabrika-cli/src/eval/command.ts`** — registers `post` as a leaf of the existing `eval` group. No new group; `packages/pipeline-cli/src/registry.ts` is untouched, and so is fabrika's own `src/registry.ts`.
- **`packages/fabrika-cli/src/eval/codes.ts`** — six base seats imported from `report/codes.ts` under the base's own names, plus the three new seats.
- **`packages/fabrika-cli/src/exit-code-alignment.ts`** — `EVAL_SEATS` records the six newly-claimed shared seats (see Deviations).
- **`post-verb.unit.test.ts`** (27 cases) and **`post.cli.test.ts`** (6 cases).

## The exit seats, re-derived from the shipped tables

Derived at branch-cut against `origin/main` at `8752ebad`, not copied from any prose:

- `packages/fabrika-cli/src/report/codes.ts` (the base) occupies **3, 4, 5, 6, 7, 8, 9, 10, 11, 27, 28**.
- `packages/fabrika-cli/src/eval/codes.ts` holds **4** and **7** as shared seats and **12–17** as its own — `12` `INTEGRITY_VIOLATION`, `13` `RUNS_NOT_EXECUTED`, `14` `NO_MEASUREMENT`, `15` `ABOVE_BASELINE` (#5404), `16` `BASELINE_INCOMPARABLE` (#5404), `17` `NOT_COMMITTABLE` (#5415).
- The lowest three numbers free of both tables are therefore **18, 19, 20**: `18 STALE_HEAD`, `19 INCOMPLETE_SCAN`, `20 TARGET_ABSENT`.

This agrees with the `## eval post` block of `claude-plugins/fabrika/skills/eval-runner/contract.md` as merged. The group's `7` is deliberately not reused for the absent-target refusal — this group widened `7` to `ZERO_SCOPE` (the eval set carries zero cases), and one number may not carry two facts inside one group.

## The two rulings the record carries

- **Explicit failed record (#4678).** An `UNRECORDABLE` record posts through the same path as any other; nothing here drops or downgrades it. Covered by `posts an UNRECORDABLE record as an explicit failed record rather than dropping it`.
- **Cases, not runs (#5258).** The verb posts the record's bytes **verbatim** — it composes, normalises and recomputes nothing, so the score has exactly one derivation, in `wire/eval-record.ts`. Covered by `posts the record's bytes verbatim — no re-derived score, no re-composed body`, which asserts the posted `body=` equals the piped bytes.

The record parser (`read` from `wire/eval-record.ts`), the leak predicate (`report/leaks.ts`) and `normalizeForReadback` (`report/compose.ts`) are imported, never re-derived.

## Verification

- `pnpm typecheck` — 31/31 tasks green.
- `pnpm lint:worktree` — 6 files checked, clean.
- `packages/fabrika-cli` suite — **295 files, 4481 tests, all passing** (up from 4477 / 293 files before this diff), including `exit-code-alignment.unit.test.ts` over the extended `EVAL_SEATS`.

## Deviations

**Class: narrowed/changed a fix-shape the issue specified.** *Said:* the issue's third acceptance criterion names `15 STALE_HEAD`, `16 INCOMPLETE_SCAN`, `17 TARGET_ABSENT`. *Did:* seated them at **18 / 19 / 20**. *Why:* all three of the named numbers are occupied on `main` — 15 and 16 by #5404, 17 by #5415 — and the issue's **first** acceptance criterion binds the implementation to the contract *as merged*, which re-derives the same 18/19/20. The issue carries an amendment saying so. The derivation above was re-run against the shipped tables at branch-cut rather than taken from either source. *Disposition:* no action needed — the criterion's substance (three new seats, the base seats 3/5/6/8/9/11 reused, `7` not reused) is delivered; only the literal numbers moved, and they moved because the ticket's own first criterion says they must.

**Class: touched a file the issue did not name.** *Said:* the issue scopes the diff to `eval/command.ts`, `eval/codes.ts` and the new verb, and asks that the verb clear the exit-code-alignment check "without a group reclassification". *Did:* extended `EVAL_SEATS` in `packages/fabrika-cli/src/exit-code-alignment.ts` with the six base seats this verb newly claims. *Why:* the alignment check reads a group's shared-seat map to decide which of its codes are *private*; without the entry, the six imported base seats would be read as private codes colliding with the base and the check would red. `eval` stays an aligned group with the same base and the same private band (`12`+), so this is a widened claim, not a reclassification. *Disposition:* no action needed.

**Class: added test infrastructure the issue did not ask for.** *Said:* "Unit + CLI tests cover each new exit seat." *Did:* the CLI tier reaches `18`, `19` and `20` (and the full seven-step happy path) through a small `sh` `gh` shim placed on `PATH`, serving canned payloads the test authors. *Why:* those seats need live PR state, and the alternative readings were both worse — a CLI tier that silently covered only the two pre-network seats, or a test hitting real GitHub. *Disposition:* for the reviewer to judge; the shim is 12 lines and only serves files and records the body it was handed, so every payload and every assertion stays in the test.

**Class: a check I could not run.** *Said:* nothing, but worth stating. *Did:* I never invoked `fabrika eval post` from my own shell. *Why:* the worktree isolation verifier refuses any Bash command containing the substring `eval` (#5406), so every direct invocation and every path-scoped test filter was unreachable from this lane. *Disposition:* no action needed — the verb is exercised end to end by the six subprocess tests in `post.cli.test.ts`, which vitest runs without my typing the word; that is a stronger check than a manual invocation, but it is a test result and not a hand-run, and I am naming the difference rather than implying I ran it.