### PR TITLE
chore(fabrika): the write-pattern graded scorecard — M44 freeze-lift condition

### DIFF
--- a/claude-plugins/fabrika/reports/eval/2026-08-11.json
+++ b/claude-plugins/fabrika/reports/eval/2026-08-11.json
@@ -1,0 +1,54 @@
+{
+	"recordedAt": "2026-08-11T18:26:39.118Z",
+	"decisionRef": 1576,
+	"framing": "This scorecard is measurement feeding the model-tiering decision (#1576); it presents pass-rate + net-token cost and does not recommend or select a model.",
+	"baseline": null,
+	"cells": [
+		{
+			"stage": "build",
+			"surface": null,
+			"model": "claude-opus-4-8",
+			"pins": {
+				"model": "claude-opus-4-8",
+				"cli": "2.1.227 (Claude Code)",
+				"harness": "0.1.0"
+			},
+			"source": {
+				"sha": "e8a6fc408679458af68753da8461161fd9c1deb5",
+				"recordedAt": "2026-08-11T18:26:08.551Z"
+			},
+			"outcome": "RECORDED",
+			"gradedRuns": 5,
+			"passedRuns": 4,
+			"unmeasuredCases": 0,
+			"passRate": 0.8,
+			"cases": [
+				{
+					"caseId": 1,
+					"verdict": "fail",
+					"dispersion": 0
+				},
+				{
+					"caseId": 2,
+					"verdict": "pass",
+					"dispersion": 0
+				},
+				{
+					"caseId": 3,
+					"verdict": "pass",
+					"dispersion": 0
+				},
+				{
+					"caseId": 4,
+					"verdict": "pass",
+					"dispersion": 0
+				},
+				{
+					"caseId": 5,
+					"verdict": "pass",
+					"dispersion": 0
+				}
+			]
+		}
+	]
+}


### PR DESCRIPTION
Runs the `/eval-runner` skill on fabrika's `write-pattern` skill — full graded axis, 5 runs per case, median — and lands the committed scorecard that is M44's freeze-lift condition (#4680 / #4678 comment 5247179323).

- The head-bound eval record is posted as a PR comment on this PR by `fabrika eval post`, bound to the anchor commit.
- The committed scorecard lands under `claude-plugins/fabrika/reports/eval/` via `fabrika eval scorecard`.
- Cell: `build` — the stage whose skill is under eval. This is **not** `/review`'s `review/skill` cell; the two sites key different cells by design.
- Model pin: `claude-opus-4-8`, matching the committed series' existing harness pin.

Portable surfaces only — no machine-local paths.

🤖 Generated with [Claude Code](https://claude.com/claude-code)