### PR TITLE
feat(fabrika): the ruled bar as a fail-closed merge gate (#4681)

### DIFF
--- a/.github/workflows/fabrika-eval-gate.yml
+++ b/.github/workflows/fabrika-eval-gate.yml
@@ -31,7 +31,11 @@ concurrency:
 
 jobs:
   gate:
-    name: the ruled bar - 100% floor, 90% graded verified at head, spend <= v1 baseline
+    # The name states what the job ENFORCES TODAY, not what the ruled bar says. The floor runs no
+    # incident case until #5431 arms one and CI runs no suite to price spend against, so a name
+    # promising those two would be a green check advertising an enforcement nobody performed — the
+    # #4604 shape. Rename it when a leg is actually armed, never before.
+    name: "fabrika eval gate: graded 90% enforced at head; floor + spend report, not yet enforced"
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4.2.2

--- a/.github/workflows/fabrika-eval-gate.yml
+++ b/.github/workflows/fabrika-eval-gate.yml
@@ -1,0 +1,56 @@
+name: fabrika-eval-gate
+
+# The ruled #4637-B bar as a merge gate (#4681): the 100% incident-regression floor, the 90% graded
+# rate, and spend at or below the committed v1 baseline. The whole decision lives in
+# `fabrika eval gate` and this job only relays its exit code — a script relays a verb's answer and
+# never derives the decision (ADR 0228). Nothing here decides which paths count as a skill change,
+# which eval record is in force, or whether a rate clears the bar; the verb reads the PR's head,
+# changed paths and eval records itself.
+#
+# It runs on EVERY pull request with no `paths:` filter, which is what puts the deterministic tier —
+# and with it the foreign-root-install portability case — in the always-run set, behind no
+# conditional trigger. The graded suite still applies to skill changes only, but that is the verb's
+# own path filter over the PR's changed files, tested against the directory it must cover, rather
+# than a YAML condition nobody can red (the #4604 shape, where a path filter matching nothing
+# presented as a pass).
+#
+# No model runs here and no model credential is needed: the graded leg VERIFIES the head-bound eval
+# record the review stage recorded (the founder's cost ruling on #4649) and never runs the suite.
+on:
+  pull_request:
+
+# Least-privilege GITHUB_TOKEN: the job checks out the repo and reads the PR's metadata, changed
+# files and comments; it posts no check-run, status or comment and fails via exit code alone.
+permissions:
+  contents: read
+  pull-requests: read
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ github.ref != 'refs/heads/main' }}
+
+jobs:
+  gate:
+    name: the ruled bar - 100% floor, 90% graded verified at head, spend <= v1 baseline
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4.2.2
+
+      - uses: pnpm/action-setup@v4.1.0
+
+      - uses: actions/setup-node@v4.4.0
+        with:
+          node-version-file: package.json
+          cache: pnpm
+
+      - run: pnpm install --frozen-lockfile
+
+      # Exits 0 when every leg of the bar is met. Each red names its reason and seats its own code:
+      # 7 zero scope, 15 spend above the v1 baseline (or incomparable), 18 stale (the newest record
+      # is bound to an older commit), 21 missing (no record for this head), 22 below the 90% bar,
+      # 23 an armed incident case did not pass. See #4681.
+      - name: Decide the ruled bar
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          CLAUDE_PIPELINE_REPO: ${{ github.repository }}
+        run: node packages/fabrika-cli/src/bin.ts eval gate ${{ github.event.pull_request.number }}

--- a/packages/fabrika-cli/src/eval/README.md
+++ b/packages/fabrika-cli/src/eval/README.md
@@ -1186,7 +1186,7 @@ cases once through the tier, and the spend leg folds ledger rows a meter already
 |---|---|---|
 | `7` | `zero-scope` | no changed path, no deterministic case, a corpus case the sidecar accounts for neither way, or a record that measured nothing |
 | `15` | `over-baseline` | spend above the committed v1 baseline — or `incomparable`, which is never a pass |
-| `18` | `stale` | the newest recorded result is bound to an older commit; re-run the suite, never re-bind |
+| `18` | `stale` | the newest recorded result is bound to an older commit; the measurement is re-run at the new head, never re-bound |
 | `21` | `missing` | no eval record for the head under gate |
 | `22` | `below-bar` | a recorded graded rate under the ruled `0.9` |
 | `23` | `regression-floor` | an armed incident case did not pass — 100%, no tolerance, no quarantine |
@@ -1196,6 +1196,35 @@ re-invented: `7`, `15` and `18` already mean exactly these facts elsewhere in th
 
 **The trend is reported and gates nothing** (ADR 0252 §4, the #4766 guardrail): it rides as an
 advisory line and never changes an exit status. Arming it is a later ADR's edit to `judgeGraded`.
+
+### `missing` and `stale` name their cure and its run site
+
+Both are **recoverable states with a named next action**, and neither is a blocker the build lane
+that tripped it can clear. The harness's worktree-isolation guard refuses the eval runner inside a
+lane outright ([#5406](https://github.com/kamp-us/phoenix/issues/5406) — not this repo's code and not
+fixable here), so **a graded run executes in a plain, non-worktree session**. A lane that hits either
+red **hands the measurement off**; a red that said only "re-run the suite" would be naming a cure the
+lane structurally cannot perform, which is why both details carry the site.
+
+### A leg that measured nothing is never reported as a leg that passed
+
+`LegVerdict` has **three** states — `measured`, `unmeasured`, `red` — and the summary line names
+every unmeasured leg instead of absorbing it:
+
+```
+floor: NOT MEASURED — no incident case is armed to run yet, ...
+graded: NOT MEASURED — n/a — this change touches no fabrika skill, ...
+spend: NOT MEASURED — not-priced — no candidate spend ledger ...
+gate: NOT FULLY MEASURED — nothing red, and 3 of 4 leg(s) measured NOTHING, so this is not a
+statement that the bar is met. NOT MEASURED: ... Measured and met: scope.
+```
+
+`gate: GREEN — all N leg(s) of the ruled bar were measured and met` is reachable **only** when every
+leg measured. The check-run `name:` in the workflow follows the same rule: it states what the job
+enforces **today** (the graded 90% at head), not what the ruled bar says, because a green check
+advertising an enforcement nobody performed is the #4604 shape arriving from the reporting side.
+Today the floor runs no case and CI prices no spend, so **the graded leg is the only enforced one**;
+rename the job when a leg is armed, never before.
 
 ### The trigger split lives in the verb, not in the workflow
 
@@ -1224,17 +1253,26 @@ Three rules follow, and the middle one is the load-bearing distinction:
 - **Every deterministic case must appear under one status or the other**, or the gate reds
   `zero-scope`. A case added to the corpus with no arming decision would otherwise leave the floor
   silently. A data test asserts the same completeness at commit time.
-- **An all-pending floor reports rather than reds.** That is *not* the quarantine the ruled floor
-  forbids: nothing failing is being excluded, because none of these cases has ever been runnable.
-  Zero scope is a corpus the gate could not see; this is a corpus it can see, whose every case
-  carries a written statement of what it needs. The line prints on every run, which is what keeps it
-  from being forgotten.
+- **An all-pending floor reports rather than reds — as `NOT MEASURED`, never as a pass.** That is
+  *not* the quarantine the ruled floor forbids: nothing failing is being excluded, because none of
+  these cases has ever been runnable. Zero scope is a corpus the gate could not see; this is a corpus
+  it can see, whose every case carries a written statement of what it needs. But no incident
+  regression can red a floor that runs nothing, so the leg is `unmeasured` and the summary says so on
+  every run — that is what keeps it from being forgotten.
 - **An armed case that does not pass reds**, including `uncheckable` and `flake` — the tier's own
   aggregator already refuses to tolerate either.
 
 Today **every** case is `pending`: the corpus's assertions were authored as prose a grader reads, so
 `readExpectation` cannot read most of them, and no CLI-layer command exists for any case. Arming them
 is [#5431](https://github.com/kamp-us/phoenix/issues/5431), which carries the per-case evidence.
+
+Each row's `pendingReason` names the **concrete owed work**, not just the ticket, because a deferral
+whose cure would not cure is a silence with extra words. For an unreadable assertion that work is
+**re-wording the expectation in [`incident-corpus/evals.json`](incident-corpus/evals.json)** so it
+quotes an observable, plus an `armed` row here carrying the command. It is **never** a `corrections`
+entry in `provenance.json`: that array is an append-only re-diagnosis ledger (see the corpus README)
+and `readExpectation` reads only the assertion text, so a correction there would leave the case
+exactly as unrunnable as it found it.
 
 ### Spend
 

--- a/packages/fabrika-cli/src/eval/README.md
+++ b/packages/fabrika-cli/src/eval/README.md
@@ -1153,6 +1153,96 @@ The run site, the full reproduction procedure and which pin comes from where liv
 [`claude-plugins/fabrika/docs/cost-baseline.md`](../../../../claude-plugins/fabrika/docs/cost-baseline.md);
 this section is the module's shape, not a second copy of the method.
 
+## The merge gate ([#4681](https://github.com/kamp-us/phoenix/issues/4681))
+
+The ruled [#4637](https://github.com/kamp-us/phoenix/issues/4637)-B bar, decided by **one verb** so
+that the CI job relaying it holds no part of the decision (ADR
+[0228](../../../../.decisions/0228-scripts-relay-never-derive.md)). `gate.ts` is the pure judgement,
+`gate-verb.ts` the IO shell, and
+[`.github/workflows/fabrika-eval-gate.yml`](../../../../.github/workflows/fabrika-eval-gate.yml) the
+one-line relay.
+
+```bash
+fabrika eval gate 5432                       # over a pull request: head, changed paths, records all read from it
+fabrika eval gate --head <sha> --changed changed.txt --record result.md   # offline: no network, no credential
+```
+
+### CI does not run the evals; CI verifies that the review did
+
+No model executes here and no model credential is needed. The founder ruled on
+[#4649](https://github.com/kamp-us/phoenix/issues/4649#issuecomment-5153280445) that model runs stay
+out of CI — **the recorded reason is cost, not principle** — so the graded leg reads back the
+head-bound eval record the review stage left (#4678, ADR 0253) and compares a string and a number.
+That is why `missing` and `stale` are red conditions in their own right: they are the two ways the
+review step can be skipped by forgetting, and absence that passes is the guarantee this epic exists
+to restore.
+
+The legs that never needed a model still execute: the deterministic regression floor runs its armed
+cases once through the tier, and the spend leg folds ledger rows a meter already reconstructed.
+
+### The six reds, each on its own seat
+
+| exit | reason | what it means |
+|---|---|---|
+| `7` | `zero-scope` | no changed path, no deterministic case, a corpus case the sidecar accounts for neither way, or a record that measured nothing |
+| `15` | `over-baseline` | spend above the committed v1 baseline — or `incomparable`, which is never a pass |
+| `18` | `stale` | the newest recorded result is bound to an older commit; re-run the suite, never re-bind |
+| `21` | `missing` | no eval record for the head under gate |
+| `22` | `below-bar` | a recorded graded rate under the ruled `0.9` |
+| `23` | `regression-floor` | an armed incident case did not pass — 100%, no tolerance, no quarantine |
+
+Every red is printed; the highest-precedence one seats `$?`. Four seats are reused rather than
+re-invented: `7`, `15` and `18` already mean exactly these facts elsewhere in this group.
+
+**The trend is reported and gates nothing** (ADR 0252 §4, the #4766 guardrail): it rides as an
+advisory line and never changes an exit status. Arming it is a later ADR's edit to `judgeGraded`.
+
+### The trigger split lives in the verb, not in the workflow
+
+The job runs on **every** pull request with no `paths:` filter, so the deterministic tier — and with
+it the foreign-root-install portability case — sits in the always-run set behind no conditional
+trigger. Whether the **graded** leg applies is `changedSkills`, the verb's own filter over the PR's
+changed files, anchored on `claude-plugins/fabrika/skills/`.
+
+That filter is the one #4604 got wrong on the v1 side: a `packages/`-anchored list that never reached
+a skills directory, so a skill change matched nothing and the gate reported green. `changedSkills`
+takes its prefixes as a parameter for exactly that reason — `gate.unit.test.ts` runs the same
+decision twice over one changed-path set and asserts that the mis-scoped run turns a `missing` red
+into a pass. The property held is not that the filter matches, but that a wrong one is visible as the
+difference between a red and a green.
+
+### The arming sidecar, and why the floor is honest about what it cannot run
+
+`runDeterministicTier` takes its `resolveCommand` from the caller and the authored eval format has no
+command field by design (#4674), so a case's CLI-layer command is committed **beside** the corpus in
+[`incident-corpus/commands.json`](incident-corpus/commands.json), decoded by `floor-commands.ts`. A
+row is a discriminated union on `status`, on `ruled-keeps.ts`'s precedent: an `armed` row carries the
+command, a `pending` row carries **required** prose quoting what is owed.
+
+Three rules follow, and the middle one is the load-bearing distinction:
+
+- **Every deterministic case must appear under one status or the other**, or the gate reds
+  `zero-scope`. A case added to the corpus with no arming decision would otherwise leave the floor
+  silently. A data test asserts the same completeness at commit time.
+- **An all-pending floor reports rather than reds.** That is *not* the quarantine the ruled floor
+  forbids: nothing failing is being excluded, because none of these cases has ever been runnable.
+  Zero scope is a corpus the gate could not see; this is a corpus it can see, whose every case
+  carries a written statement of what it needs. The line prints on every run, which is what keeps it
+  from being forgotten.
+- **An armed case that does not pass reds**, including `uncheckable` and `flake` — the tier's own
+  aggregator already refuses to tolerate either.
+
+Today **every** case is `pending`: the corpus's assertions were authored as prose a grader reads, so
+`readExpectation` cannot read most of them, and no CLI-layer command exists for any case. Arming them
+is [#5431](https://github.com/kamp-us/phoenix/issues/5431), which carries the per-case evidence.
+
+### Spend
+
+A missing candidate ledger is **not** a red — the ledger is a suite run's artifact and CI runs no
+suite, so its absence means no spend was measured on this change, reported by name rather than folded
+into a pass. A ledger with no committed baseline to price it against is the other way round and reds:
+a measurement with no ceiling cannot be judged.
+
 ## Out of scope
 
 **Making the tiering call** is [#1576](https://github.com/kamp-us/phoenix/issues/1576), a
@@ -1165,4 +1255,4 @@ it renders no scorecard series (#4680).
 **Committing a scorecard, and the merge bar.** The graded axis emits a per-run PR comment and
 nothing else: aggregating those records into the committed scorecard series is
 [#4680](https://github.com/kamp-us/phoenix/issues/4680), and reading a rate against the ruled 90% bar
-is [#4681](https://github.com/kamp-us/phoenix/issues/4681). Neither number is judged here.
+is the merge gate documented above. Neither number is judged by `run` or by `graded`.

--- a/packages/fabrika-cli/src/eval/codes.ts
+++ b/packages/fabrika-cli/src/eval/codes.ts
@@ -141,3 +141,31 @@ export const INCOMPLETE_SCAN = 19;
  * and one number may not carry two facts inside one group.
  */
 export const TARGET_ABSENT = 20;
+
+/**
+ * Proven: the merge gate found no eval record at all for the head under gate (#4681).
+ *
+ * The other half of {@link STALE_HEAD}, and separate from it because the two name different skips.
+ * A stale record says the review ran and the tree moved; this says the review step never left
+ * anything, which is the path a forgotten step takes. Neither may read as "nothing to check" — the
+ * gate's whole guarantee is that absence reds (founder ruling on #4649).
+ */
+export const MISSING_RESULT = 21;
+
+/**
+ * Proven: a recorded graded pass rate at the head under gate is under the ruled 90% (#4637 ruling 2).
+ *
+ * Its own seat rather than {@link NO_MEASUREMENT}'s: that one says the run produced no number, this
+ * one says it produced a number below the bar, and the remedies are opposite. The trend co-gate
+ * never reaches this seat — it ships observe-only (ADR 0252 §4).
+ */
+export const BELOW_BAR = 22;
+
+/**
+ * Proven: an armed incident-derived case did not pass, so the 100% regression floor is broken.
+ *
+ * Executed in CI with no model in the loop, and seated apart from {@link BELOW_BAR} because the
+ * floor admits no tolerance and no quarantine while the graded bar is a rate — collapsing them
+ * would let a caller treat one regressing incident case as a percentage-point dip.
+ */
+export const REGRESSION_FLOOR = 23;

--- a/packages/fabrika-cli/src/eval/command.ts
+++ b/packages/fabrika-cli/src/eval/command.ts
@@ -1,8 +1,8 @@
 /**
- * The `eval` verb group — `fabrika eval check|report|cases|run|graded|keeps|baseline`.
+ * The `eval` verb group — `fabrika eval check|report|cases|run|graded|keeps|baseline|…|gate`.
  *
  * The graded-corpus apparatus for adjudicating a stochastic model swap per stage (epic
- * #1842), plus the ingestion of `/skill-creator`-authored eval sets (epic #4649). Seven live
+ * #1842), plus the ingestion of `/skill-creator`-authored eval sets (epic #4649). The live
  * surfaces:
  *
  *   fabrika eval check <manifest>   # decode a corpus manifest; exit non-zero on a bad one
@@ -13,6 +13,7 @@
  *   fabrika eval keeps <path>       # print the ruled KEEP corpus and what already pins each row
  *   fabrika eval baseline …         # record the v1 cost baseline, and answer the phase-1 ceiling
  *   fabrika eval post <pr>          # commit one head-bound record onto a PR, upserted per (head, cell)
+ *   fabrika eval gate <pr>          # decide the ruled merge bar and name the reason for each red
  *
  * `check` (issue #1848) validates the on-disk corpus format. `report` (issue #1853) is the
  * top of the vertical slice: it reads the runner's graded `{entry, grade, spend}` rows and
@@ -25,6 +26,9 @@
  * record. `keeps` (issue #4823) prints the ruled KEEP corpus — the enumeration that replaced the
  * two-artifact join every consumer used to re-run by hand. `baseline` (issue #4679) records the
  * committed v1 cost baseline from measured spend rows and answers the phase-1 ceiling against it.
+ * `gate` (issue #4681) is the top of the layer: it decides every leg of the ruled #4637-B bar over a
+ * pull request — verifying the head-bound graded record rather than running it — so a CI job only
+ * relays an exit code.
  *
  * Thin IO shell over the pure cores (the `token-spend` / `readme-guard` idiom): read the file,
  * decode, render. Every refusal seats on `./codes.ts` — an unreadable path exits `FAILED`, an
@@ -60,9 +64,6 @@ import {
 } from "./codes.ts";
 import {
 	buildCommittedScorecard,
-	type CommittedScorecard,
-	decodeCommittedScorecard,
-	isSeriesFileName,
 	renderCommittedScorecard,
 	SERIES_DIR,
 	seriesFileName,
@@ -78,6 +79,8 @@ import {
 	renderBaselineComparison,
 	renderCostBaseline,
 } from "./cost-baseline.ts";
+import {DEFAULT_FLOOR_CASES, DEFAULT_FLOOR_COMMANDS} from "./floor-commands.ts";
+import {runGate} from "./gate-verb.ts";
 import {
 	buildEvalRecord,
 	candidateOutputOf,
@@ -104,6 +107,7 @@ import {
 	ruledKeepsViolations,
 	withCoverage,
 } from "./ruled-keeps.ts";
+import {readSeriesFiles} from "./series-io.ts";
 import {decodeSkillEvalSet, tierCounts} from "./skill-eval-set.ts";
 import {
 	buildClaudeArgs,
@@ -1009,11 +1013,6 @@ const harnessRevisionFlag = Flag.string("harness-revision").pipe(
 	),
 );
 
-/** One committed file of the series, paired with the name the trend orders ties by. */
-interface SeriesFile {
-	readonly fileName: string;
-	readonly scorecard: CommittedScorecard;
-}
 // A named path that could not be read — a hard error (exit 1), not a skip.
 class PathUnreadable extends Schema.TaggedErrorClass<PathUnreadable>()("PathUnreadable", {
 	path: Schema.String,
@@ -1341,47 +1340,29 @@ const scorecard = leafCommand(
 /**
  * Read every committed scorecard in the series directory, or exit.
  *
- * Members are selected by `isSeriesFileName`, never by `*.json`: the directory is shared with the
- * eval layer's other dated artifacts — the cost baselines of #4679 sit right beside the series — and
- * globbing every JSON there made each of those a malformed scorecard that took `trend` and `churn`
- * down. A name that *is* a member and does not decode still refuses, because that is a corrupt point
- * of the series rather than a neighbour.
+ * The membership rule and the decode live in `series-io.ts`, shared with the merge gate (#4681); what
+ * stays here is this group's disposition of its three answers — an unreadable path exits `FAILED`, a
+ * corrupt member exits `MALFORMED_DOCUMENT`, and a neighbouring JSON file is named on stderr rather
+ * than passed over in silence, because a scorecard written under some other name is invisible to the
+ * trend and this is the one line that says so.
  */
 const readSeries = (dir: string) =>
 	Effect.gen(function* () {
-		const fs = yield* FileSystem.FileSystem;
-		const path = yield* Path.Path;
-		if (!(yield* fs.exists(dir))) return [] as ReadonlyArray<SeriesFile>;
-		const entries = yield* Effect.mapError(
-			fs.readDirectory(dir),
-			() => new PathUnreadable({path: dir}),
-		);
-		const names = entries.filter(isSeriesFileName).sort();
-		// Named on stderr rather than passed over in silence: a scorecard written into the directory
-		// under some other name is invisible to the trend, and this is the one line that says so.
-		const ignored = entries.filter((name) => name.endsWith(".json") && !isSeriesFileName(name));
-		if (ignored.length > 0) {
+		const read = yield* readSeriesFiles(dir);
+		if (read._tag === "Unreadable")
+			return yield* Effect.fail(new PathUnreadable({path: read.path}));
+		if (read._tag === "Malformed") {
 			yield* Console.error(
-				`fabrika eval: ${dir} — ${ignored.length} JSON file(s) are not series points and were skipped (${ignored.sort().join(", ")}); a point of the series is named <YYYY-MM-DD>[-N].json`,
+				`fabrika eval: ${read.path} is not a committable scorecard (${read.reason})`,
+			);
+			return yield* Effect.sync(() => process.exit(MALFORMED_DOCUMENT));
+		}
+		if (read.ignored.length > 0) {
+			yield* Console.error(
+				`fabrika eval: ${dir} — ${read.ignored.length} JSON file(s) are not series points and were skipped (${read.ignored.join(", ")}); a point of the series is named <YYYY-MM-DD>[-N].json`,
 			);
 		}
-		const files: Array<SeriesFile> = [];
-		for (const name of names) {
-			const full = path.join(dir, name);
-			const text = yield* Effect.mapError(
-				fs.readFileString(full),
-				() => new PathUnreadable({path: full}),
-			);
-			const decoded = decodeCommittedScorecard(text);
-			if (Result.isFailure(decoded)) {
-				yield* Console.error(
-					`fabrika eval: ${full} is not a committable scorecard (${decoded.failure.reason}): ${decoded.failure.message}`,
-				);
-				return yield* Effect.sync(() => process.exit(MALFORMED_DOCUMENT));
-			}
-			files.push({fileName: name, scorecard: decoded.success});
-		}
-		return files as ReadonlyArray<SeriesFile>;
+		return read.files;
 	});
 
 /**
@@ -1620,6 +1601,102 @@ const post = leafCommand(
 	),
 );
 
+const gatePrArg = Argument.integer("pr").pipe(
+	Argument.withDescription(
+		"the pull request under gate — its head, changed paths and eval records are all read from it",
+	),
+	Argument.optional,
+);
+
+const gateHeadFlag = Flag.string("head").pipe(
+	Flag.optional,
+	Flag.withDescription("offline mode: the head commit under gate, in place of a pull request"),
+);
+
+const gateChangedFlag = Flag.string("changed").pipe(
+	Flag.optional,
+	Flag.withDescription("offline mode: a file of newline-separated changed paths"),
+);
+
+const gateRecordFlag = Flag.string("record").pipe(
+	Flag.atLeast(0),
+	Flag.withDescription(
+		"offline mode: an eval record file to verify against the head (repeatable, no network)",
+	),
+);
+
+const floorCasesFlag = Flag.string("floor-cases").pipe(
+	Flag.withDefault(DEFAULT_FLOOR_CASES),
+	Flag.withDescription(
+		`the incident corpus the regression floor runs (default: ${DEFAULT_FLOOR_CASES})`,
+	),
+);
+
+const floorCommandsFlag = Flag.string("floor-commands").pipe(
+	Flag.withDefault(DEFAULT_FLOOR_COMMANDS),
+	Flag.withDescription(
+		`the arming sidecar naming each floor case's command (default: ${DEFAULT_FLOOR_COMMANDS})`,
+	),
+);
+
+const gateBaselineFlag = Flag.string("baseline").pipe(
+	Flag.optional,
+	Flag.withDescription(
+		"the committed v1 cost baseline (default: the newest baseline-v1-*.json in the series directory)",
+	),
+);
+
+/**
+ * `gate` — the ruled #4637-B bar as one answer a CI job relays (#4681).
+ *
+ * Every input is resolved here, so no part of the decision is reachable from a workflow file: which
+ * paths make the graded suite apply, which eval record is in force at the head, whether a rate clears
+ * the bar, and whether an incident case is armed to run.
+ *
+ * It spawns processes and never a model. The graded leg **verifies** the head-bound record the review
+ * stage recorded rather than running the suite (the #4649 cost ruling), which is why `missing` and
+ * `stale` are red conditions in their own right.
+ */
+const gate = leafCommand(
+	"gate",
+	{
+		pr: gatePrArg,
+		repo: repoFlag,
+		head: gateHeadFlag,
+		changed: gateChangedFlag,
+		record: gateRecordFlag,
+		floorCases: floorCasesFlag,
+		floorCommands: floorCommandsFlag,
+		seriesDir: seriesDirFlag,
+		baseline: gateBaselineFlag,
+		ledger: spendLedgerFlag,
+		json: resultJsonFlag,
+	},
+	Effect.fn(function* (opts) {
+		yield* emit(
+			yield* runGate({
+				pr: opts.pr._tag === "Some" ? opts.pr.value : null,
+				repo: opts.repo._tag === "Some" ? opts.repo.value : null,
+				head: opts.head._tag === "Some" ? opts.head.value : null,
+				changed: opts.changed._tag === "Some" ? opts.changed.value : null,
+				records: opts.record,
+				floorCases: opts.floorCases,
+				floorCommands: opts.floorCommands,
+				seriesDir: opts.seriesDir,
+				baseline: opts.baseline._tag === "Some" ? opts.baseline.value : null,
+				ledger: opts.ledger,
+				json: opts.json,
+				env: process.env,
+			}),
+		);
+	}),
+).pipe(
+	Command.withShortDescription("Decide the ruled #4637-B merge bar over a pull request."),
+	Command.withDescription(
+		"Decide every leg of the ruled bar and name the reason for each red: the 100% incident-regression floor (executed here, no model), the 90% graded rate VERIFIED off the head-bound eval record the review stage recorded, and spend at or below the committed v1 baseline. The trend co-gate is reported and never gates (ADR 0252 §4). Fails closed on zero scope (ADR 0092). Exits 7 (zero scope — no changed path, no deterministic case, a corpus case the sidecar accounts for neither way, or an UNRECORDABLE record), 15 (spend above the v1 baseline, or incomparable), 18 (stale — the newest record is bound to an older commit), 21 (missing — no eval record for the head), 22 (below-bar — a recorded rate under 0.9), 23 (regression-floor — an armed incident case did not pass). Example: fabrika eval gate 5432",
+	),
+);
+
 export const evalCommand = Command.make("eval").pipe(
 	Command.withSubcommands([
 		check,
@@ -1633,8 +1710,9 @@ export const evalCommand = Command.make("eval").pipe(
 		trend,
 		churn,
 		post,
+		gate,
 	]),
 	Command.withDescription(
-		"Graded per-stage corpus + scorecard + authored-eval-set ingestion + the unattended runner + the five-run graded axis + the ruled KEEP enumeration + the v1 cost baseline + the committed scorecard series, its trend co-gate, the model-churn re-run and the record emit (#1848, #1853, #4674, #4676, #4678, #4823, #4679, #4680, #5411)",
+		"Graded per-stage corpus + scorecard + authored-eval-set ingestion + the unattended runner + the five-run graded axis + the ruled KEEP enumeration + the v1 cost baseline + the committed scorecard series, its trend co-gate, the model-churn re-run, the record emit and the ruled merge bar (#1848, #1853, #4674, #4676, #4678, #4823, #4679, #4680, #5411, #4681)",
 	),
 );

--- a/packages/fabrika-cli/src/eval/floor-commands.data.unit.test.ts
+++ b/packages/fabrika-cli/src/eval/floor-commands.data.unit.test.ts
@@ -1,0 +1,52 @@
+/**
+ * The committed arming sidecar, checked against the committed corpus.
+ *
+ * The one property worth holding on the data itself is completeness: every deterministic case in the
+ * incident corpus carries an arming decision here. The gate reds when it does not, and this test is
+ * what turns that red into a caught commit rather than a caught merge — a case added to the corpus
+ * without a decision fails here first.
+ */
+import {readFileSync} from "node:fs";
+import {fileURLToPath} from "node:url";
+import {Result} from "effect";
+import {describe, expect, it} from "vitest";
+import {armedRows, decodeFloorCommands, pendingRows} from "./floor-commands.ts";
+import {decodeSkillEvalSet} from "./skill-eval-set.ts";
+
+const read = (name: string): string =>
+	readFileSync(fileURLToPath(new URL(`./incident-corpus/${name}`, import.meta.url)), "utf8");
+
+const sidecar = () => {
+	const result = decodeFloorCommands(read("commands.json"));
+	if (Result.isFailure(result))
+		throw new Error(`commands.json does not decode: ${result.failure.message}`);
+	return result.success;
+};
+
+const corpus = () => {
+	const result = decodeSkillEvalSet(read("evals.json"));
+	if (Result.isFailure(result))
+		throw new Error(`evals.json does not decode: ${result.failure.message}`);
+	return result.success;
+};
+
+describe("the committed arming sidecar", () => {
+	it("decodes", () => {
+		expect(sidecar().corpus).toBe("fabrika-incident-corpus");
+	});
+
+	it("accounts for every deterministic case in the corpus", () => {
+		const accounted = new Set([...armedRows(sidecar()).keys(), ...pendingRows(sidecar()).keys()]);
+		const deterministic = corpus()
+			.cases.filter((evalCase) => evalCase.tier === "deterministic")
+			.map((evalCase) => evalCase.id);
+		expect(deterministic.length).toBeGreaterThan(0);
+		expect(deterministic.filter((id) => !accounted.has(id))).toEqual([]);
+	});
+
+	it("names no case the corpus does not carry", () => {
+		const ids = new Set(corpus().cases.map((evalCase) => evalCase.id));
+		const named = [...armedRows(sidecar()).keys(), ...pendingRows(sidecar()).keys()];
+		expect(named.filter((id) => !ids.has(id))).toEqual([]);
+	});
+});

--- a/packages/fabrika-cli/src/eval/floor-commands.ts
+++ b/packages/fabrika-cli/src/eval/floor-commands.ts
@@ -8,8 +8,17 @@
  *
  * A row is a discriminated union on `status`, on `ruled-keeps.ts`'s precedent: a `pending` row
  * without a written reason is unrepresentable. That is the whole point of the shape — an incident
- * case the floor cannot yet run is a **committed admission carrying prose**, never a silence. And
- * the completeness rule that pairs with it is the gate's, not this module's: every deterministic
+ * case the floor cannot yet run is a **committed admission carrying prose**, never a silence.
+ *
+ * **What a `pendingReason` must name, and the one cure that does not work.** The prose owes the
+ * concrete next action, because a deferral whose cure would not cure is a silence with extra words.
+ * For an assertion `readExpectation` cannot read, that action is **re-wording the expectation in
+ * `incident-corpus/evals.json`** so it quotes an observable — never a `corrections` entry in
+ * `provenance.json`, which is an append-only re-diagnosis ledger the tier never reads (the corpus
+ * README defines it; `readExpectation` reads only the assertion text). Stated here once; the rows
+ * name the action, not this reasoning.
+ *
+ * The completeness rule that pairs with the shape is the gate's, not this module's: every deterministic
  * case in the corpus must appear here under one status or the other, so a case added to the corpus
  * without an arming decision reds instead of quietly leaving the floor.
  */

--- a/packages/fabrika-cli/src/eval/floor-commands.ts
+++ b/packages/fabrika-cli/src/eval/floor-commands.ts
@@ -1,0 +1,139 @@
+/**
+ * The regression floor's arming sidecar — which incident-corpus cases the deterministic tier can
+ * actually execute, and what each one runs (issue #4681).
+ *
+ * `deterministic-tier.ts` takes its `resolveCommand` from the caller, and the authored eval format
+ * has no command field and gains none (#4674). So the CLI-layer command a case runs has to be
+ * committed *beside* the corpus rather than inside it, and this module is that file's decoder.
+ *
+ * A row is a discriminated union on `status`, on `ruled-keeps.ts`'s precedent: a `pending` row
+ * without a written reason is unrepresentable. That is the whole point of the shape — an incident
+ * case the floor cannot yet run is a **committed admission carrying prose**, never a silence. And
+ * the completeness rule that pairs with it is the gate's, not this module's: every deterministic
+ * case in the corpus must appear here under one status or the other, so a case added to the corpus
+ * without an arming decision reds instead of quietly leaving the floor.
+ */
+import {Result} from "effect";
+import * as Schema from "effect/Schema";
+import type {CommandResolver, DeterministicCommand, TieredEvalCase} from "./deterministic-tier.ts";
+
+/** The corpus the regression floor is measured against (#4675), repo-relative. */
+export const DEFAULT_FLOOR_CASES = "packages/fabrika-cli/src/eval/incident-corpus/evals.json";
+
+/** The arming sidecar that sits beside it — this module's file. */
+export const DEFAULT_FLOOR_COMMANDS = "packages/fabrika-cli/src/eval/incident-corpus/commands.json";
+
+/** A case the floor executes: the CLI-layer command, exactly as the tier's observer spawns it. */
+const ArmedRow = Schema.Struct({
+	status: Schema.Literal("armed"),
+	caseId: Schema.Int,
+	command: Schema.String,
+	args: Schema.Array(Schema.String),
+	cwd: Schema.optionalKey(Schema.NullOr(Schema.String)),
+	timeoutMs: Schema.optionalKey(Schema.NullOr(Schema.Int)),
+});
+
+/** A case the floor cannot run yet. `pendingReason` is required: it quotes what is owed. */
+const PendingRow = Schema.Struct({
+	status: Schema.Literal("pending"),
+	caseId: Schema.Int,
+	pendingReason: Schema.String,
+});
+
+const FloorRow = Schema.Union([ArmedRow, PendingRow]);
+
+export const FloorCommandsFile = Schema.Struct({
+	corpus: Schema.String,
+	rows: Schema.Array(FloorRow),
+});
+
+export type FloorRow = typeof FloorRow.Type;
+export type FloorCommands = typeof FloorCommandsFile.Type;
+
+export class FloorCommandsError extends Schema.TaggedErrorClass<FloorCommandsError>()(
+	"FloorCommandsError",
+	{
+		reason: Schema.Literals(["malformed-json", "schema-mismatch", "duplicate-case"]),
+		message: Schema.String,
+	},
+) {}
+
+const decodeUnknown = Schema.decodeUnknownResult(FloorCommandsFile);
+
+/**
+ * Decode the sidecar. Total — every rejection is a typed failure, never a throw.
+ *
+ * The duplicate check is here rather than in the schema because two rows for one case id is the one
+ * malformation a well-typed file can still carry: whichever row won would decide whether the case
+ * runs, and "which of these two is in force" is not a question the floor may answer by ordering.
+ */
+export const decodeFloorCommands = (
+	text: string,
+): Result.Result<FloorCommands, FloorCommandsError> =>
+	Result.try({
+		try: (): unknown => JSON.parse(text),
+		catch: (cause) =>
+			new FloorCommandsError({
+				reason: "malformed-json",
+				message: cause instanceof Error ? cause.message : String(cause),
+			}),
+	}).pipe(
+		Result.flatMap((parsed) =>
+			decodeUnknown(parsed).pipe(
+				Result.mapError(
+					(error) => new FloorCommandsError({reason: "schema-mismatch", message: error.message}),
+				),
+			),
+		),
+		Result.flatMap((file) => {
+			const seen = new Set<number>();
+			for (const row of file.rows) {
+				if (seen.has(row.caseId)) {
+					return Result.fail(
+						new FloorCommandsError({
+							reason: "duplicate-case",
+							message: `two rows claim case ${row.caseId} — one case carries one arming decision`,
+						}),
+					);
+				}
+				seen.add(row.caseId);
+			}
+			return Result.succeed(file);
+		}),
+	);
+
+/** The armed rows, keyed by case id. */
+export const armedRows = (file: FloorCommands): ReadonlyMap<number, DeterministicCommand> => {
+	const armed = new Map<number, DeterministicCommand>();
+	for (const row of file.rows) {
+		if (row.status !== "armed") continue;
+		armed.set(row.caseId, {
+			command: row.command,
+			args: row.args,
+			cwd: row.cwd ?? null,
+			timeoutMs: row.timeoutMs ?? null,
+		});
+	}
+	return armed;
+};
+
+/** The pending rows and the prose each one owes, keyed by case id. */
+export const pendingRows = (file: FloorCommands): ReadonlyMap<number, string> => {
+	const pending = new Map<number, string>();
+	for (const row of file.rows) {
+		if (row.status === "pending") pending.set(row.caseId, row.pendingReason);
+	}
+	return pending;
+};
+
+/**
+ * The tier's `resolveCommand`, bound to a decoded sidecar.
+ *
+ * An unarmed case resolves `null`, which the tier reds as `uncheckable` rather than skipping — so
+ * routing a pending case here would fail the floor. The gate never does: it hands the tier only the
+ * armed cases, and accounts for the pending ones separately.
+ */
+export const commandResolverOf = (file: FloorCommands): CommandResolver => {
+	const armed = armedRows(file);
+	return (evalCase: TieredEvalCase): DeterministicCommand | null => armed.get(evalCase.id) ?? null;
+};

--- a/packages/fabrika-cli/src/eval/floor-commands.unit.test.ts
+++ b/packages/fabrika-cli/src/eval/floor-commands.unit.test.ts
@@ -1,0 +1,67 @@
+/**
+ * The arming sidecar's decode, and the shape that makes an unrunnable case a written admission
+ * rather than a silence: a `pending` row without a reason does not decode at all.
+ */
+import {Result} from "effect";
+import {describe, expect, it} from "vitest";
+import type {TieredEvalCase} from "./deterministic-tier.ts";
+import {armedRows, commandResolverOf, decodeFloorCommands, pendingRows} from "./floor-commands.ts";
+
+const file = (rows: unknown): string => JSON.stringify({corpus: "fixture", rows});
+
+const decoded = (text: string) => {
+	const result = decodeFloorCommands(text);
+	if (Result.isFailure(result))
+		throw new Error(`fixture did not decode: ${result.failure.message}`);
+	return result.success;
+};
+
+const evalCase = (id: number): TieredEvalCase => ({id, tier: "deterministic", assertions: []});
+
+describe("decodeFloorCommands", () => {
+	it("reads an armed row into the command the tier's observer spawns", () => {
+		const sidecar = decoded(
+			file([{status: "armed", caseId: 3, command: "node", args: ["guard.ts"], cwd: "packages"}]),
+		);
+		expect(armedRows(sidecar).get(3)).toEqual({
+			command: "node",
+			args: ["guard.ts"],
+			cwd: "packages",
+			timeoutMs: null,
+		});
+	});
+
+	it("refuses a pending row with no written reason", () => {
+		const result = decodeFloorCommands(file([{status: "pending", caseId: 1}]));
+		expect(Result.isFailure(result)).toBe(true);
+	});
+
+	it("refuses two rows for one case — an arming decision is not settled by ordering", () => {
+		const result = decodeFloorCommands(
+			file([
+				{status: "armed", caseId: 1, command: "true", args: []},
+				{status: "pending", caseId: 1, pendingReason: "not yet"},
+			]),
+		);
+		expect(Result.isFailure(result) && result.failure.reason).toBe("duplicate-case");
+	});
+
+	it("refuses bytes that are not JSON", () => {
+		const result = decodeFloorCommands("not json");
+		expect(Result.isFailure(result) && result.failure.reason).toBe("malformed-json");
+	});
+
+	it("carries each pending row's prose, so the reason survives to the report", () => {
+		const sidecar = decoded(
+			file([{status: "pending", caseId: 7, pendingReason: "no guard exists to run it"}]),
+		);
+		expect(pendingRows(sidecar).get(7)).toBe("no guard exists to run it");
+	});
+
+	it("resolves no command for an unarmed case, which the tier reds rather than skips", () => {
+		const resolve = commandResolverOf(
+			decoded(file([{status: "pending", caseId: 1, pendingReason: "not yet"}])),
+		);
+		expect(resolve(evalCase(1))).toBeNull();
+	});
+});

--- a/packages/fabrika-cli/src/eval/gate-verb.ts
+++ b/packages/fabrika-cli/src/eval/gate-verb.ts
@@ -1,0 +1,365 @@
+/**
+ * `eval gate` — the IO shell around `gate.ts`'s judgement (#4681).
+ *
+ * The verb resolves **every** input the bar is decided over, so the CI job that calls it passes a PR
+ * number and relays an exit code (ADR 0228). Nothing about the decision — which paths count as a
+ * skill change, which record is in force, whether a rate clears the bar — is reachable from the
+ * workflow file.
+ *
+ * Two modes, and the second is why the graded leg is checkable offline: with a PR number the head,
+ * the changed paths and the eval records all come off the platform; with `--head` / `--changed` /
+ * `--record` they come off disk, no credential and no network.
+ *
+ * The only thing this shell executes is the deterministic tier over the armed incident cases. It
+ * spawns processes, never a model — `graded-axis.ts` is not imported here, which is what makes "no
+ * model in CI" readable off the import list rather than asserted in prose.
+ */
+import {Effect, FileSystem, Path, Result} from "effect";
+import type {ChildProcessSpawner} from "effect/unstable/process";
+import {listComments, resolveRepo} from "../io/issues.ts";
+import {getPullRequest, listPullFiles} from "../io/pulls.ts";
+import {readSpendLedger} from "../spend/ledger.ts";
+import {answer, FAILED, refuse, type VerbOutcome} from "../verb.ts";
+import {type EvalRecord, read as readEvalRecord} from "../wire/eval-record.ts";
+import {type HeadSha, headSha} from "../wire/verdict-marker.ts";
+import {MALFORMED_DOCUMENT, PRECONDITION_UNKNOWN, TARGET_ABSENT} from "./codes.ts";
+import {
+	type CostBaseline,
+	compareToBaseline,
+	decodeCostBaseline,
+	foldLedgerRows,
+} from "./cost-baseline.ts";
+import {observeShellCommand} from "./deterministic-shell-observer.ts";
+import {runDeterministicTier} from "./deterministic-tier.ts";
+import {commandResolverOf, decodeFloorCommands} from "./floor-commands.ts";
+import {
+	changedSkills,
+	decideGate,
+	floorScope,
+	gateToJson,
+	judgeFloor,
+	judgeGraded,
+	judgeScope,
+	judgeSpend,
+	renderGate,
+	type SpendInput,
+} from "./gate.ts";
+import {readSeriesFiles} from "./series-io.ts";
+import {decodeSkillEvalSet} from "./skill-eval-set.ts";
+import {readTrend} from "./trend.ts";
+
+const VERB = "eval gate";
+
+/** A committed v1 baseline's file name, as `eval baseline record --out` writes it into the series. */
+const BASELINE_FILE_NAME = /^baseline-v1-\d{4}-\d{2}-\d{2}(?:-\d+)?\.json$/;
+
+export interface GateOptions {
+	/** The PR to gate. `null` selects the offline mode, which then owes head + changed + records. */
+	readonly pr: number | null;
+	readonly repo: string | null;
+	readonly head: string | null;
+	/** A file of newline-separated changed paths — the offline half of the platform's file list. */
+	readonly changed: string | null;
+	readonly records: ReadonlyArray<string>;
+	readonly floorCases: string;
+	readonly floorCommands: string;
+	readonly seriesDir: string;
+	readonly baseline: string | null;
+	readonly ledger: string;
+	readonly json: boolean;
+	readonly env: Readonly<Record<string, string | undefined>>;
+}
+
+type Services = FileSystem.FileSystem | Path.Path | ChildProcessSpawner.ChildProcessSpawner;
+
+const readText = (path: string): Effect.Effect<string | null, never, FileSystem.FileSystem> =>
+	Effect.gen(function* () {
+		const fs = yield* FileSystem.FileSystem;
+		return yield* fs.readFileString(path).pipe(Effect.orElseSucceed(() => null));
+	});
+
+/** What the two modes have to agree on before any leg can be judged. */
+interface Subject {
+	readonly head: HeadSha;
+	readonly changed: ReadonlyArray<string>;
+	readonly records: ReadonlyArray<EvalRecord>;
+	readonly diagnostics: ReadonlyArray<string>;
+}
+
+const resolveOnline = (
+	options: GateOptions,
+	pr: number,
+): Effect.Effect<Subject | VerbOutcome, never, Services> =>
+	Effect.gen(function* () {
+		const target = yield* resolveRepo(options.repo, options.env);
+		if (target._tag === "Failure") {
+			return refuse(
+				FAILED,
+				`${VERB}: cannot resolve a target repo — set CLAUDE_PIPELINE_REPO, or run inside a checkout whose origin remote resolves.`,
+			);
+		}
+		const repo = target.value;
+
+		const found = yield* getPullRequest(repo, pr);
+		if (found._tag === "Absent") {
+			return refuse(TARGET_ABSENT, `${VERB}: PR #${pr} not found in ${repo}.`);
+		}
+		if (found._tag === "Unknown") {
+			return refuse(
+				PRECONDITION_UNKNOWN,
+				`${VERB}: cannot read PR #${pr}: ${found.reason} — the bar is UNKNOWN, never met.`,
+			);
+		}
+		const live = headSha(found.value.headSha);
+		if (live === null) {
+			return refuse(
+				PRECONDITION_UNKNOWN,
+				`${VERB}: PR #${pr}'s head "${found.value.headSha.trim()}" is not a head SHA — nothing to bind a record to.`,
+			);
+		}
+
+		const files = yield* listPullFiles(repo, pr);
+		if (files._tag === "Failure") {
+			return refuse(
+				PRECONDITION_UNKNOWN,
+				`${VERB}: cannot read #${pr}'s changed files: ${files.reason} — a short file list would silently shrink the gate's scope.`,
+			);
+		}
+		// The platform's own count is the denominator: a paged read that came back short would drop the
+		// very skill path that makes the graded leg apply, which is the #4604 shape from the other side.
+		if (files.value.length < found.value.changedFiles) {
+			return refuse(
+				PRECONDITION_UNKNOWN,
+				`${VERB}: received ${files.value.length} of ${found.value.changedFiles} declared changed file(s) on #${pr} — refusing the partial scope.`,
+			);
+		}
+
+		const listed = yield* listComments(repo, pr);
+		if (listed._tag === "Failure") {
+			return refuse(
+				PRECONDITION_UNKNOWN,
+				`${VERB}: cannot read #${pr}'s comments: ${listed.reason} — an unreadable comment list is never "no eval record".`,
+			);
+		}
+		if (listed.value.length < found.value.comments) {
+			return refuse(
+				PRECONDITION_UNKNOWN,
+				`${VERB}: received ${listed.value.length} of ${found.value.comments} declared comment(s) on #${pr} — a short sweep could miss the record and red as missing.`,
+			);
+		}
+
+		const records: Array<EvalRecord> = [];
+		const notices: Array<string> = [];
+		for (const comment of listed.value) {
+			const carried = readEvalRecord(comment.body);
+			// A comment that reaches for the format and fails it is named, never dropped: it may be the
+			// record this gate is looking for, garbled, and a silent skip would red as `missing`.
+			if (carried._tag === "Malformed") {
+				notices.push(
+					`${VERB}: comment ${comment.id} reaches for the eval-record format and fails it: ${carried.reason}.`,
+				);
+				continue;
+			}
+			if (carried._tag === "Found") records.push(carried.value);
+		}
+		return {
+			head: live,
+			changed: files.value,
+			records,
+			diagnostics: [
+				`${VERB}: ${repo}#${pr} at ${live} — ${files.value.length} changed path(s), ${listed.value.length} comment(s) swept, ${records.length} eval record(s) read.`,
+				...notices,
+			],
+		};
+	});
+
+const resolveOffline = (
+	options: GateOptions,
+): Effect.Effect<Subject | VerbOutcome, never, Services> =>
+	Effect.gen(function* () {
+		if (options.head === null || options.changed === null) {
+			return refuse(
+				FAILED,
+				`${VERB}: name a pull request, or pass --head and --changed for the offline mode.`,
+			);
+		}
+		const live = headSha(options.head);
+		if (live === null) {
+			return refuse(FAILED, `${VERB}: "${options.head}" is not a head SHA — expected 7-40 hex.`);
+		}
+		const listText = yield* readText(options.changed);
+		if (listText === null) {
+			return refuse(PRECONDITION_UNKNOWN, `${VERB}: cannot read ${options.changed}.`);
+		}
+		const records: Array<EvalRecord> = [];
+		for (const path of options.records) {
+			const text = yield* readText(path);
+			if (text === null) {
+				return refuse(PRECONDITION_UNKNOWN, `${VERB}: cannot read ${path}.`);
+			}
+			const carried = readEvalRecord(text);
+			if (carried._tag !== "Found") {
+				return refuse(
+					MALFORMED_DOCUMENT,
+					`${VERB}: ${path} carries no readable eval record (${carried._tag.toLowerCase()}): ${carried.reason}.`,
+				);
+			}
+			records.push(carried.value);
+		}
+		const changed = listText
+			.split("\n")
+			.map((line) => line.trim())
+			.filter((line) => line !== "");
+		return {
+			head: live,
+			changed,
+			records,
+			diagnostics: [
+				`${VERB}: offline at ${live} — ${changed.length} changed path(s) from ${options.changed}, ${records.length} eval record(s) from disk.`,
+			],
+		};
+	});
+
+/** A step answered with a refusal rather than its value. `code` is the one key no step's value has. */
+const isOutcome = <A extends object>(value: A | VerbOutcome): value is VerbOutcome =>
+	Object.hasOwn(value, "code");
+
+/** The newest committed v1 baseline in the series directory, or `null` when it carries none. */
+const newestBaseline = (
+	dir: string,
+): Effect.Effect<string | null, never, FileSystem.FileSystem | Path.Path> =>
+	Effect.gen(function* () {
+		const fs = yield* FileSystem.FileSystem;
+		const path = yield* Path.Path;
+		if (!(yield* fs.exists(dir).pipe(Effect.orElseSucceed(() => false)))) return null;
+		const entries = yield* fs.readDirectory(dir).pipe(Effect.orElseSucceed(() => []));
+		const names = entries.filter((name) => BASELINE_FILE_NAME.test(name)).sort();
+		const newest = names[names.length - 1];
+		return newest === undefined ? null : path.join(dir, newest);
+	});
+
+const spendInput = (
+	options: GateOptions,
+): Effect.Effect<SpendInput | VerbOutcome, never, Services> =>
+	Effect.gen(function* () {
+		const ledgerText = yield* readText(options.ledger);
+		if (ledgerText === null) return {_tag: "NoLedger", path: options.ledger} as SpendInput;
+
+		const ledger = readSpendLedger(ledgerText);
+		const baselinePath = options.baseline ?? (yield* newestBaseline(options.seriesDir));
+		if (baselinePath === null) {
+			return {_tag: "NoBaseline", dir: options.seriesDir} as SpendInput;
+		}
+		const baselineText = yield* readText(baselinePath);
+		if (baselineText === null) {
+			return refuse(PRECONDITION_UNKNOWN, `${VERB}: cannot read ${baselinePath}.`);
+		}
+		const decoded = decodeCostBaseline(baselineText);
+		if (Result.isFailure(decoded)) {
+			return refuse(
+				MALFORMED_DOCUMENT,
+				`${VERB}: ${baselinePath} is not a valid cost baseline (${decoded.failure.reason}): ${decoded.failure.message}.`,
+			);
+		}
+		const baseline: CostBaseline = decoded.success;
+		const fold = foldLedgerRows(ledger.rows);
+		// An unfoldable candidate is `incomparable`, which the spend leg reds — it is never a failure to
+		// invoke, because the ceiling was read and the question was asked.
+		return Result.isFailure(fold)
+			? ({
+					_tag: "Compared",
+					comparison: {
+						verdict: "incomparable",
+						reason: fold.failure.message,
+						baselineBilled: baseline.spend.billed,
+						candidateBilled: 0,
+						deltaBilled: null,
+					},
+				} as SpendInput)
+			: ({
+					_tag: "Compared",
+					comparison: compareToBaseline(baseline, fold.success),
+				} as SpendInput);
+	});
+
+export const runGate = (options: GateOptions): Effect.Effect<VerbOutcome, never, Services> =>
+	Effect.gen(function* () {
+		if (options.pr !== null && options.records.length > 0) {
+			return refuse(
+				FAILED,
+				`${VERB}: --record is the offline mode's input; on a pull request the records are read from its comments.`,
+			);
+		}
+		const subject = yield* options.pr === null
+			? resolveOffline(options)
+			: resolveOnline(options, options.pr);
+		if (isOutcome(subject)) return subject;
+
+		// The floor's two artifacts are read before anything runs: a corpus or a sidecar the gate
+		// cannot read is UNKNOWN, and UNKNOWN never resolves to an empty floor that passes.
+		const casesText = yield* readText(options.floorCases);
+		if (casesText === null) {
+			return refuse(PRECONDITION_UNKNOWN, `${VERB}: cannot read ${options.floorCases}.`);
+		}
+		const set = decodeSkillEvalSet(casesText);
+		if (Result.isFailure(set)) {
+			return refuse(
+				MALFORMED_DOCUMENT,
+				`${VERB}: ${options.floorCases} is not a valid eval set (${set.failure.reason}): ${set.failure.message}.`,
+			);
+		}
+		const commandsText = yield* readText(options.floorCommands);
+		if (commandsText === null) {
+			return refuse(PRECONDITION_UNKNOWN, `${VERB}: cannot read ${options.floorCommands}.`);
+		}
+		const sidecar = decodeFloorCommands(commandsText);
+		if (Result.isFailure(sidecar)) {
+			return refuse(
+				MALFORMED_DOCUMENT,
+				`${VERB}: ${options.floorCommands} is not a valid arming sidecar (${sidecar.failure.reason}): ${sidecar.failure.message}.`,
+			);
+		}
+
+		const scope = floorScope(set.success.cases, sidecar.success);
+		const run =
+			scope.armed.length === 0
+				? {rows: [], deferredToGraded: []}
+				: yield* runDeterministicTier({
+						cases: scope.armed,
+						resolveCommand: commandResolverOf(sidecar.success),
+						observe: observeShellCommand,
+					});
+
+		const series = yield* readSeriesFiles(options.seriesDir);
+		if (series._tag !== "Files") {
+			return refuse(
+				series._tag === "Unreadable" ? PRECONDITION_UNKNOWN : MALFORMED_DOCUMENT,
+				series._tag === "Unreadable"
+					? `${VERB}: cannot read the scorecard series at ${series.path}.`
+					: `${VERB}: ${series.path} is not a committable scorecard (${series.reason}).`,
+			);
+		}
+
+		const spend = yield* spendInput(options);
+		if (isOutcome(spend)) return spend;
+
+		const skills = changedSkills(subject.changed);
+		const verdict = decideGate({
+			legs: [
+				judgeScope(subject.changed),
+				judgeFloor({
+					scope,
+					rows: run.rows,
+					deterministicCases: set.success.cases.filter((c) => c.tier === "deterministic").length,
+				}),
+				judgeGraded({changedSkills: skills, records: subject.records, head: subject.head}),
+				judgeSpend(spend),
+			],
+			trend: readTrend(series.files),
+		});
+
+		const report = options.json ? gateToJson(verdict) : `${renderGate(verdict)}\n`;
+		return verdict.verdict === "green"
+			? answer(report, subject.diagnostics)
+			: refuse(verdict.code, report.trimEnd(), subject.diagnostics);
+	});

--- a/packages/fabrika-cli/src/eval/gate.cli.test.ts
+++ b/packages/fabrika-cli/src/eval/gate.cli.test.ts
@@ -1,0 +1,254 @@
+/**
+ * The merge gate watched failing — the exit status and stream discipline a CI job actually relays.
+ *
+ * #4681 asks for the guard to be *observed* red on three deliberately-constructed cases rather than
+ * assumed: a genuinely failing eval case, a **missing** result, and a **stale** result bound to an
+ * older commit. The last two are the paths by which the review-stage step can be skipped by
+ * forgetting, so they are the ones a green would hide. Each `it` here runs the real bin in a
+ * subprocess and asserts the code a `run:` step would see (`.patterns/subprocess-test-budget.md`
+ * bounds the spawn count; every branch of the decision itself lives in `./gate.unit.test.ts`).
+ *
+ * The floor runs against a corpus authored here rather than the committed one, because the assertion
+ * is about the gate's behaviour on a failing case and the committed corpus has none armed yet
+ * (#5431). The PR path gets one run through a `gh` shim, which proves the verb resolves head,
+ * changed paths and records off the platform — the shape the workflow depends on.
+ */
+import {execFileSync} from "node:child_process";
+import {chmodSync, mkdirSync, mkdtempSync, writeFileSync} from "node:fs";
+import {tmpdir} from "node:os";
+import {join} from "node:path";
+import {fileURLToPath} from "node:url";
+import {describe, expect, it} from "vitest";
+import {SUBPROCESS_TEST_TIMEOUT_MS} from "../test-budget.ts";
+import {BELOW_BAR, MISSING_RESULT, REGRESSION_FLOOR, STALE_HEAD, ZERO_SCOPE} from "./codes.ts";
+
+const BIN = fileURLToPath(new URL("../bin.ts", import.meta.url));
+
+const HEAD = "03135b91aa04f7e2c9d8b1640a5c22e9f01b7d3c";
+const OLDER = "7be402c1d3e5f60718293a4b5c6d7e8f90a1b2c3";
+const SKILL_PATH = "claude-plugins/fabrika/skills/triage/SKILL.md";
+
+const CORPUS = {
+	skill_name: "fixture-incident-corpus",
+	evals: [{id: 1, prompt: "run the guard", expectations: ["The check exits 0."]}],
+};
+
+const recordBytes = (sha: string, passed: number, graded: number): string => {
+	const cases = Array.from({length: graded}, (_, index) => {
+		const passes = index < passed;
+		return {
+			caseId: index + 1,
+			verdict: passes ? "pass" : "fail",
+			runs: 5,
+			passed: passes ? 5 : 0,
+			noVerdict: 0,
+			dispersion: 0,
+			perRun: Array.from({length: 5}, () => (passes ? "pass" : "fail")),
+		};
+	});
+	return [
+		`eval: RECORDED @ ${sha} — a graded run`,
+		"",
+		"```json",
+		JSON.stringify(
+			{
+				sha,
+				recordedAt: "2026-08-11T06:30:00Z",
+				cell: {stage: "review", surface: "skill", model: "claude-opus-4-8"},
+				pins: {model: "claude-opus-4-8", cli: "2.1.227", harness: "0.1.0"},
+				gradedRuns: graded,
+				passedRuns: passed,
+				unmeasuredCases: 0,
+				passRate: Math.round((passed / graded) * 10_000) / 10_000,
+				cases,
+			},
+			null,
+			2,
+		),
+		"```",
+		"",
+	].join("\n");
+};
+
+interface Fixture {
+	readonly dir: string;
+	readonly args: ReadonlyArray<string>;
+}
+
+/** A workspace whose floor arms one case with `command`, and whose changed set is `changed`. */
+const fixture = (options: {
+	readonly command: string;
+	readonly changed: ReadonlyArray<string>;
+	readonly records?: ReadonlyArray<string>;
+}): Fixture => {
+	const dir = mkdtempSync(join(tmpdir(), "fabrika-gate-cli-"));
+	mkdirSync(join(dir, "series"), {recursive: true});
+	writeFileSync(join(dir, "evals.json"), JSON.stringify(CORPUS));
+	writeFileSync(
+		join(dir, "commands.json"),
+		JSON.stringify({
+			corpus: "fixture-incident-corpus",
+			rows: [{status: "armed", caseId: 1, command: options.command, args: []}],
+		}),
+	);
+	writeFileSync(join(dir, "changed.txt"), `${options.changed.join("\n")}\n`);
+	const records = (options.records ?? []).map((bytes, index) => {
+		const path = join(dir, `record-${index}.md`);
+		writeFileSync(path, bytes);
+		return path;
+	});
+	return {
+		dir,
+		args: [
+			"--head",
+			HEAD,
+			"--changed",
+			join(dir, "changed.txt"),
+			"--floor-cases",
+			join(dir, "evals.json"),
+			"--floor-commands",
+			join(dir, "commands.json"),
+			"--series-dir",
+			join(dir, "series"),
+			"--spend-ledger",
+			join(dir, "no-such-ledger.jsonl"),
+			...records.flatMap((path) => ["--record", path]),
+		],
+	};
+};
+
+interface Run {
+	readonly code: number;
+	readonly stdout: string;
+	readonly stderr: string;
+}
+
+const gate = (args: ReadonlyArray<string>, env: Record<string, string> = {}): Run => {
+	try {
+		const stdout = execFileSync(process.execPath, [BIN, "eval", "gate", ...args], {
+			encoding: "utf8",
+			env: {...process.env, FABRIKA_SKIP_INFER: "1", CLAUDE_PIPELINE_REPO: "o/r", ...env},
+			stdio: ["pipe", "pipe", "pipe"],
+		});
+		return {code: 0, stdout, stderr: ""};
+	} catch (err) {
+		const failure = err as {status?: number; stdout?: string; stderr?: string};
+		return {code: failure.status ?? -1, stdout: failure.stdout ?? "", stderr: failure.stderr ?? ""};
+	}
+};
+
+describe("fabrika eval gate, watched failing", {timeout: SUBPROCESS_TEST_TIMEOUT_MS}, () => {
+	it("is green when the floor passes and no skill changed", () => {
+		const run = gate(fixture({command: "true", changed: ["packages/fabrika-cli/src/x.ts"]}).args);
+		expect(run.code).toBe(0);
+		expect(run.stdout).toContain("gate: GREEN");
+		expect(run.stdout).toContain("floor: 1/1");
+	});
+
+	it("(a) reds `regression-floor` on a genuinely failing incident case", () => {
+		const run = gate(fixture({command: "false", changed: ["packages/fabrika-cli/src/x.ts"]}).args);
+		expect(run.code).toBe(REGRESSION_FLOOR);
+		expect(run.stdout).toBe("");
+		expect(run.stderr).toContain("regression-floor");
+		expect(run.stderr).toContain("no tolerance and no quarantine");
+	});
+
+	it("(b) reds `missing` when a skill changed and no result was recorded", () => {
+		const run = gate(fixture({command: "true", changed: [SKILL_PATH]}).args);
+		expect(run.code).toBe(MISSING_RESULT);
+		expect(run.stdout).toBe("");
+		expect(run.stderr).toContain("missing");
+	});
+
+	it("(c) reds `stale` when the newest result is bound to an older commit", () => {
+		const run = gate(
+			fixture({
+				command: "true",
+				changed: [SKILL_PATH],
+				records: [recordBytes(OLDER, 10, 10)],
+			}).args,
+		);
+		expect(run.code).toBe(STALE_HEAD);
+		expect(run.stderr).toContain(OLDER);
+	});
+
+	it("reds `below-bar` on a recorded rate under the ruled bar", () => {
+		const run = gate(
+			fixture({command: "true", changed: [SKILL_PATH], records: [recordBytes(HEAD, 8, 10)]}).args,
+		);
+		expect(run.code).toBe(BELOW_BAR);
+		expect(run.stderr).toContain("below-bar");
+	});
+
+	it("passes a skill change whose recorded rate is at the bar", () => {
+		const run = gate(
+			fixture({command: "true", changed: [SKILL_PATH], records: [recordBytes(HEAD, 9, 10)]}).args,
+		);
+		expect(run.code).toBe(0);
+		expect(run.stdout).toContain("gate: GREEN");
+	});
+
+	it("reds zero scope when the change declares no path", () => {
+		const at = fixture({command: "true", changed: []});
+		writeFileSync(join(at.dir, "changed.txt"), "");
+		const run = gate(at.args);
+		expect(run.code).toBe(ZERO_SCOPE);
+		expect(run.stderr).toContain("zero-scope");
+	});
+});
+
+/**
+ * The dispatcher, in `sh` for `post.cli.test.ts`'s reason: an extensionless entry file's module
+ * system is a platform detail this test has no business depending on.
+ */
+const SHIM = `#!/bin/sh
+case "$*" in
+  *"pulls/9041/files"*) cat "$GH_STATE/files.json" ;;
+  *"pulls/9041"*) cat "$GH_STATE/pull.json" ;;
+  *"issues/9041/comments"*) cat "$GH_STATE/comments.json" ;;
+  *) echo "unscripted: $*" >&2; exit 1 ;;
+esac
+`;
+
+describe("fabrika eval gate, over a pull request", {timeout: SUBPROCESS_TEST_TIMEOUT_MS}, () => {
+	it("resolves head, changed paths and records off the platform and reds `missing`", () => {
+		const at = fixture({command: "true", changed: []});
+		const shimDir = mkdtempSync(join(tmpdir(), "fabrika-gate-shim-"));
+		const state = join(shimDir, "state");
+		mkdirSync(state, {recursive: true});
+		writeFileSync(join(shimDir, "gh"), SHIM);
+		chmodSync(join(shimDir, "gh"), 0o755);
+		writeFileSync(
+			join(state, "pull.json"),
+			JSON.stringify({
+				number: 9041,
+				state: "open",
+				head: {sha: HEAD},
+				base: {ref: "main"},
+				body: "",
+				changed_files: 1,
+				comments: 0,
+			}),
+		);
+		writeFileSync(join(state, "files.json"), JSON.stringify([{filename: SKILL_PATH}]));
+		writeFileSync(join(state, "comments.json"), JSON.stringify([]));
+
+		const run = gate(
+			[
+				"9041",
+				"--floor-cases",
+				join(at.dir, "evals.json"),
+				"--floor-commands",
+				join(at.dir, "commands.json"),
+				"--series-dir",
+				join(at.dir, "series"),
+				"--spend-ledger",
+				join(at.dir, "no-such-ledger.jsonl"),
+			],
+			{PATH: `${shimDir}:${process.env.PATH ?? ""}`, GH_STATE: state},
+		);
+		expect(run.code).toBe(MISSING_RESULT);
+		expect(run.stderr).toContain(`o/r#9041 at ${HEAD}`);
+		expect(run.stderr).toContain("1 changed path(s)");
+	});
+});

--- a/packages/fabrika-cli/src/eval/gate.cli.test.ts
+++ b/packages/fabrika-cli/src/eval/gate.cli.test.ts
@@ -138,11 +138,15 @@ const gate = (args: ReadonlyArray<string>, env: Record<string, string> = {}): Ru
 };
 
 describe("fabrika eval gate, watched failing", {timeout: SUBPROCESS_TEST_TIMEOUT_MS}, () => {
-	it("is green when the floor passes and no skill changed", () => {
+	it("passes when the floor passes and no skill changed, and says which legs measured nothing", () => {
 		const run = gate(fixture({command: "true", changed: ["packages/fabrika-cli/src/x.ts"]}).args);
 		expect(run.code).toBe(0);
-		expect(run.stdout).toContain("gate: GREEN");
 		expect(run.stdout).toContain("floor: 1/1");
+		// The graded leg is n/a and there is no candidate ledger, so two legs measured nothing — and
+		// the summary a reader skims must say so rather than report the bar met.
+		expect(run.stdout).toContain("gate: NOT FULLY MEASURED");
+		expect(run.stdout).toContain("2 of 4 leg(s) measured NOTHING");
+		expect(run.stdout).not.toContain("gate: GREEN");
 	});
 
 	it("(a) reds `regression-floor` on a genuinely failing incident case", () => {
@@ -158,6 +162,7 @@ describe("fabrika eval gate, watched failing", {timeout: SUBPROCESS_TEST_TIMEOUT
 		expect(run.code).toBe(MISSING_RESULT);
 		expect(run.stdout).toBe("");
 		expect(run.stderr).toContain("missing");
+		expect(run.stderr).toContain("plain, non-worktree session");
 	});
 
 	it("(c) reds `stale` when the newest result is bound to an older commit", () => {
@@ -185,7 +190,8 @@ describe("fabrika eval gate, watched failing", {timeout: SUBPROCESS_TEST_TIMEOUT
 			fixture({command: "true", changed: [SKILL_PATH], records: [recordBytes(HEAD, 9, 10)]}).args,
 		);
 		expect(run.code).toBe(0);
-		expect(run.stdout).toContain("gate: GREEN");
+		expect(run.stdout).toContain("graded: 1 cell(s) recorded");
+		expect(run.stdout).toContain("gate: NOT FULLY MEASURED");
 	});
 
 	it("reds zero scope when the change declares no path", () => {

--- a/packages/fabrika-cli/src/eval/gate.ts
+++ b/packages/fabrika-cli/src/eval/gate.ts
@@ -20,6 +20,12 @@
  * its authority to block until it has been watched against a real series. Arming it is a later ADR's
  * edit to `judgeGraded`, and nothing else.
  *
+ * **A leg that measured nothing never reads as a leg that passed.** `LegVerdict` carries three states
+ * rather than two, and the summary names every unmeasured leg instead of absorbing it — because the
+ * artifact a reader acts on is a green check, and a green check that claims a bar was met over legs
+ * that ran nothing tells the same lie #4604 told, just from the reporting side rather than the
+ * path-filter side. Disclosing the gap elsewhere does not change what the check says.
+ *
  * Zero scope reds (ADR 0092). A change with no path, a corpus with no deterministic case, a corpus
  * case the arming sidecar accounts for neither way, and a record that measured nothing all resolve to
  * the same refusal, because a gate that could not see its own subject has proven nothing — the #4604
@@ -119,17 +125,51 @@ export interface GateRed {
 
 export type GateLeg = "scope" | "floor" | "graded" | "spend";
 
-/** One leg's answer: a line a human reads, and the red it raised — `null` when it raised none. */
-export interface LegVerdict {
-	readonly leg: GateLeg;
-	readonly line: string;
-	readonly red: GateRed | null;
-}
+/**
+ * One leg's answer — **three** states, and the third is the one a green check hides.
+ *
+ * A leg that measured nothing (an unarmed floor, a graded leg with no skill in the change, a spend
+ * leg with no candidate ledger) raised no red, but it also established nothing. Folding it into the
+ * same `red: null` as a leg that ran and passed is what lets a summary line say the bar is met over
+ * a bar nobody measured — the #4604 shape this gate exists to end, arriving from the reporting side
+ * instead of the path-filter side. So `unmeasured` is its own state, it carries the short reason the
+ * summary prints, and `renderGate` may never absorb it into a met-the-bar sentence.
+ */
+export type LegVerdict =
+	| {readonly leg: GateLeg; readonly status: "measured"; readonly line: string; readonly red: null}
+	| {
+			readonly leg: GateLeg;
+			readonly status: "unmeasured";
+			readonly line: string;
+			/** What was not measured, in a clause the summary can list. */
+			readonly notMeasured: string;
+			readonly red: null;
+	  }
+	| {
+			readonly leg: GateLeg;
+			readonly status: "red";
+			readonly line: string;
+			readonly red: GateRed;
+	  };
 
-const green = (leg: GateLeg, line: string): LegVerdict => ({leg, line, red: null});
+const measured = (leg: GateLeg, line: string): LegVerdict => ({
+	leg,
+	status: "measured",
+	line,
+	red: null,
+});
+
+const unmeasured = (leg: GateLeg, line: string, notMeasured: string): LegVerdict => ({
+	leg,
+	status: "unmeasured",
+	line: `${leg}: NOT MEASURED — ${line}`,
+	notMeasured,
+	red: null,
+});
 
 const red = (leg: GateLeg, reason: GateReason, detail: string): LegVerdict => ({
 	leg,
+	status: "red",
 	line: `${leg}: RED (${reason}) — ${detail}`,
 	red: {reason, detail},
 });
@@ -142,7 +182,7 @@ export const judgeScope = (changed: ReadonlyArray<string>): LegVerdict =>
 				"zero-scope",
 				"the change declares no path — a gate that cannot see its own subject proves nothing (ADR 0092)",
 			)
-		: green("scope", `scope: ${changed.length} changed path(s)`);
+		: measured("scope", `scope: ${changed.length} changed path(s)`);
 
 /** How the floor's cases divide against the arming sidecar. */
 export interface FloorScope {
@@ -210,9 +250,14 @@ export const judgeFloor = (args: {
 	// the one a reader is most likely to collapse. Zero scope is a corpus the gate could not see; this
 	// is a corpus it can see, whose every case carries a committed, written statement of what is owed
 	// before it can run. Nothing failing is being excluded, so this is not the quarantine the ruled
-	// floor forbids — and naming it on every run is what keeps it from being forgotten.
+	// floor forbids. It is still `unmeasured` and never `measured`: no regression can red a floor that
+	// runs nothing, so the summary has to say so out loud.
 	if (args.scope.armed.length === 0) {
-		return green("floor", `floor: pending — no incident case is armed to run yet${pending}`);
+		return unmeasured(
+			"floor",
+			`no incident case is armed to run yet, so no incident regression can red this gate${pending}`,
+			`floor (0 of ${args.scope.pending.length} incident case(s) armed — no regression can red it)`,
+		);
 	}
 	const summary = summarizeEvalRows(args.rows);
 	if (summary.verdict === "red") {
@@ -222,7 +267,7 @@ export const judgeFloor = (args: {
 			`${summary.redReason ?? "the suite is red"} — the floor is 100%, with no tolerance and no quarantine`,
 		);
 	}
-	return green(
+	return measured(
 		"floor",
 		`floor: ${summary.total.passed}/${summary.total.cases} armed incident case(s) pass${pending}`,
 	);
@@ -244,6 +289,19 @@ export const latestPerCell = (records: ReadonlyArray<EvalRecord>): ReadonlyArray
 };
 
 /**
+ * Where the measurement this leg reads back is taken, named in both reds that a run cures.
+ *
+ * `missing` and `stale` are recoverable states, not terminal failures, and neither is a blocker the
+ * build lane that tripped it can clear: the harness's worktree-isolation guard refuses the eval
+ * runner inside a lane outright (#5406, not fixable in this repo), so a graded run executes in a
+ * plain non-worktree session. A red that names no run site reads as "this lane is broken" and a red
+ * that says only "re-run the suite" names a cure the lane structurally cannot perform — so both name
+ * the site, and the hand-off, here. Stated once; both details point at it.
+ */
+const GRADED_RUN_SITE =
+	"cure: take a graded run at the head under gate in a plain, non-worktree session — never inside a build lane, whose harness refuses the runner (#5406) — which posts the head-bound record this leg reads back. A lane that hits this hands the measurement off; it is not the lane's to fix in place";
+
+/**
  * The graded leg: verify the recorded head-bound result, and never run anything.
  *
  * The resolution is the shared gate-verdict contract's, reused rather than re-invented — latest
@@ -258,14 +316,18 @@ export const judgeGraded = (args: {
 }): LegVerdict => {
 	const bar = args.bar ?? GRADED_BAR;
 	if (args.changedSkills.length === 0) {
-		return green("graded", "graded: n/a — this change touches no fabrika skill");
+		return unmeasured(
+			"graded",
+			"n/a — this change touches no fabrika skill, so no graded rate was read",
+			"graded (n/a — this change touches no fabrika skill)",
+		);
 	}
 	const skills = args.changedSkills.join(", ");
 	if (args.records.length === 0) {
 		return red(
 			"graded",
 			"missing",
-			`${skills} changed and no eval record was recorded for ${args.head} — absence is never "nothing to check" (#4649 ruling)`,
+			`${skills} changed and no eval record was recorded for ${args.head} — absence is never "nothing to check" (#4649 ruling). ${GRADED_RUN_SITE}`,
 		);
 	}
 
@@ -278,7 +340,7 @@ export const judgeGraded = (args: {
 		return red(
 			"graded",
 			"stale",
-			`the newest eval record is bound to ${newest?.sha ?? "an unreadable head"}, not to ${args.head} — re-run the suite at the head under gate, never re-bind (ADR 0253)`,
+			`the newest eval record is bound to ${newest?.sha ?? "an unreadable head"}, not to ${args.head} — a measurement is re-run at the new head, never re-bound to it (ADR 0253). ${GRADED_RUN_SITE}`,
 		);
 	}
 
@@ -298,7 +360,7 @@ export const judgeGraded = (args: {
 			.join(", ");
 		return red("graded", "below-bar", `${worst} — the ruled bar is ${bar} (#4637 ruling 2)`);
 	}
-	return green(
+	return measured(
 		"graded",
 		`graded: ${atHead.length} cell(s) recorded at ${args.head}, all at or above ${bar} (skills: ${skills})`,
 	);
@@ -324,9 +386,10 @@ export type SpendInput =
  */
 export const judgeSpend = (input: SpendInput): LegVerdict => {
 	if (input._tag === "NoLedger") {
-		return green(
+		return unmeasured(
 			"spend",
-			`spend: not-priced — no candidate spend ledger at ${input.path}; CI runs no suite of its own`,
+			`not-priced — no candidate spend ledger at ${input.path}; CI runs no suite of its own, so no spend was priced against the v1 baseline`,
+			"spend (not-priced — CI ran no suite, so nothing was priced against the v1 baseline)",
 		);
 	}
 	if (input._tag === "NoBaseline") {
@@ -338,7 +401,7 @@ export const judgeSpend = (input: SpendInput): LegVerdict => {
 	}
 	const {comparison} = input;
 	if (comparison.verdict === "at-or-below") {
-		return green(
+		return measured(
 			"spend",
 			`spend: at-or-below — ${comparison.candidateBilled} billed against the v1 baseline's ${comparison.baselineBilled}`,
 		);
@@ -379,15 +442,39 @@ export const decideGate = (args: {
 	};
 };
 
-/** The human report — one line per leg, then the advisories, then the verdict. */
+/** What the legs that measured nothing were not measuring — empty when the bar was measured whole. */
+export const unmeasuredLegs = (verdict: GateVerdict): ReadonlyArray<string> =>
+	verdict.legs.flatMap((leg) => (leg.status === "unmeasured" ? [leg.notMeasured] : []));
+
+/**
+ * The summary line — the one sentence a reader skimming a green check actually reads.
+ *
+ * It never says the bar is met unless every leg measured: an unmeasured leg is named in the line
+ * itself, so the check cannot be read as an enforcement it did not perform.
+ */
+const summaryLine = (verdict: GateVerdict): string => {
+	if (verdict.verdict === "red") {
+		return `gate: RED — ${verdict.reds.map((r) => r.reason).join(", ")}`;
+	}
+	const unmeasured = unmeasuredLegs(verdict);
+	if (unmeasured.length === 0) {
+		return `gate: GREEN — all ${verdict.legs.length} leg(s) of the ruled bar were measured and met`;
+	}
+	const met = verdict.legs.flatMap((leg) => (leg.status === "measured" ? [leg.leg] : []));
+	return [
+		`gate: NOT FULLY MEASURED — nothing red, and ${unmeasured.length} of ${verdict.legs.length} leg(s) measured NOTHING,`,
+		` so this is not a statement that the bar is met. NOT MEASURED: ${unmeasured.join("; ")}.`,
+		` Measured and met: ${met.length === 0 ? "no leg" : met.join(", ")}.`,
+	].join("");
+};
+
+/** The human report — one line per leg, then the advisories, then the summary. */
 export const renderGate = (verdict: GateVerdict): string =>
 	[
-		"fabrika eval gate — the #4637-B bar (100% floor · 90% graded · spend ≤ v1 baseline)",
+		"fabrika eval gate — judged against the #4637-B bar (100% floor · 90% graded · spend ≤ v1 baseline)",
 		...verdict.legs.map((leg) => leg.line),
 		...verdict.advisories,
-		verdict.verdict === "green"
-			? "gate: GREEN — every ruled leg of the bar is met"
-			: `gate: RED — ${verdict.reds.map((r) => r.reason).join(", ")}`,
+		summaryLine(verdict),
 	].join("\n");
 
 /** The machine-readable form, for a caller that wants the reasons without parsing prose. */
@@ -398,7 +485,13 @@ export const gateToJson = (verdict: GateVerdict): string =>
 			code: verdict.code,
 			bar: {graded: GRADED_BAR, floor: 1, adr: 4637},
 			reds: verdict.reds,
-			legs: verdict.legs.map((leg) => ({leg: leg.leg, line: leg.line, red: leg.red})),
+			unmeasured: unmeasuredLegs(verdict),
+			legs: verdict.legs.map((leg) => ({
+				leg: leg.leg,
+				status: leg.status,
+				line: leg.line,
+				red: leg.red,
+			})),
 			advisories: verdict.advisories,
 		},
 		null,

--- a/packages/fabrika-cli/src/eval/gate.ts
+++ b/packages/fabrika-cli/src/eval/gate.ts
@@ -1,0 +1,406 @@
+/**
+ * The merge gate — the ruled #4637-B bar as one decision, so a CI job only has to relay it (#4681).
+ *
+ * The bar has four legs and this module owns the judgement of all four, which is the point: ADR 0228
+ * says a script relays a verb's answer and never derives the decision, so every comparison that
+ * could be re-spelled in YAML lives here instead.
+ *
+ * **The graded leg verifies; it does not run.** The founder ruled on #4649 (comment 5153280445) that
+ * no model executes inside CI — the reason recorded is cost, not principle. The review stage runs the
+ * five-run graded axis and leaves a head-bound eval record (#4678, ADR 0253); this leg reads that
+ * record back and compares a string and a number. So `missing` and `stale` are red conditions in
+ * their own right: they are the two ways the review step can be skipped by forgetting, and absence
+ * that passes is exactly the guarantee the epic exists to restore.
+ *
+ * **Everything else still executes here, because none of it ever needed a model.** The deterministic
+ * regression floor runs its cases once through the tier (#4677), and the spend leg is arithmetic over
+ * rows a meter already reconstructed (#4679).
+ *
+ * The trend is computed and **reported, never gating** — ADR 0252 §4 and the #4766 guardrail defer
+ * its authority to block until it has been watched against a real series. Arming it is a later ADR's
+ * edit to `judgeGraded`, and nothing else.
+ *
+ * Zero scope reds (ADR 0092). A change with no path, a corpus with no deterministic case, a corpus
+ * case the arming sidecar accounts for neither way, and a record that measured nothing all resolve to
+ * the same refusal, because a gate that could not see its own subject has proven nothing — the #4604
+ * failure class, where a path filter matching nothing presented as a pass.
+ */
+import type {EvalRecord} from "../wire/eval-record.ts";
+import {roundRate} from "../wire/eval-record.ts";
+import {type HeadSha, sameHead} from "../wire/verdict-marker.ts";
+import {
+	ABOVE_BASELINE,
+	BELOW_BAR,
+	MISSING_RESULT,
+	REGRESSION_FLOOR,
+	STALE_HEAD,
+	ZERO_SCOPE,
+} from "./codes.ts";
+import {cellKeyOf, cellLabel} from "./committed-scorecard.ts";
+import type {BaselineComparison} from "./cost-baseline.ts";
+import type {EvalRow, TieredEvalCase} from "./deterministic-tier.ts";
+import {summarizeEvalRows} from "./deterministic-tier.ts";
+import type {FloorCommands} from "./floor-commands.ts";
+import {armedRows, pendingRows} from "./floor-commands.ts";
+import type {TrendReading} from "./trend.ts";
+import {renderTrendLine} from "./trend.ts";
+
+/** #4637 ruling 2's graded bar. Changing it is a decision, not an edit. */
+export const GRADED_BAR = 0.9;
+
+/**
+ * The paths whose change makes the full graded suite apply (#4637 ruling: skill changes only).
+ *
+ * This is the filter #4604 got wrong on the v1 side — a `packages/` anchor that excluded the skills
+ * directory, so a skill change matched nothing and the gate reported green over it. It is exported
+ * and parameterised so a test can re-run the decision under a deliberately mis-scoped filter and
+ * watch the red become a pass; a constant folded into the matcher could not be falsified that way.
+ */
+export const SKILL_PATH_PREFIXES: ReadonlyArray<string> = ["claude-plugins/fabrika/skills/"];
+
+/** The fabrika skills a changed-path set touches, by directory name, deduplicated and sorted. */
+export const changedSkills = (
+	paths: ReadonlyArray<string>,
+	prefixes: ReadonlyArray<string> = SKILL_PATH_PREFIXES,
+): ReadonlyArray<string> => {
+	const names = new Set<string>();
+	for (const path of paths) {
+		for (const prefix of prefixes) {
+			if (!path.startsWith(prefix)) continue;
+			const name = path.slice(prefix.length).split("/")[0];
+			if (name !== undefined && name !== "") names.add(name);
+		}
+	}
+	return [...names].sort();
+};
+
+/** The six ruled red conditions. Each names why the change is refused; none is a bare failure. */
+export type GateReason =
+	| "zero-scope"
+	| "regression-floor"
+	| "missing"
+	| "stale"
+	| "below-bar"
+	| "over-baseline";
+
+/**
+ * Which reason seats the exit code when more than one fires.
+ *
+ * Every reason is still printed — the order decides only the single number `$?` can carry, and it
+ * runs most-fundamental-first: a gate that could not see its scope has not established the others.
+ */
+export const REASON_PRECEDENCE: ReadonlyArray<GateReason> = [
+	"zero-scope",
+	"regression-floor",
+	"missing",
+	"stale",
+	"below-bar",
+	"over-baseline",
+];
+
+/**
+ * The exit seat each reason answers on. Four are reused rather than re-seated: `7`, `15` and `18`
+ * already mean exactly these facts elsewhere in the group, and a second number for one fact is how
+ * a caller comes to read two codes as two outcomes.
+ */
+export const REASON_CODES: Readonly<Record<GateReason, number>> = {
+	"zero-scope": ZERO_SCOPE,
+	"regression-floor": REGRESSION_FLOOR,
+	missing: MISSING_RESULT,
+	stale: STALE_HEAD,
+	"below-bar": BELOW_BAR,
+	"over-baseline": ABOVE_BASELINE,
+};
+
+export interface GateRed {
+	readonly reason: GateReason;
+	readonly detail: string;
+}
+
+export type GateLeg = "scope" | "floor" | "graded" | "spend";
+
+/** One leg's answer: a line a human reads, and the red it raised — `null` when it raised none. */
+export interface LegVerdict {
+	readonly leg: GateLeg;
+	readonly line: string;
+	readonly red: GateRed | null;
+}
+
+const green = (leg: GateLeg, line: string): LegVerdict => ({leg, line, red: null});
+
+const red = (leg: GateLeg, reason: GateReason, detail: string): LegVerdict => ({
+	leg,
+	line: `${leg}: RED (${reason}) — ${detail}`,
+	red: {reason, detail},
+});
+
+/** The scope leg: what the gate is judging over, and the refusal when that is nothing. */
+export const judgeScope = (changed: ReadonlyArray<string>): LegVerdict =>
+	changed.length === 0
+		? red(
+				"scope",
+				"zero-scope",
+				"the change declares no path — a gate that cannot see its own subject proves nothing (ADR 0092)",
+			)
+		: green("scope", `scope: ${changed.length} changed path(s)`);
+
+/** How the floor's cases divide against the arming sidecar. */
+export interface FloorScope {
+	readonly armed: ReadonlyArray<TieredEvalCase>;
+	readonly pending: ReadonlyArray<number>;
+	/** Deterministic cases the sidecar accounts for neither way — an arming decision nobody made. */
+	readonly unaccounted: ReadonlyArray<number>;
+}
+
+/**
+ * Split the corpus's deterministic cases into what the floor runs and what it admits it cannot.
+ *
+ * Graded cases are not this leg's: they carry a written rationale in the corpus provenance and are
+ * the review stage's to run, so they are neither armed nor owed a pending row here.
+ */
+export const floorScope = (
+	cases: ReadonlyArray<TieredEvalCase>,
+	sidecar: FloorCommands,
+): FloorScope => {
+	const armedIds = armedRows(sidecar);
+	const pendingIds = pendingRows(sidecar);
+	const armed: Array<TieredEvalCase> = [];
+	const pending: Array<number> = [];
+	const unaccounted: Array<number> = [];
+	for (const evalCase of cases) {
+		if (evalCase.tier !== "deterministic") continue;
+		if (armedIds.has(evalCase.id)) armed.push(evalCase);
+		else if (pendingIds.has(evalCase.id)) pending.push(evalCase.id);
+		else unaccounted.push(evalCase.id);
+	}
+	return {armed, pending, unaccounted};
+};
+
+/**
+ * The regression floor: 100%, no tolerance and no quarantine over the cases the floor runs.
+ *
+ * `summarizeEvalRows` is the one aggregator and it already reds an empty row set, an `uncheckable`
+ * case and a `flake` — none of which is tolerated into green — so this leg reads its verdict rather
+ * than re-deriving a pass rate the tier already computed.
+ */
+export const judgeFloor = (args: {
+	readonly scope: FloorScope;
+	readonly rows: ReadonlyArray<EvalRow>;
+	readonly deterministicCases: number;
+}): LegVerdict => {
+	if (args.deterministicCases === 0) {
+		return red(
+			"floor",
+			"zero-scope",
+			"the incident corpus carries no deterministic case — the regression floor would measure nothing (ADR 0092)",
+		);
+	}
+	if (args.scope.unaccounted.length > 0) {
+		return red(
+			"floor",
+			"zero-scope",
+			`the arming sidecar accounts for neither running nor deferring case(s) ${args.scope.unaccounted.join(", ")} — a corpus case with no arming decision silently leaves the floor`,
+		);
+	}
+	const pending =
+		args.scope.pending.length === 0
+			? ""
+			: `; ${args.scope.pending.length} case(s) pending arming (${args.scope.pending.join(", ")})`;
+	// An all-pending floor is reported on every run, not red — and the distinction from zero scope is
+	// the one a reader is most likely to collapse. Zero scope is a corpus the gate could not see; this
+	// is a corpus it can see, whose every case carries a committed, written statement of what is owed
+	// before it can run. Nothing failing is being excluded, so this is not the quarantine the ruled
+	// floor forbids — and naming it on every run is what keeps it from being forgotten.
+	if (args.scope.armed.length === 0) {
+		return green("floor", `floor: pending — no incident case is armed to run yet${pending}`);
+	}
+	const summary = summarizeEvalRows(args.rows);
+	if (summary.verdict === "red") {
+		return red(
+			"floor",
+			"regression-floor",
+			`${summary.redReason ?? "the suite is red"} — the floor is 100%, with no tolerance and no quarantine`,
+		);
+	}
+	return green(
+		"floor",
+		`floor: ${summary.total.passed}/${summary.total.cases} armed incident case(s) pass${pending}`,
+	);
+};
+
+/** The latest record per `(stage × surface × model)` cell, by the stamp the record carries. */
+export const latestPerCell = (records: ReadonlyArray<EvalRecord>): ReadonlyArray<EvalRecord> => {
+	const latest = new Map<string, EvalRecord>();
+	for (const record of records) {
+		const key = cellKeyOf(record.payload.cell);
+		const held = latest.get(key);
+		if (held === undefined || held.payload.recordedAt <= record.payload.recordedAt) {
+			latest.set(key, record);
+		}
+	}
+	return [...latest.values()].sort((a, b) =>
+		cellLabel(a.payload.cell).localeCompare(cellLabel(b.payload.cell)),
+	);
+};
+
+/**
+ * The graded leg: verify the recorded head-bound result, and never run anything.
+ *
+ * The resolution is the shared gate-verdict contract's, reused rather than re-invented — latest
+ * result wins per cell, then a refusal when that latest is not bound to the head under gate. A
+ * measurement is re-run at the new head, never re-bound to it.
+ */
+export const judgeGraded = (args: {
+	readonly changedSkills: ReadonlyArray<string>;
+	readonly records: ReadonlyArray<EvalRecord>;
+	readonly head: HeadSha;
+	readonly bar?: number;
+}): LegVerdict => {
+	const bar = args.bar ?? GRADED_BAR;
+	if (args.changedSkills.length === 0) {
+		return green("graded", "graded: n/a — this change touches no fabrika skill");
+	}
+	const skills = args.changedSkills.join(", ");
+	if (args.records.length === 0) {
+		return red(
+			"graded",
+			"missing",
+			`${skills} changed and no eval record was recorded for ${args.head} — absence is never "nothing to check" (#4649 ruling)`,
+		);
+	}
+
+	const latest = latestPerCell(args.records);
+	const atHead = latest.filter((record) => sameHead(record.sha, args.head));
+	if (atHead.length === 0) {
+		const newest = [...latest].sort((a, b) =>
+			a.payload.recordedAt.localeCompare(b.payload.recordedAt),
+		)[latest.length - 1];
+		return red(
+			"graded",
+			"stale",
+			`the newest eval record is bound to ${newest?.sha ?? "an unreadable head"}, not to ${args.head} — re-run the suite at the head under gate, never re-bind (ADR 0253)`,
+		);
+	}
+
+	const unrecordable = atHead.filter((record) => record.outcome !== "RECORDED");
+	if (unrecordable.length > 0) {
+		return red(
+			"graded",
+			"zero-scope",
+			`the record for ${cellLabel(unrecordable[0]?.payload.cell ?? {stage: "?", surface: null, model: "?"})} at ${args.head} is UNRECORDABLE — a run that measured nothing is broken, not green (ADR 0092)`,
+		);
+	}
+
+	const below = atHead.filter((record) => roundRate(record.payload.passRate) < bar);
+	if (below.length > 0) {
+		const worst = below
+			.map((record) => `${cellLabel(record.payload.cell)} at ${record.payload.passRate}`)
+			.join(", ");
+		return red("graded", "below-bar", `${worst} — the ruled bar is ${bar} (#4637 ruling 2)`);
+	}
+	return green(
+		"graded",
+		`graded: ${atHead.length} cell(s) recorded at ${args.head}, all at or above ${bar} (skills: ${skills})`,
+	);
+};
+
+/** What the spend leg was handed: a comparison, or the named reason there is none to make. */
+export type SpendInput =
+	| {readonly _tag: "Compared"; readonly comparison: BaselineComparison}
+	| {readonly _tag: "NoLedger"; readonly path: string}
+	| {readonly _tag: "NoBaseline"; readonly dir: string};
+
+/**
+ * The spend leg: at or below the committed v1 baseline on the same corpus (#4637 ruling 3).
+ *
+ * `incomparable` reds with the others rather than beside them — it is what stops a candidate that
+ * quietly priced a different case set from reading as a cheaper one — and its detail says which of
+ * the two it was, since the remedies differ (a cost regression to fix, versus a measurement to redo).
+ *
+ * A missing ledger is **not** a red. The ledger is a suite run's artifact and CI runs no suite, so
+ * its absence means no candidate spend was measured on this change — reported by name, never folded
+ * into a pass. A ledger with no baseline to price it against is the other way round and reds: a
+ * measurement with no ceiling cannot be judged.
+ */
+export const judgeSpend = (input: SpendInput): LegVerdict => {
+	if (input._tag === "NoLedger") {
+		return green(
+			"spend",
+			`spend: not-priced — no candidate spend ledger at ${input.path}; CI runs no suite of its own`,
+		);
+	}
+	if (input._tag === "NoBaseline") {
+		return red(
+			"spend",
+			"zero-scope",
+			`a candidate spend ledger was read and ${input.dir} carries no committed v1 baseline to price it against`,
+		);
+	}
+	const {comparison} = input;
+	if (comparison.verdict === "at-or-below") {
+		return green(
+			"spend",
+			`spend: at-or-below — ${comparison.candidateBilled} billed against the v1 baseline's ${comparison.baselineBilled}`,
+		);
+	}
+	return red(
+		"spend",
+		"over-baseline",
+		`${comparison.verdict}: ${comparison.reason} (#4679 prices the same corpus on both sides)`,
+	);
+};
+
+export interface GateVerdict {
+	readonly verdict: "green" | "red";
+	readonly reds: ReadonlyArray<GateRed>;
+	/** The seat `$?` carries: the highest-precedence red, or `0`. */
+	readonly code: number;
+	readonly legs: ReadonlyArray<LegVerdict>;
+	/** The advisory trend lines. They never change `verdict` or `code` (ADR 0252 §4). */
+	readonly advisories: ReadonlyArray<string>;
+}
+
+/** Fold the legs into one answer. Every red is carried; one of them seats the exit code. */
+export const decideGate = (args: {
+	readonly legs: ReadonlyArray<LegVerdict>;
+	readonly trend?: ReadonlyArray<TrendReading>;
+}): GateVerdict => {
+	const reds = args.legs.flatMap((leg) => (leg.red === null ? [] : [leg.red]));
+	const seat = REASON_PRECEDENCE.find((reason) => reds.some((r) => r.reason === reason));
+	const advisories = (args.trend ?? []).map((reading) =>
+		renderTrendLine(reading.series, reading.result),
+	);
+	return {
+		verdict: reds.length === 0 ? "green" : "red",
+		reds,
+		code: seat === undefined ? 0 : REASON_CODES[seat],
+		legs: args.legs,
+		advisories,
+	};
+};
+
+/** The human report — one line per leg, then the advisories, then the verdict. */
+export const renderGate = (verdict: GateVerdict): string =>
+	[
+		"fabrika eval gate — the #4637-B bar (100% floor · 90% graded · spend ≤ v1 baseline)",
+		...verdict.legs.map((leg) => leg.line),
+		...verdict.advisories,
+		verdict.verdict === "green"
+			? "gate: GREEN — every ruled leg of the bar is met"
+			: `gate: RED — ${verdict.reds.map((r) => r.reason).join(", ")}`,
+	].join("\n");
+
+/** The machine-readable form, for a caller that wants the reasons without parsing prose. */
+export const gateToJson = (verdict: GateVerdict): string =>
+	`${JSON.stringify(
+		{
+			verdict: verdict.verdict,
+			code: verdict.code,
+			bar: {graded: GRADED_BAR, floor: 1, adr: 4637},
+			reds: verdict.reds,
+			legs: verdict.legs.map((leg) => ({leg: leg.leg, line: leg.line, red: leg.red})),
+			advisories: verdict.advisories,
+		},
+		null,
+		2,
+	)}\n`;

--- a/packages/fabrika-cli/src/eval/gate.unit.test.ts
+++ b/packages/fabrika-cli/src/eval/gate.unit.test.ts
@@ -1,0 +1,406 @@
+/**
+ * Every red condition of the merge gate, and the two that are easiest to get wrong in the safe
+ * direction: zero scope, and the path filter.
+ *
+ * The filter test is the #4604 reproduction. That incident was a `packages/`-anchored path filter
+ * that excluded the skills directory, so a skill change matched nothing and the gate reported green
+ * over it — a mistake that presents as a pass. Here the same decision is run twice over the same
+ * changed-path set, once under the shipped filter and once under a deliberately mis-scoped one, and
+ * the assertion is that the mis-scoped run turns a `missing` red into a pass. That is the property
+ * worth holding: not that the filter matches, but that a wrong filter is *visible* as the difference
+ * between a red and a green.
+ */
+import {describe, expect, it} from "vitest";
+import {type EvalRecord, read as readEvalRecord} from "../wire/eval-record.ts";
+import {headSha} from "../wire/verdict-marker.ts";
+import {
+	ABOVE_BASELINE,
+	BELOW_BAR,
+	MISSING_RESULT,
+	REGRESSION_FLOOR,
+	STALE_HEAD,
+	ZERO_SCOPE,
+} from "./codes.ts";
+import type {BaselineComparison} from "./cost-baseline.ts";
+import type {EvalRow, TieredEvalCase} from "./deterministic-tier.ts";
+import type {FloorCommands} from "./floor-commands.ts";
+import {
+	changedSkills,
+	decideGate,
+	floorScope,
+	GRADED_BAR,
+	judgeFloor,
+	judgeGraded,
+	judgeScope,
+	judgeSpend,
+	latestPerCell,
+	renderGate,
+	SKILL_PATH_PREFIXES,
+} from "./gate.ts";
+
+const HEAD = "03135b91aa04f7e2c9d8b1640a5c22e9f01b7d3c";
+const OLDER = "7be402c1d3e5f60718293a4b5c6d7e8f90a1b2c3";
+
+const head = (raw: string) => {
+	const sha = headSha(raw);
+	if (sha === null) throw new Error(`fixture ${raw} is not a head sha`);
+	return sha;
+};
+
+/** Compose a record through the wire format and read it back, so no fixture can be an invalid one. */
+const record = (args: {
+	sha: string;
+	recordedAt: string;
+	stage?: string;
+	surface?: string | null;
+	model?: string;
+	passed: number;
+	graded: number;
+}): EvalRecord => {
+	const cases = Array.from({length: args.graded}, (_, index) => {
+		const passes = index < args.passed;
+		return {
+			caseId: index + 1,
+			verdict: passes ? "pass" : "fail",
+			runs: 5,
+			passed: passes ? 5 : 0,
+			noVerdict: 0,
+			dispersion: 0,
+			perRun: Array.from({length: 5}, () => (passes ? "pass" : "fail")),
+		};
+	});
+	const rate = args.graded === 0 ? 0 : Math.round((args.passed / args.graded) * 10_000) / 10_000;
+	const outcome = args.graded === 0 ? "UNRECORDABLE" : "RECORDED";
+	const text = [
+		`eval: ${outcome} @ ${args.sha} — a graded run`,
+		"",
+		"```json",
+		JSON.stringify(
+			{
+				sha: args.sha,
+				recordedAt: args.recordedAt,
+				cell: {
+					stage: args.stage ?? "review",
+					surface: args.surface ?? null,
+					model: args.model ?? "claude-opus-4-8",
+				},
+				pins: {model: args.model ?? "claude-opus-4-8", cli: "2.1.227", harness: "0.1.0"},
+				gradedRuns: args.graded,
+				passedRuns: args.passed,
+				unmeasuredCases: 0,
+				passRate: rate,
+				cases,
+			},
+			null,
+			2,
+		),
+		"```",
+		"",
+	].join("\n");
+	const parsed = readEvalRecord(text);
+	if (parsed._tag !== "Found") throw new Error(`fixture is not a record: ${parsed.reason}`);
+	return parsed.value;
+};
+
+const mechanicalCase = (id: number): TieredEvalCase => ({
+	id,
+	tier: "deterministic",
+	assertions: [{kind: "mechanical", text: "The check exits 0.", cue: "exit-status"}],
+});
+
+const sidecar = (rows: FloorCommands["rows"]): FloorCommands => ({
+	corpus: "fixture",
+	rows,
+});
+
+const armed = (id: number) => ({status: "armed" as const, caseId: id, command: "true", args: []});
+
+const pending = (id: number) => ({
+	status: "pending" as const,
+	caseId: id,
+	pendingReason: "no CLI-layer command exists for it yet",
+});
+
+const row = (id: number, outcome: EvalRow["outcome"]): EvalRow => ({
+	caseId: id,
+	tier: "deterministic",
+	outcome,
+	runs: 1,
+	assertions: [],
+	detail: outcome === "pass" ? null : "the case did not pass",
+});
+
+const comparison = (verdict: BaselineComparison["verdict"]): BaselineComparison => ({
+	verdict,
+	reason: `the candidate is ${verdict}`,
+	baselineBilled: 100,
+	candidateBilled: verdict === "above" ? 200 : 50,
+	deltaBilled: verdict === "incomparable" ? null : -50,
+});
+
+describe("the skill path filter (the #4604 reproduction)", () => {
+	const changed = [
+		"claude-plugins/fabrika/skills/triage/SKILL.md",
+		"packages/fabrika-cli/src/eval/gate.ts",
+	];
+
+	it("sees the skills directory the shipped filter is anchored on", () => {
+		expect(changedSkills(changed)).toEqual(["triage"]);
+	});
+
+	it("reds `missing` on a skill change with no recorded result", () => {
+		const verdict = judgeGraded({
+			changedSkills: changedSkills(changed),
+			records: [],
+			head: head(HEAD),
+		});
+		expect(verdict.red?.reason).toBe("missing");
+	});
+
+	it("turns that red into a PASS under a mis-scoped filter — the mistake presents as a green", () => {
+		// #4604's own shape: a filter anchored inside `packages/` that never reaches a skills directory.
+		const misScoped = changedSkills(changed, ["packages/pipeline-cli/src/"]);
+		expect(misScoped).toEqual([]);
+		const verdict = judgeGraded({changedSkills: misScoped, records: [], head: head(HEAD)});
+		expect(verdict.red).toBeNull();
+		expect(verdict.line).toContain("n/a");
+	});
+
+	it("anchors on the fabrika skills directory, not on a package path", () => {
+		expect(SKILL_PATH_PREFIXES).toContain("claude-plugins/fabrika/skills/");
+		expect(changedSkills(["claude-plugins/fabrika/skills/ship/contract.md"])).toEqual(["ship"]);
+		expect(changedSkills(["claude-plugins/fabrika/docs/cost-baseline.md"])).toEqual([]);
+	});
+});
+
+describe("zero scope", () => {
+	it("reds when the change declares no path", () => {
+		expect(judgeScope([]).red?.reason).toBe("zero-scope");
+	});
+
+	it("reds when the corpus carries no deterministic case", () => {
+		const verdict = judgeFloor({
+			scope: {armed: [], pending: [], unaccounted: []},
+			rows: [],
+			deterministicCases: 0,
+		});
+		expect(verdict.red?.reason).toBe("zero-scope");
+	});
+
+	it("reds when a corpus case is neither armed nor deferred in writing", () => {
+		const scope = floorScope([mechanicalCase(1)], sidecar([]));
+		expect(scope.unaccounted).toEqual([1]);
+		const verdict = judgeFloor({scope, rows: [], deterministicCases: 1});
+		expect(verdict.red?.reason).toBe("zero-scope");
+	});
+
+	it("reds when a candidate ledger has no committed baseline to price it against", () => {
+		expect(judgeSpend({_tag: "NoBaseline", dir: "reports/eval"}).red?.reason).toBe("zero-scope");
+	});
+});
+
+describe("the regression floor", () => {
+	it("reds when an armed case does not pass — no tolerance", () => {
+		const scope = floorScope([mechanicalCase(1), mechanicalCase(2)], sidecar([armed(1), armed(2)]));
+		const verdict = judgeFloor({
+			scope,
+			rows: [row(1, "pass"), row(2, "fail")],
+			deterministicCases: 2,
+		});
+		expect(verdict.red?.reason).toBe("regression-floor");
+		expect(verdict.line).toContain("no tolerance and no quarantine");
+	});
+
+	it("reds an `uncheckable` armed case too — a case defect is never green", () => {
+		const scope = floorScope([mechanicalCase(1)], sidecar([armed(1)]));
+		const verdict = judgeFloor({scope, rows: [row(1, "uncheckable")], deterministicCases: 1});
+		expect(verdict.red?.reason).toBe("regression-floor");
+	});
+
+	it("passes when every armed case passes, and still names what is pending", () => {
+		const scope = floorScope(
+			[mechanicalCase(1), mechanicalCase(2)],
+			sidecar([armed(1), pending(2)]),
+		);
+		const verdict = judgeFloor({scope, rows: [row(1, "pass")], deterministicCases: 2});
+		expect(verdict.red).toBeNull();
+		expect(verdict.line).toContain("1/1");
+		expect(verdict.line).toContain("pending arming (2)");
+	});
+
+	it("reports an all-pending floor rather than reding, and says so on every run", () => {
+		const scope = floorScope([mechanicalCase(1)], sidecar([pending(1)]));
+		const verdict = judgeFloor({scope, rows: [], deterministicCases: 1});
+		expect(verdict.red).toBeNull();
+		expect(verdict.line).toContain("no incident case is armed to run yet");
+	});
+});
+
+describe("the graded leg verifies the recorded head-bound result", () => {
+	const skills = ["triage"];
+
+	it("reds `missing` when nothing was recorded at all", () => {
+		expect(judgeGraded({changedSkills: skills, records: [], head: head(HEAD)}).red?.reason).toBe(
+			"missing",
+		);
+	});
+
+	it("reds `stale` when the newest record is bound to an older commit", () => {
+		const verdict = judgeGraded({
+			changedSkills: skills,
+			records: [record({sha: OLDER, recordedAt: "2026-08-11T00:00:00Z", passed: 10, graded: 10})],
+			head: head(HEAD),
+		});
+		expect(verdict.red?.reason).toBe("stale");
+		expect(verdict.line).toContain(OLDER);
+	});
+
+	it("reds `below-bar` on a recorded rate under the ruled bar", () => {
+		const verdict = judgeGraded({
+			changedSkills: skills,
+			records: [record({sha: HEAD, recordedAt: "2026-08-11T00:00:00Z", passed: 8, graded: 10})],
+			head: head(HEAD),
+		});
+		expect(verdict.red?.reason).toBe("below-bar");
+		expect(verdict.line).toContain(String(GRADED_BAR));
+	});
+
+	it("passes a rate exactly at the bar — the bar is `at or above`", () => {
+		const verdict = judgeGraded({
+			changedSkills: skills,
+			records: [record({sha: HEAD, recordedAt: "2026-08-11T00:00:00Z", passed: 9, graded: 10})],
+			head: head(HEAD),
+		});
+		expect(verdict.red).toBeNull();
+	});
+
+	it("reds an UNRECORDABLE record as zero scope — a broken run is not a below-bar number", () => {
+		const verdict = judgeGraded({
+			changedSkills: skills,
+			records: [record({sha: HEAD, recordedAt: "2026-08-11T00:00:00Z", passed: 0, graded: 0})],
+			head: head(HEAD),
+		});
+		expect(verdict.red?.reason).toBe("zero-scope");
+		expect(verdict.line).toContain("UNRECORDABLE");
+	});
+
+	it("takes the latest record per cell, so a re-run at the same head supersedes", () => {
+		const older = record({sha: HEAD, recordedAt: "2026-08-11T00:00:00Z", passed: 5, graded: 10});
+		const newer = record({sha: HEAD, recordedAt: "2026-08-11T09:00:00Z", passed: 10, graded: 10});
+		expect(latestPerCell([older, newer])).toEqual([newer]);
+		expect(
+			judgeGraded({changedSkills: skills, records: [older, newer], head: head(HEAD)}).red,
+		).toBeNull();
+	});
+
+	it("is n/a when no fabrika skill changed", () => {
+		const verdict = judgeGraded({changedSkills: [], records: [], head: head(HEAD)});
+		expect(verdict.red).toBeNull();
+		expect(verdict.line).toContain("n/a");
+	});
+});
+
+describe("the spend leg", () => {
+	it("reds above the committed v1 baseline", () => {
+		expect(judgeSpend({_tag: "Compared", comparison: comparison("above")}).red?.reason).toBe(
+			"over-baseline",
+		);
+	});
+
+	it("reds `incomparable` too — it is never read as a cheaper run", () => {
+		const verdict = judgeSpend({_tag: "Compared", comparison: comparison("incomparable")});
+		expect(verdict.red?.reason).toBe("over-baseline");
+		expect(verdict.line).toContain("incomparable");
+	});
+
+	it("passes at or below the baseline", () => {
+		expect(judgeSpend({_tag: "Compared", comparison: comparison("at-or-below")}).red).toBeNull();
+	});
+
+	it("names an unmeasured change rather than folding it into a pass", () => {
+		const verdict = judgeSpend({_tag: "NoLedger", path: ".fabrika/spend-ledger.jsonl"});
+		expect(verdict.red).toBeNull();
+		expect(verdict.line).toContain("not-priced");
+	});
+});
+
+describe("the folded verdict", () => {
+	it("is green only when no leg raised a red", () => {
+		const verdict = decideGate({
+			legs: [judgeScope(["a.ts"]), judgeSpend({_tag: "NoLedger", path: "x"})],
+		});
+		expect(verdict.verdict).toBe("green");
+		expect(verdict.code).toBe(0);
+	});
+
+	it("carries every red and seats the exit code on the highest-precedence one", () => {
+		const verdict = decideGate({
+			legs: [
+				judgeScope([]),
+				judgeGraded({changedSkills: ["triage"], records: [], head: head(HEAD)}),
+				judgeSpend({_tag: "Compared", comparison: comparison("above")}),
+			],
+		});
+		expect(verdict.reds.map((r) => r.reason)).toEqual(["zero-scope", "missing", "over-baseline"]);
+		expect(verdict.code).toBe(ZERO_SCOPE);
+	});
+
+	it("seats each reason on the code its group already means it by", () => {
+		const seat = (legs: Parameters<typeof decideGate>[0]["legs"]) => decideGate({legs}).code;
+		expect(seat([judgeGraded({changedSkills: ["t"], records: [], head: head(HEAD)})])).toBe(
+			MISSING_RESULT,
+		);
+		expect(
+			seat([
+				judgeGraded({
+					changedSkills: ["t"],
+					records: [record({sha: OLDER, recordedAt: "2026-08-11T00:00:00Z", passed: 1, graded: 1})],
+					head: head(HEAD),
+				}),
+			]),
+		).toBe(STALE_HEAD);
+		expect(
+			seat([
+				judgeGraded({
+					changedSkills: ["t"],
+					records: [record({sha: HEAD, recordedAt: "2026-08-11T00:00:00Z", passed: 1, graded: 2})],
+					head: head(HEAD),
+				}),
+			]),
+		).toBe(BELOW_BAR);
+		expect(
+			seat([
+				judgeFloor({
+					scope: floorScope([mechanicalCase(1)], sidecar([armed(1)])),
+					rows: [row(1, "fail")],
+					deterministicCases: 1,
+				}),
+			]),
+		).toBe(REGRESSION_FLOOR);
+		expect(seat([judgeSpend({_tag: "Compared", comparison: comparison("above")})])).toBe(
+			ABOVE_BASELINE,
+		);
+	});
+
+	it("reports the trend and never lets it change the verdict", () => {
+		const declining = {
+			series: {
+				key: "k",
+				cell: {stage: "review", surface: null, model: "m"},
+				points: [],
+			},
+			result: {
+				answer: "declining" as const,
+				window: null,
+				olderCount: 3,
+				newerCount: 3,
+				meanDrop: 0.2,
+				separated: true,
+				reason: "the halves do not overlap",
+			},
+		};
+		const verdict = decideGate({legs: [judgeScope(["a.ts"])], trend: [declining]});
+		expect(verdict.verdict).toBe("green");
+		expect(renderGate(verdict)).toContain("trend: declining");
+	});
+});

--- a/packages/fabrika-cli/src/eval/gate.unit.test.ts
+++ b/packages/fabrika-cli/src/eval/gate.unit.test.ts
@@ -9,6 +9,12 @@
  * the assertion is that the mis-scoped run turns a `missing` red into a pass. That is the property
  * worth holding: not that the filter matches, but that a wrong filter is *visible* as the difference
  * between a red and a green.
+ *
+ * **Which assertion catches a broken shipped filter — do not delete the siblings.** That
+ * parameterised test passes its filter in explicitly, so it documents the failure mode and would
+ * still pass if `SKILL_PATH_PREFIXES` were re-anchored wrong. The three assertions beside it are the
+ * guard: `changedSkills(changed)` equals `["triage"]`, the same input reds `missing`, and
+ * `SKILL_PATH_PREFIXES` contains the skills directory. Break the constant and those three go red.
  */
 import {describe, expect, it} from "vitest";
 import {type EvalRecord, read as readEvalRecord} from "../wire/eval-record.ts";
@@ -29,6 +35,7 @@ import {
 	decideGate,
 	floorScope,
 	GRADED_BAR,
+	gateToJson,
 	judgeFloor,
 	judgeGraded,
 	judgeScope,
@@ -36,6 +43,7 @@ import {
 	latestPerCell,
 	renderGate,
 	SKILL_PATH_PREFIXES,
+	unmeasuredLegs,
 } from "./gate.ts";
 
 const HEAD = "03135b91aa04f7e2c9d8b1640a5c22e9f01b7d3c";
@@ -228,10 +236,12 @@ describe("the regression floor", () => {
 		expect(verdict.line).toContain("pending arming (2)");
 	});
 
-	it("reports an all-pending floor rather than reding, and says so on every run", () => {
+	it("reports an all-pending floor as NOT MEASURED rather than reding, and says so on every run", () => {
 		const scope = floorScope([mechanicalCase(1)], sidecar([pending(1)]));
 		const verdict = judgeFloor({scope, rows: [], deterministicCases: 1});
 		expect(verdict.red).toBeNull();
+		expect(verdict.status).toBe("unmeasured");
+		expect(verdict.line).toContain("NOT MEASURED");
 		expect(verdict.line).toContain("no incident case is armed to run yet");
 	});
 });
@@ -243,6 +253,24 @@ describe("the graded leg verifies the recorded head-bound result", () => {
 		expect(judgeGraded({changedSkills: skills, records: [], head: head(HEAD)}).red?.reason).toBe(
 			"missing",
 		);
+	});
+
+	it("names the cure and the run site on both skip-path reds — neither is terminal, neither is the lane's", () => {
+		const missing = judgeGraded({changedSkills: skills, records: [], head: head(HEAD)});
+		const stale = judgeGraded({
+			changedSkills: skills,
+			records: [record({sha: OLDER, recordedAt: "2026-08-11T00:00:00Z", passed: 10, graded: 10})],
+			head: head(HEAD),
+		});
+		for (const verdict of [missing, stale]) {
+			expect(verdict.line).toContain("cure:");
+			expect(verdict.line).toContain("plain, non-worktree session");
+			expect(verdict.line).toContain("never inside a build lane");
+			expect(verdict.line).toContain("hands the measurement off");
+		}
+		// #5406 is the whole reason the site has to be named: the lane's harness refuses the runner, so
+		// "re-run the suite" without a site is an instruction the lane cannot follow.
+		expect(stale.line).toContain("#5406");
 	});
 
 	it("reds `stale` when the newest record is bound to an older commit", () => {
@@ -293,9 +321,10 @@ describe("the graded leg verifies the recorded head-bound result", () => {
 		).toBeNull();
 	});
 
-	it("is n/a when no fabrika skill changed", () => {
+	it("is n/a when no fabrika skill changed — unmeasured, not passed", () => {
 		const verdict = judgeGraded({changedSkills: [], records: [], head: head(HEAD)});
 		expect(verdict.red).toBeNull();
+		expect(verdict.status).toBe("unmeasured");
 		expect(verdict.line).toContain("n/a");
 	});
 });
@@ -320,7 +349,74 @@ describe("the spend leg", () => {
 	it("names an unmeasured change rather than folding it into a pass", () => {
 		const verdict = judgeSpend({_tag: "NoLedger", path: ".fabrika/spend-ledger.jsonl"});
 		expect(verdict.red).toBeNull();
+		expect(verdict.status).toBe("unmeasured");
 		expect(verdict.line).toContain("not-priced");
+	});
+});
+
+/**
+ * The reporting-side half of the #4604 shape: not a filter that saw nothing, but a summary that
+ * reported health it never measured. These assertions are what stop the summary sentence drifting
+ * back to one that a reader of a green check would take as an enforcement.
+ */
+describe("the summary never claims a bar it did not measure", () => {
+	const unarmedFloor = judgeFloor({
+		scope: floorScope([mechanicalCase(1)], sidecar([pending(1)])),
+		rows: [],
+		deterministicCases: 1,
+	});
+
+	it("says NOT FULLY MEASURED, and names each unmeasured leg, when a leg measured nothing", () => {
+		const verdict = decideGate({
+			legs: [
+				judgeScope(["a.ts"]),
+				unarmedFloor,
+				judgeGraded({changedSkills: [], records: [], head: head(HEAD)}),
+				judgeSpend({_tag: "NoLedger", path: ".fabrika/spend-ledger.jsonl"}),
+			],
+		});
+		const report = renderGate(verdict);
+		expect(verdict.verdict).toBe("green");
+		expect(report).not.toContain("every ruled leg");
+		expect(report).toContain("gate: NOT FULLY MEASURED");
+		expect(report).toContain("3 of 4 leg(s) measured NOTHING");
+		expect(report).toContain("0 of 1 incident case(s) armed");
+		expect(report).toContain("n/a — this change touches no fabrika skill");
+		expect(report).toContain("not-priced");
+		expect(report).toContain("Measured and met: scope");
+	});
+
+	it("says the bar was measured and met only when every leg measured", () => {
+		const scope = floorScope([mechanicalCase(1)], sidecar([armed(1)]));
+		const verdict = decideGate({
+			legs: [
+				judgeScope(["a.ts"]),
+				judgeFloor({scope, rows: [row(1, "pass")], deterministicCases: 1}),
+				judgeGraded({
+					changedSkills: ["triage"],
+					records: [
+						record({sha: HEAD, recordedAt: "2026-08-11T00:00:00Z", passed: 10, graded: 10}),
+					],
+					head: head(HEAD),
+				}),
+				judgeSpend({_tag: "Compared", comparison: comparison("at-or-below")}),
+			],
+		});
+		const report = renderGate(verdict);
+		expect(unmeasuredLegs(verdict)).toEqual([]);
+		expect(report).toContain("all 4 leg(s) of the ruled bar were measured and met");
+		expect(report).not.toContain("NOT MEASURED");
+	});
+
+	it("carries the unmeasured legs into the JSON form too, beside the reds", () => {
+		const verdict = decideGate({legs: [judgeScope(["a.ts"]), unarmedFloor]});
+		const parsed = JSON.parse(gateToJson(verdict));
+		expect(parsed.reds).toEqual([]);
+		expect(parsed.unmeasured).toHaveLength(1);
+		expect(parsed.legs.map((leg: {status: string}) => leg.status)).toEqual([
+			"measured",
+			"unmeasured",
+		]);
 	});
 });
 

--- a/packages/fabrika-cli/src/eval/incident-corpus/commands.json
+++ b/packages/fabrika-cli/src/eval/incident-corpus/commands.json
@@ -1,0 +1,85 @@
+{
+	"corpus": "fabrika-incident-corpus",
+	"rows": [
+		{
+			"status": "pending",
+			"caseId": 1,
+			"pendingReason": "Not runnable at the deterministic tier: 2 of 3 authored assertions name no quoted expected output, so readExpectation cannot read them, and no CLI-layer command is committed for the case. Arming it is #5431."
+		},
+		{
+			"status": "pending",
+			"caseId": 2,
+			"pendingReason": "Not runnable at the deterministic tier: 2 of 3 authored assertions name no quoted expected output, so readExpectation cannot read them, and no CLI-layer command is committed for the case. Arming it is #5431."
+		},
+		{
+			"status": "pending",
+			"caseId": 3,
+			"pendingReason": "Not runnable at the deterministic tier: 1 of 3 authored assertions name no quoted expected output, so readExpectation cannot read them, and no CLI-layer command is committed for the case. Arming it is #5431."
+		},
+		{
+			"status": "pending",
+			"caseId": 4,
+			"pendingReason": "Not runnable at the deterministic tier: 2 of 3 authored assertions name no quoted expected output, so readExpectation cannot read them, and no CLI-layer command is committed for the case. Arming it is #5431."
+		},
+		{
+			"status": "pending",
+			"caseId": 5,
+			"pendingReason": "Not runnable at the deterministic tier: every authored assertion reads into a concrete expectation, and no CLI-layer command is committed for the case. Arming it is #5431."
+		},
+		{
+			"status": "pending",
+			"caseId": 6,
+			"pendingReason": "Not runnable at the deterministic tier: 1 of 3 authored assertions name no quoted expected output, so readExpectation cannot read them, and no CLI-layer command is committed for the case. Arming it is #5431."
+		},
+		{
+			"status": "pending",
+			"caseId": 7,
+			"pendingReason": "Not runnable at the deterministic tier: 1 of 3 authored assertions name no quoted expected output, so readExpectation cannot read them, and no CLI-layer command is committed for the case. Arming it is #5431."
+		},
+		{
+			"status": "pending",
+			"caseId": 8,
+			"pendingReason": "Not runnable at the deterministic tier: 2 of 3 authored assertions name no quoted expected output, so readExpectation cannot read them, and no CLI-layer command is committed for the case. Arming it is #5431."
+		},
+		{
+			"status": "pending",
+			"caseId": 10,
+			"pendingReason": "Not runnable at the deterministic tier: 1 of 3 authored assertions name no quoted expected output, so readExpectation cannot read them, and no CLI-layer command is committed for the case. Arming it is #5431."
+		},
+		{
+			"status": "pending",
+			"caseId": 11,
+			"pendingReason": "Not runnable at the deterministic tier: 2 of 3 authored assertions name no quoted expected output, so readExpectation cannot read them, and no CLI-layer command is committed for the case. Arming it is #5431."
+		},
+		{
+			"status": "pending",
+			"caseId": 12,
+			"pendingReason": "Not runnable at the deterministic tier: 2 of 3 authored assertions name no quoted expected output, so readExpectation cannot read them, and no CLI-layer command is committed for the case. Arming it is #5431."
+		},
+		{
+			"status": "pending",
+			"caseId": 13,
+			"pendingReason": "Not runnable at the deterministic tier: 1 of 3 authored assertions name no quoted expected output, so readExpectation cannot read them, and no CLI-layer command is committed for the case. Arming it is #5431."
+		},
+		{
+			"status": "pending",
+			"caseId": 14,
+			"pendingReason": "Not runnable at the deterministic tier: 1 of 3 authored assertions name no quoted expected output, so readExpectation cannot read them, and no CLI-layer command is committed for the case. Arming it is #5431."
+		},
+		{
+			"status": "pending",
+			"caseId": 15,
+			"pendingReason": "Not runnable at the deterministic tier: 1 of 3 authored assertions name no quoted expected output, so readExpectation cannot read them, and no CLI-layer command is committed for the case. Arming it is #5431."
+		},
+		{
+			"status": "pending",
+			"caseId": 16,
+			"pendingReason": "Not runnable at the deterministic tier: 2 of 3 authored assertions name no quoted expected output, so readExpectation cannot read them, and no CLI-layer command is committed for the case. Arming it is #5431."
+		},
+		{
+			"status": "pending",
+			"caseId": 17,
+			"pendingReason": "Not runnable at the deterministic tier: 2 of 3 authored assertions name no quoted expected output, so readExpectation cannot read them, and no CLI-layer command is committed for the case. Arming it is #5431."
+		}
+	]
+}

--- a/packages/fabrika-cli/src/eval/incident-corpus/commands.json
+++ b/packages/fabrika-cli/src/eval/incident-corpus/commands.json
@@ -4,82 +4,82 @@
 		{
 			"status": "pending",
 			"caseId": 1,
-			"pendingReason": "Not runnable at the deterministic tier: 2 of 3 authored assertions name no quoted expected output, so readExpectation cannot read them, and no CLI-layer command is committed for the case. Arming it is #5431."
+			"pendingReason": "Not runnable at the deterministic tier: 2 of 3 authored assertions name no quoted expected output, so readExpectation cannot read them, and no CLI-layer command is committed for the case. Owed: re-word those 2 expectations in this directory's evals.json so each quotes an observable, then commit an armed row here naming the command the case runs. Tracked on #5431."
 		},
 		{
 			"status": "pending",
 			"caseId": 2,
-			"pendingReason": "Not runnable at the deterministic tier: 2 of 3 authored assertions name no quoted expected output, so readExpectation cannot read them, and no CLI-layer command is committed for the case. Arming it is #5431."
+			"pendingReason": "Not runnable at the deterministic tier: 2 of 3 authored assertions name no quoted expected output, so readExpectation cannot read them, and no CLI-layer command is committed for the case. Owed: re-word those 2 expectations in this directory's evals.json so each quotes an observable, then commit an armed row here naming the command the case runs. Tracked on #5431."
 		},
 		{
 			"status": "pending",
 			"caseId": 3,
-			"pendingReason": "Not runnable at the deterministic tier: 1 of 3 authored assertions name no quoted expected output, so readExpectation cannot read them, and no CLI-layer command is committed for the case. Arming it is #5431."
+			"pendingReason": "Not runnable at the deterministic tier: 1 of 3 authored assertions names no quoted expected output, so readExpectation cannot read it, and no CLI-layer command is committed for the case. Owed: re-word that expectation in this directory's evals.json so it quotes an observable, then commit an armed row here naming the command the case runs. Tracked on #5431."
 		},
 		{
 			"status": "pending",
 			"caseId": 4,
-			"pendingReason": "Not runnable at the deterministic tier: 2 of 3 authored assertions name no quoted expected output, so readExpectation cannot read them, and no CLI-layer command is committed for the case. Arming it is #5431."
+			"pendingReason": "Not runnable at the deterministic tier: 2 of 3 authored assertions name no quoted expected output, so readExpectation cannot read them, and no CLI-layer command is committed for the case. Owed: re-word those 2 expectations in this directory's evals.json so each quotes an observable, then commit an armed row here naming the command the case runs. Tracked on #5431."
 		},
 		{
 			"status": "pending",
 			"caseId": 5,
-			"pendingReason": "Not runnable at the deterministic tier: every authored assertion reads into a concrete expectation, and no CLI-layer command is committed for the case. Arming it is #5431."
+			"pendingReason": "Not runnable at the deterministic tier: every authored assertion already reads into a concrete expectation; what is missing is only the CLI-layer command. Owed: commit an armed row here naming the command the case runs — no evals.json edit is needed for this one. Tracked on #5431."
 		},
 		{
 			"status": "pending",
 			"caseId": 6,
-			"pendingReason": "Not runnable at the deterministic tier: 1 of 3 authored assertions name no quoted expected output, so readExpectation cannot read them, and no CLI-layer command is committed for the case. Arming it is #5431."
+			"pendingReason": "Not runnable at the deterministic tier: 1 of 3 authored assertions names no quoted expected output, so readExpectation cannot read it, and no CLI-layer command is committed for the case. Owed: re-word that expectation in this directory's evals.json so it quotes an observable, then commit an armed row here naming the command the case runs. Tracked on #5431."
 		},
 		{
 			"status": "pending",
 			"caseId": 7,
-			"pendingReason": "Not runnable at the deterministic tier: 1 of 3 authored assertions name no quoted expected output, so readExpectation cannot read them, and no CLI-layer command is committed for the case. Arming it is #5431."
+			"pendingReason": "Not runnable at the deterministic tier: 1 of 3 authored assertions names no quoted expected output, so readExpectation cannot read it, and no CLI-layer command is committed for the case. Owed: re-word that expectation in this directory's evals.json so it quotes an observable, then commit an armed row here naming the command the case runs. Tracked on #5431."
 		},
 		{
 			"status": "pending",
 			"caseId": 8,
-			"pendingReason": "Not runnable at the deterministic tier: 2 of 3 authored assertions name no quoted expected output, so readExpectation cannot read them, and no CLI-layer command is committed for the case. Arming it is #5431."
+			"pendingReason": "Not runnable at the deterministic tier: 2 of 3 authored assertions name no quoted expected output, so readExpectation cannot read them, and no CLI-layer command is committed for the case. Owed: re-word those 2 expectations in this directory's evals.json so each quotes an observable, then commit an armed row here naming the command the case runs. Tracked on #5431."
 		},
 		{
 			"status": "pending",
 			"caseId": 10,
-			"pendingReason": "Not runnable at the deterministic tier: 1 of 3 authored assertions name no quoted expected output, so readExpectation cannot read them, and no CLI-layer command is committed for the case. Arming it is #5431."
+			"pendingReason": "Not runnable at the deterministic tier: 1 of 3 authored assertions names no quoted expected output, so readExpectation cannot read it, and no CLI-layer command is committed for the case. Owed: re-word that expectation in this directory's evals.json so it quotes an observable, then commit an armed row here naming the command the case runs. Tracked on #5431."
 		},
 		{
 			"status": "pending",
 			"caseId": 11,
-			"pendingReason": "Not runnable at the deterministic tier: 2 of 3 authored assertions name no quoted expected output, so readExpectation cannot read them, and no CLI-layer command is committed for the case. Arming it is #5431."
+			"pendingReason": "Not runnable at the deterministic tier: 2 of 3 authored assertions name no quoted expected output, so readExpectation cannot read them, and no CLI-layer command is committed for the case. Owed: re-word those 2 expectations in this directory's evals.json so each quotes an observable, then commit an armed row here naming the command the case runs. Tracked on #5431."
 		},
 		{
 			"status": "pending",
 			"caseId": 12,
-			"pendingReason": "Not runnable at the deterministic tier: 2 of 3 authored assertions name no quoted expected output, so readExpectation cannot read them, and no CLI-layer command is committed for the case. Arming it is #5431."
+			"pendingReason": "Not runnable at the deterministic tier: 2 of 3 authored assertions name no quoted expected output, so readExpectation cannot read them, and no CLI-layer command is committed for the case. Owed: re-word those 2 expectations in this directory's evals.json so each quotes an observable, then commit an armed row here naming the command the case runs. Tracked on #5431."
 		},
 		{
 			"status": "pending",
 			"caseId": 13,
-			"pendingReason": "Not runnable at the deterministic tier: 1 of 3 authored assertions name no quoted expected output, so readExpectation cannot read them, and no CLI-layer command is committed for the case. Arming it is #5431."
+			"pendingReason": "Not runnable at the deterministic tier: 1 of 3 authored assertions names no quoted expected output, so readExpectation cannot read it, and no CLI-layer command is committed for the case. Owed: re-word that expectation in this directory's evals.json so it quotes an observable, then commit an armed row here naming the command the case runs. Tracked on #5431."
 		},
 		{
 			"status": "pending",
 			"caseId": 14,
-			"pendingReason": "Not runnable at the deterministic tier: 1 of 3 authored assertions name no quoted expected output, so readExpectation cannot read them, and no CLI-layer command is committed for the case. Arming it is #5431."
+			"pendingReason": "Not runnable at the deterministic tier: 1 of 3 authored assertions names no quoted expected output, so readExpectation cannot read it, and no CLI-layer command is committed for the case. Owed: re-word that expectation in this directory's evals.json so it quotes an observable, then commit an armed row here naming the command the case runs. Tracked on #5431."
 		},
 		{
 			"status": "pending",
 			"caseId": 15,
-			"pendingReason": "Not runnable at the deterministic tier: 1 of 3 authored assertions name no quoted expected output, so readExpectation cannot read them, and no CLI-layer command is committed for the case. Arming it is #5431."
+			"pendingReason": "Not runnable at the deterministic tier: 1 of 3 authored assertions names no quoted expected output, so readExpectation cannot read it, and no CLI-layer command is committed for the case. Owed: re-word that expectation in this directory's evals.json so it quotes an observable, then commit an armed row here naming the command the case runs. Tracked on #5431."
 		},
 		{
 			"status": "pending",
 			"caseId": 16,
-			"pendingReason": "Not runnable at the deterministic tier: 2 of 3 authored assertions name no quoted expected output, so readExpectation cannot read them, and no CLI-layer command is committed for the case. Arming it is #5431."
+			"pendingReason": "Not runnable at the deterministic tier: 2 of 3 authored assertions name no quoted expected output, so readExpectation cannot read them, and no CLI-layer command is committed for the case. Owed: re-word those 2 expectations in this directory's evals.json so each quotes an observable, then commit an armed row here naming the command the case runs. Tracked on #5431."
 		},
 		{
 			"status": "pending",
 			"caseId": 17,
-			"pendingReason": "Not runnable at the deterministic tier: 2 of 3 authored assertions name no quoted expected output, so readExpectation cannot read them, and no CLI-layer command is committed for the case. Arming it is #5431."
+			"pendingReason": "Not runnable at the deterministic tier: 2 of 3 authored assertions name no quoted expected output, so readExpectation cannot read them, and no CLI-layer command is committed for the case. Owed: re-word those 2 expectations in this directory's evals.json so each quotes an observable, then commit an armed row here naming the command the case runs. Tracked on #5431."
 		}
 	]
 }

--- a/packages/fabrika-cli/src/eval/series-io.ts
+++ b/packages/fabrika-cli/src/eval/series-io.ts
@@ -1,0 +1,68 @@
+/**
+ * Reading the committed scorecard series off disk — the one place that decides what a member is.
+ *
+ * It exists as its own module because two callers need the same read and neither may own it: the
+ * `trend` / `churn` verbs (#4680) and the merge gate's advisory leg (#4681). A second copy of the
+ * membership rule is precisely the drift that took the series down once already.
+ *
+ * Members are selected by `isSeriesFileName`, never by `*.json`: the directory also holds the dated
+ * cost baselines (#4679), and globbing every JSON there made each of those a malformed scorecard. A
+ * name that *is* a member and does not decode is still a hard refusal — that is a corrupt point of
+ * the series rather than a neighbour.
+ *
+ * The result is a total value rather than an exit: a shared read that terminated the process would
+ * decide its callers' exit codes for them.
+ */
+import {Effect, FileSystem, Path, Result} from "effect";
+import type {CommittedScorecard} from "./committed-scorecard.ts";
+import {decodeCommittedScorecard, isSeriesFileName} from "./committed-scorecard.ts";
+
+export interface SeriesFile {
+	readonly fileName: string;
+	readonly scorecard: CommittedScorecard;
+}
+
+export type SeriesRead =
+	| {
+			readonly _tag: "Files";
+			readonly files: ReadonlyArray<SeriesFile>;
+			/** JSON files in the directory that name no point of the series — reported, never read. */
+			readonly ignored: ReadonlyArray<string>;
+	  }
+	| {readonly _tag: "Unreadable"; readonly path: string}
+	| {readonly _tag: "Malformed"; readonly path: string; readonly reason: string};
+
+/** Every committed scorecard in `dir`, oldest name first. An absent directory reads as no points. */
+export const readSeriesFiles = (
+	dir: string,
+): Effect.Effect<SeriesRead, never, FileSystem.FileSystem | Path.Path> =>
+	Effect.gen(function* () {
+		const fs = yield* FileSystem.FileSystem;
+		const path = yield* Path.Path;
+		if (!(yield* fs.exists(dir).pipe(Effect.orElseSucceed(() => false)))) {
+			return {_tag: "Files", files: [], ignored: []} as SeriesRead;
+		}
+		const entries = yield* fs.readDirectory(dir).pipe(Effect.orElseSucceed(() => null));
+		if (entries === null) return {_tag: "Unreadable", path: dir} as SeriesRead;
+
+		const files: Array<SeriesFile> = [];
+		for (const name of entries.filter(isSeriesFileName).sort()) {
+			const full = path.join(dir, name);
+			const text = yield* fs.readFileString(full).pipe(Effect.orElseSucceed(() => null));
+			if (text === null) return {_tag: "Unreadable", path: full} as SeriesRead;
+			const decoded = decodeCommittedScorecard(text);
+			if (Result.isFailure(decoded)) {
+				return {
+					_tag: "Malformed",
+					path: full,
+					reason: `${decoded.failure.reason}: ${decoded.failure.message}`,
+				} as SeriesRead;
+			}
+			files.push({fileName: name, scorecard: decoded.success});
+		}
+		return {
+			_tag: "Files",
+			files,
+			ignored: entries.filter((name) => name.endsWith(".json") && !isSeriesFileName(name)).sort(),
+		} as SeriesRead;
+	});


### PR DESCRIPTION
Fabrika's ruled ship bar is now a thing CI can actually refuse a merge on. One verb, `fabrika eval gate`, decides every leg of it — the 100% incident-regression floor, the 90% graded rate, and spend at or below the committed v1 baseline — and the workflow job does nothing but relay its exit code. The graded leg does not run any evals: it reads back the eval record the review stage recorded against this exact commit and compares a string and a number, so a review that never ran, or ran against an older commit, reds instead of passing quietly.

Part of #4681

## What changed

- **`packages/fabrika-cli/src/eval/gate.ts`** — the pure judgement. Six reds, each naming its reason: `zero-scope`, `regression-floor`, `missing`, `stale`, `below-bar`, `over-baseline`. Every red is printed; the highest-precedence one seats `$?`. Four seats are reused (`7`, `15`, `18`) because the group already means exactly those facts by those numbers; `21`/`22`/`23` are new in `codes.ts`.
- **`packages/fabrika-cli/src/eval/gate-verb.ts`** — the IO shell. Given a PR number it resolves the head, the changed paths and the eval records itself, count-checked against the platform's own denominators. `--head` / `--changed` / `--record` is the offline mode: no network, no credential.
- **`.github/workflows/fabrika-eval-gate.yml`** — one `run:` line. No `if:`, no path filter, no logic (ADR 0228).
- **`packages/fabrika-cli/src/eval/floor-commands.ts` + `incident-corpus/commands.json`** — the arming sidecar, since the tier takes its `resolveCommand` from the caller and the authored eval format has no command field. A row is `armed` (with the command) or `pending` (with required prose saying what is owed).
- **`packages/fabrika-cli/src/eval/series-io.ts`** — the series read, lifted out of `command.ts` so the gate and `trend`/`churn` share one membership rule instead of two.
- **`packages/fabrika-cli/src/eval/README.md`** — the gate's section.

Consumed, not re-derived: `trend` (advisory only, ADR 0252 §4), `compareToBaseline` / `foldLedgerRows` / `decodeCostBaseline` (#4679), `decodeCommittedScorecard` (#4680), `summarizeEvalRows` (#4677), and the `eval-record` read plus `sameHead` for the head binding (#4678, ADR 0253).

## The trigger split lives in the verb

The job runs on every pull request with **no** `paths:` filter, so the deterministic tier — and with it the foreign-root-install portability case — sits in the always-run set behind no conditional trigger. Whether the *graded* leg applies is `changedSkills`, anchored on `claude-plugins/fabrika/skills/`.

That filter is the #4604 shape, so it is falsifiable rather than asserted: `gate.unit.test.ts` runs the same decision twice over one changed-path set — once under the shipped filter, once under a `packages/pipeline-cli/src/`-anchored one — and asserts the mis-scoped run turns a `missing` red into a pass. The property held is that a wrong filter is *visible* as the difference between a red and a green. #4604 itself is untouched and stays on its own ticket.

## Watched failing

`gate.cli.test.ts` runs the real bin in a subprocess and asserts the exit code a `run:` step would see, on the three cases the amended criteria name plus two more: (a) a genuinely failing incident case → `23`, (b) a missing result → `21`, (c) a stale result bound to an older commit → `18`, plus `below-bar` → `22` and zero scope → `7`.

## Checks

- `pnpm typecheck` — 31/31 tasks clean
- `pnpm lint:worktree` — 11 files, clean
- `pnpm --filter @kampus/fabrika-cli exec vitest run` — 299 files, 4532 tests, all passing (repair round 1 re-ran the full suite; 48 tests new here)
- `pipeline-cli leak-guard scan` over the 13 changed files — clean
- `pipeline-cli readme-guard check`, `pipeline-cli path-filter-guard check` — clean

## §CP

`pipeline-cli cp-classify classify` over the changed-file list: **control-plane [path-match]**, on exactly one path — `.github/workflows/fabrika-eval-gate.yml`. Nothing under `packages/fabrika-cli/` is §CP (the CODEOWNERS row is `packages/pipeline-cli/src/*`, a different package). This needs a human merge.

## Deviations

**1. Linkage is `Part of #4681`, not `Fixes` — two criteria are undischarged.**
Said: `Fixes` only if every criterion discharges. Did: `Part of`. Why: the extended criterion asks for the **workflow job** to be *observed* red — actually watched failing — on three constructed cases, and a workflow that exists only on this branch cannot be watched failing without landing a deliberately-broken commit on the PR that must merge green. I observed the *verb* red on all five reds at the CLI tier instead, which is the closest evidence I can produce pre-merge. Disposition: for the reviewer/founder to discharge by watching the job red once it is on `main`; the issue stays open until then.

**2. The regression floor executes nothing today, and the gate reports that rather than reding.**
Said: the floor is 100%, no tolerance and no quarantine. Did: an all-`pending` floor prints `floor: pending — no incident case is armed to run yet` and does not red. Why: I verified at head that the incident corpus has **no** runnable deterministic case. Two independent blockers, both measured: no CLI-layer command is committed for any case (the tier takes `resolveCommand` from its caller by design, #4674), and 15 of the 16 deterministic cases carry at least one assertion `readExpectation` cannot read — every failure the same `names no quoted expected output`, because the assertions were authored as prose a grader reads. Case 5 is the only one whose assertions all read, and it still has no command. Reding on that would block every PR in the repo on a corpus nobody can arm from this ticket; passing silently would be the quarantine the ruling forbids. So the concession is *committed and written*: each case carries a `pending` row stating its blocker, the gate names the count on every run, and a case added to the corpus with **no** arming decision reds `zero-scope`. Disposition: follow-up #5431 filed with the per-case evidence.

**3. The foreign-root portability case is in the always-run set but does not execute.**
Said: it must run behind no conditional trigger. Did: no conditional trigger exists — the job has no `paths:` filter and the case is a member of the corpus the floor runs. But it is one of the pending cases from deviation 2, so it is not executed today. Disposition: same follow-up, #5431.

**4. The graded leg checks records, not per-skill records.**
Said: "a changed skill's graded pass rate below 90%". Did: every `RECORDED` cell bound to the head must clear the bar, and at least one must exist. Why: the shipped eval record is keyed by `(stage × surface × model)` and carries no skill field (ADR 0253), so "this skill's rate" is not expressible against the artifact. Disposition: for the reviewer to judge — tightening it would need a record-shape change, which is #4678's artifact, not this ticket's.

**5. `incomparable` spend reds under the `over-baseline` reason.**
Said: six reasons, one of which is `over-baseline`. Did: an incomparable comparison reds on that reason with `incomparable:` in its detail. Why: #4679 seats it apart precisely so it is never read as a pass, and the issue's reason set has no seventh member. The exit code is `15`, which the group already means both by. Disposition: no action needed.

**6. A missing spend ledger is reported, not red.**
Said: fail closed on absence. Did: `spend: not-priced` when no candidate ledger exists. Why: the absence rule in the amendment is about the *eval result*, and the ledger is a suite run's artifact — CI runs no suite, so on an ordinary PR there is nothing to price and reding would make the gate unpassable. A ledger *with* no committed baseline to price it against does red `zero-scope`. Disposition: for the reviewer to judge.

**7. One refactor beyond the issue's scope.**
Said: nothing about `command.ts`'s series read. Did: lifted it into `series-io.ts` and rewrote `command.ts`'s `readSeries` to call it. Why: the gate needs the same membership rule, and a second copy of "what counts as a point of the series" is the drift that took the series down once already. Disposition: no action needed; behaviour is unchanged and the existing `trend`/`churn` tests cover it.

**8. (repair round 1) The summary line no longer says the bar is met when legs measured nothing — and the check-run name no longer advertises the floor.**
Said: `gate: GREEN — every ruled leg of the bar is met`, under a check named *"the ruled bar - 100% floor, 90% graded verified at head, spend <= v1 baseline"*. Did: `LegVerdict` now carries three states (`measured` / `unmeasured` / `red`) instead of two; the floor's all-pending branch, the graded `n/a` branch and the spend `not-priced` branch each resolve `unmeasured` and print `NOT MEASURED`; and the summary reads `gate: NOT FULLY MEASURED — nothing red, and N of 4 leg(s) measured NOTHING, so this is not a statement that the bar is met. NOT MEASURED: … Measured and met: …`. `gate: GREEN — all N leg(s) of the ruled bar were measured and met` is now reachable only when every leg measured. The job `name:` is now `fabrika eval gate: graded 90% enforced at head; floor + spend report, not yet enforced`, which states what the job enforces today rather than what the ruled bar says. Why: the gate's own run on this PR (CI job 94212715499) measured three legs of four as nothing and still printed *every ruled leg of the bar is met* under a green check promising a 100% floor — the #4604 shape arriving from the reporting side, and disclosed provenance does not change what the check tells a reader. Disposition: done; `gate.unit.test.ts` and `gate.cli.test.ts` both pin the new sentence, and the two CLI cases that used to assert `gate: GREEN` now assert `gate: NOT FULLY MEASURED` and `not.toContain("gate: GREEN")`.

**9. (repair round 1) Arming case 3 alone — evaluated and declined, with the reason.**
Said (the reviewer's stronger option): arm the foreign-root-install portability case so the always-run requirement becomes true rather than nominal. Did: left it `pending`, and did not half-arm it. Why, in two independent parts. **(a) The case as authored cannot be satisfied by one observation.** The deterministic tier runs **one** command per case and checks every assertion against that single observation, but case 3's assertions are conditional — *"exits non-zero **when** a documented invocation names a path that does not resolve"* and *"exits non-zero **when** zero documented invocations were in scope"* — and `readExpectation` flattens both to `ExitNonZero`. An armed case 3 would therefore demand a single run that exits non-zero, so on a healthy repo the floor would red on every PR. Arming it honestly means re-authoring the assertions around one concrete run plus a fixture, which is a corpus edit (#5431's lane and, in part, the sibling lane on #5429), not a gate edit. **(b) I could not have watched it run.** Per #5406 the harness refuses the runner inside this worktree lane, so I could not execute the armed case even once — and the dispatch's own instruction is not to half-arm something that cannot actually run. Disposition: stays with #5431; the pending row now names the concrete owed work rather than only the ticket (entry 11).

**10. (repair round 1) `missing` and `stale` now name their cure and its run site.**
Said: *"absence is never 'nothing to check'"* and *"re-run the suite at the head under gate"*. Did: both details now carry one shared clause — take a graded run at the head under gate **in a plain, non-worktree session, never inside a build lane** (whose harness refuses the runner, #5406) — and state that a lane which hits either red **hands the measurement off** rather than fixing it in place. Why: the run-site constraint delivered on #4681 (comment `5270878967`). `missing` named no cure and no next action, so it read as terminal; `stale` named a cure that a worktree lane structurally cannot perform, which is exactly the trap that constraint exists to prevent. The clause is a single `GRADED_RUN_SITE` constant so the *why* is stated once and both reds point at it. Disposition: done; pinned at the unit tier for both reds and at the CLI tier for `missing`.

**11. (repair round 1) Every `pending` row now names the concrete owed work, not just the ticket.**
Said: *"…and no CLI-layer command is committed for the case. Arming it is #5431."* Did: each row now reads *"Owed: re-word those expectations in this directory's `evals.json` so each quotes an observable, then commit an armed row here naming the command the case runs. Tracked on #5431."* (case 5, whose assertions all read, owes only the command and says so). Why: the pending-reason constraint delivered on #4681 (comment `5270927356`). The rows delegated to #5431, whose *Suggested next step* points at a `provenance.json` correction — which cannot cure anything, since `corrections` is an append-only re-diagnosis ledger and `readExpectation` reads only the assertion text in `evals.json`. A row whose cure would not cure is not carrying the weight the `pending` design puts on it. The reasoning behind the cure is stated **once**, in `floor-commands.ts`'s docblock and the README; the sixteen rows name the action only. Disposition: done here. #5431's own *Suggested next step* still needs correcting — that is a write to another lane's issue and is **not** pre-authorized for this run, so it is surfaced rather than performed.

**12. (repair round 1) What I could not measure, stated plainly.**
The harness's worktree-isolation guard refuses any command carrying the four-letter runner token as a word (#5406, not this repo's code), so I could **not** invoke `fabrika eval gate` directly against the committed corpus from this lane, and I did not work around the guard. The substitute is the same one the reviewer accepted: `gate.cli.test.ts` spawns the real bin in a subprocess and asserts the exact stdout/stderr and exit status a `run:` step would see, including the new summary sentence and the new run-site clause. The still-undischarged criterion from deviation 1 (the **workflow job** observed red) is unchanged by this round; the reviewer is right that a deliberately-broken branch commit would demonstrate it, and it stays for the merge authority to discharge — I did not push a break-then-revert pair into a §CP PR mid-repair without being asked to.
