### PR TITLE
fix(fabrika-cli): emit the committed scorecard the way biome formats it

### DIFF
--- a/packages/fabrika-cli/src/eval/committed-scorecard.ts
+++ b/packages/fabrika-cli/src/eval/committed-scorecard.ts
@@ -216,9 +216,14 @@ export const buildCommittedScorecard = (args: {
 	};
 };
 
-/** The committed bytes. One trailing newline, so the file is a well-formed text file. */
+/**
+ * The committed bytes. One trailing newline, so the file is a well-formed text file.
+ *
+ * Tab-indented for the reason `cost-baseline.ts`'s `costBaselineToJson` states: this output is
+ * *committed*, so it is written the way biome formats committed JSON.
+ */
 export const toJson = (scorecard: CommittedScorecard): string =>
-	`${JSON.stringify(scorecard, null, 2)}\n`;
+	`${JSON.stringify(scorecard, null, "\t")}\n`;
 
 const CaseSchema = Schema.Struct({
 	caseId: Schema.Int,

--- a/packages/fabrika-cli/src/eval/committed-scorecard.unit.test.ts
+++ b/packages/fabrika-cli/src/eval/committed-scorecard.unit.test.ts
@@ -6,6 +6,8 @@
  * own case list are each rejected rather than committed. The pin-completeness rejection is #4680's
  * fourth acceptance criterion, so it is exercised once per pin rather than once in total.
  */
+import {existsSync, readdirSync, readFileSync} from "node:fs";
+import {dirname, join} from "node:path";
 import {Result} from "effect";
 import {describe, expect, it} from "vitest";
 import type {EvalRecord, EvalRecordPins} from "../wire/eval-record.ts";
@@ -15,6 +17,7 @@ import {
 	type CommittedCell,
 	decodeCommittedScorecard,
 	isSeriesFileName,
+	SERIES_DIR,
 	seriesFileName,
 	toJson,
 } from "./committed-scorecard.ts";
@@ -224,6 +227,46 @@ describe("isSeriesFileName is the inverse of seriesFileName", () => {
 		expect(isSeriesFileName("README.md")).toBe(false);
 		expect(isSeriesFileName("2026-08-11.json.bak")).toBe(false);
 		expect(isSeriesFileName("notes-2026-08-11.json")).toBe(false);
+	});
+});
+
+/**
+ * Emit-then-format is a no-op: the emitter's bytes already ARE the formatter's bytes.
+ *
+ * Asserting "the output contains a tab" would pass on any output biome still wants to rewrite. This
+ * asserts the property that actually ends the recurrence, and it is checkable because CI runs
+ * `biome check .` over the whole repo: every committed series file below is, at HEAD, exactly what
+ * biome produces. Re-emitting one through `toJson` and getting the same bytes back is therefore the
+ * proof PR #5426's reviewer had to construct by hand — re-derived here on every run, for every point
+ * of the series, instead of once per scorecard forever (#5428).
+ *
+ * Fail-closed on an empty directory (ADR 0092): a series with no member would pass this vacuously.
+ */
+describe("a freshly emitted scorecard needs no formatter pass", () => {
+	const repoRoot = (): string => {
+		let dir = import.meta.dirname;
+		while (!existsSync(join(dir, "pnpm-workspace.yaml"))) {
+			const up = dirname(dir);
+			if (up === dir) throw new Error("could not locate the repo root from the test file");
+			dir = up;
+		}
+		return dir;
+	};
+
+	const seriesDir = join(repoRoot(), SERIES_DIR);
+	const members = readdirSync(seriesDir).filter(isSeriesFileName);
+
+	it("finds committed series points to check", () => {
+		expect(members.length).toBeGreaterThan(0);
+	});
+
+	it.each(members)("re-emits %s exactly as biome formatted it", (member) => {
+		const committed = readFileSync(join(seriesDir, member), "utf8");
+		const decoded = decodeCommittedScorecard(committed);
+		if (Result.isFailure(decoded)) {
+			throw new Error(`${member} is not a readable series point: ${decoded.failure.message}`);
+		}
+		expect(toJson(decoded.success)).toBe(committed);
 	});
 });
 


### PR DESCRIPTION
`fabrika eval scorecard` wrote its committed series file with 2-space JSON, but this repo's formatter wants tabs — so the verb's own output could never be committed as emitted. Every scorecard run cost an operator a manual formatter pass, and cost a reviewer a hand-built proof that the reformat changed no numbers. This changes the serializer to tab indentation, so what the verb writes is already what the formatter wants.

Scorecards are a series, so this recurs forever if it is only fixed once by hand. The test that pins it is therefore not "the output contains a tab" — it re-emits **every** committed series point through the serializer and asserts the bytes come back identical. Since CI runs `biome check .` over the repo, those files are by definition what biome produces, so emit-then-format being a no-op is what the test actually proves.

Fixes #5428

## What changed

- `packages/fabrika-cli/src/eval/committed-scorecard.ts` — `toJson` serializes with `"\t"` instead of `2`, matching the committed-output rule the same directory already follows (`cost-baseline.ts`, `corpus.ts`). Whitespace only: no value, key order, or structure changes.
- `packages/fabrika-cli/src/eval/committed-scorecard.unit.test.ts` — adds a fixed-point check over every file in the series directory that `isSeriesFileName` admits, fail-closed on an empty directory (ADR 0092).

## Verification

- **Falsifiable, not decorative.** With the serializer reverted to 2 spaces the new test fails, and the failure diff is whitespace-only. With tabs it passes.
- **AC 2 checked against the real formatter, not inferred.** A freshly emitted scorecard (the serializer's output for the committed point's values) was written to a scratch path and run through `biome check` with the repo config: clean, exit 0. The same bytes at 2-space indentation red with one formatter error. Both scratch files were deleted; neither is in the diff.
- `pnpm typecheck`: 31/31 tasks green. `pnpm lint:worktree`: 2 files checked, clean. `@kampus/fabrika-cli` suite: 295 files / 4483 tests passed.
- `claude-plugins/fabrika/reports/eval/2026-08-11.json` is untouched — the diff is two files, both under `packages/fabrika-cli/src/eval/`.

## Deviations

- **Class: narrowed a suggested fix-shape.** Said: the report floated format-on-write or a loud check as alternatives to fixing the serializer. Did: fixed only the serializer. Why: triage already ruled the fix belongs in the serializer, and the package states the rule (committed output uses tabs, stdout-only uses 2 spaces) in `cost-baseline.ts`; the scorecard was the one committed emitter on the wrong side of it. Disposition: no action needed.
- **Class: a test file was extended rather than left alone.** Said: AC 4 expects the existing unit test to pass with no rewrite. Did: no existing test was changed or rewritten — all 25 prior tests are untouched and pass; a new `describe` block was appended. Why: AC 2's property needs an assertion that did not exist. Disposition: no action needed.
- **Class: left a sibling question for a decision.** The other committed file in the series directory, `claude-plugins/fabrika/reports/eval/baseline-v1-2026-08-11.json`, is a cost baseline, not a scorecard, so `isSeriesFileName` correctly excludes it and the new test does not cover it. Its emitter (`costBaselineToJson`) already uses tabs. Disposition: no action needed; noted so a reader does not read the test's scope as a gap.
- **Class: a check I could not run.** The harness's worktree-isolation guard refuses any Bash command containing the substring `eval`, and the paths here contain it, so no command naming these files by path could be run. Everything above was run via package-level commands (`pnpm typecheck`, `pnpm lint:worktree`, `pnpm --filter @kampus/fabrika-cli test`) and absolute-path biome invocations, all of which executed. Nothing is reported as verified that was not actually executed. Disposition: for the reviewer to judge.