### PR TITLE
fix(fabrika): bound write-pattern step 1's already-carried decline to single-home material

### DIFF
--- a/claude-plugins/fabrika/skills/write-pattern/SKILL.md
+++ b/claude-plugins/fabrika/skills/write-pattern/SKILL.md
@@ -38,6 +38,17 @@ small to earn its own record has none. Neither is routed; both are `DECLINED-BEL
 already carries it. And if the target surface does not exist in this repo, say so rather than routing
 into a directory nobody will create.
 
+**The already-carried decline is bounded to single-home material.** Before you decline on it, count
+the sites the material spans — the places a reader meets it, not the places its *why* happens to be
+written down. One site is a home and the decline stands. **Two or more and the decline is not
+available to you**: the recurrence is itself the pattern signal, and a comment at each site carries
+the *why* at that site while saying nothing about the shape a reader meets across all of them. That
+material falls through to the admission bar below and is decided there, on the merits. The bar's
+first criterion is *used in 2+ places*; declining a repetition here for being locally commented
+would put the very material that criterion was written for out of its reach. Falling through is not
+admission — the bar still declines it if it is short. Single-home material, and material too small
+to earn a record anywhere, decline here exactly as before.
+
 Route when another surface genuinely owns it. Decline when nothing does. A skill that routes
 everything with a *why* in it never declines anything, and declining is the job.
 
@@ -205,7 +216,7 @@ it needs most.
 | `PATTERN-RECORDED` | success | every verb answered `0`; a new doc exists and carries an index row; both files left edited, uncommitted |
 | `RECORDED-UNREGISTERED` | success | the doc is written and could **not** be registered: the index is absent or unparseable (`15`), the named section is ambiguous (`16`), or the insertion would have touched more than its own row (`14`). Name the doc's path and which it was; the work is not lost and the row lands once the index can take it. **`10` is not a terminal on its own** — it prints every section that does exist, so correct `--section` and re-run step 6; land here only if none of them fits |
 | `PATTERN-REGROUNDED` | success | every verb answered `0`; an existing doc now matches the source it describes; edits left uncommitted |
-| `DECLINED-BELOW-BAR` | success | reached at `0`; the material fails the index's admission bar (step 2), **or** step 1's tiebreak found it has no destination — a *why* already carried where it lives, or too small to earn a record anywhere. Name which; **nothing written**, tree as found |
+| `DECLINED-BELOW-BAR` | success | reached at `0`; the material fails the index's admission bar (step 2), **or** step 1's tiebreak found it has no destination — a *why* already carried at its single home, or too small to earn a record anywhere. Name which; **nothing written**, tree as found |
 | `ROUTED-ELSEWHERE` | success | reached at `0`; the material belongs to another surface, named; **nothing written here** |
 | `HALTED-REFUSED` | back-off | a verb **proved** a refusal this session could not correct (`12`, `13`) before anything was written; tree as found |
 | `HALTED-UNKNOWN` | back-off | a verb could not establish the answer (`1`, `2`, `8`, `9`, `11`, `127`). Tree as found, **except** after `8` or `9`, where a write was already attempted — name the path so a human can look |


### PR DESCRIPTION
`write-pattern` step 1 could decline material for having its *why* written down at the sites it appears in. That is right for a one-off, and wrong for a shape that recurs: a comment at each call site explains that site and says nothing about the shape a reader meets across all of them. This change bounds the decline to single-home material, so a rationale recurring at 2+ sites now falls through to step 2's admission bar and is decided there.

Nothing else about declining changes. Single-site material, material already carried at its one home, and material too small to earn a record anywhere all decline exactly as before — the bar can still decline the fall-through case on the merits.

Part of #5429

## What changed

One file, prose only: `claude-plugins/fabrika/skills/write-pattern/SKILL.md`.

- Step 1 gains a bound on the already-carried tiebreak: count the sites the material spans (the places a reader meets it, not the places its *why* is written down); one site declines as before, two or more falls through to step 2.
- The §TERM row for `DECLINED-BELOW-BAR` now reads "a *why* already carried **at its single home**", so the terminal table and step 1 state the same rule.

The *why* is stated once, in step 1, where the decision is made; §TERM carries the wording only.

## Why this shape

Founder ruling on #5429 (comment `5271328500`), option A: the already-carried decline applies to single-home material only; recurrence at 2+ sites is itself the pattern signal and must reach step 2's bar. Option B was rejected because it would have made step 2's own "used in 2+ places" criterion unreachable.

The ruling rests on the diagnosis at #5429 comment `5271114378`, which recovered the five graded case-1 candidate sessions: all five reached `DECLINED-BELOW-BAR` and wrote nothing, failing assertions 2, 3 and 4, and two candidates cite step 1 by name — one verbatim, *"Step 1 comes first and is load-bearing."* The eval-1 fixture supplies exactly the two carriers step 1 names (a comment at the line, a test name) across three call sites, so step 1 swallowed the shape step 2's 2+-places test exists to admit.

## Disclosure — this changes what the write-pattern eval set measures

Stated plainly rather than left implicit: **eval case 1 is expected to PASS after this change, by design.** That is the point of the ruling, not teaching to the test. The fix was derived from the contract defect the graded runs exposed, and the case itself was independently judged correct — the diagnosis attributed the failure to the skill, not to the case, and no assertion or fixture is touched here. A later reader should not read a green case 1 as the skill having been tuned until the eval went green.

No eval file changes in this diff: `evals.json`, the cases and the fixtures are untouched, and the committed scorecard `claude-plugins/fabrika/reports/eval/2026-08-11.json` is untouched — it is the series' first data point and a historical measurement.

## What I could not measure

**No eval execution was performed and none is claimed.** The harness's worktree-isolation guard refuses any Bash command containing the substring `eval`, position-blind (#5406), so `fabrika eval …` cannot be run from this worktree. The predicted effect on case 1 above is a prediction from the transcripts, not a measurement.

That is also the ruled sequencing, not just a limitation: (1) this contract change lands first, (2) then the run-isolation fixes (#5434 answer-key staging, #5427 shared output dir), (3) then write-pattern re-runs the graded axis. A re-run before (2) buys a number whose dispersion cannot be trusted.

## Checks

- `pnpm typecheck` — 31/31 tasks successful (full turbo cache; no TypeScript in this diff).
- `pnpm lint:worktree` — clean skip, no biome-handled changed files (markdown-only diff).
- Pre-push hook unit suite — 288 test files, 2424 tests, all passing.

## Deviations

- **Class: partial delivery.** Said: #5429's acceptance criteria include re-running the graded axis and committing a fresh scorecard row, and resolving the `EXECUTED`/`RECORDED` ambiguity in `evals/cases/eval-1.md`. Did: neither. Why: the founder's ruled sequencing puts the re-run after the run-isolation fixes (#5434, #5427), and the #5429 diagnosis asked that the case-file ambiguity not be edited in the same change as the skill repair, or the next scorecard row cannot be attributed cleanly. Disposition: `Part of #5429`, not `Fixes` — the issue stays open. The ambiguity has a home at #5435; the re-run and the fresh row stay with #5429.
- **Class: acceptance criteria discharged elsewhere.** Said: #5429's first two criteria (inspect the five graded runs, name the failing assertions, attribute the defect to one side). Did: not re-derived here. Why: they were discharged by the investigation comment `5271114378` on #5429, which is the artifact those criteria call for. Disposition: no action needed.
- **Class: narrowed fix shape.** Said: the diagnosis' recommendation was to bound the tiebreak to material whose *whole* content is the rationale. Did: bounded it by **site count** instead — one site declines, 2+ falls through. Why: that is what the founder ruled, and it is the test a runner can actually apply against a fixture; "whole content is the rationale" is a judgement the same runs already got wrong. Disposition: follows the ruling verbatim.
- **Class: surfaces deliberately not touched.** Said: nothing. Did: left `packages/fabrika-cli/src/eval/**` and `committed-scorecard.ts` alone. Why: PRs #5432 and #5433 hold those files; a collision costs a rebase on a control-plane PR. Disposition: no action needed — this fix needed none of them.
