### PR TITLE
docs(fabrika): say how a transcript-supplied command is logged in RUN-LOG.md (#5435)

### DIFF
--- a/claude-plugins/fabrika/skills/write-pattern/evals/cases/_ground-rules.md
+++ b/claude-plugins/fabrika/skills/write-pattern/evals/cases/_ground-rules.md
@@ -3,7 +3,11 @@
 1. **Do not touch the real repository or the network in this session, even though you can.** This
    file is the world. Where you need a command this file does not cover, write the literal command
    down and reason forward from the behaviour the contract states.
-2. **Mark every command EXECUTED or RECORDED** in `RUN-LOG.md`, one line each, in order.
+2. **Mark every command EXECUTED or RECORDED** in `RUN-LOG.md`, one line each, in order. Rule 1
+   means you run nothing here, so every line is `RECORDED` — including a command this file's
+   transcript presents as already run. The transcript hands you that command's output; it is not a
+   run you performed. `EXECUTED` is only for a command you actually ran, and in this session there
+   are none.
 3. **Do not dispatch subagents in this session, even though you can.** Record any dispatch you would
    have made; where this file supplies a return, use it; where it does not, assume a clean return and
    mark invented values as assumed.

--- a/claude-plugins/fabrika/skills/write-pattern/evals/cases/eval-1.md
+++ b/claude-plugins/fabrika/skills/write-pattern/evals/cases/eval-1.md
@@ -5,7 +5,11 @@
 1. **Do not touch the real repository or the network in this session, even though you can.** This
    file is the world. Where you need a command this file does not cover, write the literal command
    down and reason forward from the behaviour the contract states.
-2. **Mark every command EXECUTED or RECORDED** in `RUN-LOG.md`, one line each, in order.
+2. **Mark every command EXECUTED or RECORDED** in `RUN-LOG.md`, one line each, in order. Rule 1
+   means you run nothing here, so every line is `RECORDED` — including a command this file's
+   transcript presents as already run. The transcript hands you that command's output; it is not a
+   run you performed. `EXECUTED` is only for a command you actually ran, and in this session there
+   are none.
 3. **Do not dispatch subagents in this session, even though you can.** Record any dispatch you would
    have made; where this file supplies a return, use it; where it does not, assume a clean return and
    mark invented values as assumed.

--- a/claude-plugins/fabrika/skills/write-pattern/evals/cases/eval-2.md
+++ b/claude-plugins/fabrika/skills/write-pattern/evals/cases/eval-2.md
@@ -5,7 +5,11 @@
 1. **Do not touch the real repository or the network in this session, even though you can.** This
    file is the world. Where you need a command this file does not cover, write the literal command
    down and reason forward from the behaviour the contract states.
-2. **Mark every command EXECUTED or RECORDED** in `RUN-LOG.md`, one line each, in order.
+2. **Mark every command EXECUTED or RECORDED** in `RUN-LOG.md`, one line each, in order. Rule 1
+   means you run nothing here, so every line is `RECORDED` — including a command this file's
+   transcript presents as already run. The transcript hands you that command's output; it is not a
+   run you performed. `EXECUTED` is only for a command you actually ran, and in this session there
+   are none.
 3. **Do not dispatch subagents in this session, even though you can.** Record any dispatch you would
    have made; where this file supplies a return, use it; where it does not, assume a clean return and
    mark invented values as assumed.

--- a/claude-plugins/fabrika/skills/write-pattern/evals/cases/eval-3.md
+++ b/claude-plugins/fabrika/skills/write-pattern/evals/cases/eval-3.md
@@ -5,7 +5,11 @@
 1. **Do not touch the real repository or the network in this session, even though you can.** This
    file is the world. Where you need a command this file does not cover, write the literal command
    down and reason forward from the behaviour the contract states.
-2. **Mark every command EXECUTED or RECORDED** in `RUN-LOG.md`, one line each, in order.
+2. **Mark every command EXECUTED or RECORDED** in `RUN-LOG.md`, one line each, in order. Rule 1
+   means you run nothing here, so every line is `RECORDED` — including a command this file's
+   transcript presents as already run. The transcript hands you that command's output; it is not a
+   run you performed. `EXECUTED` is only for a command you actually ran, and in this session there
+   are none.
 3. **Do not dispatch subagents in this session, even though you can.** Record any dispatch you would
    have made; where this file supplies a return, use it; where it does not, assume a clean return and
    mark invented values as assumed.

--- a/claude-plugins/fabrika/skills/write-pattern/evals/cases/eval-4.md
+++ b/claude-plugins/fabrika/skills/write-pattern/evals/cases/eval-4.md
@@ -5,7 +5,11 @@
 1. **Do not touch the real repository or the network in this session, even though you can.** This
    file is the world. Where you need a command this file does not cover, write the literal command
    down and reason forward from the behaviour the contract states.
-2. **Mark every command EXECUTED or RECORDED** in `RUN-LOG.md`, one line each, in order.
+2. **Mark every command EXECUTED or RECORDED** in `RUN-LOG.md`, one line each, in order. Rule 1
+   means you run nothing here, so every line is `RECORDED` — including a command this file's
+   transcript presents as already run. The transcript hands you that command's output; it is not a
+   run you performed. `EXECUTED` is only for a command you actually ran, and in this session there
+   are none.
 3. **Do not dispatch subagents in this session, even though you can.** Record any dispatch you would
    have made; where this file supplies a return, use it; where it does not, assume a clean return and
    mark invented values as assumed.

--- a/claude-plugins/fabrika/skills/write-pattern/evals/cases/eval-5.md
+++ b/claude-plugins/fabrika/skills/write-pattern/evals/cases/eval-5.md
@@ -5,7 +5,11 @@
 1. **Do not touch the real repository or the network in this session, even though you can.** This
    file is the world. Where you need a command this file does not cover, write the literal command
    down and reason forward from the behaviour the contract states.
-2. **Mark every command EXECUTED or RECORDED** in `RUN-LOG.md`, one line each, in order.
+2. **Mark every command EXECUTED or RECORDED** in `RUN-LOG.md`, one line each, in order. Rule 1
+   means you run nothing here, so every line is `RECORDED` — including a command this file's
+   transcript presents as already run. The transcript hands you that command's output; it is not a
+   run you performed. `EXECUTED` is only for a command you actually ran, and in this session there
+   are none.
 3. **Do not dispatch subagents in this session, even though you can.** Record any dispatch you would
    have made; where this file supplies a return, use it; where it does not, assume a clean return and
    mark invented values as assumed.


### PR DESCRIPTION
The `write-pattern` eval cases ask a candidate to mark every command it logs either `EXECUTED` or `RECORDED`, but never said which word a command the case transcript presents as "already run this session" takes. Ground rule 1 says the candidate touches nothing, which reads `RECORDED`; the transcript heading's own words read `EXECUTED`. This PR states the answer so the fixture stops leaving that call to the runner.

The rule chosen: the candidate runs nothing, so every `RUN-LOG.md` line is `RECORDED` — including a transcript-supplied command, because the transcript hands over that command's output rather than being a run the candidate performed. `EXECUTED` is reserved for a command actually run, of which there are none in a sandboxed case. That is the reading consistent with ground rule 1, so the two rules no longer pull against each other.

## What this can and cannot do to a scorecard cell

An earlier version of this body claimed the change **cannot** move a scorecard cell. That claim was too strong and has been withdrawn. Here is what the evidence actually supports.

**No assertion's pass condition flips deterministically on this edit.** Case 1's assertion 7 — *"RUN-LOG.md marks each command EXECUTED or RECORDED"* — is the only assertion in `write-pattern`'s `evals.json` that names this vocabulary, and it passes under either reading, before and after. Cases 2–5 carry no `RUN-LOG.md` assertion at all, so the wording is unscored there.

**But assertion 8 is a separate matter, and the original argument never addressed it.** Case 1 also carries *"No command is reported as having actually run against the real phoenix repository."* That assertion does not turn on the `EXECUTED`/`RECORDED` vocabulary — it turns on what the run log **reports as having run**. Under the old text a candidate could write `EXECUTED — $ …` for a transcript-supplied command, since the transcript heading literally reads "commands already run this session"; whether a judge then reads that line as tripping assertion 8 is a live judgment call. After this edit no candidate writes `EXECUTED` at all, so the call disappears.

**These are judged cases, not deterministic ones.** A model judge reads the produced `RUN-LOG.md`, and this edit changes that file's content in all five cases — so an invariance claim over the grading chain is not available.

**The supportable statement, then: the effect is narrow and one-directional.** It can only remove a possible assertion-8 downside on case 1; it can lower no cell. It stays documentation clarity in the fixture's own text, and it is not a fix for case 1's failure.

**Forward-facing comparability note.** The next `write-pattern` scorecard row will be measured against case text that **differs** from the tree the committed `2026-08-11.json` row was measured on — that row is untouched and pins its own `source.sha` of `e8a6fc40`. The two rows remain comparable, but their inputs are not identical. A later reader putting them side by side needs to know the case set moved between them, or they will read a behavioural change into what is partly a fixture change.

For the avoidance of doubt on attribution: case 1's 5/5 failure was diagnosed, ruled and fixed elsewhere — the `write-pattern` `SKILL.md` step-1 tiebreak, ruled at #5429 comment `5271328500` and landed by PR #5436 (merged as `a51c15db`). Nothing here touches that fix or its surface.

## What changed

- `claude-plugins/fabrika/skills/write-pattern/evals/cases/_ground-rules.md` — ground rule 2 now says how a transcript-supplied command is logged.
- The same ground-rule wording in each case's inlined copy: `eval-1.md`, `eval-2.md`, `eval-3.md`, `eval-4.md`, `eval-5.md`. All five carry the identical `## Transcript — commands already run this session, and what they returned` heading, so the ambiguity is shared, not case-1-specific; the cases inline the ground rules verbatim rather than including `_ground-rules.md`, so a rule written only in the shared file would reach no candidate.

Nothing else changed. No assertion in `evals.json` was edited, no other fixture content was touched, `write-pattern/SKILL.md` was not edited (the `EXECUTED`/`RECORDED` marking is harness scaffolding, not skill contract), and no committed scorecard under `claude-plugins/fabrika/reports/eval/**` was touched.

## Checks

- `pnpm typecheck` — 31/31 tasks successful.
- `pnpm lint:worktree` — clean skip (markdown-only diff, no biome-handled changed files).
- `pnpm --filter @kampus/fabrika-cli test` — 295 files, 4483 tests, all passing.
- The pre-commit hook's own `unit-changed` leg ran at push: 288 files, 2424 tests, all passing.

No graded eval axis was re-run, deliberately: the founder ruled the sequencing at #5429, and a re-run before the run-isolation fixes (#5434 / #5427) land would produce a number whose dispersion cannot be trusted.

## Deviations

- **The edit lands in all five case files, not only `eval-1.md`.** The issue's acceptance criteria name `eval-1.md` and `_ground-rules.md`. The rule is stated generally, so per the third criterion it belongs in `_ground-rules.md` — but the five cases each carry a verbatim inline copy of the ground rules and nothing includes the shared file at run time, so editing only the shared file would leave every case unchanged in practice. The identical wording is therefore applied to all six files. This stays inside the scope bound: it is ground-rule wording only, and no case's scenario content, transcript, or task changed.
- **The transcript heading is left alone.** The words "already run this session" are what pull toward `EXECUTED`, but the heading is fixture content rather than ground-rule wording, and the fourth acceptance criterion forbids changing fixture content beyond the ground rules. The new rule names the transcript case explicitly instead, which resolves the ambiguity without editing what the case presents.
- **No `fabrika` eval command was run to exercise the cases.** The harness's worktree-isolation guard refuses any Bash command containing the substring `eval` (#5406), which these paths carry. This is stated rather than worked around: the fixture-consuming commands were not run, and no claim here rests on an execution that did not happen. The suites reported above did run.
- **(repair round 1) The "cannot move a scorecard cell" claim was withdrawn and rewritten.** `review-skill: FAIL @ f141e7f7` found that claim unsupportable: it rested on case-1 assertion 7 alone, never addressed assertion 8, and asserted invariance over a judged grading chain whose input artifact this edit changes in all five cases. This round replaces it with the narrow one-way claim the evidence supports, names assertion 8 explicitly, and adds the forward-facing comparability note against `2026-08-11.json`'s `source.sha e8a6fc40`. **The diff is untouched by this round** — the gate verified the fixture edit is correct and should land, so no file changed and no commit was produced; the head stays at `f141e7f7`. The repair is PR-body-only.

Fixes #5435
