### PR TITLE
fix(fabrika-cli): stage a per-run working directory for each graded candidate

### DIFF
--- a/packages/fabrika-cli/src/eval/README.md
+++ b/packages/fabrika-cli/src/eval/README.md
@@ -1049,14 +1049,26 @@ legible on disk — copies in **only** the paths that case's authored `files` fi
 same relative path the prompt reads, and feeds it through `claudeExecutor`'s existing `cwd`. The
 directory is removed when the run's scope closes.
 
+**The base a `files` entry resolves against is found, not assumed.** The corpus writes two
+conventions and neither is wrong: at the time this became the field's first consumer, 65 of the 92
+authored entries were relative to the set's own directory (`fixtures/eval-1.md`) and 17 to the skill
+root (`evals/fixtures/eval-1.md`, `evals/cases/eval-1.md`). So each entry is looked up under the set
+directory first and the skill root second, and staged at the **authored** relative path either way,
+which is what the prompt reads. (10 entries — `check-epic-plan`'s bare `eval-<n>.md`, whose files
+live under `evals/fixtures/` — resolve under neither, and are therefore `Unstageable` below rather
+than silently absent: [#5457](https://github.com/kamp-us/phoenix/issues/5457).)
+
 Three properties are deliberate:
 
 - **The answer key is refused by name**, not merely left uncopied: a case that declared
-  `evals/evals.json` would still not get it, and neither an absolute path nor one with a `..`
-  segment is staged.
-- **A run that cannot be isolated does not run.** `stageRunWorkspace` answers `Unstageable`, and the
-  verb records `no-verdict:invocation-failed` rather than falling back to the inherited tree — the
-  fallback would silently restore both defects.
+  `evals/evals.json` would still not get it. It is also the **only** refusal a run survives —
+  withholding it is the point, and everything else the case declared is still there.
+- **A run that cannot be isolated does not run, and a run missing its declared material is not
+  isolated.** `stageRunWorkspace` answers `Unstageable` — for a fixture that resolves under no base,
+  a copy that fails, an absolute path, or a `..` segment — and the verb records
+  `no-verdict:invocation-failed` rather than falling back to the inherited tree or spawning into a
+  directory short of what the prompt names. Either fallback would let a run nobody could isolate
+  reach `medianVerdict` and `dispersion` as a scored verdict.
 - **The grader is unchanged.** It is handed `expected_output` and the expectations in-process by
   `composeGraderPrompt`, stages nothing, and needs no directory of its own. `dispersion` and
   `medianVerdict` are untouched; this restores the independence they already assumed.

--- a/packages/fabrika-cli/src/eval/README.md
+++ b/packages/fabrika-cli/src/eval/README.md
@@ -1073,6 +1073,19 @@ Three properties are deliberate:
   `composeGraderPrompt`, stages nothing, and needs no directory of its own. `dispersion` and
   `medianVerdict` are untouched; this restores the independence they already assumed.
 
+**An absent `files` key is not a declaration that a case is self-contained.** The decoder keeps
+absent and `[]` apart (`files: ReadonlyArray<string> | null`) because they are different claims:
+`[]` says this case needs no material, so an empty directory is exactly right and the run scores; an
+absent key says nothing, so there is nothing to stage from and the run is `Unstageable`. The
+distinction is load-bearing rather than pedantic — of the 31 graded cases declaring no `files` at
+this writing, 9 (`report`, `adr`) write `files: []` and are genuinely self-contained, while 22
+(`review` 7, `review-ui` 5, `ship` 5, `triage` 5) omit the key entirely and their prompts name
+material by path (`fixtures/mixed-diff/BUNDLE.md`, `FIXTURE.md`, un-substituted `{FIXTURE}`
+placeholders). Those 22 report `unmeasured` until their `files` are authored, which is the loud
+failure; the alternative is the silent one this rule exists to remove — a `pass`/`fail` taken in an
+empty directory, indistinguishable in the record from a measurement
+([#5464](https://github.com/kamp-us/phoenix/issues/5464)).
+
 ## The fabrika incident corpus ([#4675](https://github.com/kamp-us/phoenix/issues/4675))
 
 `incident-corpus/` is a **second, separate** body of ground truth, and the name matters: the

--- a/packages/fabrika-cli/src/eval/README.md
+++ b/packages/fabrika-cli/src/eval/README.md
@@ -1032,6 +1032,35 @@ fact about the set, so it is validated first and records nothing. The exit code 
 a measurement exists — a below-bar rate exits `0`, because whether a rate clears the ruled bar is
 #4681's judgement and appears nowhere in this module.
 
+### Each run gets its own staged directory ([#5434](https://github.com/kamp-us/phoenix/issues/5434), [#5437](https://github.com/kamp-us/phoenix/issues/5437))
+
+A candidate used to **inherit** the verb process's working directory — nothing was staged. Two
+consequences fell out of that one fact. The authored `evals.json` carries every case's
+`expected_output` and assertion list, and the cases' own prompts (`Read evals/cases/eval-<n>.md`)
+only resolve from the directory that holds it, so the answer key sat one relative path from the
+candidate. And all five runs of a case shared that directory, so run N could read run N−1's
+deliverables — measured on the `write-pattern` case-1 lane, where 3 of 5 runs saw a prior verdict
+and run 5 wrote nothing of its own. `dispersion` (ADR 0252 §1) counts runs it assumes are
+independent, so that run measured **at most 2 independent samples, not 5**.
+
+`run-workspace.ts` stages instead. Per `(case, run)` it makes a scoped temp directory named
+`case<id>-run<n>-<session-id>` — the session id the same spawn is pinned to, so run identity is
+legible on disk — copies in **only** the paths that case's authored `files` field declares, at the
+same relative path the prompt reads, and feeds it through `claudeExecutor`'s existing `cwd`. The
+directory is removed when the run's scope closes.
+
+Three properties are deliberate:
+
+- **The answer key is refused by name**, not merely left uncopied: a case that declared
+  `evals/evals.json` would still not get it, and neither an absolute path nor one with a `..`
+  segment is staged.
+- **A run that cannot be isolated does not run.** `stageRunWorkspace` answers `Unstageable`, and the
+  verb records `no-verdict:invocation-failed` rather than falling back to the inherited tree — the
+  fallback would silently restore both defects.
+- **The grader is unchanged.** It is handed `expected_output` and the expectations in-process by
+  `composeGraderPrompt`, stages nothing, and needs no directory of its own. `dispersion` and
+  `medianVerdict` are untouched; this restores the independence they already assumed.
+
 ## The fabrika incident corpus ([#4675](https://github.com/kamp-us/phoenix/issues/4675))
 
 `incident-corpus/` is a **second, separate** body of ground truth, and the name matters: the

--- a/packages/fabrika-cli/src/eval/command.ts
+++ b/packages/fabrika-cli/src/eval/command.ts
@@ -720,10 +720,6 @@ const produceGradedRecord = (request: GradedRunRequest) =>
 		}
 
 		const crypto = yield* Crypto.Crypto;
-		const path = yield* Path.Path;
-		// A case's authored `files` are skill-root-relative (`evals/cases/eval-<n>.md`) and the set
-		// lives at `<skill-root>/evals/evals.json`, so a run stages from two levels above the set.
-		const skillRoot = path.dirname(path.dirname(request.path));
 
 		// The executor is built per invocation, not once for the axis: `cwd` is what makes a run's
 		// directory its own, so an executor shared across the five would re-share the directory (#5437).
@@ -756,7 +752,7 @@ const produceGradedRecord = (request: GradedRunRequest) =>
 					Effect.gen(function* () {
 						const sessionId = yield* Effect.orDie(crypto.randomUUIDv4);
 						const workspace = yield* stageRunWorkspace({
-							skillRoot,
+							setPath: request.path,
 							caseId: evalCase.id,
 							run,
 							sessionId,

--- a/packages/fabrika-cli/src/eval/command.ts
+++ b/packages/fabrika-cli/src/eval/command.ts
@@ -87,6 +87,7 @@ import {
 	composeGraderPrompt,
 	gradableCase,
 	graderResponseOf,
+	type RunVerdict,
 	readGraderVerdict,
 	runGradedAxis,
 } from "./graded-axis.ts";
@@ -107,6 +108,7 @@ import {
 	ruledKeepsViolations,
 	withCoverage,
 } from "./ruled-keeps.ts";
+import {stageRunWorkspace} from "./run-workspace.ts";
 import {readSeriesFiles} from "./series-io.ts";
 import {decodeSkillEvalSet, tierCounts} from "./skill-eval-set.ts";
 import {
@@ -718,47 +720,84 @@ const produceGradedRecord = (request: GradedRunRequest) =>
 		}
 
 		const crypto = yield* Crypto.Crypto;
-		const executor = claudeExecutor({timeoutMs: request.timeoutMs});
-		const invoke = (
-			evalCase: ReturnType<typeof gradableCase>,
-			prompt: string,
-			pluginDir: string | null,
-		) =>
-			Effect.gen(function* () {
-				const sessionId = yield* Effect.orDie(crypto.randomUUIDv4);
-				return yield* executor({
-					caseId: evalCase.id,
-					tier: "graded",
-					arm: "with-skill",
-					sessionId,
-					prompt,
-					model: request.model,
-					pluginDir,
-					jsonSchema: null,
-				});
+		const path = yield* Path.Path;
+		// A case's authored `files` are skill-root-relative (`evals/cases/eval-<n>.md`) and the set
+		// lives at `<skill-root>/evals/evals.json`, so a run stages from two levels above the set.
+		const skillRoot = path.dirname(path.dirname(request.path));
+
+		// The executor is built per invocation, not once for the axis: `cwd` is what makes a run's
+		// directory its own, so an executor shared across the five would re-share the directory (#5437).
+		const invoke = (args: {
+			readonly caseId: number;
+			readonly prompt: string;
+			readonly pluginDir: string | null;
+			readonly sessionId: string;
+			readonly cwd: string | null;
+		}) =>
+			claudeExecutor(
+				args.cwd === null
+					? {timeoutMs: request.timeoutMs}
+					: {timeoutMs: request.timeoutMs, cwd: args.cwd},
+			)({
+				caseId: args.caseId,
+				tier: "graded",
+				arm: "with-skill",
+				sessionId: args.sessionId,
+				prompt: args.prompt,
+				model: request.model,
+				pluginDir: args.pluginDir,
+				jsonSchema: null,
 			});
 
 		const results = yield* runGradedAxis({
 			cases,
-			runOnce: ({evalCase}) =>
-				Effect.gen(function* () {
-					const candidate = candidateOutputOf(
-						yield* invoke(evalCase, evalCase.prompt, request.pluginDir),
-					);
-					if (candidate._tag !== "Output") return candidate;
-					// The grader loads no plugin: it judges what the candidate produced against the
-					// authored expectations, and running the skill again inside the grader would make the
-					// judgement depend on a second execution nobody scored.
-					return readGraderVerdict(
-						graderResponseOf(
-							yield* invoke(
-								evalCase,
-								composeGraderPrompt({evalCase, candidateOutput: candidate.text}),
-								null,
+			runOnce: ({evalCase, run}) =>
+				Effect.scoped(
+					Effect.gen(function* () {
+						const sessionId = yield* Effect.orDie(crypto.randomUUIDv4);
+						const workspace = yield* stageRunWorkspace({
+							skillRoot,
+							caseId: evalCase.id,
+							run,
+							sessionId,
+							files: evalCase.files,
+						});
+						// A run that cannot be isolated is not run un-isolated. Falling back to the
+						// inherited tree is precisely the exposure this closes (#5434/#5437), and a
+						// measurement nobody could isolate is a `NoVerdict`, never a pass or a fail.
+						if (workspace._tag === "Unstageable") {
+							yield* Console.error(
+								`fabrika eval: case ${evalCase.id} run ${run}: no isolated working directory — ${workspace.detail}`,
+							);
+							return {_tag: "NoVerdict", reason: "invocation-failed"} satisfies RunVerdict;
+						}
+						const candidate = candidateOutputOf(
+							yield* invoke({
+								caseId: evalCase.id,
+								prompt: evalCase.prompt,
+								pluginDir: request.pluginDir,
+								sessionId,
+								cwd: workspace.dir,
+							}),
+						);
+						if (candidate._tag !== "Output") return candidate;
+						// The grader loads no plugin: it judges what the candidate produced against the
+						// authored expectations, and running the skill again inside the grader would make the
+						// judgement depend on a second execution nobody scored. It is handed the authored
+						// expectations in-process and stages nothing, so it needs no directory of its own.
+						return readGraderVerdict(
+							graderResponseOf(
+								yield* invoke({
+									caseId: evalCase.id,
+									prompt: composeGraderPrompt({evalCase, candidateOutput: candidate.text}),
+									pluginDir: null,
+									sessionId: yield* Effect.orDie(crypto.randomUUIDv4),
+									cwd: null,
+								}),
 							),
-						),
-					);
-				}),
+						);
+					}),
+				),
 		});
 
 		const built = buildEvalRecord({

--- a/packages/fabrika-cli/src/eval/graded-axis.ts
+++ b/packages/fabrika-cli/src/eval/graded-axis.ts
@@ -136,6 +136,11 @@ export interface GradableCase {
 	readonly expectedOutput: string | null;
 	/** The authored judgment assertions, verbatim. This is the rubric, and the only one. */
 	readonly expectations: ReadonlyArray<string>;
+	/**
+	 * The authored `files` — the fixture material this case needs, and the whole of what a run's
+	 * working directory is staged with (`./run-workspace.ts`, #5434/#5437).
+	 */
+	readonly files: ReadonlyArray<string>;
 }
 
 /**
@@ -147,12 +152,14 @@ export const gradableCase = (evalCase: {
 	readonly id: number;
 	readonly prompt: string;
 	readonly expectedOutput: string | null;
+	readonly files: ReadonlyArray<string>;
 	readonly assertions: ReadonlyArray<{readonly text: string}>;
 }): GradableCase => ({
 	id: evalCase.id,
 	prompt: evalCase.prompt,
 	expectedOutput: evalCase.expectedOutput,
 	expectations: evalCase.assertions.map((assertion) => assertion.text),
+	files: evalCase.files,
 });
 
 /**

--- a/packages/fabrika-cli/src/eval/graded-axis.ts
+++ b/packages/fabrika-cli/src/eval/graded-axis.ts
@@ -138,9 +138,10 @@ export interface GradableCase {
 	readonly expectations: ReadonlyArray<string>;
 	/**
 	 * The authored `files` — the fixture material this case needs, and the whole of what a run's
-	 * working directory is staged with (`./run-workspace.ts`, #5434/#5437).
+	 * working directory is staged with. `null` when the case never declared the key, which is not the
+	 * same as declaring none (`./run-workspace.ts`, #5434/#5437).
 	 */
-	readonly files: ReadonlyArray<string>;
+	readonly files: ReadonlyArray<string> | null;
 }
 
 /**
@@ -152,7 +153,7 @@ export const gradableCase = (evalCase: {
 	readonly id: number;
 	readonly prompt: string;
 	readonly expectedOutput: string | null;
-	readonly files: ReadonlyArray<string>;
+	readonly files: ReadonlyArray<string> | null;
 	readonly assertions: ReadonlyArray<{readonly text: string}>;
 }): GradableCase => ({
 	id: evalCase.id,

--- a/packages/fabrika-cli/src/eval/graded-axis.unit.test.ts
+++ b/packages/fabrika-cli/src/eval/graded-axis.unit.test.ts
@@ -38,6 +38,7 @@ const caseOf = (id: number, over: Partial<GradableCase> = {}): GradableCase => (
 	prompt: "File a report for the guard that reds on zero scope.",
 	expectedOutput: "One issue, tagged needs-triage.",
 	expectations: ["it files exactly one issue", "the issue carries no priority label"],
+	files: [`evals/cases/eval-${id}.md`],
 	...over,
 });
 

--- a/packages/fabrika-cli/src/eval/run-workspace.ts
+++ b/packages/fabrika-cli/src/eval/run-workspace.ts
@@ -8,8 +8,10 @@
  *
  * The fix is to stage rather than inherit. Each run gets a fresh directory holding **only** the
  * fixture material its own case declares in the authored `files` field, at the same relative path the
- * case's prompt reads (`evals/cases/eval-<n>.md`), and nothing else. What was never copied cannot be
- * read, so isolation is a property of the directory rather than of the candidate's restraint.
+ * case's prompt reads (`fixtures/eval-<n>.md`), and nothing else. What was never copied cannot be
+ * read, so isolation is a property of the directory rather than of the candidate's restraint. A case
+ * whose declared material cannot all be staged is `Unstageable` and scores nothing — the directory is
+ * the only thing the candidate can read, so a partial one measures a question nobody asked.
  *
  * The staging *decision* is pure ({@link stagingPlan}, {@link runDirName}); {@link stageRunWorkspace}
  * is the only part that touches a filesystem, through the services
@@ -27,11 +29,20 @@ export const EVAL_SET_FILE = "evals.json";
 export interface RefusedFixture {
 	readonly path: string;
 	readonly reason: string;
+	/**
+	 * Whether the refusal leaves the run unmeasurable.
+	 *
+	 * The answer key is the one entry a case may declare and still run without: withholding it is the
+	 * whole point, and every other fixture it named is still there. Every other refusal means the
+	 * candidate will be told to read material that is not in its directory, which is a run that cannot
+	 * measure what it claims to — so it blocks (#5434).
+	 */
+	readonly blocking: boolean;
 }
 
 /** What a case's declared `files` resolve to: what gets copied, and what was refused and why. */
 export interface StagingPlan {
-	/** Skill-root-relative paths, staged at the same relative path so the authored prompt resolves. */
+	/** Authored relative paths, staged at the same relative path so the authored prompt resolves. */
 	readonly staged: ReadonlyArray<string>;
 	readonly refused: ReadonlyArray<RefusedFixture>;
 }
@@ -41,12 +52,22 @@ const segmentsOf = (file: string): ReadonlyArray<string> => file.split(/[\\/]/);
 const isAbsolute = (file: string): boolean =>
 	file.startsWith("/") || file.startsWith("\\") || /^[A-Za-z]:[\\/]/.test(file);
 
-const refusalReason = (file: string): string | null => {
-	if (file.trim() === "") return "the entry is blank";
-	if (isAbsolute(file)) return "an absolute path would stage material from outside the eval set";
-	if (segmentsOf(file).includes("..")) return "a `..` segment would escape the run directory";
+const refusalOf = (file: string): Omit<RefusedFixture, "path"> | null => {
+	if (file.trim() === "") return {reason: "the entry is blank", blocking: true};
+	if (isAbsolute(file)) {
+		return {
+			reason: "an absolute path would stage material from outside the eval set",
+			blocking: true,
+		};
+	}
+	if (segmentsOf(file).includes("..")) {
+		return {reason: "a `..` segment would escape the run directory", blocking: true};
+	}
 	if (segmentsOf(file).at(-1) === EVAL_SET_FILE) {
-		return `${EVAL_SET_FILE} is the authored answer key — a candidate never gets it`;
+		return {
+			reason: `${EVAL_SET_FILE} is the authored answer key — a candidate never gets it`,
+			blocking: false,
+		};
 	}
 	return null;
 };
@@ -54,17 +75,17 @@ const refusalReason = (file: string): string | null => {
 /**
  * Resolve a case's declared `files` into what may be staged.
  *
- * A refusal drops one entry and never fails the run: a case that names an unstageable path still gets
- * an isolated directory, and fails on its own terms with the refusal on stderr — which is the honest
- * outcome. Silently widening the directory to satisfy such an entry is the one thing this cannot do.
+ * Silently widening the run directory to satisfy a refused entry is the one thing this cannot do; a
+ * blocking refusal instead makes the run {@link RunWorkspace.Unstageable}, so the run records no
+ * verdict rather than a scored one taken in a directory missing what the prompt reads.
  */
 export const stagingPlan = (files: ReadonlyArray<string>): StagingPlan => {
 	const staged: Array<string> = [];
 	const refused: Array<RefusedFixture> = [];
 	for (const file of files) {
-		const reason = refusalReason(file);
-		if (reason !== null) {
-			refused.push({path: file, reason});
+		const refusal = refusalOf(file);
+		if (refusal !== null) {
+			refused.push({path: file, ...refusal});
 			continue;
 		}
 		if (!staged.includes(file)) staged.push(file);
@@ -101,10 +122,14 @@ export type RunWorkspace =
  *
  * Scoped: the directory is removed when the caller's scope closes, so isolation does not trade the
  * answer-key hole for a working-tree-pollution one.
+ *
+ * A declared fixture that cannot be staged returns `Unstageable`, never a `Staged` directory missing
+ * it: the candidate would be spawned into a tree without the material its prompt names, and the
+ * verdict it produced would still be counted by `medianVerdict` and `dispersion` (#5434).
  */
 export const stageRunWorkspace = (args: {
-	/** The directory the authored `files` are relative to — where `evals/cases/…` resolves from. */
-	readonly skillRoot: string;
+	/** The authored eval set's own path — the two candidate bases below are derived from it. */
+	readonly setPath: string;
 	readonly caseId: number;
 	readonly run: number;
 	readonly sessionId: string;
@@ -114,6 +139,25 @@ export const stageRunWorkspace = (args: {
 		const fs = yield* FileSystem.FileSystem;
 		const path = yield* Path.Path;
 		const where = `case ${args.caseId} run ${args.run}`;
+		// The corpus authors two conventions and neither is wrong, so the base is found rather than
+		// assumed — set-directory-relative (`fixtures/…`) first, then skill-root-relative
+		// (`evals/fixtures/…`). Assuming one silently failed to copy for every set using the other.
+		const setDir = path.dirname(args.setPath);
+		const bases = [setDir, path.dirname(setDir)];
+
+		const plan = stagingPlan(args.files);
+		for (const refusal of plan.refused) {
+			yield* Console.error(
+				`fabrika eval: ${where}: not staging ${refusal.path} — ${refusal.reason}`,
+			);
+		}
+		const blocked = plan.refused.filter((refusal) => refusal.blocking);
+		if (blocked.length > 0) {
+			return {
+				_tag: "Unstageable",
+				detail: blocked.map((r) => `${r.path} (${r.reason})`).join("; "),
+			};
+		}
 
 		const parent = yield* Effect.result(fs.makeTempDirectoryScoped({prefix: "fabrika-graded-"}));
 		if (Result.isFailure(parent)) {
@@ -125,20 +169,26 @@ export const stageRunWorkspace = (args: {
 			return {_tag: "Unstageable", detail: made.failure.message};
 		}
 
-		const plan = stagingPlan(args.files);
-		for (const refusal of plan.refused) {
-			yield* Console.error(
-				`fabrika eval: ${where}: not staging ${refusal.path} — ${refusal.reason}`,
-			);
-		}
 		for (const file of plan.staged) {
 			const to = path.join(dir, file);
+			let from: string | null = null;
+			for (const base of bases) {
+				const candidate = path.join(base, file);
+				if (yield* fs.exists(candidate).pipe(Effect.orElseSucceed(() => false))) {
+					from = candidate;
+					break;
+				}
+			}
+			if (from === null) {
+				return {
+					_tag: "Unstageable",
+					detail: `${file} resolves under none of ${bases.join(", ")}`,
+				};
+			}
 			yield* Effect.ignore(fs.makeDirectory(path.dirname(to), {recursive: true}));
-			const copied = yield* Effect.result(fs.copy(path.join(args.skillRoot, file), to));
+			const copied = yield* Effect.result(fs.copy(from, to));
 			if (Result.isFailure(copied)) {
-				yield* Console.error(
-					`fabrika eval: ${where}: could not stage ${file} — ${copied.failure.message}`,
-				);
+				return {_tag: "Unstageable", detail: `${file}: ${copied.failure.message}`};
 			}
 		}
 		return {_tag: "Staged", dir};

--- a/packages/fabrika-cli/src/eval/run-workspace.ts
+++ b/packages/fabrika-cli/src/eval/run-workspace.ts
@@ -1,0 +1,145 @@
+/**
+ * The per-`(case, run)` ephemeral working directory a graded candidate is spawned into (#5434, #5437).
+ *
+ * A graded run used to inherit the verb process's own working directory, so every run of every case
+ * saw one tree: the authored `evals.json` — `expected_output` plus the whole assertion list — sat one
+ * relative path from the candidate, and run N could read run N−1's deliverables. Two defects, one
+ * cause, and `dispersion` (ADR 0252 §1) counts runs it assumes are independent.
+ *
+ * The fix is to stage rather than inherit. Each run gets a fresh directory holding **only** the
+ * fixture material its own case declares in the authored `files` field, at the same relative path the
+ * case's prompt reads (`evals/cases/eval-<n>.md`), and nothing else. What was never copied cannot be
+ * read, so isolation is a property of the directory rather than of the candidate's restraint.
+ *
+ * The staging *decision* is pure ({@link stagingPlan}, {@link runDirName}); {@link stageRunWorkspace}
+ * is the only part that touches a filesystem, through the services
+ * [.patterns/effect-platform-access.md](../../../../.patterns/effect-platform-access.md) names.
+ */
+import {Console, Effect, FileSystem, Path, Result, type Scope} from "effect";
+
+/**
+ * The authored eval set's own file name. It is the answer key, so it is refused by name even when a
+ * case declares it — the one fixture entry that must never resolve inside a candidate's directory.
+ */
+export const EVAL_SET_FILE = "evals.json";
+
+/** A declared fixture that will not be staged, and the reason a reader needs to see. */
+export interface RefusedFixture {
+	readonly path: string;
+	readonly reason: string;
+}
+
+/** What a case's declared `files` resolve to: what gets copied, and what was refused and why. */
+export interface StagingPlan {
+	/** Skill-root-relative paths, staged at the same relative path so the authored prompt resolves. */
+	readonly staged: ReadonlyArray<string>;
+	readonly refused: ReadonlyArray<RefusedFixture>;
+}
+
+const segmentsOf = (file: string): ReadonlyArray<string> => file.split(/[\\/]/);
+
+const isAbsolute = (file: string): boolean =>
+	file.startsWith("/") || file.startsWith("\\") || /^[A-Za-z]:[\\/]/.test(file);
+
+const refusalReason = (file: string): string | null => {
+	if (file.trim() === "") return "the entry is blank";
+	if (isAbsolute(file)) return "an absolute path would stage material from outside the eval set";
+	if (segmentsOf(file).includes("..")) return "a `..` segment would escape the run directory";
+	if (segmentsOf(file).at(-1) === EVAL_SET_FILE) {
+		return `${EVAL_SET_FILE} is the authored answer key — a candidate never gets it`;
+	}
+	return null;
+};
+
+/**
+ * Resolve a case's declared `files` into what may be staged.
+ *
+ * A refusal drops one entry and never fails the run: a case that names an unstageable path still gets
+ * an isolated directory, and fails on its own terms with the refusal on stderr — which is the honest
+ * outcome. Silently widening the directory to satisfy such an entry is the one thing this cannot do.
+ */
+export const stagingPlan = (files: ReadonlyArray<string>): StagingPlan => {
+	const staged: Array<string> = [];
+	const refused: Array<RefusedFixture> = [];
+	for (const file of files) {
+		const reason = refusalReason(file);
+		if (reason !== null) {
+			refused.push({path: file, reason});
+			continue;
+		}
+		if (!staged.includes(file)) staged.push(file);
+	}
+	return {staged, refused};
+};
+
+/**
+ * The run's directory name.
+ *
+ * It carries the session id the same spawn passes as `--session-id`, so which of the five runs a
+ * directory belongs to is legible on disk — the run identity the graded verb otherwise persists
+ * nowhere (#5429). This is a name, not a record field: the ADR 0253 record shape is untouched.
+ */
+export const runDirName = (args: {
+	readonly caseId: number;
+	readonly run: number;
+	readonly sessionId: string;
+}): string => `case${args.caseId}-run${args.run}-${args.sessionId}`;
+
+/**
+ * A staged directory, or why there is none.
+ *
+ * `Unstageable` exists so a caller can never quietly fall back to the inherited working directory: a
+ * run that could not be isolated is a run that must not happen, because an un-isolated run is exactly
+ * the measurement these two defects made untrustworthy.
+ */
+export type RunWorkspace =
+	| {readonly _tag: "Staged"; readonly dir: string}
+	| {readonly _tag: "Unstageable"; readonly detail: string};
+
+/**
+ * Make one run's working directory and copy that case's fixture material into it.
+ *
+ * Scoped: the directory is removed when the caller's scope closes, so isolation does not trade the
+ * answer-key hole for a working-tree-pollution one.
+ */
+export const stageRunWorkspace = (args: {
+	/** The directory the authored `files` are relative to — where `evals/cases/…` resolves from. */
+	readonly skillRoot: string;
+	readonly caseId: number;
+	readonly run: number;
+	readonly sessionId: string;
+	readonly files: ReadonlyArray<string>;
+}): Effect.Effect<RunWorkspace, never, FileSystem.FileSystem | Path.Path | Scope.Scope> =>
+	Effect.gen(function* () {
+		const fs = yield* FileSystem.FileSystem;
+		const path = yield* Path.Path;
+		const where = `case ${args.caseId} run ${args.run}`;
+
+		const parent = yield* Effect.result(fs.makeTempDirectoryScoped({prefix: "fabrika-graded-"}));
+		if (Result.isFailure(parent)) {
+			return {_tag: "Unstageable", detail: parent.failure.message};
+		}
+		const dir = path.join(parent.success, runDirName(args));
+		const made = yield* Effect.result(fs.makeDirectory(dir, {recursive: true}));
+		if (Result.isFailure(made)) {
+			return {_tag: "Unstageable", detail: made.failure.message};
+		}
+
+		const plan = stagingPlan(args.files);
+		for (const refusal of plan.refused) {
+			yield* Console.error(
+				`fabrika eval: ${where}: not staging ${refusal.path} — ${refusal.reason}`,
+			);
+		}
+		for (const file of plan.staged) {
+			const to = path.join(dir, file);
+			yield* Effect.ignore(fs.makeDirectory(path.dirname(to), {recursive: true}));
+			const copied = yield* Effect.result(fs.copy(path.join(args.skillRoot, file), to));
+			if (Result.isFailure(copied)) {
+				yield* Console.error(
+					`fabrika eval: ${where}: could not stage ${file} — ${copied.failure.message}`,
+				);
+			}
+		}
+		return {_tag: "Staged", dir};
+	});

--- a/packages/fabrika-cli/src/eval/run-workspace.ts
+++ b/packages/fabrika-cli/src/eval/run-workspace.ts
@@ -13,6 +13,15 @@
  * whose declared material cannot all be staged is `Unstageable` and scores nothing — the directory is
  * the only thing the candidate can read, so a partial one measures a question nobody asked.
  *
+ * The same rule reaches the case that declares **nothing**, and the distinction it turns on is
+ * declared-none versus never-declared. `files: []` is the author stating this case needs no material,
+ * so an empty directory is exactly right and the run scores. An **absent** `files` key states nothing,
+ * and 22 of the corpus's graded cases at this writing are absent-key cases whose prompts name material
+ * by path — so an empty directory is a directory provably short of what the prompt reads, and it is
+ * `Unstageable`. Absence of a declaration is not evidence that a case is self-contained, and the
+ * failure it would otherwise produce is the silent one: a `pass`/`fail` indistinguishable in the
+ * record from a measurement (#5434).
+ *
  * The staging *decision* is pure ({@link stagingPlan}, {@link runDirName}); {@link stageRunWorkspace}
  * is the only part that touches a filesystem, through the services
  * [.patterns/effect-platform-access.md](../../../../.patterns/effect-platform-access.md) names.
@@ -125,7 +134,8 @@ export type RunWorkspace =
  *
  * A declared fixture that cannot be staged returns `Unstageable`, never a `Staged` directory missing
  * it: the candidate would be spawned into a tree without the material its prompt names, and the
- * verdict it produced would still be counted by `medianVerdict` and `dispersion` (#5434).
+ * verdict it produced would still be counted by `medianVerdict` and `dispersion` (#5434). An
+ * **undeclared** `files` (`null`) returns `Unstageable` for the same reason, one step earlier.
  */
 export const stageRunWorkspace = (args: {
 	/** The authored eval set's own path — the two candidate bases below are derived from it. */
@@ -133,19 +143,28 @@ export const stageRunWorkspace = (args: {
 	readonly caseId: number;
 	readonly run: number;
 	readonly sessionId: string;
-	readonly files: ReadonlyArray<string>;
+	/** `null` when the case never declared the key — see the undeclared rule at the top of this file. */
+	readonly files: ReadonlyArray<string> | null;
 }): Effect.Effect<RunWorkspace, never, FileSystem.FileSystem | Path.Path | Scope.Scope> =>
 	Effect.gen(function* () {
 		const fs = yield* FileSystem.FileSystem;
 		const path = yield* Path.Path;
 		const where = `case ${args.caseId} run ${args.run}`;
+		const declared = args.files;
+		if (declared === null) {
+			return {
+				_tag: "Unstageable",
+				detail:
+					"the case declares no `files` — an absent declaration is not a claim that the case is self-contained, so what its prompt reads cannot be staged (author `files: []` to state it needs none)",
+			};
+		}
 		// The corpus authors two conventions and neither is wrong, so the base is found rather than
 		// assumed — set-directory-relative (`fixtures/…`) first, then skill-root-relative
 		// (`evals/fixtures/…`). Assuming one silently failed to copy for every set using the other.
 		const setDir = path.dirname(args.setPath);
 		const bases = [setDir, path.dirname(setDir)];
 
-		const plan = stagingPlan(args.files);
+		const plan = stagingPlan(declared);
 		for (const refusal of plan.refused) {
 			yield* Console.error(
 				`fabrika eval: ${where}: not staging ${refusal.path} — ${refusal.reason}`,

--- a/packages/fabrika-cli/src/eval/run-workspace.unit.test.ts
+++ b/packages/fabrika-cli/src/eval/run-workspace.unit.test.ts
@@ -43,10 +43,17 @@ const gradableCase: GradableCase = {
 	files: [FIXTURE],
 };
 
-/** A skill root shaped like a real one: the authored set beside the case material it points at. */
+/**
+ * A skill root shaped like a real one: the authored set beside the case material it points at.
+ *
+ * It carries the same file under **both** authored conventions — skill-root-relative
+ * `evals/cases/eval-1.md` and set-directory-relative `fixtures/eval-1.md` — because the corpus uses
+ * both and a run has to resolve either (#5434).
+ */
 const makeSkillRoot = (): string => {
 	const root = mkdtempSync(join(tmpdir(), "fabrika-skill-"));
 	mkdirSync(join(root, "evals", "cases"), {recursive: true});
+	mkdirSync(join(root, "evals", "fixtures"), {recursive: true});
 	writeFileSync(
 		join(root, "evals", EVAL_SET_FILE),
 		JSON.stringify({
@@ -56,8 +63,11 @@ const makeSkillRoot = (): string => {
 	);
 	writeFileSync(join(root, "evals", "cases", "eval-1.md"), FIXTURE_BODY);
 	writeFileSync(join(root, "evals", "cases", "eval-2.md"), "another case's fixture material");
+	writeFileSync(join(root, "evals", "fixtures", "eval-1.md"), FIXTURE_BODY);
 	return root;
 };
+
+const setPathOf = (skillRoot: string): string => join(skillRoot, "evals", EVAL_SET_FILE);
 
 /** Every path under `dir`, relative and slash-normalised — what a candidate could reach. */
 const treeOf = (dir: string): ReadonlyArray<string> =>
@@ -77,12 +87,15 @@ describe("which declared fixtures may be staged", () => {
 		const plan = stagingPlan([FIXTURE, `evals/${EVAL_SET_FILE}`]);
 		expect(plan.staged).toEqual([FIXTURE]);
 		expect(plan.refused.map((refusal) => refusal.path)).toEqual([`evals/${EVAL_SET_FILE}`]);
+		// Withholding the answer key is the point, so it is the one refusal a run survives.
+		expect(plan.refused.map((refusal) => refusal.blocking)).toEqual([false]);
 	});
 
-	it("refuses paths that would reach outside the run directory", () => {
+	it("refuses paths that would reach outside the run directory, and blocks the run", () => {
 		const plan = stagingPlan(["/etc/passwd", "../evals/cases/eval-2.md", "  ", "C:\\keys.json"]);
 		expect(plan.staged).toEqual([]);
 		expect(plan.refused).toHaveLength(4);
+		expect(plan.refused.every((refusal) => refusal.blocking)).toBe(true);
 	});
 
 	it("stages a repeated entry once", () => {
@@ -110,7 +123,7 @@ describe("the five graded runs of one case", () => {
 	 * Drive the real axis with a stub that stages, snapshots what it was handed, and only then writes
 	 * a deliverable — the shape a candidate leaves behind, and what the next run must not be able to see.
 	 */
-	const stageFiveRuns = () =>
+	const stageFiveRuns = (evalCase: GradableCase = gradableCase) =>
 		live(
 			Effect.gen(function* () {
 				const fs = yield* FileSystem.FileSystem;
@@ -121,13 +134,13 @@ describe("the five graded runs of one case", () => {
 					readonly staged: ReadonlyArray<string>;
 					readonly bytes: string;
 				}> = [];
-				yield* runGradedAxis({
-					cases: [gradableCase],
+				const results = yield* runGradedAxis({
+					cases: [evalCase],
 					runOnce: ({evalCase, run}) =>
 						Effect.scoped(
 							Effect.gen(function* () {
 								const workspace = yield* stageRunWorkspace({
-									skillRoot,
+									setPath: setPathOf(skillRoot),
 									caseId: evalCase.id,
 									run,
 									sessionId: `session-${run}`,
@@ -152,12 +165,12 @@ describe("the five graded runs of one case", () => {
 							}),
 						),
 				});
-				return observed;
+				return {observed, results};
 			}),
 		);
 
 	it("each execute in their own fresh directory, with no sibling run's deliverables in it", async () => {
-		const observed = await stageFiveRuns();
+		const {observed} = await stageFiveRuns();
 
 		expect(observed).toHaveLength(5);
 		expect(new Set(observed.map((run) => run.dir)).size).toBe(5);
@@ -169,7 +182,7 @@ describe("the five graded runs of one case", () => {
 	});
 
 	it("hold the case's own fixture at the path its authored prompt reads, and nothing else", async () => {
-		const observed = await stageFiveRuns();
+		const {observed} = await stageFiveRuns();
 
 		for (const run of observed) {
 			expect(run.staged).toEqual(["evals", "evals/cases", FIXTURE]);
@@ -180,8 +193,65 @@ describe("the five graded runs of one case", () => {
 	});
 
 	it("are removed when the run's scope closes, so isolation leaves nothing behind", async () => {
-		const observed = await stageFiveRuns();
+		const {observed} = await stageFiveRuns();
 
 		for (const run of observed) expect(existsSync(run.dir)).toBe(false);
+	});
+
+	// The majority convention in the corpus: `files` relative to the set's own directory, not the
+	// skill root. Both must resolve, or the base this consumer picked silently decides which sets run.
+	it("resolve a set-directory-relative fixture as well as a skill-root-relative one", async () => {
+		const {observed} = await stageFiveRuns({...gradableCase, files: ["fixtures/eval-1.md"]});
+
+		expect(observed).toHaveLength(5);
+		for (const run of observed) {
+			expect(run.staged).toEqual(["fixtures", "fixtures/eval-1.md"]);
+			expect(run.bytes).toBe(FIXTURE_BODY);
+		}
+	});
+
+	/**
+	 * The compounding half of #5434: a fixture that cannot be staged used to leave a `Staged` empty
+	 * directory, so the candidate was spawned without the material its prompt names and the verdict it
+	 * produced was still counted. The run must reach `Unstageable` instead, and land in the median as
+	 * `unmeasured`.
+	 */
+	it("score nothing when a declared fixture resolves under no base", async () => {
+		const {observed, results} = await stageFiveRuns({
+			...gradableCase,
+			files: ["fixtures/no-such-case.md"],
+		});
+
+		expect(observed).toEqual([]);
+		expect(results).toHaveLength(1);
+		expect(results[0]?.verdict).toBe("unmeasured");
+		expect(results[0]?.noVerdict).toBe(5);
+		expect(results[0]?.passed).toBe(0);
+	});
+
+	it("score nothing when a declared fixture would escape the run directory", async () => {
+		const {observed, results} = await stageFiveRuns({
+			...gradableCase,
+			files: [FIXTURE, "../evals/cases/eval-2.md"],
+		});
+
+		expect(observed).toEqual([]);
+		expect(results[0]?.verdict).toBe("unmeasured");
+		expect(results[0]?.noVerdict).toBe(5);
+	});
+
+	// The one refusal a run survives: the case still has everything else it declared.
+	it("still run when the case declares the answer key, which is withheld", async () => {
+		const {observed, results} = await stageFiveRuns({
+			...gradableCase,
+			files: [FIXTURE, `evals/${EVAL_SET_FILE}`],
+		});
+
+		expect(observed).toHaveLength(5);
+		expect(results[0]?.verdict).toBe("pass");
+		for (const run of observed) {
+			expect(run.staged).not.toContain(`evals/${EVAL_SET_FILE}`);
+			expect(run.bytes).not.toContain("answer key");
+		}
 	});
 });

--- a/packages/fabrika-cli/src/eval/run-workspace.unit.test.ts
+++ b/packages/fabrika-cli/src/eval/run-workspace.unit.test.ts
@@ -240,6 +240,35 @@ describe("the five graded runs of one case", () => {
 		expect(results[0]?.noVerdict).toBe(5);
 	});
 
+	/**
+	 * The other door onto the same defect: a case that declares **nothing** used to get a `Staged`
+	 * empty directory and score out of it, silently — a `pass`/`fail` no reader could tell from a
+	 * measurement. 22 of the corpus's graded cases are this shape and their prompts name material by
+	 * path, so an absent declaration must reach `unmeasured` too.
+	 */
+	it("score nothing when the case declares no `files` at all", async () => {
+		const {observed, results} = await stageFiveRuns({...gradableCase, files: null});
+
+		expect(observed).toEqual([]);
+		expect(results).toHaveLength(1);
+		expect(results[0]?.verdict).toBe("unmeasured");
+		expect(results[0]?.noVerdict).toBe(5);
+		expect(results[0]?.passed).toBe(0);
+	});
+
+	// The other side of that rule, and why it is keyed on the declaration rather than on emptiness: an
+	// authored `files: []` IS a claim — this case needs no material — so an empty directory is right.
+	it("run in an empty directory when the case declares it needs no material", async () => {
+		const {observed, results} = await stageFiveRuns({...gradableCase, files: []});
+
+		expect(observed).toHaveLength(5);
+		expect(results[0]?.verdict).toBe("pass");
+		for (const run of observed) {
+			expect(run.staged).toEqual([]);
+			expect(run.bytes).toBe("");
+		}
+	});
+
 	// The one refusal a run survives: the case still has everything else it declared.
 	it("still run when the case declares the answer key, which is withheld", async () => {
 		const {observed, results} = await stageFiveRuns({

--- a/packages/fabrika-cli/src/eval/run-workspace.unit.test.ts
+++ b/packages/fabrika-cli/src/eval/run-workspace.unit.test.ts
@@ -1,0 +1,187 @@
+/**
+ * What lands in a graded candidate's working directory, and that it is that run's alone (#5434, #5437).
+ *
+ * The two defects were one cause, so they are pinned by one test. A check that only asserts "no
+ * `evals.json` in the directory" passes on a build where all five runs still share one, and a check
+ * that only counts directories passes on a build that stages the answer key into each — so both
+ * properties are asserted over the same five staged runs, driven through the real `runGradedAxis` so
+ * the per-run threading `command.ts` depends on is exercised rather than assumed.
+ *
+ * The staging tier runs against the real Node filesystem on purpose: "the answer key is not there" is
+ * a property of the directory, and a scripted `FileSystem` double would assert the calls that were
+ * made instead of what a candidate could open.
+ */
+import {
+	existsSync,
+	mkdirSync,
+	mkdtempSync,
+	readdirSync,
+	readFileSync,
+	rmSync,
+	statSync,
+	writeFileSync,
+} from "node:fs";
+import {tmpdir} from "node:os";
+import {join} from "node:path";
+import {NodeServices} from "@effect/platform-node";
+import {Effect, FileSystem, Path} from "effect";
+import {afterEach, beforeEach, describe, expect, it} from "vitest";
+import {type GradableCase, type RunVerdict, runGradedAxis} from "./graded-axis.ts";
+import {EVAL_SET_FILE, runDirName, stageRunWorkspace, stagingPlan} from "./run-workspace.ts";
+
+const live = <A, E>(effect: Effect.Effect<A, E, FileSystem.FileSystem | Path.Path>): Promise<A> =>
+	Effect.runPromise(Effect.provide(effect, NodeServices.layer));
+
+const FIXTURE = "evals/cases/eval-1.md";
+const FIXTURE_BODY = "the case's own fixture material";
+
+const gradableCase: GradableCase = {
+	id: 1,
+	prompt: "Read evals/cases/eval-1.md and do what it asks.",
+	expectedOutput: "The pattern clears the bar; terminal PATTERN-RECORDED.",
+	expectations: ["the terminal is PATTERN-RECORDED"],
+	files: [FIXTURE],
+};
+
+/** A skill root shaped like a real one: the authored set beside the case material it points at. */
+const makeSkillRoot = (): string => {
+	const root = mkdtempSync(join(tmpdir(), "fabrika-skill-"));
+	mkdirSync(join(root, "evals", "cases"), {recursive: true});
+	writeFileSync(
+		join(root, "evals", EVAL_SET_FILE),
+		JSON.stringify({
+			skill_name: "write-pattern",
+			evals: [{id: 1, expected_output: "the answer key nobody under test may read"}],
+		}),
+	);
+	writeFileSync(join(root, "evals", "cases", "eval-1.md"), FIXTURE_BODY);
+	writeFileSync(join(root, "evals", "cases", "eval-2.md"), "another case's fixture material");
+	return root;
+};
+
+/** Every path under `dir`, relative and slash-normalised — what a candidate could reach. */
+const treeOf = (dir: string): ReadonlyArray<string> =>
+	readdirSync(dir, {recursive: true, encoding: "utf8"})
+		.map((entry) => entry.replaceAll("\\", "/"))
+		.sort();
+
+const bytesUnder = (dir: string): string =>
+	treeOf(dir)
+		.map((entry) => join(dir, entry))
+		.filter((full) => statSync(full).isFile())
+		.map((full) => readFileSync(full, "utf8"))
+		.join("\n");
+
+describe("which declared fixtures may be staged", () => {
+	it("refuses the authored eval set by name — the answer key is never a fixture", () => {
+		const plan = stagingPlan([FIXTURE, `evals/${EVAL_SET_FILE}`]);
+		expect(plan.staged).toEqual([FIXTURE]);
+		expect(plan.refused.map((refusal) => refusal.path)).toEqual([`evals/${EVAL_SET_FILE}`]);
+	});
+
+	it("refuses paths that would reach outside the run directory", () => {
+		const plan = stagingPlan(["/etc/passwd", "../evals/cases/eval-2.md", "  ", "C:\\keys.json"]);
+		expect(plan.staged).toEqual([]);
+		expect(plan.refused).toHaveLength(4);
+	});
+
+	it("stages a repeated entry once", () => {
+		expect(stagingPlan([FIXTURE, FIXTURE]).staged).toEqual([FIXTURE]);
+	});
+});
+
+describe("a run's directory name", () => {
+	it("carries the case, the 1-based run and the session id the same spawn is pinned to", () => {
+		expect(runDirName({caseId: 3, run: 4, sessionId: "9f1c0d2b"})).toBe("case3-run4-9f1c0d2b");
+	});
+});
+
+describe("the five graded runs of one case", () => {
+	let skillRoot = "";
+
+	beforeEach(() => {
+		skillRoot = makeSkillRoot();
+	});
+	afterEach(() => {
+		rmSync(skillRoot, {recursive: true, force: true});
+	});
+
+	/**
+	 * Drive the real axis with a stub that stages, snapshots what it was handed, and only then writes
+	 * a deliverable — the shape a candidate leaves behind, and what the next run must not be able to see.
+	 */
+	const stageFiveRuns = () =>
+		live(
+			Effect.gen(function* () {
+				const fs = yield* FileSystem.FileSystem;
+				const path = yield* Path.Path;
+				const observed: Array<{
+					readonly run: number;
+					readonly dir: string;
+					readonly staged: ReadonlyArray<string>;
+					readonly bytes: string;
+				}> = [];
+				yield* runGradedAxis({
+					cases: [gradableCase],
+					runOnce: ({evalCase, run}) =>
+						Effect.scoped(
+							Effect.gen(function* () {
+								const workspace = yield* stageRunWorkspace({
+									skillRoot,
+									caseId: evalCase.id,
+									run,
+									sessionId: `session-${run}`,
+									files: evalCase.files,
+								});
+								if (workspace._tag !== "Staged") {
+									return {_tag: "NoVerdict", reason: "invocation-failed"} satisfies RunVerdict;
+								}
+								observed.push({
+									run,
+									dir: workspace.dir,
+									staged: treeOf(workspace.dir),
+									bytes: bytesUnder(workspace.dir),
+								});
+								yield* Effect.orDie(
+									fs.writeFileString(
+										path.join(workspace.dir, "VERDICT-DRAFT.md"),
+										`run ${run} says PASS`,
+									),
+								);
+								return {_tag: "Verdict", passed: true} satisfies RunVerdict;
+							}),
+						),
+				});
+				return observed;
+			}),
+		);
+
+	it("each execute in their own fresh directory, with no sibling run's deliverables in it", async () => {
+		const observed = await stageFiveRuns();
+
+		expect(observed).toHaveLength(5);
+		expect(new Set(observed.map((run) => run.dir)).size).toBe(5);
+		for (const run of observed) {
+			expect(run.dir.endsWith(`case1-run${run.run}-session-${run.run}`)).toBe(true);
+			expect(run.staged).not.toContain("VERDICT-DRAFT.md");
+			expect(run.bytes).not.toContain("says PASS");
+		}
+	});
+
+	it("hold the case's own fixture at the path its authored prompt reads, and nothing else", async () => {
+		const observed = await stageFiveRuns();
+
+		for (const run of observed) {
+			expect(run.staged).toEqual(["evals", "evals/cases", FIXTURE]);
+			expect(run.bytes).toBe(FIXTURE_BODY);
+			expect(run.bytes).not.toContain("expected_output");
+			expect(run.bytes).not.toContain("answer key");
+		}
+	});
+
+	it("are removed when the run's scope closes, so isolation leaves nothing behind", async () => {
+		const observed = await stageFiveRuns();
+
+		for (const run of observed) expect(existsSync(run.dir)).toBe(false);
+	});
+});

--- a/packages/fabrika-cli/src/eval/skill-eval-set.ts
+++ b/packages/fabrika-cli/src/eval/skill-eval-set.ts
@@ -135,7 +135,14 @@ export interface SkillEvalCase {
 	readonly name: string | null;
 	readonly prompt: string;
 	readonly expectedOutput: string | null;
-	readonly files: ReadonlyArray<string>;
+	/**
+	 * The authored `files`, or `null` when the case never wrote the key.
+	 *
+	 * Absent and `[]` are **not** collapsed, because they are different claims: `[]` is the author
+	 * saying this case needs no material, while an absent key says nothing at all — and a graded run
+	 * cannot be staged from silence (`./run-workspace.ts`, #5434).
+	 */
+	readonly files: ReadonlyArray<string> | null;
 	readonly assertions: ReadonlyArray<SkillEvalAssertion>;
 	readonly tier: EvalTier;
 }
@@ -235,7 +242,7 @@ export const decodeSkillEvalSet = (
 					name: null,
 					prompt: authored.prompt,
 					expectedOutput: authored.expected_output ?? null,
-					files: authored.files ?? [],
+					files: authored.files ?? null,
 					assertions,
 					tier: deriveTier(assertions),
 				};

--- a/packages/fabrika-cli/src/eval/skill-eval-set.unit.test.ts
+++ b/packages/fabrika-cli/src/eval/skill-eval-set.unit.test.ts
@@ -51,6 +51,26 @@ describe("decodeSkillEvalSet — an unedited /skill-creator eval set decodes", (
 		assert.deepStrictEqual(fourth?.assertions, []);
 	});
 
+	// The two are different claims, and the staging tier reads them differently (#5434): `[]` says the
+	// case needs no material, an absent key says nothing at all. Collapsing them here is what let a
+	// case with no declaration score out of an empty directory.
+	it("keeps an absent `files` key distinct from an authored empty one", () => {
+		const result = decodeSkillEvalSet(
+			JSON.stringify({
+				skill_name: "example-skill",
+				evals: [
+					{id: 0, prompt: "no files key at all"},
+					{id: 1, prompt: "declares it needs none", files: []},
+				],
+			}),
+		);
+		assert.isTrue(Result.isSuccess(result));
+		if (Result.isSuccess(result)) {
+			assert.strictEqual(result.success.cases[0]?.files, null);
+			assert.deepStrictEqual(result.success.cases[1]?.files, []);
+		}
+	});
+
 	it("accepts the `assertions` key the authoring SKILL.md names, not only `expectations`", () => {
 		const result = decodeSkillEvalSet(
 			JSON.stringify({


### PR DESCRIPTION
A graded candidate used to run in whatever directory the command was launched from. That directory holds the authored answer key — every case's `expected_output` and its whole assertion list — and all five runs of a case shared it, so a candidate could read the key and run 5 could read run 4's deliverables. Each run now gets its own fresh directory holding only the fixture files its own case declares, and nothing else.

Part of #5434
Part of #5437

## What changed

- **`packages/fabrika-cli/src/eval/run-workspace.ts`** (new) — the per-`(case, run)` staging. `stagingPlan` and `runDirName` are pure and decide what may be staged; `stageRunWorkspace` is the one leg that touches a filesystem. It makes a scoped temp directory named `case<id>-run<n>-<session-id>`, copies in only the paths the case's authored `files` field declares, at the same relative path the prompt reads, and removes it when the run's scope closes. It resolves each entry under the set's own directory first and the skill root second (repair round 1 — see deviations 8–11), and answers `Unstageable` when a declared fixture cannot be staged.
- **`packages/fabrika-cli/src/eval/command.ts`** — `runOnce` stops discarding the 1-based `run` index, stages a directory per run, and feeds it through `claudeExecutor`'s existing `cwd`. The executor is now built per invocation rather than once for the whole axis, because a shared executor is what re-shares the directory. A run that cannot be staged records `no-verdict:invocation-failed` instead of falling back to the inherited tree.
- **`packages/fabrika-cli/src/eval/graded-axis.ts`** — `GradableCase` carries the authored `files`. `dispersion`, `medianVerdict` and the ADR 0253 record shape are untouched.
- **`packages/fabrika-cli/src/eval/run-workspace.unit.test.ts`** (new) — one regression test covering both defects over the same five staged runs, driven through the real `runGradedAxis`, plus (round 1) the base-resolution and unstageable-scores-nothing cases.
- **`packages/fabrika-cli/src/eval/skill-eval-set.ts`** (repair round 2) — the decoder stops collapsing an absent `files` key into `[]`. `SkillEvalCase.files` is `ReadonlyArray<string> | null`, so "declares it needs none" and "never said" stay different facts all the way to the staging tier.
- **`packages/fabrika-cli/src/eval/README.md`** — a section recording the defect, the fix and the deliberate properties.

## Why `Part of` and not `Fixes`

Both issues carry a final acceptance criterion — *"Live verification, not yet run. Before this closes, one real graded run must confirm …"*. This PR does not run it: the founder ruled the graded re-run comes **after** this fix lands, and the dispatch forbade running one. Every other criterion on both issues is delivered here, so both issues stay open until that run happens rather than auto-closing on merge.

## How the test bites

A check that only asserts "no answer key in the directory" passes on a build where all five runs still share one, and a check that only counts directories passes on a build that stages the key into each — so the test asserts both over the same five runs. It was verified against a deliberately broken build: `stageRunWorkspace` was temporarily mutated to memoize a single shared directory, and all three isolation assertions went red, including run N reading run N−1's `VERDICT-DRAFT.md`. The mutation was reverted and is not in this diff.

## Checks run

| check | result | round |
|---|---|---|
| `pnpm typecheck` | 31/31 tasks pass | 0 |
| `pnpm lint:worktree` | 5 files checked, clean | 0 |
| `pnpm --filter @kampus/fabrika-cli test` | 300 files / 4541 tests pass | 0 |
| `pnpm exec turbo run typecheck --filter=@kampus/fabrika-cli --force` | 1/1 pass, cache bypassed | repair 1 |
| `pnpm exec biome check packages/fabrika-cli/src` | 729 files checked, clean | repair 1 |
| `pnpm --filter @kampus/fabrika-cli test` | 300 files / 4545 tests pass | repair 1 |
| `pnpm exec turbo run typecheck --filter=@kampus/fabrika-cli --force` | 1/1 pass, cache bypassed | repair 2 |
| `pnpm lint:worktree` | 7 files checked, clean | repair 2 |
| `pnpm --filter @kampus/fabrika-cli test` | 300 files / 4595 tests pass | repair 2 |

## Deviations

**1. Scope narrowing (class: narrowed a suggested fix-shape).** *Said:* the seam is shared with #5427. *Did:* left `eval run` (`command.ts:518`), the `--cwd` flag surface and the eval-runner `SKILL.md` contradiction untouched. *Why:* they are #5427's deliverable and the dispatch scoped them out. *Disposition:* no action needed — #5427 stays open and unaffected.

**2. A field the issues did not name.** *Said:* stage "only that case's fixture material". *Did:* added `files` to `GradableCase` so the material is read off the case's own authored `files` list. *Why:* it makes "only this case's fixtures" derivable instead of guessed, and the decoder already carries the field. *Disposition:* for the reviewer to judge; it changes a pure core's type but no record shape and no ADR-0253 surface. **(Corrected in repair round 1 — see deviation 8; this entry overclaimed.)**

**3. Fail-closed on an unstageable run.** *Said:* nothing about what happens if the directory cannot be made. *Did:* the run records `no-verdict:invocation-failed`. *Why:* falling back to the inherited directory would silently restore both defects, and a run nobody could isolate is not a measurement. *Disposition:* no action needed.

**4. The grader still inherits the verb's working directory.** *Said:* #5434's criterion is that the grader's access is *unchanged*. *Did:* left it unchanged — it receives the expectations in-process and stages nothing. *Why:* isolating it was not asked for and widens the diff. *Disposition:* for the reviewer to judge.

**5. Directory naming.** *Said:* name it `case<id>-run<n>-<sessionId>`. *Did:* exactly that, using the session id the same spawn is already pinned to. *Why:* run identity on disk at no cost. *Disposition:* no action needed — no record-shape change, so #5439 is untouched.

**6. Cleanup trades away post-hoc forensics.** *Said:* run directories must be cleaned up or land under a gitignored path. *Did:* removed on scope close. *Why:* the criterion asks for it. *Cost:* a future investigation can no longer read a run's deliverables off disk the way the #5429 lane did; the per-session transcripts still exist under the `claude` data root. *Disposition:* for the reviewer to judge — a retention flag would be flag surface, which belongs to #5427.

**7. What could not be run here.** The harness isolation guard (#5406) refuses any Bash command containing the substring `eval`, position-blind, so **no path-named command under `packages/fabrika-cli/src/eval/` could be invoked at all** — including a single-file `vitest run <path>`. Package-level commands were unaffected and are the ones in the table above. Not run, and not inferred: any live `fabrika eval graded` run (founder-ruled to follow this fix), and any per-file test invocation by path. The full-package suite covers the same files. **This still holds in repair round 1** — the round-1 checks in the table are all package-level, and no per-file or live graded run was attempted or inferred.

**8. (repair round 1) Correcting deviation 2's claim about `files`.** Deviation 2 argued that reading the fixture list off the case's authored `files` makes "only this case's fixtures" *derivable instead of guessed*. That overclaimed, and the gate was right to red it. Two things it did not say. First, **this PR is the field's first consumer** — nothing read `files` before it, so this diff *defines* what the entries are relative to rather than following an existing contract. Second, the base it defined them against — the skill root — held for a **minority** of the corpus. Measured across all 21 authored sets at the round-1 head (92 declared entries in total): **17** resolve from the skill root (`evals/fixtures/…`, `evals/cases/…` — 3 sets: `governance`, `prototyping`, `write-pattern`), **65** resolve from the set's own directory (`fixtures/…` — 12 sets), **10** resolve from neither (`check-epic-plan`'s bare `eval-<n>.md`), and 5 sets / 31 cases declare no `files` at all. So at the round-1 head staging worked for 3 sets of the 16 that declare fixtures and silently copied nothing for the other 13 — and the *"Every other criterion on both issues is delivered here"* line above was, at that head, false against #5434's fixture-presence criterion. Repair round 1 closes it.

**9. (repair round 1) The base is now found, not assumed — and a run missing its material scores nothing.** *Said:* the gate offered three remedies and prescribed none. *Did:* took two of them. Each `files` entry is resolved under the set's own directory first and the skill root second, and staged at the **authored** relative path either way, so both conventions work as written. And `stageRunWorkspace` now returns `Unstageable` — not `Staged` — whenever a declared fixture fails to land: no base resolves it, the copy fails, an absolute path, or a `..` segment. That routes the run into the `no-verdict:invocation-failed` seam the module already defined, so a candidate spawned without the material its prompt names can no longer contribute a scored verdict to `medianVerdict` or `dispersion`. Withholding the authored answer key stays the **one** refusal a run survives, since that is the point of withholding it and everything else the case declared is still present. Four new unit cases pin it: a set-directory-relative fixture staging, a fixture resolving under no base scoring `unmeasured` with `noVerdict: 5`, a `..` entry doing the same, and a case declaring the answer key still running with the key withheld. *Disposition:* no action needed.

**10. (repair round 1) The corpus was NOT rewritten — one set is left knowingly unrunnable.** *Said:* the third remedy on offer was to normalise the 21 authored sets onto one base. *Did:* not that. Resolution absorbs the two real conventions; no authored set was edited. *Cost:* `check-epic-plan`'s 10 bare `eval-<n>.md` entries resolve under neither base (their files live at `evals/fixtures/eval-<n>.md`), so that skill's graded axis now records `unmeasured` for every case. *Why that is the right outcome here:* it is loud and honest rather than a fabricated score, it is a defect in one authored set rather than a base-path question, and editing authored corpus is outside this PR's failing criterion. Filed as #5457 and cited in the README. *Disposition:* for the reviewer to judge — the alternative was a 10-line corpus edit this repair round deliberately did not take.

**11. (repair round 1) `stagingPlan`'s refusal shape changed, and so did `stageRunWorkspace`'s argument.** *Said:* nothing. *Did:* `RefusedFixture` gained a `blocking` field, and `stageRunWorkspace` takes `setPath` (the authored set's own path) instead of a pre-derived `skillRoot`. *Why:* the two refusal classes are not the same fact — the answer key is withheld *by design* and the run proceeds, everything else means the candidate is short material and the run must not score — and moving the base derivation into the module deletes `command.ts`'s wrong premise at its source instead of restating it. Both are internal to this package; no exported record shape and no ADR-0253 surface moved. *Disposition:* no action needed.


**12. (repair round 2) A case that declares no `files` is now `Unstageable`, not an empty staged directory.** *Said:* the gate found the same criterion failing through a second door — `stagingPlan([])` produces no blocking refusal, so a case declaring **no** `files` got a `Staged` **empty** directory and scored normally; 31 of 118 graded cases are that shape, and for `review` (7) and `review-ui` (5) the material their prompts name exists in the corpus at a set-directory-relative path the round-1 resolver would have found. The gate prescribed no shape. *Did:* fixed it in the staging logic rather than by authoring 31 `files` lists, and keyed it on **which declaration was made**, not on emptiness. The decoder now keeps an absent `files` key (`null`) apart from an authored `files: []`, and `stageRunWorkspace` returns `Unstageable` for `null` before it makes a directory. *Why that line and not "empty directory ⇒ unstageable":* `files: []` is an author stating the case needs no material, so an empty directory is exactly what it asked for and the run scores; an absent key states nothing, and absence of a declaration is not evidence a case is self-contained. Measured over the 21 authored sets at this head: of the 31 graded cases declaring no `files`, **9** write `files: []` explicitly (`report` 6, `adr` 3) and are unaffected, and **22** omit the key entirely (`review` 7, `review-ui` 5, `ship` 5, `triage` 5) and now record `unmeasured`. Three new unit cases pin all of it, driven through the real `runGradedAxis`: an undeclared case scoring `unmeasured` with `noVerdict: 5`, an authored `files: []` running five times in an empty directory and scoring `pass`, and a decoder case asserting `null` vs `[]` do not collapse. *Disposition:* no action needed.

**13. (repair round 2) The 22 undeclared cases were NOT authored here — same call as deviation 10, and here is why per set.** *Said:* the gate named "declaring the missing `files` on the `review` and `review-ui` cases" as an equally valid remedy for 12 of them. *Did:* not that. *Why:* the 22 are three different problems wearing one symptom, and only one is a mechanical edit. `review` (7) and `review-ui` (5) do have their material in the corpus, but each entry has to be checked against what its prompt actually reads rather than pattern-matched from the filename — `review` case 0's whole prompt is a bare path, and `review-ui`'s prompts name `FIXTURE.md` in the working directory while the files on disk are `eval-{1..5}.md`, so the staged name matters. `ship` (5) names fixtures that **do not exist anywhere** — nothing to declare until they are written. `triage` (5) carries un-substituted `{FIXTURE}` / `{OUTDIR}` placeholders and no substitution mechanism exists in the runner, so a `files` list would not make those cases resolve either. Each is an authored-corpus judgment, and editing authored corpus is outside this PR's failing criterion — the same boundary the gate endorsed for deviation 10. *Cost:* 22 graded cases across four sets record `unmeasured` until their corpus is fixed, on top of `check-epic-plan`'s 10 from deviation 10. That cost is the point: it is loud, correctly excluded from the pass rate by `aggregate`, and legible in the record as a non-measurement — where the behaviour it replaces was a `pass`/`fail` nobody could tell from a measurement. Filed as #5464 with the per-set breakdown and cited in the README. *Disposition:* for the reviewer to judge — the alternative was a 12-case corpus edit this repair round deliberately did not take.
