### PR TITLE
docs(fabrika): write down the eval run-site rule a worktree lane cannot satisfy (#5406)

### DIFF
--- a/claude-plugins/fabrika/skills/build/SKILL.md
+++ b/claude-plugins/fabrika/skills/build/SKILL.md
@@ -188,6 +188,15 @@ review-appended acceptance criterion after round 2 is frozen — note it, do not
 ## Expectations you hold but never recompute
 
 - **Control-plane membership** — decided by CODEOWNERS at the merge gate. You never classify.
+- **You cannot run `fabrika eval …` from a lane, and that is the design.** You are in a worktree by
+  construction (step 4 proves it before every mutation), and a worktree-isolated session's harness
+  guard refuses any Bash command carrying the token `eval` — position-blind, so a script path or an
+  argument spelled `eval` is refused too. The measurement belongs to `eval-runner`, whose run site
+  is a plain non-worktree session (#4679, #5406). So a needed measurement is a **hand-off**: say
+  what needs measuring and stop, the same way you stop for anything outside your tree. It is not a
+  blocker to hack around, and it is never a licence to substitute reasoning about correctness for
+  the measurement — three lanes made that substitution in two days, which pushes verification onto
+  the reviewer or onto nobody (#5406).
 - **Leak scanning of changed files** — `leak-guard.yml` in CI. Your verbs guard only what you post.
 - **CI redness** — `ci.yml` owns it. `build check` predicts it in-tree; the gate's answer wins.
 - Follow-up observations leave through `/report` the moment you see them — never through scope

--- a/claude-plugins/fabrika/skills/build/SKILL.md
+++ b/claude-plugins/fabrika/skills/build/SKILL.md
@@ -189,14 +189,16 @@ review-appended acceptance criterion after round 2 is frozen — note it, do not
 
 - **Control-plane membership** — decided by CODEOWNERS at the merge gate. You never classify.
 - **You cannot run `fabrika eval …` from a lane, and that is the design.** You are in a worktree by
-  construction (step 4 proves it before every mutation), and a worktree-isolated session's harness
-  guard refuses any Bash command carrying the token `eval` — position-blind, so a script path or an
-  argument spelled `eval` is refused too. The measurement belongs to `eval-runner`, whose run site
-  is a plain non-worktree session (#4679, #5406). So a needed measurement is a **hand-off**: say
-  what needs measuring and stop, the same way you stop for anything outside your tree. It is not a
-  blocker to hack around, and it is never a licence to substitute reasoning about correctness for
-  the measurement — three lanes made that substitution in two days, which pushes verification onto
-  the reviewer or onto nobody (#5406).
+  construction (step 4 proves it before every mutation), and worktree-isolated sessions have been
+  refused on `fabrika eval …` invocations, including a form where `eval` sat in an argument rather
+  than as a shell builtin (#5406). The guard is the agent harness's, not this repo's, its rule is
+  not readable from here, and the refusals have **not** been consistent across sessions (#5458) — so
+  it is a refusal you cannot predict and must not design around. The measurement belongs to
+  `eval-runner`, whose run site is a plain non-worktree session (#4679, #5406). So a needed
+  measurement is a **hand-off**: say what needs measuring and stop, the same way you stop for
+  anything outside your tree. It is not a blocker to hack around, and it is never a licence to
+  substitute reasoning about correctness for the measurement — three lanes made that substitution
+  in two days, which pushes verification onto the reviewer or onto nobody (#5406).
 - **Leak scanning of changed files** — `leak-guard.yml` in CI. Your verbs guard only what you post.
 - **CI redness** — `ci.yml` owns it. `build check` predicts it in-tree; the gate's answer wins.
 - Follow-up observations leave through `/report` the moment you see them — never through scope

--- a/claude-plugins/fabrika/skills/eval-runner/SKILL.md
+++ b/claude-plugins/fabrika/skills/eval-runner/SKILL.md
@@ -16,10 +16,26 @@ machine can read it**: the PR-comment record, and repo-relative files inside the
 under a home directory is a defect, not a convenience (ADR 0273, on PR #5375 and not yet on
 `main`) — including when an operator asks for one.
 
-<!-- anchor: RUN-SITE-IS-AN-OPERATOR-SESSION --> **Run site: an agent session on an operator's
-machine.** CI reads the artifacts these runs produce and never spawns the model that produces
-them (#4679, same ruling) — a cost constraint, recorded as one. The package enforces the CI half
-mechanically; honouring it here is yours.
+<!-- anchor: RUN-SITE-IS-AN-OPERATOR-SESSION --> **Run site: a plain (non-worktree) agent session
+on an operator's machine.** CI reads the artifacts these runs produce and never spawns the model
+that produces them (#4679, same ruling) — a cost constraint, recorded as one. The package enforces
+the CI half mechanically; honouring it here is yours.
+
+**Plain, not worktree-isolated** — the second half of the same run site, stated because it was left
+implicit and three lanes paid for it (#5406). A worktree-isolated session's harness guard refuses
+**any** Bash command containing the token `eval`, wherever it sits: `fabrika eval cases`,
+`fabrika eval run`, `fabrika eval graded`, `fabrika eval baseline …`, and even
+`node packages/fabrika-cli/src/bin.ts eval …` — the match is on the word, not on the shell builtin,
+so an argument spelled `eval` is refused exactly like a command. This is not a new constraint on
+top of #4679; it is what #4679's "any operator machine, portable surfaces" already meant, now
+written where the reader who needs it will see it. If you are in an isolated worktree, you are not
+at this skill's run site — the measurement is a **hand-off**, not something to route around.
+
+A lane that hit the refusal before this was written down moved each command into a script file and
+ran the file. Recorded so nobody re-derives it, and bounded in the same breath: that is a way to get
+a byte out of a wedged shell, **not** a sanctioned run site for a graded run. A graded record
+carries the head it measured and the session that produced it; producing one from a worktree lane
+through a script file is a run at the wrong site, whatever it prints.
 
 <!-- anchor: MEASURE-NEVER-JUDGE --> **You measure; you never judge.** The record's token is
 `RECORDED` or `UNRECORDABLE` — no polarity, no bar (ADR 0253). A below-bar median is `RECORDED`

--- a/claude-plugins/fabrika/skills/eval-runner/SKILL.md
+++ b/claude-plugins/fabrika/skills/eval-runner/SKILL.md
@@ -22,14 +22,19 @@ that produces them (#4679, same ruling) — a cost constraint, recorded as one. 
 the CI half mechanically; honouring it here is yours.
 
 **Plain, not worktree-isolated** — the second half of the same run site, stated because it was left
-implicit and three lanes paid for it (#5406). A worktree-isolated session's harness guard refuses
-**any** Bash command containing the token `eval`, wherever it sits: `fabrika eval cases`,
-`fabrika eval run`, `fabrika eval graded`, `fabrika eval baseline …`, and even
-`node packages/fabrika-cli/src/bin.ts eval …` — the match is on the word, not on the shell builtin,
-so an argument spelled `eval` is refused exactly like a command. This is not a new constraint on
-top of #4679; it is what #4679's "any operator machine, portable surfaces" already meant, now
-written where the reader who needs it will see it. If you are in an isolated worktree, you are not
-at this skill's run site — the measurement is a **hand-off**, not something to route around.
+implicit and three lanes paid for it (#5406). What has been *observed*, and only that: in
+worktree-isolated sessions the harness refused `fabrika eval cases --help`, `fabrika eval --help`,
+and `node packages/fabrika-cli/src/bin.ts eval cases --help` — the last of those a form where
+`eval` is an argument rather than a shell builtin (#5406). Observed in the other direction as well:
+a worktree-isolated session later ran several commands carrying the same token without a refusal
+(#5458). The guard belongs to the agent harness, not to this repo, and its rule is not readable
+from here — so no mechanism is stated, and none should be inferred. Treat the refusal as one you
+**cannot predict and must not design around**; an unpredictable refusal is a worse thing to depend
+on than a deterministic one, which makes the run-site rule stronger rather than weaker. This is not
+a new constraint on top of #4679; it is what #4679's "any operator machine, portable surfaces"
+already meant, now written where the reader who needs it will see it. If you are in an isolated
+worktree, you are not at this skill's run site — the measurement is a **hand-off**, not something
+to route around.
 
 A lane that hit the refusal before this was written down moved each command into a script file and
 ran the file. Recorded so nobody re-derives it, and bounded in the same breath: that is a way to get

--- a/claude-plugins/fabrika/skills/eval-runner/contract.md
+++ b/claude-plugins/fabrika/skills/eval-runner/contract.md
@@ -67,9 +67,11 @@ the same tracked debt the sibling contracts carry.)
 - **A CI entry point.** Eval and baseline runs execute in a plain (non-worktree) agent session on
   an operator's machine, never in CI (#4679 comment 5247166010); the package reds any workflow that
   invokes the model-bearing verbs. CI's leg is reading artifacts, and that is #4681's. The
-  non-worktree half is enforced by nothing here and cannot be: a worktree-isolated session's harness
-  guard refuses any command carrying the token `eval` (#5406), so the run simply never happens
-  there. The skill's `RUN-SITE-IS-AN-OPERATOR-SESSION` anchor carries the reader-facing statement.
+  non-worktree half is enforced by nothing here and cannot be. Worktree-isolated sessions have been
+  refused on `fabrika eval …` invocations (#5406), but not consistently (#5458), and that guard is
+  the agent harness's rather than ours — so it is an observation, not an enforcement this package
+  may lean on. The skill's `RUN-SITE-IS-AN-OPERATOR-SESSION` anchor carries the reader-facing
+  statement and the observations behind it.
 - **A conductor verb sequencing the suite.** Which sets to run, at which head, at what cost, and
   whether to retry a whole five-run block is judgment — the skill's whole remaining job. A
   sequencing verb would be a script deciding what a session should.

--- a/claude-plugins/fabrika/skills/eval-runner/contract.md
+++ b/claude-plugins/fabrika/skills/eval-runner/contract.md
@@ -64,9 +64,12 @@ the same tracked debt the sibling contracts carry.)
   the merge gate ([#4681](https://github.com/kamp-us/phoenix/issues/4681)); dispersion is
   recorded and never gates (ADR 0252). The runner emitting a PASS/FAIL is the exact polarity the
   `eval-record` format refuses by construction.
-- **A CI entry point.** Eval and baseline runs execute in an agent session on an operator's
-  machine, never in CI (#4679 comment 5247166010); the package reds any workflow that invokes
-  the model-bearing verbs. CI's leg is reading artifacts, and that is #4681's.
+- **A CI entry point.** Eval and baseline runs execute in a plain (non-worktree) agent session on
+  an operator's machine, never in CI (#4679 comment 5247166010); the package reds any workflow that
+  invokes the model-bearing verbs. CI's leg is reading artifacts, and that is #4681's. The
+  non-worktree half is enforced by nothing here and cannot be: a worktree-isolated session's harness
+  guard refuses any command carrying the token `eval` (#5406), so the run simply never happens
+  there. The skill's `RUN-SITE-IS-AN-OPERATOR-SESSION` anchor carries the reader-facing statement.
 - **A conductor verb sequencing the suite.** Which sets to run, at which head, at what cost, and
   whether to retry a whole five-run block is judgment — the skill's whole remaining job. A
   sequencing verb would be a script deciding what a session should.


### PR DESCRIPTION
Fixes #5406

Fixes #5458

Folded in here rather than as a follow-up PR — a prose-accuracy correction to the same three
surfaces. See "Correction folded in" below).

## What this is

Prose only. Three markdown files. No guard, no hook, no control-plane path, no behavior change
anywhere.

The issue was re-scoped on 2026-08-12 after the investigation closed: the refusal that blocks
`fabrika eval …` is the **agent harness's** worktree-isolation guard, not anything in this repo,
so there is nothing here to narrow. The remaining deliverable is the run-site rule, written down
where the readers who need it will actually see it.

## Why it earns its place

Three lanes hit the same refusal inside two days (PR #5404, PR #5412, and the lane surfacing on
#5400). Per the intake comment `5249808011`, two of them "fell back to reasoning about correctness
instead of measuring it" — which pushes verification out of the lane and onto the reviewer, or onto
nobody. That substitution is the actual cost, and it gets reinvented per lane as long as the rule
lives only in incident comments.

## Correction folded in (#5458) — what changed on this round

The first round of this PR asserted a **mechanism**: that the guard token-matches `eval`
position-blind, and refuses **any** command carrying the token wherever it sits. #5458 falsified the
universal quantifier — a worktree-isolated session (this PR's own `review-skill` gate) ran several
commands carrying the token, including deliberate probes with the bare token in a quoted string.

The correction is **not** to swap in a better-sounding mechanism. #5458's title says the evidence
"points to a context-sensitive classifier"; that phrase is itself an inference, and writing it into
the docs would reproduce the identical defect one layer over. **Nothing about the mechanism is
source-verified** — the harness is outside this repo and nobody has read its rule; #5406's own
triage recorded the attribution as "the best-supported inference, not a verified fact." So the three
surfaces now assert **no mechanism at all**. They state what was observed, who owns the guard, and
that the refusal cannot be predicted or designed around.

**This body follows the corrected #5458 framing over #5406's original acceptance-criterion text.**
#5406's criterion mandated the reason in nearly the over-broad words ("token-matching `eval`
anywhere in the command string, position-blind"), so round 1 was faithful to its contract as
written; intake has since delivered a correction to #5406. Where the two disagree, #5458 governs.

The **operational rule is untouched and is if anything stronger**: a worktree lane does not run
`fabrika eval …`, and a needed measurement is a hand-off — an unpredictable refusal is a worse thing
for a lane to depend on than a deterministic one. No guard is weakened; none is touched.

## What was observed, graded

- **Refusals** (reported on #5406, comment `5270657740`): a worktree-isolated session was refused on
  `fabrika eval cases --help`, `fabrika eval --help`, and
  `node packages/fabrika-cli/src/bin.ts eval cases --help` — the last being a form where `eval` is a
  CLI argument, not a shell builtin. This lane's round 1 recorded two further first-party refusals
  in its own session.
- **Allowances** (the `review-skill` gate verdict on this PR, comment `5272830968`), from a session
  that was **itself worktree-isolated**: several commands carrying the token ran normally, including
  probes with the bare token inside a quoted string.
- **Inferred, and therefore not written down:** the mechanism. Both readings — deterministic token
  matcher, and context-sensitive judgment layer — are inferences from the same two observation sets.

## The three edits

**`claude-plugins/fabrika/skills/eval-runner/SKILL.md`** — the existing
`RUN-SITE-IS-AN-OPERATOR-SESSION` anchor reads "a **plain (non-worktree)** agent session on an
operator's machine", with the plain-session half spelled out below it. That paragraph now states the
observed refusals (including the argument-position one), the observed allowances, that the guard is
the harness's and its rule is unreadable from here, and that it must not be predicted or designed
around. Extended in place, not added as a competing statement.

**`claude-plugins/fabrika/skills/eval-runner/contract.md`** — the "not a CI entry point" row states
the same run site, and says plainly that the non-worktree half is enforced by nothing in the package
and cannot be. It no longer claims the harness makes the run impossible there; it records the
inconsistent refusals as an observation this package may not lean on, and points at the skill anchor
for the reader-facing statement.

**`claude-plugins/fabrika/skills/build/SKILL.md`** — a bullet in "Expectations you hold but never
recompute", which is the list a lane holds without re-deriving. A lane is in a worktree by
construction (its step 4 proves it before every mutation); worktree-isolated sessions have been
refused on `fabrika eval …` invocations, inconsistently, by a guard this repo does not own — so a
needed measurement is a **hand-off**, not a blocker to hack around and not a licence to substitute
reasoning for a measurement. This is the bullet with teeth.

## Framing held deliberately

- Stated as **making #4679's existing design explicit**, not as a new constraint. #4679 already
  ruled the run site is an operator session; only the plain-vs-worktree half was left implicit.
- **No upstream fix, timeline, or report is asserted** anywhere in the diff — per the founder ruling
  in comment `5270780281` that no upstream report is filed.
- **No mechanism is asserted** — neither the token matcher nor a classifier. This is the #5458 fix,
  and it is the whole point of the round.
- The **script-file workaround** is recorded so it stops being rediscovered, and bounded in the same
  sentence: a way to get a byte out of a wedged shell, never a sanctioned run site for a graded
  record. It cannot be read as the blessed path.
- The **struck criterion** (whether an in-lane allow rule overrides the guard) appears nowhere in
  the diff or this body.

## Acceptance criteria

From #5406 (as corrected by #5458 where they conflict):

- [x] `eval-runner/SKILL.md` states the run site as a plain (non-worktree) session with the one-line
      reason, attached to the existing anchor rather than competing with it.
- [x] A build lane's standing constraints say a lane cannot run `fabrika eval …` and that a needed
      measurement is a hand-off, not a workaround and not a licence to substitute reasoning.
- [x] Framed as making #4679 explicit; asserts no upstream fix, timeline, or report.
- [x] No repo guard, hook, or control-plane path modified — verified by the diff (3 markdown files)
      and by `pipeline-cli cp-classify classify`.
- [x] The struck criterion does not reappear.

From #5458:

- [x] No surface under `claude-plugins/fabrika/skills/` asserts the refusal is a token matcher, is
      position-blind, or fires on **any** command containing `eval`.
- [x] No surface asserts a replacement mechanism either — "classifier" / "context-sensitive" appear
      nowhere as a statement of fact about the harness guard.
- [x] The replacement text is observation-shaped and states three things: refusals observed in
      worktree-isolated sessions including argument-position `eval`; the guard is the harness's and
      its rule is not readable from this repo; refusals have not been consistent, so it cannot be
      predicted or designed around.
- [x] The operational rule is unchanged and still present on both reader surfaces.
- [x] No guard, hook, workflow, matcher, or control-plane path modified.
- [x] Every claim written about the harness carries its grade — observations are written as
      observations, nothing un-run is written as verified.

## Checks run

- `pipeline-cli cp-classify classify` over the three changed paths →
  `not-control-plane [path-clear-no-content-source]`. **This PR is not §CP.** Classified against the
  live `CONTROL_PLANE_RE` re-resolved from `origin/main`, not guessed from the directory name.
- `pipeline-cli gh-phoenix lint-skills` over all three files → clean (round 1).
- Pre-commit hooks green on both rounds: biome, leak-guard (3 doc surfaces, no user-local paths),
  primary-index-guard, primary-index-tripwire, unit-changed.
- `pipeline-cli verified-push` → `PUSH-VERDICT: MOVED`, remote ref confirmed at the local head by an
  independent `ls-remote` read.
- The branch is already on top of the latest `origin/main` (0 behind), so no rebase was taken this
  round.

## Deviations

1. **The dispatch brief and the issue disagree, and I followed the issue.** I was dispatched to
   narrow the checker's false-positive match and add tests pinning both directions — legitimate
   commands pass, genuine builtin `eval` still refused. That brief describes the issue as it stood
   *before* the 2026-08-12 re-scope. It is not buildable: the matcher is in the harness, above the
   plugin, and the re-scoped body states outright that "no repo guard, hook, or control-plane path
   is modified — this issue's whole remaining scope is prose." I confirmed the premise myself rather
   than inferring it (the refusals above). So **no matcher was changed and no matcher tests were
   written.** No guard was weakened; none was touched. The builtin-`eval` refusal the brief was most
   concerned about is exactly as strong as it was before this PR, because this PR does not go near
   it.
2. **No test pins this change.** It is prose with no executable surface. The `lint-skills` and
   `cp-classify` runs above are what can be mechanically asserted about it.
3. **The `fabrika build check --surface prose` validator was not run.** It refuses outside a lane
   whose claim it can read in its own protocol, and this lane ran under `write-code` rather than
   `fabrika build`. `lint-skills` covers the skill-corpus checks that apply to these three files.
4. **(repair round 1)** This round is **not** a gate-FAIL repair. The current-head verdict on this
   PR is a `review-skill` PASS; the round exists to fold #5458's prose correction in *before* the
   merge, while the cheap window is open. The push invalidates that PASS by design (ADR 0058
   SHA-binding) and the PR is handed back for a fresh gate at the new head.
5. **(repair round 1)** Round 1's claim that the two first-party refusals "demonstrated
   position-blindness" was itself an over-read of the evidence, and it is **removed from this body**
   rather than left standing — the observations are kept, the inference drawn from them is dropped.
   This is the one place a prior entry was revised instead of appended to, because leaving a
   falsified mechanism claim in the PR's own body would keep the defect alive on the surface the fix
   is about.

