### PR TITLE
fix(fabrika-cli): record which session produced which graded run (#5439)

### DIFF
--- a/packages/fabrika-cli/src/eval/README.md
+++ b/packages/fabrika-cli/src/eval/README.md
@@ -1086,6 +1086,52 @@ failure; the alternative is the silent one this rule exists to remove — a `pas
 empty directory, indistinguishable in the record from a measurement
 ([#5464](https://github.com/kamp-us/phoenix/issues/5464)).
 
+### Which session produced which run ([#5439](https://github.com/kamp-us/phoenix/issues/5439))
+
+The run directory above makes identity legible while the run is alive, and the directory is removed
+when its scope closes. That left the recorded number un-traceable: a session id was minted, spent on
+`--session-id` so the transcript would be locatable, and then dropped. Anyone asking which of a
+case's five runs produced which artifact had to sort artifacts by file mtime — an inference two
+separate investigations made and had to flag as one, and one that stops working the moment two runs
+land in the same second.
+
+`run-manifest.ts` gives it a landing place. Whenever `graded` (or `churn`) writes its record to
+`--out`, it writes a **sidecar manifest** beside those bytes at the same path with a `.runs.json`
+extension, one row per `(case × run)`:
+
+```jsonc
+{
+  "sha": "…",                       // the head the record attests
+  "recordedAt": "2026-08-12T18:26:39.118Z",
+  "cell": {"stage": "build", "surface": null, "model": "claude-opus-4-8"},
+  "runs": [
+    {"caseId": 1, "run": 1, "sessionId": "…", "model": "claude-opus-4-8", "verdict": "pass"}
+  ]
+}
+```
+
+Four decisions carry it:
+
+- **Beside the record, not inside it.** The record's field inventory is governed by ADR
+  [0253](../../../../.decisions/0253-eval-record-is-an-eval-namespaced-pr-comment.md), so a field
+  there is an amendment question. Nothing in `run-manifest.ts` widens `EvalCaseBlock` or
+  `EvalRecordPayload`, and `RunOnce` still returns a bare `RunVerdict`.
+- **It follows `--out` rather than a flag of its own.** The whole defect is that identity was
+  separable from the number, so a run that persists a record persists its sessions in the same act.
+  With no `--out` the record is not durable either, and there is nothing to sit beside.
+- **Checked against the record, not trusted.** `runManifestDisagreement` re-derives the join — one
+  row per run, numbered `1…runs`, each carrying the same token the record's `perRun` carries in that
+  position — and a disagreement writes **nothing** and says why. Naming the wrong session is worse
+  than naming none, because a reader cannot tell. Zero rows against a non-empty case list is a
+  disagreement, never a vacuous pass (ADR 0092).
+- **No transcript path and no working directory.** Both are absolute, machine-local and perishable,
+  and this file is meant to be committed. The session id is the durable key: it is what the
+  transcript is named after, so a reader on the same machine can still find it, and a reader
+  elsewhere at least knows exactly which session to ask for.
+
+A run that **died** keeps its row — the run that produced nothing is the one a later reader most
+needs named, so an `UNRECORDABLE` record still gets its manifest.
+
 ## The fabrika incident corpus ([#4675](https://github.com/kamp-us/phoenix/issues/4675))
 
 `incident-corpus/` is a **second, separate** body of ground truth, and the name matters: the

--- a/packages/fabrika-cli/src/eval/command.ts
+++ b/packages/fabrika-cli/src/eval/command.ts
@@ -85,8 +85,10 @@ import {
 	buildEvalRecord,
 	candidateOutputOf,
 	composeGraderPrompt,
+	type GradableCase,
 	gradableCase,
 	graderResponseOf,
+	perRunToken,
 	type RunVerdict,
 	readGraderVerdict,
 	runGradedAxis,
@@ -108,6 +110,13 @@ import {
 	ruledKeepsViolations,
 	withCoverage,
 } from "./ruled-keeps.ts";
+import {
+	type RunIdentity,
+	type RunManifest,
+	runManifestDisagreement,
+	runManifestPathFor,
+	toJson as runManifestToJson,
+} from "./run-manifest.ts";
 import {stageRunWorkspace} from "./run-workspace.ts";
 import {readSeriesFiles} from "./series-io.ts";
 import {decodeSkillEvalSet, tierCounts} from "./skill-eval-set.ts";
@@ -681,6 +690,27 @@ const produceGradedRecord = (request: GradedRunRequest) =>
 				yield* request.log(bytes);
 			});
 
+		// Write the run identities beside the record's own bytes; with no `--out` nothing durable was
+		// written, so there is nothing to sit beside. See `./run-manifest.ts` (#5439).
+		const writeRunManifest = (record: EvalRecord, runs: ReadonlyArray<RunIdentity>) =>
+			Effect.gen(function* () {
+				if (request.out === null) return;
+				const manifest: RunManifest = {
+					sha: record.payload.sha,
+					recordedAt: record.payload.recordedAt,
+					cell,
+					runs,
+				};
+				const disagreement = runManifestDisagreement(manifest, record.payload.cases);
+				if (disagreement !== null) {
+					yield* Console.error(`fabrika eval: no run manifest written — ${disagreement}`);
+					return;
+				}
+				const to = runManifestPathFor(request.out);
+				yield* fs.writeFileString(to, runManifestToJson(manifest));
+				yield* Console.error(`fabrika eval: ${runs.length} run identities written to ${to}`);
+			});
+
 		const recordNoMeasurement = (noMeasurement: string, code: number) =>
 			Effect.gen(function* () {
 				const built = buildEvalRecord({
@@ -745,53 +775,79 @@ const produceGradedRecord = (request: GradedRunRequest) =>
 				jsonSchema: null,
 			});
 
+		// Every run's identity, in run order, for the sidecar manifest below. The record itself has
+		// nowhere to put it (ADR 0253 governs its fields), so this is the accumulator that gives the
+		// minted session id a landing place instead of being spent and dropped (#5439).
+		const identities: Array<RunIdentity> = [];
+
+		const gradeRun = (args: {
+			readonly evalCase: GradableCase;
+			readonly run: number;
+			readonly sessionId: string;
+		}) =>
+			Effect.gen(function* () {
+				const {evalCase, run, sessionId} = args;
+				const workspace = yield* stageRunWorkspace({
+					setPath: request.path,
+					caseId: evalCase.id,
+					run,
+					sessionId,
+					files: evalCase.files,
+				});
+				// A run that cannot be isolated is not run un-isolated. Falling back to the inherited
+				// tree is precisely the exposure this closes (#5434/#5437), and a measurement nobody
+				// could isolate is a `NoVerdict`, never a pass or a fail.
+				if (workspace._tag === "Unstageable") {
+					yield* Console.error(
+						`fabrika eval: case ${evalCase.id} run ${run}: no isolated working directory — ${workspace.detail}`,
+					);
+					return {_tag: "NoVerdict", reason: "invocation-failed"} satisfies RunVerdict;
+				}
+				const candidate = candidateOutputOf(
+					yield* invoke({
+						caseId: evalCase.id,
+						prompt: evalCase.prompt,
+						pluginDir: request.pluginDir,
+						sessionId,
+						cwd: workspace.dir,
+					}),
+				);
+				if (candidate._tag !== "Output") return candidate;
+				// The grader loads no plugin: it judges what the candidate produced against the authored
+				// expectations, and running the skill again inside the grader would make the judgement
+				// depend on a second execution nobody scored. It is handed the authored expectations
+				// in-process and stages nothing, so it needs no directory of its own.
+				return readGraderVerdict(
+					graderResponseOf(
+						yield* invoke({
+							caseId: evalCase.id,
+							prompt: composeGraderPrompt({evalCase, candidateOutput: candidate.text}),
+							pluginDir: null,
+							sessionId: yield* Effect.orDie(crypto.randomUUIDv4),
+							cwd: null,
+						}),
+					),
+				);
+			});
+
 		const results = yield* runGradedAxis({
 			cases,
 			runOnce: ({evalCase, run}) =>
 				Effect.scoped(
 					Effect.gen(function* () {
 						const sessionId = yield* Effect.orDie(crypto.randomUUIDv4);
-						const workspace = yield* stageRunWorkspace({
-							setPath: request.path,
+						const verdict = yield* gradeRun({evalCase, run, sessionId});
+						// Recorded on every outcome, a dead run included: the run that produced nothing is
+						// exactly the one a later reader needs named, and a row that disappears with its
+						// failure leaves the same gap in the numbering this closes.
+						identities.push({
 							caseId: evalCase.id,
 							run,
 							sessionId,
-							files: evalCase.files,
+							model: request.model,
+							verdict: perRunToken(verdict),
 						});
-						// A run that cannot be isolated is not run un-isolated. Falling back to the
-						// inherited tree is precisely the exposure this closes (#5434/#5437), and a
-						// measurement nobody could isolate is a `NoVerdict`, never a pass or a fail.
-						if (workspace._tag === "Unstageable") {
-							yield* Console.error(
-								`fabrika eval: case ${evalCase.id} run ${run}: no isolated working directory — ${workspace.detail}`,
-							);
-							return {_tag: "NoVerdict", reason: "invocation-failed"} satisfies RunVerdict;
-						}
-						const candidate = candidateOutputOf(
-							yield* invoke({
-								caseId: evalCase.id,
-								prompt: evalCase.prompt,
-								pluginDir: request.pluginDir,
-								sessionId,
-								cwd: workspace.dir,
-							}),
-						);
-						if (candidate._tag !== "Output") return candidate;
-						// The grader loads no plugin: it judges what the candidate produced against the
-						// authored expectations, and running the skill again inside the grader would make the
-						// judgement depend on a second execution nobody scored. It is handed the authored
-						// expectations in-process and stages nothing, so it needs no directory of its own.
-						return readGraderVerdict(
-							graderResponseOf(
-								yield* invoke({
-									caseId: evalCase.id,
-									prompt: composeGraderPrompt({evalCase, candidateOutput: candidate.text}),
-									pluginDir: null,
-									sessionId: yield* Effect.orDie(crypto.randomUUIDv4),
-									cwd: null,
-								}),
-							),
-						);
+						return verdict;
 					}),
 				),
 		});
@@ -808,6 +864,7 @@ const produceGradedRecord = (request: GradedRunRequest) =>
 			return yield* Effect.sync(() => process.exit(FAILED));
 		}
 		yield* emitRecord(built.record);
+		yield* writeRunManifest(built.record, identities);
 		if (built.record.outcome === "UNRECORDABLE") {
 			yield* Console.error(
 				`fabrika eval: every run of all ${results.length} graded case(s) returned no verdict — the record is UNRECORDABLE, which is not a below-bar number`,

--- a/packages/fabrika-cli/src/eval/run-manifest.ts
+++ b/packages/fabrika-cli/src/eval/run-manifest.ts
@@ -1,0 +1,103 @@
+/**
+ * The sidecar run manifest — which session produced which run of which case (#5439).
+ *
+ * A graded run mints a session id per invocation, spends it on `--session-id` so the transcript is
+ * locatable, and used to drop it. So a recorded verdict could be read but never traced: the only way
+ * to say which of a case's five runs produced which artifact was to sort artifacts by file mtime, an
+ * inference two separate investigations had to make and flag as one.
+ *
+ * This is the missing landing place, and it is deliberately **beside** the eval record rather than
+ * inside it. The record's field inventory is governed by ADR
+ * [0253](../../../../.decisions/0253-eval-record-is-an-eval-namespaced-pr-comment.md), so adding a
+ * field there is an amendment question; identity needs no such permission to be written down next to
+ * it. Nothing here imports or widens the record shape — it only reads the case blocks back to check
+ * that the two agree.
+ *
+ * The rows carry no transcript path and no working directory. Both are absolute, machine-local and
+ * perishable, and this file is meant to be committed alongside the artifacts under
+ * `claude-plugins/fabrika/reports/eval/`. The session id is the durable key: it is what the transcript
+ * is named after, so a reader who still has the machine can find the transcript from the row, and a
+ * reader who does not still knows exactly which session to ask for.
+ */
+import type {EvalCaseBlock, EvalRecordCell} from "../wire/eval-record.ts";
+
+/** One run of one case, named. `verdict` is the same token the record's `perRun` carries. */
+export interface RunIdentity {
+	readonly caseId: number;
+	/** 1-based, matching `RunOnce`'s `run` and the position in the record's `perRun` list. */
+	readonly run: number;
+	/** The id the candidate was spawned under (`claude -p --session-id`), and its transcript's name. */
+	readonly sessionId: string;
+	readonly model: string;
+	readonly verdict: string;
+}
+
+/** One graded run's identity sidecar: the same head and cell the record attests, plus the rows. */
+export interface RunManifest {
+	readonly sha: string;
+	readonly recordedAt: string;
+	readonly cell: EvalRecordCell;
+	readonly runs: ReadonlyArray<RunIdentity>;
+}
+
+/**
+ * Where the manifest lands, given where the record's bytes were written.
+ *
+ * Derived rather than flagged on purpose: the whole defect is that identity was separable from the
+ * number, so a run that persists a record persists its identity in the same act. An operator who can
+ * forget the second flag is an operator who will.
+ */
+export const runManifestPathFor = (recordOut: string): string =>
+	`${recordOut.replace(/\.[^./\\]*$/, "")}.runs.json`;
+
+const rowsOfCase = (manifest: RunManifest, caseId: number): ReadonlyArray<RunIdentity> =>
+	manifest.runs.filter((row) => row.caseId === caseId).sort((a, b) => a.run - b.run);
+
+/**
+ * Why the manifest and the record disagree, or `null` when they agree row for row.
+ *
+ * The manifest is only worth committing if it names the runs the record counted, so it is checked
+ * against the record's own case blocks rather than trusted — the same re-derive-don't-trust stance
+ * ADR 0252 §1 takes inside the record. A disagreement is a bug in the wiring, and the honest response
+ * is to write nothing and say so: a manifest that names the wrong session is worse than none, because
+ * a later reader has no way to tell.
+ *
+ * Zero rows against a non-empty case list is a disagreement, not a vacuous pass (ADR 0092).
+ */
+export const runManifestDisagreement = (
+	manifest: RunManifest,
+	cases: ReadonlyArray<EvalCaseBlock>,
+): string | null => {
+	if (cases.length > 0 && manifest.runs.length === 0) {
+		return `the record carries ${cases.length} case(s) and the manifest names no run`;
+	}
+	const known = new Set(cases.map((block) => block.caseId));
+	for (const row of manifest.runs) {
+		if (!known.has(row.caseId)) {
+			return `the manifest names case ${row.caseId}, which the record does not`;
+		}
+		if (row.sessionId.trim() === "") {
+			return `case ${row.caseId} run ${row.run} names no session — an unnamed run is what this file exists to prevent`;
+		}
+	}
+	for (const block of cases) {
+		const rows = rowsOfCase(manifest, block.caseId);
+		if (rows.length !== block.runs) {
+			return `case ${block.caseId} ran ${block.runs} time(s) and the manifest names ${rows.length}`;
+		}
+		for (const [index, row] of rows.entries()) {
+			if (row.run !== index + 1) {
+				return `case ${block.caseId}'s runs are numbered ${rows.map((each) => each.run).join(", ")} — expected 1…${block.runs}`;
+			}
+			const token = block.perRun[index];
+			if (row.verdict !== token) {
+				return `case ${block.caseId} run ${row.run} is \`${row.verdict}\` in the manifest and \`${token}\` in the record`;
+			}
+		}
+	}
+	return null;
+};
+
+/** The committed bytes: tab-indented, one trailing newline — the way biome formats committed JSON. */
+export const toJson = (manifest: RunManifest): string =>
+	`${JSON.stringify(manifest, null, "\t")}\n`;

--- a/packages/fabrika-cli/src/eval/run-manifest.unit.test.ts
+++ b/packages/fabrika-cli/src/eval/run-manifest.unit.test.ts
@@ -1,0 +1,192 @@
+/**
+ * The identity sidecar's tier: does a run's session id survive from the axis to a durable file, and
+ * can a reader go from a recorded verdict back to the session that produced it?
+ *
+ * The load-bearing test is the round-trip one — the axis is driven with a stub that mints a session
+ * per run exactly as the graded command does, the record is built from the same runs, and the two are
+ * checked against each other. That is the property #5439 is about; everything else here is the
+ * refusal surface that keeps a wrong manifest from being written.
+ */
+import {Effect} from "effect";
+import {describe, expect, it} from "vitest";
+import type {EvalCaseBlock} from "../wire/eval-record.ts";
+import {
+	buildEvalRecord,
+	type GradableCase,
+	perRunToken,
+	type RunVerdict,
+	runGradedAxis,
+} from "./graded-axis.ts";
+import {
+	type RunIdentity,
+	type RunManifest,
+	runManifestDisagreement,
+	runManifestPathFor,
+	toJson,
+} from "./run-manifest.ts";
+
+const HEAD = "03135b91e7d4a2c6f1b8093a5c4d2e1f6a7b8c9d";
+const MODEL = "claude-opus-4-8";
+
+const caseOf = (id: number): GradableCase => ({
+	id,
+	prompt: "File a report for the guard that reds on zero scope.",
+	expectedOutput: null,
+	expectations: ["it files exactly one issue"],
+	files: [`evals/cases/eval-${id}.md`],
+});
+
+const pass: RunVerdict = {_tag: "Verdict", passed: true};
+const fail: RunVerdict = {_tag: "Verdict", passed: false};
+const dead: RunVerdict = {_tag: "NoVerdict", reason: "timed-out"};
+
+const rowOf = (over: Partial<RunIdentity> = {}): RunIdentity => ({
+	caseId: 1,
+	run: 1,
+	sessionId: "6f1b0930-5c4d-4e1f-8a7b-8c9d03135b91",
+	model: MODEL,
+	verdict: "pass",
+	...over,
+});
+
+const manifestOf = (runs: ReadonlyArray<RunIdentity>): RunManifest => ({
+	sha: HEAD,
+	recordedAt: "2026-08-12T18:26:39.118Z",
+	cell: {stage: "build", surface: null, model: MODEL},
+	runs,
+});
+
+const blockOf = (over: Partial<EvalCaseBlock> = {}): EvalCaseBlock => ({
+	caseId: 1,
+	verdict: "pass",
+	runs: 1,
+	passed: 1,
+	noVerdict: 0,
+	dispersion: 0,
+	perRun: ["pass"],
+	...over,
+});
+
+/**
+ * The graded command's own wiring, minus the spawn: one session per run, pushed on every outcome.
+ * Driving the real axis is what makes this a seam test rather than a restatement of the shapes.
+ */
+const runWithIdentities = (args: {
+	readonly cases: ReadonlyArray<GradableCase>;
+	readonly script: ReadonlyArray<RunVerdict>;
+}) => {
+	const identities: Array<RunIdentity> = [];
+	let minted = 0;
+	const results = Effect.runSync(
+		runGradedAxis({
+			cases: args.cases,
+			runOnce: ({evalCase, run}) =>
+				Effect.sync(() => {
+					minted += 1;
+					const verdict = args.script[(run - 1) % args.script.length] ?? fail;
+					identities.push({
+						caseId: evalCase.id,
+						run,
+						sessionId: `session-${minted}`,
+						model: MODEL,
+						verdict: perRunToken(verdict),
+					});
+					return verdict;
+				}),
+		}),
+	);
+	return {identities, results};
+};
+
+describe("the manifest a graded run leaves beside its record", () => {
+	it("names a distinct session for every run of every case, and agrees with the record", () => {
+		const {identities, results} = runWithIdentities({
+			cases: [caseOf(1), caseOf(2)],
+			script: [pass, pass, fail, dead, pass],
+		});
+		const built = buildEvalRecord({
+			sha: HEAD,
+			recordedAt: "2026-08-12T18:26:39.118Z",
+			cell: {stage: "build", surface: null, model: MODEL},
+			pins: {model: MODEL, cli: "2.1.227 (Claude Code)", harness: "0.1.0"},
+			results,
+		});
+		if (built._tag !== "Record") throw new Error(built.reason);
+
+		expect(identities).toHaveLength(10);
+		expect(new Set(identities.map((row) => row.sessionId)).size).toBe(10);
+		expect(runManifestDisagreement(manifestOf(identities), built.record.payload.cases)).toBeNull();
+
+		// The property the issue is about: a recorded token is traceable back to one session, without
+		// inferring run order from artifact mtimes.
+		const block = built.record.payload.cases[1];
+		if (block === undefined) throw new Error("the record carries no second case");
+		const third = identities.find((row) => row.caseId === block.caseId && row.run === 3);
+		expect(third?.verdict).toBe(block.perRun[2]);
+		expect(third?.sessionId).toBe("session-8");
+	});
+
+	it("keeps the row of a run that died — the run needing a name most is the one that produced nothing", () => {
+		const {identities} = runWithIdentities({cases: [caseOf(1)], script: [dead]});
+		expect(identities.map((row) => row.verdict)).toEqual(Array(5).fill("no-verdict:timed-out"));
+		expect(identities.every((row) => row.sessionId !== "")).toBe(true);
+	});
+});
+
+describe("the manifest is checked against the record, never trusted", () => {
+	it("agrees when every run is named once, in order, with the token the record carries", () => {
+		const runs = [rowOf({run: 1}), rowOf({run: 2, verdict: "fail"})];
+		const block = blockOf({verdict: "fail", runs: 2, passed: 1, perRun: ["pass", "fail"]});
+		expect(runManifestDisagreement(manifestOf(runs), [block])).toBeNull();
+	});
+
+	it("refuses a manifest naming no run against a record that carries cases (ADR 0092)", () => {
+		expect(runManifestDisagreement(manifestOf([]), [blockOf()])).toMatch(/names no run/);
+	});
+
+	it("refuses a short manifest — a dropped run is the gap this file exists to close", () => {
+		const block = blockOf({runs: 2, passed: 2, perRun: ["pass", "pass"]});
+		expect(runManifestDisagreement(manifestOf([rowOf()]), [block])).toMatch(/names 1/);
+	});
+
+	it("refuses a run numbered outside 1…runs", () => {
+		const runs = [rowOf({run: 1}), rowOf({run: 3})];
+		const block = blockOf({runs: 2, passed: 2, perRun: ["pass", "pass"]});
+		expect(runManifestDisagreement(manifestOf(runs), [block])).toMatch(/numbered 1, 3/);
+	});
+
+	it("refuses a row whose verdict contradicts the record's own token", () => {
+		const block = blockOf({verdict: "fail", passed: 0, perRun: ["fail"]});
+		expect(runManifestDisagreement(manifestOf([rowOf()]), [block])).toMatch(/`pass`.*`fail`/);
+	});
+
+	it("refuses an unnamed session and a case the record never graded", () => {
+		expect(runManifestDisagreement(manifestOf([rowOf({sessionId: "  "})]), [blockOf()])).toMatch(
+			/names no session/,
+		);
+		expect(runManifestDisagreement(manifestOf([rowOf({caseId: 9})]), [blockOf()])).toMatch(
+			/case 9, which the record does not/,
+		);
+	});
+});
+
+describe("where the manifest lands and what it looks like", () => {
+	it("sits beside the record's own bytes, whatever extension they carry", () => {
+		expect(runManifestPathFor("record.md")).toBe("record.runs.json");
+		expect(runManifestPathFor("reports/2026-08-12.json")).toBe("reports/2026-08-12.runs.json");
+		expect(runManifestPathFor("some.dir/record")).toBe("some.dir/record.runs.json");
+	});
+
+	it("is tab-indented with a trailing newline, and carries no machine-local path", () => {
+		const bytes = toJson(manifestOf([rowOf()]));
+		expect(bytes.startsWith("{\n\t")).toBe(true);
+		expect(bytes.endsWith("}\n")).toBe(true);
+		expect(Object.keys(JSON.parse(bytes).runs[0])).toEqual([
+			"caseId",
+			"run",
+			"sessionId",
+			"model",
+			"verdict",
+		]);
+	});
+});


### PR DESCRIPTION
A graded eval run made up a session id for every run, used it to pin where that run's transcript lands on disk, and then threw it away. So you could read that a case scored 3/5, but nothing could tell you which run produced which artifact — investigators had to guess run order from file timestamps and say so out loud.

This writes the identity down. Whenever `fabrika eval graded` (or `churn`) writes its record to `--out`, it now writes a small sidecar file beside those bytes — same path, `.runs.json` extension — with one row per (case × run): the case id, the 1-based run index, the session the run was spawned under, the model, and that run's verdict token. Before it writes, it checks the rows against the record's own case blocks and writes nothing if the two disagree, because naming the wrong session is worse than naming none.

**No longer stacked — #5441 has merged and this branch is rebased onto `main`.** This PR was opened stacked on `usirin/isolate-graded-run-workspaces-5434-5437-82FFBCBF`, because #5441 rewrote the exact `runOnce` lines this touches. #5441 merged to `main` as `754e629`, GitHub retargeted this PR's base to `main`, and the branch has been rebased so it carries **one** commit holding only this change. Review it against `main`. See the repair-round entry under Deviations for how the conflicts were resolved.

Fixes #5439

## What changed

- `packages/fabrika-cli/src/eval/run-manifest.ts` — new, pure. `RunIdentity` / `RunManifest`, `runManifestPathFor` (where it lands, derived from the record's own `--out`), `runManifestDisagreement` (the check against the record), `toJson` (tab-indented committed bytes).
- `packages/fabrika-cli/src/eval/command.ts` — the graded path pushes one identity row per run, on every outcome including a run that died, and writes the manifest after the record. The `runOnce` body was lifted into a named `gradeRun` so the session id is minted, used and recorded in one place instead of three return paths.
- `packages/fabrika-cli/src/eval/run-manifest.unit.test.ts` — new. Drives the real `runGradedAxis` with a stub that mints a session per run exactly as the command does, builds the record from the same runs, and asserts the two agree row for row and that a recorded token traces back to one session. Plus the six refusals.
- `packages/fabrika-cli/src/eval/README.md` — a section documenting the sidecar and the four decisions behind it.

## Acceptance criteria

| AC | Where |
|---|---|
| records `caseId` + 1-based `run` + `sessionId` per (case × run) | `RunIdentity`; pushed in `produceGradedRecord`'s `runOnce` |
| lands on a durable surface | the `.runs.json` sidecar beside the record's `--out` bytes |
| the `run` index reaches the spawn | delivered by #5441, now on `main` — see Deviations |
| verdict → session, without mtime inference | each row carries the same token the record's `perRun` carries at that position; the round-trip test asserts it |
| no `EvalCaseBlock` / `EvalRecordPayload` field ⇒ no ADR 0253 amendment | neither type is touched; `RunOnce` still returns a bare `RunVerdict`. No amendment opened, none owed |
| unit coverage at the graded-axis / record seam | `run-manifest.unit.test.ts`, the same unit tier the module already uses |
| no machine-local absolute path in a committed artifact | rows carry no transcript path and no working directory; a keys assertion in the test pins the row shape |

## Deviations

**Class: an acceptance criterion this diff does not itself deliver.**
Said: "the `run` index reaches the spawn: `command.ts`'s `runOnce` callback no longer discards the `run` field."
Did: nothing — #5441 threads `run` through `runOnce` to name the per-run working directory. This diff consumes it rather than re-doing it.
Why: re-implementing it would have collided with the lane that was then under review.
Disposition: no action needed, and the contingency is now closed. #5441 merged to `main` as `754e629`, so the criterion is satisfied by the base this PR is rebased onto — which is why the keyword is `Fixes` rather than `Part of`.

**Class: a suggested piece deliberately left out.**
Said: the issue's cost table lists a `transcriptPath` as a third piece, marked "not free — new wiring."
Did: not wired. The graded path calls `claudeExecutor` directly and never reaches `locateTranscript`, so there was nothing to un-drop.
Why: a transcript path is an absolute, machine-local, perishable path, and the last acceptance criterion forbids one in a committed artifact. The session id is the durable key — the transcript is named after it — so a reader on the machine can still resolve the file and a reader elsewhere knows which session to ask for.
Disposition: for the reviewer to judge. No follow-up filed; the issue's own rabbit-hole list names plumbing `classifyRun` into the graded path as out of scope.

**Class: a shape choice the issue left open.**
Said: "a sidecar run manifest written alongside the committed artifacts under `claude-plugins/fabrika/reports/eval/`."
Did: the sidecar path is derived from the record's `--out` rather than taking a flag or a hardcoded directory.
Why: the defect is that identity was separable from the number, so a run that persists a record persists its sessions in the same act — no second flag to forget. An operator writing a record into the reports directory gets the manifest there too. With no `--out` nothing durable is written at all, so there is nothing to sit beside.
Disposition: no action needed.

**Class: what I could not run.**
Said: verify the change.
Did: `pnpm typecheck` (clean, 31 tasks), `pnpm lint:worktree` (clean), and the whole package suite `pnpm --filter @kampus/fabrika-cli test` (301 files, 4551 tests, green), plus a name-filtered run proving the new file is collected.
Why: guard #5406 refuses any shell command whose text contains the substring `eval`, which includes a single-file `vitest run` on a path under `src/eval/`. So the new file was never run in isolation — it was run as part of the full package suite and via a `-t` name filter.
Disposition: no action needed. No graded run was executed end to end (that spends model credits); the sidecar's behaviour is covered at the unit tier only.

**(repair round 1) Class: a resolution choice made while rebasing.**
Said: nothing — the original body assumed GitHub's retarget was the whole handover.
Did: the retarget left the PR `dirty`. The branch's first commit was its own copy of #5441's then-current work, which `main` now carries in a materially later shape (two further repair rounds: `stageRunWorkspace` takes a `setPath` and resolves a case's `files` set-directory-first then skill-root-second; `SkillEvalCase.files` is `ReadonlyArray<string> | null`, so an **absent** key is `Unstageable` before any temp directory exists and routes to `no-verdict:invocation-failed`, while an explicit `files: []` still stages an empty directory and scores). That superseded duplicate commit was dropped during the rebase, and both remaining conflicts were resolved **in favour of `main`**: `gradeRun` calls `stageRunWorkspace` with `setPath: request.path` and passes `evalCase.files` through untouched, and the README keeps `main`'s absent-vs-`[]` paragraph with this PR's sidecar section appended after it. `run-workspace.ts`, `run-workspace.unit.test.ts`, `skill-eval-set.ts` and `graded-axis.ts` are **not in this PR's diff at all** — verified by an empty `git diff --stat origin/main..HEAD` over those four paths.
Why: an earlier shape restored during a rebase would re-open a defect that took two repair rounds and three gate runs to close, and it would read as a clean merge.
Disposition: no action needed; verified rather than asserted. Re-ran `pnpm typecheck` (clean, 31 tasks), `pnpm lint:worktree` (clean) and the full package suite (301 files, **4605** tests, green) — which includes `run-workspace.unit.test.ts`, the suite that pins `main`'s `null`-vs-`[]` behaviour, so the intact behaviour is asserted by its own tests and not only by the diff being empty.
