### PR TITLE
fix(fabrika-cli): give every verb group a scannable root help row

### DIFF
--- a/packages/fabrika-cli/src/adr/command.ts
+++ b/packages/fabrika-cli/src/adr/command.ts
@@ -202,6 +202,7 @@ const sweepCmd = leafCommand(
 
 export const adrCommand = Command.make("adr").pipe(
 	Command.withSubcommands([next, newCmd, resolve, supersede, amendInPart, sweepCmd]),
+	Command.withShortDescription("Record one architecture decision, from id to citations."),
 	Command.withDescription(
 		"Record one architecture decision: allocate an id, scaffold the file, sweep for contradictions, resolve citations, and edit the status lines a new decision implies",
 	),

--- a/packages/fabrika-cli/src/build/command.ts
+++ b/packages/fabrika-cli/src/build/command.ts
@@ -428,6 +428,7 @@ export const buildCommand = Command.make("build").pipe(
 		note,
 		verdicts,
 	]),
+	Command.withShortDescription("Drive one construction lane from issue pick to open PR."),
 	Command.withDescription(
 		"Drive one construction lane end to end — prove the tree, pick and claim the issue, cut the branch, validate the tree, push, open the PR, and read the verdicts back",
 	),

--- a/packages/fabrika-cli/src/epic/command.ts
+++ b/packages/fabrika-cli/src/epic/command.ts
@@ -240,6 +240,7 @@ export const epicCommand = Command.make("epic").pipe(
 		verdict,
 		status,
 	]),
+	Command.withShortDescription("Conduct one epic as a single pull request."),
 	Command.withDescription(
 		"Conduct one epic as a single PR: open the nonce-keyed run ledger, relay the next action, brief and prove each slice from the git graph, and bind a verdict to the unpushed commit",
 	),

--- a/packages/fabrika-cli/src/glossary/command.ts
+++ b/packages/fabrika-cli/src/glossary/command.ts
@@ -226,6 +226,7 @@ const check = leafCommand(
 
 export const glossaryCommand = Command.make("glossary").pipe(
 	Command.withSubcommands([init, drift, lookup, sections, add, check]),
+	Command.withShortDescription("Maintain the repo's canonical vocabulary registers."),
 	Command.withDescription(
 		"Maintain the repo's canonical vocabulary registers: what is already declared, what moved since one last changed, where a row goes, and which rows have gone stale",
 	),

--- a/packages/fabrika-cli/src/governance/command.ts
+++ b/packages/fabrika-cli/src/governance/command.ts
@@ -280,6 +280,7 @@ const readout = leafCommand(
 
 export const governanceCommand = Command.make("governance").pipe(
 	Command.withSubcommands([scope, sweep, guards, base, post, digest, readout]),
+	Command.withShortDescription("Keep the governance corpus honest across a diff."),
 	Command.withDescription(
 		"Keep the governance corpus honest: derive the namespace a diff requires, rank the records it may contradict, scan the anchored invariants it moves, read this skill's own text at the merge base, emit the one verdict, and publish the periodic non-blocking readout",
 	),

--- a/packages/fabrika-cli/src/grill/command.ts
+++ b/packages/fabrika-cli/src/grill/command.ts
@@ -191,6 +191,7 @@ const read = leafCommand(
 
 export const grillCommand = Command.make("grill").pipe(
 	Command.withSubcommands([open, round, answerCmd, rule, read]),
+	Command.withShortDescription("Run a grilling session on a GitHub issue."),
 	Command.withDescription(
 		"Run a grilling session on a GitHub issue: post rounds of fact and decision questions, record agent-established answers and founder rulings against them, and read back the frontier — every recorded ruling bound to an authority and to the round text it ruled",
 	),

--- a/packages/fabrika-cli/src/handoff/command.ts
+++ b/packages/fabrika-cli/src/handoff/command.ts
@@ -155,6 +155,7 @@ const claim = leafCommand(
 
 export const handoffCommand = Command.make("handoff").pipe(
 	Command.withSubcommands([capture, take, read, claim]),
+	Command.withShortDescription("Hand one session's work to the next."),
 	Command.withDescription(
 		"Hand one session's work to the next: derive the ground state, seal a pack of what is asserted plus what is proven, read the latest pack back with its drift, and claim it under a run nonce",
 	),

--- a/packages/fabrika-cli/src/hook/command.ts
+++ b/packages/fabrika-cli/src/hook/command.ts
@@ -82,6 +82,7 @@ export const hookCommand = Command.make("hook").pipe(
 		codes,
 		spawn,
 	]),
+	Command.withShortDescription("Own fabrika's Claude Code hook surface."),
 	Command.withDescription(
 		"Own fabrika's Claude Code hook surface — read the harness envelope a hook is handed on stdin and say whether it is one fabrika can act on",
 	),

--- a/packages/fabrika-cli/src/ledger/command.ts
+++ b/packages/fabrika-cli/src/ledger/command.ts
@@ -233,6 +233,7 @@ export const ledgerCommand = Command.make("ledger").pipe(
 		write,
 		supersede,
 	]),
+	Command.withShortDescription("Author an epic's plan and its children."),
 	Command.withDescription(
 		"Author an epic's plan: open the run on proven-fresh ground, stage the plan block, mint each child born complete and linked, declare the dependency topology, and splice both into the epic body",
 	),

--- a/packages/fabrika-cli/src/map/command.ts
+++ b/packages/fabrika-cli/src/map/command.ts
@@ -351,6 +351,7 @@ const descope = leafCommand(
 
 export const mapCommand = Command.make("map").pipe(
 	Command.withSubcommands([open, read, ticket, lane, finding, fork, record, descope]),
+	Command.withShortDescription("Chart one destination's fog into frontier tickets."),
 	Command.withDescription(
 		"Chart one destination's fog: mint the map, decompose it into frontier tickets with native dependency edges, run lanes under a run nonce, route decisions to grilling and empirical questions to prototyping, and record each answer in lockstep",
 	),

--- a/packages/fabrika-cli/src/pattern/command.ts
+++ b/packages/fabrika-cli/src/pattern/command.ts
@@ -166,6 +166,7 @@ const register = leafCommand(
 
 export const patternCommand = Command.make("pattern").pipe(
 	Command.withSubcommands([corpus, drift, anchor, create, register]),
+	Command.withShortDescription("Read and write the pattern library."),
 	Command.withDescription(
 		"Read and write the pattern library: the corpus at a base ref, whether a doc's cited source or declared dependency pin moved, and the two writes that scaffold a doc and register its row",
 	),

--- a/packages/fabrika-cli/src/plan/command.ts
+++ b/packages/fabrika-cli/src/plan/command.ts
@@ -127,6 +127,7 @@ export const planCommand = Command.make("plan").pipe(
 		flip,
 		verdict,
 	]),
+	Command.withShortDescription("Gate an epic's plan before its children build."),
 	Command.withDescription(
 		"Gate an epic's plan: read its ledger, derive the deterministic floor, flip its planned children into the build pool, and post the verdict bound to the scope digest",
 	),

--- a/packages/fabrika-cli/src/report/command.ts
+++ b/packages/fabrika-cli/src/report/command.ts
@@ -159,6 +159,7 @@ const note = leafCommand(
 
 export const reportCommand = Command.make("report").pipe(
 	Command.withSubcommands([dedup, fileCmd, note]),
+	Command.withShortDescription("File one follow-up observation into the intake queue."),
 	Command.withDescription(
 		"File one follow-up observation into the intake queue: check for a duplicate, then compose and post it over a guarded path that refuses a leak, an empty body, or a hand-applied classification",
 	),

--- a/packages/fabrika-cli/src/review-ui/command.ts
+++ b/packages/fabrika-cli/src/review-ui/command.ts
@@ -171,6 +171,7 @@ export const reviewUiCommand = Command.make("review-ui").pipe(
 		post,
 		note,
 	]),
+	Command.withShortDescription("Judge a UI pull request over its preview deployment."),
 	Command.withDescription(
 		"Judge a UI pull request over its preview deployment — capture the named surfaces at the inspected head, and emit the review-ui verdict or a typed blocker note through the one sanctioned write path",
 	),

--- a/packages/fabrika-cli/src/review/command.ts
+++ b/packages/fabrika-cli/src/review/command.ts
@@ -300,6 +300,7 @@ export const reviewCommand = Command.make("review").pipe(
 		post,
 		appendCriterion,
 	]),
+	Command.withShortDescription("Read what a text review needs off one pull request."),
 	Command.withDescription(
 		"Read everything a text review needs off one pull request — scope, diff, criteria, CI, verdicts, deviations — and emit the verdict or a reviewer-authored criterion through the one sanctioned write path",
 	),

--- a/packages/fabrika-cli/src/ship/command.ts
+++ b/packages/fabrika-cli/src/ship/command.ts
@@ -364,6 +364,7 @@ export const shipCommand = Command.make("ship").pipe(
 		note,
 		release,
 	]),
+	Command.withShortDescription("Drive one pull request down the merge path."),
 	Command.withDescription(
 		"Everything the merge path needs off one pull request — scope, §CP discharge, the verdict conjunction, head CI, run evidence and review threads — plus the four writes that arm, watch, disarm and record it",
 	),

--- a/packages/fabrika-cli/src/short-description.unit.test.ts
+++ b/packages/fabrika-cli/src/short-description.unit.test.ts
@@ -74,3 +74,48 @@ describe("every registered leaf verb carries a short list-row description", () =
 		expect((verb.description ?? "").length).toBeGreaterThan((verb.shortDescription ?? "").length);
 	});
 });
+
+/**
+ * The same guard one level up: a group with no short description falls back to its full paragraph
+ * as its row in root `fabrika --help`, which is the root index #5372 found unreadable — 110–261
+ * characters per row across 23 groups.
+ *
+ * `eval` is the one group this slice could not author: `packages/fabrika-cli/src/eval/` was held by
+ * a live lane (PR #5441) rewriting the same file, so it is listed as pending rather than edited
+ * across that lane. The listing is self-retiring — the pending assertion below reds the moment
+ * `eval` gains its short description, so the entry has to be removed rather than remembered.
+ */
+describe("every registered verb group carries a short list-row description", () => {
+	interface DescribedGroup {
+		readonly name: string;
+		readonly description?: string | undefined;
+		readonly shortDescription?: string | undefined;
+	}
+
+	const PENDING_GROUPS: ReadonlyArray<string> = ["eval"];
+	const groups: ReadonlyArray<DescribedGroup> = registeredGroups;
+	const isPending = (group: DescribedGroup) => PENDING_GROUPS.includes(group.name);
+
+	it("finds groups at all — fail closed on zero scope (ADR 0092)", () => {
+		expect(groups.length).toBeGreaterThan(0);
+	});
+
+	it.each(
+		groups.filter((group) => !isPending(group)).map((group) => [group.name, group] as const),
+	)("`fabrika %s` lists as one scannable line", (_name, group) => {
+		expect(shortDescriptionDefects(group.shortDescription)).toEqual([]);
+	});
+
+	it.each(
+		groups.filter(isPending).map((group) => [group.name, group] as const),
+	)("`fabrika %s` is still pending — delete its entry once it is authored", (_name, group) => {
+		expect(shortDescriptionDefects(group.shortDescription)).not.toEqual([]);
+	});
+
+	it.each(
+		groups.map((group) => [group.name, group] as const),
+	)("`fabrika %s` keeps its full description for its own --help", (_name, group) => {
+		expect(group.description ?? "").not.toBe("");
+		expect((group.description ?? "").length).toBeGreaterThan((group.shortDescription ?? "").length);
+	});
+});

--- a/packages/fabrika-cli/src/spend/command.ts
+++ b/packages/fabrika-cli/src/spend/command.ts
@@ -88,6 +88,7 @@ const rollup = leafCommand(
 
 export const spendCommand = Command.make("spend").pipe(
 	Command.withSubcommands([read, rollup]),
+	Command.withShortDescription("Read what fabrika's runs cost, in tokens."),
 	Command.withDescription(
 		"Read what fabrika's runs cost, in tokens — one run from its transcript, or all of them from the durable ledger",
 	),

--- a/packages/fabrika-cli/src/spike/command.ts
+++ b/packages/fabrika-cli/src/spike/command.ts
@@ -220,6 +220,7 @@ const status = leafCommand(
 
 export const spikeCommand = Command.make("spike").pipe(
 	Command.withSubcommands([open, run, capture, dispose, status]),
+	Command.withShortDescription("Settle one empirical question by building a throwaway."),
 	Command.withDescription(
 		"Settle one empirical question by building a throwaway: mint the spike and its workspace outside the repository, record every run as evidence, capture the decision on the issue, and prove the throwaway was thrown away",
 	),

--- a/packages/fabrika-cli/src/status/command.ts
+++ b/packages/fabrika-cli/src/status/command.ts
@@ -315,6 +315,7 @@ export const statusCommand = Command.make("status").pipe(
 		board,
 		bootstrap,
 	]),
+	Command.withShortDescription("Answer what state the factory is in."),
 	Command.withDescription(
 		"Answer what state the factory is in — the composite front-door readout, the config-surface detection verb, the derived skill roster, the landed-decision digest, the board's bucket counts, and the one primitive that creates a missing surface",
 	),

--- a/packages/fabrika-cli/src/triage/command.ts
+++ b/packages/fabrika-cli/src/triage/command.ts
@@ -389,6 +389,7 @@ export const triageCommand = Command.make("triage").pipe(
 		homes,
 		enrich,
 	]),
+	Command.withShortDescription("Take one intake-queue issue from arrival to triaged."),
 	Command.withDescription(
 		"Take one intake-queue issue from arrival to a triaged, homed transition — or park it, split it, or close it not-planned — over reads that page and writes that are read back",
 	),

--- a/packages/fabrika-cli/src/ui/command.ts
+++ b/packages/fabrika-cli/src/ui/command.ts
@@ -181,6 +181,7 @@ export const uiCommand = Command.make("ui").pipe(
 		golden,
 		evidence,
 	]),
+	Command.withShortDescription("What the visual modality adds to a construction lane."),
 	Command.withDescription(
 		"What the visual modality adds to a construction lane — resolve the design surfaces and the typed law, render and validate surface captures, diff them against the blessed goldens, and attach the evidence to the PR",
 	),

--- a/packages/fabrika-cli/src/wire/command.ts
+++ b/packages/fabrika-cli/src/wire/command.ts
@@ -176,6 +176,7 @@ export const wireCommand = Command.make("wire").pipe(
 		check,
 		index,
 	]),
+	Command.withShortDescription("Own the byte-level formats two skills meet through."),
 	Command.withDescription(
 		"Own the byte-level formats two skills meet through on a GitHub artifact — compose them, read them back totally (found / absent / malformed), check one without reading its fields, and keep the index doc rendered from the registry",
 	),


### PR DESCRIPTION
Part of #5372

## What changed

Every verb group registered in `packages/fabrika-cli/src/registry.ts` now carries a
`Command.withShortDescription` line alongside its existing `Command.withDescription`, so root
`fabrika --help` prints a scannable one-line row per group instead of the group's full contract
paragraph. This is the same short/long split #5208 / PR #5368 gave the leaf verbs — the same
combinator, no second mechanism.

22 of the 23 groups are authored here. `eval` is not — see Deviations.

The coverage guard in `packages/fabrika-cli/src/short-description.unit.test.ts` now runs one level
up as well: a group registered without a short row reds instead of silently falling back to its
paragraph, and it fails closed on zero scope (ADR 0092), mirroring the leaf block above it.

## The convention question the issue left open

The issue asked whether groups get their own length budget or reuse the leaf convention. They reuse
it: `SHORT_DESCRIPTION_BUDGET` (72) and `shortDescriptionDefects` are unchanged and now judge group
rows too. The budget is derived from the renderer's column arithmetic, not from what a row
summarizes, so it transfers as-is; the authored lines all land well inside it (the longest is 55
characters). Inventing a second budget for groups would have been the divergent mechanism the first
acceptance criterion rules out.

## Evidence

Root `fabrika --help` at this head, `SUBCOMMANDS` block (run from `packages/fabrika-cli` via
`node src/bin.ts --help`):

```
  adr           Record one architecture decision, from id to citations.
  build         Drive one construction lane from issue pick to open PR.
  epic          Conduct one epic as a single pull request.
  eval          Graded per-stage corpus + scorecard + authored-…-set ingestion + … (unchanged)
  glossary      Maintain the repo's canonical vocabulary registers.
  governance    Keep the governance corpus honest across a diff.
  grill         Run a grilling session on a GitHub issue.
  handoff       Hand one session's work to the next.
  hook          Own fabrika's Claude Code hook surface.
  ledger        Author an epic's plan and its children.
  map           Chart one destination's fog into frontier tickets.
  pattern       Read and write the pattern library.
  plan          Gate an epic's plan before its children build.
  report        File one follow-up observation into the intake queue.
  review        Read what a text review needs off one pull request.
  review-ui     Judge a UI pull request over its preview deployment.
  ship          Drive one pull request down the merge path.
  spend         Read what fabrika's runs cost, in tokens.
  spike         Settle one empirical question by building a throwaway.
  status        Answer what state the factory is in.
  triage        Take one intake-queue issue from arrival to triaged.
  ui            What the visual modality adds to a construction lane.
  wire          Own the byte-level formats two skills meet through.
```

Every authored row fits one line at 100 columns. `fabrika <group> --help` still prints the full
description — verified on `fabrika adr --help`, whose `DESCRIPTION` block is byte-identical to the
string on `main`.

Also run at this head: `tsc --noEmit` on the package (clean), `biome check packages/fabrika-cli/src`
(clean), and the package unit tests (`short-description.unit.test.ts` + `unknown-subcommand.unit.test.ts`,
395 passed). The pre-push hook ran the repo typecheck and the changed-scope unit suite: 288 files,
2424 tests, all green.

## Acceptance criteria

- [ ] Every registered group carries a short description using the same combinator — **22 of 23**;
      `eval` is held by a live lane (see Deviations).
- [ ] No root `SUBCOMMANDS` row exceeds one line at 100 columns — true for all 22 authored rows;
      the `eval` row is unchanged and still long.
- [x] No group's `Command.withDescription` text is shortened, truncated or deleted — every long
      description is byte-identical to `main`; the diff is pure insertion (67 lines added, 0 removed).
- [x] The short lines are authored, not derived by truncation — none is a prefix of its long form;
      no ellipsis anywhere.

## Deviations

- **The `eval` group was not given its short description.** Its only home is
  `packages/fabrika-cli/src/eval/command.ts`, which PR #5441 is rewriting right now (its file list
  includes that exact file). Editing it from this lane would have written across a live lane, so it
  is left alone and listed as pending in the new test's `PENDING_GROUPS`. That listing is
  **self-retiring, not a tolerance**: the pending assertion reds the moment `eval` gains a short
  description, so the entry must be deleted rather than remembered. Consequence: the first two
  acceptance criteria are not fully discharged, so this PR says `Part of #5372`, not `Fixes` — a
  one-line follow-up after #5441 merges closes the issue.
- **The issue's measured `eval` length (154 chars) is stale.** On this branch's merge base the
  `eval` group description is far longer than that, which makes the unfixed row the worst one in the
  index. It is still out of scope here for the reason above.
