### PR TITLE
fix(review-code): key the head handle by PR so parallel reviews cannot cross-contaminate (#5416)

### DIFF
--- a/claude-plugins/kampus-pipeline/lib/common.sh
+++ b/claude-plugins/kampus-pipeline/lib/common.sh
@@ -384,6 +384,51 @@ kp_pcli() {
 # shellcheck disable=SC2034  # read by the sourcing script, not by this file
 KP_HEAD_HANDLE_ABSENT=20
 
+# Assert an ALREADY-SOURCED head handle describes the PR its reader was invoked for, and refuse
+# loudly when it does not. Defined once here for the same reason `KP_HEAD_HANDLE_ABSENT` is: all
+# three review gates read a head handle and must not diverge on what makes one trustworthy.
+#
+# `${REVIEW_WT:?…}` was the only guard the consumers had, and it fires when the handle is ABSENT,
+# never when it is WRONG — so a handle describing PR M satisfied every reader asking for PR N. A
+# reviewer then typechecked a sibling PR's tree and bound the verdict to its own live head SHA,
+# which the post-time SHA cross-check and ADR 0058 staleness both pass: a wrong-tree green is
+# indistinguishable from a right-tree green (#5416). Keying the slug by PR is what stops the
+# handles colliding; this is the belt-and-braces that makes a collision that got through UNKNOWN
+# instead of silent.
+#
+# The operands come from the handle FILE — the `HANDLE_PR` stamp `materialize-head.sh` wrote and
+# the PR-stamped names `pipeline-cli review-head materialize` mints (`review-head-<pr>-<id>`,
+# `refs/pr/<pr>-<nonce>`) — never re-derived from the argument under test, so a mismatch can
+# actually print. An unstamped handle is a refusal too: it is a handle whose PR cannot be
+# established, which is UNKNOWN, never "close enough" (§ZS, ADR 0092).
+# usage: kp_head_handle_names_pr <pr> <handle-path-for-the-message>
+kp_head_handle_names_pr() {
+	local pr="$1" handle="${2:-<handle>}"
+	if [ -z "${HANDLE_PR:-}" ]; then
+		printf 'head handle %s carries no HANDLE_PR stamp — its PR cannot be established, so it may describe ANOTHER PR. Refusing (§ZS; #5416).\n' "$handle" >&2
+		return 1
+	fi
+	if [ "$HANDLE_PR" != "$pr" ]; then
+		printf 'head handle %s describes PR %s, but this caller was invoked for PR %s — refusing to act on a SIBLING reviewer'"'"'s tree (#5416).\n' "$handle" "$HANDLE_PR" "$pr" >&2
+		return 1
+	fi
+	case "${REVIEW_WT:-}" in
+		'' | */review-head-"$pr"-*) ;;
+		*)
+			printf 'head handle %s stamps PR %s but names worktree %s, which is not PR %s'"'"'s tree — refusing (#5416).\n' "$handle" "$pr" "$REVIEW_WT" "$pr" >&2
+			return 1
+			;;
+	esac
+	case "${PR_REF:-}" in
+		'' | refs/pr/"$pr"-*) ;;
+		*)
+			printf 'head handle %s stamps PR %s but names ref %s, which is not PR %s'"'"'s ref — refusing (#5416).\n' "$handle" "$pr" "$PR_REF" "$pr" >&2
+			return 1
+			;;
+	esac
+	return 0
+}
+
 # The per-run scratch namespace for <slug> (§SP, #3718). `open` is the run's first write of
 # scratch state; `path` re-derives it in every later call. Both print the absolute directory.
 kp_scratch_open() { kp__scratch "open" "$1"; }

--- a/claude-plugins/kampus-pipeline/skills/review-code/SKILL.md
+++ b/claude-plugins/kampus-pipeline/skills/review-code/SKILL.md
@@ -357,6 +357,20 @@ values also persist to a per-run §SP handle that this skill's *own later script
 in-process via [`scripts/head-env.sh`](scripts/head-env.sh) — in-script sourcing of a sibling script
 stays sanctioned; only the `.` at your top-level command is banned.
 
+**That handle is keyed by PR, and every consumer passes the PR it was invoked for.** This is why
+each fence below carries `"$PR"`. The key used to be the session alone, and a fanned drain runs
+several `review-code` gates inside **one** session — so they shared a single `head.env`, the last
+materialization won, and an earlier reviewer typechecked a **sibling PR's tree** while binding its
+verdict to its own correctly-read live head SHA. Every existing detector passes that: the marker's
+SHA *is* the PR's head, so the post-time cross-check and ADR 0058 staleness both agree, and a
+wrong-tree green is indistinguishable from a right-tree green (#5416). The same key is what stops
+[`scripts/teardown-head.sh`](scripts/teardown-head.sh) `rm -rf`ing a sibling's live tree. Belt and
+braces: the handle records the PR it was written for, and every consumer refuses — loudly, as
+UNKNOWN, never as a skip — when the handle it resolved does not describe its own PR. All of that is
+re-derived, not asserted, by
+`bash ./.claude/.pipeline/skills/review-code/scripts/verify-head-handle-pr-keyed.sh` — including a
+mutant that puts the constant slug back and collides the two PRs again.
+
 The cross-fork case needs no special branch: `pull/$PR/head` is the GitHub-provided ref for
 the PR head whether it lives on this repo or a fork, so the single `git fetch` above covers
 both — and because it lands in `$PR_REF` (not your working tree) and the denylist is removed
@@ -367,7 +381,7 @@ an output), run the repo's commands **inside the review worktree** — behavior 
 running beats behavior inferred from a diff:
 
 ```bash
-bash ./.claude/.pipeline/skills/review-code/scripts/worktree-checks.sh
+bash ./.claude/.pipeline/skills/review-code/scripts/worktree-checks.sh "$PR"
 ```
 
 Scoping a test to the criterion is fine when the SHA-bound run-evidence bundle (Step 2) corroborates
@@ -379,7 +393,7 @@ degrade block below: run the FULL unit project, never a subset.
 just the happy path:**
 
 ```bash
-bash ./.claude/.pipeline/skills/review-code/scripts/teardown-head.sh
+bash ./.claude/.pipeline/skills/review-code/scripts/teardown-head.sh "$PR"
 ```
 
 It is the review's own `rm -rf` of a detached, already-pushed throwaway
@@ -387,7 +401,7 @@ it materialized itself (safe — it holds no branch and no unpushed work), so ru
 the review is exiting `FAIL` or aborting after a typecheck/lint error; a leaked `review-head-*`
 tree accumulates on the shared primary otherwise (#2785). To catch a mid-block error inside a
 single Bash call, register the script as a trap right after materialization:
-`trap 'bash ./.claude/.pipeline/skills/review-code/scripts/teardown-head.sh' EXIT` —
+`trap 'bash ./.claude/.pipeline/skills/review-code/scripts/teardown-head.sh "$PR"' EXIT` —
 and note the trap belongs to **your** shell, not to any extracted script: none of them installs an
 `EXIT` trap, because under bash 3.2 the trap's last command becomes the script's exit status and
 would launder a `set -u` abort into exit 0 (#4476, class #4479). And the
@@ -415,7 +429,7 @@ the full build inputs, so the typecheck bootstrap is whole — run it and treat 
 the typecheck signal:
 
 ```bash
-bash ./.claude/.pipeline/skills/review-code/scripts/worktree-typecheck.sh
+bash ./.claude/.pipeline/skills/review-code/scripts/worktree-typecheck.sh "$PR"
 ```
 
 CI and the SHA-bound run-evidence bundle (below) are now **corroboration**, not the sole
@@ -516,7 +530,7 @@ gate exists to prevent. On the degrade path therefore:
   past a degraded verification.
 
   ```bash
-  bash ./.claude/.pipeline/skills/review-code/scripts/full-unit-project.sh
+  bash ./.claude/.pipeline/skills/review-code/scripts/full-unit-project.sh "$PR"
   ```
 
 - **If — and only if — the full unit project genuinely cannot run** (an environment fault

--- a/claude-plugins/kampus-pipeline/skills/review-code/scripts/full-unit-project.sh
+++ b/claude-plugins/kampus-pipeline/skills/review-code/scripts/full-unit-project.sh
@@ -6,13 +6,21 @@
 #
 # `test:unit` lives in `apps/web/package.json`, NOT the repo root, so the `-C` target is
 # `$REVIEW_WT/apps/web`; a bare `pnpm -C "$REVIEW_WT" test:unit` hits ERR_PNPM_NO_SCRIPT.
+#
+# usage: bash ./claude-plugins/kampus-pipeline/skills/review-code/scripts/full-unit-project.sh <pr>
 set -uo pipefail
 # shellcheck source=../../../lib/common.sh disable=SC1007,SC1091
 . "$(CDPATH= cd -- "$(dirname -- "${BASH_SOURCE[0]}")/../../../lib" && pwd)/common.sh"
 
+[ "$#" -ge 1 ] || { echo "usage: full-unit-project.sh <pr>" >&2; exit 2; }
+PR="$1"
 # re-source $REVIEW_WT/$PR_REF after a between-call reset (#1807)
-# shellcheck disable=SC1007,SC1090
-. "$("$(CDPATH= cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)/head-env.sh")" || exit 1
+# shellcheck disable=SC1007
+HERE="$(CDPATH= cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)"
+HANDLE="$(bash "$HERE/head-env.sh" "$PR")" || exit 1
+# shellcheck disable=SC1090
+. "$HANDLE" || exit 1
 : "${REVIEW_WT:?full-unit-project.sh: REVIEW_WT unset — the head was never materialized; refusing to test the base tree (§HEAD)}"
+kp_head_handle_names_pr "$PR" "$HANDLE" || exit 1   # never run a SIBLING reviewer's unit project (#5416)
 
 pnpm -C "$REVIEW_WT/apps/web" test:unit   # FULL unit project (the apps/web script) — never path-narrowed on the degrade path

--- a/claude-plugins/kampus-pipeline/skills/review-code/scripts/glossary-freshness.sh
+++ b/claude-plugins/kampus-pipeline/skills/review-code/scripts/glossary-freshness.sh
@@ -19,11 +19,16 @@ cannot() { echo "glossary-freshness: CANNOT-EVALUATE ($1) — fold as [UNVERIFIA
 [ "$#" -ge 1 ] || { echo "usage: glossary-freshness.sh <pr>" >&2; cannot "no <pr> argument" 2; }
 PR="$1"
 REPO="$(kp_repo)" || cannot "target repo unresolved"
-# BASE_REF comes from the head handle materialize-head.sh wrote — the FRESHLY FETCHED base every
-# existence probe below reads against, never the working tree (formats §RO; the PR #305 false-FAIL).
-# shellcheck disable=SC1007,SC1090
-. "$("$(CDPATH= cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)/head-env.sh")" || cannot "no head handle — run materialize-head.sh first (its \`git fetch origin \$BASE_REF\` is what makes these probes fresh)"
+# BASE_REF comes from the head handle materialize-head.sh wrote FOR THIS PR — the FRESHLY FETCHED
+# base every existence probe below reads against, never the working tree (formats §RO; the PR #305
+# false-FAIL).
+# shellcheck disable=SC1007
+HERE="$(CDPATH= cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)"
+HANDLE="$(bash "$HERE/head-env.sh" "$PR")" || cannot "no head handle for PR $PR — run materialize-head.sh first (its \`git fetch origin \$BASE_REF\` is what makes these probes fresh)"
+# shellcheck disable=SC1090
+. "$HANDLE" || cannot "the head handle $HANDLE is unreachable, which is not absent"
 [ -n "${BASE_REF:-}" ] || cannot "handle carries no BASE_REF"
+kp_head_handle_names_pr "$PR" "$HANDLE" || cannot "the head handle does not describe PR $PR — every probe below would read a SIBLING reviewer's base (#5416)"
 
 # `git cat-file -e` exits non-zero for BOTH "no such path" and "the read itself failed", so against an
 # unreadable base every probe below reads ABSENT and the graceful-absence branch prints a confident

--- a/claude-plugins/kampus-pipeline/skills/review-code/scripts/head-env.sh
+++ b/claude-plugins/kampus-pipeline/skills/review-code/scripts/head-env.sh
@@ -9,24 +9,46 @@
 # on an AGENT sourcing at its top-level command, which the isolation verifier refuses. The agent
 # reads the same four values off `materialize-head.sh`'s stdout instead.
 #
-# The namespace is per-run and per-session (§SP, #3718), which is what keeps a SIBLING reviewer's
-# tree out of reach — the failure a `git worktree list` re-derivation on a shared leaf name walks
-# straight into, pinning the wrong head (#1807). Exits non-zero with EMPTY stdout when it cannot
-# print a handle, so a caller's `.` fails loudly instead of reading the base tree — and the status is
-# WHICH cause fired: 5 / $KP_HEAD_HANDLE_ABSENT mean nothing was materialized, anything else means
-# the resolver could not look (see `KP_HEAD_HANDLE_ABSENT` in ../../../lib/common.sh).
+# usage: head-env.sh <pr>
+#
+# The namespace is per-run, per-session AND per-PR (§SP, #3718). The PR key is load-bearing, not
+# symmetry with the sibling gates: a session-only key does not discriminate at the one moment it
+# has to, because the normal drain fans several `review-code` runs inside ONE session — they then
+# shared a single `head.env`, the last `materialize-head.sh` won, and every earlier reviewer
+# silently re-pointed at the winner's tree (#5416). Callers pass the PR they were invoked for, so
+# a caller asking for PR N can never be handed a handle describing PR M — the slug separates them,
+# and `kp_head_handle_names_pr` refuses the leftovers of any way one still could.
+#
+# Exits non-zero with EMPTY stdout when it cannot print a TRUSTWORTHY handle, so a caller's `.`
+# fails loudly instead of reading the base tree — and the status is WHICH cause fired: 5 /
+# $KP_HEAD_HANDLE_ABSENT mean nothing was materialized, anything else (a mismatched handle
+# included) means the resolver could not hand over an answer, which is UNKNOWN (see
+# `KP_HEAD_HANDLE_ABSENT` in ../../../lib/common.sh).
 set -uo pipefail
 # shellcheck source=../../../lib/common.sh disable=SC1007,SC1091
 . "$(CDPATH= cd -- "$(dirname -- "${BASH_SOURCE[0]}")/../../../lib" && pwd)/common.sh"
 
-DIR="$(kp_scratch_path review-code-head)"
+[ "$#" -ge 1 ] || { echo "usage: head-env.sh <pr>" >&2; exit 2; }
+PR="$1"
+
+DIR="$(kp_scratch_path "review-code-head-$PR")"
 RC=$?
 # Propagate `kp_scratch_path`'s own status instead of flattening it to 1: teardown-head.sh decides
 # no-op-vs-error from this number, and a flattened 1 made "namespace never opened" (5) look the same
 # as "the CLI never ran" (127) — #4972.
 [ "$RC" -eq 0 ] || exit "$RC"
 [ -f "$DIR/head.env" ] || {
-  echo "head-env.sh: namespace $DIR holds no head.env — materialize-head.sh never ran (or was aborted) in THIS session, so nothing was materialized. NEVER fall back to the launched checkout's working copy (§HEAD, #793)." >&2
+  echo "head-env.sh: namespace $DIR holds no head.env — materialize-head.sh never ran for PR $PR (or was aborted) in THIS session, so nothing was materialized. NEVER fall back to the launched checkout's working copy (§HEAD, #793)." >&2
   exit "$KP_HEAD_HANDLE_ABSENT"
 }
+# Verify the handle DESCRIBES this PR before handing its path out. Read it in a subshell so the
+# check cannot leak the handle's values into this script's own environment and answer itself.
+(
+  # shellcheck disable=SC1090,SC1091  # the run-unique handle resolved just above
+  . "$DIR/head.env" || {
+    echo "head-env.sh: $DIR/head.env exists but could not be read — unreachable is not absent." >&2
+    exit 1
+  }
+  kp_head_handle_names_pr "$PR" "$DIR/head.env"
+) || exit 1
 printf '%s\n' "$DIR/head.env"

--- a/claude-plugins/kampus-pipeline/skills/review-code/scripts/materialize-head.sh
+++ b/claude-plugins/kampus-pipeline/skills/review-code/scripts/materialize-head.sh
@@ -14,8 +14,8 @@
 #
 # The same four values ALSO persist to a per-run §SP handle. That is not a second answer channel: the
 # harness resets the agent's shell between Bash calls, so the LATER scripts of this skill re-source
-# the handle in-process via head-env.sh. In-script sourcing stays sanctioned under ADR 0232 — only
-# the `.` at an agent's top-level command is banned.
+# the handle in-process via `head-env.sh <pr>`, each passing the PR it was invoked for. In-script
+# sourcing stays sanctioned under ADR 0232 — only the `.` at an agent's top-level command is banned.
 set -uo pipefail
 # shellcheck source=../../../lib/common.sh disable=SC1007,SC1091
 . "$(CDPATH= cd -- "$(dirname -- "${BASH_SOURCE[0]}")/../../../lib" && pwd)/common.sh"
@@ -66,10 +66,15 @@ git fetch origin "$BASE_REF" >&2
 # catalog/lockfile, and everything `fate generate` needs are present, so the typecheck bootstrap is
 # whole. A full checkout also lands the head's root CLAUDE.md + .claude/.decisions/.patterns — that
 # leak is closed by the explicit denylist removal + absence-assert below, NOT by any pattern set.
-WT_FILE="$(kp_scratch_open review-code-head)/head.env" || exit 1
+# The slug is keyed by PR, not by session alone: a fanned drain runs several `review-code` gates in
+# ONE session, so a constant slug made them share one handle and the last writer won (#5416). The
+# `HANDLE_PR` stamp is the same fact recorded INSIDE the file, which is what lets every reader
+# refuse a handle that reached it by any route the slug does not cover — see
+# `kp_head_handle_names_pr`.
+WT_FILE="$(kp_scratch_open "review-code-head-$PR")/head.env" || exit 1
 "$PCLI" review-head materialize --pr "$PR" --worktree \
   | jq -r '"REVIEW_WT=\(.worktreeDir)\nPR_REF=\(.prRef)\nHEAD_SHA=\(.headSha)"' > "$WT_FILE"
-printf 'BASE_REF=%s\n' "$BASE_REF" >> "$WT_FILE"
+printf 'BASE_REF=%s\nHANDLE_PR=%s\n' "$BASE_REF" "$PR" >> "$WT_FILE"
 # shellcheck disable=SC1090  # the run-unique handle this script just wrote
 . "$WT_FILE"
 [ -n "${REVIEW_WT:-}" ] && [ -n "${PR_REF:-}" ] && [ -n "${HEAD_SHA:-}" ] || {

--- a/claude-plugins/kampus-pipeline/skills/review-code/scripts/teardown-head.sh
+++ b/claude-plugins/kampus-pipeline/skills/review-code/scripts/teardown-head.sh
@@ -10,6 +10,12 @@
 # unpushed work. Idempotent — a namespace that was never opened is a clean no-op, so it may be run
 # after an aborted materialization.
 #
+# usage: bash ./claude-plugins/kampus-pipeline/skills/review-code/scripts/teardown-head.sh <pr>
+#
+# It takes the PR so it can only ever delete ITS OWN. Under the session-only handle key, a reviewer
+# finishing PR A `rm -rf`'d PR B's live worktree and dropped B's ref mid-run (#5416) — teardown is
+# the one consumer whose mis-keying destroys another lane's work rather than merely mis-reading it.
+#
 # It exits 0 ONLY on a real teardown or a real no-op. A handle read that could not RUN is UNKNOWN and
 # exits non-zero: this branch used to answer "nothing to tear down" for every failure, so the gate
 # reported success on the exact path it leaked its worktree and ref (#4972 / #5193, class #4482).
@@ -19,13 +25,15 @@ set -uo pipefail
 # shellcheck source=../../../lib/common.sh disable=SC1007,SC1091
 . "$(CDPATH= cd -- "$(dirname -- "${BASH_SOURCE[0]}")/../../../lib" && pwd)/common.sh"
 
+[ "$#" -ge 1 ] || { echo "usage: teardown-head.sh <pr>" >&2; exit 2; }
+PR="$1"
 # shellcheck disable=SC1007
 HERE="$(CDPATH= cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)"
 # `bash "$HERE/head-env.sh"`, not a direct exec: the sibling is committed non-executable in two of the
 # three gates, and a direct exec there dies 126 — a failure this script then reported as a clean no-op
 # on every single run (#5193). Every other call site in the suite already invokes via `bash`.
 # head-env.sh's stderr is deliberately NOT discarded: it names which cause fired (#4972).
-HANDLE="$(bash "$HERE/head-env.sh")"
+HANDLE="$(bash "$HERE/head-env.sh" "$PR")"
 RC=$?
 case "$RC" in
   0) ;;
@@ -45,6 +53,13 @@ esac
 }
 [ -n "${REVIEW_WT:-}" ] && [ -n "${PR_REF:-}" ] || {
   echo "teardown-head.sh: handle $HANDLE carries no REVIEW_WT/PR_REF — refusing to guess a path to \`rm -rf\`, and refusing to call that success: a readable handle is evidence something WAS materialized and is now unreachable." >&2
+  exit 1
+}
+# The last gate before an `rm -rf`: prove what is about to be deleted is PR $PR's, not a sibling
+# reviewer's live tree. A mismatch is a refusal, never a no-op — something IS materialized, and this
+# run is not the one allowed to remove it.
+kp_head_handle_names_pr "$PR" "$HANDLE" || {
+  echo "teardown-head.sh: refusing to tear down — the handle does not describe PR $PR. Nothing was removed, and a tree may still be live on the shared primary." >&2
   exit 1
 }
 

--- a/claude-plugins/kampus-pipeline/skills/review-code/scripts/verify-glossary-detector-fires.sh
+++ b/claude-plugins/kampus-pipeline/skills/review-code/scripts/verify-glossary-detector-fires.sh
@@ -74,7 +74,11 @@ BIN="$TMP/bin"
 PLUGIN="$TMP/plugin/bin"
 HEAD="$TMP/head"
 mkdir -p "$BIN" "$PLUGIN" "$HEAD" || { echo "FAIL: cannot create the stub dirs under $TMP"; exit 1; }
-printf 'BASE_REF=main\nHEAD_SHA=%s\n' "0000000000000000000000000000000000000000" > "$HEAD/head.env"
+# Every case runs the SUT for PR 1, so the handle must be PR 1's — `HANDLE_PR` plus the PR-stamped
+# worktree/ref names a real materialization writes. Without them `head-env.sh` refuses the handle as
+# possibly a sibling reviewer's, which is the fail-closed behaviour #5416 added.
+printf 'BASE_REF=main\nHEAD_SHA=%s\nHANDLE_PR=1\nREVIEW_WT=%s\nPR_REF=refs/pr/1-proof\n' \
+	"0000000000000000000000000000000000000000" "$TMP/review-head-1-proof" > "$HEAD/head.env"
 
 cat > "$BIN/gh" <<'STUB'
 #!/usr/bin/env bash

--- a/claude-plugins/kampus-pipeline/skills/review-code/scripts/verify-head-handle-pr-keyed.sh
+++ b/claude-plugins/kampus-pipeline/skills/review-code/scripts/verify-head-handle-pr-keyed.sh
@@ -1,0 +1,192 @@
+#!/usr/bin/env bash
+# Re-derives, rather than asserts, that `review-code`'s head handle is PR-keyed and that every
+# consumer of it fails closed on a handle describing another PR (#5416).
+#
+# The defect this pins is silent by construction, which is why it needs a proof rather than a
+# reading. The handle used to be keyed by session alone, so two `review-code` gates fanned in ONE
+# session — the normal drain shape — shared a single `head.env` and the last materialization won.
+# The reviewer then verified a SIBLING PR's tree while reading its own PR's live head SHA straight
+# from the API, so the marker it posted was correctly bound to a tree it never checked. Marker-shape
+# validation, the post-time SHA cross-check and ADR 0058 staleness all pass that: a wrong-tree green
+# is indistinguishable from a right-tree green.
+#
+# Nine cases, driven under ONE session id because same-session collision is the whole failure:
+#   1  two PRs, one session          -> two DIFFERENT namespaces (the keying itself)
+#   2  handle that matches           -> exit 0, its path on stdout
+#   3  handle stamped for ANOTHER PR -> non-zero, EMPTY stdout (the clobber, now refused)
+#   4  unstamped legacy handle       -> non-zero (a PR that cannot be established is UNKNOWN)
+#   5  stamp right, worktree wrong   -> non-zero (the stamp alone is not the whole evidence)
+#   6  no <pr> argument              -> exit 2 (a caller that cannot name its PR gets no handle)
+#   7  every consumer, mismatched    -> non-zero, and the sibling's tree is still there
+#   8  teardown, mismatched          -> non-zero, sibling tree NOT removed (#5416's teardown half)
+#   9  falsifiability                -> a mutant with the constant slug collides the two PRs again
+#
+# Hermetic: no network, no `gh`, and it never reaches a `pnpm` run — every consumer case is a
+# refusal, which happens before any command runs. It touches no worktree and no ref of the checkout
+# it runs in.
+#
+# usage: bash claude-plugins/kampus-pipeline/skills/review-code/scripts/verify-head-handle-pr-keyed.sh
+#
+# Shell shape per .patterns/skill-script-shell-shape.md: `set -uo pipefail`, never `-e`, no `EXIT`
+# trap — under bash 3.2 a cleanup trap's last command becomes the exit status and would launder a
+# `set -u` abort into the exit 0 this harness's whole contract rests on.
+# SC2016 is declared, not waved off: the mutant's sed program matches the LITERAL `$PR` in the
+# script's source text, so expanding it here would rewrite the mutant into something that reverts
+# nothing.
+# shellcheck disable=SC1007,SC1091,SC2016
+set -uo pipefail
+HERE="$(CDPATH= cd -P -- "$(dirname -- "$0")" && pwd -P)"
+PLUGIN="$(CDPATH= cd -P -- "$HERE/../../.." && pwd -P)"
+# shellcheck source=../../../lib/common.sh
+. "$PLUGIN/lib/common.sh"
+PCLI="$(kp_pcli)" || exit 127
+
+FAILED=0
+ok() { printf 'PASS  %s\n' "$1"; }
+bad() {
+	printf 'FAIL  %s\n' "$1"
+	FAILED=1
+}
+
+TMP="$(mktemp -d)"
+if [ -z "$TMP" ] || [ ! -d "$TMP" ]; then
+	echo "FAIL: mktemp -d produced no temp root — refusing to run against nothing (ADR 0092)"
+	exit 1
+fi
+
+SESSION="head-pr-proof-$$"
+MINE=811001
+SIBLING=811002
+MINE_WT="$TMP/review-head-$MINE-proof"
+SIBLING_WT="$TMP/review-head-$SIBLING-proof"
+mkdir -p "$MINE_WT" "$SIBLING_WT"
+
+open_ns() { CLAUDE_CODE_SESSION_ID="$SESSION" "$PCLI" scratchpad open --slug "$1" 2>/dev/null; }
+run_head_env() { CLAUDE_CODE_SESSION_ID="$SESSION" bash "$HERE/head-env.sh" "$@" 2>/dev/null; }
+
+DIR_MINE="$(open_ns "review-code-head-$MINE")"
+DIR_SIBLING="$(open_ns "review-code-head-$SIBLING")"
+if [ -z "$DIR_MINE" ] || [ -z "$DIR_SIBLING" ]; then
+	echo "FAIL: zero scope — the scratch namespaces could not be opened, so nothing below was tested (ADR 0092)"
+	exit 1
+fi
+
+# A well-formed handle, exactly as `materialize-head.sh` writes one.
+handle() { # <dir> <stamped-pr> <worktree> <ref-pr>
+	printf 'REVIEW_WT=%s\nPR_REF=refs/pr/%s-proof\nHEAD_SHA=%s\nBASE_REF=main\nHANDLE_PR=%s\n' \
+		"$3" "$4" "0000000000000000000000000000000000000000" "$2" >"$1/head.env"
+}
+
+# 1 — the keying itself. One session, two PRs, two namespaces. Pre-fix these were the same path.
+if [ "$DIR_MINE" != "$DIR_SIBLING" ]; then
+	ok "1 two PRs in one session -> two namespaces"
+else
+	bad "1 both PRs resolved to $DIR_MINE — the handle is not PR-keyed"
+fi
+
+# 2 — the handle that matches is handed over.
+handle "$DIR_MINE" "$MINE" "$MINE_WT" "$MINE"
+OUT="$(run_head_env "$MINE")"
+RC=$?
+if [ "$RC" -eq 0 ] && [ "$OUT" = "$DIR_MINE/head.env" ]; then
+	ok "2 matching handle -> exit 0, path on stdout"
+else
+	bad "2 expected $DIR_MINE/head.env at exit 0, got rc=$RC out=${OUT:-<empty>}"
+fi
+
+# 3 — THE defect: the namespace holds a handle describing the sibling. Pre-fix this is what every
+# consumer read, and it read as perfectly well-formed.
+handle "$DIR_SIBLING" "$MINE" "$MINE_WT" "$MINE"
+OUT="$(run_head_env "$SIBLING")"
+RC=$?
+if [ "$RC" -ne 0 ] && [ -z "$OUT" ]; then
+	ok "3 handle for another PR -> non-zero, empty stdout"
+else
+	bad "3 a sibling's handle was handed over (rc=$RC out=${OUT:-<empty>})"
+fi
+
+# 7 — every consumer refuses the same mismatch, and none of them touches the tree it names. Run
+# while $DIR_SIBLING still holds case 3's mismatched handle.
+for consumer in worktree-typecheck worktree-checks full-unit-project teardown-head glossary-freshness; do
+	CLAUDE_CODE_SESSION_ID="$SESSION" CLAUDE_PIPELINE_REPO=owner/repo \
+		bash "$HERE/$consumer.sh" "$SIBLING" >/dev/null 2>&1
+	RC=$?
+	if [ "$RC" -ne 0 ] && [ -d "$MINE_WT" ]; then
+		ok "7 $consumer refuses a sibling's handle (rc=$RC), sibling tree intact"
+	else
+		bad "7 $consumer acted on a sibling's handle (rc=$RC, tree-present=$([ -d "$MINE_WT" ] && echo yes || echo no))"
+	fi
+done
+
+# 8 — teardown is called out separately because its failure mode is destruction, not mis-reading:
+# a reviewer finishing one PR used to `rm -rf` another's live tree. Case 7 ran it above; this
+# asserts the surviving tree is the point, not a side effect.
+if [ -d "$MINE_WT" ]; then
+	ok "8 teardown removed nothing that was not its own"
+else
+	bad "8 teardown deleted the sibling's live worktree"
+fi
+
+# 4 — a legacy handle with no stamp. Its PR cannot be established, and unestablished is UNKNOWN.
+printf 'REVIEW_WT=%s\nPR_REF=refs/pr/%s-proof\nBASE_REF=main\n' "$SIBLING_WT" "$SIBLING" >"$DIR_SIBLING/head.env"
+OUT="$(run_head_env "$SIBLING")"
+RC=$?
+if [ "$RC" -ne 0 ] && [ -z "$OUT" ]; then
+	ok "4 unstamped handle -> non-zero, empty stdout"
+else
+	bad "4 an unstamped handle was handed over (rc=$RC out=${OUT:-<empty>})"
+fi
+
+# 5 — the stamp says the right PR while the worktree it names is another's. The stamp and the names
+# are separate evidence, so a handle that half-corresponds is still a refusal.
+handle "$DIR_SIBLING" "$SIBLING" "$MINE_WT" "$SIBLING"
+OUT="$(run_head_env "$SIBLING")"
+RC=$?
+if [ "$RC" -ne 0 ] && [ -z "$OUT" ]; then
+	ok "5 right stamp, wrong worktree -> non-zero"
+else
+	bad "5 a handle naming another PR's tree was handed over (rc=$RC out=${OUT:-<empty>})"
+fi
+
+# 6 — a caller that does not name its PR cannot be told which handle is its own.
+OUT="$(run_head_env)"
+RC=$?
+if [ "$RC" -eq 2 ] && [ -z "$OUT" ]; then
+	ok "6 no <pr> argument -> exit 2, empty stdout"
+else
+	bad "6 expected exit 2 with empty stdout, got rc=$RC out=${OUT:-<empty>}"
+fi
+
+# 9 — falsifiability. A mutant that reverts the slug to the constant `review-code-head` and drops
+# the correspondence guard must collide the two PRs again. It lives at the same depth as the
+# original: the script resolves its shared lib through `../../../lib`, so a mutant in a flat temp
+# dir would die at lib resolution — an exit this harness could score as "caught" while testing
+# nothing.
+MUT_DIR="$TMP/tree/skills/review-code/scripts"
+mkdir -p "$MUT_DIR"
+ln -s "$PLUGIN/lib" "$TMP/tree/lib"
+MUTANT="$MUT_DIR/mutant-head-env.sh"
+sed -e 's/"review-code-head-\$PR"/review-code-head/' -e '/kp_head_handle_names_pr/d' \
+	"$HERE/head-env.sh" >"$MUTANT"
+if cmp -s "$HERE/head-env.sh" "$MUTANT"; then
+	bad "9 the mutant is byte-identical to the original — it reverts nothing"
+else
+	# The un-keyed namespace is the one the pre-fix code wrote into, so the fixture opens it and
+	# gives it the sibling's handle — the state the last materialization of a fanned drain left.
+	DIR_CONSTANT="$(open_ns review-code-head)"
+	handle "$DIR_CONSTANT" "$SIBLING" "$SIBLING_WT" "$SIBLING"
+	M_MINE="$(CLAUDE_CODE_SESSION_ID="$SESSION" bash "$MUTANT" "$MINE" 2>/dev/null)"
+	M_SIBLING="$(CLAUDE_CODE_SESSION_ID="$SESSION" bash "$MUTANT" "$SIBLING" 2>/dev/null)"
+	if [ -n "$M_MINE" ] && [ "$M_MINE" = "$M_SIBLING" ]; then
+		ok "9 constant slug + no guard -> both PRs read one handle (the filed defect)"
+	else
+		bad "9 the mutant did not reproduce the collision (mine=${M_MINE:-<empty>} sibling=${M_SIBLING:-<empty>})"
+	fi
+fi
+
+rm -rf "$TMP" "$DIR_MINE" "$DIR_SIBLING" "${DIR_CONSTANT:-}"
+if [ "$FAILED" -ne 0 ]; then
+	echo "head-handle PR-keying proof: FAILED" >&2
+	exit 1
+fi
+echo "head-handle PR-keying proof: the handle is PR-keyed and every consumer fails closed on another PR's handle"

--- a/claude-plugins/kampus-pipeline/skills/review-code/scripts/verify-head-handle-pr-keyed.sh
+++ b/claude-plugins/kampus-pipeline/skills/review-code/scripts/verify-head-handle-pr-keyed.sh
@@ -37,8 +37,8 @@
 set -uo pipefail
 HERE="$(CDPATH= cd -P -- "$(dirname -- "$0")" && pwd -P)"
 PLUGIN="$(CDPATH= cd -P -- "$HERE/../../.." && pwd -P)"
-# shellcheck source=../../../lib/common.sh
-. "$PLUGIN/lib/common.sh"
+# shellcheck source=../../../lib/common.sh disable=SC1007,SC1091
+. "$(CDPATH= cd -- "$(dirname -- "${BASH_SOURCE[0]}")/../../../lib" && pwd)/common.sh"
 PCLI="$(kp_pcli)" || exit 127
 
 FAILED=0

--- a/claude-plugins/kampus-pipeline/skills/review-code/scripts/worktree-checks.sh
+++ b/claude-plugins/kampus-pipeline/skills/review-code/scripts/worktree-checks.sh
@@ -2,15 +2,23 @@
 # Step 2 — install + lint inside the review worktree (behavior verified by running beats behavior
 # inferred from a diff). Extracted from review-code/SKILL.md (#4451, epic #4435 phase 1). Extraction
 # contract + shell-option rationale: ../SKILL.md § The extracted scripts.
+#
+# usage: bash ./claude-plugins/kampus-pipeline/skills/review-code/scripts/worktree-checks.sh <pr>
 set -uo pipefail
 # shellcheck source=../../../lib/common.sh disable=SC1007,SC1091
 . "$(CDPATH= cd -- "$(dirname -- "${BASH_SOURCE[0]}")/../../../lib" && pwd)/common.sh"
 
+[ "$#" -ge 1 ] || { echo "usage: worktree-checks.sh <pr>" >&2; exit 2; }
+PR="$1"
 # re-source the run-unique $REVIEW_WT/$PR_REF after a between-call reset (#1807) — never re-derive
 # from the shared `review-head-${PR}` leaf name
-# shellcheck disable=SC1007,SC1090
-. "$("$(CDPATH= cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)/head-env.sh")" || exit 1
+# shellcheck disable=SC1007
+HERE="$(CDPATH= cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)"
+HANDLE="$(bash "$HERE/head-env.sh" "$PR")" || exit 1
+# shellcheck disable=SC1090
+. "$HANDLE" || exit 1
 : "${REVIEW_WT:?worktree-checks.sh: REVIEW_WT unset — the head was never materialized; refusing to check the base tree (§HEAD)}"
+kp_head_handle_names_pr "$PR" "$HANDLE" || exit 1   # never install+lint a SIBLING reviewer's tree (#5416)
 
 pnpm -C "$REVIEW_WT" install   # the catalog/lockfile + patches/ are present, so this succeeds
 # Lint via `pnpm lint:worktree`, never `pnpm lint` / `biome check .`: bare `.` resolves to the

--- a/claude-plugins/kampus-pipeline/skills/review-code/scripts/worktree-typecheck.sh
+++ b/claude-plugins/kampus-pipeline/skills/review-code/scripts/worktree-typecheck.sh
@@ -2,12 +2,23 @@
 # Step 2 — the authoritative in-worktree typecheck (ADR 0067, reversing 0060's deferred-to-CI
 # workaround). Extracted from review-code/SKILL.md (#4451, epic #4435 phase 1). Extraction contract:
 # ../SKILL.md § The extracted scripts.
+#
+# usage: bash ./claude-plugins/kampus-pipeline/skills/review-code/scripts/worktree-typecheck.sh <pr>
 set -uo pipefail
 # shellcheck source=../../../lib/common.sh disable=SC1007,SC1091
 . "$(CDPATH= cd -- "$(dirname -- "${BASH_SOURCE[0]}")/../../../lib" && pwd)/common.sh"
 
-# shellcheck disable=SC1007,SC1090
-. "$("$(CDPATH= cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)/head-env.sh")" || exit 1
+[ "$#" -ge 1 ] || { echo "usage: worktree-typecheck.sh <pr>" >&2; exit 2; }
+PR="$1"
+# shellcheck disable=SC1007
+HERE="$(CDPATH= cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)"
+HANDLE="$(bash "$HERE/head-env.sh" "$PR")" || exit 1
+# shellcheck disable=SC1090
+. "$HANDLE" || exit 1
 : "${REVIEW_WT:?worktree-typecheck.sh: REVIEW_WT unset — the head was never materialized; refusing to typecheck the base tree (§HEAD)}"
+# The handle is only mine if it describes MY PR: a typecheck of a sibling's tree passes, and the
+# verdict it feeds is bound to this PR's own live head SHA, so the green is wrong and unfalsifiable
+# from the outside (#5416).
+kp_head_handle_names_pr "$PR" "$HANDLE" || exit 1
 
 pnpm -C "$REVIEW_WT" typecheck   # `pnpm install` above made patches/ hashable + `fate generate` resolvable

--- a/claude-plugins/kampus-pipeline/skills/shared/scripts/teardown-head-fail-closed-proof.sh
+++ b/claude-plugins/kampus-pipeline/skills/shared/scripts/teardown-head-fail-closed-proof.sh
@@ -4,13 +4,14 @@
 # worktrees nor its refs: the one case that actually tears something down runs inside a throwaway git
 # repo under $TMPDIR.
 #
-# Six cases per gate:
+# Six cases per gate, plus a seventh that only `review-code` carries:
 #   A  namespace never opened            -> exit 0, quiet no-op (idempotence preserved)
 #   B  namespace open, no handle file    -> exit 0, quiet no-op (nothing was materialized)
 #   C  resolver could not run            -> NON-ZERO (the #4972 / #5193 fail-open, now closed)
 #   D  handle readable but malformed     -> NON-ZERO while still refusing to guess a path
 #   E  handle well-formed                -> exit 0 AND the tree + ref are actually gone
 #   F  source shape                      -> invoked via `bash`, stderr not discarded (#5193's 126)
+#   G  handle describes ANOTHER PR       -> NON-ZERO, and the sibling's tree survives (#5416)
 #
 # Case E doubles as #5193's live proof for two of the three gates: `review-skill`'s and `review-doc`'s
 # `head-env.sh` are committed 100644, so E only passes because the sibling is now run through `bash`.
@@ -41,44 +42,38 @@ expect() {
 }
 
 PR=99999
-# `<gate> <slug> <leaf> <takes-pr>` — the three copies diverge only in these four fields.
-GATES="review-code review-code-head head.env no
-review-skill review-skill-head-$PR wt.env yes
-review-doc review-doc-$PR head.env yes"
+# `<gate> <slug> <leaf>` — the three copies diverge only in these three fields. All three now take
+# the PR: `review-code`'s slug was the last session-only one, and a session-only key let a fanned
+# drain's gates share one handle and tear down each other's trees (#5416).
+GATES="review-code review-code-head-$PR head.env
+review-skill review-skill-head-$PR wt.env
+review-doc review-doc-$PR head.env"
 
 # Run one gate's teardown under a fresh session id; echoes its exit status.
-run_teardown() { # <gate> <takes-pr> <session>
-  local gate="$1" takes_pr="$2" session="$3" script
+run_teardown() { # <gate> <session>
+  local gate="$1" session="$2" script
   script="$PLUGIN/skills/$gate/scripts/teardown-head.sh"
-  if [ "$takes_pr" = yes ]; then
-    CLAUDE_CODE_SESSION_ID="$session" bash "$script" "$PR" >/dev/null 2>&1
-  else
-    CLAUDE_CODE_SESSION_ID="$session" bash "$script" >/dev/null 2>&1
-  fi
+  CLAUDE_CODE_SESSION_ID="$session" bash "$script" "$PR" >/dev/null 2>&1
   echo $?
 }
 
-while read -r GATE SLUG LEAF TAKES_PR; do
+while read -r GATE SLUG LEAF; do
   [ -n "$GATE" ] || continue
   TD="$PLUGIN/skills/$GATE/scripts/teardown-head.sh"
 
   # A — a namespace this session never opened is the genuine no-op the header promises.
-  RC="$(run_teardown "$GATE" "$TAKES_PR" "proof-a-$GATE-$$")"
+  RC="$(run_teardown "$GATE" "proof-a-$GATE-$$")"
   expect "$RC" zero "$GATE A never-opened namespace -> exit 0"
 
   # B — namespace open but no handle file: still nothing was materialized.
   SESSION="proof-b-$GATE-$$"
   CLAUDE_CODE_SESSION_ID="$SESSION" "$PCLI" scratchpad open --slug "$SLUG" >/dev/null 2>&1
-  RC="$(run_teardown "$GATE" "$TAKES_PR" "$SESSION")"
+  RC="$(run_teardown "$GATE" "$SESSION")"
   expect "$RC" zero "$GATE B open-but-no-handle -> exit 0"
 
   # C — the resolver could not look. No session id is the cheapest real instance of that class
   # (scratchpad exits 2, MissingSessionId); pre-fix EVERY such code reported as a clean no-op.
-  if [ "$TAKES_PR" = yes ]; then
-    (unset CLAUDE_CODE_SESSION_ID; bash "$TD" "$PR" >/dev/null 2>&1)
-  else
-    (unset CLAUDE_CODE_SESSION_ID; bash "$TD" >/dev/null 2>&1)
-  fi
+  (unset CLAUDE_CODE_SESSION_ID; bash "$TD" "$PR" >/dev/null 2>&1)
   RC=$?
   expect "$RC" nonzero "$GATE C unreadable handle -> non-zero"
 
@@ -86,8 +81,27 @@ while read -r GATE SLUG LEAF TAKES_PR; do
   SESSION="proof-d-$GATE-$$"
   DIR="$(CLAUDE_CODE_SESSION_ID="$SESSION" "$PCLI" scratchpad open --slug "$SLUG" 2>/dev/null)"
   printf '# malformed on purpose: no REVIEW_WT, no PR_REF\n' >"$DIR/$LEAF"
-  RC="$(run_teardown "$GATE" "$TAKES_PR" "$SESSION")"
+  RC="$(run_teardown "$GATE" "$SESSION")"
   expect "$RC" nonzero "$GATE D malformed handle -> non-zero"
+
+  # G — a well-formed handle describing a DIFFERENT PR. This is #5416's teardown half: the tree it
+  # names is real and live, and the pre-fix code `rm -rf`'d it. Nothing may be removed, and the run
+  # must not call that a no-op. Scoped to `review-code` — it is the gate that carries the guard, and
+  # letting the other two reach their `rm -rf`/`update-ref -d` here would mutate the primary's refs.
+  if [ "$GATE" = review-code ]; then
+    SESSION="proof-g-$GATE-$$"
+    DIR="$(CLAUDE_CODE_SESSION_ID="$SESSION" "$PCLI" scratchpad open --slug "$SLUG" 2>/dev/null)"
+    SIBLING_PR=$((PR + 1))
+    OTHER="$(mktemp -d "${TMPDIR:-/tmp}/review-head-$SIBLING_PR-XXXXXX")"
+    printf 'REVIEW_WT=%s\nPR_REF=refs/pr/%s-sibling\nHANDLE_PR=%s\n' "$OTHER" "$SIBLING_PR" "$SIBLING_PR" >"$DIR/$LEAF"
+    RC="$(run_teardown "$GATE" "$SESSION")"
+    if [ "$RC" -ne 0 ] && [ -d "$OTHER" ]; then
+      ok "$GATE G sibling-PR handle -> refused, sibling tree intact (rc=$RC)"
+    else
+      bad "$GATE G expected a refusal with the sibling tree kept (rc=$RC, tree-present=$([ -d "$OTHER" ] && echo yes || echo no))"
+    fi
+    rm -rf "$OTHER"
+  fi
 
   # E — the happy path, inside a throwaway repo so the primary's worktrees and refs are untouched.
   SESSION="proof-e-$GATE-$$"
@@ -95,16 +109,15 @@ while read -r GATE SLUG LEAF TAKES_PR; do
   SANDBOX="$(mktemp -d "${TMPDIR:-/tmp}/teardown-proof.XXXXXX")"
   git -C "$SANDBOX" init -q
   git -C "$SANDBOX" -c user.email=proof@invalid -c user.name=proof commit -q --allow-empty -m proof
-  REF="refs/pr/proof-$GATE-$$"
+  # The fixture is PR-shaped — `refs/pr/<pr>-<nonce>`, `review-head-<pr>-<id>`, `HANDLE_PR` — because
+  # that is what a real materialization writes, and what `review-code`'s guard requires before it
+  # will remove anything (#5416).
+  REF="refs/pr/$PR-proof$$"
   git -C "$SANDBOX" update-ref "$REF" HEAD
-  TREE="$SANDBOX/throwaway-head"
+  TREE="$SANDBOX/review-head-$PR-proof"
   mkdir -p "$TREE"
-  printf 'REVIEW_WT=%s\nPR_REF=%s\n' "$TREE" "$REF" >"$DIR/$LEAF"
-  if [ "$TAKES_PR" = yes ]; then
-    (cd "$SANDBOX" && CLAUDE_CODE_SESSION_ID="$SESSION" bash "$TD" "$PR" >/dev/null 2>&1)
-  else
-    (cd "$SANDBOX" && CLAUDE_CODE_SESSION_ID="$SESSION" bash "$TD" >/dev/null 2>&1)
-  fi
+  printf 'REVIEW_WT=%s\nPR_REF=%s\nHANDLE_PR=%s\n' "$TREE" "$REF" "$PR" >"$DIR/$LEAF"
+  (cd "$SANDBOX" && CLAUDE_CODE_SESSION_ID="$SESSION" bash "$TD" "$PR" >/dev/null 2>&1)
   RC=$?
   if [ "$RC" -eq 0 ] && [ ! -d "$TREE" ] && ! git -C "$SANDBOX" show-ref --quiet --verify "$REF"; then
     ok "$GATE E well-formed handle -> tree + ref removed, exit 0"


### PR DESCRIPTION
When two `review-code` gates run in the same session — the normal fanned drain — they used to share one file that says "here is the worktree I checked out for this PR". The last one to start won, and every earlier reviewer silently switched to the winner's tree. So a reviewer could typecheck a different PR's code, pass, and post that PASS against its own PR's correct head SHA. Nothing catches that, because the SHA is right; only the evidence behind it is wrong. The same shared file also let a reviewer finishing one PR delete another reviewer's live worktree.

This keys that file by PR, makes every reader ask for the PR it was invoked for, and makes every reader refuse — loudly — a file that describes someone else's PR.

Fixes #5416

## What changed

- **The handle is PR-keyed.** `materialize-head.sh` writes to `review-code-head-<pr>` and `head-env.sh` reads from it, matching `review-skill` and `review-doc`. `head-env.sh` now requires the PR number.
- **The handle records its own PR.** `materialize-head.sh` stamps `HANDLE_PR=<pr>` into `head.env`. That is the fact a reader checks against, so the check has real operands instead of re-deriving the argument it is testing.
- **One shared correspondence guard.** `kp_head_handle_names_pr` (in `claude-plugins/kampus-pipeline/lib/common.sh`, beside `KP_HEAD_HANDLE_ABSENT` for the same single-source reason) verifies the stamp, the `review-head-<pr>-*` worktree name and the `refs/pr/<pr>-*` ref all name the caller's PR. Any mismatch — and an unstamped handle — is a non-zero refusal, never a skip.
- **Every consumer passes its PR and fails closed.** `worktree-typecheck.sh`, `worktree-checks.sh`, `full-unit-project.sh`, `glossary-freshness.sh` and `teardown-head.sh` all take `<pr>` and refuse before they run anything. `glossary-freshness.sh` folds a mismatch as `CANNOT-EVALUATE`, its existing blocking soft-fail.
- **`teardown-head.sh` can only delete its own.** The guard runs immediately before the `rm -rf` / `update-ref -d`, and a mismatch removes nothing.
- **The false comment is gone.** `head-env.sh`'s header no longer claims session keying keeps a sibling reviewer's tree out of reach — it says why the PR key is the load-bearing part.

## Verification

Three reviewer-runnable proofs, all green locally:

- `bash claude-plugins/kampus-pipeline/skills/review-code/scripts/verify-head-handle-pr-keyed.sh` — new. Nine cases under **one** session id, because same-session collision is the whole failure: two PRs get two namespaces; a matching handle is handed over; a handle describing another PR is refused with empty stdout; an unstamped handle is refused; a right-stamp/wrong-worktree handle is refused; a missing `<pr>` exits 2; all five consumers refuse and leave the sibling's tree standing; and a mutant that restores the constant slug and drops the guard collides the two PRs again.
- `bash claude-plugins/kampus-pipeline/skills/shared/scripts/teardown-head-fail-closed-proof.sh` — extended with case G: a handle describing another PR must be refused with the sibling's tree intact. All three gates still pass A–F.
- `bash claude-plugins/kampus-pipeline/skills/review-code/scripts/verify-glossary-detector-fires.sh` — unchanged behaviour, fixture updated to a PR-shaped handle. 18/18.

Also green: `pnpm typecheck`, `pnpm lint:worktree`, `shellcheck -x` on every changed script, `pipeline-cli trap-status-guard check`, `pipeline-cli gh-phoenix lint-skills`, `validate-skills.sh`, `validate-gate-path-drift.sh`.

## Control plane

`pipeline-cli cp-classify classify` returns **`control-plane [path-match]`** — `claude-plugins/kampus-pipeline/lib/common.sh` matches the live `CONTROL_PLANE_RE`, and so does every other changed path. This is a human merge (ADR 0053). Stopped at PR-open; no self-review, no verdict, no merge.

## Deviations

**1. Shape of the belt-and-braces check (narrowed a suggested fix-shape).**
Said: the issue suggested consumers assert the resolved `REVIEW_WT` basename carries their PR.
Did: put the check in one shared function, `kp_head_handle_names_pr`, called by `head-env.sh` and again by each consumer — and widened it from the basename alone to three independent operands (the `HANDLE_PR` stamp, the worktree name, the ref).
Why: five copies of the same test would be the duplicated-rationale wall CLAUDE.md's comment convention rejects, and the basename alone is weaker evidence than the stamp. The consumer-side call is kept, not folded away, because it re-reads the handle in the consumer's own process — different operands from `head-env.sh`'s subshell check, so it can actually fail.
Disposition: no action needed; the behaviour the AC names is proven per consumer in `verify-head-handle-pr-keyed.sh` case 7.

**2. Added a `HANDLE_PR` stamp the issue did not name.**
Said: key the slug by PR.
Did: also record the PR inside `head.env`.
Why: the slug stops the collision, but a check that only re-derives the slug from the argument is true by construction. The stamp is what lets a reader detect a handle that reached it by any route the slug does not cover — including a stale handle from before this change.
Disposition: no action needed.

**3. Switched the consumers to `bash "$HERE/head-env.sh"` instead of executing it directly.**
Said: nothing about this.
Did: adopted the `#5193` invocation shape the teardown scripts already use.
Why: a direct exec of a sibling committed non-executable dies 126, which #5193 recorded as a failure that reported clean. The consumers had to be touched anyway to pass `<pr>`.
Disposition: for the reviewer to judge — it is a robustness change adjacent to, not required by, the ACs.

**4. Changed two existing proof harnesses' fixtures.**
Said: nothing about the proofs.
Did: `teardown-head-fail-closed-proof.sh` now drives all three gates with a PR argument and a PR-shaped case-E fixture, and `verify-glossary-detector-fires.sh`'s stub handle gained the stamp and PR-shaped names.
Why: both fixtures encoded the old contract, so they would fail against the new guard. Neither assertion was weakened — case E still requires a real teardown, and the glossary harness still runs all 9 shapes and all 8 mutants.
Disposition: no action needed; both re-run green above.

**5. Left the leaked `review-head-*` worktrees alone.**
Said: the incident report notes 63+ stale trees.
Did: fixed only the code that *creates* new leaks.
Why: reclaiming the existing pile was declined by a separate ruling and has no ticket.
Disposition: out of scope by ruling; `pipeline-cli worktree-sweep --execute` remains the standing reclaimer.

**6. No ADR filed.**
Said: nothing.
Did: recorded the *why* in the code and in `review-code/SKILL.md` rather than a new ADR.
Why: this is a keying bug in an existing mechanism, not a new decision; #5417 is the open unit for writing the resource-keyed-handle invariant into the fabrika review contract as a durable class-level rule.
Disposition: for the reviewer to judge.
