### PR TITLE
fix(review-code): attest that the in-worktree typecheck really ran (#4887)

### DIFF
--- a/claude-plugins/kampus-pipeline/skills/review-code/SKILL.md
+++ b/claude-plugins/kampus-pipeline/skills/review-code/SKILL.md
@@ -429,8 +429,43 @@ the full build inputs, so the typecheck bootstrap is whole — run it and treat 
 the typecheck signal:
 
 ```bash
+# stdout IS the attestation — one `TURBO-ATTESTATION: … verdict=RAN …` line. Nothing on stdout means
+# the typecheck did NOT attest, which is UNKNOWN and never a pass.
 bash ./.claude/.pipeline/skills/review-code/scripts/worktree-typecheck.sh "$PR"
 ```
+
+**Its exit status is not the signal — the attestation line is (#4887).** turbo's cache key is
+repo-relative content only (no path, no checkout identity) and a linked worktree shares the primary
+checkout's cache directory, so a bare `pnpm typecheck` here can exit 0 in milliseconds having
+**replayed** an entry a *sibling* tree produced at a *different* commit. Measured on this repo: two
+forced runs attest `executed=31 replayed=0`, and the same command without the force flag immediately
+after reports `replayed=31` — a green that says nothing about the head under review. #5416's per-PR
+head handle fixed the neighbouring defect (the gate resolving a sibling's *tree*) and does not reach
+this one; a correctly-pinned tree still reads the shared cache. So the script forces a real run
+**and** re-reads turbo's own per-task `cache.status` to prove it, refusing a replay instead of
+passing on it. That is worth doing whatever
+[#4106](https://github.com/kamp-us/phoenix/issues/4106) concludes about whether a hit can also be
+*wrong*: it makes the gate say **which** signal it consumed.
+
+**Paste the attestation line into the verdict** as the typecheck evidence — `TURBO-ATTESTATION:
+task=typecheck verdict=RAN turbo=2.10.3 tasks=31 executed=31 replayed=0`. It names repo-relative
+turbo task ids only, so it carries no machine-local path into a public artifact (§SP).
+
+**Any *other* turbo-cached task you consume as evidence goes through the same script.** `test` and
+`lint` are `"cache": true` in `turbo.json` too, so a reviewer who runs `pnpm -C "$REVIEW_WT" test` to
+verify a criterion inherits the identical hole. Run it attested instead, and cite its line the same
+way:
+
+```bash
+bash ./.claude/.pipeline/skills/review-code/scripts/attested-turbo-run.sh "$PR" test
+```
+
+Two checks are *not* turbo-driven and need no attestation: `pnpm lint:worktree` (a direct
+`node scripts/biome-worktree.mjs` run) and `full-unit-project.sh`'s `pnpm -C … test:unit` (vitest in
+`apps/web`, not a root turbo task). The claim itself is re-derived, not asserted, by
+`bash ./.claude/.pipeline/skills/review-code/scripts/verify-turbo-attestation.sh "$PR"` — its
+fixture leg pins the RAN / REPLAYED / zero-scope judgements, and its live leg runs this typecheck
+path **twice against the same tree** and requires both runs to attest `RAN`.
 
 CI and the SHA-bound run-evidence bundle (below) are now **corroboration**, not the sole
 signal. Only when the in-worktree typecheck genuinely cannot run (e.g. an environment fault
@@ -1279,6 +1314,9 @@ Verified PR #<PR> against the acceptance criteria of #<ISSUE>, one at a time:
 <$BUNDLE_LINE — the `Run-evidence bundle:` line from `run-evidence read`, pasted verbatim; on a
 non-`present` state append "— verified from diff + worktree run">
 
+<the `TURBO-ATTESTATION:` line from each attested turbo run, pasted verbatim (Step 2); if the
+in-worktree typecheck could not run at all, say that instead — never omit both>
+
 Read the PR head (§HEAD): all files under review sourced from `<HEAD_SHA>` via `$REVIEW_WT` /
 `git show "$PR_REF:<path>"`, never the launched checkout's working copy.
 
@@ -1384,6 +1422,8 @@ Verified PR #<PR> against the acceptance criteria of #<ISSUE>, one at a time —
 - [PASS] <criterion 2> — <evidence>
 
 <$BUNDLE_LINE, pasted verbatim; on a non-`present` state append "— verified from diff + worktree run">
+
+<the `TURBO-ATTESTATION:` line from each attested turbo run, pasted verbatim (Step 2)>
 ```
 
 ---
@@ -1445,6 +1485,8 @@ Verified PR #<PR> against the acceptance criteria of #<ISSUE>, one at a time:
 
 <$BUNDLE_LINE, pasted verbatim — it already names the failing suites on a `present` state; on a
 non-`present` state append "— verified from diff + worktree run">
+
+<the `TURBO-ATTESTATION:` line from each attested turbo run, pasted verbatim (Step 2)>
 
 
 Failing criteria above must be addressed before this PR can merge. The PR stays open

--- a/claude-plugins/kampus-pipeline/skills/review-code/scripts/attest-turbo-summary.mjs
+++ b/claude-plugins/kampus-pipeline/skills/review-code/scripts/attest-turbo-summary.mjs
@@ -1,0 +1,44 @@
+// Read a turbo `--summarize` run summary and say, in one citable line, whether its tasks EXECUTED
+// in this invocation or were REPLAYED from cache (#4887). Called by `attested-turbo-run.sh`; kept in
+// its own file so `verify-turbo-attestation.sh` can exercise the judgement against fixtures without
+// a materialized review worktree.
+//
+// usage: node attest-turbo-summary.mjs <run-summary.json> <task>
+// exits: 0 attested RAN (line on stdout) · 3 zero scope · 4 REPLAYED (line on stdout) · 2 usage
+//
+// `cache.status` is turbo's own field — MISS means the task executed, HIT means it was restored.
+// Anything else counts as not-executed, because an unrecognized status is UNKNOWN and UNKNOWN is
+// never the permissive answer (ADR 0092).
+import {readFileSync} from "node:fs";
+
+const [summaryPath, task] = process.argv.slice(2);
+if (!summaryPath || !task) {
+	process.stderr.write("usage: node attest-turbo-summary.mjs <run-summary.json> <task>\n");
+	process.exit(2);
+}
+
+const summary = JSON.parse(readFileSync(summaryPath, "utf8"));
+const tasks = Array.isArray(summary.tasks) ? summary.tasks : [];
+if (tasks.length === 0) {
+	process.stderr.write(
+		"attest-turbo-summary: the run summary lists 0 tasks — nothing was checked, which is UNKNOWN, not clean (ADR 0092 zero scope).\n",
+	);
+	process.exit(3);
+}
+
+const replayed = tasks.filter((t) => !t.cache || t.cache.status !== "MISS");
+const verdict = replayed.length === 0 ? "RAN" : "REPLAYED";
+const parts = [
+	`TURBO-ATTESTATION: task=${task}`,
+	`verdict=${verdict}`,
+	`turbo=${summary.turboVersion}`,
+	`tasks=${tasks.length}`,
+	`executed=${tasks.length - replayed.length}`,
+	`replayed=${replayed.length}`,
+];
+if (replayed.length > 0) {
+	const named = replayed.map((t) => `${t.taskId}:${t.cache ? t.cache.status : "unknown"}`);
+	parts.push(`replayed-tasks=${named.join(",")}`);
+}
+process.stdout.write(`${parts.join(" ")}\n`);
+process.exit(verdict === "RAN" ? 0 : 4);

--- a/claude-plugins/kampus-pipeline/skills/review-code/scripts/attested-turbo-run.sh
+++ b/claude-plugins/kampus-pipeline/skills/review-code/scripts/attested-turbo-run.sh
@@ -1,0 +1,93 @@
+#!/usr/bin/env bash
+# Step 2 — run a turbo-cached task inside the review worktree and ATTEST that it really executed
+# there, instead of consuming its exit status alone (#4887).
+#
+# turbo's cache key is repo-relative path -> git blob SHA plus a dependency hash; no absolute path
+# and no checkout identity participate in it, and a linked worktree shares the primary checkout's
+# cache directory ("using shared worktree cache" is turbo's own line for it). So an entry produced
+# by a SIBLING tree at a DIFFERENT commit replays here in milliseconds and exits 0, and a gate that
+# reads nothing but that exit status reports a check it never ran against a tree it never read.
+#
+# Two legs, both load-bearing:
+#   --force      turbo ignores the cache for READS (2.10.3: equivalent to --cache=local:w,remote:w),
+#                so every task in the run executes here. This PREVENTS the replay.
+#   --summarize  turbo writes a machine-readable run summary whose per-task `cache.status` is MISS
+#                (executed) or HIT (replayed). Re-reading it PROVES the prevention held, so the
+#                signal stops being "exit 0" and becomes "turbo says these N tasks executed here".
+# Forcing alone would put the gate back on exit-status-only consumption the day a flag is dropped;
+# reading alone would only catch a replay after paying for it.
+#
+# Correct whatever #4106 concludes: this attests WHICH signal the gate consumed — a run of this head
+# or a replay of another tree's — which is worth stating if every hit is sound and worth more if
+# some hit is not.
+#
+# usage: bash ./claude-plugins/kampus-pipeline/skills/review-code/scripts/attested-turbo-run.sh <pr> <turbo-task> [extra turbo args…]
+#
+# stdout is the attestation line, and ONLY on the path where the task both ran and passed; every
+# other outcome exits non-zero with empty stdout and the line on stderr (§ZS, ADR 0092;
+# .patterns/skill-script-io-contract.md). The line names repo-relative turbo task ids only — never a
+# machine-local path — so a reviewer pastes it verbatim into a public verdict.
+set -uo pipefail
+# shellcheck source=../../../lib/common.sh disable=SC1007,SC1091
+. "$(CDPATH= cd -- "$(dirname -- "${BASH_SOURCE[0]}")/../../../lib" && pwd)/common.sh"
+
+[ "$#" -ge 2 ] || { echo "usage: attested-turbo-run.sh <pr> <turbo-task> [extra turbo args…]" >&2; exit 2; }
+PR="$1"
+TASK="$2"
+shift 2
+# shellcheck disable=SC1007
+HERE="$(CDPATH= cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)"
+HANDLE="$(bash "$HERE/head-env.sh" "$PR")" || exit 1
+# shellcheck disable=SC1090
+. "$HANDLE" || exit 1
+: "${REVIEW_WT:?attested-turbo-run.sh: REVIEW_WT unset — the head was never materialized; refusing to run against the base tree (§HEAD)}"
+kp_head_handle_names_pr "$PR" "$HANDLE" || exit 1   # never attest a SIBLING reviewer's tree (#5416)
+
+RUNS_DIR="$REVIEW_WT/.turbo/runs"
+# Which summaries existed BEFORE this invocation, so the one it writes is identified by set
+# difference rather than by mtime. The sentinel keeps `grep -vxF` from matching every line when the
+# directory is empty or absent.
+BEFORE="$(ls -1 "$RUNS_DIR" 2>/dev/null)"
+[ -n "$BEFORE" ] || BEFORE='attested-turbo-run.sh: no pre-existing summary'
+
+if [ "$#" -gt 0 ]; then
+	pnpm -C "$REVIEW_WT" "$TASK" --force --summarize "$@" >&2
+else
+	pnpm -C "$REVIEW_WT" "$TASK" --force --summarize >&2
+fi
+RUN_RC=$?
+
+# shellcheck disable=SC2010  # this is a set difference over two `ls` listings, not name filtering; turbo names its summaries with its own alphanumeric run ids
+NEW="$(ls -1 "$RUNS_DIR" 2>/dev/null | grep -vxF "$BEFORE")"
+COUNT=0
+[ -n "$NEW" ] && COUNT="$(printf '%s\n' "$NEW" | wc -l | tr -d ' ')"
+[ "$COUNT" -eq 1 ] || {
+	printf 'attested-turbo-run.sh: expected exactly 1 new turbo run summary under the review worktree, found %s — the run is UNATTESTABLE, which is UNKNOWN and never a pass (§ZS). The task itself exited %s.\n' "$COUNT" "$RUN_RC" >&2
+	exit 1
+}
+
+# The judgement reads the summary's own `cache.status` field, never turbo's counts line ("Cached: 1
+# cached, 31 total") — that line is display text.
+ATTESTATION="$(node "$HERE/attest-turbo-summary.mjs" "$RUNS_DIR/$NEW" "$TASK")"
+ATT_RC=$?
+
+case "$ATT_RC" in
+	0) ;;
+	4)
+		printf '%s\n' "$ATTESTATION" >&2
+		printf 'attested-turbo-run.sh: BLOCKING — turbo REPLAYED cached results for the tasks listed above instead of executing them, so this run attests nothing about the head under review (#4887). Never read it as a pass.\n' >&2
+		exit 1
+		;;
+	*)
+		printf 'attested-turbo-run.sh: could not derive an attestation from the run summary (node exited %s) — UNKNOWN, never a pass (§ZS). The task itself exited %s.\n' "$ATT_RC" "$RUN_RC" >&2
+		exit 1
+		;;
+esac
+
+[ "$RUN_RC" -eq 0 ] || {
+	printf '%s\n' "$ATTESTATION" >&2
+	printf 'attested-turbo-run.sh: the task genuinely ran here and FAILED (exit %s) — a real red, not a cache artifact.\n' "$RUN_RC" >&2
+	exit "$RUN_RC"
+}
+
+printf '%s\n' "$ATTESTATION"

--- a/claude-plugins/kampus-pipeline/skills/review-code/scripts/verify-head-handle-pr-keyed.sh
+++ b/claude-plugins/kampus-pipeline/skills/review-code/scripts/verify-head-handle-pr-keyed.sh
@@ -107,9 +107,11 @@ fi
 
 # 7 — every consumer refuses the same mismatch, and none of them touches the tree it names. Run
 # while $DIR_SIBLING still holds case 3's mismatched handle.
-for consumer in worktree-typecheck worktree-checks full-unit-project teardown-head glossary-freshness; do
+# The trailing `typecheck` is `attested-turbo-run.sh`'s required task argument; every other consumer
+# reads only `$1` and ignores it.
+for consumer in worktree-typecheck worktree-checks full-unit-project teardown-head glossary-freshness attested-turbo-run; do
 	CLAUDE_CODE_SESSION_ID="$SESSION" CLAUDE_PIPELINE_REPO=owner/repo \
-		bash "$HERE/$consumer.sh" "$SIBLING" >/dev/null 2>&1
+		bash "$HERE/$consumer.sh" "$SIBLING" typecheck >/dev/null 2>&1
 	RC=$?
 	if [ "$RC" -ne 0 ] && [ -d "$MINE_WT" ]; then
 		ok "7 $consumer refuses a sibling's handle (rc=$RC), sibling tree intact"

--- a/claude-plugins/kampus-pipeline/skills/review-code/scripts/verify-turbo-attestation.sh
+++ b/claude-plugins/kampus-pipeline/skills/review-code/scripts/verify-turbo-attestation.sh
@@ -1,0 +1,114 @@
+#!/usr/bin/env bash
+# Re-derive #4887's claim instead of asserting it: the gate's turbo-driven checks are attested as
+# really having executed, and a replay is refused rather than read as a pass.
+#
+# usage: bash ./claude-plugins/kampus-pipeline/skills/review-code/scripts/verify-turbo-attestation.sh [<pr>]
+#
+# Leg 1 (always, no review worktree needed) exercises the judgement against three fixture summaries:
+# all-executed, one-replayed, and zero-task. Leg 2 (only when a PR is given, i.e. when a reviewer has
+# already materialized that PR's head) runs the gate's own typecheck path TWICE against the same
+# tree and requires BOTH runs to attest `verdict=RAN` — the second run is where an unforced
+# invocation would have gone FULL TURBO.
+#
+# stdout is prose: every check names itself and its outcome, so "it ran and found nothing" is never
+# an empty stdout. Any failure exits non-zero.
+set -uo pipefail
+# shellcheck source=../../../lib/common.sh disable=SC1007,SC1091
+. "$(CDPATH= cd -- "$(dirname -- "${BASH_SOURCE[0]}")/../../../lib" && pwd)/common.sh"
+
+# shellcheck disable=SC1007
+HERE="$(CDPATH= cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)"
+FAILED=0
+
+fixtures="$(mktemp -d)" || {
+	echo "verify-turbo-attestation: could not create a fixture directory — cannot verify." >&2
+	exit 1
+}
+
+cat >"$fixtures/all-executed.json" <<'EOF'
+{
+  "turboVersion": "2.10.3",
+  "tasks": [
+    {"taskId": "@kampus/a#typecheck", "cache": {"status": "MISS"}},
+    {"taskId": "@kampus/b#typecheck", "cache": {"status": "MISS"}}
+  ]
+}
+EOF
+cat >"$fixtures/one-replayed.json" <<'EOF'
+{
+  "turboVersion": "2.10.3",
+  "tasks": [
+    {"taskId": "@kampus/a#typecheck", "cache": {"status": "MISS"}},
+    {"taskId": "@kampus/b#typecheck", "cache": {"status": "HIT"}}
+  ]
+}
+EOF
+cat >"$fixtures/zero-tasks.json" <<'EOF'
+{"turboVersion": "2.10.3", "tasks": []}
+EOF
+
+check() { # <label> <expected-exit> <expected-substring-or-empty> <fixture>
+	local label="$1" want_rc="$2" want_text="$3" fixture="$4" out rc
+	out="$(node "$HERE/attest-turbo-summary.mjs" "$fixtures/$fixture" typecheck 2>/dev/null)"
+	rc=$?
+	if [ "$rc" -ne "$want_rc" ]; then
+		printf 'FAIL %s — exit %s, expected %s\n' "$label" "$rc" "$want_rc"
+		FAILED=1
+		return
+	fi
+	case "$want_text" in
+		'')
+			if [ -n "$out" ]; then
+				printf 'FAIL %s — expected empty stdout, got: %s\n' "$label" "$out"
+				FAILED=1
+				return
+			fi
+			;;
+		*)
+			case "$out" in
+				*"$want_text"*) ;;
+				*)
+					printf 'FAIL %s — stdout lacks %s: %s\n' "$label" "$want_text" "$out"
+					FAILED=1
+					return
+					;;
+			esac
+			;;
+	esac
+	printf 'PASS %s\n' "$label"
+}
+
+check "all tasks executed -> attested RAN" 0 "verdict=RAN" all-executed.json
+check "all tasks executed -> counts every task as executed" 0 "executed=2 replayed=0" all-executed.json
+check "one task replayed -> refused as REPLAYED" 4 "verdict=REPLAYED" one-replayed.json
+check "one task replayed -> names the replayed task" 4 "replayed-tasks=@kampus/b#typecheck:HIT" one-replayed.json
+check "zero tasks -> zero scope, no attestation on stdout" 3 "" zero-tasks.json
+
+rm -rf "$fixtures"
+
+if [ "$#" -lt 1 ]; then
+	printf 'SKIP live leg — no PR given, so no materialized head to run the gate path against. Pass a PR whose head this session materialized to run it.\n'
+else
+	PR="$1"
+	for attempt in 1 2; do
+		out="$(bash "$HERE/worktree-typecheck.sh" "$PR" 2>/dev/null)"
+		rc=$?
+		case "$out" in
+			*"verdict=RAN"*)
+				if [ "$rc" -eq 0 ]; then
+					printf 'PASS live run %s of 2 against the same tree — %s\n' "$attempt" "$out"
+				else
+					printf 'FAIL live run %s of 2 — attested RAN but exited %s\n' "$attempt" "$rc"
+					FAILED=1
+				fi
+				;;
+			*)
+				printf 'FAIL live run %s of 2 — no RAN attestation on stdout (exit %s): %s\n' "$attempt" "$rc" "$out"
+				FAILED=1
+				;;
+		esac
+	done
+fi
+
+[ "$FAILED" -eq 0 ] || { printf 'verify-turbo-attestation: FAILED\n'; exit 1; }
+printf 'verify-turbo-attestation: all checks passed\n'

--- a/claude-plugins/kampus-pipeline/skills/review-code/scripts/worktree-typecheck.sh
+++ b/claude-plugins/kampus-pipeline/skills/review-code/scripts/worktree-typecheck.sh
@@ -3,22 +3,16 @@
 # workaround). Extracted from review-code/SKILL.md (#4451, epic #4435 phase 1). Extraction contract:
 # ../SKILL.md § The extracted scripts.
 #
+# It delegates to `attested-turbo-run.sh` rather than calling `pnpm typecheck` itself, because a bare
+# invocation can exit 0 off another worktree's cached result — that script's header has the why
+# (#4887). stdout is its one-line attestation; cite it as the typecheck evidence.
+#
 # usage: bash ./claude-plugins/kampus-pipeline/skills/review-code/scripts/worktree-typecheck.sh <pr>
 set -uo pipefail
 # shellcheck source=../../../lib/common.sh disable=SC1007,SC1091
 . "$(CDPATH= cd -- "$(dirname -- "${BASH_SOURCE[0]}")/../../../lib" && pwd)/common.sh"
 
 [ "$#" -ge 1 ] || { echo "usage: worktree-typecheck.sh <pr>" >&2; exit 2; }
-PR="$1"
 # shellcheck disable=SC1007
 HERE="$(CDPATH= cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)"
-HANDLE="$(bash "$HERE/head-env.sh" "$PR")" || exit 1
-# shellcheck disable=SC1090
-. "$HANDLE" || exit 1
-: "${REVIEW_WT:?worktree-typecheck.sh: REVIEW_WT unset — the head was never materialized; refusing to typecheck the base tree (§HEAD)}"
-# The handle is only mine if it describes MY PR: a typecheck of a sibling's tree passes, and the
-# verdict it feeds is bound to this PR's own live head SHA, so the green is wrong and unfalsifiable
-# from the outside (#5416).
-kp_head_handle_names_pr "$PR" "$HANDLE" || exit 1
-
-pnpm -C "$REVIEW_WT" typecheck   # `pnpm install` above made patches/ hashable + `fate generate` resolvable
+exec bash "$HERE/attested-turbo-run.sh" "$1" typecheck


### PR DESCRIPTION
The review gate's typecheck ran `pnpm typecheck` in the review worktree and read nothing but its exit code. turbo's cache is shared across every worktree of a clone and keyed on repo-relative file content alone, so that command can exit 0 in milliseconds having replayed a result a *different* worktree produced at a *different* commit — and the gate had no way to tell that from a real check.

It now forces a real run and then re-reads turbo's own per-task cache status to prove the run happened, refusing a replay instead of passing on it. Every attested run prints one line the reviewer pastes into the verdict, so a reader can see whether the typecheck executed or was replayed.

Measured first-hand on this repo: two forced runs report `executed=31 replayed=0`, and the same command without the force flag immediately after reports `replayed=31` — the exact green the gate used to accept.

## What changed

- **`scripts/attested-turbo-run.sh`** (new) — runs any turbo task in the review worktree with `--force --summarize`, then reads the run summary's per-task `cache.status`. stdout is a single `TURBO-ATTESTATION: task=… verdict=RAN …` line, and *only* when the task both executed and passed; a replay, a missing summary, or a zero-task summary exits non-zero with empty stdout (§ZS, ADR 0092). The line carries repo-relative turbo task ids only — no machine-local path.
- **`scripts/attest-turbo-summary.mjs`** (new) — the RAN / REPLAYED / zero-scope judgement, in its own file so it can be exercised against fixtures.
- **`scripts/worktree-typecheck.sh`** — delegates to the attested runner; exit-status-only consumption is gone.
- **`scripts/verify-turbo-attestation.sh`** (new) — re-derives the claim rather than asserting it. Fixture leg (runs anywhere) pins the three judgements; live leg runs the gate's typecheck path **twice against the same tree** and requires both runs to attest `RAN`.
- **`SKILL.md`** — Step 2 states why the exit status is not the signal, mandates the same script for any *other* turbo-cached task consumed as evidence (`test` is `"cache": true` too), names the two checks that are not turbo-driven and need no attestation (`lint:worktree`, `full-unit-project.sh`), and the three verdict templates now carry the attestation line.
- **`scripts/verify-head-handle-pr-keyed.sh`** — the new script joins the consumer list that must refuse a sibling PR's head handle.

Why this is right whatever #4106 concludes: it makes the gate say **which** signal it consumed — a run of this head, or a replay of another tree's. That is worth stating if every cache hit is sound, and worth more if some hit is not.

This is the other half of #5470 (relates to #5416): that fixed the gate resolving a *sibling's tree*; a correctly-pinned tree still read the shared cache.

Fixes #4887

## Deviations

- **Narrowed the suggested fix-shape (class: narrowed a suggested remedy).** Said: the issue offered `--force` *or* reading turbo's cache status as alternatives. Did: both. Why: forcing alone puts the gate back on exit-status-only consumption the day a flag is dropped, and reading alone catches a replay only after paying for it. Disposition: no action needed — the acceptance criteria are satisfied by either, and both is strictly stronger.
- **No new `.patterns/` doc (class: declined an adjacent change).** Said: CLAUDE.md asks that a load-bearing pattern be documented in `.patterns/`. Did: kept the rule at its single load-bearing site — `review-code`'s Step 2 prose plus the script header. Why: this is how *this gate* consumes evidence, not a shape phoenix application code is written in. Disposition: for the reviewer to judge; a pattern doc is cheap to add if they disagree.
- **The live leg of the proof is conditional (class: partial verification surface).** Said: AC5 asks that the gate's typecheck path be run twice against the same tree. Did: `verify-turbo-attestation.sh` runs it twice, but only when handed a PR whose head this session materialized; with no argument it prints `SKIP` and runs the fixture leg only. Why: the path needs a `$REVIEW_WT`, which only a live review has. Disposition: no action needed — a reviewer of this PR has one, so `verify-turbo-attestation.sh <this PR>` exercises it; the equivalent measurement is quoted in the summary above.