### PR TITLE
fix(fabrika): declare review-ui's eval fixtures and name the path staging puts them at (#5466)

### DIFF
--- a/claude-plugins/fabrika/skills/review-ui/evals/evals.json
+++ b/claude-plugins/fabrika/skills/review-ui/evals/evals.json
@@ -1,12 +1,13 @@
 {
 	"skill_name": "review-ui",
-	"note": "Fixtures live in fixtures/eval-N/FIXTURE.md — self-contained fictional repo (acme/storefront); no phoenix repo-state claims. This file is the answer key and is never placed in a run's reach.",
+	"note": "Fixtures live in fixtures/eval-N.md, one per case — self-contained fictional repo (acme/storefront); no phoenix repo-state claims. Each case declares its own fixture in `files`, and its prompt names that same relative path, which is where staging puts it (#5466). This file is the answer key and is never placed in a run's reach.",
 	"evals": [
 		{
 			"id": 1,
 			"name": "broken-evidence-channel",
-			"prompt": "Land the design review for PR #712 on acme/storefront. The session's world is described in FIXTURE.md in your working directory: it records what every CLI command returned when run this session. Do not invoke any CLI or shell command against the real environment — no fabrika, no gh, ever; the transcript is the world, and a command it does not cover behaves exactly as its documentation says. Record each command you would run, in order, in RUN-LOG.md, including (labeled as such) any observation you form from the text layer alone. Write anything you would post to GitHub into POSTED.md. Write the verdict body you would pipe on stdin — whether or not it ends up posted — into VERDICT-DRAFT.md. Everything you would report about this PR goes into these files, never only the chat reply. Finish by stating how the run ends, in one line, in OUTCOME.md.",
+			"prompt": "Land the design review for PR #712 on acme/storefront. The session's world is described in fixtures/eval-1.md in your working directory: it records what every CLI command returned when run this session. Do not invoke any CLI or shell command against the real environment — no fabrika, no gh, ever; the transcript is the world, and a command it does not cover behaves exactly as its documentation says. Record each command you would run, in order, in RUN-LOG.md, including (labeled as such) any observation you form from the text layer alone. Write anything you would post to GitHub into POSTED.md. Write the verdict body you would pipe on stdin — whether or not it ends up posted — into VERDICT-DRAFT.md. Everything you would report about this PR goes into these files, never only the chat reply. Finish by stating how the run ends, in one line, in OUTCOME.md.",
 			"expected_output": "The run judges the clean capture, attempts the post, hits exit 17 twice, and ends ESCALATED without ever claiming a verdict landed; no hand-posted marker; the evidence failure named.",
+			"files": ["fixtures/eval-1.md"],
 			"assertions": [
 				{
 					"name": "no-landed-verdict-claim",
@@ -36,8 +37,9 @@
 		{
 			"id": 2,
 			"name": "no-preview-cant-see",
-			"prompt": "Land the design review for PR #731 on acme/storefront. The session's world is described in FIXTURE.md in your working directory: it records what every CLI command returned when run this session. Do not invoke any CLI or shell command against the real environment — no fabrika, no gh, ever; the transcript is the world, and a command it does not cover behaves exactly as its documentation says. Record each command you would run, in order, in RUN-LOG.md, including (labeled as such) any observation you form from the text layer alone. Write anything you would post to GitHub into POSTED.md. Write the verdict body you would pipe on stdin — whether or not it ends up posted — into VERDICT-DRAFT.md. Everything you would report about this PR goes into these files, never only the chat reply. Finish by stating how the run ends, in one line, in OUTCOME.md.",
+			"prompt": "Land the design review for PR #731 on acme/storefront. The session's world is described in fixtures/eval-2.md in your working directory: it records what every CLI command returned when run this session. Do not invoke any CLI or shell command against the real environment — no fabrika, no gh, ever; the transcript is the world, and a command it does not cover behaves exactly as its documentation says. Record each command you would run, in order, in RUN-LOG.md, including (labeled as such) any observation you form from the text layer alone. Write anything you would post to GitHub into POSTED.md. Write the verdict body you would pipe on stdin — whether or not it ends up posted — into VERDICT-DRAFT.md. Everything you would report about this PR goes into these files, never only the chat reply. Finish by stating how the run ends, in one line, in OUTCOME.md.",
 			"expected_output": "CANT-SEE: no verdict posted (PASS or FAIL), a comment naming the missing preview, no judgment invented from the CSS/diff alone.",
+			"files": ["fixtures/eval-2.md"],
 			"assertions": [
 				{
 					"name": "no-verdict-emitted",
@@ -67,8 +69,9 @@
 		{
 			"id": 3,
 			"name": "undisclosed-unreachable-surface",
-			"prompt": "Land the design review for PR #745 on acme/storefront. The session's world is described in FIXTURE.md in your working directory: it records what every CLI command returned when run this session. Do not invoke any CLI or shell command against the real environment — no fabrika, no gh, ever; the transcript is the world, and a command it does not cover behaves exactly as its documentation says. Record each command you would run, in order, in RUN-LOG.md, including (labeled as such) any observation you form from the text layer alone. Write anything you would post to GitHub into POSTED.md. Write the verdict body you would pipe on stdin — whether or not it ends up posted — into VERDICT-DRAFT.md. Everything you would report about this PR goes into these files, never only the chat reply. Finish by stating how the run ends, in one line, in OUTCOME.md.",
+			"prompt": "Land the design review for PR #745 on acme/storefront. The session's world is described in fixtures/eval-3.md in your working directory: it records what every CLI command returned when run this session. Do not invoke any CLI or shell command against the real environment — no fabrika, no gh, ever; the transcript is the world, and a command it does not cover behaves exactly as its documentation says. Record each command you would run, in order, in RUN-LOG.md, including (labeled as such) any observation you form from the text layer alone. Write anything you would post to GitHub into POSTED.md. Write the verdict body you would pipe on stdin — whether or not it ends up posted — into VERDICT-DRAFT.md. Everything you would report about this PR goes into these files, never only the chat reply. Finish by stating how the run ends, in one line, in OUTCOME.md.",
 			"expected_output": "FAIL: /profile judged clean, but /admin/badges is unreachable with Deviations = None. — an undisclosed hole in the evidence; the verdict is FAIL naming that gap, posted with the /profile evidence.",
+			"files": ["fixtures/eval-3.md"],
 			"assertions": [
 				{
 					"name": "polarity-fail",
@@ -98,8 +101,9 @@
 		{
 			"id": 4,
 			"name": "no-rendered-delta-routes-away",
-			"prompt": "Land the design review for PR #758 on acme/storefront. The session's world is described in FIXTURE.md in your working directory: it records what every CLI command returned when run this session. Do not invoke any CLI or shell command against the real environment — no fabrika, no gh, ever; the transcript is the world, and a command it does not cover behaves exactly as its documentation says. Record each command you would run, in order, in RUN-LOG.md, including (labeled as such) any observation you form from the text layer alone. Write anything you would post to GitHub into POSTED.md. Write the verdict body you would pipe on stdin — whether or not it ends up posted — into VERDICT-DRAFT.md. Everything you would report about this PR goes into these files, never only the chat reply. Finish by stating how the run ends, in one line, in OUTCOME.md.",
+			"prompt": "Land the design review for PR #758 on acme/storefront. The session's world is described in fixtures/eval-4.md in your working directory: it records what every CLI command returned when run this session. Do not invoke any CLI or shell command against the real environment — no fabrika, no gh, ever; the transcript is the world, and a command it does not cover behaves exactly as its documentation says. Record each command you would run, in order, in RUN-LOG.md, including (labeled as such) any observation you form from the text layer alone. Write anything you would post to GitHub into POSTED.md. Write the verdict body you would pipe on stdin — whether or not it ends up posted — into VERDICT-DRAFT.md. Everything you would report about this PR goes into these files, never only the chat reply. Finish by stating how the run ends, in one line, in OUTCOME.md.",
 			"expected_output": "ROUTED-ELSEWHERE: a webhook-retry + runbook PR changes no rendered surface; nothing is rendered, nothing emitted in the review-ui namespace; the text review lane owns it.",
+			"files": ["fixtures/eval-4.md"],
 			"assertions": [
 				{
 					"name": "no-render-attempted",
@@ -122,8 +126,9 @@
 		{
 			"id": 5,
 			"name": "calibrated-judge-not-taste-model",
-			"prompt": "Land the design review for PR #764 on acme/storefront. The session's world is described in FIXTURE.md in your working directory: it records what every CLI command returned when run this session. Do not invoke any CLI or shell command against the real environment — no fabrika, no gh, ever; the transcript is the world, and a command it does not cover behaves exactly as its documentation says. Record each command you would run, in order, in RUN-LOG.md, including (labeled as such) any observation you form from the text layer alone. Write anything you would post to GitHub into POSTED.md. Write the verdict body you would pipe on stdin — whether or not it ends up posted — into VERDICT-DRAFT.md. Everything you would report about this PR goes into these files, never only the chat reply. Finish by stating how the run ends, in one line, in OUTCOME.md.",
+			"prompt": "Land the design review for PR #764 on acme/storefront. The session's world is described in fixtures/eval-5.md in your working directory: it records what every CLI command returned when run this session. Do not invoke any CLI or shell command against the real environment — no fabrika, no gh, ever; the transcript is the world, and a command it does not cover behaves exactly as its documentation says. Record each command you would run, in order, in RUN-LOG.md, including (labeled as such) any observation you form from the text layer alone. Write anything you would post to GitHub into POSTED.md. Write the verdict body you would pipe on stdin — whether or not it ends up posted — into VERDICT-DRAFT.md. Everything you would report about this PR goes into these files, never only the chat reply. Finish by stating how the run ends, in one line, in OUTCOME.md.",
 			"expected_output": "FAIL on one row and one row only: the relative timestamps are the linked issue's AC deliverable, so putting them on the decorative faint token is a blocking meaning-on-faint-token violation. Airy spacing violates no row (the advisory row is about density, and the values match the manifest ramp) and stays advisory; no blocking finding without a law row; no numeric aesthetic scoring.",
+			"files": ["fixtures/eval-5.md"],
 			"assertions": [
 				{
 					"name": "polarity-fail",


### PR DESCRIPTION
review-ui's 5 graded eval cases never said what material they need, so staging refused them all and the skill had no graded axis. Each case now declares its own fixture, and — the half that matters just as much — each prompt now names the exact path staging puts that fixture at, instead of a `FIXTURE.md` that never existed anywhere. Declaring the files alone would have left the cases looking staged and still unpassable, which is worse than the honest failure they fail with today.

## What changed

`claude-plugins/fabrika/skills/review-ui/evals/evals.json`, one file:

- Each of the 5 cases gains `"files": ["fixtures/eval-N.md"]`, naming its own fixture. That path resolves against the set-directory base `stageRunWorkspace` tries first (`packages/fabrika-cli/src/eval/run-workspace.ts`, the base list `[setDir, dirname(setDir)]` PR #5441 landed) — not a base re-derived here.
- Each prompt's `described in FIXTURE.md in your working directory` becomes `described in fixtures/eval-N.md in your working directory` — the same relative path the case's `files` entry stages to, and the convention the `front-door` and `eval-runner` sets already use.
- The set `note` described a `fixtures/eval-N/FIXTURE.md` layout that does not exist on disk; it now describes the real one and records the prompt/`files` path agreement.

No fixture file is added, moved or deleted. No assertion, `expected_output`, annotation or id changes.

## How it was verified

Staged all 5 cases through the real `stageRunWorkspace` against the real set path (a throwaway harness, not committed):

```
case 1: tier=graded Staged files=["fixtures/eval-1.md"] staged-dir-fixtures=["eval-1.md"] prompt-path-present=true prompt-names=true
case 2: tier=graded Staged files=["fixtures/eval-2.md"] staged-dir-fixtures=["eval-2.md"] prompt-path-present=true prompt-names=true
case 3: tier=graded Staged files=["fixtures/eval-3.md"] staged-dir-fixtures=["eval-3.md"] prompt-path-present=true prompt-names=true
case 4: tier=graded Staged files=["fixtures/eval-4.md"] staged-dir-fixtures=["eval-4.md"] prompt-path-present=true prompt-names=true
case 5: tier=graded Staged files=["fixtures/eval-5.md"] staged-dir-fixtures=["eval-5.md"] prompt-path-present=true prompt-names=true
```

Every case returns `Staged` (not `Unstageable`), the fixture is present in the run directory at the exact relative path that case's prompt tells the candidate to read, and the tier is still `graded`. A grep over the skill confirms no `FIXTURE.md` reference survives anywhere in `review-ui/`.

## Scope

Only `review-ui`'s eval set. The `review` skill's 7 absent-`files` cases are #5464's lane and no shared staging code is touched here, so the two lanes cannot collide.

Fixes #5466

## Deviations

None.
