### PR TITLE
fix(fabrika-cli): announce each graded run's isolated working directory (#5437)

### DIFF
--- a/packages/fabrika-cli/src/eval/README.md
+++ b/packages/fabrika-cli/src/eval/README.md
@@ -1086,6 +1086,19 @@ failure; the alternative is the silent one this rule exists to remove — a `pas
 empty directory, indistinguishable in the record from a measurement
 ([#5464](https://github.com/kamp-us/phoenix/issues/5464)).
 
+**Isolation is announced, so a real run can be checked.** The directories are ephemeral by design and
+the sidecar manifest below deliberately carries no working directory, which left a live run with
+nothing to look at: the property held by construction and was pinned by unit test, but an operator
+asked to confirm it on a real run had no observable. Every staged run now prints one stderr line —
+`fabrika eval: case <id> run <n>: isolated working directory <path>` — beside the
+`no isolated working directory` line the unstageable path already printed. Five distinct paths per
+case is the check:
+
+```bash
+fabrika grade graded <set> … 2>run.log
+grep 'isolated working directory' run.log | awk '{print $NF}' | sort -u | wc -l   # 5 per case
+```
+
 ### Which session produced which run ([#5439](https://github.com/kamp-us/phoenix/issues/5439))
 
 The run directory above makes identity legible while the run is alive, and the directory is removed

--- a/packages/fabrika-cli/src/eval/run-workspace.ts
+++ b/packages/fabrika-cli/src/eval/run-workspace.ts
@@ -34,6 +34,19 @@ import {Console, Effect, FileSystem, Path, Result, type Scope} from "effect";
  */
 export const EVAL_SET_FILE = "evals.json";
 
+/**
+ * The stable phrase every staged run announces itself with, so isolation is checkable from a real run.
+ *
+ * The directories are ephemeral by design — scoped, removed when the run's scope closes, and
+ * deliberately absent from the committed run manifest because they are absolute and machine-local
+ * (see `./run-manifest.ts`). That left a live `fabrika eval graded` run with nothing to look at: the
+ * property held by construction and was pinned by unit test, but an operator asked to confirm it on a
+ * real run had no observable at all. One line per staged run gives them one — five distinct paths per
+ * case, greppable by this phrase, next to the `no isolated working directory` line the unstageable
+ * path already prints (#5437).
+ */
+export const ISOLATED_DIR_NOTE = "isolated working directory";
+
 /** A declared fixture that will not be staged, and the reason a reader needs to see. */
 export interface RefusedFixture {
 	readonly path: string;
@@ -210,5 +223,6 @@ export const stageRunWorkspace = (args: {
 				return {_tag: "Unstageable", detail: `${file}: ${copied.failure.message}`};
 			}
 		}
+		yield* Console.error(`fabrika eval: ${where}: ${ISOLATED_DIR_NOTE} ${dir}`);
 		return {_tag: "Staged", dir};
 	});

--- a/packages/fabrika-cli/src/eval/run-workspace.unit.test.ts
+++ b/packages/fabrika-cli/src/eval/run-workspace.unit.test.ts
@@ -24,10 +24,16 @@ import {
 import {tmpdir} from "node:os";
 import {join} from "node:path";
 import {NodeServices} from "@effect/platform-node";
-import {Effect, FileSystem, Path} from "effect";
+import {Console, Effect, FileSystem, Path} from "effect";
 import {afterEach, beforeEach, describe, expect, it} from "vitest";
 import {type GradableCase, type RunVerdict, runGradedAxis} from "./graded-axis.ts";
-import {EVAL_SET_FILE, runDirName, stageRunWorkspace, stagingPlan} from "./run-workspace.ts";
+import {
+	EVAL_SET_FILE,
+	ISOLATED_DIR_NOTE,
+	runDirName,
+	stageRunWorkspace,
+	stagingPlan,
+} from "./run-workspace.ts";
 
 const live = <A, E>(effect: Effect.Effect<A, E, FileSystem.FileSystem | Path.Path>): Promise<A> =>
 	Effect.runPromise(Effect.provide(effect, NodeServices.layer));
@@ -123,8 +129,17 @@ describe("the five graded runs of one case", () => {
 	 * Drive the real axis with a stub that stages, snapshots what it was handed, and only then writes
 	 * a deliverable — the shape a candidate leaves behind, and what the next run must not be able to see.
 	 */
-	const stageFiveRuns = (evalCase: GradableCase = gradableCase) =>
-		live(
+	const stageFiveRuns = (evalCase: GradableCase = gradableCase) => {
+		// Captured rather than inspected on the real stderr: the announcement is the only thing a live
+		// run leaves behind about the directories, so it is asserted here the way an operator reads it.
+		const announced: Array<string> = [];
+		const capturing: Console.Console = {
+			...globalThis.console,
+			error: (...args: ReadonlyArray<unknown>) => {
+				announced.push(args.join(" "));
+			},
+		};
+		return live(
 			Effect.gen(function* () {
 				const fs = yield* FileSystem.FileSystem;
 				const path = yield* Path.Path;
@@ -165,9 +180,10 @@ describe("the five graded runs of one case", () => {
 							}),
 						),
 				});
-				return {observed, results};
-			}),
+				return {observed, results, announced};
+			}).pipe(Effect.provideService(Console.Console, capturing)),
 		);
+	};
 
 	it("each execute in their own fresh directory, with no sibling run's deliverables in it", async () => {
 		const {observed} = await stageFiveRuns();
@@ -189,6 +205,24 @@ describe("the five graded runs of one case", () => {
 			expect(run.bytes).toBe(FIXTURE_BODY);
 			expect(run.bytes).not.toContain("expected_output");
 			expect(run.bytes).not.toContain("answer key");
+		}
+	});
+
+	/**
+	 * The observable half of the same property. The directories are removed on scope close and are
+	 * absent from the committed manifest, so without this line a real run confirms nothing — which is
+	 * what #5437's live-verification criterion asks an operator to do.
+	 */
+	it("each announce their own directory, so a real run's stderr shows five distinct ones", async () => {
+		const {observed, announced} = await stageFiveRuns();
+
+		const isolation = announced.filter((line) => line.includes(ISOLATED_DIR_NOTE));
+		expect(isolation).toHaveLength(5);
+		expect(new Set(isolation).size).toBe(5);
+		for (const run of observed) {
+			expect(isolation).toContain(
+				`fabrika eval: case 1 run ${run.run}: ${ISOLATED_DIR_NOTE} ${run.dir}`,
+			);
 		}
 	});
 


### PR DESCRIPTION
A graded eval run gives each of its five candidates its own working directory, and it has since PR #5441. But nothing about that was visible from the outside: the directories are temporary and deleted the moment a run ends, and the run manifest deliberately records no directory. So the one thing #5437 still asked for — a real run confirming the five directories are different — had nothing to look at. Each staged run now prints one line naming its directory, and this PR carries the output of a real run where five distinct ones show up.

Fixes #5437

## What this PR does and does not claim

Eight of #5437's nine acceptance criteria were delivered by PR #5441 and are already on `main` — the per-`(case, run)` directory, the threaded 1-based `run` index, `claudeExecutor`'s existing `cwd`, isolation-by-construction, the unit test through the real `runGradedAxis`, cleanup on scope close, and `dispersion` / `medianVerdict` left alone. **Nothing about that is re-implemented here, and this PR does not re-litigate it.**

The ninth was left open on purpose:

> **Live verification, not yet run.** Before this closes, one real `fabrika eval graded` run must confirm the five runs no longer share a directory.

That criterion could not be met against the code as it stood, and the reason is a gap rather than an oversight. The property held by construction and was pinned by unit test, but a live run emitted nothing about the directories at all: `stageRunWorkspace` logged only its refusals, the directories are scoped and removed on close, and `run-manifest.ts` states plainly that its rows carry no working directory because one is absolute, machine-local and perishable. An operator asked to confirm isolation on a real run had no observable. So this PR adds the observable, then runs the verification.

## What changed

- **`packages/fabrika-cli/src/eval/run-workspace.ts`** — a staged run announces its directory on stderr: `fabrika eval: case <id> run <n>: isolated working directory <path>`. It sits beside the `no isolated working directory` line the unstageable path already printed, and the phrase is exported as `ISOLATED_DIR_NOTE` so the check greps a constant instead of a copied string.
- **`packages/fabrika-cli/src/eval/run-workspace.unit.test.ts`** — one case over the same five staged runs asserts five announcements, all distinct, each naming that run's own directory. It captures the `Console` service rather than the real stderr, so it reads the line the way an operator does.
- **`packages/fabrika-cli/src/eval/README.md`** — the section on staged directories gains the check itself, as a two-line shell recipe.

## The live verification

Run at head `695ea31deff39381968ac75e3cfb803fd26edba6`, `--stage build --model claude-opus-4-8 --plugin-dir claude-plugins/fabrika`, against a one-case throwaway set declaring `files: []` — five real candidate spawns and five real grader spawns, through the same `produceGradedRecord` path a skill's set takes:

```
fabrika eval: case 1 run 1: isolated working directory …/fabrika-graded-GdYjax/case1-run1-98e95731-…
fabrika eval: case 1 run 2: isolated working directory …/fabrika-graded-dg3xP8/case1-run2-712de6cc-…
fabrika eval: case 1 run 3: isolated working directory …/fabrika-graded-VwCWpI/case1-run3-22849e3d-…
fabrika eval: case 1 run 4: isolated working directory …/fabrika-graded-UzTxAH/case1-run4-19c9b4c8-…
fabrika eval: case 1 run 5: isolated working directory …/fabrika-graded-ymNlr6/case1-run5-a110c289-…
eval: RECORDED @ 695ea31d — build/— 1 (1/1 cases, 0 unmeasured)
```

Five distinct scoped temp parents and five distinct run directories, and each directory's session id matches its row in the `.runs.json` manifest the same run wrote. The paths are elided above because they are machine-local; the run identity is the part that matters.

**Why a throwaway one-case set and not a corpus set.** The criterion asks whether five runs share a directory, which is a property of the runner and not of any skill. A corpus set would spend 5 candidate + 5 grader spawns *per case* to answer the same question the cheapest possible case answers once, and #5437 does not ask for a skill's number. The set is a probe, so it is not committed.

## What this does not verify

- **#5434's live criterion is untouched.** It reads the same way, but it is about the answer key not being reachable from the candidate's directory, and the probe set declares `files: []` — nothing to stage, so nothing about `evals.json` staging was exercised. #5434 stays open and this PR makes no claim on it.
- **No corpus set was run**, so this PR produces no skill's graded number and changes no committed scorecard.
- The announcement is stderr only. `dispersion`, `medianVerdict`, the ADR 0253 record shape and the `.runs.json` manifest are all unchanged.

## Checks run

| check | result |
|---|---|
| `pnpm typecheck` | 31/31 tasks pass |
| `pnpm lint:worktree` | 2 files checked, clean |
| `pnpm --filter @kampus/fabrika-cli test` | 301 files / 4610 tests pass |
| falsification of the new test | announcement mutated to a constant string ⇒ the case reds; mutation reverted, not in this diff |
| live `graded` run | 5 distinct directories, `RECORDED @ 695ea31d` |

## Deviations

**1. The diff is smaller than the issue's body implies (class: most of the fix already landed).** *Said:* #5437's body describes the whole per-run-isolation fix. *Did:* only the observability, because PR #5441 delivered the rest and this PR verifies it rather than repeating it. *Why:* re-implementing landed work would be a second copy of a shipped fix. *Disposition:* no action needed — the ACs are itemised above against which PR delivered each.

**2. `Fixes` rather than `Part of`, on a PR that authored only one criterion's worth of code.** *Said:* the AC-completeness gate ties the closing keyword to this diff delivering every criterion. *Did:* `Fixes #5437`, on the ground that the other eight are already merged and the ninth is discharged here, so nothing on the issue is left after this merges. *Disposition:* for the reviewer to judge — the alternative reading is `Part of`, which would leave an issue open with every criterion met.

**3. An announcement, not a durable record of the directory.** *Said:* nothing about where the evidence should live. *Did:* stderr, and left `run-manifest.ts` alone. *Why:* the manifest's own docblock states why it excludes the working directory — absolute, machine-local, perishable, and the file is committed — and that reasoning did not stop being true. *Cost:* the evidence lives in a run's console output, so an operator who did not capture stderr has to re-run. *Disposition:* for the reviewer to judge.

**4. A cross-lane commit-message bleed, hit and worked around here.** A `git commit -F` naming a file that did not exist produced a commit carrying **another lane's** message ("fix(report): state the guarantee the eval set actually delivers (#4789)") instead of failing. It was caught by reading the log back and amended before push, so this branch's history is clean. Filed as #5484 so the mechanism gets diagnosed; noted here because it is the kind of thing a reviewer should know was in this lane's path. *Disposition:* out of scope for this diff.
