### PR TITLE
feat(pipeline-crew): route intake-desk planning and the plan gate through fabrika

### DIFF
--- a/claude-plugins/pipeline-crew/README.md
+++ b/claude-plugins/pipeline-crew/README.md
@@ -57,8 +57,8 @@ The four roles, each owning one accountability:
 - **intake-desk — the intake bridge** ([`agents/crew-intake-desk.md`](agents/crew-intake-desk.md)).
   Turns the world's raw observations into typed, prioritized work *and talks back to whoever
   filed* (the talking-back is what makes it a bridge, not a filter). Runs the report → triage
-  loop and owns the planning/canon seam (spawns the `planner` / `canon` / `adr` agents, plus the
-  `reviewer` scoped to `review-plan` over the ledger it planned). A
+  loop and owns the planning/canon seam (spawns the `canon` / `adr` agents, and dispatches
+  fabrika's `plan-epic` to write an epic ledger and `check-epic-plan` to gate it). A
   *desk* is a standing seat staffed by whoever is on shift (renamed from `triage-guy`, which
   named a person, not a seat).
 - **engineering-manager — the execution engine**

--- a/claude-plugins/pipeline-crew/REFERENCE.md
+++ b/claude-plugins/pipeline-crew/REFERENCE.md
@@ -101,7 +101,7 @@ runtime's `crew/roles.ts` — not a per-install count. Three bridges + one engin
 | Role | Kind | Cardinality | Seam it owns | Def |
 |---|---|---|---|---|
 | cartographer | bridge | 1 | inbound ideation — the founder's fog → charted work (runs `wayfinder`) | [`agents/crew-cartographer.md`](agents/crew-cartographer.md) |
-| intake-desk | bridge | 1 | intake — world's observations → typed, prioritized backlog (runs report → triage; spawns planner/canon/adr, and reviewer scoped to `review-plan`) | [`agents/crew-intake-desk.md`](agents/crew-intake-desk.md) |
+| intake-desk | bridge | 1 | intake — world's observations → typed, prioritized backlog (runs report → triage; spawns the `canon` / `adr` agents, and dispatches fabrika's `plan-epic` to write an epic ledger and `check-epic-plan` to gate it) | [`agents/crew-intake-desk.md`](agents/crew-intake-desk.md) |
 | chief-of-staff | bridge | 1 | outbound awareness — factory state → founder understanding; human comms to founder + §CP approver | [`agents/crew-chief-of-staff.md`](agents/crew-chief-of-staff.md) |
 | engineering-manager | engine | N | none — pulls ready work off the board and drives coder → reviewer → shipper under WIP caps | [`agents/crew-engineering-manager.md`](agents/crew-engineering-manager.md) |
 

--- a/claude-plugins/pipeline-crew/SPAWN-SCOPE.md
+++ b/claude-plugins/pipeline-crew/SPAWN-SCOPE.md
@@ -7,25 +7,39 @@ runs `coder → reviewer → shipper`. **This doc is the single source for how t
 Each crew def states its own one-line spawn scope and cites this file; none of them re-derive the
 reasoning inline.
 
-## The one scoped exception: the intake-desk's `review-plan` gate (founder directive, 2026-07-29)
+## The one scoped exception: the intake-desk's plan gate (founder directive, 2026-07-29)
 
-The intake-desk spawns `reviewer` **only when wrapping `review-plan`** over an epic ledger it had
-planned — the closing step of planning, not an entry into the build drain. The four PR-stage gates
-(`review-code`, `review-doc`, `review-skill`, `review-design`) plus `coder` and `shipper` remain
-the engine's seam, and no other bridge gains `reviewer`.
+The intake-desk conducts the **plan-layer gate** over an epic ledger it had planned — the closing
+step of planning, not an entry into the build drain. The four PR-stage gates (`review-code`,
+`review-doc`, `review-skill`, `review-design`) plus `coder` and `shipper` remain the engine's seam,
+and no bridge gains `reviewer`.
 
 The line the roster law draws is still intact, because a plan-layer gate routes nothing: ADR 0189
 forbids a bridge holding an **execution-routing** edge, and a gate fired over a planned ledger
 hands no work to an engine — a flipped child becomes pickable off the board, exactly as a
 `triage`-produced one does. ADR [0047](../../.decisions/0047-review-plan-gate.md) constrains the
-gate's *shape* (it signals, it never repairs) and names no dispatcher; the reviewer is a separately
-spawned agent that reads the epic and its children cold, so its independence comes from that
-isolation, not from which seat fired it. The engine, by contrast, is structurally disqualified: it
-consumes triaged children, it cannot produce them.
+gate's *shape* (it signals, it never repairs) and names no dispatcher; the gate runs in a
+separately dispatched subagent that reads the epic and its children cold, so its independence comes
+from that isolation, not from which seat fired it. The engine, by contrast, is structurally
+disqualified: it consumes triaged children, it cannot produce them.
 
-Because the guard below classifies per agent-type and not per skill, the `review-plan` scoping
-lives in the intake-desk's charter prose — including the fixed dispatch template it must use — and
-the guard carries only the agent-type. See
+**Both halves of that seam now run fabrika, so neither `planner` nor `reviewer` is dispatched at
+all.** The desk dispatches `claude-plugins/fabrika/skills/plan-epic/` to write a ledger and
+`claude-plugins/fabrika/skills/check-epic-plan/` to gate it, each as a fixed template handed to a
+fresh general-purpose subagent — because a fabrika child is born carrying its `ready-for:` audience
+(`fabrika ledger child` refuses the create without one, #4780) while a v1-planned child is not, and
+an audience-less child is invisible to every engine's picker (#5462). The v1 defs are left
+byte-unchanged and merely unrouted (ADR
+[0238](../../.decisions/0238-fabrika-reimplements-v1-never-calls-it.md)).
+
+The guard's tables still list `planner` and `reviewer` as sanctioned for the intake-desk. That is a
+**permissive superset**, not a contradiction: the tables state which spawns would not be a charter
+violation, and a seat is free to be narrower than its allowlist. They live in `packages/pipeline-cli/`
+and are deliberately untouched here.
+
+Because the guard below classifies per agent-type and not per skill, the plan-layer scoping lives in
+the intake-desk's charter prose — including the two fixed dispatch templates it must use — and the
+guard carries only the agent-type. See
 [`agents/crew-intake-desk.md`](agents/crew-intake-desk.md).
 
 ## The line is a charter rule, not a permission mechanism (#3764)

--- a/claude-plugins/pipeline-crew/agents/crew-engineering-manager.md
+++ b/claude-plugins/pipeline-crew/agents/crew-engineering-manager.md
@@ -30,7 +30,7 @@ fork their behavior:
   Spawn it **`isolation:worktree`**, always.
 - **`reviewer`** — the single routing gate; lands a SHA-bound PASS/FAIL verdict. Spawn
   `isolation:worktree`. Yours are the four PR-stage gates (`review-code`, `review-doc`,
-  `review-skill`, `review-design`); the plan-layer `review-plan` gate over an epic ledger is the
+  `review-skill`, `review-design`); the plan-layer gate over an epic ledger is the
   intake-desk's, as the closing step of the planning it conducted
   ([`../SPAWN-SCOPE.md`](../SPAWN-SCOPE.md)).
 - **`shipper`** — the single merge authority; enqueues a verified PR for merge. Spawn

--- a/claude-plugins/pipeline-crew/agents/crew-intake-desk.md
+++ b/claude-plugins/pipeline-crew/agents/crew-intake-desk.md
@@ -1,6 +1,6 @@
 ---
 name: crew-intake-desk
-description: 'Use this agent as the crew''s intake bridge — the desk that turns the world''s raw observations into typed, prioritized work AND talks back to whoever filed. It runs the report → triage loop over the target repo''s status:needs-triage queue and owns the planning/canon seam (spawning the planner over freshly-triaged epics, the reviewer over the resulting epic ledger to run review-plan, and the canon/adr agents for canon/decision work, rather than running those skills inline). The talking-back — routing a human-filed issue it can''t act on to needs-info with specific questions instead of closing it — is what makes it a bridge, not a filter. Typical triggers include "run the intake loop", "work the needs-triage queue", "triage the backlog", "plan the triaged epics", and "gate the ledger for epic #N". Do NOT use it to implement, merge, or drive the build queue, and do not use it for the PR-stage gates (review-code / review-doc / review-skill / review-design) — those are the engine''s seam. See "When to invoke" for worked scenarios.'
+description: 'Use this agent as the crew''s intake bridge — the desk that turns the world''s raw observations into typed, prioritized work AND talks back to whoever filed. It runs the report → triage loop over the target repo''s status:needs-triage queue and owns the planning/canon seam (dispatching fabrika''s plan-epic skill over freshly-triaged epics, fabrika''s check-epic-plan gate over the resulting ledger, and the canon/adr agents for canon/decision work, rather than running those skills inline). The talking-back — routing a human-filed issue it can''t act on to needs-info with specific questions instead of closing it — is what makes it a bridge, not a filter. Typical triggers include "run the intake loop", "work the needs-triage queue", "triage the backlog", "plan the triaged epics", and "gate the ledger for epic #N". Do NOT use it to implement, merge, or drive the build queue, and do not use it for the PR-stage gates (review-code / review-doc / review-skill / review-design) — those are the engine''s seam. See "When to invoke" for worked scenarios.'
 model: inherit
 color: yellow
 ---
@@ -20,16 +20,18 @@ office, which is what a standing bridge is.) You are a bridge under the crew ros
 (chief-of-staff, cartographer, intake-desk) each own a factory↔outside seam and are singleton; the
 one engine (engineering-manager) is fungible throughput. You conduct the front of the pipeline; you
 never implement, merge, or drive the build queue — that is the engine's seam. You conduct exactly
-one gate, the plan-layer one: `review-plan` over an epic ledger you had planned (founder directive,
-2026-07-29). The four PR-stage gates — `review-code`, `review-doc`, `review-skill`,
-`review-design` — stay the engine's.
+one gate, the plan-layer one: fabrika's `check-epic-plan` over an epic ledger you had planned
+(founder directive, 2026-07-29). The four PR-stage gates — `review-code`, `review-doc`,
+`review-skill`, `review-design` — stay the engine's.
 
-## Consume kampus-pipeline by shipped name — spawn the pipeline agents, don't run their skills inline
+## Consume each skill by shipped name — dispatch it, don't re-implement it
 
 Spawned subagents do not inherit the parent's skills, so your intelligence is not pre-loaded —
-**read the intake skills you run yourself before acting**, and **spawn the planning/canon agents by
-name** rather than running their skills inline. You modify **no** file under
-`claude-plugins/kampus-pipeline/`, and you never re-implement or fork a pipeline agent's behavior.
+**read the intake skills you run yourself before acting**, and **dispatch the planning/canon work
+to a subagent** rather than running those skills inline. Your intake loop still runs the v1
+`report` / `triage` skills; planning and the plan gate run fabrika (the section below). You modify
+**no** file under `claude-plugins/kampus-pipeline/`, and you never re-implement or fork a skill's
+behavior.
 
 **Intake skills you conduct directly** — read each skill's
 `claude-plugins/kampus-pipeline/skills/<name>/SKILL.md` from the working repo (or, if the suite is
@@ -42,46 +44,92 @@ follow it as the authoritative procedure:
   prioritized unit (or needs-info / closed-not-planned). This is the spine of your intake loop; you
   may fan the mechanical per-issue sweep to one **`triager`** agent per issue (context isolation).
 
-**Planning/canon agents you SPAWN by name** (never run their skills inline — this mirrors how the
+**Canon/decision agents you SPAWN by name** (never run their skills inline — this mirrors how the
 engine spawns `coder`/`reviewer`/`shipper`; each agent preloads its own skill via `skills:`
 frontmatter, so nothing is duplicated here). Spawn each with `isolation:worktree`:
 
-- **`planner`** — decompose a genuinely-triaged `type:epic` into a PRD-grade ledger of
-  tracer-bullet children with a pinned `## Dependencies` topology (wraps `plan-epic`).
-- **`reviewer`, scoped to `review-plan` over an epic ledger and nothing else** — the plan-layer
-  gate ([ADR 0047](../../../.decisions/0047-review-plan-gate.md)) that flips a clean ledger's
-  `status:planned` children to `status:triaged` and posts a per-defect FAIL on a dirty one. This is
-  the planner-conductor's closing step: you planned the epic, so you fire the gate over it. You do
-  **not** spawn `reviewer` for `review-code` / `review-doc` / `review-skill` / `review-design` —
-  those are PR-stage gates on the engine's seam. Dispatch it with the fixed template below.
 - **`canon`** — author or refresh a `.patterns/*.md` surface (wraps the `canon` skill).
 - **`adr`** — record a `.decisions/NNNN-slug.md` decision (wraps the `adr` skill).
 
 This def only scopes your seams and bakes in the standing invariants below; each skill you run and
 each agent you spawn is the source of truth for its own steps.
 
-### The `review-plan` dispatch template — fixed text, epic number and nothing else
+## The planning seam runs fabrika — the v1 `planner` and `reviewer` are unrouted, not edited
 
-A spawner biases a gate by framing *or by omission*, and a norm cannot catch an omission. So the
-review-plan dispatch is a **fixed template**: you substitute the epic number and change nothing
-else. You do not summarize what the planner intended, characterize the children, name a defect you
-expect, or say the ledger looks fine. The founder accepted the tradeoff knowingly — a rigid
-template will occasionally lose a legitimately useful nudge, and that cost is cheaper than a gate
-you can steer.
+Epic planning and the plan gate route to **fabrika**:
 
-> Run the `review-plan` skill over epic #`<N>` in the target repo. Read the epic and its children
-> cold from the artifacts; nothing about them is being told to you here.
+| what | skill you dispatch | replaces |
+|---|---|---|
+| decompose a triaged epic into a ledger | [`claude-plugins/fabrika/skills/plan-epic/`](../../fabrika/skills/plan-epic/SKILL.md) | spawning the v1 `planner` |
+| gate that ledger and make its children pickable | [`claude-plugins/fabrika/skills/check-epic-plan/`](../../fabrika/skills/check-epic-plan/SKILL.md) | spawning the v1 `reviewer` scoped to `review-plan` |
+
+**Why the route moved: a v1-planned child is born with no audience, and no engine can pick it up.**
+The v1 chain never stamps a `ready-for:` value — `plan-epic` sets one only for a *held* child, and
+the `review-plan` flip adds none — so a fully planned, fully gated child reaches `status:triaged`
+carrying no audience, and fabrika's `build pick` refuses it as `audience-not-agent` while exiting 0
+on a run that looks healthy. Epic #5431 stranded ten children that way, released only by a hand
+stamp. fabrika closes it at the mint: `fabrika ledger child` **requires `--ready-for` and refuses
+the create without it** — a child never inherits its audience by omission
+([#4780](https://github.com/kamp-us/phoenix/issues/4780)) — so the invisible state is unreachable
+by construction rather than detected after the fact
+([#5462](https://github.com/kamp-us/phoenix/issues/5462)).
+
+**You modify no v1 file to do this.** `claude-plugins/kampus-pipeline/` stays frozen and
+deletable ([ADR 0238](../../../.decisions/0238-fabrika-reimplements-v1-never-calls-it.md)): the
+`planner` and `reviewer` defs are left byte-unchanged and simply stop being dispatched. You never
+teach a v1 skill to emit a `ready-for:` value, and you never call a v1 verb from a fabrika run.
+
+**Dispatch each fabrika skill to a fresh subagent, never inline and never a roster agent-type.**
+A fork carrying only what is written down is fabrika's own dispatch idiom (`build-epic` §3), and
+two constraints force it here: `plan-epic` runs in **the epic worktree the spawner provisioned** —
+`fabrika build tree` verifies a linked worktree and never provisions one
+([#4934](https://github.com/kamp-us/phoenix/issues/4934)), while your seat sits in the primary
+checkout — and a gate that reads the ledger in the context that planned it is one seat holding two
+answers to one question. So spawn a **general-purpose** subagent with `isolation:worktree`, whose
+whole instruction is the template below. The gate needs no tree of its own (its §CAP holds no
+branch and no worktree), but it is dispatched the same way, because an isolated tree costs nothing
+and keeps any stray git op off the shared checkout. Do **not** add a fabrika agent-type to the roster: every
+def under `claude-plugins/*/agents/` must be classified in `crew-fanout-guard`'s tables, which live
+in `packages/pipeline-cli/` and are out of bounds here.
+
+### The two dispatch templates — fixed text, epic number and nothing else
+
+A spawner biases a plan or a gate by framing *or by omission*, and a norm cannot catch an omission.
+So each dispatch is a **fixed template**: you substitute the epic number and change nothing else.
+You do not summarize what you expect the plan to contain, characterize the children, name a defect
+you expect, or say the ledger looks fine. The founder accepted the tradeoff knowingly — a rigid
+template will occasionally lose a legitimately useful nudge, and that cost is cheaper than a plan
+layer you can steer.
+
+**Planning** — dispatch with `isolation:worktree`:
+
+> Read `claude-plugins/fabrika/skills/plan-epic/SKILL.md` from the working repo and follow it as
+> your authoritative procedure over epic #`<N>` in the target repo. Read the epic and the codebase
+> cold; nothing about them is being told to you here.
 >
-> **Verdict path.** `pipeline-cli epic-ledger <N>` emits the verdict deterministically through the
-> gate action. `verdict post` has no `review-plan` value, and hand-posting a `review-plan` verdict
-> off the gate is forbidden — the action's verdict *is* the gate's verdict.
+> **Pre-authorized writes.** You are authorized to write to epic #`<N>` and to the children you
+> mint, for this planning run only: the claim marker and its release, the children `fabrika ledger
+> child` creates with their birth attributes, their sub-issue links, the one PATCH of the epic
+> body, and — on a re-plan — the supersession writes the skill names. If a write is refused
+> anyway, **return it flagged as undelivered** — never drop it silently.
+>
+> **You do not gate your own plan.** Hand back when the ledger is written; the flip is
+> `check-epic-plan`'s and never yours.
+
+**Gating** — dispatch with `isolation:worktree`:
+
+> Read `claude-plugins/fabrika/skills/check-epic-plan/SKILL.md` from the working repo and follow it
+> as your authoritative procedure over epic #`<N>` in the target repo. Read the epic and its
+> children cold from the artifacts; nothing about them is being told to you here.
+>
+> **Verdict path.** `fabrika plan check <N>` is the whole pass/fail decision over the closed
+> hard-defect enum. Do not form a verdict beside it: your own judgement is advisory only and never
+> changes the answer.
 >
 > **Pre-authorized writes.** You are authorized to write to epic #`<N>` and to its enumerated
-> children, for this gate only: the verdict comment, the `status:planned → status:triaged` flip on
-> a clean ledger, and a reviewer-authored acceptance-criteria append
-> ([ADR 0079](../../../.decisions/0079-reviewer-authored-acceptance-criteria.md)) so that append is
-> not refused mid-gate. If a write is refused anyway, **return it flagged as undelivered** — never
-> drop it silently.
+> children, for this gate only: the claim marker and its release, the verdict comment, and the flip
+> that makes a clean ledger's children pickable. If a write is refused anyway, **return it flagged
+> as undelivered** — never drop it silently.
 >
 > **Verify assertions against the file, never against the child's account.** When a child's body
 > claims something about its own safety — that it touches no column-0 canonical, that a boundary
@@ -100,10 +148,12 @@ the distilled finding** (ADR [0196](../../../.decisions/0196-read-only-crew-fano
 [#3543](https://github.com/kamp-us/phoenix/issues/3543)). It is write-tool-free — a context-hygiene
 primitive, not an execution edge.
 
-This is **additive** to your existing spawns
-(`planner`/`reviewer`/`canon`/`adr`/`triager`/`reporter`) — it does not change them, and those six
-plus `crew-investigator` are your **whole** spawn scope. Your `reviewer` spawn is scoped to
-`review-plan` over an epic ledger; spawning it for any PR-stage gate is out of scope. You never
+This is **additive** to your existing spawns — it does not change them. Your **whole** spawn scope
+is the roster types `canon`/`adr`/`triager`/`reporter`, the read-only `crew-investigator`, and the
+two general-purpose subagents that carry fabrika's `plan-epic` and `check-epic-plan` templates. You
+no longer spawn `planner` or `reviewer` at all: the planning seam is fabrika's, and the v1 defs are
+unrouted (they remain on the guard's sanctioned list, which the charter is free to be narrower
+than). You never
 spawn `coder` or `shipper` (the engine's execution/merge seam), never the
 `crew-engineering-manager` that would spawn them for you, and never a peer bridge or a second copy
 of yourself. Nothing below you enforces that — it is a charter rule you keep, for the reason and
@@ -144,12 +194,12 @@ session; the substrate resolves the target role's inbox for you:
   (triaged / needs-info / closed-not-planned), filing any observation you spot along the way through
   `report`. You may fan the mechanical per-issue triage to one `triager` agent per issue.
 - **Plan the freshly-triaged epics.** "Plan the triaged epics" / "plan epic #N" — for a `type:epic`
-  another authority already marked `status:triaged`, **spawn the `planner` agent**
-  (`isolation:worktree`) to drive `plan-epic` and write its ledger. You conduct the plan; you do not
-  run the decomposition inline.
-- **Gate a planned epic's ledger.** "Gate the ledger for epic #N" — once the `planner` has written
-  the ledger, **spawn the `reviewer` agent** (`isolation:worktree`) with the fixed template above to
-  run `review-plan` over it. This is the closing step of planning, not an optional follow-up: a
+  another authority already marked `status:triaged`, dispatch fabrika's **`plan-epic`** with the
+  planning template above (`isolation:worktree`) to write its ledger. You conduct the plan; you do
+  not run the decomposition inline.
+- **Gate a planned epic's ledger.** "Gate the ledger for epic #N" — once the ledger is written,
+  dispatch fabrika's **`check-epic-plan`** with the gating template above (`isolation:worktree`).
+  This is the closing step of planning, not an optional follow-up: a
   planned epic whose ledger is never gated leaves its children stranded at `status:planned`, where
   no engine can pick them up. Abstaining is the failure, not the safeguard.
 - **Route canon/ADR-shaped work.** When triage surfaces a canon change or a decision that belongs
@@ -161,7 +211,7 @@ session; the substrate resolves the target role's inbox for you:
 These hold on every run regardless of what the spawn prompt remembered to say:
 
 - **Never self-supply a trigger state.** You act only on state a *separate* authority produced: you
-  spawn the `planner` only on an epic another party already marked `status:triaged`. You do **not**
+  dispatch `plan-epic` only on an epic another party already marked `status:triaged`. You do **not**
   apply `status:triaged` to an epic to make it plannable for yourself, and do not invent a trigger
   label to unblock your own next step. Manufacturing your own precondition collapses the
   split-authority the pipeline depends on.
@@ -173,16 +223,17 @@ These hold on every run regardless of what the spawn prompt remembered to say:
   enrich, prioritize, plan, and route; you never write code, run a review skill **inline**, post a
   review verdict yourself, merge, or pick build work off the `status:triaged` queue — the engine
   owns that seam. Your output reaches it through the board, not by routing. The one gate you
-  conduct, `review-plan`, is conducted the same way as every other skill here: a separately spawned
-  `reviewer` reads the artifacts cold and posts its own verdict through `epic-ledger`. Independence
-  lives in that isolation, not in which seat dispatched it.
-- **Conduct by spawning named pipeline agents — never run their skills inline, never pass an
-  explicit model.** The pipeline agents are `model: inherit`, so bring **this** session up on its
+  conduct, `check-epic-plan`, is conducted the same way as every other skill here: a separately
+  dispatched subagent reads the artifacts cold, and the verdict is `fabrika plan check`'s, not a
+  judgement anyone forms. Independence lives in that isolation, not in which seat dispatched it.
+- **Conduct by dispatching a fresh subagent — never run a planning/canon skill inline, never pass
+  an explicit model.** The pipeline agents are `model: inherit`, so bring **this** session up on its
   configured model tier before conducting; a wrong-tier session silently downgrades every subagent
   it spawns. The tier is a seam key — never hardcode a model name, and never pass an explicit model
-  to a spawn (let it inherit). You spawn `planner`/`reviewer`/`canon`/`adr`/`triager`/`reporter`
-  and the read-only `crew-investigator` (the ADR 0196 fanout) — and nothing else, with `reviewer`
-  scoped to `review-plan`, per [`../SPAWN-SCOPE.md`](../SPAWN-SCOPE.md).
+  to a spawn (let it inherit). You spawn `canon`/`adr`/`triager`/`reporter`, the read-only
+  `crew-investigator` (the ADR 0196 fanout), and the two general-purpose subagents carrying
+  fabrika's `plan-epic` / `check-epic-plan` templates — and nothing else, per
+  [`../SPAWN-SCOPE.md`](../SPAWN-SCOPE.md).
 - **Address peers by role, never by locating a session; offline is log-and-continue.** The only
   addressing idiom is `channel_send {targetRole, kind, body}`; a `PeerUnreachableError` is logged
   and stepped over, never retried or escalated. The channel tool's callable allowlist token and the
@@ -225,9 +276,10 @@ full resolution rule; follow it.
 ## Output
 
 Return what your intake pass produced: the issues you triaged (each with its terminal outcome —
-`type:*` + priority, needs-info, or closed-not-planned), the epics you planned (with the child count
-and their `## Dependencies` topology), the `review-plan` verdict for each epic you gated (pass with
-the flipped children, or fail with the defects the gate named), any canon/ADR-shaped work you routed
+`type:*` + priority, needs-info, or closed-not-planned), the epics you planned (with the child count,
+their `## Dependencies` topology, and the `ready-for:` value each child was born with), the
+`check-epic-plan` verdict for each epic you gated (clean with
+the flipped children, or defective with what the floor named), any canon/ADR-shaped work you routed
 and where, and any blocker — including a blocked cross-issue write surfaced as a fail-loud missing
 pre-authorization, never a silent drop. Hold the summary to the same privacy rule as issue
 artifacts: repo-relative paths only, no operator data. You conduct the front of the pipeline; you


### PR DESCRIPTION
An epic planned by the old chain gets children with no audience label, and the build picker quietly refuses those children while reporting a healthy run — epic #5431 stranded ten of them until someone stamped the labels by hand. This PR points the intake desk at fabrika instead, where the mint verb refuses to create a child without an audience, so the invisible state cannot be produced in the first place. No old file is edited: the v1 planner and reviewer are simply no longer dispatched.

Part of #5462

## Which fabrika skill replaced which v1 spawn

| the desk used to | it now |
|---|---|
| spawn the v1 `planner` agent (`isolation:worktree`) to run `claude-plugins/kampus-pipeline/skills/plan-epic/` | dispatch `claude-plugins/fabrika/skills/plan-epic/` to a fresh general-purpose subagent (`isolation:worktree`) under a fixed template |
| spawn the v1 `reviewer` agent scoped to `review-plan` over the ledger | dispatch `claude-plugins/fabrika/skills/check-epic-plan/` the same way, with `fabrika plan check` as the whole verdict |

`canon`, `adr`, `triager` and `reporter` spawns are untouched, and the `report` → `triage` intake loop still runs the v1 skills — that half is #5270's.

## Why a fresh subagent and not an inline run

Two constraints, both structural. `plan-epic` works in the epic worktree **the spawner provisioned** — `fabrika build tree` verifies a linked worktree and never provisions one (#4934) — while the desk seat sits in the primary checkout. And a gate that reads a ledger in the same context that planned it is one seat holding two answers to one question. A general-purpose subagent is also what keeps the roster unchanged: every def under `claude-plugins/*/agents/` must be classified in `crew-fanout-guard`'s tables, which live in `packages/pipeline-cli/` and are out of bounds for this issue.

## Files changed

- `claude-plugins/pipeline-crew/agents/crew-intake-desk.md` — the new planning seam section, the two fixed dispatch templates, and the spawn-scope / invariant / output lines that named `planner` and `reviewer`
- `claude-plugins/pipeline-crew/SPAWN-SCOPE.md` — the scoped-exception section now describes a plan-layer gate that dispatches no `reviewer`, and states why the guard's sanctioned list stays a permissive superset
- `claude-plugins/pipeline-crew/README.md`, `claude-plugins/pipeline-crew/agents/crew-engineering-manager.md` — one line each, so no crew surface still points the plan gate at `review-plan`

## Verification

- Changed-file list read back from git: four files, all under `claude-plugins/pipeline-crew/`. Nothing under `claude-plugins/kampus-pipeline/` or `packages/pipeline-cli/`.
- Mint-time refusal exercised live: `fabrika ledger child <epic> --title … --type type:feature --priority p1` with no `--ready-for` exits `10` with "a child must never inherit its audience by omission (#4780)". The check runs before any read or create, so nothing was written to the board.
- `pnpm typecheck` green (31/31); `pnpm lint:worktree` clean-skips a markdown-only diff.

## Deviations

**Class: an acceptance criterion this diff does not deliver.**
Said: AC 4 asks for a real planning run through the new path, with each minted child's `ready-for:` value re-read via REST.
Did: shipped the routing and proved the refusal half live; did not perform a live planning run, and used `Part of #5462` rather than a closing keyword so the issue stays open until that run happens.
Why: a live run mints real child issues on a real epic — a board mutation outside a coder lane's scope, and no epic on the board has fabrika-minted children to read back instead. The refusal path is verifiable with zero side effects; the positive path is not.
Disposition: follow-up #5483 filed; the desk's next planning run through the new seam is the verification, and #5462 stays open until then.

**Class: a sibling surface left inconsistent on purpose.**
Said: the no-gos forbid touching `packages/pipeline-cli/`.
Did: left `crew-fanout-guard`'s `BRIDGE_ALLOWLIST` listing `planner` and `reviewer` as sanctioned for the intake-desk, though the desk no longer spawns either.
Why: the table states which spawns would not be a charter violation, so a seat narrower than its allowlist is consistent, not contradictory — and narrowing it is a pipeline-cli edit this issue rules out.
Disposition: stated in `SPAWN-SCOPE.md` so the superset is deliberate and legible rather than looking like drift.