### PR TITLE
fix(fabrika): make the governance floor bind in CI (#5408)

### DIFF
--- a/.github/workflows/governance-floor.yml
+++ b/.github/workflows/governance-floor.yml
@@ -1,0 +1,62 @@
+name: governance-floor
+
+# The governance floor made binding (#5408).
+#
+# The founder vetoed making `claude-plugins/fabrika/**` control-plane and substituted a control: a
+# required `governance` verdict on any diff touching a governance root (#5036 comment 5234614633).
+# The floor shipped in PR #5231 and it does derive the requirement correctly — but `ship gate` seats
+# `blocked` at exit 0, nothing read it, and no workflow invoked it at all, so two fabrika-tree PRs
+# (#5293, #5333) merged with no governance verdict after the floor was live. A control that never
+# withholds a merge is worse than none, because it looks present.
+#
+# `fabrika ship floor` is the decision; this job only relays its exit code (ADR 0228). Nothing here
+# decides which paths are governance-bearing, which verdict is in force, or whether an author may
+# author one — the verb reads the PR's changed files and resolves the verdict through `ship gate`
+# itself, which stays the single merge authority.
+#
+# It runs on EVERY pull request with no `paths:` filter on purpose. A YAML path filter is a second
+# copy of `GOVERNANCE_ROOTS` that nothing reds when it drifts (#4604); the verb's own read of the
+# PR's changed files is the one derivation, and a diff under no governance root is an `n/a` answer
+# this job passes on.
+on:
+  pull_request:
+
+# Least-privilege: the job checks out the repo and reads the PR's metadata, changed files, comments,
+# reviews and the comment authors' repository permission (the ADR 0055 write+ gate). It posts no
+# check-run, status or comment and fails by exit code alone.
+permissions:
+  contents: read
+  pull-requests: read
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ github.ref != 'refs/heads/main' }}
+
+jobs:
+  floor:
+    name: a governance-root diff carries a governance verdict at its head
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4.2.2
+
+      - uses: pnpm/action-setup@v4.1.0
+
+      - uses: actions/setup-node@v4.4.0
+        with:
+          node-version-file: package.json
+          cache: pnpm
+
+      - run: pnpm install --frozen-lockfile
+
+      # Exit 0 = the floor does not bind (`n/a`) or is discharged (`satisfied`). Every non-zero reds,
+      # and they are different facts: 18 means the diff touches a governance root and its verdict is
+      # absent, stale or fail — a human owes this PR a verdict. 7 / 11 / 13 mean the floor could not
+      # be resolved at all, which is UNKNOWN and never a pass (ADR 0092).
+      - name: Decide whether the governance floor is discharged at this head
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          CLAUDE_PIPELINE_REPO: ${{ github.repository }}
+        run: |
+          node packages/fabrika-cli/src/bin.ts ship floor \
+            ${{ github.event.pull_request.number }} \
+            --sha ${{ github.event.pull_request.head.sha }}

--- a/claude-plugins/fabrika/skills/governance/contract.md
+++ b/claude-plugins/fabrika/skills/governance/contract.md
@@ -261,6 +261,14 @@ changed-file list and raises the required set from it (`requiredWithFloor`) thro
 `touchesGovernanceRoot` predicate `governance scope` and `ship scope` use — one derivation, three
 readers. So the requirement is a property of the diff, not of what a session remembered to type.
 
+**1c. …and the requirement had to be readable by something other than an agent. LANDED (#5408).**
+`ship gate` seats `blocked` at exit 0 and no workflow invoked it, so the floor bound on nothing but
+prose in the `ship` skill and two fabrika-tree PRs merged with no governance verdict after it
+shipped. `fabrika ship floor` reads the same conjunction for this one namespace and refuses on `18`
+when the verdict is absent, stale or fail; `.github/workflows/governance-floor.yml` relays that exit
+code. The mechanism choice and why the alternatives were rejected are recorded once, in
+[the `ship` contract](../ship/contract.md#the-mechanism-choice).
+
 **The founder ruled this instead of a §CP row** ([veto on
 #5036](https://github.com/kamp-us/phoenix/issues/5036#issuecomment-5234614633), 2026-08-10):
 `claude-plugins/fabrika/**` gets **no** CODEOWNERS row and **no** §CP-boundary widening. The model

--- a/claude-plugins/fabrika/skills/ship/SKILL.md
+++ b/claude-plugins/fabrika/skills/ship/SKILL.md
@@ -66,6 +66,13 @@ never gated at this head; route to the gate that owns it — `review` for every 
 the `governance` skill for `governance` — and stop. Absence and staleness are refusals, never
 passes (#3944, ADR 0058).
 
+**Your reading of `blocked` is no longer the only thing enforcing the governance floor.**
+`.github/workflows/governance-floor.yml` runs `fabrika ship floor` on every PR and reds when a
+governance-root diff has no head-bound governance PASS — absent, stale, FAIL and a verdict from an
+author without write+ all red (#5408). This step and that job resolve the same verdict through the
+same `ship gate`, so they cannot disagree: if you read `ns governance` as anything but `pass`, the
+check is red too, and routing to the `governance` skill is what clears both.
+
 ## 4 — CI at the head, and only at the head
 
 ```bash
@@ -202,6 +209,7 @@ the surface and files the gap. No row here dead-ends on a bare error.
 | `.github/CODEOWNERS`, carrying a control-plane team row | `ship scope`'s §CP classification and `ship cp-approval`'s roster both derive from it, read at the PR's base ref — the branch the PR targets, never a literal trunk name | **fail-loud** — an unreadable boundary is exit `11`, never "ordinary"; a trivial or empty one is the printed `unknown` hold, and a zero-member roster is `stop zero-owners`. The run names `.github/CODEOWNERS` and points at front-door. |
 | A merge queue enabled on the PR's base branch | `ship enqueue` arms the queue's auto-merge; the queue, never this skill, performs the merge | **fail-loud** — a base with no queue has no arm to enter, so refuse before `ship enqueue` and end `refused — no merge queue on <base>`; `reconcile`'s `parked` covers only a queue-governed base. The run names the base branch and points at front-door — specified here. |
 | `.github/workflows/ci.yml`, gating the `merge_group` ref | `ship checks` reads its result at the head, and the queue awaits that context on `merge_group` before it merges | **fail-loud** — with no workflows at the head `ship checks` reports `facts workflows:0 runs:0` at rollup `pending` and never green, so the run stops rather than enqueue behind no gate; it names `.github/workflows/ci.yml` and points at front-door. |
+| `.github/workflows/governance-floor.yml`, running `fabrika ship floor` on every PR | it is what makes step 3's governance floor bind on a machine rather than on this prose (#5408) | **degrade** — the skill still refuses a `blocked` governance namespace itself, so the run is correct without the job; what is lost is enforcement against a run that never happened. Say so, name `.github/workflows/governance-floor.yml`, and point at front-door. |
 | The `status:awaiting-release` label | `ship release` is the dark-ship seam and the label is the whole action (ADR 0083) | **fail-loud** — a label write or its read-back failing is exit `8`/`9`, never `queued`; the run escalates that a real dark ship may be missing from the release queue, names the `status:awaiting-release` label, and points at front-door. |
 
 ## Eval enumeration (leaf-rule obligation)

--- a/claude-plugins/fabrika/skills/ship/contract.md
+++ b/claude-plugins/fabrika/skills/ship/contract.md
@@ -42,6 +42,7 @@ Named because a spec that leaves the substrate open makes the implementer guess 
 | `ship scope` | one PR's state, head, linked issue, class set with required namespaces, and §CP four-state classification | path partition against single-sourced maps, count-checked reads, and closing-keyword resolution are mechanical; what each state means for the run is judgment |
 | `ship cp-approval` | the ADR 0175 cardinality discharge: `discharge` / `stop` / `n/a` from head-bound signals only | the roster-cardinality case split and head-binding are a transcription of a ruled table; nothing in it is judgment (#2435 is what judgment did) |
 | `ship gate` | the verdict conjunction: every required namespace's in-force, current-head verdict, §CP advisory resolution and native-review fold included | in-force resolution (write-stamp ordering, staleness, authorization) is mechanical; what to do with `blocked` is judgment |
+| `ship floor` | whether the governance floor binds on this diff and is discharged at this head — `n/a` / `satisfied` / a refusal CI reds on | asking `ship gate` for the one `governance` namespace and seating the answer on an exit code is mechanical; nothing about the verdict itself is decided here |
 | `ship checks` | the head CI rollup — green/red/pending with the running/wedged split and the zero-checkset facts; `--wait` adds the bounded settle poll | latest-per-context dedupe, status vocabulary, and a budgeted poll are mechanical; the wedge remedy is a human's |
 | `ship evidence` | the SHA-bound run-evidence bundle read as five states: present / pending / failed / absent / unknown | the lookup chain and the positive-evidence rules for each state are mechanical; none of it is judgment |
 | `ship threads` | every unresolved review thread, fully paginated, with per-thread class facts | pagination, count proof, and author-type classification are mechanical; nit-vs-substantive is THE retained judgment and never enters this verb |
@@ -190,7 +191,7 @@ Stated once rather than repeated per block.
 
 ### The shared exit taxonomy
 
-All thirteen verbs allocate from one internal table, so a code means one thing across this
+All the verbs allocate from one internal table, so a code means one thing across this
 group. Where the codes overlap the shipped `report`/`triage`/`review` seats (`3`, `5`, `6`,
 `7`, `8`, `9`, `10`, `11`, `12`, `13`) they are **imported from the shipped package**
 (`packages/fabrika-cli/src/report/codes.ts`, `src/triage/codes.ts`, `src/review/codes.ts` —
@@ -214,10 +215,11 @@ authority.
 | `10` | a supplied classification value is off the closed vocabulary — an unknown `--require` namespace, a bad `--site` | `gate`, `disarm` |
 | `11` | a **precondition read failed** — nothing was proven and (for a write) nothing was written | all |
 | `12` | refused: the live head moved past the inspected `--sha` — a mutation formed over a tree that is no longer the PR | `enqueue`, `nudge` |
-| `13` | refused: a read completed but its scope is **provably incomplete** — received short of a declared count, or (where the platform declares none) pagination never reached a terminal page | `scope`, `cp-approval`, `gate`, `checks`, `evidence`, `threads`, `nudge`, `release`, `reconcile` |
+| `13` | refused: a read completed but its scope is **provably incomplete** — received short of a declared count, or (where the platform declares none) pagination never reached a terminal page | `scope`, `cp-approval`, `gate`, `checks`, `evidence`, `threads`, `nudge`, `release`, `reconcile`, `floor` |
 | `14`, `15` | *(deliberate gaps — `review`'s ACL and append-only seats; no verb here performs either)* | — |
 | `16` | refused: the target is **proven not in the state this write acts on** — nothing was mutated | `resolve`, `nudge` |
 | `17` | refused: the nudge's close landed and the reopen is **unconfirmed — the PR may be left closed**; a human re-opens before anything else happens | `nudge` |
+| `18` | refused: the diff touches a governance root and its `governance` verdict is **not** a head-bound PASS — `absent`, `stale` or `fail`. The one red that means *a human owes this PR a verdict*, kept off `16` so a CI job can tell it from "the floor could not be resolved" | `floor` |
 | `127` | the verb never ran (unresolved binary) | all |
 
 **This matrix owns what a code *means*; the per-verb tables own what *triggers* it.** Every
@@ -661,6 +663,141 @@ ns	governance	absent	-
   because the fold lives inside the same verb.
 - #1932 / #2005 / ADR 0111/0151/0226 — the advisory carrier's resolution rules, including the
   forged-marker workaround this forbids and the PASS-only rule.
+
+---
+
+## `ship floor`
+
+**Invocation**
+
+```
+fabrika ship floor 4321 --sha 03135b91 [--repo <owner/name>] [--json]
+```
+
+**Inputs**
+
+| Flag | Type | Required | Default | Description |
+|---|---|---|---|---|
+| *(positional)* | integer | yes | — | the pull-request number |
+| `--sha` | string | yes | — | the head the answer binds to (7–40 lowercase hex) |
+| `--repo` | string | no | resolved | the repository |
+| `--json` | boolean | no | `false` | emit the result object |
+
+**Output** — machine channel. Two lines: `floor\t<satisfied|n/a>\t<sha>` then
+`ns\tgovernance\t<pass|->`. With `--json`, an object with keys `outcome`, `sha`, `namespace`,
+`state` and `scanned`.
+
+**`n/a` is an answer about the diff, never a discharged verdict.** It means the changed files touch
+none of the four governance roots, so the floor does not bind — and the verb says so on stderr, in
+those words, because "the check was green" is exactly the reading that would make this gate
+decorative for the diffs it does not cover.
+
+<a id="the-mechanism-choice"></a>
+### Why a caller verb, and not a new exit code on `ship gate` (#5408)
+
+The floor had to become **machine-binding**: CI must read the governance verdict on a governance-root
+diff and red without it (founder ruling, 2026-08-11, routed onto #5408). Two mechanisms were on the
+table and the choice decides whether `gate-verb.ts` changes at all. **The caller was chosen.**
+
+- **Rejected — reseat `blocked` on the `3`+ proven-outcome band inside `ship gate`.** `blocked` is an
+  answer the verb *produced*, and `../../docs/cli-interface-convention.md` reserves `0` for exactly
+  that; moving it would break the convention's answer/refusal split for every caller at once — the
+  `ship` skill's step 3, which reads the `ns` lines to route repair, most of all. A gate that
+  refuses instead of answering also cannot report *which* namespace blocked, because `refuse()`
+  hardcodes empty stdout.
+- **Rejected — parse `gate\tblocked\t<sha>` in the workflow's `run:` step.** That puts the decision
+  in bash, which ADR 0228 forbids: a script relays a verb's answer and never derives the decision
+  itself. It would also need a second step to decide whether the floor applies at all, and that step
+  would be a second copy of `GOVERNANCE_ROOTS` that nothing reds when it drifts (#4604).
+- **Chosen — `ship floor`, a caller verb whose refusal *is* the decision.** `ship gate` is untouched
+  and keeps answering; `ship floor` asks it for the one `governance` namespace, reads the row back
+  and seats a non-PASS on `18`. The workflow relays an exit code and derives nothing. The verdict
+  resolution stays in one place, so there is no rival answer to drift.
+
+`ship floor` is therefore **not** a second conjunction and **not** an enqueue decision — `ship gate`
+remains the single merge authority. It reads one namespace, its own group's floor, and decides
+nothing about the others.
+
+### It refuses on WRONG, not only on MISSING
+
+The recurring defect is a guard that fires when the guarded thing is *absent* and stays silent when
+it is *present and wrong* (#5416, #4887). All four of these red on `18`, and each has a unit test:
+
+| The PR carries | Resolves | Why it still reds |
+|---|---|---|
+| no governance marker at all | `absent` | the #5293 / #5333 shape — the fail-open this verb closes |
+| `governance: FAIL @ <head>` | `fail` | a verdict was formed and it said no |
+| `governance: PASS @ <other-head>` | `stale` | the PASS attests a tree that is not this one (ADR 0058) |
+| `governance: PASS @ <head>` from an author without write+ | `absent` | the ADR 0055 ACL gate drops it before the polarity is read |
+
+**Exit status**
+
+| Code | Trigger |
+|---|---|
+| `7` | the PR is proven absent (404) or closed, or has zero changed files — whether it touches a governance root is unanswerable (ADR 0092) |
+| `11` | the PR, its changed-file list, or the conjunction underneath could not be read — the floor is UNKNOWN, never `n/a` |
+| `13` | the changed-file enumeration is provably short — a governance root could sit in the part nobody read |
+| `18` | the diff touches a governance root and its `governance` verdict at this head is `absent`, `stale` or `fail` |
+
+**Errors**
+
+| Message (stderr) | Code | Kind |
+|---|---|---|
+| `ship floor: PR #<n> not found in <repo>.` | 7 | refusal |
+| `ship floor: PR #<n> has zero changed files — whether it touches a governance root is unanswerable (ADR 0092).` | 7 | refusal |
+| `ship floor: cannot read PR #<n> in <repo>: <reason> — whether the floor binds is UNKNOWN, never "n/a".` | 11 | refusal |
+| `ship floor: cannot read the changed-file list for #<n>: <reason> — whether the floor binds is UNKNOWN, never "n/a".` | 11 | refusal |
+| ``ship floor: `ship gate` answered without a resolvable governance row — the floor is UNKNOWN, never discharged.`` | 11 | refusal |
+| `ship floor: received <k> of <m> changed files — a governance root could sit in the part nobody read.` | 13 | refusal |
+| `ship floor: #<n> touches a governance root and its governance verdict at <sha> is <state> — <remedy> (#5408).` | 18 | refusal |
+| `ship floor: #<n>'s diff touches no governance root, so the floor does not bind — this is an answer about the diff, not a discharged verdict.` | 0 | notice |
+
+**Scope** — one PR's changed-file list, count-checked against the declared total, plus whatever
+`ship gate` scans for the one required namespace (its own file list, the comments, the reviews and
+the comment authors' ACL). Both scanned counts reach stderr, this verb's first.
+
+**Where it is enforced.** `.github/workflows/governance-floor.yml`, job `floor`, on every
+`pull_request` with no `paths:` filter — the verb's own read of the changed files is the path
+decision, so there is no YAML copy of the root list to drift. The job relays the exit code and does
+nothing else. Making that context **required** is a repository-ruleset change and therefore a
+human's; until it is required the check is red-but-not-blocking, which is a weaker state than the
+ruling asks for and is recorded here rather than glossed.
+
+**Examples**
+
+```
+$ fabrika ship floor 5237 --sha be0ece1aac259dd906e257529ce3294441f16e85
+ship floor: scanned 8 changed files; 8 declared.
+ship floor: #5237's diff touches no governance root, so the floor does not bind — this is an answer about the diff, not a discharged verdict.
+floor	n/a	be0ece1aac259dd906e257529ce3294441f16e85
+ns	governance	-
+$ echo $?
+0
+```
+
+```
+$ fabrika ship floor 5481 --sha c9deb6047acc69da85b033a46b1fe05d2e0f5b91
+ship floor: scanned 1 changed file; 1 declared.
+ship gate: scanned 1 changed file; 1 declared.
+ship gate: scanned 2 comments; 2 declared.
+ship gate: scanned 0 reviews; pagination exhausted.
+ship floor: #5481 touches a governance root and its governance verdict at c9deb6047acc69da85b033a46b1fe05d2e0f5b91 is absent — no authorized governance verdict at this head — run the `governance` skill and emit one with `fabrika governance post` (#5408).
+$ echo $?
+18
+```
+
+**Grounding**
+
+- #5408 — the substituted control did not bind. `requiredWithFloor` was wired and correct, no
+  workflow invoked `ship gate` at all, and `blocked` exited 0, so #5293 and #5333 merged with no
+  governance verdict after the floor was live. The gap was the missing caller, not the floor.
+- ADR 0228 — a script relays a verb's answer and never derives the decision; that is why the
+  decision is a verb and the workflow step is one line.
+- #4604 — a path filter matching nothing presents as a pass, which is why this job has no `paths:`.
+- ADR 0055 / ADR 0058 — the write+ author gate and the SHA binding, both inherited from `ship gate`
+  rather than re-derived, which is what makes an unauthorized or stale PASS red here.
+- ADR 0092 — an unreadable answer reds. `11` and `13` are not softer than `18`; they are a different
+  fact, and neither is a pass.
 
 ---
 

--- a/packages/fabrika-cli/src/ship/codes.ts
+++ b/packages/fabrika-cli/src/ship/codes.ts
@@ -1,6 +1,6 @@
 /**
- * The one exit table all thirteen `ship` verbs allocate from, so a code means one thing across this
- * group whichever verb produced it.
+ * The one exit table every `ship` verb allocates from, so a code means one thing across this group
+ * whichever verb produced it.
  *
  * **Every seat this group shares is imported, never re-typed as a numeral.** `3`, `5`, `6`, `7`,
  * `8`, `9`, `10` and `11` come from `../report/codes.ts` and `../triage/codes.ts`; `12` and `13`
@@ -71,6 +71,16 @@ export const PROVEN_NOT_IN_STATE = 16;
  * folding it into {@link WRITE_UNKNOWN} would hide the fact the operator must act on immediately.
  */
 export const NUDGE_REOPEN_UNCONFIRMED = 17;
+
+/**
+ * Refused: the diff touches a governance root and its `governance` verdict is **not** a head-bound
+ * PASS — `absent`, `stale` or `fail` (`ship floor`, #5408).
+ *
+ * Its own seat rather than a fold into {@link PROVEN_NOT_IN_STATE}, because a CI job keys on it: this
+ * is the one refusal a red check means "a human owes this PR a governance verdict", and every other
+ * non-zero from that job means the floor could not be resolved at all.
+ */
+export const GOVERNANCE_FLOOR_UNMET = 18;
 
 /**
  * The unallocated codes. `4` is `report file`'s body-section seat and `14`/`15` are `review`'s ACL

--- a/packages/fabrika-cli/src/ship/command.ts
+++ b/packages/fabrika-cli/src/ship/command.ts
@@ -19,6 +19,7 @@ import {runCpApproval} from "./cp-approval-verb.ts";
 import {runDisarm} from "./disarm-verb.ts";
 import {runEnqueue} from "./enqueue-verb.ts";
 import {runEvidence} from "./evidence-verb.ts";
+import {runFloor} from "./floor-verb.ts";
 import {runGate} from "./gate-verb.ts";
 import {runNote} from "./note-verb.ts";
 import {runNudge} from "./nudge-verb.ts";
@@ -115,6 +116,19 @@ const gate = leafCommand(
 	Command.withShortDescription("The verdict conjunction over every required namespace."),
 	Command.withDescription(
 		"Resolve the verdict conjunction over every required namespace at one head. First stdout line is `gate\\t<satisfied|blocked>\\t<sha>`, then one `ns\\t<namespace>\\t<pass|fail|absent|stale>\\t<marker|advisory|review-fold|->` line per required namespace, in the order required; `satisfied` iff every one reads pass, and the coverage of the required set is asserted before that word is printed (#4520). In-force resolution is head-bound-first then by write stamp (#4189/#4200), ACL-gated fail-closed (ADR 0055). Both `absent` and `stale` block (#3944). The required set is a floor the verb raises from the diff itself: a PR touching `.decisions/`, `.claude/`, `.github/` or `claude-plugins/` gates on `governance` whether or not --require named it, so no session can turn the requirement off by omission (#5036). Exits 7 (PR proven absent or closed, or the diff has zero changed files), 10 (a --require value is not a gateable namespace), 11 (the changed-file list, comments, reviews or the ACL could not be read — the conjunction is UNKNOWN, never blocked and never satisfied), 13 (the changed-file or comment enumeration is provably short of the declared count, or the review read — which the platform gives no count for — never reached a terminal page with no `next` link). Example: fabrika ship gate 4321 --sha 03135b91 --require review-code --require review-doc",
+	),
+);
+
+const floor = leafCommand(
+	"floor",
+	{pr: prArg, sha: shaFlag, repo: repoFlag, json: jsonFlag},
+	Effect.fn(function* ({pr, sha, repo, json}) {
+		yield* emit(yield* runFloor({pr, sha, repo: Option.getOrNull(repo), json, env: process.env}));
+	}),
+).pipe(
+	Command.withShortDescription("Whether a governance-root diff carries its governance verdict."),
+	Command.withDescription(
+		"Decide whether the governance floor binds on this PR at one head, and seat the answer on an exit code a CI job can red on. Prints `floor\\t<satisfied|n/a>\\t<sha>` then `ns\\tgovernance\\t<pass|->`; `n/a` is a proven answer about the diff — it touches no governance root — and never a discharged verdict. The verdict itself is `ship gate`'s, asked for the one `governance` namespace, so this is not a second conjunction and it decides nothing about enqueue. Exits 7 (PR proven absent or closed, or zero changed files), 11 (the PR, its file list or the conjunction could not be read — the floor is UNKNOWN, never n/a), 13 (the changed-file enumeration is provably short — a governance root could sit in the part nobody read), 18 (the diff touches a governance root and its governance verdict is absent, stale or fail — the one refusal that means a human owes this PR a verdict, #5408). Example: fabrika ship floor 4321 --sha 03135b91",
 	),
 );
 
@@ -353,6 +367,7 @@ export const shipCommand = Command.make("ship").pipe(
 		scope,
 		cpApproval,
 		gate,
+		floor,
 		checks,
 		evidence,
 		threads,

--- a/packages/fabrika-cli/src/ship/floor-verb.ts
+++ b/packages/fabrika-cli/src/ship/floor-verb.ts
@@ -1,0 +1,190 @@
+/**
+ * `ship floor` — the governance floor as an exit code, so a CI job can red on it.
+ *
+ * `ship gate` seats `blocked` at exit 0, and that is right for its interface: `blocked` is an answer
+ * it proved, and a produced answer goes on 0 (`../verb.ts`). But an answer nobody reads enforces
+ * nothing. The floor landed in #5231 and two fabrika-tree PRs merged with no governance verdict
+ * anyway, because the only thing turning `blocked` into a stop was prose in the `ship` skill (#5408).
+ * A workflow step cannot read `gate\tblocked` on its own without deciding in bash, which ADR 0228
+ * forbids — so the decision is seated here and CI relays this verb's exit code.
+ *
+ * **One namespace, and the resolution is `runGate`'s own.** This verb is not a second conjunction: it
+ * asks `ship gate` for `governance` and reads that one line back, so there is one derivation of an
+ * in-force verdict in this package and no rival answer about any other namespace. It decides nothing
+ * about enqueue either — `ship gate` stays the single merge authority.
+ *
+ * **It refuses on WRONG, not only on MISSING.** `absent`, `stale` and `fail` all seat
+ * {@link GOVERNANCE_FLOOR_UNMET}; a verdict from an author without write+ resolves `absent` through
+ * the ADR 0055 ACL gate and lands there too. Only a head-bound PASS from an authorized author is
+ * satisfied.
+ */
+import {Effect} from "effect";
+import type {ChildProcessSpawner} from "effect/unstable/process";
+import {isRecord, parseJson} from "../io/json.ts";
+import {listPullFiles} from "../io/pulls.ts";
+import {touchesGovernanceRoot} from "../review/classes.ts";
+import {answer, refuse, type VerbOutcome} from "../verb.ts";
+import {
+	GOVERNANCE_FLOOR_UNMET,
+	INCOMPLETE_SCAN,
+	PRECONDITION_UNKNOWN,
+	ZERO_SCOPE,
+} from "./codes.ts";
+import {runGate} from "./gate-verb.ts";
+import {
+	badNumber,
+	inspectedSha,
+	NULL_TOKEN,
+	resolvePull,
+	resolveTargetRepo,
+	scannedLine,
+} from "./target.ts";
+
+const VERB = "ship floor";
+
+const NAMESPACE = "governance";
+
+export interface FloorOptions {
+	readonly pr: number;
+	readonly sha: string;
+	readonly repo: string | null;
+	readonly json: boolean;
+	readonly env: Readonly<Record<string, string | undefined>>;
+}
+
+/** What each blocking state means for the person reading a red check, and what clears it. */
+const REMEDY: Readonly<Record<string, string>> = {
+	absent:
+		"no authorized governance verdict at this head — run the `governance` skill and emit one with `fabrika governance post`",
+	stale:
+		"the in-force governance verdict is bound to another head — re-judge at this head and re-post (ADR 0058)",
+	fail: "the in-force governance verdict at this head is FAIL — repair the diff and re-post",
+};
+
+/**
+ * The one `ns` row this verb reads out of `ship gate --json`.
+ *
+ * Validated rather than cast: a payload that does not carry the row is UNKNOWN, and reading a missing
+ * row as anything at all is the shape that would let a parse change turn the floor off silently.
+ */
+const governanceState = (stdout: string): string | null => {
+	const parsed = parseJson(stdout);
+	if (!isRecord(parsed)) return null;
+	const namespaces = parsed.namespaces;
+	if (!Array.isArray(namespaces)) return null;
+	for (const row of namespaces) {
+		if (!isRecord(row)) continue;
+		if (row.name === NAMESPACE && typeof row.state === "string") return row.state;
+	}
+	return null;
+};
+
+export const runFloor = (
+	options: FloorOptions,
+): Effect.Effect<VerbOutcome, never, ChildProcessSpawner.ChildProcessSpawner> =>
+	Effect.gen(function* () {
+		const {pr, json} = options;
+		const bad = badNumber(VERB, "a pull-request number", pr);
+		if (bad !== null) return bad;
+		const bound = inspectedSha(VERB, options.sha);
+		if (typeof bound !== "string") return bound;
+
+		const resolved = yield* resolveTargetRepo(VERB, options.repo, options.env);
+		if (resolved._tag === "Refused") return resolved.outcome;
+		const repo = resolved.repo;
+
+		const target = yield* resolvePull(VERB, repo, pr, {
+			closedReason: "nothing to gate.",
+			unknownMessage: (reason) =>
+				`${VERB}: cannot read PR #${pr} in ${repo}: ${reason} — whether the floor binds is UNKNOWN, never "n/a".`,
+		});
+		if (target._tag === "Refused") return target.outcome;
+		const pull = target.pull;
+
+		const listed = yield* listPullFiles(repo, pr);
+		if (listed._tag === "Failure") {
+			return refuse(
+				PRECONDITION_UNKNOWN,
+				`${VERB}: cannot read the changed-file list for #${pr}: ${listed.reason} — whether the floor binds is UNKNOWN, never "n/a".`,
+			);
+		}
+		const scanned = [
+			scannedLine(VERB, listed.value.length, "changed file", `${pull.changedFiles} declared`),
+		];
+		if (listed.value.length < pull.changedFiles) {
+			return refuse(
+				INCOMPLETE_SCAN,
+				`${VERB}: received ${listed.value.length} of ${pull.changedFiles} changed files — a governance root could sit in the part nobody read.`,
+				scanned,
+			);
+		}
+		if (listed.value.length === 0) {
+			return refuse(
+				ZERO_SCOPE,
+				`${VERB}: PR #${pr} has zero changed files — whether it touches a governance root is unanswerable (ADR 0092).`,
+				scanned,
+			);
+		}
+
+		if (!touchesGovernanceRoot(listed.value)) {
+			const clear = `${VERB}: #${pr}'s diff touches no governance root, so the floor does not bind — this is an answer about the diff, not a discharged verdict.`;
+			return answer(
+				json
+					? JSON.stringify({
+							outcome: "n/a",
+							sha: bound,
+							namespace: NAMESPACE,
+							state: null,
+							scanned: listed.value.length,
+						})
+					: `floor\tn/a\t${bound}\nns\t${NAMESPACE}\t${NULL_TOKEN}`,
+				[...scanned, clear],
+			);
+		}
+
+		// The floor's whole resolution — marker read, ADR 0055 ACL, head-binding, in-force ordering —
+		// is `ship gate`'s, asked for this one namespace. A second file read cannot loosen the
+		// requirement: `--require governance` is passed because the read above already proved a
+		// governance root, so a diff that changed under us still gates.
+		const gated = yield* runGate({
+			pr,
+			sha: bound,
+			require: [NAMESPACE],
+			cp: false,
+			repo,
+			json: true,
+			env: options.env,
+		});
+		const relayed = [...scanned, ...gated.stderr];
+		if (gated.code !== 0) {
+			return {...gated, stderr: relayed};
+		}
+
+		const state = governanceState(gated.stdout);
+		if (state === null) {
+			return refuse(
+				PRECONDITION_UNKNOWN,
+				`${VERB}: \`ship gate\` answered without a resolvable ${NAMESPACE} row — the floor is UNKNOWN, never discharged.`,
+				relayed,
+			);
+		}
+		if (state !== "pass") {
+			return refuse(
+				GOVERNANCE_FLOOR_UNMET,
+				`${VERB}: #${pr} touches a governance root and its ${NAMESPACE} verdict at ${bound} is ${state} — ${REMEDY[state] ?? "the floor is not discharged"} (#5408).`,
+				relayed,
+			);
+		}
+		return answer(
+			json
+				? JSON.stringify({
+						outcome: "satisfied",
+						sha: bound,
+						namespace: NAMESPACE,
+						state,
+						scanned: listed.value.length,
+					})
+				: `floor\tsatisfied\t${bound}\nns\t${NAMESPACE}\t${state}`,
+			relayed,
+		);
+	});

--- a/packages/fabrika-cli/src/ship/floor-verb.unit.test.ts
+++ b/packages/fabrika-cli/src/ship/floor-verb.unit.test.ts
@@ -1,0 +1,156 @@
+/**
+ * The floor's whole value is that it refuses on a verdict that is WRONG, not only on one that is
+ * MISSING — a guard that fires on absence alone is the class #5416 and #4887 keep re-landing. So the
+ * battery below mutates the verdict four ways that all *look* like a governance verdict is there —
+ * FAIL at head, PASS on another head, PASS from an author without write+, a marker in a neighbouring
+ * namespace — and asserts each one still reds.
+ */
+import {Effect} from "effect";
+import {describe, expect, it} from "vitest";
+import {errOut, fakeShell, okOut} from "../fakes.test-support.ts";
+import type {ExecResult} from "../io/exec.ts";
+import {
+	GOVERNANCE_FLOOR_UNMET,
+	INCOMPLETE_SCAN,
+	PRECONDITION_UNKNOWN,
+	ZERO_SCOPE,
+} from "./codes.ts";
+import {comments, ENV, files, HEAD, OTHER_HEAD, pull, reviews} from "./fixtures.test-support.ts";
+import {runFloor} from "./floor-verb.ts";
+
+const PULL = /^gh api repos\/o\/r\/pulls\/4321$/;
+const FILES = /^gh api --paginate repos\/o\/r\/pulls\/4321\/files/;
+const COMMENTS = /^gh api --paginate repos\/o\/r\/issues\/4321\/comments/;
+const REVIEWS = /^gh api -i repos\/o\/r\/pulls\/4321\/reviews/;
+const ACL = /^gh api repos\/o\/r\/collaborators\/[^ ]+\/permission/;
+
+/** A fabrika-tree diff — `claude-plugins/` is one of the four governance roots. */
+const FABRIKA_TREE = [
+	FILES,
+	files("claude-plugins/fabrika/skills/ship/SKILL.md", "apps/web/src/b.ts"),
+] as const;
+
+const options = {pr: 4321, sha: HEAD, repo: null, json: false, env: ENV};
+
+const run = (
+	script: ReadonlyArray<readonly [RegExp, ExecResult]>,
+	overrides: Partial<typeof options> = {},
+) =>
+	Effect.runPromise(
+		Effect.provide(runFloor({...options, ...overrides}), fakeShell([...script]).layer),
+	);
+
+const marker = (namespace: string, polarity: string, sha: string): string =>
+	`${namespace}: ${polarity} @ ${sha} — the clause`;
+
+/** A governance-root PR carrying exactly one comment, with the ACL answer the test wants. */
+const withVerdict = (body: string, permission = "write") =>
+	[
+		[PULL, pull({comments: 1})],
+		FABRIKA_TREE,
+		[COMMENTS, comments({id: 1, body})],
+		[REVIEWS, reviews()],
+		[ACL, okOut(permission)],
+	] as const;
+
+describe("runFloor", () => {
+	it("is satisfied on a head-bound PASS from an authorized author", async () => {
+		const out = await run([...withVerdict(marker("governance", "PASS", HEAD))]);
+		expect(out.code).toBe(0);
+		expect(out.stdout).toBe(`floor\tsatisfied\t${HEAD}\nns\tgovernance\tpass\n`);
+	});
+
+	it("answers n/a — not satisfied — when the diff touches no governance root", async () => {
+		const out = await run([
+			[PULL, pull()],
+			[FILES, files("apps/web/src/a.ts", "apps/web/src/b.ts")],
+		]);
+		expect(out.code).toBe(0);
+		expect(out.stdout).toBe(`floor\tn/a\t${HEAD}\nns\tgovernance\t-\n`);
+		expect(out.stderr.join("\n")).toContain("not a discharged verdict");
+	});
+
+	it("reds when the verdict is ABSENT — the #5293/#5333 shape", async () => {
+		const out = await run([
+			[PULL, pull({comments: 0})],
+			FABRIKA_TREE,
+			[COMMENTS, comments()],
+			[REVIEWS, reviews()],
+		]);
+		expect(out.code).toBe(GOVERNANCE_FLOOR_UNMET);
+		expect(out.stdout).toBe("");
+		expect(out.stderr.join("\n")).toContain("is absent");
+	});
+
+	it("reds when the verdict is WRONG: a FAIL at this very head", async () => {
+		const out = await run([...withVerdict(marker("governance", "FAIL", HEAD))]);
+		expect(out.code).toBe(GOVERNANCE_FLOOR_UNMET);
+		expect(out.stderr.join("\n")).toContain("is fail");
+	});
+
+	it("reds when the verdict is WRONG: a PASS bound to another head", async () => {
+		const out = await run([...withVerdict(marker("governance", "PASS", OTHER_HEAD))]);
+		expect(out.code).toBe(GOVERNANCE_FLOOR_UNMET);
+		expect(out.stderr.join("\n")).toContain("is stale");
+	});
+
+	it("reds when the verdict is WRONG: a head-bound PASS from an author without write+", async () => {
+		const out = await run([...withVerdict(marker("governance", "PASS", HEAD), "read")]);
+		expect(out.code).toBe(GOVERNANCE_FLOOR_UNMET);
+		expect(out.stderr.join("\n")).toContain("is absent");
+	});
+
+	it("reds when the verdict is WRONG: the PASS is in a neighbouring namespace", async () => {
+		const out = await run([...withVerdict(marker("review-skill", "PASS", HEAD))]);
+		expect(out.code).toBe(GOVERNANCE_FLOOR_UNMET);
+		expect(out.stderr.join("\n")).toContain("is absent");
+	});
+
+	it("fails closed when the ACL cannot be read — UNKNOWN is never a discharge", async () => {
+		const out = await run([
+			[PULL, pull({comments: 1})],
+			FABRIKA_TREE,
+			[COMMENTS, comments({id: 1, body: marker("governance", "PASS", HEAD)})],
+			[REVIEWS, reviews()],
+			[ACL, errOut("HTTP 403")],
+		]);
+		expect(out.code).toBe(PRECONDITION_UNKNOWN);
+		expect(out.stdout).toBe("");
+	});
+
+	it("fails closed when the changed-file list cannot be read", async () => {
+		const out = await run([
+			[PULL, pull()],
+			[FILES, errOut("HTTP 502")],
+		]);
+		expect(out.code).toBe(PRECONDITION_UNKNOWN);
+		expect(out.stderr.join("\n")).toContain('never "n/a"');
+	});
+
+	it("refuses a short file list — a governance root could sit in the part nobody read", async () => {
+		const out = await run([
+			[PULL, pull({changedFiles: 9})],
+			[FILES, files("apps/web/src/a.ts")],
+		]);
+		expect(out.code).toBe(INCOMPLETE_SCAN);
+	});
+
+	it("refuses a zero-file diff rather than answering n/a (ADR 0092)", async () => {
+		const out = await run([
+			[PULL, pull({changedFiles: 0})],
+			[FILES, files()],
+		]);
+		expect(out.code).toBe(ZERO_SCOPE);
+	});
+
+	it("emits the same two outcomes as JSON", async () => {
+		const out = await run([...withVerdict(marker("governance", "PASS", HEAD))], {json: true});
+		expect(JSON.parse(out.stdout)).toEqual({
+			outcome: "satisfied",
+			sha: HEAD,
+			namespace: "governance",
+			state: "pass",
+			scanned: 2,
+		});
+	});
+});


### PR DESCRIPTION
The founder vetoed making fabrika's tree control-plane and substituted a control: a required `governance` verdict on any diff touching `.decisions/`, `.claude/`, `.github/` or `claude-plugins/`. That control did not bind. `ship gate` derived the requirement correctly, but it reports `blocked` at exit 0, no workflow ran it at all, and the only thing turning `blocked` into a stop was a paragraph in the ship skill — so #5293 and #5333 both merged with no governance verdict after the floor shipped.

This adds the missing caller. `fabrika ship floor` asks `ship gate` for the one `governance` namespace and **refuses** when the verdict is not a head-bound PASS; a new workflow runs it on every PR and relays its exit code. `ship gate` itself is untouched.

Fixes #5408

## What binds now, and on which condition

| Half | Condition it fires on |
|---|---|
| `ship floor` (the decision) | the PR's changed files touch a governance root **and** the `governance` namespace at the given head resolves to `absent`, `stale` or `fail` → exit `18`. A verdict from an author without write+ resolves `absent` through the ADR 0055 ACL gate, so it reds too. Only a head-bound PASS from an authorized author is `satisfied`. |
| `.github/workflows/governance-floor.yml` (the enforcement) | any `pull_request`, no `paths:` filter. Every non-zero exit reds the job: `18` means a human owes this PR a verdict; `7` / `11` / `13` mean the floor could not be resolved at all, which is UNKNOWN and never a pass (ADR 0092). |

## Proving the unbound path is closed, not just that the happy path works

A guard that fires on ABSENT but stays quiet on WRONG is the defect class this repo keeps re-landing (#5416, #4887), so the mutation battery is the point of `src/ship/floor-verb.unit.test.ts`. Each row is a PR that *looks* like it carries a governance verdict, and each one still reds on `18`:

- `governance: FAIL @ <head>` — present, head-bound, and negative.
- `governance: PASS @ <other-head>` — present and positive, bound to a tree nobody judged (ADR 0058).
- `governance: PASS @ <head>` from an author without write+ — present, positive, head-bound, unauthorized.
- `review-skill: PASS @ <head>` and nothing else — a PASS in the neighbouring namespace.

Plus the fail-closed rows: an unreadable ACL, an unreadable file list, a short file list, and a zero-file diff all refuse rather than answering `n/a`.

**Run against live PRs, not asserted.** On PR #5481 (a real open `claude-plugins/**` diff with no governance marker) the verb exits `18` and names the state; on PR #5237 (an `apps/web` diff) it answers `n/a` at exit 0. Both transcripts are in the contract's Examples block, copied from the runs. This PR's own `governance-floor` check is the third data point: this diff touches `.github/` and `claude-plugins/`, so the job **is expected to be red here** until a governance verdict is posted at head. That red is the acceptance criterion being met, not a build failure.

## The mechanism choice, and why the two alternatives lost

Recorded in full at `claude-plugins/fabrika/skills/ship/contract.md`, section *Why a caller verb, and not a new exit code on `ship gate`*. In short:

- **Reseating `blocked` on the `3`+ band inside `ship gate`** breaks the interface convention's answer/refusal split for every existing caller at once, and a refusal cannot report *which* namespace blocked, because `refuse()` hardcodes empty stdout.
- **Parsing `gate\tblocked` in the workflow's `run:` step** puts the decision in bash, which ADR 0228 forbids, and needs a second step to decide whether the floor applies — a second copy of `GOVERNANCE_ROOTS` that nothing reds when it drifts (#4604).
- **A caller verb** leaves `ship gate` answering as before, keeps one derivation of the verdict, and lets the workflow relay an exit code and derive nothing.

`ship floor` is not a second conjunction and decides nothing about enqueue — it reads one namespace. `ship gate` stays the single merge authority.

## Deviations

**1. Scope — the title's "both halves" is not what this PR delivers, by the issue's own instruction.** Said: the title reads *Control substituted for fabrika §CP does not bind (both halves)*. Did: delivered the enforcement half only. Why: the issue body's **Scope after split** section states this issue is now the enforcement half only and that the visibility half is #5409. Disposition: no action needed — #5409 owns the digest half.

**2. The check is red-but-not-required, and the last step is an operator's.** Said: AC 2 asks for a red *required* check. Did: shipped the job; it is not in the `main protection` ruleset's `required_status_checks` list, which today holds exactly `ci-required`, `scan changed files for leaks` and `validate skill frontmatter` (read live). Why: adding a context to a repository ruleset is a server-side control-plane change, not a diff, and not mine to make. What binds today: the red check makes `ship checks` roll up `red` at the head, so the shipper refuses to enqueue — the autonomous merge path is closed. A human with admin can still override, which the ruleset entry is what would prevent. Disposition: **for the founder, at bank time** — add the context `a governance-root diff carries a governance verdict at its head` to ruleset `17377992`. Flagged rather than done.

**3. One platform claim is not yet verified at the surface that matters.** Said: the job runs with `permissions: contents: read, pull-requests: read`. Did: verified the whole verb against live PRs with a local `gh` token, not with a workflow `GITHUB_TOKEN`. Why: the ACL read (`GET /repos/{o}/{r}/collaborators/{u}/permission`) is the one call whose availability to `GITHUB_TOKEN` at these permissions I could not establish from source. Disposition: **for the reviewer to judge, and this PR's own run answers it** — if the token cannot read the ACL, the job reds on `11` with `cannot read the ACL for <login>` rather than passing, which is the fail-closed direction; the fix is then a permissions line, and the check on this PR will say so plainly.

**4. Prose in the ship SKILL was changed, not just pointed at.** Said: AC 6 asks that step 3 no longer stand alone as the enforcement. Did: added a paragraph to step 3 naming the workflow, and a row to the skill's repo-surface table with `degrade` as the when-missing outcome. Why: the skill still refuses `blocked` itself, so a repo without the workflow is not broken — what is lost is enforcement against a run that never happened, and that is what the row says. Disposition: no action needed.