### PR TITLE
fix(fabrika): demote the eval gate's graded leg to never-red (#5498)

### DIFF
--- a/.github/workflows/fabrika-eval-gate.yml
+++ b/.github/workflows/fabrika-eval-gate.yml
@@ -1,7 +1,7 @@
 name: fabrika-eval-gate
 
-# The ruled #4637-B bar as a merge gate (#4681): the 100% incident-regression floor, the 90% graded
-# rate, and spend at or below the committed v1 baseline. The whole decision lives in
+# The ruled #4637-B bar, judged on every PR (#4681): the 100% incident-regression floor, the 90%
+# graded rate, and spend at or below the committed v1 baseline. The whole decision lives in
 # `fabrika grade gate` and this job only relays its exit code — a script relays a verb's answer and
 # never derives the decision (ADR 0228). Nothing here decides which paths count as a skill change,
 # which eval record is in force, or whether a rate clears the bar; the verb reads the PR's head,
@@ -14,8 +14,11 @@ name: fabrika-eval-gate
 # than a YAML condition nobody can red (the #4604 shape, where a path filter matching nothing
 # presented as a pass).
 #
-# No model runs here and no model credential is needed: the graded leg VERIFIES the head-bound eval
-# record the review stage recorded (the founder's cost ruling on #4649) and never runs the suite.
+# No model runs here and no model credential is needed: the graded leg reads back the head-bound eval
+# record the review stage recorded (the founder's cost ruling on #4649) and never runs the suite. It
+# also never reds — the founder's 2026-08-13 ruling on #4681 demoted it to reporting ("i dont wanna
+# wait 1h for every skill update"), so it prints the rate at head or the measurement debt and nothing
+# else. The bar keeps its teeth as the RELEASE criterion (#5498).
 on:
   pull_request:
 
@@ -31,10 +34,11 @@ concurrency:
 
 jobs:
   gate:
-    # The name states what the job ENFORCES TODAY, not what the ruled bar says. The floor runs no
-    # incident case until #5431 arms one and CI runs no suite to price spend against, so a name
-    # promising those two would be a green check advertising an enforcement nobody performed — the
-    # #4604 shape. Rename it when a leg is actually armed, never before.
+    # The name states what the job ENFORCES TODAY, not what the ruled bar says. The graded leg only
+    # reports since the 2026-08-13 demotion (#5498), the floor runs no incident case until #5431 arms
+    # one, and CI runs no suite to price spend against — so a name promising any of the three would be
+    # a green check advertising an enforcement nobody performed, the #4604 shape. Rename it when a leg
+    # is actually armed, never before.
     #
     # It spells the verb `grade`, the #5461 alias of `eval`, because this string is agent-facing: a
     # coder reading a red check copies the command out of it, and a graded-run command spelled with
@@ -44,7 +48,7 @@ jobs:
     # required contexts, and `ship checks` reads check runs name-blind apart from the
     # `^deploy`/`^cleanup` informational denylist in `src/review/rollup.ts`, which neither spelling
     # matches. Nothing in the repo matches this string literally.
-    name: "fabrika grade gate: graded 90% enforced at head; floor + spend report, not yet enforced"
+    name: "fabrika grade gate: graded reports only, never blocks; floor + spend report, not yet enforced"
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4.2.2
@@ -58,10 +62,10 @@ jobs:
 
       - run: pnpm install --frozen-lockfile
 
-      # Exits 0 when every leg of the bar is met. Each red names its reason and seats its own code:
-      # 7 zero scope, 15 spend above the v1 baseline (or incomparable), 18 stale (the newest record
-      # is bound to an older commit), 21 missing (no record for this head), 22 below the 90% bar,
-      # 23 an armed incident case did not pass. See #4681.
+      # Exits 0 unless a still-enforced leg reds, each on its own seat: 7 zero scope, 15 spend above
+      # the v1 baseline (or incomparable), 23 an armed incident case did not pass. The graded seats —
+      # 18 stale, 21 missing, 22 below the bar — are unreachable from a PR since the demotion (#5498);
+      # they remain the release criterion's vocabulary. See #4681.
       - name: Decide the ruled bar
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/packages/fabrika-cli/src/eval/README.md
+++ b/packages/fabrika-cli/src/eval/README.md
@@ -1280,15 +1280,18 @@ fabrika eval gate 5432                       # over a pull request: head, change
 fabrika eval gate --head <sha> --changed changed.txt --record result.md   # offline: no network, no credential
 ```
 
-### CI does not run the evals; CI verifies that the review did
+### CI does not run the evals; CI reports what the review recorded
 
 No model executes here and no model credential is needed. The founder ruled on
 [#4649](https://github.com/kamp-us/phoenix/issues/4649#issuecomment-5153280445) that model runs stay
 out of CI — **the recorded reason is cost, not principle** — so the graded leg reads back the
 head-bound eval record the review stage left (#4678, ADR 0253) and compares a string and a number.
-That is why `missing` and `stale` are red conditions in their own right: they are the two ways the
-review step can be skipped by forgetting, and absence that passes is the guarantee this epic exists
-to restore.
+
+**The graded leg no longer reds** ([#5498](https://github.com/kamp-us/phoenix/issues/5498), executing
+the founder's 2026-08-13 ruling on #4681: *"i dont wanna wait 1h for every skill update"*). Missing,
+stale, unrecordable and below-bar are all printed lines now — the score at head, or the measurement
+debt the weekly sweep will collect — and none of them fails a PR. The bar is untouched as the
+**release** criterion: merging is cheap, releasing is earned.
 
 The legs that never needed a model still execute: the deterministic regression floor runs its armed
 cases once through the tier, and the spend leg folds ledger rows a meter already reconstructed.
@@ -1304,20 +1307,24 @@ cases once through the tier, and the spend leg folds ledger rows a meter already
 | `22` | `below-bar` | a recorded graded rate under the ruled `0.9` |
 | `23` | `regression-floor` | an armed incident case did not pass — 100%, no tolerance, no quarantine |
 
+**Three of those seats have no producer on a PR.** `18`, `21` and `22` are the graded leg's, and
+since the demotion (#5498) it reports instead of redding — they stay as the release criterion's
+vocabulary, unreachable from `fabrika grade gate`.
+
 Every red is printed; the highest-precedence one seats `$?`. Four seats are reused rather than
 re-invented: `7`, `15` and `18` already mean exactly these facts elsewhere in this group.
 
 **The trend is reported and gates nothing** (ADR 0252 §4, the #4766 guardrail): it rides as an
 advisory line and never changes an exit status. Arming it is a later ADR's edit to `judgeGraded`.
 
-### `missing` and `stale` name their cure and its run site
+### Every graded debt line names the run site
 
-Both are **recoverable states with a named next action**, and neither is a blocker the build lane
-that tripped it can clear. The harness's worktree-isolation guard refuses the eval runner inside a
-lane outright ([#5406](https://github.com/kamp-us/phoenix/issues/5406) — not this repo's code and not
-fixable here), so **a graded run executes in a plain, non-worktree session**. A lane that hits either
-red **hands the measurement off**; a red that said only "re-run the suite" would be naming a cure the
-lane structurally cannot perform, which is why both details carry the site.
+A debt line is a **named next action**, and it is not one the build lane reading it can take. The
+harness's worktree-isolation guard refuses the eval runner inside a lane outright
+([#5406](https://github.com/kamp-us/phoenix/issues/5406) — not this repo's code and not fixable
+here), so **a graded run executes in a plain, non-worktree session**. A lane that reads a debt line
+**hands the measurement off**; a line that said only "run the suite" would be naming an act the lane
+structurally cannot perform, which is why each carries the site.
 
 ### A leg that measured nothing is never reported as a leg that passed
 
@@ -1333,11 +1340,15 @@ statement that the bar is met. NOT MEASURED: ... Measured and met: scope.
 ```
 
 `gate: GREEN — all N leg(s) of the ruled bar were measured and met` is reachable **only** when every
-leg measured. The check-run `name:` in the workflow follows the same rule: it states what the job
-enforces **today** (the graded 90% at head), not what the ruled bar says, because a green check
-advertising an enforcement nobody performed is the #4604 shape arriving from the reporting side.
-Today the floor runs no case and CI prices no spend, so **the graded leg is the only enforced one**;
-rename the job when a leg is armed, never before.
+leg measured. A demoted graded state is `unmeasured` for exactly this reason: the leg relays a number
+it no longer judges, so it establishes nothing and the summary keeps saying so — under-claiming, the
+one safe direction. Its line reads `graded: REPORTED, NOT ENFORCED — …`.
+
+The check-run `name:` in the workflow follows the same rule: it states what the job enforces
+**today**, not what the ruled bar says, because a green check advertising an enforcement nobody
+performed is the #4604 shape arriving from the reporting side. Today the graded leg only reports, the
+floor runs no case and CI prices no spend, so **no leg of the bar is enforced on a PR**; rename the
+job when a leg is armed, never before.
 
 ### The trigger split lives in the verb, not in the workflow
 
@@ -1349,9 +1360,9 @@ changed files, anchored on `claude-plugins/fabrika/skills/`.
 That filter is the one #4604 got wrong on the v1 side: a `packages/`-anchored list that never reached
 a skills directory, so a skill change matched nothing and the gate reported green. `changedSkills`
 takes its prefixes as a parameter for exactly that reason — `gate.unit.test.ts` runs the same
-decision twice over one changed-path set and asserts that the mis-scoped run turns a `missing` red
-into a pass. The property held is not that the filter matches, but that a wrong one is visible as the
-difference between a red and a green.
+decision twice over one changed-path set and asserts that the mis-scoped run erases the
+measurement-debt line the correctly-scoped one prints. The property held is not that the filter
+matches, but that a wrong one is visible in the artifact a reader acts on.
 
 ### The arming sidecar, and why the floor is honest about what it cannot run
 

--- a/packages/fabrika-cli/src/eval/gate.cli.test.ts
+++ b/packages/fabrika-cli/src/eval/gate.cli.test.ts
@@ -1,26 +1,27 @@
 /**
  * The merge gate watched failing — the exit status and stream discipline a CI job actually relays.
  *
- * #4681 asks for the guard to be *observed* red on three deliberately-constructed cases rather than
- * assumed: a genuinely failing eval case, a **missing** result, and a **stale** result bound to an
- * older commit. The last two are the paths by which the review-stage step can be skipped by
- * forgetting, so they are the ones a green would hide. Each `it` here runs the real bin in a
- * subprocess and asserts the code a `run:` step would see (`.patterns/subprocess-test-budget.md`
- * bounds the spawn count; every branch of the decision itself lives in `./gate.unit.test.ts`).
+ * #4681 asks for the guard to be *observed* rather than assumed, and the 2026-08-13 demotion (#5498)
+ * splits what there is to observe: a genuinely failing eval case is still watched **red**, while the
+ * graded states — **missing**, **stale**, **below-bar** — are watched **green with the debt printed**,
+ * which is the demotion's whole claim and the one an assumption would get wrong. Each `it` here runs
+ * the real bin in a subprocess and asserts the code a `run:` step would see
+ * (`.patterns/subprocess-test-budget.md` bounds the spawn count; every branch of the decision itself
+ * lives in `./gate.unit.test.ts`).
  *
  * The floor runs against a corpus authored here rather than the committed one, because the assertion
  * is about the gate's behaviour on a failing case and the committed corpus has none armed yet
  * (#5431). The PR path gets one run through a `gh` shim, which proves the verb resolves head,
  * changed paths and records off the platform — the shape the workflow depends on.
  */
-import {execFileSync} from "node:child_process";
+import {spawnSync} from "node:child_process";
 import {chmodSync, mkdirSync, mkdtempSync, writeFileSync} from "node:fs";
 import {tmpdir} from "node:os";
 import {join} from "node:path";
 import {fileURLToPath} from "node:url";
 import {describe, expect, it} from "vitest";
 import {SUBPROCESS_TEST_TIMEOUT_MS} from "../test-budget.ts";
-import {BELOW_BAR, MISSING_RESULT, REGRESSION_FLOOR, STALE_HEAD, ZERO_SCOPE} from "./codes.ts";
+import {REGRESSION_FLOOR, ZERO_SCOPE} from "./codes.ts";
 
 const BIN = fileURLToPath(new URL("../bin.ts", import.meta.url));
 
@@ -123,18 +124,14 @@ interface Run {
 	readonly stderr: string;
 }
 
+// `spawnSync` rather than `execFileSync` so a run that EXITS 0 still yields its stderr: since the
+// demotion the interesting graded cases are green, and their diagnostics are the thing to assert.
 const gate = (args: ReadonlyArray<string>, env: Record<string, string> = {}): Run => {
-	try {
-		const stdout = execFileSync(process.execPath, [BIN, "eval", "gate", ...args], {
-			encoding: "utf8",
-			env: {...process.env, FABRIKA_SKIP_INFER: "1", CLAUDE_PIPELINE_REPO: "o/r", ...env},
-			stdio: ["pipe", "pipe", "pipe"],
-		});
-		return {code: 0, stdout, stderr: ""};
-	} catch (err) {
-		const failure = err as {status?: number; stdout?: string; stderr?: string};
-		return {code: failure.status ?? -1, stdout: failure.stdout ?? "", stderr: failure.stderr ?? ""};
-	}
+	const run = spawnSync(process.execPath, [BIN, "eval", "gate", ...args], {
+		encoding: "utf8",
+		env: {...process.env, FABRIKA_SKIP_INFER: "1", CLAUDE_PIPELINE_REPO: "o/r", ...env},
+	});
+	return {code: run.status ?? -1, stdout: run.stdout ?? "", stderr: run.stderr ?? ""};
 };
 
 describe("fabrika eval gate, watched failing", {timeout: SUBPROCESS_TEST_TIMEOUT_MS}, () => {
@@ -157,15 +154,18 @@ describe("fabrika eval gate, watched failing", {timeout: SUBPROCESS_TEST_TIMEOUT
 		expect(run.stderr).toContain("no tolerance and no quarantine");
 	});
 
-	it("(b) reds `missing` when a skill changed and no result was recorded", () => {
+	// (b), (c) and (d) are the demotion watched live: a skill change with no record, one whose newest
+	// record is stale, and one recorded under the bar all exit 0 and print what they know instead.
+	it("(b) goes green and prints the debt when a skill changed and no result was recorded", () => {
 		const run = gate(fixture({command: "true", changed: [SKILL_PATH]}).args);
-		expect(run.code).toBe(MISSING_RESULT);
-		expect(run.stdout).toBe("");
-		expect(run.stderr).toContain("missing");
-		expect(run.stderr).toContain("plain, non-worktree session");
+		expect(run.code).toBe(0);
+		expect(run.stdout).toContain("graded: REPORTED, NOT ENFORCED");
+		expect(run.stdout).toContain("a measurement is owed");
+		expect(run.stdout).toContain("plain, non-worktree session");
+		expect(run.stdout).toContain("gate: NOT FULLY MEASURED");
 	});
 
-	it("(c) reds `stale` when the newest result is bound to an older commit", () => {
+	it("(c) goes green and names the older commit when the newest result is stale", () => {
 		const run = gate(
 			fixture({
 				command: "true",
@@ -173,16 +173,19 @@ describe("fabrika eval gate, watched failing", {timeout: SUBPROCESS_TEST_TIMEOUT
 				records: [recordBytes(OLDER, 10, 10)],
 			}).args,
 		);
-		expect(run.code).toBe(STALE_HEAD);
-		expect(run.stderr).toContain(OLDER);
+		expect(run.code).toBe(0);
+		expect(run.stdout).toContain(OLDER);
+		expect(run.stdout).toContain("graded: REPORTED, NOT ENFORCED");
 	});
 
-	it("reds `below-bar` on a recorded rate under the ruled bar", () => {
+	it("(d) goes green and still prints the score on a recorded rate under the ruled bar", () => {
 		const run = gate(
 			fixture({command: "true", changed: [SKILL_PATH], records: [recordBytes(HEAD, 8, 10)]}).args,
 		);
-		expect(run.code).toBe(BELOW_BAR);
-		expect(run.stderr).toContain("below-bar");
+		expect(run.code).toBe(0);
+		expect(run.stdout).toContain("0.8");
+		expect(run.stdout).toContain("under the ruled bar of 0.9");
+		expect(run.stdout).toContain("gate: NOT FULLY MEASURED");
 	});
 
 	it("passes a skill change whose recorded rate is at the bar", () => {
@@ -217,7 +220,7 @@ esac
 `;
 
 describe("fabrika eval gate, over a pull request", {timeout: SUBPROCESS_TEST_TIMEOUT_MS}, () => {
-	it("resolves head, changed paths and records off the platform and reds `missing`", () => {
+	it("resolves head, changed paths and records off the platform, and merges green on the debt", () => {
 		const at = fixture({command: "true", changed: []});
 		const shimDir = mkdtempSync(join(tmpdir(), "fabrika-gate-shim-"));
 		const state = join(shimDir, "state");
@@ -253,8 +256,9 @@ describe("fabrika eval gate, over a pull request", {timeout: SUBPROCESS_TEST_TIM
 			],
 			{PATH: `${shimDir}:${process.env.PATH ?? ""}`, GH_STATE: state},
 		);
-		expect(run.code).toBe(MISSING_RESULT);
+		expect(run.code).toBe(0);
 		expect(run.stderr).toContain(`o/r#9041 at ${HEAD}`);
 		expect(run.stderr).toContain("1 changed path(s)");
+		expect(run.stdout).toContain("graded: REPORTED, NOT ENFORCED");
 	});
 });

--- a/packages/fabrika-cli/src/eval/gate.ts
+++ b/packages/fabrika-cli/src/eval/gate.ts
@@ -5,12 +5,13 @@
  * says a script relays a verb's answer and never derives the decision, so every comparison that
  * could be re-spelled in YAML lives here instead.
  *
- * **The graded leg verifies; it does not run.** The founder ruled on #4649 (comment 5153280445) that
- * no model executes inside CI — the reason recorded is cost, not principle. The review stage runs the
- * five-run graded axis and leaves a head-bound eval record (#4678, ADR 0253); this leg reads that
- * record back and compares a string and a number. So `missing` and `stale` are red conditions in
- * their own right: they are the two ways the review step can be skipped by forgetting, and absence
- * that passes is exactly the guarantee the epic exists to restore.
+ * **The graded leg reports; it neither runs nor reds (founder ruling 2026-08-13 on #4681, #5498).** No
+ * model executes inside CI — recorded reason cost, not principle (#4649) — and since the ruling no
+ * graded state fails a PR either: "i dont wanna wait 1h for every skill update". The leg still reads
+ * back the head-bound eval record the review stage leaves (#4678, ADR 0253) and prints what it knows:
+ * the rate at head, or the measurement debt when there is none. Every state that used to red —
+ * missing, stale, unrecordable, below-bar — is now a printed line. The bar is unchanged as the
+ * RELEASE criterion; merging is cheap again, releasing is earned.
  *
  * **Everything else still executes here, because none of it ever needed a model.** The deterministic
  * regression floor runs its cases once through the tier (#4677), and the spend leg is arithmetic over
@@ -80,7 +81,12 @@ export const changedSkills = (
 	return [...names].sort();
 };
 
-/** The six ruled red conditions. Each names why the change is refused; none is a bare failure. */
+/**
+ * The six ruled red conditions. Each names why the change is refused; none is a bare failure.
+ *
+ * `missing`, `stale` and `below-bar` have had no producer since the graded leg was demoted (#5498):
+ * they stay because they are the release criterion's vocabulary, which the ruling left untouched.
+ */
 export type GateReason =
 	| "zero-scope"
 	| "regression-floor"
@@ -289,24 +295,38 @@ export const latestPerCell = (records: ReadonlyArray<EvalRecord>): ReadonlyArray
 };
 
 /**
- * Where the measurement this leg reads back is taken, named in both reds that a run cures.
+ * Where the measurement is taken, named on every debt line so the reader knows who can take it.
  *
- * `missing` and `stale` are recoverable states, not terminal failures, and neither is a blocker the
- * build lane that tripped it can clear: the harness's worktree-isolation guard refuses the eval
- * runner inside a lane outright (#5406, not fixable in this repo), so a graded run executes in a
- * plain non-worktree session. A red that names no run site reads as "this lane is broken" and a red
- * that says only "re-run the suite" names a cure the lane structurally cannot perform — so both name
- * the site, and the hand-off, here. Stated once; both details point at it.
+ * The harness's worktree-isolation guard refuses the eval runner inside a build lane outright (#5406,
+ * not fixable in this repo), so a graded run executes in a plain non-worktree session. A debt line
+ * that says only "run the suite" names an act the lane structurally cannot perform — so it names the
+ * site, and the hand-off, here. Stated once; every debt line points at it.
  */
 const GRADED_RUN_SITE =
-	"cure: take a graded run at the head under gate in a plain, non-worktree session — never inside a build lane, whose harness refuses the runner (#5406) — which posts the head-bound record this leg reads back. A lane that hits this hands the measurement off; it is not the lane's to fix in place";
+	"to clear this debt: take a graded run at the head under gate in a plain, non-worktree session — never inside a build lane, whose harness refuses the runner (#5406) — which posts the head-bound record this leg reads back. A lane that hits this hands the measurement off; it is not the lane's to fix in place";
 
 /**
- * The graded leg: verify the recorded head-bound result, and never run anything.
+ * A graded state that used to red and now only prints (#5498 executing the 2026-08-13 ruling).
+ *
+ * It is `unmeasured`, never `measured`, because a demoted leg establishes nothing about the bar: it
+ * relays a number it no longer judges. Under-claiming is the whole point — a green check that reads
+ * as an enforcement nobody performed is the #4604 lie arriving from the reporting side, and the
+ * summary line's job is to keep saying so out loud even when the leg has a score to print.
+ */
+const reportedGraded = (line: string, notMeasured: string): LegVerdict => ({
+	leg: "graded",
+	status: "unmeasured",
+	line: `graded: REPORTED, NOT ENFORCED — ${line}`,
+	notMeasured,
+	red: null,
+});
+
+/**
+ * The graded leg: read the recorded head-bound result back, print it, and never red (#5498).
  *
  * The resolution is the shared gate-verdict contract's, reused rather than re-invented — latest
- * result wins per cell, then a refusal when that latest is not bound to the head under gate. A
- * measurement is re-run at the new head, never re-bound to it.
+ * result wins per cell, and a latest not bound to the head under gate is a measurement owed at the
+ * new head, never one re-bound to it.
  */
 export const judgeGraded = (args: {
 	readonly changedSkills: ReadonlyArray<string>;
@@ -324,10 +344,9 @@ export const judgeGraded = (args: {
 	}
 	const skills = args.changedSkills.join(", ");
 	if (args.records.length === 0) {
-		return red(
-			"graded",
-			"missing",
-			`${skills} changed and no eval record was recorded for ${args.head} — absence is never "nothing to check" (#4649 ruling). ${GRADED_RUN_SITE}`,
+		return reportedGraded(
+			`${skills} changed and no eval record was recorded for ${args.head} — a measurement is owed. ${GRADED_RUN_SITE}`,
+			`graded (${skills} changed at ${args.head} with no record — a measurement is owed)`,
 		);
 	}
 
@@ -337,19 +356,20 @@ export const judgeGraded = (args: {
 		const newest = [...latest].sort((a, b) =>
 			a.payload.recordedAt.localeCompare(b.payload.recordedAt),
 		)[latest.length - 1];
-		return red(
-			"graded",
-			"stale",
+		return reportedGraded(
 			`the newest eval record is bound to ${newest?.sha ?? "an unreadable head"}, not to ${args.head} — a measurement is re-run at the new head, never re-bound to it (ADR 0253). ${GRADED_RUN_SITE}`,
+			`graded (the newest record is bound to ${newest?.sha ?? "an unreadable head"}, not to ${args.head} — a measurement is owed)`,
 		);
 	}
 
 	const unrecordable = atHead.filter((record) => record.outcome !== "RECORDED");
 	if (unrecordable.length > 0) {
-		return red(
-			"graded",
-			"zero-scope",
-			`the record for ${cellLabel(unrecordable[0]?.payload.cell ?? {stage: "?", surface: null, model: "?"})} at ${args.head} is UNRECORDABLE — a run that measured nothing is broken, not green (ADR 0092)`,
+		const cell = cellLabel(
+			unrecordable[0]?.payload.cell ?? {stage: "?", surface: null, model: "?"},
+		);
+		return reportedGraded(
+			`the record for ${cell} at ${args.head} is UNRECORDABLE — a run that measured nothing is broken, not a rate (ADR 0092). ${GRADED_RUN_SITE}`,
+			`graded (the record for ${cell} at ${args.head} is UNRECORDABLE — it measured nothing)`,
 		);
 	}
 
@@ -358,7 +378,10 @@ export const judgeGraded = (args: {
 		const worst = below
 			.map((record) => `${cellLabel(record.payload.cell)} at ${record.payload.passRate}`)
 			.join(", ");
-		return red("graded", "below-bar", `${worst} — the ruled bar is ${bar} (#4637 ruling 2)`);
+		return reportedGraded(
+			`${worst} — under the ruled bar of ${bar} (#4637 ruling 2), which is the RELEASE criterion and no longer blocks a merge`,
+			`graded (${worst} — under the ${bar} bar, which the release criterion still refuses)`,
+		);
 	}
 	return measured(
 		"graded",

--- a/packages/fabrika-cli/src/eval/gate.unit.test.ts
+++ b/packages/fabrika-cli/src/eval/gate.unit.test.ts
@@ -6,14 +6,15 @@
  * that excluded the skills directory, so a skill change matched nothing and the gate reported green
  * over it — a mistake that presents as a pass. Here the same decision is run twice over the same
  * changed-path set, once under the shipped filter and once under a deliberately mis-scoped one, and
- * the assertion is that the mis-scoped run turns a `missing` red into a pass. That is the property
- * worth holding: not that the filter matches, but that a wrong filter is *visible* as the difference
- * between a red and a green.
+ * the assertion is that the mis-scoped run erases the measurement-debt line the correctly-scoped run
+ * prints. Since the graded demotion (#5498) neither run reds, so the visible difference moved from
+ * red-versus-green to what the report says — but the property is the same one: not that the filter
+ * matches, but that a wrong filter is *visible* in the artifact a reader acts on.
  *
  * **Which assertion catches a broken shipped filter — do not delete the siblings.** That
  * parameterised test passes its filter in explicitly, so it documents the failure mode and would
  * still pass if `SKILL_PATH_PREFIXES` were re-anchored wrong. The three assertions beside it are the
- * guard: `changedSkills(changed)` equals `["triage"]`, the same input reds `missing`, and
+ * guard: `changedSkills(changed)` equals `["triage"]`, the same input names the debt, and
  * `SKILL_PATH_PREFIXES` contains the skills directory. Break the constant and those three go red.
  */
 import {describe, expect, it} from "vitest";
@@ -41,6 +42,7 @@ import {
 	judgeScope,
 	judgeSpend,
 	latestPerCell,
+	REASON_CODES,
 	renderGate,
 	SKILL_PATH_PREFIXES,
 	unmeasuredLegs,
@@ -156,22 +158,27 @@ describe("the skill path filter (the #4604 reproduction)", () => {
 		expect(changedSkills(changed)).toEqual(["triage"]);
 	});
 
-	it("reds `missing` on a skill change with no recorded result", () => {
+	it("reports the debt by name on a skill change with no recorded result", () => {
 		const verdict = judgeGraded({
 			changedSkills: changedSkills(changed),
 			records: [],
 			head: head(HEAD),
 		});
-		expect(verdict.red?.reason).toBe("missing");
+		expect(verdict.red).toBeNull();
+		expect(verdict.line).toContain("triage");
+		expect(verdict.line).toContain("a measurement is owed");
 	});
 
-	it("turns that red into a PASS under a mis-scoped filter — the mistake presents as a green", () => {
+	it("erases that debt line under a mis-scoped filter — the mistake is still visible in the report", () => {
 		// #4604's own shape: a filter anchored inside `packages/` that never reaches a skills directory.
+		// Since the demotion (#5498) neither run reds, so what a wrong filter destroys is the DEBT
+		// LINE: the correctly-scoped run names the skill and what it owes, the mis-scoped one says the
+		// change touches no skill at all. That difference is what the property now holds onto.
 		const misScoped = changedSkills(changed, ["packages/pipeline-cli/src/"]);
 		expect(misScoped).toEqual([]);
 		const verdict = judgeGraded({changedSkills: misScoped, records: [], head: head(HEAD)});
-		expect(verdict.red).toBeNull();
 		expect(verdict.line).toContain("n/a");
+		expect(verdict.line).not.toContain("a measurement is owed");
 	});
 
 	it("anchors on the fabrika skills directory, not on a package path", () => {
@@ -246,51 +253,65 @@ describe("the regression floor", () => {
 	});
 });
 
-describe("the graded leg verifies the recorded head-bound result", () => {
+describe("the graded leg reports the recorded head-bound result and never reds (#5498)", () => {
 	const skills = ["triage"];
-
-	it("reds `missing` when nothing was recorded at all", () => {
-		expect(judgeGraded({changedSkills: skills, records: [], head: head(HEAD)}).red?.reason).toBe(
-			"missing",
-		);
-	});
-
-	it("names the cure and the run site on both skip-path reds — neither is terminal, neither is the lane's", () => {
-		const missing = judgeGraded({changedSkills: skills, records: [], head: head(HEAD)});
-		const stale = judgeGraded({
+	const missing = () => judgeGraded({changedSkills: skills, records: [], head: head(HEAD)});
+	const stale = () =>
+		judgeGraded({
 			changedSkills: skills,
 			records: [record({sha: OLDER, recordedAt: "2026-08-11T00:00:00Z", passed: 10, graded: 10})],
 			head: head(HEAD),
 		});
-		for (const verdict of [missing, stale]) {
-			expect(verdict.line).toContain("cure:");
+	const belowBar = () =>
+		judgeGraded({
+			changedSkills: skills,
+			records: [record({sha: HEAD, recordedAt: "2026-08-11T00:00:00Z", passed: 8, graded: 10})],
+			head: head(HEAD),
+		});
+	const unrecordable = () =>
+		judgeGraded({
+			changedSkills: skills,
+			records: [record({sha: HEAD, recordedAt: "2026-08-11T00:00:00Z", passed: 0, graded: 0})],
+			head: head(HEAD),
+		});
+
+	// The demotion's whole content: the four states that used to seat exit codes 21/18/7/22 now seat
+	// none. Asserted as one sweep so a state that quietly regains teeth cannot pass unnoticed.
+	it("reds on none of the four states that used to fail a PR", () => {
+		for (const verdict of [missing(), stale(), belowBar(), unrecordable()]) {
+			expect(verdict.red).toBeNull();
+			expect(verdict.line).toContain("REPORTED, NOT ENFORCED");
+		}
+	});
+
+	it("never presents a demoted state as a leg that passed — it is unmeasured, not measured", () => {
+		for (const verdict of [missing(), stale(), belowBar(), unrecordable()]) {
+			expect(verdict.status).toBe("unmeasured");
+		}
+	});
+
+	it("names the run site on every debt line — the lane that reads it cannot take the measurement", () => {
+		for (const verdict of [missing(), stale()]) {
+			expect(verdict.line).toContain("to clear this debt:");
 			expect(verdict.line).toContain("plain, non-worktree session");
 			expect(verdict.line).toContain("never inside a build lane");
 			expect(verdict.line).toContain("hands the measurement off");
 		}
 		// #5406 is the whole reason the site has to be named: the lane's harness refuses the runner, so
-		// "re-run the suite" without a site is an instruction the lane cannot follow.
-		expect(stale.line).toContain("#5406");
+		// "run the suite" without a site is an instruction the lane cannot follow.
+		expect(stale().line).toContain("#5406");
 	});
 
-	it("reds `stale` when the newest record is bound to an older commit", () => {
-		const verdict = judgeGraded({
-			changedSkills: skills,
-			records: [record({sha: OLDER, recordedAt: "2026-08-11T00:00:00Z", passed: 10, graded: 10})],
-			head: head(HEAD),
-		});
-		expect(verdict.red?.reason).toBe("stale");
-		expect(verdict.line).toContain(OLDER);
+	it("reports which head the newest record is bound to when it is not this one", () => {
+		expect(stale().line).toContain(OLDER);
 	});
 
-	it("reds `below-bar` on a recorded rate under the ruled bar", () => {
-		const verdict = judgeGraded({
-			changedSkills: skills,
-			records: [record({sha: HEAD, recordedAt: "2026-08-11T00:00:00Z", passed: 8, graded: 10})],
-			head: head(HEAD),
-		});
-		expect(verdict.red?.reason).toBe("below-bar");
+	it("still prints the score and the bar it fell under", () => {
+		const verdict = belowBar();
+		expect(verdict.line).toContain("0.8");
 		expect(verdict.line).toContain(String(GRADED_BAR));
+		if (verdict.status !== "unmeasured") throw new Error("a below-bar rate must stay unmeasured");
+		expect(verdict.notMeasured).toContain("release criterion");
 	});
 
 	it("passes a rate exactly at the bar — the bar is `at or above`", () => {
@@ -300,16 +321,11 @@ describe("the graded leg verifies the recorded head-bound result", () => {
 			head: head(HEAD),
 		});
 		expect(verdict.red).toBeNull();
+		expect(verdict.status).toBe("measured");
 	});
 
-	it("reds an UNRECORDABLE record as zero scope — a broken run is not a below-bar number", () => {
-		const verdict = judgeGraded({
-			changedSkills: skills,
-			records: [record({sha: HEAD, recordedAt: "2026-08-11T00:00:00Z", passed: 0, graded: 0})],
-			head: head(HEAD),
-		});
-		expect(verdict.red?.reason).toBe("zero-scope");
-		expect(verdict.line).toContain("UNRECORDABLE");
+	it("reports an UNRECORDABLE record as measuring nothing — never as a rate", () => {
+		expect(unrecordable().line).toContain("UNRECORDABLE");
 	});
 
 	it("takes the latest record per cell, so a re-run at the same head supersedes", () => {
@@ -433,37 +449,32 @@ describe("the folded verdict", () => {
 		const verdict = decideGate({
 			legs: [
 				judgeScope([]),
-				judgeGraded({changedSkills: ["triage"], records: [], head: head(HEAD)}),
+				judgeFloor({
+					scope: floorScope([mechanicalCase(1)], sidecar([armed(1)])),
+					rows: [row(1, "fail")],
+					deterministicCases: 1,
+				}),
 				judgeSpend({_tag: "Compared", comparison: comparison("above")}),
 			],
 		});
-		expect(verdict.reds.map((r) => r.reason)).toEqual(["zero-scope", "missing", "over-baseline"]);
+		expect(verdict.reds.map((r) => r.reason)).toEqual([
+			"zero-scope",
+			"regression-floor",
+			"over-baseline",
+		]);
 		expect(verdict.code).toBe(ZERO_SCOPE);
+	});
+
+	// The three graded seats keep their numbers and lose their PR-side producer: the demotion (#5498)
+	// took the graded leg out of the failing set, and the release criterion still refuses on them.
+	it("keeps the graded reasons on their own seats even with no leg producing them", () => {
+		expect(REASON_CODES.missing).toBe(MISSING_RESULT);
+		expect(REASON_CODES.stale).toBe(STALE_HEAD);
+		expect(REASON_CODES["below-bar"]).toBe(BELOW_BAR);
 	});
 
 	it("seats each reason on the code its group already means it by", () => {
 		const seat = (legs: Parameters<typeof decideGate>[0]["legs"]) => decideGate({legs}).code;
-		expect(seat([judgeGraded({changedSkills: ["t"], records: [], head: head(HEAD)})])).toBe(
-			MISSING_RESULT,
-		);
-		expect(
-			seat([
-				judgeGraded({
-					changedSkills: ["t"],
-					records: [record({sha: OLDER, recordedAt: "2026-08-11T00:00:00Z", passed: 1, graded: 1})],
-					head: head(HEAD),
-				}),
-			]),
-		).toBe(STALE_HEAD);
-		expect(
-			seat([
-				judgeGraded({
-					changedSkills: ["t"],
-					records: [record({sha: HEAD, recordedAt: "2026-08-11T00:00:00Z", passed: 1, graded: 2})],
-					head: head(HEAD),
-				}),
-			]),
-		).toBe(BELOW_BAR);
 		expect(
 			seat([
 				judgeFloor({


### PR DESCRIPTION
The fabrika eval gate used to fail a PR when a skill change had no graded eval record at the head under review. That meant waiting on an hour-long graded run before a skill edit could merge. It doesn't anymore: the graded leg still reads whatever record exists and prints what it knows — the score at head, or "this skill changed and owes a measurement" — but none of that fails the check.

The bar itself is untouched. It keeps full teeth as the release criterion; only the merge-time enforcement is gone. Merging is cheap again, releasing is earned.

Fixes #5498

Executes the founder's 2026-08-13 ruling on #4681 (comment 5275146922): "i dont wanna wait 1h for every skill update."

## What changed

- `packages/fabrika-cli/src/eval/gate.ts` — `judgeGraded`'s four red states (missing / stale / UNRECORDABLE / below-bar) now return a reported line instead of a `GateRed`. They report as `unmeasured`, never `measured`, so the summary keeps saying `gate: NOT FULLY MEASURED` and a green check still cannot be read as an enforcement nobody performed (the #4604 lie the module's docblock argues against). Line prefix: `graded: REPORTED, NOT ENFORCED — …`.
- `.github/workflows/fabrika-eval-gate.yml` — the check name stopped claiming `graded 90% enforced at head`; it now reads `graded reports only, never blocks; floor + spend report, not yet enforced`. Comments updated to match, including the exit-code list.
- Tests — `gate.cli.test.ts` watches the three graded cases exit **0** with the debt printed (this is the live evidence for the first acceptance criterion, run in-process); `gate.unit.test.ts` asserts none of the four states reds and that each stays `unmeasured`.
- `packages/fabrika-cli/src/eval/README.md` — the enforcement claims it carried are now false, so they are corrected.

## What did NOT change

Deterministic/CLI legs, the floor leg, the spend leg, `GRADED_BAR`, `REGRESSION_FLOOR`, the release criterion. The three graded exit seats (18 stale / 21 missing / 22 below-bar) keep their numbers and simply lose their PR-side producer — they are the release criterion's vocabulary.

## Control-plane note

This touches `.github/workflows/fabrika-eval-gate.yml`, so it banks for human §CP approval rather than auto-shipping. Two consumer checks re-verified live before the rename: the job is **not** a required status context on the `main protection` ruleset (`scan changed files for leaks`, `validate skill frontmatter`, `ci-required`), and no file in the repo matches the old name literally.

## Deviations

- **Class: shape of the fix.** Said: "the graded leg's missing/stale/below-bar/zero-scope states map to reported lines." Did: reused the existing `unmeasured` `LegVerdict` state rather than adding a fourth status. Why: a fourth state would force edits to `summaryLine`, `unmeasuredLegs` and `gateToJson`, which report for *all* legs — a wider diff on a §CP-banked PR, and the brief says touch nothing else. `unmeasured` under-claims (it never asserts the bar was met) which is the safe direction; the printed line carries the specifics, including the actual score on a below-bar record. Disposition: for the reviewer to judge.
- **Class: adjacent files not named in the issue.** Said: gate.ts / gate-verb.ts and/or the workflow, plus the check name. Did: also updated `packages/fabrika-cli/src/eval/README.md` and both gate test files. Why: the README states "the graded leg is the only enforced one" and the tests assert the removed reds — leaving either would ship a red suite and a doc that lies. `gate-verb.ts` needed no change; it relays the leg's verdict. Disposition: no action needed.
- **Class: test infrastructure.** Said: nothing. Did: switched `gate.cli.test.ts`'s runner helper from `execFileSync` to `spawnSync`. Why: the old helper discarded stderr on a zero exit, and the interesting graded cases are now green — their diagnostics were unassertable. Disposition: no action needed.