### PR TITLE
chore(fabrika): declare the kampus marketplace in project settings (#4670)

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -3,6 +3,15 @@
 		"fabrika@kampus": true,
 		"kampus-pipeline@kampus": false
 	},
+	"extraKnownMarketplaces": {
+		"kampus": {
+			"source": {
+				"source": "github",
+				"repo": "kamp-us/phoenix"
+			},
+			"autoUpdate": true
+		}
+	},
 	"hooks": {
 		"PreToolUse": [
 			{

--- a/claude-plugins/fabrika/README.md
+++ b/claude-plugins/fabrika/README.md
@@ -47,10 +47,29 @@ claude-plugins/fabrika/
 per-skill directory and nothing else at the `skills/` root. A `.gitkeep` remains from when the
 directory was empty; it is harmless and can go with any later change.
 
+## Install
+
+fabrika ships through the `kampus` marketplace, and phoenix consumes it from that same
+marketplace entry — the ship channel is the dogfood channel ([#4670](https://github.com/kamp-us/phoenix/issues/4670)).
+
+```
+/plugin marketplace update kampus
+/plugin install fabrika@kampus
+```
+
+**Refresh first.** The install reads a locally cached catalog. A cache that predates fabrika's
+entry refuses by name — `Plugin "fabrika" not found in marketplace "kampus"` — instead of saying
+it is out of date, and the same message comes back when the marketplace was never registered on
+the machine at all, so the refusal does not tell you which of the two you hit. Updating first
+clears the common one.
+
+Inside phoenix you type neither line: `.claude/settings.json` declares the marketplace under
+`extraKnownMarketplaces.kampus` and enables `fabrika@kampus`. A fresh clone picks both up once the
+workspace is trusted — settings-declared marketplaces are read from project settings only after
+you accept the trust prompt — so no collaborator needs a registration of their own.
+
 ## What is deliberately absent
 
-- **No marketplace entry.** fabrika is not listed in the root marketplace manifest
-  (`.claude-plugin/`), so nothing here reaches the pinned external channel (#4643).
 - **No dependency on v1.** fabrika calls `pipeline-cli` nowhere — not from a skill, not from a verb.
   Its own verbs live in `packages/fabrika-cli/`. v1 is a reference to read, never a runtime to call,
   because a fabrika that calls the old tree can never be the thing that replaces it.


### PR DESCRIPTION
Phoenix enabled `fabrika@kampus` but never told anyone where the `kampus` marketplace comes from, so the enablement only resolved on a machine where someone had registered it by hand. This adds the missing declaration to the repo's own `.claude/settings.json`, and gives fabrika's README an Install section that names the one gotcha an operator hits: a stale local catalog refuses by name (`Plugin "fabrika" not found in marketplace "kampus"`) instead of saying it is out of date. With this, a collaborator on a fresh clone can resolve `fabrika@kampus` without any machine-local setup.

Fixes #4670

## What changed

- `.claude/settings.json` — adds `extraKnownMarketplaces.kampus` (github source `kamp-us/phoenix`, `autoUpdate: true`). Purely additive; `enabledPlugins` is byte-unchanged, so `kampus-pipeline@kampus` keeps its `false`.
- `claude-plugins/fabrika/README.md` — adds an Install section with the refresh-first note, and drops the now-false "No marketplace entry" bullet (the entry landed in #4771).

**This PR is control plane.** `pipeline-cli cp-classify classify` returns `control-plane [path-match] — .claude/settings.json matches the live CONTROL_PLANE_RE. BLOCKING (human merge)`. It waits for §CP approval; nothing here auto-ships.

## Grounding — what was verified against source, and how

The claim that a repo's own settings file is the right place for this was checked against the Claude Code CLI bundle rather than assumed (the issue's amendment explicitly asked an implementer to confirm it first):

- The `extraKnownMarketplaces` schema describes itself as "Additional marketplaces to make available for this repository. Typically used in repository `.claude/settings.json` to ensure team members have required plugin sources."
- The declaration shape is `{ source, installLocation?, autoUpdate? }`, and the loader scans `localSettings`, `projectSettings`, `userSettings` for it.
- Project-scope declarations take effect only once the workspace is trusted: the untrusted path falls back to a merge that skips project and local settings. The README says so.

## Consumption, demonstrated

From a plugin store with **no** `kampus` registration at all:

1. `claude plugin install fabrika@kampus` fails — and fails with the same "not found in marketplace" wording whether the marketplace is unregistered or merely stale, which is why the README calls that out.
2. After registering the marketplace from `kamp-us/phoenix` and installing, `fabrika@kampus` materializes at commit `882b44af88c3` with all 22 skills present.

Separately, against the pre-existing registration: the install failed against a stale catalog and succeeded immediately after `claude plugin marketplace update kampus` — the exact failure the issue's amendment reported, reproduced and cleared.

## Deviations

- **Narrowed scope (the added AC about recording the stale-catalog behavior).** *Said:* record it "wherever the release/runbook docs tell an operator to install". *Did:* recorded it in fabrika's README only. *Why:* the other install docs belong to `kampus-pipeline` (which AC6 requires byte-untouched) and to `pipeline-crew`/`pipeline-crew-mcp`, whose channels this issue does not own; widening would have touched three unrelated front doors. *Disposition:* for the reviewer to judge — say the word and I will file a follow-up for the pipeline-crew docs.
- **Verification gap.** *Said:* demonstrate consumption from a state with no pre-existing machine-local registration. *Did:* demonstrated it at the install layer (above), but did **not** demonstrate that the committed declaration alone auto-registers the marketplace. *Why:* a headless `-p` session performs no plugin or marketplace bootstrap (a `--debug` run emits zero plugin/marketplace lines), and the interactive path requires granting workspace trust to a scratch clone, which is a machine-local trust decision an agent should not make for the operator. *Disposition:* one human interactive session in a fresh clone closes it; the mechanism itself is grounded in the CLI source above.
- **Verification side effect.** The clean-room probe caused the CLI to write the same marketplace declaration into machine-local (non-repo) user settings. Nothing in the repo is affected; reported to the operator separately.