### PR TITLE
feat(fabrika): give build a commit verb that proves the message is this lane's (#5484)

### DIFF
--- a/claude-plugins/fabrika/skills/build/SKILL.md
+++ b/claude-plugins/fabrika/skills/build/SKILL.md
@@ -120,6 +120,23 @@ surface validates, run `build check` again there: markdown beside your code — 
 to `--surface prose`, or `--surface plan` if that markdown is an epic ledger, which runs the prose
 validators too. One run per class present is what leaves nothing in the diff unread (#5301, #5304).
 
+Commit through the verb, never a hand-rolled `git commit` — it is the only thing that reads the
+message back off the commit it just made:
+
+```bash
+git add <your files>
+fabrika build commit <<'EOF'
+fix(build): one line saying what changed (#4312)
+EOF
+```
+
+Send the message on stdin. The alternative is a leaf under `fabrika build scratch`; any other path is
+refused, because a path outside the allocator has no per-lane key — that is how a lane once committed
+a two-day-old message belonging to another lane, with nothing failing anywhere (#5484). Exit `9`
+means the commit exists and carries a message you did not write: amend it and re-run, do not push.
+Exit `4` means your message names an issue this lane holds no claim on — a related reference belongs
+in the PR body, not the merge record.
+
 ## 5 — Push verified, open the PR through the guard
 
 ```bash

--- a/claude-plugins/fabrika/skills/build/contract.md
+++ b/claude-plugins/fabrika/skills/build/contract.md
@@ -6,6 +6,8 @@
 
 **Amended 2026-08-10** — the third file class in `build check` ([#5229](https://github.com/kamp-us/phoenix/issues/5229)): a changed file matching neither the code nor the markdown pattern is now named rather than dropped out of both filters, so a diff nothing validates refuses on a new code (`22`) instead of greening, and a green over a partly-unvalidatable diff carries the files it did not cover.
 
+**Amended 2026-08-13** — `build commit` ([#5484](https://github.com/kamp-us/phoenix/issues/5484)): the group had no commit verb, so the message-carrying path at every call site was improvised and nothing asserted the message on the resulting commit. A lane's improvised `git commit -F <leaf>` read back a two-day-old message from another lane and committed it, silently, with every command exiting 0. The verb prescribes the carrying path, tests the numbers the message names against this lane's claim, and reads the message back off the created commit — plus one code (`24`) in the shared exit matrix.
+
 The verbs land in `packages/fabrika-cli/` under the `build` subcommand group, registered in
 `packages/fabrika-cli/src/registry.ts` like the shipped `adr`, `report`, `triage` and `wire`
 groups. The [CLI interface convention](../../docs/cli-interface-convention.md) governs every verb;
@@ -60,6 +62,7 @@ second answer to a gated question can contradict the gate (interface convention 
 | `build issue` | the claimed issue's body + parsed acceptance criteria, through the content gate | fetch + parse via the wire module; *judging* the criteria stays in the skill |
 | `build branch` | cut (or resume) the lane's nonce branch off a freshly fetched base | fetch, derive, create — the nonce is a function of the claim token |
 | `build scratch` | the per-lane scratch path, allocated fail-closed | deterministic path derivation keyed session + issue + claim nonce |
+| `build commit` | create this lane's commit from an authored message, and prove the commit carries it | a prescribed carrying path, a claim test over the numbers named, and a read-back — no judgment; *authoring* the message stays in the skill |
 | `build check` | run this surface's validators in this tree, cache-bypassed; green/red/unknown | command execution + tree-binding assertions; *fixing red* stays in the skill |
 | `build push` | publish the branch and independently confirm the remote ref moved | push + `ls-remote` read-back, three proven outcomes |
 | `build pr` | open the PR from a stdin body, refusing the known defect shapes, with read-back | mechanical guards over an authored body; *authoring* stays in the skill |
@@ -93,8 +96,8 @@ Every verb obeys these; stated once.
   forward/back-referenced content — not as an edit to five verbs. TOCTOU is handled by
   construction: no verb caches content across invocations; every invocation re-fetches and
   re-gates, so a gate change is in force on the next read.
-- **Isolation preconditions are guarded identically wherever they apply.** `branch`, `check`,
-  `push` and `pr` run the same tree assertions `tree` runs, with the same codes (`note` runs only
+- **Isolation preconditions are guarded identically wherever they apply.** `branch`, `commit`,
+  `check`, `push` and `pr` run the same tree assertions `tree` runs, with the same codes (`note` runs only
   the posting guards — a stop-report must remain postable from a refused tree) — a sibling that
   took the same ground unguarded would be the split this table exists to prevent.
   Their refusal messages are `tree`'s rows with the verb-name prefix substituted; **every error
@@ -251,6 +254,7 @@ range, exactly as `triage/codes.ts` itself states for `adr`.
 | `21` | proven: not admitted on the audience axis, audience not agent — the issue's `ready-for:` label is not `ready-for:agent`, or is absent |
 | `22` | proven: every changed file falls outside all three surfaces' validators — there is nothing to run, so the verdict is a refusal, never a green |
 | `23` | proven: the local head does not contain the published remote head — the push would drop its commits |
+| `24` | proven: `git commit` ran and HEAD did not move — no commit was created |
 | `127` | the verb never ran at all (unresolved binary — the shell's code, not this process's) |
 
 **`7` versus `11` is the split the whole group rests on** (the `wire` group's `ABSENT` vs
@@ -963,6 +967,118 @@ $ fabrika build scratch 4312 --slug notes
 
 ---
 
+## `build commit`
+
+**Invocation**
+
+```
+fabrika build commit < message.txt
+fabrika build commit --message-file "$(fabrika build scratch 4312 --slug commit-message)"
+```
+
+**Inputs**
+
+| Flag | Type | Required | Default | Description |
+|---|---|---|---|---|
+| stdin | text | yes, unless `--message-file` | — | the commit message, file-free |
+| `--message-file` | string | no | — | a leaf under this lane's `build scratch` directory; any other path is refused |
+
+**Output** — machine. On success, one JSON object:
+`{"answer": "committed", "sha": "<full object name>", "subject": "<the message's first non-blank line>", "carried": "stdin" | "scratch-leaf"}`.
+Every refusal produces no stdout.
+
+**The three guards, and the incident each closes.** The verb exists because there was no commit verb
+at all: nothing prescribed how a message reached `git commit`, so the call site stayed improvised,
+and nothing asserted that the message on the resulting commit was the one the lane wrote. A lane ran
+`git commit -F <leaf>` against a leaf holding a **two-day-old message from another lane**; the file
+existed, was non-empty, and was a well-formed conventional-commit message, so every cheap check read
+green and the commit landed naming an issue the lane had never touched (#5484).
+
+1. **The carrying path is prescribed.** Either **file-free** — the message on stdin, handed straight
+   to `git commit -F -`, so there is no second place the bytes live — or a **leaf under `build
+   scratch`'s claim-nonce-keyed directory**. A hand-rolled path is **refused** (`10`), not tolerated:
+   a path outside the allocator is precisely the one with no per-lane key, which is what let a stale
+   file sit where a fresh one was assumed.
+   **The containment test keys on the DIRECTORY and never on the leaf name** (§SP rule 2): a plain
+   `commit-message` leaf inside this lane's directory is admitted, and a run-keyed leaf anywhere else
+   is refused. Keying the leaf is the anti-pattern the allocator retired — a shared directory with
+   clever names is still a shared directory.
+2. **The message may name only numbers this lane holds.** Every `#<n>` in the message is tested
+   against this lane's confirmed claim; one it does not hold is `4`, before any commit exists. In
+   resume mode the permitted set also holds the issue the PR itself closes, **read off the PR** and
+   never taken on the message's word. This is the guard a shape check cannot be: the borrowed message
+   was well-formed and referenced a real issue.
+3. **The message is read back off the created commit.** `git log -1 --format=%B` asks git what it
+   *recorded*; everything upstream is only a claim about what was *sent*. A mismatch is `9` and the
+   refusal prints **both** messages, quoted, so the difference is legible without re-running. The
+   commit is created with `--cleanup=verbatim` so git edits nothing and the comparison is honest;
+   `normalizeForReadback` is what absorbs the trailing-newline difference, exactly as the two posting
+   verbs' read-backs do.
+
+**No refusal repeats a machine-local path.** `build scratch`'s path is machine-local by definition,
+and both the `--message-file` refusals and the ones quoting git's own stderr would otherwise carry
+one — git names the path it could not read. The path refusals name the **leaf only**, and every
+quoted foreign string (git's stderr, the message read back) is masked through the same
+`report/leaks.ts` predicate `build pr` and `build note` red on.
+
+Preconditions: a branch that is this lane's (`14`), a claim this session holds (`15` / `11`), and
+something staged (`7`).
+
+**Exit status** (beyond the universal four)
+
+| Code | Trigger |
+|---|---|
+| `3` | stdin was read and held nothing |
+| `4` | the message names an issue this lane holds no confirmed claim on, or `--message-file` holds no message |
+| `5` | the message carries a machine-local path |
+| `6` | the message is a bare `@` path reference |
+| `7` | nothing is staged — there is no change to commit |
+| `8` | the commit ran and HEAD, or the created commit's message, could not be read back — UNKNOWN |
+| `9` | proven: the created commit carries a message this lane did not author |
+| `10` | `--message-file` is not a leaf in this lane's `build scratch` directory |
+| `11` | a precondition read failed — nothing was committed |
+| `14` | proven: the checked-out branch is not this lane's |
+| `15` | proven: this session does not hold the claim |
+| `24` | proven: `git commit` ran and HEAD did not move — no commit was created |
+
+**Errors**
+
+| Message (stderr) | Code | Kind |
+|---|---|---|
+| `build commit: stdin held nothing — the commit message is the input.` | 3 | refusal |
+| `build commit: the message names #<m>, which this lane holds no confirmed claim on — this lane's claim is on #<n>. A commit message names only what this lane owns; a related reference belongs in the PR body.` | 4 | refusal |
+| `build commit: --message-file "<leaf>" holds no message — a commit message is the input.` | 4 | refusal |
+| `build commit: the body carries a machine-local path: <text> — redact before posting.` | 5 | refusal (the imported predicate's wording) |
+| `build commit: nothing is staged — there is no change to commit.` | 7 | refusal |
+| `build commit: commit <sha> was created but its message could not be read back: <reason> — what it carries is UNKNOWN.` | 8 | refusal |
+| `build commit: commit <sha> carries a message this lane did not author — amend it, then re-run. It needs a human eye.` | 9 | refusal, with both messages quoted above it |
+| `build commit: --message-file "<leaf>" is not a leaf in this lane's scratch directory — send the message on stdin, or write it under the path "fabrika build scratch <n> --slug <leaf>" prints. That path is machine-local, so it is not repeated here.` | 10 | refusal |
+| `build commit: cannot read the index: <reason> — nothing was committed.` | 11 | refusal |
+| `build commit: git commit ran and HEAD did not move — no commit was created: <reason>.` | 24 | refusal |
+
+**Scope** — not a judging verb. Creates one commit, or none; writes no file, and pushes nothing.
+
+**Example**
+
+```
+$ fabrika build commit < message.txt
+{"answer":"committed","sha":"03135b9188d2be6c0a4b7bd0b7a3ff9c53f0f2b1","subject":"fix(build): read the commit message back off the commit (#4312)","carried":"stdin"}
+```
+
+**Grounding**
+
+- #5484 — the incident: `git commit -F <leaf>` over a two-day-old message file, committed silently.
+  Its corrected mechanism is what shapes the guards: `-F` on a **missing** file dies (`128`), and
+  `COMMIT_EDITMSG` is per-worktree, so neither a fallback nor a cross-lane share was involved. The
+  file **existed and was stale**, which is why the answer is a keyed directory plus a read-back
+  rather than an existence check.
+- #4692 / #4516 / #4875 / #4544 — the shared-namespace clobber class the allocator already keys
+  against; this verb is what makes a lane use it for the one file that reaches the merge record.
+- §SP rules 1 and 2 (`claude-plugins/kampus-pipeline/skills/gh-issue-intake-formats.md`) — prefer no
+  file at all; where one is unavoidable, uniqueness lives in the directory.
+
+---
+
 ## `build check`
 
 **Invocation**
@@ -1495,5 +1611,5 @@ script, another skill's prose, or the authoring session. The three hand-checks t
 lineage demands: every reachable outcome above was walked against its verb's failure modes; every
 example value is derivable from its verb's stated rules (the nonce from the claim token, the
 verdict line from the protocol); and sibling verbs guard shared preconditions identically
-(`branch`/`check`/`push` run `tree`'s assertions; `pr`/`note` run the same posting guards on the
-same codes).
+(`branch`/`commit`/`check`/`push` run `tree`'s assertions; `pr`/`note` run the same posting guards on
+the same codes, and `commit` runs the same authored-text guards on `3`/`5`/`6`).

--- a/packages/fabrika-cli/src/build/codes.ts
+++ b/packages/fabrika-cli/src/build/codes.ts
@@ -1,12 +1,12 @@
 /**
- * The one exit table all fourteen `build` verbs allocate from, so a code means one thing across this
+ * The one exit table all fifteen `build` verbs allocate from, so a code means one thing across this
  * group whichever verb produced it.
  *
  * **The overlap with `report` is re-exported, never re-typed** — the discipline `review/codes.ts`
  * states in full: an aligning group *imports* the base's constant, so a drift is unrepresentable
- * rather than merely detectable. This group shares nine seats over `3`-`11` and adds its own `13`-`21`
- * for facts about the lane — the tree, the claim, the push, the validators, and the two admission
- * axes — that no writing verb has.
+ * rather than merely detectable. This group shares nine seats over `3`-`11` and adds its own `13`-`24`
+ * for facts about the lane — the tree, the claim, the commit, the push, the validators, and the two
+ * admission axes — that no writing verb has.
  *
  * `0`, `1`, `2` and `127` are reserved by the interface convention (`../verb.ts`, `../bin.ts`).
  */
@@ -107,3 +107,14 @@ export const UNCLASSIFIED_DIFF = 22;
  * otherwise read off the command that produced it. No `epic` verb can prove a push's containment.
  */
 export const HEAD_DROPS_REMOTE = 23;
+/**
+ * Proven: `git commit` ran and HEAD did not move — no commit was created.
+ *
+ * The commit-side twin of `17`, and seated separately for the same reason `23` is not `19`: the
+ * remedy differs. `17` says the remote did not take the head; this one says no head was made, so the
+ * fix is git's own refusal (an empty index, a hook that blocked) rather than anything about a ref.
+ * It is never {@link WRITE_UNKNOWN}: HEAD was re-read and compared, so the absence is *proven*, and
+ * fusing "no commit exists" with "a commit may exist" is the fusion this group refuses everywhere
+ * else (#5484).
+ */
+export const COMMIT_NOT_CREATED = 24;

--- a/packages/fabrika-cli/src/build/command.ts
+++ b/packages/fabrika-cli/src/build/command.ts
@@ -22,6 +22,7 @@ import type {VerbOutcome} from "../verb.ts";
 import {runBranch} from "./branch-verb.ts";
 import {runCheck} from "./check-verb.ts";
 import {runClaim, runConfirm, runRelease} from "./claim-verb.ts";
+import {runCommit} from "./commit-verb.ts";
 import {runEligible} from "./eligible-verb.ts";
 import {runIssue} from "./issue-verb.ts";
 import {runNote} from "./note-verb.ts";
@@ -280,6 +281,35 @@ const scratch = leafCommand(
 	),
 );
 
+const commit = leafCommand(
+	"commit",
+	{
+		messageFile: Flag.string("message-file").pipe(
+			Flag.optional,
+			Flag.withDescription(
+				"carry the message in a leaf under this lane's `build scratch` directory instead of on stdin; any other path is refused",
+			),
+		),
+		repo: repoFlag,
+	},
+	Effect.fn(function* ({messageFile, repo}) {
+		yield* emit(
+			yield* runCommit({
+				messageFile: Option.getOrNull(messageFile),
+				repo: Option.getOrNull(repo),
+				env: process.env,
+				stdin: Effect.sync(readStdin),
+				tmpRoot: tmpdir(),
+			}),
+		);
+	}),
+).pipe(
+	Command.withShortDescription("Commit the staged change and prove the message is this lane's."),
+	Command.withDescription(
+		'Create this lane\'s commit from the message on STDIN, then READ THE MESSAGE BACK off the created commit and refuse if it is not the one this lane authored — the refusal prints both. The message may name only numbers this lane holds a confirmed claim on. The carrying path is prescribed, not improvised: stdin (file-free), or --message-file pointing at a leaf under "fabrika build scratch"\'s claim-nonce-keyed directory; any other path is refused. No refusal repeats a machine-local path. Prints {"answer":"committed","sha":"…","subject":"…","carried":"stdin"|"scratch-leaf"}. Exits 3 (stdin held nothing), 4 (the message names an issue this lane does not hold, or --message-file is empty), 5 (machine-local path in the message), 6 (bare @ reference), 7 (nothing is staged), 8 (the commit ran but HEAD or its message could not be read back — UNKNOWN), 9 (proven: the created commit carries a message this lane did not author), 10 (--message-file is not a leaf in this lane\'s scratch directory), 11 (a precondition read failed — nothing was committed), 14 (the checked-out branch is not this lane\'s), 15 (this session does not hold the claim), 24 (proven: git commit ran and HEAD did not move). Example: fabrika build commit < message.txt',
+	),
+);
+
 const check = leafCommand(
 	"check",
 	{
@@ -422,6 +452,7 @@ export const buildCommand = Command.make("build").pipe(
 		issue,
 		branch,
 		scratch,
+		commit,
 		check,
 		push,
 		pr,

--- a/packages/fabrika-cli/src/build/commit-message.ts
+++ b/packages/fabrika-cli/src/build/commit-message.ts
@@ -1,0 +1,78 @@
+/**
+ * The pure reads `build commit` makes over a commit message and over the path one may arrive on.
+ *
+ * The incident this module answers is #5484: a lane ran `git commit -F <path>` against a path that
+ * held a **two-day-old message from another lane**. Nothing failed — the file existed, was
+ * non-empty, and was a well-formed conventional-commit message — so the commit landed carrying a
+ * subject about an issue the lane had never touched. That is the class property worth stating once:
+ * every cheap check reads green, so the only things that can catch it are a read-back off the
+ * created commit and a claim test over the numbers the message names.
+ */
+
+import {scanBody} from "../report/leaks.ts";
+
+/** Every `#<n>` a message names, in order, duplicates included. */
+export const issueRefsIn = (message: string): ReadonlyArray<number> =>
+	[...message.matchAll(/#(\d+)\b/g)].flatMap((match) =>
+		match[1] === undefined ? [] : [Number.parseInt(match[1], 10)],
+	);
+
+/** The numbers a message names that `permitted` does not hold — empty is the clean message. */
+export const foreignRefsIn = (
+	message: string,
+	permitted: ReadonlySet<number>,
+): ReadonlyArray<number> => [...new Set(issueRefsIn(message).filter((n) => !permitted.has(n)))];
+
+/** A path's last segment. Never machine-local on its own, which is why a refusal may name it. */
+export const leafOf = (path: string): string =>
+	path
+		.split("/")
+		.filter((s) => s !== "")
+		.at(-1) ?? "";
+
+/**
+ * Whether `path` is a leaf directly inside `dir` — the one shape a `--message-file` may take.
+ *
+ * **The test keys on the DIRECTORY and nothing else, and that is the contract, not an accident**
+ * (§SP rule 2). Uniqueness lives in `build scratch`'s claim-nonce-keyed directory, so the leaf name
+ * confers no safety and is never asked to: a run-keyed leaf in some other directory is refused
+ * exactly like a plain one, and a plain `commit-message` leaf inside this lane's directory is
+ * admitted. Keying the leaf instead is the anti-pattern the allocator was built to retire (#4692,
+ * #5484) — a shared directory with clever names is still a shared directory.
+ *
+ * Relative paths fail by construction: the allocator prints absolute paths, so anything that is not
+ * one cannot have come from it.
+ */
+export const isLaneScratchLeaf = (path: string, dir: string): boolean => {
+	const prefix = `${dir.replace(/\/+$/, "")}/`;
+	if (!path.startsWith(prefix)) return false;
+	const leaf = path.slice(prefix.length);
+	return (
+		leaf !== "" && leaf !== "." && leaf !== ".." && !leaf.includes("/") && !leaf.includes("\\")
+	);
+};
+
+/**
+ * A quoted foreign string with every machine-local path masked to its class root.
+ *
+ * Every refusal below quotes something this process did not write — git's own stderr, a message read
+ * back off a commit — and git names the path it could not read (`fatal: could not read log file
+ * '<path>'`). Quoting that verbatim would put a machine-local path in a refusal a caller pastes into
+ * an issue, which is the leak `build pr` and `build note` already red on. Masking at the quote site
+ * is what keeps the refusals free of one without keeping them silent.
+ */
+export const redact = (text: string): string => scanBody(text).redacted;
+
+/** A quoted multi-line block for stderr: redacted, indented, so two of them read as two messages. */
+export const quotedBlock = (text: string): ReadonlyArray<string> =>
+	redact(text)
+		.replace(/\n+$/, "")
+		.split("\n")
+		.map((line) => `    ${line}`);
+
+/** A message's subject line — what a reader scanning a commit list actually sees. */
+export const subjectOf = (message: string): string =>
+	message
+		.split("\n")
+		.find((line) => line.trim() !== "")
+		?.trim() ?? "";

--- a/packages/fabrika-cli/src/build/commit-message.unit.test.ts
+++ b/packages/fabrika-cli/src/build/commit-message.unit.test.ts
@@ -1,0 +1,129 @@
+import {describe, expect, it} from "vitest";
+import {scanBody} from "../report/leaks.ts";
+import {
+	foreignRefsIn,
+	isLaneScratchLeaf,
+	issueRefsIn,
+	leafOf,
+	quotedBlock,
+	redact,
+	subjectOf,
+} from "./commit-message.ts";
+
+const DIR = "/var/folders/qq/T/fabrika-build/s-9f2e/5484-c1a4d6f8";
+
+describe("issueRefsIn", () => {
+	it("reads every #<n> a message names, subject and body alike", () => {
+		expect(
+			issueRefsIn("fix(report): state the guarantee (#4789)\n\nGrounded in #4692 and #2038.\n"),
+		).toEqual([4789, 4692, 2038]);
+	});
+
+	it("names nothing for a message that references no issue", () => {
+		expect(issueRefsIn("chore: bump the catalog pin\n")).toEqual([]);
+	});
+
+	it("does not read a colour, a heading or a trailing hash as an issue reference", () => {
+		expect(issueRefsIn("style: use #fff for the rule\n\n# Notes\n")).toEqual([]);
+	});
+});
+
+describe("foreignRefsIn", () => {
+	// The incident's own commit: the borrowed message named #4789 while the lane served #5437.
+	it("names the borrowed message's issue, which the lane never held (#5484)", () => {
+		expect(
+			foreignRefsIn(
+				"fix(report): state the guarantee the eval set delivers (#4789)",
+				new Set([5437]),
+			),
+		).toEqual([4789]);
+	});
+
+	it("admits a message that names only this lane's own number", () => {
+		expect(foreignRefsIn("fix(build): read the message back (#5484)", new Set([5484]))).toEqual([]);
+	});
+
+	it("admits a resume lane's PR number and the issue that PR closes, both", () => {
+		expect(
+			foreignRefsIn("fix: address the FAIL on #8410 for #5484", new Set([8410, 5484])),
+		).toEqual([]);
+	});
+
+	it("reports one entry per distinct foreign number, however often it is repeated", () => {
+		expect(foreignRefsIn("see #99, and #99 again, and #100", new Set([1]))).toEqual([99, 100]);
+	});
+});
+
+describe("isLaneScratchLeaf", () => {
+	it("admits a plain, UNKEYED leaf in the lane's directory — uniqueness is the directory's", () => {
+		expect(isLaneScratchLeaf(`${DIR}/commit-message`, DIR)).toBe(true);
+	});
+
+	// AC 4: a keyed leaf name confers nothing. The same nonce in the leaf, one directory up, is still
+	// refused — which is what proves the test keys on the directory (§SP rule 2).
+	it("refuses a run-KEYED leaf that sits outside the lane's directory", () => {
+		expect(
+			isLaneScratchLeaf("/var/folders/qq/T/fabrika-build/s-9f2e/commit-msg-5484-c1a4d6f8.txt", DIR),
+		).toBe(false);
+	});
+
+	it("refuses a hand-rolled path outside the allocator entirely", () => {
+		expect(isLaneScratchLeaf("/tmp/msg.txt", DIR)).toBe(false);
+	});
+
+	it("refuses a path that descends below the lane's directory", () => {
+		expect(isLaneScratchLeaf(`${DIR}/nested/msg.txt`, DIR)).toBe(false);
+	});
+
+	it("refuses a traversal that reads as a leaf but is not one", () => {
+		expect(isLaneScratchLeaf(`${DIR}/..`, DIR)).toBe(false);
+	});
+
+	it("refuses the directory itself, with or without a trailing slash", () => {
+		expect(isLaneScratchLeaf(DIR, DIR)).toBe(false);
+		expect(isLaneScratchLeaf(`${DIR}/`, DIR)).toBe(false);
+	});
+
+	it("refuses a sibling lane's directory whose path merely starts the same way", () => {
+		expect(isLaneScratchLeaf(`${DIR}-other/commit-message`, DIR)).toBe(false);
+	});
+
+	it("refuses a relative path — the allocator only ever prints absolute ones", () => {
+		expect(isLaneScratchLeaf("commit-message", DIR)).toBe(false);
+	});
+});
+
+describe("redact", () => {
+	it("masks the path git names in its own refusal, so a refusal can quote git safely", () => {
+		const masked = redact(`fatal: could not read log file '${DIR}/commit-message': No such file`);
+		expect(scanBody(masked).leaks).toEqual([]);
+		expect(masked).toContain("could not read log file");
+	});
+
+	it("leaves text with no machine-local path untouched", () => {
+		expect(redact("fatal: nothing to commit")).toBe("fatal: nothing to commit");
+	});
+});
+
+describe("quotedBlock", () => {
+	it("indents each line and redacts, so two blocks read as two quoted messages", () => {
+		expect(quotedBlock("subject\n\nbody line\n\n")).toEqual([
+			"    subject",
+			"    ",
+			"    body line",
+		]);
+	});
+});
+
+describe("subjectOf", () => {
+	it("is the first non-blank line", () => {
+		expect(subjectOf("\n\nfix(build): x\n\nbody\n")).toBe("fix(build): x");
+	});
+});
+
+describe("leafOf", () => {
+	it("is the last segment, which is never a machine-local path on its own", () => {
+		expect(leafOf("/Users/someone/secret/msg.txt")).toBe("msg.txt");
+		expect(scanBody(leafOf("/Users/someone/secret/msg.txt")).leaks).toEqual([]);
+	});
+});

--- a/packages/fabrika-cli/src/build/commit-verb.ts
+++ b/packages/fabrika-cli/src/build/commit-verb.ts
@@ -1,0 +1,268 @@
+/**
+ * `build commit` — create this lane's commit from a message the lane authored, and prove the commit
+ * carries it.
+ *
+ * The verb exists because the group had **no commit verb at all**, so the message-carrying path at
+ * every call site was improvised and nothing asserted the message on the resulting commit. A lane
+ * improvised `git commit -F <scratch leaf>`, the leaf held a two-day-old message from another lane,
+ * and the commit landed claiming an issue this lane had never touched — silently, with every command
+ * exiting 0 (#5484).
+ *
+ * Three guards, each closing one half of that:
+ *
+ * - **The carrying path is prescribed, not improvised.** The message arrives on stdin (file-free) or
+ *   in a leaf under `build scratch`'s claim-nonce-keyed directory. A hand-rolled path is refused
+ *   (`10`), never tolerated — a path outside the allocator is exactly the one with no per-lane key.
+ * - **The message may name only numbers this lane holds** (`4`). The borrowed message was
+ *   well-formed and referenced a real issue, which is why a shape check cannot see it and a claim
+ *   test can.
+ * - **The message is read back off the created commit** (`9`). Everything upstream is a claim about
+ *   what was *sent*; only `git log` says what git *recorded*, and the two differed in the incident.
+ */
+import {Effect, FileSystem} from "effect";
+import type {ChildProcessSpawner} from "effect/unstable/process";
+import type {StdinRead} from "../io/stdin.ts";
+import {normalizeForReadback} from "../report/compose.ts";
+import {answer, refuse, type VerbOutcome} from "../verb.ts";
+import {leakRefusal, readAuthored} from "./authored.ts";
+import {requireSession} from "./claim.ts";
+import {
+	BAD_SECTIONS,
+	COMMIT_NOT_CREATED,
+	OFF_VOCABULARY,
+	PRECONDITION_UNKNOWN,
+	READBACK_MISMATCH,
+	WRITE_UNKNOWN,
+	ZERO_SCOPE,
+} from "./codes.ts";
+import {
+	foreignRefsIn,
+	isLaneScratchLeaf,
+	leafOf,
+	quotedBlock,
+	redact,
+	subjectOf,
+} from "./commit-message.ts";
+import {commitFromFile, commitFromStdin, commitMessage, headSha, stagedPaths} from "./git.ts";
+import {laneNumber} from "./lane.ts";
+import {requireLane} from "./lane-guard.ts";
+import {closingTargets, proseOf} from "./pr-body.ts";
+import {laneScratchDir} from "./scratch-verb.ts";
+import {openPull, resolveTargetRepo} from "./target.ts";
+
+const VERB = "build commit";
+
+const SURFACE = {
+	verb: VERB,
+	emptyMessage: `${VERB}: stdin held nothing — the commit message is the input.`,
+	bareAtMessage: `${VERB}: the message is a bare @ path reference — send the message, not a pointer to it.`,
+};
+
+export interface CommitOptions {
+	/** A leaf under this lane's `build scratch` directory, or `null` to read the message from stdin. */
+	readonly messageFile: string | null;
+	readonly repo: string | null;
+	readonly env: Readonly<Record<string, string | undefined>>;
+	readonly stdin: Effect.Effect<StdinRead>;
+	/** The OS temp root, read by the adapter — the one machine fact the allocator does not derive. */
+	readonly tmpRoot: string;
+}
+
+type Message =
+	| {readonly _tag: "Refused"; readonly outcome: VerbOutcome}
+	| {readonly _tag: "Message"; readonly text: string};
+
+export const runCommit = (
+	options: CommitOptions,
+): Effect.Effect<
+	VerbOutcome,
+	never,
+	ChildProcessSpawner.ChildProcessSpawner | FileSystem.FileSystem
+> =>
+	Effect.gen(function* () {
+		const session = requireSession(VERB, options.env);
+		if (session._tag === "Refused") return session.outcome;
+
+		const resolved = yield* resolveTargetRepo(VERB, options.repo, options.env);
+		if (resolved._tag === "Refused") return resolved.outcome;
+		const repo = resolved.repo;
+
+		const lane = yield* requireLane(VERB, repo, session.id, null);
+		if (lane._tag === "Refused") return lane.outcome;
+		const branch = lane.lane;
+		const number = laneNumber(branch);
+		const notes = lane.notes;
+
+		const read: Message = yield* readMessage(options, session.id, number, branch.nonce, notes);
+		if (read._tag === "Refused") return read.outcome;
+		const message = read.text;
+
+		const leaked = leakRefusal(VERB, message);
+		if (leaked !== null) return leaked;
+
+		// In resume mode the lane's number is the PR's, so the issue the PR itself closes is a number
+		// this lane demonstrably serves — read off the PR, never taken on the message's word.
+		const permitted = new Set([number]);
+		if (branch._tag === "Resume") {
+			const pr = branch.pr;
+			const pull = yield* openPull(
+				VERB,
+				repo,
+				pr,
+				(reason) =>
+					`${VERB}: cannot read PR #${pr}: ${reason} — the numbers this lane serves are UNKNOWN, nothing was committed.`,
+			);
+			if (pull._tag === "Refused") return pull.outcome;
+			for (const target of closingTargets(proseOf(pull.pull.body))) permitted.add(target);
+		}
+
+		const foreign = foreignRefsIn(message, permitted);
+		const first = foreign[0];
+		if (first !== undefined) {
+			return refuse(
+				BAD_SECTIONS,
+				`${VERB}: the message names #${first}, which this lane holds no confirmed claim on — this lane's claim is on #${number}. A commit message names only what this lane owns; a related reference belongs in the PR body.`,
+				notes,
+			);
+		}
+
+		const staged = yield* stagedPaths;
+		if (staged._tag === "Failure") {
+			return refuse(
+				PRECONDITION_UNKNOWN,
+				`${VERB}: cannot read the index: ${redact(staged.reason)} — nothing was committed.`,
+				notes,
+			);
+		}
+		if (staged.value.length === 0) {
+			return refuse(
+				ZERO_SCOPE,
+				`${VERB}: nothing is staged — there is no change to commit.`,
+				notes,
+			);
+		}
+
+		const before = yield* headSha;
+		if (before._tag === "Failure") {
+			return refuse(
+				PRECONDITION_UNKNOWN,
+				`${VERB}: cannot resolve HEAD: ${redact(before.reason)} — nothing was committed.`,
+				notes,
+			);
+		}
+
+		const ran =
+			options.messageFile === null
+				? yield* commitFromStdin(message)
+				: yield* commitFromFile(options.messageFile);
+
+		const after = yield* headSha;
+		if (after._tag === "Failure") {
+			return refuse(
+				WRITE_UNKNOWN,
+				`${VERB}: git commit ran and HEAD could not be re-read: ${redact(after.reason)} — whether a commit exists is UNKNOWN.`,
+				notes,
+			);
+		}
+		if (after.value === before.value) {
+			return refuse(
+				COMMIT_NOT_CREATED,
+				`${VERB}: git commit ran and HEAD did not move — no commit was created${
+					ran._tag === "Failure" ? `: ${redact(ran.reason)}` : ""
+				}.`,
+				notes,
+			);
+		}
+
+		const recorded = yield* commitMessage(after.value);
+		if (recorded._tag === "Failure") {
+			return refuse(
+				WRITE_UNKNOWN,
+				`${VERB}: commit ${short(after.value)} was created but its message could not be read back: ${redact(recorded.reason)} — what it carries is UNKNOWN.`,
+				notes,
+			);
+		}
+		if (normalizeForReadback(recorded.value) !== normalizeForReadback(message)) {
+			return refuse(
+				READBACK_MISMATCH,
+				`${VERB}: commit ${short(after.value)} carries a message this lane did not author — amend it, then re-run. It needs a human eye.`,
+				[
+					...notes,
+					`${VERB}: this lane authored:`,
+					...quotedBlock(message),
+					`${VERB}: commit ${short(after.value)} reads back:`,
+					...quotedBlock(recorded.value),
+				],
+			);
+		}
+
+		return answer(
+			JSON.stringify({
+				answer: "committed",
+				sha: after.value,
+				subject: subjectOf(message),
+				carried: options.messageFile === null ? "stdin" : "scratch-leaf",
+			}),
+			notes,
+		);
+	});
+
+const short = (sha: string): string => sha.slice(0, 8);
+
+/** The message, from stdin or from a path proven to be this lane's allocator's. */
+const readMessage = (
+	options: CommitOptions,
+	session: string,
+	number: number,
+	nonce: string,
+	notes: ReadonlyArray<string>,
+): Effect.Effect<Message, never, FileSystem.FileSystem> =>
+	Effect.gen(function* () {
+		const path = options.messageFile;
+		if (path === null) {
+			const authored = readAuthored(SURFACE, yield* options.stdin);
+			return authored._tag === "Refused"
+				? {_tag: "Refused" as const, outcome: authored.outcome}
+				: {_tag: "Message" as const, text: authored.text};
+		}
+		if (!isLaneScratchLeaf(path, laneScratchDir(options.tmpRoot, session, number, nonce))) {
+			return {
+				_tag: "Refused" as const,
+				outcome: refuse(
+					OFF_VOCABULARY,
+					`${VERB}: --message-file "${leafOf(path)}" is not a leaf in this lane's scratch directory — send the message on stdin, or write it under the path "fabrika build scratch ${number} --slug <leaf>" prints. That path is machine-local, so it is not repeated here.`,
+					notes,
+				),
+			};
+		}
+		const fs = yield* FileSystem.FileSystem;
+		// A read that FAILED and a file that is EMPTY are different answers, so they never fold: the
+		// first is UNKNOWN (`11`), the second is a proven defect in what the caller wrote (`4`).
+		const attempt = yield* fs.readFileString(path).pipe(
+			Effect.map((text) => ({_tag: "Read" as const, text})),
+			Effect.catchTag("PlatformError", (cause) =>
+				Effect.succeed({_tag: "Unreadable" as const, reason: cause.message}),
+			),
+		);
+		if (attempt._tag === "Unreadable") {
+			return {
+				_tag: "Refused" as const,
+				outcome: refuse(
+					PRECONDITION_UNKNOWN,
+					`${VERB}: --message-file "${leafOf(path)}" could not be read: ${redact(attempt.reason)} — the message is UNKNOWN, never empty.`,
+					notes,
+				),
+			};
+		}
+		const text = attempt.text;
+		return text.trim() === ""
+			? {
+					_tag: "Refused" as const,
+					outcome: refuse(
+						BAD_SECTIONS,
+						`${VERB}: --message-file "${leafOf(path)}" holds no message — a commit message is the input.`,
+						notes,
+					),
+				}
+			: {_tag: "Message" as const, text};
+	});

--- a/packages/fabrika-cli/src/build/commit-verb.unit.test.ts
+++ b/packages/fabrika-cli/src/build/commit-verb.unit.test.ts
@@ -1,0 +1,334 @@
+import {Effect, Layer} from "effect";
+import {describe, expect, it} from "vitest";
+import {errOut, fakeFs, fakeShell, okOut, once} from "../fakes.test-support.ts";
+import type {ExecResult} from "../io/exec.ts";
+import type {StdinRead} from "../io/stdin.ts";
+import {scanBody} from "../report/leaks.ts";
+import type {VerbOutcome} from "../verb.ts";
+import {
+	BAD_SECTIONS,
+	CLAIM_NOT_MINE,
+	COMMIT_NOT_CREATED,
+	LEAKED_PATH,
+	OFF_VOCABULARY,
+	PRECONDITION_UNKNOWN,
+	READBACK_MISMATCH,
+	WRITE_UNKNOWN,
+	WRONG_LANE,
+	ZERO_SCOPE,
+} from "./codes.ts";
+import {runCommit} from "./commit-verb.ts";
+import {
+	comments,
+	GIT_DIRS,
+	HEAD,
+	issue,
+	LANE_UUID,
+	marker,
+	NONCE,
+	OLD_HEAD,
+	pull,
+} from "./fixtures.test-support.ts";
+import {laneScratchDir} from "./scratch-verb.ts";
+
+const REV_PARSE = /^git rev-parse --path-format=absolute/;
+const BRANCH = /^git rev-parse --abbrev-ref HEAD$/;
+const ISSUE = /^gh api repos\/o\/r\/issues\/4312$/;
+const COMMENTS = /^gh api --paginate repos\/o\/r\/issues\/4312\/comments/;
+const PERM = /^gh api repos\/o\/r\/collaborators\/agent\/permission/;
+const HEAD_SHA = /^git rev-parse HEAD$/;
+const STAGED = /^git diff --cached --name-only -z$/;
+const COMMIT = /^git commit /;
+const LOG = /^git log -1 --format=%B /;
+
+const LANE = `build/4312-editor-focus-loss-${NONCE}`;
+const SESSION = "s-9f2e";
+const TMP_ROOT = "/var/folders/qq/T";
+const SCRATCH = laneScratchDir(TMP_ROOT, SESSION, 4312, NONCE);
+
+const MESSAGE = "fix(build): read the commit message back off the commit (#4312)\n";
+
+/** The message the #5484 incident's commit really carried — another lane's, two days stale. */
+const BORROWED = "fix(report): state the guarantee the eval set actually delivers (#4789)\n";
+
+const LANE_OK: ReadonlyArray<readonly [RegExp, ExecResult]> = [
+	[REV_PARSE, GIT_DIRS],
+	[BRANCH, okOut(`${LANE}\n`)],
+	[ISSUE, issue()],
+	[COMMENTS, comments({id: 1, body: marker(SESSION, LANE_UUID)})],
+	[PERM, okOut("write\n")],
+];
+
+/**
+ * The lane proven, a change staged, HEAD at OLD_HEAD before the commit and at HEAD after.
+ *
+ * Built fresh per call: `once` carries its own spent flag, so a shared array would answer the
+ * second test's before-read with the first test's after-read.
+ */
+const ready = (): ReadonlyArray<readonly [RegExp, ExecResult]> => [
+	...LANE_OK,
+	[STAGED, okOut("packages/fabrika-cli/src/build/commit-verb.ts\0")],
+	[once(HEAD_SHA), okOut(`${OLD_HEAD}\n`)],
+	[HEAD_SHA, okOut(`${HEAD}\n`)],
+];
+
+const options = {
+	messageFile: null as string | null,
+	repo: null,
+	env: {CLAUDE_PIPELINE_REPO: "o/r", CLAUDE_CODE_SESSION_ID: SESSION} as Record<
+		string,
+		string | undefined
+	>,
+	stdin: Effect.succeed({_tag: "Text", text: MESSAGE} as StdinRead),
+	tmpRoot: TMP_ROOT,
+};
+
+const shellFor = (script: ReadonlyArray<readonly [RegExp, ExecResult]>) => fakeShell(script);
+
+const runWith = (
+	shell: ReturnType<typeof shellFor>,
+	overrides: Partial<typeof options> = {},
+	files: Record<string, string | null> = {},
+): Promise<VerbOutcome> =>
+	Effect.runPromise(
+		Effect.provide(
+			runCommit({...options, ...overrides}),
+			Layer.merge(shell.layer, fakeFs({files}).layer),
+		),
+	);
+
+const run = (
+	script: ReadonlyArray<readonly [RegExp, ExecResult]>,
+	overrides: Partial<typeof options> = {},
+	files: Record<string, string | null> = {},
+): Promise<VerbOutcome> => runWith(shellFor(script), overrides, files);
+
+/** Every byte a refusal put on stderr — what AC 6 is asserted over. */
+const stderrOf = (outcome: VerbOutcome): string => outcome.stderr.join("\n");
+
+describe("runCommit — the carrying path", () => {
+	it("carries the message on git's own stdin, with no path in the argv at all", async () => {
+		const shell = shellFor([...ready(), [COMMIT, okOut("")], [LOG, okOut(MESSAGE)]]);
+		const out = await runWith(shell);
+		expect(out.code).toBe(0);
+		const at = shell.calls.findIndex((line) => COMMIT.test(line));
+		expect(shell.calls[at]).toBe("git commit --cleanup=verbatim -F -");
+		expect(shell.inputs[at]).toBe(MESSAGE);
+		expect(JSON.parse(out.stdout)).toEqual({
+			answer: "committed",
+			sha: HEAD,
+			subject: "fix(build): read the commit message back off the commit (#4312)",
+			carried: "stdin",
+		});
+	});
+
+	it("accepts a plain UNKEYED leaf under this lane's scratch directory (§SP rule 2)", async () => {
+		const path = `${SCRATCH}/commit-message`;
+		const shell = shellFor([...ready(), [COMMIT, okOut("")], [LOG, okOut(MESSAGE)]]);
+		const out = await runWith(shell, {messageFile: path}, {[path]: MESSAGE});
+		expect(out.code).toBe(0);
+		expect(JSON.parse(out.stdout).carried).toBe("scratch-leaf");
+		expect(shell.calls).toContain(`git commit --cleanup=verbatim -F ${path}`);
+	});
+
+	// AC 3/4: the leaf name confers nothing, so a run-keyed leaf OUTSIDE the allocator is refused
+	// exactly like a plain one — uniqueness lives in the directory.
+	it.each([
+		["a hand-rolled temp path", "/tmp/msg.txt"],
+		["a home-relative path", "/Users/someone/notes/commit-msg.txt"],
+		[
+			"a run-KEYED leaf one directory above the lane's",
+			`${TMP_ROOT}/fabrika-build/${SESSION}/commit-msg-4312-${NONCE}.txt`,
+		],
+		["a sibling lane's directory", `${SCRATCH}-other/commit-message`],
+	])("refuses %s on 10, and commits nothing", async (_name, path) => {
+		const shell = shellFor([...ready(), [COMMIT, okOut("")], [LOG, okOut(MESSAGE)]]);
+		const out = await runWith(shell, {messageFile: path}, {[path]: MESSAGE});
+		expect(out.code).toBe(OFF_VOCABULARY);
+		expect(out.stdout).toBe("");
+		expect(shell.calls.some((line) => COMMIT.test(line))).toBe(false);
+	});
+
+	it("refuses a --message-file that could not be read on 11 — UNKNOWN, never empty", async () => {
+		const out = await run([...ready()], {messageFile: `${SCRATCH}/commit-message`});
+		expect(out.code).toBe(PRECONDITION_UNKNOWN);
+		expect(out.stderr.at(-1)).toContain("the message is UNKNOWN, never empty");
+	});
+
+	it("refuses an empty --message-file on 4, which is not the same fact as an unreadable one", async () => {
+		const path = `${SCRATCH}/commit-message`;
+		const out = await run([...ready()], {messageFile: path}, {[path]: "\n \n"});
+		expect(out.code).toBe(BAD_SECTIONS);
+	});
+
+	it("refuses an empty stdin on 3", async () => {
+		const out = await run([...ready()], {
+			stdin: Effect.succeed({_tag: "Text", text: ""} as StdinRead),
+		});
+		expect(out.code).toBe(3);
+	});
+});
+
+describe("runCommit — the message names only what this lane holds", () => {
+	// The incident's own shape: a well-formed conventional-commit message referencing a real issue
+	// this lane never touched (#5484).
+	it("refuses on 4 a message naming an issue this lane holds no claim on, and commits nothing", async () => {
+		const shell = shellFor([...ready(), [COMMIT, okOut("")], [LOG, okOut(BORROWED)]]);
+		const out = await runWith(shell, {
+			stdin: Effect.succeed({_tag: "Text", text: BORROWED} as StdinRead),
+		});
+		expect(out.code).toBe(BAD_SECTIONS);
+		expect(out.stdout).toBe("");
+		expect(shell.calls.some((line) => COMMIT.test(line))).toBe(false);
+		const said = out.stderr.at(-1) ?? "";
+		expect(said).toContain("names #4789");
+		expect(said).toContain("this lane's claim is on #4312");
+	});
+
+	it("admits, on a resume lane, the issue the PR itself closes — read off the PR, not the message", async () => {
+		const resume = `build/pr-4318-${NONCE}`;
+		const shell = shellFor([
+			[REV_PARSE, GIT_DIRS],
+			[BRANCH, okOut(`${resume}\n`)],
+			[/^gh api repos\/o\/r\/issues\/4318$/, issue({number: 4318})],
+			[
+				/^gh api --paginate repos\/o\/r\/issues\/4318\/comments/,
+				comments({id: 1, body: marker(SESSION, LANE_UUID)}),
+			],
+			[PERM, okOut("write\n")],
+			[/^gh api repos\/o\/r\/pulls\/4318$/, pull()],
+			[STAGED, okOut("a.ts\0")],
+			[once(HEAD_SHA), okOut(`${OLD_HEAD}\n`)],
+			[HEAD_SHA, okOut(`${HEAD}\n`)],
+			[COMMIT, okOut("")],
+			[LOG, okOut(MESSAGE)],
+		]);
+		const out = await runWith(shell);
+		expect(out.code).toBe(0);
+	});
+
+	it("refuses on 5 a message carrying a machine-local path, before any commit", async () => {
+		const shell = shellFor([...ready(), [COMMIT, okOut("")]]);
+		const out = await runWith(shell, {
+			stdin: Effect.succeed({
+				_tag: "Text",
+				text: `chore: move the notes (#4312)\n\nSee ${SCRATCH}/notes.\n`,
+			} as StdinRead),
+		});
+		expect(out.code).toBe(LEAKED_PATH);
+		expect(shell.calls.some((line) => COMMIT.test(line))).toBe(false);
+	});
+});
+
+describe("runCommit — the read-back off the created commit", () => {
+	// AC 1, and the whole point of the verb: every check upstream is about what was SENT.
+	it("refuses on 9 when the created commit carries another lane's message, naming BOTH", async () => {
+		const out = await run([...ready(), [COMMIT, okOut("")], [LOG, okOut(BORROWED)]]);
+		expect(out.code).toBe(READBACK_MISMATCH);
+		expect(out.stdout).toBe("");
+		const said = stderrOf(out);
+		expect(said).toContain("this lane authored:");
+		expect(said).toContain("fix(build): read the commit message back off the commit (#4312)");
+		expect(said).toContain("reads back:");
+		expect(said).toContain(
+			"fix(report): state the guarantee the eval set actually delivers (#4789)",
+		);
+		expect(out.stderr.at(-1)).toContain("carries a message this lane did not author");
+	});
+
+	it("redacts a machine-local path inside the message it read back — the bytes are not this lane's", async () => {
+		const out = await run([
+			...ready(),
+			[COMMIT, okOut("")],
+			[LOG, okOut(`chore: stale (#4789)\n\nwritten to ${SCRATCH}/msg\n`)],
+		]);
+		expect(out.code).toBe(READBACK_MISMATCH);
+		expect(scanBody(stderrOf(out)).leaks).toEqual([]);
+	});
+
+	it("passes a commit whose read-back differs only by trailing whitespace git normalised", async () => {
+		const out = await run([...ready(), [COMMIT, okOut("")], [LOG, okOut(`${MESSAGE}\n\n`)]]);
+		expect(out.code).toBe(0);
+	});
+
+	it("refuses on 24 when git commit ran and HEAD did not move — proven, never UNKNOWN", async () => {
+		const out = await run([
+			...LANE_OK,
+			[STAGED, okOut("a.ts\0")],
+			[HEAD_SHA, okOut(`${OLD_HEAD}\n`)],
+			[COMMIT, errOut("error: pre-commit hook refused")],
+		]);
+		expect(out.code).toBe(COMMIT_NOT_CREATED);
+		expect(out.stderr.at(-1)).toContain("pre-commit hook refused");
+	});
+
+	it("refuses on 8 when the created commit's message could not be read back — UNKNOWN", async () => {
+		const out = await run([...ready(), [COMMIT, okOut("")], [LOG, errOut("fatal: bad object")]]);
+		expect(out.code).toBe(WRITE_UNKNOWN);
+		expect(out.stdout).toBe("");
+	});
+});
+
+describe("runCommit — preconditions", () => {
+	it("refuses on 7 when nothing is staged, and commits nothing", async () => {
+		const shell = shellFor([...LANE_OK, [STAGED, okOut("")], [COMMIT, okOut("")]]);
+		const out = await runWith(shell);
+		expect(out.code).toBe(ZERO_SCOPE);
+		expect(shell.calls.some((line) => COMMIT.test(line))).toBe(false);
+	});
+
+	it("refuses on 11 when the index could not be read — nothing was committed", async () => {
+		const shell = shellFor([...LANE_OK, [STAGED, errOut("fatal: not a git repository")]]);
+		const out = await runWith(shell);
+		expect(out.code).toBe(PRECONDITION_UNKNOWN);
+		expect(shell.calls.some((line) => COMMIT.test(line))).toBe(false);
+	});
+
+	it("refuses a branch that is not a lane branch on 14", async () => {
+		const out = await run([
+			[REV_PARSE, GIT_DIRS],
+			[BRANCH, okOut("main\n")],
+		]);
+		expect(out.code).toBe(WRONG_LANE);
+	});
+
+	it("refuses a foreign claim on 15, and commits nothing", async () => {
+		const shell = shellFor([
+			[REV_PARSE, GIT_DIRS],
+			[BRANCH, okOut(`${LANE}\n`)],
+			[ISSUE, issue()],
+			[COMMENTS, comments({id: 1, body: marker("s-77aa", LANE_UUID)})],
+			[PERM, okOut("write\n")],
+			[COMMIT, okOut("")],
+		]);
+		const out = await runWith(shell);
+		expect(out.code).toBe(CLAIM_NOT_MINE);
+		expect(shell.calls.some((line) => COMMIT.test(line))).toBe(false);
+	});
+});
+
+// AC 6, asserted mechanically rather than by reading each string: `build scratch`'s path is
+// machine-local by definition, so no refusal that talks about it may repeat one.
+describe("runCommit — no refusal repeats a machine-local path", () => {
+	it("holds across every refusal this verb can reach", async () => {
+		const outcomes = await Promise.all([
+			run([...ready()], {messageFile: "/Users/someone/notes/msg.txt"}),
+			run([...ready()], {messageFile: `${SCRATCH}/commit-message`}),
+			run([...ready()], {messageFile: `${SCRATCH}/x`}, {[`${SCRATCH}/x`]: " "}),
+			run([...LANE_OK, [STAGED, okOut("")]]),
+			run([...LANE_OK, [STAGED, errOut(`fatal: cannot read ${SCRATCH}/index`)]]),
+			run([
+				...LANE_OK,
+				[STAGED, okOut("a.ts\0")],
+				[HEAD_SHA, okOut(`${OLD_HEAD}\n`)],
+				[COMMIT, errOut(`fatal: could not read log file '${SCRATCH}/commit-message'`)],
+			]),
+			run([...ready(), [COMMIT, okOut("")], [LOG, okOut(`chore: stale\n\nat ${SCRATCH}/msg\n`)]]),
+			run([...ready(), [COMMIT, okOut("")], [LOG, errOut(`fatal: ${SCRATCH} is unreadable`)]]),
+		]);
+		for (const outcome of outcomes) {
+			expect(outcome.code).not.toBe(0);
+			expect(scanBody(stderrOf(outcome)).leaks).toEqual([]);
+		}
+	});
+});

--- a/packages/fabrika-cli/src/build/git.ts
+++ b/packages/fabrika-cli/src/build/git.ts
@@ -13,7 +13,7 @@
  *   directly, and the caller compares.
  */
 import {Effect} from "effect";
-import {execCapture} from "../io/exec.ts";
+import {execCapture, execCaptureInput} from "../io/exec.ts";
 import {
 	type Attempt,
 	fail,
@@ -171,6 +171,49 @@ export const push = (remote: string, ref: string, force: boolean): Shell<Attempt
 			`HEAD:refs/heads/${ref}`,
 		]);
 		return r.ok ? ok(undefined) : fail(r.reason);
+	});
+
+/** The paths staged for commit. An empty list is a proven "there is nothing to commit". */
+export const stagedPaths: Shell<Attempt<ReadonlyArray<string>>> = Effect.gen(function* () {
+	const r = yield* execCapture("git", ["diff", "--cached", "--name-only", "-z"]);
+	return r.ok ? ok(r.stdout.split("\0").filter((p) => p !== "")) : fail(r.reason);
+});
+
+/**
+ * `--cleanup=verbatim` — git records the message byte for byte.
+ *
+ * Every other mode edits it (`whitespace` collapses consecutive blank lines, `strip` deletes `#`
+ * lines), and an edited message makes the read-back below compare two things that were never meant
+ * to be equal — a false mismatch on a clean run, which is the fastest way to get a real one ignored.
+ */
+const COMMIT_FLAGS = ["commit", "--cleanup=verbatim"];
+
+/** Create a commit from a message on git's own stdin — the file-free carrying path (#5484). */
+export const commitFromStdin = (message: string): Shell<Attempt<void>> =>
+	Effect.gen(function* () {
+		const r = yield* execCaptureInput("git", [...COMMIT_FLAGS, "-F", "-"], message);
+		return r.ok ? ok<void>(undefined) : fail(r.reason);
+	});
+
+/** Create a commit from a message file. The caller proves the path is this lane's allocator's. */
+export const commitFromFile = (path: string): Shell<Attempt<void>> =>
+	Effect.gen(function* () {
+		const r = yield* execCapture("git", [...COMMIT_FLAGS, "-F", path]);
+		return r.ok ? ok<void>(undefined) : fail(r.reason);
+	});
+
+/**
+ * The message git actually recorded on a commit — the independent witness `build commit` turns on.
+ *
+ * `%B` is the raw body, so what comes back is what a reviewer will read in the merge record. The
+ * whole point of asking git rather than trusting the invocation is #5484: the message reaching the
+ * commit and the message the lane authored were different, every command exited 0, and nothing but
+ * a read-back could tell.
+ */
+export const commitMessage = (sha: string): Shell<Attempt<string>> =>
+	Effect.gen(function* () {
+		const r = yield* execCapture("git", ["log", "-1", "--format=%B", sha]);
+		return r.ok ? ok(r.stdout) : fail(r.reason);
 	});
 
 /** The merge base of HEAD and `base` — where this lane's diff starts. */

--- a/packages/fabrika-cli/src/fakes.test-support.ts
+++ b/packages/fabrika-cli/src/fakes.test-support.ts
@@ -146,7 +146,30 @@ export interface FakeShell {
 	readonly layer: Layer.Layer<ChildProcessSpawner.ChildProcessSpawner>;
 	/** Every command line spawned, in order — how a test asserts the fetch preceded the read. */
 	readonly calls: ReadonlyArray<string>;
+	/**
+	 * What was piped to each spawned command's stdin, aligned with {@link FakeShell.calls}; `""` when
+	 * nothing was.
+	 *
+	 * Without it, a caller that hands bytes to a child through stdin is indistinguishable from one
+	 * that hands it nothing — the argv is identical (`git commit -F -`) either way — so the whole
+	 * file-free carrying path would be untestable at this seam (#5484).
+	 */
+	readonly inputs: ReadonlyArray<string>;
 }
+
+/** The bytes a command's `stdin` option carries, decoded; `""` for a mode string or no option. */
+const pipedInput = (stdin: unknown): Effect.Effect<string> => {
+	if (stdin === undefined || typeof stdin === "string") return Effect.succeed("");
+	const source =
+		typeof stdin === "object" && stdin !== null && "stream" in stdin
+			? (stdin as {readonly stream: unknown}).stream
+			: stdin;
+	if (source === undefined || typeof source === "string") return Effect.succeed("");
+	return Stream.decodeText(source as Stream.Stream<Uint8Array, unknown>).pipe(
+		Stream.mkString,
+		Effect.orElseSucceed(() => ""),
+	);
+};
 
 /**
  * A spawner scripted on the joined `file arg arg …` command line.
@@ -160,6 +183,7 @@ export const fakeShell = (
 	fallback: ExecResult = {ok: false, stdout: "", reason: "unscripted command"},
 ): FakeShell => {
 	const calls: string[] = [];
+	const inputs: string[] = [];
 	const layer = Layer.succeed(ChildProcessSpawner.ChildProcessSpawner)(
 		ChildProcessSpawner.make(
 			Effect.fnUntraced(function* (command) {
@@ -168,6 +192,9 @@ export const fakeShell = (
 				const line =
 					cmd._tag === "StandardCommand" ? [cmd.command, ...cmd.args].join(" ") : "<piped>";
 				calls.push(line);
+				inputs.push(
+					yield* pipedInput(cmd._tag === "StandardCommand" ? cmd.options.stdin : undefined),
+				);
 				const result = script.find(([pattern]) => pattern.test(line))?.[1] ?? fallback;
 				return ChildProcessSpawner.makeHandle({
 					pid: ChildProcessSpawner.ProcessId(1),
@@ -185,7 +212,7 @@ export const fakeShell = (
 			}),
 		),
 	);
-	return {layer, calls};
+	return {layer, calls, inputs};
 };
 
 /**

--- a/packages/fabrika-cli/src/io/exec.ts
+++ b/packages/fabrika-cli/src/io/exec.ts
@@ -178,11 +178,15 @@ export const execRecord: ChildRunner = (request) =>
 		),
 	);
 
-/** Run a command, capturing stdout; a non-zero exit and a spawn fault are both data, never a throw. */
-export const execCapture = (file: string, args: ReadonlyArray<string>): Exec =>
+const captured = (file: string, args: ReadonlyArray<string>, input: string | null): Exec =>
 	Effect.scoped(
 		Effect.gen(function* () {
-			const handle = yield* ChildProcess.make(file, [...args]);
+			const handle =
+				input === null
+					? yield* ChildProcess.make(file, [...args])
+					: yield* ChildProcess.make(file, [...args], {
+							stdin: Stream.fromIterable([new TextEncoder().encode(input)]),
+						});
 			const [stdout, stderr, exitCode] = yield* Effect.all(
 				[collect(handle.stdout), collect(handle.stderr), handle.exitCode],
 				{concurrency: "unbounded"},
@@ -205,3 +209,18 @@ export const execCapture = (file: string, args: ReadonlyArray<string>): Exec =>
 			}),
 		),
 	);
+
+/** Run a command, capturing stdout; a non-zero exit and a spawn fault are both data, never a throw. */
+export const execCapture = (file: string, args: ReadonlyArray<string>): Exec =>
+	captured(file, args, null);
+
+/**
+ * The same run with `input` piped to the child's stdin — the file-free carrying path.
+ *
+ * It exists so a message can reach a command **without a file on disk at all** (§SP rule 1). The
+ * scar is `git commit -F <path>`: the path is a second place the bytes live, and a lane that read
+ * back a two-day-old file at that path committed another lane's message with nothing failing
+ * anywhere (#5484). Bytes handed straight to the child cannot be stale.
+ */
+export const execCaptureInput = (file: string, args: ReadonlyArray<string>, input: string): Exec =>
+	captured(file, args, input);


### PR DESCRIPTION
A coder lane once ran `git commit -F <path>` where the file at that path held a commit message another lane had written two days earlier. Nothing failed — the file existed, was non-empty, and was a perfectly well-formed conventional-commit message — so the commit landed carrying a subject about an issue that lane had never touched. Every cheap check read green, and the only way to notice was to read the log back, which no step required.

This adds `fabrika build commit`, the verb the group did not have. It prescribes how a message reaches git, refuses a message that names work this lane does not own, and reads the message back off the commit it just made.

## What the verb does

Three guards, each closing one half of the incident:

- **The carrying path is prescribed, not improvised.** The message arrives on stdin and is handed straight to `git commit -F -` — no file on disk at all — or in a leaf under `build scratch`'s claim-nonce-keyed directory. Any other path is refused on `10`, because a path outside the allocator is precisely the one with no per-lane key.
- **The message may name only numbers this lane holds a confirmed claim on** (`4`), checked before any commit exists. In repair mode the permitted set also holds the issue the PR itself closes, read off the PR rather than taken on the message's word.
- **The message is read back off the created commit** (`9`). Everything upstream is a claim about what was *sent*; only `git log -1 --format=%B` says what git *recorded*. The refusal prints both messages, quoted, so the mismatch is legible without re-running. The commit is made with `--cleanup=verbatim` so git edits nothing and the comparison is honest.

Uniqueness lives in the **directory**, never in the leaf filename: a plain `commit-message` leaf inside this lane's directory is admitted, and a run-keyed leaf anywhere else is refused. That is asserted directly in `commit-message.unit.test.ts`.

No refusal repeats a machine-local path. The path refusals name the leaf only, and every quoted foreign string — git's own stderr, which names the file it could not read, and the message read back off the commit — is masked through the shipped `report/leaks.ts` predicate. A test sweeps every refusal the verb can reach and asserts the leak scan finds nothing.

## Where it landed

- `packages/fabrika-cli/src/build/commit-verb.ts` — the verb.
- `packages/fabrika-cli/src/build/commit-message.ts` — the pure reads (issue refs, the directory containment test, redaction).
- `packages/fabrika-cli/src/build/git.ts` — `stagedPaths`, the two commit shapes, the message read-back.
- `packages/fabrika-cli/src/io/exec.ts` — `execCaptureInput`, so bytes can reach a child without a file.
- `packages/fabrika-cli/src/fakes.test-support.ts` — the fake spawner now records piped stdin, which is the only way the file-free path is observable at that seam.
- `packages/fabrika-cli/src/build/codes.ts` — exit `24`, proven: `git commit` ran and HEAD did not move.
- `claude-plugins/fabrika/skills/build/contract.md` and `SKILL.md` — the verb's block, the inventory row, the matrix row, and the step-4 instruction to commit through the verb.

Tests: 42 new unit tests across two files; the fabrika-cli suite is 4703 passing, `pnpm typecheck` and `pnpm lint:worktree` clean.

Fixes #5484

## Deviations

**Class: a stated acceptance criterion deliberately not built.** Said: AC 5 asks that incident-corpus case 13's three expectations pass against the implementation, and that a `provenance.json` bind the case to commit `331f9292` and issue #5484. Did: skipped it entirely — no file under `packages/fabrika-cli/src/eval/incident-corpus/` is touched. Why: founder ruling #5510 deletes `packages/fabrika-cli/src/eval/` in full, so building a case into a directory that is about to be removed is wasted work. Disposition: no action needed — the substance AC 5 asks for is delivered by the other five criteria, and the corpus case has no surviving home. Flagged here rather than dropped silently. Note also that no eval of any kind was run on this branch, per the standing prohibition.

**Class: a narrowing the issue did not specify.** Said: "refuse a commit whose message names an issue number this lane holds no confirmed claim on." Did: in repair mode, also admitted the issue the PR itself closes, resolved by reading the PR body. Why: a repair lane's claim is on the PR number, so the strict reading would refuse every ordinary repair message — which references its issue. The permitted number is derived from the PR, never from the message. Disposition: no action needed; it is the same claim test, over the numbers the lane can actually prove.

**Class: a widening beyond the literal criteria.** Said: nothing about leak-scanning the commit message itself. Did: the message goes through the group's shared authored-text door, so a machine-local path in a commit message refuses on `5` and a bare `@` reference on `6`. Why: a commit message lands in the permanent merge record, which is a worse place for a leak than a comment; and reusing the existing door was cheaper than a second, partial one. Disposition: for the reviewer to judge — it is a strict addition and touches nothing else.

**Class: a new exit code.** Said: nothing about the exit table. Did: minted `24` for "git commit ran and HEAD did not move". Why: the fact is *proven* (HEAD was re-read and compared), so folding it into `8` (UNKNOWN — may or may not have landed) would fuse "no commit exists" with "a commit may exist", which is the fusion this group refuses everywhere else. It is seated in `build/codes.ts`, not in the verb file, so the exit-code alignment guard can see it. Disposition: no action needed.