### PR TITLE
fix(fabrika): compare an anchor's whole block, not just its own line (#5514)

### DIFF
--- a/claude-plugins/fabrika/skills/governance/contract.md
+++ b/claude-plugins/fabrika/skills/governance/contract.md
@@ -615,6 +615,21 @@ diff, so a paragraph reworded under an untouched tag read as `no-anchor-change`
 comparable base path, so those keep the older same-line walk over the diff's `+`/`-` lines; a file
 covered by both scans still reports one hit per NAME.
 
+Two rules complete that definition, both load-bearing, so that two implementers build one verb.
+
+**A block continues past its own line only from a tag that opens that line.** Indentation, a
+blockquote marker, one list bullet, or a block comment's decoration may precede the tag — nothing
+else. A tag reached after real content gets only the text trailing it on that line, which is what the
+same-line walk has always compared. This is what stops a tag written inside a string literal from
+swallowing the code below it, and it is a fence on the widening, never a narrowing.
+
+**Inside a block comment, a line's prose is the line minus its decoration, and the comment's end ends
+the block.** Half the guarded corpus writes its claims in TypeScript docblocks, where every
+continuation line opens with a star — the same bytes as a markdown list item, and only the frame
+tells the two apart. Without this rule every `.ts` block stopped on the line after its tag, so those
+anchors counted toward `anchors-in-reach` while being unable to produce a hit. A real list *inside* a
+docblock still ends the block, because the break is tested against the prose, not the decoration.
+
 **What a guard-bearing file is, stated closed so two implementers build one verb.** A changed file is
 guard-bearing iff it satisfies at least one of exactly two clauses: **(a)** it contains at least one
 anchor at the bound commit, or **(b)** it is under `.github/workflows/`. Nothing else qualifies — in

--- a/claude-plugins/fabrika/skills/governance/contract.md
+++ b/claude-plugins/fabrika/skills/governance/contract.md
@@ -594,16 +594,26 @@ With `--json`:
 `{"outcome":…,"hits":[{"kind","name","file","line"}…],"guardFiles":[{"path","anchors"}…],"inReach":<n>,"scanned":<files>}`.
 
 **The three outcomes are distinct facts and none is a clearance.** `hits` — an anchored invariant
-was removed or its line changed. `no-anchor-change` — anchors exist in the diff's reach and none
+was removed or its claim changed. `no-anchor-change` — anchors exist in the diff's reach and none
 moved. `no-anchors-in-reach` — the touched files carry no anchors at all, so this scan had nothing
 to look at; it is the mechanical floor reporting its own silence, not a statement that no guard was
 weakened. A guard weakened in prose that carries no anchor is invisible here **by construction**,
 and the skill's judgment is what covers it.
 
 **What an anchor is.** The `<!-- anchor: NAME -->` HTML comment fabrika skills already carry; NAME is
-`[A-Z][A-Z0-9-]*`. The scan is over the diff's removed and added lines, pairing by NAME: a NAME
-present in a removed line and absent from every added line is `removed`; a NAME on both sides with
-different following text is `modified`.
+`[A-Z][A-Z0-9-]*`. A tag inside backticks is documentation of the pattern, not an anchor.
+
+**What is compared is the anchor's whole block, at both commits.** An anchor's block is the text
+trailing its tag plus the lines that continue the same paragraph, ending at a blank line, a heading,
+a new list item, a code fence, or the next anchor. Each changed file is read at the base commit and
+at the head, and the blocks are paired by NAME and occurrence: a NAME absent from the head is
+`removed`; a NAME whose block text differs is `modified`. Whitespace is collapsed before comparing,
+so a re-wrap or a move is not a hit. Reading both commits is what makes the answer independent of
+the diff's shape — a same-line comparison could not see an anchor whose own line was never in the
+diff, so a paragraph reworded under an untouched tag read as `no-anchor-change`
+([#5514](https://github.com/kamp-us/phoenix/issues/5514)). A deleted file and a rename have no
+comparable base path, so those keep the older same-line walk over the diff's `+`/`-` lines; a file
+covered by both scans still reports one hit per NAME.
 
 **What a guard-bearing file is, stated closed so two implementers build one verb.** A changed file is
 guard-bearing iff it satisfies at least one of exactly two clauses: **(a)** it contains at least one
@@ -644,11 +654,14 @@ anchors rather than invariants.
 | `governance guards: cannot read the diff for #<n> at <sha>: <reason> — UNKNOWN, never "nothing moved".` | 11 | refusal |
 | `governance guards: PR #<n>'s head is <live>, not <asked> — re-scan at <live> (ADR 0058).` | 12 | refusal |
 | `governance guards: the diff at <sha> carries <k> of #<n>'s <m> declared files — refusing a partial anchor scan (#3925's class).` | 13 | refusal |
-| `governance guards: scanned <k> files, <m> anchored invariants in reach.` | 0 | notice |
+| `governance guards: cannot read <path> at <sha>: <reason> — UNKNOWN, never "nothing moved".` | 11 | refusal |
+| `governance guards: scanned <k> files, <m> anchored invariants in reach, <j> compared block-by-block against <base>.` | 0 | notice |
 
 **Scope** — the bound commit's diff, completeness-checked against the PR's declared changed-file
-count, and the anchors in every file that diff touches. A truncated diff is refused rather than
-scanned, because an under-reported hit list reads as a checked-clean answer that was never checked.
+count, and the anchors in every file that diff touches, read at the base commit as well as at the
+head. A truncated diff is refused rather than scanned, because an under-reported hit list reads as a
+checked-clean answer that was never checked; a file that cannot be read at either commit is refused
+for the same reason.
 
 **Examples**
 

--- a/packages/fabrika-cli/src/governance/anchors.ts
+++ b/packages/fabrika-cli/src/governance/anchors.ts
@@ -154,6 +154,23 @@ const BLOCK_BREAK = /^\s*$|^\s*#{1,6}\s|^\s*(?:[-*+]|\d+[.)])\s|^\s*(?:```|~~~)/
  */
 const normalize = (text: string): string => text.replace(/\s+/g, " ").trim();
 
+/**
+ * What may sit before a tag on a line that still *opens* a paragraph: indentation, blockquote markers
+ * and one list bullet. Nothing else.
+ *
+ * A tag reached only after real content did not open the lines below it, so continuing through them
+ * captures text the anchor never covered. That is not hypothetical: this file's own tests embed the
+ * tag in TypeScript string literals, and the block ran off the end of the literal and swallowed the
+ * assertions after it, so editing an assertion reported the fixture as a moved invariant. Every
+ * anchor in the guarded corpus opens its line — bare, after a bullet, or after a blockquote marker —
+ * which the `anchorsIn` note above already observes from the other side.
+ *
+ * A tag that does NOT open its line still gets a block: the text trailing it on that one line, which
+ * is exactly what the diff walk has always compared. So this is a fence on the *widening*, never a
+ * narrowing of what was already covered (#5514).
+ */
+const OPENS_LINE = /^[\s>]*(?:(?:[-*+]|\d+[.)])\s+)?$/;
+
 /** One anchor's paragraph at one commit — the tag's trailing text plus the lines that continue it. */
 interface AnchorBlock {
 	readonly name: string;
@@ -177,7 +194,8 @@ export const anchorBlocksIn = (text: string): ReadonlyArray<AnchorBlock> => {
 		const matched = ANCHOR.exec(maskInlineCode(line));
 		if (matched?.[1] === undefined) continue;
 		const body = [line.slice(matched.index + matched[0].length)];
-		for (let next = index + 1; next < lines.length; next += 1) {
+		const opens = OPENS_LINE.test(line.slice(0, matched.index));
+		for (let next = index + 1; opens && next < lines.length; next += 1) {
 			const candidate = lines[next] ?? "";
 			// The break test reads the raw line and the anchor test the masked one, because masking is
 			// length-preserving but not content-preserving: it eats the leading backticks of a ``` fence,
@@ -203,10 +221,16 @@ const byName = (blocks: ReadonlyArray<AnchorBlock>): Map<string, AnchorBlock[]> 
 /**
  * Every anchored invariant whose block `before` carries and `after` removed or reworded.
  *
- * Pairing is by NAME and then by occurrence, so a name used twice in one file is two independent
- * questions rather than one that answers itself from the wrong paragraph. A name absent from `after`
- * is `removed`; a name whose normalized block text differs is `modified`, reported at the line it
- * now sits on. A block that only moved is neither.
+ * A name absent from `after` is `removed`; a name whose normalized block text differs is `modified`,
+ * reported at the line it now sits on. A block that only moved is neither.
+ *
+ * **An unchanged block is claimed before a reworded one, and each is claimed once.** Where a name is
+ * used twice in one file, matching by position alone answers the wrong question the moment a new
+ * occurrence is inserted above an old one: both blocks are intact, but occurrence 1 is now compared
+ * against occurrence 2's text and reads as reworded. Matching an identical block first makes an
+ * insertion silent while leaving a genuine rewording loud, because a reworded block has no identical
+ * counterpart to claim; consuming each match keeps two same-named blocks two questions rather than
+ * letting one answer for both.
  */
 export const scanAnchorBlocks = (
 	file: string,
@@ -214,16 +238,19 @@ export const scanAnchorBlocks = (
 	after: string,
 ): ReadonlyArray<AnchorHit> => {
 	const later = byName(anchorBlocksIn(after));
-	const seen = new Map<string, number>();
 	const hits: AnchorHit[] = [];
 	for (const block of anchorBlocksIn(before)) {
-		const nth = seen.get(block.name) ?? 0;
-		seen.set(block.name, nth + 1);
-		const match = later.get(block.name)?.[nth];
-		if (match === undefined) {
+		const candidates = later.get(block.name) ?? [];
+		const intact = candidates.findIndex((entry) => entry.text === block.text);
+		if (intact >= 0) {
+			candidates.splice(intact, 1);
+			continue;
+		}
+		const reworded = candidates.shift();
+		if (reworded === undefined) {
 			hits.push({kind: "removed", name: block.name, file, line: block.line});
-		} else if (match.text !== block.text) {
-			hits.push({kind: "modified", name: block.name, file, line: match.line});
+		} else {
+			hits.push({kind: "modified", name: block.name, file, line: reworded.line});
 		}
 	}
 	return hits;

--- a/packages/fabrika-cli/src/governance/anchors.ts
+++ b/packages/fabrika-cli/src/governance/anchors.ts
@@ -1,5 +1,6 @@
 /**
- * The anchored-invariant scan, pure over a unified diff.
+ * The anchored-invariant scan: a per-anchor **block** comparison of two commits' bytes, plus the
+ * older same-line walk over a unified diff.
  *
  * An anchor is the `<!-- anchor: NAME -->` HTML comment fabrika skills already carry. The inventory
  * therefore lives **in the guarded file**, which is the whole design difference from v1's gate check:
@@ -7,7 +8,15 @@
  * copy drifted from the guards silently and nothing checked it. Anchors cannot rot while the guards
  * move, because they move with them.
  *
- * What this scan cannot see is stated rather than implied: a guard weakened in prose carrying no
+ * **Why a block comparison exists at all (#5514).** The diff walk below can only see an anchor whose
+ * *own line* is in the diff, and it compares only the text trailing the tag on that line. Anchors in
+ * this corpus are inline — `<!-- anchor: NAME --> **Claim.** …` — and the claim wraps over several
+ * more lines, so a rewrite of those continuation lines left the anchor line byte-identical, produced
+ * no sighting at all, and the verb answered `no-anchor-change` over a guarantee that had in fact been
+ * reworded (PR #5501). {@link scanAnchorBlocks} compares each anchor's whole paragraph at both
+ * commits, so what it sees does not depend on the shape of the diff.
+ *
+ * What the scan still cannot see is stated rather than implied: a guard weakened in prose carrying no
  * anchor is invisible here **by construction**. That is why the verb's third outcome is
  * `no-anchors-in-reach` — the mechanical floor reporting its own silence — and never a clearance.
  */
@@ -124,6 +133,123 @@ export const scanAnchors = (diff: string): ReadonlyArray<AnchorHit> => {
 	}
 	flush();
 	return hits;
+};
+
+/**
+ * A line that ends the paragraph an anchor opened: blank, a heading, a new list item, or a fence.
+ *
+ * Markdown has no end-of-paragraph token, so the block has to end at what starts the *next* unit. The
+ * list-item and heading clauses are what keep an anchor sitting on one bullet from swallowing its
+ * siblings — without them a reword of the bullet *below* an anchor reads as that anchor moving, and a
+ * guard that cries on unrelated prose gets read past.
+ */
+const BLOCK_BREAK = /^\s*$|^\s*#{1,6}\s|^\s*(?:[-*+]|\d+[.)])\s|^\s*(?:```|~~~)/;
+
+/**
+ * Whitespace collapsed to single spaces, so a re-wrap is not a change.
+ *
+ * A block spans several lines and markdown line breaks are cosmetic: comparing raw bytes would report
+ * every reflow as a weakened guarantee, which is the same noise {@link scanAnchors}' move-is-not-a-hit
+ * rule exists to avoid.
+ */
+const normalize = (text: string): string => text.replace(/\s+/g, " ").trim();
+
+/** One anchor's paragraph at one commit — the tag's trailing text plus the lines that continue it. */
+interface AnchorBlock {
+	readonly name: string;
+	/** 1-based, the line the tag itself sits on. */
+	readonly line: number;
+	readonly text: string;
+}
+
+/**
+ * Every anchor a file's bytes carry, with the paragraph each one opens.
+ *
+ * Anchor detection runs on {@link maskInlineCode}'d text, on the line that *opens* a block and on
+ * every line that could *end* one, so a tag inside backticks neither mints a block nor cuts one
+ * short. The compared text is the real bytes, because that fence is about what counts as an anchor,
+ * not about which prose an anchor covers.
+ */
+export const anchorBlocksIn = (text: string): ReadonlyArray<AnchorBlock> => {
+	const lines = text.split("\n");
+	const blocks: AnchorBlock[] = [];
+	for (const [index, line] of lines.entries()) {
+		const matched = ANCHOR.exec(maskInlineCode(line));
+		if (matched?.[1] === undefined) continue;
+		const body = [line.slice(matched.index + matched[0].length)];
+		for (let next = index + 1; next < lines.length; next += 1) {
+			const candidate = lines[next] ?? "";
+			// The break test reads the raw line and the anchor test the masked one, because masking is
+			// length-preserving but not content-preserving: it eats the leading backticks of a ``` fence,
+			// which is exactly the marker the break is looking for.
+			if (BLOCK_BREAK.test(candidate) || ANCHOR.test(maskInlineCode(candidate))) break;
+			body.push(candidate);
+		}
+		blocks.push({name: matched[1], line: index + 1, text: normalize(body.join(" "))});
+	}
+	return blocks;
+};
+
+const byName = (blocks: ReadonlyArray<AnchorBlock>): Map<string, AnchorBlock[]> => {
+	const grouped = new Map<string, AnchorBlock[]>();
+	for (const block of blocks) {
+		const kept = grouped.get(block.name);
+		if (kept === undefined) grouped.set(block.name, [block]);
+		else kept.push(block);
+	}
+	return grouped;
+};
+
+/**
+ * Every anchored invariant whose block `before` carries and `after` removed or reworded.
+ *
+ * Pairing is by NAME and then by occurrence, so a name used twice in one file is two independent
+ * questions rather than one that answers itself from the wrong paragraph. A name absent from `after`
+ * is `removed`; a name whose normalized block text differs is `modified`, reported at the line it
+ * now sits on. A block that only moved is neither.
+ */
+export const scanAnchorBlocks = (
+	file: string,
+	before: string,
+	after: string,
+): ReadonlyArray<AnchorHit> => {
+	const later = byName(anchorBlocksIn(after));
+	const seen = new Map<string, number>();
+	const hits: AnchorHit[] = [];
+	for (const block of anchorBlocksIn(before)) {
+		const nth = seen.get(block.name) ?? 0;
+		seen.set(block.name, nth + 1);
+		const match = later.get(block.name)?.[nth];
+		if (match === undefined) {
+			hits.push({kind: "removed", name: block.name, file, line: block.line});
+		} else if (match.text !== block.text) {
+			hits.push({kind: "modified", name: block.name, file, line: match.line});
+		}
+	}
+	return hits;
+};
+
+/**
+ * The two scans as one hit list, at most one hit per (file, NAME).
+ *
+ * The block comparison subsumes the diff walk wherever both can run, but not everywhere: a deleted
+ * file has no head bytes to compare and a rename's base path is not in the change list, so the walk
+ * is the only scan that reaches those. Keeping both and deduping is therefore a widening, never a
+ * second opinion — and `first` wins so the walk's diff-order line numbers survive.
+ */
+export const mergeHits = (
+	first: ReadonlyArray<AnchorHit>,
+	second: ReadonlyArray<AnchorHit>,
+): ReadonlyArray<AnchorHit> => {
+	const merged: AnchorHit[] = [...first];
+	const keys = new Set(first.map((hit) => `${hit.file} ${hit.name}`));
+	for (const hit of second) {
+		const key = `${hit.file} ${hit.name}`;
+		if (keys.has(key)) continue;
+		keys.add(key);
+		merged.push(hit);
+	}
+	return merged;
 };
 
 /** A changed file is guard-bearing iff it carries an anchor, or sits under `.github/workflows/`. */

--- a/packages/fabrika-cli/src/governance/anchors.ts
+++ b/packages/fabrika-cli/src/governance/anchors.ts
@@ -142,8 +142,58 @@ export const scanAnchors = (diff: string): ReadonlyArray<AnchorHit> => {
  * list-item and heading clauses are what keep an anchor sitting on one bullet from swallowing its
  * siblings — without them a reword of the bullet *below* an anchor reads as that anchor moving, and a
  * guard that cries on unrelated prose gets read past.
+ *
+ * It is applied to a line's **prose**, which in a comment-framed block is the line with its decoration
+ * removed — see {@link commentFramedLines}.
  */
 const BLOCK_BREAK = /^\s*$|^\s*#{1,6}\s|^\s*(?:[-*+]|\d+[.)])\s|^\s*(?:```|~~~)/;
+
+const COMMENT_OPEN = "/*";
+const COMMENT_CLOSE = "*/";
+
+/**
+ * A block comment's decoration on one line: its opener, or the star a docblock repeats down its left
+ * edge. The terminator is excluded — that ends the frame rather than decorating a line inside it.
+ */
+const COMMENT_DECORATION = /^\s*(?:\/\*+|\*(?!\/))\s?/;
+
+/**
+ * Which lines sit inside a block comment — the frame the anchor's paragraph is written in (#5514).
+ *
+ * Half the guarded corpus writes its anchored claims in TypeScript docblocks, where every continuation
+ * line begins with a star. Read as markdown that star is a new list item, so {@link BLOCK_BREAK} fired
+ * on the line immediately after every `.ts` anchor and its block was truncated to the tag's own line —
+ * 80 anchors counted in the `anchors-in-reach` denominator and structurally unable to contribute to
+ * the numerator, which is the shape #5514 exists to remove.
+ *
+ * The two cases are only distinguishable by *frame*, never by the line: `* a bullet` and a docblock's
+ * `* a continuation` are the same bytes. So the frame is resolved once per file here, and a
+ * comment-framed block reads each line's prose with its decoration stripped, ending where the comment
+ * does. Keying on the frame rather than on a file extension is what keeps an anchor in a docblock and
+ * an anchor in prose one rule instead of two — a `.md` file's fenced TypeScript example is framed by
+ * the same evidence its `.ts` original is.
+ *
+ * The scan is over comment syntax, not a parse, so an unterminated opener inside a string literal
+ * would frame the lines after it. That misreads nothing on its own: the block still ends at the same
+ * paragraph boundaries, it just tolerates a leading star — and a tag reached after real content is
+ * already fenced to its own line by {@link OPENS_LINE}.
+ */
+const commentFramedLines = (lines: ReadonlyArray<string>): ReadonlyArray<boolean> => {
+	const framed: boolean[] = [];
+	let open = false;
+	for (const line of lines) {
+		if (open) {
+			framed.push(true);
+			if (line.includes(COMMENT_CLOSE)) open = false;
+			continue;
+		}
+		const opened = line.lastIndexOf(COMMENT_OPEN);
+		const closed = opened >= 0 && line.indexOf(COMMENT_CLOSE, opened + COMMENT_OPEN.length) >= 0;
+		open = opened >= 0 && !closed;
+		framed.push(open);
+	}
+	return framed;
+};
 
 /**
  * Whitespace collapsed to single spaces, so a re-wrap is not a change.
@@ -161,9 +211,13 @@ const normalize = (text: string): string => text.replace(/\s+/g, " ").trim();
  * A tag reached only after real content did not open the lines below it, so continuing through them
  * captures text the anchor never covered. That is not hypothetical: this file's own tests embed the
  * tag in TypeScript string literals, and the block ran off the end of the literal and swallowed the
- * assertions after it, so editing an assertion reported the fixture as a moved invariant. Every
- * anchor in the guarded corpus opens its line — bare, after a bullet, or after a blockquote marker —
- * which the `anchorsIn` note above already observes from the other side.
+ * assertions after it, so editing an assertion reported the fixture as a moved invariant.
+ *
+ * Nearly every anchor in the guarded corpus opens its line — bare, after a bullet, after a blockquote
+ * marker, or after a docblock's star. The exceptions are of two kinds and neither is a loss. A handful
+ * of markdown anchors are written at the very *end* of their line, so their compared text is the empty
+ * string either way. The rest are this package's own test fixtures, which embed the tag in a string
+ * literal — the case the fence exists for.
  *
  * A tag that does NOT open its line still gets a block: the text trailing it on that one line, which
  * is exactly what the diff walk has always compared. So this is a fence on the *widening*, never a
@@ -186,22 +240,33 @@ interface AnchorBlock {
  * every line that could *end* one, so a tag inside backticks neither mints a block nor cuts one
  * short. The compared text is the real bytes, because that fence is about what counts as an anchor,
  * not about which prose an anchor covers.
+ *
+ * Inside a block comment a line's prose is the line minus its decoration, and the comment's
+ * terminator ends the block — see {@link commentFramedLines} for why the frame, not the file's
+ * extension, is what decides.
  */
 export const anchorBlocksIn = (text: string): ReadonlyArray<AnchorBlock> => {
 	const lines = text.split("\n");
+	const framed = commentFramedLines(lines);
 	const blocks: AnchorBlock[] = [];
 	for (const [index, line] of lines.entries()) {
 		const matched = ANCHOR.exec(maskInlineCode(line));
 		if (matched?.[1] === undefined) continue;
+		const inComment = framed[index] === true;
+		const prose = (raw: string): string => (inComment ? raw.replace(COMMENT_DECORATION, "") : raw);
 		const body = [line.slice(matched.index + matched[0].length)];
-		const opens = OPENS_LINE.test(line.slice(0, matched.index));
+		const opens = OPENS_LINE.test(prose(line.slice(0, matched.index)));
 		for (let next = index + 1; opens && next < lines.length; next += 1) {
-			const candidate = lines[next] ?? "";
+			const raw = lines[next] ?? "";
+			if (inComment && framed[next] !== true) break;
+			const ends = inComment ? raw.indexOf(COMMENT_CLOSE) : -1;
+			const candidate = prose(ends >= 0 ? raw.slice(0, ends) : raw);
 			// The break test reads the raw line and the anchor test the masked one, because masking is
 			// length-preserving but not content-preserving: it eats the leading backticks of a ``` fence,
 			// which is exactly the marker the break is looking for.
 			if (BLOCK_BREAK.test(candidate) || ANCHOR.test(maskInlineCode(candidate))) break;
 			body.push(candidate);
+			if (ends >= 0) break;
 		}
 		blocks.push({name: matched[1], line: index + 1, text: normalize(body.join(" "))});
 	}

--- a/packages/fabrika-cli/src/governance/anchors.unit.test.ts
+++ b/packages/fabrika-cli/src/governance/anchors.unit.test.ts
@@ -107,6 +107,25 @@ const PACKED_BRANCH = (checkout: string): string =>
 		"",
 	].join("\n");
 
+/**
+ * The same defect in the other half of the guarded corpus, taken from `handoff/ground.ts`: the claim
+ * lives in a TypeScript docblock, where every continuation line opens with the star markdown reads as
+ * a new list item — so the block used to end on the line after the tag and the reworded checkout was
+ * invisible (#5514).
+ */
+const PACKED_BRANCH_DOCBLOCK = (checkout: string): string =>
+	[
+		"/**",
+		" * Rows 3-10, derived against the pack.",
+		" *",
+		" * <!-- anchor: READ-DERIVES-AGAINST-THE-PACKED-BRANCH --> **`read` re-derives against the",
+		" * pack's own branch, never the successor's `HEAD`.** A successor is by construction a",
+		` * different checkout — usually ${checkout} — so deriving there would report drift.`,
+		" */",
+		"export const deriveGitCore = () => {};",
+		"",
+	].join("\n");
+
 describe("anchorBlocksIn", () => {
 	it("carries the anchor's continuation lines, which is the text the same-line scan never read", () => {
 		expect(anchorBlocksIn("<!-- anchor: G --> a claim\nthat wraps here\n\nunrelated\n")).toEqual([
@@ -161,6 +180,39 @@ describe("anchorBlocksIn", () => {
 			{name: "G", line: 1, text: "a claim that wraps"},
 		]);
 	});
+
+	// Half the guarded corpus writes its claims in docblocks, where a continuation line and a list item
+	// are the same bytes and only the frame tells them apart (#5514).
+	it("continues through a docblock's star continuation lines and stops at the comment's end", () => {
+		expect(anchorBlocksIn(PACKED_BRANCH_DOCBLOCK("a fresh worktree"))).toEqual([
+			{
+				name: "READ-DERIVES-AGAINST-THE-PACKED-BRANCH",
+				line: 4,
+				text:
+					"**`read` re-derives against the pack's own branch, never the successor's `HEAD`.** " +
+					"A successor is by construction a different checkout — usually a fresh worktree — so " +
+					"deriving there would report drift.",
+			},
+		]);
+	});
+
+	it("ends a docblock's block at the star-only line — a docblock's paragraph break", () => {
+		expect(
+			anchorBlocksIn("/**\n * <!-- anchor: G --> a claim\n *\n * a second paragraph\n */\n"),
+		).toEqual([{name: "G", line: 2, text: "a claim"}]);
+	});
+
+	it("still breaks on a REAL list inside a docblock — the frame strips decoration, not structure", () => {
+		expect(
+			anchorBlocksIn("/**\n * <!-- anchor: G --> a claim\n * - a bullet below it\n */\n"),
+		).toEqual([{name: "G", line: 2, text: "a claim"}]);
+	});
+
+	it("still breaks on a markdown star bullet, where no comment frame says otherwise", () => {
+		expect(anchorBlocksIn("* <!-- anchor: G --> a claim\n* a sibling bullet\n")).toEqual([
+			{name: "G", line: 1, text: "a claim"},
+		]);
+	});
 });
 
 describe("scanAnchorBlocks", () => {
@@ -179,6 +231,33 @@ describe("scanAnchorBlocks", () => {
 				line: 1,
 			},
 		]);
+	});
+
+	it("reports the PR #5501 shape in a TypeScript docblock too — the .ts half of the corpus", () => {
+		expect(
+			scanAnchorBlocks(
+				"ground.ts",
+				PACKED_BRANCH_DOCBLOCK("a fresh worktree"),
+				PACKED_BRANCH_DOCBLOCK("a fresh clone"),
+			),
+		).toEqual([
+			{
+				kind: "modified",
+				name: "READ-DERIVES-AGAINST-THE-PACKED-BRANCH",
+				file: "ground.ts",
+				line: 4,
+			},
+		]);
+	});
+
+	it("reports NOTHING for a docblock re-wrap — a star continuation line break is cosmetic", () => {
+		expect(
+			scanAnchorBlocks(
+				"ground.ts",
+				"/**\n * <!-- anchor: G --> a claim that\n * wraps here\n */\n",
+				"/**\n * <!-- anchor: G --> a claim\n * that wraps here\n */\n",
+			),
+		).toEqual([]);
 	});
 
 	it("reports NOTHING for a block that only moved — the anti-noise property, at block scale", () => {

--- a/packages/fabrika-cli/src/governance/anchors.unit.test.ts
+++ b/packages/fabrika-cli/src/governance/anchors.unit.test.ts
@@ -144,6 +144,23 @@ describe("anchorBlocksIn", () => {
 			anchorBlocksIn("<!-- anchor: G --> a claim\nwritten as `<!-- anchor: NAME -->` here\n"),
 		).toEqual([{name: "G", line: 1, text: "a claim written as `<!-- anchor: NAME -->` here"}]);
 	});
+
+	// The over-capture this file's own tests exposed: the tag sits inside a TypeScript string literal,
+	// so the lines below it are unrelated code the anchor never covered (#5514).
+	it("does NOT continue past a tag that real content precedes — it covered no lines below it", () => {
+		expect(anchorBlocksIn('expect(scan("<!-- anchor: A --> one"));\nexpect(other());\n')).toEqual([
+			{name: "A", line: 1, text: 'one"));'},
+		]);
+	});
+
+	it("still continues from a tag a blockquote marker or a bullet precedes — those open a line", () => {
+		expect(anchorBlocksIn("> <!-- anchor: G --> a claim\n> that wraps\n")).toEqual([
+			{name: "G", line: 1, text: "a claim > that wraps"},
+		]);
+		expect(anchorBlocksIn("1. <!-- anchor: G --> a claim\n   that wraps\n")).toEqual([
+			{name: "G", line: 1, text: "a claim that wraps"},
+		]);
+	});
 });
 
 describe("scanAnchorBlocks", () => {
@@ -200,7 +217,7 @@ describe("scanAnchorBlocks", () => {
 		);
 	});
 
-	it("pairs a repeated NAME by occurrence — two uses are two questions, not one", () => {
+	it("reports only the reworded one of two same-named blocks — two uses are two questions", () => {
 		expect(
 			scanAnchorBlocks(
 				"a.md",
@@ -208,6 +225,38 @@ describe("scanAnchorBlocks", () => {
 				"<!-- anchor: G --> one\n\n<!-- anchor: G --> rewritten\n",
 			),
 		).toEqual([{kind: "modified", name: "G", file: "a.md", line: 3}]);
+	});
+
+	// Positional pairing alone answers the wrong question here: both blocks are intact, but the old
+	// occurrence 1 lands against the new occurrence 2's text and reads as reworded (#5514).
+	it("reports NOTHING when a new same-named anchor is INSERTED above an intact one", () => {
+		expect(
+			scanAnchorBlocks(
+				"a.md",
+				"<!-- anchor: G --> the old claim\n",
+				"<!-- anchor: G --> a new claim\n\n<!-- anchor: G --> the old claim\n",
+			),
+		).toEqual([]);
+	});
+
+	it("still reports a rewording when a same-named anchor was inserted in the same edit", () => {
+		expect(
+			scanAnchorBlocks(
+				"a.md",
+				"<!-- anchor: G --> the old claim\n",
+				"<!-- anchor: G --> a new claim\n\n<!-- anchor: G --> the old claim, softened\n",
+			),
+		).toEqual([{kind: "modified", name: "G", file: "a.md", line: 1}]);
+	});
+
+	it("reports the SECOND of two same-named blocks as removed when only one survives", () => {
+		expect(
+			scanAnchorBlocks(
+				"a.md",
+				"<!-- anchor: G --> one\n\n<!-- anchor: G --> two\n",
+				"<!-- anchor: G --> one\n",
+			),
+		).toEqual([{kind: "removed", name: "G", file: "a.md", line: 3}]);
 	});
 
 	it("reports NOTHING when an anchor is added — a new guarantee is not a moved one", () => {

--- a/packages/fabrika-cli/src/governance/anchors.unit.test.ts
+++ b/packages/fabrika-cli/src/governance/anchors.unit.test.ts
@@ -1,7 +1,15 @@
 import {readFileSync} from "node:fs";
 import {fileURLToPath} from "node:url";
 import {describe, expect, it} from "vitest";
-import {anchorsIn, filesInDiff, isGuardBearing, scanAnchors} from "./anchors.ts";
+import {
+	anchorBlocksIn,
+	anchorsIn,
+	filesInDiff,
+	isGuardBearing,
+	mergeHits,
+	scanAnchorBlocks,
+	scanAnchors,
+} from "./anchors.ts";
 
 const GOVERNANCE_SKILL = "claude-plugins/fabrika/skills/governance/SKILL.md";
 
@@ -80,6 +88,147 @@ describe("scanAnchors", () => {
 
 	it("finds nothing in a diff that carries no anchor at all", () => {
 		expect(scanAnchors(diff(...file("src/cart.ts"), "-const a = 1;", "+const a = 2;"))).toEqual([]);
+	});
+});
+
+/**
+ * The live shape of the defect, taken from the merged PR #5501: an anchored claim whose continuation
+ * line was reworded while the anchor's own line stayed byte-identical, so no `+`/`-` line in that
+ * 98-file diff carried an anchor tag at all.
+ */
+const PACKED_BRANCH = (checkout: string): string =>
+	[
+		"<!-- anchor: READ-DERIVES-AGAINST-THE-PACKED-BRANCH --> **`read` re-derives rows 3–10 against",
+		"the pack's own `git.branch`, never against the successor's `HEAD`.** A successor is by",
+		`construction a different checkout — usually ${checkout} sitting on the default branch — so`,
+		"deriving `git.head` from `HEAD` would report the successor's own location as drift.",
+		"",
+		"**The compared set is therefore sixteen of the nineteen, not all of them.**",
+		"",
+	].join("\n");
+
+describe("anchorBlocksIn", () => {
+	it("carries the anchor's continuation lines, which is the text the same-line scan never read", () => {
+		expect(anchorBlocksIn("<!-- anchor: G --> a claim\nthat wraps here\n\nunrelated\n")).toEqual([
+			{name: "G", line: 1, text: "a claim that wraps here"},
+		]);
+	});
+
+	it("ends a block at the next anchor, so one paragraph never answers for another", () => {
+		expect(anchorBlocksIn("<!-- anchor: A --> one\n<!-- anchor: B --> two\n")).toEqual([
+			{name: "A", line: 1, text: "one"},
+			{name: "B", line: 2, text: "two"},
+		]);
+	});
+
+	it("ends a block at a heading, a new list item and a fence — the units a paragraph cannot span", () => {
+		expect(anchorBlocksIn("- <!-- anchor: H --> a claim\n- a sibling bullet\n")).toEqual([
+			{name: "H", line: 1, text: "a claim"},
+		]);
+		expect(anchorBlocksIn("<!-- anchor: H --> a claim\n## Next\n")).toEqual([
+			{name: "H", line: 1, text: "a claim"},
+		]);
+		expect(anchorBlocksIn("<!-- anchor: H --> a claim\n```sh\nrm -rf\n```\n")).toEqual([
+			{name: "H", line: 1, text: "a claim"},
+		]);
+	});
+
+	it("mints NO block for a tag inside backticks — the fence holds over the widened unit", () => {
+		expect(
+			anchorBlocksIn("the `<!-- anchor: NAME -->` tags skills carry\nand more prose\n"),
+		).toEqual([]);
+	});
+
+	it("does not let a backticked tag CUT a block short — masking decides anchors, not content", () => {
+		expect(
+			anchorBlocksIn("<!-- anchor: G --> a claim\nwritten as `<!-- anchor: NAME -->` here\n"),
+		).toEqual([{name: "G", line: 1, text: "a claim written as `<!-- anchor: NAME -->` here"}]);
+	});
+});
+
+describe("scanAnchorBlocks", () => {
+	it("reports the PR #5501 shape: an anchored paragraph reworded below an untouched anchor line", () => {
+		expect(
+			scanAnchorBlocks(
+				"contract.md",
+				PACKED_BRANCH("a fresh worktree"),
+				PACKED_BRANCH("a fresh clone"),
+			),
+		).toEqual([
+			{
+				kind: "modified",
+				name: "READ-DERIVES-AGAINST-THE-PACKED-BRANCH",
+				file: "contract.md",
+				line: 1,
+			},
+		]);
+	});
+
+	it("reports NOTHING for a block that only moved — the anti-noise property, at block scale", () => {
+		expect(
+			scanAnchorBlocks(
+				"contract.md",
+				`# a doc\n\n${PACKED_BRANCH("a fresh worktree")}`,
+				`# a doc\n\nprose added above\n\n${PACKED_BRANCH("a fresh worktree")}`,
+			),
+		).toEqual([]);
+	});
+
+	it("reports NOTHING for a pure re-wrap — a markdown line break is not a weakened guarantee", () => {
+		expect(
+			scanAnchorBlocks(
+				"a.md",
+				"<!-- anchor: G --> a claim that\nwraps here\n",
+				"<!-- anchor: G --> a claim\nthat wraps here\n",
+			),
+		).toEqual([]);
+	});
+
+	it("reports NOTHING when a bullet BELOW an anchored bullet changes — blocks stop at the sibling", () => {
+		expect(
+			scanAnchorBlocks(
+				"a.md",
+				"- <!-- anchor: G --> a claim\n- an unanchored sibling\n",
+				"- <!-- anchor: G --> a claim\n- a reworded sibling\n",
+			),
+		).toEqual([]);
+	});
+
+	it("reports an anchor absent from the later bytes as `removed`, at the line it sat on", () => {
+		expect(scanAnchorBlocks("a.md", "x\n<!-- anchor: G --> a claim\n", "x\nplain prose\n")).toEqual(
+			[{kind: "removed", name: "G", file: "a.md", line: 2}],
+		);
+	});
+
+	it("pairs a repeated NAME by occurrence — two uses are two questions, not one", () => {
+		expect(
+			scanAnchorBlocks(
+				"a.md",
+				"<!-- anchor: G --> one\n\n<!-- anchor: G --> two\n",
+				"<!-- anchor: G --> one\n\n<!-- anchor: G --> rewritten\n",
+			),
+		).toEqual([{kind: "modified", name: "G", file: "a.md", line: 3}]);
+	});
+
+	it("reports NOTHING when an anchor is added — a new guarantee is not a moved one", () => {
+		expect(scanAnchorBlocks("a.md", "prose\n", "<!-- anchor: G --> a claim\n")).toEqual([]);
+	});
+});
+
+describe("mergeHits", () => {
+	const walk = {kind: "modified", name: "G", file: "a.md", line: 12} as const;
+	const block = {kind: "modified", name: "G", file: "a.md", line: 40} as const;
+
+	it("keeps one hit per file and NAME, with the first list's line", () => {
+		expect(mergeHits([walk], [block])).toEqual([walk]);
+	});
+
+	it("keeps a same-named anchor in another file — a name in two files is two questions", () => {
+		expect(mergeHits([walk], [{...block, file: "b.md"}])).toEqual([walk, {...block, file: "b.md"}]);
+	});
+
+	it("carries a block-only hit through — the case the diff walk structurally cannot see", () => {
+		expect(mergeHits([], [block])).toEqual([block]);
 	});
 });
 

--- a/packages/fabrika-cli/src/governance/guards-verb.ts
+++ b/packages/fabrika-cli/src/governance/guards-verb.ts
@@ -10,14 +10,24 @@
  * what covers it.
  *
  * A truncated diff is refused rather than scanned. An under-reported hit list reads as a
- * checked-clean answer that was never checked (#3925's class).
+ * checked-clean answer that was never checked (#3925's class). For the same reason each changed
+ * file is read at the base commit as well as at the head, so an anchor's paragraph is compared whole
+ * instead of only where the diff happens to touch it — see `anchors.ts` (#5514).
  */
 import {Effect} from "effect";
 import type {ChildProcessSpawner} from "effect/unstable/process";
 import {diffRange, diffRangeStatuses, readFileAt} from "../io/git.ts";
 import {badNumber, openPull, resolveTargetRepo} from "../review/target.ts";
 import {answer, refuse, type VerbOutcome} from "../verb.ts";
-import {anchorsIn, filesInDiff, isGuardBearing, scanAnchors} from "./anchors.ts";
+import type {AnchorHit} from "./anchors.ts";
+import {
+	anchorsIn,
+	filesInDiff,
+	isGuardBearing,
+	mergeHits,
+	scanAnchorBlocks,
+	scanAnchors,
+} from "./anchors.ts";
 import {INCOMPLETE_SCAN, PRECONDITION_UNKNOWN} from "./codes.ts";
 import {bindGovernanceHead, boundLine} from "./head.ts";
 
@@ -90,6 +100,8 @@ export const runGuards = (
 		// anchored invariants EXIST in the files this diff touches, which is the denominator that makes
 		// "I scanned nothing and found nothing" unrenderable as a pass (ADR 0092).
 		const inTree: Array<{readonly path: string; readonly anchors: number}> = [];
+		const blockHits: AnchorHit[] = [];
+		let compared = 0;
 		for (const entry of listed.value) {
 			if (entry.status.startsWith("D")) continue;
 			const bytes = yield* readFileAt(head.sha, entry.path);
@@ -101,9 +113,23 @@ export const runGuards = (
 				);
 			}
 			inTree.push({path: entry.path, anchors: anchorsIn(bytes.value)});
+			// Only a path that names the same file at both commits can be block-compared. An addition has
+			// no base side, and a rename's base path is the source `--name-status` drops, so both fall
+			// back to the diff walk rather than being read at a path the base commit does not carry.
+			if (!(entry.status.startsWith("M") || entry.status.startsWith("T"))) continue;
+			const before = yield* readFileAt(head.base, entry.path);
+			if (before._tag === "Failure") {
+				return refuse(
+					PRECONDITION_UNKNOWN,
+					`${VERB}: cannot read ${entry.path} at ${head.base}: ${before.reason} — UNKNOWN, never "nothing moved".`,
+					diagnostics,
+				);
+			}
+			compared += 1;
+			blockHits.push(...scanAnchorBlocks(entry.path, before.value, bytes.value));
 		}
 
-		const hits = scanAnchors(diff.value);
+		const hits = mergeHits(scanAnchors(diff.value), blockHits);
 		const inReach = inTree.reduce((total, file) => total + file.anchors, 0);
 		const moved = new Set(hits.map((hit) => hit.file));
 		const guardFiles = inTree.filter(
@@ -113,7 +139,7 @@ export const runGuards = (
 		const outcome =
 			hits.length > 0 ? "hits" : inReach === 0 ? "no-anchors-in-reach" : "no-anchor-change";
 		diagnostics.push(
-			`${VERB}: scanned ${listed.value.length} files, ${inReach} anchored invariants in reach.`,
+			`${VERB}: scanned ${listed.value.length} files, ${inReach} anchored invariants in reach, ${compared} compared block-by-block against ${head.base}.`,
 		);
 
 		if (json) {

--- a/packages/fabrika-cli/src/governance/guards-verb.unit.test.ts
+++ b/packages/fabrika-cli/src/governance/guards-verb.unit.test.ts
@@ -5,6 +5,7 @@ import type {ExecResult} from "../io/exec.ts";
 import {DIFF_AT} from "../review/fixtures.test-support.ts";
 import {INCOMPLETE_SCAN, PRECONDITION_UNKNOWN, STALE_HEAD, ZERO_SCOPE} from "./codes.ts";
 import {
+	BASE,
 	binding,
 	HEAD,
 	OLD_HEAD,
@@ -42,16 +43,24 @@ const diffOf = (path: string, ...body: ReadonlyArray<string>): string =>
 		"",
 	].join("\n");
 
+/**
+ * The one changed file scripted at both commits.
+ *
+ * `before` defaults to `bytes` — a file whose *blocks* are identical at both ends, so a test that
+ * only means to exercise the diff walk is not accidentally also asserting a block hit.
+ */
 const scripted = (
 	diff: string,
 	bytes: string,
 	path = SKILL,
+	before = bytes,
 ): ReadonlyArray<readonly [RegExp, ExecResult]> => [
 	[PULL, pull({changedFiles: 1})],
 	...binding(),
 	[DIFF_AT(), okOut(diff)],
 	[STATUS_AT(), statuses(["M", path])],
 	[SHOW_AT(HEAD, path), okOut(bytes)],
+	[SHOW_AT(BASE, path), okOut(before)],
 ];
 
 describe("runGuards", () => {
@@ -108,10 +117,10 @@ describe("runGuards", () => {
 		expect(out.stdout).not.toContain("guard-file");
 	});
 
-	it("states the scanned file count and the anchors in reach on stderr", async () => {
+	it("states the scanned file count, the anchors in reach and the base comparison on stderr", async () => {
 		const out = await run(scripted(diffOf(SKILL, "-a", "+b"), "<!-- anchor: G --> g\n"));
 		expect(out.stderr.at(-1)).toBe(
-			"governance guards: scanned 1 files, 1 anchored invariants in reach.",
+			`governance guards: scanned 1 files, 1 anchored invariants in reach, 1 compared block-by-block against ${BASE}.`,
 		);
 	});
 
@@ -124,6 +133,99 @@ describe("runGuards", () => {
 			hits: [{kind: "removed", name: "G", file: SKILL, line: 12}],
 			scanned: 1,
 		});
+	});
+
+	// The PR #5501 shape: not one `+`/`-` line in that 98-file diff carried an anchor tag, yet two
+	// anchored paragraphs had been reworded on their continuation lines (#5514).
+	it("reports a hit when the anchored PROSE changed and no anchor line is in the diff at all", async () => {
+		const claim = (checkout: string): string =>
+			[
+				"<!-- anchor: READ-DERIVES-AGAINST-THE-PACKED-BRANCH --> **`read` re-derives against the",
+				`pack's own branch.** A successor is a different checkout — usually ${checkout} sitting on`,
+				"the default branch — so deriving from `HEAD` would report its own location as drift.",
+				"",
+			].join("\n");
+		const out = await run(
+			scripted(
+				diffOf(
+					SKILL,
+					"-pack's own branch.** A successor is a different checkout — usually a fresh worktree sitting on",
+					"+pack's own branch.** A successor is a different checkout — usually a fresh clone sitting on",
+				),
+				claim("a fresh clone"),
+				SKILL,
+				claim("a fresh worktree"),
+			),
+		);
+		expect(out.stdout).toBe(
+			[
+				"guards\thits\t1",
+				`anchor\tmodified\tREAD-DERIVES-AGAINST-THE-PACKED-BRANCH\t${SKILL}:1`,
+				"",
+			].join("\n"),
+		);
+	});
+
+	it("still answers `no-anchor-change` when the anchored blocks are untouched — not a clearance", async () => {
+		const bytes = "<!-- anchor: G --> a claim\n\nunanchored prose\n";
+		const out = await run(
+			scripted(diffOf(SKILL, "-unanchored prose", "+other unanchored prose"), bytes, SKILL, bytes),
+		);
+		expect(out.stdout).toBe(
+			[`guards\tno-anchor-change\t1`, `guard-file\t${SKILL}\t1`, ""].join("\n"),
+		);
+	});
+
+	it("counts one hit per anchor when both scans see it — the two scans are not two findings", async () => {
+		const out = await run(
+			scripted(
+				diffOf(SKILL, "-<!-- anchor: G --> one", "+<!-- anchor: G --> two"),
+				"<!-- anchor: G --> two\n",
+				SKILL,
+				"<!-- anchor: G --> one\n",
+			),
+		);
+		expect(out.stdout).toBe([`guards\thits\t1`, `anchor\tmodified\tG\t${SKILL}:12`, ""].join("\n"));
+	});
+
+	it("refuses an unreadable BASE read on 11 — UNKNOWN, never `nothing moved`", async () => {
+		const out = await run([
+			[PULL, pull({changedFiles: 1})],
+			...binding(),
+			[DIFF_AT(), okOut(diffOf(SKILL, "-a", "+b"))],
+			[STATUS_AT(), statuses(["M", SKILL])],
+			[SHOW_AT(HEAD, SKILL), okOut("<!-- anchor: G --> g\n")],
+			[SHOW_AT(BASE, SKILL), errOut("fatal: path does not exist")],
+		]);
+		expect(out.code).toBe(PRECONDITION_UNKNOWN);
+		expect(out.stdout).toBe("");
+		expect(out.stderr.at(-1)).toBe(
+			`governance guards: cannot read ${SKILL} at ${BASE}: fatal: path does not exist — UNKNOWN, never "nothing moved".`,
+		);
+	});
+
+	it("does NOT read an added file at the base — it has no base side to compare", async () => {
+		const out = await run([
+			[PULL, pull({changedFiles: 1})],
+			...binding(),
+			[DIFF_AT(), okOut(diffOf(SKILL, "+<!-- anchor: G --> a claim"))],
+			[STATUS_AT(), statuses(["A", SKILL])],
+			[SHOW_AT(HEAD, SKILL), okOut("<!-- anchor: G --> a claim\n")],
+		]);
+		expect(out.code).toBe(0);
+		expect(out.stdout).toBe(
+			[`guards\tno-anchor-change\t1`, `guard-file\t${SKILL}\t1`, ""].join("\n"),
+		);
+	});
+
+	it("reports a deleted file's anchors as removed — the walk still covers what has no head bytes", async () => {
+		const out = await run([
+			[PULL, pull({changedFiles: 1})],
+			...binding(),
+			[DIFF_AT(), okOut(diffOf(SKILL, "-<!-- anchor: G --> a claim"))],
+			[STATUS_AT(), statuses(["D", SKILL])],
+		]);
+		expect(out.stdout).toBe([`guards\thits\t0`, `anchor\tremoved\tG\t${SKILL}:12`, ""].join("\n"));
 	});
 
 	it("refuses an absent, closed, or empty PR on 7", async () => {


### PR DESCRIPTION
`fabrika governance guards` could report `no-anchor-change` even when the prose an anchor protects had been rewritten. It only looked at diff lines that carried the `<!-- anchor: NAME -->` tag itself, and only compared the text sitting after the tag on that one line — so if the anchor line was untouched, the rest of its paragraph could be reworded with the check seeing nothing at all.

The check now reads each changed file at the base commit as well as at the head and compares each anchor's whole paragraph on both sides, so the answer no longer depends on where the diff happens to land. A re-wrap or a move is still not a hit, the three outcomes stay distinct, and none of them became a clearance.

Fixes #5514

## What changed

- `packages/fabrika-cli/src/governance/anchors.ts` — `anchorBlocksIn` reads each anchor's block (the tag's trailing text plus the lines continuing its paragraph, ending at a blank line, a heading, a new list item, a code fence, or the next anchor). A block continues onto following lines only from a tag that **opens** its line — indentation, a blockquote marker and one list bullet may precede it, nothing else; a tag reached after real content gets the text trailing it on that line, exactly what the diff walk always compared. `scanAnchorBlocks` pairs blocks by NAME across two commits' bytes, claiming an identical block before a reworded one and each one once: absent from the head is `removed`, different text is `modified`. Whitespace is collapsed before comparing, so a re-wrap and a move are not hits. `mergeHits` folds the older same-line diff walk and the block scan into one list at most one hit per (file, NAME).
- `packages/fabrika-cli/src/governance/guards-verb.ts` — every changed file that names the same path at both commits (`M`/`T`) is now read at `head.base` too and block-compared. An unreadable base read refuses on `11` (`PRECONDITION_UNKNOWN`) like every other unreadable read; the stderr notice now also states how many files were compared block-by-block.
- `claude-plugins/fabrika/skills/governance/contract.md` — the verb spec said the scan was over the diff's removed and added lines, which is no longer what it does. Rewritten to state the block comparison, the block boundaries, the whitespace normalization, and the two shapes that still fall back to the diff walk. No anchored paragraph in that file was touched (it carries no anchors — its one `anchor:` occurrence is inside backticks).
- Tests: 26 new unit tests across `anchors.unit.test.ts` and `guards-verb.unit.test.ts`.

## Why the diff walk is kept rather than replaced

The block comparison subsumes the same-line walk wherever both can run, but not everywhere. A deleted file has no head bytes to compare, and a rename's base path is the source field `--name-status` drops, so those two shapes are only reachable through the walk. Widening the rename case needs the source path carried on `ChangedPath` in `src/io/git.ts`, which is outside this issue's scope fence.

## The inline-code fence, over the widened unit

`maskInlineCode` decides what counts as an anchor on both legs of a block: the line that opens one and every line that could end one. So a tag inside backticks neither mints a block nor cuts one short. The break test deliberately reads the raw line while the anchor test reads the masked one — masking is length-preserving but eats the leading backticks of a ``` fence, which is the marker the break looks for. Two tests cover each direction.

## Verification against the reported reproduction

Merged PR #5501 (`ef0661a9`...`fceccefc`, 98 files), block-scanned with this code over all 97 modified files:

- `grep -E '^[+-].*<!--\s*anchor:'` over that diff returns nothing, and `scanAnchors` returns `[]` — the old `no-anchor-change` was structurally forced, not earned.
- The block comparison reports **4 hits out of 64 anchors in reach**: `READ-DERIVES-AGAINST-THE-PACKED-BRANCH` and `UNREACHABLE-WORK-IS-REFUSED` in `claude-plugins/fabrika/skills/handoff/contract.md` (both paragraphs triage named first-party), plus `UNREACHABLE-WORK-IS-REFUSED` in `claude-plugins/fabrika/skills/handoff/SKILL.md` and `RULED` in `claude-plugins/fabrika/skills/plan-epic/SKILL.md`. All four are real prose rewrites inside the anchored block; 60 of 64 anchors stayed silent, so the widening did not turn into noise.

None of this re-judges #5501, which earned a genuine PASS — the rewrites weakened nothing. The point is that the coverage came from an agent hand-reading, not from the tool.

Checks: `pnpm typecheck` clean, `pnpm lint:worktree` clean, `pnpm vitest run` in `packages/fabrika-cli` 315 files / 4836 tests passing.

## I ran the new scan on this PR's own diff, and it found two defects in the fix

Widening what the scan sees, in a repo full of anchored prose, means the scan can flag the change that widened it. The first run over this branch reported two hits. Both were **false positives — defects in the widening**, not anchored text moving, and both are fixed in `51e7d39`. Per hit:

**`A` in `anchors.unit.test.ts:118` — false positive, pairing artifact.** The name `A` appears in two fixture strings in that file, and this PR inserted a new one above the existing one. Both blocks were intact, but positional pairing compared old-occurrence-1 against new-occurrence-1 and reported a rewording that never happened. Fixed by claiming an identical block before a reworded one, each claimed once: an insertion is now silent, while a genuine rewording is still loud because it has no identical counterpart to claim. Three tests cover the insertion case, the rewording-during-insertion case, and the drop-to-one-occurrence case.

**`G` in `guards-verb.unit.test.ts:121` — false positive, over-capture.** The anchor's own line was byte-identical. The tag sits inside a TypeScript string literal, so the block ran off the end of the literal and swallowed the assertion lines below it; editing an assertion reported the fixture as a moved invariant. The compared block was literally ``"g\n\")); expect(out.stderr.at(-1)).toBe( ... ); });"`` — 19 words, almost none of it the anchor's text. Fixed by continuing a block only from a tag that **opens** its line (indentation, a blockquote marker, one list bullet may precede it). A tag reached after real content still gets the text trailing it on that line, which is exactly what the diff walk has always compared — so this fences the widening rather than narrowing coverage, and it cannot re-open #5514's hole: every anchor in the guarded corpus opens its line, which `anchorsIn`'s existing note already observes from the other side.

Neither fix touches the block boundary in a way that loses real anchored prose, and neither edits anchored text. The proof is the #5501 re-run below: identical before and after — **still 4 hits out of 64 anchors** across 97 modified files. Re-running the scan on this branch's own diff after the fix returns `[]`.

`anchorsIn` is deliberately untouched: it has always counted these fixture tags toward the `anchors-in-reach` denominator, which is pre-existing behavior outside this issue's scope.

## Repair round 1 — the `.ts` half of the corpus was silently excluded

The gate FAIL at `51e7d39a` proved a hole in the block rule, and it is real. `BLOCK_BREAK`'s
new-list-item clause read a leading `*` as a markdown bullet. Every continuation line of a TypeScript
docblock opens with ` * `, so the break fired on the line right after the tag and **every `.ts`
anchor's block was truncated to its own line** — counted in `anchors-in-reach`, structurally unable
to produce a hit. That is the same big-denominator/zero-numerator shape #5514 exists to remove.

**Two claims above are superseded, and I am naming them rather than quietly editing them:**

- "**still 4 hits out of 64 anchors**" on the #5501 reproduction was an undercount. The honest
  number is **6**; two real rewrites were being missed.
- "every anchor in the guarded corpus opens its line" was false. A handful of markdown anchors are
  written at the very end of their line, so their compared text is the empty string either way; the
  rest of the non-opening ones are this package's own string-literal test fixtures, which is the case
  the fence exists for. The docblock now says that instead.

### The fix

A docblock continuation line and a markdown list item are the same bytes — only the **frame** tells
them apart. `commentFramedLines` resolves that frame once per file, and inside a block comment a
line's prose is the line minus its decoration, with the comment's end ending the block. Keying on
the frame rather than on a file extension is what keeps prose and docblocks one rule instead of two,
and it is why #5520's "scope the block comparison to markdown" route was **not** taken — that would
have made the hole permanent. A real list *inside* a docblock still ends a block, because the break
is tested against the prose, not the decoration.

### Measured, both directions

`#5501` reproduction (`ef0661a9`...`fceccefc`, 97 modified files, 64 anchors in reach):

| | hits |
|---|---|
| before this round | 4 |
| after | **6** |

The two that were missing are exactly the ones the gate named, and both are the same edit as the
four already caught:

- `READ-DERIVES-AGAINST-THE-PACKED-BRANCH` — `packages/fabrika-cli/src/handoff/ground.ts:371`
- `UNREACHABLE-WORK-IS-REFUSED` — `packages/fabrika-cli/src/handoff/take-verb.ts:10`

Corpus widening over every anchor-bearing file at this branch's base, before and after:

| surface | files | anchors | widened before | widened after |
|---|---|---|---|---|
| `.md` | 19 | 132 | 129 | 129 |
| `.ts` | 21 | 80 | **0** | **29** |

29 is every `.ts` anchor that opens its line; the remaining 51 are string-literal fixtures in this
package's own tests, which the opening-line fence correctly holds to a single line. Markdown is
byte-identical before and after, so the frame rule adds nothing to the prose half.

**Self-scan stays clean.** The new scan over this branch's own diff reports `files=5 compared=5
inReach=57 block=0` — no new false positives from the widening.

### Tests

`anchorBlocksIn` and `scanAnchorBlocks` now carry `.ts` docblock fixtures, which is the gap the gate
named: the whole suite was markdown, so it was green while the real diff under-reported. Six new
tests cover the docblock continuation, the comment terminator ending the block, a real list inside a
docblock still breaking, a markdown `*` bullet still breaking with no frame to say otherwise, the
`#5501` shape reproduced in a docblock, and a docblock re-wrap staying silent.

Checks at this head: `pnpm typecheck` clean, `pnpm lint:worktree` clean, `packages/fabrika-cli`
suite 285 files / 4325 tests green. The file counts are lower than the earlier run because this
branch was rebased onto a `main` that has since dropped the eval tooling. No eval of any kind was
run.


## Deviations

- **Class: scope.** Said: the issue fences scope to `anchors.ts`, `guards-verb.ts` and their unit tests. Did: also edited `claude-plugins/fabrika/skills/governance/contract.md`. Why: that file is the verb's written spec and it stated the now-false "the scan is over the diff's removed and added lines"; leaving it would make the contract contradict the code. Disposition: no action needed — the edit touches no anchored block and adds no anchor.
- **Class: narrowed fix shape.** Said: reading both commits "subsumes the current same-line comparison". Did: kept the same-line walk alongside the block comparison and deduped the two. Why: deleted files and renames have no comparable base path, so a straight replacement would have lost the `removed` hits a deleted anchor-bearing file produces today. Disposition: for the reviewer to judge; the rename widening is named above as the follow-up seam it would need.
- **Class: defect found in my own work, fixed in-lane.** Said: nothing. Did: the first push introduced two false-positive classes (over-capture past the anchored unit, and positional pairing of same-named blocks), found by running the new scan on this branch's own diff; fixed in `51e7d39` with five tests. Why: a guard that cries on unrelated text gets read past, so this is a defect in the fix rather than something to disclose and leave. Disposition: fixed here — see the section above for the per-hit verdict and the #5501 re-run proving detection is unchanged.
- **Class: follow-up filed on a stale reading.** Said: nothing. Did: filed #5520 while the two hits above were still believed to be inherent noise, before diagnosing them as fixable defects. Why: the diagnosis came after the filing. Disposition: #5520 amended with the correction and the fix; it should be closed unless triage finds a residue in it.
- **Class: known-unfixed sibling.** Said: nothing. Did: left a rename's block comparison unimplemented. Why: it needs the rename source path on `ChangedPath` in `src/io/git.ts`, outside the fence. Disposition: no action needed — the diff walk still covers the same-line case for a rename, so this is unchanged behavior, not a new gap.
- **(repair round 1) Class: a claim in this body turned out to be false.** Said: "still 4 hits out of
  64 anchors" on the #5501 re-run, and "every anchor in the guarded corpus opens its line". Did: both
  are superseded — the honest count is 6, and a handful of markdown anchors do not open their line.
  Why: the block rule silently excluded every `.ts` docblock, so the 4 was measured through a hole.
  Disposition: fixed and re-measured; the earlier claims are left standing above with the correction
  stated in the repair section rather than edited away.
- **(repair round 1) Class: declined a suggested route.** Said: nothing. Did: did **not** take
  #5520's suggestion to scope the block comparison to markdown. Why: that makes the `.ts` blind spot
  permanent, and the `.ts` half is where `handoff` and `map` keep their invariants. Disposition: for
  the reviewer to judge — if the corpus is instead ruled out of scope, that is a deliberate ruling
  and belongs in `contract.md` as a stated blind spot with its size named, not a silent default.
- **(repair round 1) Class: known limitation of the mechanism.** Said: nothing. Did: the comment
  frame is resolved by scanning for comment syntax, not by parsing. Why: a parse is far more machinery
  than the question needs. Disposition: no action needed — an unterminated opener inside a string
  literal would frame the lines after it, which only makes the block tolerate a leading star; the
  paragraph boundaries are unchanged and a tag reached after real content is already held to its own
  line by the opening-line fence. Stated in the code at its enforcement site.
