### PR TITLE
spike capture refuses the run table it composes, deadlocking the spike

### DIFF
--- a/claude-plugins/fabrika/skills/prototyping/contract.md
+++ b/claude-plugins/fabrika/skills/prototyping/contract.md
@@ -324,6 +324,13 @@ trailing `…` when longer.
 run's command and status beside the claim rather than a hash standing in for them. The
 `evidenceDigest` proves the table matches the log; the table is what a human can actually read.
 
+**A transcribed command is masked, never refused** (#5553). The workspace root renders as
+`<workspace>`, and any other machine-local path in a recorded argv renders as its class mask. A
+recorded argv is already on the log when the table is composed, so a refusal over it would name no
+input anyone can correct — the leak scan that still runs over the composed body therefore reaches
+only the caller's own text (the decision, or the manifest's question), which is exactly the text a
+`5` can ask them to rewrite.
+
 ### The disposal invariant — stated because everything downstream leans on it
 
 **`treeDigest` is neutral to every write this group makes.** The claim is checkable by walking each
@@ -376,7 +383,7 @@ fabrika spike open --question <text> --kind <logic|ui> [--ticket <n>] [--nonce <
 **Output** — machine. One JSON object:
 
 ```json
-{"spike":9310,"nonce":"7f3a9c21","kind":"logic","workspace":"/tmp/fabrika-spike/7f3a9c21","treeDigest":"e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"}
+{"spike":9310,"nonce":"7f3a9c21","kind":"logic","workspace":"<tmp>/fabrika-spike/7f3a9c21","treeDigest":"e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"}
 ```
 
 There is no empty answer: the verb either mints a spike or refuses.
@@ -454,7 +461,7 @@ scope over a corpus.
 
 ```
 $ fabrika spike open --question "does better-auth mint a single-use token without a new table?" --kind logic
-{"spike":9310,"nonce":"7f3a9c21","kind":"logic","workspace":"/tmp/fabrika-spike/7f3a9c21","treeDigest":"e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"}
+{"spike":9310,"nonce":"7f3a9c21","kind":"logic","workspace":"<tmp>/fabrika-spike/7f3a9c21","treeDigest":"e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"}
 ```
 
 ```
@@ -749,6 +756,9 @@ is sample data returned by GitHub.)
   demotion or a grant.
 - #3086 — the decision is leak-scanned through the shipped predicates before it is posted; the
   inherited #3785 false-positive is stated rather than worked around.
+- #5553 — the same scan over the verb's **own** composition deadlocked a spike whose recorded argv
+  named the workspace: neither `capture` nor an honest `dispose` could get past it. The run table is
+  masked at composition, so a refusal can only ever name text a caller wrote.
 - v1 scar: `claude-plugins/kampus-pipeline/skills/wayfinder/SKILL.md:292-301` mandates every map
   write through the `wayfinder-map` CLI, and that tool is read-only by construction — the sanctioned
   write path is a dead end and the only alternative is explicitly banned. This group ships its own

--- a/packages/fabrika-cli/src/spike/bodies.ts
+++ b/packages/fabrika-cli/src/spike/bodies.ts
@@ -10,11 +10,15 @@
  * status beside the claim rather than a hash standing in for them; the `evidenceDigest` is what
  * proves the table matches the log.
  *
- * The body never carries the workspace path — that is the answer to #3086: the path is not scanned
- * out of the body, it is never placed in it.
+ * **The body never carries a machine-local path**, which is the answer to #3086. The prose parts
+ * never place one there; the run table is transcribed from argv a caller chose, so it is masked here
+ * at composition — the workspace root by class as `<workspace>`, anything else by the leak scanner's
+ * own class masks. The caller cannot edit an argv already on the log, so a refusal over it would have
+ * no remedy (#5553).
  */
 
 import type {CommentRecord} from "../io/issues.ts";
+import {scanBody} from "../report/leaks.ts";
 import type {EvidenceRecord, Kind} from "./workspace.ts";
 
 /** The label that makes a spike findable, countable and disposable as a class. */
@@ -118,14 +122,30 @@ export const newestCapture = (
 	return newest;
 };
 
+/** What the workspace root renders as in a transcribed command — the one path a reader never needs. */
+export const WORKSPACE_MASK = "<workspace>";
+
+/**
+ * A recorded command as it is transcribed: the workspace root masked by class, then whatever other
+ * machine-local path the argv carried masked by the leak scanner's own class masks.
+ *
+ * Masking here rather than refusing later is the whole fix: by the time a table exists the argv is
+ * already on the log, so there is no input left for a caller to correct (#5553).
+ */
+export const maskedCommand = (command: ReadonlyArray<string>, workspace: string): string => {
+	const joined = command.join(" ");
+	const rooted = workspace === "" ? joined : joined.replaceAll(workspace, WORKSPACE_MASK);
+	return scanBody(rooted).redacted;
+};
+
 /** The run table, one row per evidence line, transcribed from the log rather than re-derived. */
-export const runTable = (records: ReadonlyArray<EvidenceRecord>): string =>
+export const runTable = (records: ReadonlyArray<EvidenceRecord>, workspace: string): string =>
 	[
 		"| seq | command | exit | truncated |",
 		"| --- | --- | --- | --- |",
 		...records.map(
 			(record) =>
-				`| ${record.seq} | ${record.command.join(" ")} | ${
+				`| ${record.seq} | ${maskedCommand(record.command, workspace)} | ${
 					record.timedOut ? "timed out" : String(record.commandExit)
 				} | ${record.truncated} |`,
 		),
@@ -137,6 +157,8 @@ export const captureComment = (fields: {
 	readonly evidenceDigest: string;
 	readonly decision: string;
 	readonly records: ReadonlyArray<EvidenceRecord>;
+	/** The workspace root, masked out of every transcribed command. */
+	readonly workspace: string;
 }): string =>
 	[
 		captureMarker(fields.nonce, fields.evidenceDigest),
@@ -147,7 +169,7 @@ export const captureComment = (fields: {
 		"",
 		"## Runs",
 		"",
-		runTable(fields.records),
+		runTable(fields.records, fields.workspace),
 		"",
 	].join("\n");
 
@@ -159,6 +181,8 @@ export const forfeitNote = (fields: {
 	readonly nonce: string;
 	readonly question: string;
 	readonly records: ReadonlyArray<EvidenceRecord>;
+	/** The workspace root, masked out of every transcribed command. */
+	readonly workspace: string;
 }): string =>
 	[
 		forfeitMarker(fields.nonce, fields.records.length),
@@ -169,7 +193,7 @@ export const forfeitNote = (fields: {
 		"",
 		"## Runs",
 		"",
-		runTable(fields.records),
+		runTable(fields.records, fields.workspace),
 		"",
 		"No decision was reached; this spike was abandoned and its workspace disposed.",
 		"",

--- a/packages/fabrika-cli/src/spike/bodies.unit.test.ts
+++ b/packages/fabrika-cli/src/spike/bodies.unit.test.ts
@@ -11,8 +11,16 @@ import {
 	SPIKE_LABEL,
 	spikeTitle,
 	TITLE_LIMIT,
+	WORKSPACE_MASK,
 } from "./bodies.ts";
-import {evidenceRecord, NONCE, ONE_RUN_DIGEST, QUESTION} from "./fixtures.test-support.ts";
+import {
+	evidenceRecord,
+	LEAKY_WORKSPACE,
+	NONCE,
+	ONE_RUN_DIGEST,
+	QUESTION,
+	WORKSPACE,
+} from "./fixtures.test-support.ts";
 
 const comment = (id: number, body: string, createdAt = "2026-08-10T00:00:00Z"): CommentRecord => ({
 	id,
@@ -94,15 +102,33 @@ describe("the capture predicate is mechanical", () => {
 
 describe("the run table is transcribed, not summarised", () => {
 	it("holds one row per recorded run with its command and status", () => {
-		const table = runTable([evidenceRecord(1), evidenceRecord(2, {commandExit: 1})]);
+		const table = runTable([evidenceRecord(1), evidenceRecord(2, {commandExit: 1})], WORKSPACE);
 		expect(table).toContain("| 1 | printf no\\n | 0 | false |");
 		expect(table).toContain("| 2 | printf no\\n | 1 | false |");
 	});
 
 	it("names a timed-out run rather than printing a null exit", () => {
-		const table = runTable([evidenceRecord(1, {commandExit: null, timedOut: true})]);
+		const table = runTable([evidenceRecord(1, {commandExit: null, timedOut: true})], WORKSPACE);
 		expect(table).toContain("timed out");
 		expect(table).not.toContain("null");
+	});
+
+	it("masks the workspace root out of a transcribed argv rather than carrying it", () => {
+		const table = runTable(
+			[evidenceRecord(1, {command: ["bash", `${LEAKY_WORKSPACE}/probe.sh`]})],
+			LEAKY_WORKSPACE,
+		);
+		expect(table).toContain(`bash ${WORKSPACE_MASK}/probe.sh`);
+		expect(table).not.toContain(LEAKY_WORKSPACE);
+	});
+
+	it("masks any other machine-local path in an argv by its class", () => {
+		const table = runTable(
+			[evidenceRecord(1, {command: ["cat", "/Users/someone/notes.txt"]})],
+			LEAKY_WORKSPACE,
+		);
+		expect(table).toContain("/Users/<redacted>");
+		expect(table).not.toContain("someone");
 	});
 });
 
@@ -113,6 +139,7 @@ describe("the two comments carry their marker on the first line and nothing else
 			evidenceDigest: ONE_RUN_DIGEST,
 			decision: "A single-use token needs no new table.",
 			records: [evidenceRecord(1)],
+			workspace: WORKSPACE,
 		});
 		expect(body.split("\n")[0]).toBe(captureMarker(NONCE, ONE_RUN_DIGEST));
 		expect(body).toContain("## Decision");
@@ -120,7 +147,12 @@ describe("the two comments carry their marker on the first line and nothing else
 	});
 
 	it("composes the forfeit note from the manifest's question", () => {
-		const body = forfeitNote({nonce: NONCE, question: QUESTION, records: [evidenceRecord(1)]});
+		const body = forfeitNote({
+			nonce: NONCE,
+			question: QUESTION,
+			records: [evidenceRecord(1)],
+			workspace: WORKSPACE,
+		});
 		expect(body.split("\n")[0]).toBe(forfeitMarker(NONCE, 1));
 		expect(body).toContain("## Abandoned");
 		expect(body).toContain(QUESTION);

--- a/packages/fabrika-cli/src/spike/capture-verb.ts
+++ b/packages/fabrika-cli/src/spike/capture-verb.ts
@@ -190,8 +190,11 @@ export const runCapture = (options: CaptureOptions): SpikeEffect<VerbOutcome> =>
 			evidenceDigest,
 			decision: authored.text,
 			records: evidence.value.records,
+			workspace,
 		});
-		const composed = leakFree(VERB, "composed capture comment", body);
+		// The run table is masked at composition, so the only unmasked text left here is the decision
+		// — the one part a caller can actually rewrite and re-run (#5553).
+		const composed = leakFree(VERB, "decision, as it composes into the capture comment", body);
 		if (composed !== null) return {...composed, stderr: [scope, ...composed.stderr]};
 
 		const posted = yield* createComment(repo, options.spike, body);

--- a/packages/fabrika-cli/src/spike/capture-verb.unit.test.ts
+++ b/packages/fabrika-cli/src/spike/capture-verb.unit.test.ts
@@ -3,7 +3,7 @@ import {describe, expect, it} from "vitest";
 import {errOut, type FakeFsOptions, fakeFs, fakeShell, okOut, once} from "../fakes.test-support.ts";
 import type {ExecResult} from "../io/exec.ts";
 import type {StdinRead} from "../io/stdin.ts";
-import {captureComment, captureMarker, forfeitMarker} from "./bodies.ts";
+import {captureComment, captureMarker, forfeitMarker, WORKSPACE_MASK} from "./bodies.ts";
 import {runCapture} from "./capture-verb.ts";
 import {
 	AUTHOR_UNAUTHORIZED,
@@ -24,8 +24,13 @@ import {
 	ENV,
 	EVIDENCE,
 	evidenceRecord,
+	evidenceText,
 	ISSUE,
 	issuePayload,
+	LEAKY_EVIDENCE,
+	LEAKY_MANIFEST,
+	LEAKY_TMP_ROOT,
+	LEAKY_WORKSPACE,
 	MANIFEST,
 	manifestText,
 	NONCE,
@@ -39,6 +44,7 @@ import {
 	VIEWER,
 	WORKSPACE,
 } from "./fixtures.test-support.ts";
+import {sha256OfText} from "./workspace.ts";
 
 const DECISION = "A single-use token needs no new table — the verification record carries it.";
 const BODY = captureComment({
@@ -46,6 +52,7 @@ const BODY = captureComment({
 	evidenceDigest: ONE_RUN_DIGEST,
 	decision: DECISION,
 	records: [evidenceRecord(1)],
+	workspace: WORKSPACE,
 });
 
 const resident: FakeFsOptions = {
@@ -110,6 +117,37 @@ describe("runCapture records a decision the log grounds", () => {
 		const posted = calls.find((line) => POST.test(line)) ?? "";
 		expect(posted).toContain("## Runs");
 		expect(posted).toContain("printf");
+	});
+
+	it("captures a run whose argv names the workspace, masking it instead of refusing (#5553)", async () => {
+		const records = [evidenceRecord(1, {command: ["bash", `${LEAKY_WORKSPACE}/probe.sh`]})];
+		const log = evidenceText(records);
+		const body = captureComment({
+			nonce: NONCE,
+			evidenceDigest: sha256OfText(log),
+			decision: DECISION,
+			records,
+			workspace: LEAKY_WORKSPACE,
+		});
+		const {outcome, calls} = await run(
+			[
+				...identity,
+				[ISSUE, okOut(issuePayload())],
+				[COMMENTS, okOut(commentsPayload([]))],
+				[POST, okOut(JSON.stringify({id: 512349, html_url: "https://example.test/#c"}))],
+				[READBACK, okOut(JSON.stringify({body}))],
+				[CLOSE, okOut("{}")],
+			],
+			{tmpRoot: LEAKY_TMP_ROOT},
+			{
+				directories: [LEAKY_WORKSPACE],
+				files: {[LEAKY_MANIFEST]: manifestText(), [LEAKY_EVIDENCE]: log},
+			},
+		);
+		expect(outcome.code).toBe(0);
+		const posted = calls.find((line) => POST.test(line)) ?? "";
+		expect(posted).toContain(`${WORKSPACE_MASK}/probe.sh`);
+		expect(posted).not.toContain(LEAKY_WORKSPACE);
 	});
 });
 

--- a/packages/fabrika-cli/src/spike/dispose-verb.ts
+++ b/packages/fabrika-cli/src/spike/dispose-verb.ts
@@ -94,6 +94,7 @@ export const runDispose = (options: DisposeOptions): SpikeEffect<VerbOutcome> =>
 				forfeit: options.forfeit,
 				question: manifest.value.question,
 				records,
+				workspace,
 				evidenceDigest: evidence.value.digest,
 				repo: options.repo,
 				env: options.env,
@@ -149,6 +150,8 @@ const resolveIssueHalf = (input: {
 	readonly forfeit: boolean;
 	readonly question: string;
 	readonly records: ReadonlyArray<EvidenceRecord>;
+	/** The workspace root, masked out of every transcribed command in the forfeit note. */
+	readonly workspace: string;
 	readonly evidenceDigest: string | null;
 	readonly repo: string | null;
 	readonly env: Readonly<Record<string, string | undefined>>;
@@ -215,8 +218,11 @@ const resolveIssueHalf = (input: {
 			nonce: input.nonce,
 			question: input.question,
 			records: input.records,
+			workspace: input.workspace,
 		});
-		const leaked = leakFree(VERB, "composed forfeit note", body);
+		// The run table is masked at composition; what remains is the question the caller wrote at
+		// spike open, which is the only part a refusal here could ask anyone to change (#5553).
+		const leaked = leakFree(VERB, "question, as it composes into the forfeit note", body);
 		if (leaked !== null) return refused({...leaked, stderr: [input.scope, ...leaked.stderr]});
 
 		const posted = yield* createComment(repo, input.spike, body);

--- a/packages/fabrika-cli/src/spike/dispose-verb.unit.test.ts
+++ b/packages/fabrika-cli/src/spike/dispose-verb.unit.test.ts
@@ -37,7 +37,12 @@ import {
 	WORKSPACE,
 } from "./fixtures.test-support.ts";
 
-const NOTE = forfeitNote({nonce: NONCE, question: QUESTION, records: [evidenceRecord(1)]});
+const NOTE = forfeitNote({
+	nonce: NONCE,
+	question: QUESTION,
+	records: [evidenceRecord(1)],
+	workspace: WORKSPACE,
+});
 
 const resident: FakeFsOptions = {
 	directories: [WORKSPACE],

--- a/packages/fabrika-cli/src/spike/fixtures.test-support.ts
+++ b/packages/fabrika-cli/src/spike/fixtures.test-support.ts
@@ -25,6 +25,16 @@ export const MANIFEST = manifestPath(WORKSPACE);
 export const EVIDENCE = evidencePath(WORKSPACE);
 export const CLEAN_TREE_DIGEST = sha256OfText("");
 
+/**
+ * A temp root of the shape a real machine hands out — one the leak scanner recognises, unlike
+ * {@link TMP_ROOT}. It is what a masking test must sit on: a workspace under `/tmp-root` is not a
+ * leak, so it cannot prove the refusal #5553 named.
+ */
+export const LEAKY_TMP_ROOT = "/var/folders/z9/t0000000";
+export const LEAKY_WORKSPACE = workspacePath(LEAKY_TMP_ROOT, NONCE);
+export const LEAKY_MANIFEST = manifestPath(LEAKY_WORKSPACE);
+export const LEAKY_EVIDENCE = evidencePath(LEAKY_WORKSPACE);
+
 export const ENV = {CLAUDE_PIPELINE_REPO: REPO} as Record<string, string | undefined>;
 
 export const manifest = (overrides: Partial<Manifest> = {}): Manifest => ({


### PR DESCRIPTION
`fabrika spike capture` composed a comment, appended its own run table to it, then leak-scanned the
whole thing and refused it — because a recorded command's argv named a script inside the workspace,
and the workspace is a machine-local temp directory by design. No input fixed it: the offending text
was the verb's own, and the argv was already on the evidence log. `spike dispose --forfeit` composed
the same table and hit the same wall, so a spike that answered its question could be neither captured
nor honestly disposed.

The fix is masking at composition. `runTable` now takes the workspace root and renders it as
`<workspace>`; anything else machine-local in a recorded argv renders as the leak scanner's own class
mask (a redacted home root, a redacted temp root, …). The table is therefore leak-free by
construction, so the scan that still runs over the composed body can only reach the caller's own text
— the decision on stdin, or the question the manifest carries — which is the only text a `5` can ask
anyone to rewrite. The caller-text check at `capture-verb.ts:79` is untouched; the real leak guard
still fires on a decision that pastes a path.

Tests: a capture whose recorded argv is an absolute workspace path now composes, posts and closes
(`capture-verb.unit.test.ts`), plus two table-level tests for the workspace mask and the by-class
mask. The whole `fabrika-cli` suite is green (4358 tests).

For spike #5552 (open, 10 runs, uncaptured, workspace live): once this lands, re-run
`fabrika spike capture 5552 --nonce d21f4344` with the decision on stdin — the table will mask and
the capture will post. Then `fabrika spike dispose --nonce d21f4344` as normal. No hand-fix needed.

Fixes #5553

## Deviations

- **Out-of-scope change** — **Said:** the criteria name `spike capture`: mask the workspace root by
  class, and stop the leak check at `capture-verb.ts:194` refusing what the verb composed itself.
  **Did:** also fixed `spike dispose --forfeit`'s forfeit note. **Why:** it composes the same run
  table through the same helper and had the identical deadlock, so a capture-only fix would have left
  the documented escape hatch broken. **Disposition:** kept in this PR — same helper, same one-line
  change, and splitting it would ship a known-broken sibling path.
- **Out-of-scope change** — **Said:** nothing about the prototyping contract's sample output.
  **Did:** re-masked two pre-existing sample lines in
  `claude-plugins/fabrika/skills/prototyping/contract.md` that printed a literal temp-root workspace
  path. **Why:** those lines reded the prose leak validator the moment the file entered this diff.
  **Disposition:** kept — the file carries this PR's contract change and could not go green
  otherwise; the sample now prints a masked temp root and the JSON stays well-formed.

