### PR TITLE
ship evidence reads an all-passing run-evidence bundle as failed, deadlocking the ship

### DIFF
--- a/claude-plugins/fabrika/skills/ship/contract.md
+++ b/claude-plugins/fabrika/skills/ship/contract.md
@@ -967,7 +967,15 @@ With `--json`: `{"outcome":…,"sha":…,"run":…,"artifact":…,"checks":[{nam
   `run-evidence`; the manifest's required keys are `schemaVersion` (numeric, `1`), `commit`,
   and `checks[]` of `{name, status}` (ADR 0054). `checks[]` entries carry a string `status`
   field, **not** a boolean `pass` — the wire shape is the producer's, and prose that says
-  "boolean" ships a parser that reads everything falsy (#4392).
+  "boolean" ships a parser that reads everything falsy (#4392). Passing is the producer's own
+  word, `pass`, and nothing else: `crabbox-manifest`'s `deriveChecks` writes `pass`/`fail` and the
+  producer workflow appends its `bundle-node-core-free` entry in the same words. GitHub's
+  check-conclusion vocabulary (`success`/`neutral`/`skipped`) belongs to `ship checks`, which
+  reads check runs; against a bundle it matches nothing, so every passing check counted as
+  failing and no bundle could attest a passing run (#5563). An unrecognized `status` reads as
+  failing, never as passing — the same fail-closed posture the check-run rollup takes (#4552) —
+  and accepting both vocabularies at once is not the fix, because it re-opens the same silent
+  disagreement.
 - `pending` — a producer run for this head exists and has not completed, **or** it completed
   **within the freshness window** and lists no `run-evidence` artifact. **Pending is not absent** —
   reporting it absent invents a CI gap (#3913).
@@ -1026,8 +1034,8 @@ match only), one artifact, one manifest. All fetch intermediates live under a pe
 $ fabrika ship evidence 4321 --sha 03135b91
 evidence	present	03135b91
 lookup	run:9182736450	artifact:2211334455	status:completed
-check	typecheck	success
-check	unit	success
+check	typecheck	pass
+check	unit	pass
 ```
 
 ```
@@ -1040,8 +1048,8 @@ lookup	run:9182736999	artifact:-	status:in_progress
 $ fabrika ship evidence 4323 --sha 7c31a0de
 evidence	failed	7c31a0de
 lookup	run:9182737111	artifact:2211334999	status:completed
-check	typecheck	success
-check	unit	failure
+check	typecheck	pass
+check	unit	fail
 ```
 
 **Grounding**
@@ -1052,6 +1060,8 @@ check	unit	failure
   bundle" for a bundle present the whole time.
 - #4392 — `checks[]` `status` is a string on the wire; the contract says so, so the parser
   cannot be written against invented prose.
+- #5563 — which vocabulary that string is written in: the producer's `pass`/`fail`, not GitHub's
+  conclusions, and unrecognized reads as failing.
 - #4013 — the thin-skill rule: the skill never hand-rolls this fetch; this verb is the only
   reader.
 - ADR 0054 / 0086 — the bundle contract and the foreign-repo degradation this transcribes.

--- a/packages/fabrika-cli/src/ship/evidence-verb.ts
+++ b/packages/fabrika-cli/src/ship/evidence-verb.ts
@@ -43,8 +43,16 @@ const PRODUCER_WORKFLOW = "run-evidence.yml";
 const ARTIFACT_NAME = "run-evidence";
 const SCHEMA_VERSION = 1;
 
-/** The conclusions a bundle's `checks[]` entry may carry and still attest a passing run. */
-const PASSING = new Set(["success", "neutral", "skipped"]);
+/**
+ * The one word a bundle's `checks[]` entry carries when it attests a passing run — the PRODUCER's
+ * vocabulary (ADR 0054 §3; `crabbox-manifest`'s `deriveChecks` writes `pass`/`fail`), never
+ * GitHub's check-conclusion vocabulary, which no bundle ever contains. Reading the bundle against
+ * the wrong vocabulary made every passing check count as failing, so no bundle could attest a
+ * passing run and every ship deadlocked on green evidence (#5563). Anything else — including a
+ * word GitHub would call passing — reads as failing, the same fail-closed posture the check-run
+ * rollup takes on an unrecognized conclusion (#4552).
+ */
+const PASSING_STATUS = "pass";
 
 /**
  * How long after a run completes its artifact may still be missing from the listing and read
@@ -252,7 +260,7 @@ export const runEvidence = (
 			);
 			return emit("unknown", run.id, artifact.id, run.status, manifest.checks);
 		}
-		const failing = manifest.checks.filter((check) => !PASSING.has(check.status));
+		const failing = manifest.checks.filter((check) => check.status !== PASSING_STATUS);
 		if (failing.length > 0) {
 			diagnostics.push(
 				`${VERB}: the bundle binds ${bound} and ${failing.length} of its checks did not pass (${failing

--- a/packages/fabrika-cli/src/ship/evidence-verb.unit.test.ts
+++ b/packages/fabrika-cli/src/ship/evidence-verb.unit.test.ts
@@ -43,6 +43,24 @@ const artifactsFor = (
 const manifest = (commit: string, checks: ReadonlyArray<{name: string; status: string}>): string =>
 	JSON.stringify({schemaVersion: 1, commit, checks});
 
+/**
+ * A manifest in the shape the real producer publishes: `crabbox-manifest`'s `deriveChecks` writes
+ * `{name, status: "pass" | "fail", exitCode}` per command, and the `run-evidence` workflow appends
+ * `bundle-node-core-free` in the same words.
+ */
+const producerManifest = (commit: string): string =>
+	JSON.stringify({
+		schemaVersion: 1,
+		commit,
+		run: {producer: "crabbox", timestamp: "2026-07-25T04:57:44Z", environment: "ci"},
+		checks: [
+			{name: "run", status: "pass", exitCode: 0},
+			{name: "bundle-node-core-free", status: "pass", exitCode: 0},
+		],
+		tests: {total: 2362, passed: 2362, failed: 0, skipped: 0, failures: []},
+		logs: {ref: "run-log"},
+	});
+
 const options = {pr: 4321, sha: HEAD, repo: null, json: false, env: ENV};
 
 const run = (
@@ -66,8 +84,8 @@ const upToArtifact: ReadonlyArray<readonly [RegExp, ExecResult]> = [
 
 describe("readManifest", () => {
 	it("reads `checks[].status` as a STRING — a boolean-shaped parser reads everything falsy (#4392)", () => {
-		expect(readManifest(manifest(HEAD, [{name: "unit", status: "success"}]))?.checks).toEqual([
-			{name: "unit", status: "success"},
+		expect(readManifest(manifest(HEAD, [{name: "unit", status: "pass"}]))?.checks).toEqual([
+			{name: "unit", status: "pass"},
 		]);
 	});
 
@@ -88,8 +106,8 @@ describe("runEvidence", () => {
 				UNZIP,
 				okOut(
 					manifest(HEAD, [
-						{name: "typecheck", status: "success"},
-						{name: "unit", status: "success"},
+						{name: "typecheck", status: "pass"},
+						{name: "unit", status: "pass"},
 					]),
 				),
 			],
@@ -99,11 +117,28 @@ describe("runEvidence", () => {
 			[
 				`evidence\tpresent\t${HEAD}`,
 				"lookup\trun:9182736450\tartifact:2211334455\tstatus:completed",
-				"check\ttypecheck\tsuccess",
-				"check\tunit\tsuccess",
+				"check\ttypecheck\tpass",
+				"check\tunit\tpass",
 				"",
 			].join("\n"),
 		);
+	});
+
+	// #5563: the consumer read the bundle against GitHub's conclusion vocabulary, which the producer
+	// never writes, so every real bundle read `failed` and no PR could ship on green evidence.
+	it("reports present for a manifest in the producer's own published shape", async () => {
+		const out = await run([...upToArtifact, [UNZIP, okOut(producerManifest(HEAD))]]);
+		expect(out.code).toBe(0);
+		expect(out.stdout.split("\n")[0]).toBe(`evidence\tpresent\t${HEAD}`);
+	});
+
+	it("reports failed for a check carrying GitHub's `success` — an unknown word is not passing", async () => {
+		const out = await run([
+			...upToArtifact,
+			[UNZIP, okOut(manifest(HEAD, [{name: "unit", status: "success"}]))],
+		]);
+		expect(out.code).toBe(0);
+		expect(out.stdout.split("\n")[0]).toBe(`evidence\tfailed\t${HEAD}`);
 	});
 
 	it("reports pending for an in-flight producer run — pending is NOT absent (#3913)", async () => {
@@ -186,7 +221,7 @@ describe("runEvidence", () => {
 	it("reports failed for a bundle that binds this head and attests a failing run", async () => {
 		const out = await run([
 			...upToArtifact,
-			[UNZIP, okOut(manifest(HEAD, [{name: "unit", status: "failure"}]))],
+			[UNZIP, okOut(manifest(HEAD, [{name: "unit", status: "fail"}]))],
 		]);
 		expect(out.code).toBe(0);
 		expect(out.stdout.split("\n")[0]).toBe(`evidence\tfailed\t${HEAD}`);


### PR DESCRIPTION
`fabrika ship evidence` read every run-evidence bundle as `failed`, so no PR could ship on
green evidence. The consumer filtered the bundle's `checks[]` against GitHub's check-conclusion
words (`success`/`neutral`/`skipped`); the producer writes its own (`pass`/`fail`). The two sets
never overlap, so every passing check counted as failing.

The fix teaches the consumer the producer's vocabulary: passing is `pass` and nothing else, so
any other word — including one GitHub would call passing — reads as failing. That is the same
fail-closed posture the check-run rollup takes on an unrecognized conclusion (#4552), and it
avoids accepting both vocabularies at once, which would re-open the same silent disagreement.

Grounded in the producer, not intuition: `crabbox-manifest`'s `deriveChecks`
(`packages/pipeline-cli/src/tools/crabbox-manifest/adapter.ts`) writes
`status: exitCode === 0 ? "pass" : "fail"`, `.github/workflows/run-evidence.yml` appends its
`bundle-node-core-free` entry in the same words, and ADR 0054 §3 names `pass` as the contract
word. `packages/fabrika-cli/src/review/rollup.ts` is untouched — its set is correct for the
GitHub check runs it actually reads.

Tests: a regression case runs the verb against a manifest in the producer's own published shape
(`{name, status: "pass", exitCode}` plus the `run`/`tests`/`logs` blocks), and a second asserts
that a check carrying GitHub's `success` reads `failed`. The pre-existing cases were written in
the wrong vocabulary — they encoded the defect — so they now use `pass`/`fail`.

Live proof at the head the issue names:

```
$ fabrika ship evidence 5556 --sha 459b4e4cd903d3a0081b3bf27ffb1e6b77b178be
evidence	present	459b4e4cd903d3a0081b3bf27ffb1e6b77b178be
lookup	run:31779157449	artifact:9211118380	status:completed
check	run	pass
check	bundle-node-core-free	pass
```

The ship contract doc carried the same wrong vocabulary in its `present`/`failed` examples, so it
is corrected alongside the code and now states which vocabulary the string is written in.

## Deviations

- The issue's acceptance criteria did not ask for a doc change. `claude-plugins/fabrika/skills/ship/contract.md`
  is included anyway because its worked examples printed `check … success`, i.e. the exact wrong
  vocabulary this PR removes from the code; leaving it would re-plant the defect for the next
  reader. This may change how the merge gate classifies the PR — that classification is the gate's,
  not mine.
- The issue pointed at `packages/pipeline-cli/src/tools/run-evidence/fixtures.ts` for the
  regression fixture. `@kampus/fabrika-cli` does not depend on `@kampus/pipeline-cli`, so importing
  it would add a package dependency for a test. The fixture is reproduced locally in
  `evidence-verb.unit.test.ts` with a comment naming the producer it mirrors.

Fixes #5563
