### PR TITLE
The graduate contract specifies four verbs and none of them exists in fabrika-cli

### DIFF
--- a/claude-plugins/fabrika/docs/wire-formats.md
+++ b/claude-plugins/fabrika/docs/wire-formats.md
@@ -170,8 +170,10 @@ two buildable things graduates its remainder later at a different digest, and a 
 trail would refuse that second filing forever while claiming to prevent duplicates. And `covers`
 names the refs the spec rendered, which is what makes coverage answerable from the artifact alone: a
 digest by itself is opaque, so a reader holding one could say a source had graduated but not which
-parts of its trail were specified. Its separator is `;` rather than `,` because a map-sourced ref
-contains a space (`#9301 R1.2`).
+parts of its trail were specified. Its separator is `;` rather than `,` for readability — a
+map-sourced ref already carries a space (`#9301 R1.2`), and `R1.1, #9301 R1.2` reads as one run-on
+list where `;` keeps the refs visually apart. A comma would parse the same; this is a legibility
+choice, not a hazard.
 
 It is a new format rather than a widening of `verdict-marker`. That reader is guarded by a separate
 namespace-prefix gate that returns `Absent` for a non-member, so a widening that missed either

--- a/claude-plugins/fabrika/docs/wire-formats.md
+++ b/claude-plugins/fabrika/docs/wire-formats.md
@@ -46,6 +46,7 @@ does not exist yet — rather than missing; check the registry before assuming a
 | `grill-supersede` | [`packages/fabrika-cli/src/wire/grill-supersede.ts`](../../../packages/fabrika-cli/src/wire/grill-supersede.ts) | `grilling` | `grilling` |
 | `handoff-pack` | [`packages/fabrika-cli/src/wire/handoff-pack.ts`](../../../packages/fabrika-cli/src/wire/handoff-pack.ts) | `handoff` | `handoff` |
 | `governance-digest` | [`packages/fabrika-cli/src/wire/governance-digest.ts`](../../../packages/fabrika-cli/src/wire/governance-digest.ts) | `governance` | `front-door` |
+| `graduate-emitted` | [`packages/fabrika-cli/src/wire/graduate-emitted.ts`](../../../packages/fabrika-cli/src/wire/graduate-emitted.ts) | `graduate` | `graduate` |
 <!-- fabrika:wire-index:end -->
 
 ### `acceptance-criteria`
@@ -158,6 +159,25 @@ the record the id names and reads it there, which is what keeps a coordination a
 whoever reads it, and it is why free prose is confined to that one field. The block is upserted onto a
 durable issue rather than appended, so a reader always finds exactly one current readout instead of a
 stream a timestamp has to decide between.
+
+### `graduate-emitted`
+
+This is the record on a grilling session or a wayfinding map that one spec issue was graduated out of
+it, and the agreement it closes is a repeat one: without it, a second run over the same trail cannot
+tell a spec that already exists from one nobody has filed, so it files a duplicate. Two fields carry
+the design. The digest it binds is the **spec**'s, not the trail's — a trail deliberately split across
+two buildable things graduates its remainder later at a different digest, and a marker bound to the
+trail would refuse that second filing forever while claiming to prevent duplicates. And `covers`
+names the refs the spec rendered, which is what makes coverage answerable from the artifact alone: a
+digest by itself is opaque, so a reader holding one could say a source had graduated but not which
+parts of its trail were specified. Its separator is `;` rather than `,` because a map-sourced ref
+contains a space (`#9301 R1.2`).
+
+It is a new format rather than a widening of `verdict-marker`. That reader is guarded by a separate
+namespace-prefix gate that returns `Absent` for a non-member, so a widening that missed either
+constant would emit markers it could never read back — and an emission is not a verdict anyway: it
+carries no `PASS`/`FAIL` polarity, binds a spec digest rather than a head SHA, and nothing recorded
+in it can block a merge.
 
 ## Adding a format
 

--- a/packages/fabrika-cli/src/exit-code-alignment.ts
+++ b/packages/fabrika-cli/src/exit-code-alignment.ts
@@ -114,6 +114,28 @@ export const GRILL_SEATS: SharedSeats = {
 };
 
 /**
+ * `graduate`'s seats: all nine, under the base's own names.
+ *
+ * None of the shipped maps fits, which is why this one is written out. It seats `4` as
+ * `BAD_SECTIONS` like `build` does, but names `7` `NO_TARGET` (a source issue or a label proven
+ * absent — the base's own reading, widened only from *write target* to *named target*) and `10`
+ * `CLASSIFIED` rather than the `ZERO_SCOPE` / `OFF_VOCABULARY` aliases the eight-seat maps key on.
+ * `10` is reached rather than held empty: ADR 0246 forbids this group writing board state, and `10`
+ * is that prohibition made mechanical against a classifying `--title`. The private band is `12`-`18`.
+ */
+export const GRADUATE_SEATS: SharedSeats = {
+	EMPTY_STDIN: "EMPTY_STDIN",
+	BAD_SECTIONS: "BAD_SECTIONS",
+	LEAKED_PATH: "LEAKED_PATH",
+	BARE_AT_PATH: "BARE_AT_PATH",
+	NO_TARGET: "NO_TARGET",
+	WRITE_UNKNOWN: "WRITE_UNKNOWN",
+	READBACK_MISMATCH: "READBACK_MISMATCH",
+	CLASSIFIED: "CLASSIFIED",
+	PRECONDITION_UNKNOWN: "PRECONDITION_UNKNOWN",
+};
+
+/**
  * `handoff`'s seats: the same eight `grill` claims, so the map is reused rather than retyped.
  *
  * The two groups reach the identical set from different directions: both name `7` `NO_TARGET` (an
@@ -252,6 +274,7 @@ export const ALIGNED_GROUPS: Readonly<Record<string, SharedSeats>> = {
 	hook: HOOK_SEATS,
 	epic: BUILD_SEATS,
 	glossary: GLOSSARY_SEATS,
+	graduate: GRADUATE_SEATS,
 	grill: GRILL_SEATS,
 	handoff: HANDOFF_SEATS,
 	"heal-ci": HEAL_CI_SEATS,

--- a/packages/fabrika-cli/src/exit-code-alignment.unit.test.ts
+++ b/packages/fabrika-cli/src/exit-code-alignment.unit.test.ts
@@ -21,6 +21,7 @@ import {
 } from "./exit-code-alignment.ts";
 import * as glossary from "./glossary/codes.ts";
 import * as governance from "./governance/codes.ts";
+import * as graduate from "./graduate/codes.ts";
 import * as grill from "./grill/codes.ts";
 import * as handoff from "./handoff/codes.ts";
 import * as healCi from "./heal-ci/codes.ts";
@@ -55,6 +56,7 @@ const TABLES: Readonly<Record<string, CodeTable>> = {
 	epic,
 	glossary,
 	governance,
+	graduate,
 	grill,
 	handoff,
 	"heal-ci": healCi,

--- a/packages/fabrika-cli/src/graduate/codes.ts
+++ b/packages/fabrika-cli/src/graduate/codes.ts
@@ -1,0 +1,84 @@
+/**
+ * The one exit table all four `graduate` verbs allocate from, so a code means one thing across this
+ * group whichever verb produced it (`claude-plugins/fabrika/skills/graduate/contract.md`).
+ *
+ * The overlap with `report` is **re-exported, never re-typed**: an aligning group imports the base's
+ * constant, so a drift is unrepresentable rather than merely detectable. This group shares all nine
+ * seats over `3`-`11` — it is one of the few that reaches every one of them, including `10`, which is
+ * load-bearing here rather than a courtesy: ADR 0246 forbids this group writing board state, and `10`
+ * is that prohibition made mechanical against a classifying `--title`.
+ *
+ * `12`-`18` are the group's own and clear the base's occupied seats. They carry no cross-group
+ * uniqueness obligation, so `review`'s `12` and this group's `12` are two namespaces rather than a
+ * collision.
+ *
+ * Two stated widenings of imported seats, both narrowing the condition without moving the meaning:
+ * `5` fires unconditionally because no verb here offers `--redact`, and `7` covers a **named** target
+ * rather than only a write target — `graduate trail` and `graduate read` write nothing at all and
+ * seat `7` on a source issue proven absent.
+ *
+ * `0`, `1`, `2`, `126` and `127` are reserved by the interface convention (`../verb.ts`).
+ */
+
+import {
+	BAD_SECTIONS as REPORT_BAD_SECTIONS,
+	BARE_AT_PATH as REPORT_BARE_AT_PATH,
+	CLASSIFIED as REPORT_CLASSIFIED,
+	EMPTY_STDIN as REPORT_EMPTY_STDIN,
+	LEAKED_PATH as REPORT_LEAKED_PATH,
+	NO_TARGET as REPORT_NO_TARGET,
+	PRECONDITION_UNKNOWN as REPORT_PRECONDITION_UNKNOWN,
+	READBACK_MISMATCH as REPORT_READBACK_MISMATCH,
+	WRITE_UNKNOWN as REPORT_WRITE_UNKNOWN,
+} from "../report/codes.ts";
+
+/** Stdin was read and held nothing. `graduate compose` only — the one verb that reads fd 0. */
+export const EMPTY_STDIN = REPORT_EMPTY_STDIN;
+/** An authored section is missing, out of order, or empty; or a map body that does not parse. */
+export const BAD_SECTIONS = REPORT_BAD_SECTIONS;
+/** The text carries a machine-local path. No verb here offers `--redact`, so it fires always. */
+export const LEAKED_PATH = REPORT_LEAKED_PATH;
+/** The text is a bare `@` path reference — not redactable, so a second code. */
+export const BARE_AT_PATH = REPORT_BARE_AT_PATH;
+/** Proven: the named target does not exist — the source issue, or the `status:needs-triage` label. */
+export const NO_TARGET = REPORT_NO_TARGET;
+/** A write was attempted and its outcome could not be proven — UNKNOWN, deliberately not `1`. */
+export const WRITE_UNKNOWN = REPORT_WRITE_UNKNOWN;
+/** The write landed but the read-back differs; the artifact exists and needs a human. */
+export const READBACK_MISMATCH = REPORT_READBACK_MISMATCH;
+/** Proven: `--title` carries a type or priority classification. Triage's seat, not this group's. */
+export const CLASSIFIED = REPORT_CLASSIFIED;
+/** A precondition read failed, so nothing was written and no outcome is proven. */
+export const PRECONDITION_UNKNOWN = REPORT_PRECONDITION_UNKNOWN;
+
+/** Proven: the issue carries neither `grilling:session` nor `wayfinding:map`, or carries both. */
+export const SOURCE_UNRECOGNIZED = 12;
+/**
+ * Proven: the trail holds an unresolved decision.
+ *
+ * A refusal rather than a warning, and it lives in the verb rather than in skill prose so it holds
+ * even when the skill's own step is skipped: a spec synthesized over a decision nobody made is the
+ * #4110 failure this seat exists to refuse.
+ */
+export const TRAIL_BLOCKED = 13;
+/** Proven: a decision entry is missing a digested field, or `--trail` carries no 12-hex digest. */
+export const DIGEST_UNBINDABLE = 14;
+/** Proven: this **spec** digest already emitted an issue. A different subset may still graduate. */
+export const ALREADY_GRADUATED = 15;
+/** Proven: the trail holds zero decisions — there is nothing to synthesize. */
+export const TRAIL_EMPTY = 16;
+/**
+ * Proven: the stdin body carries a `## Decisions` heading.
+ *
+ * Deliberately not {@link BAD_SECTIONS}: the authored sections may be perfectly well-formed. What is
+ * wrong is *who wrote which section* — that one is rendered from the trail and never authored.
+ */
+export const DECISIONS_AUTHORED = 17;
+/**
+ * Proven: a ref the spec carries is absent from the re-derived trail, or its provenance or text has
+ * changed; or a `## Decisions` line does not parse.
+ *
+ * The section is machine-rendered at both ends, so a line that will not parse means the body was
+ * edited by hand.
+ */
+export const DECISIONS_STALE = 18;

--- a/packages/fabrika-cli/src/graduate/command.ts
+++ b/packages/fabrika-cli/src/graduate/command.ts
@@ -1,0 +1,158 @@
+/**
+ * The `graduate` verb group — `fabrika graduate <trail|compose|emit|read>`.
+ *
+ * The adapter and nothing else: it declares the flags (`--help` is the interface, so every flag
+ * carries a one-line description), reads the two document paths off disk, runs the pure verb, and
+ * emits its outcome. Every decision lives in the `*-verb.ts` modules beside it, which is what makes
+ * each refusal testable without spawning a process.
+ *
+ * **Every leaf is declared with `leafCommand`, never a bare `Command.make`** — the bare form silently
+ * opts out of the excess-operand guard, which `../excess-operand.unit.test.ts` reds on.
+ *
+ * There is no `--json` flag: `trail`, `emit` and `read` already answer with one JSON object, and
+ * `compose`'s answer is the markdown body a caller hands straight to `emit --spec`.
+ */
+
+import {Effect, type FileSystem, Option, Result} from "effect";
+import {Argument, Command, Flag} from "effect/unstable/cli";
+import {leafCommand} from "../excess-operand.ts";
+import {readFile} from "../io/fs.ts";
+import {readStdin} from "../io/stdin.ts";
+import type {VerbOutcome} from "../verb.ts";
+import type {DocumentRead} from "./compose-verb.ts";
+import {runCompose} from "./compose-verb.ts";
+import {runEmit} from "./emit-verb.ts";
+import {runRead} from "./read-verb.ts";
+import {runTrail} from "./trail-verb.ts";
+
+/** Write the outcome and exit on its code — stdout is the answer, everything else is stderr. */
+const emitOutcome = (outcome: VerbOutcome): Effect.Effect<void> =>
+	Effect.sync(() => {
+		for (const line of outcome.stderr) process.stderr.write(`${line}\n`);
+		if (outcome.stdout !== "") process.stdout.write(outcome.stdout);
+		process.exit(outcome.code);
+	});
+
+/**
+ * Read a document the verb was pointed at, as a value.
+ *
+ * The read happens here rather than in the verb so a verb stays a pure function of its dependencies:
+ * a test hands it the bytes, and a failed read is a value the verb branches on rather than an
+ * exception it has to catch.
+ */
+const document = (path: string): Effect.Effect<DocumentRead, never, FileSystem.FileSystem> =>
+	Effect.gen(function* () {
+		const read = yield* Effect.result(readFile(path));
+		return Result.isFailure(read)
+			? ({_tag: "Failed", reason: read.failure.reason} satisfies DocumentRead)
+			: ({_tag: "Text", text: read.success} satisfies DocumentRead);
+	});
+
+const repoFlag = Flag.string("repo").pipe(
+	Flag.optional,
+	Flag.withDescription(
+		"the target owner/name (default: $CLAUDE_PIPELINE_REPO, else $GITHUB_REPOSITORY, else the origin remote)",
+	),
+);
+
+const sourceArg = Argument.integer("source").pipe(
+	Argument.withDescription("the grilling session or wayfinding map issue the trail is read from"),
+);
+
+const trail = leafCommand(
+	"trail",
+	{source: sourceArg, repo: repoFlag},
+	Effect.fn(function* ({source, repo}) {
+		yield* emitOutcome(yield* runTrail({source, repo: Option.getOrNull(repo), env: process.env}));
+	}),
+).pipe(
+	Command.withShortDescription("Resolve a source into one provenance-tagged decision trail."),
+	Command.withDescription(
+		'Resolve a grilling session or wayfinding map THROUGH ITS OWN SIBLING RESOLVER and normalize it into one trail: {"source":n,"kind":"grilling|map","readiness":"ready|blocked|empty","trailDigest":"…","decisions":[…],"unresolved":[…],"outOfScope":[…],"counts":{…}}. All three readiness tokens exit 0 — a blocked trail is this skill working. Exits 4 (the map body does not parse), 7 (no such issue), 11 (a read could not complete, so the trail is UNKNOWN), 12 (the issue carries neither source label, or both). Example: fabrika graduate trail 9412',
+	),
+);
+
+const compose = leafCommand(
+	"compose",
+	{
+		trail: Flag.string("trail").pipe(
+			Flag.withDescription("a file holding the exact JSON object `graduate trail` printed"),
+		),
+		decisions: Flag.string("decisions").pipe(
+			Flag.atLeast(0),
+			Flag.withDescription(
+				"one ref this spec covers, given once per ref (repeatable, never comma-joined — a map ref carries a space); default: every decision on the trail",
+			),
+		),
+	},
+	Effect.fn(function* ({trail: trailPath, decisions}) {
+		yield* emitOutcome(
+			yield* runCompose({
+				trailPath,
+				trail: document(trailPath),
+				decisions,
+				stdin: Effect.sync(readStdin),
+			}),
+		);
+	}),
+).pipe(
+	Command.withShortDescription("Render the four-section spec body from the trail and stdin."),
+	Command.withDescription(
+		"Read the three authored sections (## Problem, ## Solution, ## Out of scope) from STDIN, render ## Decisions from --trail, and print the composed markdown body — the bytes `graduate emit --spec` takes. The decisions section is never authored: a stdin body carrying that heading is 17. Exits 3 (empty stdin), 4 (an authored section is missing, out of order or empty; or --decisions names a ref not on the trail), 5 (machine-local path), 6 (bare @ reference), 11 (--trail could not be read), 13 (the trail is blocked), 14 (no 12-hex trailDigest, or a decision missing a digested field), 16 (zero decisions selected), 17 (stdin carries ## Decisions). Example: fabrika graduate compose --trail trail.json < spec.md",
+	),
+);
+
+const emit = leafCommand(
+	"emit",
+	{
+		source: sourceArg,
+		spec: Flag.string("spec").pipe(
+			Flag.withDescription("a file holding the body `graduate compose` printed"),
+		),
+		title: Flag.string("title").pipe(
+			Flag.withDescription(
+				"the spec issue's title; type-neutral, and refused at 10 if it classifies the work",
+			),
+		),
+		repo: repoFlag,
+	},
+	Effect.fn(function* ({source, spec, title, repo}) {
+		yield* emitOutcome(
+			yield* runEmit({
+				source,
+				specPath: spec,
+				spec: document(spec),
+				title,
+				repo: Option.getOrNull(repo),
+				env: process.env,
+				now: () => new Date(),
+			}),
+		);
+	}),
+).pipe(
+	Command.withShortDescription("File the one spec issue and record the emission on the source."),
+	Command.withDescription(
+		'File exactly ONE spec issue carrying only status:needs-triage, read it back, then post the graduate-emitted marker on the source, and print {"source":n,"issue":n,"url":"…","specDigest":"…","labels":["status:needs-triage"],"marker":n}. The trail and the digest are re-derived from the source, never passed in. Exits 4 (--spec sections), 5 (machine-local path), 6 (bare @ reference), 7 (no such source, or no status:needs-triage label), 8 (a write failed — UNKNOWN), 9 (read-back mismatch), 10 (--title classifies), 11 (a precondition read failed), 12 (neither source label), 13 (blocked trail), 14 (a decision cannot be digested), 15 (this spec digest already emitted an issue), 16 (zero decisions), 18 (a ref the spec carries moved on the trail, or a decisions line does not parse). Example: fabrika graduate emit 9412 --spec spec.md --title "Cap moderation weight per topic"',
+	),
+);
+
+const read = leafCommand(
+	"read",
+	{source: sourceArg, repo: repoFlag},
+	Effect.fn(function* ({source, repo}) {
+		yield* emitOutcome(yield* runRead({source, repo: Option.getOrNull(repo), env: process.env}));
+	}),
+).pipe(
+	Command.withShortDescription("Has this source already graduated, and into what."),
+	Command.withDescription(
+		'Read a source\'s emission markers: {"source":n,"state":"graduated|ungraduated","emissions":[…],"disregarded":[…],"scanned":{"comments":n}}. Never refuses on marker content — a malformed marker is a disregarded row at exit 0, never an absence. Exits 7 (no such source), 11 (the comment read could not complete, so whether it graduated is UNKNOWN), 12 (neither source label). Example: fabrika graduate read 9412',
+	),
+);
+
+export const graduateCommand = Command.make("graduate").pipe(
+	Command.withSubcommands([trail, compose, emit, read]),
+	Command.withShortDescription("Turn a cleared decision trail into one buildable spec issue."),
+	Command.withDescription(
+		"Turn a cleared decision trail into ONE buildable spec issue: resolve a grilling session or a wayfinding map through its own sibling reader, render a spec whose ## Decisions section separates what the founder ruled from what an agent established, file it at status:needs-triage, and record the emission on the source",
+	),
+);

--- a/packages/fabrika-cli/src/graduate/compose-verb.ts
+++ b/packages/fabrika-cli/src/graduate/compose-verb.ts
@@ -31,6 +31,7 @@ import {
 	checkSections,
 	composeSpec,
 	DECISIONS_SECTION,
+	unplacedContent,
 } from "./spec.ts";
 import {parseTrailDocument} from "./trail.ts";
 
@@ -82,6 +83,15 @@ export const runCompose = <R = never>(
 					: problem._tag === "Empty"
 						? `${VERB}: section "${problem.heading}" is empty.`
 						: `${VERB}: sections are out of order — "${problem.heading}" follows "${problem.after}".`,
+			);
+		}
+		const unplaced = unplacedContent(authored, AUTHORED_SECTIONS);
+		if (unplaced !== null) {
+			return refuse(
+				BAD_SECTIONS,
+				unplaced._tag === "Preamble"
+					? `${VERB}: stdin carries content above "## Problem" — a spec body holds ${AUTHORED_SECTIONS.join(", ")} and nothing else, and composing would have dropped it.`
+					: `${VERB}: stdin carries section "${unplaced.heading}", which is not one of ${AUTHORED_SECTIONS.join(", ")} — composing would have dropped it.`,
 			);
 		}
 

--- a/packages/fabrika-cli/src/graduate/compose-verb.ts
+++ b/packages/fabrika-cli/src/graduate/compose-verb.ts
@@ -1,0 +1,166 @@
+/**
+ * `graduate compose` — render the four-section spec body, owning `## Decisions` entirely.
+ *
+ * Its answer channel is machine but not JSON: stdout is the composed markdown, byte-exact, ready to
+ * hand to `graduate emit --spec`. The bytes are *fed to another command* rather than grepped for a
+ * state word, and the four-section document is the declared shape.
+ *
+ * Two refusals are here rather than in skill prose, so they hold even when the skill's own step is
+ * skipped: a `blocked` trail is `13` and an `empty` one is `16`. A spec can never be composed over a
+ * decision nobody made.
+ */
+
+import {Effect} from "effect";
+import type {StdinRead} from "../io/stdin.ts";
+import {isBareAtReference, renderLeaks, scanBody} from "../report/leaks.ts";
+import {answer, FAILED, refuse, type VerbOutcome} from "../verb.ts";
+import {
+	BAD_SECTIONS,
+	BARE_AT_PATH,
+	DECISIONS_AUTHORED,
+	DIGEST_UNBINDABLE,
+	EMPTY_STDIN,
+	LEAKED_PATH,
+	PRECONDITION_UNKNOWN,
+	TRAIL_BLOCKED,
+	TRAIL_EMPTY,
+} from "./codes.ts";
+import {
+	AUTHORED_SECTIONS,
+	carriesDecisionsHeading,
+	checkSections,
+	composeSpec,
+	DECISIONS_SECTION,
+} from "./spec.ts";
+import {parseTrailDocument} from "./trail.ts";
+
+/** A document the adapter read off disk, as a value the verb branches on. */
+export type DocumentRead =
+	| {readonly _tag: "Text"; readonly text: string}
+	| {readonly _tag: "Failed"; readonly reason: string};
+
+export interface ComposeOptions<R = never> {
+	readonly trailPath: string;
+	readonly trail: Effect.Effect<DocumentRead, never, R>;
+	/** One ref this spec covers, repeatable. Empty means every decision on the trail. */
+	readonly decisions: ReadonlyArray<string>;
+	readonly stdin: Effect.Effect<StdinRead>;
+}
+
+const VERB = "graduate compose";
+
+export const runCompose = <R = never>(
+	options: ComposeOptions<R>,
+): Effect.Effect<VerbOutcome, never, R> =>
+	Effect.gen(function* () {
+		const read = yield* options.stdin;
+		if (read._tag === "Failed") {
+			return refuse(
+				FAILED,
+				`${VERB}: could not read stdin: ${read.reason} — the authored sections are UNKNOWN, never empty.`,
+			);
+		}
+		const authored = read._tag === "NoStdin" ? "" : read.text;
+		if (authored.trim() === "") {
+			return refuse(
+				EMPTY_STDIN,
+				`${VERB}: stdin was read and held nothing — refusing to compose a spec with no authored sections.`,
+			);
+		}
+		if (carriesDecisionsHeading(authored)) {
+			return refuse(
+				DECISIONS_AUTHORED,
+				`${VERB}: stdin carries a "${DECISIONS_SECTION}" heading — that section is rendered from the trail, never authored.`,
+			);
+		}
+		const problem = checkSections(authored, AUTHORED_SECTIONS);
+		if (problem !== null) {
+			return refuse(
+				BAD_SECTIONS,
+				problem._tag === "Missing"
+					? `${VERB}: section "${problem.heading}" is missing.`
+					: problem._tag === "Empty"
+						? `${VERB}: section "${problem.heading}" is empty.`
+						: `${VERB}: sections are out of order — "${problem.heading}" follows "${problem.after}".`,
+			);
+		}
+
+		const document = yield* options.trail;
+		if (document._tag === "Failed") {
+			return refuse(
+				PRECONDITION_UNKNOWN,
+				`${VERB}: cannot read --trail ${options.trailPath}: ${document.reason} — nothing was composed.`,
+			);
+		}
+		const parsed = parseTrailDocument(document.text);
+		if (parsed._tag === "Unreadable") {
+			return refuse(
+				PRECONDITION_UNKNOWN,
+				`${VERB}: cannot read --trail ${options.trailPath}: ${parsed.reason} — nothing was composed.`,
+			);
+		}
+		if (parsed._tag === "Unbindable") {
+			return refuse(
+				DIGEST_UNBINDABLE,
+				parsed.reason === "trailDigest"
+					? `${VERB}: --trail ${options.trailPath} does not carry a 12-hex trailDigest — the spec could not be bound to a trail.`
+					: `${VERB}: --trail ${options.trailPath} carries a decision with no ${parsed.reason} — it cannot be digested.`,
+			);
+		}
+		const trail = parsed.value;
+
+		if (trail.readiness === "blocked") {
+			return refuse(
+				TRAIL_BLOCKED,
+				`${VERB}: --trail ${options.trailPath} reports readiness "blocked" — ${trail.unresolved.length} decision(s) unresolved: ${trail.unresolved.map((row) => row.ref).join(", ")}. Refusing to synthesize a spec over a decision nobody made.`,
+			);
+		}
+		if (trail.decisions.length === 0) {
+			return refuse(
+				TRAIL_EMPTY,
+				`${VERB}: --trail ${options.trailPath} holds zero decisions — there is nothing to synthesize.`,
+			);
+		}
+
+		const unknown = options.decisions.find(
+			(ref) => !trail.decisions.some((row) => row.ref === ref),
+		);
+		if (unknown !== undefined) {
+			return refuse(
+				BAD_SECTIONS,
+				`${VERB}: --decisions names ${unknown}, which is not a decision on this trail — the refs on it are ${trail.decisions.map((row) => row.ref).join(", ")}.`,
+			);
+		}
+		const selected =
+			options.decisions.length === 0
+				? trail.decisions
+				: trail.decisions.filter((row) => options.decisions.includes(row.ref));
+		if (selected.length === 0) {
+			return refuse(
+				TRAIL_EMPTY,
+				`${VERB}: --decisions selected zero decisions — there is nothing to synthesize.`,
+			);
+		}
+
+		// Scanned after splicing, so the rendered decisions are scanned too and nothing this verb
+		// itself writes can escape the predicate (#3086).
+		const composed = composeSpec(authored, selected);
+		if (isBareAtReference(composed)) {
+			return refuse(
+				BARE_AT_PATH,
+				`${VERB}: the body is a bare @ path reference — not redactable, refusing to compose it.`,
+			);
+		}
+		const scan = scanBody(composed);
+		if (scan.leaks.length > 0) {
+			return refuse(
+				LEAKED_PATH,
+				`${VERB}: the body carries ${scan.leaks.length} machine-local path(s) — refusing to compose them into a spec.`,
+				renderLeaks(scan.leaks),
+			);
+		}
+
+		return answer(composed, [
+			`${VERB}: ${selected.length} of ${trail.decisions.length} decision(s) rendered from --trail ${options.trailPath}; readiness "${trail.readiness}".`,
+		]);
+	});

--- a/packages/fabrika-cli/src/graduate/compose-verb.unit.test.ts
+++ b/packages/fabrika-cli/src/graduate/compose-verb.unit.test.ts
@@ -1,0 +1,128 @@
+import {Effect} from "effect";
+import {describe, expect, it} from "vitest";
+import type {StdinRead} from "../io/stdin.ts";
+import {
+	BAD_SECTIONS,
+	DECISIONS_AUTHORED,
+	DIGEST_UNBINDABLE,
+	EMPTY_STDIN,
+	LEAKED_PATH,
+	PRECONDITION_UNKNOWN,
+	TRAIL_BLOCKED,
+	TRAIL_EMPTY,
+} from "./codes.ts";
+import {type DocumentRead, runCompose} from "./compose-verb.ts";
+import {AUTHORED, CLEARED_DECISIONS} from "./fixtures.test-support.ts";
+import {readDecisionsSection} from "./spec.ts";
+import {type DecisionRow, trailOf} from "./trail.ts";
+
+const trailJson = (
+	decisions: ReadonlyArray<DecisionRow>,
+	unresolved: ReadonlyArray<{ref: string; state: string}> = [],
+): string =>
+	JSON.stringify(trailOf({source: 9412, kind: "grilling", decisions, unresolved, outOfScope: []}));
+
+const compose = (input: {
+	readonly trail?: DocumentRead;
+	readonly stdin?: StdinRead;
+	readonly decisions?: ReadonlyArray<string>;
+}) =>
+	Effect.runPromise(
+		runCompose({
+			trailPath: "trail.json",
+			trail: Effect.succeed(input.trail ?? {_tag: "Text", text: trailJson(CLEARED_DECISIONS)}),
+			decisions: input.decisions ?? [],
+			stdin: Effect.succeed(input.stdin ?? {_tag: "Text", text: AUTHORED}),
+		}),
+	);
+
+describe("the composed body", () => {
+	it("prints the four sections on stdout at exit 0, with the decisions rendered from the trail", async () => {
+		const out = await compose({});
+		expect(out.code).toBe(0);
+		expect(out.stdout).toContain("## Problem");
+		expect(readDecisionsSection(out.stdout)).toEqual({
+			_tag: "Decisions",
+			value: CLEARED_DECISIONS,
+		});
+	});
+
+	it("renders only the selected subset when --decisions names one", async () => {
+		const out = await compose({decisions: ["R1.2"]});
+		expect(out.code).toBe(0);
+		expect(readDecisionsSection(out.stdout)).toMatchObject({value: [CLEARED_DECISIONS[1]]});
+	});
+
+	it("carries no footer — the footer is emit's, because only emit knows the spec digest", async () => {
+		expect((await compose({})).stdout).not.toContain("Filed by an agent");
+	});
+});
+
+describe("the authored half is validated before anything is rendered", () => {
+	it("refuses empty stdin", async () => {
+		const out = await compose({stdin: {_tag: "Text", text: "   \n"}});
+		expect(out.code).toBe(EMPTY_STDIN);
+		expect(out.stdout).toBe("");
+	});
+
+	it("refuses a stdin body that authors the decisions section itself", async () => {
+		const out = await compose({stdin: {_tag: "Text", text: `${AUTHORED}\n## Decisions\n- mine\n`}});
+		expect(out.code).toBe(DECISIONS_AUTHORED);
+		expect(out.stderr.join("\n")).toContain("rendered from the trail, never authored");
+	});
+
+	it("refuses a missing authored section", async () => {
+		const out = await compose({stdin: {_tag: "Text", text: "## Problem\nx\n"}});
+		expect(out.code).toBe(BAD_SECTIONS);
+	});
+
+	it("refuses a machine-local path anywhere in the composed whole", async () => {
+		const out = await compose({
+			trail: {
+				_tag: "Text",
+				text: trailJson([
+					{ref: "R1.1", provenance: "established", text: "the fixture lives at ~/code/phoenix"},
+				]),
+			},
+		});
+		expect(out.code).toBe(LEAKED_PATH);
+		expect(out.stdout).toBe("");
+	});
+});
+
+describe("a spec is never composed over an unmade decision", () => {
+	it("refuses a blocked trail, naming every unresolved ref", async () => {
+		const out = await compose({
+			trail: {_tag: "Text", text: trailJson(CLEARED_DECISIONS, [{ref: "R2.2", state: "open"}])},
+		});
+		expect(out.code).toBe(TRAIL_BLOCKED);
+		expect(out.stderr.join("\n")).toContain("R2.2");
+		expect(out.stderr.join("\n")).toContain("a decision nobody made");
+	});
+
+	it("refuses an empty trail rather than rendering an empty section", async () => {
+		const out = await compose({trail: {_tag: "Text", text: trailJson([])}});
+		expect(out.code).toBe(TRAIL_EMPTY);
+	});
+
+	it("refuses --decisions naming a ref that is not on the trail", async () => {
+		const out = await compose({decisions: ["R9.9"]});
+		expect(out.code).toBe(BAD_SECTIONS);
+		expect(out.stderr.join("\n")).toContain("R9.9");
+	});
+});
+
+describe("a trail that could not be read is UNKNOWN, never empty", () => {
+	it("seats a failed --trail read on 11", async () => {
+		const out = await compose({trail: {_tag: "Failed", reason: "no such file"}});
+		expect(out.code).toBe(PRECONDITION_UNKNOWN);
+		expect(out.stdout).toBe("");
+	});
+
+	it("seats a trail with no 12-hex digest on 14", async () => {
+		const out = await compose({
+			trail: {_tag: "Text", text: JSON.stringify({trailDigest: "nope", decisions: []})},
+		});
+		expect(out.code).toBe(DIGEST_UNBINDABLE);
+	});
+});

--- a/packages/fabrika-cli/src/graduate/compose-verb.unit.test.ts
+++ b/packages/fabrika-cli/src/graduate/compose-verb.unit.test.ts
@@ -65,6 +65,19 @@ describe("the authored half is validated before anything is rendered", () => {
 		expect(out.stdout).toBe("");
 	});
 
+	it("refuses a fourth section rather than dropping it from the composed spec", async () => {
+		const out = await compose({stdin: {_tag: "Text", text: `${AUTHORED}\n## Risks\nr\n`}});
+		expect(out.code).toBe(BAD_SECTIONS);
+		expect(out.stdout).toBe("");
+		expect(out.stderr.join("\n")).toContain("## Risks");
+	});
+
+	it("refuses a preamble above ## Problem rather than dropping it", async () => {
+		const out = await compose({stdin: {_tag: "Text", text: `intro\n\n${AUTHORED}`}});
+		expect(out.code).toBe(BAD_SECTIONS);
+		expect(out.stdout).toBe("");
+	});
+
 	it("refuses a stdin body that authors the decisions section itself", async () => {
 		const out = await compose({stdin: {_tag: "Text", text: `${AUTHORED}\n## Decisions\n- mine\n`}});
 		expect(out.code).toBe(DECISIONS_AUTHORED);

--- a/packages/fabrika-cli/src/graduate/emit-verb.ts
+++ b/packages/fabrika-cli/src/graduate/emit-verb.ts
@@ -181,7 +181,12 @@ export const runEmit = <R = never>(
 			);
 		}
 
-		const found = yield* requireSource(VERB, repo, source);
+		const found = yield* requireSource(
+			VERB,
+			repo,
+			source,
+			" — there is no trail to bind this spec to.",
+		);
 		if (found._tag === "Refused") return found.outcome;
 
 		const resolved = yield* deriveTrail(VERB, repo, source, found.value.kind, options.env);

--- a/packages/fabrika-cli/src/graduate/emit-verb.ts
+++ b/packages/fabrika-cli/src/graduate/emit-verb.ts
@@ -1,0 +1,359 @@
+/**
+ * `graduate emit` — file the one spec issue, apply the single label, read it back, and record the
+ * emission on the source.
+ *
+ * **One transaction**, checked local-first so a refusable spec costs no API call.
+ *
+ * <!-- anchor: WRITE-ORDERING-IS-AN-INVARIANT --> **The spec issue is created first and the marker
+ * second.** An interrupted run that wrote the marker first would leave a source claiming an emission
+ * that does not exist — a trail that can never be graduated again and a spec nobody can find. The
+ * reverse leaves a filed spec with no marker, which is `8` naming the orphan and which a human
+ * resolves by reading the source. A missing marker is a nuisance; a marker with no issue is a
+ * silently dropped spec.
+ *
+ * <!-- anchor: THE-BODY-MUST-MATCH-THE-TRAIL-IT-BINDS --> **The trail is re-derived here rather than
+ * trusted from `--spec`.** Without that, a caller could compose against trail A and emit against a
+ * source that has since moved to trail B, so the marker would bind a digest computed from B while the
+ * filed body stated A's decisions. The body supplies only the ref *list*; the provenance and text the
+ * digest is taken over come from the resolver, which is why a forged body cannot forge a digest.
+ *
+ * <!-- anchor: EIGHTEEN-IS-PER-REF-NOT-WHOLE-SECTION --> `18` compares ref by ref. A whole-section
+ * equality check against the re-derived trail would fail every deliberately split spec, which would
+ * reinstate the stranded remainder through a different code.
+ */
+
+import {Effect} from "effect";
+import type {ChildProcessSpawner} from "effect/unstable/process";
+import {
+	createComment,
+	createIssue,
+	type Existence,
+	getIssue,
+	type IssueRecord,
+	listComments,
+	listLabels,
+	resolveRepo,
+} from "../io/issues.ts";
+import {classifyingPrefix, deriveVocabulary, normalizeForReadback} from "../report/compose.ts";
+import {isBareAtReference, renderLeaks, scanBody} from "../report/leaks.ts";
+import {answer, FAILED, refuse, type VerbOutcome} from "../verb.ts";
+import * as graduateEmitted from "../wire/graduate-emitted.ts";
+import {stampOf} from "../wire/grill-marker.ts";
+import {
+	ALREADY_GRADUATED,
+	BAD_SECTIONS,
+	BARE_AT_PATH,
+	CLASSIFIED,
+	DECISIONS_STALE,
+	DIGEST_UNBINDABLE,
+	LEAKED_PATH,
+	NO_TARGET,
+	PRECONDITION_UNKNOWN,
+	READBACK_MISMATCH,
+	TRAIL_BLOCKED,
+	TRAIL_EMPTY,
+	WRITE_UNKNOWN,
+} from "./codes.ts";
+import type {DocumentRead} from "./compose-verb.ts";
+import {scanEmissions} from "./read-verb.ts";
+import {deriveTrail, requireSource} from "./source.ts";
+import {
+	checkSections,
+	readDecisionsSection,
+	renderFooter,
+	SPEC_SECTIONS,
+	withFooter,
+} from "./spec.ts";
+import {digestOfDecisions} from "./trail.ts";
+
+/** Unreachable: the digest is built here and the covered set is non-empty by the checks above. */
+const never = (what: string): never => {
+	throw new Error(`graduate emit: ${what} did not build — the verb's own invariant broke`);
+};
+
+/** The one label a spec leaves carrying, and the only one this verb may apply. */
+export const INTAKE_LABEL = "status:needs-triage";
+
+export interface EmitOptions<R = never> {
+	readonly source: number;
+	readonly specPath: string;
+	readonly spec: Effect.Effect<DocumentRead, never, R>;
+	readonly title: string;
+	readonly repo: string | null;
+	readonly env: Readonly<Record<string, string | undefined>>;
+	/** The footer's timestamp, injected so a filing is byte-reproducible in a test. */
+	readonly now: () => Date;
+}
+
+const VERB = "graduate emit";
+
+/**
+ * What the read-back found wrong, or `null`.
+ *
+ * Four assertions, none inherited: `report file`'s helper re-asserts its own six intake headings and
+ * its own `Filed by an agent` footer marker, so importing it would refuse every spec this group files
+ * twice over.
+ */
+export const readbackMismatch = (
+	landed: Existence<IssueRecord>,
+	title: string,
+	composed: string,
+): string | null => {
+	if (landed._tag === "Absent") return "the issue is not readable after the create";
+	if (landed._tag === "Unknown") return `the read-back itself failed: ${landed.reason}`;
+	const issue = landed.value;
+	if (issue.labels.length !== 1 || issue.labels[0] !== INTAKE_LABEL) {
+		return `it carries labels [${issue.labels.join(", ")}] rather than exactly "${INTAKE_LABEL}"`;
+	}
+	if (issue.title !== title) return `its title is "${issue.title}" rather than what --title gave`;
+	const missing = SPEC_SECTIONS.find((heading) => !issue.body.includes(heading));
+	if (missing !== undefined) return `the body is missing section "${missing}"`;
+	if (!/^<sub>Filed by an agent · graduated from #\d+ · spec [0-9a-f]{12} · /m.test(issue.body)) {
+		return "the body does not end with this group's footer line";
+	}
+	return normalizeForReadback(issue.body) === normalizeForReadback(composed)
+		? null
+		: "the landed body differs from what was sent";
+};
+
+export const runEmit = <R = never>(
+	options: EmitOptions<R>,
+): Effect.Effect<VerbOutcome, never, R | ChildProcessSpawner.ChildProcessSpawner> =>
+	Effect.gen(function* () {
+		const {source, title} = options;
+		if (!Number.isInteger(source) || source <= 0) {
+			return refuse(FAILED, `${VERB}: ${source} is not an issue number.`);
+		}
+		if (title.trim() === "") {
+			return refuse(FAILED, `${VERB}: --title is empty — refusing to file an untitled spec.`);
+		}
+
+		const repoAttempt = yield* resolveRepo(options.repo, options.env);
+		if (repoAttempt._tag === "Failure") {
+			return refuse(
+				FAILED,
+				`${VERB}: cannot resolve a target repo — pass --repo, or run inside a checkout whose origin remote resolves.`,
+			);
+		}
+		const repo = repoAttempt.value;
+
+		const document = yield* options.spec;
+		if (document._tag === "Failed") {
+			return refuse(
+				PRECONDITION_UNKNOWN,
+				`${VERB}: cannot read --spec ${options.specPath}: ${document.reason} — nothing was filed.`,
+			);
+		}
+		const body = document.text;
+
+		const problem = checkSections(body, SPEC_SECTIONS);
+		if (problem !== null) {
+			return refuse(
+				BAD_SECTIONS,
+				problem._tag === "Missing"
+					? `${VERB}: --spec ${options.specPath} is missing section "${problem.heading}".`
+					: problem._tag === "Empty"
+						? `${VERB}: --spec ${options.specPath} has an empty section "${problem.heading}".`
+						: `${VERB}: --spec ${options.specPath} has sections out of order — "${problem.heading}" follows "${problem.after}".`,
+			);
+		}
+
+		const stated = readDecisionsSection(body);
+		if (stated._tag === "Unparseable") {
+			return refuse(
+				DECISIONS_STALE,
+				`${VERB}: --spec ${options.specPath} has a ## Decisions line that does not parse: ${stated.line}. That section is machine-rendered, so a line this shape means the body was hand-edited.`,
+			);
+		}
+
+		if (isBareAtReference(body) || isBareAtReference(title)) {
+			return refuse(
+				BARE_AT_PATH,
+				`${VERB}: the spec is a bare @ path reference — not redactable, refusing to file it.`,
+			);
+		}
+		const titleScan = scanBody(title);
+		if (titleScan.leaks.length > 0) {
+			return refuse(
+				LEAKED_PATH,
+				`${VERB}: --title carries a machine-local path — refusing to file it.`,
+				renderLeaks(titleScan.leaks),
+			);
+		}
+
+		const found = yield* requireSource(VERB, repo, source);
+		if (found._tag === "Refused") return found.outcome;
+
+		const resolved = yield* deriveTrail(VERB, repo, source, found.value.kind, options.env);
+		if (resolved._tag === "Refused") return resolved.outcome;
+		const {trail, scope} = resolved.value;
+
+		if (trail.readiness === "blocked") {
+			return refuse(
+				TRAIL_BLOCKED,
+				`${VERB}: #${source}'s trail reports readiness "blocked" — ${trail.unresolved.length} decision(s) unresolved: ${trail.unresolved.map((row) => row.ref).join(", ")}. Nothing was filed.`,
+				[scope],
+			);
+		}
+		if (trail.decisions.length === 0) {
+			return refuse(
+				TRAIL_EMPTY,
+				`${VERB}: #${source}'s trail holds zero decisions — there is nothing to file.`,
+				[scope],
+			);
+		}
+		const unbindable = trail.decisions.find(
+			(row) => row.ref.trim() === "" || row.text.trim() === "",
+		);
+		if (unbindable !== undefined) {
+			return refuse(
+				DIGEST_UNBINDABLE,
+				`${VERB}: #${source}'s trail carries a decision with no ${unbindable.ref.trim() === "" ? "ref" : "text"} — it cannot be digested, so the emission binding is UNKNOWN. Nothing was filed.`,
+				[scope],
+			);
+		}
+
+		for (const claimed of stated.value) {
+			const onTrail = trail.decisions.find((row) => row.ref === claimed.ref);
+			if (onTrail === undefined) {
+				return refuse(
+					DECISIONS_STALE,
+					`${VERB}: --spec ${options.specPath} carries ${claimed.ref}, which is no longer on #${source}'s trail — the source moved after the spec was composed. Re-run graduate trail and graduate compose.`,
+					[scope],
+				);
+			}
+			const drifted =
+				onTrail.provenance !== claimed.provenance
+					? "provenance"
+					: onTrail.text !== claimed.text
+						? "text"
+						: null;
+			if (drifted !== null) {
+				return refuse(
+					DECISIONS_STALE,
+					`${VERB}: --spec ${options.specPath} carries ${claimed.ref}, whose ${drifted} on #${source} has changed since the spec was composed. Re-run graduate trail and graduate compose.`,
+					[scope],
+				);
+			}
+		}
+
+		// The digest is taken over the RE-DERIVED entries, in trail order — the body names refs and
+		// nothing more, which is what keeps a forged body from forging a digest.
+		const covered = trail.decisions.filter((row) =>
+			stated.value.some((claimed) => claimed.ref === row.ref),
+		);
+		const specDigest = digestOfDecisions(covered);
+
+		const comments = yield* listComments(repo, source);
+		if (comments._tag === "Failure") {
+			return refuse(
+				PRECONDITION_UNKNOWN,
+				`${VERB}: cannot read #${source}: ${comments.reason} — whether this trail was already graduated is UNKNOWN. Nothing was filed.`,
+				[scope],
+			);
+		}
+		const already = scanEmissions(comments.value).emissions.find(
+			(emission) => emission.specDigest === specDigest,
+		);
+		if (already !== undefined) {
+			return refuse(
+				ALREADY_GRADUATED,
+				`${VERB}: #${source} already graduated this decision set into #${already.issue} at spec digest ${specDigest} — refusing to file the same spec twice. A DIFFERENT subset of the trail may still be graduated.`,
+				[scope],
+			);
+		}
+
+		const labels = yield* listLabels(repo);
+		if (labels._tag === "Failure") {
+			return refuse(
+				PRECONDITION_UNKNOWN,
+				`${VERB}: cannot read the label set of ${repo}: ${labels.reason} — whether "${INTAKE_LABEL}" exists is UNKNOWN. Nothing was filed.`,
+				[scope],
+			);
+		}
+		if (!labels.value.includes(INTAKE_LABEL)) {
+			return refuse(
+				NO_TARGET,
+				`${VERB}: label "${INTAKE_LABEL}" does not exist in ${repo} — refusing to file a spec no triage run can find. Create it, or run the front-door bootstrap (#4952).`,
+				[scope],
+			);
+		}
+		const prefix = classifyingPrefix(title, deriveVocabulary(labels.value));
+		if (prefix !== null) {
+			return refuse(
+				CLASSIFIED,
+				`${VERB}: --title classifies the work ("${prefix}") — type and priority are triage's (ADR 0246).`,
+				[scope],
+			);
+		}
+
+		const at = stampOf(options.now());
+		if (at === null) {
+			return refuse(
+				FAILED,
+				`${VERB}: the clock produced no ISO-8601 instant — the emission could not be stamped.`,
+				[scope],
+			);
+		}
+		// The footer is appended BEFORE the scan, never after: bytes added after a scan are bytes
+		// nobody scanned, and this footer interpolates a source number and a digest (#3086).
+		const composed = withFooter(body, renderFooter({source, specDigest, timestamp: at}));
+		const scan = scanBody(composed);
+		if (scan.leaks.length > 0) {
+			return refuse(
+				LEAKED_PATH,
+				`${VERB}: the spec carries ${scan.leaks.length} machine-local path(s) — refusing to file them to a public issue.`,
+				[scope, ...renderLeaks(scan.leaks)],
+			);
+		}
+
+		const created = yield* createIssue(repo, title, composed, INTAKE_LABEL);
+		if (created._tag === "Failure") {
+			return refuse(
+				WRITE_UNKNOWN,
+				`${VERB}: the create failed, so whether a spec issue exists is UNKNOWN — check ${repo} before re-running.`,
+				[scope],
+			);
+		}
+
+		const mismatch = readbackMismatch(yield* getIssue(repo, created.value.number), title, composed);
+		if (mismatch !== null) {
+			return refuse(
+				READBACK_MISMATCH,
+				`${VERB}: filed #${created.value.number} but the read-back does not match what was sent: ${mismatch}.`,
+				[scope],
+			);
+		}
+
+		const [first, ...rest] = covered.map((row) => row.ref);
+		const marker = yield* createComment(
+			repo,
+			source,
+			graduateEmitted.emit({
+				source,
+				emitted: created.value.number,
+				digest: graduateEmitted.specDigest(specDigest) ?? never(specDigest),
+				covers: first === undefined ? never("a covered ref") : [first, ...rest],
+				at,
+			}),
+		);
+		if (marker._tag === "Failure") {
+			return refuse(
+				WRITE_UNKNOWN,
+				`${VERB}: filed #${created.value.number} and the marker write failed — the spec EXISTS but #${source} does not record it, so a re-run would file a second. Post the marker or check #${source} before re-running.`,
+				[scope],
+			);
+		}
+
+		return answer(
+			JSON.stringify({
+				source,
+				issue: created.value.number,
+				url: created.value.url,
+				specDigest,
+				labels: [INTAKE_LABEL],
+				marker: marker.value.id,
+			}),
+			[scope, `${VERB}: ${covered.length} decision(s) covered; spec digest ${specDigest}.`],
+		);
+	});

--- a/packages/fabrika-cli/src/graduate/emit-verb.unit.test.ts
+++ b/packages/fabrika-cli/src/graduate/emit-verb.unit.test.ts
@@ -1,0 +1,263 @@
+import {Effect} from "effect";
+import {describe, expect, it} from "vitest";
+import {errOut, fakeShell, okOut, once} from "../fakes.test-support.ts";
+import type {ExecResult} from "../io/exec.ts";
+import * as graduateEmitted from "../wire/graduate-emitted.ts";
+import {markerTime} from "../wire/grill-marker.ts";
+import {
+	ALREADY_GRADUATED,
+	BAD_SECTIONS,
+	CLASSIFIED,
+	DECISIONS_STALE,
+	NO_TARGET,
+	READBACK_MISMATCH,
+	WRITE_UNKNOWN,
+} from "./codes.ts";
+import type {DocumentRead} from "./compose-verb.ts";
+import {INTAKE_LABEL, runEmit} from "./emit-verb.ts";
+import {
+	CLEARED_DECISIONS,
+	CLEARED_SESSION,
+	commentsPayload,
+	issueJson,
+	REPO,
+	SESSION,
+	specFor,
+} from "./fixtures.test-support.ts";
+import {renderFooter, withFooter} from "./spec.ts";
+import {digestOfDecisions} from "./trail.ts";
+
+const ISSUE = /^gh api repos\/o\/r\/issues\/9412$/;
+const COMMENTS = /^gh api --paginate repos\/o\/r\/issues\/9412\/comments\?/;
+const PERMISSION = /collaborators\/.*\/permission/;
+const LABELS = /^gh api --paginate repos\/o\/r\/labels\?/;
+const CREATE = /^gh api --method POST repos\/o\/r\/issues /;
+const CREATED_ISSUE = /^gh api repos\/o\/r\/issues\/9520$/;
+const COMMENT = /^gh api --method POST repos\/o\/r\/issues\/9412\/comments/;
+
+const NOW = new Date("2026-08-09T18:36:48.000Z");
+const AT = markerTime("2026-08-09T18:36:48Z");
+if (AT === null) throw new Error("the fixture stamp did not build");
+
+const SPEC = specFor(CLEARED_DECISIONS);
+const SPEC_DIGEST = digestOfDecisions(CLEARED_DECISIONS);
+const LANDED = withFooter(
+	SPEC,
+	renderFooter({source: SESSION, specDigest: SPEC_DIGEST, timestamp: AT}),
+);
+const TITLE = "Cap moderation weight per topic";
+
+const emit = (
+	script: ReadonlyArray<readonly [RegExp, ExecResult]>,
+	spec: DocumentRead = {_tag: "Text", text: SPEC},
+	title = TITLE,
+) => {
+	const shell = fakeShell(script);
+	return Effect.runPromise(
+		Effect.provide(
+			runEmit({
+				source: SESSION,
+				specPath: "spec.md",
+				spec: Effect.succeed(spec),
+				title,
+				repo: null,
+				env: {CLAUDE_PIPELINE_REPO: REPO},
+				now: () => NOW,
+			}),
+			shell.layer,
+		),
+	).then((outcome) => ({outcome, shell}));
+};
+
+const healthy = (): ReadonlyArray<readonly [RegExp, ExecResult]> => [
+	[ISSUE, okOut(issueJson({number: SESSION, labels: ["grilling:session"]}))],
+	[COMMENTS, okOut(commentsPayload([...CLEARED_SESSION]))],
+	[PERMISSION, okOut("write")],
+	[LABELS, okOut(`${INTAKE_LABEL}\ntype:feature\np1`)],
+	[CREATE, okOut(JSON.stringify({number: 9520, html_url: "https://example.test/issues/9520"}))],
+	[
+		CREATED_ISSUE,
+		okOut(issueJson({number: 9520, title: TITLE, body: LANDED, labels: [INTAKE_LABEL]})),
+	],
+	[COMMENT, okOut(JSON.stringify({id: 5234567892, html_url: "https://example.test/c/5234567892"}))],
+];
+
+describe("the whole transaction", () => {
+	it("files one issue at status:needs-triage, reads it back, then posts the marker", async () => {
+		const {outcome, shell} = await emit(healthy());
+		expect(outcome.code).toBe(0);
+		expect(JSON.parse(outcome.stdout)).toEqual({
+			source: SESSION,
+			issue: 9520,
+			url: "https://example.test/issues/9520",
+			specDigest: SPEC_DIGEST,
+			labels: [INTAKE_LABEL],
+			marker: 5234567892,
+		});
+		const created = shell.calls.findIndex((line) => CREATE.test(line));
+		const marker = shell.calls.findIndex((line) => COMMENT.test(line));
+		expect(created).toBeGreaterThanOrEqual(0);
+		expect(marker).toBeGreaterThan(created);
+	});
+
+	it("applies exactly one label and no classification of its own", async () => {
+		const {shell} = await emit(healthy());
+		const create = shell.calls.find((line) => CREATE.test(line)) ?? "";
+		expect(create).toContain(`labels[]=${INTAKE_LABEL}`);
+		expect(create).not.toContain("type:");
+		expect(create).not.toContain("p1");
+	});
+
+	it("posts a marker binding the spec digest and every covered ref", async () => {
+		const {shell} = await emit(healthy());
+		const posted = shell.calls.find((line) => COMMENT.test(line)) ?? "";
+		expect(posted).toContain(`graduate-emitted: #${SESSION} → #9520 @ ${SPEC_DIGEST}`);
+		expect(posted).toContain("covers R1.1;R1.2");
+		expect(graduateEmitted.read(posted.slice(posted.indexOf("graduate-emitted:")))._tag).toBe(
+			"Found",
+		);
+	});
+
+	it("appends the footer BEFORE the leak scan, so its own bytes are scanned too", async () => {
+		const {shell} = await emit(healthy());
+		const create = shell.calls.find((line) => CREATE.test(line)) ?? "";
+		expect(create).toContain(`spec ${SPEC_DIGEST}`);
+		expect(create).toContain("Filed by an agent");
+	});
+});
+
+describe("the digest is re-derived, never trusted from --spec", () => {
+	it("refuses a ref the spec carries that is no longer on the trail", async () => {
+		const {outcome} = await emit(healthy(), {
+			_tag: "Text",
+			text: specFor([
+				...CLEARED_DECISIONS,
+				{ref: "R9.9", provenance: "ruled", text: "something nobody ruled"},
+			]),
+		});
+		expect(outcome.code).toBe(DECISIONS_STALE);
+		expect(outcome.stderr.join("\n")).toContain("R9.9");
+		expect(outcome.stdout).toBe("");
+	});
+
+	it("refuses a ref whose provenance in the spec is stronger than the trail's", async () => {
+		const forged = specFor(
+			CLEARED_DECISIONS.map((row) => ({...row, provenance: "ruled" as const})),
+		);
+		const {outcome} = await emit(healthy(), {_tag: "Text", text: forged});
+		expect(outcome.code).toBe(DECISIONS_STALE);
+		expect(outcome.stderr.join("\n")).toContain("provenance");
+	});
+
+	it("admits a deliberately split spec — a subset of the trail is the remainder's neighbour", async () => {
+		const subset = [CLEARED_DECISIONS[1]].filter((row) => row !== undefined);
+		const digest = digestOfDecisions(subset);
+		const landed = withFooter(
+			specFor(subset),
+			renderFooter({source: SESSION, specDigest: digest, timestamp: AT}),
+		);
+		const {outcome} = await emit(
+			[
+				...healthy().filter(([pattern]) => pattern !== CREATED_ISSUE),
+				[
+					CREATED_ISSUE,
+					okOut(issueJson({number: 9520, title: TITLE, body: landed, labels: [INTAKE_LABEL]})),
+				],
+			],
+			{_tag: "Text", text: specFor(subset)},
+		);
+		expect(outcome.code).toBe(0);
+		expect(JSON.parse(outcome.stdout).specDigest).toBe(digest);
+		expect(digest).not.toBe(SPEC_DIGEST);
+	});
+
+	it("refuses a second filing of the SAME spec digest", async () => {
+		const marker = graduateEmitted.emit({
+			source: SESSION,
+			emitted: 9520,
+			digest: graduateEmitted.specDigest(SPEC_DIGEST) ?? AT_FAIL(),
+			covers: ["R1.1", "R1.2"],
+			at: AT,
+		});
+		const {outcome} = await emit([
+			[ISSUE, okOut(issueJson({number: SESSION, labels: ["grilling:session"]}))],
+			[once(COMMENTS), okOut(commentsPayload([...CLEARED_SESSION]))],
+			[
+				COMMENTS,
+				okOut(commentsPayload([...CLEARED_SESSION, {id: 7, author: "acme-founder", body: marker}])),
+			],
+			[PERMISSION, okOut("write")],
+		]);
+		expect(outcome.code).toBe(ALREADY_GRADUATED);
+		expect(outcome.stderr.join("\n")).toContain("#9520");
+		expect(outcome.stderr.join("\n")).toContain("A DIFFERENT subset");
+	});
+});
+
+describe("the refusals that write nothing", () => {
+	it("refuses a spec missing a section", async () => {
+		const {outcome, shell} = await emit(healthy(), {_tag: "Text", text: "## Problem\nx\n"});
+		expect(outcome.code).toBe(BAD_SECTIONS);
+		expect(shell.calls).toEqual([]);
+	});
+
+	it("refuses a hand-edited decisions line rather than skipping it", async () => {
+		const {outcome} = await emit(healthy(), {
+			_tag: "Text",
+			text: SPEC.replace("— **ruled** · R1.2", "(he agreed)"),
+		});
+		expect(outcome.code).toBe(DECISIONS_STALE);
+		expect(outcome.stderr.join("\n")).toContain("machine-rendered");
+	});
+
+	it("refuses a repo with no status:needs-triage label", async () => {
+		const {outcome} = await emit([
+			...healthy().filter(([pattern]) => pattern !== LABELS),
+			[LABELS, okOut("type:feature\np1")],
+		]);
+		expect(outcome.code).toBe(NO_TARGET);
+		expect(outcome.stderr.join("\n")).toContain("no triage run can find");
+	});
+
+	it("refuses a --title that classifies the work — that is triage's seat", async () => {
+		const {outcome} = await emit(healthy(), {_tag: "Text", text: SPEC}, "feature: cap the weight");
+		expect(outcome.code).toBe(CLASSIFIED);
+		expect(outcome.stderr.join("\n")).toContain("ADR 0246");
+	});
+});
+
+describe("a write whose outcome is unproven", () => {
+	it("seats a failed create on 8, naming the repo to check", async () => {
+		const {outcome} = await emit([
+			...healthy().filter(([pattern]) => pattern !== CREATE),
+			[CREATE, errOut("gh: Bad gateway (HTTP 502)")],
+		]);
+		expect(outcome.code).toBe(WRITE_UNKNOWN);
+		expect(outcome.stdout).toBe("");
+	});
+
+	it("seats a failed marker write on 8, naming the ORPHANED spec a re-run would duplicate", async () => {
+		const {outcome} = await emit([
+			...healthy().filter(([pattern]) => pattern !== COMMENT),
+			[COMMENT, errOut("gh: Bad gateway (HTTP 502)")],
+		]);
+		expect(outcome.code).toBe(WRITE_UNKNOWN);
+		expect(outcome.stderr.join("\n")).toContain("the spec EXISTS but #9412 does not record it");
+	});
+
+	it("seats a read-back that does not match on 9, before any marker is written", async () => {
+		const {outcome, shell} = await emit([
+			...healthy().filter(([pattern]) => pattern !== CREATED_ISSUE),
+			[
+				CREATED_ISSUE,
+				okOut(issueJson({number: 9520, title: TITLE, body: LANDED, labels: [INTAKE_LABEL, "p1"]})),
+			],
+		]);
+		expect(outcome.code).toBe(READBACK_MISMATCH);
+		expect(shell.calls.some((line) => COMMENT.test(line))).toBe(false);
+	});
+});
+
+function AT_FAIL(): never {
+	throw new Error("the fixture digest did not build");
+}

--- a/packages/fabrika-cli/src/graduate/fixtures.test-support.ts
+++ b/packages/fabrika-cli/src/graduate/fixtures.test-support.ts
@@ -1,0 +1,108 @@
+/**
+ * The sources, trails and spec bodies the `graduate` verb tests are driven from.
+ *
+ * They compose the same bytes the group actually reads and writes — a session through the `grill`
+ * fixtures, a map body through the `map` ones, a spec through `./spec.ts` — so a test asserts against
+ * what the verbs produce rather than against a transcription of it.
+ */
+
+import {
+	AUTHORIZATION,
+	answerComment,
+	commentsPayload,
+	type FakeComment,
+	roundComment,
+	roundDigestOf,
+	rulingComment,
+} from "../grill/fixtures.test-support.ts";
+import {composeSpec} from "./spec.ts";
+import type {DecisionRow} from "./trail.ts";
+
+export const REPO = "o/r";
+export const SESSION = 9412;
+export const MAP = 9140;
+
+/** The digest the fixture session's round 1 binds. */
+export const BOUND = roundDigestOf(1);
+
+/** Round 1 as the session carries it: one fact question, one decision question. */
+export const ROUND: FakeComment = {id: 1, author: "acme-founder", body: roundComment(1)};
+
+/** A session with the fact answered and the decision ruled — the trail reads `ready`. */
+export const CLEARED_SESSION: ReadonlyArray<FakeComment> = [
+	ROUND,
+	{id: 2, author: "acme-founder", body: answerComment("R1.1", BOUND)},
+	{id: 3, author: "acme-founder", body: AUTHORIZATION},
+	{id: 4, author: "acme-founder", body: rulingComment("R1.2", BOUND)},
+];
+
+/** The two decisions a cleared fixture session normalizes into, in trail order. */
+export const CLEARED_DECISIONS: ReadonlyArray<DecisionRow> = [
+	{
+		ref: "R1.1",
+		provenance: "established",
+		text: "Does the vote table already carry a per-account weight column?",
+	},
+	{
+		ref: "R1.2",
+		provenance: "ruled",
+		text: "Do vouched-in yazars inherit their kefil's moderation weight?",
+	},
+];
+
+export {commentsPayload};
+
+export const issueJson = (input: {
+	readonly number: number;
+	readonly title?: string;
+	readonly body?: string;
+	readonly labels?: ReadonlyArray<string>;
+}): string =>
+	JSON.stringify({
+		number: input.number,
+		title: input.title ?? `issue ${input.number}`,
+		body: input.body ?? "",
+		state: "open",
+		labels: (input.labels ?? []).map((name) => ({name})),
+		html_url: `https://github.com/${REPO}/issues/${input.number}`,
+		user: {login: "acme-founder"},
+		milestone: null,
+		state_reason: null,
+	});
+
+/** A map body carrying one relayed ruling, one research finding, and one retired direction. */
+export const MAP_BODY = [
+	"## Destination",
+	"how moderation weight is earned",
+	"",
+	"## Decisions",
+	"- Weight is earned per account, never inherited from a kefil. — ruled on #9301 R1.2",
+	"- The vote table has no per-account weight column today. — from #9505",
+	"",
+	"## Frontier",
+	"- #9142 · research — which table carries the per-account weight column?",
+	"",
+	"## Fog",
+	"- what clock does weight decay on?",
+	"",
+	"## Out of scope",
+	"- a per-topic weight multiplier. It makes every action's authority unreadable — 2026-06-29",
+	"",
+].join("\n");
+
+/** The three authored sections a caller pipes to `graduate compose`. */
+export const AUTHORED = [
+	"## Problem",
+	"Moderation weight is unbounded, so one vouched account can outvote a whole topic.",
+	"",
+	"## Solution",
+	"Weight is earned per account and capped per topic; the vote table carries the cap.",
+	"",
+	"## Out of scope",
+	"Weight decay on a clock — no decision yet.",
+	"",
+].join("\n");
+
+/** The composed spec body for a set of decisions — what `graduate emit --spec` is handed. */
+export const specFor = (decisions: ReadonlyArray<DecisionRow>): string =>
+	composeSpec(AUTHORED, decisions);

--- a/packages/fabrika-cli/src/graduate/graduate.cli.test.ts
+++ b/packages/fabrika-cli/src/graduate/graduate.cli.test.ts
@@ -1,0 +1,53 @@
+/**
+ * The end-to-end half: the **exit status and the bytes on each channel** a shell caller reads.
+ *
+ * Only a subprocess proves those, and each `it` costs one cold node+TS load of `bin.ts` — so spawn
+ * count is this file's cost (`.patterns/subprocess-test-budget.md`). Two spawns, both about facts no
+ * in-process test can establish: that the group is reachable by its registration alone, and that a
+ * refusal really does leave stdout empty across the process boundary. Everything else about these
+ * verbs is covered in-process by the `*-verb.unit.test.ts` files beside them.
+ */
+import {execFileSync} from "node:child_process";
+import {fileURLToPath} from "node:url";
+import {describe, expect, it} from "vitest";
+import {SUBPROCESS_TEST_TIMEOUT_MS} from "../test-budget.ts";
+import {EMPTY_STDIN} from "./codes.ts";
+
+const BIN = fileURLToPath(new URL("../bin.ts", import.meta.url));
+
+interface Run {
+	readonly code: number;
+	readonly stdout: string;
+	readonly stderr: string;
+}
+
+/** `FABRIKA_SKIP_INFER` pins the invocation to this copy rather than whatever the repo root installs. */
+const fabrika = (args: ReadonlyArray<string>, stdin = ""): Run => {
+	try {
+		const stdout = execFileSync(process.execPath, [BIN, ...args], {
+			encoding: "utf8",
+			env: {...process.env, FABRIKA_SKIP_INFER: "1"},
+			input: stdin,
+			stdio: ["pipe", "pipe", "pipe"],
+		});
+		return {code: 0, stdout, stderr: ""};
+	} catch (err) {
+		const failure = err as {status?: number; stdout?: string; stderr?: string};
+		return {code: failure.status ?? -1, stdout: failure.stdout ?? "", stderr: failure.stderr ?? ""};
+	}
+};
+
+describe("fabrika graduate, end to end", {timeout: SUBPROCESS_TEST_TIMEOUT_MS}, () => {
+	it("lists all four verbs under --help by its registration alone", () => {
+		const run = fabrika(["graduate", "--help"]);
+		expect(run.code).toBe(0);
+		for (const verb of ["trail", "compose", "emit", "read"]) expect(run.stdout).toContain(verb);
+	});
+
+	it("refuses an empty compose on its own code with NOTHING on stdout", () => {
+		const run = fabrika(["graduate", "compose", "--trail", "trail.json"], "");
+		expect(run.code).toBe(EMPTY_STDIN);
+		expect(run.stdout).toBe("");
+		expect(run.stderr).toContain("graduate compose: stdin was read and held nothing");
+	});
+});

--- a/packages/fabrika-cli/src/graduate/read-verb.ts
+++ b/packages/fabrika-cli/src/graduate/read-verb.ts
@@ -1,0 +1,122 @@
+/**
+ * `graduate read` — the total three-valued read of a source's emission markers.
+ *
+ * <!-- anchor: READ-NEVER-REFUSES-ON-CONTENT --> **This verb never refuses on marker content.** A
+ * malformed marker is data: a `disregarded` row at exit `0`, never a refusal. Refusing would suppress
+ * the whole emission history over one bad comment, and would let anyone with write access disable the
+ * verb by posting one. Its only refusals are a source proven absent (`7`), one carrying neither label
+ * (`12`), and a read that could not complete (`11`).
+ *
+ * <!-- anchor: MALFORMED-IS-NOT-UNGRADUATED --> A source whose only marker is malformed reads
+ * `ungraduated` with a non-empty `disregarded`, and a caller must read both. That is knowingly
+ * conservative in the unsafe direction — `graduate emit` treats a malformed marker as unparseable too,
+ * so a mangled one can let a second spec be filed — and it is stated rather than hidden. The
+ * alternative, refusing every emission whenever any comment is malformed, would let one bad comment
+ * block a source forever.
+ *
+ * Coverage is derivable from `covers` and is deliberately **not** computed here: unioning the arrays
+ * against a trail is the caller's arithmetic, and doing it here would cost this verb its split test.
+ */
+
+import {Effect} from "effect";
+import type {ChildProcessSpawner} from "effect/unstable/process";
+import {type CommentRecord, listComments, resolveRepo} from "../io/issues.ts";
+import {answer, FAILED, refuse, type VerbOutcome} from "../verb.ts";
+import * as graduateEmitted from "../wire/graduate-emitted.ts";
+import {PRECONDITION_UNKNOWN} from "./codes.ts";
+import {requireSource} from "./source.ts";
+
+export interface ReadOptions {
+	readonly source: number;
+	readonly repo: string | null;
+	readonly env: Readonly<Record<string, string | undefined>>;
+}
+
+/** One parsed emission, as this verb reports it. */
+export interface Emission {
+	readonly issue: number;
+	readonly specDigest: string;
+	readonly covers: ReadonlyArray<string>;
+	readonly emittedAt: string;
+	readonly comment: number;
+}
+
+/** A purported marker not counted. `reason` is a closed set of one, so a consumer can branch on it. */
+export interface Disregarded {
+	readonly comment: number;
+	readonly reason: "malformed";
+	readonly detail: string;
+}
+
+export interface MarkerScan {
+	readonly emissions: ReadonlyArray<Emission>;
+	readonly disregarded: ReadonlyArray<Disregarded>;
+}
+
+/** Every emission marker on a comment list, oldest first, with every drift surfaced beside it. */
+export const scanEmissions = (comments: ReadonlyArray<CommentRecord>): MarkerScan => {
+	const emissions: Emission[] = [];
+	const disregarded: Disregarded[] = [];
+	for (const comment of comments) {
+		const read = graduateEmitted.read(comment.body);
+		if (read._tag === "Absent") continue;
+		if (read._tag === "Malformed") {
+			disregarded.push({comment: comment.id, reason: "malformed", detail: read.reason});
+			continue;
+		}
+		emissions.push({
+			issue: read.value.emitted,
+			specDigest: read.value.digest,
+			covers: read.value.covers,
+			emittedAt: read.value.at,
+			comment: comment.id,
+		});
+	}
+	return {emissions, disregarded};
+};
+
+const VERB = "graduate read";
+
+export const runRead = (
+	options: ReadOptions,
+): Effect.Effect<VerbOutcome, never, ChildProcessSpawner.ChildProcessSpawner> =>
+	Effect.gen(function* () {
+		const {source} = options;
+		if (!Number.isInteger(source) || source <= 0) {
+			return refuse(FAILED, `${VERB}: ${source} is not an issue number.`);
+		}
+
+		const repoAttempt = yield* resolveRepo(options.repo, options.env);
+		if (repoAttempt._tag === "Failure") {
+			return refuse(
+				FAILED,
+				`${VERB}: cannot resolve a target repo — pass --repo, or run inside a checkout whose origin remote resolves.`,
+			);
+		}
+		const repo = repoAttempt.value;
+
+		const found = yield* requireSource(VERB, repo, source);
+		if (found._tag === "Refused") return found.outcome;
+
+		const comments = yield* listComments(repo, source);
+		if (comments._tag === "Failure") {
+			return refuse(
+				PRECONDITION_UNKNOWN,
+				`${VERB}: cannot read the comments on #${source}: ${comments.reason} — whether this source graduated is UNKNOWN, never "no".`,
+			);
+		}
+
+		const scan = scanEmissions(comments.value);
+		return answer(
+			JSON.stringify({
+				source,
+				state: scan.emissions.length > 0 ? "graduated" : "ungraduated",
+				emissions: scan.emissions,
+				disregarded: scan.disregarded,
+				scanned: {comments: comments.value.length},
+			}),
+			[
+				`${VERB}: ${repo}#${source}, ${comments.value.length} comment(s) scanned, ${scan.emissions.length} emission(s) parsed, ${scan.disregarded.length} disregarded.`,
+			],
+		);
+	});

--- a/packages/fabrika-cli/src/graduate/read-verb.ts
+++ b/packages/fabrika-cli/src/graduate/read-verb.ts
@@ -95,7 +95,7 @@ export const runRead = (
 		}
 		const repo = repoAttempt.value;
 
-		const found = yield* requireSource(VERB, repo, source);
+		const found = yield* requireSource(VERB, repo, source, ".");
 		if (found._tag === "Refused") return found.outcome;
 
 		const comments = yield* listComments(repo, source);

--- a/packages/fabrika-cli/src/graduate/read-verb.unit.test.ts
+++ b/packages/fabrika-cli/src/graduate/read-verb.unit.test.ts
@@ -1,0 +1,139 @@
+import {Effect} from "effect";
+import {describe, expect, it} from "vitest";
+import {errOut, fakeShell, okOut} from "../fakes.test-support.ts";
+import type {ExecResult} from "../io/exec.ts";
+import * as graduateEmitted from "../wire/graduate-emitted.ts";
+import {markerTime} from "../wire/grill-marker.ts";
+import {NO_TARGET, PRECONDITION_UNKNOWN, SOURCE_UNRECOGNIZED} from "./codes.ts";
+import {commentsPayload, issueJson, REPO, SESSION} from "./fixtures.test-support.ts";
+import {runRead} from "./read-verb.ts";
+
+const ISSUE = /^gh api repos\/o\/r\/issues\/9412$/;
+const COMMENTS = /^gh api --paginate repos\/o\/r\/issues\/9412\/comments\?/;
+
+const AT = markerTime("2026-08-09T18:36:48Z");
+if (AT === null) throw new Error("the fixture stamp did not build");
+
+const marker = (digest: string, emitted: number, covers: [string, ...string[]]): string =>
+	graduateEmitted.emit({
+		source: SESSION,
+		emitted,
+		digest:
+			graduateEmitted.specDigest(digest) ??
+			(() => {
+				throw new Error("the fixture digest did not build");
+			})(),
+		covers,
+		at: AT,
+	});
+
+const run = (script: ReadonlyArray<readonly [RegExp, ExecResult]>) =>
+	Effect.runPromise(
+		Effect.provide(
+			runRead({source: SESSION, repo: null, env: {CLAUDE_PIPELINE_REPO: REPO}}),
+			fakeShell(script).layer,
+		),
+	);
+
+const source = [ISSUE, okOut(issueJson({number: SESSION, labels: ["grilling:session"]}))] as const;
+
+describe("the read is total and three-valued", () => {
+	it("reads a source with no comments as ungraduated — zero comments is a FACT", async () => {
+		const out = await run([source, [COMMENTS, okOut("[]")]]);
+		expect(out.code).toBe(0);
+		expect(JSON.parse(out.stdout)).toEqual({
+			source: SESSION,
+			state: "ungraduated",
+			emissions: [],
+			disregarded: [],
+			scanned: {comments: 0},
+		});
+	});
+
+	it("reports every parsed emission, oldest first, with its covers list", async () => {
+		const out = await run([
+			source,
+			[
+				COMMENTS,
+				okOut(
+					commentsPayload([
+						{id: 5, author: "acme-founder", body: marker("a1b2c3d4e5f6", 9520, ["R1.1", "R1.2"])},
+						{id: 6, author: "acme-founder", body: marker("0123456789ab", 9530, ["#9301 R1.4"])},
+					]),
+				),
+			],
+		]);
+		expect(out.code).toBe(0);
+		const answer = JSON.parse(out.stdout);
+		expect(answer.state).toBe("graduated");
+		expect(answer.emissions).toEqual([
+			{
+				issue: 9520,
+				specDigest: "a1b2c3d4e5f6",
+				covers: ["R1.1", "R1.2"],
+				emittedAt: "2026-08-09T18:36:48Z",
+				comment: 5,
+			},
+			{
+				issue: 9530,
+				specDigest: "0123456789ab",
+				covers: ["#9301 R1.4"],
+				emittedAt: "2026-08-09T18:36:48Z",
+				comment: 6,
+			},
+		]);
+	});
+
+	it("never refuses on marker content — a malformed marker is a disregarded row at exit 0", async () => {
+		const out = await run([
+			source,
+			[
+				COMMENTS,
+				okOut(
+					commentsPayload([
+						{
+							id: 9,
+							author: "acme-founder",
+							body: "graduate-emitted: #9412 → #9520 @ NOTHEX · covers R1.1 · 2026-08-09T18:36:48Z\n",
+						},
+					]),
+				),
+			],
+		]);
+		expect(out.code).toBe(0);
+		const answer = JSON.parse(out.stdout);
+		expect(answer.state).toBe("ungraduated");
+		expect(answer.disregarded).toMatchObject([{comment: 9, reason: "malformed"}]);
+	});
+
+	it("ignores an ordinary comment rather than reporting it as a drift", async () => {
+		const out = await run([
+			source,
+			[
+				COMMENTS,
+				okOut(commentsPayload([{id: 3, author: "acme-founder", body: "picking this up"}])),
+			],
+		]);
+		expect(JSON.parse(out.stdout).disregarded).toEqual([]);
+	});
+});
+
+describe("its only three refusals", () => {
+	it("refuses a source that does not exist", async () => {
+		const out = await run([[ISSUE, errOut("gh: Not Found (HTTP 404)")]]);
+		expect(out.code).toBe(NO_TARGET);
+		expect(out.stdout).toBe("");
+	});
+
+	it("refuses a source carrying neither label", async () => {
+		const out = await run([[ISSUE, okOut(issueJson({number: SESSION, labels: []}))]]);
+		expect(out.code).toBe(SOURCE_UNRECOGNIZED);
+	});
+
+	it('refuses a comment read that could not complete — never "no"', async () => {
+		const out = await run([source, [COMMENTS, errOut("gh: Bad gateway (HTTP 502)")]]);
+		expect(out.code).toBe(PRECONDITION_UNKNOWN);
+		expect(out.stdout).toBe("");
+		expect(out.stderr.join("\n")).toContain('UNKNOWN, never "no"');
+	});
+});

--- a/packages/fabrika-cli/src/graduate/read-verb.unit.test.ts
+++ b/packages/fabrika-cli/src/graduate/read-verb.unit.test.ts
@@ -125,9 +125,12 @@ describe("its only three refusals", () => {
 		expect(out.stdout).toBe("");
 	});
 
-	it("refuses a source carrying neither label", async () => {
+	it("refuses a source carrying neither label, in this verb's own words", async () => {
 		const out = await run([[ISSUE, okOut(issueJson({number: SESSION, labels: []}))]]);
 		expect(out.code).toBe(SOURCE_UNRECOGNIZED);
+		expect(out.stderr.join("\n")).toContain(
+			`graduate read: #${SESSION} carries neither grilling:session nor wayfinding:map.`,
+		);
 	});
 
 	it('refuses a comment read that could not complete — never "no"', async () => {

--- a/packages/fabrika-cli/src/graduate/source.ts
+++ b/packages/fabrika-cli/src/graduate/source.ts
@@ -17,6 +17,7 @@ import type {ChildProcessSpawner} from "effect/unstable/process";
 import {runRead as runGrillRead} from "../grill/read-verb.ts";
 import {SESSION_LABEL} from "../grill/session.ts";
 import {getIssue, type IssueRecord} from "../io/issues.ts";
+import {isRecord, parseJson} from "../io/json.ts";
 import {MAP_LABEL, readFrontier, readMap} from "../map/frontier.ts";
 import {refuse, type VerbOutcome} from "../verb.ts";
 import {BAD_SECTIONS, NO_TARGET, PRECONDITION_UNKNOWN, SOURCE_UNRECOGNIZED} from "./codes.ts";
@@ -45,11 +46,16 @@ export interface Source {
  *
  * An issue carrying **both** labels is `12` naming both rather than a merge of two trails: that is a
  * mis-shaped artifact, and guessing which one is live would be judgment inside a verb.
+ *
+ * `noTrailClause` is the tail the *neither*-label refusal ends on, and each of the three callers
+ * states a different one because the contract's error tables state three different sentences — the
+ * check is shared, the bytes a reader sees are not.
  */
 export const requireSource = (
 	verb: string,
 	repo: string,
 	source: number,
+	noTrailClause: string,
 ): Effect.Effect<Guarded<Source>, never, ChildProcessSpawner.ChildProcessSpawner> =>
 	Effect.gen(function* () {
 		const found = yield* getIssue(repo, source);
@@ -78,7 +84,7 @@ export const requireSource = (
 			return refused(
 				refuse(
 					SOURCE_UNRECOGNIZED,
-					`${verb}: #${source} carries neither ${SESSION_LABEL} nor ${MAP_LABEL} — there is no trail to read.`,
+					`${verb}: #${source} carries neither ${SESSION_LABEL} nor ${MAP_LABEL}${noTrailClause}`,
 				),
 			);
 		}
@@ -122,6 +128,26 @@ interface GrillAnswer {
 }
 
 /**
+ * The sibling's stdout, read as its answer or as nothing.
+ *
+ * The resolver's shape is a contract between two groups, not a guarantee: a rename, an added prose
+ * line, a truncated pipe all arrive here as bytes that do not parse. An unguarded `JSON.parse` would
+ * throw, and a defect is not a seated exit code — the verb would die where it owes `11`.
+ */
+export const readGrillAnswer = (stdout: string): GrillAnswer | undefined => {
+	const parsed = parseJson(stdout);
+	if (!isRecord(parsed)) return undefined;
+	if (!Array.isArray(parsed.questions)) return undefined;
+	if (typeof parsed.frontier !== "string") return undefined;
+	if (!isRecord(parsed.scanned)) return undefined;
+	return {
+		questions: parsed.questions as ReadonlyArray<ResolvedQuestion>,
+		frontier: parsed.frontier,
+		scanned: parsed.scanned as Readonly<Record<string, number>>,
+	};
+};
+
+/**
  * The trail of `source`, resolved through the reader its kind belongs to.
  *
  * Zero decisions is a **fact** — the trail reads `empty`. A read that could not complete is `11`,
@@ -138,7 +164,15 @@ export const deriveTrail = (
 		if (kind === "grilling") {
 			const outcome = yield* runGrillRead({session: source, repo, env});
 			if (outcome.code !== 0) return refused(grillRefusal(verb, source, outcome));
-			const answer = JSON.parse(outcome.stdout) as GrillAnswer;
+			const answer = readGrillAnswer(outcome.stdout);
+			if (answer === undefined) {
+				return refused(
+					refuse(
+						PRECONDITION_UNKNOWN,
+						`${verb}: the grilling resolver exited 0 on #${source} but its answer does not carry the shape this verb reads (questions, frontier, scanned) — the trail is UNKNOWN, never empty and never ready.`,
+					),
+				);
+			}
 			const normalized = fromSession(answer.questions);
 			return {
 				_tag: "Ok",

--- a/packages/fabrika-cli/src/graduate/source.ts
+++ b/packages/fabrika-cli/src/graduate/source.ts
@@ -1,0 +1,191 @@
+/**
+ * The source dispatch, and the trail derived through the sibling that owns it.
+ *
+ * Two verbs need the identical answer — `graduate trail` prints it and `graduate emit` re-derives it
+ * to bind a spec — so it is resolved once here rather than twice beside them.
+ *
+ * **The resolution runs through the siblings' own readers and parses neither artifact.** A session
+ * goes through `../grill/read-verb.ts`, whose four ruling clauses and ACL resolution are what `ruled`
+ * *means*; a map goes through `../map/frontier.ts` and `../map/body.ts`, the module rather than `map
+ * read`'s stdout, because that verb's answer carries no `## Decisions` array and a design reading
+ * decisions off it could not produce a `ruled` row at all. A second parser here would be a second
+ * answer to a question already decided elsewhere, and the two could disagree.
+ */
+
+import {Effect} from "effect";
+import type {ChildProcessSpawner} from "effect/unstable/process";
+import {runRead as runGrillRead} from "../grill/read-verb.ts";
+import {SESSION_LABEL} from "../grill/session.ts";
+import {getIssue, type IssueRecord} from "../io/issues.ts";
+import {MAP_LABEL, readFrontier, readMap} from "../map/frontier.ts";
+import {refuse, type VerbOutcome} from "../verb.ts";
+import {BAD_SECTIONS, NO_TARGET, PRECONDITION_UNKNOWN, SOURCE_UNRECOGNIZED} from "./codes.ts";
+import {
+	fromMap,
+	fromSession,
+	type ResolvedQuestion,
+	type SourceKind,
+	type Trail,
+	trailOf,
+} from "./trail.ts";
+
+export type Guarded<A> =
+	| {readonly _tag: "Ok"; readonly value: A}
+	| {readonly _tag: "Refused"; readonly outcome: VerbOutcome};
+
+const refused = (outcome: VerbOutcome): Guarded<never> => ({_tag: "Refused", outcome});
+
+export interface Source {
+	readonly issue: IssueRecord;
+	readonly kind: SourceKind;
+}
+
+/**
+ * The source issue and which trail surface it is.
+ *
+ * An issue carrying **both** labels is `12` naming both rather than a merge of two trails: that is a
+ * mis-shaped artifact, and guessing which one is live would be judgment inside a verb.
+ */
+export const requireSource = (
+	verb: string,
+	repo: string,
+	source: number,
+): Effect.Effect<Guarded<Source>, never, ChildProcessSpawner.ChildProcessSpawner> =>
+	Effect.gen(function* () {
+		const found = yield* getIssue(repo, source);
+		if (found._tag === "Absent") {
+			return refused(refuse(NO_TARGET, `${verb}: #${source} does not exist.`));
+		}
+		if (found._tag === "Unknown") {
+			return refused(
+				refuse(
+					PRECONDITION_UNKNOWN,
+					`${verb}: cannot read #${source}: ${found.reason} — the trail is UNKNOWN, never empty and never ready.`,
+				),
+			);
+		}
+		const isSession = found.value.labels.includes(SESSION_LABEL);
+		const isMap = found.value.labels.includes(MAP_LABEL);
+		if (isSession && isMap) {
+			return refused(
+				refuse(
+					SOURCE_UNRECOGNIZED,
+					`${verb}: #${source} carries both ${SESSION_LABEL} and ${MAP_LABEL} — refusing to guess which trail is live.`,
+				),
+			);
+		}
+		if (!isSession && !isMap) {
+			return refused(
+				refuse(
+					SOURCE_UNRECOGNIZED,
+					`${verb}: #${source} carries neither ${SESSION_LABEL} nor ${MAP_LABEL} — there is no trail to read.`,
+				),
+			);
+		}
+		return {_tag: "Ok", value: {issue: found.value, kind: isSession ? "grilling" : "map"}};
+	});
+
+/** What the dispatched resolver reported, for the scope line the readiness is only readable against. */
+export interface Resolved {
+	readonly trail: Trail;
+	readonly scope: string;
+}
+
+/**
+ * The grilling resolver's own refusal, re-seated under this verb's name.
+ *
+ * The ACL branch is discriminated off the sibling's message because its two `11`s mean different
+ * things to a reader — a comment read that did not complete, versus a ruling whose authority could
+ * not be resolved — and only the resolver knows which it hit. A miss lands on the general `11`, the
+ * same code with a less specific reason, never a permissive answer.
+ */
+const grillRefusal = (verb: string, source: number, outcome: VerbOutcome): VerbOutcome => {
+	const reason = outcome.stderr.at(-1) ?? "the resolver refused without a reason";
+	if (outcome.code === NO_TARGET) {
+		return refuse(NO_TARGET, `${verb}: #${source} does not exist.`);
+	}
+	return /'s permission on /.test(reason)
+		? refuse(
+				PRECONDITION_UNKNOWN,
+				`${verb}: the resolver could not resolve a marker author's permission: ${reason} — a ruling's authority is UNKNOWN, never granted.`,
+			)
+		: refuse(
+				PRECONDITION_UNKNOWN,
+				`${verb}: cannot read #${source}: ${reason} — the trail is UNKNOWN, never empty and never ready.`,
+			);
+};
+
+interface GrillAnswer {
+	readonly questions: ReadonlyArray<ResolvedQuestion>;
+	readonly frontier: string;
+	readonly scanned: Readonly<Record<string, number>>;
+}
+
+/**
+ * The trail of `source`, resolved through the reader its kind belongs to.
+ *
+ * Zero decisions is a **fact** — the trail reads `empty`. A read that could not complete is `11`,
+ * never an empty trail (ADR 0092).
+ */
+export const deriveTrail = (
+	verb: string,
+	repo: string,
+	source: number,
+	kind: SourceKind,
+	env: Readonly<Record<string, string | undefined>>,
+): Effect.Effect<Guarded<Resolved>, never, ChildProcessSpawner.ChildProcessSpawner> =>
+	Effect.gen(function* () {
+		if (kind === "grilling") {
+			const outcome = yield* runGrillRead({session: source, repo, env});
+			if (outcome.code !== 0) return refused(grillRefusal(verb, source, outcome));
+			const answer = JSON.parse(outcome.stdout) as GrillAnswer;
+			const normalized = fromSession(answer.questions);
+			return {
+				_tag: "Ok",
+				value: {
+					trail: trailOf({source, kind, ...normalized, outOfScope: []}),
+					scope: `${verb}: #${source} is a grilling session; the resolver read ${answer.scanned.comments ?? 0} comment(s) over ${answer.scanned.rounds ?? 0} round(s) and reports frontier "${answer.frontier}".`,
+				},
+			};
+		}
+
+		const map = yield* readMap(repo, source);
+		if (map._tag === "Absent") {
+			return refused(refuse(NO_TARGET, `${verb}: #${source} does not exist.`));
+		}
+		if (map._tag === "Malformed") {
+			return refused(
+				refuse(
+					BAD_SECTIONS,
+					`${verb}: #${source}'s map body does not parse into the five sections, or holds a ## Decisions entry citing neither an authority nor a ticket (${map.reason}) — this is proven malformed, not unknown. Fix the map and re-run.`,
+				),
+			);
+		}
+		if (map._tag === "Unknown") {
+			return refused(
+				refuse(
+					PRECONDITION_UNKNOWN,
+					`${verb}: cannot read #${source}: ${map.reason} — the trail is UNKNOWN, never empty and never ready.`,
+				),
+			);
+		}
+
+		const frontier = yield* readFrontier(repo, source, map.body);
+		if (frontier._tag !== "Frontier") {
+			return refused(
+				refuse(
+					PRECONDITION_UNKNOWN,
+					`${verb}: cannot read #${source}: ${frontier._tag === "MapAbsent" ? "the map reports no child list" : frontier.reason} — the trail is UNKNOWN, never empty and never ready.`,
+				),
+			);
+		}
+
+		const normalized = fromMap(map.body.decisions, frontier.value.tickets);
+		return {
+			_tag: "Ok",
+			value: {
+				trail: trailOf({source, kind, ...normalized, outOfScope: map.body.outOfScope}),
+				scope: `${verb}: #${source} is a wayfinding map; the resolver read ${frontier.value.scanned.children} child(ren) and ${frontier.value.scanned.comments} comment(s), and the body carries ${map.body.decisions.length} decision(s).`,
+			},
+		};
+	});

--- a/packages/fabrika-cli/src/graduate/source.unit.test.ts
+++ b/packages/fabrika-cli/src/graduate/source.unit.test.ts
@@ -1,0 +1,37 @@
+import {describe, expect, it} from "vitest";
+import {readGrillAnswer} from "./source.ts";
+
+const WELL_SHAPED = JSON.stringify({
+	questions: [],
+	frontier: "R1",
+	scanned: {comments: 3, rounds: 1},
+});
+
+describe("the grilling resolver's stdout is read as its answer or as nothing", () => {
+	it("reads a well-shaped answer", () => {
+		expect(readGrillAnswer(WELL_SHAPED)).toMatchObject({frontier: "R1"});
+	});
+
+	it("returns nothing for bytes that are not JSON at all", () => {
+		expect(readGrillAnswer("grill read: 3 comment(s)\n")).toBeUndefined();
+	});
+
+	it("returns nothing for a truncated payload", () => {
+		expect(readGrillAnswer(WELL_SHAPED.slice(0, 20))).toBeUndefined();
+	});
+
+	it("returns nothing when a field this verb reads is renamed or retyped", () => {
+		expect(readGrillAnswer(JSON.stringify({frontier: "R1", scanned: {}}))).toBeUndefined();
+		expect(
+			readGrillAnswer(JSON.stringify({questions: [], frontier: 1, scanned: {}})),
+		).toBeUndefined();
+		expect(
+			readGrillAnswer(JSON.stringify({questions: [], frontier: "R1", scanned: null})),
+		).toBeUndefined();
+	});
+
+	it("returns nothing for JSON that is not an object", () => {
+		expect(readGrillAnswer("[]")).toBeUndefined();
+		expect(readGrillAnswer("null")).toBeUndefined();
+	});
+});

--- a/packages/fabrika-cli/src/graduate/spec.ts
+++ b/packages/fabrika-cli/src/graduate/spec.ts
@@ -1,0 +1,197 @@
+/**
+ * The spec body this group writes: its four sections, the one it renders itself, and the footer that
+ * binds a filing to the source it came from.
+ *
+ * <!-- anchor: DECISIONS-ARE-RENDERED-NOT-AUTHORED --> **`## Decisions` is rendered from the trail
+ * and never authored.** The property the whole skill exists for is that a downstream reader can tell
+ * the founder's decisions from the model's synthesis without the source transcript (#4227). A
+ * convention telling the model to label them would be exactly the prose invariant that holds until
+ * the run that forgets; here the provenance word and the ref come from resolver output the model
+ * never touches, so a mislabelled decision is not something an agent can produce by being careless.
+ *
+ * <!-- anchor: THE-DECISIONS-LINE-IS-PARSEABLE-BACK --> The rendered line is written so `graduate
+ * emit` can recover the ref from it, which is what says which subset a spec covers. Anchoring the
+ * parse on the **bolded provenance token** — a closed two-member set — is what keeps it unambiguous
+ * when the decision text itself carries an em dash or a `·`, and it lets a ref carry a space and a
+ * `#` (`#9301 R1.2`) without quoting.
+ *
+ * `report`'s `REQUIRED_SECTIONS` is deliberately not widened to hold these four: that constant is the
+ * *intake* floor, and widening it would change what every intake filing in the repo requires to serve
+ * one caller that is not intake.
+ */
+
+import type {DecisionRow, Provenance} from "./trail.ts";
+
+/** The three sections the caller authors, in the one order a spec body may carry them. */
+export const AUTHORED_SECTIONS: ReadonlyArray<string> = [
+	"## Problem",
+	"## Solution",
+	"## Out of scope",
+];
+
+/** The heading this group owns entirely. Present on stdin, it is a refusal, never a section. */
+export const DECISIONS_SECTION = "## Decisions";
+
+/** The four sections a filed spec carries, in order and with nothing else. */
+export const SPEC_SECTIONS: ReadonlyArray<string> = [
+	"## Problem",
+	"## Solution",
+	DECISIONS_SECTION,
+	"## Out of scope",
+];
+
+export type SectionProblem =
+	| {readonly _tag: "Missing"; readonly heading: string}
+	| {readonly _tag: "Empty"; readonly heading: string}
+	| {readonly _tag: "OutOfOrder"; readonly heading: string; readonly after: string};
+
+interface Seen {
+	readonly heading: string;
+	readonly content: string;
+}
+
+/** The `##` sections of a markdown body, in the order they appear, with their content. */
+export const sectionsOf = (body: string): ReadonlyArray<Seen> => {
+	const seen: {heading: string; content: string[]}[] = [];
+	for (const line of body.split("\n")) {
+		const matched = /^##\s+(.*?)\s*$/.exec(line);
+		if (matched?.[1] !== undefined) seen.push({heading: `## ${matched[1]}`, content: []});
+		else seen.at(-1)?.content.push(line);
+	}
+	return seen.map((section) => ({heading: section.heading, content: section.content.join("\n")}));
+};
+
+/**
+ * The first thing wrong with `required`, or `null`.
+ *
+ * One problem at a time, and in this precedence — missing, then order, then empty — so every refusal
+ * names exactly one correctable thing and a second attempt is a correction rather than a rewrite.
+ */
+export const checkSections = (
+	body: string,
+	required: ReadonlyArray<string>,
+): SectionProblem | null => {
+	const seen = sectionsOf(body);
+	const headings = seen.map((section) => section.heading);
+
+	for (const heading of required) {
+		if (!headings.includes(heading)) return {_tag: "Missing", heading};
+	}
+
+	const ordered = headings.filter((heading) => required.includes(heading));
+	for (let index = 1; index < ordered.length; index += 1) {
+		const previous = ordered[index - 1];
+		const current = ordered[index];
+		if (previous === undefined || current === undefined) continue;
+		if (required.indexOf(current) < required.indexOf(previous)) {
+			return {_tag: "OutOfOrder", heading: current, after: previous};
+		}
+	}
+
+	for (const heading of required) {
+		const section = seen.find((row) => row.heading === heading);
+		if (section === undefined || section.content.trim() === "") return {_tag: "Empty", heading};
+	}
+	return null;
+};
+
+/** Whether the authored body reaches for the section this group owns. */
+export const carriesDecisionsHeading = (body: string): boolean =>
+	sectionsOf(body).some((section) => section.heading === DECISIONS_SECTION);
+
+/**
+ * One `## Decisions` entry's bytes.
+ *
+ * The source issue is **not** repeated per line — it is in the footer once. Repeating it made a
+ * map-sourced line read as two issue numbers in a row (`· #9502 #9505`).
+ */
+export const renderDecision = (row: DecisionRow): string =>
+	`- ${row.text} — **${row.provenance}** · ${row.ref}`;
+
+export const renderDecisions = (rows: ReadonlyArray<DecisionRow>): string =>
+	rows.map(renderDecision).join("\n");
+
+/** The exact shape a rendered decision line takes, and the only shape `graduate emit` reads back. */
+const DECISION_LINE = /^- (.+) — \*\*(ruled|established)\*\* · (.+)$/;
+
+export type DecisionLineRead =
+	| {readonly _tag: "Decision"; readonly value: DecisionRow}
+	| {readonly _tag: "Unparseable"; readonly line: string};
+
+export const readDecisionLine = (line: string): DecisionLineRead => {
+	const matched = DECISION_LINE.exec(line.trimEnd());
+	if (matched === null) return {_tag: "Unparseable", line};
+	return {
+		_tag: "Decision",
+		value: {
+			text: (matched[1] ?? "").trim(),
+			provenance: matched[2] as Provenance,
+			ref: (matched[3] ?? "").trim(),
+		},
+	};
+};
+
+export type DecisionsSectionRead =
+	| {readonly _tag: "Decisions"; readonly value: ReadonlyArray<DecisionRow>}
+	| {readonly _tag: "Unparseable"; readonly line: string};
+
+/**
+ * Every decision the spec body states, read back off its own rendered section.
+ *
+ * A non-blank line that does not parse is a refusal rather than a skip: the section is
+ * machine-rendered at both ends, so a line this shape means the body was edited by hand.
+ */
+export const readDecisionsSection = (body: string): DecisionsSectionRead => {
+	const section = sectionsOf(body).find((row) => row.heading === DECISIONS_SECTION);
+	const rows: DecisionRow[] = [];
+	for (const line of (section?.content ?? "").split("\n")) {
+		if (line.trim() === "") continue;
+		const read = readDecisionLine(line);
+		if (read._tag === "Unparseable") return read;
+		rows.push(read.value);
+	}
+	return {_tag: "Decisions", value: rows};
+};
+
+/** The composed four-section body: the authored sections with `## Decisions` spliced into place. */
+export const composeSpec = (authored: string, decisions: ReadonlyArray<DecisionRow>): string => {
+	const seen = sectionsOf(authored);
+	const content = (heading: string): string =>
+		(seen.find((section) => section.heading === heading)?.content ?? "").trim();
+	return [
+		"## Problem",
+		content("## Problem"),
+		"",
+		"## Solution",
+		content("## Solution"),
+		"",
+		DECISIONS_SECTION,
+		renderDecisions(decisions),
+		"",
+		"## Out of scope",
+		content("## Out of scope"),
+		"",
+	].join("\n");
+};
+
+export interface FooterFields {
+	readonly source: number;
+	readonly specDigest: string;
+	readonly timestamp: string;
+}
+
+/**
+ * The footer `graduate emit` appends — never `compose`.
+ *
+ * <!-- anchor: FILED-BY-AN-AGENT-IS-NEVER-DROPPED --> **`Filed by an agent` leads the line and is
+ * not this group's to omit.** It is ADR 0159's never-auto-close signal, and `../triage/provenance.ts`
+ * classifies a body by whether a line begins with `<sub>Filed by an agent` — so a spec filed without
+ * it is read as human-authored and loses the signal. This group *extends* the shipped shape with the
+ * source and the spec digest; it does not replace it.
+ */
+export const renderFooter = (fields: FooterFields): string =>
+	`<sub>Filed by an agent · graduated from #${fields.source} · spec ${fields.specDigest} · ${fields.timestamp}</sub>`;
+
+/** The spec body with the footer after a blank line, newline-terminated. */
+export const withFooter = (body: string, footer: string): string =>
+	`${body.replace(/\s+$/, "")}\n\n${footer}\n`;

--- a/packages/fabrika-cli/src/graduate/spec.ts
+++ b/packages/fabrika-cli/src/graduate/spec.ts
@@ -95,6 +95,26 @@ export const checkSections = (
 	return null;
 };
 
+export type Unplaced =
+	| {readonly _tag: "Preamble"}
+	| {readonly _tag: "Heading"; readonly heading: string};
+
+/**
+ * The first authored bytes `composeSpec` would not carry into the spec, or `null`.
+ *
+ * `composeSpec` rebuilds the body from the closed set of headings, so anything outside it — a
+ * preamble above `## Problem`, a fourth `## Risks` — would be dropped without a word and exist only
+ * in the caller's scrollback. Naming it is the only option that does not lose the author's bytes.
+ */
+export const unplacedContent = (body: string, allowed: ReadonlyArray<string>): Unplaced | null => {
+	const lines = body.split("\n");
+	const firstHeading = lines.findIndex((line) => /^##\s+/.test(line));
+	const preamble = (firstHeading === -1 ? lines : lines.slice(0, firstHeading)).join("\n");
+	if (preamble.trim() !== "") return {_tag: "Preamble"};
+	const stray = sectionsOf(body).find((section) => !allowed.includes(section.heading));
+	return stray === undefined ? null : {_tag: "Heading", heading: stray.heading};
+};
+
 /** Whether the authored body reaches for the section this group owns. */
 export const carriesDecisionsHeading = (body: string): boolean =>
 	sectionsOf(body).some((section) => section.heading === DECISIONS_SECTION);

--- a/packages/fabrika-cli/src/graduate/spec.unit.test.ts
+++ b/packages/fabrika-cli/src/graduate/spec.unit.test.ts
@@ -9,9 +9,29 @@ import {
 	renderDecision,
 	renderFooter,
 	SPEC_SECTIONS,
+	unplacedContent,
 	withFooter,
 } from "./spec.ts";
 import type {DecisionRow} from "./trail.ts";
+
+describe("content the composed spec would not carry", () => {
+	it("finds nothing in a body holding exactly the three sections", () => {
+		expect(unplacedContent(AUTHORED, AUTHORED_SECTIONS)).toBeNull();
+	});
+
+	it("names a fourth section rather than letting compose drop it", () => {
+		expect(unplacedContent(`${AUTHORED}\n## Risks\nr\n`, AUTHORED_SECTIONS)).toEqual({
+			_tag: "Heading",
+			heading: "## Risks",
+		});
+	});
+
+	it("names a preamble above the first heading", () => {
+		expect(unplacedContent(`intro prose\n\n${AUTHORED}`, AUTHORED_SECTIONS)).toEqual({
+			_tag: "Preamble",
+		});
+	});
+});
 
 describe("the authored section floor", () => {
 	it("passes the three sections in order", () => {

--- a/packages/fabrika-cli/src/graduate/spec.unit.test.ts
+++ b/packages/fabrika-cli/src/graduate/spec.unit.test.ts
@@ -1,0 +1,103 @@
+import {describe, expect, it} from "vitest";
+import {AUTHORED, CLEARED_DECISIONS} from "./fixtures.test-support.ts";
+import {
+	AUTHORED_SECTIONS,
+	carriesDecisionsHeading,
+	checkSections,
+	composeSpec,
+	readDecisionsSection,
+	renderDecision,
+	renderFooter,
+	SPEC_SECTIONS,
+	withFooter,
+} from "./spec.ts";
+import type {DecisionRow} from "./trail.ts";
+
+describe("the authored section floor", () => {
+	it("passes the three sections in order", () => {
+		expect(checkSections(AUTHORED, AUTHORED_SECTIONS)).toBeNull();
+	});
+
+	it("names a missing section", () => {
+		expect(checkSections("## Problem\nx\n\n## Solution\ny\n", AUTHORED_SECTIONS)).toEqual({
+			_tag: "Missing",
+			heading: "## Out of scope",
+		});
+	});
+
+	it("names an empty section", () => {
+		expect(
+			checkSections("## Problem\n\n## Solution\ny\n\n## Out of scope\nz\n", AUTHORED_SECTIONS),
+		).toEqual({_tag: "Empty", heading: "## Problem"});
+	});
+
+	it("names the pair that is out of order", () => {
+		expect(
+			checkSections("## Solution\ny\n\n## Problem\nx\n\n## Out of scope\nz\n", AUTHORED_SECTIONS),
+		).toEqual({_tag: "OutOfOrder", heading: "## Problem", after: "## Solution"});
+	});
+
+	it("sees a `## Decisions` heading on an authored body", () => {
+		expect(carriesDecisionsHeading(AUTHORED)).toBe(false);
+		expect(carriesDecisionsHeading(`${AUTHORED}\n## Decisions\n- mine\n`)).toBe(true);
+	});
+});
+
+describe("the rendered decisions section", () => {
+	it("renders the provenance in bold and the ref once, with no repeated source number", () => {
+		expect(renderDecision(CLEARED_DECISIONS[1] as DecisionRow)).toBe(
+			"- Do vouched-in yazars inherit their kefil's moderation weight? — **ruled** · R1.2",
+		);
+	});
+
+	it("splices between Solution and Out of scope, giving the four sections in order", () => {
+		const body = composeSpec(AUTHORED, CLEARED_DECISIONS);
+		expect(checkSections(body, SPEC_SECTIONS)).toBeNull();
+		expect(body.indexOf("## Decisions")).toBeGreaterThan(body.indexOf("## Solution"));
+		expect(body.indexOf("## Decisions")).toBeLessThan(body.indexOf("## Out of scope"));
+	});
+
+	it("reads every rendered line back to the row it came from", () => {
+		const read = readDecisionsSection(composeSpec(AUTHORED, CLEARED_DECISIONS));
+		expect(read).toEqual({_tag: "Decisions", value: CLEARED_DECISIONS});
+	});
+
+	it("recovers a ref that carries a space and a `#`, and text carrying its own em dash", () => {
+		const row: DecisionRow = {
+			ref: "#9301 R1.2",
+			provenance: "ruled",
+			text: "Weight is earned — never inherited · from a kefil.",
+		};
+		const read = readDecisionsSection(composeSpec(AUTHORED, [row]));
+		expect(read).toEqual({_tag: "Decisions", value: [row]});
+	});
+
+	it("reports a hand-edited line rather than skipping it", () => {
+		const body = composeSpec(AUTHORED, CLEARED_DECISIONS).replace(
+			"- Do vouched",
+			"- I decided this myself. Do vouched",
+		);
+		expect(readDecisionsSection(body.replace("— **ruled** · R1.2", ""))).toMatchObject({
+			_tag: "Unparseable",
+		});
+	});
+});
+
+describe("the footer", () => {
+	it("leads with `Filed by an agent` and carries the source and the spec digest", () => {
+		expect(
+			renderFooter({source: 9412, specDigest: "a1b2c3d4e5f6", timestamp: "2026-08-09T18:36:48Z"}),
+		).toBe(
+			"<sub>Filed by an agent · graduated from #9412 · spec a1b2c3d4e5f6 · 2026-08-09T18:36:48Z</sub>",
+		);
+	});
+
+	it("sits after the sections and a blank line, newline-terminated", () => {
+		const composed = withFooter(
+			composeSpec(AUTHORED, CLEARED_DECISIONS),
+			renderFooter({source: 9412, specDigest: "a1b2c3d4e5f6", timestamp: "2026-08-09T18:36:48Z"}),
+		);
+		expect(composed.endsWith("</sub>\n")).toBe(true);
+		expect(composed).toContain("Weight decay on a clock — no decision yet.\n\n<sub>");
+	});
+});

--- a/packages/fabrika-cli/src/graduate/trail-verb.ts
+++ b/packages/fabrika-cli/src/graduate/trail-verb.ts
@@ -42,7 +42,7 @@ export const runTrail = (
 		}
 		const repo = repoAttempt.value;
 
-		const found = yield* requireSource(VERB, repo, source);
+		const found = yield* requireSource(VERB, repo, source, " — there is no trail to read.");
 		if (found._tag === "Refused") return found.outcome;
 
 		const resolved = yield* deriveTrail(VERB, repo, source, found.value.kind, options.env);

--- a/packages/fabrika-cli/src/graduate/trail-verb.ts
+++ b/packages/fabrika-cli/src/graduate/trail-verb.ts
@@ -1,0 +1,56 @@
+/**
+ * `graduate trail` — resolve one source through its sibling reader and normalize it into one
+ * provenance-tagged decision trail.
+ *
+ * **All three readiness tokens exit `0`.** A trail holding an unresolved decision is this skill
+ * working; seating it on a non-zero code would make a caller's `[ $? -ne 0 ]` read "the founder has
+ * not decided yet" as "the verb never ran".
+ *
+ * The verb writes nothing, so its `7` is a *named* target proven absent rather than a write target —
+ * the widening this group's `./codes.ts` states.
+ */
+
+import {Effect} from "effect";
+import type {ChildProcessSpawner} from "effect/unstable/process";
+import {resolveRepo} from "../io/issues.ts";
+import {answer, FAILED, refuse, type VerbOutcome} from "../verb.ts";
+import {deriveTrail, requireSource} from "./source.ts";
+
+export interface TrailOptions {
+	readonly source: number;
+	readonly repo: string | null;
+	readonly env: Readonly<Record<string, string | undefined>>;
+}
+
+const VERB = "graduate trail";
+
+export const runTrail = (
+	options: TrailOptions,
+): Effect.Effect<VerbOutcome, never, ChildProcessSpawner.ChildProcessSpawner> =>
+	Effect.gen(function* () {
+		const {source} = options;
+		if (!Number.isInteger(source) || source <= 0) {
+			return refuse(FAILED, `${VERB}: ${source} is not an issue number.`);
+		}
+
+		const repoAttempt = yield* resolveRepo(options.repo, options.env);
+		if (repoAttempt._tag === "Failure") {
+			return refuse(
+				FAILED,
+				`${VERB}: cannot resolve a target repo — pass --repo, or run inside a checkout whose origin remote resolves.`,
+			);
+		}
+		const repo = repoAttempt.value;
+
+		const found = yield* requireSource(VERB, repo, source);
+		if (found._tag === "Refused") return found.outcome;
+
+		const resolved = yield* deriveTrail(VERB, repo, source, found.value.kind, options.env);
+		if (resolved._tag === "Refused") return resolved.outcome;
+
+		const {trail, scope} = resolved.value;
+		return answer(JSON.stringify(trail), [
+			scope,
+			`${VERB}: readiness "${trail.readiness}" over ${trail.counts.ruled} ruled, ${trail.counts.established} established and ${trail.counts.unresolved} unresolved.`,
+		]);
+	});

--- a/packages/fabrika-cli/src/graduate/trail-verb.unit.test.ts
+++ b/packages/fabrika-cli/src/graduate/trail-verb.unit.test.ts
@@ -1,0 +1,224 @@
+import {Effect} from "effect";
+import {describe, expect, it} from "vitest";
+import {errOut, fakeShell, okOut} from "../fakes.test-support.ts";
+import type {ExecResult} from "../io/exec.ts";
+import {BAD_SECTIONS, NO_TARGET, PRECONDITION_UNKNOWN, SOURCE_UNRECOGNIZED} from "./codes.ts";
+import {
+	CLEARED_DECISIONS,
+	CLEARED_SESSION,
+	commentsPayload,
+	issueJson,
+	MAP,
+	MAP_BODY,
+	REPO,
+	ROUND,
+	SESSION,
+} from "./fixtures.test-support.ts";
+import {digestOfDecisions} from "./trail.ts";
+import {runTrail} from "./trail-verb.ts";
+
+const SESSION_ISSUE = /^gh api repos\/o\/r\/issues\/9412$/;
+const SESSION_COMMENTS = /^gh api --paginate repos\/o\/r\/issues\/9412\/comments\?/;
+const PERMISSION = /collaborators\/.*\/permission/;
+const MAP_ISSUE = /^gh api repos\/o\/r\/issues\/9140$/;
+const CHILDREN = /issues\/9140\/sub_issues/;
+const TICKET_ISSUE = /issues\/9142$/;
+const TICKET_COMMENTS = /issues\/9142\/comments/;
+const BLOCKED_BY = /issues\/9142\/dependencies\/blocked_by/;
+const BLOCKING = /issues\/9142\/dependencies\/blocking/;
+
+const run = (source: number, script: ReadonlyArray<readonly [RegExp, ExecResult]>) =>
+	Effect.runPromise(
+		Effect.provide(
+			runTrail({source, repo: null, env: {CLAUDE_PIPELINE_REPO: REPO}}),
+			fakeShell(script).layer,
+		),
+	);
+
+const session = (labels: ReadonlyArray<string> = ["grilling:session"]) =>
+	[SESSION_ISSUE, okOut(issueJson({number: SESSION, labels}))] as const;
+
+describe("a grilling source resolves through the grill reader", () => {
+	it("answers `ready` at exit 0 with both provenance words and the trail digest", async () => {
+		const out = await run(SESSION, [
+			session(),
+			[SESSION_COMMENTS, okOut(commentsPayload([...CLEARED_SESSION]))],
+			[PERMISSION, okOut("write")],
+		]);
+		expect(out.code).toBe(0);
+		const answer = JSON.parse(out.stdout);
+		expect(answer).toMatchObject({
+			source: SESSION,
+			kind: "grilling",
+			readiness: "ready",
+			outOfScope: [],
+			counts: {ruled: 1, established: 1, unresolved: 0},
+		});
+		expect(answer.decisions).toEqual(CLEARED_DECISIONS);
+		expect(answer.trailDigest).toBe(digestOfDecisions(CLEARED_DECISIONS));
+	});
+
+	it("answers `blocked` at exit 0, carrying the resolver's own state word", async () => {
+		const out = await run(SESSION, [
+			session(),
+			[SESSION_COMMENTS, okOut(commentsPayload([ROUND]))],
+			[PERMISSION, okOut("write")],
+		]);
+		expect(out.code).toBe(0);
+		const answer = JSON.parse(out.stdout);
+		expect(answer.readiness).toBe("blocked");
+		expect(answer.unresolved).toEqual([
+			{ref: "R1.1", state: "open"},
+			{ref: "R1.2", state: "open"},
+		]);
+	});
+
+	it("answers `empty` at exit 0 on a session with nothing on it — zero decisions is a fact", async () => {
+		const out = await run(SESSION, [session(), [SESSION_COMMENTS, okOut("[]")]]);
+		expect(out.code).toBe(0);
+		expect(JSON.parse(out.stdout)).toMatchObject({readiness: "empty", decisions: [], counts: {}});
+	});
+});
+
+describe("the digest is neutral to every write this group makes", () => {
+	it("recomputes byte-identically after an emission marker has landed on the source", async () => {
+		const before = JSON.parse(
+			(
+				await run(SESSION, [
+					session(),
+					[SESSION_COMMENTS, okOut(commentsPayload([...CLEARED_SESSION]))],
+					[PERMISSION, okOut("write")],
+				])
+			).stdout,
+		);
+		const after = JSON.parse(
+			(
+				await run(SESSION, [
+					session(),
+					[
+						SESSION_COMMENTS,
+						okOut(
+							commentsPayload([
+								...CLEARED_SESSION,
+								{
+									id: 9,
+									author: "acme-founder",
+									body: `graduate-emitted: #9412 → #9520 @ ${digestOfDecisions(CLEARED_DECISIONS)} · covers R1.1;R1.2 · 2026-08-09T18:36:48Z\n`,
+								},
+							]),
+						),
+					],
+					[PERMISSION, okOut("write")],
+				])
+			).stdout,
+		);
+		expect(after.trailDigest).toBe(before.trailDigest);
+		expect(after.decisions).toEqual(before.decisions);
+	});
+});
+
+describe("a map source resolves through the map module, not through `map read`'s stdout", () => {
+	const mapHealthy = [
+		[MAP_ISSUE, okOut(issueJson({number: MAP, body: MAP_BODY, labels: ["wayfinding:map"]}))],
+		[CHILDREN, okOut('[{"number":9142}]')],
+		[TICKET_ISSUE, okOut(issueJson({number: 9142, body: "which table carries it?"}))],
+		[
+			TICKET_COMMENTS,
+			okOut(
+				'[{"id":1,"body":"map-ticket: #9140 · research · 7f3a9c21","user":{"login":"acme-founder"},"created_at":"2026-08-10T00:00:00Z","updated_at":"2026-08-10T00:00:00Z"}]',
+			),
+		],
+		[BLOCKED_BY, okOut("[]")],
+		[BLOCKING, okOut("[]")],
+		[PERMISSION, okOut("write")],
+	] as const;
+
+	it("takes its decisions from the body's `## Decisions` section, with the citations as refs", async () => {
+		const out = await run(MAP, [...mapHealthy]);
+		expect(out.code).toBe(0);
+		const answer = JSON.parse(out.stdout);
+		expect(answer.kind).toBe("map");
+		expect(answer.decisions).toEqual([
+			{
+				ref: "#9301 R1.2",
+				provenance: "ruled",
+				text: "Weight is earned per account, never inherited from a kefil.",
+			},
+			{
+				ref: "#9505",
+				provenance: "established",
+				text: "The vote table has no per-account weight column today.",
+			},
+		]);
+	});
+
+	it("reads an open ticket as unresolved, so the trail is blocked", async () => {
+		const answer = JSON.parse((await run(MAP, [...mapHealthy])).stdout);
+		expect(answer.readiness).toBe("blocked");
+		expect(answer.unresolved).toEqual([{ref: "#9142", state: "open"}]);
+	});
+
+	it("carries the map's out-of-scope entries through", async () => {
+		const answer = JSON.parse((await run(MAP, [...mapHealthy])).stdout);
+		expect(answer.outOfScope).toEqual([
+			{
+				direction: "a per-topic weight multiplier",
+				reason: "It makes every action's authority unreadable",
+				recordedAt: "2026-06-29",
+			},
+		]);
+	});
+
+	it("refuses a body that does not parse as PROVEN malformed, never unknown", async () => {
+		const out = await run(MAP, [
+			[
+				MAP_ISSUE,
+				okOut(issueJson({number: MAP, body: "## Fog\nnothing", labels: ["wayfinding:map"]})),
+			],
+		]);
+		expect(out.code).toBe(BAD_SECTIONS);
+		expect(out.stdout).toBe("");
+	});
+});
+
+describe("the dispatch refuses rather than guesses", () => {
+	it("refuses an issue carrying neither label", async () => {
+		const out = await run(SESSION, [session([])]);
+		expect(out.code).toBe(SOURCE_UNRECOGNIZED);
+		expect(out.stderr.join("\n")).toContain("neither grilling:session nor wayfinding:map");
+	});
+
+	it("refuses an issue carrying BOTH labels, naming both", async () => {
+		const out = await run(SESSION, [session(["grilling:session", "wayfinding:map"])]);
+		expect(out.code).toBe(SOURCE_UNRECOGNIZED);
+		expect(out.stderr.join("\n")).toContain("refusing to guess which trail is live");
+	});
+
+	it("refuses a source that does not exist", async () => {
+		const out = await run(SESSION, [[SESSION_ISSUE, errOut("gh: Not Found (HTTP 404)")]]);
+		expect(out.code).toBe(NO_TARGET);
+		expect(out.stdout).toBe("");
+	});
+});
+
+describe("a read that could not complete is UNKNOWN, never an empty trail", () => {
+	it("seats a failed comment read on 11 with nothing on stdout", async () => {
+		const out = await run(SESSION, [
+			session(),
+			[SESSION_COMMENTS, errOut("gh: Bad gateway (HTTP 502)")],
+		]);
+		expect(out.code).toBe(PRECONDITION_UNKNOWN);
+		expect(out.stdout).toBe("");
+		expect(out.stderr.join("\n")).toContain("never empty and never ready");
+	});
+
+	it("seats a failed ACL read on 11, saying a ruling's authority is never granted by it", async () => {
+		const out = await run(SESSION, [
+			session(),
+			[SESSION_COMMENTS, okOut(commentsPayload([...CLEARED_SESSION]))],
+			[PERMISSION, errOut("gh: Bad gateway (HTTP 502)")],
+		]);
+		expect(out.code).toBe(PRECONDITION_UNKNOWN);
+		expect(out.stderr.join("\n")).toContain("UNKNOWN, never granted");
+	});
+});

--- a/packages/fabrika-cli/src/graduate/trail.ts
+++ b/packages/fabrika-cli/src/graduate/trail.ts
@@ -1,0 +1,280 @@
+/**
+ * The decision trail: what a resolved source normalizes into, and the digest taken over it.
+ *
+ * Both sibling artifacts — a `grilling` session and a `wayfinding` map — reduce to one shape here:
+ * a decision carries a `ref`, a `provenance` word from a closed two-member set, and its `text`. The
+ * mapping functions below take the **sibling resolver's own output** as their input; nothing in this
+ * module parses a session comment or a map body, because whether a question is `ruled` is already
+ * answered by a verb whose whole design is answering it fail-closed against the ACL. A second parser
+ * here would be a second answer to that question, and the two could disagree — which on this question
+ * means one of them licenses synthesizing over an unproven ruling.
+ *
+ * <!-- anchor: DIGEST-NEUTRALITY --> **Both digests are neutral to every write this group makes.**
+ * The digested bytes are decision triples exactly as the resolver returned them — never a comment, a
+ * marker, a label or any rendered issue text. It must be so: `graduate emit` binds its marker to a
+ * digest the *next* run recomputes, so a digest covering the source's comments would be changed by
+ * the marker comment that emission itself posts, and every re-run would read the trail as fresh and
+ * file a second spec.
+ */
+
+import {createHash} from "node:crypto";
+import type {DecisionEntry, OutOfScopeEntry} from "../map/body.ts";
+import type {Ticket} from "../map/frontier.ts";
+
+/** The two words a decision's authority may carry. There is deliberately no word for *inferred*. */
+export type Provenance = "ruled" | "established";
+
+/** One resolved decision, in trail order. These three fields are exactly what the digest covers. */
+export interface DecisionRow {
+	readonly ref: string;
+	readonly provenance: Provenance;
+	readonly text: string;
+}
+
+/** One decision still open, carrying the resolver's own state word verbatim. */
+export interface UnresolvedRow {
+	readonly ref: string;
+	readonly state: string;
+}
+
+/** The three readiness answers. All three are answers, and all three exit `0`. */
+export type Readiness = "ready" | "blocked" | "empty";
+
+/** Which sibling the trail was resolved through. */
+export type SourceKind = "grilling" | "map";
+
+export interface Trail {
+	readonly source: number;
+	readonly kind: SourceKind;
+	readonly readiness: Readiness;
+	readonly trailDigest: string;
+	readonly decisions: ReadonlyArray<DecisionRow>;
+	readonly unresolved: ReadonlyArray<UnresolvedRow>;
+	readonly outOfScope: ReadonlyArray<OutOfScopeEntry>;
+	readonly counts: {
+		readonly ruled: number;
+		readonly established: number;
+		readonly unresolved: number;
+	};
+}
+
+/**
+ * The digest of a set of decision entries: the first 12 hex characters of the SHA-256 of each
+ * entry's `ref`, `provenance` and `text` in trail order, joined by `\n`, LF-normalized, with
+ * trailing whitespace stripped per line.
+ *
+ * One algorithm, two scopes: over every decision on the trail it is the **trail digest**, and over
+ * only the decisions rendered into a filed spec it is the **spec digest**. When a spec carries the
+ * whole trail the two are equal by construction.
+ */
+export const digestOfDecisions = (rows: ReadonlyArray<DecisionRow>): string =>
+	createHash("sha256")
+		.update(
+			rows
+				.flatMap((row) => [row.ref, row.provenance, row.text])
+				.join("\n")
+				.replace(/\r\n/g, "\n")
+				.split("\n")
+				.map((line) => line.replace(/[ \t]+$/, ""))
+				.join("\n"),
+		)
+		.digest("hex")
+		.slice(0, 12);
+
+/**
+ * <!-- anchor: READINESS-IS-NOT-THE-FRONTIER-TOKEN --> Readiness, computed in this order.
+ *
+ * It is **not** a relay of the sibling's `frontier` token. A map whose every ticket was *retired*
+ * reads `clear` there and carries nothing to synthesize, which is `empty` here; and a session's
+ * `facts-pending` and a map's `lanes-pending` both collapse to `blocked`, because this verb does not
+ * care who owes the answer, only whether one is outstanding.
+ */
+export const readinessOf = (
+	decisions: ReadonlyArray<DecisionRow>,
+	unresolved: ReadonlyArray<UnresolvedRow>,
+): Readiness => {
+	if (unresolved.length > 0) return "blocked";
+	return decisions.length === 0 ? "empty" : "ready";
+};
+
+export const trailOf = (input: {
+	readonly source: number;
+	readonly kind: SourceKind;
+	readonly decisions: ReadonlyArray<DecisionRow>;
+	readonly unresolved: ReadonlyArray<UnresolvedRow>;
+	readonly outOfScope: ReadonlyArray<OutOfScopeEntry>;
+}): Trail => ({
+	source: input.source,
+	kind: input.kind,
+	readiness: readinessOf(input.decisions, input.unresolved),
+	trailDigest: digestOfDecisions(input.decisions),
+	decisions: input.decisions,
+	unresolved: input.unresolved,
+	outOfScope: input.outOfScope,
+	counts: {
+		ruled: input.decisions.filter((row) => row.provenance === "ruled").length,
+		established: input.decisions.filter((row) => row.provenance === "established").length,
+		unresolved: input.unresolved.length,
+	},
+});
+
+/** One question row as the `grill read` resolver reports it — the only shape read here. */
+export interface ResolvedQuestion {
+	readonly id: string;
+	readonly text: string;
+	readonly state: string;
+}
+
+export interface Normalized {
+	readonly decisions: ReadonlyArray<DecisionRow>;
+	readonly unresolved: ReadonlyArray<UnresolvedRow>;
+}
+
+/**
+ * A session's resolved questions, normalized.
+ *
+ * `superseded` is omitted entirely rather than counted either way — a retired question is neither a
+ * decision nor an open one.
+ */
+export const fromSession = (questions: ReadonlyArray<ResolvedQuestion>): Normalized => {
+	const decisions: DecisionRow[] = [];
+	const unresolved: UnresolvedRow[] = [];
+	for (const question of questions) {
+		if (question.state === "ruled") {
+			decisions.push({ref: question.id, provenance: "ruled", text: question.text});
+			continue;
+		}
+		if (question.state === "answered") {
+			decisions.push({ref: question.id, provenance: "established", text: question.text});
+			continue;
+		}
+		if (question.state === "superseded") continue;
+		unresolved.push({ref: question.id, state: question.state});
+	}
+	return {decisions, unresolved};
+};
+
+/**
+ * A map's decisions and tickets, normalized — two different parts of the artifact.
+ *
+ * <!-- anchor: MAP-DECISIONS-COME-FROM-THE-BODY --> The decisions come from the body's
+ * `## Decisions` section and never from the ticket states, which is why this takes the parsed body's
+ * entries rather than `map read`'s stdout: that answer carries `tickets`, `outOfScope` and the
+ * frontier token but **no** decisions array, so a design reading them off it could not produce a
+ * `ruled` row at all and every founder ruling relayed onto a map would render as an agent's finding.
+ *
+ * A `graduated` ticket is omitted because its answer is already a `## Decisions` entry, and counting
+ * both would double it; a `retired` one is omitted because its record is the out-of-scope section.
+ */
+export const fromMap = (
+	entries: ReadonlyArray<DecisionEntry>,
+	tickets: ReadonlyArray<Ticket>,
+): Normalized => ({
+	decisions: entries.map((entry) =>
+		entry.authority._tag === "Ruled"
+			? {
+					ref: `#${entry.authority.session} ${entry.authority.questionId}`,
+					provenance: "ruled" as const,
+					text: entry.text,
+				}
+			: {
+					ref: `#${entry.authority.ticket}`,
+					provenance: "established" as const,
+					text: entry.text,
+				},
+	),
+	unresolved: tickets
+		.filter((ticket) => ticket.state !== "graduated" && ticket.state !== "retired")
+		.map((ticket) => ({ref: `#${ticket.number}`, state: ticket.state})),
+});
+
+const HEX_12 = /^[0-9a-f]{12}$/;
+
+/** A `--trail` file read back into a trail, or the reason those bytes are not one. */
+export type TrailDocument =
+	| {readonly _tag: "Trail"; readonly value: Trail}
+	| {readonly _tag: "Unreadable"; readonly reason: string}
+	/** A field the digest is taken over is missing — the binding is unbindable, not malformed. */
+	| {readonly _tag: "Unbindable"; readonly reason: string};
+
+const isRecord = (value: unknown): value is Record<string, unknown> =>
+	typeof value === "object" && value !== null && !Array.isArray(value);
+
+/**
+ * Read a `graduate trail` answer back off disk, totally.
+ *
+ * The `Unbindable` answer is separate from `Unreadable` because they seat different codes: a file
+ * that will not parse is a precondition that could not be read, and a decision missing one of the
+ * three digested fields is a proven fact about a trail that *did* parse.
+ */
+export const parseTrailDocument = (text: string): TrailDocument => {
+	let parsed: unknown;
+	try {
+		parsed = JSON.parse(text);
+	} catch (error) {
+		return {_tag: "Unreadable", reason: `it is not JSON (${(error as Error).message})`};
+	}
+	if (!isRecord(parsed)) return {_tag: "Unreadable", reason: "it is not a JSON object"};
+
+	const rows = parsed.decisions;
+	if (!Array.isArray(rows)) {
+		return {_tag: "Unreadable", reason: "it carries no `decisions` array"};
+	}
+	const decisions: DecisionRow[] = [];
+	for (const row of rows) {
+		if (!isRecord(row)) return {_tag: "Unreadable", reason: "a `decisions` entry is not an object"};
+		for (const field of ["ref", "provenance", "text"] as const) {
+			if (typeof row[field] !== "string" || (row[field] as string).trim() === "") {
+				return {_tag: "Unbindable", reason: field};
+			}
+		}
+		const provenance = row.provenance as string;
+		if (provenance !== "ruled" && provenance !== "established") {
+			return {_tag: "Unbindable", reason: "provenance"};
+		}
+		decisions.push({ref: row.ref as string, provenance, text: row.text as string});
+	}
+
+	const digest = parsed.trailDigest;
+	if (typeof digest !== "string" || !HEX_12.test(digest)) {
+		return {_tag: "Unbindable", reason: "trailDigest"};
+	}
+
+	const unresolvedRows = Array.isArray(parsed.unresolved) ? parsed.unresolved : [];
+	const unresolved = unresolvedRows.flatMap((row): UnresolvedRow[] =>
+		isRecord(row) && typeof row.ref === "string" && typeof row.state === "string"
+			? [{ref: row.ref, state: row.state}]
+			: [],
+	);
+	const outOfScopeRows = Array.isArray(parsed.outOfScope) ? parsed.outOfScope : [];
+	const outOfScope = outOfScopeRows.flatMap((row): OutOfScopeEntry[] =>
+		isRecord(row) &&
+		typeof row.direction === "string" &&
+		typeof row.reason === "string" &&
+		typeof row.recordedAt === "string"
+			? [{direction: row.direction, reason: row.reason, recordedAt: row.recordedAt}]
+			: [],
+	);
+
+	const readiness = parsed.readiness;
+	return {
+		_tag: "Trail",
+		value: {
+			source: typeof parsed.source === "number" ? parsed.source : 0,
+			kind: parsed.kind === "map" ? "map" : "grilling",
+			readiness:
+				readiness === "blocked" || readiness === "empty" || readiness === "ready"
+					? readiness
+					: readinessOf(decisions, unresolved),
+			trailDigest: digest,
+			decisions,
+			unresolved,
+			outOfScope,
+			counts: {
+				ruled: decisions.filter((row) => row.provenance === "ruled").length,
+				established: decisions.filter((row) => row.provenance === "established").length,
+				unresolved: unresolved.length,
+			},
+		},
+	};
+};

--- a/packages/fabrika-cli/src/graduate/trail.unit.test.ts
+++ b/packages/fabrika-cli/src/graduate/trail.unit.test.ts
@@ -1,0 +1,168 @@
+import {describe, expect, it} from "vitest";
+import type {Ticket} from "../map/frontier.ts";
+import {
+	type DecisionRow,
+	digestOfDecisions,
+	fromMap,
+	fromSession,
+	parseTrailDocument,
+	readinessOf,
+	trailOf,
+} from "./trail.ts";
+
+const DECISIONS: ReadonlyArray<DecisionRow> = [
+	{ref: "R2.3", provenance: "ruled", text: "Weight is earned per account."},
+	{ref: "R2.1", provenance: "established", text: "The vote table carries no weight column."},
+];
+
+describe("the digest", () => {
+	it("is 12 lowercase hex over the three digested fields in trail order", () => {
+		expect(digestOfDecisions(DECISIONS)).toMatch(/^[0-9a-f]{12}$/);
+	});
+
+	it("changes when a decision's provenance changes — a ruling is not a finding", () => {
+		const flipped = DECISIONS.map((row) => ({...row, provenance: "established" as const}));
+		expect(digestOfDecisions(flipped)).not.toBe(digestOfDecisions(DECISIONS));
+	});
+
+	it("changes when the entries are re-ordered — the digest covers trail order", () => {
+		expect(digestOfDecisions([...DECISIONS].reverse())).not.toBe(digestOfDecisions(DECISIONS));
+	});
+
+	it("is neutral to trailing whitespace, so a round trip through GitHub cannot move it", () => {
+		const padded = DECISIONS.map((row) => ({...row, text: `${row.text}   `}));
+		expect(digestOfDecisions(padded)).toBe(digestOfDecisions(DECISIONS));
+	});
+
+	it("is taken over the entries alone — the spec digest of a subset differs from the trail's", () => {
+		const subset = DECISIONS.slice(0, 1);
+		expect(digestOfDecisions(subset)).not.toBe(digestOfDecisions(DECISIONS));
+	});
+});
+
+describe("readiness", () => {
+	it("is blocked whenever anything is unresolved, however much is decided", () => {
+		expect(readinessOf(DECISIONS, [{ref: "R2.2", state: "open"}])).toBe("blocked");
+	});
+
+	it("is empty when nothing is unresolved and nothing is decided", () => {
+		expect(readinessOf([], [])).toBe("empty");
+	});
+
+	it("is ready only with decisions and no open question", () => {
+		expect(readinessOf(DECISIONS, [])).toBe("ready");
+	});
+});
+
+describe("a session's questions, normalized", () => {
+	const normalized = fromSession([
+		{id: "R1.1", text: "does the column exist?", state: "answered"},
+		{id: "R1.2", text: "is weight inherited?", state: "ruled"},
+		{id: "R1.3", text: "what about decay?", state: "open"},
+		{id: "R1.4", text: "unattested one", state: "unattested"},
+		{id: "R1.5", text: "retired one", state: "superseded"},
+	]);
+
+	it("maps ruled to `ruled` and answered to `established`, in trail order", () => {
+		expect(normalized.decisions).toEqual([
+			{ref: "R1.1", provenance: "established", text: "does the column exist?"},
+			{ref: "R1.2", provenance: "ruled", text: "is weight inherited?"},
+		]);
+	});
+
+	it("carries the resolver's own state word on every unresolved row", () => {
+		expect(normalized.unresolved).toEqual([
+			{ref: "R1.3", state: "open"},
+			{ref: "R1.4", state: "unattested"},
+		]);
+	});
+
+	it("omits a superseded question entirely — it is neither a decision nor an open one", () => {
+		const refs = [...normalized.decisions, ...normalized.unresolved].map((row) => row.ref);
+		expect(refs).not.toContain("R1.5");
+	});
+});
+
+describe("a map's body and tickets, normalized", () => {
+	const ticket = (number: number, state: Ticket["state"]): Ticket => ({
+		number,
+		kind: "research",
+		question: `question ${number}`,
+		state,
+		blockedBy: [],
+		blocking: [],
+	});
+
+	const normalized = fromMap(
+		[
+			{
+				text: "Weight is earned per account.",
+				authority: {_tag: "Ruled", session: 9301, questionId: "R1.2"},
+			},
+			{text: "The vote table has no weight column.", authority: {_tag: "Finding", ticket: 9505}},
+		],
+		[ticket(9142, "open"), ticket(9505, "graduated"), ticket(9506, "retired")],
+	);
+
+	it("takes decisions from the `## Decisions` section, not from ticket states", () => {
+		expect(normalized.decisions).toEqual([
+			{ref: "#9301 R1.2", provenance: "ruled", text: "Weight is earned per account."},
+			{ref: "#9505", provenance: "established", text: "The vote table has no weight column."},
+		]);
+	});
+
+	it("leaves a graduated and a retired ticket off the unresolved list, and keeps the open one", () => {
+		expect(normalized.unresolved).toEqual([{ref: "#9142", state: "open"}]);
+	});
+});
+
+describe("trailOf", () => {
+	it("counts by provenance and seats the digest over every decision", () => {
+		const trail = trailOf({
+			source: 9412,
+			kind: "grilling",
+			decisions: DECISIONS,
+			unresolved: [],
+			outOfScope: [],
+		});
+		expect(trail.counts).toEqual({ruled: 1, established: 1, unresolved: 0});
+		expect(trail.trailDigest).toBe(digestOfDecisions(DECISIONS));
+		expect(trail.readiness).toBe("ready");
+	});
+});
+
+describe("reading a --trail document back", () => {
+	const document = JSON.stringify(
+		trailOf({source: 9412, kind: "grilling", decisions: DECISIONS, unresolved: [], outOfScope: []}),
+	);
+
+	it("round-trips what `graduate trail` printed", () => {
+		const read = parseTrailDocument(document);
+		expect(read._tag).toBe("Trail");
+		if (read._tag !== "Trail") return;
+		expect(read.value.decisions).toEqual(DECISIONS);
+		expect(read.value.trailDigest).toBe(digestOfDecisions(DECISIONS));
+	});
+
+	it("reports bytes that are not a trail as unreadable, never as an empty trail", () => {
+		expect(parseTrailDocument("not json at all")._tag).toBe("Unreadable");
+		expect(parseTrailDocument("{}")._tag).toBe("Unreadable");
+	});
+
+	it("reports a decision missing a digested field as unbindable, naming the field", () => {
+		const read = parseTrailDocument(
+			JSON.stringify({
+				trailDigest: "a1b2c3d4e5f6",
+				decisions: [{ref: "R1.1", provenance: "ruled"}],
+			}),
+		);
+		expect(read).toMatchObject({_tag: "Unbindable", reason: "text"});
+	});
+
+	it("reports a digest that is not 12 hex as unbindable", () => {
+		const read = parseTrailDocument(
+			JSON.stringify({trailDigest: "NOTHEX", decisions: [...DECISIONS]}),
+		);
+		expect(read).toMatchObject({_tag: "Unbindable", reason: "trailDigest"});
+	});
+});

--- a/packages/fabrika-cli/src/registry.ts
+++ b/packages/fabrika-cli/src/registry.ts
@@ -20,6 +20,7 @@ import {buildCommand} from "./build/command.ts";
 import {epicCommand} from "./epic/command.ts";
 import {glossaryCommand} from "./glossary/command.ts";
 import {governanceCommand} from "./governance/command.ts";
+import {graduateCommand} from "./graduate/command.ts";
 import {grillCommand} from "./grill/command.ts";
 import {handoffCommand} from "./handoff/command.ts";
 import {healCiCommand} from "./heal-ci/command.ts";
@@ -49,6 +50,7 @@ export const registeredGroups: ReadonlyArray<VerbGroup> = [
 	epicCommand,
 	glossaryCommand,
 	governanceCommand,
+	graduateCommand,
 	grillCommand,
 	handoffCommand,
 	healCiCommand,

--- a/packages/fabrika-cli/src/wire/graduate-emitted.ts
+++ b/packages/fabrika-cli/src/wire/graduate-emitted.ts
@@ -11,8 +11,9 @@
  * trail can graduate its remainder later at a different digest instead of being refused forever by
  * the repeat guard. And `covers` is what lets a reader answer a coverage question without re-deriving
  * anything: a digest alone is opaque, so a caller holding one could not tell a remainder from a
- * duplicate. Its separator is `;` rather than `,` because a map-sourced ref contains a space
- * (`#9301 R1.2`), which makes a comma-separated list of them ambiguous.
+ * duplicate. Its separator is `;` rather than `,` for readability — a map-sourced ref already carries
+ * a space (`#9301 R1.2`), and `R1.1, #9301 R1.2` reads as one run-on list where `;` keeps the refs
+ * visually apart. A comma would parse the same; this is a legibility choice, not a hazard.
  *
  * It is a new format rather than a widening of `./verdict-marker.ts`: that reader is guarded by a
  * separate namespace-prefix gate that returns `Absent` for a non-member, so a widening missing either

--- a/packages/fabrika-cli/src/wire/graduate-emitted.ts
+++ b/packages/fabrika-cli/src/wire/graduate-emitted.ts
@@ -1,0 +1,229 @@
+/**
+ * The `graduate-emitted` marker — the first line of the comment `graduate emit` posts on the source
+ * a spec was graduated from.
+ *
+ *     graduate-emitted: #9412 → #9520 @ a1b2c3d4e5f6 · covers R1.2;R1.4 · 2026-08-09T18:36:48Z
+ *
+ * It records that a decision trail left ideation as one spec issue: which source it was read from,
+ * which issue was filed, the **spec** digest that filing bound, and the refs that spec covered.
+ *
+ * Two fields carry the design. The digest is the *spec*'s, not the trail's, so a deliberately split
+ * trail can graduate its remainder later at a different digest instead of being refused forever by
+ * the repeat guard. And `covers` is what lets a reader answer a coverage question without re-deriving
+ * anything: a digest alone is opaque, so a caller holding one could not tell a remainder from a
+ * duplicate. Its separator is `;` rather than `,` because a map-sourced ref contains a space
+ * (`#9301 R1.2`), which makes a comma-separated list of them ambiguous.
+ *
+ * It is a new format rather than a widening of `./verdict-marker.ts`: that reader is guarded by a
+ * separate namespace-prefix gate that returns `Absent` for a non-member, so a widening missing either
+ * constant would emit markers it can never read back. An emission is also not a verdict — it carries
+ * no `PASS`/`FAIL` polarity and binds a spec digest rather than a head SHA.
+ */
+
+import type {NonEmptyReadonlyArray, WireEmit, WireRead, WireReadLines} from "./format.ts";
+import {
+	absent,
+	firstNonBlankLine,
+	type MarkerTime,
+	malformed,
+	markerTime,
+	payloadOf,
+	reachesFor,
+} from "./grill-marker.ts";
+
+declare const SPEC_DIGEST: unique symbol;
+
+/** The spec digest a marker binds: exactly 12 lowercase hex characters. */
+export type SpecDigest = string & {readonly [SPEC_DIGEST]: true};
+
+const SPEC_DIGEST_RE = /^[0-9a-f]{12}$/;
+
+export const specDigest = (raw: string): SpecDigest | null => {
+	const value = raw.trim();
+	return SPEC_DIGEST_RE.test(value) ? (value as SpecDigest) : null;
+};
+
+export interface GraduateEmitted {
+	readonly source: number;
+	readonly emitted: number;
+	readonly digest: SpecDigest;
+	/** The refs the spec rendered, in trail order. Non-empty: a spec covering nothing is not one. */
+	readonly covers: NonEmptyReadonlyArray<string>;
+	readonly at: MarkerTime;
+}
+
+export type GraduateEmittedRead = WireRead<GraduateEmitted>;
+
+/** The key that names these bytes. Never widened — a second meaning would need a second format. */
+export const KEY = "graduate-emitted";
+
+/** The separator between refs. No ref shape the contract defines can contain it. */
+export const COVERS_SEPARATOR = ";";
+
+const MARKER = /^#(\d+)\s*→\s*#(\d+)\s*@\s*([^\s·]+)\s*·\s*covers\s+([^·]+?)\s*·\s*(\S+)\s*$/;
+
+const parseCovers = (raw: string): NonEmptyReadonlyArray<string> | null => {
+	const refs = raw
+		.split(COVERS_SEPARATOR)
+		.map((ref) => ref.trim())
+		.filter((ref) => ref !== "");
+	const [first, ...rest] = refs;
+	return first === undefined ? null : [first, ...rest];
+};
+
+export const read = (artifact: string): GraduateEmittedRead => {
+	if (!reachesFor(artifact, KEY)) {
+		return absent(`the first line does not open with "${KEY}:" — no marker of this format`);
+	}
+	const line = firstNonBlankLine(artifact) ?? "";
+	const evidence = `first line: "${line}"`;
+	const matched = MARKER.exec(payloadOf(line, KEY));
+	if (matched === null) {
+		return malformed(
+			`the marker is not "${KEY}: #<source> → #<emitted> @ <digest> · covers <refs> · <at>" — a field is missing or a separator drifted`,
+			evidence,
+		);
+	}
+	const digest = specDigest(matched[3] ?? "");
+	if (digest === null) {
+		return malformed(
+			`"${matched[3]}" is not a spec digest — expected 12 lowercase hex characters`,
+			evidence,
+		);
+	}
+	const covers = parseCovers(matched[4] ?? "");
+	if (covers === null) {
+		return malformed(
+			"the marker covers no ref — an emission specifying nothing is not one",
+			evidence,
+		);
+	}
+	const at = markerTime(matched[5] ?? "");
+	if (at === null) {
+		return malformed(
+			`"${matched[5]}" is not an ISO-8601 UTC timestamp — expected a Z-suffixed instant`,
+			evidence,
+		);
+	}
+	return {
+		_tag: "Found",
+		value: {
+			source: Number.parseInt(matched[1] ?? "0", 10),
+			emitted: Number.parseInt(matched[2] ?? "0", 10),
+			digest,
+			covers,
+			at,
+		},
+	};
+};
+
+/** Compose the marker's one line. Round-trips through {@link read}. */
+export const emit = (marker: GraduateEmitted): string =>
+	`${KEY}: #${marker.source} → #${marker.emitted} @ ${marker.digest} · covers ${marker.covers.join(COVERS_SEPARATOR)} · ${marker.at}\n`;
+
+/** One `<field>\t<value>` line per field — the `wire read` answer for this format. */
+export const renderMarker = (marker: GraduateEmitted): NonEmptyReadonlyArray<string> => [
+	`source\t${marker.source}`,
+	`emitted\t${marker.emitted}`,
+	`digest\t${marker.digest}`,
+	`covers\t${marker.covers.join(COVERS_SEPARATOR)}`,
+	`at\t${marker.at}`,
+];
+
+export type GraduateEmittedFields =
+	| {readonly _tag: "Fields"; readonly marker: GraduateEmitted}
+	| {readonly _tag: "Unusable"; readonly reason: string};
+
+const FIELD_LINE = /^([A-Za-z-]+)[ \t]*[:\t][ \t]*(.*)$/;
+const KEYS = ["source", "emitted", "digest", "covers", "at"] as const;
+type FieldKey = (typeof KEYS)[number];
+
+const isFieldKey = (key: string): key is FieldKey => (KEYS as ReadonlyArray<string>).includes(key);
+
+/**
+ * Parse `wire emit`'s stdin into a marker: one `<key>: <value>` per line, in any order.
+ *
+ * Every rejection is a refusal rather than a default. A missing `covers` that silently composed an
+ * empty list would emit a marker asserting an emission specified nothing, and the bytes would look
+ * perfectly well-formed.
+ */
+export const parseFields = (fields: string): GraduateEmittedFields => {
+	const seen = new Map<FieldKey, string>();
+	for (const [index, raw] of fields.split("\n").entries()) {
+		const line = raw.trim();
+		if (line === "") continue;
+		const matched = FIELD_LINE.exec(line);
+		const key = matched?.[1]?.toLowerCase() ?? "";
+		if (matched === null || !isFieldKey(key)) {
+			return {
+				_tag: "Unusable",
+				reason: `line ${index + 1} is not a "<field>: <value>" line over ${KEYS.join(", ")}: "${line}"`,
+			};
+		}
+		if (seen.has(key)) {
+			return {
+				_tag: "Unusable",
+				reason: `"${key}" is given twice — which one is the field is undecidable`,
+			};
+		}
+		seen.set(key, matched[2] ?? "");
+	}
+
+	const missing = KEYS.filter((key) => (seen.get(key) ?? "").trim() === "");
+	if (missing.length > 0) {
+		return {
+			_tag: "Unusable",
+			reason: `no value for ${missing.join(", ")} — every field is required`,
+		};
+	}
+	const source = (seen.get("source") ?? "").trim().replace(/^#/, "");
+	if (!/^\d+$/.test(source)) {
+		return {_tag: "Unusable", reason: `"${seen.get("source")}" is not an issue number`};
+	}
+	const emitted = (seen.get("emitted") ?? "").trim().replace(/^#/, "");
+	if (!/^\d+$/.test(emitted)) {
+		return {_tag: "Unusable", reason: `"${seen.get("emitted")}" is not an issue number`};
+	}
+	const digest = specDigest(seen.get("digest") ?? "");
+	if (digest === null) {
+		return {
+			_tag: "Unusable",
+			reason: `"${seen.get("digest")}" is not a spec digest — expected 12 lowercase hex characters`,
+		};
+	}
+	const covers = parseCovers(seen.get("covers") ?? "");
+	if (covers === null) {
+		return {_tag: "Unusable", reason: "covers names no ref — an emission specifies at least one"};
+	}
+	const at = markerTime(seen.get("at") ?? "");
+	if (at === null) {
+		return {
+			_tag: "Unusable",
+			reason: `"${seen.get("at")}" is not an ISO-8601 UTC timestamp — expected a Z-suffixed instant`,
+		};
+	}
+	return {
+		_tag: "Fields",
+		marker: {
+			source: Number.parseInt(source, 10),
+			emitted: Number.parseInt(emitted, 10),
+			digest,
+			covers,
+			at,
+		},
+	};
+};
+
+/** The registry row's byte-level `emit`, bound to this module's typed core. */
+export const emitFromFields = (fields: string): WireEmit => {
+	const parsed = parseFields(fields);
+	return parsed._tag === "Fields"
+		? {_tag: "Composed", bytes: emit(parsed.marker)}
+		: {_tag: "Unusable", reason: parsed.reason};
+};
+
+/** The registry row's byte-level `read`, bound to this module's typed core. */
+export const readToLines = (artifact: string): WireReadLines => {
+	const result = read(artifact);
+	return result._tag === "Found" ? {_tag: "Found", value: renderMarker(result.value)} : result;
+};

--- a/packages/fabrika-cli/src/wire/registry.ts
+++ b/packages/fabrika-cli/src/wire/registry.ts
@@ -21,6 +21,7 @@
 import * as acceptanceCriteria from "./acceptance-criteria.ts";
 import {brandWitnesses, type WireFormat} from "./format.ts";
 import * as governanceDigest from "./governance-digest.ts";
+import * as graduateEmitted from "./graduate-emitted.ts";
 import * as grillAnswer from "./grill-answer.ts";
 import * as grillRuling from "./grill-ruling.ts";
 import * as grillSupersede from "./grill-supersede.ts";
@@ -400,6 +401,46 @@ export const registeredFormats: ReadonlyArray<WireFormat> = [
 			],
 		},
 		brands: brandWitnesses<governanceDigest.DigestRow>({id: true, kind: true, note: true}),
+	},
+	{
+		key: "graduate-emitted",
+		purpose:
+			"the record on a grilling session or wayfinding map that one spec issue was graduated out of it — the spec digest it bound and the decision refs that spec covered",
+		module: "packages/fabrika-cli/src/wire/graduate-emitted.ts",
+		producers: ["graduate"],
+		consumers: ["graduate"],
+		emit: graduateEmitted.emitFromFields,
+		read: graduateEmitted.readToLines,
+		fixtures: {
+			roundTrip: {
+				fields:
+					"source: 9412\nemitted: 9520\ndigest: a1b2c3d4e5f6\ncovers: R1.2;R1.4\nat: 2026-08-09T18:36:48Z\n",
+				values: ["9412", "9520", "a1b2c3d4e5f6", "R1.2;R1.4", "2026-08-09T18:36:48Z"],
+			},
+			absent: "Reading the trail back now — nothing here reaches for the marker.\n",
+			malformed: [
+				{
+					drift: "the digest is not 12 lowercase hex",
+					artifact:
+						"graduate-emitted: #9412 → #9520 @ A1B2C3D4E5F6 · covers R1.2 · 2026-08-09T18:36:48Z\n",
+				},
+				{
+					drift: "the marker names no covered ref, so a remainder is underivable",
+					artifact:
+						"graduate-emitted: #9412 → #9520 @ a1b2c3d4e5f6 · covers  · 2026-08-09T18:36:48Z\n",
+				},
+				{
+					drift: "the emitted issue is missing, so the marker claims an emission it cannot name",
+					artifact: "graduate-emitted: #9412 @ a1b2c3d4e5f6 · covers R1.2 · 2026-08-09T18:36:48Z\n",
+				},
+				{
+					drift: "the timestamp is not an ISO-8601 UTC instant",
+					artifact:
+						"graduate-emitted: #9412 → #9520 @ a1b2c3d4e5f6 · covers R1.2 · yesterday evening\n",
+				},
+			],
+		},
+		brands: brandWitnesses<graduateEmitted.GraduateEmitted>({digest: true, at: true}),
 	},
 ];
 


### PR DESCRIPTION
The `graduate` contract derived four verbs and none of them existed. This builds the group in
`packages/fabrika-cli/src/graduate/`, registers it everywhere the guards check, and adds the
`graduate-emitted` wire format the emission marker rides on.

**What the group does.** `graduate trail <source>` reads a grilling session or a wayfinding map
**through that sibling's own resolver** — `grill read`'s outcome for a session, the `map` body parser
plus `readFrontier` for a map — and normalizes both into one trail of `{ref, provenance, text}` rows,
a `readiness` token from `{ready, blocked, empty}` and a 12-hex digest. Nothing here parses either
artifact: whether a question is `ruled` keeps exactly one answer in the codebase.
`graduate compose` renders the four-section spec body and owns `## Decisions` entirely — a stdin body
carrying that heading is refused at `17`. `graduate emit` re-derives the trail from the source,
re-checks every ref the spec carries against it, computes the **spec** digest over the re-derived
entries, files exactly one issue at `status:needs-triage`, reads it back, and only then posts the
marker. `graduate read` is a total three-valued marker read: a malformed marker is a `disregarded`
row at exit `0`, never an absence.

**Registration**, all four edits: `registry.ts`; `GRADUATE_SEATS` + the `ALIGNED_GROUPS` row in
`exit-code-alignment.ts`; the import line **and** the `TABLES` row in
`exit-code-alignment.unit.test.ts`; and the wire format — schema module, `registeredFormats` row with
its fixtures and brand witnesses, a `### graduate-emitted` narrative section, and the generated
projection re-rendered with `fabrika wire index --write`.

**Verification.** The whole `fabrika-cli` suite is green in this tree (294 files, 4,469 tests), and
`build check --surface code` and `--surface prose` are both green.

Acceptance run against the real fixture, grilling session #5561 (seven rounds, `frontier: clear`):

```
$ fabrika graduate trail 5561
graduate trail: #5561 is a grilling session; the resolver read 32 comment(s) over 7 round(s) and reports frontier "clear".
graduate trail: readiness "ready" over 8 ruled, 7 established and 0 unresolved.
{"source":5561,"kind":"grilling","readiness":"ready","trailDigest":"b2dec1424833", …}
```

Fifteen rows, one superseded question omitted entirely — the awkward states, not a happy path.
`graduate emit` was deliberately not run: filing the real spec issue is a live write the founder
drives himself.

**Round 2 (repair).** Four things moved, all named in the round-1 verdicts: the grilling resolver's
stdout is now read through a guard that seats a shape miss at `11` instead of throwing; `graduate
compose` refuses a preamble or a fourth section at `4` instead of silently dropping it from the
filed spec; the two "carries neither label" refusals now emit the contract's own per-verb bytes; and
the `covers` separator note states the real reason. Six new tests cover the two new refusals and the
guard. The deviation bullets below were also rewritten into the four-field shape the disclosure
reader parses — round 1's prose carried the same substance in a shape that read as zero entries.

## Deviations

- **Known defect left unfixed** — **Said:** work #5267 from its acceptance criteria as `fabrika
  build issue` serves them. **Did:** read the ten criteria off the issue body text instead, and left
  the issue's heading level alone. **Why:** triage wrote the criteria block at heading level 2 where
  build and review expect level 3, so the verb returns `criteria: {state: "malformed"}` and no list —
  the known repo defect #5565, whose fix is not this PR's. **Disposition:** every criterion was still
  worked from the body text; #5565 tracks the heading.
- **Guard or gate bypassed** — **Said:** claim the issue through `fabrika build claim`, which
  enforces the declared campaign focus. **Did:** claimed with `build claim --override`, recording the
  reason and the lane on the marker. **Why:** #5267 is homed in milestone 45 while `## Focus` declares
  44, so the fence refused at exit `20` before writing any marker; the operator dispatched this issue
  by number for this run, and again for this repair round. **Disposition:** the override is on the
  claim marker with its reason; nothing else about the fence was touched.
- **Out-of-scope change** — **Said:** define group-local exit seats `12`–`17`. **Did:** defined
  `12`–`18`, one seat past that range. **Why:** the contract's own exit matrix defines `18
  DECISIONS_STALE` — a ref the spec carries has moved on the trail, or a `## Decisions` line does not
  parse — and `graduate emit`'s error table triggers it three ways, so the criterion's range is one
  seat short of the spec it points at. **Disposition:** the contract won; the seat is imported by
  name like the rest, and the alignment table carries it.
- **Scope narrowing** — **Said:** resolve a grilling session through that sibling's own resolver.
  **Did:** `graduate trail` calls `runRead` and reads its process outcome, rather than importing a
  pure resolver function. **Why:** the grilling group exposes its per-question state resolution only
  inside `runRead`, and the upstream resolvers are out of scope for this ticket. The map side does
  import the module directly, because a map's decisions live in the body's `## Decisions` section,
  which `map read`'s stdout does not carry. **Disposition:** nothing in `graduate/` parses a session
  comment or a map body; round 2 added a guard so a shape change in that stdout seats `11` rather
  than throwing.
- **Scope narrowing** — **Said:** distinguish "the comment read did not complete" from "a ruling's
  authority could not be resolved", both at `11`. **Did:** discriminated the two off the sibling's own
  refusal text. **Why:** only the resolver knows which it hit, and it reports the difference in prose
  rather than in a structured field. **Disposition:** a miss lands on the general `11` — the same
  code with a less specific reason, never a permissive answer.
- **Scope narrowing** — **Said:** each decision row carries the text of the decision. **Did:** carried
  the question's text as the resolver reports it. **Why:** `grill read` surfaces no separate
  "decided text" field. **Disposition:** that is what the trail carries and what the digest covers;
  disclosed rather than synthesized.
- **Declined guidance** — **Said:** review-code finding 5's third item — `graduate compose`'s leak
  refusal drifts from the contract's stated bytes, so one of the two surfaces should move. **Did:** kept the shipped message and filed the
  contract correction as #5569 instead. **Why:** the shipped form follows the repo's existing `report
  file` idiom and names every leak rather than the first, and the contract text is out of #5267's
  scope. The reviewer said the same — "I would keep the code and fix the contract". **Disposition:**
  #5569 also carries the `covers` separator note's third surface, the contract copy, for the same
  scope reason; the two surfaces inside this diff were corrected here.

Fixes #5267
