### PR TITLE
the focus fence puts the whole fabrika fast follows milestone out of reach of build pick

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -106,7 +106,7 @@ Campaigns are bounded, milestone-backed pushes that run *concurrently* with the 
 - **Columns** are `Campaign | Milestone | State`, in that order. `Campaign` is the founder-voice name; `Milestone` pins the campaign to its GitHub milestone **by number** (`#N`) — the same row→milestone-by-number binding the roadmap-guard already enforces on `## Arcs`, and that number is the one link to the operational projection. `State` is the lifecycle cell.
 - **`State ∈ {active, done}`** — the symmetric two-state lifecycle. A campaign is `active` while its milestone is draining, and flips to `done` once that milestone is fully drained (its GitHub milestone closed). There is no `queued` state: unlike an arc, a campaign is not sequenced ahead — it opens `active` when the founder starts it and ends `done`, running concurrently with whichever arc is active.
 
-**Mentor Audit** — a security & architecture audit wave (the staff-mentor findings: the karma double-bump race, per-actor rate limiting, ops runbooks, `SECURITY.md`, …). To be solved ASAP; drains via the platform lane alongside Geçit.
+**Mentor Audit** — *done.* A security & architecture audit wave (the staff-mentor findings: the karma double-bump race, per-actor rate limiting, ops runbooks, `SECURITY.md`, …). Drained via the platform lane alongside Geçit.
 
 ## Focus
 

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -25,23 +25,25 @@ flowchart TD
 		arc_at_lye["Atölye"]:::done
 	end
 	subgraph campaigns["Campaigns"]
-		camp_mentor_audit["Mentor Audit"]:::active
+		camp_mentor_audit["Mentor Audit"]:::done
 		camp_crew_mcp_finish_replace_the_tmux_relay_with_crew_mcp["Crew-MCP Finish — replace the tmux relay with crew-mcp"]:::done
-		camp_deterministic_crew_mechanics["Deterministic Crew Mechanics"]:::active
+		camp_deterministic_crew_mechanics["Deterministic Crew Mechanics"]:::done
 		camp_di_taxis_docs_pipeline_crew_mcp["Diátaxis docs — pipeline-crew & -mcp"]:::done
-		camp_merge_gate_reliability["Merge-Gate Reliability"]:::active
-		camp_worktree_isolation_integrity["Worktree-Isolation Integrity"]:::active
-		camp_cp_verdict_integrity["§CP Verdict Integrity"]:::active
-		camp_flag_graduation["Flag Graduation"]:::active
-		camp_pipeline_cli_glue_consolidation["pipeline-cli Glue Consolidation"]:::active
-		camp_lint_gate_adoption["Lint-Gate Adoption"]:::active
+		camp_merge_gate_reliability["Merge-Gate Reliability"]:::done
+		camp_worktree_isolation_integrity["Worktree-Isolation Integrity"]:::done
+		camp_cp_verdict_integrity["§CP Verdict Integrity"]:::done
+		camp_flag_graduation["Flag Graduation"]:::done
+		camp_pipeline_cli_glue_consolidation["pipeline-cli Glue Consolidation"]:::done
+		camp_lint_gate_adoption["Lint-Gate Adoption"]:::done
 		camp_taste_skill_library["Taste-Skill Library"]:::active
-		camp_pipeline_anywhere["Pipeline Anywhere"]:::active
-		camp_pipeline_cli_effect_platform_migration["pipeline-cli @effect/platform migration"]:::active
+		camp_pipeline_anywhere["Pipeline Anywhere"]:::done
+		camp_pipeline_cli_effect_platform_migration["pipeline-cli @effect/platform migration"]:::done
 		camp_agentic_design_system_coverage["Agentic design-system coverage"]:::done
-		camp_flag_retirement_adr_0136["Flag Retirement (ADR 0136)"]:::active
+		camp_flag_retirement_adr_0136["Flag Retirement (ADR 0136)"]:::done
 		camp_writing_craft_import["Writing-Craft Import"]:::done
-		camp_fabrika_kampus_pipeline_v2["fabrika — kampus-pipeline v2"]:::active
+		camp_fabrika_kampus_pipeline_v2["fabrika — kampus-pipeline v2"]:::done
+		camp_switching_to_fabrika["switching to fabrika"]:::active
+		camp_fabrika_fast_follows["fabrika fast follows"]:::active
 	end
 	ext_3642["#3642"]:::external
 	ext_3833["#3833"]:::external
@@ -79,23 +81,25 @@ Campaigns are bounded, milestone-backed pushes that run *concurrently* with the 
 
 | Campaign | Milestone | State |
 |----------|-----------|-------|
-| Mentor Audit | #27 | active |
+| Mentor Audit | #27 | done |
 | Crew-MCP Finish — replace the tmux relay with crew-mcp | #28 | done |
-| Deterministic Crew Mechanics | #29 | active |
+| Deterministic Crew Mechanics | #29 | done |
 | Diátaxis docs — pipeline-crew & -mcp | #31 | done |
-| Merge-Gate Reliability | #36 | active |
-| Worktree-Isolation Integrity | #37 | active |
-| §CP Verdict Integrity | #38 | active |
-| Flag Graduation | #39 | active |
-| pipeline-cli Glue Consolidation | #40 | active |
-| Lint-Gate Adoption | #41 | active |
+| Merge-Gate Reliability | #36 | done |
+| Worktree-Isolation Integrity | #37 | done |
+| §CP Verdict Integrity | #38 | done |
+| Flag Graduation | #39 | done |
+| pipeline-cli Glue Consolidation | #40 | done |
+| Lint-Gate Adoption | #41 | done |
 | Taste-Skill Library | #42 | active |
-| Pipeline Anywhere | #35 | active |
-| pipeline-cli @effect/platform migration | #32 | active |
+| Pipeline Anywhere | #35 | done |
+| pipeline-cli @effect/platform migration | #32 | done |
 | Agentic design-system coverage | #33 | done |
-| Flag Retirement (ADR 0136) | #34 | active |
+| Flag Retirement (ADR 0136) | #34 | done |
 | Writing-Craft Import | #30 | done |
-| fabrika — kampus-pipeline v2 | #44 | active |
+| fabrika — kampus-pipeline v2 | #44 | done |
+| switching to fabrika | #45 | active |
+| fabrika fast follows | #46 | active |
 
 **The table is a parsed contract.** It is the single source the campaign skill (which appends a row and flips its state) and the lifecycle guard (which reads it) both bind to, so the grammar is pinned here rather than re-derived at either end:
 
@@ -110,7 +114,7 @@ The one milestone in **exclusive focus**: the campaign an execution engine may o
 
 | Milestone | Declared |
 |-----------|----------|
-| #44 | 2026-08-09 |
+| #45 | 2026-08-14 |
 
 **The grammar.** Columns are `Milestone | Declared`, in that order. `Milestone` pins the focus **by number** (`#N`) — the same row→milestone-by-number binding `## Arcs` and `## Campaigns` use, and the one link to the operational projection. `Declared` is the ISO date (`YYYY-MM-DD`) the focus was declared. The table carries **at most one row**: exclusive focus admits exactly one milestone.
 


### PR DESCRIPTION
Part of #5559.

`ROADMAP.md`'s `## Focus` row pinned milestone #44, which is closed, so `build pick` read every ticket on the live milestones as out of focus and lanes had to override to get anything done. Fixing that row alone would have left `roadmap-guard` red, so this reconciles the tables too.

Applying the founder ruling recorded on #5559 (comment 5300408067):

- `fabrika — kampus-pipeline v2` (#44) flips to `done`.
- New campaign rows for `switching to fabrika` (#45) and `fabrika fast follows` (#46), both `active` — the two milestones where current work lives, previously claimed by no row at all.
- `## Focus` now pins #45, declared 2026-08-14.
- The stale `active` rows whose milestones are closed flip to `done`.

The **Mentor Audit** prose paragraph now reads `— *done.*` to match the row this PR flipped, in the inline-state shape `## Arcs` already uses (`**Four Pillars** — *done.* …`); the falsified "To be solved ASAP" clause is gone. No new description prose was written.

The mermaid block is generated, so it was regenerated with `pipeline-cli roadmap diagram` and byte-compared against the committed block.

`pipeline-cli roadmap-guard check` after the edit:

```
roadmap-guard: in sync — 4 arc row(s) + 19 campaign row(s) validated against 42 milestone(s), 1 focus row declared (I1–I6 all green).
```

`build pick` now returns 16 candidates against focus #45, with no override.

## Deviations

- **Scope narrowing** — **Said:** the issue quotes ten drift violations from run 31779157411, including an I3 row for milestone #43 "Skill Harness Audit". **Did:** reconciled against the guard's live output, which printed nine, and left #43 with no arc or campaign row. **Why:** #43 closed before this run, so its I3 row resolved on its own and a closed milestone needs no claim; the tables are founder-voice, so minting a campaign nobody ruled would have been worse than leaving it alone. **Disposition:** the guard is green without a row for #43; nothing is owed.
- **Out-of-scope change** — **Said:** the ruling names #44 and "the six other stale `active` campaign rows". **Did:** flipped eleven closed-milestone rows to `done`, including #29, #35, #36, #37, #38 and #39, whose milestones closed mid-run. **Why:** the file defines `done` as "its GitHub milestone closed", so each flip is forced by milestone state rather than authored — and leaving them would have kept the guard red under I5, which acceptance criterion 4 forbids. **Disposition:** every flipped row's milestone verified closed live; the only open milestones are #24, #25, #42, #45 and #46, and all five are claimed.
- **Out-of-scope change** — **Said:** the ruling and the acceptance criteria cover the tables and the focus row, not the prose beneath them. **Did:** edited the **Mentor Audit** paragraph to `— *done.*` and dropped its "To be solved ASAP" clause. **Why:** flipping the row falsified the paragraph in the same commit, and marking state inline is the shape `## Arcs` already uses, so it restates milestone state rather than authoring founder-voice prose. **Disposition:** raised as finding 2 by review-doc; fixed here rather than disclosed-and-left.
- **Scope narrowing** — **Said:** acceptance criterion 5 asks that `build pick` reach a `p1`, `ready-for:agent` ticket on milestone **46** without an override. **Did:** left it unmet, and linked this PR as `Part of` rather than `Fixes`. **Why:** exclusive focus admits exactly one milestone and the ruling put it on #45, so #46's tickets read `out-of-focus` by design. **Disposition:** the founder superseded that criterion on #5559 (comment of 2026-08-15T04:06:38Z), keeping focus on #45 and instructing reviewers not to fail the PR on it.
- **Known defect left unfixed** — **Said:** the issue's acceptance criteria should be readable through `build issue`. **Did:** read the five criteria off the issue body by hand. **Why:** the block is malformed (`heading level 2, expected 3`) and the verb refuses it. **Disposition:** already filed as #5565; not fixed here, and the issue body was not edited.
- **Guard or gate bypassed** — **Said:** `build claim` admits only issues inside the campaign in exclusive focus. **Did:** claimed with `--override`, both for the original build on #5559 and for this repair on #5580. **Why:** the stale focus row fenced out the very issue that exists to fix it, and it still reads `#44` on `main` until this PR lands. **Disposition:** the operator directed both claims; each override is recorded on its claim marker with lane `roadmap-focus-reconcile`.
