### PR TITLE
fabrika map record refuses every forked decision ticket on a stale premise

### DIFF
--- a/packages/fabrika-cli/src/map/guards.ts
+++ b/packages/fabrika-cli/src/map/guards.ts
@@ -8,7 +8,9 @@
 
 import {Effect} from "effect";
 import type {ChildProcessSpawner} from "effect/unstable/process";
+import {type QuestionRow, runRead as runGrillRead} from "../grill/read-verb.ts";
 import {resolveRepo} from "../io/issues.ts";
+import {isRecord, parseJson} from "../io/json.ts";
 import {isBareAtReference, renderLeaks, scanBody} from "../report/leaks.ts";
 import {FAILED, refuse, type VerbOutcome} from "../verb.ts";
 import {digestOfBody, type MapBody} from "./body.ts";
@@ -181,6 +183,82 @@ export const notTerminal = (verb: string, ticket: Ticket, tail: string): VerbOut
 	isTerminal(ticket.state)
 		? refuse(TICKET_RETIRED, `${verb}: #${ticket.number} already left the frontier — ${tail}`)
 		: null;
+
+/** The ruling a forked decision ticket's record cites: a session, and one question inside it. */
+export interface Citation {
+	readonly session: number;
+	readonly questionId: string;
+}
+
+/**
+ * The reader's stdout, read as its question rows or as nothing.
+ *
+ * The shape is a contract between two groups, not a guarantee: a rename, an added prose line or a
+ * truncated pipe all arrive here as bytes that do not parse, and a caller seats that as `11` rather
+ * than reading a missing question as "not ruled".
+ */
+const readQuestions = (stdout: string): ReadonlyArray<QuestionRow> | undefined => {
+	const parsed = parseJson(stdout);
+	if (!isRecord(parsed)) return undefined;
+	if (!Array.isArray(parsed.questions)) return undefined;
+	return parsed.questions as ReadonlyArray<QuestionRow>;
+};
+
+/**
+ * The cited question, proven `ruled` by the `grill` group's own reader.
+ *
+ * A read that did not complete is `11` and a question that is absent or reads any other state is
+ * `13` naming the state — UNKNOWN is never resolved to `ruled`.
+ */
+export const requireRuling = (
+	verb: string,
+	repo: string,
+	citation: Citation,
+	env: Readonly<Record<string, string | undefined>>,
+): Effect.Effect<Guarded<QuestionRow>, never, ChildProcessSpawner.ChildProcessSpawner> =>
+	Effect.gen(function* () {
+		const outcome = yield* runGrillRead({session: citation.session, repo, env});
+		if (outcome.code !== 0) {
+			const reason = outcome.stderr.at(-1) ?? "the reader refused without a reason";
+			return refused(
+				outcome.code === NO_TARGET
+					? refuse(
+							NO_TARGET,
+							`${verb}: #${citation.session} does not exist, or is not a grilling session — nothing was recorded.`,
+						)
+					: refuse(
+							PRECONDITION_UNKNOWN,
+							`${verb}: cannot read #${citation.session} ${citation.questionId}: ${reason} — whether it is ruled is UNKNOWN, never assumed ruled. Nothing was recorded.`,
+						),
+			);
+		}
+		const questions = readQuestions(outcome.stdout);
+		if (questions === undefined) {
+			return refused(
+				refuse(
+					PRECONDITION_UNKNOWN,
+					`${verb}: the grilling reader exited 0 on #${citation.session} but its answer carries no questions array — whether ${citation.questionId} is ruled is UNKNOWN. Nothing was recorded.`,
+				),
+			);
+		}
+		const found = questions.find((row) => row.id === citation.questionId);
+		if (found === undefined) {
+			return refused(
+				refuse(
+					TICKET_UNKNOWN,
+					`${verb}: ${citation.questionId} names no question in session #${citation.session} — nothing was recorded.`,
+				),
+			);
+		}
+		return found.state === "ruled"
+			? {_tag: "Ok" as const, value: found}
+			: refused(
+					refuse(
+						TICKET_UNKNOWN,
+						`${verb}: #${citation.session} ${citation.questionId} reads "${found.state}", not "ruled" — only a ruled question's answer is the founder's, so nothing was recorded.`,
+					),
+				);
+	});
 
 /** The compare-and-set guard: the body must still be the one `--digest` was taken from. */
 export const digestFresh = (

--- a/packages/fabrika-cli/src/map/record-verb.ts
+++ b/packages/fabrika-cli/src/map/record-verb.ts
@@ -10,9 +10,9 @@
  * read by importing the `grill` group's reader, never by re-deriving it here.** A ruling counts only
  * when four clauses hold, and those clauses are `grill read`'s to resolve; a second implementation
  * here would be a second answer to a question already enforced elsewhere, and the one that said
- * `ruled` would win by being called. That group ships from #5023 and is not in the package yet, so
- * until it lands this verb refuses a `forked` decision ticket with `11` — the ruling's state is
- * UNKNOWN, never assumed `ruled`. The research and spike paths are unaffected.
+ * `ruled` would win by being called. So the branch calls `grill read` through `requireRuling` and
+ * records only what that reader calls `ruled`: a read that did not complete is `11` and any other
+ * state is `13` naming it, because UNKNOWN is never resolved to `ruled`.
  */
 
 import {Effect, type FileSystem} from "effect";
@@ -31,10 +31,12 @@ import {
 	WRITE_UNKNOWN,
 } from "./codes.ts";
 import {
+	type Citation,
 	digestFresh,
 	leakFree,
 	notTerminal,
 	requireMap,
+	requireRuling,
 	requireTicket,
 	targetRepo,
 } from "./guards.ts";
@@ -71,6 +73,10 @@ export const runRecord = (
 				`${VERB}: --ruled-on requires --question-id matching R<round>.<n>; got "${options.questionId ?? ""}".`,
 			);
 		}
+		const citation: Citation | null =
+			options.ruledOn !== null && options.questionId !== null
+				? {session: options.ruledOn, questionId: options.questionId}
+				: null;
 
 		const read = yield* readFile(options.finding).pipe(
 			Effect.map((value) => ({ok: true as const, value})),
@@ -129,40 +135,43 @@ export const runRecord = (
 		};
 		if (ticket.state === "forked") {
 			if (ticket.kind === "decision") {
-				if (options.ruledOn === null) {
+				if (citation === null) {
 					return refuse(
 						TICKET_UNKNOWN,
 						`${VERB}: #${ticket.number} is forked to #${ticket.session ?? 0} and --ruled-on was not given — a forked ticket's answer is the founder's, and it is recorded by citing his ruling, never by restating it.`,
 					);
 				}
-				return refuse(
-					PRECONDITION_UNKNOWN,
-					`${VERB}: #${options.ruledOn} ${options.questionId ?? ""} cannot be read — the grill question-state reader (#5023) has not landed, so whether it is ruled is UNKNOWN. Nothing was recorded.`,
-				);
+				const ruling = yield* requireRuling(VERB, repo, citation, options.env);
+				if (ruling._tag === "Refused") return ruling.outcome;
+				entry = {
+					text: finding,
+					authority: {_tag: "Ruled", session: citation.session, questionId: citation.questionId},
+				};
+			} else {
+				if (options.spike === null) {
+					return refuse(
+						TICKET_UNKNOWN,
+						`${VERB}: #${ticket.number} is forked to spike #${ticket.spike ?? 0} and --spike was not given — the record cites the spike whose captured decision it carries.`,
+					);
+				}
+				const spike = yield* getIssue(repo, options.spike);
+				if (spike._tag === "Unknown") {
+					return refuse(
+						PRECONDITION_UNKNOWN,
+						`${VERB}: cannot read spike #${options.spike}: ${spike.reason} — nothing was recorded.`,
+					);
+				}
+				if (spike._tag === "Absent" || spike.value.state !== "closed") {
+					return refuse(
+						TICKET_UNKNOWN,
+						`${VERB}: spike #${options.spike} ${spike._tag === "Absent" ? "does not exist" : "is still open"} — a spike's captured decision is recorded once the spike is done.`,
+					);
+				}
 			}
-			if (options.spike === null) {
-				return refuse(
-					TICKET_UNKNOWN,
-					`${VERB}: #${ticket.number} is forked to spike #${ticket.spike ?? 0} and --spike was not given — the record cites the spike whose captured decision it carries.`,
-				);
-			}
-			const spike = yield* getIssue(repo, options.spike);
-			if (spike._tag === "Unknown") {
-				return refuse(
-					PRECONDITION_UNKNOWN,
-					`${VERB}: cannot read spike #${options.spike}: ${spike.reason} — nothing was recorded.`,
-				);
-			}
-			if (spike._tag === "Absent" || spike.value.state !== "closed") {
-				return refuse(
-					TICKET_UNKNOWN,
-					`${VERB}: spike #${options.spike} ${spike._tag === "Absent" ? "does not exist" : "is still open"} — a spike's captured decision is recorded once the spike is done.`,
-				);
-			}
-		} else if (options.ruledOn !== null && options.questionId !== null) {
+		} else if (citation !== null) {
 			entry = {
 				text: finding,
-				authority: {_tag: "Ruled", session: options.ruledOn, questionId: options.questionId},
+				authority: {_tag: "Ruled", session: citation.session, questionId: citation.questionId},
 			};
 		}
 

--- a/packages/fabrika-cli/src/map/record-verb.unit.test.ts
+++ b/packages/fabrika-cli/src/map/record-verb.unit.test.ts
@@ -1,6 +1,13 @@
 import {Effect, Layer} from "effect";
 import {describe, expect, it} from "vitest";
 import {errOut, fakeFs, fakeShell, okOut, once} from "../fakes.test-support.ts";
+import {
+	AUTHORIZATION,
+	answerComment,
+	roundComment,
+	roundDigestOf,
+	rulingComment,
+} from "../grill/fixtures.test-support.ts";
 import type {ExecResult} from "../io/exec.ts";
 import {
 	BAD_SECTIONS,
@@ -132,29 +139,6 @@ describe("runRecord", () => {
 		expect(out.stderr.join("\n")).toContain("never by restating it");
 	});
 
-	it("exits 11 on a forked decision until the grill reader lands — never assumed ruled", async () => {
-		const out = await run(
-			[
-				...frontier(
-					ticketComments(
-						[
-							{
-								id: 2,
-								body: composeForkMarker({map: MAP, ticket: TICKET, route: "session", issue: 9301}),
-							},
-						],
-						"decision",
-					),
-				),
-				[MAP_ISSUE, okOut(issueJson({number: MAP, body: MAP_BODY, labels: ["wayfinding:map"]}))],
-			],
-			{ruledOn: 9301, questionId: "R2.3"},
-		);
-		expect(out.code).toBe(PRECONDITION_UNKNOWN);
-		expect(out.stdout).toBe("");
-		expect(out.stderr.join("\n")).toContain("Nothing was recorded");
-	});
-
 	it("exits 0 on a research finding, moving the row and closing the ticket in that order", async () => {
 		const shell = fakeShell([
 			[PATCH_TICKET, okOut("{}")],
@@ -222,5 +206,120 @@ describe("runRecord", () => {
 		expect(out.code).toBe(WRITE_UNKNOWN);
 		expect(out.stdout).toBe("");
 		expect(out.stderr.join("\n")).toContain(`Close #${TICKET} by hand`);
+	});
+});
+
+const SESSION = 9301;
+const SESSION_ISSUE = /issues\/9301$/;
+const SESSION_COMMENTS = /issues\/9301\/comments/;
+const BOUND = roundDigestOf(1);
+const QUESTION = "R1.2";
+
+/** The frontier of a map whose one ticket is a decision forked to session #9301. */
+const forkedDecision = () =>
+	frontier(
+		ticketComments(
+			[
+				{
+					id: 2,
+					body: composeForkMarker({map: MAP, ticket: TICKET, route: "session", issue: SESSION}),
+				},
+			],
+			"decision",
+		),
+	);
+
+const mapAt = (body: string) =>
+	[MAP_ISSUE, okOut(issueJson({number: MAP, body, labels: ["wayfinding:map"]}))] as const;
+
+const session = (comments: ReadonlyArray<{readonly id: number; readonly body: string}>) =>
+	[
+		[SESSION_ISSUE, okOut(issueJson({number: SESSION, labels: ["grilling:session"]}))],
+		[SESSION_COMMENTS, okOut(commentsJson(comments))],
+	] as const;
+
+/** Round 1 posted, then R1.2 ruled with its adjacent dated authorization. */
+const RULED = [
+	{id: 11, body: roundComment(1)},
+	{id: 12, body: AUTHORIZATION},
+	{id: 13, body: rulingComment(QUESTION, BOUND)},
+];
+
+const ruledRecord = applyRecord(parsed(MAP_BODY), TICKET, {
+	text: ANSWER,
+	authority: {_tag: "Ruled", session: SESSION, questionId: QUESTION},
+}) as string;
+
+describe("a forked decision ticket's ruling is read through the grill reader", () => {
+	it("exits 0 recording the ruling when the cited question reads ruled", async () => {
+		const shell = fakeShell([
+			[PATCH_TICKET, okOut("{}")],
+			[PATCH_MAP, okOut("{}")],
+			...forkedDecision(),
+			...session(RULED),
+			[
+				once(MAP_ISSUE),
+				okOut(issueJson({number: MAP, body: MAP_BODY, labels: ["wayfinding:map"]})),
+			],
+			mapAt(ruledRecord),
+		]);
+		const out = await Effect.runPromise(
+			Effect.provide(
+				runRecord({...options, ruledOn: SESSION, questionId: QUESTION}),
+				Layer.merge(shell.layer, fakeFs({files: {[FINDING]: `${ANSWER}\n`}}).layer),
+			),
+		);
+		expect(out.code).toBe(0);
+		expect(JSON.parse(out.stdout)).toMatchObject({
+			map: MAP,
+			ticket: TICKET,
+			recorded: `— ruled on #${SESSION} ${QUESTION}`,
+			closed: true,
+		});
+		const bodyAt = shell.calls.findIndex((line) => line.includes("PATCH repos/o/r/issues/9140"));
+		const closeAt = shell.calls.findIndex((line) => line.includes("state_reason=completed"));
+		expect(closeAt).toBeGreaterThan(bodyAt);
+	});
+
+	it("exits 11 when the reader cannot complete its read — never assumed ruled", async () => {
+		const out = await run(
+			[
+				...forkedDecision(),
+				mapAt(MAP_BODY),
+				[SESSION_ISSUE, okOut(issueJson({number: SESSION, labels: ["grilling:session"]}))],
+				[SESSION_COMMENTS, errOut("gh: API rate limit exceeded")],
+			],
+			{ruledOn: SESSION, questionId: QUESTION},
+		);
+		expect(out.code).toBe(PRECONDITION_UNKNOWN);
+		expect(out.stdout).toBe("");
+		expect(out.stderr.join("\n")).toContain("Nothing was recorded");
+	});
+
+	it("exits 13 when the cited question names nothing in the session", async () => {
+		const out = await run([...forkedDecision(), mapAt(MAP_BODY), ...session(RULED)], {
+			ruledOn: SESSION,
+			questionId: "R9.9",
+		});
+		expect(out.code).toBe(TICKET_UNKNOWN);
+		expect(out.stdout).toBe("");
+		expect(out.stderr.join("\n")).toContain("names no question");
+	});
+
+	it("exits 13 naming the state it read when the question is not ruled", async () => {
+		const out = await run(
+			[
+				...forkedDecision(),
+				mapAt(MAP_BODY),
+				...session([
+					{id: 11, body: roundComment(1)},
+					{id: 12, body: answerComment("R1.1", BOUND)},
+				]),
+			],
+			{ruledOn: SESSION, questionId: "R1.1"},
+		);
+		expect(out.code).toBe(TICKET_UNKNOWN);
+		expect(out.stdout).toBe("");
+		expect(out.stderr.join("\n")).toContain('reads "answered", not "ruled"');
 	});
 });

--- a/packages/fabrika-cli/src/map/record-verb.unit.test.ts
+++ b/packages/fabrika-cli/src/map/record-verb.unit.test.ts
@@ -11,6 +11,7 @@ import {
 import type {ExecResult} from "../io/exec.ts";
 import {
 	BAD_SECTIONS,
+	NO_TARGET,
 	OUTCOME_UNRECORDABLE,
 	PRECONDITION_UNKNOWN,
 	TICKET_UNKNOWN,
@@ -294,6 +295,16 @@ describe("a forked decision ticket's ruling is read through the grill reader", (
 		expect(out.code).toBe(PRECONDITION_UNKNOWN);
 		expect(out.stdout).toBe("");
 		expect(out.stderr.join("\n")).toContain("Nothing was recorded");
+	});
+
+	it("exits 7 when the cited session does not exist — an absent session is not an unread one", async () => {
+		const out = await run(
+			[...forkedDecision(), mapAt(MAP_BODY), [SESSION_ISSUE, errOut("gh: Not Found (HTTP 404)")]],
+			{ruledOn: SESSION, questionId: QUESTION},
+		);
+		expect(out.code).toBe(NO_TARGET);
+		expect(out.stdout).toBe("");
+		expect(out.stderr.join("\n")).toContain("does not exist");
 	});
 
 	it("exits 13 when the cited question names nothing in the session", async () => {


### PR DESCRIPTION
`map record`'s forked-decision branch refused unconditionally, on the premise that the grill
question-state reader had not shipped. It has: #5023 is closed and `packages/fabrika-cli/src/grill/`
carries the reader that `graduate/source.ts` already calls. So a map that forked a decision to a
grilling session could never record the answer, whatever the session said.

The branch now asks. `requireRuling` in `map/guards.ts` runs `grill read` on `--ruled-on`, finds
`--question-id` among the questions it returns, and hands back the row only when it reads `ruled`.
Everything else still refuses, and refuses harder than before rather than softer:

- a read that did not complete is `11`, naming the reader's own reason
- a session that does not exist is `7`
- an answer that exits 0 without a questions array is `11` — the shape is a contract between two
  groups, not a guarantee
- a question the session does not carry, or one reading any state other than `ruled`, is `13` with
  the state quoted

Nothing here re-derives ruled-ness from the session body, so the `RELAY-GRILLINGS-STATE-NEVER-RECOMPUTE-IT`
rule holds; the docblock now states it as a live rule instead of a wait. The `--spike` branch and the
research path are untouched and their tests pass unchanged.

Five unit tests cover the new branch — records on `ruled`, `11` on a failed read, `7` on a session
that does not exist, `13` on an absent question, `13` naming `answered` on a question that is not
ruled — driven through the real reader over the fake shell, the same way `graduate`'s tests drive it.

Fixes #5575

## Deviations

- **Known defect left unfixed** — **Said:** read the acceptance criteria off `build issue 5575`.
  **Did:** read them off the issue body by hand. **Why:** the verb reported them malformed — the
  issue's `### Acceptance criteria` section lists bullets rather than `- [ ]` checkboxes, the known
  reader/issue-shape defect. **Disposition:** all ten criteria graded by hand; the issue was not
  edited.
- **Guard or gate bypassed** — **Said:** claim the issue through `build claim`, which admits only
  issues inside the declared focus. **Did:** claimed with `--override`. **Why:** `build claim 5575`
  exited 20, out of focus — `ROADMAP.md`'s `## Focus` pins milestone #44, which closed 2026-08-13,
  while this issue lives on #45; that stale declaration is filed as #5559. **Disposition:** the
  override names the operator's dispatch of this exact number, the same route PR #5556 took on the
  same fence.
- **Scope narrowing** — **Said:** sweep the package for the same stale `#5023` premise and fix every
  hit. **Did:** fixed the code hits here and filed the prose hits as #5579. **Why:** the wayfinding,
  graduate and grilling contracts under `claude-plugins/fabrika/skills/` still say the grill group is
  held at #5023, but they are prose in the installed plugin, a different surface with its own gate.
  **Disposition:** filed as #5579; the one other `#5023` mention in the package
  (`grill/answer-verb.ts:15`) is a history citation and stays true.
- **Scope narrowing** — **Said:** prove the fix on the live fixture, map #5542 with session #5561.
  **Did:** proved it with unit tests plus a read-only `grill read 5561`. **Why:** recording on #5542
  closes the founder's ticket, which is his call and not this PR's. **Disposition:** `grill read
  5561` returns `frontier: clear` with R1.1 `ruled` — the exact input the fixed branch consumes; the
  live write is left to the founder.
- **Pre-existing test or fixture changed** — **Said:** leave existing tests standing. **Did:**
  deleted `"exits 11 on a forked decision until the grill reader lands — never assumed ruled"` from
  `packages/fabrika-cli/src/map/record-verb.unit.test.ts`. **Why:** it asserted the exact stub
  refusal #5575 exists to remove, so keeping it would pin the defect. **Disposition:** superseded by
  the five tests of the new branch, which assert the same default-deny direction against a real read
  instead of a hardcoded refusal.
