### PR TITLE
acceptance-criteria read keeps only a wrapped criterion's first line and drops the rest, silently

### DIFF
--- a/packages/fabrika-cli/src/wire/acceptance-criteria.ts
+++ b/packages/fabrika-cli/src/wire/acceptance-criteria.ts
@@ -166,6 +166,45 @@ const sectionOf = (lines: ReadonlyArray<string>, heading: Heading): ReadonlyArra
 	return body;
 };
 
+/**
+ * Where one criterion's text ends — the whole of the wrapping rule, stated once.
+ *
+ * A criterion that wraps onto a second physical line is still *one* criterion: GitHub's own `gfm`
+ * render puts both lines inside one `<li class="task-list-item">`, joined by a `<br>`. A reader
+ * that kept only line one therefore handed every grader a shorter contract than the author wrote,
+ * and said nothing about it — which is the defect this rule closes (#5572). The loss landed on the
+ * qualifiers and the "must not" clauses, because those are the half of a criterion that wraps.
+ *
+ * Four lines close the open criterion, and each is a line the CommonMark render also treats as
+ * leaving the item's paragraph:
+ *
+ * 1. a blank line,
+ * 2. the next checkbox item — including a *nested* one, which is why a sub-item stays its own
+ *    criterion and is never absorbed into its parent's text,
+ * 3. a fence delimiter, and every line inside the fence it opens,
+ * 4. the heading that ends the section — {@link sectionOf} already cuts there, so the loop ends.
+ *
+ * Anything else non-blank continues the criterion above it.
+ */
+interface OpenCriterion {
+	readonly parts: string[];
+	readonly checked: boolean;
+}
+
+/**
+ * Join a criterion's lines into its text: each continuation trimmed of its indentation, joined with
+ * one space, and interior whitespace runs collapsed so the answer carries no newline and no run.
+ *
+ * The collapse is skipped for an unwrapped criterion so that the single-line answer stays
+ * byte-for-byte what it was before the join existed — this widens `Found`, it does not restate it.
+ */
+const joinContinuations = (parts: ReadonlyArray<string>): string => {
+	const [head, ...rest] = parts;
+	if (head === undefined) return "";
+	if (rest.length === 0) return head;
+	return [head, ...rest].join(" ").replace(/\s+/g, " ").trim();
+};
+
 const malformed = (reason: string, evidence: string): AcceptanceCriteriaRead => ({
 	_tag: "Malformed",
 	reason,
@@ -206,18 +245,45 @@ export const read = (body: string): AcceptanceCriteriaRead => {
 	}
 
 	const criteria: AcceptanceCriterion[] = [];
+	let open: OpenCriterion | null = null;
+	let openFence: string | null = null;
+	const close = (): void => {
+		if (open === null) return;
+		const text = criterionText(joinContinuations(open.parts));
+		if (text !== null) criteria.push({text, checked: open.checked});
+		open = null;
+	};
+
 	for (const [offset, line] of sectionOf(lines, heading).entries()) {
 		const item = CHECKBOX_ITEM.exec(line);
-		if (item === null) continue;
-		const text = criterionText(item[2] ?? "");
-		if (text === null) {
-			return malformed(
-				"a checkbox item under the acceptance-criteria heading carries no text",
-				`line ${heading.line + offset + 1}: "${line}"`,
-			);
+		if (item !== null) {
+			close();
+			const text = criterionText(item[2] ?? "");
+			if (text === null) {
+				return malformed(
+					"a checkbox item under the acceptance-criteria heading carries no text",
+					`line ${heading.line + offset + 1}: "${line}"`,
+				);
+			}
+			open = {parts: [text], checked: (item[1] ?? " ").toLowerCase() === "x"};
+			continue;
 		}
-		criteria.push({text, checked: (item[1] ?? " ").toLowerCase() === "x"});
+
+		const fence = FENCE.exec(line);
+		if (fence !== null) {
+			const marker = fence[1] ?? "";
+			if (openFence === null) openFence = marker;
+			else if (openFence === marker) openFence = null;
+			close();
+			continue;
+		}
+		if (openFence !== null || line.trim() === "") {
+			close();
+			continue;
+		}
+		if (open !== null) open.parts.push(line.trim());
 	}
+	close();
 
 	const [head, ...rest] = criteria;
 	if (head === undefined) {

--- a/packages/fabrika-cli/src/wire/acceptance-criteria.ts
+++ b/packages/fabrika-cli/src/wire/acceptance-criteria.ts
@@ -65,6 +65,15 @@ const ATX_HEADING = /^ {0,3}(#{1,6})[ \t]+(.*?)[ \t]*#*[ \t]*$/;
 const FENCE = /^ {0,3}(```|~~~)/;
 const CHECKBOX_ITEM = /^[ \t]*[-*][ \t]+\[([ xX])\][ \t]*(.*)$/;
 
+/**
+ * A line that opens a GFM block of its own beside the item — a plain bullet, an ordered-list marker,
+ * a blockquote, or a thematic break. Each leaves the item's paragraph in the render exactly as the
+ * next checkbox item does, so each closes the open criterion here (#5596). Tested after
+ * {@link CHECKBOX_ITEM}, which owns the task-list forms this would otherwise swallow.
+ */
+const BLOCK_STARTER =
+	/^[ \t]*(?:[-*+][ \t]+|\d{1,9}[.)][ \t]+|>|(?:-[ \t]*){3,}$|(?:\*[ \t]*){3,}$|(?:_[ \t]*){3,}$)/;
+
 interface Heading {
 	readonly level: number;
 	readonly text: string;
@@ -175,16 +184,19 @@ const sectionOf = (lines: ReadonlyArray<string>, heading: Heading): ReadonlyArra
  * and said nothing about it — which is the defect this rule closes (#5572). The loss landed on the
  * qualifiers and the "must not" clauses, because those are the half of a criterion that wraps.
  *
- * Four lines close the open criterion, and each is a line the CommonMark render also treats as
- * leaving the item's paragraph:
+ * A line closes the open criterion when the CommonMark render also treats it as leaving the item's
+ * paragraph:
  *
  * 1. a blank line,
  * 2. the next checkbox item — including a *nested* one, which is why a sub-item stays its own
  *    criterion and is never absorbed into its parent's text,
  * 3. a fence delimiter, and every line inside the fence it opens,
- * 4. the heading that ends the section — {@link sectionOf} already cuts there, so the loop ends.
+ * 4. any other line that opens a block of its own — a plain bullet, an ordered-list marker, a
+ *    blockquote, a thematic break ({@link BLOCK_STARTER}). Joining those swallowed a sibling block's
+ *    prose into the contract, the same defect pointing the other way (#5596),
+ * 5. the heading that ends the section — {@link sectionOf} already cuts there, so the loop ends.
  *
- * Anything else non-blank continues the criterion above it.
+ * Only a line that continues the item's own paragraph — the wrap this rule exists for — is appended.
  */
 interface OpenCriterion {
 	readonly parts: string[];
@@ -277,7 +289,7 @@ export const read = (body: string): AcceptanceCriteriaRead => {
 			close();
 			continue;
 		}
-		if (openFence !== null || line.trim() === "") {
+		if (openFence !== null || line.trim() === "" || BLOCK_STARTER.test(line)) {
 			close();
 			continue;
 		}

--- a/packages/fabrika-cli/src/wire/acceptance-criteria.unit.test.ts
+++ b/packages/fabrika-cli/src/wire/acceptance-criteria.unit.test.ts
@@ -85,6 +85,99 @@ describe("read — Found", () => {
 	});
 });
 
+describe("read — a criterion that wraps is one criterion", () => {
+	it("joins a continuation line rather than keeping only what fit on line one", () => {
+		expect(
+			found(
+				body(
+					"### Acceptance criteria",
+					"- [ ] The change stays in the product tree. It must **not** touch",
+					"      `review-code`'s materialization or its absence assert.",
+				),
+			),
+		).toEqual([
+			criterion(
+				"The change stays in the product tree. It must **not** touch `review-code`'s materialization or its absence assert.",
+				false,
+			),
+		]);
+	});
+
+	it("closes the wrapped criterion at the next checkbox item, and keeps that item's own state", () => {
+		expect(
+			found(
+				body(
+					"### Acceptance criteria",
+					"- [ ] the first criterion wraps",
+					"      onto a second line",
+					"- [x] the second is its own",
+				),
+			),
+		).toEqual([
+			criterion("the first criterion wraps onto a second line", false),
+			criterion("the second is its own", true),
+		]);
+	});
+
+	it("closes the wrapped criterion at the heading that ends the section", () => {
+		expect(
+			found(
+				body(
+					"### Acceptance criteria",
+					"- [ ] the criterion wraps",
+					"      onto a second line",
+					"",
+					"### Out of scope",
+					"Everything below belongs to the next section.",
+				),
+			),
+		).toEqual([criterion("the criterion wraps onto a second line", false)]);
+	});
+
+	it("leaves a nested sub-item its own criterion — a wrapped parent never absorbs it", () => {
+		expect(
+			found(
+				body(
+					"### Acceptance criteria",
+					"- [ ] the parent wraps",
+					"      onto a second line",
+					"  - [ ] the nested sub-item",
+				),
+			),
+		).toEqual([
+			criterion("the parent wraps onto a second line", false),
+			criterion("the nested sub-item", false),
+		]);
+	});
+
+	it("closes the criterion at a blank line, so trailing prose is not swallowed", () => {
+		expect(
+			found(
+				body(
+					"### Acceptance criteria",
+					"- [ ] the criterion",
+					"",
+					"A note about the block, which belongs to nobody.",
+				),
+			),
+		).toEqual([criterion("the criterion", false)]);
+	});
+
+	it("closes the criterion at a fence, and joins nothing from inside it", () => {
+		expect(
+			found(
+				body("### Acceptance criteria", "- [ ] the criterion", "```sh", "pnpm typecheck", "```"),
+			),
+		).toEqual([criterion("the criterion", false)]);
+	});
+
+	it("leaves a single-line criterion byte-identical — the join widens Found, it does not restate it", () => {
+		expect(found(body("### Acceptance criteria", "- [ ] one  criterion, two  spaces"))).toEqual([
+			criterion("one  criterion, two  spaces", false),
+		]);
+	});
+});
+
 describe("read — Absent", () => {
 	it("answers Absent for a body where nothing reaches for the block", () => {
 		const result = read(body("### What to build", "Stand up the group.", "", "Some prose."));

--- a/packages/fabrika-cli/src/wire/acceptance-criteria.unit.test.ts
+++ b/packages/fabrika-cli/src/wire/acceptance-criteria.unit.test.ts
@@ -171,6 +171,46 @@ describe("read — a criterion that wraps is one criterion", () => {
 		).toEqual([criterion("the criterion", false)]);
 	});
 
+	it("closes the criterion at a plain bullet — a sibling list is not part of the contract", () => {
+		expect(
+			found(
+				body(
+					"### Acceptance criteria",
+					"- [ ] the criterion",
+					"- a plain bullet, not a checkbox",
+					"* a star bullet",
+					"+ a plus bullet",
+				),
+			),
+		).toEqual([criterion("the criterion", false)]);
+	});
+
+	it("closes the criterion at an ordered-list marker", () => {
+		expect(
+			found(
+				body("### Acceptance criteria", "- [ ] the criterion", "1. an ordered item", "2) another"),
+			),
+		).toEqual([criterion("the criterion", false)]);
+	});
+
+	it("closes the criterion at a blockquote", () => {
+		expect(
+			found(body("### Acceptance criteria", "- [ ] the criterion", "> a quoted note")),
+		).toEqual([criterion("the criterion", false)]);
+	});
+
+	it("closes the criterion at a thematic break, and joins nothing after it", () => {
+		expect(
+			found(body("### Acceptance criteria", "- [ ] the criterion", "---", "trailing prose")),
+		).toEqual([criterion("the criterion", false)]);
+		expect(found(body("### Acceptance criteria", "- [ ] the criterion", "***"))).toEqual([
+			criterion("the criterion", false),
+		]);
+		expect(found(body("### Acceptance criteria", "- [ ] the criterion", "___"))).toEqual([
+			criterion("the criterion", false),
+		]);
+	});
+
 	it("leaves a single-line criterion byte-identical — the join widens Found, it does not restate it", () => {
 		expect(found(body("### Acceptance criteria", "- [ ] one  criterion, two  spaces"))).toEqual([
 			criterion("one  criterion, two  spaces", false),

--- a/packages/fabrika-cli/src/wire/conformance.ts
+++ b/packages/fabrika-cli/src/wire/conformance.ts
@@ -44,6 +44,8 @@ export const LAWS = {
 	emits: "emit composes the round-trip fixture",
 	roundTrip: "read(emit(fields)) is Found",
 	recovers: "the Found answer carries every field value it was given",
+	foundIsFound: "each declared found fixture reads Found — never Absent, never Malformed",
+	foundRecovers: "each found fixture's answer carries every value it declared",
 	emptyIsAbsent: "empty bytes read Absent — never Found",
 	absentIsAbsent: "the declared absent fixture reads Absent — never Found, never Malformed",
 	driftIsMalformed: "each declared drift fixture reads Malformed — never Found, never Absent",
@@ -59,7 +61,7 @@ export const conformFormat = (format: WireFormat): ReadonlyArray<ConformanceFind
 		findings.push({format: format.key, law, detail});
 	};
 
-	const {roundTrip, absent, malformed} = format.fixtures;
+	const {roundTrip, found, absent, malformed} = format.fixtures;
 	const composed = format.emit(roundTrip.fields);
 	if (composed._tag !== "Composed") {
 		fail(LAWS.emits, `emit answered Unusable: ${composed.reason}`);
@@ -73,6 +75,22 @@ export const conformFormat = (format: WireFormat): ReadonlyArray<ConformanceFind
 			if (dropped.length > 0) {
 				fail(LAWS.recovers, `the answer dropped ${dropped.map((v) => `"${v}"`).join(", ")}`);
 			}
+		}
+	}
+
+	for (const fixture of found) {
+		const authored = format.read(fixture.artifact);
+		if (authored._tag !== "Found") {
+			fail(LAWS.foundIsFound, `"${fixture.shape}" read ${authored._tag}: ${authored.reason}`);
+			continue;
+		}
+		const answer = answerOf(authored);
+		const dropped = fixture.values.filter((value) => !answer.includes(value));
+		if (dropped.length > 0) {
+			fail(
+				LAWS.foundRecovers,
+				`"${fixture.shape}" dropped ${dropped.map((v) => `"${v}"`).join(", ")}`,
+			);
 		}
 	}
 

--- a/packages/fabrika-cli/src/wire/conformance.unit.test.ts
+++ b/packages/fabrika-cli/src/wire/conformance.unit.test.ts
@@ -71,6 +71,9 @@ const TOY_FORMAT: WireFormat = {
 	read: toyRead,
 	fixtures: {
 		roundTrip: {fields: "alpha", values: ["alpha"]},
+		found: [
+			{shape: "authored with surrounding blank lines", artifact: "\ntoy: beta\n", values: ["beta"]},
+		],
 		absent: "prose that reaches for nothing\n",
 		malformed: [{drift: "the key drifted", artifact: "toyish: alpha\n"}],
 	},
@@ -138,6 +141,24 @@ describe("the laws bite — each mutation is caught", () => {
 					: toyRead(artifact),
 		});
 		expect(lawsBrokenBy(format)).toContain(LAWS.driftIsMalformed);
+	});
+
+	it("catches an authored artifact answered as Absent, which emit's own bytes would have hidden", () => {
+		const format = broken({
+			read: (artifact) =>
+				artifact.includes("beta")
+					? {_tag: "Absent", reason: "read it as nothing"}
+					: toyRead(artifact),
+		});
+		expect(lawsBrokenBy(format)).toContain(LAWS.foundIsFound);
+	});
+
+	it("catches an authored artifact read as Found with part of its content dropped", () => {
+		const format = broken({
+			read: (artifact) =>
+				artifact.includes("beta") ? {_tag: "Found", value: ["value\t"]} : toyRead(artifact),
+		});
+		expect(lawsBrokenBy(format)).toContain(LAWS.foundRecovers);
 	});
 
 	it("catches two rows registered under one key", () => {

--- a/packages/fabrika-cli/src/wire/format.ts
+++ b/packages/fabrika-cli/src/wire/format.ts
@@ -73,6 +73,23 @@ export interface WireRoundTripFixture {
 	readonly values: NonEmptyReadonlyArray<string>;
 }
 
+/**
+ * An artifact *nobody emitted* that must still read `Found` — the authored-shape half of coverage.
+ *
+ * A round-trip fixture only ever drives `read` over bytes this format's own `emit` produced, so a
+ * reader and a writer that agree with each other and disagree with what a human writes round-trip
+ * perfectly while dropping content. That is exactly how a wrapped acceptance criterion lost
+ * everything past its first physical line and stayed green (#5572). This fixture is the artifact as
+ * a person or another tool would author it, and `values` is what `read`'s answer must still carry.
+ */
+export interface WireFoundFixture {
+	/** The authored shape this artifact stands for, so a broken law names the case, not an index. */
+	readonly shape: string;
+	readonly artifact: string;
+	/** Every value the answer must carry. Each must survive the read intact. */
+	readonly values: NonEmptyReadonlyArray<string>;
+}
+
 /** An artifact that reaches for the format's block and misses. */
 export interface WireMalformedFixture {
 	/** What drifted, so a broken law names the case rather than an index. */
@@ -90,6 +107,12 @@ export interface WireMalformedFixture {
  */
 export interface WireFixtures {
 	readonly roundTrip: WireRoundTripFixture;
+	/**
+	 * At least one artifact authored the way the world writes it: `Found`, carrying every declared
+	 * value. Required, not optional — a fixture kind a row may leave out is coverage a row opts out
+	 * of, which is the shape of the hole `roundTrip` alone left open.
+	 */
+	readonly found: NonEmptyReadonlyArray<WireFoundFixture>;
 	/** An artifact that genuinely carries no block: `Absent`, never `Malformed`. */
 	readonly absent: string;
 	/** At least one drift: `Malformed`, never `Found` and never `Absent`. */

--- a/packages/fabrika-cli/src/wire/index-doc.unit.test.ts
+++ b/packages/fabrika-cli/src/wire/index-doc.unit.test.ts
@@ -45,6 +45,7 @@ const TOY_FORMAT: WireFormat = {
 	read: (): WireReadLines => ({_tag: "Found", value: ["value\talpha"]}),
 	fixtures: {
 		roundTrip: {fields: "alpha", values: ["alpha"]},
+		found: [{shape: "authored by hand", artifact: "toy: alpha\n", values: ["alpha"]}],
 		absent: "prose that reaches for nothing\n",
 		malformed: [{drift: "the key drifted", artifact: "toyish: alpha\n"}],
 	},

--- a/packages/fabrika-cli/src/wire/registry.ts
+++ b/packages/fabrika-cli/src/wire/registry.ts
@@ -45,6 +45,18 @@ export const registeredFormats: ReadonlyArray<WireFormat> = [
 				fields: "- [ ] the read is total\n- [x] the registry is the seam\n",
 				values: ["the read is total", "the registry is the seam"],
 			},
+			found: [
+				{
+					shape:
+						"a criterion wrapped over two physical lines, as a body authored to 100 columns carries it",
+					artifact:
+						"### Acceptance criteria\n\n- [ ] The reader returns the criterion in full. It must **not** keep\n      only the first physical line.\n- [x] a single-line criterion is unchanged\n",
+					values: [
+						"The reader returns the criterion in full. It must **not** keep only the first physical line.",
+						"a single-line criterion is unchanged",
+					],
+				},
+			],
 			absent: "### What to build\n\nStand up the group. Nothing here reaches for the block.\n",
 			malformed: [
 				{
@@ -77,6 +89,15 @@ export const registeredFormats: ReadonlyArray<WireFormat> = [
 				fields: "namespace: review-code\npolarity: PASS\nsha: 03135b91\nclause: merge-ready\n",
 				values: ["review-code", "PASS", "03135b91", "merge-ready"],
 			},
+			found: [
+				{
+					shape:
+						"the marker as a reviewer posts it — first line of a comment that then explains itself",
+					artifact:
+						"review-code: PASS @ 03135b91 — merge-ready\n\nEvery criterion is met; the wrapped-item fixture is the one I looked at first.\n",
+					values: ["review-code", "PASS", "03135b91", "merge-ready"],
+				},
+			],
 			absent: "Thanks — this reads well to me, no notes.\n",
 			malformed: [
 				{
@@ -129,6 +150,19 @@ export const registeredFormats: ReadonlyArray<WireFormat> = [
 					"- [ ] cart and invoice render through one totals module",
 				],
 			},
+			found: [
+				{
+					shape: "the brief as a conductor hands it over, rules verbatim",
+					artifact: `## Slice\nid: C2\nissue: #312\ncriteria:\n- [ ] the invoice total is derived, never stored\n## Ground\ntree: /work/lanes/epic-310\nbranch: build/310-totals-rework-9b2e60c1\nbase: 7c1d4a9b\nhandoff: /run/fabrika-epic/310-9b2e60c1/C2/handoff.md\n## Rules\n${sliceHandoff.RULES}\n`,
+					values: [
+						"C2",
+						"312",
+						"build/310-totals-rework-9b2e60c1",
+						"7c1d4a9b",
+						"- [ ] the invoice total is derived, never stored",
+					],
+				},
+			],
 			absent: "Thanks — picking this up now, will push when the tests are green.\n",
 			malformed: [
 				{
@@ -162,6 +196,13 @@ export const registeredFormats: ReadonlyArray<WireFormat> = [
 				fields: "map: 9140\nkind: research\nnonce: 7f3a9c21\n",
 				values: ["9140", "research", "7f3a9c21"],
 			},
+			found: [
+				{
+					shape: "the marker opening a ticket comment that goes on to say what clears it",
+					artifact: "map-ticket: #9140 · research · 7f3a9c21\n\nPicking this one up now.\n",
+					values: ["9140", "research", "7f3a9c21"],
+				},
+			],
 			absent: "Picking this one up — will report back once the source read lands.\n",
 			malformed: [
 				{
@@ -194,6 +235,14 @@ export const registeredFormats: ReadonlyArray<WireFormat> = [
 				fields: "question: R2.3\ndigest: a1b2c3d4e5f6\nat: 2026-08-09T18:36:48Z\n",
 				values: ["R2.3", "a1b2c3d4e5f6", "2026-08-09T18:36:48Z"],
 			},
+			found: [
+				{
+					shape: "the marker over the ruling's own prose, as the comment is written",
+					artifact:
+						"grill-ruled: R2.3 @ a1b2c3d4e5f6 · 2026-08-09T18:36:48Z\n\nJoin the continuation, do not refuse it.\n",
+					values: ["R2.3", "a1b2c3d4e5f6", "2026-08-09T18:36:48Z"],
+				},
+			],
 			absent: "Noted — I'll take this one to him directly and report back.\n",
 			malformed: [
 				{
@@ -230,6 +279,14 @@ export const registeredFormats: ReadonlyArray<WireFormat> = [
 				fields: "question: R2.1\ndigest: a1b2c3d4e5f6\nat: 2026-08-09T18:36:48Z\n",
 				values: ["R2.1", "a1b2c3d4e5f6", "2026-08-09T18:36:48Z"],
 			},
+			found: [
+				{
+					shape: "the marker over the established answer it introduces",
+					artifact:
+						"grill-answered: R2.1 @ a1b2c3d4e5f6 · 2026-08-09T18:36:48Z\n\nGitHub's gfm render joins both lines into one item.\n",
+					values: ["R2.1", "a1b2c3d4e5f6", "2026-08-09T18:36:48Z"],
+				},
+			],
 			absent: "Checked the schema — there is no weight column today.\n",
 			malformed: [
 				{
@@ -263,6 +320,14 @@ export const registeredFormats: ReadonlyArray<WireFormat> = [
 				fields: "R1.4 @ 7c1d4a9b2e60 · round 2 · 2026-08-09T18:36:48Z\n",
 				values: ["R1.4", "7c1d4a9b2e60", "round 2", "2026-08-09T18:36:48Z"],
 			},
+			found: [
+				{
+					shape: "two questions retired in one comment, one line each",
+					artifact:
+						"grill-superseded: R1.4 @ 7c1d4a9b2e60 · round 2 · 2026-08-09T18:36:48Z\ngrill-superseded: R1.5 @ 7c1d4a9b2e60 · round 2 · 2026-08-09T18:36:48Z\n",
+					values: ["R1.4", "R1.5", "7c1d4a9b2e60", "round 2"],
+				},
+			],
 			absent: "Re-asking this one next round, it was worded too broadly.\n",
 			malformed: [
 				{
@@ -320,6 +385,20 @@ export const registeredFormats: ReadonlyArray<WireFormat> = [
 					"Whether one level is enough.",
 				],
 			},
+			found: [
+				{
+					shape: "a pack as a session writes it, each section carrying its own prose",
+					artifact:
+						'<!-- fabrika:handoff pack nonce=9b2e60c1 sealedAt=2026-08-09T21:04:11Z groundDigest=7c1d4a9b2e60 -->\n\n## Intent\nJoin a wrapped acceptance criterion instead of dropping it.\n\n## Established\nThe reader reads #5515 in full.\n\n## Next act\nCarry the wrapped artifact as a registry fixture.\n\n## Unsure\nWhether every row can author a Found fixture.\n\n## Ground state — proven\n```json\n{"issue":5572,"repo":"kamp-us/phoenix"}\n```\n',
+					values: [
+						"9b2e60c1",
+						"2026-08-09T21:04:11Z",
+						"7c1d4a9b2e60",
+						"Join a wrapped acceptance criterion instead of dropping it.",
+						"Whether every row can author a Found fixture.",
+					],
+				},
+			],
 			absent: "Picking this up — will push once the failing case is green.\n",
 			malformed: [
 				{
@@ -371,6 +450,14 @@ export const registeredFormats: ReadonlyArray<WireFormat> = [
 					"routine",
 				],
 			},
+			found: [
+				{
+					shape: "the readout as it is posted — a sentence of framing above the fenced rows",
+					artifact:
+						"## Governance readout\n\nThree records landed in the window.\n\n```governance-digest\nrow\t0398\ttension\tsits against ADR 0173\nrow\t0396\troutine\tno tension found\n```\n",
+					values: ["0398", "tension", "sits against ADR 0173", "0396", "routine"],
+				},
+			],
 			absent: "Reading through the landings now — nothing here reaches for the block.\n",
 			malformed: [
 				{
@@ -417,6 +504,14 @@ export const registeredFormats: ReadonlyArray<WireFormat> = [
 					"source: 9412\nemitted: 9520\ndigest: a1b2c3d4e5f6\ncovers: R1.2;R1.4\nat: 2026-08-09T18:36:48Z\n",
 				values: ["9412", "9520", "a1b2c3d4e5f6", "R1.2;R1.4", "2026-08-09T18:36:48Z"],
 			},
+			found: [
+				{
+					shape: "the marker over the emission note that follows it",
+					artifact:
+						"graduate-emitted: #9412 → #9520 @ a1b2c3d4e5f6 · covers R1.2;R1.4 · 2026-08-09T18:36:48Z\n\nThe remainder is R1.3.\n",
+					values: ["9412", "9520", "a1b2c3d4e5f6", "R1.2;R1.4", "2026-08-09T18:36:48Z"],
+				},
+			],
 			absent: "Reading the trail back now — nothing here reaches for the marker.\n",
 			malformed: [
 				{


### PR DESCRIPTION
`read` in `packages/fabrika-cli/src/wire/acceptance-criteria.ts` kept only the first physical line of
a criterion that wraps, and dropped the rest at exit 0. This joins the continuation lines into the
criterion they belong to, which is what GitHub's own `gfm` render puts inside the item's
`<li class="task-list-item">`.

The end of a criterion is now an explicit rule, stated in the module: a blank line, the next checkbox
item (nested ones included, so a sub-item is still its own criterion), a fence delimiter and
everything inside the fence it opens, and the heading that ends the section. Anything else non-blank
continues the criterion above it. Continuations are trimmed of their indentation and joined with one
space, and interior whitespace runs are collapsed — but only for a criterion that actually wrapped, so
a single-line criterion's text is byte-for-byte what it was. `emit` and `parseFields` are untouched.

**Joining was the right call, and I would not switch to refusing.** GitHub renders a wrapped item as
one criterion, so joining returns what the author wrote and what every human reviewer already reads.
Refusing would turn #5515, #5483 and #5073 — all open and triaged today — into unreadable contracts,
trading a silent defect for a loud outage on live work.

## The fixture question

The wrapped case **is** expressible as a registry fixture, once the fixture shape grows. `WireFixtures`
gained a required `found` kind: an artifact nobody emitted, that must still read `Found` carrying every
value it declares. That is the half `roundTrip` structurally cannot cover — a reader and a writer that
agree with each other round-trip perfectly while both disagree with what a person writes, which is
exactly why this defect stayed green. The `acceptance-criteria` row now carries a wrapped artifact, and
`conformance.ts` gained two laws over it (`foundIsFound`, `foundRecovers`), each with its own
bite test against a deliberately broken synthetic row.

The kind is required rather than optional, so it lands on all ten rows. A fixture kind a row may leave
out is coverage a row opts out of, which is the shape of the hole being closed.

## The reader over the three live issues

Run against the live bodies of #5515, #5483 and #5073, fetched from the API.

**Before — #5515 (`Found`, 5 criteria, every one truncated):**

```
1. The four `adoption-lint/command.test.ts` cases no longer fail in a tree where the harness
2. Absence is handled once, as a single explicit decision for the file (harness tree present
3. A genuinely missing `.claude/workflows/drive-issue.js` still reds **somewhere**: on a full
4. The change stays in the product tree
5. `pnpm --filter './packages/**' test` is green on a full checkout, and the four cases are
```

**After — #5515:**

```
1. The four `adoption-lint/command.test.ts` cases no longer fail in a tree where the harness surfaces (`CLAUDE.md`, `.claude/`, `.decisions/`, `.patterns/`) have been removed — they skip, with a reason a reader can see in the output, rather than passing vacuously.
2. Absence is handled once, as a single explicit decision for the file (harness tree present or not), not with a per-read `existsSync` — the existing per-read guard in `corpusFiles()` is what turns a valid mirror exemption into a "stale exemption" red, so it is part of the thing being fixed.
3. A genuinely missing `.claude/workflows/drive-issue.js` still reds **somewhere**: on a full checkout (CI, `main`) the four cases run and enforce exactly as they do today, and the `adoption-lint` workflow's scan is unchanged.
4. The change stays in the product tree (`packages/pipeline-cli/src/tools/adoption-lint/`). It must **not** touch `review-code`'s materialization/denylist or its absence assert — that is ADR 0049/0052/0067 isolation and it is […]-owned.
5. `pnpm --filter './packages/**' test` is green on a full checkout, and the four cases are green-or-skipped in a stripped tree.
```

The fourth is the one that mattered: the whole prohibition, including the ownership clause at the end
of it, is back.

Two quoted criteria name the merge gate's own classification phrase, and `build pr` refuses any body
carrying it. Those two spots read `[…]` above; nothing else in any quoted block is altered, and the
unelided output is posted on #5572.

**Before — #5483:**

```
1. An epic is planned end to end through `claude-plugins/fabrika/skills/plan-epic/` (as a real
2. Every child minted by that run is re-read over `repos/{owner}/{repo}/issues/<child>/labels`
3. Any child observed with zero or more than one `ready-for:` label is filed as its own issue
4. This issue closes on that record. If #5462 instead lands with its fourth criterion discharged
```

**After — #5483:**

```
1. An epic is planned end to end through `claude-plugins/fabrika/skills/plan-epic/` (as a real planning act, not staged for this ticket).
2. Every child minted by that run is re-read over `repos/{owner}/{repo}/issues/<child>/labels` and its observed `ready-for:` value recorded in a comment here.
3. Any child observed with zero or more than one `ready-for:` label is filed as its own issue (that would be a defect in `ledger child`, not in this record).
4. This issue closes on that record. If #5462 instead lands with its fourth criterion discharged in-lane, close this as covered by #5462.
```

**Before — #5073:**

```
1. Two `worktree-sweep-run.sh` runs overlapping in time cannot cause a failed run's outcome to
2. `worktree-sweep.failed.log` preserved for a failed run contains **that run's** output, not a
3. `worktree-sweep.log` is not left sparse or garbled by two concurrent writers.
4. A second session start while a sweep is legitimately still running does **not** print the
5. The `#1050` fail-open invariant is preserved: every path in `worktree-sweep-detach.sh` still
6. No change to `classifyWorktree` in `packages/pipeline-cli/src/tools/worktree-sweep/worktree-sweep.ts`
7. The chosen approach is stated in the PR. Per-run file naming and a single-flight lock are both
8. The PR is recognized as §CP and banks for a […] approval rather than self-merging.
```

**After — #5073:**

```
1. Two `worktree-sweep-run.sh` runs overlapping in time cannot cause a failed run's outcome to be reported as `exit 0` at the next session start. Whichever mechanism is chosen, a failure is not silently swallowed by a concurrent success.
2. `worktree-sweep.failed.log` preserved for a failed run contains **that run's** output, not a concurrent run's.
3. `worktree-sweep.log` is not left sparse or garbled by two concurrent writers.
4. A second session start while a sweep is legitimately still running does **not** print the "it was killed" stderr warning for that live run.
5. The `#1050` fail-open invariant is preserved: every path in `worktree-sweep-detach.sh` still drains stdin and exits 0, and the SessionStart hook still returns without waiting for the scan (the #4998 fix is not regressed).
6. No change to `classifyWorktree` in `packages/pipeline-cli/src/tools/worktree-sweep/worktree-sweep.ts` — that surface belongs to #4975 / #4884 / #4017.
7. The chosen approach is stated in the PR. Per-run file naming and a single-flight lock are both open options; a single-flight lock is new scheduling policy and should be argued for, not assumed.
8. The PR is recognized as §CP and banks for a […] approval rather than self-merging.
```

`pnpm --filter './packages/**' test` and `pnpm typecheck` are green in this tree.

## Deviations

- **Said:** carry the wrapped case as a registry fixture for `acceptance-criteria`. **Did:** grew
  `WireFixtures` with a required `found` kind, which forced a fixture onto all ten registered rows and
  onto the two synthetic rows in `conformance.unit.test.ts` and `index-doc.unit.test.ts`. **Why:** the
  hole is not specific to this format — any format whose authored shape differs from its emitted shape
  has it, and an optional kind is one a row opts out of silently. **Disposition:** kept; the extra rows
  are one fixture each and every one reads `Found` today.
- **Said:** the fix widens `Found` and moves no refusal. **Did:** left `- [ ]` with no text on its own
  line as `Malformed` even when a continuation line follows it. **Why:** the alternative reads that
  body as a criterion and turns a refusal into a `Found`, which is the one direction the ticket
  forbids; a criterion whose first line is empty is not a shape anyone authors. **Disposition:** kept,
  and pinned by the existing test.
- **Said:** show the reader's output over the three live issues verbatim. **Did:** elided two
  substrings as `[…]` — both are a quoted criterion naming the merge gate's classification phrase.
  **Why:** `build pr` refuses any body containing that phrase, quoted or not, so a fully verbatim body
  cannot be posted. **Disposition:** kept, elision marked in place, and the unelided output posted as
  a note on #5572 where no such guard applies.
- **Said:** joining collapses interior whitespace runs. **Did:** collapse only when the criterion
  actually wrapped. **Why:** collapsing a single-line criterion would change bytes the ticket requires
  identical. **Disposition:** kept; both halves are pinned by tests.

Fixes #5572
