### PR TITLE
Retire the v1 skill roster in one change: both .claude symlinks plus the ADR 0077 suppression

### DIFF
--- a/.claude/agents
+++ b/.claude/agents
@@ -1,1 +1,0 @@
-../claude-plugins/kampus-pipeline/agents

--- a/.claude/skills
+++ b/.claude/skills
@@ -1,1 +1,0 @@
-../claude-plugins/kampus-pipeline/skills

--- a/.decisions/0277-v1-retirement-keeps-the-plugin-suppression.md
+++ b/.decisions/0277-v1-retirement-keeps-the-plugin-suppression.md
@@ -122,6 +122,14 @@ is owed, and none is possible.
 
 ## Records
 
+- **Executed 2026-08-14** by [#5276](https://github.com/kamp-us/phoenix/issues/5276) (skills half)
+  and [#5537](https://github.com/kamp-us/phoenix/issues/5537) (agents half), landed as one pull
+  request after the founder ruled the split over: `.claude/skills` and `.claude/agents` are deleted,
+  `.claude/.pipeline` stays (a literal path alias, ADR 0255 §5), and
+  `"kampus-pipeline@kampus": false` stays in `.claude/settings.json` exactly as this entry decides.
+  The same commit repoints the ten `- run:` steps in `ci.yml`'s `skills` job at
+  `claude-plugins/kampus-pipeline/skills/…` and drops `validate-gate-path-drift.sh`'s
+  symlink-is-a-symlink invariant, which had the deleted link as its subject.
 - Closes [#5532](https://github.com/kamp-us/phoenix/issues/5532).
 - Amends in part [0255](0255-skill-namespaces-keep-v1-and-fabrika-apart.md) and
   [0077](0077-in-repo-pipeline-skill-discovery-doubling.md); both status lines carry the link, both

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -683,10 +683,13 @@ jobs:
       # Same script runs locally: `bash claude-plugins/kampus-pipeline/skills/triage/scripts/verify-apply-triage-args.sh`.
       - run: bash claude-plugins/kampus-pipeline/skills/triage/scripts/verify-apply-triage-args.sh
 
-      # Gate-path drift guard (issue #720): assert the five CONTROL_PLANE_RE= copies
-      # in ship-it/review-code/review-doc/review-skill/gh-issue-intake-formats are
-      # byte-identical to the §CP canonical line. A drifted copy otherwise silently
-      # breaks all gate checks with no build-time failure. Its second invariant — the
+      # Gate-path drift guard (issue #720): read the §CP CONTROL_PLANE_RE from its
+      # single-source const via `pipeline-cli control-plane-paths` (#2761) and diff it
+      # against the ONE un-importable copy left — the CONTROL_PLANE_RE= line in
+      # gh-issue-intake-formats.md the live gates re-resolve from origin/main (#981);
+      # the gate skills carry no copy of their own. The same const-vs-copy compare then
+      # runs over the ten other gate boundaries (#4401). A drifted copy otherwise
+      # silently breaks all gate checks with no build-time failure. Its second invariant — the
       # `.claude/skills` symlink agreeing with marketplace.json — went with the symlink
       # when v1 retired (ADR 0277).
       # Same script runs locally: `bash claude-plugins/kampus-pipeline/skills/validate-gate-path-drift.sh`.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -590,31 +590,31 @@ jobs:
 
       - run: pnpm install --frozen-lockfile
 
-      # Pure-bash guard, no toolchain: every .claude/skills/*/SKILL.md must carry
+      # Pure-bash guard, no toolchain: every claude-plugins/kampus-pipeline/skills/*/SKILL.md must carry
       # valid frontmatter (name + description, name == dir) or a skill silently
-      # stops routing. Same script runs locally: `bash .claude/skills/validate-skills.sh`.
-      - run: bash .claude/skills/validate-skills.sh
+      # stops routing. Same script runs locally: `bash claude-plugins/kampus-pipeline/skills/validate-skills.sh`.
+      - run: bash claude-plugins/kampus-pipeline/skills/validate-skills.sh
 
       # Portability safety net (ADR 0062 / 0083): assert every cycle-aware skill
       # (plan-epic/write-code/review-code/ship-it) no-ops gracefully with no
       # product-development-cycle.md — each cites the one canonical absence-probe
       # and an absent⇒no-op branch, and a hermetic doc-absent walkthrough holds.
-      # Same script runs locally: `bash .claude/skills/validate-cycle-absence.sh`.
-      - run: bash .claude/skills/validate-cycle-absence.sh
+      # Same script runs locally: `bash claude-plugins/kampus-pipeline/skills/validate-cycle-absence.sh`.
+      - run: bash claude-plugins/kampus-pipeline/skills/validate-cycle-absence.sh
 
       # Present-path twin (issue #750, ADR 0091/0092): the absence script only ever
       # exercises the foreign-repo absent branch. This asserts phoenix's PRESENT path —
       # the cycle doc resolves `present` and each skill's present-branch action is wired
       # (plan-epic stamps, write-code ships dark, review-code gates, ship-it queues) — and
       # FAILS CLOSED on zero scope (missing doc ⇒ FAIL, never a silent no-op; ADR 0092).
-      # Same script runs locally: `bash .claude/skills/validate-cycle-presence.sh`.
-      - run: bash .claude/skills/validate-cycle-presence.sh
+      # Same script runs locally: `bash claude-plugins/kampus-pipeline/skills/validate-cycle-presence.sh`.
+      - run: bash claude-plugins/kampus-pipeline/skills/validate-cycle-presence.sh
 
       # Executable pin for the shared surface resolver both cycle validators consume: a
       # partially-failing `find` must not hand them a silently narrowed — but non-empty —
       # surface that their zero-scope guard reads as complete (#4487).
-      # The lib sits beside `bin/`, outside the skills tree, so this path is the real one rather
-      # than a `.claude/skills/…` symlink hop (#4484).
+      # The lib sits beside `bin/`, outside the skills tree, and was already invoked at its real
+      # path back when the rest of this job still hopped the `.claude/skills` symlink (#4484).
       # Same script runs locally: `bash claude-plugins/kampus-pipeline/lib/common-test.sh`.
       - run: bash claude-plugins/kampus-pipeline/lib/common-test.sh
 
@@ -631,8 +631,8 @@ jobs:
       # hardcoded the seam empty, and nothing in the repo noticed for a week — ship-it is
       # the single merge authority (ADR 0048/0135), so its chain not running as written
       # is a merge-path defect. Hermetic: gh and the CLI shim are stubbed, no network.
-      # Same script runs locally: `bash .claude/skills/ship-it/scripts/verify-chain-resolves.sh`.
-      - run: bash .claude/skills/ship-it/scripts/verify-chain-resolves.sh
+      # Same script runs locally: `bash claude-plugins/kampus-pipeline/skills/ship-it/scripts/verify-chain-resolves.sh`.
+      - run: bash claude-plugins/kampus-pipeline/skills/ship-it/scripts/verify-chain-resolves.sh
 
       # Executable pin for Step 0's class parity (#4744): the printed class set must EQUAL
       # `class-probe classify`'s. The harness landed with #4730's fix and then ran nowhere for a
@@ -640,8 +640,8 @@ jobs:
       # being unable to fail. Its own falsifiability is asserted in-file (three mutants, each
       # required to red for its intended reason) and its scope is counted, so a deleted case reds
       # rather than printing a vacuous OK. Hermetic: gh is stubbed, no network.
-      # Same script runs locally: `bash .claude/skills/ship-it/scripts/verify-step0-class-parity.sh`.
-      - run: bash .claude/skills/ship-it/scripts/verify-step0-class-parity.sh
+      # Same script runs locally: `bash claude-plugins/kampus-pipeline/skills/ship-it/scripts/verify-step0-class-parity.sh`.
+      - run: bash claude-plugins/kampus-pipeline/skills/ship-it/scripts/verify-step0-class-parity.sh
 
       # Executable pin for Step 3z's precondition (#4830): the one ship-it step that mutates a live
       # PR — close→reopen — must fire ONLY in the dropped-trigger state and refuse without touching
@@ -649,8 +649,8 @@ jobs:
       # caller's prose, and a mis-read branch close→reopened a green PR (#4816). The harness carries
       # its own mutant, so an assertion that stopped having teeth reds here rather than passing
       # quietly. Hermetic: gh and the CLI shim are stubbed, no network.
-      # Same script runs locally: `bash .claude/skills/ship-it/scripts/verify-step3z-precondition.sh`.
-      - run: bash .claude/skills/ship-it/scripts/verify-step3z-precondition.sh
+      # Same script runs locally: `bash claude-plugins/kampus-pipeline/skills/ship-it/scripts/verify-step3z-precondition.sh`.
+      - run: bash claude-plugins/kampus-pipeline/skills/ship-it/scripts/verify-step3z-precondition.sh
 
       # Executable pin for plan-epic's round-trip race detector (#4596): a CLEAN splice whose
       # `## Dependencies` block is the body's last section — the standard first-time layout —
@@ -658,8 +658,8 @@ jobs:
       # pre-fix diff reported "a racer clobbered it" on every clean deps-last write, so both
       # directions are pinned; greening the false alarm by loosening the block-level byte-exactness
       # would trade it for a silent miss. Hermetic: gh is stubbed, no network.
-      # Same script runs locally: `bash .claude/skills/plan-epic/scripts/verify-roundtrip-diff.sh`.
-      - run: bash .claude/skills/plan-epic/scripts/verify-roundtrip-diff.sh
+      # Same script runs locally: `bash claude-plugins/kampus-pipeline/skills/plan-epic/scripts/verify-roundtrip-diff.sh`.
+      - run: bash claude-plugins/kampus-pipeline/skills/plan-epic/scripts/verify-roundtrip-diff.sh
 
       # Positive pin for review-code's glossary-freshness detector (3) — a new public export on an
       # existing package entry point (#4700). It shipped born-dead: the awk regex would not compile,
@@ -670,8 +670,8 @@ jobs:
       # sibling class (#4986): three reads whose failure or empty result used to reach a clean skip,
       # each driven by the could-not-see state that produced it. Hermetic: gh, git and the CLI shim
       # are stubbed, no network.
-      # Same script runs locally: `bash .claude/skills/review-code/scripts/verify-glossary-detector-fires.sh`.
-      - run: bash .claude/skills/review-code/scripts/verify-glossary-detector-fires.sh
+      # Same script runs locally: `bash claude-plugins/kampus-pipeline/skills/review-code/scripts/verify-glossary-detector-fires.sh`.
+      - run: bash claude-plugins/kampus-pipeline/skills/review-code/scripts/verify-glossary-detector-fires.sh
 
       # Executable pin for triage's apply-triage wrapper (#4936): every argument it is given reaches
       # the verb, or it refuses non-zero having spawned the verb zero times. The wrapper took `-ge 3`
@@ -680,16 +680,17 @@ jobs:
       # deliberately holding. The assertions are on the verb's ARGV, not on a clean exit, because a
       # clean exit is what the defect already produced; five mutants keep them from going toothless.
       # Hermetic: the verb is a stub, no network, no issue mutated.
-      # Same script runs locally: `bash .claude/skills/triage/scripts/verify-apply-triage-args.sh`.
-      - run: bash .claude/skills/triage/scripts/verify-apply-triage-args.sh
+      # Same script runs locally: `bash claude-plugins/kampus-pipeline/skills/triage/scripts/verify-apply-triage-args.sh`.
+      - run: bash claude-plugins/kampus-pipeline/skills/triage/scripts/verify-apply-triage-args.sh
 
       # Gate-path drift guard (issue #720): assert the five CONTROL_PLANE_RE= copies
       # in ship-it/review-code/review-doc/review-skill/gh-issue-intake-formats are
-      # byte-identical to the §CP canonical line, and that .claude/skills resolves to
-      # marketplace.json's source + /skills. A rename of the plugin path otherwise
-      # silently breaks all gate checks with no build-time failure.
-      # Same script runs locally: `bash .claude/skills/validate-gate-path-drift.sh`.
-      - run: bash .claude/skills/validate-gate-path-drift.sh
+      # byte-identical to the §CP canonical line. A drifted copy otherwise silently
+      # breaks all gate checks with no build-time failure. Its second invariant — the
+      # `.claude/skills` symlink agreeing with marketplace.json — went with the symlink
+      # when v1 retired (ADR 0277).
+      # Same script runs locally: `bash claude-plugins/kampus-pipeline/skills/validate-gate-path-drift.sh`.
+      - run: bash claude-plugins/kampus-pipeline/skills/validate-gate-path-drift.sh
 
   # Reproducible workflow-YAML lint (issue #568). `.github/workflows/**` is the most
   # control-plane-sensitive, human-merged file class (ADR 0053), yet was validated

--- a/claude-plugins/kampus-pipeline/skills/validate-gate-path-drift.sh
+++ b/claude-plugins/kampus-pipeline/skills/validate-gate-path-drift.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
-# Mechanical drift guard for the §CP canonical regex and the .claude/skills symlink
-# (issue #720). Two invariants, both runnable in CI/locally:
+# Mechanical drift guard for the §CP canonical regex (issue #720). One invariant,
+# runnable in CI/locally:
 #
 #   1. CONTROL_PLANE_RE ↔ single-source const — the §CP boundary is now single-sourced
 #      as the CONTROL_PLANE_RE const in packages/pipeline-cli (issue #2761), emitted by
@@ -11,10 +11,10 @@
 #      diffs it against that one line — the residual drift guard for the last prose
 #      surface, no byte-compare of N hand-copies.
 #
-#   2. SYMLINK ↔ MARKETPLACE — .claude/skills must resolve to the same directory
-#      as marketplace.json's `source` field + /skills. Both express the same plugin
-#      root; divergence means the harness loads skills from a different tree than
-#      the one the marketplace advertises.
+# A second invariant used to assert that `.claude/skills` was a symlink resolving to
+# marketplace.json's source + /skills. That symlink is gone: v1's skill roster is retired
+# and the tree is loaded by nobody (ADR 0277, #5276). The invariant is removed rather than
+# rewritten — with no loader path there is no drift left to detect.
 #
 # The single source for invariant 1 is the pipeline-cli const (ADR 0073 §6; #2761): the
 # CLI emits it, this script diffs the formats-doc line against it — no copy re-hardcoded.
@@ -23,10 +23,10 @@
 # substitution with mapfile. Same self-locating idiom as validate-skills.sh.
 set -euo pipefail
 
-# `pwd -P` (physical) is load-bearing: this script is invoked via the `.claude/skills`
-# symlink (CI runs `bash .claude/skills/validate-gate-path-drift.sh`), so a logical `pwd`
-# would resolve skills_dir to the 2-level symlink path `.claude/skills` and `../../..` would
-# overshoot past the repo root. Physical resolution lands on the real 3-level plugin path.
+# `pwd -P` (physical) is kept though CI now invokes this at its real path: any caller that
+# still reaches the script through a symlink would otherwise resolve skills_dir to the link's
+# own depth and send `../../..` past the repo root. Physical resolution always lands on the
+# real 3-level plugin path.
 skills_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd -P)"
 repo_root="$(cd "$skills_dir/../../.." && pwd -P)"
 
@@ -182,51 +182,9 @@ EOF
 	ok "$name copies across the corpus match the single-source const"
 done
 
-# Invariant 2: .claude/skills symlink agrees with marketplace source.
-#
-# .claude/skills -> ../claude-plugins/kampus-pipeline/skills
-# marketplace.json source -> ./claude-plugins/kampus-pipeline
-# Invariant: resolved(.claude/skills) == resolved(marketplace source)/skills
-SYMLINK="$repo_root/.claude/skills"
-MARKETPLACE="$repo_root/.claude-plugin/marketplace.json"
-
-if [ ! -L "$SYMLINK" ]; then
-	fail ".claude/skills is not a symlink (expected: symlink into the plugin skills dir)"
-else
-	ok ".claude/skills is a symlink"
-
-	# Resolve the symlink to an absolute path
-	SYMLINK_RESOLVED=$(cd "$(dirname "$SYMLINK")" && cd "$(readlink "$SYMLINK")" && pwd || true)   # || true: a broken target yields empty → drift-fail below, never a set -e abort
-
-	if [ ! -f "$MARKETPLACE" ]; then
-		fail ".claude-plugin/marketplace.json not found — cannot verify symlink ↔ marketplace agreement"
-	else
-		# Extract source field (bash 3.2: grep + sed, no python/jq required)
-		MP_SOURCE=$(grep '"source"' "$MARKETPLACE" | head -n1 \
-			| sed 's/.*"source"[[:space:]]*:[[:space:]]*"\([^"]*\)".*/\1/' || true)   # || true: no-match → empty → fail below, not a set -e abort
-		if [ -z "$MP_SOURCE" ]; then
-			fail "marketplace.json: no \"source\" field found in plugins entry"
-		else
-			# Resolve marketplace source to absolute path, then append /skills
-			if ! MP_SOURCE_RESOLVED=$(cd "$repo_root" && cd "$MP_SOURCE" && pwd) 2>/dev/null; then
-				fail "marketplace.json source \"$MP_SOURCE\" does not resolve to a directory"
-			else
-				EXPECTED_SYMLINK="$MP_SOURCE_RESOLVED/skills"
-				if [ "$SYMLINK_RESOLVED" = "$EXPECTED_SYMLINK" ]; then
-					ok ".claude/skills symlink agrees with marketplace source ($MP_SOURCE + /skills)"
-				else
-					fail ".claude/skills symlink has drifted from marketplace source
-  symlink resolves to: $SYMLINK_RESOLVED
-  marketplace expects: $EXPECTED_SYMLINK (source=\"$MP_SOURCE\" + /skills)"
-				fi
-			fi
-		fi
-	fi
-fi
-
 if [ "$errors" -gt 0 ]; then
 	echo "validate-gate-path-drift: FAILED — $errors error(s); gate-path invariants are broken (issue #720)"
 	exit 1
 fi
 
-echo "validate-gate-path-drift: OK — $checks checks; CONTROL_PLANE_RE copies and symlink agree with §CP / marketplace"
+echo "validate-gate-path-drift: OK — $checks checks; CONTROL_PLANE_RE copies agree with the §CP single-source const"


### PR DESCRIPTION
Retires the v1 skill roster in one commit: both tracked `.claude` symlinks go, and everything that loaded through them is repointed at the real plugin path in the same change.

Founder-ruled 2026-08-14 that the two halves — the skills half (#5276) and the agents half (#5537) — land as a single pull request. Both triggers had fired: milestone 44 closed for the skills half, and the founder's crew stand-down at shape "full stop" for the agents half. ADR 0253/0255 ban a half-cutover, so the split had nothing left to buy. #5537 says on its own face that it closes when this PR lands.

## What changed

- Deleted `.claude/skills` and `.claude/agents`.
- Kept `.claude/.pipeline` — a literal path alias, not a loader path (ADR 0255 §5).
- Repointed the ten `- run:` steps in `ci.yml`'s `skills` job from `bash .claude/skills/…` to `bash claude-plugins/kampus-pipeline/skills/…`, plus the thirteen comment lines in the same job that quote those paths. Nine of those were `Same script runs locally:` hints aimed at a path this commit deletes.
- Dropped invariant 2 of `claude-plugins/kampus-pipeline/skills/validate-gate-path-drift.sh` — it asserted `.claude/skills` *is* a symlink and hard-failed otherwise, so its subject no longer exists. Invariant 1 (the `CONTROL_PLANE_RE` single-source compare and its 1b/1c/1d generalizations) is untouched and still enforced: the script prints 32 ok-checks and exits 0 on this head.
- Added an execution record to ADR 0277's `## Records`, discharging #5537's third acceptance criterion.

Atomic on purpose. The symlink deletion and the `ci.yml` repoint cannot be separate PRs — `validate skill frontmatter` is a required status check with no path filter, so any interval between them reds every open PR in the repo.

## The suppression line is KEPT, deliberately

`"kampus-pipeline@kampus": false` at `.claude/settings.json:4` is **not** removed, and its absence from the diff is a decision rather than an oversight.

ADR 0077's final consequence bullet instructs that dropping the symlink obliges removing the suppression in the same change, and ADR 0255 restates that at four sites. ADR 0277 (`bfcb1c02`) reverses exactly that instruction, on a direct founder ruling recorded at #5532: 0077 assumed the published plugin was the source we still wanted to take over. Under a full stop we do not want it. Removing the line would re-enable the whole v1 roster on any machine where `kampus-pipeline@kampus` is installed at user scope — a namespace change, not a retirement.

`.claude/settings.json` is therefore not modified at all: the suppression stays and the nine `kampus-pipeline` hook entries are untouched.

## Scope

The ten scripts are v1's own CI guards and they keep running from their real path. Retiring them is a separate ticket with its own threat model — founder-ruled "keep it scoped", same posture ADR 0238 takes toward `packages/pipeline-cli/`. No job is added, removed, reordered, or given a path filter.

Doc references to `.claude/skills` in `DEVELOPMENT.md`, `CLAUDE.md`, `design-system-manifest.md` and `.patterns/` are out of scope — #5275 / #4761 / #4762. Those break links, never builds.

## Verification

All ten scripts run green in this tree at their new paths, and `actionlint` passes on `ci.yml`.

Fixes #5276

## Deviations

- **Guard or gate bypassed** — **Said:** validate the tree with `fabrika build check --surface
  code`. **Did:** ran `--surface prose`, which is green, and left four files unvalidated by any
  fabrika verdict — the two symlinks, `ci.yml`, and the guard script. **Why:** the diff changes no
  file the code surface counts as code; its surfaces are YAML, shell and markdown, so
  `--surface code` refuses as provably wrong. **Disposition:** those four are covered instead by
  running all ten skills-job scripts in-tree, by `actionlint` on `ci.yml`, and by the `skills` job
  itself on this head.
- **Known defect left unfixed** — **Said:** read the acceptance criteria off `fabrika build issue`.
  **Did:** read the criteria of #5276 and #5537 by hand from the issue bodies, and left the heading
  levels alone. **Why:** both issues write the criteria block at heading level 2 where the verb
  expects level 3, so it returns `criteria: malformed` and no list. **Disposition:** every criterion
  was still worked; #5565 tracks the heading, and its fix is not this PR's.
- **Out-of-scope change** — **Said:** repoint the `skills` job's `.claude/skills/…` paths to the
  real plugin path. **Did:** rewrote three comment passages outright instead of substituting the
  path, one of which was already false before this PR. **Why:** a substitution would have left each
  passage stating something untrue — line 617 described the lib as reached at its real path "rather
  than a `.claude/skills/…` symlink hop"; the drift-guard comment block described invariant 2, which
  this PR removes; and that block's opening sentence claimed the guard byte-compares "the five
  `CONTROL_PLANE_RE=` copies in ship-it/review-code/review-doc/review-skill/gh-issue-intake-formats",
  which has been false since #2761/#981 — the gate skills carry no copy, the script reads the const
  through `pipeline-cli control-plane-paths` and diffs it against the one un-importable copy in
  `gh-issue-intake-formats.md`. **Disposition:** the opening sentence now states what the script
  actually does, read off the script at head; the false claim predates this PR but sat inside the
  same comment block this PR rewrote, which is the standard the rest of this entry sets.
- **Guard or gate bypassed** — **Said:** claim the repair lane through `fabrika build claim`, which
  enforces the declared campaign focus. **Did:** claimed #5599 with `build claim --override`,
  recording the reason and the lane on the marker. **Why:** `## Focus` declares milestone #45 and a
  pull request carries no milestone at all, so the scope fence refuses every repair-mode claim at
  exit `20` while any focus is declared; the operator dispatched this PR by number for this repair
  round. The work is in focus on the axis the fence means to test — the issue this branch serves,
  #5276, is homed on milestone #45 and claims cleanly. **Disposition:** the override and its reason
  are on the claim marker; nothing else about the fence was touched, and #5562 already tracks the
  fence's blindness to pull requests.

## Repair round 1

Rewrote this `## Deviations` section into the four-field wire format — the one blocking finding all
three text gates named at `af8e742e`. The entries say what they said before; only their shape
changed. The one code change in this round is the drift-guard comment correction described in the
third entry above.

