### PR TITLE
The review agent shell shipped without its spawn tool, so it cannot fire governance

### DIFF
--- a/claude-plugins/fabrika/agents/review.md
+++ b/claude-plugins/fabrika/agents/review.md
@@ -2,7 +2,7 @@
 name: review
 description: Spawn target for the fabrika `review` skill — the text-review gate. Use it when a driver needs a subagent that judges one PR's textual artifacts against its linked issue and lands the SHA-bound verdicts. It carries no behaviour of its own; everything it does comes from the preloaded skill.
 skills: ["fabrika:review"]
-tools: ["Bash", "Read", "Grep", "Glob", "Skill"]
+tools: ["Bash", "Read", "Grep", "Glob", "Skill", "Agent"]
 effort: high
 ---
 

--- a/claude-plugins/fabrika/agents/ship.md
+++ b/claude-plugins/fabrika/agents/ship.md
@@ -2,7 +2,7 @@
 name: ship
 description: Spawn target for the fabrika `ship` skill — the merge authority. Use it when a driver needs a subagent that walks one verified PR's guard chain, enqueues it, and reconciles the terminal outcome. It carries no behaviour of its own; everything it does comes from the preloaded skill.
 skills: ["fabrika:ship"]
-tools: ["Bash", "Read", "Grep", "Glob", "Skill"]
+tools: ["Bash", "Read", "Grep", "Glob"]
 effort: high
 ---
 

--- a/claude-plugins/fabrika/docs/agent-shells.md
+++ b/claude-plugins/fabrika/docs/agent-shells.md
@@ -56,7 +56,8 @@ emit that namespace yourself. Without a spawn tool the shell derives that requir
 dead-ends, leaving the PR with a governance check nothing in the run can clear. The grant only lets
 the shell obey an instruction it already carried. Founder ruling of 2026-08-14 on
 [#5558](https://github.com/kamp-us/phoenix/issues/5558), verbatim *"yeah, review shell carries the
-spawn tool"*, recorded as ADR 0280.
+spawn tool"*. Its decision record, ADR 0280, is in flight on
+[#5604](https://github.com/kamp-us/phoenix/pull/5604) and is not in `.decisions/` yet.
 
 `build` and `ship` get no spawn tool: neither skill invokes another agent. `ship` routes by writing
 a `ship note` and stopping, so it holds no `Skill` grant either.

--- a/claude-plugins/fabrika/docs/agent-shells.md
+++ b/claude-plugins/fabrika/docs/agent-shells.md
@@ -38,9 +38,36 @@ nobody can reproduce from its skill text. Repo knowledge belongs in
 `model:` is either absent or exactly one of `claude-opus-4-8` / `claude-opus-4-8[1m]` —
 `ALLOWLIST` in [`packages/fabrika-cli/src/models.ts`](../../../packages/fabrika-cli/src/models.ts).
 `decideSpawn` in [`packages/fabrika-cli/src/hook/spawn.ts`](../../../packages/fabrika-cli/src/hook/spawn.ts)
-denies an explicit off-allowlist model unconditionally, and no pin overrides that deny; an unset
-`model` takes the inherit branch and passes. All three shells today leave it unset, so a spawn runs
-on the caller's own model.
+denies an explicit off-allowlist model unconditionally, and no pin overrides that deny. An unset
+`model` reaches the inherit branch **only when the effective pin is itself allowlisted** — the
+`AllowInherit` return sits inside `if (isAllowlisted(effectivePin))`, so a `WORKFLOW_MODEL` that is
+present but off the allowlist denies an unset request too (with `explicit: false`). An absent pin
+resolves to the committed default, which is allowlisted, so an unset `model` passes on a machine
+that never exported `WORKFLOW_MODEL`. All three shells today leave it unset, so a spawn runs on the
+caller's own model whenever the pin is sane.
+
+## Only the review shell carries a spawn tool
+
+`review` is the one shell whose `tools:` includes the harness spawn tool, `Agent`. That is a tool
+grant and nothing more: the behaviour stays in
+[`../skills/review/SKILL.md`](../skills/review/SKILL.md) §6, which makes the `governance` namespace
+**derived-required** on a `harness: true` diff — fire the `governance` skill, wait for it, and never
+emit that namespace yourself. Without a spawn tool the shell derives that requirement mid-run and
+dead-ends, leaving the PR with a governance check nothing in the run can clear. The grant only lets
+the shell obey an instruction it already carried. Founder ruling of 2026-08-14 on
+[#5558](https://github.com/kamp-us/phoenix/issues/5558), verbatim *"yeah, review shell carries the
+spawn tool"*, recorded as ADR 0280.
+
+`build` and `ship` get no spawn tool: neither skill invokes another agent. `ship` routes by writing
+a `ship note` and stopping, so it holds no `Skill` grant either.
+
+Write the tool's canonical name, `Agent` — the `name` on the spawn tool in the Claude Code 2.1.233
+bundle, which also carries `aliases: ["Task"]`. Both strings grant the tool (a shell built with
+`"Task"` reported `Agent` available), so `Agent` is a house choice, not the only one that works.
+
+Prove a grant by spawning, never by the file parsing: a `tools:` entry the harness does not
+recognise drops with no warning and no non-zero exit. A shell whose `tools:` named `SpawnAgent`
+loaded cleanly and reported exactly the tools it would have had without the entry.
 
 ## Fields a plugin-scope shell may not use
 


### PR DESCRIPTION
The `review` agent shell landed on `main` with no agent-spawn tool, so it could not fire the
`governance` gate its own skill (§6) makes derived-required on any governance-root diff. That is
every change to fabrika's own tree. This adds the tool, plus the two smaller defects that landed
with it in #5600.

## What changed

- `claude-plugins/fabrika/agents/review.md` — `tools:` gains `"Agent"`.
- `claude-plugins/fabrika/agents/ship.md` — `tools:` drops `"Skill"`.
- `claude-plugins/fabrika/docs/agent-shells.md` — the model-allowlist clause now matches
  `decideSpawn`, and a new section records the review shell's spawn-tool grant.

## How the tool name was established

Read out of the installed Claude Code 2.1.233 bundle, not guessed. The spawn tool's definition
object binds `name: li` with `aliases: [FU]`, and the surrounding minified source declares
`li = "Agent", FU = "Task"`. So `Agent` is the canonical registered name and `Task` is its alias.
The house choice is the canonical one.

## What the proving spawn did

Three runs of `claude --plugin-dir <this branch's plugin> --agent review -p …`, each a real spawn of
the review shell, each asked to enumerate its own tools:

1. **`tools:` with `"Agent"`** (what this PR ships) — reported `Bash, Read, Grep, Glob, Skill,
   Agent`, then actually called the spawn tool on a general-purpose subagent and printed back the
   `PONG` it returned. The grant is live, not just parsed.
2. **`tools:` with `"Task"` instead** — also reported `Agent` available. The alias resolves for a
   `tools:` narrowing too, so both strings work; the doc says so rather than claiming `Agent` is the
   only one that functions.
3. **`tools:` with `"SpawnAgent"`, an invented name** — loaded cleanly, no warning, no non-zero
   exit, and reported exactly the tools it would have had with the entry absent. This is the trap
   the issue named, reproduced: a wrong name is silent.

## The ship shell's `Skill` grant

Dropped rather than justified. Every route in `claude-plugins/fabrika/skills/ship/SKILL.md` is a
note-and-stop — §3 reads *"route to the gate that owns it … and stop"*, and its repair and heal-ci
routes are the same shape. No line in that skill invokes another skill, so the grant was wider than
the skill's own text. The `skills:` preload is untouched; it is a different mechanism from the
`Skill` tool.

## Deviations

- **Proving spawn substituted** — **Said:** The acceptance criteria ask that the grant be proven by
  a spawn that fires the `governance` skill and returns. **Did:** Proved it with a spawn that called
  the tool on a general-purpose subagent and returned its reply, plus two control runs (alias,
  invented name) that isolate what the grant is doing. **Why:** A real `governance` run needs a PR to
  bind its verdict to, and this PR did not exist when the shell had to be proven. Firing that gate
  against an unrelated PR would have posted a verdict nobody asked for. What the criterion is
  testing — whether the shell can actually spawn — is what the substitute proves, and the controls
  prove more: without the entry there is no `Agent` tool, and a wrong entry is indistinguishable from
  no entry. **Disposition:** Discharged at round 1. A `review`-shell spawn fired `fabrika:governance`
  on this PR's head and it returned a PASS bound to `65d28e27` (comment `5303737175`). The
  substitution stands disclosed and the criterion is met as written.
- **Repair claimed with an explicit override** — **Said:** `build` repair mode claims the PR number
  before it touches the lane. **Did:** `fabrika build claim 5613` refused on exit 20, out of focus, so
  the claim was retaken with `--override --override-lane repair`. **Why:** A pull request carries no
  milestone, so the scope axis reads every PR number as homeless; the issue this PR serves, #5608, is
  on milestone #45, the declared focus. There is no route around the claim — `build branch --resume`
  and `requireLane` both key off it. **Disposition:** The refusal is the milestone-less-PR gap already
  tracked on #5562, noted there again with this recurrence; the override reason is on the claim
  marker. Nothing about this PR's scope changed.

Fixes #5608

