### PR TITLE
fabrika build repair mode cannot repair a PR body's Deviations section, and its claim refuses an out-of-focus PR number

### DIFF
--- a/claude-plugins/fabrika/skills/build/contract.md
+++ b/claude-plugins/fabrika/skills/build/contract.md
@@ -171,8 +171,11 @@ chosen.
   #<n>`, the same reference `review scope` reads — and **both** axes then read that issue. A PR whose
   body names no readable issue is `refused: no-served-issue` under a declared focus (`20`, and
   overridable like any scope refusal): the fence cannot judge a ticket nobody named, and admitting it
-  would let a lane past the focus by omitting one line from a body. While the fence is inert there is
-  nothing to refuse on, so an unresolvable PR falls back to its own record.
+  would let a lane past the focus by omitting one line from a body. **The resolution runs whether or
+  not a focus is declared** — the audience axis reads the served issue either way — and only the
+  scope refusal is gated on a declaration: while the fence is inert a PR naming no readable issue
+  falls back to its own record instead of refusing. A served issue that **cannot be read** is
+  `unknown` at either setting (`11`, and not overridable), which is the `unknown` row below.
 - **The issue's home** — the number of the open milestone the issue is homed in, as a string; or, for
   an issue carrying a standing-lane label, that label.
 - **The issue's audience** — its `ready-for:` label.

--- a/claude-plugins/fabrika/skills/build/contract.md
+++ b/claude-plugins/fabrika/skills/build/contract.md
@@ -164,17 +164,27 @@ chosen.
   present-but-empty table are the same well-formed default** — no focus is declared. More than one
   data row, a milestone cell that is not `#<int>`, or a date that is not ISO is **malformed** (`4`),
   and malformed is never read as "no focus".
+- **The subject** — *which* record the two axes read. An issue is its own subject. A **pull request
+  is not**: it carries no milestone and no `ready-for:` label, so a test reading the PR's own record
+  refused every repair claim while any focus was declared ([#5562](https://github.com/kamp-us/phoenix/issues/5562)).
+  A PR resolves to the issue its lane serves — the first closing keyword in its body, else `Part of
+  #<n>`, the same reference `review scope` reads — and **both** axes then read that issue. A PR whose
+  body names no readable issue is `refused: no-served-issue` under a declared focus (`20`, and
+  overridable like any scope refusal): the fence cannot judge a ticket nobody named, and admitting it
+  would let a lane past the focus by omitting one line from a body. While the fence is inert there is
+  nothing to refuse on, so an unresolvable PR falls back to its own record.
 - **The issue's home** — the number of the open milestone the issue is homed in, as a string; or, for
   an issue carrying a standing-lane label, that label.
 - **The issue's audience** — its `ready-for:` label.
 
-**The four outcomes — state words, never a boolean.** The admission test returns exactly one across
+**The outcomes — state words, never a boolean.** The admission test returns exactly one across
 both axes, and every refusal carries its reason and names which axis refused:
 
 | Outcome | Trigger | Seat |
 |---|---|---|
 | `admitted` | a focus is declared and the issue's home is that milestone; or the issue carries a standing-lane label; or no focus is declared | kept in the pool · the claim proceeds |
 | `refused: out-of-focus` | a focus is declared, the issue's home is some other milestone or no milestone, and no standing-lane label exempts it | `20` |
+| `refused: no-served-issue` | a focus is declared and the target is a pull request whose body names no readable issue — neither a closing keyword nor `Part of #<n>`, or one naming an issue proven absent | `20` |
 | `refused: audience-not-agent` | the issue carries a `ready-for:` label other than `ready-for:agent`, or carries none at all — absence is an unknown audience, never an agent audience (#4780) | `21` |
 | `unknown` | the declaration or the issue's home could not be read (`11`), or the declaration is malformed (`4`) | `11` / `4` |
 
@@ -606,7 +616,9 @@ fabrika build release 4312 [--repo <owner/name>]
 **`claim` runs the fence before it writes anything.** After the target-open check and **before
 any marker is posted**, `claim` puts `<number>` through the
 [admission test](#admission-test--scope-admission-and-the-audience-axis) — the same imported
-module `build pick` filters on, both axes, never a second derivation. A `refused: out-of-focus` is
+module `build pick` filters on, both axes, never a second derivation. In repair, `<number>` is a PR,
+and the test judges the issue that PR serves rather than the PR's own empty home — a PR naming no
+readable issue is `refused: no-served-issue` at `20`. A `refused: out-of-focus` is
 `20` and a
 `refused: audience-not-agent` is `21`, each named on stderr; an unreadable declaration or home is
 `11` and a malformed declaration is `4`, and neither ever proceeds. Nothing is written on any of the

--- a/packages/fabrika-cli/src/build/claim-verb.ts
+++ b/packages/fabrika-cli/src/build/claim-verb.ts
@@ -18,7 +18,8 @@
  * The fence decides what may *start* (ADR 0245), so a focus row edited mid-lane must not strand a
  * running lane or block its release. Claiming is the one moment every path goes through — a number
  * handed straight to `claim` passes through no pool — which is why the refusal has teeth here and is
- * advice at the pool.
+ * advice at the pool. In repair the number is a **PR**, which carries no home and no audience of its
+ * own, so the test runs over the issue that PR serves (#5562).
  */
 import {Effect, type FileSystem} from "effect";
 import type {ChildProcessSpawner} from "effect/unstable/process";
@@ -51,7 +52,7 @@ import {
 	purposeScopeLine,
 	readDeclaredFocus,
 } from "./scope-admission.ts";
-import {openIssue, resolveTargetRepo} from "./target.ts";
+import {openIssue, resolveAdmissionSubject, resolveTargetRepo} from "./target.ts";
 
 export interface ClaimOptions {
 	readonly number: number;
@@ -178,18 +179,30 @@ export const runClaim = (
 			);
 		}
 		const scopeLine = focusScopeLine(CLAIM, read.focus);
-		const purposeLine = purposeScopeLine(CLAIM, purpose, audienceAxisOf(ready.issue));
-		const admission = admissionOf(read.focus, ready.issue, purpose);
+		const subject = yield* resolveAdmissionSubject(CLAIM, repo, read.focus, ready.issue);
+		const judged = subject._tag === "Judged" ? subject.facts : ready.issue;
+		const purposeLine = purposeScopeLine(CLAIM, purpose, audienceAxisOf(judged));
+		const admission =
+			subject._tag === "Judged"
+				? admissionOf(read.focus, subject.facts, purpose)
+				: subject.admission;
+		const lines = [
+			scopeLine,
+			...(subject._tag === "Judged" && subject.note !== null ? [subject.note] : []),
+			purposeLine,
+		];
 		const refusal = admissionRefusal(CLAIM, admission);
 		// An override answers a PROVEN refusal. UNKNOWN has proven nothing, so there is nothing to
 		// override — a fence that could not read its input must not be talked past by a flag.
-		const overridable = admission._tag === "OutOfFocus" || admission._tag === "AudienceNotAgent";
+		const overridable =
+			admission._tag === "OutOfFocus" ||
+			admission._tag === "AudienceNotAgent" ||
+			admission._tag === "NoServedIssue";
 		if (refusal !== null && !(overridable && override !== null)) {
 			return {
 				...refusal,
 				stderr: [
-					scopeLine,
-					purposeLine,
+					...lines,
 					...refusal.stderr,
 					`${CLAIM}: nothing was written — #${number} carries no marker from this run${
 						overridable
@@ -221,8 +234,7 @@ export const runClaim = (
 		// The checkpoint: posting DETECTS a race, this re-read RESOLVES it.
 		const {ownership, unauthorized} = yield* resolveOwnership(repo, number, session);
 		const notes = [
-			scopeLine,
-			purposeLine,
+			...lines,
 			...unauthorized.map(
 				(marker) =>
 					`${CLAIM}: comment ${marker.commentId} carries a claim marker from "${marker.author}", who holds no write permission — counted, never a winner.`,

--- a/packages/fabrika-cli/src/build/claim-verb.unit.test.ts
+++ b/packages/fabrika-cli/src/build/claim-verb.unit.test.ts
@@ -563,6 +563,48 @@ describe("runClaim — a PR number is judged by the issue it serves", () => {
 		);
 		expect(out.code).toBe(0);
 	});
+
+	/**
+	 * The no-focus half, under the DEFAULT `build` purpose — the one that binds the audience axis, and
+	 * so the one that reads whichever record the resolution returned.
+	 */
+	describe("with no focus declared", () => {
+		const claimInert = (body: string, servedRecord: ExecResult | null) => {
+			const shell = fakeShell([
+				[ISSUE, pull(body)],
+				...(servedRecord === null
+					? []
+					: ([[SERVED, servedRecord]] as ReadonlyArray<readonly [RegExp, ExecResult]>)),
+				[POST, POSTED],
+				[GET_COMMENT, ECHO],
+				[COMMENTS, comments({id: 9001, body: MINE})],
+				[perm("agent"), okOut("write\n")],
+			]);
+			return Effect.runPromise(
+				Effect.provide(runClaim(options), Layer.merge(shell.layer, NO_FOCUS.layer)),
+			).then((out) => ({out, shell}));
+		};
+
+		it("resolves a served issue anyway, so the audience axis reads it and the claim is won", async () => {
+			const {out} = await claimInert("Fixes #5553\n", served(null));
+			expect(out.code).toBe(0);
+			expect(out.stderr.some((line) => line.includes("PR #4312 serves #5553 (fixes)"))).toBe(true);
+			expect(out.stderr.some((line) => line.includes("scope fence inert"))).toBe(true);
+		});
+
+		it("leaves an unserved PR on its own record, audience and all — the pre-#5562 answer", async () => {
+			const {out, shell} = await claimInert("No reference at all.\n", null);
+			expect(out.code).toBe(AUDIENCE_NOT_AGENT);
+			expect(shell.calls.some((line) => POST.test(line))).toBe(false);
+			expect(out.stderr.some((line) => line.includes("serves #"))).toBe(false);
+		});
+
+		it("still refuses at 11 when the served issue cannot be read — an inert fence does not soften UNKNOWN", async () => {
+			const {out, shell} = await claimInert("Fixes #5553\n", errOut("gh: Bad gateway (HTTP 502)"));
+			expect(out.code).toBe(PRECONDITION_UNKNOWN);
+			expect(shell.calls.some((line) => POST.test(line))).toBe(false);
+		});
+	});
 });
 
 /**

--- a/packages/fabrika-cli/src/build/claim-verb.unit.test.ts
+++ b/packages/fabrika-cli/src/build/claim-verb.unit.test.ts
@@ -411,6 +411,161 @@ describe("runClaim — the admission test runs before any marker is written", ()
 });
 
 /**
+ * Repair claims a PR number, and a PR carries no milestone and no `ready-for:` label of its own — so
+ * while any focus was declared the fence refused every one of them (#5562). The subject the two axes
+ * read is the issue the PR's lane serves.
+ */
+describe("runClaim — a PR number is judged by the issue it serves", () => {
+	const FOCUSED = fakeFs({files: {[DEFAULT_ROADMAP]: focusTable(44)}});
+	const SERVED = /^gh api repos\/o\/r\/issues\/5553$/;
+
+	const pull = (body: string) =>
+		issue({
+			title: "fix(build): the repair lane",
+			body,
+			labels: [],
+			milestone: null,
+			pull_request: {url: "https://api.github.com/repos/o/r/pulls/4312"},
+		});
+
+	const served = (
+		milestone: number | null,
+		labels = labelled("status:triaged", "ready-for:agent"),
+	) =>
+		okOut(
+			JSON.stringify({
+				number: 5553,
+				title: "The ticket the lane serves",
+				body: "## Acceptance criteria\n",
+				state: "open",
+				labels,
+				html_url: "https://github.com/o/r/issues/5553",
+				milestone: milestone === null ? null : {number: milestone},
+				state_reason: null,
+			}),
+		);
+
+	const claimPull = (
+		body: string,
+		servedRecord: ExecResult,
+		overrides: Partial<typeof options> = {},
+	) => {
+		const shell = fakeShell([
+			[ISSUE, pull(body)],
+			[SERVED, servedRecord],
+			[POST, POSTED],
+			[GET_COMMENT, ECHO],
+			[COMMENTS, comments({id: 9001, body: MINE})],
+			[perm("agent"), okOut("write\n")],
+		]);
+		return Effect.runPromise(
+			Effect.provide(runClaim({...options, ...overrides}), Layer.merge(shell.layer, FOCUSED.layer)),
+		).then((out) => ({out, shell}));
+	};
+
+	it("admits a PR whose served issue is in focus, with no override", async () => {
+		const {out} = await claimPull("Fixes #5553\n", served(44));
+		expect(out.code).toBe(0);
+		expect(JSON.parse(out.stdout).answer).toBe("won");
+		expect(out.stderr.some((line) => line.includes("PR #4312 serves #5553 (fixes)"))).toBe(true);
+	});
+
+	it("reads Part of #<n> too — the partial-PR shape build --partial emits", async () => {
+		const {out} = await claimPull("Part of #5553\n", served(44));
+		expect(out.code).toBe(0);
+		expect(out.stderr.some((line) => line.includes("serves #5553 (part-of)"))).toBe(true);
+	});
+
+	it("still refuses at 20 when the served issue is genuinely out of focus, and posts NOTHING", async () => {
+		const {out, shell} = await claimPull("Fixes #5553\n", served(39));
+		expect(out.code).toBe(OUT_OF_FOCUS);
+		expect(shell.calls.some((line) => POST.test(line))).toBe(false);
+		expect(out.stderr.some((line) => line.includes("out of focus"))).toBe(true);
+		expect(out.stderr.some((line) => line.includes("this issue's home is 39"))).toBe(true);
+	});
+
+	it("keeps that refusal overridable", async () => {
+		const {out} = await claimPull("Fixes #5553\n", served(39), {
+			override: "repairing a landed FAIL",
+			overrideLane: "build",
+		});
+		expect(out.code).toBe(0);
+		expect(JSON.parse(out.stdout).answer).toBe("won");
+	});
+
+	it("refuses a PR naming no issue at 20, saying which case fired — and stays overridable", async () => {
+		const body = "A conversation-authored ADR.\n\n## Deviations\nNone.\n";
+		const {out, shell} = await claimPull(body, served(44));
+		expect(out.code).toBe(OUT_OF_FOCUS);
+		expect(shell.calls.some((line) => POST.test(line))).toBe(false);
+		expect(out.stderr.some((line) => line.includes("no served issue"))).toBe(true);
+		const overridden = await claimPull(body, served(44), {
+			override: "no ticket — the ADR was authored in conversation",
+			overrideLane: "build",
+		});
+		expect(overridden.out.code).toBe(0);
+	});
+
+	it("refuses at 20 when the named issue is proven absent — never on the PR's own empty home", async () => {
+		const {out} = await claimPull("Fixes #5553\n", errOut("gh: Not Found (HTTP 404)"));
+		expect(out.code).toBe(OUT_OF_FOCUS);
+		expect(out.stderr.some((line) => line.includes("proven absent"))).toBe(true);
+	});
+
+	it("refuses at 11 when the served issue cannot be read — UNKNOWN, never admitted", async () => {
+		const {out, shell} = await claimPull("Fixes #5553\n", errOut("gh: Bad gateway (HTTP 502)"));
+		expect(out.code).toBe(PRECONDITION_UNKNOWN);
+		expect(shell.calls.some((line) => POST.test(line))).toBe(false);
+	});
+
+	it("judges the audience on the served issue too, so a repair lane is not refused at 21", async () => {
+		const {out} = await claimPull(
+			"Fixes #5553\n",
+			served(44, labelled("status:triaged", "ready-for:agent")),
+		);
+		expect(out.code).toBe(0);
+		expect(out.stderr.some((line) => line.includes("this issue carries ready-for:agent"))).toBe(
+			true,
+		);
+	});
+
+	it("leaves an issue target reading its own record — the resolution never fires on one", async () => {
+		const shell = fakeShell([
+			[
+				ISSUE,
+				issue({milestone: {number: 44}, labels: labelled("status:triaged", "ready-for:agent")}),
+			],
+			[POST, POSTED],
+			[GET_COMMENT, ECHO],
+			[COMMENTS, comments({id: 9001, body: MINE})],
+			[perm("agent"), okOut("write\n")],
+		]);
+		const out = await Effect.runPromise(
+			Effect.provide(runClaim(options), Layer.merge(shell.layer, FOCUSED.layer)),
+		);
+		expect(out.code).toBe(0);
+		expect(out.stderr.some((line) => line.includes("serves #"))).toBe(false);
+	});
+
+	it("admits an unresolvable PR while no focus is declared — an inert fence refuses nothing", async () => {
+		const shell = fakeShell([
+			[ISSUE, pull("No reference at all.\n")],
+			[POST, POSTED],
+			[GET_COMMENT, ECHO],
+			[COMMENTS, comments({id: 9001, body: MINE})],
+			[perm("agent"), okOut("write\n")],
+		]);
+		const out = await Effect.runPromise(
+			Effect.provide(
+				runClaim({...options, purpose: "gate"}),
+				Layer.merge(shell.layer, NO_FOCUS.layer),
+			),
+		);
+		expect(out.code).toBe(0);
+	});
+});
+
+/**
  * The purpose axis (#5175): the audience fence binds a build claim only.
  *
  * The epic below is the census shape the ruling rests on — homed in the campaign, `type:epic`, and

--- a/packages/fabrika-cli/src/build/scope-admission.ts
+++ b/packages/fabrika-cli/src/build/scope-admission.ts
@@ -21,6 +21,7 @@
  */
 import {Effect, type FileSystem, Result} from "effect";
 import {exists, type ReadFailed, readFile} from "../io/fs.ts";
+import {issueRefOf} from "../review/classes.ts";
 import {refuse, type VerbOutcome} from "../verb.ts";
 import {AUDIENCE_NOT_AGENT, BAD_SECTIONS, OUT_OF_FOCUS, PRECONDITION_UNKNOWN} from "./codes.ts";
 
@@ -49,6 +50,35 @@ export interface IssueFacts {
 	readonly labels: ReadonlyArray<string>;
 	readonly milestone: number | null;
 }
+
+/** What a subject read needs off the target — the PR/issue split, and the body the link lives in. */
+export interface SubjectFacts {
+	readonly isPullRequest: boolean;
+	readonly body: string;
+}
+
+/**
+ * Whose home the admission test judges.
+ *
+ * An issue is its own subject. A pull request is not: it carries no milestone and no `ready-for:`
+ * label, so a fence reading the PR's own record refused **every** repair claim while any focus was
+ * declared (#5562). A PR's lane serves a ticket, and that ticket's home is the campaign membership
+ * the fence is actually asking about — so the PR resolves to it, through the same body reference
+ * `review scope` reads (`issueRefOf`), never a second parser.
+ */
+export type ScopeSubject =
+	| {readonly _tag: "Own"}
+	| {readonly _tag: "Served"; readonly number: number; readonly kind: "fixes" | "part-of"}
+	/** A PR whose body names no issue at all — there is nothing to resolve to. */
+	| {readonly _tag: "Unserved"};
+
+export const scopeSubjectOf = (target: SubjectFacts): ScopeSubject => {
+	if (!target.isPullRequest) return {_tag: "Own"};
+	const ref = issueRefOf(target.body);
+	return ref.kind === "none" || ref.number === null
+		? {_tag: "Unserved"}
+		: {_tag: "Served", number: ref.number, kind: ref.kind};
+};
 
 /** An issue's home: its open milestone's number as a string, or its standing lane. */
 export const homeOf = (issue: IssueFacts): string | null =>
@@ -235,7 +265,28 @@ export type Admission =
 			readonly scope: ScopeAxis;
 			readonly audience: Extract<AudienceAxis, {readonly _tag: "NotAgent"}>;
 	  }
+	/**
+	 * A pull request with no readable served issue, under a declared focus.
+	 *
+	 * It carries no axis verdict because neither axis ever ran: the fence could not identify the
+	 * record to judge. Refusing is the fail-closed answer — admitting a PR whose ticket nobody can
+	 * name would let any lane past a declared focus by omitting one line from a body — and the
+	 * remedy is a cheap one the message states: name the issue in the PR body, or override.
+	 */
+	| {
+			readonly _tag: "NoServedIssue";
+			readonly pr: number;
+			readonly focus: number;
+			readonly reason: string;
+	  }
 	| {readonly _tag: "Unknown"; readonly code: number; readonly reason: string};
+
+export const noServedIssue = (pr: number, focus: number, reason: string): Admission => ({
+	_tag: "NoServedIssue",
+	pr,
+	focus,
+	reason,
+});
 
 /**
  * Run both axes over one issue.
@@ -277,6 +328,9 @@ export const exclusionReasonOf = (
 		case "Admitted":
 			return null;
 		case "OutOfFocus":
+		// The pool reads issues only, so this arrives from the claim path alone; it is a scope-axis
+		// refusal there, and it is reported as one here rather than as an unreadable issue.
+		case "NoServedIssue":
 			return "out-of-focus";
 		case "AudienceNotAgent":
 			return "audience-not-agent";
@@ -304,7 +358,7 @@ export const ADMISSION_EXIT_CODES: ReadonlyArray<{
 	{
 		code: OUT_OF_FOCUS,
 		condition:
-			"proven: not admitted on the scope axis — the issue's home is not the declared milestone and no standing-lane label exempts it",
+			"proven: not admitted on the scope axis — the issue's home is not the declared milestone and no standing-lane label exempts it, or the target is a pull request naming no served issue to judge",
 	},
 	{
 		code: AUDIENCE_NOT_AGENT,
@@ -364,6 +418,11 @@ export const admissionRefusal = (verb: string, admission: Admission): VerbOutcom
 				`${verb}: out of focus — the declared focus is milestone #${admission.scope.focus} and this issue's home is ${home}; edit the ## Focus row, or claim it with an explicit override.`,
 			);
 		}
+		case "NoServedIssue":
+			return refuse(
+				OUT_OF_FOCUS,
+				`${verb}: no served issue — the declared focus is milestone #${admission.focus} and PR #${admission.pr} ${admission.reason}, so there is no ticket whose home the fence can judge; name the issue in the PR body (a closing keyword or "Part of #<n>"), or claim it with an explicit override.`,
+			);
 		case "AudienceNotAgent":
 			return refuse(
 				AUDIENCE_NOT_AGENT,

--- a/packages/fabrika-cli/src/build/scope-admission.unit.test.ts
+++ b/packages/fabrika-cli/src/build/scope-admission.unit.test.ts
@@ -18,12 +18,14 @@ import {
 	focusScopeLine,
 	homeOf,
 	type IssueFacts,
+	noServedIssue,
 	parseClaimPurpose,
 	purposeScopeLine,
 	readDeclaredFocus,
 	readFocus,
 	STANDING_LANE_LABELS,
 	scopeAxisOf,
+	scopeSubjectOf,
 	unknownAdmission,
 } from "./scope-admission.ts";
 
@@ -293,5 +295,53 @@ describe("readDeclaredFocus", () => {
 		const out = await read(layer);
 		expect(out._tag).toBe("Unreadable");
 		expect(out._tag === "Unreadable" && out.reason).toContain(DEFAULT_ROADMAP);
+	});
+});
+
+describe("scopeSubjectOf", () => {
+	const pull = (body: string) => ({isPullRequest: true, body});
+
+	it("reads an issue as its own subject, whatever its body says", () => {
+		expect(scopeSubjectOf({isPullRequest: false, body: "Fixes #4312"})).toEqual({_tag: "Own"});
+	});
+
+	it("resolves a PR to the issue its closing keyword names", () => {
+		expect(scopeSubjectOf(pull("A summary.\n\nFixes #4312\n"))).toEqual({
+			_tag: "Served",
+			number: 4312,
+			kind: "fixes",
+		});
+	});
+
+	it("resolves a partial PR through Part of #<n>, the reference review scope reads", () => {
+		expect(scopeSubjectOf(pull("Part of #4312\n"))).toEqual({
+			_tag: "Served",
+			number: 4312,
+			kind: "part-of",
+		});
+	});
+
+	it("reads a PR naming no issue as unserved — never as an issue with an empty home", () => {
+		expect(scopeSubjectOf(pull("A conversation-authored ADR.\n\n## Deviations\nNone.\n"))).toEqual({
+			_tag: "Unserved",
+		});
+	});
+});
+
+describe("noServedIssue", () => {
+	const unserved = noServedIssue(5556, 44, "carries no reference");
+
+	it("refuses at 20, naming the case that fired and the remedy", () => {
+		const refusal = admissionRefusal("build claim", unserved);
+		expect(refusal?.code).toBe(OUT_OF_FOCUS);
+		const text = refusal?.stderr.join("\n") ?? "";
+		expect(text).toContain("no served issue");
+		expect(text).toContain("PR #5556 carries no reference");
+		expect(text).toContain("milestone #44");
+		expect(text).toContain("explicit override");
+	});
+
+	it("is a scope-axis exclusion, never an unreadable one", () => {
+		expect(exclusionReasonOf(unserved)).toBe("out-of-focus");
 	});
 });

--- a/packages/fabrika-cli/src/build/target.ts
+++ b/packages/fabrika-cli/src/build/target.ts
@@ -105,9 +105,12 @@ export type AdmissionSubject =
 /**
  * Resolve a claim target to the record whose home and audience the fence judges.
  *
- * An issue judges itself. A pull request judges the issue its lane serves (#5562). While no focus is
- * declared the fence is inert, so an unresolvable PR is never refused on scope grounds here — it
- * falls back to its own record, exactly as before.
+ * An issue judges itself. A pull request judges the issue its lane serves (#5562). The resolution
+ * runs whether or not a focus is declared, because the audience axis reads the served issue either
+ * way; only the *scope* refusal is gated on a declaration, so an **unresolvable** PR falls back to
+ * its own record while the fence is inert instead of refusing at `20`. A served issue that cannot be
+ * READ is UNKNOWN at either setting — `11`, and outside the overridable set, because a fence that
+ * could not read its input has proven nothing.
  */
 export const resolveAdmissionSubject = (
 	verb: string,

--- a/packages/fabrika-cli/src/build/target.ts
+++ b/packages/fabrika-cli/src/build/target.ts
@@ -12,6 +12,14 @@ import {getIssue, type IssueRecord, resolveRepo} from "../io/issues.ts";
 import {getPullRequest, type PullRecord} from "../io/pulls.ts";
 import {FAILED, refuse, type VerbOutcome} from "../verb.ts";
 import {PRECONDITION_UNKNOWN, ZERO_SCOPE} from "./codes.ts";
+import {
+	type Admission,
+	type Focus,
+	type IssueFacts,
+	noServedIssue,
+	scopeSubjectOf,
+	unknownAdmission,
+} from "./scope-admission.ts";
 
 /** `<verb>: scanned <n> <noun>(s)[; <note>].` — the count first, so an empty answer is auditable. */
 export const scannedLine = (verb: string, scanned: number, noun: string, note?: string): string =>
@@ -76,6 +84,68 @@ export const openIssue = (
 			};
 		}
 		return {_tag: "Issue" as const, issue: found.value};
+	});
+
+/**
+ * The record the admission test runs over, resolved from the target the operator named.
+ *
+ * `Refused` carries an {@link Admission} rather than a seated outcome so the claim seam applies the
+ * one override rule it already has — a resolution refusal is overridable exactly like a scope one,
+ * and an unreadable served issue is UNKNOWN and so is not.
+ */
+export type AdmissionSubject =
+	| {
+			readonly _tag: "Judged";
+			readonly facts: IssueFacts;
+			/** What the fence judged, when that is not the named target itself. */
+			readonly note: string | null;
+	  }
+	| {readonly _tag: "Refused"; readonly admission: Admission};
+
+/**
+ * Resolve a claim target to the record whose home and audience the fence judges.
+ *
+ * An issue judges itself. A pull request judges the issue its lane serves (#5562). While no focus is
+ * declared the fence is inert, so an unresolvable PR is never refused on scope grounds here — it
+ * falls back to its own record, exactly as before.
+ */
+export const resolveAdmissionSubject = (
+	verb: string,
+	repo: string,
+	focus: Focus,
+	target: IssueRecord,
+): Effect.Effect<AdmissionSubject, never, ChildProcessSpawner.ChildProcessSpawner> =>
+	Effect.gen(function* () {
+		const own = {_tag: "Judged" as const, facts: target, note: null};
+		const subject = scopeSubjectOf(target);
+		if (subject._tag === "Own") return own;
+		const unresolved = (reason: string): AdmissionSubject =>
+			focus._tag === "Declared"
+				? {
+						_tag: "Refused" as const,
+						admission: noServedIssue(target.number, focus.milestone, reason),
+					}
+				: own;
+		if (subject._tag === "Unserved") {
+			return unresolved('carries neither a closing keyword nor "Part of #<n>" in its body');
+		}
+		const served = yield* getIssue(repo, subject.number);
+		if (served._tag === "Absent") {
+			return unresolved(`names #${subject.number}, which is proven absent`);
+		}
+		if (served._tag === "Unknown") {
+			return {
+				_tag: "Refused" as const,
+				admission: unknownAdmission(
+					`cannot read #${subject.number}, the issue PR #${target.number} serves: ${served.reason}`,
+				),
+			};
+		}
+		return {
+			_tag: "Judged" as const,
+			facts: served.value,
+			note: `${verb}: subject: PR #${target.number} serves #${subject.number} (${subject.kind}) — the admission test judges that issue, not the PR's own empty home.`,
+		};
 	});
 
 export type PullTarget =

--- a/packages/fabrika-cli/src/io/issues.ts
+++ b/packages/fabrika-cli/src/io/issues.ts
@@ -230,6 +230,14 @@ export interface IssueRecord {
 	 * proving a short read from a count that was never there.
 	 */
 	readonly comments: number;
+	/**
+	 * Whether this number is a pull request rather than an issue.
+	 *
+	 * `repos/<repo>/issues/<n>` answers for both, and the only thing that tells them apart is the
+	 * `pull_request` key. A caller that cannot see the difference reads a PR's empty milestone as an
+	 * unhomed issue's (#5562).
+	 */
+	readonly isPullRequest: boolean;
 }
 
 const toIssueRecord = (value: unknown): IssueRecord | null => {
@@ -254,6 +262,7 @@ const toIssueRecord = (value: unknown): IssueRecord | null => {
 			isRecord(milestone) && typeof milestone.number === "number" ? milestone.number : null,
 		stateReason: typeof state_reason === "string" ? state_reason : null,
 		comments: typeof value.comments === "number" ? value.comments : 0,
+		isPullRequest: isRecord(value.pull_request),
 	};
 };
 


### PR DESCRIPTION
A pull request carries no milestone and no `ready-for:` label, so while any `## Focus` was declared
`fabrika build claim <pr>` refused every PR number at exit 20 — repair mode's own first step was
unreachable, and every repair in the observed table needed an override or a hand-edit outside the
verbs.

The fence now judges **which record** it reads, not whether it refuses. An issue is still its own
subject. A PR resolves to the issue its lane serves — the first closing keyword in its body, else
`Part of #<n>`, read through `review scope`'s existing `issueRefOf`, not a second parser — and both
axes then read that issue. An out-of-focus served issue still refuses at 20 with the same message
shape and stays overridable.

- `scopeSubjectOf` (`build/scope-admission.ts`) is the named resolution: `Own` / `Served` /
  `Unserved`, pure and unit-tested.
- `resolveAdmissionSubject` (`build/target.ts`) is its IO half: it fetches the served issue and hands
  the admission test that record. An unreadable served issue is 11 (UNKNOWN, not overridable).
- `IssueRecord` gains `isPullRequest` — `repos/<repo>/issues/<n>` answers for both, and the
  `pull_request` key is the only thing that tells them apart. Without it a PR's empty milestone reads
  as an unhomed issue's.

**The design point the triage note left open — a PR with no linked issue.** It refuses, at 20, with
its own message naming the case (`no served issue`), and it stays overridable. The alternative was to
admit it, and that widens the fence: a lane could clear a declared focus by leaving one line out of a
PR body, which is exactly the failure a fail-closed fence exists to prevent. Refusing costs the
issueless PR one cheap remedy the message states — add the reference to the body — or the same
deliberate `--override` any scope refusal takes. While no focus is declared the fence is inert, so
there is nothing to refuse on and an unresolvable PR falls back to its own record, unchanged.

Acceptance criterion 6 (`build note <pr>` / `build branch --resume <pr>` no longer exit 15) is
discharged by the claim landing: both gate on `requireClaim`, which reads the marker on the PR
number, and neither verb changed.

## Repair round 1 — the fence refused this very PR, live

Both review namespaces FAILed at `bcc881ee` on one blocking finding, and it was not in the diff:
`fabrika review criteria 5562` refused at exit 7 because #5562's acceptance-criteria heading had
drifted to level 2. Repaired on the issue (`##` → `###`, one character, nothing else touched);
`review criteria 5562` now reads 6 criteria at exit 0. The head does not move — there was nothing to
fix on the branch.

Evidence for this PR's own premise, observed during that repair: `fabrika build claim 5633` refused
at exit 20 — "out of focus — the declared focus is milestone #45 and this issue's home is no
milestone and no standing lane" — on the PR that fixes exactly that. #5633 serves #5562, which is
unhomed, so the refusal is still correct under the new rule; what the run shows is the pre-fix
behaviour the ticket describes, reproduced on itself, and the repair path it blocks. The claim
proceeded under an operator-instructed `--override` recorded with lane 5562.

## Repair round 2 — the inert-fence sentence was false, and now says what the code does

Both namespaces FAILed at `bcc881ee` on one finding: the docblock on `resolveAdmissionSubject` and
the matching `contract.md` bullet claimed that while no focus is declared an unresolvable PR is never
refused here. The code does not hold that on one branch — the served issue is read before the focus
is consulted, so with no focus declared an unreadable served issue returns UNKNOWN and `claim` exits
`11`, which is deliberately not overridable.

Fixed in the prose direction the verdict named, because the other direction is a regression: moving
the read behind the focus check would send a resolvable PR back to its own record while the fence is
inert, and a PR carries no `ready-for:` label, so a default `--purpose build` repair claim would then
refuse at `21` on every PR whenever no focus is declared. The read stays; the two sentences now say
what happens — the resolution runs either way because the audience axis reads the served issue either
way, only the *scope* refusal is gated on a declaration, and an unreadable served issue is `11` at
either setting.

**Correcting this body.** The paragraph above ending "an unresolvable PR falls back to its own record,
unchanged" carries the same false claim and is superseded by this section: only an **unresolvable**
PR falls back, and only the scope refusal is inert.

Three tests added for the case criterion 5 names, all under the default `--purpose build`, which is
the purpose that binds the audience axis: a resolvable PR under no focus resolves and is won; an
unserved PR under no focus stays on its own record and refuses at `21` (the pre-#5562 answer,
unchanged); an unreadable served issue under no focus still refuses at `11`. The existing no-focus
test ran under `--purpose gate`, which unbinds that axis, so it proved less than the criterion asks.

The claim fence refused this PR again this round, live: `fabrika build claim 5633` exited `20` —
"out of focus — the declared focus is milestone #45 and this issue's home is no milestone and no
standing lane" — on the PR that fixes exactly that. The operator instructed the `--override`, and the
reason it records is theirs.

## Deviations

- **Said:** the Grounding names `build/scope-admission.ts` and `build/claim-verb.ts`.
  **Did:** also changed `io/issues.ts` (added `IssueRecord.isPullRequest`) and `build/target.ts`
  (the IO resolver).
  **Why:** the PR/issue split is not derivable from the fields `IssueRecord` carried, and
  `scope-admission.ts` is the pure module — putting a `gh` read in it would break the one IO boundary
  its docblock states.
  **Disposition:** kept; both are in the same seam and covered by the new tests.
- **Said:** the ticket asks for the scope axis to judge the served issue.
  **Did:** the audience axis reads the served issue too — the admission test runs over one record.
  **Why:** a PR carries no `ready-for:` label either, so scope alone would have moved the refusal
  from 20 to 21 and left acceptance criterion 1 unmet.
  **Disposition:** kept; a repair lane's audience is the audience of the ticket it serves.
- **Said:** `build check` runs one pass per artifact class present in the diff.
  **Did:** `--surface code` is green; `--surface prose` reds on `claude-plugins/fabrika/skills/build/contract.md`.
  **Why:** three pre-existing illustrative temp paths in that file's examples trip the leak check; all
  three are on `origin/main` and none is in this diff's hunks.
  **Disposition:** kept as-is, follow-up filed as #5632 — repairing them is not this ticket's change.
- **Said:** repair runs through the build verbs.
  **Did:** edited #5562's body and this PR's body with `gh api -X PATCH`, outside any verb.
  **Why:** no build verb rewrites an issue or PR body — that is the other half of this ticket's
  original filing, split out to #5618 — and the blocking finding was unrepairable any other way.
  **Disposition:** kept; the verbs' guards did not run over either write, so the issue edit was one
  heading character and was read back with `build issue 5562` and `review criteria 5562`.
- **Said:** claim the PR's number first, and never override on your own authority.
  **Did:** claimed #5633 with `--override` and `--override-lane 5562` after exit 20.
  **Why:** the operator instructed this repair explicitly; the refusal is the defect this PR fixes,
  reproduced on itself.
  **Disposition:** kept, and the reason is recorded in the claim marker's override field.

- **Said:** repair fixes findings on the branch, and no build verb rewrites a PR body.
  **Did:** appended a round-2 section and this entry to this PR body with `gh api -X PATCH`, outside
  any verb; nothing already in the body was rewritten.
  **Why:** the body repeated the same false inert-fence sentence the verdict blocked on, and the
  body-update path is the other half of this ticket, split out to #5618.
  **Disposition:** kept; the earlier paragraph is superseded in place by the round-2 section rather
  than edited, so the filed text stays readable.
- **Said:** never override the claim fence on your own authority.
  **Did:** claimed #5633 with `--override` again this round after a second live exit 20.
  **Why:** the operator instructed it; the refusal is this PR own premise, observed on itself.
  **Disposition:** kept, and the reason is recorded in the claim marker override field.

Fixes #5562


