### PR TITLE
map record writes a body its own parser rejects, leaving the map unreadable

### DIFF
--- a/claude-plugins/fabrika/skills/wayfinding/contract.md
+++ b/claude-plugins/fabrika/skills/wayfinding/contract.md
@@ -1090,12 +1090,18 @@ state unrepresentable. The close is second and its failure is `8` with the ticke
 recorded against a still-open ticket is visibly incomplete and re-runnable, whereas a closed ticket
 with no recorded answer is the forbidden state.
 
-**Re-runnable is enforced, not asserted.** When the map's `## Decisions` already cites this ticket
-and the ticket is still open, the verb takes the resume branch: it writes no body at all and only
-closes, answering `"resumed":true`. So finishing an interrupted lockstep is the same command again
-rather than a hand-close, and a re-run can never record the same answer twice. The recorded entry
-stands as written — a wrong answer is retracted in the open with a new entry (#4227), never
-overwritten by a re-run, so the resume ignores `--finding`'s text.
+**Re-runnable is enforced, not asserted.** When the map's `## Decisions` already carries the entry
+this run would write and the ticket is still open, the verb takes the resume branch: it writes no
+body at all and only closes, answering `"resumed":true`. The match key is the whole citation this
+run carries — for a research or spike finding the ticket number (`— from #<ticket>`), and for a
+relayed ruling the session **and** the question id (`— ruled on #<session> R<round>.<n>`), never the
+session alone, because one grilling session answers several questions and two decision tickets may
+fork to it. So finishing an interrupted lockstep is this verb again rather than a hand-close: re-read
+the map with `map read` for its new digest, then re-run the command against that digest — the body
+write that landed moved the digest, so the literal same command exits `12`. A re-run can never record
+the same answer twice, and the recorded entry stands as written — a wrong answer is retracted in the
+open with a new entry (#4227), never overwritten by a re-run, so the resume ignores `--finding`'s
+text.
 
 **A landed body write is never rolled back.** There is no transaction across two GitHub writes, and
 an undo PATCH is itself a write that can fail, leaving a state no reader can name. The composed
@@ -1134,7 +1140,8 @@ research path is unaffected. Both groups are fabrika's own; nothing here reaches
 
 | Code | Trigger |
 |---|---|
-| `0` | the answer is on the map and the ticket is closed — including a resume, which only closed |
+| `0` | this run recorded the answer on the map and closed the ticket (`"resumed":false`) |
+| `0` | a resume: the answer was already on the map, this run wrote no body and only closed the ticket (`"resumed":true`) |
 | `4` | the map body does not parse, `--finding` is empty, or the composed entry would not read back |
 | `5` / `6` | the finding carries a machine-local path, or is a bare `@` reference |
 | `7` | the map does not exist |
@@ -1152,7 +1159,7 @@ research path is unaffected. Both groups are fabrika's own; nothing here reaches
 | `map record: #<t> is forked to #<s> and --ruled-on was not given — a forked ticket's answer is the founder's, and it is recorded by citing his ruling, never by restating it.` | 13 | refusal |
 | `map record: #<s> <q> reads <state>, not ruled — nothing was recorded. A question that is not ruled has no answer to carry onto the map.` | 13 | refusal |
 | `map record: #<t>'s lane returned unreachable — there is no answer to record. Re-lane it once the source is reachable, or retire it with map descope --ticket.` | 21 | refusal |
-| `map record: recorded the answer on #<n> and the close of #<t> did NOT land — the answer is on the map and the ticket is still open. Re-run this same command to resume the close; it will not record the answer twice.` | 8 | refusal |
+| `map record: recorded the answer on #<n> and the close of #<t> did NOT land — the answer is on the map and the ticket is still open. Re-read the map and re-run with its new digest to resume the close; it will not record the answer twice.` | 8 | refusal |
 | `map record: #<n>'s body would not hold this record — <reason>; nothing was written.` | 4 | refusal |
 
 **Scope** — the ticket's state and, for a forked ticket, the named session's question state. A read
@@ -1167,7 +1174,8 @@ $ echo $?
 0
 ```
 
-Resuming a run whose close did not land — the same command, against the map's new digest:
+Resuming a run whose close did not land — `map read` first for the map's new digest, then the same
+arguments against that digest:
 
 ```
 $ fabrika map record 9140 --digest d4e5f6a1b2c3 --ticket 9143 --finding finding.md

--- a/claude-plugins/fabrika/skills/wayfinding/contract.md
+++ b/claude-plugins/fabrika/skills/wayfinding/contract.md
@@ -1060,8 +1060,17 @@ fabrika map record 9140 --digest a1b2c3d4e5f6 --ticket 9143 --finding finding.md
 **Output** — machine. One JSON object:
 
 ```json
-{"map":9140,"ticket":9143,"recorded":"— from #9143","closed":true,"digest":"d4e5f6a1b2c3"}
+{"map":9140,"ticket":9143,"recorded":"— from #9143","closed":true,"resumed":false,"digest":"d4e5f6a1b2c3"}
 ```
+
+`resumed` is `true` when this run only closed the ticket because the answer was already on the map —
+see the resume paragraph below.
+
+**The finding is folded to one line before it is composed**, the same expression `map descope`
+folds its `--reason` with (`src/map/body.ts`, `foldEntryText`): both sections are one entry per
+bullet, so a multi-line input written verbatim lands as lines the parser reads as neither an entry
+nor a continuation. `map record` shipped without the fold and corrupted a live map
+([#5550](https://github.com/kamp-us/phoenix/issues/5550)).
 
 **The lockstep, and the order that makes a partial application safe.** Three writes, one guard:
 
@@ -1080,6 +1089,17 @@ doc forbids — *"the map is never left in a state where a resolved unknown has 
 state unrepresentable. The close is second and its failure is `8` with the ticket named: an answer
 recorded against a still-open ticket is visibly incomplete and re-runnable, whereas a closed ticket
 with no recorded answer is the forbidden state.
+
+**Re-runnable is enforced, not asserted.** When the map's `## Decisions` already cites this ticket
+and the ticket is still open, the verb takes the resume branch: it writes no body at all and only
+closes, answering `"resumed":true`. So finishing an interrupted lockstep is the same command again
+rather than a hand-close, and a re-run can never record the same answer twice. The recorded entry
+stands as written — a wrong answer is retracted in the open with a new entry (#4227), never
+overwritten by a re-run, so the resume ignores `--finding`'s text.
+
+**A landed body write is never rolled back.** There is no transaction across two GitHub writes, and
+an undo PATCH is itself a write that can fail, leaving a state no reader can name. The composed
+entry is fenced before the write instead, and the surviving half stays the visible, resumable one.
 
 **A `forked` ticket may not be recorded without its ruling.** `--ruled-on` and `--question-id` are
 required when the ticket's state is `forked`.
@@ -1114,8 +1134,8 @@ research path is unaffected. Both groups are fabrika's own; nothing here reaches
 
 | Code | Trigger |
 |---|---|
-| `0` | the answer is on the map and the ticket is closed |
-| `4` | the map body does not parse, or `--finding` is empty |
+| `0` | the answer is on the map and the ticket is closed — including a resume, which only closed |
+| `4` | the map body does not parse, `--finding` is empty, or the composed entry would not read back |
 | `5` / `6` | the finding carries a machine-local path, or is a bare `@` reference |
 | `7` | the map does not exist |
 | `8` / `9` | a write failed, or the read-back differs |
@@ -1132,7 +1152,8 @@ research path is unaffected. Both groups are fabrika's own; nothing here reaches
 | `map record: #<t> is forked to #<s> and --ruled-on was not given — a forked ticket's answer is the founder's, and it is recorded by citing his ruling, never by restating it.` | 13 | refusal |
 | `map record: #<s> <q> reads <state>, not ruled — nothing was recorded. A question that is not ruled has no answer to carry onto the map.` | 13 | refusal |
 | `map record: #<t>'s lane returned unreachable — there is no answer to record. Re-lane it once the source is reachable, or retire it with map descope --ticket.` | 21 | refusal |
-| `map record: recorded the answer on #<n> and the close of #<t> did NOT land — the answer is on the map and the ticket is still open. Close #<t> by hand.` | 8 | refusal |
+| `map record: recorded the answer on #<n> and the close of #<t> did NOT land — the answer is on the map and the ticket is still open. Re-run this same command to resume the close; it will not record the answer twice.` | 8 | refusal |
+| `map record: #<n>'s body would not hold this record — <reason>; nothing was written.` | 4 | refusal |
 
 **Scope** — the ticket's state and, for a forked ticket, the named session's question state. A read
 that could not complete is `11`.
@@ -1141,7 +1162,16 @@ that could not complete is `11`.
 
 ```
 $ fabrika map record 9140 --digest a1b2c3d4e5f6 --ticket 9143 --finding finding.md
-{"map":9140,"ticket":9143,"recorded":"— from #9143","closed":true,"digest":"d4e5f6a1b2c3"}
+{"map":9140,"ticket":9143,"recorded":"— from #9143","closed":true,"resumed":false,"digest":"d4e5f6a1b2c3"}
+$ echo $?
+0
+```
+
+Resuming a run whose close did not land — the same command, against the map's new digest:
+
+```
+$ fabrika map record 9140 --digest d4e5f6a1b2c3 --ticket 9143 --finding finding.md
+{"map":9140,"ticket":9143,"recorded":"— from #9143","closed":true,"resumed":true,"digest":"d4e5f6a1b2c3"}
 $ echo $?
 0
 ```
@@ -1279,8 +1309,8 @@ The five hand-checks those tests cannot perform:
    creating the issue and failing the label write, leaving a map no later run can find (`8`, number
    named, write order chosen so the survivor is inert); `map ticket` filing a ticket whose sub-issue
    link then fails (`8`, number named, re-run resumes); and `map record` landing the answer and
-   failing the close (`8`, ordered so the surviving half is the visible-and-re-runnable one rather
-   than the forbidden one).
+   failing the close (`8`, ordered so the surviving half is the visible one, and re-runnable because
+   the verb's resume branch closes it without recording the answer again).
 2. **Every value an example prints is derivable from the spec.** The digest is defined as an
    algorithm over named bytes, not shown as a magic literal; `created`, `lane`, `outcome`, `state`,
    `frontier` and `kind` are closed sets enumerated above.

--- a/packages/fabrika-cli/src/map/body.ts
+++ b/packages/fabrika-cli/src/map/body.ts
@@ -95,6 +95,17 @@ export const normalizeSection = (text: string): string =>
 		.replace(/\n+$/, "");
 
 /**
+ * Free text folded onto one line — the shape every entry section takes.
+ *
+ * Shared by `map record` and `map descope` rather than written twice: both take prose from a file
+ * into a section whose grammar is one entry per bullet, so an unfolded multi-line input lands as
+ * lines the parser reads as neither an entry nor a continuation. `map descope` folded and `map
+ * record` did not, and the asymmetry corrupted a live map (#5550); one expression is what stops the
+ * two drifting apart again.
+ */
+export const foldEntryText = (text: string): string => text.trim().replace(/\s*\n\s*/g, " ");
+
+/**
  * The compare-and-set token over the five section bodies, headings excluded.
  *
  * The exclusions are the invariant, not an optimisation: the digest must cover every byte a

--- a/packages/fabrika-cli/src/map/descope-verb.ts
+++ b/packages/fabrika-cli/src/map/descope-verb.ts
@@ -26,6 +26,7 @@ import {appendOnly} from "../review/append.ts";
 import {answer, FAILED, refuse, type VerbOutcome} from "../verb.ts";
 import {
 	digestOf,
+	foldEntryText,
 	type OutOfScopeEntry,
 	parseBody,
 	renderFrontierRow,
@@ -92,9 +93,7 @@ export const runDescope = (
 				`${VERB}: could not read --reason ${options.reason}: ${read.value} — the reasoning is UNKNOWN, never empty.`,
 			);
 		}
-		// One line: the section's entries are one bullet each, so a multi-line reason is folded rather
-		// than allowed to split into entries the parser would read as separate rejections.
-		const reason = read.value.trim().replace(/\s*\n\s*/g, " ");
+		const reason = foldEntryText(read.value);
 		if (reason === "") {
 			return refuse(
 				BAD_SECTIONS,

--- a/packages/fabrika-cli/src/map/frontier.ts
+++ b/packages/fabrika-cli/src/map/frontier.ts
@@ -19,7 +19,7 @@ import {blockedBy, blocking, subIssues} from "../io/edges.ts";
 import type {Shell} from "../io/git.ts";
 import {type CommentRecord, getIssue, type IssueRecord, listComments} from "../io/issues.ts";
 import {permissionFor} from "../io/pulls.ts";
-import {type Kind, type MapBody, parseBody} from "./body.ts";
+import {type DecisionEntry, type Kind, type MapBody, parseBody} from "./body.ts";
 import {
 	type Outcome,
 	reachesForTicketMarker,
@@ -168,16 +168,22 @@ export const scanTicketMarkers = (
  * fork's session is what lets a decision ticket graduate at all; without it a forked ticket's answer
  * could land on the map and the ticket would still read `forked` forever.
  */
-export const decisionCites = (
+export const decisionCiting = (
 	body: MapBody,
 	ticket: number,
 	forkedSession: number | null,
-): boolean =>
-	body.decisions.some((entry) =>
+): DecisionEntry | undefined =>
+	body.decisions.find((entry) =>
 		entry.authority._tag === "Finding"
 			? entry.authority.ticket === ticket
 			: forkedSession !== null && entry.authority.session === forkedSession,
 	);
+
+export const decisionCites = (
+	body: MapBody,
+	ticket: number,
+	forkedSession: number | null,
+): boolean => decisionCiting(body, ticket, forkedSession) !== undefined;
 
 const stateOf = (
 	closed: boolean,

--- a/packages/fabrika-cli/src/map/frontier.ts
+++ b/packages/fabrika-cli/src/map/frontier.ts
@@ -160,30 +160,47 @@ export const scanTicketMarkers = (
 };
 
 /**
- * Whether the map's `## Decisions` already carries this ticket's answer.
+ * The entry this run would write, if the map's `## Decisions` already carries it.
  *
- * Two citations resolve to one ticket, because the contract's citation grammar has two forms and only
- * one of them names a ticket: a research or spike finding cites `— from #<ticket>`, and a relayed
- * ruling cites `— ruled on #<session>`, which names the session the fork pointed at. Matching the
- * fork's session is what lets a decision ticket graduate at all; without it a forked ticket's answer
- * could land on the map and the ticket would still read `forked` forever.
+ * The exact test, for a caller about to decide whether a write already landed. A finding cites
+ * `— from #<ticket>`, so the ticket number identifies it. A relayed ruling cites
+ * `— ruled on #<session> R<round>.<n>`, and the session alone does NOT identify it: one grilling
+ * session answers several questions, so every decision ticket forked to that session matches a
+ * session-only test. The match key is therefore the whole citation this run carries — session and
+ * question id — or recording the second such ticket would find the first ticket's entry (#5637).
  */
-export const decisionCiting = (
+export const decisionRecorded = (
 	body: MapBody,
 	ticket: number,
-	forkedSession: number | null,
+	citation: {readonly session: number; readonly questionId: string} | null,
 ): DecisionEntry | undefined =>
 	body.decisions.find((entry) =>
 		entry.authority._tag === "Finding"
 			? entry.authority.ticket === ticket
-			: forkedSession !== null && entry.authority.session === forkedSession,
+			: citation !== null &&
+				entry.authority.session === citation.session &&
+				entry.authority.questionId === citation.questionId,
 	);
 
+/**
+ * Whether the map's `## Decisions` carries an answer that could be this ticket's — the loose test,
+ * for reading a closed ticket's state off the body alone.
+ *
+ * A reader has no citation in hand, only the session the fork pointed at, so a relayed ruling can be
+ * matched no more precisely than by that session. Matching it is what lets a decision ticket read
+ * `graduated` at all; without it a forked ticket's answer could land and the ticket would still read
+ * `forked` forever. Never reuse this to decide a write — see `decisionRecorded`.
+ */
 export const decisionCites = (
 	body: MapBody,
 	ticket: number,
 	forkedSession: number | null,
-): boolean => decisionCiting(body, ticket, forkedSession) !== undefined;
+): boolean =>
+	body.decisions.some((entry) =>
+		entry.authority._tag === "Finding"
+			? entry.authority.ticket === ticket
+			: forkedSession !== null && entry.authority.session === forkedSession,
+	);
 
 const stateOf = (
 	closed: boolean,

--- a/packages/fabrika-cli/src/map/record-verb.ts
+++ b/packages/fabrika-cli/src/map/record-verb.ts
@@ -4,7 +4,9 @@
  *
  * The two body edits are one PATCH and the close is second, ordered so the surviving half of a
  * partial application is the visible-and-re-runnable one — an answer recorded against a still-open
- * ticket — rather than the forbidden one, a closed ticket with no recorded answer.
+ * ticket — rather than the forbidden one, a closed ticket with no recorded answer. Re-runnable is
+ * enforced, not asserted: a ticket whose answer the body already cites takes the resume branch and
+ * only closes, so finishing an interrupted lockstep is the same command again, never a hand-close.
  *
  * <!-- anchor: RELAY-GRILLINGS-STATE-NEVER-RECOMPUTE-IT --> **A forked decision ticket's ruling is
  * read by importing the `grill` group's reader, never by re-deriving it here.** A ruling counts only
@@ -21,7 +23,7 @@ import {readFile} from "../io/fs.ts";
 import {closeCompleted, getIssue, patchIssueBody} from "../io/issues.ts";
 import {normalizeForReadback} from "../report/compose.ts";
 import {answer, FAILED, refuse, type VerbOutcome} from "../verb.ts";
-import {type DecisionEntry, digestOf, parseBody} from "./body.ts";
+import {type DecisionEntry, digestOf, foldEntryText, parseBody} from "./body.ts";
 import {
 	BAD_SECTIONS,
 	OUTCOME_UNRECORDABLE,
@@ -30,6 +32,7 @@ import {
 	TICKET_UNKNOWN,
 	WRITE_UNKNOWN,
 } from "./codes.ts";
+import {decisionCiting} from "./frontier.ts";
 import {
 	type Citation,
 	digestFresh,
@@ -41,6 +44,12 @@ import {
 	targetRepo,
 } from "./guards.ts";
 import {applyRecord, QUESTION_ID} from "./record.ts";
+
+/** The citation an entry carries, in the one form the answer reports it. */
+const citationOf = (entry: DecisionEntry): string =>
+	entry.authority._tag === "Ruled"
+		? `— ruled on #${entry.authority.session} ${entry.authority.questionId}`
+		: `— from #${entry.authority.ticket}`;
 
 export interface RecordOptions {
 	readonly map: number;
@@ -90,7 +99,7 @@ export const runRecord = (
 				`${VERB}: could not read --finding ${options.finding}: ${read.value} — the answer is UNKNOWN, never empty.`,
 			);
 		}
-		const finding = read.value.trim();
+		const finding = foldEntryText(read.value);
 		if (finding === "") {
 			return refuse(
 				BAD_SECTIONS,
@@ -121,6 +130,40 @@ export const runRecord = (
 
 		const left = notTerminal(VERB, ticket, "its answer is already on the map.");
 		if (left !== null) return left;
+
+		// The lockstep's second half, resumed. The body write lands first and the close second, so an
+		// interrupted run leaves the answer recorded against a still-open ticket — the state the close
+		// order deliberately chooses. Re-running the same command finishes the close instead of
+		// appending the answer a second time, which is what makes that state re-runnable rather than a
+		// hand-repair (#5550). The recorded entry stands as written: a wrong answer is retracted in the
+		// open with a new entry, never overwritten by a re-run (#4227).
+		const recordedAlready = decisionCiting(
+			found.value.body,
+			options.ticket,
+			ticket.session ?? null,
+		);
+		if (recordedAlready !== undefined) {
+			const resumeScope = `${VERB}: ${repo}, #${options.ticket}'s answer is already on #${options.map} — resuming the close.`;
+			const finish = yield* closeCompleted(repo, options.ticket);
+			if (finish._tag === "Failure") {
+				return refuse(
+					WRITE_UNKNOWN,
+					`${VERB}: #${options.ticket}'s answer is on #${options.map} and the close did NOT land: ${finish.reason} — the ticket is still open. Re-run this same command to resume it.`,
+					[resumeScope],
+				);
+			}
+			return answer(
+				JSON.stringify({
+					map: options.map,
+					ticket: options.ticket,
+					recorded: citationOf(recordedAlready),
+					closed: true,
+					resumed: true,
+					digest: digestOf(found.value.body.sections),
+				}),
+				[resumeScope],
+			);
+		}
 
 		if (ticket.state === "lane-closed" && ticket.outcome === "unreachable") {
 			return refuse(
@@ -175,13 +218,14 @@ export const runRecord = (
 			};
 		}
 
-		const next = applyRecord(found.value.body, options.ticket, entry);
-		if (next === null) {
+		const applied = applyRecord(found.value.body, options.ticket, entry);
+		if (applied._tag === "Refused") {
 			return refuse(
 				BAD_SECTIONS,
-				`${VERB}: #${options.map}'s body stops parsing once the row is removed — nothing was written.`,
+				`${VERB}: #${options.map}'s body would not hold this record — ${applied.reason}; nothing was written.`,
 			);
 		}
+		const next = applied.body;
 
 		const scope = `${VERB}: ${repo}, #${options.ticket} resolved ${ticket.state}, ${found.value.body.decisions.length} existing decision(s).`;
 		const written = yield* patchIssueBody(repo, options.map, next);
@@ -216,7 +260,7 @@ export const runRecord = (
 		if (closed._tag === "Failure") {
 			return refuse(
 				WRITE_UNKNOWN,
-				`${VERB}: recorded the answer on #${options.map} and the close of #${options.ticket} did NOT land — the answer is on the map and the ticket is still open. Close #${options.ticket} by hand.`,
+				`${VERB}: recorded the answer on #${options.map} and the close of #${options.ticket} did NOT land — the answer is on the map and the ticket is still open. Re-run this same command to resume the close; it will not record the answer twice.`,
 				[scope],
 			);
 		}
@@ -225,11 +269,9 @@ export const runRecord = (
 			JSON.stringify({
 				map: options.map,
 				ticket: options.ticket,
-				recorded:
-					entry.authority._tag === "Ruled"
-						? `— ruled on #${entry.authority.session} ${entry.authority.questionId}`
-						: `— from #${entry.authority.ticket}`,
+				recorded: citationOf(entry),
 				closed: true,
+				resumed: false,
 				digest: digestOf(reparsed.value.sections),
 			}),
 			[scope],

--- a/packages/fabrika-cli/src/map/record-verb.ts
+++ b/packages/fabrika-cli/src/map/record-verb.ts
@@ -5,8 +5,9 @@
  * The two body edits are one PATCH and the close is second, ordered so the surviving half of a
  * partial application is the visible-and-re-runnable one — an answer recorded against a still-open
  * ticket — rather than the forbidden one, a closed ticket with no recorded answer. Re-runnable is
- * enforced, not asserted: a ticket whose answer the body already cites takes the resume branch and
- * only closes, so finishing an interrupted lockstep is the same command again, never a hand-close.
+ * enforced, not asserted: a ticket whose answer the body already carries takes the resume branch and
+ * only closes, so finishing an interrupted lockstep is the verb again — re-read the map, re-run
+ * against its new digest — never a hand-close.
  *
  * <!-- anchor: RELAY-GRILLINGS-STATE-NEVER-RECOMPUTE-IT --> **A forked decision ticket's ruling is
  * read by importing the `grill` group's reader, never by re-deriving it here.** A ruling counts only
@@ -32,7 +33,7 @@ import {
 	TICKET_UNKNOWN,
 	WRITE_UNKNOWN,
 } from "./codes.ts";
-import {decisionCiting} from "./frontier.ts";
+import {decisionRecorded} from "./frontier.ts";
 import {
 	type Citation,
 	digestFresh,
@@ -133,22 +134,20 @@ export const runRecord = (
 
 		// The lockstep's second half, resumed. The body write lands first and the close second, so an
 		// interrupted run leaves the answer recorded against a still-open ticket — the state the close
-		// order deliberately chooses. Re-running the same command finishes the close instead of
-		// appending the answer a second time, which is what makes that state re-runnable rather than a
-		// hand-repair (#5550). The recorded entry stands as written: a wrong answer is retracted in the
-		// open with a new entry, never overwritten by a re-run (#4227).
-		const recordedAlready = decisionCiting(
-			found.value.body,
-			options.ticket,
-			ticket.session ?? null,
-		);
+		// order deliberately chooses. Re-reading the map and re-running against its new digest finishes
+		// the close instead of appending the answer a second time, which is what makes that state
+		// re-runnable rather than a hand-repair (#5550). The match is the citation THIS run carries, so
+		// a sibling ticket forked to the same grilling session cannot resume on the other's entry
+		// (#5637). The recorded entry stands as written: a wrong answer is retracted in the open with a
+		// new entry, never overwritten by a re-run (#4227).
+		const recordedAlready = decisionRecorded(found.value.body, options.ticket, citation);
 		if (recordedAlready !== undefined) {
 			const resumeScope = `${VERB}: ${repo}, #${options.ticket}'s answer is already on #${options.map} — resuming the close.`;
 			const finish = yield* closeCompleted(repo, options.ticket);
 			if (finish._tag === "Failure") {
 				return refuse(
 					WRITE_UNKNOWN,
-					`${VERB}: #${options.ticket}'s answer is on #${options.map} and the close did NOT land: ${finish.reason} — the ticket is still open. Re-run this same command to resume it.`,
+					`${VERB}: #${options.ticket}'s answer is on #${options.map} and the close did NOT land: ${finish.reason} — the ticket is still open. Re-read the map and re-run with its new digest to resume the close.`,
 					[resumeScope],
 				);
 			}
@@ -260,7 +259,7 @@ export const runRecord = (
 		if (closed._tag === "Failure") {
 			return refuse(
 				WRITE_UNKNOWN,
-				`${VERB}: recorded the answer on #${options.map} and the close of #${options.ticket} did NOT land — the answer is on the map and the ticket is still open. Re-run this same command to resume the close; it will not record the answer twice.`,
+				`${VERB}: recorded the answer on #${options.map} and the close of #${options.ticket} did NOT land — the answer is on the map and the ticket is still open. Re-read the map and re-run with its new digest to resume the close; it will not record the answer twice.`,
 				[scope],
 			);
 		}

--- a/packages/fabrika-cli/src/map/record-verb.unit.test.ts
+++ b/packages/fabrika-cli/src/map/record-verb.unit.test.ts
@@ -9,7 +9,7 @@ import {
 	rulingComment,
 } from "../grill/fixtures.test-support.ts";
 import type {ExecResult} from "../io/exec.ts";
-import {type DecisionEntry, renderOutOfScope, spliceSection} from "./body.ts";
+import {type DecisionEntry, renderDecision, renderOutOfScope, spliceSection} from "./body.ts";
 import {
 	BAD_SECTIONS,
 	NO_TARGET,
@@ -212,7 +212,9 @@ describe("runRecord", () => {
 		]);
 		expect(out.code).toBe(WRITE_UNKNOWN);
 		expect(out.stdout).toBe("");
-		expect(out.stderr.join("\n")).toContain("Re-run this same command to resume the close");
+		expect(out.stderr.join("\n")).toContain(
+			"Re-read the map and re-run with its new digest to resume the close",
+		);
 	});
 });
 
@@ -356,7 +358,9 @@ describe("the lockstep is one act: an interrupted run resumes", () => {
 		});
 		expect(out.code).toBe(WRITE_UNKNOWN);
 		expect(out.stdout).toBe("");
-		expect(out.stderr.join("\n")).toContain("Re-run this same command to resume it");
+		expect(out.stderr.join("\n")).toContain(
+			"Re-read the map and re-run with its new digest to resume the close",
+		);
 	});
 });
 
@@ -482,5 +486,77 @@ describe("a forked decision ticket's ruling is read through the grill reader", (
 		expect(out.code).toBe(TICKET_UNKNOWN);
 		expect(out.stdout).toBe("");
 		expect(out.stderr.join("\n")).toContain('reads "answered", not "ruled"');
+	});
+});
+
+describe("two decision tickets forked to one grilling session", () => {
+	/** The map after a SIBLING ticket's R1.1 ruling landed — this ticket's row is still on it. */
+	const siblingRecorded = spliceSection(
+		parsed(MAP_BODY),
+		"Decisions",
+		renderDecision({
+			text: "the decay clock runs per account",
+			authority: {_tag: "Ruled", session: SESSION, questionId: "R1.1"},
+		}),
+	);
+
+	it("records the second ticket's own answer instead of resuming on the first's", async () => {
+		const landed = composed(
+			{text: ANSWER, authority: {_tag: "Ruled", session: SESSION, questionId: QUESTION}},
+			siblingRecorded,
+		);
+		const shell = fakeShell([
+			[PATCH_TICKET, okOut("{}")],
+			[PATCH_MAP, okOut("{}")],
+			...forkedDecision(),
+			...session(RULED),
+			[
+				once(MAP_ISSUE),
+				okOut(issueJson({number: MAP, body: siblingRecorded, labels: ["wayfinding:map"]})),
+			],
+			mapAt(landed),
+		]);
+		const out = await Effect.runPromise(
+			Effect.provide(
+				runRecord({
+					...options,
+					digest: digestFor(siblingRecorded),
+					ruledOn: SESSION,
+					questionId: QUESTION,
+				}),
+				Layer.merge(shell.layer, fakeFs({files: {[FINDING]: `${ANSWER}\n`}}).layer),
+			),
+		);
+		expect(out.code).toBe(0);
+		expect(JSON.parse(out.stdout)).toMatchObject({
+			recorded: `— ruled on #${SESSION} ${QUESTION}`,
+			closed: true,
+			resumed: false,
+		});
+		const patch = shell.calls.find((line) => line.includes("PATCH repos/o/r/issues/9140")) ?? "";
+		expect(patch).toContain(`${ANSWER} — ruled on #${SESSION} ${QUESTION}`);
+		expect(parsed(landed).decisions).toHaveLength(2);
+	});
+
+	it("still resumes when the map already carries THIS run's citation", async () => {
+		const mine = composed(
+			{text: ANSWER, authority: {_tag: "Ruled", session: SESSION, questionId: QUESTION}},
+			siblingRecorded,
+		);
+		const shell = fakeShell([[PATCH_TICKET, okOut("{}")], ...forkedDecision(), mapAt(mine)]);
+		const out = await Effect.runPromise(
+			Effect.provide(
+				runRecord({
+					...options,
+					digest: digestFor(mine),
+					ruledOn: SESSION,
+					questionId: QUESTION,
+				}),
+				Layer.merge(shell.layer, fakeFs({files: {[FINDING]: `${ANSWER}\n`}}).layer),
+			),
+		);
+		expect(out.code).toBe(0);
+		expect(JSON.parse(out.stdout)).toMatchObject({resumed: true, closed: true});
+		expect(shell.calls.some((line) => line.includes("PATCH repos/o/r/issues/9140"))).toBe(false);
 	});
 });

--- a/packages/fabrika-cli/src/map/record-verb.unit.test.ts
+++ b/packages/fabrika-cli/src/map/record-verb.unit.test.ts
@@ -9,6 +9,7 @@ import {
 	rulingComment,
 } from "../grill/fixtures.test-support.ts";
 import type {ExecResult} from "../io/exec.ts";
+import {type DecisionEntry, renderOutOfScope, spliceSection} from "./body.ts";
 import {
 	BAD_SECTIONS,
 	NO_TARGET,
@@ -17,6 +18,7 @@ import {
 	TICKET_UNKNOWN,
 	WRITE_UNKNOWN,
 } from "./codes.ts";
+import {runDescope} from "./descope-verb.ts";
 import {
 	commentsJson,
 	digestFor,
@@ -93,10 +95,14 @@ const laneClosed = (outcome: "answered" | "no-evidence" | "unreachable") =>
 		{id: 3, body: composeFindingMarker({map: MAP, ticket: TICKET, outcome, nonce: NONCE})},
 	]);
 
-const recorded = applyRecord(parsed(MAP_BODY), TICKET, {
-	text: ANSWER,
-	authority: {_tag: "Finding", ticket: TICKET},
-}) as string;
+/** The body `runRecord` composes for `entry`, or a thrown failure if the fence refuses it. */
+const composed = (entry: DecisionEntry, body = MAP_BODY): string => {
+	const outcome = applyRecord(parsed(body), TICKET, entry);
+	if (outcome._tag === "Refused") throw new Error(`applyRecord refused: ${outcome.reason}`);
+	return outcome.body;
+};
+
+const recorded = composed({text: ANSWER, authority: {_tag: "Finding", ticket: TICKET}});
 
 describe("runRecord", () => {
 	it("exits 1 when --ruled-on arrives without a well-formed --question-id", async () => {
@@ -206,7 +212,151 @@ describe("runRecord", () => {
 		]);
 		expect(out.code).toBe(WRITE_UNKNOWN);
 		expect(out.stdout).toBe("");
-		expect(out.stderr.join("\n")).toContain(`Close #${TICKET} by hand`);
+		expect(out.stderr.join("\n")).toContain("Re-run this same command to resume the close");
+	});
+});
+
+/** A finding as anyone actually writes one: bold lead-in, blank lines, a numbered list. */
+const MULTI_PARAGRAPH = [
+	"**The weight column lives on the account row.**",
+	"",
+	"Three reasons:",
+	"",
+	"1. the audit log already joins on account id",
+	"2. a per-topic column would cost a lookup per moderation action",
+	"3. the decay clock is per account, not per topic",
+	"",
+	"So the column goes on `account`.",
+].join("\n");
+
+const FOLDED = MULTI_PARAGRAPH.replace(/\s*\n\s*/g, " ");
+
+describe("a multi-paragraph finding", () => {
+	it("is folded to one line, so the body it writes still parses", async () => {
+		const folded = composed({text: FOLDED, authority: {_tag: "Finding", ticket: TICKET}});
+		const shell = fakeShell([
+			[PATCH_TICKET, okOut("{}")],
+			[PATCH_MAP, okOut("{}")],
+			...frontier(laneClosed("answered")),
+			[
+				once(MAP_ISSUE),
+				okOut(issueJson({number: MAP, body: MAP_BODY, labels: ["wayfinding:map"]})),
+			],
+			[MAP_ISSUE, okOut(issueJson({number: MAP, body: folded, labels: ["wayfinding:map"]}))],
+		]);
+		const out = await Effect.runPromise(
+			Effect.provide(
+				runRecord(options),
+				Layer.merge(shell.layer, fakeFs({files: {[FINDING]: `${MULTI_PARAGRAPH}\n`}}).layer),
+			),
+		);
+		expect(out.code).toBe(0);
+		const landed = parsed(folded);
+		expect(landed.decisions).toHaveLength(1);
+		expect(landed.decisions[0]?.text).toBe(FOLDED);
+		const patch = shell.calls.find((line) => line.includes("PATCH repos/o/r/issues/9140")) ?? "";
+		expect(patch).toContain(FOLDED);
+	});
+});
+
+describe("map record and map descope fold free text the same way", () => {
+	it("both land one line — a sibling that stopped folding fails here", async () => {
+		const folded = composed({text: FOLDED, authority: {_tag: "Finding", ticket: TICKET}});
+		const recordShell = fakeShell([
+			[PATCH_TICKET, okOut("{}")],
+			[PATCH_MAP, okOut("{}")],
+			...frontier(laneClosed("answered")),
+			[
+				once(MAP_ISSUE),
+				okOut(issueJson({number: MAP, body: MAP_BODY, labels: ["wayfinding:map"]})),
+			],
+			[MAP_ISSUE, okOut(issueJson({number: MAP, body: folded, labels: ["wayfinding:map"]}))],
+		]);
+		const fromRecord = await Effect.runPromise(
+			Effect.provide(
+				runRecord(options),
+				Layer.merge(recordShell.layer, fakeFs({files: {[FINDING]: `${MULTI_PARAGRAPH}\n`}}).layer),
+			),
+		);
+
+		const direction = "a per-topic weight column";
+		const descoped = spliceSection(
+			parsed(MAP_BODY),
+			"Out of scope",
+			renderOutOfScope({
+				direction,
+				reason: FOLDED.replace(/\.$/, ""),
+				recordedAt: "2026-08-10",
+			}),
+		);
+		const descopeShell = fakeShell([
+			[PATCH_MAP, okOut("{}")],
+			[
+				once(MAP_ISSUE),
+				okOut(issueJson({number: MAP, body: MAP_BODY, labels: ["wayfinding:map"]})),
+			],
+			[MAP_ISSUE, okOut(issueJson({number: MAP, body: descoped, labels: ["wayfinding:map"]}))],
+		]);
+		const fromDescope = await Effect.runPromise(
+			Effect.provide(
+				runDescope({
+					map: MAP,
+					digest: digestFor(MAP_BODY),
+					direction,
+					reason: FINDING,
+					ticket: null,
+					repo: null,
+					env: {CLAUDE_PIPELINE_REPO: REPO},
+					now: () => new Date("2026-08-10T00:00:00Z"),
+				}),
+				Layer.merge(descopeShell.layer, fakeFs({files: {[FINDING]: `${MULTI_PARAGRAPH}\n`}}).layer),
+			),
+		);
+
+		expect([fromRecord.code, fromDescope.code]).toEqual([0, 0]);
+		for (const shell of [recordShell, descopeShell]) {
+			const patch = shell.calls.find((line) => line.includes("PATCH repos/o/r/issues/9140")) ?? "";
+			expect(patch).toContain(FOLDED.replace(/\.$/, ""));
+			expect(patch).not.toContain("1. the audit log already joins on account id\\n");
+		}
+	});
+});
+
+describe("the lockstep is one act: an interrupted run resumes", () => {
+	/** The map after the body half landed: the answer recorded, the ticket never closed. */
+	const halfDone = () =>
+		[
+			...frontier(laneClosed("answered")),
+			[MAP_ISSUE, okOut(issueJson({number: MAP, body: recorded, labels: ["wayfinding:map"]}))],
+		] as const;
+
+	it("closes the ticket and writes no second entry when the answer is already on the map", async () => {
+		const shell = fakeShell([[PATCH_TICKET, okOut("{}")], ...halfDone()]);
+		const out = await Effect.runPromise(
+			Effect.provide(
+				runRecord({...options, digest: digestFor(recorded)}),
+				Layer.merge(shell.layer, fakeFs({files: {[FINDING]: `${ANSWER}\n`}}).layer),
+			),
+		);
+		expect(out.code).toBe(0);
+		expect(JSON.parse(out.stdout)).toMatchObject({
+			map: MAP,
+			ticket: TICKET,
+			recorded: `— from #${TICKET}`,
+			closed: true,
+			resumed: true,
+		});
+		expect(shell.calls.some((line) => line.includes("PATCH repos/o/r/issues/9140"))).toBe(false);
+		expect(shell.calls.some((line) => line.includes("state_reason=completed"))).toBe(true);
+	});
+
+	it("exits 8 when the resumed close still does not land — never 0 with the ticket open", async () => {
+		const out = await run([[PATCH_TICKET, errOut("gh: Bad gateway (HTTP 502)")], ...halfDone()], {
+			digest: digestFor(recorded),
+		});
+		expect(out.code).toBe(WRITE_UNKNOWN);
+		expect(out.stdout).toBe("");
+		expect(out.stderr.join("\n")).toContain("Re-run this same command to resume it");
 	});
 });
 
@@ -246,10 +396,10 @@ const RULED = [
 	{id: 13, body: rulingComment(QUESTION, BOUND)},
 ];
 
-const ruledRecord = applyRecord(parsed(MAP_BODY), TICKET, {
+const ruledRecord = composed({
 	text: ANSWER,
 	authority: {_tag: "Ruled", session: SESSION, questionId: QUESTION},
-}) as string;
+});
 
 describe("a forked decision ticket's ruling is read through the grill reader", () => {
 	it("exits 0 recording the ruling when the cited question reads ruled", async () => {

--- a/packages/fabrika-cli/src/map/record.ts
+++ b/packages/fabrika-cli/src/map/record.ts
@@ -9,6 +9,7 @@
  * than two writes.
  */
 
+import {appendOnly} from "../review/append.ts";
 import {
 	type DecisionEntry,
 	type MapBody,
@@ -21,14 +22,22 @@ import {
 /** The question id inside a `grilling` session. */
 export const QUESTION_ID = /^R\d+\.\d+$/;
 
+/** The composed body, or the reason it is not one a later read could hold. */
+export type RecordApply =
+	| {readonly _tag: "Applied"; readonly body: string}
+	| {readonly _tag: "Refused"; readonly reason: string};
+
 /**
  * The body with the answer appended under `## Decisions` and the ticket's row gone from
  * `## Frontier` — one string, so the two cannot separate.
  *
- * `null` when the intermediate body no longer parses, which a caller seats as a refusal rather than
- * writing bytes it cannot read back.
+ * Both halves of that string are proven here, before any caller writes bytes. The row removal must
+ * still parse, **and** the composed decisions section must be the old entries plus exactly this one
+ * that the parser reads back — the second half is the one `map record` shipped without, so a finding
+ * whose text broke the entry grammar was caught only by the read-back, after the write had landed
+ * (#5550). `map descope` fenced its composed section from the start; this is the same fence.
  */
-export const applyRecord = (body: MapBody, ticket: number, entry: DecisionEntry): string | null => {
+export const applyRecord = (body: MapBody, ticket: number, entry: DecisionEntry): RecordApply => {
 	const withoutRow = spliceSection(
 		body,
 		"Frontier",
@@ -38,10 +47,52 @@ export const applyRecord = (body: MapBody, ticket: number, entry: DecisionEntry)
 			.join("\n"),
 	);
 	const reparsed = parseBody(withoutRow);
-	if (reparsed._tag === "Malformed") return null;
-	return spliceSection(
-		reparsed.value,
-		"Decisions",
-		[...reparsed.value.decisions.map(renderDecision), renderDecision(entry)].join("\n"),
-	);
+	if (reparsed._tag === "Malformed") {
+		return {
+			_tag: "Refused",
+			reason: `the body stops parsing once #${ticket}'s row is removed (${reparsed.reason})`,
+		};
+	}
+
+	const priorEntries = reparsed.value.decisions.map(renderDecision);
+	const row = renderDecision(entry);
+	const composed = [...priorEntries, row].join("\n");
+	// The fence compares RENDERED entries, not raw section bytes, and the empty case is its own arm:
+	// `appendOnly` counts lines, and an empty section splits to one empty line, so a map's first
+	// decision would read as "1 line, expected 2" and refuse the ordinary opening write.
+	const violation =
+		priorEntries.length === 0
+			? composed === row
+				? null
+				: "the composed section is not exactly this one entry"
+			: (() => {
+					const fence = appendOnly(priorEntries.join("\n"), composed);
+					return fence._tag === "Violates" ? fence.reason : null;
+				})();
+	if (violation !== null) {
+		return {
+			_tag: "Refused",
+			reason: `the composed decisions section is not the old one plus this entry (${violation})`,
+		};
+	}
+
+	const next = spliceSection(reparsed.value, "Decisions", composed);
+	const read = parseBody(next);
+	if (read._tag === "Malformed") {
+		return {_tag: "Refused", reason: `the composed body does not parse (${read.reason})`};
+	}
+	const landed = read.value.decisions;
+	const last = landed.at(-1);
+	const grew =
+		landed.length === priorEntries.length + 1 &&
+		landed.slice(0, -1).every((prior, index) => renderDecision(prior) === priorEntries[index]) &&
+		last !== undefined &&
+		renderDecision(last) === row;
+	return grew
+		? {_tag: "Applied", body: next}
+		: {
+				_tag: "Refused",
+				reason:
+					"the composed body's decisions section does not read back as the old entries plus this one",
+			};
 };

--- a/packages/fabrika-cli/src/map/record.unit.test.ts
+++ b/packages/fabrika-cli/src/map/record.unit.test.ts
@@ -1,6 +1,14 @@
 import {describe, expect, it} from "vitest";
+import type {DecisionEntry, MapBody} from "./body.ts";
 import {MAP_BODY, parsed} from "./fixtures.test-support.ts";
 import {applyRecord, QUESTION_ID} from "./record.ts";
+
+/** The composed body, or a thrown failure — the shape every applied case asserts against. */
+const applied = (body: MapBody, ticket: number, entry: DecisionEntry): string => {
+	const outcome = applyRecord(body, ticket, entry);
+	if (outcome._tag === "Refused") throw new Error(`applyRecord refused: ${outcome.reason}`);
+	return outcome.body;
+};
 
 describe("QUESTION_ID", () => {
 	it("admits R<round>.<n> and nothing else", () => {
@@ -12,12 +20,11 @@ describe("QUESTION_ID", () => {
 
 describe("applyRecord", () => {
 	it("appends the answer and removes the row in ONE string, so the two cannot separate", () => {
-		const next = applyRecord(parsed(MAP_BODY), 9142, {
+		const next = applied(parsed(MAP_BODY), 9142, {
 			text: "the weight column lives on the account row",
 			authority: {_tag: "Finding", ticket: 9142},
 		});
-		expect(next).not.toBeNull();
-		const body = parsed(next as string);
+		const body = parsed(next);
 		expect(body.frontier).toEqual([]);
 		expect(body.decisions).toEqual([
 			{
@@ -28,7 +35,7 @@ describe("applyRecord", () => {
 	});
 
 	it("composes the citation itself, so an entry can never be recorded without one", () => {
-		const next = applyRecord(parsed(MAP_BODY), 9142, {
+		const next = applied(parsed(MAP_BODY), 9142, {
 			text: "an invited çaylak starts at 0 karma",
 			authority: {_tag: "Ruled", session: 9301, questionId: "R2.3"},
 		});
@@ -36,14 +43,14 @@ describe("applyRecord", () => {
 	});
 
 	it("appends rather than rewriting, so a superseding answer leaves both on the record", () => {
-		const once = applyRecord(parsed(MAP_BODY), 9142, {
+		const once = applied(parsed(MAP_BODY), 9142, {
 			text: "first answer",
 			authority: {_tag: "Finding", ticket: 9142},
-		}) as string;
-		const twice = applyRecord(parsed(once), 9146, {
+		});
+		const twice = applied(parsed(once), 9146, {
 			text: "second answer, replacing the first",
 			authority: {_tag: "Finding", ticket: 9146},
-		}) as string;
+		});
 		expect(parsed(twice).decisions.map((entry) => entry.text)).toEqual([
 			"first answer",
 			"second answer, replacing the first",
@@ -51,11 +58,19 @@ describe("applyRecord", () => {
 	});
 
 	it("leaves every other section's bytes alone", () => {
-		const next = applyRecord(parsed(MAP_BODY), 9142, {
+		const next = applied(parsed(MAP_BODY), 9142, {
 			text: "the weight column lives on the account row",
 			authority: {_tag: "Finding", ticket: 9142},
-		}) as string;
+		});
 		expect(next).toContain("- what clock does weight decay on?");
 		expect(parsed(next).destination).toBe("how moderation weight is earned");
+	});
+
+	it("refuses a composed entry the parser would not read back, before any caller writes", () => {
+		const outcome = applyRecord(parsed(MAP_BODY), 9142, {
+			text: "the answer\nsplit over two lines",
+			authority: {_tag: "Finding", ticket: 9142},
+		});
+		expect(outcome._tag).toBe("Refused");
 	});
 });


### PR DESCRIPTION
`map record` wrote a multi-line `--finding` into `## Decisions` verbatim, then failed parsing the body it had just written — the map went unreadable to every map verb, and the run stopped half-done. Three changes.

**The fold.** Both `## Decisions` and `## Out of scope` are one entry per bullet, so free text from a file has to be folded to one line before it is composed. `map descope` folded; `map record` did not. The expression now lives once, as `foldEntryText` in `src/map/body.ts`, and both verbs call it — the two cannot drift apart again.

**The pre-write fence.** `applyRecord` already refused when removing the frontier row broke the body. It now also proves the composed decisions section is the old entries plus exactly this one, re-parsed, before anything is sent — the same `appendOnly` fence `map descope` has always had. It returns `Applied`/`Refused` instead of `string | null`, so a body that has not been proven readable is not a value a caller can hold.

**The partial write.** The lockstep is still one body PATCH then the close, in that order — an answer recorded against an open ticket is the visible, recoverable half; a closed ticket with no answer is the forbidden one. What changed is that "re-runnable" is now true rather than asserted: when the map already carries the entry this run would write and the ticket is still open, the verb takes a resume branch, writes no body at all, and only closes, answering `"resumed":true`. Finishing an interrupted run is `map read` for the map's new digest, then the same arguments against that digest — no hand-close, and no second copy of the answer. The recorded entry stands as written (#4227), so the resume ignores `--finding`'s text.

**The resume's match key is the whole citation this run carries.** A finding is matched by its ticket number; a relayed ruling by session **and** question id, never the session alone. One grilling session answers several questions, so a session-only test let a second decision ticket forked to that session resume on the first ticket's entry — closing it at exit `0` with its own answer never recorded, the exact state the lockstep exists to prevent. `decisionRecorded` is the exact test the write decision uses; `decisionCites` stays the loose, session-level test a reader uses to call a closed ticket `graduated`, and the two now say which is which.

**What happens now when the second half fails:** exit `8`, naming the ticket and telling the operator to re-read the map and re-run against its new digest, which the resume branch then completes. The landed body write moved the digest, so the literal same command would exit `12` — the message, the contract's error table and its resume paragraph all say the two steps now. **A landed body write is deliberately not rolled back** — there is no transaction across two GitHub writes, and an undo PATCH is itself a write that can fail, leaving a state no reader can name. The contract records that choice explicitly.

`claude-plugins/fabrika/skills/wayfinding/contract.md` follows the code: the `resumed` field, the fold, the resume paragraph and its match key, the no-rollback statement, the new `4` refusal row, the reworded `8` message, and the two exit-`0` rows split apart so a run that wrote nothing is not folded into a trailing clause.

### Acceptance criteria

- [x] `record-verb.ts` folds a multi-line finding to one line, by the same expression `descope-verb.ts` uses
- [x] The pre-write validation covers the composed decision entry, refusing with *nothing was written* before any `patchIssueBody` call
- [x] A unit test in `record-verb.unit.test.ts` records a genuinely multi-paragraph finding — blank lines, a numbered list, bold lead-ins — and asserts the body still parses
- [x] A test drives both verbs with the same multi-paragraph input and fails if either one stops folding
- [x] No map verb can leave the body written with the ticket still open on the success path: exit `0` implies the close landed, and the interrupted state is recoverable by re-reading the map and re-running

Verified in this tree, cache bypassed: `build check --surface code` green, `--surface prose` green; the `map` suites pass, including two new cases for two decision tickets forked to one grilling session.

## Deviations

- **Said:** the issue leaves open whether a landed body write should roll back when a later step fails, and says shipping without deciding it is legitimate. **Did:** decided it — no rollback; made the interrupted state resumable by re-running instead. **Why:** two GitHub writes have no transaction, and a compensating PATCH can fail too, producing a state with no name; a resume path removes the hand-repair without inventing an undo. **Disposition:** recorded in the contract and in `record-verb.ts`'s docblock, open to reversal if a reviewer wants rollback instead.
- **Said:** touch only what the ticket names. **Did:** also edited `claude-plugins/fabrika/skills/wayfinding/contract.md`. **Why:** the fix changes the verb's answer shape (`resumed`), one refusal message, and adds a `4` trigger — leaving the contract unedited would ship a doc that misdescribes the shipped verb. The out-of-scope items the ticket names (`WRITE-UNPROVEN`, `SKILL.md` step 6) are untouched. **Disposition:** intended, scoped to the `map record` block plus one sentence in the hand-checks list.
- **Said:** the five acceptance criteria, and nothing about how the resume matches an existing entry. **Did:** narrowed `decisionCiting` into `decisionRecorded`, matching a ruling on session and question id, and left `decisionCites` session-level for the state reader. **Why:** the fifth criterion — no closed ticket without a recorded answer on the success path — was reachable through the resume branch this PR introduced; the loose match is only safe for a reader with no citation in hand. **Disposition:** intended, with two unit tests covering both directions.

Fixes #5550
