### PR TITLE
Re-gating a repaired PR leaves the governance-floor check permanently red

### DIFF
--- a/claude-plugins/fabrika/skills/governance/contract.md
+++ b/claude-plugins/fabrika/skills/governance/contract.md
@@ -29,7 +29,7 @@ access per
 | `governance sweep` | the uncited live-`accepted` records whose decision domain a subject touches, ranked, for a subject read out of a bound commit or out of the corpus | the ranking is arithmetic over a corpus; reading the shortlist, and reading the domain the ranking cannot see, is judgment |
 | `governance guards` | the anchored invariants the bound diff removes or modifies, and the guard-bearing files it touches | detecting an anchor's removal or mutation in a diff is textual and mechanical; whether the change *weakens* the invariant is judgment |
 | `governance base` | this skill's own text at the merge-base of a PR that edits it — the self fence's bytes | resolving a merge base and reading named paths at it is mechanical; judging the PR by those rules rather than the head's is the judgment |
-| `governance post` | the single sanctioned emit of the `governance` namespace verdict: compose through the `verdict-marker` wire format, re-resolve the head, upsert one comment, leak-scan, read back | marker composition, head re-resolution, the derived-namespace fence and the read-back are a protocol; the polarity and clause are judgment |
+| `governance post` | the single sanctioned emit of the `governance` namespace verdict: compose through the `verdict-marker` wire format, re-resolve the head, upsert one comment per head, leak-scan, read back | marker composition, head re-resolution, the derived-namespace fence and the read-back are a protocol; the polarity and clause are judgment |
 | `governance digest` | the decision records that landed in a window, each with its id, title, status, landing commit and whether its diff carried anchored-invariant changes | enumerating merges in a window and reading each record's frontmatter is mechanical; ranking tension and blast radius is judgment |
 | `governance readout` | the digest-publishing protocol: compose the ranked rows through the `governance-digest` wire format, upsert them into the durable artifact, read them back | composition, upsert and read-back are a protocol; the rows and their order are judgment |
 
@@ -880,10 +880,15 @@ namespace is a constant, so it cannot be aimed anywhere else even by a confused 
    it lands, `emit` composes bytes `read` rejects and step 6 fails every clean run.
 4. **Leak-scan the assembled comment** (`report/leaks.ts`, imported) — an authored machine-local path
    is the `5` refusal, a bare `@` reference the `6`.
-5. **Upsert one comment.** An existing comment by this bot whose first non-blank line reads as the
-   `governance` namespace is edited in place; otherwise a new comment is created. One namespace, one
-   comment: a second marker stacked on line 2 is un-anchored, resolves the namespace empty and
-   fail-closes a substantively-passing PR.
+5. **Upsert one comment per head.** An existing comment by this bot whose first non-blank line reads
+   as the `governance` namespace **bound to the head being posted** — its marker `sha` compared
+   prefix-tolerantly to that head — is edited in place; otherwise a new comment is created. So a
+   re-post at the same head upserts, and a post at a moved head appends, leaving the prior head's
+   verdict readable: a verdict is SHA-bound, so a new head's verdict is a different fact, not a
+   revision, and editing the old comment destroys the only record of what was true over that tree
+   (ADR 0213 named this half of rule 2's key as still open; #4007 closed it in v1). One namespace at
+   one head, one comment: a second marker stacked on line 2 is un-anchored, resolves the namespace
+   empty and fail-closes a substantively-passing PR.
 6. **Read it back, unconditionally, from live PR state** — re-fetch the comment, hand its body to the
    format's `read`, require `Found` with exactly the five fields posted, then compare the whole
    comment against the bytes sent through `normalizeForReadback`. A read-back that trusts a carried
@@ -952,10 +957,12 @@ $ echo $?
 
 **Grounding**
 
-- ADR 0058 — the marker is SHA-bound and one-per-(PR, namespace), upserted rather than appended. The
-  key is unchanged by this group: nothing in the enqueue decision asks which skill posted a
-  namespace, which is what makes one skill emitting N namespaces, and a namespace filled by a
-  non-primary reviewer, both already legal.
+- ADR 0058 — the marker is SHA-bound and one-per-(PR, namespace), upserted rather than appended. ADR
+  0213 refines rule 2's uniqueness key and names its head dimension as left open there; #4007 closed
+  that half in v1, and step 5 above carries it here: the key is (PR, namespace, head), so a re-post
+  at the same head upserts and a moved head appends. Which skill posted a namespace is still no part
+  of the key — nothing in the enqueue decision asks — which is what makes one skill emitting N
+  namespaces, and a namespace filled by a non-primary reviewer, both already legal.
 - #3173 — a hand-rolled emit posted a literal path and self-reported a false PASS; this verb is the
   single sanctioned path and the read-back is unconditional and from live state.
 - ADR 0055 — authority arrives through the ACL-checked read, never from the text being plausible.

--- a/claude-plugins/fabrika/skills/review/contract.md
+++ b/claude-plugins/fabrika/skills/review/contract.md
@@ -28,7 +28,7 @@ Named because a spec that leaves the substrate open makes the implementer guess 
 | `review ci` | the live CI check-run rollup at a head, fail-closed on incomplete enumeration | classifying check runs and proving the enumeration complete is mechanical (#4552, #3999); weighing a red check is judgment |
 | `review verdicts` | every verdict marker on the PR, per namespace, each with its `Current` / `Stale` / `Unbindable` binding against the live head and the content it bound | comment sweep + registered parse + `bindToContent` is mechanical; what a stale marker means for this round is judgment |
 | `review deviations` | the PR body's `## Deviations` section state (found / absent / malformed), its entries, and the Tier-M token scan over the diff | section detection and token scanning are mechanical; matching entry *substance* against findings is judgment (Tier R) |
-| `review post` | the single sanctioned verdict emit: compose through the `verdict-marker` wire format, bind to the inspected head at post time, post one comment per namespace, read it back | marker composition, head re-resolution, leak scan and read-back are a protocol; the polarity and clause are judgment |
+| `review post` | the single sanctioned verdict emit: compose through the `verdict-marker` wire format, bind to the inspected head at post time, post one comment per namespace at that head, read it back | marker composition, head re-resolution, leak scan and read-back are a protocol; the polarity and clause are judgment |
 | `review append-criterion` | append one reviewer-authored acceptance criterion to the linked issue under the four fences (append-only · ACL-gated fail-closed · frozen after round 3), with provenance tag | the fences and the diff-guarded append are mechanical (ADR 0079); whether a finding is in-scope is judgment |
 
 ### Considered and deliberately not derived
@@ -841,7 +841,7 @@ the poster reads success.
 `posted\t<namespace>\t<polarity>\t<sha>\t<content>\t<created|edited>\t<comment-url>` — counting
 `posted` as the first field, the **fifth** is the content digest the verdict binds (ADR 0276) and
 the **sixth** says whether the upsert created a fresh comment or edited this namespace's existing
-one.
+comment at this head.
 With `--json`: `{"outcome":"posted","namespace":…,"polarity":…,"sha":…,"content":…,"upsert":"created"|"edited","carrier":…,"commentUrl":…}`.
 
 **What the operation does, in order — each step gates the next.**
@@ -864,17 +864,22 @@ With `--json`: `{"outcome":"posted","namespace":…,"polarity":…,"sha":…,"co
    FAIL marker).
 4. **Leak-scan the assembled comment** (`report/leaks.ts`, imported) — an authored machine-local
    path is the `5` refusal.
-5. **Upsert one comment per namespace, matched under the carrier this post uses**: an existing
-   comment by this bot that already carries this namespace **under this carrier** is edited in
-   place; otherwise a new comment is created. With `marker` the match key is the format's `read`
-   over the first non-blank line. With `--carrier advisory` it is the ADR-0151 pair — the advisory
-   first line plus the `Reviewed-head: @ <sha>` body line, read through `readAdvisory` — because
-   the advisory first line withholds the SHA, so the marker `read` can never match one and a
-   marker-keyed upsert would post a **second** advisory on every re-post. The two keys are
-   disjoint: a `marker` post never edits an advisory comment, and an `advisory` post never edits a
-   marker one. One namespace, one comment, the carrier's anchor on its literal first line — a
-   second marker stacked on line 2 is un-anchored, resolves its namespace empty, and fail-closes a
-   substantively-passing PR (the live PR #2456 stall).
+5. **Upsert one comment per namespace *at this head*, matched under the carrier this post uses**: an
+   existing comment by this bot that already carries this namespace **under this carrier, bound to
+   the head being posted**, is edited in place; otherwise a new comment is created. A re-post at the
+   same head upserts; a post at a moved head appends, leaving the prior head's verdict intact — a
+   verdict is SHA-bound, so a new head's verdict is a different fact, not a revision, and editing
+   the old comment destroys the only record of what was true over that tree (ADR 0213 named this
+   half of rule 2's key as still open; #4007 closed it in v1). With `marker` the match key is the
+   format's `read` over the first non-blank line, plus its `sha` compared prefix-tolerantly to the
+   posted head. With `--carrier advisory` it is the ADR-0151 pair — the advisory first line plus the
+   `Reviewed-head: @ <sha>` body line, read through `readAdvisory`, whose SHA carries the same head
+   dimension — because the advisory first line withholds the SHA, so the marker `read` can never
+   match one and a marker-keyed upsert would post a **second** advisory on every re-post. The two
+   keys are disjoint: a `marker` post never edits an advisory comment, and an `advisory` post never
+   edits a marker one. One namespace at one head, one comment, the carrier's anchor on its literal
+   first line — a second marker stacked on line 2 is un-anchored, resolves its namespace empty, and
+   fail-closes a substantively-passing PR (the live PR #2456 stall).
 6. **Read it back, unconditionally, from live PR state**, under the same carrier — re-fetch the
    comment and, with `marker`, hand its body to the format's `read` and require `Found` with
    exactly the five fields posted; with `--carrier advisory`, require both ADR-0151 anchors —

--- a/packages/fabrika-cli/src/governance/post-verb.ts
+++ b/packages/fabrika-cli/src/governance/post-verb.ts
@@ -3,7 +3,7 @@
  *
  * Six steps, each gating the next: re-resolve the live head, re-derive the namespace requirement at
  * the bound commit, compose the first line through the `verdict-marker` wire format, leak-scan the
- * assembled comment, upsert one comment, and read it back unconditionally from live PR state.
+ * assembled comment, upsert one comment per head, and read it back unconditionally from live PR state.
  *
  * **The namespace is fixed.** There is no `--namespace` flag: this verb emits exactly one namespace,
  * so it cannot be aimed anywhere else even by a confused caller. That is the disjointness guarantee
@@ -33,9 +33,11 @@ import {answer, refuse, type VerbOutcome} from "../verb.ts";
 import {
 	contentDigest,
 	emit as emitMarker,
+	type HeadSha,
 	headSha,
 	type Polarity,
 	read as readMarker,
+	sameHead,
 	clause as toClause,
 } from "../wire/verdict-marker.ts";
 import {type AuthoredSurface, leakRefusal, readAuthored} from "./authored.ts";
@@ -76,10 +78,21 @@ export interface PostOptions {
 /** Either side may be abbreviated, so the match is a prefix in whichever direction is shorter. */
 const prefixMatch = (a: string, b: string): boolean => a.startsWith(b) || b.startsWith(a);
 
-/** Whether a comment already carries this namespace's marker — the upsert's match key. */
-const carriesNamespace = (body: string): boolean => {
+/**
+ * Whether a comment carries this namespace's marker **bound to this head** — the upsert's match key.
+ *
+ * The head dimension is what makes a re-gate at a moved head append instead of overwrite. A verdict
+ * is SHA-bound, so a new head's verdict is a different fact, not a revision of the old one, and
+ * PATCHing the prior head's comment destroys the only record of what was true over that tree. ADR
+ * 0213 refined rule 2's uniqueness key and named this half as still open; #4007 closed it in v1.
+ */
+const carriesNamespaceAt = (body: string, sha: HeadSha): boolean => {
 	const parsed = readMarker(body);
-	return parsed._tag === "Found" && parsed.value.namespace === NAMESPACE;
+	return (
+		parsed._tag === "Found" &&
+		parsed.value.namespace === NAMESPACE &&
+		sameHead(parsed.value.sha, sha)
+	);
 };
 
 /**
@@ -225,8 +238,8 @@ export const runPost = (
 		const leaked = leakRefusal(SURFACE, composed);
 		if (leaked !== null) return leaked;
 
-		// Step 5 — one namespace, one comment: a second marker stacked on line 2 is un-anchored,
-		// resolves the namespace empty, and fail-closes a substantively-passing PR.
+		// Step 5 — one namespace at one head, one comment: a second marker stacked on line 2 is
+		// un-anchored, resolves the namespace empty, and fail-closes a substantively-passing PR.
 		const me = yield* viewerLogin;
 		if (me._tag === "Failure") return unreadable("the authenticated user", pr, me.reason);
 		const comments = yield* listComments(repo, pr);
@@ -236,7 +249,7 @@ export const runPost = (
 		// and the edit lands where nobody reads (#5048).
 		const mine = latestByWriteRecency(
 			comments.value.filter(
-				(comment) => comment.author === me.value && carriesNamespace(comment.body),
+				(comment) => comment.author === me.value && carriesNamespaceAt(comment.body, inspected),
 			),
 		);
 

--- a/packages/fabrika-cli/src/governance/post-verb.unit.test.ts
+++ b/packages/fabrika-cli/src/governance/post-verb.unit.test.ts
@@ -71,6 +71,8 @@ describe("runPost", () => {
 		expect(out.stdout).toBe(`posted\tgovernance\tPASS\t${HEAD}\t${CONTENT}\tcreated\t${URL}\n`);
 	});
 
+	// `composed()` defaults to HEAD, and that is load-bearing: the upsert key carries a head
+	// dimension, so only a re-post at the SAME head takes the edit path at all.
 	it("edits the namespace's own comment rather than stacking a second one", async () => {
 		const out = await run([
 			[PULL, pull()],
@@ -82,6 +84,25 @@ describe("runPost", () => {
 			[READ_BACK, okOut(JSON.stringify({body: composed()}))],
 		]);
 		expect(out.stdout).toContain("\tedited\t");
+	});
+
+	// The head dimension of the upsert key. It shipped in v1 under #4007 and this tree did not carry
+	// it forward, so a re-gate after a repair PATCHed the prior head's verdict away and the record of
+	// what was true over that tree became unrecoverable (#5585).
+	it("leaves a prior head's verdict intact and appends at the new head", async () => {
+		const shell = fakeShell([
+			[PULL, pull()],
+			...binding(),
+			[PATHS_AT(), paths(".decisions/0240-x.md", "src/cart.ts")],
+			[VIEWER, okOut("kampus-bot\n")],
+			[COMMENTS, comments({id: 77, body: composed("the round before the repair\n", OLD_HEAD)})],
+			[CREATE, created()],
+			[READ_BACK, okOut(JSON.stringify({body: composed()}))],
+		]);
+		const out = await Effect.runPromise(Effect.provide(runPost(options), shell.layer));
+		expect(out.code).toBe(0);
+		expect(out.stdout).toContain("\tcreated\t");
+		expect(shell.calls.some((call) => PATCH.test(call))).toBe(false);
 	});
 
 	it("emits the record with --json, naming the fixed namespace", async () => {

--- a/packages/fabrika-cli/src/review/post-verb.ts
+++ b/packages/fabrika-cli/src/review/post-verb.ts
@@ -30,9 +30,11 @@ import {answer, refuse, type VerbOutcome} from "../verb.ts";
 import {
 	contentDigest,
 	emit as emitMarker,
+	type HeadSha,
 	headSha,
 	type Polarity,
 	read as readMarker,
+	sameHead,
 	clause as toClause,
 } from "../wire/verdict-marker.ts";
 import {emitAdvisory, readAdvisory, reviewedHeadLine} from "./advisory.ts";
@@ -147,8 +149,8 @@ const mismatchOf = (
 };
 
 /**
- * Whether a comment already holds this namespace's verdict **under this carrier** — step 5's
- * upsert-match key.
+ * Whether a comment already holds this namespace's verdict **under this carrier, at this head** —
+ * step 5's upsert-match key.
  *
  * The key is per-carrier because the two carriers anchor on different bytes, and neither read can
  * stand in for the other. An advisory withholds the SHA from its first line by design (ADR 0111), so
@@ -156,11 +158,30 @@ const mismatchOf = (
  * created a second comment, against the one-namespace-one-comment invariant this step exists for
  * (#4992). Matching per carrier also keeps the pair disjoint in the other direction — a marker post
  * never edits an advisory comment, and vice versa.
+ *
+ * The head dimension makes a re-gate at a moved head append instead of overwrite: a verdict is
+ * SHA-bound, so a new head's verdict is a different fact, not a revision, and PATCHing the prior
+ * head's comment destroys the only record of what was true over that tree. Both carriers can be
+ * keyed on it — the marker binds its head on line 1, the advisory on its `Reviewed-head:` line
+ * (ADR 0151), which `readAdvisory` already requires. ADR 0213 refined rule 2's uniqueness key and
+ * named this half as still open; #4007 closed it in v1.
  */
-const carriesNamespace = (body: string, carrier: Carrier, namespace: string): boolean => {
-	if (carrier === "advisory") return readAdvisory(body)?.namespace === namespace;
+const carriesNamespaceAt = (
+	body: string,
+	carrier: Carrier,
+	namespace: string,
+	sha: HeadSha,
+): boolean => {
+	if (carrier === "advisory") {
+		const advisory = readAdvisory(body);
+		return advisory !== null && advisory.namespace === namespace && sameHead(advisory.sha, sha);
+	}
 	const parsed = readMarker(body);
-	return parsed._tag === "Found" && parsed.value.namespace === namespace;
+	return (
+		parsed._tag === "Found" &&
+		parsed.value.namespace === namespace &&
+		sameHead(parsed.value.sha, sha)
+	);
 };
 
 /** Steps 1, 2 and 5's reads failing is `11`: nothing was written, so the outcome is known-unwritten. */
@@ -289,7 +310,7 @@ export const runPost = (
 		const leaked = leakRefusal(SURFACE, composed);
 		if (leaked !== null) return leaked;
 
-		// Step 5 — one namespace, one comment: edit this namespace's own comment, else create one.
+		// Step 5 — one namespace at one head, one comment: edit this head's own comment, else create one.
 		const me = yield* viewerLogin;
 		if (me._tag === "Failure") return unreadable("the authenticated user", pr, me.reason);
 		const comments = yield* listComments(repo, pr);
@@ -300,7 +321,8 @@ export const runPost = (
 		const mine = latestByWriteRecency(
 			comments.value.filter(
 				(comment) =>
-					comment.author === me.value && carriesNamespace(comment.body, carrier, namespace),
+					comment.author === me.value &&
+					carriesNamespaceAt(comment.body, carrier, namespace, inspected),
 			),
 		);
 

--- a/packages/fabrika-cli/src/review/post-verb.unit.test.ts
+++ b/packages/fabrika-cli/src/review/post-verb.unit.test.ts
@@ -105,6 +105,8 @@ describe("runPost", () => {
 		expect(body.split("\n").filter((line) => line.startsWith("review-doc:"))).toHaveLength(1);
 	});
 
+	// The prior comment is bound to HEAD, not OLD_HEAD, and that is load-bearing: the upsert key
+	// carries a head dimension, so only a re-post at the SAME head takes the edit path at all.
 	it("edits this namespace's existing comment instead of stacking a second one", async () => {
 		const shell = fakeShell([
 			[PULL, pull({comments: 1})],
@@ -116,7 +118,7 @@ describe("runPost", () => {
 				COMMENTS,
 				comments({
 					id: 42,
-					body: `review-doc: PASS @ ${OLD_HEAD} — older round`,
+					body: `review-doc: PASS @ ${HEAD} — earlier round at this head`,
 					author: "kampus-bot",
 				}),
 			],
@@ -127,6 +129,58 @@ describe("runPost", () => {
 		expect(out.code).toBe(0);
 		expect(out.stdout).toContain("\tedited\t");
 		expect(shell.calls.some((call) => CREATE.test(call))).toBe(false);
+	});
+
+	// The head dimension of the upsert key. It shipped in v1 under #4007 and this tree did not carry
+	// it forward, so a re-gate after a repair PATCHed the prior head's verdict away and the record of
+	// what was true over that tree became unrecoverable (#5585). Both carriers are pinned, because
+	// each binds its head on different bytes and a fix to one says nothing about the other.
+	it("leaves a prior head's marker verdict intact and appends at the new head", async () => {
+		const shell = fakeShell([
+			[PULL, pull({comments: 1})],
+			...binding(),
+			[PATHS_AT(), paths("src/cart.ts", "README.md")],
+			[FILES, files("skills/deploy/SKILL.md")],
+			[USER, okOut("kampus-bot")],
+			[
+				COMMENTS,
+				comments({
+					id: 42,
+					body: `review-doc: PASS @ ${OLD_HEAD} — the round before the repair`,
+					author: "kampus-bot",
+				}),
+			],
+			[CREATE, created],
+			[READBACK, commentBody(`${MARKER}\n\n${BODY}`)],
+		]);
+		const out = await Effect.runPromise(Effect.provide(runPost(options), shell.layer));
+		expect(out.code).toBe(0);
+		expect(out.stdout).toContain("\tcreated\t");
+		expect(shell.calls.some((call) => PATCH.test(call))).toBe(false);
+	});
+
+	it("leaves a prior head's advisory intact and appends at the new head", async () => {
+		const advisoryFor = (sha: string): string =>
+			`review-doc: advisory — blocking-set PR (manual merge)\n\nReviewed-head: @ ${sha}\n\n${BODY}`;
+		const shell = fakeShell([
+			[PULL, pull({comments: 1})],
+			...binding(),
+			[PATHS_AT(), paths("src/cart.ts", "README.md")],
+			[FILES, files("skills/deploy/SKILL.md")],
+			[USER, okOut("kampus-bot")],
+			[COMMENTS, comments({id: 42, body: advisoryFor(OLD_HEAD), author: "kampus-bot"})],
+			[CREATE, created],
+			[READBACK, commentBody(advisoryFor(HEAD))],
+		]);
+		const out = await Effect.runPromise(
+			Effect.provide(
+				runPost({...options, carrier: "advisory", clause: "blocking-set PR (manual merge)"}),
+				shell.layer,
+			),
+		);
+		expect(out.code).toBe(0);
+		expect(out.stdout).toContain("\tcreated\t");
+		expect(shell.calls.some((call) => PATCH.test(call))).toBe(false);
 	});
 
 	it("stamps the write-recency line on the comment it creates", async () => {
@@ -143,7 +197,10 @@ describe("runPost", () => {
 			[PATHS_AT(), paths("src/cart.ts", "README.md")],
 			[FILES, files("skills/deploy/SKILL.md")],
 			[USER, okOut("kampus-bot")],
-			[COMMENTS, comments({id: 42, body: `review-doc: FAIL @ ${OLD_HEAD} — older round`})],
+			[
+				COMMENTS,
+				comments({id: 42, body: `review-doc: FAIL @ ${HEAD} — earlier round at this head`}),
+			],
 			[PATCH, okOut(JSON.stringify({html_url: URL}))],
 			[READBACK, commentBody(`${MARKER}\n\n${BODY}`)],
 		]);
@@ -168,12 +225,12 @@ describe("runPost", () => {
 					{
 						id: 42,
 						createdAt: "2026-08-09T03:46:59Z",
-						body: `review-doc: FAIL @ ${OLD_HEAD} — the older duplicate`,
+						body: `review-doc: FAIL @ ${HEAD} — the older duplicate`,
 					},
 					{
 						id: 77,
 						createdAt: "2026-08-09T04:05:28Z",
-						body: `review-doc: FAIL @ ${OLD_HEAD} — the newer duplicate`,
+						body: `review-doc: FAIL @ ${HEAD} — the newer duplicate`,
 					},
 				),
 			],
@@ -203,12 +260,12 @@ describe("runPost", () => {
 					{
 						id: 42,
 						createdAt: "2026-08-09T03:46:59Z",
-						body: `review-doc: FAIL @ ${OLD_HEAD} — re-posted in place\n\nVerdict-written: 2026-08-09T05:10:00Z`,
+						body: `review-doc: FAIL @ ${HEAD} — re-posted in place\n\nVerdict-written: 2026-08-09T05:10:00Z`,
 					},
 					{
 						id: 77,
 						createdAt: "2026-08-09T04:05:28Z",
-						body: `review-doc: FAIL @ ${OLD_HEAD} — the newer slot, older verdict`,
+						body: `review-doc: FAIL @ ${HEAD} — the newer slot, older verdict`,
 					},
 				),
 			],
@@ -425,7 +482,7 @@ describe("runPost", () => {
 			[PATHS_AT(), paths("src/cart.ts", "README.md")],
 			[FILES, files("skills/deploy/SKILL.md")],
 			[USER, okOut("kampus-bot")],
-			[COMMENTS, comments({id: 42, body: advisoryFor(OLD_HEAD), author: "kampus-bot"})],
+			[COMMENTS, comments({id: 42, body: advisoryFor(HEAD), author: "kampus-bot"})],
 			[PATCH, okOut(JSON.stringify({html_url: URL}))],
 			[READBACK, commentBody(advisoryFor(HEAD))],
 		]);
@@ -435,8 +492,10 @@ describe("runPost", () => {
 		expect(again.calls.some((call) => CREATE.test(call))).toBe(false);
 	});
 
+	// Both prior comments below sit at HEAD, so the only thing that can send either post down the
+	// create path is the carrier mismatch — at OLD_HEAD the head dimension would carry the test.
 	it("never crosses the carriers: a marker post skips an advisory comment, and the reverse", async () => {
-		const advisory = `review-doc: advisory — blocking-set PR (manual merge)\n\nReviewed-head: @ ${OLD_HEAD}\n\n${BODY}`;
+		const advisory = `review-doc: advisory — blocking-set PR (manual merge)\n\nReviewed-head: @ ${HEAD}\n\n${BODY}`;
 		const overAdvisory = fakeShell([
 			[PULL, pull({comments: 1})],
 			...binding(),
@@ -461,7 +520,7 @@ describe("runPost", () => {
 				COMMENTS,
 				comments({
 					id: 42,
-					body: `review-doc: PASS @ ${OLD_HEAD} — older round`,
+					body: `review-doc: PASS @ ${HEAD} — a marker at this same head`,
 					author: "kampus-bot",
 				}),
 			],


### PR DESCRIPTION
The verdict upsert in `fabrika-cli` matched on namespace alone, with no head dimension. So a re-gate at a **new** head PATCHed the **prior** head's verdict comment away: on PR #5573 the `d2fca7f0` verdicts are unrecoverable, and both comments now read as though they were authored at `03:48:40Z` about a head that did not exist yet.

This adds the head to the match key in both post verbs. A re-post at the same head still upserts; a post at a moved head now appends, leaving the prior head's comment intact as the record of what was true over that tree.

That is not a new position — it is the one already ruled. ADR 0213 refined ADR 0058 rule 2's uniqueness key and its closing note named "the *head* dimension of the same upsert key" as explicitly **not** fixed there, handing it to #4007. #4007 shipped it in v1, where `packages/pipeline-cli/TOOLS.md` documents the resulting contract as *"A re-post at the same head upserts; anything else appends."* `fabrika-cli` did not carry it forward. So this is a regression of a landed fix, not a change of direction, and it needs no ADR amendment.

Both carriers are keyed, because each binds its head on different bytes: the marker on line 1, the advisory on its `Reviewed-head:` line (ADR 0151), which `readAdvisory` already requires and returns as `AdvisoryCarrier.sha`. Keying only the marker would have left every §CP advisory re-post still overwriting.

**The two contracts now say what the code does.** `claude-plugins/fabrika/skills/review/contract.md` and `claude-plugins/fabrika/skills/governance/contract.md` both described step 5 as a namespace-only upsert. Both step 5s, the two verb-inventory rows, `review post`'s output-field sentence and the governance grounding note on ADR 0058 now describe the head-keyed key, so nothing normative still records the behavior this PR replaced.

**Regression tests.** Three new cases pin the head dimension — governance marker, review marker, review advisory. I verified they actually catch it: with the three `sameHead` conjuncts removed and nothing else changed, exactly those three fail and the other 46 in those files pass.

**Existing tests that moved.** Six cases held their prior comment at `OLD_HEAD` while asserting `edited`, so they were pinning the defect as correct. Each is really about something else — namespace matching, #5048's newest-match, the write-recency stamp ordering, carrier disjointness — so each prior comment moved to `HEAD`, which is the only way those paths still exercise the edit branch. The two whose same-head binding is now load-bearing carry a line saying so, so a future reader does not "simplify" them back.

**One thing #5585's framing understates**, from reading `claude-plugins/fabrika/skills/ship/contract.md:759-766`: the `governance-floor` context is not a required check — "until it is required the check is red-but-not-blocking" — and `ship` resolves the same verdict itself through `ship gate` at its own moment. So mechanic 1's cost is a misleading red and normalized red-check noise, not a blocked merge. That does not make it less worth fixing, but it should be priced correctly by whoever builds it.

Full `fabrika-cli` suite: 4521 passed, 294 files. `fabrika build check` green in-tree on both surfaces — `--surface code` with the two `contract.md` files unvalidated, `--surface prose` with the four `.ts` files unvalidated, so every changed file is read by one of the two.

## Deviations

- **Scope narrowing** — **Said:** #5585 carries two mechanics — mechanic 1 (`governance-floor.yml` is `on: pull_request` only, so the floor job runs before the gate posts and nothing re-fires it) and mechanic 2 (the verdict upsert has no head dimension). **Did:** fixed mechanic 2 only; this PR is `Part of`, not `Fixes`. **Why:** the issue names three candidate fixes for mechanic 1 on three different surfaces with different costs and states it "does not rule" among them; picking one is a design call I will not invent inside a build. **Disposition:** stated here; the founder ruled mechanic 1 on 2026-08-16 — candidate 2, the gate's own post asserts the floor at its own head — and sequenced it to build on #5585 after this PR ships, so acceptance criterion 1 is out of this PR's scope by ruling, not left unmet by accident.
- **Known defect left unfixed** — **Said:** fixing the upsert is one of the two halves #5585 asks for. **Did:** left mechanic 1's race exactly as it was. **Why:** the two are independent — the floor job still reads comment state before the verdict lands, whether that verdict arrives as an edit or as a new comment. **Disposition:** stated here so "the upsert is fixed" is not misread as closing the race.
- **Pre-existing test or fixture changed** — **Said:** the existing `post-verb` suites pinned the upsert's edit branch with their prior comment held at `OLD_HEAD`. **Did:** moved six of those prior comments to `HEAD`, and added three new cases that pin the head dimension directly (governance marker, review marker, review advisory). **Why:** under the new key an `OLD_HEAD` prior comment takes the create path, so those six would have stopped exercising the edit branch they exist to test — each is really about namespace matching, #5048's newest-match, write-recency ordering or carrier disjointness, and moving the fixture keeps each testing its own subject rather than laundering the new behavior. The two whose same-head binding became load-bearing carry a line saying so. **Disposition:** stated here; verified by removing the three `sameHead` conjuncts, which fails exactly the three new cases and passes the other 46.
- **Out-of-scope change** — **Said:** review round 1 found `claude-plugins/fabrika/skills/review/contract.md` step 5 and `claude-plugins/fabrika/skills/governance/contract.md` step 5 still describing the head-less upsert key, and asked for the contract fix or an argument to split it. **Did:** folded the contract fix into this PR — both step 5s, the two verb-inventory rows, `review post`'s output-field sentence and the governance grounding note on ADR 0058. **Why:** the driver ruled the fold, and CLAUDE.md is explicit that source wins when docs and code disagree; leaving a normative contract stale re-creates the condition that caused this regression. **Disposition:** stated here; it puts `claude-plugins/fabrika/**` in the diff, which the reviewer reads as `harness: true`, so a `governance` verdict is derived-required this round — the accepted price of changing a normative contract.
- **Scope narrowing** — **Said:** at build time `build issue 5585` reported `acceptance criteria malformed: heading level 2, expected 3`, so the criteria were read from the body by hand. **Did:** did not touch #5585's heading. **Why:** it is the issue's wire defect, filed as #5565, not this PR's to fix. **Disposition:** resolved outside this PR — the driver corrected the heading and checkboxes, and `review criteria 5585` now parses 5 rows.

Part of #5585
