### PR TITLE
Build the topbar search group from the field's own left/right slots

### DIFF
--- a/apps/web/src/components/layout/Topbar.css
+++ b/apps/web/src/components/layout/Topbar.css
@@ -92,21 +92,12 @@
 	flex: 1;
 }
 
+/* The form is a bare layout box. The pill a reader sees is the field's own
+   [data-part="control"], which is also the element global.css paints the focus ring on — one
+   element draws the border and owns the ring, so they cannot disagree (#5660). */
 .kp-topbar__search {
 	display: flex;
-	align-items: center;
-	gap: 6px;
 	width: 240px;
-	height: 24px;
-	/* Asymmetric on purpose: the trailing edge holds a ⌘K keycap, which carries its own
-	   box, so it needs half the breathing room the leading magnifier does. */
-	padding: 0 var(--s-1) 0 var(--s-2);
-	background: var(--surface);
-	border: 1px solid var(--border);
-	border-radius: var(--r-sm);
-}
-.kp-topbar__search:focus-within {
-	border-color: var(--accent);
 }
 .kp-topbar__search svg {
 	color: var(--text-muted);
@@ -117,16 +108,30 @@
 	min-width: 0;
 }
 .kp-topbar__search-field[data-scope="field"] [data-part="control"] {
-	--manti-field-height: var(--letter-size);
-	width: 100%;
-	border: 0;
-	background: transparent;
-	box-shadow: none;
-	padding: 0;
+	/* An addon's glyph lands at 2 × --manti-field-addon-padding-x from the border, not at one:
+	   Manti pulls the addon's box out of the control's padding by (addon − field) and then re-adds
+	   `addon` as the addon's own padding. So s-1 here is what puts the magnifier at the s-2 the
+	   hand-rolled group used, and the input text still starts at --manti-field-padding-x. */
+	--manti-field-height: 24px;
+	--manti-field-padding-x: var(--s-2);
+	--manti-field-addon-padding-x: var(--s-1);
+	gap: 6px;
+	background: var(--surface);
+	border: 1px solid var(--border);
+	border-radius: var(--r-sm);
 }
-.kp-topbar__search-field[data-scope="field"][data-part="root"]:focus-within [data-part="control"] {
-	border-color: transparent;
-	box-shadow: none;
+/* Manti recolours the control's border to the accent on :focus-within. global.css already paints
+   the shared ring on this same element, so letting both fire is the doubled treatment #5660 is
+   about — only now concentric instead of misaligned. The ring is the one focus owner, so the
+   border holds its resting colour. This neutralizes; it does not paint. */
+.kp-topbar__search-field[data-scope="field"] [data-part="control"]:focus-within {
+	border-color: var(--border);
+}
+/* Asymmetric on purpose: the trailing edge holds a ⌘K keycap, which carries its own box, so it
+   needs half the breathing room the leading magnifier does. Dropping the addon's own trailing
+   padding leaves the keycap at s-1, where the form's asymmetric padding used to put it. */
+.kp-topbar__search-field[data-scope="field"] [data-part="addon"][data-position="right"] {
+	padding-inline-end: 0;
 }
 .kp-topbar__search-field[data-scope="field"] [data-part="input"] {
 	font: var(--t-body-sm);

--- a/apps/web/src/components/layout/Topbar.test.tsx
+++ b/apps/web/src/components/layout/Topbar.test.tsx
@@ -140,16 +140,32 @@ describe("Topbar accent-scarcity containment law (#2614)", () => {
 		expect(temaHover?.body).not.toMatch(/var\(--accent(-11)?\)/);
 	});
 
-	it("arama odağını yalnızca dış kabuk çizer; Manti kontrolü ikinci halka üretmez", () => {
-		const searchControlFocus = rules.find(
+	// #5660. The search has exactly one focus owner, and it is the shared ring global.css paints on
+	// [data-part="control"]. Two things make that true and both are asserted: the stylesheet
+	// declares no focus treatment of its own (a second one is the mismatched double-paint), and the
+	// control is the element drawing the visible border (otherwise the ring outlines a box the
+	// reader cannot see, which is what the hand-rolled group did).
+	it("the search paints no focus treatment of its own, and the ring's box is the bordered one", () => {
+		const focusRules = rules.filter(
+			(r) => /kp-topbar__search/.test(r.selector) && /:focus/.test(r.selector),
+		);
+		// Any focus rule here may only NEUTRALIZE — hold the resting border against Manti's accent
+		// recolour. One that paints an outline or an accent is the second treatment coming back.
+		for (const r of focusRules) {
+			expect(r.body).not.toMatch(/outline/);
+			expect(r.body).not.toMatch(/var\(--accent/);
+		}
+		expect(focusRules.some((r) => /border-color:\s*var\(--border\)/.test(r.body))).toBe(true);
+
+		const control = rules.find(
 			(r) =>
 				/kp-topbar__search-field/.test(r.selector) &&
-				/:focus-within/.test(r.selector) &&
-				/\[data-part="control"\]/.test(r.selector),
+				/\[data-part="control"\]/.test(r.selector) &&
+				!/:focus/.test(r.selector),
 		);
-		expect(searchControlFocus).toBeDefined();
-		expect(searchControlFocus?.body).toMatch(/border-color:\s*transparent/);
-		expect(searchControlFocus?.body).toMatch(/box-shadow:\s*none/);
+		expect(control).toBeDefined();
+		expect(control?.body).toMatch(/border:\s*1px solid var\(--border\)/);
+		expect(control?.body).toMatch(/border-radius:\s*var\(--r-sm\)/);
 	});
 
 	it("kompakt üst çubuk butonu Manti'nin ortak min-height değerine esnemez", () => {

--- a/apps/web/src/components/layout/Topbar.tsx
+++ b/apps/web/src/components/layout/Topbar.tsx
@@ -142,12 +142,14 @@ export function Topbar({
 				onSearchSubmit?.(input?.value ?? "");
 			}}
 		>
-			{/* Drawn Lucide, not the hand-inlined magnifier this replaced: ADR 0166 §2 rules
-			    icons are drawn glyphs, and §4 floors them at 16 — below that a stroke muddies
-			    on a dark surface, which is exactly how the old 11px one read. */}
-			<Icon icon={Search} size={12} />
 			{/* key + defaultValue: uncontrolled so it stays editable, yet a query→query
 			    navigation re-seeds the echoed value by remounting with the new default. */}
+			{/* The magnifier and the keycap ride the field's own `left`/`right` slots rather than
+			    sitting beside it. They land inside [data-part="control"], which is the element
+			    global.css paints the focus ring on — hand-rolling the group put the ring on a box
+			    that was not the one drawing the border (#5660). Size 12 is below ADR 0166 §4's
+			    floor on purpose: ADR 0240's labelled-glyph tier names this exact call site, since
+			    the adjacent `ara…` placeholder already carries the meaning. */}
 			<Input
 				key={searchQuery}
 				id="topbar-search"
@@ -156,8 +158,10 @@ export function Topbar({
 				defaultValue={searchQuery}
 				placeholder="ara…"
 				aria-label="Ara"
+				fullWidth
+				left={<Icon icon={Search} size={12} />}
+				right={<Kbd>⌘K</Kbd>}
 			/>
-			<Kbd>⌘K</Kbd>
 		</form>
 	);
 	// The three-way theme picker (#2612) — the sole theme control. Signed-in ⇒ it lives in


### PR DESCRIPTION
The topbar search drew two focus treatments on two different boxes. The magnifier and the `⌘K` keycap were siblings of `<Input>` inside `form.kp-topbar__search`, i.e. outside the Manti field root, and the control's border was stripped — so the pill a reader saw was the `<form>`, while the ring `global.css` paints on `[data-part="control"]` outlined a smaller inner box with the magnifier stranded outside it. The form separately recoloured its own border on `:focus-within`, so both fired at once.

Both adornments now ride the field's own `left` / `right` slots. They render inside `[data-part="control"]`, which makes the ring's target and the bordered element the same element — the design system's own answer to this shape, per `design-system-manifest.md`'s "reach for the composite primitive, never hand-build".

**Measured in a real browser** (Chromium via Playwright over the Vite dev build, `⌘K` to focus so `:focus-visible` is the real trigger):

| | before | after |
|---|---|---|
| form box | 781,7 240×24 | 781,7 240×24 |
| control box (ring's target) | inner, narrower | **781,7 240×24** — same box |
| control outline on focus | `2px solid` accent, offset 2px | unchanged |
| control border on focus | accent | `--border`, its resting colour |
| form / input outline | form recoloured its border | none on either |
| magnifier glyph | 8px inside the border | 8px |
| `⌘K` right edge | 4px inside the border | 4px |

Geometry is pixel-identical to what shipped; only the focus behaviour changed. Verified in both themes — dark measured separately, border `rgb(60,57,63)` with the same single ring.

One thing the issue did not predict: Manti recolours the control's border to the accent on `:focus-within`, and that survived the move — so the ring and an accent border were both firing again, concentric this time instead of misaligned. Acceptance criterion 1 says the two must not both fire, so there is now one rule holding the border at its resting colour. It neutralizes, it does not paint; the shared ring stays the single focus owner.

**Addon geometry, since it is not obvious.** Manti lands an addon's glyph at `2 × --manti-field-addon-padding-x` from the border, not one: it pulls the addon's box out of the control's padding by `(addon − field)` and then re-adds `addon` as the addon's own padding. That is why the leading inset is set to `--s-1` to land the magnifier at the `--s-2` the hand-rolled group used, and why the trailing keycap drops the addon's own padding rather than taking a second padding value.

Acceptance criteria: all seven met. The `⌘K` shortcut still focuses the input (asserted in the measurement run), `Topbar.test.tsx` is 20/20, the whole `client` project is 287/287, typecheck and biome clean. Every selector added is scoped to `.kp-topbar__search*`, so the admin roster search — the call site that was already correct because it keeps a real border on its own control — is untouched.

## Deviations

- **One existing test asserted the defect and was rewritten, not deleted.** `arama odağını yalnızca dış kabuk çizer` required `border-color: transparent` and `box-shadow: none` on the control's `:focus-within` — i.e. it pinned "the outer shell owns focus, the Manti control is neutralized", which is the architecture this PR inverts. Its *intent* (exactly one ring, never two) is what #5660 wants, so the case now asserts that intent under the new ownership: no focus rule here may paint an outline or an accent, one must hold the resting border, and the control must be the element drawing the visible border. Renamed to English per CLAUDE.md's technical-English rule; its Turkish-named neighbours were left alone as out of scope.
- **The comment above the magnifier was repointed from ADR 0166 §4 to ADR 0240.** It cited the retired 16px floor directly above a deliberate `size={12}`, so re-placing it verbatim onto the line I was already rewriting would have re-shipped a note I knew to be wrong. `size={12}` itself is unchanged and still ruled — ADR 0240 names this exact call site. This overlaps #5662, which was filed for that comment; triage decides whether that issue is now spent.
- **`--letter-size` is gone from this control.** It fed `--manti-field-height` while the form forced a fixed `height: 24px` around it, so the pill was 24px regardless. Now that the control *is* the pill, its height is stated once, as the 24px that was already rendering. This is not a density regression — the old value never reached the rendered box.
- **No golden-screen capture.** The before/after above is a measured-geometry table and local screenshots, not a blessed golden. `golden-pointer.json` has no entry for this surface, and blessing one is not this PR's scope.

Fixes #5660
