### PR TITLE
triage skill runs as a forked subagent via context: fork

### DIFF
--- a/claude-plugins/fabrika/skills/triage/SKILL.md
+++ b/claude-plugins/fabrika/skills/triage/SKILL.md
@@ -1,6 +1,7 @@
 ---
 name: triage
 description: Turn one raw `status:needs-triage` issue into a single actionable unit a builder can pick up cold — classified, enriched from the code, priced, homed, and addressed to whoever picks it up. Trigger on "/triage", "triage the queue", "triage issue #N", "process needs-triage", "classify these issues", and whenever someone asks to make the backlog actionable or pickable. This is the guardrail between raw intake and pickable work: nothing reaches a builder without passing through here, so a wrong-but-well-formed label written here travels downstream unchallenged. Done when the issue carries exactly one `type:`, one `p`, `status:triaged`, one `ready-for:`, and a home — or has left the queue as `status:needs-info` or a killed agent filing.
+context: fork
 ---
 
 # triage


### PR DESCRIPTION
Adds `context: fork` to the triage skill's frontmatter so invoking `/triage` runs it in its own subagent context instead of consuming the caller's, per the Claude Code skills doc (https://code.claude.com/docs/en/skills#run-skills-in-a-subagent). The skill content becomes the subagent's prompt; the caller keeps working and gets the result back when it completes.

Requested directly by the founder in-session (2026-08-16).

Notes:
- No `agent:` override — the default agent type keeps the full tool set triage needs (Bash for the fabrika CLI + gh).
- Default backgrounding is kept, so parallel triage fan-out comes for free.

🤖 Generated with [Claude Code](https://claude.com/claude-code)