### PR TITLE
A fabrika lane ledger the operator loop can drive, built on @demlik/tea

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -55,8 +55,9 @@ apps/web/tests/e2e/.auth
 # Local scratch (uncommitted explorations)
 /.scratch/
 
-# fabrika's durable spend ledger — one appended JSON line per completed eval run (#5009).
-# Per-machine measurement evidence, written by `fabrika eval run`; never committed.
+# fabrika's local machine state — never committed. The durable spend ledger (one appended
+# JSON line per completed eval run, #5009) and the lane ledger's per-lane state
+# (`.fabrika/lanes/<n>/workflow.json` + `events.jsonl`, written by `fabrika lane`, #5673).
 /.fabrika/
 
 # pipeline-cli data dir: where the SessionStart install.sh drops the installed

--- a/packages/fabrika-cli/README.md
+++ b/packages/fabrika-cli/README.md
@@ -10,7 +10,9 @@ the `/review` contract specifies; `review-ui`, the three the `/review-ui` contra
 (capture a PR's preview, emit the `review-ui` verdict, or post a typed blocker note);
 `ship`, the thirteen the `/ship` contract specifies; `map`, the eight the `/wayfinding`
 contract specifies (chart one destination's fog, and drain its frontier); `spend`, what one fabrika run cost in
-tokens; `wire`, which owns the byte-level formats two skills meet through on a GitHub
+tokens; `lane`, the four-verb lane ledger the operator loop drives — a @demlik/tea machine
+folded fresh from an append-only `events.jsonl` on every invocation; `wire`, which owns the
+byte-level formats two skills meet through on a GitHub
 artifact; `status`, the six the `/fabrika` front door's contract specifies (what state the
 factory is in); and `hook`, which reads the envelope Claude Code writes to a hook's stdin — the group
 [fabrika's hook surface](../../claude-plugins/fabrika/hooks.json) declares against.
@@ -798,6 +800,53 @@ Three things shape it:
   over the one model vocabulary in [`src/models.ts`](./src/models.ts) — the allowlist, the harness
   alias map and the committed default pin, which are one table because the request is canonicalized
   through the aliases *before* the allowlist sees it.
+
+## The `lane` group
+
+The minimal lane ledger the operator loop drives by hand
+([#5673](https://github.com/kamp-us/phoenix/issues/5673); engine direction recorded on
+[#5570](https://github.com/kamp-us/phoenix/issues/5570), de-risked by the recorded-run spikes
+[#5671](https://github.com/kamp-us/phoenix/issues/5671)/[#5672](https://github.com/kamp-us/phoenix/issues/5672)).
+A lane is a directory — `.fabrika/lanes/<n>/workflow.json` plus an append-only `events.jsonl` —
+and **fold = state**: every verb is a fresh process that re-folds the whole log through a
+[@demlik/tea](https://github.com/kamp-us/demlik) Transitions machine; no resident process, no
+snapshot. Lane state is local and never committed (the repo's `/.fabrika/` gitignore entry).
+
+| Verb | Answers |
+|---|---|
+| `lane status` | the derived state: compound `stateValue` (active phase → per-task leaf, future phases `"waiting"`), `status` active/done, per-task `{retries, maxRetries, …}` context and the tripped tasks in `errors` |
+| `lane transition` | records one operator event after the machine accepts it — `{previous, event, current, taskAffected}` |
+| `lane history` | the log verbatim, one `{task, event, at}` per event — `from`/`to` are reconstructible by folding, never stored |
+| `lane print` | the compiled topology: phases, the two workflow terminals, and each state's legal events |
+
+To open a lane, copy a template in and speak the operator's six events —
+`DONE` / `PASS` / `FAIL` / `BLOCKED` / `WIP` / `UNBLOCKED`:
+
+```bash
+mkdir -p .fabrika/lanes/5673
+cp packages/fabrika-cli/src/lane/templates/coder.workflow.json .fabrika/lanes/5673/workflow.json
+fabrika lane transition 5673 WIP     # queued → build (--task is implied on a single-task lane)
+fabrika lane status 5673
+```
+
+Three behaviours are worth knowing before you call it:
+
+- **An invalid event refuses loudly and appends nothing.** An event the current state holds no
+  cell for surfaces tea's own `NoCellError` verbatim at exit `12`, and `events.jsonl` is left
+  byte-identical — where XState silently swallows an unhandled event, the machine here names it
+  (#5671, run 8). The six-event vocabulary, the active-phase check and the finished-workflow
+  check refuse the same way.
+- **The compiler recognizes shapes, never guard names.** An array on an event is read
+  structurally as `[retry-while-retries-remain, else-fallthrough]`; a transition targeting a
+  `history` node resumes the state the task left, carried as a `was` field in the folded state;
+  a phase's `onDone` pair names the workflow terminals. `guard`/`actions` strings in
+  `workflow.json` are inert data — there is no name-normalization anywhere.
+- **One committed template today.** [`src/lane/templates/coder.workflow.json`](./src/lane/templates/coder.workflow.json)
+  is the static single-issue coder machine: `queued → build → review → ship`, review `FAIL`
+  retried on a budget of 2 then frozen (freeze-after-2 as data), `BLOCKED`/`UNBLOCKED`
+  suspend-resume from any working state, and ship `BLOCKED` parking in `human:cp-approval`
+  until the approval lands as `UNBLOCKED`. Per-type templates beyond it are deliberately out of
+  scope until a real lane snaps against the six-event vocabulary (#5570).
 
 ## The `spend` group
 

--- a/packages/fabrika-cli/package.json
+++ b/packages/fabrika-cli/package.json
@@ -54,6 +54,7 @@
 		"cli": "node src/bin.ts"
 	},
 	"dependencies": {
+		"@demlik/tea": "catalog:",
 		"@effect/platform-node": "catalog:",
 		"@playwright/test": "catalog:",
 		"effect": "catalog:"

--- a/packages/fabrika-cli/src/exit-code-alignment.ts
+++ b/packages/fabrika-cli/src/exit-code-alignment.ts
@@ -266,6 +266,22 @@ export const PATTERN_SEATS: SharedSeats = {
 	PRECONDITION_UNKNOWN: "PRECONDITION_UNKNOWN",
 };
 
+/**
+ * `lane`'s seats: four, on `spend`'s reading widened by a write.
+ *
+ * Its verbs read a local lane directory and append to its log, so the base's facts they establish
+ * are the target that is not there (`LANE_ABSENT`), the target read in full that is not the shape
+ * (`MALFORMED_RECORD`, the `review-ui` whole-record widening of the section seat), the append that
+ * did not land (`APPEND_UNKNOWN`), and the read that failed before any of that could be proven
+ * (`LANE_UNREADABLE`). The private band is `12`-`13`: the refused event and the unresolved task.
+ */
+export const LANE_SEATS: SharedSeats = {
+	MALFORMED_RECORD: "BAD_SECTIONS",
+	LANE_ABSENT: "NO_TARGET",
+	APPEND_UNKNOWN: "WRITE_UNKNOWN",
+	LANE_UNREADABLE: "PRECONDITION_UNKNOWN",
+};
+
 /** The groups that align to {@link ALIGNMENT_BASE}, each with the seats it claims to share. */
 export const ALIGNED_GROUPS: Readonly<Record<string, SharedSeats>> = {
 	adr: ADR_SEATS,
@@ -278,6 +294,7 @@ export const ALIGNED_GROUPS: Readonly<Record<string, SharedSeats>> = {
 	grill: GRILL_SEATS,
 	handoff: HANDOFF_SEATS,
 	"heal-ci": HEAL_CI_SEATS,
+	lane: LANE_SEATS,
 	ledger: BUILD_SEATS,
 	map: MAP_SEATS,
 	pattern: PATTERN_SEATS,

--- a/packages/fabrika-cli/src/exit-code-alignment.unit.test.ts
+++ b/packages/fabrika-cli/src/exit-code-alignment.unit.test.ts
@@ -27,6 +27,7 @@ import * as handoff from "./handoff/codes.ts";
 import * as healCi from "./heal-ci/codes.ts";
 import * as hook from "./hook/codes.ts";
 import {PRETOOLUSE_BLOCKING_EXIT} from "./hook/harness-exit.ts";
+import * as lane from "./lane/codes.ts";
 import * as ledger from "./ledger/codes.ts";
 import * as map from "./map/codes.ts";
 import * as pattern from "./pattern/codes.ts";
@@ -61,6 +62,7 @@ const TABLES: Readonly<Record<string, CodeTable>> = {
 	handoff,
 	"heal-ci": healCi,
 	hook,
+	lane,
 	ledger,
 	map,
 	pattern,

--- a/packages/fabrika-cli/src/lane/codes.ts
+++ b/packages/fabrika-cli/src/lane/codes.ts
@@ -1,0 +1,60 @@
+/**
+ * The one exit table every `lane` verb allocates from, so a code means one thing across the group.
+ *
+ * The four shared seats are **imported from the base, never re-typed** — the discipline
+ * `../exit-code-alignment.ts` checks. The lane verbs read a local lane directory and append to its
+ * log, so the base's facts they can establish are exactly these: the target is not there, the
+ * target was read but is not the shape, the write did not land, the read that would have proven any
+ * of that failed. `12`+ is this group's own band.
+ *
+ * **A fold that could not be made never resolves to a plausible state.** An absent lane, an
+ * unreadable one, and a lane whose bytes parse but contradict the machine stay distinct codes,
+ * because they take opposite remedies: open the lane, fix the tree, fix the record.
+ */
+
+import {
+	BAD_SECTIONS as REPORT_BAD_SECTIONS,
+	NO_TARGET as REPORT_NO_TARGET,
+	PRECONDITION_UNKNOWN as REPORT_PRECONDITION_UNKNOWN,
+	WRITE_UNKNOWN as REPORT_WRITE_UNKNOWN,
+} from "../report/codes.ts";
+
+/**
+ * The lane is not there: no `workflow.json` under the lane directory. A proven absence — the lane
+ * was never opened. The base's target seat: the thing the verb was pointed at does not exist.
+ */
+export const LANE_ABSENT = REPORT_NO_TARGET;
+
+/**
+ * The lane was read in full and is not the shape: a `workflow.json` the compiler refuses (each
+ * defect named), an `events.jsonl` line that does not parse, or a log the machine cannot replay.
+ * The base's section seat widened to a whole on-disk record, on the `review-ui` precedent.
+ */
+export const MALFORMED_RECORD = REPORT_BAD_SECTIONS;
+
+/**
+ * The append did not land. The caller refuses; it never reports the event as recorded.
+ */
+export const APPEND_UNKNOWN = REPORT_WRITE_UNKNOWN;
+
+/**
+ * The lane could not be read, or its absence could not be established. UNKNOWN, never a fresh
+ * lane: the read is what makes {@link LANE_ABSENT} and {@link MALFORMED_RECORD} *proven*, so a
+ * failed read can be neither.
+ */
+export const LANE_UNREADABLE = REPORT_PRECONDITION_UNKNOWN;
+
+/**
+ * The event is refused and the log is left unappended: the machine holds no cell for it in the
+ * task's current state (tea's `NoCellError`), the event is outside the operator's six, the task is
+ * not in the active phase, or the workflow is already done. A proven refusal — the loud surface
+ * XState's silent event-swallowing never gave the reference ledger (#5671, run 8).
+ */
+export const EVENT_REFUSED = 12;
+
+/**
+ * The task the event was addressed to is not in this lane's machine, or `--task` was omitted on a
+ * lane with more than one task. Its own seat rather than {@link EVENT_REFUSED} because the remedy
+ * differs: name a task the machine has, not a different event.
+ */
+export const TASK_UNKNOWN = 13;

--- a/packages/fabrika-cli/src/lane/command.ts
+++ b/packages/fabrika-cli/src/lane/command.ts
@@ -1,0 +1,111 @@
+/**
+ * The `lane` verb group — `fabrika lane <verb>`.
+ *
+ * The adapter and nothing else: it declares the argument and the flags (`--help` is the interface,
+ * so each carries a one-line description), runs the pure verb, and emits its outcome. Every
+ * decision lives in the verb modules beside it, which is what makes each refusal testable without
+ * spawning a process.
+ */
+import {Effect} from "effect";
+import {Argument, Command, Flag} from "effect/unstable/cli";
+import {leafCommand} from "../excess-operand.ts";
+import type {VerbOutcome} from "../verb.ts";
+import {runHistory} from "./history-verb.ts";
+import {runPrint} from "./print-verb.ts";
+import {runStatus} from "./status-verb.ts";
+import {DEFAULT_LANES_ROOT} from "./store.ts";
+import {runTransition} from "./transition-verb.ts";
+
+/** Write the outcome and exit on its code — stdout is the answer, everything else is stderr. */
+const emit = (outcome: VerbOutcome): Effect.Effect<void> =>
+	Effect.sync(() => {
+		for (const line of outcome.stderr) process.stderr.write(`${line}\n`);
+		if (outcome.stdout !== "") process.stdout.write(outcome.stdout);
+		process.exit(outcome.code);
+	});
+
+const laneArgument = Argument.string("lane").pipe(
+	Argument.withDescription("the lane id under the root — by convention the issue number"),
+);
+
+const rootFlag = Flag.string("root").pipe(
+	Flag.withDefault(DEFAULT_LANES_ROOT),
+	Flag.withDescription(`the lanes root directory (default: ${DEFAULT_LANES_ROOT})`),
+);
+
+const status = leafCommand(
+	"status",
+	{lane: laneArgument, root: rootFlag},
+	Effect.fn(function* ({lane, root}) {
+		yield* emit(yield* runStatus({root, lane}));
+	}),
+).pipe(
+	Command.withShortDescription("One lane's derived state, folded fresh from its event log."),
+	Command.withDescription(
+		"One lane's derived state, folded fresh from the whole events.jsonl every invocation — no resident process, no snapshot. stdout is the operator's status JSON: compound `stateValue` (active phase → per-task leaf state, future phases \"waiting\", or a bare terminal), `status` active/done, and per-task `{retries, maxRetries, …}` context with the tripped tasks in `errors`. Exits 4 (workflow.json or events.jsonl read in full and not the shape — every defect on stderr), 7 (no lane there — copy a workflow template to open it), 11 (the lane could not be read — its state is UNKNOWN, never fresh). Example: fabrika lane status 5673",
+	),
+);
+
+const transition = leafCommand(
+	"transition",
+	{
+		lane: laneArgument,
+		event: Argument.string("event").pipe(
+			Argument.withDescription("the operator event — DONE, PASS, FAIL, BLOCKED, WIP or UNBLOCKED"),
+		),
+		root: rootFlag,
+		task: Flag.string("task").pipe(
+			Flag.optional,
+			Flag.withDescription("the task the event addresses; omittable on a single-task lane"),
+		),
+	},
+	Effect.fn(function* ({lane, event, root, task}) {
+		yield* emit(
+			yield* runTransition({
+				root,
+				lane,
+				event,
+				task: task._tag === "Some" ? task.value : null,
+			}),
+		);
+	}),
+).pipe(
+	Command.withShortDescription("Record one operator event, refusing an invalid one unappended."),
+	Command.withDescription(
+		"Record one operator event on the lane's append-only log — after the machine accepts it, never before. stdout is `{previous, event, current, taskAffected}` with the two stateValues around the fold. An invalid event — no cell in the task's current state (tea's NoCellError, surfaced verbatim), outside the operator's six, a task outside the active phase, a finished workflow — is refused loudly and the log is left byte-identical. Exits 4 (lane record read in full and not the shape), 7 (no lane there), 8 (the append did not land — the event is NOT recorded), 11 (the lane could not be read), 12 (the event is refused, log unappended), 13 (the task is not in the machine, or --task omitted on a multi-task lane). Example: fabrika lane transition 5673 DONE",
+	),
+);
+
+const history = leafCommand(
+	"history",
+	{lane: laneArgument, root: rootFlag},
+	Effect.fn(function* ({lane, root}) {
+		yield* emit(yield* runHistory({root, lane}));
+	}),
+).pipe(
+	Command.withShortDescription("The lane's append-only event log, verbatim."),
+	Command.withDescription(
+		"The lane's append-only event log, verbatim — one `{task, event, at}` per recorded event, in append order; the log IS the history, and `from`/`to` are reconstructible by folding, never stored. A lane with no events yet answers `[]`. Exits 4 (lane record read in full and not the shape), 7 (no lane there), 11 (the lane could not be read). Example: fabrika lane history 5673",
+	),
+);
+
+const print = leafCommand(
+	"print",
+	{lane: laneArgument, root: rootFlag},
+	Effect.fn(function* ({lane, root}) {
+		yield* emit(yield* runPrint({root, lane}));
+	}),
+).pipe(
+	Command.withShortDescription("The lane's compiled machine topology, as data."),
+	Command.withDescription(
+		"The lane's compiled machine topology — phases in order, the two workflow terminals, and per task its initial state, retry budget, and each state's legal events (everything absent refuses at transition time). Exits 4 (workflow.json read in full and not the shape), 7 (no lane there), 11 (the lane could not be read). Example: fabrika lane print 5673",
+	),
+);
+
+export const laneCommand = Command.make("lane").pipe(
+	Command.withSubcommands([status, transition, history, print]),
+	Command.withShortDescription("Drive one lane's state ledger by folding its event log."),
+	Command.withDescription(
+		"Drive one lane's state ledger — a @demlik/tea machine folded fresh from an append-only events.jsonl on every invocation, speaking the operator's six events (#5673)",
+	),
+);

--- a/packages/fabrika-cli/src/lane/fixtures.test-support.ts
+++ b/packages/fabrika-cli/src/lane/fixtures.test-support.ts
@@ -1,0 +1,82 @@
+/**
+ * Shared lane fixtures: the committed coder template read verbatim (the golden-fixture idiom), and
+ * a two-phase document in the /prd-to-tasks shape small enough for a test to mutate.
+ */
+import {readGoldenFixture} from "../golden-fixture.ts";
+
+export const coderTemplateText = (): string =>
+	readGoldenFixture(import.meta.url, "./templates/coder.workflow.json");
+
+export const coderWorkflow = (): unknown => JSON.parse(coderTemplateText());
+
+const region = (ns: string): Record<string, unknown> => ({
+	initial: "doing",
+	states: {
+		doing: {on: {[`${ns}.DONE`]: "checking", [`${ns}.BLOCKED`]: "blocked"}},
+		checking: {
+			on: {
+				[`${ns}.PASS`]: "passed",
+				[`${ns}.BLOCKED`]: "blocked",
+				[`${ns}.FAIL`]: [
+					{target: "doing", guard: `${ns.toLowerCase()}RetriesRemaining`},
+					{target: "tripped"},
+				],
+			},
+		},
+		blocked: {on: {[`${ns}.UNBLOCKED`]: "hist"}},
+		hist: {type: "history"},
+		passed: {type: "final"},
+		tripped: {type: "final"},
+	},
+});
+
+/** phase1: two parallel tasks (task_a with maxRetries 2); phase2: one; noErrors gates on both. */
+export const twoPhaseWorkflow = (): Record<string, unknown> =>
+	JSON.parse(
+		JSON.stringify({
+			id: "fixture",
+			version: 1,
+			machine: {
+				id: "fixture",
+				initial: "phase1",
+				context: {
+					task_a: {retries: 0, maxRetries: 2, code: true},
+					task_b: {retries: 0, maxRetries: 3, code: false},
+					task_c: {retries: 0, maxRetries: 3, code: true},
+				},
+				states: {
+					phase1: {
+						type: "parallel",
+						states: {
+							task_a: region("TASK_A"),
+							task_b: region("TASK_B"),
+						},
+						onDone: [{target: "phase2", guard: "noErrors"}, {target: "tripped"}],
+					},
+					phase2: {
+						type: "parallel",
+						states: {task_c: region("TASK_C")},
+						onDone: [{target: "complete", guard: "noErrors"}, {target: "tripped"}],
+					},
+					complete: {type: "final"},
+					tripped: {type: "final"},
+				},
+			},
+		}),
+	);
+
+/** Reach one phase-1 state node of a fixture document, for a test to mutate its `on` map. */
+export const stateNode = (
+	workflow: Record<string, unknown>,
+	task: string,
+	state: string,
+): {on: Record<string, unknown>} => {
+	type Loose = Record<
+		string,
+		{states: Record<string, {states: Record<string, {on: Record<string, unknown>}>}>}
+	>;
+	const phases = (workflow.machine as {states: Loose}).states;
+	const node = phases.phase1?.states[task]?.states[state];
+	if (node === undefined) throw new Error(`fixture holds no state ${task}.${state}`);
+	return node;
+};

--- a/packages/fabrika-cli/src/lane/fold.ts
+++ b/packages/fabrika-cli/src/lane/fold.ts
@@ -1,0 +1,252 @@
+/**
+ * The fold — `events.jsonl` in, lane state out, every invocation from scratch.
+ *
+ * Fold = state: there is no resident process and no snapshot, a verb re-folds the whole log each
+ * run (proven trivially fast at operator scale — #5671, runs 3–12). Tasks are independent regions,
+ * so the global log partitions cleanly and each task's messages fold through its own machine.
+ *
+ * `deriveStatus` is the whole "compound machine": the active phase is the first whose tasks are not
+ * all final, and a completed phase with a task in an error final trips the workflow — the
+ * `noErrors` gate as a pure derivation, never a machine event. Everything here returns a
+ * discriminated union rather than throwing, so a verb's refusal is data it seats on an exit code.
+ */
+import {applyCell, foldMsgs, NoCellError} from "@demlik/tea";
+import {
+	bareEvent,
+	type CompiledLane,
+	isOperatorEvent,
+	OPERATOR_EVENTS,
+	type TaskState,
+} from "./machine.ts";
+
+/** One appended line of `events.jsonl`: which task, which (namespaced) event, when. */
+export interface LogEntry {
+	readonly task: string;
+	readonly event: string;
+	readonly at: string;
+}
+
+export type ParseLogResult =
+	| {readonly _tag: "Parsed"; readonly entries: ReadonlyArray<LogEntry>}
+	| {readonly _tag: "Malformed"; readonly defects: ReadonlyArray<string>};
+
+/** Parse the log text. A line that does not parse is a defect, never a silently skipped event. */
+export const parseLog = (text: string): ParseLogResult => {
+	const defects: string[] = [];
+	const entries: LogEntry[] = [];
+	const lines = text.split("\n");
+	for (const [index, line] of lines.entries()) {
+		if (line === "") continue;
+		let parsed: unknown;
+		try {
+			parsed = JSON.parse(line);
+		} catch {
+			defects.push(`line ${index + 1} is not JSON`);
+			continue;
+		}
+		const record = parsed as {task?: unknown; event?: unknown; at?: unknown};
+		if (
+			typeof record !== "object" ||
+			record === null ||
+			typeof record.task !== "string" ||
+			typeof record.event !== "string" ||
+			typeof record.at !== "string"
+		) {
+			defects.push(`line ${index + 1} does not carry string \`task\`/\`event\`/\`at\``);
+			continue;
+		}
+		entries.push({task: record.task, event: record.event, at: record.at});
+	}
+	return defects.length > 0 ? {_tag: "Malformed", defects} : {_tag: "Parsed", entries};
+};
+
+export type FoldResult =
+	| {readonly _tag: "Folded"; readonly states: Readonly<Record<string, TaskState>>}
+	| {readonly _tag: "Unreplayable"; readonly defects: ReadonlyArray<string>};
+
+/**
+ * The compiler admits a phase's task ids and the fold keys states by those same ids, so both
+ * lookups hold by construction; the throw is the invariant's enforcement site, not a code path.
+ */
+const taskIn = (lane: CompiledLane, taskId: string): CompiledLane["tasks"][string] => {
+	const task = lane.tasks[taskId];
+	if (task === undefined) throw new Error(`lane machine holds no task "${taskId}"`);
+	return task;
+};
+
+const stateIn = (states: Readonly<Record<string, TaskState>>, taskId: string): TaskState => {
+	const state = states[taskId];
+	if (state === undefined) throw new Error(`no folded state for task "${taskId}"`);
+	return state;
+};
+
+/**
+ * Fold the whole log into per-task leaf states. A log only ever appended through
+ * {@link applyEvent} replays cleanly; one that names an unknown task or carries an event the
+ * machine holds no cell for (a hand edit, or a `workflow.json` swap) is refused with the defect
+ * named — never partially applied.
+ */
+export const foldLog = (lane: CompiledLane, entries: ReadonlyArray<LogEntry>): FoldResult => {
+	const defects: string[] = [];
+	for (const entry of entries) {
+		if (lane.tasks[entry.task] === undefined) {
+			defects.push(`log names task "${entry.task}", which is not in this lane's machine`);
+		}
+	}
+	if (defects.length > 0) return {_tag: "Unreplayable", defects};
+	const states: Record<string, TaskState> = {};
+	for (const [taskId, task] of Object.entries(lane.tasks)) {
+		const msgs = entries
+			.filter((entry) => entry.task === taskId)
+			.map((entry) => ({type: bareEvent(entry.event)}));
+		try {
+			states[taskId] = foldMsgs(task.machine, task.initial, msgs);
+		} catch (error) {
+			if (error instanceof NoCellError) {
+				return {
+					_tag: "Unreplayable",
+					defects: [`task "${taskId}": the log does not replay — ${error.message}`],
+				};
+			}
+			throw error;
+		}
+	}
+	return {_tag: "Folded", states};
+};
+
+export interface LaneStatus {
+	readonly stateValue: string | Readonly<Record<string, Readonly<Record<string, string>> | string>>;
+	readonly status: "active" | "done";
+	readonly context: Readonly<Record<string, unknown>>;
+}
+
+/** The pure phase derivation — compound stateValue, `"waiting"` future phases, `noErrors` gating. */
+export const deriveStatus = (
+	lane: CompiledLane,
+	states: Readonly<Record<string, TaskState>>,
+): LaneStatus => {
+	const errors = Object.entries(states)
+		.filter(([taskId, state]) => taskIn(lane, taskId).errorFinals.has(state.type))
+		.map(([taskId]) => taskId);
+	const context: Record<string, unknown> = {};
+	for (const [taskId, state] of Object.entries(states)) {
+		context[taskId] = {
+			retries: state.retries,
+			maxRetries: state.maxRetries,
+			...taskIn(lane, taskId).extras,
+		};
+	}
+	context.errors = errors;
+
+	let active: CompiledLane["phases"][number] | undefined;
+	for (const phase of lane.phases) {
+		const done = phase.tasks.every((taskId) =>
+			taskIn(lane, taskId).finals.has(stateIn(states, taskId).type),
+		);
+		if (!done) {
+			active = phase;
+			break;
+		}
+		if (phase.tasks.some((taskId) => errors.includes(taskId))) {
+			return {stateValue: lane.terminals.tripped, status: "done", context};
+		}
+	}
+	if (active === undefined) return {stateValue: lane.terminals.complete, status: "done", context};
+
+	const stateValue: Record<string, Record<string, string> | string> = {
+		[active.name]: Object.fromEntries(
+			active.tasks.map((taskId) => [taskId, stateIn(states, taskId).type]),
+		),
+	};
+	for (const phase of lane.phases.slice(lane.phases.indexOf(active) + 1)) {
+		stateValue[phase.name] = "waiting";
+	}
+	return {stateValue, status: "active", context};
+};
+
+export type TaskResolution =
+	| {readonly _tag: "Task"; readonly taskId: string}
+	| {readonly _tag: "Unresolved"; readonly reason: string};
+
+/** `--task` may be omitted exactly when the machine leaves no choice. */
+export const resolveTask = (lane: CompiledLane, requested: string | null): TaskResolution => {
+	const known = Object.keys(lane.tasks);
+	if (requested !== null) {
+		return lane.tasks[requested] === undefined
+			? {
+					_tag: "Unresolved",
+					reason: `task "${requested}" is not in this lane's machine (tasks: ${known.join(", ")})`,
+				}
+			: {_tag: "Task", taskId: requested};
+	}
+	const only = known.length === 1 ? known[0] : undefined;
+	return only !== undefined
+		? {_tag: "Task", taskId: only}
+		: {
+				_tag: "Unresolved",
+				reason: `--task is required on a lane with ${known.length} tasks (${known.join(", ")})`,
+			};
+};
+
+export type ApplyResult =
+	| {
+			readonly _tag: "Applied";
+			readonly entry: LogEntry;
+			readonly previous: LaneStatus;
+			readonly current: LaneStatus;
+	  }
+	| {readonly _tag: "Refused"; readonly reason: string};
+
+/**
+ * Validate and apply one operator event, producing the entry to append. Every refusal is decided
+ * BEFORE anything would touch the log, which is what lets a verb prove refuse-without-append. The
+ * no-cell refusal is tea's own dispatch guard (`applyCell` → `NoCellError`), surfaced verbatim.
+ */
+export const applyEvent = (
+	lane: CompiledLane,
+	states: Readonly<Record<string, TaskState>>,
+	taskId: string,
+	event: string,
+	at: string,
+): ApplyResult => {
+	if (!isOperatorEvent(event)) {
+		return {
+			_tag: "Refused",
+			reason: `"${event}" is outside the operator's six events (${OPERATOR_EVENTS.join("/")})`,
+		};
+	}
+	const previous = deriveStatus(lane, states);
+	if (previous.status === "done") {
+		return {
+			_tag: "Refused",
+			reason: `workflow is "${String(previous.stateValue)}" — no further events`,
+		};
+	}
+	const activePhase = lane.phases.find(
+		(phase) => typeof (previous.stateValue as Record<string, unknown>)[phase.name] === "object",
+	);
+	if (activePhase === undefined || !activePhase.tasks.includes(taskId)) {
+		return {
+			_tag: "Refused",
+			reason: `task "${taskId}" is not in the active phase ("${activePhase?.name}")`,
+		};
+	}
+	let next: TaskState;
+	try {
+		[next] = applyCell<TaskState, {type: string}, never>(
+			taskIn(lane, taskId).machine,
+			stateIn(states, taskId),
+			{
+				type: event,
+			},
+		);
+	} catch (error) {
+		if (error instanceof NoCellError) {
+			return {_tag: "Refused", reason: `${error.name}: ${error.message}`};
+		}
+		throw error;
+	}
+	const entry: LogEntry = {task: taskId, event: `${taskId.toUpperCase()}.${event}`, at};
+	const current = deriveStatus(lane, {...states, [taskId]: next});
+	return {_tag: "Applied", entry, previous, current};
+};

--- a/packages/fabrika-cli/src/lane/fold.unit.test.ts
+++ b/packages/fabrika-cli/src/lane/fold.unit.test.ts
@@ -1,0 +1,300 @@
+/**
+ * The six-event contract, tested as the spike's recorded runs (#5671 run 8 and 19; the
+ * state-ledger rebuild's runs 1–6 recorded on #5570's 2026-08-15 session note are the plan).
+ */
+import {describe, expect, it} from "vitest";
+import {coderWorkflow, twoPhaseWorkflow} from "./fixtures.test-support.ts";
+import {applyEvent, deriveStatus, foldLog, type LogEntry, parseLog, resolveTask} from "./fold.ts";
+import {type CompiledLane, compile} from "./machine.ts";
+
+const lane = (workflow: unknown): CompiledLane => {
+	const result = compile(workflow);
+	if (result._tag !== "Compiled") throw new Error(result.defects.join("; "));
+	return result.lane;
+};
+
+const entry = (task: string, event: string): LogEntry => ({
+	task,
+	event: `${task.toUpperCase()}.${event}`,
+	at: "2026-08-16T00:00:00.000Z",
+});
+
+/** Drive a sequence through applyEvent, asserting every step is accepted. */
+const drive = (compiled: CompiledLane, steps: ReadonlyArray<readonly [string, string]>) => {
+	const log: LogEntry[] = [];
+	for (const [task, event] of steps) {
+		const states = statesOf(compiled, log);
+		const applied = applyEvent(compiled, states, task, event, "2026-08-16T00:00:00.000Z");
+		if (applied._tag !== "Applied") throw new Error(`${task} ${event}: ${applied.reason}`);
+		log.push(applied.entry);
+	}
+	return log;
+};
+
+const statesOf = (compiled: CompiledLane, log: ReadonlyArray<LogEntry>) => {
+	const fold = foldLog(compiled, log);
+	if (fold._tag !== "Folded") throw new Error(fold.defects.join("; "));
+	return fold.states;
+};
+
+const statusOf = (compiled: CompiledLane, log: ReadonlyArray<LogEntry>) =>
+	deriveStatus(compiled, statesOf(compiled, log));
+
+describe("run 1 — a fresh lane's status shape", () => {
+	it("answers the compound stateValue with future phases waiting and errors empty", () => {
+		const compiled = lane(twoPhaseWorkflow());
+
+		expect(statusOf(compiled, [])).toEqual({
+			stateValue: {
+				phase1: {task_a: "doing", task_b: "doing"},
+				phase2: "waiting",
+			},
+			status: "active",
+			context: {
+				task_a: {retries: 0, maxRetries: 2, code: true},
+				task_b: {retries: 0, maxRetries: 3, code: false},
+				task_c: {retries: 0, maxRetries: 3, code: true},
+				errors: [],
+			},
+		});
+	});
+});
+
+describe("run 2 — the happy path", () => {
+	it("gates phase1 → phase2 on the last PASS and lands on the complete terminal", () => {
+		const compiled = lane(twoPhaseWorkflow());
+		const log = drive(compiled, [
+			["task_a", "DONE"],
+			["task_a", "PASS"],
+			["task_b", "DONE"],
+			["task_b", "PASS"],
+			["task_c", "DONE"],
+			["task_c", "PASS"],
+		]);
+
+		expect(statusOf(compiled, log)).toMatchObject({stateValue: "complete", status: "done"});
+	});
+
+	it("walks the coder template queued → build → review → ship → shipped → complete", () => {
+		const compiled = lane(coderWorkflow());
+		const log = drive(compiled, [
+			["issue", "WIP"],
+			["issue", "DONE"],
+			["issue", "PASS"],
+			["issue", "DONE"],
+		]);
+
+		expect(statusOf(compiled, log)).toMatchObject({stateValue: "complete", status: "done"});
+	});
+});
+
+describe("run 3 — FAIL with retries remaining", () => {
+	it("returns to the retry target and increments retries in context", () => {
+		const compiled = lane(twoPhaseWorkflow());
+		const log = drive(compiled, [
+			["task_a", "DONE"],
+			["task_a", "FAIL"],
+		]);
+
+		const status = statusOf(compiled, log);
+		expect(status.stateValue).toMatchObject({phase1: {task_a: "doing"}});
+		expect(status.context.task_a).toMatchObject({retries: 1, maxRetries: 2});
+	});
+});
+
+describe("run 4 — exhaustion, sibling isolation, and the noErrors gate", () => {
+	const exhausted = () => {
+		const compiled = lane(twoPhaseWorkflow());
+		// task_a has maxRetries 2: two retried FAILs, then the third falls through to tripped.
+		const log = drive(compiled, [
+			["task_a", "DONE"],
+			["task_a", "FAIL"],
+			["task_a", "DONE"],
+			["task_a", "FAIL"],
+			["task_a", "DONE"],
+			["task_a", "FAIL"],
+		]);
+		return {compiled, log};
+	};
+
+	it("falls through to the error final at the retry budget — freeze-after-2 as data", () => {
+		const {compiled, log} = exhausted();
+
+		const status = statusOf(compiled, log);
+		expect(status.stateValue).toMatchObject({phase1: {task_a: "tripped"}});
+		expect(status.status).toBe("active");
+		expect(status.context.errors).toEqual(["task_a"]);
+	});
+
+	it("keeps the sibling moving after the trip, then trips the workflow at the gate", () => {
+		const {compiled, log} = exhausted();
+
+		const done = applyEvent(
+			compiled,
+			statesOf(compiled, log),
+			"task_b",
+			"DONE",
+			"2026-08-16T00:00:00.000Z",
+		);
+		expect(done._tag).toBe("Applied");
+		if (done._tag !== "Applied") return;
+
+		const pass = applyEvent(
+			compiled,
+			statesOf(compiled, [...log, done.entry]),
+			"task_b",
+			"PASS",
+			"2026-08-16T00:00:00.000Z",
+		);
+		expect(pass._tag).toBe("Applied");
+		if (pass._tag !== "Applied") return;
+		expect(pass.current).toMatchObject({stateValue: "tripped", status: "done"});
+	});
+});
+
+describe("run 5 — BLOCKED then UNBLOCKED resumes the state it left", () => {
+	it("resumes at the pre-blocked state via `was`, not at the initial state", () => {
+		const compiled = lane(twoPhaseWorkflow());
+		const log = drive(compiled, [
+			["task_a", "DONE"],
+			["task_a", "BLOCKED"],
+			["task_a", "UNBLOCKED"],
+		]);
+
+		expect(statusOf(compiled, log).stateValue).toMatchObject({phase1: {task_a: "checking"}});
+	});
+
+	it("routes ship BLOCKED to human:cp-approval and resumes ship on UNBLOCKED", () => {
+		const compiled = lane(coderWorkflow());
+		const log = drive(compiled, [
+			["issue", "WIP"],
+			["issue", "DONE"],
+			["issue", "PASS"],
+			["issue", "BLOCKED"],
+		]);
+		expect(statusOf(compiled, log).stateValue).toMatchObject({
+			pipeline: {issue: "human:cp-approval"},
+		});
+
+		const applied = applyEvent(
+			compiled,
+			statesOf(compiled, log),
+			"issue",
+			"UNBLOCKED",
+			"2026-08-16T00:00:00.000Z",
+		);
+		expect(applied._tag).toBe("Applied");
+		if (applied._tag === "Applied") {
+			expect(applied.current.stateValue).toMatchObject({pipeline: {issue: "ship"}});
+		}
+	});
+});
+
+describe("run 6 — invalid events refuse, producing nothing to append", () => {
+	it("refuses an event the current state holds no cell for, on tea's NoCellError surface", () => {
+		const compiled = lane(twoPhaseWorkflow());
+
+		const applied = applyEvent(
+			compiled,
+			statesOf(compiled, []),
+			"task_a",
+			"PASS",
+			"2026-08-16T00:00:00.000Z",
+		);
+		expect(applied).toMatchObject({_tag: "Refused"});
+		if (applied._tag === "Refused") expect(applied.reason).toContain("NoCellError");
+	});
+
+	it("refuses an event outside the operator's six before touching the machine", () => {
+		const compiled = lane(twoPhaseWorkflow());
+
+		const applied = applyEvent(
+			compiled,
+			statesOf(compiled, []),
+			"task_a",
+			"MERGE",
+			"2026-08-16T00:00:00.000Z",
+		);
+		expect(applied).toMatchObject({_tag: "Refused"});
+		if (applied._tag === "Refused") expect(applied.reason).toContain("six");
+	});
+
+	it("refuses a task outside the active phase", () => {
+		const compiled = lane(twoPhaseWorkflow());
+
+		const applied = applyEvent(
+			compiled,
+			statesOf(compiled, []),
+			"task_c",
+			"DONE",
+			"2026-08-16T00:00:00.000Z",
+		);
+		expect(applied).toMatchObject({_tag: "Refused"});
+		if (applied._tag === "Refused") expect(applied.reason).toContain("active phase");
+	});
+
+	it("refuses any further event once the workflow is done", () => {
+		const compiled = lane(coderWorkflow());
+		const log = drive(compiled, [
+			["issue", "WIP"],
+			["issue", "DONE"],
+			["issue", "PASS"],
+			["issue", "DONE"],
+		]);
+
+		const applied = applyEvent(
+			compiled,
+			statesOf(compiled, log),
+			"issue",
+			"DONE",
+			"2026-08-16T00:00:00.000Z",
+		);
+		expect(applied).toMatchObject({_tag: "Refused"});
+		if (applied._tag === "Refused") expect(applied.reason).toContain("no further events");
+	});
+});
+
+describe("the fold is deterministic and total over its inputs", () => {
+	it("folds the same log to the same states every time", () => {
+		const compiled = lane(twoPhaseWorkflow());
+		const log = drive(compiled, [
+			["task_a", "DONE"],
+			["task_b", "DONE"],
+			["task_a", "FAIL"],
+		]);
+
+		expect(statesOf(compiled, log)).toEqual(statesOf(compiled, log));
+	});
+
+	it("refuses to fold a log naming a task the machine does not have", () => {
+		const compiled = lane(twoPhaseWorkflow());
+
+		const fold = foldLog(compiled, [entry("task_z", "DONE")]);
+		expect(fold).toMatchObject({_tag: "Unreplayable"});
+	});
+
+	it("refuses to fold a log the machine holds no cell for — a hand edit, named", () => {
+		const compiled = lane(twoPhaseWorkflow());
+
+		const fold = foldLog(compiled, [entry("task_a", "PASS")]);
+		expect(fold).toMatchObject({_tag: "Unreplayable"});
+		if (fold._tag === "Unreplayable") expect(fold.defects.join()).toContain("does not replay");
+	});
+
+	it("parses only whole well-formed lines, naming each defective one", () => {
+		const good = JSON.stringify(entry("task_a", "DONE"));
+
+		expect(parseLog(`${good}\n`)).toMatchObject({_tag: "Parsed"});
+		expect(parseLog(`${good}\nnot json\n`)).toMatchObject({
+			_tag: "Malformed",
+			defects: ["line 2 is not JSON"],
+		});
+		expect(parseLog(`{"task":"task_a"}\n`)).toMatchObject({_tag: "Malformed"});
+	});
+
+	it("resolves an omitted --task only when the machine leaves no choice", () => {
+		expect(resolveTask(lane(coderWorkflow()), null)).toEqual({_tag: "Task", taskId: "issue"});
+		expect(resolveTask(lane(twoPhaseWorkflow()), null)).toMatchObject({_tag: "Unresolved"});
+		expect(resolveTask(lane(coderWorkflow()), "nope")).toMatchObject({_tag: "Unresolved"});
+	});
+});

--- a/packages/fabrika-cli/src/lane/history-verb.ts
+++ b/packages/fabrika-cli/src/lane/history-verb.ts
@@ -1,0 +1,23 @@
+/**
+ * `lane history` — the append-only log, verbatim: `{task, event, at}` per recorded event.
+ *
+ * The log IS the history; `from`/`to` are reconstructible by folding, never stored. A fresh lane
+ * answers `[]` — no events yet is a well-formed empty history, not a fault.
+ */
+import {Effect, type FileSystem, type Path} from "effect";
+import {answer, type VerbOutcome} from "../verb.ts";
+import {loadRefusal} from "./refusals.ts";
+import {type LaneRef, loadLane} from "./store.ts";
+
+const VERB = "fabrika lane history";
+
+export const runHistory = (
+	ref: LaneRef,
+): Effect.Effect<VerbOutcome, never, FileSystem.FileSystem | Path.Path> =>
+	Effect.gen(function* () {
+		const loaded = yield* loadLane(ref);
+		if (loaded._tag !== "Loaded") return loadRefusal(VERB, loaded);
+		return answer(JSON.stringify(loaded.entries, null, 2), [
+			`${VERB}: ${loaded.entries.length} event(s) in ${loaded.logPath}.`,
+		]);
+	});

--- a/packages/fabrika-cli/src/lane/machine.ts
+++ b/packages/fabrika-cli/src/lane/machine.ts
@@ -1,0 +1,288 @@
+/**
+ * The lane compiler — one `workflow.json` machine document in, one flat tea Transitions machine
+ * per task out, everything XState's nesting carried reduced to data (#5673; grounded in the
+ * recorded spike runs on #5671/#5672).
+ *
+ * Three structural recognitions replace every name-driven mechanism, and **no guard or action name
+ * is ever dereferenced** — a `guard`/`actions` string in the document is inert data:
+ *
+ *   - An **array on an event** means guarded-FAIL: `[retry-while-retries-remain, else-fallthrough]`.
+ *     The guard is the one inline `retries < maxRetries` in the compiled cell; the fallthrough
+ *     target, when final, is the task's error final (`frozen`, `tripped`).
+ *   - A transition **targeting a `history` node** resumes the state the task left, carried as the
+ *     `was` field in {@link TaskState} — history-state semantics as data, no pseudo-state.
+ *   - A phase's **`onDone` pair** `[{target, guard}, {target}]` names the two workflow terminals
+ *     structurally: the last phase's guarded target is the complete terminal, the fallthrough is
+ *     the tripped one.
+ *
+ * Compilation is total over its result type: a document that does not fit comes back as
+ * {@link Malformed} with every defect named, never as a machine that half-works.
+ */
+import type {Machine} from "@demlik/tea";
+import {defineMachine} from "@demlik/tea";
+
+/** The operator's whole event vocabulary — the six, closed (#5570 founder session, 2026-08-15). */
+export const OPERATOR_EVENTS = ["DONE", "PASS", "FAIL", "BLOCKED", "WIP", "UNBLOCKED"] as const;
+
+export type OperatorEvent = (typeof OPERATOR_EVENTS)[number];
+
+export const isOperatorEvent = (event: string): event is OperatorEvent =>
+	(OPERATOR_EVENTS as readonly string[]).includes(event);
+
+/** One task's folded state: the leaf, the retry budget, and the state it left (`was`). */
+export interface TaskState {
+	readonly type: string;
+	readonly retries: number;
+	readonly maxRetries: number;
+	readonly was?: string;
+}
+
+export interface LaneMsg {
+	readonly type: string;
+}
+
+export type TaskMachine = Machine<TaskState, LaneMsg, never, never, unknown>;
+
+export interface CompiledTask {
+	readonly machine: TaskMachine;
+	readonly initial: TaskState;
+	/** Every `type: "final"` state name in the task's region. */
+	readonly finals: ReadonlySet<string>;
+	/** The finals reached as a guarded array's fallthrough — the task's error terminals. */
+	readonly errorFinals: ReadonlySet<string>;
+	/** The task's `context` entry minus the retry bookkeeping — passed through to status. */
+	readonly extras: Readonly<Record<string, unknown>>;
+}
+
+export interface CompiledLane {
+	readonly tasks: Readonly<Record<string, CompiledTask>>;
+	readonly phases: ReadonlyArray<{readonly name: string; readonly tasks: ReadonlyArray<string>}>;
+	/** The workflow's two terminal names, read off the last phase's `onDone` pair. */
+	readonly terminals: {readonly complete: string; readonly tripped: string};
+}
+
+export type CompileResult =
+	| {readonly _tag: "Compiled"; readonly lane: CompiledLane}
+	| {readonly _tag: "Malformed"; readonly defects: ReadonlyArray<string>};
+
+const DEFAULT_MAX_RETRIES = 3;
+
+type Cell = (state: TaskState) => readonly [TaskState, readonly never[]];
+
+const isRecord = (value: unknown): value is Record<string, unknown> =>
+	typeof value === "object" && value !== null && !Array.isArray(value);
+
+/** `TASK_1.DONE` and `DONE` are the same operator event; the namespace is presentation. */
+export const bareEvent = (event: string): string => {
+	const dot = event.indexOf(".");
+	return dot === -1 ? event : event.slice(dot + 1);
+};
+
+const nodeType = (node: unknown): string | undefined =>
+	isRecord(node) && typeof node.type === "string" ? node.type : undefined;
+
+interface RegionCompilation {
+	readonly task?: CompiledTask;
+	readonly defects: ReadonlyArray<string>;
+}
+
+const compileRegion = (taskId: string, region: unknown, context: unknown): RegionCompilation => {
+	const defects: string[] = [];
+	if (!isRecord(region) || !isRecord(region.states) || typeof region.initial !== "string") {
+		return {defects: [`task "${taskId}": region must carry string \`initial\` and \`states\``]};
+	}
+	const states = region.states;
+	const initialState = region.initial;
+	if (states[initialState] === undefined) {
+		defects.push(`task "${taskId}": initial state "${initialState}" is not in \`states\``);
+	}
+
+	const finals = new Set<string>();
+	const errorFinals = new Set<string>();
+	for (const [name, node] of Object.entries(states)) {
+		if (nodeType(node) === "final") finals.add(name);
+	}
+
+	const table: Record<string, Record<string, Cell>> = {};
+	for (const [stateName, node] of Object.entries(states)) {
+		if (nodeType(node) === "history") continue;
+		const cells: Record<string, Cell> = {};
+		table[stateName] = cells;
+		if (!isRecord(node)) {
+			defects.push(`task "${taskId}": state "${stateName}" is not an object`);
+			continue;
+		}
+		const on = node.on ?? {};
+		if (!isRecord(on)) {
+			defects.push(`task "${taskId}": state "${stateName}" carries a non-object \`on\``);
+			continue;
+		}
+		for (const [eventName, transition] of Object.entries(on)) {
+			const msg = bareEvent(eventName);
+			if (!isOperatorEvent(msg)) {
+				defects.push(
+					`task "${taskId}": state "${stateName}" listens for "${eventName}" — outside the operator's six (${OPERATOR_EVENTS.join("/")})`,
+				);
+				continue;
+			}
+			if (Array.isArray(transition)) {
+				const targets = transition.map((arm) =>
+					isRecord(arm) && typeof arm.target === "string" ? arm.target : undefined,
+				);
+				const [retry, fallthrough] = targets;
+				if (transition.length !== 2 || retry === undefined || fallthrough === undefined) {
+					defects.push(
+						`task "${taskId}": guarded "${eventName}" must be a two-arm array of \`{target}\` — [retry-while-retries-remain, else-fallthrough]`,
+					);
+					continue;
+				}
+				for (const target of [retry, fallthrough]) {
+					if (states[target] === undefined) {
+						defects.push(`task "${taskId}": "${eventName}" targets unknown state "${target}"`);
+					}
+				}
+				if (finals.has(fallthrough)) errorFinals.add(fallthrough);
+				cells[msg] = (s) =>
+					s.retries < s.maxRetries
+						? [{...s, type: retry, retries: s.retries + 1, was: s.type}, []]
+						: [{...s, type: fallthrough, was: s.type}, []];
+				continue;
+			}
+			if (typeof transition !== "string") {
+				defects.push(`task "${taskId}": "${eventName}" is neither a target nor a guarded array`);
+				continue;
+			}
+			if (states[transition] === undefined) {
+				defects.push(`task "${taskId}": "${eventName}" targets unknown state "${transition}"`);
+				continue;
+			}
+			if (nodeType(states[transition]) === "history") {
+				cells[msg] = (s) => [{...s, type: s.was ?? initialState}, []];
+			} else {
+				const target = transition;
+				cells[msg] = (s) => [{...s, type: target, was: s.type}, []];
+			}
+		}
+	}
+	if (defects.length > 0) return {defects};
+
+	const ctx = isRecord(context) ? context : {};
+	const maxRetries = typeof ctx.maxRetries === "number" ? ctx.maxRetries : DEFAULT_MAX_RETRIES;
+	const {maxRetries: _max, retries: _retries, ...extras} = ctx;
+	const initial: TaskState = {type: initialState, retries: 0, maxRetries};
+	// The Transitions mapped type demands a cell for every (state × msg) pair; a lane machine is
+	// compiled from data and deliberately partial — the absent cells ARE the refusal contract
+	// (`applyCell` throws `NoCellError` on them). One cast at the construction boundary.
+	const machine = defineMachine<TaskState, LaneMsg, never, never, unknown>({
+		init: (loaded) => [loaded ?? initial, []],
+		update: table as never,
+	});
+	return {task: {machine, initial, finals, errorFinals, extras}, defects: []};
+};
+
+/** The two targets of a phase's `onDone` pair: `[guarded success, fallthrough trip]`. */
+const onDoneTargets = (
+	phaseName: string,
+	onDone: unknown,
+): {targets?: readonly [string, string]; defect?: string} => {
+	const defect = `phase "${phaseName}": \`onDone\` must be a two-arm array of \`{target}\` — [{target, guard}, {target}]`;
+	if (!Array.isArray(onDone) || onDone.length !== 2) return {defect};
+	const [success, trip] = onDone.map((arm) =>
+		isRecord(arm) && typeof arm.target === "string" ? arm.target : undefined,
+	);
+	return success === undefined || trip === undefined
+		? {defect}
+		: {targets: [success, trip] as const};
+};
+
+/**
+ * Compile one machine document. Phases are the machine's `parallel` states in declaration order;
+ * everything else at the machine level is either a terminal named by an `onDone` pair, or a defect.
+ */
+export const compile = (workflow: unknown): CompileResult => {
+	const defects: string[] = [];
+	const machineDef = isRecord(workflow) ? workflow.machine : undefined;
+	if (!isRecord(machineDef) || !isRecord(machineDef.states)) {
+		return {_tag: "Malformed", defects: ["document must carry a `machine.states` object"]};
+	}
+	const context = isRecord(machineDef.context) ? machineDef.context : {};
+
+	const tasks: Record<string, CompiledTask> = {};
+	const phases: Array<{name: string; tasks: string[]}> = [];
+	let terminals: {complete: string; tripped: string} | undefined;
+	for (const [phaseName, node] of Object.entries(machineDef.states)) {
+		if (nodeType(node) !== "parallel" || !isRecord(node)) continue;
+		const regions = node.states;
+		if (!isRecord(regions) || Object.keys(regions).length === 0) {
+			defects.push(`phase "${phaseName}": a parallel phase must carry task regions in \`states\``);
+			continue;
+		}
+		const phaseTasks: string[] = [];
+		for (const [taskId, region] of Object.entries(regions)) {
+			const compiled = compileRegion(taskId, region, context[taskId]);
+			defects.push(...compiled.defects);
+			if (compiled.task !== undefined) tasks[taskId] = compiled.task;
+			phaseTasks.push(taskId);
+		}
+		phases.push({name: phaseName, tasks: phaseTasks});
+		const gate = onDoneTargets(phaseName, node.onDone);
+		if (gate.defect !== undefined) defects.push(gate.defect);
+		// Every phase names the same trip terminal; the LAST phase's success target is the
+		// workflow's complete terminal, because earlier ones target the next phase.
+		if (gate.targets !== undefined)
+			terminals = {complete: gate.targets[0], tripped: gate.targets[1]};
+	}
+	if (phases.length === 0) defects.push("machine holds no `parallel` phase state");
+	if (defects.length > 0) return {_tag: "Malformed", defects};
+	if (terminals === undefined) {
+		return {_tag: "Malformed", defects: ["no phase carried a readable `onDone` pair"]};
+	}
+	return {_tag: "Compiled", lane: {tasks, phases, terminals}};
+};
+
+/** Parse and compile in one step — for a caller holding the document's bytes off disk. */
+export const compileText = (text: string): CompileResult => {
+	let parsed: unknown;
+	try {
+		parsed = JSON.parse(text);
+	} catch {
+		return {_tag: "Malformed", defects: ["the document is not JSON"]};
+	}
+	return compile(parsed);
+};
+
+export interface LaneTopology {
+	readonly phases: CompiledLane["phases"];
+	readonly terminals: CompiledLane["terminals"];
+	readonly tasks: Readonly<
+		Record<
+			string,
+			{
+				readonly initial: string;
+				readonly maxRetries: number;
+				/** Per state, the events it holds a cell for — everything else refuses. */
+				readonly states: Readonly<Record<string, ReadonlyArray<string>>>;
+			}
+		>
+	>;
+}
+
+/** The compiled machines summarized as data — what `lane print` answers with. */
+export const topology = (lane: CompiledLane): LaneTopology => ({
+	phases: lane.phases,
+	terminals: lane.terminals,
+	tasks: Object.fromEntries(
+		Object.entries(lane.tasks).map(([taskId, task]) => [
+			taskId,
+			{
+				initial: task.initial.type,
+				maxRetries: task.initial.maxRetries,
+				states: Object.fromEntries(
+					Object.entries(task.machine.update as Record<string, Record<string, unknown>>).map(
+						([state, cells]) => [state, Object.keys(cells)],
+					),
+				),
+			},
+		]),
+	),
+});

--- a/packages/fabrika-cli/src/lane/machine.ts
+++ b/packages/fabrika-cli/src/lane/machine.ts
@@ -207,10 +207,12 @@ export const compile = (workflow: unknown): CompileResult => {
 	}
 	const context = isRecord(machineDef.context) ? machineDef.context : {};
 
+	const machineStates = machineDef.states;
 	const tasks: Record<string, CompiledTask> = {};
 	const phases: Array<{name: string; tasks: string[]}> = [];
+	const gateTargets = new Set<string>();
 	let terminals: {complete: string; tripped: string} | undefined;
-	for (const [phaseName, node] of Object.entries(machineDef.states)) {
+	for (const [phaseName, node] of Object.entries(machineStates)) {
 		if (nodeType(node) !== "parallel" || !isRecord(node)) continue;
 		const regions = node.states;
 		if (!isRecord(regions) || Object.keys(regions).length === 0) {
@@ -229,8 +231,29 @@ export const compile = (workflow: unknown): CompileResult => {
 		if (gate.defect !== undefined) defects.push(gate.defect);
 		// Every phase names the same trip terminal; the LAST phase's success target is the
 		// workflow's complete terminal, because earlier ones target the next phase.
-		if (gate.targets !== undefined)
+		if (gate.targets !== undefined) {
+			for (const target of gate.targets) {
+				gateTargets.add(target);
+				if (machineStates[target] === undefined) {
+					defects.push(
+						`phase "${phaseName}": \`onDone\` targets unknown machine-level state "${target}"`,
+					);
+				}
+			}
 			terminals = {complete: gate.targets[0], tripped: gate.targets[1]};
+		}
+	}
+	// A machine-level state the loop above did not compile is a terminal or a defect — never
+	// dropped silently: a phase missing `"type": "parallel"` must refuse, not half-compile.
+	for (const [name, node] of Object.entries(machineStates)) {
+		if (nodeType(node) === "parallel" && isRecord(node)) continue;
+		if (nodeType(node) !== "final") {
+			defects.push(
+				`machine-level state "${name}" is neither a \`parallel\` phase nor a \`final\` terminal`,
+			);
+		} else if (!gateTargets.has(name)) {
+			defects.push(`machine-level final "${name}" is targeted by no phase's \`onDone\` pair`);
+		}
 	}
 	if (phases.length === 0) defects.push("machine holds no `parallel` phase state");
 	if (defects.length > 0) return {_tag: "Malformed", defects};

--- a/packages/fabrika-cli/src/lane/machine.unit.test.ts
+++ b/packages/fabrika-cli/src/lane/machine.unit.test.ts
@@ -1,0 +1,98 @@
+import {describe, expect, it} from "vitest";
+import {coderWorkflow, stateNode, twoPhaseWorkflow} from "./fixtures.test-support.ts";
+import {compile, OPERATOR_EVENTS, topology} from "./machine.ts";
+
+const compiled = (workflow: unknown) => {
+	const result = compile(workflow);
+	if (result._tag !== "Compiled") throw new Error(`malformed: ${result.defects.join("; ")}`);
+	return result.lane;
+};
+
+const defined = <T>(value: T | undefined): T => {
+	if (value === undefined) throw new Error("expected the compiled task to be present");
+	return value;
+};
+
+const defectsOf = (workflow: unknown): string => {
+	const result = compile(workflow);
+	expect(result._tag).toBe("Malformed");
+	return result._tag === "Malformed" ? result.defects.join("\n") : "";
+};
+
+describe("the compiler — structural recognition", () => {
+	it("compiles the committed coder template", () => {
+		const lane = compiled(coderWorkflow());
+
+		expect(lane.phases).toEqual([{name: "pipeline", tasks: ["issue"]}]);
+		expect(lane.terminals).toEqual({complete: "complete", tripped: "tripped"});
+		expect(defined(lane.tasks.issue).initial).toEqual({type: "queued", retries: 0, maxRetries: 2});
+		expect([...defined(lane.tasks.issue).finals].sort()).toEqual(["frozen", "shipped"]);
+		expect([...defined(lane.tasks.issue).errorFinals]).toEqual(["frozen"]);
+	});
+
+	it("reads a guarded array as retry-or-fallthrough by shape, never by guard name", () => {
+		const noNames = twoPhaseWorkflow();
+		// Strip every guard/action name — the arms are bare targets and must compile identically.
+		stateNode(noNames, "task_a", "checking").on["TASK_A.FAIL"] = [
+			{target: "doing"},
+			{target: "tripped"},
+		];
+
+		const lane = compiled(noNames);
+		expect([...defined(lane.tasks.task_a).errorFinals]).toEqual(["tripped"]);
+	});
+
+	it("carries the per-task context through: maxRetries into state, the rest into extras", () => {
+		const lane = compiled(twoPhaseWorkflow());
+
+		expect(defined(lane.tasks.task_a).initial.maxRetries).toBe(2);
+		expect(defined(lane.tasks.task_a).extras).toEqual({code: true});
+		expect(defined(lane.tasks.task_b).initial.maxRetries).toBe(3);
+	});
+
+	it("summarizes each state's legal events in the topology", () => {
+		const summary = topology(compiled(coderWorkflow()));
+
+		expect(defined(summary.tasks.issue).states.queued).toEqual(["WIP", "BLOCKED"]);
+		expect(defined(summary.tasks.issue).states.review).toEqual(["PASS", "BLOCKED", "FAIL"]);
+		expect(defined(summary.tasks.issue).states.shipped).toEqual([]);
+	});
+});
+
+describe("the compiler — refusals", () => {
+	it("refuses an event outside the operator's six, naming them", () => {
+		const workflow = twoPhaseWorkflow();
+		stateNode(workflow, "task_a", "doing").on["TASK_A.MERGE"] = "checking";
+
+		expect(defectsOf(workflow)).toContain(OPERATOR_EVENTS.join("/"));
+	});
+
+	it("refuses a transition to a state the region does not have", () => {
+		const workflow = twoPhaseWorkflow();
+		stateNode(workflow, "task_a", "doing").on["TASK_A.DONE"] = "nowhere";
+
+		expect(defectsOf(workflow)).toContain('unknown state "nowhere"');
+	});
+
+	it("refuses a guarded array that is not the two-arm shape", () => {
+		const workflow = twoPhaseWorkflow();
+		stateNode(workflow, "task_a", "checking").on["TASK_A.FAIL"] = [{target: "doing"}];
+
+		expect(defectsOf(workflow)).toContain("two-arm array");
+	});
+
+	it("refuses a machine with no parallel phase, and one with no readable onDone pair", () => {
+		expect(defectsOf({machine: {states: {alone: {type: "final"}}}})).toContain("parallel");
+
+		const noGate = twoPhaseWorkflow();
+		const phase1 = ((noGate.machine as Record<string, unknown>).states as Record<string, unknown>)
+			.phase1 as Record<string, unknown>;
+		phase1.onDone = undefined;
+		expect(defectsOf(noGate)).toContain("onDone");
+	});
+
+	it("refuses a document that is not machine-shaped at all", () => {
+		expect(defectsOf(null)).toContain("machine.states");
+		expect(defectsOf({})).toContain("machine.states");
+	});
+});

--- a/packages/fabrika-cli/src/lane/machine.unit.test.ts
+++ b/packages/fabrika-cli/src/lane/machine.unit.test.ts
@@ -19,6 +19,12 @@ const defectsOf = (workflow: unknown): string => {
 	return result._tag === "Malformed" ? result.defects.join("\n") : "";
 };
 
+/** Reach a fixture's machine-level `states` map, for a test to mutate one phase or terminal. */
+const machineStates = (
+	workflow: Record<string, unknown>,
+): Record<string, Record<string, unknown>> =>
+	(workflow.machine as Record<string, unknown>).states as Record<string, Record<string, unknown>>;
+
 describe("the compiler — structural recognition", () => {
 	it("compiles the committed coder template", () => {
 		const lane = compiled(coderWorkflow());
@@ -89,6 +95,34 @@ describe("the compiler — refusals", () => {
 			.phase1 as Record<string, unknown>;
 		phase1.onDone = undefined;
 		expect(defectsOf(noGate)).toContain("onDone");
+	});
+
+	it("refuses a machine-level state that lost its `parallel` type, never dropping it", () => {
+		const workflow = twoPhaseWorkflow();
+		delete defined(machineStates(workflow).phase2).type;
+
+		expect(defectsOf(workflow)).toContain(
+			'machine-level state "phase2" is neither a `parallel` phase nor a `final` terminal',
+		);
+	});
+
+	it("refuses an `onDone` target that names no machine-level state", () => {
+		const workflow = twoPhaseWorkflow();
+		defined(machineStates(workflow).phase2).onDone = [
+			{target: "compleet", guard: "noErrors"},
+			{target: "tripped"},
+		];
+
+		expect(defectsOf(workflow)).toContain('unknown machine-level state "compleet"');
+	});
+
+	it("refuses a machine-level final no `onDone` pair reaches", () => {
+		const workflow = twoPhaseWorkflow();
+		machineStates(workflow).orphan = {type: "final"};
+
+		expect(defectsOf(workflow)).toContain(
+			'machine-level final "orphan" is targeted by no phase\'s `onDone` pair',
+		);
 	});
 
 	it("refuses a document that is not machine-shaped at all", () => {

--- a/packages/fabrika-cli/src/lane/print-verb.ts
+++ b/packages/fabrika-cli/src/lane/print-verb.ts
@@ -1,0 +1,24 @@
+/**
+ * `lane print` — the compiled machine topology as data: per task, each state's legal events.
+ *
+ * What it answers is what compiled, not the document's bytes — the one way to see which events the
+ * machine would refuse where, without sending any.
+ */
+import {Effect, type FileSystem, type Path} from "effect";
+import {answer, type VerbOutcome} from "../verb.ts";
+import {topology} from "./machine.ts";
+import {loadRefusal} from "./refusals.ts";
+import {type LaneRef, loadLane} from "./store.ts";
+
+const VERB = "fabrika lane print";
+
+export const runPrint = (
+	ref: LaneRef,
+): Effect.Effect<VerbOutcome, never, FileSystem.FileSystem | Path.Path> =>
+	Effect.gen(function* () {
+		const loaded = yield* loadLane(ref);
+		if (loaded._tag !== "Loaded") return loadRefusal(VERB, loaded);
+		return answer(JSON.stringify(topology(loaded.lane), null, 2), [
+			`${VERB}: compiled ${Object.keys(loaded.lane.tasks).length} task machine(s) from ${loaded.dir}/workflow.json.`,
+		]);
+	});

--- a/packages/fabrika-cli/src/lane/refusals.ts
+++ b/packages/fabrika-cli/src/lane/refusals.ts
@@ -1,0 +1,45 @@
+/**
+ * The two refusal folds every `lane` verb shares, so a load or replay fault seats on the same code
+ * with the same stderr shape whichever verb hit it.
+ */
+import {refuse, type VerbOutcome} from "../verb.ts";
+import {LANE_ABSENT, LANE_UNREADABLE, MALFORMED_RECORD} from "./codes.ts";
+import type {FoldResult} from "./fold.ts";
+import type {LoadedLane} from "./store.ts";
+
+/** Seat a non-`Loaded` load outcome. Absent names the remedy: open the lane from a template. */
+export const loadRefusal = (
+	verb: string,
+	loaded: Exclude<LoadedLane, {_tag: "Loaded"}>,
+): VerbOutcome => {
+	switch (loaded._tag) {
+		case "Absent":
+			return refuse(
+				LANE_ABSENT,
+				`${verb}: no lane at ${loaded.dir} — copy a workflow template to ${loaded.dir}/workflow.json to open it.`,
+			);
+		case "Unreadable":
+			return refuse(
+				LANE_UNREADABLE,
+				`${verb}: cannot read ${loaded.path}: ${loaded.reason} — the lane state is UNKNOWN, never fresh.`,
+			);
+		case "Malformed":
+			return refuse(
+				MALFORMED_RECORD,
+				`${verb}: ${loaded.path} was read in full and is not the shape.`,
+				loaded.defects.map((defect) => `${verb}: defect: ${defect}`),
+			);
+	}
+};
+
+/** Seat an unreplayable log — read in full, contradicting the machine. */
+export const replayRefusal = (
+	verb: string,
+	logPath: string,
+	fold: Exclude<FoldResult, {_tag: "Folded"}>,
+): VerbOutcome =>
+	refuse(
+		MALFORMED_RECORD,
+		`${verb}: ${logPath} was read in full and does not replay through this lane's machine.`,
+		fold.defects.map((defect) => `${verb}: defect: ${defect}`),
+	);

--- a/packages/fabrika-cli/src/lane/status-verb.ts
+++ b/packages/fabrika-cli/src/lane/status-verb.ts
@@ -1,0 +1,28 @@
+/**
+ * `lane status` — one lane's derived state, folded fresh from its whole log every invocation.
+ *
+ * The answer is the operator's status shape: compound `stateValue` (active phase → per-task leaf,
+ * future phases `"waiting"`), `status` active/done, and per-task `{retries, maxRetries, …extras}`
+ * context with the tripped tasks in `errors`.
+ */
+import {Effect, type FileSystem, type Path} from "effect";
+import {answer, type VerbOutcome} from "../verb.ts";
+import {deriveStatus, foldLog} from "./fold.ts";
+import {loadRefusal, replayRefusal} from "./refusals.ts";
+import {type LaneRef, loadLane} from "./store.ts";
+
+const VERB = "fabrika lane status";
+
+export const runStatus = (
+	ref: LaneRef,
+): Effect.Effect<VerbOutcome, never, FileSystem.FileSystem | Path.Path> =>
+	Effect.gen(function* () {
+		const loaded = yield* loadLane(ref);
+		if (loaded._tag !== "Loaded") return loadRefusal(VERB, loaded);
+		const fold = foldLog(loaded.lane, loaded.entries);
+		if (fold._tag !== "Folded") return replayRefusal(VERB, loaded.logPath, fold);
+		const status = deriveStatus(loaded.lane, fold.states);
+		return answer(JSON.stringify(status, null, 2), [
+			`${VERB}: folded ${loaded.entries.length} event(s) from ${loaded.logPath}.`,
+		]);
+	});

--- a/packages/fabrika-cli/src/lane/store.ts
+++ b/packages/fabrika-cli/src/lane/store.ts
@@ -1,0 +1,81 @@
+/**
+ * The lane store — where a lane lives on disk, and the one guarded read every verb goes through.
+ *
+ * A lane is a directory: `.fabrika/lanes/<n>/workflow.json` (the machine document, placed there by
+ * the operator from a committed template) plus `events.jsonl` (the append-only log, born on the
+ * first recorded event). Lane state is local and gitignored — the repo `.gitignore`'s `/.fabrika/`
+ * entry covers it (#5673).
+ *
+ * The load keeps four outcomes apart because they take opposite remedies: the lane is provably not
+ * there, it could not be read (UNKNOWN, never "fresh"), it was read in full and is not the shape,
+ * or it loaded. An absent `events.jsonl` alone is NOT one of them — a lane with no events yet is a
+ * well-formed fresh lane, not a fault.
+ */
+import {Effect, type FileSystem, Path, Result} from "effect";
+import {exists, readFile} from "../io/fs.ts";
+import {type LogEntry, parseLog} from "./fold.ts";
+import {type CompiledLane, compileText} from "./machine.ts";
+
+export const DEFAULT_LANES_ROOT = ".fabrika/lanes";
+
+export interface LaneRef {
+	/** The lanes root — `.fabrika/lanes` unless a caller relocates it. */
+	readonly root: string;
+	/** The lane id under the root — by convention the issue number the lane drives. */
+	readonly lane: string;
+}
+
+export type LoadedLane =
+	| {
+			readonly _tag: "Loaded";
+			readonly lane: CompiledLane;
+			readonly entries: ReadonlyArray<LogEntry>;
+			readonly dir: string;
+			readonly logPath: string;
+	  }
+	| {readonly _tag: "Absent"; readonly dir: string}
+	| {readonly _tag: "Unreadable"; readonly path: string; readonly reason: string}
+	| {readonly _tag: "Malformed"; readonly path: string; readonly defects: ReadonlyArray<string>};
+
+/** Read and compile one lane. Every outcome is proven; nothing resolves to a plausible default. */
+export const loadLane = (
+	ref: LaneRef,
+): Effect.Effect<LoadedLane, never, FileSystem.FileSystem | Path.Path> =>
+	Effect.gen(function* () {
+		const path = yield* Path.Path;
+		const dir = path.join(ref.root, ref.lane);
+		const workflowPath = path.join(dir, "workflow.json");
+		const logPath = path.join(dir, "events.jsonl");
+
+		const workflowText = yield* Effect.result(readFile(workflowPath));
+		if (Result.isFailure(workflowText)) {
+			const probe = yield* Effect.result(exists(workflowPath));
+			if (Result.isFailure(probe) || probe.success) {
+				return {
+					_tag: "Unreadable",
+					path: workflowPath,
+					reason: workflowText.failure.reason,
+				} as const;
+			}
+			return {_tag: "Absent", dir} as const;
+		}
+
+		const compiled = compileText(workflowText.success);
+		if (compiled._tag === "Malformed") {
+			return {_tag: "Malformed", path: workflowPath, defects: compiled.defects} as const;
+		}
+
+		const logText = yield* Effect.result(readFile(logPath));
+		if (Result.isFailure(logText)) {
+			const probe = yield* Effect.result(exists(logPath));
+			if (Result.isFailure(probe) || probe.success) {
+				return {_tag: "Unreadable", path: logPath, reason: logText.failure.reason} as const;
+			}
+			return {_tag: "Loaded", lane: compiled.lane, entries: [], dir, logPath} as const;
+		}
+		const parsed = parseLog(logText.success);
+		if (parsed._tag === "Malformed") {
+			return {_tag: "Malformed", path: logPath, defects: parsed.defects} as const;
+		}
+		return {_tag: "Loaded", lane: compiled.lane, entries: parsed.entries, dir, logPath} as const;
+	});

--- a/packages/fabrika-cli/src/lane/templates/coder.workflow.json
+++ b/packages/fabrika-cli/src/lane/templates/coder.workflow.json
@@ -1,0 +1,71 @@
+{
+	"id": "coder",
+	"version": 1,
+	"machine": {
+		"id": "coder",
+		"initial": "pipeline",
+		"context": {
+			"issue": { "retries": 0, "maxRetries": 2 }
+		},
+		"states": {
+			"pipeline": {
+				"type": "parallel",
+				"states": {
+					"issue": {
+						"initial": "queued",
+						"states": {
+							"queued": {
+								"on": {
+									"ISSUE.WIP": "build",
+									"ISSUE.BLOCKED": "blocked"
+								}
+							},
+							"build": {
+								"on": {
+									"ISSUE.DONE": "review",
+									"ISSUE.BLOCKED": "blocked"
+								}
+							},
+							"review": {
+								"on": {
+									"ISSUE.PASS": "ship",
+									"ISSUE.BLOCKED": "blocked",
+									"ISSUE.FAIL": [
+										{
+											"target": "build",
+											"guard": "retriesRemaining",
+											"actions": "incrementRetries"
+										},
+										{ "target": "frozen" }
+									]
+								}
+							},
+							"ship": {
+								"on": {
+									"ISSUE.DONE": "shipped",
+									"ISSUE.BLOCKED": "human:cp-approval"
+								}
+							},
+							"blocked": {
+								"on": {
+									"ISSUE.UNBLOCKED": "hist"
+								}
+							},
+							"human:cp-approval": {
+								"on": {
+									"ISSUE.UNBLOCKED": "hist"
+								}
+							},
+							"hist": { "type": "history" },
+							"shipped": { "type": "final" },
+							"frozen": { "type": "final" }
+						}
+					}
+				},
+				"onDone": [{ "target": "complete", "guard": "noErrors" }, { "target": "tripped" }]
+			},
+			"complete": { "type": "final" },
+			"tripped": { "type": "final" }
+		}
+	}
+}

--- a/packages/fabrika-cli/src/lane/transition-verb.ts
+++ b/packages/fabrika-cli/src/lane/transition-verb.ts
@@ -1,0 +1,73 @@
+/**
+ * `lane transition` — record one operator event, or refuse it with the log left byte-identical.
+ *
+ * The order is the contract: validate against the folded state FIRST, append ONLY an event the
+ * machine accepts. An invalid event — no cell in the current state, outside the six, wrong phase,
+ * finished workflow — never reaches the append, so the refusal leaves `events.jsonl` untouched
+ * (#5671, run 8). An append that fails is {@link APPEND_UNKNOWN}, never reported as recorded.
+ */
+import {Effect, type FileSystem, type Path, Result} from "effect";
+import {appendText} from "../io/fs.ts";
+import {answer, refuse, type VerbOutcome} from "../verb.ts";
+import {APPEND_UNKNOWN, EVENT_REFUSED, TASK_UNKNOWN} from "./codes.ts";
+import {applyEvent, foldLog, resolveTask} from "./fold.ts";
+import {loadRefusal, replayRefusal} from "./refusals.ts";
+import {type LaneRef, loadLane} from "./store.ts";
+
+const VERB = "fabrika lane transition";
+
+export interface TransitionOptions extends LaneRef {
+	/** The operator event, one of the six; folded to upper case here for the operator's fingers. */
+	readonly event: string;
+	/** The task the event addresses; `null` resolves only on a single-task lane. */
+	readonly task: string | null;
+}
+
+export const runTransition = (
+	options: TransitionOptions,
+): Effect.Effect<VerbOutcome, never, FileSystem.FileSystem | Path.Path> =>
+	Effect.gen(function* () {
+		const loaded = yield* loadLane(options);
+		if (loaded._tag !== "Loaded") return loadRefusal(VERB, loaded);
+		const task = resolveTask(loaded.lane, options.task);
+		if (task._tag === "Unresolved") {
+			return refuse(TASK_UNKNOWN, `${VERB}: ${task.reason}`);
+		}
+		const fold = foldLog(loaded.lane, loaded.entries);
+		if (fold._tag !== "Folded") return replayRefusal(VERB, loaded.logPath, fold);
+
+		const at = yield* Effect.sync(() => new Date().toISOString());
+		const applied = applyEvent(
+			loaded.lane,
+			fold.states,
+			task.taskId,
+			options.event.toUpperCase(),
+			at,
+		);
+		if (applied._tag === "Refused") {
+			return refuse(EVENT_REFUSED, `${VERB}: refused (log unappended): ${applied.reason}`);
+		}
+
+		const wrote = yield* Effect.result(
+			appendText(loaded.logPath, `${JSON.stringify(applied.entry)}\n`),
+		);
+		if (Result.isFailure(wrote)) {
+			return refuse(
+				APPEND_UNKNOWN,
+				`${VERB}: the append to ${loaded.logPath} did not land: ${wrote.failure.reason} — the event is NOT recorded.`,
+			);
+		}
+		return answer(
+			JSON.stringify(
+				{
+					previous: applied.previous.stateValue,
+					event: applied.entry.event,
+					current: applied.current.stateValue,
+					taskAffected: task.taskId,
+				},
+				null,
+				2,
+			),
+			[`${VERB}: appended ${applied.entry.event} to ${loaded.logPath}.`],
+		);
+	});

--- a/packages/fabrika-cli/src/lane/transition-verb.unit.test.ts
+++ b/packages/fabrika-cli/src/lane/transition-verb.unit.test.ts
@@ -1,0 +1,113 @@
+import {Effect} from "effect";
+import {describe, expect, it} from "vitest";
+import {fakeFs} from "../fakes.test-support.ts";
+import {APPEND_UNKNOWN, EVENT_REFUSED, LANE_ABSENT, TASK_UNKNOWN} from "./codes.ts";
+import {coderTemplateText} from "./fixtures.test-support.ts";
+import {runTransition} from "./transition-verb.ts";
+
+const ROOT = ".fabrika/lanes";
+const WORKFLOW = `${ROOT}/42/workflow.json`;
+const LOG = `${ROOT}/42/events.jsonl`;
+
+const logLine = (event: string): string =>
+	`${JSON.stringify({task: "issue", event: `ISSUE.${event}`, at: "2026-08-16T00:00:00.000Z"})}\n`;
+
+const run = (fs: ReturnType<typeof fakeFs>, event: string, task: string | null = null) =>
+	Effect.runPromise(Effect.provide(runTransition({root: ROOT, lane: "42", event, task}), fs.layer));
+
+const freshLane = (log?: string, extra: Parameters<typeof fakeFs>[0] = {}) =>
+	fakeFs({
+		files: {[WORKFLOW]: coderTemplateText(), ...(log === undefined ? {} : {[LOG]: log})},
+		...extra,
+	});
+
+describe("lane transition — the answer", () => {
+	it("appends the accepted event and answers the two stateValues around the fold", async () => {
+		const fs = freshLane();
+
+		const out = await run(fs, "WIP");
+		expect(out.code).toBe(0);
+		expect(JSON.parse(out.stdout)).toMatchObject({
+			previous: {pipeline: {issue: "queued"}},
+			event: "ISSUE.WIP",
+			current: {pipeline: {issue: "build"}},
+			taskAffected: "issue",
+		});
+
+		const appended = fs.written.get(LOG);
+		expect(appended).toBeDefined();
+		expect(JSON.parse(appended?.trim() ?? "")).toMatchObject({task: "issue", event: "ISSUE.WIP"});
+	});
+
+	it("folds the existing log first, so the event lands on the folded state", async () => {
+		const fs = freshLane(logLine("WIP"));
+
+		const out = await run(fs, "DONE");
+		expect(out.code).toBe(0);
+		expect(JSON.parse(out.stdout)).toMatchObject({
+			previous: {pipeline: {issue: "build"}},
+			current: {pipeline: {issue: "review"}},
+		});
+	});
+
+	it("folds a lower-case event to the operator's spelling", async () => {
+		const out = await run(freshLane(), "wip");
+
+		expect(out.code).toBe(0);
+		expect(JSON.parse(out.stdout)).toMatchObject({event: "ISSUE.WIP"});
+	});
+});
+
+describe("lane transition — refuse without append", () => {
+	it("refuses an event the state holds no cell for, log byte-identical, nothing written", async () => {
+		const fs = freshLane(logLine("WIP"));
+
+		const out = await run(fs, "PASS");
+		expect(out.code).toBe(EVENT_REFUSED);
+		expect(out.stdout).toBe("");
+		expect(out.stderr.at(-1)).toContain("NoCellError");
+		expect(out.stderr.at(-1)).toContain("log unappended");
+		expect(fs.written.size).toBe(0);
+	});
+
+	it("refuses an event outside the operator's six the same way", async () => {
+		const fs = freshLane();
+
+		const out = await run(fs, "MERGE");
+		expect(out.code).toBe(EVENT_REFUSED);
+		expect(fs.written.size).toBe(0);
+	});
+
+	it("refuses a task the machine does not have on its own code", async () => {
+		const fs = freshLane();
+
+		const out = await run(fs, "WIP", "nope");
+		expect(out.code).toBe(TASK_UNKNOWN);
+		expect(out.stderr.at(-1)).toContain('"nope"');
+		expect(fs.written.size).toBe(0);
+	});
+
+	it("refuses a lane that is provably not there, naming the remedy", async () => {
+		const fs = fakeFs({files: {}});
+
+		const out = await run(fs, "WIP");
+		expect(out.code).toBe(LANE_ABSENT);
+		expect(out.stderr.at(-1)).toContain("template");
+		expect(fs.written.size).toBe(0);
+	});
+
+	it("reports an append that did not land as NOT recorded, never as an answer", async () => {
+		const fs = freshLane(undefined, {unwritable: [LOG]});
+
+		const out = await run(fs, "WIP");
+		expect(out.code).toBe(APPEND_UNKNOWN);
+		expect(out.stdout).toBe("");
+		expect(out.stderr.at(-1)).toContain("NOT recorded");
+	});
+
+	it("seats its codes above the reserved band, distinct from each other", () => {
+		const codes = [LANE_ABSENT, EVENT_REFUSED, TASK_UNKNOWN, APPEND_UNKNOWN];
+		expect(new Set(codes).size).toBe(codes.length);
+		for (const code of codes) expect(code).toBeGreaterThanOrEqual(3);
+	});
+});

--- a/packages/fabrika-cli/src/lane/verbs.unit.test.ts
+++ b/packages/fabrika-cli/src/lane/verbs.unit.test.ts
@@ -1,0 +1,112 @@
+/** The three read verbs, plus the load refusals they all share. */
+import {Effect} from "effect";
+import {describe, expect, it} from "vitest";
+import {fakeFs} from "../fakes.test-support.ts";
+import {LANE_ABSENT, LANE_UNREADABLE, MALFORMED_RECORD} from "./codes.ts";
+import {coderTemplateText} from "./fixtures.test-support.ts";
+import {runHistory} from "./history-verb.ts";
+import {runPrint} from "./print-verb.ts";
+import {runStatus} from "./status-verb.ts";
+import type {LaneRef} from "./store.ts";
+
+const ROOT = ".fabrika/lanes";
+const REF: LaneRef = {root: ROOT, lane: "42"};
+const WORKFLOW = `${ROOT}/42/workflow.json`;
+const LOG = `${ROOT}/42/events.jsonl`;
+
+const logLine = (event: string): string =>
+	`${JSON.stringify({task: "issue", event: `ISSUE.${event}`, at: "2026-08-16T00:00:00.000Z"})}\n`;
+
+const run = (fs: ReturnType<typeof fakeFs>, verb: typeof runStatus) =>
+	Effect.runPromise(Effect.provide(verb(REF), fs.layer));
+
+const freshLane = (files: Record<string, string> = {}) =>
+	fakeFs({files: {[WORKFLOW]: coderTemplateText(), ...files}});
+
+describe("lane status", () => {
+	it("answers the fresh-lane shape with no events.jsonl on disk at all", async () => {
+		const out = await run(freshLane(), runStatus);
+
+		expect(out.code).toBe(0);
+		expect(JSON.parse(out.stdout)).toEqual({
+			stateValue: {pipeline: {issue: "queued"}},
+			status: "active",
+			context: {issue: {retries: 0, maxRetries: 2}, errors: []},
+		});
+	});
+
+	it("folds the log fresh each invocation — state comes from the events, nowhere else", async () => {
+		const out = await run(freshLane({[LOG]: logLine("WIP") + logLine("DONE")}), runStatus);
+
+		expect(JSON.parse(out.stdout)).toMatchObject({stateValue: {pipeline: {issue: "review"}}});
+	});
+
+	it("refuses a log that does not replay through the machine as a malformed record", async () => {
+		const out = await run(freshLane({[LOG]: logLine("PASS")}), runStatus);
+
+		expect(out.code).toBe(MALFORMED_RECORD);
+		expect(out.stdout).toBe("");
+		expect(out.stderr.join("\n")).toContain("does not replay");
+	});
+});
+
+describe("lane history", () => {
+	it("answers the log verbatim, [] on a fresh lane", async () => {
+		const fresh = await run(freshLane(), runHistory);
+		expect(fresh.code).toBe(0);
+		expect(JSON.parse(fresh.stdout)).toEqual([]);
+
+		const out = await run(freshLane({[LOG]: logLine("WIP")}), runHistory);
+		expect(JSON.parse(out.stdout)).toEqual([
+			{task: "issue", event: "ISSUE.WIP", at: "2026-08-16T00:00:00.000Z"},
+		]);
+	});
+
+	it("refuses a log line that does not parse, naming the line", async () => {
+		const out = await run(freshLane({[LOG]: `${logLine("WIP")}not json\n`}), runHistory);
+
+		expect(out.code).toBe(MALFORMED_RECORD);
+		expect(out.stderr.join("\n")).toContain("line 2");
+	});
+});
+
+describe("lane print", () => {
+	it("answers the compiled topology — phases, terminals, per-state legal events", async () => {
+		const out = await run(freshLane(), runPrint);
+
+		expect(out.code).toBe(0);
+		expect(JSON.parse(out.stdout)).toMatchObject({
+			phases: [{name: "pipeline", tasks: ["issue"]}],
+			terminals: {complete: "complete", tripped: "tripped"},
+			tasks: {issue: {initial: "queued", maxRetries: 2}},
+		});
+	});
+});
+
+describe("the shared load refusals", () => {
+	it("refuses an absent lane as proven absence, naming the template remedy", async () => {
+		const out = await run(fakeFs({files: {}}), runStatus);
+
+		expect(out.code).toBe(LANE_ABSENT);
+		expect(out.stdout).toBe("");
+		expect(out.stderr.at(-1)).toContain("template");
+	});
+
+	it("refuses an unreadable lane as UNKNOWN, never as fresh", async () => {
+		const out = await run(fakeFs({files: {[WORKFLOW]: null}, unprobeable: [WORKFLOW]}), runStatus);
+
+		expect(out.code).toBe(LANE_UNREADABLE);
+		expect(out.stderr.at(-1)).toContain("UNKNOWN");
+	});
+
+	it("refuses a workflow.json the compiler rejects, with every defect on stderr", async () => {
+		const out = await run(fakeFs({files: {[WORKFLOW]: '{"machine":{"states":{}}}'}}), runPrint);
+
+		expect(out.code).toBe(MALFORMED_RECORD);
+		expect(out.stderr.join("\n")).toContain("parallel");
+	});
+
+	it("keeps the three load outcomes on three distinct codes", () => {
+		expect(new Set([LANE_ABSENT, LANE_UNREADABLE, MALFORMED_RECORD]).size).toBe(3);
+	});
+});

--- a/packages/fabrika-cli/src/registry.ts
+++ b/packages/fabrika-cli/src/registry.ts
@@ -25,6 +25,7 @@ import {grillCommand} from "./grill/command.ts";
 import {handoffCommand} from "./handoff/command.ts";
 import {healCiCommand} from "./heal-ci/command.ts";
 import {hookCommand} from "./hook/command.ts";
+import {laneCommand} from "./lane/command.ts";
 import {ledgerCommand} from "./ledger/command.ts";
 import {mapCommand} from "./map/command.ts";
 import {patternCommand} from "./pattern/command.ts";
@@ -55,6 +56,7 @@ export const registeredGroups: ReadonlyArray<VerbGroup> = [
 	handoffCommand,
 	healCiCommand,
 	hookCommand,
+	laneCommand,
 	ledgerCommand,
 	mapCommand,
 	patternCommand,

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -21,6 +21,9 @@ catalogs:
     '@cloudflare/workers-types':
       specifier: ^4.20260629.1
       version: 4.20260629.1
+    '@demlik/tea':
+      specifier: 0.5.1
+      version: 0.5.1
     '@distilled.cloud/cloudflare':
       specifier: 0.27.0
       version: 0.27.0
@@ -811,6 +814,9 @@ importers:
 
   packages/fabrika-cli:
     dependencies:
+      '@demlik/tea':
+        specifier: 'catalog:'
+        version: 0.5.1(fast-check@4.8.0)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(vitest@4.1.5(@opentelemetry/api@1.9.1)(@types/node@25.6.2)(jsdom@26.1.0)(vite@8.1.5(@types/node@25.6.2)(esbuild@0.27.3)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.9.0)))(ws@8.21.0)
       '@effect/platform-node':
         specifier: 'catalog:'
         version: 4.0.0-beta.92(effect@4.0.0-beta.92(patch_hash=ed3008c54709e9cf624df2b898d592f905c570fc0a673eeaadf06ce377caac89))(ioredis@5.10.1)
@@ -1526,6 +1532,26 @@ packages:
   '@csstools/css-tokenizer@3.0.4':
     resolution: {integrity: sha512-Vd/9EVDiu6PPJt9yAh6roZP6El1xHrdvIVGjyBsHR0RYwNHgL7FJPyIIW4fANJNG6FtyZfvlRPpFI4ZM/lubvw==}
     engines: {node: '>=18'}
+
+  '@demlik/tea@0.5.1':
+    resolution: {integrity: sha512-GziDf830RQwMTqJqzI9yaPeqWKfkIvFlm3CP6pLnswWUpSrMLXqhOyjznZOVtcgJMh8zJ2+hHEy+bQHNcJZedQ==}
+    peerDependencies:
+      fast-check: ^3 || ^4
+      react: ^18 || ^19
+      react-dom: ^18 || ^19
+      vitest: ^2 || ^3
+      ws: ^8
+    peerDependenciesMeta:
+      fast-check:
+        optional: true
+      react:
+        optional: true
+      react-dom:
+        optional: true
+      vitest:
+        optional: true
+      ws:
+        optional: true
 
   '@distilled.cloud/aws@0.27.0':
     resolution: {integrity: sha512-3yjwnQ15XJJcDuNpeRD0INSLV4tQOulo5zppdp7juT6ODcDCxLBkx6QeVWlxCGPVqKed2LDBxHzVDj+8AxaIjw==}
@@ -3423,6 +3449,9 @@ packages:
       zod:
         optional: true
 
+  better-result@2.10.0:
+    resolution: {integrity: sha512-oQhh0y1qo2/ZKdAAEvHZAqKKiHOFU5k/bW96fE2ScgQOVkJRiHwB+nOS1SgFsYqRlxMDWvefXi9Q3px7QvgNDw==}
+
   bowser@2.14.1:
     resolution: {integrity: sha512-tzPjzCxygAKWFOJP011oxFHs57HzIhOEracIgAePE4pqB3LikALKnSzUyU4MGs9/iCEUuHlAJTjTc5M+u7YEGg==}
 
@@ -5222,6 +5251,16 @@ snapshots:
       '@csstools/css-tokenizer': 3.0.4
 
   '@csstools/css-tokenizer@3.0.4': {}
+
+  '@demlik/tea@0.5.1(fast-check@4.8.0)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(vitest@4.1.5(@opentelemetry/api@1.9.1)(@types/node@25.6.2)(jsdom@26.1.0)(vite@8.1.5(@types/node@25.6.2)(esbuild@0.27.3)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.9.0)))(ws@8.21.0)':
+    dependencies:
+      better-result: 2.10.0
+    optionalDependencies:
+      fast-check: 4.8.0
+      react: 19.2.6
+      react-dom: 19.2.6(react@19.2.6)
+      vitest: 4.1.5(@opentelemetry/api@1.9.1)(@types/node@25.6.2)(jsdom@26.1.0)(vite@8.1.5(@types/node@25.6.2)(esbuild@0.27.3)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.9.0))
+      ws: 8.21.0
 
   '@distilled.cloud/aws@0.27.0(effect@4.0.0-beta.92(patch_hash=ed3008c54709e9cf624df2b898d592f905c570fc0a673eeaadf06ce377caac89))':
     dependencies:
@@ -7156,6 +7195,8 @@ snapshots:
       set-cookie-parser: 3.1.0
     optionalDependencies:
       zod: 4.4.3
+
+  better-result@2.10.0: {}
 
   bowser@2.14.1: {}
 

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -15,6 +15,9 @@ catalog:
   '@better-auth/core': 1.6.23
   '@biomejs/biome': ^2.4.15
   '@cloudflare/workers-types': ^4.20260629.1
+  # Exact pin: the lane ledger's machines fold over this engine's dispatch semantics
+  # (NoCellError refusal, Transitions-form cells), so the version is part of the contract (#5673).
+  '@demlik/tea': 0.5.1
   '@distilled.cloud/cloudflare': 0.27.0
   '@effect/language-service': ^0.85.1
   '@effect/platform-bun': 4.0.0-beta.92


### PR DESCRIPTION
## Summary

Builds the minimal lane ledger the operator loop drives by hand (#5673): a `fabrika lane` verb group in `packages/fabrika-cli/src/lane/` — `status` / `transition` / `history` / `print`, each a fresh-process fold of an append-only `.fabrika/lanes/<n>/events.jsonl` through a `@demlik/tea` Transitions machine compiled from the lane's `workflow.json`. Fold = state: no resident process, no snapshot.

- **Compiler (`machine.ts`)** — recognizes the guarded-FAIL array structurally (`[retry-while-retries-remain, else-fallthrough]`), history resume as a `was` field in the folded task state, and the workflow terminals off each phase's `onDone` pair. `guard`/`actions` name strings are inert data; no name-normalization module exists anywhere in the diff. A document that does not fit is refused with every defect named — including a machine-level state that is neither a `parallel` phase nor a `final` terminal (a phase whose `"type": "parallel"` is missing refuses instead of silently dropping), an `onDone` target naming no machine-level state, and a final no `onDone` pair reaches.
- **Fold (`fold.ts`)** — `deriveStatus` is the whole compound machine (~30 lines): active phase = first phase whose tasks are not all final; a completed phase with a task in an error final trips the workflow (the `noErrors` gate as pure derivation). `applyEvent` validates before anything touches the log, so an invalid event — no cell (tea's `NoCellError`, surfaced verbatim at exit `12`), outside the operator's six, wrong phase, finished workflow — leaves `events.jsonl` byte-identical.
- **One committed coder template** (`src/lane/templates/coder.workflow.json`) — the static single-issue machine: `queued → build → review → ship`, review `FAIL` on a retry budget of 2 then `frozen` (freeze-after-2 as data), `BLOCKED`/`UNBLOCKED` suspend-resume via `was`, ship `BLOCKED` parking in `human:cp-approval`. It compiles under test.
- **Wiring** — `@demlik/tea@0.5.1` enters via `catalog:` (exact pin); the group registers in `registry.ts` and seats its exit table in the alignment registry (`4`/`7`/`8`/`11` imported from the base, `12`/`13` private); the package README documents the four verbs, the six events and the template. Lane state stays local under the existing `/.fabrika/` gitignore entry (`git check-ignore` proves `.fabrika/lanes/...` is covered).

Unit tests (157 across the group + package contract suites) follow the spikes' recorded runs as the test plan: fresh status shape, happy path, guarded retry, exhaustion + sibling isolation + the `noErrors` trip, blocked/resume to the left-off state, refuse-without-append with the log unappended, and the template compiling. Grounded against the published `@demlik/tea@0.5.1` typings (`dist/core-*.d.ts`: `applyCell`/`foldMsgs`/`NoCellError`/`defineMachine`) and verified live — the `Transitions` mapped type demands a full state×msg grid, so the data-compiled partial table crosses `defineMachine` through one commented cast; the absent cells are the refusal contract.

Fixes #5673

## Deviations

- **Scope narrowing** — **Said:** the criterion asks for a `.gitignore` entry covering `.fabrika/lanes/`. **Did:** no new entry; the repo already ignores `/.fabrika/` wholesale, and that existing entry's comment now names the lane state it covers. **Why:** a second overlapping entry would be noise. **Disposition:** `git check-ignore` proves `.fabrika/lanes/...` is covered, which is what the criterion asks for.
- **Out-of-scope change** — **Said:** the pitch names three pipeline stages, `build → review → ship`. **Did:** the coder template carries a `queued` entry state ahead of them, entered into `build` by `WIP`. **Why:** without an entry state the operator's `WIP` event would have no cell anywhere in the committed template, making one sixth of the event contract dead on arrival. **Disposition:** stated here; the template compiles under test.
- **Flag arity choice** — **Said:** the issue's verb contract addresses `lane transition` with `--task <id>`, without pinning the flag's arity. **Did:** `--task` is optional on a single-task lane (`lane transition 5673 DONE` works bare); a multi-task lane refuses the omission at exit `13`. **Why:** the single-issue dogfood is this slice's whole point. **Disposition:** stated here.
