### PR TITLE
lane open and lane emit: boot a single-issue lane, generate an epic machine from its topology

### DIFF
--- a/packages/fabrika-cli/src/lane/__fixtures__/epic-4300.body.txt
+++ b/packages/fabrika-cli/src/lane/__fixtures__/epic-4300.body.txt
@@ -1,0 +1,10 @@
+## Plan (plan-epic)
+
+### Summary
+Three children over two phases; the phase-2 child also names an explicit requires edge.
+
+## Dependencies
+
+- phase 1: #4301, #4302
+- phase 2: #4303
+- #4303 requires: #4301

--- a/packages/fabrika-cli/src/lane/__fixtures__/epic-4300.workflow.golden.txt
+++ b/packages/fabrika-cli/src/lane/__fixtures__/epic-4300.workflow.golden.txt
@@ -1,0 +1,232 @@
+{
+	"id": "epic-4300",
+	"version": 1,
+	"machine": {
+		"id": "epic-4300",
+		"initial": "phase1",
+		"context": {
+			"issue_4301": {
+				"retries": 0,
+				"maxRetries": 2
+			},
+			"issue_4302": {
+				"retries": 0,
+				"maxRetries": 2
+			},
+			"issue_4303": {
+				"retries": 0,
+				"maxRetries": 2
+			}
+		},
+		"states": {
+			"phase1": {
+				"type": "parallel",
+				"states": {
+					"issue_4301": {
+						"initial": "queued",
+						"states": {
+							"queued": {
+								"on": {
+									"ISSUE_4301.WIP": "build",
+									"ISSUE_4301.BLOCKED": "blocked"
+								}
+							},
+							"build": {
+								"on": {
+									"ISSUE_4301.DONE": "review",
+									"ISSUE_4301.BLOCKED": "blocked"
+								}
+							},
+							"review": {
+								"on": {
+									"ISSUE_4301.PASS": "ship",
+									"ISSUE_4301.BLOCKED": "blocked",
+									"ISSUE_4301.FAIL": [
+										{
+											"target": "build",
+											"guard": "retriesRemaining",
+											"actions": "incrementRetries"
+										},
+										{
+											"target": "frozen"
+										}
+									]
+								}
+							},
+							"ship": {
+								"on": {
+									"ISSUE_4301.DONE": "shipped",
+									"ISSUE_4301.BLOCKED": "human:cp-approval"
+								}
+							},
+							"blocked": {
+								"on": {
+									"ISSUE_4301.UNBLOCKED": "hist"
+								}
+							},
+							"human:cp-approval": {
+								"on": {
+									"ISSUE_4301.UNBLOCKED": "hist"
+								}
+							},
+							"hist": {
+								"type": "history"
+							},
+							"shipped": {
+								"type": "final"
+							},
+							"frozen": {
+								"type": "final"
+							}
+						}
+					},
+					"issue_4302": {
+						"initial": "queued",
+						"states": {
+							"queued": {
+								"on": {
+									"ISSUE_4302.WIP": "build",
+									"ISSUE_4302.BLOCKED": "blocked"
+								}
+							},
+							"build": {
+								"on": {
+									"ISSUE_4302.DONE": "review",
+									"ISSUE_4302.BLOCKED": "blocked"
+								}
+							},
+							"review": {
+								"on": {
+									"ISSUE_4302.PASS": "ship",
+									"ISSUE_4302.BLOCKED": "blocked",
+									"ISSUE_4302.FAIL": [
+										{
+											"target": "build",
+											"guard": "retriesRemaining",
+											"actions": "incrementRetries"
+										},
+										{
+											"target": "frozen"
+										}
+									]
+								}
+							},
+							"ship": {
+								"on": {
+									"ISSUE_4302.DONE": "shipped",
+									"ISSUE_4302.BLOCKED": "human:cp-approval"
+								}
+							},
+							"blocked": {
+								"on": {
+									"ISSUE_4302.UNBLOCKED": "hist"
+								}
+							},
+							"human:cp-approval": {
+								"on": {
+									"ISSUE_4302.UNBLOCKED": "hist"
+								}
+							},
+							"hist": {
+								"type": "history"
+							},
+							"shipped": {
+								"type": "final"
+							},
+							"frozen": {
+								"type": "final"
+							}
+						}
+					}
+				},
+				"onDone": [
+					{
+						"target": "phase2",
+						"guard": "noErrors"
+					},
+					{
+						"target": "tripped"
+					}
+				]
+			},
+			"phase2": {
+				"type": "parallel",
+				"states": {
+					"issue_4303": {
+						"initial": "queued",
+						"states": {
+							"queued": {
+								"on": {
+									"ISSUE_4303.WIP": "build",
+									"ISSUE_4303.BLOCKED": "blocked"
+								}
+							},
+							"build": {
+								"on": {
+									"ISSUE_4303.DONE": "review",
+									"ISSUE_4303.BLOCKED": "blocked"
+								}
+							},
+							"review": {
+								"on": {
+									"ISSUE_4303.PASS": "ship",
+									"ISSUE_4303.BLOCKED": "blocked",
+									"ISSUE_4303.FAIL": [
+										{
+											"target": "build",
+											"guard": "retriesRemaining",
+											"actions": "incrementRetries"
+										},
+										{
+											"target": "frozen"
+										}
+									]
+								}
+							},
+							"ship": {
+								"on": {
+									"ISSUE_4303.DONE": "shipped",
+									"ISSUE_4303.BLOCKED": "human:cp-approval"
+								}
+							},
+							"blocked": {
+								"on": {
+									"ISSUE_4303.UNBLOCKED": "hist"
+								}
+							},
+							"human:cp-approval": {
+								"on": {
+									"ISSUE_4303.UNBLOCKED": "hist"
+								}
+							},
+							"hist": {
+								"type": "history"
+							},
+							"shipped": {
+								"type": "final"
+							},
+							"frozen": {
+								"type": "final"
+							}
+						}
+					}
+				},
+				"onDone": [
+					{
+						"target": "complete",
+						"guard": "noErrors"
+					},
+					{
+						"target": "tripped"
+					}
+				]
+			},
+			"complete": {
+				"type": "final"
+			},
+			"tripped": {
+				"type": "final"
+			}
+		}
+	}
+}

--- a/packages/fabrika-cli/src/lane/codes.ts
+++ b/packages/fabrika-cli/src/lane/codes.ts
@@ -58,3 +58,23 @@ export const EVENT_REFUSED = 12;
  * differs: name a task the machine has, not a different event.
  */
 export const TASK_UNKNOWN = 13;
+
+/**
+ * The lane directory is already there — a boot or emit over it is refused with nothing written.
+ * Resuming an existing lane needs no boot, and silently overwriting a machine mid-drive would
+ * corrupt a live fold (#5688; gate-1 friction item 1 on #5680).
+ */
+export const LANE_EXISTS = 14;
+
+/**
+ * The epic body carries no readable `## Dependencies` topology — there is nothing to emit a machine
+ * from. The remedy is planning the epic, so it never shares a seat with a topology that is there
+ * and defective.
+ */
+export const TOPOLOGY_ABSENT = 15;
+
+/** The topology references an issue that is not a child of the epic, and the ref is named. */
+export const TOPOLOGY_FOREIGN = 16;
+
+/** The topology's dependency graph holds a cycle, and the ref path is named. */
+export const TOPOLOGY_CYCLE = 17;

--- a/packages/fabrika-cli/src/lane/command.ts
+++ b/packages/fabrika-cli/src/lane/command.ts
@@ -6,11 +6,14 @@
  * decision lives in the verb modules beside it, which is what makes each refusal testable without
  * spawning a process.
  */
-import {Effect} from "effect";
+import {fileURLToPath} from "node:url";
+import {Effect, Option} from "effect";
 import {Argument, Command, Flag} from "effect/unstable/cli";
 import {leafCommand} from "../excess-operand.ts";
 import type {VerbOutcome} from "../verb.ts";
+import {runEmit} from "./emit-verb.ts";
 import {runHistory} from "./history-verb.ts";
+import {runOpen} from "./open-verb.ts";
 import {runPrint} from "./print-verb.ts";
 import {runStatus} from "./status-verb.ts";
 import {DEFAULT_LANES_ROOT} from "./store.ts";
@@ -102,8 +105,47 @@ const print = leafCommand(
 	),
 );
 
+const templatePath = fileURLToPath(new URL("./templates/coder.workflow.json", import.meta.url));
+
+const open = leafCommand(
+	"open",
+	{lane: laneArgument, root: rootFlag},
+	Effect.fn(function* ({lane, root}) {
+		yield* emit(yield* runOpen({root, lane, templatePath}));
+	}),
+).pipe(
+	Command.withShortDescription("Boot a single-issue lane from the committed coder template."),
+	Command.withDescription(
+		"Boot one single-issue lane: create `<root>/<lane>/` and place a byte-identical copy of the committed coder template as its workflow.json. An existing lane dir is refused loudly with nothing written — resuming needs no boot, and overwriting a machine mid-drive would corrupt a live fold. Exits 8 (the write did not land — the lane is NOT booted), 11 (the template or the lane dir's existence could not be read — UNKNOWN, never a boot), 14 (the lane already exists). Example: fabrika lane open 5673",
+	),
+);
+
+const emitLane = leafCommand(
+	"emit",
+	{
+		epic: Argument.integer("epic").pipe(
+			Argument.withDescription("the type:epic issue whose plan topology becomes the machine"),
+		),
+		root: rootFlag,
+		repo: Flag.string("repo").pipe(
+			Flag.optional,
+			Flag.withDescription(
+				"the target owner/name (default: $CLAUDE_PIPELINE_REPO, else $GITHUB_REPOSITORY, else the origin remote)",
+			),
+		),
+	},
+	Effect.fn(function* ({epic, root, repo}) {
+		yield* emit(yield* runEmit({epic, root, repo: Option.getOrNull(repo), env: process.env}));
+	}),
+).pipe(
+	Command.withShortDescription("Generate an epic's lane machine from its board topology."),
+	Command.withDescription(
+		"Generate a lane machine from the epic's board state: read the epic body's `## Dependencies` topology (the shape `ledger topology` stages) and emit `<root>/<epic>/workflow.json` — one region per child in the coder template's exact shape, phase-sequenced, parallel within a phase. Deterministic: the same epic body bytes and child set emit the same machine bytes. Exits 4 (the topology was read in full and does not parse — the defective line, duplicate placement or unplaced requires subject is named), 7 (the epic is proven absent or closed), 8 (the write did not land), 11 (the epic, its child list or the lane dir could not be read — UNKNOWN), 14 (the lane already exists — remove it to regenerate), 15 (no `## Dependencies` topology — plan the epic first), 16 (the topology references a non-child, named), 17 (the topology holds a cycle, path named). Example: fabrika lane emit 5680",
+	),
+);
+
 export const laneCommand = Command.make("lane").pipe(
-	Command.withSubcommands([status, transition, history, print]),
+	Command.withSubcommands([status, transition, history, print, open, emitLane]),
 	Command.withShortDescription("Drive one lane's state ledger by folding its event log."),
 	Command.withDescription(
 		"Drive one lane's state ledger — a @demlik/tea machine folded fresh from an append-only events.jsonl on every invocation, speaking the operator's six events (#5673)",

--- a/packages/fabrika-cli/src/lane/emit-verb.ts
+++ b/packages/fabrika-cli/src/lane/emit-verb.ts
@@ -1,0 +1,115 @@
+/**
+ * `lane emit` — generate one epic's lane machine from its board state and place it as a new lane.
+ *
+ * The board reads ride the shipped readers (`getIssue` via `openIssue`, the native sub-issue list
+ * via `plan/github.ts`), the emission is the pure `emit.ts`, and the placement is the same guarded
+ * boot `lane open` uses. Every topology defect seats on its own code, because each takes a
+ * different remedy: plan the epic, fix the reference, break the cycle.
+ */
+import {Effect, type FileSystem, type Path} from "effect";
+import type {ChildProcessSpawner} from "effect/unstable/process";
+import {badNumber, openIssue, resolveTargetRepo} from "../build/target.ts";
+import {listSubIssues} from "../plan/github.ts";
+import {answer, refuse, type VerbOutcome} from "../verb.ts";
+import {
+	LANE_UNREADABLE,
+	MALFORMED_RECORD,
+	TOPOLOGY_ABSENT,
+	TOPOLOGY_CYCLE,
+	TOPOLOGY_FOREIGN,
+} from "./codes.ts";
+import {type EmitResult, emitMachine} from "./emit.ts";
+import {placementRefusal} from "./refusals.ts";
+import {placeMachine} from "./store.ts";
+
+const VERB = "fabrika lane emit";
+
+export interface EmitOptions {
+	readonly epic: number;
+	readonly root: string;
+	readonly repo: string | null;
+	readonly env: Readonly<Record<string, string | undefined>>;
+}
+
+const emitRefusal = (epic: number, result: Exclude<EmitResult, {_tag: "Emitted"}>): VerbOutcome => {
+	switch (result._tag) {
+		case "NoTopology":
+			return refuse(
+				TOPOLOGY_ABSENT,
+				`${VERB}: #${epic} carries no readable \`## Dependencies\` topology — plan the epic before emitting a machine.`,
+			);
+		case "Unparseable":
+			return refuse(
+				MALFORMED_RECORD,
+				`${VERB}: #${epic}'s topology line ${result.line} does not parse: "${result.text}".`,
+			);
+		case "Duplicate":
+			return refuse(
+				MALFORMED_RECORD,
+				`${VERB}: #${epic}'s topology places #${result.child} in more than one phase.`,
+			);
+		case "Unplaced":
+			return refuse(
+				MALFORMED_RECORD,
+				`${VERB}: #${epic}'s topology names #${result.child} in a requires line but places it in no phase.`,
+			);
+		case "Foreign":
+			return refuse(
+				TOPOLOGY_FOREIGN,
+				`${VERB}: the topology references ${result.ref}, which is not a child of #${epic}.`,
+			);
+		case "Cycle":
+			return refuse(
+				TOPOLOGY_CYCLE,
+				`${VERB}: the topology holds a cycle: ${result.path.map((n) => `#${n}`).join(" → ")}.`,
+			);
+	}
+};
+
+export const runEmit = (
+	options: EmitOptions,
+): Effect.Effect<
+	VerbOutcome,
+	never,
+	ChildProcessSpawner.ChildProcessSpawner | FileSystem.FileSystem | Path.Path
+> =>
+	Effect.gen(function* () {
+		const bad = badNumber(VERB, "an issue number", options.epic);
+		if (bad !== null) return bad;
+		const resolved = yield* resolveTargetRepo(VERB, options.repo, options.env);
+		if (resolved._tag === "Refused") return resolved.outcome;
+		const target = yield* openIssue(
+			VERB,
+			resolved.repo,
+			options.epic,
+			(reason) => `${VERB}: cannot read #${options.epic}: ${reason} — nothing was emitted.`,
+		);
+		if (target._tag === "Refused") return target.outcome;
+		const listed = yield* listSubIssues(resolved.repo, options.epic);
+		if (listed._tag === "Failure") {
+			return refuse(
+				LANE_UNREADABLE,
+				`${VERB}: cannot read #${options.epic}'s children: ${listed.reason} — nothing was emitted.`,
+			);
+		}
+		const emitted = emitMachine(options.epic, target.issue.body, listed.value);
+		if (emitted._tag !== "Emitted") return emitRefusal(options.epic, emitted);
+		const placed = yield* placeMachine(
+			{root: options.root, lane: String(options.epic)},
+			emitted.text,
+		);
+		if (placed._tag !== "Placed") return placementRefusal(VERB, placed);
+		return answer(
+			JSON.stringify({
+				answer: "emitted",
+				epic: options.epic,
+				workflow: placed.workflow,
+				phases: emitted.phases,
+				children: emitted.children,
+				bytes: new TextEncoder().encode(emitted.text).length,
+			}),
+			[
+				`${VERB}: read #${options.epic} and ${listed.value.length} sub-issue link(s) from ${resolved.repo}.`,
+			],
+		);
+	});

--- a/packages/fabrika-cli/src/lane/emit-verb.unit.test.ts
+++ b/packages/fabrika-cli/src/lane/emit-verb.unit.test.ts
@@ -1,0 +1,119 @@
+/** `lane emit` — the board reads, the emit refusal seats, and the write that lands the machine. */
+import {Effect, Layer} from "effect";
+import {describe, expect, it} from "vitest";
+import {issue} from "../build/fixtures.test-support.ts";
+import {errOut, fakeFs, fakeShell, okOut} from "../fakes.test-support.ts";
+import {readGoldenFixture} from "../golden-fixture.ts";
+import type {ExecResult} from "../io/exec.ts";
+import {
+	LANE_ABSENT,
+	LANE_EXISTS,
+	LANE_UNREADABLE,
+	TOPOLOGY_ABSENT,
+	TOPOLOGY_CYCLE,
+	TOPOLOGY_FOREIGN,
+} from "./codes.ts";
+import {runEmit} from "./emit-verb.ts";
+
+const ISSUE = /^gh api repos\/o\/r\/issues\/4300$/;
+const SUBS = /^gh api --paginate repos\/o\/r\/issues\/4300\/sub_issues\?per_page=100$/;
+
+const body = (): string => readGoldenFixture(import.meta.url, "./__fixtures__/epic-4300.body.txt");
+const golden = (): string =>
+	readGoldenFixture(import.meta.url, "./__fixtures__/epic-4300.workflow.golden.txt");
+
+const children = okOut(JSON.stringify([{number: 4301}, {number: 4302}, {number: 4303}]));
+
+const OPTIONS = {
+	epic: 4300,
+	root: ".fabrika/lanes",
+	repo: null,
+	env: {CLAUDE_PIPELINE_REPO: "o/r"} as Record<string, string | undefined>,
+};
+
+const run = (script: ReadonlyArray<readonly [RegExp, ExecResult]>, fs = fakeFs({files: {}})) =>
+	Effect.runPromise(
+		Effect.provide(runEmit(OPTIONS), Layer.merge(fs.layer, fakeShell(script).layer)),
+	).then((out) => ({out, fs}));
+
+describe("lane emit", () => {
+	it("writes the golden machine bytes to the epic's lane dir", async () => {
+		const {out, fs} = await run([
+			[ISSUE, issue({number: 4300, body: body()})],
+			[SUBS, children],
+		]);
+
+		expect(out.code).toBe(0);
+		expect(fs.written.get(".fabrika/lanes/4300/workflow.json")).toBe(golden());
+		expect(JSON.parse(out.stdout)).toMatchObject({
+			answer: "emitted",
+			epic: 4300,
+			phases: 2,
+			children: 3,
+		});
+	});
+
+	it("refuses an existing lane dir with the open verb's code and writes nothing", async () => {
+		const {out, fs} = await run(
+			[
+				[ISSUE, issue({number: 4300, body: body()})],
+				[SUBS, children],
+			],
+			fakeFs({files: {}, directories: [".fabrika/lanes/4300"]}),
+		);
+
+		expect(out.code).toBe(LANE_EXISTS);
+		expect(fs.written.size).toBe(0);
+	});
+
+	it("refuses a proven-absent epic on the no-target seat", async () => {
+		const {out} = await run([[ISSUE, errOut("gh: Not Found (HTTP 404)")]]);
+		expect(out.code).toBe(LANE_ABSENT);
+	});
+
+	it("refuses an unreadable child list as UNKNOWN — never an epic with no children", async () => {
+		const {out, fs} = await run([
+			[ISSUE, issue({number: 4300, body: body()})],
+			[SUBS, errOut("gh: connect: network is unreachable")],
+		]);
+
+		expect(out.code).toBe(LANE_UNREADABLE);
+		expect(fs.written.size).toBe(0);
+	});
+
+	it("refuses an epic with no topology block, naming the absence", async () => {
+		const {out} = await run([
+			[ISSUE, issue({number: 4300, body: "## Plan\n\nno topology\n"})],
+			[SUBS, children],
+		]);
+
+		expect(out.code).toBe(TOPOLOGY_ABSENT);
+		expect(out.stderr.join("\n")).toContain("Dependencies");
+	});
+
+	it("refuses a topology referencing a non-child, naming the ref", async () => {
+		const {out} = await run([
+			[ISSUE, issue({number: 4300, body: "## Dependencies\n\n- phase 1: #9999\n"})],
+			[SUBS, children],
+		]);
+
+		expect(out.code).toBe(TOPOLOGY_FOREIGN);
+		expect(out.stderr.join("\n")).toContain("#9999");
+	});
+
+	it("refuses a cycle, naming the path", async () => {
+		const cyclic =
+			"## Dependencies\n\n- phase 1: #4301, #4302\n- #4301 requires: #4302\n- #4302 requires: #4301\n";
+		const {out} = await run([
+			[ISSUE, issue({number: 4300, body: cyclic})],
+			[SUBS, children],
+		]);
+
+		expect(out.code).toBe(TOPOLOGY_CYCLE);
+		expect(out.stderr.join("\n")).toContain("#4301");
+	});
+
+	it("keeps the emit refusal seats distinct", () => {
+		expect(new Set([LANE_EXISTS, TOPOLOGY_ABSENT, TOPOLOGY_FOREIGN, TOPOLOGY_CYCLE]).size).toBe(4);
+	});
+});

--- a/packages/fabrika-cli/src/lane/emit.ts
+++ b/packages/fabrika-cli/src/lane/emit.ts
@@ -1,0 +1,158 @@
+/**
+ * The pure epic-machine emitter — one epic body plus its child set in, one `workflow.json` text
+ * out, byte-deterministic (#5688; phase 3 of #5680).
+ *
+ * **No second grammar and no second cycle walk.** The topology is read through the shipped
+ * `build/dependencies.ts` parser — the same reader `build eligible` gates on — and the cycle check
+ * is `ledger/topology-doc.ts`'s `findCycle` over the same union graph (declared `requires` edges
+ * plus the edges the phase order implies). What this module adds is only the machine rendering:
+ * one region per child in the coder template's exact shape (same six-event vocabulary, same
+ * retry/frozen semantics), phases sequenced by `onDone`, parallel within a phase.
+ *
+ * Determinism is by construction: phases ascend, children within a phase ascend, every object's
+ * keys are inserted in one fixed order, and the serialization is a single `JSON.stringify` — the
+ * same body bytes and child set can only produce the same machine bytes.
+ */
+import {type Ref, readTopology} from "../build/dependencies.ts";
+import {type DeclaredLine, findCycle} from "../ledger/topology-doc.ts";
+
+/** The coder template's retry budget, mirrored per child (see `templates/coder.workflow.json`). */
+const MAX_RETRIES = 2;
+
+export type EmitResult =
+	| {
+			readonly _tag: "Emitted";
+			readonly text: string;
+			readonly phases: number;
+			readonly children: number;
+	  }
+	| {readonly _tag: "NoTopology"}
+	| {readonly _tag: "Unparseable"; readonly line: number; readonly text: string}
+	| {readonly _tag: "Foreign"; readonly ref: string}
+	| {readonly _tag: "Duplicate"; readonly child: number}
+	| {readonly _tag: "Unplaced"; readonly child: number}
+	| {readonly _tag: "Cycle"; readonly path: ReadonlyArray<number>};
+
+/** One child's region — the coder template's `issue` region, namespaced to the child's task id. */
+const region = (ns: string): Record<string, unknown> => ({
+	initial: "queued",
+	states: {
+		queued: {on: {[`${ns}.WIP`]: "build", [`${ns}.BLOCKED`]: "blocked"}},
+		build: {on: {[`${ns}.DONE`]: "review", [`${ns}.BLOCKED`]: "blocked"}},
+		review: {
+			on: {
+				[`${ns}.PASS`]: "ship",
+				[`${ns}.BLOCKED`]: "blocked",
+				[`${ns}.FAIL`]: [
+					{target: "build", guard: "retriesRemaining", actions: "incrementRetries"},
+					{target: "frozen"},
+				],
+			},
+		},
+		ship: {on: {[`${ns}.DONE`]: "shipped", [`${ns}.BLOCKED`]: "human:cp-approval"}},
+		blocked: {on: {[`${ns}.UNBLOCKED`]: "hist"}},
+		"human:cp-approval": {on: {[`${ns}.UNBLOCKED`]: "hist"}},
+		hist: {type: "history"},
+		shipped: {type: "final"},
+		frozen: {type: "final"},
+	},
+});
+
+const taskId = (child: number): string => `issue_${child}`;
+
+const ascending = (values: Iterable<number>): ReadonlyArray<number> =>
+	[...values].sort((a, b) => a - b);
+
+/** Emit the epic's lane machine from its body's `## Dependencies` block and its child set. */
+export const emitMachine = (
+	epic: number,
+	body: string,
+	children: ReadonlyArray<number>,
+): EmitResult => {
+	const topo = readTopology(body);
+	if (topo._tag === "Absent") return {_tag: "NoTopology"};
+	if (topo._tag === "Unparseable") return {_tag: "Unparseable", line: topo.line, text: topo.text};
+
+	const known = new Set(children);
+	const issueNumbers = (refs: ReadonlyArray<Ref>): number[] =>
+		refs.flatMap((ref) => (ref._tag === "Issue" ? [ref.number] : []));
+	const phases = new Map<number, number[]>();
+	const requires = new Map<number, number[]>();
+	for (const edge of topo.edges) {
+		const refs = edge._tag === "Phase" ? edge.members : [edge.subject, ...edge.needs];
+		for (const ref of refs) {
+			if (ref._tag === "Local") return {_tag: "Foreign", ref: ref.id};
+			if (!known.has(ref.number)) return {_tag: "Foreign", ref: `#${ref.number}`};
+		}
+		if (edge._tag === "Phase") {
+			const members = issueNumbers(edge.members);
+			phases.set(edge.phase, [...(phases.get(edge.phase) ?? []), ...members]);
+			continue;
+		}
+		const [subject] = issueNumbers([edge.subject]);
+		if (subject === undefined) continue;
+		requires.set(subject, [...(requires.get(subject) ?? []), ...issueNumbers(edge.needs)]);
+	}
+	if (phases.size === 0) return {_tag: "NoTopology"};
+
+	const placed = new Map<number, number>();
+	for (const [phase, members] of phases) {
+		for (const child of members) {
+			if (placed.has(child)) return {_tag: "Duplicate", child};
+			placed.set(child, phase);
+		}
+	}
+	for (const [subject, needs] of requires) {
+		for (const child of [subject, ...needs]) {
+			if (!placed.has(child)) return {_tag: "Unplaced", child};
+		}
+	}
+
+	const lines: DeclaredLine[] = [...placed.entries()].map(([child, phase]) => ({
+		child,
+		phase,
+		requires: requires.get(child) ?? [],
+	}));
+	const cycle = findCycle(lines);
+	if (cycle !== null) return {_tag: "Cycle", path: cycle};
+
+	const order = ascending(phases.keys());
+	const phaseName = (phase: number): string => `phase${phase}`;
+	const context: Record<string, unknown> = {};
+	const states: Record<string, unknown> = {};
+	for (const [index, phase] of order.entries()) {
+		const members = ascending(phases.get(phase) ?? []);
+		for (const child of members) context[taskId(child)] = {retries: 0, maxRetries: MAX_RETRIES};
+		const next = order[index + 1];
+		states[phaseName(phase)] = {
+			type: "parallel",
+			states: Object.fromEntries(
+				members.map((child) => [taskId(child), region(taskId(child).toUpperCase())]),
+			),
+			onDone: [
+				{target: next === undefined ? "complete" : phaseName(next), guard: "noErrors"},
+				{target: "tripped"},
+			],
+		};
+	}
+	states.complete = {type: "final"};
+	states.tripped = {type: "final"};
+
+	const first = order[0];
+	const doc = {
+		id: `epic-${epic}`,
+		version: 1,
+		machine: {
+			id: `epic-${epic}`,
+			initial: phaseName(first ?? 1),
+			context,
+			states,
+		},
+	};
+	return {
+		_tag: "Emitted",
+		text: `${JSON.stringify(doc, null, "\t")}\n`,
+		phases: order.length,
+		children: placed.size,
+	};
+};

--- a/packages/fabrika-cli/src/lane/emit.unit.test.ts
+++ b/packages/fabrika-cli/src/lane/emit.unit.test.ts
@@ -1,0 +1,113 @@
+/**
+ * The pure epic-machine emitter: golden bytes off the committed fixture pair, determinism, the
+ * compile/transition round trip, and every topology refusal as its own tagged arm.
+ */
+import {Effect} from "effect";
+import {describe, expect, it} from "vitest";
+import {fakeFs} from "../fakes.test-support.ts";
+import {readGoldenFixture} from "../golden-fixture.ts";
+import {type EmitResult, emitMachine} from "./emit.ts";
+import {compileText} from "./machine.ts";
+import {runTransition} from "./transition-verb.ts";
+
+const body = (): string => readGoldenFixture(import.meta.url, "./__fixtures__/epic-4300.body.txt");
+const golden = (): string =>
+	readGoldenFixture(import.meta.url, "./__fixtures__/epic-4300.workflow.golden.txt");
+
+const CHILDREN = [4301, 4302, 4303];
+
+const emitted = (result: EmitResult): string => {
+	if (result._tag !== "Emitted") throw new Error(`expected Emitted, got ${result._tag}`);
+	return result.text;
+};
+
+describe("emitMachine", () => {
+	it("emits the golden machine bytes from the golden epic body", () => {
+		expect(emitted(emitMachine(4300, body(), CHILDREN))).toBe(golden());
+	});
+
+	it("is deterministic — the same body bytes emit the same machine bytes", () => {
+		expect(emitted(emitMachine(4300, body(), CHILDREN))).toBe(
+			emitted(emitMachine(4300, body(), CHILDREN)),
+		);
+	});
+
+	it("emits a machine the lane compiler accepts without repair", () => {
+		const compiled = compileText(emitted(emitMachine(4300, body(), CHILDREN)));
+		if (compiled._tag !== "Compiled") throw new Error(compiled.defects.join("; "));
+		expect(compiled.lane.phases).toEqual([
+			{name: "phase1", tasks: ["issue_4301", "issue_4302"]},
+			{name: "phase2", tasks: ["issue_4303"]},
+		]);
+		expect(compiled.lane.terminals).toEqual({complete: "complete", tripped: "tripped"});
+	});
+
+	it("emits a machine whose states and events `lane transition` accepts", async () => {
+		const fs = fakeFs({
+			files: {".fabrika/lanes/4300/workflow.json": emitted(emitMachine(4300, body(), CHILDREN))},
+		});
+		const out = await Effect.runPromise(
+			Effect.provide(
+				runTransition({root: ".fabrika/lanes", lane: "4300", event: "WIP", task: "issue_4301"}),
+				fs.layer,
+			),
+		);
+		expect(out.code).toBe(0);
+		expect(JSON.parse(out.stdout)).toMatchObject({
+			event: "ISSUE_4301.WIP",
+			current: {phase1: {issue_4301: "build", issue_4302: "queued"}, phase2: "waiting"},
+		});
+	});
+
+	it("refuses a body with no ## Dependencies block", () => {
+		expect(emitMachine(4300, "## Plan\n\nno topology here\n", CHILDREN)).toEqual({
+			_tag: "NoTopology",
+		});
+	});
+
+	it("refuses a block that parses to zero phase lines as no topology", () => {
+		expect(emitMachine(4300, "## Dependencies\n\n", CHILDREN)).toEqual({_tag: "NoTopology"});
+	});
+
+	it("refuses a phase member that is not a child of the epic, naming it", () => {
+		expect(emitMachine(4300, "## Dependencies\n\n- phase 1: #9999\n", CHILDREN)).toEqual({
+			_tag: "Foreign",
+			ref: "#9999",
+		});
+	});
+
+	it("refuses a requires reference that is not a child of the epic", () => {
+		const text = "## Dependencies\n\n- phase 1: #4301\n- #4301 requires: #9999\n";
+		expect(emitMachine(4300, text, CHILDREN)).toEqual({_tag: "Foreign", ref: "#9999"});
+	});
+
+	it("refuses a ledger-local ref — an epic on the board holds only real issues", () => {
+		expect(emitMachine(4300, "## Dependencies\n\n- phase 1: C1\n", CHILDREN)).toEqual({
+			_tag: "Foreign",
+			ref: "C1",
+		});
+	});
+
+	it("refuses a cycle, naming the ref path", () => {
+		const text =
+			"## Dependencies\n\n- phase 1: #4301, #4302\n- #4301 requires: #4302\n- #4302 requires: #4301\n";
+		const out = emitMachine(4300, text, CHILDREN);
+		if (out._tag !== "Cycle") throw new Error(`expected Cycle, got ${out._tag}`);
+		expect(out.path.length).toBeGreaterThan(2);
+	});
+
+	it("refuses a line under the heading that does not parse, naming it", () => {
+		const out = emitMachine(4300, "## Dependencies\n\n- phase one: #4301\n", CHILDREN);
+		expect(out).toMatchObject({_tag: "Unparseable", text: "- phase one: #4301"});
+	});
+
+	it("refuses a child placed in two phases", () => {
+		const text = "## Dependencies\n\n- phase 1: #4301\n- phase 2: #4301\n";
+		expect(emitMachine(4300, text, CHILDREN)).toEqual({_tag: "Duplicate", child: 4301});
+	});
+
+	it("refuses a requires subject placed in no phase", () => {
+		const text = "## Dependencies\n\n- phase 1: #4301\n- #4303 requires: #4301\n";
+		expect(emitMachine(4300, text, CHILDREN)).toEqual({_tag: "Unplaced", child: 4303});
+	});
+});

--- a/packages/fabrika-cli/src/lane/open-verb.ts
+++ b/packages/fabrika-cli/src/lane/open-verb.ts
@@ -1,0 +1,44 @@
+/**
+ * `lane open` — boot one single-issue lane from the committed coder template, byte-identically.
+ *
+ * The boot the operator did by hand as `mkdir -p && cp` (#5680, gate-1 friction item 1), as a verb
+ * that refuses instead of overwriting: an existing lane dir is a loud {@link LANE_EXISTS}, because
+ * resuming needs no boot and a silent overwrite would corrupt a live fold.
+ */
+import {Effect, type FileSystem, type Path, Result} from "effect";
+import {readFile} from "../io/fs.ts";
+import {answer, refuse, type VerbOutcome} from "../verb.ts";
+import {LANE_UNREADABLE} from "./codes.ts";
+import {placementRefusal} from "./refusals.ts";
+import {type LaneRef, placeMachine} from "./store.ts";
+
+const VERB = "fabrika lane open";
+
+export interface OpenOptions extends LaneRef {
+	/** The committed coder template's on-disk path — resolved by the adapter beside this module. */
+	readonly templatePath: string;
+}
+
+export const runOpen = (
+	options: OpenOptions,
+): Effect.Effect<VerbOutcome, never, FileSystem.FileSystem | Path.Path> =>
+	Effect.gen(function* () {
+		const template = yield* Effect.result(readFile(options.templatePath));
+		if (Result.isFailure(template)) {
+			return refuse(
+				LANE_UNREADABLE,
+				`${VERB}: cannot read the committed template at ${options.templatePath}: ${template.failure.reason} — nothing was booted.`,
+			);
+		}
+		const placed = yield* placeMachine(options, template.success);
+		if (placed._tag !== "Placed") return placementRefusal(VERB, placed);
+		return answer(
+			JSON.stringify({
+				answer: "opened",
+				lane: options.lane,
+				workflow: placed.workflow,
+				bytes: new TextEncoder().encode(template.success).length,
+			}),
+			[`${VERB}: booted ${placed.dir} from ${options.templatePath}.`],
+		);
+	});

--- a/packages/fabrika-cli/src/lane/open-verb.unit.test.ts
+++ b/packages/fabrika-cli/src/lane/open-verb.unit.test.ts
@@ -1,0 +1,79 @@
+/** `lane open` — the template boot, and the refusals that leave the disk untouched. */
+import {Effect, type FileSystem, type Path} from "effect";
+import {describe, expect, it} from "vitest";
+import {fakeFs} from "../fakes.test-support.ts";
+import type {VerbOutcome} from "../verb.ts";
+import {APPEND_UNKNOWN, LANE_EXISTS, LANE_UNREADABLE} from "./codes.ts";
+import {coderTemplateText} from "./fixtures.test-support.ts";
+import {runOpen} from "./open-verb.ts";
+import {runStatus} from "./status-verb.ts";
+
+const ROOT = ".fabrika/lanes";
+const DIR = `${ROOT}/42`;
+const WORKFLOW = `${DIR}/workflow.json`;
+const TEMPLATE = "/pkg/src/lane/templates/coder.workflow.json";
+
+const OPTIONS = {root: ROOT, lane: "42", templatePath: TEMPLATE};
+
+const run = (
+	fs: ReturnType<typeof fakeFs>,
+	eff: Effect.Effect<VerbOutcome, never, FileSystem.FileSystem | Path.Path>,
+) => Effect.runPromise(Effect.provide(eff, fs.layer));
+
+describe("lane open", () => {
+	it("boots the lane with a byte-identical copy of the committed template", async () => {
+		const fs = fakeFs({files: {[TEMPLATE]: coderTemplateText()}});
+		const out = await run(fs, runOpen(OPTIONS));
+
+		expect(out.code).toBe(0);
+		expect(fs.written.get(WORKFLOW)).toBe(coderTemplateText());
+		expect(JSON.parse(out.stdout)).toMatchObject({answer: "opened", lane: "42"});
+	});
+
+	it("folds the freshly opened lane to its initial state through `lane status`", async () => {
+		const fs = fakeFs({files: {[TEMPLATE]: coderTemplateText()}});
+		await run(fs, runOpen(OPTIONS));
+		const out = await run(fs, runStatus({root: ROOT, lane: "42"}));
+
+		expect(out.code).toBe(0);
+		expect(JSON.parse(out.stdout)).toMatchObject({
+			stateValue: {pipeline: {issue: "queued"}},
+			status: "active",
+		});
+	});
+
+	it("refuses an existing lane dir with its own code and writes nothing", async () => {
+		const fs = fakeFs({files: {[TEMPLATE]: coderTemplateText()}, directories: [DIR]});
+		const out = await run(fs, runOpen(OPTIONS));
+
+		expect(out.code).toBe(LANE_EXISTS);
+		expect(out.stdout).toBe("");
+		expect(fs.written.size).toBe(0);
+		expect(out.stderr.join("\n")).toContain("already");
+	});
+
+	it("refuses when the lane dir's existence cannot be established — UNKNOWN, never a boot", async () => {
+		const fs = fakeFs({files: {[TEMPLATE]: coderTemplateText()}, unprobeable: [DIR]});
+		const out = await run(fs, runOpen(OPTIONS));
+
+		expect(out.code).toBe(LANE_UNREADABLE);
+		expect(fs.written.size).toBe(0);
+	});
+
+	it("refuses an unreadable template, naming it", async () => {
+		const fs = fakeFs({files: {}});
+		const out = await run(fs, runOpen(OPTIONS));
+
+		expect(out.code).toBe(LANE_UNREADABLE);
+		expect(out.stderr.join("\n")).toContain(TEMPLATE);
+		expect(fs.written.size).toBe(0);
+	});
+
+	it("refuses a write that did not land — the lane is never reported opened", async () => {
+		const fs = fakeFs({files: {[TEMPLATE]: coderTemplateText()}, unwritable: [WORKFLOW]});
+		const out = await run(fs, runOpen(OPTIONS));
+
+		expect(out.code).toBe(APPEND_UNKNOWN);
+		expect(out.stdout).toBe("");
+	});
+});

--- a/packages/fabrika-cli/src/lane/refusals.ts
+++ b/packages/fabrika-cli/src/lane/refusals.ts
@@ -3,9 +3,15 @@
  * with the same stderr shape whichever verb hit it.
  */
 import {refuse, type VerbOutcome} from "../verb.ts";
-import {LANE_ABSENT, LANE_UNREADABLE, MALFORMED_RECORD} from "./codes.ts";
+import {
+	APPEND_UNKNOWN,
+	LANE_ABSENT,
+	LANE_EXISTS,
+	LANE_UNREADABLE,
+	MALFORMED_RECORD,
+} from "./codes.ts";
 import type {FoldResult} from "./fold.ts";
-import type {LoadedLane} from "./store.ts";
+import type {LoadedLane, Placement} from "./store.ts";
 
 /** Seat a non-`Loaded` load outcome. Absent names the remedy: open the lane from a template. */
 export const loadRefusal = (
@@ -28,6 +34,30 @@ export const loadRefusal = (
 				MALFORMED_RECORD,
 				`${verb}: ${loaded.path} was read in full and is not the shape.`,
 				loaded.defects.map((defect) => `${verb}: defect: ${defect}`),
+			);
+	}
+};
+
+/** Seat a non-`Placed` boot outcome — nothing was written, and the reason names the remedy. */
+export const placementRefusal = (
+	verb: string,
+	placed: Exclude<Placement, {_tag: "Placed"}>,
+): VerbOutcome => {
+	switch (placed._tag) {
+		case "Exists":
+			return refuse(
+				LANE_EXISTS,
+				`${verb}: a lane already exists at ${placed.dir} — resuming needs no boot; remove the directory to rebuild it.`,
+			);
+		case "Unprobeable":
+			return refuse(
+				LANE_UNREADABLE,
+				`${verb}: cannot establish whether a lane is already at ${placed.dir}: ${placed.reason} — refusing to write over UNKNOWN.`,
+			);
+		case "Unwritten":
+			return refuse(
+				APPEND_UNKNOWN,
+				`${verb}: the write to ${placed.path} did not land: ${placed.reason} — the lane is NOT booted.`,
 			);
 	}
 };

--- a/packages/fabrika-cli/src/lane/store.ts
+++ b/packages/fabrika-cli/src/lane/store.ts
@@ -12,7 +12,7 @@
  * well-formed fresh lane, not a fault.
  */
 import {Effect, type FileSystem, Path, Result} from "effect";
-import {exists, readFile} from "../io/fs.ts";
+import {exists, readFile, writeFile} from "../io/fs.ts";
 import {type LogEntry, parseLog} from "./fold.ts";
 import {type CompiledLane, compileText} from "./machine.ts";
 
@@ -78,4 +78,37 @@ export const loadLane = (
 			return {_tag: "Malformed", path: logPath, defects: parsed.defects} as const;
 		}
 		return {_tag: "Loaded", lane: compiled.lane, entries: parsed.entries, dir, logPath} as const;
+	});
+
+export type Placement =
+	| {readonly _tag: "Placed"; readonly dir: string; readonly workflow: string}
+	| {readonly _tag: "Exists"; readonly dir: string}
+	| {readonly _tag: "Unprobeable"; readonly dir: string; readonly reason: string}
+	| {readonly _tag: "Unwritten"; readonly path: string; readonly reason: string};
+
+/**
+ * Place one machine document as a NEW lane — the boot both `lane open` and `lane emit` share.
+ *
+ * An existing lane directory refuses before anything is written: resuming an existing lane needs no
+ * boot, and silently overwriting a machine mid-drive would corrupt a live fold (#5688). A probe that
+ * cannot answer is UNKNOWN, never an absence to build on.
+ */
+export const placeMachine = (
+	ref: LaneRef,
+	text: string,
+): Effect.Effect<Placement, never, FileSystem.FileSystem | Path.Path> =>
+	Effect.gen(function* () {
+		const path = yield* Path.Path;
+		const dir = path.join(ref.root, ref.lane);
+		const probe = yield* Effect.result(exists(dir));
+		if (Result.isFailure(probe)) {
+			return {_tag: "Unprobeable", dir, reason: probe.failure.reason} as const;
+		}
+		if (probe.success) return {_tag: "Exists", dir} as const;
+		const workflow = path.join(dir, "workflow.json");
+		const wrote = yield* Effect.result(writeFile(workflow, text));
+		if (Result.isFailure(wrote)) {
+			return {_tag: "Unwritten", path: workflow, reason: wrote.failure.reason} as const;
+		}
+		return {_tag: "Placed", dir, workflow} as const;
 	});


### PR DESCRIPTION
Two new verbs in the `fabrika lane` group, beside `status`/`transition`/`history`/`print`:

- `lane open <n>` boots a single-issue lane: it places a byte-identical copy of the committed coder template as `<root>/<n>/workflow.json`, and refuses an existing lane dir loudly (exit 14) with nothing written. This closes gate-1 friction item 1 on #5680 — the boot was a hand `mkdir -p && cp`.
- `lane emit <epic>` generates a lane machine from the epic's board state: it reads the epic body's `## Dependencies` block through the shipped `build/dependencies.ts` parser (no second grammar), validates refs against the native sub-issue child list, runs `ledger/topology-doc.ts`'s `findCycle` over the same union graph (no second cycle walk), and emits one region per child in the coder template's exact shape — phase-sequenced, parallel within a phase, same six events and retry/frozen semantics. Emission is byte-deterministic by construction. Refusals seat on distinct codes: no topology (15), non-child ref (16), cycle (17), plus the existing malformed-record seat (4) for a block that is there and defective.

Both verbs share one guarded boot (`placeMachine` in `store.ts`): probe the lane dir, refuse `Exists`/`Unprobeable`/`Unwritten` before reporting anything opened. Tests were written red-first; the golden pair (epic body → machine bytes) is committed under `src/lane/__fixtures__/`, and the emitted machine is proven to compile through `src/lane/machine.ts` and to accept `lane transition` events in the tests. Verified live against #5680 itself: emit → status folds phase 1, re-emit refuses 14, two emits produce identical bytes.

Fixes #5688

## Deviations

- **Scope widening** — **Said:** the issue specifies the existing-lane-dir refusal for `lane open` only. **Did:** `lane emit` refuses an existing lane dir too, on the same exit 14. **Why:** the refusal's rationale — silently overwriting a machine mid-drive corrupts a live fold — applies identically to emit. **Disposition:** stated here; regeneration is removing the lane dir first, which the refusal message names.
- **Scope widening** — **Said:** the issue names three emit refusals (absent topology, unknown child, cycle). **Did:** two further topology defects refuse on the existing malformed-record seat (exit 4) rather than emitting a broken machine: a child placed in more than one phase, and a `requires` line naming a child placed in no phase. **Why:** each would otherwise emit a machine the fold cannot drive. **Disposition:** stated here; both are covered by unit tests.
- **Format choice** — **Said:** the issue asks for a golden epic-body fixture byte-compared in a unit test, without pinning the fixture's file extension. **Did:** the golden fixtures are committed as `.txt`, not `.json`/`.md`. **Why:** biome's JSON formatter would rewrite the golden bytes the byte-compare tests assert against. **Disposition:** stated here.
