### PR TITLE
fabrika shells: Agent tool everywhere, effort pins dropped

### DIFF
--- a/claude-plugins/fabrika/agents/builder.md
+++ b/claude-plugins/fabrika/agents/builder.md
@@ -2,8 +2,7 @@
 name: builder
 description: The builder — spawn target for the fabrika `build` skill, the construction stage. Use it when a driver needs a subagent that turns one triaged, agent-ready issue into a pull request, or repairs an existing PR against its gates' current-head verdicts. It carries no behaviour of its own; everything it does comes from the preloaded skill.
 skills: ["fabrika:build"]
-tools: ["Bash", "Read", "Write", "Edit", "Grep", "Glob", "Skill"]
-effort: high
+tools: ["Bash", "Read", "Write", "Edit", "Grep", "Glob", "Skill", "Agent"]
 ---
 
 An agent shell: the **builder** is a spawn target that exists so a driver can address the fabrika

--- a/claude-plugins/fabrika/agents/reviewer.md
+++ b/claude-plugins/fabrika/agents/reviewer.md
@@ -3,7 +3,6 @@ name: reviewer
 description: The reviewer — spawn target for the fabrika `review` skill, the text-review gate. Use it when a driver needs a subagent that judges one PR's textual artifacts against its linked issue and lands the SHA-bound verdicts. It carries no behaviour of its own; everything it does comes from the preloaded skill.
 skills: ["fabrika:review"]
 tools: ["Bash", "Read", "Grep", "Glob", "Skill", "Agent"]
-effort: high
 ---
 
 An agent shell: the **reviewer** is a spawn target that exists so a driver can address the fabrika

--- a/claude-plugins/fabrika/agents/shipper.md
+++ b/claude-plugins/fabrika/agents/shipper.md
@@ -2,8 +2,7 @@
 name: shipper
 description: The shipper — spawn target for the fabrika `ship` skill, the merge authority. Use it when a driver needs a subagent that walks one verified PR's guard chain, enqueues it, and reconciles the terminal outcome. It carries no behaviour of its own; everything it does comes from the preloaded skill.
 skills: ["fabrika:ship"]
-tools: ["Bash", "Read", "Grep", "Glob"]
-effort: high
+tools: ["Bash", "Read", "Grep", "Glob", "Agent"]
 ---
 
 An agent shell: the **shipper** is a spawn target that exists so a driver can address the fabrika


### PR DESCRIPTION
Founder-ruled direct change (no lane): add `Agent` to every fabrika shell's tools and drop the `effort: high` pins.

- builder: +Agent, −effort
- reviewer: −effort (already had Agent)
- shipper: +Agent, −effort

The operator shell (in-flight on #5690) already carries Agent; its effort pin is flagged to that PR's round.

Fixes #5686
Fixes #5669

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Deviations

- **Scope widening** — **Said:** #5669's recorded ruling dropped `effort: high` from builder and shipper only ("reviewer is fine"). **Did:** dropped it from all three shells, reviewer included. **Why:** a later founder ruling (in-session 2026-08-16) superseded the earlier one: remove effort levels from all agents. **Disposition:** the wider ruling is now recorded as a dated amendment on #5669 (comment thread); this PR implements it.
