### PR TITLE
The bare fabrika command in a worktree runs the primary checkout's code

### DIFF
--- a/claude-plugins/fabrika/docs/cli-interface-convention.md
+++ b/claude-plugins/fabrika/docs/cli-interface-convention.md
@@ -220,13 +220,25 @@ usable at an agent's top-level command.
 
 - A fabrika verb is invoked as a plain literal command string — no `$VAR`, no `${VAR:-default}`, no
   command substitution, no `source`.
-- **The literal is `fabrika`.** That name is now fixed, closing the deferral this rule carried
-  to [#4650](https://github.com/kamp-us/phoenix/issues/4650): every fence in every fabrika skill
-  writes `fabrika <group> <verb> …` and nothing else. The command and the package are deliberately
-  **different names** — `fabrika` is the `bin` *key* of the `@kampus/fabrika-cli` package, which
-  keeps its name on npm and its directory at `packages/fabrika-cli/`
-  ([#4784](https://github.com/kamp-us/phoenix/issues/4784)). [Delivery](#delivery--one-name-two-installs)
-  below is how the command comes to resolve.
+- **The literal is `pnpm exec fabrika`.** The command name is fixed, closing the deferral this rule
+  carried to [#4650](https://github.com/kamp-us/phoenix/issues/4650): every fence in every fabrika
+  skill writes `pnpm exec fabrika <group> <verb> …` and nothing else. The command and the package
+  are deliberately **different names** — `fabrika` is the `bin` *key* of the `@kampus/fabrika-cli`
+  package, which keeps its name on npm and its directory at `packages/fabrika-cli/`
+  ([#4784](https://github.com/kamp-us/phoenix/issues/4784)). The `pnpm exec` prefix is what makes
+  the fence resolve the **calling tree's** copy rather than whichever copy PATH happens to name;
+  [Delivery](#delivery--one-name-two-installs) below is why the bare name cannot be that fence.
+  This is still a plain literal — the rule above bans a variable-rooted invocation, and there is no
+  variable here. `pipeline-cli`'s opposite rule (never bare, resolved by path) is not this one: the
+  two CLIs resolve by different mechanisms, and `pipeline-cli cli-invocation-guard` enforces each
+  in its own terms ([#5679](https://github.com/kamp-us/phoenix/issues/5679)).
+- **The hook surface is the one exception, and it is enforced the other way.** A `hooks.json`
+  command stays the bare `fabrika <group> <verb>` literal: the harness runs it, not an agent in a
+  worktree, and `LITERAL_COMMAND` in
+  [`../../../packages/fabrika-cli/src/hook/declaration.ts`](../../../packages/fabrika-cli/src/hook/declaration.ts)
+  reds on anything else. A hook that cannot dispatch fails open by ruling (ADR
+  [0250](../../../.decisions/0250-fabrika-hook-cannot-run-fails-open.md)), so the worktree branch
+  costs a hook its answer, never a session. [`hook-surface.md`](hook-surface.md) owns that surface.
 - **Examples in `--help` and in a contract spec are held to the same rule.** An example an agent
   cannot paste verbatim is not an example.
 - A verb never requires an env var to *locate* itself. Configuration may still arrive by env
@@ -258,6 +270,24 @@ global's version beside the version the root manifest declared, silenceable with
 **No repo root at all is the one silent branch**, deliberately, so a global-only invocation stays
 quiet. Separating those two is the whole point — collapsing them is what makes a delegation quietly
 wrong.
+
+**The branch that decides the fence is the worktree one, and it is why rule 5's literal carries
+`pnpm exec`.** A fifth branch refuses outright: a copy that belongs to a *different checkout* is not
+a global install, so delegating it would answer from a tree the caller never named
+([#4956](https://github.com/kamp-us/phoenix/issues/4956)). Where the machine's `fabrika` on PATH is
+linked to a source checkout rather than installed from the registry, every agent working in a git
+worktree of that same repo hits exactly that branch — the copy PATH names belongs to the primary
+checkout, the cwd belongs to the worktree, and the run stops at exit `126` before any verb sees it.
+The refusal is right; what is wrong is a documented fence that can only produce it. `pnpm exec`
+resolves through the calling tree's own `node_modules/.bin` from any directory inside it, so the
+delegation's `run-here` branch serves the invocation and the answer describes the tree the caller is
+standing in ([#5679](https://github.com/kamp-us/phoenix/issues/5679)).
+
+One consumer shape degrades, and it is stated rather than hidden: `pnpm exec` needs a `package.json`
+at or above the cwd, so in a repo that is not a Node project at all it refuses with
+`ERR_PNPM_RECURSIVE_EXEC_NO_PACKAGE` where the bare name would have run the global. Such a repo pins
+no version either, so it was already on the "no repo root at all" branch — it types the bare name and
+the delivery above is unchanged for it.
 
 Three environment variables belong to the delivery layer rather than to any verb, and none of them
 locates the binary, so none weakens the rule above: `FABRIKA_DEBUG` prints one stderr line naming

--- a/claude-plugins/fabrika/skills/adr/SKILL.md
+++ b/claude-plugins/fabrika/skills/adr/SKILL.md
@@ -11,7 +11,7 @@ implies, because discovery is the CLAUDE.md contract and there is no index. Exam
 ## 1 — Claim the number
 
 ```bash
-fabrika adr next
+pnpm exec fabrika adr next
 ```
 
 Unions the freshly fetched merged set with the ids open ADR PRs already claim, so a checkout sitting
@@ -29,7 +29,7 @@ and re-run; a repo with no decision directory at all is a setup question for
 ## 2 — Write the decision
 
 ```bash
-fabrika adr new 0240 only-landed-adrs-may-be-cited
+pnpm exec fabrika adr new 0240 only-landed-adrs-may-be-cited
 ```
 
 Scaffolds the frontmatter and section skeleton; the slug is kebab-case, at most 5 words.
@@ -52,7 +52,7 @@ questions** — *"may an open issue exist without a milestone?"* — not as a su
 for a question you cannot phrase. Then rank the uncited live-accepted ADRs your domain touches:
 
 ```bash
-fabrika adr sweep --new 0240
+pnpm exec fabrika adr sweep --new 0240
 ```
 
 None of its three outcomes is a clearance:
@@ -75,7 +75,7 @@ append a dated `- **#NNNN — <what changed> (YYYY-MM-DD).**` line under its `##
 ## 4 — Resolve every reference, then edit the status lines
 
 ```bash
-fabrika adr resolve 0164 0023 0126
+pnpm exec fabrika adr resolve 0164 0023 0126
 ```
 
 Answers against a freshly fetched base ref, printing `live`, `landed`, `in-flight` or `absent` with
@@ -87,7 +87,7 @@ citation to one can pass every gate and still be dead on arrival. **A non-zero e
 never `absent`.** **Use the filename it prints** — a remembered slug is usually the wrong one.
 
 ```bash
-fabrika adr supersede 0126 --by 0240
+pnpm exec fabrika adr supersede 0126 --by 0240
 ```
 
 Where the rest of that ADR still stands, `fabrika adr amend-in-part 0023 --by 0240` instead.
@@ -106,7 +106,7 @@ on **exactly one** outcome; the explicit "none" separates *considered it* from *
 ## 6 — Check, then report
 
 ```bash
-fabrika adr resolve 0240
+pnpm exec fabrika adr resolve 0240
 ```
 
 Your own id, one last time: `absent` means nobody claimed it while you wrote; `in-flight` means

--- a/claude-plugins/fabrika/skills/build-epic/SKILL.md
+++ b/claude-plugins/fabrika/skills/build-epic/SKILL.md
@@ -29,7 +29,7 @@ works in the tree you are in, never its own. Where that tree sits is the operato
 skill's. Then:
 
 ```bash
-fabrika epic open 4300
+pnpm exec fabrika epic open 4300
 ```
 
 Done when it prints the run id: the epic is planned, its slice topology parses, the ledger
@@ -40,7 +40,7 @@ again. Cut the one branch: `fabrika build branch 4300 --slug checkout-totals`.
 ## 2 — Ask, never infer: the tick loop
 
 ```bash
-fabrika epic next 4300
+pnpm exec fabrika epic next 4300
 ```
 
 You do not walk the plan or remember where you are — the run's state lives in the ledger, and
@@ -60,7 +60,7 @@ slice-dispatched --slice C3`.
 When it returns, **read the graph, not the report**:
 
 ```bash
-fabrika epic landed 4300 --slice C3
+pnpm exec fabrika epic landed 4300 --slice C3
 ```
 
 `landed` proves a new commit on this branch since the slice opened — and its refusals are the
@@ -79,7 +79,7 @@ verbatim** (the polarity is the evaluator's, the recording fence is the claim-ho
 the **commit SHA in the local graph** — content-addressed, so any rewrite unbinds it:
 
 ```bash
-fabrika epic verdict 4300 --slice C3 --commit 8c1f2a9d --polarity PASS <<'EOF'
+pnpm exec fabrika epic verdict 4300 --slice C3 --commit 8c1f2a9d --polarity PASS <<'EOF'
 …the evaluator's per-criterion evidence, verbatim…
 EOF
 ```

--- a/claude-plugins/fabrika/skills/build-ui/SKILL.md
+++ b/claude-plugins/fabrika/skills/build-ui/SKILL.md
@@ -33,8 +33,8 @@ confirm, issue, branch, scratch, check, push, pr, note, verdicts, release ([`../
 This skill adds only the `ui` group ([`contract.md`](contract.md)); nothing here re-derives a lane rule.
 
 ```bash
-fabrika build tree --require-clean
-fabrika build pick
+pnpm exec fabrika build tree --require-clean
+pnpm exec fabrika build pick
 ```
 
 Isolation behaves as in `build`: on the `build` verbs, exit 13/14 is stop-and-report (the `ui`
@@ -48,7 +48,7 @@ every later mutation.
 ## 2 — Read the law before you generate anything
 
 ```bash
-fabrika ui manifest
+pnpm exec fabrika ui manifest
 ```
 
 This resolves the **repo's** design surfaces by convention — the design manifest, the typed
@@ -59,7 +59,7 @@ instance, not the definition: whatever repo you run in, its manifest is the law 
 Fail loud, route to the bootstrap, **never improvise a design language**.
 
 ```bash
-fabrika ui law
+pnpm exec fabrika ui law
 ```
 
 The typed registry rows are your generation-time law (row shape: the contract's registry
@@ -81,7 +81,7 @@ Branch (`fabrika build branch <n> --slug <slug>`), then capture the **before** s
 surface you are about to change, while the tree still renders it:
 
 ```bash
-fabrika ui render --out before --surface /pano --surface /pano/yeni
+pnpm exec fabrika ui render --out before --surface /pano --surface /pano/yeni
 ```
 
 You name the surfaces — bare routes; a `:state` suffix is reserved grammar and refused (exit
@@ -99,7 +99,7 @@ over the sanctioned scale, or a hand-rolled color function where a token exists 
 class every real design failure has shipped. Then the inner loop, per iteration:
 
 ```bash
-fabrika ui render --out after --surface /pano
+pnpm exec fabrika ui render --out after --surface /pano
 ```
 
 **Look at the capture and judge composition** — balance, rhythm, alignment, hierarchy, whether
@@ -129,7 +129,7 @@ Push (`fabrika build push`, done only on `PUSH-VERDICT: MOVED`) and open the PR
 classification claims. Then attach what you rendered:
 
 ```bash
-fabrika ui evidence --pr <pr> --before before --after after
+pnpm exec fabrika ui evidence --pr <pr> --before before --after after
 ```
 
 The verb uploads every capture, **verifies each upload landed, and refuses on any failure** — a

--- a/claude-plugins/fabrika/skills/build/SKILL.md
+++ b/claude-plugins/fabrika/skills/build/SKILL.md
@@ -23,7 +23,7 @@ An argument that is a PR number is repair mode — skip to **Repair**.
 ## 1 — Prove the ground, then pick
 
 ```bash
-fabrika build tree --require-clean
+pnpm exec fabrika build tree --require-clean
 ```
 
 Done when it printed this tree's root. Work wherever you were spawned; where that is, is
@@ -33,7 +33,7 @@ Re-prove before every mutation — once you hold a claim, use `fabrika build tre
 lane check arms too.
 
 ```bash
-fabrika build pick
+pnpm exec fabrika build pick
 ```
 
 The pool is `status:triaged` + `ready-for:agent` + unassigned + inside the campaign in exclusive
@@ -47,7 +47,7 @@ Two refusals before claiming: a `type:decision`'s deliverable is a recorded choi
 it executes the whole loop itself. Then gate your choice:
 
 ```bash
-fabrika build eligible 4312
+pnpm exec fabrika build eligible 4312
 ```
 
 Only `eligible` proceeds. `blocked` (`16`) names every open dependency, so one call tells you the
@@ -57,7 +57,7 @@ be read, and it is named on stderr.
 ## 2 — Claim, and keep proving the claim
 
 ```bash
-fabrika build claim 4312
+pnpm exec fabrika build claim 4312
 ```
 
 `won` prints your token; `lost` names the winner — that lane is theirs, back off. Exit
@@ -69,7 +69,7 @@ theirs, not a rationale you compose. Before **every** later mutation addressed t
 number, re-confirm:
 
 ```bash
-fabrika build confirm 4312
+pnpm exec fabrika build confirm 4312
 ```
 
 **The refusal is not overridable by reasoning**: a lost confirm means another lane owns this number
@@ -78,7 +78,7 @@ now, and your next write lands in their lane.
 ## 3 — Read the contract, then the ground it stands on
 
 ```bash
-fabrika build issue 4312
+pnpm exec fabrika build issue 4312
 ```
 
 That is the issue body and its acceptance criteria, off the verb, never off memory. Check any
@@ -91,7 +91,7 @@ something you can point at.
 ## 4 — Branch, build, verify in this tree
 
 ```bash
-fabrika build branch 4312 --slug editor-focus-loss
+pnpm exec fabrika build branch 4312 --slug editor-focus-loss
 ```
 
 Construct. Match the surrounding artifact's idiom; for code: domain logic in domain objects,
@@ -100,7 +100,7 @@ mutation — the cwd resets between shell calls, so the tree you proved is not t
 standing in until you prove it again. Scratch files go only where this prints:
 
 ```bash
-fabrika build scratch 4312 --slug notes
+pnpm exec fabrika build scratch 4312 --slug notes
 ```
 
 Then validate **in this tree, cache bypassed** — a green borrowed from another checkout's cache is
@@ -108,7 +108,7 @@ the false green this verb exists to refuse. Hand it the surface you named in ste
 refuses a surface the diff contradicts.
 
 ```bash
-fabrika build check --surface code
+pnpm exec fabrika build check --surface code
 ```
 
 Loop construct → check until green. `red` rows name the diagnostics; fix them here, in this tree.
@@ -123,7 +123,7 @@ message back off the commit it just made:
 
 ```bash
 git add <your files>
-fabrika build commit <<'EOF'
+pnpm exec fabrika build commit <<'EOF'
 fix(build): one line saying what changed (#<n>)
 EOF
 ```
@@ -138,7 +138,7 @@ in the PR body, not the merge record.
 ## 5 — Push verified, open the PR through the guard
 
 ```bash
-fabrika build push
+pnpm exec fabrika build push
 ```
 
 Done only on `PUSH-VERDICT: MOVED`. `UNKNOWN` is not a success with a caveat — re-run; an
@@ -157,7 +157,7 @@ per row defending a choice nobody attacked. Same no-op test as the prose — del
 absence would change no reviewer behaviour.
 
 ```bash
-fabrika build pr 4312 <<'EOF'
+pnpm exec fabrika build pr 4312 <<'EOF'
 …body…
 EOF
 ```
@@ -166,10 +166,10 @@ The verb is the guard: it refuses leaks, stray closing keywords, a missing Devia
 reads back what landed. Then hand off and release:
 
 ```bash
-fabrika build note 4312 <<'EOF'
+pnpm exec fabrika build note 4312 <<'EOF'
 …what was done, what a reviewer should look at first…
 EOF
-fabrika build release 4312
+pnpm exec fabrika build release 4312
 ```
 
 **Terminal vocabulary** — end on exactly one: `SHIPPED-PR` (PR open, branch pushed);
@@ -188,8 +188,8 @@ the receiver re-fetches from the artifact.
 Claim the PR's number first — repair mutates a shared lane exactly like a build does:
 
 ```bash
-fabrika build claim 4310
-fabrika build verdicts --pr 4310
+pnpm exec fabrika build claim 4310
+pnpm exec fabrika build verdicts --pr 4310
 ```
 
 The fold is the only entry: paginated, current-head, per-gate — polarity visible, round count

--- a/claude-plugins/fabrika/skills/check-epic-plan/SKILL.md
+++ b/claude-plugins/fabrika/skills/check-epic-plan/SKILL.md
@@ -32,7 +32,7 @@ The planner and this gate must not interleave on one epic, so claim it before re
 the claim is `build`'s, reused, not a second lock:
 
 ```bash
-fabrika build claim 4300 --purpose gate
+pnpm exec fabrika build claim 4300 --purpose gate
 ```
 
 `--purpose gate` is not optional here. The audience axis (`ready-for:agent`) asks whether an agent
@@ -52,7 +52,7 @@ is a proven out-of-focus epic. Exit `21` is no longer reachable at this step, be
 is not bound by the audience axis.
 
 ```bash
-fabrika plan read 4300
+pnpm exec fabrika plan read 4300
 ```
 
 This is the **advisory layer's** read — the floor re-fetches on its own so it never grades a
@@ -62,7 +62,7 @@ assignee slot, criteria token, stories and containment.
 ## 2 — Run the floor; do not re-derive it
 
 ```bash
-fabrika plan check 4300
+pnpm exec fabrika plan check 4300
 ```
 
 This is the **whole pass/fail decision** over the closed hard-defect enum in
@@ -82,7 +82,7 @@ defective path is terminal here.** Re-planning is `plan-epic`'s lane; hand back 
 Only on a clean floor:
 
 ```bash
-fabrika plan flip 4300 --digest 4d90e1bb27ac
+pnpm exec fabrika plan flip 4300 --digest 4d90e1bb27ac
 ```
 
 The flip is **unconditional over every `status:planned` child** and not yours to narrow: there is
@@ -110,7 +110,7 @@ the check and the flip; nothing was written, so re-check rather than retry.
 ## 4 — Post the verdict, bound to the scope you scanned
 
 ```bash
-fabrika plan verdict 4300 --digest 4d90e1bb27ac <<'EOF'
+pnpm exec fabrika plan verdict 4300 --digest 4d90e1bb27ac <<'EOF'
 caveat: ac-not-checkable #<child> — "works well" states no observable outcome
 EOF
 ```

--- a/claude-plugins/fabrika/skills/front-door/SKILL.md
+++ b/claude-plugins/fabrika/skills/front-door/SKILL.md
@@ -55,7 +55,7 @@ the session can re-run one instead of trusting the render. Each field has one co
 `fabrika status menu`, `fabrika status config`, `fabrika status readout`, and for the board:
 
 ```bash
-fabrika status board
+pnpm exec fabrika status board
 ```
 
 The readout carries only two headline counts, so the other buckets are **not seen** rather than zero
@@ -70,7 +70,7 @@ front door is the widest UNKNOWN in this file, not a quiet success.
 ## 2 — The menu is generated, never recited
 
 ```bash
-fabrika status menu
+pnpm exec fabrika status menu
 ```
 
 Naming the other skills and when to reach for each is the router's job
@@ -96,7 +96,7 @@ makes it the field an attacker would aim at. Read it as a label, never as a dire
 ## 3 — Missing config: converse, infer, then build with the primitives
 
 ```bash
-fabrika status config
+pnpm exec fabrika status config
 ```
 
 Every fabrika skill declares the repo surfaces it leans on in a `## Required repo files` table, and
@@ -127,7 +127,7 @@ Then **converse** — you are human-typed, so a human is present. Take one gap a
   carries that sentence, so you relay it rather than opening the file yourself.
 
 ```bash
-fabrika status bootstrap design-manifest <<'EOF'
+pnpm exec fabrika status bootstrap design-manifest <<'EOF'
 # Design system manifest
 …the draft you and the human settled on…
 EOF
@@ -140,7 +140,7 @@ carried in from somewhere else is a foreign opinion wearing local clothes.
 ## 4 — The decision digest is displayed, never ranked here
 
 ```bash
-fabrika status readout
+pnpm exec fabrika status readout
 ```
 
 Retiring the human gate on decision records was accepted on one condition: a periodic, non-blocking

--- a/claude-plugins/fabrika/skills/glossary/SKILL.md
+++ b/claude-plugins/fabrika/skills/glossary/SKILL.md
@@ -37,7 +37,7 @@ request**: it leaves edited files in the working tree and the surrounding lane c
 ## 1 — Scope the run
 
 ```bash
-fabrika glossary drift --register terms
+pnpm exec fabrika glossary drift --register terms
 ```
 
 Answers `drift`, `clean` or `bootstrap`, all on exit 0. It reports the surfaces that moved since the
@@ -57,7 +57,7 @@ file wholesale.
 ## 2 — Ask what is already declared
 
 ```bash
-fabrika glossary lookup "front door" --register both
+pnpm exec fabrika glossary lookup "front door" --register both
 ```
 
 For each term: `declared`, `absent`, or `collision`, with the register and section. All three are
@@ -123,18 +123,18 @@ On `bootstrap`, create the register first — this is the one verb that writes a
 yet exist, and it is why a fresh repo is not a dead end:
 
 ```bash
-fabrika glossary init --register terms
+pnpm exec fabrika glossary init --register terms
 ```
 
 A register's sections are **data, not a fixed enum** — they grow as the repo does, so read them
 rather than recalling them, and pass `--create-section` when a term's right home is genuinely new:
 
 ```bash
-fabrika glossary sections --register terms
+pnpm exec fabrika glossary sections --register terms
 ```
 
 ```bash
-fabrika glossary add "front door" --register terms --section "fabrika skill nouns" --definition-file -
+pnpm exec fabrika glossary add "front door" --register terms --section "fabrika skill nouns" --definition-file -
 ```
 
 Reads the definition on stdin, inserts the row in that section's alphabetical place, and re-reads the
@@ -147,7 +147,7 @@ before merge — concurrent lanes derive the same one — so a row citing an unm
 dead link the day it lands. Resolve the citation rather than assuming it:
 
 ```bash
-fabrika adr resolve 0240
+pnpm exec fabrika adr resolve 0240
 ```
 
 Cite only `live` or `landed`. On `in-flight` or `absent`, end on `HELD-UNMERGED-ADR` and say which
@@ -156,7 +156,7 @@ record.
 ## 5 — Check the register
 
 ```bash
-fabrika glossary check --register both
+pnpm exec fabrika glossary check --register both
 ```
 
 Answers `clean`, `defects` or `bootstrap` on exit 0, enumerating row-shape breaks, duplicate keys,

--- a/claude-plugins/fabrika/skills/governance/SKILL.md
+++ b/claude-plugins/fabrika/skills/governance/SKILL.md
@@ -20,7 +20,7 @@ edits.**
 ## 1 — Derive the requirement; you cannot elect it
 
 ```bash
-fabrika governance scope 4321
+pnpm exec fabrika governance scope 4321
 ```
 
 <!-- anchor: DERIVED-NOT-ELECTED --> The requirement is a **total function of the changed-file list
@@ -69,8 +69,8 @@ not read?"* — before you look for a conflict. You cannot sweep for a question 
 **Where the diff adds or edits a decision record**, rank the corpus against it:
 
 ```bash
-fabrika governance sweep 4321 --record 0240 --sha 03135b91
-fabrika adr resolve 0164 0055
+pnpm exec fabrika governance sweep 4321 --record 0240 --sha 03135b91
+pnpm exec fabrika adr resolve 0164 0055
 ```
 
 <!-- anchor: NO-SWEEP-OUTCOME-IS-A-CLEARANCE --> `sweep` returns `shortlist` · `no-overlap` ·
@@ -102,7 +102,7 @@ body names the sweep outcome or records that there was no record to sweep.
 ## 3 — The gate half: does this quietly weaken a guard
 
 ```bash
-fabrika governance guards 4321 --sha 03135b91
+pnpm exec fabrika governance guards 4321 --sha 03135b91
 ```
 
 The question is narrow and catastrophic: does the edit **remove or soften** an invariant? A diff that
@@ -140,7 +140,7 @@ no authorizing decision at all.
 diff edits this skill or its contract, and `base` serves this file's bytes at the merge-base:
 
 ```bash
-fabrika governance base 4321
+pnpm exec fabrika governance base 4321
 ```
 
 <!-- anchor: SELF-COVERING --> **Judge by those, not the head's** — a bytes read that loads no
@@ -154,7 +154,7 @@ you applied are the base revision's and the verdict says so.
 ## 5 — Emit one verdict, bound to what you saw
 
 ```bash
-fabrika governance post 4321 --polarity PASS --sha 03135b91 --clause "no contradiction, no weakening" <<'EOF'
+pnpm exec fabrika governance post 4321 --polarity PASS --sha 03135b91 --clause "no contradiction, no weakening" <<'EOF'
 …the verdict body: the questions swept, the sweep outcome or the no-record note,
 the domain read by hand, the anchored invariants in reach and their disposition…
 EOF
@@ -179,9 +179,9 @@ overwrite it, so consecutive digests neither overlap nor leave a gap. With no pr
 the cadence's start and say which you used.
 
 ```bash
-fabrika governance digest --since 2026-08-02
-fabrika governance sweep --landed 0398
-fabrika governance readout <<'EOF'
+pnpm exec fabrika governance digest --since 2026-08-02
+pnpm exec fabrika governance sweep --landed 0398
+pnpm exec fabrika governance readout <<'EOF'
 row	0398	tension	sits against 0173 on whether a pending required check blocks admission
 EOF
 ```

--- a/claude-plugins/fabrika/skills/graduate/SKILL.md
+++ b/claude-plugins/fabrika/skills/graduate/SKILL.md
@@ -58,8 +58,8 @@ opposite of this skill; reaching for it here would close the trail this skill mu
 ## 1 — Read the trail, and check it has not already graduated
 
 ```bash
-fabrika graduate read 9412
-fabrika graduate trail 9412 > trail.json
+pnpm exec fabrika graduate read 9412
+pnpm exec fabrika graduate trail 9412 > trail.json
 ```
 
 Read first, and **read the `emissions` array, not just `state`.** Each emission names the refs it
@@ -118,7 +118,7 @@ spec you invented a boundary for.
 ## 3 — Check it is not already filed
 
 ```bash
-fabrika report dedup --query "moderation weight earned per account not inherited from kefil"
+pnpm exec fabrika report dedup --query "moderation weight earned per account not inherited from kefil"
 ```
 
 Three outcomes, and only one is about your spec: `candidates` (open each and judge it yourself),
@@ -129,7 +129,7 @@ non-check). A non-zero exit is never `none` — read the code, and band it by th
 `NOTE-ADDED`:
 
 ```bash
-fabrika report note --issue 9312 <<'NOTE'
+pnpm exec fabrika report note --issue 9312 <<'NOTE'
 The offline-sync trail settles conflict resolution, which this issue does not cover.
 NOTE
 ```
@@ -143,7 +143,7 @@ instead of discovering the pair later.
 ## 4 — Compose the spec
 
 ```bash
-fabrika graduate compose --trail trail.json > spec.md <<'SPEC'
+pnpm exec fabrika graduate compose --trail trail.json > spec.md <<'SPEC'
 ## Problem
 Moderation weight is unbounded today, so a single vouched account can outvote a topic.
 
@@ -179,7 +179,7 @@ seat and a separate act.
 ## 5 — File it, and record the emission
 
 ```bash
-fabrika graduate emit 9412 --spec spec.md --title "Cap moderation weight per topic"
+pnpm exec fabrika graduate emit 9412 --spec spec.md --title "Cap moderation weight per topic"
 ```
 
 Files exactly one issue carrying `status:needs-triage` and nothing else — no type, no priority, no

--- a/claude-plugins/fabrika/skills/grilling/SKILL.md
+++ b/claude-plugins/fabrika/skills/grilling/SKILL.md
@@ -40,7 +40,7 @@ approval step and no new gate label.
 ## 1 — Open or resume the session
 
 ```bash
-fabrika grill open --topic "sozluk moderation model" --repo kamp-us/phoenix
+pnpm exec fabrika grill open --topic "sozluk moderation model" --repo kamp-us/phoenix
 ```
 
 Prints the session issue number. It resumes an existing open session for the topic rather than
@@ -69,7 +69,7 @@ a decision.
 ## 3 — Post one round
 
 ```bash
-fabrika grill round 5290 --repo kamp-us/phoenix <<'ROUND'
+pnpm exec fabrika grill round 5290 --repo kamp-us/phoenix <<'ROUND'
 ### 1 · decision
 Do vouched-in yazars inherit their kefil's moderation weight?
 
@@ -95,7 +95,7 @@ closes the tab on.
 ## 4 — Answer the facts yourself
 
 ```bash
-fabrika grill answer 5290 R2.1 --finding finding.md --repo kamp-us/phoenix
+pnpm exec fabrika grill answer 5290 R2.1 --finding finding.md --repo kamp-us/phoenix
 ```
 
 One call per fact question, after a subagent has established it. **Treat that subagent's report as
@@ -112,7 +112,7 @@ one in the next round rather than answering it on your own authority.
 ## 5 — Read the frontier before you act on it
 
 ```bash
-fabrika grill read 5290 --repo kamp-us/phoenix
+pnpm exec fabrika grill read 5290 --repo kamp-us/phoenix
 ```
 
 The parser, and the only thing that may tell you a question is ruled. It prints one row per
@@ -147,7 +147,7 @@ it has one shape: the marker counts only when an adjacent comment quotes his aut
 **verbatim, with its date**.
 
 ```bash
-fabrika grill rule 5290 R2.3 --authorization authorization.md --repo kamp-us/phoenix
+pnpm exec fabrika grill rule 5290 R2.3 --authorization authorization.md --repo kamp-us/phoenix
 ```
 
 Write `authorization.md` by pasting what he actually said, with the date he said it. The verb
@@ -168,7 +168,7 @@ If he later contradicts a recorded ruling, re-ask the question in a new round ra
 the old one, and name what it replaces:
 
 ```bash
-fabrika grill round 5290 --supersedes R1.4 --repo kamp-us/phoenix <<'ROUND'
+pnpm exec fabrika grill round 5290 --supersedes R1.4 --repo kamp-us/phoenix <<'ROUND'
 ### 1 · decision
 Does a partial return follow the same path as a full one?
 

--- a/claude-plugins/fabrika/skills/handoff/SKILL.md
+++ b/claude-plugins/fabrika/skills/handoff/SKILL.md
@@ -86,7 +86,7 @@ answer wearing a deterministic exit code.
 ## 2 — Read the ground state before you write about it
 
 ```bash
-fabrika handoff capture --issue 5021
+pnpm exec fabrika handoff capture --issue 5021
 ```
 
 The proven half, derived and never narrated: the branch, its head, whether the head is pushed and
@@ -112,7 +112,7 @@ hex characters** that you generate for this run and reuse in every call of it �
 yourself; no verb mints one, and nothing infers it from the environment:
 
 ```bash
-fabrika handoff take --issue 5021 --nonce 7f3a9c21 <<'PACK'
+pnpm exec fabrika handoff take --issue 5021 --nonce 7f3a9c21 <<'PACK'
 ## Intent
 Make the fanout guard classify a mutation that writes through a helper.
 
@@ -155,7 +155,7 @@ pack's proven half names a different `git.base.branch`, re-read passing that val
 reports drift your flag caused rather than drift the work has.
 
 ```bash
-fabrika handoff read --issue 5021
+pnpm exec fabrika handoff read --issue 5021
 ```
 
 One call answers both questions a successor has, because asking only the first is the trap: **what
@@ -186,7 +186,7 @@ none, that is itself the most useful thing the pack told you.
 ## 5 — Claim it, so a third session knows you are on it
 
 ```bash
-fabrika handoff claim --issue 5021 --nonce 4b8e2f01
+pnpm exec fabrika handoff claim --issue 5021 --nonce 4b8e2f01
 ```
 
 **A claim says you are doing this pack's work — not merely that you read it.** Claim when you intend

--- a/claude-plugins/fabrika/skills/heal-ci/SKILL.md
+++ b/claude-plugins/fabrika/skills/heal-ci/SKILL.md
@@ -30,7 +30,7 @@ Your mutations are exactly three: one rerun request, one comment, one filed repo
 An argument that is a PR number is single-PR mode. No argument is **Sweep** — skip to that section.
 
 ```bash
-fabrika heal-ci diagnose 4321
+pnpm exec fabrika heal-ci diagnose 4321
 ```
 
 The verb prints one `stall` token and the evidence that proves it. Every token is an answer at
@@ -88,7 +88,7 @@ or decision PR may legitimately carry no issue at all, so a missing row is not a
 ## 3 — The red stalls: classify before you touch anything
 
 ```bash
-fabrika heal-ci logs 4321 | fabrika heal-ci classify
+pnpm exec fabrika heal-ci logs 4321 | pnpm exec fabrika heal-ci classify
 ```
 
 `logs` emits **every** failing gating context and `classify` returns one line per context — a PR is
@@ -111,7 +111,7 @@ and treating one as healable is how a non-failure stalled a mergeable PR.
 ## 4 — The one rerun, and why the verb owns the guard
 
 ```bash
-fabrika heal-ci rerun 4321 --run 9182736450 --sha 03135b91 --signature preview-warmup
+pnpm exec fabrika heal-ci rerun 4321 --run 9182736450 --sha 03135b91 --signature preview-warmup
 ```
 
 A transient gets **exactly one** rerun per head, ever. The verb re-derives that precondition itself
@@ -128,7 +128,7 @@ say why.
 ## 5 — When the red is not in the code, or nothing started
 
 ```bash
-fabrika heal-ci surface 4321
+pnpm exec fabrika heal-ci surface 4321
 ```
 
 Some PRs are red, or unmergeable while reading green, because the **required-check surface is
@@ -165,7 +165,7 @@ PR blocked solely by an open thread lands in another class.
 ## Sweep — the scheduled surface
 
 ```bash
-fabrika heal-ci sweep
+pnpm exec fabrika heal-ci sweep
 ```
 
 Both hour-long strands were found by someone tracing a downstream hold backwards. A lane that only

--- a/claude-plugins/fabrika/skills/operate/SKILL.md
+++ b/claude-plugins/fabrika/skills/operate/SKILL.md
@@ -15,27 +15,28 @@ closed translation table below is the only way a report moves the machine.
 Writes used — lane-ledger appends and comments on the driven issue. No branch, no push, no merge,
 no verdict of your own.
 
-Every lane verb is invoked as a plain literal through the in-tree entrypoint:
+Every lane verb is invoked through the calling tree's own install:
 
 ```bash
-node packages/fabrika-cli/src/bin.ts lane <verb> …
+pnpm exec fabrika lane <verb> …
 ```
 
-**Never the bare `fabrika` binstub** — in a worktree it resolves to another checkout's code
-([#5679](https://github.com/kamp-us/phoenix/issues/5679)), so its answer describes a tree you are
-not standing in. The same rule goes into every spawn prompt you write.
+**Never the bare `fabrika`** — it resolves whichever copy is on PATH, and from a worktree that copy
+belongs to another checkout, so the delegation refuses at exit `126` rather than answer from a tree
+you are not standing in ([#5679](https://github.com/kamp-us/phoenix/issues/5679)). The same rule
+goes into every spawn prompt you write.
 
 ## 1 — Boot or resume
 
 ```bash
-node packages/fabrika-cli/src/bin.ts lane status 5539
+pnpm exec fabrika lane status 5539
 ```
 
 Exit `0` is resume — the lane exists and its fold is the state; go to step 2. Exit `7` (no lane)
 is boot:
 
 ```bash
-node packages/fabrika-cli/src/bin.ts lane emit 5539
+pnpm exec fabrika lane emit 5539
 ```
 
 `lane emit` generates an epic lane — one region per child, phase-sequenced — from the epic body's
@@ -44,7 +45,7 @@ that refusal-first order is what keeps the boot type-blind: no label is read any
 refusal, boot the single-issue lane instead:
 
 ```bash
-node packages/fabrika-cli/src/bin.ts lane open 5539
+pnpm exec fabrika lane open 5539
 ```
 
 `lane open`'s already-exists refusal is tolerated as resume, not treated as an error. Both verbs
@@ -85,8 +86,8 @@ Every spawn, no exceptions:
 - **The prompt points at the spec, never restates it**: it carries the URLs — the issue, the PR,
   the verdict comments, as each exists — and no summary of their content; the shell re-reads its
   own ground through its own verbs.
-- **The prompt instructs `node packages/fabrika-cli/src/bin.ts` for every fabrika verb**, never
-  the bare binstub (#5679 again, now in the spawned tree).
+- **The prompt instructs `pnpm exec fabrika` for every fabrika verb**, never the bare name
+  (#5679 again, now in the spawned tree, which is a worktree by the rule above).
 
 Done when every active task has either a spawn in flight or an event recorded this pass.
 
@@ -95,7 +96,7 @@ Done when every active task has either a spawn in flight or an event recorded th
 Translate each spawn's report into **exactly one** of the machine's events and record it:
 
 ```bash
-node packages/fabrika-cli/src/bin.ts lane transition 5539 DONE
+pnpm exec fabrika lane transition 5539 DONE
 ```
 
 (On a multi-task lane, address the event with `--task <name>`, the name exactly as `lane status`
@@ -153,7 +154,7 @@ and ends `LANE-PARKED` again; the ledger, not your patience, decides when the la
 the transcript**, posted to the driven issue straight off the verbs:
 
 ```bash
-node packages/fabrika-cli/src/bin.ts lane print 5539 | gh issue comment 5539 --body-file -
+pnpm exec fabrika lane print 5539 | gh issue comment 5539 --body-file -
 ```
 
 with `lane history 5539` appended the same way when the event log adds anything `print` does not
@@ -184,6 +185,6 @@ fabrika skill, so one reader parses all of them. No row here dead-ends on a bare
 
 | Must exist | Why this skill needs it | When missing |
 | --- | --- | --- |
-| The lane verb group — `packages/fabrika-cli/src/bin.ts` routing `lane status`/`transition`/`history`/`print` plus `open`/`emit` (#5688) | Every state read and every event write in this skill is one of these verbs; there is no other path to the ledger | **fail-loud** — a verb that cannot be executed leaves the lane state UNKNOWN; the run ends `STOPPED` naming `packages/fabrika-cli/src/bin.ts` and points at front-door. |
+| The lane verb group — `fabrika lane status`/`transition`/`history`/`print` plus `open`/`emit` (#5688), served from `packages/fabrika-cli/` | Every state read and every event write in this skill is one of these verbs; there is no other path to the ledger | **fail-loud** — a verb that cannot be executed leaves the lane state UNKNOWN; the run ends `STOPPED` naming the verb group and points at front-door. |
 | The agent shells — `claude-plugins/fabrika/agents/builder.md`, `reviewer.md`, `shipper.md` | Step 2's routing table spawns exactly these three by their bare noun names | **fail-loud** — a route whose shell does not exist cannot spawn; the run ends `STOPPED` naming the absent shell file, and no event is recorded for a spawn that never started. |
 | `.gitignore` covering `.fabrika/` | The ledger is a disposable machine-local artifact, regenerable from the board — committed, it would smuggle one machine's lane state into every checkout | **degrade** — the verbs still work; state the uncovered `.fabrika/` in the park or transcript comment and file the gap via `/report`. |

--- a/claude-plugins/fabrika/skills/plan-epic/SKILL.md
+++ b/claude-plugins/fabrika/skills/plan-epic/SKILL.md
@@ -44,8 +44,8 @@ A plan is only as good as the ground it was derived from. Claim first — the cl
 `build`'s, reused, not a second lock:
 
 ```bash
-fabrika build claim 4300 --purpose plan
-fabrika build tree --require-clean
+pnpm exec fabrika build claim 4300 --purpose plan
+pnpm exec fabrika build tree --require-clean
 ```
 
 `--purpose plan` is not optional here. The audience axis (`ready-for:agent`) asks whether an agent
@@ -71,7 +71,7 @@ back to `build`: you hold no claim, and `build note` requires one.
 ## 2 — Open the run
 
 ```bash
-fabrika ledger open 4300
+pnpm exec fabrika ledger open 4300
 ```
 
 This proves the ground fresh against `origin/main`, allocates the run directory keyed on the
@@ -97,7 +97,7 @@ syncing and planning again is a fresh run from step 1, not a loop inside this on
 This is your work. Write the plan block and stage it:
 
 ```bash
-fabrika ledger draft 4300 --body-digest 8f2c1a90b4d7 <<'EOF'
+pnpm exec fabrika ledger draft 4300 --body-digest 8f2c1a90b4d7 <<'EOF'
 ## Plan (plan-epic)
 
 ### Summary
@@ -122,7 +122,7 @@ cannot say which story each slice serves is telling you the split is wrong.
 ## 4 — Mint each child, born complete
 
 ```bash
-fabrika ledger child 4300 --title "queue view: fate loader" \
+pnpm exec fabrika ledger child 4300 --title "queue view: fate loader" \
   --type type:feature --priority p1 --ready-for agent --milestone "fabrika campaign" <<'EOF'
 **Stories:** 1, 2
 **TDD:** yes
@@ -165,7 +165,7 @@ parser that harvests every digit run reads `1, 3 (see #<other>)` as claiming a s
 On a `re-plan`, a child the new plan drops is retired rather than left dangling:
 
 ```bash
-fabrika ledger supersede 4300 --child 4288 --reason "folded into the loader slice"
+pnpm exec fabrika ledger supersede 4300 --child 4288 --reason "folded into the loader slice"
 ```
 
 It journals the reason, unlinks, then closes as not-planned — in that order, so a child is never
@@ -174,7 +174,7 @@ closed while still linked. It refuses a child that is not this epic's, and one t
 ## 5 — Declare the topology
 
 ```bash
-fabrika ledger topology 4300 <<'EOF'
+pnpm exec fabrika ledger topology 4300 <<'EOF'
 #<child-a> phase 1
 #<child-b> phase 1
 #<child-c> phase 2 requires #<child-a>
@@ -192,7 +192,7 @@ file plan; you can. Sequence them, or say in `### Task-split rationale` why they
 ## 6 — Write it into the epic
 
 ```bash
-fabrika ledger write 4300 --body-digest 8f2c1a90b4d7
+pnpm exec fabrika ledger write 4300 --body-digest 8f2c1a90b4d7
 ```
 
 The staged plan and topology go into the epic body in one PATCH, re-read and compared byte for
@@ -210,7 +210,7 @@ Release the claim, then hand off — clearing the floor and flipping children is
 `check-epic-plan`'s, and doing it yourself is the two-answers defect:
 
 ```bash
-fabrika build release 4300
+pnpm exec fabrika build release 4300
 ```
 
 If you find something that ought to block a plan, that is a finding about the **floor** — file it

--- a/claude-plugins/fabrika/skills/prototyping/SKILL.md
+++ b/claude-plugins/fabrika/skills/prototyping/SKILL.md
@@ -54,7 +54,7 @@ recognise when you saw it. Two questions is two spikes, because a single artifac
 things is an artifact you will be tempted to keep.
 
 ```bash
-fabrika spike open --question "does better-auth mint a single-use token without a new table?" --kind logic
+pnpm exec fabrika spike open --question "does better-auth mint a single-use token without a new table?" --kind logic
 ```
 
 **The verb mints the nonce and prints it; you never invent one.** It keys this run's workspace, and
@@ -90,7 +90,7 @@ first edit lands in the primary checkout easily enough, so `spike open` recorded
 ## 3 — Run it through the verb, or you have no evidence
 
 ```bash
-fabrika spike run --nonce 7f3a9c21 -- node walkthrough.mjs --case suspended
+pnpm exec fabrika spike run --nonce 7f3a9c21 -- node walkthrough.mjs --case suspended
 ```
 
 **This is the step the skill exists for.** The verb executes the command with the workspace as its
@@ -116,7 +116,7 @@ line of its captured output answers the question.
 ## 4 — Capture the decision, then destroy the artifact
 
 ```bash
-fabrika spike capture 9310 --nonce 7f3a9c21 <<'MD'
+pnpm exec fabrika spike capture 9310 --nonce 7f3a9c21 <<'MD'
 A single-use token needs no new table — the verification record carries it, and the walkthrough
 drove sign-in twice on one token with the second rejected (run 2).
 MD
@@ -130,7 +130,7 @@ the evidence beside the claim rather than a hash standing in for it.
 Then the half a session skips because the question is already answered:
 
 ```bash
-fabrika spike dispose --nonce 7f3a9c21
+pnpm exec fabrika spike dispose --nonce 7f3a9c21
 ```
 
 <!-- anchor: DISPOSAL-IS-CHECKED-NOT-INTENDED --> **This is what makes "throwaway" a property rather

--- a/claude-plugins/fabrika/skills/report/SKILL.md
+++ b/claude-plugins/fabrika/skills/report/SKILL.md
@@ -48,7 +48,7 @@ Report runs go concurrently, so what you just saw may have reached the board min
 creating stays small:
 
 ```bash
-fabrika report dedup --query "http worker aborted request downstream plain timeout reason"
+pnpm exec fabrika report dedup --query "http worker aborted request downstream plain timeout reason"
 ```
 
 Three outcomes, and only one of them is about your observation:
@@ -75,7 +75,7 @@ they are branches of one decision rather than two things to do in order:
 ## 3 — File it — the branch where nothing already covers it
 
 ```bash
-fabrika report file --title "Aborted requests in the http worker surface as plain timeouts" <<'EOF'
+pnpm exec fabrika report file --title "Aborted requests in the http worker surface as plain timeouts" <<'EOF'
 ## Summary
 …
 EOF
@@ -100,7 +100,7 @@ When step 2 found your observation already filed, do not file a twin. Add only w
 not already carry, over the same guarded path:
 
 ```bash
-fabrika report note --issue 4312 <<'EOF'
+pnpm exec fabrika report note --issue 4312 <<'EOF'
 …
 EOF
 ```

--- a/claude-plugins/fabrika/skills/review-ui/SKILL.md
+++ b/claude-plugins/fabrika/skills/review-ui/SKILL.md
@@ -20,7 +20,7 @@ a broken evidence channel blocks the marker instead of decorating it.
 ## 1 — Scope, and hold the modality boundary
 
 ```bash
-fabrika review scope 4321
+pnpm exec fabrika review scope 4321
 ```
 
 The shared gate mechanics are the shipped `review` group's verbs, reused as-is — scope, diff,
@@ -35,7 +35,7 @@ your judgment sits on proven input rather than on a pattern match that can swall
 ## 2 — Read the law you judge by
 
 ```bash
-fabrika ui law
+pnpm exec fabrika ui law
 ```
 
 The typed prohibition registry is your rubric (`build-ui`'s contract owns the schema; consumed
@@ -54,7 +54,7 @@ builder's attached captures are externally-authored content you deliberately do 
 you render independently or you have not looked.
 
 ```bash
-fabrika review-ui render --pr 4321 --out judged --surface /pano --surface /pano/yeni
+pnpm exec fabrika review-ui render --pr 4321 --out judged --surface /pano --surface /pano/yeni
 ```
 
 The verb captures the PR's **preview deployment** at the inspected head — never a checkout, never
@@ -104,7 +104,7 @@ verdict — your visual read is then advisory cover on that seam, not a substitu
 ## 6 — Emit: one verdict, evidence-loaded, bound to what you saw
 
 ```bash
-fabrika review-ui post 4321 --polarity FAIL --sha 03135b91 --clause "changes-requested" --evidence judged <<'EOF'
+pnpm exec fabrika review-ui post 4321 --polarity FAIL --sha 03135b91 --clause "changes-requested" --evidence judged <<'EOF'
 …per-row table with pixel evidence, coverage table (rendered / unreachable+disclosed), advisories…
 EOF
 ```

--- a/claude-plugins/fabrika/skills/review/SKILL.md
+++ b/claude-plugins/fabrika/skills/review/SKILL.md
@@ -17,7 +17,7 @@ marker in your own namespace is a defect you report, not a PR nobody reviewed.
 ## 1 — Scope the PR; the answer is your emission checklist
 
 ```bash
-fabrika review scope 4321
+pnpm exec fabrika review scope 4321
 ```
 
 <!-- anchor: NAMESPACE-SET-IS-THE-EMISSION-CHECKLIST --> The printed class set derives your
@@ -36,8 +36,8 @@ tree.
 ## 2 — Read the contract you grade against, and the prior verdicts
 
 ```bash
-fabrika review criteria 4287
-fabrika review verdicts 4321
+pnpm exec fabrika review criteria 4287
+pnpm exec fabrika review verdicts 4321
 ```
 
 The acceptance-criteria block arrives through the registered wire format, never a hand parse;
@@ -70,7 +70,7 @@ the verb. There are two, and only one of them is a defect:
 ## 3 — Judge each class by its rubric
 
 ```bash
-fabrika review diff 4321 --sha 03135b91
+pnpm exec fabrika review diff 4321 --sha 03135b91
 ```
 
 The diff verb refuses a truncated read rather than serving a prefix as the whole PR, and serves
@@ -87,7 +87,7 @@ green as this PR's. The code class's execution evidence is the structural CI-at-
 incomplete enumerations:
 
 ```bash
-fabrika review ci 4321 --sha 03135b91
+pnpm exec fabrika review ci 4321 --sha 03135b91
 ```
 
 No class checks out the head: content arrives through the verbs as bytes, so the PR's own
@@ -103,7 +103,7 @@ severity tier. In-scope findings append an acceptance criterion under the verb's
 never this one's. Out-of-scope findings go to fabrika's `/report`, non-blocking.
 
 ```bash
-fabrika review append-criterion 4287 --pr 4321 --round 1 <<'EOF'
+pnpm exec fabrika review append-criterion 4287 --pr 4321 --round 1 <<'EOF'
 a regression test covers qty > 1
 EOF
 ```
@@ -115,7 +115,7 @@ routes back to the full path, and the verdict stays conjunctive default-deny.
 ## 5 — Verify the deviations disclosure
 
 ```bash
-fabrika review deviations 4321 --sha 03135b91
+pnpm exec fabrika review deviations 4321 --sha 03135b91
 ```
 
 <!-- anchor: DEV-VOCABULARY --> Match your findings against each entry's **substance**, never its
@@ -136,7 +136,7 @@ undisclosed that this gate could see"* — never "no deviations exist".
 ## 7 — Emit: one comment per namespace, read back, bound to what you saw
 
 ```bash
-fabrika review post 4321 --namespace review-code --polarity PASS --sha 03135b91 --clause "merge-ready" <<'EOF'
+pnpm exec fabrika review post 4321 --namespace review-code --polarity PASS --sha 03135b91 --clause "merge-ready" <<'EOF'
 …the verdict body: per-criterion evidence, findings, deviations table…
 EOF
 ```

--- a/claude-plugins/fabrika/skills/ship/SKILL.md
+++ b/claude-plugins/fabrika/skills/ship/SKILL.md
@@ -20,7 +20,7 @@ disposition; it changes what you report (`merge intent: NOT cleared`).
 ## 1 — Scope
 
 ```bash
-fabrika ship scope 4321
+pnpm exec fabrika ship scope 4321
 ```
 
 Already `merged` is an idempotent success — report it and end. `draft`/`closed` is a refusal.
@@ -38,7 +38,7 @@ An ADR-only PR is `not-control-plane` and owes no approval; its required `govern
 what still gates it (founder ruling, 2026-08-15 on #5531).
 
 ```bash
-fabrika ship cp-approval 4321 --sha 03135b91
+pnpm exec fabrika ship cp-approval 4321 --sha 03135b91
 ```
 
 `discharge` → continue, and pass `--cp` to step 3's gate. `stop` → disarm, post
@@ -55,7 +55,7 @@ repair exactly as an ordinary FAIL; the advisory carrier is a PASS path only.
 ## 3 — The verdict conjunction
 
 ```bash
-fabrika ship gate 4321 --sha 03135b91 --require review-code --require review-skill
+pnpm exec fabrika ship gate 4321 --sha 03135b91 --require review-code --require review-skill
 ```
 
 `--require` is repeated verbatim from `scope`'s printed namespace set — the verb refuses a
@@ -80,7 +80,7 @@ is red too, and routing to the `governance` skill is what clears both.
 ## 4 — CI at the head, and only at the head
 
 ```bash
-fabrika ship checks 4321 --sha 03135b91 --wait
+pnpm exec fabrika ship checks 4321 --sha 03135b91 --wait
 ```
 
 Terminals: `green` → continue. `red` → disarm, note, route the failed run to `heal-ci`, stop.
@@ -94,7 +94,7 @@ stop. `head-moved` → start over at step 1; every answer so far was about a tre
 ## 5 — Run-evidence
 
 ```bash
-fabrika ship evidence 4321 --sha 03135b91
+pnpm exec fabrika ship evidence 4321 --sha 03135b91
 ```
 
 `present` → continue. `pending` → wait or stop; pending is not absent, and a run that completed
@@ -108,7 +108,7 @@ exist: stop without a verdict; **a failed read is never "no bundle"**.
 ## 6 — Unresolved threads: the one judgment
 
 ```bash
-fabrika ship threads 4321
+pnpm exec fabrika ship threads 4321
 ```
 
 The ruleset blocks the enqueue on unresolved threads, and your resolve is the pipeline's only
@@ -124,7 +124,7 @@ unresolved thread:
   answers, a finding a later commit made moot → resolve it, rationale first:
 
 ```bash
-fabrika ship resolve 4321 --thread PRRT_kwDOxx <<'EOF'
+pnpm exec fabrika ship resolve 4321 --thread PRRT_kwDOxx <<'EOF'
 Resolving: the import this flags was removed in the follow-up commit at this head.
 EOF
 ```
@@ -135,8 +135,8 @@ real objection.
 ## 7 — Enqueue, then reconcile honestly
 
 ```bash
-fabrika ship enqueue 4321 --sha 03135b91
-fabrika ship reconcile 4321
+pnpm exec fabrika ship enqueue 4321 --sha 03135b91
+pnpm exec fabrika ship reconcile 4321
 ```
 
 `enqueue` is the only step that arms an intent, and it never passes a merge-method flag — the
@@ -154,7 +154,7 @@ read and disarms nothing), note, and stop.
 ## 8 — Release queue (dark ships only)
 
 ```bash
-fabrika ship release 4321
+pnpm exec fabrika ship release 4321
 ```
 
 `queued` or `n/a` — the label is the whole action. `no-issue` (a dark-ship signal with no

--- a/claude-plugins/fabrika/skills/triage/SKILL.md
+++ b/claude-plugins/fabrika/skills/triage/SKILL.md
@@ -12,7 +12,7 @@ merely well-formed. You have full rewrite authority; **salvage first**.
 ## 1 — Claim it before you mutate it
 
 ```bash
-fabrika triage claim 4312
+pnpm exec fabrika triage claim 4312
 ```
 
 Done when it printed `won` — that means this session holds it; on anything else, move on.
@@ -24,7 +24,7 @@ in your own words. **Check any falsifiable claim it rests on against source befo
 of it** — a summary of a contract is not the contract. A hand-filed issue skipped dedup:
 
 ```bash
-fabrika report dedup --query "sozluk definition editor loses focus after save" --exclude 4312
+pnpm exec fabrika report dedup --query "sozluk definition editor loses focus after save" --exclude 4312
 ```
 
 Read `candidates` yourself — shared vocabulary is not a shared observation; `indeterminate` is a
@@ -60,7 +60,7 @@ question — is there already a ticket that *owns this surface* and should absor
 surface, not on your issue's wording:
 
 ```bash
-fabrika report dedup --query "sozluk definition editor keyboard focus" --exclude 4312
+pnpm exec fabrika report dedup --query "sozluk definition editor keyboard focus" --exclude 4312
 ```
 
 Read the candidates yourself and take the cheapest true route:
@@ -85,7 +85,7 @@ Done when you have taken one of the three routes and the reason is written down.
 Two problems agents could work at different times are a bundle; two facets of one change are not.
 
 ```bash
-fabrika triage split 4312 --title "Editor loses focus after save" <<'EOF'
+pnpm exec fabrika triage split 4312 --title "Editor loses focus after save" <<'EOF'
 …
 EOF
 ```
@@ -103,11 +103,11 @@ approves a pitch**. Take an existing home: **triage never creates a milestone**,
 `wayfinder:backlog` is bounded to genuine fog rather than work you would rather not decide about.
 
 ```bash
-fabrika triage homes
+pnpm exec fabrika triage homes
 ```
 
 ```bash
-fabrika triage enrich 4312 <<'EOF'
+pnpm exec fabrika triage enrich 4312 <<'EOF'
 …
 EOF
 ```
@@ -129,7 +129,7 @@ merit: `p0` for ship-work and fires, `p1` for what you would genuinely pull next
 default** and most of a healthy backlog. A roadmap row confers no band either way.
 
 ```bash
-fabrika triage apply 4312 --type bug --priority p2 --ready-for agent --home 47
+pnpm exec fabrika triage apply 4312 --type bug --priority p2 --ready-for agent --home 47
 ```
 
 A standing lane takes `--lane wayfinder:backlog` (or `axis:pipeline-hardening`) **instead of**
@@ -150,7 +150,7 @@ Done when the verb read back exactly one `type:`, one `p`, `status:triaged`, `re
 ## 8 — The two outcomes that are not "triaged"
 
 ```bash
-fabrika triage provenance 4312
+pnpm exec fabrika triage provenance 4312
 ```
 
 Provenance decides what may be closed, and it has **two agent signals**: the `Filed by an agent`
@@ -162,7 +162,7 @@ author. Footer-absence from anyone else is still human-owned.
   closed**. When in doubt treat it as human: ignoring a person costs more than a cheap agent issue.
 
 ```bash
-fabrika triage park 4312 <<'EOF'
+pnpm exec fabrika triage park 4312 <<'EOF'
 …
 EOF
 ```
@@ -174,7 +174,7 @@ EOF
   issue's content into that one before closing; without it the content is simply lost.
 
 ```bash
-fabrika triage kill 4312 --confirm --duplicate-of 4290 <<'EOF'
+pnpm exec fabrika triage kill 4312 --confirm --duplicate-of 4290 <<'EOF'
 …
 EOF
 ```
@@ -184,7 +184,7 @@ Done when the issue has left the queue by exactly one route.
 ## Sweeping the queue
 
 ```bash
-fabrika triage queue
+pnpm exec fabrika triage queue
 ```
 
 **Only `empty` ends a sweep** — a proven-empty queue and a failed read are different answers. Then

--- a/claude-plugins/fabrika/skills/wayfinding/SKILL.md
+++ b/claude-plugins/fabrika/skills/wayfinding/SKILL.md
@@ -63,7 +63,7 @@ be built, it is a deliverable, and charting it buries buildable work under a map
 Enumerate your open questions and hand them to the verb on stdin, one per line:
 
 ```bash
-printf 'does a suspended account keep its weight?\nwhat clock does weight decay on?\n' | fabrika map open --destination "how moderation weight is earned"
+printf 'does a suspended account keep its weight?\nwhat clock does weight decay on?\n' | pnpm exec fabrika map open --destination "how moderation weight is earned"
 ```
 
 The verb does not classify for you — a verb guessing fog would be a stochastic answer wearing a
@@ -111,7 +111,7 @@ elsewhere and stopped.
 ## 2 — Read the map before you write to it
 
 ```bash
-fabrika map read 9140
+pnpm exec fabrika map read 9140
 ```
 
 The parser, and the only thing that may tell you what the frontier holds. It prints the
@@ -138,7 +138,7 @@ rather than re-reading between each.
 ## 3 — Lay the frontier out as blocking edges
 
 ```bash
-fabrika map ticket 9140 --digest a1b2c3d4e5f6 --kind research --question "does better-auth mint a single-use token without a new table?" --blocks 9143
+pnpm exec fabrika map ticket 9140 --digest a1b2c3d4e5f6 --kind research --question "does better-auth mint a single-use token without a new table?" --blocks 9143
 ```
 
 One call per open question. The verb files the ticket, links it as a native sub-issue, sets the
@@ -163,7 +163,7 @@ The delta that makes charting one session's work rather than one ticket per sess
 per **answerable** ticket now, instead of leaving each to a later run.
 
 ```bash
-fabrika map lane 9140 --ticket 9143 --nonce 7f3a9c21
+pnpm exec fabrika map lane 9140 --ticket 9143 --nonce 7f3a9c21
 ```
 
 **A `decision` ticket cannot be laned.** `map lane` and `map finding` refuse one, naming `map fork`
@@ -182,7 +182,7 @@ human-readable label like `run-1` is refused rather than quietly shared with the
 Each lane closes with an outcome from a closed set:
 
 ```bash
-fabrika map finding 9140 --ticket 9143 --nonce 7f3a9c21 --outcome no-evidence
+pnpm exec fabrika map finding 9140 --ticket 9143 --nonce 7f3a9c21 --outcome no-evidence
 ```
 
 <!-- anchor: NOTHING-IS-NOT-EMPTY --> **Three answers an absence would collapse into one.**
@@ -214,7 +214,7 @@ primitive, which owns question rounds, recommended answers, and the four-clause 
 needs. Do not reimplement any of that here, and never write an answer onto the map in his voice.
 
 ```bash
-fabrika map fork 9140 --digest a1b2c3d4e5f6 --ticket 9144 --session 9301
+pnpm exec fabrika map fork 9140 --digest a1b2c3d4e5f6 --ticket 9144 --session 9301
 ```
 
 **An empirical question is a spike's.** When the only thing that settles a question is *running
@@ -223,7 +223,7 @@ something* — not a conversation, not a subagent reading source — the model f
 that code itself, and the spike stays disposable.
 
 ```bash
-fabrika map fork 9140 --digest a1b2c3d4e5f6 --ticket 9147 --spike 9310
+pnpm exec fabrika map fork 9140 --digest a1b2c3d4e5f6 --ticket 9147 --spike 9310
 ```
 
 The ticket's kind decides which flag is admitted, so a mis-sorted question is refused rather than
@@ -245,7 +245,7 @@ map, or the run ends naming what he owes.
 ## 6 — Summarize a cleared ticket back to the map
 
 ```bash
-fabrika map record 9140 --digest a1b2c3d4e5f6 --ticket 9143 --finding finding.md
+pnpm exec fabrika map record 9140 --digest a1b2c3d4e5f6 --ticket 9143 --finding finding.md
 ```
 
 One verb moves the whole lockstep: the answer lands under the decisions section and the ticket's row
@@ -262,7 +262,7 @@ the sibling established; you never restate it in your own voice.
 ## 7 — Record what was decided against
 
 ```bash
-fabrika map descope 9140 --digest a1b2c3d4e5f6 --direction "a per-topic weight multiplier" --reason reason.md
+pnpm exec fabrika map descope 9140 --digest a1b2c3d4e5f6 --direction "a per-topic weight multiplier" --reason reason.md
 ```
 
 The out-of-scope section is **append-only and never graduates**. Every other section empties as the

--- a/claude-plugins/fabrika/skills/write-pattern/SKILL.md
+++ b/claude-plugins/fabrika/skills/write-pattern/SKILL.md
@@ -81,7 +81,7 @@ is the correct outcome, not a failure to deliver.
 ## 3 — Read the library before you add to it
 
 ```bash
-fabrika pattern corpus
+pnpm exec fabrika pattern corpus
 ```
 
 One line per doc: its slug, whether `.patterns/index.md` carries a table row for it, which section
@@ -104,8 +104,8 @@ Skip to step 5 for a genuinely new doc. For an existing one, two independent thi
 only one of them is visible in git.
 
 ```bash
-fabrika pattern drift worker-queue-retry
-fabrika pattern anchor worker-queue-retry
+pnpm exec fabrika pattern drift worker-queue-retry
+pnpm exec fabrika pattern anchor worker-queue-retry
 ```
 
 `drift` answers whether the **in-repo source the doc itself cites** moved since the doc was last
@@ -142,7 +142,7 @@ in-repo path. Do not treat one as a stale pointer.
 **For a new doc only:**
 
 ```bash
-fabrika pattern new worker-queue-retry
+pnpm exec fabrika pattern new worker-queue-retry
 ```
 
 Scaffolds the file and nothing else; it never touches the index and never overwrites. **A
@@ -170,7 +170,7 @@ between them, so they cannot drift apart.
 ## 6 — Register it, or nobody finds it
 
 ```bash
-fabrika pattern register worker-queue-retry --section "Index — services" --topic "Retry and backoff on the worker queue" --read-when "Adding a queue consumer, or changing a retry policy"
+pnpm exec fabrika pattern register worker-queue-retry --section "Index — services" --topic "Retry and backoff on the worker queue" --read-when "Adding a queue consumer, or changing a retry policy"
 ```
 
 The section name above is sample data — pass one this repo's index actually carries. The row goes

--- a/packages/pipeline-cli/src/tools/cli-invocation-guard/cli-invocation-guard.ts
+++ b/packages/pipeline-cli/src/tools/cli-invocation-guard/cli-invocation-guard.ts
@@ -2,14 +2,24 @@
  * `cli-invocation-guard` core — the pure, IO-free matcher behind
  * `pipeline-cli cli-invocation-guard check <file>…` (#3314).
  *
- * Two non-canonical forms are banned, for the same reason: neither's failure is
- * distinguishable from a verb result at the call site. A bare `pipeline-cli <verb>` is not on
- * PATH where pipeline agents spawn and never will be (ADR 0207 retired PATH-shadowing), so it
- * dies `command not found`; a cwd-relative `node …/pipeline-cli/src/bin.ts <verb>` resolves
- * only from the repo root, so it dies `Cannot find module` anywhere else. Both land at a gate
- * step, inside a fail-closed wrapper that converts the miss into a wrong verdict. The canonical
- * resolution and its exit-code taxonomy live once in the formats contract's §CLI; this core is
- * the mechanical enforcement of its bans (#3314, #4236).
+ * Two CLIs live in the plugin corpus and each has ONE canonical resolution; every other form is
+ * banned for the same reason, that its failure is not distinguishable from a verb result at the
+ * call site. The canonical forms and their exit-code taxonomies live once per CLI — the formats
+ * contract's §CLI for `pipeline-cli`, rule 5 of `claude-plugins/fabrika/docs/cli-interface-convention.md`
+ * for `fabrika` — and this core is the mechanical enforcement of their bans (#3314, #4236, #5679).
+ *
+ * The two CLIs resolve by opposite mechanisms, so their bans are not symmetric and must not be
+ * collapsed. `pipeline-cli` is never on PATH (ADR 0207 retired PATH-shadowing), so its bare name
+ * dies `command not found` and the canonical form is the shim resolved by path. `fabrika` IS on
+ * PATH, but a bare call resolves the copy PATH points at, which in a git worktree belongs to
+ * another checkout — the delegation refuses that outright at exit `126` rather than answer from a
+ * tree the caller is not standing in, so every fence in a worktree dies on step one (#5679). Its
+ * canonical form is `pnpm exec fabrika`, which resolves through the calling tree's own
+ * `node_modules/.bin` from any directory inside it.
+ *
+ * The `node …/src/bin.ts` entrypoint is banned for BOTH: it resolves only from the repo root, so
+ * from a nested app dir — the dir sessions launch in — it dies `Cannot find module` with exit 1
+ * and empty stdout.
  *
  * Scoped to what an agent actually RUNS: a `bash`/`sh` fenced block, minus comment-only
  * lines. Prose that merely names a verb ("the `pipeline-cli claim is-mine` verb") is not an
@@ -31,12 +41,17 @@ export interface ScanFile {
 	readonly content: string;
 }
 
+/** The CLIs this guard knows a canonical resolution for. */
+export type Cli = "pipeline-cli" | "fabrika";
+
 export interface Finding {
 	readonly file: string;
 	/** 1-based line number of the offending line. */
 	readonly line: number;
 	/** The offending line, trimmed — enough to locate it without opening the file. */
 	readonly text: string;
+	/** Which CLI's rule this line broke — the two have different canonical forms and remedies. */
+	readonly cli: Cli;
 }
 
 export interface GuardResult {
@@ -65,10 +80,23 @@ const unquote = (line: string): string => line.replace(/^(\s*>)+\s?/, "");
  * lookbehind-free form is a negated character class on the preceding char, so `bin/pipeline-cli`,
  * `packages/pipeline-cli`, `@kampus/pipeline-cli` and `-pipeline-cli` all fall through.
  */
-const BARE_INVOCATION = /(^|[^\w./@-])pipeline-cli(\s|$)/;
+const BARE_PIPELINE_CLI = /(^|[^\w./@-])pipeline-cli(\s|$)/;
 
 /**
- * The second non-canonical form: running the CLI's entrypoint directly through `node` at a
+ * A bare `fabrika`, matched only in **command position** — line start, or after a `|`, `;`, `&`,
+ * `(`, `!` or `$(`, with any number of `VAR=value` assignments in between.
+ *
+ * The tighter anchor is not a stylistic difference from the rule above; it is forced by the token.
+ * `fabrika` is also a plugin directory, a label, a marketplace entry and a brand noun, so the
+ * `pipeline-cli` rule's "any non-word char before it" would red `gh issue edit 1 --add-label
+ * fabrika` and every other argument-position mention in a runnable fence. Command position is what
+ * separates a call from a word. It also lets the canonical `pnpm exec fabrika` through with no
+ * carve-out: there, `fabrika` is an argument to `exec`, not a command.
+ */
+const BARE_FABRIKA = /(?:^|[|;&(!]|\$\()\s*(?:[A-Za-z_]\w*=\S*\s+)*fabrika(?=\s|$)/;
+
+/**
+ * The form banned for both CLIs: running an entrypoint directly through `node` at a
  * **cwd-relative** path. It resolves only from the repo root and only in this repo, so from a
  * nested app dir — the dir sessions launch in — it dies `Cannot find module` with **exit 1 and
  * empty stdout**. That is byte-identical to the clean answer several call sites consume
@@ -76,7 +104,23 @@ const BARE_INVOCATION = /(^|[^\w./@-])pipeline-cli(\s|$)/;
  * stdout = "nothing found"), so a resolution failure launders into a permissive verdict —
  * a fail-open on a gate, not a style nit (#4236). §CLI's exit-code taxonomy covers it.
  */
-const NODE_ENTRYPOINT_INVOCATION = /\bnode\s+\S*pipeline-cli\/src\/bin\.ts(\s|$)/;
+const nodeEntrypoint = (pkg: string): RegExp =>
+	new RegExp(String.raw`\bnode\s+\S*${pkg}\/src\/bin\.ts(\s|$)`);
+
+const PIPELINE_CLI_ENTRYPOINT = nodeEntrypoint("pipeline-cli");
+const FABRIKA_ENTRYPOINT = nodeEntrypoint("fabrika-cli");
+
+/**
+ * Which CLI's rule this line breaks, or `null` for a line that invokes neither non-canonically.
+ *
+ * `pipeline-cli` is tested first so a line that somehow offends both is reported once, under the
+ * CLI whose remedy is the more specific.
+ */
+const offendingCli = (line: string): Cli | null => {
+	if (BARE_PIPELINE_CLI.test(line) || PIPELINE_CLI_ENTRYPOINT.test(line)) return "pipeline-cli";
+	if (BARE_FABRIKA.test(line) || FABRIKA_ENTRYPOINT.test(line)) return "fabrika";
+	return null;
+};
 
 /** A line that is only a shell comment carries no invocation to run. */
 const COMMENT_ONLY = /^\s*#/;
@@ -120,8 +164,9 @@ export const scanFile = (
 		}
 		if (openLang === null || !RUNNABLE_LANGS.has(openLang)) continue;
 		if (COMMENT_ONLY.test(lineText)) continue;
-		if (!BARE_INVOCATION.test(lineText) && !NODE_ENTRYPOINT_INVOCATION.test(lineText)) continue;
-		findings.push({file, line: i + 1, text: lineText.trim()});
+		const cli = offendingCli(lineText);
+		if (cli === null) continue;
+		findings.push({file, line: i + 1, text: lineText.trim(), cli});
 	}
 	return {findings, fences};
 };
@@ -203,10 +248,17 @@ export const attribute = (
  */
 export const isUsableBaseline = (baseline: GuardResult): boolean => !isZeroScope(baseline);
 
+const isCli = (value: unknown): value is Cli => value === "pipeline-cli" || value === "fabrika";
+
 const isFinding = (value: unknown): value is Finding => {
 	if (typeof value !== "object" || value === null) return false;
 	const f = value as Record<string, unknown>;
-	return typeof f.file === "string" && typeof f.line === "number" && typeof f.text === "string";
+	return (
+		typeof f.file === "string" &&
+		typeof f.line === "number" &&
+		typeof f.text === "string" &&
+		isCli(f.cli)
+	);
 };
 
 /**
@@ -217,6 +269,9 @@ const isFinding = (value: unknown): value is Finding => {
  * `isZeroScope`'s `=== 0` test does not catch that — so a zero-shell-scope baseline would sail
  * through as usable. Only reachable under version skew between the base-side `baseline` and the
  * head-side `check`, but "no pre-existing violations" is the wrong direction to be wrong in.
+ * Each finding's `cli` is asserted the same way and for the same reason: a manifest predating the
+ * two-CLI split (#5679) is a baseline this build cannot attribute against, and refusing it reds
+ * rather than silently treating every fabrika violation as newly introduced.
  */
 export const parseBaseline = (raw: string): GuardResult | null => {
 	let parsed: unknown;

--- a/packages/pipeline-cli/src/tools/cli-invocation-guard/cli-invocation-guard.unit.test.ts
+++ b/packages/pipeline-cli/src/tools/cli-invocation-guard/cli-invocation-guard.unit.test.ts
@@ -249,6 +249,86 @@ describe("cli-invocation-guard core", () => {
 	});
 });
 
+// #5679: `fabrika` IS on PATH, so a bare call resolves whichever copy PATH names. In a worktree
+// that copy belongs to another checkout, and the delegation refuses it at exit 126 rather than
+// answer from a tree the caller is not standing in — so every bare fence dies on step one.
+describe("the fabrika surface — a bare `fabrika` is not the canonical form (#5679)", () => {
+	it("flags a bare `fabrika` at the start of a runnable line", () => {
+		const {findings} = scanFile("s.md", fence("bash", "fabrika build tree --require-clean"));
+		assert.strictEqual(findings.length, 1);
+		assert.strictEqual(findings[0]?.line, 2);
+		assert.strictEqual(findings[0]?.cli, "fabrika");
+	});
+
+	it("flags a bare `fabrika` in a pipe, a substitution, a conditional and an env prefix", () => {
+		const {findings} = scanFile(
+			"s.md",
+			fence(
+				"bash",
+				"fabrika build print 5679 | gh issue comment 5679 --body-file -",
+				'STATE="$(fabrika build confirm 5679)"',
+				"if ! fabrika build claim 5679; then exit 0; fi",
+				"FABRIKA_DEBUG=1 fabrika build tree",
+			),
+		);
+		assert.strictEqual(findings.length, 4);
+		assert.deepStrictEqual(new Set(findings.map((f) => f.cli)), new Set(["fabrika"]));
+	});
+
+	it("accepts the canonical `pnpm exec fabrika` form", () => {
+		const {findings} = scanFile(
+			"s.md",
+			fence(
+				"bash",
+				"pnpm exec fabrika build tree --require-clean",
+				'STATE="$(pnpm exec fabrika build confirm 5679)"',
+			),
+		);
+		assert.deepStrictEqual(findings, []);
+	});
+
+	// The reason this rule anchors on command position while the `pipeline-cli` rule does not:
+	// `fabrika` is also a label, a directory, a marketplace entry and a plugin namespace, and all
+	// four appear as ARGUMENTS in runnable fences. Flagging those would make the guard unusable.
+	it("does not flag `fabrika` in argument position — a label, a path, a namespace", () => {
+		const {findings} = scanFile(
+			"s.md",
+			fence(
+				"bash",
+				"gh issue edit 5679 --add-label fabrika",
+				"ls claude-plugins/fabrika/skills/",
+				"cat .fabrika/lanes/5679/events.jsonl",
+				'gh pr list --search "fabrika in:title"',
+			),
+		);
+		assert.deepStrictEqual(findings, []);
+	});
+
+	it("flags the cwd-relative `node …/fabrika-cli/src/bin.ts` entrypoint form", () => {
+		const {findings} = scanFile(
+			"s.md",
+			fence("bash", "node packages/fabrika-cli/src/bin.ts lane status 5539"),
+		);
+		assert.strictEqual(findings.length, 1);
+		assert.strictEqual(findings[0]?.cli, "fabrika");
+	});
+
+	it("ignores a named verb in prose and a commented-out call", () => {
+		const {findings} = scanFile(
+			"s.md",
+			"Run `fabrika build pick` to take the next issue.\n" +
+				fence("bash", "# was: fabrika build claim 5679", "true"),
+		);
+		assert.deepStrictEqual(findings, []);
+	});
+
+	it("flags a bare `fabrika` in a `.sh` file, which is one implicit fence", () => {
+		const {findings} = scanFile("skills/build/scripts/claim.sh", "fabrika build claim 5679\n");
+		assert.strictEqual(findings.length, 1);
+		assert.strictEqual(findings[0]?.cli, "fabrika");
+	});
+});
+
 describe("cli-invocation-guard attribution (#4250)", () => {
 	const OFFENDER = "pipeline-cli claim status --issue 1";
 
@@ -372,6 +452,16 @@ describe("cli-invocation-guard attribution (#4250)", () => {
 			assert.isNull(parseBaseline(JSON.stringify({...wellFormed, findings: undefined})));
 			assert.isNull(parseBaseline(JSON.stringify({...wellFormed, scanned: [1]})));
 			assert.isNull(parseBaseline(JSON.stringify({...wellFormed, fenceCount: "1"})));
+		});
+
+		it("rejects a finding with no `cli` — a manifest predating the two-CLI split (#5679)", () => {
+			const legacy = {...wellFormed, findings: [{file: "a.md", line: 2, text: "pipeline-cli x"}]};
+			assert.isNull(parseBaseline(JSON.stringify(legacy)));
+			const current = {
+				...wellFormed,
+				findings: [{file: "a.md", line: 2, text: "pipeline-cli x", cli: "pipeline-cli" as const}],
+			};
+			assert.deepStrictEqual(parseBaseline(JSON.stringify(current)), current);
 		});
 	});
 });

--- a/packages/pipeline-cli/src/tools/cli-invocation-guard/command.ts
+++ b/packages/pipeline-cli/src/tools/cli-invocation-guard/command.ts
@@ -1,12 +1,12 @@
 /**
  * The `cli-invocation-guard` tool — `pipeline-cli cli-invocation-guard check|baseline <file>…`.
  *
- * Reds on any non-canonical `pipeline-cli` invocation inside runnable shell in the pipeline
- * corpus — a bare `pipeline-cli <verb>` (#3314) or a cwd-relative
- * `node …/pipeline-cli/src/bin.ts <verb>` (#4236) — across **both** corpus surfaces: a runnable
- * fence in a `.md`, and a `.sh` file scanned whole as one implicit fence (#4486). See the formats
- * contract's §CLI for the canonical resolution this enforces and the exit-code taxonomy it
- * protects. Follows the `adoption-lint` / `gh-phoenix lint-skills` shape — an IO-free core over
+ * Reds on any non-canonical invocation of either plugin CLI inside runnable shell in the plugin
+ * corpus — a bare `pipeline-cli <verb>` (#3314), a bare `fabrika <verb>` (#5679), or a cwd-relative
+ * `node …/src/bin.ts <verb>` of either (#4236) — across **both** corpus surfaces: a runnable
+ * fence in a `.md`, and a `.sh` file scanned whole as one implicit fence (#4486). Each CLI's
+ * canonical resolution is documented in its own home, and the remedy printed below names it.
+ * Follows the `adoption-lint` / `gh-phoenix lint-skills` shape — an IO-free core over
  * handed-in file contents, with a thin CLI that maps the verdict to a fail-closed exit contract
  * (ADR 0092):
  *
@@ -27,6 +27,7 @@ import {Argument, Command, Flag} from "effect/unstable/cli";
 import {
 	type AttributedFinding,
 	attribute,
+	type Cli,
 	type GuardResult,
 	isUsableBaseline,
 	isZeroScope,
@@ -38,9 +39,17 @@ import {
 const FINDING_EXIT_CODE = 2;
 const ZERO_SCOPE_EXIT_CODE = 3;
 
-const FIX_ATTRIBUTABLE =
-	// biome-ignore lint/suspicious/noTemplateCurlyInString: shell parameter expansion in the remediation literal a reader pastes, not a JS template
-	'  FIX (NEW — yours to edit): resolve the shim once per fence — PCLI="${CLAUDE_PLUGIN_ROOT:-$(git rev-parse --show-toplevel)/claude-plugins/kampus-pipeline}/bin/pipeline-cli" — then call "$PCLI" <verb>. See §CLI in claude-plugins/kampus-pipeline/skills/gh-issue-intake-formats.md.';
+/**
+ * One remedy per CLI, because the two resolve by opposite mechanisms and a shared line would send
+ * half the readers to the wrong fix (#5679).
+ */
+const FIX_ATTRIBUTABLE: Record<Cli, string> = {
+	"pipeline-cli":
+		// biome-ignore lint/suspicious/noTemplateCurlyInString: shell parameter expansion in the remediation literal a reader pastes, not a JS template
+		'  FIX (NEW — yours to edit, `pipeline-cli`): resolve the shim once per fence — PCLI="${CLAUDE_PLUGIN_ROOT:-$(git rev-parse --show-toplevel)/claude-plugins/kampus-pipeline}/bin/pipeline-cli" — then call "$PCLI" <verb>. See §CLI in claude-plugins/kampus-pipeline/skills/gh-issue-intake-formats.md.',
+	fabrika:
+		"  FIX (NEW — yours to edit, `fabrika`): write `pnpm exec fabrika <group> <verb> …`. It resolves through the calling tree's own node_modules/.bin from any directory inside it; the bare name resolves whatever copy PATH points at, which in a worktree is another checkout and refuses at exit 126. See rule 5 in claude-plugins/fabrika/docs/cli-interface-convention.md.",
+};
 
 const FIX_PRE_EXISTING =
 	"  FIX (PRE-EXISTING — not yours to edit): the offender was already at the merge-base. The remedy is a REBASE onto a `main` where it is fixed, not an edit — editing it here puts an unrelated change in your diff (#4250).";
@@ -59,7 +68,7 @@ const readFileOrSkip = (file: string): string | null =>
 const fileArg = Argument.string("file").pipe(
 	Argument.atLeast(1),
 	Argument.withDescription(
-		"one or more corpus file paths (SKILL.md / agent defs / plugin docs / extracted `scripts/*.sh`) to scan for non-canonical `pipeline-cli` invocations",
+		"one or more corpus file paths (SKILL.md / agent defs / plugin docs / extracted `scripts/*.sh`) to scan for non-canonical `pipeline-cli` or `fabrika` invocations",
 	),
 );
 
@@ -111,7 +120,7 @@ const loadBaseline = (
 
 const reportFinding = (f: AttributedFinding): Effect.Effect<void> =>
 	Console.error(
-		`  [${f.attribution === "new" ? "NEW — introduced by this change" : "PRE-EXISTING at the merge-base"}] ${f.file}:${f.line}: ${f.text}`,
+		`  [${f.attribution === "new" ? "NEW — introduced by this change" : "PRE-EXISTING at the merge-base"}] [${f.cli}] ${f.file}:${f.line}: ${f.text}`,
 	);
 
 const guardZeroScope = (result: GuardResult): Effect.Effect<void, ZeroScope> =>
@@ -146,8 +155,8 @@ const judge = (
 		if (attributable.length === 0) {
 			yield* Console.log(
 				preExisting.length === 0
-					? "cli-invocation-guard: clean — every `pipeline-cli` call in runnable shell (fenced or `.sh`) resolves the shim by path (§CLI)."
-					: `cli-invocation-guard: clean — this change introduces no non-canonical \`pipeline-cli\` invocation. ${preExisting.length} violation(s) are PRE-EXISTING at the merge-base and are NOT this change's to fix:`,
+					? "cli-invocation-guard: clean — every `pipeline-cli` and `fabrika` call in runnable shell (fenced or `.sh`) uses that CLI's canonical resolution."
+					: `cli-invocation-guard: clean — this change introduces no non-canonical invocation. ${preExisting.length} violation(s) are PRE-EXISTING at the merge-base and are NOT this change's to fix:`,
 			);
 			for (const f of preExisting) yield* reportFinding(f);
 			if (preExisting.length > 0) yield* Console.log(FIX_PRE_EXISTING);
@@ -155,10 +164,12 @@ const judge = (
 		}
 
 		yield* Console.error(
-			`cli-invocation-guard: FAIL — ${attributable.length} non-canonical \`pipeline-cli\` invocation(s) in runnable shell attributable to this change${preExisting.length > 0 ? ` (plus ${preExisting.length} pre-existing at the merge-base, listed but not counted against you)` : ""}. A bare name is NOT on PATH where agents spawn (ADR 0207 retired PATH-shadowing) and dies \`command not found\` (exit 127); a cwd-relative \`node …/src/bin.ts\` dies \`Cannot find module\` (exit 1, empty stdout) from any dir but the repo root. Either way a fail-closed wrapper turns the miss into a wrong verdict (#3314, #4236):`,
+			`cli-invocation-guard: FAIL — ${attributable.length} non-canonical invocation(s) in runnable shell attributable to this change${preExisting.length > 0 ? ` (plus ${preExisting.length} pre-existing at the merge-base, listed but not counted against you)` : ""}. A bare \`pipeline-cli\` is NOT on PATH where agents spawn (ADR 0207 retired PATH-shadowing) and dies \`command not found\` (exit 127); a bare \`fabrika\` IS on PATH but resolves whichever copy PATH names, and from a worktree that is another checkout, refused at exit 126 (#5679); a cwd-relative \`node …/src/bin.ts\` dies \`Cannot find module\` (exit 1, empty stdout) from any dir but the repo root. Each way a fail-closed wrapper turns the miss into a wrong verdict (#3314, #4236, #5679):`,
 		);
 		for (const f of attributed) yield* reportFinding(f);
-		yield* Console.error(FIX_ATTRIBUTABLE);
+		for (const cli of new Set(attributable.map((f) => f.cli))) {
+			yield* Console.error(FIX_ATTRIBUTABLE[cli]);
+		}
 		if (preExisting.length > 0) yield* Console.error(FIX_PRE_EXISTING);
 		return yield* Effect.fail(new FindingsFound({count: attributable.length}));
 	});
@@ -197,7 +208,7 @@ const check = Command.make(
 	}),
 ).pipe(
 	Command.withDescription(
-		"Red on any bare or `node …/src/bin.ts` `pipeline-cli` invocation in runnable shell — a bash/sh fence or a whole `.sh` file (fails closed on zero scope, per surface; --baseline narrows the verdict to newly-introduced ones)",
+		"Red on any non-canonical `pipeline-cli` or `fabrika` invocation in runnable shell — a bash/sh fence or a whole `.sh` file (fails closed on zero scope, per surface; --baseline narrows the verdict to newly-introduced ones)",
 	),
 );
 
@@ -226,6 +237,6 @@ const baseline = Command.make(
 export const cliInvocationGuardCommand = Command.make("cli-invocation-guard").pipe(
 	Command.withSubcommands([check, baseline]),
 	Command.withDescription(
-		"Enforce §CLI: every `pipeline-cli` call in the corpus resolves the shim by path, never bare on PATH (#3314)",
+		"Enforce each plugin CLI's canonical resolution in the corpus: `pipeline-cli` by shim path (#3314), `fabrika` through `pnpm exec` (#5679)",
 	),
 );


### PR DESCRIPTION
Every runnable fence in the fabrika skill corpus wrote a bare `fabrika <verb>`. In a git worktree that command does not run: the copy on PATH belongs to another checkout, and the delegation refuses it outright rather than answer from a tree the caller is not standing in. Since fabrika builders always work in worktrees, every skill died on its first fence.

This moves the corpus, and rule 5 that governs it, to `pnpm exec fabrika <verb>` — which resolves through the calling tree's own `node_modules/.bin` from any directory inside it — and teaches `cli-invocation-guard` to red a bare `fabrika` so the convention cannot drift back.

## What changed

- **149 fence lines across 22 `SKILL.md` files** now read `pnpm exec fabrika …`. Prose that merely names a verb is untouched; the rewrite edited exactly the lines the guard flags, so there is no second fence parser to drift from it.
- **`claude-plugins/fabrika/docs/cli-interface-convention.md`** — rule 5's literal is now `pnpm exec fabrika`, and the Delivery section gains the worktree branch plus the one shape that degrades. This is the one home for the fact; leaving it would make the corpus contradict its own convention.
- **`cli-invocation-guard`** covers both CLIs. A `Finding` names which CLI's rule it broke, and each gets its own remedy line — the two resolve by opposite mechanisms and a shared remedy would send half the readers to the wrong fix.
- **`operate/SKILL.md`** used `node packages/fabrika-cli/src/bin.ts` and cited this issue for it. That form is now banned too, and its rationale is corrected.

## The verification (AC3), run from this worktree

Bare name, from the worktree root — `FABRIKA_DEBUG=1 fabrika build tree`:

```
fabrika: refusing — /…/phoenix/packages/fabrika-cli is in checkout /…/phoenix, the cwd is in /…/phoenix/.claude/worktrees/…
exit 126
```

Canonical form, from the worktree root **and** from `apps/web` — `FABRIKA_DEBUG=1 pnpm exec fabrika --version`:

```
fabrika: running here, at /…/.claude/worktrees/…/packages/fabrika-cli — the repo-local install is this copy
fabrika v0.1.0
```

The `packageRoot` in that trace is this worktree's own `packages/fabrika-cli`, which is the claim AC3 asks for. The banned `node packages/fabrika-cli/src/bin.ts` form was checked the same way: from `apps/web` it dies `Cannot find module` at exit 1.

Guard over the corpus at head: `396 file(s), 435 runnable fence(s), 268 shell file(s)` — clean, exit 0, every zero-scope axis populated (AC5).

## Deviations

**The issue's central claim is false at head, and I built on the corrected version.** The triage note says the bare `fabrika` "silently" runs the primary checkout's code, confirmed by reading the pnpm shim. The shim does exec the primary checkout's `bin.ts` — but that file delegates: `src/delegate/` finds the repo root above the cwd and, since #4956, **refuses** when the invoked copy belongs to a different checkout (exit 126, message quoted above). So the failure is loud, not silent, and nothing has ever run against the wrong tree. The fix direction triage forced is unchanged; the reason it matters is different, and both the guard's messages and rule 5 state the true one.

**Two files outside `claude-plugins/fabrika/skills/**`.** AC1 scopes the rewrite to the skills; the convention doc and the guard package are also in this diff, because AC4 requires the guard and because rule 5 is the one home for the literal the skills now write.

**The hook surface keeps the bare literal, and rule 5 now says so explicitly.** `LITERAL_COMMAND` in `packages/fabrika-cli/src/hook/declaration.ts` is `/^fabrika [a-z][a-z-]*(?: [a-z][a-z-]*)+$/`, checked as data by a golden test, so a `hooks.json` command cannot carry the prefix. The harness runs those commands, not an agent in a worktree, and a hook that cannot dispatch fails open by ADR 0250 — so the worktree branch costs a hook its answer, never a session.

**`pnpm exec` degrades in one consumer shape, stated rather than hidden.** It needs a `package.json` at or above the cwd; in a repo that is not a Node project it refuses with `ERR_PNPM_RECURSIVE_EXEC_NO_PACKAGE` where the bare name would have run the global. Verified in a bare temp dir. Such a repo pins no version either, so it was already on the delegation's "no repo root at all" branch — the Delivery section records this.

**Three doc surfaces left stale, filed as #5702.** `packages/fabrika-cli/README.md` (outside the guard's corpus, and the bare name still works for its consumer audience); `docs/hook-surface.md`'s grading records (commit-pinned dated snapshots — editing them would falsify a record); and `skills/report/contract.md`'s obsolete "every fence exits 127" paragraph. The last one I wrote a fix for and reverted: that file's own machine-local-path taxonomy reds `build check --surface prose` the moment the file enters any diff, so correcting one paragraph costs the PR its prose green. #5702 carries that, and the underlying question of whether the prose check needs the merge-base attribution split `cli-invocation-guard` already has.

Fixes #5679
