### PR TITLE
The bare fabrika command in a worktree runs the primary checkout's code

### DIFF
--- a/packages/fabrika-cli/README.md
+++ b/packages/fabrika-cli/README.md
@@ -56,24 +56,35 @@ TypeScript ([#4784](https://github.com/kamp-us/phoenix/issues/4784)).
 | Where you are | What runs | Warning |
 | --- | --- | --- |
 | In phoenix | the working tree — `packages/fabrika-cli` | — |
+| In a **git worktree** of phoenix | that worktree's `packages/fabrika-cli` | — |
 | In a consumer repo that installed it | that repo's pinned version | — |
 | In a consumer repo that did **not** install it | the global | **yes**, naming both versions |
 | In no repo at all | the global | no — deliberately |
-| Running a **different checkout's** copy by path | nothing — it refuses, exit `126` | **yes**, naming both checkouts |
+| Running a copy from a **different repository** by path | nothing — it refuses, exit `126` | **yes**, naming both checkouts |
 
-Rows three and four are the original design. Running the global outside any repo is a normal,
+Rows four and five are the original design. Running the global outside any repo is a normal,
 correct invocation, so it stays quiet. Running the global *inside a repo that asked for a specific
 version* is the quietly-wrong case, so it says so out loud and names the global's version beside the
 one the root manifest declared. Set `FABRIKA_GLOBAL_WARNING_DISABLED=1` to silence it.
 
 The last row closes the one case that used to be quietly wrong ([#4956](https://github.com/kamp-us/phoenix/issues/4956)).
-`node <other-checkout>/packages/fabrika-cli/src/bin.ts` run from a cwd inside *this* checkout looked
-exactly like a global install on `PATH`, so it delegated — and answered from the checkout you did
+`node <other-repo>/packages/fabrika-cli/src/bin.ts` run from a cwd inside *this* repo looked
+exactly like a global install on `PATH`, so it delegated — and answered from a repository you did
 not name, with no warning at all. It is a live hazard for anyone reviewing from a second checkout: the CLI
 reports the state of `main` while you are reading a branch. The two are separated by asking which
-checkout the *invoked copy* belongs to; an installed copy (anything under `node_modules`) belongs to
+repository the *invoked copy* belongs to; an installed copy (anything under `node_modules`) belongs to
 none, which is what keeps the global-install delegation exactly as it was. Either run it from inside
-its own checkout, or pass `--skip-infer` to make the copy you named serve the invocation.
+its own repository, or pass `--skip-infer` to make the copy you named serve the invocation.
+
+Row two is the carve-out that refusal needed ([#5679](https://github.com/kamp-us/phoenix/issues/5679)).
+A `pnpm link --global` install puts a checkout's own copy on `PATH`, so an agent standing in a
+worktree who types the bare `fabrika` invokes the primary checkout's copy — a different checkout, and
+the refusal swallowed it, leaving the bare command unusable from every worktree. `git worktree` gives
+one repository several working trees, so the comparison is the repository, not the checkout: the two
+trees' `$GIT_COMMON_DIR` is read off disk (`.git` directory, else the `.git` file's `gitdir:` and that
+dir's `commondir`, per `gitrepository-layout(5)`) and equal common dirs delegate. A tree whose
+repository cannot be established is treated as a different one, so the refusal is what an unreadable
+answer falls back to.
 
 The property this buys is a **repo-pinned version**. phoenix carries `@kampus/fabrika-cli` in its
 root `devDependencies`, so a bare `fabrika` anywhere in a phoenix checkout runs the version this

--- a/packages/fabrika-cli/src/delegate/entry.ts
+++ b/packages/fabrika-cli/src/delegate/entry.ts
@@ -12,6 +12,7 @@ import * as Schema from "effect/Schema";
 import {NO_IMPLEMENTATION} from "../verb.ts";
 import {VERSION} from "../version.ts";
 import {declaredVersion, probeLocalInstall} from "./local.ts";
+import {relateCopy} from "./repository.ts";
 import {
 	DEBUG_ENV,
 	foreignCheckoutRefusal,
@@ -71,7 +72,10 @@ const program = Effect.gen(function* () {
 	const invocationDir = process.cwd();
 	const repoRoot = yield* discoverRepoRoot(invocationDir);
 	const local = repoRoot === undefined ? undefined : yield* probeLocalInstall(repoRoot);
-	const resolution = resolve({selfPackageRoot, selfOrigin, repoRoot, local});
+	// The relation, not the two roots, is what the refusal turns on: a worktree of the copy's own
+	// repository is a different checkout but the same project (#5679).
+	const origin = yield* relateCopy(selfOrigin, repoRoot);
+	const resolution = resolve({selfPackageRoot, origin, repoRoot, local});
 
 	if (process.env[DEBUG_ENV] !== undefined) console.error(traceLine(selfPackageRoot, resolution));
 

--- a/packages/fabrika-cli/src/delegate/foreign-checkout.cli.test.ts
+++ b/packages/fabrika-cli/src/delegate/foreign-checkout.cli.test.ts
@@ -61,7 +61,7 @@ describe("invoking this checkout's bin from a cwd in another checkout", {
 		const run = invokeFromConsumer("--version");
 		expect(run.stdout).not.toContain(IMPOSTER);
 		expect(run.code).toBe(NO_IMPLEMENTATION);
-		expect(run.stderr).toContain("different checkouts");
+		expect(run.stderr).toContain("different repositories");
 	});
 
 	it("names both checkouts in the refusal, so the caller can see which copy it declined", () => {

--- a/packages/fabrika-cli/src/delegate/repository.ts
+++ b/packages/fabrika-cli/src/delegate/repository.ts
@@ -1,0 +1,90 @@
+/**
+ * Which git repository a checkout belongs to, and therefore whether two checkouts are one repository.
+ *
+ * The delegation refuses to hand an invocation to a *different* checkout (#4956). A linked working
+ * tree is not one: `git worktree` gives a single repository several working trees, so the copy on
+ * `PATH` sitting in the primary checkout while the cwd sits in a worktree is one project seen twice,
+ * and refusing there made the bare `fabrika` unusable from every worktree (#5679).
+ *
+ * The identity compared is git's own `$GIT_COMMON_DIR`, read **off disk** rather than by spawning
+ * `git`: this runs in the bootstrap, before any dependency is guaranteed linked and before there is
+ * a runtime to carry a subprocess, which is the same constraint that makes `root.ts` hand-read
+ * `pnpm-workspace.yaml`. The read follows `gitrepository-layout(5)`: a `.git` **directory** is the
+ * common dir itself; a `.git` **file** holds `gitdir: <path>` naming this working tree's own git
+ * dir, and that dir's `commondir` file — when present — names the common dir it shares, "relative to
+ * $GIT_DIR" when the path in it is relative.
+ */
+import {Effect, type FileSystem, Path} from "effect";
+import {exists, isDirectory, type ReadFailed, readFile, realPath} from "../io/fs.ts";
+import type {SelfOrigin} from "./root.ts";
+
+const GIT_ENTRY = ".git";
+const COMMON_DIR_FILE = "commondir";
+const GIT_FILE = /^gitdir:\s*(.*)$/m;
+
+/** The git dir a `.git` file names, or `undefined` when the text is not a git file at all. */
+export const gitFileTarget = (text: string): string | undefined => {
+	const target = GIT_FILE.exec(text)?.[1]?.trim();
+	return target === undefined || target === "" ? undefined : target;
+};
+
+/**
+ * The `$GIT_COMMON_DIR` of the checkout at `root`, real-path resolved so two spellings of one
+ * directory compare equal — or `undefined` when `root` is not a git working tree, or its pointer is
+ * stale.
+ *
+ * `undefined` is never read as "same repository" by {@link relateCopy}: a checkout whose repository
+ * cannot be established is treated as a different one, which is the direction that refuses rather
+ * than the one that answers from a tree nobody named.
+ */
+export const repositoryOf = (
+	root: string,
+): Effect.Effect<string | undefined, ReadFailed, FileSystem.FileSystem | Path.Path> =>
+	Effect.gen(function* () {
+		const path = yield* Path.Path;
+		const entry = path.join(root, GIT_ENTRY);
+		if (!(yield* exists(entry))) return undefined;
+		if (yield* isDirectory(entry)) return yield* realPath(entry);
+		const target = gitFileTarget(yield* readFile(entry));
+		if (target === undefined) return undefined;
+		const gitDir = path.resolve(root, target);
+		const commonDirFile = path.join(gitDir, COMMON_DIR_FILE);
+		const common = (yield* exists(commonDirFile))
+			? path.resolve(gitDir, (yield* readFile(commonDirFile)).trim())
+			: gitDir;
+		return (yield* exists(common)) ? yield* realPath(common) : undefined;
+	});
+
+/**
+ * Where the running copy's home stands relative to the repo the cwd is in — the single fact the
+ * foreign-checkout refusal turns on.
+ *
+ * `other-repository` is the only state that refuses, and it carries the checkout the refusal has to
+ * name. Everything else is `same-repository`, which is a claim about crossing rather than about
+ * sameness: an installed copy belongs to no repository to cross out of, the cwd's own checkout is
+ * not a crossing, and another working tree of one repository is the tree the caller named by
+ * standing in it.
+ */
+export type CopyOrigin =
+	| {readonly _tag: "same-repository"}
+	| {readonly _tag: "other-repository"; readonly checkout: string};
+
+/**
+ * Relate the running copy's checkout to the repo root above the cwd.
+ *
+ * The two cheap answers come first and touch no git plumbing at all: an installed artifact, and a
+ * cwd already inside the copy's own checkout. Only a genuine second tree costs two reads.
+ */
+export const relateCopy = (
+	self: SelfOrigin,
+	repoRoot: string | undefined,
+): Effect.Effect<CopyOrigin, ReadFailed, FileSystem.FileSystem | Path.Path> =>
+	Effect.gen(function* () {
+		if (self._tag === "no-checkout" || repoRoot === undefined || repoRoot === self.root)
+			return {_tag: "same-repository"} as const;
+		const mine = yield* repositoryOf(self.root);
+		const theirs = yield* repositoryOf(repoRoot);
+		return mine !== undefined && mine === theirs
+			? ({_tag: "same-repository"} as const)
+			: ({_tag: "other-repository", checkout: self.root} as const);
+	});

--- a/packages/fabrika-cli/src/delegate/repository.unit.test.ts
+++ b/packages/fabrika-cli/src/delegate/repository.unit.test.ts
@@ -1,0 +1,134 @@
+/**
+ * Real directories rather than {@link fakeFs}: the subject is the difference between a `.git`
+ * directory and a `.git` file, which is a filesystem fact, and a fake that scripted the answer would
+ * be asserting against the very thing under test.
+ */
+import {mkdirSync, mkdtempSync, rmSync, writeFileSync} from "node:fs";
+import {tmpdir} from "node:os";
+import {join} from "node:path";
+import {NodeServices} from "@effect/platform-node";
+import {Effect} from "effect";
+import {afterEach, beforeEach, describe, expect, it} from "vitest";
+import {realPath} from "../io/fs.ts";
+import {gitFileTarget, relateCopy, repositoryOf} from "./repository.ts";
+
+let scratch: string;
+
+beforeEach(() => {
+	scratch = mkdtempSync(join(tmpdir(), "fabrika-repository-"));
+});
+
+afterEach(() => rmSync(scratch, {recursive: true, force: true}));
+
+const run = <A, E>(effect: Effect.Effect<A, E, NodeServices.NodeServices>) =>
+	Effect.runPromise(effect.pipe(Effect.provide(NodeServices.layer)));
+
+/** An assertion compares what the subject compares — macOS `/tmp` is a symlink to `/private/tmp`. */
+const real = (path: string) => run(realPath(path));
+
+/** A primary checkout: a real `.git` directory, which is its own common dir. */
+const primary = (name: string): string => {
+	const root = join(scratch, name);
+	mkdirSync(join(root, ".git"), {recursive: true});
+	return root;
+};
+
+/** A linked working tree of `of`, wired the way `git worktree add` wires one. */
+const worktree = (of: string, name: string): string => {
+	const root = join(scratch, name);
+	const gitDir = join(of, ".git", "worktrees", name);
+	mkdirSync(root, {recursive: true});
+	mkdirSync(gitDir, {recursive: true});
+	writeFileSync(join(gitDir, "commondir"), "../..\n");
+	writeFileSync(join(root, ".git"), `gitdir: ${gitDir}\n`);
+	return root;
+};
+
+describe("gitFileTarget", () => {
+	it("reads the git dir out of a `.git` file, trailing newline and all", () => {
+		expect(gitFileTarget("gitdir: /repo/.git/worktrees/lane\n")).toBe("/repo/.git/worktrees/lane");
+	});
+
+	it("answers undefined for text that is not a git file — never an empty path", () => {
+		expect(gitFileTarget("ref: refs/heads/main\n")).toBeUndefined();
+		expect(gitFileTarget("gitdir:\n")).toBeUndefined();
+	});
+});
+
+describe("repositoryOf", () => {
+	it("answers a primary checkout's own `.git` directory", async () => {
+		const root = primary("main");
+		expect(await run(repositoryOf(root))).toBe(await real(join(root, ".git")));
+	});
+
+	it("follows a worktree's `.git` file through `commondir` to the SHARED common dir", async () => {
+		const of = primary("main");
+		const lane = worktree(of, "lane");
+		expect(await run(repositoryOf(lane))).toBe(await run(repositoryOf(of)));
+	});
+
+	it("falls back to the named git dir when no `commondir` sits beside it", async () => {
+		const root = join(scratch, "separate");
+		const gitDir = join(scratch, "elsewhere.git");
+		mkdirSync(root, {recursive: true});
+		mkdirSync(gitDir, {recursive: true});
+		writeFileSync(join(root, ".git"), `gitdir: ${gitDir}\n`);
+		expect(await run(repositoryOf(root))).toBe(await real(gitDir));
+	});
+
+	it("answers undefined for a tree that is not a git checkout at all", async () => {
+		const root = join(scratch, "plain");
+		mkdirSync(root, {recursive: true});
+		expect(await run(repositoryOf(root))).toBeUndefined();
+	});
+
+	/** A pruned worktree leaves its `.git` file behind; an unprovable repository is not a shared one. */
+	it("answers undefined when the `.git` file points at a git dir that is gone", async () => {
+		const root = join(scratch, "stale");
+		mkdirSync(root, {recursive: true});
+		writeFileSync(join(root, ".git"), `gitdir: ${join(scratch, "pruned", "worktrees", "gone")}\n`);
+		expect(await run(repositoryOf(root))).toBeUndefined();
+	});
+});
+
+describe("relateCopy", () => {
+	it("reads an installed copy as same-repository — it belongs to no repo to cross out of", async () => {
+		expect(await run(relateCopy({_tag: "no-checkout"}, primary("main")))).toEqual({
+			_tag: "same-repository",
+		});
+	});
+
+	it("reads the cwd's OWN checkout as same-repository without touching git at all", async () => {
+		expect(await run(relateCopy({_tag: "checkout", root: "/repo"}, "/repo"))).toEqual({
+			_tag: "same-repository",
+		});
+	});
+
+	/** The defect #5679 names: the copy on `PATH` lives in the primary, the cwd is in a worktree. */
+	it("reads two working trees of ONE repository as same-repository", async () => {
+		const of = primary("main");
+		const lane = worktree(of, "lane");
+		expect(await run(relateCopy({_tag: "checkout", root: of}, lane))).toEqual({
+			_tag: "same-repository",
+		});
+	});
+
+	it("reads two unrelated repositories as other-repository, naming the copy's checkout", async () => {
+		const mine = primary("mine");
+		const theirs = primary("theirs");
+		expect(await run(relateCopy({_tag: "checkout", root: mine}, theirs))).toEqual({
+			_tag: "other-repository",
+			checkout: mine,
+		});
+	});
+
+	it("refuses to call a non-git tree the same repository — an unprovable peer is a foreign one", async () => {
+		const mine = primary("mine");
+		const plain = join(scratch, "plain");
+		mkdirSync(plain, {recursive: true});
+		expect(await run(relateCopy({_tag: "checkout", root: mine}, plain))).toEqual({
+			_tag: "other-repository",
+			checkout: mine,
+		});
+	});
+});

--- a/packages/fabrika-cli/src/delegate/resolve.ts
+++ b/packages/fabrika-cli/src/delegate/resolve.ts
@@ -10,14 +10,16 @@
  * corrupt runs the global too, but *says so loudly* — that pairing is the whole design: tiers that
  * can only be right or loudly absent are fine; tiers that can be quietly wrong are the defect
  * (#4784). One tier used to be quietly wrong against that rule and is now a refusal: a copy invoked
- * out of a *different checkout* is not a global install, and delegating it answered from a tree the
- * caller never named (#4956).
+ * out of a *different repository* is not a global install, and delegating it answered from a tree
+ * the caller never named (#4956). What counts as different is
+ * [`repository.ts`](./repository.ts)'s to decide — a working tree of the same repository is not
+ * (#5679).
  */
 import {Effect} from "effect";
 import {ChildProcess, type ChildProcessSpawner} from "effect/unstable/process";
 import {NO_IMPLEMENTATION} from "../verb.ts";
 import type {LocalInstall, LocalProbe} from "./local.ts";
-import type {SelfOrigin} from "./root.ts";
+import type {CopyOrigin} from "./repository.ts";
 
 /**
  * The child's recursion guard, passed as a **flag** rather than an environment variable so it is
@@ -46,7 +48,7 @@ export type Resolution =
 	| {
 			readonly _tag: "refuse-foreign-checkout";
 			readonly selfPackageRoot: string;
-			/** The checkout the invoked copy belongs to — never equal to {@link repoRoot}. */
+			/** The checkout the invoked copy belongs to — never a working tree of {@link repoRoot}'s. */
 			readonly selfCheckout: string;
 			readonly repoRoot: string;
 			/** The install the cwd's repo would have answered from, named so the refusal is checkable. */
@@ -56,35 +58,28 @@ export type Resolution =
 export interface ResolveInput {
 	/** The real path of the package root the running bin belongs to. */
 	readonly selfPackageRoot: string;
-	/** Which checkout, if any, {@link selfPackageRoot} belongs to. */
-	readonly selfOrigin: SelfOrigin;
+	/** Whether {@link selfPackageRoot}'s home is a repository other than the cwd's. */
+	readonly origin: CopyOrigin;
 	/** `undefined` when the cwd is in no repo at all — the one silent branch. */
 	readonly repoRoot: string | undefined;
 	readonly local: LocalProbe | undefined;
 }
 
 /** Which copy serves this invocation. Total over the five states; there is no fallthrough. */
-export const resolve = ({
-	selfPackageRoot,
-	selfOrigin,
-	repoRoot,
-	local,
-}: ResolveInput): Resolution => {
+export const resolve = ({selfPackageRoot, origin, repoRoot, local}: ResolveInput): Resolution => {
 	if (repoRoot === undefined) return {_tag: "run-here", why: "the cwd is not inside a repo"};
 	if (local === undefined || local._tag === "absent")
 		return {_tag: "warn-and-run-here", repoRoot, reason: "it has no local install"};
 	if (local._tag === "corrupt") return {_tag: "warn-and-run-here", repoRoot, reason: local.reason};
 	if (local.install.packageRoot === selfPackageRoot)
 		return {_tag: "run-here", why: "the repo-local install is this copy"};
-	// Only a copy that belongs to NO checkout is the global install this delegation was designed for.
-	// A copy from another checkout reaches the same comparison and used to be indistinguishable from
-	// it (#4956) — the refusal is placed here, on the delegate branch alone, so the two loud branches
-	// above keep their behaviour and their text exactly.
-	if (selfOrigin._tag === "checkout" && selfOrigin.root !== repoRoot)
+	// The refusal is placed here, on the delegate branch alone, so the two loud branches above keep
+	// their behaviour and their text exactly (#4956).
+	if (origin._tag === "other-repository")
 		return {
 			_tag: "refuse-foreign-checkout",
 			selfPackageRoot,
-			selfCheckout: selfOrigin.root,
+			selfCheckout: origin.checkout,
 			repoRoot,
 			wouldHaveRun: local.install,
 		};
@@ -109,10 +104,10 @@ export const foreignCheckoutRefusal = ({
 	readonly wouldHaveRun: LocalInstall;
 }): string =>
 	[
-		"fabrika: refusing to run — the copy you invoked and your cwd are in different checkouts.",
+		"fabrika: refusing to run — the copy you invoked and your cwd are in different repositories.",
 		`  invoked copy: ${selfPackageRoot} (checkout ${selfCheckout})`,
 		`  cwd checkout: ${repoRoot}, which resolves ${wouldHaveRun.binPath} (v${wouldHaveRun.version})`,
-		"  Delegating would have answered from a checkout you did not name.",
+		"  Delegating would have answered from a repository you did not name.",
 		`  Re-run with the cwd inside ${selfCheckout}, or pass ${SKIP_INFER_FLAG} to make the copy you named serve this invocation.`,
 	].join("\n");
 
@@ -153,7 +148,7 @@ export const traceLine = (selfPackageRoot: string, resolution: Resolution): stri
 		case "warn-and-run-here":
 			return `fabrika: running here, at ${selfPackageRoot} — repo root ${resolution.repoRoot}, but ${resolution.reason}`;
 		case "refuse-foreign-checkout":
-			return `fabrika: refusing — ${selfPackageRoot} is in checkout ${resolution.selfCheckout}, the cwd is in ${resolution.repoRoot}`;
+			return `fabrika: refusing — ${selfPackageRoot} is in checkout ${resolution.selfCheckout}, a different repository from the cwd's ${resolution.repoRoot}`;
 		case "run-here":
 			return `fabrika: running here, at ${selfPackageRoot} — ${resolution.why}`;
 	}

--- a/packages/fabrika-cli/src/delegate/resolve.unit.test.ts
+++ b/packages/fabrika-cli/src/delegate/resolve.unit.test.ts
@@ -7,6 +7,7 @@ import {describe, expect, it} from "vitest";
 import {faultingShell, signalledExitError, signalledShell} from "../fakes.test-support.ts";
 import {NO_IMPLEMENTATION} from "../verb.ts";
 import type {LocalInstall} from "./local.ts";
+import type {CopyOrigin} from "./repository.ts";
 import {
 	foreignCheckoutRefusal,
 	GLOBAL_WARNING_DISABLED_ENV,
@@ -17,7 +18,6 @@ import {
 	spawnDelegate,
 	traceLine,
 } from "./resolve.ts";
-import type {SelfOrigin} from "./root.ts";
 
 const install: LocalInstall = {
 	packageRoot: "/repo/packages/fabrika-cli",
@@ -28,19 +28,20 @@ const install: LocalInstall = {
 
 const GLOBAL = "/usr/local/pnpm/global/5/node_modules/@kampus/fabrika-cli";
 
-/** A copy on `PATH`: it belongs to no checkout, which is what makes delegating from it correct. */
-const INSTALLED: SelfOrigin = {_tag: "no-checkout"};
+/** A copy on `PATH`: it belongs to no repository to cross out of, so it may always hand over. */
+const INSTALLED: CopyOrigin = {_tag: "same-repository"};
 
-/** The reviewer's shape — a second checkout of the same repo, invoked by path from elsewhere. */
-const OTHER_CHECKOUT = "/repo/.claude/worktrees/agent-1";
+/** A copy whose checkout is a genuinely different repository — the one state that refuses. */
+const OTHER_CHECKOUT = "/elsewhere";
 const otherCopy = `${OTHER_CHECKOUT}/packages/fabrika-cli`;
+const ELSEWHERE: CopyOrigin = {_tag: "other-repository", checkout: OTHER_CHECKOUT};
 
 describe("resolve", () => {
 	it("delegates to the repo-local install — the pinned version wins over the global", () => {
 		expect(
 			resolve({
 				selfPackageRoot: GLOBAL,
-				selfOrigin: INSTALLED,
+				origin: INSTALLED,
 				repoRoot: "/repo",
 				local: {_tag: "found", install},
 			}),
@@ -50,7 +51,7 @@ describe("resolve", () => {
 	it("runs here SILENTLY outside any repo — a global-only invocation is not a defect", () => {
 		const resolution = resolve({
 			selfPackageRoot: GLOBAL,
-			selfOrigin: INSTALLED,
+			origin: INSTALLED,
 			repoRoot: undefined,
 			local: undefined,
 		});
@@ -60,7 +61,7 @@ describe("resolve", () => {
 	it("WARNS when a repo root exists but nothing is installed — the quietly-wrong case", () => {
 		const resolution = resolve({
 			selfPackageRoot: GLOBAL,
-			selfOrigin: INSTALLED,
+			origin: INSTALLED,
 			repoRoot: "/repo",
 			local: {_tag: "absent"},
 		});
@@ -70,7 +71,7 @@ describe("resolve", () => {
 	it("warns rather than throws on a corrupt local — the worst outcome is running the global", () => {
 		const resolution = resolve({
 			selfPackageRoot: GLOBAL,
-			selfOrigin: INSTALLED,
+			origin: INSTALLED,
 			repoRoot: "/repo",
 			local: {_tag: "corrupt", reason: "manifest declares no version"},
 		});
@@ -84,29 +85,46 @@ describe("resolve", () => {
 	it("runs here when the install it found IS this copy, rather than spawning itself", () => {
 		const resolution = resolve({
 			selfPackageRoot: install.packageRoot,
-			selfOrigin: {_tag: "checkout", root: "/repo"},
+			origin: INSTALLED,
 			repoRoot: "/repo",
 			local: {_tag: "found", install},
 		});
 		expect(resolution._tag).toBe("run-here");
 	});
+
+	/**
+	 * The recursion guard's second, independent half: the delegated child lands here with the cwd's
+	 * repo root and its own package root, and must proceed rather than spawn itself again — including
+	 * on the worktree hop, where the parent reached the child ACROSS working trees.
+	 */
+	it("runs here in the child of a worktree hop, where the install found is the child itself", () => {
+		const worktreeInstall: LocalInstall = {
+			...install,
+			packageRoot: "/repo/.claude/worktrees/lane/packages/fabrika-cli",
+			binPath: "/repo/.claude/worktrees/lane/packages/fabrika-cli/src/bin.ts",
+		};
+		expect(
+			resolve({
+				selfPackageRoot: worktreeInstall.packageRoot,
+				origin: {_tag: "same-repository"},
+				repoRoot: "/repo/.claude/worktrees/lane",
+				local: {_tag: "found", install: worktreeInstall},
+			})._tag,
+		).toBe("run-here");
+	});
 });
 
 /**
- * The two cases #4956 fused. Both reach the delegate comparison with `selfPackageRoot` outside the
- * cwd's repo root, so `selfOrigin` is the only fact separating them — and these two assertions
- * disagree on the outcome, which is what makes a future edit that drops the field fail rather than
- * quietly restore the wrong answer.
+ * The two cases #4956 fused, and the third #5679 split back out. All three reach the delegate
+ * comparison with `selfPackageRoot` outside the cwd's repo root, so `origin` is the only fact
+ * separating them — and these assertions disagree on the outcome, which is what makes a future edit
+ * that drops the field fail rather than quietly restore the wrong answer.
  */
-describe("resolve — a global install and a foreign checkout are NOT the same input", () => {
+describe("resolve — an install, a worktree peer and a foreign checkout are NOT the same input", () => {
 	const input = {repoRoot: "/repo", local: {_tag: "found", install}} as const;
 
-	it("REFUSES a copy invoked out of a different checkout, naming both roots", () => {
-		const resolution = resolve({
-			...input,
-			selfPackageRoot: otherCopy,
-			selfOrigin: {_tag: "checkout", root: OTHER_CHECKOUT},
-		});
+	it("REFUSES a copy invoked out of a different repository, naming both roots", () => {
+		const resolution = resolve({...input, selfPackageRoot: otherCopy, origin: ELSEWHERE});
 		expect(resolution).toEqual({
 			_tag: "refuse-foreign-checkout",
 			selfPackageRoot: otherCopy,
@@ -117,10 +135,25 @@ describe("resolve — a global install and a foreign checkout are NOT the same i
 	});
 
 	it("still delegates SILENTLY from an install that belongs to no checkout — same comparison, opposite answer", () => {
-		expect(resolve({...input, selfPackageRoot: GLOBAL, selfOrigin: INSTALLED})).toEqual({
+		expect(resolve({...input, selfPackageRoot: GLOBAL, origin: INSTALLED})).toEqual({
 			_tag: "delegate",
 			to: install,
 		});
+	});
+
+	/**
+	 * #5679: the copy on `PATH` is a link into the primary checkout, so it belongs to a checkout — but
+	 * the cwd's worktree is that same repository, and refusing there is what made the bare `fabrika`
+	 * unusable from every worktree.
+	 */
+	it("delegates from another WORKING TREE of the same repository — a peer is not foreign", () => {
+		expect(
+			resolve({
+				...input,
+				selfPackageRoot: "/primary/packages/fabrika-cli",
+				origin: {_tag: "same-repository"},
+			}),
+		).toEqual({_tag: "delegate", to: install});
 	});
 
 	it("delegates within ONE checkout — the pinned install may differ from the copy you ran", () => {
@@ -128,7 +161,7 @@ describe("resolve — a global install and a foreign checkout are NOT the same i
 			resolve({
 				...input,
 				selfPackageRoot: "/repo/vendor/fabrika-cli",
-				selfOrigin: {_tag: "checkout", root: "/repo"},
+				origin: {_tag: "same-repository"},
 			}),
 		).toEqual({_tag: "delegate", to: install});
 	});
@@ -180,7 +213,7 @@ describe("traceLine", () => {
 			GLOBAL,
 			resolve({
 				selfPackageRoot: GLOBAL,
-				selfOrigin: INSTALLED,
+				origin: INSTALLED,
 				repoRoot: "/repo",
 				local: {_tag: "found", install},
 			}),
@@ -195,7 +228,7 @@ describe("traceLine", () => {
 			GLOBAL,
 			resolve({
 				selfPackageRoot: GLOBAL,
-				selfOrigin: INSTALLED,
+				origin: INSTALLED,
 				repoRoot: undefined,
 				local: undefined,
 			}),

--- a/packages/fabrika-cli/src/delegate/worktree-peer.cli.test.ts
+++ b/packages/fabrika-cli/src/delegate/worktree-peer.cli.test.ts
@@ -1,0 +1,108 @@
+/**
+ * The end-to-end half of the worktree-peer delegation (#5679): a real process, invoked exactly the
+ * way the defect is met.
+ *
+ * The copy on `PATH` is a `pnpm link --global` of the primary checkout, so an agent standing in a
+ * worktree who types the bare `fabrika` invokes the *primary's* `bin.ts` with a cwd in another
+ * working tree of the same repository. Only a spawn proves the copy on disk hands the invocation
+ * over, because the delegation's whole failure mode is that both copies print the same bytes.
+ *
+ * The fixture points a scratch checkout's git plumbing at THIS checkout's real common dir, which is
+ * what `git worktree add` does and what makes the two trees one repository. Its counterpart is
+ * [`foreign-checkout.cli.test.ts`](./foreign-checkout.cli.test.ts), whose scratch tree shares no
+ * repository and must still be refused.
+ */
+import {execFileSync} from "node:child_process";
+import {mkdirSync, mkdtempSync, rmSync, writeFileSync} from "node:fs";
+import {tmpdir} from "node:os";
+import {join, resolve} from "node:path";
+import {fileURLToPath} from "node:url";
+import {afterAll, beforeAll, describe, expect, it} from "vitest";
+import {SUBPROCESS_TEST_TIMEOUT_MS} from "../test-budget.ts";
+
+const BIN = fileURLToPath(new URL("../bin.ts", import.meta.url));
+const CHECKOUT = fileURLToPath(new URL("../../../../", import.meta.url)).replace(/\/$/, "");
+
+/** What the peer working tree's install prints when it is allowed to answer — as it must be. */
+const PEER = "answered-from-the-peer-working-tree";
+
+/** This checkout's `$GIT_COMMON_DIR`, asked of git itself, or `undefined` outside a repository. */
+const commonDirOfThisCheckout = (): string | undefined => {
+	try {
+		const out = execFileSync("git", ["rev-parse", "--git-common-dir"], {
+			cwd: CHECKOUT,
+			encoding: "utf8",
+			stdio: ["ignore", "pipe", "ignore"],
+		});
+		return resolve(CHECKOUT, out.trim());
+	} catch {
+		return undefined;
+	}
+};
+
+const commonDir = commonDirOfThisCheckout();
+
+let peer: string;
+
+beforeAll(() => {
+	if (commonDir === undefined) return;
+	const scratch = mkdtempSync(join(tmpdir(), "fabrika-peer-"));
+	peer = join(scratch, "lane");
+	const gitDir = join(scratch, "gitdir");
+	const installed = join(peer, "node_modules", "@kampus", "fabrika-cli");
+	mkdirSync(installed, {recursive: true});
+	mkdirSync(gitDir, {recursive: true});
+	// `commondir` is what makes this tree the same repository as the invoked copy's — the mechanism
+	// `git worktree` uses, per `gitrepository-layout(5)`.
+	writeFileSync(join(gitDir, "commondir"), `${commonDir}\n`);
+	writeFileSync(join(peer, ".git"), `gitdir: ${gitDir}\n`);
+	writeFileSync(join(peer, "package.json"), '{"name":"lane","version":"0.0.0"}\n');
+	writeFileSync(join(installed, "bin.js"), `console.log(${JSON.stringify(PEER)});\n`);
+	writeFileSync(
+		join(installed, "package.json"),
+		'{"name":"@kampus/fabrika-cli","version":"9.9.9","bin":{"fabrika":"./bin.js"}}\n',
+	);
+});
+
+afterAll(() => {
+	if (peer !== undefined) rmSync(join(peer, ".."), {recursive: true, force: true});
+});
+
+const invokeFromPeer = (...args: ReadonlyArray<string>) => {
+	try {
+		const stdout = execFileSync(process.execPath, [BIN, ...args], {
+			cwd: peer,
+			encoding: "utf8",
+			stdio: ["ignore", "pipe", "pipe"],
+		});
+		return {code: 0, stdout, stderr: ""};
+	} catch (err) {
+		const failure = err as {status?: number; stdout?: string; stderr?: string};
+		return {code: failure.status ?? -1, stdout: failure.stdout ?? "", stderr: failure.stderr ?? ""};
+	}
+};
+
+describe("invoking this checkout's bin from a cwd in another working tree of the same repository", {
+	timeout: SUBPROCESS_TEST_TIMEOUT_MS,
+	// The bin's own delegation is under test, so the guard that pins an invocation to this copy has
+	// to stay unset — and vitest inherits the parent env. Outside a git repository the fixture
+	// cannot be built at all, which is a missing fixture rather than a passing subject.
+	skip: process.env.FABRIKA_SKIP_INFER !== undefined || commonDir === undefined,
+}, () => {
+	it("hands the invocation to the peer tree's own install rather than answering itself", () => {
+		const run = invokeFromPeer("--version");
+		expect(run.stdout).toContain(PEER);
+		expect(run.code).toBe(0);
+	});
+
+	it("does not refuse — a working tree of this repository is not a foreign checkout", () => {
+		expect(invokeFromPeer("--version").stderr).not.toContain("refusing to run");
+	});
+
+	it("still serves the invocation itself under --skip-infer — the guard outranks the walk", () => {
+		const run = invokeFromPeer("--skip-infer", "--version");
+		expect(run.code).toBe(0);
+		expect(run.stdout).toContain("fabrika v");
+		expect(run.stdout).not.toContain(PEER);
+	});
+});

--- a/packages/fabrika-cli/src/hook/pretooluse-polarity.cli.test.ts
+++ b/packages/fabrika-cli/src/hook/pretooluse-polarity.cli.test.ts
@@ -123,7 +123,7 @@ describe("the PreToolUse hook the surface declares, run from a checkout it refus
 	};
 
 	it("refuses, and says so on stderr — fail open and loud, per ADR 0250", () => {
-		expect(run().stderr).toContain("different checkouts");
+		expect(run().stderr).toContain("different repositories");
 	});
 
 	it("does not exit on the blocking code, so the spawn proceeds", () => {


### PR DESCRIPTION
The bare `fabrika` is the DX and stays the committed form everywhere. What changes is the code the command runs: it now hands the invocation to the working tree you are standing in.

## What was wrong

`fabrika` is installed with `pnpm link --global`, so the shim on `PATH` execs the **primary checkout's** `packages/fabrika-cli/src/bin.ts`. That copy belongs to a checkout, and the delegation refused to hand an invocation to a different checkout (#4956). A worktree is a different checkout, so the bare `fabrika` from any worktree ended at exit `126`:

```
fabrika: refusing to run — the copy you invoked and your cwd are in different checkouts.
```

That is a correction to the issue's premise, which expected a *silent* wrong answer. Since #4956 landed it has been a loud refusal, so the practical damage was not a false green — it was that the bare command did not work in a worktree at all.

## What changed

The refusal's comparison is no longer "same checkout?" but "same repository?". `git worktree` gives one repository several working trees, so the identity compared is git's own `$GIT_COMMON_DIR`, read off disk in the new `delegate/repository.ts`: a `.git` directory is the common dir; a `.git` file's `gitdir:` plus that dir's `commondir` names the shared one, per `gitrepository-layout(5)`. Equal common dirs delegate; anything else refuses exactly as before. It is read rather than asked of `git`, because this runs in the bootstrap before any dependency is guaranteed linked — the same constraint that already makes `root.ts` hand-read `pnpm-workspace.yaml`.

`resolve`'s input now carries that one relation (`CopyOrigin`) instead of the copy's own checkout, so "installed globally" and "same repository" cannot disagree with each other in a way the branch has to untangle.

A tree whose repository cannot be established — no `.git`, or a pruned worktree's stale pointer — is treated as a different repository, so an unreadable answer falls back to the refusal rather than to a delegation.

The fix only takes effect for the installed shim once this lands, since the shim runs the primary checkout's copy.

## Verification

Recorded against the real repository, invoking the fixed copy from one working tree with the cwd in another, `FABRIKA_DEBUG=1`:

| cwd | trace | exit |
| --- | --- | --- |
| the invoked copy's own worktree | `running here … the repo-local install is this copy` | 0 |
| a **sibling worktree** | `delegating to the repo-local install at <sibling>/packages/fabrika-cli` | 0 |
| the **primary checkout** | `delegating to the repo-local install at <primary>/packages/fabrika-cli` | 0 |
| outside any checkout | `running here … the cwd is not inside a repo` | 0 |

Before the change the middle two rows were the refusal at exit `126`.

Tests were written red first: the nine new assertions failed against the pre-fix tree, the end-to-end one reproducing the refusal verbatim. `packages/fabrika-cli` is green at 4635 tests, and `build check` is green on both `code` and `prose`.

The end-to-end test builds a scratch checkout whose git plumbing points at this checkout's real common dir, which is what `git worktree add` does. Its counterpart, `foreign-checkout.cli.test.ts`, keeps its scratch tree unrelated and still asserts the refusal — that test needed no change to its subject, which is the evidence the guard kept its teeth.

## Deviations

- **Pre-existing test or fixture changed** — **Said:** the guard landed by #4956 keeps its refusal message, and the three assertions pinning that message stand. **Did:** the message now reads "different repositories" instead of "different checkouts", and three existing assertions were updated to match — the matched string in `delegate/foreign-checkout.cli.test.ts:64` and `hook/pretooluse-polarity.cli.test.ts:126`, and the `selfOrigin` → `origin` field rename in `delegate/resolve.unit.test.ts:120`. **Why:** two worktrees *are* different checkouts and are deliberately no longer refused, so the old wording named the wrong boundary. **Disposition:** disclosed here; every one of the three keeps its subject and its expected outcome — only the string it matches moved — and the README's table row was reworded in the same pass.
- **Scope narrowing** — **Said:** narrowing a guard that landed with its own decision trail (#4956) is the kind of call this repo records in `.decisions/`. **Did:** shipped the narrowing with no ADR in this diff. **Why:** authoring a decision record is a different surface with its own skill, and folding it in would put two unrelated reviews on one diff. **Disposition:** filed as #5706 and left open there; this PR does not close it.
- **Scope narrowing** — **Said:** the first acceptance criterion asks for a recorded verification run through the globally-installed `fabrika`. **Did:** recorded the Verification table by invoking the fixed copy directly with the cwd set, not through the shim on `PATH`. **Why:** the shim execs the primary checkout's copy, which does not carry this fix until this merges, so a probe through it would have measured the old code and proved nothing. **Disposition:** disclosed here; the probes supply the same two inputs the shim supplies — which copy runs, and from which cwd — and exercise the same resolution path.

Fixes #5679
