### PR TITLE
Re-gating a repaired PR leaves the governance-floor check permanently red

### DIFF
--- a/claude-plugins/fabrika/skills/governance/SKILL.md
+++ b/claude-plugins/fabrika/skills/governance/SKILL.md
@@ -217,10 +217,14 @@ periodic sweep otherwise re-raises what a ruling killed, every cycle.
 
 <!-- anchor: CAPABILITIES --> This skill opens no PR, mutates no branch, pushes nothing, merges
 nothing and applies no label — **every terminal below leaves the branch untouched, because this
-skill cannot touch one.** It holds a shell and a repo-scoped token, and performs exactly two writes
-of its own: the namespaced verdict comment and the readout artifact. (Routing a finding to
-`/report` fires that skill, whose write is that skill's capability and not one claimed here.) Every
-run ends as exactly one of:
+skill cannot touch one.** It holds a shell and a repo-scoped token, and performs exactly three
+writes of its own: the namespaced verdict comment, the readout artifact, and one re-run request for
+the `governance-floor` run at the head its verdict binds — which is why the token also needs
+`actions: write`. **That third write asserts nothing:** it writes no check-run and no status, so the
+floor's green stays a green that job derived itself against live comment state, and a token without
+`actions: write` costs a red check, never a false one. (Routing a finding to `/report` fires that
+skill, whose write is that skill's capability and not one claimed here.) Every run ends as exactly
+one of:
 
 - **verdict PASS** — swept or hand-read, no contradiction and no weakening found.
 - **verdict FAIL** — a named contradiction or a named weakening, with the line and the invariant.

--- a/claude-plugins/fabrika/skills/governance/SKILL.md
+++ b/claude-plugins/fabrika/skills/governance/SKILL.md
@@ -170,7 +170,15 @@ it is; this namespace rides the same channel as every other.
 the head you actually inspected; the verb re-resolves the live head at post time and refuses a moved
 one. Re-review, never re-bind.
 
-**Done when** `post` prints `posted` and its read-back conformed.
+**`post` also re-fires the floor check at that head.** The `governance-floor` job runs on
+`pull_request`, so it judged the PR before your verdict existed and nothing else re-fires it. The verb
+re-runs that job, which re-derives `ship floor` against your verdict — it never writes a check-run, so
+the green is the job's own. Its last stderr line says which of `refired` / `green` / `in-flight` /
+`no-run` / `unknown` happened.
+
+**Done when** `post` prints `posted`, its read-back conformed, and you have read the floor line — an
+`in-flight` or `unknown` floor means the check may still red at this head, and clearing it is
+`heal-ci`'s, not a human's.
 
 ## 6 — Digest time: the readout that replaced the human gate
 

--- a/claude-plugins/fabrika/skills/governance/contract.md
+++ b/claude-plugins/fabrika/skills/governance/contract.md
@@ -901,7 +901,10 @@ namespace is a constant, so it cannot be aimed anywhere else even by a confused 
    newest `governance-floor` run there is completed-and-red it requests a re-run of that run's failed
    jobs, then re-reads the run and requires `run_attempt` to have increased. **The re-run is a
    re-derivation, never a claim**: nothing here writes a check-run or a status, so the green a PR ends
-   with is one `ship floor` reached itself against live comment state.
+   with is one `ship floor` reached itself against live comment state. **This step is the one place
+   the verb needs `actions: write`** on its token; no earlier step asks for it. Without it the
+   `rerun-failed-jobs` request 403s, the floor reads `unknown`, and the fix degrades to
+   #5585's own symptom — a red check a human clears — never to a false green.
 
 **The floor assertion never changes the exit code.** By step 7 the verdict is landed and read back, so
 a floor that could not be asserted is a red check, not an unwritten verdict — every outcome is one

--- a/claude-plugins/fabrika/skills/governance/contract.md
+++ b/claude-plugins/fabrika/skills/governance/contract.md
@@ -29,7 +29,7 @@ access per
 | `governance sweep` | the uncited live-`accepted` records whose decision domain a subject touches, ranked, for a subject read out of a bound commit or out of the corpus | the ranking is arithmetic over a corpus; reading the shortlist, and reading the domain the ranking cannot see, is judgment |
 | `governance guards` | the anchored invariants the bound diff removes or modifies, and the guard-bearing files it touches | detecting an anchor's removal or mutation in a diff is textual and mechanical; whether the change *weakens* the invariant is judgment |
 | `governance base` | this skill's own text at the merge-base of a PR that edits it — the self fence's bytes | resolving a merge base and reading named paths at it is mechanical; judging the PR by those rules rather than the head's is the judgment |
-| `governance post` | the single sanctioned emit of the `governance` namespace verdict: compose through the `verdict-marker` wire format, re-resolve the head, upsert one comment per head, leak-scan, read back | marker composition, head re-resolution, the derived-namespace fence and the read-back are a protocol; the polarity and clause are judgment |
+| `governance post` | the single sanctioned emit of the `governance` namespace verdict: compose through the `verdict-marker` wire format, re-resolve the head, upsert one comment per head, leak-scan, read back, then re-fire the floor check at that head | marker composition, head re-resolution, the derived-namespace fence and the read-back are a protocol; the polarity and clause are judgment |
 | `governance digest` | the decision records that landed in a window, each with its id, title, status, landing commit and whether its diff carried anchored-invariant changes | enumerating merges in a window and reading each record's frontmatter is mechanical; ranking tension and blast radius is judgment |
 | `governance readout` | the digest-publishing protocol: compose the ranked rows through the `governance-digest` wire format, upsert them into the durable artifact, read them back | composition, upsert and read-back are a protocol; the rows and their order are judgment |
 
@@ -855,7 +855,8 @@ poster reads success.
 `posted\tgovernance\t<polarity>\t<sha>\t<content>\t<created|edited>\t<comment-url>`, where
 `<content>` is the content digest the verdict binds (ADR 0276).
 With `--json`:
-`{"outcome":"posted","namespace":"governance","polarity":…,"sha":…,"content":…,"upsert":"created"|"edited","commentUrl":…}`.
+`{"outcome":"posted","namespace":"governance","polarity":…,"sha":…,"content":…,"upsert":"created"|"edited","floor":"refired"|"green"|"in-flight"|"no-run"|"unknown","commentUrl":…}`.
+The tab line does not carry `floor` — the floor's outcome is on stderr, one line, always.
 
 **The namespace is fixed.** There is no `--namespace` flag: this verb emits exactly one namespace and
 composing another is not a mode it has. That is the disjointness guarantee made structural in the
@@ -893,6 +894,22 @@ namespace is a constant, so it cannot be aimed anywhere else even by a confused 
    format's `read`, require `Found` with exactly the five fields posted, then compare the whole
    comment against the bytes sent through `normalizeForReadback`. A read-back that trusts a carried
    variable instead of live state re-ships #3173's false PASS.
+7. **Assert the floor at this head.** `governance-floor.yml` triggers on `pull_request` alone, so it
+   ran before this verdict could exist, judged a head with no verdict on it, and no comment write can
+   re-fire a `pull_request`-triggered job — every governance-root PR reds at least once and stays red
+   until something re-runs the job (#5585). The verb reads the runs at the bound head, and when the
+   newest `governance-floor` run there is completed-and-red it requests a re-run of that run's failed
+   jobs, then re-reads the run and requires `run_attempt` to have increased. **The re-run is a
+   re-derivation, never a claim**: nothing here writes a check-run or a status, so the green a PR ends
+   with is one `ship floor` reached itself against live comment state.
+
+**The floor assertion never changes the exit code.** By step 7 the verdict is landed and read back, so
+a floor that could not be asserted is a red check, not an unwritten verdict — every outcome is one
+stderr line and the `--json` `floor` field. The five: `refired` (a new attempt exists), `green` (the
+run at this head already passed), `in-flight` (the run had not completed, so it may still judge state
+older than this verdict — re-read the check), `no-run` (no floor run at this head: not installed in
+this repository, or not fired yet), `unknown` (the state could not be read or the re-fire could not be
+proven — never read as a pass).
 
 **No advisory carrier.** `review post` takes `--carrier advisory` for §CP PRs, where a human approval
 is the gate. This verb has no such mode: §CP is not this namespace's question, the governance verdict
@@ -933,8 +950,9 @@ clothes.
 | `governance post: posted, but the read-back does not yield this marker (<wire reason>) — the PR may carry a garbled verdict; inspect comment <id>.` | 9 | refusal |
 
 **Scope** — one PR: its live head, the bound commit's file list for the re-derivation, its comments,
-and the caller's stdin. A read failing at any of those is `11` — nothing written, outcome
-known-unwritten.
+and the caller's stdin, plus the workflow runs at the bound head for step 7. A read failing at any of
+the first four is `11` — nothing written, outcome known-unwritten; a read failing at the fifth is the
+`unknown` floor, because by then the verdict is written.
 
 **Examples**
 
@@ -945,7 +963,7 @@ posted	governance	PASS	03135b91	2f1a9c4e0b7d	created	https://github.com/kamp-us/
 
 ```
 $ fabrika governance post 4321 --polarity PASS --sha 03135b91 --clause "no contradiction, no weakening" --json < verdict.md
-{"outcome":"posted","namespace":"governance","polarity":"PASS","sha":"03135b91","content":"2f1a9c4e0b7d","upsert":"created","commentUrl":"https://github.com/kamp-us/phoenix/pull/4321#issuecomment-5154902211"}
+{"outcome":"posted","namespace":"governance","polarity":"PASS","sha":"03135b91","content":"2f1a9c4e0b7d","upsert":"created","floor":"refired","commentUrl":"https://github.com/kamp-us/phoenix/pull/4321#issuecomment-5154902211"}
 ```
 
 ```

--- a/packages/fabrika-cli/src/governance/floor-assert.ts
+++ b/packages/fabrika-cli/src/governance/floor-assert.ts
@@ -1,0 +1,122 @@
+/**
+ * The gate's own assertion of the governance floor at the head it just posted to.
+ *
+ * `governance-floor.yml` triggers on `pull_request` alone, so it always runs *before* the verdict it
+ * looks for can exist — a governance verdict is written by an agent that has to read the diff first.
+ * The job reads comment state at its own start, finds no verdict at the head, exits 18, and no
+ * comment write can re-fire a `pull_request`-triggered job. Every governance-root PR therefore reds
+ * at least once and only a re-run clears it (#5585).
+ *
+ * The founder ruled the fix direction on 2026-08-16: the gate's own post asserts the floor at its own
+ * head. The gate is the one actor with no ordering problem — it knows it just wrote the verdict — and
+ * the fix stays inside this package rather than editing `.github/workflows/`, which CODEOWNERS assigns
+ * to the control plane.
+ *
+ * **Asserting is re-deriving, never claiming.** Nothing here writes a check-run or a status: it
+ * re-fires the floor job, which re-runs `ship floor` against live comment state and reaches its own
+ * verdict. A fabricated green is the one outcome this module must never be able to produce.
+ *
+ * The run IO is imported from the two homes that already serve it — `../ship/github.ts` for the runs
+ * at a head, `../heal-ci/github.ts` for one run and the rerun request. A third copy of either is how
+ * two groups come to disagree about what the platform returns.
+ */
+import {Effect} from "effect";
+import {getWorkflowRun, rerunFailedJobs} from "../heal-ci/github.ts";
+import type {Shell} from "../io/git.ts";
+import {listRunsAtHead} from "../ship/github.ts";
+
+/** The floor workflow's `name:`, which is what a run at a head carries. */
+export const FLOOR_WORKFLOW_NAME = "governance-floor";
+
+/** The conclusions that leave the check red. Anything else at `completed` is not a red to clear. */
+const RED_CONCLUSIONS = new Set(["failure", "timed_out", "cancelled", "action_required"]);
+
+export type FloorAssertion =
+	/** No floor run at this head: the workflow is not installed here, or it has not fired yet. */
+	| {readonly _tag: "NoRun"}
+	/** The run at this head already concluded green — the check reflects the gate's state. */
+	| {readonly _tag: "Green"; readonly run: number}
+	/** The run is still going, so it may yet judge state older than the verdict just written. */
+	| {readonly _tag: "InFlight"; readonly run: number}
+	/** A new attempt exists and is re-deriving `ship floor` against live comment state. */
+	| {readonly _tag: "Refired"; readonly run: number; readonly attempt: number}
+	/** The floor state could not be read or the re-fire could not be proven. Never a pass. */
+	| {readonly _tag: "Unknown"; readonly reason: string};
+
+const unknown = (reason: string): FloorAssertion => ({_tag: "Unknown", reason});
+
+/**
+ * Re-fire the red governance-floor run at `sha`, and prove a new attempt exists.
+ *
+ * The dispatch's 2xx is an acknowledgement and not a new attempt, so the run is re-read and
+ * `run_attempt` must have increased — `heal-ci rerun` learned that the hard way, and reporting a
+ * re-fire that never happened would leave the caller believing a red will clear itself.
+ */
+export const assertFloorAt = (repo: string, sha: string): Shell<FloorAssertion> =>
+	Effect.gen(function* () {
+		const listed = yield* listRunsAtHead(repo, sha);
+		if (listed._tag === "Failure") return unknown(listed.reason);
+		if (listed.value.runs.length < listed.value.declared) {
+			return unknown(
+				`received ${listed.value.runs.length} of ${listed.value.declared} declared runs at ${sha}`,
+			);
+		}
+		const floors = listed.value.runs.filter((run) => run.name === FLOOR_WORKFLOW_NAME);
+		if (floors.length === 0) return {_tag: "NoRun"};
+		// The newest run at this head, by id. A head can carry several — a re-created PR, a retriggered
+		// workflow — and the check the PR shows is the last one.
+		const latest = floors.reduce((held, run) => (run.id > held.id ? run : held));
+		if (latest.status !== "completed") return {_tag: "InFlight", run: latest.id};
+		if (!RED_CONCLUSIONS.has(latest.conclusion ?? "")) return {_tag: "Green", run: latest.id};
+
+		const before = yield* getWorkflowRun(repo, latest.id);
+		if (before._tag !== "Present") {
+			return unknown(
+				before._tag === "Absent"
+					? `run ${latest.id} is not in ${repo}`
+					: `run ${latest.id}: ${before.reason}`,
+			);
+		}
+		const requested = yield* rerunFailedJobs(repo, latest.id);
+		if (requested._tag === "Failure") return unknown(requested.reason);
+		const after = yield* getWorkflowRun(repo, latest.id);
+		if (after._tag !== "Present") {
+			return unknown(
+				`the re-fire was requested and the confirming read of run ${latest.id} failed — UNKNOWN whether it re-ran`,
+			);
+		}
+		if (after.value.runAttempt <= before.value.runAttempt) {
+			return unknown(
+				`the re-fire was requested and run ${latest.id} stayed at attempt ${after.value.runAttempt} — UNKNOWN whether it re-ran`,
+			);
+		}
+		return {_tag: "Refired", run: latest.id, attempt: after.value.runAttempt};
+	});
+
+/** The one-token closed vocabulary a caller emits under `--json`. */
+export const floorToken = (assertion: FloorAssertion): string =>
+	assertion._tag === "NoRun"
+		? "no-run"
+		: assertion._tag === "Green"
+			? "green"
+			: assertion._tag === "InFlight"
+				? "in-flight"
+				: assertion._tag === "Refired"
+					? "refired"
+					: "unknown";
+
+/** The stderr line, which states what the caller must do next when the floor is not asserted. */
+export const floorLine = (verb: string, assertion: FloorAssertion): string => {
+	switch (assertion._tag) {
+		case "NoRun":
+			return `${verb}: no ${FLOOR_WORKFLOW_NAME} run at this head — the floor is not installed in this repository, or it has not fired yet.`;
+		case "Green":
+			return `${verb}: ${FLOOR_WORKFLOW_NAME} run ${assertion.run} already reads green at this head — nothing to re-fire.`;
+		case "InFlight":
+			return `${verb}: ${FLOOR_WORKFLOW_NAME} run ${assertion.run} is still in flight, so it may judge comment state older than this verdict — re-read the check and re-post if it reds.`;
+		case "Refired":
+			return `${verb}: re-fired ${FLOOR_WORKFLOW_NAME} run ${assertion.run} at attempt ${assertion.attempt} — it re-derives \`ship floor\` against this verdict (#5585).`;
+		case "Unknown":
+			return `${verb}: the ${FLOOR_WORKFLOW_NAME} check could not be asserted at this head: ${assertion.reason} — the verdict landed; the check may still need a re-fire.`;
+	}
+};

--- a/packages/fabrika-cli/src/governance/floor-assert.unit.test.ts
+++ b/packages/fabrika-cli/src/governance/floor-assert.unit.test.ts
@@ -1,0 +1,132 @@
+import {Effect} from "effect";
+import {describe, expect, it} from "vitest";
+import {errOut, fakeShell, okOut, once} from "../fakes.test-support.ts";
+import {runsAtHead, workflowRun} from "../heal-ci/fixtures.test-support.ts";
+import type {ExecResult} from "../io/exec.ts";
+import {HEAD} from "./fixtures.test-support.ts";
+import {assertFloorAt, floorLine} from "./floor-assert.ts";
+
+const RUNS = /^gh api --paginate repos\/o\/r\/actions\/runs\?head_sha=/;
+const RUN = /^gh api repos\/o\/r\/actions\/runs\/\d+$/;
+const RERUN = /^gh api --method POST repos\/o\/r\/actions\/runs\/\d+\/rerun-failed-jobs$/;
+
+const FLOOR = 31_863_008_185;
+
+const assert = (script: ReadonlyArray<readonly [RegExp, ExecResult]>) =>
+	Effect.runPromise(Effect.provide(assertFloorAt("o/r", HEAD), fakeShell(script).layer));
+
+const withCalls = (script: ReadonlyArray<readonly [RegExp, ExecResult]>) => {
+	const shell = fakeShell(script);
+	return Effect.runPromise(Effect.provide(assertFloorAt("o/r", HEAD), shell.layer)).then(
+		(assertion) => ({assertion, shell}),
+	);
+};
+
+/** A red floor run at the head, re-fired into a second attempt. */
+const red = (): ReadonlyArray<readonly [RegExp, ExecResult]> => [
+	[
+		RUNS,
+		runsAtHead(2, [
+			{id: 1, name: "ci"},
+			{id: FLOOR, name: "governance-floor"},
+		]),
+	],
+	[once(RUN), workflowRun({id: FLOOR, attempt: 1})],
+	[RERUN, okOut("")],
+	[RUN, workflowRun({id: FLOOR, attempt: 2})],
+];
+
+describe("assertFloorAt re-derives the floor rather than claiming it", () => {
+	it("re-fires the red floor run at this head and proves the new attempt", async () => {
+		const {assertion, shell} = await withCalls(red());
+		expect(assertion).toEqual({_tag: "Refired", run: FLOOR, attempt: 2});
+		expect(shell.calls.some((call) => RERUN.test(call))).toBe(true);
+		// The re-fire re-runs `ship floor` in CI. Nothing here writes a check-run or a status, so the
+		// green a PR ends up with is one the gate's own job derived (#5585).
+		expect(shell.calls.some((call) => call.includes("check-runs"))).toBe(false);
+	});
+
+	it("picks the NEWEST floor run at the head, not the first one listed", async () => {
+		const {shell} = await withCalls([
+			[
+				RUNS,
+				runsAtHead(2, [
+					{id: 700, name: "governance-floor"},
+					{id: 900, name: "governance-floor"},
+				]),
+			],
+			[once(RUN), workflowRun({id: 900, attempt: 1})],
+			[RERUN, okOut("")],
+			[RUN, workflowRun({id: 900, attempt: 2})],
+		]);
+		expect(shell.calls.some((call) => call.endsWith("/actions/runs/900"))).toBe(true);
+		expect(shell.calls.some((call) => call.endsWith("/actions/runs/700"))).toBe(false);
+	});
+
+	it("leaves an in-flight run alone — it cannot be re-fired, and saying so is the answer", async () => {
+		const {assertion, shell} = await withCalls([
+			[RUNS, runsAtHead(1, [{id: FLOOR, name: "governance-floor", status: "in_progress"}])],
+		]);
+		expect(assertion).toEqual({_tag: "InFlight", run: FLOOR});
+		expect(shell.calls.some((call) => RERUN.test(call))).toBe(false);
+	});
+
+	it("re-fires nothing when the run at this head already reads green", async () => {
+		const {assertion, shell} = await withCalls([
+			[RUNS, runsAtHead(1, [{id: FLOOR, name: "governance-floor", conclusion: "success"}])],
+		]);
+		expect(assertion).toEqual({_tag: "Green", run: FLOOR});
+		expect(shell.calls.some((call) => RERUN.test(call))).toBe(false);
+	});
+
+	it("answers NoRun when the repository runs no floor at this head", async () => {
+		expect(await assert([[RUNS, runsAtHead(1, [{id: 1, name: "ci"}])]])).toEqual({_tag: "NoRun"});
+	});
+});
+
+describe("every unread state is UNKNOWN, never a re-fire nobody proved", () => {
+	it("refuses to read NoRun out of a truncated run list", async () => {
+		const assertion = await assert([[RUNS, runsAtHead(9, [{id: 1, name: "ci"}])]]);
+		expect(assertion._tag).toBe("Unknown");
+		expect(assertion._tag === "Unknown" && assertion.reason).toContain("of 9 declared runs");
+	});
+
+	it("reports a failed re-fire request as UNKNOWN", async () => {
+		const assertion = await assert([
+			[RUNS, runsAtHead(1, [{id: FLOOR, name: "governance-floor"}])],
+			[once(RUN), workflowRun({id: FLOOR, attempt: 1})],
+			[RERUN, errOut("gh: Forbidden (HTTP 403)")],
+		]);
+		expect(assertion._tag).toBe("Unknown");
+		expect(assertion._tag === "Unknown" && assertion.reason).toContain("403");
+	});
+
+	// The dispatch's 2xx is an acknowledgement, not an attempt: a re-fire reported on the strength of
+	// the response would tell the caller a red is clearing itself when nothing re-ran.
+	it("refuses to call it re-fired when run_attempt did not move", async () => {
+		const assertion = await assert([
+			[RUNS, runsAtHead(1, [{id: FLOOR, name: "governance-floor"}])],
+			[RUN, workflowRun({id: FLOOR, attempt: 1})],
+			[RERUN, okOut("")],
+		]);
+		expect(assertion._tag).toBe("Unknown");
+		expect(assertion._tag === "Unknown" && assertion.reason).toContain("stayed at attempt 1");
+	});
+
+	it("reports an unreadable run list as UNKNOWN", async () => {
+		const assertion = await assert([[RUNS, errOut("gh: Bad gateway (HTTP 502)")]]);
+		expect(assertion._tag).toBe("Unknown");
+	});
+});
+
+describe("floorLine says what the caller must do next", () => {
+	it("names the attempt on a re-fire and the residual red otherwise", async () => {
+		expect(floorLine("governance post", {_tag: "Refired", run: FLOOR, attempt: 2})).toContain(
+			"attempt 2",
+		);
+		expect(floorLine("governance post", {_tag: "Unknown", reason: "502"})).toContain(
+			"may still need a re-fire",
+		);
+		expect(floorLine("governance post", {_tag: "InFlight", run: FLOOR})).toContain("re-read");
+	});
+});

--- a/packages/fabrika-cli/src/governance/post-verb.ts
+++ b/packages/fabrika-cli/src/governance/post-verb.ts
@@ -49,6 +49,7 @@ import {
 	STALE_HEAD,
 	WRITE_UNKNOWN,
 } from "./codes.ts";
+import {assertFloorAt, floorLine, floorToken} from "./floor-assert.ts";
 import {bindGovernanceHead, boundLine} from "./head.ts";
 
 const VERB = "governance post";
@@ -291,6 +292,13 @@ export const runPost = (
 			);
 		}
 
+		// Step 7 — assert the floor at this head. The floor job ran before this verdict existed and
+		// nothing re-fires it, so the gate that just wrote the verdict is the actor that re-derives the
+		// check (#5585). It never gates the post: the verdict is landed and read back by here, and a
+		// floor that could not be asserted is a red check, not an unwritten verdict.
+		const floor = yield* assertFloorAt(repo, head.sha);
+		diagnostics.push(floorLine(VERB, floor));
+
 		return json
 			? answer(
 					JSON.stringify({
@@ -300,6 +308,7 @@ export const runPost = (
 						sha: inspected,
 						content: content.value,
 						upsert,
+						floor: floorToken(floor),
 						commentUrl: landed.url,
 					}),
 					diagnostics,

--- a/packages/fabrika-cli/src/governance/post-verb.unit.test.ts
+++ b/packages/fabrika-cli/src/governance/post-verb.unit.test.ts
@@ -1,6 +1,7 @@
 import {Effect} from "effect";
 import {describe, expect, it} from "vitest";
 import {errOut, fakeShell, okOut, once} from "../fakes.test-support.ts";
+import {runsAtHead, workflowRun} from "../heal-ci/fixtures.test-support.ts";
 import type {ExecResult} from "../io/exec.ts";
 import type {StdinRead} from "../io/stdin.ts";
 import {CONTENT, PATHS_AT} from "../review/fixtures.test-support.ts";
@@ -25,6 +26,10 @@ const COMMENTS = /^gh api --paginate repos\/o\/r\/issues\/4321\/comments/;
 const CREATE = /^gh api --method POST repos\/o\/r\/issues\/4321\/comments/;
 const PATCH = /^gh api --method PATCH repos\/o\/r\/issues\/comments\/77/;
 const READ_BACK = /^gh api repos\/o\/r\/issues\/comments\/(\d+)$/;
+const RUNS = /^gh api --paginate repos\/o\/r\/actions\/runs\?head_sha=/;
+const RUN = /^gh api repos\/o\/r\/actions\/runs\/\d+$/;
+const RERUN = /^gh api --method POST repos\/o\/r\/actions\/runs\/\d+\/rerun-failed-jobs$/;
+const FLOOR = 31_863_008_185;
 
 const BODY = "The sweep found no contradiction; no anchored invariant is in reach.\n";
 const URL = "https://github.com/o/r/pull/4321#issuecomment-5154902211";
@@ -201,5 +206,57 @@ describe("runPost", () => {
 		);
 		await Effect.runPromise(Effect.provide(runPost(options), fake.layer));
 		expect(fake.calls).toContain("gh api repos/o/r/issues/comments/91");
+	});
+});
+
+// The floor job runs on `pull_request` and reads comment state at its own start, so it always judges
+// a head that has no verdict yet and nothing re-fires it. The gate that just wrote the verdict is the
+// actor with no ordering problem — founder ruling, 2026-08-16 (#5585).
+describe("runPost asserts the governance floor at the head it posted to", () => {
+	const landed = (
+		...extra: ReadonlyArray<readonly [RegExp, ExecResult]>
+	): ReadonlyArray<readonly [RegExp, ExecResult]> =>
+		governing(
+			[CREATE, created()],
+			[READ_BACK, okOut(JSON.stringify({body: composed()}))],
+			...extra,
+		);
+
+	const floorRed = (): ReadonlyArray<readonly [RegExp, ExecResult]> => [
+		[RUNS, runsAtHead(1, [{id: FLOOR, name: "governance-floor"}])],
+		[once(RUN), workflowRun({id: FLOOR, attempt: 1})],
+		[RERUN, okOut("")],
+		[RUN, workflowRun({id: FLOOR, attempt: 2})],
+	];
+
+	it("re-fires the red floor run and names the new attempt on stderr", async () => {
+		const shell = fakeShell(landed(...floorRed()));
+		const out = await Effect.runPromise(Effect.provide(runPost(options), shell.layer));
+		expect(out.code).toBe(0);
+		expect(shell.calls.some((call) => RERUN.test(call))).toBe(true);
+		expect(out.stderr.at(-1)).toContain(`re-fired governance-floor run ${FLOOR} at attempt 2`);
+	});
+
+	it("carries the floor's outcome in the --json record", async () => {
+		const out = await run(landed(...floorRed()), {json: true});
+		expect(JSON.parse(out.stdout)).toMatchObject({outcome: "posted", floor: "refired"});
+	});
+
+	// The verdict is landed and read back before the floor is touched, so a floor that could not be
+	// asserted is a red check to clear, never an unwritten verdict to retry.
+	it("still answers 0 when the floor cannot be asserted, and says the check may need a re-fire", async () => {
+		const out = await run(landed([RUNS, errOut("gh: Bad gateway (HTTP 502)")]));
+		expect(out.code).toBe(0);
+		expect(out.stdout).toContain("\tcreated\t");
+		expect(out.stderr.at(-1)).toContain("may still need a re-fire");
+	});
+
+	it("asserts the floor only after the verdict has been read back", async () => {
+		const shell = fakeShell(landed(...floorRed()));
+		await Effect.runPromise(Effect.provide(runPost(options), shell.layer));
+		const readBack = shell.calls.findIndex((call) => READ_BACK.test(call));
+		const refire = shell.calls.findIndex((call) => RERUN.test(call));
+		expect(readBack).toBeGreaterThanOrEqual(0);
+		expect(refire).toBeGreaterThan(readBack);
 	});
 });

--- a/packages/fabrika-cli/src/heal-ci/fixtures.test-support.ts
+++ b/packages/fabrika-cli/src/heal-ci/fixtures.test-support.ts
@@ -116,7 +116,12 @@ export const workflowRun = (shape: {
 
 export const runsAtHead = (
 	declared: number,
-	rows: ReadonlyArray<{id: number; name?: string}>,
+	rows: ReadonlyArray<{
+		id: number;
+		name?: string;
+		status?: string;
+		conclusion?: string | null;
+	}>,
 ): ExecResult =>
 	okOut(
 		JSON.stringify({
@@ -124,8 +129,8 @@ export const runsAtHead = (
 			workflow_runs: rows.map((row) => ({
 				id: row.id,
 				name: row.name ?? "ci",
-				status: "completed",
-				conclusion: "failure",
+				status: row.status ?? "completed",
+				conclusion: row.conclusion === undefined ? "failure" : row.conclusion,
 				completed_at: "2026-08-08T00:00:00Z",
 			})),
 		}),


### PR DESCRIPTION
The `governance-floor` job triggers on `pull_request` alone, so it always runs before the verdict it
looks for can exist — a governance verdict is written by an agent that has to read the diff first. It
reads comment state at its own start, finds nothing at the head, exits 18, and no comment write can
re-fire a `pull_request`-triggered job. Every governance-root PR reds at least once and only a re-run
clears it.

Per the founder ruling on the issue (2026-08-16), the gate's own post now asserts the floor at its own
head: after `governance post` has landed and read back the verdict, it reads the workflow runs at the
bound head and, when the newest `governance-floor` run there is completed-and-red, re-runs that run's
failed jobs and re-reads the run until `run_attempt` has increased.

The re-run is a re-derivation, never a claim. Nothing writes a check-run or a status, so the green a
PR ends with is one `ship floor` reached itself against live comment state. The fix stays inside
`packages/fabrika-cli/`; no workflow file changes.

The floor assertion never changes `governance post`'s exit code — by then the verdict is written and
read back, so a floor that could not be asserted is a red check, not an unwritten verdict. It reports
one stderr line and a `--json` `floor` field over a closed vocabulary: `refired`, `green`,
`in-flight`, `no-run`, `unknown`.

- `packages/fabrika-cli/src/governance/floor-assert.ts` — the assertion, with unit tests over each arm
- `packages/fabrika-cli/src/governance/post-verb.ts` — step 7, after the read-back
- the `governance` skill's `SKILL.md` and `contract.md` — the step, the vocabulary, the JSON shape, the
  `CAPABILITIES` anchor and the `actions: write` requirement

Fixes #5585

## Deviations

- **Said:** "A re-gate at a new head no longer destroys the prior head's verdict" and "a regression
  test pins the head dimension of the upsert key" (acceptance criteria 2 and 4).
  **Did:** Nothing here. Both were already discharged.
  **Why:** PR #5674 shipped them for both `governance post` and `review post` and merged into `main`
  at `08793089`, which this branch is cut from.
  **Disposition:** Out of scope by prior landing; the tests it added are on `main` and still pass.

- **Said:** "the `governance-floor` check reflects the gate's actual state at the current head, with
  no human re-run" (acceptance criterion 1).
  **Did:** The post re-fires only a floor run that has already completed red. A run still in flight is
  reported as `in-flight` and left alone.
  **Why:** GitHub refuses a re-run of an in-progress run, and the alternative — blocking the gate's
  post for minutes waiting for the job to finish — is worse than reporting the state. In practice the
  job (about a minute) finishes long before an agent has read a diff and composed a verdict.
  **Disposition:** Accepted. When it does happen the run reds after the verdict lands, `ship` refuses
  to enqueue on red and routes to `heal-ci` — an agent, not a human clicking re-run.

- **Said:** Acceptance criterion 2 names both `governance/post-verb.ts` and `review/post-verb.ts`.
  **Did:** Only `governance post` asserts the floor.
  **Why:** `ship floor` resolves the `governance` namespace only, so a review verdict's write never
  changes what the floor reads. Wiring the assertion into `review post` would fire a job whose answer
  that post cannot move.
  **Disposition:** Deliberate.

- **Said:** Nothing about test fixtures.
  **Did:** `heal-ci/fixtures.test-support.ts`'s `runsAtHead` gained optional `status` and `conclusion`
  per row.
  **Why:** The floor cases need a run at a head that is in-flight or green; the fixture hardcoded
  completed-and-failed. Defaults are unchanged, so every existing caller reads as before.
  **Disposition:** Extended in place rather than copied — a second literal for one platform response is
  how two test groups come to disagree about what the platform returns.

- **Said:** The `governance` skill's `CAPABILITIES` anchor declares the skill "performs exactly two
  writes of its own: the namespaced verdict comment and the readout artifact".
  **Did:** Step 7 adds a third write — `POST .../actions/runs/{id}/rerun-failed-jobs` — so this repair
  amends the anchor to name it and its bound, and `contract.md` now declares the `actions: write` the
  step needs.
  **Why:** The anchor is the fence a reader consults to judge whether a later `post` step overreached.
  A count left one short stops bounding anything, and the token requirement the whole fix turns on was
  declared nowhere. Both were caught by the `governance` and `review-skill` verdicts at `0b19075d`.
  **Disposition:** Fixed, not accepted. The anchor's text is deliberately widened by this PR: the
  amendment states that the third write writes no check-run and no status, so the floor's green is
  still the job's own derivation, and that a token without `actions: write` costs a red check, never a
  false one.
