### PR TITLE
review deviations demands a four-field entry grammar that no producer verb or author-facing doc requires

### DIFF
--- a/claude-plugins/fabrika/docs/wire-formats.md
+++ b/claude-plugins/fabrika/docs/wire-formats.md
@@ -38,6 +38,7 @@ does not exist yet — rather than missing; check the registry before assuming a
 | Format | Owner module | Producers | Consumers |
 | --- | --- | --- | --- |
 | `acceptance-criteria` | [`packages/fabrika-cli/src/wire/acceptance-criteria.ts`](../../../packages/fabrika-cli/src/wire/acceptance-criteria.ts) | `triage`, `build-epic` | `build`, `review` |
+| `deviations` | [`packages/fabrika-cli/src/wire/deviations.ts`](../../../packages/fabrika-cli/src/wire/deviations.ts) | `build`, `build-ui`, `build-epic` | `review`, `review-ui` |
 | `verdict-marker` | [`packages/fabrika-cli/src/wire/verdict-marker.ts`](../../../packages/fabrika-cli/src/wire/verdict-marker.ts) | `review`, `check-epic-plan`, `governance` | `build`, `ship` |
 | `slice-handoff` | [`packages/fabrika-cli/src/wire/slice-handoff.ts`](../../../packages/fabrika-cli/src/wire/slice-handoff.ts) | `build-epic` | `build` |
 | `map-ticket` | [`packages/fabrika-cli/src/wire/map-ticket.ts`](../../../packages/fabrika-cli/src/wire/map-ticket.ts) | `map` | `map` |
@@ -61,6 +62,26 @@ recognition reads back as *a body with no criteria*, which is byte-identical to 
 genuinely has none, so a grader scores against nothing and passes. Reading through the owner module
 is what keeps a drifted block reportable as a defect instead of arriving as a plausible empty
 answer.
+
+### `deviations`
+
+This is what a PR body discloses about where the build departed from its contract — the `##
+Deviations` section, carried as four-field entries or the literal `None.`. It is the one format
+whose two sides used to disagree *by construction*: `build pr` asked only that the heading exist
+with something under it, while the review reader dropped every bullet carrying no `Said` field and
+then called a section of zero surviving entries malformed. A body that fully satisfied the producer
+was therefore guaranteed to fail the consumer closed, and no author-facing doc stated the grammar
+either side judged against (#5566). Registering it is what makes that unrepresentable: the entry
+shape is written down once, in the owner module, and both sides resolve it there — so the refusal
+now lands at the point the body is written, naming the missing field, instead of costing a review
+round that could not say what was wrong.
+
+The read is total over three answers where the section has four meanings, so `None.` is a `Found`
+carrying a tag of its own rather than an empty entry list. That is the load-bearing distinction:
+`None.` is a *checked* claim — an author who considered the question and has nothing to disclose —
+and folding it into `Absent` is how "never considered it" comes to read as "nothing to disclose".
+An entry states all four fields. The label is a routing hint and stays optional, but a disclosure
+missing *Why* or *Disposition* states what changed without stating whether anyone accepted it.
 
 ### `verdict-marker`
 

--- a/claude-plugins/fabrika/skills/build/SKILL.md
+++ b/claude-plugins/fabrika/skills/build/SKILL.md
@@ -145,10 +145,29 @@ Done only on `PUSH-VERDICT: MOVED`. `UNKNOWN` is not a success with a caveat —
 unverified push is how "pushed" and "the remote never heard" become one claim.
 
 Author the PR body yourself: a human-first summary, `Fixes #<n>` only when every acceptance
-criterion is met (else `Part of #<n>`, and pass `--partial`), and a `## Deviations` section — the verb refuses a body
-without the heading, and an empty one is a lie if you deviated. **Assert no control-plane
-verdict in it**: that classification is the merge gate's, and a body claiming "not control-plane"
-has been wrong before.
+criterion is met (else `Part of #<n>`, and pass `--partial`), and a `## Deviations` section — the
+verb refuses a body without the heading, and an empty one is a lie if you deviated. **Assert no
+control-plane verdict in it**: that classification is the merge gate's, and a body claiming "not
+control-plane" has been wrong before.
+
+**The section has one grammar, and both the verb that opens the PR and the gate that reads it back
+resolve the same module for it** ([`wire/deviations.ts`](../../../../packages/fabrika-cli/src/wire/deviations.ts)).
+Under the exact heading `## Deviations`, write either the literal `None.` or one bullet per
+deviation, each stating all four fields:
+
+```markdown
+## Deviations
+
+- **Out-of-scope change** — **Said:** #4312 names the editor only. **Did:** also fixed the same
+  focus steal in the comment box. **Why:** both call the one `refocus()` helper this changes.
+  **Disposition:** stated here.
+```
+
+An optional bold class lead (`Scope narrowing`, `Governing-ADR departure`, `Known defect left
+unfixed`, `Declined guidance`, `Guard or gate bypassed`, `Pre-existing test or fixture changed`,
+`Out-of-scope change`) routes the entry; the gate matches an entry's substance, never its label. A
+prose bullet with no fields is refused by `build pr` at the point you write it — that refusal used
+to arrive a whole review round later, and could not say what was wrong (#5566).
 
 **State what changed and why, and stop.** Two things earn their lines: the summary, and
 `## Deviations` — deviations catch real defects, so state each plainly and never trim one for
@@ -162,8 +181,8 @@ fabrika build pr 4312 <<'EOF'
 EOF
 ```
 
-The verb is the guard: it refuses leaks, stray closing keywords, a missing Deviations heading, and
-reads back what landed. Then hand off and release:
+The verb is the guard: it refuses leaks, stray closing keywords, a Deviations section the review
+gate would read as malformed, and reads back what landed. Then hand off and release:
 
 ```bash
 fabrika build note 4312 <<'EOF'

--- a/claude-plugins/fabrika/skills/build/contract.md
+++ b/claude-plugins/fabrika/skills/build/contract.md
@@ -1382,9 +1382,15 @@ The guards, in order, all before any write:
 
 1. **stdin non-empty** (`3`).
 2. **no machine-local path** — the imported `leaks.ts` predicates (`5`, `6`).
-3. **body shape** (`4`): a `## Deviations` heading is present **and non-empty** — at least one
-   non-blank line before the next heading or EOF; "None." is content, silence is not (the
-   *truth* of the section stays the skill's — a verb can force the author to write, not to be
+3. **body shape** (`4`): the `## Deviations` section reads `Found` through the registered
+   `deviations` wire format
+   ([`packages/fabrika-cli/src/wire/deviations.ts`](../../../../packages/fabrika-cli/src/wire/deviations.ts)) —
+   the same module `review deviations` resolves against, so a body this verb accepts can never
+   fail that gate as malformed (#5566). That means: the heading is exactly `## Deviations`, and
+   under it either the literal `None.` or one or more entries, each stating all four of
+   `**Said:**` / `**Did:**` / `**Why:**` / `**Disposition:**`. "None." is content, silence is not,
+   and a prose bullet is refused here rather than a review round later (the *truth* of the
+   section stays the skill's — a verb can force the author to write, not to be
    honest); exactly one closing-keyword line, targeting `<number>` and matching `--partial`
    (`Fixes #4312` without `--partial`, `Part of #4312` with it); no second closing keyword aimed
    at any other issue (#4471's stray auto-close).
@@ -1404,7 +1410,7 @@ posts the literal string (#4683).
 | Code | Trigger |
 |---|---|
 | `3` | stdin held nothing |
-| `4` | `## Deviations` missing or empty, or the closing-keyword line is absent, duplicated, mistargeted, or contradicts `--partial` |
+| `4` | the `## Deviations` section does not read `Found` through the `deviations` wire format — absent, empty, a drifted heading, or an entry short a field — or the closing-keyword line is absent, duplicated, mistargeted, or contradicts `--partial` |
 | `5` | the body carries a machine-local path |
 | `6` | the body is a bare `@` path reference |
 | `7` | the issue is proven absent or closed |
@@ -1420,7 +1426,7 @@ posts the literal string (#4683).
 | Message (stderr) | Code | Kind |
 |---|---|---|
 | `build pr: stdin held nothing — the body is the input.` | 3 | refusal |
-| `build pr: the body has no "## Deviations" heading, or it is empty — state deviations, or state "None."` | 4 | refusal |
+| `build pr: the body's "## Deviations" section is not readable — <the wire format's reason>. State each deviation as an entry, or state "None."` | 4 | refusal |
 | `build pr: the body says "Fixes #<n>" but --partial was given — a partial PR must say "Part of #<n>".` | 4 | refusal |
 | `build pr: the body carries a closing keyword aimed at #<m> — this PR serves #<n>.` | 4 | refusal |
 | `build pr: the body carries a machine-local path: <first hit> — redact before posting.` | 5 | refusal |
@@ -1447,14 +1453,25 @@ Fixes #4312
 Editor focus now survives a save: the toolbar re-render no longer steals it.
 
 ## Deviations
-None.
+
+- **Pre-existing test or fixture changed** — **Said:** the fixture asserts focus lands on the
+  toolbar after a save. **Did:** rewrote it to assert focus stays in the editor. **Why:** it
+  asserted the defect, so keeping it would have red-lit the fix. **Disposition:** stated here;
+  no other test covered the old behaviour.
+- **Out-of-scope change** — **Said:** #4312 names the editor only. **Did:** also fixed the same
+  steal in the comment box. **Why:** both call the one `refocus()` helper this changes, so
+  leaving it would have shipped a knowingly half-fixed helper. **Disposition:** stated here.
 EOF
 {"answer":"opened","number":4318,"url":"https://github.com/kamp-us/phoenix/pull/4318"}
 ```
 
+The section is `None.` when there is nothing to disclose, and that is a *checked* claim rather than
+a skip — `review deviations` reads it beside the diff's Tier-M scan, so a `None.` over a suppressed
+lint rule is a falsified disclosure the gate can see in one read.
+
 ```
-$ printf 'Fixes #4312\n\nbody with no deviations heading\n' | fabrika build pr 4312
-build pr: the body has no "## Deviations" heading, or it is empty — state deviations, or state "None."
+$ printf 'Fixes #4312\n\n## Deviations\n\n- narrowed the scope a bit.\n' | fabrika build pr 4312
+build pr: the body's "## Deviations" section is not readable — an entry carries no **Said:**, **Did:**, **Why:**, **Disposition:** — every entry states **Said:** / **Did:** / **Why:** / **Disposition:**. State each deviation as an entry, or state "None."
 $ echo $?
 4
 ```
@@ -1462,6 +1479,8 @@ $ echo $?
 **Grounding**
 
 - #4542 — the Deviations check must block, not warn.
+- #5566 — the check and `review deviations` asked for different shapes, so a conforming body was
+  guaranteed to fail the gate closed; both now read the one registered `deviations` format.
 - #4471 — a stray closing keyword auto-closed an issue the PR did not fix.
 - #4153 — a false control-plane negative shipped in a PR body; the claim is now unrepresentable.
 - #4683 / #3086 — the `-f body=@file` literal and the temp-path leak; both guarded here.

--- a/claude-plugins/fabrika/skills/review/contract.md
+++ b/claude-plugins/fabrika/skills/review/contract.md
@@ -708,15 +708,22 @@ fabrika review deviations 4321 [--sha <head>] [--repo <owner/name>] [--json]
 | `--json` | boolean | no | `false` | emit the result object |
 
 **Output** — machine channel. First line: `deviations\t<found|none-declared|absent|malformed>`.
-On `found`, one line per entry: `entry\t<class-label-or-->\t<first-line-of-Said>` (the null
-token is the ASCII hyphen `-`, the same one `review verdicts` uses). Then the
+On `found`, one line per entry: `entry\t<class-label-or-->\t<Said>` (the null
+token is the ASCII hyphen `-`, the same one `review verdicts` uses; a **Said** authored across
+wrapped lines is carried in full, collapsed to one line, so the answer never holds a partial clause). Then the
 Tier-M scan over the head diff, one line per hit:
 `tier-m\t<suppression|removed-assertion>\t<file>:<line>\t<token>` — the mechanically-detectable
 §DEV classes (an in-diff `biome-ignore` / `@ts-expect-error` / `test.skip` / `.only`; a deleted
 assertion line), each a fact the judgment layer matches against the disclosed entries.
 
 `none-declared` is the literal `None.` body; `absent` is **no `## Deviations` heading at all**;
-`malformed` is a heading whose section fits neither shape. The three stay distinct on the wire
+`malformed` is a heading whose section fits neither shape. Which shapes those are is not stated
+here: the grammar is the registered `deviations` wire format
+([`packages/fabrika-cli/src/wire/deviations.ts`](../../../../packages/fabrika-cli/src/wire/deviations.ts)),
+which `build pr` refuses against at creation, so a body that verb accepted never reaches this one as
+`malformed` (#5566). On `malformed` and `absent` the verb prints the format's own reason as a
+diagnostic — a gate that answers a bare `malformed` never tells an author which field is missing.
+The three stay distinct on the wire
 because the skill's verdict vocabulary depends on the distinction: absent-on-owing fails closed,
 `None.` is a checked claim, and this verb is what makes the claim checkable — a `None.` printed
 beside a non-empty Tier-M list is a falsified disclosure the caller can see in one read.

--- a/packages/fabrika-cli/src/build/pr-body.ts
+++ b/packages/fabrika-cli/src/build/pr-body.ts
@@ -3,9 +3,11 @@
  *
  * Three defects, each with a scar behind it:
  *
- * - **A missing or empty `## Deviations` section** (#4542). The check blocks rather than warns, and
- *   "None." counts while silence does not — the verb can force the author to *write*, never to be
- *   honest, so the section's truth stays the skill's problem and its presence is this one's.
+ * - **A `## Deviations` section the review gate cannot read** (#4542, #5566). The check blocks rather
+ *   than warns, and "None." counts while silence does not — the verb can force the author to *write*,
+ *   never to be honest, so the section's truth stays the skill's problem and its shape is this one's.
+ *   The shape itself is not restated here: it is `../wire/deviations.ts`, the same registered format
+ *   `review deviations` reads, so a body this verb accepts cannot fail that gate as malformed.
  * - **A stray closing keyword** (#4471). One closing line, aimed at this PR's own issue; a second
  *   aimed anywhere else auto-closed an issue the PR did not fix.
  * - **A classification claim** (#4153). CODEOWNERS decides control-plane membership at the merge gate
@@ -16,6 +18,8 @@
  * and "refuse any spelling of it" is two guards. Fences and block quotes are excluded before matching,
  * so a body that *quotes* a classification to discuss it is not refused for the quotation.
  */
+
+import {read as readDeviations} from "../wire/deviations.ts";
 
 /** GitHub's own auto-closing keywords. A body may carry exactly one, aimed at its own issue. */
 const CLOSING_RE = /\b(close[sd]?|fix(e[sd])?|resolve[sd]?)\s+#(\d+)\b/gi;
@@ -47,17 +51,10 @@ export const proseOf = (body: string): string => {
 	return lines.join("\n");
 };
 
-/** Whether a `## Deviations` heading is present with at least one non-blank line under it. */
-export const hasDeviations = (body: string): boolean => {
-	const lines = body.split("\n");
-	const start = lines.findIndex((line) => /^##\s+Deviations\s*$/.test(line.trim()));
-	if (start === -1) return false;
-	for (let i = start + 1; i < lines.length; i++) {
-		const text = (lines[i] ?? "").trim();
-		if (text === "") continue;
-		return !/^#{1,6}\s+/.test(text);
-	}
-	return false;
+/** Why the body's `## Deviations` section is not readable, or `null` when the wire format reads it. */
+export const deviationsDefect = (body: string): string | null => {
+	const result = readDeviations(body);
+	return result._tag === "Found" ? null : result.reason;
 };
 
 /** Every issue number a closing keyword in `prose` aims at, in order. */
@@ -76,7 +73,8 @@ export const classificationIn = (prose: string): string | null =>
 	CLASSIFICATION_PATTERNS.find(({re}) => re.test(prose))?.name ?? null;
 
 export type BodyDefect =
-	| {readonly _tag: "NoDeviations"}
+	/** The section is absent, or present in a shape the review gate reads as malformed. */
+	| {readonly _tag: "NoDeviations"; readonly reason: string}
 	/** A closing keyword aimed somewhere other than this PR's issue. */
 	| {readonly _tag: "StrayClosing"; readonly target: number}
 	/** `--partial` was given and the body still auto-closes. */
@@ -93,7 +91,8 @@ export type BodyDefect =
  * forgot, and a body missing both should say so about the section rather than about the link.
  */
 export const bodyDefect = (body: string, issue: number, partial: boolean): BodyDefect | null => {
-	if (!hasDeviations(body)) return {_tag: "NoDeviations"};
+	const deviations = deviationsDefect(body);
+	if (deviations !== null) return {_tag: "NoDeviations", reason: deviations};
 
 	const prose = proseOf(body);
 	const targets = closingTargets(prose);

--- a/packages/fabrika-cli/src/build/pr-body.unit.test.ts
+++ b/packages/fabrika-cli/src/build/pr-body.unit.test.ts
@@ -1,19 +1,31 @@
 import {describe, expect, it} from "vitest";
-import {bodyDefect, classificationIn, hasDeviations, proseOf} from "./pr-body.ts";
+import {bodyDefect, classificationIn, deviationsDefect, proseOf} from "./pr-body.ts";
 
 const body = (extra: string) => `Fixes #4312\n\nsome prose.\n${extra}\n## Deviations\n\nNone.\n`;
 
 describe("the Deviations section blocks, and 'None.' counts", () => {
-	it("accepts a section with content", () => {
-		expect(hasDeviations("## Deviations\nNone.\n")).toBe(true);
+	it("accepts the `None.` claim", () => {
+		expect(deviationsDefect("## Deviations\n\nNone.\n")).toBeNull();
+	});
+
+	it("accepts a four-field entry", () => {
+		const section =
+			"## Deviations\n\n- **Scope narrowing** — **Said:** four gates. **Did:** three. **Why:** the fourth is trivial. **Disposition:** stated here.\n";
+		expect(deviationsDefect(section)).toBeNull();
 	});
 
 	it("refuses a missing section", () => {
-		expect(hasDeviations("Fixes #4312\n")).toBe(false);
+		expect(deviationsDefect("Fixes #4312\n")).not.toBeNull();
 	});
 
 	it("refuses a section whose only content is the next heading — silence is not content (#4542)", () => {
-		expect(hasDeviations("## Deviations\n\n## Testing\nran it\n")).toBe(false);
+		expect(deviationsDefect("## Deviations\n\n## Testing\nran it\n")).not.toBeNull();
+	});
+
+	it("refuses a prose bullet at creation, naming the fields it owes (#5566)", () => {
+		const reason = deviationsDefect("## Deviations\n\n- narrowed the scope a bit.\n");
+		expect(reason).toContain("**Said:**");
+		expect(reason).toContain("**Disposition:**");
 	});
 });
 
@@ -23,7 +35,7 @@ describe("the closing keyword", () => {
 	});
 
 	it("refuses a stray keyword aimed elsewhere — the #4471 auto-close", () => {
-		expect(bodyDefect(`${body("")}\nAlso closes #999.\n`, 4312, false)).toEqual({
+		expect(bodyDefect(body("\nAlso closes #999.\n"), 4312, false)).toEqual({
 			_tag: "StrayClosing",
 			target: 999,
 		});
@@ -34,7 +46,7 @@ describe("the closing keyword", () => {
 	});
 
 	it("refuses a duplicated keyword aimed at the same issue", () => {
-		expect(bodyDefect(`${body("")}\nfixes #4312 again\n`, 4312, false)).toEqual({
+		expect(bodyDefect(body("\nfixes #4312 again\n"), 4312, false)).toEqual({
 			_tag: "DuplicateClosing",
 		});
 	});
@@ -45,7 +57,7 @@ describe("the closing keyword", () => {
 	});
 
 	it("puts the Deviations refusal ahead of the link refusal when both are wrong", () => {
-		expect(bodyDefect("no link, no section", 4312, false)).toEqual({_tag: "NoDeviations"});
+		expect(bodyDefect("no link, no section", 4312, false)?._tag).toBe("NoDeviations");
 	});
 });
 

--- a/packages/fabrika-cli/src/build/pr-verb.ts
+++ b/packages/fabrika-cli/src/build/pr-verb.ts
@@ -56,7 +56,7 @@ const shapeRefusal = (
 		case "NoDeviations":
 			return refuse(
 				BAD_SECTIONS,
-				`${VERB}: the body has no "## Deviations" heading, or it is empty — state deviations, or state "None."`,
+				`${VERB}: the body's "## Deviations" section is not readable — ${defect.reason}. State each deviation as an entry, or state "None."`,
 			);
 		case "StrayClosing":
 			return refuse(

--- a/packages/fabrika-cli/src/build/pr-verb.unit.test.ts
+++ b/packages/fabrika-cli/src/build/pr-verb.unit.test.ts
@@ -91,12 +91,15 @@ describe("runPr — the body guards run before any write", () => {
 		const out = await run([], withBody("Fixes #4312\n\njust prose\n"));
 		expect(out.code).toBe(BAD_SECTIONS);
 		expect(out.stderr.at(-1)).toBe(
-			'build pr: the body has no "## Deviations" heading, or it is empty — state deviations, or state "None."',
+			'build pr: the body\'s "## Deviations" section is not readable — no heading in the body reaches for "## Deviations". State each deviation as an entry, or state "None."',
 		);
 	});
 
 	it("refuses a stray closing keyword on 4 (#4471)", async () => {
-		const out = await run([], withBody(`${BODY}\nAlso closes #999.\n`));
+		const out = await run(
+			[],
+			withBody(BODY.replace("## Deviations", "Also closes #999.\n\n## Deviations")),
+		);
 		expect(out.code).toBe(BAD_SECTIONS);
 		expect(out.stderr.at(-1)).toBe(
 			"build pr: the body carries a closing keyword aimed at #999 — this PR serves #4312.",

--- a/packages/fabrika-cli/src/review/command.ts
+++ b/packages/fabrika-cli/src/review/command.ts
@@ -186,7 +186,7 @@ const deviations = leafCommand(
 ).pipe(
 	Command.withShortDescription("The PR body's Deviations state, entries and token scan."),
 	Command.withDescription(
-		"Report the PR body's `## Deviations` state — found | none-declared | absent | malformed, three distinct facts — with its entries and the Tier-M token scan over the diff at the bound commit. First stdout line is `deviations\\t<state>`, then one `entry\\t<class-label-or-->\\t<first-line-of-Said>` line per entry and one `tier-m\\t<kind>\\t<file>:<line>\\t<token>` line per hit. Exits 7 (PR proven absent), 10 (--sha is not a head SHA), 11 (the body or diff could not be read, or the commit could not be bound — the disclosure state is UNKNOWN, never `none`), 12 (--sha is not the PR's head — re-scope, never re-bind), 13 (a partial diff must not print a partial scan beside a disclosure claim). Example: fabrika review deviations 4321 --sha 03135b91",
+		"Report the PR body's `## Deviations` state — found | none-declared | absent | malformed, three distinct facts — with its entries and the Tier-M token scan over the diff at the bound commit. First stdout line is `deviations\\t<state>`, then one `entry\\t<class-label-or-->\\t<Said>` line per entry and one `tier-m\\t<kind>\\t<file>:<line>\\t<token>` line per hit. Exits 7 (PR proven absent), 10 (--sha is not a head SHA), 11 (the body or diff could not be read, or the commit could not be bound — the disclosure state is UNKNOWN, never `none`), 12 (--sha is not the PR's head — re-scope, never re-bind), 13 (a partial diff must not print a partial scan beside a disclosure claim). Example: fabrika review deviations 4321 --sha 03135b91",
 	),
 );
 

--- a/packages/fabrika-cli/src/review/deviations-verb.ts
+++ b/packages/fabrika-cli/src/review/deviations-verb.ts
@@ -109,6 +109,9 @@ export const runDeviations = (
 		}
 
 		const section = readDeviations(pull.body);
+		if (section.reason !== null) {
+			diagnostics.push(`${VERB}: ${section.state} — ${section.reason}.`);
+		}
 		const hits = tierMHits(diff);
 		return json
 			? answer(

--- a/packages/fabrika-cli/src/review/deviations-verb.unit.test.ts
+++ b/packages/fabrika-cli/src/review/deviations-verb.unit.test.ts
@@ -116,7 +116,7 @@ describe("runDeviations", () => {
 
 	it("prints an entry's label and the first line of its Said", async () => {
 		const body =
-			"## Deviations\n\n- **Pre-existing test or fixture changed** — **Said:** replaced the two-decimal rendering assertion. **Did:** dropped it.";
+			"## Deviations\n\n- **Pre-existing test or fixture changed** — **Said:** replaced the two-decimal rendering assertion. **Did:** dropped it. **Why:** it asserted the defect. **Disposition:** stated here.";
 		const out = await run(happy({body}));
 		expect(out.stdout).toBe(
 			["deviations\tfound", "entry\t6\treplaced the two-decimal rendering assertion.", ""].join(

--- a/packages/fabrika-cli/src/review/deviations.ts
+++ b/packages/fabrika-cli/src/review/deviations.ts
@@ -1,132 +1,53 @@
 /**
- * The PR body's `## Deviations` section: which of four states it is in, and what it discloses.
+ * `review deviations`' view of the PR body's `## Deviations` section: which of four states it is in,
+ * and what it discloses.
  *
- * The four states stay distinct on the wire because the skill's verdict vocabulary depends on the
- * distinction — absent-on-owing fails closed, `None.` is a *checked* claim, and this reader is what
- * makes the claim checkable. Collapsing `absent` into `none-declared` is how "never considered it"
- * comes to read as "nothing to disclose".
+ * The grammar is not here. It lives in `../wire/deviations.ts`, the registered format both this
+ * reader and `build pr`'s body-shape check resolve against — one writer and one reader cannot
+ * disagree about a shape neither of them owns (#5566). This module is the projection from the wire's
+ * three answers onto the four states the review verdict vocabulary needs, and nothing else.
  *
- * v1's §DEV supplied the semantics — the four fields, the seven classes, the M/R/D tiers — and was
- * read as prior art, never called (ADR 0238). Its heading detection is triplicated in awk across
- * three surfaces; this is one reader.
+ * The fourth state is why a projection is needed at all: `None.` is a *checked* claim, and
+ * collapsing it into `absent` is how "never considered it" comes to read as "nothing to disclose".
+ * The wire carries it as a `Found` of its own tag; this reader names it `none-declared`.
  */
+
+import {read as readWire} from "../wire/deviations.ts";
 
 export type DeviationsState = "found" | "none-declared" | "absent" | "malformed";
 
 export interface DeviationEntry {
 	/** The class label `1`–`7`, or `null` when the entry carries none this reader recognises. */
 	readonly label: string | null;
-	/** The first line of the entry's **Said** field — what the spec asked. */
+	/** The entry's **Said** field — what the spec asked. */
 	readonly said: string;
 }
 
 export interface DeviationsRead {
 	readonly state: DeviationsState;
 	readonly entries: ReadonlyArray<DeviationEntry>;
+	/**
+	 * Why the section is not readable, on `absent` and `malformed` — the wire's own reason.
+	 *
+	 * Carried so the verb can say *what* drifted. A gate that answers a bare `malformed` tells an
+	 * author their body is wrong and never which field is missing, which is the round this issue's
+	 * defect cost every time it fired.
+	 */
+	readonly reason: string | null;
 }
 
-/**
- * The seven classes, keyed by their canonical names normalised to letters.
- *
- * The vocabulary is **this contract's, enumerated closed** — never a pointer into v1's prose. The
- * label is a routing hint, not the disclosure: a gate matches an entry's substance, never its label,
- * so an unrecognised label costs a `-` and nothing else.
- */
-const CLASSES: ReadonlyArray<readonly [string, string]> = [
-	["1", "scopenarrowing"],
-	["2", "governingadrdeparture"],
-	["3", "knowndefectleftunfixed"],
-	["4", "declinedguidance"],
-	["5", "guardorgatebypassed"],
-	["6", "preexistingtestorfixturechanged"],
-	["7", "outofscopechange"],
-];
-
-const HEADING = /^ {0,3}##[ \t]+(.*?)[ \t]*#*[ \t]*$/;
-const ANY_HEADING = /^ {0,3}#{1,6}[ \t]+/;
-const FENCE = /^ {0,3}(?:```|~~~)/;
-const normalize = (text: string): string => text.toLowerCase().replace(/[^a-z0-9]/g, "");
-
-/** The lines under the `## Deviations` heading, or `null` when the body carries no such heading. */
-const sectionOf = (body: string): ReadonlyArray<string> | null => {
-	const lines = body.split("\n");
-	let start = -1;
-	let fenced = false;
-	for (const [index, line] of lines.entries()) {
-		if (FENCE.test(line)) {
-			fenced = !fenced;
-			continue;
-		}
-		if (fenced) continue;
-		if (start >= 0) {
-			if (ANY_HEADING.test(line)) return lines.slice(start, index);
-			continue;
-		}
-		const heading = HEADING.exec(line);
-		if (heading !== null && normalize(heading[1] ?? "") === "deviations") start = index + 1;
-	}
-	return start >= 0 ? lines.slice(start) : null;
-};
-
-const labelOf = (lead: string): string | null => {
-	const key = normalize(lead);
-	const named = CLASSES.find(([, name]) => key.startsWith(name));
-	if (named !== undefined) return named[0];
-	const numeric = /^([1-7])\b/.exec(lead.trim());
-	return numeric?.[1] ?? null;
-};
-
-/**
- * The `**Said:**` field's first line, or `null` when the bullet carries no `Said` at all.
- *
- * The emphasis is admitted on both sides of the colon: the canonical §DEV entry writes `**Said:**`,
- * closing the bold *after* the punctuation, so a pattern anchored only on `**Said**:` would leave the
- * closer at the head of every value it read.
- */
-const saidOf = (text: string): string | null => {
-	const at = /\*{0,2}said\*{0,2}\s*:\s*\*{0,2}/i.exec(text);
-	if (at === null) return null;
-	const rest = text.slice(at.index + at[0].length);
-	const end = /\*{0,2}(?:did|why|disposition)\*{0,2}\s*:/i.exec(rest);
-	const value = (end === null ? rest : rest.slice(0, end.index)).trim();
-	return value.split("\n")[0]?.trim() ?? "";
-};
-
-/**
- * Each top-level `- ` bullet in the section, joined with its continuation lines.
- *
- * An entry spans several lines in practice — the four fields wrap — so a per-line read would report
- * one entry as four and lose every `Said` that started on the second line.
- */
-const bulletsOf = (section: ReadonlyArray<string>): ReadonlyArray<string> => {
-	const bullets: string[] = [];
-	for (const line of section) {
-		if (/^[ \t]{0,3}[-*][ \t]+/.test(line)) bullets.push(line.replace(/^[ \t]{0,3}[-*][ \t]+/, ""));
-		else if (bullets.length > 0 && line.trim() !== "") bullets[bullets.length - 1] += `\n${line}`;
-	}
-	return bullets;
-};
-
-/** The bold or plain lead of a bullet — `**Scope narrowing**` — before the first field. */
-const leadOf = (bullet: string): string => {
-	const bold = /^\s*\*\*(.+?)\*\*/.exec(bullet);
-	if (bold?.[1] !== undefined) return bold[1];
-	return bullet.split(/[—–:]/)[0] ?? "";
-};
-
 export const readDeviations = (body: string): DeviationsRead => {
-	const section = sectionOf(body);
-	if (section === null) return {state: "absent", entries: []};
-
-	const text = section.join("\n").trim();
-	if (text === "") return {state: "malformed", entries: []};
-	if (/^none\.?$/i.test(text)) return {state: "none-declared", entries: []};
-
-	const entries: DeviationEntry[] = [];
-	for (const bullet of bulletsOf(section)) {
-		const said = saidOf(bullet);
-		if (said === null) continue;
-		entries.push({label: labelOf(leadOf(bullet)), said});
+	const result = readWire(body);
+	if (result._tag === "Absent") return {state: "absent", entries: [], reason: result.reason};
+	if (result._tag === "Malformed") {
+		return {state: "malformed", entries: [], reason: result.reason};
 	}
-	return entries.length === 0 ? {state: "malformed", entries: []} : {state: "found", entries};
+	if (result.value._tag === "NoneDeclared") {
+		return {state: "none-declared", entries: [], reason: null};
+	}
+	return {
+		state: "found",
+		entries: result.value.entries.map(({label, said}) => ({label, said})),
+		reason: null,
+	};
 };

--- a/packages/fabrika-cli/src/review/deviations.unit.test.ts
+++ b/packages/fabrika-cli/src/review/deviations.unit.test.ts
@@ -1,4 +1,5 @@
 import {describe, expect, it} from "vitest";
+import {bodyDefect} from "../build/pr-body.ts";
 import {readDeviations} from "./deviations.ts";
 
 const ENTRY =
@@ -6,16 +7,16 @@ const ENTRY =
 
 describe("readDeviations", () => {
 	it("reads absent when the body carries no `## Deviations` heading at all", () => {
-		expect(readDeviations("Fixes #1\n\n## Summary\n\nstuff")).toEqual({
-			state: "absent",
-			entries: [],
-		});
+		const result = readDeviations("Fixes #1\n\n## Summary\n\nstuff");
+		expect(result.state).toBe("absent");
+		expect(result.entries).toEqual([]);
 	});
 
 	it("reads none-declared for the literal `None.`, which is a CHECKED claim", () => {
 		expect(readDeviations("## Deviations\n\nNone.\n")).toEqual({
 			state: "none-declared",
 			entries: [],
+			reason: null,
 		});
 	});
 
@@ -25,33 +26,48 @@ describe("readDeviations", () => {
 		);
 	});
 
-	it("reads an entry's class label and the first line of its Said", () => {
+	it("reads an entry's class label and its Said", () => {
 		expect(readDeviations(`## Deviations\n\n${ENTRY}\n`)).toEqual({
 			state: "found",
 			entries: [{label: "1", said: "the AC asks for four gates."}],
+			reason: null,
 		});
 	});
 
 	it("prints `-` for an entry whose label this reader does not recognise", () => {
-		const body = "## Deviations\n\n- **Something else** — **Said:** a thing. **Did:** another.";
+		const body = `## Deviations\n\n- **Something else** — **Said:** a thing. **Did:** another. **Why:** a reason. **Disposition:** stated.`;
 		expect(readDeviations(body).entries[0]?.label).toBeNull();
 	});
 
 	it("accepts a bare numeric label too — the label is a routing hint, not the disclosure", () => {
-		const body = "## Deviations\n\n- **6** — **Said:** the fixture asserted the defect.";
+		const body = `## Deviations\n\n- **6** — **Said:** the fixture asserted the defect. **Did:** replaced it. **Why:** it asserted the bug. **Disposition:** stated.`;
 		expect(readDeviations(body).entries[0]?.label).toBe("6");
 	});
 
 	it("joins an entry's continuation lines, so one wrapped entry is one entry", () => {
-		const body = `## Deviations\n\n- **Declined guidance**\n  **Said:** take the reviewer's shape.\n  **Did:** kept mine.\n`;
+		const body = `## Deviations\n\n- **Declined guidance**\n  **Said:** take the reviewer's shape.\n  **Did:** kept mine.\n  **Why:** it reads the label.\n  **Disposition:** stated here.\n`;
 		const result = readDeviations(body);
 		expect(result.entries).toHaveLength(1);
 		expect(result.entries[0]).toEqual({label: "4", said: "take the reviewer's shape."});
 	});
 
+	it("carries a Said that wraps in full, collapsed to one line", () => {
+		const body = `## Deviations\n\n- **Said:** the criterion asks for the whole clause,\n  including the half that wrapped.\n  **Did:** kept it. **Why:** #5572. **Disposition:** stated.\n`;
+		expect(readDeviations(body).entries[0]?.said).toBe(
+			"the criterion asks for the whole clause, including the half that wrapped.",
+		);
+	});
+
 	it("reads a heading whose section fits neither shape as malformed", () => {
 		expect(readDeviations("## Deviations\n\nprobably nothing?\n").state).toBe("malformed");
 		expect(readDeviations("## Deviations\n\n").state).toBe("malformed");
+	});
+
+	it("names what drifted on malformed, so the author is told which field is missing", () => {
+		const body = "## Deviations\n\n- **Said:** a. **Did:** b. **Why:** c.\n";
+		const result = readDeviations(body);
+		expect(result.state).toBe("malformed");
+		expect(result.reason).toContain("**Disposition:**");
 	});
 
 	it("stops at the next heading, so a later section is not read as an entry", () => {
@@ -63,4 +79,44 @@ describe("readDeviations", () => {
 		const body = "before\n\n```\n## Deviations\n\nNone.\n```\n\nafter";
 		expect(readDeviations(body).state).toBe("absent");
 	});
+});
+
+/**
+ * The defect #5566 named: the producer accepted bodies the consumer failed closed on, and nothing
+ * ran one body through both sides. These do, over the shapes each side used to answer differently.
+ */
+describe("what `build pr` accepts is never read as malformed", () => {
+	const accepted = (body: string): boolean => bodyDefect(body, 4312, false) === null;
+
+	const bodies: ReadonlyArray<readonly [string, string]> = [
+		["a four-field entry", `Fixes #4312\n\ndid a thing.\n\n## Deviations\n\n${ENTRY}\n`],
+		[
+			"a wrapped four-field entry",
+			`Fixes #4312\n\ndid a thing.\n\n## Deviations\n\n- **Out-of-scope change**\n  **Said:** one file.\n  **Did:** two.\n  **Why:** the second stated the same rule.\n  **Disposition:** stated here.\n`,
+		],
+		["the `None.` claim", "Fixes #4312\n\ndid a thing.\n\n## Deviations\n\nNone.\n"],
+	];
+
+	for (const [shape, body] of bodies) {
+		it(`accepts ${shape}, and the review reader agrees`, () => {
+			expect(accepted(body)).toBe(true);
+			expect(readDeviations(body).state).not.toBe("malformed");
+		});
+	}
+
+	const refused: ReadonlyArray<readonly [string, string]> = [
+		["a bare prose bullet", "Fixes #4312\n\n## Deviations\n\n- narrowed the scope a bit.\n"],
+		["an empty section", "Fixes #4312\n\n## Deviations\n\n## Testing\n\nran it\n"],
+		["no section at all", "Fixes #4312\n\ndid a thing.\n"],
+		[
+			"an entry missing a field",
+			"Fixes #4312\n\n## Deviations\n\n- **Said:** a. **Did:** b. **Why:** c.\n",
+		],
+	];
+
+	for (const [shape, body] of refused) {
+		it(`refuses ${shape} at creation, where the review round used to catch it`, () => {
+			expect(accepted(body)).toBe(false);
+		});
+	}
 });

--- a/packages/fabrika-cli/src/wire/deviations.ts
+++ b/packages/fabrika-cli/src/wire/deviations.ts
@@ -1,0 +1,420 @@
+/**
+ * The PR body's `## Deviations` section — the one place its grammar is stated.
+ *
+ * The section had two contracts that disagreed: `build pr` asked only that the heading exist with
+ * something under it, while the review reader dropped every bullet carrying no `Said` field and then
+ * called a section of zero surviving entries `malformed`. A body that fully satisfied the producer
+ * was therefore guaranteed to fail the consumer closed, and no author-facing doc stated the field
+ * grammar either side was judging against (#5566). Registering the section as a wire format is what
+ * makes that disagreement unrepresentable: one module owns the bytes, and both sides read it.
+ *
+ * `read` is total, and `Found` carries a {@link DeviationsDisclosure} rather than a bare list,
+ * because this section has **four** meanings where the wire has three answers. `None.` is a checked
+ * claim — an author who considered the question and has nothing to disclose — and folding it into
+ * `Absent` is how "never considered it" comes to read as "nothing to disclose". So `None.` is a
+ * `Found` of its own tag, and `Absent` stays reserved for a body with no such heading at all.
+ *
+ * An entry carries all four fields. The reader required `Said` alone and the class label is a
+ * routing hint, but a disclosure missing *Why* or *Disposition* states what changed without stating
+ * whether anyone accepted it — so the refusal now names the missing field at the point the body is
+ * written, instead of costing a review round that could not say what was wrong.
+ *
+ * v1's §DEV supplied the semantics — the four fields, the seven classes, the M/R/D tiers — and was
+ * read as prior art, never called (ADR 0238).
+ */
+
+import type {NonEmptyReadonlyArray, WireEmit, WireRead, WireReadLines} from "./format.ts";
+
+declare const FIELD_TEXT: unique symbol;
+
+/**
+ * One field's value, collapsed to a single line and non-blank.
+ *
+ * Branded for the reason `CriterionText` is: `**Said:**` with nothing after it is not a disclosure,
+ * and a `Found` carrying one would be a well-formed answer that discloses nothing.
+ */
+export type FieldText = string & {readonly [FIELD_TEXT]: true};
+
+/**
+ * A field's value as the answer carries it: interior whitespace runs — including the newlines a
+ * wrapped field is authored across — collapsed to one space, so no field spans two output lines.
+ */
+export const fieldText = (raw: string): FieldText | null => {
+	const value = raw.replace(/\s+/g, " ").trim();
+	return value === "" ? null : (value as FieldText);
+};
+
+/** The seven classes. A label outside this set is not a drift — it costs a `-` and nothing else. */
+export const CLASSES: ReadonlyArray<readonly [string, string]> = [
+	["1", "Scope narrowing"],
+	["2", "Governing-ADR departure"],
+	["3", "Known defect left unfixed"],
+	["4", "Declined guidance"],
+	["5", "Guard or gate bypassed"],
+	["6", "Pre-existing test or fixture changed"],
+	["7", "Out-of-scope change"],
+];
+
+/** The four fields, in the order an entry states them. The grammar, as data. */
+export const FIELDS = ["said", "did", "why", "disposition"] as const;
+export type FieldKey = (typeof FIELDS)[number];
+
+/** How an entry writes a field's name — `**Said:**`, the canonical §DEV spelling. */
+export const fieldLabel = (key: FieldKey): string => key.charAt(0).toUpperCase() + key.slice(1);
+
+export interface DeviationEntry {
+	/** The class label `1`–`7`, or `null` when the entry carries none this reader recognises. */
+	readonly label: string | null;
+	/** What the spec asked. */
+	readonly said: FieldText;
+	/** What was built instead. */
+	readonly did: FieldText;
+	/** Why the departure was taken. */
+	readonly why: FieldText;
+	/** What now becomes of it — stated, filed, accepted. */
+	readonly disposition: FieldText;
+}
+
+/**
+ * What the section discloses. `NoneDeclared` is a *claim*, not an empty list — which is why it is a
+ * tag here rather than an entries array of length zero.
+ */
+export type DeviationsDisclosure =
+	| {readonly _tag: "NoneDeclared"}
+	| {readonly _tag: "Entries"; readonly entries: NonEmptyReadonlyArray<DeviationEntry>};
+
+export type DeviationsRead = WireRead<DeviationsDisclosure>;
+
+/** The one conforming heading. Level and spelling are both part of it. */
+export const HEADING_LEVEL = 2;
+export const HEADING_TEXT = "Deviations";
+
+/** The literal body that declares nothing to disclose. */
+export const NONE_TEXT = "None.";
+
+const ATX_HEADING = /^ {0,3}(#{1,6})[ \t]+(.*?)[ \t]*#*[ \t]*$/;
+const FENCE = /^ {0,3}(```|~~~)/;
+const BULLET = /^[ \t]{0,3}[-*][ \t]+/;
+const NONE_RE = /^none\.?$/i;
+const FIELD_MARKER = /\*{0,2}(said|did|why|disposition)\*{0,2}[ \t]*:[ \t]*\*{0,2}/gi;
+
+const normalize = (text: string): string => text.toLowerCase().replace(/[^a-z0-9]/g, "");
+
+interface Heading {
+	readonly level: number;
+	readonly text: string;
+	/** 1-based, so a refusal can point at a line a human can find. */
+	readonly line: number;
+}
+
+/** Every ATX heading outside a fenced block — a fenced example must not pass for the real one. */
+const scanHeadings = (lines: ReadonlyArray<string>): ReadonlyArray<Heading> => {
+	const headings: Heading[] = [];
+	let openFence: string | null = null;
+	for (const [index, line] of lines.entries()) {
+		const fence = FENCE.exec(line);
+		if (fence !== null) {
+			const marker = fence[1] ?? "";
+			if (openFence === null) openFence = marker;
+			else if (openFence === marker) openFence = null;
+			continue;
+		}
+		if (openFence !== null) continue;
+		const heading = ATX_HEADING.exec(line);
+		if (heading === null) continue;
+		headings.push({level: (heading[1] ?? "").length, text: heading[2] ?? "", line: index + 1});
+	}
+	return headings;
+};
+
+/**
+ * Does this heading reach for the section at all?
+ *
+ * Wider than the conforming form on purpose: every heading admitted and then rejected becomes a
+ * `Malformed` naming the drift, and every one turned away becomes an `Absent`. Erring wide is what
+ * keeps `## deviations` from being reported as "the author never wrote the section".
+ */
+const reachesForBlock = (text: string): boolean => normalize(text).includes("deviation");
+
+const conforms = (heading: Heading): boolean =>
+	heading.level === HEADING_LEVEL && heading.text === HEADING_TEXT;
+
+const quote = (heading: Heading): string =>
+	`line ${heading.line}: "${"#".repeat(heading.level)} ${heading.text}"`;
+
+const driftReason = (heading: Heading): string => {
+	const parts = [
+		heading.level === HEADING_LEVEL
+			? null
+			: `heading level ${heading.level}, expected ${HEADING_LEVEL}`,
+		heading.text === HEADING_TEXT
+			? null
+			: `heading text "${heading.text}", expected "${HEADING_TEXT}"`,
+	].filter((part): part is string => part !== null);
+	return `the deviations heading has drifted — ${parts.join("; ")}`;
+};
+
+/** The lines under `heading`, up to the next heading outside a fence, or the end of the body. */
+const sectionOf = (lines: ReadonlyArray<string>, heading: Heading): ReadonlyArray<string> => {
+	const body: string[] = [];
+	let openFence: string | null = null;
+	for (const line of lines.slice(heading.line)) {
+		const fence = FENCE.exec(line);
+		if (fence !== null) {
+			const marker = fence[1] ?? "";
+			if (openFence === null) openFence = marker;
+			else if (openFence === marker) openFence = null;
+			body.push(line);
+			continue;
+		}
+		if (openFence === null && ATX_HEADING.test(line)) break;
+		body.push(line);
+	}
+	return body;
+};
+
+/**
+ * Each top-level bullet in the section, joined with its continuation lines.
+ *
+ * An entry spans several lines in practice — four fields do not fit one 100-column line — so a
+ * per-line read would report one entry as four and lose every field that started on a later line.
+ */
+const bulletsOf = (section: ReadonlyArray<string>): ReadonlyArray<string> => {
+	const bullets: string[] = [];
+	for (const line of section) {
+		if (BULLET.test(line)) bullets.push(line.replace(BULLET, ""));
+		else if (bullets.length > 0 && line.trim() !== "") bullets[bullets.length - 1] += `\n${line}`;
+	}
+	return bullets;
+};
+
+/** The bold or plain lead of a bullet — `**Scope narrowing**` — before the first field. */
+const leadOf = (bullet: string): string => {
+	const bold = /^\s*\*\*(.+?)\*\*/.exec(bullet);
+	if (bold?.[1] !== undefined) return bold[1];
+	return bullet.split(/[—–:]/)[0] ?? "";
+};
+
+const labelOf = (lead: string): string | null => {
+	const key = normalize(lead);
+	const named = CLASSES.find(([, name]) => key.startsWith(normalize(name)));
+	if (named !== undefined) return named[0];
+	return /^([1-7])\b/.exec(lead.trim())?.[1] ?? null;
+};
+
+/**
+ * Each field's raw slice — from the end of its own marker to the start of the next field's.
+ *
+ * The emphasis is admitted on both sides of the colon: the canonical entry writes `**Said:**`,
+ * closing the bold *after* the punctuation, so a pattern anchored only on `**Said**:` would leave
+ * the closer at the head of every value it read.
+ */
+const slicesOf = (bullet: string): ReadonlyMap<FieldKey, string> => {
+	const marks: Array<{readonly key: FieldKey; readonly from: number; readonly at: number}> = [];
+	FIELD_MARKER.lastIndex = 0;
+	for (const match of bullet.matchAll(FIELD_MARKER)) {
+		const key = (match[1] ?? "").toLowerCase() as FieldKey;
+		marks.push({key, at: match.index, from: match.index + match[0].length});
+	}
+	const slices = new Map<FieldKey, string>();
+	for (const [index, mark] of marks.entries()) {
+		if (slices.has(mark.key)) continue;
+		const end = marks[index + 1]?.at ?? bullet.length;
+		slices.set(mark.key, bullet.slice(mark.from, end));
+	}
+	return slices;
+};
+
+const malformed = (reason: string, evidence: string): DeviationsRead => ({
+	_tag: "Malformed",
+	reason,
+	evidence,
+});
+
+/** One bullet as an entry, or the reason it is not one. */
+const entryOf = (
+	bullet: string,
+):
+	| {readonly _tag: "Entry"; readonly entry: DeviationEntry}
+	| {readonly _tag: "Bad"; readonly reason: string} => {
+	const slices = slicesOf(bullet);
+	const values = new Map<FieldKey, FieldText>();
+	const missing: string[] = [];
+	for (const key of FIELDS) {
+		const value = fieldText(slices.get(key) ?? "");
+		if (value === null) missing.push(`**${fieldLabel(key)}:**`);
+		else values.set(key, value);
+	}
+	if (missing.length > 0) {
+		return {
+			_tag: "Bad",
+			reason: `an entry carries no ${missing.join(", ")} — every entry states ${FIELDS.map((key) => `**${fieldLabel(key)}:**`).join(" / ")}`,
+		};
+	}
+	const [said, did, why, disposition] = FIELDS.map((key) => values.get(key));
+	if (said === undefined || did === undefined || why === undefined || disposition === undefined) {
+		return {_tag: "Bad", reason: "an entry lost a field between reading it and building it"};
+	}
+	return {
+		_tag: "Entry",
+		entry: {label: labelOf(leadOf(bullet)), said, did, why, disposition},
+	};
+};
+
+/** Read the `## Deviations` section out of a PR body. Total: `Found` | `Absent` | `Malformed`. */
+export const read = (body: string): DeviationsRead => {
+	const lines = body.split("\n");
+	const candidates = scanHeadings(lines).filter((heading) => reachesForBlock(heading.text));
+	const first = candidates[0];
+	if (first === undefined) {
+		return {
+			_tag: "Absent",
+			reason: `no heading in the body reaches for "${"#".repeat(HEADING_LEVEL)} ${HEADING_TEXT}"`,
+		};
+	}
+
+	const conforming = candidates.filter(conforms);
+	if (conforming.length === 0) return malformed(driftReason(first), quote(first));
+	if (conforming.length > 1) {
+		return malformed(
+			`the body carries ${conforming.length} deviations headings — which one is the disclosure is undecidable`,
+			conforming.map(quote).join(" | "),
+		);
+	}
+
+	const heading = conforming[0];
+	if (heading === undefined) return malformed("the deviations heading could not be resolved", "");
+
+	const section = sectionOf(lines, heading);
+	const text = section.join("\n").trim();
+	if (text === "") {
+		return malformed(
+			`"${"#".repeat(HEADING_LEVEL)} ${HEADING_TEXT}" is present and its section is empty — state a deviation, or state "${NONE_TEXT}"`,
+			`line ${heading.line}`,
+		);
+	}
+	if (NONE_RE.test(text)) return {_tag: "Found", value: {_tag: "NoneDeclared"}};
+
+	const entries: DeviationEntry[] = [];
+	for (const bullet of bulletsOf(section)) {
+		const parsed = entryOf(bullet);
+		if (parsed._tag === "Bad") {
+			return malformed(parsed.reason, `line ${heading.line}: "${bullet.split("\n")[0] ?? ""}"`);
+		}
+		entries.push(parsed.entry);
+	}
+
+	const [head, ...rest] = entries;
+	if (head === undefined) {
+		return malformed(
+			`"${"#".repeat(HEADING_LEVEL)} ${HEADING_TEXT}" is present and its section holds no "- " entry — state a deviation, or state "${NONE_TEXT}"`,
+			`line ${heading.line}`,
+		);
+	}
+	return {_tag: "Found", value: {_tag: "Entries", entries: [head, ...rest]}};
+};
+
+const entryLine = (entry: DeviationEntry): string => {
+	const lead = CLASSES.find(([label]) => label === entry.label)?.[1] ?? null;
+	const fields = FIELDS.map((key) => `**${fieldLabel(key)}:** ${entry[key]}`).join(" ");
+	return lead === null ? `- ${fields}` : `- **${lead}** — ${fields}`;
+};
+
+/** Compose the section's bytes. Round-trips through {@link read}. */
+export const emit = (disclosure: DeviationsDisclosure): string => {
+	const heading = `${"#".repeat(HEADING_LEVEL)} ${HEADING_TEXT}`;
+	const body =
+		disclosure._tag === "NoneDeclared" ? NONE_TEXT : disclosure.entries.map(entryLine).join("\n");
+	return `${heading}\n\n${body}\n`;
+};
+
+export type DeviationsFields =
+	| {readonly _tag: "Fields"; readonly disclosure: DeviationsDisclosure}
+	| {readonly _tag: "Unusable"; readonly reason: string};
+
+/** The null label on stdin and in the answer — the same token `review verdicts` uses. */
+export const NULL_LABEL = "-";
+
+/**
+ * Parse `emit`'s stdin: the literal `None.`, or one tab-separated entry per line —
+ * `<label-or-->\t<said>\t<did>\t<why>\t<disposition>`.
+ *
+ * Every rejection is a refusal rather than a default. A dropped field that silently composed a
+ * three-field entry would emit bytes this format's own reader then calls malformed.
+ */
+export const parseFields = (fields: string): DeviationsFields => {
+	if (NONE_RE.test(fields.trim())) {
+		return {_tag: "Fields", disclosure: {_tag: "NoneDeclared"}};
+	}
+	const entries: DeviationEntry[] = [];
+	for (const [index, raw] of fields.split("\n").entries()) {
+		const line = raw.trim();
+		if (line === "") continue;
+		const columns = line.split("\t");
+		if (columns.length !== FIELDS.length + 1) {
+			return {
+				_tag: "Unusable",
+				reason: `line ${index + 1} carries ${columns.length} tab-separated columns, expected ${FIELDS.length + 1}: <label-or-${NULL_LABEL}>\t${FIELDS.join("\t")}`,
+			};
+		}
+		const values = FIELDS.map((key, at) => [key, fieldText(columns[at + 1] ?? "")] as const);
+		const blank = values.filter(([, value]) => value === null).map(([key]) => key);
+		if (blank.length > 0) {
+			return {_tag: "Unusable", reason: `line ${index + 1} carries no ${blank.join(", ")}`};
+		}
+		const [said, did, why, disposition] = values.map(([, value]) => value);
+		if (
+			said === undefined ||
+			said === null ||
+			did === undefined ||
+			did === null ||
+			why === undefined ||
+			why === null ||
+			disposition === undefined ||
+			disposition === null
+		) {
+			return {_tag: "Unusable", reason: `line ${index + 1} lost a field after it was read`};
+		}
+		const label = (columns[0] ?? "").trim();
+		entries.push({
+			label: label === NULL_LABEL || label === "" ? null : (labelOf(label) ?? null),
+			said,
+			did,
+			why,
+			disposition,
+		});
+	}
+	const [head, ...rest] = entries;
+	if (head === undefined) {
+		return {
+			_tag: "Unusable",
+			reason: `no entry lines — an empty section is malformed; state "${NONE_TEXT}" to declare nothing`,
+		};
+	}
+	return {_tag: "Fields", disclosure: {_tag: "Entries", entries: [head, ...rest]}};
+};
+
+/** The `wire read` answer for this format: `none-declared`, or one line per entry. */
+export const renderDisclosure = (
+	disclosure: DeviationsDisclosure,
+): NonEmptyReadonlyArray<string> => {
+	if (disclosure._tag === "NoneDeclared") return ["none-declared"];
+	const line = (entry: DeviationEntry): string =>
+		["entry", entry.label ?? NULL_LABEL, ...FIELDS.map((key) => entry[key])].join("\t");
+	const [head, ...rest] = disclosure.entries;
+	return [line(head), ...rest.map(line)];
+};
+
+/** The registry row's byte-level `emit`, bound to this module's typed core. */
+export const emitFromFields = (fields: string): WireEmit => {
+	const parsed = parseFields(fields);
+	return parsed._tag === "Fields"
+		? {_tag: "Composed", bytes: emit(parsed.disclosure)}
+		: {_tag: "Unusable", reason: parsed.reason};
+};
+
+/** The registry row's byte-level `read`, bound to this module's typed core. */
+export const readToLines = (artifact: string): WireReadLines => {
+	const result = read(artifact);
+	return result._tag === "Found" ? {_tag: "Found", value: renderDisclosure(result.value)} : result;
+};

--- a/packages/fabrika-cli/src/wire/deviations.unit.test.ts
+++ b/packages/fabrika-cli/src/wire/deviations.unit.test.ts
@@ -1,0 +1,73 @@
+import {describe, expect, it} from "vitest";
+import {emitFromFields, parseFields, read} from "./deviations.ts";
+
+const ENTRY =
+	"- **Scope narrowing** — **Said:** four gates. **Did:** three plus a bounce. **Why:** the fourth emits a trivial verdict. **Disposition:** stated here.";
+
+describe("read", () => {
+	it("is Absent only when nothing in the body reaches for the section", () => {
+		expect(read("Fixes #1\n\n## Summary\n\nstuff")._tag).toBe("Absent");
+	});
+
+	it("is Malformed, never Absent, when a heading reaches for the section and misses", () => {
+		expect(read("### Deviations\n\nNone.\n")._tag).toBe("Malformed");
+		expect(read("## deviations\n\nNone.\n")._tag).toBe("Malformed");
+	});
+
+	it("carries `None.` as a Found claim of its own tag, never an empty entry list", () => {
+		const result = read("## Deviations\n\nNone.\n");
+		expect(result._tag === "Found" && result.value._tag).toBe("NoneDeclared");
+	});
+
+	it("carries all four fields of an entry", () => {
+		const result = read(`## Deviations\n\n${ENTRY}\n`);
+		if (result._tag !== "Found" || result.value._tag !== "Entries") {
+			throw new Error(`expected Found/Entries, got ${result._tag}`);
+		}
+		expect(result.value.entries[0]).toEqual({
+			label: "1",
+			said: "four gates.",
+			did: "three plus a bounce.",
+			why: "the fourth emits a trivial verdict.",
+			disposition: "stated here.",
+		});
+	});
+
+	it("names the missing field rather than answering a bare Malformed", () => {
+		const result = read("## Deviations\n\n- **Said:** a. **Did:** b. **Why:** c.\n");
+		expect(result._tag === "Malformed" && result.reason).toContain("**Disposition:**");
+	});
+
+	it("refuses a section whose entries disclose nothing", () => {
+		expect(read("## Deviations\n\nprobably nothing?\n")._tag).toBe("Malformed");
+	});
+
+	it("refuses two conforming headings — which one is the disclosure is undecidable", () => {
+		const body = `## Deviations\n\nNone.\n\n## Deviations\n\n${ENTRY}\n`;
+		expect(read(body)._tag).toBe("Malformed");
+	});
+
+	it("ignores a heading inside a fenced block", () => {
+		expect(read("before\n\n```\n## Deviations\n\nNone.\n```\n\nafter")._tag).toBe("Absent");
+	});
+});
+
+describe("parseFields", () => {
+	it("takes the literal `None.` as the checked claim", () => {
+		const parsed = parseFields("None.\n");
+		expect(parsed._tag === "Fields" && parsed.disclosure._tag).toBe("NoneDeclared");
+	});
+
+	it("refuses a row short a column rather than composing a three-field entry", () => {
+		expect(parseFields("4\ta\tb\tc\n")._tag).toBe("Unusable");
+	});
+
+	it("refuses a row whose field is blank", () => {
+		expect(parseFields("4\ta\tb\tc\t \n")._tag).toBe("Unusable");
+	});
+
+	it("composes bytes its own reader accepts", () => {
+		const composed = emitFromFields("-\ta.\tb.\tc.\td.\n");
+		expect(composed._tag === "Composed" && read(composed.bytes)._tag).toBe("Found");
+	});
+});

--- a/packages/fabrika-cli/src/wire/registry.ts
+++ b/packages/fabrika-cli/src/wire/registry.ts
@@ -19,6 +19,7 @@
  * registered without them — which is what makes the totality law inherited rather than re-written.
  */
 import * as acceptanceCriteria from "./acceptance-criteria.ts";
+import * as deviations from "./deviations.ts";
 import {brandWitnesses, type WireFormat} from "./format.ts";
 import * as governanceDigest from "./governance-digest.ts";
 import * as graduateEmitted from "./graduate-emitted.ts";
@@ -74,6 +75,75 @@ export const registeredFormats: ReadonlyArray<WireFormat> = [
 			],
 		},
 		brands: brandWitnesses<acceptanceCriteria.AcceptanceCriterion>({text: true}),
+	},
+	{
+		key: "deviations",
+		purpose:
+			"what a PR body discloses about where the build departed from its contract, carried under `## Deviations` as four-field entries or the literal `None.`",
+		module: "packages/fabrika-cli/src/wire/deviations.ts",
+		producers: ["build", "build-ui", "build-epic"],
+		consumers: ["review", "review-ui"],
+		emit: deviations.emitFromFields,
+		read: deviations.readToLines,
+		fixtures: {
+			roundTrip: {
+				fields:
+					"4\tthe issue named two artifacts.\talso re-grounded a third.\tit stated a rule the change contradicts.\tstated here.\n",
+				values: [
+					"the issue named two artifacts.",
+					"also re-grounded a third.",
+					"it stated a rule the change contradicts.",
+					"stated here.",
+				],
+			},
+			found: [
+				{
+					shape:
+						"an entry authored across four wrapped lines, as a body written to 100 columns carries it",
+					artifact:
+						"## Deviations\n\n- **Declined guidance** — **Said:** take the reviewer's shape.\n  **Did:** kept mine.\n  **Why:** the reviewer's shape reads the label, and the label is a routing hint.\n  **Disposition:** stated here.\n",
+					values: [
+						"take the reviewer's shape.",
+						"kept mine.",
+						"the reviewer's shape reads the label, and the label is a routing hint.",
+						"stated here.",
+					],
+				},
+				{
+					shape: "the checked claim that there is nothing to disclose",
+					artifact: "Fixes #4312\n\n## Deviations\n\nNone.\n",
+					values: ["none-declared"],
+				},
+			],
+			absent: "Fixes #4312\n\n## Summary\n\nThe editor keeps focus across a save.\n",
+			malformed: [
+				{
+					drift: "the heading level drifted",
+					artifact:
+						"### Deviations\n\n- **Said:** a. **Did:** b. **Why:** c. **Disposition:** d.\n",
+				},
+				{
+					drift: "an entry is prose, carrying none of the four fields",
+					artifact:
+						"## Deviations\n\n- Narrowed the scope to the reader, and left the writer alone.\n",
+				},
+				{
+					drift: "an entry states what changed and never what becomes of it",
+					artifact:
+						"## Deviations\n\n- **Scope narrowing** — **Said:** both sides. **Did:** the reader only. **Why:** the writer is #5562's.\n",
+				},
+				{
+					drift: "the heading is present over an empty section",
+					artifact: "## Deviations\n\n## Testing\n\nran it\n",
+				},
+			],
+		},
+		brands: brandWitnesses<deviations.DeviationEntry>({
+			said: true,
+			did: true,
+			why: true,
+			disposition: true,
+		}),
 	},
 	{
 		key: "verdict-marker",


### PR DESCRIPTION
Fixes #5566

The PR body's `## Deviations` section had two contracts that disagreed. `build pr` asked only that
the heading exist with something under it; `review deviations` dropped every bullet carrying no
`Said` field and then reported a section of zero surviving entries as `malformed`. A body that fully
satisfied the producer was therefore guaranteed to fail the consuming gate closed, and no
author-facing doc stated the field grammar either side was judging against.

The section is now a registered wire format. `packages/fabrika-cli/src/wire/deviations.ts` owns the
bytes, and both sides resolve it: `build pr`'s body-shape check accepts exactly what the format reads
as `Found`, and `review deviations` is a thin projection from the format's three answers onto its
four states. The disagreement is unrepresentable rather than merely rarer.

What an author meets:

- `claude-plugins/fabrika/skills/build/SKILL.md` now shows the entry shape at the point the body is
  authored — the exact heading, the four fields, the optional class lead.
- `claude-plugins/fabrika/skills/build/contract.md`'s worked example shows two real entries rather
  than only `None.`, and its refusal example shows what a prose bullet gets back.
- The refusal now names the missing field, at the moment the body is written. That message used to
  arrive a review round later and could not say what was wrong.

The four states stay distinct, which is why `Found` carries a tagged disclosure rather than a list:
`None.` is a checked claim an author makes, so it is a `Found` of its own tag and never an empty
entry array. `Absent` stays reserved for a body with no such heading at all.

Where to look first: `read` in `packages/fabrika-cli/src/wire/deviations.ts`, then the
`what build pr accepts is never read as malformed` block in
`packages/fabrika-cli/src/review/deviations.unit.test.ts`, which runs one body through both sides
over every shape the two used to answer differently.

Related: #5701 is an untriaged report of this same defect, filed independently. #5565 is the sibling
instance one format over.

## Deviations

- **Pre-existing test or fixture changed** — **Said:** nothing in #5566 asks for existing fixtures to
  move. **Did:** updated four: the `runDeviations` entry fixture and three `pr-body` / `pr-verb`
  bodies. **Why:** the entry fixture carried only `Said` and `Did`, and the `pr-body` helper appended
  its extra prose *inside* the section, so under the one grammar both read malformed; each was
  updated to the conforming shape, never to a laxer assertion. **Disposition:** stated here; the
  behaviour each test guards is unchanged.
- **Out-of-scope change** — **Said:** #5566 names the build-side artifacts, the reader and the
  registry. **Did:** also edited `claude-plugins/fabrika/skills/review/contract.md` and the
  `review deviations` help text in `packages/fabrika-cli/src/review/command.ts`. **Why:** both
  documented the entry line as `<first-line-of-Said>`, and a field authored across wrapped lines is
  now carried in full and collapsed to one line — the same content loss #5572 closed for acceptance
  criteria; leaving the two docs stating the old shape would have re-created the drift this issue is
  about. **Disposition:** stated here.
- **Known defect left unfixed** — **Said:** `build check --surface prose` must be green.
  **Did:** shipped with it red. **Why:** all three hits are illustrative example paths that predate
  this branch in `claude-plugins/fabrika/skills/build/contract.md` — verified absent from this diff
  and present at `origin/main` — and the prose scan reads whole changed files, not hunks; the root
  cause is already filed and triaged as #5632. **Disposition:** left to #5632; `build check --surface
  code` is green in this tree and covers every source file changed here.
- **Reader tightening** — **Said:** the two contracts must agree, and which side moves is the
  builder's call. **Did:** required all four fields of every entry, where the reader previously
  required `Said` alone. **Why:** an entry stating what changed without stating whether anyone
  accepted it is what the review gate cannot act on, and the alternative — a reader admitting any
  prose bullet — leaves the author-facing grammar unenforceable by the producer. **Disposition:**
  stated here; the visible consequence is that an open PR whose section carries a partial entry will
  read malformed at its next review round, with the missing field now named.
