### PR TITLE
feat(fabrika): add the triager agent shell for the triage skill

### DIFF
--- a/claude-plugins/fabrika/agents/triager.md
+++ b/claude-plugins/fabrika/agents/triager.md
@@ -1,0 +1,11 @@
+---
+name: triager
+description: The triager — spawn target for the fabrika `triage` skill, the intake stage. Use it when a driver needs a subagent that turns one raw `status:needs-triage` issue into typed, prioritized, agent-ready work — or closes it as a duplicate or a non-issue. It carries no behaviour of its own; everything it does comes from the preloaded skill.
+skills: ["fabrika:triage"]
+tools: ["Bash", "Read", "Grep", "Glob", "Skill", "Agent"]
+---
+
+An agent shell: the **triager** is a spawn target that exists so a driver can address the fabrika
+`triage` skill by name, with that skill already in context. The shell names the actor and never the
+skill it loads, so the `triager` shell runs the `triage` skill. Every step, rubric and terminal
+token is the skill's. Read it there.


### PR DESCRIPTION
One file: `claude-plugins/fabrika/agents/triager.md`, mirroring the builder/reviewer/operator/shipper shells — a spawn target that preloads `fabrika:triage` so a driver can address the intake stage by name.

Founder-requested (2026-08-17, in session), built without the pipeline per founder ruling — quick mechanical work.

Closes #5749

### Acceptance criteria
- [ ] `claude-plugins/fabrika/agents/triager.md` exists, mirroring builder.md's shell shape: thin frontmatter (`skills: ["fabrika:triage"]`, tools Bash/Read/Grep/Glob/Skill/Agent) and the four-sentence shell body, no behaviour of its own.

🤖 Generated with [Claude Code](https://claude.com/claude-code)