### PR TITLE
One retry cap: fold the three round budgets onto the lane machine's transition guard

### DIFF
--- a/claude-plugins/fabrika/skills/build/SKILL.md
+++ b/claude-plugins/fabrika/skills/build/SKILL.md
@@ -196,16 +196,14 @@ The fold is the only entry: paginated, current-head, per-gate — polarity visib
 included. Act only on rows it prints; empty rows at exit 0 are a proven no-work answer, but an
 UNKNOWN exit means the verdict state is unread — **never "nothing to fix"**. The budget is the
 fold's own `capReached` field, never a number you carry: on `true`, end `ESCALATED` and post the
-escalation via `fabrika build note` instead of another push. Fix findings
-on the same branch (`fabrika build tree --issue 4310`, then `fabrika build branch --resume
-4310`), re-validate
-with `fabrika build check --surface <yours>`, push with `fabrika build push --force-with-lease`,
-answer the findings in a `fabrika build note` naming each one addressed, release. Exit `23` on that
-push means your head **drops commits the PR already published** — `build branch --resume` again so
-you rebuild on the published head, never `--drop-remote-commits`, which is for a rewrite you
-actually intend. The fold's
-`frozenCriteria` rows are the review-appended criteria past the freeze — note them, do not chase
-them.
+escalation via `fabrika build note` instead of another push. Fix findings on the same branch
+(`fabrika build tree --issue 4310`, then `fabrika build branch --resume 4310`), re-validate with
+`fabrika build check --surface <yours>`, push with `fabrika build push --force-with-lease`, answer
+the findings in a `fabrika build note` naming each one addressed, release. Exit `23` on that push
+means your head **drops commits the PR already published** — `build branch --resume` again so you
+rebuild on the published head, never `--drop-remote-commits`, which is for a rewrite you actually
+intend. The fold's `frozenCriteria` rows are the review-appended criteria past the freeze — note
+them, do not chase them.
 
 ## Expectations you hold but never recompute
 

--- a/claude-plugins/fabrika/skills/build/SKILL.md
+++ b/claude-plugins/fabrika/skills/build/SKILL.md
@@ -194,16 +194,18 @@ fabrika build verdicts --pr 4310
 
 The fold is the only entry: paginated, current-head, per-gate — polarity visible, round count
 included. Act only on rows it prints; empty rows at exit 0 are a proven no-work answer, but an
-UNKNOWN exit means the verdict state is unread — **never "nothing to fix"**. At round 3, end
-`ESCALATED`: post the escalation via `fabrika build note` instead of a fourth push. Fix findings
+UNKNOWN exit means the verdict state is unread — **never "nothing to fix"**. The budget is the
+fold's own `capReached` field, never a number you carry: on `true`, end `ESCALATED` and post the
+escalation via `fabrika build note` instead of another push. Fix findings
 on the same branch (`fabrika build tree --issue 4310`, then `fabrika build branch --resume
 4310`), re-validate
 with `fabrika build check --surface <yours>`, push with `fabrika build push --force-with-lease`,
 answer the findings in a `fabrika build note` naming each one addressed, release. Exit `23` on that
 push means your head **drops commits the PR already published** — `build branch --resume` again so
 you rebuild on the published head, never `--drop-remote-commits`, which is for a rewrite you
-actually intend. A
-review-appended acceptance criterion after round 2 is frozen — note it, do not chase it.
+actually intend. The fold's
+`frozenCriteria` rows are the review-appended criteria past the freeze — note them, do not chase
+them.
 
 ## Expectations you hold but never recompute
 

--- a/claude-plugins/fabrika/skills/build/contract.md
+++ b/claude-plugins/fabrika/skills/build/contract.md
@@ -1555,10 +1555,11 @@ fabrika build verdicts --pr 4310 [--repo <owner/name>]
 ```
 
 (`frozenCriteria` rows carry `text` and `appendedRound`; the array is empty when nothing was
-appended after round 2. **Each row's `body` is the finding's full text, passed through the
+appended past the freeze. **Each row's `body` is the finding's full text, passed through the
 content gate** — the repair loop consumes findings from here and never raw-fetches a comment,
 which is what keeps AC 3's one-door property over the repair path. `capReached` is
-`rounds >= 3`, computed here so the cap is a field read, not a number remembered.)
+`rounds >= CAP_ROUND`, read from `src/retry-budget.ts` — the package's one declared retry budget
+— and computed here so the cap is a field read, not a number remembered.)
 
 The fold: resolve the PR's current head; fetch **every** comment and **every** review, paginated
 in full; parse each comment through the imported `verdict-marker` read; keep the latest marker
@@ -1573,7 +1574,7 @@ comment snapshot, `stepR-round-count.sh` + `stepR1-verdicts.sh:48`; the off-by-o
 every FAIL-polarity marker comment, sorted by `created_at` ascending; a marker whose gap from
 the previous FAIL marker exceeds 120 seconds starts a new cluster, a gap of exactly 120 seconds
 or less continues the current one; `rounds` is the cluster count. `frozenCriteria` lists
-review-appended acceptance-criterion rows dated after round 2.
+review-appended acceptance-criterion rows dated at or past `CAP_ROUND`.
 
 **`{"rows": [], ...}` on exit 0 is a proven "no verdicts", readable against the scope line's
 comment/review counts. An unreadable page is `11` — never a shorter list.** All content passes

--- a/claude-plugins/fabrika/skills/review/SKILL.md
+++ b/claude-plugins/fabrika/skills/review/SKILL.md
@@ -99,7 +99,8 @@ namespace posts a native APPROVE.
 Sweep the loaded diff on silent-failure, type-design and test-gap as checklist lines in this same
 pass, then route each finding **binary** — traces to the linked issue's stated goal, or not; no
 severity tier. In-scope findings append an acceptance criterion under the verb's fences
-(append-only, ACL-gated fail-closed, frozen at round 3); the row enters the *next* cycle's verdict,
+(append-only, ACL-gated fail-closed, frozen at the round the verb declares — hand it `--round` and
+read its answer, never a remembered number); the row enters the *next* cycle's verdict,
 never this one's. Out-of-scope findings go to fabrika's `/report`, non-blocking.
 
 ```bash

--- a/claude-plugins/fabrika/skills/review/contract.md
+++ b/claude-plugins/fabrika/skills/review/contract.md
@@ -29,7 +29,7 @@ Named because a spec that leaves the substrate open makes the implementer guess 
 | `review verdicts` | every verdict marker on the PR, per namespace, each with its `Current` / `Stale` / `Unbindable` binding against the live head and the content it bound | comment sweep + registered parse + `bindToContent` is mechanical; what a stale marker means for this round is judgment |
 | `review deviations` | the PR body's `## Deviations` section state (found / absent / malformed), its entries, and the Tier-M token scan over the diff | section detection and token scanning are mechanical; matching entry *substance* against findings is judgment (Tier R) |
 | `review post` | the single sanctioned verdict emit: compose through the `verdict-marker` wire format, bind to the inspected head at post time, post one comment per namespace at that head, read it back | marker composition, head re-resolution, leak scan and read-back are a protocol; the polarity and clause are judgment |
-| `review append-criterion` | append one reviewer-authored acceptance criterion to the linked issue under the four fences (append-only · ACL-gated fail-closed · frozen after round 3), with provenance tag | the fences and the diff-guarded append are mechanical (ADR 0079); whether a finding is in-scope is judgment |
+| `review append-criterion` | append one reviewer-authored acceptance criterion to the linked issue under the four fences (append-only · ACL-gated fail-closed · frozen at `src/retry-budget.ts`'s `CAP_ROUND`), with provenance tag | the fences and the diff-guarded append are mechanical (ADR 0079); whether a finding is in-scope is judgment |
 
 ### Considered and deliberately not derived
 

--- a/claude-plugins/fabrika/skills/review/contract.md
+++ b/claude-plugins/fabrika/skills/review/contract.md
@@ -969,13 +969,13 @@ The criterion text arrives on **stdin** — one checkbox row's text, without the
 |---|---|---|---|---|
 | *(positional)* | integer | yes | — | the linked issue receiving the criterion |
 | `--pr` | integer | yes | — | the PR whose review round produced the finding — half the provenance tag |
-| `--round` | integer | yes | — | this review round's number; at or past the freeze (3) the verb escalates instead of appending |
+| `--round` | integer | yes | — | this review round's number; at or past the freeze (`src/retry-budget.ts`'s `CAP_ROUND`) the verb escalates instead of appending |
 | `--repo` | string | no | resolved | the repository |
 | `--json` | boolean | no | `false` | emit the result object |
 | stdin | markdown | yes | — | the criterion text |
 
 **Output** — machine channel. One line: `appended\t<issue>\t<row-count-after>`, or
-`escalated-frozen\t<issue>\t<round>` when `--round` ≥ 3 — the escalation comment landed and the
+`escalated-frozen\t<issue>\t<round>` when `--round` is at or past `CAP_ROUND` — the escalation comment landed and the
 AC did **not** (fence 4: append-rate stays bounded by fix-rate; a finding raised at the freeze
 routes to a human). Both are proven answers at exit 0, discriminated by the token.
 
@@ -989,7 +989,8 @@ With `--json`: `{"outcome":…,"issue":…,"rows":…,"round":…,"acl":"write+"
 2. **Append-only**: the new body is the old body plus exactly one row (`- [ ] <text>
    <!-- ac:review pr:#<pr> round:<round> -->`) under the existing conforming heading; a diff
    guard refuses any write that would drop or mutate a prior byte.
-3. **Frozen at round K = 3**: `--round` ≥ 3 posts the escalation comment instead of appending.
+3. **Frozen at ADR 0079's round K**, read from `src/retry-budget.ts`'s `CAP_ROUND`: a `--round` at
+   or past it posts the escalation comment instead of appending.
 4. **In-scope-only is the caller's** (the trace-to-stated-goal test is judgment); the provenance
    tag is what makes a routed row auditable after the fact.
 
@@ -1045,7 +1046,8 @@ escalated-frozen	4287	3
 **Grounding**
 
 - ADR 0079 — reviewer-authored acceptance criteria: routed binary, appended under fences, frozen
-  at K = N = 3; v1's `reviewer-append-ac.sh` was mandated at four call sites and called at none
+  at K = N = 3 (the value the ADR set; the fence reads it from `src/retry-budget.ts`'s
+  `CAP_ROUND`); v1's `reviewer-append-ac.sh` was mandated at four call sites and called at none
   (the S8 scar) — a first-class verb is the difference between a fence and a fence description.
 - ADR 0055 — authority from the ACL check; a below-write author or a failed lookup skips the
   append entirely, fail-closed.

--- a/packages/fabrika-cli/src/build/rounds.ts
+++ b/packages/fabrika-cli/src/build/rounds.ts
@@ -14,9 +14,6 @@
 /** The gap at which a FAIL still belongs to the round before it. Inclusive. */
 export const ROUND_GAP_MS = 120_000;
 
-/** The round at which a repair loop is capped — `capReached` is a field read, not a remembered number. */
-export const ROUND_CAP = 3;
-
 /** Cluster FAIL timestamps into rounds. An empty input is zero rounds, which is a fact, not a gap. */
 export const countRounds = (createdAt: ReadonlyArray<string>): number => {
 	const times = createdAt

--- a/packages/fabrika-cli/src/build/rounds.unit.test.ts
+++ b/packages/fabrika-cli/src/build/rounds.unit.test.ts
@@ -1,5 +1,6 @@
 import {describe, expect, it} from "vitest";
-import {countRounds, ROUND_CAP, ROUND_GAP_MS} from "./rounds.ts";
+import {CAP_ROUND} from "../retry-budget.ts";
+import {countRounds, ROUND_GAP_MS} from "./rounds.ts";
 
 const at = (secondsFromStart: number) =>
 	new Date(1_770_000_000_000 + secondsFromStart * 1000).toISOString();
@@ -24,7 +25,7 @@ describe("countRounds clusters FAIL markers by the 120-second gap rule", () => {
 	});
 
 	it("counts three separated rounds, which is the cap", () => {
-		expect(countRounds([at(0), at(300), at(600)])).toBe(ROUND_CAP);
+		expect(countRounds([at(0), at(300), at(600)])).toBe(CAP_ROUND);
 	});
 
 	it("sorts before clustering, so an out-of-order list counts the same", () => {

--- a/packages/fabrika-cli/src/build/rounds.unit.test.ts
+++ b/packages/fabrika-cli/src/build/rounds.unit.test.ts
@@ -1,5 +1,4 @@
 import {describe, expect, it} from "vitest";
-import {CAP_ROUND} from "../retry-budget.ts";
 import {countRounds, ROUND_GAP_MS} from "./rounds.ts";
 
 const at = (secondsFromStart: number) =>
@@ -24,8 +23,8 @@ describe("countRounds clusters FAIL markers by the 120-second gap rule", () => {
 		expect(countRounds([at(0), at(121)])).toBe(2);
 	});
 
-	it("counts three separated rounds, which is the cap", () => {
-		expect(countRounds([at(0), at(300), at(600)])).toBe(CAP_ROUND);
+	it("counts three separated markers as three rounds", () => {
+		expect(countRounds([at(0), at(300), at(600)])).toBe(3);
 	});
 
 	it("sorts before clustering, so an out-of-order list counts the same", () => {

--- a/packages/fabrika-cli/src/build/verdicts-verb.ts
+++ b/packages/fabrika-cli/src/build/verdicts-verb.ts
@@ -18,6 +18,7 @@
 import {Effect} from "effect";
 import type {ChildProcessSpawner} from "effect/unstable/process";
 import {getIssue, listComments} from "../io/issues.ts";
+import {CAP_ROUND} from "../retry-budget.ts";
 import {answer, refuse, type VerbOutcome} from "../verb.ts";
 import {read as readCriteria} from "../wire/acceptance-criteria.ts";
 import {bindToHead, read as readMarker} from "../wire/verdict-marker.ts";
@@ -25,7 +26,7 @@ import {PRECONDITION_UNKNOWN} from "./codes.ts";
 import {contentOf, gate} from "./content-gate.ts";
 import {listReviews} from "./github.ts";
 import {closingTargets, proseOf} from "./pr-body.ts";
-import {countRounds, ROUND_CAP} from "./rounds.ts";
+import {countRounds} from "./rounds.ts";
 import {openPull, resolveTargetRepo} from "./target.ts";
 
 const VERB = "build verdicts";
@@ -130,7 +131,7 @@ export const runVerdicts = (
 				head,
 				rows,
 				rounds,
-				capReached: rounds >= ROUND_CAP,
+				capReached: rounds >= CAP_ROUND,
 				frozenCriteria: frozen.rows,
 			}),
 			[
@@ -144,7 +145,7 @@ type Frozen =
 	| {readonly _tag: "Unknown"; readonly reason: string};
 
 /**
- * The reviewer-appended criteria on this PR's linked issue that landed after round 2.
+ * The reviewer-appended criteria on this PR's linked issue that landed at or past the freeze round.
  *
  * The provenance tag ADR 0079 requires is what makes them findable at all — the round is written into
  * the row, so the freeze is a property of the artifact rather than of a session's memory. A PR with no
@@ -169,7 +170,7 @@ const frozenCriteria = (
 			if (tag?.[1] === undefined || tag[2] === undefined) continue;
 			if (Number.parseInt(tag[1], 10) !== pr) continue;
 			const round = Number.parseInt(tag[2], 10);
-			if (round > 2) {
+			if (round >= CAP_ROUND) {
 				rows.push({text: criterion.text.replace(PROVENANCE_RE, "").trim(), appendedRound: round});
 			}
 		}

--- a/packages/fabrika-cli/src/exit-code-alignment.ts
+++ b/packages/fabrika-cli/src/exit-code-alignment.ts
@@ -542,8 +542,9 @@ const LOCAL_NUMBER = /^(?:export )?const ([A-Za-z_$][\w$]*)\s*=\s*-?\d/gm;
  * A code is seated here when `refuse(...)` is handed a numeric literal, or a name the same file
  * declares as a number. That is deliberately narrower than {@link verbLocalCodesIn}'s shape-only
  * read, which cannot be the repo-wide check: `triage`'s `DEFAULT_TTL_MINUTES` is a numeric constant
- * a verb file is entitled to declare, and only its use as an exit code would make it a seat. Reading the source is still the only way — an import and a
- * declaration are the same export once the module is loaded.
+ * a verb file is entitled to declare, and only its use as an exit code would make it a seat.
+ * Reading the source is still the only way — an import and a declaration are the same export once
+ * the module is loaded.
  *
  * Throws on a scan that read no verb file. An all-clear over nothing is the vacuous pass ADR 0092
  * forbids, and it is the shape a mistyped source root would produce first.

--- a/packages/fabrika-cli/src/exit-code-alignment.ts
+++ b/packages/fabrika-cli/src/exit-code-alignment.ts
@@ -541,9 +541,8 @@ const LOCAL_NUMBER = /^(?:export )?const ([A-Za-z_$][\w$]*)\s*=\s*-?\d/gm;
  *
  * A code is seated here when `refuse(...)` is handed a numeric literal, or a name the same file
  * declares as a number. That is deliberately narrower than {@link verbLocalCodesIn}'s shape-only
- * read, which cannot be the repo-wide check: `review`'s `FREEZE_ROUND` and `triage`'s
- * `DEFAULT_TTL_MINUTES` are numeric constants a verb file is entitled to declare, and only their use
- * as an exit code would make them a seat. Reading the source is still the only way — an import and a
+ * read, which cannot be the repo-wide check: `triage`'s `DEFAULT_TTL_MINUTES` is a numeric constant
+ * a verb file is entitled to declare, and only its use as an exit code would make it a seat. Reading the source is still the only way — an import and a
  * declaration are the same export once the module is loaded.
  *
  * Throws on a scan that read no verb file. An all-clear over nothing is the vacuous pass ADR 0092

--- a/packages/fabrika-cli/src/exit-code-alignment.unit.test.ts
+++ b/packages/fabrika-cli/src/exit-code-alignment.unit.test.ts
@@ -218,7 +218,7 @@ describe("no verb file seats an exit code its group's table does not", () => {
 	it("passes a numeric constant the file never refuses with — a round count is not a seat", () => {
 		const root = stub({
 			"thing-verb.ts":
-				"const FREEZE_ROUND = 3;\nif (round >= FREEZE_ROUND) refuse(ZERO_SCOPE, 'x');\n",
+				"const ROUND_LIMIT = 3;\nif (round >= ROUND_LIMIT) refuse(ZERO_SCOPE, 'x');\n",
 		});
 		expect(verbSeatedExitCodes(root, ["ghost"]).seated).toEqual([]);
 	});

--- a/packages/fabrika-cli/src/lane/emit.ts
+++ b/packages/fabrika-cli/src/lane/emit.ts
@@ -15,9 +15,7 @@
  */
 import {type Ref, readTopology} from "../build/dependencies.ts";
 import {type DeclaredLine, findCycle} from "../ledger/topology-doc.ts";
-
-/** The coder template's retry budget, mirrored per child (see `templates/coder.workflow.json`). */
-const MAX_RETRIES = 2;
+import {RETRY_BUDGET} from "../retry-budget.ts";
 
 export type EmitResult =
 	| {
@@ -122,7 +120,7 @@ export const emitMachine = (
 	const states: Record<string, unknown> = {};
 	for (const [index, phase] of order.entries()) {
 		const members = ascending(phases.get(phase) ?? []);
-		for (const child of members) context[taskId(child)] = {retries: 0, maxRetries: MAX_RETRIES};
+		for (const child of members) context[taskId(child)] = {retries: 0, maxRetries: RETRY_BUDGET};
 		const next = order[index + 1];
 		states[phaseName(phase)] = {
 			type: "parallel",

--- a/packages/fabrika-cli/src/lane/machine.ts
+++ b/packages/fabrika-cli/src/lane/machine.ts
@@ -20,6 +20,7 @@
  */
 import type {Machine} from "@demlik/tea";
 import {defineMachine} from "@demlik/tea";
+import {RETRY_BUDGET} from "../retry-budget.ts";
 
 /** The operator's whole event vocabulary — the six, closed (#5570 founder session, 2026-08-15). */
 export const OPERATOR_EVENTS = ["DONE", "PASS", "FAIL", "BLOCKED", "WIP", "UNBLOCKED"] as const;
@@ -64,8 +65,6 @@ export interface CompiledLane {
 export type CompileResult =
 	| {readonly _tag: "Compiled"; readonly lane: CompiledLane}
 	| {readonly _tag: "Malformed"; readonly defects: ReadonlyArray<string>};
-
-const DEFAULT_MAX_RETRIES = 3;
 
 type Cell = (state: TaskState) => readonly [TaskState, readonly never[]];
 
@@ -167,7 +166,7 @@ const compileRegion = (taskId: string, region: unknown, context: unknown): Regio
 	if (defects.length > 0) return {defects};
 
 	const ctx = isRecord(context) ? context : {};
-	const maxRetries = typeof ctx.maxRetries === "number" ? ctx.maxRetries : DEFAULT_MAX_RETRIES;
+	const maxRetries = typeof ctx.maxRetries === "number" ? ctx.maxRetries : RETRY_BUDGET;
 	const {maxRetries: _max, retries: _retries, ...extras} = ctx;
 	const initial: TaskState = {type: initialState, retries: 0, maxRetries};
 	// The Transitions mapped type demands a cell for every (state × msg) pair; a lane machine is

--- a/packages/fabrika-cli/src/retry-budget.ts
+++ b/packages/fabrika-cli/src/retry-budget.ts
@@ -1,0 +1,20 @@
+/**
+ * The one repair-retry budget in fabrika — how many retries a failing task gets before its loop
+ * freezes, and the round at which that freeze lands.
+ *
+ * The number lived three times with three values (#5732): `build/rounds.ts`'s `ROUND_CAP = 3`,
+ * `lane/emit.ts`'s `MAX_RETRIES = 2` beside the coder template's `maxRetries: 2`, and
+ * `review/append-criterion-verb.ts`'s `FREEZE_ROUND = 3`. The lane machine's is the survivor
+ * because it is the only one a transition enforces (`retries < maxRetries` in the compiled cell)
+ * rather than a caller remembering to check; the others read it from here, so a PR driven by a lane
+ * and the same PR read through `build verdicts` cannot disagree about whether the loop is capped.
+ *
+ * `lane/templates/coder.workflow.json` is JSON and cannot import — `retry-budget.unit.test.ts`
+ * fails closed if the committed template or an emitted epic machine drifts off {@link RETRY_BUDGET}.
+ */
+
+/** The retries a failing task gets. The one declared budget; everything else derives from it. */
+export const RETRY_BUDGET = 2;
+
+/** The round the budget is spent at, so the loop freezes — ADR 0079's K, derived, never a second number. */
+export const CAP_ROUND = RETRY_BUDGET + 1;

--- a/packages/fabrika-cli/src/retry-budget.unit.test.ts
+++ b/packages/fabrika-cli/src/retry-budget.unit.test.ts
@@ -1,0 +1,47 @@
+/**
+ * The drift guard on the one retry budget (#5732).
+ *
+ * `lane/templates/coder.workflow.json` is JSON and cannot import {@link RETRY_BUDGET}, so an edit to
+ * the template is exactly how the number quietly grew a second value before. These assertions read
+ * the committed bytes and the emitter's output back against the constant, so that edit reds here.
+ */
+import {describe, expect, it} from "vitest";
+import {readGoldenFixture} from "./golden-fixture.ts";
+import {emitMachine} from "./lane/emit.ts";
+import {coderTemplateText} from "./lane/fixtures.test-support.ts";
+import {compileText} from "./lane/machine.ts";
+import {RETRY_BUDGET} from "./retry-budget.ts";
+
+const EPIC = 4300;
+const CHILDREN = [4301, 4302, 4303];
+
+const epicBody = (): string =>
+	readGoldenFixture(import.meta.url, "./lane/__fixtures__/epic-4300.body.txt");
+
+const compiledInitials = (text: string): ReadonlyArray<number> => {
+	const compiled = compileText(text);
+	if (compiled._tag !== "Compiled") throw new Error(compiled.defects.join("; "));
+	return Object.values(compiled.lane.tasks).map((task) => task.initial.maxRetries);
+};
+
+describe("the one retry budget", () => {
+	it("is what the committed coder template carries into its compiled task", () => {
+		expect(compiledInitials(coderTemplateText())).toEqual([RETRY_BUDGET]);
+	});
+
+	it("is what an emitted epic machine carries into every child task", () => {
+		const emitted = emitMachine(EPIC, epicBody(), CHILDREN);
+		if (emitted._tag !== "Emitted") throw new Error(`expected Emitted, got ${emitted._tag}`);
+
+		expect(compiledInitials(emitted.text)).toEqual(CHILDREN.map(() => RETRY_BUDGET));
+	});
+
+	it("is the default a task context that declares no budget of its own compiles to", () => {
+		const noBudget = JSON.parse(coderTemplateText()) as {
+			machine: {context: Record<string, unknown>};
+		};
+		noBudget.machine.context.issue = {retries: 0};
+
+		expect(compiledInitials(JSON.stringify(noBudget))).toEqual([RETRY_BUDGET]);
+	});
+});

--- a/packages/fabrika-cli/src/review/append-criterion-verb.ts
+++ b/packages/fabrika-cli/src/review/append-criterion-verb.ts
@@ -8,9 +8,9 @@
  *    `14`. Authority comes from the ACL check, never from the text being plausible.
  * 2. **Append-only** — the new body is the old plus exactly one row, proven by a diff guard before
  *    the PATCH is sent (`./append.ts`).
- * 3. **Frozen at round K = 3** — at or past the freeze the verb posts the escalation comment and
- *    appends nothing. Append-rate stays bounded by fix-rate; a finding raised at the freeze routes
- *    to a human.
+ * 3. **Frozen at ADR 0079's round K**, read from `../retry-budget.ts`'s `CAP_ROUND` — at or past
+ *    the freeze the verb posts the escalation comment and appends nothing. Append-rate stays
+ *    bounded by fix-rate; a finding raised at the freeze routes to a human.
  * 4. **In-scope-only is the caller's** — the trace-to-stated-goal test is judgment. What this verb
  *    contributes is the provenance tag, which is what makes a routed row auditable afterwards.
  *
@@ -22,6 +22,7 @@ import type {ChildProcessSpawner} from "effect/unstable/process";
 import {createComment, getIssue, patchIssueBody} from "../io/issues.ts";
 import {permissionFor, viewerLogin} from "../io/pulls.ts";
 import type {StdinRead} from "../io/stdin.ts";
+import {CAP_ROUND} from "../retry-budget.ts";
 import {answer, refuse, type VerbOutcome} from "../verb.ts";
 import {read as readCriteria} from "../wire/acceptance-criteria.ts";
 import {appendOnly, criterionRow, grewByOne, insertAfterLastCriterion} from "./append.ts";
@@ -37,9 +38,6 @@ import {
 import {badNumber, resolveTargetRepo} from "./target.ts";
 
 const VERB = "review append-criterion";
-
-/** The round at which the fence closes. ADR 0079 sets K = N = 3. */
-export const FREEZE_ROUND = 3;
 
 /** The permissions that resolve at or above `write`. Anything else, or a failed lookup, refuses. */
 const WRITE_OR_ABOVE = new Set(["admin", "maintain", "write"]);
@@ -128,13 +126,13 @@ export const runAppendCriterion = (
 		}
 		const before = block.value;
 
-		// Fence 3 — frozen at K = 3. The escalation lands and the AC does not; both are proven exit-0
+		// Fence 3 — frozen at the cap round. The escalation lands and the AC does not; both are exit-0
 		// answers, discriminated by the stdout token.
-		if (round >= FREEZE_ROUND) {
+		if (round >= CAP_ROUND) {
 			const escalated = yield* createComment(
 				repo,
 				issue,
-				`review append-criterion: a finding from PR #${pr}'s round ${round} was NOT appended — the acceptance-criteria fence is frozen at round ${FREEZE_ROUND} (ADR 0079). Routing it to a human instead.\n\n${authored.text}`,
+				`review append-criterion: a finding from PR #${pr}'s round ${round} was NOT appended — the acceptance-criteria fence is frozen at round ${CAP_ROUND} (ADR 0079). Routing it to a human instead.\n\n${authored.text}`,
 			);
 			if (escalated._tag === "Failure") {
 				return refuse(

--- a/packages/fabrika-cli/src/review/command.ts
+++ b/packages/fabrika-cli/src/review/command.ts
@@ -13,6 +13,7 @@ import {Effect, Option} from "effect";
 import {Argument, Command, Flag} from "effect/unstable/cli";
 import {leafCommand} from "../excess-operand.ts";
 import {readStdin} from "../io/stdin.ts";
+import {CAP_ROUND} from "../retry-budget.ts";
 import type {VerbOutcome} from "../verb.ts";
 import {runAppendCriterion} from "./append-criterion-verb.ts";
 import {runCi} from "./ci-verb.ts";
@@ -262,7 +263,7 @@ const appendCriterion = leafCommand(
 		),
 		round: Flag.integer("round").pipe(
 			Flag.withDescription(
-				"this review round's number; at or past the freeze (3) the verb escalates instead of appending",
+				`this review round's number; at or past the freeze (${CAP_ROUND}) the verb escalates instead of appending`,
 			),
 		),
 		repo: repoFlag,


### PR DESCRIPTION
The retry cap was three numbers for one concept: `build/rounds.ts`'s `ROUND_CAP = 3`, `lane/emit.ts`'s `MAX_RETRIES = 2` beside the coder template's `maxRetries: 2`, and `review/append-criterion-verb.ts`'s `FREEZE_ROUND = 3`. This folds them onto one declaration in `packages/fabrika-cli/src/retry-budget.ts`:

- `RETRY_BUDGET = 2` — the retries a failing task gets. The lane machine's number survived because its transition guard (`retries < maxRetries`) enforces it, rather than a caller remembering to check.
- `CAP_ROUND = RETRY_BUDGET + 1` — derived, not a second value. Every previous `3` was this.

`capReached` is still `rounds >= 3`, the acceptance-criteria fence still freezes at round 3, the coder template and every emitted epic machine still carry `maxRetries: 2`, and the golden epic-machine fixture is byte-identical. `verdicts-verb.ts`'s `round > 2` threshold became `round >= CAP_ROUND`, which is the same round.

`countRounds` and its 120 s clustering rule are untouched, including the exactly-120 000 ms boundary case pinned by #4570. Its three-separated-timestamps test now asserts the literal `3` it counts, so raising `RETRY_BUDGET` cannot red a test about the clustering rule.

`retry-budget.unit.test.ts` is the drift guard the issue asks for: the committed `coder.workflow.json` is JSON and cannot import the constant, so the test compiles the committed template bytes and an emitted epic machine and asserts both land on `RETRY_BUDGET`. A template edit reds there.

The `review` and `build` skill texts now name where the budget is read from instead of restating a number: `review/contract.md`'s `--round` flag row, its `escalated-frozen` output line, and fence 3 all point at `src/retry-budget.ts`'s `CAP_ROUND`.

`epic/ledger.ts`'s `FAIL_AXIS_CAP` / `DEAD_AXIS_CAP` are untouched — frozen by #5683, retired by #5731.

Fixes #5732

## Deviations

- **Out-of-scope change** — **Said:** fold the three declared caps onto one constant; the issue never asked to change any compiled value. **Did:** `lane/machine.ts`'s compile default `DEFAULT_MAX_RETRIES = 3` became `RETRY_BUDGET`, which is 2, so a task context that omits `maxRetries` now compiles to one fewer retry than before. **Why:** a default that disagrees with the declared budget is a fourth value of the same number, and leaving it at 3 would have kept the drift this issue exists to kill. The direction is fail-closed — the guard `retries < maxRetries` fires sooner, so nothing passes that the old default stopped. No committed workflow relies on it: the coder template and every emitted epic machine declare `maxRetries` explicitly. **Disposition:** kept, disclosed here.
- **Pre-existing test or fixture changed** — **Said:** `countRounds`'s existing unit tests pass untouched. **Did:** `build/rounds.unit.test.ts`'s three-separated-timestamps case was rewritten twice — first from `ROUND_CAP` to the imported `CAP_ROUND`, then, this round, to the literal `3`. The 120 000 ms boundary case and `countRounds` itself are untouched. **Why:** the case asserted the cap rather than what the clustering rule counts, so any budget change would have reddened a test about the 120 s rule. Asserting the literal cuts that coupling, which is acceptance criterion 6. **Disposition:** kept; the assertion is tighter than before, not removed.
- **Pre-existing test or fixture changed** — **Said:** touch only the retry-cap declarations. **Did:** `exit-code-alignment.unit.test.ts`'s synthetic source fixture renamed its made-up constant `FREEZE_ROUND` to `ROUND_LIMIT`. **Why:** `FREEZE_ROUND` no longer exists anywhere, so the fixture read as a reference to a real declaration. It is a string of fake source the scanner parses, not a declaration. **Disposition:** renamed, behaviour identical.
- **Known defect left unfixed** — **Said:** validate every changed file class, so the four changed skill markdown files should carry a prose green. **Did:** `fabrika build check --surface prose` is red on this branch and the markdown rests on the code green and on review instead. **Why:** it reds on three illustrative example paths in `build/contract.md` (lines 333, 972, 1216) that this diff does not touch — byte-identical on `origin/main`. **Disposition:** left; already filed as #5632.
