### PR TITLE
chore: gitignore agent-session working state

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -74,3 +74,19 @@ apps/web/tests/e2e/.auth
 !.vscode/extensions.json
 !.vscode/settings.json
 .idea
+
+# Driver/agent session working state — dropped into the repo root by live
+# sessions (status pages, screenshots, retro notes, per-session crew state);
+# never committed. Real repo images live under app dirs, not the root.
+/scratchpad/
+/scratchpad-*.png
+/*.png
+/retro/
+/.claude/crew-run/
+/.claude/settings.local.json
+
+# Stray .claude/ dirs subagents mint inside package trees when a tool runs
+# with a package cwd — always accidental; the root /.claude/ stays tracked.
+packages/**/.claude/
+claude-plugins/**/.claude/
+apps/**/.claude/


### PR DESCRIPTION
Founder-requested quick change, no pipeline: ignore the working state live sessions drop into the checkout — `/scratchpad/`, root screenshots (`/*.png`, `/scratchpad-*.png`), `/retro/`, `.claude/crew-run/`, `.claude/settings.local.json`, and the stray `.claude/` dirs subagents mint inside package trees (root `/.claude/` stays tracked).

Deliberately NOT ignored (left visible for a human call): `DESIGN-AUDIT.md`, `apps/web/.github/`, `apps/web/binclusive.json`, and `packages/pipeline-crew-mcp/` — the last is a whole untracked package, which is real code sitting uncommitted, not droppings.

### Acceptance criteria
- [ ] `git status` on a driver checkout no longer lists scratchpad/screenshot/retro/crew-run/stray-.claude paths as untracked, and root `/.claude/settings.json` remains tracked.

🤖 Generated with [Claude Code](https://claude.com/claude-code)