### PR TITLE
docs(adr): 0285 — an epic run produces one PR, and its machine ends in one review of that PR

### DIFF
--- a/.decisions/0285-epic-machine-ends-in-review.md
+++ b/.decisions/0285-epic-machine-ends-in-review.md
@@ -1,21 +1,21 @@
 ---
 id: 0285
-title: An epic's machine ends in one epic-level review state, never a re-review of its children
+title: An epic run produces one PR, and its machine ends in one review of that PR
 status: accepted
 date: 2026-08-17
 tags: [fabrika, pipeline, review, epics, lane]
 ---
 
-# 0285 — An epic's machine ends in one epic-level review state, never a re-review of its children
+# 0285 — An epic run produces one PR, and its machine ends in one review of that PR
 
-**What this decides:** an epic gets exactly one review above its children — a state in the emitted
-lane machine, sitting between the last phase and `complete`, that reviews the epic's merged range.
-Each child's own review still happens once, inside its own region, and one PR per child stays the
-shape.
+**What this decides:** one epic lane run = one branch, one PR. Children land as commits on that
+shared branch and each child's review judges its own commit range locally, on the machine, with no
+push and no CI run. The machine then ends in one epic-level review state that reviews the single PR
+as a whole, and the merge happens once.
 
 ## Context
 
-Retiring `build-epic` ([#5731](https://github.com/kamp-us/phoenix/issues/5731)) drops a property
+Retiring `build-epic` ([#5731](https://github.com/kamp-us/phoenix/issues/5731)) dropped a property
 nothing replaced. `build-epic` conducted an epic into one branch and one PR, so an epic had exactly
 one reviewable unit. The replacement engine does not:
 [`packages/fabrika-cli/src/lane/emit.ts`](../packages/fabrika-cli/src/lane/emit.ts) renders one
@@ -28,72 +28,90 @@ states.tripped  = {type: "final"};
 ```
 
 `complete` is bare. Nothing runs between the last child shipping and the machine finishing, and each
-child's `review` judges that child's PR against that child's own acceptance criteria. So nothing
+child's `review` judges that child's own PR against that child's own acceptance criteria. So nothing
 looks at the epic as a whole: two children can each pass their own gate and contradict each other, a
 child can satisfy its criteria while breaking the epic's stated goal, and an epic can land half its
 children and stop. `fabrika lane status` folds the ledger, which is control flow, not a diff.
 
-One PR per child is [#5680](https://github.com/kamp-us/phoenix/issues/5680)'s stated design, ruled
-and not in question. The open question, filed as
-[#5784](https://github.com/kamp-us/phoenix/issues/5784), was only whether the dropped property needs
-a replacement. The founder ruled on 2026-08-17 that it does, and named the shape.
+That was the question filed as [#5784](https://github.com/kamp-us/phoenix/issues/5784). The founder
+first ruled that the missing epic review is real and must be a state. He then
+[re-ruled the surrounding shape](https://github.com/kamp-us/phoenix/issues/5784#issuecomment-5310972958)
+on 2026-08-17: an epic run produces **one PR total**, not one per child. His earlier "we can trust
+each commit is reviewed locally" meant commits inside one PR; the per-child-PR reading was the
+driver's, and he corrected it directly ("I WANT A SINGLE PR FOR EACH WORKFLOW").
 
-This supersedes and amends nothing. It sits beside
-[0283](0283-local-ledger-holds-ownable-orderings.md), which draws the line between what the local
-lane ledger may own and what stays on the board: an epic-review verdict is a verdict, so it lives on
-GitHub like every other one, and only the state that *sequences* the review lives in the machine. It
-also completes a pair rather than duplicating one: [0047](0047-review-plan-gate.md) gates an epic's
-*plan* before any child is built; this gates the epic's *result* after every child has shipped.
+The reason is cost, and it is the design center rather than a bonus
+([rationale](https://github.com/kamp-us/phoenix/issues/5800#issuecomment-5310985901)): moving the
+build → review → repair loop onto the machine makes a FAIL-repair round cost zero pushes, zero CI
+runs and zero board writes. The per-child-PR lanes that ran that night each spent one to two repair
+rounds through GitHub. That round trip is what this removes.
+
+This reverses [#5680](https://github.com/kamp-us/phoenix/issues/5680)'s one-PR-per-child shape, for
+epic lane runs only. #5680's phase-3 children already shipped under the old shape and that history
+stands. Single-issue lanes are untouched: one issue, one PR, as today.
+
+It sits beside [0283](0283-local-ledger-holds-ownable-orderings.md), which draws the line between
+what the local lane ledger may own and what stays on the board: a review verdict is a verdict, so it
+lives on GitHub, and only the state that *sequences* a review lives in the machine. It also completes
+a pair rather than duplicating one: [0047](0047-review-plan-gate.md) gates an epic's *plan* before
+any child is built; this gates the epic's *result* before the one PR merges.
 
 ## Decision
 
-**An epic's emitted lane machine ends in one epic-level review state — between the last phase and
-`complete` — that reviews the epic's merged range as one change, and per-child review inside each
-region stays the inner trust unit.**
+**An epic lane run produces one branch and one PR. Each child's region reviews that child's commit
+range locally on the branch, and the machine ends — between the last phase and `complete` — in one
+epic-level review state that reviews the single PR as a whole.**
 
 Two halves, and the split is the whole point.
 
-*The inner unit is already trusted.* An operator run encompasses the agent spawns beneath it, so
-every commit is reviewed locally as it lands, against the child issue that asked for it. That local
-review is the cheap one — small diff, small context, one issue's criteria. The epic-level state
-therefore reviews the merged range for coherence, not correctness re-run: cross-child
-contradictions, drift from the epic's stated goal, and children that landed against a topology that
-changed under them. Re-reviewing every child's diff at the epic level would pay the token cost twice
-and buy the second-cheapest signal.
+*The inner unit is local and range-scoped.* An operator run encompasses the agent spawns beneath it,
+so every child's commits are reviewed as they land, against the child issue that asked for them,
+without leaving the machine. That review is the cheap one — small diff, small context, one issue's
+criteria — and a FAIL sends the child straight back into repair with nothing published. Nothing
+reaches GitHub until the child's range passes.
 
-*The machine definition is where a structural guarantee belongs.* This is encoded as a state, not a
-convention a driver is expected to remember. A state cannot be skipped by an agent that forgot, it
-shows up in `lane status`, and it is deterministic output of `emitMachine` for every epic — a
-convention living in a skill's prose is none of those things.
+*The outer unit is the PR.* The epic-level state reviews the one PR for coherence, not correctness
+re-run: cross-child contradictions, drift from the epic's stated goal, and children built against a
+shape that changed under them. Re-reviewing every child's diff there would pay the token cost twice
+for the second-cheapest signal.
 
 **Binding constraints.**
 
-- One PR per child region stands. This record does not reverse #5680's shape, does not reintroduce a
-  single epic branch, and is not a step back toward `build-epic`.
-- Per-child `review` is untouched. The epic-level state never re-judges a child's PR against that
-  child's acceptance criteria — that verdict already exists and is in force.
+- One PR per epic **run**, not per child. One branch, children as commits on it, one merge at the
+  end. A shape that opens a PR per child does not satisfy this record.
+- Per-child review is local and range-scoped. It judges a commit range on the shared branch, runs
+  entirely on the machine, and its build → review → repair rounds cost zero pushes, zero CI runs and
+  zero board writes.
+- The epic-level review reviews the single PR as a whole, and never re-judges a child's range against
+  that child's acceptance criteria — that verdict already exists and is in force.
 - The guarantee is a state in `emitMachine`'s output, never a step a driver or skill is trusted to
-  perform. A shape that puts it anywhere but the machine definition does not satisfy this record.
-- The review's scope is a commit range, not a PR. Whatever seam is built for it must accept that
-  scope rather than fold the epic back into a pull request to make an existing reviewer fit.
-- The epic-level verdict is a verdict: it lives on GitHub, not in the local lane ledger
+  perform. A convention in a skill's prose can be skipped by an agent that forgot, does not show up
+  in `lane status`, and is not deterministic output; a state is all three.
+- Verdicts are verdicts: the per-child range verdicts and the epic verdict live on GitHub, bound to
+  the range or the PR they judge, not in the local lane ledger
   ([0283](0283-local-ledger-holds-ownable-orderings.md)).
+- Single-issue lanes keep one PR per issue. Nothing here touches them.
 
 The build is a separate issue. This record decides the shape and nothing else.
 
 ## Consequences
 
-Easier: an epic has an answer to "review this as one change" again, and it is one the reader finds
-in `workflow.json` rather than in a skill's prose. The property `build-epic` bought survives its
-retirement without the single-branch cost that made `build-epic` worth retiring.
+Easier: an epic has one reviewable unit again — the property `build-epic` bought, without
+`build-epic`. The repair loop stops paying GitHub for every round: a child that fails review costs a
+local retry instead of a push, a CI run and a board write. The board surface shrinks to the one PR,
+the range-bound verdicts, and the terminal epic review.
 
-Harder: the emitter grows a spawn seam and the review surface grows a scope it does not have today —
-a merged commit range instead of a pull request. An epic also stops being done the moment its last
-child ships; it is done when the epic-level state passes. That interacts with
-[0131](0131-epic-autoclose-on-all-children-closed.md), which closes an epic on all-children-closed:
-the auto-close still fires on the GitHub edge and is unchanged by this record, so an epic's issue can
-close while its lane is still in the review state. The building issue owns reconciling those two, and
-this record does not pre-decide it.
+Harder: the emitter grows a spawn seam, the branch is now shared across children so regions can no
+longer be treated as independent trees, and the review surface grows a scope it does not have today —
+a commit range on a live branch, not a pull request. An epic also stops being done when its last
+child's commits land; it is done when the epic review passes and the one PR merges.
+
+That interacts with [0131](0131-epic-autoclose-on-all-children-closed.md), which closes an epic once
+all its children close, and the one-PR shape deepens it: children now close as their ranges land,
+before the single PR exists in a mergeable state, so an epic issue can auto-close while its lane is
+still building, still in the epic review, or waiting on the merge. The auto-close fires on the GitHub
+edge and is unchanged by this record. The building issue owns reconciling the two, and this record
+does not pre-decide it.
 
 ## Records
 
@@ -101,6 +119,10 @@ no vocabulary impact — epic-level review, lane machine, region and phase are a
 #5680/#5688 vocabulary; nothing is coined or redefined here.
 
 Sources: [#5784](https://github.com/kamp-us/phoenix/issues/5784) (the question and the founder's
-ruling, comment 5310867155), [#5680](https://github.com/kamp-us/phoenix/issues/5680) (the one-PR-per-child
-design), [#5731](https://github.com/kamp-us/phoenix/issues/5731) (the `build-epic` retirement this
-unblocks), [`packages/fabrika-cli/src/lane/emit.ts`](../packages/fabrika-cli/src/lane/emit.ts).
+[re-ruling](https://github.com/kamp-us/phoenix/issues/5784#issuecomment-5310972958)),
+[#5800](https://github.com/kamp-us/phoenix/issues/5800) (the
+[rationale amendment](https://github.com/kamp-us/phoenix/issues/5800#issuecomment-5310985901) — the
+local loop is the point), [#5680](https://github.com/kamp-us/phoenix/issues/5680) (the one-PR-per-child
+design this reverses for epic runs), [#5731](https://github.com/kamp-us/phoenix/issues/5731) (the
+`build-epic` retirement this unblocks),
+[`packages/fabrika-cli/src/lane/emit.ts`](../packages/fabrika-cli/src/lane/emit.ts).

--- a/.decisions/0285-epic-machine-ends-in-review.md
+++ b/.decisions/0285-epic-machine-ends-in-review.md
@@ -1,0 +1,106 @@
+---
+id: 0285
+title: An epic's machine ends in one epic-level review state, never a re-review of its children
+status: accepted
+date: 2026-08-17
+tags: [fabrika, pipeline, review, epics, lane]
+---
+
+# 0285 — An epic's machine ends in one epic-level review state, never a re-review of its children
+
+**What this decides:** an epic gets exactly one review above its children — a state in the emitted
+lane machine, sitting between the last phase and `complete`, that reviews the epic's merged range.
+Each child's own review still happens once, inside its own region, and one PR per child stays the
+shape.
+
+## Context
+
+Retiring `build-epic` ([#5731](https://github.com/kamp-us/phoenix/issues/5731)) drops a property
+nothing replaced. `build-epic` conducted an epic into one branch and one PR, so an epic had exactly
+one reviewable unit. The replacement engine does not:
+[`packages/fabrika-cli/src/lane/emit.ts`](../packages/fabrika-cli/src/lane/emit.ts) renders one
+region per child (`region()` — `queued → build → review → ship → shipped`), groups regions into
+phases, sequences phases by `onDone`, and then ends:
+
+```ts
+states.complete = {type: "final"};
+states.tripped  = {type: "final"};
+```
+
+`complete` is bare. Nothing runs between the last child shipping and the machine finishing, and each
+child's `review` judges that child's PR against that child's own acceptance criteria. So nothing
+looks at the epic as a whole: two children can each pass their own gate and contradict each other, a
+child can satisfy its criteria while breaking the epic's stated goal, and an epic can land half its
+children and stop. `fabrika lane status` folds the ledger, which is control flow, not a diff.
+
+One PR per child is [#5680](https://github.com/kamp-us/phoenix/issues/5680)'s stated design, ruled
+and not in question. The open question, filed as
+[#5784](https://github.com/kamp-us/phoenix/issues/5784), was only whether the dropped property needs
+a replacement. The founder ruled on 2026-08-17 that it does, and named the shape.
+
+This supersedes and amends nothing. It sits beside
+[0283](0283-local-ledger-holds-ownable-orderings.md), which draws the line between what the local
+lane ledger may own and what stays on the board: an epic-review verdict is a verdict, so it lives on
+GitHub like every other one, and only the state that *sequences* the review lives in the machine. It
+also completes a pair rather than duplicating one: [0047](0047-review-plan-gate.md) gates an epic's
+*plan* before any child is built; this gates the epic's *result* after every child has shipped.
+
+## Decision
+
+**An epic's emitted lane machine ends in one epic-level review state — between the last phase and
+`complete` — that reviews the epic's merged range as one change, and per-child review inside each
+region stays the inner trust unit.**
+
+Two halves, and the split is the whole point.
+
+*The inner unit is already trusted.* An operator run encompasses the agent spawns beneath it, so
+every commit is reviewed locally as it lands, against the child issue that asked for it. That local
+review is the cheap one — small diff, small context, one issue's criteria. The epic-level state
+therefore reviews the merged range for coherence, not correctness re-run: cross-child
+contradictions, drift from the epic's stated goal, and children that landed against a topology that
+changed under them. Re-reviewing every child's diff at the epic level would pay the token cost twice
+and buy the second-cheapest signal.
+
+*The machine definition is where a structural guarantee belongs.* This is encoded as a state, not a
+convention a driver is expected to remember. A state cannot be skipped by an agent that forgot, it
+shows up in `lane status`, and it is deterministic output of `emitMachine` for every epic — a
+convention living in a skill's prose is none of those things.
+
+**Binding constraints.**
+
+- One PR per child region stands. This record does not reverse #5680's shape, does not reintroduce a
+  single epic branch, and is not a step back toward `build-epic`.
+- Per-child `review` is untouched. The epic-level state never re-judges a child's PR against that
+  child's acceptance criteria — that verdict already exists and is in force.
+- The guarantee is a state in `emitMachine`'s output, never a step a driver or skill is trusted to
+  perform. A shape that puts it anywhere but the machine definition does not satisfy this record.
+- The review's scope is a commit range, not a PR. Whatever seam is built for it must accept that
+  scope rather than fold the epic back into a pull request to make an existing reviewer fit.
+- The epic-level verdict is a verdict: it lives on GitHub, not in the local lane ledger
+  ([0283](0283-local-ledger-holds-ownable-orderings.md)).
+
+The build is a separate issue. This record decides the shape and nothing else.
+
+## Consequences
+
+Easier: an epic has an answer to "review this as one change" again, and it is one the reader finds
+in `workflow.json` rather than in a skill's prose. The property `build-epic` bought survives its
+retirement without the single-branch cost that made `build-epic` worth retiring.
+
+Harder: the emitter grows a spawn seam and the review surface grows a scope it does not have today —
+a merged commit range instead of a pull request. An epic also stops being done the moment its last
+child ships; it is done when the epic-level state passes. That interacts with
+[0131](0131-epic-autoclose-on-all-children-closed.md), which closes an epic on all-children-closed:
+the auto-close still fires on the GitHub edge and is unchanged by this record, so an epic's issue can
+close while its lane is still in the review state. The building issue owns reconciling those two, and
+this record does not pre-decide it.
+
+## Records
+
+no vocabulary impact — epic-level review, lane machine, region and phase are all already the
+#5680/#5688 vocabulary; nothing is coined or redefined here.
+
+Sources: [#5784](https://github.com/kamp-us/phoenix/issues/5784) (the question and the founder's
+ruling, comment 5310867155), [#5680](https://github.com/kamp-us/phoenix/issues/5680) (the one-PR-per-child
+design), [#5731](https://github.com/kamp-us/phoenix/issues/5731) (the `build-epic` retirement this
+unblocks), [`packages/fabrika-cli/src/lane/emit.ts`](../packages/fabrika-cli/src/lane/emit.ts).


### PR DESCRIPTION
Records the founder's **re-ruling** of 2026-08-17 on #5784 ([comment](https://github.com/kamp-us/phoenix/issues/5784#issuecomment-5310972958)) as ADR `0285`. This PR was halted pre-ship and rewritten to that shape; the earlier draft recorded the superseded per-child-PR reading.

The ruling: an epic lane run produces **one PR total**. Children land as commits on one shared branch, each child's review judges its own commit range **locally** — zero pushes, zero CI runs, zero board writes per repair round — and the machine ends in one epic-level review state that reviews the single PR as a whole. Merge happens once, at the end. Single-issue lanes are untouched: one issue, one PR.

Why this shape ([rationale amendment on #5800](https://github.com/kamp-us/phoenix/issues/5800#issuecomment-5310985901)): moving the build → review → repair loop onto the machine is the design center, not a bonus. The per-child-PR lanes each spent one to two repair rounds through GitHub; that round trip is what this removes. The board surface shrinks to the one PR, the range-bound verdicts, and the terminal epic review.

This **reverses** #5680's one-PR-per-child shape, for epic lane runs only. #5680's phase-3 children already shipped under the old shape and that history stands.

Sweep: `fabrika adr sweep --new 0285` re-run after the rewrite (271 records scanned, 230 uncited live-accepted in scope). Shortlist judged; no contradiction with any live-accepted record. #0048's "one PR per invocation" is about `ship` taking one PR and stays true (an epic run ships its one PR once). #0047 (`review-plan`) gates an epic's plan before any child is built, this gates its result before the one PR merges. #0283 keeps the verdicts on GitHub, so only the sequencing state lives in the machine. #0131 (epic auto-close on all-children-closed) is untouched, and the interaction **deepens** under the one-PR shape: children now close as their ranges land, before the single PR is mergeable, so an epic issue can auto-close while its lane is still building or waiting on the merge. Named in Consequences for the build issue to reconcile; not pre-decided here.

The engine change (region shape, shared branch, review scope) is a re-plan filed separately — this PR records the decision and builds nothing.

Closes #5784

### Acceptance criteria

- [ ] A `.decisions/` record answers the question: does an epic get a review unit above its children, yes or no, with the why.
- [ ] If the answer is yes, the shape is named and a follow-up issue is filed to build it; this issue does not build it.
- [ ] The disposition is linked back on #5731 so its "every lost row filed with a disposition" criterion can be checked off.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Deviations

None.
