### PR TITLE
The operator hand-writes every spawn prompt; there is no lane counterpart to epic brief

### DIFF
--- a/claude-plugins/fabrika/docs/wire-formats.md
+++ b/claude-plugins/fabrika/docs/wire-formats.md
@@ -41,6 +41,7 @@ does not exist yet — rather than missing; check the registry before assuming a
 | `deviations` | [`packages/fabrika-cli/src/wire/deviations.ts`](../../../packages/fabrika-cli/src/wire/deviations.ts) | `build`, `build-ui`, `build-epic` | `review`, `review-ui` |
 | `verdict-marker` | [`packages/fabrika-cli/src/wire/verdict-marker.ts`](../../../packages/fabrika-cli/src/wire/verdict-marker.ts) | `review`, `check-epic-plan`, `governance` | `build`, `ship` |
 | `slice-handoff` | [`packages/fabrika-cli/src/wire/slice-handoff.ts`](../../../packages/fabrika-cli/src/wire/slice-handoff.ts) | `build-epic` | `build` |
+| `lane-brief` | [`packages/fabrika-cli/src/wire/lane-brief.ts`](../../../packages/fabrika-cli/src/wire/lane-brief.ts) | `operate` | `build`, `review`, `ship` |
 | `map-ticket` | [`packages/fabrika-cli/src/wire/map-ticket.ts`](../../../packages/fabrika-cli/src/wire/map-ticket.ts) | `map` | `map` |
 | `grill-ruling` | [`packages/fabrika-cli/src/wire/grill-ruling.ts`](../../../packages/fabrika-cli/src/wire/grill-ruling.ts) | `grilling` | `grilling` |
 | `grill-answer` | [`packages/fabrika-cli/src/wire/grill-answer.ts`](../../../packages/fabrika-cli/src/wire/grill-answer.ts) | `grilling` | `grilling` |
@@ -106,6 +107,18 @@ own words from someone else's. So the section set is closed and the rules text i
 module, and a brief carrying anything outside them reads as drifted rather than as a brief with
 extra advice. Its paths are machine-local by construction, which is also why a brief is consumed in
 session and never posted to a public surface.
+
+### `lane-brief`
+
+This is the spawn prompt a lane driver hands one fabrika shell, and it exists because the prompt is
+the whole interface between the machine and the work. Written per dispatch, two drivers driving the
+same state send materially different instructions, and the rule that matters most — carry the URLs,
+never a restatement, because a restated spec is a stale spec — is enforced by nothing but the
+driver's care. So the format owns the rules text byte for byte and the state → shell routing table
+with it, and `lane brief` prints what it derives instead of composing anything. `## Ground` carries
+links and no content at all: the shell re-reads its own issue, PR and verdicts through its own
+verbs. A `review` or `ship` brief with no PR is malformed rather than dispatchable, because that
+shell would have nothing to read.
 
 ### `map-ticket`
 

--- a/claude-plugins/fabrika/skills/operate/SKILL.md
+++ b/claude-plugins/fabrika/skills/operate/SKILL.md
@@ -73,29 +73,35 @@ active phase** (future phases read `waiting`; leave them alone), route on the le
 | Leaf state | Action |
 | --- | --- |
 | `queued` | record `WIP` — the task enters build |
-| `build` | spawn `builder` — repair mode with the PR when the task's issue already carries an open PR, construction with the issue otherwise |
-| `review` | spawn `reviewer` on the task's PR |
-| `ship` | spawn `shipper` on the task's PR |
+| `build` / `review` / `ship` | dispatch through `lane brief` — below |
 | `human:*` | park — step 4 |
 | `blocked` | park — step 4 |
 | any other name | park naming the state — never guess a shell for a state you do not recognise |
 
-The issue a task drives: on an emitted epic lane the task's own name (regions are the children);
-on an opened single lane the lane number itself. The task's PR is read off the board, never off
-your memory: the open PR whose body traces to the task's issue
-(`gh pr list --state open --search "$issue_number in:body" --json number,url,headRefName`) — exactly one is
-the lane's; zero where the state demands one, or several, is a park naming the ambiguity.
-Parallel active tasks spawn in parallel.
+**You never compose a spawn prompt.** The verb prints it:
 
-Every spawn, no exceptions:
+```bash
+node packages/fabrika-cli/src/bin.ts lane brief $issue_number --task <name>
+```
 
-- **Worktree isolation** (`isolation: worktree`) — a non-isolated subagent shares the primary
-  checkout and can mutate its git state.
-- **The prompt points at the spec, never restates it**: it carries the URLs — the issue, the PR,
-  the verdict comments, as each exists — and no summary of their content; the shell re-reads its
-  own ground through its own verbs.
-- **The prompt instructs `node packages/fabrika-cli/src/bin.ts` for every fabrika verb**, never
-  the bare binstub (#5679 again, now in the spawned tree).
+Its stdout is the whole prompt — send those bytes to the spawn verbatim and add nothing to them. It
+derives every value: the state from the same fold you just read, the shell from its own routing
+table (`build` → builder, `review` → reviewer, `ship` → shipper), the issue and PR URLs off the
+board, and its rules from byte-fixed text the `lane-brief` wire format owns
+([`packages/fabrika-cli/src/wire/lane-brief.ts`](../../../../packages/fabrika-cli/src/wire/lane-brief.ts)).
+Those rules are the three a driver used to carry in their own prose — the isolated worktree, URLs
+never restatements, and `node packages/fabrika-cli/src/bin.ts` for every fabrika verb rather than
+the bare binstub (#5679, now in the spawned tree). They are in the brief because a prompt written
+per dispatch is a prompt two drivers write differently.
+
+The spawn flag is still yours: **`isolation: worktree`, no exceptions** — a non-isolated subagent
+shares the primary checkout and can mutate its git state, and no bytes in a prompt can enforce that
+from the inside.
+
+`lane brief`'s refusals are the parks it saves you from guessing at: `18` is a state that routes to
+no shell, `19` is a task whose issue cannot be resolved or is absent, `20` is zero open PRs where
+the state needs one or several where one is required. Each is a park naming what the verb named —
+never a prompt you write by hand instead. Parallel active tasks brief and spawn in parallel.
 
 Done when every active task has either a spawn in flight or an event recorded this pass.
 
@@ -193,6 +199,6 @@ fabrika skill, so one reader parses all of them. No row here dead-ends on a bare
 
 | Must exist | Why this skill needs it | When missing |
 | --- | --- | --- |
-| The lane verb group — `packages/fabrika-cli/src/bin.ts` routing `lane status`/`transition`/`history`/`print` plus `open`/`emit` (#5688) | Every state read and every event write in this skill is one of these verbs; there is no other path to the ledger | **fail-loud** — a verb that cannot be executed leaves the lane state UNKNOWN; the run ends `STOPPED` naming `packages/fabrika-cli/src/bin.ts` and points at front-door. |
+| The lane verb group — `packages/fabrika-cli/src/bin.ts` routing `lane status`/`transition`/`history`/`print` plus `open`/`emit` (#5688) and `brief` (#5751) | Every state read, every event write and every spawn prompt in this skill is one of these verbs; there is no other path to the ledger, and none to a prompt | **fail-loud** — a verb that cannot be executed leaves the lane state UNKNOWN; the run ends `STOPPED` naming `packages/fabrika-cli/src/bin.ts` and points at front-door. |
 | The agent shells — `claude-plugins/fabrika/agents/builder.md`, `reviewer.md`, `shipper.md` | Step 2's routing table spawns exactly these three by their bare noun names | **fail-loud** — a route whose shell does not exist cannot spawn; the run ends `STOPPED` naming the absent shell file, and no event is recorded for a spawn that never started. |
 | `.gitignore` covering `.fabrika/` | The ledger is a disposable machine-local artifact, regenerable from the board — committed, it would smuggle one machine's lane state into every checkout | **degrade** — the verbs still work; state the uncovered `.fabrika/` in the park or transcript comment and file the gap via `/report`. |

--- a/packages/fabrika-cli/src/io/pulls.ts
+++ b/packages/fabrika-cli/src/io/pulls.ts
@@ -14,7 +14,15 @@
 import {Effect} from "effect";
 import {execCapture} from "./exec.ts";
 import {type Attempt, fail, ok, type Shell} from "./git.ts";
-import {absent, type Existence, httpStatusOf, pagedJson, present, unknown} from "./issues.ts";
+import {
+	absent,
+	type Existence,
+	httpStatusOf,
+	pagedJson,
+	parseTabRows,
+	present,
+	unknown,
+} from "./issues.ts";
 import {isRecord, parseJson} from "./json.ts";
 
 export interface PullRecord {
@@ -251,6 +259,46 @@ export const patchComment = (repo: string, id: number, body: string): Shell<Atte
 		return isRecord(parsed) && typeof parsed.html_url === "string"
 			? ok(parsed.html_url)
 			: fail("`gh api` exited 0 but its output is not an edited comment");
+	});
+
+/** One open pull request as a body-trace lookup sees it: the number and the link to hand on. */
+export interface TracingPull {
+	readonly number: number;
+	readonly url: string;
+}
+
+/**
+ * Every OPEN pull request whose body mentions `issue`, paged.
+ *
+ * The lane's PR is read off the board and never off a driver's memory, so the answer is the whole
+ * match set rather than a first hit: zero and several are facts a caller must be able to refuse on,
+ * and a read that narrowed to one would invent the lane's PR whenever two branches trace to the
+ * same issue.
+ */
+export const openPullsTracing = (
+	repo: string,
+	issue: number,
+): Shell<Attempt<ReadonlyArray<TracingPull>>> =>
+	Effect.gen(function* () {
+		const q = `repo:${repo} is:pr is:open ${issue} in:body`;
+		const r = yield* execCapture("gh", [
+			"api",
+			"--paginate",
+			`search/issues?q=${encodeURIComponent(q)}&per_page=100`,
+			"--jq",
+			'.items[] | "\\(.number)\t\\(.html_url)"',
+		]);
+		if (!r.ok) return fail(r.reason);
+		const rows = parseTabRows(r.stdout, 2);
+		if (rows === null) return fail("`gh api` exited 0 but its output is not a list of pull rows");
+		const out: TracingPull[] = [];
+		for (const [number, url] of rows) {
+			if (number === undefined || !/^\d+$/.test(number) || url === undefined || url === "") {
+				return fail("`gh api` exited 0 but one row is not a pull request");
+			}
+			out.push({number: Number.parseInt(number, 10), url});
+		}
+		return ok(out);
 	});
 
 /** One pull request as a branch lookup sees it — enough to pick the newest and state what it is. */

--- a/packages/fabrika-cli/src/lane/brief-verb.ts
+++ b/packages/fabrika-cli/src/lane/brief-verb.ts
@@ -1,0 +1,160 @@
+/**
+ * `lane brief` — the spawn prompt for one task's current leaf state, printed rather than composed.
+ *
+ * Every value is derived: the state from the fold, the shell from the format's routing table, the
+ * issue and PR from the board, the rules from the format's own byte-fixed text. Nothing here is
+ * authored per run, which is the point — a prompt a driver writes by hand is a prompt two drivers
+ * write differently, and the "URLs, never restatements" rule is then enforced by nothing but care.
+ *
+ * The brief is a dispatch artifact, consumed in-session and never posted, so it is not leak-scanned.
+ * It carries no path and no content — only URLs the board already published.
+ */
+import {Effect, type FileSystem, type Path} from "effect";
+import type {ChildProcessSpawner} from "effect/unstable/process";
+import {getIssue, resolveRepo} from "../io/issues.ts";
+import {openPullsTracing} from "../io/pulls.ts";
+import {answer, refuse, type VerbOutcome} from "../verb.ts";
+import {
+	artifactUrl,
+	emit as emitBrief,
+	type LaneBrief,
+	shellOf,
+	shellState,
+} from "../wire/lane-brief.ts";
+import {ISSUE_UNRESOLVED, LANE_UNREADABLE, NO_SHELL, PR_AMBIGUOUS, TASK_UNKNOWN} from "./codes.ts";
+import {foldLog, resolveTask} from "./fold.ts";
+import {loadRefusal, replayRefusal} from "./refusals.ts";
+import {type LaneRef, loadLane} from "./store.ts";
+
+const VERB = "fabrika lane brief";
+
+export interface BriefOptions extends LaneRef {
+	/** The task the brief serves; omittable exactly when the machine leaves no choice. */
+	readonly task: string | null;
+	readonly repo: string | null;
+	readonly env: Readonly<Record<string, string | undefined>>;
+}
+
+/**
+ * The issue a task drives: the number in an emitted epic lane's task name (`issue_<n>`), else the
+ * lane id itself on a single-issue lane. `null` when neither carries one.
+ */
+const issueOf = (lane: string, task: string): number | null => {
+	const named = /^issue_(\d+)$/.exec(task);
+	if (named?.[1] !== undefined) return Number.parseInt(named[1], 10);
+	return /^\d+$/.test(lane.trim()) ? Number.parseInt(lane.trim(), 10) : null;
+};
+
+export const runBrief = (
+	options: BriefOptions,
+): Effect.Effect<
+	VerbOutcome,
+	never,
+	FileSystem.FileSystem | Path.Path | ChildProcessSpawner.ChildProcessSpawner
+> =>
+	Effect.gen(function* () {
+		const loaded = yield* loadLane(options);
+		if (loaded._tag !== "Loaded") return loadRefusal(VERB, loaded);
+		const fold = foldLog(loaded.lane, loaded.entries);
+		if (fold._tag !== "Folded") return replayRefusal(VERB, loaded.logPath, fold);
+
+		const resolved = resolveTask(loaded.lane, options.task);
+		if (resolved._tag !== "Task") return refuse(TASK_UNKNOWN, `${VERB}: ${resolved.reason}.`);
+		const task = resolved.taskId;
+		const leaf = fold.states[task]?.type ?? "";
+		const state = shellState(leaf);
+		if (state === null) {
+			return refuse(
+				NO_SHELL,
+				`${VERB}: task "${task}" is "${leaf}", which routes to no shell — act on that state, do not dispatch.`,
+			);
+		}
+		const shell = shellOf(state);
+
+		const notes = [`${VERB}: folded ${loaded.entries.length} event(s) from ${loaded.logPath}.`];
+		const issue = issueOf(options.lane, task);
+		if (issue === null) {
+			return refuse(
+				ISSUE_UNRESOLVED,
+				`${VERB}: neither task "${task}" nor lane "${options.lane}" names an issue number.`,
+				notes,
+			);
+		}
+
+		const repo = yield* resolveRepo(options.repo, options.env);
+		if (repo._tag === "Failure") {
+			return refuse(
+				LANE_UNREADABLE,
+				`${VERB}: cannot resolve the repository: ${repo.reason} — the ground is UNKNOWN.`,
+				notes,
+			);
+		}
+		const record = yield* getIssue(repo.value, issue);
+		if (record._tag === "Absent") {
+			return refuse(
+				ISSUE_UNRESOLVED,
+				`${VERB}: issue #${issue} is proven absent or closed — there is no ground to brief.`,
+				notes,
+			);
+		}
+		if (record._tag === "Unknown") {
+			return refuse(
+				LANE_UNREADABLE,
+				`${VERB}: cannot read #${issue}: ${record.reason} — the ground is UNKNOWN.`,
+				notes,
+			);
+		}
+		const issueUrl = artifactUrl(record.value.url);
+		if (issueUrl === null) {
+			return refuse(
+				LANE_UNREADABLE,
+				`${VERB}: the board published no URL for #${issue} — the ground is UNKNOWN.`,
+				notes,
+			);
+		}
+
+		const pulls = yield* openPullsTracing(repo.value, issue);
+		if (pulls._tag === "Failure") {
+			return refuse(
+				LANE_UNREADABLE,
+				`${VERB}: cannot read the open PRs tracing to #${issue}: ${pulls.reason} — UNKNOWN.`,
+				notes,
+			);
+		}
+		const [only, ...rest] = pulls.value;
+		if (rest.length > 0) {
+			return refuse(
+				PR_AMBIGUOUS,
+				`${VERB}: ${pulls.value.length} open PRs trace to #${issue} — exactly one is the lane's, and which is not this verb's to guess.`,
+				[...notes, `${VERB}: candidates: ${pulls.value.map((p) => `#${p.number}`).join(", ")}.`],
+			);
+		}
+		if (only === undefined && state !== "build") {
+			return refuse(
+				PR_AMBIGUOUS,
+				`${VERB}: no open PR traces to #${issue}, and a "${state}" shell has nothing to read without one.`,
+				notes,
+			);
+		}
+		const prUrl = only === undefined ? null : artifactUrl(only.url);
+		if (only !== undefined && prUrl === null) {
+			return refuse(
+				LANE_UNREADABLE,
+				`${VERB}: the board published no URL for PR #${only.number} — the ground is UNKNOWN.`,
+				notes,
+			);
+		}
+
+		const brief: LaneBrief = {
+			lane: options.lane,
+			task,
+			state,
+			shell,
+			issue: issueUrl,
+			pr: prUrl,
+		};
+		return answer(emitBrief(brief), [
+			...notes,
+			`${VERB}: task "${task}" is "${state}" — brief the ${shell}.`,
+		]);
+	});

--- a/packages/fabrika-cli/src/lane/brief-verb.unit.test.ts
+++ b/packages/fabrika-cli/src/lane/brief-verb.unit.test.ts
@@ -1,0 +1,275 @@
+/** `lane brief` — the three shell prompts it prints, and every refusal that prints none. */
+import {Effect, Layer} from "effect";
+import {describe, expect, it} from "vitest";
+import {errOut, fakeFs, fakeShell, okOut} from "../fakes.test-support.ts";
+import type {ExecResult} from "../io/exec.ts";
+import {RULES, read as readBrief} from "../wire/lane-brief.ts";
+import {runBrief} from "./brief-verb.ts";
+import {
+	ISSUE_UNRESOLVED,
+	LANE_ABSENT,
+	LANE_UNREADABLE,
+	MALFORMED_RECORD,
+	NO_SHELL,
+	PR_AMBIGUOUS,
+	TASK_UNKNOWN,
+} from "./codes.ts";
+import {coderTemplateText} from "./fixtures.test-support.ts";
+
+const ROOT = ".fabrika/lanes";
+const ISSUE_URL = "https://github.com/o/r/issues/5751";
+const PR_URL = "https://github.com/o/r/pull/5790";
+const TITLE = "the operator hand-writes every spawn prompt";
+
+const ISSUE_READ = /^gh api repos\/o\/r\/issues\/5751$/;
+const CHILD_READ = /^gh api repos\/o\/r\/issues\/5729$/;
+const PR_SEARCH = /^gh api --paginate search\/issues/;
+
+const issuePayload = (number: number, url: string): ExecResult =>
+	okOut(
+		JSON.stringify({
+			number,
+			title: TITLE,
+			body: "## What is wrong\n\nNothing prints it, nothing records it.",
+			state: "open",
+			labels: [{name: "type:feature"}],
+			html_url: url,
+		}),
+	);
+
+const pullRows = (...rows: ReadonlyArray<readonly [number, string]>): ExecResult =>
+	okOut(rows.map(([number, url]) => `${number}\t${url}`).join("\n"));
+
+/** A single-issue lane at `lane`, with one log line per operator event already recorded. */
+const lane = (id: string, events: ReadonlyArray<string>) =>
+	fakeFs({
+		files: {
+			[`${ROOT}/${id}/workflow.json`]: coderTemplateText(),
+			[`${ROOT}/${id}/events.jsonl`]:
+				events.length === 0
+					? null
+					: `${events
+							.map((event) =>
+								JSON.stringify({
+									task: "issue",
+									event: `ISSUE.${event}`,
+									at: "2026-08-17T00:00:00Z",
+								}),
+							)
+							.join("\n")}\n`,
+		},
+	});
+
+const options = {
+	root: ROOT,
+	lane: "5751",
+	task: null as string | null,
+	repo: null as string | null,
+	env: {CLAUDE_PIPELINE_REPO: "o/r"} as Record<string, string | undefined>,
+};
+
+const run = (
+	fs: ReturnType<typeof fakeFs>,
+	script: ReadonlyArray<readonly [RegExp, ExecResult]>,
+	overrides: Partial<typeof options> = {},
+) =>
+	Effect.runPromise(
+		Effect.provide(
+			runBrief({...options, ...overrides}),
+			Layer.merge(fs.layer, fakeShell(script).layer),
+		),
+	);
+
+describe("lane brief", () => {
+	it("briefs the builder on a `build` state, with no PR when construction has none", async () => {
+		const out = await run(lane("5751", ["WIP"]), [
+			[ISSUE_READ, issuePayload(5751, ISSUE_URL)],
+			[PR_SEARCH, okOut("")],
+		]);
+
+		expect(out.code).toBe(0);
+		const brief = readBrief(out.stdout);
+		expect(brief).toMatchObject({
+			_tag: "Found",
+			value: {lane: "5751", task: "issue", state: "build", shell: "builder", issue: ISSUE_URL},
+		});
+		expect(out.stdout).toContain(RULES);
+	});
+
+	it("briefs the reviewer on a `review` state, carrying the one open PR that traces to the issue", async () => {
+		const out = await run(lane("5751", ["WIP", "DONE"]), [
+			[ISSUE_READ, issuePayload(5751, ISSUE_URL)],
+			[PR_SEARCH, pullRows([5790, PR_URL])],
+		]);
+
+		expect(out.code).toBe(0);
+		expect(readBrief(out.stdout)).toMatchObject({
+			_tag: "Found",
+			value: {state: "review", shell: "reviewer", issue: ISSUE_URL, pr: PR_URL},
+		});
+	});
+
+	it("briefs the shipper on a `ship` state", async () => {
+		const out = await run(lane("5751", ["WIP", "DONE", "PASS"]), [
+			[ISSUE_READ, issuePayload(5751, ISSUE_URL)],
+			[PR_SEARCH, pullRows([5790, PR_URL])],
+		]);
+
+		expect(out.code).toBe(0);
+		expect(readBrief(out.stdout)).toMatchObject({
+			_tag: "Found",
+			value: {state: "ship", shell: "shipper", pr: PR_URL},
+		});
+	});
+
+	it("carries URLs only — no title, no body, no verdict text", async () => {
+		const out = await run(lane("5751", ["WIP", "DONE"]), [
+			[ISSUE_READ, issuePayload(5751, ISSUE_URL)],
+			[PR_SEARCH, pullRows([5790, PR_URL])],
+		]);
+
+		expect(out.stdout).not.toContain(TITLE);
+		expect(out.stdout).not.toContain("Nothing prints it");
+	});
+
+	it("resolves an emitted epic lane's task to the child issue its name carries", async () => {
+		const fs = fakeFs({
+			files: {
+				[`${ROOT}/5680/workflow.json`]: JSON.stringify({
+					id: "epic-5680",
+					version: 1,
+					machine: {
+						id: "epic-5680",
+						initial: "phase1",
+						context: {issue_5729: {retries: 0, maxRetries: 2}},
+						states: {
+							phase1: {
+								type: "parallel",
+								states: {
+									issue_5729: {
+										initial: "queued",
+										states: {
+											queued: {on: {"ISSUE_5729.WIP": "build"}},
+											build: {on: {"ISSUE_5729.DONE": "review"}},
+											review: {on: {"ISSUE_5729.PASS": "ship"}},
+											ship: {on: {"ISSUE_5729.DONE": "shipped"}},
+											shipped: {type: "final"},
+										},
+									},
+								},
+								onDone: [{target: "complete", guard: "noErrors"}, {target: "tripped"}],
+							},
+							complete: {type: "final"},
+							tripped: {type: "final"},
+						},
+					},
+				}),
+				[`${ROOT}/5680/events.jsonl`]: `${JSON.stringify({
+					task: "issue_5729",
+					event: "ISSUE_5729.WIP",
+					at: "2026-08-17T00:00:00Z",
+				})}\n`,
+			},
+		});
+		const out = await run(
+			fs,
+			[
+				[CHILD_READ, issuePayload(5729, "https://github.com/o/r/issues/5729")],
+				[PR_SEARCH, okOut("")],
+			],
+			{lane: "5680", task: "issue_5729"},
+		);
+
+		expect(out.code).toBe(0);
+		expect(readBrief(out.stdout)).toMatchObject({
+			_tag: "Found",
+			value: {lane: "5680", task: "issue_5729", issue: "https://github.com/o/r/issues/5729"},
+		});
+	});
+
+	it("refuses a leaf state that routes to no shell, naming the state", async () => {
+		const out = await run(lane("5751", []), []);
+
+		expect(out.code).toBe(NO_SHELL);
+		expect(out.stdout).toBe("");
+		expect(out.stderr.join("\n")).toContain('"queued"');
+	});
+
+	it("refuses a `human:*` park the same way — a park is never a dispatch", async () => {
+		const out = await run(lane("5751", ["WIP", "DONE", "PASS", "BLOCKED"]), []);
+
+		expect(out.code).toBe(NO_SHELL);
+		expect(out.stderr.join("\n")).toContain("human:cp-approval");
+	});
+
+	it("refuses a task the machine does not hold", async () => {
+		const out = await run(lane("5751", ["WIP"]), [], {task: "issue_9999"});
+
+		expect(out.code).toBe(TASK_UNKNOWN);
+		expect(out.stdout).toBe("");
+	});
+
+	it("refuses a lane that is not there", async () => {
+		const out = await run(fakeFs({files: {}}), []);
+
+		expect(out.code).toBe(LANE_ABSENT);
+		expect(out.stdout).toBe("");
+	});
+
+	it("refuses a lane record that was read in full and does not replay", async () => {
+		const fs = fakeFs({
+			files: {
+				[`${ROOT}/5751/workflow.json`]: coderTemplateText(),
+				[`${ROOT}/5751/events.jsonl`]: "{not json}\n",
+			},
+		});
+		const out = await run(fs, []);
+
+		expect(out.code).toBe(MALFORMED_RECORD);
+	});
+
+	it("refuses when neither the task nor the lane names an issue", async () => {
+		const out = await run(lane("scratch", ["WIP"]), [], {lane: "scratch"});
+
+		expect(out.code).toBe(ISSUE_UNRESOLVED);
+		expect(out.stdout).toBe("");
+	});
+
+	it("refuses when the issue is proven absent", async () => {
+		const out = await run(lane("5751", ["WIP"]), [
+			[ISSUE_READ, errOut("gh: Not Found (HTTP 404)")],
+		]);
+
+		expect(out.code).toBe(ISSUE_UNRESOLVED);
+	});
+
+	it("refuses when the issue could not be read — UNKNOWN, never a brief", async () => {
+		const out = await run(lane("5751", ["WIP"]), [
+			[ISSUE_READ, errOut("gh: Server Error (HTTP 503)")],
+		]);
+
+		expect(out.code).toBe(LANE_UNREADABLE);
+		expect(out.stdout).toBe("");
+	});
+
+	it("refuses several open PRs, naming every candidate", async () => {
+		const out = await run(lane("5751", ["WIP", "DONE"]), [
+			[ISSUE_READ, issuePayload(5751, ISSUE_URL)],
+			[PR_SEARCH, pullRows([5790, PR_URL], [5791, "https://github.com/o/r/pull/5791"])],
+		]);
+
+		expect(out.code).toBe(PR_AMBIGUOUS);
+		expect(out.stderr.join("\n")).toContain("#5790");
+		expect(out.stderr.join("\n")).toContain("#5791");
+	});
+
+	it("refuses zero open PRs where the state needs one", async () => {
+		const out = await run(lane("5751", ["WIP", "DONE", "PASS"]), [
+			[ISSUE_READ, issuePayload(5751, ISSUE_URL)],
+			[PR_SEARCH, okOut("")],
+		]);
+
+		expect(out.code).toBe(PR_AMBIGUOUS);
+		expect(out.stdout).toBe("");
+	});
+});

--- a/packages/fabrika-cli/src/lane/codes.ts
+++ b/packages/fabrika-cli/src/lane/codes.ts
@@ -78,3 +78,24 @@ export const TOPOLOGY_FOREIGN = 16;
 
 /** The topology's dependency graph holds a cycle, and the ref path is named. */
 export const TOPOLOGY_CYCLE = 17;
+
+/**
+ * The task's leaf state routes to no shell — `queued`, `blocked`, a `human:*` park, a final, or a
+ * name this machine does not recognise. Its own seat because there is nothing to fix in the lane:
+ * the remedy is the driver acting on that state (record an event, clear the park), not a re-run.
+ */
+export const NO_SHELL = 18;
+
+/**
+ * The issue a task drives could not be resolved: neither the task name nor the lane id carries an
+ * issue number, or the number they carry is proven absent or closed. Separate from
+ * {@link TASK_UNKNOWN}: the task IS in the machine, and what is missing is its ground on the board.
+ */
+export const ISSUE_UNRESOLVED = 19;
+
+/**
+ * Exactly one open PR was required to trace to the task's issue and zero or several did. Never
+ * resolved by picking the newest: a brief handed the wrong PR sends a shell to judge or merge
+ * someone else's work, so the ambiguity is named and the dispatch stops.
+ */
+export const PR_AMBIGUOUS = 20;

--- a/packages/fabrika-cli/src/lane/command.ts
+++ b/packages/fabrika-cli/src/lane/command.ts
@@ -11,6 +11,7 @@ import {Effect, Option} from "effect";
 import {Argument, Command, Flag} from "effect/unstable/cli";
 import {leafCommand} from "../excess-operand.ts";
 import type {VerbOutcome} from "../verb.ts";
+import {runBrief} from "./brief-verb.ts";
 import {runEmit} from "./emit-verb.ts";
 import {runHistory} from "./history-verb.ts";
 import {runOpen} from "./open-verb.ts";
@@ -144,8 +145,42 @@ const emitLane = leafCommand(
 	),
 );
 
+const brief = leafCommand(
+	"brief",
+	{
+		lane: laneArgument,
+		root: rootFlag,
+		task: Flag.string("task").pipe(
+			Flag.optional,
+			Flag.withDescription("the task to brief; omittable on a single-task lane"),
+		),
+		repo: Flag.string("repo").pipe(
+			Flag.optional,
+			Flag.withDescription(
+				"the target owner/name (default: $CLAUDE_PIPELINE_REPO, else $GITHUB_REPOSITORY, else the origin remote)",
+			),
+		),
+	},
+	Effect.fn(function* ({lane, root, task, repo}) {
+		yield* emit(
+			yield* runBrief({
+				root,
+				lane,
+				task: Option.getOrNull(task),
+				repo: Option.getOrNull(repo),
+				env: process.env,
+			}),
+		);
+	}),
+).pipe(
+	Command.withShortDescription("The spawn prompt for one task's current leaf state."),
+	Command.withDescription(
+		"Print the spawn prompt for one task's current leaf state, folded fresh from the ledger — so a driver pastes a brief rather than composing one. stdout is the `lane-brief` wire format: which lane, task, state and shell, the resolved issue and PR URLs (URLs only — the spawned shell re-reads its own ground), and the format's byte-fixed rules. Exits 4 (lane record read in full and not the shape), 7 (no lane there), 11 (the lane, the issue or its PRs could not be read — UNKNOWN), 13 (the task is not in the machine, or --task omitted on a multi-task lane), 18 (the leaf state routes to no shell — `queued`, `blocked`, `human:*`, a final), 19 (neither the task nor the lane names an issue, or that issue is proven absent), 20 (zero open PRs where the state needs one, or several where one is required). Example: fabrika lane brief 5680 --task issue_5729",
+	),
+);
+
 export const laneCommand = Command.make("lane").pipe(
-	Command.withSubcommands([status, transition, history, print, open, emitLane]),
+	Command.withSubcommands([status, transition, history, print, open, emitLane, brief]),
 	Command.withShortDescription("Drive one lane's state ledger by folding its event log."),
 	Command.withDescription(
 		"Drive one lane's state ledger — a @demlik/tea machine folded fresh from an append-only events.jsonl on every invocation, speaking the operator's six events (#5673)",

--- a/packages/fabrika-cli/src/wire/lane-brief.ts
+++ b/packages/fabrika-cli/src/wire/lane-brief.ts
@@ -1,0 +1,314 @@
+/**
+ * The lane-brief — the bytes a lane driver hands one freshly-spawned fabrika shell.
+ *
+ * Three fixed sections and nothing else: `## Task` (which lane, which task, which state, which
+ * shell), `## Ground` (the URLs, and only URLs), and `## Rules` (byte-fixed text this module owns).
+ *
+ * **The rules are the format's own bytes, not a driver's phrasing.** A prompt composed per dispatch
+ * is a prompt two drivers write differently, and the rule that matters most — carry URLs, never a
+ * restatement — is then enforced by nothing but the driver's care. Fixing the bytes here makes the
+ * drift unrepresentable rather than detectable.
+ *
+ * **`## Ground` carries URLs and no content.** A brief that summarised an issue would hand the shell
+ * a stale contract to work from, and the shell has verbs that read the live one.
+ */
+
+import type {NonEmptyReadonlyArray, WireEmit, WireRead, WireReadLines} from "./format.ts";
+
+declare const ARTIFACT_URL: unique symbol;
+
+/** An `https://` artifact link. Branded so a blank or a summary cannot ride in a `Found`. */
+export type ArtifactUrl = string & {readonly [ARTIFACT_URL]: true};
+
+export const artifactUrl = (raw: string): ArtifactUrl | null => {
+	const value = raw.trim();
+	return /^https:\/\/\S+$/.test(value) ? (value as ArtifactUrl) : null;
+};
+
+/** The three leaf states that route to a shell. Every other state is a refusal, never a guess. */
+export const SHELL_STATES = ["build", "review", "ship"] as const;
+
+export type ShellState = (typeof SHELL_STATES)[number];
+
+export type LaneShell = "builder" | "reviewer" | "shipper";
+
+const SHELLS: Readonly<Record<ShellState, LaneShell>> = {
+	build: "builder",
+	review: "reviewer",
+	ship: "shipper",
+};
+
+/** The state → shell table, total over the states that route — owned here, not in the verb. */
+export const shellOf = (state: ShellState): LaneShell => SHELLS[state];
+
+/**
+ * A leaf state, only if it routes to a shell.
+ *
+ * `null` for every other one — `queued`, `blocked`, `human:*`, a name nobody recognises — which is
+ * what makes "guess a shell for an unrouted state" unwritable rather than merely discouraged.
+ */
+export const shellState = (raw: string): ShellState | null => {
+	const value = raw.trim();
+	return (SHELL_STATES as ReadonlyArray<string>).includes(value) ? (value as ShellState) : null;
+};
+
+export interface LaneBrief {
+	/** The lane id as the store names it — by convention the driven issue number. */
+	readonly lane: string;
+	/** The task the state belongs to, exactly as `lane status` prints it. */
+	readonly task: string;
+	readonly state: ShellState;
+	readonly shell: LaneShell;
+	readonly issue: ArtifactUrl;
+	/** The lane's open PR. `null` only on `build`, where construction has none yet. */
+	readonly pr: ArtifactUrl | null;
+}
+
+export type LaneBriefRead = WireRead<LaneBrief>;
+
+/**
+ * The `## Rules` text, byte-fixed and owned by the format.
+ *
+ * Each sentence is a rule a driver used to carry in their own prose: worktree isolation, URLs over
+ * restatements, and the in-tree entrypoint with the reason it exists (#5679).
+ */
+export const RULES = `Run in your own git worktree; a shell that shares the primary checkout can mutate its git state.
+Work from the URLs above and never from a summary of them — read the issue, the PR and its verdicts
+through your own verbs, because a restated spec is a stale spec.
+Invoke every fabrika verb as \`node packages/fabrika-cli/src/bin.ts <group> <verb>\`, never the bare
+\`fabrika\` binstub: in a worktree it resolves to another checkout's code (#5679), so its answer
+describes a tree you are not standing in.`;
+
+/** The section headings this format admits, in the order it emits them. */
+export const SECTIONS = ["Task", "Ground", "Rules"] as const;
+
+export const emit = (brief: LaneBrief): string =>
+	[
+		"## Task",
+		`lane: ${brief.lane}`,
+		`task: ${brief.task}`,
+		`state: ${brief.state}`,
+		`shell: ${brief.shell}`,
+		"## Ground",
+		`issue: ${brief.issue}`,
+		...(brief.pr === null ? [] : [`pr: ${brief.pr}`]),
+		"## Rules",
+		RULES,
+		"",
+	].join("\n");
+
+const malformed = (reason: string, evidence: string): LaneBriefRead => ({
+	_tag: "Malformed",
+	reason,
+	evidence,
+});
+
+const HEADING = /^##\s+(.*\S)\s*$/;
+const FIELD = /^([a-z-]+):\s*(.*)$/;
+
+interface Section {
+	readonly name: string;
+	readonly lines: ReadonlyArray<string>;
+}
+
+interface Scan {
+	readonly sections: ReadonlyArray<Section>;
+	/** The first non-blank line before any heading: text that instructs outside every section. */
+	readonly stray: string | null;
+}
+
+const sectionsOf = (artifact: string): Scan => {
+	const sections: {name: string; lines: string[]}[] = [];
+	let stray: string | null = null;
+	for (const raw of artifact.split("\n")) {
+		const heading = HEADING.exec(raw);
+		if (heading?.[1] !== undefined) {
+			sections.push({name: heading[1], lines: []});
+			continue;
+		}
+		const current = sections.at(-1);
+		if (current === undefined) {
+			if (raw.trim() !== "" && stray === null) stray = raw.trim();
+			continue;
+		}
+		current.lines.push(raw);
+	}
+	return {sections, stray};
+};
+
+const trimmed = (lines: ReadonlyArray<string>): ReadonlyArray<string> => {
+	const out = [...lines];
+	while (out.length > 0 && (out.at(-1) ?? "").trim() === "") out.pop();
+	return out;
+};
+
+type FieldScan =
+	| {readonly _tag: "Fields"; readonly fields: ReadonlyMap<string, string>}
+	| {readonly _tag: "NotAField"; readonly line: string};
+
+const fieldsOf = (sections: ReadonlyArray<Section>): FieldScan => {
+	const fields = new Map<string, string>();
+	for (const section of sections) {
+		for (const line of section.lines) {
+			if (line.trim() === "") continue;
+			const field = FIELD.exec(line.trim());
+			if (field?.[1] === undefined) return {_tag: "NotAField", line: line.trim()};
+			fields.set(field[1], field[2] ?? "");
+		}
+	}
+	return {_tag: "Fields", fields};
+};
+
+/** Read a brief. Total: `Found` | `Absent` | `Malformed`. */
+export const read = (artifact: string): LaneBriefRead => {
+	const {sections, stray} = sectionsOf(artifact);
+	// Stray text is a *drift* only once the bytes reach for this format at all. Bytes carrying no
+	// section are simply not a brief, and reporting those as malformed would make every unrelated
+	// comment a defective one.
+	if (sections.find((section) => section.name === "Task") === undefined) {
+		return {_tag: "Absent", reason: 'no "## Task" section — these bytes are not a lane brief'};
+	}
+	if (stray !== null) {
+		return malformed(
+			"the brief carries text outside its sections — a brief instructs only through them",
+			`"${stray}"`,
+		);
+	}
+
+	const unknown = sections.find(
+		(section) => !(SECTIONS as ReadonlyArray<string>).includes(section.name),
+	);
+	if (unknown !== undefined) {
+		return malformed(
+			`"## ${unknown.name}" is not a section of this format — a brief instructs only through its three fixed sections`,
+			`"## ${unknown.name}"`,
+		);
+	}
+
+	const task = sections.find((section) => section.name === "Task");
+	const ground = sections.find((section) => section.name === "Ground");
+	const rules = sections.find((section) => section.name === "Rules");
+	if (task === undefined || ground === undefined || rules === undefined) {
+		return malformed(
+			'a brief carries "## Task", "## Ground" and "## Rules" — one of them is missing',
+			sections.map((section) => `## ${section.name}`).join(" | "),
+		);
+	}
+
+	if (trimmed(rules.lines).join("\n") !== RULES) {
+		return malformed(
+			'"## Rules" does not carry this format\'s own text — the rules are byte-fixed, so an edited one is not a brief',
+			trimmed(rules.lines).join("\n"),
+		);
+	}
+
+	const scan = fieldsOf([task, ground]);
+	if (scan._tag === "NotAField") {
+		return malformed(`a section carries a line that is not a field: "${scan.line}"`, scan.line);
+	}
+	const fields = scan.fields;
+
+	const laneRaw = (fields.get("lane") ?? "").trim();
+	if (laneRaw === "") return malformed("the brief names no lane", "lane");
+	const taskName = (fields.get("task") ?? "").trim();
+	if (taskName === "") return malformed("the brief names no task", "task");
+	const state = shellState(fields.get("state") ?? "");
+	if (state === null) {
+		return malformed(
+			`"${(fields.get("state") ?? "").trim()}" is not a state that routes to a shell (${SHELL_STATES.join("/")})`,
+			"state",
+		);
+	}
+	const shell = SHELLS[state];
+	if ((fields.get("shell") ?? "").trim() !== shell) {
+		return malformed(
+			`"${(fields.get("shell") ?? "").trim()}" is not the shell state "${state}" routes to`,
+			"shell",
+		);
+	}
+	const issue = artifactUrl(fields.get("issue") ?? "");
+	if (issue === null) {
+		return malformed(`"${(fields.get("issue") ?? "").trim()}" is not an issue URL`, "issue");
+	}
+	const prRaw = (fields.get("pr") ?? "").trim();
+	const pr = prRaw === "" ? null : artifactUrl(prRaw);
+	if (pr === null && prRaw !== "") return malformed(`"${prRaw}" is not a PR URL`, "pr");
+	// A reviewer or shipper with no PR has nothing to judge or merge, so the brief that would send
+	// one is not a well-formed brief — the ambiguity is the driver's to resolve before dispatch.
+	if (pr === null && state !== "build") {
+		return malformed(`a "${state}" brief carries no PR URL — that shell has nothing to read`, "pr");
+	}
+
+	return {
+		_tag: "Found",
+		value: {lane: laneRaw, task: taskName, state, shell, issue, pr},
+	};
+};
+
+/** One `<field>\t<value>` line per field — the `wire read` answer for this format. */
+export const renderBrief = (brief: LaneBrief): NonEmptyReadonlyArray<string> => [
+	`lane\t${brief.lane}`,
+	`task\t${brief.task}`,
+	`state\t${brief.state}`,
+	`shell\t${brief.shell}`,
+	`issue\t${brief.issue}`,
+	...(brief.pr === null ? [] : [`pr\t${brief.pr}`]),
+];
+
+export type LaneBriefFields =
+	| {readonly _tag: "Fields"; readonly brief: LaneBrief}
+	| {readonly _tag: "Unusable"; readonly reason: string};
+
+/**
+ * Parse `emit`'s stdin: one `<key>: <value>` per line.
+ *
+ * `shell` is derived from `state` rather than accepted, so a caller cannot compose a brief whose
+ * shell and state disagree — the routing table has one reader.
+ */
+export const parseFields = (fields: string): LaneBriefFields => {
+	const values = new Map<string, string>();
+	for (const [index, raw] of fields.split("\n").entries()) {
+		const line = raw.trim();
+		if (line === "") continue;
+		const field = FIELD.exec(line);
+		if (field?.[1] === undefined) {
+			return {_tag: "Unusable", reason: `line ${index + 1} is not a "<field>: <value>" line`};
+		}
+		values.set(field[1], field[2] ?? "");
+	}
+
+	const laneRaw = (values.get("lane") ?? "").trim();
+	const task = (values.get("task") ?? "").trim();
+	const state = shellState(values.get("state") ?? "");
+	const issue = artifactUrl(values.get("issue") ?? "");
+	const prRaw = (values.get("pr") ?? "").trim();
+	const pr = prRaw === "" ? null : artifactUrl(prRaw);
+	if (laneRaw === "") return {_tag: "Unusable", reason: "no lane id"};
+	if (task === "") return {_tag: "Unusable", reason: "no task name"};
+	if (state === null) {
+		return {_tag: "Unusable", reason: `no shell state (${SHELL_STATES.join("/")})`};
+	}
+	if (issue === null) return {_tag: "Unusable", reason: "no issue URL"};
+	if (pr === null && prRaw !== "") return {_tag: "Unusable", reason: "no PR URL"};
+	if (pr === null && state !== "build") {
+		return {_tag: "Unusable", reason: `a "${state}" brief needs a PR URL`};
+	}
+	return {
+		_tag: "Fields",
+		brief: {lane: laneRaw, task, state, shell: SHELLS[state], issue, pr},
+	};
+};
+
+/** The registry row's byte-level `emit`, bound to this module's typed core. */
+export const emitFromFields = (fields: string): WireEmit => {
+	const parsed = parseFields(fields);
+	return parsed._tag === "Fields"
+		? {_tag: "Composed", bytes: emit(parsed.brief)}
+		: {_tag: "Unusable", reason: parsed.reason};
+};
+
+/** The registry row's byte-level `read`, bound to this module's typed core. */
+export const readToLines = (artifact: string): WireReadLines => {
+	const result = read(artifact);
+	return result._tag === "Found" ? {_tag: "Found", value: renderBrief(result.value)} : result;
+};

--- a/packages/fabrika-cli/src/wire/registry.ts
+++ b/packages/fabrika-cli/src/wire/registry.ts
@@ -27,6 +27,7 @@ import * as grillAnswer from "./grill-answer.ts";
 import * as grillRuling from "./grill-ruling.ts";
 import * as grillSupersede from "./grill-supersede.ts";
 import * as handoffPack from "./handoff-pack.ts";
+import * as laneBrief from "./lane-brief.ts";
 import * as mapTicket from "./map-ticket.ts";
 import * as sliceHandoff from "./slice-handoff.ts";
 import * as verdictMarker from "./verdict-marker.ts";
@@ -251,6 +252,67 @@ export const registeredFormats: ReadonlyArray<WireFormat> = [
 			],
 		},
 		brands: brandWitnesses<sliceHandoff.SliceHandoff>({id: true, branch: true, base: true}),
+	},
+	{
+		key: "lane-brief",
+		purpose:
+			"the spawn prompt a lane driver hands one fabrika shell — which task and state it serves, the URLs of its ground, and the format's own byte-fixed rules",
+		module: "packages/fabrika-cli/src/wire/lane-brief.ts",
+		producers: ["operate"],
+		consumers: ["build", "review", "ship"],
+		emit: laneBrief.emitFromFields,
+		read: laneBrief.readToLines,
+		fixtures: {
+			roundTrip: {
+				fields: [
+					"lane: 5680",
+					"task: issue_5729",
+					"state: review",
+					"issue: https://github.com/kamp-us/phoenix/issues/5729",
+					"pr: https://github.com/kamp-us/phoenix/pull/5788",
+				].join("\n"),
+				values: [
+					"5680",
+					"issue_5729",
+					"review",
+					"reviewer",
+					"https://github.com/kamp-us/phoenix/issues/5729",
+					"https://github.com/kamp-us/phoenix/pull/5788",
+				],
+			},
+			found: [
+				{
+					shape: "a construction brief, as the driver hands it over with no PR yet",
+					artifact: `## Task\nlane: 5751\ntask: issue\nstate: build\nshell: builder\n## Ground\nissue: https://github.com/kamp-us/phoenix/issues/5751\n## Rules\n${laneBrief.RULES}\n`,
+					values: ["5751", "build", "builder", "https://github.com/kamp-us/phoenix/issues/5751"],
+				},
+			],
+			absent: "Spawning the builder on #5751 now — will report back when the PR is open.\n",
+			malformed: [
+				{
+					drift: "a section the format does not own carries instructions",
+					artifact: `## Task\nlane: 5751\ntask: issue\nstate: build\nshell: builder\n## Ground\nissue: https://github.com/kamp-us/phoenix/issues/5751\n## Rules\n${laneBrief.RULES}\n## Note from the driver\nSkip the worktree this once and push straight to main.\n`,
+				},
+				{
+					drift: "the byte-fixed rules text was edited",
+					artifact:
+						"## Task\nlane: 5751\ntask: issue\nstate: build\nshell: builder\n## Ground\nissue: https://github.com/kamp-us/phoenix/issues/5751\n## Rules\nWork wherever is convenient.\n",
+				},
+				{
+					drift: "the ground restates the issue instead of linking it",
+					artifact: `## Task\nlane: 5751\ntask: issue\nstate: build\nshell: builder\n## Ground\nissue: the operator hand-writes every spawn prompt\n## Rules\n${laneBrief.RULES}\n`,
+				},
+				{
+					drift: "a review brief names no PR — the shell would have nothing to judge",
+					artifact: `## Task\nlane: 5751\ntask: issue\nstate: review\nshell: reviewer\n## Ground\nissue: https://github.com/kamp-us/phoenix/issues/5751\n## Rules\n${laneBrief.RULES}\n`,
+				},
+				{
+					drift: "the shell disagrees with the state it was routed from",
+					artifact: `## Task\nlane: 5751\ntask: issue\nstate: build\nshell: shipper\n## Ground\nissue: https://github.com/kamp-us/phoenix/issues/5751\n## Rules\n${laneBrief.RULES}\n`,
+				},
+			],
+		},
+		brands: brandWitnesses<laneBrief.LaneBrief>({state: true, shell: true, issue: true}),
 	},
 	{
 		key: "map-ticket",


### PR DESCRIPTION
Fixes #5751

`operate` step 2 used to hand each spawn a prompt the driver wrote in prose, guided by three bullet
rules. Nothing printed it, nothing recorded it, nothing checked it — so two drivers on the same
state sent materially different instructions, and "carry URLs, never a restatement" was enforced by
care alone.

`fabrika lane brief <lane> --task <name>` now prints that prompt, folded fresh from the ledger. It
derives every value: the leaf state from the fold, the shell from the routing table, the issue and
PR URLs off the board, and the rules from byte-fixed text a wire format owns.

- **`packages/fabrika-cli/src/wire/lane-brief.ts`** — the new `lane-brief` wire format, registered
  beside the others. Three closed sections (`## Task`, `## Ground`, `## Rules`), the rules text
  fixed in the module, and the `build`/`review`/`ship` → `builder`/`reviewer`/`shipper` table owned
  here rather than in the verb or in a skill's prose. `## Ground` carries links and nothing else. A
  `review` or `ship` brief with no PR is malformed rather than dispatchable.
- **`packages/fabrika-cli/src/lane/brief-verb.ts`** — the verb. Refuses on its own codes: `18` a
  leaf state that routes to no shell, `19` an issue it cannot resolve or that is absent, `20` zero
  open PRs where the state needs one or several where one is required, plus the group's existing
  `7`/`11`/`4`/`13`.
- **`packages/fabrika-cli/src/io/pulls.ts`** — `openPullsTracing`, which returns the whole match set
  so zero and several stay facts the caller refuses on rather than a first hit.
- **`claude-plugins/fabrika/skills/operate/SKILL.md`** — step 2 dispatches through the verb and
  sends its stdout verbatim. `isolation: worktree` stays the driver's spawn flag, because no bytes
  inside a prompt can enforce it from the outside.

15 unit tests cover the three shell prompts, the epic-lane task resolution, the URLs-only property,
and every refusal. `pnpm typecheck`, `pnpm lint:worktree` and the fabrika-cli suite (308 files,
4700 tests) are green.

## Deviations

- **Said:** the verb refuses on a leaf state with no shell, an unknown task, a missing lane, and a
  PR resolution that finds zero or several where one is required.
  **Did:** added a fifth refusal — `19`, the issue a task drives cannot be resolved or is proven
  absent.
  **Why:** the issue number comes from the task name on an epic lane and the lane id on a single
  lane, and a lane named neither way (or naming a closed issue) would otherwise brief a shell with
  a URL nobody proved.
  **Disposition:** seated on its own code in `lane/codes.ts` and covered by two tests.

- **Said:** the printed prompt for a `build`, `review` and `ship` leaf state each carries the
  resolved issue and PR URLs.
  **Did:** a `build` brief carries the PR only when one traces to the issue.
  **Why:** the ticket's own routing says `build` is construction when no PR exists yet and repair
  when one does; requiring a PR there would make the first build of every issue undispatchable.
  **Disposition:** `review` and `ship` refuse without one (`20`); `build` does not.

- **Said:** #5731's lost-capability row for the dispatch brief links here and reads as covered.
  **Did:** left #5731's body untouched and posted the coverage on the issue as a comment instead.
  **Why:** #5731's body is another lane's artifact, and its checkbox is that lane's to tick;
  rewriting a filed body from here would overwrite a record with no history.
  **Disposition:** stated on #5731 as a dated comment naming this PR.

- **Said:** nothing about `packages/fabrika-cli/src/io/pulls.ts` or the wire registry.
  **Did:** touched both — a new board read, a registry row, and the regenerated
  `claude-plugins/fabrika/docs/wire-formats.md`.
  **Why:** the registry is the only way a format exists (`wire index` reds otherwise), and no
  shipped read answered "which open PRs trace to this issue".
  **Disposition:** both are additions; nothing existing changed behaviour.

- **Said:** nothing about #5788, which is open and deletes `packages/fabrika-cli/src/epic/` and the
  `slice-handoff` format.
  **Did:** built the format standalone, sharing no module with `slice-handoff`.
  **Why:** a shared module would be deleted out from under this one when #5788 lands.
  **Disposition:** the two touch `wire/registry.ts` and `docs/wire-formats.md`, so whichever lands
  second rebases those two files.
