### PR TITLE
fabrika skills: context: fork plus background: on the six heavy skills

### DIFF
--- a/claude-plugins/fabrika/docs/skill-conventions.md
+++ b/claude-plugins/fabrika/docs/skill-conventions.md
@@ -390,6 +390,68 @@ it the shell expands it to empty and the verb refuses on a missing number.
 > and otherwise replaces every declared name — with nothing when the parsed argument list is empty;
 > the agent-shell preload path calls it with an explicit empty string.
 
+## 13. Six skills fork; every other one runs inline
+
+**A skill declares `context: fork` and `background: true` when both clauses hold, and declares
+neither field otherwise:**
+
+1. **The run is open-ended.** Its length is set by something outside the skill, so it can consume a
+   caller's whole context window before it reaches a terminal. `build` loops construct→check until
+   green and again per review round; `review` walks a whole diff and waits on a spawned
+   `governance` run; `heal-ci` sweeps every open PR.
+2. **Nobody is waiting on the value.** Everything the run decides lands in a GitHub artifact the
+   caller re-fetches by reference — a PR, a SHA-bound verdict comment, a PR driven back into
+   motion — so the report to the caller is a pointer and nothing dies with the run's context.
+
+The six that pass both: **`build`, `build-epic`, `build-ui`, `review`, `review-ui`, `heal-ci`**.
+The other eighteen fail at least one clause, and the two clauses fail in distinct ways:
+
+| Excluded | Fails |
+|---|---|
+| `ship` | clause 2 — its whole output is the terminal merge verdict the caller routes on, and a background fork files that verdict as a task notification the caller is not reading. |
+| `operate` | clause 2 — a `LANE-PARKED` is a human's cue to act, and the two terminals differ in exactly who moves next. |
+| `check-epic-plan`, `governance` | clause 2 — each returns a gate verdict its caller waits on; `review` §6 fires `governance` and waits, so a backgrounded `governance` would return after `review` had already emitted. |
+| `grilling`, `wayfinding`, `prototyping`, `taste-color`, `front-door` | clause 2 — a human is mid-conversation, waiting. |
+| `graduate`, `handoff` | clause 2, and harder: their subject is the calling session, which a fork does not have. |
+| `adr`, `write-pattern`, `glossary`, `report`, `triage`, `plan-epic` | clause 1 — each writes one document or one issue's labels and stops, so its length is knowable from its own steps. |
+| `writing-for-agents` | clause 1 — reference read during another skill's run; it has no run of its own. |
+
+### What the two fields actually do, as observed
+
+`background` already defaults to `true` under `context: fork` (`e.background ?? !0`), so declaring
+it changes nothing at runtime — it is declared so the setting is legible in the file rather than in
+a bundle. Two conditions force it off regardless: `CLAUDE_CODE_DISABLE_BACKGROUND_TASKS`, and a
+**non-interactive session**, where the fork still happens but blocks and returns its result in-line.
+So a `-p` run never demonstrates the notification path, and the path fires exactly where it was
+meant to: a human typing `/fabrika:build 1234` in a live session.
+
+Neither of the six declares `agent:`, so a fork spawns a `general-purpose` subagent carrying the
+skill body. Naming a shell there would make the shell's `tools:` set bind instead of the caller's,
+which is a change to who may do what — not this convention's call.
+
+**Preloading a forking skill into an agent shell does not fork, and is safe for all six.** The
+`skills:` preload and the `context: fork` machinery are two unrelated code paths: the preload
+renders the skill body and pushes it into the spawned agent's own prompt as a meta message, never
+consulting `context` or `background`. Observed rather than reasoned — spawning `fabrika:reviewer`
+(which preloads `fabrika:review`, carrying `context: fork`) produced exactly one subagent at
+`spawnDepth: 1`, whose transcript opens with the `fabrika:review` body as an `isMeta` message and
+contains no `Skill` call. So the field is inert on that path, in the harmless direction: a shell
+behaves exactly as it did before this section existed.
+
+The one path where it could bite is a shell re-invoking its own preloaded skill by name mid-run.
+The build carries a recursion guard for it — a `Skill` invocation is refused with *"already
+executing in this forked context — you are the subagent running it"* — but the guard keys on the
+agent having been *spawned by* that skill, which a `skills:` preload does not set. Nothing in the
+corpus tells a shell to re-invoke its own skill, so this stays a note rather than a defence.
+
+> Source: [#5588](https://github.com/kamp-us/phoenix/issues/5588), the M45 native-shell campaign.
+> The frontmatter schema, the `background` default, the two suppressors and the recursion guard are
+> read out of the installed Claude Code build (2.1.233), whose schema describes `context` as
+> "`inline` expands into the current conversation; `fork` spawns a subagent" and `background` as
+> "Only for `context: fork`. Forks run as background agents that report back as a task notification
+> instead of blocking the turn". The two runs behind the observations are recorded on the pull
+> request that landed this section.
+
 ## What these conventions deliberately do not cover
 
 - **What a verb owes its caller** — `--help` discoverability, output contracts, usage examples —

--- a/claude-plugins/fabrika/skills/build-epic/SKILL.md
+++ b/claude-plugins/fabrika/skills/build-epic/SKILL.md
@@ -3,6 +3,8 @@ name: build-epic
 description: "Conduct one planned epic into ONE pull request. Trigger on \"build epic #N\", \"conduct epic #N\", \"drive epic #N to a PR\", \"run the epic\", and whenever a planned epic's slices need landing as commits on one branch. Construction is `build`/`build-ui`'s, judgment `review`/`review-ui`'s, planning and merging their own lanes — this skill only conducts."
 arguments: [epic_number]
 argument-hint: "[epic-number] — the planned epic to conduct into one PR"
+context: fork
+background: true
 ---
 
 # build-epic

--- a/claude-plugins/fabrika/skills/build-ui/SKILL.md
+++ b/claude-plugins/fabrika/skills/build-ui/SKILL.md
@@ -3,6 +3,8 @@ name: build-ui
 description: "Execute one triaged issue whose deliverable is a rendered visual surface, and land it as a PR — or, given a PR number, enter repair mode. Trigger on \"build the UI for #N\", \"implement the page/component/screen\", \"make the visual change in #N\", \"repair the design FAIL on PR #N\", and whenever backlog work's deliverable is something a user will see rendered. Text construction — code-as-text, prose, plans — is `build`'s lane; judging a rendered surface is `review-ui`'s."
 arguments: [issue_or_pr_number]
 argument-hint: "[issue-number|pr-number] — an issue number builds, a PR number repairs; omit to pick from the pool"
+context: fork
+background: true
 ---
 
 # build-ui

--- a/claude-plugins/fabrika/skills/build/SKILL.md
+++ b/claude-plugins/fabrika/skills/build/SKILL.md
@@ -3,6 +3,8 @@ name: build
 description: "Execute one triaged, agent-ready issue end to end and land it as a PR — or, given a PR number, enter repair mode on that PR's branch. Trigger on \"work the next issue\", \"pick up an issue\", \"implement issue #N\", \"build #N\", \"repair PR #N\", \"fix the FAIL on #N\", and whenever triaged backlog work needs turning into a pull request. Rendered-visual construction is `build-ui`'s lane, not this skill's."
 arguments: [issue_or_pr_number]
 argument-hint: "[issue-number|pr-number] — an issue number builds, a PR number repairs; omit to pick from the pool"
+context: fork
+background: true
 ---
 
 # build

--- a/claude-plugins/fabrika/skills/heal-ci/SKILL.md
+++ b/claude-plugins/fabrika/skills/heal-ci/SKILL.md
@@ -3,6 +3,8 @@ name: heal-ci
 description: "Answer why one pull request is not moving and drive it back into motion — one PR, or a scheduled sweep of every open PR. Trigger on \"heal #N\", \"why is this PR stuck\", \"why has this not merged\", \"this PR has been sitting\", \"nothing is happening on this PR\", \"sweep for stranded PRs\", and whenever `ship` reports red or a PR looks abandoned — a green PR that nobody owns is stranded too. Not review, not repair (`build`), not merge (`ship`)."
 arguments: [pr_number]
 argument-hint: "[pr-number] — the stuck pull request; omit to sweep every open one"
+context: fork
+background: true
 ---
 
 # heal-ci

--- a/claude-plugins/fabrika/skills/review-ui/SKILL.md
+++ b/claude-plugins/fabrika/skills/review-ui/SKILL.md
@@ -3,6 +3,8 @@ name: review-ui
 description: "The rendered-visual review gate — judge one PR's rendered surfaces against the repo's design law. Trigger on \"/review-ui\", \"design-review PR #N\", \"review the UI on PR #N\", \"judge the rendered surfaces of #N\", and whenever a PR changes what a user sees rendered and owes its visual verdict before it can ship. Text judgment — code, docs, skills, plans — is `review`'s lane; constructing UI is `build-ui`'s."
 arguments: [pr_number]
 argument-hint: "[pr-number] — the pull request whose rendered surfaces to judge"
+context: fork
+background: true
 ---
 
 # review-ui

--- a/claude-plugins/fabrika/skills/review/SKILL.md
+++ b/claude-plugins/fabrika/skills/review/SKILL.md
@@ -3,6 +3,8 @@ name: review
 description: "The merged text-review gate — judge one PR's textual artifacts (code, docs, skills) against the linked issue's acceptance criteria. Trigger on \"/review\", \"review PR #N\", \"verify PR #N\", \"gate PR #N before merge\", and whenever a PR needs its review verdict before it can ship. Not plans (`check-epic-plan`), not rendered visuals (`review-ui`), not governance-corpus integrity (`governance` — this skill invokes it and must not absorb it)."
 arguments: [pr_number]
 argument-hint: "[pr-number] — the pull request to review"
+context: fork
+background: true
 ---
 
 # review


### PR DESCRIPTION
Six fabrika skills now run in their own subagent instead of the caller's conversation: `build`,
`build-epic`, `build-ui`, `review`, `review-ui`, `heal-ci` each declare `context: fork` and
`background: true`. `claude-plugins/fabrika/docs/skill-conventions.md` gets a §13 recording the
set, the rule behind it, and what the fields actually do when observed rather than assumed.

## The rule that admitted six and excluded eighteen

A skill forks when **both** hold:

1. **The run is open-ended** — its length is set by something outside the skill, so it can consume
   a caller's whole context window. `build` loops construct→check until green and again per review
   round; `review` walks a whole diff and waits on a spawned `governance` run; `heal-ci` sweeps
   every open PR.
2. **Nobody is waiting on the value** — everything the run decides lands in a GitHub artifact the
   caller re-fetches by reference (a PR, a SHA-bound verdict comment, a PR driven back into
   motion), so the report to the caller is a pointer.

Six pass both. The other eighteen fail at least one, and §13 carries the per-skill table.

**`ship` is excluded on clause 2**, and this is the case the clause exists for: its whole output is
the terminal merge verdict — `QUEUED`, `landed`, `refused`, and the rest of its enum — and that
verdict is what its caller routes on next. A background fork files it as a task notification, which
puts the one value the caller needs somewhere the caller is not looking. `operate`,
`check-epic-plan` and `governance` are excluded for the same reason: each hands its caller a value
that caller waits on. `governance` is the sharpest instance, since `review` §6 fires it and waits.

## A real forked run, on Claude Code 2.1.233

`/fabrika:review 5738` in a headless session that loaded this branch's plugin via `--plugin-dir`.
The parent session's transcript is 6 lines and reports `num_turns: 0`; it contains no skill body
and no tool call. Beside it the harness wrote `subagents/agent-a313a698226f16110.jsonl` — a
13-line transcript, every line `isSidechain: true`, opening with `Base directory for this skill:
…/skills/review` and running the skill's own `fabrika review scope 5738` and `gh pr view` calls.
The skill terminated correctly on a merged PR (`Exit code 7 · review scope: PR #5738 is closed —
nothing to review`), so the run exercised the real skill, not a stub. The fork spawned
`{"agentType":"general-purpose"}` — none of the six declares `agent:`.

The `background: true` **notification** path is not what that run demonstrates, and this PR does
not claim it: the build forces background off in a non-interactive session, so a `-p` fork blocks
and returns in-line. In the bundle the value resolves as `e.background ?? !0` with two suppressors,
`CLAUDE_CODE_DISABLE_BACKGROUND_TASKS` and non-interactive. So the declaration matches the default
and fires where it was meant to — a human typing `/fabrika:build 1234` in a live session.

## Fork plus shell: inert, in the harmless direction

Nobody had run a forking skill preloaded into one of the agent shells. Spawning `fabrika:reviewer`
(which preloads `fabrika:review`, now carrying `context: fork`) produced **exactly one** subagent,
`{"agentType":"fabrika:reviewer","spawnDepth":1}`. Its transcript opens with the `fabrika:review`
body as an `isMeta: true` message in its own context and contains no `Skill` call and no second
fork. It then ran the review and stopped on the same merged-PR refusal.

That matches the two code paths: the `skills:` preload renders the body and pushes it into the
spawned agent's prompt, never reading `context` or `background`. So the combination is broken in
neither direction, no fix is required, and **all six are safe to preload into a shell** — a shell
behaves exactly as it did before this PR.

One adjacent note, recorded in §13 rather than defended in code: the build carries a recursion
guard for a shell re-invoking its own skill by name (*"already executing in this forked context"*),
but that guard keys on the agent having been spawned *by* the skill, which a preload does not set.
Nothing in the corpus tells a shell to re-invoke its own skill.

## Deviations

- **Said:** the brief calls the non-forking remainder "the other seventeen".
  **Did:** wrote eighteen, and excluded `operate` explicitly.
  **Why:** the corpus is 24 skills — `operate` landed 2026-08-16 from epic #5680, after this brief
  was written.
  **Disposition:** followed the derivation. The set of six is unchanged; only the excluded count
  moved. `operate` fails clause 2 — a `LANE-PARKED` is a human's cue to act.

- **Said:** every existing eval under `claude-plugins/fabrika/skills/*/evals/` still passes at its
  committed bar.
  **Did:** ran none.
  **Why:** no such directory exists anywhere in the fabrika corpus —
  `find claude-plugins/fabrika -name "*eval*"` returns nothing.
  **Disposition:** stated rather than reported as a pass. The rest of that criterion holds: no
  skill's `name` or `description` is touched, and the `arguments:` / `argument-hint:` lines landed
  by #5587 are byte-identical on all six.

- **Said:** if the shell-plus-fork combination is broken in either direction, fix it here or file
  it.
  **Did:** filed a different defect hit while probing — `agent-shells.md` records the bare noun as
  a shell's spawn address, and `subagent_type: reviewer` failed where `fabrika:reviewer` worked.
  **Why:** the combination this issue asks about is not broken, and the address conflict lives on a
  doc surface outside the two this issue bounds.
  **Disposition:** #5808. No code change here.

- **Said:** run `build check` once per file class present in the diff.
  **Did:** ran `--surface prose` only.
  **Why:** every changed file is markdown; the green returned `unvalidated: []`, so no file class
  was left unread.
  **Disposition:** no second surface run.

Fixes #5588
