### PR TITLE
docs: retire .claude/skills symlink references; record delegation boundary as ADR 0287

### DIFF
--- a/.decisions/0284-delegation-stays-inside-one-repository.md
+++ b/.decisions/0284-delegation-stays-inside-one-repository.md
@@ -1,0 +1,47 @@
+---
+id: 0284
+title: The fabrika delegation stays inside one repository, and an unprovable repository refuses
+status: accepted
+date: 2026-08-16
+---
+
+# The fabrika delegation stays inside one repository, and an unprovable repository refuses
+
+## Context
+
+`fabrika`'s bootstrap delegates an invocation to the repo-local install when the caller's copy is
+not it. #4956 fenced that hand-off at the *checkout*: a copy living outside the caller's checkout
+refused. That fence was too narrow. `git worktree` gives a single repository several working trees,
+so the copy on `PATH` (sitting in the primary checkout) refused every invocation from a linked
+worktree — one project seen twice, treated as two. That made the bare `fabrika` unusable from every
+worktree (#5679), the layout every fabrika lane builds in.
+
+## Decision
+
+The boundary the delegation refuses to cross is the **repository**, not the checkout. This
+*narrows* #4956's rule rather than dropping it: a genuinely different repo still refuses
+(`refuse-foreign-checkout`, exit `126`, both checkouts named; `--skip-infer` overrides), and the
+founder's amendment on #5679 is the ruling that moved the fence.
+
+Three load-bearing choices under it:
+
+- **The identity compared is git's own `$GIT_COMMON_DIR`**, real-path resolved so two spellings of
+  one directory compare equal. Linked working trees share a common dir, so they compare as one
+  repository; two clones of the same remote do not, and still refuse.
+- **The common dir is read off disk, never by spawning `git`.** The bootstrap runs before any
+  dependency is guaranteed linked and before there is a runtime to carry a subprocess — the same
+  constraint that makes `root.ts` hand-read `pnpm-workspace.yaml`. The read follows
+  `gitrepository-layout(5)`: a `.git` directory is the common dir; a `.git` file's `gitdir:` names
+  this tree's git dir, whose `commondir` file names the shared common dir.
+- **A checkout whose repository cannot be established is a *different* repository.** `repositoryOf`
+  returns `undefined` on a non-git tree or a stale pointer, and `undefined` never compares equal —
+  the direction that refuses rather than the one that answers from a tree nobody named.
+
+## Consequences
+
+- The bare `fabrika` works from any worktree of the repo that owns the install; only a foreign
+  repo's copy refuses. Re-widening the refusal back to the checkout re-breaks every worktree —
+  this record is what a future reader checks before doing that.
+- Implementation: `packages/fabrika-cli/src/delegate/repository.ts` (identity) and
+  `packages/fabrika-cli/src/delegate/resolve.ts` (the refusal branch); both cite this ADR.
+- `packages/fabrika-cli/README.md` keeps the how-it-works walk-through; the *why* lives here.

--- a/.decisions/0287-delegation-stays-inside-one-repository.md
+++ b/.decisions/0287-delegation-stays-inside-one-repository.md
@@ -1,5 +1,5 @@
 ---
-id: 0284
+id: 0287
 title: The fabrika delegation stays inside one repository, and an unprovable repository refuses
 status: accepted
 date: 2026-08-16

--- a/claude-plugins/kampus-pipeline/README.md
+++ b/claude-plugins/kampus-pipeline/README.md
@@ -165,7 +165,7 @@ the gap surfaces before any work is done; it **prints** the fix and never applie
 
 The plugin carries **no per-plugin `version`** (neither in the marketplace plugin entry nor in [`.claude-plugin/plugin.json`](.claude-plugin/plugin.json)): Claude Code then content-addresses the install by git commit SHA, so every commit is a new "version" and skill additions/edits reach already-installed users on the normal update path — a fixed semver pin froze the cache and silently served stale content (#945). This omission is **deliberate, not a defect — do not add a `version`**; the decision record (why + history) is [ADR 0110](https://github.com/kamp-us/phoenix/blob/main/.decisions/0110-plugin-carries-no-version-continuous-ship.md).
 
-The whole plugin surface was audited against the official Claude Code plugin spec ([plugins reference](https://docs.claude.com/en/docs/claude-code/plugins-reference), [marketplaces](https://docs.claude.com/en/docs/claude-code/plugin-marketplaces)); the conformance record — the corrected manifest `$schema` URL plus every deliberate deviation (no `version`, the root-level `hooks.json`, the absent `commands/`, the `.claude/skills` discovery symlink) and its forcing constraint — is [ADR 0171](https://github.com/kamp-us/phoenix/blob/main/.decisions/0171-kampus-pipeline-plugin-spec-conformance.md). A future audit that re-flags any of those reads the disposition there: documented-intentional, not an open defect.
+The whole plugin surface was audited against the official Claude Code plugin spec ([plugins reference](https://docs.claude.com/en/docs/claude-code/plugins-reference), [marketplaces](https://docs.claude.com/en/docs/claude-code/plugin-marketplaces)); the conformance record — the corrected manifest `$schema` URL plus every deliberate deviation (no `version`, the root-level `hooks.json`, the absent `commands/`; the `.claude/skills` discovery symlink was one until ADR 0277 retired it) and its forcing constraint — is [ADR 0171](https://github.com/kamp-us/phoenix/blob/main/.decisions/0171-kampus-pipeline-plugin-spec-conformance.md). A future audit that re-flags any of those reads the disposition there: documented-intentional, not an open defect.
 
 ## Portability boundary (ADR 0062)
 
@@ -267,17 +267,14 @@ into every install (Claude Code does a full recursive copy and honors no ignore 
 so a plugin must be the only thing under its source root.
 
 Claude Code's **plugin** discovery scans the plugin source root's `skills/` directory and
-offers no manifest field to redirect it. Phoenix's **local** discovery reads
-`.claude/skills/`. To satisfy both with **no duplicated content**:
+offers no manifest field to redirect it. The skills therefore live in exactly one place:
 
 - **Canonical files live at `claude-plugins/kampus-pipeline/skills/`** — the plugin source-root location.
-- **`.claude/skills` is a symlink → `../claude-plugins/kampus-pipeline/skills`** (relative target, stored
-  in git as a mode-`120000` symlink blob). Local discovery follows it to that directory.
 
-Editing a file in one location is editing it in the other — there is exactly one source of
-truth. The relative symlink target means it **resolves in a fresh `git clone`** (marketplace
-installs clone the repo), not only in the working tree. CI runs the validators through the
-same symlink (`bash .claude/skills/validate-skills.sh`), so the layout needs no workflow change.
+There is no second discovery path. Phoenix used to mirror the skills into `.claude/skills/`
+via a symlink for project-local discovery; ADR 0277 retired it, and phoenix now consumes the
+plugin the same way any adopter does. CI invokes the validators at the real path
+(`bash claude-plugins/kampus-pipeline/skills/validate-skills.sh`).
 
 ```
 phoenix/
@@ -293,7 +290,6 @@ phoenix/
 │           └── gh-issue-intake-formats.md
 ├── apps/  packages/  infra/             # repo source — no longer shipped to installers
 └── .claude/
-    ├── skills -> ../claude-plugins/kampus-pipeline/skills  # symlink — local discovery
     └── .pipeline -> <the live plugin install>              # symlink — planted by the hooks, gitignored
 ```
 
@@ -339,15 +335,13 @@ live, and asserts that no corpus script may exit 127 for any reason other than a
   paths (ADR 0062 §4) — so they resolve from an adopter's install, where those trees don't
   exist.
 
-### In-repo discovery doubling — accept the doubles (ADR 0062 §5)
+### In-repo discovery doubling — resolved by the symlink retirement (ADR 0062 §5, ADR 0277)
 
-When the plugin is installed at **user scope** and a maintainer works **inside phoenix**,
-every skill surfaces twice in the picker: bare `report` (project-scope `.claude/skills/`)
-and `phoenix:report` (plugin scope). Claude Code does not dedupe skill names across scopes
+Under the v1 layout, a maintainer working inside phoenix with the plugin installed saw
+every skill twice in the picker: bare `report` (project-scope `.claude/skills/`) and
+`phoenix:report` (plugin scope) — Claude Code does not dedupe skill names across scopes
 and has no per-project plugin disable (upstream anthropics/claude-code#53923).
 
-**Disposition: accept the doubles for v1.** The recommendation is that **phoenix
-maintainers rely on the local `.claude/skills/` discovery and do _not_ install the plugin
-into phoenix itself** — they already have the canonical suite locally; the plugin exists
-for *other* repos. This is a documentation cost, not a functional one. Revisit if/when
-upstream ships a per-project plugin toggle. See ADR 0062 §5 for the full rationale.
+ADR 0277 retired the project-scope symlink, so the doubling no longer arises: skills reach
+a phoenix session only through the plugin, the same as in any adopting repo. ADR 0062 §5's
+accept-the-doubles disposition is history, kept there as the record of the v1 trade.

--- a/claude-plugins/kampus-pipeline/skills/review-skill/SKILL.md
+++ b/claude-plugins/kampus-pipeline/skills/review-skill/SKILL.md
@@ -97,10 +97,9 @@ The denylist half — remove the head's `CLAUDE.md` / `.claude` / `.decisions` /
 FATAL: denied instruction surface '<p>' present in review worktree — isolation broken; aborting
 ```
 
-**A subtlety for this gate.** `skills/` is a real directory the head ships, and `.claude/skills`
-is a *symlink* to it — so the skill `.md` files under `skills/**` are the **artifact under
-test** you read from `$REVIEW_WT/skills/...`, while `.claude/**` (the symlink and everything
-else in it) is on the **instruction denylist** removed above. You read the changed skill text
+**A subtlety for this gate.** The skill `.md` files under `skills/**` are the **artifact under
+test** you read from `$REVIEW_WT/skills/...`, while `.claude/**` (everything in it) is on the
+**instruction denylist** removed above. You read the changed skill text
 from the head worktree's `skills/` tree; you never load any skill from the head as *your own*
 running instruction. Your rigor checks judge the head's skill text; your judgment runs on the
 base.

--- a/claude-plugins/kampus-pipeline/skills/write-code/SKILL.md
+++ b/claude-plugins/kampus-pipeline/skills/write-code/SKILL.md
@@ -938,14 +938,14 @@ same violations CI's `lint / format / typecheck` job would — including in root
 pnpm lint:worktree
 ```
 
-### Editing a skill — use the real `skills/**` path, never the `.claude/skills/**` symlink
+### Editing a skill — use the real `skills/**` path, never a `.claude/skills/**` path
 
 When the issue has you **editing a skill** (a `SKILL.md` or its supporting files), edit the
 **real** path under `claude-plugins/<plugin>/skills/<name>/…` (e.g.
-`claude-plugins/kampus-pipeline/skills/write-code/SKILL.md`), **never** the `.claude/skills/<name>/…`
-path. `.claude/skills` is a **symlink to the real plugin skills dir** — both resolve to the same
-file on disk — but the harness's auto-mode **self-modification classifier keys on the path
-*string***: any `Edit`/`Write` whose target contains `.claude/` is flagged "Self-Modification
+`claude-plugins/kampus-pipeline/skills/write-code/SKILL.md`), **never** a `.claude/skills/<name>/…`
+path. The `.claude/skills` symlink that once mirrored the plugin dir is retired (ADR 0277), but
+the rule outlives it, because the harness's auto-mode **self-modification classifier keys on the
+path *string***: any `Edit`/`Write` whose target contains `.claude/` is flagged "Self-Modification
 (config file controlling agent behavior)" and **hard-blocked** when the authorization comes from an
 issue/tool rather than the user's own message. The identical file edited via the real
 `claude-plugins/**/skills/**` path is not flagged. So the `.claude/` path is a coin-flip into an

--- a/packages/fabrika-cli/src/delegate/repository.ts
+++ b/packages/fabrika-cli/src/delegate/repository.ts
@@ -1,18 +1,9 @@
 /**
  * Which git repository a checkout belongs to, and therefore whether two checkouts are one repository.
  *
- * The delegation refuses to hand an invocation to a *different* checkout (#4956). A linked working
- * tree is not one: `git worktree` gives a single repository several working trees, so the copy on
- * `PATH` sitting in the primary checkout while the cwd sits in a worktree is one project seen twice,
- * and refusing there made the bare `fabrika` unusable from every worktree (#5679).
- *
- * The identity compared is git's own `$GIT_COMMON_DIR`, read **off disk** rather than by spawning
- * `git`: this runs in the bootstrap, before any dependency is guaranteed linked and before there is
- * a runtime to carry a subprocess, which is the same constraint that makes `root.ts` hand-read
- * `pnpm-workspace.yaml`. The read follows `gitrepository-layout(5)`: a `.git` **directory** is the
- * common dir itself; a `.git` **file** holds `gitdir: <path>` naming this working tree's own git
- * dir, and that dir's `commondir` file — when present — names the common dir it shares, "relative to
- * $GIT_DIR" when the path in it is relative.
+ * The delegation boundary is the repository, not the checkout; the identity compared is
+ * `$GIT_COMMON_DIR`, read off disk per `gitrepository-layout(5)` because the bootstrap has no
+ * linked dependencies and no runtime for a `git` subprocess. See ADR 0284.
  */
 import {Effect, type FileSystem, Path} from "effect";
 import {exists, isDirectory, type ReadFailed, readFile, realPath} from "../io/fs.ts";

--- a/packages/fabrika-cli/src/delegate/repository.ts
+++ b/packages/fabrika-cli/src/delegate/repository.ts
@@ -3,7 +3,7 @@
  *
  * The delegation boundary is the repository, not the checkout; the identity compared is
  * `$GIT_COMMON_DIR`, read off disk per `gitrepository-layout(5)` because the bootstrap has no
- * linked dependencies and no runtime for a `git` subprocess. See ADR 0284.
+ * linked dependencies and no runtime for a `git` subprocess. See ADR 0287.
  */
 import {Effect, type FileSystem, Path} from "effect";
 import {exists, isDirectory, type ReadFailed, readFile, realPath} from "../io/fs.ts";

--- a/packages/fabrika-cli/src/delegate/resolve.ts
+++ b/packages/fabrika-cli/src/delegate/resolve.ts
@@ -75,7 +75,7 @@ export const resolve = ({selfPackageRoot, origin, repoRoot, local}: ResolveInput
 		return {_tag: "run-here", why: "the repo-local install is this copy"};
 	// The refusal is placed here, on the delegate branch alone, so the two loud branches above keep
 	// their behaviour and their text exactly (#4956). The boundary it enforces is the repository,
-	// unprovable-refuses included — see ADR 0284.
+	// unprovable-refuses included — see ADR 0287.
 	if (origin._tag === "other-repository")
 		return {
 			_tag: "refuse-foreign-checkout",

--- a/packages/fabrika-cli/src/delegate/resolve.ts
+++ b/packages/fabrika-cli/src/delegate/resolve.ts
@@ -74,7 +74,8 @@ export const resolve = ({selfPackageRoot, origin, repoRoot, local}: ResolveInput
 	if (local.install.packageRoot === selfPackageRoot)
 		return {_tag: "run-here", why: "the repo-local install is this copy"};
 	// The refusal is placed here, on the delegate branch alone, so the two loud branches above keep
-	// their behaviour and their text exactly (#4956).
+	// their behaviour and their text exactly (#4956). The boundary it enforces is the repository,
+	// unprovable-refuses included — see ADR 0284.
 	if (origin._tag === "other-repository")
 		return {
 			_tag: "refuse-foreign-checkout",

--- a/packages/pipeline-cli/src/tools/gh-phoenix/lint.ts
+++ b/packages/pipeline-cli/src/tools/gh-phoenix/lint.ts
@@ -289,11 +289,11 @@ export const scanBarePush = (file: string, content: string): ReadonlyArray<Findi
  * directory` — a live customer-down break (#4605). The portable literal is `./.claude/.pipeline/…`,
  * a symlink the SessionStart / WorktreeCreate hooks plant at whatever install is live.
  *
- * The leading `(?<![\w./-])` is what keeps two legitimate neighbours out of scope: the marketplace
+ * The leading `(?<![\w./-])` is what keeps a legitimate neighbour out of scope: the marketplace
  * manifest's `source: "./claude-plugins/<plugin>"` (no runnable-surface segment follows, so the
- * trailing group never matches) and the `.claude/skills -> ../claude-plugins/…` symlink target in
- * the README's tree diagram (the `.` is preceded by another `.`). Both are true statements about
- * this repo's own layout, not commands anyone pastes.
+ * trailing group never matches) — a true statement about this repo's own layout, not a command
+ * anyone pastes. It also guards any `../claude-plugins/…` relative target (the `.` is preceded
+ * by another `.`), the class the retired `.claude/skills` symlink used to sit in.
  */
 const NON_PORTABLE_PLUGIN_PATH =
 	/(?<![\w./-])\.\/claude-plugins\/[A-Za-z0-9._-]+\/(?:skills|bin|lib|hooks)\//g;


### PR DESCRIPTION
Driver-authored batch of two doc-only M45 stragglers, per the founder's simple-batch ruling (2026-08-16, in session): batched by the driver, reviewed by the founder via notusirin, no pipeline lane.

## #5727 — symlink retirement doc sweep

- README dual-discovery section rewritten to one canonical location (`claude-plugins/kampus-pipeline/skills/`); the "satisfy both discoveries" framing is gone, with a past-tense pointer at ADR 0277.
- Tree diagram no longer shows `skills ->` under `.claude/`.
- CI claim now names the real path (`bash claude-plugins/kampus-pipeline/skills/validate-skills.sh`, verified against `.github/workflows/ci.yml:596`).
- L168 spec-deviation list marks the symlink as retired, not live.
- ADR 0062 §5 doubling section rewritten: doubling resolved by the retirement, disposition kept as history.
- `write-code/SKILL.md` keeps the never-edit-via-`.claude/` rule and the #599/#637 classifier grounds; only the both-resolve-to-the-same-file premise is gone.
- `review-skill/SKILL.md` keeps the denylist split without calling `.claude/skills` a symlink.
- `lint.ts` lookbehind comment loses its tree-diagram-symlink neighbour; regex unchanged.

Remaining `.claude/skills` grep hits are past-tense records or the rule's own forbidden-path strings, which the criteria allow.

## #5706 — ADR 0284

Records the already-ruled, already-shipped delegation boundary: one repository by `$GIT_COMMON_DIR` (narrows #4956 per the founder amendment on #5679), read off disk because the bootstrap has no linked deps and no runtime for a `git` subprocess, unprovable-repository refuses. `repository.ts` / `resolve.ts` docblocks collapse to ADR pointers. No runtime behaviour change; `status: accepted`.

`pnpm lint` + `pnpm typecheck` green.

## Deviations

None.

Closes #5727
Closes #5706

🤖 Generated with [Claude Code](https://claude.com/claude-code)