### PR TITLE
fix: Builder PR titles are not conventional commits, so squash-merged fixes are invisible to release-please

### DIFF
--- a/claude-plugins/fabrika/skills/build/contract.md
+++ b/claude-plugins/fabrika/skills/build/contract.md
@@ -330,7 +330,7 @@ The two assertions, each proven from git state alone:
 
 ```
 $ fabrika build tree --require-clean
-/private/var/folders/…/lanes/build-4312
+/private/var/<redacted>/lanes/build-4312
 ```
 
 ```
@@ -969,7 +969,7 @@ Preconditions: a confirmed claim on `<number>` (`15` / `11`).
 
 ```
 $ fabrika build scratch 4312 --slug notes
-/tmp/fabrika-build/s-9f2e/4312-c1a4d6f8/notes
+/tmp/<redacted>/s-9f2e/4312-c1a4d6f8/notes
 ```
 
 **Grounding**
@@ -1213,7 +1213,7 @@ surface that ran, so a file another surface would have read counts as uncovered 
 
 ```
 $ fabrika build check --surface code
-{"verdict":"green","surface":"code","tree":"/private/var/folders/…/build-4312","ran":["pnpm typecheck","pnpm lint:worktree"],"unvalidated":["README.md","scripts/deploy.sh"]}
+{"verdict":"green","surface":"code","tree":"/private/var/<redacted>/build-4312","ran":["pnpm typecheck","pnpm lint:worktree"],"unvalidated":["README.md","scripts/deploy.sh"]}
 ```
 
 **Grounding**
@@ -1400,6 +1400,14 @@ The guards, in order, all before any write:
    and triage own those verdicts. The pattern set is closed on purpose: two implementers must
    ship the same guard, and a "any spelling" instruction is two guards.
 5. **claim confirmed** (`15`/`11`), **target issue open** (`7`).
+
+The PR title is **derived, not the issue title verbatim**
+([`packages/fabrika-cli/src/build/pr-title.ts`](../../../../packages/fabrika-cli/src/build/pr-title.ts)):
+the served issue's `type:` label maps to a conventional-commit prefix (`type:bug` → `fix`,
+`type:feature` → `feat`, everything else → `chore`) ahead of the issue title unchanged, and a title
+that already leads with a conventional prefix passes through untouched. The repo squash-merges with
+`COMMIT_OR_PR_TITLE`, so on a multi-commit PR this title becomes the commit subject on `main` —
+deriving it is what keeps every builder squash parseable by release-please (#5771).
 
 Then create, **re-read the created PR**, and compare body through `normalizeForReadback` (`9` on
 mismatch). The write path is `gh api` with the body from a file — never `-f body=@file`, which

--- a/packages/fabrika-cli/src/build/pr-title.ts
+++ b/packages/fabrika-cli/src/build/pr-title.ts
@@ -1,0 +1,31 @@
+/**
+ * The pure read `build pr` makes over the served issue's title before it becomes the PR title.
+ *
+ * The incident this module answers is #5771: the repo squash-merges with
+ * `squash_merge_commit_title: COMMIT_OR_PR_TITLE`, so on a multi-commit PR the PR title becomes the
+ * commit subject on `main` — and release-please cannot route a subject with no conventional prefix,
+ * so the change lands with no version bump and no changelog line. Issue titles are descriptive
+ * sentences; the prefix is derived here, from the served issue's `type:` label, so every builder PR
+ * squashes to a subject release-please can parse.
+ */
+
+/** `type:<label>` → conventional-commit type. Anything unlisted falls back to `chore`. */
+const PREFIX_BY_LABEL: ReadonlyMap<string, string> = new Map([
+	["type:bug", "fix"],
+	["type:feature", "feat"],
+]);
+
+/**
+ * A subject that already leads with a conventional-commit prefix — `type(scope)!: rest` — which the
+ * derivation must leave alone rather than double-prefix. The type set is open (any word) on purpose:
+ * a hand-titled `docs:` or `perf:` issue is already routable, and `fix: docs: …` helps nobody.
+ */
+const CONVENTIONAL_SUBJECT = /^[a-z]+(\([^()]*\))?!?: \S/;
+
+/** The served issue's title as a conventional-commit PR title. Pure; the one derivation site. */
+export const conventionalTitleOf = (title: string, labels: ReadonlyArray<string>): string => {
+	const trimmed = title.trim();
+	if (CONVENTIONAL_SUBJECT.test(trimmed)) return trimmed;
+	const type = labels.map((label) => PREFIX_BY_LABEL.get(label)).find((t) => t !== undefined);
+	return `${type ?? "chore"}: ${trimmed}`;
+};

--- a/packages/fabrika-cli/src/build/pr-title.unit.test.ts
+++ b/packages/fabrika-cli/src/build/pr-title.unit.test.ts
@@ -1,0 +1,58 @@
+import {describe, expect, it} from "vitest";
+import {conventionalTitleOf} from "./pr-title.ts";
+
+describe("conventionalTitleOf", () => {
+	it("derives fix from type:bug", () => {
+		expect(
+			conventionalTitleOf("Builder PR titles are not conventional commits", [
+				"type:bug",
+				"status:triaged",
+				"p1",
+				"ready-for:agent",
+			]),
+		).toBe("fix: Builder PR titles are not conventional commits");
+	});
+
+	it("derives feat from type:feature", () => {
+		expect(conventionalTitleOf("Add a sozluk term page", ["type:feature", "p2"])).toBe(
+			"feat: Add a sozluk term page",
+		);
+	});
+
+	it("falls back to chore for every other type label", () => {
+		expect(conventionalTitleOf("Sweep the stale worktrees", ["type:chore"])).toBe(
+			"chore: Sweep the stale worktrees",
+		);
+		expect(conventionalTitleOf("Why is the queue stuck?", ["type:investigation"])).toBe(
+			"chore: Why is the queue stuck?",
+		);
+		expect(conventionalTitleOf("No type label at all", ["p1"])).toBe("chore: No type label at all");
+	});
+
+	// The squash rule reads the PR title verbatim, so a hand-prefixed title must pass through
+	// untouched — `fix: docs: …` would be worse than what it replaces.
+	it("leaves an already-conventional title alone rather than double-prefixing", () => {
+		expect(conventionalTitleOf("fix(fabrika): route the map open", ["type:bug"])).toBe(
+			"fix(fabrika): route the map open",
+		);
+		expect(conventionalTitleOf("docs: repoint the dead links", ["type:chore"])).toBe(
+			"docs: repoint the dead links",
+		);
+		expect(conventionalTitleOf("feat!: drop the legacy wire format", ["type:feature"])).toBe(
+			"feat!: drop the legacy wire format",
+		);
+	});
+
+	it("does not read a plain sentence with a colon as already prefixed", () => {
+		expect(conventionalTitleOf("One retry cap: fold the three round budgets", ["type:bug"])).toBe(
+			"fix: One retry cap: fold the three round budgets",
+		);
+		expect(conventionalTitleOf("Sözlük: seed the first terms", ["type:feature"])).toBe(
+			"feat: Sözlük: seed the first terms",
+		);
+	});
+
+	it("trims the title before deriving", () => {
+		expect(conventionalTitleOf("  A padded title  ", ["type:bug"])).toBe("fix: A padded title");
+	});
+});

--- a/packages/fabrika-cli/src/build/pr-verb.ts
+++ b/packages/fabrika-cli/src/build/pr-verb.ts
@@ -27,6 +27,7 @@ import {
 import {createPull, defaultBranch, openPullForHead} from "./github.ts";
 import {requireLane} from "./lane-guard.ts";
 import {bodyDefect, classificationIn, proseOf} from "./pr-body.ts";
+import {conventionalTitleOf} from "./pr-title.ts";
 import {openIssue, resolveTargetRepo} from "./target.ts";
 
 const VERB = "build pr";
@@ -155,7 +156,13 @@ export const runPr = (
 			);
 		}
 
-		const created = yield* createPull(repo, target.issue.title, lane.branch, base.value, body);
+		const created = yield* createPull(
+			repo,
+			conventionalTitleOf(target.issue.title, target.issue.labels),
+			lane.branch,
+			base.value,
+			body,
+		);
 		if (created._tag === "Failure") {
 			return refuse(
 				WRITE_UNKNOWN,


### PR DESCRIPTION
## Summary

`fabrika build pr` used to pass the served issue's title verbatim into the created PR. The repo squash-merges with `COMMIT_OR_PR_TITLE`, so on a multi-commit PR that descriptive sentence became the commit subject on `main`, and release-please could not parse it — the change landed with no version bump and no changelog line.

The verb now derives the title through a new pure module, `packages/fabrika-cli/src/build/pr-title.ts`, unit-tested beside it:

```
type:bug     -> fix:  <issue title>
type:feature -> feat: <issue title>
anything else -> chore: <issue title>
already-prefixed titles pass through untouched (no double prefix)
```

`claude-plugins/fabrika/skills/build/contract.md`'s `build pr` section now documents the derivation, so the contract no longer reads as "title from the issue".

## Demonstration

This PR was opened by the changed verb running from this branch's tree, serving a bug-labeled issue titled `Builder PR titles are not conventional commits, so squash-merged fixes are invisible to release-please`. The derived title this PR carries:

```
fix: Builder PR titles are not conventional commits, so squash-merged fixes are invisible to release-please
```

Fixes #5771

## Deviations

- **Prefixing is unconditional, not path-conditional** — **Said:** #5771 leaves open whether the prefix applies to every builder PR or only when the diff enters a released package root. **Did:** every builder PR gets the derived prefix, regardless of what the diff touches. **Why:** release-please routes by changed file path, so a prefixed docs-only subject routes nowhere and costs nothing beyond a slightly noisier subject; path-conditional would need the diff read at PR-create time for no mechanical gain. **Disposition:** stated here.
- **Out-of-scope change** — **Said:** #5771 names the title derivation, its tests, and the contract's `build pr` section. **Did:** three hunks elsewhere in `claude-plugins/fabrika/skills/build/contract.md` rewrite pre-existing machine-local segments of example-output paths to the literal `<redacted>` — the `fabrika build tree` sample output, the `fabrika build scratch` sample output, and the `tree` field inside the `fabrika build check` sample JSON. **Why:** `build check --surface prose` runs the leak scanner over the whole changed file and reds it on those machine-local example paths, so the in-scope contract edit could not land green without masking them; `<redacted>` is the scanner's own mask idiom, so the examples stay truthful. **Disposition:** stated here.

