### PR TITLE
triage writes the acceptance-criteria heading at a level build and review reject

### DIFF
--- a/claude-plugins/fabrika/skills/triage/SKILL.md
+++ b/claude-plugins/fabrika/skills/triage/SKILL.md
@@ -127,7 +127,7 @@ it preserves verbatim for the planner; no *rewrite* goes above an epic's brief. 
 real paths and function names over vague framing, and acceptance criteria that make "done" legible —
 not a closed set, a `review-*` gate may append. The criteria block's grammar is the wire format's,
 not this skill's ([`packages/fabrika-cli/src/wire/acceptance-criteria.ts`](../../../../packages/fabrika-cli/src/wire/acceptance-criteria.ts)):
-`enrich` runs that reader over the body it composed and refuses a drifted block on exit `14` before
+`enrich` runs that reader over the body it composed and refuses a drifted block on exit `15` before
 writing anything, naming the defect the reader found — so write the criteria and let the verb answer.
 A rewrite carrying **no** criteria block is still accepted, where none is warranted.
 **No invention**: enrich from what you found, keep

--- a/claude-plugins/fabrika/skills/triage/SKILL.md
+++ b/claude-plugins/fabrika/skills/triage/SKILL.md
@@ -125,12 +125,12 @@ For an epic, `fabrika triage enrich 4318 --epic` takes the pitch's five fields o
 Problem / Arc / Appetite / Rabbit-holes / No-gos — and heads them `## Pitch` above the brief, which
 it preserves verbatim for the planner; no *rewrite* goes above an epic's brief. The rewrite adds
 real paths and function names over vague framing, and acceptance criteria that make "done" legible —
-not a closed set, a `review-*` gate may append. The criteria block has exactly one shape, the one
-the wire format registers (`packages/fabrika-cli/src/wire/acceptance-criteria.ts`): a **level-3**
-`### Acceptance criteria` heading — never `##` — over `- [ ]` checkbox items, one criterion per
-item. Every consumer (`build issue`, `review criteria`) rejects any drift, so `enrich` refuses a
-drifted block on exit `14` before writing anything; a rewrite with **no** criteria block is still
-accepted where none is warranted. **No invention**: enrich from what you found, keep
+not a closed set, a `review-*` gate may append. The criteria block's grammar is the wire format's,
+not this skill's ([`packages/fabrika-cli/src/wire/acceptance-criteria.ts`](../../../../packages/fabrika-cli/src/wire/acceptance-criteria.ts)):
+`enrich` runs that reader over the body it composed and refuses a drifted block on exit `14` before
+writing anything, naming the defect the reader found — so write the criteria and let the verb answer.
+A rewrite carrying **no** criteria block is still accepted, where none is warranted.
+**No invention**: enrich from what you found, keep
 the uncertainty the original had, and mark your own reads `Triage note:`. On a **re-type, rewrite the
 body's criteria to the new type** — stale criteria under a re-scoped comment ship a misleading spec.
 Done when every claim traces to something you read.

--- a/claude-plugins/fabrika/skills/triage/SKILL.md
+++ b/claude-plugins/fabrika/skills/triage/SKILL.md
@@ -125,7 +125,12 @@ For an epic, `fabrika triage enrich 4318 --epic` takes the pitch's five fields o
 Problem / Arc / Appetite / Rabbit-holes / No-gos — and heads them `## Pitch` above the brief, which
 it preserves verbatim for the planner; no *rewrite* goes above an epic's brief. The rewrite adds
 real paths and function names over vague framing, and acceptance criteria that make "done" legible —
-not a closed set, a `review-*` gate may append. **No invention**: enrich from what you found, keep
+not a closed set, a `review-*` gate may append. The criteria block has exactly one shape, the one
+the wire format registers (`packages/fabrika-cli/src/wire/acceptance-criteria.ts`): a **level-3**
+`### Acceptance criteria` heading — never `##` — over `- [ ]` checkbox items, one criterion per
+item. Every consumer (`build issue`, `review criteria`) rejects any drift, so `enrich` refuses a
+drifted block on exit `14` before writing anything; a rewrite with **no** criteria block is still
+accepted where none is warranted. **No invention**: enrich from what you found, keep
 the uncertainty the original had, and mark your own reads `Triage note:`. On a **re-type, rewrite the
 body's criteria to the new type** — stale criteria under a re-scoped comment ship a misleading spec.
 Done when every claim traces to something you read.

--- a/claude-plugins/fabrika/skills/triage/contract.md
+++ b/claude-plugins/fabrika/skills/triage/contract.md
@@ -158,6 +158,7 @@ or the search index could not be read
 | `11` | a **precondition read failed** — nothing was written and the outcome is UNKNOWN | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ |
 | `12` | refused: the issue is human-filed | — | — | — | — | — | — | — | — | ✓ |
 | `13` | refused: agent-filed and close-eligible, but the kill is unconfirmed (ADR 0159) | — | — | — | — | — | — | — | — | ✓ |
+| `14` | refused: the body this verb composed carries an acceptance-criteria block its registered wire reader classifies `Malformed` (ADR 0288) | — | — | — | — | — | ✓ | — | — | — |
 | `127` | the verb never ran (unresolved binary) | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ |
 
 **This matrix owns what a code *means*; the per-verb tables own what *triggers* it.** Every verb in
@@ -1073,8 +1074,9 @@ to bold text.**
 `pitch-guard`'s, at the `status:triaged` seam `triage apply` trips; this spec computes no second
 verdict on a gated question, which is the same reason a `triage pitch-check` verb is not derived.
 This verb refuses only what it can refuse about text the caller just wrote — empty (`3`), a
-machine-local path (`5`), a bare `@` reference (`6`) — and **adds no exit code**: `--epic` reaching
-those three is the removal of a restriction, not a new outcome.
+machine-local path (`5`), a bare `@` reference (`6`), and an acceptance-criteria block the wire
+reader rejects (`14`, below) — and `--epic` **adds no exit code of its own**: reaching those same
+refusals is the removal of a restriction, not a new outcome.
 
 **The re-enrich detector is the marker this verb writes — one rule, mode-independent** (founder
 ruling on [#4866](https://github.com/kamp-us/phoenix/issues/4866), 2026-08-08, option (b)). A body
@@ -1205,16 +1207,34 @@ original" is not a case that arises. This holds over a **planned** epic body (th
 #4850) and it holds when the re-run's mode **differs** from the mode that wrote the envelope (the
 mode axis, #4866) — the two qualifications the sentence previously needed. The one case it does not
 claim is a body carrying no marker and matching neither v1 shape, which is a *first* enrichment by
-definition rather than a re-run. No branch here refuses, so the exit-status and error tables are
-unchanged and the **adds no exit code** statement above stands: the marker is a body-composition
-change, not a refusal branch. This is the rule's only statement in this spec; the Scope section below
-states the scope and does not restate it.
+definition rather than a re-run. The detector itself refuses nothing — it is a body-composition
+rule, not a refusal branch, so it adds no row to the exit-status or error tables below. This is the
+rule's only statement in this spec; the Scope section below states the scope and does not restate it.
 
 **Redaction is asymmetric and deliberate.** The **preserved original** is foreign content: any
 machine-local path in it is masked to its class root, counted, and reported on stderr with its line
 number. **Your rewrite** is authored now, so a machine-local path in it is refused on exit `5` — you
 can fix what you just wrote. Refusing the original instead would strand the enrichment on somebody
 else's leak, and preserving it unredacted re-commits that leak into a public issue.
+
+**The acceptance-criteria block is read back before the write, and the split follows redaction's.**
+Per ADR [0288](../../../../.decisions/0288-producers-run-consumer-readers.md) this verb runs the
+criteria format's own registered reader
+([`packages/fabrika-cli/src/wire/acceptance-criteria.ts`](../../../../packages/fabrika-cli/src/wire/acceptance-criteria.ts))
+over the body it has composed and refuses on `14` when the answer is `Malformed`, so a block every
+downstream grader would reject never reaches the board. **The grammar is not restated here or in
+`SKILL.md`** — the module owns it and the refusal quotes the reader's own reason (ADR 0241).
+Two boundaries carry the weight:
+
+- **The read runs over the composed body, not over stdin.** The authored region includes what the
+  envelope adds, so a heading the template itself demoted is caught. Reading stdin alone would miss
+  exactly the case 0288 §1 names.
+- **It stops above the marker**, on the same asymmetry redaction uses: the preserved original is
+  foreign content, and a legacy `##` heading buried in it would otherwise refuse every
+  re-enrichment of that issue forever.
+
+`Absent` is **not** a refusal. An epic pitch, a decision, a parked ticket may legitimately carry no
+criteria block; a verb that demanded one would be a different verb.
 
 **Exit status**
 
@@ -1227,6 +1247,7 @@ else's leak, and preserving it unredacted re-commits that leak into a public iss
 | `8` | the `PATCH` failed — UNKNOWN whether the body changed |
 | `9` | the body was written but the read-back does not match |
 | `11` | the issue body could not be read — there is no original to preserve |
+| `14` | the composed body's **authored region** carries an acceptance-criteria block the wire reader classifies `Malformed` |
 
 **Errors**
 
@@ -1241,6 +1262,7 @@ else's leak, and preserving it unredacted re-commits that leak into a public iss
 | `triage enrich: redacted <k> machine-local path(s) from the preserved original (lines <l1>, <l2>).` | 0 | notice |
 | `triage enrich: PATCH failed: <reason> — UNKNOWN whether the body changed; re-read #<n> before retrying.` | 8 | refusal |
 | `triage enrich: body written but the read-back does not match — inspect #<n> before continuing.` | 9 | refusal |
+| `triage enrich: the rewrite composes an acceptance-criteria block the wire reader rejects — <reader's reason> (<evidence>). The grammar is owned by packages/fabrika-cli/src/wire/acceptance-criteria.ts; fix the block or drop it.` | 14 | refusal |
 
 **Scope** — one issue body, plus the caller's stdin: the rewrite, or the pitch with `--epic`. An
 issue proven absent is `7`; a body that could not be read is `11`; a body that *was* read and is

--- a/claude-plugins/fabrika/skills/triage/contract.md
+++ b/claude-plugins/fabrika/skills/triage/contract.md
@@ -1269,7 +1269,7 @@ criteria block; a verb that demanded one would be a different verb.
 | `triage enrich: redacted <k> machine-local path(s) from the preserved original (lines <l1>, <l2>).` | 0 | notice |
 | `triage enrich: PATCH failed: <reason> — UNKNOWN whether the body changed; re-read #<n> before retrying.` | 8 | refusal |
 | `triage enrich: body written but the read-back does not match — inspect #<n> before continuing.` | 9 | refusal |
-| `triage enrich: the rewrite composes an acceptance-criteria block the wire reader rejects — <reader's reason> (<evidence>). The grammar is owned by packages/fabrika-cli/src/wire/acceptance-criteria.ts; fix the block or drop it.` | 14 | refusal |
+| `triage enrich: the rewrite composes an acceptance-criteria block the wire reader rejects — <reader's reason> (<evidence>). The grammar is owned by packages/fabrika-cli/src/wire/acceptance-criteria.ts; fix the block or drop it.` | 15 | refusal |
 
 **Scope** — one issue body, plus the caller's stdin: the rewrite, or the pitch with `--epic`. An
 issue proven absent is `7`; a body that could not be read is `11`; a body that *was* read and is

--- a/claude-plugins/fabrika/skills/triage/contract.md
+++ b/claude-plugins/fabrika/skills/triage/contract.md
@@ -158,7 +158,7 @@ or the search index could not be read
 | `11` | a **precondition read failed** — nothing was written and the outcome is UNKNOWN | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ |
 | `12` | refused: the issue is human-filed | — | — | — | — | — | — | — | — | ✓ |
 | `13` | refused: agent-filed and close-eligible, but the kill is unconfirmed (ADR 0159) | — | — | — | — | — | — | — | — | ✓ |
-| `14` | refused: the body this verb composed carries an acceptance-criteria block its registered wire reader classifies `Malformed` (ADR 0288) | — | — | — | — | — | ✓ | — | — | — |
+| `15` | refused: the body this verb composed carries an acceptance-criteria block its registered wire reader classifies `Malformed` (ADR 0288) | — | — | — | — | — | ✓ | — | — | — |
 | `127` | the verb never ran (unresolved binary) | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ |
 
 **This matrix owns what a code *means*; the per-verb tables own what *triggers* it.** Every verb in
@@ -168,6 +168,13 @@ proven outcomes, `3` and up, phrased as that verb's trigger rather than as a res
 meaning. The reason is a defect this spec already shipped once: an earlier revision restated every
 code in all nine verb tables, and a `127` row added to the matrix reached only five of them. One fact
 in ten places is nine chances to drift, so the fact has one place.
+
+**`14` is allocated in code and missing from this matrix, and that is a known gap this spec does not
+close.** `packages/fabrika-cli/src/triage/codes.ts` seats `UNREPAIRABLE = 14` for `triage
+repair-criteria`, a tenth verb this document does not yet specify at all — it has no column above
+and no section below. Writing its row here would be guessing at a spec nobody has written, so `15`
+takes the next free seat instead of compacting into `14`, and the gap is disclosed rather than
+silently filled ([#5855](https://github.com/kamp-us/phoenix/issues/5855)).
 
 **`4` is a deliberate gap, not a free slot.** It held *"the target issue does not exist, or is not
 readable"* — one code for a proven fact and an unknown at once, which is the exact fusion `7` and
@@ -1075,7 +1082,7 @@ to bold text.**
 verdict on a gated question, which is the same reason a `triage pitch-check` verb is not derived.
 This verb refuses only what it can refuse about text the caller just wrote — empty (`3`), a
 machine-local path (`5`), a bare `@` reference (`6`), and an acceptance-criteria block the wire
-reader rejects (`14`, below) — and `--epic` **adds no exit code of its own**: reaching those same
+reader rejects (`15`, below) — and `--epic` **adds no exit code of its own**: reaching those same
 refusals is the removal of a restriction, not a new outcome.
 
 **The re-enrich detector is the marker this verb writes — one rule, mode-independent** (founder
@@ -1221,7 +1228,7 @@ else's leak, and preserving it unredacted re-commits that leak into a public iss
 Per ADR [0288](../../../../.decisions/0288-producers-run-consumer-readers.md) this verb runs the
 criteria format's own registered reader
 ([`packages/fabrika-cli/src/wire/acceptance-criteria.ts`](../../../../packages/fabrika-cli/src/wire/acceptance-criteria.ts))
-over the body it has composed and refuses on `14` when the answer is `Malformed`, so a block every
+over the body it has composed and refuses on `15` when the answer is `Malformed`, so a block every
 downstream grader would reject never reaches the board. **The grammar is not restated here or in
 `SKILL.md`** — the module owns it and the refusal quotes the reader's own reason (ADR 0241).
 Two boundaries carry the weight:
@@ -1247,7 +1254,7 @@ criteria block; a verb that demanded one would be a different verb.
 | `8` | the `PATCH` failed — UNKNOWN whether the body changed |
 | `9` | the body was written but the read-back does not match |
 | `11` | the issue body could not be read — there is no original to preserve |
-| `14` | the composed body's **authored region** carries an acceptance-criteria block the wire reader classifies `Malformed` |
+| `15` | the composed body's **authored region** carries an acceptance-criteria block the wire reader classifies `Malformed` |
 
 **Errors**
 

--- a/packages/fabrika-cli/src/triage/codes.ts
+++ b/packages/fabrika-cli/src/triage/codes.ts
@@ -103,6 +103,21 @@ export const UNCONFIRMED = 13;
  * thing the review gate is forbidden to do.
  */
 export const UNREPAIRABLE = 14;
+/**
+ * Refused: the **authored region of the composed body** carries an acceptance-criteria block the
+ * wire reader classifies `Malformed`.
+ *
+ * Every downstream consumer (`build issue`, `review criteria`) reads the block through
+ * `../wire/acceptance-criteria.ts` and rejects exactly what it rejects, so writing it to a body only
+ * defers the refusal to a lane that cannot fix it (#5565, ADR 0288). `Absent` stays allowed: an
+ * issue with no criteria block is a fact, not a defect, and this code never turns enrich into
+ * "every issue must have criteria".
+ *
+ * Distinct from {@link UNREPAIRABLE}, which is `repair-criteria`'s answer about a block already on
+ * the board. This one is `enrich`'s answer about a block that has not landed yet, so the fix is a
+ * re-send rather than a hand-edit.
+ */
+export const MALFORMED_CRITERIA = 15;
 
 /** The verb never ran (unresolved binary). The shell's, not this process's — no constant owns it. */
 const NEVER_RAN = 127;
@@ -147,6 +162,11 @@ export const TRIAGE_EXIT_TABLE: ReadonlyArray<ExitCodeRow> = [
 		code: UNREPAIRABLE,
 		meaning:
 			"refused: the acceptance-criteria drift is not mechanically repairable — not a pure level drift on exact heading text",
+	},
+	{
+		code: MALFORMED_CRITERIA,
+		meaning:
+			"refused: the composed body's authored region carries an acceptance-criteria block the wire reader classifies Malformed",
 	},
 	{code: NO_IMPLEMENTATION, meaning: "no implementation could be resolved"},
 	{code: NEVER_RAN, meaning: "the verb never ran (unresolved binary)"},

--- a/packages/fabrika-cli/src/triage/codes.unit.test.ts
+++ b/packages/fabrika-cli/src/triage/codes.unit.test.ts
@@ -8,6 +8,7 @@ import {
 	EMPTY_STDIN,
 	HUMAN_FILED,
 	LEAKED_PATH,
+	MALFORMED_CRITERIA,
 	OFF_VOCABULARY,
 	PRECONDITION_UNKNOWN,
 	READBACK_MISMATCH,
@@ -38,7 +39,7 @@ describe("the overlap with `report`'s writing verbs is code-for-code", () => {
 	});
 });
 
-describe("the two codes this group adds", () => {
+describe("the codes this group adds", () => {
 	it("seats the human-filed refusal clear of `report`'s shipped 11", () => {
 		expect(HUMAN_FILED).toBe(12);
 		expect(HUMAN_FILED).not.toBe(report.PRECONDITION_UNKNOWN);
@@ -52,6 +53,16 @@ describe("the two codes this group adds", () => {
 	it("seats the unrepairable-drift refusal on its own code", () => {
 		expect(UNREPAIRABLE).toBe(14);
 		expect(UNREPAIRABLE).not.toBe(UNCONFIRMED);
+	});
+
+	/**
+	 * Two criteria refusals, two codes, and the distinctness is the point: `repair-criteria` answers
+	 * `14` about a block already on the board, `enrich` answers `15` about one that has not landed.
+	 * Fusing them would tell a caller to hand-edit an issue it has not written yet.
+	 */
+	it("seats the malformed-criteria refusal clear of the unrepairable one", () => {
+		expect(MALFORMED_CRITERIA).toBe(15);
+		expect(MALFORMED_CRITERIA).not.toBe(UNREPAIRABLE);
 	});
 
 	/**
@@ -74,7 +85,7 @@ describe("TRIAGE_EXIT_TABLE", () => {
 	});
 
 	it("carries every allocated code exactly once", () => {
-		expect(codes).toEqual([0, 1, 3, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 126, 127]);
+		expect(codes).toEqual([0, 1, 3, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 126, 127]);
 	});
 
 	it("gives every code a non-empty meaning", () => {
@@ -88,5 +99,6 @@ describe("TRIAGE_EXIT_TABLE", () => {
 		expect(meaningOf(HUMAN_FILED)).toContain("human-filed");
 		expect(meaningOf(UNCONFIRMED)).toContain("unconfirmed");
 		expect(meaningOf(UNREPAIRABLE)).toContain("not mechanically repairable");
+		expect(meaningOf(MALFORMED_CRITERIA)).toContain("acceptance-criteria");
 	});
 });

--- a/packages/fabrika-cli/src/triage/enrich-verb.ts
+++ b/packages/fabrika-cli/src/triage/enrich-verb.ts
@@ -28,7 +28,7 @@ import {
 	WRITE_UNKNOWN,
 	ZERO_SCOPE,
 } from "./codes.ts";
-import {composeBody, detect, type EnrichMode, wrapOriginal} from "./enrich.ts";
+import {authoredRegion, composeBody, detect, type EnrichMode, wrapOriginal} from "./enrich.ts";
 import {legacyPreserved} from "./enrich-legacy.ts";
 
 export interface EnrichOptions {
@@ -72,17 +72,6 @@ export const runEnrich = (
 		if (authored._tag === "Refused") return authored.outcome;
 		const leak = leakRefusal(surface, authored.text);
 		if (leak !== null) return leak;
-
-		// Over the authored stdin only, like the leak guard above: the composed body preserves the
-		// original by design, and an old `##` heading buried in it must never block a re-enrichment.
-		// `Absent` stays allowed — an issue may legitimately carry no criteria block (#5565).
-		const criteria = readCriteria(authored.text);
-		if (criteria._tag === "Malformed") {
-			return refuse(
-				MALFORMED_CRITERIA,
-				`triage enrich: ${surface.noun} carries an acceptance-criteria block every downstream reader rejects — ${criteria.reason} (${criteria.evidence}). Emit "### Acceptance criteria" with "- [ ]" items, or drop the block.`,
-			);
-		}
 
 		const target = yield* getIssue(repo, issue);
 		if (target._tag === "Absent") {
@@ -139,6 +128,19 @@ export const runEnrich = (
 		}
 
 		const composed = composeBody({mode, issue, authored: authored.text, preserved});
+
+		// ADR 0288 §1: the read runs over the bytes about to be posted, not over stdin — an enclosing
+		// template can demote a heading that arrived conforming. It is scoped to the region above the
+		// marker, which `composeBody` guarantees is `composed`'s own prefix, because the preserved
+		// original below it is redacted rather than refused; a legacy `##` heading buried there would
+		// otherwise refuse every re-enrichment forever. `Absent` stays allowed (#5565).
+		const criteria = readCriteria(authoredRegion(mode, authored.text));
+		if (criteria._tag === "Malformed") {
+			return refuse(
+				MALFORMED_CRITERIA,
+				`triage enrich: ${surface.noun} composes an acceptance-criteria block the wire reader rejects — ${criteria.reason} (${criteria.evidence}). The grammar is owned by packages/fabrika-cli/src/wire/acceptance-criteria.ts; fix the block or drop it.`,
+			);
+		}
 
 		const written = yield* patchIssueBody(repo, issue, composed);
 		if (written._tag === "Failure") {

--- a/packages/fabrika-cli/src/triage/enrich-verb.ts
+++ b/packages/fabrika-cli/src/triage/enrich-verb.ts
@@ -19,8 +19,15 @@ import type {StdinRead} from "../io/stdin.ts";
 import {normalizeForReadback} from "../report/compose.ts";
 import {renderLeaks, scanBody} from "../report/leaks.ts";
 import {answer, FAILED, refuse, type VerbOutcome} from "../verb.ts";
+import {read as readCriteria} from "../wire/acceptance-criteria.ts";
 import {leakRefusal, readAuthored} from "./authored.ts";
-import {PRECONDITION_UNKNOWN, READBACK_MISMATCH, WRITE_UNKNOWN, ZERO_SCOPE} from "./codes.ts";
+import {
+	MALFORMED_CRITERIA,
+	PRECONDITION_UNKNOWN,
+	READBACK_MISMATCH,
+	WRITE_UNKNOWN,
+	ZERO_SCOPE,
+} from "./codes.ts";
 import {composeBody, detect, type EnrichMode, wrapOriginal} from "./enrich.ts";
 import {legacyPreserved} from "./enrich-legacy.ts";
 
@@ -65,6 +72,17 @@ export const runEnrich = (
 		if (authored._tag === "Refused") return authored.outcome;
 		const leak = leakRefusal(surface, authored.text);
 		if (leak !== null) return leak;
+
+		// Over the authored stdin only, like the leak guard above: the composed body preserves the
+		// original by design, and an old `##` heading buried in it must never block a re-enrichment.
+		// `Absent` stays allowed — an issue may legitimately carry no criteria block (#5565).
+		const criteria = readCriteria(authored.text);
+		if (criteria._tag === "Malformed") {
+			return refuse(
+				MALFORMED_CRITERIA,
+				`triage enrich: ${surface.noun} carries an acceptance-criteria block every downstream reader rejects — ${criteria.reason} (${criteria.evidence}). Emit "### Acceptance criteria" with "- [ ]" items, or drop the block.`,
+			);
+		}
 
 		const target = yield* getIssue(repo, issue);
 		if (target._tag === "Absent") {

--- a/packages/fabrika-cli/src/triage/enrich-verb.unit.test.ts
+++ b/packages/fabrika-cli/src/triage/enrich-verb.unit.test.ts
@@ -267,7 +267,7 @@ describe("runEnrich — legacy migration", () => {
 });
 
 describe("runEnrich — the composed body's criteria block must be one the wire reader accepts (#5565, ADR 0288)", () => {
-	it("refuses a level-2 heading on 14, naming the level it read and the level expected", async () => {
+	it("refuses a level-2 heading on 15, naming the level it read and the level expected", async () => {
 		const shell = fakeShell([[READ, issue(ORIGINAL)]]);
 		const outcome = await Effect.runPromise(
 			Effect.provide(

--- a/packages/fabrika-cli/src/triage/enrich-verb.unit.test.ts
+++ b/packages/fabrika-cli/src/triage/enrich-verb.unit.test.ts
@@ -266,7 +266,7 @@ describe("runEnrich — legacy migration", () => {
 	});
 });
 
-describe("runEnrich — the acceptance-criteria block on stdin must be one the wire reader accepts (#5565)", () => {
+describe("runEnrich — the composed body's criteria block must be one the wire reader accepts (#5565, ADR 0288)", () => {
 	it("refuses a level-2 heading on 14, naming the level it read and the level expected", async () => {
 		const shell = fakeShell([[READ, issue(ORIGINAL)]]);
 		const outcome = await Effect.runPromise(
@@ -309,6 +309,25 @@ describe("runEnrich — the acceptance-criteria block on stdin must be one the w
 		});
 		expect(outcome.code).toBe(0);
 		expect(body).toContain("## Acceptance criteria");
+	});
+
+	it("refuses a drifted block in an --epic pitch too, where the envelope heads it with `## Pitch`", async () => {
+		const shell = fakeShell([[READ, issue(ORIGINAL)]]);
+		const outcome = await Effect.runPromise(
+			Effect.provide(
+				runEnrich({
+					...options,
+					epic: true,
+					stdin: Effect.succeed<StdinRead>({
+						_tag: "Text",
+						text: "**Problem:** x\n\n## Acceptance criteria\n\n- [ ] keep focus\n",
+					}),
+				}),
+				shell.layer,
+			),
+		);
+		expect(outcome.code).toBe(MALFORMED_CRITERIA);
+		expect(shell.calls.some((line) => PATCH.test(line))).toBe(false);
 	});
 });
 

--- a/packages/fabrika-cli/src/triage/enrich-verb.unit.test.ts
+++ b/packages/fabrika-cli/src/triage/enrich-verb.unit.test.ts
@@ -7,6 +7,7 @@ import {
 	BARE_AT_PATH,
 	EMPTY_STDIN,
 	LEAKED_PATH,
+	MALFORMED_CRITERIA,
 	PRECONDITION_UNKNOWN,
 	READBACK_MISMATCH,
 	WRITE_UNKNOWN,
@@ -262,6 +263,52 @@ describe("runEnrich — legacy migration", () => {
 		expect(body).toContain("I think this format is wrong:");
 		expect(body).toContain("What should it be?");
 		expect(summaryLines(body ?? "")).toEqual([SUMMARY_LINE.rewrite, SUMMARY_LINE.wrap]);
+	});
+});
+
+describe("runEnrich — the acceptance-criteria block on stdin must be one the wire reader accepts (#5565)", () => {
+	it("refuses a level-2 heading on 14, naming the level it read and the level expected", async () => {
+		const shell = fakeShell([[READ, issue(ORIGINAL)]]);
+		const outcome = await Effect.runPromise(
+			Effect.provide(
+				runEnrich({
+					...options,
+					stdin: Effect.succeed<StdinRead>({
+						_tag: "Text",
+						text: `${REWRITE}\n\n## Acceptance criteria\n\n- [ ] keep focus\n`,
+					}),
+				}),
+				shell.layer,
+			),
+		);
+		expect(outcome.code).toBe(MALFORMED_CRITERIA);
+		expect(outcome.stderr.at(-1)).toContain("heading level 2, expected 3");
+		expect(shell.calls.some((line) => PATCH.test(line))).toBe(false);
+	});
+
+	it("accepts a conforming level-3 block", async () => {
+		const {outcome} = await run(ORIGINAL, {
+			stdin: Effect.succeed<StdinRead>({
+				_tag: "Text",
+				text: `${REWRITE}\n\n### Acceptance criteria\n\n- [ ] keep focus\n`,
+			}),
+		});
+		expect(outcome.code).toBe(0);
+	});
+
+	it("accepts a rewrite that carries no criteria block at all — Absent is never a defect", async () => {
+		const {outcome} = await run(ORIGINAL);
+		expect(outcome.code).toBe(0);
+	});
+
+	it("never blocks a re-enrichment on a `##` heading inside the PRESERVED original", async () => {
+		const driftedOriginal = `## Summary\n\nx\n\n## Acceptance criteria\n\n- [ ] old item`;
+		const enriched = `${REWRITE}\n\n---\n\n${renderMarker(4312, "rewrite")}\n<details>\n${SUMMARY_LINE.rewrite}\n\n${driftedOriginal}\n\n</details>\n`;
+		const {outcome, body} = await run(enriched, {
+			stdin: Effect.succeed<StdinRead>({_tag: "Text", text: "## A sharper rewrite"}),
+		});
+		expect(outcome.code).toBe(0);
+		expect(body).toContain("## Acceptance criteria");
 	});
 });
 

--- a/packages/fabrika-cli/src/triage/enrich.ts
+++ b/packages/fabrika-cli/src/triage/enrich.ts
@@ -109,8 +109,16 @@ export const detect = (
 
 const EPIC_HEADER = "## Epic — awaiting plan";
 
-/** The authored region — everything above the marker — for one mode and one caller's stdin. */
-const authoredRegion = (mode: EnrichMode, text: string): string =>
+/**
+ * The authored region — everything above the marker — for one mode and one caller's stdin.
+ *
+ * Exported because it is the slice a producer's own read-back runs over (ADR 0288 §1): it is the
+ * composed body's leading bytes, template headings and separators included, so a section the
+ * envelope demoted is visible; and it stops above the marker, so the preserved original — foreign
+ * bytes this verb redacts rather than judges — stays out of reach. `composeBody` below is the law
+ * that the two are the same bytes.
+ */
+export const authoredRegion = (mode: EnrichMode, text: string): string =>
 	mode === "rewrite"
 		? `${text.trim()}\n\n---\n\n`
 		: `## Pitch\n\n${text.trim()}\n\n${EPIC_HEADER}\n\n\`plan-epic\` appends its plan and dependency topology below.\n\n`;

--- a/packages/fabrika-cli/src/triage/enrich.unit.test.ts
+++ b/packages/fabrika-cli/src/triage/enrich.unit.test.ts
@@ -1,5 +1,6 @@
 import {describe, expect, it} from "vitest";
 import {
+	authoredRegion,
 	composeBody,
 	detect,
 	MARKER_RE,
@@ -67,6 +68,16 @@ describe("the composed envelope", () => {
 		expect(enrichedEpic()).toBe(
 			`## Pitch\n\n${PITCH}\n\n## Epic — awaiting plan\n\n\`plan-epic\` appends its plan and dependency topology below.\n\n<!-- fabrika:enriched issue=4312 mode=wrap -->\n<details>\n${SUMMARY_LINE.wrap}\n\n${ORIGINAL}\n\n</details>\n`,
 		);
+	});
+
+	/**
+	 * The verb's ADR-0288 read-back runs over `authoredRegion(...)` and posts `composeBody(...)`. If
+	 * those two ever stop being the same leading bytes, the verb is reading something it does not
+	 * post — which is the defect 0288 §1 exists to refuse — and no test of the verb would show it.
+	 */
+	it("leads the composed body with exactly the authored region, in both modes", () => {
+		expect(enrichedDefault().startsWith(authoredRegion("rewrite", REWRITE))).toBe(true);
+		expect(enrichedEpic().startsWith(authoredRegion("wrap", PITCH))).toBe(true);
 	});
 
 	it("binds the issue number and the mode into the marker", () => {


### PR DESCRIPTION
Triage's enrich verb accepted whatever heading level the composing model typed, while every
downstream reader (`build issue`, `review criteria`) pins `### Acceptance criteria` at level 3 —
so a `##` block shipped, read back `Malformed`, and cost a repair round per issue. This closes the
producer side, both halves:

- **Point at the shape.** Per ADR 0288 §Decision.4 the skill does not restate the grammar; it
  points at the registered wire format module
  (`packages/fabrika-cli/src/wire/acceptance-criteria.ts`) and the refusal teaches the rest.
- **Refuse what the consumers cannot read.** `runEnrich` runs the wire reader over the authored
  region of the final composed body (ADR 0288 §Decision.1) — the composed body preserves
  the original by design, so an old `##` heading buried in the preserved original never blocks a
  re-enrichment. A `Malformed` read refuses on the allocated code `15` (`MALFORMED_CRITERIA`, listed by
  `triage codes`), and the message carries the wire reader's drift reason ("heading level 2,
  expected 3"). `Absent` stays allowed — enrich does not become "every issue must have criteria".

Unit tests pin all four cases from the issue: level-2 refused, conforming level-3 accepted, no-block
accepted, `##` inside the preserved original accepted.

Fixes #5565

## Deviations

None.

