### PR TITLE
fix: Free-text in:body PR lookup returns PRs that only mention the issue number

### DIFF
--- a/claude-plugins/fabrika/skills/operate/SKILL.md
+++ b/claude-plugins/fabrika/skills/operate/SKILL.md
@@ -100,7 +100,9 @@ from the inside.
 
 `lane brief`'s refusals are the parks it saves you from guessing at: `18` is a state that routes to
 no shell, `19` is a task whose issue cannot be resolved or is absent, `20` is zero open PRs where
-the state needs one or several where one is required. Each is a park naming what the verb named —
+the state needs one or several where one is required. It counts a PR only when the PR **declares it
+closes** the task's issue — GitHub's own closing-issue link, not a body mention — so a PR that
+quotes the number in prose never makes `20` fire (#5805). Each is a park naming what the verb named —
 never a prompt you write by hand instead. Parallel active tasks brief and spawn in parallel.
 
 Done when every active task has either a spawn in flight or an event recorded this pass.

--- a/packages/fabrika-cli/src/io/pulls.ts
+++ b/packages/fabrika-cli/src/io/pulls.ts
@@ -3,9 +3,10 @@
  * list, its diff bytes, the check runs at a commit, the invoking token's identity and repository
  * permission, and the comment edit an upsert needs.
  *
- * The `issues.ts` disciplines hold here unchanged — `gh api` REST and never GraphQL, every list read
- * paged, absent split from unreadable through {@link Existence}, and a shape that is not what was
- * asked for treated as a failure rather than an empty result.
+ * The `issues.ts` disciplines hold here — every list read paged, absent split from unreadable
+ * through {@link Existence}, and a shape that is not what was asked for treated as a failure rather
+ * than an empty result. REST is the default surface; {@link openPullsClosing} is on GraphQL because
+ * the closing-issue link edge it needs is published nowhere else.
  *
  * **Every list read returns what it received alongside what the platform declared.** A review whose
  * scope was silently truncated is a review over unknown scope, and the only way a caller can refuse
@@ -14,15 +15,7 @@
 import {Effect} from "effect";
 import {execCapture} from "./exec.ts";
 import {type Attempt, fail, ok, type Shell} from "./git.ts";
-import {
-	absent,
-	type Existence,
-	httpStatusOf,
-	pagedJson,
-	parseTabRows,
-	present,
-	unknown,
-} from "./issues.ts";
+import {absent, type Existence, httpStatusOf, pagedJson, present, unknown} from "./issues.ts";
 import {isRecord, parseJson} from "./json.ts";
 
 export interface PullRecord {
@@ -261,42 +254,85 @@ export const patchComment = (repo: string, id: number, body: string): Shell<Atte
 			: fail("`gh api` exited 0 but its output is not an edited comment");
 	});
 
-/** One open pull request as a body-trace lookup sees it: the number and the link to hand on. */
-export interface TracingPull {
+/** One open pull request that declares it closes the issue: the number and the link to hand on. */
+export interface ClosingPull {
 	readonly number: number;
 	readonly url: string;
 }
 
+const CLOSERS_QUERY =
+	"query($owner:String!,$name:String!,$number:Int!,$cursor:String){repository(owner:$owner,name:$name){issue(number:$number){closedByPullRequestsReferences(first:100,includeClosedPrs:true,after:$cursor){pageInfo{hasNextPage endCursor} nodes{number url state}}}}}";
+
 /**
- * Every OPEN pull request whose body mentions `issue`, paged.
+ * Every OPEN pull request that **declares it closes** `issue`, read off GitHub's own closing-issue
+ * link edge and paged.
  *
- * The lane's PR is read off the board and never off a driver's memory, so the answer is the whole
- * match set rather than a first hit: zero and several are facts a caller must be able to refuse on,
- * and a read that narrowed to one would invent the lane's PR whenever two branches trace to the
- * same issue.
+ * v1 asked `search/issues` for `<issue> in:body`, which matches any prose quoting the number: a PR
+ * closing a different issue but naming this one in a table came back as a candidate, and the
+ * caller's several-hits refusal then parked a lane that had exactly one real PR (#5805). The edge
+ * read here is the one GitHub builds from a closing keyword, so a mention is not a hit and
+ * "several" means what the caller needs it to mean — two PRs each declaring they close this issue.
+ *
+ * `includeClosedPrs: true` plus an explicit `OPEN` filter, rather than the field's own exclusion:
+ * that argument's name promises more than it delivers (a merged PR is still returned under
+ * `false`), and the caller is asking about open PRs specifically.
+ *
+ * The answer is the whole set rather than a first hit: zero and several are facts a caller must be
+ * able to refuse on, and a read that narrowed to one would invent the lane's PR.
  */
-export const openPullsTracing = (
+export const openPullsClosing = (
 	repo: string,
 	issue: number,
-): Shell<Attempt<ReadonlyArray<TracingPull>>> =>
+): Shell<Attempt<ReadonlyArray<ClosingPull>>> =>
 	Effect.gen(function* () {
-		const q = `repo:${repo} is:pr is:open ${issue} in:body`;
-		const r = yield* execCapture("gh", [
-			"api",
-			"--paginate",
-			`search/issues?q=${encodeURIComponent(q)}&per_page=100`,
-			"--jq",
-			'.items[] | "\\(.number)\t\\(.html_url)"',
-		]);
-		if (!r.ok) return fail(r.reason);
-		const rows = parseTabRows(r.stdout, 2);
-		if (rows === null) return fail("`gh api` exited 0 but its output is not a list of pull rows");
-		const out: TracingPull[] = [];
-		for (const [number, url] of rows) {
-			if (number === undefined || !/^\d+$/.test(number) || url === undefined || url === "") {
-				return fail("`gh api` exited 0 but one row is not a pull request");
+		const [owner, name] = repo.split("/");
+		if (owner === undefined || name === undefined) return fail(`\`${repo}\` is not owner/name`);
+		const out: ClosingPull[] = [];
+		let cursor: string | null = null;
+		for (let page = 0; page < 50; page++) {
+			const args = [
+				"api",
+				"graphql",
+				"-f",
+				`query=${CLOSERS_QUERY}`,
+				"-F",
+				`owner=${owner}`,
+				"-F",
+				`name=${name}`,
+				"-F",
+				`number=${issue}`,
+			];
+			if (cursor !== null) args.push("-F", `cursor=${cursor}`);
+			const r = yield* execCapture("gh", args);
+			if (!r.ok) return fail(r.reason);
+			const parsed = parseJson(r.stdout);
+			const data = isRecord(parsed) && isRecord(parsed.data) ? parsed.data : null;
+			const repository = data !== null && isRecord(data.repository) ? data.repository : null;
+			const issueNode = repository !== null && isRecord(repository.issue) ? repository.issue : null;
+			const set =
+				issueNode !== null && isRecord(issueNode.closedByPullRequestsReferences)
+					? issueNode.closedByPullRequestsReferences
+					: null;
+			if (set === null || !Array.isArray(set.nodes)) {
+				return fail("`gh api graphql` exited 0 but its output is not a closing-pull page");
 			}
-			out.push({number: Number.parseInt(number, 10), url});
+			for (const node of set.nodes) {
+				if (
+					!isRecord(node) ||
+					typeof node.number !== "number" ||
+					typeof node.url !== "string" ||
+					node.url === "" ||
+					typeof node.state !== "string"
+				) {
+					return fail("`gh api graphql` exited 0 but one node is not a pull request");
+				}
+				if (node.state !== "OPEN") continue;
+				out.push({number: node.number, url: node.url});
+			}
+			const info = isRecord(set.pageInfo) ? set.pageInfo : null;
+			if (info === null || info.hasNextPage !== true) break;
+			cursor = typeof info.endCursor === "string" ? info.endCursor : "";
+			if (cursor === "") return fail("`gh api graphql` declared another page and named no cursor");
 		}
 		return ok(out);
 	});

--- a/packages/fabrika-cli/src/io/pulls.unit.test.ts
+++ b/packages/fabrika-cli/src/io/pulls.unit.test.ts
@@ -1,0 +1,142 @@
+/** `openPullsClosing` — the closing-issue link edge, and every shape it refuses to read. */
+import {Effect} from "effect";
+import {describe, expect, it} from "vitest";
+import {errOut, fakeShell, okOut, once} from "../fakes.test-support.ts";
+import type {ExecResult} from "./exec.ts";
+import {openPullsClosing} from "./pulls.ts";
+
+const GRAPHQL = /^gh api graphql /;
+
+interface Node {
+	readonly number: number;
+	readonly url: string;
+	readonly state: string;
+}
+
+const pr = (number: number, state = "OPEN"): Node => ({
+	number,
+	url: `https://github.com/kamp-us/phoenix/pull/${number}`,
+	state,
+});
+
+const page = (nodes: ReadonlyArray<Node>, endCursor: string | null = null): ExecResult =>
+	okOut(
+		JSON.stringify({
+			data: {
+				repository: {
+					issue: {
+						closedByPullRequestsReferences: {
+							pageInfo: {hasNextPage: endCursor !== null, endCursor},
+							nodes,
+						},
+					},
+				},
+			},
+		}),
+	);
+
+const run = (script: ReadonlyArray<readonly [RegExp, ExecResult]>, issue = 5751) => {
+	const shell = fakeShell(script);
+	return Effect.runPromise(
+		Effect.provide(openPullsClosing("kamp-us/phoenix", issue), shell.layer),
+	).then((result) => ({result, calls: shell.calls}));
+};
+
+describe("openPullsClosing", () => {
+	it("returns the one PR declaring it closes the issue", async () => {
+		const {result} = await run([[GRAPHQL, page([pr(5803)])]]);
+
+		expect(result).toEqual({
+			_tag: "Ok",
+			value: [{number: 5803, url: "https://github.com/kamp-us/phoenix/pull/5803"}],
+		});
+	});
+
+	it("reads zero closers as an empty FACT, not a failure — the caller owns that park", async () => {
+		const {result} = await run([[GRAPHQL, page([])]]);
+
+		expect(result).toEqual({_tag: "Ok", value: []});
+	});
+
+	it("returns both when two PRs genuinely declare they close the same issue", async () => {
+		const {result} = await run([[GRAPHQL, page([pr(5803), pr(5804)])]]);
+
+		expect(result).toEqual({
+			_tag: "Ok",
+			value: [
+				{number: 5803, url: "https://github.com/kamp-us/phoenix/pull/5803"},
+				{number: 5804, url: "https://github.com/kamp-us/phoenix/pull/5804"},
+			],
+		});
+	});
+
+	it("drops a closer that is no longer open — the caller asked about open PRs", async () => {
+		const {result} = await run([
+			[GRAPHQL, page([pr(5788, "MERGED"), pr(5803), pr(5799, "CLOSED")])],
+		]);
+
+		expect(result).toEqual({
+			_tag: "Ok",
+			value: [{number: 5803, url: "https://github.com/kamp-us/phoenix/pull/5803"}],
+		});
+	});
+
+	it("asks the closing-issue edge, never a free-text body search (#5805)", async () => {
+		const {calls} = await run([[GRAPHQL, page([pr(5803)])]]);
+
+		expect(calls[0]).toContain("closedByPullRequestsReferences");
+		expect(calls[0]).not.toContain("in:body");
+		expect(calls[0]).not.toContain("search/issues");
+	});
+
+	it("pages — a second page's closers are not dropped", async () => {
+		const {result} = await run([
+			[once(GRAPHQL), page([pr(5803)], "cursor-1")],
+			[GRAPHQL, page([pr(5804)])],
+		]);
+
+		expect(result).toEqual({
+			_tag: "Ok",
+			value: [
+				{number: 5803, url: "https://github.com/kamp-us/phoenix/pull/5803"},
+				{number: 5804, url: "https://github.com/kamp-us/phoenix/pull/5804"},
+			],
+		});
+	});
+
+	it("refuses when another page is declared with no cursor to fetch it", async () => {
+		const {result} = await run([[GRAPHQL, page([pr(5803)], "")]]);
+
+		expect(result._tag).toBe("Failure");
+	});
+
+	it("refuses when gh fails", async () => {
+		const {result} = await run([[GRAPHQL, errOut("HTTP 502")]]);
+
+		expect(result._tag).toBe("Failure");
+	});
+
+	it("refuses a 0 exit whose output is not a closing-pull page", async () => {
+		const {result} = await run([[GRAPHQL, okOut('{"data":{"repository":{"issue":null}}}')]]);
+
+		expect(result._tag).toBe("Failure");
+	});
+
+	it("refuses a node that is not a pull request rather than shortening the list", async () => {
+		const {result} = await run([
+			[GRAPHQL, page([{number: 5803, url: "", state: "OPEN"}] as ReadonlyArray<Node>)],
+		]);
+
+		expect(result._tag).toBe("Failure");
+	});
+
+	it("refuses a repo that is not owner/name", async () => {
+		const shell = fakeShell([[GRAPHQL, page([pr(5803)])]]);
+		const result = await Effect.runPromise(
+			Effect.provide(openPullsClosing("phoenix", 5751), shell.layer),
+		);
+
+		expect(result._tag).toBe("Failure");
+		expect(shell.calls).toEqual([]);
+	});
+});

--- a/packages/fabrika-cli/src/lane/brief-verb.ts
+++ b/packages/fabrika-cli/src/lane/brief-verb.ts
@@ -12,7 +12,7 @@
 import {Effect, type FileSystem, type Path} from "effect";
 import type {ChildProcessSpawner} from "effect/unstable/process";
 import {getIssue, resolveRepo} from "../io/issues.ts";
-import {openPullsTracing} from "../io/pulls.ts";
+import {openPullsClosing} from "../io/pulls.ts";
 import {answer, refuse, type VerbOutcome} from "../verb.ts";
 import {
 	artifactUrl,
@@ -113,11 +113,11 @@ export const runBrief = (
 			);
 		}
 
-		const pulls = yield* openPullsTracing(repo.value, issue);
+		const pulls = yield* openPullsClosing(repo.value, issue);
 		if (pulls._tag === "Failure") {
 			return refuse(
 				LANE_UNREADABLE,
-				`${VERB}: cannot read the open PRs tracing to #${issue}: ${pulls.reason} — UNKNOWN.`,
+				`${VERB}: cannot read the open PRs declaring they close #${issue}: ${pulls.reason} — UNKNOWN.`,
 				notes,
 			);
 		}
@@ -125,14 +125,14 @@ export const runBrief = (
 		if (rest.length > 0) {
 			return refuse(
 				PR_AMBIGUOUS,
-				`${VERB}: ${pulls.value.length} open PRs trace to #${issue} — exactly one is the lane's, and which is not this verb's to guess.`,
+				`${VERB}: ${pulls.value.length} open PRs declare they close #${issue} — exactly one is the lane's, and which is not this verb's to guess.`,
 				[...notes, `${VERB}: candidates: ${pulls.value.map((p) => `#${p.number}`).join(", ")}.`],
 			);
 		}
 		if (only === undefined && state !== "build") {
 			return refuse(
 				PR_AMBIGUOUS,
-				`${VERB}: no open PR traces to #${issue}, and a "${state}" shell has nothing to read without one.`,
+				`${VERB}: no open PR declares it closes #${issue}, and a "${state}" shell has nothing to read without one.`,
 				notes,
 			);
 		}

--- a/packages/fabrika-cli/src/lane/brief-verb.unit.test.ts
+++ b/packages/fabrika-cli/src/lane/brief-verb.unit.test.ts
@@ -23,7 +23,7 @@ const TITLE = "the operator hand-writes every spawn prompt";
 
 const ISSUE_READ = /^gh api repos\/o\/r\/issues\/5751$/;
 const CHILD_READ = /^gh api repos\/o\/r\/issues\/5729$/;
-const PR_SEARCH = /^gh api --paginate search\/issues/;
+const PR_CLOSERS = /^gh api graphql -f query=query\(/;
 
 const issuePayload = (number: number, url: string): ExecResult =>
 	okOut(
@@ -37,8 +37,22 @@ const issuePayload = (number: number, url: string): ExecResult =>
 		}),
 	);
 
-const pullRows = (...rows: ReadonlyArray<readonly [number, string]>): ExecResult =>
-	okOut(rows.map(([number, url]) => `${number}\t${url}`).join("\n"));
+/** One page of the closing-issue link edge — every node OPEN, since the verb filters on that. */
+const closingPulls = (...rows: ReadonlyArray<readonly [number, string]>): ExecResult =>
+	okOut(
+		JSON.stringify({
+			data: {
+				repository: {
+					issue: {
+						closedByPullRequestsReferences: {
+							pageInfo: {hasNextPage: false, endCursor: null},
+							nodes: rows.map(([number, url]) => ({number, url, state: "OPEN"})),
+						},
+					},
+				},
+			},
+		}),
+	);
 
 /** A single-issue lane at `lane`, with one log line per operator event already recorded. */
 const lane = (id: string, events: ReadonlyArray<string>) =>
@@ -84,7 +98,7 @@ describe("lane brief", () => {
 	it("briefs the builder on a `build` state, with no PR when construction has none", async () => {
 		const out = await run(lane("5751", ["WIP"]), [
 			[ISSUE_READ, issuePayload(5751, ISSUE_URL)],
-			[PR_SEARCH, okOut("")],
+			[PR_CLOSERS, closingPulls()],
 		]);
 
 		expect(out.code).toBe(0);
@@ -99,7 +113,7 @@ describe("lane brief", () => {
 	it("briefs the reviewer on a `review` state, carrying the one open PR that traces to the issue", async () => {
 		const out = await run(lane("5751", ["WIP", "DONE"]), [
 			[ISSUE_READ, issuePayload(5751, ISSUE_URL)],
-			[PR_SEARCH, pullRows([5790, PR_URL])],
+			[PR_CLOSERS, closingPulls([5790, PR_URL])],
 		]);
 
 		expect(out.code).toBe(0);
@@ -112,7 +126,7 @@ describe("lane brief", () => {
 	it("briefs the shipper on a `ship` state", async () => {
 		const out = await run(lane("5751", ["WIP", "DONE", "PASS"]), [
 			[ISSUE_READ, issuePayload(5751, ISSUE_URL)],
-			[PR_SEARCH, pullRows([5790, PR_URL])],
+			[PR_CLOSERS, closingPulls([5790, PR_URL])],
 		]);
 
 		expect(out.code).toBe(0);
@@ -125,7 +139,7 @@ describe("lane brief", () => {
 	it("carries URLs only — no title, no body, no verdict text", async () => {
 		const out = await run(lane("5751", ["WIP", "DONE"]), [
 			[ISSUE_READ, issuePayload(5751, ISSUE_URL)],
-			[PR_SEARCH, pullRows([5790, PR_URL])],
+			[PR_CLOSERS, closingPulls([5790, PR_URL])],
 		]);
 
 		expect(out.stdout).not.toContain(TITLE);
@@ -175,7 +189,7 @@ describe("lane brief", () => {
 			fs,
 			[
 				[CHILD_READ, issuePayload(5729, "https://github.com/o/r/issues/5729")],
-				[PR_SEARCH, okOut("")],
+				[PR_CLOSERS, closingPulls()],
 			],
 			{lane: "5680", task: "issue_5729"},
 		);
@@ -255,7 +269,7 @@ describe("lane brief", () => {
 	it("refuses several open PRs, naming every candidate", async () => {
 		const out = await run(lane("5751", ["WIP", "DONE"]), [
 			[ISSUE_READ, issuePayload(5751, ISSUE_URL)],
-			[PR_SEARCH, pullRows([5790, PR_URL], [5791, "https://github.com/o/r/pull/5791"])],
+			[PR_CLOSERS, closingPulls([5790, PR_URL], [5791, "https://github.com/o/r/pull/5791"])],
 		]);
 
 		expect(out.code).toBe(PR_AMBIGUOUS);
@@ -266,7 +280,7 @@ describe("lane brief", () => {
 	it("refuses zero open PRs where the state needs one", async () => {
 		const out = await run(lane("5751", ["WIP", "DONE", "PASS"]), [
 			[ISSUE_READ, issuePayload(5751, ISSUE_URL)],
-			[PR_SEARCH, okOut("")],
+			[PR_CLOSERS, closingPulls()],
 		]);
 
 		expect(out.code).toBe(PR_AMBIGUOUS);

--- a/packages/fabrika-cli/src/lane/codes.ts
+++ b/packages/fabrika-cli/src/lane/codes.ts
@@ -94,7 +94,8 @@ export const NO_SHELL = 18;
 export const ISSUE_UNRESOLVED = 19;
 
 /**
- * Exactly one open PR was required to trace to the task's issue and zero or several did. Never
+ * Exactly one open PR was required to declare it closes the task's issue and zero or several did.
+ * A PR that merely quotes the number in prose is not one of them (#5805). Never
  * resolved by picking the newest: a brief handed the wrong PR sends a shell to judge or merge
  * someone else's work, so the ambiguity is named and the dispatch stops.
  */


### PR DESCRIPTION
A lane's pull request is now resolved off GitHub's closing-issue link edge instead of a free-text
search over PR bodies.

The old lookup asked `search/issues` for `<issue> in:body`. That matches any PR whose body merely
quotes the number, so a PR closing a different issue but naming this one in a table came back as a
candidate — and `lane brief`'s several-hits refusal then parked a lane that had exactly one real PR.

`openPullsTracing` is now `openPullsClosing`, on the GraphQL
`issue.closedByPullRequestsReferences` edge. A prose mention is not a hit; "several" now means two
PRs each declaring they close the same issue. Zero-hits behaviour is unchanged — where the state
demands a PR, zero is still a park, and an empty edge is an `Ok([])` fact rather than a failure.

It asks for `includeClosedPrs: true` and filters `state === "OPEN"` itself. I checked the field
live: under `includeClosedPrs: false` a merged PR is still returned, so the argument does not mean
what the caller needs, and doing the filter here makes the open-only contract explicit.

Renames ripple to the one caller (`lane brief`) and its refusal wording, which said "trace to" and
now says "declare they close".

New `packages/fabrika-cli/src/io/pulls.unit.test.ts` covers one closer, zero closers, two genuine
closers, non-open closers dropped, paging, and each unreadable shape. Whole `fabrika-cli` suite is
green at 4722 tests.

## Deviations

- **Said:** the acceptance criteria name `claude-plugins/fabrika/skills/operate/SKILL.md` line 86's
  `gh pr list --state open --search "$issue_number in:body"` command. **Did:** updated the surviving
  sentence about `lane brief`'s exit `20` instead. **Why:** that command is no longer on `main` —
  step 2 now dispatches through `lane brief`, and the only text left describing the lookup is the
  refusal sentence. **Disposition:** stated here; the skill no longer describes a body search
  anywhere.
- **Said:** the criteria name only `pulls.ts` and the skill. **Did:** also edited
  `packages/fabrika-cli/src/lane/codes.ts` (the `PR_AMBIGUOUS` docblock) and `pulls.ts`'s
  top-of-file docblock. **Why:** both asserted the old framing — `codes.ts` said "trace to the
  task's issue", and the module docblock claimed "`gh api` REST and never GraphQL", which this
  change makes false. Leaving either is the stale framing the fourth criterion exists to kill.
  **Disposition:** stated here.
- **Known defect left unfixed** — **Said:** criterion 5 asks the lookup to return only #5803 given
  issue 5751 with #5788 and #5803 both open. **Did:** verified the edge live (it answered #5803
  alone) but could not reproduce the stated open/open board state. **Why:** both PRs merged before
  this branch was cut, so an open-only lookup now correctly answers zero. **Disposition:** the case
  is encoded as a fixture instead — the two-candidate shape is the "drops a closer that is no longer
  open" test.

Fixes #5805
