### PR TITLE
feat: chore lane: name-keyed ledger + chore workflow definition

### DIFF
--- a/.glossary/LANGUAGE.md
+++ b/.glossary/LANGUAGE.md
@@ -265,7 +265,8 @@ composition API — flat element-props*, which coins both terms; it builds on AD
 `PageShell` source is defined by that ADR — the term is grounded in the ADR until the shells
 land in [`apps/web/src/components/layout/`](../apps/web/src/components/layout/).)
 
-- **`recipe`** — the composition-primitive idiom: **one flat element-prop per zone**,
+- **`recipe`** (UI sense; the pipeline sense is below) — the composition-primitive idiom: **one
+  flat element-prop per zone**,
   orphan-as-type-error. NOT a zones-object, NOT compound components
   (`<Shell.Destinations>…`) — a compound API leaves an *orphan slot* (an element rendered
   but placed nowhere) that only a lint pass catches; flat element-props make that
@@ -276,6 +277,28 @@ land in [`apps/web/src/components/layout/`](../apps/web/src/components/layout/).
   primitive (wrapping it, not replacing it); `PageShell` composes `SubnavShell` plus the routed
   page content below it. A shell sits *between* a **primitive** and the page — distinct from a
   **primitive**, which owns no zone and exposes raw slots.
+
+### The lane, the chore lane, and the pipeline sense of "recipe"
+
+A **lane** is one unit of pipeline work driven by a machine document plus an append-only
+`events.jsonl`, folded fresh on every read — no resident process, no snapshot (#5673). A lane
+is addressed by a key, and the key decides where its ledger lives:
+
+- **`chore lane`** — a lane keyed by a **name** rather than an issue number, because a recurring
+  chore has no issue to be keyed by; its state lives at `.fabrika/chores/<name>/events.jsonl`,
+  against `.fabrika/lanes/<n>/` for an issue lane. Same fold, same six-event vocabulary
+  (DONE/PASS/FAIL/BLOCKED/WIP/UNBLOCKED), different key. Source:
+  [`packages/fabrika-cli/src/lane/key.ts`](../packages/fabrika-cli/src/lane/key.ts) (#5840).
+- **`recipe`** (pipeline sense) — one deterministic fabrika verb a chore workflow state applies:
+  a fixed sequence with named exit codes and no judgment in it. A recipe **relays a verb's
+  answer, it never derives the decision** — ADR
+  [0228](../.decisions/0228-scripts-relay-never-derive.md). The operator that runs one is a thin
+  executor of the machine it is handed; the known/novel split lives in the verb's exit codes,
+  never in operator prose.
+
+**Two senses of `recipe`.** This is the pipeline one. The other is the UI composition idiom
+above ("The composition shell / recipe", ADR 0182) — one flat element-prop per zone. They share
+nothing but the word; name which one you mean when the context does not fix it.
 
 ### The three senses of "phoenix"
 

--- a/packages/fabrika-cli/src/lane/codes.ts
+++ b/packages/fabrika-cli/src/lane/codes.ts
@@ -100,3 +100,10 @@ export const ISSUE_UNRESOLVED = 19;
  * someone else's work, so the ambiguity is named and the dispatch stops.
  */
 export const PR_AMBIGUOUS = 20;
+
+/**
+ * The `lane` argument is not a lane key: an empty key, or a `chore:<name>` whose name is not the one
+ * shape a chore lane's directory may carry. Refused before any path is joined and before any read,
+ * so a name carrying a separator or a traversal never becomes a directory nobody meant.
+ */
+export const KEY_MALFORMED = 21;

--- a/packages/fabrika-cli/src/lane/command.ts
+++ b/packages/fabrika-cli/src/lane/command.ts
@@ -14,10 +14,12 @@ import type {VerbOutcome} from "../verb.ts";
 import {runBrief} from "./brief-verb.ts";
 import {runEmit} from "./emit-verb.ts";
 import {runHistory} from "./history-verb.ts";
+import {type LaneKey, laneRef, parseKey, templateFile} from "./key.ts";
 import {runOpen} from "./open-verb.ts";
 import {runPrint} from "./print-verb.ts";
+import {keyRefusal} from "./refusals.ts";
 import {runStatus} from "./status-verb.ts";
-import {DEFAULT_LANES_ROOT} from "./store.ts";
+import {DEFAULT_CHORES_ROOT, DEFAULT_LANES_ROOT, type LaneRef} from "./store.ts";
 import {runTransition} from "./transition-verb.ts";
 
 /** Write the outcome and exit on its code — stdout is the answer, everything else is stderr. */
@@ -29,24 +31,43 @@ const emit = (outcome: VerbOutcome): Effect.Effect<void> =>
 	});
 
 const laneArgument = Argument.string("lane").pipe(
-	Argument.withDescription("the lane id under the root — by convention the issue number"),
+	Argument.withDescription(
+		"the lane key — the issue number the lane drives, or `chore:<name>` for a chore lane",
+	),
 );
 
 const rootFlag = Flag.string("root").pipe(
-	Flag.withDefault(DEFAULT_LANES_ROOT),
-	Flag.withDescription(`the lanes root directory (default: ${DEFAULT_LANES_ROOT})`),
+	Flag.optional,
+	Flag.withDescription(
+		`the lanes root directory (default: ${DEFAULT_LANES_ROOT}, or ${DEFAULT_CHORES_ROOT} for a chore key)`,
+	),
 );
+
+/**
+ * Resolve the `lane` argument to a key and its directory, or refuse it — the one step every keyed
+ * verb shares, so a malformed key is caught before any verb reads or writes anything.
+ */
+const onKey = <R>(
+	raw: string,
+	root: Option.Option<string>,
+	run: (key: LaneKey, ref: LaneRef) => Effect.Effect<VerbOutcome, never, R>,
+): Effect.Effect<VerbOutcome, never, R> => {
+	const parsed = parseKey(raw);
+	return parsed._tag === "Malformed"
+		? Effect.succeed(keyRefusal(parsed))
+		: run(parsed.key, laneRef(parsed.key, Option.getOrNull(root)));
+};
 
 const status = leafCommand(
 	"status",
 	{lane: laneArgument, root: rootFlag},
 	Effect.fn(function* ({lane, root}) {
-		yield* emit(yield* runStatus({root, lane}));
+		yield* emit(yield* onKey(lane, root, (_key, ref) => runStatus(ref)));
 	}),
 ).pipe(
 	Command.withShortDescription("One lane's derived state, folded fresh from its event log."),
 	Command.withDescription(
-		"One lane's derived state, folded fresh from the whole events.jsonl every invocation — no resident process, no snapshot. stdout is the operator's status JSON: compound `stateValue` (active phase → per-task leaf state, future phases \"waiting\", or a bare terminal), `status` active/done, and per-task `{retries, maxRetries, …}` context with the tripped tasks in `errors`. Exits 4 (workflow.json or events.jsonl read in full and not the shape — every defect on stderr), 7 (no lane there — copy a workflow template to open it), 11 (the lane could not be read — its state is UNKNOWN, never fresh). Example: fabrika lane status 5673",
+		"One lane's derived state, folded fresh from the whole events.jsonl every invocation — no resident process, no snapshot. stdout is the operator's status JSON: compound `stateValue` (active phase → per-task leaf state, future phases \"waiting\", or a bare terminal), `status` active/done, and per-task `{retries, maxRetries, …}` context with the tripped tasks in `errors`. Exits 4 (workflow.json or events.jsonl read in full and not the shape — every defect on stderr), 7 (no lane there — copy a workflow template to open it), 11 (the lane could not be read — its state is UNKNOWN, never fresh), 21 (the key is not a lane key). Examples: fabrika lane status 5673 · fabrika lane status chore:park-sweep",
 	),
 );
 
@@ -65,18 +86,15 @@ const transition = leafCommand(
 	},
 	Effect.fn(function* ({lane, event, root, task}) {
 		yield* emit(
-			yield* runTransition({
-				root,
-				lane,
-				event,
-				task: task._tag === "Some" ? task.value : null,
-			}),
+			yield* onKey(lane, root, (_key, ref) =>
+				runTransition({...ref, event, task: Option.getOrNull(task)}),
+			),
 		);
 	}),
 ).pipe(
 	Command.withShortDescription("Record one operator event, refusing an invalid one unappended."),
 	Command.withDescription(
-		"Record one operator event on the lane's append-only log — after the machine accepts it, never before. stdout is `{previous, event, current, taskAffected}` with the two stateValues around the fold. An invalid event — no cell in the task's current state (tea's NoCellError, surfaced verbatim), outside the operator's six, a task outside the active phase, a finished workflow — is refused loudly and the log is left byte-identical. Exits 4 (lane record read in full and not the shape), 7 (no lane there), 8 (the append did not land — the event is NOT recorded), 11 (the lane could not be read), 12 (the event is refused, log unappended), 13 (the task is not in the machine, or --task omitted on a multi-task lane). Example: fabrika lane transition 5673 DONE",
+		"Record one operator event on the lane's append-only log — after the machine accepts it, never before. stdout is `{previous, event, current, taskAffected}` with the two stateValues around the fold. An invalid event — no cell in the task's current state (tea's NoCellError, surfaced verbatim), outside the operator's six, a task outside the active phase, a finished workflow — is refused loudly and the log is left byte-identical. Exits 4 (lane record read in full and not the shape), 7 (no lane there), 8 (the append did not land — the event is NOT recorded), 11 (the lane could not be read), 12 (the event is refused, log unappended), 13 (the task is not in the machine, or --task omitted on a multi-task lane), 21 (the key is not a lane key). Example: fabrika lane transition 5673 DONE",
 	),
 );
 
@@ -84,12 +102,12 @@ const history = leafCommand(
 	"history",
 	{lane: laneArgument, root: rootFlag},
 	Effect.fn(function* ({lane, root}) {
-		yield* emit(yield* runHistory({root, lane}));
+		yield* emit(yield* onKey(lane, root, (_key, ref) => runHistory(ref)));
 	}),
 ).pipe(
 	Command.withShortDescription("The lane's append-only event log, verbatim."),
 	Command.withDescription(
-		"The lane's append-only event log, verbatim — one `{task, event, at}` per recorded event, in append order; the log IS the history, and `from`/`to` are reconstructible by folding, never stored. A lane with no events yet answers `[]`. Exits 4 (lane record read in full and not the shape), 7 (no lane there), 11 (the lane could not be read). Example: fabrika lane history 5673",
+		"The lane's append-only event log, verbatim — one `{task, event, at}` per recorded event, in append order; the log IS the history, and `from`/`to` are reconstructible by folding, never stored. A lane with no events yet answers `[]`. Exits 4 (lane record read in full and not the shape), 7 (no lane there), 11 (the lane could not be read), 21 (the key is not a lane key). Example: fabrika lane history 5673",
 	),
 );
 
@@ -97,27 +115,30 @@ const print = leafCommand(
 	"print",
 	{lane: laneArgument, root: rootFlag},
 	Effect.fn(function* ({lane, root}) {
-		yield* emit(yield* runPrint({root, lane}));
+		yield* emit(yield* onKey(lane, root, (_key, ref) => runPrint(ref)));
 	}),
 ).pipe(
 	Command.withShortDescription("The lane's compiled machine topology, as data."),
 	Command.withDescription(
-		"The lane's compiled machine topology — phases in order, the two workflow terminals, and per task its initial state, retry budget, and each state's legal events (everything absent refuses at transition time). Exits 4 (workflow.json read in full and not the shape), 7 (no lane there), 11 (the lane could not be read). Example: fabrika lane print 5673",
+		"The lane's compiled machine topology — phases in order, the two workflow terminals, and per task its initial state, retry budget, and each state's legal events (everything absent refuses at transition time). Exits 4 (workflow.json read in full and not the shape), 7 (no lane there), 11 (the lane could not be read), 21 (the key is not a lane key). Example: fabrika lane print 5673",
 	),
 );
 
-const templatePath = fileURLToPath(new URL("./templates/coder.workflow.json", import.meta.url));
+const templatePath = (key: LaneKey): string =>
+	fileURLToPath(new URL(`./templates/${templateFile(key)}`, import.meta.url));
 
 const open = leafCommand(
 	"open",
 	{lane: laneArgument, root: rootFlag},
 	Effect.fn(function* ({lane, root}) {
-		yield* emit(yield* runOpen({root, lane, templatePath}));
+		yield* emit(
+			yield* onKey(lane, root, (key, ref) => runOpen({...ref, templatePath: templatePath(key)})),
+		);
 	}),
 ).pipe(
-	Command.withShortDescription("Boot a single-issue lane from the committed coder template."),
+	Command.withShortDescription("Boot a lane from the committed template its key selects."),
 	Command.withDescription(
-		"Boot one single-issue lane: create `<root>/<lane>/` and place a byte-identical copy of the committed coder template as its workflow.json. An existing lane dir is refused loudly with nothing written — resuming needs no boot, and overwriting a machine mid-drive would corrupt a live fold. Exits 8 (the write did not land — the lane is NOT booted), 11 (the template or the lane dir's existence could not be read — UNKNOWN, never a boot), 14 (the lane already exists). Example: fabrika lane open 5673",
+		"Boot one lane: create `<root>/<key>/` and place a byte-identical copy of the committed template the key selects as its workflow.json — the coder template for an issue number, the chore template for a `chore:<name>` key. An existing lane dir is refused loudly with nothing written — resuming needs no boot, and overwriting a machine mid-drive would corrupt a live fold. Exits 8 (the write did not land — the lane is NOT booted), 11 (the template or the lane dir's existence could not be read — UNKNOWN, never a boot), 14 (the lane already exists), 21 (the key is not a lane key). Examples: fabrika lane open 5673 · fabrika lane open chore:park-sweep",
 	),
 );
 
@@ -136,7 +157,14 @@ const emitLane = leafCommand(
 		),
 	},
 	Effect.fn(function* ({epic, root, repo}) {
-		yield* emit(yield* runEmit({epic, root, repo: Option.getOrNull(repo), env: process.env}));
+		yield* emit(
+			yield* runEmit({
+				epic,
+				root: Option.getOrNull(root) ?? DEFAULT_LANES_ROOT,
+				repo: Option.getOrNull(repo),
+				env: process.env,
+			}),
+		);
 	}),
 ).pipe(
 	Command.withShortDescription("Generate an epic's lane machine from its board topology."),
@@ -163,19 +191,20 @@ const brief = leafCommand(
 	},
 	Effect.fn(function* ({lane, root, task, repo}) {
 		yield* emit(
-			yield* runBrief({
-				root,
-				lane,
-				task: Option.getOrNull(task),
-				repo: Option.getOrNull(repo),
-				env: process.env,
-			}),
+			yield* onKey(lane, root, (_key, ref) =>
+				runBrief({
+					...ref,
+					task: Option.getOrNull(task),
+					repo: Option.getOrNull(repo),
+					env: process.env,
+				}),
+			),
 		);
 	}),
 ).pipe(
 	Command.withShortDescription("The spawn prompt for one task's current leaf state."),
 	Command.withDescription(
-		"Print the spawn prompt for one task's current leaf state, folded fresh from the ledger — so a driver pastes a brief rather than composing one. stdout is the `lane-brief` wire format: which lane, task, state and shell, the resolved issue and PR URLs (URLs only — the spawned shell re-reads its own ground), and the format's byte-fixed rules. Exits 4 (lane record read in full and not the shape), 7 (no lane there), 11 (the lane, the issue or its PRs could not be read — UNKNOWN), 13 (the task is not in the machine, or --task omitted on a multi-task lane), 18 (the leaf state routes to no shell — `queued`, `blocked`, `human:*`, a final), 19 (neither the task nor the lane names an issue, or that issue is proven absent), 20 (zero open PRs where the state needs one, or several where one is required). Example: fabrika lane brief 5680 --task issue_5729",
+		"Print the spawn prompt for one task's current leaf state, folded fresh from the ledger — so a driver pastes a brief rather than composing one. stdout is the `lane-brief` wire format: which lane, task, state and shell, the resolved issue and PR URLs (URLs only — the spawned shell re-reads its own ground), and the format's byte-fixed rules. Exits 4 (lane record read in full and not the shape), 7 (no lane there), 11 (the lane, the issue or its PRs could not be read — UNKNOWN), 13 (the task is not in the machine, or --task omitted on a multi-task lane), 18 (the leaf state routes to no shell — `queued`, `blocked`, `human:*`, a final), 19 (neither the task nor the lane names an issue, or that issue is proven absent), 20 (zero open PRs where the state needs one, or several where one is required), 21 (the key is not a lane key). Example: fabrika lane brief 5680 --task issue_5729",
 	),
 );
 
@@ -183,6 +212,6 @@ export const laneCommand = Command.make("lane").pipe(
 	Command.withSubcommands([status, transition, history, print, open, emitLane, brief]),
 	Command.withShortDescription("Drive one lane's state ledger by folding its event log."),
 	Command.withDescription(
-		"Drive one lane's state ledger — a @demlik/tea machine folded fresh from an append-only events.jsonl on every invocation, speaking the operator's six events (#5673)",
+		"Drive one lane's state ledger — a @demlik/tea machine folded fresh from an append-only events.jsonl on every invocation, speaking the operator's six events (#5673). A lane is keyed by the issue number it drives, or by name as `chore:<name>` for a chore that has no issue number (#5840)",
 	),
 );

--- a/packages/fabrika-cli/src/lane/fixtures.test-support.ts
+++ b/packages/fabrika-cli/src/lane/fixtures.test-support.ts
@@ -1,6 +1,6 @@
 /**
- * Shared lane fixtures: the committed coder template read verbatim (the golden-fixture idiom), and
- * a two-phase document in the /prd-to-tasks shape small enough for a test to mutate.
+ * Shared lane fixtures: the committed coder and chore templates read verbatim (the golden-fixture
+ * idiom), and a two-phase document in the /prd-to-tasks shape small enough for a test to mutate.
  */
 import {readGoldenFixture} from "../golden-fixture.ts";
 
@@ -8,6 +8,11 @@ export const coderTemplateText = (): string =>
 	readGoldenFixture(import.meta.url, "./templates/coder.workflow.json");
 
 export const coderWorkflow = (): unknown => JSON.parse(coderTemplateText());
+
+export const choreTemplateText = (): string =>
+	readGoldenFixture(import.meta.url, "./templates/chore.workflow.json");
+
+export const choreWorkflow = (): unknown => JSON.parse(choreTemplateText());
 
 const region = (ns: string): Record<string, unknown> => ({
 	initial: "doing",

--- a/packages/fabrika-cli/src/lane/key.ts
+++ b/packages/fabrika-cli/src/lane/key.ts
@@ -1,0 +1,67 @@
+/**
+ * The lane key — how a lane is addressed, and where that address puts it on disk.
+ *
+ * Two kinds. An **issue lane** is keyed by the issue number it drives, under `.fabrika/lanes/`. A
+ * **chore lane** is keyed by a name, because a recurring chore has no issue number to be keyed by,
+ * and lives under `.fabrika/chores/` (#5840). Both fold through the same fresh-process fold; the key
+ * decides the directory and the boot template, nothing else.
+ *
+ * The kind travels **in the argument** (`5673` vs `chore:park-sweep`) rather than in a flag beside
+ * it, so a key that names one kind while the root names the other cannot be expressed. A chore name
+ * is checked against one shape before it ever reaches a path join: it is a directory name, so
+ * anything carrying a separator, a traversal, or shell-significant bytes is refused as malformed
+ * rather than resolved into a path nobody meant.
+ */
+import {DEFAULT_CHORES_ROOT, DEFAULT_LANES_ROOT, type LaneRef} from "./store.ts";
+
+/** What marks an argument as naming a chore rather than an issue. */
+export const CHORE_PREFIX = "chore:";
+
+/** Lowercase kebab, the repo's file-name idiom — one shape, so a name reads the same everywhere. */
+const CHORE_NAME = /^[a-z0-9]+(?:-[a-z0-9]+)*$/;
+
+/** Long enough for a descriptive chore name, short enough to stay a legible directory. */
+export const CHORE_NAME_LIMIT = 64;
+
+export type LaneKey =
+	| {readonly _tag: "Issue"; readonly lane: string}
+	| {readonly _tag: "Chore"; readonly name: string};
+
+export type KeyResult =
+	| {readonly _tag: "Key"; readonly key: LaneKey}
+	| {readonly _tag: "Malformed"; readonly raw: string; readonly reason: string};
+
+const malformed = (raw: string, reason: string): KeyResult => ({_tag: "Malformed", raw, reason});
+
+/** Read one `lane` argument as a key. Total: every string is a key or a named refusal. */
+export const parseKey = (raw: string): KeyResult => {
+	if (!raw.startsWith(CHORE_PREFIX)) {
+		return raw === ""
+			? malformed(raw, "a lane key is empty")
+			: {_tag: "Key", key: {_tag: "Issue", lane: raw}};
+	}
+	const name = raw.slice(CHORE_PREFIX.length);
+	if (name.length > CHORE_NAME_LIMIT) {
+		return malformed(raw, `a chore name is at most ${CHORE_NAME_LIMIT} characters`);
+	}
+	return CHORE_NAME.test(name)
+		? {_tag: "Key", key: {_tag: "Chore", name}}
+		: malformed(
+				raw,
+				`a chore name is lowercase kebab (${CHORE_NAME.source}) — it is a directory name, so a separator, a traversal or an empty name is refused`,
+			);
+};
+
+/** The root a key lives under when the caller relocates nothing. */
+export const defaultRoot = (key: LaneKey): string =>
+	key._tag === "Chore" ? DEFAULT_CHORES_ROOT : DEFAULT_LANES_ROOT;
+
+/** Where a key puts its lane — the caller's `--root` wins over the kind's default. */
+export const laneRef = (key: LaneKey, root: string | null): LaneRef => ({
+	root: root ?? defaultRoot(key),
+	lane: key._tag === "Chore" ? key.name : key.lane,
+});
+
+/** The committed template a key boots from, by file name under `./templates/`. */
+export const templateFile = (key: LaneKey): string =>
+	key._tag === "Chore" ? "chore.workflow.json" : "coder.workflow.json";

--- a/packages/fabrika-cli/src/lane/key.unit.test.ts
+++ b/packages/fabrika-cli/src/lane/key.unit.test.ts
@@ -1,0 +1,64 @@
+/** The lane key — which kind an argument names, where it lands, and the names it refuses. */
+import {describe, expect, it} from "vitest";
+import {CHORE_NAME_LIMIT, laneRef, parseKey, templateFile} from "./key.ts";
+import {DEFAULT_CHORES_ROOT, DEFAULT_LANES_ROOT} from "./store.ts";
+
+const key = (raw: string) => {
+	const parsed = parseKey(raw);
+	if (parsed._tag !== "Key") throw new Error(`refused "${raw}": ${parsed.reason}`);
+	return parsed.key;
+};
+
+const reasonFor = (raw: string): string => {
+	const parsed = parseKey(raw);
+	expect(parsed._tag).toBe("Malformed");
+	return parsed._tag === "Malformed" ? parsed.reason : "";
+};
+
+describe("the lane key", () => {
+	it("reads a bare argument as the issue lane it drives", () => {
+		expect(key("5673")).toEqual({_tag: "Issue", lane: "5673"});
+		expect(laneRef(key("5673"), null)).toEqual({root: DEFAULT_LANES_ROOT, lane: "5673"});
+	});
+
+	it("reads a `chore:` argument as a chore lane under the chores root", () => {
+		expect(key("chore:park-sweep")).toEqual({_tag: "Chore", name: "park-sweep"});
+		expect(laneRef(key("chore:park-sweep"), null)).toEqual({
+			root: DEFAULT_CHORES_ROOT,
+			lane: "park-sweep",
+		});
+	});
+
+	it("lets an explicit root win over either kind's default", () => {
+		expect(laneRef(key("5673"), "/tmp/lanes").root).toBe("/tmp/lanes");
+		expect(laneRef(key("chore:park-sweep"), "/tmp/lanes").root).toBe("/tmp/lanes");
+	});
+
+	it("selects the boot template by kind, never by root", () => {
+		expect(templateFile(key("5673"))).toBe("coder.workflow.json");
+		expect(templateFile(key("chore:park-sweep"))).toBe("chore.workflow.json");
+	});
+
+	it("refuses a chore name that is not lowercase kebab", () => {
+		for (const raw of ["chore:", "chore:Park-Sweep", "chore:park sweep", "chore:park_sweep"]) {
+			expect(reasonFor(raw)).toContain("lowercase kebab");
+		}
+	});
+
+	it("refuses a chore name carrying a separator or a traversal, before any path is joined", () => {
+		for (const raw of ["chore:../../etc", "chore:a/b", "chore:.", "chore:park-sweep/"]) {
+			expect(parseKey(raw)._tag).toBe("Malformed");
+		}
+	});
+
+	it("refuses a chore name past the length limit", () => {
+		const long = `chore:${"a".repeat(CHORE_NAME_LIMIT + 1)}`;
+
+		expect(reasonFor(long)).toContain(String(CHORE_NAME_LIMIT));
+		expect(parseKey(`chore:${"a".repeat(CHORE_NAME_LIMIT)}`)._tag).toBe("Key");
+	});
+
+	it("refuses an empty key rather than resolving it to the root itself", () => {
+		expect(reasonFor("")).toContain("empty");
+	});
+});

--- a/packages/fabrika-cli/src/lane/machine.ts
+++ b/packages/fabrika-cli/src/lane/machine.ts
@@ -60,6 +60,12 @@ export interface CompiledLane {
 	readonly phases: ReadonlyArray<{readonly name: string; readonly tasks: ReadonlyArray<string>}>;
 	/** The workflow's two terminal names, read off the last phase's `onDone` pair. */
 	readonly terminals: {readonly complete: string; readonly tripped: string};
+	/**
+	 * What fires this lane, as the document declares it — a chore workflow's own field (#5840). Read
+	 * and carried rather than ignored, so a mistyped declaration is a defect instead of a silence;
+	 * what a trigger name *means* is the caller's, exactly as a guard name is.
+	 */
+	readonly trigger?: string;
 }
 
 export type CompileResult =
@@ -205,6 +211,10 @@ export const compile = (workflow: unknown): CompileResult => {
 		return {_tag: "Malformed", defects: ["document must carry a `machine.states` object"]};
 	}
 	const context = isRecord(machineDef.context) ? machineDef.context : {};
+	const declaredTrigger = isRecord(workflow) ? workflow.trigger : undefined;
+	if (declaredTrigger !== undefined && typeof declaredTrigger !== "string") {
+		defects.push("document `trigger` must be a string naming what fires this lane");
+	}
 
 	const machineStates = machineDef.states;
 	const tasks: Record<string, CompiledTask> = {};
@@ -259,7 +269,15 @@ export const compile = (workflow: unknown): CompileResult => {
 	if (terminals === undefined) {
 		return {_tag: "Malformed", defects: ["no phase carried a readable `onDone` pair"]};
 	}
-	return {_tag: "Compiled", lane: {tasks, phases, terminals}};
+	return {
+		_tag: "Compiled",
+		lane: {
+			tasks,
+			phases,
+			terminals,
+			...(typeof declaredTrigger === "string" ? {trigger: declaredTrigger} : {}),
+		},
+	};
 };
 
 /** Parse and compile in one step — for a caller holding the document's bytes off disk. */
@@ -276,6 +294,7 @@ export const compileText = (text: string): CompileResult => {
 export interface LaneTopology {
 	readonly phases: CompiledLane["phases"];
 	readonly terminals: CompiledLane["terminals"];
+	readonly trigger?: string;
 	readonly tasks: Readonly<
 		Record<
 			string,
@@ -293,6 +312,7 @@ export interface LaneTopology {
 export const topology = (lane: CompiledLane): LaneTopology => ({
 	phases: lane.phases,
 	terminals: lane.terminals,
+	...(lane.trigger === undefined ? {} : {trigger: lane.trigger}),
 	tasks: Object.fromEntries(
 		Object.entries(lane.tasks).map(([taskId, task]) => [
 			taskId,

--- a/packages/fabrika-cli/src/lane/machine.unit.test.ts
+++ b/packages/fabrika-cli/src/lane/machine.unit.test.ts
@@ -1,5 +1,10 @@
 import {describe, expect, it} from "vitest";
-import {coderWorkflow, stateNode, twoPhaseWorkflow} from "./fixtures.test-support.ts";
+import {
+	choreWorkflow,
+	coderWorkflow,
+	stateNode,
+	twoPhaseWorkflow,
+} from "./fixtures.test-support.ts";
 import {compile, OPERATOR_EVENTS, topology} from "./machine.ts";
 
 const compiled = (workflow: unknown) => {
@@ -62,6 +67,30 @@ describe("the compiler — structural recognition", () => {
 		expect(defined(summary.tasks.issue).states.queued).toEqual(["WIP", "BLOCKED"]);
 		expect(defined(summary.tasks.issue).states.review).toEqual(["PASS", "BLOCKED", "FAIL"]);
 		expect(defined(summary.tasks.issue).states.shipped).toEqual([]);
+		expect(summary.trigger).toBeUndefined();
+	});
+
+	it("compiles the committed chore template, carrying its declared trigger", () => {
+		const lane = compiled(choreWorkflow());
+
+		expect(lane.phases).toEqual([{name: "sweep", tasks: ["park_sweep"]}]);
+		expect(lane.trigger).toBe("lane-parked");
+		expect(topology(lane).trigger).toBe("lane-parked");
+		expect(defined(lane.tasks.park_sweep).initial).toEqual({
+			type: "queued",
+			retries: 0,
+			maxRetries: 2,
+		});
+		expect([...defined(lane.tasks.park_sweep).errorFinals]).toEqual(["frozen"]);
+	});
+
+	it("holds the chore template to the same six events as every other lane", () => {
+		const summary = topology(compiled(choreWorkflow()));
+		const listened = new Set(
+			Object.values(defined(summary.tasks.park_sweep).states).flatMap((events) => events),
+		);
+
+		for (const event of listened) expect(OPERATOR_EVENTS).toContain(event);
 	});
 });
 
@@ -123,6 +152,12 @@ describe("the compiler — refusals", () => {
 		expect(defectsOf(workflow)).toContain(
 			'machine-level final "orphan" is targeted by no phase\'s `onDone` pair',
 		);
+	});
+
+	it("refuses a `trigger` that is not a string, rather than ignoring the declaration", () => {
+		const workflow = {...twoPhaseWorkflow(), trigger: {on: "lane-parked"}};
+
+		expect(defectsOf(workflow)).toContain("`trigger` must be a string");
 	});
 
 	it("refuses a document that is not machine-shaped at all", () => {

--- a/packages/fabrika-cli/src/lane/open-verb.unit.test.ts
+++ b/packages/fabrika-cli/src/lane/open-verb.unit.test.ts
@@ -4,9 +4,10 @@ import {describe, expect, it} from "vitest";
 import {fakeFs} from "../fakes.test-support.ts";
 import type {VerbOutcome} from "../verb.ts";
 import {APPEND_UNKNOWN, LANE_EXISTS, LANE_UNREADABLE} from "./codes.ts";
-import {coderTemplateText} from "./fixtures.test-support.ts";
+import {choreTemplateText, coderTemplateText} from "./fixtures.test-support.ts";
 import {runOpen} from "./open-verb.ts";
 import {runStatus} from "./status-verb.ts";
+import {DEFAULT_CHORES_ROOT} from "./store.ts";
 
 const ROOT = ".fabrika/lanes";
 const DIR = `${ROOT}/42`;
@@ -38,6 +39,27 @@ describe("lane open", () => {
 		expect(out.code).toBe(0);
 		expect(JSON.parse(out.stdout)).toMatchObject({
 			stateValue: {pipeline: {issue: "queued"}},
+			status: "active",
+		});
+	});
+
+	it("boots a chore lane by name and folds it, with no issue number anywhere", async () => {
+		const chore = {
+			root: DEFAULT_CHORES_ROOT,
+			lane: "park-sweep",
+			templatePath: "/pkg/src/lane/templates/chore.workflow.json",
+		};
+		const fs = fakeFs({files: {[chore.templatePath]: choreTemplateText()}});
+		const opened = await run(fs, runOpen(chore));
+		const folded = await run(fs, runStatus({root: chore.root, lane: chore.lane}));
+
+		expect(opened.code).toBe(0);
+		expect(fs.written.get(`${DEFAULT_CHORES_ROOT}/park-sweep/workflow.json`)).toBe(
+			choreTemplateText(),
+		);
+		expect(folded.code).toBe(0);
+		expect(JSON.parse(folded.stdout)).toMatchObject({
+			stateValue: {sweep: {park_sweep: "queued"}},
 			status: "active",
 		});
 	});

--- a/packages/fabrika-cli/src/lane/refusals.ts
+++ b/packages/fabrika-cli/src/lane/refusals.ts
@@ -1,17 +1,29 @@
 /**
- * The two refusal folds every `lane` verb shares, so a load or replay fault seats on the same code
- * with the same stderr shape whichever verb hit it.
+ * The refusal folds every `lane` verb shares, so a key, load, boot or replay fault seats on the same
+ * code with the same stderr shape whichever verb hit it.
  */
 import {refuse, type VerbOutcome} from "../verb.ts";
 import {
 	APPEND_UNKNOWN,
+	KEY_MALFORMED,
 	LANE_ABSENT,
 	LANE_EXISTS,
 	LANE_UNREADABLE,
 	MALFORMED_RECORD,
 } from "./codes.ts";
 import type {FoldResult} from "./fold.ts";
+import type {KeyResult} from "./key.ts";
 import type {LoadedLane, Placement} from "./store.ts";
+
+/**
+ * Seat an unreadable `lane` argument. Group-level rather than per-verb: the key is parsed by the
+ * adapter every verb shares, before any of them is reached.
+ */
+export const keyRefusal = (malformed: Extract<KeyResult, {_tag: "Malformed"}>): VerbOutcome =>
+	refuse(
+		KEY_MALFORMED,
+		`fabrika lane: "${malformed.raw}" is not a lane key — ${malformed.reason}. A key is an issue number, or \`chore:<name>\` for a chore lane.`,
+	);
 
 /** Seat a non-`Loaded` load outcome. Absent names the remedy: open the lane from a template. */
 export const loadRefusal = (

--- a/packages/fabrika-cli/src/lane/store.ts
+++ b/packages/fabrika-cli/src/lane/store.ts
@@ -1,10 +1,11 @@
 /**
  * The lane store — where a lane lives on disk, and the one guarded read every verb goes through.
  *
- * A lane is a directory: `.fabrika/lanes/<n>/workflow.json` (the machine document, placed there by
- * the operator from a committed template) plus `events.jsonl` (the append-only log, born on the
- * first recorded event). Lane state is local and gitignored — the repo `.gitignore`'s `/.fabrika/`
- * entry covers it (#5673).
+ * A lane is a directory: `<root>/<key>/workflow.json` (the machine document, placed there by the
+ * operator from a committed template) plus `events.jsonl` (the append-only log, born on the first
+ * recorded event) — `.fabrika/lanes/<n>/` for an issue lane, `.fabrika/chores/<name>/` for a chore
+ * lane. Lane state is local and gitignored — the repo `.gitignore`'s `/.fabrika/` entry covers it
+ * (#5673). Which root a key resolves to is [`key.ts`](key.ts)'s call, not this module's.
  *
  * The load keeps four outcomes apart because they take opposite remedies: the lane is provably not
  * there, it could not be read (UNKNOWN, never "fresh"), it was read in full and is not the shape,
@@ -18,10 +19,13 @@ import {type CompiledLane, compileText} from "./machine.ts";
 
 export const DEFAULT_LANES_ROOT = ".fabrika/lanes";
 
+/** Where a chore lane lives: keyed by name, because a chore has no issue number (#5840). */
+export const DEFAULT_CHORES_ROOT = ".fabrika/chores";
+
 export interface LaneRef {
-	/** The lanes root — `.fabrika/lanes` unless a caller relocates it. */
+	/** The lanes root — `.fabrika/lanes`, or `.fabrika/chores` for a chore key. */
 	readonly root: string;
-	/** The lane id under the root — by convention the issue number the lane drives. */
+	/** The lane id under the root — an issue number, or a chore lane's name. */
 	readonly lane: string;
 }
 

--- a/packages/fabrika-cli/src/lane/store.unit.test.ts
+++ b/packages/fabrika-cli/src/lane/store.unit.test.ts
@@ -1,0 +1,65 @@
+/** The store under a name key — a chore lane placed, read back, and refused when one is there. */
+import {Effect} from "effect";
+import {describe, expect, it} from "vitest";
+import {fakeFs} from "../fakes.test-support.ts";
+import {choreTemplateText} from "./fixtures.test-support.ts";
+import {laneRef, parseKey} from "./key.ts";
+import {DEFAULT_CHORES_ROOT, loadLane, placeMachine} from "./store.ts";
+
+const CHORE = "park-sweep";
+const DIR = `${DEFAULT_CHORES_ROOT}/${CHORE}`;
+const WORKFLOW = `${DIR}/workflow.json`;
+const LOG = `${DIR}/events.jsonl`;
+
+const ref = () => {
+	const parsed = parseKey(`chore:${CHORE}`);
+	if (parsed._tag !== "Key") throw new Error(parsed.reason);
+	return laneRef(parsed.key, null);
+};
+
+describe("the lane store under a name key", () => {
+	it("places a chore lane's machine under the chores root", async () => {
+		const fs = fakeFs({files: {}});
+		const placed = await Effect.runPromise(
+			Effect.provide(placeMachine(ref(), choreTemplateText()), fs.layer),
+		);
+
+		expect(placed).toMatchObject({_tag: "Placed", dir: DIR, workflow: WORKFLOW});
+		expect(fs.written.get(WORKFLOW)).toBe(choreTemplateText());
+	});
+
+	it("loads a placed chore lane back as a fresh, event-less lane", async () => {
+		const fs = fakeFs({files: {[WORKFLOW]: choreTemplateText()}});
+		const loaded = await Effect.runPromise(Effect.provide(loadLane(ref()), fs.layer));
+
+		expect(loaded._tag).toBe("Loaded");
+		if (loaded._tag !== "Loaded") return;
+		expect(loaded.logPath).toBe(LOG);
+		expect(loaded.entries).toEqual([]);
+		expect(Object.keys(loaded.lane.tasks)).toEqual(["park_sweep"]);
+	});
+
+	it("refuses a collision with an existing chore lane and writes nothing", async () => {
+		const fs = fakeFs({files: {}, directories: [DIR]});
+		const placed = await Effect.runPromise(
+			Effect.provide(placeMachine(ref(), choreTemplateText()), fs.layer),
+		);
+
+		expect(placed).toEqual({_tag: "Exists", dir: DIR});
+		expect(fs.written.size).toBe(0);
+	});
+
+	it("proves a chore lane absent by its own directory, never by the issue lanes root", async () => {
+		const fs = fakeFs({files: {}});
+		const loaded = await Effect.runPromise(Effect.provide(loadLane(ref()), fs.layer));
+
+		expect(loaded).toEqual({_tag: "Absent", dir: DIR});
+	});
+
+	it("keeps an unreadable chore lane UNKNOWN rather than absent", async () => {
+		const fs = fakeFs({files: {[WORKFLOW]: choreTemplateText()}, unreadable: [WORKFLOW]});
+		const loaded = await Effect.runPromise(Effect.provide(loadLane(ref()), fs.layer));
+
+		expect(loaded._tag).toBe("Unreadable");
+	});
+});

--- a/packages/fabrika-cli/src/lane/templates/chore.workflow.json
+++ b/packages/fabrika-cli/src/lane/templates/chore.workflow.json
@@ -1,0 +1,68 @@
+{
+	"id": "park-sweep",
+	"version": 1,
+	"trigger": "lane-parked",
+	"machine": {
+		"id": "park-sweep",
+		"initial": "sweep",
+		"context": {
+			"park_sweep": { "retries": 0, "maxRetries": 2 }
+		},
+		"states": {
+			"sweep": {
+				"type": "parallel",
+				"states": {
+					"park_sweep": {
+						"initial": "queued",
+						"states": {
+							"queued": {
+								"on": {
+									"PARK_SWEEP.WIP": "classify",
+									"PARK_SWEEP.BLOCKED": "human:novel-park"
+								}
+							},
+							"classify": {
+								"on": {
+									"PARK_SWEEP.PASS": "apply",
+									"PARK_SWEEP.DONE": "swept",
+									"PARK_SWEEP.BLOCKED": "human:novel-park"
+								}
+							},
+							"apply": {
+								"on": {
+									"PARK_SWEEP.DONE": "verify",
+									"PARK_SWEEP.BLOCKED": "human:novel-park"
+								}
+							},
+							"verify": {
+								"on": {
+									"PARK_SWEEP.PASS": "swept",
+									"PARK_SWEEP.BLOCKED": "human:novel-park",
+									"PARK_SWEEP.FAIL": [
+										{
+											"target": "apply",
+											"guard": "retriesRemaining",
+											"actions": "incrementRetries"
+										},
+										{ "target": "frozen" }
+									]
+								}
+							},
+							"human:novel-park": {
+								"on": {
+									"PARK_SWEEP.UNBLOCKED": "hist"
+								}
+							},
+							"hist": { "type": "history" },
+							"swept": { "type": "final" },
+							"frozen": { "type": "final" }
+						}
+					}
+				},
+				"onDone": [{ "target": "complete", "guard": "noErrors" }, { "target": "tripped" }]
+			},
+			"complete": { "type": "final" },
+			"tripped": { "type": "final" }
+		}
+	}
+}


### PR DESCRIPTION
A chore that has no issue number can now be driven in the same lane ledger as an issue lane.

**How a chore is addressed.** The kind travels in the `lane` argument itself — `5673` is an issue
lane, `chore:park-sweep` is a chore lane — rather than in a flag beside it, so a key naming one kind
while the root names the other cannot be expressed. `packages/fabrika-cli/src/lane/key.ts` parses the
argument, picks the root (`.fabrika/lanes/<n>/` or `.fabrika/chores/<name>/`), and picks the boot
template. A chore name must be lowercase kebab within 64 characters; anything else — a separator, a
traversal, an empty name — is refused on the new exit `21` before any path is joined and before any
read, so a name nobody meant never becomes a directory. `--root` still overrides either default.

The fold is untouched: same fresh-process fold, same six events, no resident process. `lane
status`/`transition`/`history`/`print`/`brief`/`open` all take either key; `lane emit` stays
epic-shaped.

**The chore workflow definition.** `lane/templates/chore.workflow.json` is a park-sweep chore in the
same document family as the coder template: a `trigger` of `lane-parked`, and the recipe states
`queued → classify → apply → verify → swept`, with a novel park at `human:novel-park` and the same
guarded-FAIL retry shape. The compiler now reads a document's `trigger` and carries it on the
compiled lane and in `lane print`, so a mistyped declaration is a defect rather than a silence; what
a trigger name *means* stays the caller's, exactly as a guard name does.

**Verified live, not only in tests:** booting `chore:park-sweep`, recording `WIP`, folding it back to
`classify`, exit `21` on `chore:../escape`, exit `7` on an unopened chore, and the default root
landing at `.fabrika/chores/`.

Unit tests ride the change: the key's parse/refusal/root/template table, the name-keyed store's
place-load-collision-absent-unreadable paths, the chore template compiling with its trigger and
nothing outside the six events, and a boot-then-fold round trip through `runOpen` + `runStatus`.

Fixes #5846

## Deviations

- **Known defect left unfixed** — **Said:** acceptance criterion 5 bars any change outside
  `packages/fabrika-cli/src/lane/` and `.glossary/LANGUAGE.md`. **Did:** left
  `packages/fabrika-cli/README.md`'s lane section describing only issue-keyed lanes, so it does not
  mention chore keys or exit `21`. **Why:** the README is outside the permitted file set, and
  widening it would breach the criterion the sibling phase-1 child's boundary rests on.
  **Disposition:** filed as follow-up #5863.

