### PR TITLE
feat: recipe verbs: known-park clear + governance-verdict-then-rerun

### DIFF
--- a/packages/fabrika-cli/src/exit-code-alignment.ts
+++ b/packages/fabrika-cli/src/exit-code-alignment.ts
@@ -282,6 +282,22 @@ export const LANE_SEATS: SharedSeats = {
 	LANE_UNREADABLE: "PRECONDITION_UNKNOWN",
 };
 
+/**
+ * `recipe`'s seats: five, `lane`'s four widened by the read-back seat.
+ *
+ * A recipe verb applies a fixed fix and then proves it, so alone among the lane-shaped groups it can
+ * establish the base's *the write landed and the read-back contradicts it* — a lane that did not
+ * leave its park, a workflow run that shows no new attempt. Its private band is `12`-`21`, and the
+ * two seats the group exists for are in it: the park's cause is known, or it is novel.
+ */
+export const RECIPE_SEATS: SharedSeats = {
+	MALFORMED_RECORD: "BAD_SECTIONS",
+	TARGET_ABSENT: "NO_TARGET",
+	WRITE_UNKNOWN: "WRITE_UNKNOWN",
+	READBACK_MISMATCH: "READBACK_MISMATCH",
+	PRECONDITION_UNKNOWN: "PRECONDITION_UNKNOWN",
+};
+
 /** The groups that align to {@link ALIGNMENT_BASE}, each with the seats it claims to share. */
 export const ALIGNED_GROUPS: Readonly<Record<string, SharedSeats>> = {
 	adr: ADR_SEATS,
@@ -299,6 +315,7 @@ export const ALIGNED_GROUPS: Readonly<Record<string, SharedSeats>> = {
 	map: MAP_SEATS,
 	pattern: PATTERN_SEATS,
 	plan: BUILD_SEATS,
+	recipe: RECIPE_SEATS,
 	triage: SHARED_SEATS,
 	review: SHARED_SEATS,
 	"review-ui": REVIEW_UI_SEATS,

--- a/packages/fabrika-cli/src/exit-code-alignment.unit.test.ts
+++ b/packages/fabrika-cli/src/exit-code-alignment.unit.test.ts
@@ -32,6 +32,7 @@ import * as ledger from "./ledger/codes.ts";
 import * as map from "./map/codes.ts";
 import * as pattern from "./pattern/codes.ts";
 import * as plan from "./plan/codes.ts";
+import * as recipe from "./recipe/codes.ts";
 import {registeredGroups} from "./registry.ts";
 import * as report from "./report/codes.ts";
 import * as review from "./review/codes.ts";
@@ -67,6 +68,7 @@ const TABLES: Readonly<Record<string, CodeTable>> = {
 	map,
 	pattern,
 	plan,
+	recipe,
 	report,
 	review,
 	"review-ui": reviewUi,

--- a/packages/fabrika-cli/src/recipe/codes.ts
+++ b/packages/fabrika-cli/src/recipe/codes.ts
@@ -1,0 +1,105 @@
+/**
+ * The one exit table every `recipe` verb allocates from, so a code means one thing across the group.
+ *
+ * The five shared seats are **imported from the base, never re-typed** — the discipline
+ * `../exit-code-alignment.ts` checks. A recipe verb reads a lane or a pull request, applies a fixed
+ * fix, and reads the fix back, so the base's facts it can establish are exactly these: the target is
+ * not there, the target was read but is not the shape, the write did not land, the write landed and
+ * the read-back contradicts it, the read that would have proven any of that failed. `12`+ is this
+ * group's own band.
+ *
+ * **The known/novel split is an exit code, never prose** (#5847). A recipe either matched and its
+ * fixed fix applied, or it did not match and nothing was touched — and those two are different
+ * numbers, because the caller routes autonomously on the first and to a human on the second.
+ */
+
+import {
+	BAD_SECTIONS as REPORT_BAD_SECTIONS,
+	NO_TARGET as REPORT_NO_TARGET,
+	PRECONDITION_UNKNOWN as REPORT_PRECONDITION_UNKNOWN,
+	READBACK_MISMATCH as REPORT_READBACK_MISMATCH,
+	WRITE_UNKNOWN as REPORT_WRITE_UNKNOWN,
+} from "../report/codes.ts";
+
+/**
+ * The target is proven absent: no lane under the lanes root, or a pull request that does not exist
+ * or is closed. The base's target seat — the thing the verb was pointed at is not there to act on.
+ */
+export const TARGET_ABSENT = REPORT_NO_TARGET;
+
+/**
+ * A record was read in full and is not the shape: a `workflow.json` the lane compiler refuses, an
+ * `events.jsonl` line that does not parse, or a log the machine cannot replay. The base's section
+ * seat widened to a whole on-disk record, on the `lane` precedent.
+ */
+export const MALFORMED_RECORD = REPORT_BAD_SECTIONS;
+
+/** The fix's own write did not land. The verb never reports the recipe as applied. */
+export const WRITE_UNKNOWN = REPORT_WRITE_UNKNOWN;
+
+/**
+ * The write landed and the read-back contradicts it — the lane did not leave the park, or the
+ * rerun's own run record shows no new attempt. The artifact moved and needs a human.
+ */
+export const READBACK_MISMATCH = REPORT_READBACK_MISMATCH;
+
+/**
+ * A precondition read failed, so nothing was written and no outcome is proven. UNKNOWN, never a
+ * permissive reading: the read is what makes every proven code above *proven*.
+ */
+export const PRECONDITION_UNKNOWN = REPORT_PRECONDITION_UNKNOWN;
+
+/**
+ * The park's cause is outside the known-recipe set. **Nothing was mutated** — the verb refuses
+ * before it would touch the log, which is what makes the novel exit a proven no-op rather than a
+ * claim about one. This is the seat the founder's grill answer sits on (epic #5840): known clears
+ * autonomously, novel routes to a human, and the split lives here rather than in operator prose.
+ */
+export const PARK_NOVEL = 12;
+
+/**
+ * The park matched a known recipe and the recipe's clearing condition is not met yet — the §CP
+ * approval this park waits on is still outstanding. Its own seat rather than {@link PARK_NOVEL}
+ * because the remedy differs: wait for the named signal and re-run, do not route a human at the
+ * recipe.
+ */
+export const PARK_HOLDS = 13;
+
+/** The task's leaf state is not a park — there is nothing to clear, and nothing was written. */
+export const NOT_PARKED = 14;
+
+/**
+ * The task the recipe was addressed to is not in this lane's machine, `--task` was omitted on a lane
+ * with more than one task, or neither the task nor the lane names the issue the park hangs on.
+ */
+export const TASK_UNRESOLVED = 15;
+
+/** The pull request carries no `governance` verdict at all. The remedy is forming one. */
+export const VERDICT_ABSENT = 16;
+
+/**
+ * A `governance` verdict is there and is bound to another head. Never folded into
+ * {@link VERDICT_ABSENT}: "the PASS is old" and "nobody judged this" take opposite remedies, and
+ * folding them is how a stale PASS comes to authorise a rerun at a head it never saw.
+ */
+export const VERDICT_STALE = 17;
+
+/** The `governance` verdict at the current head is FAIL. Nothing is rerun. */
+export const VERDICT_FAIL = 18;
+
+/** No workflow run at the pull request's head concluded in failure — there is nothing to rerun. */
+export const NOTHING_TO_RERUN = 19;
+
+/**
+ * The lane machine refused the `UNBLOCKED` the recipe would have recorded, and the log is left
+ * unappended. Distinct from {@link WRITE_UNKNOWN}: the append never happened by decision, not by
+ * fault, so the remedy is the lane's state and not the filesystem.
+ */
+export const UNPARK_REFUSED = 20;
+
+/**
+ * The rerun was requested and its outcome could not be re-read, so whether it was accepted is
+ * UNKNOWN. Distinct from {@link READBACK_MISMATCH}, which is a read-back that succeeded and
+ * disagreed: here nothing is proven in either direction and the remedy is reading the run.
+ */
+export const RERUN_UNKNOWN = 21;

--- a/packages/fabrika-cli/src/recipe/command.ts
+++ b/packages/fabrika-cli/src/recipe/command.ts
@@ -1,0 +1,90 @@
+/**
+ * The `recipe` verb group — `fabrika recipe <verb>`.
+ *
+ * The adapter and nothing else: it declares the argument and the flags (`--help` is the interface,
+ * so each carries a one-line description and the verb's own block carries its whole exit table),
+ * runs the pure verb, and emits its outcome. Every decision lives in the verb modules beside it,
+ * which is what makes each refusal testable without spawning a process.
+ */
+import {Effect, Option} from "effect";
+import {Argument, Command, Flag} from "effect/unstable/cli";
+import {leafCommand} from "../excess-operand.ts";
+import {DEFAULT_LANES_ROOT} from "../lane/store.ts";
+import type {VerbOutcome} from "../verb.ts";
+import {runRerun} from "./rerun-verb.ts";
+import {runUnpark} from "./unpark-verb.ts";
+
+/** Write the outcome and exit on its code — stdout is the answer, everything else is stderr. */
+const emit = (outcome: VerbOutcome): Effect.Effect<void> =>
+	Effect.sync(() => {
+		for (const line of outcome.stderr) process.stderr.write(`${line}\n`);
+		if (outcome.stdout !== "") process.stdout.write(outcome.stdout);
+		process.exit(outcome.code);
+	});
+
+const repoFlag = Flag.string("repo").pipe(
+	Flag.optional,
+	Flag.withDescription(
+		"the target owner/name (default: $CLAUDE_PIPELINE_REPO, else $GITHUB_REPOSITORY, else the origin remote)",
+	),
+);
+
+const unpark = leafCommand(
+	"unpark",
+	{
+		lane: Argument.string("lane").pipe(
+			Argument.withDescription("the lane id under the root — by convention the issue number"),
+		),
+		root: Flag.string("root").pipe(
+			Flag.withDefault(DEFAULT_LANES_ROOT),
+			Flag.withDescription(`the lanes root directory (default: ${DEFAULT_LANES_ROOT})`),
+		),
+		task: Flag.string("task").pipe(
+			Flag.optional,
+			Flag.withDescription("the parked task; omittable on a single-task active phase"),
+		),
+		repo: repoFlag,
+	},
+	Effect.fn(function* ({lane, root, task, repo}) {
+		yield* emit(
+			yield* runUnpark({
+				root,
+				lane,
+				task: Option.getOrNull(task),
+				repo: Option.getOrNull(repo),
+				env: process.env,
+			}),
+		);
+	}),
+).pipe(
+	Command.withShortDescription("Clear a parked lane when the park is a known recipe."),
+	Command.withDescription(
+		"Clear one parked lane when its park matches the known-recipe table, and refuse with the ledger untouched when it does not. The park is read off `lane status`'s fold, the recipe's clearing condition is read off the verb that owns it (`ship cp-approval`'s ADR 0175 discharge at the PR's live head), the clear is recorded through `lane transition … UNBLOCKED`, and the answer is emitted only after a second fold reads the task out of the park. stdout is `{lane, task, park, clearance, mechanism, current}`. Respawning what the lane parked out of is the operator's, not this verb's. Exits 4 (a lane record was read in full and is not the shape), 7 (no lane there, or the PR the park waits on is proven absent or closed), 8 (the UNBLOCKED append did not land — it is NOT recorded), 9 (the append landed and the re-fold does not prove the clear — the lane needs a human), 11 (a precondition could not be read — UNKNOWN, never cleared), 12 (the park's cause is outside the recipe table — nothing was written; route it to a human), 13 (a known recipe whose clearing condition is not met yet — nothing was written), 14 (the task is not parked), 15 (the task is not in the active phase, --task was omitted where it is required, or no issue number can be resolved), 20 (the machine refused the UNBLOCKED, log unappended). Example: fabrika recipe unpark 5847",
+	),
+);
+
+const rerun = leafCommand(
+	"rerun",
+	{
+		pr: Argument.integer("pr").pipe(
+			Argument.withDescription("the pull request whose failed workflow runs are rerequested"),
+		),
+		repo: repoFlag,
+	},
+	Effect.fn(function* ({pr, repo}) {
+		yield* emit(yield* runRerun({pr, repo: Option.getOrNull(repo), env: process.env}));
+	}),
+).pipe(
+	Command.withShortDescription("Rerun a PR's failed runs behind a governance PASS at head."),
+	Command.withDescription(
+		"Rerun every workflow run that concluded in failure at a pull request's live head, and only behind a `governance` verdict that is PASS and bound to that head. The verdict is read first and the rerun is the only write, so every refusal is a proven no-op; each rerun is proven by re-reading its own run record — a new attempt, or a run no longer completed — never by the POST's own status. stdout is `{pr, head, verdict, rerun}`. Exits 7 (the PR is proven absent or closed), 8 (the rerun request did not land — it is NOT rerequested), 9 (the request landed and the run's re-read shows no new attempt — NOT proven), 11 (a precondition could not be read — UNKNOWN, never \"PASS\"), 16 (no governance verdict at all — form one), 17 (the latest governance verdict is bound to another head — re-form it here), 18 (the governance verdict at head is FAIL — repair the PR), 19 (no run at this head concluded in failure), 21 (the rerun was requested and could not be re-read — UNKNOWN). Example: fabrika recipe rerun 5851",
+	),
+);
+
+export const recipeCommand = Command.make("recipe").pipe(
+	Command.withSubcommands([unpark, rerun]),
+	Command.withShortDescription("Apply one standing driver recipe as a deterministic verb."),
+	Command.withDescription(
+		"Apply one standing driver recipe: a fixed sequence with a checkable outcome and no judgment in it, versioned once instead of retyped nightly. Each verb relays a decision another verb already owns and proves every mutation with a read-back (ADR 0228; epic #5840)",
+	),
+);

--- a/packages/fabrika-cli/src/recipe/fixtures.test-support.ts
+++ b/packages/fabrika-cli/src/recipe/fixtures.test-support.ts
@@ -1,0 +1,85 @@
+/**
+ * The canned payloads the `recipe` verb tests script their spawner and their filesystem with.
+ *
+ * The PR shape itself is `ship/fixtures.test-support.ts`'s — the §CP clearance is that group's verb
+ * relayed, so a second PR fixture here would let the two disagree about what the platform returns.
+ */
+import {okOut} from "../fakes.test-support.ts";
+import type {ExecResult} from "../io/exec.ts";
+import {coderTemplateText} from "../lane/fixtures.test-support.ts";
+
+export const LANES_ROOT = ".fabrika/lanes";
+
+/** The lane the fixtures drive: the `ship` fixtures' issue, whose PR is their #4321. */
+export const LANE = "4287";
+export const WORKFLOW = `${LANES_ROOT}/${LANE}/workflow.json`;
+export const LOG = `${LANES_ROOT}/${LANE}/events.jsonl`;
+
+export const laneTemplate = coderTemplateText;
+
+/** An `events.jsonl` that folds the coder lane into each named state. */
+export const eventLog = (...events: ReadonlyArray<string>): string =>
+	events
+		.map(
+			(event, index) =>
+				`${JSON.stringify({
+					task: "issue",
+					event: `ISSUE.${event}`,
+					at: `2026-08-16T00:0${index}:00.000Z`,
+				})}\n`,
+		)
+		.join("");
+
+/** queued → build → review → ship → human:cp-approval, the park the §CP recipe clears. */
+export const PARKED_AT_CP = eventLog("WIP", "DONE", "PASS", "BLOCKED");
+
+/** queued → blocked, the bare park no fixed fix keys on. */
+export const PARKED_BLOCKED = eventLog("BLOCKED");
+
+/** The closing-PR edge `openPullsClosing` reads — one open PR declaring it closes the issue. */
+export const closingPulls = (...numbers: ReadonlyArray<number>): ExecResult =>
+	okOut(
+		JSON.stringify({
+			data: {
+				repository: {
+					issue: {
+						closedByPullRequestsReferences: {
+							pageInfo: {hasNextPage: false, endCursor: null},
+							nodes: numbers.map((number) => ({
+								number,
+								url: `https://example.test/pull/${number}`,
+								state: "OPEN",
+							})),
+						},
+					},
+				},
+			},
+		}),
+	);
+
+export interface RunShape {
+	readonly id: number;
+	readonly name?: string;
+	readonly status?: string;
+	readonly conclusion?: string | null;
+	readonly attempt?: number;
+}
+
+const runBody = (shape: RunShape): Record<string, unknown> => ({
+	id: shape.id,
+	name: shape.name ?? "ci",
+	status: shape.status ?? "completed",
+	conclusion: shape.conclusion === undefined ? "failure" : shape.conclusion,
+	run_attempt: shape.attempt ?? 1,
+});
+
+/** The Actions list endpoint's page — rows under `workflow_runs`, never a bare array. */
+export const runsAtHead = (...shapes: ReadonlyArray<RunShape>): ExecResult =>
+	okOut(JSON.stringify({total_count: shapes.length, workflow_runs: shapes.map(runBody)}));
+
+/** One run, re-read. */
+export const oneRun = (shape: RunShape): ExecResult => okOut(JSON.stringify(runBody(shape)));
+
+/** A `governance` verdict comment body at `sha`. */
+export const governanceMarker = (polarity: "PASS" | "FAIL", sha: string): string =>
+	`governance: ${polarity} @ ${sha} — corpus intact`;

--- a/packages/fabrika-cli/src/recipe/github.ts
+++ b/packages/fabrika-cli/src/recipe/github.ts
@@ -1,0 +1,107 @@
+/**
+ * The Actions reads and the one write the `recipe rerun` verb needs.
+ *
+ * The house disciplines hold: `gh api` REST and never GraphQL, every list read pages, a shape that
+ * is not what was asked for is a failure rather than an empty result, and `ok` is read before
+ * `stdout`.
+ *
+ * **A rerun is proven by re-reading the run, never by the POST's own status.** GitHub answers the
+ * rerun endpoint before the run has moved, so the acceptance evidence is the run record itself:
+ * either its attempt counter advanced past the one observed before the POST, or it is no longer
+ * `completed`. Both are the same claim from two directions, and accepting either keeps a re-read
+ * that caught the run mid-transition from reading as a refusal.
+ */
+import {Effect} from "effect";
+import {execCapture} from "../io/exec.ts";
+import {type Attempt, fail, ok, type Shell} from "../io/git.ts";
+import {scanJsonPages} from "../io/issues.ts";
+import {isRecord, parseJson} from "../io/json.ts";
+
+/** One workflow run at a head, reduced to the fields the recipe reads. */
+export interface WorkflowRun {
+	readonly id: number;
+	readonly name: string;
+	/** `queued` / `in_progress` / `completed` — a run off `completed` is moving. */
+	readonly status: string;
+	/** `success` / `failure` / …, `null` while the run has not concluded. */
+	readonly conclusion: string | null;
+	/** The attempt counter GitHub advances when a rerun is accepted. */
+	readonly runAttempt: number;
+}
+
+const toRun = (value: unknown): WorkflowRun | null => {
+	if (!isRecord(value)) return null;
+	const {id, name, status, conclusion} = value;
+	if (typeof id !== "number" || typeof status !== "string") return null;
+	const attempt = value.run_attempt;
+	return {
+		id,
+		name: typeof name === "string" ? name : "",
+		status,
+		conclusion: typeof conclusion === "string" ? conclusion : null,
+		runAttempt: typeof attempt === "number" ? attempt : 1,
+	};
+};
+
+const SHAPE = "`gh api` exited 0 but its output is not a workflow run";
+
+/**
+ * Every workflow run recorded against `sha`, paged in full.
+ *
+ * Unaccounted bytes are a failure, not a shorter list: a stream that stopped mid-page would answer
+ * "no failed run at this head" from a page nobody read, and the caller seats that as "nothing to
+ * rerun" — a proven no-op it never proved.
+ */
+export const listRunsAtHead = (
+	repo: string,
+	sha: string,
+): Shell<Attempt<ReadonlyArray<WorkflowRun>>> =>
+	Effect.gen(function* () {
+		const r = yield* execCapture("gh", [
+			"api",
+			"--paginate",
+			`repos/${repo}/actions/runs?head_sha=${encodeURIComponent(sha)}&per_page=100`,
+		]);
+		if (!r.ok) return fail(r.reason);
+		const scanned = scanJsonPages(r.stdout);
+		if (scanned.truncated !== null) return fail(scanned.truncated);
+		const runs: WorkflowRun[] = [];
+		for (const page of scanned.pages) {
+			const parsed = parseJson(page);
+			// The Actions list endpoint wraps its rows; a bare array is a shape nobody asked for.
+			if (!isRecord(parsed) || !Array.isArray(parsed.workflow_runs)) {
+				return fail("`gh api` exited 0 but its output is not a workflow-run page");
+			}
+			for (const value of parsed.workflow_runs) {
+				const run = toRun(value);
+				if (run === null) return fail(SHAPE);
+				runs.push(run);
+			}
+		}
+		return ok(runs);
+	});
+
+/** One workflow run, re-read — the evidence a rerun was accepted. */
+export const getRun = (repo: string, id: number): Shell<Attempt<WorkflowRun>> =>
+	Effect.gen(function* () {
+		const r = yield* execCapture("gh", ["api", `repos/${repo}/actions/runs/${id}`]);
+		if (!r.ok) return fail(r.reason);
+		const run = toRun(parseJson(r.stdout));
+		return run === null ? fail(SHAPE) : ok(run);
+	});
+
+/** Ask GitHub to rerun a whole workflow run — the endpoint `gh run rerun` posts to. */
+export const rerunRun = (repo: string, id: number): Shell<Attempt<void>> =>
+	Effect.gen(function* () {
+		const r = yield* execCapture("gh", [
+			"api",
+			"--method",
+			"POST",
+			`repos/${repo}/actions/runs/${id}/rerun`,
+		]);
+		return r.ok ? ok<void>(undefined) : fail(r.reason);
+	});
+
+/** Whether a re-read proves the rerun landed: a new attempt, or a run that is no longer completed. */
+export const rerunAccepted = (before: WorkflowRun, after: WorkflowRun): boolean =>
+	after.runAttempt > before.runAttempt || after.status !== "completed";

--- a/packages/fabrika-cli/src/recipe/parks.ts
+++ b/packages/fabrika-cli/src/recipe/parks.ts
@@ -1,0 +1,69 @@
+/**
+ * The known-park recipe table — which parks a recipe verb may clear on its own, as data.
+ *
+ * Every entry names a park's leaf state, the one read that proves the park's cause is gone, and the
+ * sentence a refusal quotes. Nothing here is derived at run time: ADR 0228's rule is that the verb
+ * answers a decision it already owns, so the set of parks that clear autonomously is a literal in
+ * this file and the founder's grill answer (epic #5840 — known clears, novel routes to a human) is
+ * the shape of {@link classifyPark}'s result rather than a sentence in an operator's prompt.
+ *
+ * The parks themselves come from the lane machine, not from here: `blocked` and every `human:*`
+ * state is a park (`lane/templates/coder.workflow.json`, and `operate` §4's routing table). A park
+ * with no row below is **novel** — which is a decision this table records, not one a verb makes.
+ */
+
+/** The clearance read a recipe relays. One constructor per read, so a new recipe cannot be prose. */
+export type Clearance = "cp-approval";
+
+export interface ParkRecipe {
+	/** The lane leaf state this recipe clears. */
+	readonly park: string;
+	/** The read whose answer decides whether the park's cause is gone. */
+	readonly clearance: Clearance;
+	/** What the park is waiting on, in one clause a refusal can quote. */
+	readonly waitingOn: string;
+}
+
+/**
+ * `human:cp-approval` is the one park with a fixed fix today.
+ *
+ * Its clearance is `ship cp-approval`'s own discharge table (ADR 0175), relayed rather than
+ * re-derived — the §CP cardinality question has exactly one answer in this package and a second
+ * reading of it here would be the drift #2435 closed.
+ */
+export const KNOWN_PARKS: ReadonlyArray<ParkRecipe> = [
+	{
+		park: "human:cp-approval",
+		clearance: "cp-approval",
+		waitingOn: "a control-plane approval at the PR's current head",
+	},
+];
+
+/** Whether a leaf state is a park at all — the lane machine's two park shapes. */
+export const isPark = (leaf: string): boolean => leaf === "blocked" || leaf.startsWith("human:");
+
+export type ParkClass =
+	| {readonly _tag: "NotParked"; readonly leaf: string}
+	| {readonly _tag: "Known"; readonly recipe: ParkRecipe}
+	| {readonly _tag: "Novel"; readonly leaf: string; readonly reason: string};
+
+/**
+ * Classify one folded leaf state against the table.
+ *
+ * A bare `blocked` is novel by construction and says so: the ledger records the event, never the
+ * cause, so there is nothing for a fixed fix to key on. That is the honest answer, and stating it
+ * here is what keeps a caller from reading "no recipe" as "no problem".
+ */
+export const classifyPark = (leaf: string): ParkClass => {
+	if (!isPark(leaf)) return {_tag: "NotParked", leaf};
+	const recipe = KNOWN_PARKS.find((row) => row.park === leaf);
+	if (recipe !== undefined) return {_tag: "Known", recipe};
+	return {
+		_tag: "Novel",
+		leaf,
+		reason:
+			leaf === "blocked"
+				? "a bare BLOCKED park records the event and not its cause, so no fixed fix keys on it"
+				: `no recipe covers the park "${leaf}"`,
+	};
+};

--- a/packages/fabrika-cli/src/recipe/parks.unit.test.ts
+++ b/packages/fabrika-cli/src/recipe/parks.unit.test.ts
@@ -1,0 +1,44 @@
+import {describe, expect, it} from "vitest";
+import {classifyPark, isPark, KNOWN_PARKS} from "./parks.ts";
+
+describe("the park table", () => {
+	it("recognises the lane machine's two park shapes and nothing else", () => {
+		expect(isPark("blocked")).toBe(true);
+		expect(isPark("human:cp-approval")).toBe(true);
+		expect(isPark("human:anything-later")).toBe(true);
+		expect(isPark("build")).toBe(false);
+		expect(isPark("shipped")).toBe(false);
+	});
+
+	it("names one park per row, so a recipe cannot cover two", () => {
+		const parks = KNOWN_PARKS.map((row) => row.park);
+		expect(new Set(parks).size).toBe(parks.length);
+	});
+});
+
+describe("classifyPark", () => {
+	it("is Known for the §CP park, and carries the clearance the verb relays", () => {
+		const parked = classifyPark("human:cp-approval");
+
+		expect(parked._tag).toBe("Known");
+		expect(parked._tag === "Known" && parked.recipe.clearance).toBe("cp-approval");
+	});
+
+	it("is Novel for a bare BLOCKED, and says the ledger records no cause", () => {
+		const parked = classifyPark("blocked");
+
+		expect(parked._tag).toBe("Novel");
+		expect(parked._tag === "Novel" && parked.reason).toMatch(/records the event and not its cause/);
+	});
+
+	it("is Novel for a human park the table does not carry", () => {
+		const parked = classifyPark("human:some-future-park");
+
+		expect(parked._tag).toBe("Novel");
+		expect(parked._tag === "Novel" && parked.reason).toMatch(/human:some-future-park/);
+	});
+
+	it("is NotParked for a working state — never a park to clear", () => {
+		expect(classifyPark("review")._tag).toBe("NotParked");
+	});
+});

--- a/packages/fabrika-cli/src/recipe/relay.ts
+++ b/packages/fabrika-cli/src/recipe/relay.ts
@@ -1,0 +1,67 @@
+/**
+ * How another group's verb outcome is re-seated on this group's table.
+ *
+ * A recipe verb relays: it reads a lane through `lane status`, records the clear through
+ * `lane transition`, and asks `ship cp-approval` whether a §CP park's cause is gone (ADR 0228 — the
+ * verb answers, the caller relays, neither derives a decision it does not own). Those verbs answer
+ * on **their** tables, and two of `lane`'s private codes sit on numbers this group spells
+ * differently, so passing an exit through unchanged would report a refused event as a novel park.
+ *
+ * The mapping therefore imports both tables and is a pure function, so a re-seat on either side is a
+ * type-level fact rather than a number two files agree about by luck.
+ */
+import {
+	LANE_ABSENT,
+	APPEND_UNKNOWN as LANE_APPEND_UNKNOWN,
+	EVENT_REFUSED as LANE_EVENT_REFUSED,
+	MALFORMED_RECORD as LANE_MALFORMED_RECORD,
+	TASK_UNKNOWN as LANE_TASK_UNKNOWN,
+	LANE_UNREADABLE,
+} from "../lane/codes.ts";
+import {refuse, type VerbOutcome} from "../verb.ts";
+import {
+	MALFORMED_RECORD,
+	PRECONDITION_UNKNOWN,
+	TARGET_ABSENT,
+	TASK_UNRESOLVED,
+	UNPARK_REFUSED,
+	WRITE_UNKNOWN,
+} from "./codes.ts";
+
+/**
+ * This group's seat for a `lane` verb's refusal. An unrecognised lane code is
+ * {@link PRECONDITION_UNKNOWN} rather than a guess: a code this module has no reading for has
+ * proven nothing here.
+ */
+export const laneExit = (code: number): number => {
+	switch (code) {
+		case LANE_MALFORMED_RECORD:
+			return MALFORMED_RECORD;
+		case LANE_ABSENT:
+			return TARGET_ABSENT;
+		case LANE_APPEND_UNKNOWN:
+			return WRITE_UNKNOWN;
+		case LANE_UNREADABLE:
+			return PRECONDITION_UNKNOWN;
+		case LANE_EVENT_REFUSED:
+			return UNPARK_REFUSED;
+		case LANE_TASK_UNKNOWN:
+			return TASK_UNRESOLVED;
+		default:
+			return PRECONDITION_UNKNOWN;
+	}
+};
+
+/**
+ * Re-seat a relayed refusal, keeping the relayed verb's own diagnostics verbatim beneath a line
+ * naming which verb refused and on what code — a relay that rewrote the reason would be deriving.
+ */
+export const relayRefusal = (
+	verb: string,
+	relayed: string,
+	outcome: VerbOutcome,
+	code: number,
+): VerbOutcome =>
+	refuse(code, `${verb}: ${relayed} refused at exit ${outcome.code} — relayed as ${code}.`, [
+		...outcome.stderr,
+	]);

--- a/packages/fabrika-cli/src/recipe/relay.unit.test.ts
+++ b/packages/fabrika-cli/src/recipe/relay.unit.test.ts
@@ -1,0 +1,32 @@
+import {describe, expect, it} from "vitest";
+import * as lane from "../lane/codes.ts";
+import * as recipe from "./codes.ts";
+import {laneExit} from "./relay.ts";
+
+describe("laneExit", () => {
+	it("keeps the shared seats on their own numbers", () => {
+		expect(laneExit(lane.MALFORMED_RECORD)).toBe(recipe.MALFORMED_RECORD);
+		expect(laneExit(lane.LANE_ABSENT)).toBe(recipe.TARGET_ABSENT);
+		expect(laneExit(lane.APPEND_UNKNOWN)).toBe(recipe.WRITE_UNKNOWN);
+		expect(laneExit(lane.LANE_UNREADABLE)).toBe(recipe.PRECONDITION_UNKNOWN);
+	});
+
+	it("re-seats the two lane private codes this group spells differently", () => {
+		expect(laneExit(lane.EVENT_REFUSED)).toBe(recipe.UNPARK_REFUSED);
+		expect(laneExit(lane.TASK_UNKNOWN)).toBe(recipe.TASK_UNRESOLVED);
+	});
+
+	it("never relays a lane private code onto this group's park seats", () => {
+		const relayed = [lane.EVENT_REFUSED, lane.TASK_UNKNOWN, lane.LANE_EXISTS, lane.NO_SHELL].map(
+			laneExit,
+		);
+
+		expect(relayed).not.toContain(recipe.PARK_NOVEL);
+		expect(relayed).not.toContain(recipe.PARK_HOLDS);
+	});
+
+	it("is UNKNOWN for a lane code it has no reading for, never a guess", () => {
+		expect(laneExit(lane.TOPOLOGY_CYCLE)).toBe(recipe.PRECONDITION_UNKNOWN);
+		expect(laneExit(99)).toBe(recipe.PRECONDITION_UNKNOWN);
+	});
+});

--- a/packages/fabrika-cli/src/recipe/rerun-verb.ts
+++ b/packages/fabrika-cli/src/recipe/rerun-verb.ts
@@ -1,0 +1,188 @@
+/**
+ * `recipe rerun` — rerun a driver PR's failed workflow runs, and only behind a `governance` PASS at
+ * the PR's live head.
+ *
+ * The gate is read first and the rerun is the only write, in that order: a verdict that is absent,
+ * bound to another head, or FAIL refuses before anything is posted, so a refusal here is a proven
+ * no-op. The three refusals stay three codes because their remedies are opposite — form a verdict,
+ * re-form it at this head, or repair the PR — and folding any two is how a stale PASS comes to
+ * authorise a rerun at a head nobody judged.
+ *
+ * Each rerun is proven by re-reading its own run record, never by the POST's status
+ * ([`github.ts`](./github.ts)). A run whose re-read shows no new attempt is a mismatch, not a
+ * success with a caveat.
+ */
+import {Effect} from "effect";
+import type {ChildProcessSpawner} from "effect/unstable/process";
+import {listComments} from "../io/issues.ts";
+import {answer, refuse, type VerbOutcome} from "../verb.ts";
+import {bindToHead, read as readMarker} from "../wire/verdict-marker.ts";
+import {
+	NOTHING_TO_RERUN,
+	PRECONDITION_UNKNOWN,
+	READBACK_MISMATCH,
+	RERUN_UNKNOWN,
+	VERDICT_ABSENT,
+	VERDICT_FAIL,
+	VERDICT_STALE,
+	WRITE_UNKNOWN,
+} from "./codes.ts";
+import {getRun, listRunsAtHead, rerunAccepted, rerunRun, type WorkflowRun} from "./github.ts";
+import {badNumber, openPull, resolveTargetRepo, scannedLine} from "./target.ts";
+
+const VERB = "fabrika recipe rerun";
+
+/** The namespace `governance post` emits, and the only one this recipe reads. */
+const NAMESPACE = "governance";
+
+export interface RerunOptions {
+	readonly pr: number;
+	readonly repo: string | null;
+	readonly env: Readonly<Record<string, string | undefined>>;
+}
+
+export const runRerun = (
+	options: RerunOptions,
+): Effect.Effect<VerbOutcome, never, ChildProcessSpawner.ChildProcessSpawner> =>
+	Effect.gen(function* () {
+		const {pr} = options;
+		const bad = badNumber(VERB, "a pull-request number", pr);
+		if (bad !== null) return bad;
+
+		const resolved = yield* resolveTargetRepo(VERB, options.repo, options.env);
+		if (resolved._tag === "Refused") return resolved.outcome;
+		const repo = resolved.repo;
+
+		const target = yield* openPull(
+			VERB,
+			repo,
+			pr,
+			(reason) =>
+				`${VERB}: cannot read PR #${pr}: ${reason} — the verdict state is UNKNOWN, never "PASS".`,
+		);
+		if (target._tag === "Refused") return target.outcome;
+		const head = target.pull.headSha;
+
+		const listed = yield* listComments(repo, pr);
+		if (listed._tag === "Failure") {
+			return refuse(
+				PRECONDITION_UNKNOWN,
+				`${VERB}: cannot read #${pr}'s comments: ${listed.reason} — the verdict state is UNKNOWN, never "PASS".`,
+			);
+		}
+		const diagnostics = [scannedLine(VERB, listed.value.length, "comment", `head ${head}`)];
+
+		// Latest wins by write stamp, not by creation: a FAIL upserted into an older comment after a
+		// PASS is the current verdict, and `created_at` would order it behind (#4200).
+		let latest: {readonly polarity: string; readonly sha: string; readonly at: string} | null =
+			null;
+		for (const comment of listed.value) {
+			const parsed = readMarker(comment.body);
+			if (parsed._tag !== "Found" || parsed.value.namespace !== NAMESPACE) continue;
+			const bound = bindToHead(parsed.value, head);
+			if (latest !== null && comment.updatedAt < latest.at) continue;
+			latest = {
+				polarity: bound._tag === "Current" ? parsed.value.polarity : "stale",
+				sha: parsed.value.sha,
+				at: comment.updatedAt,
+			};
+		}
+		if (latest === null) {
+			return refuse(
+				VERDICT_ABSENT,
+				`${VERB}: #${pr} carries no ${NAMESPACE} verdict — form one before anything is rerun.`,
+				diagnostics,
+			);
+		}
+		if (latest.polarity === "stale") {
+			return refuse(
+				VERDICT_STALE,
+				`${VERB}: #${pr}'s latest ${NAMESPACE} verdict is bound to ${latest.sha}, not the live head ${head} — re-form it at this head; nothing was rerun.`,
+				diagnostics,
+			);
+		}
+		if (latest.polarity !== "PASS") {
+			return refuse(
+				VERDICT_FAIL,
+				`${VERB}: #${pr}'s ${NAMESPACE} verdict at ${head} is ${latest.polarity} — repair the PR; nothing was rerun.`,
+				diagnostics,
+			);
+		}
+
+		const runs = yield* listRunsAtHead(repo, head);
+		if (runs._tag === "Failure") {
+			return refuse(
+				PRECONDITION_UNKNOWN,
+				`${VERB}: cannot read the workflow runs at ${head}: ${runs.reason} — whether anything failed is UNKNOWN, never "nothing".`,
+				diagnostics,
+			);
+		}
+		const failed = runs.value.filter((run) => run.conclusion === "failure");
+		diagnostics.push(
+			scannedLine(VERB, runs.value.length, "workflow run", `${failed.length} concluded failure`),
+		);
+		if (failed.length === 0) {
+			return refuse(
+				NOTHING_TO_RERUN,
+				`${VERB}: no workflow run at ${head} concluded in failure — there is nothing to rerun.`,
+				diagnostics,
+			);
+		}
+
+		const rerun: Array<{id: number; name: string; attempt: number}> = [];
+		for (const run of failed) {
+			const proven = yield* rerunOne(repo, run);
+			if (proven._tag === "Refused") {
+				return {
+					...proven.outcome,
+					stderr: [...diagnostics, ...proven.outcome.stderr],
+				};
+			}
+			rerun.push({id: run.id, name: run.name, attempt: proven.attempt});
+		}
+
+		return answer(JSON.stringify({pr, head, verdict: "PASS", rerun}), [
+			...diagnostics,
+			`${VERB}: rerequested ${rerun.length} run(s), each proven by its own re-read.`,
+		]);
+	});
+
+type RerunProof =
+	| {readonly _tag: "Accepted"; readonly attempt: number}
+	| {readonly _tag: "Refused"; readonly outcome: VerbOutcome};
+
+const rerunOne = (
+	repo: string,
+	run: WorkflowRun,
+): Effect.Effect<RerunProof, never, ChildProcessSpawner.ChildProcessSpawner> =>
+	Effect.gen(function* () {
+		const posted = yield* rerunRun(repo, run.id);
+		if (posted._tag === "Failure") {
+			return {
+				_tag: "Refused" as const,
+				outcome: refuse(
+					WRITE_UNKNOWN,
+					`${VERB}: the rerun of run ${run.id} (${run.name}) did not land: ${posted.reason} — it is NOT rerequested.`,
+				),
+			};
+		}
+		const after = yield* getRun(repo, run.id);
+		if (after._tag === "Failure") {
+			return {
+				_tag: "Refused" as const,
+				outcome: refuse(
+					RERUN_UNKNOWN,
+					`${VERB}: run ${run.id} (${run.name}) was rerequested and could not be re-read: ${after.reason} — whether it was accepted is UNKNOWN.`,
+				),
+			};
+		}
+		return rerunAccepted(run, after.value)
+			? {_tag: "Accepted" as const, attempt: after.value.runAttempt}
+			: {
+					_tag: "Refused" as const,
+					outcome: refuse(
+						READBACK_MISMATCH,
+						`${VERB}: run ${run.id} (${run.name}) still reads attempt ${after.value.runAttempt} and status "${after.value.status}" — the rerun is NOT proven.`,
+					),
+				};
+	});

--- a/packages/fabrika-cli/src/recipe/rerun-verb.unit.test.ts
+++ b/packages/fabrika-cli/src/recipe/rerun-verb.unit.test.ts
@@ -1,0 +1,201 @@
+import {Effect} from "effect";
+import {describe, expect, it} from "vitest";
+import {errOut, fakeShell, once} from "../fakes.test-support.ts";
+import type {ExecResult} from "../io/exec.ts";
+import {comments, ENV, HEAD, OTHER_HEAD, pull} from "../ship/fixtures.test-support.ts";
+import {
+	NOTHING_TO_RERUN,
+	PRECONDITION_UNKNOWN,
+	READBACK_MISMATCH,
+	RERUN_UNKNOWN,
+	TARGET_ABSENT,
+	VERDICT_ABSENT,
+	VERDICT_FAIL,
+	VERDICT_STALE,
+	WRITE_UNKNOWN,
+} from "./codes.ts";
+import {governanceMarker, oneRun, runsAtHead} from "./fixtures.test-support.ts";
+import {runRerun} from "./rerun-verb.ts";
+
+const PULL = /^gh api repos\/o\/r\/pulls\/4321$/;
+const COMMENTS = /^gh api --paginate repos\/o\/r\/issues\/4321\/comments/;
+const RUNS = /^gh api --paginate repos\/o\/r\/actions\/runs\?head_sha=/;
+const RERUN = /^gh api --method POST repos\/o\/r\/actions\/runs\/77\/rerun$/;
+const ONE_RUN = /^gh api repos\/o\/r\/actions\/runs\/77$/;
+
+const run = (script: ReadonlyArray<readonly [RegExp, ExecResult]>) =>
+	Effect.runPromise(
+		Effect.provide(runRerun({pr: 4321, repo: null, env: ENV}), fakeShell(script).layer),
+	);
+
+const PASSING = comments({id: 1, body: governanceMarker("PASS", HEAD)});
+
+describe("recipe rerun — the gate is read before anything moves", () => {
+	it("reruns the failed run and proves it by the run's own new attempt", async () => {
+		const shell = fakeShell([
+			[PULL, pull()],
+			[COMMENTS, PASSING],
+			[RUNS, runsAtHead({id: 77, name: "ci"}, {id: 78, conclusion: "success"})],
+			[RERUN, ok()],
+			[ONE_RUN, oneRun({id: 77, attempt: 2, status: "queued", conclusion: null})],
+		]);
+
+		const out = await Effect.runPromise(
+			Effect.provide(runRerun({pr: 4321, repo: null, env: ENV}), shell.layer),
+		);
+
+		expect(out.code).toBe(0);
+		expect(JSON.parse(out.stdout)).toMatchObject({
+			pr: 4321,
+			head: HEAD,
+			verdict: "PASS",
+			rerun: [{id: 77, name: "ci", attempt: 2}],
+		});
+		// The read-back is a real second call, not the POST's own status re-read as evidence.
+		expect(shell.calls.filter((line) => ONE_RUN.test(line))).toHaveLength(1);
+	});
+
+	it("is VERDICT_ABSENT with nothing posted when the PR carries no governance verdict", async () => {
+		const shell = fakeShell([
+			[PULL, pull()],
+			[COMMENTS, comments({id: 1, body: `review-code: PASS @ ${HEAD} — ok`})],
+		]);
+
+		const out = await Effect.runPromise(
+			Effect.provide(runRerun({pr: 4321, repo: null, env: ENV}), shell.layer),
+		);
+
+		expect(out.code).toBe(VERDICT_ABSENT);
+		expect(shell.calls.some((line) => line.includes("--method POST"))).toBe(false);
+	});
+
+	it("is VERDICT_STALE when the verdict is bound to another head — never folded into absent", async () => {
+		const out = await run([
+			[PULL, pull()],
+			[COMMENTS, comments({id: 1, body: governanceMarker("PASS", OTHER_HEAD)})],
+		]);
+
+		expect(out.code).toBe(VERDICT_STALE);
+		expect(out.code).not.toBe(VERDICT_ABSENT);
+	});
+
+	it("is VERDICT_FAIL on a FAIL at head, and reruns nothing", async () => {
+		const shell = fakeShell([
+			[PULL, pull()],
+			[COMMENTS, comments({id: 1, body: governanceMarker("FAIL", HEAD)})],
+		]);
+
+		const out = await Effect.runPromise(
+			Effect.provide(runRerun({pr: 4321, repo: null, env: ENV}), shell.layer),
+		);
+
+		expect(out.code).toBe(VERDICT_FAIL);
+		expect(shell.calls.some((line) => line.includes("--method POST"))).toBe(false);
+	});
+
+	it("takes the latest verdict by write stamp, so a FAIL upserted into an older comment wins", async () => {
+		const out = await run([
+			[PULL, pull()],
+			[
+				COMMENTS,
+				comments(
+					{id: 1, body: governanceMarker("FAIL", HEAD), updatedAt: "2026-08-16T02:00:00Z"},
+					{id: 2, body: governanceMarker("PASS", HEAD), updatedAt: "2026-08-16T01:00:00Z"},
+				),
+			],
+		]);
+
+		expect(out.code).toBe(VERDICT_FAIL);
+	});
+
+	it("is TARGET_ABSENT on a closed PR", async () => {
+		expect((await run([[PULL, pull({state: "closed"})]])).code).toBe(TARGET_ABSENT);
+	});
+
+	it('is UNKNOWN when the comments cannot be read — never "no verdict"', async () => {
+		const out = await run([
+			[PULL, pull()],
+			[COMMENTS, errOut("api down")],
+		]);
+
+		expect(out.code).toBe(PRECONDITION_UNKNOWN);
+		expect(out.code).not.toBe(VERDICT_ABSENT);
+	});
+});
+
+describe("recipe rerun — nothing to do, and writes that do not prove themselves", () => {
+	it("is NOTHING_TO_RERUN when no run at the head concluded in failure", async () => {
+		const out = await run([
+			[PULL, pull()],
+			[COMMENTS, PASSING],
+			[RUNS, runsAtHead({id: 78, conclusion: "success"})],
+		]);
+
+		expect(out.code).toBe(NOTHING_TO_RERUN);
+	});
+
+	it('is UNKNOWN when the run list cannot be read — never "nothing to rerun"', async () => {
+		const out = await run([
+			[PULL, pull()],
+			[COMMENTS, PASSING],
+			[RUNS, errOut("api down")],
+		]);
+
+		expect(out.code).toBe(PRECONDITION_UNKNOWN);
+		expect(out.code).not.toBe(NOTHING_TO_RERUN);
+	});
+
+	it("is WRITE_UNKNOWN when the rerun request itself does not land", async () => {
+		const out = await run([
+			[PULL, pull()],
+			[COMMENTS, PASSING],
+			[RUNS, runsAtHead({id: 77})],
+			[RERUN, errOut("422 Unprocessable")],
+		]);
+
+		expect(out.code).toBe(WRITE_UNKNOWN);
+	});
+
+	it("is RERUN_UNKNOWN when the request landed and the run cannot be re-read", async () => {
+		const out = await run([
+			[PULL, pull()],
+			[COMMENTS, PASSING],
+			[RUNS, runsAtHead({id: 77})],
+			[RERUN, ok()],
+			[ONE_RUN, errOut("api down")],
+		]);
+
+		expect(out.code).toBe(RERUN_UNKNOWN);
+		expect(out.stdout).toBe("");
+	});
+
+	it("is READBACK_MISMATCH when the re-read shows the same attempt on a completed run", async () => {
+		const out = await run([
+			[PULL, pull()],
+			[COMMENTS, PASSING],
+			[once(RUNS), runsAtHead({id: 77, attempt: 3})],
+			[RERUN, ok()],
+			[ONE_RUN, oneRun({id: 77, attempt: 3, status: "completed"})],
+		]);
+
+		expect(out.code).toBe(READBACK_MISMATCH);
+		expect(out.stdout).toBe("");
+	});
+
+	it("accepts a run still on its old attempt once it has left `completed`", async () => {
+		const out = await run([
+			[PULL, pull()],
+			[COMMENTS, PASSING],
+			[RUNS, runsAtHead({id: 77, attempt: 3})],
+			[RERUN, ok()],
+			[ONE_RUN, oneRun({id: 77, attempt: 3, status: "in_progress", conclusion: null})],
+		]);
+
+		expect(out.code).toBe(0);
+	});
+});
+
+/** The rerun endpoint answers 201 with no body. */
+function ok(): ExecResult {
+	return {ok: true, stdout: "", reason: ""};
+}

--- a/packages/fabrika-cli/src/recipe/status-read.ts
+++ b/packages/fabrika-cli/src/recipe/status-read.ts
@@ -1,0 +1,101 @@
+/**
+ * Reading one task's leaf state out of `lane status`'s answer.
+ *
+ * The recipe verb relays the lane's own fold rather than re-folding the log itself (ADR 0228), so
+ * what it holds is the status verb's stdout — a `stateValue` that is either a bare terminal name or
+ * `{phase: {task: leaf}}` with future phases as the string `"waiting"`. Turning that back into one
+ * task's leaf is the only derivation this file does, and it is pure so the ambiguity cases are
+ * testable without a lane on disk.
+ *
+ * A finished workflow answers {@link Finished} rather than a leaf: a terminal is not a park, and
+ * inventing a leaf for it is how a completed lane would read as clearable.
+ */
+import {isRecord, parseJson} from "../io/json.ts";
+import {isPark} from "./parks.ts";
+
+export type LeafRead =
+	| {readonly _tag: "Leaf"; readonly task: string; readonly leaf: string}
+	| {readonly _tag: "Finished"; readonly terminal: string}
+	| {readonly _tag: "Unreadable"; readonly reason: string};
+
+/**
+ * The tasks of the active phase — the one phase whose value is an object rather than `"waiting"`.
+ */
+const activeTasks = (stateValue: unknown): Readonly<Record<string, unknown>> | null => {
+	if (!isRecord(stateValue)) return null;
+	for (const value of Object.values(stateValue)) {
+		if (isRecord(value)) return value;
+	}
+	return null;
+};
+
+/** One task's leaf, off `lane status`'s stdout. `requested` is `null` on a single-task lane. */
+export const leafOf = (stdout: string, requested: string | null): LeafRead => {
+	const parsed = parseJson(stdout);
+	if (!isRecord(parsed) || parsed.stateValue === undefined) {
+		return {_tag: "Unreadable", reason: "lane status answered no `stateValue`"};
+	}
+	const stateValue = parsed.stateValue;
+	if (typeof stateValue === "string") return {_tag: "Finished", terminal: stateValue};
+
+	const tasks = activeTasks(stateValue);
+	if (tasks === null) {
+		return {_tag: "Unreadable", reason: "lane status answered no active phase"};
+	}
+	const names = Object.keys(tasks);
+	if (requested === null && names.length !== 1) {
+		return {
+			_tag: "Unreadable",
+			reason: `--task is required on a phase with ${names.length} tasks (${names.join(", ")})`,
+		};
+	}
+	const task = requested ?? names[0];
+	if (task === undefined || !Object.hasOwn(tasks, task)) {
+		return {
+			_tag: "Unreadable",
+			reason: `task "${task}" is not in the active phase (${names.join(", ")})`,
+		};
+	}
+	const leaf = tasks[task];
+	return typeof leaf === "string"
+		? {_tag: "Leaf", task, leaf}
+		: {_tag: "Unreadable", reason: `task "${task}" carries no leaf state`};
+};
+
+export type ClearProof =
+	| {readonly _tag: "Cleared"; readonly leaf: string}
+	| {readonly _tag: "Unproven"; readonly reason: string};
+
+/**
+ * Whether a re-fold proves a park was cleared — the whole read-back decision, as a pure function.
+ *
+ * The three ways it can fail take one answer because they take one remedy (a human reads the lane),
+ * and none of them may read as success: a re-fold that refused, a re-fold whose bytes name no leaf,
+ * and a re-fold that reads a leaf still in a park. Keeping it out of the verb is what makes the
+ * failed-read-back path testable without a filesystem that fails its second read only.
+ */
+export const clearProof = (code: number, stdout: string, task: string): ClearProof => {
+	if (code !== 0) {
+		return {_tag: "Unproven", reason: `the re-fold refused at exit ${code}`};
+	}
+	const read = leafOf(stdout, task);
+	if (read._tag !== "Leaf") {
+		const detail = read._tag === "Finished" ? `is "${read.terminal}"` : read.reason;
+		return {_tag: "Unproven", reason: `the re-fold ${detail}`};
+	}
+	return isPark(read.leaf)
+		? {_tag: "Unproven", reason: `the re-fold still reads the park "${read.leaf}"`}
+		: {_tag: "Cleared", leaf: read.leaf};
+};
+
+/**
+ * The issue a task drives: the number in an emitted epic lane's task name (`issue_<n>`), else the
+ * lane id itself on a single-issue lane. `null` when neither carries one — the same derivation
+ * `lane brief` makes, kept identical so a park and its brief never disagree about which issue they
+ * are about.
+ */
+export const issueOf = (lane: string, task: string): number | null => {
+	const named = /^issue_(\d+)$/.exec(task);
+	if (named?.[1] !== undefined) return Number.parseInt(named[1], 10);
+	return /^\d+$/.test(lane.trim()) ? Number.parseInt(lane.trim(), 10) : null;
+};

--- a/packages/fabrika-cli/src/recipe/status-read.unit.test.ts
+++ b/packages/fabrika-cli/src/recipe/status-read.unit.test.ts
@@ -1,0 +1,84 @@
+import {describe, expect, it} from "vitest";
+import {clearProof, issueOf, leafOf} from "./status-read.ts";
+
+const status = (stateValue: unknown): string => JSON.stringify({stateValue, status: "active"});
+
+describe("leafOf", () => {
+	it("reads the only task of a single-task active phase with no --task", () => {
+		const read = leafOf(status({pipeline: {issue: "human:cp-approval"}}), null);
+
+		expect(read).toEqual({_tag: "Leaf", task: "issue", leaf: "human:cp-approval"});
+	});
+
+	it("reads the named task past the future phases the fold marks waiting", () => {
+		const read = leafOf(
+			status({phase1: {issue_1: "blocked", issue_2: "build"}, phase2: "waiting"}),
+			"issue_2",
+		);
+
+		expect(read).toEqual({_tag: "Leaf", task: "issue_2", leaf: "build"});
+	});
+
+	it("refuses to guess on a multi-task phase with no --task", () => {
+		const read = leafOf(status({phase1: {issue_1: "blocked", issue_2: "build"}}), null);
+
+		expect(read._tag).toBe("Unreadable");
+		expect(read._tag === "Unreadable" && read.reason).toMatch(/--task is required/);
+	});
+
+	it("refuses a task outside the active phase rather than inventing a leaf", () => {
+		const read = leafOf(status({phase1: {issue_1: "blocked"}, phase2: "waiting"}), "issue_9");
+
+		expect(read._tag).toBe("Unreadable");
+		expect(read._tag === "Unreadable" && read.reason).toMatch(/not in the active phase/);
+	});
+
+	it("answers Finished on a terminal, never a leaf a park could be read from", () => {
+		expect(leafOf(status("complete"), null)).toEqual({_tag: "Finished", terminal: "complete"});
+	});
+
+	it("is Unreadable on bytes that carry no stateValue", () => {
+		expect(leafOf("not json", null)._tag).toBe("Unreadable");
+		expect(leafOf(JSON.stringify({status: "active"}), null)._tag).toBe("Unreadable");
+	});
+});
+
+describe("clearProof", () => {
+	it("is Cleared when the re-fold reads the task out of the park", () => {
+		const proof = clearProof(0, status({pipeline: {issue: "ship"}}), "issue");
+
+		expect(proof).toEqual({_tag: "Cleared", leaf: "ship"});
+	});
+
+	it("is Unproven when the re-fold refused — never read as a clear", () => {
+		const proof = clearProof(11, "", "issue");
+
+		expect(proof._tag).toBe("Unproven");
+		expect(proof._tag === "Unproven" && proof.reason).toMatch(/refused at exit 11/);
+	});
+
+	it("is Unproven when the re-fold's bytes name no leaf", () => {
+		expect(clearProof(0, "not json", "issue")._tag).toBe("Unproven");
+	});
+
+	it("is Unproven when the task is still in a park", () => {
+		const proof = clearProof(0, status({pipeline: {issue: "human:cp-approval"}}), "issue");
+
+		expect(proof._tag).toBe("Unproven");
+		expect(proof._tag === "Unproven" && proof.reason).toMatch(/still reads the park/);
+	});
+});
+
+describe("issueOf", () => {
+	it("takes the number out of an emitted epic lane's task name", () => {
+		expect(issueOf("5840", "issue_5847")).toBe(5847);
+	});
+
+	it("falls back to the lane id on a single-issue lane", () => {
+		expect(issueOf("5847", "issue")).toBe(5847);
+	});
+
+	it("is null when neither names a number", () => {
+		expect(issueOf("nightly-sweep", "issue")).toBeNull();
+	});
+});

--- a/packages/fabrika-cli/src/recipe/target.ts
+++ b/packages/fabrika-cli/src/recipe/target.ts
@@ -1,0 +1,74 @@
+/**
+ * The preconditions both recipe verbs run before they act: resolve the repo, resolve the pull
+ * request, and keep *proven absent* apart from *unreadable*.
+ *
+ * It lives here rather than in each verb because that split is the group's posture, and two copies
+ * of it are two chances to fold the two facts together — which is how "I could not read the PR"
+ * comes to authorise a rerun.
+ */
+import {Effect} from "effect";
+import type {ChildProcessSpawner} from "effect/unstable/process";
+import {resolveRepo} from "../io/issues.ts";
+import {getPullRequest, type PullRecord} from "../io/pulls.ts";
+import {FAILED, refuse, type VerbOutcome} from "../verb.ts";
+import {PRECONDITION_UNKNOWN, TARGET_ABSENT} from "./codes.ts";
+
+/** `<verb>: scanned <n> <noun>(s)[; <note>].` — the count first, so an empty answer is auditable. */
+export const scannedLine = (verb: string, scanned: number, noun: string, note?: string): string =>
+	`${verb}: scanned ${scanned} ${noun}${scanned === 1 ? "" : "s"}${
+		note === undefined ? "" : `; ${note}`
+	}.`;
+
+/** A positive integer, or the usage refusal — every number-taking verb's first check. */
+export const badNumber = (verb: string, noun: string, value: number): VerbOutcome | null =>
+	Number.isInteger(value) && value > 0 ? null : refuse(FAILED, `${verb}: ${value} is not ${noun}.`);
+
+export type Resolved =
+	| {readonly _tag: "Refused"; readonly outcome: VerbOutcome}
+	| {readonly _tag: "Repo"; readonly repo: string};
+
+export const resolveTargetRepo = (
+	verb: string,
+	explicit: string | null,
+	env: Readonly<Record<string, string | undefined>>,
+): Effect.Effect<Resolved, never, ChildProcessSpawner.ChildProcessSpawner> =>
+	Effect.gen(function* () {
+		const attempt = yield* resolveRepo(explicit, env);
+		return attempt._tag === "Failure"
+			? {
+					_tag: "Refused" as const,
+					outcome: refuse(
+						FAILED,
+						`${verb}: cannot resolve a target repo — set CLAUDE_PIPELINE_REPO, or run inside a checkout whose origin remote resolves.`,
+					),
+				}
+			: {_tag: "Repo" as const, repo: attempt.value};
+	});
+
+export type PullTarget =
+	| {readonly _tag: "Refused"; readonly outcome: VerbOutcome}
+	| {readonly _tag: "Pull"; readonly pull: PullRecord};
+
+/** One open pull request, or the refusal. Absent and closed are the same fact: nothing to act on. */
+export const openPull = (
+	verb: string,
+	repo: string,
+	pr: number,
+	unknownMessage: (reason: string) => string,
+): Effect.Effect<PullTarget, never, ChildProcessSpawner.ChildProcessSpawner> =>
+	Effect.gen(function* () {
+		const found = yield* getPullRequest(repo, pr);
+		if (found._tag === "Unknown") {
+			return {
+				_tag: "Refused" as const,
+				outcome: refuse(PRECONDITION_UNKNOWN, unknownMessage(found.reason)),
+			};
+		}
+		if (found._tag === "Absent" || found.value.state !== "open") {
+			return {
+				_tag: "Refused" as const,
+				outcome: refuse(TARGET_ABSENT, `${verb}: PR #${pr} is proven absent or closed.`),
+			};
+		}
+		return {_tag: "Pull" as const, pull: found.value};
+	});

--- a/packages/fabrika-cli/src/recipe/unpark-verb.ts
+++ b/packages/fabrika-cli/src/recipe/unpark-verb.ts
@@ -1,0 +1,247 @@
+/**
+ * `recipe unpark` — clear one parked lane when the park's cause is a known recipe, and refuse
+ * without touching anything when it is not.
+ *
+ * The order is the contract, and every step is somebody else's answer relayed (ADR 0228):
+ *
+ *   1. `lane status` folds the ledger — this verb never re-folds a log.
+ *   2. {@link classifyPark} seats the leaf against the recipe table. **Novel refuses here**, before
+ *      any read that could write and long before the append, which is what makes the novel exit a
+ *      proven no-op rather than a claim about one.
+ *   3. The recipe's clearance is read from the verb that owns it — `ship cp-approval`'s ADR 0175
+ *      discharge table, never a second reading of §CP in this file.
+ *   4. `lane transition … UNBLOCKED` records the clear.
+ *   5. `lane status` is folded **again**, and the answer is emitted only once that re-fold shows the
+ *      task out of the park (epic #5840's no-go: no recipe reports a mutation it did not read back).
+ *
+ * Respawning whatever the lane parked out of is the operator's, not this verb's.
+ */
+import {Effect, type FileSystem, type Path} from "effect";
+import type {ChildProcessSpawner} from "effect/unstable/process";
+import {isRecord, parseJson} from "../io/json.ts";
+import {openPullsClosing} from "../io/pulls.ts";
+import {runStatus} from "../lane/status-verb.ts";
+import {runTransition} from "../lane/transition-verb.ts";
+import {runCpApproval} from "../ship/cp-approval-verb.ts";
+import {answer, refuse, type VerbOutcome} from "../verb.ts";
+import {
+	NOT_PARKED,
+	PARK_HOLDS,
+	PARK_NOVEL,
+	PRECONDITION_UNKNOWN,
+	READBACK_MISMATCH,
+	TARGET_ABSENT,
+	TASK_UNRESOLVED,
+} from "./codes.ts";
+import {classifyPark, type ParkRecipe} from "./parks.ts";
+import {laneExit, relayRefusal} from "./relay.ts";
+import {clearProof, issueOf, leafOf} from "./status-read.ts";
+import {openPull, resolveTargetRepo, scannedLine} from "./target.ts";
+
+const VERB = "fabrika recipe unpark";
+
+export interface UnparkOptions {
+	/** The lanes root — `.fabrika/lanes` unless a caller relocates it. */
+	readonly root: string;
+	/** The lane id under the root — by convention the issue number the lane drives. */
+	readonly lane: string;
+	/** The task the park sits on; `null` resolves only on a single-task active phase. */
+	readonly task: string | null;
+	readonly repo: string | null;
+	readonly env: Readonly<Record<string, string | undefined>>;
+}
+
+type Clearance =
+	| {readonly _tag: "Cleared"; readonly mechanism: string}
+	| {readonly _tag: "Refused"; readonly outcome: VerbOutcome};
+
+type Deps = FileSystem.FileSystem | Path.Path | ChildProcessSpawner.ChildProcessSpawner;
+
+export const runUnpark = (options: UnparkOptions): Effect.Effect<VerbOutcome, never, Deps> =>
+	Effect.gen(function* () {
+		const ref = {root: options.root, lane: options.lane};
+
+		const before = yield* runStatus(ref);
+		if (before.code !== 0) {
+			return relayRefusal(VERB, "fabrika lane status", before, laneExit(before.code));
+		}
+		const read = leafOf(before.stdout, options.task);
+		if (read._tag === "Finished") {
+			return refuse(
+				NOT_PARKED,
+				`${VERB}: lane ${options.lane} is "${read.terminal}" — a finished workflow holds no park to clear.`,
+			);
+		}
+		if (read._tag === "Unreadable") {
+			return refuse(TASK_UNRESOLVED, `${VERB}: ${read.reason}.`);
+		}
+		const {task, leaf} = read;
+
+		const parked = classifyPark(leaf);
+		if (parked._tag === "NotParked") {
+			return refuse(
+				NOT_PARKED,
+				`${VERB}: task "${task}" is "${leaf}", which is not a park — there is nothing to clear.`,
+			);
+		}
+		if (parked._tag === "Novel") {
+			return refuse(
+				PARK_NOVEL,
+				`${VERB}: task "${task}" is parked at "${leaf}" and ${parked.reason} — refusing with the ledger untouched; route this to a human.`,
+			);
+		}
+
+		const clearance = yield* clear(options, task, parked.recipe);
+		if (clearance._tag === "Refused") return clearance.outcome;
+
+		const recorded = yield* runTransition({...ref, event: "UNBLOCKED", task});
+		if (recorded.code !== 0) {
+			return relayRefusal(VERB, "fabrika lane transition", recorded, laneExit(recorded.code));
+		}
+
+		const after = yield* runStatus(ref);
+		const proof = clearProof(after.code, after.stdout, task);
+		if (proof._tag === "Unproven") {
+			return refuse(
+				READBACK_MISMATCH,
+				`${VERB}: UNBLOCKED was appended and ${proof.reason} — the clear is NOT proven, and the lane needs a human.`,
+				[...after.stderr],
+			);
+		}
+
+		return answer(
+			JSON.stringify({
+				lane: options.lane,
+				task,
+				park: leaf,
+				clearance: parked.recipe.clearance,
+				mechanism: clearance.mechanism,
+				current: proof.leaf,
+			}),
+			[
+				`${VERB}: park "${leaf}" matched a known recipe; cleared via ${clearance.mechanism}.`,
+				`${VERB}: re-fold reads "${proof.leaf}" — the clear is proven.`,
+			],
+		);
+	});
+
+/**
+ * Read whether the recipe's clearing condition holds, relaying the verb that owns the question.
+ *
+ * The §CP answer is `ship cp-approval`'s, at the PR's live head, and its three outcomes route
+ * differently on purpose: `discharge` clears, `stop` is the park still holding, and `n/a` means the
+ * lane parked at `human:cp-approval` over something that is not a §CP block at all — the mislabeled
+ * park `operate` §4 names — which no fixed fix covers and so is novel.
+ */
+const clear = (
+	options: UnparkOptions,
+	task: string,
+	recipe: ParkRecipe,
+): Effect.Effect<Clearance, never, ChildProcessSpawner.ChildProcessSpawner> =>
+	Effect.gen(function* () {
+		const no = (outcome: VerbOutcome): Clearance => ({_tag: "Refused", outcome});
+
+		const issue = issueOf(options.lane, task);
+		if (issue === null) {
+			return no(
+				refuse(
+					TASK_UNRESOLVED,
+					`${VERB}: neither task "${task}" nor lane "${options.lane}" names an issue number, so the park's PR cannot be resolved.`,
+				),
+			);
+		}
+		const resolved = yield* resolveTargetRepo(VERB, options.repo, options.env);
+		if (resolved._tag === "Refused") return no(resolved.outcome);
+		const repo = resolved.repo;
+
+		const pulls = yield* openPullsClosing(repo, issue);
+		if (pulls._tag === "Failure") {
+			return no(
+				refuse(
+					PRECONDITION_UNKNOWN,
+					`${VERB}: cannot read the open PRs declaring they close #${issue}: ${pulls.reason} — the park's cause is UNKNOWN, never cleared.`,
+				),
+			);
+		}
+		const [only, ...rest] = pulls.value;
+		if (only === undefined) {
+			return no(
+				refuse(
+					TARGET_ABSENT,
+					`${VERB}: no open PR declares it closes #${issue}, and "${recipe.park}" waits on ${recipe.waitingOn} — there is no subject to read.`,
+				),
+			);
+		}
+		if (rest.length > 0) {
+			return no(
+				refuse(
+					PARK_NOVEL,
+					`${VERB}: ${pulls.value.length} open PRs declare they close #${issue} (${pulls.value
+						.map((p) => `#${p.number}`)
+						.join(
+							", ",
+						)}) — which one the park hangs on is not this verb's to guess; route this to a human.`,
+				),
+			);
+		}
+
+		const target = yield* openPull(
+			VERB,
+			repo,
+			only.number,
+			(reason) =>
+				`${VERB}: cannot read PR #${only.number}: ${reason} — the park's cause is UNKNOWN, never cleared.`,
+		);
+		if (target._tag === "Refused") return no(target.outcome);
+		const head = target.pull.headSha;
+
+		const discharge = yield* runCpApproval({
+			pr: only.number,
+			sha: head,
+			repo,
+			json: true,
+			env: options.env,
+		});
+		if (discharge.code !== 0) {
+			return no(
+				refuse(
+					PRECONDITION_UNKNOWN,
+					`${VERB}: fabrika ship cp-approval refused at exit ${discharge.code} — the park's cause is UNKNOWN, never cleared.`,
+					[...discharge.stderr],
+				),
+			);
+		}
+		const answered = parseJson(discharge.stdout);
+		if (!isRecord(answered) || typeof answered.outcome !== "string") {
+			return no(
+				refuse(
+					PRECONDITION_UNKNOWN,
+					`${VERB}: fabrika ship cp-approval exited 0 and named no outcome — the park's cause is UNKNOWN, never cleared.`,
+				),
+			);
+		}
+		const scope = scannedLine(VERB, 1, "pull request", `#${only.number} at ${head}`);
+		switch (answered.outcome) {
+			case "discharge":
+				return {
+					_tag: "Cleared",
+					mechanism: `cp-approval:${String(answered.mechanism ?? "discharge")}`,
+				};
+			case "stop":
+				return no(
+					refuse(
+						PARK_HOLDS,
+						`${VERB}: "${recipe.park}" still waits on ${recipe.waitingOn} — PR #${only.number} is not discharged at ${head}; nothing was written.`,
+						[scope],
+					),
+				);
+			default:
+				return no(
+					refuse(
+						PARK_NOVEL,
+						`${VERB}: PR #${only.number} is not control-plane, so "${recipe.park}" is parked over something this recipe does not cover — refusing with the ledger untouched; route this to a human.`,
+						[scope],
+					),
+				);
+		}
+	});

--- a/packages/fabrika-cli/src/recipe/unpark-verb.unit.test.ts
+++ b/packages/fabrika-cli/src/recipe/unpark-verb.unit.test.ts
@@ -1,0 +1,211 @@
+import {Effect, Layer} from "effect";
+import {describe, expect, it} from "vitest";
+import {errOut, fakeFs, fakeShell, okOut} from "../fakes.test-support.ts";
+import type {ExecResult} from "../io/exec.ts";
+import {CODEOWNERS, ENV, files, HEAD, pull, reviews} from "../ship/fixtures.test-support.ts";
+import {
+	NOT_PARKED,
+	PARK_HOLDS,
+	PARK_NOVEL,
+	PRECONDITION_UNKNOWN,
+	TARGET_ABSENT,
+	TASK_UNRESOLVED,
+	WRITE_UNKNOWN,
+} from "./codes.ts";
+import {
+	closingPulls,
+	LANE,
+	LANES_ROOT,
+	LOG,
+	laneTemplate,
+	PARKED_AT_CP,
+	PARKED_BLOCKED,
+	WORKFLOW,
+} from "./fixtures.test-support.ts";
+import {runUnpark} from "./unpark-verb.ts";
+
+const CLOSERS = /^gh api graphql/;
+const PULL = /^gh api repos\/o\/r\/pulls\/4321$/;
+const FILES = /^gh api --paginate repos\/o\/r\/pulls\/4321\/files/;
+const OWNERS = /contents\/\.github\/CODEOWNERS/;
+const COMPARE = /^gh api repos\/o\/r\/compare\//;
+const ROSTER = /^gh api --paginate orgs\/kamp-us\/teams\/control-plane\/members/;
+const REVIEWS = /^gh api -i repos\/o\/r\/pulls\/4321\/reviews/;
+
+/** The §CP path set, so the boundary classifies `control-plane` and the discharge table runs. */
+const CP_FILES = files(".github/workflows/ci.yml", "README.md");
+
+const members = (...logins: ReadonlyArray<string>): ExecResult =>
+	okOut(JSON.stringify(logins.map((login) => ({login}))));
+
+/** The whole read chain behind a discharged §CP park: an approving owner at the live head. */
+const DISCHARGED: ReadonlyArray<readonly [RegExp, ExecResult]> = [
+	[CLOSERS, closingPulls(4321)],
+	[PULL, pull({author: "usirin"})],
+	[FILES, CP_FILES],
+	[OWNERS, okOut(CODEOWNERS)],
+	[COMPARE, okOut("0")],
+	[ROSTER, members("usirin", "notusirin")],
+	[REVIEWS, reviews({login: "notusirin", state: "APPROVED", commit: HEAD})],
+];
+
+const lane = (log: string, extra: Parameters<typeof fakeFs>[0] = {}) =>
+	fakeFs({files: {[WORKFLOW]: laneTemplate(), [LOG]: log}, ...extra});
+
+const run = (
+	fs: ReturnType<typeof fakeFs>,
+	script: ReadonlyArray<readonly [RegExp, ExecResult]>,
+	task: string | null = null,
+) =>
+	Effect.runPromise(
+		Effect.provide(
+			runUnpark({root: LANES_ROOT, lane: LANE, task, repo: null, env: ENV}),
+			Layer.merge(fs.layer, fakeShell(script).layer),
+		),
+	);
+
+describe("recipe unpark — the known recipe clears", () => {
+	it("records UNBLOCKED and answers only after the re-fold reads the task out of the park", async () => {
+		const fs = lane(PARKED_AT_CP);
+
+		const out = await run(fs, DISCHARGED);
+
+		expect(out.code).toBe(0);
+		expect(JSON.parse(out.stdout)).toMatchObject({
+			lane: LANE,
+			task: "issue",
+			park: "human:cp-approval",
+			clearance: "cp-approval",
+			current: "ship",
+		});
+		expect(fs.written.get(LOG)).toMatch(/ISSUE\.UNBLOCKED/);
+	});
+
+	it("names the discharge mechanism it relayed rather than restating the §CP rule", async () => {
+		const out = await run(lane(PARKED_AT_CP), DISCHARGED);
+
+		expect(JSON.parse(out.stdout).mechanism).toMatch(/member-approval:notusirin/);
+	});
+});
+
+describe("recipe unpark — the refusals write nothing", () => {
+	it("is PARK_NOVEL on a bare BLOCKED park, with the log byte-identical", async () => {
+		const fs = lane(PARKED_BLOCKED);
+
+		const out = await run(fs, DISCHARGED);
+
+		expect(out.code).toBe(PARK_NOVEL);
+		expect(out.stdout).toBe("");
+		expect(fs.written.size).toBe(0);
+	});
+
+	it("is PARK_NOVEL on a §CP park over a PR the boundary calls ordinary — the mislabeled park", async () => {
+		const fs = lane(PARKED_AT_CP);
+
+		const out = await run(fs, [
+			[CLOSERS, closingPulls(4321)],
+			[PULL, pull()],
+			[FILES, files("apps/web/src/App.tsx", "README.md")],
+			[OWNERS, okOut(CODEOWNERS)],
+			[COMPARE, okOut("0")],
+		]);
+
+		expect(out.code).toBe(PARK_NOVEL);
+		expect(fs.written.size).toBe(0);
+	});
+
+	it("is PARK_NOVEL when several open PRs declare they close the issue", async () => {
+		const fs = lane(PARKED_AT_CP);
+
+		const out = await run(fs, [[CLOSERS, closingPulls(4321, 4322)]]);
+
+		expect(out.code).toBe(PARK_NOVEL);
+		expect(out.stderr.join("\n")).toMatch(/#4321, #4322/);
+		expect(fs.written.size).toBe(0);
+	});
+
+	it("is PARK_HOLDS while the approval is still outstanding — a distinct code from novel", async () => {
+		const fs = lane(PARKED_AT_CP);
+
+		const out = await run(fs, [
+			[CLOSERS, closingPulls(4321)],
+			[PULL, pull({author: "usirin"})],
+			[FILES, CP_FILES],
+			[OWNERS, okOut(CODEOWNERS)],
+			[COMPARE, okOut("0")],
+			[ROSTER, members("usirin", "notusirin")],
+			[REVIEWS, reviews()],
+		]);
+
+		expect(out.code).toBe(PARK_HOLDS);
+		expect(out.code).not.toBe(PARK_NOVEL);
+		expect(fs.written.size).toBe(0);
+	});
+
+	it("is NOT_PARKED on a working state", async () => {
+		const fs = lane("");
+
+		const out = await run(fs, DISCHARGED);
+
+		expect(out.code).toBe(NOT_PARKED);
+		expect(fs.written.size).toBe(0);
+	});
+
+	it("is TARGET_ABSENT when no open PR declares it closes the issue the park hangs on", async () => {
+		const fs = lane(PARKED_AT_CP);
+
+		const out = await run(fs, [[CLOSERS, closingPulls()]]);
+
+		expect(out.code).toBe(TARGET_ABSENT);
+		expect(fs.written.size).toBe(0);
+	});
+
+	it("is UNKNOWN when the closing-PR read fails — never a cleared park", async () => {
+		const fs = lane(PARKED_AT_CP);
+
+		const out = await run(fs, [[CLOSERS, errOut("api down")]]);
+
+		expect(out.code).toBe(PRECONDITION_UNKNOWN);
+		expect(fs.written.size).toBe(0);
+	});
+
+	it("relays a lane refusal onto this group's seat, not the lane's own number", async () => {
+		const fs = fakeFs({files: {}});
+
+		const out = await run(fs, DISCHARGED);
+
+		expect(out.code).toBe(TARGET_ABSENT);
+		expect(fs.written.size).toBe(0);
+	});
+
+	it("is TASK_UNRESOLVED when the lane names no issue and the task does not either", async () => {
+		const root = ".fabrika/lanes";
+		const fs = fakeFs({
+			files: {
+				[`${root}/nightly/workflow.json`]: laneTemplate(),
+				[`${root}/nightly/events.jsonl`]: PARKED_AT_CP,
+			},
+		});
+
+		const out = await Effect.runPromise(
+			Effect.provide(
+				runUnpark({root, lane: "nightly", task: null, repo: null, env: ENV}),
+				Layer.merge(fs.layer, fakeShell(DISCHARGED).layer),
+			),
+		);
+
+		expect(out.code).toBe(TASK_UNRESOLVED);
+		expect(fs.written.size).toBe(0);
+	});
+});
+
+describe("recipe unpark — the read-back is the proof", () => {
+	it("is WRITE_UNKNOWN when the append itself does not land — never reported as cleared", async () => {
+		const fs = lane(PARKED_AT_CP, {unwritable: [LOG]});
+
+		const out = await run(fs, DISCHARGED);
+
+		expect(out.code).toBe(WRITE_UNKNOWN);
+		expect(out.stdout).toBe("");
+	});
+});

--- a/packages/fabrika-cli/src/registry.ts
+++ b/packages/fabrika-cli/src/registry.ts
@@ -30,6 +30,7 @@ import {ledgerCommand} from "./ledger/command.ts";
 import {mapCommand} from "./map/command.ts";
 import {patternCommand} from "./pattern/command.ts";
 import {planCommand} from "./plan/command.ts";
+import {recipeCommand} from "./recipe/command.ts";
 import {reportCommand} from "./report/command.ts";
 import {reviewCommand} from "./review/command.ts";
 import {reviewUiCommand} from "./review-ui/command.ts";
@@ -61,6 +62,7 @@ export const registeredGroups: ReadonlyArray<VerbGroup> = [
 	mapCommand,
 	patternCommand,
 	planCommand,
+	recipeCommand,
 	reportCommand,
 	reviewCommand,
 	reviewUiCommand,


### PR DESCRIPTION
Adds `fabrika recipe`, one verb group holding the two standing driver recipes that survive the epic's subtraction. Both were hand-run repeatedly in the 2026-08-16 driver evening.

`recipe unpark <lane>` clears a parked lane when the park's cause is a known recipe. It reads the fold through `lane status`, seats the leaf against the recipe table in `parks.ts`, and on the one known park (`human:cp-approval`) relays `ship cp-approval`'s ADR 0175 discharge at the PR's live head. On a discharge it records `UNBLOCKED` through `lane transition`, re-folds, and answers only once the re-fold reads the task out of the park. On a bare `blocked`, an unlisted `human:*` park, a §CP park over a PR the boundary calls ordinary, or several candidate PRs, it refuses at exit `12` with the ledger untouched. Respawning is left to the operator.

`recipe rerun <pr>` reruns every workflow run that concluded in failure at a PR's live head, and only behind a `governance` verdict that is PASS and bound to that head. No verdict, a stale one, and a FAIL are three separate exits because they take three different remedies. Each rerun is proven by re-reading its own run record — a new attempt, or a run no longer `completed` — never by the POST's own status.

The known/novel split lives in the exit codes (`12` novel, `13` a known recipe still waiting), which is where the founder's grill answer belongs rather than in operator prose. Every classification table and every relay mapping is a pure function with unit tests, including the novel-park and failed-read-back paths; 48 new tests, and the package's full 4816-test suite is green.

Grounding: the marker read and head binding come from `wire/verdict-marker.ts`; the §CP discharge is `ship/cp-approval-verb.ts`'s own answer, not a second reading of it; the lane fold is `lane status`'s, never re-derived here.

Fixes #5847

## Deviations

- **Out-of-scope change** — **Said:** #5847's last criterion says the only file touched outside the new group directory is the single root-router registration. **Did:** also edited `packages/fabrika-cli/src/exit-code-alignment.ts` (added `RECIPE_SEATS` and the `recipe` row in `ALIGNED_GROUPS`) and `packages/fabrika-cli/src/exit-code-alignment.unit.test.ts` (added `recipe` to the `TABLES` map). **Why:** the alignment guard scans the shipped registry, so registering a group without seating it there reds `exit-code-alignment.unit.test.ts` fail-closed on three assertions — the registration cannot land alone. **Disposition:** stated here; both edits are additive rows, no existing seat changed.
- **Scope narrowing** — **Said:** classify the park's cause against the known-recipe set. **Did:** the set holds exactly one entry, `human:cp-approval`; a bare `blocked` is classified novel with the reason stated. **Why:** the ledger records the event and not its cause, so nothing keys a fixed fix on `blocked`, and the epic's non-goals rule out the criteria-heading and worktree recipes. **Disposition:** stated here; the table is data, so a later recipe is a row.
