### PR TITLE
fix: triage enrich's stdin-only criteria guard leaves a re-enrichment's composed body unreadable

### DIFF
--- a/packages/fabrika-cli/src/triage/enrich.unit.test.ts
+++ b/packages/fabrika-cli/src/triage/enrich.unit.test.ts
@@ -1,4 +1,5 @@
 import {describe, expect, it} from "vitest";
+import {read} from "../wire/acceptance-criteria.ts";
 import {
 	authoredRegion,
 	composeBody,
@@ -246,6 +247,65 @@ describe("legacy migration — recognise once, stamp in passing, never wrap twic
 
 	it("refuses a summary line with no <details> opener above it", () => {
 		expect(legacyPreserved(`${REWRITE}\n\n${SUMMARY_LINE.rewrite}\n\n</details>\n`)).toBeNull();
+	});
+});
+
+describe("the composed body is readable — the appendix is never the contract (#5852)", () => {
+	const ORIGINAL_DRIFTED =
+		"## Summary\n\nFocus is lost.\n\n## Acceptance criteria\n\n- [ ] the record";
+	const ORIGINAL_CONFORMING =
+		"## Summary\n\nFocus is lost.\n\n### Acceptance criteria\n\n- [ ] the record";
+	const REWRITE_WITH_CRITERIA =
+		"## What to build\n\nKeep focus.\n\n### Acceptance criteria\n\n- [ ] focus survives a save";
+
+	/** A re-enrichment: an earlier run wrapped the original, and this run preserves it byte for byte. */
+	const reEnriched = (original: string, authored: string): string => {
+		const first = composeBody({
+			mode: "rewrite",
+			issue: ISSUE,
+			authored: REWRITE,
+			preserved: wrapOriginal("rewrite", original),
+		});
+		const detection = detect(first, ISSUE, legacyPreserved);
+		if (detection._tag !== "Enriched") throw new Error("unreachable");
+		return composeBody({mode: "rewrite", issue: ISSUE, authored, preserved: detection.preserved});
+	};
+
+	const texts = (source: string): ReadonlyArray<string> => {
+		const result = read(source);
+		if (result._tag !== "Found") throw new Error(`expected Found, got ${result._tag}`);
+		return result.value.map((item) => String(item.text));
+	};
+
+	it("a rewrite with NO criteria over a DRIFTED original reads Absent, not Malformed", () => {
+		expect(read(reEnriched(ORIGINAL_DRIFTED, REWRITE))._tag).toBe("Absent");
+	});
+
+	it("a rewrite WITH criteria over a CONFORMING original reads the authored block, not `undecidable`", () => {
+		expect(texts(reEnriched(ORIGINAL_CONFORMING, REWRITE_WITH_CRITERIA))).toEqual([
+			"focus survives a save",
+		]);
+	});
+
+	it("covers a body wrapped BEFORE this fix — a pre-marker v1 envelope reads the same way", () => {
+		const legacy = `${REWRITE}\n\n---\n\n${wrapOriginal("rewrite", ORIGINAL_DRIFTED)}`;
+		expect(read(legacy)._tag).toBe("Absent");
+		const detection = detect(legacy, ISSUE, legacyPreserved);
+		if (detection._tag !== "Enriched") throw new Error("unreachable");
+		expect(
+			texts(
+				composeBody({
+					mode: "rewrite",
+					issue: ISSUE,
+					authored: REWRITE_WITH_CRITERIA,
+					preserved: detection.preserved,
+				}),
+			),
+		).toEqual(["focus survives a save"]);
+	});
+
+	it("reads the authored region alone exactly as before — the producer guard is unchanged", () => {
+		expect(read(authoredRegion("rewrite", REWRITE_WITH_CRITERIA))._tag).toBe("Found");
 	});
 });
 

--- a/packages/fabrika-cli/src/triage/repair-criteria.ts
+++ b/packages/fabrika-cli/src/triage/repair-criteria.ts
@@ -13,9 +13,9 @@
  * The plan acts on the **authored region only**. The `<!-- fabrika:enriched … -->` marker (or the
  * legacy v1 envelope) is the boundary `triage enrich`'s own guards rely on, and a `##` heading down
  * inside the preserved original is a historical record — rewriting it would falsify the verbatim
- * block. Classification, though, reads the **whole body**, because that is what the reader grades:
- * a body whose only drift lives inside the preserved block is un-gateable *and* unrepairable, and
- * that pair must land on a refusal that says so, not on a plausible no-op.
+ * block. Classification reads the **whole body**, because that is what the reader grades; since
+ * #5852 the reader skips a `<details>` appendix, so a body whose only drift is buried there is
+ * `Absent` — nothing to repair, and nothing left un-gateable either.
  */
 
 import {

--- a/packages/fabrika-cli/src/triage/repair-criteria.unit.test.ts
+++ b/packages/fabrika-cli/src/triage/repair-criteria.unit.test.ts
@@ -70,11 +70,10 @@ describe("planRepair — the mechanical repair", () => {
 		expect(result.reason).toContain('heading text "Acceptance criterias"');
 	});
 
-	it("refuses when the only drift lives inside the preserved original — never a no-op", () => {
-		const result = plan(enveloped("Just prose above the marker, no heading."));
-		expect(result._tag).toBe("Refused");
-		if (result._tag !== "Refused") return;
-		expect(result.reason).toContain("authored region");
+	it("answers NoBlock when the only heading lives inside the preserved original (#5852)", () => {
+		// The reader no longer counts a `<details>` appendix, so this body is `Absent` rather than
+		// the `Malformed` that used to have to land on a refusal here.
+		expect(plan(enveloped("Just prose above the marker, no heading."))._tag).toBe("NoBlock");
 	});
 
 	it("refuses two drifted headings in the authored region as undecidable", () => {

--- a/packages/fabrika-cli/src/wire/acceptance-criteria.ts
+++ b/packages/fabrika-cli/src/wire/acceptance-criteria.ts
@@ -14,6 +14,9 @@
  * `Absent`. Neither is an answer on stdout: the adapter seats them on distinct non-zero codes
  * (`./codes.ts`).
  *
+ * The scan runs over the body's *contract* region, not its bytes end to end: a fenced code block
+ * and a `<details>` appendix are both out of reach (see {@link scanHeadings}).
+ *
  * v1's `claude-plugins/kampus-pipeline/skills/gh-issue-intake-formats.md` §2 is where the semantics
  * come from — read as prior art, never called (ADR 0238). Its reviewer-append provenance tag
  * (`<!-- ac:review-code … -->`) is deliberately not carried here.
@@ -89,6 +92,15 @@ const FENCE = /^ {0,3}(```|~~~)/;
 const CHECKBOX_ITEM = /^[ \t]*[-*][ \t]+\[([ xX])\][ \t]*(.*)$/;
 
 /**
+ * A `<details>` block's own opening and closing lines.
+ *
+ * Whole-line and nothing else: an envelope writes its opener on a line of its own, so matching only
+ * that shape cannot mistake prose mentioning the tag for a block boundary.
+ */
+const DETAILS_OPEN = /^[ \t]*<details(?:[ \t][^>]*)?>[ \t]*$/;
+const DETAILS_CLOSE = /^[ \t]*<\/details>[ \t]*$/;
+
+/**
  * A line that opens a GFM block of its own beside the item — a plain bullet, an ordered-list marker,
  * a blockquote, or a thematic break. Each leaves the item's paragraph in the render exactly as the
  * next checkbox item does, so each closes the open criterion here (#5596). Tested after
@@ -140,7 +152,19 @@ const reachesForBlock = (headingText: string): boolean => {
 };
 
 /**
- * Every ATX heading outside a fenced code block — a fenced example must not pass for the real one.
+ * Every ATX heading outside a fenced code block **and outside a `<details>` block** — neither a
+ * fenced example nor a collapsed appendix may pass for the real one.
+ *
+ * The `<details>` rule is what makes an enriched body readable. `triage enrich` composes
+ * `authored region + marker + preserved original`, and the preserved original is kept verbatim
+ * inside a `<details>` block — so a legacy `## Acceptance criteria` buried there used to be a
+ * candidate, and the composed body read `Malformed` (drifted heading) or `Malformed` (two
+ * conforming headings) over an authored block that was clean (#5852). A collapsed block is an
+ * appendix, never the contract: it renders folded shut, so nothing a grader must read lives in it.
+ * Skipping it here rather than at compose time is what covers the bodies already wrapped — the
+ * board's whole enriched corpus — and not only the ones wrapped from now on.
+ *
+ * An unclosed `<details>` swallows the rest of the body, exactly as the GitHub render does.
  *
  * Exported for `triage repair-criteria`, which must locate a drifted heading by exactly the rules
  * this reader refuses it under — a second scanner would be a second definition of "heading".
@@ -148,6 +172,7 @@ const reachesForBlock = (headingText: string): boolean => {
 export const scanHeadings = (lines: ReadonlyArray<string>): ReadonlyArray<Heading> => {
 	const headings: Heading[] = [];
 	let openFence: string | null = null;
+	let detailsDepth = 0;
 	for (const [index, line] of lines.entries()) {
 		const fence = FENCE.exec(line);
 		if (fence !== null) {
@@ -157,6 +182,15 @@ export const scanHeadings = (lines: ReadonlyArray<string>): ReadonlyArray<Headin
 			continue;
 		}
 		if (openFence !== null) continue;
+		if (DETAILS_OPEN.test(line)) {
+			detailsDepth += 1;
+			continue;
+		}
+		if (DETAILS_CLOSE.test(line)) {
+			detailsDepth = Math.max(0, detailsDepth - 1);
+			continue;
+		}
+		if (detailsDepth > 0) continue;
 		const heading = ATX_HEADING.exec(line);
 		if (heading === null) continue;
 		headings.push({
@@ -184,7 +218,14 @@ const driftReason = (heading: Heading): string => {
 	return `the acceptance-criteria heading has drifted — ${parts.join("; ")}`;
 };
 
-/** The lines under `heading`, up to the next heading outside a fence, or the end of the body. */
+/**
+ * The lines under `heading`, up to the next heading outside a fence, the opening line of a
+ * `<details>` block, or the end of the body.
+ *
+ * A `<details>` opener ends the section for the same reason {@link scanHeadings} skips inside one:
+ * the collapsed block is an appendix. Without it, a preserved original that opens on checkbox lines
+ * before its first heading has them read back as criteria the author never wrote (#5852).
+ */
 const sectionOf = (lines: ReadonlyArray<string>, heading: Heading): ReadonlyArray<string> => {
 	const body: string[] = [];
 	let openFence: string | null = null;
@@ -197,7 +238,7 @@ const sectionOf = (lines: ReadonlyArray<string>, heading: Heading): ReadonlyArra
 			body.push(line);
 			continue;
 		}
-		if (openFence === null && ATX_HEADING.test(line)) break;
+		if (openFence === null && (ATX_HEADING.test(line) || DETAILS_OPEN.test(line))) break;
 		body.push(line);
 	}
 	return body;

--- a/packages/fabrika-cli/src/wire/acceptance-criteria.unit.test.ts
+++ b/packages/fabrika-cli/src/wire/acceptance-criteria.unit.test.ts
@@ -322,6 +322,94 @@ describe("read — a fenced example is not the real block", () => {
 	});
 });
 
+describe("read — a `<details>` appendix is not the real block (#5852)", () => {
+	const appendix = (...lines: ReadonlyArray<string>): string =>
+		body(
+			"<details>",
+			"<summary>Original report (verbatim)</summary>",
+			"",
+			...lines,
+			"",
+			"</details>",
+		);
+
+	it("answers Absent when the only criteria heading is buried in a `<details>` block", () => {
+		const result = read(
+			body(
+				"A rewrite that carries no criteria block.",
+				"",
+				appendix("## Acceptance criteria", "- [ ] the historical record"),
+			),
+		);
+		expect(result._tag).toBe("Absent");
+	});
+
+	it("reads the authored block when the appendix carries a conforming one too", () => {
+		expect(
+			found(
+				body(
+					"### Acceptance criteria",
+					"- [ ] the contract",
+					"",
+					appendix("### Acceptance criteria", "- [ ] the historical record"),
+				),
+			),
+		).toEqual([criterion("the contract", false)]);
+	});
+
+	it("does not absorb the appendix's checkbox items into the authored block", () => {
+		expect(
+			found(
+				body(
+					"### Acceptance criteria",
+					"- [ ] the contract",
+					"",
+					appendix("- [ ] a leading item, before any heading"),
+				),
+			),
+		).toEqual([criterion("the contract", false)]);
+	});
+
+	it("skips a nested `<details>`, and reads a block below the outer one", () => {
+		expect(
+			found(
+				body(
+					"<details>",
+					"<summary>outer</summary>",
+					"<details>",
+					"<summary>inner</summary>",
+					"## Acceptance criteria",
+					"</details>",
+					"</details>",
+					"",
+					"### Acceptance criteria",
+					"- [ ] the contract",
+				),
+			),
+		).toEqual([criterion("the contract", false)]);
+	});
+
+	it("still reads a `<details>` line quoted inside a fence as ordinary text", () => {
+		expect(
+			found(
+				body(
+					"```markdown",
+					"<details>",
+					"```",
+					"",
+					"### Acceptance criteria",
+					"- [ ] the contract",
+				),
+			),
+		).toEqual([criterion("the contract", false)]);
+	});
+
+	it("keeps a heading whose line only mentions the tag — the boundary is a line of its own", () => {
+		const result = read(body("Text about <details> blocks.", "", "## Acceptance criteria"));
+		expect(result._tag).toBe("Malformed");
+	});
+});
+
 describe("parseFields", () => {
 	it("takes one criterion per line, with the state marker optional", () => {
 		expect(parseFields("first\n[x] second\n- [ ] third\n")).toEqual({


### PR DESCRIPTION
`triage enrich` composes `authored region + marker + preserved original`, and keeps the preserved
original verbatim inside a `<details>` block. The acceptance-criteria reader had no notion of that
envelope, so a legacy `## Acceptance criteria` buried in the appendix was a candidate heading: the
composed body read `Malformed` — either the drift reason (nothing authored, one drifted heading
below) or the "which one is the contract is undecidable" refusal (a conforming heading in both
halves) — over an authored block that was clean.

**Surface chosen: the reader.** The composer was the other candidate, and it is the smaller diff,
but demoting a heading at wrap time only fixes bodies wrapped after it lands. `runEnrich` takes
`detection.preserved` byte for byte on a re-enrich and never re-scans, so the board's existing
enriched corpus would stay unreadable forever. The reader covers both, and it covers the pre-marker
v1 envelopes too, which carry no marker to key on.

The rule is one sentence: a `<details>` block is an appendix, never the contract. It renders folded
shut, so nothing a grader must read lives inside one. `scanHeadings` now tracks `<details>` /
`</details>` depth exactly as it already tracks fences, and skips headings inside — which means
`triage repair-criteria` inherits it from the one scanner rather than growing a second definition of
"heading". `sectionOf` stops at a `<details>` opener for the same reason: without it, a preserved
original whose first lines are checkboxes had them read back as criteria the author never wrote.

Boundary matching is whole-line only (`<details>`, `<details open>`, `</details>`), so prose that
mentions the tag is still ordinary text. A `<details>` line inside a fence stays inside the fence.
An unclosed `<details>` swallows the rest of the body, exactly as the GitHub render does.

Tests cover both faces through the real composer (`enrich.ts`), including a pre-marker legacy body,
plus the format rules in the wire tier. `triage enrich` itself is untouched: its stdin-scoped leak
asymmetry stands, and the test pinning that a preserved-original heading never blocks a
re-enrichment still passes.

Fixes #5852

## Deviations

- **Pre-existing test or fixture changed** — **Said:** #5852 asks that a buried drifted heading no
  longer produce a `Malformed` composed body. **Did:** flipped
  `packages/fabrika-cli/src/triage/repair-criteria.unit.test.ts`'s "refuses when the only drift lives
  inside the preserved original" from `Refused` to `NoBlock`, and rewrote the paragraph of
  `repair-criteria.ts`'s docblock that stated the old outcome. **Why:** that test pinned the exact
  behaviour this issue removes — such a body now reads `Absent`, so there is nothing to repair and
  nothing left un-gateable; leaving the assertion would have been pinning the defect. **Disposition:**
  stated here; the test still asserts a definite plan tag, it was not deleted.
- **Out-of-scope change** — **Said:** the issue names the two `Malformed` faces. **Did:** also made
  `sectionOf` stop at a `<details>` opener. **Why:** same root cause — a preserved original opening
  on checkbox lines had them absorbed into the authored contract, which is the same "reader scanning
  bytes the composer never claimed" defect pointing at the item list instead of the heading.
  **Disposition:** stated here; covered by a test.
