### PR TITLE
chore: driver instructions: subtract the retyped recipes, point at the verbs

### DIFF
--- a/claude-plugins/fabrika/skills/operate/SKILL.md
+++ b/claude-plugins/fabrika/skills/operate/SKILL.md
@@ -248,10 +248,10 @@ spawned shell fail-louds on, a criteria block that reads as no shape the verbs p
 you originate, so the order above binds: record `BLOCKED`, re-fold and confirm the state, then
 post the park comment — the step both #5643 and #5714 skipped, leaving parks the machine could
 not resume. The fix is `triage`'s: the surface that stamped the issue agent-ready owns its
-wire shape, so the park comment names the defective section and says explicitly that a `triage`
-re-run on this issue is the fix — never delegating both the what and the who to the parking
-spawn's report, and never editing the body yourself (you are type-blind, and a driven issue's body
-is not your artifact). Clearing a park is a
+wire shape, so the park comment names the defective section and points at the verb that owns the
+repair — `triage repair-criteria`, whose `--help` is its interface — never restating what that
+verb does, never delegating both the what and the who to the parking spawn's report, and never
+editing the body yourself (you are type-blind, and a driven issue's body is not your artifact). Clearing a park is a
 human's `UNBLOCKED`, recorded through the same `lane transition` verb — you never record
 `UNBLOCKED`. One exception, and it is still not yours: on a **known** park a recipe verb owns,
 `recipe unpark` records that lane's `UNBLOCKED` itself, and only after a re-fold proves the task

--- a/packages/fabrika-cli/README.md
+++ b/packages/fabrika-cli/README.md
@@ -868,6 +868,40 @@ Three behaviours are worth knowing before you call it:
   until the approval lands as `UNBLOCKED`. Per-type templates beyond it are deliberately out of
   scope until a real lane snaps against the six-event vocabulary (#5570).
 
+## The `recipe` group
+
+The standing driver recipes, versioned once instead of retyped nightly
+([#5840](https://github.com/kamp-us/phoenix/issues/5840)). A recipe is one deterministic verb with
+named exits over a fixed sequence that has no judgment in it: it relays a decision another verb
+already owns and never derives one (ADR
+[0228](../../.decisions/0228-scripts-relay-never-derive.md)). Every mutation is proven by a
+read-back before the verb reports success.
+
+| Verb | Answers |
+|---|---|
+| `recipe unpark` | whether a parked lane's park is a known recipe, and on a known one clears it — `lane transition … UNBLOCKED`, emitted only after a second fold reads the task out of the park |
+| `recipe rerun` | the failed workflow runs at a PR's live head, rerequested only behind a `governance` PASS bound to that head, each proven by re-reading its own run record |
+| `recipe route` | which recipe a chore-lane state applies, and which of the machine's six events one of that recipe's exits folds to |
+
+Each verb's `--help` is its interface — the exit table lives there, not here:
+
+```bash
+node packages/fabrika-cli/src/bin.ts recipe unpark --help
+```
+
+Two behaviours are worth knowing before you call it:
+
+- **Known clears, novel escalates, and both are exit codes.** `unpark`'s `12` is a park whose cause
+  is outside the recipe table — nothing written, route it to a human — while `13` is a known recipe
+  whose clearing condition is simply not met yet. `recipe route --exit` folds the first to `BLOCKED`
+  and the second to `WIP`, so how autonomous a chore drive is never depends on a caller's reading.
+- **Two recipes are deliberately absent.** The acceptance-criteria heading repair is
+  [`triage repair-criteria`](#the-triage-group), landed with its producer fix
+  ([#5744](https://github.com/kamp-us/phoenix/issues/5744) /
+  [#5565](https://github.com/kamp-us/phoenix/issues/5565)); orphaned-worktree reclamation is
+  [#5197](https://github.com/kamp-us/phoenix/issues/5197)'s port. Neither is re-implemented here —
+  a recipe for work another ticket owns buys a workaround and pays twice.
+
 ## The `spend` group
 
 What one fabrika run cost, in tokens, read from its transcript


### PR DESCRIPTION
Fixes #5849

Epic #5840's last criterion: the driver's own instruction surfaces stop carrying the retyped recipe
sequences and point at the verbs instead.

**The sweep.** Every driver-facing fabrika surface was grepped for the two sequences the epic keeps
(unpark-then-respawn, governance-verdict-then-rerun) and the two it hands to other tickets
(criteria-heading repair, worktree reclamation): `claude-plugins/fabrika/**` (all skills, `docs/`,
`agents/`, `README.md`), `packages/fabrika-cli/README.md`, `.claude/`, `CLAUDE.md`, `DEVELOPMENT.md`.
Two surfaces needed a change; the rest were already clean, and `docs/hook-surface.md` already names
#5197 as the owner of worktree reclamation rather than restating it.

**`packages/fabrika-cli/README.md`** — the `recipe` group was the one registered group with no
section, so a driver looking up "how do I clear this park" had nowhere to land and retyped the
sequence. Adds the section in the house shape: what a recipe is (one deterministic verb that relays,
never derives — ADR 0228), the three verbs and what each answers, `--help` named as the interface,
the known-versus-novel exit split, and the two recipes that are deliberately absent because
`triage repair-criteria` (#5744 / #5565) and #5197 own them.

**`claude-plugins/fabrika/skills/operate/SKILL.md`** — the wire-defect park told the operator to say
"a `triage` re-run is the fix", which is the criteria-heading repair described in prose. It now
points at `triage repair-criteria` and its `--help`, and says not to restate what the verb does. The
rules around it are unchanged: the operator still never edits a driven issue's body.

Docs-only. No verb behaviour changes.

## Deviations

- **Out-of-scope change** — **Said:** #5849 names removing restated sequences from driver-facing
  docs. **Did:** also added the missing `recipe` group section to `packages/fabrika-cli/README.md`.
  **Why:** the criterion asks each occurrence to point at its verb, and the CLI README is the
  driver-facing verb catalogue — a pointer with no destination is how the sequence gets retyped
  again. **Disposition:** stated here.
