### PR TITLE
feat: emitMachine one-PR reshape: child regions land locally, an epic-tail phase reviews and ships the single PR

### DIFF
--- a/packages/fabrika-cli/src/lane/__fixtures__/epic-4300.workflow.golden.txt
+++ b/packages/fabrika-cli/src/lane/__fixtures__/epic-4300.workflow.golden.txt
@@ -16,6 +16,10 @@
 			"issue_4303": {
 				"retries": 0,
 				"maxRetries": 2
+			},
+			"epic_4300": {
+				"retries": 0,
+				"maxRetries": 2
 			}
 		},
 		"states": {
@@ -39,7 +43,7 @@
 							},
 							"review": {
 								"on": {
-									"ISSUE_4301.PASS": "ship",
+									"ISSUE_4301.PASS": "landed",
 									"ISSUE_4301.BLOCKED": "blocked",
 									"ISSUE_4301.FAIL": [
 										{
@@ -53,18 +57,7 @@
 									]
 								}
 							},
-							"ship": {
-								"on": {
-									"ISSUE_4301.DONE": "shipped",
-									"ISSUE_4301.BLOCKED": "human:cp-approval"
-								}
-							},
 							"blocked": {
-								"on": {
-									"ISSUE_4301.UNBLOCKED": "hist"
-								}
-							},
-							"human:cp-approval": {
 								"on": {
 									"ISSUE_4301.UNBLOCKED": "hist"
 								}
@@ -72,7 +65,7 @@
 							"hist": {
 								"type": "history"
 							},
-							"shipped": {
+							"landed": {
 								"type": "final"
 							},
 							"frozen": {
@@ -97,7 +90,7 @@
 							},
 							"review": {
 								"on": {
-									"ISSUE_4302.PASS": "ship",
+									"ISSUE_4302.PASS": "landed",
 									"ISSUE_4302.BLOCKED": "blocked",
 									"ISSUE_4302.FAIL": [
 										{
@@ -111,18 +104,7 @@
 									]
 								}
 							},
-							"ship": {
-								"on": {
-									"ISSUE_4302.DONE": "shipped",
-									"ISSUE_4302.BLOCKED": "human:cp-approval"
-								}
-							},
 							"blocked": {
-								"on": {
-									"ISSUE_4302.UNBLOCKED": "hist"
-								}
-							},
-							"human:cp-approval": {
 								"on": {
 									"ISSUE_4302.UNBLOCKED": "hist"
 								}
@@ -130,7 +112,7 @@
 							"hist": {
 								"type": "history"
 							},
-							"shipped": {
+							"landed": {
 								"type": "final"
 							},
 							"frozen": {
@@ -169,7 +151,7 @@
 							},
 							"review": {
 								"on": {
-									"ISSUE_4303.PASS": "ship",
+									"ISSUE_4303.PASS": "landed",
 									"ISSUE_4303.BLOCKED": "blocked",
 									"ISSUE_4303.FAIL": [
 										{
@@ -183,20 +165,69 @@
 									]
 								}
 							},
-							"ship": {
-								"on": {
-									"ISSUE_4303.DONE": "shipped",
-									"ISSUE_4303.BLOCKED": "human:cp-approval"
-								}
-							},
 							"blocked": {
 								"on": {
 									"ISSUE_4303.UNBLOCKED": "hist"
 								}
 							},
+							"hist": {
+								"type": "history"
+							},
+							"landed": {
+								"type": "final"
+							},
+							"frozen": {
+								"type": "final"
+							}
+						}
+					}
+				},
+				"onDone": [
+					{
+						"target": "epic",
+						"guard": "noErrors"
+					},
+					{
+						"target": "tripped"
+					}
+				]
+			},
+			"epic": {
+				"type": "parallel",
+				"states": {
+					"epic_4300": {
+						"initial": "review",
+						"states": {
+							"review": {
+								"on": {
+									"EPIC_4300.PASS": "ship",
+									"EPIC_4300.BLOCKED": "blocked",
+									"EPIC_4300.FAIL": [
+										{
+											"target": "review",
+											"guard": "retriesRemaining",
+											"actions": "incrementRetries"
+										},
+										{
+											"target": "human:epic-review"
+										}
+									]
+								}
+							},
+							"ship": {
+								"on": {
+									"EPIC_4300.DONE": "shipped",
+									"EPIC_4300.BLOCKED": "human:cp-approval"
+								}
+							},
+							"blocked": {
+								"on": {
+									"EPIC_4300.UNBLOCKED": "hist"
+								}
+							},
 							"human:cp-approval": {
 								"on": {
-									"ISSUE_4303.UNBLOCKED": "hist"
+									"EPIC_4300.UNBLOCKED": "hist"
 								}
 							},
 							"hist": {
@@ -205,7 +236,7 @@
 							"shipped": {
 								"type": "final"
 							},
-							"frozen": {
+							"human:epic-review": {
 								"type": "final"
 							}
 						}

--- a/packages/fabrika-cli/src/lane/emit.ts
+++ b/packages/fabrika-cli/src/lane/emit.ts
@@ -6,8 +6,14 @@
  * `build/dependencies.ts` parser — the same reader `build eligible` gates on — and the cycle check
  * is `ledger/topology-doc.ts`'s `findCycle` over the same union graph (declared `requires` edges
  * plus the edges the phase order implies). What this module adds is only the machine rendering:
- * one region per child in the coder template's exact shape (same six-event vocabulary, same
- * retry/frozen semantics), phases sequenced by `onDone`, parallel within a phase.
+ * one region per child, phases sequenced by `onDone`, parallel within a phase, and one epic tail
+ * phase after the last of them.
+ *
+ * **One epic run is one branch and one PR** (ADR 0285). A child's region is the local loop only —
+ * `queued → build → review`, PASS landing that child's commits on the shared branch — and the merge
+ * lives once, in the tail phase's single epic-level region (`review → ship → shipped`). The tail is
+ * a *phase* rather than a bare state because `machine.ts` reads the workflow's two terminals off the
+ * last phase's `onDone` pair; shaped this way the compiler needs no change at all.
  *
  * Determinism is by construction: phases ascend, children within a phase ascend, every object's
  * keys are inserted in one fixed order, and the serialization is a single `JSON.stringify` — the
@@ -25,6 +31,7 @@ export type EmitResult =
 	| {
 			readonly _tag: "Emitted";
 			readonly text: string;
+			/** The child phases the topology declares. The machine also carries the epic tail phase. */
 			readonly phases: number;
 			readonly children: number;
 	  }
@@ -37,29 +44,65 @@ export type EmitResult =
 
 /**
  * Where a child's region boots. Only a `completed` close asserts the work landed, so only it earns
- * `shipped`; every other close (`not_planned`, `duplicate`, a legacy null reason) is
+ * `landed`; every other close (`not_planned`, `duplicate`, a legacy null reason) is
  * closed-without-landing and boots `frozen` — `lane status` reads `frozen` as an error final and
  * trips the phase, which is the loud answer for a topology that still requires a child the board
- * abandoned. Marking it `shipped` would fabricate a landing.
+ * abandoned. Marking it `landed` would fabricate a landing.
  */
-const initialFor = (link: SubIssueLink): "queued" | "shipped" | "frozen" => {
+const initialFor = (link: SubIssueLink): "queued" | "landed" | "frozen" => {
 	if (link.state === "open") return "queued";
-	return link.stateReason === "completed" ? "shipped" : "frozen";
+	return link.stateReason === "completed" ? "landed" : "frozen";
 };
 
-/** One child's region — the coder template's `issue` region, namespaced to the child's task id. */
-const region = (ns: string, initial: "queued" | "shipped" | "frozen"): Record<string, unknown> => ({
+/**
+ * One child's region — the local loop, namespaced to the child's task id.
+ *
+ * It ends at `landed`: the child's commits are on the epic's shared branch and nothing was pushed,
+ * reviewed on GitHub or merged. There is no per-child `ship` and no per-child `human:cp-approval`
+ * because there is no per-child PR to ship or to gate (ADR 0285).
+ */
+const region = (ns: string, initial: "queued" | "landed" | "frozen"): Record<string, unknown> => ({
 	initial,
 	states: {
 		queued: {on: {[`${ns}.WIP`]: "build", [`${ns}.BLOCKED`]: "blocked"}},
 		build: {on: {[`${ns}.DONE`]: "review", [`${ns}.BLOCKED`]: "blocked"}},
 		review: {
 			on: {
-				[`${ns}.PASS`]: "ship",
+				[`${ns}.PASS`]: "landed",
 				[`${ns}.BLOCKED`]: "blocked",
 				[`${ns}.FAIL`]: [
 					{target: "build", guard: "retriesRemaining", actions: "incrementRetries"},
 					{target: "frozen"},
+				],
+			},
+		},
+		blocked: {on: {[`${ns}.UNBLOCKED`]: "hist"}},
+		hist: {type: "history"},
+		landed: {type: "final"},
+		frozen: {type: "final"},
+	},
+});
+
+/**
+ * The epic's own region — the tail phase's single task: review the one PR, then merge it once.
+ *
+ * `review` FAIL is a two-arm guarded array so the fallthrough final is an *error* final by the
+ * compiler's own structural read; a plain target would leave a failed epic review folding to
+ * `complete`. The retry arm is `review` itself: a repair round happens outside the machine and the
+ * next verdict is another review. Where the fallthrough goes — `human:epic-review`, a park-shaped
+ * final that trips the lane for a human — is deliberately the safe placeholder #5793 asked for, not
+ * a resolved answer: what a failing epic review *means* is still an open founder question.
+ */
+const epicRegion = (ns: string): Record<string, unknown> => ({
+	initial: "review",
+	states: {
+		review: {
+			on: {
+				[`${ns}.PASS`]: "ship",
+				[`${ns}.BLOCKED`]: "blocked",
+				[`${ns}.FAIL`]: [
+					{target: "review", guard: "retriesRemaining", actions: "incrementRetries"},
+					{target: "human:epic-review"},
 				],
 			},
 		},
@@ -68,11 +111,15 @@ const region = (ns: string, initial: "queued" | "shipped" | "frozen"): Record<st
 		"human:cp-approval": {on: {[`${ns}.UNBLOCKED`]: "hist"}},
 		hist: {type: "history"},
 		shipped: {type: "final"},
-		frozen: {type: "final"},
+		"human:epic-review": {type: "final"},
 	},
 });
 
 const taskId = (child: number): string => `issue_${child}`;
+
+/** The tail phase's name and its one task id. Neither can collide with a `phase<N>`/`issue_<n>`. */
+const EPIC_PHASE = "epic";
+const epicTaskId = (epic: number): string => `epic_${epic}`;
 
 const ascending = (values: Iterable<number>): ReadonlyArray<number> =>
 	[...values].sort((a, b) => a - b);
@@ -91,7 +138,7 @@ export const emitMachine = (
 	const known = new Set(initials.keys());
 	// Every phase member is checked against `known` below, so the lookup holds by construction; the
 	// throw is the invariant's enforcement site — a defaulted initial would re-open #5746.
-	const initialOf = (child: number): "queued" | "shipped" | "frozen" => {
+	const initialOf = (child: number): "queued" | "landed" | "frozen" => {
 		const initial = initials.get(child);
 		if (initial === undefined) throw new Error(`no child link for #${child}`);
 		return initial;
@@ -155,11 +202,17 @@ export const emitMachine = (
 				]),
 			),
 			onDone: [
-				{target: next === undefined ? "complete" : phaseName(next), guard: "noErrors"},
+				{target: next === undefined ? EPIC_PHASE : phaseName(next), guard: "noErrors"},
 				{target: "tripped"},
 			],
 		};
 	}
+	context[epicTaskId(epic)] = {retries: 0, maxRetries: RETRY_BUDGET};
+	states[EPIC_PHASE] = {
+		type: "parallel",
+		states: {[epicTaskId(epic)]: epicRegion(epicTaskId(epic).toUpperCase())},
+		onDone: [{target: "complete", guard: "noErrors"}, {target: "tripped"}],
+	};
 	states.complete = {type: "final"};
 	states.tripped = {type: "final"};
 

--- a/packages/fabrika-cli/src/lane/emit.unit.test.ts
+++ b/packages/fabrika-cli/src/lane/emit.unit.test.ts
@@ -7,7 +7,8 @@ import {describe, expect, it} from "vitest";
 import {fakeFs} from "../fakes.test-support.ts";
 import {readGoldenFixture} from "../golden-fixture.ts";
 import {type EmitResult, emitMachine} from "./emit.ts";
-import {compileText} from "./machine.ts";
+import {applyEvent, deriveStatus, foldLog, type LogEntry} from "./fold.ts";
+import {type CompiledLane, compileText} from "./machine.ts";
 import {runTransition} from "./transition-verb.ts";
 
 const body = (): string => readGoldenFixture(import.meta.url, "./__fixtures__/epic-4300.body.txt");
@@ -39,6 +40,55 @@ const emitted = (result: EmitResult): string => {
 	return result.text;
 };
 
+const regionOf = (text: string, task: string): Record<string, unknown> => {
+	const doc = JSON.parse(text) as {
+		machine: {states: Record<string, {states?: Record<string, Record<string, unknown>>}>};
+	};
+	for (const phase of Object.values(doc.machine.states)) {
+		const node = phase.states?.[task];
+		if (node !== undefined) return node;
+	}
+	throw new Error(`no region for ${task}`);
+};
+
+const laneOf = (text: string): CompiledLane => {
+	const compiled = compileText(text);
+	if (compiled._tag !== "Compiled") throw new Error(compiled.defects.join("; "));
+	return compiled.lane;
+};
+
+/** Drive a sequence through `applyEvent`, asserting every step is accepted, and fold the result. */
+const drive = (
+	compiled: CompiledLane,
+	steps: ReadonlyArray<readonly [string, string]>,
+): ReturnType<typeof deriveStatus> => {
+	const log: LogEntry[] = [];
+	const statesOf = (entries: ReadonlyArray<LogEntry>) => {
+		const fold = foldLog(compiled, entries);
+		if (fold._tag !== "Folded") throw new Error(fold.defects.join("; "));
+		return fold.states;
+	};
+	for (const [task, event] of steps) {
+		const applied = applyEvent(compiled, statesOf(log), task, event, "2026-08-17T00:00:00.000Z");
+		if (applied._tag !== "Applied") throw new Error(`${task} ${event}: ${applied.reason}`);
+		log.push(applied.entry);
+	}
+	return deriveStatus(compiled, statesOf(log));
+};
+
+/** Every child through its local loop to `landed`, in phase order. */
+const LAND_ALL: ReadonlyArray<readonly [string, string]> = [
+	["issue_4301", "WIP"],
+	["issue_4301", "DONE"],
+	["issue_4301", "PASS"],
+	["issue_4302", "WIP"],
+	["issue_4302", "DONE"],
+	["issue_4302", "PASS"],
+	["issue_4303", "WIP"],
+	["issue_4303", "DONE"],
+	["issue_4303", "PASS"],
+];
+
 describe("emitMachine", () => {
 	it("emits the golden machine bytes from the golden epic body", () => {
 		expect(emitted(emitMachine(4300, body(), CHILDREN))).toBe(golden());
@@ -50,12 +100,20 @@ describe("emitMachine", () => {
 		);
 	});
 
+	it("is deterministic over a partly-built epic too — the child states are input, not drift", () => {
+		const links = [closed(4301), closed(4302, "not_planned"), open(4303)];
+		expect(emitted(emitMachine(4300, body(), links))).toBe(
+			emitted(emitMachine(4300, body(), links)),
+		);
+	});
+
 	it("emits a machine the lane compiler accepts without repair", () => {
 		const compiled = compileText(emitted(emitMachine(4300, body(), CHILDREN)));
 		if (compiled._tag !== "Compiled") throw new Error(compiled.defects.join("; "));
 		expect(compiled.lane.phases).toEqual([
 			{name: "phase1", tasks: ["issue_4301", "issue_4302"]},
 			{name: "phase2", tasks: ["issue_4303"]},
+			{name: "epic", tasks: ["epic_4300"]},
 		]);
 		expect(compiled.lane.terminals).toEqual({complete: "complete", tripped: "tripped"});
 	});
@@ -81,9 +139,9 @@ describe("emitMachine", () => {
 		expect(emitted(emitMachine(4300, body(), [open(4301), open(4302), open(4303)]))).toBe(golden());
 	});
 
-	it("boots a completed-closed child in `shipped` and leaves its open siblings queued", () => {
+	it("boots a completed-closed child in `landed` and leaves its open siblings queued", () => {
 		const text = emitted(emitMachine(4300, body(), [closed(4301), open(4302), open(4303)]));
-		expect(initialOf(text, "issue_4301")).toBe("shipped");
+		expect(initialOf(text, "issue_4301")).toBe("landed");
 		expect(initialOf(text, "issue_4302")).toBe("queued");
 	});
 
@@ -111,6 +169,108 @@ describe("emitMachine", () => {
 			previous: {phase2: {issue_4303: "queued"}},
 			current: {phase2: {issue_4303: "build"}},
 		});
+	});
+
+	it("gives a child no `ship` and no `human:cp-approval` — an epic run has one PR, not one per child", () => {
+		const child = regionOf(emitted(emitMachine(4300, body(), CHILDREN)), "issue_4301") as {
+			states: Record<string, unknown>;
+		};
+		expect(Object.keys(child.states)).toEqual([
+			"queued",
+			"build",
+			"review",
+			"blocked",
+			"hist",
+			"landed",
+			"frozen",
+		]);
+	});
+
+	it("lands a child's review PASS locally — the success final asserts a landing, not a merge", () => {
+		const compiled = laneOf(emitted(emitMachine(4300, body(), CHILDREN)));
+		const status = drive(compiled, [
+			["issue_4301", "WIP"],
+			["issue_4301", "DONE"],
+			["issue_4301", "PASS"],
+		]);
+		expect(status.stateValue).toEqual({
+			phase1: {issue_4301: "landed", issue_4302: "queued"},
+			phase2: "waiting",
+			epic: "waiting",
+		});
+	});
+
+	it("carries an epic tail phase whose one region reviews the single PR, then ships it", () => {
+		const tail = regionOf(emitted(emitMachine(4300, body(), CHILDREN)), "epic_4300");
+		expect(tail).toMatchObject({
+			initial: "review",
+			states: {
+				review: {
+					on: {
+						"EPIC_4300.PASS": "ship",
+						"EPIC_4300.FAIL": [
+							{target: "review", guard: "retriesRemaining", actions: "incrementRetries"},
+							{target: "human:epic-review"},
+						],
+					},
+				},
+				ship: {on: {"EPIC_4300.DONE": "shipped", "EPIC_4300.BLOCKED": "human:cp-approval"}},
+				shipped: {type: "final"},
+				"human:epic-review": {type: "final"},
+			},
+		});
+	});
+
+	it("reaches the epic review only after every child has landed, and completes on its ship", () => {
+		const compiled = laneOf(emitted(emitMachine(4300, body(), CHILDREN)));
+		expect(drive(compiled, LAND_ALL).stateValue).toEqual({epic: {epic_4300: "review"}});
+		expect(
+			drive(compiled, [...LAND_ALL, ["epic_4300", "PASS"], ["epic_4300", "DONE"]]),
+		).toMatchObject({stateValue: "complete", status: "done"});
+	});
+
+	it("trips the lane when the epic review fails past its retry budget — a park, never `complete`", () => {
+		const compiled = laneOf(emitted(emitMachine(4300, body(), CHILDREN)));
+		const fails: ReadonlyArray<readonly [string, string]> = [
+			["epic_4300", "FAIL"],
+			["epic_4300", "FAIL"],
+		];
+		expect(drive(compiled, [...LAND_ALL, ...fails]).stateValue).toEqual({
+			epic: {epic_4300: "review"},
+		});
+		const spent = drive(compiled, [...LAND_ALL, ...fails, ["epic_4300", "FAIL"]]);
+		expect(spent).toMatchObject({stateValue: "tripped", status: "done"});
+		expect(spent.context.errors).toEqual(["epic_4300"]);
+	});
+
+	it("terminates a partly-built epic — every child closed still leaves the epic review to run", () => {
+		const compiled = laneOf(
+			emitted(emitMachine(4300, body(), [closed(4301), closed(4302), closed(4303)])),
+		);
+		expect(drive(compiled, []).stateValue).toEqual({epic: {epic_4300: "review"}});
+		expect(
+			drive(compiled, [
+				["epic_4300", "PASS"],
+				["epic_4300", "DONE"],
+			]),
+		).toMatchObject({
+			stateValue: "complete",
+			status: "done",
+		});
+	});
+
+	it("trips before the epic review when a child was closed without landing", () => {
+		const compiled = laneOf(
+			emitted(emitMachine(4300, body(), [closed(4301, "not_planned"), closed(4302), open(4303)])),
+		);
+		expect(drive(compiled, [])).toMatchObject({stateValue: "tripped", status: "done"});
+	});
+
+	it("leaves `coder.workflow.json` byte-untouched — a single-issue lane still ships its own PR", () => {
+		const template = readGoldenFixture(import.meta.url, "./templates/coder.workflow.json");
+		expect(template).toContain('"ISSUE.PASS": "ship"');
+		expect(template).toContain('"ISSUE.BLOCKED": "human:cp-approval"');
+		expect(template).not.toContain("landed");
 	});
 
 	it("refuses a body with no ## Dependencies block", () => {

--- a/packages/fabrika-cli/src/retry-budget.unit.test.ts
+++ b/packages/fabrika-cli/src/retry-budget.unit.test.ts
@@ -33,11 +33,13 @@ describe("the one retry budget", () => {
 		expect(compiledInitials(coderTemplateText())).toEqual([RETRY_BUDGET]);
 	});
 
-	it("is what an emitted epic machine carries into every child task", () => {
+	it("is what an emitted epic machine carries into every task — each child, and the epic tail", () => {
 		const emitted = emitMachine(EPIC, epicBody(), CHILDREN);
 		if (emitted._tag !== "Emitted") throw new Error(`expected Emitted, got ${emitted._tag}`);
 
-		expect(compiledInitials(emitted.text)).toEqual(CHILDREN.map(() => RETRY_BUDGET));
+		expect(compiledInitials(emitted.text)).toEqual(
+			[...CHILDREN, "epic tail"].map(() => RETRY_BUDGET),
+		);
 	});
 
 	it("is the default a task context that declares no budget of its own compiles to", () => {


### PR DESCRIPTION
`emitMachine` now emits ADR 0285's one-PR epic shape.

**Child regions are local only.** `queued → build → review`, and a review PASS lands the child's
commits on the epic's shared branch (`landed`, a final). The per-child `ship` and
`human:cp-approval` states are gone — with one PR per run there is no per-child PR to ship or to
gate. `blocked`/`hist` resume, the guarded-FAIL retry array and the six operator events are
untouched. A `completed`-closed child boots `landed`; every other close still boots `frozen`.

**The tail is a phase, not a state.** After the last child phase the machine carries one more
parallel phase, `epic`, holding a single region `epic_<n>`: `review` of the one PR → `ship` →
`shipped`, with `ship` BLOCKED still parking in `human:cp-approval` — that is where the merge now
lives, so that is where the §CP park belongs. Modelling the tail as a phase is what keeps
`machine.ts` and `fold.ts` byte-unchanged: the compiler reads the workflow's two terminals off the
**last** phase's `onDone` pair and dereferences no names, so `epic`'s pair supplies
`complete`/`tripped` exactly as `phase2`'s used to.

Epic-review FAIL is a two-arm guarded array whose retry arm is `review` itself (a repair round
happens outside the machine; the next verdict is another review) and whose fallthrough is
`human:epic-review`, a park-shaped error final. The array shape is load-bearing rather than
stylistic: the compiler only recognises an *error* final through a guarded array's fallthrough, so a
plain target would let a failed epic review fold to `complete`.

Tests cover the child region's exact state set, a local PASS landing, the tail region's shape, a
full drive to `complete`, a FAIL past the retry budget tripping to `human:epic-review`, an
all-children-closed epic still terminating through the epic review, and determinism over a
partly-built epic. `templates/coder.workflow.json` is byte-untouched, asserted by a test.

Fixes #5824. Part of #5800.

## Deviations

- **Known defect left unfixed** — **Said:** #5824 asks for the FAIL routing as "a park-shaped error
  final in the #5737 recorded-park direction, with the open FAIL-semantics question noted in the
  PR as #5793 specified". **Did:** routed FAIL to `human:epic-review` and am noting the question
  here rather than answering it. **Why:** what a failing epic review *means* — retry, human park,
  or something else — is an open founder question #5793 explicitly declined to let a builder settle.
  `human:epic-review` is the safe placeholder: `isPark` reads it as a park, `classifyPark` reads it
  as novel (no recipe), and the lane trips rather than reporting `complete`. **Disposition:** stated
  here for the ruling.
- **Out-of-scope change** — **Said:** #5824 names `lane/emit.ts` and `emit.unit.test.ts`.
  **Did:** also updated `src/retry-budget.unit.test.ts`. **Why:** it asserts the emitted machine's
  per-task budgets as a list, and the tail phase adds a fourth task; the test now reads "each child,
  and the epic tail". No production code changed. **Disposition:** stated here.
- **Declined guidance** — **Said:** the emitted machine now carries one more phase than the topology
  declares, so `EmitResult.phases` could count it. **Did:** left `phases` meaning the *child* phase
  count and documented that on the field, so `lane emit`'s JSON answer keeps its existing meaning.
  **Why:** silently shifting a reported number's meaning is worse than a narrower one that says what
  it counts. **Disposition:** stated here; raise it if the emitted-phase count is what a caller wants.
