### PR TITLE
feat: the plan gate flips the gated epic itself to ready-for:agent on a clean floor

### DIFF
--- a/claude-plugins/fabrika/skills/check-epic-plan/SKILL.md
+++ b/claude-plugins/fabrika/skills/check-epic-plan/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: check-epic-plan
-description: "Gate one planned epic's task ledger and, only on a clean floor, flip its planned children to pickable. Trigger on \"gate epic #N\", \"check the plan for epic #N\", \"run the plan gate\", \"is epic #N's ledger clean\", \"make epic #N's children pickable\", and whenever a planned epic's ledger needs clearing before its children can be built. It does not plan (`plan-epic`) and never reviews a pull request (`review`)."
+description: "Gate one planned epic's task ledger and, only on a clean floor, flip its planned children and the epic itself to pickable. Trigger on \"gate epic #N\", \"check the plan for epic #N\", \"run the plan gate\", \"is epic #N's ledger clean\", \"make epic #N's children pickable\", and whenever a planned epic's ledger needs clearing before its children can be built. It does not plan (`plan-epic`) and never reviews a pull request (`review`)."
 arguments: [epic_number]
 argument-hint: "[epic-number] — the planned epic whose ledger to gate"
 ---
@@ -23,10 +23,11 @@ an ACL-checked verb. Every read routes through a verb, and the window between ch
 is re-gated by construction — you carry the scope digest forward and each writing verb re-derives
 the floor and refuses if it moved.
 
-**Capability set:** a repo-scoped token and a claim on the epic. Its write surface is **two
-labels on the epic's children** and **comments on the epic** — the claim marker, its release, the
-verdict, and a successor note. It holds no branch and no checkout of its own, so every terminal below shares
-one branch disposition: none, nothing checked out, nothing to clean up.
+**Capability set:** a repo-scoped token and a claim on the epic. Its write surface is **two labels on
+the epic's children**, **the epic's own audience label**, and **comments on the epic** — the claim
+marker, its release, the verdict, and a successor note. It holds no branch and no checkout of its
+own, so every terminal below shares one branch disposition: none, nothing checked out, nothing to
+clean up.
 
 ## 1 — Claim the epic, read the ledger
 
@@ -46,7 +47,8 @@ fabrika build claim $epic_number --purpose gate
 
 `--purpose gate` is not optional here. The audience axis (`ready-for:agent`) asks whether an agent
 should pick the issue up to **build**, and an epic earns that label only *after* it has been planned
-and gated — so fencing this gate on it is circular, and the fence binds build-purpose claims only.
+and gated — at step 3, from this very run — so fencing this gate on it is circular, and the fence
+binds build-purpose claims only.
 A `gate` claim is admitted without the label; the scope axis still binds, so an out-of-focus epic is still exit
 `20`. Never reach for `--override` to get past the audience axis — that is the fail-open convention
 the purpose exists to remove.
@@ -100,13 +102,24 @@ The barrier keeping a held child out of the build pool is the **assignee slot**,
 never touches and the floor checks instead (`HELD_CHILD_UNASSIGNED` / `UNVERIFIABLE_ASSIGNEE`) — a
 signal plus its enforcement, composed, not rivals.
 
+<!-- anchor: GATE-OWNS-THE-AUDIENCE-FLIP --> **The same clean floor also flips the epic itself to
+`ready-for:agent`, and this gate is that flip's only owner.** Under the single-PR model the operator
+picks the epic up, so the epic's own audience label decides whether the epic is pickable at all. The
+planner never writes it — an ungated plan would become pickable. The operator never writes it — it
+would be admitting itself. Only this gate has already proven the floor clean, so only this gate may
+write it, and the verb writes it **last**, after every child's re-read proves it moved: an epic that
+became pickable over a half-flipped ledger is exactly the failure the ordering removes. You never
+write the label by hand; the verb writes it and reads it back.
+
 Done when you have read the outcome from the channel that carries it. On exit `0`, read the
 answer's closed `terminal` token — `flipped-all` or `nothing-to-flip`; do not derive it from the
 counters. `nothing-to-flip` is a **clean gate that changed nothing**, which is not the same outcome
-as one that made children pickable.
+as one that made children pickable — and it now means the epic was already `ready-for:agent` too.
+The `audience` object beside the counters carries that fact and the epic's observed labels.
 
 A non-zero exit prints no answer at all, so read the refusal on stderr: `22` is a partial flip and
-the verb names there the children that did not move — **those refs are the whole of what you post,
+the verb names there what did not move — the children, or the epic when every child moved and its
+own audience label did not — **those refs are the whole of what you post,
 and you claim nothing about what any child carries now**, in a table or in prose. Nothing in this
 run read that back: the `22` refusal carries the un-flipped refs and no observed labels, and `plan
 read`'s `children[].labels` are pre-flip — they were read at step 1, before the write. So any
@@ -129,9 +142,10 @@ caveats, never the verdict. It is the only emit path and it reads its own commen
 it answers `posted` with a comment id.
 
 **Every clean floor comes through here, `FLIP-PARTIAL` included** — skip it there and the caveats
-that run formed are simply dropped. A partial flip writes only `status:planned` / `status:triaged` on a subset, both excluded
-from the digest and neither a floor trigger ([`contract.md`](contract.md), `flip-neutral`), so the
-digest you carried still binds and this verb still re-derives a clean floor after a `22`. **Order on
+that run formed are simply dropped. A partial flip writes only `status:planned` / `status:triaged` on
+a subset of children plus the epic's own audience label, none of them in the digest and none a floor
+trigger ([`contract.md`](contract.md), `flip-neutral`), so the digest you carried still binds and
+this verb still re-derives a clean floor after a `22`. **Order on
 that terminal: this verdict first, then `fabrika build note` with the un-flipped refs.** The note's
 body is free prose — no closed-kind check, no digest binding — so it carries refs and
 never caveats, and posting the verdict first is what keeps the rule below true.
@@ -158,20 +172,22 @@ local, or remove.** Release the claim with `fabrika build release $epic_number` 
 **after step 1 answered `won`** — if it never did, you hold nothing and there is nothing to release.
 An unreleased claim is a lock nobody can reclaim, which a human then clears by hand.
 
-- `PLAN-CLEARED` — floor clean, `skipped` empty, children flipped, verdict posted.
+- `PLAN-CLEARED` — floor clean, `skipped` empty, children flipped, the epic `ready-for:agent`,
+  verdict posted.
 - `PLAN-CLEARED-PARTIAL` — as above, but a defect class could not be derived; the marker names it,
   so nobody reads the verdict as a full-enum pass.
 - `PLAN-CLEARED-NO-FLIP` — floor clean, `terminal: nothing-to-flip`; verdict posted, no label
-  written. A success that changed nothing, said so.
+  written — every child was already pickable and so was the epic. A success that changed nothing,
+  said so.
 - `PLAN-REFUSED` — the floor proved defects, whether at step 2 or at the flip's re-gate (`20`);
   verdict posted naming them, nothing flipped. A verdict **is** the deliverable, so this is a
   success, not a back-off.
 - `PLAN-MOVED` — `21`: the plan changed between the check and a writing verb. Nothing was written
   and no verdict is posted; re-check from step 2.
-- `FLIP-PARTIAL` — `22`: the floor was clean and some children did not move. Post the verdict with
-  any caveats (step 4), **then** the refs the verb named with `fabrika build note` — refs only, no
-  claim about what any child carries now (step 3); the epic needs a human. Never reported as a gate
-  failure.
+- `FLIP-PARTIAL` — `22`: the floor was clean and something did not move — some children, or the
+  epic's own audience label. Post the verdict with any caveats (step 4), **then** the refs the verb
+  named with `fabrika build note` — refs only, no claim about what any issue carries now (step 3);
+  the epic needs a human. Never reported as a gate failure.
 - `PLAN-UNGATEABLE` — `7` or `10`: the target is **proven** not gateable — absent or closed, not a
   `type:epic`, or it has zero children. Nothing was written. Proven, so not `STOPPED`.
 - `WRITE-UNPROVEN` — `8` or `9` from **either** writing verb: a write landed, or may have landed,
@@ -211,6 +227,6 @@ fabrika installs into repos that are not phoenix; the when-missing vocabulary is
 | --- | --- | --- |
 | A planned epic: a `type:epic` issue with native sub-issue links to its children | `plan read` derives the child set from it | **fail-loud** — `plan read` exits `7`/`10`; the run ends `PLAN-UNGATEABLE`. |
 | A `## Dependencies` block in the epic body | the topology the three dependency defects rest on | **fail-loud**, two ways: *absent* is the defect `MISSING_DEPS_SECTION`, so the run ends `PLAN-REFUSED` and routes to the planning lane; *unparseable or duplicated* is `plan read`'s `4`, which ends `STOPPED`. |
-| The label taxonomy: `status:planned`, `status:triaged`, `status:needs-triage`, `ready-for:human`, `type:*`, `p0`/`p1`/`p2` | the floor reads them and the flip writes two; `POST .../labels` **creates** an unknown label rather than rejecting it, so the vocabulary is a precondition, not politeness | **fail-loud** — `plan flip` exits `23` naming the absent label rather than minting it; taxonomy creation is the front door's. |
+| The label taxonomy: `status:planned`, `status:triaged`, `status:needs-triage`, `ready-for:human`, `ready-for:agent`, `type:*`, `p0`/`p1`/`p2` | the floor reads them and the flip writes three — `status:triaged` and `status:planned` on children, `ready-for:agent` on the epic; `POST .../labels` **creates** an unknown label rather than rejecting it, so the vocabulary is a precondition, not politeness | **fail-loud** — `plan flip` exits `23` naming the absent label rather than minting it; taxonomy creation is the front door's. |
 | `product-development-cycle.md` at the repo root | gates whether `MISSING_CONTAINMENT` is derived | **degrade** — an *absent* file evaluates the class false; an *unreadable* probe puts it in `skipped` and the run ends `PLAN-CLEARED-PARTIAL`. Never silently dropped. |
 | Repository permissions readable for claim authorship | `build claim`'s ownership resolution is ACL-sourced | **fail-loud** — as declared in [`build`'s contract](../build/contract.md); a permission read that fails is `Unknown`, never a demotion to unclaimed. |

--- a/claude-plugins/fabrika/skills/check-epic-plan/SKILL.md
+++ b/claude-plugins/fabrika/skills/check-epic-plan/SKILL.md
@@ -113,9 +113,12 @@ write the label by hand; the verb writes it and reads it back.
 
 Done when you have read the outcome from the channel that carries it. On exit `0`, read the
 answer's closed `terminal` token — `flipped-all` or `nothing-to-flip`; do not derive it from the
-counters. `nothing-to-flip` is a **clean gate that changed nothing**, which is not the same outcome
-as one that made children pickable — and it now means the epic was already `ready-for:agent` too.
-The `audience` object beside the counters carries that fact and the epic's observed labels.
+counters. `nothing-to-flip` is a **clean gate that changed nothing**: every child was already
+pickable and the epic was already `ready-for:agent`. `flipped-all` means something moved, which is
+not the same as children moving — a re-gated epic whose children are all already `status:triaged`
+prints `flipped-all` with `flipped: 0` and an `audience.result` of `flipped`. So **read `flipped`
+before you say a child became pickable**, and the `audience` object beside the counters for the
+epic's own outcome and observed labels.
 
 A non-zero exit prints no answer at all, so read the refusal on stderr: `22` is a partial flip and
 the verb names there what did not move — the children, or the epic when every child moved and its
@@ -172,8 +175,9 @@ local, or remove.** Release the claim with `fabrika build release $epic_number` 
 **after step 1 answered `won`** — if it never did, you hold nothing and there is nothing to release.
 An unreleased claim is a lock nobody can reclaim, which a human then clears by hand.
 
-- `PLAN-CLEARED` — floor clean, `skipped` empty, children flipped, the epic `ready-for:agent`,
-  verdict posted.
+- `PLAN-CLEARED` — floor clean, `skipped` empty, `terminal: flipped-all`, the epic
+  `ready-for:agent`, verdict posted. Say children were flipped only when `flipped` is non-zero; on a
+  re-gate it is `0` and the epic's own label is all that moved.
 - `PLAN-CLEARED-PARTIAL` — as above, but a defect class could not be derived; the marker names it,
   so nobody reads the verdict as a full-enum pass.
 - `PLAN-CLEARED-NO-FLIP` — floor clean, `terminal: nothing-to-flip`; verdict posted, no label

--- a/claude-plugins/fabrika/skills/check-epic-plan/contract.md
+++ b/claude-plugins/fabrika/skills/check-epic-plan/contract.md
@@ -603,12 +603,18 @@ child carried neither label — a clean floor permits this, since `MISSING_LABEL
 some other `status:` value; the flip does not consider it and does not touch it).
 
 `terminal` is a closed token the skill reads rather than deriving from counters, and **it has
-exactly two values, because it only ever appears on the answer channel**: `flipped-all` (at least
-one `flipped`, no `unchanged`) · `nothing-to-flip` (no child carried `status:planned` **and** the
+exactly two values, because it only ever appears on the answer channel**: `flipped-all` (something
+moved and nothing is `unchanged` — at least one `flipped` child, **or** an `audience.result` of
+`flipped`, or both) · `nothing-to-flip` (no child carried `status:planned` **and** the
 epic's audience was `already` — a run that wrote one label is not a run that changed nothing). A partial
 flip has no token here at all — any `unchanged` child forces exit `22`, and a non-zero exit prints
 nothing on stdout, so the unchanged refs are named on **stderr** and the caller reads them there.
 There is deliberately no `unchanged` counter in the answer object: it could only ever be `0`.
+
+So `flipped-all` does **not** imply a child moved. Re-gating an epic planned before #5832 takes
+exactly that arm: every child already sits at `status:triaged`, only the epic's audience is owed, and
+the run prints `flipped-all` with `flipped: 0` and `audience.result: "flipped"`. A caller that wants
+to know whether any child became pickable reads `flipped`, never the token.
 
 **The flip is unconditional over every `status:planned` child** — ruled, with no per-child
 predicate and no opt-out hook (#4693 AC4). The barrier keeping a held child out of the build pool

--- a/claude-plugins/fabrika/skills/check-epic-plan/contract.md
+++ b/claude-plugins/fabrika/skills/check-epic-plan/contract.md
@@ -99,7 +99,7 @@ as the sibling contracts do):
 |---|---|---|
 | `plan read` | fetch the epic and its children, parse the ledger, print it as one object | fetch + registered parses — no judgment; *what the plan is worth* stays in the skill |
 | `plan check` | the deterministic floor: the thirteen hard defect types over the scanned child set | a total function from the ledger to a sorted defect list; the whole pass/fail decision, checkable by construction |
-| `plan flip` | flip every `status:planned` child to `status:triaged`, re-gating first, reporting the **observed** result per child | a guarded batch write with a read-back — no judgment; *what a partial flip means* stays in the skill |
+| `plan flip` | flip every `status:planned` child to `status:triaged` and the epic itself to `ready-for:agent`, re-gating first, reporting the **observed** result for each | a guarded batch write with a read-back — no judgment; *what a partial flip means* stays in the skill |
 | `plan verdict` | post the gate's verdict comment, bound to the scope digest, and read it back | marker composition + a guarded write; the caveats are the skill's judgment, taken as input |
 
 **Considered and not derived: a `plan defects --explain` verb.** A defect's *remedy* is the
@@ -211,10 +211,13 @@ epic=<number>|stories=<ids ascending comma-joined, or "" when the epic declares 
 
 <a id="flip-neutral"></a>
 **The flip is digest-neutral and floor-neutral by construction — this is the invariant the whole
-gate rests on.** The only two labels `plan flip` writes are `status:planned` and `status:triaged`,
-and both are **excluded from the digest serialization**. Neither is a floor trigger either:
-`MISSING_LABEL` requires *a* `status:` prefix, which both satisfy, and `NEEDS_TRIAGE_LABEL` names
-`status:needs-triage`, which the flip never writes. So a digest taken at check time still binds
+gate rests on.** The only two labels `plan flip` writes on a **child** are `status:planned` and
+`status:triaged`, and both are **excluded from the digest serialization**. Neither is a floor trigger
+either: `MISSING_LABEL` requires *a* `status:` prefix, which both satisfy, and `NEEDS_TRIAGE_LABEL`
+names `status:needs-triage`, which the flip never writes. The audience labels it writes on the
+**epic** are neutral for a stronger reason: the epic line carries no labels field at all, and every
+defect in the enum is derived from a child, so nothing about the epic's own labels reaches either the
+digest or the floor. So a digest taken at check time still binds
 after the flip, and a verdict posted after the flip attests **the scope the floor actually
 scanned**. Without this exclusion the digest would be invalidated by the very write it guards, and
 every clean verdict would bind a scope no floor had checked.
@@ -569,18 +572,26 @@ fabrika plan flip 4300 --digest 4d90e1bb27ac
 
 | Flag | Type | Required | Default | Description |
 |---|---|---|---|---|
-| `<number>` | positional integer | yes | — | the epic whose planned children are flipped |
+| `<number>` | positional integer | yes | — | the epic whose planned children are flipped, and whose own audience label is flipped with them |
 | `--digest` | string, 12 lowercase hex | yes | — | the scope digest `plan check` printed; the flip refuses if the plan has moved since |
 | `--repo` | string | no | `resolveRepo`'s precedence | the repository written |
 
-**Output** — machine. The **observed** result per child, never the intended one:
+**Output** — machine. The **observed** result per child and for the epic, never the intended one:
 
 ```
 {"answer": "flipped", "epic": 4300, "digest": "4d90e1bb27ac", "terminal": "flipped-all",
  "children": [{"number": 4301, "observed": ["p1","status:triaged","type:feature"], "result": "flipped"},
               {"number": 4302, "observed": ["p2","status:triaged","type:chore"], "result": "already"}],
- "flipped": 1, "already": 1}
+ "flipped": 1, "already": 1,
+ "audience": {"result": "flipped", "observed": ["ready-for:agent","type:epic"]}}
 ```
+
+`audience` is the epic's own result, on the same observed-not-intended discipline: `flipped` (the
+epic did not carry `ready-for:agent` alone, the labels moved, and the re-read proves it) · `already`
+(it carried `ready-for:agent` and no `ready-for:human` before the run — nothing was written) ·
+`unchanged` is unreachable on this channel, because it forces exit `22`. There is no `not-planned`
+arm: an epic carrying no audience label at all is still owed `ready-for:agent`, so absence is a
+write, not an exemption.
 
 `children` enumerates **every** child of the epic, not only the planned ones, so the answer states
 the whole set the flip considered. `result` is closed and **total over that set**: `flipped` (the
@@ -593,7 +604,8 @@ some other `status:` value; the flip does not consider it and does not touch it)
 
 `terminal` is a closed token the skill reads rather than deriving from counters, and **it has
 exactly two values, because it only ever appears on the answer channel**: `flipped-all` (at least
-one `flipped`, no `unchanged`) · `nothing-to-flip` (no child carried `status:planned`). A partial
+one `flipped`, no `unchanged`) · `nothing-to-flip` (no child carried `status:planned` **and** the
+epic's audience was `already` — a run that wrote one label is not a run that changed nothing). A partial
 flip has no token here at all — any `unchanged` child forces exit `22`, and a non-zero exit prints
 nothing on stdout, so the unchanged refs are named on **stderr** and the caller reads them there.
 There is deliberately no `unchanged` counter in the answer object: it could only ever be `0`.
@@ -602,16 +614,29 @@ There is deliberately no `unchanged` counter in the answer object: it could only
 predicate and no opt-out hook (#4693 AC4). The barrier keeping a held child out of the build pool
 is the assignee slot, which this verb never touches and `plan check` checks instead.
 
+<a id="gate-owns-the-audience-flip"></a>
+**The epic's audience flip has exactly one owner, and it is this verb** (#5832). Under the single-PR
+model the operator picks the **epic** up, so the epic's own `ready-for:agent` decides whether the
+epic is pickable at all — and before #5832 nobody wrote it, leaving planned-and-gated epics sitting
+at `ready-for:human` (#5680). The other two candidates are both wrong for the same reason, that
+neither has proven a clean floor: the **planner** never flips, because an ungated plan would become
+pickable; the **operator** never flips, because it would be admitting itself. The gate re-derives the
+floor at the moment of writing, so the gate is the seat. It writes the epic **last**, after every
+child's re-read proves it moved, so an epic never becomes pickable over a half-flipped ledger.
+
 Order of operations, each guard designed against a named v1 failure:
 
 1. **Re-gate.** Re-run the floor and recompute the digest. Any defect refuses on `20`; a digest
    differing from `--digest` refuses on `21`. The gap between deciding and writing is closed by
    re-deciding, not by trusting. Neither refusal writes anything.
-2. **Vocabulary precondition.** When there is at least one `status:planned` child to write, confirm
-   `status:triaged` and `status:planned` exist in the repository's label list. `POST .../labels`
+2. **Vocabulary precondition.** Confirm every label this run would **POST** exists in the
+   repository's label list: `status:triaged` and `status:planned` when there is at least one
+   `status:planned` child, and `ready-for:agent` when the epic is owed it. `POST .../labels`
    **creates** an unknown label rather than rejecting it (#4285), so an absent label would be
-   silently minted; refuse on `23` instead. With nothing to write the check is skipped — a
-   `nothing-to-flip` success must not refuse over a label it was never going to touch.
+   silently minted; refuse on `23` instead. Only posted labels are guarded — a `DELETE` of a label
+   the repository never defined removes nothing and mints nothing. With nothing to write the check is
+   skipped entirely — a `nothing-to-flip` success must not refuse over a label it was never going to
+   touch.
 3. **Write, bounded and per-child, add before remove.** Concurrency 8, decomposed into
    individually-observable calls so the failure index is reportable — never a replace-set `PUT`.
    **`status:triaged` is added first and `status:planned` removed second, always.** That order is
@@ -625,6 +650,12 @@ Order of operations, each guard designed against a named v1 failure:
 4. **Re-read every child** and report its observed labels. v1 asserted the flip from its
    pre-mutation intent list and re-read nothing, so a child left carrying both labels — the ADD
    landing and the DELETE failing — was reported as pickable.
+5. **Then flip the epic, add before remove, and read it back.** `ready-for:agent` is added, then
+   `ready-for:human` removed, so an epic caught between the two calls is over-labelled rather than
+   audience-less. This step runs only once step 4 proves every child moved: any `unchanged` child
+   refuses on `22` with the epic untouched. The read-back decides the result — `ready-for:agent`
+   present and `ready-for:human` absent, or it is `unchanged` and refuses on `22` in turn. An epic
+   that cannot be re-read after a write is exit `8`, never an assumed flip.
 
 Because the flip is [digest-neutral and floor-neutral](#flip-neutral), step 1's recomputation is
 comparable to `plan check`'s directly, and a verdict posted afterwards binds the same digest.
@@ -641,8 +672,8 @@ comparable to `plan check`'s directly, and a verdict posted afterwards binds the
 | `15` | proven: this session does not hold the epic's claim |
 | `20` | proven: the re-gate derived hard defects — the floor is not clean, nothing is written |
 | `21` | proven: the recomputed digest differs from `--digest` — the plan moved since the check |
-| `22` | proven: at least one child is `unchanged` — the observed set is on stderr |
-| `23` | proven: `status:triaged` or `status:planned` is absent from the repository's labels |
+| `22` | proven: at least one child is `unchanged`, or the epic did not reach `ready-for:agent` — the refs are on stderr |
+| `23` | proven: a label this run would post — `status:triaged`, `status:planned` or `ready-for:agent` — is absent from the repository's labels |
 
 **Errors**
 
@@ -651,6 +682,7 @@ comparable to `plan check`'s directly, and a verdict posted afterwards binds the
 | `plan flip: the floor is not clean (<k> defect(s)) — refusing to flip.` | 20 | refusal |
 | `plan flip: the plan moved since the check (digest <a> → <b>) — re-check before flipping.` | 21 | refusal |
 | `plan flip: <a> of <n> children flipped; <b> unchanged (#<x>, #<y>) — the epic is half-flipped and needs a human.` | 22 | refusal |
+| `plan flip: every child flipped but epic #<n> does not carry ready-for:agent alone — the epic is half-flipped and needs a human.` | 22 | refusal |
 | `plan flip: label "<name>" is absent from <repo>'s taxonomy — refusing to create it (#4285).` | 23 | refusal |
 | `plan flip: wrote <n> label change(s) and could not re-read <what> — the outcome is UNKNOWN.` | 8 | refusal |
 | `plan flip: this session does not hold #<n>'s claim.` | 15 | refusal |
@@ -660,16 +692,18 @@ comparable to `plan check`'s directly, and a verdict posted afterwards binds the
 | `plan flip: cannot read <what>: <reason> — nothing was written.` | 11 | refusal |
 | `plan flip: the ledger grammar refused during the re-gate: <reason>` | 4 | refusal |
 
-**Scope** — the verb *reads* every child of the epic and reports each one; it *writes* only those
-carrying `status:planned`. Zero children carrying it is **not** zero scope: it is the answer with
+**Scope** — the verb *reads* every child of the epic and reports each one; it *writes* those carrying
+`status:planned`, plus the epic's own audience labels. Zero children carrying `status:planned` is
+**not** zero scope: with the epic already `ready-for:agent` it is the answer with
 `terminal: "nothing-to-flip"` at exit `0`, because a gate that finds its work already done has
-succeeded. Zero *children at all* is `7`.
+succeeded — and with the epic still owed its label, that one write is the whole of the run. Zero
+*children at all* is `7`.
 
 **Examples**
 
 ```
 $ fabrika plan flip 4300 --digest 4d90e1bb27ac
-{"answer":"flipped","epic":4300,"digest":"4d90e1bb27ac","terminal":"flipped-all","children":[{"number":4301,"observed":["p1","status:triaged","type:feature"],"result":"flipped"}],"flipped":1,"already":0}
+{"answer":"flipped","epic":4300,"digest":"4d90e1bb27ac","terminal":"flipped-all","children":[{"number":4301,"observed":["p1","status:triaged","type:feature"],"result":"flipped"}],"flipped":1,"already":0,"audience":{"result":"flipped","observed":["ready-for:agent","type:epic"]}}
 ```
 
 ```
@@ -687,6 +721,8 @@ $ echo $?
   labels, the PASS comment posted only after every write so a partial flip posted nothing, and
   `discard: true` erasing the per-child record. Steps 3 and 4 answer all four.
 - #4285 — `POST .../labels` creates unknown labels; the vocabulary check is a precondition.
+- #5832 / #5680 — the gate owns the epic's audience flip; before it, a planned-and-gated epic sat at
+  `ready-for:human` and the operator could never pick it up.
 - ADR 0058's shape — the re-gate is a relation checked at write time, not a cached decision.
 
 ---

--- a/packages/fabrika-cli/src/plan/flip-verb.ts
+++ b/packages/fabrika-cli/src/plan/flip-verb.ts
@@ -1,6 +1,13 @@
 /**
- * `plan flip` — flip every `status:planned` child to `status:triaged`, re-gating first, and report the
- * **observed** result per child.
+ * `plan flip` — flip every `status:planned` child to `status:triaged` and the epic itself to
+ * `ready-for:agent`, re-gating first, and report the **observed** result for each.
+ *
+ * **The epic's audience flip has exactly one owner, and this verb is it.** Under the single-PR model
+ * the operator picks the epic up, so the epic's own audience label is load-bearing; the planner must
+ * not write it (an ungated plan would become pickable) and the operator must not write it (it would
+ * admit itself). The gate is the only place a clean floor has already been proven. It is written
+ * last, after every child is *observed* pickable, so the epic never becomes pickable over a
+ * half-flipped ledger.
  *
  * Four guards, each designed against a named v1 failure:
  *
@@ -24,7 +31,7 @@ import {Effect} from "effect";
 import type {ChildProcessSpawner} from "effect/unstable/process";
 import {requireClaim, requireSession} from "../build/claim.ts";
 import {badNumber, resolveTargetRepo} from "../build/target.ts";
-import {addLabels, listLabels, removeLabel} from "../io/issues.ts";
+import {addLabels, getIssue, listLabels, removeLabel} from "../io/issues.ts";
 import {answer, refuse, type VerbOutcome} from "../verb.ts";
 import {
 	FLOOR_DEFECTIVE,
@@ -50,6 +57,8 @@ const VERB = "plan flip";
 
 const PLANNED = "status:planned";
 const TRIAGED = "status:triaged";
+const AUDIENCE_AGENT = "ready-for:agent";
+const AUDIENCE_HUMAN = "ready-for:human";
 
 export const MESSAGES: PlanMessages = {
 	verb: VERB,
@@ -62,6 +71,24 @@ export const MESSAGES: PlanMessages = {
 
 /** Closed and **total over every child**, not only the ones the flip wrote. */
 export type FlipResult = "flipped" | "already" | "unchanged" | "not-planned";
+
+/**
+ * The epic's audience result. There is no `not-planned` arm: an epic carrying neither audience label
+ * is still owed `ready-for:agent`, so absence is a write, not an exemption.
+ */
+export type AudienceResult = "flipped" | "already" | "unchanged";
+
+/** The two audience writes the epic is owed, read off its observed labels. */
+export const audienceWrites = (
+	labels: ReadonlyArray<string>,
+): {readonly add: boolean; readonly remove: boolean} => ({
+	add: !labels.includes(AUDIENCE_AGENT),
+	remove: labels.includes(AUDIENCE_HUMAN),
+});
+
+/** The settled epic, decided by the read-back: pickable by agents and by nobody else. */
+export const audienceSettled = (observed: ReadonlyArray<string>): boolean =>
+	observed.includes(AUDIENCE_AGENT) && !observed.includes(AUDIENCE_HUMAN);
 
 export interface FlipOptions {
 	readonly number: number;
@@ -132,7 +159,14 @@ export const runFlip = (
 		}
 
 		const planned = ledger.children.filter((child) => child.labels.includes(PLANNED));
-		if (planned.length > 0) {
+		const audience = audienceWrites(target.issue.labels);
+		// Only the labels this run would POST are guarded: it is the POST that mints an unknown label,
+		// and a DELETE of a label the repo never defined removes nothing.
+		const required = [
+			...(planned.length > 0 ? FLIP_LABELS : []),
+			...(audience.add ? [AUDIENCE_AGENT] : []),
+		];
+		if (required.length > 0) {
 			const labels = yield* listLabels(repo);
 			if (labels._tag === "Failure") {
 				return refuse(
@@ -141,7 +175,7 @@ export const runFlip = (
 					notes,
 				);
 			}
-			for (const label of FLIP_LABELS) {
+			for (const label of required) {
 				if (labels.value.includes(label)) continue;
 				return refuse(
 					LABEL_ABSENT,
@@ -195,17 +229,49 @@ export const runFlip = (
 			);
 		}
 
+		let audienceResult: AudienceResult = "already";
+		let audienceObserved = [...target.issue.labels].sort();
+		if (audience.add || audience.remove) {
+			if (audience.add) {
+				const added = yield* addLabels(repo, ledger.epic, [AUDIENCE_AGENT]);
+				if (added._tag === "Ok") writes += 1;
+			}
+			if (audience.remove) {
+				const removed = yield* removeLabel(repo, ledger.epic, AUDIENCE_HUMAN);
+				if (removed._tag === "Ok") writes += 1;
+			}
+			const reread = yield* getIssue(repo, ledger.epic);
+			if (reread._tag !== "Present") {
+				return refuse(
+					WRITE_UNKNOWN,
+					`${VERB}: wrote ${writes} label change(s) and could not re-read the epic #${ledger.epic} — the outcome is UNKNOWN.`,
+					notes,
+				);
+			}
+			audienceObserved = [...reread.value.labels].sort();
+			audienceResult = audienceSettled(audienceObserved) ? "flipped" : "unchanged";
+			if (audienceResult === "unchanged") {
+				return refuse(
+					PARTIAL_FLIP,
+					`${VERB}: every child flipped but epic #${ledger.epic} does not carry ${AUDIENCE_AGENT} alone — the epic is half-flipped and needs a human.`,
+					notes,
+				);
+			}
+		}
+
 		const flipped = rows.filter((row) => row.result === "flipped").length;
 		const already = rows.filter((row) => row.result === "already").length;
+		const nothingToFlip = planned.length === 0 && audienceResult === "already";
 		return answer(
 			JSON.stringify({
 				answer: "flipped",
 				epic: ledger.epic,
 				digest: ledger.digest,
-				terminal: planned.length === 0 ? "nothing-to-flip" : "flipped-all",
+				terminal: nothingToFlip ? "nothing-to-flip" : "flipped-all",
 				children: rows,
 				flipped,
 				already,
+				audience: {result: audienceResult, observed: audienceObserved},
 			}),
 			notes,
 		);

--- a/packages/fabrika-cli/src/plan/flip-verb.unit.test.ts
+++ b/packages/fabrika-cli/src/plan/flip-verb.unit.test.ts
@@ -295,6 +295,32 @@ describe("runFlip", () => {
 		expect(calls.some((line) => /--method (POST|DELETE) .*labels/.test(line))).toBe(false);
 	});
 
+	/** #5680's shape: an epic planned and gated before #5832, re-gated to earn its audience label. */
+	it("flips the epic alone when every child is already triaged", async () => {
+		const already = child({number: 4301, labels: ["type:feature", "p1", "status:triaged"]});
+		const digest = await digestOf([
+			[EPIC, ONE_CHILD_EPIC],
+			[SUBS, subIssues(4301)],
+			[CHILD, already],
+			[CYCLE, okOut("{}")],
+		]);
+		const {outcome, calls} = await run(digest, [
+			...CLAIMED,
+			...ledger(already, already),
+			[LABELS, labelSet("ready-for:agent")],
+			[ADD_EPIC, okOut("[]")],
+			[REMOVE_EPIC, okOut("[]")],
+		]);
+		expect(outcome.code).toBe(0);
+		expect(JSON.parse(outcome.stdout)).toMatchObject({
+			terminal: "flipped-all",
+			flipped: 0,
+			already: 1,
+			audience: {result: "flipped", observed: ["ready-for:agent", "type:epic"]},
+		});
+		expect(calls.some((line) => ADD.test(line) || REMOVE.test(line))).toBe(false);
+	});
+
 	/**
 	 * v1 asserted the flip from its pre-mutation intent list and re-read nothing, so a child left
 	 * carrying both labels — the ADD landing and the DELETE failing — was reported as pickable.

--- a/packages/fabrika-cli/src/plan/flip-verb.unit.test.ts
+++ b/packages/fabrika-cli/src/plan/flip-verb.unit.test.ts
@@ -33,8 +33,18 @@ const PERM = /^gh api repos\/o\/r\/collaborators\/agent\/permission/;
 const LABELS = /^gh api --paginate repos\/o\/r\/labels/;
 const ADD = /^gh api --method POST repos\/o\/r\/issues\/4301\/labels/;
 const REMOVE = /^gh api --method DELETE repos\/o\/r\/issues\/4301\/labels/;
+const ADD_EPIC = /^gh api --method POST repos\/o\/r\/issues\/4300\/labels/;
+const REMOVE_EPIC = /^gh api --method DELETE repos\/o\/r\/issues\/4300\/labels/;
 
-const ONE_CHILD_EPIC = epic({body: epicBody({dependencies: "- phase 1: #4301"})});
+const oneChildEpic = (labels: ReadonlyArray<string>): ExecResult =>
+	epic({
+		body: epicBody({dependencies: "- phase 1: #4301"}),
+		labels: labels.map((name) => ({name})),
+	});
+
+const ONE_CHILD_EPIC = oneChildEpic(["type:epic", "ready-for:human"]);
+/** The epic as the read-back finds it once the audience flip landed. */
+const AGENT_EPIC = oneChildEpic(["type:epic", "ready-for:agent"]);
 
 const env = {CLAUDE_PIPELINE_REPO: "o/r", CLAUDE_CODE_SESSION_ID: SESSION} as Record<
 	string,
@@ -49,16 +59,18 @@ const CLAIMED: ReadonlyArray<readonly [RegExp, ExecResult]> = [
 const PLANNED = child({number: 4301, labels: ["type:feature", "p1", "status:planned"]});
 const TRIAGED = child({number: 4301, labels: ["type:feature", "p1", "status:triaged"]});
 
-/** The ledger reads, in the order the flip issues them; `once` lets the re-read differ. */
+/** The ledger reads, in the order the flip issues them; `once` lets each re-read differ. */
 const ledger = (
 	first: ExecResult,
 	reread: ExecResult,
+	epics: {first?: ExecResult; reread?: ExecResult} = {},
 ): ReadonlyArray<readonly [RegExp, ExecResult]> => [
-	[EPIC, ONE_CHILD_EPIC],
+	[once(EPIC), epics.first ?? ONE_CHILD_EPIC],
 	[SUBS, subIssues(4301)],
 	[once(CHILD), first],
 	[CYCLE, okOut("{}")],
 	[CHILD, reread],
+	[EPIC, epics.reread ?? AGENT_EPIC],
 ];
 
 const digestOf = async (script: ReadonlyArray<readonly [RegExp, ExecResult]>): Promise<string> => {
@@ -91,9 +103,11 @@ describe("runFlip", () => {
 		const {outcome} = await run(digest, [
 			...CLAIMED,
 			...ledger(PLANNED, TRIAGED),
-			[LABELS, labelSet("status:planned", "status:triaged", "type:feature")],
+			[LABELS, labelSet("status:planned", "status:triaged", "ready-for:agent", "type:feature")],
 			[ADD, okOut("[]")],
 			[REMOVE, okOut("[]")],
+			[ADD_EPIC, okOut("[]")],
+			[REMOVE_EPIC, okOut("[]")],
 		]);
 		expect(outcome.code).toBe(0);
 		expect(JSON.parse(outcome.stdout)).toMatchObject({
@@ -104,7 +118,82 @@ describe("runFlip", () => {
 			children: [
 				{number: 4301, observed: ["p1", "status:triaged", "type:feature"], result: "flipped"},
 			],
+			audience: {result: "flipped", observed: ["ready-for:agent", "type:epic"]},
 		});
+	});
+
+	/**
+	 * The epic is admitted only once every child is *observed* pickable — flip it earlier and a
+	 * ledger the re-read proves half-flipped still ships an epic the operator can pick up.
+	 */
+	it("writes the epic's audience label last, after every child re-read", async () => {
+		const digest = await digestOf(CLEAN_READ);
+		const {calls} = await run(digest, [
+			...CLAIMED,
+			...ledger(PLANNED, TRIAGED),
+			[LABELS, labelSet("status:planned", "status:triaged", "ready-for:agent")],
+			[ADD, okOut("[]")],
+			[REMOVE, okOut("[]")],
+			[ADD_EPIC, okOut("[]")],
+			[REMOVE_EPIC, okOut("[]")],
+		]);
+		const childReread = calls.findIndex((line) => /^gh api repos\/o\/r\/issues\/4301$/.test(line));
+		const epicAdd = calls.findIndex((line) => ADD_EPIC.test(line));
+		const epicRemove = calls.findIndex((line) => REMOVE_EPIC.test(line));
+		expect(childReread).toBeGreaterThanOrEqual(0);
+		expect(epicAdd).toBeGreaterThan(childReread);
+		expect(epicRemove).toBeGreaterThan(epicAdd);
+	});
+
+	it("refuses 22 when the re-read proves the epic did not reach ready-for:agent", async () => {
+		const digest = await digestOf(CLEAN_READ);
+		const {outcome} = await run(digest, [
+			...CLAIMED,
+			...ledger(PLANNED, TRIAGED, {reread: ONE_CHILD_EPIC}),
+			[LABELS, labelSet("status:planned", "status:triaged", "ready-for:agent")],
+			[ADD, okOut("[]")],
+			[REMOVE, okOut("[]")],
+			[ADD_EPIC, okOut("[]")],
+			[REMOVE_EPIC, errOut("gh: Bad gateway (HTTP 502)")],
+		]);
+		expect(outcome.code).toBe(PARTIAL_FLIP);
+		expect(outcome.stdout).toBe("");
+		expect(outcome.stderr.at(-1)).toContain(
+			"epic #4300 does not carry ready-for:agent alone — the epic is half-flipped",
+		);
+	});
+
+	it("refuses 8 when the epic's audience write cannot be proven", async () => {
+		const digest = await digestOf(CLEAN_READ);
+		const {outcome} = await run(digest, [
+			...CLAIMED,
+			...ledger(PLANNED, TRIAGED, {reread: errOut("gh: Bad gateway (HTTP 502)")}),
+			[LABELS, labelSet("status:planned", "status:triaged", "ready-for:agent")],
+			[ADD, okOut("[]")],
+			[REMOVE, okOut("[]")],
+			[ADD_EPIC, okOut("[]")],
+			[REMOVE_EPIC, okOut("[]")],
+		]);
+		expect(outcome.code).toBe(WRITE_UNKNOWN);
+		expect(outcome.stderr.at(-1)).toContain("could not re-read the epic #4300");
+	});
+
+	it("refuses 23 when ready-for:agent is absent from the taxonomy, writing nothing", async () => {
+		const already = child({number: 4301, labels: ["type:feature", "p1", "status:triaged"]});
+		const digest = await digestOf([
+			[EPIC, ONE_CHILD_EPIC],
+			[SUBS, subIssues(4301)],
+			[CHILD, already],
+			[CYCLE, okOut("{}")],
+		]);
+		const {outcome, calls} = await run(digest, [
+			...CLAIMED,
+			...ledger(already, already),
+			[LABELS, labelSet("status:planned", "status:triaged", "type:feature")],
+		]);
+		expect(outcome.code).toBe(LABEL_ABSENT);
+		expect(outcome.stderr.at(-1)).toContain('label "ready-for:agent" is absent');
+		expect(calls.some((line) => /--method POST .*labels/.test(line))).toBe(false);
 	});
 
 	/**
@@ -117,12 +206,14 @@ describe("runFlip", () => {
 		const {calls} = await run(digest, [
 			...CLAIMED,
 			...ledger(PLANNED, TRIAGED),
-			[LABELS, labelSet("status:planned", "status:triaged")],
+			[LABELS, labelSet("status:planned", "status:triaged", "ready-for:agent")],
 			[ADD, okOut("[]")],
 			[REMOVE, okOut("[]")],
+			[ADD_EPIC, okOut("[]")],
+			[REMOVE_EPIC, okOut("[]")],
 		]);
-		const add = calls.findIndex((line) => /--method POST .*labels/.test(line));
-		const remove = calls.findIndex((line) => /--method DELETE .*labels/.test(line));
+		const add = calls.findIndex((line) => ADD.test(line));
+		const remove = calls.findIndex((line) => REMOVE.test(line));
 		expect(add).toBeGreaterThanOrEqual(0);
 		expect(remove).toBeGreaterThan(add);
 	});
@@ -184,19 +275,24 @@ describe("runFlip", () => {
 	it("skips the vocabulary check when there is nothing to flip", async () => {
 		const already = child({number: 4301, labels: ["type:feature", "p1", "status:triaged"]});
 		const digest = await digestOf([
-			[EPIC, ONE_CHILD_EPIC],
+			[EPIC, AGENT_EPIC],
 			[SUBS, subIssues(4301)],
 			[CHILD, already],
 			[CYCLE, okOut("{}")],
 		]);
-		const {outcome, calls} = await run(digest, [...CLAIMED, ...ledger(already, already)]);
+		const {outcome, calls} = await run(digest, [
+			...CLAIMED,
+			...ledger(already, already, {first: AGENT_EPIC}),
+		]);
 		expect(outcome.code).toBe(0);
 		expect(JSON.parse(outcome.stdout)).toMatchObject({
 			terminal: "nothing-to-flip",
 			flipped: 0,
 			already: 1,
+			audience: {result: "already", observed: ["ready-for:agent", "type:epic"]},
 		});
 		expect(calls.some((line) => LABELS.test(line))).toBe(false);
+		expect(calls.some((line) => /--method (POST|DELETE) .*labels/.test(line))).toBe(false);
 	});
 
 	/**
@@ -209,16 +305,17 @@ describe("runFlip", () => {
 			number: 4301,
 			labels: ["type:feature", "p1", "status:planned", "status:triaged"],
 		});
-		const {outcome} = await run(digest, [
+		const {outcome, calls} = await run(digest, [
 			...CLAIMED,
 			...ledger(PLANNED, stuck),
-			[LABELS, labelSet("status:planned", "status:triaged")],
+			[LABELS, labelSet("status:planned", "status:triaged", "ready-for:agent")],
 			[ADD, okOut("[]")],
 			[REMOVE, errOut("gh: Bad gateway (HTTP 502)")],
 		]);
 		expect(outcome.code).toBe(PARTIAL_FLIP);
 		expect(outcome.stdout).toBe("");
 		expect(outcome.stderr.at(-1)).toContain("1 unchanged (#4301) — the epic is half-flipped");
+		expect(calls.some((line) => ADD_EPIC.test(line))).toBe(false);
 	});
 
 	it("refuses 8 when a write landed and no re-read can prove its outcome", async () => {
@@ -226,7 +323,7 @@ describe("runFlip", () => {
 		const {outcome} = await run(digest, [
 			...CLAIMED,
 			...ledger(PLANNED, errOut("gh: Bad gateway (HTTP 502)")),
-			[LABELS, labelSet("status:planned", "status:triaged")],
+			[LABELS, labelSet("status:planned", "status:triaged", "ready-for:agent")],
 			[ADD, okOut("[]")],
 			[REMOVE, okOut("[]")],
 		]);


### PR DESCRIPTION
`plan flip` now writes the epic's own audience label. On a clean floor, once every child's re-read
proves it moved to `status:triaged`, the verb adds `ready-for:agent` to the epic and removes
`ready-for:human`, then reads the epic back. Under the single-PR model the operator picks the epic
up, so that label is what makes the epic pickable at all — and nobody was writing it, which is why
#5680 sat planned, gated and still `ready-for:human`.

The fail-closed arms:

- A red floor or a moved digest refuses before any write, children and epic alike.
- The epic is written **last**. Any `unchanged` child forces exit `22` with the epic untouched, so an
  epic never becomes pickable over a half-flipped ledger.
- Add before remove, so an epic caught between the two calls is over-labelled rather than
  audience-less.
- The result comes from the read-back: `ready-for:agent` present and `ready-for:human` absent, or it
  is `unchanged` and refuses `22`. An epic that cannot be re-read after a write is exit `8`, never an
  assumed flip.
- The vocabulary precondition now covers `ready-for:agent` too, since `POST .../labels` mints an
  unknown label (#4285). Only posted labels are guarded — a `DELETE` mints nothing.
- `terminal: nothing-to-flip` now means the children *and* the epic were already where they belong.

`SKILL.md` and `contract.md` name the gate as the flip's only owner and state the two prohibitions:
the planner never flips (an ungated plan would become pickable) and the operator never flips (it
would admit itself). The answer object gains an `audience` field carrying the observed result.

The epic flip is digest- and floor-neutral for a stronger reason than the child flip: the digest's
epic line carries no labels field at all, and every defect in the enum is derived from a child.

Fixes #5832

## Deviations

None.
