### PR TITLE
feat: range-scoped content binding: a child's verdict survives its merge into the epic branch

### DIFF
--- a/claude-plugins/fabrika/docs/wire-formats.md
+++ b/claude-plugins/fabrika/docs/wire-formats.md
@@ -40,6 +40,7 @@ does not exist yet — rather than missing; check the registry before assuming a
 | `acceptance-criteria` | [`packages/fabrika-cli/src/wire/acceptance-criteria.ts`](../../../packages/fabrika-cli/src/wire/acceptance-criteria.ts) | `triage` | `build`, `review` |
 | `deviations` | [`packages/fabrika-cli/src/wire/deviations.ts`](../../../packages/fabrika-cli/src/wire/deviations.ts) | `build`, `build-ui` | `review`, `review-ui` |
 | `verdict-marker` | [`packages/fabrika-cli/src/wire/verdict-marker.ts`](../../../packages/fabrika-cli/src/wire/verdict-marker.ts) | `review`, `check-epic-plan`, `governance` | `build`, `ship` |
+| `range-verdict-marker` | [`packages/fabrika-cli/src/wire/range-verdict-marker.ts`](../../../packages/fabrika-cli/src/wire/range-verdict-marker.ts) | `review` | `build`, `operate` |
 | `lane-brief` | [`packages/fabrika-cli/src/wire/lane-brief.ts`](../../../packages/fabrika-cli/src/wire/lane-brief.ts) | `operate` | `build`, `review`, `ship` |
 | `map-ticket` | [`packages/fabrika-cli/src/wire/map-ticket.ts`](../../../packages/fabrika-cli/src/wire/map-ticket.ts) | `map` | `map` |
 | `grill-ruling` | [`packages/fabrika-cli/src/wire/grill-ruling.ts`](../../../packages/fabrika-cli/src/wire/grill-ruling.ts) | `grilling` | `grilling` |
@@ -94,6 +95,20 @@ moved is stale rather than passing. Drift costs both directions: a marker the re
 recognise makes a reviewed PR look unreviewed and stalls it, while one whose binding is lost would
 let a stale approval carry an unreviewed tree through a merge. The module owns the composing and the
 reading, including the staleness question; the skills keep the judgement of when to flip a verdict.
+
+### `range-verdict-marker`
+
+This is the same verdict, over a commit range instead of a pull request head — what a child's local
+review judges on its own branch, posted on the child issue. It exists because the head binding above
+cannot survive the one event every child's verdict has to survive: the moment the range is merged
+into the epic branch, the SHAs the verdict names stop being that branch's history, and a reader
+holding only those SHAs has to re-review work nobody changed. So this form drops the head and makes
+the **content digest mandatory** — the twelve hex of the same ADR 0276 serialization, over the same
+`<base>...<tip>` records. A clean merge that preserves every judged blob leaves that digest
+derivable from the epic branch and the verdict in force; a conflict resolution, or any later commit
+touching a judged path, moves it and kills the verdict, which is exactly the re-review that is owed.
+A marker of this form written with no digest binds nothing at all, so it is malformed rather than a
+weaker verdict — the one place this format is stricter than the head-bound one.
 
 ### `lane-brief`
 

--- a/packages/fabrika-cli/src/io/git.ts
+++ b/packages/fabrika-cli/src/io/git.ts
@@ -142,22 +142,50 @@ export const diffRange = (base: string, head: string): Shell<Attempt<string>> =>
 	});
 
 /**
- * The `--raw` record stream of that range: one header per changed path naming both endpoint blobs.
+ * A commit range as this package names one: what `tip` adds since it diverged from `base`.
+ *
+ * `Rev` is a parameter so a caller holding validated revisions — a verdict marker's branded SHAs —
+ * carries that validation into the range instead of widening back to `string` at the boundary.
+ */
+export interface CommitRange<Rev extends string = string> {
+	readonly base: Rev;
+	readonly tip: Rev;
+}
+
+/**
+ * The argv of the `--raw` read, written once because a digest is only comparable across two runs of
+ * the *same* invocation. A test that re-types these flags proves a serialization production never
+ * computes, which is why this is exported rather than inlined below.
  *
  * `--abbrev=40` because the default abbreviation is a display convenience whose width depends on
  * the repository's object count — a digest taken over abbreviated names would change with the clone
  * rather than with the content (`../review/content-binding.ts`).
+ *
+ * An empty `paths` reads the whole range; a non-empty one limits it to that pathspec. A caller that
+ * means "these paths and no others" must therefore refuse an empty set before it reaches here — a
+ * pathspec that silently widens to everything digests a scope nobody chose (ADR 0092).
  */
-export const diffRangeRaw = (base: string, head: string): Shell<Attempt<string>> =>
+export const rawDiffArgs = (
+	range: CommitRange,
+	paths: ReadonlyArray<string> = [],
+): ReadonlyArray<string> => [
+	"diff",
+	...DIFF_FLAGS,
+	"--raw",
+	"--abbrev=40",
+	"-z",
+	`${range.base}...${range.tip}`,
+	...(paths.length === 0 ? [] : ["--", ...paths]),
+];
+
+/** The `--raw` record stream of a range: one header per changed path naming both endpoint blobs. */
+export const diffRangeRaw = (
+	base: string,
+	head: string,
+	paths: ReadonlyArray<string> = [],
+): Shell<Attempt<string>> =>
 	Effect.gen(function* () {
-		const r = yield* execCapture("git", [
-			"diff",
-			...DIFF_FLAGS,
-			"--raw",
-			"--abbrev=40",
-			"-z",
-			`${base}...${head}`,
-		]);
+		const r = yield* execCapture("git", rawDiffArgs({base, tip: head}, paths));
 		return r.ok ? ok(r.stdout) : fail(r.reason);
 	});
 

--- a/packages/fabrika-cli/src/review/content-binding.ts
+++ b/packages/fabrika-cli/src/review/content-binding.ts
@@ -20,11 +20,17 @@
  * **A digest that could not be computed is never a digest.** Every failure below resolves to a
  * reason, never to an empty serialization, because an empty one hashes to a perfectly well-formed
  * value that two unrelated heads would share.
+ *
+ * **Two scopes, one serialization.** The PR scope binds a head; the range scope (#5825) binds what
+ * a child's `<base>...<tip>` changed, and survives that range being merged into an epic branch
+ * where those SHAs are no longer the history. Both hash the same records the same way — the range
+ * half adds only the judged paths, which is what lets a later state be asked the same question.
  */
 
 import {createHash} from "node:crypto";
 import {Effect} from "effect";
-import {type Attempt, diffRangeRaw, fail, ok, type Shell} from "../io/git.ts";
+import {type Attempt, type CommitRange, diffRangeRaw, fail, ok, type Shell} from "../io/git.ts";
+import type {NonEmptyReadonlyArray} from "../wire/format.ts";
 
 /** One `git diff --raw` record: a changed path with both endpoints of its change. */
 export interface ChangedRecord {
@@ -108,6 +114,17 @@ export const contentDigest = (records: ReadonlyArray<ChangedRecord>): string =>
 		.digest("hex")
 		.slice(0, DIGEST_LENGTH);
 
+const recordsAt = (
+	range: CommitRange,
+	paths: ReadonlyArray<string> = [],
+): Shell<Attempt<ReadonlyArray<ChangedRecord>>> =>
+	Effect.gen(function* () {
+		const raw = yield* diffRangeRaw(range.base, range.tip, paths);
+		if (raw._tag === "Failure") return raw;
+		const parsed = parseRaw(raw.value);
+		return typeof parsed === "string" ? fail(`unreadable --raw stream: ${parsed}`) : ok(parsed);
+	});
+
 /**
  * The digest of `base...head`, read from the object database with nothing checked out.
  *
@@ -117,11 +134,118 @@ export const contentDigest = (records: ReadonlyArray<ChangedRecord>): string =>
  */
 export const contentDigestAt = (base: string, head: string): Shell<Attempt<string>> =>
 	Effect.gen(function* () {
-		const raw = yield* diffRangeRaw(base, head);
-		if (raw._tag === "Failure") return raw;
-		const parsed = parseRaw(raw.value);
-		if (typeof parsed === "string") return fail(`unreadable --raw stream: ${parsed}`);
-		return parsed.length === 0
+		const parsed = yield* recordsAt({base, tip: head});
+		if (parsed._tag === "Failure") return parsed;
+		return parsed.value.length === 0
 			? fail(`${base}...${head} changes no path — an empty range digests to nothing`)
-			: ok(contentDigest(parsed));
+			: ok(contentDigest(parsed.value));
 	});
+
+/**
+ * Every path a record set names, **both** sides of a rename, deduplicated and ordered.
+ *
+ * Both sides because a later state is asked about these paths under a pathspec: limit a renamed
+ * change to its destination alone and git has no source to detect the rename from, so the record
+ * comes back as an add and the digest moves for a change nobody made.
+ */
+export const judgedPaths = (records: ReadonlyArray<ChangedRecord>): ReadonlyArray<string> =>
+	[
+		...new Set(records.flatMap((r) => (r.srcPath === null ? [r.path] : [r.srcPath, r.path]))),
+	].sort();
+
+/** What a range verdict binds: the digest of what the range changed, and the paths it changed. */
+export interface RangeContent {
+	readonly digest: string;
+	readonly paths: NonEmptyReadonlyArray<string>;
+}
+
+/**
+ * What a child's range changed — the pair a range verdict carries into the world (#5825).
+ *
+ * The digest is the ADR 0276 serialization over `<base>...<tip>` and nothing else, so a range
+ * verdict and a PR verdict over the same two commits carry the same twelve hex. The paths ride
+ * along because the marker cannot: a verdict names a range and a digest, and re-deriving that
+ * digest from a *later* state needs the pathspec the digest was taken under.
+ */
+export const rangeContentAt = (range: CommitRange): Shell<Attempt<RangeContent>> =>
+	Effect.gen(function* () {
+		const parsed = yield* recordsAt(range);
+		if (parsed._tag === "Failure") return parsed;
+		const paths = judgedPaths(parsed.value);
+		const [first, ...rest] = paths;
+		return first === undefined
+			? fail(`${range.base}...${range.tip} changes no path — an empty range digests to nothing`)
+			: ok({digest: contentDigest(parsed.value), paths: [first, ...rest] as const});
+	});
+
+/**
+ * What a later state derived over the judged paths — the three answers the in-force rule folds.
+ *
+ * `Unchanged` is separate from `Unreadable` because they are opposite facts: the first is git
+ * answering that the state carries none of the judged change (a reverted or never-landed merge),
+ * the second is git not answering at all. Fold them and a dropped change reports as a broken
+ * checkout, which is the one thing an operator reading the refusal needs told apart.
+ */
+export type Derivation =
+	| {readonly _tag: "Digest"; readonly digest: string}
+	| {readonly _tag: "Unchanged"}
+	| {readonly _tag: "Unreadable"; readonly reason: string};
+
+/**
+ * The judged content re-derived from `state` — `<base>...<state>` limited to the judged paths.
+ *
+ * The pathspec is what makes this a *range* answer rather than a branch answer: the epic branch
+ * carries every other child's work too, and an unlimited read would digest all of it and move for
+ * every sibling merge. Limited to the paths this verdict judged, the answer moves only when this
+ * verdict's own content moves.
+ */
+export const rangeDigestOnto = (
+	base: string,
+	state: string,
+	paths: NonEmptyReadonlyArray<string>,
+): Shell<Derivation> =>
+	Effect.gen(function* () {
+		const parsed = yield* recordsAt({base, tip: state}, paths);
+		if (parsed._tag === "Failure") return {_tag: "Unreadable" as const, reason: parsed.reason};
+		return parsed.value.length === 0
+			? {_tag: "Unchanged" as const}
+			: {_tag: "Digest" as const, digest: contentDigest(parsed.value)};
+	});
+
+/**
+ * Whether a range verdict still binds the state that claims it — the range half of ADR 0276.
+ *
+ * The PR-scoped rule can lean on head equality first, and a range verdict has no such shortcut: the
+ * SHAs it names stop being the epic branch's history the moment the range is merged in, so content
+ * is the only thing left to compare. That is why `../wire/range-verdict-marker.ts` makes the digest
+ * mandatory where the PR-scoped marker leaves it optional — for a range, absence of a binding would
+ * leave nothing at all to judge.
+ *
+ * Same three arms as `bindToContent`, and the same non-folding: a derivation that could not be made
+ * is `Unbindable`, never `Current` and never `Stale`.
+ */
+export type RangeBinding =
+	| {readonly _tag: "Current"; readonly digest: string}
+	| {readonly _tag: "Stale"; readonly claimed: string; readonly found: string | null}
+	| {readonly _tag: "Unbindable"; readonly reason: string};
+
+export const bindRange = (claim: {readonly content: string}, derived: Derivation): RangeBinding => {
+	if (!CONTENT_DIGEST_RE.test(claim.content)) {
+		return {
+			_tag: "Unbindable",
+			reason: `"${claim.content}" is not a content digest — the range verdict's binding cannot be judged`,
+		};
+	}
+	if (derived._tag === "Unreadable") {
+		return {
+			_tag: "Unbindable",
+			reason: `the verdict binds content ${claim.content}, but this state's digest could not be derived: ${derived.reason}`,
+		};
+	}
+	if (derived._tag === "Unchanged") {
+		return {_tag: "Stale", claimed: claim.content, found: null};
+	}
+	return derived.digest === claim.content
+		? {_tag: "Current", digest: derived.digest}
+		: {_tag: "Stale", claimed: claim.content, found: derived.digest};
+};

--- a/packages/fabrika-cli/src/review/content-binding.unit.test.ts
+++ b/packages/fabrika-cli/src/review/content-binding.unit.test.ts
@@ -12,8 +12,17 @@ import {Effect} from "effect";
 import {describe, expect, it} from "vitest";
 import {fakeShell, okOut} from "../fakes.test-support.ts";
 import type {ExecResult} from "../io/exec.ts";
-import {contentDigest, contentDigestAt, parseRaw, serializeContent} from "./content-binding.ts";
-import {BASE, HEAD, RAW, RAW_AT} from "./fixtures.test-support.ts";
+import {
+	bindRange,
+	contentDigest,
+	contentDigestAt,
+	judgedPaths,
+	parseRaw,
+	rangeContentAt,
+	rangeDigestOnto,
+	serializeContent,
+} from "./content-binding.ts";
+import {BASE, HEAD, OLD_HEAD, RAW, RAW_AT, RAW_ONTO} from "./fixtures.test-support.ts";
 
 const oid = (letter: string) => letter.repeat(40);
 
@@ -123,5 +132,79 @@ describe("contentDigestAt", () => {
 	it("FAILS on an unreadable stream rather than digesting what it could parse", async () => {
 		const out = await run([[RAW_AT(), okOut("src/cart.ts\0")]]);
 		expect(out._tag).toBe("Failure");
+	});
+});
+
+describe("the range scope", () => {
+	const JUDGED = ["README.md", "src/cart.ts"] as const;
+	const ONTO = RAW_ONTO(BASE, OLD_HEAD, ...JUDGED);
+
+	const range = (script: ReadonlyArray<readonly [RegExp, ExecResult]>) =>
+		Effect.runPromise(
+			Effect.provide(rangeContentAt({base: BASE, tip: HEAD}), fakeShell(script).layer),
+		);
+	const onto = (script: ReadonlyArray<readonly [RegExp, ExecResult]>) =>
+		Effect.runPromise(
+			Effect.provide(rangeDigestOnto(BASE, OLD_HEAD, [...JUDGED]), fakeShell(script).layer),
+		);
+
+	it("names both sides of a rename, so the pathspec can still detect it", () => {
+		const renamed = rows(record("R100", oid("a"), oid("b"), "src/new.ts", "src/old.ts"));
+		expect(judgedPaths(renamed)).toEqual(["src/new.ts", "src/old.ts"]);
+	});
+
+	it("digests a range through the SAME serialization the PR scope uses", async () => {
+		const out = await range([[RAW_AT(), okOut(RAW)]]);
+		expect(out).toEqual({_tag: "Ok", value: {digest: digestOf(RAW), paths: JUDGED}});
+	});
+
+	it("FAILS on an empty range rather than binding a verdict to nothing", async () => {
+		expect((await range([[RAW_AT(), okOut("")]]))._tag).toBe("Failure");
+	});
+
+	it("re-derives from a later state over the judged paths only", async () => {
+		expect(await onto([[ONTO, okOut(RAW)]])).toEqual({_tag: "Digest", digest: digestOf(RAW)});
+	});
+
+	it("tells a state that carries none of the judged change from one it could not read", async () => {
+		expect(await onto([[ONTO, okOut("")]])).toEqual({_tag: "Unchanged"});
+		expect((await onto([[ONTO, okOut("src/cart.ts\0")]]))._tag).toBe("Unreadable");
+	});
+});
+
+describe("bindRange", () => {
+	const CLAIMED = "7af166f42fdb";
+
+	it("is Current only when the state re-derives the claimed digest", () => {
+		expect(bindRange({content: CLAIMED}, {_tag: "Digest", digest: CLAIMED})).toEqual({
+			_tag: "Current",
+			digest: CLAIMED,
+		});
+	});
+
+	it("is Stale when the state derives a different digest", () => {
+		expect(bindRange({content: CLAIMED}, {_tag: "Digest", digest: "0123456789ab"})).toEqual({
+			_tag: "Stale",
+			claimed: CLAIMED,
+			found: "0123456789ab",
+		});
+	});
+
+	it("is Stale, not Unbindable, when the state carries none of the judged change", () => {
+		expect(bindRange({content: CLAIMED}, {_tag: "Unchanged"})._tag).toBe("Stale");
+	});
+
+	/**
+	 * The non-folding ADR 0276 turns on: a derivation that could not be made is UNKNOWN. Read as
+	 * `Current` it would ship an unverifiable verdict; read as `Stale` it would name the wrong cause
+	 * and send an operator to re-review instead of to a broken checkout.
+	 */
+	it("is Unbindable when the derivation could not be made", () => {
+		const out = bindRange({content: CLAIMED}, {_tag: "Unreadable", reason: "no merge base"});
+		expect(out._tag).toBe("Unbindable");
+	});
+
+	it("is Unbindable on a claim that is not a digest — never a comparison against a typo", () => {
+		expect(bindRange({content: "nope"}, {_tag: "Digest", digest: CLAIMED})._tag).toBe("Unbindable");
 	});
 });

--- a/packages/fabrika-cli/src/review/fixtures.test-support.ts
+++ b/packages/fabrika-cli/src/review/fixtures.test-support.ts
@@ -36,8 +36,8 @@ export const pull = (shape: PullShape = {}): ExecResult =>
 
 const DIFF_FLAGS = "--no-ext-diff --no-color --find-renames --src-prefix=a/ --dst-prefix=b/";
 
-const range = (base: string, head: string, extra = ""): RegExp =>
-	new RegExp(`^git diff ${DIFF_FLAGS}${extra} ${base}\\.\\.\\.${head}$`);
+const range = (base: string, head: string, extra = "", trailing = ""): RegExp =>
+	new RegExp(`^git diff ${DIFF_FLAGS}${extra} ${base}\\.\\.\\.${head}${trailing}$`);
 
 /** The bound diff read: `git diff <base>...<head>` under the config-proof flags. */
 export const DIFF_AT = (base: string = BASE, head: string = HEAD): RegExp => range(base, head);
@@ -53,6 +53,10 @@ export const paths = (...names: ReadonlyArray<string>): ExecResult =>
 /** The bound `--raw` read the content binding digests (ADR 0276). */
 export const RAW_AT = (base: string = BASE, head: string = HEAD): RegExp =>
 	range(base, head, " --raw --abbrev=40 -z");
+
+/** The same read limited to the paths a range verdict judged — the re-derivation read (#5825). */
+export const RAW_ONTO = (base: string, state: string, ...judged: ReadonlyArray<string>): RegExp =>
+	range(base, state, " --raw --abbrev=40 -z", ` -- ${judged.join(" ")}`);
 
 /** One `--raw -z` stream over the same two paths {@link DIFF} carries. */
 export const RAW = [

--- a/packages/fabrika-cli/src/review/range-durability.git.test.ts
+++ b/packages/fabrika-cli/src/review/range-durability.git.test.ts
@@ -1,0 +1,175 @@
+/**
+ * The range digest's durability, driven against **real git** in a throwaway repository (#5825).
+ *
+ * The claim under test is not one about hashing — it is one about what git leaves behind when a
+ * child's range is merged into an epic branch. "A clean merge preserves the destination blobs" and
+ * "a conflict resolution moves them" are statements about a program's behaviour, so they are run
+ * rather than reasoned about (CLAUDE.md: ground platform claims in source or in a real run).
+ *
+ * What is exercised here is the derivation the shipped code performs: the argv from
+ * {@link rawDiffArgs}, the walk in {@link parseRaw}, the serialization in {@link contentDigest} and
+ * the pathspec from {@link judgedPaths}. The Effect wrappers around them (`rangeContentAt`,
+ * `rangeDigestOnto`) fold the same pieces over a scripted shell in `content-binding.unit.test.ts` —
+ * that split is deliberate: `execCapture` runs in the process's own working directory, so pointing
+ * it at a fixture repository would mean mutating the test runner's cwd.
+ */
+import {execFileSync} from "node:child_process";
+import {mkdtempSync, writeFileSync} from "node:fs";
+import {tmpdir} from "node:os";
+import {join} from "node:path";
+import {describe, expect, it} from "vitest";
+import {type CommitRange, rawDiffArgs} from "../io/git.ts";
+import {SUBPROCESS_TEST_TIMEOUT_MS} from "../test-budget.ts";
+import {contentDigest, judgedPaths, parseRaw} from "./content-binding.ts";
+
+/**
+ * Both config layers are pinned away from the developer's own: merge behaviour is configurable
+ * (`merge.conflictstyle`, `merge.ff`, `diff.renames`), and a fixture that inherits it proves what
+ * this machine does rather than what git does.
+ */
+const GIT_ENV = {
+	...process.env,
+	GIT_CONFIG_GLOBAL: "/dev/null",
+	GIT_CONFIG_SYSTEM: "/dev/null",
+	GIT_AUTHOR_NAME: "fixture",
+	GIT_AUTHOR_EMAIL: "fixture@example.invalid",
+	GIT_COMMITTER_NAME: "fixture",
+	GIT_COMMITTER_EMAIL: "fixture@example.invalid",
+	GIT_AUTHOR_DATE: "2026-08-15T00:00:00Z",
+	GIT_COMMITTER_DATE: "2026-08-15T00:00:00Z",
+};
+
+interface Repo {
+	readonly git: (...args: ReadonlyArray<string>) => string;
+	readonly write: (path: string, body: string) => void;
+	readonly commit: (message: string) => string;
+	readonly rev: (ref: string) => string;
+}
+
+const openRepo = (): Repo => {
+	const dir = mkdtempSync(join(tmpdir(), "fabrika-range-"));
+	const git = (...args: ReadonlyArray<string>): string =>
+		execFileSync("git", [...args], {cwd: dir, env: GIT_ENV, encoding: "utf8"});
+	git("init", "--quiet", "-b", "epic");
+	const rev = (ref: string): string => git("rev-parse", ref).trim();
+	return {
+		git,
+		rev,
+		write: (path, body) => writeFileSync(join(dir, path), body),
+		commit: (message) => {
+			git("add", "-A");
+			git("commit", "--quiet", "-m", message);
+			return rev("HEAD");
+		},
+	};
+};
+
+/** The digest of a range, taken over the same argv and the same serialization production uses. */
+const digestOf = (repo: Repo, range: CommitRange, paths: ReadonlyArray<string> = []): string => {
+	const parsed = parseRaw(repo.git(...rawDiffArgs(range, paths)));
+	if (typeof parsed === "string") throw new Error(`unreadable --raw stream: ${parsed}`);
+	return contentDigest(parsed);
+};
+
+const pathsOf = (repo: Repo, range: CommitRange): ReadonlyArray<string> => {
+	const parsed = parseRaw(repo.git(...rawDiffArgs(range)));
+	if (typeof parsed === "string") throw new Error(`unreadable --raw stream: ${parsed}`);
+	return judgedPaths(parsed);
+};
+
+/**
+ * One epic branch, one child branch off it, and the verdict a reviewer would have formed on the
+ * child: the digest of `base...tip` and the paths that digest was taken over.
+ */
+const withChild = () => {
+	const repo = openRepo();
+	repo.write("cart.ts", "one\n");
+	repo.write("untouched.ts", "steady\n");
+	const base = repo.commit("base");
+
+	repo.git("checkout", "--quiet", "-b", "child");
+	repo.write("cart.ts", "one\ntwo\n");
+	repo.write("added.ts", "new\n");
+	const tip = repo.commit("child work");
+	repo.git("checkout", "--quiet", "epic");
+
+	const range: CommitRange = {base, tip};
+	return {repo, range, judged: pathsOf(repo, range), verdict: digestOf(repo, range)};
+};
+
+/** The verdict's own re-derivation: `<base>...<state>` limited to the paths the verdict judged. */
+const rederive = (
+	repo: Repo,
+	range: CommitRange,
+	judged: ReadonlyArray<string>,
+	state: string,
+): string => digestOf(repo, {base: range.base, tip: state}, judged);
+
+describe("a range verdict's digest across the merge into its epic branch", {
+	timeout: SUBPROCESS_TEST_TIMEOUT_MS,
+}, () => {
+	it("holds across a fast-forward — the epic branch becomes the range, byte for byte", () => {
+		const {repo, range, judged, verdict} = withChild();
+		repo.git("merge", "--quiet", "--ff-only", "child");
+		expect(rederive(repo, range, judged, repo.rev("epic"))).toBe(verdict);
+	});
+
+	it("holds across a clean merge that preserves every judged blob", () => {
+		const {repo, range, judged, verdict} = withChild();
+		repo.write("sibling.ts", "another child's work\n");
+		repo.commit("a sibling lands first");
+		repo.git("merge", "--quiet", "--no-ff", "-m", "merge child", "child");
+
+		// The merge commit's tree carries the sibling's path too; the pathspec is what keeps this
+		// verdict's answer about its own content rather than about the whole branch.
+		expect(rederive(repo, range, judged, repo.rev("epic"))).toBe(verdict);
+		expect(digestOf(repo, {base: range.base, tip: repo.rev("epic")})).not.toBe(verdict);
+	});
+
+	it("MOVES across a conflicted merge whose resolution rewrites a judged path", () => {
+		const {repo, range, judged, verdict} = withChild();
+		repo.write("cart.ts", "one\nconflicting\n");
+		repo.commit("the epic branch edits the same file");
+		expect(() => repo.git("merge", "--quiet", "--no-ff", "-m", "merge child", "child")).toThrow();
+
+		repo.write("cart.ts", "one\ntwo\nconflicting\n");
+		repo.git("add", "-A");
+		repo.git("commit", "--quiet", "--no-edit");
+		expect(rederive(repo, range, judged, repo.rev("epic"))).not.toBe(verdict);
+	});
+
+	it("MOVES on a later commit touching a judged path, after the merge held", () => {
+		const {repo, range, judged, verdict} = withChild();
+		repo.git("merge", "--quiet", "--ff-only", "child");
+		expect(rederive(repo, range, judged, repo.rev("epic"))).toBe(verdict);
+
+		repo.write("cart.ts", "one\ntwo\nthree\n");
+		repo.commit("someone edits the reviewed file afterwards");
+		expect(rederive(repo, range, judged, repo.rev("epic"))).not.toBe(verdict);
+	});
+
+	it("holds when a later commit touches a path the verdict never judged", () => {
+		const {repo, range, judged, verdict} = withChild();
+		repo.git("merge", "--quiet", "--ff-only", "child");
+		repo.write("untouched.ts", "moved on\n");
+		repo.commit("an unjudged path changes");
+		expect(rederive(repo, range, judged, repo.rev("epic"))).toBe(verdict);
+	});
+
+	it("carries a rename's SOURCE path, so the rename is still detectable under the pathspec", () => {
+		const repo = openRepo();
+		repo.write("old.ts", "content\n");
+		const base = repo.commit("base");
+		repo.git("checkout", "--quiet", "-b", "child");
+		repo.git("mv", "old.ts", "new.ts");
+		const tip = repo.commit("rename");
+		repo.git("checkout", "--quiet", "epic");
+
+		const range: CommitRange = {base, tip};
+		const judged = pathsOf(repo, range);
+		expect(judged).toEqual(["new.ts", "old.ts"]);
+
+		repo.git("merge", "--quiet", "--ff-only", "child");
+		expect(rederive(repo, range, judged, repo.rev("epic"))).toBe(digestOf(repo, range));
+	});
+});

--- a/packages/fabrika-cli/src/wire/marker-line.ts
+++ b/packages/fabrika-cli/src/wire/marker-line.ts
@@ -1,0 +1,180 @@
+/**
+ * The parts every verdict marker is built from — the brands, the namespace grammar, and the walk
+ * from a comment body to `<namespace>: <polarity> …`.
+ *
+ * Two formats meet here: the PR-scoped marker (`./verdict-marker.ts`) and the range-scoped one
+ * (`./range-verdict-marker.ts`). What differs between them is the *binding* — a head SHA against a
+ * commit range — and nothing else, so everything up to and including the polarity, and everything
+ * from the clause separator on, is written once. A second copy of this walk would drift silently:
+ * both readers would still round-trip their own bytes while disagreeing about what a human wrote.
+ */
+
+import type {WireAbsent, WireMalformed} from "./format.ts";
+
+declare const HEAD_SHA: unique symbol;
+declare const CLAUSE: unique symbol;
+declare const CONTENT_DIGEST: unique symbol;
+
+/**
+ * A git object name a marker is bound to: 7–40 hex characters, lowercased.
+ *
+ * Branded so a `Found` cannot carry `""`. The abbreviation floor is 7 because that is what git
+ * itself abbreviates to and what v1's scanner accepted; shorter is ambiguous across a real
+ * repository, and an ambiguous binding is not a binding.
+ */
+export type HeadSha = string & {readonly [HEAD_SHA]: true};
+
+/** The trailing human clause. Branded for the same reason: a blank clause is not a clause. */
+export type Clause = string & {readonly [CLAUSE]: true};
+
+/**
+ * The digest of the content a verdict was formed over: exactly 12 lowercase hex.
+ *
+ * Fixed-width rather than a prefix match, unlike {@link HeadSha}: a SHA is abbreviated by the tools
+ * that print it, whereas this value only ever comes from `../review/content-binding.ts`, so a
+ * shorter-or-longer one is a drift and reads as `Malformed`, never as a value to compare loosely.
+ */
+export type ContentDigest = string & {readonly [CONTENT_DIGEST]: true};
+
+/** The reviewer's go/no-go. A third token is not a polarity — it is a drift. */
+export type Polarity = "PASS" | "FAIL";
+
+export const SHA_MIN = 7;
+export const SHA_MAX = 40;
+
+const HEX = /^[0-9a-f]+$/;
+const CONTENT_HEX = /^[0-9a-f]{12}$/;
+
+/** The content field's token, wherever it is read: on a marker line or off `wire emit`. */
+export const CONTENT_PREFIX = "content:";
+
+/** The conforming separator between the binding and the clause; the ASCII dashes are read tolerantly. */
+export const CLAUSE_SEPARATOR = "—";
+const SEPARATOR = /^(?:—|–|--|-)\s*/;
+
+/**
+ * The gates these formats serve: the `review` family, `check-epic-plan`, and `governance`.
+ *
+ * Each widening is additive — no existing marker's reading changes — and each namespace is its own
+ * family rather than a `review-<gate>` member, because a verdict wearing another gate's namespace is
+ * the family confusion the partition ruling removed (#4891). `governance` is admitted here (#5199)
+ * ahead of the verb that will emit it: `ship scope` already derives it as a required namespace, so a
+ * format that cannot carry it makes every governance-root PR permanently `blocked` at `ship gate`.
+ * Nothing here grants emission authority — `review post` still refuses any namespace this PR's diff
+ * did not derive, and `governance` is not in that image.
+ */
+const NAMESPACE = /^(review|check-epic-plan|governance)(-[a-z0-9]+)*$/;
+
+/** The one sentence both formats name the admitted namespaces by, so their refusals cannot drift. */
+export const NAMESPACE_PHRASE =
+	'"review", "review-<gate>", "check-epic-plan" or "governance"' as const;
+
+/**
+ * The prefixes {@link openMarkerLine}'s first gate admits, which must widen with {@link NAMESPACE}
+ * or a format can emit a marker it can never read back — the gate runs *before* the regex is tested.
+ */
+const NAMESPACE_PREFIXES = ["review", "check-epic-plan", "governance"];
+
+export const isGateNamespace = (namespace: string): boolean => NAMESPACE.test(namespace);
+
+/**
+ * The emphasis a skill's bolding adds, and the `<namespace>:` prefix.
+ *
+ * The namespace class is deliberately wider than {@link NAMESPACE}: a token this admits and
+ * {@link NAMESPACE} rejects becomes a `Malformed` naming the drift, one this turns away becomes an
+ * `Absent`. Erring wide is what keeps `review_code:` from being reported as "no verdict here".
+ */
+const MARKER_LINE = /^\s*(\*{0,2})\s*([A-Za-z0-9_-]+)\s*:\s*(.*)$/;
+
+export const headSha = (raw: string): HeadSha | null => {
+	const value = raw.trim().toLowerCase();
+	if (value.length < SHA_MIN || value.length > SHA_MAX || !HEX.test(value)) return null;
+	return value as HeadSha;
+};
+
+export const contentDigest = (raw: string): ContentDigest | null => {
+	const value = raw.trim().toLowerCase();
+	return CONTENT_HEX.test(value) ? (value as ContentDigest) : null;
+};
+
+export const clause = (raw: string): Clause | null => {
+	const value = raw.trim();
+	return value === "" ? null : (value as Clause);
+};
+
+export const polarityOf = (token: string): Polarity | null => {
+	const value = token.toUpperCase();
+	return value === "PASS" || value === "FAIL" ? value : null;
+};
+
+export const malformed = (reason: string, evidence: string): WireMalformed => ({
+	_tag: "Malformed",
+	reason,
+	evidence,
+});
+
+/** The marker is the artifact's first non-blank line — a marker merely quoted further down is not one. */
+const firstNonBlankLine = (artifact: string): string | null =>
+	artifact.split("\n").find((line) => line.trim() !== "") ?? null;
+
+export const takeToken = (rest: string): {readonly token: string; readonly after: string} => {
+	const trimmed = rest.trimStart();
+	const end = trimmed.search(/\s/);
+	return end === -1
+		? {token: trimmed, after: ""}
+		: {token: trimmed.slice(0, end), after: trimmed.slice(end)};
+};
+
+/** A line that opens a marker of this family: its emphasis, its namespace, and what follows. */
+export interface OpenedMarkerLine {
+	readonly _tag: "Open";
+	/** Quoted back in every later refusal, so a caller names the bytes it judged. */
+	readonly evidence: string;
+	readonly emphasis: string;
+	readonly namespace: string;
+	/** Everything after `<namespace>:`, starting at the polarity. */
+	readonly rest: string;
+}
+
+export type MarkerLineRead = OpenedMarkerLine | WireAbsent | WireMalformed;
+
+/** Walk a comment body to the marker line's namespace, or say it carries no marker of this family. */
+export const openMarkerLine = (artifact: string): MarkerLineRead => {
+	const line = firstNonBlankLine(artifact);
+	if (line === null) {
+		return {_tag: "Absent", reason: "the artifact holds no non-blank line to carry a marker"};
+	}
+	const matched = MARKER_LINE.exec(line);
+	const namespace = matched?.[2]?.toLowerCase() ?? "";
+	const reaches = NAMESPACE_PREFIXES.some((prefix) => namespace.startsWith(prefix));
+	if (matched === null || !reaches) {
+		return {
+			_tag: "Absent",
+			reason:
+				'the first line does not open with a "review…:", "check-epic-plan…:" or "governance…:" namespace — no marker of this format',
+		};
+	}
+	const evidence = `first line: "${line.trim()}"`;
+	return isGateNamespace(namespace)
+		? {_tag: "Open", evidence, emphasis: matched[1] ?? "", namespace, rest: matched[3] ?? ""}
+		: malformed(
+				`the gate namespace "${namespace}" is not kebab-case ${NAMESPACE_PHRASE}`,
+				evidence,
+			);
+};
+
+/**
+ * The trailing clause, once the binding has been taken off the line.
+ *
+ * A skill that bolds the whole marker closes it after the clause, so that closer belongs to the
+ * emphasis rather than to the human's sentence. Stripped only when the line opened with one.
+ */
+export const readClause = (remainder: string, emphasis: string): Clause | null => {
+	const tail = remainder.trim();
+	const unemphasized =
+		emphasis !== "" && tail.endsWith(emphasis) ? tail.slice(0, -emphasis.length) : tail;
+	return clause(unemphasized.replace(SEPARATOR, ""));
+};
+
+/** Whether two head SHAs name the same commit — a prefix match in whichever direction is shorter. */
+export const sameHead = (a: HeadSha, b: HeadSha): boolean => a.startsWith(b) || b.startsWith(a);

--- a/packages/fabrika-cli/src/wire/range-verdict-marker.ts
+++ b/packages/fabrika-cli/src/wire/range-verdict-marker.ts
@@ -1,0 +1,246 @@
+/**
+ * The range-scoped verdict marker — a verdict over a commit range, on the board.
+ *
+ *     review-child: PASS range:9f2c1ab..03135b9 content:2f1a9c4e0b7d — every criterion met
+ *
+ * A child's local review judges what its branch adds over the epic branch point, and its verdict
+ * lands on the child issue (verdicts live on GitHub, ADR 0283). The two SHAs it names stop being
+ * the epic branch's history the moment the range is merged in, so the durable claim is the
+ * **content digest**, not the range — and the range is what tells a later reader which paths that
+ * digest was taken over (`../review/content-binding.ts`, ADR 0276 + #5825).
+ *
+ * **The content field is mandatory here, and optional in `./verdict-marker.ts`.** That is not an
+ * inconsistency: a PR-scoped marker whose digest is absent falls back to head equality, which is the
+ * stricter rule; a range-scoped one has no such fallback, because the head it would fall back to is
+ * exactly the thing a merge takes away. A range marker with no digest binds nothing at all, so it
+ * is `Malformed` rather than a weaker verdict.
+ *
+ * **The two formats read each other's bytes as drift, loudly.** A range marker fed to
+ * `./verdict-marker.ts` is `Malformed` ("bound to no head SHA"), and a head-bound marker fed to
+ * this reader is `Malformed` ("carries no range"). Neither reads as `Absent`, so a verdict posted
+ * on the wrong surface surfaces as a broken marker instead of as a surface nobody reviewed. Both
+ * walk the same line grammar (`./marker-line.ts`), which is what keeps that symmetry true.
+ */
+
+import type {CommitRange} from "../io/git.ts";
+import type {NonEmptyReadonlyArray, WireEmit, WireRead, WireReadLines} from "./format.ts";
+import {
+	CLAUSE_SEPARATOR,
+	type Clause,
+	CONTENT_PREFIX,
+	type ContentDigest,
+	clause,
+	contentDigest,
+	type HeadSha,
+	headSha,
+	isGateNamespace,
+	malformed,
+	NAMESPACE_PHRASE,
+	openMarkerLine,
+	type Polarity,
+	polarityOf,
+	readClause,
+	SHA_MAX,
+	SHA_MIN,
+	takeToken,
+} from "./marker-line.ts";
+
+/** The range field's token, and the two dots inside it. */
+export const RANGE_PREFIX = "range:";
+const RANGE_SEPARATOR = "..";
+
+export interface RangeVerdictMarker {
+	/** The gate that formed the verdict — the same family as the PR-scoped marker's. */
+	readonly namespace: string;
+	readonly polarity: Polarity;
+	/** What the reviewer judged: everything `tip` adds since it diverged from `base`. */
+	readonly range: CommitRange<HeadSha>;
+	/** Never `null` — see the module docblock. */
+	readonly content: ContentDigest;
+	readonly clause: Clause;
+}
+
+export type RangeVerdictMarkerRead = WireRead<RangeVerdictMarker>;
+
+/**
+ * Split `<base>..<tip>` into two validated revisions.
+ *
+ * `indexOf` rather than `split`, so a three-dot spelling refuses instead of yielding a tip that
+ * opens with a stray dot: the digest is taken over a three-dot range, but the marker writes the
+ * two-dot form, and a reader that accepted both would let two spellings of the same claim exist.
+ */
+export const parseRange = (raw: string): CommitRange<HeadSha> | null => {
+	const at = raw.indexOf(RANGE_SEPARATOR);
+	if (at <= 0) return null;
+	const base = headSha(raw.slice(0, at));
+	const tip = headSha(raw.slice(at + RANGE_SEPARATOR.length));
+	return base === null || tip === null ? null : {base, tip};
+};
+
+export const renderRange = (range: CommitRange<HeadSha>): string =>
+	`${range.base}${RANGE_SEPARATOR}${range.tip}`;
+
+/** Read the range-scoped marker out of a comment body. Total: `Found` | `Absent` | `Malformed`. */
+export const read = (artifact: string): RangeVerdictMarkerRead => {
+	const opened = openMarkerLine(artifact);
+	if (opened._tag !== "Open") return opened;
+	const {evidence, emphasis, namespace, rest} = opened;
+
+	const {token: polarityToken, after: afterPolarity} = takeToken(rest);
+	if (polarityToken === "") {
+		return malformed(`"${namespace}:" carries no polarity — expected PASS or FAIL`, evidence);
+	}
+	const polarity = polarityOf(polarityToken);
+	if (polarity === null) {
+		return malformed(`"${polarityToken}" is not a polarity — expected PASS or FAIL`, evidence);
+	}
+
+	const {token: rangeToken, after: afterRange} = takeToken(afterPolarity);
+	if (!rangeToken.toLowerCase().startsWith(RANGE_PREFIX)) {
+		return malformed(
+			`the ${polarity} marker carries no range — expected ${RANGE_PREFIX}<base>${RANGE_SEPARATOR}<tip>`,
+			evidence,
+		);
+	}
+	const range = parseRange(rangeToken.slice(RANGE_PREFIX.length));
+	if (range === null) {
+		return malformed(
+			`"${rangeToken}" is not a range — expected two ${SHA_MIN}–${SHA_MAX} hex revisions around "${RANGE_SEPARATOR}"`,
+			evidence,
+		);
+	}
+
+	const {token: contentToken, after: afterContent} = takeToken(afterRange);
+	if (!contentToken.toLowerCase().startsWith(CONTENT_PREFIX)) {
+		return malformed(
+			`the ${polarity} range marker carries no content binding — the SHAs alone do not survive the merge`,
+			evidence,
+		);
+	}
+	const content = contentDigest(contentToken.slice(CONTENT_PREFIX.length));
+	if (content === null) {
+		return malformed(
+			`"${contentToken}" is not a content binding — expected ${CONTENT_PREFIX}<12 hex characters>`,
+			evidence,
+		);
+	}
+
+	const text = readClause(afterContent, emphasis);
+	if (text === null) {
+		return malformed(
+			"the marker carries no trailing clause — the one field that says what the verdict means to a human",
+			evidence,
+		);
+	}
+
+	return {_tag: "Found", value: {namespace, polarity, range, content, clause: text}};
+};
+
+/** Compose the marker's first line. Round-trips through {@link read}. */
+export const emit = ({
+	namespace,
+	polarity,
+	range,
+	content,
+	clause: text,
+}: RangeVerdictMarker): string =>
+	`${namespace}: ${polarity} ${RANGE_PREFIX}${renderRange(range)} ${CONTENT_PREFIX}${content} ${CLAUSE_SEPARATOR} ${text}\n`;
+
+export type RangeVerdictMarkerFields =
+	| {readonly _tag: "Fields"; readonly marker: RangeVerdictMarker}
+	| {readonly _tag: "Unusable"; readonly reason: string};
+
+/** `<key>: <value>` or `<key><TAB><value>`, so `wire read`'s own output pipes back into `wire emit`. */
+const FIELD_LINE = /^([A-Za-z-]+)[ \t]*[:\t][ \t]*(.*)$/;
+/** Every field is required — the range form has no optional half, which is the whole point of it. */
+const KEYS = ["namespace", "polarity", "base", "tip", "content", "clause"] as const;
+type FieldKey = (typeof KEYS)[number];
+
+const isFieldKey = (key: string): key is FieldKey => (KEYS as ReadonlyArray<string>).includes(key);
+
+/** Parse `emit`'s stdin into a marker: one `<key>: <value>` per line, in any order. */
+export const parseFields = (fields: string): RangeVerdictMarkerFields => {
+	const seen = new Map<FieldKey, string>();
+	for (const [index, raw] of fields.split("\n").entries()) {
+		const line = raw.trim();
+		if (line === "") continue;
+		const matched = FIELD_LINE.exec(line);
+		const key = matched?.[1]?.toLowerCase() ?? "";
+		if (matched === null || !isFieldKey(key)) {
+			return {
+				_tag: "Unusable",
+				reason: `line ${index + 1} is not a "<field>: <value>" line over ${KEYS.join(", ")}: "${line}"`,
+			};
+		}
+		if (seen.has(key)) {
+			return {
+				_tag: "Unusable",
+				reason: `"${key}" is given twice — which one is the field is undecidable`,
+			};
+		}
+		seen.set(key, matched[2] ?? "");
+	}
+
+	const missing = KEYS.filter((key) => (seen.get(key) ?? "").trim() === "");
+	if (missing.length > 0) {
+		return {
+			_tag: "Unusable",
+			reason: `no value for ${missing.join(", ")} — every field is required`,
+		};
+	}
+
+	const namespace = (seen.get("namespace") ?? "").trim().toLowerCase();
+	if (!isGateNamespace(namespace)) {
+		return {_tag: "Unusable", reason: `"${namespace}" is not a ${NAMESPACE_PHRASE} namespace`};
+	}
+	const polarity = polarityOf((seen.get("polarity") ?? "").trim());
+	if (polarity === null) {
+		return {
+			_tag: "Unusable",
+			reason: `"${seen.get("polarity")}" is not a polarity — expected PASS or FAIL`,
+		};
+	}
+	const base = headSha(seen.get("base") ?? "");
+	const tip = headSha(seen.get("tip") ?? "");
+	if (base === null || tip === null) {
+		return {
+			_tag: "Unusable",
+			reason: `"${seen.get(base === null ? "base" : "tip")}" is not a revision — expected ${SHA_MIN}–${SHA_MAX} hex characters`,
+		};
+	}
+	const content = contentDigest(seen.get("content") ?? "");
+	if (content === null) {
+		return {
+			_tag: "Unusable",
+			reason: `"${seen.get("content")}" is not a content digest — expected 12 hex characters; a range verdict may not omit it`,
+		};
+	}
+	const text = clause(seen.get("clause") ?? "");
+	if (text === null) return {_tag: "Unusable", reason: "the trailing clause is blank"};
+
+	return {_tag: "Fields", marker: {namespace, polarity, range: {base, tip}, content, clause: text}};
+};
+
+/** One `<field>\t<value>` line per field — the `wire read` answer for this format. */
+export const renderMarker = (marker: RangeVerdictMarker): NonEmptyReadonlyArray<string> => [
+	`namespace\t${marker.namespace}`,
+	`polarity\t${marker.polarity}`,
+	`base\t${marker.range.base}`,
+	`tip\t${marker.range.tip}`,
+	`content\t${marker.content}`,
+	`clause\t${marker.clause}`,
+];
+
+/** The registry row's byte-level `emit`, bound to this module's typed core. */
+export const emitFromFields = (fields: string): WireEmit => {
+	const parsed = parseFields(fields);
+	return parsed._tag === "Fields"
+		? {_tag: "Composed", bytes: emit(parsed.marker)}
+		: {_tag: "Unusable", reason: parsed.reason};
+};
+
+/** The registry row's byte-level `read`, bound to this module's typed core. */
+export const readToLines = (artifact: string): WireReadLines => {
+	const result = read(artifact);
+	return result._tag === "Found" ? {_tag: "Found", value: renderMarker(result.value)} : result;
+};

--- a/packages/fabrika-cli/src/wire/range-verdict-marker.unit.test.ts
+++ b/packages/fabrika-cli/src/wire/range-verdict-marker.unit.test.ts
@@ -1,0 +1,195 @@
+/**
+ * The range-scoped marker's own tier: `emit`, the three answers `read` may give, and the two-format
+ * boundary.
+ *
+ * The assertions that carry the design are the ones about the **mandatory** content field and about
+ * what each reader does with the other's bytes. A range marker whose digest went missing binds
+ * nothing — the SHAs it names do not survive the merge it exists to survive — so it must read
+ * `Malformed` rather than as a weaker verdict, and a head-bound marker must not read as a range one.
+ */
+import {describe, expect, it} from "vitest";
+import {clause, contentDigest, headSha} from "./marker-line.ts";
+import {
+	emit,
+	emitFromFields,
+	parseFields,
+	parseRange,
+	type RangeVerdictMarker,
+	read,
+	readToLines,
+	renderMarker,
+} from "./range-verdict-marker.ts";
+import {read as readHeadMarker} from "./verdict-marker.ts";
+
+const sha = (raw: string) => {
+	const value = headSha(raw);
+	if (value === null) throw new Error(`fixture is not a revision: ${raw}`);
+	return value;
+};
+const digest = (raw: string) => {
+	const value = contentDigest(raw);
+	if (value === null) throw new Error(`fixture is not a content digest: ${raw}`);
+	return value;
+};
+const text = (raw: string) => {
+	const value = clause(raw);
+	if (value === null) throw new Error("fixture clause is blank");
+	return value;
+};
+
+const BASE = "9f2c1ab7d4a2c6f1b8093a5c4d2e1f6a7b8c9d01";
+const TIP = "03135b91e7d4a2c6f1b8093a5c4d2e1f6a7b8c9d";
+const CONTENT = "2f1a9c4e0b7d";
+
+const MARKER: RangeVerdictMarker = {
+	namespace: "review-child",
+	polarity: "PASS",
+	range: {base: sha(BASE), tip: sha(TIP)},
+	content: digest(CONTENT),
+	clause: text("every criterion met"),
+};
+
+const found = (artifact: string): RangeVerdictMarker => {
+	const result = read(artifact);
+	if (result._tag !== "Found") throw new Error(`expected Found, got ${result._tag}`);
+	return result.value;
+};
+
+describe("emit", () => {
+	it("composes the one recognizable first line", () => {
+		expect(emit(MARKER)).toBe(
+			`review-child: PASS range:${BASE}..${TIP} content:${CONTENT} — every criterion met\n`,
+		);
+	});
+
+	it("round-trips: every field emitted is a field `read` recovers", () => {
+		expect(found(emit(MARKER))).toEqual(MARKER);
+	});
+});
+
+describe("read", () => {
+	it("reads the marker off the first line of a comment that then explains itself", () => {
+		const body = `${emit(MARKER)}\nThe range is the child's branch over the epic branch point.\n`;
+		expect(found(body)).toEqual(MARKER);
+	});
+
+	it("reads a bolded marker, closer and all", () => {
+		expect(found(`**review-child: PASS range:${BASE}..${TIP} content:${CONTENT} — done**`)).toEqual(
+			{...MARKER, clause: text("done")},
+		);
+	});
+
+	it("lowercases the revisions, so one commit has one spelling", () => {
+		expect(
+			found(`review-child: pass range:${BASE.toUpperCase()}..${TIP} content:${CONTENT} — done`)
+				.range.base,
+		).toBe(BASE);
+	});
+
+	it("is Absent — not Malformed — on a comment carrying no marker of this family", () => {
+		expect(read("Thanks — this reads well to me, no notes.\n")._tag).toBe("Absent");
+	});
+
+	/** Each of these would be a plausible PASS to a lenient reader, which is why each is pinned. */
+	const drifts = [
+		[
+			"no content digest at all — the range form's one refusal",
+			`review-child: PASS range:${BASE}..${TIP} — done`,
+		],
+		[
+			"a content digest that is not 12 hex",
+			`review-child: PASS range:${BASE}..${TIP} content:2f1a — done`,
+		],
+		["a head-bound marker, read here", `review-child: PASS @ ${TIP} content:${CONTENT} — done`],
+		["a range naming one revision", `review-child: PASS range:${TIP} content:${CONTENT} — done`],
+		["a range with an empty side", `review-child: PASS range:..${TIP} content:${CONTENT} — done`],
+		[
+			"a three-dot range, which is not the marker's spelling",
+			`review-child: PASS range:${BASE}...${TIP} content:${CONTENT} — done`,
+		],
+		[
+			"a revision too short to name one commit",
+			`review-child: PASS range:03135..${TIP} content:${CONTENT} — done`,
+		],
+		[
+			"a polarity nobody defined",
+			`review-child: APPROVED range:${BASE}..${TIP} content:${CONTENT} — done`,
+		],
+		[
+			"a namespace that is not kebab-case",
+			`review_child: PASS range:${BASE}..${TIP} content:${CONTENT} — done`,
+		],
+		["no trailing clause", `review-child: PASS range:${BASE}..${TIP} content:${CONTENT}`],
+	] as const;
+
+	for (const [name, line] of drifts) {
+		it(`is Malformed on ${name}`, () => {
+			const result = read(`${line}\n`);
+			expect(result._tag).toBe("Malformed");
+			if (result._tag === "Malformed") expect(result.reason).not.toBe("");
+		});
+	}
+});
+
+/**
+ * The two formats partition the surface loudly. Either reader answering `Absent` over the other's
+ * bytes is what would make a verdict posted on the wrong surface look like no verdict at all.
+ */
+describe("the boundary with the PR-scoped marker", () => {
+	it("reads a range marker as Malformed over there, never as Absent", () => {
+		expect(readHeadMarker(emit(MARKER))._tag).toBe("Malformed");
+	});
+
+	it("reads a head-bound marker as Malformed here, never as Absent", () => {
+		expect(read(`review-code: PASS @ ${TIP} content:${CONTENT} — merge-ready\n`)._tag).toBe(
+			"Malformed",
+		);
+	});
+});
+
+describe("parseRange", () => {
+	it("refuses a three-dot spelling rather than reading a tip that opens with a dot", () => {
+		expect(parseRange(`${BASE}...${TIP}`)).toBeNull();
+	});
+
+	it("takes the FIRST separator, so a trailing one cannot silently retarget the tip", () => {
+		expect(parseRange(`${BASE}..${TIP}..${BASE}`)).toBeNull();
+	});
+});
+
+describe("parseFields", () => {
+	const FIELDS = `namespace: review-child\npolarity: PASS\nbase: ${BASE}\ntip: ${TIP}\ncontent: ${CONTENT}\nclause: every criterion met\n`;
+
+	it("composes the marker `read` recovers, from fields in any order", () => {
+		const parsed = parseFields(FIELDS.split("\n").reverse().join("\n"));
+		expect(parsed._tag === "Fields" && parsed.marker).toEqual(MARKER);
+	});
+
+	it("refuses a missing content field — a range verdict may not omit its binding", () => {
+		const parsed = parseFields(FIELDS.replace(`content: ${CONTENT}\n`, ""));
+		expect(parsed._tag).toBe("Unusable");
+		expect(parsed._tag === "Unusable" && parsed.reason).toContain("content");
+	});
+
+	it("refuses a field given twice rather than picking one", () => {
+		expect(parseFields(`${FIELDS}tip: ${BASE}\n`)._tag).toBe("Unusable");
+	});
+
+	it("refuses an unknown field rather than dropping it", () => {
+		expect(parseFields(`${FIELDS}sha: ${TIP}\n`)._tag).toBe("Unusable");
+	});
+});
+
+describe("the registry adapters", () => {
+	it("emit → read is a round-trip through the byte-level pair", () => {
+		const composed = emitFromFields(
+			`namespace: review-child\npolarity: FAIL\nbase: ${BASE}\ntip: ${TIP}\ncontent: ${CONTENT}\nclause: two criteria unmet\n`,
+		);
+		expect(composed._tag).toBe("Composed");
+		if (composed._tag !== "Composed") return;
+		expect(readToLines(composed.bytes)).toEqual({
+			_tag: "Found",
+			value: renderMarker({...MARKER, polarity: "FAIL", clause: text("two criteria unmet")}),
+		});
+	});
+});

--- a/packages/fabrika-cli/src/wire/registry.ts
+++ b/packages/fabrika-cli/src/wire/registry.ts
@@ -29,6 +29,7 @@ import * as grillSupersede from "./grill-supersede.ts";
 import * as handoffPack from "./handoff-pack.ts";
 import * as laneBrief from "./lane-brief.ts";
 import * as mapTicket from "./map-ticket.ts";
+import * as rangeVerdictMarker from "./range-verdict-marker.ts";
 import * as verdictMarker from "./verdict-marker.ts";
 
 export const registeredFormats: ReadonlyArray<WireFormat> = [
@@ -189,6 +190,71 @@ export const registeredFormats: ReadonlyArray<WireFormat> = [
 			],
 		},
 		brands: brandWitnesses<verdictMarker.VerdictMarker>({sha: true, clause: true, polarity: true}),
+	},
+	{
+		key: "range-verdict-marker",
+		purpose:
+			"the range-bound first line of a child's verdict on its own issue — namespace, polarity, the commit range judged, and the content digest that outlives the merge of that range",
+		module: "packages/fabrika-cli/src/wire/range-verdict-marker.ts",
+		producers: ["review"],
+		consumers: ["build", "operate"],
+		emit: rangeVerdictMarker.emitFromFields,
+		read: rangeVerdictMarker.readToLines,
+		fixtures: {
+			roundTrip: {
+				fields:
+					"namespace: review-child\npolarity: PASS\nbase: 9f2c1ab\ntip: 03135b91\ncontent: 2f1a9c4e0b7d\nclause: every criterion met\n",
+				values: [
+					"review-child",
+					"PASS",
+					"9f2c1ab",
+					"03135b91",
+					"2f1a9c4e0b7d",
+					"every criterion met",
+				],
+			},
+			found: [
+				{
+					shape: "the marker as a child reviewer posts it — first line of a comment on the issue",
+					artifact:
+						"review-child: PASS range:9f2c1ab..03135b91 content:2f1a9c4e0b7d — every criterion met\n\nThe range is the child's branch over the epic branch point.\n",
+					values: [
+						"review-child",
+						"PASS",
+						"9f2c1ab",
+						"03135b91",
+						"2f1a9c4e0b7d",
+						"every criterion met",
+					],
+				},
+			],
+			absent: "Thanks — this reads well to me, no notes.\n",
+			malformed: [
+				{
+					drift: "the range form carries no content digest, so nothing survives the merge",
+					artifact: "review-child: PASS range:9f2c1ab..03135b91 — every criterion met\n",
+				},
+				{
+					drift: "a head-bound marker read as a range one",
+					artifact: "review-child: PASS @ 03135b91 content:2f1a9c4e0b7d — every criterion met\n",
+				},
+				{
+					drift: "the range names one revision",
+					artifact:
+						"review-child: PASS range:03135b91 content:2f1a9c4e0b7d — every criterion met\n",
+				},
+				{
+					drift: "the namespace is not kebab-case",
+					artifact:
+						"review_child: PASS range:9f2c1ab..03135b91 content:2f1a9c4e0b7d — every criterion met\n",
+				},
+			],
+		},
+		brands: brandWitnesses<rangeVerdictMarker.RangeVerdictMarker>({
+			polarity: true,
+			content: true,
+			clause: true,
+		}),
 	},
 	{
 		key: "lane-brief",

--- a/packages/fabrika-cli/src/wire/verdict-marker.ts
+++ b/packages/fabrika-cli/src/wire/verdict-marker.ts
@@ -31,34 +31,37 @@
  */
 
 import type {NonEmptyReadonlyArray, WireEmit, WireRead, WireReadLines} from "./format.ts";
+import {
+	CLAUSE_SEPARATOR,
+	type Clause,
+	CONTENT_PREFIX,
+	type ContentDigest,
+	clause,
+	contentDigest,
+	type HeadSha,
+	headSha,
+	isGateNamespace,
+	malformed,
+	NAMESPACE_PHRASE,
+	openMarkerLine,
+	type Polarity,
+	polarityOf,
+	readClause,
+	SHA_MAX,
+	SHA_MIN,
+	sameHead,
+	takeToken,
+} from "./marker-line.ts";
 
-declare const HEAD_SHA: unique symbol;
-declare const CLAUSE: unique symbol;
-declare const CONTENT_DIGEST: unique symbol;
-
-/**
- * A git object name the marker is bound to: 7–40 hex characters, lowercased.
- *
- * Branded so a `Found` cannot carry `""`. The abbreviation floor is 7 because that is what git
- * itself abbreviates to and what v1's scanner accepted; shorter is ambiguous across a real
- * repository, and an ambiguous binding is not a binding.
- */
-export type HeadSha = string & {readonly [HEAD_SHA]: true};
-
-/** The trailing human clause. Branded for the same reason: a blank clause is not a clause. */
-export type Clause = string & {readonly [CLAUSE]: true};
-
-/**
- * The digest of the content the verdict was formed over: exactly 12 lowercase hex.
- *
- * Fixed-width rather than a prefix match, unlike {@link HeadSha}: a SHA is abbreviated by the tools
- * that print it, whereas this value only ever comes from `review/content-binding.ts`, so a
- * shorter-or-longer one is a drift and reads as `Malformed`, never as a value to compare loosely.
- */
-export type ContentDigest = string & {readonly [CONTENT_DIGEST]: true};
-
-/** The reviewer's go/no-go. A third token is not a polarity — it is a drift. */
-export type Polarity = "PASS" | "FAIL";
+export type {Clause, ContentDigest, HeadSha, Polarity} from "./marker-line.ts";
+export {
+	CLAUSE_SEPARATOR,
+	CONTENT_PREFIX,
+	clause,
+	contentDigest,
+	headSha,
+	sameHead,
+} from "./marker-line.ts";
 
 export interface VerdictMarker {
 	/**
@@ -75,84 +78,6 @@ export interface VerdictMarker {
 
 export type VerdictMarkerRead = WireRead<VerdictMarker>;
 
-const SHA_MIN = 7;
-const SHA_MAX = 40;
-
-/**
- * The gates this format serves: the `review` family, `check-epic-plan`, and `governance`.
- *
- * Each widening is additive — no existing marker's reading changes — and each namespace is its own
- * family rather than a `review-<gate>` member, because a verdict wearing another gate's namespace is
- * the family confusion the partition ruling removed (#4891). `governance` is admitted here (#5199)
- * ahead of the verb that will emit it: `ship scope` already derives it as a required namespace, so a
- * format that cannot carry it makes every governance-root PR permanently `blocked` at `ship gate`.
- * Nothing here grants emission authority — `review post` still refuses any namespace this PR's diff
- * did not derive, and `governance` is not in that image.
- */
-const NAMESPACE = /^(review|check-epic-plan|governance)(-[a-z0-9]+)*$/;
-/**
- * The prefixes {@link read}'s first gate admits, which must widen with {@link NAMESPACE} or the
- * format can emit a marker it can never read back — the gate runs *before* the regex is ever tested.
- */
-const NAMESPACE_PREFIXES = ["review", "check-epic-plan", "governance"];
-const HEX = /^[0-9a-f]+$/;
-
-/** The optional content field's token, wherever it is read: on the marker line or off `wire emit`. */
-export const CONTENT_PREFIX = "content:";
-const CONTENT_HEX = /^[0-9a-f]{12}$/;
-
-/** The conforming separator between the SHA and the clause; the ASCII dashes are read tolerantly. */
-export const CLAUSE_SEPARATOR = "—";
-const SEPARATOR = /^(?:—|–|--|-)\s*/;
-
-/**
- * The emphasis a skill's bolding adds, and the `<namespace>:` prefix.
- *
- * The namespace class is deliberately wider than {@link NAMESPACE}: a token this admits and
- * {@link NAMESPACE} rejects becomes a `Malformed` naming the drift, one this turns away becomes an
- * `Absent`. Erring wide is what keeps `review_code:` from being reported as "no verdict here".
- */
-const MARKER_LINE = /^\s*(\*{0,2})\s*([A-Za-z0-9_-]+)\s*:\s*(.*)$/;
-
-export const headSha = (raw: string): HeadSha | null => {
-	const value = raw.trim().toLowerCase();
-	if (value.length < SHA_MIN || value.length > SHA_MAX || !HEX.test(value)) return null;
-	return value as HeadSha;
-};
-
-export const contentDigest = (raw: string): ContentDigest | null => {
-	const value = raw.trim().toLowerCase();
-	return CONTENT_HEX.test(value) ? (value as ContentDigest) : null;
-};
-
-export const clause = (raw: string): Clause | null => {
-	const value = raw.trim();
-	return value === "" ? null : (value as Clause);
-};
-
-const polarityOf = (token: string): Polarity | null => {
-	const value = token.toUpperCase();
-	return value === "PASS" || value === "FAIL" ? value : null;
-};
-
-const malformed = (reason: string, evidence: string): VerdictMarkerRead => ({
-	_tag: "Malformed",
-	reason,
-	evidence,
-});
-
-/** The marker is the artifact's first non-blank line — a marker merely quoted further down is not one. */
-const firstNonBlankLine = (artifact: string): string | null =>
-	artifact.split("\n").find((line) => line.trim() !== "") ?? null;
-
-const takeToken = (rest: string): {readonly token: string; readonly after: string} => {
-	const trimmed = rest.trimStart();
-	const end = trimmed.search(/\s/);
-	return end === -1
-		? {token: trimmed, after: ""}
-		: {token: trimmed.slice(0, end), after: trimmed.slice(end)};
-};
-
 /**
  * Read the verdict marker out of a comment body. Total: `Found` | `Absent` | `Malformed`.
  *
@@ -161,31 +86,10 @@ const takeToken = (rest: string): {readonly token: string; readonly after: strin
  * and telling a reviewer which half of its own marker is wrong is the whole value of the refusal.
  */
 export const read = (artifact: string): VerdictMarkerRead => {
-	const line = firstNonBlankLine(artifact);
-	if (line === null) {
-		return {_tag: "Absent", reason: "the artifact holds no non-blank line to carry a marker"};
-	}
+	const opened = openMarkerLine(artifact);
+	if (opened._tag !== "Open") return opened;
+	const {evidence, emphasis, namespace, rest} = opened;
 
-	const matched = MARKER_LINE.exec(line);
-	const namespace = matched?.[2]?.toLowerCase() ?? "";
-	const reaches = NAMESPACE_PREFIXES.some((prefix) => namespace.startsWith(prefix));
-	if (matched === undefined || matched === null || !reaches) {
-		return {
-			_tag: "Absent",
-			reason:
-				'the first line does not open with a "review…:", "check-epic-plan…:" or "governance…:" namespace — no marker of this format',
-		};
-	}
-	const evidence = `first line: "${line.trim()}"`;
-	if (!NAMESPACE.test(namespace)) {
-		return malformed(
-			`the gate namespace "${namespace}" is not kebab-case "review", "review-<gate>", "check-epic-plan" or "governance"`,
-			evidence,
-		);
-	}
-
-	const emphasis = matched[1] ?? "";
-	const rest = matched[3] ?? "";
 	const {token: polarityToken, after: afterPolarity} = takeToken(rest);
 	if (polarityToken === "") {
 		return malformed(`"${namespace}:" carries no polarity — expected PASS or FAIL`, evidence);
@@ -235,12 +139,7 @@ export const read = (artifact: string): VerdictMarkerRead => {
 		remainder = afterContent.after;
 	}
 
-	// A skill that bolds the whole marker closes it after the clause, so that closer belongs to the
-	// emphasis rather than to the human's sentence. Stripped only when the line opened with one.
-	const tail = remainder.trim();
-	const unemphasized =
-		emphasis !== "" && tail.endsWith(emphasis) ? tail.slice(0, -emphasis.length) : tail;
-	const text = clause(unemphasized.replace(SEPARATOR, ""));
+	const text = readClause(remainder, emphasis);
 	if (text === null) {
 		return malformed(
 			"the marker carries no trailing clause — the one field that says what the verdict means to a human",
@@ -270,15 +169,6 @@ export type Binding =
 	| {readonly _tag: "Current"; readonly sha: HeadSha; readonly via: "head" | "content"}
 	| {readonly _tag: "Stale"; readonly markerSha: HeadSha; readonly head: HeadSha}
 	| {readonly _tag: "Unbindable"; readonly reason: string};
-
-/**
- * Whether two head SHAs name the same commit. Either side may be abbreviated, so the match is a
- * prefix in whichever direction is shorter.
- *
- * Exported because {@link bindToHead} is not the only caller: `eval-record.ts` asks the same question
- * of a payload against its own marker line. One copy, so the prefix rule cannot drift between them.
- */
-export const sameHead = (a: HeadSha, b: HeadSha): boolean => a.startsWith(b) || b.startsWith(a);
 
 export const bindToHead = (marker: VerdictMarker, head: string): Binding => {
 	const resolved = headSha(head);
@@ -398,11 +288,8 @@ export const parseFields = (fields: string): VerdictMarkerFields => {
 	}
 
 	const namespace = (seen.get("namespace") ?? "").trim().toLowerCase();
-	if (!NAMESPACE.test(namespace)) {
-		return {
-			_tag: "Unusable",
-			reason: `"${namespace}" is not a "review", "review-<gate>", "check-epic-plan" or "governance" namespace`,
-		};
+	if (!isGateNamespace(namespace)) {
+		return {_tag: "Unusable", reason: `"${namespace}" is not a ${NAMESPACE_PHRASE} namespace`};
 	}
 	const polarity = polarityOf((seen.get("polarity") ?? "").trim());
 	if (polarity === null) {


### PR DESCRIPTION
A child's local review judges a commit range on the child's branch, and its verdict names two SHAs.
The moment that range is merged into the epic branch, those SHAs stop being the branch's history and
the verdict dies over content nobody changed. This adds the range scope to ADR 0276's content
binding so the durable claim is the digest, not the SHAs.

**The digest.** `rangeContentAt` hashes the same `git diff --raw` records ADR 0276 already
serializes, over `<base>...<tip>` — no second serialization — and returns the judged paths alongside
it. `rangeDigestOnto` re-derives that digest from a later state, `<base>...<state>` limited to those
paths: unlimited, the epic branch's other children would move it on every sibling merge.

**The rule.** `bindRange` answers `Current` / `Stale` / `Unbindable` with the same non-folding
`bindToContent` has — a derivation that could not be made is UNKNOWN, never a permissive read. A
state that carries none of the judged change is `Stale` (the change is gone), distinct from a read
that failed (`Unbindable`), because those two send an operator to opposite places.

**The grammar.** `wire/range-verdict-marker.ts` carries
`review-child: PASS range:<base>..<tip> content:<12hex> — <clause>`, registered as a wire format so
it emits and reads through the same seam every other format does. The content field is **mandatory**
here and optional in the PR-scoped marker: absence of a binding falls back to head equality there,
which is the stricter rule, and falls back to nothing here. Each reader reads the other's bytes as
`Malformed`, never `Absent`, so a verdict posted on the wrong surface is a broken marker rather than
a surface nobody reviewed.

**Verified against real git, not reasoned about.** `review/range-durability.git.test.ts` builds a
throwaway repository and runs the merges: the digest holds across a fast-forward and across a clean
merge that preserves the judged blobs (while the unlimited read over the same commit moves, which is
the pathspec earning its place), and moves on a conflicted-then-resolved merge and on a later commit
touching a judged path. A rename case pins why both sides of a rename are in the pathspec.

Nothing is wired into `lane prove` — that is the prove child's job. The PR-scoped path is untouched
in behaviour: every existing verdict-marker test passes unchanged.

## Deviations

- **Out-of-scope change** — **Said:** #5825 names `review/content-binding.ts` and a marker grammar.
  **Did:** also split the shared marker-line grammar out of `wire/verdict-marker.ts` into
  `wire/marker-line.ts`, which both readers now sit on. **Why:** the range reader needs the same
  first-line walk, the same brands and the same namespace rule; a second copy would let the two
  readers drift while each round-trips its own bytes perfectly. **Disposition:** stated here — the
  move is mechanical, `verdict-marker.ts` re-exports every symbol it exported before, and its own
  test file is unchanged.
- **Out-of-scope change** — **Said:** ship the pure functions plus the grammar. **Did:** also
  registered the format in `wire/registry.ts` and wrote its narrative section in
  `claude-plugins/fabrika/docs/wire-formats.md`. **Why:** that registry is how a wire format exists
  at all in this package, and `fabrika wire index` reds on a registered format with no section.
  **Disposition:** stated here.
- **Out-of-scope change** — **Said:** extend the content binding. **Did:** also added `CommitRange`
  and an exported `rawDiffArgs` to `io/git.ts`, and an optional pathspec to `diffRangeRaw`.
  **Why:** the re-derivation is a path-limited read, and the real-git test must run the *same* argv
  production runs — a test that re-types the flags proves a serialization nothing computes.
  **Disposition:** stated here; the existing two-argument call sites are unchanged.

Fixes #5825
