### PR TITLE
feat: in-run merge collision is a routed machine state with a repair spawn, never a merge-queue ejection

### DIFF
--- a/packages/fabrika-cli/src/lane/__fixtures__/epic-4300.workflow.golden.txt
+++ b/packages/fabrika-cli/src/lane/__fixtures__/epic-4300.workflow.golden.txt
@@ -43,7 +43,23 @@
 							},
 							"review": {
 								"on": {
-									"ISSUE_4301.PASS": "landed",
+									"ISSUE_4301.PASS": "integrate",
+									"ISSUE_4301.BLOCKED": "blocked",
+									"ISSUE_4301.FAIL": [
+										{
+											"target": "build",
+											"guard": "retriesRemaining",
+											"actions": "incrementRetries"
+										},
+										{
+											"target": "frozen"
+										}
+									]
+								}
+							},
+							"integrate": {
+								"on": {
+									"ISSUE_4301.DONE": "landed",
 									"ISSUE_4301.BLOCKED": "blocked",
 									"ISSUE_4301.FAIL": [
 										{
@@ -90,7 +106,23 @@
 							},
 							"review": {
 								"on": {
-									"ISSUE_4302.PASS": "landed",
+									"ISSUE_4302.PASS": "integrate",
+									"ISSUE_4302.BLOCKED": "blocked",
+									"ISSUE_4302.FAIL": [
+										{
+											"target": "build",
+											"guard": "retriesRemaining",
+											"actions": "incrementRetries"
+										},
+										{
+											"target": "frozen"
+										}
+									]
+								}
+							},
+							"integrate": {
+								"on": {
+									"ISSUE_4302.DONE": "landed",
 									"ISSUE_4302.BLOCKED": "blocked",
 									"ISSUE_4302.FAIL": [
 										{
@@ -151,7 +183,23 @@
 							},
 							"review": {
 								"on": {
-									"ISSUE_4303.PASS": "landed",
+									"ISSUE_4303.PASS": "integrate",
+									"ISSUE_4303.BLOCKED": "blocked",
+									"ISSUE_4303.FAIL": [
+										{
+											"target": "build",
+											"guard": "retriesRemaining",
+											"actions": "incrementRetries"
+										},
+										{
+											"target": "frozen"
+										}
+									]
+								}
+							},
+							"integrate": {
+								"on": {
+									"ISSUE_4303.DONE": "landed",
 									"ISSUE_4303.BLOCKED": "blocked",
 									"ISSUE_4303.FAIL": [
 										{

--- a/packages/fabrika-cli/src/lane/emit.ts
+++ b/packages/fabrika-cli/src/lane/emit.ts
@@ -10,10 +10,11 @@
  * phase after the last of them.
  *
  * **One epic run is one branch and one PR** (ADR 0285). A child's region is the local loop only —
- * `queued → build → review`, PASS landing that child's commits on the shared branch — and the merge
- * lives once, in the tail phase's single epic-level region (`review → ship → shipped`). The tail is
- * a *phase* rather than a bare state because `machine.ts` reads the workflow's two terminals off the
- * last phase's `onDone` pair; shaped this way the compiler needs no change at all.
+ * `queued → build → review → integrate`, the integrate step merging the child's range into the epic
+ * branch — and the merge to `main` lives once, in the tail phase's single epic-level region
+ * (`review → ship → shipped`). The tail is a *phase* rather than a bare state because `machine.ts`
+ * reads the workflow's two terminals off the last phase's `onDone` pair; shaped this way the
+ * compiler needs no change at all.
  *
  * Determinism is by construction: phases ascend, children within a phase ascend, every object's
  * keys are inserted in one fixed order, and the serialization is a single `JSON.stringify` — the
@@ -60,6 +61,14 @@ const initialFor = (link: SubIssueLink): "queued" | "landed" | "frozen" => {
  * It ends at `landed`: the child's commits are on the epic's shared branch and nothing was pushed,
  * reviewed on GitHub or merged. There is no per-child `ship` and no per-child `human:cp-approval`
  * because there is no per-child PR to ship or to gate (ADR 0285).
+ *
+ * `integrate` is the merge of the reviewed range into the epic branch, and it is a *state* so that a
+ * collision between two children resolves inside the run: its `FAIL` — a textual conflict, or a
+ * failed post-merge check, which is the semantic collision — re-enters `build` under the same
+ * guarded-FAIL retry array `review` uses, and exhausts into `frozen`. No route from it reaches a
+ * merge queue, and none reaches `landed` without passing back through `review`: post-resolution
+ * content is not what the range verdict judged, so the verdict is re-proven before the landing
+ * rather than after it.
  */
 const region = (ns: string, initial: "queued" | "landed" | "frozen"): Record<string, unknown> => ({
 	initial,
@@ -68,7 +77,17 @@ const region = (ns: string, initial: "queued" | "landed" | "frozen"): Record<str
 		build: {on: {[`${ns}.DONE`]: "review", [`${ns}.BLOCKED`]: "blocked"}},
 		review: {
 			on: {
-				[`${ns}.PASS`]: "landed",
+				[`${ns}.PASS`]: "integrate",
+				[`${ns}.BLOCKED`]: "blocked",
+				[`${ns}.FAIL`]: [
+					{target: "build", guard: "retriesRemaining", actions: "incrementRetries"},
+					{target: "frozen"},
+				],
+			},
+		},
+		integrate: {
+			on: {
+				[`${ns}.DONE`]: "landed",
 				[`${ns}.BLOCKED`]: "blocked",
 				[`${ns}.FAIL`]: [
 					{target: "build", guard: "retriesRemaining", actions: "incrementRetries"},

--- a/packages/fabrika-cli/src/lane/emit.unit.test.ts
+++ b/packages/fabrika-cli/src/lane/emit.unit.test.ts
@@ -6,6 +6,7 @@ import {Effect} from "effect";
 import {describe, expect, it} from "vitest";
 import {fakeFs} from "../fakes.test-support.ts";
 import {readGoldenFixture} from "../golden-fixture.ts";
+import {RETRY_BUDGET} from "../retry-budget.ts";
 import {type EmitResult, emitMachine} from "./emit.ts";
 import {applyEvent, deriveStatus, foldLog, type LogEntry} from "./fold.ts";
 import {type CompiledLane, compileText} from "./machine.ts";
@@ -76,17 +77,19 @@ const drive = (
 	return deriveStatus(compiled, statesOf(log));
 };
 
+/** One child driven queued → build → review → integrate → landed. */
+const land = (task: string): ReadonlyArray<readonly [string, string]> => [
+	[task, "WIP"],
+	[task, "DONE"],
+	[task, "PASS"],
+	[task, "DONE"],
+];
+
 /** Every child through its local loop to `landed`, in phase order. */
 const LAND_ALL: ReadonlyArray<readonly [string, string]> = [
-	["issue_4301", "WIP"],
-	["issue_4301", "DONE"],
-	["issue_4301", "PASS"],
-	["issue_4302", "WIP"],
-	["issue_4302", "DONE"],
-	["issue_4302", "PASS"],
-	["issue_4303", "WIP"],
-	["issue_4303", "DONE"],
-	["issue_4303", "PASS"],
+	...land("issue_4301"),
+	...land("issue_4302"),
+	...land("issue_4303"),
 ];
 
 describe("emitMachine", () => {
@@ -95,9 +98,9 @@ describe("emitMachine", () => {
 	});
 
 	it("is deterministic — the same body bytes emit the same machine bytes", () => {
-		expect(emitted(emitMachine(4300, body(), CHILDREN))).toBe(
-			emitted(emitMachine(4300, body(), CHILDREN)),
-		);
+		const text = emitted(emitMachine(4300, body(), CHILDREN));
+		expect(text).toBe(emitted(emitMachine(4300, body(), CHILDREN)));
+		expect(text.match(/"integrate": \{/g)).toHaveLength(CHILDREN.length);
 	});
 
 	it("is deterministic over a partly-built epic too — the child states are input, not drift", () => {
@@ -179,6 +182,7 @@ describe("emitMachine", () => {
 			"queued",
 			"build",
 			"review",
+			"integrate",
 			"blocked",
 			"hist",
 			"landed",
@@ -186,7 +190,26 @@ describe("emitMachine", () => {
 		]);
 	});
 
-	it("lands a child's review PASS locally — the success final asserts a landing, not a merge", () => {
+	it("routes an integrate collision back into the local loop — no arm reaches a merge queue", () => {
+		const child = regionOf(emitted(emitMachine(4300, body(), CHILDREN)), "issue_4301");
+		expect(child).toMatchObject({
+			states: {
+				review: {on: {"ISSUE_4301.PASS": "integrate"}},
+				integrate: {
+					on: {
+						"ISSUE_4301.DONE": "landed",
+						"ISSUE_4301.BLOCKED": "blocked",
+						"ISSUE_4301.FAIL": [
+							{target: "build", guard: "retriesRemaining", actions: "incrementRetries"},
+							{target: "frozen"},
+						],
+					},
+				},
+			},
+		});
+	});
+
+	it("sends a child's review PASS to integrate — the merge into the epic branch is its own state", () => {
 		const compiled = laneOf(emitted(emitMachine(4300, body(), CHILDREN)));
 		const status = drive(compiled, [
 			["issue_4301", "WIP"],
@@ -194,10 +217,66 @@ describe("emitMachine", () => {
 			["issue_4301", "PASS"],
 		]);
 		expect(status.stateValue).toEqual({
+			phase1: {issue_4301: "integrate", issue_4302: "queued"},
+			phase2: "waiting",
+			epic: "waiting",
+		});
+	});
+
+	it("lands a child on its integrate DONE — the success final asserts a landing, not a merge to main", () => {
+		const compiled = laneOf(emitted(emitMachine(4300, body(), CHILDREN)));
+		expect(drive(compiled, land("issue_4301")).stateValue).toEqual({
 			phase1: {issue_4301: "landed", issue_4302: "queued"},
 			phase2: "waiting",
 			epic: "waiting",
 		});
+	});
+
+	it("re-enters build on a collision at integrate, and re-proves the range through review before landing", () => {
+		const compiled = laneOf(emitted(emitMachine(4300, body(), CHILDREN)));
+		const collided: ReadonlyArray<readonly [string, string]> = [
+			["issue_4301", "WIP"],
+			["issue_4301", "DONE"],
+			["issue_4301", "PASS"],
+			["issue_4301", "FAIL"],
+		];
+		expect(drive(compiled, collided).stateValue).toMatchObject({
+			phase1: {issue_4301: "build"},
+		});
+		expect(drive(compiled, [...collided, ["issue_4301", "DONE"]]).stateValue).toMatchObject({
+			phase1: {issue_4301: "review"},
+		});
+		expect(
+			drive(compiled, [
+				...collided,
+				["issue_4301", "DONE"],
+				["issue_4301", "PASS"],
+				["issue_4301", "DONE"],
+			]).stateValue,
+		).toMatchObject({phase1: {issue_4301: "landed"}});
+	});
+
+	it("trips the lane when integrate keeps colliding past the retry budget — never a landing", () => {
+		const compiled = laneOf(emitted(emitMachine(4300, body(), CHILDREN)));
+		/** One collided integration: the range passes review, the merge fails, the repair rebuilds. */
+		const collide: ReadonlyArray<readonly [string, string]> = [
+			["issue_4301", "PASS"],
+			["issue_4301", "FAIL"],
+			["issue_4301", "DONE"],
+		];
+		const exhausted: ReadonlyArray<readonly [string, string]> = [
+			["issue_4301", "WIP"],
+			["issue_4301", "DONE"],
+			...Array.from({length: RETRY_BUDGET}, () => collide).flat(),
+			["issue_4301", "PASS"],
+			["issue_4301", "FAIL"],
+		];
+		expect(drive(compiled, exhausted).stateValue).toMatchObject({
+			phase1: {issue_4301: "frozen"},
+		});
+		const tripped = drive(compiled, [...exhausted, ...land("issue_4302")]);
+		expect(tripped).toMatchObject({stateValue: "tripped", status: "done"});
+		expect(tripped.context.errors).toEqual(["issue_4301"]);
 	});
 
 	it("carries an epic tail phase whose one region reviews the single PR, then ships it", () => {
@@ -271,6 +350,7 @@ describe("emitMachine", () => {
 		expect(template).toContain('"ISSUE.PASS": "ship"');
 		expect(template).toContain('"ISSUE.BLOCKED": "human:cp-approval"');
 		expect(template).not.toContain("landed");
+		expect(template).not.toContain("integrate");
 	});
 
 	it("refuses a body with no ## Dependencies block", () => {


### PR DESCRIPTION
A child's region now carries an `integrate` state between `review` and `landed`: the step where the driver merges the child's reviewed range into the epic branch. Before this, a review PASS went straight to `landed`, so a collision between two children in flight had nowhere to be — the run either stranded or pushed the conflict out to the merge queue. Tonight's live case: PRs #5803 and #5804 both took lane exit codes 18–21 and a repair builder had to renumber #5804's by hand.

The route:

- `review` PASS → `integrate`. `integrate` DONE → `landed`.
- `integrate` FAIL — a textual conflict, or a failed post-merge check, which is the semantic collision — re-enters `build` under the same guarded-FAIL retry array `review` already uses, and exhausts into `frozen`. `frozen` is an error final by the compiler's structural read, so the phase's `onDone` trips the lane.
- Nothing reaches `landed` except through `integrate` DONE, and nothing reaches `integrate` except through `review` PASS. That is the re-proof ordering: post-resolution content is not what the range verdict judged (#5825's digest moves), so a repaired integrate is re-reviewed before it lands. It is a property of the graph, not a line of choreography prose.

`machine.ts` and `fold.ts` are untouched — the new state is one more cell over the existing recognitions (guarded array, history target, `onDone` pair) and stays inside the six operator events. The golden fixture was regenerated from the emitter; `templates/coder.workflow.json` is byte-untouched, and the test now pins that it carries neither `landed` nor `integrate`.

Tests: the region's state list, the integrate cells' shape, a drive through `foldLog`/`deriveStatus` proving PASS → integrate → landed, a collision drive proving integrate FAIL → build → review → integrate → landed, and a budget-exhaustion drive proving `frozen` plus a tripped lane with `errors: ["issue_4301"]`. The determinism test now asserts the emitted bytes carry one `integrate` per child, so it covers the new shape rather than the old one.

Driving the new state is its siblings' work, not this PR's: `lane brief`'s one-PR arms (#5828) and `operate`'s choreography (#5830) are the children that route `integrate` to an actor. Until they land, a driver that reaches `integrate` parks on `lane brief` exit 18 — the loud answer, not a silent one.

Fixes #5826

## Deviations

None.
