### PR TITLE
feat: Operator shells die silently while idling on a long-running child spawn

### DIFF
--- a/claude-plugins/fabrika/skills/operate/SKILL.md
+++ b/claude-plugins/fabrika/skills/operate/SKILL.md
@@ -282,6 +282,20 @@ chore's transcript is posted.
 operator again with the same issue number — step 1 tolerates the existing lane, and the fold says
 everything a successor needs. That is why no step above holds session state.
 
+**A non-parked lane with no live operator is a detectable defect, not a wait.** The ledger records
+state, not liveness, so an operator that dies mid-drive leaves its lane reading `build` or `review`
+forever and nothing here can record the `BLOCKED` a dead spawn is owed — the dead shell is the one
+that would have to record it. What catches it is a driver-side sweep, not a driver's patience:
+
+```bash
+node packages/fabrika-cli/src/bin.ts lane stale --older-than 60
+```
+
+Every `stale` row is a lane something is owed on that has not moved in the threshold; `parked`,
+`terminal` and `unstarted` rows are never reported stale, so the list is exactly the lanes to
+re-spawn. It reports and never resumes: a driver or a human decides, and the resume is the
+re-spawn above ([#5897](https://github.com/kamp-us/phoenix/issues/5897)).
+
 ## Terminal vocabulary
 
 Every run ends as exactly one of — each naming what was recorded and what the fold reads after:
@@ -310,7 +324,7 @@ fabrika skill, so one reader parses all of them. No row here dead-ends on a bare
 
 | Must exist | Why this skill needs it | When missing |
 | --- | --- | --- |
-| The lane verb group — `packages/fabrika-cli/src/bin.ts` routing `lane status`/`transition`/`prove` (#5747)/`history`/`print` plus `open`/`emit` (#5688) and `brief` (#5751) | Every state read, every proof, every event write and every spawn prompt in this skill is one of these verbs; there is no other path to the ledger, and none to a prompt | **fail-loud** — a verb that cannot be executed leaves the lane state UNKNOWN; the run ends `STOPPED` naming `packages/fabrika-cli/src/bin.ts` and points at front-door. |
+| The lane verb group — `packages/fabrika-cli/src/bin.ts` routing `lane status`/`transition`/`prove` (#5747)/`history`/`print` plus `open`/`emit` (#5688), `brief` (#5751) and `stale` (#5897) | Every state read, every proof, every event write, every spawn prompt and the dead-operator sweep in this skill is one of these verbs; there is no other path to the ledger, and none to a prompt | **fail-loud** — a verb that cannot be executed leaves the lane state UNKNOWN; the run ends `STOPPED` naming `packages/fabrika-cli/src/bin.ts` and points at front-door. |
 | The recipe verb group — `packages/fabrika-cli/src/bin.ts` routing `recipe route` plus the recipes it names (`unpark`, `rerun`), and the chore template at `packages/fabrika-cli/src/lane/templates/chore.workflow.json` | A chore drive routes and folds through `recipe route`, runs the recipe it names, and boots from that template; there is no other path to either answer | **fail-loud** — a chore drive whose routing verb cannot be executed knows neither what to run nor what an exit meant; the run ends `STOPPED` naming `packages/fabrika-cli/src/recipe/`, records no event, and points at front-door. An issue lane is unaffected. |
 | The agent shells — `claude-plugins/fabrika/agents/builder.md`, `reviewer.md`, `shipper.md` | Step 2's routing table spawns exactly these three by their bare noun names | **fail-loud** — a route whose shell does not exist cannot spawn; the run ends `STOPPED` naming the absent shell file, and no event is recorded for a spawn that never started. |
 | `.gitignore` covering `.fabrika/` | The ledger is a disposable machine-local artifact, regenerable from the board — committed, it would smuggle one machine's lane state into every checkout | **degrade** — the verbs still work; state the uncovered `.fabrika/` in the park or transcript comment and file the gap via `/report`. |

--- a/packages/fabrika-cli/README.md
+++ b/packages/fabrika-cli/README.md
@@ -10,7 +10,7 @@ gate's; `review`, the eight the `/review` contract specifies; `review-ui`, the t
 (capture a PR's preview, emit the `review-ui` verdict, or post a typed blocker note);
 `ship`, the thirteen the `/ship` contract specifies; `map`, the eight the `/wayfinding`
 contract specifies (chart one destination's fog, and drain its frontier); `spend`, what one fabrika run cost in
-tokens; `lane`, the four-verb lane ledger the operator loop drives — a @demlik/tea machine
+tokens; `lane`, the lane ledger the operator loop drives — a @demlik/tea machine
 folded fresh from an append-only `events.jsonl` on every invocation; `wire`, which owns the
 byte-level formats two skills meet through on a GitHub
 artifact; `status`, the six the `/fabrika` front door's contract specifies (what state the
@@ -799,6 +799,7 @@ snapshot. Lane state is local and never committed (the repo's `/.fabrika/` gitig
 | `lane transition` | records one operator event after the machine accepts it — `{previous, event, current, taskAffected}` |
 | `lane history` | the log verbatim, one `{task, event, at}` per event — `from`/`to` are reconstructible by folding, never stored |
 | `lane print` | the compiled topology: phases, the two workflow terminals, and each state's legal events |
+| `lane stale` | every lane on disk with the age of its last event and one verdict — which lanes are non-terminal, unparked and silent past `--older-than` (default 60 minutes), so a dead operator is detectable instead of invisible |
 
 To open a lane, copy a template in and speak the operator's six events —
 `DONE` / `PASS` / `FAIL` / `BLOCKED` / `WIP` / `UNBLOCKED`:

--- a/packages/fabrika-cli/src/lane/command.ts
+++ b/packages/fabrika-cli/src/lane/command.ts
@@ -19,6 +19,8 @@ import {runOpen} from "./open-verb.ts";
 import {runPrint} from "./print-verb.ts";
 import {runProve} from "./prove-verb.ts";
 import {keyRefusal} from "./refusals.ts";
+import {DEFAULT_STALE_MINUTES} from "./stale.ts";
+import {runStale} from "./stale-verb.ts";
 import {runStatus} from "./status-verb.ts";
 import {DEFAULT_CHORES_ROOT, DEFAULT_LANES_ROOT, type LaneRef} from "./store.ts";
 import {runTransition} from "./transition-verb.ts";
@@ -248,8 +250,48 @@ const brief = leafCommand(
 	),
 );
 
+const stale = leafCommand(
+	"stale",
+	{
+		root: rootFlag,
+		olderThan: Flag.integer("older-than").pipe(
+			Flag.optional,
+			Flag.withDescription(
+				`minutes of silence before a lane something is owed on is stale (default: ${DEFAULT_STALE_MINUTES})`,
+			),
+		),
+	},
+	Effect.fn(function* ({root, olderThan}) {
+		yield* emit(
+			yield* runStale({
+				roots: Option.match(root, {
+					onNone: () => [DEFAULT_LANES_ROOT, DEFAULT_CHORES_ROOT],
+					onSome: (only) => [only],
+				}),
+				olderThanMinutes: Option.getOrElse(olderThan, () => DEFAULT_STALE_MINUTES),
+				now: new Date().toISOString(),
+			}),
+		);
+	}),
+).pipe(
+	Command.withShortDescription("Which lanes have gone quiet with something owed on them."),
+	Command.withDescription(
+		`Sweep every lane on disk and answer which ones nothing is driving. A lane's ledger records state, not liveness, so a shell that dies leaves the lane reading active forever (#5897); the age here comes off the \`at\` every event line already carries — nothing new is stored. stdout is {now, olderThanMinutes, scanned, summary, lanes}, oldest silence first, each lane carrying its folded stateValue, its last event's timestamp, its age in minutes and one verdict: "stale" (non-terminal, unparked and silent past the threshold), "moving", "parked" (blocked or a human:* hold — a park is meant to sit), "terminal", "unstarted" (a lane with no events at all, so no age to judge) or "unreadable" (the lane is there and its record is not readable — it is reported, never dropped). Both default roots are swept unless --root names one; an absent root holds no lanes and is not a fault, and zero lanes is an empty answer at exit 0. Stale lanes exit 0 too — this reports, it never resumes. Exits 1 (--older-than is not a non-negative number of minutes), 11 (a root is there and could not be listed — the lane set is UNKNOWN, never a short list). Examples: fabrika lane stale · fabrika lane stale --older-than 30`,
+	),
+);
+
 export const laneCommand = Command.make("lane").pipe(
-	Command.withSubcommands([status, transition, prove, history, print, open, emitLane, brief]),
+	Command.withSubcommands([
+		status,
+		transition,
+		prove,
+		history,
+		print,
+		open,
+		emitLane,
+		brief,
+		stale,
+	]),
 	Command.withShortDescription("Drive one lane's state ledger by folding its event log."),
 	Command.withDescription(
 		"Drive one lane's state ledger — a @demlik/tea machine folded fresh from an append-only events.jsonl on every invocation, speaking the operator's six events (#5673). A lane is keyed by the issue number it drives, or by name as `chore:<name>` for a chore that has no issue number (#5840)",

--- a/packages/fabrika-cli/src/lane/stale-verb.ts
+++ b/packages/fabrika-cli/src/lane/stale-verb.ts
@@ -1,0 +1,201 @@
+/**
+ * `lane stale` — every lane on disk, with how long since it moved, and which ones nothing is driving.
+ *
+ * The one verb in the group that reads across lanes rather than into one, because the question it
+ * answers is a sweep: a driver (or a cron) asks which lanes are non-terminal and have gone quiet, and
+ * gets a list. It writes nothing and stores nothing — the age comes off the `at` each event line
+ * already carries (#5897).
+ *
+ * A lane that could not be read is a row, not the end of the sweep: refusing the whole answer over
+ * one broken lane would hide every other lane's silence, which is the failure this verb exists to
+ * end. The sweep itself refuses only when a root it was asked to scan is there and cannot be listed —
+ * that leaves the lane set UNKNOWN, and an UNKNOWN lane set is never a short list.
+ */
+import {Effect, type FileSystem, type Path, Result} from "effect";
+import {exists, readDir} from "../io/fs.ts";
+import {answer, FAILED, refuse, type VerbOutcome} from "../verb.ts";
+import {LANE_UNREADABLE} from "./codes.ts";
+import {deriveStatus, foldLog, type LaneStatus} from "./fold.ts";
+import {CHORE_PREFIX} from "./key.ts";
+import {type Judgement, judge, lastMoved, type Verdict} from "./stale.ts";
+import {DEFAULT_CHORES_ROOT, loadLane} from "./store.ts";
+
+const VERB = "fabrika lane stale";
+
+export interface StaleOptions {
+	/** The lane roots to sweep, in order. An absent root is an empty one, not a fault. */
+	readonly roots: ReadonlyArray<string>;
+	readonly olderThanMinutes: number;
+	/** The instant the ages are measured against, ISO — the adapter's clock, so the verb stays pure. */
+	readonly now: string;
+}
+
+interface LaneRow extends Judgement {
+	/** The key this lane is addressed by — what a caller passes to any other `lane` verb. */
+	readonly key: string;
+	readonly root: string;
+	readonly stateValue: LaneStatus["stateValue"] | null;
+	readonly status: LaneStatus["status"] | null;
+	/** Why the lane could not be judged; absent on every readable lane. */
+	readonly reason?: string;
+}
+
+interface ScannedRoot {
+	readonly root: string;
+	/** Whether the root directory is there at all — an absent root holds no lanes and is not a fault. */
+	readonly present: boolean;
+	readonly lanes: number;
+}
+
+const VERDICTS: ReadonlyArray<Verdict> = [
+	"stale",
+	"moving",
+	"parked",
+	"terminal",
+	"unstarted",
+	"unreadable",
+];
+
+/** How a caller addresses this lane: a chore root's entries are keyed `chore:<name>` (`key.ts`). */
+const keyOf = (root: string, name: string): string =>
+	root === DEFAULT_CHORES_ROOT ? `${CHORE_PREFIX}${name}` : name;
+
+const unreadableRow = (key: string, root: string, reason: string): LaneRow => ({
+	key,
+	root,
+	stateValue: null,
+	status: null,
+	verdict: "unreadable",
+	ageMinutes: null,
+	lastEventAt: null,
+	reason,
+});
+
+/** Read and judge one lane directory. `null` when the entry holds no lane at all. */
+const judgeLane = (
+	root: string,
+	name: string,
+	nowEpochMs: number,
+	olderThanMinutes: number,
+): Effect.Effect<LaneRow | null, never, FileSystem.FileSystem | Path.Path> =>
+	Effect.gen(function* () {
+		const key = keyOf(root, name);
+		const loaded = yield* loadLane({root, lane: name});
+		// An entry with no workflow.json is not a lane — a scratch directory under the root is not a
+		// silence to report, and calling it one would put noise in front of every real stall.
+		if (loaded._tag === "Absent") return null;
+		if (loaded._tag === "Unreadable") {
+			return unreadableRow(key, root, `cannot read ${loaded.path}: ${loaded.reason}`);
+		}
+		if (loaded._tag === "Malformed") {
+			return unreadableRow(
+				key,
+				root,
+				`${loaded.path} is not the shape: ${loaded.defects.join("; ")}`,
+			);
+		}
+		const fold = foldLog(loaded.lane, loaded.entries);
+		if (fold._tag !== "Folded") {
+			return unreadableRow(
+				key,
+				root,
+				`${loaded.logPath} does not replay: ${fold.defects.join("; ")}`,
+			);
+		}
+		const status = deriveStatus(loaded.lane, fold.states);
+		const judged = judge(
+			status,
+			lastMoved(loaded.entries.map((entry) => entry.at)),
+			nowEpochMs,
+			olderThanMinutes,
+		);
+		const row: LaneRow = {
+			key,
+			root,
+			stateValue: status.stateValue,
+			status: status.status,
+			...judged,
+		};
+		return judged.verdict === "unreadable"
+			? {...row, reason: `${loaded.logPath} carries no parseable \`at\``}
+			: row;
+	});
+
+/** Oldest silence first, then the ages nobody can compute, then alphabetically — stable per run. */
+const byAge = (left: LaneRow, right: LaneRow): number => {
+	if (left.ageMinutes !== right.ageMinutes) {
+		if (left.ageMinutes === null) return 1;
+		if (right.ageMinutes === null) return -1;
+		return right.ageMinutes - left.ageMinutes;
+	}
+	return left.key.localeCompare(right.key);
+};
+
+export const runStale = (
+	options: StaleOptions,
+): Effect.Effect<VerbOutcome, never, FileSystem.FileSystem | Path.Path> =>
+	Effect.gen(function* () {
+		if (!Number.isFinite(options.olderThanMinutes) || options.olderThanMinutes < 0) {
+			return refuse(FAILED, `${VERB}: --older-than must be a non-negative number of minutes.`);
+		}
+		const nowEpochMs = Date.parse(options.now);
+		if (Number.isNaN(nowEpochMs)) {
+			return refuse(FAILED, `${VERB}: "${options.now}" is not an instant to measure ages against.`);
+		}
+
+		const scanned: ScannedRoot[] = [];
+		const lanes: LaneRow[] = [];
+		for (const root of options.roots) {
+			const probe = yield* Effect.result(exists(root));
+			if (Result.isFailure(probe)) {
+				return refuse(
+					LANE_UNREADABLE,
+					`${VERB}: cannot establish whether ${root} is there: ${probe.failure.reason} — the lane set is UNKNOWN, never empty.`,
+				);
+			}
+			if (!probe.success) {
+				scanned.push({root, present: false, lanes: 0});
+				continue;
+			}
+			const names = yield* Effect.result(readDir(root));
+			if (Result.isFailure(names)) {
+				return refuse(
+					LANE_UNREADABLE,
+					`${VERB}: cannot list ${root}: ${names.failure.reason} — the lane set is UNKNOWN, never empty.`,
+				);
+			}
+			let found = 0;
+			for (const name of [...names.success].sort()) {
+				const row = yield* judgeLane(root, name, nowEpochMs, options.olderThanMinutes);
+				if (row === null) continue;
+				found += 1;
+				lanes.push(row);
+			}
+			scanned.push({root, present: true, lanes: found});
+		}
+
+		const summary = Object.fromEntries(
+			VERDICTS.map((verdict) => [verdict, lanes.filter((row) => row.verdict === verdict).length]),
+		);
+		const sorted = [...lanes].sort(byAge);
+		const stale = sorted.filter((row) => row.verdict === "stale");
+		return answer(
+			JSON.stringify(
+				{
+					now: options.now,
+					olderThanMinutes: options.olderThanMinutes,
+					scanned,
+					summary,
+					lanes: sorted,
+				},
+				null,
+				2,
+			),
+			[
+				`${VERB}: swept ${scanned.map((entry) => `${entry.root} (${entry.present ? `${entry.lanes} lane(s)` : "absent"})`).join(", ")}.`,
+				stale.length === 0
+					? `${VERB}: no lane has been silent for ${options.olderThanMinutes} minute(s) with something owed on it.`
+					: `${VERB}: ${stale.length} stale: ${stale.map((row) => `${row.key} (${String(row.ageMinutes)}m)`).join(", ")}.`,
+			],
+		);
+	});

--- a/packages/fabrika-cli/src/lane/stale-verb.unit.test.ts
+++ b/packages/fabrika-cli/src/lane/stale-verb.unit.test.ts
@@ -1,0 +1,223 @@
+/** `lane stale` — the sweep across lanes, its per-lane rows, and the one thing it refuses. */
+import {Effect} from "effect";
+import {describe, expect, it} from "vitest";
+import {type FakeFsOptions, fakeFs} from "../fakes.test-support.ts";
+import {LANE_UNREADABLE} from "./codes.ts";
+import {coderTemplateText} from "./fixtures.test-support.ts";
+import {runStale} from "./stale-verb.ts";
+import {DEFAULT_CHORES_ROOT, DEFAULT_LANES_ROOT} from "./store.ts";
+
+const NOW = "2026-08-17T12:00:00.000Z";
+const minutesAgo = (n: number): string => new Date(Date.parse(NOW) - n * 60_000).toISOString();
+
+const line = (event: string, at: string): string =>
+	`${JSON.stringify({task: "issue", event: `ISSUE.${event}`, at})}\n`;
+
+interface LaneFixture {
+	readonly root?: string;
+	readonly lane: string;
+	readonly log?: string;
+	readonly workflow?: string | null;
+}
+
+const tree = (lanes: ReadonlyArray<LaneFixture>, extra: FakeFsOptions = {}) => {
+	const files: Record<string, string | null> = {};
+	const dirs: Record<string, Array<string>> = {[DEFAULT_LANES_ROOT]: []};
+	for (const {root = DEFAULT_LANES_ROOT, lane, log, workflow} of lanes) {
+		const names = dirs[root] ?? [];
+		names.push(lane);
+		dirs[root] = names;
+		const value = workflow === undefined ? coderTemplateText() : workflow;
+		if (value !== null) files[`${root}/${lane}/workflow.json`] = value;
+		if (log !== undefined) files[`${root}/${lane}/events.jsonl`] = log;
+	}
+	return fakeFs({
+		files,
+		dirs: {...dirs, ...extra.dirs},
+		directories: [...Object.keys(dirs), ...(extra.directories ?? [])],
+		...(extra.unreadable === undefined ? {} : {unreadable: extra.unreadable}),
+		...(extra.unprobeable === undefined ? {} : {unprobeable: extra.unprobeable}),
+	});
+};
+
+const sweep = (
+	fs: ReturnType<typeof fakeFs>,
+	options: {roots?: ReadonlyArray<string>; olderThanMinutes?: number; now?: string} = {},
+) =>
+	Effect.runPromise(
+		Effect.provide(
+			runStale({
+				roots: options.roots ?? [DEFAULT_LANES_ROOT],
+				olderThanMinutes: options.olderThanMinutes ?? 60,
+				now: options.now ?? NOW,
+			}),
+			fs.layer,
+		),
+	);
+
+describe("lane stale", () => {
+	it("reports a driven lane silent past the threshold as stale, with its state and age", async () => {
+		const out = await sweep(tree([{lane: "5829", log: line("WIP", minutesAgo(76))}]));
+
+		expect(out.code).toBe(0);
+		const answer = JSON.parse(out.stdout);
+		expect(answer.lanes).toEqual([
+			{
+				key: "5829",
+				root: DEFAULT_LANES_ROOT,
+				stateValue: {pipeline: {issue: "build"}},
+				status: "active",
+				verdict: "stale",
+				ageMinutes: 76,
+				lastEventAt: minutesAgo(76),
+			},
+		]);
+		expect(answer.summary.stale).toBe(1);
+		expect(out.stderr.join("\n")).toContain("5829 (76m)");
+	});
+
+	it("reports a recently moved lane as moving", async () => {
+		const out = await sweep(tree([{lane: "5825", log: line("WIP", minutesAgo(5))}]));
+
+		expect(JSON.parse(out.stdout).lanes[0]).toMatchObject({verdict: "moving", ageMinutes: 5});
+	});
+
+	it("never calls a human park stale, however long it has sat", async () => {
+		const log =
+			line("WIP", minutesAgo(900)) +
+			line("DONE", minutesAgo(880)) +
+			line("PASS", minutesAgo(870)) +
+			line("BLOCKED", minutesAgo(860));
+		const out = await sweep(tree([{lane: "5832", log}]));
+
+		expect(JSON.parse(out.stdout).lanes[0]).toMatchObject({
+			verdict: "parked",
+			stateValue: {pipeline: {issue: "human:cp-approval"}},
+			ageMinutes: 860,
+		});
+	});
+
+	it("never calls a finished lane stale", async () => {
+		const log =
+			line("WIP", minutesAgo(900)) +
+			line("DONE", minutesAgo(880)) +
+			line("PASS", minutesAgo(870)) +
+			line("DONE", minutesAgo(860));
+		const out = await sweep(tree([{lane: "5680", log}]));
+
+		expect(JSON.parse(out.stdout).lanes[0]).toMatchObject({verdict: "terminal", status: "done"});
+	});
+
+	it("calls a lane with no events at all unstarted rather than fresh", async () => {
+		const out = await sweep(tree([{lane: "5897"}]));
+
+		expect(JSON.parse(out.stdout).lanes[0]).toMatchObject({
+			verdict: "unstarted",
+			ageMinutes: null,
+			lastEventAt: null,
+		});
+	});
+
+	it("answers zero lanes cleanly at exit 0, both for an empty root and an absent one", async () => {
+		const empty = await sweep(tree([]));
+		expect(empty.code).toBe(0);
+		expect(JSON.parse(empty.stdout)).toMatchObject({
+			summary: {stale: 0},
+			lanes: [],
+			scanned: [{root: DEFAULT_LANES_ROOT, present: true, lanes: 0}],
+		});
+
+		const absent = await sweep(fakeFs({files: {}}), {roots: [".fabrika/nowhere"]});
+		expect(absent.code).toBe(0);
+		expect(JSON.parse(absent.stdout).scanned).toEqual([
+			{root: ".fabrika/nowhere", present: false, lanes: 0},
+		]);
+	});
+
+	it("skips a directory under the root that holds no workflow.json", async () => {
+		const out = await sweep(tree([{lane: "scratch", workflow: null}]));
+
+		expect(JSON.parse(out.stdout)).toMatchObject({
+			lanes: [],
+			scanned: [{root: DEFAULT_LANES_ROOT, lanes: 0}],
+		});
+	});
+
+	it("reports an unreadable lane as its own row and keeps sweeping the rest", async () => {
+		const out = await sweep(
+			tree([
+				{lane: "1", workflow: '{"machine":{"states":{}}}'},
+				{lane: "2", log: line("WIP", minutesAgo(90))},
+			]),
+		);
+
+		expect(out.code).toBe(0);
+		const {lanes, summary} = JSON.parse(out.stdout);
+		expect(summary).toMatchObject({unreadable: 1, stale: 1});
+		expect(lanes.map((row: {key: string}) => row.key)).toEqual(["2", "1"]);
+		expect(lanes[1].reason).toContain("not the shape");
+	});
+
+	it("reports a lane whose timestamps do not parse as unreadable, never as moving", async () => {
+		const out = await sweep(tree([{lane: "3", log: line("WIP", "whenever")}]));
+
+		expect(JSON.parse(out.stdout).lanes[0]).toMatchObject({
+			verdict: "unreadable",
+			ageMinutes: null,
+		});
+	});
+
+	it("keys a chore root's lanes the way a caller addresses them", async () => {
+		const out = await sweep(
+			tree([{root: DEFAULT_CHORES_ROOT, lane: "park-sweep", log: line("WIP", minutesAgo(90))}]),
+			{roots: [DEFAULT_CHORES_ROOT]},
+		);
+
+		expect(JSON.parse(out.stdout).lanes[0]).toMatchObject({key: "chore:park-sweep"});
+	});
+
+	it("sweeps every root it is given and sorts the oldest silence first", async () => {
+		const out = await sweep(
+			tree([
+				{lane: "10", log: line("WIP", minutesAgo(70))},
+				{lane: "11", log: line("WIP", minutesAgo(400))},
+				{root: DEFAULT_CHORES_ROOT, lane: "sweep", log: line("WIP", minutesAgo(200))},
+			]),
+			{roots: [DEFAULT_LANES_ROOT, DEFAULT_CHORES_ROOT]},
+		);
+
+		expect(JSON.parse(out.stdout).lanes.map((row: {key: string}) => row.key)).toEqual([
+			"11",
+			"chore:sweep",
+			"10",
+		]);
+	});
+
+	it("takes the threshold from the caller — the same tree answers differently", async () => {
+		const fixture = () => tree([{lane: "12", log: line("WIP", minutesAgo(45))}]);
+
+		expect(JSON.parse((await sweep(fixture(), {olderThanMinutes: 30})).stdout).summary.stale).toBe(
+			1,
+		);
+		expect(JSON.parse((await sweep(fixture(), {olderThanMinutes: 60})).stdout).summary.stale).toBe(
+			0,
+		);
+	});
+
+	it("refuses a root that is there and cannot be listed — UNKNOWN, never a short list", async () => {
+		const out = await sweep(
+			fakeFs({files: {}, directories: [DEFAULT_LANES_ROOT], dirs: {[DEFAULT_LANES_ROOT]: null}}),
+		);
+
+		expect(out.code).toBe(LANE_UNREADABLE);
+		expect(out.stdout).toBe("");
+		expect(out.stderr.at(-1)).toContain("UNKNOWN");
+	});
+
+	it("refuses a negative threshold as a usage error", async () => {
+		const out = await sweep(tree([]), {olderThanMinutes: -1});
+
+		expect(out.code).toBe(1);
+		expect(out.stdout).toBe("");
+	});
+});

--- a/packages/fabrika-cli/src/lane/stale.ts
+++ b/packages/fabrika-cli/src/lane/stale.ts
@@ -1,0 +1,137 @@
+/**
+ * The stall derivation — a lane's folded state plus the age of its last event, judged.
+ *
+ * The ledger records state, not liveness: when the shell driving a lane dies, the last recorded
+ * state stays on disk and every reader still sees an active lane (#5897). Nothing new is stored to
+ * fix that. Every event line already carries an ISO `at`, so "how long since this lane moved" is
+ * already on disk, and this module is the reading of it.
+ *
+ * The judgement turns on one question — **should something be driving this lane right now?** Three
+ * dispositions answer it and only one is judged against the clock:
+ *
+ *   - A lane whose fold is `done` has no driver by design.
+ *   - A lane where no task can be driven and at least one sits in a **park** — `blocked` or a
+ *     `human:*` state — is waiting on a person, and waiting is what a park is for. It may sit for
+ *     days without that being a defect.
+ *   - Everything else is a lane something is supposed to be doing: a task in a state that routes to
+ *     a shell (`lane brief`'s own routing, so the two agree by construction), or a `queued` task
+ *     nobody has dispatched. Silence there is the defect.
+ */
+import {shellState} from "../wire/lane-brief.ts";
+import type {LaneStatus} from "./fold.ts";
+
+/** The default silence a lane may hold before it is called stale, in minutes. */
+export const DEFAULT_STALE_MINUTES = 60;
+
+/**
+ * Whether a leaf state is a park — a hold only a human or a driver clears.
+ *
+ * `blocked` and the `human:*` family are exactly the states whose only exit is an `UNBLOCKED` event
+ * somebody decides to record; sitting in one is the state working, not a stall. Deliberately NOT
+ * every state that routes to no shell: `queued` also routes to none, and a queued lane nobody
+ * dispatched is the silence this module exists to catch.
+ */
+export const isPark = (leaf: string): boolean => leaf === "blocked" || leaf.startsWith("human:");
+
+/**
+ * The active phase's per-task leaf states, read off the status the fold derived.
+ *
+ * The active phase is the one entry whose value is an object — the same structural recognition
+ * `applyEvent` uses — because a future phase is the string `"waiting"` and a done workflow is a bare
+ * terminal name.
+ */
+export const activeLeaves = (status: LaneStatus): ReadonlyArray<string> => {
+	if (typeof status.stateValue === "string") return [];
+	const leaves: string[] = [];
+	for (const phase of Object.values(status.stateValue)) {
+		if (typeof phase === "string") continue;
+		leaves.push(...Object.values(phase));
+	}
+	return leaves;
+};
+
+export type Disposition = "terminal" | "parked" | "driven";
+
+/** What a lane's folded state says about whether anything should be driving it. */
+export const dispositionOf = (status: LaneStatus): Disposition => {
+	if (status.status === "done") return "terminal";
+	const leaves = activeLeaves(status);
+	if (leaves.some((leaf) => shellState(leaf) !== null)) return "driven";
+	return leaves.length > 0 && leaves.every(isPark) ? "parked" : "driven";
+};
+
+/**
+ * The most recent event instant across a log, in epoch milliseconds.
+ *
+ * The maximum rather than the last line: the log is appended in order, but a hand edit or a clock
+ * step can put an older `at` last, and taking the tail there would report a lane as older than it
+ * is. `Unreadable` when entries exist and none of their `at` values parse — never folded into
+ * "no events", because the two take opposite remedies (fix the log vs drive the lane).
+ */
+export type LastMoved =
+	| {readonly _tag: "Moved"; readonly at: string; readonly epochMs: number}
+	| {readonly _tag: "Never"}
+	| {readonly _tag: "Unreadable"};
+
+export const lastMoved = (ats: ReadonlyArray<string>): LastMoved => {
+	if (ats.length === 0) return {_tag: "Never"};
+	let best: {at: string; epochMs: number} | undefined;
+	for (const at of ats) {
+		const epochMs = Date.parse(at);
+		if (Number.isNaN(epochMs)) continue;
+		if (best === undefined || epochMs > best.epochMs) best = {at, epochMs};
+	}
+	return best === undefined ? {_tag: "Unreadable"} : {_tag: "Moved", ...best};
+};
+
+/**
+ * A lane's verdict.
+ *
+ * `unstarted` and `unreadable` are their own seats rather than either edge of `stale`/`moving`: a
+ * lane with no events has no age to judge, and one whose timestamps do not parse has an age nobody
+ * can compute. Resolving either to "moving" would hide it, and to "stale" would invent a fact.
+ */
+export type Verdict = "stale" | "moving" | "parked" | "terminal" | "unstarted" | "unreadable";
+
+export interface Judgement {
+	readonly verdict: Verdict;
+	/** Minutes since the lane's most recent event; `null` when there is no age to compute. */
+	readonly ageMinutes: number | null;
+	/** The `at` the age was measured from; `null` when the lane has never moved. */
+	readonly lastEventAt: string | null;
+}
+
+/**
+ * Judge one lane against the clock. `nowEpochMs` is the caller's, so the answer is a pure function
+ * of its inputs and a test needs no fake timer.
+ */
+export const judge = (
+	status: LaneStatus,
+	moved: LastMoved,
+	nowEpochMs: number,
+	olderThanMinutes: number,
+): Judgement => {
+	const at = moved._tag === "Moved" ? moved.at : null;
+	const disposition = dispositionOf(status);
+	if (disposition !== "driven") {
+		return {
+			verdict: disposition === "terminal" ? "terminal" : "parked",
+			ageMinutes: moved._tag === "Moved" ? ageInMinutes(moved.epochMs, nowEpochMs) : null,
+			lastEventAt: at,
+		};
+	}
+	if (moved._tag === "Never") return {verdict: "unstarted", ageMinutes: null, lastEventAt: null};
+	if (moved._tag === "Unreadable") {
+		return {verdict: "unreadable", ageMinutes: null, lastEventAt: null};
+	}
+	const ageMinutes = ageInMinutes(moved.epochMs, nowEpochMs);
+	return {
+		verdict: ageMinutes >= olderThanMinutes ? "stale" : "moving",
+		ageMinutes,
+		lastEventAt: at,
+	};
+};
+
+/** Whole minutes between two instants, floored at zero — a clock that ran backwards is age 0. */
+const ageInMinutes = (epochMs: number, nowEpochMs: number): number =>
+	Math.max(0, Math.floor((nowEpochMs - epochMs) / 60_000));

--- a/packages/fabrika-cli/src/lane/stale.unit.test.ts
+++ b/packages/fabrika-cli/src/lane/stale.unit.test.ts
@@ -1,0 +1,134 @@
+/** The stall derivation: which lanes are owed a driver, and how old their silence is. */
+import {describe, expect, it} from "vitest";
+import type {LaneStatus} from "./fold.ts";
+import {activeLeaves, dispositionOf, isPark, judge, lastMoved} from "./stale.ts";
+
+const active = (leaves: Record<string, string>): LaneStatus => ({
+	stateValue: {pipeline: leaves, ship: "waiting"},
+	status: "active",
+	context: {},
+});
+
+const done: LaneStatus = {stateValue: "complete", status: "done", context: {}};
+
+const NOW = Date.parse("2026-08-17T12:00:00.000Z");
+const minutesAgo = (n: number): string => new Date(NOW - n * 60_000).toISOString();
+
+describe("isPark", () => {
+	it("holds for the states only a human clears, and for nothing else", () => {
+		expect(isPark("blocked")).toBe(true);
+		expect(isPark("human:cp-approval")).toBe(true);
+		expect(isPark("queued")).toBe(false);
+		expect(isPark("build")).toBe(false);
+	});
+});
+
+describe("activeLeaves", () => {
+	it("reads the active phase's leaves and skips the waiting phases", () => {
+		expect(activeLeaves(active({a: "build", b: "queued"}))).toEqual(["build", "queued"]);
+	});
+
+	it("answers none for a workflow folded onto a bare terminal", () => {
+		expect(activeLeaves(done)).toEqual([]);
+	});
+});
+
+describe("dispositionOf", () => {
+	it("calls a finished workflow terminal", () => {
+		expect(dispositionOf(done)).toBe("terminal");
+	});
+
+	it("calls a lane driven while any task routes to a shell", () => {
+		expect(dispositionOf(active({a: "build"}))).toBe("driven");
+		expect(dispositionOf(active({a: "human:cp-approval", b: "review"}))).toBe("driven");
+	});
+
+	it("calls a lane parked only when every task sits in a park", () => {
+		expect(dispositionOf(active({a: "blocked"}))).toBe("parked");
+		expect(dispositionOf(active({a: "blocked", b: "human:cp-approval"}))).toBe("parked");
+	});
+
+	it("keeps a queued task driven — nobody dispatching it is the silence, not a park", () => {
+		expect(dispositionOf(active({a: "queued"}))).toBe("driven");
+		expect(dispositionOf(active({a: "blocked", b: "queued"}))).toBe("driven");
+	});
+});
+
+describe("lastMoved", () => {
+	it("answers never on an empty log", () => {
+		expect(lastMoved([])).toEqual({_tag: "Never"});
+	});
+
+	it("takes the maximum instant, not the last line", () => {
+		const moved = lastMoved(["2026-08-17T10:00:00.000Z", "2026-08-17T09:00:00.000Z"]);
+
+		expect(moved).toMatchObject({_tag: "Moved", at: "2026-08-17T10:00:00.000Z"});
+	});
+
+	it("keeps a log whose timestamps do not parse apart from a log with no events", () => {
+		expect(lastMoved(["not a time"])).toEqual({_tag: "Unreadable"});
+	});
+
+	it("ignores an unparseable `at` beside a good one rather than losing the age", () => {
+		expect(lastMoved(["nope", "2026-08-17T11:00:00.000Z"])).toMatchObject({
+			at: "2026-08-17T11:00:00.000Z",
+		});
+	});
+});
+
+describe("judge", () => {
+	const at = (minutes: number) => lastMoved([minutesAgo(minutes)]);
+
+	it("calls a driven lane stale once its silence reaches the threshold", () => {
+		expect(judge(active({a: "build"}), at(76), NOW, 60)).toEqual({
+			verdict: "stale",
+			ageMinutes: 76,
+			lastEventAt: minutesAgo(76),
+		});
+		expect(judge(active({a: "build"}), at(60), NOW, 60).verdict).toBe("stale");
+	});
+
+	it("calls a driven lane moving below the threshold", () => {
+		expect(judge(active({a: "review"}), at(59), NOW, 60)).toMatchObject({
+			verdict: "moving",
+			ageMinutes: 59,
+		});
+	});
+
+	it("never calls a parked lane stale, however long it has sat", () => {
+		expect(judge(active({a: "human:cp-approval"}), at(6000), NOW, 60)).toMatchObject({
+			verdict: "parked",
+			ageMinutes: 6000,
+		});
+	});
+
+	it("never calls a terminal lane stale", () => {
+		expect(judge(done, at(6000), NOW, 60)).toMatchObject({verdict: "terminal"});
+	});
+
+	it("calls a lane with no events unstarted — there is no age to judge", () => {
+		expect(judge(active({a: "queued"}), lastMoved([]), NOW, 60)).toEqual({
+			verdict: "unstarted",
+			ageMinutes: null,
+			lastEventAt: null,
+		});
+	});
+
+	it("calls a lane whose timestamps do not parse unreadable, never moving", () => {
+		expect(judge(active({a: "build"}), lastMoved(["nope"]), NOW, 60)).toMatchObject({
+			verdict: "unreadable",
+			ageMinutes: null,
+		});
+	});
+
+	it("floors a clock that ran backwards at age 0 rather than reporting a negative silence", () => {
+		expect(judge(active({a: "build"}), lastMoved([minutesAgo(-30)]), NOW, 60)).toMatchObject({
+			verdict: "moving",
+			ageMinutes: 0,
+		});
+	});
+
+	it("takes the threshold from its argument — 0 makes every driven lane stale", () => {
+		expect(judge(active({a: "build"}), at(0), NOW, 0).verdict).toBe("stale");
+	});
+});


### PR DESCRIPTION
A lane's ledger records state, not liveness. When the shell driving a lane dies, the last recorded
state stays on disk and every reader still sees an active lane — three lanes died on 2026-08-17 and
all three still read active hours later. This adds the read that catches it.

`fabrika lane stale` sweeps every lane on disk and answers, per lane, its folded state, the
timestamp of its most recent event, the age of that silence, and one verdict:

- `stale` — non-terminal, unparked, and silent past `--older-than` (default 60 minutes). These are
  the lanes to re-spawn.
- `moving` — driven and recently moved.
- `parked` — `blocked` or a `human:*` hold. A park is meant to sit, so it is never stale however
  long it has been there.
- `terminal` — the fold is done; there is no driver by design.
- `unstarted` — a lane with no events at all, so there is no age to judge. Its own seat rather than
  being resolved into `moving` (which would hide it) or `stale` (which would invent a fact).
- `unreadable` — the lane is there and its record does not read. Reported as a row rather than
  ending the sweep, because refusing the whole answer over one broken lane would hide every other
  lane's silence.

Nothing new is stored: no liveness field, no lockfile, no pidfile. Every event line already carries
an ISO `at`, so the age is a read of what is already on disk. The verb writes nothing and never
resumes anything — a stale lane exits 0 like any other answer, and a driver or a human decides.

The park/driven split reuses `lane brief`'s own state routing (`shellState`), so "a shell should be
working on this" means the same thing in both places by construction. `queued` is deliberately
judged rather than treated as a park: a queued lane nobody dispatched is exactly the silence this
catches.

The sweep refuses in one case only — a root that is there and cannot be listed, at exit 11, because
an UNKNOWN lane set is never a short list. An absent root holds no lanes and is not a fault.

`operate`'s SKILL.md now states that a non-parked lane with no live operator is a detectable defect
and names the check, so "resume is a re-spawn" has a trigger other than a human noticing silence.

Verified against the 48 real lanes in the primary checkout: 1 stale, 2 moving, 4 parked, 41
terminal, 0 unreadable.

Fixes #5897

## Deviations

- **Out-of-scope change** — **Said:** #5897 names the verb, its tests and the `operate` skill line.
  **Did:** also corrected `packages/fabrika-cli/README.md`'s "the four-verb lane ledger" to "the
  lane ledger". **Why:** the group already shipped eight verbs before this one, so the count was
  wrong the moment I added a ninth, and CLAUDE.md makes the source authoritative over the doc.
  **Disposition:** stated here; one phrase, no other README content touched.
- **Known defect left unfixed** — **Said:** nothing about the README's verb table.
  **Did:** added only the `lane stale` row, leaving `open`, `emit` and `brief` still missing from
  it. **Why:** those three predate this issue and backfilling them is a doc sweep, not this ticket.
  **Disposition:** filed as a follow-up issue rather than widened into this PR.
