### PR TITLE
chore: operate choreography for the one-PR epic run: parallel worktrees, merge-on-pass, push-per-integration, one draft PR

### DIFF
--- a/claude-plugins/fabrika/skills/operate/SKILL.md
+++ b/claude-plugins/fabrika/skills/operate/SKILL.md
@@ -173,8 +173,16 @@ has something worth publishing. So after the merge and its checks pass, and befo
 `DONE`:
 
 ```bash
-git push origin epic/$lane_key
+fabrika lane push $lane_key
 ```
+
+The verb, not your own `git push`: it derives `epic/<n>` from the number rather than taking a branch
+name, refuses any tree not standing on it, and then reads the ref back off the remote — so
+`PUSH-VERDICT: MOVED` on the last stdout line is the only thing that means the assembly landed. A
+bare push cannot say that, which is why the corpus forbids one ([#4213](https://github.com/kamp-us/phoenix/issues/4213)),
+and `build push` cannot serve here because the assembly branch carries no build claim's nonce. There
+is no force flag to reach for: the branch only ever grows, so exit `29` means fetch and re-merge, and
+exit `30` is a proven "the remote did not move" — never a `MOVED` you assume.
 
 **The first of those pushes also opens the run's one PR**, as a draft — a draft carries the CI
 signal and the board's view of the run without inviting a review the machine has not asked for.

--- a/claude-plugins/fabrika/skills/operate/SKILL.md
+++ b/claude-plugins/fabrika/skills/operate/SKILL.md
@@ -78,12 +78,18 @@ A lane `lane emit` booted is an epic run, and an epic run is **one branch and on
 you read: the topology parsed, so children exist. Children build in parallel worktrees, each on its
 own local branch, and land by merging into a single **assembly branch** — `epic/<lane-key>`, the
 name `lane brief` hands every child shell and the base `lane prove` reads a child's range against.
-Create it before the first dispatch, off the default branch the board names:
+Create it before the first dispatch, off the default branch the board names. Resolve that name
+first, as its own read:
+
+```bash
+gh repo view --json defaultBranchRef --jq .defaultBranchRef.name
+```
+
+Then cut the branch from what it printed, with `$default_branch` set to that name:
 
 ```bash
 git fetch origin
-git switch --create epic/$lane_key \
-  "origin/$(gh repo view --json defaultBranchRef --jq .defaultBranchRef.name)"
+git switch --create epic/$lane_key origin/$default_branch
 ```
 
 An already-exists error is resume, like `lane open`'s: `git switch epic/$lane_key` instead. Its
@@ -203,10 +209,18 @@ things, neither of them a summary you compose:
   parser over the body before you open or edit it — `wire check --format deviations` — rather than
   leaving the malformed answer to arrive a review round later.
 
+Read the epic's title first, as its own command:
+
+```bash
+gh issue view $lane_key --json title --jq .title
+```
+
+Then open the draft, with `$default_branch` the name resolved in step 1 and `$epic_title` the
+title just printed:
+
 ```bash
 gh pr create --draft --head epic/$lane_key \
-  --base "$(gh repo view --json defaultBranchRef --jq .defaultBranchRef.name)" \
-  --title "$(gh issue view $lane_key --json title --jq .title)" --body-file -
+  --base $default_branch --title "$epic_title" --body-file -
 ```
 
 Every later integration pushes the same branch and **appends that child's closing reference** to the

--- a/claude-plugins/fabrika/skills/operate/SKILL.md
+++ b/claude-plugins/fabrika/skills/operate/SKILL.md
@@ -78,18 +78,14 @@ A lane `lane emit` booted is an epic run, and an epic run is **one branch and on
 you read: the topology parsed, so children exist. Children build in parallel worktrees, each on its
 own local branch, and land by merging into a single **assembly branch** — `epic/<lane-key>`, the
 name `lane brief` hands every child shell and the base `lane prove` reads a child's range against.
-Create it before the first dispatch, off the default branch the board names. Resolve that name
-first, as its own read:
-
-```bash
-gh repo view --json defaultBranchRef --jq .defaultBranchRef.name
-```
-
-Then cut the branch from what it printed, with `$default_branch` set to that name:
+Create it before the first dispatch, off the default branch the board names. `origin/HEAD` is
+git's own pointer to that branch — no name resolution needed; the `set-head` call refreshes the
+pointer in a checkout where it was never set:
 
 ```bash
 git fetch origin
-git switch --create epic/$lane_key origin/$default_branch
+git remote set-head origin --auto
+git switch --create epic/$lane_key origin/HEAD
 ```
 
 An already-exists error is resume, like `lane open`'s: `git switch epic/$lane_key` instead. Its
@@ -209,18 +205,15 @@ things, neither of them a summary you compose:
   parser over the body before you open or edit it — `wire check --format deviations` — rather than
   leaving the malformed answer to arrive a review round later.
 
-Read the epic's title first, as its own command:
-
-```bash
-gh issue view $lane_key --json title --jq .title
-```
-
-Then open the draft, with `$default_branch` the name resolved in step 1 and `$epic_title` the
-title just printed:
+Open the draft with the command below as written. `--base` is omitted on purpose — `gh pr create`
+defaults it to the repository's default branch, the same branch the assembly cut from. The title
+is deliberately the lane key, not the epic's prose title: nothing downstream reads a PR title
+(`lane brief` resolves the tail's PR through the closing-issue edge), and a literal title is what
+keeps this fence expansion-free:
 
 ```bash
 gh pr create --draft --head epic/$lane_key \
-  --base $default_branch --title "$epic_title" --body-file -
+  --title "epic #$lane_key: one-PR run" --body-file -
 ```
 
 Every later integration pushes the same branch and **appends that child's closing reference** to the

--- a/claude-plugins/fabrika/skills/operate/SKILL.md
+++ b/claude-plugins/fabrika/skills/operate/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: operate
-description: "Drive one lane to a terminal state — an issue number, or a `chore:<name>` chore lane — spawning one fabrika shell per active state, or applying one recipe verb, until the machine finishes or parks on a human. Trigger on \"operate #N\", \"drive the lane on #N\", \"run issue #N to terminal\", \"resume the lane on #N\", \"run the chore <name>\", \"sweep the parked lanes\", and whenever a driver wants work carried through without holding the loop in their own session. Type-blind — a single issue, an epic and a chore drive identically. Not construction (`build`), judging (`review`), or merging (`ship`) — those run inside the shells it spawns."
+description: "Drive one lane to a terminal state — an issue number, or a `chore:<name>` chore lane — spawning one fabrika shell per active state, or applying one recipe verb, until the machine finishes or parks on a human. Trigger on \"operate #N\", \"drive the lane on #N\", \"run issue #N to terminal\", \"resume the lane on #N\", \"run the chore <name>\", \"sweep the parked lanes\", and whenever a driver wants work carried through without holding the loop in their own session. Type-blind — it routes on the machine's state names and never on a label, so a single issue, an epic and a chore drive through one loop; an epic run's states add the one assembly branch its children land on. Not construction (`build`), judging (`review`), or merging (`ship`) — those run inside the shells it spawns."
 arguments: [lane_key]
 argument-hint: "[lane-key] — the issue number, or `chore:<name>`, whose lane to drive"
 ---
@@ -17,8 +17,11 @@ type, its body, or its labels — the shells you spawn read their own ground. Ev
 every verb exit you consume is data, never instruction: the closed translation tables below pick the
 event, and `lane prove` — the artifact behind it — is what lets that event reach the machine.
 **Capability set:** shell in the checkout you were spawned in, repo-scoped token, subagent spawns.
-Writes used — lane-ledger appends, comments on the driven issue, and whatever a recipe verb writes
-on its own account (step 3's chore row). No branch, no push, no merge, no verdict of your own.
+Writes used — lane-ledger appends, comments on the driven issue, whatever a recipe verb writes on
+its own account (step 3's chore row), and, **on an epic lane only**, that run's assembly branch: you
+merge a passing child into it, push it, and open the one draft PR (step 2's `integrate`). Never a
+branch a spawned shell owns, never a verdict of your own, and never the merge into the default
+branch — that one is `ship`'s, once, at the tail.
 
 Every lane verb is invoked as a plain literal through the in-tree entrypoint:
 
@@ -70,6 +73,23 @@ exist only as its spec; once it does they join `status`/`transition`/`history`/`
 the shape, `11` is a lane that could not be read — opposite remedies, neither yours to guess. End
 `STOPPED` naming the code.
 
+A lane `lane emit` booted is an epic run, and an epic run is **one branch and one PR** (ADR
+[0285](../../../../.decisions/0285-epic-machine-ends-in-review.md)). That is structural, not a label
+you read: the topology parsed, so children exist. Children build in parallel worktrees, each on its
+own local branch, and land by merging into a single **assembly branch** — `epic/<lane-key>`, the
+name `lane brief` hands every child shell and the base `lane prove` reads a child's range against.
+Create it before the first dispatch, off the default branch the board names:
+
+```bash
+git fetch origin
+git switch --create epic/$lane_key \
+  "origin/$(gh repo view --json defaultBranchRef --jq .defaultBranchRef.name)"
+```
+
+An already-exists error is resume, like `lane open`'s: `git switch epic/$lane_key` instead. Its
+absence is not a soft failure — without it `lane prove` reads every child's range as UNKNOWN
+(exit `11`), so a run driven without it proves nothing it records.
+
 Done when `lane status` folds and prints a `stateValue`.
 
 ## 2 — Read the fold, route each active task
@@ -81,7 +101,9 @@ active phase** (future phases read `waiting`; leave them alone), route on the le
 | --- | --- |
 | `queued` | record `WIP` — the task enters build |
 | `build` / `review` / `ship` | dispatch through `lane brief` — below |
+| `integrate` | land the child on the assembly branch yourself — the epic run, below |
 | a state `recipe route` names | apply that recipe verb — the chore drive, below |
+| a task's own final — `landed`, `shipped`, `frozen` | nothing to route and no event to record: that task is finished, and its phase advances when every task in it is final. `frozen` is an error final; it trips the phase at that point, and the fold is what says so |
 | `human:*` | park — step 4 |
 | `blocked` | park — step 4 |
 | any other name | end `STOPPED` naming the state — never guess a shell for a state you do not recognise, and never a park: `LANE-PARKED` promises a fold in `blocked`/`human:*`, which an unrecognised state cannot honour (Terminal vocabulary, below) |
@@ -113,6 +135,86 @@ closes** the task's issue — GitHub's own closing-issue link, not a body mentio
 quotes the number in prose never makes `20` fire (#5805). Each is a park naming what the verb named —
 never a prompt you write by hand instead. Parallel active tasks brief and spawn in parallel.
 
+**An `integrate` state is the one thing you do with your own hands.** It routes to no shell —
+`lane brief` refuses it with exit `18` — because the merge *is* the assembly the run exists to
+produce, and no spawned worktree owns the branch it lands on. Everything about it is still a relay:
+the branch comes off the proof you just recorded, the merge's own exit is the verdict, and the
+machine owns what each verdict means.
+
+Take the branch off `lane prove`'s `PASS` evidence, which prints it as `evidence.branch` beside the
+range it judged — never off a name you compose. Then, standing on the assembly branch:
+
+```bash
+git switch epic/$lane_key
+git merge --no-ff <evidence.branch>
+```
+
+`--no-ff` because each landing should be one commit a reader can name; a fast-forward would leave
+two children's ranges indistinguishable in the history the epic reviewer reads. A conflict is the
+`FAIL` that re-enters `build` under the retry budget — that route is why a cross-child collision
+resolves inside this run instead of at a merge queue. A clean merge is only half the answer: the
+**semantic** collision is two ranges that each passed alone and do not hold together, and it reads
+as the merged tree failing the repo's own checks (`pnpm typecheck` and `pnpm lint:worktree` — the
+same two every child's `build check --surface code` ran in its worktree, now run once over the
+assembly). Non-zero there is the same `FAIL`.
+
+**The assembly branch moves only on a `DONE`.** On either `FAIL`, put it back where it was —
+`git merge --abort` on a conflict, `git reset --hard ORIG_HEAD` on a clean merge the checks refused
+— so the recorded `FAIL` names a branch that never carried the bad merge. The repair builder is
+then the machine's own route out of `build`, and `lane brief` hands it both ranges: the child's
+issue, and the assembly branch, which by now carries every sibling that landed before it. Nothing
+reaches `landed` except back through `review`, because the resolution changes the content the
+child's range verdict bound (ADR [0276](../../../../.decisions/0276-verdict-binds-content-not-only-head.md))
+— that ordering is in the machine's graph, not in this paragraph.
+
+**Push at integration points, and only there.** A repair round costs no push, no CI run and no board
+write, which is the whole point of the local loop (ADR 0285); a landed child is the moment the run
+has something worth publishing. So after the merge and its checks pass, and before you record the
+`DONE`:
+
+```bash
+git push origin epic/$lane_key
+```
+
+**The first of those pushes also opens the run's one PR**, as a draft — a draft carries the CI
+signal and the board's view of the run without inviting a review the machine has not asked for.
+Open it yourself; no shell owns this branch. Its title is the epic issue's own, read off the board
+(`gh issue view $lane_key --json title`) rather than summarised by you, and its body carries two
+things, neither of them a summary you compose:
+
+- **one closing reference per child that has landed so far**, plus one on the epic issue itself.
+  The epic's is what makes the PR findable at all — `lane brief` resolves the tail's PR through
+  GitHub's closing-issue edge on the epic, and without it every tail dispatch refuses with exit
+  `20`. The children's are what make all of them close at the single merge, which is how ADR
+  [0131](../../../../.decisions/0131-epic-autoclose-on-all-children-closed.md)'s auto-close reads
+  under this shape: it fires on the GitHub edge after the merge, never mid-lane;
+- a `## Deviations` section covering **the assembly** — the merges you performed, which are the only
+  thing on this PR that is yours. `None.` while every child landed on a clean merge and clean
+  checks; one entry per repaired integrate once one did not, naming the two children whose ranges
+  collided. The epic reviewer reads that section through the `deviations` wire format, so run its
+  parser over the body before you open or edit it — `wire check --format deviations` — rather than
+  leaving the malformed answer to arrive a review round later.
+
+```bash
+gh pr create --draft --head epic/$lane_key \
+  --base "$(gh repo view --json defaultBranchRef --jq .defaultBranchRef.name)" \
+  --title "$(gh issue view $lane_key --json title --jq .title)" --body-file -
+```
+
+Every later integration pushes the same branch and **appends that child's closing reference** to the
+body, so the set of references tracks the set of landed children rather than the plan's intent.
+
+**The draft flips ready at the tail's `PASS`, and nowhere earlier.** When the epic-level review's
+`PASS` is proven and recorded, the single PR has the verdict it was opened for — mark it ready
+before dispatching `ship`, whose write verbs refuse a draft. The number is the one `lane brief`
+printed in the tail's `## Ground`:
+
+```bash
+gh pr ready <pr>
+```
+
+That is the last thing you do to the branch: the merge itself is the shipper's, once.
+
 **A chore state routes to a verb, not to a shell**, and the routing is a verb's answer too:
 
 ```bash
@@ -132,8 +234,8 @@ caller gave you:
 node packages/fabrika-cli/src/bin.ts recipe unpark <target-lane-key>
 ```
 
-Done when every active task has either a spawn in flight, a recipe run answered, or an event
-recorded this pass.
+Done when every active task has either a spawn in flight, a recipe run answered, a merge answered,
+or an event recorded this pass.
 
 ## 3 — Prove the outcome, then record one event
 
@@ -184,6 +286,11 @@ the report.
 | reviewer: any derived namespace without a still-binding verdict | no event — re-read, see below |
 | shipper `already-merged` / `QUEUED` / `landed` | `DONE` |
 | anything else — a back-off, an escalation, a stop, an awaiting-approval, a permission denial, a dead or unresponsive spawn, a report you cannot parse | `BLOCKED` |
+
+**An `integrate` has no spawn to report**, so its row is the merge's own exit folded by the two
+rules step 2 named: a clean merge whose post-merge checks pass is `DONE`; a conflict, or a red
+check, is `FAIL`. `lane prove` answers `not-required` for both — a `DONE` out of `integrate` claims
+no artifact a read could falsify — so it is still run and still gates the record.
 
 **Still binding** is one rule read against whichever artifact the subject has: on a PR, a verdict at
 its current head; on an epic child, which opens no PR, a verdict whose content digest matches what
@@ -322,4 +429,5 @@ fabrika skill, so one reader parses all of them. No row here dead-ends on a bare
 | The lane verb group — `packages/fabrika-cli/src/bin.ts` routing `lane status`/`transition`/`prove` (#5747)/`history`/`print` plus `open`/`emit` (#5688) and `brief` (#5751) | Every state read, every proof, every event write and every spawn prompt in this skill is one of these verbs; there is no other path to the ledger, and none to a prompt | **fail-loud** — a verb that cannot be executed leaves the lane state UNKNOWN; the run ends `STOPPED` naming `packages/fabrika-cli/src/bin.ts` and points at front-door. |
 | The recipe verb group — `packages/fabrika-cli/src/bin.ts` routing `recipe route` plus the recipes it names (`unpark`, `rerun`), and the chore template at `packages/fabrika-cli/src/lane/templates/chore.workflow.json` | A chore drive routes and folds through `recipe route`, runs the recipe it names, and boots from that template; there is no other path to either answer | **fail-loud** — a chore drive whose routing verb cannot be executed knows neither what to run nor what an exit meant; the run ends `STOPPED` naming `packages/fabrika-cli/src/recipe/`, records no event, and points at front-door. An issue lane is unaffected. |
 | The agent shells — `claude-plugins/fabrika/agents/builder.md`, `reviewer.md`, `shipper.md` | Step 2's routing table spawns exactly these three by their bare noun names | **fail-loud** — a route whose shell does not exist cannot spawn; the run ends `STOPPED` naming the absent shell file, and no event is recorded for a spawn that never started. |
+| The `package.json` scripts `typecheck` and `lint:worktree` | An epic run's `integrate` reads the semantic collision off them — two ranges that each passed alone and fail together show up as the merged assembly failing the checks, and a clean `git merge` alone cannot see that | **degrade** — a clean merge is then the whole `DONE` answer and a semantic collision only surfaces at the epic review; say so in the transcript comment and file the gap via `/report`. An epic run still drives; a single-issue lane is unaffected. |
 | `.gitignore` covering `.fabrika/` | The ledger is a disposable machine-local artifact, regenerable from the board — committed, it would smuggle one machine's lane state into every checkout | **degrade** — the verbs still work; state the uncovered `.fabrika/` in the park or transcript comment and file the gap via `/report`. |

--- a/claude-plugins/fabrika/skills/operate/SKILL.md
+++ b/claude-plugins/fabrika/skills/operate/SKILL.md
@@ -78,7 +78,7 @@ A lane `lane emit` booted is an epic run, and an epic run is **one branch and on
 you read: the topology parsed, so children exist. Children build in parallel worktrees, each on its
 own local branch, and land by merging into a single **assembly branch** — `epic/<lane-key>`, the
 name `lane brief` hands every child shell and the base `lane prove` reads a child's range against.
-Create it before the first dispatch, off the default branch the board names. `origin/HEAD` is
+Create it before the first dispatch, off the repository's default branch. `origin/HEAD` is
 git's own pointer to that branch — no name resolution needed; the `set-head` call refreshes the
 pointer in a checkout where it was never set:
 
@@ -188,8 +188,7 @@ exit `30` is a proven "the remote did not move" — never a `MOVED` you assume.
 
 **The first of those pushes also opens the run's one PR**, as a draft — a draft carries the CI
 signal and the board's view of the run without inviting a review the machine has not asked for.
-Open it yourself; no shell owns this branch. Its title is the epic issue's own, read off the board
-(`gh issue view $lane_key --json title`) rather than summarised by you, and its body carries two
+Open it yourself; no shell owns this branch. Its body carries two
 things, neither of them a summary you compose:
 
 - **one closing reference per child that has landed so far**, plus one on the epic issue itself.

--- a/claude-plugins/fabrika/skills/operate/SKILL.md
+++ b/claude-plugins/fabrika/skills/operate/SKILL.md
@@ -173,7 +173,7 @@ has something worth publishing. So after the merge and its checks pass, and befo
 `DONE`:
 
 ```bash
-fabrika lane push $lane_key
+node packages/fabrika-cli/src/bin.ts lane push $lane_key
 ```
 
 The verb, not your own `git push`: it derives `epic/<n>` from the number rather than taking a branch

--- a/packages/fabrika-cli/src/exit-code-alignment.ts
+++ b/packages/fabrika-cli/src/exit-code-alignment.ts
@@ -272,7 +272,8 @@ export const PATTERN_SEATS: SharedSeats = {
  * are the target that is not there (`LANE_ABSENT`), the target read in full that is not the shape
  * (`MALFORMED_RECORD`, the `review-ui` whole-record widening of the section seat), the append that
  * did not land (`APPEND_UNKNOWN`), and the read that failed before any of that could be proven
- * (`LANE_UNREADABLE`). The private band is `12`-`13`: the refused event and the unresolved task.
+ * (`LANE_UNREADABLE`). The private band runs `12`-`30`, skipping `27` and `28` because the base
+ * already speaks for both.
  */
 export const LANE_SEATS: SharedSeats = {
 	MALFORMED_RECORD: "BAD_SECTIONS",

--- a/packages/fabrika-cli/src/lane/codes.ts
+++ b/packages/fabrika-cli/src/lane/codes.ts
@@ -142,3 +142,29 @@ export const PROOF_CONTRADICTED = 24;
  * picking one would record a DONE against another lane's work — a park, never a guess.
  */
 export const PROOF_AMBIGUOUS = 25;
+
+/**
+ * The tree is not standing on the run's assembly branch — a detached HEAD, or another branch checked
+ * out. Refused before anything is pushed: the branch name is derived from the epic number, so a push
+ * from anywhere else would publish a tree this run never assembled.
+ */
+export const WRONG_BRANCH = 26;
+
+/**
+ * The push would not fast-forward — the local head does not contain the published assembly head, so
+ * it would drop commits the remote already carries. The assembly branch only ever grows (every
+ * landing is a merge onto it), so no force path exists and no flag opens one: the remedy is to fetch
+ * and re-merge, never to overwrite.
+ *
+ * `27` and `28` are skipped rather than taken: the base already speaks for both
+ * (`report`'s `QUEUE_UNREADABLE` and `SEARCH_UNREADABLE`), and `exit-code-alignment.ts` reds on a
+ * private code that collides with one of the base's.
+ */
+export const UNSAFE_PUSH = 29;
+
+/**
+ * Proven: the push ran and the remote ref is **not** at the local head. Its own seat rather than
+ * {@link APPEND_UNKNOWN}'s, because "it did not land" and "whether it landed is unreadable" take
+ * opposite remedies — push again, versus re-read before touching anything.
+ */
+export const REF_NOT_MOVED = 30;

--- a/packages/fabrika-cli/src/lane/command.ts
+++ b/packages/fabrika-cli/src/lane/command.ts
@@ -18,6 +18,7 @@ import {type LaneKey, laneRef, parseKey, templateFile} from "./key.ts";
 import {runOpen} from "./open-verb.ts";
 import {runPrint} from "./print-verb.ts";
 import {runProve} from "./prove-verb.ts";
+import {runPush} from "./push-verb.ts";
 import {keyRefusal} from "./refusals.ts";
 import {runStatus} from "./status-verb.ts";
 import {DEFAULT_CHORES_ROOT, DEFAULT_LANES_ROOT, type LaneRef} from "./store.ts";
@@ -213,6 +214,30 @@ const emitLane = leafCommand(
 	),
 );
 
+const pushLane = leafCommand(
+	"push",
+	{
+		epic: Argument.integer("epic").pipe(
+			Argument.withDescription("the epic issue whose run owns the assembly branch"),
+		),
+		root: rootFlag,
+	},
+	Effect.fn(function* ({epic, root}) {
+		yield* emit(
+			yield* runPush({
+				epic,
+				root: Option.getOrNull(root) ?? DEFAULT_LANES_ROOT,
+				lane: String(epic),
+			}),
+		);
+	}),
+).pipe(
+	Command.withShortDescription("Publish an epic run's assembly branch, confirming the ref moved."),
+	Command.withDescription(
+		"Publish the assembly branch of one epic run — `epic/<n>`, derived from the epic number and never taken from the caller — and INDEPENDENTLY confirm the remote ref moved by reading it back with git ls-remote. The sanctioned push for the one branch no spawned shell owns (ADR 0285), where `build push` refuses because the branch carries no build claim's nonce and a bare `git push` cannot report whether the ref landed (#4213). The whole report is stdout, single-stream, so `tail -1` of stdout on exit 0 is always `PUSH-VERDICT: MOVED`. No force flag exists: the assembly branch only ever grows, one merge per landed child, so a non-fast-forward push is always a mistake. Exits 4 (the lane record was read in full and is not the shape), 7 (no lane there — emit the run's machine first), 8 (pushed, but the remote ref could not be re-read — the outcome is UNKNOWN), 11 (the lane, HEAD, the remote ref or containment could not be read — nothing was pushed), 26 (the tree is not on the assembly branch, or HEAD is detached), 29 (the push would drop commits the remote holds — fetch and merge, never rewrite), 30 (proven: the remote ref did not move). Example: fabrika lane push 5680",
+	),
+);
+
 const brief = leafCommand(
 	"brief",
 	{
@@ -249,7 +274,17 @@ const brief = leafCommand(
 );
 
 export const laneCommand = Command.make("lane").pipe(
-	Command.withSubcommands([status, transition, prove, history, print, open, emitLane, brief]),
+	Command.withSubcommands([
+		status,
+		transition,
+		prove,
+		history,
+		print,
+		open,
+		emitLane,
+		brief,
+		pushLane,
+	]),
 	Command.withShortDescription("Drive one lane's state ledger by folding its event log."),
 	Command.withDescription(
 		"Drive one lane's state ledger — a @demlik/tea machine folded fresh from an append-only events.jsonl on every invocation, speaking the operator's six events (#5673). A lane is keyed by the issue number it drives, or by name as `chore:<name>` for a chore that has no issue number (#5840)",

--- a/packages/fabrika-cli/src/lane/push-verb.ts
+++ b/packages/fabrika-cli/src/lane/push-verb.ts
@@ -1,0 +1,136 @@
+/**
+ * `lane push` — publish an epic run's assembly branch, then **independently confirm the remote ref
+ * moved**.
+ *
+ * `build push` cannot serve this branch: it proves the checked-out branch carries a build claim's
+ * nonce, and the assembly branch is owned by no spawned shell (ADR 0285). The alternative was a bare
+ * `git push` in the driver's own hands, which cannot report whether the ref landed — the exact hole
+ * #4213 closed everywhere else in the corpus. So the assembly step gets a verb of its own with the
+ * same evidence discipline: `git ls-remote` asks the remote directly and the caller compares.
+ *
+ * The branch name is derived from the epic number through {@link epicBranch}, never taken from the
+ * caller, and the run's lane must be on disk — together that makes "this is the run's assembly
+ * branch" a fact read off the ledger rather than a claim the argument asserts.
+ *
+ * There is no force flag. The assembly branch only ever grows, one merge per landed child, so a
+ * non-fast-forward push is always a mistake and the flag that would let one through does not exist.
+ */
+import {Effect, type FileSystem, type Path} from "effect";
+import type {ChildProcessSpawner} from "effect/unstable/process";
+import {
+	commitsDropped,
+	ensureCommitPresent,
+	headSha,
+	isAncestor,
+	push,
+	remoteSha,
+	upstreamOf,
+} from "../build/git.ts";
+import {currentBranch} from "../io/issues.ts";
+import {answer, refuse, type VerbOutcome} from "../verb.ts";
+import {epicBranch} from "../wire/lane-brief.ts";
+import {
+	APPEND_UNKNOWN,
+	LANE_UNREADABLE,
+	REF_NOT_MOVED,
+	UNSAFE_PUSH,
+	WRONG_BRANCH,
+} from "./codes.ts";
+import {loadRefusal} from "./refusals.ts";
+import {type LaneRef, loadLane} from "./store.ts";
+
+const VERB = "fabrika lane push";
+
+export interface PushOptions extends LaneRef {
+	readonly epic: number;
+}
+
+export const runPush = (
+	options: PushOptions,
+): Effect.Effect<
+	VerbOutcome,
+	never,
+	ChildProcessSpawner.ChildProcessSpawner | FileSystem.FileSystem | Path.Path
+> =>
+	Effect.gen(function* () {
+		const loaded = yield* loadLane(options);
+		if (loaded._tag !== "Loaded") return loadRefusal(VERB, loaded);
+
+		const branch = epicBranch(options.epic);
+		const checkedOut = yield* currentBranch;
+		if (checkedOut === null) {
+			return refuse(
+				WRONG_BRANCH,
+				`${VERB}: HEAD is detached — switch to ${branch}, the run's assembly branch.`,
+			);
+		}
+		if (checkedOut !== branch) {
+			return refuse(
+				WRONG_BRANCH,
+				`${VERB}: the checked-out branch "${checkedOut}" is not #${options.epic}'s assembly branch (${branch}) — nothing was pushed.`,
+			);
+		}
+
+		const local = yield* headSha;
+		if (local._tag === "Failure") {
+			return refuse(
+				LANE_UNREADABLE,
+				`${VERB}: cannot resolve HEAD: ${local.reason} — nothing was pushed.`,
+			);
+		}
+
+		const upstream = yield* upstreamOf(branch);
+		const remote = upstream?.remote ?? "origin";
+		const ref = upstream?.ref ?? branch;
+
+		const before = yield* remoteSha(remote, ref);
+		if (before._tag === "Failure") {
+			return refuse(
+				LANE_UNREADABLE,
+				`${VERB}: cannot read ${remote}/${ref}: ${before.reason} — nothing was pushed.`,
+			);
+		}
+		if (before.value !== null) {
+			if (!(yield* ensureCommitPresent(remote, ref, before.value))) {
+				return refuse(
+					LANE_UNREADABLE,
+					`${VERB}: cannot prove containment — ${remote}/${ref} is at ${before.value}, which this checkout does not hold and could not fetch. Nothing was pushed.`,
+				);
+			}
+			if (!(yield* isAncestor(before.value, local.value))) {
+				const dropped = yield* commitsDropped(local.value, before.value);
+				return refuse(
+					UNSAFE_PUSH,
+					`${VERB}: the local head does not contain ${remote}/${ref} (${before.value}) — this push would DROP ${
+						dropped.lines.length === 0
+							? "commits the remote holds and this head does not"
+							: `${dropped.lines.join("; ")}${dropped.truncated ? "; …" : ""}`
+					}. Fetch and merge the published assembly head; the assembly branch is never rewritten.`,
+				);
+			}
+		}
+
+		const pushed = yield* push(remote, ref, false);
+		const after = yield* remoteSha(remote, ref);
+		if (after._tag === "Failure") {
+			return refuse(
+				APPEND_UNKNOWN,
+				`${VERB}: pushed, but the remote ref could not be re-read: ${after.reason} — the outcome is UNKNOWN.`,
+			);
+		}
+		if (after.value !== local.value) {
+			return refuse(
+				REF_NOT_MOVED,
+				`${VERB}: the remote ref did not move (remote ${after.value ?? "absent"} ≠ local ${local.value}).`,
+				pushed._tag === "Failure" ? [`${VERB}: git push reported: ${pushed.reason}.`] : [],
+			);
+		}
+		return answer(
+			[
+				`pushed ${branch} → ${remote}/${ref}`,
+				`remote ref read back: ${after.value}`,
+				"PUSH-VERDICT: MOVED",
+			].join("\n"),
+			[`${VERB}: assembly branch of the lane at ${loaded.dir}.`],
+		);
+	});

--- a/packages/fabrika-cli/src/lane/push-verb.unit.test.ts
+++ b/packages/fabrika-cli/src/lane/push-verb.unit.test.ts
@@ -1,0 +1,160 @@
+/** `lane push` — the assembly branch is derived, the push is proven, and no force path exists. */
+import {Effect, Layer} from "effect";
+import {describe, expect, it} from "vitest";
+import {HEAD, OLD_HEAD} from "../build/fixtures.test-support.ts";
+import {errOut, fakeFs, fakeShell, okOut, once} from "../fakes.test-support.ts";
+import type {ExecResult} from "../io/exec.ts";
+import {
+	APPEND_UNKNOWN,
+	LANE_ABSENT,
+	LANE_UNREADABLE,
+	REF_NOT_MOVED,
+	UNSAFE_PUSH,
+	WRONG_BRANCH,
+} from "./codes.ts";
+import {coderTemplateText} from "./fixtures.test-support.ts";
+import {runPush} from "./push-verb.ts";
+
+const ROOT = ".fabrika/lanes";
+const EPIC = 5680;
+const BRANCH = `epic/${EPIC}`;
+const LANE_FILES = {[`${ROOT}/${EPIC}/workflow.json`]: coderTemplateText()};
+
+const CURRENT_BRANCH = /^git rev-parse --abbrev-ref HEAD$/;
+const HEAD_SHA = /^git rev-parse HEAD$/;
+const UPSTREAM = /^git rev-parse --abbrev-ref --symbolic-full-name /;
+const PRESENT = /^git rev-parse --verify --quiet /;
+const LS_REMOTE = /^git ls-remote origin /;
+const PUSH = /^git push /;
+const ANCESTOR = /^git merge-base --is-ancestor /;
+const LOG = /^git log /;
+
+/** `git ls-remote` output for the assembly ref; an absent ref prints nothing. */
+const refRow = (sha: string | null): ExecResult =>
+	okOut(sha === null ? "" : `${sha}\trefs/heads/${BRANCH}\n`);
+
+/**
+ * The two `ls-remote` reads one run makes, in order: the head before the push, then the read-back.
+ * They are the same command line, so the first entry is spent by {@link once}.
+ */
+const remote = (
+	before: ExecResult,
+	after: ExecResult,
+): ReadonlyArray<readonly [RegExp, ExecResult]> => [
+	[once(LS_REMOTE), before],
+	[LS_REMOTE, after],
+];
+
+/** On the assembly branch, at HEAD, with a remote head this checkout holds and contains. */
+const GROUND: ReadonlyArray<readonly [RegExp, ExecResult]> = [
+	[CURRENT_BRANCH, okOut(`${BRANCH}\n`)],
+	[HEAD_SHA, okOut(`${HEAD}\n`)],
+	[UPSTREAM, errOut("fatal: no upstream")],
+	[PRESENT, okOut(`${OLD_HEAD}\n`)],
+	[ANCESTOR, okOut("")],
+	[PUSH, okOut("")],
+];
+
+const run = (
+	script: ReadonlyArray<readonly [RegExp, ExecResult]>,
+	files: Record<string, string> = LANE_FILES,
+) => {
+	const shell = fakeShell(script);
+	return Effect.runPromise(
+		Effect.provide(
+			runPush({epic: EPIC, root: ROOT, lane: String(EPIC)}),
+			Layer.merge(shell.layer, fakeFs({files}).layer),
+		),
+	).then((outcome) => ({outcome, calls: shell.calls}));
+};
+
+const pushed = (calls: ReadonlyArray<string>): boolean =>
+	calls.some((line) => line.startsWith("git push"));
+
+describe("runPush", () => {
+	it("pushes the derived assembly branch and reports MOVED once the remote reads back at HEAD", async () => {
+		const {outcome, calls} = await run([...remote(refRow(OLD_HEAD), refRow(HEAD)), ...GROUND]);
+
+		expect(outcome.code).toBe(0);
+		expect(outcome.stdout.trimEnd().split("\n").at(-1)).toBe("PUSH-VERDICT: MOVED");
+		expect(calls).toContain(`git push origin HEAD:refs/heads/${BRANCH}`);
+	});
+
+	it("publishes a branch the remote does not carry yet, with no containment to prove", async () => {
+		const {outcome, calls} = await run([...remote(refRow(null), refRow(HEAD)), ...GROUND]);
+
+		expect(outcome.code).toBe(0);
+		expect(outcome.stdout).toContain(`remote ref read back: ${HEAD}`);
+		expect(calls.some((line) => line.startsWith("git merge-base"))).toBe(false);
+	});
+
+	it("refuses a checked-out branch that is not this epic's assembly branch, pushing nothing", async () => {
+		const {outcome, calls} = await run([
+			[CURRENT_BRANCH, okOut("build/5729-child-a1b2c3d4\n")],
+			...remote(refRow(OLD_HEAD), refRow(HEAD)),
+			...GROUND,
+		]);
+
+		expect(outcome.code).toBe(WRONG_BRANCH);
+		expect(outcome.stdout).toBe("");
+		expect(outcome.stderr.join("\n")).toContain(BRANCH);
+		expect(pushed(calls)).toBe(false);
+	});
+
+	it("refuses a detached HEAD as a wrong branch, not as an unreadable tree", async () => {
+		const {outcome, calls} = await run([
+			[CURRENT_BRANCH, okOut("HEAD\n")],
+			...remote(refRow(OLD_HEAD), refRow(HEAD)),
+			...GROUND,
+		]);
+
+		expect(outcome.code).toBe(WRONG_BRANCH);
+		expect(outcome.stderr.join("\n")).toContain("detached");
+		expect(pushed(calls)).toBe(false);
+	});
+
+	it("refuses a push that would drop the published assembly head, naming the commits", async () => {
+		const {outcome, calls} = await run([
+			[ANCESTOR, errOut("not an ancestor")],
+			[LOG, okOut("deadbee land child #5729\n")],
+			...remote(refRow(OLD_HEAD), refRow(HEAD)),
+			...GROUND,
+		]);
+
+		expect(outcome.code).toBe(UNSAFE_PUSH);
+		expect(outcome.stderr.join("\n")).toContain("land child #5729");
+		expect(pushed(calls)).toBe(false);
+	});
+
+	it("reports a proven not-moved ref rather than reading the push's own exit as evidence", async () => {
+		const {outcome, calls} = await run([...remote(refRow(OLD_HEAD), refRow(OLD_HEAD)), ...GROUND]);
+
+		expect(outcome.code).toBe(REF_NOT_MOVED);
+		expect(outcome.stdout).toBe("");
+		expect(pushed(calls)).toBe(true);
+	});
+
+	it("reports UNKNOWN, never MOVED, when the ref cannot be re-read after the push", async () => {
+		const {outcome} = await run([
+			...remote(refRow(OLD_HEAD), errOut("network is unreachable")),
+			...GROUND,
+		]);
+
+		expect(outcome.code).toBe(APPEND_UNKNOWN);
+		expect(outcome.stderr.join("\n")).toContain("UNKNOWN");
+	});
+
+	it("refuses an unreadable remote before pushing anything", async () => {
+		const {outcome, calls} = await run([[LS_REMOTE, errOut("network is unreachable")], ...GROUND]);
+
+		expect(outcome.code).toBe(LANE_UNREADABLE);
+		expect(pushed(calls)).toBe(false);
+	});
+
+	it("refuses an epic whose lane was never emitted — a branch name alone proves nothing", async () => {
+		const {outcome, calls} = await run([...remote(refRow(OLD_HEAD), refRow(HEAD)), ...GROUND], {});
+
+		expect(outcome.code).toBe(LANE_ABSENT);
+		expect(calls).toEqual([]);
+	});
+});


### PR DESCRIPTION
`operate` now knows how to drive an epic run under the one-PR shape its machine already emits. Before this, a driver that reached a child's `integrate` state parked on `lane brief` exit 18 — no actor was named for the merge.

What the epic-lane section adds:

- **One assembly branch, cut at boot.** `epic/<lane-key>`, off the default branch the board names. That is the name `lane brief` hands every child shell and the base `lane prove` reads a child's range against, so without it every child's proof reads UNKNOWN.
- **`integrate` is the driver's own merge**, because no spawned worktree owns the branch it lands on. The branch to merge comes off `lane prove`'s `PASS` evidence (`evidence.branch`), never a name composed by hand; `git merge`'s exit is the `DONE`/`FAIL`, and a clean merge that fails the repo's checks is the semantic collision, the same `FAIL`. The assembly branch moves only on a `DONE` — either failure resets it, so the recorded `FAIL` names a branch that never carried the bad merge.
- **Push per integration, never per repair round.** One draft PR opens at the first integration; its body carries one closing reference per landed child plus one on the epic (that one is how `lane brief` resolves the tail's PR at all — without it every tail dispatch is exit 20), and a `## Deviations` section scoped to the merges the driver performed. The draft flips ready at the tail's `PASS`, before `ship`, whose write verbs refuse a draft.
- Two routing rows the reshaped machine needs: `integrate`, and a task sitting in its own final (`landed`/`shipped`/`frozen`) inside a phase a sibling is still active in — which the old table would have ended `STOPPED` on.

The collision route, the re-review-before-landing ordering, and the retry budget are all stated as the machine's graph rather than the driver's judgment; the merge verdict is git's exit and the branch is the proof verb's field.

Single-issue lanes are untouched: every addition is scoped to a lane `lane emit` booted, and no prompt, commit assertion or boot state changes.

Fixes #5830

## Deviations

- **Out-of-scope change** — **Said:** #5830 names the epic-lane choreography. **Did:** also added a routing row for a task in its own final state (`landed`/`shipped`/`frozen`). **Why:** the reshaped child region ends in `landed` while siblings in the same phase are still active, so the fold prints a final leaf the old table would have ended `STOPPED` on — the choreography is unroutable without it. **Disposition:** stated here.
- **Declined guidance** — **Said:** the plan describes the choreography as relaying verbs. **Did:** the integrate merge, the push, and the PR open/edit/ready-flip are plain `git` and `gh` calls, not fabrika verbs. **Why:** no verb owns them today — `build pr` requires a lane claim and refuses a duplicated closing keyword, and `build check` refuses a branch that is not a lane branch. Each call still relays an answer (git's exit, the board's default branch and title, `lane prove`'s branch field) rather than deriving one. **Disposition:** stated here; a verb for the assembly step is worth filing if the shape holds after a real run.
- **Known defect left unfixed** — **Said:** nothing about where a child's build deviations are disclosed. **Did:** left it unfixed and scoped the PR body's `## Deviations` to the assembly only. **Why:** a child opens no PR, so `build`'s only disclosure surface does not exist for it; choosing a new home is a design question, not this PR's. **Disposition:** filed as #5903.

- **Out-of-scope change** — **Said:** #5830 scopes this to the skill document, "no runtime code path". **Did:** added `fabrika lane push <epic>`, its unit tests, and three lane exit codes. **Why:** review round 1 appended an acceptance criterion requiring the push step to clear the corpus' bare-`git push` guard, and no existing verb can serve the assembly branch — `build push` proves a build claim's nonce that branch does not carry, and fabrika calls `pipeline-cli` nowhere (ADR 0238), so `verified-push` is not reachable either. The criterion is unsatisfiable without a verb. **Disposition:** stated here; it supersedes the push half of the "Declined guidance" entry above, whose merge, reset and PR-open halves still stand as written.


- **Out-of-scope actor** — **Said:** repairs land through the builder's repair loop. **Did:** the round-4+ commits `73ca7ec6`, `7073a30a` (merge of main, keep-both on the lane subcommand array) `55ba88c7` (the fences drop their derived values entirely: `origin/HEAD` for the branch cut, defaulted `--base` and a literal lane-key title for the draft) and `0196ea51` (deleting the orphaned epic-title read that 55ba88c7 left behind) were authored by the driver directly, past the spent three-round repair budget. **Why:** the retry budget was spent with only corpus-rule findings open; the founder ruled to land the issue narrow — fences fixed as plain sequential reads, no further runtime verbs — and the driver-side edit outside the repair loop is the sanctioned cap-clear (precedent: PR #5788). Verb-ization of these reads is deliberately deferred to #5905. **Disposition:** stated here.


