### PR TITLE
chore: repair claim admits a served decision issue when an open PR exists

### DIFF
--- a/claude-plugins/fabrika/skills/build/SKILL.md
+++ b/claude-plugins/fabrika/skills/build/SKILL.md
@@ -223,6 +223,12 @@ fabrika build claim $issue_or_pr_number
 fabrika build verdicts --pr $issue_or_pr_number
 ```
 
+**Step 1's "never claim a `type:decision`" is about picking one up fresh, and it does not reach
+here.** An ADR PR is served by a decision issue, and repairing it is the ordinary path: the claim
+admits it with no flag and no `--override`, and says so on its purpose line (#5914). Everything else
+still refuses — the same decision issue claimed by its own number is `21`, and the scope fence binds
+this claim exactly as it binds a build.
+
 The fold is the only entry: paginated, current-head, per-gate — polarity visible, round count
 included. Act only on rows it prints; empty rows at exit 0 are a proven no-work answer, but an
 UNKNOWN exit means the verdict state is unread — **never "nothing to fix"**. The budget is the

--- a/claude-plugins/fabrika/skills/build/contract.md
+++ b/claude-plugins/fabrika/skills/build/contract.md
@@ -121,7 +121,8 @@ from two separate questions, computed together and answered together:
 - **The audience axis** — is the issue's `ready-for:` label `ready-for:agent`? This axis is older
   than the fence (#4780); `build pick` already carried it, and ADR 0245 asks for the scope axis to
   be added **beside** it, not folded into it. Refusal is `21`, and it binds a **build-purpose** claim
-  only (see `build claim`'s `--purpose`, #5175).
+  only (see `build claim`'s `--purpose`, #5175) — and not even that one when the claim repairs an
+  open PR whose served issue is `type:decision` (#5914).
 
 **Keep the two names apart.** *Scope admission* is a different question from the audience axis (who
 the work is for), from dependency eligibility (`build eligible` asks whether an issue's predecessors
@@ -639,6 +640,18 @@ repair round settled. A `21` is therefore reachable under `--purpose build` only
 reachable under every purpose. `claim`'s purpose line names which reading applied, and the audience
 it saw either way, so a claim admitted over a non-agent audience is readable as one afterwards.
 
+**Repair of a decision PR is admitted on its own, with no flag and no override.** When `<number>` is
+an open PR and the issue it serves carries `type:decision`, the audience axis does not bind that
+claim (founder ruling on [#5866](https://github.com/kamp-us/phoenix/issues/5866), built as #5914).
+Triage routes a decision to `ready-for:human`, so `type:decision` and `ready-for:agent` are mutually
+exclusive by construction and an ADR PR's repair lane was failing a fence it could never pass — the
+only way through was `--override`, which spent a founder-authorized escape hatch on routine repair.
+The exemption is read off the **target**, not typed: there is no `--purpose repair`, because a flag
+could be passed against a bare issue and would then have to be refused, while naming a PR is already
+proof that a build is in flight. Its width is exactly one pairing — the same decision issue claimed
+directly is still `21`, an open PR serving any other type still reads the audience label, and the
+scope axis is untouched. `claim`'s purpose line names the exemption when it fires.
+
 This is the seam where the refusal has teeth. A pool filter is bypassed by an operator naming a
 number, and a number handed straight to `claim` passes through no pool — claiming is the moment work
 starts and the one moment every path goes through (ADR 0245). `--override "<reason>"
@@ -683,7 +696,7 @@ proven-foreign only; a missing session id is `1`; an unreadable marker set is `1
 | `11` | the marker set could not be read — ownership is UNKNOWN, never "unclaimed"; or, `claim` only, the focus declaration or the issue's home could not be read — scope admission is UNKNOWN, never admitted |
 | `15` | proven: another session's earlier authorized marker wins (`claim`), holds (`confirm`), or `release` was asked for a token this session does not hold |
 | `20` | `claim` only, proven: the issue's home is outside the declared focus — no marker was written |
-| `21` | `claim --purpose build` only (the default), proven: the issue's audience is not an agent — no marker was written |
+| `21` | `claim --purpose build` only (the default), proven: the issue's audience is not an agent — no marker was written. Unreachable when the target is an open PR serving a `type:decision` issue (#5914) |
 
 **Errors**
 

--- a/packages/fabrika-cli/src/build/claim-verb.ts
+++ b/packages/fabrika-cli/src/build/claim-verb.ts
@@ -19,7 +19,9 @@
  * running lane or block its release. Claiming is the one moment every path goes through — a number
  * handed straight to `claim` passes through no pool — which is why the refusal has teeth here and is
  * advice at the pool. In repair the number is a **PR**, which carries no home and no audience of its
- * own, so the test runs over the issue that PR serves (#5562).
+ * own, so the test runs over the issue that PR serves (#5562) — and when that issue is
+ * `type:decision` the audience axis does not bind, because triage bars a decision from
+ * `ready-for:agent` and the fence could otherwise never be satisfied (#5914).
  */
 import {Effect, type FileSystem} from "effect";
 import type {ChildProcessSpawner} from "effect/unstable/process";
@@ -48,6 +50,7 @@ import {
 	CLAIM_PURPOSES,
 	DEFAULT_CLAIM_PURPOSE,
 	focusScopeLine,
+	NOT_REPAIR,
 	parseClaimPurpose,
 	purposeScopeLine,
 	readDeclaredFocus,
@@ -181,10 +184,11 @@ export const runClaim = (
 		const scopeLine = focusScopeLine(CLAIM, read.focus);
 		const subject = yield* resolveAdmissionSubject(CLAIM, repo, read.focus, ready.issue);
 		const judged = subject._tag === "Judged" ? subject.facts : ready.issue;
-		const purposeLine = purposeScopeLine(CLAIM, purpose, audienceAxisOf(judged));
+		const repair = subject._tag === "Judged" ? subject.repair : NOT_REPAIR;
+		const purposeLine = purposeScopeLine(CLAIM, purpose, audienceAxisOf(judged), repair);
 		const admission =
 			subject._tag === "Judged"
-				? admissionOf(read.focus, subject.facts, purpose)
+				? admissionOf(read.focus, subject.facts, purpose, repair)
 				: subject.admission;
 		const lines = [
 			scopeLine,

--- a/packages/fabrika-cli/src/build/claim-verb.unit.test.ts
+++ b/packages/fabrika-cli/src/build/claim-verb.unit.test.ts
@@ -605,6 +605,71 @@ describe("runClaim — a PR number is judged by the issue it serves", () => {
 			expect(shell.calls.some((line) => POST.test(line))).toBe(false);
 		});
 	});
+
+	/**
+	 * The decision arm (founder ruling on #5866, built as #5914). An ADR PR is served by a
+	 * `type:decision` issue, and triage routes those to `ready-for:human` — so before this the repair
+	 * lane failed a fence the issue could never pass, and the only way through was an operator's
+	 * `--override`, which spent the override's audit value on routine repair.
+	 */
+	describe("a decision issue served by an open PR", () => {
+		const DECISION = labelled("status:triaged", "type:decision", "ready-for:human");
+
+		it("admits the repair claim with no override, and writes the marker", async () => {
+			const {out, shell} = await claimPull("Fixes #5553\n", served(44, DECISION));
+			expect(out.code).toBe(0);
+			expect(JSON.parse(out.stdout)).toEqual({
+				answer: "won",
+				number: 4312,
+				purpose: "build",
+				token: `build:s-9f2e:${LANE_UUID}`,
+			});
+			expect(shell.calls.some((line) => POST.test(line))).toBe(true);
+			expect(
+				out.stderr.some((line) =>
+					line.includes(
+						"repairing open PR #4312, whose served issue is type:decision: the audience axis does not bind (#5914)",
+					),
+				),
+			).toBe(true);
+		});
+
+		it("records no override on the answer — the ruling made this the ordinary path", async () => {
+			const {out} = await claimPull("Fixes #5553\n", served(44, DECISION));
+			expect(JSON.parse(out.stdout).override).toBeUndefined();
+		});
+
+		it("refuses the very same issue at 21 when it is claimed directly, writing nothing", async () => {
+			const shell = fakeShell([
+				[ISSUE, issue({milestone: {number: 44}, labels: DECISION})],
+				[POST, POSTED],
+				[GET_COMMENT, ECHO],
+				[COMMENTS, comments({id: 9001, body: MINE})],
+				[perm("agent"), okOut("write\n")],
+			]);
+			const out = await Effect.runPromise(
+				Effect.provide(runClaim(options), Layer.merge(shell.layer, FOCUSED.layer)),
+			);
+			expect(out.code).toBe(AUDIENCE_NOT_AGENT);
+			expect(shell.calls.some((line) => POST.test(line))).toBe(false);
+			expect(out.stderr.some((line) => line.includes("audience not agent"))).toBe(true);
+		});
+
+		it("keeps the fence for every other type an open PR serves", async () => {
+			const {out, shell} = await claimPull(
+				"Fixes #5553\n",
+				served(44, labelled("status:triaged", "type:bug", "ready-for:human")),
+			);
+			expect(out.code).toBe(AUDIENCE_NOT_AGENT);
+			expect(shell.calls.some((line) => POST.test(line))).toBe(false);
+		});
+
+		it("keeps the scope fence armed — an out-of-focus decision PR is still 20", async () => {
+			const {out, shell} = await claimPull("Fixes #5553\n", served(39, DECISION));
+			expect(out.code).toBe(OUT_OF_FOCUS);
+			expect(shell.calls.some((line) => POST.test(line))).toBe(false);
+		});
+	});
 });
 
 /**

--- a/packages/fabrika-cli/src/build/scope-admission.ts
+++ b/packages/fabrika-cli/src/build/scope-admission.ts
@@ -44,6 +44,14 @@ export type StandingLaneLabel = (typeof STANDING_LANE_LABELS)[number];
 export const READY_FOR_AGENT = "ready-for:agent";
 const READY_FOR_PREFIX = "ready-for:";
 
+/**
+ * The type whose deliverable is a recorded choice rather than a pull request — `/adr`'s lane.
+ *
+ * Triage routes such an issue to `ready-for:human`, so `type:decision` and `ready-for:agent` are
+ * mutually exclusive by construction. That is the collision {@link RepairClaim} answers.
+ */
+export const DECISION_TYPE_LABEL = "type:decision";
+
 /** Everything either axis reads off an issue — no derived field, and nothing else. */
 export interface IssueFacts {
 	readonly number: number;
@@ -235,8 +243,46 @@ export const DEFAULT_CLAIM_PURPOSE: ClaimPurpose = "build";
 export const parseClaimPurpose = (value: string): ClaimPurpose | null =>
 	CLAIM_PURPOSES.find((purpose) => purpose === value) ?? null;
 
-/** Only a build-purpose claim is bound by the audience axis (#5175). Scope binds every purpose. */
-export const audienceAxisBinds = (purpose: ClaimPurpose): boolean => purpose === "build";
+/**
+ * Whether this claim repairs an open pull request, and whether the issue that PR serves is a
+ * decision.
+ *
+ * A claim's target is either an issue — a fresh build — or an open PR, which can only be a repair:
+ * the PR exists, so "should an agent start this" is already answered. The word is therefore
+ * **derived from the target**, never typed. A `--purpose repair` flag would be passable against a
+ * bare issue, which is a state the seam would then have to refuse; deriving it means the only way to
+ * be in repair is to name a PR (founder ruling on #5866, #5914).
+ */
+export type RepairClaim =
+	/** The target is an issue and judges itself — no PR is in flight. */
+	| {readonly _tag: "NotRepair"}
+	/** An open PR serves this issue, whose deliverable is a recorded decision. */
+	| {readonly _tag: "DecisionRepair"; readonly pr: number}
+	/** An open PR serves this issue, and the issue is not a decision. */
+	| {readonly _tag: "OrdinaryRepair"; readonly pr: number};
+
+/** The reading every seam but the claim path takes: the pool judges issues, never a PR in flight. */
+export const NOT_REPAIR: RepairClaim = {_tag: "NotRepair"};
+
+/** Read the repair state off an open PR and the issue the fence judges in its place. */
+export const repairClaimOf = (pr: number, served: IssueFacts): RepairClaim =>
+	served.labels.includes(DECISION_TYPE_LABEL)
+		? {_tag: "DecisionRepair", pr}
+		: {_tag: "OrdinaryRepair", pr};
+
+/**
+ * Only a build-purpose claim is bound by the audience axis (#5175), and not even that one when it
+ * repairs an open PR whose served issue is a decision. Scope binds every purpose and every repair.
+ *
+ * The exemption is narrow on purpose: it is the one pairing where the fence can never be satisfied,
+ * because a decision issue is barred from `ready-for:agent` by triage's own routing. An ordinary
+ * repair still reads the audience label, so an issue re-routed to a human mid-flight still stops a
+ * builder — the founder's ruling exempts decisions, not repair at large.
+ */
+export const audienceAxisBinds = (
+	purpose: ClaimPurpose,
+	repair: RepairClaim = NOT_REPAIR,
+): boolean => purpose === "build" && repair._tag !== "DecisionRepair";
 
 /** Absence is an unknown audience, never an agent audience (#4780). */
 export const audienceAxisOf = (issue: IssueFacts): AudienceAxis =>
@@ -296,13 +342,15 @@ export const noServedIssue = (pr: number, focus: number, reason: string): Admiss
  * send an operator to re-label work that the scope fence would refuse again. The unreported axis is
  * still on the outcome.
  *
- * `purpose` decides only whether an audience refusal is *seated*; the audience verdict itself is read
- * and reported either way, so a `plan`/`gate` claim admitted over a non-agent audience still says so.
+ * `purpose` and `repair` decide only whether an audience refusal is *seated*; the audience verdict
+ * itself is read and reported either way, so a claim admitted over a non-agent audience still says
+ * so.
  */
 export const admissionOf = (
 	focus: Focus,
 	issue: IssueFacts,
 	purpose: ClaimPurpose = DEFAULT_CLAIM_PURPOSE,
+	repair: RepairClaim = NOT_REPAIR,
 ): Admission => {
 	if (focus._tag === "Malformed") {
 		return {
@@ -314,7 +362,7 @@ export const admissionOf = (
 	const scope = scopeAxisOf(focus, issue);
 	const audience = audienceAxisOf(issue);
 	if (scope._tag === "OutOfFocus") return {_tag: "OutOfFocus", scope, audience};
-	if (audience._tag === "NotAgent" && audienceAxisBinds(purpose)) {
+	if (audience._tag === "NotAgent" && audienceAxisBinds(purpose, repair)) {
 		return {_tag: "AudienceNotAgent", scope, audience};
 	}
 	return {_tag: "Admitted", scope, audience};
@@ -362,7 +410,7 @@ export const ADMISSION_EXIT_CODES: ReadonlyArray<{
 	},
 	{
 		code: AUDIENCE_NOT_AGENT,
-		condition: `proven: not admitted on the audience axis — the issue's ${READY_FOR_PREFIX} label is not ${READY_FOR_AGENT}, or is absent; reachable only under purpose build`,
+		condition: `proven: not admitted on the audience axis — the issue's ${READY_FOR_PREFIX} label is not ${READY_FOR_AGENT}, or is absent; reachable only under purpose build, and never when an open PR serves a ${DECISION_TYPE_LABEL} issue`,
 	},
 ];
 
@@ -371,11 +419,15 @@ export const purposeScopeLine = (
 	verb: string,
 	purpose: ClaimPurpose,
 	audience: AudienceAxis,
+	repair: RepairClaim = NOT_REPAIR,
 ): string => {
 	const carried =
 		audience._tag === "Agent"
 			? READY_FOR_AGENT
 			: (audience.label ?? `no ${READY_FOR_PREFIX} label`);
+	if (repair._tag === "DecisionRepair") {
+		return `${verb}: purpose: ${purpose} — repairing open PR #${repair.pr}, whose served issue is ${DECISION_TYPE_LABEL}: the audience axis does not bind (#5914); this issue carries ${carried}.`;
+	}
 	return audienceAxisBinds(purpose)
 		? `${verb}: purpose: ${purpose} — the audience axis binds; this issue carries ${carried}.`
 		: `${verb}: purpose: ${purpose} — the audience axis does not bind a ${purpose} claim (#5175); this issue carries ${carried}.`;

--- a/packages/fabrika-cli/src/build/scope-admission.unit.test.ts
+++ b/packages/fabrika-cli/src/build/scope-admission.unit.test.ts
@@ -10,6 +10,7 @@ import {
 	audienceAxisBinds,
 	audienceAxisOf,
 	CLAIM_PURPOSES,
+	DECISION_TYPE_LABEL,
 	DEFAULT_CLAIM_PURPOSE,
 	DEFAULT_ROADMAP,
 	exclusionReasonOf,
@@ -18,11 +19,13 @@ import {
 	focusScopeLine,
 	homeOf,
 	type IssueFacts,
+	NOT_REPAIR,
 	noServedIssue,
 	parseClaimPurpose,
 	purposeScopeLine,
 	readDeclaredFocus,
 	readFocus,
+	repairClaimOf,
 	STANDING_LANE_LABELS,
 	scopeAxisOf,
 	scopeSubjectOf,
@@ -227,6 +230,76 @@ describe("admissionOf", () => {
 			);
 			expect(purposeScopeLine("build claim", "gate", audience)).toContain(
 				"the audience axis does not bind a gate claim (#5175)",
+			);
+		});
+	});
+
+	/**
+	 * The repair carve-out (founder ruling on #5866, built as #5914). A decision issue can never carry
+	 * `ready-for:agent` — triage routes it to a human — so the fence it fails is one it could never
+	 * pass. The exemption is therefore conditioned on an open PR already serving it, and on nothing
+	 * else: no PR, no exemption, and no other type gets one.
+	 */
+	describe("repair of an open PR whose served issue is a decision", () => {
+		const decision = issue({labels: ["status:triaged", "type:decision", "ready-for:human"]});
+		const decisionRepair = repairClaimOf(4703, decision);
+
+		it("admits it under the default build purpose, with no override", () => {
+			expect(decisionRepair).toEqual({_tag: "DecisionRepair", pr: 4703});
+			const out = admissionOf(declared, decision, DEFAULT_CLAIM_PURPOSE, decisionRepair);
+			expect(out._tag).toBe("Admitted");
+			expect(admissionRefusal("build claim", out)).toBeNull();
+		});
+
+		it("still reports the non-agent audience it saw, so the exemption is readable afterwards", () => {
+			const out = admissionOf(declared, decision, DEFAULT_CLAIM_PURPOSE, decisionRepair);
+			const audience = audienceAxisOf(decision);
+			expect(out._tag === "Admitted" && out.audience).toEqual(audience);
+			expect(audience).toEqual({_tag: "NotAgent", label: "ready-for:human"});
+			expect(purposeScopeLine("build claim", "build", audience, decisionRepair)).toBe(
+				"build claim: purpose: build — repairing open PR #4703, whose served issue is type:decision: the audience axis does not bind (#5914); this issue carries ready-for:human.",
+			);
+		});
+
+		it("refuses the same decision issue at 21 with no PR serving it — the other arm", () => {
+			expect(audienceAxisBinds("build", NOT_REPAIR)).toBe(true);
+			const out = admissionOf(declared, decision);
+			expect(out._tag).toBe("AudienceNotAgent");
+			expect(admissionRefusal("build claim", out)?.code).toBe(AUDIENCE_NOT_AGENT);
+			expect(purposeScopeLine("build claim", "build", audienceAxisOf(decision))).toContain(
+				"the audience axis binds",
+			);
+		});
+
+		it("exempts the decision type only — an ordinary repair still reads the audience label", () => {
+			const human = issue({labels: ["status:triaged", "type:bug", "ready-for:human"]});
+			const ordinary = repairClaimOf(4703, human);
+			expect(ordinary).toEqual({_tag: "OrdinaryRepair", pr: 4703});
+			expect(audienceAxisBinds("build", ordinary)).toBe(true);
+			expect(admissionOf(declared, human, DEFAULT_CLAIM_PURPOSE, ordinary)._tag).toBe(
+				"AudienceNotAgent",
+			);
+		});
+
+		it("leaves the scope axis armed — an out-of-focus decision PR is still 20", () => {
+			const elsewhere = issue({
+				milestone: 24,
+				labels: ["status:triaged", "type:decision", "ready-for:human"],
+			});
+			const out = admissionOf(
+				declared,
+				elsewhere,
+				DEFAULT_CLAIM_PURPOSE,
+				repairClaimOf(4703, elsewhere),
+			);
+			expect(out._tag).toBe("OutOfFocus");
+			expect(admissionRefusal("build claim", out)?.code).toBe(OUT_OF_FOCUS);
+		});
+
+		it("names the decision label once, so the test and the fence read the same string", () => {
+			expect(DECISION_TYPE_LABEL).toBe("type:decision");
+			expect(repairClaimOf(4703, issue({labels: [DECISION_TYPE_LABEL]}))._tag).toBe(
+				"DecisionRepair",
 			);
 		});
 	});

--- a/packages/fabrika-cli/src/build/target.ts
+++ b/packages/fabrika-cli/src/build/target.ts
@@ -16,7 +16,10 @@ import {
 	type Admission,
 	type Focus,
 	type IssueFacts,
+	NOT_REPAIR,
 	noServedIssue,
+	type RepairClaim,
+	repairClaimOf,
 	scopeSubjectOf,
 	unknownAdmission,
 } from "./scope-admission.ts";
@@ -99,6 +102,13 @@ export type AdmissionSubject =
 			readonly facts: IssueFacts;
 			/** What the fence judged, when that is not the named target itself. */
 			readonly note: string | null;
+			/**
+			 * Whether this claim repairs an open PR — derived here, the one place that proves it.
+			 *
+			 * The caller reached this through {@link openIssue}, which refuses a closed target, so a
+			 * resolved served issue means an **open** PR serves it (#5914).
+			 */
+			readonly repair: RepairClaim;
 	  }
 	| {readonly _tag: "Refused"; readonly admission: Admission};
 
@@ -111,6 +121,9 @@ export type AdmissionSubject =
  * its own record while the fence is inert instead of refusing at `20`. A served issue that cannot be
  * READ is UNKNOWN at either setting — `11`, and outside the overridable set, because a fence that
  * could not read its input has proven nothing.
+ *
+ * Resolving the subject is also what proves the {@link RepairClaim}: only a PR's path reaches a
+ * served issue, so this is the one place that can answer "is an open PR already in flight here".
  */
 export const resolveAdmissionSubject = (
 	verb: string,
@@ -119,7 +132,7 @@ export const resolveAdmissionSubject = (
 	target: IssueRecord,
 ): Effect.Effect<AdmissionSubject, never, ChildProcessSpawner.ChildProcessSpawner> =>
 	Effect.gen(function* () {
-		const own = {_tag: "Judged" as const, facts: target, note: null};
+		const own = {_tag: "Judged" as const, facts: target, note: null, repair: NOT_REPAIR};
 		const subject = scopeSubjectOf(target);
 		if (subject._tag === "Own") return own;
 		const unresolved = (reason: string): AdmissionSubject =>
@@ -148,6 +161,7 @@ export const resolveAdmissionSubject = (
 			_tag: "Judged" as const,
 			facts: served.value,
 			note: `${verb}: subject: PR #${target.number} serves #${subject.number} (${subject.kind}) — the admission test judges that issue, not the PR's own empty home.`,
+			repair: repairClaimOf(target.number, served.value),
 		};
 	});
 


### PR DESCRIPTION
An ADR pull request is served by a decision-type issue, and triage routes decisions to
`ready-for:human` — so the decision type and `ready-for:agent` are mutually exclusive by
construction. That made `build claim <pr>` refuse every ADR PR's repair lane at exit 21, on a fence
the served issue could never pass. The only way through was `--override` + `--override-lane`, which
spends a founder-authorized escape hatch on routine repair and erodes what the override means.

Per the founder's ruling on #5866: when an open PR already serves a decision-type issue, the
audience axis does not bind that claim. No flag, no override.

**What changed**

- `scope-admission.ts` grows a `RepairClaim` — `NotRepair` | `DecisionRepair` | `OrdinaryRepair` —
  and `audienceAxisBinds` takes it beside the purpose. The exemption fires on `DecisionRepair` only.
- `target.ts` derives the repair state where it is actually proven: only a PR's path resolves to a
  served issue, and the caller reached it through `openIssue`, which refuses a closed target — so a
  resolved served issue means an *open* PR serves it.
- `claim-verb.ts` threads it into the admission test and into the purpose line, which names the
  exemption when it fires.
- `contract.md` and the skill's `## Repair` section say so, including that step 1's "never claim a
  decision issue" is about picking one up fresh and does not reach repair.

**The width is one pairing.** The same decision issue claimed by its own number is still 21. An open
PR serving any other type still reads the audience label. The scope axis is untouched at every
purpose. Unit tests cover each of those arms plus the admitted one, at both the pure-module and the
`runClaim` level.

Fixes #5914

## Deviations

- **Declined guidance** — **Said:** #5914 and #5866's shape 1 name a fourth `--purpose repair`.
  **Did:** derived the repair state from the target instead; no new enum word, no new flag.
  **Why:** `--purpose repair` is passable against a bare issue, and the acceptance criterion
  ("without an open PR it still refuses") means the seam would then have to refuse that combination
  — an invalid state the flag itself creates and nothing else needs. Naming a PR is already proof a
  build is in flight. It also leaves the `## Repair` section's `fabrika build claim <pr>` line
  unchanged, so no agent can forget a flag the way `plan-epic` shipped without `--purpose plan` for
  a whole release (#5217). **Disposition:** stated here; the ruling's outcome is the same either way.
- **Out-of-scope change** — **Said:** #5914 names `build claim`'s admission only. **Did:** also
  edited `claude-plugins/fabrika/skills/build/SKILL.md`'s `## Repair` section. **Why:** step 1's
  "do not claim a decision issue" is the prose a builder reads before repairing an ADR PR, and
  leaving it unqualified would keep the lane backing off even though the verb now admits it.
  **Disposition:** stated here.
