### PR TITLE
chore: epic child build-deviations disclose via a child marker comment

### DIFF
--- a/claude-plugins/fabrika/docs/wire-formats.md
+++ b/claude-plugins/fabrika/docs/wire-formats.md
@@ -39,6 +39,7 @@ does not exist yet — rather than missing; check the registry before assuming a
 | --- | --- | --- | --- |
 | `acceptance-criteria` | [`packages/fabrika-cli/src/wire/acceptance-criteria.ts`](../../../packages/fabrika-cli/src/wire/acceptance-criteria.ts) | `triage` | `build`, `review` |
 | `deviations` | [`packages/fabrika-cli/src/wire/deviations.ts`](../../../packages/fabrika-cli/src/wire/deviations.ts) | `build`, `build-ui` | `review`, `review-ui` |
+| `build-deviations` | [`packages/fabrika-cli/src/wire/build-deviations.ts`](../../../packages/fabrika-cli/src/wire/build-deviations.ts) | `build` | `review` |
 | `verdict-marker` | [`packages/fabrika-cli/src/wire/verdict-marker.ts`](../../../packages/fabrika-cli/src/wire/verdict-marker.ts) | `review`, `check-epic-plan`, `governance` | `build`, `ship` |
 | `range-verdict-marker` | [`packages/fabrika-cli/src/wire/range-verdict-marker.ts`](../../../packages/fabrika-cli/src/wire/range-verdict-marker.ts) | `review` | `build`, `operate` |
 | `lane-brief` | [`packages/fabrika-cli/src/wire/lane-brief.ts`](../../../packages/fabrika-cli/src/wire/lane-brief.ts) | `operate` | `build`, `review`, `ship` |
@@ -83,6 +84,23 @@ carrying a tag of its own rather than an empty entry list. That is the load-bear
 and folding it into `Absent` is how "never considered it" comes to read as "nothing to disclose".
 An entry states all four fields. The label is a routing hint and stays optional, but a disclosure
 missing *Why* or *Disposition* states what changed without stating whether anyone accepted it.
+
+### `build-deviations`
+
+This is the deviations disclosure for a build that opens no PR — an epic run's child, which lands by
+merging into the assembly branch (ADR 0285) and so has no PR body to carry the `## Deviations`
+section above. Ruled on #5903: the disclosure lands as a marker comment on the child's own issue,
+`build-deviations: #<issue>` over the same `## Deviations` section a PR body carries, and the
+epic-tail review — the one gate the run's single PR passes — reads every landed child's comment from
+there. The producer is the child's build shell, at the moment it would have opened a PR; the
+consumer is the tail review, which reaches each comment through the PR body's closing references.
+The section's grammar is not restated here or in the module: everything under the marker line is
+delegated wholesale to the `deviations` owner module, because two readers of the four-field bullet
+is the disagreement that format exists to remove. What this format adds is the marker line binding
+the disclosure to the issue it sits on — a comment pasted onto the wrong issue reads as a mismatch,
+not a disclosure — and the Absent/Malformed split for comments: an ordinary comment is `Absent`,
+while a marker line whose promised section is missing or drifted is `Malformed`, so a tail reviewer
+cannot mistake a broken disclosure for a child with nothing to say.
 
 ### `verdict-marker`
 

--- a/claude-plugins/fabrika/skills/build/SKILL.md
+++ b/claude-plugins/fabrika/skills/build/SKILL.md
@@ -181,6 +181,15 @@ unfixed`, `Declined guidance`, `Guard or gate bypassed`, `Pre-existing test or f
 prose bullet with no fields is refused by `build pr` at the point you write it — that refusal used
 to arrive a whole review round later, and could not say what was wrong (#5566).
 
+**An epic child opens no PR, and its disclosure surface moves with that** (#5903). When your spawn
+brief carries the epic rules — you build on a branch cut from the assembly branch, and steps 5's
+push and PR are not yours — the same `## Deviations` section lands as a `build-deviations` marker
+comment on the child issue instead: the line `build-deviations: #<n>` over the section, composed
+through `fabrika wire emit --format build-deviations` and posted with `gh issue comment`. The
+epic-tail review reads every landed child's comment from there, so a child with nothing to disclose
+still posts the checked `None.` — an absent comment reads as "never considered it", not as
+"nothing to disclose".
+
 **State what changed and why, and stop.** Two things earn their lines: the summary, and
 `## Deviations` — deviations catch real defects, so state each plainly and never trim one for
 brevity. Everything else goes: sweep methodology, a "what I deliberately kept" section, a clause

--- a/claude-plugins/fabrika/skills/operate/SKILL.md
+++ b/claude-plugins/fabrika/skills/operate/SKILL.md
@@ -202,7 +202,10 @@ things, neither of them a summary you compose:
   checks; one entry per repaired integrate once one did not, naming the two children whose ranges
   collided. The epic reviewer reads that section through the `deviations` wire format, so run its
   parser over the body before you open or edit it — `wire check --format deviations` — rather than
-  leaving the malformed answer to arrive a review round later.
+  leaving the malformed answer to arrive a review round later. A child's own deviations are not
+  yours to restate here: each child disclosed them as a `build-deviations` marker comment on its
+  own issue (#5903), and the tail review's brief names that surface, so the epic reviewer reads
+  them there.
 
 Open the draft with the command below as written. `--base` is omitted on purpose — `gh pr create`
 defaults it to the repository's default branch, the same branch the assembly cut from. The title

--- a/packages/fabrika-cli/src/lane/brief-verb.ts
+++ b/packages/fabrika-cli/src/lane/brief-verb.ts
@@ -192,13 +192,20 @@ export const runBrief = (
 			);
 		}
 
+		// The epic run's tail (task `epic_<n>`, and a PR is resolved — the tail states require one
+		// above): the ground carries the epic too, so the tail review's brief names where each
+		// child's `build-deviations` disclosure lives (#5903).
+		const ground: LaneGround =
+			epic !== null && prUrl !== null && state !== "build"
+				? {_tag: "Tail", pr: prUrl, epic: read.url}
+				: {_tag: "Pull", pr: prUrl};
 		const brief: LaneBrief = {
 			lane: options.lane,
 			task,
 			state,
 			shell,
 			issue: read.url,
-			ground: {_tag: "Pull", pr: prUrl},
+			ground,
 		};
 		return answer(emitBrief(brief), [
 			...notes,

--- a/packages/fabrika-cli/src/lane/brief-verb.unit.test.ts
+++ b/packages/fabrika-cli/src/lane/brief-verb.unit.test.ts
@@ -3,7 +3,7 @@ import {Effect, Layer} from "effect";
 import {describe, expect, it} from "vitest";
 import {errOut, fakeFs, fakeShell, okOut} from "../fakes.test-support.ts";
 import type {ExecResult} from "../io/exec.ts";
-import {EPIC_RULES, RULES, read as readBrief} from "../wire/lane-brief.ts";
+import {EPIC_RULES, EPIC_TAIL_RULES, RULES, read as readBrief} from "../wire/lane-brief.ts";
 import {runBrief} from "./brief-verb.ts";
 import {
 	ISSUE_UNRESOLVED,
@@ -428,9 +428,11 @@ describe("lane brief on an epic lane", () => {
 				state: "review",
 				shell: "reviewer",
 				issue: EPIC_URL,
-				ground: {_tag: "Pull", pr: PR_URL},
+				ground: {_tag: "Tail", pr: PR_URL, epic: EPIC_URL},
 			},
 		});
+		// The tail's brief names where each child's build-deviations disclosure lives (#5903).
+		expect(out.stdout).toContain(EPIC_TAIL_RULES);
 		expect(out.stdout).not.toContain(EPIC_RULES);
 	});
 

--- a/packages/fabrika-cli/src/wire/build-deviations.ts
+++ b/packages/fabrika-cli/src/wire/build-deviations.ts
@@ -1,0 +1,142 @@
+/**
+ * The `build-deviations` marker comment — an epic child's deviation disclosure, on its own issue.
+ *
+ *     build-deviations: #5828
+ *
+ *     ## Deviations
+ *
+ *     None.
+ *
+ * A child of an epic run opens no PR (ADR 0285), so the one disclosure surface `build` has — the PR
+ * body's `## Deviations` section — does not exist for it. Ruled on #5903: the disclosure lands as a
+ * marker comment on the child issue, and the epic-tail review reads it from there.
+ *
+ * Two parts, each with one owner. The first non-blank line is the marker: `build-deviations:` plus
+ * the issue the comment discloses for, so a comment pasted onto the wrong issue is visible as a
+ * mismatch rather than silently counted. Everything under it is the `## Deviations` section exactly
+ * as a PR body carries it, delegated wholesale to `./deviations.ts` — this module never re-states
+ * the entry grammar, because two readers of the four-field bullet is the disagreement that format
+ * exists to remove (#5566).
+ *
+ * The discrimination that carries the weight is **Absent vs Malformed**: bytes with no
+ * `build-deviations:` first line are `Absent` — an ordinary comment, not a defective disclosure —
+ * while a marker line over a missing or drifted section is `Malformed`, because the marker promised
+ * a disclosure and the promise is what a tail reviewer would otherwise count as "nothing to read".
+ */
+
+import * as deviations from "./deviations.ts";
+import type {NonEmptyReadonlyArray, WireEmit, WireRead, WireReadLines} from "./format.ts";
+
+export interface BuildDeviations {
+	/** The child issue this comment discloses for — the issue the comment sits on. */
+	readonly issue: number;
+	/** The section's content, owned end to end by `./deviations.ts`. */
+	readonly disclosure: deviations.DeviationsDisclosure;
+}
+
+export type BuildDeviationsRead = WireRead<BuildDeviations>;
+
+export const KEY_PREFIX = "build-deviations:";
+const MARKER = /^build-deviations:\s*#(\d+)\s*$/i;
+
+const firstNonBlankLine = (artifact: string): string | null =>
+	artifact.split("\n").find((line) => line.trim() !== "") ?? null;
+
+const malformed = (reason: string, evidence: string): BuildDeviationsRead => ({
+	_tag: "Malformed",
+	reason,
+	evidence,
+});
+
+/** Whether the bytes reach for this format at all — the gate that keeps `Absent` off a real drift. */
+export const reaches = (artifact: string): boolean =>
+	(firstNonBlankLine(artifact) ?? "").trimStart().toLowerCase().startsWith(KEY_PREFIX);
+
+/** Read the marker comment. Total: `Found` | `Absent` | `Malformed`. */
+export const read = (artifact: string): BuildDeviationsRead => {
+	const line = firstNonBlankLine(artifact);
+	if (line === null || !reaches(artifact)) {
+		return {
+			_tag: "Absent",
+			reason:
+				'the first non-blank line does not open with "build-deviations:" — no marker of this format',
+		};
+	}
+	const evidence = `first line: "${line.trim()}"`;
+	const matched = MARKER.exec(line.trim());
+	if (matched === null) {
+		return malformed(
+			'the marker is not "build-deviations: #<issue>" — the issue the comment discloses for is missing',
+			evidence,
+		);
+	}
+	const issue = Number.parseInt(matched[1] ?? "0", 10);
+
+	const lines = artifact.split("\n");
+	const rest = lines.slice(lines.findIndex((raw) => raw.trim() !== "") + 1).join("\n");
+	const section = deviations.read(rest);
+	if (section._tag === "Absent") {
+		return malformed(
+			`the marker promises a disclosure and no "${"#".repeat(deviations.HEADING_LEVEL)} ${deviations.HEADING_TEXT}" section follows — ${section.reason}`,
+			evidence,
+		);
+	}
+	if (section._tag === "Malformed") return section;
+	return {_tag: "Found", value: {issue, disclosure: section.value}};
+};
+
+/** Compose the comment's bytes. Round-trips through {@link read}. */
+export const emit = ({issue, disclosure}: BuildDeviations): string =>
+	`${KEY_PREFIX} #${issue}\n\n${deviations.emit(disclosure)}`;
+
+export type BuildDeviationsFields =
+	| {readonly _tag: "Fields"; readonly value: BuildDeviations}
+	| {readonly _tag: "Unusable"; readonly reason: string};
+
+const ISSUE_LINE = /^issue[ \t]*[:\t][ \t]*(.*)$/i;
+
+/**
+ * Parse `emit`'s stdin: an `issue: <n>` first line, then the section's fields exactly as the
+ * `deviations` format takes them — the literal `None.`, or one tab-separated entry per line.
+ */
+export const parseFields = (fields: string): BuildDeviationsFields => {
+	const lines = fields.split("\n");
+	const at = lines.findIndex((raw) => raw.trim() !== "");
+	const head = ISSUE_LINE.exec((lines[at] ?? "").trim());
+	if (at === -1 || head === null) {
+		return {
+			_tag: "Unusable",
+			reason: 'the first line is not "issue: <n>" — the disclosure must name the issue it is for',
+		};
+	}
+	const raw = (head[1] ?? "").trim().replace(/^#/, "");
+	if (!/^\d+$/.test(raw)) {
+		return {_tag: "Unusable", reason: `"${head[1]}" is not an issue number`};
+	}
+	const section = deviations.parseFields(lines.slice(at + 1).join("\n"));
+	if (section._tag === "Unusable") return section;
+	return {
+		_tag: "Fields",
+		value: {issue: Number.parseInt(raw, 10), disclosure: section.disclosure},
+	};
+};
+
+/** The `wire read` answer for this format: the issue line, then the section's own rendering. */
+export const render = (value: BuildDeviations): NonEmptyReadonlyArray<string> => [
+	`issue\t${value.issue}`,
+	...deviations.renderDisclosure(value.disclosure),
+];
+
+/** The registry row's byte-level `emit`, bound to this module's typed core. */
+export const emitFromFields = (fields: string): WireEmit => {
+	const parsed = parseFields(fields);
+	return parsed._tag === "Fields"
+		? {_tag: "Composed", bytes: emit(parsed.value)}
+		: {_tag: "Unusable", reason: parsed.reason};
+};
+
+/** The registry row's byte-level `read`, bound to this module's typed core. */
+export const readToLines = (artifact: string): WireReadLines => {
+	const result = read(artifact);
+	return result._tag === "Found" ? {_tag: "Found", value: render(result.value)} : result;
+};

--- a/packages/fabrika-cli/src/wire/build-deviations.unit.test.ts
+++ b/packages/fabrika-cli/src/wire/build-deviations.unit.test.ts
@@ -1,0 +1,79 @@
+import {describe, expect, it} from "vitest";
+import {emit, parseFields, read} from "./build-deviations.ts";
+
+const entry =
+	"- **Scope narrowing** — **Said:** both surfaces. **Did:** the reader only. **Why:** the writer is the next child's range. **Disposition:** stated here.";
+
+describe("read", () => {
+	it("finds the issue and the entries under the section", () => {
+		const result = read(`build-deviations: #5828\n\n## Deviations\n\n${entry}\n`);
+		expect(result).toMatchObject({
+			_tag: "Found",
+			value: {issue: 5828, disclosure: {_tag: "Entries"}},
+		});
+	});
+
+	it("finds the None. claim as NoneDeclared, not as an empty list", () => {
+		expect(read("build-deviations: #5828\n\n## Deviations\n\nNone.\n")).toEqual({
+			_tag: "Found",
+			value: {issue: 5828, disclosure: {_tag: "NoneDeclared"}},
+		});
+	});
+
+	it("answers Absent for a comment that never reaches for the format", () => {
+		expect(read("Landed on the assembly branch — over to the next child.\n")._tag).toBe("Absent");
+	});
+
+	it("answers Malformed when the marker names no issue", () => {
+		const result = read("build-deviations:\n\n## Deviations\n\nNone.\n");
+		expect(result._tag).toBe("Malformed");
+	});
+
+	it("answers Malformed, not Absent, when the marker promises a section that never follows", () => {
+		const result = read("build-deviations: #5828\n\nEverything went to plan.\n");
+		expect(result._tag).toBe("Malformed");
+	});
+
+	it("passes the section's own drift through as Malformed", () => {
+		const result = read("build-deviations: #5828\n\n### Deviations\n\nNone.\n");
+		expect(result._tag).toBe("Malformed");
+	});
+
+	it("does not read a marker quoted further down the body", () => {
+		expect(
+			read(`A child would post:\n\nbuild-deviations: #5828\n\n## Deviations\n\nNone.\n`)._tag,
+		).toBe("Absent");
+	});
+});
+
+describe("emit", () => {
+	it("round-trips the None. claim through read", () => {
+		const composed = emit({issue: 5828, disclosure: {_tag: "NoneDeclared"}});
+		expect(read(composed)).toMatchObject({
+			_tag: "Found",
+			value: {issue: 5828, disclosure: {_tag: "NoneDeclared"}},
+		});
+	});
+});
+
+describe("parseFields", () => {
+	it("takes the issue line, then the section's fields as the deviations format takes them", () => {
+		const parsed = parseFields("issue: 5828\nNone.\n");
+		expect(parsed).toEqual({
+			_tag: "Fields",
+			value: {issue: 5828, disclosure: {_tag: "NoneDeclared"}},
+		});
+	});
+
+	it("tolerates a leading # on the issue, which is how a human writes it", () => {
+		expect(parseFields("issue: #5828\nNone.\n")._tag).toBe("Fields");
+	});
+
+	it.each([
+		["no issue line", "None.\n"],
+		["an issue that is not a number", "issue: the editor one\nNone.\n"],
+		["an entry line missing a field", "issue: 5828\n1\tsaid\tdid\twhy\n"],
+	])("refuses %s", (_case, fields) => {
+		expect(parseFields(fields)._tag).toBe("Unusable");
+	});
+});

--- a/packages/fabrika-cli/src/wire/lane-brief.ts
+++ b/packages/fabrika-cli/src/wire/lane-brief.ts
@@ -13,10 +13,11 @@
  * **`## Ground` carries URLs, git refs and no content.** A brief that summarised an issue would hand
  * the shell a stale contract to work from, and the shell has verbs that read the live one.
  *
- * Ground comes in two shapes because an epic run has one branch and one PR (ADR 0285): a child's
+ * Ground comes in three shapes because an epic run has one branch and one PR (ADR 0285): a child's
  * states have no PR at all — they build in a worktree and their review judges a commit range on the
- * epic branch — while every other state has one PR to read. {@link LaneGround} is that union, so a
- * brief carrying both a PR and an epic branch is not a value anyone can construct.
+ * epic branch — the epic's tail has that one PR plus the epic issue whose children's disclosures
+ * its review reads, and every other state has one PR to read. {@link LaneGround} is that union, so
+ * a brief carrying both a PR and an epic branch is not a value anyone can construct.
  */
 
 import type {NonEmptyReadonlyArray, WireEmit, WireRead, WireReadLines} from "./format.ts";
@@ -83,12 +84,15 @@ export const shellState = (raw: string): ShellState | null => {
 /**
  * What the shell works over.
  *
- * `Pull` is a single-issue lane's state and an epic lane's tail — one PR to read, `null` only on
- * `build`, where construction has none yet. `Epic` is a child's state on an epic lane: the epic
- * issue, the assembly branch its worktree is cut from, and no PR, because a child never opens one.
+ * `Pull` is a single-issue lane's state — one PR to read, `null` only on `build`, where
+ * construction has none yet. `Tail` is an epic lane's tail: the run's one PR, plus the epic issue
+ * whose children's `build-deviations` comments the tail review reads. `Epic` is a child's state on
+ * an epic lane: the epic issue, the assembly branch its worktree is cut from, and no PR, because a
+ * child never opens one.
  */
 export type LaneGround =
 	| {readonly _tag: "Pull"; readonly pr: ArtifactUrl | null}
+	| {readonly _tag: "Tail"; readonly pr: ArtifactUrl; readonly epic: ArtifactUrl}
 	| {readonly _tag: "Epic"; readonly epic: ArtifactUrl; readonly branch: GitRef};
 
 export interface LaneBrief {
@@ -126,9 +130,25 @@ describes a tree you are not standing in.`;
 export const EPIC_RULES = `This lane is one epic run: one shared branch and one pull request at its tail (ADR 0285). Build in
 your own worktree on a local branch cut from \`branch\`, and never push or open a pull request for a
 child state — the merge happens once, after the epic review.
+A child's build discloses its deviations — the section a PR body would carry — as a
+\`build-deviations\` marker comment on the child issue, composed through
+\`node packages/fabrika-cli/src/bin.ts wire emit --format build-deviations\`; the epic-tail review
+reads them from there (#5903).
 A child's review judges the \`range\` above and records its verdict on the child issue in the
 \`range-verdict-marker\` format, composed through
 \`node packages/fabrika-cli/src/bin.ts wire emit --format range-verdict-marker\`.`;
+
+/**
+ * The rules an epic run's tail adds — the counterpart of {@link EPIC_RULES}, appended when the
+ * ground is `Tail`. This is where the tail review is told where each child's deviation disclosure
+ * lives (#5903): the brief is the one artifact every tail shell provably reads.
+ */
+export const EPIC_TAIL_RULES = `This PR is one epic run's tail: its branch assembles every child's range (ADR 0285), and its
+\`## Deviations\` section covers only that assembly. Each landed child disclosed its own build
+deviations as a \`build-deviations\` marker comment on its child issue — the issues the PR body's
+closing references name. The tail review reads every one of them through
+\`node packages/fabrika-cli/src/bin.ts wire read --format build-deviations\` before forming its
+verdict.`;
 
 /** The section headings this format admits, in the order it emits them. */
 export const SECTIONS = ["Task", "Ground", "Rules"] as const;
@@ -138,6 +158,12 @@ const groundFields = (brief: LaneBrief): ReadonlyArray<readonly [string, string]
 	if (brief.ground._tag === "Pull") {
 		return brief.ground.pr === null ? [] : [["pr", brief.ground.pr]];
 	}
+	if (brief.ground._tag === "Tail") {
+		return [
+			["pr", brief.ground.pr],
+			["epic", brief.ground.epic],
+		];
+	}
 	const {epic, branch} = brief.ground;
 	return [
 		["epic", epic],
@@ -146,8 +172,10 @@ const groundFields = (brief: LaneBrief): ReadonlyArray<readonly [string, string]
 	];
 };
 
-const rulesFor = (ground: LaneGround): string =>
-	ground._tag === "Pull" ? RULES : `${RULES}\n${EPIC_RULES}`;
+const rulesFor = (ground: LaneGround): string => {
+	if (ground._tag === "Pull") return RULES;
+	return ground._tag === "Tail" ? `${RULES}\n${EPIC_TAIL_RULES}` : `${RULES}\n${EPIC_RULES}`;
+};
 
 export const emit = (brief: LaneBrief): string =>
 	[
@@ -252,14 +280,34 @@ const groundOf = (fields: ReadonlyMap<string, string>, state: ShellState): Groun
 		}
 		return {_tag: "Ground", ground: {_tag: "Pull", pr}};
 	}
+	const epic = artifactUrl(epicRaw);
+	if (epic === null) return bad(`"${epicRaw}" is not an epic issue URL`, "epic");
+	if (branchRaw === "" && rangeRaw === "") {
+		// The epic run's tail: one PR to judge or merge, plus the epic whose children's
+		// `build-deviations` comments the tail review reads.
+		const pr = artifactUrl(prRaw);
+		if (pr === null) {
+			return bad(
+				prRaw === ""
+					? "a tail brief carries the run's one PR — without it the shell has nothing to read"
+					: `"${prRaw}" is not a PR URL`,
+				"pr",
+			);
+		}
+		if (state === "build") {
+			return bad(
+				"an epic tail briefs review or ship — construction happens in the children",
+				"state",
+			);
+		}
+		return {_tag: "Ground", ground: {_tag: "Tail", pr, epic}};
+	}
 	if (prRaw !== "") {
 		return bad(
 			"an epic lane's child state has no PR — one run is one PR, merged at its tail",
 			"pr",
 		);
 	}
-	const epic = artifactUrl(epicRaw);
-	if (epic === null) return bad(`"${epicRaw}" is not an epic issue URL`, "epic");
 	const branch = gitRef(branchRaw);
 	if (branch === null) return bad(`"${branchRaw}" is not a branch name`, "branch");
 	if (state === "ship") {

--- a/packages/fabrika-cli/src/wire/registry.ts
+++ b/packages/fabrika-cli/src/wire/registry.ts
@@ -19,6 +19,7 @@
  * registered without them — which is what makes the totality law inherited rather than re-written.
  */
 import * as acceptanceCriteria from "./acceptance-criteria.ts";
+import * as buildDeviations from "./build-deviations.ts";
 import * as deviations from "./deviations.ts";
 import {brandWitnesses, type WireFormat} from "./format.ts";
 import * as governanceDigest from "./governance-digest.ts";
@@ -136,6 +137,74 @@ export const registeredFormats: ReadonlyArray<WireFormat> = [
 				{
 					drift: "the heading is present over an empty section",
 					artifact: "## Deviations\n\n## Testing\n\nran it\n",
+				},
+			],
+		},
+		brands: brandWitnesses<deviations.DeviationEntry>({
+			said: true,
+			did: true,
+			why: true,
+			disposition: true,
+		}),
+	},
+	{
+		key: "build-deviations",
+		purpose:
+			"an epic child's deviation disclosure, as a marker comment on its own issue — a child opens no PR, so the `## Deviations` section lands here and the epic-tail review reads it (#5903)",
+		module: "packages/fabrika-cli/src/wire/build-deviations.ts",
+		producers: ["build"],
+		consumers: ["review"],
+		emit: buildDeviations.emitFromFields,
+		read: buildDeviations.readToLines,
+		fixtures: {
+			roundTrip: {
+				fields:
+					"issue: 5828\n1\tthe child's contract names both surfaces.\tbuilt the reader only.\tthe writer is the next child's range.\tstated here.\n",
+				values: [
+					"5828",
+					"the child's contract names both surfaces.",
+					"built the reader only.",
+					"the writer is the next child's range.",
+					"stated here.",
+				],
+			},
+			found: [
+				{
+					shape:
+						"the comment as a child builder posts it — the marker line, then an entry authored across wrapped lines",
+					artifact:
+						"build-deviations: #5828\n\n## Deviations\n\n- **Scope narrowing** — **Said:** the child's contract names both surfaces.\n  **Did:** built the reader only.\n  **Why:** the writer is the next child's range.\n  **Disposition:** stated here.\n",
+					values: [
+						"5828",
+						"the child's contract names both surfaces.",
+						"built the reader only.",
+						"the writer is the next child's range.",
+						"stated here.",
+					],
+				},
+				{
+					shape: "the checked claim that the child has nothing to disclose",
+					artifact: "build-deviations: #5828\n\n## Deviations\n\nNone.\n",
+					values: ["5828", "none-declared"],
+				},
+			],
+			absent: "Landed on the assembly branch — over to the next child.\n",
+			malformed: [
+				{
+					drift: "the marker names no issue, so the disclosure binds to nothing",
+					artifact: "build-deviations:\n\n## Deviations\n\nNone.\n",
+				},
+				{
+					drift: "the marker promises a disclosure and no section follows",
+					artifact: "build-deviations: #5828\n\nEverything went to plan.\n",
+				},
+				{
+					drift: "an entry is prose, carrying none of the four fields",
+					artifact: "build-deviations: #5828\n\n## Deviations\n\n- narrowed the scope a bit\n",
+				},
+				{
+					drift: "the section's heading level drifted",
+					artifact: "build-deviations: #5828\n\n### Deviations\n\nNone.\n",
 				},
 			],
 		},
@@ -290,6 +359,17 @@ export const registeredFormats: ReadonlyArray<WireFormat> = [
 					values: ["5751", "build", "builder", "https://github.com/kamp-us/phoenix/issues/5751"],
 				},
 				{
+					shape:
+						"an epic run's tail review — the one PR, plus the epic whose children's build-deviations comments it reads",
+					artifact: `## Task\nlane: 5800\ntask: epic_5800\nstate: review\nshell: reviewer\n## Ground\nissue: https://github.com/kamp-us/phoenix/issues/5800\npr: https://github.com/kamp-us/phoenix/pull/5904\nepic: https://github.com/kamp-us/phoenix/issues/5800\n## Rules\n${laneBrief.RULES}\n${laneBrief.EPIC_TAIL_RULES}\n`,
+					values: [
+						"epic_5800",
+						"review",
+						"https://github.com/kamp-us/phoenix/pull/5904",
+						"https://github.com/kamp-us/phoenix/issues/5800",
+					],
+				},
+				{
 					shape: "an epic lane's child review — the range it judges, and no PR anywhere",
 					artifact: `## Task\nlane: 5800\ntask: issue_5828\nstate: review\nshell: reviewer\n## Ground\nissue: https://github.com/kamp-us/phoenix/issues/5828\nepic: https://github.com/kamp-us/phoenix/issues/5800\nbranch: epic/5800\nrange: epic/5800..HEAD\n## Rules\n${laneBrief.RULES}\n${laneBrief.EPIC_RULES}\n`,
 					values: [
@@ -332,6 +412,15 @@ export const registeredFormats: ReadonlyArray<WireFormat> = [
 				{
 					drift: "a child review names no range — the reviewer would have nothing scoped to judge",
 					artifact: `## Task\nlane: 5800\ntask: issue_5828\nstate: review\nshell: reviewer\n## Ground\nissue: https://github.com/kamp-us/phoenix/issues/5828\nepic: https://github.com/kamp-us/phoenix/issues/5800\nbranch: epic/5800\n## Rules\n${laneBrief.RULES}\n${laneBrief.EPIC_RULES}\n`,
+				},
+				{
+					drift:
+						"a tail brief carries only the single-issue rules, which never name where the children's disclosures live",
+					artifact: `## Task\nlane: 5800\ntask: epic_5800\nstate: review\nshell: reviewer\n## Ground\nissue: https://github.com/kamp-us/phoenix/issues/5800\npr: https://github.com/kamp-us/phoenix/pull/5904\nepic: https://github.com/kamp-us/phoenix/issues/5800\n## Rules\n${laneBrief.RULES}\n`,
+				},
+				{
+					drift: "a tail brief names no PR — the run's one PR is the thing its shells work over",
+					artifact: `## Task\nlane: 5800\ntask: epic_5800\nstate: review\nshell: reviewer\n## Ground\nissue: https://github.com/kamp-us/phoenix/issues/5800\nepic: https://github.com/kamp-us/phoenix/issues/5800\n## Rules\n${laneBrief.RULES}\n${laneBrief.EPIC_TAIL_RULES}\n`,
 				},
 				{
 					drift:


### PR DESCRIPTION
Carries ruled #5903 (via #5936): an epic child opens no PR, so its build-deviation disclosure now lands as a wire-checkable marker comment on the child's own issue, and the epic-tail review is pointed at it.

- New `build-deviations` wire format (`packages/fabrika-cli/src/wire/build-deviations.ts`, registered in `registry.ts`): the first line `build-deviations: #<issue>` binds the comment to its issue; everything under it is the `## Deviations` section delegated wholesale to the existing `deviations` owner module, so the entry grammar keeps one reader. `wire emit`/`read`/`check --format build-deviations` all work; an ordinary comment reads `Absent`, a marker over a missing or drifted section reads `Malformed`.
- The tail review's brief names where to read them: `lane-brief` gains a `Tail` ground (the run's one PR plus the epic issue) whose byte-fixed `EPIC_TAIL_RULES` tell the tail shell to read every child's `build-deviations` comment; `lane brief` emits it for the `epic_<n>` task. `EPIC_RULES` now also tells the child builder to post the disclosure.
- Documented in both skills: `build` (step 5 — where the disclosure lands when the brief carries the epic rules) and `operate` (the epic PR's `## Deviations` covers the assembly only; the children's live on their issues).
- Narrative section added to `claude-plugins/fabrika/docs/wire-formats.md`; generated region re-rendered by `wire index --write`.

Fixes #5936

## Deviations

None.
