### PR TITLE
fix: A control-plane PR's advisory verdict reads as absent to lane prove, holding the lane at exit 22

### DIFF
--- a/packages/fabrika-cli/src/lane/prove-verb.ts
+++ b/packages/fabrika-cli/src/lane/prove-verb.ts
@@ -24,9 +24,12 @@ import {resolveTargetRepo} from "../build/target.ts";
 import {localBranches, rangeCommits, resolveCommit} from "../io/git.ts";
 import {getIssue, listComments} from "../io/issues.ts";
 import {getPullRequest, listPullFiles, openPullsClosing, searchOpenPulls} from "../io/pulls.ts";
+import {readAdvisory} from "../review/advisory.ts";
 import {issueRefOf, namespacesOf, partition, touchesGovernanceRoot} from "../review/classes.ts";
 import {bindRange, contentDigestAt, rangeContentAt} from "../review/content-binding.ts";
 import {bindHead} from "../review/head.ts";
+import {CODEOWNERS_PATH, readBoundary} from "../ship/boundary.ts";
+import {classify} from "../ship/codeowners.ts";
 import {answer, refuse, type VerbOutcome} from "../verb.ts";
 import {epicBranch} from "../wire/lane-brief.ts";
 import {read as readRangeMarker} from "../wire/range-verdict-marker.ts";
@@ -350,6 +353,14 @@ const proveNoPull = (
  * gates enforce. `review-ui` is deliberately not derived here: the rendered-visual verdict is
  * `review-ui`'s own lane and the lane machine spawns no shell that emits it, so requiring it would
  * stall every UI lane on a verdict nothing in this loop writes.
+ *
+ * On a control-plane PR the reviewer's PASS arrives through the §CP advisory carrier by design —
+ * no first-line marker, the head in the body (ADR 0111/0226) — so a marker-only read would row it
+ * `absent` and hold the lane at `PROOF_IN_FLIGHT` forever. The advisory is read exactly as
+ * `ship gate`'s `candidateOf` reads it: head-bound with no content binding (ADR 0276), a `[FAIL]`
+ * row treated as fail (an invalid emission, reported) — and admitted only after the diff itself
+ * classifies control-plane through the shipped `classify` over CODEOWNERS at the PR's base ref,
+ * never a caller assertion. On any other PR a marker-less comment stays no verdict.
  */
 const proveVerdicts = (
 	repo: string,
@@ -385,9 +396,28 @@ const proveVerdicts = (
 		// a FAIL upserted after a PASS must win (#4200).
 		const latest = new Map<string, Claim>();
 		const stamps = new Map<string, string>();
+		const advisories: {readonly claim: Claim; readonly stamp: string}[] = [];
 		for (const comment of commented.value) {
 			const parsed = readMarker(comment.body);
-			if (parsed._tag !== "Found") continue;
+			if (parsed._tag !== "Found") {
+				const advisory = readAdvisory(comment.body);
+				if (advisory !== null && required.includes(advisory.namespace)) {
+					advisories.push({
+						claim: {
+							namespace: advisory.namespace,
+							// ADR 0226 makes the advisory carrier PASS-only; a [FAIL] row inside one is an
+							// invalid emission — treated as fail below, never read as a pass.
+							polarity: /\[FAIL\]/.test(comment.body) ? "FAIL" : "PASS",
+							commentId: comment.id,
+							sha: advisory.sha,
+							// The advisory withholds a content binding by design (ADR 0276) — head-bound only.
+							content: null,
+						},
+						stamp: comment.updatedAt,
+					});
+				}
+				continue;
+			}
 			const marker = parsed.value;
 			if (!required.includes(marker.namespace)) continue;
 			const seen = stamps.get(marker.namespace);
@@ -403,6 +433,33 @@ const proveVerdicts = (
 		}
 
 		const notes = [...diagnostics];
+		if (advisories.length > 0) {
+			const boundary = yield* readBoundary(repo, pull.value.baseRef);
+			if (boundary._tag === "Unreadable") {
+				return unreadable(`${CODEOWNERS_PATH} at ${pull.value.baseRef}`, boundary.reason);
+			}
+			const cp = classify(boundary.rows, files.value);
+			if (cp === "control-plane") {
+				for (const {claim, stamp} of advisories) {
+					if (claim.polarity === "FAIL") {
+						notes.push(
+							`${VERB}: #${pr} carries a §CP advisory with a [FAIL] row — an invalid emission (ADR 0226); treated as fail, report it.`,
+						);
+					}
+					const seen = stamps.get(claim.namespace);
+					if (seen !== undefined && seen > stamp) continue;
+					stamps.set(claim.namespace, stamp);
+					latest.set(claim.namespace, claim);
+					notes.push(
+						`${VERB}: ${claim.namespace} on #${pr} is advisory-carried (§CP, ADR 0111) — head-bound at ${claim.sha}, no content binding (ADR 0276).`,
+					);
+				}
+			} else {
+				notes.push(
+					`${VERB}: #${pr} classifies ${cp} against ${CODEOWNERS_PATH} at ${pull.value.baseRef}, so a marker-less advisory-shaped comment reads as no verdict.`,
+				);
+			}
+		}
 		const claims = [...latest.values()];
 		// A verdict survives a head move only through the content it bound (ADR 0276), so the digest
 		// is computed exactly when a head-only read would call a content-bearing verdict stale.

--- a/packages/fabrika-cli/src/lane/prove-verb.unit.test.ts
+++ b/packages/fabrika-cli/src/lane/prove-verb.unit.test.ts
@@ -303,6 +303,115 @@ describe("lane prove — the union of the two nomination reads", () => {
 	});
 });
 
+describe("lane prove — the §CP advisory carrier (ADR 0111/0226)", () => {
+	const CODEOWNERS =
+		/^gh api -H Accept: application\/vnd\.github\.raw repos\/o\/r\/contents\/\.github\/CODEOWNERS\?ref=main$/;
+	const advisory = (rows = ""): string =>
+		`review-code: advisory — merge stays human-gated\n${rows}\nReviewed-head: @ ${HEAD}\n`;
+	const codeFile = okOut(JSON.stringify([{filename: "packages/fabrika-cli/src/lane/prove.ts"}]));
+
+	it("proves a review PASS carried by an advisory when the diff classifies control-plane", async () => {
+		const shell = fakeShell([
+			[CLOSERS, closingPulls()],
+			[SEARCH, okOut("4318\n")],
+			[PULL, pull()],
+			[FILES, codeFile],
+			[PR_COMMENTS, comments({id: 1, body: advisory()})],
+			[CODEOWNERS, okOut("/packages/fabrika-cli/ @kamp-us/control-plane\n")],
+		]);
+
+		const out = await run(laneAt("review"), shell, "PASS");
+
+		expect(out.code).toBe(0);
+		expect(JSON.parse(out.stdout)).toMatchObject({
+			proof: "proven",
+			evidence: {kind: "head-verdicts", pr: 4318, head: HEAD},
+		});
+		expect(out.stderr.join("\n")).toContain("advisory-carried");
+	});
+
+	it("still rows a marker-less comment absent when the diff is not control-plane", async () => {
+		const shell = fakeShell([
+			[CLOSERS, closingPulls()],
+			[SEARCH, okOut("4318\n")],
+			[PULL, pull()],
+			[FILES, codeFile],
+			[PR_COMMENTS, comments({id: 1, body: advisory()})],
+			[CODEOWNERS, okOut("/claude-plugins/ @kamp-us/control-plane\n")],
+		]);
+
+		const out = await run(laneAt("review"), shell, "PASS");
+
+		expect(out.code).toBe(PROOF_IN_FLIGHT);
+		expect(out.stderr.join("\n")).toContain("review-code (absent)");
+		expect(out.stderr.join("\n")).toContain("not-control-plane");
+	});
+
+	it("reads a [FAIL] row inside an advisory as fail, never as a pass", async () => {
+		const shell = fakeShell([
+			[CLOSERS, closingPulls()],
+			[SEARCH, okOut("4318\n")],
+			[PULL, pull()],
+			[FILES, codeFile],
+			[PR_COMMENTS, comments({id: 1, body: advisory("\n- [FAIL] the guard is bypassed\n")})],
+			[CODEOWNERS, okOut("/packages/fabrika-cli/ @kamp-us/control-plane\n")],
+		]);
+
+		const out = await run(laneAt("review"), shell, "PASS");
+
+		expect(out.code).toBe(PROOF_CONTRADICTED);
+		expect(out.stderr.join("\n")).toContain("invalid emission (ADR 0226)");
+	});
+
+	it("refuses an advisory bound to a head the PR has moved past as in-flight, not proven", async () => {
+		const stale = `review-code: advisory — merge stays human-gated\n\nReviewed-head: @ ${OLD}\n`;
+		const shell = fakeShell([
+			[CLOSERS, closingPulls()],
+			[SEARCH, okOut("4318\n")],
+			[PULL, pull()],
+			[FILES, codeFile],
+			[PR_COMMENTS, comments({id: 1, body: stale})],
+			[CODEOWNERS, okOut("/packages/fabrika-cli/ @kamp-us/control-plane\n")],
+		]);
+
+		const out = await run(laneAt("review"), shell, "PASS");
+
+		expect(out.code).toBe(PROOF_IN_FLIGHT);
+		expect(out.stderr.join("\n")).toContain("review-code (stale)");
+	});
+
+	it("leaves the proof UNKNOWN when the boundary itself cannot be read", async () => {
+		const shell = fakeShell([
+			[CLOSERS, closingPulls()],
+			[SEARCH, okOut("4318\n")],
+			[PULL, pull()],
+			[FILES, codeFile],
+			[PR_COMMENTS, comments({id: 1, body: advisory()})],
+			[CODEOWNERS, errOut("HTTP 502")],
+		]);
+
+		const out = await run(laneAt("review"), shell, "PASS");
+
+		expect(out.code).toBe(LANE_UNREADABLE);
+		expect(out.stderr.join("\n")).toContain(".github/CODEOWNERS");
+	});
+
+	it("never reads the boundary while no comment reaches for the advisory carrier", async () => {
+		const shell = fakeShell([
+			[CLOSERS, closingPulls()],
+			[SEARCH, okOut("4318\n")],
+			[PULL, pull()],
+			[FILES, codeFile],
+			[PR_COMMENTS, comments({id: 1, body: "looks good to me"})],
+		]);
+
+		const out = await run(laneAt("review"), shell, "PASS");
+
+		expect(out.code).toBe(PROOF_IN_FLIGHT);
+		expect(shell.calls.some((line) => CODEOWNERS.test(line))).toBe(false);
+	});
+});
+
 describe("lane prove — what it does not claim, and what it never writes", () => {
 	it("answers not-required for an event no board read can falsify, reading nothing", async () => {
 		const shell = fakeShell([]);


### PR DESCRIPTION
On a PR the CODEOWNERS boundary owns, the reviewer posts its PASS through the advisory carrier by design (ADR 0111/0226): no first-line marker, the head bound in the body. `lane prove`'s verdict read was marker-only, so every reviewed namespace rowed `absent`, the fold answered `InFlight`, and the lane re-read forever at `PROOF_IN_FLIGHT` with no escape — such a lane could never finish its review.

`proveVerdicts` now reads the advisory carrier exactly as `ship gate`'s `candidateOf` does:

- A marker-less comment is tried against `readAdvisory` and collected apart; it is admitted only after the diff itself derives that the boundary owns it — through the shipped `classify` over CODEOWNERS at the PR's base ref (`readBoundary`), never a caller assertion. On any other answer from `classify` (including `unknown`) a marker-less comment still reads as no verdict.
- An admitted advisory stays head-bound with `content: null` (ADR 0276) — a moved head rows it `stale`, and it never gains content survival.
- A `[FAIL]` row inside an advisory is polarity FAIL — the invalid-emission treatment `gate-verb.ts` gives it (ADR 0226), named in the diagnostics.
- An unreadable CODEOWNERS is the caller's UNKNOWN (`LANE_UNREADABLE`), never proven and never absent.
- The boundary is read lazily: no advisory-shaped comment, no CODEOWNERS fetch — the common path is unchanged.

`lane prove` proves the review event only; the merge-side approval gate stays `ship cp-approval`'s, untouched.

Unit tests cover: an advisory PASS proves on a boundary-owned diff; a marker-less comment on an unowned diff rows `absent`; `[FAIL]` inside an advisory contradicts rather than proves; a stale-head advisory is in-flight; an unreadable boundary is UNKNOWN; and the boundary is never fetched without an advisory-shaped comment.

Grounded in: `ship/gate-verb.ts` `candidateOf` (the mirrored read), `review/advisory.ts` (the carrier), `ship/codeowners.ts` `classify` + `ship/boundary.ts` (the derivation), ADRs 0111, 0226, 0276.

Fixes #5871

## Deviations

None.
