### PR TITLE
feat: The lane stale detector ships but nothing invokes it

### DIFF
--- a/claude-plugins/fabrika/skills/front-door/SKILL.md
+++ b/claude-plugins/fabrika/skills/front-door/SKILL.md
@@ -52,7 +52,9 @@ question.
 
 **Say where each answer came from, and drill in rather than guess.** Every field names its source, so
 the session can re-run one instead of trusting the render. Each field has one command behind it —
-`fabrika status menu`, `fabrika status config`, `fabrika status readout`, and for the board:
+`fabrika status menu`, `fabrika status config`, `fabrika status readout`, `fabrika lane stale` for
+the lanes field (the stale-lane sweep over this machine's `.fabrika/` roots — it reports, it never
+resumes), and for the board:
 
 ```bash
 fabrika status board

--- a/claude-plugins/fabrika/skills/front-door/contract.md
+++ b/claude-plugins/fabrika/skills/front-door/contract.md
@@ -24,7 +24,7 @@ access per
 
 | Verb | Purpose | Split test |
 |---|---|---|
-| `status open` | the composite front-door readout: four fields, each with its own state, source and freshness | assembling four independent reads and rendering each one's three-state outcome is a total function; deciding what to *do* about a gap is the skill's |
+| `status open` | the composite front-door readout: five fields, each with its own state, source and freshness | assembling five independent reads and rendering each one's three-state outcome is a total function; deciding what to *do* about a gap is the skill's |
 | `status config` | which repo surfaces every landed skill declares it needs, and whether each is present here | parsing a fixed table shape and probing a path or a label is mechanical, zero judgement (the founder's detection-verb ruling, #4952); drafting a missing surface's *content* is judgment |
 | `status menu` | the landed skill roster with each skill's invocation and one-line description | reading a directory and each file's frontmatter is a total function; choosing which skill fits the work at hand is judgment |
 | `status readout` | the landed-decision digest as published in the durable artifact | fetching an artifact and decoding a registered wire format is mechanical; ranking the rows is `governance`'s judgment and is not recomputed here |
@@ -145,7 +145,7 @@ vocabulary in this group. Four consequences bind every verb below:
    clamping, so the failure stays attributable — the shape
    `packages/pipeline-cli/src/tools/run-evidence/run-evidence.ts` prints, and the shape v1's
    `doctor.sh` prints when it tells the reader what not to conclude.
-3. **Per-field state cannot be an exit code.** A composite readout has four independent outcomes and
+3. **Per-field state cannot be an exit code.** A composite readout has five independent outcomes and
    one exit status; because a non-zero exit cannot carry a payload, the exit status answers only
    *"did I produce a readout at all"* and each field carries its own state inside it.
 4. <a id="open-is-total"></a>**`status open` therefore has no zero-scope and no failed-read seat at
@@ -224,6 +224,10 @@ purpose — keeping proven-empty apart from unread — to chance.
 | `readout` | artifact unfetchable, or the format unregistered | `unknown` | the raw failure |
 | `readout` | artifact fetched, its `updated_at` unreadable | `unknown` | `freshness unreadable` — a digest whose age cannot be established is not a digest you may present as current |
 | `menu` / `config` | roster readable, one `SKILL.md` inside it unreadable | `unknown` | which file failed — a partial roster is not a roster |
+| `lanes` | sweep answered, ≥1 lane verdicted `stale` | `stale` | `<n> stale: <key> (<age>m), …` — each silent lane named with its age |
+| `lanes` | sweep answered, zero `stale`, zero `unreadable` | `empty` | `no lanes on disk`, or `<n> lane(s), none silent past <threshold>m` — the threshold echoed from the verb's answer, never a second constant. **Zero lanes on disk is this row, not a fault**: a fresh checkout has none |
+| `lanes` | sweep answered, zero `stale`, ≥1 lane record `unreadable` | `unknown` | which lane failed and why — a lane whose silence cannot be judged is never flattened to clean |
+| `lanes` | the sweep refused — a lane root is there and cannot be listed | `unknown` | the refusal's reason — the lane set is UNKNOWN, never empty |
 
 **A proven-absent artifact is `absent` inside the composite, never `unknown`** — the two rows above
 that both yield `absent` are both facts about the repository, and only a failed *read* is `unknown`.
@@ -348,7 +352,7 @@ fabrika status open [--field <name>] [--repo <owner/name>] [--skills-dir <path>]
 
 | Flag | Type | Required | Default | Description |
 |---|---|---|---|---|
-| `--field` | string | no | all four | render one field only — `menu`, `config`, `board` or `readout`; any other value is off-vocabulary |
+| `--field` | string | no | all five | render one field only — `menu`, `config`, `board`, `readout` or `lanes`; any other value is off-vocabulary |
 | `--repo` | string | no | resolved | the repository the board and digest fields read |
 | `--skills-dir` | string | no | [resolved](#roster-location) | the roster root the menu and config fields read |
 | `--json` | boolean | no | `false` | emit the result object |
@@ -374,7 +378,7 @@ field	<name>	<state>	<detail>	<source>	<as-of>
 the render: the resolved roster path for `menu`/`config`, `<owner>/<name>` for `board`, and
 `<owner>/<name>#<issue>` for `readout` when an artifact resolved — otherwise `<owner>/<name>`.
 
-**No aggregate state, deliberately.** A roll-up over four independently-sourced fields would need a
+**No aggregate state, deliberately.** A roll-up over five independently-sourced fields would need a
 rule for "three fine, one unknown", and every such rule either hides the unknown or drowns the three.
 
 **Exit status**
@@ -392,7 +396,7 @@ token; a refusal would write zero bytes on the cold start it exists for.
 
 | Message (stderr) | Code | Kind |
 |---|---|---|
-| `status open: --field "<v>" is not one of menu, config, board, readout.` | 10 | usage error |
+| `status open: --field "<v>" is not one of menu, config, board, readout, lanes.` | 10 | usage error |
 | `status open: roster <path> (<tier>), <n> skills; repo <owner/name>; <k> field(s) rendered, <u> unknown.` | 0 | notice |
 
 **Scope** — the fields requested, each named on the scope line with the source it resolved and the

--- a/packages/fabrika-cli/README.md
+++ b/packages/fabrika-cli/README.md
@@ -972,7 +972,7 @@ What state the factory is in — the six verbs
 [`contract.md`](../../claude-plugins/fabrika/skills/front-door/contract.md)).
 
 ```
-status open                       # the composite four-field readout the skill injects
+status open                       # the composite five-field readout the skill injects
 status config                     # which declared repo surfaces exist here — the detection verb
 status menu                       # the landed skill roster, derived from the skills tree
 status readout                    # the landed-decision digest, as published
@@ -990,7 +990,12 @@ Three things about it are load-bearing:
   [`src/verb.ts`](./src/verb.ts)'s `refuse()` hardcodes empty stdout — so a refusal would leave the
   front door silent on exactly the cold start it exists for. Every source it cannot read becomes a
   field state; its one refusal seat is a bad `--field`. It composes by **importing** the sibling
-  cores, never by spawning a verb and reading its exit code.
+  cores, never by spawning a verb and reading its exit code. The fifth field, `lanes`, renders the
+  `lane stale` sweep ([`src/lane/stale-verb.ts`](./src/lane/stale-verb.ts)) over both default roots
+  at that verb's documented 60-minute threshold, so a dead operator's silent lane surfaces on every
+  cold session without anyone typing the command (#5908): stale lanes are named with their ages,
+  zero stale lanes — including zero lanes on disk — is the proven negative `empty`, and an
+  unreadable root or lane record is `unknown` with its reason. It reports; it never resumes.
 - **`7` and `11` are the pair.** `7` is an **explicitly passed** `--skills-dir` proven absent; `11`
   is a failed read. An *implicitly* resolved roster holding zero skills is neither — it is `empty`
   at exit `0`.

--- a/packages/fabrika-cli/src/status/command.ts
+++ b/packages/fabrika-cli/src/status/command.ts
@@ -16,6 +16,9 @@ import {leafCommand} from "../excess-operand.ts";
 import type {Attempt} from "../io/git.ts";
 import {listLabels, resolveRepo} from "../io/issues.ts";
 import {readStdin} from "../io/stdin.ts";
+import {DEFAULT_STALE_MINUTES} from "../lane/stale.ts";
+import {runStale} from "../lane/stale-verb.ts";
+import {DEFAULT_CHORES_ROOT, DEFAULT_LANES_ROOT} from "../lane/store.ts";
 import type {VerbOutcome} from "../verb.ts";
 import {readBoard, runBoard} from "./board-verb.ts";
 import {knownIds, runBootstrap} from "./bootstrap-verb.ts";
@@ -29,6 +32,7 @@ import {
 	FIELDS,
 	type Field,
 	isFieldName,
+	lanesField,
 	menuField,
 	readoutField,
 	runOpen,
@@ -288,6 +292,20 @@ const open = leafCommand(
 					),
 				);
 			}
+			if (name === "lanes") {
+				const roots = [DEFAULT_LANES_ROOT, DEFAULT_CHORES_ROOT];
+				fields.push(
+					lanesField(
+						yield* runStale({
+							roots,
+							olderThanMinutes: DEFAULT_STALE_MINUTES,
+							now: new Date().toISOString(),
+						}),
+						roots,
+						asOf,
+					),
+				);
+			}
 		}
 		const rosterScope =
 			roster === null
@@ -296,9 +314,11 @@ const open = leafCommand(
 		yield* emit(runOpen({fields, json, scope: `${rosterScope}; repo ${repoName}`}));
 	}),
 ).pipe(
-	Command.withShortDescription("The composite front-door readout: menu, config, board, readout."),
+	Command.withShortDescription(
+		"The composite front-door readout: menu, config, board, readout, lanes.",
+	),
 	Command.withDescription(
-		"The composite front-door readout: four fields — menu, config, board, readout — each with its own state, source and freshness. Every unreadable source becomes a field state, so this verb has no zero-scope seat and no failed-read seat: it is injected before the session reads a token and a refusal would write zero bytes. First stdout line is `open\\t<field-count>`, then one `field\\t<name>\\t<state>\\t<detail>\\t<source>\\t<as-of>` line each. Exits 10 (--field is off the closed vocabulary). Example: fabrika status open",
+		"The composite front-door readout: five fields — menu, config, board, readout, lanes — each with its own state, source and freshness. The lanes field renders `fabrika lane stale`'s sweep over both default roots at its documented threshold: `stale` names the silent lanes, zero stale lanes is the proven negative `empty` (no lanes on disk is `empty` too), and an unreadable root or lane record is `unknown` with its reason — it reports, it never resumes. Every unreadable source becomes a field state, so this verb has no zero-scope seat and no failed-read seat: it is injected before the session reads a token and a refusal would write zero bytes. First stdout line is `open\\t<field-count>`, then one `field\\t<name>\\t<state>\\t<detail>\\t<source>\\t<as-of>` line each. Exits 10 (--field is off the closed vocabulary). Example: fabrika status open",
 	),
 );
 

--- a/packages/fabrika-cli/src/status/open-verb.ts
+++ b/packages/fabrika-cli/src/status/open-verb.ts
@@ -1,5 +1,5 @@
 /**
- * `status open` — the composite front-door readout: four fields, each with its own state, source
+ * `status open` — the composite front-door readout: five fields, each with its own state, source
  * and freshness.
  *
  * **This verb has no zero-scope seat and no failed-read seat at all.** It is the command the skill
@@ -18,7 +18,7 @@
  * a rule for "three fine, one unknown", and every such rule either hides the unknown or drowns the
  * three.
  */
-import {answer, refuse, type VerbOutcome} from "../verb.ts";
+import {ANSWER, answer, refuse, type VerbOutcome} from "../verb.ts";
 import type {BoardRead} from "./board-verb.ts";
 import {boardState} from "./board-verb.ts";
 import {OFF_VOCABULARY} from "./codes.ts";
@@ -31,7 +31,7 @@ import type {RosterRead} from "./roster.ts";
 const VERB = "status open";
 
 /** The closed `--field` vocabulary. Any other value is off-vocabulary. */
-export const FIELDS = ["menu", "config", "board", "readout"] as const;
+export const FIELDS = ["menu", "config", "board", "readout", "lanes"] as const;
 export type FieldName = (typeof FIELDS)[number];
 
 export interface Field {
@@ -176,6 +176,105 @@ export const readoutField = (read: ReadoutRead): Field => {
 					? "unknown"
 					: read.repo,
 		asOf: noAsOf,
+	};
+};
+
+/** What `lanes` reads out of `fabrika lane stale`'s documented answer object. */
+interface StaleSweep {
+	readonly olderThanMinutes: number;
+	readonly lanes: ReadonlyArray<{
+		readonly key: string;
+		readonly verdict: string;
+		readonly ageMinutes: number | null;
+		readonly reason?: string;
+	}>;
+}
+
+const parseSweep = (stdout: string): StaleSweep | null => {
+	try {
+		const parsed: unknown = JSON.parse(stdout);
+		if (
+			typeof parsed !== "object" ||
+			parsed === null ||
+			!Array.isArray((parsed as StaleSweep).lanes)
+		) {
+			return null;
+		}
+		return parsed as StaleSweep;
+	} catch {
+		return null;
+	}
+};
+
+/**
+ * The stale-lane sweep as a field, composed from `lane stale`'s in-process outcome — the one field
+ * sourced outside this group, because lanes are machine-local and no scheduled job can see them
+ * (#5908). The sweep's refusal (an unreadable root) and a lane whose record does not read are both
+ * `unknown` with the reason, never flattened to clean; zero stale lanes — including zero lanes on
+ * disk at all — is the proven negative `empty`.
+ */
+export const lanesField = (
+	outcome: VerbOutcome,
+	roots: ReadonlyArray<string>,
+	asOf: AsOf,
+): Field => {
+	const source = roots.join(",");
+	if (outcome.code !== ANSWER) {
+		return {
+			name: "lanes",
+			state: UNKNOWN,
+			detail: detail(outcome.stderr.at(-1) ?? "the sweep refused without naming a reason"),
+			source,
+			asOf: noAsOf,
+		};
+	}
+	const sweep = parseSweep(outcome.stdout);
+	if (sweep === null) {
+		return {
+			name: "lanes",
+			state: UNKNOWN,
+			detail: detail(
+				"the sweep's answer is not the documented object — a failed read, not zero lanes",
+			),
+			source,
+			asOf: noAsOf,
+		};
+	}
+	const stale = sweep.lanes.filter((lane) => lane.verdict === "stale");
+	const unreadable = sweep.lanes.filter((lane) => lane.verdict === "unreadable");
+	if (stale.length > 0) {
+		const tail = unreadable.length > 0 ? ` — ${unreadable.length} unreadable` : "";
+		return {
+			name: "lanes",
+			state: "stale",
+			detail: detail(
+				`${stale.length} stale: ${stale.map((lane) => `${lane.key} (${String(lane.ageMinutes)}m)`).join(", ")}${tail}`,
+			),
+			source,
+			asOf,
+		};
+	}
+	if (unreadable.length > 0) {
+		const first = unreadable[0];
+		return {
+			name: "lanes",
+			state: UNKNOWN,
+			detail: detail(
+				`${unreadable.length} lane(s) unreadable: ${first?.key ?? "?"} — ${first?.reason ?? "no reason recorded"}`,
+			),
+			source,
+			asOf: noAsOf,
+		};
+	}
+	return {
+		name: "lanes",
+		state: "empty",
+		detail:
+			sweep.lanes.length === 0
+				? "no lanes on disk"
+				: `${sweep.lanes.length} lane(s), none silent past ${sweep.olderThanMinutes}m`,
+		source,
+		asOf,
 	};
 };
 

--- a/packages/fabrika-cli/src/status/verbs.unit.test.ts
+++ b/packages/fabrika-cli/src/status/verbs.unit.test.ts
@@ -5,7 +5,13 @@
  * The property under test throughout is the three-state law: a proven negative is an exit-`0` token,
  * an unread source is `unknown`, and the two never collapse.
  */
+import {Effect} from "effect";
 import {describe, expect, it} from "vitest";
+import {fakeFs} from "../fakes.test-support.ts";
+import {coderTemplateText} from "../lane/fixtures.test-support.ts";
+import {DEFAULT_STALE_MINUTES} from "../lane/stale.ts";
+import {runStale} from "../lane/stale-verb.ts";
+import {DEFAULT_CHORES_ROOT, DEFAULT_LANES_ROOT} from "../lane/store.ts";
 import * as report from "../report/codes.ts";
 import {ANSWER} from "../verb.ts";
 import {type BoardRead, type Bucket, boardState, runBoard} from "./board-verb.ts";
@@ -25,6 +31,7 @@ import {
 	badFieldRefusal,
 	boardField,
 	configField,
+	lanesField,
 	menuField,
 	readoutField,
 	runOpen,
@@ -279,17 +286,22 @@ describe("status bootstrap", () => {
 });
 
 describe("status open is TOTAL — every unreadable source is a field state, never a refusal", () => {
-	it("renders four fields at exit 0 when EVERY source failed", () => {
+	it("renders five fields at exit 0 when EVERY source failed", () => {
 		const fields = [
 			menuField({_tag: "Failed", path: "/x", display: "x", reason: "EACCES"}, AS_OF),
 			configField({_tag: "Failed", path: "/x", display: "x", reason: "EACCES"}, [], AS_OF),
 			boardField({_tag: "Failed", repo: "acme/storefront", reason: "EAI_AGAIN"}),
 			readoutField({_tag: "NoFormat"}),
+			lanesField(
+				{code: 11, stdout: "", stderr: ["fabrika lane stale: cannot list .fabrika/lanes"]},
+				[DEFAULT_LANES_ROOT, DEFAULT_CHORES_ROOT],
+				AS_OF,
+			),
 		];
 		const out = runOpen({fields, json: false, scope: "roster x; repo acme/storefront"});
 		expect(out.code).toBe(ANSWER);
-		expect(out.stdout.split("\n")[0]).toBe("open\t4");
-		expect(out.stdout.split("\n").filter((l) => l.startsWith("field\t"))).toHaveLength(4);
+		expect(out.stdout.split("\n")[0]).toBe("open\t5");
+		expect(out.stdout.split("\n").filter((l) => l.startsWith("field\t"))).toHaveLength(5);
 		for (const field of fields) expect(field.state).toBe("unknown");
 	});
 
@@ -310,6 +322,92 @@ describe("status open is TOTAL — every unreadable source is a field state, nev
 		const source = menuField(resolvedRoster([]), AS_OF).source;
 		expect(source).toBe("claude-plugins/fabrika/skills");
 		expect(source.startsWith("/")).toBe(false);
+	});
+});
+
+describe("the lanes field renders `lane stale`'s sweep, never a second staleness implementation", () => {
+	const NOW = "2026-08-17T12:00:00.000Z";
+	const ROOTS = [DEFAULT_LANES_ROOT, DEFAULT_CHORES_ROOT];
+	const minutesAgo = (n: number): string => new Date(Date.parse(NOW) - n * 60_000).toISOString();
+	const logLine = (at: string): string =>
+		`${JSON.stringify({task: "issue", event: "ISSUE.WIP", at})}\n`;
+
+	const laneTree = (lanes: ReadonlyArray<{lane: string; log?: string; workflow?: string}>) => {
+		const files: Record<string, string> = {};
+		for (const {lane, log, workflow} of lanes) {
+			files[`${DEFAULT_LANES_ROOT}/${lane}/workflow.json`] = workflow ?? coderTemplateText();
+			if (log !== undefined) files[`${DEFAULT_LANES_ROOT}/${lane}/events.jsonl`] = log;
+		}
+		return fakeFs({
+			files,
+			dirs: {[DEFAULT_LANES_ROOT]: lanes.map((entry) => entry.lane)},
+			directories: [DEFAULT_LANES_ROOT],
+		});
+	};
+
+	const sweep = (fs: ReturnType<typeof fakeFs>) =>
+		Effect.runPromise(
+			Effect.provide(
+				runStale({roots: ROOTS, olderThanMinutes: DEFAULT_STALE_MINUTES, now: NOW}),
+				fs.layer,
+			),
+		);
+
+	it("renders no lanes on disk as the proven negative `empty`, not a fault", async () => {
+		const field = lanesField(await sweep(fakeFs({})), ROOTS, AS_OF);
+		expect(field.state).toBe("empty");
+		expect(field.detail).toBe("no lanes on disk");
+		expect(field.source).toBe(`${DEFAULT_LANES_ROOT},${DEFAULT_CHORES_ROOT}`);
+	});
+
+	it("renders zero stale lanes over live ones as `empty`, echoing the verb's own threshold", async () => {
+		const field = lanesField(
+			await sweep(laneTree([{lane: "5908", log: logLine(minutesAgo(5))}])),
+			ROOTS,
+			AS_OF,
+		);
+		expect(field.state).toBe("empty");
+		expect(field.detail).toBe(`1 lane(s), none silent past ${DEFAULT_STALE_MINUTES}m`);
+	});
+
+	it("renders a silent lane as `stale`, naming the lane and its age", async () => {
+		const field = lanesField(
+			await sweep(laneTree([{lane: "5908", log: logLine(minutesAgo(76))}])),
+			ROOTS,
+			AS_OF,
+		);
+		expect(field.state).toBe("stale");
+		expect(field.detail).toContain("1 stale: 5908 (76m)");
+		expect(field.asOf).toBe(AS_OF);
+	});
+
+	it("renders an unreadable lane record as `unknown` with its reason, never flattened to clean", async () => {
+		const field = lanesField(
+			await sweep(laneTree([{lane: "5908", workflow: "not json", log: logLine(minutesAgo(5))}])),
+			ROOTS,
+			AS_OF,
+		);
+		expect(field.state).toBe("unknown");
+		expect(field.detail).toContain("1 lane(s) unreadable: 5908");
+		expect(field.asOf).toBe(noAsOf);
+	});
+
+	it("renders the sweep's refusal — an unlistable root — as `unknown` with the refusal's reason", async () => {
+		const fs = fakeFs({
+			dirs: {[DEFAULT_LANES_ROOT]: null},
+			directories: [DEFAULT_LANES_ROOT],
+		});
+		const outcome = await sweep(fs);
+		expect(outcome.code).not.toBe(ANSWER);
+		const field = lanesField(outcome, ROOTS, AS_OF);
+		expect(field.state).toBe("unknown");
+		expect(field.detail).toContain(`cannot list ${DEFAULT_LANES_ROOT}`);
+	});
+
+	it("renders an answer that is not the documented object as `unknown`, never zero lanes", () => {
+		const field = lanesField({code: ANSWER, stdout: "not json\n", stderr: []}, ROOTS, AS_OF);
+		expect(field.state).toBe("unknown");
+		expect(field.detail).toContain("a failed read, not zero lanes");
 	});
 });
 


### PR DESCRIPTION
## Summary

`fabrika lane stale` landed in PR #5899 but nothing ran it — the detector for silent operator
deaths only fired when a driver remembered to type it. This wires the sweep into the surface every
cold session already renders: `status open` gains a fifth field, `lanes`, sourced from the existing
verb's core in-process (no second staleness implementation, no spawned process).

- `packages/fabrika-cli/src/status/open-verb.ts` — `FIELDS` gains `lanes`; `lanesField` maps the
  sweep's outcome to the front door's three-state grammar: `stale` names each silent lane with its
  age, zero stale lanes (including zero lanes on disk) is the proven negative `empty`, and both an
  unlistable root (the verb's refusal) and an unreadable lane record render `unknown` with the
  reason — never flattened to clean.
- `packages/fabrika-cli/src/status/command.ts` — the `open` adapter runs `runStale` over both
  default roots at the verb's own `DEFAULT_STALE_MINUTES`; the rendered detail echoes the threshold
  back out of the verb's answer, so no second constant exists anywhere.
- Tests in `verbs.unit.test.ts` drive the real `runStale` over the fake filesystem and feed its
  actual outcome into `lanesField`, so the payload shape the field reads is grounded in the verb,
  not a hand-written mimic: empty (no lanes / live lanes), stale-hit, per-lane unreadable,
  refused root, and a non-parsing answer.
- Docs: `packages/fabrika-cli/README.md` and the front-door skill (`SKILL.md` field list +
  `contract.md` core-to-field mapping, `--field` vocabulary and refusal message) all name the new
  field, so the documented vocabulary matches what renders.

The surface reports and never resumes, holding #5897's no-auto-resume ruling. The issue's open
founder question (a machine-local scheduler for the truly unwatched case) is explicitly out of
scope here and stays with the issue.

Fixes #5908

## Deviations

None.
