### PR TITLE
fix: Lane machine has no FAIL cell in the ship state, so a re-review FAIL at ship cannot be recorded

### DIFF
--- a/claude-plugins/fabrika/skills/operate/SKILL.md
+++ b/claude-plugins/fabrika/skills/operate/SKILL.md
@@ -302,7 +302,8 @@ the report.
 | reviewer: every derived namespace terminal on a still-binding verdict, at least one `FAIL` | `FAIL` |
 | reviewer: any derived namespace without a still-binding verdict | no event — re-read, see below |
 | shipper `already-merged` / `QUEUED` / `landed` | `DONE` |
-| anything else — a back-off, an escalation, a stop, an awaiting-approval, a permission denial, a dead or unresponsive spawn, a report you cannot parse | `BLOCKED` |
+| shipper `routed to repair` / `EJECTED — routed to repair` | `FAIL` — the repair build the shipper named is what the machine's `ship` FAIL edge routes to, and it spends a retry (#5807) |
+| anything else not claimed above — a back-off, an escalation, a stop, an awaiting-approval, a permission denial, a dead or unresponsive spawn, a report you cannot parse | `BLOCKED` |
 
 **An `integrate` has no spawn to report**, so its row is the merge's own exit folded by the two
 rules step 2 named: a clean merge whose post-merge checks pass is `DONE`; a conflict, or a red

--- a/packages/fabrika-cli/src/lane/__fixtures__/epic-4300.workflow.golden.txt
+++ b/packages/fabrika-cli/src/lane/__fixtures__/epic-4300.workflow.golden.txt
@@ -265,7 +265,17 @@
 							"ship": {
 								"on": {
 									"EPIC_4300.DONE": "shipped",
-									"EPIC_4300.BLOCKED": "human:cp-approval"
+									"EPIC_4300.BLOCKED": "human:cp-approval",
+									"EPIC_4300.FAIL": [
+										{
+											"target": "review",
+											"guard": "retriesRemaining",
+											"actions": "incrementRetries"
+										},
+										{
+											"target": "human:epic-review"
+										}
+									]
 								}
 							},
 							"blocked": {

--- a/packages/fabrika-cli/src/lane/emit.ts
+++ b/packages/fabrika-cli/src/lane/emit.ts
@@ -105,6 +105,11 @@ const region = (ns: string, initial: "queued" | "landed" | "frozen"): Record<str
 /**
  * The epic's own region — the tail phase's single task: review the one PR, then merge it once.
  *
+ * `ship` carries the same guarded FAIL, because a PR can be re-reviewed at a rewritten head while
+ * the lane sits there and a park clear is exactly that path (#5807). Its retry arm is `review` for
+ * the same reason the review edge's is: the repair round happens outside the machine, so the next
+ * thing the lane can record is another verdict.
+ *
  * `review` FAIL is a two-arm guarded array so the fallthrough final is an *error* final by the
  * compiler's own structural read; a plain target would leave a failed epic review folding to
  * `complete`. The retry arm is `review` itself: a repair round happens outside the machine and the
@@ -125,7 +130,16 @@ const epicRegion = (ns: string): Record<string, unknown> => ({
 				],
 			},
 		},
-		ship: {on: {[`${ns}.DONE`]: "shipped", [`${ns}.BLOCKED`]: "human:cp-approval"}},
+		ship: {
+			on: {
+				[`${ns}.DONE`]: "shipped",
+				[`${ns}.BLOCKED`]: "human:cp-approval",
+				[`${ns}.FAIL`]: [
+					{target: "review", guard: "retriesRemaining", actions: "incrementRetries"},
+					{target: "human:epic-review"},
+				],
+			},
+		},
 		blocked: {on: {[`${ns}.UNBLOCKED`]: "hist"}},
 		"human:cp-approval": {on: {[`${ns}.UNBLOCKED`]: "hist"}},
 		hist: {type: "history"},

--- a/packages/fabrika-cli/src/lane/emit.unit.test.ts
+++ b/packages/fabrika-cli/src/lane/emit.unit.test.ts
@@ -293,7 +293,16 @@ describe("emitMachine", () => {
 						],
 					},
 				},
-				ship: {on: {"EPIC_4300.DONE": "shipped", "EPIC_4300.BLOCKED": "human:cp-approval"}},
+				ship: {
+					on: {
+						"EPIC_4300.DONE": "shipped",
+						"EPIC_4300.BLOCKED": "human:cp-approval",
+						"EPIC_4300.FAIL": [
+							{target: "review", guard: "retriesRemaining", actions: "incrementRetries"},
+							{target: "human:epic-review"},
+						],
+					},
+				},
 				shipped: {type: "final"},
 				"human:epic-review": {type: "final"},
 			},
@@ -306,6 +315,25 @@ describe("emitMachine", () => {
 		expect(
 			drive(compiled, [...LAND_ALL, ["epic_4300", "PASS"], ["epic_4300", "DONE"]]),
 		).toMatchObject({stateValue: "complete", status: "done"});
+	});
+
+	it("takes a FAIL at the epic ship back to review, and parks it once the retries are spent", () => {
+		const compiled = laneOf(emitted(emitMachine(4300, body(), CHILDREN)));
+		const toShip: ReadonlyArray<readonly [string, string]> = [...LAND_ALL, ["epic_4300", "PASS"]];
+		expect(drive(compiled, [...toShip, ["epic_4300", "FAIL"]]).stateValue).toEqual({
+			epic: {epic_4300: "review"},
+		});
+
+		const spent = drive(compiled, [
+			...toShip,
+			["epic_4300", "FAIL"],
+			["epic_4300", "PASS"],
+			["epic_4300", "FAIL"],
+			["epic_4300", "PASS"],
+			["epic_4300", "FAIL"],
+		]);
+		expect(spent).toMatchObject({stateValue: "tripped", status: "done"});
+		expect(spent.context.errors).toEqual(["epic_4300"]);
 	});
 
 	it("trips the lane when the epic review fails past its retry budget — a park, never `complete`", () => {

--- a/packages/fabrika-cli/src/lane/machine.unit.test.ts
+++ b/packages/fabrika-cli/src/lane/machine.unit.test.ts
@@ -5,7 +5,8 @@ import {
 	stateNode,
 	twoPhaseWorkflow,
 } from "./fixtures.test-support.ts";
-import {compile, OPERATOR_EVENTS, topology} from "./machine.ts";
+import {applyEvent, foldLog, type LogEntry} from "./fold.ts";
+import {type CompiledLane, compile, OPERATOR_EVENTS, topology} from "./machine.ts";
 
 const compiled = (workflow: unknown) => {
 	const result = compile(workflow);
@@ -16,6 +17,26 @@ const compiled = (workflow: unknown) => {
 const defined = <T>(value: T | undefined): T => {
 	if (value === undefined) throw new Error("expected the compiled task to be present");
 	return value;
+};
+
+/** Drive one task's events through `applyEvent`, returning the leaf state each one folded to. */
+const leaves = (
+	lane: CompiledLane,
+	task: string,
+	events: ReadonlyArray<string>,
+): ReadonlyArray<string> => {
+	const log: LogEntry[] = [];
+	const statesOf = () => {
+		const fold = foldLog(lane, log);
+		if (fold._tag !== "Folded") throw new Error(fold.defects.join("; "));
+		return fold.states;
+	};
+	return events.map((event) => {
+		const applied = applyEvent(lane, statesOf(), task, event, "2026-08-17T00:00:00.000Z");
+		if (applied._tag !== "Applied") throw new Error(`${task} ${event}: ${applied.reason}`);
+		log.push(applied.entry);
+		return defined(statesOf()[task]).type;
+	});
 };
 
 const defectsOf = (workflow: unknown): string => {
@@ -66,8 +87,28 @@ describe("the compiler — structural recognition", () => {
 
 		expect(defined(summary.tasks.issue).states.queued).toEqual(["WIP", "BLOCKED"]);
 		expect(defined(summary.tasks.issue).states.review).toEqual(["PASS", "BLOCKED", "FAIL"]);
+		expect(defined(summary.tasks.issue).states.ship).toEqual(["DONE", "BLOCKED", "FAIL"]);
 		expect(defined(summary.tasks.issue).states.shipped).toEqual([]);
 		expect(summary.trigger).toBeUndefined();
+	});
+
+	it("re-enters build on a FAIL at ship, and freezes once the retries are spent (#5807)", () => {
+		const lane = compiled(coderWorkflow());
+		const toShip = ["WIP", "DONE", "PASS"];
+		const roundTrip = ["FAIL", "DONE", "PASS"];
+
+		expect(leaves(lane, "issue", [...toShip, ...roundTrip, ...roundTrip, "FAIL"])).toEqual([
+			"build",
+			"review",
+			"ship",
+			"build",
+			"review",
+			"ship",
+			"build",
+			"review",
+			"ship",
+			"frozen",
+		]);
 	});
 
 	it("compiles the committed chore template, carrying its declared trigger", () => {
@@ -86,9 +127,7 @@ describe("the compiler — structural recognition", () => {
 
 	it("holds the chore template to the same six events as every other lane", () => {
 		const summary = topology(compiled(choreWorkflow()));
-		const listened = new Set(
-			Object.values(defined(summary.tasks.park_sweep).states).flatMap((events) => events),
-		);
+		const listened = new Set(Object.values(defined(summary.tasks.park_sweep).states).flat());
 
 		for (const event of listened) expect(OPERATOR_EVENTS).toContain(event);
 	});

--- a/packages/fabrika-cli/src/lane/templates/coder.workflow.json
+++ b/packages/fabrika-cli/src/lane/templates/coder.workflow.json
@@ -43,7 +43,15 @@
 							"ship": {
 								"on": {
 									"ISSUE.DONE": "shipped",
-									"ISSUE.BLOCKED": "human:cp-approval"
+									"ISSUE.BLOCKED": "human:cp-approval",
+									"ISSUE.FAIL": [
+										{
+											"target": "build",
+											"guard": "retriesRemaining",
+											"actions": "incrementRetries"
+										},
+										{ "target": "frozen" }
+									]
 								}
 							},
 							"blocked": {


### PR DESCRIPTION
The lane machine's `ship` state listened for only `DONE` and `BLOCKED`, so `lane transition <lane> FAIL` at `ship` was refused with `NoCellError` (exit 12). A PR can legitimately be re-reviewed at a rewritten head while the lane sits at `ship` — an `UNBLOCKED` park clear that rewrites the branch is exactly that path — and the operator had no event to record the failing verdict with.

What changed:

- `coder.workflow.json`'s `ship` gains the same two-arm guarded `FAIL` its `review` already carries: retry to `build` while retries remain, fall through to `frozen` once they are spent.
- `emit.ts`'s epic tail region gains the analogous edge on its `ship`: retry to `review`, fall through to `human:epic-review`. The golden fixture is regenerated to match.
- `operate`'s step-3 fold table gains a row folding the shipper's `routed to repair` and `EJECTED — routed to repair` to `FAIL`, and the catch-all is narrowed to "anything else not claimed above" so exactly one row claims them. Before this, a shipper that explicitly routed to repair was recorded as `BLOCKED`, which at `ship` parks under `human:cp-approval` — a name the outcome does not fit — and spent none of the retry budget.
- Two unit tests: `machine.unit.test.ts` drives the coder template `FAIL` at `ship` through both arms and asserts `ship` lists `FAIL` in the topology `lane print` reads; `emit.unit.test.ts` drives the same for the epic tail.

**Open question the issue asked to raise here rather than settle silently:** the shipper's third repair-routing terminal, `routed to review`, is left in the `BLOCKED` catch-all. The `ship` `FAIL` cell targets `build`, so folding it to `FAIL` would send a lane that only needs re-review through a build round. `routed to heal-ci` is likewise left `BLOCKED` — a red-CI stall is a stuck PR, not a repair build. Both rows are cheap to move if a reviewer reads them the other way.

## Deviations

- **Scope narrowing** — **Said:** the acceptance criteria say the generated regions carry the *identical* edge to the template's, `[{target: "build"}, {target: "frozen"}]`. **Did:** the epic tail region's edge targets `review` and `human:epic-review` instead. **Why:** the epic tail region has no `build` and no `frozen` state (ADR 0285 — an epic run has one PR, and repair happens outside the machine), so the literal edge would be a compile defect on two unknown targets. The shape mirrors the tail's own `review` `FAIL`, which retries into `review` for the same reason. **Disposition:** stated here.
- **Pre-existing test or fixture changed** — **Said:** #5807 names no lint cleanup. **Did:** rewrote a pre-existing `.flatMap((events) => events)` to `.flat()` in `machine.unit.test.ts`. **Why:** `lint:worktree` scopes to changed files, so touching this file surfaced the `noFlatMapIdentity` diagnostic and `build check --surface code` stayed red until it was fixed. **Disposition:** stated here.
- **Known defect left unfixed** — **Said:** nothing in the issue. **Did:** left the generic `BLOCKED` at `ship` still folding to the `human:cp-approval` park even when the block has another cause. **Why:** #5820 already owns that cell. **Disposition:** stated here.

Fixes #5807
