### PR TITLE
fix: build check's changed-file scope silently omits untracked files

### DIFF
--- a/packages/fabrika-cli/src/build/check-verb.ts
+++ b/packages/fabrika-cli/src/build/check-verb.ts
@@ -309,7 +309,7 @@ export const runCheck = (
 		if (listed._tag === "Failure") {
 			return refuse(
 				PRECONDITION_UNKNOWN,
-				`${VERB}: cannot read the diff against ${base}: ${listed.reason} — the verdict is UNKNOWN, never green.`,
+				`${VERB}: cannot enumerate the files changed against ${base}: ${listed.reason} — the verdict is UNKNOWN, never green.`,
 				lane.notes,
 			);
 		}
@@ -318,7 +318,7 @@ export const runCheck = (
 		if (files.length === 0) {
 			return refuse(
 				ZERO_SCOPE,
-				`${VERB}: the diff against ${base} is empty — nothing to validate (ADR 0092).`,
+				`${VERB}: this tree changes nothing against ${base}, tracked or untracked — nothing to validate (ADR 0092).`,
 				scope,
 			);
 		}

--- a/packages/fabrika-cli/src/build/check-verb.unit.test.ts
+++ b/packages/fabrika-cli/src/build/check-verb.unit.test.ts
@@ -29,7 +29,8 @@ const PERM = /^gh api repos\/o\/r\/collaborators\/agent\/permission/;
 const REPO_META = /^gh api repos\/o\/r --jq \.default_branch$/;
 const MERGE_BASE = /^git merge-base HEAD origin\/main$/;
 const DIFF = /^git diff --name-only /;
-const UNTRACKED = /^git ls-files --others --exclude-standard$/;
+const UNTRACKED_ARGV = "git ls-files --others --exclude-standard --full-name -- :/";
+const UNTRACKED = /^git ls-files --others --exclude-standard --full-name -- :\/$/;
 const TYPECHECK = /^pnpm typecheck --force$/;
 const LINT = /^pnpm lint:worktree$/;
 
@@ -596,6 +597,25 @@ describe("the enumeration unions the untracked files with the diff", () => {
 	it("still refuses on 7 when neither source yields a path", async () => {
 		const out = await run([untracked(""), ...LANE_OK, [DIFF, okOut("")]]);
 		expect(out.code).toBe(ZERO_SCOPE);
+	});
+
+	// Scripting stdout cannot catch a cwd-scoped read: bare `ls-files --others` answers only for the
+	// cwd and answers cwd-relative, while `git diff` answers repo-wide and root-relative. Run from a
+	// subdirectory that drops untracked files elsewhere in the tree and misresolves the rest against
+	// `lane.root`. Only the argv proves the two reads cover the same tree, so assert the argv.
+	it("reads the untracked list repo-wide and root-relative", async () => {
+		const shell = fakeShell([
+			untracked("apps/web/src/New.tsx\n"),
+			...LANE_OK,
+			[DIFF, okOut("apps/web/src/App.tsx\n")],
+			[TYPECHECK, okOut("")],
+			[LINT, okOut("")],
+		]);
+		const out = await Effect.runPromise(
+			Effect.provide(runCheck(options), Layer.merge(shell.layer, fakeFs({}).layer)),
+		);
+		expect(out.code).toBe(0);
+		expect(shell.calls).toContain(UNTRACKED_ARGV);
 	});
 
 	it("refuses an unreadable untracked read on 11 — a short list is a fail-open green", async () => {

--- a/packages/fabrika-cli/src/build/check-verb.unit.test.ts
+++ b/packages/fabrika-cli/src/build/check-verb.unit.test.ts
@@ -29,10 +29,14 @@ const PERM = /^gh api repos\/o\/r\/collaborators\/agent\/permission/;
 const REPO_META = /^gh api repos\/o\/r --jq \.default_branch$/;
 const MERGE_BASE = /^git merge-base HEAD origin\/main$/;
 const DIFF = /^git diff --name-only /;
+const UNTRACKED = /^git ls-files --others --exclude-standard$/;
 const TYPECHECK = /^pnpm typecheck --force$/;
 const LINT = /^pnpm lint:worktree$/;
 
 const LANE = `build/4312-editor-focus-loss-${NONCE}`;
+
+/** A scripted untracked-file list. Placed ahead of `LANE_OK`, whose default is an empty one. */
+const untracked = (stdout: string): readonly [RegExp, ExecResult] => [UNTRACKED, okOut(stdout)];
 
 const LANE_OK: ReadonlyArray<readonly [RegExp, ExecResult]> = [
 	[REV_PARSE, GIT_DIRS],
@@ -42,6 +46,7 @@ const LANE_OK: ReadonlyArray<readonly [RegExp, ExecResult]> = [
 	[PERM, okOut("write\n")],
 	[REPO_META, okOut("main\n")],
 	[MERGE_BASE, okOut(`${HEAD}\n`)],
+	untracked(""),
 ];
 
 const options = {
@@ -166,7 +171,7 @@ describe("runCheck", () => {
 		const out = await run([...LANE_OK, [DIFF, okOut("")]]);
 		expect(out.code).toBe(ZERO_SCOPE);
 		expect(out.stderr.at(-1)).toBe(
-			"build check: the diff against origin/main is empty — nothing to validate (ADR 0092).",
+			"build check: this tree changes nothing against origin/main, tracked or untracked — nothing to validate (ADR 0092).",
 		);
 	});
 
@@ -518,5 +523,88 @@ describe("--surface plan covers the markdown class it claims", () => {
 		const verdict = JSON.parse(out.stdout);
 		expect(verdict.unvalidated).toEqual([]);
 		expect(verdict.ran).toEqual(["markdown link + leak scan", "## Dependencies grammar"]);
+	});
+});
+
+// #5823: `git diff` reports no untracked path, so a brand-new file reached neither the validated
+// set nor `unvalidated` — invisible instead of disclosed, under a green verdict. The lane order is
+// construct, check, then commit, so every new file is untracked exactly when the verb runs.
+describe("the enumeration unions the untracked files with the diff", () => {
+	it("counts an untracked file in the scanned scope", async () => {
+		const out = await run([
+			untracked("packages/fabrika-cli/src/build/pr-title.ts\n"),
+			...LANE_OK,
+			[DIFF, okOut("apps/web/src/App.tsx\n")],
+			[TYPECHECK, okOut("")],
+			[LINT, okOut("")],
+		]);
+		expect(out.code).toBe(0);
+		expect(out.stderr).toContain("build check: 2 changed file(s) against origin/main.");
+		expect(JSON.parse(out.stdout).unvalidated).toEqual([]);
+	});
+
+	it("names an untracked markdown file in a code run's unvalidated list", async () => {
+		const out = await run([
+			untracked("docs/new-guide.md\n"),
+			...LANE_OK,
+			[DIFF, okOut("apps/web/src/App.tsx\n")],
+			[TYPECHECK, okOut("")],
+			[LINT, okOut("")],
+		]);
+		expect(out.code).toBe(0);
+		expect(JSON.parse(out.stdout).unvalidated).toEqual(["docs/new-guide.md"]);
+	});
+
+	// The prose scanners read per enumerated file, so an unlisted markdown file is scanned by nothing.
+	it("scans an untracked markdown file under --surface prose", async () => {
+		const out = await run(
+			[untracked("docs/new-guide.md\n"), ...LANE_OK, [DIFF, okOut("docs/tracked.md\n")]],
+			{surface: "prose"},
+			{
+				"/repo/trees/lane-a/docs/tracked.md": "fine\n",
+				"/repo/trees/lane-a/docs/new-guide.md": "run it from /Users/someone/phoenix\n",
+			},
+		);
+		expect(out.code).toBe(VALIDATION_RED);
+		expect(out.stderr.some((line) => line.includes("machine-local path"))).toBe(true);
+	});
+
+	it("validates an all-untracked tree instead of refusing it as empty", async () => {
+		const out = await run([
+			untracked("apps/web/src/New.tsx\n"),
+			...LANE_OK,
+			[DIFF, okOut("")],
+			[TYPECHECK, okOut("")],
+			[LINT, okOut("")],
+		]);
+		expect(out.code).toBe(0);
+		expect(out.stderr).toContain("build check: 1 changed file(s) against origin/main.");
+	});
+
+	it("lists a path both sources report exactly once", async () => {
+		const out = await run([
+			untracked("b.ts\na.ts\n"),
+			...LANE_OK,
+			[DIFF, okOut("b.ts\nc.ts\n")],
+			[TYPECHECK, okOut("")],
+			[LINT, okOut("")],
+		]);
+		expect(out.code).toBe(0);
+		expect(out.stderr).toContain("build check: 3 changed file(s) against origin/main.");
+	});
+
+	it("still refuses on 7 when neither source yields a path", async () => {
+		const out = await run([untracked(""), ...LANE_OK, [DIFF, okOut("")]]);
+		expect(out.code).toBe(ZERO_SCOPE);
+	});
+
+	it("refuses an unreadable untracked read on 11 — a short list is a fail-open green", async () => {
+		const out = await run([
+			[UNTRACKED, errOut("fatal: not a git repository")],
+			...LANE_OK,
+			[DIFF, okOut("apps/web/src/App.tsx\n")],
+		]);
+		expect(out.code).toBe(PRECONDITION_UNKNOWN);
+		expect(out.stderr.at(-1)).toContain("the verdict is UNKNOWN, never green");
 	});
 });

--- a/packages/fabrika-cli/src/build/git.ts
+++ b/packages/fabrika-cli/src/build/git.ts
@@ -225,15 +225,33 @@ export const mergeBase = (base: string): Shell<Attempt<string>> =>
 		return isObjectName(sha) ? ok(sha) : fail(`git named no merge base with ${base}`);
 	});
 
-/** Every path this tree changes against `base`, committed and working-tree alike. */
+const pathLines = (stdout: string): ReadonlyArray<string> =>
+	stdout
+		.split("\n")
+		.map((l) => l.trim())
+		.filter((l) => l !== "");
+
+/**
+ * Every path this tree changes against `base`: what `git diff` reports — commits plus tracked
+ * working-tree edits — unioned with the untracked, non-ignored paths `git ls-files --others` lists.
+ * Deduped and sorted, so a path listed by both sources appears once.
+ *
+ * Ignored files stay out; `--exclude-standard` is what keeps them out.
+ *
+ * The second source is the scar (#5823). `git diff` never reports an untracked path, so a
+ * brand-new file was absent from the list `build check` partitions — neither validated nor named in
+ * `unvalidated`, invisible instead of disclosed, while the verdict read green. The natural lane
+ * order is construct, check, then commit, which is exactly the window where a new file is untracked.
+ *
+ * Either source failing is a failure of the whole read: a short list here becomes a green that
+ * understates its own coverage, which is the fail-open direction.
+ */
 export const changedFiles = (base: string): Shell<Attempt<ReadonlyArray<string>>> =>
 	Effect.gen(function* () {
-		const r = yield* execCapture("git", ["diff", "--name-only", base]);
-		if (!r.ok) return fail(r.reason);
-		return ok(
-			r.stdout
-				.split("\n")
-				.map((l) => l.trim())
-				.filter((l) => l !== ""),
-		);
+		const tracked = yield* execCapture("git", ["diff", "--name-only", base]);
+		if (!tracked.ok) return fail(tracked.reason);
+		const untracked = yield* execCapture("git", ["ls-files", "--others", "--exclude-standard"]);
+		if (!untracked.ok) return fail(untracked.reason);
+		const union = new Set([...pathLines(tracked.stdout), ...pathLines(untracked.stdout)]);
+		return ok([...union].sort());
 	});

--- a/packages/fabrika-cli/src/build/git.ts
+++ b/packages/fabrika-cli/src/build/git.ts
@@ -238,6 +238,12 @@ const pathLines = (stdout: string): ReadonlyArray<string> =>
  *
  * Ignored files stay out; `--exclude-standard` is what keeps them out.
  *
+ * `--full-name -- :/` is load-bearing on the second read: bare `ls-files --others` is cwd-scoped and
+ * prints cwd-relative paths, while `git diff` is repo-wide and root-relative. Run from a
+ * subdirectory the two disagree, dropping untracked files outside the cwd and handing the rest a
+ * path that does not resolve against `lane.root`. The pathspec restores repo-wide, the flag
+ * restores root-relative.
+ *
  * The second source is the scar (#5823). `git diff` never reports an untracked path, so a
  * brand-new file was absent from the list `build check` partitions — neither validated nor named in
  * `unvalidated`, invisible instead of disclosed, while the verdict read green. The natural lane
@@ -250,7 +256,14 @@ export const changedFiles = (base: string): Shell<Attempt<ReadonlyArray<string>>
 	Effect.gen(function* () {
 		const tracked = yield* execCapture("git", ["diff", "--name-only", base]);
 		if (!tracked.ok) return fail(tracked.reason);
-		const untracked = yield* execCapture("git", ["ls-files", "--others", "--exclude-standard"]);
+		const untracked = yield* execCapture("git", [
+			"ls-files",
+			"--others",
+			"--exclude-standard",
+			"--full-name",
+			"--",
+			":/",
+		]);
 		if (!untracked.ok) return fail(untracked.reason);
 		const union = new Set([...pathLines(tracked.stdout), ...pathLines(untracked.stdout)]);
 		return ok([...union].sort());


### PR DESCRIPTION
`fabrika build check` built its changed-file list from `git diff --name-only <merge-base>` alone. `git diff` never reports an untracked path, so a file that had been written but not yet staged was in neither the validated set nor `unvalidated` — invisible rather than disclosed, while the verdict read green. The lane order is construct, check, then commit, which is exactly the window where every new file is untracked.

`changedFiles` in `packages/fabrika-cli/src/build/git.ts` now unions the diff with `git ls-files --others --exclude-standard`, deduped and sorted, so a path reported by both sources appears once and ignored files stay out. Either read failing fails the whole enumeration: a short list here would become a green that understates its own coverage.

Two refusal messages in `check-verb.ts` were narrowed by the old single source and are now honest about both — the UNKNOWN one no longer blames "the diff" for a failed `ls-files` read, and the zero-scope one says the tree changes nothing tracked or untracked.

Seven unit tests in `check-verb.unit.test.ts` cover the union: an untracked file reaching the scanned count, an untracked `.md` landing in a `--surface code` run's `unvalidated`, the prose scanners actually opening an untracked `.md`, an all-untracked tree validating instead of refusing as empty, a both-sources path listed once, the zero-scope refusal still firing when neither source yields a path, and an unreadable `ls-files` refusing on 11.

Fixes #5823

## Deviations

None.
