### PR TITLE
feat: Two operate drivers ran the same epic at once; nothing claims a lane, only its issues

### DIFF
--- a/claude-plugins/fabrika/skills/operate/SKILL.md
+++ b/claude-plugins/fabrika/skills/operate/SKILL.md
@@ -33,7 +33,7 @@ node packages/fabrika-cli/src/bin.ts lane <verb> …
 ([#5679](https://github.com/kamp-us/phoenix/issues/5679)), so its answer describes a tree you are
 not standing in. The same rule goes into every spawn prompt you write.
 
-## 1 — Boot or resume
+## 1 — Claim the lane, then boot or resume
 
 The lane you were invoked on is `$lane_key`, and every command below carries it — an issue number,
 or `chore:<name>` for a chore drive, which is how a chore is addressed by name. A blank there
@@ -42,6 +42,27 @@ blank, because the harness hands the preload an empty argument and the key arriv
 brief instead — so on a blank, take the lane your caller named there. Only when no caller named
 one are you actually without a key, and then ask for it before running a verb. Never invent one
 nobody named.
+
+**Claim it before you write anything.** Two drivers ran epic #5492's children at once, each folding
+its own machine-local ledger and each spawning its own builder on the same repair, and nothing saw
+the collision until `build claim` caught it one level down
+([#5761](https://github.com/kamp-us/phoenix/issues/5761)):
+
+```bash
+node packages/fabrika-cli/src/bin.ts lane claim $lane_key
+```
+
+Exit `0` is yours to drive — `won` on an issue lane, `unclaimable` on a `chore:<name>` key, which
+carries no board number for a marker to sit on and so races with nobody. Exit `31` is a **proven
+loss**: another driver holds this lane, its token is named on stderr, and this run ends `LANE-HELD`
+having emitted no ledger and spawned no shell. `1` (no `CLAUDE_CODE_SESSION_ID`), `8` (the marker
+write is UNKNOWN), `9` (it landed and does not read back) and `11` (the marker set could not be
+read) all end `STOPPED` naming the code — an unproven claim is never driven through.
+
+The claim is the driver's own namespace, `lane-claim:`, not the builder's `build-claim:`. That is
+what lets the builder you spawn on this very number claim it and win: two markers on one thread,
+two races that never see each other. You never read the other namespace and never retract a marker
+that is not this run's.
 
 ```bash
 node packages/fabrika-cli/src/bin.ts lane status $lane_key
@@ -358,7 +379,22 @@ re-run before trusting anything. Then loop to step 2.
 
 Done when the fold reads a terminal state or a park.
 
-## 4 — Park, or end with the transcript
+## 4 — Park, or end with the transcript — then release
+
+Both ends of the loop release the claim, and it is the **last** thing the run does — after the park
+comment or the transcript has landed, so a successor that wins the lane the moment you let go finds
+the artifact already there:
+
+```bash
+node packages/fabrika-cli/src/bin.ts lane release $lane_key
+```
+
+Exit `0` is released (or `inert` on a chore key, which was never claimable). `31` means this session
+holds no claim — say so and stop; you never retract another driver's marker. `8` or `11` leaves
+whether the lane is still held UNKNOWN: name the code in your terminal line rather than reporting a
+release you cannot prove. A `STOPPED` run releases too — a claim outliving the driver that took it
+is the same lane nobody can pick up.
+
 
 **A run never ends `LANE-PARKED` while the fold reads a non-parked state.** `human:*` and
 `blocked` are already parked — the fold itself says so, and no event is owed on top of it. Any
@@ -436,7 +472,9 @@ Every run ends as exactly one of — each naming what was recorded and what the 
 `tripped`; no event recorded on top of a final fold; transcript posted on the driven issue) ·
 **`LANE-PARKED`** (the fold reads `blocked` or `human:*` — either it already did and no event was
 owed, or the `BLOCKED` this run recorded put it there and the re-fold confirmed it; the need
-posted on the driven issue) · **`STOPPED`** (a verb exit UNKNOWN, a malformed record, an
+posted on the driven issue) · **`LANE-HELD`** (step 1's claim was proven lost — another driver owns
+this lane, its token named; no ledger emitted, no shell spawned, no marker retracted, nothing
+posted) · **`STOPPED`** (a verb exit UNKNOWN, a malformed record, an
 unroutable state, or a `BLOCKED` refused with exit `12` — the code or state named, nothing
 guessed, no event recorded, the fold unchanged). An unroutable state ends `STOPPED`, never
 `LANE-PARKED`: a park promises a mechanical `UNBLOCKED` resume from `blocked`/`human:*`, which a
@@ -457,7 +495,7 @@ fabrika skill, so one reader parses all of them. No row here dead-ends on a bare
 
 | Must exist | Why this skill needs it | When missing |
 | --- | --- | --- |
-| The lane verb group — `packages/fabrika-cli/src/bin.ts` routing `lane status`/`transition`/`prove` (#5747)/`history`/`print` plus `open`/`emit` (#5688), `brief` (#5751) and `stale` (#5897) | Every state read, every proof, every event write, every spawn prompt and the dead-operator sweep in this skill is one of these verbs; there is no other path to the ledger, and none to a prompt | **fail-loud** — a verb that cannot be executed leaves the lane state UNKNOWN; the run ends `STOPPED` naming `packages/fabrika-cli/src/bin.ts` and points at front-door. |
+| The lane verb group — `packages/fabrika-cli/src/bin.ts` routing `lane status`/`transition`/`prove` (#5747)/`history`/`print` plus `open`/`emit` (#5688), `brief` (#5751), `stale` (#5897) and `claim`/`release` (#5761) | Every state read, every proof, every event write, every spawn prompt, the dead-operator sweep and the driver's own exclusivity in this skill is one of these verbs; there is no other path to the ledger, none to a prompt, and none to knowing whether a second driver is already here | **fail-loud** — a verb that cannot be executed leaves the lane state UNKNOWN; the run ends `STOPPED` naming `packages/fabrika-cli/src/bin.ts` and points at front-door. |
 | The recipe verb group — `packages/fabrika-cli/src/bin.ts` routing `recipe route` plus the recipes it names (`unpark`, `rerun`), and the chore template at `packages/fabrika-cli/src/lane/templates/chore.workflow.json` | A chore drive routes and folds through `recipe route`, runs the recipe it names, and boots from that template; there is no other path to either answer | **fail-loud** — a chore drive whose routing verb cannot be executed knows neither what to run nor what an exit meant; the run ends `STOPPED` naming `packages/fabrika-cli/src/recipe/`, records no event, and points at front-door. An issue lane is unaffected. |
 | The agent shells — `claude-plugins/fabrika/agents/builder.md`, `reviewer.md`, `shipper.md` | Step 2's routing table spawns exactly these three by their bare noun names | **fail-loud** — a route whose shell does not exist cannot spawn; the run ends `STOPPED` naming the absent shell file, and no event is recorded for a spawn that never started. |
 | The `package.json` scripts `typecheck` and `lint:worktree` | An epic run's `integrate` reads the semantic collision off them — two ranges that each passed alone and fail together show up as the merged assembly failing the checks, and a clean `git merge` alone cannot see that | **degrade** — a clean merge is then the whole `DONE` answer and a semantic collision only surfaces at the epic review; say so in the transcript comment and file the gap via `/report`. An epic run still drives; a single-issue lane is unaffected. |

--- a/packages/fabrika-cli/README.md
+++ b/packages/fabrika-cli/README.md
@@ -801,6 +801,7 @@ snapshot. Lane state is local and never committed (the repo's `/.fabrika/` gitig
 | `lane history` | the log verbatim, one `{task, event, at}` per event — `from`/`to` are reconstructible by folding, never stored |
 | `lane print` | the compiled topology: phases, the two workflow terminals, and each state's legal events |
 | `lane stale` | every lane on disk with the age of its last event and one verdict — which lanes are non-terminal, unparked and silent past `--older-than` (default 60 minutes), so a dead operator is detectable instead of invisible |
+| `lane claim` / `lane release` | who is driving this lane: the same detect-then-tiebreak race `build claim` runs, in the driver's own `lane-claim:` namespace, so the builder a driver spawns claims the same issue and wins ([#5761](https://github.com/kamp-us/phoenix/issues/5761)). A `chore:<name>` key carries no board number and answers `unclaimable`/`inert` at exit 0 |
 
 To open a lane, copy a template in and speak the operator's six events —
 `DONE` / `PASS` / `FAIL` / `BLOCKED` / `WIP` / `UNBLOCKED`:

--- a/packages/fabrika-cli/src/build/claim.ts
+++ b/packages/fabrika-cli/src/build/claim.ts
@@ -14,6 +14,10 @@
  *
  * Three refusals stay separate, because v1 fused them and callers guessed: a proven loss is `15`, a
  * missing session id is `1`, and an unreadable marker set is `11` — never "unclaimed".
+ *
+ * The protocol is namespaced by a {@link ClaimGrammar} so a second kind of lane can race on the same
+ * issue without colliding with a build claim; `build` reads {@link BUILD_CLAIM}, which is the default
+ * everywhere, and the `lane` group reads its own (`../lane/claim.ts`).
  */
 import {Effect} from "effect";
 import type {ChildProcessSpawner} from "effect/unstable/process";
@@ -30,12 +34,45 @@ export const SESSION_ENV = "CLAUDE_CODE_SESSION_ID";
 const AUTHORIZED = new Set(["admin", "maintain", "write"]);
 
 /**
- * The marker's one line: `build-claim: <token> · <ISO-8601-UTC>`.
+ * One claim namespace: the marker line's leading word, and the token's leading segment.
+ *
+ * Two namespaces race on the same issue and never see each other — `build-claim:`/`build:` for a
+ * builder, `lane-claim:`/`lane:` for the `operate` driver that spawns it (#5761). That separation is
+ * the whole reason the grammar is a value: the marker's regex is *derived* from the keyword and the
+ * prefix, so a namespace cannot ship a writer and a reader that disagree, and a driver holding a
+ * lane claim on issue N cannot lock its own builder out of N.
+ */
+export interface ClaimGrammar {
+	readonly keyword: string;
+	readonly prefix: string;
+	readonly marker: RegExp;
+}
+
+const NAMESPACE = /^[a-z]+(?:-[a-z]+)*$/;
+
+/**
+ * A namespace's grammar. Both halves are checked because they are interpolated into a regex: a
+ * keyword carrying a metacharacter would compile a pattern nobody wrote, and the callers pass module
+ * constants, so an off-shape one is a programming error rather than input to refuse.
+ */
+export const claimGrammar = (keyword: string, prefix: string): ClaimGrammar => {
+	if (!NAMESPACE.test(keyword) || !NAMESPACE.test(prefix)) {
+		throw new Error(`"${keyword}"/"${prefix}" is not a claim namespace (${NAMESPACE.source})`);
+	}
+	return {
+		keyword,
+		prefix,
+		marker: new RegExp(`^${keyword}:\\s*(${prefix}:[^\\s·]+)\\s*(?:·.*)?$`, "m"),
+	};
+};
+
+/**
+ * The builder's namespace, and the one every existing caller reads: `build-claim: <token> · <ISO>`.
  *
  * The token is the only field ownership turns on. The timestamp is for a human reading the thread —
  * the tiebreak uses the comment's own `created_at`, which a claimant cannot author.
  */
-const MARKER_RE = /^build-claim:\s*(build:[^\s·]+)\s*(?:·.*)?$/m;
+export const BUILD_CLAIM: ClaimGrammar = claimGrammar("build-claim", "build");
 
 /** An admission override: the lane it is taken for, and why. Both required — see `readOverride`. */
 export interface ClaimOverride {
@@ -55,15 +92,19 @@ export const composeMarker = (
 	token: string,
 	at: string,
 	override: ClaimOverride | null = null,
+	grammar: ClaimGrammar = BUILD_CLAIM,
 ): string =>
 	override === null
-		? `build-claim: ${token} · ${at}`
-		: `build-claim: ${token} · ${at}\nbuild-claim-override: ${override.lane} · ${override.reason}`;
+		? `${grammar.keyword}: ${token} · ${at}`
+		: `${grammar.keyword}: ${token} · ${at}\n${grammar.keyword}-override: ${override.lane} · ${override.reason}`;
 
-/** The token a comment body claims, or `null` when it carries no marker. */
-export const readMarkerToken = (body: string): string | null => {
-	const m = MARKER_RE.exec(body);
-	return m?.[1] === undefined || parseToken(m[1]) === null ? null : m[1];
+/** The token a comment body claims in `grammar`, or `null` when it carries no marker of that kind. */
+export const readMarkerToken = (
+	body: string,
+	grammar: ClaimGrammar = BUILD_CLAIM,
+): string | null => {
+	const m = grammar.marker.exec(body);
+	return m?.[1] === undefined || parseToken(m[1], grammar.prefix) === null ? null : m[1];
 };
 
 export interface ClaimMarker {
@@ -73,11 +114,14 @@ export interface ClaimMarker {
 	readonly token: string;
 }
 
-/** Every claim marker in a comment list, oldest first, ties broken by comment id. */
-export const markersIn = (comments: ReadonlyArray<CommentRecord>): ReadonlyArray<ClaimMarker> => {
+/** Every claim marker of `grammar` in a comment list, oldest first, ties broken by comment id. */
+export const markersIn = (
+	comments: ReadonlyArray<CommentRecord>,
+	grammar: ClaimGrammar = BUILD_CLAIM,
+): ReadonlyArray<ClaimMarker> => {
 	const markers: ClaimMarker[] = [];
 	for (const comment of comments) {
-		const token = readMarkerToken(comment.body);
+		const token = readMarkerToken(comment.body, grammar);
 		if (token !== null) {
 			markers.push({
 				commentId: comment.id,
@@ -111,6 +155,7 @@ export const resolveOwnership = (
 	repo: string,
 	number: number,
 	session: string,
+	grammar: ClaimGrammar = BUILD_CLAIM,
 ): Effect.Effect<
 	{readonly ownership: Ownership; readonly unauthorized: ReadonlyArray<ClaimMarker>},
 	never,
@@ -121,7 +166,7 @@ export const resolveOwnership = (
 		if (listed._tag === "Failure") {
 			return {ownership: {_tag: "Unknown" as const, reason: listed.reason}, unauthorized: []};
 		}
-		const markers = markersIn(listed.value);
+		const markers = markersIn(listed.value, grammar);
 		const unauthorized: ClaimMarker[] = [];
 		const permissions = new Map<string, string | null>();
 		for (const marker of markers) {
@@ -144,7 +189,7 @@ export const resolveOwnership = (
 				unauthorized.push(marker);
 				continue;
 			}
-			const parsed = parseToken(marker.token);
+			const parsed = parseToken(marker.token, grammar.prefix);
 			const mine = parsed !== null && parsed.session === session;
 			return {
 				ownership: mine ? ({_tag: "Mine", marker} as const) : ({_tag: "Foreign", marker} as const),

--- a/packages/fabrika-cli/src/build/lane.ts
+++ b/packages/fabrika-cli/src/build/lane.ts
@@ -19,13 +19,24 @@ export const TOKEN_PREFIX = "build";
 /** A UUID's first 8 hex characters — the nonce every lane branch carries. */
 export const NONCE_LENGTH = 8;
 
-const TOKEN_RE = /^build:([^:\s]+):([0-9a-f-]{8,})$/;
+const TOKEN_RES = new Map<string, RegExp>();
 
-/** The `<session-id>` and `<uuid>` halves of a token, or `null` when it is not a build token. */
+// Derived from the prefix rather than typed beside it, so a second claim namespace (`lane:`, #5761)
+// cannot ship a token writer and a token reader that disagree.
+const tokenRe = (prefix: string): RegExp => {
+	const cached = TOKEN_RES.get(prefix);
+	if (cached !== undefined) return cached;
+	const compiled = new RegExp(`^${prefix}:([^:\\s]+):([0-9a-f-]{8,})$`);
+	TOKEN_RES.set(prefix, compiled);
+	return compiled;
+};
+
+/** The `<session-id>` and `<uuid>` halves of a token, or `null` when it does not carry `prefix`. */
 export const parseToken = (
 	token: string,
+	prefix: string = TOKEN_PREFIX,
 ): {readonly session: string; readonly uuid: string} | null => {
-	const m = TOKEN_RE.exec(token.trim());
+	const m = tokenRe(prefix).exec(token.trim());
 	return m?.[1] === undefined || m[2] === undefined ? null : {session: m[1], uuid: m[2]};
 };
 
@@ -38,8 +49,11 @@ export const nonceOf = (token: string): string | null => {
 };
 
 /** Compose a token from this session's id and a fresh UUID. */
-export const composeToken = (session: string, uuid: string): string =>
-	`${TOKEN_PREFIX}:${session}:${uuid}`;
+export const composeToken = (
+	session: string,
+	uuid: string,
+	prefix: string = TOKEN_PREFIX,
+): string => `${prefix}:${session}:${uuid}`;
 
 /**
  * A slug the branch name may carry: kebab-case, ≤5 words, never flag-shaped.

--- a/packages/fabrika-cli/src/exit-code-alignment.ts
+++ b/packages/fabrika-cli/src/exit-code-alignment.ts
@@ -266,19 +266,22 @@ export const PATTERN_SEATS: SharedSeats = {
 };
 
 /**
- * `lane`'s seats: four, on `spend`'s reading widened by a write.
+ * `lane`'s seats: five, on `spend`'s reading widened by a write.
  *
  * Its verbs read a local lane directory and append to its log, so the base's facts they establish
  * are the target that is not there (`LANE_ABSENT`), the target read in full that is not the shape
  * (`MALFORMED_RECORD`, the `review-ui` whole-record widening of the section seat), the append that
  * did not land (`APPEND_UNKNOWN`), and the read that failed before any of that could be proven
- * (`LANE_UNREADABLE`). The private band runs `12`-`30`, skipping `27` and `28` because the base
- * already speaks for both.
+ * (`LANE_UNREADABLE`). `lane claim` adds the fifth: it posts a marker and reads it back, so alone in
+ * this group it can establish *the write landed and the read-back contradicts it* (`MARKER_READBACK`,
+ * #5761). The private band runs `12`-`31`, skipping `27` and `28` because the base already speaks for
+ * both.
  */
 export const LANE_SEATS: SharedSeats = {
 	MALFORMED_RECORD: "BAD_SECTIONS",
 	LANE_ABSENT: "NO_TARGET",
 	APPEND_UNKNOWN: "WRITE_UNKNOWN",
+	MARKER_READBACK: "READBACK_MISMATCH",
 	LANE_UNREADABLE: "PRECONDITION_UNKNOWN",
 };
 

--- a/packages/fabrika-cli/src/lane/claim-verb.ts
+++ b/packages/fabrika-cli/src/lane/claim-verb.ts
@@ -1,0 +1,190 @@
+/**
+ * `lane claim` / `lane release` — the driver's end of the claim protocol, in one file because
+ * splitting a claim from its release is how the two come to disagree about who holds a lane.
+ *
+ * Same race as `build claim`'s, one namespace over (`./claim.ts`): post the marker, **re-read**, and
+ * the earliest authorized marker wins. Posting alone only detects a race; the checkpoint read is what
+ * resolves it. A loser retracts its **own** marker and nothing else — never another lane's, which is
+ * the one write this protocol must never make.
+ *
+ * **No admission test runs here.** The fence decides what may start *building* (ADR 0245), and the
+ * builder this driver spawns runs it on its own account; a second copy in the driver would refuse a
+ * lane at a different moment than the shell it drives, for reasons the driver is type-blind to.
+ */
+
+import {Effect} from "effect";
+import type {ChildProcessSpawner} from "effect/unstable/process";
+import {composeMarker, readMarkerToken, requireSession, resolveOwnership} from "../build/claim.ts";
+import {composeToken} from "../build/lane.ts";
+import {resolveTargetRepo} from "../build/target.ts";
+import {createComment, deleteComment, getComment} from "../io/issues.ts";
+import {normalizeForReadback} from "../report/compose.ts";
+import {answer, refuse, type VerbOutcome} from "../verb.ts";
+import {claimTarget, LANE_CLAIM} from "./claim.ts";
+import {APPEND_UNKNOWN, CLAIM_NOT_MINE, LANE_UNREADABLE, MARKER_READBACK} from "./codes.ts";
+import type {LaneKey} from "./key.ts";
+
+export interface ProtocolOptions {
+	readonly key: LaneKey;
+	readonly lane: string;
+	readonly repo: string | null;
+	readonly env: Readonly<Record<string, string | undefined>>;
+}
+
+export interface LaneClaimOptions extends ProtocolOptions {
+	/** A fresh UUID, supplied by the adapter so the token this run mints is deterministic under test. */
+	readonly uuid: string;
+	/** The marker's human-readable ISO-8601 timestamp. The tiebreak uses GitHub's `created_at`. */
+	readonly at: string;
+}
+
+type Preflight =
+	| {readonly _tag: "Refused"; readonly outcome: VerbOutcome}
+	| {readonly _tag: "Inert"; readonly outcome: VerbOutcome}
+	| {
+			readonly _tag: "Ready";
+			readonly repo: string;
+			readonly session: string;
+			readonly number: number;
+	  };
+
+const preflight = (
+	verb: string,
+	kind: string,
+	options: ProtocolOptions,
+): Effect.Effect<Preflight, never, ChildProcessSpawner.ChildProcessSpawner> =>
+	Effect.gen(function* () {
+		const session = requireSession(verb, options.env);
+		if (session._tag === "Refused") return {_tag: "Refused" as const, outcome: session.outcome};
+		const target = claimTarget(options.key);
+		if (target._tag === "Inert") {
+			return {
+				_tag: "Inert" as const,
+				outcome: answer(JSON.stringify({answer: kind, lane: options.lane, why: target.why}), [
+					`${verb}: ${target.why} — nothing was written, and no second driver can be detected here.`,
+				]),
+			};
+		}
+		const resolved = yield* resolveTargetRepo(verb, options.repo, options.env);
+		if (resolved._tag === "Refused") return {_tag: "Refused" as const, outcome: resolved.outcome};
+		return {
+			_tag: "Ready" as const,
+			repo: resolved.repo,
+			session: session.id,
+			number: target.number,
+		};
+	});
+
+const CLAIM = "lane claim";
+
+const unauthorizedNotes = (
+	verb: string,
+	markers: ReadonlyArray<{readonly commentId: number; readonly author: string}>,
+): ReadonlyArray<string> =>
+	markers.map(
+		(marker) =>
+			`${verb}: comment ${marker.commentId} carries a lane-claim marker from "${marker.author}", who holds no write permission — counted, never a winner.`,
+	);
+
+export const runLaneClaim = (
+	options: LaneClaimOptions,
+): Effect.Effect<VerbOutcome, never, ChildProcessSpawner.ChildProcessSpawner> =>
+	Effect.gen(function* () {
+		const ready = yield* preflight(CLAIM, "unclaimable", options);
+		if (ready._tag !== "Ready") return ready.outcome;
+		const {repo, session, number} = ready;
+
+		const token = composeToken(session, options.uuid, LANE_CLAIM.prefix);
+		const posted = yield* createComment(
+			repo,
+			number,
+			composeMarker(token, options.at, null, LANE_CLAIM),
+		);
+		if (posted._tag === "Failure") {
+			return refuse(
+				APPEND_UNKNOWN,
+				`${CLAIM}: the marker write failed: ${posted.reason} — whether this driver holds #${number} is UNKNOWN; re-run before emitting a ledger.`,
+			);
+		}
+		const back = yield* getComment(repo, posted.value.id);
+		if (
+			back._tag === "Failure" ||
+			readMarkerToken(normalizeForReadback(back.value), LANE_CLAIM) !== token
+		) {
+			return refuse(
+				MARKER_READBACK,
+				`${CLAIM}: the marker landed but the read-back does not match — the claim needs a human eye.`,
+				[`${CLAIM}: comment ${posted.value.id} on #${number} is the one to inspect.`],
+			);
+		}
+
+		// The checkpoint: posting DETECTS a race, this re-read RESOLVES it.
+		const {ownership, unauthorized} = yield* resolveOwnership(repo, number, session, LANE_CLAIM);
+		const notes = unauthorizedNotes(CLAIM, unauthorized);
+		if (ownership._tag === "Unknown") {
+			return refuse(
+				LANE_UNREADABLE,
+				`${CLAIM}: cannot read the lane-claim markers on #${number}: ${ownership.reason} — ownership is UNKNOWN, never "unclaimed".`,
+				notes,
+			);
+		}
+		if (ownership._tag === "Mine") {
+			return answer(JSON.stringify({answer: "won", lane: options.lane, number, token}), notes);
+		}
+
+		// Lost, or shadowed by an unauthorized-only thread: retract this run's OWN marker, nothing else.
+		const retracted = yield* deleteComment(repo, posted.value.id);
+		const trailer =
+			retracted._tag === "Failure"
+				? [
+						`${CLAIM}: could not retract this run's own marker (comment ${posted.value.id}): ${retracted.reason}.`,
+					]
+				: [`${CLAIM}: retracted this run's own marker (comment ${posted.value.id}).`];
+		return ownership._tag === "Foreign"
+			? refuse(
+					CLAIM_NOT_MINE,
+					`${CLAIM}: lost to ${ownership.marker.token} (posted ${ownership.marker.createdAt}, authorized) — another driver holds this lane.`,
+					[...notes, ...trailer],
+				)
+			: refuse(
+					CLAIM_NOT_MINE,
+					`${CLAIM}: this run's own marker is not authorized — its author holds no write permission, so it can never win (ADR 0055).`,
+					[...notes, ...trailer],
+				);
+	});
+
+const RELEASE = "lane release";
+
+export const runLaneRelease = (
+	options: ProtocolOptions,
+): Effect.Effect<VerbOutcome, never, ChildProcessSpawner.ChildProcessSpawner> =>
+	Effect.gen(function* () {
+		const ready = yield* preflight(RELEASE, "inert", options);
+		if (ready._tag !== "Ready") return ready.outcome;
+		const {repo, session, number} = ready;
+
+		const {ownership, unauthorized} = yield* resolveOwnership(repo, number, session, LANE_CLAIM);
+		const notes = unauthorizedNotes(RELEASE, unauthorized);
+		if (ownership._tag === "Unknown") {
+			return refuse(
+				LANE_UNREADABLE,
+				`${RELEASE}: cannot read the lane-claim markers on #${number}: ${ownership.reason} — ownership is UNKNOWN, never "unclaimed".`,
+				notes,
+			);
+		}
+		if (ownership._tag !== "Mine") {
+			return refuse(
+				CLAIM_NOT_MINE,
+				`${RELEASE}: this session holds no lane claim on #${number} — refusing to release another driver's.`,
+				notes,
+			);
+		}
+		const deleted = yield* deleteComment(repo, ownership.marker.commentId);
+		return deleted._tag === "Failure"
+			? refuse(
+					APPEND_UNKNOWN,
+					`${RELEASE}: the retraction failed: ${deleted.reason} — whether this driver still holds #${number} is UNKNOWN.`,
+					notes,
+				)
+			: answer(JSON.stringify({answer: "released", lane: options.lane, number}), notes);
+	});

--- a/packages/fabrika-cli/src/lane/claim-verb.unit.test.ts
+++ b/packages/fabrika-cli/src/lane/claim-verb.unit.test.ts
@@ -1,0 +1,255 @@
+import {Effect} from "effect";
+import {describe, expect, it} from "vitest";
+import {runClaim} from "../build/claim-verb.ts";
+import {CLAIM_NOT_MINE as BUILD_CLAIM_NOT_MINE} from "../build/codes.ts";
+import {
+	comments as buildComments,
+	issue as buildIssue,
+	LANE_UUID,
+	truncatedComments,
+} from "../build/fixtures.test-support.ts";
+import {fakeFs, fakeShell, okOut} from "../fakes.test-support.ts";
+import type {ExecResult} from "../io/exec.ts";
+import {FAILED} from "../verb.ts";
+import {runLaneClaim, runLaneRelease} from "./claim-verb.ts";
+import {APPEND_UNKNOWN, CLAIM_NOT_MINE, LANE_UNREADABLE, MARKER_READBACK} from "./codes.ts";
+import {parseKey} from "./key.ts";
+
+const COMMENTS = /^gh api --paginate repos\/o\/r\/issues\/5492\/comments/;
+const POST = /^gh api --method POST repos\/o\/r\/issues\/5492\/comments/;
+const GET_COMMENT = /^gh api repos\/o\/r\/issues\/comments\/9001$/;
+const DELETE = /^gh api --method DELETE repos\/o\/r\/issues\/comments\//;
+const perm = (login: string) => new RegExp(`^gh api repos/o/r/collaborators/${login}/permission`);
+
+const OTHER_UUID = "9d8c7b6a-5f4e-3d2c-1b0a-998877665544";
+
+const laneMarker = (session: string, uuid: string): string =>
+	`lane-claim: lane:${session}:${uuid} · 2026-08-17T00:00:00Z`;
+
+const MINE = laneMarker("s-9f2e", LANE_UUID);
+const THEIRS = laneMarker("s-77aa", OTHER_UUID);
+
+const POSTED = okOut(JSON.stringify({id: 9001, html_url: "https://github.com/o/r/issues/5492#c"}));
+const ECHO = okOut(JSON.stringify({body: MINE}));
+
+const key = (raw: string) => {
+	const parsed = parseKey(raw);
+	if (parsed._tag === "Malformed") throw new Error(`fixture key "${raw}" is malformed`);
+	return parsed.key;
+};
+
+const options = {
+	key: key("5492"),
+	lane: "5492",
+	repo: null,
+	env: {CLAUDE_PIPELINE_REPO: "o/r", CLAUDE_CODE_SESSION_ID: "s-9f2e"} as Record<
+		string,
+		string | undefined
+	>,
+	uuid: LANE_UUID,
+	at: "2026-08-17T00:00:00Z",
+};
+
+const run = (
+	script: ReadonlyArray<readonly [RegExp, ExecResult]>,
+	overrides: Partial<typeof options> = {},
+) =>
+	Effect.runPromise(
+		Effect.provide(runLaneClaim({...options, ...overrides}), fakeShell(script).layer),
+	);
+
+const release = (
+	script: ReadonlyArray<readonly [RegExp, ExecResult]>,
+	overrides: Partial<typeof options> = {},
+) =>
+	Effect.runPromise(
+		Effect.provide(runLaneRelease({...options, ...overrides}), fakeShell(script).layer),
+	);
+
+describe("runLaneClaim", () => {
+	it("wins when its own marker is the earliest authorized one", async () => {
+		const out = await run([
+			[POST, POSTED],
+			[GET_COMMENT, ECHO],
+			[COMMENTS, buildComments({id: 9001, body: MINE})],
+			[perm("agent"), okOut("write\n")],
+		]);
+		expect(out.code).toBe(0);
+		expect(JSON.parse(out.stdout)).toEqual({
+			answer: "won",
+			lane: "5492",
+			number: 5492,
+			token: `lane:s-9f2e:${LANE_UUID}`,
+		});
+	});
+
+	it("re-reads AFTER posting — the checkpoint is what resolves a staggered race", async () => {
+		const shell = fakeShell([
+			[POST, POSTED],
+			[GET_COMMENT, ECHO],
+			[COMMENTS, buildComments({id: 9001, body: MINE})],
+			[perm("agent"), okOut("write\n")],
+		]);
+		await Effect.runPromise(Effect.provide(runLaneClaim(options), shell.layer));
+		const posted = shell.calls.findIndex((line) => POST.test(line));
+		const swept = shell.calls.findIndex((line) => COMMENTS.test(line));
+		expect(posted).toBeGreaterThanOrEqual(0);
+		expect(swept).toBeGreaterThan(posted);
+	});
+
+	it("exits 31 on a proven loss — never 0 — and retracts only its OWN marker", async () => {
+		const shell = fakeShell([
+			[POST, POSTED],
+			[GET_COMMENT, ECHO],
+			[
+				COMMENTS,
+				buildComments(
+					{id: 8000, body: THEIRS, createdAt: "2026-08-16T00:00:00Z"},
+					{id: 9001, body: MINE, createdAt: "2026-08-17T00:00:00Z"},
+				),
+			],
+			[perm("agent"), okOut("write\n")],
+			[DELETE, okOut("")],
+		]);
+		const out = await Effect.runPromise(Effect.provide(runLaneClaim(options), shell.layer));
+		expect(out.code).toBe(CLAIM_NOT_MINE);
+		expect(out.stdout).toBe("");
+		expect(out.stderr.join("\n")).toContain(`lane:s-77aa:${OTHER_UUID}`);
+		const deletes = shell.calls.filter((line) => DELETE.test(line));
+		expect(deletes).toEqual(["gh api --method DELETE repos/o/r/issues/comments/9001"]);
+	});
+
+	it("exits 11 on an unreadable marker set — UNKNOWN, never unclaimed", async () => {
+		const out = await run([
+			[POST, POSTED],
+			[GET_COMMENT, ECHO],
+			[COMMENTS, truncatedComments({id: 9001, body: MINE})],
+			[perm("agent"), okOut("write\n")],
+		]);
+		expect(out.code).toBe(LANE_UNREADABLE);
+		expect(out.stdout).toBe("");
+		expect(out.stderr.join("\n")).toContain("UNKNOWN");
+	});
+
+	it("exits 1 with no session id, and writes nothing", async () => {
+		const shell = fakeShell([]);
+		const out = await Effect.runPromise(
+			Effect.provide(runLaneClaim({...options, env: {CLAUDE_PIPELINE_REPO: "o/r"}}), shell.layer),
+		);
+		expect(out.code).toBe(FAILED);
+		expect(shell.calls).toEqual([]);
+	});
+
+	it("exits 8 when the marker write fails — UNKNOWN, never a held lane", async () => {
+		const out = await run([[POST, {ok: false, stdout: "", reason: "502"}]]);
+		expect(out.code).toBe(APPEND_UNKNOWN);
+		expect(out.stdout).toBe("");
+	});
+
+	it("exits 9 when the marker lands and does not read back", async () => {
+		const out = await run([
+			[POST, POSTED],
+			[GET_COMMENT, okOut(JSON.stringify({body: THEIRS}))],
+		]);
+		expect(out.code).toBe(MARKER_READBACK);
+		expect(out.stderr.join("\n")).toContain("9001");
+	});
+
+	it("answers unclaimable on a chore lane, writing nothing", async () => {
+		const shell = fakeShell([]);
+		const out = await Effect.runPromise(
+			Effect.provide(
+				runLaneClaim({...options, key: key("chore:park-sweep"), lane: "chore:park-sweep"}),
+				shell.layer,
+			),
+		);
+		expect(out.code).toBe(0);
+		expect(JSON.parse(out.stdout).answer).toBe("unclaimable");
+		expect(shell.calls).toEqual([]);
+	});
+});
+
+describe("runLaneRelease", () => {
+	it("retracts this driver's own marker", async () => {
+		const shell = fakeShell([
+			[COMMENTS, buildComments({id: 9001, body: MINE})],
+			[perm("agent"), okOut("write\n")],
+			[DELETE, okOut("")],
+		]);
+		const out = await Effect.runPromise(Effect.provide(runLaneRelease(options), shell.layer));
+		expect(out.code).toBe(0);
+		expect(JSON.parse(out.stdout)).toEqual({answer: "released", lane: "5492", number: 5492});
+		expect(shell.calls).toContain("gh api --method DELETE repos/o/r/issues/comments/9001");
+	});
+
+	it("exits 31 rather than retracting another driver's marker", async () => {
+		const shell = fakeShell([
+			[COMMENTS, buildComments({id: 8000, body: THEIRS})],
+			[perm("agent"), okOut("write\n")],
+		]);
+		const out = await Effect.runPromise(Effect.provide(runLaneRelease(options), shell.layer));
+		expect(out.code).toBe(CLAIM_NOT_MINE);
+		expect(shell.calls.filter((line) => DELETE.test(line))).toEqual([]);
+	});
+
+	it("answers inert on a chore lane", async () => {
+		const out = await release([], {key: key("chore:park-sweep"), lane: "chore:park-sweep"});
+		expect(out.code).toBe(0);
+		expect(JSON.parse(out.stdout).answer).toBe("inert");
+	});
+});
+
+describe("a driver's claim and the builder it spawns", () => {
+	/**
+	 * The collision this pair exists to prevent, and the one it must NOT create: the driver holds
+	 * #5492 and the builder it spawns claims the same number and wins, because the two markers are
+	 * two namespaces on one thread rather than one race with two entrants (#5761).
+	 */
+	it("lets the spawned builder claim the same issue and win", async () => {
+		const BUILD_ISSUE = /^gh api repos\/o\/r\/issues\/5492$/;
+		const BUILD_COMMENTS = COMMENTS;
+		const claimable = buildIssue({
+			number: 5492,
+			labels: [
+				{name: "type:feature"},
+				{name: "p1"},
+				{name: "status:triaged"},
+				{name: "ready-for:agent"},
+			],
+		});
+		const buildMarker = `build-claim: build:s-b1:${OTHER_UUID} · 2026-08-17T00:10:00Z`;
+		const out = await Effect.runPromise(
+			Effect.provide(
+				runClaim({
+					number: 5492,
+					repo: null,
+					env: {CLAUDE_PIPELINE_REPO: "o/r", CLAUDE_CODE_SESSION_ID: "s-b1"},
+					uuid: OTHER_UUID,
+					at: "2026-08-17T00:10:00Z",
+					purpose: "build",
+					override: null,
+					overrideLane: null,
+				}),
+				fakeShell([
+					[BUILD_ISSUE, claimable],
+					[POST, okOut(JSON.stringify({id: 9002, html_url: "https://github.com/o/r#c"}))],
+					[
+						/^gh api repos\/o\/r\/issues\/comments\/9002$/,
+						okOut(JSON.stringify({body: buildMarker})),
+					],
+					[
+						BUILD_COMMENTS,
+						buildComments(
+							// The driver's own claim, posted first and still held.
+							{id: 9001, body: MINE, createdAt: "2026-08-17T00:00:00Z"},
+							{id: 9002, body: buildMarker, createdAt: "2026-08-17T00:10:00Z"},
+						),
+					],
+					[perm("agent"), okOut("write\n")],
+				]).layer,
+			).pipe(Effect.provide(fakeFs({files: {}}).layer)),
+		);
+		expect(out.code).not.toBe(BUILD_CLAIM_NOT_MINE);
+		expect(JSON.parse(out.stdout).answer).toBe("won");
+	});
+});

--- a/packages/fabrika-cli/src/lane/claim.ts
+++ b/packages/fabrika-cli/src/lane/claim.ts
@@ -1,0 +1,50 @@
+/**
+ * The driver's claim namespace, and what a lane key can race on.
+ *
+ * `operate` drives a lane; nothing above the issue level said who was driving it, so two drivers ran
+ * epic #5492's children at once, each folding its own machine-local ledger, and `build claim` only
+ * caught the collision one level down — after both had spawned a builder on the same repair (#5761).
+ * A driver now claims the number it was handed, and nothing else.
+ *
+ * **The namespace is `lane-claim:`/`lane:`, not `build-claim:`/`build:`.** The build marker is
+ * purpose-blind — `MARKER_RE` matches every `build-claim:` line whatever the claim was taken for — so
+ * a driver claiming issue N under that grammar would be read as a foreign holder by the builder it
+ * then spawns on N, locking itself out of its own lane. Two grammars are two races on one thread,
+ * which is the one property the driver's claim must have.
+ *
+ * **The ledger is untouched.** Claims live on GitHub (#5680's phase-3 ruling on #5734); nothing here
+ * writes `events.jsonl`, and no claim state is derivable from a fold.
+ */
+
+import {type ClaimGrammar, claimGrammar} from "../build/claim.ts";
+import {CHORE_PREFIX, type LaneKey} from "./key.ts";
+
+/** The driver's namespace. Separate from the builder's by construction — see the module note. */
+export const LANE_CLAIM: ClaimGrammar = claimGrammar("lane-claim", "lane");
+
+/** A board number is a number: a key that is not one names no thread to race on. */
+const BOARD_NUMBER = /^[1-9][0-9]*$/;
+
+/**
+ * What a lane key races on.
+ *
+ * `Inert` is a fact, not a refusal: a chore lane is keyed by name precisely because it has no issue
+ * number (#5840), so there is nowhere for a marker to be posted and nothing for a second driver to
+ * read. The verbs answer it at exit 0 and say so, rather than inventing a substrate for it.
+ */
+export type ClaimTarget =
+	| {readonly _tag: "Number"; readonly number: number}
+	| {readonly _tag: "Inert"; readonly why: string};
+
+export const claimTarget = (key: LaneKey): ClaimTarget =>
+	key._tag === "Chore"
+		? {
+				_tag: "Inert",
+				why: `a ${CHORE_PREFIX}<name> lane has no board number, so there is no thread to race a claim on`,
+			}
+		: BOARD_NUMBER.test(key.lane)
+			? {_tag: "Number", number: Number.parseInt(key.lane, 10)}
+			: {
+					_tag: "Inert",
+					why: `"${key.lane}" is not a board number, so there is no thread to race a claim on`,
+				};

--- a/packages/fabrika-cli/src/lane/claim.unit.test.ts
+++ b/packages/fabrika-cli/src/lane/claim.unit.test.ts
@@ -1,0 +1,54 @@
+import {describe, expect, it} from "vitest";
+import {BUILD_CLAIM, composeMarker, readMarkerToken} from "../build/claim.ts";
+import {claimTarget, LANE_CLAIM} from "./claim.ts";
+import {parseKey} from "./key.ts";
+
+const key = (raw: string) => {
+	const parsed = parseKey(raw);
+	if (parsed._tag === "Malformed") throw new Error(`fixture key "${raw}" is malformed`);
+	return parsed.key;
+};
+
+describe("LANE_CLAIM", () => {
+	it("reads its own markers and is blind to a build claim's", () => {
+		const driver = composeMarker(
+			"lane:s-1:c1a4d6f8-3b7e-4a19-9c2d-5e8f0a1b2c3d",
+			"at",
+			null,
+			LANE_CLAIM,
+		);
+		expect(readMarkerToken(driver, LANE_CLAIM)).toBe(
+			"lane:s-1:c1a4d6f8-3b7e-4a19-9c2d-5e8f0a1b2c3d",
+		);
+		expect(readMarkerToken(driver, BUILD_CLAIM)).toBeNull();
+	});
+
+	it("is invisible to the build namespace, so a driver never locks out its own builder", () => {
+		const builder = composeMarker("build:s-2:c1a4d6f8-3b7e-4a19-9c2d-5e8f0a1b2c3d", "at");
+		expect(readMarkerToken(builder, BUILD_CLAIM)).toBe(
+			"build:s-2:c1a4d6f8-3b7e-4a19-9c2d-5e8f0a1b2c3d",
+		);
+		expect(readMarkerToken(builder, LANE_CLAIM)).toBeNull();
+	});
+
+	it("refuses a token whose prefix belongs to the other namespace", () => {
+		const crossed = "lane-claim: build:s-1:c1a4d6f8-3b7e-4a19-9c2d-5e8f0a1b2c3d · at";
+		expect(readMarkerToken(crossed, LANE_CLAIM)).toBeNull();
+	});
+});
+
+describe("claimTarget", () => {
+	it("races on the board number an issue lane is keyed by", () => {
+		expect(claimTarget(key("5492"))).toEqual({_tag: "Number", number: 5492});
+	});
+
+	it("is inert on a chore lane — no board number, so no thread to race on", () => {
+		const target = claimTarget(key("chore:park-sweep"));
+		expect(target._tag).toBe("Inert");
+	});
+
+	it("is inert on a key that is not a board number, rather than racing on a guess", () => {
+		expect(claimTarget(key("epic-5492"))._tag).toBe("Inert");
+		expect(claimTarget(key("0"))._tag).toBe("Inert");
+	});
+});

--- a/packages/fabrika-cli/src/lane/codes.ts
+++ b/packages/fabrika-cli/src/lane/codes.ts
@@ -1,11 +1,11 @@
 /**
  * The one exit table every `lane` verb allocates from, so a code means one thing across the group.
  *
- * The four shared seats are **imported from the base, never re-typed** — the discipline
+ * The five shared seats are **imported from the base, never re-typed** — the discipline
  * `../exit-code-alignment.ts` checks. The lane verbs read a local lane directory and append to its
  * log, so the base's facts they can establish are exactly these: the target is not there, the
- * target was read but is not the shape, the write did not land, the read that would have proven any
- * of that failed. `12`+ is this group's own band.
+ * target was read but is not the shape, the write did not land, a marker landed and does not read
+ * back, the read that would have proven any of that failed. `12`+ is this group's own band.
  *
  * **A fold that could not be made never resolves to a plausible state.** An absent lane, an
  * unreadable one, and a lane whose bytes parse but contradict the machine stay distinct codes,
@@ -16,6 +16,7 @@ import {
 	BAD_SECTIONS as REPORT_BAD_SECTIONS,
 	NO_TARGET as REPORT_NO_TARGET,
 	PRECONDITION_UNKNOWN as REPORT_PRECONDITION_UNKNOWN,
+	READBACK_MISMATCH as REPORT_READBACK_MISMATCH,
 	WRITE_UNKNOWN as REPORT_WRITE_UNKNOWN,
 } from "../report/codes.ts";
 
@@ -33,9 +34,16 @@ export const LANE_ABSENT = REPORT_NO_TARGET;
 export const MALFORMED_RECORD = REPORT_BAD_SECTIONS;
 
 /**
- * The append did not land. The caller refuses; it never reports the event as recorded.
+ * The append did not land, or `lane claim`'s marker write did not. The caller refuses; it never
+ * reports the event as recorded, nor the claim as held.
  */
 export const APPEND_UNKNOWN = REPORT_WRITE_UNKNOWN;
+
+/**
+ * `lane claim`'s marker landed and does not read back as the token this run posted. The comment
+ * exists, so it is neither a failed write nor a lost race — it needs a human eye.
+ */
+export const MARKER_READBACK = REPORT_READBACK_MISMATCH;
 
 /**
  * The lane could not be read, or its absence could not be established. UNKNOWN, never a fresh
@@ -168,3 +176,14 @@ export const UNSAFE_PUSH = 29;
  * opposite remedies — push again, versus re-read before touching anything.
  */
 export const REF_NOT_MOVED = 30;
+
+/**
+ * Proven: this session does not hold the driver's claim on the lane — another driver won the race,
+ * or there is no claim to release. Its own seat rather than `build`'s `15`, which this group already
+ * spends on {@link TOPOLOGY_ABSENT}; the two prove different facts and share no remedy.
+ *
+ * Proven-unclaimed sits here too, on `build claim`'s reading: zero markers means this session does
+ * not hold the lane, which is the one fact a driver acts on. The stderr detail keeps unclaimed and
+ * foreign apart for a reader; the code does not, because the caller stops either way.
+ */
+export const CLAIM_NOT_MINE = 31;

--- a/packages/fabrika-cli/src/lane/command.ts
+++ b/packages/fabrika-cli/src/lane/command.ts
@@ -6,12 +6,14 @@
  * decision lives in the verb modules beside it, which is what makes each refusal testable without
  * spawning a process.
  */
+import {randomUUID} from "node:crypto";
 import {fileURLToPath} from "node:url";
 import {Effect, Option} from "effect";
 import {Argument, Command, Flag} from "effect/unstable/cli";
 import {leafCommand} from "../excess-operand.ts";
 import type {VerbOutcome} from "../verb.ts";
 import {runBrief} from "./brief-verb.ts";
+import {runLaneClaim, runLaneRelease} from "./claim-verb.ts";
 import {runEmit} from "./emit-verb.ts";
 import {runHistory} from "./history-verb.ts";
 import {type LaneKey, laneRef, parseKey, templateFile} from "./key.ts";
@@ -275,6 +277,63 @@ const brief = leafCommand(
 	),
 );
 
+const claim = leafCommand(
+	"claim",
+	{
+		lane: laneArgument,
+		repo: Flag.string("repo").pipe(
+			Flag.optional,
+			Flag.withDescription(
+				"the target owner/name (default: $CLAUDE_PIPELINE_REPO, else $GITHUB_REPOSITORY, else the origin remote)",
+			),
+		),
+	},
+	Effect.fn(function* ({lane, repo}) {
+		yield* emit(
+			yield* onKey(lane, Option.none(), (key) =>
+				runLaneClaim({
+					key,
+					lane,
+					repo: Option.getOrNull(repo),
+					env: process.env,
+					uuid: randomUUID(),
+					at: new Date().toISOString(),
+				}),
+			),
+		);
+	}),
+).pipe(
+	Command.withShortDescription("Race the driver's claim on a lane and win it or name the winner."),
+	Command.withDescription(
+		'Race the earliest AUTHORIZED lane-claim marker on the issue a lane drives: post this driver\'s token (lane:<CLAUDE_CODE_SESSION_ID>:<uuid>), re-read, and win or name the winner. Two drivers over one lane used to be invisible until the builders they spawned collided one level down (#5761). The namespace is the driver\'s own — `lane-claim:`/`lane:`, never `build-claim:`/`build:` — so the builder this driver spawns claims the same issue and wins; the two races never see each other. Authorization is the author\'s repository permission (ADR 0055); marker text confers nothing. No admission test runs here — the fence is the spawned builder\'s. Prints {"answer":"won","lane":"…","number":n,"token":"…"}. A `chore:<name>` lane, or any key that is not a board number, has no thread to race on and answers {"answer":"unclaimable","lane":"…","why":"…"} at exit 0 with nothing written. A lost race retracts this run\'s own marker and exits 31, never 0; an unset CLAUDE_CODE_SESSION_ID is 1. Exits 8 (the marker write failed — UNKNOWN, never a claim), 9 (the marker landed and does not read back), 11 (the marker set could not be read — UNKNOWN, never "unclaimed"), 21 (the key is not a lane key), 31 (proven lost). Example: fabrika lane claim 5492',
+	),
+);
+
+const release = leafCommand(
+	"release",
+	{
+		lane: laneArgument,
+		repo: Flag.string("repo").pipe(
+			Flag.optional,
+			Flag.withDescription(
+				"the target owner/name (default: $CLAUDE_PIPELINE_REPO, else $GITHUB_REPOSITORY, else the origin remote)",
+			),
+		),
+	},
+	Effect.fn(function* ({lane, repo}) {
+		yield* emit(
+			yield* onKey(lane, Option.none(), (key) =>
+				runLaneRelease({key, lane, repo: Option.getOrNull(repo), env: process.env}),
+			),
+		);
+	}),
+).pipe(
+	Command.withShortDescription("Retract this driver's own lane-claim marker."),
+	Command.withDescription(
+		'Retract this driver\'s own lane-claim marker, so the lane is drivable again — run at both ends of the loop, the terminal fold and the park. It refuses to delete a marker this session does not hold: a driver never retracts another driver\'s claim. Prints {"answer":"released","lane":"…","number":n}. A `chore:<name>` lane, or any key that is not a board number, was never claimable and answers {"answer":"inert","lane":"…","why":"…"} at exit 0. Exits 1 (CLAUDE_CODE_SESSION_ID unset), 8 (the retraction failed — whether the claim is still held is UNKNOWN), 11 (the marker set could not be read), 21 (the key is not a lane key), 31 (proven: held by another driver, or no claim exists). Example: fabrika lane release 5492',
+	),
+);
+
 const stale = leafCommand(
 	"stale",
 	{
@@ -317,6 +376,8 @@ export const laneCommand = Command.make("lane").pipe(
 		brief,
 		pushLane,
 		stale,
+		claim,
+		release,
 	]),
 	Command.withShortDescription("Drive one lane's state ledger by folding its event log."),
 	Command.withDescription(


### PR DESCRIPTION
Fixes #5761

`operate` is the pipeline's driver, and nothing said who was driving a lane. Two drivers ran epic
#5492's children at once, each folding its own machine-local ledger and each spawning its own Opus
builder on the same repair; `build claim` caught the collision one level down, after the duplicated
work.

A driver now claims the number it was handed, at boot, before `lane emit` / `lane open` writes
anything — and releases it at the end.

- `lane claim` / `lane release`: the same detect-then-tiebreak race `build claim` runs (post the
  marker, re-read, earliest authorized marker wins), in the driver's **own** namespace,
  `lane-claim:` / `lane:`. That is route 1 of the two the issue named. The builder a driver spawns
  claims the same issue under `build-claim:` / `build:` and wins — two markers on one thread, two
  races that never see each other, so a driver cannot lock itself out of its own lane.
- The three claim outcomes stay apart the way `build claim` keeps them: `31` proven-lost, `1` no
  session id, `11` an unreadable marker set. None collapses into "unclaimed". A loser retracts its
  own marker and nothing else.
- `operate` step 1 claims first and ends on a new terminal word, `LANE-HELD`, having emitted no
  ledger and spawned no shell. Step 4 releases as the last act of the run.
- A `chore:<name>` lane carries no board number, so there is no thread to race on: both verbs answer
  `unclaimable` / `inert` at exit 0 with nothing written, rather than inventing a substrate.
- Nothing about the ledger changes. Claims live on GitHub; no claim state enters `events.jsonl`.

The claim protocol is now namespaced by a `ClaimGrammar` whose marker regex is derived from the
keyword and the prefix, so a namespace cannot ship a writer and a reader that disagree.

## Deviations

- **Out-of-scope change** — **Said:** #5761's non-goals bar changes to `build claim` / `confirm` /
  `release` semantics beyond what route 2 requires. **Did:** touched `build/claim.ts` and
  `build/lane.ts` to make the marker keyword, token prefix and marker regex a `ClaimGrammar`
  parameter. **Why:** route 1 needs a second namespace running the same race, and the alternative was
  a second copy of the ACL-authorized tiebreak — the drift risk ADR 0055's rules exist to avoid. No
  semantics move: the grammar is a trailing parameter defaulting to `BUILD_CLAIM`, every existing
  call site is byte-identical, and the whole `build` suite is unchanged and green.
  **Disposition:** stated here.
- **Out-of-scope change** — **Said:** the criteria name release at `LANE-TERMINAL` and
  `LANE-PARKED`. **Did:** `operate` also releases on `STOPPED`. **Why:** a claim outliving the driver
  that took it leaves a lane nobody can pick up, which is the defect this ticket is about, one
  terminal over. **Disposition:** stated here.
