### PR TITLE
fix: The global fabrika shim's NODE_PATH makes a foreign repo report the global copy as its own local install

### DIFF
--- a/packages/fabrika-cli/README.md
+++ b/packages/fabrika-cli/README.md
@@ -86,6 +86,16 @@ dir's `commondir`, per `gitrepository-layout(5)`) and equal common dirs delegate
 repository cannot be established is treated as a different one, so the refusal is what an unreadable
 answer falls back to.
 
+Row three needs one more rule to hold, because the probe asks Node and Node answers about more than
+the repo ([#5768](https://github.com/kamp-us/phoenix/issues/5768)). After the `node_modules` walk
+fails, Node falls back to `NODE_PATH` — and the pnpm-generated global `fabrika` shim exports an
+absolute `NODE_PATH` chain rooted at the checkout it was installed from. So a repo with no install
+of its own still resolved one: the global's own copy, which read as "the repo-local install is this
+copy" and swallowed the warning row three exists for. The probe therefore requires the resolved
+install to live at or under the repo root; anything outside is `absent`, whatever Node found. The
+same rule drops a copy hoisted into a directory above the repo, which is not that repo's install
+either.
+
 The property this buys is a **repo-pinned version**. phoenix carries `@kampus/fabrika-cli` in its
 root `devDependencies`, so a bare `fabrika` anywhere in a phoenix checkout runs the version this
 repo pins — and because pnpm links the workspace package, that means the **working tree**: edit

--- a/packages/fabrika-cli/src/delegate/local.ts
+++ b/packages/fabrika-cli/src/delegate/local.ts
@@ -9,6 +9,13 @@
  * there is **no** platform-package resolution here (turbo `main` @ `c6fbc97`,
  * `crates/turborepo-shim/local_turbo_state.rs`).
  *
+ * Node's own resolution is not *only* the `node_modules` walk, though: it falls back to `NODE_PATH`,
+ * which the pnpm-generated global `fabrika` shim exports as an absolute chain rooted at the checkout
+ * it was installed from. So the walk fails in a repo with no install and the fallback answers
+ * anyway — with the global's own copy, which `resolve` then reads as "the repo-local install is this
+ * copy" (#5768). {@link isInsideRepo} is the containment rule that closes it: an install the probe
+ * cannot place under `repoRoot` is not that repo's install, whatever Node found.
+ *
  * The probe is total over three outcomes and **none of them is a throw**: found, absent, or corrupt.
  * Corrupt is deliberately not fatal — turbo's own note at the equivalent branch is *"we can choose
  * to operate this aggressively because the _worst_ outcome is that we run global turbo"* — but it is
@@ -64,6 +71,18 @@ export const readInstallManifest = (
 };
 
 /**
+ * Whether `candidate` is `root` itself or lives beneath it.
+ *
+ * Both sides are expected to be canonical already — the caller resolves symlinks before asking,
+ * because pnpm's `node_modules/@kampus/fabrika-cli` link and its `.pnpm` target are one install
+ * under two names and only the target is under the repo on every layout.
+ */
+export const isInsideRepo = (path: Path.Path, root: string, candidate: string): boolean => {
+	const rel = path.relative(root, candidate);
+	return rel === "" || (!path.isAbsolute(rel) && rel !== ".." && !rel.startsWith(`..${path.sep}`));
+};
+
+/**
  * Probe `repoRoot` for an installed copy of this package.
  *
  * The `E` channel carries only failures the caller must *stop* on — a manifest that exists but
@@ -80,20 +99,28 @@ export const probeLocalInstall = (
 		if (resolved._tag !== "resolved") return resolved;
 		const {manifestPath} = resolved;
 
-		const text = yield* readFile(manifestPath).pipe(Effect.catch(() => Effect.succeed(undefined)));
-		if (text === undefined)
-			return {_tag: "corrupt", reason: `${manifestPath} could not be read`} as const;
-		const manifest = readInstallManifest(path, manifestPath, text);
-		if ("corrupt" in manifest) return {_tag: "corrupt", reason: manifest.corrupt} as const;
-
 		// Real paths on both ends of the eventual self-check: pnpm links a workspace package into
 		// `node_modules`, so the symlink and its target are one install under two names. Comparing the
 		// unresolved name against a running package root would make a repo-local copy delegate to
 		// itself forever.
 		const soften = Effect.catch(() => Effect.succeed(undefined));
 		const packageRoot = yield* fs.realPath(path.dirname(manifestPath)).pipe(soften);
+		if (packageRoot === undefined)
+			return {_tag: "corrupt", reason: `${manifestPath} is not on disk`} as const;
+		// Containment before trust, and before any corrupt verdict: a copy outside this repo is not
+		// this repo's install even when it is perfectly well-formed, so it answers `absent` rather
+		// than being reported as a broken local one.
+		const root = (yield* fs.realPath(repoRoot).pipe(soften)) ?? path.resolve(repoRoot);
+		if (!isInsideRepo(path, root, packageRoot)) return {_tag: "absent"} as const;
+
+		const text = yield* readFile(manifestPath).pipe(Effect.catch(() => Effect.succeed(undefined)));
+		if (text === undefined)
+			return {_tag: "corrupt", reason: `${manifestPath} could not be read`} as const;
+		const manifest = readInstallManifest(path, manifestPath, text);
+		if ("corrupt" in manifest) return {_tag: "corrupt", reason: manifest.corrupt} as const;
+
 		const binPath = yield* fs.realPath(manifest.bin).pipe(soften);
-		if (packageRoot === undefined || binPath === undefined)
+		if (binPath === undefined)
 			return {
 				_tag: "corrupt",
 				reason: `${manifestPath} points at a bin that is not on disk (${manifest.bin})`,

--- a/packages/fabrika-cli/src/delegate/local.unit.test.ts
+++ b/packages/fabrika-cli/src/delegate/local.unit.test.ts
@@ -2,7 +2,7 @@ import {Effect, Path} from "effect";
 import {describe, expect, it} from "vitest";
 import {fakeFs} from "../fakes.test-support.ts";
 import {takeSkipInfer} from "./entry.ts";
-import {declaredVersion, readInstallManifest} from "./local.ts";
+import {declaredVersion, isInsideRepo, readInstallManifest} from "./local.ts";
 import {SKIP_INFER_ENV, SKIP_INFER_FLAG} from "./resolve.ts";
 
 const manifest = (text: string) =>
@@ -40,6 +40,39 @@ describe("readInstallManifest", () => {
 		expect(manifest("{not json")).toMatchObject({
 			corrupt: expect.stringContaining("not valid JSON"),
 		});
+	});
+});
+
+describe("isInsideRepo — the rule that keeps a NODE_PATH hit from posing as a local install", () => {
+	const inside = (root: string, candidate: string) =>
+		Effect.runSync(
+			Effect.gen(function* () {
+				return isInsideRepo(yield* Path.Path, root, candidate);
+			}).pipe(Effect.provide(Path.layer)),
+		);
+
+	it("accepts an ordinary node_modules install", () => {
+		expect(inside("/repo", "/repo/node_modules/@kampus/fabrika-cli")).toBe(true);
+	});
+
+	it("accepts pnpm's real target — a workspace package linked into node_modules", () => {
+		expect(inside("/repo", "/repo/packages/fabrika-cli")).toBe(true);
+	});
+
+	it("accepts the repo root itself, for a repo that IS the package", () => {
+		expect(inside("/repo", "/repo")).toBe(true);
+	});
+
+	it("rejects a copy in another checkout — the NODE_PATH case", () => {
+		expect(inside("/other", "/repo/packages/fabrika-cli")).toBe(false);
+	});
+
+	it("rejects an install hoisted above the repo root", () => {
+		expect(inside("/repo/inner", "/repo/node_modules/@kampus/fabrika-cli")).toBe(false);
+	});
+
+	it("is not fooled by a sibling whose name starts with the root's", () => {
+		expect(inside("/repo", "/repo-two/node_modules/@kampus/fabrika-cli")).toBe(false);
 	});
 });
 

--- a/packages/fabrika-cli/src/delegate/node-path-pollution.cli.test.ts
+++ b/packages/fabrika-cli/src/delegate/node-path-pollution.cli.test.ts
@@ -1,0 +1,112 @@
+/**
+ * The end-to-end half of the `NODE_PATH` containment rule (#5768), spawned because the defect only
+ * exists in a real process: `NODE_PATH` is baked into `Module.globalPaths` when a process loads, so
+ * no in-test mutation reproduces it.
+ *
+ * The pnpm-generated global `fabrika` shim exports an absolute `NODE_PATH` chain rooted at the
+ * checkout it was installed from. Standing in a repo with no install of its own, Node's walk fails
+ * and that fallback answers instead — with the invoked copy itself, which used to read as "the
+ * repo-local install is this copy" and silently swallow the global warning.
+ */
+import {spawnSync} from "node:child_process";
+import {existsSync, mkdirSync, mkdtempSync, rmSync, writeFileSync} from "node:fs";
+import {tmpdir} from "node:os";
+import {join} from "node:path";
+import {fileURLToPath} from "node:url";
+import {afterAll, beforeAll, describe, expect, it} from "vitest";
+import {SUBPROCESS_TEST_TIMEOUT_MS} from "../test-budget.ts";
+import {NO_IMPLEMENTATION} from "../verb.ts";
+import {GLOBAL_WARNING_DISABLED_ENV} from "./resolve.ts";
+
+const BIN = fileURLToPath(new URL("../bin.ts", import.meta.url));
+const CHECKOUT = fileURLToPath(new URL("../../../../", import.meta.url)).replace(/\/$/, "");
+
+/** This checkout's own `node_modules`, i.e. the chain the real global shim exports. */
+const SELF_NODE_MODULES = join(CHECKOUT, "node_modules");
+const selfLinkInstalled = existsSync(
+	join(SELF_NODE_MODULES, "@kampus", "fabrika-cli", "package.json"),
+);
+
+/** What a copy reachable only through `NODE_PATH` prints if it is ever allowed to answer. */
+const IMPOSTER = "answered-from-the-NODE_PATH-copy";
+
+let scratch: string;
+/** A repo root with a manifest and no install at all — the shape the defect was reported against. */
+let bare: string;
+/** The same, but carrying its own install, so the foreign-checkout refusal has something to refuse. */
+let installed: string;
+/** A `@kampus/fabrika-cli` copy that lives in neither repo and is reachable only via `NODE_PATH`. */
+let strayNodeModules: string;
+
+const writeInstall = (nodeModules: string, marker: string) => {
+	const pkg = join(nodeModules, "@kampus", "fabrika-cli");
+	mkdirSync(pkg, {recursive: true});
+	writeFileSync(join(pkg, "bin.js"), `console.log(${JSON.stringify(marker)});\n`);
+	writeFileSync(
+		join(pkg, "package.json"),
+		'{"name":"@kampus/fabrika-cli","version":"9.9.9","bin":{"fabrika":"./bin.js"}}\n',
+	);
+};
+
+beforeAll(() => {
+	scratch = mkdtempSync(join(tmpdir(), "fabrika-nodepath-"));
+	bare = join(scratch, "bare");
+	installed = join(scratch, "installed");
+	strayNodeModules = join(scratch, "stray", "node_modules");
+	mkdirSync(bare, {recursive: true});
+	mkdirSync(installed, {recursive: true});
+	writeFileSync(join(bare, "package.json"), '{"name":"bare","version":"0.0.0"}\n');
+	writeFileSync(join(installed, "package.json"), '{"name":"installed","version":"0.0.0"}\n');
+	writeInstall(join(installed, "node_modules"), "answered-from-the-cwd-checkout");
+	writeInstall(strayNodeModules, IMPOSTER);
+});
+
+afterAll(() => rmSync(scratch, {recursive: true, force: true}));
+
+/**
+ * `spawnSync`, not `execFileSync`: the subject here is a **stderr warning on an exit-0 run**, and
+ * `execFileSync` hands stderr back only on the throwing path.
+ */
+const invoke = (cwd: string, nodePath: string, ...args: ReadonlyArray<string>) => {
+	const env: Record<string, string | undefined> = {...process.env, NODE_PATH: nodePath};
+	delete env[GLOBAL_WARNING_DISABLED_ENV];
+	const run = spawnSync(process.execPath, [BIN, ...args], {
+		cwd,
+		env,
+		encoding: "utf8",
+		stdio: ["ignore", "pipe", "pipe"],
+	});
+	return {code: run.status ?? -1, stdout: run.stdout ?? "", stderr: run.stderr ?? ""};
+};
+
+describe("invoking this checkout's bin under a NODE_PATH that reaches a @kampus/fabrika-cli copy", {
+	timeout: SUBPROCESS_TEST_TIMEOUT_MS,
+	// The bin's own delegation is what is under test, so the guard that pins an invocation to this
+	// copy has to stay unset — and vitest inherits the parent env.
+	skip: process.env.FABRIKA_SKIP_INFER !== undefined,
+}, () => {
+	// The exact shim shape: the chain points back at the invoked copy, so before the containment rule
+	// the probe found `selfPackageRoot` and `resolve` answered `run-here`, silently. It needs this
+	// checkout to actually be installed; an uninstalled tree is a missing fixture, not a pass.
+	it.skipIf(!selfLinkInstalled)("warns loudly in a repo with no install of its own", () => {
+		const run = invoke(bare, SELF_NODE_MODULES, "--version");
+		expect(run.code).toBe(0);
+		expect(run.stdout).toContain("fabrika v");
+		expect(run.stderr).toContain("running the GLOBAL install");
+		expect(run.stderr).toContain("it has no local install");
+	});
+
+	it("warns just the same when the reachable copy is a stray third one, and never runs it", () => {
+		const run = invoke(bare, strayNodeModules, "--version");
+		expect(run.stdout).not.toContain(IMPOSTER);
+		expect(run.code).toBe(0);
+		expect(run.stderr).toContain("it has no local install");
+	});
+
+	it("leaves the foreign-checkout refusal alone — the repo's own walk outranks the fallback", () => {
+		const run = invoke(installed, strayNodeModules, "--version");
+		expect(run.code).toBe(NO_IMPLEMENTATION);
+		expect(run.stderr).toContain("different repositories");
+		expect(run.stdout).not.toContain(IMPOSTER);
+	});
+});


### PR DESCRIPTION
Node's resolver falls back to `NODE_PATH` once the `node_modules` walk fails, and the pnpm-generated
global `fabrika` shim exports an absolute `NODE_PATH` chain rooted at the checkout it was installed
from. So in a repo with no install of its own, `probeLocalInstall` still resolved one — the global's
own copy — and `resolve` answered `run-here` with "the repo-local install is this copy", a sentence
that is false about that repo. The `warn-and-run-here` branch that should have fired, and the
version-pinning advice it carries, never ran.

I verified the mechanism before building on it: `createRequire(<root>/package.json).resolve(...)`
in a bare tmp repo returns the `NODE_PATH` copy with the chain set and throws `MODULE_NOT_FOUND`
without it.

## The shape I picked

Containment, not `NODE_PATH` neutralisation. The probe now requires the resolved install to sit at
or under the repo root; anything else is `absent`. Two reasons over the alternative:

- `NODE_PATH` is baked into `Module.globalPaths` when the process loads, so suppressing it means
  either respawning or reaching into Node's module internals. Containment needs neither and holds
  regardless of how a foreign copy became reachable.
- It states the thing the probe actually means. The question is "does *this repo* have an install",
  and a path outside the repo cannot be one — including a copy hoisted into a directory above the
  repo root, which the same rule now drops.

The check runs on real paths on both sides, before the manifest is read, so a well-formed copy in
another tree reads as `absent` rather than as a broken local one. pnpm's symlinked layouts are
unaffected: Node already returns the link target, and phoenix's own workspace self-link still takes
`run-here` (the full 5050-test suite is green in this tree).

## Tests

- `isInsideRepo` unit tests: node_modules install, pnpm workspace target, repo-is-the-package,
  another checkout, hoisted-above-root, and a sibling whose name prefixes the root's.
- `node-path-pollution.cli.test.ts` spawns real processes, because `NODE_PATH` is only readable at
  process load. Two cases assert `warn-and-run-here` under pollution — one with the chain pointed at
  this checkout's `node_modules` (the exact shim shape) and one at a stray third copy. Both fail on
  the pre-fix code; I confirmed that by stashing the fix and re-running.
- The third case covers the fourth acceptance criterion by exercise rather than argument: the same
  pollution against a repo that *has* its own differing install still produces the
  `refuse-foreign-checkout` exit `126`. The `node_modules` walk outranks the fallback, so that path
  never saw the polluted copy — it passes before and after.

`pnpm typecheck` and `pnpm lint:worktree` are green in this tree.

Fixes #5768

## Deviations

- **Out-of-scope change** — **Said:** #5768 scopes the fix to `packages/fabrika-cli`'s probe and
  names no doc work. **Did:** also added a paragraph to `packages/fabrika-cli/README.md`, under the
  delegation table. **Why:** that README's table row three ("in a consumer repo that did not install
  it → the global, warns") is the behaviour this defect silently broke, so the README documented an
  outcome the code did not produce. **Disposition:** stated here.
- **Pre-existing test or fixture changed** — **Said:** existing tests stay green, and nothing asks
  for edits to them. **Did:** left `foreign-checkout.cli.test.ts` and `worktree-peer.cli.test.ts`
  untouched, but the new CLI test uses `spawnSync` where those two use `execFileSync`.
  **Why:** `execFileSync` returns stderr only on the throwing path, and the subject here is a stderr
  warning on an exit-0 run — the helper copied from those files silently reported an empty stderr.
  **Disposition:** stated here; the divergence is noted in a comment on the new helper.
