### PR TITLE
feat: A founder-cleared extra repair round has no representation the builder can read

### DIFF
--- a/.decisions/0292-config-narrows-the-acl-never-replaces-it.md
+++ b/.decisions/0292-config-narrows-the-acl-never-replaces-it.md
@@ -1,0 +1,74 @@
+---
+id: 0292
+title: A `.fabrika.jsonc` authority set narrows the live repo ACL, it never replaces one
+status: accepted
+date: 2026-08-18
+tags: [fabrika, config, security, pipeline, plugin-portability]
+---
+
+# 0292 — A `.fabrika.jsonc` authority set narrows the live repo ACL, it never replaces one
+
+**What this decides:** when a fabrika verb reads *who* may do a privileged thing out of the repo's
+`.fabrika.jsonc`, that configured set is a narrowing on top of a live `write+` ACL read, never a
+source of authority on its own. The first instance is `capClearAuthors`, the set that may clear a
+repair round (#5959).
+
+## Context
+
+ADR [0055](0055-acl-sourced-review-authz.md) supersedes 0051 because a checked-in identity
+list is "instructions, not enforcement": the same actor it constrains can edit it. ADRs 0063, 0071,
+0140, 0213 and 0253 each restate it — a committed file has no author gate.
+
+ADR [0286](0286-standing-lanes-come-from-config.md) then moved a different repo-specific set out of
+CLI source and into `.fabrika.jsonc`, on the founder's rule that "everything we use today can be
+default config but it should be configurable". #5959's ruling extends that to the cap-clear set
+verbatim: *"'founder' concept can change repo by repo, let's make it a configuration? it can be an
+array of github usernames and github teams"*.
+
+Those two records pull in opposite directions if `capClearAuthors` is read as *the* authority. As
+first written it was: `build clear` resolved the invoking login and tested only membership of the
+configured set, and the honour-read judged a landed `cap-cleared` marker under the same one test. A
+login in the file with no collaboration on the repo could clear a round, and on a stacked PR the
+config is read at a base ref its own author controls. That is `AUTHORIZED_REVIEWERS` under a new
+key, guarding a different privilege — exactly the shape 0055 forbids.
+
+The sibling verb both modules cite as the shape being copied does not have that hole:
+`grill rule` resolves `permissionFor` and refuses anything below `write`
+([`packages/fabrika-cli/src/grill/rule-verb.ts`](../packages/fabrika-cli/src/grill/rule-verb.ts)).
+
+The two records are only in tension over what the file *is*. 0286 rules where a repo-specific set is
+written down. 0055 rules where authority comes from. Read that way both hold at once, and the
+resolution is an intersection rather than a choice.
+
+## Decision
+
+**A `.fabrika.jsonc` authority set is a narrowing predicate over a live ACL read, and both clauses
+are conjunctive.**
+
+1. The account must be named by the configured set, resolved at the PR's base ref so a PR cannot
+   widen the set that governs it (#981).
+2. The account must hold `admin`, `maintain` or `write` at GitHub's collaborator ACL, read live at
+   the moment of the act — the same `write+` floor 0055 fixed and every other fabrika verb applies.
+
+Neither clause substitutes for the other. Widening the file grants nothing to an account with no
+collaboration; holding `write+` grants nothing to an account the repo did not name. A configured set
+can therefore only ever be *more* restrictive than the ACL, which is what makes it safe to keep it in
+a committed file at all.
+
+A permission read that fails is UNKNOWN — the verb refuses, and the honour-read holds the whole fold
+UNKNOWN rather than resolving to "nobody granted".
+
+This does not amend 0055; it states how a config key coexists with it. Any future
+`.fabrika.jsonc` key naming *who may act* inherits this rule without a new ADR.
+
+## Consequences
+
+- `build clear` reads the invoking login's permission after the config clause and refuses on `25`
+  below the write floor; the honour-read in
+  [`packages/fabrika-cli/src/build/clearances.ts`](../packages/fabrika-cli/src/build/clearances.ts)
+  applies the same clause per marker author, so the set that may post a grant and the set whose
+  grant counts stay one set.
+- The stacked-PR path is closed by clause 2 rather than by trusting the base ref: an author who lands
+  their own login on a branch they control still resolves to whatever the ACL says they are.
+- Config keys that name *values* rather than *actors* (0286's `lanes`) are untouched — this rule
+  binds authority keys only.

--- a/.decisions/0294-config-narrows-the-acl-never-replaces-it.md
+++ b/.decisions/0294-config-narrows-the-acl-never-replaces-it.md
@@ -1,12 +1,12 @@
 ---
-id: 0292
+id: 0294
 title: A `.fabrika.jsonc` authority set narrows the live repo ACL, it never replaces one
 status: accepted
 date: 2026-08-18
 tags: [fabrika, config, security, pipeline, plugin-portability]
 ---
 
-# 0292 — A `.fabrika.jsonc` authority set narrows the live repo ACL, it never replaces one
+# 0294 — A `.fabrika.jsonc` authority set narrows the live repo ACL, it never replaces one
 
 **What this decides:** when a fabrika verb reads *who* may do a privileged thing out of the repo's
 `.fabrika.jsonc`, that configured set is a narrowing on top of a live `write+` ACL read, never a

--- a/.fabrika.jsonc
+++ b/.fabrika.jsonc
@@ -1,0 +1,7 @@
+{
+	// Who may clear one extra repair round on a PR (`fabrika build clear`). Founder-ruled 2026-08-18
+	// on #5959: the grant-author set is repo configuration, not a compiled-in "founder" concept —
+	// GitHub usernames and teams, both `@`-prefixed as GitHub writes them. In phoenix it is the
+	// three founder accounts. One grant buys exactly one round.
+	"capClearAuthors": ["@usirin", "@notusirin", "@cansirin"]
+}

--- a/claude-plugins/fabrika/docs/wire-formats.md
+++ b/claude-plugins/fabrika/docs/wire-formats.md
@@ -45,6 +45,7 @@ does not exist yet — rather than missing; check the registry before assuming a
 | `lane-brief` | [`packages/fabrika-cli/src/wire/lane-brief.ts`](../../../packages/fabrika-cli/src/wire/lane-brief.ts) | `operate` | `build`, `review`, `ship` |
 | `map-ticket` | [`packages/fabrika-cli/src/wire/map-ticket.ts`](../../../packages/fabrika-cli/src/wire/map-ticket.ts) | `map` | `map` |
 | `grill-ruling` | [`packages/fabrika-cli/src/wire/grill-ruling.ts`](../../../packages/fabrika-cli/src/wire/grill-ruling.ts) | `grilling` | `grilling` |
+| `cap-clearance` | [`packages/fabrika-cli/src/wire/cap-clearance.ts`](../../../packages/fabrika-cli/src/wire/cap-clearance.ts) | `build` | `build`, `operate` |
 | `grill-answer` | [`packages/fabrika-cli/src/wire/grill-answer.ts`](../../../packages/fabrika-cli/src/wire/grill-answer.ts) | `grilling` | `grilling` |
 | `grill-supersede` | [`packages/fabrika-cli/src/wire/grill-supersede.ts`](../../../packages/fabrika-cli/src/wire/grill-supersede.ts) | `grilling` | `grilling` |
 | `handoff-pack` | [`packages/fabrika-cli/src/wire/handoff-pack.ts`](../../../packages/fabrika-cli/src/wire/handoff-pack.ts) | `handoff` | `handoff` |
@@ -172,6 +173,19 @@ it answered, and the reader settles authority against repository permissions and
 authorization comment beside it. The digest is what keeps the ruling honest over time: re-word the
 question and the recomputed digest differs, so the ruling stops counting and the question is open
 again. A ruling that drifted out from under the founder must never keep reading as his.
+
+### `cap-clearance`
+
+This is the founder's grant of one extra repair round, carried on the pull request the round belongs
+to. The agreement it closes is the one the repair loop had no way to express: the round budget is
+counted off the FAIL markers and enforced again by the lane machine, and a clearance that lived only
+as prose could not reach either, so a legitimately cleared round could only land as an edit outside
+the loop. The marker names the round it clears and nothing else — deliberately no head SHA, because a
+clearance exists precisely so a *new* head can be pushed, and a head-bound grant would be void the
+moment it was used. Naming the round is also what spends it exactly once: the grant covers the round
+it names, and the next FAIL round leaves it behind. Like the ruling marker, it is not authority on
+its own — the reader settles that against the repo's configured grant-author set and a dated
+authorization comment beside it.
 
 ### `grill-answer`
 

--- a/claude-plugins/fabrika/skills/build/SKILL.md
+++ b/claude-plugins/fabrika/skills/build/SKILL.md
@@ -248,7 +248,8 @@ escalation via `fabrika build note` instead of another push.
 data on the PR — an authorized account records it with `fabrika build clear`, and the fold counts it,
 so `capReached: false` beside a `clearances` row *is* the granted round and you simply build it. What
 you never do is grant one: `build clear` is the operator's verb, it refuses an account outside the
-repo's configured set, and an escalation is your whole move when the cap is reached. One grant is one
+repo's configured set or below `write` at the ACL, and an escalation is your whole move when the cap
+is reached. One grant is one
 round — it survives the push it permits, and the next FAIL round spends it, so a second round needs a
 second grant. Fix findings on the same branch
 (`fabrika build tree --issue $issue_or_pr_number`, then `fabrika build branch --resume $issue_or_pr_number`), re-validate with

--- a/claude-plugins/fabrika/skills/build/SKILL.md
+++ b/claude-plugins/fabrika/skills/build/SKILL.md
@@ -242,7 +242,15 @@ The fold is the only entry: paginated, current-head, per-gate — polarity visib
 included. Act only on rows it prints; empty rows at exit 0 are a proven no-work answer, but an
 UNKNOWN exit means the verdict state is unread — **never "nothing to fix"**. The budget is the
 fold's own `capReached` field, never a number you carry: on `true`, end `ESCALATED` and post the
-escalation via `fabrika build note` instead of another push. Fix findings on the same branch
+escalation via `fabrika build note` instead of another push.
+
+**A founder can clear one more round, and you read that through the same field.** The clearance is
+data on the PR — an authorized account records it with `fabrika build clear`, and the fold counts it,
+so `capReached: false` beside a `clearances` row *is* the granted round and you simply build it. What
+you never do is grant one: `build clear` is the operator's verb, it refuses an account outside the
+repo's configured set, and an escalation is your whole move when the cap is reached. One grant is one
+round — it survives the push it permits, and the next FAIL round spends it, so a second round needs a
+second grant. Fix findings on the same branch
 (`fabrika build tree --issue $issue_or_pr_number`, then `fabrika build branch --resume $issue_or_pr_number`), re-validate with
 `fabrika build check --surface <yours>`, push with `fabrika build push --force-with-lease`, answer
 the findings in a `fabrika build note` naming each one addressed, release. Exit `23` on that push
@@ -274,4 +282,5 @@ fabrika skill, so one reader parses all of them. No row here dead-ends on a bare
 | `ROADMAP.md` with a `## Focus` section | It is the declaration `build pick` and `build claim` judge campaign scope against (`fabrika wire doc-section --heading "The admission test — scope admission composed with the audience axis, one module, two seams" < <skill-base>/contract.md`) | **degrade** — an absent file and an absent or empty section are the same well-formed default: no focus is declared, the fence is inert, every issue is admitted, and both verbs print that on their scope line. A section that reads but does not parse is exit `4` and the run stops — malformed is never read as "no focus". |
 | The `package.json` scripts `typecheck` and `lint:worktree` | `build check --surface code` runs exactly `pnpm typecheck` and `pnpm lint:worktree` in this tree, cache bypassed | **fail-loud** — a validator that cannot be executed is exit `11`, UNKNOWN, never green; the run stops naming the absent `package.json` script and points at front-door. |
 | The prose placement homes — `README`, `DEVELOPMENT.md`, `.decisions/`, `.patterns/`, `reports/`, `.glossary/LANGUAGE.md` | [`references/prose.md`](references/prose.md)'s one-home rule places every prose fact in exactly one of them | **degrade** — write into the homes that exist and disclose the substituted home in the PR's `## Deviations`; a home is never invented silently |
+| `.fabrika.jsonc` with a `capClearAuthors` array | It is the set `build clear` admits a round-clearance from, and `build verdicts` honours a recorded one against | **degrade** — an absent file, an absent key or an empty array all mean nobody may clear a round: `build clear` refuses on `25` and the cap stands at its declared value, which is the pre-clearance behaviour. A read that *failed* is exit `11`, never an empty set. |
 | `.github/workflows/ci.yml` | It is the superseding authority over `build check`'s in-tree prediction (`fabrika wire doc-section --heading "build check" < <skill-base>/contract.md`) | **degrade** — with no CI gate to supersede it, `build check`'s green is the only evidence the PR carries, and the PR says so in its `## Deviations` |

--- a/claude-plugins/fabrika/skills/build/contract.md
+++ b/claude-plugins/fabrika/skills/build/contract.md
@@ -1608,7 +1608,7 @@ computed here so the cap is a field read, not a number remembered.)
 **Cleared rounds.** `clearances` lists every `cap-cleared` marker on the PR, judged. A row is
 `honoured` only when four clauses hold: its author is in `.fabrika.jsonc`'s `capClearAuthors` set at
 the PR's **base** ref, that author holds `write+` at the repository ACL read live (ADR 0055 — the
-configured set narrows the ACL, it never replaces one, ADR 0292), the round it names is at or past
+configured set narrows the ACL, it never replaces one, ADR 0294), the round it names is at or past
 `CAP_ROUND`, and a dated authorization comment from that same author sits **immediately before** it
 and is not itself a `cap-cleared` marker — the strict adjacency `grill rule` enforces, because
 without it a second bare marker rests on the first grant's own dated marker and every grant after
@@ -1716,7 +1716,7 @@ fields are the landed grant's, not this run's.
 **Who may grant** — an account that is **both** named by `.fabrika.jsonc`'s `capClearAuthors`, read
 at the PR's **base** ref so a PR cannot widen the set that clears its own cap, **and** resolved to
 `write+` at the repository ACL at the moment it runs. The configured set narrows the ACL, it never
-replaces one (ADR 0292): a committed file has no author gate (ADR 0055), so widening the file grants
+replaces one (ADR 0294): a committed file has no author gate (ADR 0055), so widening the file grants
 nothing to an account with no collaboration. Entries are `@user` or `@org/team`, both as GitHub
 writes them; a team is expanded through its membership, and a membership or permission that cannot
 be read is `11`, never a grant and never a refusal. An absent file, an absent key, an empty array and
@@ -1796,7 +1796,7 @@ $ fabrika build clear --pr 5953 --authorization authorization.md
 - #4938 — a bare stamp is void; the quoted, dated authorization is what a ruling means, and it must
   be the comment immediately before the marker.
 - #981 — repo configuration is read at the base ref, never from the PR that would change it.
-- ADR 0055 / ADR 0292 — authority is the live ACL's; the configured set narrows it, never replaces it.
+- ADR 0055 / ADR 0294 — authority is the live ACL's; the configured set narrows it, never replaces it.
 
 ---
 

--- a/claude-plugins/fabrika/skills/build/contract.md
+++ b/claude-plugins/fabrika/skills/build/contract.md
@@ -68,6 +68,7 @@ second answer to a gated question can contradict the gate (interface convention 
 | `build pr` | open the PR from a stdin body, refusing the known defect shapes, with read-back | mechanical guards over an authored body; *authoring* stays in the skill |
 | `build note` | post a progress/handoff comment, head-stamped, leak-guarded, with read-back | as `report note`, plus the head stamp |
 | `build verdicts` | the paginated, current-head, per-gate verdict fold on a PR | fetch-all + fold via the wire module; *acting on rows* stays in the skill |
+| `build clear` | record the founder's clearance of one extra repair round on a PR | a conjunctive ACL/authorization protocol with read-back; *whether to grant* is the founder's, never the verb's |
 
 **Considered and not derived: a surface classifier.** Naming the surface (code / prose / plan) is
 a judgment the skill makes reading the issue; a verb that guessed it from file extensions would be
@@ -1591,6 +1592,8 @@ fabrika build verdicts --pr 4310 [--repo <owner/name>]
     "reviewId": 98001, "kind": "native", "body": "…the review's text…"}
  ],
  "rounds": 2, "capReached": false,
+ "clearances": [{"round": 3, "at": "2026-08-18T07:16:03Z", "by": "usirin", "commentId": 512400,
+                 "authorization": 512399, "honoured": true}],
  "frozenCriteria": [{"text": "add an e2e for the empty-list case", "appendedRound": 3}]}
 ```
 
@@ -1598,8 +1601,18 @@ fabrika build verdicts --pr 4310 [--repo <owner/name>]
 appended past the freeze. **Each row's `body` is the finding's full text, passed through the
 content gate** — the repair loop consumes findings from here and never raw-fetches a comment,
 which is what keeps AC 3's one-door property over the repair path. `capReached` is
-`rounds >= CAP_ROUND`, read from `src/retry-budget.ts` — the package's one declared retry budget
-— and computed here so the cap is a field read, not a number remembered.)
+`rounds >= CAP_ROUND + <cleared rounds>`, over the `CAP_ROUND` in `src/retry-budget.ts` — the
+package's one declared retry budget — plus what the founder cleared through `build clear`; it is
+computed here so the cap is a field read, not a number remembered.)
+
+**Cleared rounds.** `clearances` lists every `cap-cleared` marker on the PR, judged. A row is
+`honoured` only when its author is in `.fabrika.jsonc`'s `capClearAuthors` set at the PR's **base**
+ref, a dated authorization comment from that same author precedes it, and the round it names is at
+or past `CAP_ROUND`; a row that misses carries the `reason` it missed and grants nothing. Each
+honoured round adds one to the cap, counted by distinct round, so a re-posted grant buys one round
+and not two — and because a clearance binds the *round* rather than a head SHA, it survives the push
+it exists to permit and is spent the moment the next FAIL round lands. A read that cannot complete —
+the config file, a configured team's membership — is `11`, never an empty set.
 
 The fold: resolve the PR's current head; fetch **every** comment and **every** review, paginated
 in full; parse each comment through the imported `verdict-marker` read; keep the latest marker
@@ -1625,7 +1638,7 @@ the content gate.
 | Code | Trigger |
 |---|---|
 | `7` | the PR is proven absent or closed |
-| `11` | the head, any comment page, or any review page could not be read — the fold is UNKNOWN, never partial |
+| `11` | the head, any comment page, any review page, or the grant-author set could not be read — the fold is UNKNOWN, never partial |
 
 **Errors**
 
@@ -1633,6 +1646,7 @@ the content gate.
 |---|---|---|
 | `build verdicts: PR #<n> is proven absent or closed.` | 7 | refusal |
 | `build verdicts: cannot read <what> (page <k>): <reason> — the verdict state is UNKNOWN, never "none".` | 11 | refusal |
+| `build verdicts: cannot read the recorded cap clearances: <reason> — whether the budget is spent is UNKNOWN, never "capped".` | 11 | refusal |
 
 **Scope** — one PR: its head, all comments, all reviews. The stderr scope line names the head SHA
 and both counts, so an empty `rows` is auditable as "N comments read, none carried a marker".
@@ -1653,6 +1667,110 @@ $ fabrika build verdicts --pr 4310
 - #4555 (open decision) — native-review rows are reported as their own kind, never coerced;
   the ruling lands as a change to the *skill's* routing, not to this verb.
 - ADR 0092 / #4208 / #4219 — a proven-empty fold and an unreadable fold sit on different codes.
+- #5959 — a founder-cleared round had no representation either enforcement site could read, so it
+  could only land as an edit outside the loop; `clearances` is that representation.
+
+---
+
+## `build clear`
+
+**Purpose** — record the founder's clearance of one extra repair round on a PR, as data both
+enforcement sites read. The operator's verb, never the builder's: a builder that reads a spent cap
+escalates (`ESCALATED`), and this is what an authorized human runs so the next round can be built
+inside the loop instead of as an edit outside it (#5959).
+
+**Invocation**
+
+```
+fabrika build clear --pr 5953 --authorization authorization.md [--lane-root <dir>] [--task <id>] [--repo <owner/name>]
+```
+
+**Inputs**
+
+| Flag | Type | Required | Default | Description |
+|---|---|---|---|---|
+| `--pr` | integer | yes | — | the pull request whose repair budget is cleared |
+| `--authorization` | path | yes | — | a file quoting the founder's authorization verbatim, carrying an ISO-8601 date |
+| `--lane-root` | string | no | `.fabrika/lanes` | the lanes root the local half of the grant is recorded in |
+| `--task` | string | no | the lane's only task | the lane task the grant addresses, on a multi-task lane |
+| `--repo` | string | no | the `origin` remote's `owner/name` | the repository written |
+
+**Output** — machine. One JSON object:
+
+```
+{"pr": 5953, "round": 3, "at": "2026-08-18T07:16:03Z", "by": "usirin",
+ "authorization": 512399, "marker": 512400, "cap": 4,
+ "lane": "recorded on issue in .fabrika/lanes/5941/workflow.json", "resolvesTo": "cleared"}
+```
+
+**Who may grant** — the accounts and teams `.fabrika.jsonc` names in `capClearAuthors`, read at the
+PR's **base** ref so a PR cannot widen the set that clears its own cap. Entries are `@user` or
+`@org/team`, both as GitHub writes them; a team is expanded through its membership, and a membership
+that cannot be read is `11`, never a grant and never a refusal. An absent file, an absent key, an
+empty array and a malformed entry are all *nobody may grant* — fail-closed on every axis (ruled
+2026-08-18: the grant-author set is repo configuration, not a compiled-in "founder" concept).
+
+**The clauses are conjunctive**, and any miss resolves to *not cleared*: the PR is open, the budget
+is actually spent (`rounds >= ` the current cap — clearing an unspent budget would pre-arm a round
+nobody has needed), the invoking account is in the set, and the authorization is present and dated.
+A bare stamp is void (#4938), which is why `--authorization` is required rather than inferred.
+
+**Write ordering is an invariant.** The authorization comment lands first, the `cap-cleared` marker
+second, the lane's local bump last. An interrupted run that wrote the marker first would leave a
+void grant a careless reader folds as budget; the order used leaves, at worst, a quote that grants
+nobody anything, or a lane that freezes one round early until a re-run reconciles it. **One grant is
+one round**, keyed by the round it names: it survives the push it exists to permit, and the next
+FAIL round spends it. Re-running is safe — the round is added as a set member on both sides, so a
+reconciling re-run buys nothing extra.
+
+**What `cleared` proves, exactly.** That a configured account posted a marker naming a round whose
+budget was spent, with a dated authorization comment beside it. It does not prove the quoted
+authorization is a truthful record of what the founder said; nothing mechanical can, and in a repo
+where agents run on a configured account's own token the agent's restraint is what holds — the same
+residue `grill rule` carries (#4441).
+
+**Exit status** (beyond the universal four)
+
+| Code | Trigger |
+|---|---|
+| `5` | the authorization carries a machine-local path |
+| `6` | the authorization is a bare `@` path reference |
+| `7` | the PR is proven absent or closed, or its budget is not spent — there is no round to clear |
+| `8` | a write failed — UNKNOWN; read the PR before re-running |
+| `9` | the marker posted and does not read back |
+| `11` | a precondition read failed — the config, a team's membership, the comments, the clock |
+| `25` | the invoking account is not in the configured grant-author set |
+| `26` | `--authorization` is missing, empty, or undated |
+| `29` | the grant is recorded on the PR and the local lane did not take it — re-run to reconcile |
+
+**Errors**
+
+| Message (stderr) | Code | Kind |
+|---|---|---|
+| `build clear: --authorization <path> is empty — a clearance with no quoted authorization is void (#4938).` | 26 | refusal |
+| `build clear: --authorization <path> carries no ISO-8601 date — the authorization must be dated.` | 26 | refusal |
+| `build clear: #<n> has <k> round(s) against a cap of <c> — the budget is not spent, so there is no round to clear.` | 7 | refusal |
+| `build clear: <login> is not in .fabrika.jsonc's grant-author set at <ref> — refusing to record a clearance.` | 25 | refusal |
+| `build clear: the authorization comment landed as #<id> and the marker write failed — the clearance is INCOMPLETE and grants nothing. Read #<n> before re-running.` | 8 | refusal |
+| `build clear: the clearance is recorded on #<n>, and the lane at <path> did not take it: <reason> — the lane still freezes. Re-run to reconcile; the grant is not doubled.` | 29 | refusal |
+
+**Scope** — one PR: its comments (for the round count and the recorded grants), the config at its
+base ref, and the lane its closing keyword names. The stderr scope line states the round count and
+the cap it is judged against, so a refusal is auditable without a second read.
+
+**Example**
+
+```
+$ fabrika build clear --pr 5953 --authorization authorization.md
+{"pr":5953,"round":3,"at":"2026-08-18T07:16:03Z","by":"usirin","authorization":512399,"marker":512400,"cap":4,"lane":"recorded on issue in .fabrika/lanes/5941/workflow.json","resolvesTo":"cleared"}
+```
+
+**Grounding**
+
+- #5959 — the cap was enforced in two places and neither could see a founder's clearance, so a
+  cleared round could only land as a driver-side edit outside the loop.
+- #4938 — a bare stamp is void; the quoted, dated authorization is what a ruling means.
+- #981 — repo configuration is read at the base ref, never from the PR that would change it.
 
 ---
 

--- a/claude-plugins/fabrika/skills/build/contract.md
+++ b/claude-plugins/fabrika/skills/build/contract.md
@@ -1709,6 +1709,10 @@ fabrika build clear --pr 5953 --authorization authorization.md [--lane-root <dir
  "lane": "recorded on issue in .fabrika/lanes/5941/workflow.json", "resolvesTo": "cleared"}
 ```
 
+`resolvesTo` is `cleared` when this run posted the grant, and `reconciled` when the grant was already
+on the PR and only the lane was written; on `reconciled` the `at`, `by`, `authorization` and `marker`
+fields are the landed grant's, not this run's.
+
 **Who may grant** — an account that is **both** named by `.fabrika.jsonc`'s `capClearAuthors`, read
 at the PR's **base** ref so a PR cannot widen the set that clears its own cap, **and** resolved to
 `write+` at the repository ACL at the moment it runs. The configured set narrows the ACL, it never
@@ -1730,8 +1734,15 @@ second, the lane's local bump last. An interrupted run that wrote the marker fir
 void grant a careless reader folds as budget; the order used leaves, at worst, a quote that grants
 nobody anything, or a lane that freezes one round early until a re-run reconciles it. **One grant is
 one round**, keyed by the round it names: it survives the push it exists to permit, and the next
-FAIL round spends it. Re-running is safe — the round is added as a set member on both sides, so a
-reconciling re-run buys nothing extra.
+FAIL round spends it.
+
+**A re-run for a round already granted reconciles; it never re-grants.** Once the marker has landed,
+the cap it raised is itself the reason the budget test would say "not spent", so a run that finds an
+honoured grant at the current round count *skips* the budget test and both writes, and does only the
+half that is still undone — the lane's local bump. It answers `resolvesTo: "reconciled"` at exit 0,
+carrying the existing marker's ids, so exit `29`'s stated remedy is a command that runs rather than
+advice. The lane write is a set insert, so a lane that already took the round answers `already held`
+and nothing is doubled.
 
 **What `cleared` proves, exactly.** That a configured account posted a marker naming a round whose
 budget was spent, with a dated authorization comment beside it. It does not prove the quoted
@@ -1748,8 +1759,8 @@ residue `grill rule` carries (#4441).
 | `7` | the PR is proven absent or closed, or its budget is not spent — there is no round to clear |
 | `8` | a write failed — UNKNOWN; read the PR before re-running |
 | `9` | the marker posted and does not read back |
-| `11` | a precondition read failed — the config, a team's membership, the comments, the clock |
-| `25` | the invoking account is not in the configured grant-author set |
+| `11` | a precondition read failed — the config, a team's membership, the invoking account's permission, the comments, the clock |
+| `25` | the invoking account is not in the configured grant-author set, or resolves below `write` at the ACL |
 | `26` | `--authorization` is missing, empty, or undated |
 | `29` | the grant is recorded on the PR and the local lane did not take it — re-run to reconcile |
 
@@ -1761,11 +1772,14 @@ residue `grill rule` carries (#4441).
 | `build clear: --authorization <path> carries no ISO-8601 date — the authorization must be dated.` | 26 | refusal |
 | `build clear: #<n> has <k> round(s) against a cap of <c> — the budget is not spent, so there is no round to clear.` | 7 | refusal |
 | `build clear: <login> is not in .fabrika.jsonc's grant-author set at <ref> — refusing to record a clearance.` | 25 | refusal |
+| `build clear: <login> resolves to <level> on <repo>, below write — authority is the ACL's, never .fabrika.jsonc's alone (ADR 0055).` | 25 | refusal |
+| `build clear: cannot resolve <login>'s repository permission: <reason> — authority is UNKNOWN, never granted. Nothing was posted.` | 11 | refusal |
+| `build clear: the clearance is recorded on #<n> as comment <id>, and the lane at <path> still did not take it: <reason> — the lane still freezes.` | 29 | refusal |
 | `build clear: the authorization comment landed as #<id> and the marker write failed — the clearance is INCOMPLETE and grants nothing. Read #<n> before re-running.` | 8 | refusal |
 | `build clear: the clearance is recorded on #<n>, and the lane at <path> did not take it: <reason> — the lane still freezes. Re-run to reconcile; the grant is not doubled.` | 29 | refusal |
 
 **Scope** — one PR: its comments (for the round count and the recorded grants), the config at its
-base ref, and the lane its closing keyword names. The stderr scope line states the round count and
+base ref, the invoking account's repository permission, and the lane its closing keyword names. The stderr scope line states the round count and
 the cap it is judged against, so a refusal is auditable without a second read.
 
 **Example**
@@ -1779,8 +1793,10 @@ $ fabrika build clear --pr 5953 --authorization authorization.md
 
 - #5959 — the cap was enforced in two places and neither could see a founder's clearance, so a
   cleared round could only land as a driver-side edit outside the loop.
-- #4938 — a bare stamp is void; the quoted, dated authorization is what a ruling means.
+- #4938 — a bare stamp is void; the quoted, dated authorization is what a ruling means, and it must
+  be the comment immediately before the marker.
 - #981 — repo configuration is read at the base ref, never from the PR that would change it.
+- ADR 0055 / ADR 0292 — authority is the live ACL's; the configured set narrows it, never replaces it.
 
 ---
 

--- a/claude-plugins/fabrika/skills/build/contract.md
+++ b/claude-plugins/fabrika/skills/build/contract.md
@@ -1606,13 +1606,19 @@ package's one declared retry budget — plus what the founder cleared through `b
 computed here so the cap is a field read, not a number remembered.)
 
 **Cleared rounds.** `clearances` lists every `cap-cleared` marker on the PR, judged. A row is
-`honoured` only when its author is in `.fabrika.jsonc`'s `capClearAuthors` set at the PR's **base**
-ref, a dated authorization comment from that same author precedes it, and the round it names is at
-or past `CAP_ROUND`; a row that misses carries the `reason` it missed and grants nothing. Each
+`honoured` only when four clauses hold: its author is in `.fabrika.jsonc`'s `capClearAuthors` set at
+the PR's **base** ref, that author holds `write+` at the repository ACL read live (ADR 0055 — the
+configured set narrows the ACL, it never replaces one, ADR 0292), the round it names is at or past
+`CAP_ROUND`, and a dated authorization comment from that same author sits **immediately before** it
+and is not itself a `cap-cleared` marker — the strict adjacency `grill rule` enforces, because
+without it a second bare marker rests on the first grant's own dated marker and every grant after
+the first is authorized by nothing. A row that misses carries the `reason` it missed and grants
+nothing; the ACL is read only for authors the configured set already names. Each
 honoured round adds one to the cap, counted by distinct round, so a re-posted grant buys one round
 and not two — and because a clearance binds the *round* rather than a head SHA, it survives the push
 it exists to permit and is spent the moment the next FAIL round lands. A read that cannot complete —
-the config file, a configured team's membership — is `11`, never an empty set.
+the config file, a configured team's membership, a named author's permission — is `11`, never an
+empty set.
 
 The fold: resolve the PR's current head; fetch **every** comment and **every** review, paginated
 in full; parse each comment through the imported `verdict-marker` read; keep the latest marker
@@ -1703,17 +1709,21 @@ fabrika build clear --pr 5953 --authorization authorization.md [--lane-root <dir
  "lane": "recorded on issue in .fabrika/lanes/5941/workflow.json", "resolvesTo": "cleared"}
 ```
 
-**Who may grant** — the accounts and teams `.fabrika.jsonc` names in `capClearAuthors`, read at the
-PR's **base** ref so a PR cannot widen the set that clears its own cap. Entries are `@user` or
-`@org/team`, both as GitHub writes them; a team is expanded through its membership, and a membership
-that cannot be read is `11`, never a grant and never a refusal. An absent file, an absent key, an
-empty array and a malformed entry are all *nobody may grant* — fail-closed on every axis (ruled
-2026-08-18: the grant-author set is repo configuration, not a compiled-in "founder" concept).
+**Who may grant** — an account that is **both** named by `.fabrika.jsonc`'s `capClearAuthors`, read
+at the PR's **base** ref so a PR cannot widen the set that clears its own cap, **and** resolved to
+`write+` at the repository ACL at the moment it runs. The configured set narrows the ACL, it never
+replaces one (ADR 0292): a committed file has no author gate (ADR 0055), so widening the file grants
+nothing to an account with no collaboration. Entries are `@user` or `@org/team`, both as GitHub
+writes them; a team is expanded through its membership, and a membership or permission that cannot
+be read is `11`, never a grant and never a refusal. An absent file, an absent key, an empty array and
+a malformed entry are all *nobody may grant* — fail-closed on every axis (ruled 2026-08-18: the
+grant-author set is repo configuration, not a compiled-in "founder" concept).
 
 **The clauses are conjunctive**, and any miss resolves to *not cleared*: the PR is open, the budget
 is actually spent (`rounds >= ` the current cap — clearing an unspent budget would pre-arm a round
-nobody has needed), the invoking account is in the set, and the authorization is present and dated.
-A bare stamp is void (#4938), which is why `--authorization` is required rather than inferred.
+nobody has needed), the invoking account is in the set and above the write floor, and the
+authorization is present and dated. A bare stamp is void (#4938), which is why `--authorization` is
+required rather than inferred.
 
 **Write ordering is an invariant.** The authorization comment lands first, the `cap-cleared` marker
 second, the lane's local bump last. An interrupted run that wrote the marker first would leave a

--- a/packages/fabrika-cli/src/build/clear-verb.ts
+++ b/packages/fabrika-cli/src/build/clear-verb.ts
@@ -2,9 +2,11 @@
  * `build clear` — record the founder's clearance of one extra repair round on a PR.
  *
  * The clauses are conjunctive and any miss resolves to *not cleared*, never to a warning: the
- * invoking account is in the repo's `.fabrika.jsonc` grant-author set at the PR's base ref, the PR
- * is open, its budget is actually spent, and the quoted authorization is present and dated. A bare
- * stamp is void (#4938), which is why `--authorization` is required rather than inferred.
+ * invoking account is in the repo's `.fabrika.jsonc` grant-author set at the PR's base ref AND holds
+ * `write+` at GitHub's ACL, the PR is open, its budget is actually spent, and the quoted
+ * authorization is present and dated. A bare stamp is void (#4938), which is why `--authorization`
+ * is required rather than inferred; the ACL clause is ADR 0055's, which is why the configured set
+ * narrows the ACL rather than replacing it (ADR 0292).
  *
  * **Write ordering is an invariant, not an implementation detail** — the same one `grill rule`
  * holds. The authorization comment lands first and the marker second: an interrupted run that wrote
@@ -19,6 +21,13 @@
  * the residue is the same one #4441 is open on for `grill rule`. In a repo where an agent runs on
  * the founder's own token, the agent's restraint is what holds — this verb is the operator's, and
  * `build`'s Repair section tells a builder that reads a cap to escalate, never to clear it.
+ *
+ * **Re-running after a partial write reconciles, it does not re-grant.** Once the marker has landed,
+ * the cap it raised is the reason the budget test would now say "not spent" — so a run that finds
+ * this round already granted skips both the budget test and the two writes, and does the one thing
+ * that is still undone: the lane's local bump. Without that branch exit `29`'s own stated remedy
+ * refuses on `7` and the lane can only be unfrozen by an edit outside the loop, which is the thing
+ * #5959 exists to remove.
  */
 
 import type {FileSystem, Path} from "effect";
@@ -37,7 +46,13 @@ import {answer, FAILED, refuse, type VerbOutcome} from "../verb.ts";
 import * as capClearance from "../wire/cap-clearance.ts";
 import {stampOf} from "../wire/grill-marker.ts";
 import {read as readMarker} from "../wire/verdict-marker.ts";
-import {clearancesOn, grantedFrom, membershipAt} from "./clearances.ts";
+import {
+	clearancesOn,
+	clearsWriteFloor,
+	grantedFrom,
+	membershipAt,
+	permissionsFor,
+} from "./clearances.ts";
 import {
 	AUTHORIZATION_VOID,
 	BARE_AT_PATH,
@@ -160,7 +175,8 @@ export const runClear = <R = never>(
 		const granted = grantedFrom(recorded.rows);
 		const cap = effectiveCap(granted);
 		const scopeLine = `${VERB}: ${repo}#${pr} at ${rounds} round(s); cap ${cap} = ${CAP_ROUND} declared + ${grantedRounds(granted)} cleared.`;
-		if (rounds < cap) {
+		const held = recorded.rows.find((row) => row.honoured && row.round === rounds);
+		if (held === undefined && rounds < cap) {
 			return refuse(
 				ZERO_SCOPE,
 				`${VERB}: #${pr} has ${rounds} round(s) against a cap of ${cap} — the budget is not spent, so there is no round to clear.`,
@@ -195,6 +211,50 @@ export const runClear = <R = never>(
 			return refuse(
 				GRANT_UNAUTHORIZED,
 				`${VERB}: ${viewer.value} is not in ${CONFIG_PATH}'s grant-author set at ${baseRef} — refusing to record a clearance.`,
+				[scopeLine],
+			);
+		}
+		// ADR 0055: the committed set narrows the ACL, it never stands in for one. Read through the
+		// same door that judges a landed marker, so the set that may post a grant and the set whose
+		// grant counts can never drift into two.
+		const permissions = yield* permissionsFor(repo, [viewer.value]);
+		if (permissions._tag === "Unknown") {
+			return refuse(
+				PRECONDITION_UNKNOWN,
+				`${VERB}: cannot resolve ${viewer.value}'s repository permission: ${permissions.reason} — authority is UNKNOWN, never granted. Nothing was posted.`,
+				[scopeLine],
+			);
+		}
+		const level = permissions.levelOf(viewer.value);
+		if (!clearsWriteFloor(level)) {
+			return refuse(
+				GRANT_UNAUTHORIZED,
+				`${VERB}: ${viewer.value} resolves to ${level ?? "no collaboration"} on ${repo}, below write — authority is the ACL's, never ${CONFIG_PATH}'s alone (ADR 0055).`,
+				[scopeLine],
+			);
+		}
+
+		if (held !== undefined) {
+			const reconciled = yield* bumpLane(options, target.pull.body, held.round);
+			if (reconciled._tag === "Unwritten") {
+				return refuse(
+					LOCAL_LANE_UNWRITTEN,
+					`${VERB}: the clearance is recorded on #${pr} as comment ${held.commentId}, and the lane at ${reconciled.path} still did not take it: ${reconciled.reason} — the lane still freezes.`,
+					[scopeLine],
+				);
+			}
+			return answer(
+				JSON.stringify({
+					pr,
+					round: held.round,
+					at: held.at,
+					by: held.by,
+					authorization: held.authorization,
+					marker: held.commentId,
+					cap,
+					lane: reconciled.note,
+					resolvesTo: "reconciled",
+				}),
 				[scopeLine],
 			);
 		}

--- a/packages/fabrika-cli/src/build/clear-verb.ts
+++ b/packages/fabrika-cli/src/build/clear-verb.ts
@@ -1,0 +1,314 @@
+/**
+ * `build clear` — record the founder's clearance of one extra repair round on a PR.
+ *
+ * The clauses are conjunctive and any miss resolves to *not cleared*, never to a warning: the
+ * invoking account is in the repo's `.fabrika.jsonc` grant-author set at the PR's base ref, the PR
+ * is open, its budget is actually spent, and the quoted authorization is present and dated. A bare
+ * stamp is void (#4938), which is why `--authorization` is required rather than inferred.
+ *
+ * **Write ordering is an invariant, not an implementation detail** — the same one `grill rule`
+ * holds. The authorization comment lands first and the marker second: an interrupted run that wrote
+ * the marker first would leave a void grant a careless reader folds as budget, while the reverse
+ * leaves a quote with no marker, which resolves to nothing and grants nobody anything. The lane's
+ * local bump is last, because a lane that has not heard about the grant only freezes early, and a
+ * lane bumped with no marker behind it would run a round nobody granted.
+ *
+ * **What `cleared` proves, exactly.** That an account the repo configured posted a marker naming a
+ * round whose budget was spent, with a dated authorization comment beside it. It does not prove the
+ * quoted authorization is a truthful record of what the founder said; nothing mechanical can, and
+ * the residue is the same one #4441 is open on for `grill rule`. In a repo where an agent runs on
+ * the founder's own token, the agent's restraint is what holds — this verb is the operator's, and
+ * `build`'s Repair section tells a builder that reads a cap to escalate, never to clear it.
+ */
+
+import type {FileSystem, Path} from "effect";
+import {Effect} from "effect";
+import type {ChildProcessSpawner} from "effect/unstable/process";
+import {effectiveCap, grantedRounds} from "../cap-clearance.ts";
+import {createComment, getComment, listComments} from "../io/issues.ts";
+import {viewerLogin} from "../io/pulls.ts";
+import {recordClearedRound} from "../lane/clearance.ts";
+import {laneRef, parseKey} from "../lane/key.ts";
+import {CONFIG_PATH} from "../repo-config.ts";
+import {normalizeForReadback} from "../report/compose.ts";
+import {isBareAtReference, renderLeaks, scanBody} from "../report/leaks.ts";
+import {CAP_ROUND} from "../retry-budget.ts";
+import {answer, FAILED, refuse, type VerbOutcome} from "../verb.ts";
+import * as capClearance from "../wire/cap-clearance.ts";
+import {stampOf} from "../wire/grill-marker.ts";
+import {read as readMarker} from "../wire/verdict-marker.ts";
+import {clearancesOn, grantedFrom, membershipAt} from "./clearances.ts";
+import {
+	AUTHORIZATION_VOID,
+	BARE_AT_PATH,
+	GRANT_UNAUTHORIZED,
+	LEAKED_PATH,
+	LOCAL_LANE_UNWRITTEN,
+	PRECONDITION_UNKNOWN,
+	READBACK_MISMATCH,
+	WRITE_UNKNOWN,
+	ZERO_SCOPE,
+} from "./codes.ts";
+import {closingTargets, proseOf} from "./pr-body.ts";
+import {countRounds} from "./rounds.ts";
+import {openPull, resolveTargetRepo} from "./target.ts";
+
+const VERB = "build clear";
+
+/** Any ISO-8601 date in the quote — a clearance the reader cannot place in time is not dated. */
+const ISO_DATE = /\d{4}-\d{2}-\d{2}/;
+
+/** A file the adapter read for the verb, so the verb itself touches no filesystem for it. */
+export type DocumentRead =
+	| {readonly _tag: "Text"; readonly text: string}
+	| {readonly _tag: "Failed"; readonly reason: string};
+
+export interface ClearOptions<R = never> {
+	readonly pr: number;
+	/** The `--authorization` path, carried for the refusal messages only. */
+	readonly authorizationPath: string;
+	readonly authorization: Effect.Effect<DocumentRead, never, R>;
+	/** The lanes root override, and the task the grant addresses on a multi-task lane. */
+	readonly laneRoot: string | null;
+	readonly task: string | null;
+	readonly repo: string | null;
+	readonly env: Readonly<Record<string, string | undefined>>;
+	readonly now: () => Date;
+}
+
+export const runClear = <R = never>(
+	options: ClearOptions<R>,
+): Effect.Effect<
+	VerbOutcome,
+	never,
+	R | ChildProcessSpawner.ChildProcessSpawner | FileSystem.FileSystem | Path.Path
+> =>
+	Effect.gen(function* () {
+		const {pr, authorizationPath} = options;
+		const resolved = yield* resolveTargetRepo(VERB, options.repo, options.env);
+		if (resolved._tag === "Refused") return resolved.outcome;
+		const repo = resolved.repo;
+
+		const read = yield* options.authorization;
+		if (read._tag === "Failed") {
+			return refuse(
+				FAILED,
+				`${VERB}: could not read --authorization ${authorizationPath}: ${read.reason} — the authorization is UNKNOWN, never empty.`,
+			);
+		}
+		const quoted = read.text;
+		if (quoted.trim() === "") {
+			return refuse(
+				AUTHORIZATION_VOID,
+				`${VERB}: --authorization ${authorizationPath} is empty — a clearance with no quoted authorization is void (#4938).`,
+			);
+		}
+		if (!ISO_DATE.test(quoted)) {
+			return refuse(
+				AUTHORIZATION_VOID,
+				`${VERB}: --authorization ${authorizationPath} carries no ISO-8601 date — the authorization must be dated.`,
+			);
+		}
+		if (isBareAtReference(quoted)) {
+			return refuse(
+				BARE_AT_PATH,
+				`${VERB}: the authorization is a bare @ path reference — not redactable, refusing to post it.`,
+			);
+		}
+		const leaks = scanBody(quoted);
+		const firstLeak = leaks.leaks[0];
+		if (firstLeak !== undefined) {
+			return refuse(
+				LEAKED_PATH,
+				`${VERB}: the authorization carries a machine-local path: ${firstLeak.text} — refusing to post it.`,
+				renderLeaks(leaks.leaks),
+			);
+		}
+
+		const target = yield* openPull(
+			VERB,
+			repo,
+			pr,
+			(reason) =>
+				`${VERB}: cannot read PR #${pr}: ${reason} — whether it can be cleared is UNKNOWN. Nothing was posted.`,
+		);
+		if (target._tag === "Refused") return target.outcome;
+		const baseRef = target.pull.baseRef;
+
+		const listed = yield* listComments(repo, pr);
+		if (listed._tag === "Failure") {
+			return refuse(
+				PRECONDITION_UNKNOWN,
+				`${VERB}: cannot read the comments on #${pr}: ${listed.reason} — the round count is UNKNOWN. Nothing was posted.`,
+			);
+		}
+		const rounds = countRounds(
+			listed.value.flatMap((comment) => {
+				const parsed = readMarker(comment.body);
+				return parsed._tag === "Found" && parsed.value.polarity === "FAIL"
+					? [comment.createdAt]
+					: [];
+			}),
+		);
+		const recorded = yield* clearancesOn(repo, baseRef, listed.value);
+		if (recorded._tag === "Unknown") {
+			return refuse(
+				PRECONDITION_UNKNOWN,
+				`${VERB}: cannot read the recorded clearances: ${recorded.reason} — the granted budget is UNKNOWN. Nothing was posted.`,
+			);
+		}
+		const granted = grantedFrom(recorded.rows);
+		const cap = effectiveCap(granted);
+		const scopeLine = `${VERB}: ${repo}#${pr} at ${rounds} round(s); cap ${cap} = ${CAP_ROUND} declared + ${grantedRounds(granted)} cleared.`;
+		if (rounds < cap) {
+			return refuse(
+				ZERO_SCOPE,
+				`${VERB}: #${pr} has ${rounds} round(s) against a cap of ${cap} — the budget is not spent, so there is no round to clear.`,
+				[scopeLine],
+			);
+		}
+
+		const viewer = yield* viewerLogin;
+		if (viewer._tag === "Failure") {
+			return refuse(
+				PRECONDITION_UNKNOWN,
+				`${VERB}: cannot resolve the invoking account: ${viewer.reason} — authority is UNKNOWN, never granted. Nothing was posted.`,
+				[scopeLine],
+			);
+		}
+		// The ACL is read through the same door that judges a landed marker, so the set that may post
+		// a grant and the set whose grant counts can never drift into two.
+		const authority = yield* membershipAt(repo, baseRef);
+		if (authority._tag === "Unknown") {
+			return refuse(
+				PRECONDITION_UNKNOWN,
+				`${VERB}: cannot resolve ${viewer.value}'s authority on ${repo}: ${authority.reason} — nothing was posted.`,
+				[scopeLine],
+			);
+		}
+		if (authority._tag === "Unusable") {
+			return refuse(GRANT_UNAUTHORIZED, `${VERB}: ${authority.reason}. Nothing was posted.`, [
+				scopeLine,
+			]);
+		}
+		if (!authority.holds(viewer.value)) {
+			return refuse(
+				GRANT_UNAUTHORIZED,
+				`${VERB}: ${viewer.value} is not in ${CONFIG_PATH}'s grant-author set at ${baseRef} — refusing to record a clearance.`,
+				[scopeLine],
+			);
+		}
+
+		const stamped = stampOf(options.now());
+		if (stamped === null) {
+			return refuse(
+				PRECONDITION_UNKNOWN,
+				`${VERB}: the clock did not render an ISO-8601 UTC instant — the marker cannot be stamped. Nothing was posted.`,
+				[scopeLine],
+			);
+		}
+		const round = capClearance.clearedRound(rounds);
+		if (round === null) {
+			return refuse(
+				PRECONDITION_UNKNOWN,
+				`${VERB}: #${pr} counts ${rounds} rounds, which is not a round a clearance can name.`,
+				[scopeLine],
+			);
+		}
+		const authorizationBody = quoted.trim().endsWith("\n") ? quoted.trim() : `${quoted.trim()}\n`;
+		const authorization = yield* createComment(repo, pr, authorizationBody);
+		if (authorization._tag === "Failure") {
+			return refuse(
+				WRITE_UNKNOWN,
+				`${VERB}: the authorization write failed, so whether it posted is UNKNOWN and no marker was written — read #${pr} before re-running.`,
+				[scopeLine],
+			);
+		}
+		const markerBody = capClearance.emit({round, at: stamped});
+		const marker = yield* createComment(repo, pr, markerBody);
+		if (marker._tag === "Failure") {
+			return refuse(
+				WRITE_UNKNOWN,
+				`${VERB}: the authorization comment landed as #${authorization.value.id} and the marker write failed — the clearance is INCOMPLETE and grants nothing. Read #${pr} before re-running.`,
+				[scopeLine],
+			);
+		}
+		const landed = yield* getComment(repo, marker.value.id);
+		if (
+			landed._tag === "Failure" ||
+			normalizeForReadback(landed.value) !== normalizeForReadback(markerBody)
+		) {
+			return refuse(
+				READBACK_MISMATCH,
+				`${VERB}: the marker posted but the read-back does not match what was sent.`,
+				[scopeLine],
+			);
+		}
+
+		const lane = yield* bumpLane(options, target.pull.body, round);
+		if (lane._tag === "Unwritten") {
+			return refuse(
+				LOCAL_LANE_UNWRITTEN,
+				`${VERB}: the clearance is recorded on #${pr}, and the lane at ${lane.path} did not take it: ${lane.reason} — the lane still freezes. Re-run to reconcile; the grant is not doubled.`,
+				[scopeLine],
+			);
+		}
+
+		return answer(
+			JSON.stringify({
+				pr,
+				round,
+				at: stamped,
+				by: viewer.value,
+				authorization: authorization.value.id,
+				marker: marker.value.id,
+				cap: effectiveCap([...granted, round]),
+				lane: lane.note,
+				resolvesTo: "cleared",
+			}),
+			[scopeLine],
+		);
+	});
+
+type LaneBump =
+	| {readonly _tag: "Note"; readonly note: string}
+	| {readonly _tag: "Unwritten"; readonly path: string; readonly reason: string};
+
+/**
+ * Carry the grant into the local lane, if one is there.
+ *
+ * The lane is the PR's linked issue — the same closing keyword every other reader resolves the
+ * contract through — so nothing here invents a lane key. A PR that closes nothing, or a lane that
+ * is not on this machine, is an answer: there is no local guard to trip.
+ */
+const bumpLane = <R>(
+	options: ClearOptions<R>,
+	body: string,
+	round: number,
+): Effect.Effect<LaneBump, never, FileSystem.FileSystem | Path.Path> =>
+	Effect.gen(function* () {
+		const issue = closingTargets(proseOf(body))[0];
+		if (issue === undefined) return {_tag: "Note" as const, note: "no linked issue, so no lane"};
+		const key = parseKey(String(issue));
+		if (key._tag === "Malformed") {
+			return {_tag: "Note" as const, note: `#${issue} is not a lane key`};
+		}
+		const written = yield* recordClearedRound(
+			laneRef(key.key, options.laneRoot),
+			options.task,
+			round,
+		);
+		if (written._tag === "NoLane") {
+			return {_tag: "Note" as const, note: `no lane at ${written.dir}`};
+		}
+		if (written._tag === "Unusable") {
+			return {_tag: "Unwritten" as const, path: written.path, reason: written.reason};
+		}
+		return {
+			_tag: "Note" as const,
+			note:
+				written._tag === "Recorded"
+					? `recorded on ${written.task} in ${written.path}`
+					: `${written.task} already held round ${round}`,
+		};
+	});

--- a/packages/fabrika-cli/src/build/clear-verb.ts
+++ b/packages/fabrika-cli/src/build/clear-verb.ts
@@ -6,7 +6,7 @@
  * `write+` at GitHub's ACL, the PR is open, its budget is actually spent, and the quoted
  * authorization is present and dated. A bare stamp is void (#4938), which is why `--authorization`
  * is required rather than inferred; the ACL clause is ADR 0055's, which is why the configured set
- * narrows the ACL rather than replacing it (ADR 0292).
+ * narrows the ACL rather than replacing it (ADR 0294).
  *
  * **Write ordering is an invariant, not an implementation detail** — the same one `grill rule`
  * holds. The authorization comment lands first and the marker second: an interrupted run that wrote

--- a/packages/fabrika-cli/src/build/clear-verb.unit.test.ts
+++ b/packages/fabrika-cli/src/build/clear-verb.unit.test.ts
@@ -211,7 +211,7 @@ describe("runClear", () => {
 		expect(parsed.cap).toBe(CAP_ROUND + 2);
 	});
 
-	/** A committed set narrows the ACL; it never stands in for one (ADR 0055, ADR 0292). */
+	/** A committed set narrows the ACL; it never stands in for one (ADR 0055, ADR 0294). */
 	it("refuses a configured account that resolves below write at the ACL", async () => {
 		const {outcome, calls} = await run([
 			[PULL, pull({number: 4310, base: {ref: "main"}})],

--- a/packages/fabrika-cli/src/build/clear-verb.unit.test.ts
+++ b/packages/fabrika-cli/src/build/clear-verb.unit.test.ts
@@ -1,0 +1,210 @@
+import {Effect, Layer} from "effect";
+import {describe, expect, it} from "vitest";
+import {fakeFs, fakeShell, okOut} from "../fakes.test-support.ts";
+import type {ExecResult} from "../io/exec.ts";
+import {coderTemplateText} from "../lane/fixtures.test-support.ts";
+import {compileText} from "../lane/machine.ts";
+import {CAP_ROUND, RETRY_BUDGET} from "../retry-budget.ts";
+import {type DocumentRead, runClear} from "./clear-verb.ts";
+import {AUTHORIZATION_VOID, GRANT_UNAUTHORIZED, PRECONDITION_UNKNOWN, ZERO_SCOPE} from "./codes.ts";
+import {comments, HEAD, pull} from "./fixtures.test-support.ts";
+
+const PULL = /^gh api repos\/o\/r\/pulls\/4310$/;
+const COMMENTS = /^gh api --paginate repos\/o\/r\/issues\/4310\/comments/;
+const VIEWER = /^gh api user --jq \.login$/;
+const CONFIG =
+	/^gh api -H Accept: application\/vnd\.github\.raw repos\/o\/r\/contents\/\.fabrika\.jsonc\?ref=main$/;
+const TEAM = /^gh api --paginate orgs\/kamp-us\/teams\/control-plane\/members/;
+const POST = /^gh api --method POST repos\/o\/r\/issues\/4310\/comments/;
+const GET_COMMENT = /^gh api repos\/o\/r\/issues\/comments\/(\d+)$/;
+
+const WORKFLOW = ".fabrika/lanes/4312/workflow.json";
+const NOW = new Date("2026-08-18T07:16:03Z");
+const AUTHORIZATION = 'Founder ruling 2026-08-18: "one more round on this one."';
+
+/** Three FAIL rounds, each its own cluster — the count at which the declared budget is spent. */
+const THREE_ROUNDS = comments(
+	{id: 1, body: `review-code: FAIL @ ${HEAD} — one`, createdAt: "2026-08-18T01:00:00Z"},
+	{id: 2, body: `review-code: FAIL @ ${HEAD} — two`, createdAt: "2026-08-18T02:00:00Z"},
+	{id: 3, body: `review-code: FAIL @ ${HEAD} — three`, createdAt: "2026-08-18T03:00:00Z"},
+);
+
+const CONFIGURED = okOut('{\n\t// the founder accounts\n\t"capClearAuthors": ["@usirin"]\n}\n');
+const POSTED = (id: number): ExecResult => okOut(JSON.stringify({id, html_url: "https://x/y#c"}));
+
+const document = (text: string): Effect.Effect<DocumentRead> =>
+	Effect.succeed(text === "" ? {_tag: "Failed", reason: "no such file"} : {_tag: "Text", text});
+
+const options = {
+	pr: 4310,
+	authorizationPath: "authorization.md",
+	authorization: document(AUTHORIZATION),
+	laneRoot: null,
+	task: null,
+	repo: null,
+	env: {CLAUDE_PIPELINE_REPO: "o/r"} as Record<string, string | undefined>,
+	now: () => NOW,
+};
+
+const run = (
+	script: ReadonlyArray<readonly [RegExp, ExecResult]>,
+	overrides: Partial<typeof options> = {},
+	files: Record<string, string | null> = {},
+) => {
+	const shell = fakeShell(script);
+	const fs = fakeFs({files});
+	return Effect.runPromise(
+		Effect.provide(runClear({...options, ...overrides}), Layer.merge(shell.layer, fs.layer)),
+	).then((outcome) => ({outcome, inputs: shell.inputs, calls: shell.calls, written: fs.written}));
+};
+
+const GRANTABLE: ReadonlyArray<readonly [RegExp, ExecResult]> = [
+	[PULL, pull({number: 4310, base: {ref: "main"}})],
+	[COMMENTS, THREE_ROUNDS],
+	[CONFIG, CONFIGURED],
+	[VIEWER, okOut("usirin\n")],
+];
+
+describe("runClear", () => {
+	it("posts the authorization first and the marker second, then answers `cleared`", async () => {
+		const {outcome, calls} = await run(
+			[
+				...GRANTABLE,
+				[POST, POSTED(900)],
+				[
+					GET_COMMENT,
+					okOut(JSON.stringify({body: "cap-cleared: round 3 · 2026-08-18T07:16:03Z\n"})),
+				],
+			],
+			{},
+			{[WORKFLOW]: coderTemplateText()},
+		);
+		expect(outcome.code).toBe(0);
+		const parsed = JSON.parse(outcome.stdout);
+		expect(parsed).toMatchObject({round: CAP_ROUND, by: "usirin", resolvesTo: "cleared"});
+		expect(parsed.cap).toBe(CAP_ROUND + 1);
+		const posted = calls.filter((line) => line.includes("--method POST"));
+		expect(posted[0]).toContain("Founder ruling 2026-08-18");
+		expect(posted[1]).toContain("cap-cleared: round 3");
+	});
+
+	it("carries the grant into the local lane, so the guard does not freeze the cleared round", async () => {
+		const {written} = await run(
+			[
+				...GRANTABLE,
+				[POST, POSTED(900)],
+				[
+					GET_COMMENT,
+					okOut(JSON.stringify({body: "cap-cleared: round 3 · 2026-08-18T07:16:03Z\n"})),
+				],
+			],
+			{},
+			{[WORKFLOW]: coderTemplateText()},
+		);
+		const compiled = compileText(written.get(WORKFLOW) ?? "");
+		if (compiled._tag !== "Compiled") throw new Error("the lane document did not recompile");
+		expect(compiled.lane.tasks.issue?.initial.maxRetries).toBe(RETRY_BUDGET + 1);
+	});
+
+	it("refuses an account outside the configured set, writing nothing", async () => {
+		const {outcome, calls} = await run([
+			[PULL, pull({number: 4310, base: {ref: "main"}})],
+			[COMMENTS, THREE_ROUNDS],
+			[CONFIG, CONFIGURED],
+			[VIEWER, okOut("someone-else\n")],
+		]);
+		expect(outcome.code).toBe(GRANT_UNAUTHORIZED);
+		expect(calls.some((line) => /--method POST/.test(line))).toBe(false);
+	});
+
+	it("refuses when the repo configures nobody — an absent config grants nobody (#5959)", async () => {
+		const {outcome} = await run([
+			[PULL, pull({number: 4310, base: {ref: "main"}})],
+			[COMMENTS, THREE_ROUNDS],
+			[CONFIG, {ok: false, stdout: "", reason: "gh: Not Found (HTTP 404)"}],
+			[VIEWER, okOut("usirin\n")],
+		]);
+		expect(outcome.code).toBe(GRANT_UNAUTHORIZED);
+	});
+
+	it("holds an unreadable team membership UNKNOWN rather than granting or refusing", async () => {
+		const {outcome} = await run([
+			[PULL, pull({number: 4310, base: {ref: "main"}})],
+			[COMMENTS, THREE_ROUNDS],
+			[CONFIG, okOut('{"capClearAuthors": ["@kamp-us/control-plane"]}')],
+			[TEAM, {ok: false, stdout: "", reason: "HTTP 502"}],
+			[VIEWER, okOut("usirin\n")],
+		]);
+		expect(outcome.code).toBe(PRECONDITION_UNKNOWN);
+	});
+
+	it("refuses a bare stamp — an authorization with no date is void (#4938)", async () => {
+		const {outcome, calls} = await run(GRANTABLE, {
+			authorization: document("one more round, go ahead"),
+		});
+		expect(outcome.code).toBe(AUTHORIZATION_VOID);
+		expect(calls).toEqual([]);
+	});
+
+	it("refuses an empty authorization before reading anything", async () => {
+		const {outcome} = await run(GRANTABLE, {
+			authorization: Effect.succeed({_tag: "Text", text: " "}),
+		});
+		expect(outcome.code).toBe(AUTHORIZATION_VOID);
+	});
+
+	/** Clearing a budget that is not spent would pre-arm a round nobody has needed yet. */
+	it("refuses while the budget still has rounds in it", async () => {
+		const {outcome} = await run([
+			[PULL, pull({number: 4310, base: {ref: "main"}})],
+			[
+				COMMENTS,
+				comments({
+					id: 1,
+					body: `review-code: FAIL @ ${HEAD} — one`,
+					createdAt: "2026-08-18T01:00:00Z",
+				}),
+			],
+			[CONFIG, CONFIGURED],
+			[VIEWER, okOut("usirin\n")],
+		]);
+		expect(outcome.code).toBe(ZERO_SCOPE);
+	});
+
+	it("counts an already-honoured clearance, so the second grant clears the next round", async () => {
+		const {outcome} = await run(
+			[
+				[PULL, pull({number: 4310, base: {ref: "main"}})],
+				[
+					COMMENTS,
+					comments(
+						{id: 1, body: `review-code: FAIL @ ${HEAD} — one`, createdAt: "2026-08-18T01:00:00Z"},
+						{id: 2, body: `review-code: FAIL @ ${HEAD} — two`, createdAt: "2026-08-18T02:00:00Z"},
+						{id: 3, body: `review-code: FAIL @ ${HEAD} — three`, createdAt: "2026-08-18T03:00:00Z"},
+						{id: 4, body: AUTHORIZATION, author: "usirin", createdAt: "2026-08-18T03:10:00Z"},
+						{
+							id: 5,
+							body: "cap-cleared: round 3 · 2026-08-18T03:11:00Z",
+							author: "usirin",
+							createdAt: "2026-08-18T03:11:00Z",
+						},
+						{id: 6, body: `review-code: FAIL @ ${HEAD} — four`, createdAt: "2026-08-18T04:00:00Z"},
+					),
+				],
+				[CONFIG, CONFIGURED],
+				[VIEWER, okOut("usirin\n")],
+				[POST, POSTED(901)],
+				[
+					GET_COMMENT,
+					okOut(JSON.stringify({body: "cap-cleared: round 4 · 2026-08-18T07:16:03Z\n"})),
+				],
+			],
+			{},
+			{[WORKFLOW]: coderTemplateText()},
+		);
+		expect(outcome.code).toBe(0);
+		const parsed = JSON.parse(outcome.stdout);
+		expect(parsed.round).toBe(CAP_ROUND + 1);
+		expect(parsed.cap).toBe(CAP_ROUND + 2);
+	});
+});

--- a/packages/fabrika-cli/src/build/clear-verb.unit.test.ts
+++ b/packages/fabrika-cli/src/build/clear-verb.unit.test.ts
@@ -15,6 +15,7 @@ const VIEWER = /^gh api user --jq \.login$/;
 const CONFIG =
 	/^gh api -H Accept: application\/vnd\.github\.raw repos\/o\/r\/contents\/\.fabrika\.jsonc\?ref=main$/;
 const TEAM = /^gh api --paginate orgs\/kamp-us\/teams\/control-plane\/members/;
+const PERMISSION = /^gh api repos\/o\/r\/collaborators\/usirin\/permission/;
 const POST = /^gh api --method POST repos\/o\/r\/issues\/4310\/comments/;
 const GET_COMMENT = /^gh api repos\/o\/r\/issues\/comments\/(\d+)$/;
 
@@ -63,6 +64,7 @@ const GRANTABLE: ReadonlyArray<readonly [RegExp, ExecResult]> = [
 	[COMMENTS, THREE_ROUNDS],
 	[CONFIG, CONFIGURED],
 	[VIEWER, okOut("usirin\n")],
+	[PERMISSION, okOut("admin\n")],
 ];
 
 describe("runClear", () => {
@@ -193,6 +195,7 @@ describe("runClear", () => {
 				],
 				[CONFIG, CONFIGURED],
 				[VIEWER, okOut("usirin\n")],
+				[PERMISSION, okOut("admin\n")],
 				[POST, POSTED(901)],
 				[
 					GET_COMMENT,
@@ -206,5 +209,73 @@ describe("runClear", () => {
 		const parsed = JSON.parse(outcome.stdout);
 		expect(parsed.round).toBe(CAP_ROUND + 1);
 		expect(parsed.cap).toBe(CAP_ROUND + 2);
+	});
+
+	/** A committed set narrows the ACL; it never stands in for one (ADR 0055, ADR 0292). */
+	it("refuses a configured account that resolves below write at the ACL", async () => {
+		const {outcome, calls} = await run([
+			[PULL, pull({number: 4310, base: {ref: "main"}})],
+			[COMMENTS, THREE_ROUNDS],
+			[CONFIG, CONFIGURED],
+			[VIEWER, okOut("usirin\n")],
+			[PERMISSION, okOut("read\n")],
+		]);
+		expect(outcome.code).toBe(GRANT_UNAUTHORIZED);
+		expect(outcome.stderr.at(-1)).toContain("below write");
+		expect(calls.some((line) => /--method POST/.test(line))).toBe(false);
+	});
+
+	it("holds an unreadable permission UNKNOWN rather than granting on the config alone", async () => {
+		const {outcome} = await run([
+			[PULL, pull({number: 4310, base: {ref: "main"}})],
+			[COMMENTS, THREE_ROUNDS],
+			[CONFIG, CONFIGURED],
+			[VIEWER, okOut("usirin\n")],
+			[PERMISSION, {ok: false, stdout: "", reason: "HTTP 502"}],
+		]);
+		expect(outcome.code).toBe(PRECONDITION_UNKNOWN);
+	});
+
+	/**
+	 * Exit 29's own remedy: the marker landed and the lane write did not, so the raised cap is what
+	 * now makes the budget test say "not spent". The re-run must reconcile the lane, not refuse on 7.
+	 */
+	it("reconciles the lane on a re-run for a round already granted, posting nothing", async () => {
+		const {outcome, calls, written} = await run(
+			[
+				[PULL, pull({number: 4310, base: {ref: "main"}})],
+				[
+					COMMENTS,
+					comments(
+						{id: 1, body: `review-code: FAIL @ ${HEAD} — one`, createdAt: "2026-08-18T01:00:00Z"},
+						{id: 2, body: `review-code: FAIL @ ${HEAD} — two`, createdAt: "2026-08-18T02:00:00Z"},
+						{id: 3, body: `review-code: FAIL @ ${HEAD} — three`, createdAt: "2026-08-18T03:00:00Z"},
+						{id: 4, body: AUTHORIZATION, author: "usirin", createdAt: "2026-08-18T03:10:00Z"},
+						{
+							id: 5,
+							body: "cap-cleared: round 3 · 2026-08-18T03:11:00Z",
+							author: "usirin",
+							createdAt: "2026-08-18T03:11:00Z",
+						},
+					),
+				],
+				[CONFIG, CONFIGURED],
+				[VIEWER, okOut("usirin\n")],
+				[PERMISSION, okOut("admin\n")],
+			],
+			{},
+			{[WORKFLOW]: coderTemplateText()},
+		);
+		expect(outcome.code).toBe(0);
+		expect(JSON.parse(outcome.stdout)).toMatchObject({
+			round: CAP_ROUND,
+			marker: 5,
+			authorization: 4,
+			resolvesTo: "reconciled",
+		});
+		expect(calls.some((line) => /--method POST/.test(line))).toBe(false);
+		const compiled = compileText(written.get(WORKFLOW) ?? "");
+		if (compiled._tag !== "Compiled") throw new Error("the lane document did not recompile");
+		expect(compiled.lane.tasks.issue?.initial.maxRetries).toBe(RETRY_BUDGET + 1);
 	});
 });

--- a/packages/fabrika-cli/src/build/clearances.ts
+++ b/packages/fabrika-cli/src/build/clearances.ts
@@ -15,7 +15,7 @@
  * Clause 3 is ADR 0055 applied: the committed file says whom the repo *nominates*, and the ACL says
  * who may actually act, so the two are intersected and a login with no collaboration clears nothing.
  * A committed list alone has no author gate, which is the thing 0055 supersedes 0051 to forbid; ADR
- * 0292 records why the file is nevertheless the place the nomination is written down.
+ * 0294 records why the file is nevertheless the place the nomination is written down.
  *
  * Every miss is a row carrying its reason rather than a dropped marker: an operator who posted a
  * void grant must be able to see it was void, and a silently dropped one reads as a PR nobody ever

--- a/packages/fabrika-cli/src/build/clearances.ts
+++ b/packages/fabrika-cli/src/build/clearances.ts
@@ -1,0 +1,181 @@
+/**
+ * The cleared repair rounds recorded on a PR — the read `build verdicts` folds and `build clear`
+ * re-reads before granting another.
+ *
+ * A `cap-cleared` marker is bytes, and bytes are not authority. A row is **honoured** only when all
+ * three clauses hold, the same conjunctive shape `grill rule` records a ruling under (#4938):
+ *
+ *   1. the marker parses, and names a round at or past the declared cap;
+ *   2. its author is in the repo's `.fabrika.jsonc` grant-author set, read at the PR's **base** ref
+ *      so a PR cannot widen the set that clears its own cap (#981);
+ *   3. a dated authorization comment sits immediately before it, from that same author.
+ *
+ * Every miss is a row carrying its reason rather than a dropped marker: an operator who posted a
+ * void grant must be able to see it was void, and a silently dropped one reads as a PR nobody ever
+ * cleared.
+ *
+ * A read that could not complete — the config, a team's membership — is `Unknown`, never an empty
+ * set. Resolving an unreadable ACL to "nobody granted" would be safe for the budget and wrong for
+ * the answer, and resolving it the other way would hand out authority nobody proved.
+ */
+
+import {Effect} from "effect";
+import type {ChildProcessSpawner} from "effect/unstable/process";
+import type {CommentRecord} from "../io/issues.ts";
+import {CONFIG_PATH, type GrantAuthor, readCapClearAuthors} from "../repo-config.ts";
+import {CAP_ROUND} from "../retry-budget.ts";
+import {listTeamMembers, readFileAtRef} from "../ship/github.ts";
+import {read as readClearance} from "../wire/cap-clearance.ts";
+
+/** Any ISO-8601 date in the quoted authorization — the same dating rule `grill rule` enforces. */
+const ISO_DATE = /\d{4}-\d{2}-\d{2}/;
+
+export interface ClearanceRow {
+	readonly round: number;
+	readonly at: string;
+	readonly by: string;
+	readonly commentId: number;
+	/** The dated authorization comment this grant rests on, or `null` when none was found. */
+	readonly authorization: number | null;
+	/** Whether all three clauses hold. Only an honoured row is budget. */
+	readonly honoured: boolean;
+	/** Why the row is not honoured. Absent on an honoured row. */
+	readonly reason?: string;
+}
+
+export type ClearancesRead =
+	| {readonly _tag: "Rows"; readonly rows: ReadonlyArray<ClearanceRow>}
+	| {readonly _tag: "Unknown"; readonly reason: string};
+
+/** The rounds an honoured row grants — what `../cap-clearance.ts`'s derivations take. */
+export const grantedFrom = (rows: ReadonlyArray<ClearanceRow>): ReadonlyArray<number> =>
+	rows.filter((row) => row.honoured).map((row) => row.round);
+
+export type Membership =
+	| {readonly _tag: "Set"; readonly holds: (login: string) => boolean}
+	| {readonly _tag: "Unusable"; readonly reason: string}
+	| {readonly _tag: "Unknown"; readonly reason: string};
+
+/**
+ * The grant-author set as a predicate, with every team expanded once.
+ *
+ * Teams are resolved eagerly rather than per marker so a PR carrying several markers costs one
+ * membership read per team; a **404 team** is proven to hold nobody, while a failed read is
+ * `Unknown` — the split the whole group rests on.
+ */
+export const membershipAt = (
+	repo: string,
+	baseRef: string,
+): Effect.Effect<Membership, never, ChildProcessSpawner.ChildProcessSpawner> =>
+	Effect.gen(function* () {
+		const file = yield* readFileAtRef(repo, CONFIG_PATH, baseRef);
+		if (file._tag === "Unknown") {
+			return {_tag: "Unknown" as const, reason: `${CONFIG_PATH} at ${baseRef}: ${file.reason}`};
+		}
+		if (file._tag === "Absent") {
+			return {
+				_tag: "Unusable" as const,
+				reason: `${repo} carries no ${CONFIG_PATH} at ${baseRef} — nobody is configured to clear a round`,
+			};
+		}
+		const declared = readCapClearAuthors(file.value);
+		if (declared._tag === "Unusable") return {_tag: "Unusable" as const, reason: declared.reason};
+
+		const logins = new Set<string>();
+		for (const author of declared.authors as ReadonlyArray<GrantAuthor>) {
+			if (author._tag === "User") {
+				logins.add(author.login.toLowerCase());
+				continue;
+			}
+			const members = yield* listTeamMembers(author.org, author.team);
+			if (members._tag === "Unknown") {
+				return {
+					_tag: "Unknown" as const,
+					reason: `@${author.org}/${author.team}'s membership: ${members.reason}`,
+				};
+			}
+			if (members._tag === "Absent") continue;
+			for (const member of members.value) logins.add(member.toLowerCase());
+		}
+		return {
+			_tag: "Set" as const,
+			holds: (login: string) => logins.has(login.trim().toLowerCase()),
+		};
+	});
+
+/** Why this marker is not budget, or `null` when all three clauses hold. */
+const refusalFor = (
+	membership: Exclude<Membership, {readonly _tag: "Unknown"}>,
+	baseRef: string,
+	author: string,
+	round: number,
+	authorization: number | null,
+): string | null => {
+	if (membership._tag === "Unusable") return membership.reason;
+	if (!membership.holds(author)) {
+		return `${author} is not in ${CONFIG_PATH}'s grant-author set at ${baseRef}`;
+	}
+	if (round < CAP_ROUND) {
+		return `round ${round} is below the declared cap of ${CAP_ROUND} — there was no round to clear`;
+	}
+	return authorization === null
+		? "no dated authorization comment precedes the marker — a bare stamp is void (#4938)"
+		: null;
+};
+
+/**
+ * Every cap-clearance recorded on the PR, judged.
+ *
+ * The comments are handed in rather than re-listed: `build verdicts` already holds the full paged
+ * set, and a second read could see a different one — two answers about one PR is exactly the drift
+ * the one-door property exists to remove.
+ */
+export const clearancesOn = (
+	repo: string,
+	baseRef: string,
+	comments: ReadonlyArray<CommentRecord>,
+): Effect.Effect<ClearancesRead, never, ChildProcessSpawner.ChildProcessSpawner> =>
+	Effect.gen(function* () {
+		const marked = comments.flatMap((comment) => {
+			const parsed = readClearance(comment.body);
+			return parsed._tag === "Absent" ? [] : [{comment, parsed}];
+		});
+		if (marked.length === 0) return {_tag: "Rows" as const, rows: []};
+
+		const membership = yield* membershipAt(repo, baseRef);
+		if (membership._tag === "Unknown") {
+			return {_tag: "Unknown" as const, reason: membership.reason};
+		}
+
+		const rows: ClearanceRow[] = [];
+		for (const {comment, parsed} of marked) {
+			const base = {by: comment.author, commentId: comment.id};
+			if (parsed._tag === "Malformed") {
+				rows.push({
+					...base,
+					round: 0,
+					at: comment.createdAt,
+					authorization: null,
+					honoured: false,
+					reason: `the marker is malformed: ${parsed.reason}`,
+				});
+				continue;
+			}
+			const {round, at} = parsed.value;
+			const priorByAuthor = comments
+				.filter((other) => other.id < comment.id && other.author === comment.author)
+				.at(-1);
+			const authorization =
+				priorByAuthor !== undefined && ISO_DATE.test(priorByAuthor.body) ? priorByAuthor.id : null;
+			const reason = refusalFor(membership, baseRef, comment.author, round, authorization);
+			rows.push({
+				...base,
+				round,
+				at,
+				authorization,
+				honoured: reason === null,
+				...(reason === null ? {} : {reason}),
+			});
+		}
+		return {_tag: "Rows" as const, rows};
+	});

--- a/packages/fabrika-cli/src/build/clearances.ts
+++ b/packages/fabrika-cli/src/build/clearances.ts
@@ -3,12 +3,19 @@
  * re-reads before granting another.
  *
  * A `cap-cleared` marker is bytes, and bytes are not authority. A row is **honoured** only when all
- * three clauses hold, the same conjunctive shape `grill rule` records a ruling under (#4938):
+ * four clauses hold, the same conjunctive shape `grill rule` records a ruling under (#4938):
  *
  *   1. the marker parses, and names a round at or past the declared cap;
  *   2. its author is in the repo's `.fabrika.jsonc` grant-author set, read at the PR's **base** ref
  *      so a PR cannot widen the set that clears its own cap (#981);
- *   3. a dated authorization comment sits immediately before it, from that same author.
+ *   3. that same author holds `write+` on the repo, read live from GitHub's ACL;
+ *   4. a dated authorization comment sits immediately before it, from that same author, and is not
+ *      itself a `cap-cleared` marker.
+ *
+ * Clause 3 is ADR 0055 applied: the committed file says whom the repo *nominates*, and the ACL says
+ * who may actually act, so the two are intersected and a login with no collaboration clears nothing.
+ * A committed list alone has no author gate, which is the thing 0055 supersedes 0051 to forbid; ADR
+ * 0292 records why the file is nevertheless the place the nomination is written down.
  *
  * Every miss is a row carrying its reason rather than a dropped marker: an operator who posted a
  * void grant must be able to see it was void, and a silently dropped one reads as a PR nobody ever
@@ -22,6 +29,7 @@
 import {Effect} from "effect";
 import type {ChildProcessSpawner} from "effect/unstable/process";
 import type {CommentRecord} from "../io/issues.ts";
+import {permissionFor} from "../io/pulls.ts";
 import {CONFIG_PATH, type GrantAuthor, readCapClearAuthors} from "../repo-config.ts";
 import {CAP_ROUND} from "../retry-budget.ts";
 import {listTeamMembers, readFileAtRef} from "../ship/github.ts";
@@ -30,6 +38,13 @@ import {read as readClearance} from "../wire/cap-clearance.ts";
 /** Any ISO-8601 date in the quoted authorization — the same dating rule `grill rule` enforces. */
 const ISO_DATE = /\d{4}-\d{2}-\d{2}/;
 
+/** The repository permissions that count as `write+`, the floor every fabrika ACL read stands on. */
+const WRITE_FLOOR: ReadonlySet<string> = new Set(["admin", "maintain", "write"]);
+
+/** Whether a resolved permission level clears the write floor. `null` is no collaboration at all. */
+export const clearsWriteFloor = (level: string | null): boolean =>
+	level !== null && WRITE_FLOOR.has(level);
+
 export interface ClearanceRow {
 	readonly round: number;
 	readonly at: string;
@@ -37,7 +52,7 @@ export interface ClearanceRow {
 	readonly commentId: number;
 	/** The dated authorization comment this grant rests on, or `null` when none was found. */
 	readonly authorization: number | null;
-	/** Whether all three clauses hold. Only an honoured row is budget. */
+	/** Whether all four clauses hold. Only an honoured row is budget. */
 	readonly honoured: boolean;
 	/** Why the row is not honoured. Absent on an honoured row. */
 	readonly reason?: string;
@@ -103,9 +118,61 @@ export const membershipAt = (
 		};
 	});
 
-/** Why this marker is not budget, or `null` when all three clauses hold. */
+export type Permissions =
+	| {readonly _tag: "Levels"; readonly levelOf: (login: string) => string | null}
+	| {readonly _tag: "Unknown"; readonly reason: string};
+
+/**
+ * Each login's live repository permission, read once per distinct login.
+ *
+ * A 404 collaborator is proven to hold nothing and resolves to `null`; a read that failed is
+ * `Unknown`, because "GitHub did not answer" and "this account may not write" are different facts
+ * and only one of them is a refusal.
+ */
+export const permissionsFor = (
+	repo: string,
+	logins: ReadonlyArray<string>,
+): Effect.Effect<Permissions, never, ChildProcessSpawner.ChildProcessSpawner> =>
+	Effect.gen(function* () {
+		const levels = new Map<string, string | null>();
+		for (const login of new Set(logins.map((raw) => raw.trim()))) {
+			const read = yield* permissionFor(repo, login);
+			if (read._tag === "Unknown") {
+				return {
+					_tag: "Unknown" as const,
+					reason: `${login}'s repository permission on ${repo}: ${read.reason}`,
+				};
+			}
+			levels.set(login, read._tag === "Present" ? read.value : null);
+		}
+		return {_tag: "Levels" as const, levelOf: (login: string) => levels.get(login.trim()) ?? null};
+	});
+
+/**
+ * Clause 4: the comment immediately before the marker, from its author, dated, and not itself a
+ * `cap-cleared` marker — `grill rule`'s `adjacentAuthorization` (`../grill/read-verb.ts`), same shape.
+ *
+ * The adjacency and the marker exclusion are one clause and neither is optional. Taking the last
+ * prior comment by that author instead lets a bare second marker rest on the FIRST grant's own
+ * marker — the marker body carries an ISO-8601 date, so it passes the dating test — and every grant
+ * after the first would need no authorization at all, which is the bare stamp #4938 ruled void.
+ */
+const adjacentAuthorization = (
+	comments: ReadonlyArray<CommentRecord>,
+	index: number,
+	author: string,
+): number | null => {
+	const previous = comments[index - 1];
+	if (previous === undefined || previous.author !== author) return null;
+	if (readClearance(previous.body)._tag !== "Absent") return null;
+	return ISO_DATE.test(previous.body) ? previous.id : null;
+};
+
+/** Why this marker is not budget, or `null` when all four clauses hold. */
 const refusalFor = (
 	membership: Exclude<Membership, {readonly _tag: "Unknown"}>,
+	permissions: Extract<Permissions, {readonly _tag: "Levels"}>,
+	repo: string,
 	baseRef: string,
 	author: string,
 	round: number,
@@ -115,11 +182,15 @@ const refusalFor = (
 	if (!membership.holds(author)) {
 		return `${author} is not in ${CONFIG_PATH}'s grant-author set at ${baseRef}`;
 	}
+	const level = permissions.levelOf(author);
+	if (!clearsWriteFloor(level)) {
+		return `${author} resolves to ${level ?? "no collaboration"} on ${repo}, below write — authority is the ACL's, never ${CONFIG_PATH}'s alone (ADR 0055)`;
+	}
 	if (round < CAP_ROUND) {
 		return `round ${round} is below the declared cap of ${CAP_ROUND} — there was no round to clear`;
 	}
 	return authorization === null
-		? "no dated authorization comment precedes the marker — a bare stamp is void (#4938)"
+		? "no dated authorization comment from that author sits immediately before the marker — a bare stamp is void (#4938)"
 		: null;
 };
 
@@ -136,9 +207,9 @@ export const clearancesOn = (
 	comments: ReadonlyArray<CommentRecord>,
 ): Effect.Effect<ClearancesRead, never, ChildProcessSpawner.ChildProcessSpawner> =>
 	Effect.gen(function* () {
-		const marked = comments.flatMap((comment) => {
+		const marked = comments.flatMap((comment, index) => {
 			const parsed = readClearance(comment.body);
-			return parsed._tag === "Absent" ? [] : [{comment, parsed}];
+			return parsed._tag === "Absent" ? [] : [{comment, index, parsed}];
 		});
 		if (marked.length === 0) return {_tag: "Rows" as const, rows: []};
 
@@ -146,9 +217,21 @@ export const clearancesOn = (
 		if (membership._tag === "Unknown") {
 			return {_tag: "Unknown" as const, reason: membership.reason};
 		}
+		// Only the authors the config already names are worth an ACL read: one the file does not name
+		// is refused on that clause alone, and reading it would let a hiccup on an irrelevant login
+		// turn a plainly-void marker into an UNKNOWN fold.
+		const permissions = yield* permissionsFor(
+			repo,
+			membership._tag === "Set"
+				? marked.flatMap(({comment}) => (membership.holds(comment.author) ? [comment.author] : []))
+				: [],
+		);
+		if (permissions._tag === "Unknown") {
+			return {_tag: "Unknown" as const, reason: permissions.reason};
+		}
 
 		const rows: ClearanceRow[] = [];
-		for (const {comment, parsed} of marked) {
+		for (const {comment, index, parsed} of marked) {
 			const base = {by: comment.author, commentId: comment.id};
 			if (parsed._tag === "Malformed") {
 				rows.push({
@@ -162,12 +245,16 @@ export const clearancesOn = (
 				continue;
 			}
 			const {round, at} = parsed.value;
-			const priorByAuthor = comments
-				.filter((other) => other.id < comment.id && other.author === comment.author)
-				.at(-1);
-			const authorization =
-				priorByAuthor !== undefined && ISO_DATE.test(priorByAuthor.body) ? priorByAuthor.id : null;
-			const reason = refusalFor(membership, baseRef, comment.author, round, authorization);
+			const authorization = adjacentAuthorization(comments, index, comment.author);
+			const reason = refusalFor(
+				membership,
+				permissions,
+				repo,
+				baseRef,
+				comment.author,
+				round,
+				authorization,
+			);
 			rows.push({
 				...base,
 				round,

--- a/packages/fabrika-cli/src/build/codes.ts
+++ b/packages/fabrika-cli/src/build/codes.ts
@@ -119,12 +119,15 @@ export const HEAD_DROPS_REMOTE = 23;
  */
 export const COMMIT_NOT_CREATED = 24;
 /**
- * Proven: the invoking account is not in the repo's configured cap-clear grant-author set.
+ * Proven: the invoking account may not clear a cap — outside the configured grant-author set, or
+ * below `write` at the repository ACL.
  *
- * Its own seat rather than a borrowed `21`: that code is about the *issue's* audience label, and
- * this one is about who the repo configured to hold founder authority — the remedies share nothing.
- * It is never {@link PRECONDITION_UNKNOWN}: the config and the memberships were read in full, so the
- * refusal is a fact about the account (#5959).
+ * One seat for both clauses because they answer one question, "may this account grant?", and a
+ * caller's next move is the same either way: get authority, then re-run. Its own seat rather than a
+ * borrowed `21`: that code is about the *issue's* audience label, and this one is about who may hold
+ * founder authority — the remedies share nothing. It is never {@link PRECONDITION_UNKNOWN}: the
+ * config, the memberships and the ACL were read in full, so the refusal is a fact about the account
+ * (#5959; the ACL clause is ADR 0055's).
  */
 export const GRANT_UNAUTHORIZED = 25;
 /** Proven: the quoted authorization is empty or undated — a bare stamp is void (#4938). */

--- a/packages/fabrika-cli/src/build/codes.ts
+++ b/packages/fabrika-cli/src/build/codes.ts
@@ -118,3 +118,25 @@ export const HEAD_DROPS_REMOTE = 23;
  * else (#5484).
  */
 export const COMMIT_NOT_CREATED = 24;
+/**
+ * Proven: the invoking account is not in the repo's configured cap-clear grant-author set.
+ *
+ * Its own seat rather than a borrowed `21`: that code is about the *issue's* audience label, and
+ * this one is about who the repo configured to hold founder authority — the remedies share nothing.
+ * It is never {@link PRECONDITION_UNKNOWN}: the config and the memberships were read in full, so the
+ * refusal is a fact about the account (#5959).
+ */
+export const GRANT_UNAUTHORIZED = 25;
+/** Proven: the quoted authorization is empty or undated — a bare stamp is void (#4938). */
+export const AUTHORIZATION_VOID = 26;
+/**
+ * Proven: the grant is recorded on the PR and the local lane did not take it.
+ *
+ * Never {@link WRITE_UNKNOWN}: the remote half landed and read back, so the outcome is known and
+ * partial. The lane freezes a round early until a re-run reconciles it, which is the conservative
+ * direction and a state an operator must be able to see rather than infer.
+ *
+ * `27` and `28` are the base's (`QUEUE_UNREADABLE`, `SEARCH_UNREADABLE`), so the next free seat is
+ * `29` — a group never re-uses a number the base already spoke for.
+ */
+export const LOCAL_LANE_UNWRITTEN = 29;

--- a/packages/fabrika-cli/src/build/command.ts
+++ b/packages/fabrika-cli/src/build/command.ts
@@ -14,14 +14,17 @@
  */
 import {randomUUID} from "node:crypto";
 import {tmpdir} from "node:os";
-import {Effect, Option} from "effect";
+import {Effect, type FileSystem, Option, Result} from "effect";
 import {Argument, Command, Flag} from "effect/unstable/cli";
 import {leafCommand} from "../excess-operand.ts";
+import {readFile} from "../io/fs.ts";
 import {readStdin} from "../io/stdin.ts";
+import {DEFAULT_LANES_ROOT} from "../lane/store.ts";
 import type {VerbOutcome} from "../verb.ts";
 import {runBranch} from "./branch-verb.ts";
 import {runCheck} from "./check-verb.ts";
 import {runClaim, runConfirm, runRelease} from "./claim-verb.ts";
+import {type DocumentRead, runClear} from "./clear-verb.ts";
 import {runCommit} from "./commit-verb.ts";
 import {runEligible} from "./eligible-verb.ts";
 import {runIssue} from "./issue-verb.ts";
@@ -440,6 +443,59 @@ const verdicts = leafCommand(
 	),
 );
 
+/** A file the adapter reads for a verb, so the verb itself touches no filesystem for it. */
+const document = (path: string): Effect.Effect<DocumentRead, never, FileSystem.FileSystem> =>
+	Effect.gen(function* () {
+		const read = yield* Effect.result(readFile(path));
+		return Result.isFailure(read)
+			? ({_tag: "Failed", reason: read.failure.reason} satisfies DocumentRead)
+			: ({_tag: "Text", text: read.success} satisfies DocumentRead);
+	});
+
+const clear = leafCommand(
+	"clear",
+	{
+		pr: Flag.integer("pr").pipe(
+			Flag.withDescription("the pull request whose repair budget the founder cleared a round on"),
+		),
+		authorization: Flag.string("authorization").pipe(
+			Flag.withDescription(
+				"a file quoting the founder's authorization verbatim, carrying an ISO-8601 date; posted as an adjacent comment, never summarized",
+			),
+		),
+		laneRoot: Flag.string("lane-root").pipe(
+			Flag.optional,
+			Flag.withDescription(
+				`the lanes root the local grant is recorded in (default: ${DEFAULT_LANES_ROOT})`,
+			),
+		),
+		task: Flag.string("task").pipe(
+			Flag.optional,
+			Flag.withDescription("the lane task the grant addresses; omittable on a single-task lane"),
+		),
+		repo: repoFlag,
+	},
+	Effect.fn(function* ({pr, authorization, laneRoot, task, repo}) {
+		yield* emit(
+			yield* runClear({
+				pr,
+				authorizationPath: authorization,
+				authorization: document(authorization),
+				laneRoot: Option.getOrNull(laneRoot),
+				task: Option.getOrNull(task),
+				repo: Option.getOrNull(repo),
+				env: process.env,
+				now: () => new Date(),
+			}),
+		);
+	}),
+).pipe(
+	Command.withShortDescription("Record the founder's clearance of one extra repair round."),
+	Command.withDescription(
+		'Record one founder-cleared repair round on a PR, refusing without a verbatim dated authorization and an invoking account inside `.fabrika.jsonc`\'s `capClearAuthors` at the PR\'s base ref. Writes the authorization comment FIRST, the `cap-cleared` marker second, then carries the grant into the local lane so `build verdicts` and the lane guard spend the same round. One grant buys exactly the round it names: it survives the push it permits and expires when the next FAIL round lands. Prints {"pr":n,"round":n,"at":"…","by":"…","authorization":n,"marker":n,"cap":n,"lane":"…","resolvesTo":"cleared"}. Exits 5 (machine-local path), 6 (bare @ reference), 7 (PR proven absent or closed, or the budget is not spent — there is no round to clear), 8 (a write failed — UNKNOWN), 9 (read-back mismatch), 11 (a precondition read failed), 25 (the invoking account may not clear a round here), 26 (--authorization missing, empty or undated), 29 (recorded on the PR, and the local lane did not take it — re-run to reconcile). Example: fabrika build clear --pr 5953 --authorization authorization.md',
+	),
+);
+
 export const buildCommand = Command.make("build").pipe(
 	Command.withSubcommands([
 		// One leaf per line, so concurrent slices append at distinct lines rather than all editing one.
@@ -458,6 +514,7 @@ export const buildCommand = Command.make("build").pipe(
 		pr,
 		note,
 		verdicts,
+		clear,
 	]),
 	Command.withShortDescription("Drive one construction lane from issue pick to open PR."),
 	Command.withDescription(

--- a/packages/fabrika-cli/src/build/verdicts-verb.ts
+++ b/packages/fabrika-cli/src/build/verdicts-verb.ts
@@ -11,17 +11,23 @@
  * - **An unreadable page is `11`, never a shorter list.** `{"rows": []}` on exit 0 is a proven "no
  *   verdicts", readable against the scope line's counts (ADR 0092, #4208 / #4219).
  *
+ * - **`capReached` is the declared cap plus what the founder cleared, never a second constant.** A
+ *   recorded clearance (`./clearances.ts`) buys the one round it names, so the field the Repair
+ *   section tells a builder to trust stays the only budget number anyone reads (#5959).
+ *
  * Every row's `body` is the finding's full text through the content gate — the repair loop consumes
  * findings from here and never raw-fetches a comment, which is what keeps the one-door property over
  * the repair path.
  */
 import {Effect} from "effect";
 import type {ChildProcessSpawner} from "effect/unstable/process";
+import {capReached, effectiveCap, grantedRounds} from "../cap-clearance.ts";
 import {getIssue, listComments} from "../io/issues.ts";
 import {CAP_ROUND} from "../retry-budget.ts";
 import {answer, refuse, type VerbOutcome} from "../verb.ts";
 import {read as readCriteria} from "../wire/acceptance-criteria.ts";
 import {bindToHead, read as readMarker} from "../wire/verdict-marker.ts";
+import {clearancesOn, grantedFrom} from "./clearances.ts";
 import {PRECONDITION_UNKNOWN} from "./codes.ts";
 import {contentOf, gate} from "./content-gate.ts";
 import {listReviews} from "./github.ts";
@@ -118,6 +124,13 @@ export const runVerdicts = (
 		}
 
 		const rounds = countRounds(failedAt);
+		const cleared = yield* clearancesOn(repo, target.pull.baseRef, listed.value);
+		if (cleared._tag === "Unknown") {
+			return refuse(
+				PRECONDITION_UNKNOWN,
+				`${VERB}: cannot read the recorded cap clearances: ${cleared.reason} — whether the budget is spent is UNKNOWN, never "capped".`,
+			);
+		}
 		const frozen = yield* frozenCriteria(repo, pr, target.pull.body);
 		if (frozen._tag === "Unknown") {
 			return refuse(
@@ -126,16 +139,19 @@ export const runVerdicts = (
 			);
 		}
 
+		const granted = grantedFrom(cleared.rows);
 		return answer(
 			JSON.stringify({
 				head,
 				rows,
 				rounds,
-				capReached: rounds >= CAP_ROUND,
+				capReached: capReached(rounds, granted),
+				clearances: cleared.rows,
 				frozenCriteria: frozen.rows,
 			}),
 			[
 				`${VERB}: head ${head}; scanned ${listed.value.length} comment(s) and ${reviews.value.length} review(s) on #${pr}.`,
+				`${VERB}: cap ${effectiveCap(granted)} = ${CAP_ROUND} declared + ${grantedRounds(granted)} cleared round(s), from ${cleared.rows.length} marker(s).`,
 			],
 		);
 	});

--- a/packages/fabrika-cli/src/build/verdicts-verb.unit.test.ts
+++ b/packages/fabrika-cli/src/build/verdicts-verb.unit.test.ts
@@ -187,6 +187,8 @@ describe("runVerdicts", () => {
 		const CONFIG =
 			/^gh api -H Accept: application\/vnd\.github\.raw repos\/o\/r\/contents\/\.fabrika\.jsonc\?ref=main$/;
 		const CONFIGURED = okOut('{"capClearAuthors": ["@usirin"]}');
+		const PERMISSION = /^gh api repos\/o\/r\/collaborators\/usirin\/permission/;
+		const WRITES = okOut("admin\n");
 		const AUTHORIZATION = 'Founder ruling 2026-08-18: "one more round."';
 		const CAPPED = [
 			{id: 1, body: `review-code: FAIL @ ${HEAD} — one`, createdAt: "2026-08-18T01:00:00Z"},
@@ -220,6 +222,7 @@ describe("runVerdicts", () => {
 				[PULL, PR_ON_MAIN],
 				[COMMENTS, comments(...CAPPED, ...GRANT)],
 				[CONFIG, CONFIGURED],
+				[PERMISSION, WRITES],
 				[REVIEWS, NO_REVIEWS],
 				[ISSUE, issue()],
 			]);
@@ -241,12 +244,76 @@ describe("runVerdicts", () => {
 					}),
 				],
 				[CONFIG, CONFIGURED],
+				[PERMISSION, WRITES],
 				[REVIEWS, NO_REVIEWS],
 				[ISSUE, issue()],
 			]);
 			const parsed = JSON.parse(out.stdout);
 			expect(parsed.rounds).toBe(4);
 			expect(parsed.capReached).toBe(true);
+		});
+
+		/**
+		 * The bare second stamp: without the adjacency clause the read takes the last prior comment
+		 * by that author — grant #1's own marker, which carries an ISO date — and every grant after
+		 * the first is authorized by nothing (#4938).
+		 */
+		it("refuses a second marker whose only precedent is the first grant's marker", async () => {
+			const out = await run([
+				[PULL, PR_ON_MAIN],
+				[
+					COMMENTS,
+					comments(
+						...CAPPED,
+						...GRANT,
+						{id: 6, body: `review-code: FAIL @ ${HEAD} — four`, createdAt: "2026-08-18T04:00:00Z"},
+						{
+							id: 7,
+							body: "cap-cleared: round 4 · 2026-08-18T05:00:00Z",
+							author: "usirin",
+							createdAt: "2026-08-18T05:00:00Z",
+						},
+					),
+				],
+				[CONFIG, CONFIGURED],
+				[PERMISSION, WRITES],
+				[REVIEWS, NO_REVIEWS],
+				[ISSUE, issue()],
+			]);
+			const parsed = JSON.parse(out.stdout);
+			const bare = parsed.clearances.find((row: {round: number}) => row.round === 4);
+			expect(bare).toMatchObject({honoured: false, authorization: null});
+			expect(bare.reason).toContain("immediately before");
+			expect(parsed.capReached).toBe(true);
+		});
+
+		/** A committed set narrows the ACL; it never stands in for one (ADR 0055, ADR 0292). */
+		it("refuses a configured author who resolves below write at the ACL", async () => {
+			const out = await run([
+				[PULL, PR_ON_MAIN],
+				[COMMENTS, comments(...CAPPED, ...GRANT)],
+				[CONFIG, CONFIGURED],
+				[PERMISSION, okOut("read\n")],
+				[REVIEWS, NO_REVIEWS],
+				[ISSUE, issue()],
+			]);
+			const parsed = JSON.parse(out.stdout);
+			expect(parsed.capReached).toBe(true);
+			expect(parsed.clearances[0]).toMatchObject({honoured: false});
+			expect(parsed.clearances[0].reason).toContain("below write");
+		});
+
+		it("holds the fold UNKNOWN when a configured author's permission cannot be read", async () => {
+			const out = await run([
+				[PULL, PR_ON_MAIN],
+				[COMMENTS, comments(...CAPPED, ...GRANT)],
+				[CONFIG, CONFIGURED],
+				[PERMISSION, errOut("gh: Bad gateway (HTTP 502)")],
+				[REVIEWS, NO_REVIEWS],
+				[ISSUE, issue()],
+			]);
+			expect(out.code).toBe(PRECONDITION_UNKNOWN);
+			expect(out.stdout).toBe("");
 		});
 
 		it("keeps an unauthorized marker visible as a refused row, never as budget", async () => {

--- a/packages/fabrika-cli/src/build/verdicts-verb.unit.test.ts
+++ b/packages/fabrika-cli/src/build/verdicts-verb.unit.test.ts
@@ -287,7 +287,7 @@ describe("runVerdicts", () => {
 			expect(parsed.capReached).toBe(true);
 		});
 
-		/** A committed set narrows the ACL; it never stands in for one (ADR 0055, ADR 0292). */
+		/** A committed set narrows the ACL; it never stands in for one (ADR 0055, ADR 0294). */
 		it("refuses a configured author who resolves below write at the ACL", async () => {
 			const out = await run([
 				[PULL, PR_ON_MAIN],

--- a/packages/fabrika-cli/src/build/verdicts-verb.unit.test.ts
+++ b/packages/fabrika-cli/src/build/verdicts-verb.unit.test.ts
@@ -16,6 +16,11 @@ const PASS_STALE = `review-doc: PASS @ ${OLD_HEAD} — guide matches shipped beh
 
 const NO_REVIEWS = okOut("[]");
 const PR = pull({number: 4310, body: "Fixes #4312\n\n## Deviations\nNone.\n"});
+const PR_ON_MAIN = pull({
+	number: 4310,
+	body: "Fixes #4312\n\n## Deviations\nNone.\n",
+	base: {ref: "main"},
+});
 
 const options = {
 	pr: 4310,
@@ -137,7 +142,8 @@ describe("runVerdicts", () => {
 		const parsed = JSON.parse(out.stdout);
 		expect(parsed.rows).toEqual([]);
 		expect(parsed.rounds).toBe(0);
-		expect(out.stderr.at(-1)).toContain("scanned 1 comment(s) and 0 review(s)");
+		expect(out.stderr.join("\n")).toContain("scanned 1 comment(s) and 0 review(s)");
+		expect(out.stderr.at(-1)).toContain("cap 3 = 3 declared + 0 cleared round(s)");
 	});
 
 	it("refuses a proven-absent PR on 7", async () => {
@@ -176,5 +182,105 @@ describe("runVerdicts", () => {
 		expect(shell.calls.filter((line) => line.includes("--paginate")).length).toBeGreaterThanOrEqual(
 			2,
 		);
+	});
+	describe("the founder's cleared rounds", () => {
+		const CONFIG =
+			/^gh api -H Accept: application\/vnd\.github\.raw repos\/o\/r\/contents\/\.fabrika\.jsonc\?ref=main$/;
+		const CONFIGURED = okOut('{"capClearAuthors": ["@usirin"]}');
+		const AUTHORIZATION = 'Founder ruling 2026-08-18: "one more round."';
+		const CAPPED = [
+			{id: 1, body: `review-code: FAIL @ ${HEAD} — one`, createdAt: "2026-08-18T01:00:00Z"},
+			{id: 2, body: `review-code: FAIL @ ${HEAD} — two`, createdAt: "2026-08-18T02:00:00Z"},
+			{id: 3, body: `review-code: FAIL @ ${HEAD} — three`, createdAt: "2026-08-18T03:00:00Z"},
+		];
+		const GRANT = [
+			{id: 4, body: AUTHORIZATION, author: "usirin", createdAt: "2026-08-18T03:10:00Z"},
+			{
+				id: 5,
+				body: "cap-cleared: round 3 · 2026-08-18T03:11:00Z",
+				author: "usirin",
+				createdAt: "2026-08-18T03:11:00Z",
+			},
+		];
+
+		it("caps the loop at the declared round when nothing is cleared", async () => {
+			const out = await run([
+				[PULL, PR_ON_MAIN],
+				[COMMENTS, comments(...CAPPED)],
+				[REVIEWS, NO_REVIEWS],
+				[ISSUE, issue()],
+			]);
+			const parsed = JSON.parse(out.stdout);
+			expect(parsed.rounds).toBe(3);
+			expect(parsed.capReached).toBe(true);
+		});
+
+		it("folds an honoured clearance as budget, so the granted round proceeds", async () => {
+			const out = await run([
+				[PULL, PR_ON_MAIN],
+				[COMMENTS, comments(...CAPPED, ...GRANT)],
+				[CONFIG, CONFIGURED],
+				[REVIEWS, NO_REVIEWS],
+				[ISSUE, issue()],
+			]);
+			const parsed = JSON.parse(out.stdout);
+			expect(parsed.capReached).toBe(false);
+			expect(parsed.clearances).toHaveLength(1);
+			expect(parsed.clearances[0]).toMatchObject({round: 3, by: "usirin", honoured: true});
+		});
+
+		it("spends the grant on the next round — it never re-arms", async () => {
+			const out = await run([
+				[PULL, PR_ON_MAIN],
+				[
+					COMMENTS,
+					comments(...CAPPED, ...GRANT, {
+						id: 6,
+						body: `review-code: FAIL @ ${HEAD} — four`,
+						createdAt: "2026-08-18T04:00:00Z",
+					}),
+				],
+				[CONFIG, CONFIGURED],
+				[REVIEWS, NO_REVIEWS],
+				[ISSUE, issue()],
+			]);
+			const parsed = JSON.parse(out.stdout);
+			expect(parsed.rounds).toBe(4);
+			expect(parsed.capReached).toBe(true);
+		});
+
+		it("keeps an unauthorized marker visible as a refused row, never as budget", async () => {
+			const out = await run([
+				[PULL, PR_ON_MAIN],
+				[
+					COMMENTS,
+					comments(...CAPPED, {
+						id: 5,
+						body: "cap-cleared: round 3 · 2026-08-18T03:11:00Z",
+						author: "an-agent",
+						createdAt: "2026-08-18T03:11:00Z",
+					}),
+				],
+				[CONFIG, CONFIGURED],
+				[REVIEWS, NO_REVIEWS],
+				[ISSUE, issue()],
+			]);
+			const parsed = JSON.parse(out.stdout);
+			expect(parsed.capReached).toBe(true);
+			expect(parsed.clearances[0]).toMatchObject({honoured: false});
+			expect(parsed.clearances[0].reason).toContain("grant-author set");
+		});
+
+		it("holds the whole fold UNKNOWN when the grant-author set cannot be read", async () => {
+			const out = await run([
+				[PULL, PR_ON_MAIN],
+				[COMMENTS, comments(...CAPPED, ...GRANT)],
+				[CONFIG, errOut("gh: Bad gateway (HTTP 502)")],
+				[REVIEWS, NO_REVIEWS],
+				[ISSUE, issue()],
+			]);
+			expect(out.code).toBe(PRECONDITION_UNKNOWN);
+			expect(out.stdout).toBe("");
+		});
 	});
 });

--- a/packages/fabrika-cli/src/cap-clearance.ts
+++ b/packages/fabrika-cli/src/cap-clearance.ts
@@ -1,0 +1,43 @@
+/**
+ * The cleared repair round — one founder grant, one extra round, on top of the one declared budget.
+ *
+ * The cap in `./retry-budget.ts` is enforced in two places that never see each other: `build
+ * verdicts` folds `capReached` off the FAIL-marker round count, and the lane machine guards each
+ * task with `retries < maxRetries`. A founder clearance used to live only as issue prose, so the
+ * round it granted could only land as an edit outside the loop (#5959). This module is the one
+ * derivation both readers apply, so a PR read through `build verdicts` and the same PR driven by a
+ * lane cannot disagree about whether the loop still has budget.
+ *
+ * **A grant is keyed by the round it clears, which is what makes it spendable exactly once.** A
+ * clearance recorded at round N raises the cap to N+1, so the round it was issued for proceeds; the
+ * moment another FAIL lands the count is N+1 and the cap is spent again. Binding the round rather
+ * than the head SHA is deliberate — a clearance exists precisely so a *new* head can be pushed, so a
+ * head-bound grant would be void the instant it was used.
+ *
+ * A round below {@link CAP_ROUND} is never counted. Nothing can be cleared before the budget is
+ * spent, so such a marker is either hand-written or from a drifted writer, and counting it would
+ * silently widen the cap by a round nobody granted.
+ */
+
+import {CAP_ROUND, RETRY_BUDGET} from "./retry-budget.ts";
+
+/**
+ * How many extra rounds a set of recorded clearances buys.
+ *
+ * Distinct rounds, not markers: two clearances stamped at the same round clear the same round, so a
+ * double-posted grant — a re-run, a reconciled write — can never buy two.
+ */
+export const grantedRounds = (cleared: ReadonlyArray<number>): number =>
+	new Set(cleared.filter((round) => Number.isInteger(round) && round >= CAP_ROUND)).size;
+
+/** The round the loop freezes at, given what has been cleared. {@link CAP_ROUND} plus the grants. */
+export const effectiveCap = (cleared: ReadonlyArray<number>): number =>
+	CAP_ROUND + grantedRounds(cleared);
+
+/** The retries a lane task holds, given what has been cleared. {@link RETRY_BUDGET} plus the grants. */
+export const effectiveBudget = (cleared: ReadonlyArray<number>): number =>
+	RETRY_BUDGET + grantedRounds(cleared);
+
+/** Whether the repair loop is out of budget — the one field `build`'s Repair section trusts. */
+export const capReached = (rounds: number, cleared: ReadonlyArray<number>): boolean =>
+	rounds >= effectiveCap(cleared);

--- a/packages/fabrika-cli/src/cap-clearance.unit.test.ts
+++ b/packages/fabrika-cli/src/cap-clearance.unit.test.ts
@@ -1,0 +1,64 @@
+import {describe, expect, it} from "vitest";
+import {capReached, effectiveBudget, effectiveCap, grantedRounds} from "./cap-clearance.ts";
+import {CAP_ROUND, RETRY_BUDGET} from "./retry-budget.ts";
+
+describe("grantedRounds", () => {
+	it("counts distinct rounds, so a double-posted grant buys one round and not two", () => {
+		expect(grantedRounds([CAP_ROUND, CAP_ROUND])).toBe(1);
+		expect(grantedRounds([CAP_ROUND, CAP_ROUND + 1])).toBe(2);
+	});
+
+	it("ignores a round below the declared cap — nothing can be cleared before it is spent", () => {
+		expect(grantedRounds([CAP_ROUND - 1])).toBe(0);
+		expect(grantedRounds([0, -1, 1.5])).toBe(0);
+	});
+
+	it("is zero on no grants, which is the only way the cap stays the declared one", () => {
+		expect(effectiveCap([])).toBe(CAP_ROUND);
+		expect(effectiveBudget([])).toBe(RETRY_BUDGET);
+	});
+});
+
+describe("capReached", () => {
+	it("caps at the declared round with nothing cleared", () => {
+		expect(capReached(CAP_ROUND - 1, [])).toBe(false);
+		expect(capReached(CAP_ROUND, [])).toBe(true);
+	});
+
+	/** The whole point of the grant: the round it was issued at proceeds. */
+	it("lets the cleared round through", () => {
+		expect(capReached(CAP_ROUND, [CAP_ROUND])).toBe(false);
+	});
+
+	/**
+	 * A clearance binds the round, not the head, so the push it exists to permit does not spend it —
+	 * only another FAIL round does, and then it does not re-arm.
+	 */
+	it("spends the grant on the next round and never re-arms", () => {
+		expect(capReached(CAP_ROUND + 1, [CAP_ROUND])).toBe(true);
+		expect(capReached(CAP_ROUND + 1, [CAP_ROUND, CAP_ROUND + 1])).toBe(false);
+		expect(capReached(CAP_ROUND + 2, [CAP_ROUND, CAP_ROUND + 1])).toBe(true);
+	});
+});
+
+/**
+ * The two enforcement sites must spend one grant identically, which is the defect #5959 names: a
+ * lane-driven repair froze while `build verdicts` said the budget remained. The lane's guard fires
+ * on the Nth FAIL when `retries` has reached `maxRetries`, and `retries` at that moment is the round
+ * count minus one — so the two agree exactly when `effectiveBudget` and `effectiveCap` move together.
+ */
+describe("the lane guard and the verdict fold spend the same grant", () => {
+	const laneFreezes = (rounds: number, cleared: ReadonlyArray<number>): boolean =>
+		rounds - 1 >= effectiveBudget(cleared);
+
+	it.each([
+		{rounds: CAP_ROUND - 1, cleared: []},
+		{rounds: CAP_ROUND, cleared: []},
+		{rounds: CAP_ROUND, cleared: [CAP_ROUND]},
+		{rounds: CAP_ROUND + 1, cleared: [CAP_ROUND]},
+		{rounds: CAP_ROUND + 1, cleared: [CAP_ROUND, CAP_ROUND + 1]},
+		{rounds: CAP_ROUND + 2, cleared: [CAP_ROUND, CAP_ROUND + 1]},
+	])("agrees at $rounds round(s) with $cleared cleared", ({rounds, cleared}) => {
+		expect(laneFreezes(rounds, cleared)).toBe(capReached(rounds, cleared));
+	});
+});

--- a/packages/fabrika-cli/src/lane/clearance.ts
+++ b/packages/fabrika-cli/src/lane/clearance.ts
@@ -1,0 +1,88 @@
+/**
+ * Recording a founder-cleared round into a lane's own machine document.
+ *
+ * The clearance itself lives on the PR, where it is audited (`../build/clearances.ts`). This is the
+ * local half: the lane's `retriesRemaining` guard reads `retries < maxRetries` out of the compiled
+ * context, so a lane that never heard about the grant freezes the same repair `build verdicts` says
+ * still has budget. Writing the granted round into the task's `clearedRounds` is what keeps the two
+ * readers on one derivation (`../cap-clearance.ts`).
+ *
+ * **Set semantics, so a re-run buys nothing.** The round is added only when it is not already
+ * there, which makes reconciling an interrupted grant safe: the operator re-runs the verb and the
+ * budget is the same as if it had landed the first time.
+ */
+
+import {Effect, type FileSystem, Path, Result} from "effect";
+import {readFile, writeFile} from "../io/fs.ts";
+import {isRecord, parseJson} from "../io/json.ts";
+import type {LaneRef} from "./store.ts";
+
+export type Recorded =
+	| {readonly _tag: "Recorded"; readonly task: string; readonly path: string}
+	| {readonly _tag: "AlreadyHeld"; readonly task: string; readonly path: string}
+	/** No lane at this ref — nothing local can trip, so this is an answer, not a fault. */
+	| {readonly _tag: "NoLane"; readonly dir: string}
+	| {readonly _tag: "Unusable"; readonly path: string; readonly reason: string};
+
+/** Add one cleared round to a lane task's context. Every refusal names the document it read. */
+export const recordClearedRound = (
+	ref: LaneRef,
+	task: string | null,
+	round: number,
+): Effect.Effect<Recorded, never, FileSystem.FileSystem | Path.Path> =>
+	Effect.gen(function* () {
+		const path = yield* Path.Path;
+		const dir = path.join(ref.root, ref.lane);
+		const workflowPath = path.join(dir, "workflow.json");
+		const text = yield* Effect.result(readFile(workflowPath));
+		if (Result.isFailure(text)) return {_tag: "NoLane" as const, dir};
+
+		const parsed = parseJson(text.success);
+		if (parsed === null) {
+			return {_tag: "Unusable" as const, path: workflowPath, reason: "the document is not JSON"};
+		}
+		const machine = isRecord(parsed) ? parsed.machine : undefined;
+		const context = isRecord(machine) && isRecord(machine.context) ? machine.context : undefined;
+		if (context === undefined) {
+			return {
+				_tag: "Unusable" as const,
+				path: workflowPath,
+				reason: "the document carries no `machine.context` to record the grant in",
+			};
+		}
+		const ids = Object.keys(context);
+		const only = ids.length === 1 ? ids[0] : undefined;
+		const taskId = task ?? only;
+		if (taskId === undefined || context[taskId] === undefined) {
+			return {
+				_tag: "Unusable" as const,
+				path: workflowPath,
+				reason:
+					task === null
+						? `--task is required on a lane with ${ids.length} tasks (${ids.join(", ")})`
+						: `task "${task}" is not in this lane's machine (tasks: ${ids.join(", ")})`,
+			};
+		}
+
+		const entry = context[taskId];
+		if (!isRecord(entry)) {
+			return {
+				_tag: "Unusable" as const,
+				path: workflowPath,
+				reason: `task "${taskId}"'s context entry is not an object`,
+			};
+		}
+		const held = Array.isArray(entry.clearedRounds)
+			? entry.clearedRounds.filter((value): value is number => typeof value === "number")
+			: [];
+		if (held.includes(round)) {
+			return {_tag: "AlreadyHeld" as const, task: taskId, path: workflowPath};
+		}
+		context[taskId] = {...entry, clearedRounds: [...held, round].sort((a, b) => a - b)};
+		const wrote = yield* Effect.result(
+			writeFile(workflowPath, `${JSON.stringify(parsed, null, "\t")}\n`),
+		);
+		return Result.isFailure(wrote)
+			? ({_tag: "Unusable", path: workflowPath, reason: wrote.failure.reason} as const)
+			: ({_tag: "Recorded", task: taskId, path: workflowPath} as const);
+	});

--- a/packages/fabrika-cli/src/lane/clearance.unit.test.ts
+++ b/packages/fabrika-cli/src/lane/clearance.unit.test.ts
@@ -1,0 +1,67 @@
+import {Effect} from "effect";
+import {describe, expect, it} from "vitest";
+import {fakeFs} from "../fakes.test-support.ts";
+import {RETRY_BUDGET} from "../retry-budget.ts";
+import {recordClearedRound} from "./clearance.ts";
+import {coderTemplateText} from "./fixtures.test-support.ts";
+import {compileText} from "./machine.ts";
+
+const ROOT = ".fabrika/lanes";
+const WORKFLOW = `${ROOT}/5959/workflow.json`;
+const REF = {root: ROOT, lane: "5959"};
+
+const run = (files: Record<string, string | null>, task: string | null, round: number) => {
+	const fs = fakeFs({files});
+	return Effect.runPromise(
+		Effect.provide(recordClearedRound(REF, task, round), fs.layer).pipe(
+			Effect.map((result) => ({result, written: fs.written})),
+		),
+	);
+};
+
+describe("recordClearedRound", () => {
+	it("writes the round into the task's context, so the guard reads a budget of one more", async () => {
+		const {result, written} = await run({[WORKFLOW]: coderTemplateText()}, null, 3);
+		expect(result._tag).toBe("Recorded");
+		const text = written.get(WORKFLOW) ?? "";
+		const compiled = compileText(text);
+		if (compiled._tag !== "Compiled") throw new Error(compiled.defects.join("; "));
+		expect(compiled.lane.tasks.issue?.initial.maxRetries).toBe(RETRY_BUDGET + 1);
+		expect(compiled.lane.tasks.issue?.extras.clearedRounds).toEqual([3]);
+	});
+
+	it("is a set, so re-running the same grant leaves the budget where it was", async () => {
+		const {written} = await run({[WORKFLOW]: coderTemplateText()}, null, 3);
+		const {result, written: again} = await run({[WORKFLOW]: written.get(WORKFLOW) ?? ""}, null, 3);
+		expect(result._tag).toBe("AlreadyHeld");
+		expect(again.size).toBe(0);
+	});
+
+	it("stacks two distinct rounds, each buying exactly one", async () => {
+		const {written} = await run({[WORKFLOW]: coderTemplateText()}, null, 3);
+		const {written: again} = await run({[WORKFLOW]: written.get(WORKFLOW) ?? ""}, null, 4);
+		const compiled = compileText(again.get(WORKFLOW) ?? "");
+		if (compiled._tag !== "Compiled") throw new Error(compiled.defects.join("; "));
+		expect(compiled.lane.tasks.issue?.initial.maxRetries).toBe(RETRY_BUDGET + 2);
+	});
+
+	it("answers NoLane rather than failing when there is no lane on this machine", async () => {
+		const {result, written} = await run({}, null, 3);
+		expect(result._tag).toBe("NoLane");
+		expect(written.size).toBe(0);
+	});
+
+	it("refuses an unnamed task on a multi-task lane rather than guessing which one", async () => {
+		const document = JSON.stringify({
+			machine: {context: {issue_1: {retries: 0}, issue_2: {retries: 0}}},
+		});
+		const {result, written} = await run({[WORKFLOW]: document}, null, 3);
+		expect(result).toMatchObject({_tag: "Unusable"});
+		expect(written.size).toBe(0);
+	});
+
+	it("refuses a task the machine does not hold", async () => {
+		const {result} = await run({[WORKFLOW]: coderTemplateText()}, "issue_9", 3);
+		expect(result).toMatchObject({_tag: "Unusable"});
+	});
+});

--- a/packages/fabrika-cli/src/lane/machine.ts
+++ b/packages/fabrika-cli/src/lane/machine.ts
@@ -20,6 +20,7 @@
  */
 import type {Machine} from "@demlik/tea";
 import {defineMachine} from "@demlik/tea";
+import {grantedRounds} from "../cap-clearance.ts";
 import {RETRY_BUDGET} from "../retry-budget.ts";
 
 /** The operator's whole event vocabulary — the six, closed (#5570 founder session, 2026-08-15). */
@@ -172,7 +173,13 @@ const compileRegion = (taskId: string, region: unknown, context: unknown): Regio
 	if (defects.length > 0) return {defects};
 
 	const ctx = isRecord(context) ? context : {};
-	const maxRetries = typeof ctx.maxRetries === "number" ? ctx.maxRetries : RETRY_BUDGET;
+	const declared = typeof ctx.maxRetries === "number" ? ctx.maxRetries : RETRY_BUDGET;
+	// The founder's cleared rounds are additive on the declared budget, so the lane guard and
+	// `build verdicts`'s `capReached` spend the same grant — see `../cap-clearance.ts` (#5959).
+	const cleared = Array.isArray(ctx.clearedRounds)
+		? ctx.clearedRounds.filter((round): round is number => typeof round === "number")
+		: [];
+	const maxRetries = declared + grantedRounds(cleared);
 	const {maxRetries: _max, retries: _retries, ...extras} = ctx;
 	const initial: TaskState = {type: initialState, retries: 0, maxRetries};
 	// The Transitions mapped type demands a cell for every (state × msg) pair; a lane machine is

--- a/packages/fabrika-cli/src/repo-config.ts
+++ b/packages/fabrika-cli/src/repo-config.ts
@@ -1,0 +1,127 @@
+/**
+ * The repo's own fabrika configuration — `.fabrika.jsonc` at the repository root.
+ *
+ * Today it answers exactly one question: **who may clear a repair round** (#5959, ruled 2026-08-18
+ * — "'founder' concept can change repo by repo, let's make it a configuration? it can be an array
+ * of github usernames and github teams"). The file is the home epic #5631 names for every value
+ * that is a literal in source today; this module opens it for the one key that has a ruling and
+ * leaves the rest of the surface to that epic.
+ *
+ * **Fail-closed on every axis.** An absent file, an absent key, an empty array and a malformed
+ * entry all resolve to *nobody may grant* rather than to a default set — a config that silently
+ * widened who holds founder authority is the one failure this key cannot have. A read that failed
+ * resolves to neither: it is UNKNOWN, and the caller refuses on it.
+ */
+
+import {isRecord, parseJson} from "./io/json.ts";
+
+/** The file, at the repository root. Read at a base ref, never from the working tree (#981). */
+export const CONFIG_PATH = ".fabrika.jsonc";
+
+/** The key naming the accounts and teams that may clear a repair round. */
+export const CAP_CLEAR_AUTHORS = "capClearAuthors";
+
+/**
+ * Strip line and block comments, leaving string literals untouched, so the bytes parse as JSON.
+ *
+ * Hand-written rather than taken from a dependency because the whole surface is two comment forms
+ * and one escape rule, and the string-awareness is the part that matters: a naive strip cuts a URL
+ * in half at its `//` and turns a readable config into "the document is not JSON".
+ */
+export const stripJsonComments = (text: string): string => {
+	let out = "";
+	let inString = false;
+	let escaped = false;
+	let index = 0;
+	while (index < text.length) {
+		const char = text[index] ?? "";
+		if (inString) {
+			out += char;
+			if (escaped) escaped = false;
+			else if (char === "\\") escaped = true;
+			else if (char === '"') inString = false;
+			index += 1;
+			continue;
+		}
+		if (char === '"') {
+			inString = true;
+			out += char;
+			index += 1;
+			continue;
+		}
+		if (char === "/" && text[index + 1] === "/") {
+			while (index < text.length && text[index] !== "\n") index += 1;
+			continue;
+		}
+		if (char === "/" && text[index + 1] === "*") {
+			index += 2;
+			while (index < text.length && !(text[index] === "*" && text[index + 1] === "/")) index += 1;
+			index += 2;
+			continue;
+		}
+		out += char;
+		index += 1;
+	}
+	return out;
+};
+
+/** One entry of the grant-author set: a `@login`, or a `@org/team` whose membership is resolved. */
+export type GrantAuthor =
+	| {readonly _tag: "User"; readonly login: string}
+	| {readonly _tag: "Team"; readonly org: string; readonly team: string};
+
+export type AuthorsRead =
+	| {readonly _tag: "Authors"; readonly authors: ReadonlyArray<GrantAuthor>}
+	/** The bytes were read in full and hold no usable set — nobody may grant. */
+	| {readonly _tag: "Unusable"; readonly reason: string};
+
+const USER = /^@([A-Za-z0-9](?:[A-Za-z0-9-]*[A-Za-z0-9])?)$/;
+const TEAM = /^@([^/\s]+)\/([^/\s]+)$/;
+
+/**
+ * The grant-author set the config declares. Every rejection names what it rejected.
+ *
+ * An entry that is not a `@`-prefixed user or `@org/team` refuses the **whole** set rather than
+ * being skipped: a typo'd entry silently dropped is an author the operator believes is configured
+ * and is not, which surfaces only as a refused grant nobody can explain.
+ */
+export const readCapClearAuthors = (text: string): AuthorsRead => {
+	const parsed = parseJson(stripJsonComments(text));
+	if (!isRecord(parsed)) {
+		return {_tag: "Unusable", reason: `${CONFIG_PATH} is not a JSON object with comments`};
+	}
+	const raw = parsed[CAP_CLEAR_AUTHORS];
+	if (raw === undefined) {
+		return {_tag: "Unusable", reason: `${CONFIG_PATH} declares no \`${CAP_CLEAR_AUTHORS}\``};
+	}
+	if (!Array.isArray(raw)) {
+		return {_tag: "Unusable", reason: `\`${CAP_CLEAR_AUTHORS}\` is not an array`};
+	}
+	const authors: GrantAuthor[] = [];
+	for (const entry of raw) {
+		if (typeof entry !== "string") {
+			return {
+				_tag: "Unusable",
+				reason: `\`${CAP_CLEAR_AUTHORS}\` holds a non-string entry — expected "@user" or "@org/team"`,
+			};
+		}
+		const value = entry.trim();
+		const team = TEAM.exec(value);
+		if (team?.[1] !== undefined && team[2] !== undefined) {
+			authors.push({_tag: "Team", org: team[1], team: team[2]});
+			continue;
+		}
+		const user = USER.exec(value);
+		if (user?.[1] !== undefined) {
+			authors.push({_tag: "User", login: user[1]});
+			continue;
+		}
+		return {
+			_tag: "Unusable",
+			reason: `"${entry}" is not a \`${CAP_CLEAR_AUTHORS}\` entry — expected "@user" or "@org/team"`,
+		};
+	}
+	return authors.length === 0
+		? {_tag: "Unusable", reason: `\`${CAP_CLEAR_AUTHORS}\` is empty — nobody may clear a round`}
+		: {_tag: "Authors", authors};
+};

--- a/packages/fabrika-cli/src/repo-config.unit.test.ts
+++ b/packages/fabrika-cli/src/repo-config.unit.test.ts
@@ -1,0 +1,51 @@
+import {describe, expect, it} from "vitest";
+import {readCapClearAuthors, stripJsonComments} from "./repo-config.ts";
+
+describe("stripJsonComments", () => {
+	it("drops line and block comments", () => {
+		expect(stripJsonComments('{\n\t// who may clear\n\t"a": 1 /* and why */\n}')).toBe(
+			'{\n\t\n\t"a": 1 \n}',
+		);
+	});
+
+	it("leaves a comment sequence inside a string alone — a URL is not a comment", () => {
+		expect(stripJsonComments('{"a": "https://kamp.us/x"}')).toBe('{"a": "https://kamp.us/x"}');
+		expect(stripJsonComments('{"a": "an escaped \\" then // not a comment"}')).toBe(
+			'{"a": "an escaped \\" then // not a comment"}',
+		);
+	});
+});
+
+describe("readCapClearAuthors", () => {
+	it("reads users and teams, both `@`-prefixed as GitHub writes them", () => {
+		const read = readCapClearAuthors('{"capClearAuthors": ["@usirin", "@kamp-us/control-plane"]}');
+		expect(read).toEqual({
+			_tag: "Authors",
+			authors: [
+				{_tag: "User", login: "usirin"},
+				{_tag: "Team", org: "kamp-us", team: "control-plane"},
+			],
+		});
+	});
+
+	it("reads through comments, which is the whole point of the `.jsonc` home", () => {
+		const read = readCapClearAuthors(
+			'{\n\t// the founder accounts\n\t"capClearAuthors": ["@a"]\n}',
+		);
+		expect(read._tag).toBe("Authors");
+	});
+
+	/** Every one of these is "nobody may grant" — never a default set, never a silent skip. */
+	it.each([
+		{shape: "no file content at all", text: ""},
+		{shape: "a document that is not an object", text: "[]"},
+		{shape: "no key", text: '{"other": 1}'},
+		{shape: "a key that is not an array", text: '{"capClearAuthors": "@usirin"}'},
+		{shape: "an empty array", text: '{"capClearAuthors": []}'},
+		{shape: "a non-string entry", text: '{"capClearAuthors": [1]}'},
+		{shape: "an entry with no `@`", text: '{"capClearAuthors": ["usirin"]}'},
+		{shape: "an entry naming a nested path", text: '{"capClearAuthors": ["@a/b/c"]}'},
+	])("refuses the whole set on $shape", ({text}) => {
+		expect(readCapClearAuthors(text)._tag).toBe("Unusable");
+	});
+});

--- a/packages/fabrika-cli/src/wire/cap-clearance.ts
+++ b/packages/fabrika-cli/src/wire/cap-clearance.ts
@@ -1,0 +1,164 @@
+/**
+ * The cap-clearance marker — the comment `build clear` posts on a PR after its authorization.
+ *
+ *     cap-cleared: round 3 · 2026-08-18T07:16:03Z
+ *
+ * Two fields, and the round is the load-bearing one: a clearance is spent by the round it names, so
+ * it survives the push it exists to permit and expires the moment another FAIL round lands (see
+ * `../cap-clearance.ts`). It carries no head SHA on purpose — a verdict attests a tree, but a
+ * clearance authorizes the *next* tree, so binding one to a head would void it on first use.
+ *
+ * The marker is never proof on its own. What `build verdicts` folds as budget is this marker
+ * **plus** an author in the repo's configured grant-author set plus the dated authorization comment
+ * beside it, exactly as `grill-ruled` means the four clauses `grill read` applies and not the bytes.
+ */
+
+import type {NonEmptyReadonlyArray, WireEmit, WireRead, WireReadLines} from "./format.ts";
+import {
+	absent,
+	FIELD_SEPARATOR,
+	firstNonBlankLine,
+	type MarkerTime,
+	malformed,
+	markerTime,
+	payloadOf,
+	reachesFor,
+} from "./grill-marker.ts";
+
+export type {MarkerTime} from "./grill-marker.ts";
+
+/** The key that names these bytes. Never widened — a second meaning would need a second format. */
+export const KEY = "cap-cleared";
+
+/** The word before the round, so the number is never a bare token a reader has to guess at. */
+const ROUND_PREFIX = "round";
+
+declare const CLEARED_ROUND: unique symbol;
+
+/** The round a clearance clears: a positive integer. No other inhabitant exists. */
+export type ClearedRound = number & {readonly [CLEARED_ROUND]: true};
+
+export const clearedRound = (raw: number): ClearedRound | null =>
+	Number.isInteger(raw) && raw > 0 ? (raw as ClearedRound) : null;
+
+export interface CapClearance {
+	readonly round: ClearedRound;
+	readonly at: MarkerTime;
+}
+
+export type CapClearanceRead = WireRead<CapClearance>;
+
+/**
+ * Read the clearance marker out of a comment body. Total: `Found` | `Absent` | `Malformed`.
+ *
+ * The walk is stepwise so a refusal names which field drifted. A body that reaches for the key and
+ * misses must never read as a PR nobody cleared — the operator would re-grant a round already
+ * granted, and the audit trail would carry two markers for one act.
+ */
+export const read = (artifact: string): CapClearanceRead => {
+	if (!reachesFor(artifact, KEY)) {
+		return absent(`the first line does not open with "${KEY}:" — no marker of this format`);
+	}
+	const line = firstNonBlankLine(artifact) ?? "";
+	const evidence = `first line: "${line}"`;
+	const payload = payloadOf(line, KEY);
+	const [roundPart, ...afterSeparator] = payload.split(FIELD_SEPARATOR);
+	if (afterSeparator.length === 0) {
+		return malformed(
+			`the marker carries no "${FIELD_SEPARATOR}"-separated timestamp after the round`,
+			evidence,
+		);
+	}
+	const words = (roundPart ?? "").trim().split(/\s+/);
+	if (words[0]?.toLowerCase() !== ROUND_PREFIX || words.length !== 2) {
+		return malformed(
+			`"${(roundPart ?? "").trim()}" is not a cleared round — expected "${ROUND_PREFIX} <n>"`,
+			evidence,
+		);
+	}
+	const round = clearedRound(Number(words[1]));
+	if (round === null) {
+		return malformed(`"${words[1]}" is not a round number — expected a positive integer`, evidence);
+	}
+	const at = markerTime(afterSeparator.join(FIELD_SEPARATOR));
+	if (at === null) {
+		return malformed(
+			`"${afterSeparator.join(FIELD_SEPARATOR).trim()}" is not an ISO-8601 UTC timestamp — expected a Z-suffixed instant`,
+			evidence,
+		);
+	}
+	return {_tag: "Found", value: {round, at}};
+};
+
+/** Compose the marker's first line. Round-trips through {@link read}. */
+export const emit = ({round, at}: CapClearance): string =>
+	`${KEY}: ${ROUND_PREFIX} ${round} ${FIELD_SEPARATOR} ${at}\n`;
+
+/** One `<field>\t<value>` line per field — the `wire read` answer for this format. */
+export const renderClearance = (clearance: CapClearance): NonEmptyReadonlyArray<string> => [
+	`round\t${clearance.round}`,
+	`at\t${clearance.at}`,
+];
+
+export type CapClearanceFields =
+	| {readonly _tag: "Fields"; readonly clearance: CapClearance}
+	| {readonly _tag: "Unusable"; readonly reason: string};
+
+/** `<key>: <value>` or `<key><TAB><value>`, so `wire read`'s own output pipes back into `wire emit`. */
+const FIELD_LINE = /^([A-Za-z-]+)[ \t]*[:\t][ \t]*(.*)$/;
+const KEYS = ["round", "at"] as const;
+type FieldKey = (typeof KEYS)[number];
+
+const isFieldKey = (key: string): key is FieldKey => (KEYS as ReadonlyArray<string>).includes(key);
+
+/** Parse `wire emit`'s stdin into a clearance. Every rejection is a refusal, never a default. */
+export const parseFields = (fields: string): CapClearanceFields => {
+	const seen = new Map<FieldKey, string>();
+	for (const [index, raw] of fields.split("\n").entries()) {
+		const line = raw.trim();
+		if (line === "") continue;
+		const matched = FIELD_LINE.exec(line);
+		const key = matched?.[1]?.toLowerCase() ?? "";
+		if (matched === null || !isFieldKey(key)) {
+			return {
+				_tag: "Unusable",
+				reason: `line ${index + 1} is not a "<field>: <value>" line over ${KEYS.join(", ")}: "${line}"`,
+			};
+		}
+		if (seen.has(key)) {
+			return {
+				_tag: "Unusable",
+				reason: `"${key}" is given twice — which one is the field is undecidable`,
+			};
+		}
+		seen.set(key, matched[2] ?? "");
+	}
+
+	const raw = (seen.get("round") ?? "").trim();
+	const round = /^[0-9]+$/.test(raw) ? clearedRound(Number(raw)) : null;
+	if (round === null) {
+		return {_tag: "Unusable", reason: `"${raw}" is not a round — expected a positive integer`};
+	}
+	const at = markerTime(seen.get("at") ?? "");
+	if (at === null) {
+		return {
+			_tag: "Unusable",
+			reason: `"${seen.get("at") ?? ""}" is not an ISO-8601 UTC timestamp — expected a Z-suffixed instant`,
+		};
+	}
+	return {_tag: "Fields", clearance: {round, at}};
+};
+
+/** The registry row's byte-level `emit`, bound to this module's typed core. */
+export const emitFromFields = (fields: string): WireEmit => {
+	const parsed = parseFields(fields);
+	return parsed._tag === "Fields"
+		? {_tag: "Composed", bytes: emit(parsed.clearance)}
+		: {_tag: "Unusable", reason: parsed.reason};
+};
+
+/** The registry row's byte-level `read`, bound to this module's typed core. */
+export const readToLines = (artifact: string): WireReadLines => {
+	const result = read(artifact);
+	return result._tag === "Found" ? {_tag: "Found", value: renderClearance(result.value)} : result;
+};

--- a/packages/fabrika-cli/src/wire/registry.ts
+++ b/packages/fabrika-cli/src/wire/registry.ts
@@ -20,6 +20,7 @@
  */
 import * as acceptanceCriteria from "./acceptance-criteria.ts";
 import * as buildDeviations from "./build-deviations.ts";
+import * as capClearance from "./cap-clearance.ts";
 import * as deviations from "./deviations.ts";
 import {brandWitnesses, type WireFormat} from "./format.ts";
 import * as governanceDigest from "./governance-digest.ts";
@@ -513,6 +514,46 @@ export const registeredFormats: ReadonlyArray<WireFormat> = [
 			],
 		},
 		brands: brandWitnesses<grillRuling.GrillRuling>({question: true, digest: true, at: true}),
+	},
+	{
+		key: "cap-clearance",
+		purpose:
+			"the founder's grant of one extra repair round on a PR, carried as a marker comment beside its dated authorization and folded as budget by `build verdicts`",
+		module: "packages/fabrika-cli/src/wire/cap-clearance.ts",
+		producers: ["build"],
+		consumers: ["build", "operate"],
+		emit: capClearance.emitFromFields,
+		read: capClearance.readToLines,
+		fixtures: {
+			roundTrip: {
+				fields: "round: 3\nat: 2026-08-18T07:16:03Z\n",
+				values: ["3", "2026-08-18T07:16:03Z"],
+			},
+			found: [
+				{
+					shape: "the marker over the round it grants, as `build clear` posts it",
+					artifact:
+						"cap-cleared: round 3 · 2026-08-18T07:16:03Z\n\nOne round, on the authorization above.\n",
+					values: ["3", "2026-08-18T07:16:03Z"],
+				},
+			],
+			absent: "Re-ran the gate at the new head and it is green now.\n",
+			malformed: [
+				{
+					drift: "the round is not a number",
+					artifact: "cap-cleared: round three · 2026-08-18T07:16:03Z\n",
+				},
+				{
+					drift: "the marker names no round, so the grant binds to nothing",
+					artifact: "cap-cleared: 2026-08-18T07:16:03Z\n",
+				},
+				{
+					drift: "the timestamp is not an ISO-8601 UTC instant",
+					artifact: "cap-cleared: round 3 · this morning\n",
+				},
+			],
+		},
+		brands: brandWitnesses<capClearance.CapClearance>({at: true}),
 	},
 	{
 		key: "grill-answer",


### PR DESCRIPTION
A founder-cleared repair round is now data on the PR, so the round lands inside the loop instead of
as an edit outside it.

## What changed

`fabrika build clear --pr <n> --authorization <file>` records the clearance. It refuses unless every
clause holds: the PR is open, its budget is actually spent, the invoking account is in the repo's
`.fabrika.jsonc` `capClearAuthors` set read at the PR's **base** ref, and the quoted authorization is
present and dated. It writes the authorization comment first, the `cap-cleared` marker second, and
the lane's local bump last — the order where an interruption leaves a grant that counts for nobody
rather than one that counts for free.

The grant is keyed by the round it clears, not by a head SHA, which is what makes it survive the push
it exists to permit and expire the moment the next FAIL round lands. One grant is one round, counted
by distinct round, so a re-posted or reconciled grant buys nothing extra.

Both enforcement sites now read one derivation (`src/cap-clearance.ts`): `build verdicts` folds
honoured clearances into `capReached` and lists them in a new `clearances` array, and the lane
machine's `retriesRemaining` guard reads `RETRY_BUDGET + <cleared rounds>` off the task's context.
`RETRY_BUDGET`/`CAP_ROUND` stay the single declared budget — the clearance is additive on top, never a
second cap. A unit test drives the two formulas against each other over six round/grant combinations,
because "the lane froze while verdicts said budget remains" is the defect this closes.

The grant-author set is repo configuration per the 2026-08-18 ruling, so `.fabrika.jsonc` is opened
for that one key. Fail-closed on every axis: an absent file, an absent key, an empty array or a
malformed entry all mean nobody may grant; only a read that *failed* is `11`.

The configured set is a narrowing over a live `write+` ACL read, never a substitute for one, and both
enforcement sites apply both clauses. That is recorded as ADR 0294,
`.decisions/0294-config-narrows-the-acl-never-replaces-it.md`.

## Deviations

- **Out-of-scope change** — **Said:** #5959 names the two enforcement sites and the recording verb.
  **Did:** also opened `.fabrika.jsonc` as a config surface, with a small string-aware comment
  stripper and a one-key reader. **Why:** the ruling names that file as the grant-author set's home
  and it did not exist — no config loader of any kind is in the CLI today. **Disposition:** scoped to
  the one ruled key; epic #5631 owns the rest of the surface and can absorb the reader.
- **Out-of-scope change** — **Said:** the clearance is a marker on the PR. **Did:** the same verb also
  writes the granted round into the local lane's `workflow.json` context. **Why:** the lane fold is
  offline and pure, so a criterion asking the lane guard to honour the grant cannot be met by a
  remote-only marker. **Disposition:** stated here; the PR marker stays the durable record and the
  local write is idempotent, with its own exit code (`29`) when it does not land.
- **Known defect left unfixed** — **Said:** the verb refuses unless the account is authorized.
  **Did:** left the residue that in a repo where an agent runs on a configured account's own token,
  the agent could invoke it. **Why:** nothing mechanical distinguishes an agent's call from the
  account holder's — the same residue `grill rule` carries, open as #4441. **Disposition:** stated in
  the verb docblock and in the contract, and `build`'s Repair section tells a builder to escalate,
  never to clear.
- **Pre-existing test or fixture changed** — **Said:** add the fold's new field. **Did:** also changed
  one assertion in `verdicts-verb.unit.test.ts` from `stderr.at(-1)` to a joined scan. **Why:** the
  verb now emits a second scope line, so the old assertion read the wrong line. **Disposition:** the
  original expectation is kept, plus a new one on the added line.
- **Governing-ADR departure** — **Said:** state the cleared-round path in `SKILL.md` and
  `contract.md`, and record no decision. **Did:** round 2 added
  `.decisions/0294-config-narrows-the-acl-never-replaces-it.md`, so this build did author a decision
  record. **Why:** round 1's `governance` FAIL required the departure from ADR 0055 — a committed
  identity list read as authority — to be recorded before the config clause could stand.
  **Disposition:** the record states the conjunction (configured set AND live `write+`), and both
  enforcement sites implement it. This entry replaces the earlier "recorded no ADR" one, which went
  stale at that head.
- **Guard or gate bypassed** — **Said:** the repair cap is `RETRY_BUDGET` rounds and a spent cap is an
  escalation. **Did:** this round was built past the spent cap, on a driver grant posted at
  https://github.com/kamp-us/phoenix/issues/5959#issuecomment-5325671552 rather than through
  `build clear` — the verb this PR adds is not landed yet, so it could not grant its own round.
  **Why:** the round-2 `governance` FAIL is an ADR-id collision that no later round can fix any more
  cheaply, and abandoning the branch would strand the whole change. **Disposition:** one grant, one
  round; the grant names its scope (the renumber and this body refresh) and nothing else was built
  under it.
- **Out-of-scope change** — **Said:** each commit on this branch is its lane builder's own work.
  **Did:** commit `6e76e7f6` is round-2 repair work recovered from an abandoned builder worktree and
  committed by the driver, verbatim apart from a biome format pass — it covers `clear-verb.ts`,
  `clear-verb.unit.test.ts`, `clearances.ts`, `codes.ts`, `verdicts-verb.unit.test.ts` and the
  decision record. **Why:** the builder's session ended before it could commit, an allocator defect
  filed as #6035. **Disposition:** disclosed by the driver on this PR at
  https://github.com/kamp-us/phoenix/pull/6020#issuecomment-5325429957; it carries no prior review and
  is graded on its own merits by the re-review at the current head.
- **Out-of-scope change** — **Said:** the decision record is `.decisions/0292-…`. **Did:** renumbered
  it to `0294` and moved all six citations — `contract.md` (3), `clear-verb.ts`, `clearances.ts`, and
  two unit-test docblocks. **Why:** `0292` and `0293` are both held by open sibling PRs, and ADR 0074
  claims a number against the in-flight ADR PRs rather than next-free-on-disk; `adr next` computes
  `0294` at this head. **Disposition:** filename, `id:` frontmatter and heading all moved together;
  no `0292` reference remains on the branch.

Fixes #5959
