### PR TITLE
fix: fabrika-cli ships no workflow templates, so `lane open` cannot boot a lane in any installed repo

### DIFF
--- a/.patterns/release-path.md
+++ b/.patterns/release-path.md
@@ -63,12 +63,30 @@ Ruled by ADR [0076](../.decisions/0076-decisions-index-npm-publish-automated-rel
 ruling — so superseded-0076 remains this constraint's only ADR home, cited as live on that
 point alone (ADR 0239 §2 carries the same caveat).
 
-### 3. The package ships compiled JS, never raw `.ts`
+### 3. The package ships compiled JS, never raw `.ts` — plus every asset `tsc` will not emit
 
 Node refuses to strip types under `node_modules`, so a source-only tarball is dead on
 arrival for a consumer. `bin`/`exports` point at `dist/`, `files` is `[dist]`, and
 `publish.yml` runs an explicit build step before publishing (`prepublishOnly` also runs it;
 the explicit step makes the gate visible).
+
+`tsc` emits `.js`/`.d.ts` and copies nothing else, so a file under `src/` that no module
+imports never reaches `dist/`. A module reading such a file by path off `import.meta.url`
+therefore works in-tree and finds nothing in every install — invisible until someone runs the
+published package, which is how `fabrika-cli` released a `lane open` that could boot no lane
+at all ([#6011](https://github.com/kamp-us/phoenix/issues/6011)). A package whose build is
+`tsc` alone carries a copy step after it
+([`packages/fabrika-cli/scripts/copy-src-assets.mjs`](../packages/fabrika-cli/scripts/copy-src-assets.mjs)),
+and the rule that step applies is **every** non-`.ts` file with no exception list: an
+exception list is maintained by whoever adds an asset knowing that reading a file by path is
+different from importing it, which is exactly the knowledge the defect proves absent.
+
+Only a build-and-pack test can see this — read from `src/`, the asset is right there. The
+worked one is
+[`packages/fabrika-cli/src/packaging.cli.test.ts`](../packages/fabrika-cli/src/packaging.cli.test.ts):
+it runs the real build, packs the real tarball, and drives the tarball's own `dist/bin.js`.
+The two sibling published packages do not have it yet
+([#6039](https://github.com/kamp-us/phoenix/issues/6039)).
 
 **No live ADR rules this.** It is written down in ADR 0076 §1, which is superseded and
 which 0103 does not restate on this point, and in `publish.yml`'s own comment citing

--- a/packages/fabrika-cli/package.json
+++ b/packages/fabrika-cli/package.json
@@ -46,7 +46,7 @@
 		}
 	},
 	"scripts": {
-		"build": "tsc -p tsconfig.build.json",
+		"build": "tsc -p tsconfig.build.json && node ./scripts/copy-src-assets.mjs",
 		"postinstall": "node ./scripts/provision-browser.mjs",
 		"prepublishOnly": "pnpm run build",
 		"typecheck": "tsc -p tsconfig.json",

--- a/packages/fabrika-cli/scripts/copy-src-assets.mjs
+++ b/packages/fabrika-cli/scripts/copy-src-assets.mjs
@@ -1,0 +1,34 @@
+#!/usr/bin/env node
+/**
+ * Copy every non-TypeScript file under `src/` to the same relative path under `dist/`.
+ *
+ * `tsc` emits `.js`/`.d.ts` and nothing else, so a file no module imports never reaches `dist/`.
+ * `lane/command.ts` resolves its two workflow templates by path off `import.meta.url`, which under
+ * `dist/` is `dist/lane/templates/…` — a directory the compiler never created, so the published
+ * package booted no lane at all and `lane open` exited on the unreadable-template code (#6011).
+ *
+ * The rule is total on purpose: **every** non-`.ts` file, with no exception list. An exception list
+ * is where the next unshipped asset hides, and it can only be maintained by whoever adds an asset
+ * remembering that reading it by path is different from importing it. The whole set is a few
+ * kilobytes, so shipping a test fixture costs nothing next to shipping a package that cannot run.
+ */
+import {copyFileSync, mkdirSync, readdirSync} from "node:fs";
+import {dirname, join} from "node:path";
+import {fileURLToPath} from "node:url";
+
+const PACKAGE_ROOT = fileURLToPath(new URL("..", import.meta.url));
+const SRC = join(PACKAGE_ROOT, "src");
+const DIST = join(PACKAGE_ROOT, "dist");
+
+/** Every file under `src/` that `tsc` will not emit, as paths relative to `src/`. */
+const assets = readdirSync(SRC, {recursive: true, withFileTypes: true})
+	.filter((entry) => entry.isFile() && !entry.name.endsWith(".ts"))
+	.map((entry) => join(entry.parentPath, entry.name).slice(SRC.length + 1))
+	.sort();
+
+for (const asset of assets) {
+	const target = join(DIST, asset);
+	mkdirSync(dirname(target), {recursive: true});
+	copyFileSync(join(SRC, asset), target);
+}
+console.log(`copy-src-assets: copied ${assets.length} asset(s) from src/ to dist/`);

--- a/packages/fabrika-cli/src/packaging.cli.test.ts
+++ b/packages/fabrika-cli/src/packaging.cli.test.ts
@@ -1,0 +1,128 @@
+/**
+ * The packaged copy still boots a lane — the half of `lane open` that only a real build and a real
+ * pack can prove.
+ *
+ * `lane/command.ts` resolves its workflow templates by path off `import.meta.url`, and `tsc` copies
+ * no file it does not compile, so `dist/lane/templates/` never existed and every install outside
+ * this checkout booted nothing (#6011). No in-process test could see it: read from `src/`, the
+ * templates are right there. What is under test is the *build output*, so this suite builds and
+ * packs for real and drives the tarball's own `dist/bin.js`.
+ *
+ * The tarball is unpacked with the package's own `node_modules` symlinked beside it rather than
+ * installed from a registry: what the defect is about is which files the tarball carries, and a
+ * real dependency install proves nothing further while putting the network on a gate path
+ * (`.patterns/subprocess-test-budget.md`).
+ */
+import {execFileSync} from "node:child_process";
+import {existsSync, mkdtempSync, readdirSync, readFileSync, symlinkSync} from "node:fs";
+import {tmpdir} from "node:os";
+import {join} from "node:path";
+import {fileURLToPath} from "node:url";
+import {beforeAll, describe, expect, it} from "vitest";
+import {SUBPROCESS_TEST_TIMEOUT_MS} from "./test-budget.ts";
+
+const PACKAGE_ROOT = fileURLToPath(new URL("..", import.meta.url));
+const SRC = join(PACKAGE_ROOT, "src");
+const DIST = join(PACKAGE_ROOT, "dist");
+
+/**
+ * Walked here rather than imported from `scripts/copy-src-assets.mjs`: that script's own idea of
+ * what an asset is is the thing under test, so sharing it would let a defect in it hide itself.
+ */
+const assetsUnder = (root: string): readonly string[] =>
+	readdirSync(root, {recursive: true, withFileTypes: true})
+		.filter((entry) => entry.isFile() && !entry.name.endsWith(".ts"))
+		.map((entry) => join(entry.parentPath, entry.name).slice(root.length + 1))
+		.sort();
+
+interface Run {
+	readonly code: number;
+	readonly stdout: string;
+	readonly stderr: string;
+}
+
+/** `FABRIKA_SKIP_INFER` pins the invocation to the unpacked tarball rather than this checkout. */
+const bootLane = (key: string, root: string): Run => {
+	try {
+		const stdout = execFileSync(
+			process.execPath,
+			[join(tarballRoot, "dist", "bin.js"), "lane", "open", key, "--root", root],
+			{
+				encoding: "utf8",
+				env: {...process.env, FABRIKA_SKIP_INFER: "1"},
+				stdio: ["ignore", "pipe", "pipe"],
+			},
+		);
+		return {code: 0, stdout, stderr: ""};
+	} catch (err) {
+		const failure = err as {status?: number; stdout?: string; stderr?: string};
+		return {code: failure.status ?? -1, stdout: failure.stdout ?? "", stderr: failure.stderr ?? ""};
+	}
+};
+
+const committedTemplate = (name: string): string =>
+	readFileSync(join(SRC, "lane", "templates", name), "utf8");
+
+let tarballRoot = "";
+let scratch = "";
+
+describe("the packed package ships what it reads at run time (#6011)", {
+	timeout: SUBPROCESS_TEST_TIMEOUT_MS,
+}, () => {
+	beforeAll(() => {
+		const tmp = mkdtempSync(join(tmpdir(), "fabrika-6011-"));
+		const pnpm = (args: readonly string[]): string =>
+			execFileSync("pnpm", [...args], {
+				cwd: PACKAGE_ROOT,
+				encoding: "utf8",
+				stdio: ["ignore", "pipe", "pipe"],
+			});
+		pnpm(["run", "build"]);
+		const tarball = pnpm(["pack", "--pack-destination", tmp]).trim().split("\n").at(-1)?.trim();
+		if (tarball === undefined || tarball === "") throw new Error("pnpm pack named no tarball");
+		execFileSync("tar", ["-xzf", tarball, "-C", tmp], {stdio: ["ignore", "pipe", "pipe"]});
+		tarballRoot = join(tmp, "package");
+		symlinkSync(join(PACKAGE_ROOT, "node_modules"), join(tarballRoot, "node_modules"), "dir");
+		scratch = join(tmp, "scratch");
+	}, SUBPROCESS_TEST_TIMEOUT_MS);
+
+	/**
+	 * The general guard: an asset added under `src/` tomorrow and read by path is caught the same
+	 * way the two templates are, without anyone naming it here. Zero assets is a red, not a pass
+	 * (ADR 0092) — a walk that stopped finding files reads exactly like a build that ships them.
+	 */
+	it("copies every non-TypeScript file under src/ into dist/, byte for byte", () => {
+		const assets = assetsUnder(SRC);
+		expect(assets.length).toBeGreaterThan(0);
+		expect(assets.filter((asset) => !existsSync(join(DIST, asset)))).toEqual([]);
+		const differing = assets.filter(
+			(asset) => !readFileSync(join(SRC, asset)).equals(readFileSync(join(DIST, asset))),
+		);
+		expect(differing).toEqual([]);
+	});
+
+	it("carries those assets inside the tarball, past the `files` field", () => {
+		const absent = assetsUnder(SRC).filter(
+			(asset) => !existsSync(join(tarballRoot, "dist", asset)),
+		);
+		expect(absent).toEqual([]);
+	});
+
+	it("boots an issue lane from the tarball, byte-identical to the committed template", () => {
+		const run = bootLane("6011", join(scratch, "lanes"));
+		expect(run.stderr).not.toContain("cannot read the committed template");
+		expect(run.code).toBe(0);
+		expect(readFileSync(join(scratch, "lanes", "6011", "workflow.json"), "utf8")).toBe(
+			committedTemplate("coder.workflow.json"),
+		);
+	});
+
+	it("boots a chore lane from the tarball, byte-identical to the committed template", () => {
+		const run = bootLane("chore:park-sweep", join(scratch, "chores"));
+		expect(run.stderr).not.toContain("cannot read the committed template");
+		expect(run.code).toBe(0);
+		expect(readFileSync(join(scratch, "chores", "park-sweep", "workflow.json"), "utf8")).toBe(
+			committedTemplate("chore.workflow.json"),
+		);
+	});
+});


### PR DESCRIPTION
`tsc` emits `.js`/`.d.ts` and copies nothing else, so the two lane workflow templates — read by path
off `import.meta.url`, never imported — never reached `dist/`. Every install outside this checkout
exited on the unreadable-template code, and `lane open` is the only boot path for a non-epic lane.

The build now runs `scripts/copy-src-assets.mjs` after `tsc`. The rule it applies is **every**
non-`.ts` file under `src/`, with no exception list: an exception list is maintained by whoever adds
an asset knowing that reading a file by path is different from importing it, which is exactly the
knowledge this defect proves absent. The whole set is 12 files.

`src/packaging.cli.test.ts` is the regression guard. No in-process test can see this class — read
from `src/`, the asset is right there — so the suite runs the real `pnpm run build`, packs the real
tarball, unpacks it, and drives the tarball's own `dist/bin.js lane open` for both an issue key and
a `chore:<name>` key, asserting each booted `workflow.json` is byte-identical to the committed
template. Its first assertion is a generic src→dist parity walk, so an asset added tomorrow is
caught without anyone naming it here, and zero assets found reds rather than passes (ADR 0092).

Verified by unwiring the copy step and re-running: all four tests go red with the reported
`cannot read the committed template at …/dist/lane/templates/chore.workflow.json` error. Five
spawns, ~3s, under the package's `SUBPROCESS_TEST_TIMEOUT_MS`
(`.patterns/subprocess-test-budget.md`); `pipeline-cli`'s subprocess-budget guard passes.

The templates stay JSON, so `retry-budget.ts:12`'s "is JSON and cannot import" note stays true and
`fixtures.test-support.ts` / `emit.unit.test.ts` / `retry-budget.unit.test.ts` are untouched. Full
`fabrika-cli` suite: 5098 passed.

`.patterns/release-path.md` constraint 3 gains the rule, since that doc already owns what the
tarball must contain.

Fixes #6011

## Deviations

- **Out-of-scope change** — **Said:** #6011 names `packages/fabrika-cli` only. **Did:** also
  extended `.patterns/release-path.md` constraint 3 with the asset rule and pointers to the script
  and the test. **Why:** CLAUDE.md requires a load-bearing pattern to be documented, and that
  constraint already covers what a published tarball must contain, so a new doc would split one
  rule across two homes. **Disposition:** stated here.
- **Known defect left unfixed** — **Said:** the acceptance criteria are scoped to `fabrika-cli`.
  **Did:** left `pipeline-cli` and `depo` on the same `tsc`-only build with no copy step. **Why:**
  both are separately published packages, and folding them in would widen a scoped bug fix into a
  packaging sweep. **Disposition:** filed as #6039, and named from the pattern doc.
- **Declined guidance** — **Said:** the issue offers turning the templates into TypeScript modules
  as an equally acceptable route. **Did:** kept them as JSON and fixed the packaging instead.
  **Why:** acceptance criterion 2 requires both templates to resolve at the path `command.ts`
  computes from `import.meta.url` after a `dist` build, which only exists on the JSON route; the
  module route would also invalidate `retry-budget.ts:12`'s note and three golden-fixture readers
  for no gain the copy step does not already give. **Disposition:** stated here.
