### PR TITLE
fix: lane emit misreads a plain issue's prose as topology and dead-ends the boot

### DIFF
--- a/packages/fabrika-cli/src/lane/emit.ts
+++ b/packages/fabrika-cli/src/lane/emit.ts
@@ -163,6 +163,11 @@ export const emitMachine = (
 	body: string,
 	children: ReadonlyArray<SubIssueLink>,
 ): EmitResult => {
+	// Childlessness is read before the body, because an issue with no sub-issue links is not an epic
+	// whatever its prose says — parsing first let a plain issue's `## Dependencies` heading refuse as
+	// a malformed epic record and dead-end the boot (#5973).
+	if (children.length === 0) return {_tag: "NoTopology"};
+
 	const topo = readTopology(body);
 	if (topo._tag === "Absent") return {_tag: "NoTopology"};
 	if (topo._tag === "Unparseable") return {_tag: "Unparseable", line: topo.line, text: topo.text};

--- a/packages/fabrika-cli/src/lane/emit.unit.test.ts
+++ b/packages/fabrika-cli/src/lane/emit.unit.test.ts
@@ -391,6 +391,21 @@ describe("emitMachine", () => {
 		expect(emitMachine(4300, "## Dependencies\n\n", CHILDREN)).toEqual({_tag: "NoTopology"});
 	});
 
+	it("refuses a childless issue whose body carries prose under the topology heading", () => {
+		const text = "## Dependencies\n\nNone blocking. PR #5899 merged, so this is buildable\n";
+		expect(emitMachine(5908, text, [])).toEqual({_tag: "NoTopology"});
+	});
+
+	it("refuses a childless issue whose body carries a well-formed topology", () => {
+		const text = "## Dependencies\n\n- phase 1: #4301\n";
+		expect(emitMachine(4300, text, [])).toEqual({_tag: "NoTopology"});
+	});
+
+	it("still refuses an unparseable line once the epic has children", () => {
+		const out = emitMachine(4300, "## Dependencies\n\n- phase one: #4301\n", CHILDREN);
+		expect(out).toMatchObject({_tag: "Unparseable", line: 3, text: "- phase one: #4301"});
+	});
+
 	it("refuses a phase member that is not a child of the epic, naming it", () => {
 		expect(emitMachine(4300, "## Dependencies\n\n- phase 1: #9999\n", CHILDREN)).toEqual({
 			_tag: "Foreign",


### PR DESCRIPTION
`lane emit` read an issue body's topology before it looked at whether the issue has any children. A
plain issue that happened to carry a literal `## Dependencies` heading with prose under it was
judged by the epic grammar and refused with exit `4` (`MALFORMED_RECORD`) instead of exit `15`
(`TOPOLOGY_ABSENT`). The operate boot table treats exit `4` as a hard stop, so such an issue could
never boot a lane — `lane open` was unreachable.

`emitMachine` now returns `NoTopology` when `children` is empty, before `readTopology` runs. An
issue with no native sub-issue links is not an emittable epic whatever its body says, and exit
`15`'s "plan the epic before emitting a machine" is already the right answer for it. The boot stays
type-blind: no label is read.

The fail-closed refusal is untouched for a real epic. An epic with children whose topology holds an
unparseable line still exits `4` naming the line number and text.

Three unit tests in `emit.unit.test.ts`: childless plus prose under the heading is `NoTopology`,
childless plus a well-formed topology is `NoTopology`, and children plus an unparseable line is
still `Unparseable` carrying line and text.

`operate/SKILL.md` step 1 needed no edit — its sentence that the absent-topology refusal is the
deterministic "this is not an epic" answer is what this change makes true.

Fixes #5973

## Deviations

None.
