### PR TITLE
fix: Epic-run child builds hit the claim focus fence a cleared epic cannot carry them past

### DIFF
--- a/claude-plugins/fabrika/skills/plan-epic/SKILL.md
+++ b/claude-plugins/fabrika/skills/plan-epic/SKILL.md
@@ -148,7 +148,9 @@ EOF
 
 **Every classification attribute lands in the one create call** — labels, milestone, and, for a
 held child, the assignee. `--ready-for` is required and has no default: a child must never inherit
-its audience by omission. A **held** child is born `ready-for:human` *and* assigned, in the
+its audience by omission. **A home is required the same way**: pass `--milestone`, or `--label` the
+child with the parent's standing lane. A child born with neither is one the claim fence refuses at
+exit `20`, so `ledger child` refuses it at mint instead of publishing an issue nobody can pick up. A **held** child is born `ready-for:human` *and* assigned, in the
 same write: the label is the routing signal, the assignment is the enforced hold, and
 neither substitutes for the other.
 
@@ -310,6 +312,6 @@ fabrika installs into repos that are not phoenix. When-missing vocabulary: **fai
 | A triaged `type:epic` issue | the subject of the plan | **fail-loud** — `ledger open` exits `7`/`10`; the run ends `EPIC-UNPLANNABLE`. |
 | A git checkout of this repo, and a reachable `origin/main` | the plan is grounded in source, and staleness is proven rather than assumed | **fail-loud** — `13` ends `STOPPED`; an unprovable freshness read is `11`, never "probably fresh". |
 | The label taxonomy: `type:*`, `p0`/`p1`/`p2`, `status:planned`, `ready-for:human`, `ready-for:agent` | every child is born carrying them; `POST .../labels` **creates** an unknown label rather than rejecting it | **fail-loud** — `ledger child` exits `10` naming the absent label rather than minting it; taxonomy creation is the front door's. |
-| An open milestone, or a standing-lane exemption | every child needs a home; where the host repo enforces homing at its own labelling seam, this skill states the expectation and computes no second answer | **degrade** — an unhomed child reds at a homing guard where the repo has one, and nowhere where it does not. Pass `--milestone` unless the child is genuinely standing-lane work. |
+| An open milestone, or one of the standing-lane labels `wayfinder:backlog` / `axis:pipeline-hardening` | every child needs a home, because the claim fence refuses a homeless issue at exit `20` and nothing downstream can build it | **fail-loud** — `ledger child` exits `10` before it reads or creates anything, naming both remedies (#5969). Pass `--milestone` unless the child is genuinely standing-lane work, in which case `--label` it with the parent's lane; creating a milestone is the front door's. |
 | `product-development-cycle.md` at the repo root | decides whether `**Containment:**` is required on a `type:feature` child | **degrade** — absent means containment is not required; an *unreadable* probe is `11`, never "absent". |
 | Repository permissions readable for claim authorship | `build claim`'s ownership resolution is ACL-sourced | **fail-loud** — as declared for `build claim` (`fabrika wire doc-section --heading "build claim" < <build skill's base dir>/contract.md`); a failed permission read is `Unknown`, never a demotion to unclaimed. |

--- a/claude-plugins/fabrika/skills/plan-epic/contract.md
+++ b/claude-plugins/fabrika/skills/plan-epic/contract.md
@@ -648,7 +648,7 @@ $ echo $?
 **Invocation**
 
 ```
-fabrika ledger child 4300 --title "queue view: fate loader" --type type:feature --priority p1 --ready-for agent [--assignee <login>] [--milestone <title>] [--label <name>]… <<'EOF'
+fabrika ledger child 4300 --title "queue view: fate loader" --type type:feature --priority p1 --ready-for agent [--assignee <login>] --milestone <title> [--label <name>]… <<'EOF'
 **Stories:** 1, 2
 **TDD:** yes
 **Containment:** flag (default-off)
@@ -671,7 +671,7 @@ EOF
 | `--priority` | string, one of `p0`/`p1`/`p2` | yes | — | the child's priority label; `p3` is retired, not admitted |
 | `--ready-for` | string, one of `human`/`agent` | **optional at the parser, refused in the body** | none | the child's audience; an absent value is refused on `10`, never defaulted |
 | `--assignee` | string (login) | no | none | required when `--ready-for human`; born-assignment is the enforced hold |
-| `--milestone` | string (open milestone title) | no | none | the child's home; absent mints an unhomed child the repo's homing guard will red |
+| `--milestone` | string (open milestone title) | **required unless a `--label` carries a standing lane** | none | the child's home; a call naming neither is refused on `10` before any read (#5969) |
 | `--label` | string, repeatable | no | none | any further label, applied in the same create call |
 | `--repo` | string | no | `resolveRepo`'s precedence | the repository written |
 | stdin | markdown | yes | — | the child body's fields and sections |
@@ -692,6 +692,12 @@ applied by a follow-up PATCH — and a follow-up PATCH opens a window in which t
 **no** `ready-for:` value, which is the fail-open shape the ruling forbids, where an absent label
 reads as a permissive default rather than an unknown. v1's own sibling script knows the hazard by
 name and warns that patching a fresh child "reopens the label-less-orphan window".
+
+**A home is required and is never defaulted** (#5969): the call names an open milestone, or a
+`--label` from the claim fence's standing-lane set (`STANDING_LANE_LABELS`, ADR 0208) — a child
+carrying neither is what the fence refuses at exit `20`, so the refusal moves to the mint, where
+nothing has been written yet. The lane set is *imported* from `build/scope-admission.ts`, never
+re-listed here in code: two copies is how the two seams drift into disagreeing about what a home is.
 
 **`--ready-for` is required and has no default** (#4780): a child must never inherit its audience
 by omission. **`--ready-for human` requires `--assignee`** (#4693): the label is the routing
@@ -777,6 +783,7 @@ link, deliberately** — see step 5.
 | `ledger child: --ready-for human requires --assignee — a held child is born assigned (#4693).` | 10 | refusal |
 | `ledger child: label "<name>" is absent from <repo>'s taxonomy — refusing to create it (#4285).` | 10 | refusal |
 | `ledger child: milestone "<title>" is not an open milestone of <repo>.` | 10 | refusal |
+| `ledger child: a child needs a home — pass --milestone <open milestone title>, or --label the child with the parent's standing lane (wayfinder:backlog, axis:pipeline-hardening). A homeless child is refused at the claim fence, so it can never be built (#5969).` | 10 | refusal |
 | `ledger child: --priority <v> is off the closed set (p0, p1, p2).` | 10 | refusal |
 | `ledger child: cannot read <what>: <reason> — nothing was created.` | 11 | refusal |
 | `ledger child: this session does not hold #<n>'s claim.` | 15 | refusal |

--- a/packages/fabrika-cli/src/ledger/child-verb.ts
+++ b/packages/fabrika-cli/src/ledger/child-verb.ts
@@ -9,6 +9,10 @@
  * therefore be neither placed (`24`, dangling) nor retired (`10`, not a sub-issue) — created,
  * unusable, and unreachable by every other verb in the group.
  *
+ * **A home is required too** (#5969): a child born with neither an open milestone nor a standing lane
+ * is refused by the claim fence at exit `20`, so it can never be built — and ADR 0208 names that
+ * milestone-less-and-lane-less category as one that must not exist.
+ *
  * `--ready-for` is required and has no default (#4780); `--ready-for human` requires `--assignee`
  * (#4693) — the label is the routing signal, born-assignment is the enforced hold, and neither
  * substitutes for the other. That pair is not merely a convention: the gate's floor reds
@@ -19,6 +23,7 @@
 import {Effect, type FileSystem, type Path} from "effect";
 import type {ChildProcessSpawner} from "effect/unstable/process";
 import {readAuthored} from "../build/authored.ts";
+import {STANDING_LANE_LABELS, type StandingLaneLabel} from "../build/scope-admission.ts";
 import {scannedLine} from "../build/target.ts";
 import {listLabels, listOpenMilestones} from "../io/issues.ts";
 import type {StdinRead} from "../io/stdin.ts";
@@ -54,6 +59,13 @@ export const TYPES: ReadonlyArray<string> = [
 export const PRIORITIES: ReadonlyArray<string> = ["p0", "p1", "p2"];
 
 export const AUDIENCES: ReadonlyArray<string> = ["human", "agent"];
+
+/**
+ * A home is a milestone **or** a standing lane, read off the one set the claim fence reads (ADR 0208)
+ * — never a second copy of it here, which is how the two seams drift into disagreeing.
+ */
+const isStandingLane = (label: string): label is StandingLaneLabel =>
+	(STANDING_LANE_LABELS as ReadonlyArray<string>).includes(label);
 
 export const MESSAGES: LedgerMessages = {
 	verb: VERB,
@@ -109,6 +121,12 @@ export const runChild = (
 			return refuse(
 				OFF_VOCABULARY,
 				`${VERB}: --priority ${options.priority} is off the closed set (${PRIORITIES.join(", ")}).`,
+			);
+		}
+		if (options.milestone === null && !options.labels.some(isStandingLane)) {
+			return refuse(
+				OFF_VOCABULARY,
+				`${VERB}: a child needs a home — pass --milestone <open milestone title>, or --label the child with the parent's standing lane (${STANDING_LANE_LABELS.join(", ")}). A homeless child is refused at the claim fence, so it can never be built (#5969).`,
 			);
 		}
 

--- a/packages/fabrika-cli/src/ledger/child-verb.unit.test.ts
+++ b/packages/fabrika-cli/src/ledger/child-verb.unit.test.ts
@@ -39,6 +39,10 @@ const MILESTONES = /^gh api --paginate repos\/o\/r\/milestones/;
 
 const MINTED_LABELS = ["type:feature", "p1", "status:planned", "ready-for:agent"];
 
+/** Every child is born homed (#5969), so the shared options carry a milestone the fixture knows. */
+const HOME = "fabrika campaign";
+const LANE = "axis:pipeline-hardening";
+
 const RUN_JSON = (cycleDoc: "present" | "absent" | "unknown" = "present") =>
 	renderRunRecord({
 		epic: 4300,
@@ -58,7 +62,7 @@ const HAPPY: ReadonlyArray<readonly [RegExp, ExecResult]> = [
 	[MILESTONES, milestones([44, "fabrika campaign"])],
 	[CREATE, CREATED],
 	[LINK, okOut("{}")],
-	[READBACK, childIssue({number: 4301, labels: MINTED_LABELS})],
+	[READBACK, childIssue({number: 4301, labels: MINTED_LABELS, milestone: HOME})],
 	[SUBS, okOut(JSON.stringify([{number: 4301, id: 90210, state: "open", state_reason: null}]))],
 ];
 
@@ -69,7 +73,7 @@ const options = {
 	priority: "p1",
 	readyFor: "agent" as string | null,
 	assignee: null as string | null,
-	milestone: null as string | null,
+	milestone: HOME as string | null,
 	labels: [] as ReadonlyArray<string>,
 	repo: null,
 	env,
@@ -101,7 +105,7 @@ describe("runChild", () => {
 			epic: 4300,
 			child: 4301,
 			linked: true,
-			observed: {labels: [...MINTED_LABELS].sort(), assignees: [], milestone: null},
+			observed: {labels: [...MINTED_LABELS].sort(), assignees: [], milestone: HOME},
 			stories: [1, 2],
 			containment: "flag",
 		});
@@ -169,6 +173,40 @@ describe("runChild", () => {
 		expect(outcome.stderr.at(-1)).toBe(
 			"ledger child: --ready-for human requires --assignee — a held child is born assigned (#4693).",
 		);
+	});
+
+	/**
+	 * #5969: a child with neither an open milestone nor a standing lane is refused by the claim fence
+	 * at exit 20, so it can never be built. The three cases are the whole homing axis.
+	 */
+	it("refuses a homeless child before it reads anything, naming both remedies", async () => {
+		const {outcome, calls} = await run({milestone: null});
+		expect(outcome.code).toBe(OFF_VOCABULARY);
+		expect(outcome.stderr.at(-1)).toBe(
+			"ledger child: a child needs a home — pass --milestone <open milestone title>, or --label the child with the parent's standing lane (wayfinder:backlog, axis:pipeline-hardening). A homeless child is refused at the claim fence, so it can never be built (#5969).",
+		);
+		expect(calls).toEqual([]);
+	});
+
+	it("mints a milestone-homed child", async () => {
+		const {outcome, calls} = await run({milestone: HOME});
+		expect(outcome.code).toBe(0);
+		expect(calls.find((line) => CREATE.test(line)) ?? "").toContain("milestone=44");
+	});
+
+	/** ADR 0208's lane exemption holds here too — homing is never collapsed into "milestone required". */
+	it("mints a lane-homed child carrying no milestone", async () => {
+		const {outcome, calls} = await run({milestone: null, labels: [LANE]}, [
+			...HAPPY.filter(([pattern]) => pattern !== LABELS && pattern !== READBACK),
+			[LABELS, labelSet(...DEFAULT_LABELS, LANE)],
+			[READBACK, childIssue({number: 4301, labels: [...MINTED_LABELS, LANE]})],
+		]);
+		expect(outcome.code).toBe(0);
+		expect(JSON.parse(outcome.stdout).observed.milestone).toBe(null);
+		const create = calls.find((line) => CREATE.test(line)) ?? "";
+		expect(create).toContain(`labels[]=${LANE}`);
+		expect(create).not.toContain("milestone=");
+		expect(calls.some((line) => MILESTONES.test(line))).toBe(false);
 	});
 
 	it("refuses a retired priority", async () => {

--- a/packages/fabrika-cli/src/ledger/command.ts
+++ b/packages/fabrika-cli/src/ledger/command.ts
@@ -120,7 +120,7 @@ const child = leafCommand(
 		milestone: Flag.string("milestone").pipe(
 			Flag.optional,
 			Flag.withDescription(
-				"the title of an open milestone; absent mints an unhomed child the repo's homing guard will red",
+				"the title of an open milestone; required unless --label carries a standing lane (#5969)",
 			),
 		),
 		label: Flag.string("label").pipe(
@@ -161,7 +161,7 @@ const child = leafCommand(
 ).pipe(
 	Command.withShortDescription("Mint one child issue with every birth attribute at once."),
 	Command.withDescription(
-		'Mint one child with EVERY birth attribute in the one POST — title, body, every label, milestone and assignee — record it in the run manifest, link it as a native sub-issue, then re-read and report the OBSERVED result. Prints {"answer":"minted","epic":n,"child":n,"linked":true,"observed":{…},"stories":[…],"containment":"…"}. Exits 3 (stdin held nothing), 4 (the composed body\'s fields or sections do not parse: a malformed **Stories:** value, absent or malformed acceptance criteria, or a type:feature child whose **Containment:** is missing, unset or none while the cycle doc is present), 5 (machine-local path), 6 (bare @ reference), 7 (the epic is proven absent or closed), 8 (the create was attempted and no re-read could prove it — UNKNOWN), 9 (created and it does not read back as sent), 10 (a label, --type, --priority, --milestone or --ready-for off its closed vocabulary; --ready-for absent; --ready-for human without --assignee; or not a type:epic), 11 (a precondition read failed — NOTHING was created), 15 (this session does not hold the claim), 23 (created and the sub-issue link could not be proven), 26 (created and the run manifest could not be written). Example: fabrika ledger child 4300 --title "queue view: fate loader" --type type:feature --priority p1 --ready-for agent < child.md',
+		'Mint one child with EVERY birth attribute in the one POST — title, body, every label, milestone and assignee — record it in the run manifest, link it as a native sub-issue, then re-read and report the OBSERVED result. Prints {"answer":"minted","epic":n,"child":n,"linked":true,"observed":{…},"stories":[…],"containment":"…"}. Exits 3 (stdin held nothing), 4 (the composed body\'s fields or sections do not parse: a malformed **Stories:** value, absent or malformed acceptance criteria, or a type:feature child whose **Containment:** is missing, unset or none while the cycle doc is present), 5 (machine-local path), 6 (bare @ reference), 7 (the epic is proven absent or closed), 8 (the create was attempted and no re-read could prove it — UNKNOWN), 9 (created and it does not read back as sent), 10 (a label, --type, --priority, --milestone or --ready-for off its closed vocabulary; --ready-for absent; --ready-for human without --assignee; neither --milestone nor a standing-lane --label, so the child would be born homeless; or not a type:epic), 11 (a precondition read failed — NOTHING was created), 15 (this session does not hold the claim), 23 (created and the sub-issue link could not be proven), 26 (created and the run manifest could not be written). Example: fabrika ledger child 4300 --title "queue view: fate loader" --type type:feature --priority p1 --ready-for agent < child.md',
 	),
 );
 


### PR DESCRIPTION
`fabrika ledger child` minted epic children with no home: `--milestone` was optional and no
standing-lane label stood in for it. The claim fence reads only the issue's own milestone and lane
labels, so a homeless child is refused at exit `20` and can never be built — which is how epic
#5894's phase-1 builders both backed off before writing anything.

The refusal moves to the mint, beside the existing `--ready-for` one: a call naming neither an open
milestone nor a `STANDING_LANE_LABELS` label is refused on `10` before any read or create, naming
both remedies. The lane set is imported from `build/scope-admission.ts` rather than re-listed, so the
two seams cannot drift on what a home is; ADR 0208's lane exemption still admits a lane-labelled
child carrying no milestone.

Docs follow the enforcement: `plan-epic`'s degrade row for homing becomes fail-loud, and the
contract's input table, prose and error table carry the new refusal.

Fixes #5969

## Deviations

- **Pre-existing test or fixture changed** — **Said:** the criteria ask for three new unit tests.
  **Did:** also changed the shared test options in `child-verb.unit.test.ts` to carry a milestone,
  and the happy-path readback fixture and assertion with it. **Why:** the shared options minted a
  homeless child, so every existing case would now hit the new refusal instead of the behaviour it
  tests. **Disposition:** stated here; no assertion was weakened, all 24 cases still assert what
  they did.
- **Out-of-scope change** — **Said:** the criteria name `plan-epic/SKILL.md` only. **Did:** also
  updated `plan-epic/contract.md` and the `--milestone` flag description plus the exit-`10` summary
  in `ledger/command.ts`. **Why:** all three state `--milestone` as optional and would contradict
  the verb the moment this lands. **Disposition:** stated here.
