### PR TITLE
fix: lane report's shipper ROUTED token cannot distinguish repair from heal-ci/review, so #5807's ship FAIL edge is half-reachable

### DIFF
--- a/claude-plugins/fabrika/skills/ship/SKILL.md
+++ b/claude-plugins/fabrika/skills/ship/SKILL.md
@@ -182,8 +182,11 @@ implementation, no review verdict, no flag flip. Every run ends as exactly one o
 **already-merged (idempotent success)** · **QUEUED — enqueued, awaiting the queue** (success
 without a merge observed) · **landed** · **refused — <reason>** (a successful decline: disarmed,
 noted, nothing mutated beyond the note) · **awaiting control-plane approval** · **routed to
-repair / heal-ci / review** · **UNRESOLVED at horizon** · **EJECTED — routed to repair** ·
-**UNKNOWN — a read failed** (never rendered as any of the above). A refusal is not a back-off:
+repair** · **routed to heal-ci** · **routed to review** · **UNRESOLVED at horizon** ·
+**EJECTED — routed to repair** ·
+**UNKNOWN — a read failed** (never rendered as any of the above). The three routings are three
+terminals, not one: repair is work this lane retries, heal-ci and review are waits it cannot, and
+a flat "routed" parked the lane on an approval nobody was waiting on (#6002). A refusal is not a back-off:
 it names what was proven; UNKNOWN names what was not. Branch disposition is always "untouched" —
 this skill owns no branch. If any disarm failed, the report carries `merge intent: NOT cleared`.
 A note that routes another lane opens with the fixed first line
@@ -192,9 +195,11 @@ branded reference, no steering prose; the receiver re-fetches from the PR itself
 
 **Record the terminal yourself, then print it.** When your spawn brief named a lane, your terminal
 step is the verb — pass back the `lane` and `root` its `## Task` section carries, one token per
-terminal above (`ALREADY-MERGED`, `QUEUED`, `LANDED`, `REFUSED`, `AWAITING-CP-APPROVAL`, `ROUTED`,
-`UNRESOLVED`, `EJECTED`, `UNKNOWN`), mapped to a lane event in its code, with the PR as the event's
-evidence (#5736):
+terminal above (`ALREADY-MERGED`, `QUEUED`, `LANDED`, `REFUSED`, `AWAITING-CP-APPROVAL`,
+`ROUTED-REPAIR`, `ROUTED-HEAL-CI`, `ROUTED-REVIEW`, `UNRESOLVED`, `EJECTED`, `UNKNOWN`), mapped to a
+lane event in its code, with the PR as the event's evidence (#5736). The routing token names the arm
+your note's first line already names — report the one you took, never a bare `ROUTED`, which is the
+reviewer's token and means something else:
 
 ```bash
 node packages/fabrika-cli/src/bin.ts lane report <lane> --root <root> --token LANDED --pr <pr-url>

--- a/packages/fabrika-cli/src/lane/report.ts
+++ b/packages/fabrika-cli/src/lane/report.ts
@@ -37,7 +37,13 @@ export const SHELL_VOCABULARIES = {
 		LANDED: "DONE",
 		REFUSED: "BLOCKED",
 		"AWAITING-CP-APPROVAL": "BLOCKED",
-		ROUTED: "BLOCKED",
+		// A routing terminal names its arm, because the three arms are three different answers to
+		// the machine: repair is work this lane can retry, heal-ci and review are waits it cannot
+		// (#6002). A shipper that routed to repair and reported one flat `ROUTED` parked the lane
+		// on a control-plane approval nobody was waiting on.
+		"ROUTED-REPAIR": "FAIL",
+		"ROUTED-HEAL-CI": "BLOCKED",
+		"ROUTED-REVIEW": "BLOCKED",
 		UNRESOLVED: "BLOCKED",
 		// An ejection is always "routed to repair", so it feeds the machine's `ship` FAIL edge and
 		// spends a retry rather than parking the lane (#5807).
@@ -46,10 +52,50 @@ export const SHELL_VOCABULARIES = {
 	},
 } as const satisfies Readonly<Record<string, Readonly<Record<string, OperatorEvent>>>>;
 
-const TOKEN_EVENTS: Readonly<Record<string, OperatorEvent>> = Object.assign(
-	{},
-	...Object.values(SHELL_VOCABULARIES),
-);
+export type Flattening =
+	| {readonly _tag: "Flat"; readonly tokens: Readonly<Record<string, OperatorEvent>>}
+	| {readonly _tag: "Collision"; readonly collisions: ReadonlyArray<string>};
+
+/**
+ * Flatten the per-shell vocabularies into the one map `lane report` looks a bare token up in, and
+ * name every disagreement rather than resolve it.
+ *
+ * `lane report` takes no shell argument — a token is all a shell hands over — so the lookup has to
+ * be flat, and two shells may legitimately share a spelling: `UNKNOWN` is both the reviewer's and
+ * the shipper's, and means `BLOCKED` in both. What must never happen is two shells spelling one
+ * token with *different* events. A plain spread resolves that to whichever group is written last,
+ * silently rewriting the loser's event; here it is a `Collision` the caller cannot read past.
+ */
+export const flattenVocabularies = (
+	vocabularies: Readonly<Record<string, Readonly<Record<string, OperatorEvent>>>>,
+): Flattening => {
+	const tokens: Record<string, OperatorEvent> = {};
+	const owners: Record<string, string> = {};
+	const collisions: string[] = [];
+	for (const [shell, vocabulary] of Object.entries(vocabularies)) {
+		for (const [token, event] of Object.entries(vocabulary)) {
+			const seen = tokens[token];
+			if (seen !== undefined && seen !== event) {
+				collisions.push(`${token}: ${owners[token]} reports ${seen}, ${shell} reports ${event}`);
+				continue;
+			}
+			tokens[token] = event;
+			owners[token] = shell;
+		}
+	}
+	return collisions.length === 0
+		? {_tag: "Flat", tokens}
+		: {_tag: "Collision", collisions: collisions.sort()};
+};
+
+const flattened = flattenVocabularies(SHELL_VOCABULARIES);
+if (flattened._tag === "Collision") {
+	throw new Error(
+		`lane report: the shell vocabularies disagree on ${flattened.collisions.length} token(s) — ${flattened.collisions.join("; ")}. Give the arms distinct spellings; one flat lookup cannot hold both.`,
+	);
+}
+
+const TOKEN_EVENTS: Readonly<Record<string, OperatorEvent>> = flattened.tokens;
 
 /** The recognised tokens, for the refusal message — sorted so the listing is deterministic. */
 export const KNOWN_TOKENS: ReadonlyArray<string> = Object.keys(TOKEN_EVENTS).sort();

--- a/packages/fabrika-cli/src/lane/report.unit.test.ts
+++ b/packages/fabrika-cli/src/lane/report.unit.test.ts
@@ -1,0 +1,59 @@
+import {describe, expect, it} from "vitest";
+import {eventForToken, flattenVocabularies, SHELL_VOCABULARIES} from "./report.ts";
+
+describe("the shipper's routing arms are three answers, not one", () => {
+	it("routes the repair arm to FAIL so the ship state spends a retry back into build", () => {
+		expect(eventForToken("ROUTED-REPAIR")).toEqual({
+			_tag: "Mapped",
+			token: "ROUTED-REPAIR",
+			event: "FAIL",
+		});
+		expect(eventForToken("EJECTED")).toEqual({_tag: "Mapped", token: "EJECTED", event: "FAIL"});
+	});
+
+	it("leaves the heal-ci and review arms BLOCKED — neither is work this lane can retry", () => {
+		expect(eventForToken("ROUTED-HEAL-CI")).toMatchObject({event: "BLOCKED"});
+		expect(eventForToken("ROUTED-REVIEW")).toMatchObject({event: "BLOCKED"});
+	});
+
+	it("no longer recognises a bare ROUTED as the shipper's — the reviewer's is what it resolves to", () => {
+		expect(SHELL_VOCABULARIES.shipper).not.toHaveProperty("ROUTED");
+		expect(eventForToken("ROUTED")).toEqual({_tag: "Mapped", token: "ROUTED", event: "BLOCKED"});
+	});
+});
+
+describe("flattening the per-shell vocabularies", () => {
+	it("flattens the real vocabularies with nothing overwritten", () => {
+		const flat = flattenVocabularies(SHELL_VOCABULARIES);
+		expect(flat).toMatchObject({_tag: "Flat"});
+	});
+
+	it("keeps a token two shells spell the same way when they agree on the event", () => {
+		const flat = flattenVocabularies({
+			reviewer: {UNKNOWN: "BLOCKED"},
+			shipper: {UNKNOWN: "BLOCKED"},
+		});
+		expect(flat).toEqual({_tag: "Flat", tokens: {UNKNOWN: "BLOCKED"}});
+	});
+
+	it("names a token two shells spell the same way with different events, both sides in the reason", () => {
+		const flat = flattenVocabularies({
+			reviewer: {ROUTED: "BLOCKED"},
+			shipper: {ROUTED: "FAIL"},
+		});
+		expect(flat._tag).toBe("Collision");
+		if (flat._tag !== "Collision") return;
+		expect(flat.collisions).toEqual(["ROUTED: reviewer reports BLOCKED, shipper reports FAIL"]);
+	});
+
+	it("catches the collision whichever shell is written last", () => {
+		const flat = flattenVocabularies({
+			shipper: {ROUTED: "FAIL"},
+			reviewer: {ROUTED: "BLOCKED"},
+		});
+		expect(flat).toMatchObject({
+			_tag: "Collision",
+			collisions: ["ROUTED: shipper reports FAIL, reviewer reports BLOCKED"],
+		});
+	});
+});


### PR DESCRIPTION
The shipper spelled all three of its routing outcomes as one token, `ROUTED`, so the token map
could not tell "routed to repair" from "routed to heal-ci / review". It had to map the lot to
`BLOCKED`, and at the `ship` state `ISSUE.BLOCKED` targets `human:cp-approval` — a lane that
routed to repair parked waiting on a human nobody had asked, instead of spending a retry back
into `build`.

Split it into three tokens the shipper already knows apart (its note's first line names the arm):

- `ROUTED-REPAIR` → `FAIL`, which is the `ship` FAIL edge #5988 recorded
- `ROUTED-HEAL-CI` → `BLOCKED`
- `ROUTED-REVIEW` → `BLOCKED`

`EJECTED` was already `FAIL`. The reviewer keeps the bare `ROUTED` → `BLOCKED`, and now nothing
overwrites it.

The flattening changed too. `Object.assign` over the three shell vocabularies resolved a
same-named token to whichever group was spread last, so a future per-shell divergence would have
silently rewritten the loser's event with nothing failing. `flattenVocabularies` returns a
`Collision` naming both sides instead, and the module refuses to load on one. Tokens two shells
spell alike and agree on still flatten fine — `UNKNOWN` is both the reviewer's and the shipper's,
`BLOCKED` in both.

`ship/SKILL.md`'s terminal vocabulary now lists the three routing terminals separately and its
report token list names the three spellings, so what the shipper is told to emit is what the map
keys on.

Tests: the existing per-token loop in `report-verb.unit.test.ts` picks up the three new tokens
automatically and drives each through the real machine from the `ship` state. New
`report.unit.test.ts` covers the repair-vs-heal-ci/review split, the reviewer's `ROUTED` surviving
the shipper's, and the collision case in both shell orders.

Fixes #6002

## Deviations

None.
