### PR TITLE
fix: Two reviewers split on whether governance is owed on an epic child's range verdict

### DIFF
--- a/claude-plugins/fabrika/skills/governance/SKILL.md
+++ b/claude-plugins/fabrika/skills/governance/SKILL.md
@@ -189,6 +189,41 @@ the green is the job's own. Its last stderr line says which of `refired` / `gree
 `in-flight` or `unknown` floor means the check may still red at this head, and clearing it is
 `heal-ci`'s, not a human's.
 
+### The range form — an epic child's verdict
+
+An epic run opens one tail PR (ADR [0285](../../../../.decisions/0285-epic-machine-ends-in-review.md)),
+so mid-run a child has no PR and no head to bind to. Same verb, two ends instead of a head, and the
+positional is the **child issue**. §1's `scope` takes a PR and has no range form, so on a child the
+range comes from your caller and the derivation is re-run by `post` itself over that range — the
+`14` refusal below is the same fail-closed floor, asked of the range's paths:
+
+```bash
+fabrika governance post 6007 --polarity PASS --base 4f2a91c1 --tip 9b516363 --clause "no contradiction, no weakening" <<'EOF'
+…the same verdict body…
+EOF
+```
+
+What the verb refuses here is what tells you the shape is not the PR one:
+
+- **`--base` and `--tip` come together, and both are revisions** — 7–40 lowercase hex. A branch name
+  is refused, so resolve the range's ends before you call.
+- **`--sha` does not combine with them.** A range verdict binds **content, not a head** (ADR
+  [0276](../../../../.decisions/0276-verdict-binds-content-not-only-head.md)): the two revisions
+  stop being history the moment the range merges into the epic branch, so what a later read compares
+  is the digest of `<base>...<tip>`, and `lane prove`'s child arm calls a verdict whose digest no
+  longer matches `Stale`.
+- **The positional is an open issue, not a PR.** Hand it a PR number and the verb says so and sends
+  you back to `--sha`.
+- **The requirement is re-derived from the range's own changed paths**, through the same
+  governance-root floor as the PR path — a range touching none is the same `14` refusal, so this
+  form cannot attest a scope nobody derived either.
+- **No floor line comes back.** `governance-floor` runs on `pull_request` and a child has no PR, so
+  there is nothing to re-fire; the tail PR carries that check when it opens.
+
+**Done when** `post` prints `posted` over the range you judged and its read-back conformed. Which
+namespaces a child owes at all — governance among them — is `review`'s §6, and it defers nothing to
+the tail.
+
 ## 6 — Digest time: the readout that replaced the human gate
 
 `--since` is the day after the previous readout's last landing — read it off the artifact before you

--- a/claude-plugins/fabrika/skills/review/SKILL.md
+++ b/claude-plugins/fabrika/skills/review/SKILL.md
@@ -149,6 +149,26 @@ undisclosed that this gate could see"* — never "no deviations exist".
   repair undispatchable. Fire it, and expect to fire it again at each repair head — the extra run
   is the accepted cost. Neither namespace discharges the other. You never emit governance's
   namespace yourself.
+- **On an epic child the governance verdict is range-scoped and lands on the child issue** —
+  nothing governance-shaped waits for the epic tail. An epic run opens one tail PR (ADR
+  [0285](../../../../.decisions/0285-epic-machine-ends-in-review.md)), so mid-run a child has no PR
+  a head could bind to, and `lane prove`'s child arm derives that child's namespaces from the
+  **range's own changed paths** through the same `touchesGovernanceRoot` floor it uses on a PR
+  ([`prove-verb.ts`](../../../../packages/fabrika-cli/src/lane/prove-verb.ts)) — a range touching a
+  governance root derives `governance` exactly as a PR diff does. So post every namespace the range
+  derives over that range, on the child issue, with `--base`/`--tip` in place of `--sha`: yours
+  through `fabrika review post <child-issue> --namespace <ns> --base <b> --tip <t>`, governance's
+  through the `governance` skill's own range form (its §5). What binds is content, not a head (ADR
+  [0276](../../../../.decisions/0276-verdict-binds-content-not-only-head.md)). Deferring the
+  namespace strands the lane whichever polarity you reached: a claimed `PASS` reds at `lane prove`
+  exit `23`, and a `FAIL` is recorded only once every derived namespace is terminal against the
+  range (`operate`'s `FAIL` row). The every-round rule above is unchanged here — a child's FAIL
+  round owes its governance verdict too.
+- **The tail's own review is a separate subject, so this is not a double post.** The tail PR's
+  namespaces are derived from the tail PR's own diff and its verdicts are head-bound on that PR; a
+  child's are derived from the child's range and are content-bound on the child issue. Posting on
+  the child discharges the child, never the tail, and re-posting a child's verdict onto the tail
+  discharges nothing — the two reads ask different scopes.
 - `self: true` (the diff touches `claude-plugins/fabrika/skills/review/`) ⇒ a PR must not review
   itself by its own new rules: re-read this `SKILL.md` and the rubrics at the **merge-base**
   revision (`git show` — a bytes read that loads no instructions) and judge by those.


### PR DESCRIPTION
Two reviewers on two children of the same epic split on whether the `governance` namespace belongs on a child's range verdict or waits for the epic tail. The verbs already answered: `lane prove`'s child arm derives `governance` off the range's own changed paths with the same `touchesGovernanceRoot` floor it uses on a PR, and `governance post --base/--tip <child-issue>` is the emit path for it. Only the two skills a reviewer reads were silent.

`review/SKILL.md` §6 gains two bullets: on an epic child every namespace the range derives — governance included — is posted range-scoped on the child issue with `--base`/`--tip`, nothing is deferred to the tail, and a deferred namespace strands the lane at either polarity (`lane prove` exit `23` on a claimed PASS, `operate`'s all-namespaces-terminal floor on a FAIL). The second bullet says the tail PR's review is its own subject with its own derived namespaces, so the child rule is not a licence to double-post. Both are worded to sit with ADR 0293, which merged today and put the every-round rule in the bullet above them.

`governance/SKILL.md` §5 gains the range form beside the `--sha` one: the positional is the child issue, both ends are revisions in hex, `--sha` is refused because content and not a head is the binding (ADR 0276), the governance-root floor is re-derived over the range, a PR number is refused, and no floor line comes back because `governance-floor` runs on `pull_request`.

Every sentence was checked against `packages/fabrika-cli/src/lane/prove-verb.ts`, `governance/post-verb.ts` and `review/range-post.ts`. No code changed.

A reviewer should look first at whether the §6 bullets and the ADR 0293 bullet above them read as one rule rather than two.

Fixes #6043

## Deviations

- **Out-of-scope change** — **Said:** #6043 scopes the §5 edit to documenting `governance post`'s range form. **Did:** also added one sentence naming that §1's `governance scope` has no range form, so on a child the range comes from the caller. **Why:** without it a reader following §1 then §5 hits a verb that refuses a child issue, and the section would document a path its own predecessor cannot reach. **Disposition:** stated here; the underlying gap (`scope` and `base` are both PR-shaped, so §4's self fence is unrunnable on a child) is filed as #6064.
- **Known defect left unfixed** — **Said:** nothing about #6058. **Did:** left #6058 open and uncorrected. **Why:** it claims `governance post` does not apply to an epic-lane range, which is wrong — the range form landed under #5935 and is what this PR documents. Its other half (`review post`'s ranged admit derives namespaces from a different partition than the ship side) is a real code defect outside this ticket's no-behaviour-change fence. **Disposition:** stated here for triage; not edited from this lane.
