### PR TITLE
feat: Operate's BLOCKED path owes a dead spawn its residue: file its report, release its claim

### DIFF
--- a/claude-plugins/fabrika/skills/operate/SKILL.md
+++ b/claude-plugins/fabrika/skills/operate/SKILL.md
@@ -305,6 +305,27 @@ Two reads stay yours, because no shell can take them:
   machine (`FAIL` spends one; `frozen` is its answer), and you never re-spawn what the fold has not
   re-asked for. Record `BLOCKED`.
 
+**A dead spawn's residue is yours to clear** — the founder's ruling on
+[#5752](https://github.com/kamp-us/phoenix/issues/5752). `BLOCKED` records where the lane stands; it
+does not clean up after the shell that died, and what a dead spawn leaves behind is an incident
+nobody filed and a claim nobody can take. Three obligations, in this order:
+
+- **Read its final message.** What the spawn printed before it stopped is the only account of what
+  it was doing, and both the filing and the park comment come out of it.
+- **File what it could not file.** A dying agent cannot run `fabrika report file` itself, so the
+  incident reaches the board only if you file it — through [`report`](../report/SKILL.md), as the
+  spawn would have.
+- **Release the claim it stranded.** `node packages/fabrika-cli/src/bin.ts build release <issue>`
+  is the whole act: the spawn ran under your `CLAUDE_CODE_SESSION_ID`, so its marker resolves as
+  this session's and the verb that already exists retracts it. No new verb and no widened one — the
+  ruling rejected a lease, a TTL, supersession and steal outright, and eviction by inference from
+  absence stays banned (ADR
+  [0215](../../../../.decisions/0215-claim-identity-continuity-proof.md) §5).
+
+**A claim held by a different, gone session is not yours to release.** `build release` refuses it on
+exit `15`, proven-foreign, and that refusal is the guard rather than an obstacle to reason past.
+Name that claim in the park comment with its token and leave it to a human.
+
 **Every event is proven first — artifacts over self-reports.** A report is
 data; what moves the machine is the artifact behind it. The verb below is the read `lane report`
 already ran for the shell; on your own two records it is yours to run. The retired epic conductor held this rule


### PR DESCRIPTION
The operate skill routed a dead spawn to `BLOCKED` and parked, and nothing obligated the driver to
clean up after it. Two things were left behind every time: an incident nobody filed (the dying agent
cannot run `fabrika report file` itself) and a build claim nobody could take (#5760 is the downstream
nonce disagreement one such strand caused).

This adds one paragraph plus three bullets to step 3, immediately after the bullet that diagnoses a
dead spawn as a `BLOCKED`-class outcome — the line a driver actually hits when a spawn goes quiet.
It states the three obligations (read the final message; file through `report` what the spawn could
not; release the stranded claim with `build release`), names `build release` as the existing verb
that works because the spawn ran under the driver's `CLAUDE_CODE_SESSION_ID`, and writes down the
cross-session carve-out: a claim taken by a different, gone session refuses on exit `15` and stays a
human act, named in the park comment with its token.

No CLI change. `runRelease` in `packages/fabrika-cli/src/build/claim-verb.ts` already refuses a
foreign session's claim (`CLAIM_NOT_MINE`, exit `15`), so the carve-out is enforced by the verb and
not only by the prose. The claim protocol is untouched — no lease, no TTL, no supersession, no
steal.

Fixes #5795

## Deviations

- **Out-of-scope change** — **Said:** #5795 names the skill edit only. **Did:** also left a stray
  branch `build/5795-dead-spawn-residue-0c713d74` checked out in the operator's primary checkout,
  which is now off `main` at `main`'s commit with a clean tree. **Why:** I ran `build branch` once
  with a `cd` into the shared checkout before the isolation guard caught the mistake, and the
  worktree guard blocks me from switching that checkout back. **Disposition:** stated here; the
  operator restores it with `git switch main` and `git branch -d build/5795-dead-spawn-residue-0c713d74`.
  Filed separately as a gap in the isolation guard.
