### PR TITLE
fix: build eligible blocks every epic child on its siblings, because a one-PR epic run keeps them all open until the tail merges

### DIFF
--- a/claude-plugins/fabrika/skills/build/contract.md
+++ b/claude-plugins/fabrika/skills/build/contract.md
@@ -55,7 +55,7 @@ second answer to a gated question can contradict the gate (interface convention 
 |---|---|---|
 | `build tree` | prove the ground: optionally clean, optionally this lane's | two git-derivable assertions — no judgment; *what to do on a refusal* (stop, report) stays in the skill |
 | `build pick` | the ranked candidate pool: `status:triaged` + `ready-for:agent` + unassigned, paginated | a label/assignee filter over a paged listing — no judgment; the *choice* among candidates stays in the skill |
-| `build eligible` | one issue's dependency gate: `eligible` / blocked-by-named-edge / UNKNOWN | derivable entirely from the parent ledger's `## Dependencies` and issue states |
+| `build eligible` | one issue's dependency gate: `eligible` / blocked-by-named-edge / UNKNOWN | derivable entirely from the parent ledger's `## Dependencies`, issue states, and the commits `epic/<parent>` carries in this tree |
 | `build claim` | race the earliest-authorized claim on an issue; win, or name the winner | a deterministic race protocol; *what to do on a loss* stays in the skill |
 | `build confirm` | re-prove this session still holds the claim before a mutation | a lookup with a defined answer |
 | `build release` | retract this session's own claim | a guarded single write |
@@ -514,6 +514,22 @@ from one call, not one edge per call. Blockedness is **derived from the topology
 label** — a label is a claim, the topology is the fact. The parent body arrives through the content
 gate.
 
+**A predecessor is discharged from two sources, and the second one is git** (#6063). It is
+discharged when its issue is closed **or** when the parent epic's assembly branch, `epic/<parent>`,
+carries a commit whose message names it. Under ADR 0285 an epic run is one branch and one PR, so no
+child issue closes until the tail PR merges — reading only the closed state would make every
+phase-2-or-later child of a run in flight permanently blocked, on a gate that cannot be satisfied
+before the epic it blocks has shipped. The branch name is derived from the parent's number, never
+taken from a caller, and the message is read with the same `#<n>` rule `build commit` and
+`lane prove` use.
+
+The second source only ever discharges, and only on evidence it read: a branch this tree does not
+carry, or a git read that failed, leaves every edge exactly as the board gave it — `16` for an open
+one, `11` for an unread one — and names the unread branch on stderr. A ledger-local `C<int>` ref is
+never discharged this way, since no commit can name an issue nobody filed. The branch is read only
+when at least one edge is still undischarged, so a standalone issue and a child whose predecessors
+are all closed make no git call at all.
+
 **Every predecessor is read before the answer is seated**, so the answer never depends on the order
 the topology lists them in. A predecessor whose state could not be read is its **own reported row**
 on stderr, never counted closed: beside a *proven* open edge it leaves the verdict `16` (one proven
@@ -545,7 +561,7 @@ and the whole derivation refuses on `4` — "no parseable edges" is never read a
 | `4` | the parent ledger was read but its `## Dependencies` block is absent or unparseable — eligibility cannot be derived, fail-closed |
 | `7` | the issue is proven absent (404) or closed |
 | `11` | the issue, parent, or any predecessor could not be read — eligibility is UNKNOWN |
-| `16` | proven blocked — an open predecessor or `requires:` edge, named on stderr |
+| `16` | proven blocked — an open predecessor or `requires:` edge no commit on `epic/<parent>` discharges, named on stderr |
 
 **Errors**
 
@@ -557,8 +573,12 @@ and the whole derivation refuses on `4` — "no parseable edges" is never read a
 | `build eligible: <n> predecessors could not be read — eligibility is UNKNOWN, never "eligible".` | 11 | refusal |
 | `build eligible: cannot read <edge-kind> predecessor #<m>: <reason> — its state is UNKNOWN, never counted closed.` | 11 or 16 | detail line, one per unread predecessor |
 | `build eligible: blocked by <n> open dependency edges: <edge-kind> #<m>, <edge-kind> #<k>.` | 16 | refusal |
+| `build eligible: epic/<p> carries a commit naming #<m> — that work landed on the epic run's assembly branch, so the edge is discharged whatever the board says about the issue (ADR 0285).` | 0, 11 or 16 | detail line, once |
+| `build eligible: epic/<p> carries <n> commit(s), none naming an undischarged predecessor.` | 11 or 16 | detail line, once |
+| `build eligible: cannot read epic/<p> in this tree: <reason> — no edge is counted discharged off it, and every edge keeps the state the board gave it.` | 11 or 16 | detail line, once |
 
-**Scope** — one issue, its parent (if any), and every predecessor the parent's topology names.
+**Scope** — one issue, its parent (if any), every predecessor the parent's topology names, and —
+only when an edge is still undischarged — `epic/<parent>` in this tree.
 The scope line on stderr counts the edges checked, so `eligible` is readable as "N edges, all
 closed", never as "no edges found". An edge whose state could not be read is subtracted from that
 claim by its own stderr row, so "all closed" is never asserted over an edge nobody could see.
@@ -587,9 +607,23 @@ $ echo $?
 16
 ```
 
+```
+$ fabrika build eligible 6007
+build eligible: scanned 1 dependency edge; parent #5817.
+build eligible: epic/5817 carries a commit naming #6004 — that work landed on the epic run's assembly branch, so the edge is discharged whatever the board says about the issue (ADR 0285).
+{"answer":"eligible","number":6007,"parent":5817}
+$ echo $?
+0
+```
+
 **Grounding**
 
 - #4244 — lane entry must refuse while a `requires:` member is open.
+- #6063 — inside a one-PR epic run every predecessor issue is open by design (ADR 0285), so the
+  closed-state proxy made the gate structurally unsatisfiable: no child could become eligible before
+  the epic shipped, and no epic could ship before its children built. The fix is the second
+  discharge source, reading the assembly branch the way `lane prove` already reads a child's range —
+  never a skip of the gate, and never a discharge off the lane's own fold (ADR 0283).
 - #4920 — the eligibility question needed a verb; prose-derived blockedness was re-derived
   differently per session. Its acceptance also fixes two properties of the answer: a `blocked`
   refusal names **every** open edge, and every unreadable input on the path is `11` with a test

--- a/claude-plugins/fabrika/skills/build/contract.md
+++ b/claude-plugins/fabrika/skills/build/contract.md
@@ -55,7 +55,7 @@ second answer to a gated question can contradict the gate (interface convention 
 |---|---|---|
 | `build tree` | prove the ground: optionally clean, optionally this lane's | two git-derivable assertions — no judgment; *what to do on a refusal* (stop, report) stays in the skill |
 | `build pick` | the ranked candidate pool: `status:triaged` + `ready-for:agent` + unassigned, paginated | a label/assignee filter over a paged listing — no judgment; the *choice* among candidates stays in the skill |
-| `build eligible` | one issue's dependency gate: `eligible` / blocked-by-named-edge / UNKNOWN | derivable entirely from the parent ledger's `## Dependencies`, issue states, and the commits `epic/<parent>` carries in this tree |
+| `build eligible` | one issue's dependency gate: `eligible` / blocked-by-named-edge / UNKNOWN | derivable entirely from the parent ledger's `## Dependencies`, issue states, and the commits `epic/<parent>` adds over the trunk in this tree |
 | `build claim` | race the earliest-authorized claim on an issue; win, or name the winner | a deterministic race protocol; *what to do on a loss* stays in the skill |
 | `build confirm` | re-prove this session still holds the claim before a mutation | a lookup with a defined answer |
 | `build release` | retract this session's own claim | a guarded single write |
@@ -523,9 +523,17 @@ before the epic it blocks has shipped. The branch name is derived from the paren
 taken from a caller, and the message is read with the same `#<n>` rule `build commit` and
 `lane prove` use.
 
+**"Carries" is the run's own commits, and the range is stated in every line the verb prints**:
+`<merge base with the trunk>..epic/<parent>`, the two-dot shape `lane prove` locates a child's range
+with, where the trunk is `origin/<the repo's default branch>`. Not everything reachable from the
+branch tip — that set is the whole trunk history the branch was cut from, and since the `#<n>` rule
+matches a bare mention anywhere in a message, an old commit writing "blocked on #<n>" would
+discharge an edge whose work was never built.
+
 The second source only ever discharges, and only on evidence it read: a branch this tree does not
-carry, or a git read that failed, leaves every edge exactly as the board gave it — `16` for an open
-one, `11` for an unread one — and names the unread branch on stderr. A ledger-local `C<int>` ref is
+carry, a trunk this repo would not name, no merge base, or a git read that failed, leaves every edge
+exactly as the board gave it — `16` for an open one, `11` for an unread one — and names the unread
+branch on stderr. A ledger-local `C<int>` ref is
 never discharged this way, since no commit can name an issue nobody filed. The branch is read only
 when at least one edge is still undischarged, so a standalone issue and a child whose predecessors
 are all closed make no git call at all.
@@ -561,7 +569,7 @@ and the whole derivation refuses on `4` — "no parseable edges" is never read a
 | `4` | the parent ledger was read but its `## Dependencies` block is absent or unparseable — eligibility cannot be derived, fail-closed |
 | `7` | the issue is proven absent (404) or closed |
 | `11` | the issue, parent, or any predecessor could not be read — eligibility is UNKNOWN |
-| `16` | proven blocked — an open predecessor or `requires:` edge no commit on `epic/<parent>` discharges, named on stderr |
+| `16` | proven blocked — an open predecessor or `requires:` edge no commit in `<base>..epic/<parent>` discharges, named on stderr |
 
 **Errors**
 
@@ -573,9 +581,9 @@ and the whole derivation refuses on `4` — "no parseable edges" is never read a
 | `build eligible: <n> predecessors could not be read — eligibility is UNKNOWN, never "eligible".` | 11 | refusal |
 | `build eligible: cannot read <edge-kind> predecessor #<m>: <reason> — its state is UNKNOWN, never counted closed.` | 11 or 16 | detail line, one per unread predecessor |
 | `build eligible: blocked by <n> open dependency edges: <edge-kind> #<m>, <edge-kind> #<k>.` | 16 | refusal |
-| `build eligible: epic/<p> carries a commit naming #<m> — that work landed on the epic run's assembly branch, so the edge is discharged whatever the board says about the issue (ADR 0285).` | 0, 11 or 16 | detail line, once |
-| `build eligible: epic/<p> carries <n> commit(s), none naming an undischarged predecessor.` | 11 or 16 | detail line, once |
-| `build eligible: cannot read epic/<p> in this tree: <reason> — no edge is counted discharged off it, and every edge keeps the state the board gave it.` | 11 or 16 | detail line, once |
+| `build eligible: origin/<trunk>..epic/<p> adds a commit naming #<m> — that work landed on the epic run's assembly branch, so the edge is discharged whatever the board says about the issue (ADR 0285).` | 0, 11 or 16 | detail line, once |
+| `build eligible: origin/<trunk>..epic/<p> adds <n> commit(s), none naming an undischarged predecessor.` | 11 or 16 | detail line, once |
+| `build eligible: cannot read epic/<p> in this tree: <reason> — no edge is counted discharged off it, and every edge keeps the state the board gave it.` (`<reason>` also covers an unnameable trunk and an absent merge base — the range's other two endpoints) | 11 or 16 | detail line, once |
 
 **Scope** — one issue, its parent (if any), every predecessor the parent's topology names, and —
 only when an edge is still undischarged — `epic/<parent>` in this tree.
@@ -610,7 +618,7 @@ $ echo $?
 ```
 $ fabrika build eligible 6007
 build eligible: scanned 1 dependency edge; parent #5817.
-build eligible: epic/5817 carries a commit naming #6004 — that work landed on the epic run's assembly branch, so the edge is discharged whatever the board says about the issue (ADR 0285).
+build eligible: origin/main..epic/5817 adds a commit naming #6004 — that work landed on the epic run's assembly branch, so the edge is discharged whatever the board says about the issue (ADR 0285).
 {"answer":"eligible","number":6007,"parent":5817}
 $ echo $?
 0
@@ -623,7 +631,9 @@ $ echo $?
   closed-state proxy made the gate structurally unsatisfiable: no child could become eligible before
   the epic shipped, and no epic could ship before its children built. The fix is the second
   discharge source, reading the assembly branch the way `lane prove` already reads a child's range —
-  never a skip of the gate, and never a discharge off the lane's own fold (ADR 0283).
+  never a skip of the gate, and never a discharge off the lane's own fold (ADR 0283). Its review
+  round then bounded that read to the run's own commits: an unbounded walk let a `#<n>` written
+  anywhere in the trunk's history discharge an edge, which is the same fail-open by another route.
 - #4920 — the eligibility question needed a verb; prose-derived blockedness was re-derived
   differently per session. Its acceptance also fixes two properties of the answer: a `blocked`
   refusal names **every** open edge, and every unreadable input on the path is `11` with a test

--- a/packages/fabrika-cli/src/build/eligible-verb.ts
+++ b/packages/fabrika-cli/src/build/eligible-verb.ts
@@ -15,7 +15,8 @@
  * ADR 0285 an epic run's children stay open until the single tail PR merges, so inside a run the
  * closed-state proxy answers "is the issue closed" where the gate means "did the work land" — and
  * reading only the first makes every phase-2 child unbuildable until the epic it blocks has shipped.
- * The second source is evidence, not a skip: no assembly branch, no discharge.
+ * The second source is evidence, not a skip: no assembly branch, no discharge — and the evidence is
+ * only what the run added over the trunk, never the history the branch was cut from.
  *
  * **Every predecessor is scanned before the answer is seated, so the answer does not depend on the
  * order the topology happens to list them in.** One *proven* open edge is proof of blockedness
@@ -57,12 +58,13 @@ const assemblyNotes = (
 			`${VERB}: cannot read ${assembly.branch} in this tree: ${assembly.reason} — no edge is counted discharged off it, and every edge keeps the state the board gave it.`,
 		];
 	}
+	const range = `${assembly.baseRef}..${assembly.branch}`;
 	return discharged.length === 0
 		? [
-				`${VERB}: ${assembly.branch} carries ${assembly.commits} commit(s), none naming an undischarged predecessor.`,
+				`${VERB}: ${range} adds ${assembly.commits} commit(s), none naming an undischarged predecessor.`,
 			]
 		: [
-				`${VERB}: ${assembly.branch} carries a commit naming ${discharged.map((edge) => `#${edge.number}`).join(", ")} — that work landed on the epic run's assembly branch, so the edge is discharged whatever the board says about the issue (ADR 0285).`,
+				`${VERB}: ${range} adds a commit naming ${discharged.map((edge) => `#${edge.number}`).join(", ")} — that work landed on the epic run's assembly branch, so the edge is discharged whatever the board says about the issue (ADR 0285).`,
 			];
 };
 
@@ -152,7 +154,7 @@ export const runEligible = (
 		}
 
 		const undischarged = [...open, ...unread].some((edge) => edge.number !== null);
-		const assembly = undischarged ? yield* readAssembly(parent.value) : null;
+		const assembly = undischarged ? yield* readAssembly(repo, parent.value) : null;
 		const landed = assembly?._tag === "Read" ? assembly.landed : new Set<number>();
 		const carries = (edge: Edge) => edge.number !== null && landed.has(edge.number);
 		const stillOpen = open.filter((edge) => !carries(edge));

--- a/packages/fabrika-cli/src/build/eligible-verb.ts
+++ b/packages/fabrika-cli/src/build/eligible-verb.ts
@@ -11,6 +11,12 @@
  * is open work, and the alternative — treating it as satisfied — is the fail-open this verb exists to
  * remove.
  *
+ * **A predecessor is discharged by closed issue OR by landed commit** (`./landed.ts`, #6063). Under
+ * ADR 0285 an epic run's children stay open until the single tail PR merges, so inside a run the
+ * closed-state proxy answers "is the issue closed" where the gate means "did the work land" — and
+ * reading only the first makes every phase-2 child unbuildable until the epic it blocks has shipped.
+ * The second source is evidence, not a skip: no assembly branch, no discharge.
+ *
  * **Every predecessor is scanned before the answer is seated, so the answer does not depend on the
  * order the topology happens to list them in.** One *proven* open edge is proof of blockedness
  * whatever else could not be read, so a predecessor read that failed alongside it downgrades neither
@@ -26,9 +32,39 @@ import {BAD_SECTIONS, BLOCKED, PRECONDITION_UNKNOWN, ZERO_SCOPE} from "./codes.t
 import {gate} from "./content-gate.ts";
 import {predecessorsOf, readTopology, renderRef} from "./dependencies.ts";
 import {getParent} from "./github.ts";
+import {type Assembly, readAssembly} from "./landed.ts";
 import {openIssue, resolveTargetRepo, scannedLine} from "./target.ts";
 
 const VERB = "build eligible";
+
+/**
+ * One edge that is not discharged by the board, and the issue it names — `null` for a ledger-local
+ * ref, which names no issue a commit could reference and so is never dischargeable off the branch.
+ */
+interface Edge {
+	readonly number: number | null;
+	readonly text: string;
+}
+
+/** What the assembly-branch read added to the answer, said on stderr so the upgrade is auditable. */
+const assemblyNotes = (
+	assembly: Assembly | null,
+	discharged: ReadonlyArray<Edge>,
+): ReadonlyArray<string> => {
+	if (assembly === null) return [];
+	if (assembly._tag === "Unreadable") {
+		return [
+			`${VERB}: cannot read ${assembly.branch} in this tree: ${assembly.reason} — no edge is counted discharged off it, and every edge keeps the state the board gave it.`,
+		];
+	}
+	return discharged.length === 0
+		? [
+				`${VERB}: ${assembly.branch} carries ${assembly.commits} commit(s), none naming an undischarged predecessor.`,
+			]
+		: [
+				`${VERB}: ${assembly.branch} carries a commit naming ${discharged.map((edge) => `#${edge.number}`).join(", ")} — that work landed on the epic run's assembly branch, so the edge is discharged whatever the board says about the issue (ADR 0285).`,
+			];
+};
 
 export interface EligibleOptions {
 	readonly number: number;
@@ -96,39 +132,52 @@ export const runEligible = (
 			"dependency edge",
 			`parent #${parent.value}`,
 		);
-		const open: string[] = [];
-		const unread: string[] = [];
+		const open: Edge[] = [];
+		const unread: Edge[] = [];
 		for (const {kind, ref} of predecessors) {
 			if (ref._tag === "Local") {
-				open.push(`${kind} ${renderRef(ref)} (unfiled, so open)`);
+				open.push({number: null, text: `${kind} ${renderRef(ref)} (unfiled, so open)`});
 				continue;
 			}
 			const state = yield* getIssue(repo, ref.number);
 			if (state._tag === "Unknown") {
-				unread.push(
-					`${VERB}: cannot read ${kind} predecessor #${ref.number}: ${state.reason} — its state is UNKNOWN, never counted closed.`,
-				);
+				unread.push({
+					number: ref.number,
+					text: `${VERB}: cannot read ${kind} predecessor #${ref.number}: ${state.reason} — its state is UNKNOWN, never counted closed.`,
+				});
 				continue;
 			}
 			if (state._tag === "Absent" || state.value.state === "open")
-				open.push(`${kind} #${ref.number}`);
+				open.push({number: ref.number, text: `${kind} #${ref.number}`});
 		}
+
+		const undischarged = [...open, ...unread].some((edge) => edge.number !== null);
+		const assembly = undischarged ? yield* readAssembly(parent.value) : null;
+		const landed = assembly?._tag === "Read" ? assembly.landed : new Set<number>();
+		const carries = (edge: Edge) => edge.number !== null && landed.has(edge.number);
+		const stillOpen = open.filter((edge) => !carries(edge));
+		const stillUnread = unread.filter((edge) => !carries(edge));
+		const branchNotes = assemblyNotes(assembly, [...open, ...unread].filter(carries));
 
 		const plural = (n: number, noun: string) => `${n} ${noun}${n === 1 ? "" : "s"}`;
-		if (open.length > 0) {
+		const detail = stillUnread.map((edge) => edge.text);
+		if (stillOpen.length > 0) {
 			return refuse(
 				BLOCKED,
-				`${VERB}: blocked by ${plural(open.length, "open dependency edge")}: ${open.join(", ")}.`,
-				[scope, ...unread],
+				`${VERB}: blocked by ${plural(stillOpen.length, "open dependency edge")}: ${stillOpen.map((edge) => edge.text).join(", ")}.`,
+				[scope, ...branchNotes, ...detail],
 			);
 		}
-		if (unread.length > 0) {
+		if (stillUnread.length > 0) {
 			return refuse(
 				PRECONDITION_UNKNOWN,
-				`${VERB}: ${plural(unread.length, "predecessor")} could not be read — eligibility is UNKNOWN, never "eligible".`,
-				[scope, ...unread],
+				`${VERB}: ${plural(stillUnread.length, "predecessor")} could not be read — eligibility is UNKNOWN, never "eligible".`,
+				[scope, ...branchNotes, ...detail],
 			);
 		}
 
-		return answer(JSON.stringify({answer: "eligible", number, parent: parent.value}), [scope]);
+		return answer(JSON.stringify({answer: "eligible", number, parent: parent.value}), [
+			scope,
+			...branchNotes,
+		]);
 	});

--- a/packages/fabrika-cli/src/build/eligible-verb.unit.test.ts
+++ b/packages/fabrika-cli/src/build/eligible-verb.unit.test.ts
@@ -34,8 +34,19 @@ const runWatched = async (script: ReadonlyArray<readonly [RegExp, ExecResult]>) 
 };
 
 const ASSEMBLY = /^git rev-parse --verify --quiet epic\/4300\^\{commit\}$/;
-const ASSEMBLY_LOG = /^git log --format=.* [0-9a-f]{40}$/;
+const TRUNK = /^gh api repos\/o\/r --jq \.default_branch$/;
+const MERGE_BASE = /^git merge-base origin\/main [0-9a-f]{40}$/;
+/** The bounded walk: two dots, base first — a one-dot rev would not match. */
+const ASSEMBLY_LOG = /^git log --format=.* [0-9a-f]{40}\.\.[0-9a-f]{40}$/;
 const TIP = "9a1c2b3d4e5f60718293a4b5c6d7e8f901234567";
+const BASE = "0123456789abcdef0123456789abcdef01234567";
+
+/** The three reads that bound the assembly range, scripted together — tip, trunk, merge base. */
+const RANGE_ENDPOINTS: ReadonlyArray<readonly [RegExp, ExecResult]> = [
+	[ASSEMBLY, okOut(`${TIP}\n`)],
+	[TRUNK, okOut("main\n")],
+	[MERGE_BASE, okOut(`${BASE}\n`)],
+];
 
 /** One `git log` record stream, in the framing `rangeCommits` reads. */
 const commitLog = (...messages: ReadonlyArray<string>): ExecResult =>
@@ -189,12 +200,12 @@ describe("runEligible", () => {
 				[PARENT, okOut("4300\n")],
 				[LEDGER, ledger("- phase 1: #210\n- phase 2: #4312")],
 				[PRED(210), issue({number: 210, state: "open"})],
-				[ASSEMBLY, okOut(`${TIP}\n`)],
+				...RANGE_ENDPOINTS,
 				[ASSEMBLY_LOG, commitLog("feat(guide): the front door (#210)\n\nPart of #4300")],
 			]);
 			expect(out.code).toBe(0);
 			expect(JSON.parse(out.stdout)).toEqual({answer: "eligible", number: 4312, parent: 4300});
-			expect(out.stderr.at(-1)).toContain("epic/4300 carries a commit naming #210");
+			expect(out.stderr.at(-1)).toContain("origin/main..epic/4300 adds a commit naming #210");
 		});
 
 		it("reads no branch at all when every predecessor is already closed", async () => {
@@ -223,7 +234,7 @@ describe("runEligible", () => {
 				[PARENT, okOut("4300\n")],
 				[LEDGER, ledger("- phase 1: #210\n- phase 2: #4312")],
 				[PRED(210), issue({number: 210, state: "open"})],
-				[ASSEMBLY, okOut(`${TIP}\n`)],
+				...RANGE_ENDPOINTS,
 				[ASSEMBLY_LOG, commitLog("feat(guide): some other child (#211)")],
 			]);
 			expect(out.code).toBe(BLOCKED);
@@ -247,13 +258,42 @@ describe("runEligible", () => {
 			);
 		});
 
+		it("never discharges when the trunk to bound the range against cannot be named", async () => {
+			const out = await run([
+				[ISSUE, issue()],
+				[PARENT, okOut("4300\n")],
+				[LEDGER, ledger("- phase 1: #210\n- phase 2: #4312")],
+				[PRED(210), issue({number: 210, state: "open"})],
+				[ASSEMBLY, okOut(`${TIP}\n`)],
+				[TRUNK, GATEWAY],
+			]);
+			expect(out.code).toBe(BLOCKED);
+			expect(out.stderr.some((line) => line.includes("cannot name o/r's default branch"))).toBe(
+				true,
+			);
+		});
+
+		it("never discharges when the range has no merge base with the trunk", async () => {
+			const out = await run([
+				[ISSUE, issue()],
+				[PARENT, okOut("4300\n")],
+				[LEDGER, ledger("- phase 1: #210\n- phase 2: #4312")],
+				[PRED(210), issue({number: 210, state: "open"})],
+				[ASSEMBLY, okOut(`${TIP}\n`)],
+				[TRUNK, okOut("main\n")],
+				[MERGE_BASE, errOut("fatal: refusing to merge unrelated histories")],
+			]);
+			expect(out.code).toBe(BLOCKED);
+			expect(out.stderr.some((line) => line.includes("no merge base with origin/main"))).toBe(true);
+		});
+
 		it("never discharges off a log that failed — an unread predecessor stays 11", async () => {
 			const out = await run([
 				[ISSUE, issue()],
 				[PARENT, okOut("4300\n")],
 				[LEDGER, ledger("- phase 1: #210\n- phase 2: #4312")],
 				[PRED(210), GATEWAY],
-				[ASSEMBLY, okOut(`${TIP}\n`)],
+				...RANGE_ENDPOINTS,
 				[ASSEMBLY_LOG, errOut("fatal: bad object")],
 			]);
 			expect(out.code).toBe(PRECONDITION_UNKNOWN);
@@ -269,7 +309,7 @@ describe("runEligible", () => {
 				[PARENT, okOut("4300\n")],
 				[LEDGER, ledger("- phase 1: C1, #210\n- phase 2: #4312")],
 				[PRED(210), issue({number: 210, state: "open"})],
-				[ASSEMBLY, okOut(`${TIP}\n`)],
+				...RANGE_ENDPOINTS,
 				[ASSEMBLY_LOG, commitLog("feat: landed (#210)")],
 			]);
 			expect(out.code).toBe(BLOCKED);

--- a/packages/fabrika-cli/src/build/eligible-verb.unit.test.ts
+++ b/packages/fabrika-cli/src/build/eligible-verb.unit.test.ts
@@ -26,6 +26,21 @@ const options = {
 const run = (script: ReadonlyArray<readonly [RegExp, ExecResult]>) =>
 	Effect.runPromise(Effect.provide(runEligible(options), fakeShell(script).layer));
 
+/** The same run, with the command lines it spawned — how "no git read happened" is asserted. */
+const runWatched = async (script: ReadonlyArray<readonly [RegExp, ExecResult]>) => {
+	const shell = fakeShell(script);
+	const out = await Effect.runPromise(Effect.provide(runEligible(options), shell.layer));
+	return {out, calls: shell.calls};
+};
+
+const ASSEMBLY = /^git rev-parse --verify --quiet epic\/4300\^\{commit\}$/;
+const ASSEMBLY_LOG = /^git log --format=.* [0-9a-f]{40}$/;
+const TIP = "9a1c2b3d4e5f60718293a4b5c6d7e8f901234567";
+
+/** One `git log` record stream, in the framing `rangeCommits` reads. */
+const commitLog = (...messages: ReadonlyArray<string>): ExecResult =>
+	okOut(messages.map((message, i) => `${TIP.slice(0, 39)}${i}\x1f${message}\x1e`).join(""));
+
 describe("runEligible", () => {
 	it("answers eligible for a standalone issue, with parent null", async () => {
 		const out = await run([
@@ -157,6 +172,109 @@ describe("runEligible", () => {
 			expect(out.stdout).toBe("");
 			expect(out.stderr.some((line) => line.includes("cannot read phase predecessor #210"))).toBe(
 				true,
+			);
+		});
+	});
+
+	/**
+	 * The epic-run arm (#6063): inside a one-PR run every predecessor issue is open by design, so the
+	 * closed-state proxy alone makes every phase-2 child permanently blocked. Each case pins one half
+	 * of the two-source rule — and the two negatives pin that the second source only ever discharges
+	 * on evidence it actually read.
+	 */
+	describe("a predecessor is discharged by a closed issue OR by a commit on epic/<n>", () => {
+		it("discharges an OPEN predecessor whose work landed on the assembly branch", async () => {
+			const out = await run([
+				[ISSUE, issue()],
+				[PARENT, okOut("4300\n")],
+				[LEDGER, ledger("- phase 1: #210\n- phase 2: #4312")],
+				[PRED(210), issue({number: 210, state: "open"})],
+				[ASSEMBLY, okOut(`${TIP}\n`)],
+				[ASSEMBLY_LOG, commitLog("feat(guide): the front door (#210)\n\nPart of #4300")],
+			]);
+			expect(out.code).toBe(0);
+			expect(JSON.parse(out.stdout)).toEqual({answer: "eligible", number: 4312, parent: 4300});
+			expect(out.stderr.at(-1)).toContain("epic/4300 carries a commit naming #210");
+		});
+
+		it("reads no branch at all when every predecessor is already closed", async () => {
+			const {out, calls} = await runWatched([
+				[ISSUE, issue()],
+				[PARENT, okOut("4300\n")],
+				[LEDGER, ledger("- phase 1: #210\n- phase 2: #4312")],
+				[PRED(210), issue({number: 210, state: "closed"})],
+			]);
+			expect(out.code).toBe(0);
+			expect(calls.some((line) => line.startsWith("git"))).toBe(false);
+		});
+
+		it("reads no branch for a standalone issue", async () => {
+			const {out, calls} = await runWatched([
+				[ISSUE, issue()],
+				[PARENT, NOT_FOUND],
+			]);
+			expect(JSON.parse(out.stdout).parent).toBe(null);
+			expect(calls.some((line) => line.startsWith("git"))).toBe(false);
+		});
+
+		it("stays blocked when the branch names no commit for the open predecessor", async () => {
+			const out = await run([
+				[ISSUE, issue()],
+				[PARENT, okOut("4300\n")],
+				[LEDGER, ledger("- phase 1: #210\n- phase 2: #4312")],
+				[PRED(210), issue({number: 210, state: "open"})],
+				[ASSEMBLY, okOut(`${TIP}\n`)],
+				[ASSEMBLY_LOG, commitLog("feat(guide): some other child (#211)")],
+			]);
+			expect(out.code).toBe(BLOCKED);
+			expect(out.stderr.at(-1)).toBe(
+				"build eligible: blocked by 1 open dependency edge: phase #210.",
+			);
+		});
+
+		it("never discharges off a branch it could not read — absent epic/<n> stays 16", async () => {
+			const out = await run([
+				[ISSUE, issue()],
+				[PARENT, okOut("4300\n")],
+				[LEDGER, ledger("- phase 1: #210\n- phase 2: #4312")],
+				[PRED(210), issue({number: 210, state: "open"})],
+				[ASSEMBLY, errOut("fatal: ambiguous argument 'epic/4300'")],
+			]);
+			expect(out.code).toBe(BLOCKED);
+			expect(out.stdout).toBe("");
+			expect(out.stderr.some((line) => line.includes("cannot read epic/4300 in this tree"))).toBe(
+				true,
+			);
+		});
+
+		it("never discharges off a log that failed — an unread predecessor stays 11", async () => {
+			const out = await run([
+				[ISSUE, issue()],
+				[PARENT, okOut("4300\n")],
+				[LEDGER, ledger("- phase 1: #210\n- phase 2: #4312")],
+				[PRED(210), GATEWAY],
+				[ASSEMBLY, okOut(`${TIP}\n`)],
+				[ASSEMBLY_LOG, errOut("fatal: bad object")],
+			]);
+			expect(out.code).toBe(PRECONDITION_UNKNOWN);
+			expect(out.stdout).toBe("");
+			expect(out.stderr.some((line) => line.includes("cannot read epic/4300 in this tree"))).toBe(
+				true,
+			);
+		});
+
+		it("never discharges an unfiled ledger-local ref — no commit can name one", async () => {
+			const out = await run([
+				[ISSUE, issue()],
+				[PARENT, okOut("4300\n")],
+				[LEDGER, ledger("- phase 1: C1, #210\n- phase 2: #4312")],
+				[PRED(210), issue({number: 210, state: "open"})],
+				[ASSEMBLY, okOut(`${TIP}\n`)],
+				[ASSEMBLY_LOG, commitLog("feat: landed (#210)")],
+			]);
+			expect(out.code).toBe(BLOCKED);
+			expect(out.stderr.at(-1)).toBe(
+				"build eligible: blocked by 1 open dependency edge: phase C1 (unfiled, so open).",
 			);
 		});
 	});

--- a/packages/fabrika-cli/src/build/landed.ts
+++ b/packages/fabrika-cli/src/build/landed.ts
@@ -1,0 +1,62 @@
+/**
+ * What an epic run's assembly branch says has already landed.
+ *
+ * Under ADR 0285 an epic run is one branch and one PR: a child's work is merged onto `epic/<N>` and
+ * its issue stays open until the single tail PR merges (ADR 0131). So inside a run in flight, "the
+ * predecessor's issue is closed" answers a different question from "the predecessor's work landed",
+ * and only the second is the one a dependency gate means (#6063).
+ *
+ * The evidence is the git graph, never the lane's own fold — a machine's self-report is not evidence
+ * (ADR 0283), which is why `lane prove` reads commits too. The ref-matching rule is
+ * {@link issueRefsIn}, the same one `build commit` and `lane prove` read messages with, so a
+ * predecessor cannot be discharged here by a spelling nothing else recognises.
+ */
+import {Effect} from "effect";
+import type {ChildProcessSpawner} from "effect/unstable/process";
+import {reachableCommits, resolveCommit} from "../io/git.ts";
+import {epicBranch} from "../wire/lane-brief.ts";
+import {issueRefsIn} from "./commit-message.ts";
+
+/** Every issue number these commit messages name — the set whose work this branch carries. */
+export const landedRefs = (messages: ReadonlyArray<string>): ReadonlySet<number> =>
+	new Set(messages.flatMap((message) => [...issueRefsIn(message)]));
+
+/**
+ * What the assembly branch said, or why it said nothing.
+ *
+ * `Unreadable` folds an absent branch together with a failed read on purpose: neither is evidence
+ * that work landed, so both leave every edge exactly as the board reads it. Discharge is the only
+ * direction this read may move an answer in.
+ */
+export type Assembly =
+	| {
+			readonly _tag: "Read";
+			readonly branch: string;
+			readonly landed: ReadonlySet<number>;
+			readonly commits: number;
+	  }
+	| {readonly _tag: "Unreadable"; readonly branch: string; readonly reason: string};
+
+/**
+ * Read epic `epic`'s assembly branch in this tree.
+ *
+ * The branch name is derived from the epic number through {@link epicBranch} and never taken from a
+ * caller: a caller-named branch is a caller-chosen answer to "has this landed".
+ */
+export const readAssembly = (
+	epic: number,
+): Effect.Effect<Assembly, never, ChildProcessSpawner.ChildProcessSpawner> =>
+	Effect.gen(function* () {
+		const branch = epicBranch(epic);
+		const tip = yield* resolveCommit(branch, " — the epic run's assembly branch");
+		if (tip._tag === "Failure") return {_tag: "Unreadable" as const, branch, reason: tip.reason};
+		const walked = yield* reachableCommits(tip.value);
+		if (walked._tag === "Failure")
+			return {_tag: "Unreadable" as const, branch, reason: walked.reason};
+		return {
+			_tag: "Read" as const,
+			branch,
+			landed: landedRefs(walked.value.map((commit) => commit.message)),
+			commits: walked.value.length,
+		};
+	});

--- a/packages/fabrika-cli/src/build/landed.ts
+++ b/packages/fabrika-cli/src/build/landed.ts
@@ -10,12 +10,20 @@
  * (ADR 0283), which is why `lane prove` reads commits too. The ref-matching rule is
  * {@link issueRefsIn}, the same one `build commit` and `lane prove` read messages with, so a
  * predecessor cannot be discharged here by a spelling nothing else recognises.
+ *
+ * **The read is the run's own commits, never everything reachable from the branch tip.** The set is
+ * `<merge base with the trunk>..epic/<N>`, the two-dot shape `lane prove` locates a child's range
+ * with. A one-dot walk sweeps in the whole trunk history the branch was cut from, and since
+ * `issueRefsIn` matches a bare `#<n>` anywhere in a message, a years-old commit writing "blocked on
+ * #<n>" would then discharge an edge whose work was never built — the fail-open `build eligible`
+ * exists to remove.
  */
 import {Effect} from "effect";
 import type {ChildProcessSpawner} from "effect/unstable/process";
-import {reachableCommits, resolveCommit} from "../io/git.ts";
+import {mergeBase, rangeCommits, resolveCommit} from "../io/git.ts";
 import {epicBranch} from "../wire/lane-brief.ts";
 import {issueRefsIn} from "./commit-message.ts";
+import {defaultBranch} from "./github.ts";
 
 /** Every issue number these commit messages name — the set whose work this branch carries. */
 export const landedRefs = (messages: ReadonlyArray<string>): ReadonlySet<number> =>
@@ -24,38 +32,59 @@ export const landedRefs = (messages: ReadonlyArray<string>): ReadonlySet<number>
 /**
  * What the assembly branch said, or why it said nothing.
  *
- * `Unreadable` folds an absent branch together with a failed read on purpose: neither is evidence
- * that work landed, so both leave every edge exactly as the board reads it. Discharge is the only
- * direction this read may move an answer in.
+ * `Unreadable` folds an absent branch, an unnameable trunk and a failed read together on purpose:
+ * none is evidence that work landed, so all of them leave every edge exactly as the board reads it.
+ * Discharge is the only direction this read may move an answer in.
  */
 export type Assembly =
 	| {
 			readonly _tag: "Read";
 			readonly branch: string;
+			/** The trunk ref the range is bounded against, so a diagnostic names a range a human can re-run. */
+			readonly baseRef: string;
 			readonly landed: ReadonlySet<number>;
+			/** How many commits the run put on the branch — not how many the branch can reach. */
 			readonly commits: number;
 	  }
 	| {readonly _tag: "Unreadable"; readonly branch: string; readonly reason: string};
 
 /**
- * Read epic `epic`'s assembly branch in this tree.
+ * Read epic `epic`'s assembly branch in this tree, bounded to the commits the run put on it.
  *
- * The branch name is derived from the epic number through {@link epicBranch} and never taken from a
- * caller: a caller-named branch is a caller-chosen answer to "has this landed".
+ * Both endpoints are derived, never taken from a caller: the branch name from the epic number
+ * through {@link epicBranch}, the base from the repo's own default branch. A caller-named endpoint
+ * is a caller-chosen answer to "has this landed".
  */
 export const readAssembly = (
+	repo: string,
 	epic: number,
 ): Effect.Effect<Assembly, never, ChildProcessSpawner.ChildProcessSpawner> =>
 	Effect.gen(function* () {
 		const branch = epicBranch(epic);
 		const tip = yield* resolveCommit(branch, " — the epic run's assembly branch");
 		if (tip._tag === "Failure") return {_tag: "Unreadable" as const, branch, reason: tip.reason};
-		const walked = yield* reachableCommits(tip.value);
+		const trunk = yield* defaultBranch(repo);
+		if (trunk._tag === "Failure")
+			return {
+				_tag: "Unreadable" as const,
+				branch,
+				reason: `cannot name ${repo}'s default branch to bound the read against: ${trunk.reason}`,
+			};
+		const baseRef = `origin/${trunk.value}`;
+		const base = yield* mergeBase(baseRef, tip.value);
+		if (base._tag === "Failure")
+			return {
+				_tag: "Unreadable" as const,
+				branch,
+				reason: `no merge base with ${baseRef}: ${base.reason}`,
+			};
+		const walked = yield* rangeCommits(base.value, tip.value);
 		if (walked._tag === "Failure")
 			return {_tag: "Unreadable" as const, branch, reason: walked.reason};
 		return {
 			_tag: "Read" as const,
 			branch,
+			baseRef,
 			landed: landedRefs(walked.value.map((commit) => commit.message)),
 			commits: walked.value.length,
 		};

--- a/packages/fabrika-cli/src/build/landed.unit.test.ts
+++ b/packages/fabrika-cli/src/build/landed.unit.test.ts
@@ -1,0 +1,20 @@
+import {describe, expect, it} from "vitest";
+import {landedRefs} from "./landed.ts";
+
+describe("landedRefs", () => {
+	it("reads every issue a message names, subject and body alike", () => {
+		expect([
+			...landedRefs(["feat(guide): the front door (#6004)\n\nPart of #5817", "chore: nothing"]),
+		]).toEqual([6004, 5817]);
+	});
+
+	it("is empty for a branch that carries no commit", () => {
+		expect(landedRefs([]).size).toBe(0);
+	});
+
+	// The same rule `build commit` and `lane prove` read messages with, so a number written without
+	// its `#` is not a reference — a discharge off "issue 210" would be a discharge off prose.
+	it("does not read a bare number as a reference", () => {
+		expect(landedRefs(["fix: closes issue 210"]).size).toBe(0);
+	});
+});

--- a/packages/fabrika-cli/src/build/landed.unit.test.ts
+++ b/packages/fabrika-cli/src/build/landed.unit.test.ts
@@ -1,5 +1,8 @@
+import {Effect} from "effect";
 import {describe, expect, it} from "vitest";
-import {landedRefs} from "./landed.ts";
+import {errOut, fakeShell, okOut} from "../fakes.test-support.ts";
+import type {ExecResult} from "../io/exec.ts";
+import {landedRefs, readAssembly} from "./landed.ts";
 
 describe("landedRefs", () => {
 	it("reads every issue a message names, subject and body alike", () => {
@@ -16,5 +19,39 @@ describe("landedRefs", () => {
 	// its `#` is not a reference — a discharge off "issue 210" would be a discharge off prose.
 	it("does not read a bare number as a reference", () => {
 		expect(landedRefs(["fix: closes issue 210"]).size).toBe(0);
+	});
+});
+
+const TIP = "9a1c2b3d4e5f60718293a4b5c6d7e8f901234567";
+const BASE = "0123456789abcdef0123456789abcdef01234567";
+
+const script: ReadonlyArray<readonly [RegExp, ExecResult]> = [
+	[/^git rev-parse --verify --quiet epic\/4300\^\{commit\}$/, okOut(`${TIP}\n`)],
+	[/^gh api repos\/o\/r --jq \.default_branch$/, okOut("main\n")],
+	[/^git merge-base origin\/main /, okOut(`${BASE}\n`)],
+	[/^git log /, okOut(`${TIP}\x1ffeat: landed (#210)\x1e`)],
+];
+
+describe("readAssembly", () => {
+	/**
+	 * The bound is the finding this module was repaired for: a one-dot walk sweeps in the whole trunk
+	 * history the assembly branch was cut from, and `issueRefsIn` matching a bare `#<n>` anywhere would
+	 * then discharge an edge off a commit that predates the epic.
+	 */
+	it("walks only what the branch adds over its merge base with the trunk", async () => {
+		const shell = fakeShell(script);
+		const read = await Effect.runPromise(Effect.provide(readAssembly("o/r", 4300), shell.layer));
+		expect(read).toMatchObject({_tag: "Read", branch: "epic/4300", baseRef: "origin/main"});
+		expect(shell.calls.some((line) => line.endsWith(`${BASE}..${TIP}`))).toBe(true);
+	});
+
+	it("is Unreadable when the trunk cannot be named — never a partial discharge", async () => {
+		const shell = fakeShell([
+			script[0] as readonly [RegExp, ExecResult],
+			[/^gh api repos\/o\/r --jq \.default_branch$/, errOut("gh: Bad gateway (HTTP 502)")],
+		]);
+		const read = await Effect.runPromise(Effect.provide(readAssembly("o/r", 4300), shell.layer));
+		expect(read._tag).toBe("Unreadable");
+		expect(shell.calls.some((line) => line.startsWith("git log"))).toBe(false);
 	});
 });

--- a/packages/fabrika-cli/src/io/git.ts
+++ b/packages/fabrika-cli/src/io/git.ts
@@ -372,33 +372,20 @@ const FIELD_SEPARATOR = "\x1f";
 /**
  * The commits `tip` adds over `base`, newest first — two dots, because the question is what this
  * branch carries that the base does not.
+ *
+ * Framed with the two ASCII separators rather than newlines or NULs: a commit message is multi-line
+ * by construction, so a line-oriented format splits one message into commits nobody wrote, and `-z`
+ * frames records with the same NUL a pathological message may carry inside it.
  */
 export const rangeCommits = (
 	base: string,
 	tip: string,
-): Shell<Attempt<ReadonlyArray<RangeCommit>>> => walkCommits(`${base}..${tip}`);
-
-/**
- * Every commit reachable from `rev`, newest first.
- *
- * A branch a caller holds without a base cannot be asked a two-dot question, and inventing a base
- * to ask one would answer about a range nobody named.
- */
-export const reachableCommits = (rev: string): Shell<Attempt<ReadonlyArray<RangeCommit>>> =>
-	walkCommits(rev);
-
-/**
- * The one `git log` walk both reads take, framed with the two ASCII separators rather than newlines
- * or NULs: a commit message is multi-line by construction, so a line-oriented format splits one
- * message into commits nobody wrote, and `-z` frames records with the same NUL a pathological
- * message may carry inside it.
- */
-const walkCommits = (revs: string): Shell<Attempt<ReadonlyArray<RangeCommit>>> =>
+): Shell<Attempt<ReadonlyArray<RangeCommit>>> =>
 	Effect.gen(function* () {
 		const r = yield* execCapture("git", [
 			"log",
 			`--format=%H${FIELD_SEPARATOR}%B${RECORD_SEPARATOR}`,
-			revs,
+			`${base}..${tip}`,
 		]);
 		if (!r.ok) return fail(r.reason);
 		const rows: RangeCommit[] = [];

--- a/packages/fabrika-cli/src/io/git.ts
+++ b/packages/fabrika-cli/src/io/git.ts
@@ -372,20 +372,33 @@ const FIELD_SEPARATOR = "\x1f";
 /**
  * The commits `tip` adds over `base`, newest first — two dots, because the question is what this
  * branch carries that the base does not.
- *
- * Framed with the two ASCII separators rather than newlines or NULs: a commit message is multi-line
- * by construction, so a line-oriented format splits one message into commits nobody wrote, and `-z`
- * frames records with the same NUL a pathological message may carry inside it.
  */
 export const rangeCommits = (
 	base: string,
 	tip: string,
-): Shell<Attempt<ReadonlyArray<RangeCommit>>> =>
+): Shell<Attempt<ReadonlyArray<RangeCommit>>> => walkCommits(`${base}..${tip}`);
+
+/**
+ * Every commit reachable from `rev`, newest first.
+ *
+ * A branch a caller holds without a base cannot be asked a two-dot question, and inventing a base
+ * to ask one would answer about a range nobody named.
+ */
+export const reachableCommits = (rev: string): Shell<Attempt<ReadonlyArray<RangeCommit>>> =>
+	walkCommits(rev);
+
+/**
+ * The one `git log` walk both reads take, framed with the two ASCII separators rather than newlines
+ * or NULs: a commit message is multi-line by construction, so a line-oriented format splits one
+ * message into commits nobody wrote, and `-z` frames records with the same NUL a pathological
+ * message may carry inside it.
+ */
+const walkCommits = (revs: string): Shell<Attempt<ReadonlyArray<RangeCommit>>> =>
 	Effect.gen(function* () {
 		const r = yield* execCapture("git", [
 			"log",
 			`--format=%H${FIELD_SEPARATOR}%B${RECORD_SEPARATOR}`,
-			`${base}..${tip}`,
+			revs,
 		]);
 		if (!r.ok) return fail(r.reason);
 		const rows: RangeCommit[] = [];


### PR DESCRIPTION
Fixes #6063

`build eligible` asked whether a predecessor's **issue is closed** when the question it means is
whether the predecessor's **work landed**. Outside an epic those coincide; inside a one-PR run
(ADR 0285) they never do, because no child issue closes until the tail PR merges. Every
phase-2-or-later child of a live run was therefore blocked on siblings already merged onto
`epic/<n>` — a gate no child could pass before the epic shipped, and no epic could ship before its
children built.

A predecessor is now discharged from two sources: its issue is closed, **or** the parent epic's
assembly branch carries a commit whose message names it. The branch name is derived from the parent
number (`epicBranch`), and messages are read with `issueRefsIn` — the same rule `build commit` and
`lane prove` use, not a second one.

The second source only ever discharges, and only on evidence it read:

- a branch this tree does not carry, or a failed `git log`, leaves every edge as the board gave it
  (open ⇒ `16`, unread ⇒ `11`) and names the unread branch on stderr;
- a ledger-local `C<int>` ref is never discharged — no commit can name an unfiled issue;
- the branch is read only when an edge is still undischarged, so a standalone issue and a child
  whose predecessors are all closed make no git call at all.

`landed.ts` holds the read; `io/git.ts` gains `reachableCommits`, sharing one `git log` walk with
`rangeCommits`. `contract.md`'s `build eligible` section states the two-source rule, the exit table
and the three new stderr rows.

## Deviations

None.
