### PR TITLE
fix: governance post reports an in-progress floor re-fire as UNKNOWN, sending agents on phantom heal-ci hunts

### DIFF
--- a/claude-plugins/fabrika/skills/governance/SKILL.md
+++ b/claude-plugins/fabrika/skills/governance/SKILL.md
@@ -182,12 +182,14 @@ one. Re-review, never re-bind.
 **`post` also re-fires the floor check at that head.** The `governance-floor` job runs on
 `pull_request`, so it judged the PR before your verdict existed and nothing else re-fires it. The verb
 re-runs that job, which re-derives `ship floor` against your verdict — it never writes a check-run, so
-the green is the job's own. Its last stderr line says which of `refired` / `green` / `in-flight` /
-`no-run` / `unknown` happened.
+the green is the job's own. Its last stderr line says which of `refired` / `restarting` / `green` /
+`in-flight` / `no-run` / `unknown` happened.
 
 **Done when** `post` prints `posted`, its read-back conformed, and you have read the floor line — an
 `in-flight` or `unknown` floor means the check may still red at this head, and clearing it is
-`heal-ci`'s, not a human's.
+`heal-ci`'s, not a human's. `restarting` is **not** one of those: the re-fire took and the run is
+going again under its own id, GitHub simply had not published the new attempt number yet — wait and
+re-read that run, and escalating it is how three agents burned an evening on a green (#5982).
 
 ### The range form — an epic child's verdict
 

--- a/claude-plugins/fabrika/skills/governance/contract.md
+++ b/claude-plugins/fabrika/skills/governance/contract.md
@@ -855,7 +855,7 @@ poster reads success.
 `posted\tgovernance\t<polarity>\t<sha>\t<content>\t<created|edited>\t<comment-url>`, where
 `<content>` is the content digest the verdict binds (ADR 0276).
 With `--json`:
-`{"outcome":"posted","namespace":"governance","polarity":…,"sha":…,"content":…,"upsert":"created"|"edited","floor":"refired"|"green"|"in-flight"|"no-run"|"unknown","commentUrl":…}`.
+`{"outcome":"posted","namespace":"governance","polarity":…,"sha":…,"content":…,"upsert":"created"|"edited","floor":"refired"|"restarting"|"green"|"in-flight"|"no-run"|"unknown","commentUrl":…}`.
 The tab line does not carry `floor` — the floor's outcome is on stderr, one line, always.
 
 **The namespace is fixed.** There is no `--namespace` flag: this verb emits exactly one namespace and
@@ -899,7 +899,10 @@ namespace is a constant, so it cannot be aimed anywhere else even by a confused 
    re-fire a `pull_request`-triggered job — every governance-root PR reds at least once and stays red
    until something re-runs the job (#5585). The verb reads the runs at the bound head, and when the
    newest `governance-floor` run there is completed-and-red it requests a re-run of that run's failed
-   jobs, then re-reads the run and requires `run_attempt` to have increased. **The re-run is a
+   jobs, then re-reads the run and requires the re-fire to be **proven from run state** — either
+   `run_attempt` increased, or that same run id is no longer `completed`, which only this dispatch
+   could have caused. The counter lags the dispatch by a beat, and calling that beat unproven is what
+   sent three agents chasing a `heal-ci` pass over re-fires that had taken (#5982). **The re-run is a
    re-derivation, never a claim**: nothing here writes a check-run or a status, so the green a PR ends
    with is one `ship floor` reached itself against live comment state. **This step is the one place
    the verb needs `actions: write`** on its token; no earlier step asks for it. Without it the
@@ -908,11 +911,13 @@ namespace is a constant, so it cannot be aimed anywhere else even by a confused 
 
 **The floor assertion never changes the exit code.** By step 7 the verdict is landed and read back, so
 a floor that could not be asserted is a red check, not an unwritten verdict — every outcome is one
-stderr line and the `--json` `floor` field. The five: `refired` (a new attempt exists), `green` (the
-run at this head already passed), `in-flight` (the run had not completed, so it may still judge state
-older than this verdict — re-read the check), `no-run` (no floor run at this head: not installed in
-this repository, or not fired yet), `unknown` (the state could not be read or the re-fire could not be
-proven — never read as a pass).
+stderr line and the `--json` `floor` field. The six: `refired` (a new attempt exists), `restarting`
+(the re-fired run is queued or running again under its own id with the new attempt number not yet
+published — wait and re-read that run, never escalate it), `green` (the run at this head already
+passed), `in-flight` (the run had not completed, so it may still judge state older than this verdict
+— re-read the check), `no-run` (no floor run at this head: not installed in this repository, or not
+fired yet), `unknown` (the state could not be read or the re-fire could not be proven — never read as
+a pass).
 
 **No advisory carrier.** `review post` takes `--carrier advisory` for §CP PRs, where a human approval
 is the gate. This verb has no such mode: §CP is not this namespace's question, the governance verdict

--- a/packages/fabrika-cli/src/governance/floor-assert.ts
+++ b/packages/fabrika-cli/src/governance/floor-assert.ts
@@ -40,6 +40,12 @@ export type FloorAssertion =
 	| {readonly _tag: "InFlight"; readonly run: number}
 	/** A new attempt exists and is re-deriving `ship floor` against live comment state. */
 	| {readonly _tag: "Refired"; readonly run: number; readonly attempt: number}
+	/**
+	 * The re-fire took but GitHub has not published its attempt number yet: the run this verb read as
+	 * completed-and-red a moment ago is running again under the same id. That transition is proof from
+	 * run state, so it is a re-fire to wait on rather than an unread one to escalate (#5982).
+	 */
+	| {readonly _tag: "Restarting"; readonly run: number; readonly status: string}
 	/** The floor state could not be read or the re-fire could not be proven. Never a pass. */
 	| {readonly _tag: "Unknown"; readonly reason: string};
 
@@ -48,9 +54,11 @@ const unknown = (reason: string): FloorAssertion => ({_tag: "Unknown", reason});
 /**
  * Re-fire the red governance-floor run at `sha`, and prove a new attempt exists.
  *
- * The dispatch's 2xx is an acknowledgement and not a new attempt, so the run is re-read and
- * `run_attempt` must have increased — `heal-ci rerun` learned that the hard way, and reporting a
- * re-fire that never happened would leave the caller believing a red will clear itself.
+ * The dispatch's 2xx is an acknowledgement and not a new attempt, so the run is re-read and the
+ * re-fire is proven from run state — `heal-ci rerun` learned that the hard way, and reporting a
+ * re-fire that never happened would leave the caller believing a red will clear itself. Either
+ * signal proves it: `run_attempt` increased, or the completed-and-red run is running again under the
+ * same id while the counter catches up.
  */
 export const assertFloorAt = (repo: string, sha: string): Shell<FloorAssertion> =>
 	Effect.gen(function* () {
@@ -86,24 +94,37 @@ export const assertFloorAt = (repo: string, sha: string): Shell<FloorAssertion> 
 			);
 		}
 		if (after.value.runAttempt <= before.value.runAttempt) {
-			return unknown(
-				`the re-fire was requested and run ${latest.id} stayed at attempt ${after.value.runAttempt} — UNKNOWN whether it re-ran`,
-			);
+			// The attempt counter lags the dispatch, and reading its absence as UNKNOWN sent three agents
+			// to `heal-ci` over re-fires that had taken (#5982). A run this verb just read as
+			// completed-and-red that is running again under the same id can only be running because of
+			// this dispatch — that is proof from run state, which is the one thing the counter was here
+			// to supply. A still-`completed` run proves nothing and stays UNKNOWN.
+			return after.value.status === "completed"
+				? unknown(
+						`the re-fire was requested and run ${latest.id} stayed at attempt ${after.value.runAttempt}, still completed — UNKNOWN whether it re-ran`,
+					)
+				: {_tag: "Restarting", run: latest.id, status: after.value.status};
 		}
 		return {_tag: "Refired", run: latest.id, attempt: after.value.runAttempt};
 	});
 
 /** The one-token closed vocabulary a caller emits under `--json`. */
-export const floorToken = (assertion: FloorAssertion): string =>
-	assertion._tag === "NoRun"
-		? "no-run"
-		: assertion._tag === "Green"
-			? "green"
-			: assertion._tag === "InFlight"
-				? "in-flight"
-				: assertion._tag === "Refired"
-					? "refired"
-					: "unknown";
+export const floorToken = (assertion: FloorAssertion): string => {
+	switch (assertion._tag) {
+		case "NoRun":
+			return "no-run";
+		case "Green":
+			return "green";
+		case "InFlight":
+			return "in-flight";
+		case "Refired":
+			return "refired";
+		case "Restarting":
+			return "restarting";
+		case "Unknown":
+			return "unknown";
+	}
+};
 
 /** The stderr line, which states what the caller must do next when the floor is not asserted. */
 export const floorLine = (verb: string, assertion: FloorAssertion): string => {
@@ -116,6 +137,8 @@ export const floorLine = (verb: string, assertion: FloorAssertion): string => {
 			return `${verb}: ${FLOOR_WORKFLOW_NAME} run ${assertion.run} is still in flight, so it may judge comment state older than this verdict — re-read the check and re-post if it reds.`;
 		case "Refired":
 			return `${verb}: re-fired ${FLOOR_WORKFLOW_NAME} run ${assertion.run} at attempt ${assertion.attempt} — it re-derives \`ship floor\` against this verdict (#5585).`;
+		case "Restarting":
+			return `${verb}: re-fired ${FLOOR_WORKFLOW_NAME} run ${assertion.run} — it is ${assertion.status} again and GitHub has not published the new attempt number yet; wait and re-read run ${assertion.run}, there is nothing to escalate.`;
 		case "Unknown":
 			return `${verb}: the ${FLOOR_WORKFLOW_NAME} check could not be asserted at this head: ${assertion.reason} — the verdict landed; the check may still need a re-fire.`;
 	}

--- a/packages/fabrika-cli/src/governance/floor-assert.unit.test.ts
+++ b/packages/fabrika-cli/src/governance/floor-assert.unit.test.ts
@@ -4,7 +4,7 @@ import {errOut, fakeShell, okOut, once} from "../fakes.test-support.ts";
 import {runsAtHead, workflowRun} from "../heal-ci/fixtures.test-support.ts";
 import type {ExecResult} from "../io/exec.ts";
 import {HEAD} from "./fixtures.test-support.ts";
-import {assertFloorAt, floorLine} from "./floor-assert.ts";
+import {assertFloorAt, floorLine, floorToken} from "./floor-assert.ts";
 
 const RUNS = /^gh api --paginate repos\/o\/r\/actions\/runs\?head_sha=/;
 const RUN = /^gh api repos\/o\/r\/actions\/runs\/\d+$/;
@@ -79,6 +79,29 @@ describe("assertFloorAt re-derives the floor rather than claiming it", () => {
 		expect(shell.calls.some((call) => RERUN.test(call))).toBe(false);
 	});
 
+	// GitHub bumps `run_attempt` a beat after it accepts the dispatch, and calling that beat UNKNOWN
+	// sent three agents to `heal-ci` over re-fires that had taken and went green untouched (#5982).
+	it("reads a same-id run that is running again as a re-fire to wait on, not UNKNOWN", async () => {
+		const {assertion, shell} = await withCalls([
+			[RUNS, runsAtHead(1, [{id: FLOOR, name: "governance-floor"}])],
+			[once(RUN), workflowRun({id: FLOOR, attempt: 1})],
+			[RERUN, okOut("")],
+			[RUN, workflowRun({id: FLOOR, attempt: 1, status: "in_progress", conclusion: null})],
+		]);
+		expect(assertion).toEqual({_tag: "Restarting", run: FLOOR, status: "in_progress"});
+		expect(shell.calls.some((call) => RERUN.test(call))).toBe(true);
+	});
+
+	it("reads a queued same-id run the same way — the counter has simply not caught up", async () => {
+		const assertion = await assert([
+			[RUNS, runsAtHead(1, [{id: FLOOR, name: "governance-floor"}])],
+			[once(RUN), workflowRun({id: FLOOR, attempt: 1})],
+			[RERUN, okOut("")],
+			[RUN, workflowRun({id: FLOOR, attempt: 1, status: "queued", conclusion: null})],
+		]);
+		expect(assertion).toEqual({_tag: "Restarting", run: FLOOR, status: "queued"});
+	});
+
 	it("answers NoRun when the repository runs no floor at this head", async () => {
 		expect(await assert([[RUNS, runsAtHead(1, [{id: 1, name: "ci"}])]])).toEqual({_tag: "NoRun"});
 	});
@@ -103,7 +126,7 @@ describe("every unread state is UNKNOWN, never a re-fire nobody proved", () => {
 
 	// The dispatch's 2xx is an acknowledgement, not an attempt: a re-fire reported on the strength of
 	// the response would tell the caller a red is clearing itself when nothing re-ran.
-	it("refuses to call it re-fired when run_attempt did not move", async () => {
+	it("refuses to call it re-fired when the run stayed completed at the same attempt", async () => {
 		const assertion = await assert([
 			[RUNS, runsAtHead(1, [{id: FLOOR, name: "governance-floor"}])],
 			[RUN, workflowRun({id: FLOOR, attempt: 1})],
@@ -128,5 +151,17 @@ describe("floorLine says what the caller must do next", () => {
 			"may still need a re-fire",
 		);
 		expect(floorLine("governance post", {_tag: "InFlight", run: FLOOR})).toContain("re-read");
+	});
+
+	it("tells a restarting re-fire to wait on its run rather than escalate", () => {
+		const line = floorLine("governance post", {
+			_tag: "Restarting",
+			run: FLOOR,
+			status: "in_progress",
+		});
+		expect(line).toContain(String(FLOOR));
+		expect(line).toContain("wait and re-read");
+		expect(line).toContain("nothing to escalate");
+		expect(floorToken({_tag: "Restarting", run: FLOOR, status: "in_progress"})).toBe("restarting");
 	});
 });


### PR DESCRIPTION
`governance post` re-fires the `governance-floor` run at the head it just posted to, then re-reads
the run to prove the re-fire took. That read fires right after the POST and usually beats GitHub's
bump of `run_attempt`, so the verb reported `unknown` — and the skill routes an `unknown` floor to
`heal-ci`. Three agents escalated in one evening over re-fires that had taken and went green
untouched.

A run this verb just read as completed-and-red that is queued or running again under the same id can
only be running because of this dispatch. That is proof from run state, which is the whole reason
the attempt counter was here. So the readback now accepts it as a sixth outcome, `Restarting`, whose
line names the run and says wait and re-read it. A run that is still `completed` at the same attempt
proves nothing and stays `Unknown` with its reason — the guard against a dispatch that never took is
untouched, and nothing here can produce a green.

The token joins the closed vocabulary in `floorToken`, and both the skill's §5 and the contract's
step 7 list it and say it is not a `heal-ci` case. Tests cover both sides: `in_progress` and
`queued` delayed bumps resolve to `Restarting`, the still-completed case still resolves to
`Unknown`.

Fixes #5982

## Deviations

- **Scope narrowing** — **Said:** the issue offers two fix shapes, bounded re-read polling or
  accepting a post-dispatch status change as its own proof. **Did:** implemented only the second.
  **Why:** it needs no clock, so both sides stay deterministic in unit tests, and the reported runs
  all showed the status had already moved when the counter had not. **Disposition:** stated here;
  the polling shape remains compatible if a case ever shows both signals lagging.
