### PR TITLE
fix: The build skill's terminal vocabulary has no word for an epic child that built successfully and opened no PR

### DIFF
--- a/claude-plugins/fabrika/skills/build/SKILL.md
+++ b/claude-plugins/fabrika/skills/build/SKILL.md
@@ -191,7 +191,8 @@ comment on the child issue instead: the line `build-deviations: #<n>` over the s
 through `fabrika wire emit --format build-deviations` and posted with `gh issue comment`. The
 epic-tail review reads every landed child's comment from there, so a child with nothing to disclose
 still posts the checked `None.` — an absent comment reads as "never considered it", not as
-"nothing to disclose".
+"nothing to disclose". A child that lands its commit and posts that comment ends on `BUILT-NO-PR`,
+below — not on a `SHIPPED-PR` naming a PR nobody opened.
 
 **State what changed and why, and stop.** Two things earn their lines: the summary, and
 `## Deviations` — deviations catch real defects, so state each plainly and never trim one for
@@ -217,7 +218,10 @@ fabrika build release $issue_or_pr_number
 
 **Terminal vocabulary** — end on exactly one: `SHIPPED-PR` (PR open, branch pushed);
 `SUCCESS-NO-PR` (a `type:investigation` answered by a diagnosis posted with `build note` — branch
-removed, findings filed via `/report`; closing the issue is triage's, not yours); `BACKED-OFF` (claim lost or blocked — branch removed, nothing written); `ESCALATED`
+removed, findings filed via `/report`; closing the issue is triage's, not yours); `BUILT-NO-PR` (an
+epic child under the epic rules — your commit landed on the branch you cut from the assembly branch
+and the `build-deviations` marker is posted on the child issue; branch left local, unpushed, for the
+epic driver to fold); `BACKED-OFF` (claim lost or blocked — branch removed, nothing written); `ESCALATED`
 (repair cap reached — branch left pushed at its last verified head, escalation note posted);
 `STOPPED` (isolation or verdict UNKNOWN — branch left local, state named). An empty pick pool is
 `BACKED-OFF` too — nothing to build, nothing written, and on a lost claim "branch removed" means
@@ -235,10 +239,12 @@ node packages/fabrika-cli/src/bin.ts lane report <lane> --root <root> --token SH
 ```
 
 `--pr` whenever the terminal names one; `--comment` for the diagnosis comment behind a
-`SUCCESS-NO-PR`. The verb refuses a token outside this vocabulary (exit `32`) rather than
+`SUCCESS-NO-PR`; a `BUILT-NO-PR` carries neither, because its evidence is the commits themselves.
+The verb refuses a token outside this vocabulary (exit `32`) rather than
 interpreting it — never respell one to get past it. It also **proves the event before it records**:
-your `SHIPPED-PR` lands only against an open PR the board shows linking the issue, and a
-`SUCCESS-NO-PR` only against the diagnosis comment you posted — so a refusal here is the board
+your `SHIPPED-PR` lands only against an open PR the board shows linking the issue, a
+`SUCCESS-NO-PR` only against the diagnosis comment you posted, and a `BUILT-NO-PR` only against a
+local branch in this tree whose commits name the child issue — so a refusal here is the board
 disagreeing with your terminal, never a token to change. On any refusal, print the token and name
 the exit code; the operator re-reads and routes. Then print the token as the last line either way;
 a run whose caller named no lane prints the token only and records nothing.

--- a/claude-plugins/fabrika/skills/operate/SKILL.md
+++ b/claude-plugins/fabrika/skills/operate/SKILL.md
@@ -342,7 +342,8 @@ event and never skipped as an optimisation. Its refusals each name a different n
 A builder's `SUCCESS-NO-PR` is a proven `DONE`, not an unproven one: the verb takes the no-PR arm
 only for a `type:investigation`, and proves it from the diagnosis comment posted since the task
 entered `build` — the artifact the builder's terminal names, read off the issue rather than off
-the report.
+the report. An epic child's `BUILT-NO-PR` is the other proven `DONE` without a PR, and its artifact
+is the range's own commits — a child opens no PR to prove one against (#6019).
 
 **An `integrate` has no spawn to report**, so its row is the merge's own exit folded by the two
 rules step 2 named: a clean merge whose post-merge checks pass is `DONE`; a conflict, or a red

--- a/packages/fabrika-cli/src/lane/report.ts
+++ b/packages/fabrika-cli/src/lane/report.ts
@@ -19,6 +19,11 @@ export const SHELL_VOCABULARIES = {
 	builder: {
 		"SHIPPED-PR": "DONE",
 		"SUCCESS-NO-PR": "DONE",
+		// An epic child builds, commits and deliberately opens no PR (ADR 0285), so neither of the
+		// two terminals above fits and the token used to fall to the refusal — recording a clean
+		// build as BLOCKED (#6019). Its proof is already the child arm of `lane prove`: a DONE out
+		// of `build` in a child role stands on the range's commits, not on a PR.
+		"BUILT-NO-PR": "DONE",
 		"BACKED-OFF": "BLOCKED",
 		ESCALATED: "BLOCKED",
 		STOPPED: "BLOCKED",

--- a/packages/fabrika-cli/src/lane/report.unit.test.ts
+++ b/packages/fabrika-cli/src/lane/report.unit.test.ts
@@ -1,5 +1,29 @@
 import {describe, expect, it} from "vitest";
+import {EPIC_RULES} from "../wire/lane-brief.ts";
 import {eventForToken, flattenVocabularies, SHELL_VOCABULARIES} from "./report.ts";
+
+describe("the builder's no-PR terminals", () => {
+	it("routes an epic child's BUILT-NO-PR to DONE, not to the BLOCKED a clean build never earned", () => {
+		expect(eventForToken("BUILT-NO-PR")).toEqual({
+			_tag: "Mapped",
+			token: "BUILT-NO-PR",
+			event: "DONE",
+		});
+	});
+
+	it("keeps SUCCESS-NO-PR its own token — the child terminal is additive, not a widening", () => {
+		expect(SHELL_VOCABULARIES.builder).toMatchObject({
+			"SUCCESS-NO-PR": "DONE",
+			"BUILT-NO-PR": "DONE",
+		});
+	});
+
+	it("recognises the terminal the epic-run brief tells a child to end on", () => {
+		const named = /ends on `([A-Z][A-Z-]+)`/.exec(EPIC_RULES);
+		expect(named?.[1]).toBe("BUILT-NO-PR");
+		expect(eventForToken(named?.[1] ?? "")).toMatchObject({event: "DONE"});
+	});
+});
 
 describe("the shipper's routing arms are three answers, not one", () => {
 	it("routes the repair arm to FAIL so the ship state spends a retry back into build", () => {

--- a/packages/fabrika-cli/src/wire/lane-brief.ts
+++ b/packages/fabrika-cli/src/wire/lane-brief.ts
@@ -167,7 +167,9 @@ describes a tree you are not standing in.`;
  */
 export const EPIC_RULES = `This lane is one epic run: one shared branch and one pull request at its tail (ADR 0285). Build in
 your own worktree on a local branch cut from \`branch\`, and never push or open a pull request for a
-child state — the merge happens once, after the epic review.
+child state — the merge happens once, after the epic review. A child's build that lands its commit
+ends on \`BUILT-NO-PR\`, whose branch disposition is exactly that: left local and unpushed for this
+lane to fold (#6019).
 A child's build discloses its deviations — the section a PR body would carry — as a
 \`build-deviations\` marker comment on the child issue, composed through
 \`node packages/fabrika-cli/src/bin.ts wire emit --format build-deviations\`; the epic-tail review


### PR DESCRIPTION
An epic child builds, commits and deliberately opens no PR (ADR 0285). None of `build`'s five
terminals named that outcome, so `lane report` refused the improvised token and the child fell to
the `BLOCKED` reading — a clean build recorded as a failure.

This adds a sixth terminal, `BUILT-NO-PR`, and names it in the three places a child builder and its
driver already read:

- `build/SKILL.md` — the terminal paragraph, with its branch disposition (left local, unpushed, for
  the epic driver to fold), plus the epic-child paragraph in section 5 and the `lane report` refs
  note.
- `EPIC_RULES` in `lane-brief.ts` — beside the existing no-push / no-PR rule, so a child reads the
  terminal where it reads the rule that produces it.
- `lane/report.ts` — `BUILT-NO-PR` maps to `DONE`.

No new proof machinery was needed. `lane prove` already keys its claim on event + leaf + role, so a
`DONE` out of `build` in a child role stands on the range's commits rather than on a PR. The token
was the only missing piece.

`SUCCESS-NO-PR` is untouched and still scoped to the investigation-diagnosis case. `build-ui` is
untouched and its "no success-without-PR terminal" statement still stands.

Three tests: the token maps to `DONE`, both no-PR terminals coexist in the builder's vocabulary, and
the terminal `EPIC_RULES` names is one the map recognises — so the brief and the vocabulary cannot
drift apart silently.

Fixes #6019

## Deviations

- **Scope narrowing** — **Said:** the criteria ask that `operate/SKILL.md`'s spawn-report table
  route the new terminal to `DONE`. **Did:** added the token to `packages/fabrika-cli/src/lane/report.ts`
  instead, and added one clause to `operate/SKILL.md`'s proven-`DONE` paragraph naming the terminal.
  **Why:** #5736 landed first and moved that table out of prose into code; `operate/SKILL.md` now
  points at `report.ts` and lists no tokens, which the issue's own triage note anticipated ("if it
  ships first, this ticket's new token must be added to that map instead of to the prose table").
  **Disposition:** stated here.
- **Known defect left unfixed** — **Said:** the criteria ask that the vocabulary's count be updated
  "wherever it is stated" in the skill's prose. **Did:** changed no count. **Why:** `build/SKILL.md`
  states no number — it says "end on exactly one" and enumerates; the only "five"/"six" hits in the
  skill are unrelated (a contract sentence about verbs, and operate's count of the machine's
  events). **Disposition:** nothing to update; stated here so the criterion reads as considered
  rather than skipped.
