### PR TITLE
feat: Triage homes every new fabrika issue in the closing milestone, so M46 grows faster than it drains

### DIFF
--- a/claude-plugins/fabrika/skills/triage/SKILL.md
+++ b/claude-plugins/fabrika/skills/triage/SKILL.md
@@ -110,6 +110,9 @@ Lane-entering work (an epic, or a parentless feature) additionally carries a `##
 *is* that home — inside your rewrite for a feature, on stdin for an epic — and **only the founder
 approves a pitch**. Take an existing home: **triage never creates a milestone**, and
 `wayfinder:backlog` is bounded to genuine fog rather than work you would rather not decide about.
+**The milestone in exclusive focus is closed to new intake** unless the work is `p0` or blocks one of
+that milestone's own in-flight lanes — `triage homes` marks that row `running`, and is where you read
+which milestone it is. That is a subtraction and nothing more: home the work by fit exactly as above.
 
 ```bash
 fabrika triage homes

--- a/claude-plugins/fabrika/skills/triage/contract.md
+++ b/claude-plugins/fabrika/skills/triage/contract.md
@@ -30,7 +30,7 @@ makes the implementer guess ([#4734](https://github.com/kamp-us/phoenix/issues/4
 | `triage queue` | the claimable `status:needs-triage` queue, with the count it scanned | paginating a label query and separating a proven-empty queue from a failed read is mechanical; which issue to take is judgment |
 | `triage claim` | take a session-scoped claim on one issue, proven by read-back | a marker write plus an earliest-claim tiebreak is a protocol, not a decision |
 | `triage provenance` | was this issue reported by an agent or hand-typed by a human | a structural marker test over a fetched body, plus a membership test over the configured operator set — an empty body fails closed to `human`, an unreadable one refuses rather than guessing; what to *do* about a human filing stays in the skill |
-| `triage homes` | the assignable homes — open milestones joined to their ROADMAP rows, plus the standing lanes | the join and the open-milestone filter are mechanical; picking which home fits is judgment |
+| `triage homes` | the assignable homes — open milestones joined to their ROADMAP rows, plus the standing lanes, with the milestone in exclusive focus marked `running` | the join, the open-milestone filter and reading the focus declaration are mechanical; picking which home fits, and whether an exception applies, is judgment |
 | `triage split` | create one split child, once, keyed on the parent back-reference | idempotency keyed on a durable reference is mechanical; deciding a report *is* a bundle is judgment |
 | `triage enrich` | replace the body with your rewrite — or, for an epic, your pitch — over a preserved, leak-redacted original | envelope assembly, redaction and read-back are mechanical; what the rewrite says is judgment |
 | `triage apply` | apply the whole triaged transition — type, priority, audience, home — and read it back | closed-vocabulary validation and an atomic label envelope are mechanical; the classification is judgment |
@@ -661,6 +661,31 @@ machine-channel answer.
 With `--json`, an object with keys `outcome`, `milestones` (array of `{number, title, roadmapRow}`),
 `lanes` (array of `{label, meaning}`), and `scanned`.
 
+**The milestone in exclusive focus is marked `running`.** That campaign is closed to new intake
+unless the work is `p0` or blocks one of that milestone's own in-flight lanes, so its row carries a
+fourth tab-separated column, verbatim `running: p0/blocker only`, and its `--json` object carries
+`"running": "p0/blocker only"` as a fourth key. Every other row is unchanged on both channels — no
+fourth column, and no `running` key — so a reader written against the pre-marker shape still parses.
+The marked milestone is still listed: the two exceptions are real work, and a removed row cannot
+carry them. This verb states the subtraction and stops; where excluded work goes instead is the
+caller's by-fit judgement, and no output here names a destination.
+
+**Which milestone is running is data, never a literal in this spec or in the verb.** It is
+`ROADMAP.md`'s `## Focus` table — the same exclusive-focus declaration `build pick` fences on, read
+through the same parser, off the roadmap text this verb has already read for the arc join. Moving the
+focus to the next campaign is a `ROADMAP.md` edit and never a code or skill edit; `--roadmap` moves
+both reads together. The declaration's three states are the ones that declaration already has:
+
+| `## Focus` | Rows marked | stderr |
+|---|---|---|
+| declares a milestone | that milestone's row, if it is open | `triage homes: focus: milestone #<n>, declared <date>.` |
+| absent, or an empty section | none — the answer is exactly the pre-marker one | `triage homes: focus: none declared — scope fence inert.` |
+| reads but does not parse | none | `triage homes: focus: unreadable — <reason>.` |
+
+A malformed declaration is **never** rendered as "no milestone is running", and it does not refuse: a
+home list is still the right answer, and the stderr line is where the defect is named. A focus naming
+a milestone that is closed or absent from the open set marks no row and passes.
+
 **Only open milestones appear, and each is joined to its roadmap arc/campaign row.** `roadmapRow` is
 `null` for an open milestone no roadmap row pins, which is itself a signal worth seeing rather than a
 row to hide. The two standing lanes are fixed and are not read from the repo. There is no third, and
@@ -684,6 +709,10 @@ milestone titled `Sözlük — search and discovery`, and the two share no subst
 |---|---|
 | `7` | the repository has zero open milestones, **or the roadmap parsed to zero arc rows** — zero scope |
 | `11` | the milestone list or the roadmap file could not be read — the outcome is UNKNOWN |
+
+A malformed `## Focus` declaration is not on this table: it marks no row and names itself on stderr.
+The focus is an annotation on an answer this verb can give without it, so refusing over one would
+withhold the home list a triager needs.
 
 **Errors**
 
@@ -721,14 +750,14 @@ hands a byte-reading caller two rows and no token.
 $ fabrika triage homes
 homes
 milestone	47	Sözlük — search and discovery
-milestone	52	Merge-Gate Reliability
+milestone	52	Merge-Gate Reliability	running: p0/blocker only
 lane	wayfinder:backlog	fog — uncharted work upstream of any arc
 lane	axis:pipeline-hardening	the standing pipeline and reliability lane
 ```
 
 ```
 $ fabrika triage homes --json
-{"outcome":"homes","milestones":[{"number":47,"title":"Sözlük — search and discovery","roadmapRow":"Geçit"},{"number":52,"title":"Merge-Gate Reliability","roadmapRow":null}],"lanes":[{"label":"wayfinder:backlog","meaning":"fog — uncharted work upstream of any arc"},{"label":"axis:pipeline-hardening","meaning":"the standing pipeline and reliability lane"}],"scanned":2}
+{"outcome":"homes","milestones":[{"number":47,"title":"Sözlük — search and discovery","roadmapRow":"Geçit"},{"number":52,"title":"Merge-Gate Reliability","roadmapRow":null,"running":"p0/blocker only"}],"lanes":[{"label":"wayfinder:backlog","meaning":"fog — uncharted work upstream of any arc"},{"label":"axis:pipeline-hardening","meaning":"the standing pipeline and reliability lane"}],"scanned":2}
 ```
 
 **Grounding**
@@ -742,6 +771,10 @@ $ fabrika triage homes --json
   on-roadmap, so a closed milestone reports as a valid home. Offering only open, roadmap-joined
   milestones designs that mismatch out at the point of assignment rather than detecting it later.
 - ADR 0072 §3 — curating the milestone set is a human roadmap act, so no verb here creates one.
+- #6080 — a closing campaign kept taking every lane's follow-ups because nothing in this verb's
+  output said which milestone was running, so triagers homed by title match. The marker is only a
+  subtraction; enforcement is deliberately absent, since both exceptions are judgements a verb cannot
+  check and a guard blind to them would refuse exactly the work the rule allows.
 
 ---
 

--- a/packages/fabrika-cli/src/triage/command.ts
+++ b/packages/fabrika-cli/src/triage/command.ts
@@ -335,7 +335,7 @@ const homes = leafCommand(
 ).pipe(
 	Command.withShortDescription("The assignable homes: open milestones and standing lanes."),
 	Command.withDescription(
-		"List the assignable homes: every OPEN milestone joined to its roadmap arc/campaign row by `#<number>`, plus the two standing lanes. First stdout line is `homes`, then one `<kind>\\t<key>\\t<label>` line per candidate. Exits 7 (zero open milestones, or the roadmap parsed to 0 arc rows), 11 (the milestone list or the roadmap could not be read). Example: fabrika triage homes",
+		"List the assignable homes: every OPEN milestone joined to its roadmap arc/campaign row by `#<number>`, plus the two standing lanes. First stdout line is `homes`, then one `<kind>\\t<key>\\t<label>` line per candidate; the milestone in exclusive focus carries a fourth column, `running: p0/blocker only` (a `running` field under `--json`) — that campaign is closed to new intake unless the work is p0 or blocks one of its own in-flight lanes. Exits 7 (zero open milestones, or the roadmap parsed to 0 arc rows), 11 (the milestone list or the roadmap could not be read). Example: fabrika triage homes",
 	),
 );
 

--- a/packages/fabrika-cli/src/triage/homes-verb.ts
+++ b/packages/fabrika-cli/src/triage/homes-verb.ts
@@ -11,8 +11,15 @@
  * Curating the milestone set is a human roadmap act (ADR 0072 §3), so this verb creates none. It
  * offers only open, roadmap-joined milestones, which designs out the mismatch where a closed
  * milestone reports as a valid home.
+ *
+ * One row can carry a **running** marker: the campaign in exclusive focus is closed to new intake
+ * unless the work is p0 or blocks one of that milestone's own in-flight lanes (#6080). Which
+ * milestone that is, is data — `ROADMAP.md`'s `## Focus` table, the same declaration `build pick`
+ * fences on, read through the same parser off the roadmap text this verb already has open. The
+ * marked row is still offered: the two exceptions are real, and a removed row cannot carry them.
  */
 import {Effect, Result} from "effect";
+import {focusScopeLine, readFocus} from "../build/scope-admission.ts";
 import {readFile} from "../io/fs.ts";
 import {listOpenMilestones, resolveRepo} from "../io/issues.ts";
 import {answer, FAILED, refuse} from "../verb.ts";
@@ -40,6 +47,9 @@ export const STANDING_LANES: ReadonlyArray<StandingLane> = [
 	{label: "wayfinder:backlog", meaning: "fog — uncharted work upstream of any arc"},
 	{label: "axis:pipeline-hardening", meaning: "the standing pipeline and reliability lane"},
 ];
+
+/** What the marked row says, on both channels — the subtraction, not a routing instruction. */
+export const RUNNING_MARKER = "running: p0/blocker only";
 
 export interface HomesOptions {
 	readonly roadmap: string;
@@ -103,13 +113,22 @@ export const runHomes = Effect.fn("runHomes")(function* (options: HomesOptions) 
 		);
 	}
 
+	// Malformed is never read as "no milestone is running": it marks no row and says so here, and it
+	// does not refuse — a home list is still the right answer over an unreadable focus declaration.
+	const focus = readFocus(read.success);
+	const inFocus = focus._tag === "Declared" ? focus.milestone : null;
+
 	const homes = [...milestones.value]
 		.sort((a, b) => a.number - b.number)
 		.map((milestone) => ({
 			number: milestone.number,
 			title: milestone.title,
 			roadmapRow: roadmapRowFor(rows, milestone.number),
+			// `undefined` rather than `false`: `JSON.stringify` drops the key, so a not-in-focus row
+			// serialises byte-for-byte as it did before the marker existed.
+			running: milestone.number === inFocus ? RUNNING_MARKER : undefined,
 		}));
+	const notices = [scope, focusScopeLine("triage homes", focus)];
 
 	if (json) {
 		return answer(
@@ -119,15 +138,19 @@ export const runHomes = Effect.fn("runHomes")(function* (options: HomesOptions) 
 				lanes: STANDING_LANES,
 				scanned: milestones.value.length,
 			}),
-			[scope],
+			notices,
 		);
 	}
 	return answer(
 		[
 			"homes",
-			...homes.map((home) => `milestone\t${home.number}\t${home.title}`),
+			...homes.map((home) =>
+				["milestone", home.number, home.title, home.running]
+					.filter((cell) => cell !== undefined)
+					.join("\t"),
+			),
 			...STANDING_LANES.map((lane) => `lane\t${lane.label}\t${lane.meaning}`),
 		].join("\n"),
-		[scope],
+		notices,
 	);
 });

--- a/packages/fabrika-cli/src/triage/homes-verb.unit.test.ts
+++ b/packages/fabrika-cli/src/triage/homes-verb.unit.test.ts
@@ -3,7 +3,7 @@ import {describe, expect, it} from "vitest";
 import {errOut, fakeFs, fakeShell, okOut} from "../fakes.test-support.ts";
 import {ANSWER, FAILED} from "../verb.ts";
 import {PRECONDITION_UNKNOWN, ZERO_SCOPE} from "./codes.ts";
-import {runHomes, STANDING_LANES} from "./homes-verb.ts";
+import {RUNNING_MARKER, runHomes, STANDING_LANES} from "./homes-verb.ts";
 
 const MILESTONES = /repos\/o\/r\/milestones/;
 
@@ -161,6 +161,60 @@ describe("runHomes", () => {
 		);
 		expect(out.code).toBe(FAILED);
 		expect(out.stderr.at(-1)).toContain("CLAUDE_PIPELINE_REPO");
+	});
+});
+
+describe("runHomes and the running-campaign marker", () => {
+	const withFocus = (milestone: string, declared = "2026-08-18") =>
+		`${ROADMAP}\n## Focus\n\n| Milestone | Declared |\n|---|---|\n| ${milestone} | ${declared} |\n`;
+
+	it("marks the in-focus milestone's row and leaves every other row exactly as today", async () => {
+		const out = await run([twoMilestones], {"ROADMAP.md": withFocus("#44")});
+		expect(out.code).toBe(ANSWER);
+		expect(out.stdout.trimEnd().split("\n")).toEqual([
+			"homes",
+			"milestone\t24\tSözlük — search and discovery",
+			`milestone\t44\tfabrika\t${RUNNING_MARKER}`,
+			"lane\twayfinder:backlog\tfog — uncharted work upstream of any arc",
+			"lane\taxis:pipeline-hardening\tthe standing pipeline and reliability lane",
+		]);
+	});
+
+	it("carries the same fact as a per-milestone --json field, absent on a not-in-focus row", async () => {
+		const out = await run([twoMilestones], {"ROADMAP.md": withFocus("#44")}, {json: true});
+		expect(JSON.parse(out.stdout).milestones).toEqual([
+			{number: 24, title: "Sözlük — search and discovery", roadmapRow: "Geçit"},
+			{number: 44, title: "fabrika", roadmapRow: "fabrika campaign", running: RUNNING_MARKER},
+		]);
+	});
+
+	it("still LISTS the in-focus milestone — the marker annotates a row, it never removes one", async () => {
+		const out = await run([twoMilestones], {"ROADMAP.md": withFocus("#44")});
+		expect(out.stdout).toContain("milestone\t44\tfabrika");
+	});
+
+	it("marks no row when no focus is declared, and answers exactly as it does today", async () => {
+		const text = await run([twoMilestones], {"ROADMAP.md": ROADMAP});
+		const machine = await run([twoMilestones], {"ROADMAP.md": ROADMAP}, {json: true});
+		expect(text.stdout).not.toContain("running");
+		expect(machine.stdout).not.toContain("running");
+		expect(text.stderr.join("\n")).toContain("focus: none declared");
+	});
+
+	it("never reads a MALFORMED focus as `no milestone is running` — it says so and marks no row", async () => {
+		const out = await run([twoMilestones], {
+			"ROADMAP.md": `${ROADMAP}\n## Focus\n\n| Milestone | Declared |\n|---|---|\n| forty-four | 2026-08-18 |\n`,
+		});
+		expect(out.code).toBe(ANSWER);
+		expect(out.stdout).not.toContain("running");
+		expect(out.stderr.join("\n")).toContain("focus: unreadable");
+	});
+
+	it("leaves every row unmarked, and does not fail, when the focus names a milestone not open", async () => {
+		const out = await run([twoMilestones], {"ROADMAP.md": withFocus("#999")});
+		expect(out.code).toBe(ANSWER);
+		expect(out.stdout).not.toContain("running");
+		expect(out.stderr.join("\n")).toContain("focus: milestone #999");
 	});
 });
 


### PR DESCRIPTION
`fabrika triage homes` listed every open milestone the same way, so a triager picked the one whose
title matched the work — and the campaign we were trying to close kept absorbing every lane's
follow-ups.

Now the milestone in exclusive focus is marked. Its text row gains a fourth column,
`running: p0/blocker only`, and its `--json` object gains a `running` key. Every other row is
byte-identical to before on both channels, and the marked milestone is still listed: the two
exceptions (`p0`, or blocking one of that milestone's own in-flight lanes) are real work, and a
removed row cannot carry them.

Which milestone is running is data, not a literal. `triage homes` runs `readFocus` over the
`ROADMAP.md` text it already has open for the arc join — the same `## Focus` declaration `build pick`
fences on, through the same parser. Moving the focus is a `ROADMAP.md` edit. No new flag, key or
config lands here. The declaration's three states carry through unchanged: declared marks a row,
absent marks none, and malformed marks none while naming itself on stderr via the shared
`focusScopeLine` — never rendered as "no milestone is running". A focus naming a closed or absent
milestone marks nothing and does not fail.

Step 6 of the triage skill gains one rule line stating the subtraction and pointing at `triage homes`
for which milestone it is. It names no destination for the excluded work: step 6's existing by-fit
homing is untouched.

No enforcement. `triage apply --home` still accepts the running milestone, deliberately — both
exceptions are judgements a verb cannot check, so a guard would refuse exactly the work the rule
allows.

Five unit tests cover the in-focus row, a not-in-focus row, no focus, a malformed focus, and a focus
naming a milestone outside the open set.

Fixes #6080

## Deviations

- **Out-of-scope change** — **Said:** #6080 names `triage homes` and the triage SKILL step 6.
  **Did:** also updated the verb's `--help` text in `packages/fabrika-cli/src/triage/command.ts` and
  the `triage homes` section of `claude-plugins/fabrika/skills/triage/contract.md`. **Why:** both
  restate this verb's output shape verbatim; leaving them would ship a spec and a help string that
  contradict the bytes the verb now emits. **Disposition:** stated here.
