### PR TITLE
fix: A routed-not-fired governance namespace stalls the operate loop with no event it may record

### DIFF
--- a/claude-plugins/fabrika/skills/operate/SKILL.md
+++ b/claude-plugins/fabrika/skills/operate/SKILL.md
@@ -408,13 +408,19 @@ namespace is still in flight, it orphans that namespace's verdict mid-write and 
 machine's retries on a verdict set nobody finished. A reviewer report carrying a `FAIL` beside a
 namespace with no verdict that still binds is an incomplete read, not an event: re-read the
 artifact's verdicts — the PR's, or the child range's — until every derived namespace is terminal
-against what that artifact carries now, then record. No repair builder is
+against what that artifact carries now, then record. **The re-read is bounded, not a hold**: it runs
+only while the reviewer's run is still in flight, and once that run has ended with the namespace
+still empty the outcome is the `BLOCKED` the next paragraph names — never an indefinite wait on a
+state that reads as active. No repair builder is
 ever spawned while any namespace at the head is non-terminal.
 
-**Re-reading terminates, because no reviewer may decline a derived namespace on a `FAIL` round.**
-ADR [0293](../../../../.decisions/0293-governance-fires-every-round.md) rules governance
+**Re-reading terminates, because no reviewer may decline a derived namespace on a `FAIL` round, and
+none may route one away either.** ADR
+[0293](../../../../.decisions/0293-governance-fires-every-round.md) rules governance
 derived-required at every round and every head on a `harness: true` diff, FAIL rounds included —
-`review` §6 states it on both arms. So a governance verdict missing at a `harness: true` head is
+`review` §6 states it on both arms, and that skill's `routed elsewhere` terminal covers `review-ui`
+and `check-epic-plan` only, so no reviewer terminal ends a run with governance un-fired (#5769). So a
+governance verdict missing at a `harness: true` head is
 always a read still in flight or a reviewer that died mid-emit, never a licensed refusal, and the
 remedy above reaches a verdict instead of waiting on one nobody will write. The floor stays, and no
 `harness: true` FAIL round holds the old deadlock — the state where the verdict is refused by rule,

--- a/claude-plugins/fabrika/skills/review/SKILL.md
+++ b/claude-plugins/fabrika/skills/review/SKILL.md
@@ -148,7 +148,9 @@ undisclosed that this gate could see"* — never "no deviations exist".
   namespace holds a binding verdict, so a declined governance round strands the lane with the
   repair undispatchable. Fire it, and expect to fire it again at each repair head — the extra run
   is the accepted cost. Neither namespace discharges the other. You never emit governance's
-  namespace yourself.
+  namespace yourself. **And there is no route out of it**: the Terminal vocabulary's `routed
+  elsewhere` covers `review-ui` and `check-epic-plan` only, so this skill has no terminal that ends
+  a `harness: true` run with the governance namespace un-fired.
 - **On an epic child the governance verdict is range-scoped and lands on the child issue** —
   nothing governance-shaped waits for the epic tail. An epic run opens one tail PR (ADR
   [0285](../../../../.decisions/0285-epic-machine-ends-in-review.md)), so mid-run a child has no PR
@@ -196,9 +198,19 @@ repo-scoped token and **uses** four writes — verdict comments, AC appends, the
 escalation comment, and one append to the driver's lane ledger through `lane report` at the
 `--root` your brief carries, a path outside this checkout — no push, no merge, no label. Every run ends as exactly one of: **verdict PASS**
 · **verdict FAIL** · **UNKNOWN — the artifact could not be read** (never a verdict) · **prior marker
-Stale/Unbindable — re-review required** · **routed elsewhere** (governance / `review-ui` /
-`check-epic-plan`). Precedence: **an unseen input blocks PASS, never FAIL** — FAIL on what you did
+Stale/Unbindable — re-review required** · **routed elsewhere** (`review-ui` / `check-epic-plan`
+only). Precedence: **an unseen input blocks PASS, never FAIL** — FAIL on what you did
 see, naming the unread piece UNKNOWN; no namespace PASSes on an unseen input.
+
+**Governance is not one of the routes, and never was a legal way to end.** `routed elsewhere` carries
+the two modality handoffs and nothing else — `review-ui` for a rendered visual, `check-epic-plan` for
+a plan ledger — each a subject this skill cannot judge at all. Governance it can and must reach: §6
+makes the namespace derived-required at every round on a `harness: true` diff, so firing it and
+waiting happens **inside** this run, and no terminal above ends a run with that namespace un-fired.
+Routing it away instead is what stranded PR [#5738](https://github.com/kamp-us/phoenix/pull/5738) at
+head `7847ecf3` (#5769): `operate`'s `FAIL`-row floor correctly refused to record the FAIL while
+governance held no binding verdict, the machine had no state that could fire it, and the namespace
+filled only because an unrelated second driver happened to run governance on the same lane.
 
 **Record the terminal yourself, then print it.** When your spawn brief named a lane, your terminal
 step is the verb — pass back the `lane` and `root` its `## Task` section carries, one token per


### PR DESCRIPTION
The review skill said two different things about governance on a `harness: true` diff. Step 6 says fire it and wait, every round, whatever polarity you reach (ADR 0293). The Terminal vocabulary listed `routed elsewhere (governance / review-ui / check-epic-plan)` as a legal way for the run to end. A reviewer that took the routed terminal left the derived-required namespace with no binding verdict, and `operate`'s FAIL-row floor then correctly refused to record the FAIL — so the lane sat in `review` carrying an event nobody was allowed to record, with no state that could fire the missing namespace.

That is the case this closes: PR #5738 at head `7847ecf3`, driving epic #5492 / child #5587. The reviewer ended "routed elsewhere (governance)", the fold read `[('governance','PASS','ddb45c5a',current=False), ('review-skill','FAIL','7847ecf3',current=True)]`, and the namespace only filled because an unrelated second driver (#5761) happened to run governance on the same lane three minutes later.

What changed, both prose-only:

`claude-plugins/fabrika/skills/review/SKILL.md` — `routed elsewhere` is now scoped to `review-ui` / `check-epic-plan` only, the two modality handoffs for subjects this skill cannot judge at all. A paragraph under Terminal vocabulary says why governance is not one of them: it is a subject the skill can and must reach, so firing it and waiting happens inside the run and no terminal ends a run with it un-fired. Step 6 gained the matching back-pointer, so a reader who only reads §6 learns there is no routing escape either. The two passages now state one rule from both ends.

`claude-plugins/fabrika/skills/operate/SKILL.md` — the FAIL-row refusal now says its re-read is bounded: it runs only while the reviewer's run is in flight, and once that run has ended with the namespace still empty the outcome is the `BLOCKED` the following paragraph already named. That `BLOCKED` was there; nothing in the refusal itself pointed at it, so a reader could stop at "re-read until terminal" and hold. The "re-reading terminates" paragraph also picks up the no-route half, since a decline and a route-away strand the lane identically.

No agent shell is added. The `ROUTED` token in `lane report`'s reviewer vocabulary is untouched and still maps to `BLOCKED` — it now carries only the two modality routes, which is a visible park a human clears, not the silent stall this fixes.

Reviewer: check that §6 and the Terminal vocabulary cannot be satisfied independently, and that scoping `routed elsewhere` does not orphan a real reviewer situation — the question is whether any run legitimately needs to end with governance un-fired, and I claim none does on a `harness: true` diff under ADR 0293.

## Deviations

- **Scope narrowing** — **Said:** #5769's scope allows `operate` "naming the outstanding-namespace state explicitly rather than silently holding". **Did:** added only a bounded-re-read clause pointing at the `BLOCKED` that ADR 0293's landing already put in the paragraph below. **Why:** the named, visible outcome the criterion asks for already exists in that text; a second name for it would be a duplicate rule to keep in sync. **Disposition:** stated here.
- **Declined guidance** — **Said:** the acceptance-criteria block asks the change to name PR #5738 at head `7847ecf3` as the case it closes. **Did:** named it in the review SKILL.md paragraph and in full here, rather than in an ADR. **Why:** ADR 0293 already owns the governance-every-round decision and this is the consistency fix that record implies, not a new decision. **Disposition:** stated here.
- **Pre-existing defect left unfixed** — **Said:** nothing. **Did:** `build issue 5769` reported the acceptance-criteria block malformed — plain bullets, no `- [ ]` checkboxes — and I built against the bullets as written without editing the issue body. **Why:** rewriting a filed body is not this lane's act; the criteria were unambiguous to read. **Disposition:** stated here, so the reviewer knows the criteria set it should gate against is the five bullets under `### Acceptance criteria`.

Fixes #5769
