### PR TITLE
fix: Dependencies reader parses an appended amendment's --- separator as a topology line

### DIFF
--- a/claude-plugins/fabrika/skills/plan-epic/contract.md
+++ b/claude-plugins/fabrika/skills/plan-epic/contract.md
@@ -217,12 +217,13 @@ it on every child and the tolerant read made "forgot" indistinguishable from "no
 **`## Dependencies` — the rendered block.** Exactly the two line forms `readTopology` parses, and
 nothing else: one `- phase <n>: #<ref>[, #<ref>…]` row per phase, phases ascending and members
 ascending within a row, then one `- #<ref> requires: #<ref>[, #<ref>…]` row per child that declares
-a prerequisite, ascending by subject. There is no `###` heading inside the section, no label column
-and no parenthesized clause — `readTopology` breaks at the first heading of any level
-(`ANY_HEADING_RE`, `packages/fabrika-cli/src/build/dependencies.ts:47,84`), so a `### Phase <n>`
-line would end the scan on the line after `## Dependencies` and the block would read back as zero
-edges: a well-formed, plausible, always-wrong answer the gate then reads as an epic every one of
-whose children is orphaned. The block ends with a trailing blank line so a later heading stays
+a prerequisite, ascending by subject. There is no `###` heading inside the section, no label column,
+no parenthesized clause and no `---` rule — `readTopology` breaks at the first heading of any level
+**or** the first thematic break (`packages/fabrika-cli/src/build/dependencies.ts`), so a `### Phase
+<n>` line would end the scan on the line after `## Dependencies` and the block would read back as
+zero edges: a well-formed, plausible, always-wrong answer the gate then reads as an epic every one
+of whose children is orphaned. The thematic break is the same boundary an appended amendment's
+separator draws, which is why one below the block leaves the block itself intact (#5816). The block ends with a trailing blank line so a later heading stays
 separated. The illustrated block above is the round trip this grammar buys — pasted into
 `readTopology` it parses to the three edges it depicts (`phase 1: #4301, #4302`, `phase 2: #4303`,
 `#4303 requires: #4301`), never the empty set, which is what lets `ledger topology` stage instead of

--- a/packages/fabrika-cli/src/build/dependencies.ts
+++ b/packages/fabrika-cli/src/build/dependencies.ts
@@ -15,6 +15,14 @@
  * **Any other non-blank line inside the section is unparseable, and unparseability refuses.** "No
  * parseable edges" is never read as "no edges" — a topology nobody could read is not a topology
  * proving nothing blocks (ADR 0092, #4104).
+ *
+ * **The section ends at the next ATX heading or at the first thematic break (`---`, `***`, `___`),
+ * whichever comes first** — this is the canonical statement of that boundary, and `plan/ledger.ts`
+ * reads its own sections through the `isThematicBreak` exported here rather than restating it. A
+ * filed body is amended by appending a dated block below the original, and that block is
+ * conventionally introduced by a bare `---`; with `## Dependencies` last, a heading-only boundary
+ * put that separator inside the section and refused the whole topology over a line that was never
+ * part of it (#5816).
  */
 
 /** A reference in the topology: a real issue, or an id local to the ledger. */
@@ -45,8 +53,15 @@ export type Topology =
 
 const HEADING_RE = /^##\s+Dependencies\s*$/;
 const ANY_HEADING_RE = /^#{1,6}\s+/;
+const THEMATIC_BREAK_RE = /^ {0,3}(?:(?:\*[ \t]*){3,}|(?:-[ \t]*){3,}|(?:_[ \t]*){3,})$/;
 const PHASE_RE = /^-\s*phase\s+(\d+)\s*:\s*(.+)$/i;
 const REQUIRES_RE = /^-\s*(\S+)\s+requires\s*:\s*(.+)$/i;
+
+/**
+ * A CommonMark thematic break: three or more `-`, `*` or `_`, optionally spaced, indented at most
+ * three. Tested against the raw line, because the indent is part of the rule.
+ */
+export const isThematicBreak = (line: string): boolean => THEMATIC_BREAK_RE.test(line);
 
 const parseRef = (raw: string): Ref | null => {
 	const text = raw.trim();
@@ -81,7 +96,7 @@ export const readTopology = (body: string): Topology => {
 		const raw = lines[i] ?? "";
 		const text = raw.trim();
 		if (text === "") continue;
-		if (ANY_HEADING_RE.test(text)) break;
+		if (ANY_HEADING_RE.test(text) || isThematicBreak(raw)) break;
 
 		const phase = PHASE_RE.exec(text);
 		if (phase?.[1] !== undefined && phase[2] !== undefined) {

--- a/packages/fabrika-cli/src/build/dependencies.unit.test.ts
+++ b/packages/fabrika-cli/src/build/dependencies.unit.test.ts
@@ -25,6 +25,46 @@ describe("readTopology", () => {
 	it("refuses a ref that is neither #<int> nor C<int>", () => {
 		expect(readTopology(ledger("- phase 1: #210, PR-7"))._tag).toBe("Unparseable");
 	});
+
+	it("ends the section at a thematic break, so an appended amendment does not refuse it", () => {
+		const read = readTopology(
+			"# Epic\n\n## Dependencies\n\n- phase 1: #210\n- phase 2: #212\n\n---\n\n## Amendment — 2026-08-16\n\nnothing here parses as an edge\n",
+		);
+		expect(read._tag).toBe("Parsed");
+		expect(read._tag === "Parsed" ? read.edges : []).toHaveLength(2);
+	});
+
+	it.each([
+		"***",
+		"___",
+		"- - -",
+		"   ---",
+	])("ends the section at the %s spelling of a thematic break", (marker) => {
+		const read = readTopology(
+			`## Dependencies\n\n- phase 1: #210\n${marker}\nnot a topology line\n`,
+		);
+		expect(read._tag).toBe("Parsed");
+		expect(read._tag === "Parsed" ? read.edges : []).toHaveLength(1);
+	});
+
+	it("keeps only the edges above the break", () => {
+		const read = readTopology("## Dependencies\n\n- phase 1: #210\n\n---\n\n- phase 2: #212\n");
+		expect(read._tag === "Parsed" ? read.edges : []).toEqual([
+			{_tag: "Phase", phase: 1, members: [{_tag: "Issue", number: 210}]},
+		]);
+	});
+
+	it("still refuses a garbage line reached before any break", () => {
+		const read = readTopology("## Dependencies\n\n- phase 1: #210\nnot an edge\n\n---\n");
+		expect(read._tag).toBe("Unparseable");
+		expect(read._tag === "Unparseable" ? read.line : 0).toBe(4);
+		expect(read._tag === "Unparseable" ? read.text : "").toBe("not an edge");
+	});
+
+	it("does not read a two-dash rule or a four-space-indented one as a break", () => {
+		expect(readTopology("## Dependencies\n\n- phase 1: #210\n--\n")._tag).toBe("Unparseable");
+		expect(readTopology("## Dependencies\n\n- phase 1: #210\n    ---\n")._tag).toBe("Unparseable");
+	});
 });
 
 describe("predecessorsOf", () => {

--- a/packages/fabrika-cli/src/plan/ledger.ts
+++ b/packages/fabrika-cli/src/plan/ledger.ts
@@ -16,8 +16,13 @@
  * documentation example inside a fence set a real child's data.
  *
  * `## Dependencies` is deliberately absent from this module: it is read through the imported
- * `../build/dependencies.ts` parser, and this spec adds no second grammar for it.
+ * `../build/dependencies.ts` parser, and this spec adds no second grammar for it. The **section
+ * boundary** is imported from there for the same reason — a section ends at the next heading of
+ * equal or shallower depth, or at the first thematic break, and the two readers would silently
+ * disagree about where a ledger's last section ends if each spelled that rule itself (#5816).
  */
+
+import {isThematicBreak} from "../build/dependencies.ts";
 
 const FENCE = /^ {0,3}(```|~~~)/;
 const ATX_HEADING = /^ {0,3}(#{1,6})[ \t]+(.*?)[ \t]*#*[ \t]*$/;
@@ -78,7 +83,10 @@ export const sectionCount = (body: string, heading: string): number => {
 	return headingsIn(unfencedLines(body)).filter((h) => h.key === key).length;
 };
 
-/** A section's content lines: everything up to the next heading of the same or shallower level. */
+/**
+ * A section's content lines: everything up to the next heading of the same or shallower level, or
+ * the first thematic break, whichever comes first.
+ */
 const sectionBody = (body: string, heading: string): ReadonlyArray<LedgerLine> | null => {
 	const lines = unfencedLines(body);
 	const headings = headingsIn(lines);
@@ -86,7 +94,14 @@ const sectionBody = (body: string, heading: string): ReadonlyArray<LedgerLine> |
 	const opener = headings.find((h) => h.key === key);
 	if (opener === undefined) return null;
 	const closer = headings.find((h) => h.index > opener.index && h.level <= opener.level);
-	return lines.slice(opener.index + 1, closer?.index ?? lines.length);
+	const broken = lines.findIndex(
+		(line, index) => index > opener.index && isThematicBreak(line.text),
+	);
+	const ends = [closer?.index, broken === -1 ? undefined : broken].filter(
+		(index): index is number => index !== undefined,
+	);
+	const end = ends.length === 0 ? lines.length : Math.min(...ends);
+	return lines.slice(opener.index + 1, end);
 };
 
 export const USER_STORIES_HEADING = "User stories";

--- a/packages/fabrika-cli/src/plan/ledger.unit.test.ts
+++ b/packages/fabrika-cli/src/plan/ledger.unit.test.ts
@@ -70,6 +70,21 @@ describe("readEpicStories", () => {
 		const body = "### User stories\n\n1. one\n\n### Other\n\n2. not a story\n";
 		expect(readEpicStories(body)).toEqual({_tag: "Stories", ids: [1]});
 	});
+
+	/**
+	 * The boundary is `../build/dependencies.ts`'s, imported rather than restated, so this reader and
+	 * the topology reader cannot disagree about where a last section ends (#5816).
+	 */
+	it("stops at a thematic break, so an appended amendment adds no stories", () => {
+		const body =
+			"### User stories\n\n1. one\n\n---\n\n## Amendment — 2026-08-16\n\n2. not a story\n";
+		expect(readEpicStories(body)).toEqual({_tag: "Stories", ids: [1]});
+	});
+
+	it("stops at whichever of the break and the heading comes first", () => {
+		const heldByHeading = "### User stories\n\n1. one\n\n### Other\n\n2. no\n\n---\n\n3. no\n";
+		expect(readEpicStories(heldByHeading)).toEqual({_tag: "Stories", ids: [1]});
+	});
 });
 
 describe("readChildStories", () => {


### PR DESCRIPTION
`readTopology` scanned an epic's `## Dependencies` block from its heading down and broke only on the
next markdown heading. Every other non-blank line in that window had to parse as a phase or a
`requires:` line, or the whole read came back `Unparseable`.

Appending a dated amendment below a filed body is the mandated way to change one, and that block is
conventionally introduced by a bare `---`. With `## Dependencies` sitting last, the `---` landed
inside the scanned window and the reader refused the entire topology over a line that was never part
of the section. Epic #5492 was live proof: `readTopology` on its body returned
`{"_tag":"Unparseable","line":198,"text":"---"}`, which stopped both `lane emit` and its children's
`build eligible` dependency gate.

A section now ends at the next ATX heading **or** the first thematic break (`---`, `***`, `___`,
CommonMark spelling — 3+ markers, optionally spaced, indented at most 3), whichever comes first.
Nothing else is loosened: a garbage line reached before a break still returns `Unparseable` with its
line number and text.

`dependencies.ts` is the canonical statement of the boundary and exports `isThematicBreak`;
`plan/ledger.ts`'s `sectionBody` imports it rather than restating it, so the two readers cannot
disagree about where a last section ends. That closes the same hole on `### User stories` — an
appended amendment's ordered list would otherwise have been absorbed as epic story ids.

Verified against the live #5492 body: it now reads `Parsed` with all of its edges. Full fabrika-cli
suite is green (5205 tests).

Fixes #5816

## Deviations

- **Scope narrowing** — **Said:** the third acceptance criterion asks for the same boundary rule on
  `readPlan`'s `## Slices` scan in `packages/fabrika-cli/src/epic/plan.ts`. **Did:** applied it to
  `sectionBody` in `packages/fabrika-cli/src/plan/ledger.ts` instead. **Why:** `epic/plan.ts` and
  `readPlan` were deleted in #5788 ("Retire build-epic and the epic verb group onto lane emit's
  machines"), which landed after #5816 was filed — `grep -rn readPlan packages/` finds nothing. The
  criterion's stated purpose is that two readers not disagree about where a section ends, and
  `sectionBody` is the surviving section reader that carried the heading-only boundary.
  **Disposition:** stated here.
- **Out-of-scope change** — **Said:** #5816 names the two readers and their unit tests. **Did:** also
  corrected `claude-plugins/fabrika/skills/plan-epic/contract.md`, which stated the old
  heading-only rule and cited stale line numbers. **Why:** the doc would have contradicted the code
  this PR ships, and the repo's rule is that source wins and the doc gets fixed.
  **Disposition:** stated here.
- **Known defect left unfixed** — **Said:** nothing about the issue's own formatting. **Did:** left
  #5816's acceptance-criteria heading at `##` where the parser expects `###`, so `build issue`
  reports `criteria: malformed`. **Why:** amending a filed body is not this PR's scope and the
  criteria block itself reads fine. **Disposition:** stated here.
