### PR TITLE
fix: Triage can resolve a founder-class fork by declaring one option forced, so the decision never reaches a human

### DIFF
--- a/claude-plugins/fabrika/skills/triage/SKILL.md
+++ b/claude-plugins/fabrika/skills/triage/SKILL.md
@@ -58,8 +58,17 @@ issue from the code and the dedup outcome is read.
   a PR**; if you must carve the work down to call it a feature, it is an epic and your carve-out is
   its first child. Tells: missing prerequisite infrastructure, implied new surfaces, and your own
   hedging — "if this balloons, split X out" is the epic boundary talking.
+- **decision vs the type you already picked** — if landing on that type meant rejecting a *named
+  alternative* on a developer-experience or product-facing surface, the rejection is the tell:
+  someone still has to pick that direction, so it leaves triage as a `type:decision`, or as the type
+  you picked stamped `ready-for:human` in step 7. **"Forced" describes implementation mechanics,
+  never direction** — step 4's *forced fit* is the separate question of where a ticket attaches — and
+  "no PR in this repo can change X" eliminates nothing on its own, because the code X invokes is
+  usually repo-ownable (#5679's global shim vs `packages/fabrika-cli/src/bin.ts`; that exclusion cost
+  a full build round).
 
-Done when one type holds and you can name the question that excluded its nearest neighbour.
+Done when one type holds and you can name the question that excluded its nearest neighbour — a
+question about which category this is, never about which direction it should take.
 
 ## 4 — Attach before you mint
 


### PR DESCRIPTION
Triage could reject a named fix direction, call the survivor "forced", and stamp the issue `ready-for:agent` — so a founder-class call left the pipeline without a human ever seeing it. That is what happened on #5679, and it cost a full 26-file build round (PR #5703, closed on sight).

This adds one disambiguation bullet to step 3 of the triage skill. The rule: if landing on a type meant rejecting a named alternative on a DX or product-facing surface, that rejection is the tell — the issue leaves triage as a decision ticket, or as the picked type stamped `ready-for:human`. It says "forced" describes implementation mechanics and never direction, and that "no PR in this repo can change X" eliminates nothing by itself, since the code X invokes is usually repo-ownable.

Step 3's closing line also changes. It used to ask only for "the question that excluded its nearest neighbour", which a confident wrong exclusion satisfies just as well as a right one; it now asks that the question be about which category this is, not which direction it takes.

**Why step 3 and not step 7.** The acceptance criteria let the tell land in either place. Step 3 is where the exclusion is actually reasoned — by step 7 the type is already wrong and `apply` only stamps it, so a rule there fires after the damage. Step 7's `--ready-for` paragraph already covers "anything resting on a product call nobody has made"; the new bullet points at it rather than restating it.

**On step 4's "forced".** Step 4 already uses the word for a forced fold-in. The new bullet disambiguates inline — step 4's *forced fit* is named as the separate question of where a ticket attaches.

No new gate, verb, or process step; no section restructured.

Fixes #5704

## Deviations

None.
