### PR TITLE
fix: No build verb rewrites an open PR's body, so a deviations FAIL is repaired outside the guards

### DIFF
--- a/claude-plugins/fabrika/skills/build/SKILL.md
+++ b/claude-plugins/fabrika/skills/build/SKILL.md
@@ -286,6 +286,14 @@ rebuild on the published head, never `--drop-remote-commits`, which is for a rew
 intend. The fold's `frozenCriteria` rows are the review-appended criteria past the freeze — note
 them, do not chase them.
 
+**When the whole fix is the PR body, the route is `fabrika build pr-body <pr>` and nothing else.**
+The recurring one is a FAIL reading `deviations malformed`: the head does not need to move, so a
+push is the wrong tool and a raw `gh` call runs none of the guards `build pr` runs on a create. This
+verb runs all of them over the rewrite — leak scan, the `## Deviations` shape, the closing-keyword
+target read off the PR's own head branch, the classification check — and reads the landed body back
+(#5618). Re-send the corrected body on stdin, then answer the finding in a `fabrika build note` and
+release; no commit, no `build check`, no `build push`.
+
 ## Expectations you hold but never recompute
 
 - **Control-plane membership** — decided by CODEOWNERS at the merge gate. You never classify.

--- a/claude-plugins/fabrika/skills/build/contract.md
+++ b/claude-plugins/fabrika/skills/build/contract.md
@@ -66,6 +66,7 @@ second answer to a gated question can contradict the gate (interface convention 
 | `build check` | run this surface's validators in this tree, cache-bypassed; green/red/unknown | command execution + tree-binding assertions; *fixing red* stays in the skill |
 | `build push` | publish the branch and independently confirm the remote ref moved | push + `ls-remote` read-back, three proven outcomes |
 | `build pr` | open the PR from a stdin body, refusing the known defect shapes, with read-back | mechanical guards over an authored body; *authoring* stays in the skill |
+| `build pr-body` | replace an open PR's body from a stdin body, under `build pr`'s guards, with read-back | the same mechanical guards as `build pr`, over a `PATCH` that moves no ref; *authoring* stays in the skill |
 | `build note` | post a progress/handoff comment, head-stamped, leak-guarded, with read-back | as `report note`, plus the head stamp |
 | `build verdicts` | the paginated, current-head, per-gate verdict fold on a PR | fetch-all + fold via the wire module; *acting on rows* stays in the skill |
 | `build clear` | record the founder's clearance of one extra repair round on a PR | a conjunctive ACL/authorization protocol with read-back; *whether to grant* is the founder's, never the verb's |
@@ -98,7 +99,7 @@ Every verb obeys these; stated once.
   construction: no verb caches content across invocations; every invocation re-fetches and
   re-gates, so a gate change is in force on the next read.
 - **Isolation preconditions are guarded identically wherever they apply.** `branch`, `commit`,
-  `check`, `push` and `pr` run the same tree assertions `tree` runs, with the same codes (`note` runs only
+  `check`, `push`, `pr` and `pr-body` run the same tree assertions `tree` runs, with the same codes (`note` runs only
   the posting guards — a stop-report must remain postable from a refused tree) — a sibling that
   took the same ground unguarded would be the split this table exists to prevent.
   Their refusal messages are `tree`'s rows with the verb-name prefix substituted; **every error
@@ -1519,6 +1520,123 @@ $ echo $?
 
 ---
 
+## `build pr-body`
+
+**Invocation**
+
+```
+fabrika build pr-body 4318 [--partial] [--repo <owner/name>] <<'EOF'
+…the authored body…
+EOF
+```
+
+**Inputs**
+
+| Flag | Type | Required | Default | Description |
+|---|---|---|---|---|
+| `<pr>` | positional integer | yes | — | the open pull request whose body is replaced |
+| `--partial` | boolean | no | `false` | the acceptance criteria are not all met: the body must say `Part of #<n>`, not `Fixes #<n>` |
+| stdin | text | yes | — | the replacement PR body |
+
+**Output** — machine. One JSON object:
+`{"answer": "updated", "number": 4318, "url": "..."}`.
+
+The verb exists because a review FAIL whose whole fix is a body edit — the recurring one is a
+`## Deviations` section the gate reads as malformed — otherwise had no guarded route at all: `build
+pr` answers `existing` and writes nothing, `build push` moves a head that did not need to move, and
+the raw `gh` call the repairer fell back to ran none of the create path's guards (#5618).
+
+The guards are `build pr`'s, in `build pr`'s order with **one step moved**: the served issue is read
+off the PR before the two guards that name it can run. Everything still happens before any write,
+which is what the ordering is for.
+
+1. **stdin non-empty** (`3`); **no machine-local path** (`5`, `6`); **no forbidden classification**
+   (`10`) — the three that need no issue number, so they refuse before a single read.
+2. **The PR is open** (`7` proven absent, closed or merged; `11` unreadable).
+3. **The served issue** is `parseLaneBranch`'d out of the PR's own head ref — `build/<issue>-<slug>-<nonce>`,
+   which is the head ref even for a resumed PR, since resume mode checks out `build/pr-<pr>-<nonce>`
+   locally and tracks the original. A head that is not a lane branch is `14`. The **body is never the
+   source**: the closing keyword is the thing being checked, so reading the issue off it would let a
+   mistargeted body validate itself.
+4. **Body shape** (`4`) against that issue — identical to `build pr`'s step 3, same `deviations` wire
+   format, same closing-keyword and `--partial` rules.
+5. **Claim confirmed and this lane addresses this PR** (`15`/`11`/`14`): the checked-out branch is a
+   lane whose claim this session holds, and it serves this PR — the resume branch names it, or the
+   create branch *is* its head ref.
+
+Then `PATCH repos/<repo>/pulls/<pr>` carrying `body` alone — no title, no base, no ref — and
+re-read the PR, comparing through `normalizeForReadback` (`9` on mismatch). The body travels as an
+argv value, never `-f body=@file` (#4683).
+
+**Exit status** (beyond the universal four)
+
+| Code | Trigger |
+|---|---|
+| `3` | stdin held nothing |
+| `4` | the `## Deviations` section does not read `Found` through the `deviations` wire format, or the closing-keyword line is absent, duplicated, mistargeted, or contradicts `--partial` |
+| `5` | the body carries a machine-local path |
+| `6` | the body is a bare `@` path reference |
+| `7` | the PR is proven absent, closed or merged |
+| `8` | the update failed — it may or may not have landed; re-read the PR before retrying |
+| `9` | the body was replaced but does not read back as sent |
+| `10` | the body carries a control-plane (or type/priority) classification claim |
+| `11` | a precondition read failed |
+| `14` | the PR's head is not a lane branch, or the checked-out branch does not serve this PR |
+| `15` | proven: this session does not hold the claim |
+
+**Errors**
+
+| Message (stderr) | Code | Kind |
+|---|---|---|
+| `build pr-body: stdin held nothing — the body is the input.` | 3 | refusal |
+| `build pr-body: the body's "## Deviations" section is not readable — <the wire format's reason>. State each deviation as an entry, or state "None."` | 4 | refusal |
+| `build pr-body: the body carries a closing keyword aimed at #<m> — this PR serves #<n>.` | 4 | refusal |
+| `build pr-body: the body carries a machine-local path: <first hit> — redact before posting.` | 5 | refusal |
+| `build pr-body: the body is a bare @ path reference — write the body, not a pointer to it.` | 6 | refusal |
+| `build pr-body: PR #<pr> is proven absent, closed or merged — there is no body to rewrite.` | 7 | refusal |
+| `build pr-body: the update failed: <reason> — it may or may not have landed; re-read PR #<pr> before retrying.` | 8 | refusal |
+| `build pr-body: PR #<pr>'s body was replaced but does not read back as sent — it needs a human eye.` | 9 | refusal |
+| `build pr-body: the body asserts a control-plane classification — that verdict is the merge gate's.` | 10 | refusal |
+| `build pr-body: cannot read PR #<pr>: <reason> — nothing was written.` | 11 | refusal |
+| `build pr-body: PR #<pr>'s head branch "<ref>" is not a lane branch — this verb rewrites a lane's own PR.` | 14 | refusal |
+| `build pr-body: the checked-out branch "<branch>" does not serve PR #<pr> — wrong lane.` | 14 | refusal |
+| `build pr-body: #<n> is held by <token>, not this session.` | 15 | refusal |
+
+**Scope** — one body replacement on one open PR. Nothing else about the PR moves: no commit, no
+push, no branch, no title, no base.
+
+**Examples**
+
+```
+$ fabrika build pr-body 4318 <<'EOF'
+Fixes #4312
+
+Editor focus now survives a save: the toolbar re-render no longer steals it.
+
+## Deviations
+
+- **Out-of-scope change** — **Said:** #4312 names the editor only. **Did:** also fixed the same
+  steal in the comment box. **Why:** both call the one `refocus()` helper this changes.
+  **Disposition:** stated here.
+EOF
+{"answer":"updated","number":4318,"url":"https://github.com/kamp-us/phoenix/pull/4318"}
+```
+
+```
+$ printf 'Fixes #4312\n\n## Deviations\n\n- narrowed the scope a bit.\n' | fabrika build pr-body 4318
+build pr-body: the body's "## Deviations" section is not readable — an entry carries no **Said:**, **Did:**, **Why:**, **Disposition:** — every entry states **Said:** / **Did:** / **Why:** / **Disposition:**. State each deviation as an entry, or state "None."
+$ echo $?
+4
+```
+
+**Grounding**
+
+- #5618 — no `build` verb rewrote an open PR's body, so a `deviations malformed` FAIL was repaired
+  with a raw `gh` call that ran none of the guards. PRs #5556 and #5599 both went out that way.
+- #5566 — the `deviations` shape both this verb and `review deviations` resolve against.
+
+---
+
 ## `build note`
 
 **Invocation**
@@ -1820,5 +1938,5 @@ script, another skill's prose, or the authoring session. The three hand-checks t
 lineage demands: every reachable outcome above was walked against its verb's failure modes; every
 example value is derivable from its verb's stated rules (the nonce from the claim token, the
 verdict line from the protocol); and sibling verbs guard shared preconditions identically
-(`branch`/`commit`/`check`/`push` run `tree`'s assertions; `pr`/`note` run the same posting guards on
+(`branch`/`commit`/`check`/`push` run `tree`'s assertions; `pr`/`pr-body`/`note` run the same posting guards on
 the same codes, and `commit` runs the same authored-text guards on `3`/`5`/`6`).

--- a/packages/fabrika-cli/src/build/command.ts
+++ b/packages/fabrika-cli/src/build/command.ts
@@ -30,7 +30,7 @@ import {runEligible} from "./eligible-verb.ts";
 import {runIssue} from "./issue-verb.ts";
 import {runNote} from "./note-verb.ts";
 import {runPick} from "./pick-verb.ts";
-import {runPr} from "./pr-verb.ts";
+import {runPr, runPrBody} from "./pr-verb.ts";
 import {runPush} from "./push-verb.ts";
 import {
 	ADMISSION_EXIT_CODES,
@@ -400,6 +400,37 @@ const pr = leafCommand(
 	),
 );
 
+const prBody = leafCommand(
+	"pr-body",
+	{
+		pr: Argument.integer("pr").pipe(
+			Argument.withDescription("the open pull request whose body is replaced"),
+		),
+		partial: Flag.boolean("partial").pipe(
+			Flag.withDescription(
+				'the acceptance criteria are not all met: the body must say "Part of #<n>", not "Fixes #<n>" (default: false)',
+			),
+		),
+		repo: repoFlag,
+	},
+	Effect.fn(function* ({pr, partial, repo}) {
+		yield* emit(
+			yield* runPrBody({
+				pr,
+				partial,
+				repo: Option.getOrNull(repo),
+				env: process.env,
+				stdin: Effect.sync(readStdin),
+			}),
+		);
+	}),
+).pipe(
+	Command.withShortDescription("Replace an open PR's body from stdin, guarded and read back."),
+	Command.withDescription(
+		'Replace an open pull request\'s body with the one on STDIN, running the same pre-write guards `build pr` runs on a create — leak scan, "## Deviations" shape, closing-keyword target, classification claim — and reading the body back through normalizeForReadback. Nothing but the body moves: no commit, no push, no branch. This is the route for a review FAIL whose whole fix is a body edit. The issue the closing keyword must name is read off the PR\'s own head branch, never off the body. Prints {"answer":"updated","number":n,"url":"…"}. Exits 3 (stdin held nothing), 4 ("## Deviations" missing or empty, or the closing-keyword line is absent, duplicated, mistargeted, or contradicts --partial), 5 (machine-local path), 6 (bare @ reference), 7 (the PR is proven absent, closed or merged), 8 (the update failed — UNKNOWN; re-read the PR before retrying), 9 (replaced but does not read back), 10 (the body asserts a control-plane, type or priority classification), 11 (a precondition read failed), 14 (the PR\'s head is not a lane branch, or the checked-out branch does not serve this PR), 15 (this session does not hold the claim). Example: fabrika build pr-body 4318 < body.md',
+	),
+);
+
 const note = leafCommand(
 	"note",
 	{
@@ -512,6 +543,7 @@ export const buildCommand = Command.make("build").pipe(
 		check,
 		push,
 		pr,
+		prBody,
 		note,
 		verdicts,
 		clear,

--- a/packages/fabrika-cli/src/build/github.ts
+++ b/packages/fabrika-cli/src/build/github.ts
@@ -240,6 +240,32 @@ export const createPull = (
 			: fail("`gh api` exited 0 but its output is not a created pull request");
 	});
 
+/**
+ * Replace an open pull request's body, and move nothing else.
+ *
+ * A `PATCH` carrying only `body` is what lets a body-only defect — the recurring one is a
+ * `## Deviations` section the review gate reads as malformed — be repaired without a push (#5618).
+ * The body travels as an argv value for the same reason {@link createPull}'s does.
+ */
+export const updatePullBody = (repo: string, pr: number, body: string): Shell<Attempt<PullRef>> =>
+	Effect.gen(function* () {
+		const r = yield* execCapture("gh", [
+			"api",
+			"--method",
+			"PATCH",
+			`repos/${repo}/pulls/${pr}`,
+			"-f",
+			`body=${body}`,
+		]);
+		if (!r.ok) return fail(r.reason);
+		const parsed = parseJson(r.stdout);
+		return isRecord(parsed) &&
+			typeof parsed.number === "number" &&
+			typeof parsed.html_url === "string"
+			? ok({number: parsed.number, url: parsed.html_url})
+			: fail("`gh api` exited 0 but its output is not an updated pull request");
+	});
+
 /** One native review on a pull request — its own row kind, never coerced into a marker (#4555). */
 export interface ReviewRecord {
 	readonly id: number;

--- a/packages/fabrika-cli/src/build/pr-verb.ts
+++ b/packages/fabrika-cli/src/build/pr-verb.ts
@@ -1,5 +1,5 @@
 /**
- * `build pr` — open the PR from a stdin body, refusing the known defect shapes, with a read-back.
+ * The two guarded writes over a PR body: `build pr` opens one, `build pr-body` rewrites an open one.
  *
  * *Authoring* stays the skill's; the guards here are mechanical and run **in order, all before any
  * write**: stdin non-empty (`3`), no machine-local path (`5` / `6`), body shape (`4`), no
@@ -8,6 +8,13 @@
  *
  * An already-open PR for this head branch is an **answer**, not an error: a create whose outcome could
  * not be proven (`8`) is re-run, and the re-run must not open a second PR (#4544's class).
+ *
+ * Both verbs live in one module because they must guard identically. `build pr-body` exists so a FAIL
+ * whose whole fix is a body edit — the recurring one is a `## Deviations` section the review gate reads
+ * as malformed — has a route that runs the guards, instead of a raw `gh` call that runs none (#5618).
+ * It reorders one step and nothing else: it cannot name the served issue until it has read the PR, so
+ * the two issue-dependent guards (`4`, and the closing-keyword half of it) sit after that read — still
+ * before any write, which is the invariant the ordering is for.
  */
 import {Effect} from "effect";
 import type {ChildProcessSpawner} from "effect/unstable/process";
@@ -23,20 +30,27 @@ import {
 	PRECONDITION_UNKNOWN,
 	READBACK_MISMATCH,
 	WRITE_UNKNOWN,
+	WRONG_LANE,
+	ZERO_SCOPE,
 } from "./codes.ts";
-import {createPull, defaultBranch, openPullForHead} from "./github.ts";
+import {createPull, defaultBranch, getPullHead, openPullForHead, updatePullBody} from "./github.ts";
+import {parseLaneBranch} from "./lane.ts";
 import {requireLane} from "./lane-guard.ts";
 import {bodyDefect, classificationIn, proseOf} from "./pr-body.ts";
 import {conventionalTitleOf} from "./pr-title.ts";
 import {openIssue, resolveTargetRepo} from "./target.ts";
 
 const VERB = "build pr";
+const BODY_VERB = "build pr-body";
 
-const SURFACE = {
-	verb: VERB,
-	emptyMessage: `${VERB}: stdin held nothing — the body is the input.`,
-	bareAtMessage: `${VERB}: the body is a bare @ path reference — write the body, not a pointer to it.`,
-};
+const surfaceFor = (verb: string) => ({
+	verb,
+	emptyMessage: `${verb}: stdin held nothing — the body is the input.`,
+	bareAtMessage: `${verb}: the body is a bare @ path reference — write the body, not a pointer to it.`,
+});
+
+const SURFACE = surfaceFor(VERB);
+const BODY_SURFACE = surfaceFor(BODY_VERB);
 
 export interface PrOptions {
 	readonly number: number;
@@ -47,8 +61,18 @@ export interface PrOptions {
 	readonly stdin: Effect.Effect<StdinRead>;
 }
 
+export interface PrBodyOptions {
+	/** The open PR whose body is replaced. Nothing else about it moves. */
+	readonly pr: number;
+	readonly partial: boolean;
+	readonly repo: string | null;
+	readonly env: Readonly<Record<string, string | undefined>>;
+	readonly stdin: Effect.Effect<StdinRead>;
+}
+
 /** The `4` refusal for each shape defect, in the contract's own words. */
 const shapeRefusal = (
+	verb: string,
 	defect: NonNullable<ReturnType<typeof bodyDefect>>,
 	issue: number,
 	partial: boolean,
@@ -57,31 +81,43 @@ const shapeRefusal = (
 		case "NoDeviations":
 			return refuse(
 				BAD_SECTIONS,
-				`${VERB}: the body's "## Deviations" section is not readable — ${defect.reason}. State each deviation as an entry, or state "None."`,
+				`${verb}: the body's "## Deviations" section is not readable — ${defect.reason}. State each deviation as an entry, or state "None."`,
 			);
 		case "StrayClosing":
 			return refuse(
 				BAD_SECTIONS,
-				`${VERB}: the body carries a closing keyword aimed at #${defect.target} — this PR serves #${issue}.`,
+				`${verb}: the body carries a closing keyword aimed at #${defect.target} — this PR serves #${issue}.`,
 			);
 		case "ClosesWhilePartial":
 			return refuse(
 				BAD_SECTIONS,
-				`${VERB}: the body says "Fixes #${defect.target}" but --partial was given — a partial PR must say "Part of #${defect.target}".`,
+				`${verb}: the body says "Fixes #${defect.target}" but --partial was given — a partial PR must say "Part of #${defect.target}".`,
 			);
 		case "DuplicateClosing":
 			return refuse(
 				BAD_SECTIONS,
-				`${VERB}: the body carries more than one closing keyword aimed at #${issue} — exactly one closes the issue.`,
+				`${verb}: the body carries more than one closing keyword aimed at #${issue} — exactly one closes the issue.`,
 			);
 		case "NoLink":
 			return refuse(
 				BAD_SECTIONS,
 				partial
-					? `${VERB}: the body names no "Part of #${issue}" line — a partial PR must say what it is part of.`
-					: `${VERB}: the body names no "Fixes #${issue}" line — a PR that closes its issue must say so.`,
+					? `${verb}: the body names no "Part of #${issue}" line — a partial PR must say what it is part of.`
+					: `${verb}: the body names no "Fixes #${issue}" line — a PR that closes its issue must say so.`,
 			);
 	}
+};
+
+/** The `10` refusal — the classification guard both write paths run over the body's prose. */
+const classificationRefusal = (verb: string, body: string): VerbOutcome | null => {
+	const classification = classificationIn(proseOf(body));
+	if (classification === null) return null;
+	return refuse(
+		OFF_VOCABULARY,
+		classification === "control-plane"
+			? `${verb}: the body asserts a control-plane classification — that verdict is the merge gate's.`
+			: `${verb}: the body asserts a ${classification} classification — that verdict is triage's.`,
+	);
 };
 
 export const runPr = (
@@ -98,17 +134,10 @@ export const runPr = (
 		if (leaked !== null) return leaked;
 
 		const defect = bodyDefect(body, number, partial);
-		if (defect !== null) return shapeRefusal(defect, number, partial);
+		if (defect !== null) return shapeRefusal(VERB, defect, number, partial);
 
-		const classification = classificationIn(proseOf(body));
-		if (classification !== null) {
-			return refuse(
-				OFF_VOCABULARY,
-				classification === "control-plane"
-					? `${VERB}: the body asserts a control-plane classification — that verdict is the merge gate's.`
-					: `${VERB}: the body asserts a ${classification} classification — that verdict is triage's.`,
-			);
-		}
+		const classified = classificationRefusal(VERB, body);
+		if (classified !== null) return classified;
 
 		const session = requireSession(VERB, options.env);
 		if (session._tag === "Refused") return session.outcome;
@@ -183,6 +212,108 @@ export const runPr = (
 			: refuse(
 					READBACK_MISMATCH,
 					`${VERB}: the PR landed (#${created.value.number}) but its body does not read back as sent — it needs a human eye.`,
+					lane.notes,
+				);
+	});
+
+/**
+ * The issue an open PR serves, read off its head ref rather than off its body.
+ *
+ * The head ref is a create-mode lane branch — `build/<issue>-<slug>-<nonce>` — even for a PR the
+ * repairer resumed, because resume mode checks out `build/pr-<pr>-<nonce>` locally and tracks the
+ * original ref (`build branch --resume`). The body is deliberately not a source: the closing keyword
+ * is exactly what this verb checks, so trusting it would let a mistargeted body validate itself.
+ */
+const servedIssueOf = (headRef: string): number | null => {
+	const lane = parseLaneBranch(headRef);
+	return lane === null || lane._tag !== "Create" ? null : lane.number;
+};
+
+export const runPrBody = (
+	options: PrBodyOptions,
+): Effect.Effect<VerbOutcome, never, ChildProcessSpawner.ChildProcessSpawner> =>
+	Effect.gen(function* () {
+		const {pr, partial} = options;
+
+		const authored = readAuthored(BODY_SURFACE, yield* options.stdin);
+		if (authored._tag === "Refused") return authored.outcome;
+		const body = authored.text;
+
+		const leaked = leakRefusal(BODY_VERB, body);
+		if (leaked !== null) return leaked;
+
+		const classified = classificationRefusal(BODY_VERB, body);
+		if (classified !== null) return classified;
+
+		const session = requireSession(BODY_VERB, options.env);
+		if (session._tag === "Refused") return session.outcome;
+
+		const resolved = yield* resolveTargetRepo(BODY_VERB, options.repo, options.env);
+		if (resolved._tag === "Refused") return resolved.outcome;
+		const repo = resolved.repo;
+
+		const head = yield* getPullHead(repo, pr);
+		if (head._tag === "Unknown") {
+			return refuse(
+				PRECONDITION_UNKNOWN,
+				`${BODY_VERB}: cannot read PR #${pr}: ${head.reason} — nothing was written.`,
+			);
+		}
+		if (head._tag === "Absent" || head.value.state !== "open") {
+			return refuse(
+				ZERO_SCOPE,
+				`${BODY_VERB}: PR #${pr} is proven absent, closed or merged — there is no body to rewrite.`,
+			);
+		}
+
+		const issue = servedIssueOf(head.value.ref);
+		if (issue === null) {
+			return refuse(
+				WRONG_LANE,
+				`${BODY_VERB}: PR #${pr}'s head branch "${head.value.ref}" is not a lane branch — this verb rewrites a lane's own PR.`,
+			);
+		}
+
+		const defect = bodyDefect(body, issue, partial);
+		if (defect !== null) return shapeRefusal(BODY_VERB, defect, issue, partial);
+
+		const lane = yield* requireLane(BODY_VERB, repo, session.id, null);
+		if (lane._tag === "Refused") return lane.outcome;
+		const addressed =
+			lane.lane._tag === "Resume" ? lane.lane.pr === pr : lane.branch === head.value.ref;
+		if (!addressed) {
+			return refuse(
+				WRONG_LANE,
+				`${BODY_VERB}: the checked-out branch "${lane.branch}" does not serve PR #${pr} — wrong lane.`,
+				lane.notes,
+			);
+		}
+
+		const updated = yield* updatePullBody(repo, pr, body);
+		if (updated._tag === "Failure") {
+			return refuse(
+				WRITE_UNKNOWN,
+				`${BODY_VERB}: the update failed: ${updated.reason} — it may or may not have landed; re-read PR #${pr} before retrying.`,
+				lane.notes,
+			);
+		}
+
+		const back = yield* getPullRequest(repo, pr);
+		const matches =
+			back._tag === "Present" &&
+			normalizeForReadback(back.value.body) === normalizeForReadback(body);
+		return matches
+			? answer(
+					JSON.stringify({
+						answer: "updated",
+						number: updated.value.number,
+						url: updated.value.url,
+					}),
+					lane.notes,
+				)
+			: refuse(
+					READBACK_MISMATCH,
+					`${BODY_VERB}: PR #${pr}'s body was replaced but does not read back as sent — it needs a human eye.`,
 					lane.notes,
 				);
 	});

--- a/packages/fabrika-cli/src/build/pr-verb.unit.test.ts
+++ b/packages/fabrika-cli/src/build/pr-verb.unit.test.ts
@@ -6,11 +6,14 @@ import type {StdinRead} from "../io/stdin.ts";
 import {
 	BAD_SECTIONS,
 	BARE_AT_PATH,
+	CLAIM_NOT_MINE,
 	EMPTY_STDIN,
 	LEAKED_PATH,
 	OFF_VOCABULARY,
+	PRECONDITION_UNKNOWN,
 	READBACK_MISMATCH,
 	WRITE_UNKNOWN,
+	WRONG_LANE,
 	ZERO_SCOPE,
 } from "./codes.ts";
 import {
@@ -22,7 +25,7 @@ import {
 	NONCE,
 	pull,
 } from "./fixtures.test-support.ts";
-import {runPr} from "./pr-verb.ts";
+import {runPr, runPrBody} from "./pr-verb.ts";
 
 const REV_PARSE = /^git rev-parse --path-format=absolute/;
 const BRANCH = /^git rev-parse --abbrev-ref HEAD$/;
@@ -203,5 +206,262 @@ describe("runPr — the write path", () => {
 	it("refuses a closed target issue on 7", async () => {
 		const out = await run([[once(ISSUE), issue({state: "closed"})]]);
 		expect(out.code).toBe(ZERO_SCOPE);
+	});
+});
+
+const PULL_HEAD = /^gh api repos\/o\/r\/pulls\/4318 --jq/;
+const PATCH_BODY = /^gh api --method PATCH repos\/o\/r\/pulls\/4318/;
+
+const head = (
+	overrides: {ref?: string; state?: string; merged?: boolean} = {},
+): readonly [RegExp, ExecResult] => [
+	PULL_HEAD,
+	okOut(
+		[
+			overrides.ref ?? LANE,
+			"03135b9188d2be6c0a4b7bd0b7a3ff9c53f0f2b1",
+			overrides.state ?? "open",
+			String(overrides.merged ?? false),
+		].join("\t"),
+	),
+];
+
+const PATCHED = okOut(JSON.stringify({number: 4318, html_url: "https://github.com/o/r/pull/4318"}));
+
+/** The lane reads `runPrBody` makes — `build pr`'s minus the served issue, which it never fetches. */
+const LANE_ONLY: ReadonlyArray<readonly [RegExp, ExecResult]> = [
+	[REV_PARSE, GIT_DIRS],
+	[BRANCH, okOut(`${LANE}\n`)],
+	[COMMENTS, comments({id: 1, body: marker("s-9f2e", LANE_UUID)})],
+	[PERM, okOut("write\n")],
+];
+
+const bodyOptions = {
+	pr: 4318,
+	partial: false,
+	repo: null,
+	env: {CLAUDE_PIPELINE_REPO: "o/r", CLAUDE_CODE_SESSION_ID: "s-9f2e"} as Record<
+		string,
+		string | undefined
+	>,
+	stdin: Effect.succeed<StdinRead>({_tag: "Text", text: BODY}),
+};
+
+const runBody = (
+	script: ReadonlyArray<readonly [RegExp, ExecResult]>,
+	overrides: Partial<typeof bodyOptions> = {},
+) =>
+	Effect.runPromise(
+		Effect.provide(runPrBody({...bodyOptions, ...overrides}), fakeShell(script).layer),
+	);
+
+describe("runPrBody — the guarded body-only repair (#5618)", () => {
+	it("replaces an open PR's body and reads it back, moving no ref", async () => {
+		const shell = fakeShell([
+			...LANE_ONLY,
+			head(),
+			[PATCH_BODY, PATCHED],
+			[READ_BACK, pull({body: BODY})],
+		]);
+		const out = await Effect.runPromise(Effect.provide(runPrBody(bodyOptions), shell.layer));
+		expect(out.code).toBe(0);
+		expect(JSON.parse(out.stdout)).toEqual({
+			answer: "updated",
+			number: 4318,
+			url: "https://github.com/o/r/pull/4318",
+		});
+		expect(shell.calls.some((line) => CREATE.test(line))).toBe(false);
+		expect(shell.calls.some((line) => line.startsWith("git push"))).toBe(false);
+	});
+
+	it("never posts the body through the `-f body=@file` form (#4683)", async () => {
+		const shell = fakeShell([
+			...LANE_ONLY,
+			head(),
+			[PATCH_BODY, PATCHED],
+			[READ_BACK, pull({body: BODY})],
+		]);
+		await Effect.runPromise(Effect.provide(runPrBody(bodyOptions), shell.layer));
+		expect(shell.calls.some((line) => line.includes("body=@"))).toBe(false);
+	});
+
+	it("refuses empty stdin on 3, and touches nothing", async () => {
+		const shell = fakeShell([]);
+		const out = await Effect.runPromise(
+			Effect.provide(
+				runPrBody({...bodyOptions, stdin: Effect.succeed<StdinRead>({_tag: "Text", text: " \n"})}),
+				shell.layer,
+			),
+		);
+		expect(out.code).toBe(EMPTY_STDIN);
+		expect(shell.calls).toEqual([]);
+	});
+
+	it("refuses a bare @ reference on 6", async () => {
+		const out = await runBody([], {
+			stdin: Effect.succeed<StdinRead>({_tag: "Text", text: "@/tmp/pr-body.md"}),
+		});
+		expect(out.code).toBe(BARE_AT_PATH);
+	});
+
+	it("refuses a machine-local path on 5, before any read", async () => {
+		const shell = fakeShell([]);
+		const out = await Effect.runPromise(
+			Effect.provide(
+				runPrBody({
+					...bodyOptions,
+					stdin: Effect.succeed<StdinRead>({
+						_tag: "Text",
+						text: "Fixes #4312\n\nsee /Users/someone/notes.md\n\n## Deviations\nNone.\n",
+					}),
+				}),
+				shell.layer,
+			),
+		);
+		expect(out.code).toBe(LEAKED_PATH);
+		expect(shell.calls).toEqual([]);
+	});
+
+	it("refuses a malformed Deviations section on 4 — the FAIL this verb exists for", async () => {
+		const shell = fakeShell([
+			...LANE_ONLY,
+			head(),
+			[PATCH_BODY, PATCHED],
+			[READ_BACK, pull({body: BODY})],
+		]);
+		const out = await Effect.runPromise(
+			Effect.provide(
+				runPrBody({
+					...bodyOptions,
+					stdin: Effect.succeed<StdinRead>({
+						_tag: "Text",
+						text: "Fixes #4312\n\n## Deviations\n\n- narrowed the scope a bit.\n",
+					}),
+				}),
+				shell.layer,
+			),
+		);
+		expect(out.code).toBe(BAD_SECTIONS);
+		expect(out.stderr.at(-1)).toContain('build pr-body: the body\'s "## Deviations" section');
+		expect(shell.calls.some((line) => PATCH_BODY.test(line))).toBe(false);
+	});
+
+	it("refuses a stray closing keyword on 4, naming the issue read off the head branch", async () => {
+		const out = await runBody([...LANE_ONLY, head()], {
+			stdin: Effect.succeed<StdinRead>({
+				_tag: "Text",
+				text: BODY.replace("## Deviations", "Also closes #999.\n\n## Deviations"),
+			}),
+		});
+		expect(out.code).toBe(BAD_SECTIONS);
+		expect(out.stderr.at(-1)).toBe(
+			"build pr-body: the body carries a closing keyword aimed at #999 — this PR serves #4312.",
+		);
+	});
+
+	it("refuses Fixes under --partial on 4", async () => {
+		const out = await runBody([...LANE_ONLY, head()], {partial: true});
+		expect(out.code).toBe(BAD_SECTIONS);
+		expect(out.stderr.at(-1)).toBe(
+			'build pr-body: the body says "Fixes #4312" but --partial was given — a partial PR must say "Part of #4312".',
+		);
+	});
+
+	it("refuses a control-plane classification on 10, before any read", async () => {
+		const shell = fakeShell([]);
+		const out = await Effect.runPromise(
+			Effect.provide(
+				runPrBody({
+					...bodyOptions,
+					stdin: Effect.succeed<StdinRead>({
+						_tag: "Text",
+						text: "Fixes #4312\n\nThis is not control-plane.\n\n## Deviations\nNone.\n",
+					}),
+				}),
+				shell.layer,
+			),
+		);
+		expect(out.code).toBe(OFF_VOCABULARY);
+		expect(out.stderr.at(-1)).toBe(
+			"build pr-body: the body asserts a control-plane classification — that verdict is the merge gate's.",
+		);
+		expect(shell.calls).toEqual([]);
+	});
+
+	it("refuses a closed PR on 7 — there is no body to rewrite", async () => {
+		const out = await runBody([...LANE_ONLY, head({state: "closed"})]);
+		expect(out.code).toBe(ZERO_SCOPE);
+	});
+
+	it("refuses an unreadable PR on 11, never on 7", async () => {
+		const out = await runBody([...LANE_ONLY, [PULL_HEAD, errOut("gh: Bad gateway (HTTP 502)")]]);
+		expect(out.code).toBe(PRECONDITION_UNKNOWN);
+	});
+
+	it("refuses a PR whose head is not a lane branch on 14", async () => {
+		const out = await runBody([...LANE_ONLY, head({ref: "someone/hotfix"})]);
+		expect(out.code).toBe(WRONG_LANE);
+		expect(out.stderr.at(-1)).toContain("is not a lane branch");
+	});
+
+	it("refuses when the checked-out lane does not serve this PR on 14", async () => {
+		const other = `build/9999-other-lane-${NONCE}`;
+		const out = await runBody([
+			[REV_PARSE, GIT_DIRS],
+			[BRANCH, okOut(`${other}\n`)],
+			[
+				/^gh api --paginate repos\/o\/r\/issues\/9999\/comments/,
+				comments({id: 1, body: marker("s-9f2e", LANE_UUID)}),
+			],
+			[PERM, okOut("write\n")],
+			head(),
+		]);
+		expect(out.code).toBe(WRONG_LANE);
+		expect(out.stderr.at(-1)).toContain("does not serve PR #4318");
+	});
+
+	it("refuses without a held claim on 15, before any write", async () => {
+		const shell = fakeShell([
+			[REV_PARSE, GIT_DIRS],
+			[BRANCH, okOut(`${LANE}\n`)],
+			[COMMENTS, comments()],
+			[PERM, okOut("write\n")],
+			head(),
+			[PATCH_BODY, PATCHED],
+		]);
+		const out = await Effect.runPromise(Effect.provide(runPrBody(bodyOptions), shell.layer));
+		expect(out.code).toBe(CLAIM_NOT_MINE);
+		expect(shell.calls.some((line) => PATCH_BODY.test(line))).toBe(false);
+	});
+
+	it("refuses a failed update on 8 — UNKNOWN, pointing at a re-read", async () => {
+		const out = await runBody([
+			...LANE_ONLY,
+			head(),
+			[PATCH_BODY, errOut("gh: Gateway timeout (HTTP 504)")],
+		]);
+		expect(out.code).toBe(WRITE_UNKNOWN);
+		expect(out.stderr.at(-1)).toContain("re-read PR #4318 before retrying");
+	});
+
+	it("refuses a body that does not read back on 9", async () => {
+		const out = await runBody([
+			...LANE_ONLY,
+			head(),
+			[PATCH_BODY, PATCHED],
+			[READ_BACK, pull({body: "something else"})],
+		]);
+		expect(out.code).toBe(READBACK_MISMATCH);
+		expect(out.stderr.at(-1)).toContain("does not read back as sent");
+	});
+
+	it("compares the read-back through normalizeForReadback, not byte-for-byte", async () => {
+		const out = await runBody([
+			...LANE_ONLY,
+			head(),
+			[PATCH_BODY, PATCHED],
+			[READ_BACK, pull({body: `${BODY.replace(/\n/g, "\r\n")}\r\n\r\n`})],
+		]);
+		expect(out.code).toBe(0);
 	});
 });


### PR DESCRIPTION
Fixes #5618

A `review` FAIL whose whole fix is a PR-body edit — the recurring one is `deviations malformed` —
had no guarded route. `build pr` answers `existing` and writes nothing, `build push` moves a head
that did not need to move, so the repair went out through a raw `gh` call that ran none of the
create path's guards. PRs #5556 and #5599 were both fixed that way.

This adds `build pr-body <pr>`: replace an open PR's body from stdin, under the same guards
`build pr` runs on a create, with a read-back. Nothing else moves — no commit, no push, no branch,
no title, no base.

Two design points worth a reviewer's eye:

- **It is a sibling verb, not a flag on `build pr`.** A repair lane's branch is
  `build/pr-<pr>-<nonce>` and its claim sits on the PR number, so a `--update` addressed by issue
  number would refuse `14` in exactly the case the ticket exists for. Addressing by PR number works
  in both create and repair mode.
- **The served issue is read off the PR's head ref, never off the body.** The closing keyword is the
  thing being checked, so trusting the body would let a mistargeted body validate itself. A resumed
  PR still carries the create-mode ref on GitHub (`build branch --resume` tracks it), so one
  derivation covers both modes.

Guard order is `build pr`'s with one step moved: the three issue-independent guards (stdin, leak,
classification) refuse before any read; the PR read then names the served issue; the shape guard and
the lane/claim guard follow. Everything is still before the write.

Docs: the skill's `## Repair` names the verb as the route for a body-only FAIL, and `contract.md`
gains the verb's section plus its inventory row.

## Deviations

- **Out-of-scope change** — **Said:** #5618 names the new write path and its tests. **Did:** also
  extended `contract.md` with a `build pr-body` section, an inventory row, and two shared-convention
  lines that enumerate the guarded verbs. **Why:** `contract.md` is the doc-of-record every build
  verb has a section in, and `wire doc-section --heading "build pr-body"` would otherwise find
  nothing. **Disposition:** stated here.
- **Out-of-scope change** — **Said:** the acceptance criteria name only the new path. **Did:** also
  refactored `runPr` to take its verb name through the shared `shapeRefusal` and a new
  `classificationRefusal`. **Why:** the criteria require the update path to run *the same* guards;
  two copies of the refusal text would be two guards that can drift. **Disposition:** stated here;
  `runPr`'s behaviour and message text are unchanged, and its existing tests assert that.
