### PR TITLE
feat: Triage has no value kill bar — the #4634 rule lives where triage cannot see it

### DIFF
--- a/claude-plugins/fabrika/skills/triage/SKILL.md
+++ b/claude-plugins/fabrika/skills/triage/SKILL.md
@@ -137,8 +137,8 @@ Done when every claim traces to something you read.
 
 ## 7 — Price it, stamp it, and say who picks it up
 
-Ask the kill question first — *if the founder never learned this ticket existed, would anything
-visibly change?* A "no" earns no home by default; it earns a kill. Then price on the work's own
+Run the value bar first — it is stated once, in step 8 on the `agent` kill route, and a ticket that
+fails it earns a kill rather than a price. Then price what survives, on the work's own
 merit: `p0` for ship-work and fires, `p1` for what you would genuinely pull next, **`p2` is the
 default** and most of a healthy backlog. A roadmap row confers no band either way.
 
@@ -188,7 +188,7 @@ fabrika triage park $issue_number <<'EOF'
 EOF
 ```
 
-- **`agent`** and unsalvageable, duplicate, or moving nothing forward → kill it, which closes it
+- **`agent`** and unsalvageable, duplicate, or failing the value bar below → kill it, which closes it
   not-planned carrying `closed-by-triage`. **`--confirm` is you attesting that salvage was genuinely
   attempted**: a human-invoked `/report` carries the same agent footer, so footer presence alone
   never licenses a close. Killing a duplicate takes `--duplicate-of <survivor>`, which folds this
@@ -199,6 +199,25 @@ fabrika triage kill $issue_number --confirm --duplicate-of 4290 <<'EOF'
 …
 EOF
 ```
+
+**The value bar.** An issue can be correct, well-written, and still worth nothing. This is the bar
+the founder's own sweeps run on ([#4634](https://github.com/kamp-us/phoenix/issues/4634)), and it
+kills an agent-filed issue when any one of five clauses holds:
+
+- **process ceremony** — the deliverable is a record nobody then acts on, a decision written down for
+  its own sake;
+- **self-generated churn** — refactor or build work we filed against our own output with no behaviour
+  change: restated vocabulary, a duplicated list tidied, a docblock or sample-transcript nit, a doc
+  sentence that omits one clause of a check that already works;
+- **hardening with no incident** — *has this ever failed in production?* This clause is a factual
+  test, not a taste call, and a "no" kills it. A missing unit test for a refusal that already works
+  is this clause; so is nice-to-have telemetry or cost reporting for a cost nobody is paying;
+- **superseded** — something already landed, or already ruled, makes it moot;
+- **duplicate of its parent** — the parent's scope already covers it.
+
+Those examples are verdicts, not hypotheticals: a sweep on 2026-08-18 killed twelve of thirty-five
+triaged `p2`s, and every one of them landed in a clause above. The bar reaches agent-filed work only
+— **a human filing is parked, never killed**, however cleanly it fits a clause.
 
 Done when the issue has left the queue by exactly one route.
 


### PR DESCRIPTION
Triage could only kill an issue that was wrong, unsalvageable, or a duplicate. Nothing in the skill
tested whether an issue was worth doing, so correct-but-pointless tickets survived until the founder
swept them by hand.

This adds the value bar to `claude-plugins/fabrika/skills/triage/SKILL.md`, step 8, on the `agent`
kill route — the five clauses the founder's own #4634 sweep ran on, with "has this ever failed in
production?" stated as the factual test it is, and today's p2-sweep kill classes folded in as
examples so a triager pattern-matches them at intake.

The bar is stated once. Step 7's old kill question ("if the founder never learned this ticket
existed, would anything visibly change?") is replaced by a pointer at step 8, so pricing runs after
the bar instead of carrying a second, vaguer version of it.

The human route is untouched: a human filing is still parked on `status:needs-info` and never
closed, and the block says so explicitly. Nothing under `packages/fabrika-cli/` changes —
`kill-verb.ts`'s exit 12 refusal is exactly as it was. `contract.md` is untouched too: the kill
routes did not move, only the prose describing the verdict.

Fixes #5574

## Deviations

- **Declined guidance** — **Said:** the issue leaves open whether the clauses land as prose in step
  8's bullet or as their own list, and whether step 7's question is rewritten or deleted.
  **Did:** made them their own list under the kill fence, and rewrote step 7's question into a
  one-line pointer rather than deleting it. **Why:** the bullet already carries the `--confirm` and
  `--duplicate-of` mechanics, so five clauses inside it would bury them; step 7 still needs the
  ordering signal that pricing comes after the bar. **Disposition:** stated here.
