### PR TITLE
fix: ship release silently mints status:awaiting-release while its four sibling verbs refuse, and bootstrap-verb.ts's docblock claims it refuses

### DIFF
--- a/claude-plugins/fabrika/skills/ship/contract.md
+++ b/claude-plugins/fabrika/skills/ship/contract.md
@@ -220,6 +220,7 @@ authority.
 | `16` | refused: the target is **proven not in the state this write acts on** — nothing was mutated | `resolve`, `nudge` |
 | `17` | refused: the nudge's close landed and the reopen is **unconfirmed — the PR may be left closed**; a human re-opens before anything else happens | `nudge` |
 | `18` | refused: the diff touches a governance root and its `governance` verdict is **not** a head-bound PASS — `absent`, `stale` or `fail`. The one red that means *a human owes this PR a verdict*, kept off `16` so a CI job can tell it from "the floor could not be resolved" | `floor` |
+| `23` | refused: a label this run would POST is absent from the repository's taxonomy — `plan flip`'s seat, imported, because both verbs prove one fact over one board's labels (#4285) | `release` |
 | `127` | the verb never ran (unresolved binary) | all |
 
 **This matrix owns what a code *means*; the per-verb tables own what *triggers* it.** Every
@@ -1723,6 +1724,9 @@ PR, and reading it queued a phantom release (#1257). No signal → `n/a`; a sign
 linked issue → `no-issue` (see Output — a proven answer, never `n/a`).
 The label write is read back; a failed or unconfirmed write is `8`/`9`, never `queued` —
 v1's unverified label POST could report a release queued that no human would ever find.
+The write is taxonomy-guarded first: `status:awaiting-release` absent from the repo's labels
+refuses on `23` rather than let GitHub's POST mint it (#4285, #6054), and the taxonomy is read
+only on the path that would post — `n/a` and `no-issue` read none.
 
 **Exit status**
 
@@ -1733,6 +1737,7 @@ v1's unverified label POST could report a release queued that no human would eve
 | `9` | the label write landed but the read-back does not show it |
 | `11` | the diff, body, flag registry, or linked issue could not be read — dark-ship-ness is UNKNOWN, never `n/a` |
 | `13` | the changed-file or diff enumeration is provably short — a partial diff must not read as "no flag declaration added" |
+| `23` | `status:awaiting-release` is absent from the repository's taxonomy — refused rather than let the POST mint it (#4285); guarded only on the path that would post, so `n/a` and `no-issue` read no taxonomy |
 
 **Errors**
 
@@ -1743,9 +1748,12 @@ v1's unverified label POST could report a release queued that no human would eve
 | `ship release: label write failed: <reason> — a real dark ship may be missing from the release queue; escalate.` | 8 | refusal |
 | `ship release: label read-back does not show status:awaiting-release on #<issue> — inspect it.` | 9 | refusal |
 | `ship release: received <k> of <m> declared files — refusing to scan a truncated diff for flag signals.` | 13 | refusal |
+| `ship release: label "status:awaiting-release" is absent from <repo>'s taxonomy — refusing to create it (#4285). A real dark ship is not queued; run `fabrika status bootstrap label-taxonomy` and re-run.` | 23 | refusal |
+| `ship release: cannot read <repo>'s label taxonomy: <reason> — nothing was written, and a real dark ship is not queued; escalate.` | 11 | refusal |
 
-**Scope** — one PR's diff and body, the flag registry file at the PR's base ref, one linked issue's
-labels; one label write with read-back.
+**Scope** — one PR's diff and body, the flag registry file at the PR's base ref, the repository's
+label taxonomy (read only when a write is due), one linked issue's labels; one label write with
+read-back.
 
 **Examples**
 

--- a/packages/fabrika-cli/src/ship/codes.ts
+++ b/packages/fabrika-cli/src/ship/codes.ts
@@ -4,8 +4,8 @@
  *
  * **Every seat this group shares is imported, never re-typed as a numeral.** `3`, `5`, `6`, `7`,
  * `8`, `9`, `10` and `11` come from `../report/codes.ts` and `../triage/codes.ts`; `12` and `13`
- * come from `../review/codes.ts`, whose meanings this group holds unchanged. A restated numeral is
- * a second source that can drift silently; an import cannot.
+ * come from `../review/codes.ts` and `23` from `../plan/codes.ts`, whose meanings this group holds
+ * unchanged. A restated numeral is a second source that can drift silently; an import cannot.
  *
  * `16` and `17` are this group's own proven refusals, and they sit above `review`'s private band on
  * purpose — `14`/`15` are `review`'s ACL and append-only seats, meanings no verb here performs, so a
@@ -14,6 +14,7 @@
  * `0`, `1`, `2` and `127` are reserved by the interface convention (`../verb.ts`, `../bin.ts`).
  */
 
+import {LABEL_ABSENT as PLAN_LABEL_ABSENT} from "../plan/codes.ts";
 import {
 	BARE_AT_PATH as REPORT_BARE_AT_PATH,
 	EMPTY_STDIN as REPORT_EMPTY_STDIN,
@@ -81,6 +82,20 @@ export const NUDGE_REOPEN_UNCONFIRMED = 17;
  * non-zero from that job means the floor could not be resolved at all.
  */
 export const GOVERNANCE_FLOOR_UNMET = 18;
+
+/**
+ * Refused: a label this run would POST is absent from the repository's taxonomy (#4285).
+ *
+ * `plan`'s seat, imported, under `plan`'s own rule — *import a code when two groups prove the same
+ * fact*. `plan flip` and `ship release` prove one fact here, on one board, over the same taxonomy:
+ * the label the write is about to create does not exist, so the write would mint it. The operator
+ * drives both in one sweep, and two verbs proving one fact on two codes is the collision that bites.
+ *
+ * Not {@link ZERO_SCOPE}, which `triage apply`/`park` reach for the same refusal: this group
+ * documents `7` as the **target** proven absent, and the target here — the PR, the linked issue —
+ * exists. Folding an absent label into it would make `7` two facts in one group.
+ */
+export const LABEL_ABSENT = PLAN_LABEL_ABSENT;
 
 /**
  * The unallocated codes. `4` is `report file`'s body-section seat and `14`/`15` are `review`'s ACL

--- a/packages/fabrika-cli/src/ship/release-verb.ts
+++ b/packages/fabrika-cli/src/ship/release-verb.ts
@@ -8,15 +8,25 @@
  * there is no linked issue to label, which means a dark ship the release queue cannot see — the
  * exact hazard this verb exists to prevent. The label write is read back, because v1's unverified
  * POST could report a release queued that no human would ever find.
+ *
+ * The write is also taxonomy-guarded like every other board-label writer (#4285, #6054): GitHub's
+ * label POST creates what it cannot find, so on a repo that never bootstrapped its taxonomy an
+ * unguarded write mints `status:awaiting-release` with a random colour and no description.
  */
 import {Effect} from "effect";
 import type {ChildProcessSpawner} from "effect/unstable/process";
-import {addLabels, getIssue} from "../io/issues.ts";
+import {addLabels, getIssue, listLabels} from "../io/issues.ts";
 import {getPullDiff, listPullFiles} from "../io/pulls.ts";
 import {AWAITING_RELEASE} from "../labels.ts";
 import {linkedIssueOf} from "../review/classes.ts";
 import {answer, refuse, type VerbOutcome} from "../verb.ts";
-import {INCOMPLETE_SCAN, PRECONDITION_UNKNOWN, READBACK_MISMATCH, WRITE_UNKNOWN} from "./codes.ts";
+import {
+	INCOMPLETE_SCAN,
+	LABEL_ABSENT,
+	PRECONDITION_UNKNOWN,
+	READBACK_MISMATCH,
+	WRITE_UNKNOWN,
+} from "./codes.ts";
 import {detect, FLAG_REGISTRY} from "./dark-ship.ts";
 import {readFileAtRef} from "./github.ts";
 import {badNumber, NULL_TOKEN, resolvePull, resolveTargetRepo, scannedLine} from "./target.ts";
@@ -92,6 +102,24 @@ export const runRelease = (
 
 		const issue = linkedIssueOf(pull.body);
 		if (issue === null) return emit("no-issue", shipped.key, null);
+
+		// Guarded here and not earlier: it is the POST below that mints an unknown label, so an `n/a`
+		// or `no-issue` run — which posts nothing — owes the taxonomy no read (`plan flip`, #4285).
+		const taxonomy = yield* listLabels(repo);
+		if (taxonomy._tag === "Failure") {
+			return refuse(
+				PRECONDITION_UNKNOWN,
+				`${VERB}: cannot read ${repo}'s label taxonomy: ${taxonomy.reason} — nothing was written, and a real dark ship is not queued; escalate.`,
+				diagnostics,
+			);
+		}
+		if (!taxonomy.value.includes(AWAITING_RELEASE)) {
+			return refuse(
+				LABEL_ABSENT,
+				`${VERB}: label "${AWAITING_RELEASE}" is absent from ${repo}'s taxonomy — refusing to create it (#4285). A real dark ship is not queued; run \`fabrika status bootstrap label-taxonomy\` and re-run.`,
+				diagnostics,
+			);
+		}
 
 		const labelled = yield* addLabels(repo, issue, [AWAITING_RELEASE]);
 		if (labelled._tag === "Failure") {

--- a/packages/fabrika-cli/src/ship/release-verb.unit.test.ts
+++ b/packages/fabrika-cli/src/ship/release-verb.unit.test.ts
@@ -2,7 +2,13 @@ import {Effect} from "effect";
 import {describe, expect, it} from "vitest";
 import {errOut, fakeShell, okOut} from "../fakes.test-support.ts";
 import type {ExecResult} from "../io/exec.ts";
-import {INCOMPLETE_SCAN, PRECONDITION_UNKNOWN, READBACK_MISMATCH, WRITE_UNKNOWN} from "./codes.ts";
+import {
+	INCOMPLETE_SCAN,
+	LABEL_ABSENT,
+	PRECONDITION_UNKNOWN,
+	READBACK_MISMATCH,
+	WRITE_UNKNOWN,
+} from "./codes.ts";
 import {FLAG_REGISTRY} from "./dark-ship.ts";
 import {ENV, files, issue, pull} from "./fixtures.test-support.ts";
 import {runRelease} from "./release-verb.ts";
@@ -11,6 +17,7 @@ const PULL = /^gh api repos\/o\/r\/pulls\/4321$/;
 const FILES = /^gh api --paginate repos\/o\/r\/pulls\/4321\/files/;
 const DIFF = /^gh api -H Accept: application\/vnd\.github\.diff repos\/o\/r\/pulls\/4321$/;
 const REGISTRY = /contents\/apps\/web\/worker\/features\/flagship\/resources\.ts/;
+const LABELS = /^gh api --paginate repos\/o\/r\/labels/;
 const LABEL = /^gh api --method POST repos\/o\/r\/issues\/4287\/labels/;
 const ISSUE = /^gh api repos\/o\/r\/issues\/4287$/;
 
@@ -18,6 +25,8 @@ const REGISTRY_TEXT = `export const flags = [
 	FlagshipFlag("sozluk-vote-widget", {defaultVariation: "off"}),
 ];
 `;
+
+const TAXONOMY = okOut("status:awaiting-release\nstatus:triaged\ntype:bug\n");
 
 const PLAIN_DIFF = `diff --git a/apps/web/src/App.tsx b/apps/web/src/App.tsx
 +const a = 1;
@@ -36,6 +45,14 @@ const run = (
 	Effect.runPromise(
 		Effect.provide(runRelease({...options, ...overrides}), fakeShell(script).layer),
 	);
+
+const runObserved = (script: ReadonlyArray<readonly [RegExp, ExecResult]>) => {
+	const shell = fakeShell(script);
+	return Effect.runPromise(Effect.provide(runRelease(options), shell.layer)).then((out) => ({
+		out,
+		calls: shell.calls,
+	}));
+};
 
 const twoFiles = files("apps/web/src/App.tsx", "README.md");
 
@@ -57,6 +74,7 @@ describe("runRelease", () => {
 			[FILES, twoFiles],
 			[DIFF, okOut(PLAIN_DIFF)],
 			[REGISTRY, okOut(REGISTRY_TEXT)],
+			[LABELS, TAXONOMY],
 			[LABEL, okOut("[]")],
 			[ISSUE, issue(["status:awaiting-release"])],
 		]);
@@ -120,6 +138,7 @@ describe("runRelease", () => {
 			[FILES, twoFiles],
 			[DIFF, okOut(PLAIN_DIFF)],
 			[REGISTRY, okOut(REGISTRY_TEXT)],
+			[LABELS, TAXONOMY],
 			[LABEL, errOut("gh: Bad gateway (HTTP 502)")],
 		]);
 		expect(out.code).toBe(WRITE_UNKNOWN);
@@ -132,9 +151,58 @@ describe("runRelease", () => {
 			[FILES, twoFiles],
 			[DIFF, okOut(PLAIN_DIFF)],
 			[REGISTRY, okOut(REGISTRY_TEXT)],
+			[LABELS, TAXONOMY],
 			[LABEL, okOut("[]")],
 			[ISSUE, issue([])],
 		]);
 		expect(out.code).toBe(READBACK_MISMATCH);
+	});
+
+	it("refuses on 23 when status:awaiting-release is absent — never minting it (#4285)", async () => {
+		const {out, calls} = await runObserved([
+			[PULL, pull({body: "Fixes #4287\n\nFlag: sozluk-vote-widget\n"})],
+			[FILES, twoFiles],
+			[DIFF, okOut(PLAIN_DIFF)],
+			[REGISTRY, okOut(REGISTRY_TEXT)],
+			[LABELS, okOut("status:triaged\ntype:bug\n")],
+		]);
+		expect(out.code).toBe(LABEL_ABSENT);
+		expect(out.stderr.at(-1)).toContain('label "status:awaiting-release" is absent');
+		expect(out.stderr.at(-1)).toContain("#4285");
+		expect(out.stderr.at(-1)).toContain("A real dark ship is not queued");
+		expect(calls.some((line) => LABEL.test(line))).toBe(false);
+	});
+
+	it("refuses an unreadable taxonomy on 11 — an unreachable GitHub is not an absent label", async () => {
+		const {out, calls} = await runObserved([
+			[PULL, pull({body: "Fixes #4287\n\nFlag: sozluk-vote-widget\n"})],
+			[FILES, twoFiles],
+			[DIFF, okOut(PLAIN_DIFF)],
+			[REGISTRY, okOut(REGISTRY_TEXT)],
+			[LABELS, errOut("gh: Bad gateway (HTTP 502)")],
+		]);
+		expect(out.code).toBe(PRECONDITION_UNKNOWN);
+		expect(out.stderr.at(-1)).toContain("cannot read o/r's label taxonomy");
+		expect(calls.some((line) => LABEL.test(line))).toBe(false);
+	});
+
+	it("reads no taxonomy on the paths that post nothing — n/a and no-issue", async () => {
+		const nonWriting = await runObserved([
+			[PULL, pull()],
+			[FILES, twoFiles],
+			[DIFF, okOut(PLAIN_DIFF)],
+			[REGISTRY, okOut(REGISTRY_TEXT)],
+		]);
+		expect(nonWriting.out.code).toBe(0);
+		expect(nonWriting.calls.some((line) => LABELS.test(line))).toBe(false);
+
+		const noIssue = await runObserved([
+			[PULL, pull({body: "no closing keyword here"})],
+			[FILES, twoFiles],
+			[DIFF, okOut(DECLARING_DIFF)],
+			[REGISTRY, okOut(REGISTRY_TEXT)],
+		]);
+		expect(noIssue.out.code).toBe(0);
+		expect(noIssue.calls.some((line) => LABELS.test(line))).toBe(false);
 	});
 });


### PR DESCRIPTION
`ship release` was the one board-label writer that never checked the repo's label taxonomy before
posting. GitHub's `POST /issues/{n}/labels` creates a label it cannot find, so on a board that never
ran `status bootstrap label-taxonomy` the verb silently minted `status:awaiting-release` with a
random colour and no description — the exact silent-create #4285 established the refusal to prevent.

`runRelease` now lists the taxonomy and refuses when the label is absent. Three details carry the
weight:

- The read happens only where a POST is due, right before `addLabels`. An `n/a` or `no-issue` run
  posts nothing, so it reads no taxonomy — `plan flip`'s rule, and a test asserts both paths make no
  labels call.
- An unreadable taxonomy refuses on `PRECONDITION_UNKNOWN` (`11`), not on the absent-label code. An
  unreachable GitHub is not proof the label is missing.
- The absent-label refusal seats on `LABEL_ABSENT`, imported into `ship/codes.ts` from
  `plan/codes.ts` rather than restated. `plan flip` and `ship release` prove the same fact over the
  same board, and `plan`'s own rule is to import a code when two groups prove one fact. The
  alternative precedent (`triage apply`/`park` fold it into `ZERO_SCOPE`) would make `7` two facts
  in this group, which documents it as the *target* proven absent — and the PR and issue both exist
  here.

The refusal message names the label, cites #4285, says the dark ship is not queued, and points at
`fabrika status bootstrap label-taxonomy`.

`status/bootstrap-verb.ts`'s docblock claim "each refuses a label the repo lacks" is now true as
written for all four siblings plus `ship release`, so it is left alone.

`skills/ship/contract.md` gains the `23` row in the group matrix and the per-verb table, both new
error rows, and the scope line now names the taxonomy read.

Fixes #6054

## Deviations

None.
