### PR TITLE
docs(roadmap): add the fabrika everywhere campaign row (#47)

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -42,8 +42,9 @@ flowchart TD
 		camp_flag_retirement_adr_0136["Flag Retirement (ADR 0136)"]:::done
 		camp_writing_craft_import["Writing-Craft Import"]:::done
 		camp_fabrika_kampus_pipeline_v2["fabrika — kampus-pipeline v2"]:::done
-		camp_switching_to_fabrika["switching to fabrika"]:::active
+		camp_switching_to_fabrika["switching to fabrika"]:::done
 		camp_fabrika_fast_follows["fabrika fast follows"]:::active
+		camp_fabrika_everywhere["fabrika everywhere"]:::active
 	end
 	ext_3642["#3642"]:::external
 	ext_3833["#3833"]:::external
@@ -100,6 +101,7 @@ Campaigns are bounded, milestone-backed pushes that run *concurrently* with the 
 | fabrika — kampus-pipeline v2 | #44 | done |
 | switching to fabrika | #45 | done |
 | fabrika fast follows | #46 | active |
+| fabrika everywhere | #47 | active |
 
 **The table is a parsed contract.** It is the single source the campaign skill (which appends a row and flips its state) and the lifecycle guard (which reads it) both bind to, so the grammar is pinned here rather than re-derived at either end:
 


### PR DESCRIPTION
Founder-directed (2026-08-18, in session). Milestone 47 has taken homed work all day under the new running-milestone fence but had no campaign row, so roadmap-guard I3 reds every open PR (#6118).

- Appends `| fabrika everywhere | #47 | active |` per the campaign-table contract (founder-voice name, milestone by number, two-state lifecycle).
- Regenerates the mermaid dependency diagram with `pipeline-cli roadmap diagram` (generated block, never hand-edited).
- Ritual applied from the campaign skill (row lands via PR); fabrika has no port of that skill yet — filed as #6121.

`pipeline-cli roadmap-guard check` local: I1–I6 all green (4 arcs + 20 campaigns against 43 milestones).

Fixes #6118

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Deviations

- **Said:** the mermaid dependency diagram is regenerated, never hand-edited. **Did:** regenerated with `pipeline-cli roadmap diagram`; the fresh output also flips `switching to fabrika` (#45) from `active` to `done` — the table has read `done` for a while and the committed block was stale, so the regeneration carries that correction alongside the new #47 node. **Why:** the block is generated from the tables as one unit; splicing only the new node by hand would violate the never-hand-edit rule. **Disposition:** kept, both changes.
