### PR TITLE
fix: review scope and governance scope print a stale merge-base under a moved main

### DIFF
--- a/claude-plugins/fabrika/skills/governance/contract.md
+++ b/claude-plugins/fabrika/skills/governance/contract.md
@@ -196,11 +196,13 @@ verdict over text nobody judged. All four run one shared binding step
 `packages/fabrika-cli/src/review/head.ts` and importing `bindHead` from it) before any artifact read:
 
 1. An explicit `--sha` must be **the PR's head**, or the verb refuses on `12`. Malformed is `10`.
-   `governance base` takes no `--sha`: it resolves the merge base itself and re-resolves the live
-   head, and its `12` refuses when that head moved mid-resolve.
+   `governance base` takes no `--sha`: it binds against the live head and re-resolves it, and its
+   `12` refuses when that head moved mid-resolve.
 2. A configured git remote must serve the target repo, `pull/<pr>/head` must **fetch**, the commit
    must resolve in the object database, and `git rev-parse` must resolve it to *itself*. The base ref
-   must resolve too, since a diff is a range. Any of these unmet is `11`, naming what is UNKNOWN.
+   must resolve too, since a diff is a range, **and so must the merge base of that branch tip and
+   this head** — the binding carries the tip and the branch point as two separate values, and every
+   verb's `base` is the branch point (#5770). Any of these unmet is `11`, naming what is UNKNOWN.
    There is no permissive fallback to the PR-number endpoints.
 3. The artifact is then read with `git diff <base>...<head>` and `git show <head>:<path>` under flags
    that pin output to the two commits rather than to the invoking user's own git configuration
@@ -780,7 +782,7 @@ either; the bytes come from the object database.
 | ``governance base: no `*/fabrika/skills/governance/SKILL.md` at merge-base <sha> — this skill is not installed in the base revision, so there is no self fence to run.`` | 7 | refusal |
 | `governance base: <n> candidate skill roots at merge-base <sha> (<list>) — which one is this skill is UNKNOWN; refusing to guess.` | 11 | refusal |
 | `governance base: --path "<v>" is outside this skill's own directory (<resolved>) — this verb reads only this skill's own text.` | 10 | refusal |
-| `governance base: cannot resolve the merge base of #<n>: <reason> — the base rules are UNKNOWN; refusing to judge by the head's.` | 11 | refusal |
+| `governance base: cannot resolve the merge base of <baseRef> (<tip>) and <head>: <reason> — the merge base cannot be resolved, so the base rules are UNKNOWN.` | 11 | refusal |
 | `governance base: cannot read <path> at <sha>: <reason> — UNKNOWN.` | 11 | refusal |
 | `governance base: #<n>'s head moved to <live> while resolving — re-run.` | 12 | refusal |
 | `governance base: merge base of #<n> is <sha>.` | 0 | notice |

--- a/claude-plugins/fabrika/skills/review/contract.md
+++ b/claude-plugins/fabrika/skills/review/contract.md
@@ -182,14 +182,16 @@ already requires, and all four run one shared binding step
 2. A configured git remote in this checkout must serve the target repo, `pull/<pr>/head` must
    fetch, the commit must resolve in the **object database**, and `git rev-parse` must resolve it
    to *itself* — a local ref or tag spelled as hex resolves elsewhere, which is how a name that
-   verifies still names the wrong tree. The base ref must resolve too, since a diff is a range.
-   Any of these unmet is `11`, naming what is UNKNOWN. There is no permissive fallback to the
-   PR-number endpoints: unbindable is a refusal, never a plausible value.
-3. The artifact is then read with `git diff <base>...<head>` — bytes for `review diff` and
-   `review deviations`'s Tier-M scan, the `--name-only -z` path list for `review scope` and
-   `review post`'s namespace recompute — under flags that pin the output to the two commits
-   rather than to the invoking user's own git configuration (`--no-ext-diff`, explicit `a/`/`b/`
-   prefixes).
+   verifies still names the wrong tree. The base ref must resolve too, since a diff is a range,
+   **and so must the merge base of that branch tip and this head** — the binding carries the tip
+   and the branch point as two separate values, and every verb's `base` is the branch point
+   (#5770). Any of these unmet is `11`, naming what is UNKNOWN. There is no permissive fallback to
+   the PR-number endpoints: unbindable is a refusal, never a plausible value.
+3. The artifact is then read with `git diff <base>...<head>`, where `<base>` is that branch point
+   — bytes for `review diff` and `review deviations`'s Tier-M scan, the `--name-only -z` path list
+   for `review scope` and `review post`'s namespace recompute — under flags that pin the output to
+   the two commits rather than to the invoking user's own git configuration (`--no-ext-diff`,
+   explicit `a/`/`b/` prefixes).
 
 Every one of them prints the bound commit and its base on stderr, and `review scope`'s `scoped`
 line prints **the commit it read the files out of**, so the head named and the files partitioned

--- a/packages/fabrika-cli/src/governance/base-verb.ts
+++ b/packages/fabrika-cli/src/governance/base-verb.ts
@@ -16,7 +16,7 @@
  */
 import {Effect} from "effect";
 import type {ChildProcessSpawner} from "effect/unstable/process";
-import {listTreePaths, mergeBase, readFileAt} from "../io/git.ts";
+import {listTreePaths, readFileAt} from "../io/git.ts";
 import {getPullRequest} from "../io/pulls.ts";
 import {badNumber, openPull, resolveTargetRepo} from "../review/target.ts";
 import {answer, refuse, type VerbOutcome} from "../verb.ts";
@@ -59,8 +59,8 @@ export const runBase = (
 		});
 		if (target._tag === "Refused") return target.outcome;
 
-		// This verb takes no `--sha`: it resolves the base itself, so the binding runs against the live
-		// head and the staleness check below is what pairs the two.
+		// This verb takes no `--sha`, so the binding runs against the live head and the staleness check
+		// below is what pairs the two.
 		const bound = yield* bindGovernanceHead(
 			VERB,
 			"the merge base cannot be resolved, so the base rules are UNKNOWN.",
@@ -72,16 +72,13 @@ export const runBase = (
 		if (bound._tag === "Refused") return bound.outcome;
 		const head = bound.head;
 
-		const base = yield* mergeBase(head.base, head.sha);
-		if (base._tag === "Failure") {
-			return refuse(
-				PRECONDITION_UNKNOWN,
-				`${VERB}: cannot resolve the merge base of #${pr}: ${base.reason} — the base rules are UNKNOWN; refusing to judge by the head's.`,
-			);
-		}
+		// The binding already resolved this, and resolving it twice is how two answers to one question
+		// come to disagree (#5770). A failed resolve refuses inside `bindGovernanceHead` above, wearing
+		// this verb's own tail.
+		const base = head.mergeBase;
 
 		// A base paired with a head nobody judged is not a fence, so the head is re-read after the
-		// resolve rather than trusted from before it.
+		// binding rather than trusted from before it.
 		const after = yield* getPullRequest(repo, pr);
 		if (after._tag !== "Present") {
 			return refuse(
@@ -96,29 +93,29 @@ export const runBase = (
 			);
 		}
 
-		const tree = yield* listTreePaths(base.value);
+		const tree = yield* listTreePaths(base);
 		if (tree._tag === "Failure") {
 			return refuse(
 				PRECONDITION_UNKNOWN,
-				`${VERB}: cannot list the tree at merge base ${base.value}: ${tree.reason} — the base rules are UNKNOWN; refusing to judge by the head's.`,
+				`${VERB}: cannot list the tree at merge base ${base}: ${tree.reason} — the base rules are UNKNOWN; refusing to judge by the head's.`,
 			);
 		}
 		const roots = resolveSkillRoots(tree.value);
 		if (roots._tag === "None") {
 			return refuse(
 				ZERO_SCOPE,
-				`${VERB}: no \`*/fabrika/skills/governance/SKILL.md\` at merge-base ${base.value} — this skill is not installed in the base revision, so there is no self fence to run.`,
+				`${VERB}: no \`*/fabrika/skills/governance/SKILL.md\` at merge-base ${base} — this skill is not installed in the base revision, so there is no self fence to run.`,
 			);
 		}
 		if (roots._tag === "Many") {
 			return refuse(
 				PRECONDITION_UNKNOWN,
-				`${VERB}: ${roots.candidates.length} candidate skill roots at merge-base ${base.value} (${roots.candidates.join(", ")}) — which one is this skill is UNKNOWN; refusing to guess.`,
+				`${VERB}: ${roots.candidates.length} candidate skill roots at merge-base ${base} (${roots.candidates.join(", ")}) — which one is this skill is UNKNOWN; refusing to guess.`,
 			);
 		}
 		const root = roots.root;
 		const diagnostics = [
-			`${VERB}: resolved this skill's own directory to ${root} at merge-base ${base.value}.`,
+			`${VERB}: resolved this skill's own directory to ${root} at merge-base ${base}.`,
 		];
 
 		const wanted =
@@ -139,11 +136,11 @@ export const runBase = (
 			// Absence is PROVEN from the tree listing, so a path that is simply not there is skipped and
 			// a path that is there and will not read is `11` — the two are different facts.
 			if (!present.has(path)) continue;
-			const bytes = yield* readFileAt(base.value, path);
+			const bytes = yield* readFileAt(base, path);
 			if (bytes._tag === "Failure") {
 				return refuse(
 					PRECONDITION_UNKNOWN,
-					`${VERB}: cannot read ${path} at ${base.value}: ${bytes.reason} — UNKNOWN.`,
+					`${VERB}: cannot read ${path} at ${base}: ${bytes.reason} — UNKNOWN.`,
 					diagnostics,
 				);
 			}
@@ -152,11 +149,11 @@ export const runBase = (
 		if (blocks.length === 0) {
 			return refuse(
 				ZERO_SCOPE,
-				`${VERB}: none of the requested paths exist at merge-base ${base.value} — there is no base revision to judge by.`,
+				`${VERB}: none of the requested paths exist at merge-base ${base} — there is no base revision to judge by.`,
 				diagnostics,
 			);
 		}
 
-		diagnostics.push(`${VERB}: merge base of #${pr} is ${base.value}.`);
-		return answer(`base\t${base.value}\t${blocks.length}\n${blocks.join("")}`, diagnostics);
+		diagnostics.push(`${VERB}: merge base of #${pr} is ${base}.`);
+		return answer(`base\t${base}\t${blocks.length}\n${blocks.join("")}`, diagnostics);
 	});

--- a/packages/fabrika-cli/src/governance/base-verb.unit.test.ts
+++ b/packages/fabrika-cli/src/governance/base-verb.unit.test.ts
@@ -7,6 +7,7 @@ import {OFF_VOCABULARY, PRECONDITION_UNKNOWN, STALE_HEAD, ZERO_SCOPE} from "./co
 import {
 	binding,
 	HEAD,
+	BASE as MERGE_BASE,
 	pull,
 	SHOW_AT,
 	SKILL_ROOT,
@@ -15,7 +16,6 @@ import {
 } from "./fixtures.test-support.ts";
 
 const PULL = /^gh api repos\/o\/r\/pulls\/4321$/;
-const MERGE_BASE = "8b1e0c4499ad72f635e0117a9bb2d3c058e7fa16";
 
 const options = {
 	pr: 4321,
@@ -38,7 +38,6 @@ const upTo = (
 ): ReadonlyArray<readonly [RegExp, ExecResult]> => [
 	[once(PULL), pull()],
 	...binding(),
-	[/^git merge-base /, okOut(`${MERGE_BASE}\n`)],
 	[PULL, pull()],
 	[TREE_AT(MERGE_BASE), treeOf(...tree)],
 ];
@@ -115,26 +114,25 @@ describe("runBase", () => {
 
 	it("refuses on 12 when the head moved while the base was being resolved", async () => {
 		const moved = "0b1c2d3e4f5a6b7c8d9e0f1a2b3c4d5e6f708192";
-		const out = await run([
-			[once(PULL), pull()],
-			...binding(),
-			[/^git merge-base /, okOut(`${MERGE_BASE}\n`)],
-			[PULL, pull({head: moved})],
-		]);
+		const out = await run([[once(PULL), pull()], ...binding(), [PULL, pull({head: moved})]]);
 		expect(out.code).toBe(STALE_HEAD);
 		expect(out.stderr.at(-1)).toBe(
 			`governance base: #4321's head moved to ${moved} while resolving — re-run.`,
 		);
 	});
 
+	// The resolve moved into the binding (#5770), so the failure arrives wearing this verb's own tail
+	// rather than `bindHead`'s — the entry precedes `binding()` because the first match wins.
 	it("refuses an unresolvable merge base on 11", async () => {
 		const out = await run([
 			[once(PULL), pull()],
-			...binding(),
 			[/^git merge-base /, errOut("fatal: no merge base")],
+			...binding(),
 		]);
 		expect(out.code).toBe(PRECONDITION_UNKNOWN);
-		expect(out.stderr.at(-1)).toContain("refusing to judge by the head's");
+		expect(out.stderr.at(-1)).toContain(
+			"the merge base cannot be resolved, so the base rules are UNKNOWN.",
+		);
 	});
 
 	it("refuses an absent PR on 7 and a non-PR number on 1", async () => {

--- a/packages/fabrika-cli/src/governance/fixtures.test-support.ts
+++ b/packages/fabrika-cli/src/governance/fixtures.test-support.ts
@@ -13,6 +13,7 @@ import {BASE, HEAD} from "../review/fixtures.test-support.ts";
 
 export {
 	BASE,
+	BASE_TIP,
 	binding,
 	comments,
 	HEAD,

--- a/packages/fabrika-cli/src/governance/guards-verb.ts
+++ b/packages/fabrika-cli/src/governance/guards-verb.ts
@@ -11,8 +11,11 @@
  *
  * A truncated diff is refused rather than scanned. An under-reported hit list reads as a
  * checked-clean answer that was never checked (#3925's class). For the same reason each changed
- * file is read at the base commit as well as at the head, so an anchor's paragraph is compared whole
- * instead of only where the diff happens to touch it — see `anchors.ts` (#5514).
+ * file is read at the merge base as well as at the head, so an anchor's paragraph is compared whole
+ * instead of only where the diff happens to touch it — see `anchors.ts` (#5514). That "before" read
+ * is a point read at one commit, not a range, so nothing recomputes a merge base for it the way a
+ * three-dot diff would: reading it at the base *branch tip* compares this PR's anchors against
+ * main's newest bytes and invents a move nobody made (#5770/#6077).
  */
 import {Effect} from "effect";
 import type {ChildProcessSpawner} from "effect/unstable/process";
@@ -70,7 +73,7 @@ export const runGuards = (
 		const head = bound.head;
 		const diagnostics = [boundLine(VERB, head)];
 
-		const diff = yield* diffRange(head.base, head.sha);
+		const diff = yield* diffRange(head.mergeBase, head.sha);
 		if (diff._tag === "Failure") {
 			return refuse(
 				PRECONDITION_UNKNOWN,
@@ -87,7 +90,7 @@ export const runGuards = (
 			);
 		}
 
-		const listed = yield* diffRangeStatuses(head.base, head.sha);
+		const listed = yield* diffRangeStatuses(head.mergeBase, head.sha);
 		if (listed._tag === "Failure") {
 			return refuse(
 				PRECONDITION_UNKNOWN,
@@ -117,11 +120,11 @@ export const runGuards = (
 			// no base side, and a rename's base path is the source `--name-status` drops, so both fall
 			// back to the diff walk rather than being read at a path the base commit does not carry.
 			if (!(entry.status.startsWith("M") || entry.status.startsWith("T"))) continue;
-			const before = yield* readFileAt(head.base, entry.path);
+			const before = yield* readFileAt(head.mergeBase, entry.path);
 			if (before._tag === "Failure") {
 				return refuse(
 					PRECONDITION_UNKNOWN,
-					`${VERB}: cannot read ${entry.path} at ${head.base}: ${before.reason} — UNKNOWN, never "nothing moved".`,
+					`${VERB}: cannot read ${entry.path} at ${head.mergeBase}: ${before.reason} — UNKNOWN, never "nothing moved".`,
 					diagnostics,
 				);
 			}
@@ -139,7 +142,7 @@ export const runGuards = (
 		const outcome =
 			hits.length > 0 ? "hits" : inReach === 0 ? "no-anchors-in-reach" : "no-anchor-change";
 		diagnostics.push(
-			`${VERB}: scanned ${listed.value.length} files, ${inReach} anchored invariants in reach, ${compared} compared block-by-block against ${head.base}.`,
+			`${VERB}: scanned ${listed.value.length} files, ${inReach} anchored invariants in reach, ${compared} compared block-by-block against ${head.mergeBase}.`,
 		);
 
 		if (json) {

--- a/packages/fabrika-cli/src/governance/guards-verb.unit.test.ts
+++ b/packages/fabrika-cli/src/governance/guards-verb.unit.test.ts
@@ -6,6 +6,7 @@ import {DIFF_AT} from "../review/fixtures.test-support.ts";
 import {INCOMPLETE_SCAN, PRECONDITION_UNKNOWN, STALE_HEAD, ZERO_SCOPE} from "./codes.ts";
 import {
 	BASE,
+	BASE_TIP,
 	binding,
 	HEAD,
 	OLD_HEAD,
@@ -115,6 +116,30 @@ describe("runGuards", () => {
 			),
 		);
 		expect(out.stdout).not.toContain("guard-file");
+	});
+
+	/**
+	 * The point read #6077 found, pinned (#5770).
+	 *
+	 * The block comparison is a read at ONE commit, so unlike the three-dot diff around it nothing
+	 * recomputes a branch point for it. Main here has edited the anchor since this branch left: at the
+	 * merge base the anchor still reads `one`, which is what the head carries, and at the branch tip
+	 * it reads `three`. Reading the tip would report a modification this PR did not make.
+	 */
+	it("compares the anchor block at the merge base, not at a main that edited it since", async () => {
+		const anchored = (text: string): string => `<!-- anchor: G --> ${text}\n`;
+		const out = await run([
+			[PULL, pull({changedFiles: 1})],
+			...binding(),
+			[DIFF_AT(), okOut(diffOf(SKILL, "-prose", "+other prose"))],
+			[STATUS_AT(), statuses(["M", SKILL])],
+			[SHOW_AT(HEAD, SKILL), okOut(anchored("one"))],
+			[SHOW_AT(BASE, SKILL), okOut(anchored("one"))],
+			[SHOW_AT(BASE_TIP, SKILL), okOut(anchored("three"))],
+		]);
+		expect(out.stdout).toBe(
+			[`guards\tno-anchor-change\t1`, `guard-file\t${SKILL}\t1`, ""].join("\n"),
+		);
 	});
 
 	it("states the scanned file count, the anchors in reach and the base comparison on stderr", async () => {

--- a/packages/fabrika-cli/src/governance/post-verb.ts
+++ b/packages/fabrika-cli/src/governance/post-verb.ts
@@ -277,15 +277,15 @@ export const runPost = (
 		);
 		if (bound._tag === "Refused") return bound.outcome;
 		const head = bound.head;
-		const listed = yield* diffRangePaths(head.base, head.sha);
+		const listed = yield* diffRangePaths(head.mergeBase, head.sha);
 		if (listed._tag === "Failure") return unreadable("the changed-file list", pr, listed.reason);
 		// Taken at the SAME bound commit the requirement is re-derived at — see `review/post-verb.ts`.
-		const content = yield* contentDigestAt(head.base, head.sha);
+		const content = yield* contentDigestAt(head.mergeBase, head.sha);
 		if (content._tag === "Failure") return unreadable("the content digest", pr, content.reason);
 		const diagnostics = [
 			boundLine(VERB, head),
 			scannedLine(VERB, listed.value.length, "changed file"),
-			`${VERB}: content ${content.value} — the digest of ${head.base}...${head.sha} this verdict survives on (ADR 0276).`,
+			`${VERB}: content ${content.value} — the digest of ${head.mergeBase}...${head.sha} this verdict survives on (ADR 0276).`,
 		];
 		if (!touchesGovernanceRoot(listed.value)) {
 			return refuse(

--- a/packages/fabrika-cli/src/governance/scope-verb.ts
+++ b/packages/fabrika-cli/src/governance/scope-verb.ts
@@ -71,7 +71,7 @@ export const runScope = (
 		if (bound._tag === "Refused") return withNotice(bound.outcome);
 		const head = bound.head;
 
-		const listed = yield* diffRangeStatuses(head.base, head.sha);
+		const listed = yield* diffRangeStatuses(head.mergeBase, head.sha);
 		if (listed._tag === "Failure") {
 			return withNotice(
 				refuse(
@@ -127,7 +127,7 @@ export const runScope = (
 					head: head.sha,
 					roots: result.roots.map((tally) => ({name: tally.name, files: tally.files})),
 					self: result.self,
-					base: head.base,
+					base: head.mergeBase,
 					records: result.records,
 					scanned: result.scanned,
 				}),

--- a/packages/fabrika-cli/src/governance/scope-verb.unit.test.ts
+++ b/packages/fabrika-cli/src/governance/scope-verb.unit.test.ts
@@ -11,6 +11,7 @@ import {
 } from "./codes.ts";
 import {
 	BASE,
+	BASE_TIP,
 	binding,
 	FULL_TREE,
 	HEAD,
@@ -80,9 +81,12 @@ describe("runScope", () => {
 		expect(out.stdout).toContain("self\ttrue");
 	});
 
-	it("emits the record with --json, carrying the base the range was read across", async () => {
+	// The binding runs against a main that has moved on (`BASE_TIP` is ahead of `BASE`), so `base`
+	// naming the branch point rather than that tip is the whole assertion here (#5770).
+	it("emits the record with --json, carrying the merge base the range was read across", async () => {
 		const out = await run(GOVERNING, {json: true});
-		expect(JSON.parse(out.stdout)).toMatchObject({
+		const record = JSON.parse(out.stdout);
+		expect(record).toMatchObject({
 			outcome: "required",
 			head: HEAD,
 			base: BASE,
@@ -90,6 +94,7 @@ describe("runScope", () => {
 			scanned: 2,
 			records: [{id: "0240", change: "added"}],
 		});
+		expect(record.base).not.toBe(BASE_TIP);
 	});
 
 	it("says on stderr, on every run, that this is not the §CP answer", async () => {

--- a/packages/fabrika-cli/src/governance/sweep-verb.ts
+++ b/packages/fabrika-cli/src/governance/sweep-verb.ts
@@ -157,7 +157,7 @@ export const runSweep = (
 			const head = bound.head;
 			diagnostics.push(boundLine(VERB, head));
 
-			const listed = yield* diffRangeStatuses(head.base, head.sha);
+			const listed = yield* diffRangeStatuses(head.mergeBase, head.sha);
 			if (listed._tag === "Failure") {
 				return refuse(
 					PRECONDITION_UNKNOWN,

--- a/packages/fabrika-cli/src/lane/prove-verb.ts
+++ b/packages/fabrika-cli/src/lane/prove-verb.ts
@@ -468,7 +468,9 @@ const proveVerdicts = (
 		) {
 			const bound = yield* bindHead(VERB, repo, pr, pull.value, null);
 			const computed =
-				bound._tag === "Bound" ? yield* contentDigestAt(bound.head.base, bound.head.sha) : null;
+				bound._tag === "Bound"
+					? yield* contentDigestAt(bound.head.mergeBase, bound.head.sha)
+					: null;
 			if (computed !== null && computed._tag === "Ok") digest = computed.value;
 			if (digest === null) {
 				notes.push(

--- a/packages/fabrika-cli/src/review/deviations-verb.ts
+++ b/packages/fabrika-cli/src/review/deviations-verb.ts
@@ -63,7 +63,7 @@ export const runDeviations = (
 		if (bound._tag === "Refused") return bound.outcome;
 		const head = bound.head;
 
-		const served = yield* diffRange(head.base, head.sha);
+		const served = yield* diffRange(head.mergeBase, head.sha);
 		if (served._tag === "Failure") {
 			return refuse(PRECONDITION_UNKNOWN, unreadable(pr, served.reason));
 		}
@@ -76,11 +76,11 @@ export const runDeviations = (
 		// prove the range is the right one, and a fault that shortens both reads alike is invisible to
 		// it. GitHub's `changed_files` is a third party's answer over its own base and its own rename
 		// detection, so it is reported in the diagnostics and never refused on (#5157).
-		const listed = yield* diffRangePaths(head.base, head.sha);
+		const listed = yield* diffRangePaths(head.mergeBase, head.sha);
 		if (listed._tag === "Failure") {
 			return refuse(
 				PRECONDITION_UNKNOWN,
-				`${VERB}: cannot read the file list of the range ${head.base}...${head.sha} for #${pr}: ${listed.reason} — the disclosure state is UNKNOWN, never "none".`,
+				`${VERB}: cannot read the file list of the range ${head.mergeBase}...${head.sha} for #${pr}: ${listed.reason} — the disclosure state is UNKNOWN, never "none".`,
 			);
 		}
 		const inRange = listed.value.length;
@@ -103,7 +103,7 @@ export const runDeviations = (
 		if (seen < inRange) {
 			return refuse(
 				INCOMPLETE_SCAN,
-				`${VERB}: the scan at ${head.sha} covers ${seen} of the ${inRange} files git lists for the same range ${head.base}...${head.sha} — both counts from git, so these bytes are provably short of the range they were read from; refusing a partial Tier-M scan beside a disclosure claim.`,
+				`${VERB}: the scan at ${head.sha} covers ${seen} of the ${inRange} files git lists for the same range ${head.mergeBase}...${head.sha} — both counts from git, so these bytes are provably short of the range they were read from; refusing a partial Tier-M scan beside a disclosure claim.`,
 				diagnostics,
 			);
 		}

--- a/packages/fabrika-cli/src/review/diff-verb.ts
+++ b/packages/fabrika-cli/src/review/diff-verb.ts
@@ -55,7 +55,7 @@ export const runDiff = (
 		if (bound._tag === "Refused") return bound.outcome;
 		const head = bound.head;
 
-		const served = yield* diffRange(head.base, head.sha);
+		const served = yield* diffRange(head.mergeBase, head.sha);
 		if (served._tag === "Failure") {
 			return refuse(
 				PRECONDITION_UNKNOWN,
@@ -69,11 +69,11 @@ export const runDiff = (
 		// so rename pairing and merge-base choice cancel instead of being compared across systems. What
 		// that does and does not prove is in `diff.ts`. GitHub's `changed_files` is its own merge base
 		// and its own rename detection, so it is reported below and never refused on (#5139).
-		const listed = yield* diffRangePaths(head.base, head.sha);
+		const listed = yield* diffRangePaths(head.mergeBase, head.sha);
 		if (listed._tag === "Failure") {
 			return refuse(
 				PRECONDITION_UNKNOWN,
-				`${VERB}: cannot read the file list of the range ${head.base}...${head.sha} for #${pr}: ${listed.reason} — UNKNOWN.`,
+				`${VERB}: cannot read the file list of the range ${head.mergeBase}...${head.sha} for #${pr}: ${listed.reason} — UNKNOWN.`,
 			);
 		}
 		const inRange = listed.value.length;
@@ -96,7 +96,7 @@ export const runDiff = (
 		if (seen < inRange) {
 			return refuse(
 				INCOMPLETE_SCAN,
-				`${VERB}: the diff at ${head.sha} carries ${seen} of the ${inRange} files git reports for the same range ${head.base}...${head.sha} — both counts from git, so this diff is provably short; refusing to serve a partial diff as the whole (#3925's class).`,
+				`${VERB}: the diff at ${head.sha} carries ${seen} of the ${inRange} files git reports for the same range ${head.mergeBase}...${head.sha} — both counts from git, so this diff is provably short; refusing to serve a partial diff as the whole (#3925's class).`,
 				diagnostics,
 			);
 		}

--- a/packages/fabrika-cli/src/review/fixtures.test-support.ts
+++ b/packages/fabrika-cli/src/review/fixtures.test-support.ts
@@ -9,8 +9,16 @@ import type {ExecResult} from "../io/exec.ts";
 
 export const HEAD = "03135b91aa04f7e2c9d8b1640a5c22e9f01b7d3c";
 export const OLD_HEAD = "0b1c2d3e4f5a6b7c8d9e0f1a2b3c4d5e6f708192";
-/** The base commit the bound range diffs from — the merge base `git diff base...head` resolves. */
+/** The commit this branch left the base branch at — every bound range's other end. */
 export const BASE = "0f1e2d3c4b5a69788796a5b4c3d2e1f009182736";
+/**
+ * Where `origin/main` is *now*: a commit ahead of {@link BASE}, never equal to it.
+ *
+ * The two are kept distinct on purpose. A fixture where the branch tip and the merge base are the
+ * same commit cannot tell a verb that reports the tip from one that reports the branch point — which
+ * is the whole of #5770. Every test that binds a head therefore runs against a moved main.
+ */
+export const BASE_TIP = "5a4b3c2d1e0f98877665544332211000ffeeddcc";
 
 export interface PullShape {
 	readonly state?: string;
@@ -75,14 +83,17 @@ export const CONTENT = "7af166f42fdb";
 
 /**
  * Every command `bindHead` issues, scripted green — remote lookup, the `pull/<pr>/head` fetch, the
- * object-database resolve of the head, and the base's fetch-then-resolve.
+ * object-database resolve of the head, the base branch's fetch-then-resolve, and the merge base of
+ * that tip and the head.
  *
  * One helper because both read verbs bind identically: two hand-written copies are two chances for a
- * test to prove a binding the other verb does not make.
+ * test to prove a binding the other verb does not make. `tip` defaults ahead of `base`, so every
+ * caller of this helper is bound under a moved main (#5770).
  */
 export const binding = (
 	sha: string = HEAD,
 	base: string = BASE,
+	tip: string = BASE_TIP,
 ): ReadonlyArray<readonly [RegExp, ExecResult]> => [
 	[
 		/^git remote -v$/,
@@ -92,7 +103,8 @@ export const binding = (
 	[new RegExp(`^git rev-parse --verify --quiet ${sha}\\^\\{commit\\}$`), okOut(`${sha}\n`)],
 	[/^git remote$/, okOut("origin\n")],
 	[/^git fetch --quiet origin main$/, okOut("")],
-	[/^git rev-parse --verify --quiet origin\/main\^\{commit\}$/, okOut(`${base}\n`)],
+	[/^git rev-parse --verify --quiet origin\/main\^\{commit\}$/, okOut(`${tip}\n`)],
+	[new RegExp(`^git merge-base ${tip} ${sha}$`), okOut(`${base}\n`)],
 	// The content binding's own read, in the binding script because every verb that binds a head then
 	// digests that same range (ADR 0276); a per-test copy is how two tests come to digest differently.
 	[RAW_AT(base, sha), okOut(RAW)],

--- a/packages/fabrika-cli/src/review/head.ts
+++ b/packages/fabrika-cli/src/review/head.ts
@@ -23,16 +23,27 @@
  */
 import {Effect} from "effect";
 import type {ChildProcessSpawner} from "effect/unstable/process";
-import {fetchAndResolve, fetchRef, remoteFor, resolveCommit} from "../io/git.ts";
+import {fetchAndResolve, fetchRef, mergeBase, remoteFor, resolveCommit} from "../io/git.ts";
 import type {PullRecord} from "../io/pulls.ts";
 import {refuse, type VerbOutcome} from "../verb.ts";
 import {headSha} from "../wire/verdict-marker.ts";
 import {OFF_VOCABULARY, PRECONDITION_UNKNOWN, STALE_HEAD} from "./codes.ts";
 
-/** The two commits every bound read is taken between, each a full object name git itself resolved. */
+/**
+ * The commits every bound read is taken between, each a full object name git itself resolved.
+ *
+ * **`baseTip` and `mergeBase` are different commits, and the difference is not intermittent.** Under
+ * a moving base branch `origin/<baseRef>` runs ahead of the point this branch diverged from, so a
+ * value read as "the base" while it holds the branch tip is wrong by construction (#5770). They are
+ * two fields rather than one so that no caller can take the wrong one silently: a range, a point
+ * read and a printed base all mean the merge base, and the tip is only what derives it.
+ */
 export interface BoundHead {
 	readonly sha: string;
-	readonly base: string;
+	/** Where the base branch is *now* — `origin/<baseRef>` at fetch time, ahead of the branch point. */
+	readonly baseTip: string;
+	/** Where this branch left the base branch. The commit every reader downstream means by "base". */
+	readonly mergeBase: string;
 }
 
 export type Binding =
@@ -65,7 +76,9 @@ const prefixMatch = (a: string, b: string): boolean => a.startsWith(b) || b.star
  *    `git rev-parse` must resolve it to itself. That second half is not ceremony: a local ref or tag
  *    spelled as hex resolves to a different object, which is how a "verified" name still names the
  *    wrong tree.
- * 4. The base must resolve too, since a diff is a range and an unresolvable end makes it UNKNOWN.
+ * 4. The base must resolve too, since a diff is a range and an unresolvable end makes it UNKNOWN —
+ *    and so must the merge base of that tip and this head, because *that* is the end every caller
+ *    downstream means by "base" (#5770).
  */
 export const bindHead = (
 	verb: string,
@@ -114,13 +127,28 @@ export const bindHead = (
 		if (!prefixMatch(resolved.value, wanted)) {
 			return unknown(verb, `git resolved ${wanted} to ${resolved.value}, a different commit`);
 		}
-		const base = yield* fetchAndResolve(`${remote}/${pull.baseRef}`);
-		if (base._tag === "Failure") {
-			return unknown(verb, `cannot resolve base ${pull.baseRef}: ${base.reason}`);
+		const tip = yield* fetchAndResolve(`${remote}/${pull.baseRef}`);
+		if (tip._tag === "Failure") {
+			return unknown(verb, `cannot resolve base ${pull.baseRef}: ${tip.reason}`);
 		}
-		return {_tag: "Bound" as const, head: {sha: resolved.value, base: base.value}};
+		const forked = yield* mergeBase(tip.value, resolved.value);
+		if (forked._tag === "Failure") {
+			return unknown(
+				verb,
+				`cannot resolve the merge base of ${pull.baseRef} (${tip.value}) and ${resolved.value}: ${forked.reason}`,
+			);
+		}
+		return {
+			_tag: "Bound" as const,
+			head: {sha: resolved.value, baseTip: tip.value, mergeBase: forked.value},
+		};
 	});
 
-/** The stderr line that says which commit the answer was read out of. Evidence, on every answer. */
+/**
+ * The stderr line that says which commit the answer was read out of. Evidence, on every answer.
+ *
+ * The `(base …)` clause names the **merge base** — what every reader of this line has always taken
+ * it for. Printing the branch tip there cost three agents a hand-correction each in one lane (#5770).
+ */
 export const boundLine = (verb: string, head: BoundHead): string =>
-	`${verb}: bound to ${head.sha} (base ${head.base}) — read from the object database, nothing checked out.`;
+	`${verb}: bound to ${head.sha} (base ${head.mergeBase}) — read from the object database, nothing checked out.`;

--- a/packages/fabrika-cli/src/review/head.unit.test.ts
+++ b/packages/fabrika-cli/src/review/head.unit.test.ts
@@ -1,0 +1,109 @@
+/**
+ * The binding's own tests, all of them run against a **moved base branch** — `origin/main` ahead of
+ * the commit this branch left it at.
+ *
+ * That is the only arrangement in which the two values are distinguishable, and for a long time
+ * nothing here arranged it: the binding resolved `origin/<baseRef>` and every caller downstream read
+ * that one value as "the base", so a verb printing the branch tip and a verb printing the branch
+ * point were indistinguishable from any test (#5770).
+ */
+import {Effect} from "effect";
+import {describe, expect, it} from "vitest";
+import {errOut, fakeShell, okOut} from "../fakes.test-support.ts";
+import type {ExecResult} from "../io/exec.ts";
+import type {PullRecord} from "../io/pulls.ts";
+import {PRECONDITION_UNKNOWN} from "./codes.ts";
+import {BASE, BASE_TIP, HEAD, OLD_HEAD} from "./fixtures.test-support.ts";
+import {bindHead, boundLine} from "./head.ts";
+
+const PULL: PullRecord = {
+	number: 4321,
+	state: "open",
+	headSha: HEAD,
+	body: "",
+	changedFiles: 2,
+	comments: 0,
+	draft: false,
+	merged: false,
+	baseRef: "main",
+	autoMerge: false,
+	authorLogin: "kampus-bot",
+	assignees: [],
+	updatedAt: "2026-08-18T00:00:00Z",
+};
+
+/** `origin/main` resolves AHEAD of the branch point, which is the normal state of a busy main. */
+const MOVED_MAIN: ReadonlyArray<readonly [RegExp, ExecResult]> = [
+	[
+		/^git remote -v$/,
+		okOut("origin\tgit@github.com:o/r.git (fetch)\norigin\tgit@github.com:o/r.git (push)\n"),
+	],
+	[/^git fetch --quiet origin pull\/4321\/head$/, okOut("")],
+	[new RegExp(`^git rev-parse --verify --quiet ${HEAD}\\^\\{commit\\}$`), okOut(`${HEAD}\n`)],
+	[/^git remote$/, okOut("origin\n")],
+	[/^git fetch --quiet origin main$/, okOut("")],
+	[/^git rev-parse --verify --quiet origin\/main\^\{commit\}$/, okOut(`${BASE_TIP}\n`)],
+	[new RegExp(`^git merge-base ${BASE_TIP} ${HEAD}$`), okOut(`${BASE}\n`)],
+];
+
+const bind = (script: ReadonlyArray<readonly [RegExp, ExecResult]> = MOVED_MAIN) => {
+	const fake = fakeShell(script);
+	return {
+		fake,
+		bound: Effect.runPromise(
+			Effect.provide(bindHead("review scope", "o/r", 4321, PULL, null), fake.layer),
+		),
+	};
+};
+
+describe("bindHead under a moved base branch", () => {
+	it("carries the branch tip and the merge base as two different commits", async () => {
+		const bound = await bind().bound;
+		expect(bound._tag).toBe("Bound");
+		if (bound._tag !== "Bound") return;
+		expect(bound.head.sha).toBe(HEAD);
+		expect(bound.head.baseTip).toBe(BASE_TIP);
+		expect(bound.head.mergeBase).toBe(BASE);
+	});
+
+	it("asks git for the merge base of the tip and the head, never assuming the tip is one", async () => {
+		const {fake, bound} = bind();
+		await bound;
+		expect(fake.calls).toContain(`git merge-base ${BASE_TIP} ${HEAD}`);
+	});
+
+	/**
+	 * The divergence criterion of #5770, stated as the report stated it: on the observed instance the
+	 * printed base was a *later* main commit than the real branch point, so the failure this pins is a
+	 * tip leaking into the line, not a stale local ref.
+	 */
+	it("prints the merge base on the bound line, never the tip that is ahead of it", async () => {
+		const bound = await bind().bound;
+		if (bound._tag !== "Bound") throw new Error("expected a binding");
+		const line = boundLine("review scope", bound.head);
+		expect(line).toContain(`(base ${BASE})`);
+		expect(line).not.toContain(BASE_TIP);
+	});
+
+	it("refuses on 11 when git names no merge base — UNKNOWN, never the tip as a fallback", async () => {
+		const bound = await bind([
+			...MOVED_MAIN.filter((entry) => !entry[0].source.startsWith("^git merge-base")),
+			[/^git merge-base /, errOut("fatal: refusing to work with unrelated histories")],
+		]).bound;
+		expect(bound._tag).toBe("Refused");
+		if (bound._tag !== "Refused") return;
+		expect(bound.outcome.code).toBe(PRECONDITION_UNKNOWN);
+		expect(bound.outcome.stderr.at(-1)).toContain(
+			`cannot resolve the merge base of main (${BASE_TIP})`,
+		);
+	});
+
+	it("still refuses a --sha the PR has moved past, before it resolves any base", async () => {
+		const fake = fakeShell(MOVED_MAIN);
+		const bound = await Effect.runPromise(
+			Effect.provide(bindHead("review scope", "o/r", 4321, PULL, OLD_HEAD), fake.layer),
+		);
+		expect(bound._tag).toBe("Refused");
+		expect(fake.calls).toEqual([]);
+	});
+});

--- a/packages/fabrika-cli/src/review/post-verb.ts
+++ b/packages/fabrika-cli/src/review/post-verb.ts
@@ -339,7 +339,7 @@ export const runPost = (
 		const bound = yield* bindHead(VERB, repo, pr, target.pull, options.sha);
 		if (bound._tag === "Refused") return bound.outcome;
 		const head = bound.head;
-		const listed = yield* diffRangePaths(head.base, head.sha);
+		const listed = yield* diffRangePaths(head.mergeBase, head.sha);
 		if (listed._tag === "Failure") return unreadable("the changed-file list", pr, listed.reason);
 		const derived = namespacesOf(partition(listed.value));
 		// The content binding is taken at the SAME bound commit the class set is derived at, so the
@@ -347,14 +347,14 @@ export const runPost = (
 		// (ADR 0276). A digest that cannot be computed refuses the post: a marker silently emitted
 		// without one is head-bound forever, and nothing downstream could tell that apart from a
 		// deliberate head-only verdict.
-		const content = yield* contentDigestAt(head.base, head.sha);
+		const content = yield* contentDigestAt(head.mergeBase, head.sha);
 		if (content._tag === "Failure") {
 			return unreadable("the content digest", pr, content.reason);
 		}
 		const diagnostics = [
 			boundLine(VERB, head),
 			scannedLine(VERB, listed.value.length, "changed file"),
-			`${VERB}: content ${content.value} — the digest of ${head.base}...${head.sha} this verdict survives on (ADR 0276).`,
+			`${VERB}: content ${content.value} — the digest of ${head.mergeBase}...${head.sha} this verdict survives on (ADR 0276).`,
 		];
 		if (!derived.includes(namespace)) {
 			return refuse(

--- a/packages/fabrika-cli/src/review/scope-verb.ts
+++ b/packages/fabrika-cli/src/review/scope-verb.ts
@@ -58,7 +58,7 @@ export const runScope = (
 		if (bound._tag === "Refused") return bound.outcome;
 		const head = bound.head;
 
-		const listed = yield* diffRangePaths(head.base, head.sha);
+		const listed = yield* diffRangePaths(head.mergeBase, head.sha);
 		if (listed._tag === "Failure") {
 			return refuse(
 				PRECONDITION_UNKNOWN,
@@ -82,7 +82,7 @@ export const runScope = (
 		if (files.length === 0) {
 			return refuse(
 				INCOMPLETE_SCAN,
-				`${VERB}: git reports no changed files for the range ${head.base}...${head.sha}, so ${head.sha} has nothing to partition — refusing to scope an empty read (#3999).`,
+				`${VERB}: git reports no changed files for the range ${head.mergeBase}...${head.sha}, so ${head.sha} has nothing to partition — refusing to scope an empty read (#3999).`,
 				diagnostics,
 			);
 		}

--- a/packages/fabrika-cli/src/review/scope-verb.unit.test.ts
+++ b/packages/fabrika-cli/src/review/scope-verb.unit.test.ts
@@ -11,6 +11,7 @@ import {
 } from "./codes.ts";
 import {
 	BASE,
+	BASE_TIP,
 	binding,
 	files,
 	HEAD,
@@ -122,11 +123,14 @@ describe("runScope reads the partial-split marker its own builder emits", () => 
 });
 
 describe("runScope refusals and diagnostics", () => {
+	// `binding()` puts `origin/main` ahead of the branch point, so the base on this line naming `BASE`
+	// rather than `BASE_TIP` is what says the verb reports the merge base (#5770).
 	it("reports the commit it bound to, then what it scanned against what was declared", async () => {
 		const out = await run(happy());
 		expect(out.stderr[0]).toBe(
 			`review scope: bound to ${HEAD} (base ${BASE}) — read from the object database, nothing checked out.`,
 		);
+		expect(out.stderr[0]).not.toContain(BASE_TIP);
 		expect(out.stderr[1]).toBe("review scope: scanned 2 changed files; 2 declared by GitHub.");
 	});
 

--- a/packages/fabrika-cli/src/review/verdicts-verb.ts
+++ b/packages/fabrika-cli/src/review/verdicts-verb.ts
@@ -197,7 +197,9 @@ export const runVerdicts = (
 		if (contested && found._tag === "Present") {
 			const bound = yield* bindHead(VERB, repo, pr, found.value, null);
 			const read =
-				bound._tag === "Bound" ? yield* contentDigestAt(bound.head.base, bound.head.sha) : null;
+				bound._tag === "Bound"
+					? yield* contentDigestAt(bound.head.mergeBase, bound.head.sha)
+					: null;
 			if (read !== null && read._tag === "Ok") digest = read.value;
 			else {
 				diagnostics.push(

--- a/packages/fabrika-cli/src/ship/gate-verb.ts
+++ b/packages/fabrika-cli/src/ship/gate-verb.ts
@@ -334,7 +334,7 @@ export const runGate = (
 		if (contested) {
 			const head = yield* bindHead(VERB, repo, pr, pull, options.sha);
 			const digest =
-				head._tag === "Bound" ? yield* contentDigestAt(head.head.base, head.head.sha) : null;
+				head._tag === "Bound" ? yield* contentDigestAt(head.head.mergeBase, head.head.sha) : null;
 			if (digest !== null && digest._tag === "Ok") headDigest = digest.value;
 			else {
 				diagnostics.push(

--- a/packages/fabrika-cli/src/ship/gate-verb.unit.test.ts
+++ b/packages/fabrika-cli/src/ship/gate-verb.unit.test.ts
@@ -418,6 +418,8 @@ describe("requiredWithFloor", () => {
  */
 describe("runGate — staleness is the content question", () => {
 	const BASE = "0f1e2d3c4b5a69788796a5b4c3d2e1f009182736";
+	/** Ahead of {@link BASE}, so the digest is proven to be taken over the branch point (#5770). */
+	const BASE_TIP = "5a4b3c2d1e0f98877665544332211000ffeeddcc";
 	/** The digest of RAW below, written out so the fixture cannot agree with the code by calling it. */
 	const DIGEST = "65ebe421b3c0";
 	const RAW = `:100644 100644 ${"a".repeat(40)} ${"b".repeat(40)} M\0apps/web/src/a.ts\0`;
@@ -431,8 +433,9 @@ describe("runGate — staleness is the content question", () => {
 		[new RegExp(`^git rev-parse --verify --quiet ${HEAD}\\^\\{commit\\}$`), okOut(`${HEAD}\n`)],
 		[/^git remote$/, okOut("origin\n")],
 		[/^git fetch --quiet origin main$/, okOut("")],
-		[/^git rev-parse --verify --quiet origin\/main\^\{commit\}$/, okOut(`${BASE}\n`)],
-		[/^git diff .* --raw --abbrev=40 -z /, raw],
+		[/^git rev-parse --verify --quiet origin\/main\^\{commit\}$/, okOut(`${BASE_TIP}\n`)],
+		[new RegExp(`^git merge-base ${BASE_TIP} ${HEAD}$`), okOut(`${BASE}\n`)],
+		[new RegExp(`^git diff .* --raw --abbrev=40 -z ${BASE}\\.\\.\\.${HEAD}$`), raw],
 	];
 
 	const bindingMarker = (sha: string, content: string | null): string =>


### PR DESCRIPTION
Both scope verbs printed `origin/<baseRef>` — the base branch's current tip — under the name "base".
Under a moving main that value runs *ahead* of the commit the PR branched from, so it diverged by
construction, not intermittently. It cost three agents a hand-correction each in one lane, and lane
6001 hit the same class again the following night.

The binding now resolves both commits and keeps them apart. `BoundHead` carries `baseTip` (where the
base branch is now) and `mergeBase` (where this branch left it), so no caller can read one where it
means the other — the old single `base` field is gone, and the compiler visited every reader.

- `review scope`'s `boundLine()` and `governance scope --json`'s `base` field now report the merge base.
- Every three-dot diff range keeps the exact file set it had: `mergeBase...head` and `baseTip...head`
  resolve the same merge base internally, so nothing about scoping moves.
- `governance guards`' anchored-invariant "before" read is a **point** read, so three-dot semantics
  never covered it. It read main's newest bytes; it now reads the branch point. This is the #6077
  half folded into this issue, and it is the one place a wrong verdict was reachable.
- `governance base` stops re-deriving the merge base itself and takes the binding's — same value, one
  answer instead of two that could drift. An unresolvable merge base refuses `11` inside the binding,
  wearing that verb's own noun, so its message changed and the contract row is updated.

Every test fixture that binds a head now runs against a *moved* main (`BASE_TIP` ahead of `BASE`).
That is what makes the divergence observable at all: with the two collapsed onto one commit, a verb
printing the tip and a verb printing the branch point were indistinguishable from any test. New
`src/review/head.unit.test.ts` pins the binding directly, and a new guards case pins the point read —
verified to fail when the old `head.baseTip` read is put back.

Fixes #5770

## Deviations

None.
