### PR TITLE
fix: Repair-round count buckets by 120s, so gates at one head count as separate rounds

### DIFF
--- a/claude-plugins/fabrika/skills/build/contract.md
+++ b/claude-plugins/fabrika/skills/build/contract.md
@@ -1772,9 +1772,9 @@ fabrika build verdicts --pr 4310 [--repo <owner/name>]
 appended past the freeze. **Each row's `body` is the finding's full text, passed through the
 content gate** — the repair loop consumes findings from here and never raw-fetches a comment,
 which is what keeps AC 3's one-door property over the repair path. `capReached` is
-`rounds >= CAP_ROUND + <cleared rounds>`, over the `CAP_ROUND` in `src/retry-budget.ts` — the
-package's one declared retry budget — plus what the founder cleared through `build clear`; it is
-computed here so the cap is a field read, not a number remembered.)
+`rounds >= <the cap>`, where the cap is the `CAP_ROUND` in `src/retry-budget.ts` — the package's one
+declared retry budget — raised to the round after the highest one the founder cleared through
+`build clear`; it is computed here so the cap is a field read, not a number remembered.)
 
 **Cleared rounds.** `clearances` lists every `cap-cleared` marker on the PR, judged. A row is
 `honoured` only when four clauses hold: its author is in `.fabrika.jsonc`'s `capClearAuthors` set at
@@ -1784,10 +1784,12 @@ configured set narrows the ACL, it never replaces one, ADR 0294), the round it n
 and is not itself a `cap-cleared` marker — the strict adjacency `grill rule` enforces, because
 without it a second bare marker rests on the first grant's own dated marker and every grant after
 the first is authorized by nothing. A row that misses carries the `reason` it missed and grants
-nothing; the ACL is read only for authors the configured set already names. Each
-honoured round adds one to the cap, counted by distinct round, so a re-posted grant buys one round
-and not two — and because a clearance binds the *round* rather than a head SHA, it survives the push
-it exists to permit and is spent the moment the next FAIL round lands. A read that cannot complete —
+nothing; the ACL is read only for authors the configured set already names. The cap is the round
+**after** the highest honoured round, so a grant stamped at any round buys exactly the round it
+names and a re-posted grant buys one round and not two — the old `CAP_ROUND + <grants>` tally held
+that only when the grant landed at exactly `CAP_ROUND`, and a grant past it was inert (#6137).
+Because a clearance binds the *round* rather than a head SHA, it survives the push it exists to
+permit and is spent the moment the next FAIL round lands. A read that cannot complete —
 the config file, a configured team's membership, a named author's permission — is `11`, never an
 empty set.
 
@@ -1797,13 +1799,16 @@ per gate namespace; bind each to the current head (`current: true|false` — a s
 visible *as stale*, never dropped, because "the FAIL is old" and "there is no FAIL" are different
 facts, #4105's class). **Native reviews are their own row kind**, not coerced into markers —
 whether a `CHANGES_REQUESTED` with no marker drives a repair is the open decision #4555; this
-verb reports the state honestly and pre-rules nothing. `rounds` counts distinct FAIL clusters by
-the 120-second gap rule computed over the *full* comment set (v1 counted off a truncated 100-
-comment snapshot, `stepR-round-count.sh` + `stepR1-verdicts.sh:48`; the off-by-one at the cap is
-#4570 — the count here is covered by a unit test at the boundary). **The rule, exactly:** take
-every FAIL-polarity marker comment, sorted by `created_at` ascending; a marker whose gap from
-the previous FAIL marker exceeds 120 seconds starts a new cluster, a gap of exactly 120 seconds
-or less continues the current one; `rounds` is the cluster count. `frozenCriteria` lists
+verb reports the state honestly and pre-rules nothing. `rounds` counts the distinct heads the FAIL
+markers name, computed over the *full* comment set (v1 counted off a truncated 100-comment
+snapshot, `stepR-round-count.sh` + `stepR1-verdicts.sh:48`). **The rule, exactly:** take every
+FAIL-polarity marker comment; the distinct head SHAs they name — matched by the same prefix rule
+that binds a verdict to a head, so an abbreviation and the full SHA are one head — are the rounds.
+A round is one graded head, so two gates grading one head are one round however far apart they
+post. A FAIL naming no readable head cannot join a head's round and is never dropped: those
+cluster among themselves by the inclusive 120-second gap (#4570's boundary, now the fallback's
+only home) and the clusters are added to the head count. Counting by wall clock was #6137 — gate
+latency read as repair effort and burned the cap at twice the real rate. `frozenCriteria` lists
 review-appended acceptance-criterion rows dated at or past `CAP_ROUND`.
 
 **`{"rows": [], ...}` on exit 0 is a proven "no verdicts", readable against the scope line's

--- a/packages/fabrika-cli/src/build/clear-verb.ts
+++ b/packages/fabrika-cli/src/build/clear-verb.ts
@@ -33,7 +33,7 @@
 import type {FileSystem, Path} from "effect";
 import {Effect} from "effect";
 import type {ChildProcessSpawner} from "effect/unstable/process";
-import {effectiveCap, grantedRounds} from "../cap-clearance.ts";
+import {capNote, effectiveCap} from "../cap-clearance.ts";
 import {createComment, getComment, listComments} from "../io/issues.ts";
 import {viewerLogin} from "../io/pulls.ts";
 import {recordClearedRound} from "../lane/clearance.ts";
@@ -41,11 +41,9 @@ import {laneRef, parseKey} from "../lane/key.ts";
 import {CONFIG_PATH} from "../repo-config.ts";
 import {normalizeForReadback} from "../report/compose.ts";
 import {isBareAtReference, renderLeaks, scanBody} from "../report/leaks.ts";
-import {CAP_ROUND} from "../retry-budget.ts";
 import {answer, FAILED, refuse, type VerbOutcome} from "../verb.ts";
 import * as capClearance from "../wire/cap-clearance.ts";
 import {stampOf} from "../wire/grill-marker.ts";
-import {read as readMarker} from "../wire/verdict-marker.ts";
 import {
 	clearancesOn,
 	clearsWriteFloor,
@@ -65,7 +63,7 @@ import {
 	ZERO_SCOPE,
 } from "./codes.ts";
 import {closingTargets, proseOf} from "./pr-body.ts";
-import {countRounds} from "./rounds.ts";
+import {roundsOn} from "./rounds.ts";
 import {openPull, resolveTargetRepo} from "./target.ts";
 
 const VERB = "build clear";
@@ -157,14 +155,7 @@ export const runClear = <R = never>(
 				`${VERB}: cannot read the comments on #${pr}: ${listed.reason} — the round count is UNKNOWN. Nothing was posted.`,
 			);
 		}
-		const rounds = countRounds(
-			listed.value.flatMap((comment) => {
-				const parsed = readMarker(comment.body);
-				return parsed._tag === "Found" && parsed.value.polarity === "FAIL"
-					? [comment.createdAt]
-					: [];
-			}),
-		);
+		const rounds = roundsOn(listed.value);
 		const recorded = yield* clearancesOn(repo, baseRef, listed.value);
 		if (recorded._tag === "Unknown") {
 			return refuse(
@@ -174,7 +165,7 @@ export const runClear = <R = never>(
 		}
 		const granted = grantedFrom(recorded.rows);
 		const cap = effectiveCap(granted);
-		const scopeLine = `${VERB}: ${repo}#${pr} at ${rounds} round(s); cap ${cap} = ${CAP_ROUND} declared + ${grantedRounds(granted)} cleared.`;
+		const scopeLine = `${VERB}: ${repo}#${pr} at ${rounds} round(s); ${capNote(granted)}.`;
 		const held = recorded.rows.find((row) => row.honoured && row.round === rounds);
 		if (held === undefined && rounds < cap) {
 			return refuse(

--- a/packages/fabrika-cli/src/build/clear-verb.unit.test.ts
+++ b/packages/fabrika-cli/src/build/clear-verb.unit.test.ts
@@ -7,7 +7,7 @@ import {compileText} from "../lane/machine.ts";
 import {CAP_ROUND, RETRY_BUDGET} from "../retry-budget.ts";
 import {type DocumentRead, runClear} from "./clear-verb.ts";
 import {AUTHORIZATION_VOID, GRANT_UNAUTHORIZED, PRECONDITION_UNKNOWN, ZERO_SCOPE} from "./codes.ts";
-import {comments, HEAD, pull} from "./fixtures.test-support.ts";
+import {comments, HEAD, PRIOR_HEADS, pull} from "./fixtures.test-support.ts";
 
 const PULL = /^gh api repos\/o\/r\/pulls\/4310$/;
 const COMMENTS = /^gh api --paginate repos\/o\/r\/issues\/4310\/comments/;
@@ -23,12 +23,13 @@ const WORKFLOW = ".fabrika/lanes/4312/workflow.json";
 const NOW = new Date("2026-08-18T07:16:03Z");
 const AUTHORIZATION = 'Founder ruling 2026-08-18: "one more round on this one."';
 
-/** Three FAIL rounds, each its own cluster — the count at which the declared budget is spent. */
-const THREE_ROUNDS = comments(
-	{id: 1, body: `review-code: FAIL @ ${HEAD} — one`, createdAt: "2026-08-18T01:00:00Z"},
-	{id: 2, body: `review-code: FAIL @ ${HEAD} — two`, createdAt: "2026-08-18T02:00:00Z"},
-	{id: 3, body: `review-code: FAIL @ ${HEAD} — three`, createdAt: "2026-08-18T03:00:00Z"},
-);
+/** Three graded heads — three rounds, the count at which the declared budget is spent. */
+const THREE_ROUND_COMMENTS = [
+	{id: 1, body: `review-code: FAIL @ ${PRIOR_HEADS[0]} — one`, createdAt: "2026-08-18T01:00:00Z"},
+	{id: 2, body: `review-code: FAIL @ ${PRIOR_HEADS[1]} — two`, createdAt: "2026-08-18T02:00:00Z"},
+	{id: 3, body: `review-code: FAIL @ ${PRIOR_HEADS[2]} — three`, createdAt: "2026-08-18T03:00:00Z"},
+];
+const THREE_ROUNDS = comments(...THREE_ROUND_COMMENTS);
 
 const CONFIGURED = okOut('{\n\t// the founder accounts\n\t"capClearAuthors": ["@usirin"]\n}\n');
 const POSTED = (id: number): ExecResult => okOut(JSON.stringify({id, html_url: "https://x/y#c"}));
@@ -180,9 +181,7 @@ describe("runClear", () => {
 				[
 					COMMENTS,
 					comments(
-						{id: 1, body: `review-code: FAIL @ ${HEAD} — one`, createdAt: "2026-08-18T01:00:00Z"},
-						{id: 2, body: `review-code: FAIL @ ${HEAD} — two`, createdAt: "2026-08-18T02:00:00Z"},
-						{id: 3, body: `review-code: FAIL @ ${HEAD} — three`, createdAt: "2026-08-18T03:00:00Z"},
+						...THREE_ROUND_COMMENTS,
 						{id: 4, body: AUTHORIZATION, author: "usirin", createdAt: "2026-08-18T03:10:00Z"},
 						{
 							id: 5,
@@ -247,9 +246,7 @@ describe("runClear", () => {
 				[
 					COMMENTS,
 					comments(
-						{id: 1, body: `review-code: FAIL @ ${HEAD} — one`, createdAt: "2026-08-18T01:00:00Z"},
-						{id: 2, body: `review-code: FAIL @ ${HEAD} — two`, createdAt: "2026-08-18T02:00:00Z"},
-						{id: 3, body: `review-code: FAIL @ ${HEAD} — three`, createdAt: "2026-08-18T03:00:00Z"},
+						...THREE_ROUND_COMMENTS,
 						{id: 4, body: AUTHORIZATION, author: "usirin", createdAt: "2026-08-18T03:10:00Z"},
 						{
 							id: 5,

--- a/packages/fabrika-cli/src/build/command.ts
+++ b/packages/fabrika-cli/src/build/command.ts
@@ -470,7 +470,7 @@ const verdicts = leafCommand(
 ).pipe(
 	Command.withShortDescription("The latest gate verdict per namespace at a PR's live head."),
 	Command.withDescription(
-		'The paginated, current-head, per-gate verdict fold on a PR: every comment and every review, the latest marker per gate namespace bound to the live head, native reviews as their OWN row kind (never coerced), the 120-second FAIL round count, capReached, and the criteria frozen after round 2. Prints one JSON object with head, rows, rounds, capReached and frozenCriteria; {"rows":[]} on exit 0 is a proven "no verdicts", readable against the scope line. A stale marker prints as stale, never dropped. Exits 7 (PR proven absent or closed), 11 (the head, any comment page or any review page could not be read — UNKNOWN, never "none"). Example: fabrika build verdicts --pr 4310',
+		'The paginated, current-head, per-gate verdict fold on a PR: every comment and every review, the latest marker per gate namespace bound to the live head, native reviews as their OWN row kind (never coerced), the per-head FAIL round count, capReached, and the criteria frozen after round 2. Prints one JSON object with head, rows, rounds, capReached and frozenCriteria; {"rows":[]} on exit 0 is a proven "no verdicts", readable against the scope line. A stale marker prints as stale, never dropped. Exits 7 (PR proven absent or closed), 11 (the head, any comment page or any review page could not be read — UNKNOWN, never "none"). Example: fabrika build verdicts --pr 4310',
 	),
 );
 

--- a/packages/fabrika-cli/src/build/fixtures.test-support.ts
+++ b/packages/fabrika-cli/src/build/fixtures.test-support.ts
@@ -11,6 +11,19 @@ import type {ExecResult} from "../io/exec.ts";
 export const HEAD = "03135b9188d2be6c0a4b7bd0b7a3ff9c53f0f2b1";
 export const OLD_HEAD = "8f1c2ad4e5b6c7d8e9f0a1b2c3d4e5f6a7b8c9d0";
 
+/**
+ * Heads a repair loop pushed before the live one, newest last.
+ *
+ * A round is one graded head (`./rounds.ts`), so a test that wants N rounds needs N distinct heads;
+ * repeating one head is one round however the timestamps are spread.
+ */
+export const PRIOR_HEADS = [
+	"1a2b3c4d5e6f708192a3b4c5d6e7f8091a2b3c4d",
+	"2b3c4d5e6f708192a3b4c5d6e7f8091a2b3c4d5e",
+	"3c4d5e6f708192a3b4c5d6e7f8091a2b3c4d5e6f",
+	"4d5e6f708192a3b4c5d6e7f8091a2b3c4d5e6f70",
+] as const;
+
 /** What `git rev-parse` names for a checkout: its git dir, then its tree root. */
 export const GIT_DIRS = okOut(["/repo/trees/lane-a/.git", "/repo/trees/lane-a"].join("\n"));
 

--- a/packages/fabrika-cli/src/build/rounds.ts
+++ b/packages/fabrika-cli/src/build/rounds.ts
@@ -1,30 +1,87 @@
 /**
- * How many repair rounds a PR has been through, counted by clustering FAIL markers in time.
+ * How many repair rounds a PR has been through, counted by the heads its FAIL markers name.
  *
- * A gate's FAIL often arrives as several comments seconds apart, so counting comments would count one
- * round several times. The rule, pinned so two implementations agree: FAIL-polarity markers sorted by
- * `created_at` ascending; a marker whose gap from the previous FAIL **exceeds** 120 seconds starts a
- * new cluster, and a gap of **exactly** 120 seconds or less continues the current one.
+ * A round is one graded head, not one span of wall-clock time. Every gate writes the head SHA it
+ * inspected into its marker, so every FAIL at one head is one round however far apart the gates
+ * post, and the count moves only when a new head is pushed and graded.
  *
- * The boundary is stated because it is where the off-by-one lived (#4570), and it is counted over the
- * **full** comment set — v1 counted off a truncated 100-comment snapshot (`stepR-round-count.sh` +
- * `stepR1-verdicts.sh:48`), which under-counts exactly when the cap matters most.
+ * The rule used to be a 120-second cluster over `created_at`, which counted gate latency as repair
+ * effort: two gates grading one head 8 minutes apart read as two rounds, so a PR burned its cap at
+ * twice the real rate and escalated with rounds left (#6137, seen on #6122). #4570's inclusive-gap
+ * boundary belonged to that rule and now governs only the head-less fallback below.
+ *
+ * Heads are matched the way a verdict is bound to one — `sameHead`'s prefix rule in
+ * `../wire/marker-line.ts` — so an abbreviated SHA and the full SHA it abbreviates are one round.
+ *
+ * **A FAIL whose head is unreadable is counted, never dropped.** It cannot join a head's round, so
+ * the head-less FAILs cluster among themselves by {@link ROUND_GAP_MS} and those clusters are added
+ * to the head count. Under-counting here would hand a lane repair rounds nobody granted. A comment
+ * whose marker does not parse at all is a different fact and stays out of the count: it is not a
+ * proven FAIL, and the repair loop does not act on one either.
  */
 
-/** The gap at which a FAIL still belongs to the round before it. Inclusive. */
+import type {CommentRecord} from "../io/issues.ts";
+import {type HeadSha, headSha, sameHead} from "../wire/marker-line.ts";
+import {read as readMarker} from "../wire/verdict-marker.ts";
+
+/** The gap at which a head-less FAIL still belongs to the round before it. Inclusive. */
 export const ROUND_GAP_MS = 120_000;
 
-/** Cluster FAIL timestamps into rounds. An empty input is zero rounds, which is a fact, not a gap. */
-export const countRounds = (createdAt: ReadonlyArray<string>): number => {
+/** One FAIL verdict as the counter reads it: the head it graded, and when it landed. */
+export interface FailedHead {
+	/** `null` when the marker named no readable head — the fallback below, never a dropped round. */
+	readonly sha: string | null;
+	readonly createdAt: string;
+}
+
+/** Cluster head-less FAIL timestamps by the inclusive 120-second gap. */
+const timeClusters = (createdAt: ReadonlyArray<string>): number => {
 	const times = createdAt
 		.map((at) => Date.parse(at))
 		.filter((ms) => !Number.isNaN(ms))
 		.sort((a, b) => a - b);
-	let rounds = 0;
+	let clusters = 0;
 	let previous: number | null = null;
 	for (const ms of times) {
-		if (previous === null || ms - previous > ROUND_GAP_MS) rounds += 1;
+		if (previous === null || ms - previous > ROUND_GAP_MS) clusters += 1;
 		previous = ms;
 	}
-	return rounds;
+	return clusters;
 };
+
+/**
+ * Count the rounds a set of FAIL verdicts represents. No FAILs is zero rounds, which is a fact.
+ *
+ * Distinct heads are collected in encounter order against `sameHead`, so a 7-character SHA and the
+ * 40-character one it abbreviates land in one round rather than in two.
+ */
+export const countRounds = (failed: ReadonlyArray<FailedHead>): number => {
+	const heads: HeadSha[] = [];
+	const headless: string[] = [];
+	for (const fail of failed) {
+		const sha = fail.sha === null ? null : headSha(fail.sha);
+		if (sha === null) {
+			headless.push(fail.createdAt);
+			continue;
+		}
+		if (!heads.some((seen) => sameHead(seen, sha))) heads.push(sha);
+	}
+	return heads.length + timeClusters(headless);
+};
+
+/**
+ * The round count of a PR, off its full comment set — the one derivation both call sites take.
+ *
+ * `build verdicts` and `build clear` judge the same budget, so both read the count through this
+ * function rather than each folding the comments their own way. Two answers about one PR is how a
+ * founder's cleared round gets stamped against a number the other reader does not hold (#6137).
+ */
+export const roundsOn = (comments: ReadonlyArray<CommentRecord>): number =>
+	countRounds(
+		comments.flatMap((comment) => {
+			const parsed = readMarker(comment.body);
+			return parsed._tag === "Found" && parsed.value.polarity === "FAIL"
+				? [{sha: parsed.value.sha, createdAt: comment.createdAt}]
+				: [];
+		}),
+	);

--- a/packages/fabrika-cli/src/build/rounds.unit.test.ts
+++ b/packages/fabrika-cli/src/build/rounds.unit.test.ts
@@ -1,37 +1,127 @@
 import {describe, expect, it} from "vitest";
-import {countRounds, ROUND_GAP_MS} from "./rounds.ts";
+import type {CommentRecord} from "../io/issues.ts";
+import {countRounds, ROUND_GAP_MS, roundsOn} from "./rounds.ts";
 
 const at = (secondsFromStart: number) =>
 	new Date(1_770_000_000_000 + secondsFromStart * 1000).toISOString();
 
-describe("countRounds clusters FAIL markers by the 120-second gap rule", () => {
+const comment = (id: number, body: string, createdAt: string): CommentRecord => ({
+	id,
+	author: "a-gate",
+	createdAt,
+	updatedAt: createdAt,
+	body,
+});
+
+const HEAD_A = "73d6db5a1c2e4f60b8d9a0c1e2f3a4b5c6d7e8f9";
+const HEAD_B = "b640e87f1a2b3c4d5e6f708192a3b4c5d6e7f809";
+
+describe("countRounds counts one round per graded head", () => {
 	it("counts no FAILs as zero rounds — a fact, not a gap", () => {
 		expect(countRounds([])).toBe(0);
 	});
 
-	it("folds a burst of markers seconds apart into one round", () => {
-		expect(countRounds([at(0), at(3), at(9)])).toBe(1);
+	it("folds every FAIL at one head into one round, however far apart they post", () => {
+		expect(
+			countRounds([
+				{sha: HEAD_A, createdAt: at(0)},
+				{sha: HEAD_A, createdAt: at(600)},
+				{sha: HEAD_A, createdAt: at(4000)},
+			]),
+		).toBe(1);
 	});
 
 	/**
-	 * The boundary is the whole point of pinning the rule: 120 seconds *continues* the round and 121
-	 * starts a new one. Off by one here is #4570, and it decides whether the cap has been reached.
+	 * PR #6122's shape: two heads, two gates each, 8 and 4 minutes between the gates at one head.
+	 * The wall-clock rule read this as four rounds and spent the cap on gate latency (#6137).
 	 */
-	it("continues the round at EXACTLY 120 seconds and starts a new one at 121", () => {
-		expect(ROUND_GAP_MS).toBe(120_000);
-		expect(countRounds([at(0), at(120)])).toBe(1);
-		expect(countRounds([at(0), at(121)])).toBe(2);
+	it("counts #6122's four markers over two heads as two rounds", () => {
+		expect(
+			countRounds([
+				{sha: HEAD_A, createdAt: "2026-08-18T20:36:29Z"},
+				{sha: HEAD_A, createdAt: "2026-08-18T20:44:35Z"},
+				{sha: HEAD_B, createdAt: "2026-08-18T20:56:57Z"},
+				{sha: HEAD_B, createdAt: "2026-08-18T21:01:05Z"},
+			]),
+		).toBe(2);
 	});
 
-	it("counts three separated markers as three rounds", () => {
-		expect(countRounds([at(0), at(300), at(600)])).toBe(3);
+	it("counts two heads graded seconds apart as two rounds — time is not the axis", () => {
+		expect(
+			countRounds([
+				{sha: HEAD_A, createdAt: at(0)},
+				{sha: HEAD_B, createdAt: at(1)},
+			]),
+		).toBe(2);
 	});
 
-	it("sorts before clustering, so an out-of-order list counts the same", () => {
-		expect(countRounds([at(600), at(0), at(300)])).toBe(3);
+	it("reads an abbreviated SHA and the full one it abbreviates as one head", () => {
+		expect(
+			countRounds([
+				{sha: HEAD_A.slice(0, 7), createdAt: at(0)},
+				{sha: HEAD_A, createdAt: at(600)},
+			]),
+		).toBe(1);
 	});
 
-	it("ignores an unparseable timestamp rather than treating it as time zero", () => {
-		expect(countRounds(["not a date", at(0), at(3)])).toBe(1);
+	it("is order-independent, so a list read out of order counts the same", () => {
+		expect(
+			countRounds([
+				{sha: HEAD_B, createdAt: at(600)},
+				{sha: HEAD_A, createdAt: at(0)},
+				{sha: HEAD_B, createdAt: at(10)},
+			]),
+		).toBe(2);
+	});
+
+	describe("a FAIL whose head is unreadable", () => {
+		it("still counts, clustered by the inclusive 120-second gap", () => {
+			expect(ROUND_GAP_MS).toBe(120_000);
+			expect(
+				countRounds([
+					{sha: null, createdAt: at(0)},
+					{sha: null, createdAt: at(120)},
+				]),
+			).toBe(1);
+			expect(
+				countRounds([
+					{sha: null, createdAt: at(0)},
+					{sha: null, createdAt: at(121)},
+				]),
+			).toBe(2);
+		});
+
+		it("adds its clusters to the head count rather than joining a head's round", () => {
+			expect(
+				countRounds([
+					{sha: HEAD_A, createdAt: at(0)},
+					{sha: "not a sha", createdAt: at(5)},
+				]),
+			).toBe(2);
+		});
+
+		it("counts nothing for a timestamp that does not parse either", () => {
+			expect(countRounds([{sha: null, createdAt: "not a date"}])).toBe(0);
+		});
+	});
+});
+
+describe("roundsOn folds a PR's comments — the one derivation both call sites take", () => {
+	it("counts only FAIL markers, by their heads", () => {
+		const page = [
+			comment(1, `governance: FAIL @ ${HEAD_A} — the ADR collides`, at(0)),
+			comment(2, `review-doc: FAIL @ ${HEAD_A} — the same head, later`, at(600)),
+			comment(3, `review-code: PASS @ ${HEAD_B} — merge-ready`, at(700)),
+			comment(4, "just a normal comment", at(800)),
+		];
+		expect(roundsOn(page)).toBe(1);
+	});
+
+	it("moves the count only when a new head is graded", () => {
+		const page = [
+			comment(1, `governance: FAIL @ ${HEAD_A} — one`, at(0)),
+			comment(2, `governance: FAIL @ ${HEAD_B} — two`, at(600)),
+		];
+		expect(roundsOn(page)).toBe(2);
 	});
 });

--- a/packages/fabrika-cli/src/build/verdicts-verb.ts
+++ b/packages/fabrika-cli/src/build/verdicts-verb.ts
@@ -21,7 +21,7 @@
  */
 import {Effect} from "effect";
 import type {ChildProcessSpawner} from "effect/unstable/process";
-import {capReached, effectiveCap, grantedRounds} from "../cap-clearance.ts";
+import {capNote, capReached} from "../cap-clearance.ts";
 import {getIssue, listComments} from "../io/issues.ts";
 import {CAP_ROUND} from "../retry-budget.ts";
 import {answer, refuse, type VerbOutcome} from "../verb.ts";
@@ -32,7 +32,7 @@ import {PRECONDITION_UNKNOWN} from "./codes.ts";
 import {contentOf, gate} from "./content-gate.ts";
 import {listReviews} from "./github.ts";
 import {closingTargets, proseOf} from "./pr-body.ts";
-import {countRounds} from "./rounds.ts";
+import {roundsOn} from "./rounds.ts";
 import {openPull, resolveTargetRepo} from "./target.ts";
 
 const VERB = "build verdicts";
@@ -91,14 +91,13 @@ export const runVerdicts = (
 			);
 		}
 
-		// Latest marker per gate namespace, and every FAIL's timestamp for the round count.
+		// Latest marker per gate namespace. The round count is `roundsOn`'s, so this verb and `build
+		// clear` cannot disagree about how many rounds the PR has been through (#6137).
 		const latest = new Map<string, Row>();
-		const failedAt: string[] = [];
 		for (const comment of listed.value) {
 			const parsed = readMarker(comment.body);
 			if (parsed._tag !== "Found") continue;
 			const marker = parsed.value;
-			if (marker.polarity === "FAIL") failedAt.push(comment.createdAt);
 			latest.set(marker.namespace, {
 				gate: marker.namespace,
 				polarity: marker.polarity,
@@ -123,7 +122,7 @@ export const runVerdicts = (
 			});
 		}
 
-		const rounds = countRounds(failedAt);
+		const rounds = roundsOn(listed.value);
 		const cleared = yield* clearancesOn(repo, target.pull.baseRef, listed.value);
 		if (cleared._tag === "Unknown") {
 			return refuse(
@@ -151,7 +150,7 @@ export const runVerdicts = (
 			}),
 			[
 				`${VERB}: head ${head}; scanned ${listed.value.length} comment(s) and ${reviews.value.length} review(s) on #${pr}.`,
-				`${VERB}: cap ${effectiveCap(granted)} = ${CAP_ROUND} declared + ${grantedRounds(granted)} cleared round(s), from ${cleared.rows.length} marker(s).`,
+				`${VERB}: ${capNote(granted)}, from ${cleared.rows.length} marker(s).`,
 			],
 		);
 	});

--- a/packages/fabrika-cli/src/build/verdicts-verb.unit.test.ts
+++ b/packages/fabrika-cli/src/build/verdicts-verb.unit.test.ts
@@ -3,7 +3,7 @@ import {describe, expect, it} from "vitest";
 import {errOut, fakeShell, okOut} from "../fakes.test-support.ts";
 import type {ExecResult} from "../io/exec.ts";
 import {PRECONDITION_UNKNOWN, ZERO_SCOPE} from "./codes.ts";
-import {comments, HEAD, issue, OLD_HEAD, pull} from "./fixtures.test-support.ts";
+import {comments, HEAD, issue, OLD_HEAD, PRIOR_HEADS, pull} from "./fixtures.test-support.ts";
 import {runVerdicts} from "./verdicts-verb.ts";
 
 const PULL = /^gh api repos\/o\/r\/pulls\/4310$/;
@@ -12,6 +12,7 @@ const REVIEWS = /^gh api --paginate repos\/o\/r\/pulls\/4310\/reviews/;
 const ISSUE = /^gh api repos\/o\/r\/issues\/4312$/;
 
 const FAIL_NOW = `review-code: FAIL @ ${HEAD} — the debounce fix races the unmount`;
+const failAt = (sha: string) => `review-code: FAIL @ ${sha} — the debounce fix races the unmount`;
 const PASS_STALE = `review-doc: PASS @ ${OLD_HEAD} — guide matches shipped behavior`;
 
 const NO_REVIEWS = okOut("[]");
@@ -93,10 +94,10 @@ describe("runVerdicts", () => {
 			[
 				COMMENTS,
 				comments(
-					{id: 1, body: FAIL_NOW, createdAt: at(0)},
-					{id: 2, body: FAIL_NOW, createdAt: at(5)},
-					{id: 3, body: FAIL_NOW, createdAt: at(400)},
-					{id: 4, body: FAIL_NOW, createdAt: at(900)},
+					{id: 1, body: failAt(PRIOR_HEADS[0]), createdAt: at(0)},
+					{id: 2, body: failAt(PRIOR_HEADS[0]), createdAt: at(5)},
+					{id: 3, body: failAt(PRIOR_HEADS[1]), createdAt: at(400)},
+					{id: 4, body: failAt(PRIOR_HEADS[2]), createdAt: at(900)},
 				),
 			],
 			[REVIEWS, NO_REVIEWS],
@@ -105,6 +106,46 @@ describe("runVerdicts", () => {
 		const parsed = JSON.parse(out.stdout);
 		expect(parsed.rounds).toBe(3);
 		expect(parsed.capReached).toBe(true);
+	});
+
+	/**
+	 * PR #6122: two heads, two gates each, minutes between the gates at one head. The wall-clock rule
+	 * read this as four rounds and spent the cap on gate latency (#6137).
+	 */
+	it("counts two gates grading one head as ONE round, however far apart they post", async () => {
+		const out = await run([
+			[PULL, PR],
+			[
+				COMMENTS,
+				comments(
+					{
+						id: 1,
+						body: `governance: FAIL @ ${PRIOR_HEADS[0]} — the ADR collides`,
+						createdAt: "2026-08-18T20:36:29Z",
+					},
+					{
+						id: 2,
+						body: `review-doc: FAIL @ ${PRIOR_HEADS[0]} — the guide drifted`,
+						createdAt: "2026-08-18T20:44:35Z",
+					},
+					{
+						id: 3,
+						body: `governance: FAIL @ ${HEAD} — the ADR still collides`,
+						createdAt: "2026-08-18T20:56:57Z",
+					},
+					{
+						id: 4,
+						body: `review-doc: FAIL @ ${HEAD} — the guide still drifted`,
+						createdAt: "2026-08-18T21:01:05Z",
+					},
+				),
+			],
+			[REVIEWS, NO_REVIEWS],
+			[ISSUE, issue()],
+		]);
+		const parsed = JSON.parse(out.stdout);
+		expect(parsed.rounds).toBe(2);
+		expect(parsed.capReached).toBe(false);
 	});
 
 	it("lists only the criteria appended AFTER round 2, by their provenance tag", async () => {
@@ -143,7 +184,7 @@ describe("runVerdicts", () => {
 		expect(parsed.rows).toEqual([]);
 		expect(parsed.rounds).toBe(0);
 		expect(out.stderr.join("\n")).toContain("scanned 1 comment(s) and 0 review(s)");
-		expect(out.stderr.at(-1)).toContain("cap 3 = 3 declared + 0 cleared round(s)");
+		expect(out.stderr.at(-1)).toContain("cap 3 = 3 declared, nothing cleared");
 	});
 
 	it("refuses a proven-absent PR on 7", async () => {
@@ -190,10 +231,23 @@ describe("runVerdicts", () => {
 		const PERMISSION = /^gh api repos\/o\/r\/collaborators\/usirin\/permission/;
 		const WRITES = okOut("admin\n");
 		const AUTHORIZATION = 'Founder ruling 2026-08-18: "one more round."';
+		// Three graded heads, so three rounds — a round is a head, not a span of clock (#6137).
 		const CAPPED = [
-			{id: 1, body: `review-code: FAIL @ ${HEAD} — one`, createdAt: "2026-08-18T01:00:00Z"},
-			{id: 2, body: `review-code: FAIL @ ${HEAD} — two`, createdAt: "2026-08-18T02:00:00Z"},
-			{id: 3, body: `review-code: FAIL @ ${HEAD} — three`, createdAt: "2026-08-18T03:00:00Z"},
+			{
+				id: 1,
+				body: `review-code: FAIL @ ${PRIOR_HEADS[0]} — one`,
+				createdAt: "2026-08-18T01:00:00Z",
+			},
+			{
+				id: 2,
+				body: `review-code: FAIL @ ${PRIOR_HEADS[1]} — two`,
+				createdAt: "2026-08-18T02:00:00Z",
+			},
+			{
+				id: 3,
+				body: `review-code: FAIL @ ${PRIOR_HEADS[2]} — three`,
+				createdAt: "2026-08-18T03:00:00Z",
+			},
 		];
 		const GRANT = [
 			{id: 4, body: AUTHORIZATION, author: "usirin", createdAt: "2026-08-18T03:10:00Z"},

--- a/packages/fabrika-cli/src/cap-clearance.ts
+++ b/packages/fabrika-cli/src/cap-clearance.ts
@@ -14,6 +14,13 @@
  * than the head SHA is deliberate — a clearance exists precisely so a *new* head can be pushed, so a
  * head-bound grant would be void the instant it was used.
  *
+ * **The cap is the round after the highest cleared one, not the declared cap plus a tally.** Adding
+ * one per grant held that invariant only when the grant landed at exactly {@link CAP_ROUND}: a
+ * clearance stamped at round 4 with no prior grant raised the cap to 4, so `capReached(4, [4])` was
+ * still true and the granted round could not be built (#6137, which parked #6122 with an honoured
+ * clearance buying nothing). Taking the maximum is the same number whenever the grants are the
+ * contiguous run from `CAP_ROUND` up, and the right one when they are not.
+ *
  * A round below {@link CAP_ROUND} is never counted. Nothing can be cleared before the budget is
  * spent, so such a marker is either hand-written or from a drifted writer, and counting it would
  * silently widen the cap by a round nobody granted.
@@ -21,23 +28,59 @@
 
 import {CAP_ROUND, RETRY_BUDGET} from "./retry-budget.ts";
 
+/** The recorded rounds that are grants at all: whole numbers at or past the declared cap. */
+const honoured = (cleared: ReadonlyArray<number>): ReadonlyArray<number> =>
+	cleared.filter((round) => Number.isInteger(round) && round >= CAP_ROUND);
+
 /**
- * How many extra rounds a set of recorded clearances buys.
+ * How many distinct rounds a set of recorded clearances names — what a scope line reports.
  *
  * Distinct rounds, not markers: two clearances stamped at the same round clear the same round, so a
- * double-posted grant — a re-run, a reconciled write — can never buy two.
+ * double-posted grant — a re-run, a reconciled write — can never read as two.
  */
 export const grantedRounds = (cleared: ReadonlyArray<number>): number =>
-	new Set(cleared.filter((round) => Number.isInteger(round) && round >= CAP_ROUND)).size;
+	new Set(honoured(cleared)).size;
 
-/** The round the loop freezes at, given what has been cleared. {@link CAP_ROUND} plus the grants. */
-export const effectiveCap = (cleared: ReadonlyArray<number>): number =>
-	CAP_ROUND + grantedRounds(cleared);
+/** The highest round a clearance names, or `null` when nothing was cleared. */
+export const highestCleared = (cleared: ReadonlyArray<number>): number | null => {
+	const rounds = honoured(cleared);
+	return rounds.length === 0 ? null : Math.max(...rounds);
+};
 
-/** The retries a lane task holds, given what has been cleared. {@link RETRY_BUDGET} plus the grants. */
+/** The freeze round for a declared cap, given what has been cleared — the derivation both readers take. */
+export const capWith = (declaredCap: number, cleared: ReadonlyArray<number>): number => {
+	const highest = highestCleared(cleared);
+	return highest === null ? declaredCap : Math.max(declaredCap, highest + 1);
+};
+
+/** The round the loop freezes at, given what has been cleared. */
+export const effectiveCap = (cleared: ReadonlyArray<number>): number => capWith(CAP_ROUND, cleared);
+
+/** The retries a lane task holds, given what has been cleared. One below the cap it freezes at. */
 export const effectiveBudget = (cleared: ReadonlyArray<number>): number =>
-	RETRY_BUDGET + grantedRounds(cleared);
+	budgetWith(RETRY_BUDGET, cleared);
+
+/**
+ * The retries a lane task with its own declared budget holds. The lane guard fires at
+ * `retries >= maxRetries`, one round below the cap, so the two readers spend one grant identically.
+ */
+export const budgetWith = (declaredBudget: number, cleared: ReadonlyArray<number>): number =>
+	capWith(declaredBudget + 1, cleared) - 1;
 
 /** Whether the repair loop is out of budget — the one field `build`'s Repair section trusts. */
 export const capReached = (rounds: number, cleared: ReadonlyArray<number>): boolean =>
 	rounds >= effectiveCap(cleared);
+
+/**
+ * The one phrase both verbs put the cap on a scope line with.
+ *
+ * Written as the derivation actually runs — the round after the highest grant — so an operator
+ * reading it can check the arithmetic against the markers instead of against a tally that no longer
+ * explains the number (#6137).
+ */
+export const capNote = (cleared: ReadonlyArray<number>): string => {
+	const highest = highestCleared(cleared);
+	return highest === null
+		? `cap ${effectiveCap(cleared)} = ${CAP_ROUND} declared, nothing cleared`
+		: `cap ${effectiveCap(cleared)} = the round after cleared round ${highest} (${CAP_ROUND} declared, ${grantedRounds(cleared)} cleared round(s))`;
+};

--- a/packages/fabrika-cli/src/cap-clearance.unit.test.ts
+++ b/packages/fabrika-cli/src/cap-clearance.unit.test.ts
@@ -1,9 +1,15 @@
 import {describe, expect, it} from "vitest";
-import {capReached, effectiveBudget, effectiveCap, grantedRounds} from "./cap-clearance.ts";
+import {
+	budgetWith,
+	capReached,
+	effectiveBudget,
+	effectiveCap,
+	grantedRounds,
+} from "./cap-clearance.ts";
 import {CAP_ROUND, RETRY_BUDGET} from "./retry-budget.ts";
 
 describe("grantedRounds", () => {
-	it("counts distinct rounds, so a double-posted grant buys one round and not two", () => {
+	it("counts distinct rounds, so a double-posted grant reads as one and not two", () => {
 		expect(grantedRounds([CAP_ROUND, CAP_ROUND])).toBe(1);
 		expect(grantedRounds([CAP_ROUND, CAP_ROUND + 1])).toBe(2);
 	});
@@ -39,6 +45,22 @@ describe("capReached", () => {
 		expect(capReached(CAP_ROUND + 1, [CAP_ROUND, CAP_ROUND + 1])).toBe(false);
 		expect(capReached(CAP_ROUND + 2, [CAP_ROUND, CAP_ROUND + 1])).toBe(true);
 	});
+
+	/**
+	 * The grant a founder stamps past the declared cap is the one #6137 found inert: with the cap
+	 * tallied as `CAP_ROUND + grants` it landed exactly ON the new cap and bought nothing, so #6122
+	 * sat with an honoured clearance and no round to build.
+	 */
+	it.each([
+		CAP_ROUND,
+		CAP_ROUND + 1,
+		CAP_ROUND + 4,
+		CAP_ROUND + 9,
+	])("lets round %i through when the grant was stamped at it, with no earlier grant", (round) => {
+		expect(capReached(round, [round])).toBe(false);
+		expect(capReached(round + 1, [round])).toBe(true);
+		expect(effectiveCap([round])).toBe(round + 1);
+	});
 });
 
 /**
@@ -58,7 +80,16 @@ describe("the lane guard and the verdict fold spend the same grant", () => {
 		{rounds: CAP_ROUND + 1, cleared: [CAP_ROUND]},
 		{rounds: CAP_ROUND + 1, cleared: [CAP_ROUND, CAP_ROUND + 1]},
 		{rounds: CAP_ROUND + 2, cleared: [CAP_ROUND, CAP_ROUND + 1]},
+		{rounds: CAP_ROUND + 3, cleared: [CAP_ROUND + 3]},
+		{rounds: CAP_ROUND + 4, cleared: [CAP_ROUND + 3]},
 	])("agrees at $rounds round(s) with $cleared cleared", ({rounds, cleared}) => {
 		expect(laneFreezes(rounds, cleared)).toBe(capReached(rounds, cleared));
+	});
+
+	/** A lane carrying its own declared budget spends the grant the same way. */
+	it("holds for a lane whose template declares a budget of its own", () => {
+		expect(budgetWith(5, [])).toBe(5);
+		expect(budgetWith(5, [CAP_ROUND + 3])).toBe(CAP_ROUND + 3);
+		expect(budgetWith(1, [CAP_ROUND])).toBe(CAP_ROUND);
 	});
 });

--- a/packages/fabrika-cli/src/lane/machine.ts
+++ b/packages/fabrika-cli/src/lane/machine.ts
@@ -20,7 +20,7 @@
  */
 import type {Machine} from "@demlik/tea";
 import {defineMachine} from "@demlik/tea";
-import {grantedRounds} from "../cap-clearance.ts";
+import {budgetWith} from "../cap-clearance.ts";
 import {RETRY_BUDGET} from "../retry-budget.ts";
 
 /** The operator's whole event vocabulary — the six, closed (#5570 founder session, 2026-08-15). */
@@ -174,12 +174,12 @@ const compileRegion = (taskId: string, region: unknown, context: unknown): Regio
 
 	const ctx = isRecord(context) ? context : {};
 	const declared = typeof ctx.maxRetries === "number" ? ctx.maxRetries : RETRY_BUDGET;
-	// The founder's cleared rounds are additive on the declared budget, so the lane guard and
-	// `build verdicts`'s `capReached` spend the same grant — see `../cap-clearance.ts` (#5959).
+	// The lane guard and `build verdicts`'s `capReached` spend one grant identically, which is why the
+	// budget is derived there rather than tallied here — see `../cap-clearance.ts` (#5959, #6137).
 	const cleared = Array.isArray(ctx.clearedRounds)
 		? ctx.clearedRounds.filter((round): round is number => typeof round === "number")
 		: [];
-	const maxRetries = declared + grantedRounds(cleared);
+	const maxRetries = budgetWith(declared, cleared);
 	const {maxRetries: _max, retries: _retries, ...extras} = ctx;
 	const initial: TaskState = {type: initialState, retries: 0, maxRetries};
 	// The Transitions mapped type demands a cell for every (state × msg) pair; a lane machine is


### PR DESCRIPTION
Fixes #6137

A repair round is now the head its FAIL markers name, not a 120-second cluster of timestamps. Two gates grading one head minutes apart used to count as two rounds, so every PR burned its repair budget at 2-3x the real rate.

The cap arithmetic is fixed with it: the effective cap is the round **after** the highest cleared round, not `CAP_ROUND + <number of grants>`. The old tally only raised the cap above the grant when the grant landed at exactly `CAP_ROUND` — a grant stamped past it landed *on* the new cap and bought nothing.

- `countRounds` takes `{sha, createdAt}` entries and counts distinct heads, matched by the same prefix rule that binds a verdict to a head. A FAIL with no readable head clusters by the old 120-second gap and those clusters are added, so nothing is dropped.
- `roundsOn(comments)` is the one derivation `build verdicts` and `build clear` both call, so they cannot disagree about a PR's round count.
- `effectiveCap` / `effectiveBudget` derive from `capWith`, and `lane/machine.ts` takes its `maxRetries` from `budgetWith` so the lane guard and the fold still spend one grant identically.

Run live against the PR that was parked: `build verdicts --pr 6122` now reports `rounds: 2`, `capReached: false`, with the honoured round-4 clearance actually buying its round.

## Deviations

- **Out-of-scope change** — **Said:** #6137 names `rounds.ts`, `cap-clearance.ts` and the two verbs. **Did:** also changed `packages/fabrika-cli/src/lane/machine.ts`, which computed `maxRetries` as `declared + grantedRounds(cleared)`. **Why:** it is the second enforcement site of the same cap; leaving the tally there would make the lane freeze one round early at exactly the round this fix exists to release, and `cap-clearance.unit.test.ts` pins the two together. **Disposition:** stated here.
- **Scope narrowing** — **Said:** a FAIL marker with no readable head SHA is still counted. **Did:** the counter counts one (a `sha: null` entry clusters by the 120-second gap), but a comment whose marker does not parse at all stays outside the count, exactly as before. **Why:** `verdict-marker`'s read yields no polarity for a malformed marker, so counting one would count a malformed PASS as a repair round. **Disposition:** stated here and in the `rounds.ts` docblock beside the rule.
- **Out-of-scope change** — **Said:** nothing about verb output. **Did:** the stderr scope line on `build verdicts` and `build clear` changed from `cap 4 = 3 declared + 1 cleared round(s)` to `cap 5 = the round after cleared round 4 (3 declared, 1 cleared round(s))`, through one shared `capNote`. **Why:** the old phrase states the arithmetic this PR removes, so it would have printed a sum that no longer explains the number. **Disposition:** stated here; the assertion in `verdicts-verb.unit.test.ts` moved with it.
