### PR TITLE
feat: Implement the frozen-state UNBLOCKED door the 5909 ruling recorded

### DIFF
--- a/.decisions/0297-frozen-is-a-park-not-an-end.md
+++ b/.decisions/0297-frozen-is-a-park-not-an-end.md
@@ -62,7 +62,10 @@ exactly one round.
 A region booted straight into `frozen` — an epic child whose issue was closed without landing — left
 no prior state behind it, so its door resolves back to the park itself. The fold refuses that
 `UNBLOCKED` rather than recording a resume that did not move; such a child is re-emitted, not
-unfrozen.
+unfrozen. That refusal is read off the task's own state, never off the lane's fold: an epic phase
+holding a booted-`frozen` child beside a still-open sibling never folds at all, so the lane is
+`active` and a fold-gated check would let the no-op resume through on exactly the shape the epic
+emitter produces.
 
 **Binding constraints.**
 

--- a/.decisions/0297-frozen-is-a-park-not-an-end.md
+++ b/.decisions/0297-frozen-is-a-park-not-an-end.md
@@ -1,0 +1,90 @@
+---
+id: 0297
+title: A lane task's `frozen` is a park with a door out, and the door hands out no retries
+status: accepted
+date: 2026-08-18
+tags: [fabrika, lane, pipeline, state-machine]
+---
+
+# 0297 — A lane task's `frozen` is a park with a door out, and the door hands out no retries
+
+**What this decides:** a task that burned its retry budget can be sent back into the run by a
+recorded `UNBLOCKED`, it still trips the lane while it sits there, and coming back buys it nothing —
+the next failure freezes it again.
+
+## Context
+
+`frozen` was `{"type": "final"}` in all three lane machine sources — the coder template, the chore
+template, and the epic-child machine `lane/emit.ts` builds — with no event out of it. When the
+founder granted an extra repair round on a lane already sitting in `frozen`, the grant could only
+exist as issue prose the machine cannot see. Two milestone-46 lanes were stuck on exactly that at
+filing (#6006 under epic 5817, and 6037).
+
+The founder ruled it on [#5909](https://github.com/kamp-us/phoenix/issues/5909): option 1, a door
+back to the state the task left, retries held. Option 2 — abandon the frozen lane and open a fresh
+one per clearance — lost because a lane is the whole run's ledger for one issue
+(ADR [0283](0283-local-ledger-holds-ownable-orderings.md)): a second lane splits one issue's history
+across two ledgers, restarts the retry count at zero, and hands the loop a fresh budget nobody
+granted. The thing a clearance exists to buy is one more round, not a clean slate.
+
+The load-bearing constraint is that the compiler derives its sets structurally, never by name
+(ADR [0290](0290-retire-epic-conduction-onto-lane-machines.md) is what put every epic on this
+machine). `finals` is exactly the `type: "final"` states; a guarded FAIL's fallthrough joins
+`errorFinals` only when it is in `finals`; and `deriveStatus` reads a task as the lane's error
+condition off `errorFinals`. Dropping `"type": "final"` from `frozen` to give it an `on` would have
+taken it out of both sets at once: a frozen lane would stop reading as tripped, and its phase would
+never fold at all, so the run would hang instead of ending loud.
+
+## Decision
+
+**A `final` that carries an `on` is a park rather than an end: it stays in `finals` and
+`errorFinals`, and the door out stays walkable.**
+
+`frozen` keeps `"type": "final"` and gains `"<TASK>.UNBLOCKED": "hist"` in all three machine
+sources. Nothing about the trip changes — the phase still folds on it, `lane status` still reads it
+as the lane's error condition, and a lane whose only unfinished task is frozen still ends at
+`tripped` rather than hanging. What changes is that `applyEvent`'s "workflow is done, no further
+events" refusal admits one case: an event addressed to a task sitting in an open final, at the
+tripped terminal. `complete` admits none, because every task there finished clean and no door leads
+out of that.
+
+The resume runs through the same history cell `blocked` and `human:cp-approval` use, which copies
+the task's retry count forward. So a resumed task walks back into the state it left with its budget
+still spent, and the next `FAIL` freezes it again.
+
+**The door and the retry budget are two different things, and only one of them grants a round.** A
+founder clearance recorded through `build clear` writes the round into the lane document's context,
+and the compiler adds it to `maxRetries` — so re-folding the same event log resumes the task into
+`build` on its own, with no `UNBLOCKED` needed. The door is for a frozen task nobody granted a round
+for: a chore lane with no PR to clear, or a park a human fixed out of band. Either way one grant is
+exactly one round.
+
+A region booted straight into `frozen` — an epic child whose issue was closed without landing — left
+no prior state behind it, so its door resolves back to the park itself. The fold refuses that
+`UNBLOCKED` rather than recording a resume that did not move; such a child is re-emitted, not
+unfrozen.
+
+**Binding constraints.**
+
+- A machine source may give a `final` an `on` only from the operator's six events; the six-event
+  vocabulary is unchanged and closed.
+- A door out of an error final never widens `maxRetries`. Budget comes from a recorded clearance
+  and nowhere else.
+- `operate` never records the `UNBLOCKED` itself — clearing a park stays a human's event, as it
+  already is for `blocked` and `human:*`.
+
+## Consequences
+
+`frozen` moves from `LANE-TERMINAL` to `LANE-PARKED` in
+[`operate`](../claude-plugins/fabrika/skills/operate/SKILL.md), which is the honest reading now:
+someone can act on it. A `tripped` fold is therefore no longer proof that a run is over, and a
+driver reading one has to look at which state the error task sits in.
+
+The cost is that a park can be walked repeatedly with no new grant, each pass ending in the same
+freeze. That is deliberate — the door records a human's decision to try again, and the budget guard
+is what stops the loop from spending anything on it.
+
+## Records
+
+No vocabulary impact. `frozen`, `LANE-PARKED` and `LANE-TERMINAL` are the `operate` skill's own
+terminal vocabulary, defined there rather than in `.glossary/TERMS.md`.

--- a/claude-plugins/fabrika/skills/operate/SKILL.md
+++ b/claude-plugins/fabrika/skills/operate/SKILL.md
@@ -142,10 +142,11 @@ active phase** (future phases read `waiting`; leave them alone), route on the le
 | `build` / `review` / `ship` | dispatch through `lane brief` — below |
 | `integrate` | land the child on the assembly branch yourself — the epic run, below |
 | a state `recipe route` names | apply that recipe verb — the chore drive, below |
-| a task's own final — `landed`, `shipped`, `frozen` | nothing to route and no event to record: that task is finished, and its phase advances when every task in it is final. `frozen` is an error final; it trips the phase at that point, and the fold is what says so |
+| a task's own final — `landed`, `shipped` | nothing to route and no event to record: that task is finished, and its phase advances when every task in it is final |
+| `frozen` | park — step 4. It is an error final, so it trips the phase where it sits and the fold says so; it is also the one final with a door out (ADR [0297](../../../../.decisions/0297-frozen-is-a-park-not-an-end.md)), and walking it is a human's `UNBLOCKED`, never yours |
 | `human:*` | park — step 4 |
 | `blocked` | park — step 4 |
-| any other name | end `STOPPED` naming the state — never guess a shell for a state you do not recognise, and never a park: `LANE-PARKED` promises a fold in `blocked`/`human:*`, which an unrecognised state cannot honour (Terminal vocabulary, below) |
+| any other name | end `STOPPED` naming the state — never guess a shell for a state you do not recognise, and never a park: `LANE-PARKED` promises a fold in `blocked`/`human:*`/`frozen`, which an unrecognised state cannot honour (Terminal vocabulary, below) |
 
 **You never compose a spawn prompt.** The verb prints it:
 
@@ -468,8 +469,8 @@ release you cannot prove. A `STOPPED` run releases too — a claim outliving the
 is the same lane nobody can pick up.
 
 
-**A run never ends `LANE-PARKED` while the fold reads a non-parked state.** `human:*` and
-`blocked` are already parked — the fold itself says so, and no event is owed on top of it. Any
+**A run never ends `LANE-PARKED` while the fold reads a non-parked state.** `human:*`, `blocked`
+and `frozen` are already parked — the fold itself says so, and no event is owed on top of it. Any
 park you originate — one this section names rather than a state the fold already holds — records
 the event that matches the terminal first: `lane transition $lane_key BLOCKED`, then a fresh
 `lane status`, and only when the re-fold reads `blocked` or `human:*` does the run end
@@ -483,7 +484,10 @@ block is generic — [#5820](https://github.com/kamp-us/phoenix/issues/5820) tra
 
 You cannot clear a park: post on the driven issue what is needed and from whom (the parking
 spawn's report names both; for `human:cp-approval` it is a control-plane approval at the PR's
-current head), then end `LANE-PARKED`. One park class names its owner here, not off the spawn's
+current head; for `frozen` it is a founder-cleared repair round, recorded with `build clear`, which
+re-folds the task into `build` on its own — a bare `UNBLOCKED` walks the door back into the same
+review with the budget still spent, so the next `FAIL` freezes it again). One park class names its
+owner here, not off the spawn's
 report: **a wire defect on the driven issue's own body** — an acceptance-criteria heading a
 spawned shell fail-louds on, a criteria block that reads as no shape the verbs parse.
 
@@ -526,7 +530,7 @@ fold reads (`human:novel-park` is the named park a recipe refusal folds to), and
 caller re-reads the ledger, never your summary. A resumed run that folds into a still-parked lane restates the park in one comment
 and ends `LANE-PARKED` again; the ledger, not your patience, decides when the lane moves.
 
-**A terminal fold (`status: done` — `shipped`, `frozen`, `complete`, `tripped`, and a chore's
+**A terminal fold (`status: done` — `shipped`, `complete`, `tripped`, and a chore's
 `swept`) ends the run with the transcript**, posted to the driven issue straight off the verbs:
 
 ```bash
@@ -537,6 +541,10 @@ with `lane history $lane_key` appended the same way when the event log adds anyt
 show. Name the terminal state in the comment. End `LANE-TERMINAL`. On a chore lane the pipe has no
 issue to land on: print the same two verbs and hand their bytes to your caller, who owns where a
 chore's transcript is posted.
+
+**A `tripped` fold is not automatically a terminal** — read which state its error task sits in. On
+`frozen` the run ends `LANE-PARKED` with the transcript and the need posted (the founder-cleared
+round above); every other error final has no door and ends `LANE-TERMINAL`.
 
 **Resume is a re-spawn.** There is no handoff and no memory: resuming a lane is spawning the
 operator again with the same issue number — step 1 tolerates the existing lane, and the fold says
@@ -559,17 +567,17 @@ re-spawn above ([#5897](https://github.com/kamp-us/phoenix/issues/5897)).
 ## Terminal vocabulary
 
 Every run ends as exactly one of — each naming what was recorded and what the fold reads after:
-**`LANE-TERMINAL`** (the machine folded to a final state — `shipped`, `frozen`, `complete`,
+**`LANE-TERMINAL`** (the machine folded to a final state with no door out — `shipped`, `complete`,
 `tripped`; no event recorded on top of a final fold; transcript posted on the driven issue) ·
-**`LANE-PARKED`** (the fold reads `blocked` or `human:*` — either it already did and no event was
-owed, or the `BLOCKED` this run recorded put it there and the re-fold confirmed it; the need
+**`LANE-PARKED`** (the fold reads `blocked`, `human:*` or `frozen` — either it already did and no
+event was owed, or the `BLOCKED` this run recorded put it there and the re-fold confirmed it; the need
 posted on the driven issue) · **`LANE-HELD`** (step 1's claim was proven lost — another driver owns
 this lane, its token named; no ledger emitted, no shell spawned, no marker retracted, nothing
 posted) · **`STOPPED`** (a verb exit UNKNOWN, a malformed record, an
 unroutable state, or a `BLOCKED` refused with exit `12` — the code or state named, nothing
 guessed, no event recorded, the fold unchanged). An unroutable state ends `STOPPED`, never
-`LANE-PARKED`: a park promises a mechanical `UNBLOCKED` resume from `blocked`/`human:*`, which a
-state this skill does not recognise cannot honour — and appending `BLOCKED` toward cells you do
+`LANE-PARKED`: a park promises a mechanical `UNBLOCKED` resume from `blocked`/`human:*`/`frozen`,
+which a state this skill does not recognise cannot honour — and appending `BLOCKED` toward cells you do
 not know is exactly the guess step 2's routing table forbids. A park reported as a
 terminal destroys the caller's routing: the two differ in exactly who acts next. Follow-up
 observations leave through `/report` the moment you see them — never through scope creep in a

--- a/packages/fabrika-cli/src/lane/__fixtures__/epic-4300.workflow.golden.txt
+++ b/packages/fabrika-cli/src/lane/__fixtures__/epic-4300.workflow.golden.txt
@@ -85,7 +85,10 @@
 								"type": "final"
 							},
 							"frozen": {
-								"type": "final"
+								"type": "final",
+								"on": {
+									"ISSUE_4301.UNBLOCKED": "hist"
+								}
 							}
 						}
 					},
@@ -148,7 +151,10 @@
 								"type": "final"
 							},
 							"frozen": {
-								"type": "final"
+								"type": "final",
+								"on": {
+									"ISSUE_4302.UNBLOCKED": "hist"
+								}
 							}
 						}
 					}
@@ -225,7 +231,10 @@
 								"type": "final"
 							},
 							"frozen": {
-								"type": "final"
+								"type": "final",
+								"on": {
+									"ISSUE_4303.UNBLOCKED": "hist"
+								}
 							}
 						}
 					}

--- a/packages/fabrika-cli/src/lane/emit.ts
+++ b/packages/fabrika-cli/src/lane/emit.ts
@@ -48,7 +48,9 @@ export type EmitResult =
  * `landed`; every other close (`not_planned`, `duplicate`, a legacy null reason) is
  * closed-without-landing and boots `frozen` — `lane status` reads `frozen` as an error final and
  * trips the phase, which is the loud answer for a topology that still requires a child the board
- * abandoned. Marking it `landed` would fabricate a landing.
+ * abandoned. Marking it `landed` would fabricate a landing. A child booted there left no state
+ * behind it, so `frozen`'s `UNBLOCKED` door has nowhere to resume to and the fold refuses it —
+ * that child is re-emitted, not unfrozen (ADR 0297).
  */
 const initialFor = (link: SubIssueLink): "queued" | "landed" | "frozen" => {
 	if (link.state === "open") return "queued";
@@ -65,7 +67,8 @@ const initialFor = (link: SubIssueLink): "queued" | "landed" | "frozen" => {
  * `integrate` is the merge of the reviewed range into the epic branch, and it is a *state* so that a
  * collision between two children resolves inside the run: its `FAIL` — a textual conflict, or a
  * failed post-merge check, which is the semantic collision — re-enters `build` under the same
- * guarded-FAIL retry array `review` uses, and exhausts into `frozen`. No route from it reaches a
+ * guarded-FAIL retry array `review` uses, and exhausts into `frozen` — a park with an `UNBLOCKED`
+ * door back to the state it left, spent retries held (ADR 0297). No route from it reaches a
  * merge queue, and none reaches `landed` without passing back through `review`: post-resolution
  * content is not what the range verdict judged, so the verdict is re-proven before the landing
  * rather than after it.
@@ -98,7 +101,7 @@ const region = (ns: string, initial: "queued" | "landed" | "frozen"): Record<str
 		blocked: {on: {[`${ns}.UNBLOCKED`]: "hist"}},
 		hist: {type: "history"},
 		landed: {type: "final"},
-		frozen: {type: "final"},
+		frozen: {type: "final", on: {[`${ns}.UNBLOCKED`]: "hist"}},
 	},
 });
 

--- a/packages/fabrika-cli/src/lane/fold.ts
+++ b/packages/fabrika-cli/src/lane/fold.ts
@@ -242,13 +242,17 @@ export const applyEvent = (
 		};
 	}
 	const previous = deriveStatus(lane, states);
-	// A task sitting in an open final is parked, not finished: the lane tripped on it and the door
-	// out is still walkable (ADR 0297). Only the tripped terminal admits one — `complete` means
+	// A task sitting in an open final is parked, not finished: the door out is still walkable (ADR
+	// 0297). This is a fact about the task alone — a phase holding a parked child beside an
+	// unfinished sibling never folds, so the lane's own status says nothing about it.
+	const compiled = lane.tasks[taskId];
+	const state = states[taskId];
+	const inOpenFinal =
+		compiled !== undefined && state !== undefined && compiled.openFinals.has(state.type);
+	// Only the tripped terminal admits an event once the whole lane has folded — `complete` means
 	// every task finished clean, and no door leads out of that.
 	const parked =
-		previous.status === "done" &&
-		previous.stateValue === lane.terminals.tripped &&
-		taskIn(lane, taskId).openFinals.has(stateIn(states, taskId).type);
+		previous.status === "done" && previous.stateValue === lane.terminals.tripped && inOpenFinal;
 	if (previous.status === "done" && !parked) {
 		return {
 			_tag: "Refused",
@@ -283,7 +287,7 @@ export const applyEvent = (
 	}
 	// A region booted straight into a park left no state behind it, so its door resolves to the park
 	// itself; recording that would answer "resumed" for a fold that did not move.
-	if (parked && next.type === stateIn(states, taskId).type) {
+	if (inOpenFinal && next.type === stateIn(states, taskId).type) {
 		return {
 			_tag: "Refused",
 			reason: `task "${taskId}" booted in "${next.type}" and left no state to resume — the door leads back to itself`,

--- a/packages/fabrika-cli/src/lane/fold.ts
+++ b/packages/fabrika-cli/src/lane/fold.ts
@@ -242,15 +242,24 @@ export const applyEvent = (
 		};
 	}
 	const previous = deriveStatus(lane, states);
-	if (previous.status === "done") {
+	// A task sitting in an open final is parked, not finished: the lane tripped on it and the door
+	// out is still walkable (ADR 0297). Only the tripped terminal admits one — `complete` means
+	// every task finished clean, and no door leads out of that.
+	const parked =
+		previous.status === "done" &&
+		previous.stateValue === lane.terminals.tripped &&
+		taskIn(lane, taskId).openFinals.has(stateIn(states, taskId).type);
+	if (previous.status === "done" && !parked) {
 		return {
 			_tag: "Refused",
 			reason: `workflow is "${String(previous.stateValue)}" — no further events`,
 		};
 	}
-	const activePhase = lane.phases.find(
-		(phase) => typeof (previous.stateValue as Record<string, unknown>)[phase.name] === "object",
-	);
+	const activePhase = parked
+		? lane.phases.find((phase) => phase.tasks.includes(taskId))
+		: lane.phases.find(
+				(phase) => typeof (previous.stateValue as Record<string, unknown>)[phase.name] === "object",
+			);
 	if (activePhase === undefined || !activePhase.tasks.includes(taskId)) {
 		return {
 			_tag: "Refused",
@@ -271,6 +280,14 @@ export const applyEvent = (
 			return {_tag: "Refused", reason: `${error.name}: ${error.message}`};
 		}
 		throw error;
+	}
+	// A region booted straight into a park left no state behind it, so its door resolves to the park
+	// itself; recording that would answer "resumed" for a fold that did not move.
+	if (parked && next.type === stateIn(states, taskId).type) {
+		return {
+			_tag: "Refused",
+			reason: `task "${taskId}" booted in "${next.type}" and left no state to resume — the door leads back to itself`,
+		};
 	}
 	const entry: LogEntry = {task: taskId, event: `${taskId.toUpperCase()}.${event}`, at};
 	const current = deriveStatus(lane, {...states, [taskId]: next});

--- a/packages/fabrika-cli/src/lane/fold.unit.test.ts
+++ b/packages/fabrika-cli/src/lane/fold.unit.test.ts
@@ -281,6 +281,63 @@ describe("the frozen park — an UNBLOCKED door out of an error final (ADR 0297)
 		if (applied._tag === "Refused") expect(applied.reason).toContain("no state to resume");
 	});
 
+	/** twoPhaseWorkflow with task_a's `tripped` turned into a park, optionally booted into it. */
+	const parkedSibling = (booted: boolean): Record<string, unknown> => {
+		const workflow = twoPhaseWorkflow();
+		const region = (
+			workflow.machine as {
+				states: {phase1: {states: {task_a: {initial: string; states: Record<string, unknown>}}}};
+			}
+		).states.phase1.states.task_a;
+		region.states.tripped = {type: "final", on: {"TASK_A.UNBLOCKED": "hist"}};
+		if (booted) region.initial = "tripped";
+		return workflow;
+	};
+
+	it("refuses the booted park's door while a sibling keeps the phase active", () => {
+		const compiled = lane(parkedSibling(true));
+
+		// The phase never folds — task_b is still `doing` — so the lane reads active and the whole
+		// tripped-terminal path is unreachable; the self-loop has to be caught on the task itself.
+		expect(statusOf(compiled, []).status).toBe("active");
+		const applied = applyEvent(
+			compiled,
+			statesOf(compiled, []),
+			"task_a",
+			"UNBLOCKED",
+			"2026-08-16T00:00:00.000Z",
+		);
+		expect(applied).toMatchObject({_tag: "Refused"});
+		if (applied._tag === "Refused") expect(applied.reason).toContain("no state to resume");
+	});
+
+	it("still resumes a park the task walked into, with the phase active around it", () => {
+		const compiled = lane(parkedSibling(false));
+
+		const log = drive(compiled, [
+			["task_a", "DONE"],
+			["task_a", "FAIL"],
+			["task_a", "DONE"],
+			["task_a", "FAIL"],
+			["task_a", "DONE"],
+			["task_a", "FAIL"],
+		]);
+		expect(statusOf(compiled, log)).toMatchObject({
+			stateValue: {phase1: {task_a: "tripped", task_b: "doing"}},
+			status: "active",
+		});
+		const applied = applyEvent(
+			compiled,
+			statesOf(compiled, log),
+			"task_a",
+			"UNBLOCKED",
+			"2026-08-16T00:00:00.000Z",
+		);
+		expect(applied._tag).toBe("Applied");
+		if (applied._tag !== "Applied") return;
+		expect(applied.current.stateValue).toMatchObject({phase1: {task_a: "checking"}});
+	});
+
 	it("still refuses an event the park holds no cell for", () => {
 		const compiled = lane(coderWorkflow());
 

--- a/packages/fabrika-cli/src/lane/fold.unit.test.ts
+++ b/packages/fabrika-cli/src/lane/fold.unit.test.ts
@@ -3,6 +3,7 @@
  * state-ledger rebuild's runs 1–6 recorded on #5570's 2026-08-15 session note are the plan).
  */
 import {describe, expect, it} from "vitest";
+import {CAP_ROUND, RETRY_BUDGET} from "../retry-budget.ts";
 import {coderWorkflow, twoPhaseWorkflow} from "./fixtures.test-support.ts";
 import {applyEvent, deriveStatus, foldLog, type LogEntry, parseLog, resolveTask} from "./fold.ts";
 import {type CompiledLane, compile} from "./machine.ts";
@@ -187,6 +188,111 @@ describe("run 5 — BLOCKED then UNBLOCKED resumes the state it left", () => {
 		if (applied._tag === "Applied") {
 			expect(applied.current.stateValue).toMatchObject({pipeline: {issue: "ship"}});
 		}
+	});
+});
+
+describe("the frozen park — an UNBLOCKED door out of an error final (ADR 0297)", () => {
+	const round: ReadonlyArray<readonly [string, string]> = [
+		["issue", "DONE"],
+		["issue", "FAIL"],
+	];
+	/** WIP, then a FAIL per round until the budget is spent and the last one freezes the task. */
+	const freeze: ReadonlyArray<readonly [string, string]> = [
+		["issue", "WIP"],
+		...Array.from({length: RETRY_BUDGET + 1}, () => round).flat(),
+	];
+
+	/** The coder template with one founder-cleared round recorded on the task's context. */
+	const cleared = (): unknown => {
+		const workflow = coderWorkflow() as {machine: {context: {issue: Record<string, unknown>}}};
+		const issue = workflow.machine.context.issue;
+		workflow.machine.context.issue = {...issue, clearedRounds: [CAP_ROUND]};
+		return workflow;
+	};
+
+	it("trips the lane on the frozen task rather than hanging its phase", () => {
+		const compiled = lane(coderWorkflow());
+
+		const status = statusOf(compiled, drive(compiled, freeze));
+		expect(status).toMatchObject({stateValue: "tripped", status: "done"});
+		expect(status.context.errors).toEqual(["issue"]);
+		expect(status.context.issue).toMatchObject({retries: RETRY_BUDGET, maxRetries: RETRY_BUDGET});
+	});
+
+	it("resumes the state the task left, with the spent retries held", () => {
+		const compiled = lane(coderWorkflow());
+
+		const applied = applyEvent(
+			compiled,
+			statesOf(compiled, drive(compiled, freeze)),
+			"issue",
+			"UNBLOCKED",
+			"2026-08-16T00:00:00.000Z",
+		);
+		expect(applied._tag).toBe("Applied");
+		if (applied._tag !== "Applied") return;
+		expect(applied.current).toMatchObject({
+			stateValue: {pipeline: {issue: "review"}},
+			status: "active",
+		});
+		expect(applied.current.context.issue).toMatchObject({retries: RETRY_BUDGET});
+		expect(applied.current.context.errors).toEqual([]);
+	});
+
+	it("re-freezes on the next FAIL when no further round was granted", () => {
+		const compiled = lane(coderWorkflow());
+
+		const log = drive(compiled, [...freeze, ["issue", "UNBLOCKED"], ["issue", "FAIL"]]);
+		expect(statusOf(compiled, log)).toMatchObject({stateValue: "tripped", status: "done"});
+	});
+
+	it("hands the door no budget — a recorded grant re-folds the same log into the repair", () => {
+		const compiled = lane(cleared());
+
+		// The clearance widens the budget at compile time, so the FAIL that froze this log now spends
+		// the granted round instead: nothing to unblock, and the door grants nothing of its own.
+		const granted = drive(compiled, freeze);
+		expect(statusOf(compiled, granted).stateValue).toMatchObject({pipeline: {issue: "build"}});
+		expect(statusOf(compiled, granted).context.issue).toMatchObject({
+			retries: RETRY_BUDGET + 1,
+			maxRetries: RETRY_BUDGET + 1,
+		});
+		expect(statusOf(compiled, drive(compiled, [...freeze, ...round]))).toMatchObject({
+			stateValue: "tripped",
+			status: "done",
+		});
+	});
+
+	it("refuses the door on a region booted in the park — there is no state to resume", () => {
+		const workflow = coderWorkflow() as {
+			machine: {states: {pipeline: {states: {issue: {initial: string}}}}};
+		};
+		workflow.machine.states.pipeline.states.issue.initial = "frozen";
+		const compiled = lane(workflow);
+
+		const applied = applyEvent(
+			compiled,
+			statesOf(compiled, []),
+			"issue",
+			"UNBLOCKED",
+			"2026-08-16T00:00:00.000Z",
+		);
+		expect(applied).toMatchObject({_tag: "Refused"});
+		if (applied._tag === "Refused") expect(applied.reason).toContain("no state to resume");
+	});
+
+	it("still refuses an event the park holds no cell for", () => {
+		const compiled = lane(coderWorkflow());
+
+		const applied = applyEvent(
+			compiled,
+			statesOf(compiled, drive(compiled, freeze)),
+			"issue",
+			"DONE",
+			"2026-08-16T00:00:00.000Z",
+		);
+		expect(applied).toMatchObject({_tag: "Refused"});
+		if (applied._tag === "Refused") expect(applied.reason).toContain("NoCellError");
 	});
 });
 

--- a/packages/fabrika-cli/src/lane/machine.ts
+++ b/packages/fabrika-cli/src/lane/machine.ts
@@ -14,6 +14,9 @@
  *   - A phase's **`onDone` pair** `[{target, guard}, {target}]` names the two workflow terminals
  *     structurally: the last phase's guarded target is the complete terminal, the fallthrough is
  *     the tripped one.
+ *   - A **`final` carrying an `on`** is a park rather than an end: it stays in `finals`, so its
+ *     phase still folds and its trip still reads, and the door out stays walkable — how `frozen`
+ *     takes an `UNBLOCKED` without leaving either set (ADR 0297).
  *
  * Compilation is total over its result type: a document that does not fit comes back as
  * {@link Malformed} with every defect named, never as a machine that half-works.
@@ -52,6 +55,8 @@ export interface CompiledTask {
 	readonly finals: ReadonlySet<string>;
 	/** The finals reached as a guarded array's fallthrough — the task's error terminals. */
 	readonly errorFinals: ReadonlySet<string>;
+	/** The finals that hold a cell for some event — parks the lane trips on and resumes from. */
+	readonly openFinals: ReadonlySet<string>;
 	/** The task's `context` entry minus the retry bookkeeping — passed through to status. */
 	readonly extras: Readonly<Record<string, unknown>>;
 }
@@ -172,6 +177,12 @@ const compileRegion = (taskId: string, region: unknown, context: unknown): Regio
 	}
 	if (defects.length > 0) return {defects};
 
+	const openFinals = new Set(
+		Object.entries(table)
+			.filter(([name, cells]) => finals.has(name) && Object.keys(cells).length > 0)
+			.map(([name]) => name),
+	);
+
 	const ctx = isRecord(context) ? context : {};
 	const declared = typeof ctx.maxRetries === "number" ? ctx.maxRetries : RETRY_BUDGET;
 	// The founder's cleared rounds are additive on the declared budget, so the lane guard and
@@ -189,7 +200,7 @@ const compileRegion = (taskId: string, region: unknown, context: unknown): Regio
 		init: (loaded) => [loaded ?? initial, []],
 		update: table as never,
 	});
-	return {task: {machine, initial, finals, errorFinals, extras}, defects: []};
+	return {task: {machine, initial, finals, errorFinals, openFinals, extras}, defects: []};
 };
 
 /** The two targets of a phase's `onDone` pair: `[guarded success, fallthrough trip]`. */

--- a/packages/fabrika-cli/src/lane/machine.unit.test.ts
+++ b/packages/fabrika-cli/src/lane/machine.unit.test.ts
@@ -60,6 +60,7 @@ describe("the compiler — structural recognition", () => {
 		expect(defined(lane.tasks.issue).initial).toEqual({type: "queued", retries: 0, maxRetries: 2});
 		expect([...defined(lane.tasks.issue).finals].sort()).toEqual(["frozen", "shipped"]);
 		expect([...defined(lane.tasks.issue).errorFinals]).toEqual(["frozen"]);
+		expect([...defined(lane.tasks.issue).openFinals]).toEqual(["frozen"]);
 	});
 
 	it("reads a guarded array as retry-or-fallthrough by shape, never by guard name", () => {
@@ -89,6 +90,8 @@ describe("the compiler — structural recognition", () => {
 		expect(defined(summary.tasks.issue).states.review).toEqual(["PASS", "BLOCKED", "FAIL"]);
 		expect(defined(summary.tasks.issue).states.ship).toEqual(["DONE", "BLOCKED", "FAIL"]);
 		expect(defined(summary.tasks.issue).states.shipped).toEqual([]);
+		// `frozen` is a final that carries a door: a park the lane trips on, not an end (ADR 0297).
+		expect(defined(summary.tasks.issue).states.frozen).toEqual(["UNBLOCKED"]);
 		expect(summary.trigger).toBeUndefined();
 	});
 
@@ -123,6 +126,7 @@ describe("the compiler — structural recognition", () => {
 			maxRetries: 2,
 		});
 		expect([...defined(lane.tasks.park_sweep).errorFinals]).toEqual(["frozen"]);
+		expect([...defined(lane.tasks.park_sweep).openFinals]).toEqual(["frozen"]);
 	});
 
 	it("holds the chore template to the same six events as every other lane", () => {

--- a/packages/fabrika-cli/src/lane/templates/chore.workflow.json
+++ b/packages/fabrika-cli/src/lane/templates/chore.workflow.json
@@ -43,7 +43,12 @@
 							},
 							"hist": { "type": "history" },
 							"swept": { "type": "final" },
-							"frozen": { "type": "final" }
+							"frozen": {
+								"type": "final",
+								"on": {
+									"PARK_SWEEP.UNBLOCKED": "hist"
+								}
+							}
 						}
 					}
 				},

--- a/packages/fabrika-cli/src/lane/templates/coder.workflow.json
+++ b/packages/fabrika-cli/src/lane/templates/coder.workflow.json
@@ -66,7 +66,12 @@
 							},
 							"hist": { "type": "history" },
 							"shipped": { "type": "final" },
-							"frozen": { "type": "final" }
+							"frozen": {
+								"type": "final",
+								"on": {
+									"ISSUE.UNBLOCKED": "hist"
+								}
+							}
 						}
 					}
 				},


### PR DESCRIPTION
A lane task that burns its retry budget lands in `frozen`, which had no event out of it in any of
the three machine sources. A founder-granted extra round on an already-frozen lane could only exist
as issue prose the machine cannot see. This implements the ruling recorded on #5909: `frozen` gains
an `UNBLOCKED` door back to the state the task left, with the spent retries held.

**`frozen` keeps `"type": "final"` and gains an `on`.** That is the structural answer to the tension
triage flagged: `finals` and `errorFinals` are derived by shape, so dropping the final marker would
have taken `frozen` out of both — a frozen lane would stop reading as tripped and its phase would
never fold at all. A final carrying transitions is a park instead: the trip still reads, and the
door is walkable. The compiler already built cells for finals, so this is one new derived set
(`openFinals`) plus one exception in `applyEvent`'s "workflow is done" refusal, admitted only at the
tripped terminal — `complete` admits none.

**The door hands out no budget, and that is how the grant stays worth exactly one round.** A
clearance recorded through `build clear` widens `maxRetries` at compile time, so re-folding the same
log resumes the task into `build` on its own with no `UNBLOCKED` needed. The door is for a frozen
task nobody granted a round for — a chore lane with no PR to clear, or a park fixed out of band —
and a task walked back through it re-freezes on the next `FAIL`. Both halves are unit-tested.

One case the ruling did not name: a region booted straight into `frozen` (an epic child whose issue
was closed without landing) left no prior state, so its door resolves back to itself. The fold
refuses that `UNBLOCKED` rather than recording a resume that did not move.

Reviewer's first look: `applyEvent` in `packages/fabrika-cli/src/lane/fold.ts` — the done-refusal is
the only behaviour gate here, and its exception is narrowed to `stateValue === terminals.tripped`.

ADR [0297](.decisions/0297-frozen-is-a-park-not-an-end.md) records the ruling and why the fresh-lane-per-clearance option lost.

Fixes #6143

## Deviations

- **Out-of-scope change** — **Said:** #6143 names the three machine sources, the skill doc, the
  golden and the ADR. **Did:** also refused the `UNBLOCKED` door on a region booted into `frozen`,
  in `applyEvent`. **Why:** without it the new door answers "resumed" for a fold that did not move,
  on a case the epic emitter produces today. **Disposition:** stated here and in ADR 0297.
