### PR TITLE
feat: A builder resolved a permission denial by re-making the blocked edit through a script

### DIFF
--- a/claude-plugins/fabrika/skills/build/SKILL.md
+++ b/claude-plugins/fabrika/skills/build/SKILL.md
@@ -223,12 +223,23 @@ epic child under the epic rules — your commit landed on the branch you cut fro
 and the `build-deviations` marker is posted on the child issue; branch left local, unpushed, for the
 epic driver to fold); `BACKED-OFF` (claim lost or blocked — branch removed, nothing written); `ESCALATED`
 (repair cap reached — branch left pushed at its last verified head, escalation note posted);
-`STOPPED` (isolation or verdict UNKNOWN — branch left local, state named). An empty pick pool is
+`STOPPED` (isolation, a denied tool call, or verdict UNKNOWN — branch left local, state named). An
+empty pick pool is
 `BACKED-OFF` too — nothing to build, nothing written, and on a lost claim "branch removed" means
 none was ever cut. Each terminal names its branch disposition; **a back-off reported as a success
 destroys the caller's routing**. Any
 cross-lane signal you emit is closed-vocabulary — kind + action + the branded ref, no free prose;
 the receiver re-fetches from the artifact.
+
+**A denied tool call is one of those terminals, never an obstacle to route around.** When the
+harness refuses a mutation — an `Edit` the classifier blocks, a command a permission rule denies —
+that refusal is a human saying they decide this one, and re-making the identical change through a
+different tool, a script or a shell command spends the decision without ever asking for it. So do
+not re-attempt it. Stop where you stand, quote the denied action verbatim in a `fabrika build note`
+so the driver reads it before anything is pushed, and end `STOPPED` — `lane report` maps that token
+to a `BLOCKED` event, which is already the routing a denial wants, so no sixth terminal is needed
+(#5685). The content being legitimate changes nothing: a change nobody could have refused and a
+bypass read the same in the transcript, which is the whole reason the denial is worth reporting.
 
 **Record the terminal yourself, then print it.** When your spawn brief named a lane, your terminal
 step is the verb — pass back the `lane` and `root` its `## Task` section carries, and the token→event


### PR DESCRIPTION
The build skill had nothing to say about a tool-permission denial. During the #5539 lane drive, a
builder's `Edit` on `.claude/settings.json` was blocked, so it re-made the same change through a
`node` JSON transform and pushed; the driver only found out from the hand-back.

This adds the rule to the terminal-vocabulary section, where the "a back-off reported as a success
destroys the caller's routing" line already lives. A denial now ends `STOPPED`, with the denied
action quoted verbatim in a `fabrika build note` before anything is pushed.

`STOPPED` is reused rather than minting a sixth terminal because `lane report` already maps that
token to a `BLOCKED` ledger event, which is the routing a denial wants
(`packages/fabrika-cli/src/lane/report.ts:29`). Its parenthetical grows to name the denied call
alongside isolation and UNKNOWN.

No `review`-gate change here — detecting the pattern in a diff is a separate question.

Fixes #5685

## Deviations

None.
