### PR TITLE
fix: triage enrich overwrites an issue that is closed and claimed by another session, with no check

### DIFF
--- a/claude-plugins/fabrika/skills/triage/SKILL.md
+++ b/claude-plugins/fabrika/skills/triage/SKILL.md
@@ -26,6 +26,12 @@ fabrika triage claim $issue_number
 
 Done when it printed `won` — that means this session holds it; on anything else, move on.
 
+**That rule has teeth now.** Every verb below that writes — `enrich`, `apply`, `park`, `kill`,
+`split` — re-reads the claim before its first write and refuses on `17` when a live marker names
+another session, so proceeding on a `lost` no longer overwrites the winner's work; it just fails.
+The same re-read refuses a closed target on `7`. Neither refusal is overridable, and a comment read
+that fails is `11` — never a pass.
+
 ## 2 — Read the issue, then read the code it is about
 
 Never classify from the title. Read the body, then read enough of the repo to say what this is about

--- a/claude-plugins/fabrika/skills/triage/contract.md
+++ b/claude-plugins/fabrika/skills/triage/contract.md
@@ -363,7 +363,7 @@ $ fabrika triage queue --json
 **Invocation**
 
 ```
-fabrika triage claim 4312 [--ttl-minutes <n>] [--repo <owner/name>] [--json]
+fabrika triage claim 4312 [--repo <owner/name>] [--json]
 ```
 
 **Inputs**
@@ -371,7 +371,6 @@ fabrika triage claim 4312 [--ttl-minutes <n>] [--repo <owner/name>] [--json]
 | Flag | Type | Required | Default | Description |
 |---|---|---|---|---|
 | *(positional)* | integer | yes | — | the issue number to claim |
-| `--ttl-minutes` | integer | no | `60` | how long an existing claim marker stays binding before it is treated as abandoned |
 | `--repo` | string | no | resolved | the repository |
 | `--json` | boolean | no | `false` | emit the result object |
 
@@ -398,8 +397,14 @@ matching that prefix is not a marker and is ignored.
 
 **The ordering key is the comment's `created_at` as returned by GitHub**, never a timestamp embedded
 in the marker text: the body is caller-supplied and a caller could backdate itself into winning every
-race. "Older than `--ttl-minutes`" is measured against that same `created_at`. Earliest surviving
-marker wins.
+race. "Older than the TTL" is measured against that same `created_at`. Earliest surviving marker
+wins.
+
+**The TTL is a fixed 60 minutes and there is no flag for it.** A marker carries no TTL of its own, so
+the session that ages it out is never the session that placed it: `--ttl-minutes 240` posted a claim
+its placer thought bound for four hours and the five mutating verbs stopped honouring at one — the
+fail-open direction the guard exists to close. One constant is the only reading, for placer and
+reader alike; widening the window means changing that constant.
 
 **The claim is a session-stamped comment, never the assignee.** Every agent authenticates as the same
 login, so the assignee field cannot discriminate two concurrent sweeps — it is a shared availability
@@ -408,7 +413,7 @@ login, so the assignee is one shared slot"*). The session id comes from `$CLAUDE
 unset the verb exits `1` rather than posting an unattributable marker.
 
 **Resolution.** Post this session's marker, re-read all markers on the issue, discard any older than
-`--ttl-minutes`, and the **earliest surviving marker wins**. `won` requires a positive proof that the
+the TTL, and the **earliest surviving marker wins**. `won` requires a positive proof that the
 winner is this session; every unresolvable state answers `lost`, never `won`.
 
 **The claim binds, and every mutating verb is what makes it bind.** `split`, `enrich`, `apply`,
@@ -883,10 +888,11 @@ a silent lost split, in the one direction v1's own module says it refuses.
 | `3` | stdin was read and held nothing |
 | `5` | the composed child body carries a machine-local path |
 | `6` | the child body is a bare `@` path reference — the body never arrived |
-| `7` | the parent is proven absent (404), or `status:needs-triage` does not exist in the repository |
+| `7` | the parent is proven absent (404), is closed, or `status:needs-triage` does not exist in the repository |
 | `8` | the create failed — UNKNOWN whether a child landed |
 | `9` | the child was created but the read-back does not match |
-| `11` | a precondition read failed — the parent, the queue, the timeline, or a candidate's body |
+| `11` | a precondition read failed — the parent, its comments, the claim on it, the queue, the timeline, or a candidate's body |
+| `17` | a live claim marker on the parent names another session |
 
 **Errors**
 
@@ -894,6 +900,10 @@ a silent lost split, in the one direction v1's own module says it refuses.
 |---|---|---|
 | `triage split: no body on stdin — pipe the child body in.` | 3 | refusal |
 | `triage split: parent #<n> not found in <repo>.` | 7 | refusal |
+| `triage split: parent #<n> is already closed.` | 7 | refusal |
+| `triage split: cannot read #<n>'s comments in <repo>: <reason> — the claim on it is UNKNOWN; nothing was written.` | 11 | refusal |
+| `triage split: cannot resolve the claim on #<n> in <repo>: <reason> — nothing was written.` | 11 | refusal |
+| `triage split: #<n> is claimed by session <s> — refusing to mutate another session's issue. Run `fabrika triage claim <n>` and act only on `won`.` | 17 | refusal |
 | `triage split: label status:needs-triage does not exist in <repo> — refusing to create a child over a queue that would scan nothing (ADR 0092).` | 7 | refusal |
 | `triage split: the child body carries a machine-local path at line <k> (<class>) — rewrite it repo-relative.` | 5 | refusal |
 | `triage split: the child body is a bare "@" path reference — the body never arrived. Send it on stdin.` | 6 | refusal |
@@ -1297,10 +1307,11 @@ criteria block; a verb that demanded one would be a different verb.
 | `3` | stdin was read and held nothing — the rewrite, or the pitch with `--epic` |
 | `5` | the **authored** text carries a machine-local path — the rewrite, or the pitch with `--epic` |
 | `6` | the **authored** text is a bare `@` path reference — the rewrite, or the pitch with `--epic` |
-| `7` | the issue is proven absent (404), or it was read and its body is empty — a read that succeeded over nothing |
+| `7` | the issue is proven absent (404), is closed, or it was read and its body is empty — a read that succeeded over nothing |
 | `8` | the `PATCH` failed — UNKNOWN whether the body changed |
 | `9` | the body was written but the read-back does not match |
-| `11` | the issue body could not be read — there is no original to preserve |
+| `11` | the issue body could not be read, so there is no original to preserve — or its comments, or the claim on them, could not be read |
+| `17` | a live claim marker on the issue names another session |
 | `15` | the composed body's **authored region** carries an acceptance-criteria block the wire reader classifies `Malformed` |
 
 **Errors**
@@ -1309,6 +1320,10 @@ criteria block; a verb that demanded one would be a different verb.
 |---|---|---|
 | `triage enrich: no body on stdin — pipe the rewritten body in (with --epic, the pitch's five fields).` | 3 | refusal |
 | `triage enrich: issue #<n> not found in <repo>.` | 7 | refusal |
+| `triage enrich: issue #<n> is already closed.` | 7 | refusal |
+| `triage enrich: cannot read #<n>'s comments in <repo>: <reason> — the claim on it is UNKNOWN; nothing was written.` | 11 | refusal |
+| `triage enrich: cannot resolve the claim on #<n> in <repo>: <reason> — nothing was written.` | 11 | refusal |
+| `triage enrich: #<n> is claimed by session <s> — refusing to mutate another session's issue. Run `fabrika triage claim <n>` and act only on `won`.` | 17 | refusal |
 | `triage enrich: #<n> has an empty body — there is no original to preserve, and an empty one must never be preserved as though it were the record.` | 7 | refusal |
 | `triage enrich: cannot read #<n> in <repo>: <reason> — refusing to write an envelope over an original that was never read.` | 11 | refusal |
 | `triage enrich: the text you sent on stdin carries a machine-local path at line <k> (<class>) — rewrite it repo-relative. The preserved original is redacted automatically; this refusal is about the text you wrote.` | 5 | refusal |
@@ -1503,11 +1518,12 @@ for drift, not because they are currently absent.)
 
 | Code | Trigger |
 |---|---|
-| `7` | a label this invocation would write does not exist in the repository |
+| `7` | a label this invocation would write does not exist in the repository, or the issue is closed |
 | `8` | a label or milestone write failed — UNKNOWN which changes landed |
 | `9` | the writes landed but the read-back does not show the required end state |
 | `10` | an off-vocabulary enum value, or `--home` names a milestone that is not open |
-| `11` | the issue, the repository's label set, or its milestone set could not be read |
+| `11` | the issue, its comments, the claim on it, the repository's label set, or its milestone set could not be read |
+| `17` | a live claim marker on the issue names another session |
 | `16` | `--ready-for agent` over a live body the wire reader does not answer `Found` on — every type but `epic`; nothing was written |
 
 The issue being proven absent is `7` as well — the same zero-scope seat, since there is no issue to
@@ -1525,6 +1541,10 @@ stamp.
 | `triage apply: give exactly one of --home or --lane; an issue cannot be both homed and lane-exempt.` | 1 | usage error |
 | `triage apply: label <name> does not exist in <repo> — refusing to write, because the API would create it (#4285).` | 7 | refusal |
 | `triage apply: issue #<n> not found in <repo>.` | 7 | refusal |
+| `triage apply: issue #<n> is already closed.` | 7 | refusal |
+| `triage apply: cannot read #<n>'s comments in <repo>: <reason> — the claim on it is UNKNOWN; nothing was written.` | 11 | refusal |
+| `triage apply: cannot resolve the claim on #<n> in <repo>: <reason> — nothing was written.` | 11 | refusal |
+| `triage apply: #<n> is claimed by session <s> — refusing to mutate another session's issue. Run `fabrika triage claim <n>` and act only on `won`.` | 17 | refusal |
 | `triage apply: cannot read <what> in <repo>: <reason> — nothing was written; the transition is UNKNOWN.` | 11 | refusal |
 | `triage apply: write failed after <k> of <m> changes: <reason> — #<n> may be partially labelled; re-run this verb, which is idempotent.` | 8 | refusal |
 | `triage apply: read-back shows <observed> — expected exactly one type, one priority, status:triaged, one ready-for, and <the milestone / no milestone>.` | 9 | refusal |
@@ -1664,10 +1684,11 @@ it.
 | `3` | stdin was read and held nothing — a park with no questions is not a park |
 | `5` | the questions carry a machine-local path |
 | `6` | the questions are a bare `@` path reference — they never arrived |
-| `7` | the issue is proven absent (404), or `status:needs-info` does not exist in the repository |
+| `7` | the issue is proven absent (404), is closed, or `status:needs-info` does not exist in the repository |
 | `8` | the comment or the label swap failed — UNKNOWN which landed |
 | `9` | the writes landed but the read-back does not match |
-| `11` | the issue or the repository's label set could not be read |
+| `11` | the issue, its comments, the claim on it, or the repository's label set could not be read |
+| `17` | a live claim marker on the issue names another session |
 
 **Errors**
 
@@ -1675,6 +1696,10 @@ it.
 |---|---|---|
 | `triage park: no body on stdin — a parked issue must say what would unblock it: pipe the questions in.` | 3 | refusal |
 | `triage park: issue #<n> not found in <repo>.` | 7 | refusal |
+| `triage park: issue #<n> is already closed.` | 7 | refusal |
+| `triage park: cannot read #<n>'s comments in <repo>: <reason> — the claim on it is UNKNOWN; nothing was written.` | 11 | refusal |
+| `triage park: cannot resolve the claim on #<n> in <repo>: <reason> — nothing was written.` | 11 | refusal |
+| `triage park: #<n> is claimed by session <s> — refusing to mutate another session's issue. Run `fabrika triage claim <n>` and act only on `won`.` | 17 | refusal |
 | `triage park: the questions text carries a machine-local path at line <k> (<class>) — rewrite it repo-relative.` | 5 | refusal |
 | `triage park: the questions text is a bare "@" path reference — the body never arrived. Send it on stdin.` | 6 | refusal |
 | `triage park: label status:needs-info does not exist in <repo> — refusing to write, because the API would create it (#4285).` | 7 | refusal |
@@ -1781,7 +1806,8 @@ location, with the leak matcher literally named for comments.
 | `7` | the issue is proven absent or already closed; `--duplicate-of` is proven absent or closed; or `closed-by-triage` does not exist in the repository |
 | `8` | one of the four writes failed — the message names what did and did not land |
 | `9` | the writes landed but the read-back does not show a not-planned close |
-| `11` | the issue body, the duplicate, or the label set could not be read — no kill was attempted |
+| `11` | the issue body, its comments, the claim on it, the duplicate, or the label set could not be read — no kill was attempted |
+| `17` | a live claim marker on the issue names another session |
 | `12` | refused: the issue is human-filed — no agent footer and no operator author |
 | `13` | refused: agent-filed and close-eligible, but `--confirm` was absent (ADR 0159) |
 
@@ -1797,6 +1823,9 @@ location, with the leak matcher literally named for comments.
 | `triage kill: the reason is a bare "@" path reference — the body never arrived. Send it on stdin.` | 6 | refusal |
 | `triage kill: label closed-by-triage does not exist in <repo> — refusing a kill that would be invisible to the audit.` | 7 | refusal |
 | `triage kill: cannot read #<n> in <repo>: <reason> — the provenance test has no evidence; refusing to close on a body that was never read.` | 11 | refusal |
+| `triage kill: cannot read #<n>'s comments in <repo>: <reason> — the claim on it is UNKNOWN; nothing was written.` | 11 | refusal |
+| `triage kill: cannot resolve the claim on #<n> in <repo>: <reason> — nothing was written.` | 11 | refusal |
+| `triage kill: #<n> is claimed by session <s> — refusing to mutate another session's issue. Run `fabrika triage claim <n>` and act only on `won`.` | 17 | refusal |
 | `triage kill: #<n> is human-filed — refusing to close it. Park it with questions instead.` | 12 | refusal |
 | `triage kill: #<n> is agent-filed and close-eligible, but ADR 0159 makes the confirmation the guard — pass --confirm once salvage has genuinely been attempted.` | 13 | refusal |
 | `triage kill: the fold comment on #<m> failed: <reason> — #<n> is NOT closed, carries no reason and no label; nothing was lost. Re-run.` | 8 | refusal |

--- a/claude-plugins/fabrika/skills/triage/contract.md
+++ b/claude-plugins/fabrika/skills/triage/contract.md
@@ -160,6 +160,7 @@ or the search index could not be read
 | `13` | refused: agent-filed and close-eligible, but the kill is unconfirmed (ADR 0159) | — | — | — | — | — | — | — | — | ✓ |
 | `15` | refused: the body this verb composed carries an acceptance-criteria block its registered wire reader classifies `Malformed` (ADR 0288) | — | — | — | — | — | ✓ | — | — | — |
 | `16` | refused: `--ready-for agent` over a live body whose acceptance-criteria block the wire reader does not answer `Found` on — every type but `epic` | — | — | — | — | — | — | ✓ | — | — |
+| `17` | refused: a live claim marker on the target names a session other than this one | — | — | — | — | ✓ | ✓ | ✓ | ✓ | ✓ |
 | `127` | the verb never ran (unresolved binary) | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ |
 
 **This matrix owns what a code *means*; the per-verb tables own what *triggers* it.** Every verb in
@@ -409,6 +410,18 @@ unset the verb exits `1` rather than posting an unattributable marker.
 **Resolution.** Post this session's marker, re-read all markers on the issue, discard any older than
 `--ttl-minutes`, and the **earliest surviving marker wins**. `won` requires a positive proof that the
 winner is this session; every unresolvable state answers `lost`, never `won`.
+
+**The claim binds, and every mutating verb is what makes it bind.** `split`, `enrich`, `apply`,
+`park` and `kill` each re-read the markers on their target immediately before their first write, and
+refuse on `17` when a live one names another session — the check reuses this verb's own reader and
+resolver, so there is one marker grammar. Holding **no** marker still passes: an unclaimed issue is
+the ordinary first-triage case, and demanding one would refuse every existing caller. The same
+re-read refuses a closed target on `7`, and a comment read that fails is `11`. Before, the protocol
+was advisory at exactly the point it needed to bite: on 2026-08-15 a session that had read `lost`
+ran `enrich` anyway and replaced the winner's authored body
+([#5644](https://github.com/kamp-us/phoenix/issues/5644), on
+[#5642](https://github.com/kamp-us/phoenix/issues/5642)). There is no override flag — nothing in that
+incident needed one, and a flag added before a real need is a flag agents learn to pass reflexively.
 
 **The marker has a lifecycle, and both ends of it are specified.** This is the one verb here that
 *is* a race protocol, so leaving either end to an implementer's judgment would let the protocol

--- a/packages/fabrika-cli/src/triage/apply-verb.ts
+++ b/packages/fabrika-cli/src/triage/apply-verb.ts
@@ -38,6 +38,7 @@ import {
 	triagedFacets,
 } from "./facets.ts";
 import {scannedLine} from "./scope.ts";
+import {guardTarget} from "./target-guard.ts";
 
 export interface ApplyOptions {
 	readonly issue: number;
@@ -150,6 +151,15 @@ export const runApply = (
 		if (target._tag === "Unknown") {
 			return unreadable(`issue #${issue}`, repo, target.reason);
 		}
+
+		const guarded = yield* guardTarget({
+			verb: "triage apply",
+			repo,
+			issue,
+			target: target.value,
+			env: options.env,
+		});
+		if (guarded !== null) return guarded;
 
 		const refusal = criteriaRefusal(issue, type, readyFor, target.value.body);
 		if (refusal !== null) return refusal;

--- a/packages/fabrika-cli/src/triage/apply-verb.unit.test.ts
+++ b/packages/fabrika-cli/src/triage/apply-verb.unit.test.ts
@@ -1,9 +1,11 @@
 import {Effect} from "effect";
 import {describe, expect, it} from "vitest";
-import {errOut, fakeShell, okOut, once} from "../fakes.test-support.ts";
+import {errOut, okOut, once} from "../fakes.test-support.ts";
 import type {ExecResult} from "../io/exec.ts";
 import {runApply} from "./apply-verb.ts";
+import {COMMENTS, claimPage, EXPIRED, guardedShell, LIVE} from "./claim-fixtures.test-support.ts";
 import {
+	CLAIMED_ELSEWHERE,
 	CRITERIA_REQUIRED,
 	OFF_VOCABULARY,
 	PRECONDITION_UNKNOWN,
@@ -85,7 +87,9 @@ const run = (
 	script: ReadonlyArray<readonly [RegExp, ExecResult]>,
 	overrides: Partial<typeof options> = {},
 ) =>
-	Effect.runPromise(Effect.provide(runApply({...options, ...overrides}), fakeShell(script).layer));
+	Effect.runPromise(
+		Effect.provide(runApply({...options, ...overrides}), guardedShell(script).layer),
+	);
 
 describe("runApply", () => {
 	it("stamps the whole transition and prints the tab-separated triaged line", async () => {
@@ -115,7 +119,7 @@ describe("runApply", () => {
 	});
 
 	it("homes BEFORE it labels, so the homing guard never sees a triaged un-homed issue", async () => {
-		const shell = fakeShell(happy());
+		const shell = guardedShell(happy());
 		await Effect.runPromise(Effect.provide(runApply(options), shell.layer));
 		const writes = shell.calls.filter((c) => PATCH.test(c) || REMOVE.test(c) || ADD.test(c));
 		expect(writes[0]).toBe("gh api --method PATCH repos/o/r/issues/4312 -F milestone=47");
@@ -123,7 +127,7 @@ describe("runApply", () => {
 	});
 
 	it("removes the superseded priority and never the applied one (#4285)", async () => {
-		const shell = fakeShell(happy());
+		const shell = guardedShell(happy());
 		await Effect.runPromise(Effect.provide(runApply(options), shell.layer));
 		const removes = shell.calls.filter((c) => REMOVE.test(c));
 		expect(removes).toEqual([
@@ -134,7 +138,7 @@ describe("runApply", () => {
 	});
 
 	it("leaves a label no facet owns entirely alone", async () => {
-		const shell = fakeShell([
+		const shell = guardedShell([
 			[once(ISSUE), issue(["area:pipeline", "p1"], 47)],
 			[ISSUE, issue(["area:pipeline", "type:bug", "p2", "status:triaged", "ready-for:agent"], 47)],
 			[LABELS, VOCABULARY],
@@ -148,7 +152,7 @@ describe("runApply", () => {
 	});
 
 	it("clears the milestone under --lane, because a lane-exempt issue is not homed (ADR 0208)", async () => {
-		const shell = fakeShell([
+		const shell = guardedShell([
 			[once(ISSUE), issue(["status:needs-triage"], 47)],
 			[
 				ISSUE,
@@ -191,7 +195,7 @@ describe("runApply", () => {
 		["ready-for", {readyFor: "robot"}],
 		["lane", {home: null, lane: "axis:whatever"}],
 	])("refuses an off-vocabulary --%s on 10, before any read", async (_flag, override) => {
-		const shell = fakeShell(happy());
+		const shell = guardedShell(happy());
 		const out = await Effect.runPromise(
 			Effect.provide(runApply({...options, ...override}), shell.layer),
 		);
@@ -207,7 +211,7 @@ describe("runApply", () => {
 	});
 
 	it("refuses to write a label the repo does not define — the API would mint it (#4285)", async () => {
-		const shell = fakeShell([
+		const shell = guardedShell([
 			[once(ISSUE), issue(["status:needs-triage"], null)],
 			[ISSUE, issue([], null)],
 			[LABELS, okOut(["type:bug", "p2", "status:triaged"].join("\n"))],
@@ -243,7 +247,7 @@ describe("runApply", () => {
 	});
 
 	it("separates an UNREADABLE issue from an absent one, and writes nothing", async () => {
-		const shell = fakeShell([[ISSUE, errOut("gh: Bad gateway (HTTP 502)")]]);
+		const shell = guardedShell([[ISSUE, errOut("gh: Bad gateway (HTTP 502)")]]);
 		const out = await Effect.runPromise(Effect.provide(runApply(options), shell.layer));
 		expect(out.code).toBe(PRECONDITION_UNKNOWN);
 		expect(out.stderr.at(-1)).toContain("nothing was written");
@@ -335,7 +339,7 @@ describe("runApply", () => {
 	 */
 	describe("the acceptance-criteria precondition on --ready-for agent", () => {
 		const criteriaShell = (body: string) =>
-			fakeShell([
+			guardedShell([
 				[ISSUE, issue(["status:needs-triage"], null, body)],
 				[LABELS, VOCABULARY],
 				[MILESTONES, OPEN_MILESTONES],
@@ -402,9 +406,74 @@ describe("runApply", () => {
 
 	it("refuses an unresolvable repo rather than guessing one", async () => {
 		const out = await Effect.runPromise(
-			Effect.provide(runApply({...options, env: {}}), fakeShell([]).layer),
+			Effect.provide(runApply({...options, env: {}}), guardedShell([]).layer),
 		);
 		expect(out.code).toBe(1);
 		expect(out.stderr.at(-1)).toContain("cannot resolve a target repo");
+	});
+});
+
+/** #5644: the claim protocol only holds if the mutating verbs re-read it. */
+describe("runApply — the target guard", () => {
+	const MINE = "session-mine";
+	const THEIRS = "session-theirs";
+	const mine = {CLAUDE_PIPELINE_REPO: "o/r", CLAUDE_CODE_SESSION_ID: MINE} as Record<
+		string,
+		string | undefined
+	>;
+	const closed = okOut(
+		JSON.stringify({
+			number: 4312,
+			title: "t",
+			body: CRITERIA_BODY,
+			state: "closed",
+			labels: [],
+			html_url: "https://example.test/issues/4312",
+			milestone: null,
+		}),
+	);
+
+	const guard = async (script: ReadonlyArray<readonly [RegExp, ExecResult]>) => {
+		const shell = guardedShell(script);
+		const out = await Effect.runPromise(
+			Effect.provide(runApply({...options, env: mine}), shell.layer),
+		);
+		return {out, wrote: shell.calls.some((line) => ADD.test(line) || PATCH.test(line))};
+	};
+
+	it("refuses a closed issue on 7 and writes nothing", async () => {
+		const {out, wrote} = await guard([[ISSUE, closed]]);
+		expect(out.code).toBe(ZERO_SCOPE);
+		expect(wrote).toBe(false);
+	});
+
+	it("refuses a live claim held by another session on 17 and writes nothing", async () => {
+		const {out, wrote} = await guard([
+			...happy(),
+			[COMMENTS, claimPage({session: THEIRS, createdAt: LIVE})],
+		]);
+		expect(out.code).toBe(CLAIMED_ELSEWHERE);
+		expect(wrote).toBe(false);
+	});
+
+	it("applies when the live claim is this session's own", async () => {
+		const {out} = await guard([
+			...happy(),
+			[COMMENTS, claimPage({session: MINE, createdAt: LIVE})],
+		]);
+		expect(out.code).toBe(0);
+	});
+
+	it("applies over an issue nobody has claimed", async () => {
+		const {out} = await guard(happy());
+		expect(out.code).toBe(0);
+	});
+
+	it("applies when the only foreign claim has aged out", async () => {
+		const {out} = await guard([
+			...happy(),
+			[COMMENTS, claimPage({session: THEIRS, createdAt: EXPIRED})],
+		]);
+		expect(out.code).toBe(0);
 	});
 });

--- a/packages/fabrika-cli/src/triage/claim-fixtures.test-support.ts
+++ b/packages/fabrika-cli/src/triage/claim-fixtures.test-support.ts
@@ -1,0 +1,49 @@
+/**
+ * The claim-marker read every mutating `triage` verb runs, as scripted comment pages.
+ *
+ * Shared rather than repeated per verb because the guard is one module, so a test that disagrees
+ * with another about the marker's shape would be testing the fixture (#5644).
+ *
+ * The TTL is measured against the real clock, so the two ages are written as timestamps far either
+ * side of any run rather than as an injected `now` no verb accepts: {@link LIVE} cannot age out and
+ * {@link EXPIRED} cannot come back.
+ */
+import {type FakeShell, fakeShell, okOut} from "../fakes.test-support.ts";
+import type {ExecResult} from "../io/exec.ts";
+import {markerBody} from "./claim.ts";
+
+/** `listComments`' command line, whichever issue it names. */
+export const COMMENTS = /^gh api --paginate repos\/[^ ]+\/comments\?per_page=100$/;
+
+/** A `created_at` no TTL can have passed. */
+export const LIVE = "2999-01-01T00:00:00Z";
+/** A `created_at` every TTL has passed. */
+export const EXPIRED = "2020-01-01T00:00:00Z";
+
+/** One comments page carrying a claim marker per `(session, createdAt)` pair. */
+export const claimPage = (
+	...held: ReadonlyArray<{readonly session: string; readonly createdAt: string}>
+): ExecResult =>
+	okOut(
+		JSON.stringify(
+			held.map((row, index) => ({
+				id: 900 + index,
+				user: {login: "agent"},
+				created_at: row.createdAt,
+				updated_at: row.createdAt,
+				body: markerBody(row.session),
+			})),
+		),
+	);
+
+/** The default every existing test gets: the issue carries no claim marker at all. */
+export const UNCLAIMED: readonly [RegExp, ExecResult] = [COMMENTS, okOut("[]")];
+
+/**
+ * A spawner scripted on `script`, with the unclaimed comments page appended as the last resort.
+ *
+ * Appended rather than prepended so a test that scripts its own comments page still wins:
+ * {@link fakeShell} resolves each call by the first pattern that matches.
+ */
+export const guardedShell = (script: ReadonlyArray<readonly [RegExp, ExecResult]>): FakeShell =>
+	fakeShell([...script, UNCLAIMED]);

--- a/packages/fabrika-cli/src/triage/claim-verb.ts
+++ b/packages/fabrika-cli/src/triage/claim-verb.ts
@@ -33,7 +33,7 @@ import {
 import {PRECONDITION_UNKNOWN, READBACK_MISMATCH, WRITE_UNKNOWN, ZERO_SCOPE} from "./codes.ts";
 import {scannedLine} from "./scope.ts";
 
-export const DEFAULT_TTL_MINUTES = 60;
+export {DEFAULT_TTL_MINUTES} from "./claim.ts";
 
 export interface ClaimOptions {
 	readonly issue: number;

--- a/packages/fabrika-cli/src/triage/claim-verb.ts
+++ b/packages/fabrika-cli/src/triage/claim-verb.ts
@@ -23,6 +23,7 @@ import type {ChildProcessSpawner} from "effect/unstable/process";
 import {createComment, deleteComment, getIssue, listComments, resolveRepo} from "../io/issues.ts";
 import {answer, FAILED, refuse, type VerbOutcome} from "../verb.ts";
 import {
+	DEFAULT_TTL_MINUTES,
 	expiryOf,
 	isStampableSession,
 	markerBody,
@@ -33,11 +34,8 @@ import {
 import {PRECONDITION_UNKNOWN, READBACK_MISMATCH, WRITE_UNKNOWN, ZERO_SCOPE} from "./codes.ts";
 import {scannedLine} from "./scope.ts";
 
-export {DEFAULT_TTL_MINUTES} from "./claim.ts";
-
 export interface ClaimOptions {
 	readonly issue: number;
-	readonly ttlMinutes: number;
 	readonly repo: string | null;
 	readonly json: boolean;
 	readonly env: Readonly<Record<string, string | undefined>>;
@@ -82,13 +80,10 @@ export const runClaim = (
 	options: ClaimOptions,
 ): Effect.Effect<VerbOutcome, never, ChildProcessSpawner.ChildProcessSpawner> =>
 	Effect.gen(function* () {
-		const {issue, ttlMinutes, json} = options;
+		const {issue, json} = options;
 
 		if (!Number.isInteger(issue) || issue <= 0) {
 			return refuse(FAILED, `${VERB}: ${issue} is not an issue number.`);
-		}
-		if (!Number.isInteger(ttlMinutes) || ttlMinutes <= 0) {
-			return refuse(FAILED, `${VERB}: --ttl-minutes ${ttlMinutes} is not a positive integer.`);
 		}
 
 		const stamped = sessionFrom(options.env);
@@ -130,7 +125,12 @@ export const runClaim = (
 		// Re-running inside one session is idempotent: a second marker is strictly later than the
 		// first, so it can win nothing the first did not and only adds litter to clean up.
 		const alreadyHeld = myMarker(
-			resolveClaim({markers: markersOf(before.value), session, now, ttlMinutes}),
+			resolveClaim({
+				markers: markersOf(before.value),
+				session,
+				now,
+				ttlMinutes: DEFAULT_TTL_MINUTES,
+			}),
 		);
 
 		let postedId: number | null = null;
@@ -162,7 +162,7 @@ export const runClaim = (
 			markers: markersOf(after.value),
 			session,
 			now,
-			ttlMinutes,
+			ttlMinutes: DEFAULT_TTL_MINUTES,
 		});
 
 		if (resolution._tag === "Unresolvable") {
@@ -201,7 +201,7 @@ export const runClaim = (
 		// already conceded would beat a rightful winner on a later run.
 		const deleted = yield* deleteComment(repo, resolution.mine.id);
 		if (deleted._tag === "Failure") {
-			const expiry = expiryOf(resolution.mine.createdAt, ttlMinutes) ?? "an unknown time";
+			const expiry = expiryOf(resolution.mine.createdAt, DEFAULT_TTL_MINUTES) ?? "an unknown time";
 			return refuse(
 				READBACK_MISMATCH,
 				`${VERB}: lost #${issue}, but this session's marker ${resolution.mine.id} could not be deleted: ${deleted.reason} — a stale claim is live on the issue until ${expiry}; delete it by hand.`,

--- a/packages/fabrika-cli/src/triage/claim-verb.unit.test.ts
+++ b/packages/fabrika-cli/src/triage/claim-verb.unit.test.ts
@@ -63,7 +63,6 @@ const THEIR_MARKER = comment(4002, markerBody(THEIRS), "2026-08-02T09:14:02Z");
 
 const options = {
 	issue: 4312,
-	ttlMinutes: 60,
 	repo: null,
 	json: false,
 	env: {
@@ -315,8 +314,7 @@ describe("runClaim — preconditions", () => {
 		expect(outcome.stderr.join("\n")).toContain("this session's marker 5001 is live on #4312");
 	});
 
-	it("refuses at 1 on a non-positive ttl and on a non-issue number", async () => {
-		expect((await run([], {ttlMinutes: 0})).outcome.code).toBe(1);
+	it("refuses at 1 on a non-issue number", async () => {
 		expect((await run([], {issue: 0})).outcome.code).toBe(1);
 	});
 });

--- a/packages/fabrika-cli/src/triage/claim.ts
+++ b/packages/fabrika-cli/src/triage/claim.ts
@@ -73,7 +73,14 @@ export const instantOf = (iso: string): number | null => {
 	return Number.isNaN(ms) ? null : ms;
 };
 
-/** How long a marker binds before it is treated as abandoned. */
+/**
+ * How long a marker binds before it is treated as abandoned — the only TTL in the protocol.
+ *
+ * A constant rather than a flag: `triage claim --ttl-minutes 240` posted a marker the five mutating
+ * verbs stopped honouring at 60, because they age a marker they did not place and the marker carries
+ * no TTL of its own. That is the fail-open case #5644 exists to close, so the flag went and one
+ * reading stands. Widening it means widening it here, for placer and reader alike.
+ */
 export const DEFAULT_TTL_MINUTES = 60;
 
 export type ClaimResolution =

--- a/packages/fabrika-cli/src/triage/claim.ts
+++ b/packages/fabrika-cli/src/triage/claim.ts
@@ -73,6 +73,9 @@ export const instantOf = (iso: string): number | null => {
 	return Number.isNaN(ms) ? null : ms;
 };
 
+/** How long a marker binds before it is treated as abandoned. */
+export const DEFAULT_TTL_MINUTES = 60;
+
 export type ClaimResolution =
 	| {readonly _tag: "Won"; readonly marker: Marker; readonly live: number; readonly expired: number}
 	| {
@@ -96,21 +99,30 @@ export interface ResolveInput {
 	readonly ttlMinutes: number;
 }
 
+/** The markers still binding at `now`, oldest first — or the reason the set could not be ordered. */
+export type LiveMarkers =
+	| {readonly _tag: "Live"; readonly live: ReadonlyArray<Marker>; readonly expired: number}
+	| {readonly _tag: "Unresolvable"; readonly reason: string};
+
 /**
- * Discard the markers older than the TTL, then let the earliest survivor win.
+ * Discard the markers older than the TTL and order what survives, oldest first.
  *
  * A marker whose `created_at` will not parse is **not** dropped as expired and **not** ordered
- * against: it can neither be aged out nor placed, so the race has no answer and this refuses. The
+ * against: it can neither be aged out nor placed, so the set has no answer and this refuses. The
  * tempting alternatives both break the invariant — treating it as expired discards a possibly-live
  * competitor, and treating it as newest lets an unreadable marker lose a race it was never placed
  * in.
+ *
+ * Split out of {@link resolveClaim} because two questions need it and only one of them is a race:
+ * `triage claim` asks who won, and the mutating verbs ask whether any live marker names a session
+ * other than theirs — a question `resolveClaim` cannot answer, since a caller holding no marker of
+ * its own resolves {@link ClaimResolution} to `MineAbsent` however many competitors are live (#5644).
  */
-export const resolveClaim = ({
+export const liveMarkers = ({
 	markers,
-	session,
 	now,
 	ttlMinutes,
-}: ResolveInput): ClaimResolution => {
+}: Omit<ResolveInput, "session">): LiveMarkers => {
 	const ttlMs = ttlMinutes * 60_000;
 	const live: Marker[] = [];
 	let expired = 0;
@@ -125,21 +137,33 @@ export const resolveClaim = ({
 		if (now - at > ttlMs) expired++;
 		else live.push(marker);
 	}
-
 	const ordered = [...live].sort((a, b) => {
 		const at = instantOf(a.createdAt) ?? 0;
 		const bt = instantOf(b.createdAt) ?? 0;
 		return at === bt ? a.id - b.id : at - bt;
 	});
+	return {_tag: "Live", live: ordered, expired};
+};
+
+/** Order the live markers, then let the earliest survivor win. */
+export const resolveClaim = ({
+	markers,
+	session,
+	now,
+	ttlMinutes,
+}: ResolveInput): ClaimResolution => {
+	const scanned = liveMarkers({markers, now, ttlMinutes});
+	if (scanned._tag === "Unresolvable") return scanned;
+	const {live: ordered, expired} = scanned;
 
 	const mine = ordered.find((m) => m.session === session) ?? null;
 	const earliest = ordered[0];
 	if (earliest === undefined || mine === null) {
-		return {_tag: "MineAbsent", live: live.length, expired};
+		return {_tag: "MineAbsent", live: ordered.length, expired};
 	}
 	return earliest.session === session
-		? {_tag: "Won", marker: earliest, live: live.length, expired}
-		: {_tag: "Lost", holder: earliest, mine, live: live.length, expired};
+		? {_tag: "Won", marker: earliest, live: ordered.length, expired}
+		: {_tag: "Lost", holder: earliest, mine, live: ordered.length, expired};
 };
 
 /**

--- a/packages/fabrika-cli/src/triage/codes.ts
+++ b/packages/fabrika-cli/src/triage/codes.ts
@@ -132,6 +132,20 @@ export const MALFORMED_CRITERIA = 15;
  * answer about a body already on the board, where `Absent` is the case it exists to refuse.
  */
 export const CRITERIA_REQUIRED = 16;
+/**
+ * Refused: a live claim marker on the target names a session other than this one.
+ *
+ * The claim protocol was advisory at exactly the point it needed to bite — `triage claim` resolved
+ * the race and no verb after it re-read the answer, so a session that read `lost` could still
+ * overwrite the winner's authored body (#5644, on #5642). Every mutating verb now re-reads it, and
+ * this is what they refuse on.
+ *
+ * Its own seat rather than {@link ZERO_SCOPE}'s: a closed target and a contested one need opposite
+ * responses — the first says this issue is finished, the second says wait or take the next one — and
+ * a caller cannot route on a code that fuses them. Holding **no** marker is not this refusal: an
+ * unclaimed issue is the ordinary first-triage case and stays mutable.
+ */
+export const CLAIMED_ELSEWHERE = 17;
 
 /** The verb never ran (unresolved binary). The shell's, not this process's — no constant owns it. */
 const NEVER_RAN = 127;
@@ -186,6 +200,10 @@ export const TRIAGE_EXIT_TABLE: ReadonlyArray<ExitCodeRow> = [
 		code: CRITERIA_REQUIRED,
 		meaning:
 			"refused: --ready-for agent over a body carrying no acceptance-criteria block the wire reader answers Found on",
+	},
+	{
+		code: CLAIMED_ELSEWHERE,
+		meaning: "refused: a live claim marker on the target names another session",
 	},
 	{code: NO_IMPLEMENTATION, meaning: "no implementation could be resolved"},
 	{code: NEVER_RAN, meaning: "the verb never ran (unresolved binary)"},

--- a/packages/fabrika-cli/src/triage/codes.unit.test.ts
+++ b/packages/fabrika-cli/src/triage/codes.unit.test.ts
@@ -4,6 +4,7 @@ import * as report from "../report/codes.ts";
 import * as codes from "./codes.ts";
 import {
 	BARE_AT_PATH,
+	CLAIMED_ELSEWHERE,
 	CRITERIA_REQUIRED,
 	DELIBERATE_GAP,
 	EMPTY_STDIN,
@@ -96,7 +97,7 @@ describe("TRIAGE_EXIT_TABLE", () => {
 	});
 
 	it("carries every allocated code exactly once", () => {
-		expect(codes).toEqual([0, 1, 3, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 126, 127]);
+		expect(codes).toEqual([0, 1, 3, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 126, 127]);
 	});
 
 	it("gives every code a non-empty meaning", () => {
@@ -112,5 +113,6 @@ describe("TRIAGE_EXIT_TABLE", () => {
 		expect(meaningOf(UNREPAIRABLE)).toContain("not mechanically repairable");
 		expect(meaningOf(MALFORMED_CRITERIA)).toContain("acceptance-criteria");
 		expect(meaningOf(CRITERIA_REQUIRED)).toContain("--ready-for agent");
+		expect(meaningOf(CLAIMED_ELSEWHERE)).toContain("another session");
 	});
 });

--- a/packages/fabrika-cli/src/triage/command.ts
+++ b/packages/fabrika-cli/src/triage/command.ts
@@ -110,7 +110,7 @@ const kill = leafCommand(
 ).pipe(
 	Command.withShortDescription("Close an agent-filed issue not-planned, with a reason."),
 	Command.withDescription(
-		"Close an agent-filed issue not-planned over four gated writes — the optional redacted duplicate fold, the reason from STDIN, the closed-by-triage label, then the close — and read back that it says not_planned. Prints `killed\\t<number>\\t<foldedInto|none>`. Exits 3 (empty stdin), 5 (machine-local path in the reason), 6 (bare @ reference), 7 (issue absent or closed, duplicate absent or closed, or no closed-by-triage label), 8 (a write failed — UNKNOWN), 9 (read-back is not a not-planned close), 11 (a precondition read failed), 12 (human-filed — no agent footer and no operator author, see $FABRIKA_OPERATOR_ACCOUNTS), 13 (unconfirmed). Example: fabrika triage kill 4312 --confirm --duplicate-of 4290 < reason.md",
+		"Close an agent-filed issue not-planned over four gated writes — the optional redacted duplicate fold, the reason from STDIN, the closed-by-triage label, then the close — and read back that it says not_planned. Prints `killed\\t<number>\\t<foldedInto|none>`. Exits 3 (empty stdin), 5 (machine-local path in the reason), 6 (bare @ reference), 7 (issue absent or closed, duplicate absent or closed, or no closed-by-triage label), 8 (a write failed — UNKNOWN), 9 (read-back is not a not-planned close), 11 (a precondition read failed, including the claim on the issue), 12 (human-filed — no agent footer and no operator author, see $FABRIKA_OPERATOR_ACCOUNTS), 13 (unconfirmed), 17 (a live claim marker on the issue names another session). Example: fabrika triage kill 4312 --confirm --duplicate-of 4290 < reason.md",
 	),
 );
 
@@ -148,7 +148,7 @@ const split = leafCommand(
 ).pipe(
 	Command.withShortDescription("Create one child of a bundled report, exactly once."),
 	Command.withDescription(
-		'Create one child of a bundled report from the body on STDIN, exactly once, and cross-link the parent. Prints `<created|reused>\\t<number>\\t<url>`; both outcomes exit 0. Exits 3 (empty stdin), 5 (machine-local path), 6 (bare @ reference), 7 (parent absent, or the queue label does not exist), 8 (create failed — UNKNOWN), 9 (read-back mismatch), 11 (a precondition read failed — never a silent create). Example: fabrika triage split 4312 --title "Editor loses focus after save" < child.md',
+		'Create one child of a bundled report from the body on STDIN, exactly once, and cross-link the parent. Prints `<created|reused>\\t<number>\\t<url>`; both outcomes exit 0. Exits 3 (empty stdin), 5 (machine-local path), 6 (bare @ reference), 7 (parent absent or closed, or the queue label does not exist), 8 (create failed — UNKNOWN), 9 (read-back mismatch), 11 (a precondition read failed, including the claim on the parent — never a silent create), 17 (a live claim marker on the parent names another session). Example: fabrika triage split 4312 --title "Editor loses focus after save" < child.md',
 	),
 );
 
@@ -206,7 +206,7 @@ const apply = leafCommand(
 ).pipe(
 	Command.withShortDescription("Stamp the whole triaged transition as one reconcile."),
 	Command.withDescription(
-		"Stamp the whole triaged transition — type, priority, audience, status and home — as ONE owned-facet reconcile, then read the end state back positively. Exactly one of --home / --lane. Prints `triaged\\t<n>\\t<type>\\t<priority>\\t<ready-for>\\t<home>`. Exits 7 (no such issue, or a label this run would write does not exist), 8 (a write failed — UNKNOWN), 9 (read-back mismatch), 10 (off-vocabulary value, or a non-open milestone), 11 (a precondition read failed), 16 (--ready-for agent over a body with no readable acceptance-criteria block — every type but epic). Example: fabrika triage apply 4312 --type bug --priority p2 --ready-for agent --home 47",
+		"Stamp the whole triaged transition — type, priority, audience, status and home — as ONE owned-facet reconcile, then read the end state back positively. Exactly one of --home / --lane. Prints `triaged\\t<n>\\t<type>\\t<priority>\\t<ready-for>\\t<home>`. Exits 7 (no such issue, it is closed, or a label this run would write does not exist), 8 (a write failed — UNKNOWN), 9 (read-back mismatch), 10 (off-vocabulary value, or a non-open milestone), 11 (a precondition read failed, including the claim on the issue), 16 (--ready-for agent over a body with no readable acceptance-criteria block — every type but epic), 17 (a live claim marker on the issue names another session). Example: fabrika triage apply 4312 --type bug --priority p2 --ready-for agent --home 47",
 	),
 );
 
@@ -227,7 +227,7 @@ const park = leafCommand(
 ).pipe(
 	Command.withShortDescription("Demote an issue to needs-info with the questions on stdin."),
 	Command.withDescription(
-		"Demote an issue to status:needs-info with the questions on STDIN, clearing every priced facet — type, priority, audience, lane and milestone. The comment is posted BEFORE the labels move. Prints `parked\\t<n>\\t<comment-url>`. Exits 3 (empty stdin), 5 (machine-local path), 6 (bare @ reference), 7 (no such issue, or status:needs-info does not exist), 8 (a write failed — UNKNOWN), 9 (read-back mismatch), 11 (a precondition read failed). Example: fabrika triage park 4290 < questions.md",
+		"Demote an issue to status:needs-info with the questions on STDIN, clearing every priced facet — type, priority, audience, lane and milestone. The comment is posted BEFORE the labels move. Prints `parked\\t<n>\\t<comment-url>`. Exits 3 (empty stdin), 5 (machine-local path), 6 (bare @ reference), 7 (no such issue, it is closed, or status:needs-info does not exist), 8 (a write failed — UNKNOWN), 9 (read-back mismatch), 11 (a precondition read failed, including the claim on the issue), 17 (a live claim marker on the issue names another session). Example: fabrika triage park 4290 < questions.md",
 	),
 );
 
@@ -371,7 +371,7 @@ const enrich = leafCommand(
 ).pipe(
 	Command.withShortDescription("Replace an issue body with the rewrite on stdin."),
 	Command.withDescription(
-		"Replace an issue body with the rewrite on STDIN above the preserved, leak-redacted original — or with --epic, a pitch above the original under a fixed header. A prior enrichment is recognised by the marker this verb writes, bound to this issue number, so a re-run in EITHER mode replaces the authored region instead of nesting a second envelope. Prints `enriched\\t<number>\\t<redactions>`. Exits 3 (empty stdin), 5 (machine-local path in the authored text), 6 (bare @ reference), 7 (issue absent, or its body is empty — no original to preserve), 8 (the PATCH failed — UNKNOWN), 9 (read-back mismatch), 11 (the issue could not be read). Example: fabrika triage enrich 4312 < enriched.md",
+		"Replace an issue body with the rewrite on STDIN above the preserved, leak-redacted original — or with --epic, a pitch above the original under a fixed header. A prior enrichment is recognised by the marker this verb writes, bound to this issue number, so a re-run in EITHER mode replaces the authored region instead of nesting a second envelope. Prints `enriched\\t<number>\\t<redactions>`. Exits 3 (empty stdin), 5 (machine-local path in the authored text), 6 (bare @ reference), 7 (issue absent or closed, or its body is empty — no original to preserve), 8 (the PATCH failed — UNKNOWN), 9 (read-back mismatch), 11 (the issue, or the claim on it, could not be read), 17 (a live claim marker on the issue names another session). Example: fabrika triage enrich 4312 < enriched.md",
 	),
 );
 

--- a/packages/fabrika-cli/src/triage/command.ts
+++ b/packages/fabrika-cli/src/triage/command.ts
@@ -20,7 +20,7 @@ import {leafCommand} from "../excess-operand.ts";
 import {readStdin} from "../io/stdin.ts";
 import type {VerbOutcome} from "../verb.ts";
 import {runApply} from "./apply-verb.ts";
-import {DEFAULT_TTL_MINUTES, runClaim} from "./claim-verb.ts";
+import {runClaim} from "./claim-verb.ts";
 import {runCodes} from "./codes-verb.ts";
 import {runEnrich} from "./enrich-verb.ts";
 import {AUDIENCES, PRIORITIES, STANDING_LANES, TYPES} from "./facets.ts";
@@ -235,20 +235,13 @@ const claim = leafCommand(
 	"claim",
 	{
 		issue: Argument.integer("issue").pipe(Argument.withDescription("the issue number to claim")),
-		ttlMinutes: Flag.integer("ttl-minutes").pipe(
-			Flag.withDefault(DEFAULT_TTL_MINUTES),
-			Flag.withDescription(
-				`how long an existing claim marker stays binding before it is treated as abandoned (default: ${DEFAULT_TTL_MINUTES})`,
-			),
-		),
 		repo: repoFlag,
 		json: jsonFlag,
 	},
-	Effect.fn(function* ({issue, ttlMinutes, repo, json}) {
+	Effect.fn(function* ({issue, repo, json}) {
 		yield* emit(
 			yield* runClaim({
 				issue,
-				ttlMinutes,
 				repo: Option.getOrNull(repo),
 				json,
 				env: process.env,

--- a/packages/fabrika-cli/src/triage/enrich-verb.ts
+++ b/packages/fabrika-cli/src/triage/enrich-verb.ts
@@ -30,6 +30,7 @@ import {
 } from "./codes.ts";
 import {authoredRegion, composeBody, detect, type EnrichMode, wrapOriginal} from "./enrich.ts";
 import {legacyPreserved} from "./enrich-legacy.ts";
+import {guardTarget} from "./target-guard.ts";
 
 export interface EnrichOptions {
 	readonly issue: number;
@@ -83,6 +84,15 @@ export const runEnrich = (
 				`triage enrich: cannot read #${issue} in ${repo}: ${target.reason} — refusing to write an envelope over an original that was never read.`,
 			);
 		}
+
+		const guarded = yield* guardTarget({
+			verb: "triage enrich",
+			repo,
+			issue,
+			target: target.value,
+			env: options.env,
+		});
+		if (guarded !== null) return guarded;
 
 		const before = target.value.body;
 		const detection = detect(before, issue, legacyPreserved);

--- a/packages/fabrika-cli/src/triage/enrich-verb.unit.test.ts
+++ b/packages/fabrika-cli/src/triage/enrich-verb.unit.test.ts
@@ -1,10 +1,12 @@
 import {Effect} from "effect";
 import {describe, expect, it} from "vitest";
-import {errOut, fakeShell, okOut, once} from "../fakes.test-support.ts";
+import {errOut, okOut, once} from "../fakes.test-support.ts";
 import type {ExecResult} from "../io/exec.ts";
 import type {StdinRead} from "../io/stdin.ts";
+import {COMMENTS, claimPage, EXPIRED, guardedShell, LIVE} from "./claim-fixtures.test-support.ts";
 import {
 	BARE_AT_PATH,
+	CLAIMED_ELSEWHERE,
 	EMPTY_STDIN,
 	LEAKED_PATH,
 	MALFORMED_CRITERIA,
@@ -59,7 +61,7 @@ const written = (calls: ReadonlyArray<string>): string | null => {
  * make every read-back assertion a statement about the fixture rather than about the verb.
  */
 const run = async (before: string, overrides: Partial<typeof options> = {}) => {
-	const shell = fakeShell([
+	const shell = guardedShell([
 		[once(READ), issue(before)],
 		[PATCH, okOut("{}")],
 	]);
@@ -69,7 +71,7 @@ const run = async (before: string, overrides: Partial<typeof options> = {}) => {
 	);
 	const patched = written(shell.calls);
 	if (patched === null) return {outcome: probe, body: null, calls: shell.calls};
-	const echoing = fakeShell([
+	const echoing = guardedShell([
 		[once(READ), issue(before)],
 		[PATCH, okOut("{}")],
 		[READ, issue(patched)],
@@ -84,7 +86,9 @@ const runScripted = (
 	script: ReadonlyArray<readonly [RegExp, ExecResult]>,
 	overrides: Partial<typeof options> = {},
 ) =>
-	Effect.runPromise(Effect.provide(runEnrich({...options, ...overrides}), fakeShell(script).layer));
+	Effect.runPromise(
+		Effect.provide(runEnrich({...options, ...overrides}), guardedShell(script).layer),
+	);
 
 const summaryLines = (body: string): ReadonlyArray<string> =>
 	body.split("\n").filter((line) => line === SUMMARY_LINE.rewrite || line === SUMMARY_LINE.wrap);
@@ -268,7 +272,7 @@ describe("runEnrich — legacy migration", () => {
 
 describe("runEnrich — the composed body's criteria block must be one the wire reader accepts (#5565, ADR 0288)", () => {
 	it("refuses a level-2 heading on 15, naming the level it read and the level expected", async () => {
-		const shell = fakeShell([[READ, issue(ORIGINAL)]]);
+		const shell = guardedShell([[READ, issue(ORIGINAL)]]);
 		const outcome = await Effect.runPromise(
 			Effect.provide(
 				runEnrich({
@@ -312,7 +316,7 @@ describe("runEnrich — the composed body's criteria block must be one the wire 
 	});
 
 	it("refuses a drifted block in an --epic pitch too, where the envelope heads it with `## Pitch`", async () => {
-		const shell = fakeShell([[READ, issue(ORIGINAL)]]);
+		const shell = guardedShell([[READ, issue(ORIGINAL)]]);
 		const outcome = await Effect.runPromise(
 			Effect.provide(
 				runEnrich({
@@ -341,7 +345,7 @@ describe("runEnrich — refusals", () => {
 	});
 
 	it("refuses empty-but-READ stdin on 3, and writes nothing", async () => {
-		const shell = fakeShell([[READ, issue(ORIGINAL)]]);
+		const shell = guardedShell([[READ, issue(ORIGINAL)]]);
 		const outcome = await Effect.runPromise(
 			Effect.provide(
 				runEnrich({...options, stdin: Effect.succeed<StdinRead>({_tag: "Text", text: "  \n"})}),
@@ -360,7 +364,7 @@ describe("runEnrich — refusals", () => {
 	});
 
 	it("refuses a machine-local path in the AUTHORED rewrite on 5, while redacting the original", async () => {
-		const shell = fakeShell([[READ, issue(ORIGINAL)]]);
+		const shell = guardedShell([[READ, issue(ORIGINAL)]]);
 		const outcome = await Effect.runPromise(
 			Effect.provide(
 				runEnrich({
@@ -385,7 +389,7 @@ describe("runEnrich — refusals", () => {
 	});
 
 	it("separates an UNREADABLE issue from an absent one, and writes nothing", async () => {
-		const shell = fakeShell([[READ, errOut("gh: Bad gateway (HTTP 502)")]]);
+		const shell = guardedShell([[READ, errOut("gh: Bad gateway (HTTP 502)")]]);
 		const outcome = await Effect.runPromise(Effect.provide(runEnrich(options), shell.layer));
 		expect(outcome.code).toBe(PRECONDITION_UNKNOWN);
 		expect(outcome.stderr.at(-1)).toContain("an original that was never read");
@@ -393,7 +397,7 @@ describe("runEnrich — refusals", () => {
 	});
 
 	it("refuses an EMPTY body rather than preserving nothing as though it were the record", async () => {
-		const shell = fakeShell([[READ, issue("   \n")]]);
+		const shell = guardedShell([[READ, issue("   \n")]]);
 		const outcome = await Effect.runPromise(Effect.provide(runEnrich(options), shell.layer));
 		expect(outcome.code).toBe(ZERO_SCOPE);
 		expect(outcome.stderr.at(-1)).toContain("there is no original to preserve");
@@ -443,11 +447,85 @@ describe("runEnrich — refusals", () => {
 
 	it("refuses a non-issue number, and an unresolvable repo, before reading anything", async () => {
 		expect((await runScripted([], {issue: -1})).code).toBe(1);
-		const shell = fakeShell([]);
+		const shell = guardedShell([]);
 		const outcome = await Effect.runPromise(
 			Effect.provide(runEnrich({...options, env: {}}), shell.layer),
 		);
 		expect(outcome.code).toBe(1);
 		expect(shell.calls.some((line) => PATCH.test(line))).toBe(false);
+	});
+});
+
+/** #5644: the claim protocol was advisory, and this is the verb that overwrote #5642's body. */
+describe("runEnrich — the target guard", () => {
+	const MINE = "session-mine";
+	const THEIRS = "session-theirs";
+	const mine = {CLAUDE_PIPELINE_REPO: "o/r", CLAUDE_CODE_SESSION_ID: MINE} as Record<
+		string,
+		string | undefined
+	>;
+	const closed = okOut(
+		JSON.stringify({
+			number: 4312,
+			title: "t",
+			body: ORIGINAL,
+			state: "closed",
+			labels: [],
+			html_url: "https://example.test/issues/4312",
+			milestone: null,
+		}),
+	);
+
+	const guard = async (script: ReadonlyArray<readonly [RegExp, ExecResult]>) => {
+		const shell = guardedShell(script);
+		const outcome = await Effect.runPromise(
+			Effect.provide(runEnrich({...options, env: mine}), shell.layer),
+		);
+		return {outcome, patched: shell.calls.some((line) => PATCH.test(line))};
+	};
+
+	it("refuses a closed issue on 7 and writes nothing", async () => {
+		const {outcome, patched} = await guard([[READ, closed]]);
+		expect(outcome.code).toBe(ZERO_SCOPE);
+		expect(patched).toBe(false);
+	});
+
+	it("refuses a live claim held by another session on 17 and writes nothing", async () => {
+		const {outcome, patched} = await guard([
+			[READ, issue(ORIGINAL)],
+			[COMMENTS, claimPage({session: THEIRS, createdAt: LIVE})],
+			[PATCH, okOut("{}")],
+		]);
+		expect(outcome.code).toBe(CLAIMED_ELSEWHERE);
+		expect(patched).toBe(false);
+	});
+
+	it("writes when the live claim is this session's own", async () => {
+		const {patched} = await guard([
+			[once(READ), issue(ORIGINAL)],
+			[COMMENTS, claimPage({session: MINE, createdAt: LIVE})],
+			[PATCH, okOut("{}")],
+			[READ, issue(ORIGINAL)],
+		]);
+		expect(patched).toBe(true);
+	});
+
+	it("writes over an issue nobody has claimed", async () => {
+		const {patched} = await guard([
+			[once(READ), issue(ORIGINAL)],
+			[PATCH, okOut("{}")],
+			[READ, issue(ORIGINAL)],
+		]);
+		expect(patched).toBe(true);
+	});
+
+	it("writes when the only foreign claim has aged out", async () => {
+		const {patched} = await guard([
+			[once(READ), issue(ORIGINAL)],
+			[COMMENTS, claimPage({session: THEIRS, createdAt: EXPIRED})],
+			[PATCH, okOut("{}")],
+			[READ, issue(ORIGINAL)],
+		]);
+		expect(patched).toBe(true);
 	});
 });

--- a/packages/fabrika-cli/src/triage/kill-verb.ts
+++ b/packages/fabrika-cli/src/triage/kill-verb.ts
@@ -42,6 +42,7 @@ import {
 } from "./codes.ts";
 import {OPERATOR_ACCOUNTS_ENV, provenanceOf, resolveOperatorAccounts} from "./provenance.ts";
 import {scannedLine} from "./scope.ts";
+import {guardTarget} from "./target-guard.ts";
 
 /** The label a kill is audited by. Its absence in the repo is a zero-scope refusal, not a create. */
 export const KILL_LABEL = "closed-by-triage";
@@ -111,9 +112,14 @@ export const runKill = (
 				`triage kill: cannot read #${issue} in ${repo}: ${target.reason} — the provenance test has no evidence; refusing to close on a body that was never read.`,
 			);
 		}
-		if (target.value.state === "closed") {
-			return refuse(ZERO_SCOPE, `triage kill: issue #${issue} is already closed.`);
-		}
+		const guarded = yield* guardTarget({
+			verb: "triage kill",
+			repo,
+			issue,
+			target: target.value,
+			env: options.env,
+		});
+		if (guarded !== null) return guarded;
 
 		const operators = resolveOperatorAccounts(options.env);
 		const provenance = provenanceOf(target.value, operators);

--- a/packages/fabrika-cli/src/triage/kill-verb.unit.test.ts
+++ b/packages/fabrika-cli/src/triage/kill-verb.unit.test.ts
@@ -1,10 +1,12 @@
 import {Effect} from "effect";
 import {describe, expect, it} from "vitest";
-import {errOut, fakeShell, okOut} from "../fakes.test-support.ts";
+import {errOut, okOut} from "../fakes.test-support.ts";
 import type {ExecResult} from "../io/exec.ts";
 import type {StdinRead} from "../io/stdin.ts";
+import {COMMENTS, claimPage, EXPIRED, guardedShell, LIVE} from "./claim-fixtures.test-support.ts";
 import {
 	BARE_AT_PATH,
+	CLAIMED_ELSEWHERE,
 	EMPTY_STDIN,
 	HUMAN_FILED,
 	LEAKED_PATH,
@@ -121,7 +123,7 @@ const runWith = (
 	script: ReadonlyArray<readonly [RegExp, ExecResult]>,
 	overrides: Partial<typeof options> = {},
 ) => {
-	const shell = fakeShell(script);
+	const shell = guardedShell(script);
 	return Effect.runPromise(Effect.provide(runKill({...options, ...overrides}), shell.layer)).then(
 		(out) => ({out, calls: shell.calls}),
 	);
@@ -569,5 +571,60 @@ describe("runKill", () => {
 		const {out} = await runWith(happy(), {duplicateOf: 4312});
 		expect(out.code).toBe(1);
 		expect(out.stderr.at(-1)).toContain("into itself");
+	});
+});
+
+/** #5644: kill already refused a closed target; the claim half is what it was missing. */
+describe("runKill — the target guard", () => {
+	const MINE = "session-mine";
+	const THEIRS = "session-theirs";
+	const mine = {
+		CLAUDE_PIPELINE_REPO: "o/r",
+		CLAUDE_CODE_SESSION_ID: MINE,
+	} as Record<string, string | undefined>;
+
+	const guard = async (script: ReadonlyArray<readonly [RegExp, ExecResult]>) => {
+		const {out, calls} = await runWith(script, {env: mine});
+		return {out, wrote: calls.some((line) => CLOSE.test(line) || REASON_COMMENT.test(line))};
+	};
+
+	it("refuses a closed issue on 7 and writes nothing", async () => {
+		const {out, wrote} = await guard([
+			[ISSUE, issue({state: "closed"})],
+			[LABELS, labelSet],
+		]);
+		expect(out.code).toBe(ZERO_SCOPE);
+		expect(out.stderr.at(-1)).toContain("issue #4312 is already closed.");
+		expect(wrote).toBe(false);
+	});
+
+	it("refuses a live claim held by another session on 17 and writes nothing", async () => {
+		const {out, wrote} = await guard([
+			...happy(),
+			[COMMENTS, claimPage({session: THEIRS, createdAt: LIVE})],
+		]);
+		expect(out.code).toBe(CLAIMED_ELSEWHERE);
+		expect(wrote).toBe(false);
+	});
+
+	it("kills when the live claim is this session's own", async () => {
+		const {out} = await guard([
+			...happy(),
+			[COMMENTS, claimPage({session: MINE, createdAt: LIVE})],
+		]);
+		expect(out.code).toBe(0);
+	});
+
+	it("kills an issue nobody has claimed", async () => {
+		const {out} = await guard(happy());
+		expect(out.code).toBe(0);
+	});
+
+	it("kills when the only foreign claim has aged out", async () => {
+		const {out} = await guard([
+			...happy(),
+			[COMMENTS, claimPage({session: THEIRS, createdAt: EXPIRED})],
+		]);
+		expect(out.code).toBe(0);
 	});
 });

--- a/packages/fabrika-cli/src/triage/park-verb.ts
+++ b/packages/fabrika-cli/src/triage/park-verb.ts
@@ -23,6 +23,7 @@ import {PRECONDITION_UNKNOWN, READBACK_MISMATCH, WRITE_UNKNOWN, ZERO_SCOPE} from
 import {applyChanges} from "./facet-writes.ts";
 import {parkedFacets, planReconcile, renderShape, shapeViolations} from "./facets.ts";
 import {scannedLine} from "./scope.ts";
+import {guardTarget} from "./target-guard.ts";
 
 const SURFACE: AuthoredSurface = {
 	verb: "triage park",
@@ -76,6 +77,15 @@ export const runPark = (
 			return refuse(ZERO_SCOPE, `triage park: issue #${issue} not found in ${repo}.`);
 		}
 		if (target._tag === "Unknown") return unreadable(`issue #${issue}`, repo, target.reason);
+
+		const guarded = yield* guardTarget({
+			verb: "triage park",
+			repo,
+			issue,
+			target: target.value,
+			env: options.env,
+		});
+		if (guarded !== null) return guarded;
 
 		const vocabulary = yield* listLabels(repo);
 		if (vocabulary._tag === "Failure") return unreadable("the label set", repo, vocabulary.reason);

--- a/packages/fabrika-cli/src/triage/park-verb.unit.test.ts
+++ b/packages/fabrika-cli/src/triage/park-verb.unit.test.ts
@@ -1,10 +1,12 @@
 import {Effect} from "effect";
 import {describe, expect, it} from "vitest";
-import {errOut, fakeShell, okOut, once} from "../fakes.test-support.ts";
+import {errOut, okOut, once} from "../fakes.test-support.ts";
 import type {ExecResult} from "../io/exec.ts";
 import type {StdinRead} from "../io/stdin.ts";
+import {COMMENTS, claimPage, EXPIRED, guardedShell, LIVE} from "./claim-fixtures.test-support.ts";
 import {
 	BARE_AT_PATH,
+	CLAIMED_ELSEWHERE,
 	EMPTY_STDIN,
 	LEAKED_PATH,
 	PRECONDITION_UNKNOWN,
@@ -70,7 +72,9 @@ const run = (
 	script: ReadonlyArray<readonly [RegExp, ExecResult]>,
 	overrides: Partial<typeof options> = {},
 ) =>
-	Effect.runPromise(Effect.provide(runPark({...options, ...overrides}), fakeShell(script).layer));
+	Effect.runPromise(
+		Effect.provide(runPark({...options, ...overrides}), guardedShell(script).layer),
+	);
 
 describe("runPark", () => {
 	it("parks the issue and prints the tab-separated parked line", async () => {
@@ -97,7 +101,7 @@ describe("runPark", () => {
 	});
 
 	it("posts the questions BEFORE it touches a label", async () => {
-		const shell = fakeShell(happy());
+		const shell = guardedShell(happy());
 		await Effect.runPromise(Effect.provide(runPark(options), shell.layer));
 		const writes = shell.calls.filter(
 			(c) => COMMENT.test(c) || PATCH.test(c) || REMOVE.test(c) || ADD.test(c),
@@ -107,7 +111,7 @@ describe("runPark", () => {
 	});
 
 	it("clears every priced facet, milestone included", async () => {
-		const shell = fakeShell(happy());
+		const shell = guardedShell(happy());
 		await Effect.runPromise(Effect.provide(runPark(options), shell.layer));
 		expect(shell.calls).toContain("gh api --method PATCH repos/o/r/issues/4290 -F milestone=null");
 		expect(shell.calls.filter((c) => REMOVE.test(c))).toEqual([
@@ -120,7 +124,7 @@ describe("runPark", () => {
 	});
 
 	it("leaves a label no facet owns alone across a park", async () => {
-		const shell = fakeShell([
+		const shell = guardedShell([
 			[once(ISSUE), issue(["area:pipeline", "status:needs-triage"], null)],
 			[ISSUE, issue(["area:pipeline", "status:needs-info"], null)],
 			[LABELS, VOCABULARY],
@@ -207,7 +211,7 @@ describe("runPark", () => {
 	});
 
 	it("writes nothing at all on any stdin refusal", async () => {
-		const shell = fakeShell(happy());
+		const shell = guardedShell(happy());
 		await Effect.runPromise(
 			Effect.provide(
 				runPark({
@@ -227,14 +231,14 @@ describe("runPark", () => {
 	});
 
 	it("separates an UNREADABLE issue from an absent one, and posts nothing", async () => {
-		const shell = fakeShell([[ISSUE, errOut("gh: Bad gateway (HTTP 502)")]]);
+		const shell = guardedShell([[ISSUE, errOut("gh: Bad gateway (HTTP 502)")]]);
 		const out = await Effect.runPromise(Effect.provide(runPark(options), shell.layer));
 		expect(out.code).toBe(PRECONDITION_UNKNOWN);
 		expect(shell.calls.some((c) => COMMENT.test(c))).toBe(false);
 	});
 
 	it("refuses to write status:needs-info when the repo does not define it (#4285)", async () => {
-		const shell = fakeShell([
+		const shell = guardedShell([
 			[ISSUE, issue(["status:needs-triage"], null)],
 			[LABELS, okOut(["type:bug", "status:needs-triage"].join("\n"))],
 			[COMMENT, POSTED],
@@ -255,7 +259,7 @@ describe("runPark", () => {
 	});
 
 	it("reports a failed comment as UNKNOWN, and says nothing was labelled", async () => {
-		const shell = fakeShell([
+		const shell = guardedShell([
 			[ISSUE, issue(["status:needs-triage"], null)],
 			[LABELS, VOCABULARY],
 			[COMMENT, errOut("gh: timeout")],
@@ -340,9 +344,74 @@ describe("runPark", () => {
 
 	it("refuses an unresolvable repo rather than guessing one", async () => {
 		const out = await Effect.runPromise(
-			Effect.provide(runPark({...options, env: {}}), fakeShell([]).layer),
+			Effect.provide(runPark({...options, env: {}}), guardedShell([]).layer),
 		);
 		expect(out.code).toBe(1);
 		expect(out.stderr.at(-1)).toContain("cannot resolve a target repo");
+	});
+});
+
+/** #5644: the claim protocol only holds if the mutating verbs re-read it. */
+describe("runPark — the target guard", () => {
+	const MINE = "session-mine";
+	const THEIRS = "session-theirs";
+	const mine = {CLAUDE_PIPELINE_REPO: "o/r", CLAUDE_CODE_SESSION_ID: MINE} as Record<
+		string,
+		string | undefined
+	>;
+	const closed = okOut(
+		JSON.stringify({
+			number: 4290,
+			title: "t",
+			body: "b",
+			state: "closed",
+			labels: [],
+			html_url: "https://example.test/issues/4290",
+			milestone: null,
+		}),
+	);
+
+	const guard = async (script: ReadonlyArray<readonly [RegExp, ExecResult]>) => {
+		const shell = guardedShell(script);
+		const out = await Effect.runPromise(
+			Effect.provide(runPark({...options, env: mine}), shell.layer),
+		);
+		return {out, wrote: shell.calls.some((line) => COMMENT.test(line) || ADD.test(line))};
+	};
+
+	it("refuses a closed issue on 7 and writes nothing", async () => {
+		const {out, wrote} = await guard([[ISSUE, closed]]);
+		expect(out.code).toBe(ZERO_SCOPE);
+		expect(wrote).toBe(false);
+	});
+
+	it("refuses a live claim held by another session on 17 and writes nothing", async () => {
+		const {out, wrote} = await guard([
+			...happy(),
+			[COMMENTS, claimPage({session: THEIRS, createdAt: LIVE})],
+		]);
+		expect(out.code).toBe(CLAIMED_ELSEWHERE);
+		expect(wrote).toBe(false);
+	});
+
+	it("parks when the live claim is this session's own", async () => {
+		const {out} = await guard([
+			...happy(),
+			[COMMENTS, claimPage({session: MINE, createdAt: LIVE})],
+		]);
+		expect(out.code).toBe(0);
+	});
+
+	it("parks an issue nobody has claimed", async () => {
+		const {out} = await guard(happy());
+		expect(out.code).toBe(0);
+	});
+
+	it("parks when the only foreign claim has aged out", async () => {
+		const {out} = await guard([
+			...happy(),
+			[COMMENTS, claimPage({session: THEIRS, createdAt: EXPIRED})],
+		]);
+		expect(out.code).toBe(0);
 	});
 });

--- a/packages/fabrika-cli/src/triage/split-verb.ts
+++ b/packages/fabrika-cli/src/triage/split-verb.ts
@@ -44,6 +44,7 @@ import {
 	isExistingChild,
 	normalizeTitle,
 } from "./split.ts";
+import {guardTarget} from "./target-guard.ts";
 
 const VERB = "triage split";
 const QUEUE_LABEL = "status:needs-triage";
@@ -170,6 +171,17 @@ export const runSplit = Effect.fn(function* (options: SplitOptions) {
 	if (parentIssue._tag === "Unknown") {
 		return unreadable(`parent #${parent}`, repo, parentIssue.reason, []);
 	}
+
+	const guarded = yield* guardTarget({
+		verb: VERB,
+		repo,
+		issue: parent,
+		target: parentIssue.value,
+		noun: "parent",
+		env: options.env,
+		now: options.now,
+	});
+	if (guarded !== null) return guarded;
 
 	// Read 1's label is a hardcoded literal while --repo is generic, so a renamed label or a
 	// scope-limited token returns HTTP 200 with `[]` — not a read failure, and therefore not 11. The

--- a/packages/fabrika-cli/src/triage/split-verb.unit.test.ts
+++ b/packages/fabrika-cli/src/triage/split-verb.unit.test.ts
@@ -1,10 +1,12 @@
 import {Effect} from "effect";
 import {describe, expect, it} from "vitest";
-import {errOut, fakeShell, okOut} from "../fakes.test-support.ts";
+import {errOut, okOut} from "../fakes.test-support.ts";
 import type {ExecResult} from "../io/exec.ts";
 import type {StdinRead} from "../io/stdin.ts";
 import {renderFooter} from "../report/compose.ts";
+import {COMMENTS, claimPage, EXPIRED, guardedShell, LIVE} from "./claim-fixtures.test-support.ts";
 import {
+	CLAIMED_ELSEWHERE,
 	EMPTY_STDIN,
 	LEAKED_PATH,
 	PRECONDITION_UNKNOWN,
@@ -85,7 +87,7 @@ const run = (
 	steps: ReadonlyArray<readonly [RegExp, ExecResult]> = base,
 	over: Partial<typeof options> = {},
 ) => {
-	const shell = fakeShell(steps);
+	const shell = guardedShell(steps);
 	return Effect.runPromise(Effect.provide(runSplit({...options, ...over}), shell.layer)).then(
 		(outcome) => ({outcome, calls: shell.calls}),
 	);
@@ -313,5 +315,56 @@ describe("runSplit — the authored-text guard", () => {
 		const {outcome, calls} = await run(base, {parent: 0});
 		expect(outcome.code).toBe(1);
 		expect(calls).toEqual([]);
+	});
+});
+
+/** #5644: the guard reads the PARENT — the issue this verb mutates by cross-linking it. */
+describe("runSplit — the parent guard", () => {
+	const MINE = "session-mine";
+	const THEIRS = "session-theirs";
+	const mine = {CLAUDE_PIPELINE_REPO: "o/r", CLAUDE_CODE_SESSION_ID: MINE} as Record<
+		string,
+		string | undefined
+	>;
+
+	// The composed child body carries the session in its footer, so a run under a session id cannot
+	// match COMPOSED's read-back. What the guard decides is whether the create was reached at all.
+	const guard = async (steps: ReadonlyArray<readonly [RegExp, ExecResult]>) => {
+		const {outcome, calls} = await run(steps, {env: mine});
+		return {outcome, created: calls.some((line) => CREATE.test(line))};
+	};
+
+	it("refuses a closed parent on 7 and creates nothing", async () => {
+		const {outcome, created} = await guard(
+			script([PARENT, issue({number: 4312, title: "Two unrelated bugs", state: "closed"})]),
+		);
+		expect(outcome.code).toBe(ZERO_SCOPE);
+		expect(outcome.stderr.at(-1)).toContain("parent #4312 is already closed.");
+		expect(created).toBe(false);
+	});
+
+	it("refuses a live claim held by another session on 17 and creates nothing", async () => {
+		const {outcome, created} = await guard(
+			script([COMMENTS, claimPage({session: THEIRS, createdAt: LIVE})]),
+		);
+		expect(outcome.code).toBe(CLAIMED_ELSEWHERE);
+		expect(created).toBe(false);
+	});
+
+	it("creates when the live claim is this session's own", async () => {
+		const {created} = await guard(script([COMMENTS, claimPage({session: MINE, createdAt: LIVE})]));
+		expect(created).toBe(true);
+	});
+
+	it("creates over a parent nobody has claimed", async () => {
+		const {created} = await guard(base);
+		expect(created).toBe(true);
+	});
+
+	it("creates when the only foreign claim has aged out", async () => {
+		const {created} = await guard(
+			script([COMMENTS, claimPage({session: THEIRS, createdAt: EXPIRED})]),
+		);
+		expect(created).toBe(true);
 	});
 });

--- a/packages/fabrika-cli/src/triage/target-guard.ts
+++ b/packages/fabrika-cli/src/triage/target-guard.ts
@@ -69,7 +69,6 @@ export interface GuardOptions {
 	readonly noun?: string;
 	readonly env: Readonly<Record<string, string | undefined>>;
 	readonly now?: () => Date;
-	readonly ttlMinutes?: number;
 }
 
 /**
@@ -101,7 +100,7 @@ export const guardTarget = (
 			markers: markersOf(comments.value),
 			session: options.env.CLAUDE_CODE_SESSION_ID ?? "",
 			now: (options.now ?? (() => new Date()))().getTime(),
-			ttlMinutes: options.ttlMinutes ?? DEFAULT_TTL_MINUTES,
+			ttlMinutes: DEFAULT_TTL_MINUTES,
 		});
 		if (scanned._tag === "Unresolvable") {
 			return refuse(

--- a/packages/fabrika-cli/src/triage/target-guard.ts
+++ b/packages/fabrika-cli/src/triage/target-guard.ts
@@ -1,0 +1,121 @@
+/**
+ * The two preconditions every mutating `triage` verb re-reads on its target: it is still open, and
+ * no live claim marker on it names another session.
+ *
+ * `triage claim` resolved the race correctly and nothing after it read the answer back, so the
+ * protocol held only as long as prose discipline did. On 2026-08-15 it did not: a session that had
+ * read `lost` ran `triage enrich` anyway and replaced the winner's authored body four minutes after
+ * that session had closed the issue (#5644, on #5642). Both facts were sitting on the issue and
+ * neither was read.
+ *
+ * **Holding no marker passes.** The check is "does a live marker name somebody else", not "do I hold
+ * one": an unclaimed issue is the ordinary first-triage case, and demanding a marker would refuse
+ * every existing caller. The consequence is that this guard narrows the window rather than closing
+ * it — two unclaimed sessions still race — which is `triage claim`'s job, not this one's.
+ */
+import {Effect} from "effect";
+import type {ChildProcessSpawner} from "effect/unstable/process";
+import {type IssueRecord, listComments} from "../io/issues.ts";
+import {refuse, type VerbOutcome} from "../verb.ts";
+import {
+	DEFAULT_TTL_MINUTES,
+	isStampableSession,
+	liveMarkers,
+	type Marker,
+	markersOf,
+} from "./claim.ts";
+import {CLAIMED_ELSEWHERE, PRECONDITION_UNKNOWN, ZERO_SCOPE} from "./codes.ts";
+
+/**
+ * The live markers naming a session other than `session`, or the reason the set is unreadable.
+ *
+ * A session id this module cannot attribute a marker to — unset, or not one stampable token — makes
+ * **every** live marker foreign. The alternative fails open exactly where it matters: an empty id
+ * matches no marker, so a set full of live competitors would resolve to "nobody else holds it".
+ */
+export const foreignMarkers = ({
+	markers,
+	session,
+	now,
+	ttlMinutes,
+}: {
+	readonly markers: ReadonlyArray<Marker>;
+	readonly session: string;
+	readonly now: number;
+	readonly ttlMinutes: number;
+}):
+	| {readonly _tag: "Foreign"; readonly foreign: ReadonlyArray<Marker>}
+	| {
+			readonly _tag: "Unresolvable";
+			readonly reason: string;
+	  } => {
+	const scanned = liveMarkers({markers, now, ttlMinutes});
+	if (scanned._tag === "Unresolvable") return scanned;
+	const mine = isStampableSession(session) ? session : null;
+	return {
+		_tag: "Foreign",
+		foreign: scanned.live.filter((m) => mine === null || m.session !== mine),
+	};
+};
+
+export interface GuardOptions {
+	/** The verb's own name, so the refusal reads as that verb's. */
+	readonly verb: string;
+	readonly repo: string;
+	readonly issue: number;
+	/** The record already read — this guard never re-fetches an issue a verb has in hand. */
+	readonly target: IssueRecord;
+	/** What the target is to this verb — `split` guards a parent, not the issue it creates. */
+	readonly noun?: string;
+	readonly env: Readonly<Record<string, string | undefined>>;
+	readonly now?: () => Date;
+	readonly ttlMinutes?: number;
+}
+
+/**
+ * The refusal this target earns, or `null` when it is open and uncontested.
+ *
+ * Placed after the verb's own read of the issue and before its first write, so a refusal here always
+ * means nothing landed.
+ */
+export const guardTarget = (
+	options: GuardOptions,
+): Effect.Effect<VerbOutcome | null, never, ChildProcessSpawner.ChildProcessSpawner> =>
+	Effect.gen(function* () {
+		const {verb, repo, issue, target} = options;
+		const noun = options.noun ?? "issue";
+
+		if (target.state === "closed") {
+			return refuse(ZERO_SCOPE, `${verb}: ${noun} #${issue} is already closed.`);
+		}
+
+		const comments = yield* listComments(repo, issue);
+		if (comments._tag === "Failure") {
+			return refuse(
+				PRECONDITION_UNKNOWN,
+				`${verb}: cannot read #${issue}'s comments in ${repo}: ${comments.reason} — the claim on it is UNKNOWN; nothing was written.`,
+			);
+		}
+
+		const scanned = foreignMarkers({
+			markers: markersOf(comments.value),
+			session: options.env.CLAUDE_CODE_SESSION_ID ?? "",
+			now: (options.now ?? (() => new Date()))().getTime(),
+			ttlMinutes: options.ttlMinutes ?? DEFAULT_TTL_MINUTES,
+		});
+		if (scanned._tag === "Unresolvable") {
+			return refuse(
+				PRECONDITION_UNKNOWN,
+				`${verb}: cannot resolve the claim on #${issue} in ${repo}: ${scanned.reason} — nothing was written.`,
+			);
+		}
+
+		const holder = scanned.foreign[0];
+		if (holder !== undefined) {
+			return refuse(
+				CLAIMED_ELSEWHERE,
+				`${verb}: #${issue} is claimed by session ${holder.session === "" ? "(unreadable)" : holder.session} — refusing to mutate another session's issue. Run \`fabrika triage claim ${issue}\` and act only on \`won\`.`,
+			);
+		}
+		return null;
+	});

--- a/packages/fabrika-cli/src/triage/target-guard.unit.test.ts
+++ b/packages/fabrika-cli/src/triage/target-guard.unit.test.ts
@@ -1,0 +1,162 @@
+import {Effect} from "effect";
+import {describe, expect, it} from "vitest";
+import {errOut, type okOut} from "../fakes.test-support.ts";
+import type {IssueRecord} from "../io/issues.ts";
+import {DEFAULT_TTL_MINUTES} from "./claim.ts";
+import {COMMENTS, claimPage, EXPIRED, guardedShell, LIVE} from "./claim-fixtures.test-support.ts";
+import {CLAIMED_ELSEWHERE, PRECONDITION_UNKNOWN, ZERO_SCOPE} from "./codes.ts";
+import {foreignMarkers, guardTarget} from "./target-guard.ts";
+
+const MINE = "session-mine";
+const THEIRS = "session-theirs";
+
+const target = (over: Partial<IssueRecord> = {}): IssueRecord => ({
+	number: 4312,
+	title: "t",
+	body: "b",
+	state: "open",
+	labels: [],
+	url: "https://example.test/issues/4312",
+	author: "agent",
+	milestone: null,
+	stateReason: null,
+	comments: 0,
+	isPullRequest: false,
+	...over,
+});
+
+const said = (outcome: {readonly stderr: ReadonlyArray<string>} | null): string =>
+	(outcome?.stderr ?? []).join("\n");
+
+const run = (
+	script: ReadonlyArray<readonly [RegExp, ReturnType<typeof okOut>]>,
+	over: {readonly state?: "open" | "closed"; readonly session?: string} = {},
+) =>
+	Effect.runPromise(
+		Effect.provide(
+			guardTarget({
+				verb: "triage enrich",
+				repo: "o/r",
+				issue: 4312,
+				target: target(over.state === undefined ? {} : {state: over.state}),
+				env:
+					over.session === undefined
+						? {CLAUDE_PIPELINE_REPO: "o/r"}
+						: {CLAUDE_PIPELINE_REPO: "o/r", CLAUDE_CODE_SESSION_ID: over.session},
+			}),
+			guardedShell(script).layer,
+		),
+	);
+
+describe("foreignMarkers", () => {
+	const now = Date.parse("2026-08-15T00:00:00Z");
+	const scan = (
+		markers: ReadonlyArray<{
+			readonly id: number;
+			readonly session: string;
+			readonly createdAt: string;
+		}>,
+		session: string,
+	) => foreignMarkers({markers, session, now, ttlMinutes: DEFAULT_TTL_MINUTES});
+
+	it("counts a live marker of another session foreign", () => {
+		const scanned = scan([{id: 1, session: THEIRS, createdAt: LIVE}], MINE);
+		expect(scanned._tag).toBe("Foreign");
+		expect(scanned._tag === "Foreign" && scanned.foreign.map((m) => m.session)).toEqual([THEIRS]);
+	});
+
+	it("counts this session's own live marker as not foreign", () => {
+		const scanned = scan([{id: 1, session: MINE, createdAt: LIVE}], MINE);
+		expect(scanned._tag === "Foreign" && scanned.foreign).toEqual([]);
+	});
+
+	it("ages an expired foreign marker out", () => {
+		const scanned = scan([{id: 1, session: THEIRS, createdAt: EXPIRED}], MINE);
+		expect(scanned._tag === "Foreign" && scanned.foreign).toEqual([]);
+	});
+
+	// An empty id matches no marker, so a session-blind filter would answer "nobody else holds it"
+	// over a set full of live competitors — the one direction this may not fail.
+	it("counts every live marker foreign when this session cannot be attributed", () => {
+		const scanned = scan([{id: 1, session: MINE, createdAt: LIVE}], "");
+		expect(scanned._tag === "Foreign" && scanned.foreign).toHaveLength(1);
+	});
+
+	it("refuses to resolve a marker whose ordering key will not parse", () => {
+		const scanned = scan([{id: 1, session: THEIRS, createdAt: "whenever"}], MINE);
+		expect(scanned._tag).toBe("Unresolvable");
+	});
+});
+
+describe("guardTarget", () => {
+	it("passes an open, unclaimed issue", async () => {
+		expect(await run([])).toBeNull();
+	});
+
+	it("refuses a closed issue on 7, before reading any comment", async () => {
+		const shell = guardedShell([]);
+		const outcome = await Effect.runPromise(
+			Effect.provide(
+				guardTarget({
+					verb: "triage enrich",
+					repo: "o/r",
+					issue: 4312,
+					target: target({state: "closed"}),
+					env: {CLAUDE_PIPELINE_REPO: "o/r"},
+				}),
+				shell.layer,
+			),
+		);
+		expect(outcome?.code).toBe(ZERO_SCOPE);
+		expect(shell.calls).toEqual([]);
+	});
+
+	it("names the target by the caller's noun", async () => {
+		const outcome = await Effect.runPromise(
+			Effect.provide(
+				guardTarget({
+					verb: "triage split",
+					repo: "o/r",
+					issue: 4312,
+					target: target({state: "closed"}),
+					noun: "parent",
+					env: {CLAUDE_PIPELINE_REPO: "o/r"},
+				}),
+				guardedShell([]).layer,
+			),
+		);
+		expect(said(outcome)).toContain("triage split: parent #4312 is already closed.");
+	});
+
+	it("refuses a live foreign claim on 17, naming the holder", async () => {
+		const outcome = await run([[COMMENTS, claimPage({session: THEIRS, createdAt: LIVE})]], {
+			session: MINE,
+		});
+		expect(outcome?.code).toBe(CLAIMED_ELSEWHERE);
+		expect(said(outcome)).toContain(THEIRS);
+	});
+
+	it("passes when the live claim is this session's own", async () => {
+		expect(
+			await run([[COMMENTS, claimPage({session: MINE, createdAt: LIVE})]], {session: MINE}),
+		).toBeNull();
+	});
+
+	it("passes an expired foreign claim — the TTL still ages markers out", async () => {
+		expect(
+			await run([[COMMENTS, claimPage({session: THEIRS, createdAt: EXPIRED})]], {session: MINE}),
+		).toBeNull();
+	});
+
+	it("refuses on 11 when the comment read fails — never a pass", async () => {
+		const outcome = await run([[COMMENTS, errOut("gh: Bad gateway (HTTP 502)")]], {session: MINE});
+		expect(outcome?.code).toBe(PRECONDITION_UNKNOWN);
+	});
+
+	it("refuses on 11 when a marker's ordering key will not parse", async () => {
+		const outcome = await run([[COMMENTS, claimPage({session: THEIRS, createdAt: "whenever"})]], {
+			session: MINE,
+		});
+		expect(outcome?.code).toBe(PRECONDITION_UNKNOWN);
+	});
+});


### PR DESCRIPTION
`triage claim` resolved the race correctly and nothing after it read the answer back, so the
protocol held only as long as prose discipline did. On 2026-08-15 it did not: a session that had
read `lost` ran `triage enrich` anyway and replaced the winner's authored body on #5642, four
minutes after that session had closed the issue.

All five mutating verbs — `enrich`, `apply`, `park`, `kill`, `split` — now re-read both facts on
their target immediately before their first write, through one shared guard
(`packages/fabrika-cli/src/triage/target-guard.ts`):

- a closed target refuses on `7` (`ZERO_SCOPE`), the message shape `kill` already used;
- a live claim marker naming another session refuses on the new `17` (`CLAIMED_ELSEWHERE`), naming
  the holder;
- an unreadable comment list, or a marker whose `created_at` will not parse, refuses on `11` —
  never a pass.

Holding no marker still passes, so an unclaimed issue stays mutable and no existing caller breaks.
The claim reading reuses `markersOf` / `resolveClaim` from `claim.ts`: `resolveClaim` is refactored
onto a new `liveMarkers` primitive that both callers share, because `resolveClaim` alone cannot
answer this question — a caller holding no marker of its own resolves to `MineAbsent` however many
competitors are live, which is the fail-open shape.

There is no override flag, per the triage note on the issue.

The TTL is now one constant with no flag. A marker carries no TTL of its own, so the session that
ages it out is never the session that placed it: `triage claim --ttl-minutes 240` posted a claim its
placer read as binding for four hours and the five verbs stopped honouring at one hour — the
fail-open direction this guard exists to close. `DEFAULT_TTL_MINUTES` is the only reading now, for
placer and reader alike.

`contract.md`'s per-verb tables name the two outcomes the guard makes reachable: each of `split`,
`enrich`, `apply`, `park` and `kill` gains a `17` row, a closed target on its `7` row, the claim
read on its `11` row, and the three new refusal lines in its Errors table.

Reviewer's first look: `foreignMarkers` in `target-guard.ts`, and specifically the branch where
`CLAUDE_CODE_SESSION_ID` is unset or unstampable — an empty id matches no marker, so a
session-blind filter would answer "nobody else holds it" over a set full of live competitors. Every
live marker is counted foreign there instead.

Fixes #5644

## Deviations

- **Scope narrowing** — **Said:** the acceptance criteria name `14` as the new exit code, on the
  reading that `13` (`UNCONFIRMED`) was the highest allocated. **Did:** allocated `17`. **Why:** at
  the current head `codes.ts` already seats `UNREPAIRABLE = 14`, `MALFORMED_CRITERIA = 15` and
  `CRITERIA_REQUIRED = 16`; `17` is the next free seat, and `4` stays unallocated as the criteria
  require. **Disposition:** stated here; the code's meaning and placement are otherwise exactly what
  the issue specifies.
- **Out-of-scope change** — **Said:** #5644 names the five verbs, their `--help` tables and
  `SKILL.md` step 1. **Did:** also updated `claude-plugins/fabrika/skills/triage/contract.md` — the
  group's exit matrix gains its `17` row, every per-verb exit and error table names the new
  outcomes, and the `triage claim` section states that the claim now binds. **Why:** that file is
  the spec the `--help` tables and the skill both restate; leaving it saying the claim is advisory
  would ship a doc contradicting the code this PR lands. **Disposition:** stated here.
- **Out-of-scope change** — **Said:** the criteria's TTL row offers two routes — the marker carries
  its own TTL, or the flag goes. **Did:** removed the public `--ttl-minutes` flag from `triage
  claim`, and with it the `1` refusal on a non-positive value. **Why:** a per-marker TTL is
  caller-supplied text on the one comment a competitor could backdate, and the contract already
  fixes the ordering key as GitHub's `created_at` for that reason; one constant is the reading both
  the placer and the reader can hold. No skill or script passes the flag. **Disposition:** stated
  here.
- **Pre-existing test or fixture changed** — **Said:** nothing about the existing verb tests.
  **Did:** every `fakeShell(...)` in the five verbs' unit tests is now `guardedShell(...)`, a
  one-line wrapper in the new `claim-fixtures.test-support.ts` that appends an empty comments page
  as the last-resort script entry. **Why:** the guard adds a `listComments` call to each verb, and
  `fakeShell`'s fallback is a failed command, so every pre-existing test would otherwise refuse on
  `11`. The append is last-resort, so a test that scripts its own comments page still wins.
  **Disposition:** stated here; no existing assertion was changed, except `codes.unit.test.ts`'s
  allocated-code list, which gains `17`, and `claim-verb.unit.test.ts`'s ttl case, which the flag
  removal deletes.
