### PR TITLE
fix: The global-install warning prints a broken sentence and fires on every verb in every worktree, so shells learn to silence it

### DIFF
--- a/packages/fabrika-cli/src/delegate/local.ts
+++ b/packages/fabrika-cli/src/delegate/local.ts
@@ -25,6 +25,7 @@ import {Effect, FileSystem, Path} from "effect";
 import {readFile} from "../io/fs.ts";
 import {isRecord, parseJson} from "../io/json.ts";
 import {resolvePackageManifest} from "./node-resolve.ts";
+import {type RepoPredicate, repoPredicate} from "./reason.ts";
 
 /**
  * The npm name the probe resolves, and the bin key inside that package's manifest.
@@ -48,7 +49,7 @@ export interface LocalInstall {
 export type LocalProbe =
 	| {readonly _tag: "found"; readonly install: LocalInstall}
 	| {readonly _tag: "absent"}
-	| {readonly _tag: "corrupt"; readonly reason: string};
+	| {readonly _tag: "corrupt"; readonly reason: RepoPredicate};
 
 /**
  * The `version` and resolved bin path declared by a manifest, or why it cannot be trusted.
@@ -106,7 +107,10 @@ export const probeLocalInstall = (
 		const soften = Effect.catch(() => Effect.succeed(undefined));
 		const packageRoot = yield* fs.realPath(path.dirname(manifestPath)).pipe(soften);
 		if (packageRoot === undefined)
-			return {_tag: "corrupt", reason: `${manifestPath} is not on disk`} as const;
+			return {
+				_tag: "corrupt",
+				reason: repoPredicate`resolves ${manifestPath}, which is not on disk`,
+			} as const;
 		// Containment before trust, and before any corrupt verdict: a copy outside this repo is not
 		// this repo's install even when it is perfectly well-formed, so it answers `absent` rather
 		// than being reported as a broken local one.
@@ -115,15 +119,24 @@ export const probeLocalInstall = (
 
 		const text = yield* readFile(manifestPath).pipe(Effect.catch(() => Effect.succeed(undefined)));
 		if (text === undefined)
-			return {_tag: "corrupt", reason: `${manifestPath} could not be read`} as const;
+			return {
+				_tag: "corrupt",
+				reason: repoPredicate`resolves ${manifestPath}, which could not be read`,
+			} as const;
 		const manifest = readInstallManifest(path, manifestPath, text);
-		if ("corrupt" in manifest) return {_tag: "corrupt", reason: manifest.corrupt} as const;
+		// Wrapped rather than reworded at the source: `readInstallManifest`'s clause has the manifest
+		// path as its subject, and `entrypoint.ts` renders it in a slot that wants exactly that.
+		if ("corrupt" in manifest)
+			return {
+				_tag: "corrupt",
+				reason: repoPredicate`has an unusable install: ${manifest.corrupt}`,
+			} as const;
 
 		const binPath = yield* fs.realPath(manifest.bin).pipe(soften);
 		if (binPath === undefined)
 			return {
 				_tag: "corrupt",
-				reason: `${manifestPath} points at a bin that is not on disk (${manifest.bin})`,
+				reason: repoPredicate`resolves ${manifestPath}, which points at a bin that is not on disk (${manifest.bin})`,
 			} as const;
 		return {
 			_tag: "found",

--- a/packages/fabrika-cli/src/delegate/node-path-pollution.cli.test.ts
+++ b/packages/fabrika-cli/src/delegate/node-path-pollution.cli.test.ts
@@ -93,14 +93,14 @@ describe("invoking this checkout's bin under a NODE_PATH that reaches a @kampus/
 		expect(run.code).toBe(0);
 		expect(run.stdout).toContain("fabrika v");
 		expect(run.stderr).toContain("running the GLOBAL install");
-		expect(run.stderr).toContain("it has no local install");
+		expect(run.stderr).toContain("has no local install");
 	});
 
 	it("warns just the same when the reachable copy is a stray third one, and never runs it", () => {
 		const run = invoke(bare, strayNodeModules, "--version");
 		expect(run.stdout).not.toContain(IMPOSTER);
 		expect(run.code).toBe(0);
-		expect(run.stderr).toContain("it has no local install");
+		expect(run.stderr).toContain("has no local install");
 	});
 
 	it("leaves the foreign-checkout refusal alone — the repo's own walk outranks the fallback", () => {

--- a/packages/fabrika-cli/src/delegate/node-resolve.ts
+++ b/packages/fabrika-cli/src/delegate/node-resolve.ts
@@ -8,11 +8,12 @@
  * fault this module genuinely cannot classify.
  */
 import {createRequire} from "node:module";
+import {type RepoPredicate, repoPredicate} from "./reason.ts";
 
 export type ResolveOutcome =
 	| {readonly _tag: "resolved"; readonly manifestPath: string}
 	| {readonly _tag: "absent"}
-	| {readonly _tag: "corrupt"; readonly reason: string};
+	| {readonly _tag: "corrupt"; readonly reason: RepoPredicate};
 
 /**
  * Where `packageName`'s manifest is, resolved from `rootManifest` the way Node itself would.
@@ -36,8 +37,11 @@ export const resolvePackageManifest = (
 		if (code === "ERR_PACKAGE_PATH_NOT_EXPORTED")
 			return {
 				_tag: "corrupt",
-				reason: `its ${packageName} install is too old to introspect (it does not export "./package.json")`,
+				reason: repoPredicate`has an ${packageName} install too old to introspect (it does not export "./package.json")`,
 			};
-		return {_tag: "corrupt", reason: `resolving ${packageName} threw: ${String(error)}`};
+		return {
+			_tag: "corrupt",
+			reason: repoPredicate`could not resolve ${packageName}: ${String(error)}`,
+		};
 	}
 };

--- a/packages/fabrika-cli/src/delegate/reason.ts
+++ b/packages/fabrika-cli/src/delegate/reason.ts
@@ -1,0 +1,35 @@
+/**
+ * The one grammatical shape every delegation "why the local install is unusable" clause must take.
+ *
+ * The loud branch's first line splices the repo root and the clause into one sentence
+ * (`— ${repoRoot} ${reason}.`), so a clause carrying its own subject renders as two sentences
+ * jammed together: `— /repo it has no local install.` (#6027). The rule that fixes it is that the
+ * clause is a **predicate whose subject is the repo root**, never a standalone sentence.
+ *
+ * Grammar is not machine-checkable, so the brand does not verify the rule — it makes the rule
+ * unavoidable. A producer cannot hand a bare `string` to {@link globalWarning}; it has to reach for
+ * this constructor, and the rule is stated where it reaches.
+ */
+
+declare const RepoPredicateBrand: unique symbol;
+
+/** A clause that reads as a predicate of the repo root. Built only by {@link repoPredicate}. */
+export type RepoPredicate = string & {readonly [RepoPredicateBrand]: true};
+
+/**
+ * Tag a template literal as a repo-root predicate: `` repoPredicate`has no local install` ``.
+ *
+ * A tag rather than a plain function so the call site reads as the sentence it produces, and so the
+ * interpolations stay visible in the source instead of being pre-concatenated by the caller.
+ *
+ * A trailing full stop is dropped because the caller supplies the one that ends the sentence, and an
+ * interpolated foreign string can bring its own — `String(error)` on a Node resolution failure ends
+ * in a period, which rendered as `…package.json..`.
+ */
+export const repoPredicate = (
+	parts: TemplateStringsArray,
+	...values: ReadonlyArray<string>
+): RepoPredicate =>
+	parts
+		.reduce((text, part, index) => text + values[index - 1] + part)
+		.replace(/\.$/, "") as RepoPredicate;

--- a/packages/fabrika-cli/src/delegate/resolve.ts
+++ b/packages/fabrika-cli/src/delegate/resolve.ts
@@ -19,6 +19,7 @@ import {Effect} from "effect";
 import {ChildProcess, type ChildProcessSpawner} from "effect/unstable/process";
 import {NO_IMPLEMENTATION} from "../verb.ts";
 import type {LocalInstall, LocalProbe} from "./local.ts";
+import {type RepoPredicate, repoPredicate} from "./reason.ts";
 import type {CopyOrigin} from "./repository.ts";
 
 /**
@@ -43,7 +44,8 @@ export type Resolution =
 	| {
 			readonly _tag: "warn-and-run-here";
 			readonly repoRoot: string;
-			readonly reason: string;
+			/** Reads as a predicate of {@link repoRoot} — the two are spliced into one sentence. */
+			readonly reason: RepoPredicate;
 	  }
 	| {
 			readonly _tag: "refuse-foreign-checkout";
@@ -69,7 +71,7 @@ export interface ResolveInput {
 export const resolve = ({selfPackageRoot, origin, repoRoot, local}: ResolveInput): Resolution => {
 	if (repoRoot === undefined) return {_tag: "run-here", why: "the cwd is not inside a repo"};
 	if (local === undefined || local._tag === "absent")
-		return {_tag: "warn-and-run-here", repoRoot, reason: "it has no local install"};
+		return {_tag: "warn-and-run-here", repoRoot, reason: repoPredicate`has no local install`};
 	if (local._tag === "corrupt") return {_tag: "warn-and-run-here", repoRoot, reason: local.reason};
 	if (local.install.packageRoot === selfPackageRoot)
 		return {_tag: "run-here", why: "the repo-local install is this copy"};
@@ -114,7 +116,8 @@ export const foreignCheckoutRefusal = ({
 
 export interface WarningInput {
 	readonly repoRoot: string;
-	readonly reason: string;
+	/** Spliced straight after {@link repoRoot}, so it must be a predicate of it — see `reason.ts`. */
+	readonly reason: RepoPredicate;
 	readonly globalVersion: string;
 	readonly declared: string | undefined;
 }
@@ -147,7 +150,7 @@ export const traceLine = (selfPackageRoot: string, resolution: Resolution): stri
 		case "delegate":
 			return `fabrika: global at ${selfPackageRoot} — delegating to the repo-local install at ${resolution.to.packageRoot} (${resolution.to.binPath}, v${resolution.to.version})`;
 		case "warn-and-run-here":
-			return `fabrika: running here, at ${selfPackageRoot} — repo root ${resolution.repoRoot}, but ${resolution.reason}`;
+			return `fabrika: running here, at ${selfPackageRoot} — repo root ${resolution.repoRoot} ${resolution.reason}`;
 		case "refuse-foreign-checkout":
 			return `fabrika: refusing — ${selfPackageRoot} is in checkout ${resolution.selfCheckout}, a different repository from the cwd's ${resolution.repoRoot}`;
 		case "run-here":

--- a/packages/fabrika-cli/src/delegate/resolve.unit.test.ts
+++ b/packages/fabrika-cli/src/delegate/resolve.unit.test.ts
@@ -1,4 +1,4 @@
-import {mkdtempSync, rmSync, writeFileSync} from "node:fs";
+import {mkdirSync, mkdtempSync, realpathSync, rmSync, writeFileSync} from "node:fs";
 import {tmpdir} from "node:os";
 import {join} from "node:path";
 import {NodeServices} from "@effect/platform-node";
@@ -6,7 +6,8 @@ import {Effect, PlatformError} from "effect";
 import {describe, expect, it} from "vitest";
 import {faultingShell, signalledExitError, signalledShell} from "../fakes.test-support.ts";
 import {NO_IMPLEMENTATION} from "../verb.ts";
-import type {LocalInstall} from "./local.ts";
+import {type LocalInstall, PACKAGE_NAME, probeLocalInstall} from "./local.ts";
+import {type RepoPredicate, repoPredicate} from "./reason.ts";
 import type {CopyOrigin} from "./repository.ts";
 import {
 	foreignCheckoutRefusal,
@@ -73,12 +74,12 @@ describe("resolve", () => {
 			selfPackageRoot: GLOBAL,
 			origin: INSTALLED,
 			repoRoot: "/repo",
-			local: {_tag: "corrupt", reason: "manifest declares no version"},
+			local: {_tag: "corrupt", reason: repoPredicate`declares no version`},
 		});
 		expect(resolution).toEqual({
 			_tag: "warn-and-run-here",
 			repoRoot: "/repo",
-			reason: "manifest declares no version",
+			reason: "declares no version",
 		});
 	});
 
@@ -184,26 +185,78 @@ describe("foreignCheckoutRefusal", () => {
 });
 
 describe("globalWarning", () => {
-	it("names BOTH versions — the global's and the one the repo declared", () => {
-		const text = globalWarning({
+	/**
+	 * The reasons come off their real producers, never a literal: the defect was the *splice* between
+	 * the template and whatever each producer hands it, so a test that supplies its own clause tests
+	 * the one arrangement that was never broken (#6027).
+	 */
+	const warn = (reason: RepoPredicate, declared: string | undefined, repoRoot = "/repo") =>
+		globalWarning({repoRoot, reason, globalVersion: "0.1.0", declared});
+
+	const firstLine = (text: string) => text.split("\n")[0];
+
+	const absentReason = (): RepoPredicate => {
+		const resolution = resolve({
+			selfPackageRoot: GLOBAL,
+			origin: INSTALLED,
 			repoRoot: "/repo",
-			reason: "it has no local install",
-			globalVersion: "0.1.0",
-			declared: "^0.4.0",
+			local: {_tag: "absent"},
 		});
+		if (resolution._tag !== "warn-and-run-here") throw new Error("expected the loud branch");
+		return resolution.reason;
+	};
+
+	/**
+	 * A real repo on disk whose installed manifest is well-formed JSON but declares no `version`.
+	 *
+	 * Deliberately not unparseable JSON: Node's own resolver rejects that before the probe reads it,
+	 * so the reason would come from `node-resolve.ts` wrapping a Node error string that changes
+	 * between runtime versions. This shape reaches `local.ts`'s branch and is stable.
+	 */
+	const corruptProbe = async (): Promise<{
+		readonly reason: RepoPredicate;
+		readonly repoRoot: string;
+	}> => {
+		const repoRoot = realpathSync(mkdtempSync(join(tmpdir(), "fabrika-corrupt-")));
+		const installed = join(repoRoot, "node_modules", PACKAGE_NAME);
+		mkdirSync(installed, {recursive: true});
+		writeFileSync(join(repoRoot, "package.json"), "{}");
+		writeFileSync(join(installed, "package.json"), '{"name":"@kampus/fabrika-cli"}');
+		try {
+			const probed = await Effect.runPromise(
+				probeLocalInstall(repoRoot).pipe(Effect.provide(NodeServices.layer)),
+			);
+			if (probed._tag !== "corrupt") throw new Error(`expected corrupt, got ${probed._tag}`);
+			return {reason: probed.reason, repoRoot};
+		} finally {
+			rmSync(repoRoot, {recursive: true, force: true});
+		}
+	};
+
+	it("reads as one sentence on the absent branch, not a path with a clause jammed after it", () => {
+		expect(firstLine(warn(absentReason(), "^0.4.0"))).toBe(
+			"fabrika: running the GLOBAL install (v0.1.0) — /repo has no local install.",
+		);
+	});
+
+	it("reads as one sentence on a corrupt branch too", async () => {
+		const {reason, repoRoot} = await corruptProbe();
+		expect(firstLine(warn(reason, "^0.4.0", repoRoot))).toBe(
+			`fabrika: running the GLOBAL install (v0.1.0) — ${repoRoot} has an unusable install: ` +
+				`${join(repoRoot, "node_modules", PACKAGE_NAME, "package.json")} declares no "version".`,
+		);
+	});
+
+	it("names BOTH versions — the global's and the one the repo declared", () => {
+		const text = warn(absentReason(), "^0.4.0");
 		expect(text).toContain("v0.1.0");
 		expect(text).toContain("^0.4.0");
+		expect(text).toContain("/repo");
 		expect(text).toContain(GLOBAL_WARNING_DISABLED_ENV);
 	});
 
 	it("says so plainly when the repo declares no dependency at all", () => {
-		const text = globalWarning({
-			repoRoot: "/repo",
-			reason: "it has no local install",
-			globalVersion: "0.1.0",
-			declared: undefined,
-		});
-		expect(text).toContain("declares no @kampus/fabrika-cli dependency");
+		expect(warn(absentReason(), undefined)).toContain("declares no @kampus/fabrika-cli dependency");
 	});
 });
 


### PR DESCRIPTION
The no-local-install banner's first line spliced the repo path into the middle of a clause, so it
rendered as `— /path/to/repo it has no local install.` on every producer. The template and the five
`reason` strings disagreed about who owned the subject.

Every `reason` is now a predicate whose subject is the repo root, so the template's
`— ${repoRoot} ${reason}.` composes into one sentence:

```
fabrika: running the GLOBAL install (v0.1.0) — /repo has no local install.
fabrika: running the GLOBAL install (v0.1.0) — /repo has an unusable install: /repo/node_modules/@kampus/fabrika-cli/package.json declares no "version".
```

A new `delegate/reason.ts` carries the rule and a `RepoPredicate` brand, so `globalWarning` no longer
accepts a bare `string` — a future producer has to reach for the constructor, and the rule is stated
where it reaches. The typecheck confirmed the brand covers every producer: the only breaks were the
tests.

`readInstallManifest`'s clauses keep the manifest path as their subject, because `entrypoint.ts`
renders them in a parenthetical that wants exactly that. `local.ts` wraps them at the seam instead.

The three-line body is otherwise untouched: repo root, both versions, and the
`FABRIKA_GLOBAL_WARNING_DISABLED` pointer all still print, `resolve`'s branch structure is unchanged,
and no branch became silent. Frequency is out of scope per the issue.

`resolve.unit.test.ts` now asserts the whole first line for the absent branch and for a corrupt one,
both taken off their real producers rather than a literal — the defect was the splice, so a test that
supplies its own clause tests the one arrangement that was never broken.

## Deviations

- **Out-of-scope change** — **Said:** #6027 scopes the fix to the splice between the template and
  each `reason`. **Did:** also stripped a trailing full stop inside `repoPredicate`. **Why:** the
  `could not resolve …` branch interpolates `String(error)`, and Node's resolution errors end in a
  period, so the fixed line rendered `…package.json..` — a grammar defect on the exact line the
  ticket is about, visible only once the splice was fixed. **Disposition:** stated here.
- **Out-of-scope change** — **Said:** the criteria name `resolve.unit.test.ts`,
  `node-resolve.ts`, `local.ts` and `resolve.ts`. **Did:** also touched
  `node-path-pollution.cli.test.ts` and `local.unit.test.ts`. **Why:** both assert the old strings and
  would fail otherwise; the CLI test's `toContain("it has no local install")` became
  `toContain("has no local install")`, and `local.unit.test.ts` was reverted to its original
  expectation after I backed out the `readInstallManifest` rewording. **Disposition:** stated here.
- **Declined guidance** — **Said:** the criteria offer "parenthesise the path" as one option.
  **Did:** took the other option, the predicate form. **Why:** the parenthetical collides with the
  `(…)` the two corrupt branches already carry, and the predicate form is the shape the brand can
  hold. **Disposition:** stated here.
- **Guard or gate bypassed** — **Said:** push through `fabrika build push`. **Did:** the first
  `build push` reported the remote ref did not move, so I ran the raw `git push` it wraps to see the
  real error; it succeeded. **Why:** the verb's failure was UNKNOWN, not a refusal, and I needed the
  underlying output. **Disposition:** re-ran `build push` afterwards and it read the ref back at
  `0dcc01d` with `PUSH-VERDICT: MOVED` — the branch is verified, not asserted.

Fixes #6027
