### PR TITLE
chore: Seven skills with heavy contracts never adopted the 0296 read-by-section shape

### DIFF
--- a/claude-plugins/fabrika/skills/adr/SKILL.md
+++ b/claude-plugins/fabrika/skills/adr/SKILL.md
@@ -20,7 +20,9 @@ One call allocates the id and scaffolds the record, and that is why it is one ca
 freshly fetched merged set with the ids open ADR PRs already claim, so a checkout sitting at `0150`
 while origin is at `0151` cannot mint a duplicate — **and an id you allocate now and write later is
 already stale**, which is how 0284 landed on two pull requests at once (#5841). The slug is
-kebab-case, at most 5 words; it prints the path written.
+kebab-case, at most 5 words; it prints the path written. How the union is computed, and the exact
+bytes it scaffolds, are the verb's section
+(`fabrika wire doc-section --heading "adr mint" < <skill-base>/contract.md`).
 
 **A non-zero exit is UNKNOWN, never "nothing reserved."** Re-run it. Falling back to the highest id
 on disk mints the same number from two lanes at once.
@@ -32,7 +34,8 @@ yet, create it and re-run; a repo with no decision directory at all is a setup q
 [front-door](../front-door/SKILL.md).
 
 `fabrika adr next` still answers the id on its own, and `fabrika adr new 0240 <slug>` still
-scaffolds against an id you name. Reach for the pair only when you genuinely need the id before the
+scaffolds against an id you name (`fabrika wire doc-section --heading "adr next" < <skill-base>/contract.md`,
+then `--heading "adr new"`). Reach for the pair only when you genuinely need the id before the
 file — the gap between them is the race, so do not re-open it out of habit. Whichever route, the
 minted file is not a reservation: nothing outside this checkout sees the id until the pull request
 opens, and step 6 is where you find out whether someone got there first.
@@ -60,7 +63,9 @@ for a question you cannot phrase. Then rank the uncited live-accepted ADRs your 
 fabrika adr sweep --new 0240
 ```
 
-None of its three outcomes is a clearance:
+How the ranking is computed, and why it caps where it does, are the verb's section
+(`fabrika wire doc-section --heading "adr sweep" < <skill-base>/contract.md`). None of its three
+outcomes is a clearance:
 
 - **`shortlist`** — open the entries and judge each once. It ranks lexical adjacency, caps at 8, and
   **re-ranks as you add citations**, so the tail refills and chasing a clean result is the trap.
@@ -89,7 +94,9 @@ the real filename. Pass every citation, supersede link and amend target in one c
 **Cite only `live`.** `landed` means present but `proposed`, `superseded` or `retired`, and citing
 one as settled law applies a decision that was already withdrawn. `in-flight` may never merge, so a
 citation to one can pass every gate and still be dead on arrival. **A non-zero exit is UNKNOWN,
-never `absent`.** **Use the filename it prints** — a remembered slug is usually the wrong one.
+never `absent`.** **Use the filename it prints** — a remembered slug is usually the wrong one. How
+each state is proven against the fetched base is the verb's section
+(`fabrika wire doc-section --heading "adr resolve" < <skill-base>/contract.md`).
 
 ```bash
 fabrika adr supersede 0126 --by 0240
@@ -97,7 +104,9 @@ fabrika adr supersede 0126 --by 0240
 
 Where the rest of that ADR still stands, `fabrika adr amend-in-part 0023 --by 0240` instead.
 Either verb touches the `status:` line and nothing else — an accepted ADR's decision text is
-immutable, so name the relationship in your own `## Context` rather than editing theirs.
+immutable, so name the relationship in your own `## Context` rather than editing theirs. Which line
+each rewrites, and what each refuses, is their shared section:
+`fabrika wire doc-section --heading "adr supersede and adr amend-in-part" < <skill-base>/contract.md`.
 
 ## 5 — Record the vocabulary impact
 

--- a/claude-plugins/fabrika/skills/glossary/SKILL.md
+++ b/claude-plugins/fabrika/skills/glossary/SKILL.md
@@ -54,7 +54,9 @@ suggestion list**, never a work order.
 
 **A non-zero exit is UNKNOWN, never "nothing drifted."** Re-run it — a shallow clone with no
 history for the register reads as "never committed", and acting on that regenerates a populated
-file wholesale.
+file wholesale. Which surfaces it scans, and the suppression rules that thin the candidate list, are
+the verb's section
+(`fabrika wire doc-section --heading "glossary drift" < <skill-base>/contract.md`).
 
 ## 2 — Ask what is already declared
 
@@ -73,7 +75,9 @@ as one manufactures false duplicates. Judge each collision: **redefine** the exi
 genuinely distinct term.
 
 Comparison folds case, whitespace and hyphens, so `front-door` and `front door` are one key. It does
-not fold parentheses, slashes or commas.
+not fold parentheses, slashes or commas. The normalization is one function every verb shares:
+`fabrika wire doc-section --heading "Term normalization — one function, used by every verb" < <skill-base>/contract.md`.
+How a collision span is computed is `--heading "glossary lookup"` against the same file.
 
 ## 3 — Judge the term
 
@@ -128,8 +132,12 @@ yet exist, and it is why a fresh repo is not a dead end:
 fabrika glossary init --register terms
 ```
 
+What `init` seeds into an empty register is its section
+(`fabrika wire doc-section --heading "glossary init" < <skill-base>/contract.md`).
+
 A register's sections are **data, not a fixed enum** — they grow as the repo does, so read them
-rather than recalling them, and pass `--create-section` when a term's right home is genuinely new:
+rather than recalling them, and pass `--create-section` when a term's right home is genuinely new
+(`fabrika wire doc-section --heading "glossary sections" < <skill-base>/contract.md`):
 
 ```bash
 fabrika glossary sections --register terms
@@ -142,7 +150,9 @@ fabrika glossary add "front door" --register terms --section "fabrika skill noun
 Reads the definition on stdin, inserts the row in that section's alphabetical place, and re-reads the
 file to prove what landed. It refuses to touch a byte outside the row it wrote — a re-sort or a
 reflow of an untouched section aborts the write rather than landing quietly. Rewriting an existing
-row is the same verb with `--replace`, under the read-first rule in step 3.
+row is the same verb with `--replace`, under the read-first rule in step 3. The row grammar, the
+insertion rule and every write the verb refuses are its section
+(`fabrika wire doc-section --heading "glossary add" < <skill-base>/contract.md`).
 
 **Land the row only after the decision that coins it is on `main`.** An ADR number is not stable
 before merge — concurrent lanes derive the same one — so a row citing an unmerged decision is a
@@ -162,7 +172,9 @@ fabrika glossary check --register both
 ```
 
 Answers `clean`, `defects` or `bootstrap` on exit 0, enumerating row-shape breaks, duplicate keys,
-out-of-order rows and citations that no longer resolve live.
+out-of-order rows and citations that no longer resolve live — each defect class, and what it takes to
+clear it, is the verb's section
+(`fabrika wire doc-section --heading "glossary check" < <skill-base>/contract.md`).
 
 **Two things it deliberately does not answer, because something else already does.** Machine-local
 paths in a changed markdown file, and dead internal links, are each decided by a merge-blocking gate

--- a/claude-plugins/fabrika/skills/report/SKILL.md
+++ b/claude-plugins/fabrika/skills/report/SKILL.md
@@ -39,7 +39,9 @@ A hand-typed classification is indistinguishable from a triaged one, so a guess 
 corrupts the signal triage runs on. One observation, one issue — two things you noticed are two
 filings.
 
-You are done here when all six sections carry content, except the last, which may be empty.
+You are done here when all six sections carry content, except the last, which may be empty. The
+section names the verb checks for, and how it decides a section is empty, are its own section
+(`fabrika wire doc-section --heading "report file" < <skill-base>/contract.md`).
 
 ## 2 — Check whether it is already filed
 
@@ -51,7 +53,9 @@ creating stays small:
 fabrika report dedup --query "http worker aborted request downstream plain timeout reason"
 ```
 
-Three outcomes, and only one of them is about your observation:
+Which sources it reads and how the cap is applied are the verb's section
+(`fabrika wire doc-section --heading "report dedup" < <skill-base>/contract.md`). Three outcomes, and
+only one of them is about your observation:
 
 - **`candidates`** — open each and judge it yourself. Shared vocabulary is not a shared observation.
   The list is capped, and the verb says on stderr when it truncated.
@@ -86,7 +90,11 @@ section, a machine-local path in the body, a body that never reached stdin, a ti
 — and each is a thing to correct. **A refusal is never a signal to post some other way.** Retrying a
 blocked command through a form that passes the body as a *file path* posts the path text instead of
 the file's contents, which is how a machine-local path reaches a public artifact while the poster
-reads success.
+reads success — the rule and its reasoning are one section
+(`fabrika wire doc-section --heading "The body is a value, never a path" < <skill-base>/contract.md`).
+Which exit carries which refusal is
+`--heading "The shared exit taxonomy for the two writing verbs"`, and what counts as a leak is
+`--heading "The body-surface leak predicate"`.
 
 Use `--redact` when a machine-local path is genuinely part of the evidence — reporting a leak
 incident is the case it exists for. It masks each path down to its class and says so; it never
@@ -105,7 +113,9 @@ fabrika report note --issue 4312 <<'EOF'
 EOF
 ```
 
-Done when the verb exits 0 and prints the comment id and URL.
+Done when the verb exits 0 and prints the comment id and URL. It runs the same guards as `file` over
+a comment body, and its section says which
+(`fabrika wire doc-section --heading "report note" < <skill-base>/contract.md`).
 
 ## 5 — Report and return
 

--- a/claude-plugins/fabrika/skills/review-ui/SKILL.md
+++ b/claude-plugins/fabrika/skills/review-ui/SKILL.md
@@ -36,8 +36,11 @@ fabrika review scope $pr_number
 ```
 
 The shared gate mechanics are the shipped `review` group's verbs, reused as-is — scope, diff,
-criteria, ci, verdicts, deviations ([`../review/contract.md`](../review/contract.md)); this skill adds
-only the `review-ui` group ([`contract.md`](contract.md)). **You owe a verdict only when the PR
+criteria, ci, verdicts, deviations, each addressed in that group's contract by its own name
+(`fabrika wire doc-section --heading "review scope" < <review skill's base dir>/contract.md`, and
+likewise `--heading "review diff"`, `"review criteria"`, `"review ci"`, `"review verdicts"`,
+`"review deviations"`). This skill adds only the `review-ui` group, whose three verbs are listed at
+`fabrika wire doc-section --heading "Verb inventory" < <skill-base>/contract.md`. **You owe a verdict only when the PR
 changes a rendered-visual surface** — a page, component, screen, state, or style a user sees. Read
 the diff (`fabrika review diff $pr_number`) and decide; a PR with no rendered delta is `review`'s alone —
 end **ROUTED-ELSEWHERE**, emit nothing, because a namespace you did not judge is one you never
@@ -80,7 +83,11 @@ surface is FAIL ground** — a screenshot of a broken page is not composition to
 FAIL finding, because an undisclosed hole in the evidence is indistinguishable from a clean read.
 Exit 16 or an every-surface-unreachable render is **CANT-SEE**: post no verdict — the empty
 namespace fail-closes the ship gate — and name the blocker on the PR through `fabrika review-ui
-note` (stdin body, never a marker); never a "plausible" partial PASS.
+note` (stdin body, never a marker); never a "plausible" partial PASS. Each per-surface outcome, each
+run-level refusal and what makes a capture valid are the verb's section
+(`fabrika wire doc-section --heading "review-ui render" < <skill-base>/contract.md`; the note verb is
+`--heading "review-ui note"`). The two render paths this needs are
+`--heading "Required environment — the two render paths"`.
 
 **Two eyes, one record:** when this session's tool surface carries the `claude-in-chrome` tools you
 may additionally inspect the preview live — navigate, probe states, look closer. Detection is tool
@@ -130,7 +137,8 @@ paths; upserts one comment; reads it back from live state. On a control-plane PR
 marker). Control-plane membership is an **input**: this skill computes no control-plane
 classification, the carrier is explicit, and the gate's authority stays at the merge check.
 Precedence: **an unseen input blocks PASS, never FAIL** — FAIL on what you saw, naming every unseen
-piece UNKNOWN.
+piece UNKNOWN. The marker format, the evidence-upload proof and every exit are the verb's section
+(`fabrika wire doc-section --heading "review-ui post" < <skill-base>/contract.md`).
 
 ## Terminal vocabulary
 

--- a/claude-plugins/fabrika/skills/ship/SKILL.md
+++ b/claude-plugins/fabrika/skills/ship/SKILL.md
@@ -17,7 +17,10 @@ First act: `fabrika ship disarm $pr_number --site preflight` — a parked `--aut
 enqueues the PR the second an approval lands. Every stop below repeats it with `--site refuse`, and
 every stop posts its reason durably with `fabrika ship note`, because a shipper that dies silently
 leaves a green-but-not-enqueued PR with zero signal. A failed disarm never rewrites a stop's
-disposition; it changes what you report (`merge intent: NOT cleared`).
+disposition; it changes what you report (`merge intent: NOT cleared`). The `--site` vocabulary and
+what each disarm proves are the verb's own section
+(`fabrika wire doc-section --heading "ship disarm" < <skill-base>/contract.md`, and
+`--heading "ship note"` for the note's grammar).
 
 ## 1 — Scope
 
@@ -37,7 +40,9 @@ The verb prints the head SHA, the class set with its **required namespaces** (yo
 all of them), the control-plane state, and the linked issue: `code`/`skill` classes require
 `Fixes #N` or an explicit `Part of #N` (partial split — merge without auto-close);
 doc/vocabulary-surface-only PRs are legitimately issueless. Carry the printed head into every later
-`--sha`; a verb refusing `12` means the head moved — start over at 1.
+`--sha`; a verb refusing `12` means the head moved — start over at 1. How each class maps to a
+required namespace, and how the control-plane state is derived, is the verb's section
+(`fabrika wire doc-section --heading "ship scope" < <skill-base>/contract.md`).
 
 ## 2 — Control-plane approval, discharged not assumed
 
@@ -59,7 +64,9 @@ re-approval, patch-identical or not. **That is the human approval only.** A fabr
 `governance` marker binds the content it judged as well as the head, so a branch update leaving the
 diff and every changed file byte-identical keeps it; the control-plane approval and GitHub's own
 review object do not. A control-plane PR whose latest verdict is FAIL routes to
-repair exactly as an ordinary FAIL; the advisory carrier is a PASS path only.
+repair exactly as an ordinary FAIL; the advisory carrier is a PASS path only. The roster resolution,
+the base-drift notice and every refusal on this path are the verb's section
+(`fabrika wire doc-section --heading "ship cp-approval" < <skill-base>/contract.md`).
 
 ## 3 — The verdict conjunction
 
@@ -77,14 +84,19 @@ never gated at this head; route to the gate that owns it — `review` for every 
 the `governance` skill for `governance` — and stop. **Absence and staleness are refusals, never
 passes.** A `pass` on a verdict posted at an *earlier* head is not a refusal it missed: the verb
 says so on stderr, having proved this head's content digest is the one that verdict bound. What it
-never does is pass a content binding it could not check — that reads `stale`.
+never does is pass a content binding it could not check — that reads `stale`. The polarity rules, the
+content-digest binding and the whole `blocked` taxonomy are the verb's section
+(`fabrika wire doc-section --heading "ship gate" < <skill-base>/contract.md`).
 
 **Your reading of `blocked` is not the only thing enforcing the governance floor.**
 `.github/workflows/governance-floor.yml` runs `fabrika ship floor` on every PR and reds when a
 governance-root diff has no head-bound governance PASS — absent, stale, FAIL and a verdict from an
 author without write+ all red. This step and that job resolve the same verdict through the same
 `ship gate`, so they cannot disagree: if you read `ns governance` as anything but `pass`, the check
-is red too, and routing to the `governance` skill is what clears both.
+is red too, and routing to the `governance` skill is what clears both. Why the floor is a caller verb
+rather than a new exit code, and why it refuses on WRONG and not only on MISSING, are its sections
+(`fabrika wire doc-section --heading "ship floor" < <skill-base>/contract.md`, then
+`--heading "It refuses on WRONG, not only on MISSING"`).
 
 ## 4 — CI at the head, and only at the head
 
@@ -98,7 +110,10 @@ human** — you diagnose, you never pull it. `no-runs` → one bounded nudge:
 `fabrika ship nudge $pr_number --sha 03135b91` re-derives the dropped-trigger state itself and refuses
 otherwise; after the nudge, re-enter this step once. `budget-exhausted` → disarm, note,
 stop. `head-moved` → start over at step 1; every answer so far was about a tree that is gone.
-**You never re-run, re-trigger, or locally reproduce a check** — CI's verdict is CI's.
+**You never re-run, re-trigger, or locally reproduce a check** — CI's verdict is CI's. Each terminal's
+proof, the `--wait` budget and the nudge's own refusals are their sections
+(`fabrika wire doc-section --heading "ship checks" < <skill-base>/contract.md`, then
+`--heading "ship nudge"`).
 
 ## 5 — Run-evidence
 
@@ -112,7 +127,9 @@ and attests a failing run: that is a **verdict**, so route the failure, disarm, 
 treat it as an unreadable answer. `absent` (proven: producer exists, a run completed outside the
 freshness window, nothing published) → disarm, note, stop. `unknown` (the lookup completed but
 cannot bind this head), or the verb refusing with a failed read — either way the answer does not
-exist: stop without a verdict; **a failed read is never "no bundle"**.
+exist: stop without a verdict; **a failed read is never "no bundle"**. The manifest shape, the
+freshness window and how each answer is proven are the verb's section
+(`fabrika wire doc-section --heading "ship evidence" < <skill-base>/contract.md`).
 
 ## 6 — Unresolved threads: the one judgment
 
@@ -121,8 +138,10 @@ fabrika ship threads $pr_number
 ```
 
 The ruleset blocks the enqueue on unresolved threads, and your resolve is the pipeline's only
-thread-clearing mechanism — so judge, don't route: repair cannot resolve threads. For each
-unresolved thread:
+thread-clearing mechanism — so judge, don't route: repair cannot resolve threads. Which facts make a
+thread bot-classed, and what `resolve` refuses on, are the two verbs' sections
+(`fabrika wire doc-section --heading "ship threads" < <skill-base>/contract.md`, then
+`--heading "ship resolve"`). For each unresolved thread:
 
 - **Not positively bot-classed** (any human participation, any doubt in the class facts) →
   refuse the ship; the thread's author gets it resolved, not you. `ship resolve` enforces this
@@ -158,7 +177,10 @@ repair; re-entry is rebase → re-review → fresh gate pass, never a re-enqueue
 `unresolved` → report it in those words with the horizon; still-queued at the horizon is
 neither a landing nor a failure, and **"auto-merges on green" is not a thing you say**. `parked` →
 the enqueue never took effect: run `fabrika ship disarm $pr_number --site post-enqueue` (reconcile is a
-read and disarms nothing), note, and stop.
+read and disarms nothing), note, and stop. The `mergeable_state` assertion and each terminal's proof
+are the two verbs' sections
+(`fabrika wire doc-section --heading "ship enqueue" < <skill-base>/contract.md`, then
+`--heading "ship reconcile"`).
 
 ## 8 — Release queue (dark ships only)
 
@@ -169,7 +191,8 @@ fabrika ship release $pr_number
 `queued` or `n/a` — the label is the whole action. `no-issue` (a dark-ship signal with no
 linked issue to label) escalates to a human with the flag key named. Deploy is yours; release
 is a human's. **You never flip a flag, and never read an inherited containment stamp as a release
-signal.**
+signal.** What counts as a dark-ship signal, and how the flag key is read off the body, are the
+verb's section (`fabrika wire doc-section --heading "ship release" < <skill-base>/contract.md`).
 
 ## Terminal vocabulary
 
@@ -224,11 +247,12 @@ a `ship` verb.
 
 ## Enforced elsewhere, decided elsewhere
 
-CI and the ruleset own their own verdicts — the contract's "Considered and deliberately not
-derived" section names each with its owning workflow; **you expect them and never compute a second
-answer.**
+CI and the ruleset own their own verdicts — this section names each with its owning workflow:
+`fabrika wire doc-section --heading "Considered and deliberately not derived" < <skill-base>/contract.md`.
+**You expect them and never compute a second answer.**
 
-**Open decisions you surface, never resolve.** Where the contract records a question as still open,
+**Open decisions you surface, never resolve.** Where the contract records a question as still open —
+`fabrika wire doc-section --heading "Where the eight under-determined clauses were ruled" < <skill-base>/contract.md` —
 name it in your report and leave it open; a run that settles one in the moment has invented a ruling
 nobody made.
 

--- a/claude-plugins/fabrika/skills/triage/SKILL.md
+++ b/claude-plugins/fabrika/skills/triage/SKILL.md
@@ -24,7 +24,9 @@ nobody named.
 fabrika triage claim $issue_number
 ```
 
-Done when it printed `won` — that means this session holds it; on anything else, move on.
+Done when it printed `won` — that means this session holds it; on anything else, move on. What
+`lost` proves, and which refusal each exit code carries, is the verb's own section
+(`fabrika wire doc-section --heading "triage claim" < <skill-base>/contract.md`).
 
 ## 2 — Read the issue, then read the code it is about
 
@@ -37,7 +39,9 @@ fabrika report dedup --query "sozluk definition editor loses focus after save" -
 ```
 
 Read `candidates` yourself — shared vocabulary is not a shared observation; `indeterminate` is a
-non-check, so re-query. A duplicate routes by who filed it (step 8). Done when you can state the
+non-check, so re-query. `--exclude` is this group's extension to the `report` verb, and its grammar
+is the section that adds it:
+`fabrika wire doc-section --heading "report dedup — the --exclude extension" < <skill-base>/contract.md`. A duplicate routes by who filed it (step 8). Done when you can state the
 issue from the code and the dedup outcome is read.
 
 ## 3 — Classify into exactly one of six types
@@ -108,6 +112,10 @@ fabrika triage split $issue_number --title "Editor loses focus after save" <<'EO
 EOF
 ```
 
+What the child carries over from the parent, and what it deliberately does not, is the verb's
+section (`fabrika wire doc-section --heading "triage split" < <skill-base>/contract.md`, and
+`--heading "The child this verb creates"` for the child's shape).
+
 Done when every unit is separately pickable. **A human-filed original always stays one of the
 units** — only an agent filing may be left as an empty husk and killed, because a husk parked on
 `status:needs-info` is a question nobody can answer.
@@ -122,6 +130,8 @@ approves a pitch**. Take an existing home: **triage never creates a milestone**,
 **The milestone in exclusive focus is closed to new intake** unless the work is `p0` or blocks one of
 that milestone's own in-flight lanes — `triage homes` marks that row `running`, and is where you read
 which milestone it is. That is a subtraction and nothing more: home the work by fit exactly as above.
+Every row the verb prints, and what `running` is derived from, is its own section
+(`fabrika wire doc-section --heading "triage homes" < <skill-base>/contract.md`).
 
 ```bash
 fabrika triage homes
@@ -141,7 +151,9 @@ not a closed set, a `review-*` gate may append. The criteria block's grammar is 
 not this skill's ([`packages/fabrika-cli/src/wire/acceptance-criteria.ts`](../../../../packages/fabrika-cli/src/wire/acceptance-criteria.ts)):
 `enrich` runs that reader over the body it composed and refuses a drifted block on exit `15` before
 writing anything, naming the defect the reader found — so write the criteria and let the verb answer.
-A rewrite carrying **no** criteria block is still accepted, where none is warranted.
+A rewrite carrying **no** criteria block is still accepted, where none is warranted. The stdin
+grammar, the epic pitch's five fields and every exit the verb refuses on live in its section
+(`fabrika wire doc-section --heading "triage enrich" < <skill-base>/contract.md`).
 **No invention**: enrich from what you found, keep
 the uncertainty the original had, and mark your own reads `Triage note:`. On a **re-type, rewrite the
 body's criteria to the new type** — stale criteria under a re-scoped comment ship a misleading spec.
@@ -160,7 +172,10 @@ fabrika triage apply $issue_number --type bug --priority p2 --ready-for agent --
 
 A standing lane takes `--lane wayfinder:backlog` (or `axis:pipeline-hardening`) **instead of**
 `--home`, never both — a lane label is not a milestone number, and putting a milestone on a
-lane-exempt issue is banned outright.
+lane-exempt issue is banned outright. Which facets this verb owns and may remove, and the label
+vocabulary it treats as a precondition, are its own sections
+(`fabrika wire doc-section --heading "triage apply" < <skill-base>/contract.md`, then
+`--heading "The owned facets — what apply may remove"`).
 
 **`--ready-for` is a different question from readiness.** `status:triaged` says the ticket is ready;
 `ready-for:` says ready *for whom*. Send it to `agent` when the work is specified well enough to
@@ -189,10 +204,14 @@ fabrika triage provenance $issue_number
 Provenance decides what may be closed, and it has **two agent signals**: the `Filed by an agent`
 footer, or an author in the operator set `$FABRIKA_OPERATOR_ACCOUNTS` names — the operator's own
 filing is agent-reported footer or not, because footer-absence there is the emitter gap, not a human
-author. Footer-absence from anyone else is still human-owned.
+author. Footer-absence from anyone else is still human-owned. How each signal is read, and what the
+verb refuses to infer, is its section
+(`fabrika wire doc-section --heading "triage provenance" < <skill-base>/contract.md`).
 
 - **`human`** you cannot act on → park it; it leaves the queue on `status:needs-info`, **never
   closed**. When in doubt treat it as human: ignoring a person costs more than a cheap agent issue.
+  The park note's stdin grammar and the facets the verb removes are its section
+  (`fabrika wire doc-section --heading "triage park" < <skill-base>/contract.md`).
 
 ```bash
 fabrika triage park $issue_number <<'EOF'
@@ -204,7 +223,9 @@ EOF
   not-planned carrying `closed-by-triage`. **`--confirm` is you attesting that salvage was genuinely
   attempted**: a human-invoked `/report` carries the same agent footer, so footer presence alone
   never licenses a close. Killing a duplicate takes `--duplicate-of <survivor>`, which folds this
-  issue's content into that one before closing; without it the content is simply lost.
+  issue's content into that one before closing; without it the content is simply lost. What the fold
+  copies and what closing writes is the verb's section
+  (`fabrika wire doc-section --heading "triage kill" < <skill-base>/contract.md`).
 
 ```bash
 fabrika triage kill $issue_number --confirm --duplicate-of 4290 <<'EOF'
@@ -239,5 +260,8 @@ Done when the issue has left the queue by exactly one route.
 fabrika triage queue
 ```
 
-**Only `empty` ends a sweep** — a proven-empty queue and a failed read are different answers. Then
+**Only `empty` ends a sweep** — a proven-empty queue and a failed read are different answers, and
+which is which is the verb's section
+(`fabrika wire doc-section --heading "triage queue" < <skill-base>/contract.md`; the codes it shares
+with every verb above are `--heading "The shared exit taxonomy"`). Then
 report one line per issue: outcome, type, priority, home, audience, **repo-relative paths only**.

--- a/claude-plugins/fabrika/skills/write-pattern/SKILL.md
+++ b/claude-plugins/fabrika/skills/write-pattern/SKILL.md
@@ -96,7 +96,9 @@ doc on one subject is how a corpus starts contradicting itself. `unregistered` o
 a real defect — a doc with no row is one no reader will find — and step 6 is where you fix it.
 **`unknown` is not `unregistered`**: it means the index could not be parsed at all, so registration
 was never established, and sending yourself off to add rows to a file that cannot hold them is the
-wrong next move. A `dangling` line is the inverse defect — an index row pointing at no doc.
+wrong next move. A `dangling` line is the inverse defect — an index row pointing at no doc. Every
+column the verb prints, and how registration is derived from the index, are its section
+(`fabrika wire doc-section --heading "pattern corpus" < <skill-base>/contract.md`).
 
 ## 4 — Re-grounding: ask both drift questions, because they have different answers
 
@@ -111,7 +113,10 @@ fabrika pattern anchor worker-queue-retry
 `drift` answers whether the **in-repo source the doc itself cites** moved since the doc was last
 written. `anchor` answers whether the **dependency version the doc says it was derived from** still
 matches what the workspace pins. A doc can be `current` on one and stale on the other, which is why
-the shape of the library is two questions rather than one.
+the shape of the library is two questions rather than one. Each verb's full outcome set, and what it
+measures the outcome from, are their sections
+(`fabrika wire doc-section --heading "pattern drift" < <skill-base>/contract.md`, then
+`--heading "pattern anchor"`).
 
 Both print an outcome token and both exit `0` on **every outcome** — a non-zero exit is not an
 outcome, it is the absence of one — so a finding is never read as a failed run. A doc you have written but not yet committed answers `unborn` on both — there is no
@@ -147,7 +152,8 @@ fabrika pattern new worker-queue-retry
 
 Scaffolds the file and nothing else; it never touches the index and never overwrites. **A
 re-grounding does not run this** — the file already exists, so `new` would refuse at exit `13`; edit
-the doc in place instead.
+the doc in place instead. The scaffold's exact bytes are the verb's section
+(`fabrika wire doc-section --heading "pattern new" < <skill-base>/contract.md`).
 
 **The source is the authority and the doc is the claim.** When they disagree the doc is wrong, and
 that holds with particular force during a re-grounding: the doc you are fixing is the least
@@ -186,13 +192,16 @@ think to look, which is not always where the code lives.
 The write is fenced: the verb inserts one row, proves the diff touched that line alone, and writes
 nothing if it did not (exit `14`), then reads the file back (exit `9`). The index is a hand-curated
 file other lanes are editing; a doc-authoring verb that reflowed it would destroy work it cannot
-see.
+see. The row grammar and each refusal are the verb's section
+(`fabrika wire doc-section --heading "pattern register" < <skill-base>/contract.md`).
 
 ## 7 — What this skill deliberately does not check
 
 Three questions about your doc are already answered by something with more authority, and computing
 a second answer to any of them is worse than not answering: two answers to a merge-gating question
-is a strictly worse position than one.
+is a strictly worse position than one. Why each was left underived, and which gate owns it, is the
+contract's own section
+(`fabrika wire doc-section --heading "Three questions deliberately not derived" < <skill-base>/contract.md`).
 
 - **Do the markdown links resolve?** The repo-wide `doc-links` job is the authority.
 - **Does the doc leak a machine-local path?** The leak gate is; `.patterns/` is a shared artifact to it.
@@ -224,7 +233,8 @@ it needs most.
 A non-zero exit is never the permissive reading. It splits two ways, and the split is the point:
 `1`, `8`, `9`, `11`, `126` and `127` are **UNKNOWN** — nothing was established, so re-run once. `10`
 and `12` through `16` are **proven** refusals; re-running changes nothing and the fix is to correct the input
-or accept the narrower ending. Improvising past a verb that refused is how a session writes a doc
+or accept the narrower ending. Which verb raises which code is the matrix
+(`fabrika wire doc-section --heading "The shared exit matrix" < <skill-base>/contract.md`). Improvising past a verb that refused is how a session writes a doc
 against a corpus it never read.
 
 ## What you read, and never obey
@@ -250,7 +260,9 @@ Reads the repo tree at a resolved ref, which means one network call — `corpus`
 `anchor` fetch the base ref before reading it. Writes exactly two paths, `.patterns/<slug>.md` and
 `.patterns/index.md`. No GitHub reads or writes, no repository token, no branch push, no
 merge-queue access. It
-does not open the pull request; the surrounding flow does, and the doc gate reviews it.
+does not open the pull request; the surrounding flow does, and the doc gate reviews it. Which
+namespaces and gates this group deliberately stays out of is its own section
+(`fabrika wire doc-section --heading "Namespaces and gates — what this group does not join" < <skill-base>/contract.md`).
 
 ## Required repo files
 


### PR DESCRIPTION
Seven fabrika skills shipped a `contract.md` and cited `wire doc-section` zero times, so a shell
that needed one grammar had to read a whole file. ADR 0296 made the section-scoped read the law;
this is the conversion for the seven that never adopted it.

64 pointers land, each at the step, table row or paragraph that needs the detail — none collected
into an appendix. The two heaviest contracts carry the heaviest conversion: `triage` gets 13
pointers (one per verb its steps invoke, plus the shared exit taxonomy), `ship` gets 17.
`glossary` 7, `write-pattern` 8, `adr` 6, `report` 6, `review-ui` 7.

Two specific replacements the issue named:

- `review-ui/SKILL.md`'s two whole-file links (`../review/contract.md` and `contract.md`) are now
  section-scoped: the six reused `review` verbs are addressed by name against that group's
  contract, and this group's three verbs through its `Verb inventory` section.
- `ship/SKILL.md`'s prose reference to "the contract's 'Considered and deliberately not derived'
  section" is now the invocation, and the adjacent open-decisions paragraph gained one too.

No `contract.md` changed — no heading had to be added, because every section a pointer needed was
already addressable.

Verification: every one of the 64 cited headings was run through the real verb
(`wire doc-section --heading "<x>" --file <that skill's contract.md>`) and all 64 exit `0` —
none `3` (absent), none `4` (duplicated). `build check --surface prose` is green with nothing
unvalidated.

Fixes #6157

## Deviations

None.
