### PR TITLE
fix: fabrika-cli's Node >=24 engine floor is stricter than the code needs, warning on every call in Node-22 repos

### DIFF
--- a/packages/fabrika-cli/README.md
+++ b/packages/fabrika-cli/README.md
@@ -152,8 +152,10 @@ The two entry points need different Nodes, so the manifest carries two floors an
 
 `publishConfig.engines` is a real field replacement, not a hopeful one: packing this package with
 pnpm 10.27.0 (the `packageManager` pin `publish.yml` runs on) emits a tarball `package.json` whose
-`engines.node` is `>=22.12` and whose `publishConfig` is gone entirely. So the dev floor never
-reaches a consumer, and a Node-22 repo installs and runs with no `Unsupported engine` warning —
+`engines.node` is `>=22.12` and whose `publishConfig` is stripped to `{"access": "public"}` — pnpm
+copies a whitelisted field onto the manifest and deletes it from `publishConfig`, and `access` is a
+publish setting rather than a manifest field, so it stays behind. So the dev floor never reaches a
+consumer, and a Node-22 repo installs and runs with no `Unsupported engine` warning —
 including under `engine-strict=true`, where `>=24` was a hard install failure rather than noise.
 
 `>=22.12` is what the bundle was measured to need, not what it was assumed to need. Running
@@ -1148,8 +1150,9 @@ pnpm --filter @kampus/fabrika-cli build       # tsc -> dist/, for the published 
 types natively, so an edit to `src/` is live on the next invocation — which is the entire point of
 the workspace `devDependencies` line in the root `package.json`. `build` emits `dist/` for the
 published tarball and nothing else reads it; see [the two Node floors](#the-two-node-floors) for why
-that `≥ 24` is this workspace's number and not the published package's. Emit and type-check now run the same binary — the stable native `tsc` (ADR 0271) — so the
-published artifact and the gate can no longer disagree about the compiler.
+that `≥ 24` is this workspace's number and not the published package's. Emit and type-check now run
+the same binary — the stable native `tsc` (ADR 0271) — so the published artifact and the gate can no
+longer disagree about the compiler.
 
 A verb is a **pure function of its dependencies** — the `*-verb.ts` modules compute a
 `VerbOutcome` (exit code, stdout, stderr) and never write a stream or exit. The Effect CLI

--- a/packages/fabrika-cli/README.md
+++ b/packages/fabrika-cli/README.md
@@ -136,9 +136,37 @@ refuse an unknown flag.
 > installed copy, which is what a real `pnpm add --global` produces. `publishConfig` is what lets
 > both halves be true at once: the manifest's `bin` stays `./src/bin.ts` for the workspace, where
 > pnpm's link resolves *outside* `node_modules` and an edit to `src/` is live on the next
-> invocation, and npm rewrites `bin`/`main`/`types`/`exports` onto the compiled `dist/` at publish
-> time. `files` is `["dist"]` and `prepublishOnly` runs the build, so a tarball can neither miss
-> `dist/` nor ship a stale one (#4784).
+> invocation, and npm rewrites `bin`/`main`/`types`/`exports`/`engines` onto the compiled `dist/` at
+> publish time. `files` is `["dist", "scripts"]` and `prepublishOnly` runs the build, so a tarball
+> can neither miss `dist/` nor ship a stale one (#4784).
+
+### The two Node floors
+
+The two entry points need different Nodes, so the manifest carries two floors and never one number
+(#5943):
+
+| Floor | Where it lives | What it is | Who reads it |
+| --- | --- | --- | --- |
+| `>=22.12` | `publishConfig.engines.node` | what the compiled `dist/` runs on | consumers, via the tarball |
+| `>=24` | top-level `engines.node` | what the `.ts` `bin` needs for type stripping | this workspace |
+
+`publishConfig.engines` is a real field replacement, not a hopeful one: packing this package with
+pnpm 10.27.0 (the `packageManager` pin `publish.yml` runs on) emits a tarball `package.json` whose
+`engines.node` is `>=22.12` and whose `publishConfig` is gone entirely. So the dev floor never
+reaches a consumer, and a Node-22 repo installs and runs with no `Unsupported engine` warning —
+including under `engine-strict=true`, where `>=24` was a hard install failure rather than noise.
+
+`>=22.12` is what the bundle was measured to need, not what it was assumed to need. Running
+`dist/bin.js` down the Node ladder: 22.12 and up is clean; 22.11 works but warns
+(`ExperimentalWarning: Importing JSON modules`, from [`src/version.ts`](./src/version.ts)'s
+`import pkg from "../package.json" with {type: "json"}` — import attributes for JSON stopped being
+experimental in 22.12); Node 20 and 18 throw, because `undici` in the dependency tree calls
+`webidl.util.markAsUncloneable`, which lands in Node 22.
+
+The dev floor stays `>=24` and is deliberately conservative — the `.ts` `bin` in fact starts on
+22.18+, where native type stripping was backported, but nothing in this repo runs below 24. It is
+also not the only home for that number: `volta.node` pins `26.2.0` here and at the root, and CI
+reads `node-version-file: package.json`.
 
 ## Quickstart
 
@@ -1119,8 +1147,8 @@ pnpm --filter @kampus/fabrika-cli build       # tsc -> dist/, for the published 
 **The development loop has no build step.** `bin` points at `./src/bin.ts` and Node ≥ 24 strips the
 types natively, so an edit to `src/` is live on the next invocation — which is the entire point of
 the workspace `devDependencies` line in the root `package.json`. `build` emits `dist/` for the
-published tarball and nothing else reads it; see the publish note above for why the two halves
-differ. Emit and type-check now run the same binary — the stable native `tsc` (ADR 0271) — so the
+published tarball and nothing else reads it; see [the two Node floors](#the-two-node-floors) for why
+that `≥ 24` is this workspace's number and not the published package's. Emit and type-check now run the same binary — the stable native `tsc` (ADR 0271) — so the
 published artifact and the gate can no longer disagree about the compiler.
 
 A verb is a **pure function of its dependencies** — the `*-verb.ts` modules compute a

--- a/packages/fabrika-cli/package.json
+++ b/packages/fabrika-cli/package.json
@@ -28,6 +28,9 @@
 	},
 	"publishConfig": {
 		"access": "public",
+		"engines": {
+			"node": ">=22.12"
+		},
 		"bin": {
 			"fabrika": "./dist/bin.js"
 		},


### PR DESCRIPTION
`@kampus/fabrika-cli` declared `engines: {"node": ">=24"}` at the top level, where nothing
overrides it at publish time. That number was minted for the **development** `bin`
(`./src/bin.ts`, which needs Node's type stripping) and is false of the **published** one
(`./dist/bin.js`, compiled JS). Consumers only ever take the second path, so a Node-22 repo got an
`Unsupported engine` warning on every single call — noise on the exact stderr channel fabrika uses
for its real refusals — and would have hard-failed at install under `engine-strict=true`.

The fix is one field: `publishConfig.engines.node` is now `>=22.12`. The top-level `>=24` stays as
the workspace's own dev floor.

## What was measured, not assumed

**`publishConfig.engines` is honoured by pnpm 10.27.0** — the version `publish.yml` runs on. Packed
this package and read the tarball's `package.json`: `engines.node` is `>=22.12` and `publishConfig`
is stripped to `{"access": "public"}`. So the fallback route the issue named (lower `engines`
outright) is not needed.

**`>=22.12` is where the compiled bundle actually runs.** Ran `dist/bin.js status config` down the
volta Node ladder:

| Node | Result |
| --- | --- |
| 22.12 – 26.2 | clean |
| 22.11 | works, but warns `ExperimentalWarning: Importing JSON modules` |
| 20.14, 18.20 | throws — `undici` calls `webidl.util.markAsUncloneable`, which lands in Node 22 |

The 22.11 warning traces to `src/version.ts`'s `import pkg from "../package.json" with {type:
"json"}`; import attributes for JSON stopped being experimental in 22.12. Trading one permanent
warning for another would have missed the point, so the floor is 22.12 rather than 22.11.

**The end-to-end check.** Packed the tarball, installed it into a throwaway consumer with
`engine-strict=true` in `.npmrc` under Node v22.22.3 (the reporter's version): install exited 0
with no `Unsupported engine` line, and `fabrika status config --skills-dir` from that install ran
at exit 0.

The README gains a **The two Node floors** section stating which floor is which, why they differ,
and the ladder above, so the next reader does not reconstruct it from a commit message.

Fixes #5943

## Deviations

- **Out-of-scope change** — **Said:** #5943 names `engines`, `publishConfig` and the README's floor
  documentation. **Did:** also corrected the publish NOTE's claim that `files` is `["dist"]` (it is
  `["dist", "scripts"]`) and that publish rewrites `bin`/`main`/`types`/`exports` (it now rewrites
  `engines` too). **Why:** both sentences sit in the paragraph this PR extends, and a wrong `files`
  claim beside a newly-verified floor claim makes the whole note untrustworthy.
  **Disposition:** stated here.
- **Known defect left unfixed** — **Said:** the dev floor keeps whatever it genuinely needs.
  **Did:** left the top-level `engines.node` at `>=24` even though the `.ts` `bin` was measured to
  start on 22.18+ (native type stripping was backported there; 23.7 and 24.2 run it with an
  `ExperimentalWarning`, 22.22.3 and 25+ run it clean). **Why:** the dev floor no longer reaches a
  consumer, nothing in this repo runs below 24, and loosening a workspace-only floor is a separate
  decision from the published-contract bug this issue is about. **Disposition:** stated here; the
  README records the measurement so the number is no longer a mystery.
