### PR TITLE
fix: review deviations' Tier-M scan misses chai-style assert.isTrue, so a removed assertion is invisible

### DIFF
--- a/packages/fabrika-cli/src/review/diff.ts
+++ b/packages/fabrika-cli/src/review/diff.ts
@@ -175,8 +175,14 @@ export interface TierMHit {
 const SUPPRESSIONS = ["biome-ignore", "@ts-expect-error", "test.skip", ".only"];
 
 const TEST_FILE = /\.(?:test|spec)\.[cm]?[jt]sx?$/;
-/** What counts as an assertion for class 6. Both spellings the repo's two runners use. */
-const ASSERTION = /\b(?:expect|assert)\s*\(/;
+/**
+ * What counts as an assertion for class 6: a call on `expect`/`assert` itself (`expect(`, `assert(`)
+ * or on any member chain hanging off one (`assert.isTrue(`, `assert.deepStrictEqual(`,
+ * `expect.fail(`). Chai-style member calls are the dominant spelling in this repo's tests, and the
+ * call-paren-only pattern this replaces saw none of them (#5742). The `\b` guards keep it off an
+ * identifier that merely contains the word — `assertions.push(` is not a hit.
+ */
+const ASSERTION = /\b(?:expect|assert)\b(?:\s*\.\s*[A-Za-z_$][\w$]*)*\s*\(/;
 
 /**
  * The Tier-M scan: the §DEV classes a gate can see in the diff itself.

--- a/packages/fabrika-cli/src/review/diff.unit.test.ts
+++ b/packages/fabrika-cli/src/review/diff.unit.test.ts
@@ -195,6 +195,43 @@ describe("tierMHits", () => {
 		expect(tierMHits(diff)).toEqual([]);
 	});
 
+	it("finds a removed assertion in each spelling the repo's two runners write", () => {
+		const spellings = [
+			"assert(ok);",
+			"expect(x).toBe(1);",
+			"assert.isTrue(ok);",
+			"assert.isFalse(ok);",
+			"assert.strictEqual(a, b);",
+			"assert.deepStrictEqual(a, b);",
+			'expect.fail("nope");',
+		];
+		for (const line of spellings) {
+			const diff = `diff --git a/a.test.ts b/a.test.ts\n@@ -1,2 +1,1 @@\n a\n-\t${line}\n`;
+			expect(tierMHits(diff)).toEqual([
+				{kind: "removed-assertion", file: "a.test.ts", line: 2, token: line},
+			]);
+		}
+	});
+
+	it("reports the removed assertion PR #5730 printed None. beside", () => {
+		const line = 'assert.isTrue(isSelfExempt(".claude/skills/triage/SKILL.md"));';
+		const file = "packages/pipeline-cli/src/tools/leak-guard/leak-guard.unit.test.ts";
+		const diff = `diff --git a/${file} b/${file}\n@@ -268,2 +268,1 @@\n \tit("exempts a skill", () => {\n-\t\t${line}\n`;
+		expect(tierMHits(diff)).toEqual([{kind: "removed-assertion", file, line: 269, token: line}]);
+	});
+
+	it("does not report a removed non-assertion line in a test file", () => {
+		const diff = `diff --git a/a.test.ts b/a.test.ts\n@@ -1,2 +1,1 @@\n a\n-\tconst rows = collect();\n`;
+		expect(tierMHits(diff)).toEqual([]);
+	});
+
+	it("does not report an identifier that merely contains expect or assert", () => {
+		for (const line of ["assertions.push(1);", "expectation(x);", "myassert(x);", "reexpect(x);"]) {
+			const diff = `diff --git a/a.test.ts b/a.test.ts\n@@ -1,2 +1,1 @@\n a\n-\t${line}\n`;
+			expect(tierMHits(diff)).toEqual([]);
+		}
+	});
+
 	it("does not report a suppression that was REMOVED — only what the diff adds", () => {
 		const diff = `diff --git a/a.ts b/a.ts\n@@ -1,2 +1,1 @@\n a\n-// biome-ignore lint: gone\n`;
 		expect(tierMHits(diff)).toEqual([]);


### PR DESCRIPTION
Class 6 of the Tier-M scan (`removed-assertion`) required the call paren directly after `expect` or
`assert`, so every chai-style member call — `assert.isTrue(`, `assert.strictEqual(`, `expect.fail(` —
was invisible to it. That is the dominant assertion spelling in this repo's tests, so a PR that
deleted assertions and printed `None.` got an empty Tier-M list and the gate said nothing.

`ASSERTION` now matches a call on `expect`/`assert` itself or on any member chain hanging off one,
with `\b` on both sides so `assertions.push(` and `expectation(` are still not hits. The docblock
says what the pattern actually covers instead of claiming "both spellings".

New tests in `diff.unit.test.ts` cover all seven spellings the criteria name, a removed
non-assertion line, the four near-miss identifiers, and the real line PR #5730 printed `None.`
beside. `pnpm typecheck`, `pnpm lint:worktree` and the full `fabrika-cli` suite (5408 tests) pass.

Fixes #5742

## Deviations

- **Known defect left unfixed** — **Said:** the issue also flags `SUPPRESSIONS` four lines away —
  `.only` matches any member call ending in `.only`, and `test.skip` misses `it.skip` /
  `describe.skip` — and leaves widening it to the builder. **Did:** left it as-is; only `ASSERTION`
  moved. **Why:** the `SUPPRESSIONS` docblock says the list is the four tokens the §DEV contract
  enumerates, so changing what class 5 sees is a contract change, not a regex fix, and it needs its
  own verdict. **Disposition:** filed as issue #6194.
