### PR TITLE
fix: build check --surface prose reds on markdown-link examples written inside code spans

### DIFF
--- a/packages/fabrika-cli/src/build/check-verb.ts
+++ b/packages/fabrika-cli/src/build/check-verb.ts
@@ -179,13 +179,6 @@ const leakDefects = (
 		(leak) => `${file}:${leak.line} carries a machine-local path (${leak.reason}): ${leak.matched}`,
 	);
 
-/**
- * Every in-repo link target a markdown file names.
- *
- * Absolute URLs and bare fragments are skipped: a link with a scheme is not this tree's to resolve,
- * and a fragment resolves within the page. A fabrika doc cited by a relative path is covered by the
- * same rule, so there is no second reference check to drift from this one.
- */
 /** Fold `.` and `..` out of an absolute path, so a link's target is compared in one spelling. */
 export const normalizePath = (path: string): string => {
 	const out: string[] = [];
@@ -197,9 +190,94 @@ export const normalizePath = (path: string): string => {
 	return `/${out.join("/")}`;
 };
 
+/** Every byte replaced by a space, newlines kept, so masking moves no offset and no line number. */
+const blank = (text: string): string => text.replace(/[^\n]/g, " ");
+
+const FENCE_RE = /^ {0,3}(`{3,}|~{3,})/;
+
+/**
+ * Blank out every code span in a fence-free region. A run of n backticks opens a span the next run
+ * of exactly n backticks closes; a run with no partner is literal text and masks nothing.
+ */
+const maskSpans = (text: string): string => {
+	let out = "";
+	let i = 0;
+	while (i < text.length) {
+		if (text[i] !== "`") {
+			out += text[i];
+			i += 1;
+			continue;
+		}
+		let open = i;
+		while (text[open] === "`") open += 1;
+		const run = open - i;
+		const closer = new RegExp(`(?<!\`)\`{${run}}(?!\`)`, "g");
+		closer.lastIndex = open;
+		const close = closer.exec(text);
+		if (close === null) {
+			out += text.slice(i, open);
+			i = open;
+			continue;
+		}
+		const end = close.index + run;
+		out += blank(text.slice(i, end));
+		i = end;
+	}
+	return out;
+};
+
+/**
+ * Blank out fenced blocks and code spans, so a markdown link written as an *illustration* is not
+ * extracted as a live one (#5639). The docs that state this repo's link convention are precisely
+ * the docs that spell a link out as an example, and they were the ones this predictor red.
+ *
+ * Masked bytes become spaces rather than being dropped: the link pattern cannot cross whitespace,
+ * so a masked example can never fuse with live text on either side of it.
+ */
+const maskCode = (text: string): string => {
+	const out: string[] = [];
+	let prose: string[] = [];
+	let fence: string | null = null;
+	const flush = () => {
+		if (prose.length > 0) out.push(maskSpans(prose.join("\n")));
+		prose = [];
+	};
+	for (const line of text.split("\n")) {
+		const marker = FENCE_RE.exec(line)?.[1];
+		if (fence !== null) {
+			out.push(blank(line));
+			if (marker !== undefined && marker[0] === fence[0] && marker.length >= fence.length) {
+				fence = null;
+			}
+			continue;
+		}
+		if (marker !== undefined) {
+			flush();
+			out.push(blank(line));
+			fence = marker;
+			continue;
+		}
+		prose.push(line);
+	}
+	flush();
+	return out.join("\n");
+};
+
+/**
+ * Every in-repo link target a markdown file names, ignoring the ones written as examples.
+ *
+ * Absolute URLs and bare fragments are skipped: a link with a scheme is not this tree's to resolve,
+ * and a fragment resolves within the page. A fabrika doc cited by a relative path is covered by the
+ * same rule, so there is no second reference check to drift from this one.
+ *
+ * The extractor stays a regex over masked text rather than moving to a markdown parser: fabrika is
+ * installed into repos it does not control (ADR 0273) on four runtime dependencies, and code-span
+ * plus fenced-block masking is the one property #2308 bought by retiring the CI gate's in-house
+ * extractor. Reference-style and HTML links stay out of scope here, as they always were.
+ */
 export const linkTargets = (text: string): ReadonlyArray<string> => {
 	const targets: string[] = [];
-	for (const match of text.matchAll(/\[[^\]]*\]\(([^)\s]+)[^)]*\)/g)) {
+	for (const match of maskCode(text).matchAll(/\[[^\]]*\]\(([^)\s]+)[^)]*\)/g)) {
 		const target = (match[1] ?? "").split("#")[0]?.trim() ?? "";
 		if (target === "" || /^[a-z][a-z0-9+.-]*:/i.test(target)) continue;
 		targets.push(target);

--- a/packages/fabrika-cli/src/build/check-verb.unit.test.ts
+++ b/packages/fabrika-cli/src/build/check-verb.unit.test.ts
@@ -2,7 +2,14 @@ import {Effect, Layer} from "effect";
 import {describe, expect, it} from "vitest";
 import {errOut, fakeFs, fakeShell, okOut} from "../fakes.test-support.ts";
 import type {ExecResult} from "../io/exec.ts";
-import {classifyDiff, notCoveredBy, runCheck, SURFACES, surfaceMismatch} from "./check-verb.ts";
+import {
+	classifyDiff,
+	linkTargets,
+	notCoveredBy,
+	runCheck,
+	SURFACES,
+	surfaceMismatch,
+} from "./check-verb.ts";
 import {
 	OFF_VOCABULARY,
 	PRECONDITION_UNKNOWN,
@@ -695,5 +702,84 @@ describe("the enumeration unions the untracked files with the diff", () => {
 		]);
 		expect(out.code).toBe(PRECONDITION_UNKNOWN);
 		expect(out.stderr.at(-1)).toContain("the verdict is UNKNOWN, never green");
+	});
+});
+
+// #5639: the extractor read a markdown link written as an *example* as a live one, so the five docs
+// that state this repo's link convention could not pass the surface that reads them.
+describe("linkTargets — an illustrated link is not a link", () => {
+	const TOOLS_MD_493 =
+		"`doc-links` validates markdown `[text](path)` links and *masks* code spans by construction.\n";
+
+	it("returns no target for the TOOLS.md line that illustrates the link grammar", () => {
+		expect(linkTargets(TOOLS_MD_493)).toEqual([]);
+	});
+
+	it("returns no target for a link inside a fenced block", () => {
+		expect(linkTargets("intro\n\n```markdown\nSee [the ADR](NNNN-slug.md).\n```\n")).toEqual([]);
+	});
+
+	it("returns no target for a link inside a tilde fence, or a fence indented up to three", () => {
+		expect(linkTargets("~~~\n[a](gone.md)\n~~~\n")).toEqual([]);
+		expect(linkTargets("   ```\n[a](gone.md)\n   ```\n")).toEqual([]);
+	});
+
+	it("returns no target for a link inside a multi-backtick span", () => {
+		expect(linkTargets("write `` [a](`x`.md) `` to show it\n")).toEqual([]);
+	});
+
+	it("still returns a real relative link", () => {
+		expect(linkTargets("see [the index](.patterns/index.md) first\n")).toEqual([
+			".patterns/index.md",
+		]);
+	});
+
+	it("still returns a real repo-rooted link", () => {
+		expect(linkTargets("see [the index](/.patterns/index.md)\n")).toEqual(["/.patterns/index.md"]);
+	});
+
+	it("still returns a link sharing its line with an unrelated code span", () => {
+		expect(linkTargets("run `pnpm dev`, then read [the guide](DEVELOPMENT.md)\n")).toEqual([
+			"DEVELOPMENT.md",
+		]);
+	});
+
+	it("still returns a link after a fence closes, and after an unpartnered backtick", () => {
+		expect(linkTargets("```\n[a](gone.md)\n```\n\n[b](DEVELOPMENT.md)\n")).toEqual([
+			"DEVELOPMENT.md",
+		]);
+		expect(linkTargets("a lone ` tick, then [b](DEVELOPMENT.md)\n")).toEqual(["DEVELOPMENT.md"]);
+	});
+
+	it("keeps skipping schemes and bare fragments, masked or not", () => {
+		expect(linkTargets("[home](https://kamp.us) and [top](#intro)\n")).toEqual([]);
+	});
+});
+
+describe("the prose link check still reds a dead link", () => {
+	const DOC = "/repo/trees/lane-a/docs/guide.md";
+
+	it("reds a genuinely dead relative link in a changed doc", async () => {
+		const out = await run(
+			[...LANE_OK, [DIFF, okOut("docs/guide.md\n")]],
+			{surface: "prose"},
+			{
+				[DOC]: "see [the plan](plan.md)\n",
+			},
+		);
+		expect(out.code).toBe(VALIDATION_RED);
+		expect(out.stderr.some((line) => line.includes('links to "plan.md"'))).toBe(true);
+	});
+
+	it("greens the same doc when that link is written as an example", async () => {
+		const out = await run(
+			[...LANE_OK, [DIFF, okOut("docs/guide.md\n")]],
+			{surface: "prose"},
+			{
+				[DOC]: "write `[the plan](plan.md)` to cite it\n",
+			},
+		);
+		expect(out.code).toBe(0);
+		expect(JSON.parse(out.stdout).verdict).toBe("green");
 	});
 });


### PR DESCRIPTION
`build check --surface prose` read a markdown link written as an *example* as a live link, then
resolved it against the filesystem and red. The docs that state this repo's link convention are
exactly the docs that spell a link out as an example, so a builder amending `CLAUDE.md`, an ADR
skill or `TOOLS.md` got a red naming a link they did not write and could not delete without
deleting the documentation of the convention itself.

`linkTargets` now runs its regex over masked text. `maskCode` blanks fenced blocks (backtick or
tilde, indented up to three, closed by a matching run) and `maskSpans` blanks code spans (a run of
n backticks opens, the next run of exactly n closes; an unpartnered run is literal and masks
nothing). Masked bytes become spaces rather than being dropped, so offsets and line numbers hold
and a masked example can never fuse with live text beside it.

**The extractor stays an in-house regex**, over masked text. #2308 retired the CI gate's in-house
extractor for lychee and bought code-span masking, reference-link and HTML-link coverage in one
move. Only the first of those was missing here, and it is ~40 lines of pure, tested text. fabrika
installs into repos it does not control (ADR 0273) on four runtime dependencies; adding a markdown
parser to that set for one validator costs every consumer an install. Reference-style and HTML
links stay out of scope, as they already were — the CI gate (`doc-links.yml`, lychee offline) is
still the authority over them, and this predictor never claimed them.

Verified over the five files the issue lists under Blast radius: at `main` the extractor produced 13
unresolved targets across three of them; it now produces none, and still returns 41 live links from
the same five. Swept every tracked `.md` in the repo (593 files): 37 targets dropped, each one
inside a code span or a fence.

New tests in `check-verb.unit.test.ts` cover both directions — the exact `TOOLS.md` illustration
shape, fenced and tilde-fenced links, a multi-backtick span, and on the other side a real relative
link, a repo-rooted link, a link sharing its line with an unrelated code span, and a link after a
fence closes — plus two end-to-end `runCheck` cases: a dead relative link still reds, the same link
written as an example greens.

Fixes #5639

## Deviations

- **Out-of-scope change** — **Said:** #5639 names `linkTargets` and its masking gap. **Did:** also
  moved the `linkTargets` docblock, which sat above `normalizePath` instead of above the function it
  documents. **Why:** it is the docblock of the function this PR rewrites, and it had to be edited
  anyway to record the regex-vs-parser reason the acceptance criteria ask for.
  **Disposition:** stated here.
- **Known defect left unfixed** — **Said:** mask code so an illustrated link is not extracted.
  **Did:** masked fenced blocks and code spans, not 4-space-indented code blocks. **Why:** telling
  an indented code block from a list continuation needs block-level parsing, which is the parser
  this PR argues against; no doc in the repo trips it today. **Disposition:** stated here.
