### PR TITLE
fix: status bootstrap readout-artifact reports READBACK_MISMATCH on a first creation that landed correctly

### DIFF
--- a/packages/fabrika-cli/src/status/bootstrap-verb.ts
+++ b/packages/fabrika-cli/src/status/bootstrap-verb.ts
@@ -18,7 +18,13 @@ import {Effect, type FileSystem, Path, Result} from "effect";
 import type {ChildProcessSpawner} from "effect/unstable/process";
 import {exists, readFile, writeFile} from "../io/fs.ts";
 import type {Attempt} from "../io/git.ts";
-import {createLabel, createUnlabelledIssue, listLabels, openIssuesTitled} from "../io/issues.ts";
+import {
+	createLabel,
+	createUnlabelledIssue,
+	getIssue,
+	listLabels,
+	openIssuesTitled,
+} from "../io/issues.ts";
 import type {StdinRead} from "../io/stdin.ts";
 import {STATUSES} from "../labels.ts";
 import {normalizeForReadback} from "../report/compose.ts";
@@ -303,6 +309,13 @@ const buildLabels = (
 		);
 	});
 
+/**
+ * **The pre-write probe and the read-back use different primitives, and the asymmetry is the point.**
+ * With no number in hand a title scan is the only probe there is; once `createUnlabelledIssue` has
+ * returned one, `getIssue` reads the issue's own resource. The issues *list* is eventually
+ * consistent, so re-scanning it spends `READBACK_MISMATCH` — the loudest code here — on a correct
+ * first creation whose row has not propagated yet (#5776).
+ */
 const buildArtifact = (
 	surface: Extract<BuildableSurface, {kind: "issue"}>,
 	input: BootstrapInput,
@@ -329,14 +342,18 @@ const buildArtifact = (
 			);
 		}
 		const target = `${repo}#${write.value.number}`;
-		const back = yield* openIssuesTitled(repo, ARTIFACT_TITLE);
-		if (back._tag === "Failure") {
+		const back = yield* getIssue(repo, write.value.number);
+		if (back._tag === "Unknown") {
 			return refuse(
 				WRITE_UNKNOWN,
 				`${VERB}: created ${target} and it could not be read back: ${back.reason} — the outcome is UNKNOWN.`,
 			);
 		}
-		if (!back.value.some((issue) => issue.number === write.value.number)) {
+		if (
+			back._tag === "Absent" ||
+			back.value.title !== ARTIFACT_TITLE ||
+			back.value.state !== "open"
+		) {
 			return refuse(
 				READBACK_MISMATCH,
 				`${VERB}: wrote ${target} and the read-back differs — it does not resolve open under that exact title.`,

--- a/packages/fabrika-cli/src/status/verbs.unit.test.ts
+++ b/packages/fabrika-cli/src/status/verbs.unit.test.ts
@@ -5,9 +5,12 @@
  * The property under test throughout is the three-state law: a proven negative is an exit-`0` token,
  * an unread source is `unknown`, and the two never collapse.
  */
-import {Effect} from "effect";
+import {Effect, Layer} from "effect";
 import {describe, expect, it} from "vitest";
-import {fakeFs} from "../fakes.test-support.ts";
+import {errOut, fakeFs, fakeShell, okOut} from "../fakes.test-support.ts";
+import type {ExecResult} from "../io/exec.ts";
+import {ok} from "../io/git.ts";
+import type {StdinRead} from "../io/stdin.ts";
 import {AWAITING_RELEASE, PLANNED, STATUSES} from "../labels.ts";
 import {coderTemplateText} from "../lane/fixtures.test-support.ts";
 import {DEFAULT_STALE_MINUTES} from "../lane/stale.ts";
@@ -30,9 +33,16 @@ import {
 	ISSUE_SHAPE_MARKERS,
 	knownIds,
 	MARKER_COLOR,
+	runBootstrap,
 	TAXONOMY,
 } from "./bootstrap-verb.ts";
-import {NOT_BUILDABLE, PRECONDITION_UNKNOWN, ZERO_SCOPE} from "./codes.ts";
+import {
+	NOT_BUILDABLE,
+	PRECONDITION_UNKNOWN,
+	READBACK_MISMATCH,
+	WRITE_UNKNOWN,
+	ZERO_SCOPE,
+} from "./codes.ts";
 import {configState, countsOf, runConfig, type SurfaceRow} from "./config-verb.ts";
 import {noAsOf, oneLine, readNow} from "./fields.ts";
 import {runMenu} from "./menu-verb.ts";
@@ -45,7 +55,7 @@ import {
 	readoutField,
 	runOpen,
 } from "./open-verb.ts";
-import {digestComment, issueNumberOf, runReadout} from "./readout-verb.ts";
+import {ARTIFACT_TITLE, digestComment, issueNumberOf, runReadout} from "./readout-verb.ts";
 import {
 	IN_REPO_ROSTER,
 	PLUGIN_MANIFEST,
@@ -407,6 +417,83 @@ describe("status bootstrap", () => {
 		const taxonomy = new Set(TAXONOMY.map((label) => label.name));
 		for (const label of ISSUE_SHAPE_MARKERS) expect(taxonomy.has(label.name)).toBe(false);
 		expect(TAXONOMY.every((label) => label.color === null)).toBe(true);
+	});
+});
+
+/**
+ * #5776: the read-back re-scanned the eventually-consistent issues *list*, so a correct first
+ * creation reported `READBACK_MISMATCH`. Every case here scripts that list to stay empty after the
+ * write — the branch is proven only when the outcome no longer depends on it.
+ */
+describe("the readout-artifact read-back reads the created issue by number", () => {
+	const LIST = /^gh api --paginate repos\/o\/r\/issues\?state=open/;
+	const CREATE = /^gh api --method POST repos\/o\/r\/issues /;
+	const READBACK = /^gh api repos\/o\/r\/issues\/3$/;
+	const CREATED = okOut(JSON.stringify({number: 3, html_url: "https://github.com/o/r/issues/3"}));
+
+	const artifact = (overrides: Readonly<Record<string, unknown>> = {}) =>
+		okOut(
+			JSON.stringify({
+				number: 3,
+				title: ARTIFACT_TITLE,
+				body: "",
+				state: "open",
+				labels: [],
+				html_url: "https://github.com/o/r/issues/3",
+				...overrides,
+			}),
+		);
+
+	const run = (readback: ExecResult) => {
+		const shell = fakeShell([
+			[LIST, okOut("")],
+			[CREATE, CREATED],
+			[READBACK, readback],
+		]);
+		const fs = fakeFs({files: {}});
+		return Effect.runPromise(
+			Effect.provide(
+				runBootstrap({
+					surfaceId: "readout-artifact",
+					path: null,
+					json: true,
+					repoRoot: "/repo",
+					repo: ok("o/r"),
+					stdin: Effect.succeed({_tag: "NoStdin"} as StdinRead),
+				}),
+				Layer.mergeAll(shell.layer, fs.layer),
+			),
+		).then((outcome) => ({outcome, calls: shell.calls}));
+	};
+
+	it("reports created off the issue's own resource, never a second list read", async () => {
+		const {outcome, calls} = await run(artifact());
+		expect(outcome.code).toBe(ANSWER);
+		expect(JSON.parse(outcome.stdout)).toEqual({
+			outcome: "created",
+			surfaceId: "readout-artifact",
+			target: "o/r#3",
+			readback: "ok",
+		});
+		expect(calls.filter((line) => LIST.test(line))).toHaveLength(1);
+		expect(calls.filter((line) => READBACK.test(line))).toHaveLength(1);
+	});
+
+	it("spends READBACK_MISMATCH only on a proven 404", async () => {
+		const {outcome} = await run(errOut("gh: Not Found (HTTP 404)"));
+		expect(outcome.code).toBe(READBACK_MISMATCH);
+	});
+
+	it("reads an unreadable re-read as WRITE_UNKNOWN, never as a mismatch", async () => {
+		const {outcome} = await run(errOut("gh: Bad Gateway (HTTP 502)"));
+		expect(outcome.code).toBe(WRITE_UNKNOWN);
+	});
+
+	it("proves the artifact, not merely that the number resolves", async () => {
+		const wrongTitle = await run(artifact({title: "Something else"}));
+		expect(wrongTitle.outcome.code).toBe(READBACK_MISMATCH);
+		const closed = await run(artifact({state: "closed"}));
+		expect(closed.outcome.code).toBe(READBACK_MISMATCH);
 	});
 });
 


### PR DESCRIPTION
Fixes #5776

`status bootstrap readout-artifact` created the Governance readout issue, then proved the write by
re-scanning the open-issues *list* and checking the new number appeared in it. That list is
eventually consistent, so a correct first creation could report `READBACK_MISMATCH` — the loudest
code the verb has — over a write that landed. This is exactly what happened on a cold bootstrap in
another repo.

The read-back now calls `getIssue(repo, write.value.number)`, which reads `repos/<repo>/issues/<n>`
directly, and asserts the record is the artifact: `title` equals `ARTIFACT_TITLE` and `state` is
open. `getIssue`'s three outcomes stay apart — present and conforming is `created`, absent (a proven
404) is `READBACK_MISMATCH`, unreadable is `WRITE_UNKNOWN`.

The pre-write existence probe stays `openIssuesTitled`. With no number in hand a title scan is the
only probe there is; the asymmetry between the two is the point, and it is noted on `buildArtifact`.

`buildLabels` is untouched: `createLabel` returns no identifier, so there is nothing to read a
single label back by. That is a different fix and the issue rules it out of scope.

New tests in `verbs.unit.test.ts` cover the `readout-artifact` branch, which previously had none.
Every case scripts the issues list to stay empty after the write, so the happy path passes only
because the outcome no longer depends on list propagation.

## Deviations

None.
