### PR TITLE
feat: roadmap-focus is bootstrappable but its parse contract is undocumented, so a drafted ROADMAP.md silently joins nothing

### DIFF
--- a/claude-plugins/fabrika/skills/front-door/SKILL.md
+++ b/claude-plugins/fabrika/skills/front-door/SKILL.md
@@ -135,6 +135,24 @@ fabrika status bootstrap design-manifest <<'EOF'
 EOF
 ```
 
+<!-- anchor: MACHINE-READ-SURFACE --> **`roadmap-focus` is the exception to "draft by inference".**
+`ROADMAP.md` is read by machine — `triage homes` joins the repo's open milestones to its `## Arcs`
+and `## Campaigns` rows by the `#<number>` in each row's **second** cell, never by the title — so a
+plausible-looking draft joins nothing. The content (which arcs, which campaigns) is still yours and
+the human's; the *shape* is not. Read the grammar before drafting — it is stated in full in the same
+section the registry lives in (`fabrika wire doc-section --heading "status bootstrap" <
+<skill-base>/contract.md`) — then read the row count back off the notice:
+
+```bash
+fabrika status bootstrap roadmap-focus <<'EOF'
+…the roadmap you and the human settled on…
+EOF
+# status bootstrap: created ROADMAP.md for roadmap-focus, read-back conformed — 1 arc, 0 campaigns.
+```
+
+`0 arcs` is written and conformed, and it is also a roadmap nothing can join — fix it now rather
+than leaving `triage homes` to refuse over it in some later session.
+
 <!-- anchor: DESIGN-LAW-IS-REPO-CONTENT --> **The design law is repo content, never skill content.**
 phoenix's manifest is one repo's instance. Write what *this* repo's evidence supports; a pillar
 carried in from somewhere else is a foreign opinion wearing local clothes.

--- a/claude-plugins/fabrika/skills/front-door/contract.md
+++ b/claude-plugins/fabrika/skills/front-door/contract.md
@@ -980,7 +980,7 @@ a seventh is a change to this table, not a new rule.
 | `<surface-id>` | Target | Content | Read-back predicate |
 |---|---|---|---|
 | `design-manifest` | `--path`, default `design-system-manifest.md` at the repo root | **stdin**, required — the skill's inferred draft | the file's bytes match stdin through `normalizeForReadback` |
-| `roadmap-focus` | `--path`, default `ROADMAP.md` at the repo root | **stdin**, required | same |
+| `roadmap-focus` | `--path`, default `ROADMAP.md` at the repo root | **stdin**, required — to the [grammar below](#roadmap-grammar), which is not the drafting skill's judgement | same, plus the parsed row count in the notice ([why](#roadmap-grammar)) |
 | `gitignore-row` | `--path`, default `.gitignore` at the repo root | **none** — the two comment lines and the row `/.fabrika/`, fixed below, appended to whatever the file already holds | the re-read contains both the row and the whole of the pre-existing text, each through `normalizeForReadback` |
 | `label-taxonomy` | the repo's labels | **none** — the set is every imported `STATUSES` member (`status:needs-triage`, `status:triaged`, `status:needs-info`, `status:planned`, `status:awaiting-release`), every imported `PRIORITIES` member (`p0`, `p1`, `p2`), `type:` + every imported `TYPES` member, and `ready-for:` + every imported `AUDIENCES` member — sixteen today, each created with GitHub's default colour and a description naming this group as its creator | every label in the set resolves on a re-read |
 | `issue-shape-markers` | the repo's labels | **none** — three labels, each at colour `1D76DB`, with the descriptions fixed below | every label in the set resolves on a re-read |
@@ -1014,6 +1014,40 @@ set would flip a settled `exists` back to `created` and make the earlier answer 
 covers all three markers rather than one each, because a fresh repo needs the whole set on day one —
 `graduate trail` dispatches on two of them at once — and three ids means three commands, of which the
 skipped one fails later in exactly the shape this registry exists to prevent.
+
+<a id="roadmap-grammar"></a>**`roadmap-focus` is the one file whose shape is not the skill's
+judgement.** Every other stdin surface is prose a human and the skill settle together; a `ROADMAP.md`
+is read by machine — `triage homes` joins the repo's open milestones to its rows — so a plausible
+draft that does not parse joins nothing. The grammar is stated here, in full, because the drafting
+session must not need a second file open:
+
+- The section headings are exactly `## Arcs` and `## Campaigns`. A section runs to the next `## `
+  heading. Any other spelling — `## Arcs (2026)`, `### Arcs` — is not the section.
+- Each row is `| <name> | #<number> | <state> |`, and it counts **only** when the *second* cell is
+  `#<number>` and the first is non-empty. That is what drops the header row and the `|---|`
+  separator without matching on their text.
+- **The join key is that number, never the title.** An arc named `Geçit` pins a milestone titled
+  `Sözlük — search and discovery`; the two share no substring, so a title cell joins nothing.
+- The `State` column is **not read**. It is for humans; nothing filters on it.
+
+```markdown
+## Arcs
+
+| Arc | Milestone | State |
+|---|---|---|
+| Geçit | #46 | active |
+```
+
+**So the write reports what parsed** — `status bootstrap roadmap-focus` runs the same parser over the
+bytes it just wrote and appends the counts to its notice: `read-back conformed — 3 arcs, 0
+campaigns`, singular at one (`1 arc`). `--json` carries them as the number fields `arcs` and
+`campaigns`. The tab-separated line does not change.
+
+**The count is reported, never enforced.** Zero arcs is still `created` at exit `0`, and the
+read-back predicate stays the byte match this table states — a count is not a second predicate.
+Refusing an unjoinable roadmap belongs to `triage homes`, whose exit `7` already fires at the point
+the rows are actually needed; gating here would block the write a human then has to fix by hand. A
+later reader tempted to "fix" this into a gate is looking at the design, not a gap.
 
 The `gitignore-row` block, fixed here so no clause defers to source. The last line is the row
 itself, and it is also the marker the collision guard and the read-back match on:
@@ -1076,7 +1110,8 @@ same name. Reconciling a hand-made label's colour is a hand fix.
 
 **The operation.** Resolve the id against the registry — not in it is `12`. Probe the target; already
 present is `exists` at `0`. For a stdin surface: read stdin, leak-scan the content (`5`, `6`), write,
-re-read and compare through `normalizeForReadback` (`9` on mismatch). For the [line
+re-read and compare through `normalizeForReadback` (`9` on mismatch), and for `roadmap-focus` parse
+the written bytes and [report the counts](#roadmap-grammar). For the [line
 surface](#line-surface) the probe is the marker rather than the path, the content is the registry's
 own block so no stdin is read and no leak scan is owed, and the read-back asserts the marker **and**
 the prior text. A write whose outcome cannot be
@@ -1116,6 +1151,7 @@ creating several would have to report a partial outcome, and a partial write rep
 | `status bootstrap: appended <marker> to <target> and the read-back differs — the outcome is UNKNOWN.` | 9 | refusal |
 | `status bootstrap: "<v>" is not a buildable surface. Known: design-manifest, roadmap-focus, gitignore-row, label-taxonomy, issue-shape-markers, readout-artifact.` | 12 | refusal |
 | `status bootstrap: created <target> for <surface-id>, read-back conformed.` | 0 | notice |
+| `status bootstrap: created <target> for roadmap-focus, read-back conformed — <n> arc(s), <n> campaign(s).` | 0 | notice |
 | `status bootstrap: appended <marker> to <target> for <surface-id>, read-back conformed.` | 0 | notice |
 
 **Scope** — the single write target named by `<surface-id>`.
@@ -1135,6 +1171,28 @@ bootstrap	created	design-manifest	design-system-manifest.md	ok
 $ fabrika status bootstrap readout-artifact
 bootstrap	created	readout-artifact	acme/storefront#9420	ok
 ```
+
+```
+$ fabrika status bootstrap roadmap-focus <<'EOF'
+# Roadmap
+## Arcs
+| Arc | Milestone | State |
+|---|---|---|
+| Storefront | #12 | active |
+EOF
+bootstrap	created	roadmap-focus	ROADMAP.md	ok
+status bootstrap: created ROADMAP.md for roadmap-focus, read-back conformed — 1 arc, 0 campaigns.
+```
+
+```
+$ fabrika status bootstrap roadmap-focus --json < inert-draft.md
+{"outcome":"created","surfaceId":"roadmap-focus","target":"ROADMAP.md","readback":"ok","arcs":0,"campaigns":0}
+$ echo $?
+0
+```
+
+The second is a draft whose milestone cells carry titles rather than `#<n>`: written, conformed, and
+joining nothing. It exits `0` — the count is the signal, not a gate.
 
 ```
 $ fabrika status bootstrap merge-queue

--- a/packages/fabrika-cli/src/status/bootstrap-verb.ts
+++ b/packages/fabrika-cli/src/status/bootstrap-verb.ts
@@ -32,6 +32,7 @@ import {STATUSES} from "../labels.ts";
 import {normalizeForReadback} from "../report/compose.ts";
 import {isBareAtReference, renderLeaks, scanBody} from "../report/leaks.ts";
 import {AUDIENCES, PRIORITIES, TYPES} from "../triage/facets.ts";
+import {parseRoadmap} from "../triage/roadmap.ts";
 import {answer, FAILED, refuse, type VerbOutcome} from "../verb.ts";
 import {
 	BARE_AT_PATH,
@@ -107,6 +108,38 @@ export const ARTIFACT_BODY = `The durable home for the landed-decision digest. \
 here; \`fabrika status readout\` displays it. This issue stays open and is not worked.`;
 
 /**
+ * What a machine-read file's own parser saw in the bytes just written: a clause for the notice, and
+ * the same numbers as `--json` fields.
+ *
+ * **Reported, never enforced.** The read-back predicate stays the byte match, so a zero-row roadmap
+ * is still `created`. Refusing an unjoinable roadmap is `triage homes`'s exit `7`, at the point the
+ * rows are actually needed.
+ */
+export interface ContentCount {
+	/** The clause appended to the `created` notice, e.g. `3 arcs, 0 campaigns`. */
+	readonly clause: string;
+	/** The same counts, merged into the `--json` object. */
+	readonly fields: Readonly<Record<string, number>>;
+}
+
+const plural = (n: number, noun: string): string => `${n} ${noun}${n === 1 ? "" : "s"}`;
+
+/**
+ * The `roadmap-focus` count: what {@link parseRoadmap} joins out of the roadmap just written.
+ *
+ * A roadmap is the one buildable file whose shape is not the drafting skill's judgement — it is a
+ * grammar `triage homes` joins milestones through — so the write says what parsed rather than
+ * leaving an inert draft to be discovered in some later session (#5778).
+ */
+export const roadmapCount = (text: string): ContentCount => {
+	const {arcs, campaigns} = parseRoadmap(text);
+	return {
+		clause: `${plural(arcs.length, "arc")}, ${plural(campaigns.length, "campaign")}`,
+		fields: {arcs: arcs.length, campaigns: campaigns.length},
+	};
+};
+
+/**
  * A surface carries only the fields its own kind uses, so no caller reads a `defaultPath` off a
  * label surface or a label set off a file.
  */
@@ -116,6 +149,11 @@ export type BuildableSurface =
 			readonly kind: "file";
 			/** The registry default write path. */
 			readonly defaultPath: string;
+			/**
+			 * Present only where the content is machine-read. Absent leaves the notice and the `--json`
+			 * object exactly as they were, which is what keeps the other surfaces byte-identical.
+			 */
+			readonly count?: (text: string) => ContentCount;
 	  }
 	| {
 			readonly id: string;
@@ -140,7 +178,7 @@ ${FABRIKA_IGNORE_ROW}`;
 /** Six ids. A seventh is a change to this table, not a new rule. */
 export const BUILDABLE_SURFACES: ReadonlyArray<BuildableSurface> = [
 	{id: "design-manifest", kind: "file", defaultPath: "design-system-manifest.md"},
-	{id: "roadmap-focus", kind: "file", defaultPath: "ROADMAP.md"},
+	{id: "roadmap-focus", kind: "file", defaultPath: "ROADMAP.md", count: roadmapCount},
 	{
 		id: "gitignore-row",
 		kind: "line",
@@ -170,9 +208,15 @@ export interface BootstrapInput {
 
 type Requirements = FileSystem.FileSystem | Path.Path | ChildProcessSpawner.ChildProcessSpawner;
 
-const created = (surfaceId: string, target: string, json: boolean, notice: string): VerbOutcome => {
+const created = (
+	surfaceId: string,
+	target: string,
+	json: boolean,
+	notice: string,
+	fields?: Readonly<Record<string, number>>,
+): VerbOutcome => {
 	const stdout = json
-		? `${JSON.stringify({outcome: "created", surfaceId, target, readback: "ok"})}\n`
+		? `${JSON.stringify({outcome: "created", surfaceId, target, readback: "ok", ...fields})}\n`
 		: `${row("bootstrap", "created", surfaceId, target, "ok")}\n`;
 	return answer(stdout, [notice]);
 };
@@ -287,11 +331,13 @@ const buildFile = (
 				`${VERB}: wrote ${relative} and the read-back differs — the outcome is UNKNOWN.`,
 			);
 		}
+		const count = surface.count?.(content);
 		return created(
 			surface.id,
 			relative,
 			input.json,
-			`${VERB}: created ${relative} for ${surface.id}, read-back conformed.`,
+			`${VERB}: created ${relative} for ${surface.id}, read-back conformed${count === undefined ? "" : ` — ${count.clause}`}.`,
+			count?.fields,
 		);
 	});
 

--- a/packages/fabrika-cli/src/status/verbs.unit.test.ts
+++ b/packages/fabrika-cli/src/status/verbs.unit.test.ts
@@ -34,6 +34,7 @@ import {
 	ISSUE_SHAPE_MARKERS,
 	knownIds,
 	MARKER_COLOR,
+	roadmapCount,
 	runBootstrap,
 	TAXONOMY,
 } from "./bootstrap-verb.ts";
@@ -525,6 +526,99 @@ describe("the .fabrika/ gitignore row", () => {
 		);
 		expect(outcome.code).toBe(PRECONDITION_UNKNOWN);
 		expect(fs.written.size).toBe(0);
+	});
+});
+
+/**
+ * #5778: `roadmap-focus` writes a machine-read file — `triage homes` joins milestones through its
+ * `#<n>` cells — and a byte-match read-back reads the same over a roadmap that parses to nothing.
+ * The counts make an inert draft visible at the moment it is written; they gate nothing, and the
+ * other file surface's bytes do not move.
+ */
+describe("the roadmap-focus row count", () => {
+	const write = (content: string, surfaceId = "roadmap-focus") => {
+		const fs = fakeFs({files: {}});
+		return Effect.runPromise(
+			Effect.provide(
+				runBootstrap({
+					surfaceId,
+					path: null,
+					json: true,
+					repoRoot: "/repo",
+					repo: ok("o/r"),
+					stdin: Effect.succeed({_tag: "Text", text: content} as StdinRead),
+				}),
+				Layer.mergeAll(fs.layer, fakeShell([]).layer),
+			),
+		);
+	};
+
+	const PARSING = [
+		"# Roadmap",
+		"",
+		"## Arcs",
+		"",
+		"| Arc | Milestone | State |",
+		"|---|---|---|",
+		"| Geçit | #46 | active |",
+		"| Sözlük | #47 | next |",
+		"",
+		"## Campaigns",
+		"",
+		"| Campaign | Milestone | State |",
+		"|---|---|---|",
+		"| fabrika everywhere | #48 | active |",
+		"",
+	].join("\n");
+
+	// What drafting by inference produces: the milestone's TITLE where the parser wants `#<n>`.
+	const INERT = [
+		"# Roadmap",
+		"",
+		"## Arcs",
+		"",
+		"| Arc | Milestone | State |",
+		"|---|---|---|",
+		"| Geçit | Sözlük — search and discovery | active |",
+		"",
+	].join("\n");
+
+	it("reports what parsed, and a roadmap that parses to nothing is still created", async () => {
+		const outcome = await write(INERT);
+		expect(outcome.code).toBe(ANSWER);
+		expect(JSON.parse(outcome.stdout)).toEqual({
+			outcome: "created",
+			surfaceId: "roadmap-focus",
+			target: "ROADMAP.md",
+			readback: "ok",
+			arcs: 0,
+			campaigns: 0,
+		});
+		expect(outcome.stderr).toEqual([
+			"status bootstrap: created ROADMAP.md for roadmap-focus, read-back conformed — 0 arcs, 0 campaigns.",
+		]);
+	});
+
+	it("counts the rows a parsing roadmap joins, singular at one", async () => {
+		const outcome = await write(PARSING);
+		expect(JSON.parse(outcome.stdout)).toMatchObject({arcs: 2, campaigns: 1});
+		expect(outcome.stderr).toEqual([
+			"status bootstrap: created ROADMAP.md for roadmap-focus, read-back conformed — 2 arcs, 1 campaign.",
+		]);
+		expect(roadmapCount(PARSING).clause).toBe("2 arcs, 1 campaign");
+	});
+
+	it("leaves the other file surface's bytes and notice exactly as they were", async () => {
+		const outcome = await write("# Design system manifest\n", "design-manifest");
+		expect(JSON.parse(outcome.stdout)).toEqual({
+			outcome: "created",
+			surfaceId: "design-manifest",
+			target: "design-system-manifest.md",
+			readback: "ok",
+		});
+		expect(outcome.stderr).toEqual([
+			"status bootstrap: created design-system-manifest.md for design-manifest, read-back conformed.",
+		]);
 	});
 });
 


### PR DESCRIPTION
`ROADMAP.md` is the one file `status bootstrap` writes whose shape is not the drafting session's
judgement: `triage homes` joins open milestones to its `## Arcs` / `## Campaigns` rows by the
`#<number>` in each row's **second** cell. That grammar was written down only in the *consuming*
verb's contract, and the front door tells the session to draft by inference from what the repo
already has — which for this file produces a plausible page with a milestone title where the parser
wants `#<n>`. The read-back is a byte match, so it says `conformed` over a roadmap that joins nothing.

Two halves:

- **The grammar now lives at the drafting site.** `front-door/contract.md`'s `status bootstrap`
  section states the exact headings, the row shape, that the join key is the number and never the
  title, and that `State` is not read — in full, so no second file has to be open.
  `front-door/SKILL.md`'s bootstrap step names `roadmap-focus` as the exception to "draft by
  inference": the content is still the session's, the shape is not.
- **The write reports what parsed.** `status bootstrap roadmap-focus` runs `parseRoadmap` over the
  bytes it just wrote and appends the counts to its notice — `read-back conformed — 1 arc, 0
  campaigns` — with `arcs` and `campaigns` as `--json` fields. Reported, never enforced: 0 arcs is
  still `created` at exit `0`, the read-back predicate stays the byte match, and refusing an
  unjoinable roadmap remains `triage homes`'s exit `7`. The contract says so, so a later reader does
  not "fix" it into a gate.

Carried on the registry as an optional `count` on the file surface, so the other four surfaces'
stdout, notices and exit codes do not move — a test asserts `design-manifest`'s JSON and notice are
exactly what they were.

Reviewer: start at the `roadmap-grammar` anchor in `front-door/contract.md` and check it against
`packages/fabrika-cli/src/triage/roadmap.ts` — the grammar is restated there rather than pointed at,
so drift between the two is the risk this change takes on.

Fixes #5778

## Deviations

None.
