### PR TITLE
feat: The build skill's type:decision refusal has no arm for a ruling already on the board

### DIFF
--- a/.decisions/0300-a-cited-ruling-makes-a-decision-buildable.md
+++ b/.decisions/0300-a-cited-ruling-makes-a-decision-buildable.md
@@ -51,16 +51,23 @@ whether the question is settled.
   no verb serves free body prose, so a URL that lives only there is readable by no gate.
 - The builder transcribes only what the ruling says. Filling a gap the ruling left open is deciding,
   and it goes back to the founder.
+- Triage routes a decision issue carrying such a comment to `ready-for:agent`; every other decision
+  issue keeps the `ready-for:human` default. That stamp is what makes the arm reachable — the
+  audience axis is a separate fence and the citation does not lift it.
 - `build pick`'s type exclusion is unchanged: this route is entered by number, never picked.
 
 ## Consequences
 
 A ruled decision now costs one agent lane instead of one founder round-trip, which is the whole
-point — the ruling was already the expensive part.
+point — the ruling was already the expensive part. That saving needs both halves of the path, so
+both are written here: `triage` routes a decision carrying a ruling comment to `ready-for:agent`
+instead of the `human` default, and `build`'s refusal opens on the citation. With only the second
+half the arm is unreachable, because `build claim`'s audience axis refuses a `ready-for:human` issue
+at exit `21` and the builder may not override that on its own authority.
 
 The cost is that the fence is prose the builder reads, not a check anything runs. `build claim`'s
-audience axis already admits a `type:decision` issue that triage stamped `ready-for:agent`, so the
-refusal and its arm both live in the skill.
+audience axis reads the label it finds and infers nothing from the type, so the refusal and its arm
+both live in the skills.
 
 **Nothing catches an uncited transcription today.** Putting the URL in the artifact means a reviewer
 who opens the diff can see it, because the diff is served by a verb — but no gate looks for it, and

--- a/.decisions/0300-a-cited-ruling-makes-a-decision-buildable.md
+++ b/.decisions/0300-a-cited-ruling-makes-a-decision-buildable.md
@@ -45,8 +45,10 @@ whether the question is settled.
   claim is refused exactly as it was before this ADR.
 - The builder cites a comment. "This looks settled", "the thread converged", or a ruling inferred
   from anything other than a comment recording it is not a citation.
-- The builder records the cited comment's URL in the PR body, so the ruling it transcribed is
-  readable off the merge record.
+- The builder records the cited comment's URL **inside the artifact it writes** — the ADR or
+  amendment names the ruling it transcribes — so the citation lands in the diff, where `review diff`
+  serves it. It goes in the PR body too, for the merge record, but the body is not where it counts:
+  no verb serves free body prose, so a URL that lives only there is readable by no gate.
 - The builder transcribes only what the ruling says. Filling a gap the ruling left open is deciding,
   and it goes back to the founder.
 - `build pick`'s type exclusion is unchanged: this route is entered by number, never picked.
@@ -56,11 +58,16 @@ whether the question is settled.
 A ruled decision now costs one agent lane instead of one founder round-trip, which is the whole
 point — the ruling was already the expensive part.
 
-The cost is that the fence is prose the builder reads, not a check the CLI runs. `build claim`'s
+The cost is that the fence is prose the builder reads, not a check anything runs. `build claim`'s
 audience axis already admits a `type:decision` issue that triage stamped `ready-for:agent`, so the
-refusal and its arm both live in the skill. A builder that transcribes without a citation is caught
-at review, not at claim time. Mechanizing the citation check is a separate question and a separate
-ticket; nobody has asked for it yet, and the review gate reads the PR body where the URL lands.
+refusal and its arm both live in the skill.
+
+**Nothing catches an uncited transcription today.** Putting the URL in the artifact means a reviewer
+who opens the diff can see it, because the diff is served by a verb — but no gate looks for it, and
+none knows a given PR is a transcription that owes one. So the fence is the builder's discipline plus
+a human reading the record, and the honest cost of this ADR is that a builder who skips the citation
+ships. Mechanizing the check is a separate question and a separate ticket; nobody has asked for it
+yet.
 
 ## Records
 

--- a/.decisions/0300-a-cited-ruling-makes-a-decision-buildable.md
+++ b/.decisions/0300-a-cited-ruling-makes-a-decision-buildable.md
@@ -1,0 +1,67 @@
+---
+id: 0300
+title: A recorded founder ruling makes a decision issue buildable as transcription, never as judgement
+status: accepted
+date: 2026-08-19
+tags: [fabrika, pipeline, decisions, agents]
+---
+
+# 0300 — A recorded founder ruling makes a decision issue buildable as transcription, never as judgement
+
+**What this decides:** Once a founder has written the ruling down on the issue, an agent may pick
+that decision issue up and write the ruling into the ADR or skill amendment it names. It may not
+decide anything itself: it points at the comment carrying the ruling, or it refuses.
+
+## Context
+
+The `build` skill refused every `type:decision` issue outright — the deliverable is a recorded
+choice, and choosing is human work. That refusal was written as an absolute, so it also caught the
+case where the choosing had already happened. On 2026-08-18 it bit twice in one day:
+[#5909](https://github.com/kamp-us/phoenix/issues/5909) and
+[#5879](https://github.com/kamp-us/phoenix/issues/5879) both carried a founder ruling recorded as an
+issue comment, and both parked as builder-refused with nothing left to do but copy the ruling into a
+file. Every settled decision was costing a founder round-trip to transcribe.
+
+The founder ruled on that on
+[#5879, comment 5335398768](https://github.com/kamp-us/phoenix/issues/5879#issuecomment-5335398768)
+(option 2). This ADR records that ruling.
+
+The pool exclusion is a different fence and stays: `build pick` never offers a `type:decision` issue,
+because a blind pick has nothing to cite. A cited-ruling decision issue is entered by number.
+
+## Decision
+
+**A `type:decision` issue is claimable by an agent when, and only when, the build can cite a founder
+ruling comment recorded on that issue; the deliverable is transcribing that ruling into the ADR or
+amendment it names.**
+
+The citation is the fence, and it is what keeps deciding human-only. The comment exists on the board
+before the claim, written by a human, and the builder's whole judgement is reading it — not deciding
+whether the question is settled.
+
+**Binding constraints.**
+
+- The refusal is the default branch. With no citable ruling comment on the issue, a `type:decision`
+  claim is refused exactly as it was before this ADR.
+- The builder cites a comment. "This looks settled", "the thread converged", or a ruling inferred
+  from anything other than a comment recording it is not a citation.
+- The builder records the cited comment's URL in the PR body, so the ruling it transcribed is
+  readable off the merge record.
+- The builder transcribes only what the ruling says. Filling a gap the ruling left open is deciding,
+  and it goes back to the founder.
+- `build pick`'s type exclusion is unchanged: this route is entered by number, never picked.
+
+## Consequences
+
+A ruled decision now costs one agent lane instead of one founder round-trip, which is the whole
+point — the ruling was already the expensive part.
+
+The cost is that the fence is prose the builder reads, not a check the CLI runs. `build claim`'s
+audience axis already admits a `type:decision` issue that triage stamped `ready-for:agent`, so the
+refusal and its arm both live in the skill. A builder that transcribes without a citation is caught
+at review, not at claim time. Mechanizing the citation check is a separate question and a separate
+ticket; nobody has asked for it yet, and the review gate reads the PR body where the URL lands.
+
+## Records
+
+no vocabulary impact

--- a/claude-plugins/fabrika/skills/build/SKILL.md
+++ b/claude-plugins/fabrika/skills/build/SKILL.md
@@ -60,8 +60,11 @@ Two refusals before claiming: a `type:decision`'s deliverable is a recorded choi
 (`build-ui`'s) — **do not claim either**. The decision refusal has one arm, and a citation is the only
 thing that opens it: when the issue carries a founder ruling comment that already made the choice,
 the deciding is done and the writing is all that is left, so claim it and transcribe — turn that
-ruling into the ADR or amendment it names, nothing more, and record the comment's URL in the PR body
-as the ruling you transcribed (ADR [0300](../../../../.decisions/0300-a-cited-ruling-makes-a-decision-buildable.md)).
+ruling into the ADR or amendment it names, nothing more. **The citation goes inside the artifact you
+write** — the ADR or amendment names the ruling comment's URL in its own text, so it lands in the
+diff, which is a surface `review diff` serves; free prose in the PR body is read by no verb, so a URL
+that lives only there is invisible to every gate. Name it in the PR body as well, for the merge
+record (ADR [0300](../../../../.decisions/0300-a-cited-ruling-makes-a-decision-buildable.md)).
 **With no citable ruling comment the refusal stands exactly as it reads above.** You never judge a
 decision settled yourself: "this looks settled" is not a citation, a converged thread is not a
 citation, and a gap the ruling left open goes back to the founder rather than getting filled here.

--- a/claude-plugins/fabrika/skills/build/SKILL.md
+++ b/claude-plugins/fabrika/skills/build/SKILL.md
@@ -57,7 +57,15 @@ against. `focus` says whether a focus is declared at all — an inert fence is a
 shorter pool to explain.
 Two refusals before claiming: a `type:decision`'s deliverable is a recorded choice
 (`/adr`'s, not yours), and a rendered-visual deliverable is outside this skill's modality
-(`build-ui`'s) — **do not claim either**. This skill is not a router: on its own text surfaces
+(`build-ui`'s) — **do not claim either**. The decision refusal has one arm, and a citation is the only
+thing that opens it: when the issue carries a founder ruling comment that already made the choice,
+the deciding is done and the writing is all that is left, so claim it and transcribe — turn that
+ruling into the ADR or amendment it names, nothing more, and record the comment's URL in the PR body
+as the ruling you transcribed (ADR [0300](../../../../.decisions/0300-a-cited-ruling-makes-a-decision-buildable.md)).
+**With no citable ruling comment the refusal stands exactly as it reads above.** You never judge a
+decision settled yourself: "this looks settled" is not a citation, a converged thread is not a
+citation, and a gap the ruling left open goes back to the founder rather than getting filled here.
+This skill is not a router: on its own text surfaces
 it executes the whole loop itself. In pick mode neither the argument nor your caller gave you a
 number, so the one `pick` returned stands in its place everywhere below. Then gate your choice:
 
@@ -274,11 +282,12 @@ fabrika build claim $issue_or_pr_number
 fabrika build verdicts --pr $issue_or_pr_number
 ```
 
-**Step 1's "never claim a `type:decision`" is about picking one up fresh, and it does not reach
-here.** An ADR PR is served by a decision issue, and repairing it is the ordinary path: the claim
-admits it with no flag and no `--override`, and says so on its purpose line (#5914). Everything else
-still refuses — the same decision issue claimed by its own number is `21`, and the scope fence binds
-this claim exactly as it binds a build.
+**Step 1's refusal of a `type:decision` is about picking one up fresh, and it does not reach here.**
+An ADR PR is served by a decision issue, and repairing it is the ordinary path: the claim admits it
+with no flag and no `--override`, and says so on its purpose line (#5914) — no citation needed, since
+the PR being in flight is already the proof a ruling was transcribed. Everything else still refuses —
+the same decision issue claimed by its own number reads its own audience label and is `21` on a
+`ready-for:human`, and the scope fence binds this claim exactly as it binds a build.
 
 The fold is the only entry: paginated, current-head, per-gate — polarity visible, round count
 included. Act only on rows it prints; empty rows at exit 0 are a proven no-work answer, but an

--- a/claude-plugins/fabrika/skills/build/SKILL.md
+++ b/claude-plugins/fabrika/skills/build/SKILL.md
@@ -68,6 +68,12 @@ record (ADR [0300](../../../../.decisions/0300-a-cited-ruling-makes-a-decision-b
 **With no citable ruling comment the refusal stands exactly as it reads above.** You never judge a
 decision settled yourself: "this looks settled" is not a citation, a converged thread is not a
 citation, and a gap the ruling left open goes back to the founder rather than getting filled here.
+**The arm opens this refusal and nothing else** — the audience fence at step 2 is a separate gate the
+citation does not lift, so the issue still has to carry `ready-for:agent`, which triage stamps on a
+ruled decision issue — its [`--ready-for` routing](../triage/SKILL.md) owns that call, not this
+skill. On `ready-for:human` the claim is exit `21` and
+step 2's rule holds unchanged: end the run naming the code and say the issue needs re-stamping by
+triage — never override on your own authority, however good the citation.
 This skill is not a router: on its own text surfaces
 it executes the whole loop itself. In pick mode neither the argument nor your caller gave you a
 number, so the one `pick` returned stands in its place everywhere below. Then gate your choice:

--- a/claude-plugins/fabrika/skills/build/contract.md
+++ b/claude-plugins/fabrika/skills/build/contract.md
@@ -741,13 +741,15 @@ founder-authorized escape hatch on routine repair. That default is not an exclus
 issue carrying a founder ruling comment is buildable as transcription (ADR
 [0300](../../../../.decisions/0300-a-cited-ruling-makes-a-decision-buildable.md)), which is why the
 exemption is read off the target rather than off the impossibility of the pairing. This axis reads
-the `ready-for:` label the issue carries and never infers one from the type, so which decision issues
-end up carrying `ready-for:agent` is triage's judgement, not a behaviour this verb assumes.
+the `ready-for:` label the issue carries and never infers one from the type, in either direction;
+which decision issues end up carrying `ready-for:agent` is decided by triage's `--ready-for` routing
+([`triage/SKILL.md`](../triage/SKILL.md)), not by anything this verb assumes.
 The exemption is read off the **target**, not typed: there is no `--purpose repair`, because a flag
 could be passed against a bare issue and would then have to be refused, while naming a PR is already
 proof that a build is in flight. Its width is exactly one pairing — the same decision issue claimed
 directly still reads its own audience label and is `21` on a `ready-for:human`, an open PR serving
-any other type still reads the audience label, and the scope axis is untouched. `claim`'s purpose line names the exemption when it fires.
+any other type still reads the audience label, and the scope axis is untouched. `claim`'s purpose
+line names the exemption when it fires.
 
 This is the seam where the refusal has teeth. A pool filter is bypassed by an operator naming a
 number, and a number handed straight to `claim` passes through no pool — claiming is the moment work

--- a/claude-plugins/fabrika/skills/build/contract.md
+++ b/claude-plugins/fabrika/skills/build/contract.md
@@ -415,8 +415,12 @@ The filter, fail-closed on every axis:
 - **unassigned.** Any assignee excludes — assignment is the one attribute that keeps a human's
   document out of this pool (#4764, #4693).
 - `type:` is one of `feature` / `chore` / `bug` / `investigation`. `type:decision` and `type:epic`
-  never enter; a rendered-visual deliverable is excluded by the *skill* at reading time, not by
-  this verb, because modality is not a label.
+  never enter *this pool*, which is narrower than never being built: a decision issue carrying a
+  founder ruling comment is buildable as transcription and is entered by number at `build claim`
+  (ADR [0300](../../../../.decisions/0300-a-cited-ruling-makes-a-decision-buildable.md)), never
+  picked — a blind pick has no ruling to cite, which is why the exclusion here stands. A
+  rendered-visual deliverable is excluded by the *skill* at reading time, not by this verb, because
+  modality is not a label.
 - **a body carrying an acceptance-criteria block the wire reader answers `Found` on.** A candidate
   with no contract can only fail at `review criteria`, once a branch, a build, a push, a PR and a CI
   run are already spent, and neither the builder nor the reviewer can repair it — so the pool
@@ -731,14 +735,18 @@ it saw either way, so a claim admitted over a non-agent audience is readable as 
 **Repair of a decision PR is admitted on its own, with no flag and no override.** When `<number>` is
 an open PR and the issue it serves carries `type:decision`, the audience axis does not bind that
 claim (founder ruling on [#5866](https://github.com/kamp-us/phoenix/issues/5866), built as #5914).
-Triage routes a decision to `ready-for:human`, so `type:decision` and `ready-for:agent` are mutually
-exclusive by construction and an ADR PR's repair lane was failing a fence it could never pass — the
-only way through was `--override`, which spent a founder-authorized escape hatch on routine repair.
+Triage routes a decision to `ready-for:human` by default, so an ADR PR's repair lane was failing a
+fence it could normally never pass — the only way through was `--override`, which spent a
+founder-authorized escape hatch on routine repair. That default is not an exclusion: a decision
+issue carrying a founder ruling comment is buildable as transcription and triage stamps it
+`ready-for:agent` (ADR
+[0300](../../../../.decisions/0300-a-cited-ruling-makes-a-decision-buildable.md)), which is why the
+exemption is read off the target rather than off the impossibility of the pairing.
 The exemption is read off the **target**, not typed: there is no `--purpose repair`, because a flag
 could be passed against a bare issue and would then have to be refused, while naming a PR is already
 proof that a build is in flight. Its width is exactly one pairing — the same decision issue claimed
-directly is still `21`, an open PR serving any other type still reads the audience label, and the
-scope axis is untouched. `claim`'s purpose line names the exemption when it fires.
+directly still reads its own audience label and is `21` on a `ready-for:human`, an open PR serving
+any other type still reads the audience label, and the scope axis is untouched. `claim`'s purpose line names the exemption when it fires.
 
 This is the seam where the refusal has teeth. A pool filter is bypassed by an operator naming a
 number, and a number handed straight to `claim` passes through no pool — claiming is the moment work

--- a/claude-plugins/fabrika/skills/build/contract.md
+++ b/claude-plugins/fabrika/skills/build/contract.md
@@ -738,10 +738,11 @@ claim (founder ruling on [#5866](https://github.com/kamp-us/phoenix/issues/5866)
 Triage routes a decision to `ready-for:human` by default, so an ADR PR's repair lane was failing a
 fence it could normally never pass — the only way through was `--override`, which spent a
 founder-authorized escape hatch on routine repair. That default is not an exclusion: a decision
-issue carrying a founder ruling comment is buildable as transcription and triage stamps it
-`ready-for:agent` (ADR
+issue carrying a founder ruling comment is buildable as transcription (ADR
 [0300](../../../../.decisions/0300-a-cited-ruling-makes-a-decision-buildable.md)), which is why the
-exemption is read off the target rather than off the impossibility of the pairing.
+exemption is read off the target rather than off the impossibility of the pairing. This axis reads
+the `ready-for:` label the issue carries and never infers one from the type, so which decision issues
+end up carrying `ready-for:agent` is triage's judgement, not a behaviour this verb assumes.
 The exemption is read off the **target**, not typed: there is no `--purpose repair`, because a flag
 could be passed against a bare issue and would then have to be refused, while naming a PR is already
 proof that a build is in flight. Its width is exactly one pairing — the same decision issue claimed

--- a/claude-plugins/fabrika/skills/triage/SKILL.md
+++ b/claude-plugins/fabrika/skills/triage/SKILL.md
@@ -189,6 +189,15 @@ execute cold; to `human` when the deliverable is a judgment — a `type:decision
 anything resting on a product call nobody has made. Get it wrong and a document written for a human
 lands in a builder's candidate pool.
 
+**A `type:decision` goes to `agent` when the choice is already recorded on it.** Send it there when
+the issue carries a founder ruling comment that made the call: the deliverable is then transcription
+— write that ruling into the ADR or amendment it names — and transcription executes cold (ADR
+[0300](../../../../.decisions/0300-a-cited-ruling-makes-a-decision-buildable.md)). This is the stamp
+`build`'s citation arm reads; without it the arm is unreachable and the ruling costs another human
+round-trip. No such comment, and the default above stands: `human`. You cite the comment rather than
+judging the question settled yourself, and a ruling that left a gap open is still a judgment, so it
+stays `human`.
+
 **`--ready-for agent` requires a criteria block on every type but `epic`.** The verb reads the live
 body through the same wire reader every grader downstream reads, and refuses on `16` — writing no
 label — when the block is absent or malformed: that label promises a builder can pick the issue up

--- a/packages/fabrika-cli/src/build/claim-verb.ts
+++ b/packages/fabrika-cli/src/build/claim-verb.ts
@@ -39,8 +39,11 @@
  * handed straight to `claim` passes through no pool — which is why the refusal has teeth here and is
  * advice at the pool. In repair the number is a **PR**, which carries no home and no audience of its
  * own, so the test runs over the issue that PR serves (#5562) — and when that issue is
- * `type:decision` the audience axis does not bind, because triage bars a decision from
- * `ready-for:agent` and the fence could otherwise never be satisfied (#5914).
+ * `type:decision` the audience axis does not bind, because triage routes a decision to
+ * `ready-for:human` by default and a repair lane would otherwise fail a fence it had no way to
+ * satisfy (#5914). The default is not an exclusion — a decision issue carrying a founder ruling
+ * comment is buildable as transcription (ADR 0300) — so the exemption is read off the target being
+ * a PR, never off the pairing being impossible.
  */
 import {Effect, type FileSystem} from "effect";
 import type {ChildProcessSpawner} from "effect/unstable/process";

--- a/packages/fabrika-cli/src/build/scope-admission.ts
+++ b/packages/fabrika-cli/src/build/scope-admission.ts
@@ -50,8 +50,9 @@ const READY_FOR_PREFIX = "ready-for:";
  * Triage routes such an issue to `ready-for:human` by default, which is the collision
  * {@link RepairClaim} answers: an ADR PR's repair lane would otherwise fail a fence it could not
  * pass. The default is not an exclusion — a decision issue carrying a founder ruling comment is
- * buildable as transcription and is stamped `ready-for:agent` (ADR 0300), so this axis reads the
- * audience label it finds and never infers one from the type.
+ * buildable as transcription, and triage may route that one to `ready-for:agent` instead (ADR 0300).
+ * Which ones it does is triage's per-issue judgement; this axis reads the audience label it finds
+ * and never infers one from the type, in either direction.
  */
 export const DECISION_TYPE_LABEL = "type:decision";
 
@@ -277,10 +278,11 @@ export const repairClaimOf = (pr: number, served: IssueFacts): RepairClaim =>
  * Only a build-purpose claim is bound by the audience axis (#5175), and not even that one when it
  * repairs an open PR whose served issue is a decision. Scope binds every purpose and every repair.
  *
- * The exemption is narrow on purpose: it is the one pairing where the fence can never be satisfied,
- * because a decision issue is barred from `ready-for:agent` by triage's own routing. An ordinary
- * repair still reads the audience label, so an issue re-routed to a human mid-flight still stops a
- * builder — the founder's ruling exempts decisions, not repair at large.
+ * The exemption is narrow on purpose, and it is read off the target being a PR rather than off the
+ * pairing being impossible: triage routes a decision to `ready-for:human` by default, so an ADR PR's
+ * repair lane would otherwise stall on a label nobody changes mid-flight. An ordinary repair still
+ * reads the audience label, so an issue re-routed to a human mid-flight still stops a builder — the
+ * founder's ruling exempts decisions, not repair at large.
  */
 export const audienceAxisBinds = (
 	purpose: ClaimPurpose,

--- a/packages/fabrika-cli/src/build/scope-admission.ts
+++ b/packages/fabrika-cli/src/build/scope-admission.ts
@@ -47,8 +47,11 @@ const READY_FOR_PREFIX = "ready-for:";
 /**
  * The type whose deliverable is a recorded choice rather than a pull request — `/adr`'s lane.
  *
- * Triage routes such an issue to `ready-for:human`, so `type:decision` and `ready-for:agent` are
- * mutually exclusive by construction. That is the collision {@link RepairClaim} answers.
+ * Triage routes such an issue to `ready-for:human` by default, which is the collision
+ * {@link RepairClaim} answers: an ADR PR's repair lane would otherwise fail a fence it could not
+ * pass. The default is not an exclusion — a decision issue carrying a founder ruling comment is
+ * buildable as transcription and is stamped `ready-for:agent` (ADR 0300), so this axis reads the
+ * audience label it finds and never infers one from the type.
  */
 export const DECISION_TYPE_LABEL = "type:decision";
 


### PR DESCRIPTION
The `build` skill refused every decision-typed issue outright. That refusal was an absolute, so it
also caught the case where the founder had already made the choice and written it on the issue —
leaving nothing to do but copy it into a file. It bit twice on 2026-08-18 (#5909, #5879). The founder
ruled on #5879, [comment 5335398768](https://github.com/kamp-us/phoenix/issues/5879#issuecomment-5335398768):
a decision issue whose ruling is recorded on the board is agent-buildable as transcription, gated on
the builder citing that comment. That comment is the ruling this PR transcribes. This is its
mechanical half.

**What changed**

- `claude-plugins/fabrika/skills/build/SKILL.md` — the "Two refusals before claiming" text gains one
  arm, written refusal-first: with no citable ruling comment the refusal reads exactly as before, and
  the builder cites a comment rather than judging a decision settled itself. It names what the PR
  must carry: the ruling comment's URL. The arm also names its own precondition — it opens the type
  refusal only, so the issue still has to carry `ready-for:agent`, and on `ready-for:human` the claim
  is exit `21` and the builder reports back instead of overriding.
- `claude-plugins/fabrika/skills/triage/SKILL.md` — the `--ready-for` routing gains the matching arm,
  so the stamp the build arm needs actually exists: a decision issue carrying a ruling comment routes
  to `agent` because its deliverable is transcription; every other decision issue keeps the `human`
  default. Without this half the build arm is unreachable and the ruling still costs a human
  round-trip.
- `.decisions/0300-a-cited-ruling-makes-a-decision-buildable.md` — a new ADR recording the ruling,
  citing #5879's comment 5335398768 as the ruling of record. It carries the triage half as a binding
  constraint and says plainly that the saving needs both halves.
- `claude-plugins/fabrika/skills/build/contract.md`, and the `DECISION_TYPE_LABEL` and
  `audienceAxisBinds` docblocks in `packages/fabrika-cli/src/build/scope-admission.ts` plus the
  module docblock in `packages/fabrika-cli/src/build/claim-verb.ts` — these asserted that a decision
  label and `ready-for:agent` are mutually exclusive by construction, which the ruling makes false.
  Each is narrowed to what is still true: triage routes a decision to `ready-for:human` *by default*,
  the pool exclusion is about the pool rather than about buildability, the repair exemption is read
  off the target being a PR rather than off the pairing being impossible, and the audience axis reads
  the label it finds and infers nothing from the type in either direction. Where the axis's own
  behaviour needed triage's routing named, it cites `triage/SKILL.md` rather than paraphrasing it.
- The SKILL.md repair passage said a decision issue claimed by its own number is always `21`; it now
  says it reads its own audience label.

**No CLI behaviour change.** `build pick`'s type exclusion stays (a blind pick has no ruling to
cite — a cited-ruling issue is entered by number) and `scope-admission`'s audience axis is untouched.
Every source edit in this PR is a docblock: `scope-admission.ts` (two) and `claim-verb.ts` (one). No
executable line changes. The fence lives in skill prose, which is where the old refusal lived too.

`pnpm typecheck` and `pnpm lint:worktree` pass in this tree; `build check` is green on both
`--surface prose` and `--surface code`.

Fixes #6187

## Deviations

- **Out-of-scope change** — **Said:** #6187 scopes the amendment to `build`'s refusal, its contract,
  and the `scope-admission.ts` docblock. **Did:** also amended `claude-plugins/fabrika/skills/triage/SKILL.md`'s
  `--ready-for` routing. **Why:** criterion 12 offers this as one of its two remedies, and it is the
  only one that makes the arm reachable rather than documenting that it is not — without the triage
  stamp, `build claim` refuses a ruled decision issue at exit `21` and ADR 0300 is inert.
  **Disposition:** stated here, and the criterion names it as an accepted resolution.
