### PR TITLE
chore: Three fabrika doc surfaces still describe the bare fabrika invocation after the fence form moved

### DIFF
--- a/claude-plugins/fabrika/skills/report/contract.md
+++ b/claude-plugins/fabrika/skills/report/contract.md
@@ -14,17 +14,16 @@ below is implemented from scratch here. v1's tools were read for their semantics
 each Grounding section names what the corresponding v1 tool gets wrong and what this spec does
 instead — but no clause defers to one, and none is invoked.
 
-**How the bare binary name resolves is an open blocker, not an assumption this spec makes.** The
-skill's fences invoke `fabrika` as a plain literal name, which is what the harness's isolation
-verifier requires — that check is *syntactic*, on the command string. Whether the name then
-**resolves** is a separate question this spec does not answer, and the repo's own evidence says the
-analogous v1 shape does not: `packages/pipeline-cli/src/tools/cli-invocation-guard/cli-invocation-guard.ts`
-records that a bare `pipeline-cli <verb>` "is not on PATH where pipeline agents spawn and never will
-be (ADR 0207 retired PATH-shadowing), so it dies `command not found`." Until
-[#4650](https://github.com/kamp-us/phoenix/issues/4650) lands a resolution mechanism, **every fence
-in this skill exits 127**, and 127 means the verb never ran — never a verdict. Stated here so it is
-a tracked blocker rather than a surprise, and so an eval run cannot quietly grade "the verb is not
-available yet" as though it were the skill's own behaviour.
+**The bare binary name resolves, and this spec assumes it.** The skill's fences invoke `fabrika` as
+a plain literal name, which is what the harness's isolation verifier requires — that check is
+*syntactic*, on the command string. The name then resolves through the delivery
+[`packages/fabrika-cli/README.md`](../../../../packages/fabrika-cli/README.md) documents under
+*How it is delivered*: one global install whose binary finds the repo root above the working
+directory, asks Node's resolver what copy that root installed, and hands the invocation to it —
+including from a git worktree, which resolves to that worktree's own copy.
+[#4650](https://github.com/kamp-us/phoenix/issues/4650) landed that mechanism. What an eval run
+still must not do is grade "the verb is not available yet" as though it were the skill's own
+behaviour: an exit 127 means the verb never ran, so it is a broken install to fix, never a verdict.
 
 **One skill named `report` already exists** at `claude-plugins/kampus-pipeline/skills/report/`, and
 it is model-invoked with an overlapping trigger list. This paragraph used to say the collision was


### PR DESCRIPTION
`claude-plugins/fabrika/skills/report/contract.md` opened by calling bare-name resolution an open
blocker and stating that every fence in the skill exits 127. Neither is true: #4650 landed the
resolution mechanism, and `packages/fabrika-cli/README.md` (*How it is delivered*) documents the
shipped delegation — including the worktree row from #5679/#5707. A reader picking the skill up cold
got its fences from `SKILL.md` and, one file over, a contract saying those fences all die.

The paragraph now says what actually happens and points at the README section that owns the detail.
The one clause still true is kept: an eval run must not grade "the verb is not available yet" as the
skill's own behaviour.

Nothing else in the file moved — the machine-local-path taxonomy is byte-identical.

Fixes #5702

## Deviations

- **Declined guidance** — **Said:** the issue body says the fix is blocked by #5755, because
  `build check --surface prose` would red on the file's pre-existing machine-local-path taxonomy.
  **Did:** built and landed it now; #5755 is still open. **Why:** the premise did not reproduce.
  `build check --surface prose` is green on this diff — the taxonomy lines use placeholder accounts
  (`/Users/<account>`), which the leak scan does not match. **Disposition:** stated here; #5755
  stands on its own as a general question about baseline attribution.
