### PR TITLE
chore: pin the kampus-pipeline marketplace entry to a commit sha

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -12,7 +12,12 @@
 	"plugins": [
 		{
 			"name": "kampus-pipeline",
-			"source": "./claude-plugins/kampus-pipeline",
+			"source": {
+				"source": "git-subdir",
+				"url": "https://github.com/kamp-us/phoenix",
+				"path": "claude-plugins/kampus-pipeline",
+				"sha": "633d61e5913f7666178e0bb4a7fe1a89b5c206fd"
+			},
 			"description": "The kamp.us agent pipeline: report → triage → plan-epic → write-code → review → ship-it, with artifact-class review gates (code/doc/skill/plan) plus adr, heal-ci, and deslop-comments. Repo-agnostic — operates on the working git repo's issue queue (CLAUDE_PIPELINE_REPO override).",
 			"author": {
 				"name": "kamp-us",


### PR DESCRIPTION
Closes #6239

One-line change, founder-directed fast path (umut, 2026-08-18): the kampus-pipeline marketplace entry flips from a relative-path source to a github source pinned to sha `633d61e5` (current main). A sha-pinned install keeps working after upstream deletion as long as the commit is reachable (Claude Code plugin docs), so binclusive/monorepo (binclusive#4926) is decoupled from #5937 / #6100.

binclusive gets a heads-up before #5937/#6100 fire.

## Deviations

- **Fast path.** Founder-directed direct PR by the driver (skipping the build/review lanes) for a single-line §CP change; notusirin approves at head per CODEOWNERS.

🤖 Generated with [Claude Code](https://claude.com/claude-code)