### PR TITLE
fix: fabrika build claim runs no type check — the type filter lives only in the pick pool

### DIFF
--- a/claude-plugins/fabrika/skills/build/SKILL.md
+++ b/claude-plugins/fabrika/skills/build/SKILL.md
@@ -83,8 +83,19 @@ names the winner — that lane is theirs, back off, including when the winner sh
 including on a number handed straight to you: end the run naming the code, and **never override on
 your own authority**. `--override "<reason>" --override-lane "<lane>"` (both flags required) is the
 operator's act, taken only when they ask for it in so many words, and the reason it records is
-theirs, not a rationale you compose. Before **every** later mutation addressed to an issue or PR
-number, re-confirm:
+theirs, not a rationale you compose.
+
+Exit `30` (type not buildable) is the third refusal, and it is the step-1 rule with teeth rather
+than a new one: the verb now reads the issue's type itself, so a `type:decision` or `type:epic`
+handed straight to you is refused before any marker, whatever labels it carries (#5490). **It is not
+overridable, and the remedy is on the refusal line.** An epic goes to `--purpose plan` or
+`--purpose gate`, which claim it exactly as before. A decision opens on
+`--cites <ruling-comment-url>` — the comment URL is checked against this repository and this issue,
+and the verb can prove no more than that, so citing a comment that does not rule anything is a lie
+the tool cannot catch and you must not tell. Passing `--cites` on a decision whose audience is still
+`ready-for:human` lands on `21`, because the citation opens the type axis and nothing else.
+
+Before **every** later mutation addressed to an issue or PR number, re-confirm:
 
 ```bash
 fabrika build confirm $issue_or_pr_number --token <claim-token>

--- a/claude-plugins/fabrika/skills/build/contract.md
+++ b/claude-plugins/fabrika/skills/build/contract.md
@@ -130,6 +130,14 @@ from two separate questions, computed together and answered together:
   be added **beside** it, not folded into it. Refusal is `21`, and it binds a **build-purpose** claim
   only (see `build claim`'s `--purpose`, #5175) — and not even that one when the claim repairs an
   open PR whose served issue is `type:decision` (#5914).
+- **The type axis** — is the deliverable a pull request an agent build lane produces? The four types
+  that are (`type:feature` / `type:chore` / `type:bug` / `type:investigation`) are declared once in
+  the same module, and `type:decision` and `type:epic` are not. Refusal is `30`. It binds a **fresh
+  build** and nothing else: a `plan` or `gate` claim takes an epic by design (#5175), and a repair
+  claim names a PR whose existence already answers the question. The rule is older than the axis —
+  it lived in `build pick`'s private type set, where a number handed straight to `build claim` met
+  no type check at all and an in-lane `type:decision` carrying `ready-for:agent` was admitted with
+  no refusal (#5490).
 
 **Keep the two names apart.** *Scope admission* is a different question from the audience axis (who
 the work is for), from dependency eligibility (`build eligible` asks whether an issue's predecessors
@@ -155,6 +163,30 @@ through no pool — so the claim seam runs the same predicate before it writes a
 either one is a hole: without the claim refusal the direct handoff is unfenced, without the pool
 filter every off-campaign issue is still offered and the refusal only arrives after an agent has
 chosen.
+
+**That argument covers the type rule too, and #5490 is what it cost to leave it uncovered.** The
+type set was the pool's own constant, so the claim seam could not see it and the audience axis was
+doing the type rule's job by coincidence — a `type:decision` was refused because triage happens to
+route decisions to `ready-for:human`, not because it is a decision. Where that coincidence did not
+hold the claim was simply admitted, and where it did the refusal named the wrong objection: an
+operator sent to fix `audience-not-agent` would re-label the issue `ready-for:agent`, satisfy the
+fence, and build the wrong artifact. So the type axis sits in the module with the other two, and
+refusals are reported **scope, then type, then audience** — the order an operator's remedies run in.
+
+**The type axis has one arm, and a citation is the only thing that opens it.** A `type:decision`
+whose choice a founder has already recorded on the issue is buildable, because the deliverable is
+then transcription rather than judgement (founder ruling on
+[#5879, comment 5335398768](https://github.com/kamp-us/phoenix/issues/5879#issuecomment-5335398768)).
+`build claim --cites <url>` names that ruling comment, in the grammar
+`https://github.com/<owner>/<repo>/issues/<n>#issuecomment-<comment-id>`, and the verb refuses a URL
+that names another repository or another issue — a ruling recorded elsewhere opens nothing here. It
+is **not an override**: an override admits a proven refusal, while a citation says the refusal does
+not apply, so a type refusal is not on the overridable set at all. What the verb can check is the
+pointer's shape and its target; whether that comment rules anything is the reader's judgement and is
+stated as such. `type:epic` has no arm — its deliverable is a ledger no citation turns into a pull
+request, and the remedy is `--purpose plan` or `--purpose gate`. The arm opens the type axis and
+nothing else: the issue still has to carry `ready-for:agent`, which triage stamps, so a
+`ready-for:human` decision with a perfect citation is still `21`.
 
 **The inputs, and where each is read.**
 
@@ -276,6 +308,7 @@ range, exactly as `triage/codes.ts` itself states for `adr`.
 | `22` | proven: every changed file falls outside all three surfaces' validators — there is nothing to run, so the verdict is a refusal, never a green |
 | `23` | proven: the local head does not contain the published remote head — the push would drop its commits |
 | `24` | proven: `git commit` ran and HEAD did not move — no commit was created |
+| `30` | proven: not admitted on the type axis — the issue is `type:decision` or `type:epic`, whose deliverable is not a pull request a build lane produces |
 | `127` | the verb never ran at all (unresolved binary — the shell's code, not this process's) |
 
 **`7` versus `11` is the split the whole group rests on** (the `wire` group's `ABSENT` vs
@@ -827,6 +860,7 @@ proven-foreign only; a missing session id is `1`; an unreadable marker set is `1
 | `15` | proven: another lane's earlier authorized marker wins (`claim`), holds (`confirm`), or `release` was asked for a token this lane does not hold. `claim` also refuses here over a claim this lane has *adopted* — release it first |
 | `20` | `claim` only, proven: the issue's home is outside the declared focus — no marker was written |
 | `21` | `claim --purpose build` only (the default), proven: the issue's audience is not an agent — no marker was written. Unreachable when the target is an open PR serving a `type:decision` issue (#5914) |
+| `30` | `claim --purpose build` against an **issue** only, proven: the issue is `type:decision` or `type:epic` — no marker was written. Not overridable: a decision opens it with `--cites <ruling-comment-url>`, an epic with `--purpose plan` or `--purpose gate` |
 
 **Errors**
 
@@ -835,6 +869,8 @@ proven-foreign only; a missing session id is `1`; an unreadable marker set is `1
 | `build claim: issue #<n> is proven absent or closed.` | 7 | refusal |
 | `build claim: #<n> is homed in milestone <home>, outside the declared focus #<focus> — refusing before any marker; pass --override "<reason>" --override-lane "<lane>" to claim it anyway.` | 20 | refusal |
 | `build claim: #<n> carries <audience>, not "ready-for:agent" — refusing before any marker; pass --override "<reason>" --override-lane "<lane>" to claim it anyway.` (`<audience>` is the issue's `ready-for:` label, or the literal `no "ready-for:" label` when it carries none) | 21 | refusal |
+| `build claim: type not buildable — this issue carries <label>, whose deliverable is not a pull request an agent build lane produces; <remedy>.` (`<remedy>` names `--cites` for a decision and `--purpose plan`/`--purpose gate` for an epic) | 30 | refusal |
+| `build claim: --cites <detail>; nothing was written.` — the URL is not an issue-comment URL, or names another repository or another issue | 1 | refusal |
 | `build claim: cannot read the "## Focus" declaration: <reason> — scope is UNKNOWN, never admitted; nothing was written.` | 11 | refusal |
 | `build claim: the "## Focus" declaration does not parse: <detail> — a malformed declaration is never read as "no focus"; nothing was written.` | 4 | refusal |
 | `build claim: #<n> is already held by this lane (comment <id>) — answered with the marker that owns it; nothing was written.` — beside `{"answer":"won", …}` on exit 0, when `--token` names a lane that already holds `<n>` | 0 | answer |

--- a/packages/fabrika-cli/src/build/claim-verb.ts
+++ b/packages/fabrika-cli/src/build/claim-verb.ts
@@ -78,13 +78,18 @@ import {
 	admissionOf,
 	admissionRefusal,
 	audienceAxisOf,
+	type Citation,
 	CLAIM_PURPOSES,
 	DEFAULT_CLAIM_PURPOSE,
 	focusScopeLine,
+	NO_CITATION,
 	NOT_REPAIR,
+	parseCitation,
 	parseClaimPurpose,
 	purposeScopeLine,
 	readDeclaredFocus,
+	typeAxisOf,
+	typeScopeLine,
 } from "./scope-admission.ts";
 import {openIssue, resolveAdmissionSubject, resolveTargetRepo} from "./target.ts";
 
@@ -103,6 +108,14 @@ export interface ClaimOptions {
 	/** The lane an override is taken for — required with an override, refused without one. */
 	readonly overrideLane: string | null;
 	/**
+	 * The founder ruling comment this build transcribes, or `null` — the type axis's one arm.
+	 *
+	 * It is not an override and never seats one: an override admits a refusal, while a citation says
+	 * the refusal does not apply, because the choosing this issue asked for already happened on the
+	 * board (founder ruling on #5879, comment 5335398768).
+	 */
+	readonly cites: string | null;
+	/**
 	 * The token this lane ALREADY holds, when it is re-claiming — `null` on a fresh claim.
 	 *
 	 * It is what makes the idempotent answer expressible per lane: without it, "already mine" could
@@ -113,7 +126,7 @@ export interface ClaimOptions {
 
 export type ProtocolOptions = Omit<
 	ClaimOptions,
-	"uuid" | "at" | "purpose" | "override" | "overrideLane" | "token"
+	"uuid" | "at" | "purpose" | "override" | "overrideLane" | "cites" | "token"
 > & {
 	/** The token `build claim` handed this lane — the identity it is asking under (#6037). */
 	readonly token: string;
@@ -258,13 +271,26 @@ export const runClaim = (
 		const judged = subject._tag === "Judged" ? subject.facts : ready.issue;
 		const repair = subject._tag === "Judged" ? subject.repair : NOT_REPAIR;
 		const purposeLine = purposeScopeLine(CLAIM, purpose, audienceAxisOf(judged), repair);
+		// The citation is read against the issue the fence actually judges, so a URL naming some other
+		// thread cannot open the arm. A value that does not parse refuses here, before any marker: a
+		// citation is the whole authority for building a decision, and a broken one confers nothing.
+		let citation: Citation = NO_CITATION;
+		if (options.cites !== null) {
+			const cited = parseCitation(options.cites, repo, judged.number);
+			if (cited._tag === "Malformed") {
+				return refuse(FAILED, `${CLAIM}: --cites ${cited.reason}; nothing was written.`);
+			}
+			citation = cited.citation;
+		}
 		const admission =
 			subject._tag === "Judged"
-				? admissionOf(read.focus, subject.facts, purpose, repair)
+				? admissionOf(read.focus, subject.facts, purpose, repair, citation)
 				: subject.admission;
+		const typeLine = typeScopeLine(CLAIM, typeAxisOf(judged), citation);
 		const lines = [
 			scopeLine,
 			...(subject._tag === "Judged" && subject.note !== null ? [subject.note] : []),
+			...(typeLine === null ? [] : [typeLine]),
 			purposeLine,
 		];
 		const refusal = admissionRefusal(CLAIM, admission);
@@ -355,6 +381,7 @@ export const runClaim = (
 					token: ownership.marker.token,
 					purpose,
 					...(override === null ? {} : {override}),
+					...(citation._tag === "Cited" ? {cites: citation.url} : {}),
 				}),
 				notes,
 			);

--- a/packages/fabrika-cli/src/build/claim-verb.unit.test.ts
+++ b/packages/fabrika-cli/src/build/claim-verb.unit.test.ts
@@ -12,6 +12,7 @@ import {
 	OUT_OF_FOCUS,
 	PRECONDITION_UNKNOWN,
 	READBACK_MISMATCH,
+	TYPE_NOT_BUILDABLE,
 	WRITE_UNKNOWN,
 	ZERO_SCOPE,
 } from "./codes.ts";
@@ -87,6 +88,7 @@ const options = {
 	purpose: "build",
 	override: null as string | null,
 	overrideLane: null as string | null,
+	cites: null as string | null,
 };
 
 const run = (
@@ -722,7 +724,10 @@ describe("runClaim — a PR number is judged by the issue it serves", () => {
 			expect(JSON.parse(out.stdout).override).toBeUndefined();
 		});
 
-		it("refuses the very same issue at 21 when it is claimed directly, writing nothing", async () => {
+		// It refused at 21 until #5490 seated the type axis. The exemption's other arm is unchanged —
+		// the direct claim is still refused, still writes nothing — but the reason it prints is now the
+		// objection an operator can act on rather than a label they could talk past.
+		it("refuses the very same issue on type when it is claimed directly, writing nothing", async () => {
 			const shell = fakeShell([
 				[ISSUE, issue({milestone: {number: 44}, labels: DECISION})],
 				unclaimed(),
@@ -734,9 +739,79 @@ describe("runClaim — a PR number is judged by the issue it serves", () => {
 			const out = await Effect.runPromise(
 				Effect.provide(runClaim(options), Layer.merge(shell.layer, FOCUSED.layer)),
 			);
+			expect(out.code).toBe(TYPE_NOT_BUILDABLE);
+			expect(shell.calls.some((line) => POST.test(line))).toBe(false);
+			expect(out.stderr.some((line) => line.includes("type not buildable"))).toBe(true);
+		});
+
+		it("leaves the audience fence standing — a cited ruling opens type, and only type", async () => {
+			const shell = fakeShell([
+				[ISSUE, issue({milestone: {number: 44}, labels: DECISION})],
+				unclaimed(),
+				[POST, POSTED],
+				[GET_COMMENT, ECHO],
+				[COMMENTS, comments({id: 9001, body: MINE})],
+				[perm("agent"), okOut("write\n")],
+			]);
+			const out = await Effect.runPromise(
+				Effect.provide(
+					runClaim({
+						...options,
+						cites: "https://github.com/o/r/issues/4312#issuecomment-5335398768",
+					}),
+					Layer.merge(shell.layer, FOCUSED.layer),
+				),
+			);
+			// The DECISION fixture is `ready-for:human`, which triage re-stamps when it routes a ruled
+			// decision to an agent. Until it does, the claim stops here (ADR 0300's binding constraint).
 			expect(out.code).toBe(AUDIENCE_NOT_AGENT);
 			expect(shell.calls.some((line) => POST.test(line))).toBe(false);
-			expect(out.stderr.some((line) => line.includes("audience not agent"))).toBe(true);
+		});
+
+		it("takes the ruled decision once triage has stamped it for an agent", async () => {
+			const shell = fakeShell([
+				[
+					ISSUE,
+					issue({
+						milestone: {number: 44},
+						labels: labelled("status:triaged", "type:decision", "ready-for:agent"),
+					}),
+				],
+				unclaimed(),
+				[POST, POSTED],
+				[GET_COMMENT, ECHO],
+				[COMMENTS, comments({id: 9001, body: MINE})],
+				[perm("agent"), okOut("write\n")],
+			]);
+			const cites = "https://github.com/o/r/issues/4312#issuecomment-5335398768";
+			const out = await Effect.runPromise(
+				Effect.provide(runClaim({...options, cites}), Layer.merge(shell.layer, FOCUSED.layer)),
+			);
+			expect(out.code).toBe(0);
+			expect(JSON.parse(out.stdout).cites).toBe(cites);
+			expect(out.stderr.some((line) => line.includes(cites))).toBe(true);
+		});
+
+		it("refuses a citation recorded on some other issue, before any marker", async () => {
+			const shell = fakeShell([
+				[ISSUE, issue({milestone: {number: 44}, labels: DECISION})],
+				unclaimed(),
+				[POST, POSTED],
+				[GET_COMMENT, ECHO],
+				[COMMENTS, comments({id: 9001, body: MINE})],
+				[perm("agent"), okOut("write\n")],
+			]);
+			const out = await Effect.runPromise(
+				Effect.provide(
+					runClaim({
+						...options,
+						cites: "https://github.com/o/r/issues/9999#issuecomment-5335398768",
+					}),
+					Layer.merge(shell.layer, FOCUSED.layer),
+				),
+			);
+			expect(out.code).toBe(1);
+			expect(shell.calls.some((line) => POST.test(line))).toBe(false);
 		});
 
 		it("keeps the fence for every other type an open PR serves", async () => {
@@ -789,15 +864,26 @@ describe("runClaim — the purpose axis", () => {
 		labels: labelled("type:epic", "p1", "status:triaged"),
 	});
 
-	it("keeps the fence with no purpose passed — 21, and no marker written", async () => {
+	// Both fences bind this epic under build. It refused at 21 until #5490 seated the type axis; type
+	// is read first now, and an epic is refused whatever its `ready-for:` label says, which is what
+	// the audience axis alone could never prove. The `type:bug` case below keeps 21 under test.
+	it("keeps the fence with no purpose passed — 30, and no marker written", async () => {
 		const {out, shell} = await claimWith(UNLABELLED_EPIC);
-		expect(out.code).toBe(AUDIENCE_NOT_AGENT);
+		expect(out.code).toBe(TYPE_NOT_BUILDABLE);
 		expect(shell.calls.some((line) => POST.test(line))).toBe(false);
-		expect(out.stderr.some((line) => line.includes("audience not agent"))).toBe(true);
+		expect(out.stderr.some((line) => line.includes("type not buildable"))).toBe(true);
 	});
 
 	it("keeps the fence under an explicit --purpose build — the default is not the only path", async () => {
 		const {out, shell} = await claimWith(UNLABELLED_EPIC, {purpose: "build"});
+		expect(out.code).toBe(TYPE_NOT_BUILDABLE);
+		expect(shell.calls.some((line) => POST.test(line))).toBe(false);
+	});
+
+	it("still seats 21 under build on a type the type axis admits", async () => {
+		const {out, shell} = await claimWith(
+			issue({milestone: {number: 44}, labels: labelled("type:bug", "p1", "status:triaged")}),
+		);
 		expect(out.code).toBe(AUDIENCE_NOT_AGENT);
 		expect(shell.calls.some((line) => POST.test(line))).toBe(false);
 	});

--- a/packages/fabrika-cli/src/build/codes.ts
+++ b/packages/fabrika-cli/src/build/codes.ts
@@ -143,3 +143,16 @@ export const AUTHORIZATION_VOID = 26;
  * `29` — a group never re-uses a number the base already spoke for.
  */
 export const LOCAL_LANE_UNWRITTEN = 29;
+/**
+ * Proven: not admitted on the **type axis** — the deliverable is not a pull request a build lane
+ * produces (#5490).
+ *
+ * The third sibling of {@link OUT_OF_FOCUS} and {@link AUDIENCE_NOT_AGENT}, and seated apart from
+ * both for the reason they are seated apart from each other: the remedy is unlike either. `20` says
+ * edit the focus row, `21` says re-label the audience, and this one says the work belongs to another
+ * skill's lane — `/adr` for a decision, `plan-epic` for an epic — or, on a decision whose choice a
+ * founder already recorded, that the claim must cite that ruling comment. Borrowing `21` is what the
+ * code did before there was a fence at all, and it named the wrong objection: an operator sent to
+ * re-label a decision `ready-for:agent` would satisfy `21` and still be building the wrong artifact.
+ */
+export const TYPE_NOT_BUILDABLE = 30;

--- a/packages/fabrika-cli/src/build/command.ts
+++ b/packages/fabrika-cli/src/build/command.ts
@@ -34,8 +34,11 @@ import {runPr, runPrBody} from "./pr-verb.ts";
 import {runPush} from "./push-verb.ts";
 import {
 	ADMISSION_EXIT_CODES,
+	CITATION_GRAMMAR,
 	CLAIM_PURPOSES,
+	DECISION_TYPE_LABEL,
 	DEFAULT_CLAIM_PURPOSE,
+	EPIC_TYPE_LABEL,
 	READY_FOR_AGENT,
 } from "./scope-admission.ts";
 import {runScratch} from "./scratch-verb.ts";
@@ -158,7 +161,7 @@ const claim = leafCommand(
 		override: Flag.string("override").pipe(
 			Flag.optional,
 			Flag.withDescription(
-				"claim an issue the admission test refused on either axis, naming why; requires --override-lane, and both are written into the claim marker",
+				"claim an issue the admission test refused on the scope or audience axis, naming why; requires --override-lane, and both are written into the claim marker. A type-axis refusal is not overridable — a decision cites its ruling, an epic changes its --purpose",
 			),
 		),
 		overrideLane: Flag.string("override-lane").pipe(
@@ -167,9 +170,15 @@ const claim = leafCommand(
 				"the lane an --override is taken for; required with it, refused without it",
 			),
 		),
+		cites: Flag.string("cites").pipe(
+			Flag.optional,
+			Flag.withDescription(
+				`the founder ruling comment this build transcribes, as ${CITATION_GRAMMAR} — the type axis's one arm, and only on a ${DECISION_TYPE_LABEL}`,
+			),
+		),
 		repo: repoFlag,
 	},
-	Effect.fn(function* ({number, token, purpose, override, overrideLane, repo}) {
+	Effect.fn(function* ({number, token, purpose, override, overrideLane, cites, repo}) {
 		yield* emit(
 			yield* runClaim({
 				number,
@@ -181,13 +190,14 @@ const claim = leafCommand(
 				purpose,
 				override: Option.getOrNull(override),
 				overrideLane: Option.getOrNull(overrideLane),
+				cites: Option.getOrNull(cites),
 			}),
 		);
 	}),
 ).pipe(
 	Command.withShortDescription("Race the claim marker on an issue and win it or name the winner."),
 	Command.withDescription(
-		`Race the earliest AUTHORIZED claim marker on an issue: post this session's token (build:<CLAUDE_CODE_SESSION_ID>:<uuid>), re-read, and win or name the winner. Authorization is the author's repository permission (ADR 0055) — marker text confers nothing. The admission test runs FIRST, before any marker is written, so a refused claim leaves no trace to retract. --purpose says why this lane claims (${CLAIM_PURPOSES.join(" | ")}, default ${DEFAULT_CLAIM_PURPOSE}): the audience axis (${READY_FOR_AGENT}) binds a build claim only, because an epic earns that label AFTER it is planned and gated (#5175); the scope axis binds every purpose, and an off-enum --purpose refuses on 10 rather than falling back. --override "<reason>" admits a proven refusal and REQUIRES --override-lane "<lane>"; both are recorded on the marker, and an UNKNOWN admission is never overridable. Prints {"answer":"won","number":n,"token":"…","purpose":"…"}, plus "override":{"lane","reason"} when one was used. --token makes the re-claim idempotent per LANE: handed the token this lane already holds, a number that lane already owns answers won with that same marker and writes nothing (#5782), while a same-session marker under another nonce is a sibling lane and races normally. A lost race retracts this run's own marker and exits 15, never 0 — including when the winner is another lane of THIS session, since ownership turns on the whole token and never the session id (#6037); an unset CLAUDE_CODE_SESSION_ID, a --token that is not a claim token of this session, an empty --override reason, an --override with no lane, or an --override-lane with no override, is 1. Exits 7 (issue proven absent or closed), 8 (the marker write failed — UNKNOWN; run confirm), 9 (the marker landed but does not read back), 10 (--purpose is off-enum), 15 (proven lost), and from the admission test: ${admissionExits}. Example: fabrika build claim 4312 --purpose gate`,
+		`Race the earliest AUTHORIZED claim marker on an issue: post this session's token (build:<CLAUDE_CODE_SESSION_ID>:<uuid>), re-read, and win or name the winner. Authorization is the author's repository permission (ADR 0055) — marker text confers nothing. The admission test runs FIRST, before any marker is written, so a refused claim leaves no trace to retract. --purpose says why this lane claims (${CLAIM_PURPOSES.join(" | ")}, default ${DEFAULT_CLAIM_PURPOSE}): the audience axis (${READY_FOR_AGENT}) binds a build claim only, because an epic earns that label AFTER it is planned and gated (#5175); the scope axis binds every purpose, and an off-enum --purpose refuses on 10 rather than falling back. --override "<reason>" admits a proven refusal and REQUIRES --override-lane "<lane>"; both are recorded on the marker, and an UNKNOWN admission is never overridable. The type axis binds a build claim against an ISSUE only, so ${DECISION_TYPE_LABEL} and ${EPIC_TYPE_LABEL} refuse before any marker is written; --cites ${CITATION_GRAMMAR} opens it on a decision whose choice a founder already recorded on that issue, and the URL must name this repository and the issue being judged. It is not an override: it says the refusal does not apply, and it is never accepted for an epic. Prints {"answer":"won","number":n,"token":"…","purpose":"…"}, plus "override":{"lane","reason"} when one was used and "cites" when a ruling was cited. --token makes the re-claim idempotent per LANE: handed the token this lane already holds, a number that lane already owns answers won with that same marker and writes nothing (#5782), while a same-session marker under another nonce is a sibling lane and races normally. A lost race retracts this run's own marker and exits 15, never 0 — including when the winner is another lane of THIS session, since ownership turns on the whole token and never the session id (#6037); an unset CLAUDE_CODE_SESSION_ID, a --token that is not a claim token of this session, an empty --override reason, an --override with no lane, or an --override-lane with no override, is 1. Exits 7 (issue proven absent or closed), 8 (the marker write failed — UNKNOWN; run confirm), 9 (the marker landed but does not read back), 10 (--purpose is off-enum), 15 (proven lost), and from the admission test: ${admissionExits}. Example: fabrika build claim 4312 --purpose gate`,
 	),
 );
 

--- a/packages/fabrika-cli/src/build/pick-verb.ts
+++ b/packages/fabrika-cli/src/build/pick-verb.ts
@@ -5,10 +5,12 @@
  * The filter is fail-closed on every axis, and two of them are negative tests rather than positive
  * ones:
  *
- * - **The admission test decides both the scope and audience axes**, imported from
+ * - **The admission test decides the scope, audience and type axes**, imported from
  *   [`./scope-admission.ts`](./scope-admission.ts) and re-derived nowhere (ADR 0245). An issue with
  *   no `ready-for:` label is excluded — absence is an unknown audience, never an agent audience
- *   (#4780) — and one homed outside the declared focus is excluded with its own reason.
+ *   (#4780) — and one homed outside the declared focus is excluded with its own reason. The type
+ *   set used to be this file's private constant, which is how a directly-handed `type:decision`
+ *   reached `claim` with nothing to refuse it (#5490).
  * - **Any assignee excludes.** Assignment is the one attribute that keeps a human's live document out
  *   of an agent's pool (#4764, #4693).
  * - **A body with no readable acceptance-criteria block excludes**, reported on the same
@@ -31,11 +33,13 @@ import {BAD_SECTIONS, PRECONDITION_UNKNOWN} from "./codes.ts";
 import {type CandidateIssue, listLabelled} from "./github.ts";
 import {
 	admissionOf,
+	BUILDABLE_TYPE_LABELS,
 	exclusionReasonOf,
 	focusReport,
 	focusScopeLine,
 	homeOf,
 	readDeclaredFocus,
+	typeAxisOf,
 } from "./scope-admission.ts";
 import {resolveTargetRepo} from "./target.ts";
 
@@ -44,9 +48,6 @@ const VERB = "build pick";
 /** The priority buckets, in the order the spine reads them. */
 const BUCKETS = ["p0", "p1", "p2"] as const;
 type Bucket = (typeof BUCKETS)[number];
-
-/** The four types an agent lane may take. `type:decision` and `type:epic` never enter. */
-const TYPES = new Set(["type:feature", "type:chore", "type:bug", "type:investigation"]);
 
 export interface PickOptions {
 	readonly repo: string | null;
@@ -81,20 +82,24 @@ interface ExclusionEntry {
 }
 
 /**
- * The axes that are this verb's own — board hygiene, not admission.
+ * Board hygiene, plus the type axis read through the shared predicate.
  *
- * The audience axis is deliberately absent: it lives in the admission test with the scope axis, so an
- * issue it excludes can be *reported* with its reason instead of vanishing from the pool unexplained.
+ * The audience and scope axes are deliberately absent: they run below, so an issue they exclude is
+ * *reported* with its reason instead of vanishing from the pool unexplained. Type stays up here
+ * because this pool has never offered a decision or an epic at all, and reporting one as excluded
+ * would be a change to what the pool says rather than to where the rule lives.
  */
 export const isCandidate = (issue: CandidateIssue): boolean => {
 	if (issue.isPullRequest || issue.assigned) return false;
 	const status = issue.labels.filter((label) => label.startsWith("status:"));
 	if (status.length !== 1 || status[0] !== "status:triaged") return false;
-	return issue.labels.filter((label) => label.startsWith("type:")).every((t) => TYPES.has(t));
+	return typeAxisOf(issue)._tag === "Buildable";
 };
 
 const typeOf = (issue: CandidateIssue): string =>
-	issue.labels.find((label) => TYPES.has(label))?.slice("type:".length) ?? "";
+	issue.labels
+		.find((label) => BUILDABLE_TYPE_LABELS.some((buildable) => buildable === label))
+		?.slice("type:".length) ?? "";
 
 /** Milestone order inside a bucket: homed before unhomed, lower milestone first, then oldest number. */
 const rankWithinBucket = (a: PoolEntry, b: PoolEntry): number => {

--- a/packages/fabrika-cli/src/build/scope-admission.ts
+++ b/packages/fabrika-cli/src/build/scope-admission.ts
@@ -6,11 +6,16 @@
  *   exclusive focus? It refuses on {@link OUT_OF_FOCUS}.
  * - **The audience axis** is who the work is for (`ready-for:agent`), a question older than the fence
  *   (#4780). This module *hosts* it; it does not redefine it. It refuses on {@link AUDIENCE_NOT_AGENT}.
+ * - **The type axis** is whether the deliverable is a pull request at all. It refuses on
+ *   {@link TYPE_NOT_BUILDABLE}, and it lives here rather than in the pool because the pool is the
+ *   browse path: a number handed straight to `claim` passes through no pool, so a type rule fenced
+ *   only there is no fence (#5490).
  *
- * They are siblings with different remedies — edit the focus row, or re-label the audience — so they
- * stay separately named, separately seated and separately reported everywhere. A single predicate
- * answering both questions at once is the shape the contract's repair round removed; every outcome
- * below therefore carries **both** axis verdicts, so a caller can never lose one behind the other.
+ * They are siblings with different remedies — edit the focus row, re-label the audience, or take the
+ * work to the skill whose lane it is — so they stay separately named, separately seated and
+ * separately reported everywhere. A single predicate answering all three questions at once is the
+ * shape the contract's repair round removed; every outcome below therefore carries **every** axis
+ * verdict, so a caller can never lose one behind another.
  *
  * A claim's {@link ClaimPurpose} rides **beside** those axes: it decides whether the audience axis
  * *binds* this claim, and it never enters either axis's own reading (#5175).
@@ -23,7 +28,13 @@ import {Effect, type FileSystem, Result} from "effect";
 import {exists, type ReadFailed, readFile} from "../io/fs.ts";
 import {issueRefOf} from "../review/classes.ts";
 import {refuse, type VerbOutcome} from "../verb.ts";
-import {AUDIENCE_NOT_AGENT, BAD_SECTIONS, OUT_OF_FOCUS, PRECONDITION_UNKNOWN} from "./codes.ts";
+import {
+	AUDIENCE_NOT_AGENT,
+	BAD_SECTIONS,
+	OUT_OF_FOCUS,
+	PRECONDITION_UNKNOWN,
+	TYPE_NOT_BUILDABLE,
+} from "./codes.ts";
 
 /** The declaration's file, relative to the repository root. */
 export const DEFAULT_ROADMAP = "ROADMAP.md";
@@ -51,6 +62,115 @@ const READY_FOR_PREFIX = "ready-for:";
  * mutually exclusive by construction. That is the collision {@link RepairClaim} answers.
  */
 export const DECISION_TYPE_LABEL = "type:decision";
+
+/** The type whose deliverable is a ledger of children rather than one pull request — `plan-epic`'s. */
+export const EPIC_TYPE_LABEL = "type:epic";
+
+/**
+ * The four types an agent build lane may take — the type axis's whole vocabulary, declared once.
+ *
+ * The pool used to own a private copy of this set, so the claim seam could not see it and a
+ * directly-handed `type:decision` was admitted with no refusal at all (#5490). One declaration is
+ * what makes the two seams unable to disagree, the same rule ADR 0245 states for the other axes.
+ */
+export const BUILDABLE_TYPE_LABELS = [
+	"type:feature",
+	"type:chore",
+	"type:bug",
+	"type:investigation",
+] as const;
+
+const TYPE_PREFIX = "type:";
+
+/**
+ * Axis three — whether the deliverable is a pull request an agent build lane produces.
+ *
+ * An issue carrying **no** `type:` label is `Buildable` here, which is deliberate and is not this
+ * axis's judgement to make: it is the pool's long-standing reading, preserved so this axis changes
+ * where the rule is enforced without changing what the rule says. The untyped hole is its own
+ * defect on its own ticket (#5490's triage note).
+ */
+export type TypeAxis =
+	/** Every `type:` label carried is one of {@link BUILDABLE_TYPE_LABELS}, or none is carried. */
+	| {readonly _tag: "Buildable"}
+	/** `label` is the first carried `type:` label outside the buildable set. */
+	| {readonly _tag: "NotBuildable"; readonly label: string};
+
+export const typeAxisOf = (issue: IssueFacts): TypeAxis => {
+	const barred = issue.labels
+		.filter((label) => label.startsWith(TYPE_PREFIX))
+		.find((label) => !BUILDABLE_TYPE_LABELS.some((buildable) => buildable === label));
+	return barred === undefined ? {_tag: "Buildable"} : {_tag: "NotBuildable", label: barred};
+};
+
+/**
+ * A founder ruling recorded on the issue, named by the comment it lives in.
+ *
+ * It is what opens the type axis on a `type:decision`: once the choosing has happened on the board,
+ * the deliverable is transcription and transcription is a pull request like any other (founder
+ * ruling on [#5879](https://github.com/kamp-us/phoenix/issues/5879#issuecomment-5335398768)). The
+ * citation is the fence — an agent points at the comment or it refuses — so what this module can
+ * check is the pointer's shape and its target, never whether the comment rules anything. Judging
+ * that stays the reader's, and the arm is worth exactly as much as that honesty: it rules out a
+ * citation that names some other issue, not one that names the wrong comment.
+ */
+export type Citation =
+	| {readonly _tag: "None"}
+	| {
+			readonly _tag: "Cited";
+			readonly issue: number;
+			readonly commentId: number;
+			/** The URL as written, already proven to name this repository and this issue. */
+			readonly url: string;
+	  };
+
+/** No ruling was cited — the reading every seam but a `--cites` claim takes. */
+export const NO_CITATION: Citation = {_tag: "None"};
+
+const CITATION_URL =
+	/^https:\/\/github\.com\/([^/\s]+)\/([^/\s]+)\/issues\/(\d+)#issuecomment-(\d+)$/;
+
+/** The canonical shape a citation is written in, quoted in every refusal that asks for one. */
+export const CITATION_GRAMMAR =
+	"https://github.com/<owner>/<repo>/issues/<n>#issuecomment-<comment-id>";
+
+export type CitationRead =
+	| {readonly _tag: "Read"; readonly citation: Citation}
+	| {readonly _tag: "Malformed"; readonly reason: string};
+
+/**
+ * Read a `--cites` value against the repository and issue the claim is actually addressed to.
+ *
+ * Both bindings are the point: a URL naming another repository or another issue is a ruling recorded
+ * somewhere else, and admitting it would let one founder comment unlock every decision on the board.
+ */
+export const parseCitation = (value: string, repo: string, issue: number): CitationRead => {
+	const trimmed = value.trim();
+	const match = CITATION_URL.exec(trimmed);
+	if (match === null) {
+		return {
+			_tag: "Malformed",
+			reason: `"${trimmed}" is not an issue-comment URL — the grammar is ${CITATION_GRAMMAR}`,
+		};
+	}
+	const [, owner, name, cited, commentId] = match;
+	if (`${owner}/${name}` !== repo) {
+		return {
+			_tag: "Malformed",
+			reason: `"${trimmed}" names ${owner}/${name}, not ${repo} — a ruling recorded in another repository rules nothing here`,
+		};
+	}
+	if (Number(cited) !== issue) {
+		return {
+			_tag: "Malformed",
+			reason: `"${trimmed}" names issue #${cited}, not #${issue} — the ruling has to be recorded on the issue being claimed`,
+		};
+	}
+	return {
+		_tag: "Read",
+		citation: {_tag: "Cited", issue, commentId: Number(commentId), url: trimmed},
+	};
+};
 
 /** Everything either axis reads off an issue — no derived field, and nothing else. */
 export interface IssueFacts {
@@ -284,6 +404,27 @@ export const audienceAxisBinds = (
 	repair: RepairClaim = NOT_REPAIR,
 ): boolean => purpose === "build" && repair._tag !== "DecisionRepair";
 
+/**
+ * The type axis binds a **fresh build** and nothing else.
+ *
+ * `plan` and `gate` claim epics by design — that is the whole reason those purposes exist (#5175) —
+ * and a repair claim names a PR, whose existence already answers "should an agent produce a pull
+ * request here". So the axis asks its question at the one moment the answer is still open: an issue
+ * being picked up cold to build.
+ */
+export const typeAxisBinds = (purpose: ClaimPurpose, repair: RepairClaim = NOT_REPAIR): boolean =>
+	purpose === "build" && repair._tag === "NotRepair";
+
+/**
+ * Whether a cited ruling opens the type axis on this label.
+ *
+ * One label has an arm and the rest do not: a `type:decision` whose choice is already recorded is
+ * transcription, which an agent may build (founder ruling on #5879, comment 5335398768). An epic's
+ * deliverable is a ledger no citation turns into a pull request, so it has no arm at all.
+ */
+export const citationOpens = (label: string, citation: Citation): boolean =>
+	label === DECISION_TYPE_LABEL && citation._tag === "Cited";
+
 /** Absence is an unknown audience, never an agent audience (#4780). */
 export const audienceAxisOf = (issue: IssueFacts): AudienceAxis =>
 	issue.labels.includes(READY_FOR_AGENT)
@@ -300,16 +441,31 @@ export const audienceAxisOf = (issue: IssueFacts): AudienceAxis =>
  * apart no matter which one refused.
  */
 export type Admission =
-	| {readonly _tag: "Admitted"; readonly scope: ScopeAxis; readonly audience: AudienceAxis}
+	| {
+			readonly _tag: "Admitted";
+			readonly scope: ScopeAxis;
+			readonly audience: AudienceAxis;
+			readonly type: TypeAxis;
+			/** The ruling that opened the type axis, or `None` — so an arm taken is read, not inferred. */
+			readonly citation: Citation;
+	  }
 	| {
 			readonly _tag: "OutOfFocus";
 			readonly scope: Extract<ScopeAxis, {readonly _tag: "OutOfFocus"}>;
 			readonly audience: AudienceAxis;
+			readonly type: TypeAxis;
+	  }
+	| {
+			readonly _tag: "TypeNotBuildable";
+			readonly scope: ScopeAxis;
+			readonly audience: AudienceAxis;
+			readonly type: Extract<TypeAxis, {readonly _tag: "NotBuildable"}>;
 	  }
 	| {
 			readonly _tag: "AudienceNotAgent";
 			readonly scope: ScopeAxis;
 			readonly audience: Extract<AudienceAxis, {readonly _tag: "NotAgent"}>;
+			readonly type: TypeAxis;
 	  }
 	/**
 	 * A pull request with no readable served issue, under a declared focus.
@@ -337,20 +493,22 @@ export const noServedIssue = (pr: number, focus: number, reason: string): Admiss
 /**
  * Run both axes over one issue.
  *
- * **Scope is reported before audience when both refuse**, deliberately: while an issue sits outside the
- * campaign in focus its audience label is not the thing to fix, and reporting the audience first would
- * send an operator to re-label work that the scope fence would refuse again. The unreported axis is
+ * The refusals are ordered scope, then type, then audience, and the order is the operator's remedy
+ * path rather than a preference. While an issue sits outside the campaign in focus, neither its type
+ * nor its audience label is the thing to fix. Inside the focus, type outranks audience because a
+ * decision or an epic reported as `audience-not-agent` sends an operator to re-label work that is
+ * not a build lane's under any label — the misnaming #5490 was filed on. Every unreported axis is
  * still on the outcome.
  *
- * `purpose` and `repair` decide only whether an audience refusal is *seated*; the audience verdict
- * itself is read and reported either way, so a claim admitted over a non-agent audience still says
- * so.
+ * `purpose`, `repair` and `citation` decide only whether a refusal is *seated*; each axis's verdict
+ * is read and reported either way, so a claim admitted over a non-agent audience still says so.
  */
 export const admissionOf = (
 	focus: Focus,
 	issue: IssueFacts,
 	purpose: ClaimPurpose = DEFAULT_CLAIM_PURPOSE,
 	repair: RepairClaim = NOT_REPAIR,
+	citation: Citation = NO_CITATION,
 ): Admission => {
 	if (focus._tag === "Malformed") {
 		return {
@@ -361,17 +519,25 @@ export const admissionOf = (
 	}
 	const scope = scopeAxisOf(focus, issue);
 	const audience = audienceAxisOf(issue);
-	if (scope._tag === "OutOfFocus") return {_tag: "OutOfFocus", scope, audience};
-	if (audience._tag === "NotAgent" && audienceAxisBinds(purpose, repair)) {
-		return {_tag: "AudienceNotAgent", scope, audience};
+	const type = typeAxisOf(issue);
+	if (scope._tag === "OutOfFocus") return {_tag: "OutOfFocus", scope, audience, type};
+	if (
+		type._tag === "NotBuildable" &&
+		typeAxisBinds(purpose, repair) &&
+		!citationOpens(type.label, citation)
+	) {
+		return {_tag: "TypeNotBuildable", scope, audience, type};
 	}
-	return {_tag: "Admitted", scope, audience};
+	if (audience._tag === "NotAgent" && audienceAxisBinds(purpose, repair)) {
+		return {_tag: "AudienceNotAgent", scope, audience, type};
+	}
+	return {_tag: "Admitted", scope, audience, type, citation};
 };
 
 /** The word `build pick` reports per excluded issue; `null` for an admitted one. */
 export const exclusionReasonOf = (
 	admission: Admission,
-): "out-of-focus" | "audience-not-agent" | "unreadable" | null => {
+): "out-of-focus" | "audience-not-agent" | "type-not-buildable" | "unreadable" | null => {
 	switch (admission._tag) {
 		case "Admitted":
 			return null;
@@ -382,6 +548,8 @@ export const exclusionReasonOf = (
 			return "out-of-focus";
 		case "AudienceNotAgent":
 			return "audience-not-agent";
+		case "TypeNotBuildable":
+			return "type-not-buildable";
 		default:
 			return "unreadable";
 	}
@@ -409,6 +577,10 @@ export const ADMISSION_EXIT_CODES: ReadonlyArray<{
 			"proven: not admitted on the scope axis — the issue's home is not the declared milestone and no standing-lane label exempts it, or the target is a pull request naming no served issue to judge",
 	},
 	{
+		code: TYPE_NOT_BUILDABLE,
+		condition: `proven: not admitted on the type axis — the issue carries ${DECISION_TYPE_LABEL} or ${EPIC_TYPE_LABEL}, not one of ${BUILDABLE_TYPE_LABELS.join(" / ")}; reachable only under purpose build against an issue, and opened on a decision by --cites naming a founder ruling comment recorded on that issue`,
+	},
+	{
 		code: AUDIENCE_NOT_AGENT,
 		condition: `proven: not admitted on the audience axis — the issue's ${READY_FOR_PREFIX} label is not ${READY_FOR_AGENT}, or is absent; reachable only under purpose build, and never when an open PR serves a ${DECISION_TYPE_LABEL} issue`,
 	},
@@ -431,6 +603,24 @@ export const purposeScopeLine = (
 	return audienceAxisBinds(purpose)
 		? `${verb}: purpose: ${purpose} — the audience axis binds; this issue carries ${carried}.`
 		: `${verb}: purpose: ${purpose} — the audience axis does not bind a ${purpose} claim (#5175); this issue carries ${carried}.`;
+};
+
+/**
+ * The type line, or `null` on the ordinary case where the issue's type is buildable.
+ *
+ * A taken arm is the one thing here nobody may have to infer: when a citation admits a decision, the
+ * comment it points at is printed, so the transcription's authority is on the record beside the
+ * claim rather than only inside whatever the lane later writes.
+ */
+export const typeScopeLine = (
+	verb: string,
+	type: TypeAxis,
+	citation: Citation = NO_CITATION,
+): string | null => {
+	if (type._tag === "Buildable") return null;
+	return citationOpens(type.label, citation) && citation._tag === "Cited"
+		? `${verb}: type: ${type.label} — admitted as transcription of the founder ruling at ${citation.url}; the deliverable is that ruling written down, nothing more.`
+		: `${verb}: type: ${type.label} — the type axis binds a build claim against an issue.`;
 };
 
 /** The scope line both seams print, so an operator sees the fence's state rather than inferring it. */
@@ -474,6 +664,15 @@ export const admissionRefusal = (verb: string, admission: Admission): VerbOutcom
 			return refuse(
 				OUT_OF_FOCUS,
 				`${verb}: no served issue — the declared focus is milestone #${admission.focus} and PR #${admission.pr} ${admission.reason}, so there is no ticket whose home the fence can judge; name the issue in the PR body (a closing keyword or "Part of #<n>"), or claim it with an explicit override.`,
+			);
+		case "TypeNotBuildable":
+			return refuse(
+				TYPE_NOT_BUILDABLE,
+				`${verb}: type not buildable — this issue carries ${admission.type.label}, whose deliverable is not a pull request an agent build lane produces; ${
+					admission.type.label === DECISION_TYPE_LABEL
+						? `a decision is /adr's lane unless the choice is already recorded on it, in which case pass --cites ${CITATION_GRAMMAR} naming that founder ruling comment`
+						: `an epic is plan-epic's lane — claim it with --purpose plan or --purpose gate`
+				}.`,
 			);
 		case "AudienceNotAgent":
 			return refuse(

--- a/packages/fabrika-cli/src/build/scope-admission.unit.test.ts
+++ b/packages/fabrika-cli/src/build/scope-admission.unit.test.ts
@@ -1,7 +1,14 @@
 import {Effect, FileSystem, Layer, Path, PlatformError} from "effect";
 import {describe, expect, it} from "vitest";
 import {fakeFs} from "../fakes.test-support.ts";
-import {AUDIENCE_NOT_AGENT, BAD_SECTIONS, OUT_OF_FOCUS, PRECONDITION_UNKNOWN} from "./codes.ts";
+import {
+	AUDIENCE_NOT_AGENT,
+	BAD_SECTIONS,
+	OUT_OF_FOCUS,
+	PRECONDITION_UNKNOWN,
+	TYPE_NOT_BUILDABLE,
+} from "./codes.ts";
+import {isCandidate} from "./pick-verb.ts";
 import {
 	ADMISSION_EXIT_CODES,
 	type Admission,
@@ -9,18 +16,24 @@ import {
 	admissionRefusal,
 	audienceAxisBinds,
 	audienceAxisOf,
+	BUILDABLE_TYPE_LABELS,
+	type Citation,
 	CLAIM_PURPOSES,
+	citationOpens,
 	DECISION_TYPE_LABEL,
 	DEFAULT_CLAIM_PURPOSE,
 	DEFAULT_ROADMAP,
+	EPIC_TYPE_LABEL,
 	exclusionReasonOf,
 	type Focus,
 	focusReport,
 	focusScopeLine,
 	homeOf,
 	type IssueFacts,
+	NO_CITATION,
 	NOT_REPAIR,
 	noServedIssue,
+	parseCitation,
 	parseClaimPurpose,
 	purposeScopeLine,
 	readDeclaredFocus,
@@ -29,6 +42,9 @@ import {
 	STANDING_LANE_LABELS,
 	scopeAxisOf,
 	scopeSubjectOf,
+	typeAxisBinds,
+	typeAxisOf,
+	typeScopeLine,
 	unknownAdmission,
 } from "./scope-admission.ts";
 
@@ -193,10 +209,21 @@ describe("admissionOf", () => {
 
 		it("defaults to build, so an omitted purpose keeps the fence", () => {
 			expect(DEFAULT_CLAIM_PURPOSE).toBe("build");
-			expect(admissionOf(declared, unlabelled)._tag).toBe("AudienceNotAgent");
-			expect(admissionOf(declared, unlabelled, DEFAULT_CLAIM_PURPOSE)._tag).toBe(
-				"AudienceNotAgent",
-			);
+			// Both fences bind this epic under build; type is reported first (#5490), and the audience
+			// verdict it saw rides along, so neither refusal hides the other.
+			for (const out of [
+				admissionOf(declared, unlabelled),
+				admissionOf(declared, unlabelled, DEFAULT_CLAIM_PURPOSE),
+			]) {
+				expect(out._tag).toBe("TypeNotBuildable");
+				expect(out._tag === "TypeNotBuildable" && out.audience).toEqual({
+					_tag: "NotAgent",
+					label: null,
+				});
+			}
+			// And on a type the type axis admits, the audience fence is still the one that binds.
+			const bug = issue({labels: ["status:triaged", "type:bug"]});
+			expect(admissionOf(declared, bug)._tag).toBe("AudienceNotAgent");
 		});
 
 		for (const purpose of ["plan", "gate"] as const) {
@@ -261,14 +288,18 @@ describe("admissionOf", () => {
 			);
 		});
 
-		it("refuses the same decision issue at 21 with no PR serving it — the other arm", () => {
+		it("refuses the same decision issue with no PR serving it — the other arm, now on type", () => {
+			// It refused at 21 until #5490 seated the type axis: the audience axis did bind, and still
+			// does, but type is read first so the refusal names the objection an operator can act on.
+			// Re-labelling this issue `ready-for:agent` would satisfy 21 and build the wrong artifact.
 			expect(audienceAxisBinds("build", NOT_REPAIR)).toBe(true);
 			const out = admissionOf(declared, decision);
-			expect(out._tag).toBe("AudienceNotAgent");
-			expect(admissionRefusal("build claim", out)?.code).toBe(AUDIENCE_NOT_AGENT);
-			expect(purposeScopeLine("build claim", "build", audienceAxisOf(decision))).toContain(
-				"the audience axis binds",
-			);
+			expect(out._tag).toBe("TypeNotBuildable");
+			expect(admissionRefusal("build claim", out)?.code).toBe(TYPE_NOT_BUILDABLE);
+			expect(out._tag === "TypeNotBuildable" && out.audience).toEqual({
+				_tag: "NotAgent",
+				label: "ready-for:human",
+			});
 		});
 
 		it("exempts the decision type only — an ordinary repair still reads the audience label", () => {
@@ -304,6 +335,147 @@ describe("admissionOf", () => {
 		});
 	});
 
+	/**
+	 * The type axis (#5490). It lived in the pool as a private set, so a number handed straight to
+	 * `claim --purpose build` passed through no pool and met no type check at all.
+	 */
+	describe("the type axis", () => {
+		const decision = issue({
+			labels: ["status:triaged", "type:decision", "ready-for:agent", "axis:pipeline-hardening"],
+			milestone: null,
+		});
+		const epic = issue({labels: ["status:triaged", "type:epic", "ready-for:agent"]});
+		const ruling: Citation = {
+			_tag: "Cited",
+			issue: 1,
+			commentId: 5335398768,
+			url: "https://github.com/kamp-us/phoenix/issues/1#issuecomment-5335398768",
+		};
+
+		it("reads every buildable type as Buildable, and an untyped issue too", () => {
+			for (const label of BUILDABLE_TYPE_LABELS) {
+				expect(typeAxisOf(issue({labels: [label]}))).toEqual({_tag: "Buildable"});
+			}
+			// Deliberately unchanged: the pool has always admitted an untyped issue, and moving where
+			// the rule is enforced must not quietly move what it says. Its own defect, its own ticket.
+			expect(typeAxisOf(issue({labels: ["status:triaged"]}))).toEqual({_tag: "Buildable"});
+		});
+
+		it("names the barred label rather than answering a boolean", () => {
+			expect(typeAxisOf(decision)).toEqual({_tag: "NotBuildable", label: DECISION_TYPE_LABEL});
+			expect(typeAxisOf(epic)).toEqual({_tag: "NotBuildable", label: EPIC_TYPE_LABEL});
+		});
+
+		/**
+		 * #5490's decisive case, read off the live board: a `type:decision` on a standing lane carrying
+		 * `ready-for:agent`. Both older axes admit it — scope by the lane exemption, audience by the
+		 * label — so before the type axis this composed to `Admitted` and a claim marker was written.
+		 */
+		it("refuses the standing-lane decision that both other axes admit", () => {
+			expect(scopeAxisOf(declared, decision)).toEqual({
+				_tag: "LaneExempt",
+				lane: "axis:pipeline-hardening",
+			});
+			expect(audienceAxisOf(decision)).toEqual({_tag: "Agent"});
+			const out = admissionOf(declared, decision);
+			expect(out._tag).toBe("TypeNotBuildable");
+			const refusal = admissionRefusal("build claim", out);
+			expect(refusal?.code).toBe(TYPE_NOT_BUILDABLE);
+			expect(refusal?.stderr[0]).toContain("type not buildable");
+			expect(refusal?.stderr[0]).toContain("--cites");
+			expect(exclusionReasonOf(out)).toBe("type-not-buildable");
+		});
+
+		it("sends an epic to its own skill rather than asking it for a citation", () => {
+			const refusal = admissionRefusal("build claim", admissionOf(declared, epic));
+			expect(refusal?.code).toBe(TYPE_NOT_BUILDABLE);
+			expect(refusal?.stderr[0]).toContain("--purpose plan");
+			expect(refusal?.stderr[0]).not.toContain("--cites");
+		});
+
+		it("binds a fresh build only — plan and gate claims still take an epic", () => {
+			expect(typeAxisBinds("build", NOT_REPAIR)).toBe(true);
+			for (const purpose of ["plan", "gate"] as const) {
+				expect(typeAxisBinds(purpose)).toBe(false);
+				expect(admissionOf(declared, epic, purpose)._tag).toBe("Admitted");
+			}
+		});
+
+		it("does not bind a repair — the PR in flight already answered the question", () => {
+			const served = issue({labels: ["status:triaged", "type:decision", "ready-for:human"]});
+			const repair = repairClaimOf(4703, served);
+			expect(typeAxisBinds("build", repair)).toBe(false);
+			expect(admissionOf(declared, served, DEFAULT_CLAIM_PURPOSE, repair)._tag).toBe("Admitted");
+		});
+
+		it("opens the decision arm on a cited ruling, and never the epic's", () => {
+			expect(citationOpens(DECISION_TYPE_LABEL, ruling)).toBe(true);
+			expect(citationOpens(DECISION_TYPE_LABEL, NO_CITATION)).toBe(false);
+			expect(citationOpens(EPIC_TYPE_LABEL, ruling)).toBe(false);
+			const admitted = admissionOf(declared, decision, "build", NOT_REPAIR, ruling);
+			expect(admitted._tag).toBe("Admitted");
+			expect(admitted._tag === "Admitted" && admitted.citation).toEqual(ruling);
+			expect(admissionOf(declared, epic, "build", NOT_REPAIR, ruling)._tag).toBe(
+				"TypeNotBuildable",
+			);
+		});
+
+		it("prints the cited ruling, so a taken arm is read rather than inferred", () => {
+			expect(typeScopeLine("build claim", typeAxisOf(decision), ruling)).toContain(ruling.url);
+			expect(typeScopeLine("build claim", typeAxisOf(decision))).toContain(
+				"the type axis binds a build claim against an issue",
+			);
+			expect(typeScopeLine("build claim", typeAxisOf(issue()))).toBeNull();
+		});
+
+		it("reports scope before type — the focus row is the first thing to fix", () => {
+			const elsewhere = issue({milestone: 24, labels: ["status:triaged", "type:epic"]});
+			expect(admissionOf(declared, elsewhere)._tag).toBe("OutOfFocus");
+		});
+
+		it("seats 30 in the shared exit table, so a consuming verb's --help lists it", () => {
+			const seat = ADMISSION_EXIT_CODES.find((row) => row.code === TYPE_NOT_BUILDABLE);
+			expect(seat?.condition).toContain(DECISION_TYPE_LABEL);
+			expect(seat?.condition).toContain(EPIC_TYPE_LABEL);
+		});
+
+		/** The whole point of the fix: one predicate, so the two seams cannot disagree (ADR 0245). */
+		it("is the same predicate the pool filters on", () => {
+			for (const candidate of [decision, epic]) {
+				const listed = {...candidate, title: "", body: "", assigned: false, isPullRequest: false};
+				expect(isCandidate(listed)).toBe(false);
+				expect(admissionOf(declared, candidate)._tag).toBe("TypeNotBuildable");
+			}
+		});
+	});
+
+	describe("parseCitation", () => {
+		const url = "https://github.com/kamp-us/phoenix/issues/5879#issuecomment-5335398768";
+
+		it("reads a comment URL that names this repository and this issue", () => {
+			expect(parseCitation(`  ${url}  `, "kamp-us/phoenix", 5879)).toEqual({
+				_tag: "Read",
+				citation: {_tag: "Cited", issue: 5879, commentId: 5335398768, url},
+			});
+		});
+
+		it("refuses a ruling recorded on another issue or in another repository", () => {
+			expect(parseCitation(url, "kamp-us/phoenix", 5490)._tag).toBe("Malformed");
+			expect(parseCitation(url, "kamp-us/other", 5879)._tag).toBe("Malformed");
+		});
+
+		it("refuses anything that is not an issue-comment URL", () => {
+			for (const bad of [
+				"",
+				"yes",
+				"https://github.com/kamp-us/phoenix/issues/5879",
+				"https://github.com/kamp-us/phoenix/pull/5879#issuecomment-1",
+			]) {
+				expect(parseCitation(bad, "kamp-us/phoenix", 5879)._tag).toBe("Malformed");
+			}
+		});
+	});
+
 	it("resolves a malformed declaration to UNKNOWN at 4, never to admitted", () => {
 		const out = admissionOf({_tag: "Malformed", reason: "two data rows"}, issue());
 		expect(out._tag).toBe("Unknown");
@@ -323,9 +495,10 @@ describe("admissionOf", () => {
 			BAD_SECTIONS,
 			PRECONDITION_UNKNOWN,
 			OUT_OF_FOCUS,
+			TYPE_NOT_BUILDABLE,
 			AUDIENCE_NOT_AGENT,
 		]);
-		expect(new Set(ADMISSION_EXIT_CODES.map((row) => row.code)).size).toBe(4);
+		expect(new Set(ADMISSION_EXIT_CODES.map((row) => row.code)).size).toBe(5);
 		expect(ADMISSION_EXIT_CODES.every((row) => row.condition.trim() !== "")).toBe(true);
 	});
 });

--- a/packages/fabrika-cli/src/lane/claim-verb.unit.test.ts
+++ b/packages/fabrika-cli/src/lane/claim-verb.unit.test.ts
@@ -230,6 +230,7 @@ describe("a driver's claim and the builder it spawns", () => {
 					purpose: "build",
 					override: null,
 					overrideLane: null,
+					cites: null,
 				}),
 				fakeShell([
 					[BUILD_ISSUE, claimable],


### PR DESCRIPTION
`build pick` filtered the offered pool on the issue's type label, and `build claim` checked nothing.
A number handed straight to `build claim --purpose build` passes through no pool, so a decision or an
epic reached the claim seam with no type check at all. Where the issue also carried `ready-for:agent`
and a standing-lane label, every existing axis admitted it and a claim marker was written — the live
case triage found on the board was #5129.

This makes the type rule a third axis in the admission test, beside scope and audience:

- The four buildable type labels are declared once, in `scope-admission.ts`. `pick-verb.ts` no longer
  owns a private set the claim path cannot see, and both seams read `typeAxisOf`.
- A build-purpose claim against a decision or an epic refuses on the new code `30`, before any marker
  is written.
- Refusals report scope, then type, then audience. That order is the fix for the second half of the
  defect: a decision reported as `audience-not-agent` sent an operator to re-label it
  `ready-for:agent`, which satisfies that fence and then builds the wrong artifact.
- `--purpose plan` and `--purpose gate` still take an epic, and a repair claim still names a PR — the
  axis binds a fresh build against an issue and nothing else.

**The decision arm.** The founder ruled on
[#5879, comment 5335398768](https://github.com/kamp-us/phoenix/issues/5879#issuecomment-5335398768)
that a decision issue whose choice is already recorded is buildable as transcription. So the type
refusal is not flat: `build claim --cites <ruling-comment-url>` opens it, and the URL must name this
repository and the issue being claimed. The verb checks the pointer's shape and its target and says
plainly that it can check no more — whether that comment rules anything stays the reader's judgement.
An epic has no arm. The citation opens the type axis only, so a `ready-for:human` decision with a
perfect citation is still `21`, which is the constraint the ruling puts on triage rather than on this
verb.

Worth a reviewer's eye: three existing cases asserted `21` for a decision or an epic claimed directly
under build purpose and now assert `30`. Each keeps a sibling case proving `21` is still seated where
the type axis admits the issue.

## Deviations

- **Scope narrowing** — **Said:** #5490's triage note flags a second, pool-side hole — `isCandidate`
  used `.every()` over the issue's type labels, so an issue carrying none at all passes vacuously.
  **Did:** preserved that behaviour exactly. `typeAxisOf` answers `Buildable` for an untyped issue,
  at both seams, and says so in its docblock and a test. **Why:** the issue's own triage note puts
  the untyped hole outside these acceptance criteria and asks for its own ticket; changing where the
  rule is enforced without changing what it says is what kept this diff reviewable.
  **Disposition:** stated here, and named in the code so the next reader does not read it as an
  oversight.
- **Pre-existing test or fixture changed** — **Said:** the criteria ask that the `--purpose plan` and
  `--purpose gate` cases in `claim-verb.unit.test.ts` still pass unchanged, which they do.
  **Did:** also changed four *other* pre-existing cases — three in `claim-verb.unit.test.ts` and one
  in `scope-admission.unit.test.ts` — that asserted `AUDIENCE_NOT_AGENT` for a decision or an epic
  claimed directly under build purpose. **Why:** those are the exact misnamed refusals the issue was
  filed about, so the new code is the assertion; each rewritten case carries a comment saying what it
  asserted before and why, and each gained a sibling case keeping `21` under test on a type the new
  axis admits. **Disposition:** stated here.
- **Out-of-scope change** — **Said:** #5490 names the claim seam. **Did:** also added `cites: null`
  to the `runClaim` fixtures in `packages/fabrika-cli/src/lane/claim-verb.unit.test.ts`. **Why:** the
  new field is required on `ClaimOptions`, and that file constructs one directly.
  **Disposition:** mechanical, stated here.
- **Known defect left unfixed** — **Said:** nothing about the contract's exit matrix. **Did:** seated
  `30` there and left the `24` to `127` gap alone; codes `25`, `26` and `29` exist in `codes.ts` and
  have no row. **Why:** three unrelated rows are a different change.
  **Disposition:** filed as https://github.com/kamp-us/phoenix/issues/6244.
- **Declined guidance** — **Said:** the brief points at #6228, open for #6187, which touches four of
  the same files and adds a new ADR file. **Did:** cited the #5879 ruling comment rather than that
  ADR path, and kept every edit out of #6228's hunks — the `DECISION_TYPE_LABEL` and
  `audienceAxisBinds` docblocks it rewrites are untouched here, the SKILL.md text lands in step 2
  rather than in the step-1 paragraph it rewrites, and the `build pick` filter bullet it amends is
  untouched. The claim-side counterpart the criteria ask for went into the admission-test section
  instead, which #6228 does not touch. **Why:** that ADR is not on main, and two lanes rewriting one
  paragraph is a conflict neither can resolve alone. **Disposition:** stated here. If #6228 lands
  first the two texts agree — its prose arm and this verb's mechanical arm say the same thing.

Fixes #5490
