### PR TITLE
fix: lane prove calls an integrated epic child's DONE unproven, deadlocking the lane

### DIFF
--- a/packages/fabrika-cli/src/io/git.ts
+++ b/packages/fabrika-cli/src/io/git.ts
@@ -399,6 +399,45 @@ export const rangeCommits = (
 		return ok(rows);
 	});
 
+/** One commit and the parents git recorded for it, in git's own order — `^1` first. */
+export interface ParentedCommit {
+	readonly sha: string;
+	readonly parents: ReadonlyArray<string>;
+}
+
+/**
+ * The commits between `base` and `tip` that descend from `base`, each with its parents, newest
+ * first.
+ *
+ * `--ancestry-path` because the question is what happened *to* `base` on the way to `tip`, not what
+ * else landed alongside it: the walk is then the few commits `base` flows through, and the merge
+ * that integrated it is one of them.
+ */
+export const rangeParents = (
+	base: string,
+	tip: string,
+): Shell<Attempt<ReadonlyArray<ParentedCommit>>> =>
+	Effect.gen(function* () {
+		const r = yield* execCapture("git", [
+			"rev-list",
+			"--parents",
+			"--ancestry-path",
+			`${base}..${tip}`,
+		]);
+		if (!r.ok) return fail(r.reason);
+		const rows: ParentedCommit[] = [];
+		for (const line of r.stdout.split("\n")) {
+			if (line.trim() === "") continue;
+			const names = line.trim().split(/\s+/);
+			const [sha, ...parents] = names;
+			if (sha === undefined || !names.every(isObjectName)) {
+				return fail(`unreadable rev-list row "${line.trim().slice(0, 80)}"`);
+			}
+			rows.push({sha, parents});
+		}
+		return ok(rows);
+	});
+
 /** The merge base of two commits, as a full object name. */
 export const mergeBase = (a: string, b: string): Shell<Attempt<string>> =>
 	Effect.gen(function* () {

--- a/packages/fabrika-cli/src/lane/brief-verb.unit.test.ts
+++ b/packages/fabrika-cli/src/lane/brief-verb.unit.test.ts
@@ -108,6 +108,8 @@ const locating = (
 	[REV("epic/5800"), okOut(`${EPIC_BASE}\n`)],
 	[/^git rev-parse --verify --quiet build\//, okOut(`${CHILD_TIP}\n`)],
 	[BRANCHES, okOut(`${branches.join("\n")}\n`)],
+	// The child is not integrated here, so its fork point is where the epic branch stands.
+	[/^git merge-base /, okOut(`${EPIC_BASE}\n`)],
 	[LOG_RANGE, logOf(...commits)],
 ];
 

--- a/packages/fabrika-cli/src/lane/prove-verb.ts
+++ b/packages/fabrika-cli/src/lane/prove-verb.ts
@@ -572,7 +572,7 @@ const proveRangeVerdicts = (
 	Effect.gen(function* () {
 		const read = yield* located(epic, issue);
 		if (read._tag === "Refused") return read.outcome;
-		const range = `${read.range.baseRef}..${read.range.branch}`;
+		const range = `${read.range.base}..${read.range.tip}`;
 
 		const content = yield* rangeContentAt({base: read.range.base, tip: read.range.tip});
 		if (content._tag === "Failure") {

--- a/packages/fabrika-cli/src/lane/prove-verb.unit.test.ts
+++ b/packages/fabrika-cli/src/lane/prove-verb.unit.test.ts
@@ -544,6 +544,8 @@ const REV = (rev: string) =>
 	new RegExp(`^git rev-parse --verify --quiet ${literally(rev)}\\^\\{commit\\}$`);
 const BRANCHES = /^git for-each-ref --format=%\(refname:short\) refs\/heads$/;
 const LOG_RANGE = /^git log --format=/;
+const MERGE_BASE = /^git merge-base /;
+const ANCESTRY = /^git rev-list --parents --ancestry-path /;
 const RAW = /^git diff .* --raw --abbrev=40 -z /;
 const CHILD_COMMENTS = /^gh api --paginate repos\/o\/r\/issues\/4301\/comments/;
 
@@ -575,8 +577,20 @@ const locating = (
 	[BRANCHES, okOut(`${branches.join("\n")}\n`)],
 	[REV(CHILD_BRANCH), okOut(`${CHILD_TIP}\n`)],
 	[/^git rev-parse --verify --quiet build\//, okOut(`${CHILD_TIP}\n`)],
+	// The child is not integrated here, so the fork point is where the epic branch stands.
+	[MERGE_BASE, okOut(`${EPIC_BASE}\n`)],
 	[LOG_RANGE, logOf(...commits)],
 ];
+
+/** A 40-hex object name from a short seed, so a fixture SHA reads as the thing it stands for. */
+const sha = (seed: string): string => seed.repeat(40).slice(0, 40);
+
+/** Where the child branch left the epic branch — the base its reviewer was handed. */
+const FORK = sha("664eb9dc");
+/** The epic branch after a sibling, and then this child, landed on it. */
+const EPIC_MOVED = sha("ec3894d3");
+/** The epic branch as it stood the instant before this child's integrating merge. */
+const EPIC_BEFORE = sha("d67022dc");
 
 const rangeMarker = (
 	polarity: "PASS" | "FAIL",
@@ -628,6 +642,46 @@ describe("lane prove — an epic child's DONE stands on commits, never on a PR",
 		expect(out.stderr.join("\n")).toContain("adds 2 commit(s), 1 of them naming #4301");
 	});
 
+	it("proves a child DONE after its commits have landed on the epic branch", async () => {
+		// The merge base of a contained tip IS that tip, so the range only survives integration if the
+		// verb recovers the epic branch as it stood before the merge that took the child in (#5984).
+		const shell = fakeShell([
+			[REV("epic/4300"), okOut(`${EPIC_MOVED}\n`)],
+			[BRANCHES, okOut(`${CHILD_BRANCH}\n`)],
+			[/^git rev-parse --verify --quiet build\//, okOut(`${CHILD_TIP}\n`)],
+			[new RegExp(`^git merge-base ${EPIC_MOVED} ${CHILD_TIP}$`), okOut(`${CHILD_TIP}\n`)],
+			[ANCESTRY, okOut(`${EPIC_MOVED} ${EPIC_BEFORE} ${CHILD_TIP}\n`)],
+			[new RegExp(`^git merge-base ${EPIC_BEFORE} ${CHILD_TIP}$`), okOut(`${FORK}\n`)],
+			[LOG_RANGE, logOf([CHILD_TIP, CHILD_MESSAGE])],
+		]);
+
+		const out = await runEpic(epicLaneAt("build"), shell, "DONE", "issue_4301");
+
+		expect(out.code).toBe(0);
+		expect(JSON.parse(out.stdout).evidence).toMatchObject({
+			range: {base: FORK, tip: CHILD_TIP},
+			commits: 1,
+			naming: 1,
+		});
+	});
+
+	it("measures a not-yet-integrated child over its fork point, not over the moved epic tip", async () => {
+		const shell = fakeShell([
+			[REV("epic/4300"), okOut(`${EPIC_MOVED}\n`)],
+			[BRANCHES, okOut(`${CHILD_BRANCH}\n`)],
+			[/^git rev-parse --verify --quiet build\//, okOut(`${CHILD_TIP}\n`)],
+			[MERGE_BASE, okOut(`${FORK}\n`)],
+			[LOG_RANGE, logOf([CHILD_TIP, CHILD_MESSAGE])],
+		]);
+
+		const out = await runEpic(epicLaneAt("build"), shell, "DONE", "issue_4301");
+
+		expect(out.code).toBe(0);
+		expect(JSON.parse(out.stdout).evidence).toMatchObject({range: {base: FORK, tip: CHILD_TIP}});
+		expect(shell.calls.some((line) => line.includes(`${FORK}..${CHILD_TIP}`))).toBe(true);
+		expect(shell.calls.some((line) => ANCESTRY.test(line))).toBe(false);
+	});
+
 	it("refuses a child DONE whose branch was cut and never built on", async () => {
 		const shell = fakeShell([...locating([CHILD_BRANCH], [])]);
 
@@ -636,6 +690,27 @@ describe("lane prove — an epic child's DONE stands on commits, never on a PR",
 		expect(out.code).toBe(PROOF_ABSENT);
 		expect(out.stdout).toBe("");
 		expect(out.stderr.join("\n")).toContain("cut and not built on");
+	});
+
+	it("still refuses a never-built branch whose tip a sibling's merge names as first parent", async () => {
+		// The tip is an epic commit, so it is contained and a later merge names it — as its FIRST
+		// parent. Reading the second there would hand back a sibling's fork point and prove nothing.
+		const shell = fakeShell([
+			[REV("epic/4300"), okOut(`${EPIC_MOVED}\n`)],
+			[BRANCHES, okOut(`${CHILD_BRANCH}\n`)],
+			[/^git rev-parse --verify --quiet build\//, okOut(`${CHILD_TIP}\n`)],
+			[new RegExp(`^git merge-base ${EPIC_MOVED} ${CHILD_TIP}$`), okOut(`${CHILD_TIP}\n`)],
+			[ANCESTRY, okOut(`${EPIC_MOVED} ${CHILD_TIP} ${sha("5b1b1a9c")}\n`)],
+			[LOG_RANGE, logOf()],
+		]);
+
+		const out = await runEpic(epicLaneAt("build"), shell, "DONE", "issue_4301");
+
+		expect(out.code).toBe(PROOF_ABSENT);
+		expect(out.stderr.join("\n")).toContain("cut and not built on");
+		expect(shell.calls.some((line) => line.startsWith(`git merge-base ${sha("5b1b1a9c")}`))).toBe(
+			false,
+		);
 	});
 
 	it("refuses a child DONE when the branch carries only another child's commits", async () => {
@@ -654,6 +729,7 @@ describe("lane prove — an epic child's DONE stands on commits, never on a PR",
 			[REV("epic/4300"), okOut(`${EPIC_BASE}\n`)],
 			[BRANCHES, okOut(`${CHILD_BRANCH}\nbuild/4301-second-try-deadbeef\n`)],
 			[/^git rev-parse --verify --quiet build\//, okOut(`${CHILD_TIP}\n`)],
+			[MERGE_BASE, okOut(`${EPIC_BASE}\n`)],
 			[LOG_RANGE, logOf([CHILD_TIP, CHILD_MESSAGE])],
 		]);
 
@@ -722,6 +798,31 @@ describe("lane prove — an epic child's PASS stands on a range verdict that sti
 			issue: 4301,
 			evidence: {kind: "range-verdicts", epic: 4300, content: CHILD_DIGEST},
 		});
+	});
+
+	it("digests the range the reviewer measured once the child has been integrated", async () => {
+		// The binding is content and only content (ADR 0276), so an integrated child's PASS reads
+		// `Current` only while prove diffs the same two endpoints the marker was posted over (#5984).
+		const shell = fakeShell([
+			[REV("epic/4300"), okOut(`${EPIC_MOVED}\n`)],
+			[BRANCHES, okOut(`${CHILD_BRANCH}\n`)],
+			[/^git rev-parse --verify --quiet build\//, okOut(`${CHILD_TIP}\n`)],
+			[new RegExp(`^git merge-base ${EPIC_MOVED} ${CHILD_TIP}$`), okOut(`${CHILD_TIP}\n`)],
+			[ANCESTRY, okOut(`${EPIC_MOVED} ${EPIC_BEFORE} ${CHILD_TIP}\n`)],
+			[new RegExp(`^git merge-base ${EPIC_BEFORE} ${CHILD_TIP}$`), okOut(`${FORK}\n`)],
+			[LOG_RANGE, logOf([CHILD_TIP, CHILD_MESSAGE])],
+			[RAW, okOut(CHILD_RAW)],
+			[CHILD_COMMENTS, comments_([{id: 1, body: rangeMarker("PASS", CHILD_DIGEST)}])],
+		]);
+
+		const out = await runEpic(epicLaneAt("review"), shell, "PASS", "issue_4301");
+
+		expect(out.code).toBe(0);
+		expect(JSON.parse(out.stdout).evidence).toMatchObject({
+			range: {base: FORK, tip: CHILD_TIP},
+			content: CHILD_DIGEST,
+		});
+		expect(shell.calls.some((line) => RAW.test(line) && line.includes(FORK))).toBe(true);
 	});
 
 	it("refuses a child PASS with no verdict at all on the child issue", async () => {

--- a/packages/fabrika-cli/src/lane/prove.ts
+++ b/packages/fabrika-cli/src/lane/prove.ts
@@ -26,6 +26,7 @@
 
 import {issueRefsIn} from "../build/commit-message.ts";
 import {parseLaneBranch} from "../build/lane.ts";
+import type {ParentedCommit} from "../io/git.ts";
 
 /** The leaf state a builder runs in — a `DONE` out of it claims the built work exists. */
 export const BUILD_STATE = "build";
@@ -103,19 +104,46 @@ export const issueOf = (taskId: string, lane: string): number | null => {
 	return /^\d+$/.test(key) ? Number.parseInt(key, 10) : null;
 };
 
-/** One local branch, with the commits it adds over the epic branch already read off the tree. */
+/** One local branch, with the commits it adds over its own fork point already read off the tree. */
 export interface BranchFact {
 	readonly branch: string;
+	/** Where this branch left the epic branch — the near end of the range, as an object name. */
+	readonly base: string;
 	/** The branch tip as an object name — what a range read is taken against, never the ref name. */
 	readonly tip: string;
 	/** Every message the range adds, whole. Empty where the branch adds nothing. */
 	readonly messages: ReadonlyArray<string>;
 }
 
+/**
+ * The epic-side commit the merge that integrated `tip` joined it to — `null` where nothing did.
+ *
+ * A child lands on the assembly branch as `git merge --no-ff <child>` run *from* the epic branch, so
+ * the child's tip is that merge's second parent and the epic branch as it stood is the first.
+ * Reading the first parent — never merely "the parent that is not the tip" — is what keeps a branch
+ * that was cut and never built on out of this arm: its tip IS an epic commit, so it turns up as some
+ * later merge's *first* parent, and answering with that merge's second parent would hand back a
+ * sibling's fork point and dress an empty range up as work.
+ *
+ * Oldest match wins: a tip merged twice still forked once, and the first landing is where.
+ */
+export const integratedFrom = (tip: string, rows: ReadonlyArray<ParentedCommit>): string | null => {
+	let joined: string | null = null;
+	// `rows` is newest-first, so the last match is the oldest merge that took this tip in.
+	for (const row of rows) {
+		const [first, ...rest] = row.parents;
+		if (first === undefined || first === tip || !rest.includes(tip)) continue;
+		joined = first;
+	}
+	return joined;
+};
+
 export type RangeTrace =
 	| {
 			readonly _tag: "One";
 			readonly branch: string;
+			/** Where the branch forked from the epic branch — the range's near end. */
+			readonly base: string;
 			readonly tip: string;
 			/** Every commit the range adds — the artifact's size. */
 			readonly commits: number;
@@ -161,6 +189,7 @@ export const traceRange = (
 			? {
 					_tag: "One",
 					branch: first.branch,
+					base: first.base,
 					tip: first.tip,
 					commits: first.messages.length,
 					naming: first.messages.filter((message) => issueRefsIn(message).includes(issue)).length,

--- a/packages/fabrika-cli/src/lane/prove.unit.test.ts
+++ b/packages/fabrika-cli/src/lane/prove.unit.test.ts
@@ -4,6 +4,7 @@ import {
 	claimOf,
 	epicOf,
 	foldNamespaces,
+	integratedFrom,
 	issueOf,
 	judgeVerdicts,
 	roleOf,
@@ -93,10 +94,40 @@ describe("childLaneBranches", () => {
 	});
 });
 
+describe("integratedFrom", () => {
+	const TIP = "4cca8326";
+	const EPIC_BEFORE = "ec3894d2";
+
+	it("reads the epic branch as it stood off the integrating merge's first parent", () => {
+		expect(
+			integratedFrom(TIP, [
+				{sha: "aaaa1111", parents: ["ec3894d3", "sibling1"]},
+				{sha: "ec3894d3", parents: [EPIC_BEFORE, TIP]},
+			]),
+		).toBe(EPIC_BEFORE);
+	});
+
+	it("answers nothing for a tip no merge took in — a branch cut and never built on", () => {
+		// The never-built tip IS an epic commit, so a later sibling merge names it as its FIRST
+		// parent. Answering with that merge's second parent would hand back a sibling's fork point.
+		expect(integratedFrom(TIP, [{sha: "aaaa1111", parents: [TIP, "sibling1"]}])).toBe(null);
+	});
+
+	it("takes the oldest merge when a tip was taken in twice", () => {
+		expect(
+			integratedFrom(TIP, [
+				{sha: "bbbb2222", parents: ["later", TIP]},
+				{sha: "ec3894d3", parents: [EPIC_BEFORE, TIP]},
+			]),
+		).toBe(EPIC_BEFORE);
+	});
+});
+
 describe("traceRange", () => {
 	const commit = (issue: number) => `feat(lane): do the thing (#${issue})`;
 	const carrying = {
 		branch: "build/5829-prove-range-arms-154c981b",
+		base: "664eb9d",
 		tip: "03135b9",
 		messages: [commit(5829)],
 	};
@@ -105,6 +136,7 @@ describe("traceRange", () => {
 		expect(traceRange(5829, "epic/5800", [carrying])).toEqual({
 			_tag: "One",
 			branch: carrying.branch,
+			base: "664eb9d",
 			tip: "03135b9",
 			commits: 1,
 			naming: 1,
@@ -119,6 +151,7 @@ describe("traceRange", () => {
 		expect(traceRange(5829, "epic/5800", [mixed])).toEqual({
 			_tag: "One",
 			branch: carrying.branch,
+			base: "664eb9d",
 			tip: "03135b9",
 			commits: 3,
 			naming: 1,

--- a/packages/fabrika-cli/src/lane/range.ts
+++ b/packages/fabrika-cli/src/lane/range.ts
@@ -16,15 +16,23 @@
 
 import {Effect} from "effect";
 import type {ChildProcessSpawner} from "effect/unstable/process";
-import {localBranches, rangeCommits, resolveCommit} from "../io/git.ts";
+import {
+	type Attempt,
+	localBranches,
+	mergeBase,
+	ok,
+	rangeCommits,
+	rangeParents,
+	resolveCommit,
+	type Shell,
+} from "../io/git.ts";
 import {epicBranch} from "../wire/lane-brief.ts";
-import {type BranchFact, childLaneBranches, traceRange} from "./prove.ts";
+import {type BranchFact, childLaneBranches, integratedFrom, traceRange} from "./prove.ts";
 
 /** The located range: the branch it was read off, and the two commits that bound it. */
 export interface ChildRange {
 	readonly branch: string;
-	/** The epic branch's own ref name, so a diagnostic names a range a human can re-run. */
-	readonly baseRef: string;
+	/** Where the branch forked from the epic branch — never that branch's tip. See {@link forkPoint}. */
 	readonly base: string;
 	readonly tip: string;
 	/** Every commit the range adds — the artifact's size. */
@@ -46,6 +54,32 @@ export type RangeLocation =
 	| {readonly _tag: "Absent"; readonly why: string; readonly notes: ReadonlyArray<string>}
 	| {readonly _tag: "Ambiguous"; readonly why: string; readonly notes: ReadonlyArray<string>}
 	| {readonly _tag: "Unreadable"; readonly what: string; readonly reason: string};
+
+/**
+ * Where `tip` left the assembly branch — the near end of the range its reviewer measured.
+ *
+ * Not `epic/<n>`'s tip. That tip moves under every child as its siblings land, and once this child's
+ * own commits land on it the `epic/<n>..branch` range empties, which reads as "cut and never built
+ * on" and deadlocks the lane (#5984). The fork point survives both: the commits stay the same
+ * through the drift, and the diff the digest is taken over stays the diff the verdict was bound to
+ * (ADR 0276), so `bindRange` still answers `Current` after integration.
+ *
+ * Two reads, because the merge base alone stops answering the moment the tip is contained in the
+ * epic branch — it is then the tip itself. The second read recovers the epic branch as it stood
+ * before the merge that brought the tip in, and takes the merge base against that.
+ */
+const forkPoint = (epicTip: string, tip: string): Shell<Attempt<string>> =>
+	Effect.gen(function* () {
+		const shared = yield* mergeBase(epicTip, tip);
+		if (shared._tag === "Failure" || shared.value !== tip) return shared;
+		const walked = yield* rangeParents(tip, epicTip);
+		if (walked._tag === "Failure") return walked;
+		const before = integratedFrom(tip, walked.value);
+		// Nothing merged this tip in, so it is a commit of the assembly branch itself: it forked from
+		// itself, the range is empty, and `traceRange` says cut-and-never-built-on in those words.
+		if (before === null) return ok(tip);
+		return yield* mergeBase(before, tip);
+	});
 
 export const locateRange = (
 	verb: string,
@@ -73,15 +107,28 @@ export const locateRange = (
 			if (tip._tag === "Failure") {
 				return {_tag: "Unreadable" as const, what: `branch "${branch}"`, reason: tip.reason};
 			}
-			const walked = yield* rangeCommits(base.value, tip.value);
+			const forked = yield* forkPoint(base.value, tip.value);
+			if (forked._tag === "Failure") {
+				return {
+					_tag: "Unreadable" as const,
+					what: `where "${branch}" forked from ${baseRef}`,
+					reason: forked.reason,
+				};
+			}
+			const walked = yield* rangeCommits(forked.value, tip.value);
 			if (walked._tag === "Failure") {
 				return {
 					_tag: "Unreadable" as const,
-					what: `the commits "${branch}" adds over ${baseRef}`,
+					what: `the commits "${branch}" adds over ${forked.value}`,
 					reason: walked.reason,
 				};
 			}
-			facts.push({branch, tip: tip.value, messages: walked.value.map((row) => row.message)});
+			facts.push({
+				branch,
+				base: forked.value,
+				tip: tip.value,
+				messages: walked.value.map((row) => row.message),
+			});
 		}
 
 		const notes = [
@@ -100,15 +147,14 @@ export const locateRange = (
 			_tag: "Located" as const,
 			range: {
 				branch: trace.branch,
-				baseRef,
-				base: base.value,
+				base: trace.base,
 				tip: trace.tip,
 				commits: trace.commits,
 				naming: trace.naming,
 			},
 			notes: [
 				...notes,
-				`${verb}: ${baseRef}..${trace.branch} adds ${trace.commits} commit(s), ${trace.naming} of them naming #${issue}.`,
+				`${verb}: ${trace.branch} forked ${baseRef} at ${trace.base} and adds ${trace.commits} commit(s), ${trace.naming} of them naming #${issue}.`,
 			],
 		};
 	});


### PR DESCRIPTION
`fabrika lane prove <epic> DONE --task issue_<child>` measured a child's work as
the commits its branch adds over the **current tip** of `epic/<n>`. That tip
moves under every child, so the range was wrong twice:

- once a sibling landed, the base drifted off the point the child forked from, so
  the content digest no longer matched the one the reviewer's verdict was bound
  to and a live PASS read `stale`;
- once the child's own commits landed, the range emptied outright, `traceRange`
  read that as "the branch was cut and not built on", and the `DONE` refused at
  exit 22 — the state lane 5894 has been stuck in.

The base is now the fork point, which survives both. `locateRange` takes the
merge base of the epic branch and the branch tip; when the tip is already
contained in the epic branch the merge base *is* the tip and says nothing, so it
recovers the epic branch as it stood before the integrating merge (that merge's
first parent) and takes the merge base against that. A branch nothing merged in
is a commit of the epic branch itself, forks from itself, and still refuses with
the same words.

I took the tree route rather than reading the base off the verdict marker: the
`DONE` proof runs before any verdict exists, and `lane brief` shares this
function to hand the reviewer its endpoints before review has run at all. So no
claim ever chooses the range that proves it, and the criterion about validating a
marker-supplied base does not arise.

Reading the integrating merge's **first** parent is load-bearing: a branch cut
and never built on has an epic commit for a tip, so a later sibling merge names
it — as its first parent. Taking "the parent that is not the tip" there would
hand back a sibling's fork point and dress an empty range up as work.

Verified live against lane 5894 on a scratch copy of its ledger, with the fix in
this tree: both children's `DONE` proofs now exit 0, `#5965`'s range resolves to
`664eb9dc..4cca8326` — the range its surviving verdicts name — and
`rangeContentAt` over it digests to `45000a6fe675`, the value those markers carry.

Fixes #5984

## Deviations

None.
