### PR TITLE
chore: The known-park/novel-park autonomy split has no decision record

### DIFF
--- a/.decisions/0297-frozen-is-a-park-not-an-end.md
+++ b/.decisions/0297-frozen-is-a-park-not-an-end.md
@@ -1,7 +1,7 @@
 ---
 id: 0297
 title: A lane task's `frozen` is a park with a door out, and the door hands out no retries
-status: accepted
+status: amended-in-part by [0301](0301-known-parks-clear-novel-routes-human.md)
 date: 2026-08-18
 tags: [fabrika, lane, pipeline, state-machine]
 ---

--- a/.decisions/0301-known-parks-clear-novel-routes-human.md
+++ b/.decisions/0301-known-parks-clear-novel-routes-human.md
@@ -1,0 +1,103 @@
+---
+id: 0301
+title: Only a registered recipe proven by a re-fold clears a lane park without a human
+status: accepted
+date: 2026-08-19
+tags: [fabrika, lane, pipeline, recipes, agents]
+---
+
+# 0301 — Only a registered recipe proven by a re-fold clears a lane park without a human
+
+**What this decides:** a parked lane gets out on its own only when a recipe table already names that
+exact park and a second fold proves the task left it. Every other park goes to a person through a
+cell in the machine. No agent ever judges a park clear.
+
+## Context
+
+A lane task parks at `blocked` or at any `human:*` state, and until 2026-08-16 the rule was flat: a
+human records the `UNBLOCKED` that walks it out, and the operator never records one. Epic
+[#5840](https://github.com/kamp-us/phoenix/issues/5840) put the flat rule to the founder in a grill,
+and he qualified it — the answer is recorded verbatim on
+[#5840, comment 5311487661](https://github.com/kamp-us/phoenix/issues/5840#issuecomment-5311487661)
+("yes, autonomous on known recipes"), with the escalation half on
+[comment 5311537313](https://github.com/kamp-us/phoenix/issues/5840#issuecomment-5311537313)
+(a novel park goes to the driver first, and to the founder only when it is decision-shaped).
+
+That ruling shipped as code under #5847 and #5848 and has governed real machine behaviour since. It
+was never written to `.decisions/`, so the only written authority was skill prose plus an epic body
+that closes when the epic does. The corpus had 0228 (a script relays, never derives), 0231 (logic
+that computes a decision becomes a verb) and 0283 (the local ledger holds ownable orderings) — verb
+shape and ledger placement, none of them about who may clear a park.
+
+This record is a transcription of the founder ruling above, entered under ADR
+[0300](0300-a-cited-ruling-makes-a-decision-buildable.md)'s citation arm, not a fresh decision.
+
+**It amends ADR [0297](0297-frozen-is-a-park-not-an-end.md) in part.** 0297 landed after the grill
+and restated the flat form as a binding constraint — "clearing a park stays a human's event, as it
+already is for `blocked` and `human:*`". Everything else in 0297 stands: `frozen` is still a park
+with a door out, the door still hands out no retries, and the operator still records no `UNBLOCKED`.
+What narrows is the actor list, which was already narrower in the tree than 0297's sentence read.
+
+## Decision
+
+**A park clears without a human only when a registered recipe classifies it and a re-fold proves the
+clear; everything else routes to a person through a cell in the machine, never through an agent's
+judgement.**
+
+The split is data, not reasoning. `KNOWN_PARKS` in
+[`packages/fabrika-cli/src/recipe/parks.ts`](../packages/fabrika-cli/src/recipe/parks.ts) is a
+literal table of park states, one row per park a fixed fix exists for, and `classifyPark` returns
+`Known` only on a row it finds. A park with no row is `Novel` — including a bare `blocked`, which
+records the event and not the cause, so nothing keys on it.
+
+**The refuse-before-any-write ordering is the load-bearing part.**
+[`packages/fabrika-cli/src/recipe/unpark-verb.ts`](../packages/fabrika-cli/src/recipe/unpark-verb.ts)
+seats the leaf against the table as step 2 of five, before it reads any clearance and long before it
+appends anything. A novel park therefore exits `PARK_NOVEL` with the ledger untouched, so the refusal
+is a proven no-op rather than a claim about one. On the other side, the verb emits nothing until step
+5 re-folds the ledger and reads the task out of the park; an `UNBLOCKED` appended without that proof
+is a fail-loud, not a success.
+
+Those two ends are what make the autonomy safe, and they are what a future widening has to argue
+against. "If a known park may clear itself, why not a known FAIL" is the shape to expect: the answer
+is that a park names one blocked state with one enumerated cause and one read that proves the cause
+gone, while a FAIL is a verdict about content with no such read. Widening this needs a table row and
+a proving read, not an analogy.
+
+The novel side is a machine cell, not a message.
+[`packages/fabrika-cli/src/lane/templates/chore.workflow.json`](../packages/fabrika-cli/src/lane/templates/chore.workflow.json)
+routes every `PARK_SWEEP.BLOCKED` to `human:novel-park`, and only a `PARK_SWEEP.UNBLOCKED` leaves it.
+A human's clear is a recorded transition, so it sits in the ledger and survives the session.
+
+**Binding constraints.**
+
+- The exception belongs to a recipe verb, never to the operator. `operate` records no `UNBLOCKED`
+  anywhere; it relays `recipe unpark`'s exit into the chore lane's event. ADR 0297's constraint holds
+  for the operator unchanged.
+- A park is `Known` only by a row in `KNOWN_PARKS`. Reasoning that a park resembles a known one, or
+  that its cause looks gone, is not a classification.
+- Classification refuses before any write. A verb that reads a clearance, or appends, before it has
+  seated the park against the table is not implementing this decision.
+- No clear is reported without a re-fold proving it. An unproven append is a fail-loud that hands the
+  lane to a human.
+- Every other park routes to a human through a state in the machine, reachable only by a recorded
+  `UNBLOCKED`.
+
+## Consequences
+
+The parks worth automating are the ones somebody enumerated, which is deliberate friction: adding an
+autonomous clear means adding a row and the read that proves it, in a file a reviewer reads as data.
+Today that table holds exactly one row, `human:cp-approval`, whose read is `ship cp-approval`'s own
+discharge table (ADR [0175](0175-cp-self-approval-cardinality-check.md)) relayed rather than
+re-derived.
+
+The cost is that a bare `blocked` can never clear autonomously, however obvious its cause looks in a
+comment. That is the honest position — the ledger records the event, not the cause — and the remedy
+is a park state that names its cause, not a smarter reader.
+
+## Records
+
+`known park` and `novel park` are named here for the corpus. They are not added to
+`.glossary/TERMS.md` in this PR: the glossary's existing `park / expiry` row carries the
+roadmap-appetite sense, and disambiguating two senses of one noun is `/glossary`'s call, not this
+record's. Routed there with a follow-up filed.

--- a/claude-plugins/fabrika/skills/operate/SKILL.md
+++ b/claude-plugins/fabrika/skills/operate/SKILL.md
@@ -523,9 +523,10 @@ and the who to the parking spawn's report. Clearing a park is a
 human's `UNBLOCKED`, recorded through the same `lane transition` verb — you never record
 `UNBLOCKED`. One exception, and it is still not yours: on a **known** park a recipe verb owns,
 `recipe unpark` records that lane's `UNBLOCKED` itself, and only after a re-fold proves the task
-left the park (#5848, on the founder's grill answer for epic #5840 — known clears autonomously,
-novel routes to a human). You relay that verb's exit into the chore lane's own event and type no
-`UNBLOCKED` anywhere.
+left the park. The rule and its actor list are ADR
+[0301](../../../../.decisions/0301-known-parks-clear-novel-routes-human.md)'s, which amends ADR 0297
+in part — this section states no park-clearing authority of its own. You relay that verb's exit into
+the chore lane's own event and type no `UNBLOCKED` anywhere.
 
 A chore lane has **no driven issue** — that is what a chore is — so a park it holds has nowhere to
 be commented. Report it to your caller instead, in the terminal line: the chore key, the state the


### PR DESCRIPTION
Records the known-park/novel-park autonomy split as ADR 0301. The rule has governed shipped machine
behaviour since #5847/#5848, but the only written authority was skill prose plus epic #5840's body —
a surface that disappears when the epic closes.

The ruling this transcribes is the founder's, recorded on
[#5840, comment 5311487661](https://github.com/kamp-us/phoenix/issues/5840#issuecomment-5311487661)
("yes, autonomous on known recipes"), with the escalation half on
[comment 5311537313](https://github.com/kamp-us/phoenix/issues/5840#issuecomment-5311537313). Both
URLs are named inside the ADR itself, per ADR 0300's citation arm.

Three files:

- `.decisions/0301-known-parks-clear-novel-routes-human.md` — the record. It names the
  refuse-before-any-write ordering in `recipe unpark` as the load-bearing part, and answers the
  widening argument to expect ("if a known park may clear, why not a known FAIL") with the concrete
  difference: a park has one enumerated cause and one read that proves it gone; a FAIL has neither.
  It cites the three enforcing paths — `recipe/parks.ts`, `recipe/unpark-verb.ts`,
  `lane/templates/chore.workflow.json`.
- `.decisions/0297-frozen-is-a-park-not-an-end.md` — status line only, via `adr amend-in-part`. 0297
  landed after the 2026-08-16 grill and restated the flat "clearing a park stays a human's event"
  as a binding constraint. 0301 narrows the actor list; everything else in 0297 stands.
- `claude-plugins/fabrika/skills/operate/SKILL.md` — the park paragraph now points at 0301 instead of
  being the only written authority. The operator's rule is unchanged: it records no `UNBLOCKED`.

Reviewer: read the ADR's `## Decision` against `packages/fabrika-cli/src/recipe/unpark-verb.ts`'s
five-step docblock. The ordering claim is the one thing worth checking against source.

Fixes #5879

## Deviations

- **Declined guidance** — **Said:** ADR 0300's citation arm reads as a founder ruling comment
  recorded on *that issue*, and #5879's own ruling comment (5335398768) is the routing ruling 0300
  already records, not the park split. **Did:** cited the park-split ruling comments on epic #5840
  instead, which #5879's body names as its source. **Why:** the fence exists so a builder points at a
  recorded ruling rather than judging one settled; the #5840 comments carry the founder's verbatim
  answer, and the issue body names them. **Disposition:** stated here and inside the ADR, where
  `review diff` serves it.
- **Scope narrowing** — **Said:** `/adr` step 5 routes a coined term to `.glossary/TERMS.md` in this
  PR when the definition is short and unambiguous. **Did:** left `known park` / `novel park` out of
  the glossary and routed them to `/glossary`. **Why:** TERMS.md's existing `park / expiry` row is
  the roadmap-appetite sense, so a lane park needs disambiguating two senses of one noun — not a
  short unambiguous row, and outside this issue's criteria. **Disposition:** stated in the ADR's
  `## Records`, follow-up filed.
