### PR TITLE
Renumber the second ADR 0301 to 0302

### DIFF
--- a/.decisions/0297-frozen-is-a-park-not-an-end.md
+++ b/.decisions/0297-frozen-is-a-park-not-an-end.md
@@ -1,7 +1,7 @@
 ---
 id: 0297
 title: A lane task's `frozen` is a park with a door out, and the door hands out no retries
-status: amended-in-part by [0301](0301-known-parks-clear-novel-routes-human.md)
+status: amended-in-part by [0302](0302-known-parks-clear-novel-routes-human.md)
 date: 2026-08-18
 tags: [fabrika, lane, pipeline, state-machine]
 ---

--- a/.decisions/0302-known-parks-clear-novel-routes-human.md
+++ b/.decisions/0302-known-parks-clear-novel-routes-human.md
@@ -1,12 +1,12 @@
 ---
-id: 0301
+id: 0302
 title: Only a registered recipe proven by a re-fold clears a lane park without a human
 status: accepted
 date: 2026-08-19
 tags: [fabrika, lane, pipeline, recipes, agents]
 ---
 
-# 0301 — Only a registered recipe proven by a re-fold clears a lane park without a human
+# 0302 — Only a registered recipe proven by a re-fold clears a lane park without a human
 
 **What this decides:** a parked lane gets out on its own only when a recipe table already names that
 exact park and a second fold proves the task left it. Every other park goes to a person through a

--- a/claude-plugins/fabrika/skills/operate/SKILL.md
+++ b/claude-plugins/fabrika/skills/operate/SKILL.md
@@ -524,7 +524,7 @@ human's `UNBLOCKED`, recorded through the same `lane transition` verb — you ne
 `UNBLOCKED`. One exception, and it is still not yours: on a **known** park a recipe verb owns,
 `recipe unpark` records that lane's `UNBLOCKED` itself, and only after a re-fold proves the task
 left the park. The rule and its actor list are ADR
-[0301](../../../../.decisions/0301-known-parks-clear-novel-routes-human.md)'s, which amends ADR 0297
+[0302](../../../../.decisions/0302-known-parks-clear-novel-routes-human.md)'s, which amends ADR 0297
 in part — this section states no park-clearing authority of its own. You relay that verb's exit into
 the chore lane's own event and type no `UNBLOCKED` anywhere.
 


### PR DESCRIPTION
Two decision lanes merged ADRs numbered 0301 within five minutes tonight (#6250 at 02:55 PT, #6252 at 03:00 PT). Both files live on main. This renumbers the later-merged one, the known-parks record, to 0302 and updates its two inbound references (the status line in ADR 0297 and the park paragraph in the operate skill). No content changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)