### PR TITLE
chore: fabrika guide: the adopter arm — a getting-started tutorial and an adopt-in-an-existing-repo how-to

### DIFF
--- a/claude-plugins/fabrika/guide/README.md
+++ b/claude-plugins/fabrika/guide/README.md
@@ -9,8 +9,8 @@ These pages are written for a person. Each holds one Diátaxis mode.
 
 | Page | Mode | Answers |
 |---|---|---|
-| `getting-started.md` | tutorial | Walk me from nothing to a first working fabrika run. |
-| `adopt-fabrika-in-a-new-repo.md` | how-to | Wire fabrika into a repo I already have. |
+| [`getting-started.md`](getting-started.md) | tutorial | Walk me from nothing to a first working fabrika run. |
+| [`adopt-fabrika-in-a-new-repo.md`](adopt-fabrika-in-a-new-repo.md) | how-to | Wire fabrika into a repo I already have. |
 | [`delegation.md`](delegation.md) | reference | Which copy of fabrika serves this invocation, and why did it refuse? |
 | [`how-fabrika-works.md`](how-fabrika-works.md) | explanation | Why is fabrika shaped the way it is? |
 

--- a/claude-plugins/fabrika/guide/adopt-fabrika-in-a-new-repo.md
+++ b/claude-plugins/fabrika/guide/adopt-fabrika-in-a-new-repo.md
@@ -1,0 +1,228 @@
+# Adopt fabrika in a repo you already have
+
+Steps to get fabrika running on an existing repo — one with a board, a history and its own
+conventions. Everything below is what the verbs do at the commit this page was written against; each
+step names the file or issue the claim was read from, and the two steps that hit an open bug say what
+to do about it today.
+
+If you have never run fabrika at all, do [`getting-started.md`](getting-started.md) first on a repo
+you do not mind experimenting on. This page assumes you know what the stages are.
+
+## 1. Install
+
+The tool is one global install; the skills are a Claude Code plugin.
+
+```bash
+pnpm add --global @kampus/fabrika-cli
+```
+
+```
+/plugin marketplace update kampus
+/plugin install fabrika@kampus
+```
+
+**You do not need `@kampus/fabrika-cli` in your repo's own `package.json`.** A repo-local install
+pins the version and is worth having for that reason, but a repo without one is not broken: the
+global runs and prints a warning naming both versions. The one invocation that refuses outright is a
+copy run from a *different* repository's checkout. The whole resolution table is in
+[`delegation.md`](delegation.md); do not reason about it from first principles, the outcomes are
+non-obvious.
+
+## 2. Find out what your repo is missing
+
+```bash
+fabrika status config
+```
+
+This is the completeness answer, and it is the one to keep re-running. **A `read-back conformed`
+from `status bootstrap` means one surface landed — it does not mean the setup is finished**, and
+nothing in that verb's output says so ([#5772](https://github.com/kamp-us/phoenix/issues/5772);
+`status config`'s per-skill rows are what closed the gap,
+[#5779](https://github.com/kamp-us/phoenix/issues/5779)).
+
+Each row is one surface a landed skill declares, with the disposition that skill takes when it is
+absent: `fail-loud`, `degrade` or `bootstrap`. Act on `fail-loud` rows for skills you will use.
+`degrade` rows are optional by declaration. `unprobeable` means the declared subject is not a path or
+a label — a `package.json` script, a running dev server — so the verb cannot check it for you.
+
+## 3. Create the surfaces the CLI can create
+
+Six surface ids are buildable today. Read them off the verb rather than off any prose:
+
+```bash
+fabrika status bootstrap --help
+```
+
+```
+surface-id string    one id from the buildable-surface registry: design-manifest, roadmap-focus, gitignore-row, label-taxonomy, issue-shape-markers, readout-artifact
+```
+
+The registry is `BUILDABLE_SURFACES` in
+[`packages/fabrika-cli/src/status/bootstrap-verb.ts`](../../../packages/fabrika-cli/src/status/bootstrap-verb.ts).
+One id per invocation; a target already present is `exists` at exit 0 and nothing is written or
+overwritten. `design-manifest` and `roadmap-focus` take their content on stdin. `gitignore-row`
+appends its own row and reads no stdin. `label-taxonomy`, `issue-shape-markers` and
+`readout-artifact` write to GitHub and need a resolvable repo — `--repo`, `$CLAUDE_PIPELINE_REPO`,
+`$GITHUB_REPOSITORY`, or an `origin` remote.
+
+## 4. Create the labels
+
+```bash
+fabrika status bootstrap label-taxonomy
+fabrika status bootstrap issue-shape-markers
+```
+
+**The `label-taxonomy` set is derived, not listed** — read it off `TAXONOMY` in
+[`bootstrap-verb.ts`](../../../packages/fabrika-cli/src/status/bootstrap-verb.ts), which composes
+four closed vocabularies:
+
+| Vocabulary | Where it is declared | Count |
+|---|---|---|
+| `STATUSES` | [`packages/fabrika-cli/src/labels.ts`](../../../packages/fabrika-cli/src/labels.ts) | 5 |
+| `PRIORITIES` | [`packages/fabrika-cli/src/triage/facets.ts`](../../../packages/fabrika-cli/src/triage/facets.ts) | 3 |
+| `TYPES` (as `type:<x>`) | same file | 6 |
+| `AUDIENCES` (as `ready-for:<x>`) | same file | 2 |
+
+Sixteen, and it widens on its own when a vocabulary grows — which is why the number is not worth
+writing down anywhere. `issue-shape-markers` adds three more (`wayfinding:map`,
+`prototyping:spike`, `grilling:session`), declared as `ISSUE_SHAPE_MARKERS` in the same file. They
+are a separate surface because nothing ranks or counts them.
+
+Partial existence is not existence here: where some labels are present the verb creates only the
+missing ones and reports what it created. A label already there under another colour is left alone.
+
+This is the step that used to cost the most. Until
+[#5772](https://github.com/kamp-us/phoenix/issues/5772) landed, the verb minted 5 of the 16 and the
+other 11 had to be reverse-engineered off skill tables and created by hand.
+
+## 5. Ignore fabrika's run state
+
+fabrika writes a per-run ledger into your working tree: `.fabrika/lanes/<n>/` for an issue lane and
+`.fabrika/chores/` for a chore lane, each holding a `workflow.json` and an `events.jsonl`
+([`packages/fabrika-cli/src/lane/key.ts`](../../../packages/fabrika-cli/src/lane/key.ts)). That is
+one machine's log and never belongs in shared history.
+
+```bash
+fabrika status bootstrap gitignore-row
+```
+
+It appends its own block to `.gitignore` and rewrites nothing already there; the collision guard is
+the row `/.fabrika/` appearing anywhere in the file, so a row you added by hand with the same
+spelling reads as `exists`. Commit the change before running a lane
+([#5777](https://github.com/kamp-us/phoenix/issues/5777)).
+
+## 6. Write a `ROADMAP.md`
+
+**Write one even though the corpus calls it optional.** The `build` skill's required-files table
+declares `ROADMAP.md` **degrade** — an absent file means no focus is declared and the scope fence is
+inert. But `triage homes` refuses `PRECONDITION_UNKNOWN` (exit 11) when the file is absent, because
+its read cannot tell an absent file from an unreadable one:
+
+```
+triage homes: cannot read the roadmap at NO-SUCH-ROADMAP.md: NotFound: FileSystem.readFile (NO-SUCH-ROADMAP.md) — the home list is UNKNOWN, never empty.
+```
+
+That is [#5773](https://github.com/kamp-us/phoenix/issues/5773), still open. Writing the file is the
+whole workaround — there is nothing to configure around it, and `triage homes` stands between a fresh
+repo and its first triaged issue.
+
+The file's grammar is a real parse contract, not a convention
+([`packages/fabrika-cli/src/triage/roadmap.ts`](../../../packages/fabrika-cli/src/triage/roadmap.ts)):
+
+- Headings exactly `## Arcs` and `## Campaigns`. A section ends at the next `## ` heading.
+- Each table row's **second cell** is the join key and must match `^#(\d+)$` — the milestone's
+  number. The row's title is never matched on, so an arc named anything at all can pin any milestone.
+- The first cell is the row's name and must be non-empty. A `State` column is allowed and is not read.
+- Zero `## Campaigns` rows is legal. **Zero `## Arcs` rows is a refusal** — `triage homes` exits 7
+  rather than answer over a roadmap it could not join, on the reading that an empty parse means the
+  table grammar drifted.
+
+A `## Focus` section is separate, optional, and read by a different parser
+([`packages/fabrika-cli/src/build/scope-admission.ts`](../../../packages/fabrika-cli/src/build/scope-admission.ts)).
+Its columns are exactly `Milestone | Declared` in that order, one row per milestone in focus:
+`#<int>` and an ISO `YYYY-MM-DD` date. One unreadable row makes the whole declaration malformed —
+there is no fallback to the rows that parsed.
+
+Draft it and hand it to the verb, which reports what its own parser joined out of the bytes it wrote:
+
+```bash
+fabrika status bootstrap roadmap-focus <<'EOF'
+## Arcs
+
+| Arc | Milestone | State |
+|---|---|---|
+| First arc | #1 | active |
+EOF
+```
+
+```
+status bootstrap: created ROADMAP.md for roadmap-focus, read-back conformed — 1 arc, 0 campaigns.
+```
+
+`0 arcs` there means the table did not parse. Fix it before moving on, or the join is silently empty
+([#5778](https://github.com/kamp-us/phoenix/issues/5778)).
+
+## 7. Open at least one milestone
+
+`triage homes` offers only **open** milestones joined to a roadmap row, and zero open milestones is a
+refusal (exit 7), not an empty answer. It creates none — curating the milestone set is a human act.
+Open one on GitHub, then pin it from a `## Arcs` row by its number.
+
+```bash
+fabrika triage homes
+```
+
+Your milestone should appear as a `milestone` row. If it does not, the roadmap row's second cell does
+not match `^#(\d+)$`.
+
+## 8. Ignore the two `lane` rows
+
+`triage homes` will also print these, in your repo, whatever your board looks like:
+
+```
+lane	wayfinder:backlog	fog — uncharted work upstream of any arc
+lane	axis:pipeline-hardening	the standing pipeline and reliability lane
+```
+
+Those are phoenix's own standing lanes, compiled into
+[`packages/fabrika-cli/src/triage/homes-verb.ts`](../../../packages/fabrika-cli/src/triage/homes-verb.ts)
+and printed unconditionally. Taking either at its word fails one step later at a different verb
+citing a different missing label.
+
+[ADR 0286](../../../.decisions/0286-standing-lanes-come-from-config.md) ruled that lanes come from
+your repo's own `.fabrika.jsonc` under a `lanes` key, and that a repo declaring none has none. **That
+key is not read yet** — the literal still has three copies in the CLI
+([#5785](https://github.com/kamp-us/phoenix/issues/5785)). Today: treat the two `lane` rows as noise,
+home everything to a milestone, and do not pass `--lane` to `triage apply` unless you have actually
+created those two labels on your board.
+
+## 9. Add the config file
+
+`.fabrika.jsonc` at your repo root carries the keys the CLI reads
+([`packages/fabrika-cli/src/repo-config.ts`](../../../packages/fabrika-cli/src/repo-config.ts)).
+Every key is fail-closed: an absent file, an absent key, an empty array and a malformed entry all
+give the narrowest behaviour, never the permissive one.
+
+- `capClearAuthors` — the GitHub accounts and teams that may clear one extra repair round on a pull
+  request. Declare none and nobody can.
+- `docLeakExempt` — repo-relative path suffixes of docs whose subject *is* path hygiene, skipped by
+  the prose leak scan. Declare none and nothing is exempt.
+- `workflowValidators` — your repo's own commands that machine-read `.github/workflows/**`. Declare
+  none and that surface stands on `actionlint` alone.
+
+phoenix's own file at [`.fabrika.jsonc`](../../../.fabrika.jsonc) is a worked example of all three,
+with the reasoning for each value in comments.
+
+## 10. Re-run the front door
+
+```bash
+fabrika status open
+```
+
+Five fields: the installed skill roster, the config gaps from step 2, your board's counts, the
+decision digest, and any lanes on this machine. The `readout` field reads `absent` with the detail
+`no readout artifact` until you run `fabrika status bootstrap readout-artifact`, which opens the
+durable issue the digest is upserted into, and then `absent` with `no digest block` until
+`fabrika governance readout` writes one. Both are facts, not failed reads.
+
+Then file something with `/fabrika:report`, triage it with `/fabrika:triage`, and you are running.

--- a/claude-plugins/fabrika/guide/getting-started.md
+++ b/claude-plugins/fabrika/guide/getting-started.md
@@ -1,0 +1,234 @@
+# Getting started with fabrika
+
+In this lesson you stand fabrika up on a GitHub repo you own, then drive one issue from filing to an
+open pull request. It takes about half an hour. Nothing here is throwaway — the repo you set up is
+the repo you keep using.
+
+Use a repo you are happy to add labels and a milestone to. This lesson creates nineteen labels and
+one milestone on its board.
+
+You need:
+
+- Claude Code, signed in.
+- Node 24 or newer.
+- `gh` logged in to an account with write access to the repo.
+- A clone of that repo on disk, with an `origin` remote pointing at it.
+
+Every command below is run from the root of that clone unless it starts with `/`, which means you
+type it into Claude Code rather than a shell.
+
+## 1. Install the command-line tool
+
+fabrika's skills call a command-line tool for everything they read and write. Install it once, on
+your machine, not in the repo:
+
+```bash
+pnpm add --global @kampus/fabrika-cli
+```
+
+Check it answers:
+
+```bash
+fabrika --version
+```
+
+```
+fabrika v0.3.0
+```
+
+Your version may be higher. Anything that prints a version is fine.
+
+## 2. Install the plugin
+
+The skills arrive as a Claude Code plugin. In Claude Code, type:
+
+```
+/plugin marketplace update kampus
+/plugin install fabrika@kampus
+```
+
+Update first. The install reads a cached catalog, and a stale cache refuses by name rather than
+saying it is out of date.
+
+## 3. Look at the front door
+
+Back in your shell, at the root of your clone:
+
+```bash
+fabrika status open
+```
+
+```
+status open: roster claude-plugins/fabrika/skills (repo); repo kamp-us/phoenix; 5 field(s) rendered, 0 unknown.
+open	5
+field	menu	ready	25 skills	claude-plugins/fabrika/skills	2026-08-19T03:23:01Z
+field	config	gaps	20 declared, 3 missing, 5 undeclared	claude-plugins/fabrika/skills	2026-08-19T03:23:01Z
+field	board	counted	3 needs-triage, 367 triaged	kamp-us/phoenix	2026-08-19T03:23:02Z
+field	readout	absent	no digest block in kamp-us/phoenix#5616	kamp-us/phoenix#5616	unknown
+field	lanes	empty	no lanes on disk	.fabrika/lanes,.fabrika/chores	2026-08-19T03:23:01Z
+```
+
+That output is from a repo already set up, so yours will differ — the `board` row will report a
+board with no fabrika labels on it yet, and the `readout` row will say `absent`. Read the five
+fields as: which skills are installed, which repo surfaces they need, what is on the board, whether
+the decision digest exists, and which runs are in flight on this machine.
+
+## 4. Create the labels
+
+fabrika's stages write their state onto issues as labels, so the labels have to exist before
+anything can move. Create them:
+
+```bash
+fabrika status bootstrap label-taxonomy
+```
+
+On a fresh board that reports `created` and names all sixteen. On a board that already has them it
+reports `exists` and writes nothing:
+
+```
+status bootstrap: status:needs-triage,status:triaged,status:needs-info,status:planned,status:awaiting-release,p0,p1,p2,type:bug,type:feature,type:chore,type:decision,type:investigation,type:epic,ready-for:human,ready-for:agent is already present for label-taxonomy — nothing written.
+bootstrap	exists	label-taxonomy	status:needs-triage,status:triaged,status:needs-info,status:planned,status:awaiting-release,p0,p1,p2,type:bug,type:feature,type:chore,type:decision,type:investigation,type:epic,ready-for:human,ready-for:agent	-
+```
+
+Three more labels mark what an issue *is* rather than where it sits:
+
+```bash
+fabrika status bootstrap issue-shape-markers
+```
+
+## 5. Keep fabrika's run state out of git
+
+fabrika writes a per-run ledger under `.fabrika/` in your clone. That is one machine's log, not
+shared history, so it is ignored rather than committed:
+
+```bash
+fabrika status bootstrap gitignore-row
+```
+
+```
+status bootstrap: appended /.fabrika/ to .gitignore for gitignore-row, read-back conformed.
+bootstrap	created	gitignore-row	.gitignore	ok
+```
+
+Commit that `.gitignore` change now, before anything writes a lane.
+
+## 6. Give the board a home to put work in
+
+Triage refuses to classify an issue with nowhere to put it, so the repo needs one open milestone and
+a `ROADMAP.md` that pins it. Create the milestone:
+
+```bash
+gh api repos/:owner/:repo/milestones -f title='First arc' --jq '.number'
+```
+
+It prints the milestone's number. Write a roadmap pinning it — substitute that number for `1`:
+
+```bash
+fabrika status bootstrap roadmap-focus <<'EOF'
+## Arcs
+
+| Arc | Milestone | State |
+|---|---|---|
+| First arc | #1 | active |
+EOF
+```
+
+```
+status bootstrap: created ROADMAP.md for roadmap-focus, read-back conformed — 1 arc, 0 campaigns.
+bootstrap	created	roadmap-focus	ROADMAP.md	ok
+```
+
+The `1 arc` on the end is the file's own parser reporting what it joined out of the bytes just
+written. If it says `0 arcs`, the table did not parse and nothing downstream will see your
+milestone. Check the homes:
+
+```bash
+fabrika triage homes
+```
+
+```
+triage homes: scanned 5 open milestones in kamp-us/phoenix.
+triage homes: focus: none declared — scope fence inert.
+homes
+milestone	24	Geçit
+```
+
+Your milestone should be in that list. Commit `ROADMAP.md`.
+
+## 7. See what is still missing
+
+```bash
+fabrika status config
+```
+
+The first line is the summary — how many surfaces the installed skills declare, how many are
+missing, and how many skills declare none. This is the verb that tells you whether the setup is
+finished; a `created` from step 4 says one surface landed, not that the repo is ready.
+
+Some rows will say `missing`. That is fine for now — every one of them belongs to a skill this
+lesson does not use.
+
+## 8. File your first issue
+
+Now leave the shell. In Claude Code, in this repo:
+
+```
+/fabrika:report the README has no install section
+```
+
+It files one issue labelled `status:needs-triage` and prints its number. That label is the intake
+queue, and it is the only way work enters the pipeline.
+
+## 9. Triage it
+
+```
+/fabrika:triage <the number it printed>
+```
+
+Triage reads the issue, gives it a type, a priority and a home, rewrites the body into something a
+builder can pick up cold, and stamps it `status:triaged` plus `ready-for:agent`. Read what it wrote
+on the issue before you go on — the acceptance criteria it left there are the contract everything
+after this is graded against.
+
+## 10. Build it
+
+```
+/fabrika:build <the same number>
+```
+
+This is the long one. The builder claims the issue, cuts a branch, writes the change, validates it
+in your tree, commits, pushes and opens a pull request. When it finishes it prints one word:
+`SHIPPED-PR`, and the pull request's URL.
+
+## 11. Review and merge it
+
+```
+/fabrika:review <the pull request number>
+```
+
+The reviewer judges the pull request against the acceptance criteria triage wrote, and lands a
+PASS or FAIL verdict on the pull request itself. On a PASS:
+
+```
+/fabrika:ship <the pull request number>
+```
+
+The shipper walks the merge guards and merges. On a FAIL, hand the pull request back to the builder
+— `/fabrika:build <the pull request number>` enters repair mode on the same branch, fixes what the
+verdict named, and answers it.
+
+## You are done
+
+You have a repo with fabrika's labels on it, a roadmap the pipeline can read, and one issue that
+went from a sentence you typed to a merged pull request without you editing a file.
+
+Where to go next:
+
+- [`adopt-fabrika-in-a-new-repo.md`](adopt-fabrika-in-a-new-repo.md) — the same setup as a checklist
+  for a repo that already has a board, a history and its own conventions.
+- [`how-fabrika-works.md`](how-fabrika-works.md) — why the stages are separate actors, and why a run's
+  state lives on disk.
+- [`delegation.md`](delegation.md) — which copy of `fabrika` served a command, and what each refusal
+  means.
+- [`../../../packages/fabrika-cli/README.md`](../../../packages/fabrika-cli/README.md) — every verb,
+  its flags and its exit codes.


### PR DESCRIPTION
Two pages under `claude-plugins/fabrika/guide/`, one Diátaxis mode each, aimed at someone outside phoenix who wants to use fabrika.

`getting-started.md` is a tutorial: install the CLI and the plugin, look at `status open`, create the labels, ignore `.fabrika/`, open a milestone and write a `ROADMAP.md` the parser joins, then drive one issue through report → triage → build → review → ship. One path, no option tables, no design argument.

`adopt-fabrika-in-a-new-repo.md` is a how-to: the same setup as a checklist for a repo that already has a board and a history. It answers the eight questions the demlik and binclusive adoptions threw off, each traced to the file or issue it was read from — the derived label set, what `read-back conformed` does and does not mean, whether `ROADMAP.md` is required, the roadmap's parse grammar, the six bootstrap surface ids, what fabrika writes into the tree, whether you need `fabrika-cli` in your own `package.json`, and the two standing lanes the CLI still prints on every repo.

Behaviour is described as it stands at `origin/main`. Seven of the eight adoption issues have since landed; the two live gaps — #5773 and the standing-lane literal behind #5785 — each name their issue and say what to do today.

## Deviations

- **Out-of-scope change** — **Said:** #6006 says neither page edits the other children's pages, and `guide/README.md` is child A's. **Did:** changed two cells in that file's map table, turning the `getting-started.md` and `adopt-fabrika-in-a-new-repo.md` rows from plain code spans into links. **Why:** the same issue's acceptance criterion 8 requires both pages be linked from that map, and the rows were unlinked placeholders. **Disposition:** stated here; no other line of that file was touched.
- **Declined guidance** — **Said:** requirement 5 names five bootstrap surface ids. **Did:** documented six, including `gitignore-row`. **Why:** the criterion above it says read the set off the verbs at authoring time, and `status bootstrap --help` prints six — `gitignore-row` landed with #5777 after the issue was filed. **Disposition:** stated here.
- **Declined guidance** — **Said:** "five of those eight issues are open code bugs with owners (#5772, #5773, #5775, #5776, #5777)". **Did:** only #5773 is described as live, plus the standing-lane implementation gap tracked by #5785. **Why:** #5772, #5775, #5776, #5777, #5778, #5779 and #5774 are all closed as of this writing, and the issue's own instruction is to describe behaviour as it is at `origin/main`, never a fix that has not shipped. **Disposition:** stated here.
- **Known defect left unfixed** — **Said:** every command in the tutorial must be one actually run. **Did:** ran every `fabrika` and `gh` read command quoted, but not the two `/plugin` lines, the `/fabrika:*` skill invocations, or the milestone-create POST. **Why:** a build lane cannot install a Claude Code plugin, and creating a milestone on this board is a side effect the lane has no mandate for; the `/plugin` lines come from the plugin README's record verified on Claude Code 2.1.234, and the same `gh api` endpoint was exercised as a GET. **Disposition:** stated here.
- **Out-of-scope change** — **Said:** nothing about sample output provenance. **Did:** every quoted output block was produced against `kamp-us/phoenix`, so it carries phoenix's repo name and milestone numbers, and the two `created` lines for `gitignore-row` and `roadmap-focus` were produced by running the same verb at a throwaway `--path` inside this tree with only the target filename substituted. **Why:** an adopting repo was not available to run against, and inventing an output block is worse than quoting a real one from a labelled source. **Disposition:** stated here; both pages say the output is from a repo already set up.
- **Scope narrowing** — **Said:** a how-to omits what a working reader already knows, and should link out rather than teach. **Did:** step 6 of the how-to carries the `ROADMAP.md` parse grammar inline. **Why:** no reference page owns that grammar — #5778 is exactly the observation that it lives only in the consuming verb's contract — and acceptance criterion 4 requires the how-to answer it. **Disposition:** stated here; the moment a reference page for it exists this block should become a link.

Fixes #6006
