### PR TITLE
fix: triage claim does not stop a second concurrent writer — two triagers wrote one issue twice tonight

### DIFF
--- a/claude-plugins/fabrika/skills/triage/SKILL.md
+++ b/claude-plugins/fabrika/skills/triage/SKILL.md
@@ -24,8 +24,11 @@ nobody named.
 fabrika triage claim $issue_number
 ```
 
-Done when it printed `won` — that means this session holds it; on anything else, move on. What
-`lost` proves, and which refusal each exit code carries, is the verb's own section
+Done when it printed `won\t<claim-token>` — that means **this lane** holds it; on anything else, move
+on. **Keep the token.** A fan-out runs several triagers under one session id, so the token is the
+only thing that tells your lane from a sibling's: pass it back as `--token` if you ever re-run the
+claim, and never re-run without it — a tokenless re-run is a new lane racing your own. What `lost`
+proves, and which refusal each exit code carries, is the verb's own section
 (`fabrika wire doc-section --heading "triage claim" < <skill-base>/contract.md`).
 
 **That rule has teeth now.** Every verb below that writes — `enrich`, `apply`, `park`, `kill`,

--- a/claude-plugins/fabrika/skills/triage/contract.md
+++ b/claude-plugins/fabrika/skills/triage/contract.md
@@ -28,7 +28,7 @@ makes the implementer guess ([#4734](https://github.com/kamp-us/phoenix/issues/4
 | Verb | Purpose | Split test |
 |---|---|---|
 | `triage queue` | the claimable `status:needs-triage` queue, with the count it scanned | paginating a label query and separating a proven-empty queue from a failed read is mechanical; which issue to take is judgment |
-| `triage claim` | take a session-scoped claim on one issue, proven by read-back | a marker write plus an earliest-claim tiebreak is a protocol, not a decision |
+| `triage claim` | take one lane's claim on one issue, proven by read-back | a marker write plus an earliest-claim tiebreak is a protocol, not a decision |
 | `triage provenance` | was this issue reported by an agent or hand-typed by a human | a structural marker test over a fetched body, plus a membership test over the configured operator set — an empty body fails closed to `human`, an unreadable one refuses rather than guessing; what to *do* about a human filing stays in the skill |
 | `triage homes` | the assignable homes — open milestones joined to their ROADMAP rows, plus the standing lanes, with every milestone in declared focus marked `running` | the join, the open-milestone filter and reading the focus declaration are mechanical; picking which home fits, and whether an exception applies, is judgment |
 | `triage split` | create one split child, once, keyed on the parent back-reference | idempotency keyed on a durable reference is mechanical; deciding a report *is* a bundle is judgment |
@@ -364,7 +364,7 @@ $ fabrika triage queue --json
 **Invocation**
 
 ```
-fabrika triage claim 4312 [--repo <owner/name>] [--json]
+fabrika triage claim 4312 [--token <claim-token>] [--repo <owner/name>] [--json]
 ```
 
 **Inputs**
@@ -372,29 +372,42 @@ fabrika triage claim 4312 [--repo <owner/name>] [--json]
 | Flag | Type | Required | Default | Description |
 |---|---|---|---|---|
 | *(positional)* | integer | yes | — | the issue number to claim |
+| `--token` | string | no | mint a new lane | the token a previous claim handed THIS lane — re-enter it rather than minting a second |
 | `--repo` | string | no | resolved | the repository |
 | `--json` | boolean | no | `false` | emit the result object |
 
-**Output** — machine channel. One line: `won`, or `lost\t<holder-session-id>`. **Both are proven
-answers and both exit 0**, with the discriminator in the state word — the same three-outcome shape
-`report dedup` already uses. A losing claim is something this verb *determined*, not something that
-prevented it from answering, so seating it on a non-zero code would contradict the shared rule that a
-non-zero exit is UNKNOWN and would make "another sweep holds it" indistinguishable from "the verb is
-broken".
+**Output** — machine channel. One line: `won\t<claim-token>`, or `lost\t<holder-session-id>`. **Both
+are proven answers and both exit 0**, with the discriminator in the state word — the same
+three-outcome shape `report dedup` already uses. A losing claim is something this verb *determined*,
+not something that prevented it from answering, so seating it on a non-zero code would contradict the
+shared rule that a non-zero exit is UNKNOWN and would make "another sweep holds it"
+indistinguishable from "the verb is broken".
 
-With `--json`, an object with keys `outcome` (`won` / `lost`), `session` (this session's id),
-`holder` (the winning session id, `null` on `won`), `markers` (count of live markers considered), and
-`expired` (count discarded as older than the TTL).
+With `--json`, an object with keys `outcome` (`won` / `lost`), `session` (this session's id), `token`
+(this lane's claim token), `holder` (the winning session id, `null` on `won`), `holderLane` (the
+winning lane's nonce, `null` on `won` or when the winner is a pre-#6132 marker), `markers` (count of
+live markers considered), and `expired` (count discarded as older than the TTL).
+
+**A claim names a lane, not a session.** One fan-out runs several triagers under one
+`$CLAUDE_CODE_SESSION_ID`, so a marker stamped with the session alone cannot tell two of them apart:
+on 2026-08-18 two siblings each read the other's marker back as their own, both answered `won`, and
+both wrote the issue ([#6132](https://github.com/kamp-us/phoenix/issues/6132)). The lane is a token,
+`triage:<session-id>:<uuid>` — the same shape and the same nonce rule the `build` namespace resolves
+ownership by ([#6037](https://github.com/kamp-us/phoenix/issues/6037)), in its own namespace so the
+two never collide. A run with no `--token` mints one and races under its nonce; a run that passes the
+token it was handed re-enters the lane it already holds.
 
 **The marker literal.** A claim is one issue comment whose body is exactly:
 
 ```
-<!-- fabrika-triage-claim session=<session-id> -->
+<!-- fabrika-triage-claim session=<session-id> lane=<nonce> -->
 ```
 
 One line, no surrounding prose, so a marker is matched by an exact prefix rather than by parsing
-human text. `<session-id>` is the verbatim value of `$CLAUDE_CODE_SESSION_ID`. Any comment not
-matching that prefix is not a marker and is ignored.
+human text. `<session-id>` is the verbatim value of `$CLAUDE_CODE_SESSION_ID`; `<nonce>` is the first
+8 hex of the claim token's UUID. Any comment not matching that prefix is not a marker and is ignored.
+A marker carrying no `lane=` field is a pre-#6132 claim: it is counted, it ages out on the same TTL,
+and every lane reads it as **another** claimant's — never as its own.
 
 **The ordering key is the comment's `created_at` as returned by GitHub**, never a timestamp embedded
 in the marker text: the body is caller-supplied and a caller could backdate itself into winning every
@@ -420,7 +433,9 @@ winner is this session; every unresolvable state answers `lost`, never `won`.
 **The claim binds, and every mutating verb is what makes it bind.** `split`, `enrich`, `apply`,
 `park` and `kill` each re-read the markers on their target immediately before their first write, and
 refuse on `17` when a live one names another session — the check reuses this verb's own reader and
-resolver, so there is one marker grammar. Holding **no** marker still passes: an unclaimed issue is
+resolver, so there is one marker grammar. Those five read the **session** axis only: they are handed
+no claim token, so a sibling lane of one session still passes that check, exactly as it did before
+the lane nonce existed. Holding **no** marker still passes: an unclaimed issue is
 the ordinary first-triage case, and demanding one would refuse every existing caller. The same
 re-read refuses a closed target on `7`, and a comment read that fails is `11`. Before, the protocol
 was advisory at exactly the point it needed to bite: on 2026-08-15 a session that had read `lost`
@@ -441,10 +456,11 @@ create the race it exists to resolve. Every other write verb states its idempote
 - **A failed deletion is `9`, not `0`.** The write landed, the intended end state (no marker of mine)
   is not what the issue carries, and the caller has to know a stale marker of theirs is sitting on
   the issue. Answering `lost` at exit 0 would hide it until it won a race nobody was running.
-- **A session that already holds a live marker on the issue re-reads and re-resolves rather than
-  posting a second.** A second marker from the same session cannot win anything the first did not —
-  it is strictly later — so posting it only adds litter to clean up. Re-running this verb inside one
-  session is therefore idempotent: the same marker, re-resolved.
+- **A lane that already holds a live marker on the issue re-reads and re-resolves rather than
+  posting a second.** A second marker under the same nonce cannot win anything the first did not —
+  it is strictly later — so posting it only adds litter to clean up. Re-running this verb under the
+  `--token` it was handed is therefore idempotent: the same marker, re-resolved. Re-running it
+  *without* the token is not a re-entry at all — it is a new lane, and it races like one.
 
 **Exit status**
 
@@ -465,9 +481,11 @@ rather than to this verb.
 | Message (stderr) | Code | Kind |
 |---|---|---|
 | `triage claim: CLAUDE_CODE_SESSION_ID is unset — refusing to post an unattributable claim.` | 1 | refusal |
+| `triage claim: --token "<t>" is not a claim token (triage:<session-id>:<uuid>) — which lane is asking is not stated.` | 1 | refusal |
+| `triage claim: --token "<t>" carries session <s>, but this run is session <mine> — a lane names itself, never another.` | 1 | refusal |
 | `triage claim: issue #<n> not found in <repo>.` | 7 | refusal |
 | `triage claim: issue #<n> is closed — nothing to triage.` | 7 | refusal |
-| `triage claim: #<n> is held by session <holder> since <created_at> — backing off.` | 0 | notice |
+| `triage claim: #<n> is held by session <holder> [on lane <nonce>] since <created_at> — backing off.` | 0 | notice |
 | `triage claim: cannot read #<n> or its comments in <repo>: <reason> — no claim was resolved; never "won".` | 11 | refusal |
 | `triage claim: marker POST failed: <reason> — UNKNOWN whether it landed; re-run before mutating #<n>.` | 8 | refusal |
 | `triage claim: marker posted but absent on read-back — treating the claim as lost.` | 9 | refusal |
@@ -482,20 +500,29 @@ by a caller.
 
 ```
 $ fabrika triage claim 4312
-won
+won	triage:b2e1-4c07-4a99-9f30-55da1e6b7c02:5f1c9a20-4b11-4e05-8d77-c2a4f9be1234
 ```
 
 ```
 $ fabrika triage claim 4312
-triage claim: #4312 is held by session 7f3c-9a20-4b11-8e05-1d77c2a4f9be since 2026-08-02T09:14:02Z — backing off.
+triage claim: #4312 is held by session 7f3c-9a20-4b11-8e05-1d77c2a4f9be on lane 9a204b11 since 2026-08-02T09:14:02Z — backing off.
 lost	7f3c-9a20-4b11-8e05-1d77c2a4f9be
 $ echo $?
 0
 ```
 
+A sibling lane of your OWN session wins the same way, and the notice names the lane so the answer
+does not read as this lane losing to itself:
+
+```
+$ fabrika triage claim 4312
+triage claim: #4312 is held by session b2e1-4c07-4a99-9f30-55da1e6b7c02 on lane 7c3d0e91 since 2026-08-18T21:02:11Z — backing off.
+lost	b2e1-4c07-4a99-9f30-55da1e6b7c02
+```
+
 ```
 $ fabrika triage claim 4312 --json
-{"outcome":"won","session":"b2e1-4c07-4a99-9f30-55da1e6b7c02","holder":null,"markers":1,"expired":0}
+{"outcome":"won","session":"b2e1-4c07-4a99-9f30-55da1e6b7c02","token":"triage:b2e1-4c07-4a99-9f30-55da1e6b7c02:5f1c9a20-4b11-4e05-8d77-c2a4f9be1234","holder":null,"holderLane":null,"markers":1,"expired":0}
 ```
 
 **Grounding**

--- a/packages/fabrika-cli/src/triage/claim-fixtures.test-support.ts
+++ b/packages/fabrika-cli/src/triage/claim-fixtures.test-support.ts
@@ -20,9 +20,19 @@ export const LIVE = "2999-01-01T00:00:00Z";
 /** A `created_at` every TTL has passed. */
 export const EXPIRED = "2020-01-01T00:00:00Z";
 
-/** One comments page carrying a claim marker per `(session, createdAt)` pair. */
+/**
+ * One comments page carrying a claim marker per row.
+ *
+ * `lane` defaults to a per-row nonce rather than to the caller's: a fixture that silently handed
+ * every marker one lane would make a sibling-lane race look like a re-entry (#6132). A row naming a
+ * lane explicitly is how a test writes "this marker is that lane's".
+ */
 export const claimPage = (
-	...held: ReadonlyArray<{readonly session: string; readonly createdAt: string}>
+	...held: ReadonlyArray<{
+		readonly session: string;
+		readonly createdAt: string;
+		readonly lane?: string;
+	}>
 ): ExecResult =>
 	okOut(
 		JSON.stringify(
@@ -31,7 +41,7 @@ export const claimPage = (
 				user: {login: "agent"},
 				created_at: row.createdAt,
 				updated_at: row.createdAt,
-				body: markerBody(row.session),
+				body: markerBody({session: row.session, nonce: row.lane ?? `fixture${index}`}),
 			})),
 		),
 	);

--- a/packages/fabrika-cli/src/triage/claim-verb.ts
+++ b/packages/fabrika-cli/src/triage/claim-verb.ts
@@ -1,11 +1,17 @@
 /**
- * `triage claim` — take a session-scoped claim on one issue, proven by read-back.
+ * `triage claim` — take one lane's claim on one issue, proven by read-back.
  *
- * Post this session's marker, re-read every marker on the issue, discard the ones older than the
+ * Post this lane's marker, re-read every marker on the issue, discard the ones older than the
  * TTL, and let the earliest survivor win. `won` and `lost` are both **proven answers** and both exit
  * 0, with the discriminator in the state word: a losing claim is something this verb *determined*,
  * so seating it on a non-zero code would make "another sweep holds it" indistinguishable from "the
  * verb is broken".
+ *
+ * **A claim names a lane, and the lane is the token this verb hands back.** A run with no `--token`
+ * mints one and races under its nonce; a run that passes the token it was handed re-enters the lane
+ * it already owns. That is what makes re-entry idempotent *and* keeps two triagers of one session
+ * apart — the session id alone told each sibling of a fan-out that it held its sibling's marker, and
+ * both wrote the issue (#6132).
  *
  * Everything a marker set could fail to say is a refusal instead. An unreadable comment list, a
  * shape that is not a list of comments, a marker whose ordering key will not parse — none of them
@@ -23,13 +29,19 @@ import type {ChildProcessSpawner} from "effect/unstable/process";
 import {createComment, deleteComment, getIssue, listComments, resolveRepo} from "../io/issues.ts";
 import {answer, FAILED, refuse, type VerbOutcome} from "../verb.ts";
 import {
+	claimNonceOf,
+	composeClaimToken,
 	DEFAULT_TTL_MINUTES,
 	expiryOf,
 	isStampableSession,
+	type LaneCaller,
+	laneCaller,
 	markerBody,
 	markersOf,
 	myMarker,
+	parseClaimToken,
 	resolveClaim,
+	TOKEN_PREFIX,
 } from "./claim.ts";
 import {PRECONDITION_UNKNOWN, READBACK_MISMATCH, WRITE_UNKNOWN, ZERO_SCOPE} from "./codes.ts";
 import {scannedLine} from "./scope.ts";
@@ -38,6 +50,10 @@ export interface ClaimOptions {
 	readonly issue: number;
 	readonly repo: string | null;
 	readonly json: boolean;
+	/** The token this lane was already handed, or `null` on a first claim — see {@link callerFrom}. */
+	readonly token: string | null;
+	/** The UUID a fresh lane's token is minted from; injected so a test can pin the nonce. */
+	readonly uuid: string;
 	readonly env: Readonly<Record<string, string | undefined>>;
 	readonly now: () => Date;
 }
@@ -76,6 +92,53 @@ const sessionFrom = (
 	return {session};
 };
 
+/**
+ * The lane that is asking — the one it was handed a token for, or a fresh one minted here.
+ *
+ * A token from another session is refused rather than trusted: the env says which session is
+ * running, the flag says which lane of it, and a pair that disagrees is a token threaded through
+ * from somewhere else.
+ */
+const callerFrom = (
+	session: string,
+	token: string | null,
+	uuid: string,
+): {readonly caller: LaneCaller; readonly token: string} | {readonly refusal: VerbOutcome} => {
+	if (token === null) {
+		const minted = composeClaimToken(session, uuid);
+		const nonce = claimNonceOf(minted);
+		if (nonce === null) {
+			return {
+				refusal: refuse(
+					FAILED,
+					`${VERB}: could not mint a lane token for session ${session} — nothing was written.`,
+				),
+			};
+		}
+		return {caller: laneCaller(session, nonce, minted), token: minted};
+	}
+	const trimmed = token.trim();
+	const parsed = parseClaimToken(trimmed);
+	const nonce = claimNonceOf(trimmed);
+	if (parsed === null || nonce === null) {
+		return {
+			refusal: refuse(
+				FAILED,
+				`${VERB}: --token "${trimmed}" is not a claim token (${TOKEN_PREFIX}:<session-id>:<uuid>) — which lane is asking is not stated.`,
+			),
+		};
+	}
+	if (parsed.session !== session) {
+		return {
+			refusal: refuse(
+				FAILED,
+				`${VERB}: --token "${trimmed}" carries session ${parsed.session}, but this run is session ${session} — a lane names itself, never another.`,
+			),
+		};
+	}
+	return {caller: laneCaller(session, nonce, trimmed), token: trimmed};
+};
+
 export const runClaim = (
 	options: ClaimOptions,
 ): Effect.Effect<VerbOutcome, never, ChildProcessSpawner.ChildProcessSpawner> =>
@@ -89,6 +152,10 @@ export const runClaim = (
 		const stamped = sessionFrom(options.env);
 		if ("refusal" in stamped) return stamped.refusal;
 		const {session} = stamped;
+
+		const asking = callerFrom(session, options.token, options.uuid);
+		if ("refusal" in asking) return asking.refusal;
+		const {caller, token: laneToken} = asking;
 
 		const repoAttempt = yield* resolveRepo(options.repo, options.env);
 		if (repoAttempt._tag === "Failure") {
@@ -122,12 +189,14 @@ export const runClaim = (
 		}
 
 		const now = options.now().getTime();
-		// Re-running inside one session is idempotent: a second marker is strictly later than the
-		// first, so it can win nothing the first did not and only adds litter to clean up.
+		// Re-entering one lane is idempotent: a second marker under the same nonce is strictly later
+		// than the first, so it can win nothing the first did not and only adds litter to clean up. It
+		// is the LANE that re-enters, not the session — a sibling lane of the same session holds a
+		// marker under another nonce, and posting its own is exactly what the race needs (#6132).
 		const alreadyHeld = myMarker(
 			resolveClaim({
 				markers: markersOf(before.value),
-				session,
+				caller,
 				now,
 				ttlMinutes: DEFAULT_TTL_MINUTES,
 			}),
@@ -135,7 +204,7 @@ export const runClaim = (
 
 		let postedId: number | null = null;
 		if (alreadyHeld === null) {
-			const posted = yield* createComment(repo, issue, markerBody(session));
+			const posted = yield* createComment(repo, issue, markerBody(caller));
 			if (posted._tag === "Failure") {
 				return refuse(
 					WRITE_UNKNOWN,
@@ -153,14 +222,14 @@ export const runClaim = (
 				postedId === null
 					? []
 					: [
-							`${VERB}: this session's marker ${postedId} is live on #${issue} and was not read back — delete it by hand if this session stops here.`,
+							`${VERB}: this lane's marker ${postedId} is live on #${issue} and was not read back — delete it by hand if this lane stops here.`,
 						],
 			);
 		}
 		const scope = scannedLine(VERB, repo, after.value.length, "comment");
 		const resolution = resolveClaim({
 			markers: markersOf(after.value),
-			session,
+			caller,
 			now,
 			ttlMinutes: DEFAULT_TTL_MINUTES,
 		});
@@ -187,13 +256,15 @@ export const runClaim = (
 						JSON.stringify({
 							outcome: "won",
 							session,
+							token: laneToken,
 							holder: null,
+							holderLane: null,
 							markers: resolution.live,
 							expired: resolution.expired,
 						}),
 						[scope],
 					)
-				: answer("won", [scope]);
+				: answer(`won\t${laneToken}`, [scope]);
 		}
 
 		// A losing claim deletes the marker it just posted, before it says so. Litter survives the
@@ -204,18 +275,27 @@ export const runClaim = (
 			const expiry = expiryOf(resolution.mine.createdAt, DEFAULT_TTL_MINUTES) ?? "an unknown time";
 			return refuse(
 				READBACK_MISMATCH,
-				`${VERB}: lost #${issue}, but this session's marker ${resolution.mine.id} could not be deleted: ${deleted.reason} — a stale claim is live on the issue until ${expiry}; delete it by hand.`,
+				`${VERB}: lost #${issue}, but this lane's marker ${resolution.mine.id} could not be deleted: ${deleted.reason} — a stale claim is live on the issue until ${expiry}; delete it by hand.`,
 				[scope],
 			);
 		}
 
-		const notice = `${VERB}: #${issue} is held by session ${resolution.holder.session} since ${resolution.holder.createdAt} — backing off.`;
+		// The lane is named beside the session because under a fan-out the winner IS this session — a
+		// notice reading "held by session <mine>" and nothing else describes a lane losing to itself.
+		const holderLane = resolution.holder.lane;
+		const heldBy =
+			holderLane === null
+				? `session ${resolution.holder.session}`
+				: `session ${resolution.holder.session} on lane ${holderLane}`;
+		const notice = `${VERB}: #${issue} is held by ${heldBy} since ${resolution.holder.createdAt} — backing off.`;
 		return json
 			? answer(
 					JSON.stringify({
 						outcome: "lost",
 						session,
+						token: laneToken,
 						holder: resolution.holder.session,
+						holderLane,
 						markers: resolution.live,
 						expired: resolution.expired,
 					}),

--- a/packages/fabrika-cli/src/triage/claim-verb.unit.test.ts
+++ b/packages/fabrika-cli/src/triage/claim-verb.unit.test.ts
@@ -2,12 +2,20 @@ import {Effect} from "effect";
 import {describe, expect, it} from "vitest";
 import {errOut, fakeShell, okOut} from "../fakes.test-support.ts";
 import type {ExecResult} from "../io/exec.ts";
-import {markerBody} from "./claim.ts";
+import {composeClaimToken, markerBody} from "./claim.ts";
 import {runClaim} from "./claim-verb.ts";
 import {PRECONDITION_UNKNOWN, READBACK_MISMATCH, WRITE_UNKNOWN, ZERO_SCOPE} from "./codes.ts";
 
 const MINE = "b2e1-4c07-4a99-9f30-55da1e6b7c02";
 const THEIRS = "7f3c-9a20-4b11-8e05-1d77c2a4f9be";
+
+/** This lane's uuid and the nonce it confers; the sibling shares MINE's session and nothing else. */
+const MY_UUID = "aaaaaaaa-1111-4222-8333-444444444444";
+const MY_NONCE = "aaaaaaaa";
+const MY_TOKEN = composeClaimToken(MINE, MY_UUID);
+const SIBLING_UUID = "bbbbbbbb-1111-4222-8333-444444444444";
+const SIBLING_NONCE = "bbbbbbbb";
+const THEIR_NONCE = "cccccccc";
 
 const ISSUE = /^gh api repos\/o\/r\/issues\/4312$/;
 const LIST = /^gh api --paginate repos\/o\/r\/issues\/4312\/comments/;
@@ -58,13 +66,28 @@ const posted = (id: number) =>
 	okOut(JSON.stringify({id, html_url: `https://example.test/issues/4312#issuecomment-${id}`}));
 
 const NOW = new Date("2026-08-02T10:00:00Z");
-const MY_MARKER = comment(5001, markerBody(MINE), "2026-08-02T09:50:00Z");
-const THEIR_MARKER = comment(4002, markerBody(THEIRS), "2026-08-02T09:14:02Z");
+const MY_MARKER = comment(
+	5001,
+	markerBody({session: MINE, nonce: MY_NONCE}),
+	"2026-08-02T09:50:00Z",
+);
+const SIBLING_MARKER = comment(
+	4003,
+	markerBody({session: MINE, nonce: SIBLING_NONCE}),
+	"2026-08-02T09:14:02Z",
+);
+const THEIR_MARKER = comment(
+	4002,
+	markerBody({session: THEIRS, nonce: THEIR_NONCE}),
+	"2026-08-02T09:14:02Z",
+);
 
 const options = {
 	issue: 4312,
 	repo: null,
 	json: false,
+	token: null as string | null,
+	uuid: MY_UUID,
 	env: {
 		CLAUDE_PIPELINE_REPO: "o/r",
 		CLAUDE_CODE_SESSION_ID: MINE,
@@ -102,8 +125,10 @@ describe("runClaim — winning", () => {
 	it("posts the exact marker literal and prints the state word `won`", async () => {
 		const {outcome, calls} = await run(winning());
 		expect(outcome.code).toBe(0);
-		expect(outcome.stdout).toBe("won\n");
-		expect(calls.find((c) => POST.test(c))).toContain(`body=${markerBody(MINE)}`);
+		expect(outcome.stdout).toBe(`won\t${MY_TOKEN}\n`);
+		expect(calls.find((c) => POST.test(c))).toContain(
+			`body=${markerBody({session: MINE, nonce: MY_NONCE})}`,
+		);
 	});
 
 	it("reports the scanned comment count on stderr — a verdict names its scope", async () => {
@@ -116,14 +141,20 @@ describe("runClaim — winning", () => {
 		expect(JSON.parse(outcome.stdout)).toEqual({
 			outcome: "won",
 			session: MINE,
+			token: MY_TOKEN,
 			holder: null,
+			holderLane: null,
 			markers: 1,
 			expired: 0,
 		});
 	});
 
 	it("wins over a marker the TTL has aged out, and counts it as expired", async () => {
-		const stale = comment(4002, markerBody(THEIRS), "2026-08-02T08:00:00Z");
+		const stale = comment(
+			4002,
+			markerBody({session: THEIRS, nonce: THEIR_NONCE}),
+			"2026-08-02T08:00:00Z",
+		);
 		const {outcome} = await run(
 			[
 				[ISSUE, issue("open")],
@@ -136,14 +167,93 @@ describe("runClaim — winning", () => {
 		expect(JSON.parse(outcome.stdout)).toMatchObject({outcome: "won", markers: 1, expired: 1});
 	});
 
-	it("re-resolves rather than posting a second marker when this session already holds one", async () => {
-		const {outcome, calls} = await run([
-			[ISSUE, issue("open")],
-			[LIST, comments(MY_MARKER)],
-		]);
-		expect(outcome.stdout).toBe("won\n");
+	it("re-resolves rather than posting a second marker when this LANE already holds one", async () => {
+		const {outcome, calls} = await run(
+			[
+				[ISSUE, issue("open")],
+				[LIST, comments(MY_MARKER)],
+			],
+			{token: MY_TOKEN},
+		);
+		expect(outcome.stdout).toBe(`won\t${MY_TOKEN}\n`);
 		expect(calls.filter((c) => POST.test(c))).toHaveLength(0);
 		expect(calls.filter((c) => LIST.test(c))).toHaveLength(1);
+	});
+});
+
+describe("runClaim — two lanes of one session", () => {
+	// The defect: both siblings share CLAUDE_CODE_SESSION_ID, so a session-only marker read each
+	// sibling's claim back as its own and both wrote the issue (#6132).
+	const race = (): ReadonlyArray<readonly [RegExp, ExecResult]> => [
+		[ISSUE, issue("open")],
+		[POST, posted(5001)],
+		[once(LIST), comments(SIBLING_MARKER)],
+		[LIST, comments(SIBLING_MARKER, MY_MARKER)],
+		[DELETE, okOut("")],
+	];
+
+	it("loses to a sibling lane of its own session instead of adopting its marker", async () => {
+		const {outcome} = await run(race());
+		expect(outcome.code).toBe(0);
+		expect(outcome.stdout).toBe(`lost\t${MINE}\n`);
+		expect(outcome.stderr.join("\n")).toContain(
+			`#4312 is held by session ${MINE} on lane ${SIBLING_NONCE}`,
+		);
+	});
+
+	it("retracts its OWN marker on that loss, never the sibling's", async () => {
+		const {calls} = await run(race());
+		const deletes = calls.filter((c) => DELETE.test(c));
+		expect(deletes).toHaveLength(1);
+		expect(deletes[0]).toContain("issues/comments/5001");
+	});
+
+	it("posts its own marker rather than reading the sibling's as a re-entry", async () => {
+		const {calls} = await run(race());
+		expect(calls.filter((c) => POST.test(c))).toHaveLength(1);
+	});
+
+	it("wins when its own marker is the earliest — the sibling is later, not equal", async () => {
+		const later = {...SIBLING_MARKER, created_at: "2026-08-02T09:55:00Z"};
+		const {outcome} = await run([
+			[ISSUE, issue("open")],
+			[POST, posted(5001)],
+			[once(LIST), comments()],
+			[LIST, comments(MY_MARKER, later)],
+		]);
+		expect(outcome.stdout).toBe(`won\t${MY_TOKEN}\n`);
+	});
+});
+
+describe("runClaim — --token", () => {
+	it("refuses at 1 on a token that is not a triage claim token", async () => {
+		const {outcome, calls} = await run([], {token: "build:whoever:0123456789ab"});
+		expect(outcome.code).toBe(1);
+		expect(outcome.stderr.join("\n")).toContain("which lane is asking is not stated");
+		expect(calls).toHaveLength(0);
+	});
+
+	it("refuses at 1 on another session's token — a lane names itself, never another", async () => {
+		const {outcome, calls} = await run([], {token: composeClaimToken(THEIRS, SIBLING_UUID)});
+		expect(outcome.code).toBe(1);
+		expect(outcome.stderr.join("\n")).toContain(`carries session ${THEIRS}`);
+		expect(calls).toHaveLength(0);
+	});
+
+	it("re-posts under the named lane when its marker aged out, and answers with that same token", async () => {
+		const {outcome, calls} = await run(
+			[
+				[ISSUE, issue("open")],
+				[POST, posted(5001)],
+				[once(LIST), comments()],
+				[LIST, comments(MY_MARKER)],
+			],
+			{token: MY_TOKEN},
+		);
+		expect(outcome.stdout).toBe(`won\t${MY_TOKEN}\n`);
+		expect(calls.find((c) => POST.test(c))).toContain(
+			`body=${markerBody({session: MINE, nonce: MY_NONCE})}`,
+		);
 	});
 });
 
@@ -153,7 +263,7 @@ describe("runClaim — losing", () => {
 		expect(outcome.code).toBe(0);
 		expect(outcome.stdout).toBe(`lost\t${THEIRS}\n`);
 		expect(outcome.stderr.join("\n")).toContain(
-			`#4312 is held by session ${THEIRS} since 2026-08-02T09:14:02Z — backing off.`,
+			`#4312 is held by session ${THEIRS} on lane ${THEIR_NONCE} since 2026-08-02T09:14:02Z — backing off.`,
 		);
 	});
 
@@ -311,7 +421,7 @@ describe("runClaim — preconditions", () => {
 			[once(LIST), comments()],
 			[LIST, errOut("gh: Bad gateway (HTTP 502)")],
 		]);
-		expect(outcome.stderr.join("\n")).toContain("this session's marker 5001 is live on #4312");
+		expect(outcome.stderr.join("\n")).toContain("this lane's marker 5001 is live on #4312");
 	});
 
 	it("refuses at 1 on a non-issue number", async () => {

--- a/packages/fabrika-cli/src/triage/claim.ts
+++ b/packages/fabrika-cli/src/triage/claim.ts
@@ -2,23 +2,61 @@
  * The `triage claim` race protocol, as a pure function of the comments that were read.
  *
  * The whole verb is one rule: **`won` requires positive proof that the earliest surviving marker is
- * this session's.** Nothing else may produce it — not an empty comment list, not a marker whose
+ * this lane's.** Nothing else may produce it — not an empty comment list, not a marker whose
  * ordering key is unreadable, not a set the caller could not fetch. v1's claim printed `won` and
  * exited 0 when its own identity read came back empty, because every comparison against an empty
  * string succeeded; that is a fail-open claim on a token that cannot write. Here the absence of
  * evidence resolves to {@link Unresolvable} or to `lost`, never to `won`.
  *
+ * **A session is not a lane.** One triage fan-out routinely runs several triagers under one
+ * `CLAUDE_CODE_SESSION_ID`, so a marker stamped with the session alone cannot tell two of them
+ * apart: on 2026-08-18 two siblings each read a same-session marker back as their own and both
+ * resolved `won`, then both wrote the issue (#6132). Every claimant therefore names itself as a
+ * {@link Caller} — the same identity the `build` namespace resolves ownership against (#6037) — and
+ * a same-session marker under a different lane nonce is somebody else's.
+ *
  * Keeping the resolution here rather than in the verb is what makes the losing and the ambiguous
- * branches testable without a network: the verb supplies markers, a clock and a session id, and
+ * branches testable without a network: the verb supplies markers, a clock and a caller, and
  * this module decides.
  */
+import type {Caller} from "../build/claim.ts";
+import {composeToken, nonceOf, parseToken} from "../build/lane.ts";
+
+export {anySessionCaller, type Caller, type LaneCaller, laneCaller} from "../build/claim.ts";
+
+/**
+ * The claim token shape a triage lane holds: `triage:<session-id>:<uuid>`.
+ *
+ * Its own namespace beside `build:` and `lane:`, on the shared token grammar rather than a second
+ * one — the reader and the writer are `../build/lane.ts`'s, parameterised by this prefix.
+ */
+export const TOKEN_PREFIX = "triage";
+
+/** Compose this lane's token from the session id and a fresh UUID. */
+export const composeClaimToken = (session: string, uuid: string): string =>
+	composeToken(session, uuid, TOKEN_PREFIX);
+
+/** The lane nonce a triage token confers, or `null` when it does not parse as one. */
+export const claimNonceOf = (token: string): string | null => nonceOf(token, TOKEN_PREFIX);
+
+/** The session and uuid halves of a triage token, or `null` when it does not parse as one. */
+export const parseClaimToken = (
+	token: string,
+): {readonly session: string; readonly uuid: string} | null => parseToken(token, TOKEN_PREFIX);
 
 /** The exact one-line body a claim marker carries, up to the session id. */
 export const MARKER_PREFIX = "<!-- fabrika-triage-claim session=";
+const LANE_KEY = " lane=";
 const MARKER_SUFFIX = " -->";
 
-/** The marker literal for `session`. One line, no surrounding prose — matched back by prefix. */
-export const markerBody = (session: string): string => `${MARKER_PREFIX}${session}${MARKER_SUFFIX}`;
+/**
+ * The marker literal for one lane. One line, no surrounding prose — matched back by prefix.
+ *
+ * The `lane=` field is what a sibling lane of the same session reads back as *not* its own; a marker
+ * without it is a pre-#6132 claim, which every lane now treats as another claimant's.
+ */
+export const markerBody = (caller: {readonly session: string; readonly nonce: string}): string =>
+	`${MARKER_PREFIX}${caller.session}${LANE_KEY}${caller.nonce}${MARKER_SUFFIX}`;
 
 /**
  * A session id fit to stamp a marker with: one whitespace-free token that cannot close the comment
@@ -47,10 +85,31 @@ export const sessionOf = (body: string): string | null => {
 	return token;
 };
 
+// The whitespace is required, not cosmetic: without it a session id that itself began `lane=` would
+// be read as its own lane nonce, and the marker would name a claimant nobody posted.
+const LANE_RE = /\slane=(\S*)/;
+
+/**
+ * The lane nonce stamped on `body`, or `null` when the marker carries no `lane=` field at all.
+ *
+ * `null` is the pre-#6132 marker — a claimant that named a session and nothing else. It is read as a
+ * distinct claimant rather than as a wildcard: a marker no live lane can prove is its own must lose
+ * a race to the lane that can, and it ages out on the same TTL as any other.
+ */
+export const laneOf = (body: string): string | null => {
+	if (sessionOf(body) === null) return null;
+	const trimmed = body.trim();
+	const rest = trimmed.slice(MARKER_PREFIX.length);
+	const found = LANE_RE.exec(rest);
+	return found?.[1] ?? null;
+};
+
 /** One claim marker, as the resolution orders it. */
 export interface Marker {
 	readonly id: number;
 	readonly session: string;
+	/** The lane nonce the marker names, or `null` for a pre-#6132 session-only marker. */
+	readonly lane: string | null;
 	/** GitHub's `created_at` — the ordering key, never a timestamp from the caller-supplied body. */
 	readonly createdAt: string;
 }
@@ -62,7 +121,14 @@ export const markersOf = (
 	const out: Marker[] = [];
 	for (const comment of comments) {
 		const session = sessionOf(comment.body);
-		if (session !== null) out.push({id: comment.id, session, createdAt: comment.createdAt});
+		if (session !== null) {
+			out.push({
+				id: comment.id,
+				session,
+				lane: laneOf(comment.body),
+				createdAt: comment.createdAt,
+			});
+		}
 	}
 	return out;
 };
@@ -88,23 +154,37 @@ export type ClaimResolution =
 	| {
 			readonly _tag: "Lost";
 			readonly holder: Marker;
-			/** Non-null by construction: a set holding no marker of this session is {@link MineAbsent}. */
+			/** Non-null by construction: a set holding no marker of this lane is {@link MineAbsent}. */
 			readonly mine: Marker;
 			readonly live: number;
 			readonly expired: number;
 	  }
-	/** No marker of this session survives — whatever was posted is not on the issue. */
+	/** No marker of this lane survives — whatever was posted is not on the issue. */
 	| {readonly _tag: "MineAbsent"; readonly live: number; readonly expired: number}
 	/** The ordering key itself could not be read, so no claim was resolved. */
 	| {readonly _tag: "Unresolvable"; readonly reason: string};
 
 export interface ResolveInput {
 	readonly markers: ReadonlyArray<Marker>;
-	readonly session: string;
+	/** Which claimant is asking — a lane, or a whole session for a namespace with no nonce yet. */
+	readonly caller: Caller;
 	/** Epoch milliseconds — the clock the TTL is measured against. */
 	readonly now: number;
 	readonly ttlMinutes: number;
 }
+
+/**
+ * Does `marker` name the asking claimant — its session, and its lane nonce too unless the caller
+ * named none?
+ *
+ * A `Lane` caller matches on the pair, which is the whole fix: two lanes of one session read each
+ * other's markers as foreign. An `AnySession` caller is the pre-#6132 identity, kept for the readers
+ * that have not adopted a nonce, and named rather than defaulted so the session-only rule cannot
+ * come back by omission.
+ */
+export const namesCaller = (marker: Marker, caller: Caller): boolean =>
+	marker.session === caller.session &&
+	(caller._tag === "AnySession" || marker.lane === caller.nonce);
 
 /** The markers still binding at `now`, oldest first — or the reason the set could not be ordered. */
 export type LiveMarkers =
@@ -129,7 +209,7 @@ export const liveMarkers = ({
 	markers,
 	now,
 	ttlMinutes,
-}: Omit<ResolveInput, "session">): LiveMarkers => {
+}: Omit<ResolveInput, "caller">): LiveMarkers => {
 	const ttlMs = ttlMinutes * 60_000;
 	const live: Marker[] = [];
 	let expired = 0;
@@ -153,28 +233,23 @@ export const liveMarkers = ({
 };
 
 /** Order the live markers, then let the earliest survivor win. */
-export const resolveClaim = ({
-	markers,
-	session,
-	now,
-	ttlMinutes,
-}: ResolveInput): ClaimResolution => {
+export const resolveClaim = ({markers, caller, now, ttlMinutes}: ResolveInput): ClaimResolution => {
 	const scanned = liveMarkers({markers, now, ttlMinutes});
 	if (scanned._tag === "Unresolvable") return scanned;
 	const {live: ordered, expired} = scanned;
 
-	const mine = ordered.find((m) => m.session === session) ?? null;
+	const mine = ordered.find((m) => namesCaller(m, caller)) ?? null;
 	const earliest = ordered[0];
 	if (earliest === undefined || mine === null) {
 		return {_tag: "MineAbsent", live: ordered.length, expired};
 	}
-	return earliest.session === session
+	return namesCaller(earliest, caller)
 		? {_tag: "Won", marker: earliest, live: ordered.length, expired}
 		: {_tag: "Lost", holder: earliest, mine, live: ordered.length, expired};
 };
 
 /**
- * This session's surviving marker, on either resolved outcome — `null` when it holds none.
+ * This lane's surviving marker, on either resolved outcome — `null` when it holds none.
  *
  * What "do I already hold a live marker here?" and "which marker do I retract on a loss?" both ask,
  * so both ask it once.

--- a/packages/fabrika-cli/src/triage/claim.unit.test.ts
+++ b/packages/fabrika-cli/src/triage/claim.unit.test.ts
@@ -1,11 +1,17 @@
 import {describe, expect, it} from "vitest";
 import {
+	anySessionCaller,
+	claimNonceOf,
+	composeClaimToken,
 	expiryOf,
 	isStampableSession,
+	laneCaller,
+	laneOf,
 	MARKER_PREFIX,
 	markerBody,
 	markersOf,
 	myMarker,
+	parseClaimToken,
 	resolveClaim,
 	sessionOf,
 } from "./claim.ts";
@@ -13,23 +19,36 @@ import {
 const MINE = "b2e1-4c07-4a99-9f30-55da1e6b7c02";
 const THEIRS = "7f3c-9a20-4b11-8e05-1d77c2a4f9be";
 
+const MY_LANE = "aaaaaaaa";
+const SIBLING_LANE = "bbbbbbbb";
+const THEIR_LANE = "cccccccc";
+
+/** The lane every case below asks as, and the sibling that shares its session and nothing else. */
+const me = laneCaller(MINE, MY_LANE);
+const sibling = laneCaller(MINE, SIBLING_LANE);
+
 const at = (iso: string) => Date.parse(iso);
 
-const marker = (id: number, session: string, createdAt: string) => ({
-	id,
-	session,
-	createdAt,
-});
+const body = (session: string, nonce: string) => markerBody({session, nonce});
 
-describe("markerBody / sessionOf", () => {
-	it("round-trips the exact one-line literal", () => {
-		expect(markerBody(MINE)).toBe(`${MARKER_PREFIX}${MINE} -->`);
-		expect(sessionOf(markerBody(MINE))).toBe(MINE);
+const marker = (
+	id: number,
+	session: string,
+	createdAt: string,
+	lane: string | null = session === MINE ? MY_LANE : THEIR_LANE,
+) => ({id, session, lane, createdAt});
+
+describe("markerBody / sessionOf / laneOf", () => {
+	it("round-trips the exact one-line literal, session and lane both", () => {
+		expect(body(MINE, MY_LANE)).toBe(`${MARKER_PREFIX}${MINE} lane=${MY_LANE} -->`);
+		expect(sessionOf(body(MINE, MY_LANE))).toBe(MINE);
+		expect(laneOf(body(MINE, MY_LANE))).toBe(MY_LANE);
 	});
 
 	it("ignores any comment that does not carry the prefix", () => {
 		expect(sessionOf("I am triaging this one, hands off")).toBeNull();
-		expect(sessionOf(`prose then ${markerBody(MINE)}`)).toBeNull();
+		expect(sessionOf(`prose then ${body(MINE, MY_LANE)}`)).toBeNull();
+		expect(laneOf("I am triaging this one, hands off")).toBeNull();
 	});
 
 	it("reads a malformed marker as a foreign claim, never as absent", () => {
@@ -37,6 +56,33 @@ describe("markerBody / sessionOf", () => {
 		// one direction the protocol may not fail.
 		expect(sessionOf(`${MARKER_PREFIX} -->`)).toBe("");
 		expect(sessionOf(`${MARKER_PREFIX}${MINE}`)).toBe(MINE);
+	});
+
+	it("reads a pre-#6132 session-only marker as a claim carrying no lane", () => {
+		const legacy = `${MARKER_PREFIX}${MINE} -->`;
+		expect(sessionOf(legacy)).toBe(MINE);
+		expect(laneOf(legacy)).toBeNull();
+	});
+
+	it("never reads a session id that begins `lane=` as its own lane nonce", () => {
+		expect(laneOf(`${MARKER_PREFIX}lane=forged -->`)).toBeNull();
+	});
+});
+
+describe("the triage claim token", () => {
+	it("carries its own namespace and confers the nonce the marker is stamped with", () => {
+		const token = composeClaimToken(MINE, "aaaaaaaa-1111-4222-8333-444444444444");
+		expect(token).toBe(`triage:${MINE}:aaaaaaaa-1111-4222-8333-444444444444`);
+		expect(parseClaimToken(token)).toEqual({
+			session: MINE,
+			uuid: "aaaaaaaa-1111-4222-8333-444444444444",
+		});
+		expect(claimNonceOf(token)).toBe(MY_LANE);
+	});
+
+	it("does not parse another namespace's token — a build lane is not a triage lane", () => {
+		expect(parseClaimToken(`build:${MINE}:aaaaaaaa-1111-4222-8333-444444444444`)).toBeNull();
+		expect(claimNonceOf("not-a-token")).toBeNull();
 	});
 });
 
@@ -53,27 +99,29 @@ describe("isStampableSession", () => {
 	it("rejects an id carrying `-->` — it would close the comment and escape as body text", () => {
 		// Both halves of the guard are load-bearing, and only the whitespace half fails loudly. An id
 		// containing `-->` is a single token, so it passes the first half; what it produces is
-		// `<!-- fabrika-triage-claim session=-->@here -->`, whose comment ends at the FIRST `-->` and
-		// renders `@here -->` as visible markdown in the comment this verb posts.
+		// `<!-- fabrika-triage-claim session=-->@here lane=x -->`, whose comment ends at the FIRST
+		// `-->` and renders the rest as visible markdown in the comment this verb posts.
 		expect(isStampableSession("-->x")).toBe(false);
 		expect(isStampableSession("-->@here")).toBe(false);
 		// the escape itself, so the guard is pinned to the thing it prevents rather than to a literal
-		const escaped = markerBody("-->@here");
+		const escaped = body("-->@here", MY_LANE);
 		expect(escaped.indexOf("-->")).toBeLessThan(escaped.length - "-->".length);
 	});
 });
 
 describe("markersOf", () => {
-	it("keeps only the marker comments, in read order", () => {
+	it("keeps only the marker comments, in read order, with the lane each names", () => {
 		expect(
 			markersOf([
 				{id: 1, createdAt: "2026-08-02T09:00:00Z", body: "a human comment"},
-				{id: 2, createdAt: "2026-08-02T09:14:02Z", body: markerBody(THEIRS)},
-				{id: 3, createdAt: "2026-08-02T09:15:00Z", body: markerBody(MINE)},
+				{id: 2, createdAt: "2026-08-02T09:14:02Z", body: body(THEIRS, THEIR_LANE)},
+				{id: 3, createdAt: "2026-08-02T09:15:00Z", body: body(MINE, MY_LANE)},
+				{id: 4, createdAt: "2026-08-02T09:16:00Z", body: `${MARKER_PREFIX}${MINE} -->`},
 			]),
 		).toEqual([
-			{id: 2, session: THEIRS, createdAt: "2026-08-02T09:14:02Z"},
-			{id: 3, session: MINE, createdAt: "2026-08-02T09:15:00Z"},
+			{id: 2, session: THEIRS, lane: THEIR_LANE, createdAt: "2026-08-02T09:14:02Z"},
+			{id: 3, session: MINE, lane: MY_LANE, createdAt: "2026-08-02T09:15:00Z"},
+			{id: 4, session: MINE, lane: null, createdAt: "2026-08-02T09:16:00Z"},
 		]);
 	});
 });
@@ -81,10 +129,10 @@ describe("markersOf", () => {
 describe("resolveClaim", () => {
 	const now = at("2026-08-02T10:00:00Z");
 
-	it("wins only when the earliest surviving marker is this session's", () => {
+	it("wins only when the earliest surviving marker is this lane's", () => {
 		const out = resolveClaim({
 			markers: [marker(3, MINE, "2026-08-02T09:50:00Z")],
-			session: MINE,
+			caller: me,
 			now,
 			ttlMinutes: 60,
 		});
@@ -94,7 +142,7 @@ describe("resolveClaim", () => {
 	it("loses to an earlier live marker and names the holder", () => {
 		const out = resolveClaim({
 			markers: [marker(3, MINE, "2026-08-02T09:50:00Z"), marker(2, THEIRS, "2026-08-02T09:14:02Z")],
-			session: MINE,
+			caller: me,
 			now,
 			ttlMinutes: 60,
 		});
@@ -108,7 +156,7 @@ describe("resolveClaim", () => {
 		const same = "2026-08-02T09:50:00Z";
 		const out = resolveClaim({
 			markers: [marker(9, MINE, same), marker(4, THEIRS, same)],
-			session: MINE,
+			caller: me,
 			now,
 			ttlMinutes: 60,
 		});
@@ -118,7 +166,7 @@ describe("resolveClaim", () => {
 	it("discards a marker older than the TTL and counts it", () => {
 		const out = resolveClaim({
 			markers: [marker(2, THEIRS, "2026-08-02T08:00:00Z"), marker(3, MINE, "2026-08-02T09:50:00Z")],
-			session: MINE,
+			caller: me,
 			now,
 			ttlMinutes: 60,
 		});
@@ -128,7 +176,7 @@ describe("resolveClaim", () => {
 	it("keeps a marker exactly at the TTL boundary binding", () => {
 		const out = resolveClaim({
 			markers: [marker(2, THEIRS, "2026-08-02T09:00:00Z"), marker(3, MINE, "2026-08-02T09:50:00Z")],
-			session: MINE,
+			caller: me,
 			now,
 			ttlMinutes: 60,
 		});
@@ -138,19 +186,19 @@ describe("resolveClaim", () => {
 	it("REFUSES rather than answering when an ordering key will not parse — `won` needs proof", () => {
 		const out = resolveClaim({
 			markers: [marker(2, THEIRS, "not-a-timestamp"), marker(3, MINE, "2026-08-02T09:50:00Z")],
-			session: MINE,
+			caller: me,
 			now,
 			ttlMinutes: 60,
 		});
 		expect(out._tag).toBe("Unresolvable");
 	});
 
-	it("reports MineAbsent — never Won — when no marker of this session survives", () => {
-		expect(resolveClaim({markers: [], session: MINE, now, ttlMinutes: 60})._tag).toBe("MineAbsent");
+	it("reports MineAbsent — never Won — when no marker of this lane survives", () => {
+		expect(resolveClaim({markers: [], caller: me, now, ttlMinutes: 60})._tag).toBe("MineAbsent");
 		expect(
 			resolveClaim({
 				markers: [marker(2, THEIRS, "2026-08-02T09:14:02Z")],
-				session: MINE,
+				caller: me,
 				now,
 				ttlMinutes: 60,
 			})._tag,
@@ -160,9 +208,10 @@ describe("resolveClaim", () => {
 	it("never resolves Won for a session that is not the caller's, whatever the marker set", () => {
 		// The fail-open shape v1 shipped: an empty identity compared equal to everything. Here an
 		// empty session matches only a marker that literally carries none.
+		const nameless = laneCaller("", MY_LANE);
 		const out = resolveClaim({
 			markers: [marker(2, THEIRS, "2026-08-02T09:14:02Z")],
-			session: "",
+			caller: nameless,
 			now,
 			ttlMinutes: 60,
 		});
@@ -172,8 +221,11 @@ describe("resolveClaim", () => {
 		// winner comparison itself runs — which is where the empty identity would compare equal. This
 		// case, not the one above, is what pins it.
 		const holdingOne = resolveClaim({
-			markers: [marker(2, THEIRS, "2026-08-02T09:14:02Z"), marker(3, "", "2026-08-02T09:50:00Z")],
-			session: "",
+			markers: [
+				marker(2, THEIRS, "2026-08-02T09:14:02Z"),
+				marker(3, "", "2026-08-02T09:50:00Z", MY_LANE),
+			],
+			caller: nameless,
 			now,
 			ttlMinutes: 60,
 		});
@@ -181,18 +233,62 @@ describe("resolveClaim", () => {
 	});
 });
 
+describe("resolveClaim — two lanes of one session", () => {
+	const now = at("2026-08-02T10:00:00Z");
+	// #6132: both siblings of a fan-out carry one CLAUDE_CODE_SESSION_ID. Resolved on the session id
+	// alone, each read the other's marker back as its own and BOTH answered `won`.
+	const markers = [
+		{id: 2, session: MINE, lane: SIBLING_LANE, createdAt: "2026-08-02T09:14:02Z"},
+		{id: 3, session: MINE, lane: MY_LANE, createdAt: "2026-08-02T09:50:00Z"},
+	];
+
+	it("hands the claim to exactly one of them — never both", () => {
+		const mine = resolveClaim({markers, caller: me, now, ttlMinutes: 60});
+		const theirs = resolveClaim({markers, caller: sibling, now, ttlMinutes: 60});
+		expect([mine._tag, theirs._tag].filter((tag) => tag === "Won")).toHaveLength(1);
+		expect(theirs._tag).toBe("Won");
+		expect(mine._tag).toBe("Lost");
+	});
+
+	it("gives the loser its OWN marker to retract, never the winner's", () => {
+		const mine = resolveClaim({markers, caller: me, now, ttlMinutes: 60});
+		expect(myMarker(mine)?.id).toBe(3);
+		if (mine._tag !== "Lost") throw new Error("unreachable");
+		expect(mine.holder.id).toBe(2);
+		expect(mine.holder.lane).toBe(SIBLING_LANE);
+	});
+
+	it("reads a sibling's marker as absent, not as its own, when it holds none itself", () => {
+		const only = [markers[0] as (typeof markers)[number]];
+		expect(resolveClaim({markers: only, caller: me, now, ttlMinutes: 60})._tag).toBe("MineAbsent");
+	});
+
+	it("treats a pre-#6132 session-only marker as another claimant's", () => {
+		const legacy = [{id: 2, session: MINE, lane: null, createdAt: "2026-08-02T09:14:02Z"}];
+		expect(resolveClaim({markers: legacy, caller: me, now, ttlMinutes: 60})._tag).toBe(
+			"MineAbsent",
+		);
+	});
+
+	it("still resolves on the session alone for a caller that named no lane", () => {
+		// The opt-in the readers with no nonce of their own keep — named, never a default.
+		const out = resolveClaim({markers, caller: anySessionCaller(MINE), now, ttlMinutes: 60});
+		expect(out._tag).toBe("Won");
+	});
+});
+
 describe("myMarker", () => {
-	it("finds this session's marker on both resolved outcomes and nowhere else", () => {
+	it("finds this lane's marker on both resolved outcomes and nowhere else", () => {
 		const now = at("2026-08-02T10:00:00Z");
 		const won = resolveClaim({
 			markers: [marker(3, MINE, "2026-08-02T09:50:00Z")],
-			session: MINE,
+			caller: me,
 			now,
 			ttlMinutes: 60,
 		});
 		const lost = resolveClaim({
 			markers: [marker(3, MINE, "2026-08-02T09:50:00Z"), marker(2, THEIRS, "2026-08-02T09:14:02Z")],
-			session: MINE,
+			caller: me,
 			now,
 			ttlMinutes: 60,
 		});

--- a/packages/fabrika-cli/src/triage/command.ts
+++ b/packages/fabrika-cli/src/triage/command.ts
@@ -14,6 +14,7 @@
  * **Every leaf is declared with `leafCommand`, never a bare `Command.make`** — the bare form
  * silently opts out of the excess-operand guard, which `../excess-operand.unit.test.ts` reds on.
  */
+import {randomUUID} from "node:crypto";
 import {Effect, Option} from "effect";
 import {Argument, Command, Flag} from "effect/unstable/cli";
 import {leafCommand} from "../excess-operand.ts";
@@ -235,24 +236,30 @@ const claim = leafCommand(
 	"claim",
 	{
 		issue: Argument.integer("issue").pipe(Argument.withDescription("the issue number to claim")),
+		token: Flag.string("token").pipe(
+			Flag.withDescription("the token a previous claim handed this lane — re-enter it, never mint"),
+			Flag.optional,
+		),
 		repo: repoFlag,
 		json: jsonFlag,
 	},
-	Effect.fn(function* ({issue, repo, json}) {
+	Effect.fn(function* ({issue, token, repo, json}) {
 		yield* emit(
 			yield* runClaim({
 				issue,
 				repo: Option.getOrNull(repo),
 				json,
+				token: Option.getOrNull(token),
+				uuid: randomUUID(),
 				env: process.env,
 				now: () => new Date(),
 			}),
 		);
 	}),
 ).pipe(
-	Command.withShortDescription("Take a session-scoped claim on one issue."),
+	Command.withShortDescription("Take one lane's claim on one issue."),
 	Command.withDescription(
-		'Take a session-scoped claim on one issue, proven by re-reading the markers back. Prints `won` or `lost\\t<holder-session-id>` — both are proven answers and both exit 0. Exits 1 (CLAUDE_CODE_SESSION_ID unset), 7 (no such issue, or it is closed), 8 (marker POST failed — UNKNOWN), 9 (marker absent on read-back, or a conceded marker could not be deleted), 11 (the issue or its comments could not be read — never "won"). Example: fabrika triage claim 4312',
+		"Take one lane's claim on one issue, proven by re-reading the markers back. Prints `won\\t<claim-token>` or `lost\\t<holder-session-id>` — both are proven answers and both exit 0. Keep the token: passing it back as --token re-enters this lane instead of minting a second one, which is what tells two triagers of ONE session apart. Exits 1 (CLAUDE_CODE_SESSION_ID unset, or --token is not this session's), 7 (no such issue, or it is closed), 8 (marker POST failed — UNKNOWN), 9 (marker absent on read-back, or a conceded marker could not be deleted), 11 (the issue or its comments could not be read — never \"won\"). Example: fabrika triage claim 4312",
 	),
 );
 

--- a/packages/fabrika-cli/src/triage/target-guard.ts
+++ b/packages/fabrika-cli/src/triage/target-guard.ts
@@ -12,6 +12,11 @@
  * one": an unclaimed issue is the ordinary first-triage case, and demanding a marker would refuse
  * every existing caller. The consequence is that this guard narrows the window rather than closing
  * it — two unclaimed sessions still race — which is `triage claim`'s job, not this one's.
+ *
+ * **The session is the whole identity here, and the lane nonce #6132 added is not read.** These five
+ * verbs are handed no claim token, so a sibling lane of one session reads its sibling's marker as
+ * its own and passes — the same window that stayed open before, no wider. Closing it means threading
+ * the token through every mutating verb, which is its own change.
  */
 import {Effect} from "effect";
 import type {ChildProcessSpawner} from "effect/unstable/process";

--- a/packages/fabrika-cli/src/triage/target-guard.unit.test.ts
+++ b/packages/fabrika-cli/src/triage/target-guard.unit.test.ts
@@ -9,6 +9,8 @@ import {foreignMarkers, guardTarget} from "./target-guard.ts";
 
 const MINE = "session-mine";
 const THEIRS = "session-theirs";
+/** This guard reads the session axis only, so which lane a marker names never changes its answer. */
+const LANE = "aaaaaaaa";
 
 const target = (over: Partial<IssueRecord> = {}): IssueRecord => ({
 	number: 4312,
@@ -54,36 +56,37 @@ describe("foreignMarkers", () => {
 		markers: ReadonlyArray<{
 			readonly id: number;
 			readonly session: string;
+			readonly lane: string | null;
 			readonly createdAt: string;
 		}>,
 		session: string,
 	) => foreignMarkers({markers, session, now, ttlMinutes: DEFAULT_TTL_MINUTES});
 
 	it("counts a live marker of another session foreign", () => {
-		const scanned = scan([{id: 1, session: THEIRS, createdAt: LIVE}], MINE);
+		const scanned = scan([{id: 1, session: THEIRS, lane: LANE, createdAt: LIVE}], MINE);
 		expect(scanned._tag).toBe("Foreign");
 		expect(scanned._tag === "Foreign" && scanned.foreign.map((m) => m.session)).toEqual([THEIRS]);
 	});
 
 	it("counts this session's own live marker as not foreign", () => {
-		const scanned = scan([{id: 1, session: MINE, createdAt: LIVE}], MINE);
+		const scanned = scan([{id: 1, session: MINE, lane: LANE, createdAt: LIVE}], MINE);
 		expect(scanned._tag === "Foreign" && scanned.foreign).toEqual([]);
 	});
 
 	it("ages an expired foreign marker out", () => {
-		const scanned = scan([{id: 1, session: THEIRS, createdAt: EXPIRED}], MINE);
+		const scanned = scan([{id: 1, session: THEIRS, lane: LANE, createdAt: EXPIRED}], MINE);
 		expect(scanned._tag === "Foreign" && scanned.foreign).toEqual([]);
 	});
 
 	// An empty id matches no marker, so a session-blind filter would answer "nobody else holds it"
 	// over a set full of live competitors — the one direction this may not fail.
 	it("counts every live marker foreign when this session cannot be attributed", () => {
-		const scanned = scan([{id: 1, session: MINE, createdAt: LIVE}], "");
+		const scanned = scan([{id: 1, session: MINE, lane: LANE, createdAt: LIVE}], "");
 		expect(scanned._tag === "Foreign" && scanned.foreign).toHaveLength(1);
 	});
 
 	it("refuses to resolve a marker whose ordering key will not parse", () => {
-		const scanned = scan([{id: 1, session: THEIRS, createdAt: "whenever"}], MINE);
+		const scanned = scan([{id: 1, session: THEIRS, lane: LANE, createdAt: "whenever"}], MINE);
 		expect(scanned._tag).toBe("Unresolvable");
 	});
 });


### PR DESCRIPTION
Fixes #6132

`triage claim` could tell two claimants apart only by `CLAUDE_CODE_SESSION_ID`, and a triage
fan-out gives every sibling the same one. Both siblings read a same-session marker back as their
own, both answered `won`, and both wrote the issue (twice on 2026-08-18).

A claim now names a **lane**, not a session:

- The marker carries the lane: `<!-- fabrika-triage-claim session=<id> lane=<nonce> -->`.
- The lane is a token, `triage:<session-id>:<uuid>`, minted by the claim and printed back as
  `won\t<token>`. It reuses the `Caller` / nonce primitive and the token grammar the `build`
  namespace already resolves ownership by (#6037), in its own prefix so the two never collide.
- `resolveClaim` decides `mine` and `Won` on session **and** nonce, so a sibling's marker is
  somebody else's — including for the retraction, where a loser used to delete whichever
  same-session marker was earliest, which could be its sibling's.
- Passing the token back as `--token` re-enters the same lane and posts no second marker, so genuine
  re-entry stays idempotent. A tokenless re-run is a new lane and races like one.
- A pre-existing marker with no `lane=` field still parses, still ages out on the TTL, and reads as
  another claimant's — never as a wildcard.

Tests drive two claimants that share one session id and assert exactly one wins, that the loser
retracts its own marker, and that a lane re-entering under its token posts nothing.

Start with `packages/fabrika-cli/src/triage/claim.ts` (`namesCaller`, `markerBody`, `laneOf`), then
`callerFrom` in `claim-verb.ts`.

## Deviations

- **Known defect left unfixed** — **Said:** #6132's criteria cover the claim marker, `resolveClaim`,
  the tests and the `claim-verb.ts` docblock. **Did:** left `guardTarget` / `foreignMarkers` in
  `target-guard.ts` resolving on the session id alone, so the five mutating verbs still let a
  sibling lane of one session write an issue it lost. **Why:** those verbs are handed no claim
  token, so closing it means adding `--token` to `apply`/`enrich`/`split`/`park`/`kill` and their
  contract rows — a change wider than this issue, and the window is no wider than before this PR
  (the loser used to win outright). **Disposition:** filed as #6303, and stated in the module's
  docblock and in the contract so nobody reads the guard as lane-aware.
- **Out-of-scope change** — **Said:** nothing in #6132 asks for the verb's output grammar to change.
  **Did:** `won` now prints `won\t<claim-token>`, `--json` gained `token` and `holderLane`, the
  `lost` notice names the holder's lane, and `triage claim` gained a `--token` flag; the contract
  and the triage SKILL step 1 are updated to match. **Why:** the nonce has to reach the lane that
  owns it, or the lane can never prove re-entry — criterion 4's idempotency has no other carrier.
  **Disposition:** stated here.
