### PR TITLE
fix: The lane: and epic claim namespaces still resolve ownership on session id alone

### DIFF
--- a/claude-plugins/fabrika/skills/check-epic-plan/SKILL.md
+++ b/claude-plugins/fabrika/skills/check-epic-plan/SKILL.md
@@ -98,7 +98,7 @@ defective path is terminal here.** Re-planning is `plan-epic`'s lane; hand back 
 Only on a clean floor:
 
 ```bash
-fabrika plan flip $epic_number --digest 4d90e1bb27ac
+fabrika plan flip $epic_number --digest 4d90e1bb27ac --token <claim-token>
 ```
 
 The flip is **unconditional over every `status:planned` child** and not yours to narrow: there is
@@ -140,7 +140,7 @@ the check and the flip; nothing was written, so re-check rather than retry.
 ## 4 — Post the verdict, bound to the scope you scanned
 
 ```bash
-fabrika plan verdict $epic_number --digest 4d90e1bb27ac <<'EOF'
+fabrika plan verdict $epic_number --digest 4d90e1bb27ac --token <claim-token> <<'EOF'
 caveat: ac-not-checkable #<child> — "works well" states no observable outcome
 EOF
 ```

--- a/claude-plugins/fabrika/skills/check-epic-plan/contract.md
+++ b/claude-plugins/fabrika/skills/check-epic-plan/contract.md
@@ -340,7 +340,7 @@ nothing, since `epic` already seats `20`–`24` over the same two `build` codes.
 | `9` | the write landed but the read-back does not match | — | — | — | ✓ |
 | `10` | a value off its closed vocabulary — a semantic refusal, never a malformed-flag usage error | ✓ | ✓ | ✓ | ✓ |
 | `11` | a required read failed — nothing was written, no outcome is proven | ✓ | ✓ | ✓ | ✓ |
-| `15` | proven: this session does not hold the epic's claim (imported from `build`) | — | — | ✓ | ✓ |
+| `15` | proven: this lane does not hold the epic's claim (imported from `build`) | — | — | ✓ | ✓ |
 | `20` | proven: the floor derived hard defects — refused as a **precondition to writing**, never as `plan check`'s own answer | — | — | ✓ | — |
 | `21` | proven: the plan moved — the recomputed digest differs from the `--digest` the caller carried | — | — | ✓ | ✓ |
 | `22` | proven: at least one child is `unchanged` — the flip did not fully apply; the observed set is on stderr | — | — | ✓ | — |
@@ -565,7 +565,7 @@ $ echo $?
 **Invocation**
 
 ```
-fabrika plan flip 4300 --digest 4d90e1bb27ac
+fabrika plan flip 4300 --digest 4d90e1bb27ac --token <claim-token>
 ```
 
 **Inputs**
@@ -574,6 +574,7 @@ fabrika plan flip 4300 --digest 4d90e1bb27ac
 |---|---|---|---|---|
 | `<number>` | positional integer | yes | — | the epic whose planned children are flipped, and whose own audience label is flipped with them |
 | `--digest` | string, 12 lowercase hex | yes | — | the scope digest `plan check` printed; the flip refuses if the plan has moved since |
+| `--token` | string | yes | — | the claim token `build claim <epic> --purpose gate` printed — which lane is asking (#6060) |
 | `--repo` | string | no | `resolveRepo`'s precedence | the repository written |
 
 **Output** — machine. The **observed** result per child and for the epic, never the intended one:
@@ -675,7 +676,7 @@ comparable to `plan check`'s directly, and a verdict posted afterwards binds the
 | `8` | a write was attempted and no re-read could prove its outcome — UNKNOWN |
 | `10` | the issue is not a `type:epic`, or `--digest` is not 12 lowercase hex |
 | `11` | a read the flip depends on failed — **nothing is written** |
-| `15` | proven: this session does not hold the epic's claim |
+| `15` | proven: this lane does not hold the epic's claim |
 | `20` | proven: the re-gate derived hard defects — the floor is not clean, nothing is written |
 | `21` | proven: the recomputed digest differs from `--digest` — the plan moved since the check |
 | `22` | proven: at least one child is `unchanged`, or the epic did not reach `ready-for:agent` — the refs are on stderr |
@@ -691,7 +692,7 @@ comparable to `plan check`'s directly, and a verdict posted afterwards binds the
 | `plan flip: every child flipped but epic #<n> does not carry ready-for:agent alone — the epic is half-flipped and needs a human.` | 22 | refusal |
 | `plan flip: label "<name>" is absent from <repo>'s taxonomy — refusing to create it (#4285).` | 23 | refusal |
 | `plan flip: wrote <n> label change(s) and could not re-read <what> — the outcome is UNKNOWN.` | 8 | refusal |
-| `plan flip: this session does not hold #<n>'s claim.` | 15 | refusal |
+| `plan flip: #<n> is held by <token>, not by <this lane's token>.` | 15 | refusal |
 | `plan flip: --digest must be 12 lowercase hex — got "<v>".` | 10 | refusal |
 | `plan flip: #<n> is not a type:epic — refusing to flip its children.` | 10 | refusal |
 | `plan flip: #<n> has zero children — refusing to act over zero scope (ADR 0092).` | 7 | refusal |
@@ -708,12 +709,12 @@ succeeded — and with the epic still owed its label, that one write is the whol
 **Examples**
 
 ```
-$ fabrika plan flip 4300 --digest 4d90e1bb27ac
+$ fabrika plan flip 4300 --digest 4d90e1bb27ac --token <claim-token>
 {"answer":"flipped","epic":4300,"digest":"4d90e1bb27ac","terminal":"flipped-all","children":[{"number":4301,"observed":["p1","status:triaged","type:feature"],"result":"flipped"}],"flipped":1,"already":0,"audience":{"result":"flipped","observed":["ready-for:agent","type:epic"]}}
 ```
 
 ```
-$ fabrika plan flip 4300 --digest 4d90e1bb27ac
+$ fabrika plan flip 4300 --digest 4d90e1bb27ac --token <claim-token>
 plan flip: 2 of 3 children flipped; 1 unchanged (#4303) — the epic is half-flipped and needs a human.
 $ echo $?
 22
@@ -738,7 +739,7 @@ $ echo $?
 **Invocation**
 
 ```
-fabrika plan verdict 4300 --digest 4d90e1bb27ac <<'EOF'
+fabrika plan verdict 4300 --digest 4d90e1bb27ac --token <claim-token> <<'EOF'
 caveat: ac-not-checkable #4302 — "works well" states no observable outcome
 EOF
 ```
@@ -750,6 +751,7 @@ EOF
 | `<number>` | positional integer | yes | — | the epic the verdict is posted on |
 | `--digest` | string, 12 lowercase hex | yes | — | the scope digest `plan check` printed; the verdict binds it and refuses if the plan has moved |
 | `--polarity` | enum: `PASS` \| `FAIL` | no | derived from the floor | an optional cross-check — when supplied and it disagrees with the floor this verb derives, the verb refuses on `10` rather than posting either. No step in [SKILL.md](SKILL.md) supplies it; it exists for an operator driving the verb by hand, and its absence from the skill is deliberate, not a missing step |
+| `--token` | string | yes | — | the claim token `build claim <epic> --purpose gate` printed — which lane is asking (#6060) |
 | `--repo` | string | no | `resolveRepo`'s precedence | the repository written |
 | stdin | markdown | no | empty | advisory caveats, one per line, each `caveat: <kind> #<ref> — <text>`; empty is an ordinary answer |
 
@@ -799,7 +801,7 @@ the only emit path; a hand-posted marker is how v1's corpus carried a fake-looki
 | `9` | the comment posted but the read-back does not match |
 | `10` | `--digest` malformed; the issue is not a `type:epic`; `--polarity` disagrees with the derived floor; a caveat kind off the closed set; a caveat naming a ref outside the scanned set |
 | `11` | a read the verdict depends on failed — nothing is posted |
-| `15` | proven: this session does not hold the epic's claim |
+| `15` | proven: this lane does not hold the epic's claim |
 | `21` | proven: the recomputed digest differs from `--digest` — the plan moved since the check |
 
 There is no `20` here. A defective floor is not a refusal for this verb — it posts the `FAIL`
@@ -823,7 +825,7 @@ which is what `10` means.
 | `plan verdict: the comment posted but does not read back — the verdict needs a human eye.` | 9 | refusal |
 | `plan verdict: #<n> has zero children — there is no scope to attest.` | 7 | refusal |
 | `plan verdict: cannot read <what>: <reason> — nothing was posted.` | 11 | refusal |
-| `plan verdict: this session does not hold #<n>'s claim.` | 15 | refusal |
+| `plan verdict: #<n> is held by <token>, not by <this lane's token>.` | 15 | refusal |
 | `plan verdict: the ledger grammar refused: <reason>` | 4 | refusal |
 
 **Scope** — one epic and **every one of its children**, because deriving the floor and recomputing
@@ -833,14 +835,14 @@ Zero children is `7`.
 **Examples**
 
 ```
-$ fabrika plan verdict 4300 --digest 4d90e1bb27ac <<'EOF'
+$ fabrika plan verdict 4300 --digest 4d90e1bb27ac --token <claim-token> <<'EOF'
 caveat: ac-not-checkable #4302 — "works well" states no observable outcome
 EOF
 {"answer":"posted","epic":4300,"polarity":"PASS","digest":"4d90e1bb27ac","skipped":[],"comment":5230661234,"caveats":1}
 ```
 
 ```
-$ fabrika plan verdict 4300 --digest 81c7a30f5e42 <<'EOF'
+$ fabrika plan verdict 4300 --digest 81c7a30f5e42 --token <claim-token> <<'EOF'
 caveat: vibes #4302 — feels thin
 EOF
 plan verdict: caveat kind "vibes" is not in the closed set (ac-not-checkable, brief-fidelity, slice-too-broad, dependency-implied-not-declared).

--- a/claude-plugins/fabrika/skills/operate/SKILL.md
+++ b/claude-plugins/fabrika/skills/operate/SKILL.md
@@ -71,9 +71,18 @@ node <fabrika> lane claim $lane_key
 Exit `0` is yours to drive — `won` on an issue lane, `unclaimable` on a `chore:<name>` key, which
 carries no board number for a marker to sit on and so races with nobody. Exit `31` is a **proven
 loss**: another driver holds this lane, its token is named on stderr, and this run ends `LANE-HELD`
-having emitted no ledger and spawned no shell. `1` (no `CLAUDE_CODE_SESSION_ID`), `8` (the marker
-write is UNKNOWN), `9` (it landed and does not read back) and `11` (the marker set could not be
-read) all end `STOPPED` naming the code — an unproven claim is never driven through.
+having emitted no ledger and spawned no shell. `1` (no `CLAUDE_CODE_SESSION_ID`, or a `--token` that
+is not a lane-claim token of this session), `8` (the marker write is UNKNOWN), `9` (it landed and
+does not read back) and `11` (the marker set could not be read) all end `STOPPED` naming the code —
+an unproven claim is never driven through.
+
+**Keep the `token` a `won` prints — it is this driver's name, and `lane release` takes it as
+`--token`.** One session routinely spawns several operators, so a release handed only the session id
+cannot tell a sibling driver's marker from yours, and used to delete it: an unrecoverable retraction
+that left the lane reading unclaimed ([#6060](https://github.com/kamp-us/phoenix/issues/6060)).
+Re-claiming with the token you already hold is the idempotent path — it answers `won` with the same
+marker and writes nothing, rather than stacking a second marker a single release cannot clear
+([#6087](https://github.com/kamp-us/phoenix/issues/6087)).
 
 The claim is the driver's own namespace, `lane-claim:`, not the builder's `build-claim:`. That is
 what lets the builder you spawn on this very number claim it and win: two markers on one thread,
@@ -463,11 +472,16 @@ comment or the transcript has landed, so a successor that wins the lane the mome
 the artifact already there:
 
 ```bash
-node <fabrika> lane release $lane_key
+node <fabrika> lane release $lane_key --token <lane-claim-token>
 ```
 
-Exit `0` is released (or `inert` on a chore key, which was never claimable). `31` means this session
-holds no claim — say so and stop; you never retract another driver's marker. `8` or `11` leaves
+The token is the one step 1's `won` printed — omit it on a board lane and the verb refuses on `1`
+rather than guessing which driver is releasing. A `chore:<name>` key needs none, having never been
+handed one.
+
+Exit `0` is released (or `inert` on a chore key, which was never claimable). `31` means this driver
+holds no claim — say so and stop; you never retract another driver's marker, including a sibling
+driver of your own session. `8` or `11` leaves
 whether the lane is still held UNKNOWN: name the code in your terminal line rather than reporting a
 release you cannot prove. A `STOPPED` run releases too — a claim outliving the driver that took it
 is the same lane nobody can pick up.

--- a/claude-plugins/fabrika/skills/plan-epic/SKILL.md
+++ b/claude-plugins/fabrika/skills/plan-epic/SKILL.md
@@ -85,12 +85,14 @@ back to `build`: you hold no claim, and `build note` requires one.
 ## 2 — Open the run
 
 ```bash
-fabrika ledger open $epic_number
+fabrika ledger open $epic_number --token <claim-token>
 ```
 
 This proves the ground fresh against `origin/main`, allocates the run directory keyed on the
-**claim nonce** — never the session, which every sibling subagent of one run shares — and reads
-what already exists.
+**claim nonce `--token` names** — never the session, which every sibling subagent of one run shares
+— and reads what already exists. That is why every `ledger` verb takes the token: handed only a
+session id, the claim check passed for a lane that had *lost* the epic's claim and then derived the
+holder's run key, so two planning lanes wrote into one directory (#6060).
 
 Done when you hold `run`, `mode` (`fresh` or `re-plan`), `children`, `cycleDoc`, `bodyDigest`, and
 `candidates`. Carry `bodyDigest` as `--body-digest` to `ledger draft` and `ledger write`; it is how
@@ -111,7 +113,7 @@ syncing and planning again is a fresh run from step 1, not a loop inside this on
 This is your work. Write the plan block and stage it:
 
 ```bash
-fabrika ledger draft $epic_number --body-digest 8f2c1a90b4d7 <<'EOF'
+fabrika ledger draft $epic_number --body-digest 8f2c1a90b4d7 --token <claim-token> <<'EOF'
 ## Plan (plan-epic)
 
 ### Summary
@@ -137,7 +139,8 @@ cannot say which story each slice serves is telling you the split is wrong.
 
 ```bash
 fabrika ledger child $epic_number --title "queue view: fate loader" \
-  --type type:feature --priority p1 --ready-for agent --milestone "fabrika campaign" <<'EOF'
+  --type type:feature --priority p1 --ready-for agent --milestone "fabrika campaign" \
+  --token <claim-token> <<'EOF'
 **Stories:** 1, 2
 **TDD:** yes
 **Containment:** flag (default-off)
@@ -181,7 +184,7 @@ parser that harvests every digit run reads `1, 3 (see #<other>)` as claiming a s
 On a `re-plan`, a child the new plan drops is retired rather than left dangling:
 
 ```bash
-fabrika ledger supersede $epic_number --child 4288 --reason "folded into the loader slice"
+fabrika ledger supersede $epic_number --child 4288 --reason "folded into the loader slice" --token <claim-token>
 ```
 
 It journals the reason, unlinks, then closes as not-planned — in that order, so a child is never
@@ -190,7 +193,7 @@ closed while still linked. It refuses a child that is not this epic's, and one t
 ## 5 — Declare the topology
 
 ```bash
-fabrika ledger topology $epic_number <<'EOF'
+fabrika ledger topology $epic_number --token <claim-token> <<'EOF'
 #<child-a> phase 1
 #<child-b> phase 1
 #<child-c> phase 2 requires #<child-a>
@@ -208,7 +211,7 @@ file plan; you can. Sequence them, or say in `### Task-split rationale` why they
 ## 6 — Write it into the epic
 
 ```bash
-fabrika ledger write $epic_number --body-digest 8f2c1a90b4d7
+fabrika ledger write $epic_number --body-digest 8f2c1a90b4d7 --token <claim-token>
 ```
 
 The staged plan and topology go into the epic body in one PATCH, re-read and compared byte for

--- a/claude-plugins/fabrika/skills/plan-epic/contract.md
+++ b/claude-plugins/fabrika/skills/plan-epic/contract.md
@@ -397,7 +397,7 @@ it, and the alignment checker is base-only by design (`occupied = allocatedCodes
 | `10` | a value off its closed vocabulary — a semantic refusal, never a malformed-flag usage error | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ |
 | `11` | a required read failed — nothing was written, no outcome is proven | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ |
 | `13` | proven: the tree was dirty at a `--require-clean` open (`build`'s meaning, reserved — no `ledger` verb declares that flag) | — | — | — | — | — | — |
-| `15` | proven: this session does not hold the epic's claim (imported from `build`) | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ |
+| `15` | proven: this lane does not hold the epic's claim (imported from `build`) | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ |
 | `20` | proven: the tree's base is behind `origin/main` | ✓ | — | — | — | — | — |
 | `21` | proven: the epic body moved — the recomputed digest differs from `--body-digest` | — | ✓ | — | — | ✓ | — |
 | `22` | proven: the plan region is unresolvable — a duplicated anchor, or a mode the body contradicts | ✓ | — | — | — | ✓ | — |
@@ -431,7 +431,7 @@ opposite repairs.
 **Invocation**
 
 ```
-fabrika ledger open 4300 [--repo <owner/name>]
+fabrika ledger open 4300 --token <claim-token> [--repo <owner/name>]
 ```
 
 **Inputs**
@@ -439,6 +439,7 @@ fabrika ledger open 4300 [--repo <owner/name>]
 | Flag | Type | Required | Default | Description |
 |---|---|---|---|---|
 | `<number>` | positional integer | yes | — | the epic being planned |
+| `--token` | string | yes | — | the claim token `build claim <epic> --purpose plan` printed — which lane is asking, and the nonce the run key is derived from (#6060) |
 | `--repo` | string | no | `resolveRepo`'s precedence | the repository read |
 
 **Output** — machine. One JSON object:
@@ -491,7 +492,7 @@ call site (#4167) — so the tree is stale by default until shown otherwise.
 | `7` | the epic is proven absent (404) or closed |
 | `10` | the issue is not a `type:epic` |
 | `11` | the epic, its sub-issue list, the backlog read, the cycle-doc probe, or the freshness probe could not be read |
-| `15` | this session does not hold the epic's claim |
+| `15` | this lane does not hold the epic's claim |
 | `20` | the tree's base is proven behind `origin/main` |
 | `22` | the body carries two or more `## Plan (plan-epic)` headings — the run's mode cannot be decided |
 
@@ -502,7 +503,7 @@ call site (#4167) — so the tree is stale by default until shown otherwise.
 | `ledger open: issue #<n> is proven absent or closed.` | 7 | refusal |
 | `ledger open: #<n> is not a type:epic — refusing to plan it.` | 10 | refusal |
 | `ledger open: cannot read <what>: <reason> — the ground is UNKNOWN.` | 11 | refusal |
-| `ledger open: this session does not hold #<n>'s claim.` | 15 | refusal |
+| `ledger open: this lane does not hold #<n>'s claim.` | 15 | refusal |
 | `ledger open: base is <k> commit(s) behind origin/main — a plan derived here is derived on stale ground (#3330).` | 20 | refusal |
 | `ledger open: #<n>'s body carries <k> "## Plan (plan-epic)" headings — the plan mode has no single meaning.` | 22 | refusal |
 
@@ -515,12 +516,12 @@ which is why `outcome: "none"` is an answer and only an unreachable index is `in
 **Examples**
 
 ```
-$ fabrika ledger open 4300
+$ fabrika ledger open 4300 --token <claim-token>
 {"answer":"opened","epic":4300,"run":"4300-7f31a2","mode":"fresh","bodyDigest":"8f2c1a90b4d7","dir":"/w/.fabrika-plan/4300-7f31a2","children":[],"cycleDoc":"present","candidates":{"outcome":"none","items":[]}}
 ```
 
 ```
-$ fabrika ledger open 4300
+$ fabrika ledger open 4300 --token <claim-token>
 ledger open: base is 47 commit(s) behind origin/main — a plan derived here is derived on stale ground (#3330).
 $ echo $?
 20
@@ -546,7 +547,7 @@ $ echo $?
 **Invocation**
 
 ```
-fabrika ledger draft 4300 --body-digest 8f2c1a90b4d7 <<'EOF'
+fabrika ledger draft 4300 --body-digest 8f2c1a90b4d7 --token <claim-token> <<'EOF'
 ## Plan (plan-epic)
 
 ### Summary
@@ -560,6 +561,7 @@ EOF
 |---|---|---|---|---|
 | `<number>` | positional integer | yes | — | the epic whose plan is staged |
 | `--body-digest` | string, 12 lowercase hex | yes | — | the digest `ledger open` printed; the draft refuses if the epic body has moved since |
+| `--token` | string | yes | — | the claim token `build claim <epic> --purpose plan` printed — which lane is asking, and the nonce the run key is derived from (#6060) |
 | `--repo` | string | no | `resolveRepo`'s precedence | the repository read |
 | stdin | markdown | yes | — | the plan block, opening with `## Plan (plan-epic)` |
 
@@ -595,7 +597,7 @@ splices.
 | `7` | the epic is proven absent or closed |
 | `10` | the issue is not a `type:epic`, or `--body-digest` is not 12 lowercase hex |
 | `11` | the epic body or the run directory could not be read |
-| `15` | this session does not hold the epic's claim |
+| `15` | this lane does not hold the epic's claim |
 | `21` | the recomputed body digest differs from `--body-digest` |
 
 **Errors**
@@ -615,7 +617,7 @@ splices.
 | `ledger draft: --body-digest must be 12 lowercase hex — got "<v>".` | 10 | refusal |
 | `ledger draft: #<n> is not a type:epic — refusing to stage a plan for it.` | 10 | refusal |
 | `ledger draft: cannot read <what>: <reason> — nothing was staged.` | 11 | refusal |
-| `ledger draft: this session does not hold #<n>'s claim.` | 15 | refusal |
+| `ledger draft: this lane does not hold #<n>'s claim.` | 15 | refusal |
 | `ledger draft: the epic body moved since open (digest <a> → <b>) — re-open before staging.` | 21 | refusal |
 
 **Scope** — one document on stdin and one epic body read. Zero scope is unreachable: stdin is
@@ -624,12 +626,12 @@ required, and an empty one is `3`.
 **Examples**
 
 ```
-$ fabrika ledger draft 4300 --body-digest 8f2c1a90b4d7 < plan.md
+$ fabrika ledger draft 4300 --body-digest 8f2c1a90b4d7 --token <claim-token> < plan.md
 {"answer":"staged","epic":4300,"document":"plan","sections":10,"stories":[1,2,3],"bytes":4187}
 ```
 
 ```
-$ fabrika ledger draft 4300 --body-digest 8f2c1a90b4d7 < plan.md
+$ fabrika ledger draft 4300 --body-digest 8f2c1a90b4d7 --token <claim-token> < plan.md
 ledger draft: user stories are numbered 1, 2, 4 — a story list must run from 1 with no gaps or repeats.
 $ echo $?
 4
@@ -652,7 +654,7 @@ $ echo $?
 **Invocation**
 
 ```
-fabrika ledger child 4300 --title "queue view: fate loader" --type type:feature --priority p1 --ready-for agent [--assignee <login>] --milestone <title> [--label <name>]… <<'EOF'
+fabrika ledger child 4300 --title "queue view: fate loader" --type type:feature --priority p1 --ready-for agent [--assignee <login>] --milestone <title> [--label <name>]… --token <claim-token> <<'EOF'
 **Stories:** 1, 2
 **TDD:** yes
 **Containment:** flag (default-off)
@@ -677,6 +679,7 @@ EOF
 | `--assignee` | string (login) | no | none | required when `--ready-for human`; born-assignment is the enforced hold |
 | `--milestone` | string (open milestone title) | **required unless a `--label` carries a standing lane** | none | the child's home; a call naming neither is refused on `10` before any read (#5969) |
 | `--label` | string, repeatable | no | none | any further label, applied in the same create call |
+| `--token` | string | yes | — | the claim token `build claim <epic> --purpose plan` printed — which lane is asking, and the nonce the run key is derived from (#6060) |
 | `--repo` | string | no | `resolveRepo`'s precedence | the repository written |
 | stdin | markdown | yes | — | the child body's fields and sections |
 
@@ -765,7 +768,7 @@ link, deliberately** — see step 5.
 | `9` | the child was created and the re-read does not match what was sent |
 | `10` | a label, `--type`, `--priority`, `--milestone` or `--ready-for` value off its closed vocabulary; `--ready-for` absent; `--ready-for human` without `--assignee`; or the issue is not a `type:epic` |
 | `11` | a precondition read failed — **nothing was created** |
-| `15` | this session does not hold the epic's claim |
+| `15` | this lane does not hold the epic's claim |
 | `23` | the child was created and its sub-issue link could not be proven |
 | `26` | the child was created and the run manifest could not be written — the child exists and this run has no record of it |
 
@@ -790,7 +793,7 @@ link, deliberately** — see step 5.
 | `ledger child: a child needs a home — pass --milestone <open milestone title>, or --label the child with the parent's standing lane (wayfinder:backlog, axis:pipeline-hardening). A homeless child is refused at the claim fence, so it can never be built (#5969).` | 10 | refusal |
 | `ledger child: --priority <v> is off the closed set (p0, p1, p2).` | 10 | refusal |
 | `ledger child: cannot read <what>: <reason> — nothing was created.` | 11 | refusal |
-| `ledger child: this session does not hold #<n>'s claim.` | 15 | refusal |
+| `ledger child: this lane does not hold #<n>'s claim.` | 15 | refusal |
 | `ledger child: created #<c> and could not prove the sub-issue link — the child exists, is recorded in the run manifest as linked:false, and is unlinked on GitHub.` | 23 | refusal |
 | `ledger child: created #<c> and could not write the run manifest: <reason> — the child exists and this run holds no record of it.` | 26 | refusal |
 
@@ -801,12 +804,12 @@ scope is unreachable: the verb writes exactly one child or refuses.
 **Examples**
 
 ```
-$ fabrika ledger child 4300 --title "queue view: fate loader" --type type:feature --priority p1 --ready-for agent --milestone "fabrika campaign" < child.md
+$ fabrika ledger child 4300 --title "queue view: fate loader" --type type:feature --priority p1 --ready-for agent --milestone "fabrika campaign" --token <claim-token> < child.md
 {"answer":"minted","epic":4300,"child":4301,"linked":true,"observed":{"labels":["p1","ready-for:agent","status:planned","type:feature"],"assignees":[],"milestone":"fabrika campaign"},"stories":[1,2],"containment":"flag"}
 ```
 
 ```
-$ fabrika ledger child 4300 --title "moderation queue triage rules" --type type:feature --priority p1 --ready-for human < child.md
+$ fabrika ledger child 4300 --title "moderation queue triage rules" --type type:feature --priority p1 --ready-for human --token <claim-token> < child.md
 ledger child: --ready-for human requires --assignee — a held child is born assigned (#4693).
 $ echo $?
 10
@@ -835,7 +838,7 @@ $ echo $?
 **Invocation**
 
 ```
-fabrika ledger topology 4300 <<'EOF'
+fabrika ledger topology 4300 --token <claim-token> <<'EOF'
 #4301 phase 1
 #4302 phase 1
 #4303 phase 2 requires #4301
@@ -847,6 +850,7 @@ EOF
 | Flag | Type | Required | Default | Description |
 |---|---|---|---|---|
 | `<number>` | positional integer | yes | — | the epic whose topology is declared |
+| `--token` | string | yes | — | the claim token `build claim <epic> --purpose plan` printed — which lane is asking, and the nonce the run key is derived from (#6060) |
 | `--repo` | string | no | `resolveRepo`'s precedence | the repository read |
 | stdin | line grammar | yes | — | one line per child: `#<ref> phase <n> [requires #<a>[, #<b>]…]` |
 
@@ -883,7 +887,7 @@ skill carries (#3709), and the verb does not pretend otherwise.
 | `7` | zero scope: the epic is proven absent or closed, **or the run manifest holds zero children** |
 | `10` | the issue is not a `type:epic`, or a phase number is not a positive integer |
 | `11` | the run manifest or the epic could not be read |
-| `15` | this session does not hold the epic's claim |
+| `15` | this lane does not hold the epic's claim |
 | `24` | the topology is proven invalid: a cycle, a reference to a non-child, a manifest child placed nowhere, or a rendered block that does not parse back to the declared edges |
 
 **Errors**
@@ -902,7 +906,7 @@ skill carries (#3709), and the verb does not pretend otherwise.
 | `ledger topology: #<n> is not a type:epic — refusing to declare a topology for it.` | 10 | refusal |
 | `ledger topology: phase "<v>" is not a positive integer.` | 10 | refusal |
 | `ledger topology: cannot read <what>: <reason> — nothing was staged.` | 11 | refusal |
-| `ledger topology: this session does not hold #<n>'s claim.` | 15 | refusal |
+| `ledger topology: this lane does not hold #<n>'s claim.` | 15 | refusal |
 
 **Scope** — the run manifest's whole child set and every declared line, plus one read of the epic for the shared preconditions. It writes nothing. **Zero scope reds on `7`**:
 an empty manifest means the epic has no children at all — none retained by the seed and none minted since — and rendering a topology over no children
@@ -914,12 +918,12 @@ of calling it defect number one (ADR 0092).
 **Examples**
 
 ```
-$ fabrika ledger topology 4300 < topo.txt
+$ fabrika ledger topology 4300 --token <claim-token> < topo.txt
 {"answer":"staged","epic":4300,"document":"topology","phases":2,"children":3,"edges":[["#4303","#4301"]],"bytes":214}
 ```
 
 ```
-$ fabrika ledger topology 4300 < topo.txt
+$ fabrika ledger topology 4300 --token <claim-token> < topo.txt
 ledger topology: child #4302 is placed in no phase.
 $ echo $?
 24
@@ -942,7 +946,7 @@ $ echo $?
 **Invocation**
 
 ```
-fabrika ledger write 4300 --body-digest 8f2c1a90b4d7
+fabrika ledger write 4300 --body-digest 8f2c1a90b4d7 --token <claim-token>
 ```
 
 **Inputs**
@@ -951,6 +955,7 @@ fabrika ledger write 4300 --body-digest 8f2c1a90b4d7
 |---|---|---|---|---|
 | `<number>` | positional integer | yes | — | the epic whose body is written |
 | `--body-digest` | string, 12 lowercase hex | yes | — | the digest `ledger open` printed; the write refuses if the body has moved since |
+| `--token` | string | yes | — | the claim token `build claim <epic> --purpose plan` printed — which lane is asking, and the nonce the run key is derived from (#6060) |
 | `--repo` | string | no | `resolveRepo`'s precedence | the repository written |
 
 **Output** — machine.
@@ -1000,7 +1005,7 @@ every byte outside it.
 | `9` | the body was written and does not read back as composed |
 | `10` | the issue is not a `type:epic`, or `--body-digest` is not 12 lowercase hex |
 | `11` | the epic body or the run directory could not be read — **nothing was written** |
-| `15` | this session does not hold the epic's claim |
+| `15` | this lane does not hold the epic's claim |
 | `21` | the recomputed body digest differs from `--body-digest` |
 | `22` | the plan region is unresolvable: a duplicated anchor, or a mode the body contradicts |
 | `25` | `plan.md` or `topology.md` was never staged in this run |
@@ -1019,7 +1024,7 @@ every byte outside it.
 | `ledger write: #<n> is not a type:epic — refusing to write a plan into it.` | 10 | refusal |
 | `ledger write: issue #<n> is proven absent or closed.` | 7 | refusal |
 | `ledger write: cannot read <what>: <reason> — nothing was written.` | 11 | refusal |
-| `ledger write: this session does not hold #<n>'s claim.` | 15 | refusal |
+| `ledger write: this lane does not hold #<n>'s claim.` | 15 | refusal |
 
 **Scope** — one epic body read, one PATCH, one confirming read. Zero scope is unreachable: the
 staged documents are required and their absence is `25`.
@@ -1027,12 +1032,12 @@ staged documents are required and their absence is `25`.
 **Examples**
 
 ```
-$ fabrika ledger write 4300 --body-digest 8f2c1a90b4d7
+$ fabrika ledger write 4300 --body-digest 8f2c1a90b4d7 --token <claim-token>
 {"answer":"written","epic":4300,"mode":"fresh","bodyDigest":"8f2c1a90b4d7","newDigest":"c41b7e0a91f6","planBytes":4187,"topologyBytes":214,"verified":true}
 ```
 
 ```
-$ fabrika ledger write 4300 --body-digest 8f2c1a90b4d7
+$ fabrika ledger write 4300 --body-digest 8f2c1a90b4d7 --token <claim-token>
 ledger write: topology.md was never staged in this run — stage it before writing.
 $ echo $?
 25
@@ -1062,7 +1067,7 @@ $ echo $?
 **Invocation**
 
 ```
-fabrika ledger supersede 4300 --child 4288 --reason "folded into the loader slice"
+fabrika ledger supersede 4300 --child 4288 --reason "folded into the loader slice" --token <claim-token>
 ```
 
 **Inputs**
@@ -1072,6 +1077,7 @@ fabrika ledger supersede 4300 --child 4288 --reason "folded into the loader slic
 | `<number>` | positional integer | yes | — | the parent epic |
 | `--child` | integer | yes | — | the child being retired |
 | `--reason` | string | yes | — | why it is retired; posted as the journal comment |
+| `--token` | string | yes | — | the claim token `build claim <epic> --purpose plan` printed — which lane is asking, and the nonce the run key is derived from (#6060) |
 | `--repo` | string | no | `resolveRepo`'s precedence | the repository written |
 
 **Output** — machine.
@@ -1110,7 +1116,7 @@ exists for, so the refusal narrows to the minted set rather than the whole manif
 | `9` | the legs landed and the child does not read back closed and unlinked |
 | `10` | the issue is not a `type:epic`; `--child` is not a sub-issue of it; or `--child`'s manifest line carries `"mintedThisRun":true` |
 | `11` | a precondition read failed — **nothing was written** |
-| `15` | this session does not hold the epic's claim |
+| `15` | this lane does not hold the epic's claim |
 
 **Errors**
 
@@ -1125,7 +1131,7 @@ exists for, so the refusal narrows to the minted set rather than the whole manif
 | `ledger supersede: #<c> was minted by this run — refusing to supersede a child of the current plan.` | 10 | refusal |
 | `ledger supersede: #<n> is not a type:epic.` | 10 | refusal |
 | `ledger supersede: cannot read <what>: <reason> — nothing was written.` | 11 | refusal |
-| `ledger supersede: this session does not hold #<n>'s claim.` | 15 | refusal |
+| `ledger supersede: this lane does not hold #<n>'s claim.` | 15 | refusal |
 
 **Scope** — one child: one comment, one unlink, one close, one confirming read. Zero scope is
 unreachable: `--child` is required.
@@ -1133,12 +1139,12 @@ unreachable: `--child` is required.
 **Examples**
 
 ```
-$ fabrika ledger supersede 4300 --child 4288 --reason "folded into the loader slice"
+$ fabrika ledger supersede 4300 --child 4288 --reason "folded into the loader slice" --token <claim-token>
 {"answer":"superseded","epic":4300,"child":4288,"comment":5230661234,"unlinked":true,"state":"closed"}
 ```
 
 ```
-$ fabrika ledger supersede 4300 --child 4301 --reason "no longer needed"
+$ fabrika ledger supersede 4300 --child 4301 --reason "no longer needed" --token <claim-token>
 ledger supersede: #4301 was minted by this run — refusing to supersede a child of the current plan.
 $ echo $?
 10

--- a/packages/fabrika-cli/src/build/claim.ts
+++ b/packages/fabrika-cli/src/build/claim.ts
@@ -254,22 +254,29 @@ export type CallerRead =
 	| {readonly _tag: "Caller"; readonly caller: LaneCaller};
 
 /**
- * The asking lane, read off the `--token` it was handed by `build claim`.
+ * The asking lane, read off the `--token` its `claim` verb handed it.
  *
  * A token from another session is refused rather than trusted: the env says which session is running,
  * the flag says which lane, and a pair that disagrees is a threaded-through token from somewhere else.
+ * `grammar` is what keeps a namespace from admitting another's token — a `lane:` token handed to a
+ * `build` verb names no lane it can resolve, so it is read as unparseable rather than as an identity.
  */
-export const requireCallerToken = (verb: string, session: string, token: string): CallerRead => {
+export const requireCallerToken = (
+	verb: string,
+	session: string,
+	token: string,
+	grammar: ClaimGrammar = BUILD_CLAIM,
+): CallerRead => {
 	const usage = (message: string): CallerRead => ({
 		_tag: "Refused",
 		outcome: refuse(FAILED, `${verb}: ${message}`),
 	});
 	const trimmed = token.trim();
-	const parsed = parseToken(trimmed);
-	const nonce = nonceOf(trimmed);
+	const parsed = parseToken(trimmed, grammar.prefix);
+	const nonce = nonceOf(trimmed, grammar.prefix);
 	if (parsed === null || nonce === null) {
 		return usage(
-			`--token "${trimmed}" is not a claim token (build:<session-id>:<uuid>) — which lane is asking is not stated.`,
+			`--token "${trimmed}" is not a claim token (${grammar.prefix}:<session-id>:<uuid>) — which lane is asking is not stated.`,
 		);
 	}
 	if (parsed.session !== session) {

--- a/packages/fabrika-cli/src/lane/claim-verb.ts
+++ b/packages/fabrika-cli/src/lane/claim-verb.ts
@@ -7,6 +7,22 @@
  * resolves it. A loser retracts its **own** marker and nothing else — never another lane's, which is
  * the one write this protocol must never make.
  *
+ * **Ownership turns on the whole token, never on the session id alone** (#6060). A session is not a
+ * driver: one session routinely spawns several operators, and each mints its own token. Under the
+ * session-only rule a sibling lane read the first lane's marker as its own, so `claim` answered `won`
+ * carrying a token that owned nothing and `release` deleted the holder's marker — an unrecoverable
+ * retraction that left the issue reading unclaimed. Every ownership question here is therefore asked
+ * as a {@link Caller} carrying the lane's nonce, read off the `--token` this verb's own `claim`
+ * handed back.
+ *
+ * **One driver leaves at most one marker on a thread**, the same fixed point `build claim` holds
+ * (#5782, per lane since #6037). `claim` handed the token it already holds reads ownership before
+ * writing and answers `won` with that same marker, posting nothing; `release` sweeps every marker
+ * carrying THIS lane's token rather than only the winner. Without both, N claims left N markers and
+ * each release peeled one off a stack, and since nothing here expires a marker (`triage claim`'s TTL
+ * has no counterpart in this namespace) the leftovers made the lane refuse on `31` until a human
+ * deleted the comment.
+ *
  * **No admission test runs here.** The fence decides what may start *building* (ADR 0245), and the
  * builder this driver spawns runs it on its own account; a second copy in the driver would refuse a
  * lane at a different moment than the shell it drives, for reasons the driver is type-blind to.
@@ -15,17 +31,20 @@
 import {Effect} from "effect";
 import type {ChildProcessSpawner} from "effect/unstable/process";
 import {
-	anySessionCaller,
 	composeMarker,
+	describeCaller,
+	laneCaller,
+	markersIn,
 	readMarkerToken,
+	requireCallerToken,
 	requireSession,
 	resolveOwnership,
 } from "../build/claim.ts";
-import {composeToken} from "../build/lane.ts";
+import {composeToken, nonceOf, parseToken} from "../build/lane.ts";
 import {resolveTargetRepo} from "../build/target.ts";
-import {createComment, deleteComment, getComment} from "../io/issues.ts";
+import {createComment, deleteComment, getComment, listComments} from "../io/issues.ts";
 import {normalizeForReadback} from "../report/compose.ts";
-import {answer, refuse, type VerbOutcome} from "../verb.ts";
+import {answer, FAILED, refuse, type VerbOutcome} from "../verb.ts";
 import {claimTarget, LANE_CLAIM} from "./claim.ts";
 import {APPEND_UNKNOWN, CLAIM_NOT_MINE, LANE_UNREADABLE, MARKER_READBACK} from "./codes.ts";
 import type {LaneKey} from "./key.ts";
@@ -34,6 +53,13 @@ export interface ProtocolOptions {
 	readonly key: LaneKey;
 	readonly lane: string;
 	readonly repo: string | null;
+	/**
+	 * The token `lane claim` handed this driver — which lane is asking.
+	 *
+	 * Nullable because a `chore:<name>` key was never claimable and so was never handed one; against
+	 * a board number a null is refused rather than widened back to the session.
+	 */
+	readonly token: string | null;
 	readonly env: Readonly<Record<string, string | undefined>>;
 }
 
@@ -92,6 +118,10 @@ const unauthorizedNotes = (
 			`${verb}: comment ${marker.commentId} carries a lane-claim marker from "${marker.author}", who holds no write permission — counted, never a winner.`,
 	);
 
+/** How a refusal names a same-session winner, which is a sibling driver rather than a stranger. */
+const siblingNote = (verb: string, token: string): string =>
+	`${verb}: ${token} carries this very session under another nonce — a sibling driver of this session, or a marker an earlier run of it left behind.`;
+
 export const runLaneClaim = (
 	options: LaneClaimOptions,
 ): Effect.Effect<VerbOutcome, never, ChildProcessSpawner.ChildProcessSpawner> =>
@@ -100,7 +130,39 @@ export const runLaneClaim = (
 		if (ready._tag !== "Ready") return ready.outcome;
 		const {repo, session, number} = ready;
 
+		// Already THIS DRIVER's: answer with the marker that owns it and write nothing. A second marker
+		// would leave `claim` printing one nonce while `release` deleted the earliest, so each release
+		// peeled one off a stack and the leftovers locked the lane out (#6087). Only a caller that
+		// named its own token can be answered this way — a same-session marker under another nonce
+		// belongs to a sibling driver, and races below like any other (#6060).
+		if (options.token !== null) {
+			const holding = requireCallerToken(CLAIM, session, options.token, LANE_CLAIM);
+			if (holding._tag === "Refused") return holding.outcome;
+			const prior = yield* resolveOwnership(repo, number, holding.caller, LANE_CLAIM);
+			if (prior.ownership._tag === "Mine") {
+				return answer(
+					JSON.stringify({
+						answer: "won",
+						lane: options.lane,
+						number,
+						token: prior.ownership.marker.token,
+					}),
+					[
+						...unauthorizedNotes(CLAIM, prior.unauthorized),
+						`${CLAIM}: #${number} is already held by this driver (comment ${prior.ownership.marker.commentId}) — answered with the marker that owns it; nothing was written.`,
+					],
+				);
+			}
+		}
+
 		const token = composeToken(session, options.uuid, LANE_CLAIM.prefix);
+		const nonce = nonceOf(token, LANE_CLAIM.prefix);
+		if (nonce === null) {
+			return refuse(
+				FAILED,
+				`${CLAIM}: the token this run mints, ${token}, yields no lane nonce — nothing was written.`,
+			);
+		}
 		const posted = yield* createComment(
 			repo,
 			number,
@@ -124,26 +186,26 @@ export const runLaneClaim = (
 			);
 		}
 
-		// The checkpoint: posting DETECTS a race, this re-read RESOLVES it.
+		// The checkpoint: posting DETECTS a race, this re-read RESOLVES it. It resolves against the
+		// token this run just minted, so a sibling driver of the same session is a co-racer like any
+		// other rather than this run reading its neighbour's marker as its own (#6060).
 		const {ownership, unauthorized} = yield* resolveOwnership(
 			repo,
 			number,
-			anySessionCaller(session),
+			laneCaller(session, nonce, token),
 			LANE_CLAIM,
 		);
 		const notes = unauthorizedNotes(CLAIM, unauthorized);
-		if (ownership._tag === "Unknown") {
-			return refuse(
-				LANE_UNREADABLE,
-				`${CLAIM}: cannot read the lane-claim markers on #${number}: ${ownership.reason} — ownership is UNKNOWN, never "unclaimed".`,
+		if (ownership._tag === "Mine") {
+			return answer(
+				JSON.stringify({answer: "won", lane: options.lane, number, token: ownership.marker.token}),
 				notes,
 			);
 		}
-		if (ownership._tag === "Mine") {
-			return answer(JSON.stringify({answer: "won", lane: options.lane, number, token}), notes);
-		}
 
-		// Lost, or shadowed by an unauthorized-only thread: retract this run's OWN marker, nothing else.
+		// Lost, unreadable, or shadowed by an unauthorized-only thread: retract this run's OWN marker,
+		// nothing else. The UNKNOWN arm retracts too — its comment id is in hand and is provably this
+		// run's own write, and leaving it behind strands a marker no later run can resolve (#6000).
 		const retracted = yield* deleteComment(repo, posted.value.id);
 		const trailer =
 			retracted._tag === "Failure"
@@ -151,11 +213,22 @@ export const runLaneClaim = (
 						`${CLAIM}: could not retract this run's own marker (comment ${posted.value.id}): ${retracted.reason}.`,
 					]
 				: [`${CLAIM}: retracted this run's own marker (comment ${posted.value.id}).`];
+		if (ownership._tag === "Unknown") {
+			return refuse(
+				LANE_UNREADABLE,
+				`${CLAIM}: cannot read the lane-claim markers on #${number}: ${ownership.reason} — ownership is UNKNOWN, never "unclaimed".`,
+				[...notes, ...trailer],
+			);
+		}
 		return ownership._tag === "Foreign"
 			? refuse(
 					CLAIM_NOT_MINE,
 					`${CLAIM}: lost to ${ownership.marker.token} (posted ${ownership.marker.createdAt}, authorized) — another driver holds this lane.`,
-					[...notes, ...trailer],
+					[
+						...notes,
+						...(ownership.sameSession ? [siblingNote(CLAIM, ownership.marker.token)] : []),
+						...trailer,
+					],
 				)
 			: refuse(
 					CLAIM_NOT_MINE,
@@ -174,12 +247,17 @@ export const runLaneRelease = (
 		if (ready._tag !== "Ready") return ready.outcome;
 		const {repo, session, number} = ready;
 
-		const {ownership, unauthorized} = yield* resolveOwnership(
-			repo,
-			number,
-			anySessionCaller(session),
-			LANE_CLAIM,
-		);
+		if (options.token === null) {
+			return refuse(
+				FAILED,
+				`${RELEASE}: --token is unset — which driver is releasing #${number} is not stated, and a release that guesses retracts somebody else's marker; pass the token "fabrika lane claim ${options.lane}" printed.`,
+			);
+		}
+		const asking = requireCallerToken(RELEASE, session, options.token, LANE_CLAIM);
+		if (asking._tag === "Refused") return asking.outcome;
+		const lane = asking.caller;
+
+		const {ownership, unauthorized} = yield* resolveOwnership(repo, number, lane, LANE_CLAIM);
 		const notes = unauthorizedNotes(RELEASE, unauthorized);
 		if (ownership._tag === "Unknown") {
 			return refuse(
@@ -191,16 +269,46 @@ export const runLaneRelease = (
 		if (ownership._tag !== "Mine") {
 			return refuse(
 				CLAIM_NOT_MINE,
-				`${RELEASE}: this session holds no lane claim on #${number} — refusing to release another driver's.`,
+				ownership._tag === "Foreign"
+					? `${RELEASE}: #${number} is held by ${ownership.marker.token}, not by ${describeCaller(lane)} — refusing to retract another driver's marker.`
+					: `${RELEASE}: no lane claim exists on #${number} — nothing to retract.`,
+				ownership._tag === "Foreign" && ownership.sameSession
+					? [...notes, siblingNote(RELEASE, ownership.marker.token)]
+					: notes,
+			);
+		}
+		// Every marker carrying THIS DRIVER's token, not only the winning one: a thread carrying
+		// duplicates — a write that landed after it reported UNKNOWN, then re-posted — would otherwise
+		// leave the leftovers behind for the next claim to lose to (#6087). The filter is the lane's
+		// whole token, never its session: a sibling driver's marker is another driver's claim, and
+		// sweeping it is the one write this protocol must never make (#6060).
+		const listed = yield* listComments(repo, number);
+		if (listed._tag === "Failure") {
+			return refuse(
+				LANE_UNREADABLE,
+				`${RELEASE}: cannot re-read the lane-claim markers on #${number}: ${listed.reason} — nothing was retracted; run "fabrika lane release ${options.lane} --token ${options.token.trim()}" again.`,
 				notes,
 			);
 		}
-		const deleted = yield* deleteComment(repo, ownership.marker.commentId);
-		return deleted._tag === "Failure"
-			? refuse(
+		const ids = new Set([
+			ownership.marker.commentId,
+			...markersIn(listed.value, LANE_CLAIM)
+				.filter(
+					(held) =>
+						parseToken(held.token, LANE_CLAIM.prefix)?.session === lane.session &&
+						nonceOf(held.token, LANE_CLAIM.prefix) === lane.nonce,
+				)
+				.map((held) => held.commentId),
+		]);
+		for (const id of ids) {
+			const deleted = yield* deleteComment(repo, id);
+			if (deleted._tag === "Failure") {
+				return refuse(
 					APPEND_UNKNOWN,
 					`${RELEASE}: the retraction failed: ${deleted.reason} — whether this driver still holds #${number} is UNKNOWN.`,
 					notes,
-				)
-			: answer(JSON.stringify({answer: "released", lane: options.lane, number}), notes);
+				);
+			}
+		}
+		return answer(JSON.stringify({answer: "released", lane: options.lane, number}), notes);
 	});

--- a/packages/fabrika-cli/src/lane/claim-verb.unit.test.ts
+++ b/packages/fabrika-cli/src/lane/claim-verb.unit.test.ts
@@ -7,6 +7,7 @@ import {
 	issue as buildIssue,
 	LANE_UUID,
 	NO_BLOCKERS,
+	SIBLING_UUID,
 	truncatedComments,
 } from "../build/fixtures.test-support.ts";
 import {fakeFs, fakeShell, okOut} from "../fakes.test-support.ts";
@@ -29,6 +30,11 @@ const laneMarker = (session: string, uuid: string): string =>
 
 const MINE = laneMarker("s-9f2e", LANE_UUID);
 const THEIRS = laneMarker("s-77aa", OTHER_UUID);
+/** A second driver of the SAME session — the two-lanes-one-session shape (#6060). */
+const SIBLING = laneMarker("s-9f2e", SIBLING_UUID);
+
+const MY_TOKEN = `lane:s-9f2e:${LANE_UUID}`;
+const SIBLING_TOKEN = `lane:s-9f2e:${SIBLING_UUID}`;
 
 const POSTED = okOut(JSON.stringify({id: 9001, html_url: "https://github.com/o/r/issues/5492#c"}));
 const ECHO = okOut(JSON.stringify({body: MINE}));
@@ -42,6 +48,7 @@ const key = (raw: string) => {
 const options = {
 	key: key("5492"),
 	lane: "5492",
+	token: null as string | null,
 	repo: null,
 	env: {CLAUDE_PIPELINE_REPO: "o/r", CLAUDE_CODE_SESSION_ID: "s-9f2e"} as Record<
 		string,
@@ -120,16 +127,53 @@ describe("runLaneClaim", () => {
 		expect(deletes).toEqual(["gh api --method DELETE repos/o/r/issues/comments/9001"]);
 	});
 
-	it("exits 11 on an unreadable marker set — UNKNOWN, never unclaimed", async () => {
-		const out = await run([
+	/**
+	 * A sibling driver of THIS session is a co-racer, not this run: ownership turns on the whole
+	 * token, so the older marker wins and this run retracts its own rather than reading the
+	 * neighbour's claim as its own (#6060).
+	 */
+	it("loses to a sibling driver of its own session, and says which one", async () => {
+		const shell = fakeShell([
+			[POST, POSTED],
+			[GET_COMMENT, ECHO],
+			[
+				COMMENTS,
+				buildComments(
+					{id: 8000, body: SIBLING, createdAt: "2026-08-16T00:00:00Z"},
+					{id: 9001, body: MINE, createdAt: "2026-08-17T00:00:00Z"},
+				),
+			],
+			[perm("agent"), okOut("write\n")],
+			[DELETE, okOut("")],
+		]);
+		const out = await Effect.runPromise(Effect.provide(runLaneClaim(options), shell.layer));
+		expect(out.code).toBe(CLAIM_NOT_MINE);
+		expect(out.stderr.join("\n")).toContain(SIBLING_TOKEN);
+		expect(shell.calls.filter((line) => DELETE.test(line))).toEqual([
+			"gh api --method DELETE repos/o/r/issues/comments/9001",
+		]);
+	});
+
+	/**
+	 * The UNKNOWN path retracts too. Its comment id is in hand and is provably this run's own write —
+	 * the one write a loser may always make — and leaving it stranded is a marker no later run can
+	 * resolve, on a namespace with no TTL to expire it (#6000).
+	 */
+	it("exits 11 on an unreadable marker set — UNKNOWN, never unclaimed — retracting its own", async () => {
+		const shell = fakeShell([
 			[POST, POSTED],
 			[GET_COMMENT, ECHO],
 			[COMMENTS, truncatedComments({id: 9001, body: MINE})],
 			[perm("agent"), okOut("write\n")],
+			[DELETE, okOut("")],
 		]);
+		const out = await Effect.runPromise(Effect.provide(runLaneClaim(options), shell.layer));
 		expect(out.code).toBe(LANE_UNREADABLE);
 		expect(out.stdout).toBe("");
 		expect(out.stderr.join("\n")).toContain("UNKNOWN");
+		expect(shell.calls.filter((line) => DELETE.test(line))).toEqual([
+			"gh api --method DELETE repos/o/r/issues/comments/9001",
+		]);
 	});
 
 	it("exits 1 with no session id, and writes nothing", async () => {
@@ -177,7 +221,9 @@ describe("runLaneRelease", () => {
 			[perm("agent"), okOut("write\n")],
 			[DELETE, okOut("")],
 		]);
-		const out = await Effect.runPromise(Effect.provide(runLaneRelease(options), shell.layer));
+		const out = await Effect.runPromise(
+			Effect.provide(runLaneRelease({...options, token: MY_TOKEN}), shell.layer),
+		);
 		expect(out.code).toBe(0);
 		expect(JSON.parse(out.stdout)).toEqual({answer: "released", lane: "5492", number: 5492});
 		expect(shell.calls).toContain("gh api --method DELETE repos/o/r/issues/comments/9001");
@@ -188,15 +234,154 @@ describe("runLaneRelease", () => {
 			[COMMENTS, buildComments({id: 8000, body: THEIRS})],
 			[perm("agent"), okOut("write\n")],
 		]);
-		const out = await Effect.runPromise(Effect.provide(runLaneRelease(options), shell.layer));
+		const out = await Effect.runPromise(
+			Effect.provide(runLaneRelease({...options, token: MY_TOKEN}), shell.layer),
+		);
 		expect(out.code).toBe(CLAIM_NOT_MINE);
 		expect(shell.calls.filter((line) => DELETE.test(line))).toEqual([]);
 	});
 
-	it("answers inert on a chore lane", async () => {
+	/**
+	 * The sharpest edge of the session-only rule: this release used to resolve `Mine` on a sibling
+	 * driver's marker and delete it, which is unrecoverable and leaves the issue reading unclaimed
+	 * (#6060). The refusal names the holding token so a reader can find the comment.
+	 */
+	it("refuses a sibling driver of its OWN session, naming the holding token", async () => {
+		const shell = fakeShell([
+			[COMMENTS, buildComments({id: 8000, body: SIBLING})],
+			[perm("agent"), okOut("write\n")],
+		]);
+		const out = await Effect.runPromise(
+			Effect.provide(runLaneRelease({...options, token: MY_TOKEN}), shell.layer),
+		);
+		expect(out.code).toBe(CLAIM_NOT_MINE);
+		expect(out.stderr.join("\n")).toContain(SIBLING_TOKEN);
+		expect(shell.calls.filter((line) => DELETE.test(line))).toEqual([]);
+	});
+
+	it("exits 1 with no --token on a board lane, and reads nothing", async () => {
+		const shell = fakeShell([]);
+		const out = await Effect.runPromise(Effect.provide(runLaneRelease(options), shell.layer));
+		expect(out.code).toBe(FAILED);
+		expect(shell.calls).toEqual([]);
+	});
+
+	/** A read that failed is UNKNOWN, and an UNKNOWN holding never authorizes a delete. */
+	it("exits 11 on an unreadable marker read, retracting nothing", async () => {
+		const shell = fakeShell([
+			[COMMENTS, truncatedComments({id: 9001, body: MINE})],
+			[perm("agent"), okOut("write\n")],
+		]);
+		const out = await Effect.runPromise(
+			Effect.provide(runLaneRelease({...options, token: MY_TOKEN}), shell.layer),
+		);
+		expect(out.code).toBe(LANE_UNREADABLE);
+		expect(out.stderr.join("\n")).toContain("UNKNOWN");
+		expect(shell.calls.filter((line) => DELETE.test(line))).toEqual([]);
+	});
+
+	it("exits 8 when the delete fails — whether the lane is still held is UNKNOWN", async () => {
+		const shell = fakeShell([
+			[COMMENTS, buildComments({id: 9001, body: MINE})],
+			[perm("agent"), okOut("write\n")],
+			[DELETE, {ok: false, stdout: "", reason: "502"}],
+		]);
+		const out = await Effect.runPromise(
+			Effect.provide(runLaneRelease({...options, token: MY_TOKEN}), shell.layer),
+		);
+		expect(out.code).toBe(APPEND_UNKNOWN);
+		expect(out.stderr.join("\n")).toContain("UNKNOWN");
+	});
+
+	it("answers inert on a chore lane, which was never handed a token", async () => {
 		const out = await release([], {key: key("chore:park-sweep"), lane: "chore:park-sweep"});
 		expect(out.code).toBe(0);
 		expect(JSON.parse(out.stdout).answer).toBe("inert");
+	});
+});
+
+/**
+ * The protocol's fixed point: one DRIVER, one marker, one token (#6087, scoped per driver by #6060).
+ *
+ * Before the guard, N claims left N markers and each release peeled one off — and since nothing in
+ * this namespace expires a marker, the leftovers made the lane refuse on `31` for good.
+ */
+describe("one driver, one marker", () => {
+	const held = (...bodies: ReadonlyArray<readonly [number, string]>) =>
+		buildComments(...bodies.map(([id, body]) => ({id, body})));
+
+	it("posts no second marker on a re-claim, and answers with the owning token", async () => {
+		const shell = fakeShell([
+			[COMMENTS, held([9001, MINE])],
+			[perm("agent"), okOut("write\n")],
+		]);
+		const out = await Effect.runPromise(
+			Effect.provide(runLaneClaim({...options, token: MY_TOKEN}), shell.layer),
+		);
+		expect(out.code).toBe(0);
+		expect(JSON.parse(out.stdout)).toEqual({
+			answer: "won",
+			lane: "5492",
+			number: 5492,
+			token: MY_TOKEN,
+		});
+		expect(shell.calls.filter((line) => POST.test(line))).toEqual([]);
+	});
+
+	/** Claim, re-claim, release once: no marker of this driver survives for a later claim to lose to. */
+	it("leaves nothing behind after one release", async () => {
+		const shell = fakeShell([
+			[COMMENTS, held([9001, MINE])],
+			[perm("agent"), okOut("write\n")],
+			[DELETE, okOut("")],
+		]);
+		await Effect.runPromise(
+			Effect.provide(runLaneClaim({...options, token: MY_TOKEN}), shell.layer),
+		);
+		const out = await Effect.runPromise(
+			Effect.provide(runLaneRelease({...options, token: MY_TOKEN}), shell.layer),
+		);
+		expect(out.code).toBe(0);
+		expect(shell.calls.filter((line) => DELETE.test(line))).toEqual([
+			"gh api --method DELETE repos/o/r/issues/comments/9001",
+		]);
+	});
+
+	/** A thread that already carries duplicates — written before the guard — is swept, not crashed on. */
+	it("sweeps every marker carrying this driver's token, and only those", async () => {
+		const shell = fakeShell([
+			[COMMENTS, held([9001, MINE], [9002, MINE], [9003, THEIRS])],
+			[perm("agent"), okOut("write\n")],
+			[DELETE, okOut("")],
+		]);
+		const out = await Effect.runPromise(
+			Effect.provide(runLaneRelease({...options, token: MY_TOKEN}), shell.layer),
+		);
+		expect(out.code).toBe(0);
+		expect(shell.calls.filter((line) => DELETE.test(line))).toEqual([
+			"gh api --method DELETE repos/o/r/issues/comments/9001",
+			"gh api --method DELETE repos/o/r/issues/comments/9002",
+		]);
+	});
+
+	/** The claim and the release agree about the nonce, so neither can address the other's marker. */
+	it("hands back a token release resolves as its own", async () => {
+		const claimed = await run([
+			[POST, POSTED],
+			[GET_COMMENT, ECHO],
+			[COMMENTS, buildComments({id: 9001, body: MINE})],
+			[perm("agent"), okOut("write\n")],
+		]);
+		const token = JSON.parse(claimed.stdout).token as string;
+		const shell = fakeShell([
+			[COMMENTS, buildComments({id: 9001, body: MINE})],
+			[perm("agent"), okOut("write\n")],
+			[DELETE, okOut("")],
+		]);
+		const out = await Effect.runPromise(
+			Effect.provide(runLaneRelease({...options, token}), shell.layer),
+		);
+		expect(out.code).toBe(0);
 	});
 });
 

--- a/packages/fabrika-cli/src/lane/command.ts
+++ b/packages/fabrika-cli/src/lane/command.ts
@@ -335,10 +335,16 @@ const brief = leafCommand(
 	),
 );
 
+const laneTokenFlag = Flag.string("token").pipe(
+	Flag.optional,
+	Flag.withDescription("the lane-claim token `lane claim` handed this driver — its identity"),
+);
+
 const claim = leafCommand(
 	"claim",
 	{
 		lane: laneArgument,
+		token: laneTokenFlag,
 		repo: Flag.string("repo").pipe(
 			Flag.optional,
 			Flag.withDescription(
@@ -346,12 +352,13 @@ const claim = leafCommand(
 			),
 		),
 	},
-	Effect.fn(function* ({lane, repo}) {
+	Effect.fn(function* ({lane, token, repo}) {
 		yield* emit(
 			yield* onKey(lane, Option.none(), (key) =>
 				runLaneClaim({
 					key,
 					lane,
+					token: Option.getOrNull(token),
 					repo: Option.getOrNull(repo),
 					env: process.env,
 					uuid: randomUUID(),
@@ -363,7 +370,7 @@ const claim = leafCommand(
 ).pipe(
 	Command.withShortDescription("Race the driver's claim on a lane and win it or name the winner."),
 	Command.withDescription(
-		'Race the earliest AUTHORIZED lane-claim marker on the issue a lane drives: post this driver\'s token (lane:<CLAUDE_CODE_SESSION_ID>:<uuid>), re-read, and win or name the winner. Two drivers over one lane used to be invisible until the builders they spawned collided one level down (#5761). The namespace is the driver\'s own — `lane-claim:`/`lane:`, never `build-claim:`/`build:` — so the builder this driver spawns claims the same issue and wins; the two races never see each other. Authorization is the author\'s repository permission (ADR 0055); marker text confers nothing. No admission test runs here — the fence is the spawned builder\'s. Prints {"answer":"won","lane":"…","number":n,"token":"…"}. A `chore:<name>` lane, or any key that is not a board number, has no thread to race on and answers {"answer":"unclaimable","lane":"…","why":"…"} at exit 0 with nothing written. A lost race retracts this run\'s own marker and exits 31, never 0; an unset CLAUDE_CODE_SESSION_ID is 1. Exits 8 (the marker write failed — UNKNOWN, never a claim), 9 (the marker landed and does not read back), 11 (the marker set could not be read — UNKNOWN, never "unclaimed"), 21 (the key is not a lane key), 31 (proven lost). Example: fabrika lane claim 5492',
+		'Race the earliest AUTHORIZED lane-claim marker on the issue a lane drives: post this driver\'s token (lane:<CLAUDE_CODE_SESSION_ID>:<uuid>), re-read, and win or name the winner. Two drivers over one lane used to be invisible until the builders they spawned collided one level down (#5761). The namespace is the driver\'s own — `lane-claim:`/`lane:`, never `build-claim:`/`build:` — so the builder this driver spawns claims the same issue and wins; the two races never see each other. Authorization is the author\'s repository permission (ADR 0055); marker text confers nothing. No admission test runs here — the fence is the spawned builder\'s. Prints {"answer":"won","lane":"…","number":n,"token":"…"}. --token makes the re-claim idempotent per DRIVER: handed the token this driver already holds, a lane it already owns answers won with that same marker and writes nothing, so N claims can never leave N markers for a later release to peel off one at a time (#6087); a same-session marker under another nonce is a sibling driver and races normally. A `chore:<name>` lane, or any key that is not a board number, has no thread to race on and answers {"answer":"unclaimable","lane":"…","why":"…"} at exit 0 with nothing written. A lost race retracts this run\'s own marker and exits 31, never 0 — including when the winner is another driver of THIS session, since ownership turns on the whole token and never the session id (#6060); an unset CLAUDE_CODE_SESSION_ID, or a --token that is not a lane-claim token of this session, is 1. Exits 8 (the marker write failed — UNKNOWN, never a claim), 9 (the marker landed and does not read back), 11 (the marker set could not be read — UNKNOWN, never "unclaimed"; this run\'s own marker is retracted first), 21 (the key is not a lane key), 31 (proven lost). Example: fabrika lane claim 5492',
 	),
 );
 
@@ -371,6 +378,7 @@ const release = leafCommand(
 	"release",
 	{
 		lane: laneArgument,
+		token: laneTokenFlag,
 		repo: Flag.string("repo").pipe(
 			Flag.optional,
 			Flag.withDescription(
@@ -378,17 +386,23 @@ const release = leafCommand(
 			),
 		),
 	},
-	Effect.fn(function* ({lane, repo}) {
+	Effect.fn(function* ({lane, token, repo}) {
 		yield* emit(
 			yield* onKey(lane, Option.none(), (key) =>
-				runLaneRelease({key, lane, repo: Option.getOrNull(repo), env: process.env}),
+				runLaneRelease({
+					key,
+					lane,
+					token: Option.getOrNull(token),
+					repo: Option.getOrNull(repo),
+					env: process.env,
+				}),
 			),
 		);
 	}),
 ).pipe(
 	Command.withShortDescription("Retract this driver's own lane-claim marker."),
 	Command.withDescription(
-		'Retract this driver\'s own lane-claim marker, so the lane is drivable again — run at both ends of the loop, the terminal fold and the park. It refuses to delete a marker this session does not hold: a driver never retracts another driver\'s claim. Prints {"answer":"released","lane":"…","number":n}. A `chore:<name>` lane, or any key that is not a board number, was never claimable and answers {"answer":"inert","lane":"…","why":"…"} at exit 0. Exits 1 (CLAUDE_CODE_SESSION_ID unset), 8 (the retraction failed — whether the claim is still held is UNKNOWN), 11 (the marker set could not be read), 21 (the key is not a lane key), 31 (proven: held by another driver, or no claim exists). Example: fabrika lane release 5492',
+		'Retract this DRIVER\'s OWN lane-claim marker, and only its own, so the lane is drivable again — run at both ends of the loop, the terminal fold and the park. --token says which driver that is: ownership turns on the whole token, so a sibling driver of one session is a foreign holder here and its marker is never swept (#6060). Every marker carrying this driver\'s token goes, not merely the winning one, so a duplicate a re-claim left behind cannot outlive the release (#6087). Prints {"answer":"released","lane":"…","number":n}. A `chore:<name>` lane, or any key that is not a board number, was never claimable and answers {"answer":"inert","lane":"…","why":"…"} at exit 0 — and needs no token, having never been handed one. Exits 1 (CLAUDE_CODE_SESSION_ID unset, --token omitted on a board number, or a --token that is not a lane-claim token of this session), 8 (the retraction failed — whether the claim is still held is UNKNOWN), 11 (the marker set could not be read), 21 (the key is not a lane key), 31 (proven: held by another driver, or no claim exists). Example: fabrika lane release 5492 --token lane:s-9f2e:c1a4d6f8-…',
 	),
 );
 

--- a/packages/fabrika-cli/src/ledger/child-verb.unit.test.ts
+++ b/packages/fabrika-cli/src/ledger/child-verb.unit.test.ts
@@ -27,6 +27,7 @@ import {
 	epic,
 	labelSet,
 	milestones,
+	TOKEN,
 } from "./fixtures.test-support.ts";
 import {manifestPath, parseManifest, renderRunRecord, runJsonPath} from "./run.ts";
 
@@ -75,6 +76,7 @@ const options = {
 	assignee: null as string | null,
 	milestone: HOME as string | null,
 	labels: [] as ReadonlyArray<string>,
+	token: TOKEN,
 	repo: null,
 	env,
 };

--- a/packages/fabrika-cli/src/ledger/command.ts
+++ b/packages/fabrika-cli/src/ledger/command.ts
@@ -46,6 +46,12 @@ const epicArg = Argument.integer("number").pipe(
 	Argument.withDescription("the epic this verb plans"),
 );
 
+const tokenFlag = Flag.string("token").pipe(
+	Flag.withDescription(
+		"the claim token `build claim <epic> --purpose plan` handed this lane — its identity, and what the run directory is keyed on",
+	),
+);
+
 const bodyDigestFlag = Flag.string("body-digest").pipe(
 	Flag.withDescription(
 		"the 12-lowercase-hex body digest `ledger open` printed; the verb recomputes it from the live body and refuses on 21 if the epic moved",
@@ -56,25 +62,26 @@ const stdin = Effect.sync(readStdin);
 
 const open = leafCommand(
 	"open",
-	{number: epicArg, repo: repoFlag},
-	Effect.fn(function* ({number, repo}) {
-		yield* emit(yield* runOpen({number, repo: Option.getOrNull(repo), env: process.env}));
+	{number: epicArg, token: tokenFlag, repo: repoFlag},
+	Effect.fn(function* ({number, token, repo}) {
+		yield* emit(yield* runOpen({number, token, repo: Option.getOrNull(repo), env: process.env}));
 	}),
 ).pipe(
 	Command.withShortDescription("Prove the ground and open the plan run for an epic."),
 	Command.withDescription(
-		'Prove the ground fresh, allocate the run directory (keyed on the claim nonce, never the session), read the epic\'s existing children, probe the cycle doc, and rank duplicate candidates. Prints {"answer":"opened","epic":n,"run":"…","mode":"fresh|re-plan","bodyDigest":"…","dir":"…","children":[…],"cycleDoc":"present|absent|unknown","candidates":{"outcome":"candidates|none|indeterminate","items":[…]}}. Carry bodyDigest to `ledger draft` and `ledger write`. Exits 7 (the epic is proven absent or closed), 10 (not a type:epic), 11 (the epic, its sub-issue list, the backlog, the cycle-doc probe or the freshness probe could not be read), 15 (this session does not hold the epic\'s claim), 20 (the base is proven behind origin/main), 22 (two or more "## Plan (plan-epic)" headings — the mode has no single meaning). Example: fabrika ledger open 4300',
+		'Prove the ground fresh, allocate the run directory (keyed on the claim nonce --token names, never the session), read the epic\'s existing children, probe the cycle doc, and rank duplicate candidates. Prints {"answer":"opened","epic":n,"run":"…","mode":"fresh|re-plan","bodyDigest":"…","dir":"…","children":[…],"cycleDoc":"present|absent|unknown","candidates":{"outcome":"candidates|none|indeterminate","items":[…]}}. Carry bodyDigest to `ledger draft` and `ledger write`. Exits 7 (the epic is proven absent or closed), 10 (not a type:epic), 11 (the epic, its sub-issue list, the backlog, the cycle-doc probe or the freshness probe could not be read), 15 (this LANE does not hold the epic\'s claim — --token says which lane is asking, since ownership turns on the whole token and never the session id, #6060), 20 (the base is proven behind origin/main), 22 (two or more "## Plan (plan-epic)" headings — the mode has no single meaning). Example: fabrika ledger open 4300 --token build:s-9f2e:c1a4d6f8-…',
 	),
 );
 
 const draft = leafCommand(
 	"draft",
-	{number: epicArg, bodyDigest: bodyDigestFlag, repo: repoFlag},
-	Effect.fn(function* ({number, bodyDigest, repo}) {
+	{number: epicArg, bodyDigest: bodyDigestFlag, token: tokenFlag, repo: repoFlag},
+	Effect.fn(function* ({number, bodyDigest, token, repo}) {
 		yield* emit(
 			yield* runDraft({
 				number,
 				bodyDigest,
+				token,
 				repo: Option.getOrNull(repo),
 				env: process.env,
 				stdin,
@@ -84,7 +91,7 @@ const draft = leafCommand(
 ).pipe(
 	Command.withShortDescription("Validate the plan block on stdin and stage it."),
 	Command.withDescription(
-		'Validate the plan block on STDIN against the closed section set and the story grammar, then stage it in the run directory. Prints {"answer":"staged","epic":n,"document":"plan","sections":10,"stories":[…],"bytes":n}. It does not judge content — a "### Approach" reading TBD stages cleanly. Exits 3 (stdin held nothing), 4 (a required ### section is missing, duplicated or out of order; the block does not open with "## Plan (plan-epic)"; zero user stories; or story ids that are not contiguous from 1), 5 (machine-local path), 6 (bare @ reference), 7 (the epic is proven absent or closed), 10 (not a type:epic, or --body-digest is not 12 lowercase hex), 11 (a read failed — nothing was staged), 15 (this session does not hold the claim), 21 (the epic body moved since open). Example: fabrika ledger draft 4300 --body-digest 8f2c1a90b4d7 < plan.md',
+		'Validate the plan block on STDIN against the closed section set and the story grammar, then stage it in the run directory. Prints {"answer":"staged","epic":n,"document":"plan","sections":10,"stories":[…],"bytes":n}. It does not judge content — a "### Approach" reading TBD stages cleanly. Exits 3 (stdin held nothing), 4 (a required ### section is missing, duplicated or out of order; the block does not open with "## Plan (plan-epic)"; zero user stories; or story ids that are not contiguous from 1), 5 (machine-local path), 6 (bare @ reference), 7 (the epic is proven absent or closed), 10 (not a type:epic, or --body-digest is not 12 lowercase hex), 11 (a read failed — nothing was staged), 15 (this LANE does not hold the epic\'s claim — --token says which lane is asking, #6060), 21 (the epic body moved since open). Example: fabrika ledger draft 4300 --body-digest 8f2c1a90b4d7 --token build:s-9f2e:c1a4d6f8-… < plan.md',
 	),
 );
 
@@ -123,6 +130,7 @@ const child = leafCommand(
 				"the title of an open milestone; required unless --label carries a standing lane (#5969)",
 			),
 		),
+		token: tokenFlag,
 		label: Flag.string("label").pipe(
 			Flag.atLeast(0),
 			Flag.withDescription(
@@ -139,6 +147,7 @@ const child = leafCommand(
 		readyFor,
 		assignee,
 		milestone,
+		token,
 		label,
 		repo,
 	}) {
@@ -152,6 +161,7 @@ const child = leafCommand(
 				assignee: Option.getOrNull(assignee),
 				milestone: Option.getOrNull(milestone),
 				labels: label,
+				token,
 				repo: Option.getOrNull(repo),
 				env: process.env,
 				stdin,
@@ -161,37 +171,37 @@ const child = leafCommand(
 ).pipe(
 	Command.withShortDescription("Mint one child issue with every birth attribute at once."),
 	Command.withDescription(
-		'Mint one child with EVERY birth attribute in the one POST — title, body, every label, milestone and assignee — record it in the run manifest, link it as a native sub-issue, then re-read and report the OBSERVED result. Prints {"answer":"minted","epic":n,"child":n,"linked":true,"observed":{…},"stories":[…],"containment":"…"}. Exits 3 (stdin held nothing), 4 (the composed body\'s fields or sections do not parse: a malformed **Stories:** value, absent or malformed acceptance criteria, or a type:feature child whose **Containment:** is missing, unset or none while the cycle doc is present), 5 (machine-local path), 6 (bare @ reference), 7 (the epic is proven absent or closed), 8 (the create was attempted and no re-read could prove it — UNKNOWN), 9 (created and it does not read back as sent), 10 (a label, --type, --priority, --milestone or --ready-for off its closed vocabulary; --ready-for absent; --ready-for human without --assignee; neither --milestone nor a standing-lane --label, so the child would be born homeless; or not a type:epic), 11 (a precondition read failed — NOTHING was created), 15 (this session does not hold the claim), 23 (created and the sub-issue link could not be proven), 26 (created and the run manifest could not be written). Example: fabrika ledger child 4300 --title "queue view: fate loader" --type type:feature --priority p1 --ready-for agent < child.md',
+		'Mint one child with EVERY birth attribute in the one POST — title, body, every label, milestone and assignee — record it in the run manifest, link it as a native sub-issue, then re-read and report the OBSERVED result. Prints {"answer":"minted","epic":n,"child":n,"linked":true,"observed":{…},"stories":[…],"containment":"…"}. Exits 3 (stdin held nothing), 4 (the composed body\'s fields or sections do not parse: a malformed **Stories:** value, absent or malformed acceptance criteria, or a type:feature child whose **Containment:** is missing, unset or none while the cycle doc is present), 5 (machine-local path), 6 (bare @ reference), 7 (the epic is proven absent or closed), 8 (the create was attempted and no re-read could prove it — UNKNOWN), 9 (created and it does not read back as sent), 10 (a label, --type, --priority, --milestone or --ready-for off its closed vocabulary; --ready-for absent; --ready-for human without --assignee; neither --milestone nor a standing-lane --label, so the child would be born homeless; or not a type:epic), 11 (a precondition read failed — NOTHING was created), 15 (this LANE does not hold the epic\'s claim — --token says which lane is asking, #6060), 23 (created and the sub-issue link could not be proven), 26 (created and the run manifest could not be written). Example: fabrika ledger child 4300 --title "queue view: fate loader" --type type:feature --priority p1 --ready-for agent --token build:s-9f2e:c1a4d6f8-… < child.md',
 	),
 );
 
 const topology = leafCommand(
 	"topology",
-	{number: epicArg, repo: repoFlag},
-	Effect.fn(function* ({number, repo}) {
+	{number: epicArg, token: tokenFlag, repo: repoFlag},
+	Effect.fn(function* ({number, token, repo}) {
 		yield* emit(
-			yield* runTopology({number, repo: Option.getOrNull(repo), env: process.env, stdin}),
+			yield* runTopology({number, token, repo: Option.getOrNull(repo), env: process.env, stdin}),
 		);
 	}),
 ).pipe(
 	Command.withShortDescription("Validate the declared topology and render its Dependencies block."),
 	Command.withDescription(
-		'Validate the topology declared on STDIN — one "#<ref> phase <n> [requires #<a>, #<b>]" line per child, order-indifferent — against the run manifest, render the "## Dependencies" block, and parse it back through the shipped reader before staging it. Prints {"answer":"staged","epic":n,"document":"topology","phases":n,"children":n,"edges":[["#4303","#4301"]],"bytes":n}. It cannot see a shared-file conflict — whether two children in one phase write the same module is the skill\'s judgment (#3709). Exits 3 (stdin held nothing), 4 (a line does not parse), 7 (the epic is proven absent or closed, or the run manifest holds zero children), 10 (not a type:epic, or a phase is not a positive integer), 11 (a read failed — nothing was staged), 15 (this session does not hold the claim), 24 (a cycle, a reference to a non-child, a manifest child placed nowhere, or a rendered block that does not parse back to the declared edges). Example: fabrika ledger topology 4300 < topo.txt',
+		'Validate the topology declared on STDIN — one "#<ref> phase <n> [requires #<a>, #<b>]" line per child, order-indifferent — against the run manifest, render the "## Dependencies" block, and parse it back through the shipped reader before staging it. Prints {"answer":"staged","epic":n,"document":"topology","phases":n,"children":n,"edges":[["#4303","#4301"]],"bytes":n}. It cannot see a shared-file conflict — whether two children in one phase write the same module is the skill\'s judgment (#3709). Exits 3 (stdin held nothing), 4 (a line does not parse), 7 (the epic is proven absent or closed, or the run manifest holds zero children), 10 (not a type:epic, or a phase is not a positive integer), 11 (a read failed — nothing was staged), 15 (this LANE does not hold the epic\'s claim — --token says which lane is asking, #6060), 24 (a cycle, a reference to a non-child, a manifest child placed nowhere, or a rendered block that does not parse back to the declared edges). Example: fabrika ledger topology 4300 --token build:s-9f2e:c1a4d6f8-… < topo.txt',
 	),
 );
 
 const write = leafCommand(
 	"write",
-	{number: epicArg, bodyDigest: bodyDigestFlag, repo: repoFlag},
-	Effect.fn(function* ({number, bodyDigest, repo}) {
+	{number: epicArg, bodyDigest: bodyDigestFlag, token: tokenFlag, repo: repoFlag},
+	Effect.fn(function* ({number, bodyDigest, token, repo}) {
 		yield* emit(
-			yield* runWrite({number, bodyDigest, repo: Option.getOrNull(repo), env: process.env}),
+			yield* runWrite({number, bodyDigest, token, repo: Option.getOrNull(repo), env: process.env}),
 		);
 	}),
 ).pipe(
 	Command.withShortDescription("Splice the staged plan and topology into the epic body."),
 	Command.withDescription(
-		'Splice the staged plan and topology into the epic body in one PATCH, then re-read and compare the WHOLE normalized body. The plan region is resolved through the verb-written enrichment marker, never by position, and is never cut to end-of-file (#4879). mode is carried from `ledger open`, never re-derived. Prints {"answer":"written","epic":n,"mode":"…","bodyDigest":"…","newDigest":"…","planBytes":n,"topologyBytes":n,"verified":true}. Exits 7 (the epic is proven absent or closed), 8 (the PATCH was issued and could not be confirmed — UNKNOWN), 9 (written and it does not read back as composed), 10 (not a type:epic, or --body-digest is not 12 lowercase hex), 11 (a read failed — NOTHING was written), 15 (this session does not hold the claim), 21 (the epic body moved since open), 22 (the plan region is unresolvable), 25 (plan.md or topology.md was never staged in this run). Example: fabrika ledger write 4300 --body-digest 8f2c1a90b4d7',
+		'Splice the staged plan and topology into the epic body in one PATCH, then re-read and compare the WHOLE normalized body. The plan region is resolved through the verb-written enrichment marker, never by position, and is never cut to end-of-file (#4879). mode is carried from `ledger open`, never re-derived. Prints {"answer":"written","epic":n,"mode":"…","bodyDigest":"…","newDigest":"…","planBytes":n,"topologyBytes":n,"verified":true}. Exits 7 (the epic is proven absent or closed), 8 (the PATCH was issued and could not be confirmed — UNKNOWN), 9 (written and it does not read back as composed), 10 (not a type:epic, or --body-digest is not 12 lowercase hex), 11 (a read failed — NOTHING was written), 15 (this LANE does not hold the epic\'s claim — --token says which lane is asking, #6060), 21 (the epic body moved since open), 22 (the plan region is unresolvable), 25 (plan.md or topology.md was never staged in this run). Example: fabrika ledger write 4300 --body-digest 8f2c1a90b4d7 --token build:s-9f2e:c1a4d6f8-…',
 	),
 );
 
@@ -203,14 +213,16 @@ const supersede = leafCommand(
 		reason: Flag.string("reason").pipe(
 			Flag.withDescription("why it is retired; posted verbatim as the journal comment"),
 		),
+		token: tokenFlag,
 		repo: repoFlag,
 	},
-	Effect.fn(function* ({number, child: childNumber, reason, repo}) {
+	Effect.fn(function* ({number, child: childNumber, reason, token, repo}) {
 		yield* emit(
 			yield* runSupersede({
 				number,
 				child: childNumber,
 				reason,
+				token,
 				repo: Option.getOrNull(repo),
 				env: process.env,
 			}),
@@ -219,7 +231,7 @@ const supersede = leafCommand(
 ).pipe(
 	Command.withShortDescription("Retire a child the re-plan no longer contains."),
 	Command.withDescription(
-		'Retire a child the re-plan no longer contains: comment, unlink, close as not_planned — in that order, so a child is never closed while still linked — then re-read and prove it. Prints {"answer":"superseded","epic":n,"child":n,"comment":id,"unlinked":true,"state":"closed"}. Refuses a child that is not this epic\'s sub-issue, and one this run minted. Exits 5 (the reason carries a machine-local path), 6 (bare @ reference), 7 (the epic or the child is proven absent or closed), 8 (a leg was attempted and its outcome could not be proven), 9 (the legs landed and the child does not read back closed and unlinked), 10 (not a type:epic; --child is not a sub-issue of it; or --child was minted by this run), 11 (a precondition read failed — nothing was written), 15 (this session does not hold the claim). Example: fabrika ledger supersede 4300 --child 4288 --reason "folded into the loader slice"',
+		'Retire a child the re-plan no longer contains: comment, unlink, close as not_planned — in that order, so a child is never closed while still linked — then re-read and prove it. Prints {"answer":"superseded","epic":n,"child":n,"comment":id,"unlinked":true,"state":"closed"}. Refuses a child that is not this epic\'s sub-issue, and one this run minted. Exits 5 (the reason carries a machine-local path), 6 (bare @ reference), 7 (the epic or the child is proven absent or closed), 8 (a leg was attempted and its outcome could not be proven), 9 (the legs landed and the child does not read back closed and unlinked), 10 (not a type:epic; --child is not a sub-issue of it; or --child was minted by this run), 11 (a precondition read failed — nothing was written), 15 (this LANE does not hold the epic\'s claim — --token says which lane is asking, #6060). Example: fabrika ledger supersede 4300 --child 4288 --reason "folded into the loader slice" --token build:s-9f2e:c1a4d6f8-…',
 	),
 );
 

--- a/packages/fabrika-cli/src/ledger/draft-verb.unit.test.ts
+++ b/packages/fabrika-cli/src/ledger/draft-verb.unit.test.ts
@@ -15,7 +15,7 @@ import {
 } from "./codes.ts";
 import {bodyDigest} from "./digest.ts";
 import {runDraft} from "./draft-verb.ts";
-import {CLAIMED, DIR, env, epic, planBlock} from "./fixtures.test-support.ts";
+import {CLAIMED, DIR, env, epic, planBlock, TOKEN} from "./fixtures.test-support.ts";
 import {planPath, renderRunRecord, runJsonPath} from "./run.ts";
 
 const EPIC_BODY = "An epic brief about the moderation queue.\n";
@@ -53,6 +53,7 @@ const run = (
 			runDraft({
 				number: 4300,
 				bodyDigest: options.digest ?? DIGEST,
+				token: TOKEN,
 				repo: null,
 				env,
 				stdin,

--- a/packages/fabrika-cli/src/ledger/fixtures.test-support.ts
+++ b/packages/fabrika-cli/src/ledger/fixtures.test-support.ts
@@ -7,7 +7,7 @@
  * for the same reason the link and unlink take it: it is the field the relation is keyed on.
  */
 
-import {comments, LANE_UUID, marker, NONCE} from "../build/fixtures.test-support.ts";
+import {comments, LANE_TOKEN, LANE_UUID, marker, NONCE} from "../build/fixtures.test-support.ts";
 import {okOut} from "../fakes.test-support.ts";
 import type {ExecResult} from "../io/exec.ts";
 import {PLAN_SECTIONS} from "./plan-block.ts";
@@ -146,7 +146,7 @@ export const milestones = (...rows: ReadonlyArray<readonly [number, string]>): E
 export const issueRows = (...rows: ReadonlyArray<readonly [number, string]>): ExecResult =>
 	okOut(rows.map(([number, title]) => `${number}\t${title}`).join("\n"));
 
-/** The claim on the epic, held by this session under the lane the run key is derived from. */
+/** The claim on the epic, held by the lane `TOKEN` names — the one the run key is derived from. */
 export const CLAIMED: ReadonlyArray<readonly [RegExp, ExecResult]> = [
 	[
 		new RegExp(`^gh api --paginate repos/${REPO}/issues/${EPIC}/comments`),
@@ -154,5 +154,8 @@ export const CLAIMED: ReadonlyArray<readonly [RegExp, ExecResult]> = [
 	],
 	[new RegExp(`^gh api repos/${REPO}/collaborators/agent/permission`), okOut("write\n")],
 ];
+
+/** The `--token` the fixture lane passes: the claim `CLAIMED` posts, read back as an identity. */
+export const TOKEN = LANE_TOKEN;
 
 export {NONCE};

--- a/packages/fabrika-cli/src/ledger/open-verb.unit.test.ts
+++ b/packages/fabrika-cli/src/ledger/open-verb.unit.test.ts
@@ -19,6 +19,7 @@ import {
 	epic,
 	issueRows,
 	subIssues,
+	TOKEN,
 } from "./fixtures.test-support.ts";
 import {runOpen} from "./open-verb.ts";
 import {manifestPath, parseManifest, parseRunRecord, runJsonPath} from "./run.ts";
@@ -58,7 +59,10 @@ const run = (
 	const shell = fakeShell(script);
 	const fs = fakeFs({files});
 	return Effect.runPromise(
-		Effect.provide(runOpen({number: 4300, repo: null, env}), Layer.mergeAll(shell.layer, fs.layer)),
+		Effect.provide(
+			runOpen({number: 4300, token: TOKEN, repo: null, env}),
+			Layer.mergeAll(shell.layer, fs.layer),
+		),
 	).then((outcome) => ({outcome, written: fs.written, calls: shell.calls}));
 };
 
@@ -218,7 +222,7 @@ describe("runOpen", () => {
 		expect(outcome.code).toBe(PRECONDITION_UNKNOWN);
 	});
 
-	it("refuses when this session does not hold the claim", async () => {
+	it("refuses when this lane does not hold the claim", async () => {
 		const {outcome} = await run([
 			[EPIC_READ, epic()],
 			[TREE, GIT_DIRS],
@@ -229,7 +233,7 @@ describe("runOpen", () => {
 			...CLEAN.slice(4),
 		]);
 		expect(outcome.code).toBe(CLAIM_NOT_MINE);
-		expect(outcome.stderr.at(-1)).toBe("ledger open: this session does not hold #4300's claim.");
+		expect(outcome.stderr.at(-1)).toBe("ledger open: this lane does not hold #4300's claim.");
 	});
 
 	/** An unreachable index is `indeterminate`; only a read that ran and matched nothing is `none`. */

--- a/packages/fabrika-cli/src/ledger/preconditions.ts
+++ b/packages/fabrika-cli/src/ledger/preconditions.ts
@@ -10,12 +10,15 @@
  * holder's claim.
  *
  * The run directory is derived from the **claim nonce** here and nowhere else, which is what makes two
- * parallel planning lanes of one session independent (#4516, #4544, #4500).
+ * parallel planning lanes of one session independent (#4516, #4544, #4500). That independence is why
+ * the claim is proven against the `--token` this lane holds rather than against its session id: under
+ * the session-only rule a lane that had *lost* the epic's claim still read the holder's marker as its
+ * own, and derived the holder's run key from it, so both lanes wrote into one directory (#6060).
  */
 
 import {Effect} from "effect";
 import type {ChildProcessSpawner} from "effect/unstable/process";
-import {anySessionCaller, requireClaim, requireSession} from "../build/claim.ts";
+import {requireCallerToken, requireClaim, requireSession} from "../build/claim.ts";
 import {nonceOf} from "../build/lane.ts";
 import {badNumber, openIssue, resolveTargetRepo} from "../build/target.ts";
 import {assertGround} from "../build/tree.ts";
@@ -51,6 +54,8 @@ export type Opened =
 
 export interface OpenOptions {
 	readonly number: number;
+	/** The claim token `build claim <epic> --purpose plan` handed this lane — which lane is asking. */
+	readonly token: string;
 	readonly repo: string | null;
 	readonly env: Readonly<Record<string, string | undefined>>;
 }
@@ -71,6 +76,9 @@ export const openGround = (
 		const session = requireSession(verb, options.env);
 		if (session._tag === "Refused") return refused(session.outcome);
 
+		const asking = requireCallerToken(verb, session.id, options.token);
+		if (asking._tag === "Refused") return refused(asking.outcome);
+
 		const resolved = yield* resolveTargetRepo(verb, options.repo, options.env);
 		if (resolved._tag === "Refused") return refused(resolved.outcome);
 		const repo = resolved.repo;
@@ -86,14 +94,14 @@ export const openGround = (
 		const tree = yield* assertGround(verb, false);
 		if (tree._tag === "Refused") return refused(tree.outcome);
 
-		const held = yield* requireClaim(verb, repo, epicNumber, anySessionCaller(session.id));
+		const held = yield* requireClaim(verb, repo, epicNumber, asking.caller);
 		if (held._tag === "Refused") {
 			const outcome = held.outcome;
 			return refused(
 				outcome.code === CLAIM_NOT_MINE
 					? refuse(
 							CLAIM_NOT_MINE,
-							`${verb}: this session does not hold #${epicNumber}'s claim.`,
+							`${verb}: this lane does not hold #${epicNumber}'s claim.`,
 							outcome.stderr,
 						)
 					: outcome,

--- a/packages/fabrika-cli/src/ledger/supersede-verb.unit.test.ts
+++ b/packages/fabrika-cli/src/ledger/supersede-verb.unit.test.ts
@@ -13,7 +13,7 @@ import {
 	ZERO_SCOPE,
 } from "./codes.ts";
 import {bodyDigest} from "./digest.ts";
-import {CLAIMED, childIssue, DIR, env, epic, subIssues} from "./fixtures.test-support.ts";
+import {CLAIMED, childIssue, DIR, env, epic, subIssues, TOKEN} from "./fixtures.test-support.ts";
 import {
 	type ChildRecord,
 	manifestPath,
@@ -97,6 +97,7 @@ const run = (
 				number: 4300,
 				child: options.child ?? 4288,
 				reason: options.reason ?? "folded into the loader slice",
+				token: TOKEN,
 				repo: null,
 				env,
 			}),

--- a/packages/fabrika-cli/src/ledger/topology-verb.unit.test.ts
+++ b/packages/fabrika-cli/src/ledger/topology-verb.unit.test.ts
@@ -13,7 +13,7 @@ import {
 	ZERO_SCOPE,
 } from "./codes.ts";
 import {bodyDigest} from "./digest.ts";
-import {CLAIMED, DIR, env, epic} from "./fixtures.test-support.ts";
+import {CLAIMED, DIR, env, epic, TOKEN} from "./fixtures.test-support.ts";
 import {
 	type ChildRecord,
 	manifestPath,
@@ -65,7 +65,7 @@ const run = (
 	const stdin: Effect.Effect<StdinRead> = Effect.succeed({_tag: "Text", text: stdinText});
 	return Effect.runPromise(
 		Effect.provide(
-			runTopology({number: 4300, repo: null, env, stdin}),
+			runTopology({number: 4300, token: TOKEN, repo: null, env, stdin}),
 			Layer.mergeAll(shell.layer, fs.layer),
 		),
 	).then((outcome) => ({outcome, written: fs.written}));

--- a/packages/fabrika-cli/src/ledger/write-verb.unit.test.ts
+++ b/packages/fabrika-cli/src/ledger/write-verb.unit.test.ts
@@ -13,7 +13,7 @@ import {
 	WRITE_UNKNOWN,
 } from "./codes.ts";
 import {bodyDigest} from "./digest.ts";
-import {CLAIMED, DIR, env, epic} from "./fixtures.test-support.ts";
+import {CLAIMED, DIR, env, epic, TOKEN} from "./fixtures.test-support.ts";
 import {planPath, renderRunRecord, runJsonPath, topologyPath} from "./run.ts";
 import {runWrite} from "./write-verb.ts";
 
@@ -64,7 +64,7 @@ const run = (
 	const fs = fakeFs({files});
 	return Effect.runPromise(
 		Effect.provide(
-			runWrite({number: 4300, bodyDigest: digest, repo: null, env}),
+			runWrite({number: 4300, bodyDigest: digest, token: TOKEN, repo: null, env}),
 			Layer.mergeAll(shell.layer, fs.layer),
 		),
 	).then((outcome) => ({outcome, calls: shell.calls}));

--- a/packages/fabrika-cli/src/plan/command.ts
+++ b/packages/fabrika-cli/src/plan/command.ts
@@ -42,6 +42,12 @@ const epicArg = Argument.integer("number").pipe(
 	Argument.withDescription("the epic whose ledger this verb reads"),
 );
 
+const tokenFlag = Flag.string("token").pipe(
+	Flag.withDescription(
+		"the claim token `build claim <epic> --purpose gate` handed this lane — its identity",
+	),
+);
+
 const digestFlag = Flag.string("digest").pipe(
 	Flag.withDescription(
 		"the 12-lowercase-hex scope digest `plan check` printed; the verb recomputes it and refuses on 21 if the plan moved",
@@ -76,14 +82,16 @@ const check = leafCommand(
 
 const flip = leafCommand(
 	"flip",
-	{number: epicArg, digest: digestFlag, repo: repoFlag},
-	Effect.fn(function* ({number, digest, repo}) {
-		yield* emit(yield* runFlip({number, digest, repo: Option.getOrNull(repo), env: process.env}));
+	{number: epicArg, digest: digestFlag, token: tokenFlag, repo: repoFlag},
+	Effect.fn(function* ({number, digest, token, repo}) {
+		yield* emit(
+			yield* runFlip({number, digest, token, repo: Option.getOrNull(repo), env: process.env}),
+		);
 	}),
 ).pipe(
 	Command.withShortDescription("Flip every planned child to triaged, re-gating first."),
 	Command.withDescription(
-		'Flip every status:planned child to status:triaged, re-gating first, and report the OBSERVED result per child — flipped | already | unchanged | not-planned, read back from GitHub, never asserted from intent. status:triaged is added before status:planned is removed, always, so a child caught mid-write still carries a status: label. Zero planned children is an answer with terminal "nothing-to-flip", not a refusal. Exits 4 (the grammar refused during the re-gate), 7 (zero children), 8 (a write was attempted and no re-read could prove its outcome), 10 (not a type:epic, or --digest is not 12 lowercase hex), 11 (a read failed — nothing was written), 15 (this session does not hold the epic\'s claim), 20 (the re-gate derived hard defects), 21 (the plan moved since the check), 22 (at least one child is unchanged — the refs are on stderr), 23 (a label the flip must write is absent from the repo taxonomy — refused, never created, #4285). Example: fabrika plan flip 4300 --digest 4d90e1bb27ac',
+		'Flip every status:planned child to status:triaged, re-gating first, and report the OBSERVED result per child — flipped | already | unchanged | not-planned, read back from GitHub, never asserted from intent. status:triaged is added before status:planned is removed, always, so a child caught mid-write still carries a status: label. Zero planned children is an answer with terminal "nothing-to-flip", not a refusal. Exits 4 (the grammar refused during the re-gate), 7 (zero children), 8 (a write was attempted and no re-read could prove its outcome), 10 (not a type:epic, or --digest is not 12 lowercase hex), 11 (a read failed — nothing was written), 15 (this LANE does not hold the epic\'s claim — --token says which lane is asking, since ownership turns on the whole token and never the session id, #6060), 20 (the re-gate derived hard defects), 21 (the plan moved since the check), 22 (at least one child is unchanged — the refs are on stderr), 23 (a label the flip must write is absent from the repo taxonomy — refused, never created, #4285). Example: fabrika plan flip 4300 --digest 4d90e1bb27ac --token build:s-9f2e:c1a4d6f8-…',
 	),
 );
 
@@ -92,6 +100,7 @@ const verdict = leafCommand(
 	{
 		number: epicArg,
 		digest: digestFlag,
+		token: tokenFlag,
 		polarity: Flag.string("polarity").pipe(
 			Flag.optional,
 			Flag.withDescription(
@@ -100,11 +109,12 @@ const verdict = leafCommand(
 		),
 		repo: repoFlag,
 	},
-	Effect.fn(function* ({number, digest, polarity, repo}) {
+	Effect.fn(function* ({number, digest, token, polarity, repo}) {
 		yield* emit(
 			yield* runVerdict({
 				number,
 				digest,
+				token,
 				polarity: Option.getOrNull(polarity),
 				repo: Option.getOrNull(repo),
 				env: process.env,
@@ -115,7 +125,7 @@ const verdict = leafCommand(
 ).pipe(
 	Command.withShortDescription("Post the plan gate's verdict, bound to the scope digest."),
 	Command.withDescription(
-		'Post the gate\'s verdict comment, bound to the scope digest, and read it back. Prints {"answer":"posted","epic":n,"polarity":"PASS","digest":"…","skipped":[],"comment":id,"caveats":k}. The polarity is DERIVED by re-running the floor — a caller never supplies it. Optional stdin carries advisory caveats, one per line, "caveat: <kind> #<ref> — <text>", over the closed set ac-not-checkable | brief-fidelity | slice-too-broad | dependency-implied-not-declared; an empty stdin is an ordinary answer. Exits 4 (the grammar refused), 5/6 (the authored caveats carry a machine-local path, or are a bare @ path reference), 7 (zero children), 8 (posted and unprovable — UNKNOWN), 9 (posted but the read-back does not match), 10 (--digest malformed, not a type:epic, --polarity disagrees with the derived floor, an off-set caveat kind, or a caveat naming a ref outside the scanned set), 11 (a read failed — nothing was posted), 15 (this session does not hold the epic\'s claim), 21 (the plan moved since the check). Example: fabrika plan verdict 4300 --digest 4d90e1bb27ac < caveats.md',
+		'Post the gate\'s verdict comment, bound to the scope digest, and read it back. Prints {"answer":"posted","epic":n,"polarity":"PASS","digest":"…","skipped":[],"comment":id,"caveats":k}. The polarity is DERIVED by re-running the floor — a caller never supplies it. Optional stdin carries advisory caveats, one per line, "caveat: <kind> #<ref> — <text>", over the closed set ac-not-checkable | brief-fidelity | slice-too-broad | dependency-implied-not-declared; an empty stdin is an ordinary answer. Exits 4 (the grammar refused), 5/6 (the authored caveats carry a machine-local path, or are a bare @ path reference), 7 (zero children), 8 (posted and unprovable — UNKNOWN), 9 (posted but the read-back does not match), 10 (--digest malformed, not a type:epic, --polarity disagrees with the derived floor, an off-set caveat kind, or a caveat naming a ref outside the scanned set), 11 (a read failed — nothing was posted), 15 (this LANE does not hold the epic\'s claim — --token says which lane is asking, since ownership turns on the whole token and never the session id, #6060), 21 (the plan moved since the check). Example: fabrika plan verdict 4300 --digest 4d90e1bb27ac --token build:s-9f2e:c1a4d6f8-… < caveats.md',
 	),
 );
 

--- a/packages/fabrika-cli/src/plan/flip-verb.ts
+++ b/packages/fabrika-cli/src/plan/flip-verb.ts
@@ -29,7 +29,7 @@
 
 import {Effect} from "effect";
 import type {ChildProcessSpawner} from "effect/unstable/process";
-import {anySessionCaller, requireClaim, requireSession} from "../build/claim.ts";
+import {requireCallerToken, requireClaim, requireSession} from "../build/claim.ts";
 import {badNumber, resolveTargetRepo} from "../build/target.ts";
 import {addLabels, getIssue, listLabels, removeLabel} from "../io/issues.ts";
 import {PLANNED, TRIAGED} from "../labels.ts";
@@ -92,6 +92,8 @@ export const audienceSettled = (observed: ReadonlyArray<string>): boolean =>
 export interface FlipOptions {
 	readonly number: number;
 	readonly digest: string;
+	/** The claim token `build claim <epic> --purpose gate` handed this lane — which lane is asking. */
+	readonly token: string;
 	readonly repo: string | null;
 	readonly env: Readonly<Record<string, string | undefined>>;
 }
@@ -128,7 +130,10 @@ export const runFlip = (
 		const target = yield* requireEpic(MESSAGES, repo, options.number);
 		if (target._tag === "Refused") return target.outcome;
 
-		const held = yield* requireClaim(VERB, repo, options.number, anySessionCaller(session.id));
+		const asking = requireCallerToken(VERB, session.id, options.token);
+		if (asking._tag === "Refused") return asking.outcome;
+
+		const held = yield* requireClaim(VERB, repo, options.number, asking.caller);
 		if (held._tag === "Refused") return held.outcome;
 
 		const read = yield* loadLedger(MESSAGES, repo, target.issue);

--- a/packages/fabrika-cli/src/plan/flip-verb.unit.test.ts
+++ b/packages/fabrika-cli/src/plan/flip-verb.unit.test.ts
@@ -1,6 +1,6 @@
 import {Effect} from "effect";
 import {describe, expect, it} from "vitest";
-import {comments, LANE_UUID, marker} from "../build/fixtures.test-support.ts";
+import {comments, LANE_UUID, marker, LANE_TOKEN as TOKEN} from "../build/fixtures.test-support.ts";
 import {errOut, fakeShell, okOut, once} from "../fakes.test-support.ts";
 import type {ExecResult} from "../io/exec.ts";
 import {runCheck} from "./check-verb.ts";
@@ -93,7 +93,7 @@ const CLEAN_READ: ReadonlyArray<readonly [RegExp, ExecResult]> = [
 const run = (digest: string, script: ReadonlyArray<readonly [RegExp, ExecResult]>) => {
 	const shell = fakeShell(script);
 	return Effect.runPromise(
-		Effect.provide(runFlip({number: 4300, digest, repo: null, env}), shell.layer),
+		Effect.provide(runFlip({number: 4300, digest, token: TOKEN, repo: null, env}), shell.layer),
 	).then((outcome) => ({outcome, calls: shell.calls}));
 };
 

--- a/packages/fabrika-cli/src/plan/verdict-verb.ts
+++ b/packages/fabrika-cli/src/plan/verdict-verb.ts
@@ -12,7 +12,7 @@
 
 import {Effect} from "effect";
 import type {ChildProcessSpawner} from "effect/unstable/process";
-import {anySessionCaller, requireClaim, requireSession} from "../build/claim.ts";
+import {requireCallerToken, requireClaim, requireSession} from "../build/claim.ts";
 import {badNumber, resolveTargetRepo} from "../build/target.ts";
 import {createComment, getComment} from "../io/issues.ts";
 import type {StdinRead} from "../io/stdin.ts";
@@ -105,6 +105,8 @@ export const composeVerdict = (
 export interface VerdictOptions {
 	readonly number: number;
 	readonly digest: string;
+	/** The claim token `build claim <epic> --purpose gate` handed this lane — which lane is asking. */
+	readonly token: string;
 	readonly polarity: string | null;
 	readonly repo: string | null;
 	readonly env: Readonly<Record<string, string | undefined>>;
@@ -143,7 +145,10 @@ export const runVerdict = (
 		const target = yield* requireEpic(MESSAGES, repo, options.number);
 		if (target._tag === "Refused") return target.outcome;
 
-		const held = yield* requireClaim(VERB, repo, options.number, anySessionCaller(session.id));
+		const asking = requireCallerToken(VERB, session.id, options.token);
+		if (asking._tag === "Refused") return asking.outcome;
+
+		const held = yield* requireClaim(VERB, repo, options.number, asking.caller);
 		if (held._tag === "Refused") return held.outcome;
 
 		const read = yield* loadLedger(MESSAGES, repo, target.issue);

--- a/packages/fabrika-cli/src/plan/verdict-verb.unit.test.ts
+++ b/packages/fabrika-cli/src/plan/verdict-verb.unit.test.ts
@@ -1,6 +1,6 @@
 import {Effect} from "effect";
 import {describe, expect, it} from "vitest";
-import {comments, LANE_UUID, marker} from "../build/fixtures.test-support.ts";
+import {comments, LANE_UUID, marker, LANE_TOKEN as TOKEN} from "../build/fixtures.test-support.ts";
 import {errOut, fakeShell, okOut} from "../fakes.test-support.ts";
 import type {ExecResult} from "../io/exec.ts";
 import type {StdinRead} from "../io/stdin.ts";
@@ -76,6 +76,7 @@ const run = (
 			runVerdict({
 				number: 4300,
 				digest,
+				token: TOKEN,
 				polarity: overrides.polarity ?? null,
 				repo: null,
 				env,
@@ -262,6 +263,7 @@ describe("runVerdict", () => {
 				runVerdict({
 					number: 4300,
 					digest: "4d90e1bb27ac",
+					token: TOKEN,
 					polarity: null,
 					repo: null,
 					env,


### PR DESCRIPTION
Three claim call sites outside the `build` namespace decided "is this claim mine?" by comparing the
session id alone, so two lanes of one session both resolved `Mine` on the same issue. Each now asks
the ownership question as the lane it actually is, read off the `--token` its own claim verb handed
back — the same shape the `build` namespace already uses.

**`lane claim` / `lane release`** take `--token`. The claim checkpoint and the release both resolve
under that lane's nonce, so a sibling driver of one session is a foreign holder rather than this
run. The release refusal names the holding token, and adds a note when the winner is this very
session under another nonce — the case that used to end in an unrecoverable delete of the holder's
marker.

Two defects folded in by the founder ruling on the issue, both on the same file:

- **Duplicate markers on re-claim.** `lane claim` handed the token it already holds now answers
  `won` with the owning marker and writes nothing, and `lane release` sweeps every marker carrying
  this driver's token rather than only the winner. Nothing in this namespace expires a marker, so a
  leftover used to lock the lane out on `31` until a human deleted the comment.
- **The claim UNKNOWN path leaked its own marker.** It now retracts the comment it just posted —
  provably its own write — before exiting `11`, matching the loss path's trailer.

**The epic claims (`ledger` ×6, `plan verdict`, `plan flip`) thread per-lane identity** rather than
declaring themselves one-per-session. `preconditions.ts` derives the run directory from the winning
marker's nonce, and its docblock claims that is what makes two parallel planning lanes of one
session independent. Under the session-only rule that was false: a lane that had *lost* the epic's
claim still read the holder's marker as `Mine` and landed on the holder's run key. Passing the
explicit any-lane caller would have meant deleting the docblock's invariant instead of honouring it.

`triage/claim-verb.ts` and `handoff/claim-verb.ts` are untouched — they already guard.

Every call site that lost a flag gained one in its skill: `operate` carries the lane token from
`lane claim` to `lane release`, and `plan-epic` / `check-epic-plan` pass the token their `build
claim` already prints (both SKILL.md files already told the reader every later verb takes `--token`;
the `ledger` and `plan` verbs are what did not).

Fixes #6060

## Deviations

- **Out-of-scope change** — **Said:** the issue names `lane/claim-verb.ts`, `ledger/preconditions.ts`,
  `plan/verdict-verb.ts` and `plan/flip-verb.ts`. **Did:** also added a `--token` flag to the six
  `ledger` leaves and the two `plan` leaves in their adapters, and to the skill docs that invoke
  them. **Why:** `openGround` reads the token, and an adapter that cannot pass one makes the verb
  unrunnable. **Disposition:** stated here.
- **Out-of-scope change** — **Said:** nothing about `build/claim.ts`. **Did:** `requireCallerToken`
  gained a `ClaimGrammar` parameter, defaulted to `BUILD_CLAIM`. **Why:** the `lane:` namespace
  needs the same token reader, and a copy would be a second parser for one grammar. No `build`
  caller changes behaviour. **Disposition:** stated here.
- **Pre-existing test or fixture changed** — **Said:** the existing `build` claim tests still pass
  unchanged. **Did:** they do, untouched; the `ledger` and `plan` unit tests gained a `token:` field
  on their options fixtures, and `open-verb.unit.test.ts` follows the refusal wording from "this
  session" to "this lane". **Why:** the options types now require it, and the refusal it asserts
  changed. No assertion was weakened. **Disposition:** stated here.
