### PR TITLE
chore: ui/harness.ts hand-rolls validation of repo-authored config instead of using Schema

### DIFF
--- a/.patterns/effect-schema-validation.md
+++ b/.patterns/effect-schema-validation.md
@@ -89,6 +89,37 @@ The error tags appear in the method's `E` channel, the resolver maps them to wir
 
 Reach for `Schema.decodeUnknown` *inside* a service method only when the validation is genuinely complex enough to be tedious as if/else — nested shape validation, conditional fields, branded primitives. Even then, the schema lives inside the service's closure as an implementation detail, not at the method signature.
 
+## A repo-authored config file: whole-file refusal with pinned wording
+
+`packages/fabrika-cli/src/ui/harness.ts` is the worked example — `design-harness.json` is untrusted
+text a consuming repo wrote, and every failure has to come back as one human-readable line a verb
+interpolates into its refusal. Three rules make that work with `Schema` rather than hand predicates:
+
+**The native `JSON.parse` stays outside the schema.** Parsing an untrusted string needs a native
+`try/catch`, which the repo bans in any file importing `effect` (#2736, enforced by a biome plugin).
+So the boundary lives in `io/json.ts` — which imports no `effect` on purpose — and returns
+`{_tag: "Parsed" | "Failed"}`; `Schema` starts at the already-parsed `unknown`.
+
+**Unknown keys refuse the file.** Pass `{onExcessProperty: "error"}` to the decoder, and annotate the
+struct with `messageUnexpectedKey`. That check runs before any property is read, so an unknown key is
+always the reported violation.
+
+**One message per field, however that field fails.** A missing key, a wrong type and a failed check
+should read the same, so the wording goes in three places for one field: `.annotate({message})` on
+the base schema (the wrong-type leaf), the check's own `{message}` option, and
+`.annotateKey({messageMissingKey})` (the absent key). Annotate the *base* schema before `.check(...)`
+— annotating the checked schema leaves the wrong-type leaf on the default `"Expected string, got 3"`.
+
+Read the first violation back with `SchemaIssue.makeFormatterStandardSchemaV1`, which yields
+`{message, path}` per issue; with the default `errors: "first"`, `issues[0]` is the one to report. A
+message that has to name a key the schema cannot know statically (the unexpected one) carries a
+placeholder the formatter fills from `path`.
+
+Defaults and normalisation ride the declaration too: `Schema.withDecodingDefaultTypeKey` for an
+absent key's value, `Schema.decode({decode: SchemaGetter.transform(...)})` for a normalisation like
+stripping a trailing slash. `HarnessConfig` is then `typeof Harness.Type` — one declaration, not an
+interface kept in sync beside it.
+
 ## Schema for tagged errors that cross boundaries
 
 [effect-errors.md](./effect-errors.md) covers this briefly. If an error needs to round-trip through JSON (RPC, persisted error log, message queue), use `Schema.TaggedErrorClass`:

--- a/packages/fabrika-cli/src/io/json.ts
+++ b/packages/fabrika-cli/src/io/json.ts
@@ -1,19 +1,31 @@
 /**
- * The JSON boundary for `gh api` responses.
+ * The JSON boundary — the one native `try/catch` around `JSON.parse` in this package.
  *
  * **No `effect` import here on purpose.** Parsing an untrusted string needs a native `try/catch`,
  * and the repo bans that inside Effect control flow (#2736) — so this is the boundary half, and the
- * Effect seams in `issues.ts` wrap it. A parse that fails resolves to `null`, which every caller
- * turns into a typed refusal rather than into an empty result.
+ * Effect seams in `issues.ts` wrap it. A parse that fails never resolves to a value: it is either
+ * `null` or a tagged reason, which every caller turns into a typed refusal rather than into an
+ * empty result.
  */
+
+/** A parse that landed, or the engine's own reason when the bytes were not JSON at all. */
+export type JsonParse =
+	| {readonly _tag: "Parsed"; readonly value: unknown}
+	| {readonly _tag: "Failed"; readonly reason: string};
+
+/** The parsed value, or why the bytes were not JSON — for a caller that reports the reason. */
+export const parseJsonOrReason = (text: string): JsonParse => {
+	try {
+		return {_tag: "Parsed", value: JSON.parse(text) as unknown};
+	} catch (err) {
+		return {_tag: "Failed", reason: (err as Error).message};
+	}
+};
 
 /** The parsed value, or `null` when the bytes were not JSON at all. */
 export const parseJson = (text: string): unknown => {
-	try {
-		return JSON.parse(text) as unknown;
-	} catch {
-		return null;
-	}
+	const parsed = parseJsonOrReason(text);
+	return parsed._tag === "Parsed" ? parsed.value : null;
 };
 
 export const isRecord = (value: unknown): value is Record<string, unknown> =>

--- a/packages/fabrika-cli/src/ui/harness.ts
+++ b/packages/fabrika-cli/src/ui/harness.ts
@@ -5,80 +5,101 @@
  * URL and the readiness probe are the repo's own declaration, so the render leg needs no knowledge of
  * any particular stack. Validated whole-file, the same rule the registry gets.
  */
+import {Effect, Result, Schema, SchemaGetter, SchemaIssue} from "effect";
+import {parseJsonOrReason} from "../io/json.ts";
 
 /** The capture viewport in CSS px, when the harness does not name one. */
 export const DEFAULT_VIEWPORT = {width: 1280, height: 900} as const;
 /** The readiness bound: a harness that has not answered 200 by here leaves every surface UNKNOWN. */
 export const READY_TIMEOUT_MS = 60_000;
 
-export interface HarnessConfig {
-	readonly command: string;
-	readonly url: string;
-	readonly readyPath: string;
-	readonly viewport: {readonly width: number; readonly height: number};
-	readonly evidenceStore: string | null;
-}
+/**
+ * The refusal wording, one string per field however that field fails — a missing key, a wrong type
+ * and a failed check all read the same. Callers interpolate these into user-facing refusals
+ * (`render-verb.ts`, `evidence-verb.ts`) and `harness.unit.test.ts` pins them, so they are the
+ * schema's contract rather than incidental text.
+ */
+const VIOLATION = {
+	topLevel: "the top level is not an object",
+	/** The unexpected key is only known to the formatter, which fills the placeholder from the path. */
+	unknownKey: 'unknown key "%key%"',
+	command: '"command" is missing or not a non-empty string',
+	url: '"url" is missing or is not an http(s) base URL',
+	readyPath: '"readyPath" is not a path beginning with "/"',
+	viewport: '"viewport" is not an object',
+	width: '"viewport.width" is not a positive integer',
+	height: '"viewport.height" is not a positive integer',
+	evidenceStore: '"evidenceStore" is not a string',
+} as const;
+
+const KEY_PLACEHOLDER = "%key%";
+
+const positiveInt = (message: string) =>
+	Schema.Number.annotate({message})
+		.check(Schema.isInt({message}).abort(), Schema.isGreaterThan(0, {message}))
+		.annotateKey({messageMissingKey: message});
+
+const Viewport = Schema.Struct({
+	width: positiveInt(VIOLATION.width),
+	height: positiveInt(VIOLATION.height),
+})
+	.annotate({message: VIOLATION.viewport, messageUnexpectedKey: VIOLATION.unknownKey})
+	.pipe(Schema.withDecodingDefaultTypeKey(Effect.succeed({...DEFAULT_VIEWPORT})));
+
+const Harness = Schema.Struct({
+	command: Schema.String.annotate({message: VIOLATION.command})
+		.check(Schema.makeFilter((value) => value.trim() !== "", {message: VIOLATION.command}))
+		.annotateKey({messageMissingKey: VIOLATION.command}),
+	url: Schema.String.annotate({message: VIOLATION.url})
+		.check(Schema.isPattern(/^https?:\/\//, {message: VIOLATION.url}))
+		.annotateKey({messageMissingKey: VIOLATION.url})
+		.pipe(
+			Schema.decode({
+				decode: SchemaGetter.transform((url: string) => url.replace(/\/+$/, "")),
+				encode: SchemaGetter.passthrough(),
+			}),
+		),
+	readyPath: Schema.String.annotate({message: VIOLATION.readyPath})
+		.check(Schema.isStartsWith("/", {message: VIOLATION.readyPath}))
+		.pipe(Schema.withDecodingDefaultKey(Effect.succeed("/"))),
+	viewport: Viewport,
+	evidenceStore: Schema.NullOr(Schema.String)
+		.annotate({message: VIOLATION.evidenceStore})
+		.pipe(Schema.withDecodingDefaultTypeKey(Effect.succeed(null))),
+}).annotate({message: VIOLATION.topLevel, messageUnexpectedKey: VIOLATION.unknownKey});
+
+export type HarnessConfig = typeof Harness.Type;
 
 export type HarnessParse =
 	| {readonly _tag: "Config"; readonly config: HarnessConfig}
 	| {readonly _tag: "Violation"; readonly violation: string};
 
-const isRecord = (value: unknown): value is Record<string, unknown> =>
-	typeof value === "object" && value !== null && !Array.isArray(value);
+const decodeHarness = Schema.decodeUnknownResult(Harness, {onExcessProperty: "error"});
 
-const KNOWN = ["command", "url", "readyPath", "viewport", "evidenceStore"];
+const formatIssues = SchemaIssue.makeFormatterStandardSchemaV1({
+	leafHook: SchemaIssue.defaultLeafHook,
+	checkHook: SchemaIssue.defaultCheckHook,
+});
 
-const viewportOf = (raw: unknown): {width: number; height: number} | string => {
-	if (raw === undefined) return {...DEFAULT_VIEWPORT};
-	if (!isRecord(raw)) return '"viewport" is not an object';
-	const {width, height} = raw;
-	if (typeof width !== "number" || !Number.isInteger(width) || width <= 0) {
-		return '"viewport.width" is not a positive integer';
-	}
-	if (typeof height !== "number" || !Number.isInteger(height) || height <= 0) {
-		return '"viewport.height" is not a positive integer';
-	}
-	return {width, height};
+const violationOf = (error: Schema.SchemaError): string => {
+	const [first] = formatIssues(error.issue).issues;
+	if (first === undefined) return VIOLATION.topLevel;
+	const segment = first.path?.at(-1);
+	return first.message.replace(
+		KEY_PLACEHOLDER,
+		String(typeof segment === "object" ? segment.key : segment),
+	);
 };
 
 export const parseHarness = (text: string): HarnessParse => {
-	let parsed: unknown;
-	try {
-		parsed = JSON.parse(text);
-	} catch (err) {
-		return {_tag: "Violation", violation: `the file is not JSON (${(err as Error).message})`};
+	const parsed = parseJsonOrReason(text);
+	if (parsed._tag === "Failed") {
+		return {_tag: "Violation", violation: `the file is not JSON (${parsed.reason})`};
 	}
-	if (!isRecord(parsed)) return {_tag: "Violation", violation: "the top level is not an object"};
-	const extra = Object.keys(parsed).filter((key) => !KNOWN.includes(key));
-	if (extra[0] !== undefined) {
-		return {_tag: "Violation", violation: `unknown key "${extra[0]}"`};
-	}
-	if (typeof parsed.command !== "string" || parsed.command.trim() === "") {
-		return {_tag: "Violation", violation: '"command" is missing or not a non-empty string'};
-	}
-	if (typeof parsed.url !== "string" || !/^https?:\/\//.test(parsed.url)) {
-		return {_tag: "Violation", violation: '"url" is missing or is not an http(s) base URL'};
-	}
-	const readyPath = parsed.readyPath ?? "/";
-	if (typeof readyPath !== "string" || !readyPath.startsWith("/")) {
-		return {_tag: "Violation", violation: '"readyPath" is not a path beginning with "/"'};
-	}
-	const viewport = viewportOf(parsed.viewport);
-	if (typeof viewport === "string") return {_tag: "Violation", violation: viewport};
-	const evidenceStore = parsed.evidenceStore;
-	if (evidenceStore !== undefined && typeof evidenceStore !== "string") {
-		return {_tag: "Violation", violation: '"evidenceStore" is not a string'};
-	}
-	return {
-		_tag: "Config",
-		config: {
-			command: parsed.command,
-			url: parsed.url.replace(/\/+$/, ""),
-			readyPath,
-			viewport,
-			evidenceStore: evidenceStore ?? null,
-		},
-	};
+	const decoded = decodeHarness(parsed.value);
+	return Result.isSuccess(decoded)
+		? {_tag: "Config", config: decoded.success}
+		: {_tag: "Violation", violation: violationOf(decoded.failure)};
 };
 
 /** `/` → `root`; every other route becomes its slug (`/pano/yeni` → `pano-yeni`). */

--- a/packages/fabrika-cli/src/ui/harness.unit.test.ts
+++ b/packages/fabrika-cli/src/ui/harness.unit.test.ts
@@ -52,8 +52,36 @@ describe("parseHarness", () => {
 			'"viewport.width" is not a positive integer',
 		],
 		["an unknown key", config({browser: "chromium"}), 'unknown key "browser"'],
+		[
+			"a non-string command",
+			config({command: 3}),
+			'"command" is missing or not a non-empty string',
+		],
+		["a non-string url", config({url: 3}), '"url" is missing or is not an http(s) base URL'],
+		["a null readyPath", config({readyPath: null}), '"readyPath" is not a path beginning with "/"'],
+		["a non-object viewport", config({viewport: 3}), '"viewport" is not an object'],
+		[
+			"an unknown key inside viewport",
+			config({viewport: {width: 390, height: 844, depth: 2}}),
+			'unknown key "depth"',
+		],
+		["a non-object top level", JSON.stringify([]), "the top level is not an object"],
 	])("refuses %s whole-file", (_label, text, violation) => {
 		expect(parseHarness(text)).toEqual({_tag: "Violation", violation});
+	});
+
+	it("refuses a file that is not JSON, naming the parse error", () => {
+		const parsed = parseHarness("{oops");
+		expect(parsed._tag).toBe("Violation");
+		if (parsed._tag !== "Violation") return;
+		expect(parsed.violation).toMatch(/^the file is not JSON \(/);
+	});
+
+	it("reads an explicit null evidenceStore as no store", () => {
+		const parsed = parseHarness(config({evidenceStore: null}));
+		expect(parsed._tag).toBe("Config");
+		if (parsed._tag !== "Config") return;
+		expect(parsed.config.evidenceStore).toBeNull();
 	});
 });
 


### PR DESCRIPTION
Fixes #5634

`design-harness.json` is repo-authored, untrusted input, and `parseHarness` was checking it with an
`isRecord` predicate, a `KNOWN` key array, and per-field `typeof` / `Number.isInteger` branching.
That is the shape effect-smol's `LLMS.md` tells you not to write ("AVOID using predicates or manual
parsing, instead use `Schema`"), and it is the precedent #5631's `.fabrika.jsonc` loader was about to
copy.

The parse is now one `Schema.Struct` decoded with `{onExcessProperty: "error"}`, and `HarnessConfig`
is `typeof Harness.Type` rather than an interface maintained beside it. All five violation strings
`ui/harness.unit.test.ts` pins are reproduced exactly — the wording is load-bearing, since
`render-verb.ts` and `evidence-verb.ts` interpolate it into user-facing refusals. Each field carries
its message in three places (`.annotate({message})` on the base schema, the check's `{message}`, and
`.annotateKey({messageMissingKey})`) so a missing key, a wrong type and a failed check all read the
same; `SchemaIssue.makeFormatterStandardSchemaV1` reads the first issue back.

The `JSON.parse` try/catch stays native, but it moved: a biome plugin bans raw `try/catch` in any
file importing `effect` (#2736), so it now lives in `io/json.ts` — the module whose docblock already
explains why that boundary is effect-free — as a new `parseJsonOrReason` that keeps the engine's
message. The existing `parseJson` is now written in terms of it, so there is still exactly one
`JSON.parse` in the package.

Grounded in the pinned `effect` 4.0.0-beta.92: `SchemaAST.ts`'s excess-property handling (it runs
before any property is read, so an unknown key is always the reported violation),
`SchemaIssue.ts`'s `defaultLeafHook` / `messageUnexpectedKey`, and `packages/effect/SCHEMA.md`'s key
annotations and formatter sections.

Tests: seven new cases pin the type-level failures and the two behaviour changes below. Full
`fabrika-cli` suite green (6567 tests), typecheck and lint green in-tree.

## Deviations

- **Out-of-scope change** — **Said:** #5634 scopes the work to `harness.ts`. **Did:** also added
  `parseJsonOrReason` to `io/json.ts` and rewrote `parseJson` in terms of it. **Why:** the criterion
  requiring the `JSON.parse` boundary to stay native collides with the biome plugin that bans raw
  `try/catch` in an `effect`-importing file, and `io/json.ts` is the module that exists precisely to
  hold that boundary. **Disposition:** stated here.
- **Out-of-scope change** — **Said:** the issue asks for a code change only. **Did:** also added a
  section to `.patterns/effect-schema-validation.md`. **Why:** the issue's own framing is that this
  becomes the precedent #5631's loader copies, and CLAUDE.md requires a load-bearing pattern to have
  a home; the existing doc had no section on repo-authored config files. **Disposition:** stated
  here.
- **Known defect left unfixed** — **Said:** nothing about the rest of the pattern doc. **Did:** left
  its older examples (`Schema.minLength`, `Schema.pattern`, `Schema.optionalWith`) untouched, though
  those names do not exist in the pinned beta.92. **Why:** out of scope for this ticket and a
  separate sweep. **Disposition:** filed as #6317.
- **Pre-existing test or fixture changed** — **Said:** the five pinned violation strings must be
  reproduced or updated deliberately. **Did:** reproduced all five exactly; two adjacent behaviours
  changed, and both are now pinned by new tests. `"evidenceStore": null` is accepted as "no store"
  where it was previously refused, and `"readyPath": null` is now refused where it previously
  defaulted to `/`. **Why:** both fall out of declaring the field once — `evidenceStore` is
  `NullOr(String)` because its decoded type is `string | null`, and `readyPath`'s default now fires
  on an absent key rather than on any nullish value. Neither input appears in a real harness file,
  and each moves in the safer direction for its field. **Disposition:** stated here.
- **Out-of-scope change** — **Said:** nothing about nested keys. **Did:** an unknown key *inside*
  `viewport` now refuses the file, where it was previously ignored. **Why:**
  `onExcessProperty: "error"` applies to the whole tree, and the file's own docblock says it is
  "validated whole-file". **Disposition:** stated here, and pinned by a test.

