### PR TITLE
fix: The ship stage has no merge path for a repo without a merge queue, so a consuming repo's lane cannot reach shipped

### DIFF
--- a/claude-plugins/fabrika/skills/ship/SKILL.md
+++ b/claude-plugins/fabrika/skills/ship/SKILL.md
@@ -8,9 +8,11 @@ argument-hint: "[pr-number] — the verified pull request to merge"
 # ship
 
 You are the merge authority: one PR in, one terminal token out. The checkout you stand in is not
-this PR — **read-only, no local git, ever**. Success is **enqueued + green** — the queue owns the
-async merge, so "QUEUED" is your victory condition and "merged" is something you *confirm*, never
-assert.
+this PR — **read-only, no local git, ever**. Where a merge queue governs the base, success is
+**enqueued + green** — the queue owns the async merge, so "QUEUED" is your victory condition and
+"merged" is something you *confirm*, never assert. Where no queue governs it, you land the PR
+yourself with `ship merge` and success is the **proven** landing. Which of the two you are on is a
+fact `ship scope` prints; it is never a guess.
 
 <!-- anchor: DISARM-LIFECYCLE --> **Every run that does not enqueue disarms the merge intent.**
 First act: `fabrika ship disarm $pr_number --site preflight` — a parked `--auto` from an interrupted run
@@ -40,7 +42,16 @@ The verb prints the head SHA, the class set with its **required namespaces** (yo
 all of them), the control-plane state, and the linked issue: `code`/`skill` classes require
 `Fixes #N` or an explicit `Part of #N` (partial split — merge without auto-close);
 doc/vocabulary-surface-only PRs are legitimately issueless. Carry the printed head into every later
-`--sha`; a verb refusing `12` means the head moved — start over at 1. How each class maps to a
+`--sha`; a verb refusing `12` means the head moved — start over at 1.
+
+It also prints `landing`, which is **your route at step 7 and the only place you read it**:
+`queue` → `ship enqueue`; `direct` → `ship merge`, with the method it names; `none` → the repository
+permits no way to land this branch, so stop and escalate to a human with settings access. `unknown`
+means the read failed — do not infer a path from it; take the `queue` route, because `ship merge`
+refuses on that same read anyway. Never compose this yourself from a merge-queue check and a
+repository-settings check: two reads a shipper does by hand are two reads a shipper can get wrong.
+
+How each class maps to a
 required namespace, and how the control-plane state is derived, is the verb's section
 (`fabrika wire doc-section --heading "ship scope" < <skill-base>/contract.md`).
 
@@ -160,7 +171,22 @@ EOF
 In doubt, substantive: a false route-back costs one cycle; a false resolve silently discards a
 real objection.
 
-## 7 — Enqueue, then reconcile honestly
+## 7 — Land it, by the route step 1 printed
+
+**`landing direct` — no queue governs the base.** One verb lands it and proves the landing:
+
+```bash
+fabrika ship merge $pr_number --sha 03135b91
+```
+
+`merged\t<commit>\t<method>` at exit 0 is a landing proven by reading `merged` plus the merge
+commit back — go to step 8. `16` is a proven refusal: either a queue governs the base after all
+(run the queue route below) or the PR is not mergeable (disarm, note, route to repair). `19` means
+the repository permits no merge method — stop and escalate to a human with settings access; no verb
+can fix it. `8` means whether it landed is **UNKNOWN**: re-read the PR before you say anything, and
+never report a landing you did not read.
+
+**`landing queue` — enqueue, then reconcile honestly.**
 
 ```bash
 fabrika ship enqueue $pr_number --sha 03135b91
@@ -178,9 +204,9 @@ repair; re-entry is rebase → re-review → fresh gate pass, never a re-enqueue
 neither a landing nor a failure, and **"auto-merges on green" is not a thing you say**. `parked` →
 the enqueue never took effect: run `fabrika ship disarm $pr_number --site post-enqueue` (reconcile is a
 read and disarms nothing), note, and stop. The `mergeable_state` assertion and each terminal's proof
-are the two verbs' sections
+are the verbs' sections
 (`fabrika wire doc-section --heading "ship enqueue" < <skill-base>/contract.md`, then
-`--heading "ship reconcile"`).
+`--heading "ship reconcile"`, and `--heading "ship merge"` for the direct route).
 
 ## 8 — Release queue (dark ships only)
 
@@ -197,13 +223,16 @@ verb's section (`fabrika wire doc-section --heading "ship release" < <skill-base
 ## Terminal vocabulary
 
 <!-- anchor: CAPABILITIES --> Capability set: a shell and a repo-scoped token; writes used —
-merge-queue enqueue/disarm, PR comments (`note`, thread rationale), thread resolution, the
+merge-queue enqueue/disarm, the direct merge on an unqueued base (`ship merge`, and only through
+that verb), PR comments (`note`, thread rationale), thread resolution, the
 close→reopen nudge, one label (`status:awaiting-release`), and one append to the driver's lane
 ledger through `lane report` at the `--root` your brief carries, a path outside this checkout. No
 push, no local git mutation, no
 implementation, no review verdict, no flag flip. Every run ends as exactly one of:
 **already-merged (idempotent success)** · **QUEUED — enqueued, awaiting the queue** (success
-without a merge observed) · **landed** · **refused — <reason>** (a successful decline: disarmed,
+without a merge observed, the queue route's victory) · **landed** (the direct route's, and
+`reconcile`'s — either way it is a landing you *read back*, never one you infer) ·
+**refused — <reason>** (a successful decline: disarmed,
 noted, nothing mutated beyond the note) · **awaiting control-plane approval** · **routed to
 repair** · **routed to heal-ci** · **routed to review** · **UNRESOLVED at horizon** ·
 **EJECTED — routed to repair** ·
@@ -267,7 +296,7 @@ every fabrika skill, so one reader parses all of them. No row here dead-ends on 
 | Must exist | Why this skill needs it | When missing |
 | --- | --- | --- |
 | `.github/CODEOWNERS`, carrying a control-plane team row | `ship scope`'s control-plane classification and `ship cp-approval`'s roster both derive from it, read at the PR's base ref — the branch the PR targets, never a literal trunk name | **fail-loud** — an unreadable boundary is exit `11`, never "ordinary"; a trivial or empty one is the printed `unknown` hold, and a zero-member roster is `stop zero-owners`. The run names `.github/CODEOWNERS` and points at front-door. |
-| A merge queue enabled on the PR's base branch | `ship enqueue` arms the queue's auto-merge; the queue, never this skill, performs the merge | **fail-loud** — a base with no queue has no arm to enter, so refuse before `ship enqueue` and end `refused — no merge queue on <base>`; `reconcile`'s `parked` covers only a queue-governed base. The run names the base branch and points at front-door. |
+| A landing path on the PR's base branch — either a merge queue, or a repository permitting at least one merge method | Step 7 lands the PR through one of exactly two verbs, and `ship scope`'s `landing` line says which (`fabrika wire doc-section --heading "ship merge" < <skill-base>/contract.md`) | **degrade** — a base with no queue is not a missing surface, it is the other path: `ship merge` lands it and `reconcile`'s `parked` never applies. Only a repository permitting *no* merge method has nothing at all, and that ends the run `refused — no landing path on <base>` naming the base branch, because no verb can grant one. |
 | `.github/workflows/ci.yml`, gating the `merge_group` ref | `ship checks` reads its result at the head, and the queue awaits that context on `merge_group` before it merges | **fail-loud** — with no workflows at the head `ship checks` reports `facts workflows:0 runs:0` at rollup `pending` and never green, so the run stops rather than enqueue behind no gate; it names `.github/workflows/ci.yml` and points at front-door. |
 | `.github/workflows/governance-floor.yml`, running `fabrika ship floor` on every PR | it is what makes step 3's governance floor bind on a machine rather than on this prose | **degrade** — the skill still refuses a `blocked` governance namespace itself, so the run is correct without the job; what is lost is enforcement against a run that never happened. Say so, name `.github/workflows/governance-floor.yml`, and point at front-door. |
 | The `status:awaiting-release` label | `ship release` is the dark-ship seam and the label is the whole action | **fail-loud** — a label write or its read-back failing is exit `8`/`9`, never `queued`; the run escalates that a real dark ship may be missing from the release queue, names the `status:awaiting-release` label, and points at front-door. |

--- a/claude-plugins/fabrika/skills/ship/contract.md
+++ b/claude-plugins/fabrika/skills/ship/contract.md
@@ -48,6 +48,7 @@ Named because a spec that leaves the substrate open makes the implementer guess 
 | `ship threads` | every unresolved review thread, fully paginated, with per-thread class facts | pagination, count proof, and author-type classification are mechanical; nit-vs-substantive is THE retained judgment and never enters this verb |
 | `ship resolve` | the sanctioned thread-resolution write: rationale reply, resolve mutation, read-back — refusing any thread not positively bot-classed | the protocol and the bot-only structural anchor are mechanical; deciding a bot thread is a nit is the skill's |
 | `ship enqueue` | arm the queue's auto-merge at a pinned head, method-flag-free by construction, and prove the arm landed | the arm, its error discrimination, and the entry read are mechanical; whether the PR should ship was settled by the gates |
+| `ship merge` | the second landing path: land directly on a base branch no merge queue governs, with the method read off the repository, and prove the landing | reading the regime, picking a permitted method and proving `merged` + the merge commit are mechanical; whether the PR should ship was settled by the gates |
 | `ship reconcile` | the bounded post-enqueue watch: `landed` / `ejected` / `unresolved` / `parked`, each a proven answer at exit 0 | multi-signal terminal classification against timeline + base-branch evidence is mechanical; what ejection means for the lane is judgment |
 | `ship disarm` | the four-site merge-intent lifecycle (ADR 0198): `kept` / `disarmed`, read-back-verified | the site policy table and the verified write are mechanical |
 | `ship nudge` | the at-most-once dropped-trigger remedy: re-derive the zero-runs state, close→reopen, verify both legs | the precondition re-derivation and the guarded PATCH pair are mechanical; the verb refuses rather than trusting its dispatch (#4816) |
@@ -211,16 +212,17 @@ authority.
 | `5` | the **authored** text carries a machine-local path | `resolve`, `note` |
 | `6` | the **authored** text is a bare `@` path reference — not redactable | `resolve`, `note` |
 | `7` | zero scope: the target is **proven absent (404)**, or the PR is closed/draft where the verb requires an open one, or it has zero changed files — a fail-closed refusal | all except `disarm` |
-| `8` | the write, or the read that confirms it, failed — the outcome is **UNKNOWN** | `resolve`, `enqueue`, `disarm`, `nudge`, `note`, `release` |
-| `9` | the write landed but the read-back does not match | `resolve`, `note`, `release` |
+| `8` | the write, or the read that confirms it, failed — the outcome is **UNKNOWN** | `resolve`, `enqueue`, `merge`, `disarm`, `nudge`, `note`, `release` |
+| `9` | the write landed but the read-back does not match | `resolve`, `merge`, `note`, `release` |
 | `10` | a supplied classification value is off the closed vocabulary — an unknown `--require` namespace, a bad `--site` | `gate`, `disarm` |
 | `11` | a **precondition read failed** — nothing was proven and (for a write) nothing was written | all |
-| `12` | refused: the live head moved past the inspected `--sha` — a mutation formed over a tree that is no longer the PR | `enqueue`, `nudge` |
+| `12` | refused: the live head moved past the inspected `--sha` — a mutation formed over a tree that is no longer the PR | `enqueue`, `merge`, `nudge` |
 | `13` | refused: a read completed but its scope is **provably incomplete** — received short of a declared count, or (where the platform declares none) pagination never reached a terminal page | `scope`, `cp-approval`, `gate`, `checks`, `evidence`, `threads`, `nudge`, `release`, `reconcile`, `floor` |
 | `14`, `15` | *(deliberate gaps — `review`'s ACL and append-only seats; no verb here performs either)* | — |
-| `16` | refused: the target is **proven not in the state this write acts on** — nothing was mutated | `resolve`, `nudge` |
+| `16` | refused: the target is **proven not in the state this write acts on** — nothing was mutated | `resolve`, `merge`, `nudge` |
 | `17` | refused: the nudge's close landed and the reopen is **unconfirmed — the PR may be left closed**; a human re-opens before anything else happens | `nudge` |
 | `18` | refused: the diff touches a governance root and its `governance` verdict is **not** a head-bound PASS — `absent`, `stale` or `fail`. The one red that means *a human owes this PR a verdict*, kept off `16` so a CI job can tell it from "the floor could not be resolved" | `floor` |
+| `19` | refused: the repository permits **no merge method at all** — squash, merge-commit and rebase are all disabled, so nothing can land directly. Its own seat rather than a fold into `16`, because the two route opposite ways: `16` sends the run to `ship enqueue`, `19` ends it at a human with repository-settings access (#6018) | `merge` |
 | `23` | refused: a label this run would POST is absent from the repository's taxonomy — `plan flip`'s seat, imported, because both verbs prove one fact over one board's labels (#4285) | `release` |
 | `127` | the verb never ran (unresolved binary) | all |
 
@@ -239,8 +241,9 @@ reported as "awaiting approval" (#4223), a failed file read reported as "no §CP
 (#4216), a 503 body reported as "no run-evidence bundle" (#3716).
 
 **`16` and `17` are this group's own proven refusals.** `16` is the write-side state guard: a
-nudge dispatched at a head that has runs, or a resolve aimed at a thread that is not
-positively bot-classed or is already resolved — the verb proved the state and declined, which
+nudge dispatched at a head that has runs, a resolve aimed at a thread that is not
+positively bot-classed or is already resolved, a direct merge aimed at a queue-governed base or a
+provably unmergeable PR — the verb proved the state and declined, which
 is neither `7` (the target exists) nor `11` (nothing failed). It is the #4816 fix made
 structural: the verb that mutates re-derives its own precondition and refuses without
 touching the PR. `17` exists because the nudge is the group's one two-legged mutation: v1's
@@ -288,9 +291,10 @@ fabrika ship scope 4321 [--repo <owner/name>] [--json]
 `fixes:<n>`, `part-of:<n>`, or `-` (none). Then one line per present artifact class —
 `class\t<code|doc|skill|ui>\t<file-count>` — then one line per required namespace —
 `namespace\t<review-code|review-doc|review-skill|review-ui|governance>` — then
-`cp\t<control-plane|not-control-plane|unknown>` and `files\t<scanned>`.
+`cp\t<control-plane|not-control-plane|unknown>`,
+`landing\t<queue|direct|none|unknown>\t<squash|merge|rebase|->` and `files\t<scanned>`.
 
-With `--json`: `{"outcome":"scoped","head":<40-hex>,"state":…,"issue":{"kind":"fixes"|"part-of"|"none","number":<n|null>},"classes":[{name,files}…],"namespaces":[…],"cp":…,"scanned":<n>}`.
+With `--json`: `{"outcome":"scoped","head":<40-hex>,"state":…,"issue":{"kind":"fixes"|"part-of"|"none","number":<n|null>},"classes":[{name,files}…],"namespaces":[…],"cp":…,"landing":{"path":…,"method":…},"scanned":<n>}`.
 
 **A `merged` PR is an answer, not a refusal** — the skill reports idempotent success and ends.
 `draft` and `closed` are likewise answers here; this verb reports state, the skill acts on it.
@@ -346,12 +350,26 @@ first match), else an explicit `Part of #N` (an intentional partial split — th
 without auto-close), else `-`. Which classes may ship issueless is the skill's law (ADR 0075),
 not this verb's.
 
+**The `landing` line names which of the two landing paths this base branch has**, so the shipper
+reads its route from one verb instead of composing it from two API reads nobody currently performs
+(#6018). `queue` — a merge queue governs the base, so `ship enqueue` lands it and the method is the
+queue's; `direct` — no queue and the repository permits at least one merge method, named beside the
+path, so `ship merge` lands it; `none` — no queue and no permitted method, so nothing in this
+repository can land this branch and a human owes it a settings change.
+
+`landing` is **the one field that degrades instead of refusing**: an unreadable branch-rule or
+repository read prints `unknown` with the reason on stderr, and the rest of the scope still answers.
+That is deliberate and it is not fail-open, because this line licenses nothing — `ship merge`
+re-derives the same fact from the same reads and refuses `11` exactly where this printed `unknown`.
+Refusing the whole scope here would cost a run its head, classes and §CP state over a fact only one
+downstream verb consumes, and that verb guards itself.
+
 **Exit status**
 
 | Code | Trigger |
 |---|---|
 | `7` | the PR is proven absent (404); or it has zero changed files; or its non-empty diff derives zero required namespaces — a vacuous conjunction (#2765, ADR 0092) |
-| `11` | the PR, its file list, or the §CP boundary could not be read — the scope is UNKNOWN |
+| `11` | the PR, its file list, or the §CP boundary could not be read — the scope is UNKNOWN. **Not** the landing read, which degrades to `unknown` |
 | `13` | the changed-file enumeration is provably short (received < declared count) |
 
 **Errors**
@@ -362,6 +380,7 @@ not this verb's.
 | `ship scope: PR #<n> has zero changed files — nothing to ship (ADR 0092).` | 7 | refusal |
 | `ship scope: #<n>'s diff derives zero review namespaces — a merge gated on nothing is vacuously green (#2765); the class map has a hole, file it.` | 7 | refusal |
 | `ship scope: cannot read <what> for #<n>: <reason> — the scope is UNKNOWN.` | 11 | refusal |
+| `ship scope: cannot read <base>'s landing path: <reason> — reporting it unknown; `ship merge` refuses on the same read rather than landing.` | 0 | notice |
 | `ship scope: file list shows <k> of <m> declared files — refusing to partition a truncated read.` | 13 | refusal |
 
 **Scope** — one PR's metadata and changed-file list, paginated and count-checked, plus one
@@ -377,12 +396,13 @@ class	doc	1
 namespace	review-code
 namespace	review-doc
 cp	not-control-plane
+landing	direct	squash
 files	4
 ```
 
 ```
 $ fabrika ship scope 4321 --json
-{"outcome":"scoped","head":"03135b91aa04f7e2c9d8b1640a5c22e9f01b7d3c","state":"open","issue":{"kind":"fixes","number":4287},"classes":[{"name":"code","files":3},{"name":"doc","files":1}],"namespaces":["review-code","review-doc"],"cp":"not-control-plane","scanned":4}
+{"outcome":"scoped","head":"03135b91aa04f7e2c9d8b1640a5c22e9f01b7d3c","state":"open","issue":{"kind":"fixes","number":4287},"classes":[{"name":"code","files":3},{"name":"doc","files":1}],"namespaces":["review-code","review-doc"],"cp":"not-control-plane","landing":{"path":"direct","method":"squash"},"scanned":4}
 ```
 
 ```
@@ -1354,6 +1374,130 @@ enqueued	03135b91	queued
 - ADR 0198 — this is the only verb that arms; every other path is a disarm site.
 - #5067 clause 8 / #5144 — the pre-arm mergeability precondition and its probe: the arm is not
   refused by the platform on a conflicted PR, so the gate is load-bearing rather than redundant.
+
+---
+
+## `ship merge`
+
+**Invocation**
+
+```
+fabrika ship merge 4321 --sha 03135b91 [--repo <owner/name>] [--json]
+```
+
+**Inputs**
+
+| Flag | Type | Required | Default | Description |
+|---|---|---|---|---|
+| *(positional)* | integer | yes | — | the pull-request number |
+| `--sha` | string | yes | — | the head every gate verified; the landing binds to it |
+| `--repo` | string | no | resolved | the repository |
+| `--json` | boolean | no | `false` | emit the result object |
+
+**Output** — machine channel. One line: `merged\t<merge-commit-sha>\t<squash|merge|rebase>`.
+With `--json`: `{"outcome":"merged","sha":…,"method":…,"mergeCommit":…}`.
+
+**This is a second landing path, not a merge-method flag on the first.** `ship enqueue` argues,
+correctly, that a method flag alongside the queue arm conflicts with the queue and no-ops the
+enqueue silently at exit 0 — but that argument is entirely about a queue-governed base, and says
+nothing about a base with no queue. Where no queue exists, `ship enqueue` had nothing to arm and no
+other verb could land anything, so a lane in a consuming repo built, reviewed and gated correctly
+and then stopped one inch short of shipped (#6018, observed on the first non-phoenix lane). The
+method surface therefore lives here, on the path where the queue is **proven absent**, and
+`ship enqueue` still carries none.
+
+**The queue check is a refusal, never a fallback.** A base a merge queue governs is `ship enqueue`'s
+and this verb refuses `16` pointing there — a direct merge into a queue-governed base walks past the
+gate the queue exists to run. The regime is read off the **branch's** active rules, the same read
+`ship disarm` uses, never this PR's queue history. An unreadable regime refuses `11`: this verb never
+lands on a base whose regime it could not read, which is also what makes `ship scope`'s degraded
+`landing unknown` safe.
+
+**The method is read, never guessed.** The repository's `allow_squash_merge` /
+`allow_merge_commit` / `allow_rebase_merge` decide it, preferring squash, then the merge commit,
+then rebase. Squash leads because its default subject ends `(#<pr>)`, which is the anchor
+`ship reconcile`'s base-branch cross-check proves a landing with; a rebase landing publishes the
+branch's own subjects and that cross-check cannot see it. A repository permitting none of the three
+refuses `19` — its own seat rather than a fold into `16`, because the two route opposite ways: `16`
+sends the run onward to `ship enqueue`, `19` ends the lane at a human with repository-settings
+access.
+
+**A definite `mergeable_state` is asserted before the write**, on the same poll policy
+`ship enqueue` uses and out of the same shared read — indefinite is re-read up to 3 times, 2 seconds
+apart, and a still-indefinite value is UNKNOWN and refuses `11`. Unlike the arm, this verb also acts
+on the definite value: a definite `mergeable: false` refuses `16` rather than sending a call the
+endpoint will reject with a 405 that is indistinguishable, from the outside, from a write whose
+outcome nobody knows.
+
+**The landing is proven, not claimed.** The write hands the platform the **full** live head as its
+`sha` parameter, so the platform rejects it if the head moved — a second drift guard under the
+verb's own `12`. After the write, `merged` **and** the merge commit are read back off the PR: the
+merge call's own response is the writer's claim about its own write, and a `merged: true` with no
+commit behind it is a claim with no evidence. An unreadable read-back is `8` and never a success,
+because whether the PR landed is exactly what is UNKNOWN there.
+
+**Exit status**
+
+| Code | Trigger |
+|---|---|
+| `7` | the PR is proven absent (404), closed, or already merged (an idempotent success belongs to `ship scope`'s answer, not to a landing) |
+| `8` | the merge request, or its confirming read-back, failed — whether the PR landed is UNKNOWN; re-read the PR before stopping |
+| `9` | the merge was sent and the read-back does not show it merged at a commit — the landing is not proven |
+| `11` | the live head, the landing path or the mergeability could not be read, or the mergeability was still indefinite after the polls — nothing was merged |
+| `12` | the live head moved past `--sha` — every verdict upstream bound a tree that is gone; re-enter at step 1 |
+| `16` | proven: a merge queue governs the base (run `ship enqueue`), or the PR is definitely not mergeable — nothing was merged |
+| `19` | the repository permits no merge method at all — a human enables one in the repository settings |
+
+**Errors**
+
+| Message (stderr) | Code | Kind |
+|---|---|---|
+| `ship merge: PR #<n> not found in <repo>.` | 7 | refusal |
+| `ship merge: PR #<n> is <closed\|merged> — nothing to merge.` | 7 | refusal |
+| `ship merge: <base> is not queue-governed and <repo> permits <method> — landing directly.` | 0 | notice |
+| `ship merge: mergeable_state is <state> (mergeable: true) — a definite read; merging.` | 0 | notice |
+| `ship merge: cannot read #<n>'s live head: <reason> — nothing was merged.` | 11 | refusal |
+| `ship merge: cannot read <base>'s landing path: <reason> — nothing was merged.` | 11 | refusal |
+| `ship merge: cannot read #<n>'s mergeability: <reason> — nothing was merged.` | 11 | refusal |
+| `ship merge: #<n>'s mergeable_state is still indefinite after <k> polls — mergeability is UNKNOWN, never green; nothing was merged.` | 11 | refusal |
+| `ship merge: the live head is <live>, gates ran at <sha> — refusing to merge a tree nobody verified.` | 12 | refusal |
+| ``ship merge: a merge queue governs <base> — the queue owns the method and the landing; run `fabrika ship enqueue` instead.`` | 16 | refusal |
+| `ship merge: #<n> is not mergeable (mergeable_state: <state>) — a definite read; nothing was merged.` | 16 | refusal |
+| `ship merge: <repo> permits no merge method — squash, merge-commit and rebase are all disabled, so nothing can land on <base>; a human enables one in the repository settings.` | 19 | refusal |
+| `ship merge: the merge failed: "<error>" — whether #<n> landed is UNKNOWN; re-read the PR before stopping.` | 8 | refusal |
+| `ship merge: the merge was sent and the confirming read-back failed: <reason> — whether #<n> landed is UNKNOWN; re-read the PR before stopping.` | 8 | refusal |
+| `ship merge: the merge was sent and the read-back shows merged: <bool> at merge commit <sha\|-> — the landing is not proven.` | 9 | refusal |
+
+**Scope** — one PR's live head, its base branch's active rules, the repository's permitted merge
+methods, the PR's mergeability (re-read until definite or refused), one merge request, one
+read-back of `merged` plus the merge commit.
+
+**Examples**
+
+```
+$ fabrika ship merge 4321 --sha 03135b91
+merged	5c7d1e930a2b4f6d8e0c1a3b5d7f9e1c3a5b7d9f	squash
+```
+
+```
+$ fabrika ship merge 4321 --sha 03135b91
+ship merge: a merge queue governs main — the queue owns the method and the landing; run `fabrika ship enqueue` instead.
+$ echo $?
+16
+```
+
+**Grounding**
+
+- #6018 — the gap itself: `ship`'s only landing verb armed a queue, so a repo with
+  `allow_auto_merge: false` and `mergeQueue: null` had no verb that could land a PR, and every
+  stage before the merge was already portable.
+- `ship enqueue`'s method-flag argument, kept intact — the reason this is a second path rather
+  than a flag on the first.
+- ADR 0198 — arming is `ship enqueue`'s alone and every other path is a disarm site; a direct
+  landing arms nothing, so it opens no new disarm site.
+- The `operate` skill names `ship` the pipeline's single merge authority and the merge into the
+  default branch "the shipper's, once" — so the answer to a queueless repo is a verb here, not a
+  driver reaching for `gh pr merge`.
 
 ---
 

--- a/packages/fabrika-cli/src/ship/codes.ts
+++ b/packages/fabrika-cli/src/ship/codes.ts
@@ -84,6 +84,17 @@ export const NUDGE_REOPEN_UNCONFIRMED = 17;
 export const GOVERNANCE_FLOOR_UNMET = 18;
 
 /**
+ * Refused: the repository permits **no** merge method at all — `ship merge` has nothing to land with.
+ *
+ * Its own seat rather than a fold into {@link PROVEN_NOT_IN_STATE}, which `ship merge` already
+ * spends on the queue-governed base: those two refusals route opposite ways. A queue-governed base
+ * sends the run onward to `ship enqueue`; a repository with squash, merge-commit and rebase all
+ * disabled sends it to a human with repository-settings access and ends the lane there. One code
+ * carrying both would make the caller parse a message to know which (#6018).
+ */
+export const NO_LANDING_METHOD = 19;
+
+/**
  * Refused: a label this run would POST is absent from the repository's taxonomy (#4285).
  *
  * `plan`'s seat, imported, under `plan`'s own rule — *import a code when two groups prove the same

--- a/packages/fabrika-cli/src/ship/command.ts
+++ b/packages/fabrika-cli/src/ship/command.ts
@@ -21,6 +21,7 @@ import {runEnqueue} from "./enqueue-verb.ts";
 import {runEvidence} from "./evidence-verb.ts";
 import {runFloor} from "./floor-verb.ts";
 import {runGate} from "./gate-verb.ts";
+import {runMerge} from "./merge-verb.ts";
 import {runNote} from "./note-verb.ts";
 import {runNudge} from "./nudge-verb.ts";
 import {runReconcile} from "./reconcile-verb.ts";
@@ -67,7 +68,7 @@ const scope = leafCommand(
 ).pipe(
 	Command.withShortDescription("A PR's head, lifecycle, linked issue, classes and CP state."),
 	Command.withDescription(
-		"Report one PR's head, lifecycle state, linked issue, artifact classes with the review namespaces they require, and the three-state §CP classification derived from .github/CODEOWNERS at the base branch. First stdout line is `scoped\\t<head>\\t<open|draft|merged|closed>\\t<fixes:n|part-of:n|->`, then one `class\\t<name>\\t<files>` line per present class, one `namespace\\t<ns>` line per required namespace, `cp\\t<state>` and `files\\t<n>`. A merged, draft or closed PR is an ANSWER, not a refusal. Exits 7 (PR proven absent, zero changed files, or a non-empty diff deriving zero namespaces — a vacuous conjunction, #2765), 11 (the PR, its file list or the §CP boundary could not be read — the scope is UNKNOWN), 13 (the file list is provably short of the declared count). Example: fabrika ship scope 4321",
+		"Report one PR's head, lifecycle state, linked issue, artifact classes with the review namespaces they require, and the three-state §CP classification derived from .github/CODEOWNERS at the base branch. First stdout line is `scoped\\t<head>\\t<open|draft|merged|closed>\\t<fixes:n|part-of:n|->`, then one `class\\t<name>\\t<files>` line per present class, one `namespace\\t<ns>` line per required namespace, `cp\\t<state>`, `landing\\t<queue|direct|none|unknown>\\t<squash|merge|rebase|->` and `files\\t<n>`. The landing line names which of the two landing paths this base branch has — `queue` is `ship enqueue`'s, `direct` is `ship merge`'s — so a shipper does not compose it from a merge-queue read and a repository-settings read on two different APIs (#6018); it is the one field that degrades to `unknown` rather than refusing, because `ship merge` re-derives the same fact and refuses on its own read. A merged, draft or closed PR is an ANSWER, not a refusal. Exits 7 (PR proven absent, zero changed files, or a non-empty diff deriving zero namespaces — a vacuous conjunction, #2765), 11 (the PR, its file list or the §CP boundary could not be read — the scope is UNKNOWN), 13 (the file list is provably short of the declared count). Example: fabrika ship scope 4321",
 	),
 );
 
@@ -258,6 +259,19 @@ const enqueue = leafCommand(
 	),
 );
 
+const merge = leafCommand(
+	"merge",
+	{pr: prArg, sha: shaFlag, repo: repoFlag, json: jsonFlag},
+	Effect.fn(function* ({pr, sha, repo, json}) {
+		yield* emit(yield* runMerge({pr, sha, repo: Option.getOrNull(repo), json, env: process.env}));
+	}),
+).pipe(
+	Command.withShortDescription("Land a PR on a base no merge queue governs, proof read back."),
+	Command.withDescription(
+		"Land a pull request directly on a base branch NO merge queue governs, and prove the landing. Prints `merged\\t<merge-commit-sha>\\t<squash|merge|rebase>`. This is the second landing path, not a flag on the first: `ship enqueue` stays method-free because a method alongside the queue arm no-ops the enqueue at exit 0, and that argument says nothing about a base with no queue, where nothing could land a PR at all (#6018). The method is READ off the repository's allow_squash_merge / allow_merge_commit / allow_rebase_merge, preferring squash because its subject is the `(#<pr>)` anchor `ship reconcile` proves a landing with; a repo permitting none refuses rather than guessing. A definite `mergeable_state` is asserted before the write and a definite `false` refuses. The merge call's own response is never the proof — `merged` plus the merge commit are read back off the PR after it. Exits 7 (PR proven absent, closed or already merged), 8 (the merge, or its confirming read-back, failed — whether it landed is UNKNOWN; re-read the PR), 9 (the read-back does not show it merged at a commit), 11 (the live head, the landing path or the mergeability could not be read, or mergeability stayed indefinite — nothing was merged), 12 (the live head moved past --sha), 16 (a merge queue governs the base — run `fabrika ship enqueue`; or the PR is provably not mergeable), 19 (the repository permits no merge method at all — a human enables one in the repository settings). Example: fabrika ship merge 4321 --sha 03135b91",
+	),
+);
+
 const reconcile = leafCommand(
 	"reconcile",
 	{
@@ -373,6 +387,7 @@ export const shipCommand = Command.make("ship").pipe(
 		threads,
 		resolve,
 		enqueue,
+		merge,
 		reconcile,
 		disarm,
 		nudge,
@@ -381,6 +396,6 @@ export const shipCommand = Command.make("ship").pipe(
 	]),
 	Command.withShortDescription("Drive one pull request down the merge path."),
 	Command.withDescription(
-		"Everything the merge path needs off one pull request — scope, §CP discharge, the verdict conjunction, head CI, run evidence and review threads — plus the four writes that arm, watch, disarm and record it",
+		"Everything the merge path needs off one pull request — scope, §CP discharge, the verdict conjunction, head CI, run evidence and review threads — plus the writes that arm, land, watch, disarm and record it",
 	),
 );

--- a/packages/fabrika-cli/src/ship/enqueue-verb.ts
+++ b/packages/fabrika-cli/src/ship/enqueue-verb.ts
@@ -22,17 +22,12 @@ import {Effect} from "effect";
 import type {ChildProcessSpawner} from "effect/unstable/process";
 import {answer, refuse, type VerbOutcome} from "../verb.ts";
 import {PRECONDITION_UNKNOWN, STALE_HEAD, WRITE_UNKNOWN} from "./codes.ts";
-import {armAutoMerge, isIndefinite, pullTimeline, readMergeability} from "./github.ts";
+import {armAutoMerge, pullTimeline} from "./github.ts";
+import {readDefiniteMergeability} from "./mergeability.ts";
 import {queueStateOf} from "./queue.ts";
 import {badNumber, inspectedSha, prefixMatch, resolvePull, resolveTargetRepo} from "./target.ts";
 
 const VERB = "ship enqueue";
-
-/** How many extra reads the indefinite value gets before it is called UNKNOWN. */
-const MERGEABILITY_POLLS = 3;
-
-/** How long to wait between those reads, giving GitHub's background computation time to land. */
-const MERGEABILITY_CADENCE_SECONDS = 2;
 
 export interface EnqueueOptions {
 	readonly pr: number;
@@ -72,22 +67,17 @@ export const runEnqueue = (
 		}
 
 		const diagnostics: string[] = [];
-		let mergeability = yield* readMergeability(repo, pr);
-		for (let poll = 1; poll <= MERGEABILITY_POLLS; poll++) {
-			if (mergeability._tag === "Failure" || !isIndefinite(mergeability.value)) break;
-			yield* Effect.sleep(`${MERGEABILITY_CADENCE_SECONDS} seconds`);
-			mergeability = yield* readMergeability(repo, pr);
-		}
-		if (mergeability._tag === "Failure") {
+		const mergeability = yield* readDefiniteMergeability(repo, pr);
+		if (mergeability._tag === "Unreadable") {
 			return refuse(
 				PRECONDITION_UNKNOWN,
 				`${VERB}: cannot read #${pr}'s mergeability: ${mergeability.reason} — nothing was armed.`,
 			);
 		}
-		if (isIndefinite(mergeability.value)) {
+		if (mergeability._tag === "Indefinite") {
 			return refuse(
 				PRECONDITION_UNKNOWN,
-				`${VERB}: #${pr}'s mergeable_state is still indefinite after ${MERGEABILITY_POLLS} polls — mergeability is UNKNOWN, never green; nothing was armed.`,
+				`${VERB}: #${pr}'s mergeable_state is still indefinite after ${mergeability.polls} polls — mergeability is UNKNOWN, never green; nothing was armed.`,
 			);
 		}
 		diagnostics.push(

--- a/packages/fabrika-cli/src/ship/fixtures.test-support.ts
+++ b/packages/fabrika-cli/src/ship/fixtures.test-support.ts
@@ -203,4 +203,27 @@ export const issue = (labels: ReadonlyArray<string> = []): ExecResult =>
 		}),
 	);
 
+/** The branch's active rules. `[]` is the answer for a branch nothing governs, not a failure. */
+export const branchRules = (...types: ReadonlyArray<string>): ExecResult =>
+	okOut(JSON.stringify(types.map((type) => ({type}))));
+
+/** The repository's permitted merge methods. An omitted flag reads `false`. */
+export const repository = (
+	allowed: {squash?: boolean; merge?: boolean; rebase?: boolean} = {},
+): ExecResult =>
+	okOut(
+		JSON.stringify({
+			full_name: "o/r",
+			allow_squash_merge: allowed.squash ?? true,
+			allow_merge_commit: allowed.merge ?? true,
+			allow_rebase_merge: allowed.rebase ?? true,
+		}),
+	);
+
+/** The landing read-back projection: `merged` beside the commit that proves it. */
+export const mergeProof = (shape: {merged?: boolean; commit?: string} = {}): ExecResult =>
+	okOut(JSON.stringify({merged: shape.merged ?? true, commit: shape.commit ?? MERGE_COMMIT}));
+
+export const MERGE_COMMIT = "5c7d1e930a2b4f6d8e0c1a3b5d7f9e1c3a5b7d9f";
+
 export const ENV = {CLAUDE_PIPELINE_REPO: "o/r"} as Record<string, string | undefined>;

--- a/packages/fabrika-cli/src/ship/landing.ts
+++ b/packages/fabrika-cli/src/ship/landing.ts
@@ -1,0 +1,135 @@
+/**
+ * Which landing path a base branch has, and which method a direct landing may use.
+ *
+ * The fact is composed from **two** platform reads that live on different APIs — whether a merge
+ * queue governs the branch, and which merge methods the repository permits — and neither read is
+ * about the pull request. A shipper left to do that composition itself is the #6018 gap: `ship`
+ * could arm a queue and nothing else, so a repo with no queue had `allow_auto_merge: false` and
+ * `mergeQueue: null` sitting on two endpoints, with no verb reading either.
+ *
+ * The three paths are exclusive and each is a proven answer:
+ *
+ * - `queue` — a merge queue governs the branch, so the queue owns both the method and the landing
+ *   (`ship enqueue`). The permitted-method read is skipped here, because it decides nothing.
+ * - `direct` — no queue, and the repository permits at least one method (`ship merge`).
+ * - `none` — no queue and no permitted method: nothing in this repository can land this branch, and
+ *   that is a settings fact a human fixes, never a method to guess at.
+ */
+import {Effect} from "effect";
+import {execCapture} from "../io/exec.ts";
+import {type Attempt, fail, ok, type Shell} from "../io/git.ts";
+import {isRecord, parseJson} from "../io/json.ts";
+import {isQueueGoverned} from "./github.ts";
+
+/** The three values GitHub's merge endpoint accepts for `merge_method`. */
+export type MergeMethod = "squash" | "merge" | "rebase";
+
+export interface AllowedMethods {
+	readonly squash: boolean;
+	readonly merge: boolean;
+	readonly rebase: boolean;
+}
+
+/**
+ * Preference order for a direct landing, most preferred first.
+ *
+ * Squash leads because it is the only method whose default subject ends `(#<pr>)`, which is the
+ * anchor `landedOnBase` in `./queue.ts` proves a landing with — a rebase landing publishes the
+ * branch's own subjects and is invisible to that cross-check.
+ */
+export const METHOD_PREFERENCE: ReadonlyArray<MergeMethod> = ["squash", "merge", "rebase"];
+
+export const preferredMethod = (allowed: AllowedMethods): MergeMethod | null =>
+	METHOD_PREFERENCE.find((method) => allowed[method]) ?? null;
+
+/** What the repository permits. An absent flag reads `false` — never a method assumed available. */
+export const readAllowedMethods = (repo: string): Shell<Attempt<AllowedMethods>> =>
+	Effect.gen(function* () {
+		const r = yield* execCapture("gh", ["api", `repos/${repo}`]);
+		if (!r.ok) return fail(r.reason);
+		const parsed = parseJson(r.stdout);
+		if (!isRecord(parsed)) return fail("`gh api` exited 0 but its output is not a repository");
+		return ok({
+			squash: parsed.allow_squash_merge === true,
+			merge: parsed.allow_merge_commit === true,
+			rebase: parsed.allow_rebase_merge === true,
+		});
+	});
+
+export type LandingPath = "queue" | "direct" | "none";
+
+export interface Landing {
+	readonly path: LandingPath;
+	/** The method a direct landing would use — `null` on `queue` (the queue owns it) and on `none`. */
+	readonly method: MergeMethod | null;
+}
+
+export const landingOf = (queueGoverned: boolean, allowed: AllowedMethods | null): Landing => {
+	if (queueGoverned) return {path: "queue", method: null};
+	const method = allowed === null ? null : preferredMethod(allowed);
+	return method === null ? {path: "none", method: null} : {path: "direct", method};
+};
+
+export const readLanding = (repo: string, base: string): Shell<Attempt<Landing>> =>
+	Effect.gen(function* () {
+		const governed = yield* isQueueGoverned(repo, base);
+		if (governed._tag === "Failure") return governed;
+		if (governed.value) return ok(landingOf(true, null));
+		const allowed = yield* readAllowedMethods(repo);
+		return allowed._tag === "Failure" ? allowed : ok(landingOf(false, allowed.value));
+	});
+
+/** What a landing must show to be proven: the flag and the commit it produced. */
+export interface MergeProof {
+	readonly merged: boolean;
+	readonly mergeCommitSha: string;
+}
+
+const PROOF_FILTER = '{merged: .merged, commit: (.merge_commit_sha // "")}';
+
+/**
+ * Read the landing back off the pull request.
+ *
+ * Separate from `../io/pulls.ts`'s `PullRecord`, which carries `merged` and not the merge SHA: a
+ * `merged: true` with no commit behind it is a claim with no evidence, and the pair is what makes
+ * the landing falsifiable. The projection is asked for by name rather than filtered out of the full
+ * payload, so the read that confirms the write is a different request from the read that resolved
+ * the head — one endpoint answering two questions is one request nobody can tell apart in a log.
+ */
+export const readMergeProof = (repo: string, pr: number): Shell<Attempt<MergeProof>> =>
+	Effect.gen(function* () {
+		const r = yield* execCapture("gh", ["api", `repos/${repo}/pulls/${pr}`, "--jq", PROOF_FILTER]);
+		if (!r.ok) return fail(r.reason);
+		const parsed = parseJson(r.stdout);
+		if (!isRecord(parsed) || typeof parsed.commit !== "string") {
+			return fail("`gh api` exited 0 but named no merge state");
+		}
+		return ok({merged: parsed.merged === true, mergeCommitSha: parsed.commit});
+	});
+
+/**
+ * Land the pull request directly.
+ *
+ * `sha` is the **full** live head, not the caller's possibly-abbreviated `--sha`: the platform
+ * compares it exactly and rejects the merge if the head moved, so it is the write's own drift guard
+ * on top of the verb's. Its exit status is never the proof — the caller re-reads.
+ */
+export const mergePull = (
+	repo: string,
+	pr: number,
+	sha: string,
+	method: MergeMethod,
+): Shell<Attempt<void>> =>
+	Effect.gen(function* () {
+		const r = yield* execCapture("gh", [
+			"api",
+			"--method",
+			"PUT",
+			`repos/${repo}/pulls/${pr}/merge`,
+			"-f",
+			`sha=${sha}`,
+			"-f",
+			`merge_method=${method}`,
+		]);
+		return r.ok ? ok(undefined) : fail(r.reason);
+	});

--- a/packages/fabrika-cli/src/ship/landing.unit.test.ts
+++ b/packages/fabrika-cli/src/ship/landing.unit.test.ts
@@ -1,0 +1,86 @@
+import {Effect} from "effect";
+import {describe, expect, it} from "vitest";
+import {errOut, fakeShell, okOut} from "../fakes.test-support.ts";
+import type {ExecResult} from "../io/exec.ts";
+import {branchRules, repository} from "./fixtures.test-support.ts";
+import {landingOf, preferredMethod, readLanding} from "./landing.ts";
+
+const RULES = /^gh api repos\/o\/r\/rules\/branches\/main$/;
+const REPO = /^gh api repos\/o\/r$/;
+
+const read = (script: ReadonlyArray<readonly [RegExp, ExecResult]>) =>
+	Effect.runPromise(Effect.provide(readLanding("o/r", "main"), fakeShell(script).layer));
+
+describe("preferredMethod", () => {
+	it("prefers squash — the only subject `landedOnBase` can anchor on", () => {
+		expect(preferredMethod({squash: true, merge: true, rebase: true})).toBe("squash");
+	});
+
+	it("falls to the merge commit, then the rebase, as each is disabled", () => {
+		expect(preferredMethod({squash: false, merge: true, rebase: true})).toBe("merge");
+		expect(preferredMethod({squash: false, merge: false, rebase: true})).toBe("rebase");
+	});
+
+	it("names none rather than guessing when the repository permits none", () => {
+		expect(preferredMethod({squash: false, merge: false, rebase: false})).toBeNull();
+	});
+});
+
+describe("landingOf", () => {
+	it("names the queue path with no method — the queue owns it", () => {
+		expect(landingOf(true, {squash: true, merge: true, rebase: true})).toEqual({
+			path: "queue",
+			method: null,
+		});
+	});
+
+	it("names `none` when nothing is permitted — a settings fact, never a method to guess", () => {
+		expect(landingOf(false, {squash: false, merge: false, rebase: false})).toEqual({
+			path: "none",
+			method: null,
+		});
+	});
+});
+
+describe("readLanding", () => {
+	it("answers `queue` off the branch's rules, without reading the repository at all", async () => {
+		const shell = fakeShell([[RULES, branchRules("merge_queue", "pull_request")]]);
+		const out = await Effect.runPromise(Effect.provide(readLanding("o/r", "main"), shell.layer));
+		expect(out).toEqual({_tag: "Ok", value: {path: "queue", method: null}});
+		expect(shell.calls.some((line) => line === "gh api repos/o/r")).toBe(false);
+	});
+
+	it("answers `direct` with the preferred method when no queue governs the branch", async () => {
+		const out = await read([
+			[RULES, branchRules("pull_request")],
+			[REPO, repository()],
+		]);
+		expect(out).toEqual({_tag: "Ok", value: {path: "direct", method: "squash"}});
+	});
+
+	it("answers `none` when the repository permits no merge method", async () => {
+		const out = await read([
+			[RULES, okOut("[]")],
+			[REPO, repository({squash: false, merge: false, rebase: false})],
+		]);
+		expect(out).toEqual({_tag: "Ok", value: {path: "none", method: null}});
+	});
+
+	it("fails rather than assuming a regime when the rules read fails", async () => {
+		const out = await read([[RULES, errOut("HTTP 503")]]);
+		expect(out._tag).toBe("Failure");
+	});
+
+	it("fails rather than assuming a method when the repository read fails", async () => {
+		const out = await read([
+			[RULES, okOut("[]")],
+			[REPO, errOut("HTTP 503")],
+		]);
+		expect(out._tag).toBe("Failure");
+	});
+
+	it("fails on a rule payload that is not a list — a shape mismatch is never `no queue`", async () => {
+		const out = await read([[RULES, okOut('{"message":"Not Found"}')]]);
+		expect(out._tag).toBe("Failure");
+	});
+});

--- a/packages/fabrika-cli/src/ship/merge-verb.ts
+++ b/packages/fabrika-cli/src/ship/merge-verb.ts
@@ -1,0 +1,167 @@
+/**
+ * `ship merge` — land a PR on a base branch no merge queue governs, and prove the landing.
+ *
+ * **The second landing path, not a flag on the first.** `ship enqueue` carries no merge-method flag
+ * by construction, because a method alongside the queue arm conflicts with the queue and no-ops the
+ * enqueue silently at exit 0. That argument is about a queue-governed base and says nothing about a
+ * base with no queue — where, before this verb, `ship` could land nothing at all (#6018). So the
+ * method surface lives here, on the path where the queue is *proven absent*, and `ship enqueue`
+ * still has none.
+ *
+ * The queue check is a refusal and never a fallback: a base a queue governs is `ship enqueue`'s, and
+ * a direct merge into it walks straight past the gate the queue exists to run. An unreadable queue
+ * regime refuses too — this verb never lands on a base whose regime it could not read.
+ *
+ * The method is read off the repository, never guessed. A repo permitting none of the three refuses
+ * on `19` rather than sending the platform a method it will reject.
+ *
+ * The write is proved the way the arm is: `merged` **and** the merge commit read back off the PR
+ * after the call, because the merge call's own response is a claim and not evidence.
+ */
+import {Effect} from "effect";
+import type {ChildProcessSpawner} from "effect/unstable/process";
+import {answer, refuse, type VerbOutcome} from "../verb.ts";
+import {
+	NO_LANDING_METHOD,
+	PRECONDITION_UNKNOWN,
+	PROVEN_NOT_IN_STATE,
+	READBACK_MISMATCH,
+	STALE_HEAD,
+	WRITE_UNKNOWN,
+} from "./codes.ts";
+import {mergePull, readLanding, readMergeProof} from "./landing.ts";
+import {readDefiniteMergeability} from "./mergeability.ts";
+import {
+	badNumber,
+	inspectedSha,
+	NULL_TOKEN,
+	prefixMatch,
+	resolvePull,
+	resolveTargetRepo,
+} from "./target.ts";
+
+const VERB = "ship merge";
+
+export interface MergeOptions {
+	readonly pr: number;
+	readonly sha: string;
+	readonly repo: string | null;
+	readonly json: boolean;
+	readonly env: Readonly<Record<string, string | undefined>>;
+}
+
+export const runMerge = (
+	options: MergeOptions,
+): Effect.Effect<VerbOutcome, never, ChildProcessSpawner.ChildProcessSpawner> =>
+	Effect.gen(function* () {
+		const {pr, json} = options;
+		const bad = badNumber(VERB, "a pull-request number", pr);
+		if (bad !== null) return bad;
+		const bound = inspectedSha(VERB, options.sha);
+		if (typeof bound !== "string") return bound;
+
+		const resolved = yield* resolveTargetRepo(VERB, options.repo, options.env);
+		if (resolved._tag === "Refused") return resolved.outcome;
+		const repo = resolved.repo;
+
+		const target = yield* resolvePull(VERB, repo, pr, {
+			closedReason: "nothing to merge.",
+			mergedReason: "nothing to merge.",
+			unknownMessage: (reason) =>
+				`${VERB}: cannot read #${pr}'s live head: ${reason} — nothing was merged.`,
+		});
+		if (target._tag === "Refused") return target.outcome;
+		const pull = target.pull;
+		if (!prefixMatch(pull.headSha, bound)) {
+			return refuse(
+				STALE_HEAD,
+				`${VERB}: the live head is ${pull.headSha}, gates ran at ${bound} — refusing to merge a tree nobody verified.`,
+			);
+		}
+
+		const landing = yield* readLanding(repo, pull.baseRef);
+		if (landing._tag === "Failure") {
+			return refuse(
+				PRECONDITION_UNKNOWN,
+				`${VERB}: cannot read ${pull.baseRef}'s landing path: ${landing.reason} — nothing was merged.`,
+			);
+		}
+		if (landing.value.path === "queue") {
+			return refuse(
+				PROVEN_NOT_IN_STATE,
+				`${VERB}: a merge queue governs ${pull.baseRef} — the queue owns the method and the landing; run \`fabrika ship enqueue\` instead.`,
+			);
+		}
+		const method = landing.value.method;
+		if (method === null) {
+			return refuse(
+				NO_LANDING_METHOD,
+				`${VERB}: ${repo} permits no merge method — squash, merge-commit and rebase are all disabled, so nothing can land on ${pull.baseRef}; a human enables one in the repository settings.`,
+			);
+		}
+		const diagnostics = [
+			`${VERB}: ${pull.baseRef} is not queue-governed and ${repo} permits ${method} — landing directly.`,
+		];
+
+		const mergeability = yield* readDefiniteMergeability(repo, pr);
+		if (mergeability._tag === "Unreadable") {
+			return refuse(
+				PRECONDITION_UNKNOWN,
+				`${VERB}: cannot read #${pr}'s mergeability: ${mergeability.reason} — nothing was merged.`,
+				diagnostics,
+			);
+		}
+		if (mergeability._tag === "Indefinite") {
+			return refuse(
+				PRECONDITION_UNKNOWN,
+				`${VERB}: #${pr}'s mergeable_state is still indefinite after ${mergeability.polls} polls — mergeability is UNKNOWN, never green; nothing was merged.`,
+				diagnostics,
+			);
+		}
+		// Unlike the queue arm, which leaves a definite `dirty` to the platform, the direct merge acts
+		// on it here: the endpoint would reject the call and that rejection is indistinguishable from a
+		// write whose outcome nobody knows.
+		if (!mergeability.value.mergeable) {
+			return refuse(
+				PROVEN_NOT_IN_STATE,
+				`${VERB}: #${pr} is not mergeable (mergeable_state: ${mergeability.value.state}) — a definite read; nothing was merged.`,
+				diagnostics,
+			);
+		}
+		diagnostics.push(
+			`${VERB}: mergeable_state is ${mergeability.value.state} (mergeable: true) — a definite read; merging.`,
+		);
+
+		const written = yield* mergePull(repo, pr, pull.headSha, method);
+		if (written._tag === "Failure") {
+			return refuse(
+				WRITE_UNKNOWN,
+				`${VERB}: the merge failed: "${written.reason}" — whether #${pr} landed is UNKNOWN; re-read the PR before stopping.`,
+				diagnostics,
+			);
+		}
+
+		const proof = yield* readMergeProof(repo, pr);
+		if (proof._tag === "Failure") {
+			return refuse(
+				WRITE_UNKNOWN,
+				`${VERB}: the merge was sent and the confirming read-back failed: ${proof.reason} — whether #${pr} landed is UNKNOWN; re-read the PR before stopping.`,
+				diagnostics,
+			);
+		}
+		const commit = proof.value.mergeCommitSha;
+		if (!proof.value.merged || commit === "") {
+			return refuse(
+				READBACK_MISMATCH,
+				`${VERB}: the merge was sent and the read-back shows merged: ${String(proof.value.merged)} at merge commit ${commit === "" ? NULL_TOKEN : commit} — the landing is not proven.`,
+				diagnostics,
+			);
+		}
+
+		return json
+			? answer(
+					JSON.stringify({outcome: "merged", sha: bound, method, mergeCommit: commit}),
+					diagnostics,
+				)
+			: answer(`merged\t${commit}\t${method}`, diagnostics);
+	});

--- a/packages/fabrika-cli/src/ship/merge-verb.unit.test.ts
+++ b/packages/fabrika-cli/src/ship/merge-verb.unit.test.ts
@@ -1,0 +1,213 @@
+import {Effect} from "effect";
+import {describe, expect, it} from "vitest";
+import {errOut, fakeShell, okOut} from "../fakes.test-support.ts";
+import type {ExecResult} from "../io/exec.ts";
+import {
+	NO_LANDING_METHOD,
+	PRECONDITION_UNKNOWN,
+	PROVEN_NOT_IN_STATE,
+	READBACK_MISMATCH,
+	STALE_HEAD,
+	WRITE_UNKNOWN,
+	ZERO_SCOPE,
+} from "./codes.ts";
+import {
+	branchRules,
+	ENV,
+	HEAD,
+	MERGE_COMMIT,
+	mergeProof,
+	OTHER_HEAD,
+	pull,
+	repository,
+} from "./fixtures.test-support.ts";
+import {runMerge} from "./merge-verb.ts";
+
+const PULL = /^gh api repos\/o\/r\/pulls\/4321$/;
+const PROOF = /^gh api repos\/o\/r\/pulls\/4321 --jq /;
+const RULES = /^gh api repos\/o\/r\/rules\/branches\/main$/;
+const REPO = /^gh api repos\/o\/r$/;
+const MERGE = /^gh api --method PUT repos\/o\/r\/pulls\/4321\/merge/;
+const UNQUEUED: readonly [RegExp, ExecResult] = [RULES, branchRules("pull_request")];
+
+const options = {pr: 4321, sha: HEAD, repo: null, json: false, env: ENV};
+
+const land = (
+	script: ReadonlyArray<readonly [RegExp, ExecResult]>,
+	overrides: Partial<typeof options> = {},
+) => {
+	const shell = fakeShell(script);
+	return Effect.runPromise(Effect.provide(runMerge({...options, ...overrides}), shell.layer)).then(
+		(outcome) => ({outcome, calls: shell.calls}),
+	);
+};
+
+/** Every read the happy path makes, in the order the verb makes them. */
+const HAPPY: ReadonlyArray<readonly [RegExp, ExecResult]> = [
+	[PULL, pull()],
+	UNQUEUED,
+	[REPO, repository()],
+	[MERGE, okOut("")],
+	[PROOF, mergeProof()],
+];
+
+const withoutWrite = (calls: ReadonlyArray<string>): boolean =>
+	calls.every((line) => !line.includes("--method PUT"));
+
+describe("runMerge", () => {
+	it("lands on an unqueued base with the repo's preferred method and proves the commit", async () => {
+		const {outcome, calls} = await land(HAPPY);
+		expect(outcome.code).toBe(0);
+		expect(outcome.stdout).toBe(`merged\t${MERGE_COMMIT}\tsquash\n`);
+		expect(calls).toContain(
+			`gh api --method PUT repos/o/r/pulls/4321/merge -f sha=${HEAD} -f merge_method=squash`,
+		);
+	});
+
+	it("hands the platform the FULL live head, not the caller's abbreviation", async () => {
+		const {calls} = await land(HAPPY, {sha: HEAD.slice(0, 8)});
+		expect(calls.some((line) => line.includes(`-f sha=${HEAD} `))).toBe(true);
+	});
+
+	it("falls to the merge commit when the repository has squash disabled", async () => {
+		const {outcome} = await land([
+			[PULL, pull()],
+			UNQUEUED,
+			[REPO, repository({squash: false})],
+			[MERGE, okOut("")],
+			[PROOF, mergeProof()],
+		]);
+		expect(outcome.stdout).toBe(`merged\t${MERGE_COMMIT}\tmerge\n`);
+	});
+
+	it("refuses on 16 when a merge queue governs the base, and points at `ship enqueue`", async () => {
+		const {outcome, calls} = await land([
+			[PULL, pull()],
+			[RULES, branchRules("merge_queue")],
+		]);
+		expect(outcome.code).toBe(PROVEN_NOT_IN_STATE);
+		expect(outcome.stderr.at(-1)).toBe(
+			"ship merge: a merge queue governs main — the queue owns the method and the landing; run `fabrika ship enqueue` instead.",
+		);
+		expect(withoutWrite(calls)).toBe(true);
+	});
+
+	it("refuses on 19 when the repository permits no merge method — never guessing one", async () => {
+		const {outcome, calls} = await land([
+			[PULL, pull()],
+			[RULES, okOut("[]")],
+			[REPO, repository({squash: false, merge: false, rebase: false})],
+		]);
+		expect(outcome.code).toBe(NO_LANDING_METHOD);
+		expect(outcome.stderr.at(-1)).toContain("permits no merge method");
+		expect(withoutWrite(calls)).toBe(true);
+	});
+
+	it("refuses on 11 when the landing path cannot be read — never landing on an unread regime", async () => {
+		const {outcome, calls} = await land([
+			[PULL, pull()],
+			[RULES, errOut("HTTP 503")],
+		]);
+		expect(outcome.code).toBe(PRECONDITION_UNKNOWN);
+		expect(outcome.stderr.at(-1)).toContain("cannot read main's landing path");
+		expect(withoutWrite(calls)).toBe(true);
+	});
+
+	it("refuses on 11 when mergeability stays indefinite — an unknown read is never green", async () => {
+		const {outcome, calls} = await land([
+			[PULL, pull({mergeable: null, mergeableState: "unknown"})],
+			UNQUEUED,
+			[REPO, repository()],
+		]);
+		expect(outcome.code).toBe(PRECONDITION_UNKNOWN);
+		expect(outcome.stderr.at(-1)).toBe(
+			"ship merge: #4321's mergeable_state is still indefinite after 3 polls — mergeability is UNKNOWN, never green; nothing was merged.",
+		);
+		expect(withoutWrite(calls)).toBe(true);
+	}, 20_000);
+
+	it("refuses on 16 on a definite `dirty` — the endpoint would reject it indistinguishably", async () => {
+		const {outcome, calls} = await land([
+			[PULL, pull({mergeable: false, mergeableState: "dirty"})],
+			UNQUEUED,
+			[REPO, repository()],
+		]);
+		expect(outcome.code).toBe(PROVEN_NOT_IN_STATE);
+		expect(outcome.stderr.at(-1)).toBe(
+			"ship merge: #4321 is not mergeable (mergeable_state: dirty) — a definite read; nothing was merged.",
+		);
+		expect(withoutWrite(calls)).toBe(true);
+	});
+
+	it("refuses on 12 when the live head moved past --sha", async () => {
+		const {outcome, calls} = await land([[PULL, pull({head: OTHER_HEAD})]]);
+		expect(outcome.code).toBe(STALE_HEAD);
+		expect(outcome.stderr.at(-1)).toContain("refusing to merge a tree nobody verified");
+		expect(withoutWrite(calls)).toBe(true);
+	});
+
+	it("refuses an already-merged PR on 7 — an idempotent success is `ship scope`'s answer", async () => {
+		const {outcome} = await land([[PULL, pull({merged: true, state: "closed"})]]);
+		expect(outcome.code).toBe(ZERO_SCOPE);
+		expect(outcome.stderr.at(-1)).toBe("ship merge: PR #4321 is merged — nothing to merge.");
+	});
+
+	it("refuses on 8 when the merge call fails, quoting the error", async () => {
+		const {outcome} = await land([
+			[PULL, pull()],
+			UNQUEUED,
+			[REPO, repository()],
+			[MERGE, errOut("HTTP 405: Pull Request is not mergeable")],
+		]);
+		expect(outcome.code).toBe(WRITE_UNKNOWN);
+		expect(outcome.stderr.at(-1)).toContain(
+			'the merge failed: "HTTP 405: Pull Request is not mergeable"',
+		);
+	});
+
+	it("refuses on 8 when the confirming read-back fails — the landing is UNKNOWN", async () => {
+		const {outcome} = await land([
+			[PULL, pull()],
+			UNQUEUED,
+			[REPO, repository()],
+			[MERGE, okOut("")],
+			[PROOF, errOut("HTTP 503")],
+		]);
+		expect(outcome.code).toBe(WRITE_UNKNOWN);
+		expect(outcome.stderr.at(-1)).toContain("the confirming read-back failed");
+	});
+
+	it("refuses on 9 when the read-back names no merge commit — a claim is not evidence", async () => {
+		const {outcome} = await land([
+			[PULL, pull()],
+			UNQUEUED,
+			[REPO, repository()],
+			[MERGE, okOut("")],
+			[PROOF, mergeProof({commit: ""})],
+		]);
+		expect(outcome.code).toBe(READBACK_MISMATCH);
+		expect(outcome.stderr.at(-1)).toContain("the landing is not proven");
+	});
+
+	it("refuses on 9 when the read-back shows the PR is still not merged", async () => {
+		const {outcome} = await land([
+			[PULL, pull()],
+			UNQUEUED,
+			[REPO, repository()],
+			[MERGE, okOut("")],
+			[PROOF, mergeProof({merged: false})],
+		]);
+		expect(outcome.code).toBe(READBACK_MISMATCH);
+		expect(outcome.stderr.at(-1)).toContain("merged: false");
+	});
+
+	it("emits the landing object under --json", async () => {
+		const {outcome} = await land(HAPPY, {json: true});
+		expect(JSON.parse(outcome.stdout)).toEqual({
+			outcome: "merged",
+			sha: HEAD,
+			method: "squash",
+			mergeCommit: MERGE_COMMIT,
+		});
+	});
+});

--- a/packages/fabrika-cli/src/ship/mergeability.ts
+++ b/packages/fabrika-cli/src/ship/mergeability.ts
@@ -1,0 +1,44 @@
+/**
+ * The pre-write mergeability read both landing verbs run, with its indefinite-value handling.
+ *
+ * `mergeable` is computed lazily by GitHub, so a `null` / `unknown` read is routine and is **not an
+ * answer**: it is re-read, and a still-indefinite value is UNKNOWN and refuses. The three outcomes
+ * are kept apart at the type layer because folding `Indefinite` into either neighbour is the whole
+ * defect — read as `Definite` it becomes a green nobody computed, read as `Unreadable` it loses the
+ * fact that the platform answered and simply had not finished.
+ *
+ * It lives here rather than in `ship enqueue`, which had it first, because `ship merge` asserts the
+ * same precondition and a second copy of a poll loop is a second poll policy that can drift.
+ */
+import {Effect} from "effect";
+import type {Attempt, Shell} from "../io/git.ts";
+import {isIndefinite, type Mergeability, readMergeability} from "./github.ts";
+
+/** How many extra reads the indefinite value gets before it is called UNKNOWN. */
+export const MERGEABILITY_POLLS = 3;
+
+/** How long to wait between those reads, giving GitHub's background computation time to land. */
+export const MERGEABILITY_CADENCE_SECONDS = 2;
+
+export type MergeabilityRead =
+	| {readonly _tag: "Definite"; readonly value: Mergeability}
+	| {readonly _tag: "Indefinite"; readonly polls: number}
+	| {readonly _tag: "Unreadable"; readonly reason: string};
+
+const definiteOf = (attempt: Attempt<Mergeability>): MergeabilityRead =>
+	attempt._tag === "Failure"
+		? {_tag: "Unreadable", reason: attempt.reason}
+		: isIndefinite(attempt.value)
+			? {_tag: "Indefinite", polls: MERGEABILITY_POLLS}
+			: {_tag: "Definite", value: attempt.value};
+
+export const readDefiniteMergeability = (repo: string, pr: number): Shell<MergeabilityRead> =>
+	Effect.gen(function* () {
+		let attempt = yield* readMergeability(repo, pr);
+		for (let poll = 1; poll <= MERGEABILITY_POLLS; poll++) {
+			if (attempt._tag === "Failure" || !isIndefinite(attempt.value)) break;
+			yield* Effect.sleep(`${MERGEABILITY_CADENCE_SECONDS} seconds`);
+			attempt = yield* readMergeability(repo, pr);
+		}
+		return definiteOf(attempt);
+	});

--- a/packages/fabrika-cli/src/ship/scope-verb.ts
+++ b/packages/fabrika-cli/src/ship/scope-verb.ts
@@ -10,6 +10,13 @@
  * A `merged`, `draft` or `closed` PR is an **answer**, not a refusal: this verb reports state and
  * the skill acts on it. The write verbs downstream refuse a non-open PR themselves — no verb trusts
  * its dispatch.
+ *
+ * The `landing` line is the one place the two landing paths are named, so a shipper reads its route
+ * here rather than composing it from a merge-queue read and a repository-settings read on two
+ * different APIs (#6018). It is the one field that **degrades instead of refusing**: an unreadable
+ * landing prints `unknown` and costs the run nothing else, because the guard that matters sits on
+ * the write — `ship merge` re-derives the same fact itself and refuses `11` where this printed
+ * `unknown`, so a degraded read here can never license a landing.
  */
 import {Effect} from "effect";
 import type {ChildProcessSpawner} from "effect/unstable/process";
@@ -19,6 +26,7 @@ import {answer, refuse, type VerbOutcome} from "../verb.ts";
 import {readBoundary} from "./boundary.ts";
 import {classify} from "./codeowners.ts";
 import {INCOMPLETE_SCAN, PRECONDITION_UNKNOWN, ZERO_SCOPE} from "./codes.ts";
+import {readLanding} from "./landing.ts";
 import {badNumber, NULL_TOKEN, resolvePull, resolveTargetRepo, scannedLine} from "./target.ts";
 
 const VERB = "ship scope";
@@ -101,6 +109,14 @@ export const runScope = (
 		const state = lifecycleOf(pull.merged, pull.draft, pull.state);
 		const issue = issueRefOf(pull.body);
 
+		const read = yield* readLanding(repo, pull.baseRef);
+		if (read._tag === "Failure") {
+			diagnostics.push(
+				`${VERB}: cannot read ${pull.baseRef}'s landing path: ${read.reason} — reporting it unknown; \`ship merge\` refuses on the same read rather than landing.`,
+			);
+		}
+		const landing = read._tag === "Failure" ? {path: "unknown", method: null} : read.value;
+
 		if (json) {
 			return answer(
 				JSON.stringify({
@@ -111,6 +127,7 @@ export const runScope = (
 					classes: partition.classes,
 					namespaces,
 					cp,
+					landing,
 					scanned: partition.scanned,
 				}),
 				diagnostics,
@@ -122,6 +139,7 @@ export const runScope = (
 				...partition.classes.map((entry) => `class\t${entry.name}\t${entry.files}`),
 				...namespaces.map((namespace) => `namespace\t${namespace}`),
 				`cp\t${cp}`,
+				`landing\t${landing.path}\t${landing.method ?? NULL_TOKEN}`,
 				`files\t${partition.scanned}`,
 			].join("\n"),
 			diagnostics,

--- a/packages/fabrika-cli/src/ship/scope-verb.unit.test.ts
+++ b/packages/fabrika-cli/src/ship/scope-verb.unit.test.ts
@@ -3,12 +3,22 @@ import {describe, expect, it} from "vitest";
 import {errOut, fakeShell, okOut} from "../fakes.test-support.ts";
 import type {ExecResult} from "../io/exec.ts";
 import {INCOMPLETE_SCAN, PRECONDITION_UNKNOWN, ZERO_SCOPE} from "./codes.ts";
-import {CODEOWNERS, ENV, files, HEAD, pull} from "./fixtures.test-support.ts";
+import {
+	branchRules,
+	CODEOWNERS,
+	ENV,
+	files,
+	HEAD,
+	pull,
+	repository,
+} from "./fixtures.test-support.ts";
 import {runScope} from "./scope-verb.ts";
 
 const PULL = /^gh api repos\/o\/r\/pulls\/4321$/;
 const FILES = /^gh api --paginate repos\/o\/r\/pulls\/4321\/files/;
 const OWNERS = /contents\/\.github\/CODEOWNERS/;
+const RULES = /^gh api repos\/o\/r\/rules\/branches\/main$/;
+const REPO = /^gh api repos\/o\/r$/;
 
 const options = {pr: 4321, repo: null, json: false, env: ENV};
 
@@ -28,11 +38,13 @@ describe("runScope", () => {
 		expect(out.stdout.split("\n")[0]).toBe(`scoped\t${HEAD}\topen\tpart-of:4000`);
 	});
 
-	it("prints one derivation: state, issue ref, classes, the namespaces they require, cp and count", async () => {
+	it("prints one derivation: state, issue ref, classes, the namespaces they require, cp, landing and count", async () => {
 		const out = await run([
 			[PULL, pull()],
 			[FILES, files("apps/web/src/App.tsx", "README.md")],
 			[OWNERS, okOut(CODEOWNERS)],
+			[RULES, branchRules("pull_request")],
+			[REPO, repository()],
 		]);
 		expect(out.code).toBe(0);
 		expect(out.stdout).toBe(
@@ -45,10 +57,37 @@ describe("runScope", () => {
 				"namespace\treview-doc",
 				"namespace\treview-ui",
 				"cp\tnot-control-plane",
+				"landing\tdirect\tsquash",
 				"files\t2",
 				"",
 			].join("\n"),
 		);
+	});
+
+	it("names the queue path when a queue governs the base — the shipper's route, read once", async () => {
+		const out = await run([
+			[PULL, pull()],
+			[FILES, files("README.md", "DEVELOPMENT.md")],
+			[OWNERS, okOut(CODEOWNERS)],
+			[RULES, branchRules("merge_queue")],
+		]);
+		expect(out.stdout).toContain(`landing\tqueue\t-\n`);
+	});
+
+	/**
+	 * The one field that degrades rather than refusing: `ship merge` re-derives the same fact and
+	 * refuses `11` on the same failed read, so a printed `unknown` can never license a landing.
+	 */
+	it("prints `unknown` and still answers when the landing path cannot be read", async () => {
+		const out = await run([
+			[PULL, pull()],
+			[FILES, files("README.md", "DEVELOPMENT.md")],
+			[OWNERS, okOut(CODEOWNERS)],
+			[RULES, errOut("HTTP 503")],
+		]);
+		expect(out.code).toBe(0);
+		expect(out.stdout).toContain(`landing\tunknown\t-\n`);
+		expect(out.stderr.some((line) => line.includes("cannot read main's landing path"))).toBe(true);
 	});
 
 	it("derives review-ui from a rendered surface but not from its own test file", async () => {


### PR DESCRIPTION
Fixes #6018

`ship` could only land a PR by arming a merge queue. A repo with no queue and
`allow_auto_merge: false` had no verb that could land anything, so a lane built,
reviewed and gated correctly and then stopped one inch short of shipped —
observed on the first non-phoenix lane.

## What this adds

**`ship merge`** — the second landing path, not a merge-method flag on the first.
`ship enqueue`'s "no method flag, by construction" argument is about a
queue-governed base and says nothing about a base with no queue, so the method
surface lives on the path where the queue is *proven absent* and `enqueue` still
carries none. The verb:

- refuses `16` when a merge queue governs the base, pointing at `ship enqueue` —
  a refusal, never a fallback, since a direct merge into a queued base walks past
  the gate the queue runs;
- reads the method off `allow_squash_merge` / `allow_merge_commit` /
  `allow_rebase_merge`, preferring squash because its subject ends `(#<pr>)`, the
  anchor `ship reconcile`'s base-branch cross-check needs; a repo permitting none
  refuses `19` rather than guessing;
- asserts a definite `mergeable_state` before the write, on the same poll policy
  `ship enqueue` uses (now one shared read, so the two cannot drift), and refuses
  a definite `mergeable: false` rather than sending a call the endpoint rejects
  with a 405 that looks identical to an unknown outcome;
- hands the platform the **full** live head as the merge call's `sha`, so the
  platform refuses a moved head too;
- proves the landing by reading `merged` **and** the merge commit back off the PR
  — the merge call's own response is the writer's claim about its own write.

**`ship scope` gains a `landing` line** — `queue` / `direct` / `none` / `unknown`
with the method beside it — so the shipper reads its route from one verb instead
of composing it from a merge-queue read and a repository-settings read, neither of
which any verb performed. It is the one scope field that degrades to `unknown`
instead of refusing; that is safe because `ship merge` re-derives the same fact
from the same reads and refuses `11` exactly where scope printed `unknown`, so the
degraded line licenses nothing.

`19` gets its own exit seat rather than folding into `16`: the two route opposite
ways — `16` sends the run onward to `ship enqueue`, `19` ends the lane at a human
with repository-settings access.

Docs: the `ship` contract gains the `ship merge` section, the inventory row, the
`19` taxonomy row and the `landing` output grammar; `SKILL.md` step 1 reads the
route and step 7 splits into the two landing paths.

## Deviations

- **Out-of-scope change** — **Said:** #6018 names a landing path for an unqueued
  repo. **Did:** also moved `ship enqueue`'s mergeability poll loop into a shared
  `mergeability.ts` that both verbs call. **Why:** `ship merge` asserts the same
  precondition on the same policy, and a second copy of the loop is a second poll
  policy that can drift; every refusal string and the poll counts are unchanged,
  and `enqueue`'s existing tests pass untouched. **Disposition:** stated here.
- **Out-of-scope change** — **Said:** nothing about how `ship scope` reads the PR.
  **Did:** the new landing read-back asks GitHub for a two-field projection
  (`--jq`) instead of the full pull payload. **Why:** the read that confirms the
  write has to be distinguishable from the read that resolved the head — one
  endpoint answering two questions is one request nobody can tell apart, in a log
  or in a test. **Disposition:** stated here.
