### PR TITLE
fix: getting-started.md quotes a trimmed triage homes output block, so the lesson hides rows the reader will see

### DIFF
--- a/claude-plugins/fabrika/guide/getting-started.md
+++ b/claude-plugins/fabrika/guide/getting-started.md
@@ -148,10 +148,21 @@ fabrika triage homes
 
 ```
 triage homes: scanned 5 open milestones in kamp-us/phoenix.
-triage homes: focus: none declared — scope fence inert.
+triage homes: campaigns: 2 active — fabrika fast follows (#46), fabrika everywhere (#47).
 homes
 milestone	24	Geçit
+milestone	25	Mecmua v2 — PARKED (reading-experience arc, unstarted)
+milestone	42	Taste-Skill Library
+milestone	46	fabrika fast follows	running: p0/blocker only
+milestone	47	fabrika everywhere	running: p0/blocker only
+lane	wayfinder:backlog	fog — uncharted work upstream of any arc
+lane	axis:pipeline-hardening	the standing pipeline and reliability lane
 ```
+
+That output is from a repo already set up, so yours will differ: one `milestone` row, the one you
+just created, and a second line reading `campaigns: none active — scope fence inert.` because your
+roadmap has no campaigns table. The two `lane` rows are phoenix's own standing lanes and print in
+every repo — [the how-to](adopt-fabrika-in-a-new-repo.md) explains why you ignore them.
 
 Your milestone should be in that list. Commit `ROADMAP.md`.
 


### PR DESCRIPTION
The getting-started tutorial quoted a `fabrika triage homes` output block that had rows cut out of
it with no marker. It showed one milestone row; the real command prints five, plus two `lane` rows
that print in every repo. A reader hit that mismatch at the exact step telling them to compare their
output against the page.

The block now carries what the command actually prints today, verified by running
`fabrika triage homes` against kamp-us/phoenix and diffing the output against the quoted lines. The
second line also changes: the page quoted `focus: none declared — scope fence inert.`, a string the
CLI has never printed. `dispatchScopeLine` in
`packages/fabrika-cli/src/build/scope-admission.ts` prints `campaigns: …`, and against phoenix today
that reads `campaigns: 2 active`.

Below the block, one paragraph in the same idiom the page already uses for its `status open` sample:
your run differs, you get one milestone row and `campaigns: none active — scope fence inert.`
(grounded in `readCampaigns`, which returns `None` when the roadmap has no `## Campaigns` heading —
and the roadmap this lesson writes has none), and the two `lane` rows are phoenix's own, with a
pointer to the how-to that explains ignoring them.

Fixes #6275

## Deviations

- **Out-of-scope change** — **Said:** #6275 names the trimmed rows. **Did:** also corrected the
  block's second line from `focus: none declared` to the real `campaigns: 2 active` text. **Why:**
  the third acceptance criterion is that the block matches what the command actually prints, and
  that line was a second thing in the same block it did not match. **Disposition:** stated here.
