### PR TITLE
fix: A child issue with an open range FAIL is offered to a fresh build lane as an ordinary claim

### DIFF
--- a/claude-plugins/fabrika/skills/build/SKILL.md
+++ b/claude-plugins/fabrika/skills/build/SKILL.md
@@ -367,6 +367,33 @@ target read off the PR's own head branch, the classification check — and reads
 (#5618). Re-send the corrected body on stdin, then answer the finding in a `fabrika build note` and
 release; no commit, no `build check`, no `build push`.
 
+**An epic child is repaired too, and it is the one repair that names an issue rather than a PR.** A
+child opens no PR (ADR 0285), so its verdicts are range-bound comments on the child issue and there
+is no head to resume from. `build claim` reads those verdicts on every fresh build-purpose claim: a
+child whose newest verdict in any gate is `FAIL` refuses on `31` naming that FAIL, because building
+it fresh re-implements work a reviewer already graded — which cost two whole lanes on epic #5631, and
+on one of them produced two divergent implementations of a single criterion (#6386). The route the
+refusal names is the whole repair:
+
+```bash
+fabrika build claim $issue_or_pr_number --resume
+fabrika build verdicts --issue $issue_or_pr_number
+fabrika build tree --issue $issue_or_pr_number
+fabrika build branch $issue_or_pr_number --resume-lane --token <claim-token>
+```
+
+`--resume` is checked against the board, not trusted: on a child holding no standing `FAIL` it
+refuses on `31` too, so the flag can never be typed past the fence. `--resume-lane` **re-keys** the
+branch the prior lane built on to this claim's nonce instead of cutting a second one — two branches
+carrying one child's commits is the range `lane prove` calls underivable, and that refusal cannot be
+cleared from inside a worktree. It refuses on `7` when no such branch is in this tree (the prior
+lane's is, and only a lane standing there can resume it) and on `11` when the re-key fails because
+another worktree still holds the branch — that one is an operator's to release, so end `STOPPED`
+naming the code. From there the loop is the ordinary one minus the publishing half: fix, `build
+check`, `build commit`, no push and no PR, then the `build-deviations` comment and `BUILT-NO-PR`.
+There is no cap clearance on this path — a grant is recorded against a PR's base branch — so a child
+at its cap escalates to the operator.
+
 ## Expectations you hold but never recompute
 
 - **Control-plane membership** — decided by CODEOWNERS at the merge gate. You never classify.

--- a/claude-plugins/fabrika/skills/build/SKILL.md
+++ b/claude-plugins/fabrika/skills/build/SKILL.md
@@ -386,10 +386,12 @@ fabrika build branch $issue_or_pr_number --resume-lane --token <claim-token>
 refuses on `31` too, so the flag can never be typed past the fence. `--resume-lane` **re-keys** the
 branch the prior lane built on to this claim's nonce instead of cutting a second one — two branches
 carrying one child's commits is the range `lane prove` calls underivable, and that refusal cannot be
-cleared from inside a worktree. It refuses on `7` when no such branch is in this tree (the prior
-lane's is, and only a lane standing there can resume it) and on `11` when the re-key fails because
-another worktree still holds the branch — that one is an operator's to release, so end `STOPPED`
-naming the code. From there the loop is the ordinary one minus the publishing half: fix, `build
+cleared from inside a worktree. It refuses on `7` when no branch in this clone's refs was cut for the
+number — refs are shared across every worktree, so that means the branch is gone, not that you are
+standing in the wrong tree — and on `11` when another worktree still holds the branch, which it
+proves **before** re-keying: `git branch -m` does not refuse there, it renames the branch out from
+under that lane. Releasing that worktree is an operator's act, so end `STOPPED` naming the code. From
+there the loop is the ordinary one minus the publishing half: fix, `build
 check`, `build commit`, no push and no PR, then the `build-deviations` comment and `BUILT-NO-PR`.
 There is no cap clearance on this path — a grant is recorded against a PR's base branch — so a child
 at its cap escalates to the operator.

--- a/claude-plugins/fabrika/skills/build/contract.md
+++ b/claude-plugins/fabrika/skills/build/contract.md
@@ -928,6 +928,15 @@ graded, which is the fact this gate exists for. The read runs **after** the pure
 blockedness gate, so an issue those already refused pays for no comment page, and an unreadable page
 is `11` — never "no prior build".
 
+**The gate has three answers, not two, and the third is `11`.** A comment whose first line opens with
+a gate namespace and then fails to parse as a range marker is a verdict that *cannot be read*, and it
+is refused on the same code an unreachable comment page is, in both directions — with `--resume` and
+without. Counting the break on stderr and admitting the claim anyway would resolve unreadable to "no
+prior build", which is the failure this whole gate exists to stop, wearing a log line: a `FAIL`
+posted in a broken format is still a reviewer saying no. Only a gate-namespace first line can reach
+this arm (`packages/fabrika-cli/src/wire/marker-line.ts`), so ordinary discussion on a child never
+trips it, and the remedy is to repost or delete the comment.
+
 `--resume` is the other side, and it is **checked, not trusted**: it admits a claim over a standing
 `FAIL` and refuses on `31` over a child holding none. Repair is otherwise derived from the target
 being an open PR and never typed (founder ruling on #5866, #5914); the objection there was that a
@@ -960,6 +969,7 @@ the word is admitted here exactly because the seam checks the fact it asserts. T
 | `build claim: #<n> already carries a build a reviewer failed — <gate> FAIL over <base>..<tip> (comment <id>). A fresh build would re-implement it; run "fabrika build claim <n> --resume" to take the repair lane instead, then "fabrika build branch <n> --resume-lane --token <token>" to stand on the branch that build left. Nothing was written.` | 31 | refusal |
 | `build claim: --resume says #<n> holds a build to repair, and no gate holds a standing FAIL over it — drop --resume and claim it as the fresh build it is. Nothing was written.` | 31 | refusal |
 | `build claim: cannot read the comments on #<n>: <reason> — whether it already carries a graded build is UNKNOWN, never "no"; nothing was written.` | 11 | refusal |
+| `build claim: <n> comment(s) on #<n> reach for a verdict marker and are not readable range ones — <#id: why>; …. A verdict that cannot be read is UNKNOWN, never "no prior build"; repost or delete the comment(s), then claim again. Nothing was written.` | 11 | refusal |
 | `build claim: lost to <token> (posted <timestamp>, authorized).` | 15 | refusal |
 | `build claim: the marker landed but the read-back does not match — the claim needs a human eye.` | 9 | refusal |
 | `build confirm: #<n> is held by <winning token>, not by <caller token>.` — with ` — another lane of this same session` appended when the two tokens share a session id | 15 | refusal |
@@ -1167,9 +1177,16 @@ never published. A re-run under the same nonce resolves the same name and re-key
 
 Renaming rather than cutting a second branch is the whole point: two branches carrying one child's
 commits is the range `lane prove` reports as underivable, and that refusal cannot be cleared from
-inside a worktree, because `git branch -D` refuses a branch another worktree holds (#6386). When the
-re-key itself hits that — the prior lane's tree is still standing on the branch — it is `11` naming
-git's own reason, which is the operator's to release.
+inside a worktree, because `git branch -D` refuses a branch another worktree holds (#6386).
+
+**The re-key is proven safe before it runs, because `git branch -m` will not refuse for it.** Unlike
+`-D`, a rename of a branch a second worktree has checked out **succeeds** — git exits 0 and retargets
+that worktree's `HEAD` to the new name; only the `git switch` afterwards fails, by which point the
+prior lane is silently standing on a branch keyed to this one. So the verb reads
+`git worktree list --porcelain` first and refuses on `11` naming the worktree that holds the branch,
+which is the operator's to release. If a switch fails after a rename did land, the refusal says the
+rename stands rather than "nothing was changed" — that phrase is reserved for a tree that was not
+touched. Measured against git 2.40.1 rather than reasoned about.
 
 Preconditions, guarded identically to `build tree`: a readable tree root (`11`), a confirmed claim
 (`15` / `11`) — in create and child-repair mode on `<number>`, in resume mode on the `--resume` PR's
@@ -1179,9 +1196,9 @@ number, which is the number repair mode claims.
 
 | Code | Trigger |
 |---|---|
-| `7` | `--resume`'s PR is proven absent, closed, or merged; or `--resume-lane` found no local branch cut for `<number>` |
+| `7` | `--resume`'s PR is proven absent, closed, or merged; or `--resume-lane` found no branch anywhere in this clone's refs cut for `<number>` |
 | `10` | `--slug` is not kebab-case, exceeds 5 words, or is flag-shaped; or `--resume-lane` was given beside `--resume` or `--slug` |
-| `11` | the fetch failed, the claim state could not be read, or `--resume-lane` could not read this tree's branches, found several candidates, or could not re-key the one it found |
+| `11` | the fetch failed, the claim state could not be read, or `--resume-lane` could not read this clone's branches or its worktrees, found several candidates, proved another worktree holds the branch, or could not re-key or check out the one it found |
 | `15` | proven: the claim on `<number>` is foreign |
 
 **Errors**
@@ -1193,9 +1210,12 @@ number, which is the number repair mode claims.
 | `build branch: PR #<n> is proven closed or merged — nothing to resume.` | 7 | refusal |
 | `build branch: --resume-lane takes over the local branch of an epic child, which has no PR — it cannot be combined with --resume <pr>.` | 10 | refusal |
 | `build branch: --resume-lane reads the slug off the branch it takes over — drop --slug "<value>".` | 10 | refusal |
-| `build branch: no local branch in this tree was cut for #<n> — the build to resume is not here. …` | 7 | refusal |
+| `build branch: no branch anywhere in this clone's refs was cut for #<n> — the build to resume is gone. …` | 7 | refusal |
 | `build branch: <a>, <b> were all cut for #<n> — which one this lane resumes is not derivable here; retire the superseded branches, then re-run.` | 11 | refusal |
-| `build branch: cannot re-key <old> to <new>: <reason> — the prior lane's worktree is likely still standing on it, and only an operator can release that; nothing was changed.` | 11 | refusal |
+| `build branch: <branch> is checked out in the worktree <path>, so re-keying it here would rename the branch out from under that lane rather than fail — retiring or releasing that worktree is an operator's act, not this lane's. Nothing was changed.` | 11 | refusal |
+| `build branch: cannot read which worktree holds <branch>: <reason> — re-keying it could silently retarget another lane's HEAD, so whether the take-over is safe is UNKNOWN; nothing was changed.` | 11 | refusal |
+| `build branch: cannot re-key <old> to <new>: <reason> — nothing was changed.` | 11 | refusal |
+| `build branch: cannot check out <new>: <reason> — <old> WAS re-keyed to <new> and that rename stands; this tree is still on the branch it started on, so re-run once <new> is free, or rename it back.` | 11 | refusal |
 | `build branch: #<n> is held by <winning token>, not by <caller token>.` | 15 | refusal |
 
 **Scope** — not a judging verb. It mutates only the current tree's HEAD and local refs.

--- a/claude-plugins/fabrika/skills/build/contract.md
+++ b/claude-plugins/fabrika/skills/build/contract.md
@@ -77,7 +77,7 @@ second answer to a gated question can contradict the gate (interface convention 
 | `build pr` | open the PR from a stdin body, refusing the known defect shapes, with read-back | mechanical guards over an authored body; *authoring* stays in the skill |
 | `build pr-body` | replace an open PR's body from a stdin body, under `build pr`'s guards, with read-back | the same mechanical guards as `build pr`, over a `PATCH` that moves no ref; *authoring* stays in the skill |
 | `build note` | post a progress/handoff comment, head-stamped, leak-guarded, with read-back | as `report note`, plus the head stamp |
-| `build verdicts` | the paginated, current-head, per-gate verdict fold on a PR | fetch-all + fold via the wire module; *acting on rows* stays in the skill |
+| `build verdicts` | the paginated, per-gate verdict fold: current-head on a PR, range-bound on an epic child | fetch-all + fold via the wire module; *acting on rows* stays in the skill |
 | `build clear` | record the founder's clearance of one extra repair round on a PR | a conjunctive ACL/authorization protocol with read-back; *whether to grant* is the founder's, never the verb's |
 
 **Considered and not derived: a surface classifier.** Naming the surface (code / prose / plan) is
@@ -320,6 +320,7 @@ range, exactly as `triage/codes.ts` itself states for `adr`.
 | `23` | proven: the local head does not contain the published remote head — the push would drop its commits |
 | `24` | proven: `git commit` ran and HEAD did not move — no commit was created |
 | `30` | proven: not admitted on the type axis — the issue is `type:decision` or `type:epic`, whose deliverable is not a pull request a build lane produces |
+| `31` | proven: the claim's mode and the child's standing range verdict disagree — a fresh build over a child holding a `FAIL`, or a `--resume` over a child holding none |
 | `127` | the verb never ran at all (unresolved binary — the shell's code, not this process's) |
 
 **`7` versus `11` is the split the whole group rests on** (the `wire` group's `ABSENT` vs
@@ -909,6 +910,30 @@ proven-foreign only; a missing session id is `1`; an unreadable marker set is `1
 | `20` | `claim` only, proven: the issue's home is pinned by no `active` campaign row — no marker was written |
 | `21` | `claim --purpose build` only (the default), proven: the issue's audience is not an agent — no marker was written. Unreachable when the target is an open PR serving a `type:decision` issue (#5914) |
 | `30` | `claim --purpose build` against an **issue** only, proven: the issue is `type:decision` or `type:epic` — no marker was written. Not overridable: a decision opens it with `--cites <ruling-comment-url>`, an epic with `--purpose plan` or `--purpose gate` |
+| `31` | `claim --purpose build` against an **issue** only, proven: the claim's mode disagrees with the child's standing range verdicts — a fresh claim over a child holding a `FAIL`, or `--resume` over a child holding none. No marker was written, and neither direction is overridable: `--override` admits a *scope* refusal, and this is not one |
+
+**The prior-build gate — "no lane holds this" is not "this has no reviewed build"**
+
+An epic child opens no pull request (ADR 0285), so its review lands as range-bound comments on the
+child issue (ADR 0276) — a surface neither `build eligible` (which reads the `blocked_by` graph) nor
+the claim protocol (which reads claim markers) ever looked at. A child released after a `FAIL` was
+therefore handed to the next lane as ordinary work and rebuilt from scratch, twice on epic #5631; on
+#6298 the two lanes chose different config-key shapes for one criterion, and only `lane prove`'s
+refusal kept the wrong branch out of the assembly (#6386).
+
+So a fresh build-purpose claim against an issue folds those comments — newest write per namespace,
+the same rule `lane prove` folds on — and refuses on `31` when any namespace's newest verdict is
+`FAIL`. Staleness is deliberately not asked: a stale `FAIL` still proves the child was built and
+graded, which is the fact this gate exists for. The read runs **after** the pure axes and the
+blockedness gate, so an issue those already refused pays for no comment page, and an unreadable page
+is `11` — never "no prior build".
+
+`--resume` is the other side, and it is **checked, not trusted**: it admits a claim over a standing
+`FAIL` and refuses on `31` over a child holding none. Repair is otherwise derived from the target
+being an open PR and never typed (founder ruling on #5866, #5914); the objection there was that a
+typed mode is passable in a state where it means nothing, and a child has no PR to derive from — so
+the word is admitted here exactly because the seam checks the fact it asserts. The route it opens is
+`build branch --resume-lane`.
 
 **Errors**
 
@@ -932,6 +957,9 @@ proven-foreign only; a missing session id is `1`; an unreadable marker set is `1
 | `build claim: --purpose "<value>" is not one of plan \| gate \| build — an unrecognised purpose refuses, and never falls back to build.` | 10 | usage error |
 | `build claim: the marker write failed: <reason> — the claim state is UNKNOWN; run "fabrika build confirm <n> --token <minted token>" before any further action.` — preceded by `build claim: the token this run minted is <minted token> — it addresses the marker the failed write may still have landed. Do not re-run "fabrika build claim <n>": it mints a second token, and if the first marker landed the race resolves to that earlier one, leaving a claim no lane holds a token for.` | 8 | refusal |
 | `build claim: cannot read the claim markers on #<n>: <reason> — ownership is UNKNOWN, never "unclaimed".` | 11 | refusal |
+| `build claim: #<n> already carries a build a reviewer failed — <gate> FAIL over <base>..<tip> (comment <id>). A fresh build would re-implement it; run "fabrika build claim <n> --resume" to take the repair lane instead, then "fabrika build branch <n> --resume-lane --token <token>" to stand on the branch that build left. Nothing was written.` | 31 | refusal |
+| `build claim: --resume says #<n> holds a build to repair, and no gate holds a standing FAIL over it — drop --resume and claim it as the fresh build it is. Nothing was written.` | 31 | refusal |
+| `build claim: cannot read the comments on #<n>: <reason> — whether it already carries a graded build is UNKNOWN, never "no"; nothing was written.` | 11 | refusal |
 | `build claim: lost to <token> (posted <timestamp>, authorized).` | 15 | refusal |
 | `build claim: the marker landed but the read-back does not match — the claim needs a human eye.` | 9 | refusal |
 | `build confirm: #<n> is held by <winning token>, not by <caller token>.` — with ` — another lane of this same session` appended when the two tokens share a session id | 15 | refusal |
@@ -1091,6 +1119,7 @@ $ fabrika build issue 4312
 ```
 fabrika build branch 4312 --slug editor-focus-loss --token <token> [--base <ref>]
 fabrika build branch --resume 4310 --token <token>
+fabrika build branch 6296 --resume-lane --token <token>
 ```
 
 **Inputs**
@@ -1101,6 +1130,7 @@ fabrika build branch --resume 4310 --token <token>
 | `--slug` | string | yes (create mode) | — | kebab-case, ≤5 words, must not begin with `-` |
 | `--base` | string | no | `origin/main` | the base ref, **fetched before the branch is cut** |
 | `--resume` | integer | exclusive with the positional | — | a PR number whose head branch to switch to, for repair |
+| `--resume-lane` | boolean | no | `false` | child-repair mode: take over the local branch a prior lane built `<number>` on. Exclusive with `--resume` and with `--slug` |
 | `--token` | string | yes | — | the token `build claim` handed this lane — which lane is asking (#6037). Not a claim token, or one carrying another session id, is `1` |
 
 
@@ -1126,17 +1156,32 @@ head branch — `build push` publishes via that tracked upstream, so the PR upda
 name carries the *current* repair claim's nonce. Each repair run gets its own local branch, so a
 dead earlier lane can never pin this one (#4868's class). A closed or merged PR refuses (`7`).
 
+**Child-repair mode (`--resume-lane`) — resume for the artifact that has no PR to resume.** An epic
+child opens none (ADR 0285), so `--resume` has nothing to take, and a fresh cut off the assembly
+branch would throw away the commits a reviewer already graded. This mode instead finds the one local
+branch this file's own grammar says was cut for `<number>`
+(`packages/fabrika-cli/src/build/lane.ts`'s `childLaneBranches`, the same reader `lane prove` and
+`lane brief` take), **re-keys** it to this claim's nonce with `git branch -m`, and checks it out. The
+slug comes off that name, so `--slug` is refused; nothing is fetched, because a child's branch is
+never published. A re-run under the same nonce resolves the same name and re-keys nothing.
+
+Renaming rather than cutting a second branch is the whole point: two branches carrying one child's
+commits is the range `lane prove` reports as underivable, and that refusal cannot be cleared from
+inside a worktree, because `git branch -D` refuses a branch another worktree holds (#6386). When the
+re-key itself hits that — the prior lane's tree is still standing on the branch — it is `11` naming
+git's own reason, which is the operator's to release.
+
 Preconditions, guarded identically to `build tree`: a readable tree root (`11`), a confirmed claim
-(`15` / `11`) — in create mode on `<number>`, in resume mode on the `--resume` PR's number, which
-is the number repair mode claims.
+(`15` / `11`) — in create and child-repair mode on `<number>`, in resume mode on the `--resume` PR's
+number, which is the number repair mode claims.
 
 **Exit status** (beyond the universal four)
 
 | Code | Trigger |
 |---|---|
-| `7` | `--resume`'s PR is proven absent, closed, or merged |
-| `10` | `--slug` is not kebab-case, exceeds 5 words, or is flag-shaped |
-| `11` | the fetch failed, or the claim state could not be read |
+| `7` | `--resume`'s PR is proven absent, closed, or merged; or `--resume-lane` found no local branch cut for `<number>` |
+| `10` | `--slug` is not kebab-case, exceeds 5 words, or is flag-shaped; or `--resume-lane` was given beside `--resume` or `--slug` |
+| `11` | the fetch failed, the claim state could not be read, or `--resume-lane` could not read this tree's branches, found several candidates, or could not re-key the one it found |
 | `15` | proven: the claim on `<number>` is foreign |
 
 **Errors**
@@ -1146,6 +1191,11 @@ is the number repair mode claims.
 | `build branch: --slug "<value>" is not kebab-case (lowercase letters, digits, single hyphens, ≤5 words).` | 10 | refusal |
 | `build branch: cannot fetch <ref>: <reason> — refusing to cut a branch off a stale base.` | 11 | refusal |
 | `build branch: PR #<n> is proven closed or merged — nothing to resume.` | 7 | refusal |
+| `build branch: --resume-lane takes over the local branch of an epic child, which has no PR — it cannot be combined with --resume <pr>.` | 10 | refusal |
+| `build branch: --resume-lane reads the slug off the branch it takes over — drop --slug "<value>".` | 10 | refusal |
+| `build branch: no local branch in this tree was cut for #<n> — the build to resume is not here. …` | 7 | refusal |
+| `build branch: <a>, <b> were all cut for #<n> — which one this lane resumes is not derivable here; retire the superseded branches, then re-run.` | 11 | refusal |
+| `build branch: cannot re-key <old> to <new>: <reason> — the prior lane's worktree is likely still standing on it, and only an operator can release that; nothing was changed.` | 11 | refusal |
 | `build branch: #<n> is held by <winning token>, not by <caller token>.` | 15 | refusal |
 
 **Scope** — not a judging verb. It mutates only the current tree's HEAD and local refs.
@@ -2060,7 +2110,8 @@ fabrika build verdicts --pr 4310 [--repo <owner/name>]
 
 | Flag | Type | Required | Default | Description |
 |---|---|---|---|---|
-| `--pr` | integer | yes | — | the pull request whose verdict state is folded |
+| `--pr` | integer | exactly one of `--pr` / `--issue` | — | the pull request whose verdict state is folded |
+| `--issue` | integer | exactly one of `--pr` / `--issue` | — | the epic child whose range-scoped verdicts are folded |
 | `--repo` | string | no | the `origin` remote's `owner/name` | the repository read |
 
 **Output** — machine. One JSON object:
@@ -2125,11 +2176,23 @@ review-appended acceptance-criterion rows dated at or past `CAP_ROUND`.
 comment/review counts. An unreadable page is `11` — never a shorter list.** All content passes
 the content gate.
 
+**The child arm (`--issue`).** An epic child opens no PR (ADR 0285), so the same fold is asked of the
+range-bound comments on the child issue (ADR 0276) — this is where a lane sent to repair by
+`build claim --resume` reads its findings, through a verb rather than a raw fetch. Each row names the
+`range` it was formed over instead of a `sha`/`current` pair, `kind` is `range-marker`, and there is
+no `head` and no `frozenCriteria`, because neither exists on this surface. A round is one graded
+**tip** — the range analogue of one graded head, folded through the same counter — so two gates over
+one range are one round. `clearances` is always empty and stderr says why: a grant is recorded
+against a PR's base branch and a child has none, so a child at its cap escalates to the operator
+rather than reading a grant with nowhere to live. A comment reaching for the range format and missing
+it is named on stderr, never dropped.
+
 **Exit status** (beyond the universal four)
 
 | Code | Trigger |
 |---|---|
-| `7` | the PR is proven absent or closed |
+| `7` | the PR is proven absent or closed; or `--issue`'s number is proven absent, or is a pull request |
+| `10` | neither `--pr` nor `--issue` was given, or both were |
 | `11` | the head, any comment page, any review page, or the grant-author set could not be read — the fold is UNKNOWN, never partial |
 
 **Errors**
@@ -2139,6 +2202,8 @@ the content gate.
 | `build verdicts: PR #<n> is proven absent or closed.` | 7 | refusal |
 | `build verdicts: cannot read <what> (page <k>): <reason> — the verdict state is UNKNOWN, never "none".` | 11 | refusal |
 | `build verdicts: cannot read the recorded cap clearances: <reason> — whether the budget is spent is UNKNOWN, never "capped".` | 11 | refusal |
+| `build verdicts: give either --pr <n> or --issue <n>, never both and never neither.` | 10 | usage error |
+| `build verdicts: #<n> is a pull request — its verdicts are head-bound; drop --issue and pass --pr.` | 7 | refusal |
 
 **Scope** — one PR: its head, all comments, all reviews. The stderr scope line names the head SHA
 and both counts, so an empty `rows` is auditable as "N comments read, none carried a marker".

--- a/packages/fabrika-cli/src/build/branch-verb.ts
+++ b/packages/fabrika-cli/src/build/branch-verb.ts
@@ -8,17 +8,29 @@
  * the remote head, so `build push` updates the PR while the local name carries *this* repair claim's
  * nonce — which is what stops a dead earlier lane from pinning this one (#4868's class).
  *
+ * `--resume-lane` is resume mode for the one artifact with no PR to resume — an epic child
+ * (ADR 0285). It re-keys the branch a prior lane built the child on to this claim's nonce rather than
+ * cutting a second one off it, because two branches carrying one child's commits is the underivable
+ * range `lane prove` refuses on, and that refusal cannot be cleared from inside a worktree (#6386).
+ *
  * A re-run is idempotent: the nonce is a function of the claim, so the second run resolves the same
  * name and switches to it instead of failing on a branch that is already there.
  */
 import {Effect} from "effect";
 import type {ChildProcessSpawner} from "effect/unstable/process";
+import {localBranches} from "../io/git.ts";
 import {answer, refuse, type VerbOutcome} from "../verb.ts";
 import {requireCallerToken, requireClaim, requireSession} from "./claim.ts";
 import {OFF_VOCABULARY, PRECONDITION_UNKNOWN, ZERO_SCOPE} from "./codes.ts";
-import {branchExists, fetchBase, setUpstream, switchTo, switchToNew} from "./git.ts";
+import {branchExists, fetchBase, renameBranch, setUpstream, switchTo, switchToNew} from "./git.ts";
 import {getPullHead} from "./github.ts";
-import {createBranchName, isKebabSlug, resumeBranchName} from "./lane.ts";
+import {
+	childLaneBranches,
+	createBranchName,
+	isKebabSlug,
+	parseLaneBranch,
+	resumeBranchName,
+} from "./lane.ts";
 import {resolveTargetRepo} from "./target.ts";
 import {assertGround} from "./tree.ts";
 
@@ -31,6 +43,14 @@ export interface BranchOptions {
 	readonly base: string;
 	/** Resume mode: the PR whose head branch to publish back to. Exclusive with `number`. */
 	readonly resume: number | null;
+	/**
+	 * Child-repair mode: take over the branch a prior lane already built `number` on.
+	 *
+	 * The counterpart of `--resume` for the one artifact that has no PR to resume — an epic child
+	 * (ADR 0285). It takes `<number>` rather than a PR, needs no `--slug` because the branch already
+	 * carries one, and re-keys that branch to this claim's nonce instead of cutting a second one.
+	 */
+	readonly resumeLane: boolean;
 	/** The token `build claim` handed this lane — the identity it cuts the branch under (#6037). */
 	readonly token: string;
 	readonly repo: string | null;
@@ -47,14 +67,26 @@ export const runBranch = (
 	options: BranchOptions,
 ): Effect.Effect<VerbOutcome, never, ChildProcessSpawner.ChildProcessSpawner> =>
 	Effect.gen(function* () {
-		const {number, slug, resume} = options;
+		const {number, slug, resume, resumeLane} = options;
 		if ((number === null) === (resume === null)) {
 			return refuse(
 				OFF_VOCABULARY,
 				`${VERB}: give either <number> --slug <slug> or --resume <pr>, never both and never neither.`,
 			);
 		}
-		if (resume === null && (slug === null || !isKebabSlug(slug))) {
+		if (resumeLane && resume !== null) {
+			return refuse(
+				OFF_VOCABULARY,
+				`${VERB}: --resume-lane takes over the local branch of an epic child, which has no PR — it cannot be combined with --resume <pr>.`,
+			);
+		}
+		if (resumeLane && slug !== null) {
+			return refuse(
+				OFF_VOCABULARY,
+				`${VERB}: --resume-lane reads the slug off the branch it takes over — drop --slug "${slug}".`,
+			);
+		}
+		if (resume === null && !resumeLane && (slug === null || !isKebabSlug(slug))) {
 			return refuse(
 				OFF_VOCABULARY,
 				`${VERB}: --slug "${slug ?? ""}" is not kebab-case (lowercase letters, digits, single hyphens, ≤5 words).`,
@@ -125,6 +157,67 @@ export const runBranch = (
 						held.notes,
 					)
 				: answer(name, held.notes);
+		}
+
+		if (resumeLane) {
+			const issue = number as number;
+			const branches = yield* localBranches;
+			if (branches._tag === "Failure") {
+				return refuse(
+					PRECONDITION_UNKNOWN,
+					`${VERB}: cannot read this tree's local branches: ${branches.reason} — which branch carries #${issue}'s build is UNKNOWN; nothing was changed.`,
+					held.notes,
+				);
+			}
+			const candidates = childLaneBranches(issue, branches.value);
+			const [only, ...rest] = candidates;
+			if (only === undefined) {
+				return refuse(
+					ZERO_SCOPE,
+					`${VERB}: no local branch in this tree was cut for #${issue} — the build to resume is not here. A child's branch is never pushed (ADR 0285), so it exists only in the tree that built it; resume from that tree, or claim #${issue} without --resume once its FAIL is retracted.`,
+					held.notes,
+				);
+			}
+			if (rest.length > 0) {
+				return refuse(
+					PRECONDITION_UNKNOWN,
+					`${VERB}: ${candidates.join(", ")} were all cut for #${issue} — which one this lane resumes is not derivable here; retire the superseded branches, then re-run.`,
+					held.notes,
+				);
+			}
+			const prior = parseLaneBranch(only);
+			if (prior === null || prior._tag !== "Create") {
+				return refuse(
+					PRECONDITION_UNKNOWN,
+					`${VERB}: "${only}" does not parse back into a lane branch — nothing was changed.`,
+					held.notes,
+				);
+			}
+			const name = createBranchName(issue, prior.slug, nonce);
+			// Re-keyed in place rather than cut off `only`, so exactly one branch keeps naming this
+			// child — two is the underivable range `lane prove` refuses on, and an idempotent re-run
+			// under the same nonce resolves the same name and has nothing to rename.
+			if (name !== only) {
+				const renamed = yield* renameBranch(only, name);
+				if (renamed._tag === "Failure") {
+					return refuse(
+						PRECONDITION_UNKNOWN,
+						`${VERB}: cannot re-key ${only} to ${name}: ${renamed.reason} — the prior lane's worktree is likely still standing on it, and only an operator can release that; nothing was changed.`,
+						held.notes,
+					);
+				}
+			}
+			const switched = yield* switchTo(name);
+			return switched._tag === "Failure"
+				? refuse(
+						PRECONDITION_UNKNOWN,
+						`${VERB}: cannot check out ${name}: ${switched.reason} — nothing was changed.`,
+						held.notes,
+					)
+				: answer(name, [
+						...held.notes,
+						`${VERB}: took over ${only} as ${name} — #${issue}'s build continues on the commits it already carries.`,
+					]);
 		}
 
 		const fetched = yield* fetchBase(options.base);

--- a/packages/fabrika-cli/src/build/branch-verb.ts
+++ b/packages/fabrika-cli/src/build/branch-verb.ts
@@ -22,7 +22,16 @@ import {localBranches} from "../io/git.ts";
 import {answer, refuse, type VerbOutcome} from "../verb.ts";
 import {requireCallerToken, requireClaim, requireSession} from "./claim.ts";
 import {OFF_VOCABULARY, PRECONDITION_UNKNOWN, ZERO_SCOPE} from "./codes.ts";
-import {branchExists, fetchBase, renameBranch, setUpstream, switchTo, switchToNew} from "./git.ts";
+import {
+	branchExists,
+	currentBranch,
+	fetchBase,
+	renameBranch,
+	setUpstream,
+	switchTo,
+	switchToNew,
+	worktreeCheckouts,
+} from "./git.ts";
 import {getPullHead} from "./github.ts";
 import {
 	childLaneBranches,
@@ -165,7 +174,7 @@ export const runBranch = (
 			if (branches._tag === "Failure") {
 				return refuse(
 					PRECONDITION_UNKNOWN,
-					`${VERB}: cannot read this tree's local branches: ${branches.reason} — which branch carries #${issue}'s build is UNKNOWN; nothing was changed.`,
+					`${VERB}: cannot read this clone's local branches: ${branches.reason} — which branch carries #${issue}'s build is UNKNOWN; nothing was changed.`,
 					held.notes,
 				);
 			}
@@ -174,7 +183,7 @@ export const runBranch = (
 			if (only === undefined) {
 				return refuse(
 					ZERO_SCOPE,
-					`${VERB}: no local branch in this tree was cut for #${issue} — the build to resume is not here. A child's branch is never pushed (ADR 0285), so it exists only in the tree that built it; resume from that tree, or claim #${issue} without --resume once its FAIL is retracted.`,
+					`${VERB}: no branch anywhere in this clone's refs was cut for #${issue} — the build to resume is gone. Refs are shared across every worktree of a clone, so no other tree here holds one either; a child's branch is never pushed (ADR 0285), so it survives only in the clone that built it. Resume from that clone, or claim #${issue} without --resume once its FAIL is retracted.`,
 					held.notes,
 				);
 			}
@@ -197,12 +206,44 @@ export const runBranch = (
 			// Re-keyed in place rather than cut off `only`, so exactly one branch keeps naming this
 			// child — two is the underivable range `lane prove` refuses on, and an idempotent re-run
 			// under the same nonce resolves the same name and has nothing to rename.
-			if (name !== only) {
+			const rekeying = name !== only;
+			if (rekeying) {
+				// The rename is proven safe BEFORE it runs, because `git branch -m` does not refuse a
+				// branch another worktree holds — it renames it and retargets that worktree's HEAD, and
+				// only the switch below then fails (#6386, review round 1). Asking git afterwards would
+				// mean reporting a mutation that already landed under someone else's lane.
+				const checkouts = yield* worktreeCheckouts;
+				if (checkouts._tag === "Failure") {
+					return refuse(
+						PRECONDITION_UNKNOWN,
+						`${VERB}: cannot read which worktree holds ${only}: ${checkouts.reason} — re-keying it could silently retarget another lane's HEAD, so whether the take-over is safe is UNKNOWN; nothing was changed.`,
+						held.notes,
+					);
+				}
+				const mine = yield* currentBranch;
+				if (mine._tag === "Failure") {
+					return refuse(
+						PRECONDITION_UNKNOWN,
+						`${VERB}: cannot read which branch this tree holds: ${mine.reason} — whether ${only} is held here or by another lane is UNKNOWN; nothing was changed.`,
+						held.notes,
+					);
+				}
+				const holder =
+					mine.value === only
+						? undefined
+						: checkouts.value.find((checkout) => checkout.branch === only);
+				if (holder !== undefined) {
+					return refuse(
+						PRECONDITION_UNKNOWN,
+						`${VERB}: ${only} is checked out in the worktree ${holder.path}, so re-keying it here would rename the branch out from under that lane rather than fail — retiring or releasing that worktree is an operator's act, not this lane's. Nothing was changed.`,
+						held.notes,
+					);
+				}
 				const renamed = yield* renameBranch(only, name);
 				if (renamed._tag === "Failure") {
 					return refuse(
 						PRECONDITION_UNKNOWN,
-						`${VERB}: cannot re-key ${only} to ${name}: ${renamed.reason} — the prior lane's worktree is likely still standing on it, and only an operator can release that; nothing was changed.`,
+						`${VERB}: cannot re-key ${only} to ${name}: ${renamed.reason} — nothing was changed.`,
 						held.notes,
 					);
 				}
@@ -211,7 +252,11 @@ export const runBranch = (
 			return switched._tag === "Failure"
 				? refuse(
 						PRECONDITION_UNKNOWN,
-						`${VERB}: cannot check out ${name}: ${switched.reason} — nothing was changed.`,
+						`${VERB}: cannot check out ${name}: ${switched.reason} — ${
+							rekeying
+								? `${only} WAS re-keyed to ${name} and that rename stands; this tree is still on the branch it started on, so re-run once ${name} is free, or rename it back`
+								: "nothing was changed"
+						}.`,
 						held.notes,
 					)
 				: answer(name, [

--- a/packages/fabrika-cli/src/build/branch-verb.unit.test.ts
+++ b/packages/fabrika-cli/src/build/branch-verb.unit.test.ts
@@ -32,6 +32,7 @@ const options = {
 	slug: "editor-focus-loss" as string | null,
 	base: "origin/main",
 	resume: null as number | null,
+	resumeLane: false,
 	token: LANE_TOKEN,
 	repo: null,
 	env: {CLAUDE_PIPELINE_REPO: "o/r", CLAUDE_CODE_SESSION_ID: "s-9f2e"} as Record<
@@ -193,5 +194,105 @@ describe("runBranch — resume mode", () => {
 		expect(out.stderr.at(-1)).toBe(
 			"build branch: PR #4310 is proven closed or merged — nothing to resume.",
 		);
+	});
+});
+
+/**
+ * Child-repair mode: the route a `build claim --resume` on an epic child hands its lane. It has to
+ * exist, or the prior-build refusal strands the child it stops (#6386).
+ */
+describe("runBranch — --resume-lane", () => {
+	const FOR_EACH_REF = /^git for-each-ref /;
+	const RENAME = /^git branch -m /;
+	const SWITCH = /^git switch build\//;
+	const PRIOR = "build/4312-path-surface-config-c4367b0b";
+	const RESUMED = `build/4312-path-surface-config-${NONCE}`;
+	const resumeLaneOptions = {slug: null, resumeLane: true};
+
+	it("re-keys the prior lane's branch to this claim's nonce and checks it out", async () => {
+		const shell = fakeShell([
+			...CLAIMED,
+			[FOR_EACH_REF, okOut(`main\n${PRIOR}\nepic/5631\n`)],
+			[RENAME, okOut("")],
+			[SWITCH, okOut("")],
+		]);
+		const out = await Effect.runPromise(
+			Effect.provide(runBranch({...options, ...resumeLaneOptions}), shell.layer),
+		);
+		expect(out.code).toBe(0);
+		expect(out.stdout).toBe(`${RESUMED}\n`);
+		expect(shell.calls).toContain(`git branch -m ${PRIOR} ${RESUMED}`);
+		expect(shell.calls).toContain(`git switch ${RESUMED}`);
+		// A second branch carrying the child's commits is the underivable range `lane prove` refuses
+		// on, and no cut here is what keeps that from happening.
+		expect(shell.calls.some((line) => SWITCH_NEW.test(line))).toBe(false);
+	});
+
+	it("fetches nothing — a child's branch is local, and the remote knows none of it", async () => {
+		const shell = fakeShell([
+			...CLAIMED,
+			[FOR_EACH_REF, okOut(`${PRIOR}\n`)],
+			[RENAME, okOut("")],
+			[SWITCH, okOut("")],
+		]);
+		await Effect.runPromise(
+			Effect.provide(runBranch({...options, ...resumeLaneOptions}), shell.layer),
+		);
+		expect(shell.calls.some((line) => /^git fetch/.test(line))).toBe(false);
+	});
+
+	it("renames nothing on a re-run under the same nonce — the name already resolves", async () => {
+		const shell = fakeShell([
+			...CLAIMED,
+			[FOR_EACH_REF, okOut(`${RESUMED}\n`)],
+			[SWITCH, okOut("")],
+		]);
+		const out = await Effect.runPromise(
+			Effect.provide(runBranch({...options, ...resumeLaneOptions}), shell.layer),
+		);
+		expect(out.code).toBe(0);
+		expect(shell.calls.some((line) => RENAME.test(line))).toBe(false);
+	});
+
+	it("refuses on 7 when no local branch was cut for the number", async () => {
+		const out = await run([...CLAIMED, [FOR_EACH_REF, okOut("main\nepic/5631\n")]], {
+			...resumeLaneOptions,
+		});
+		expect(out.code).toBe(ZERO_SCOPE);
+		expect(out.stderr.at(-1)).toContain("no local branch in this tree was cut for #4312");
+	});
+
+	it("refuses on 11 when several branches were cut for the number", async () => {
+		const out = await run(
+			[...CLAIMED, [FOR_EACH_REF, okOut(`${PRIOR}\nbuild/4312-other-shape-11223344\n`)]],
+			{...resumeLaneOptions},
+		);
+		expect(out.code).toBe(PRECONDITION_UNKNOWN);
+		expect(out.stderr.at(-1)).toContain("which one this lane resumes is not derivable here");
+	});
+
+	it("refuses on 11 when the re-key fails, naming the worktree that holds the branch", async () => {
+		const out = await run(
+			[
+				...CLAIMED,
+				[FOR_EACH_REF, okOut(`${PRIOR}\n`)],
+				[RENAME, errOut(`fatal: '${PRIOR}' is checked out at another worktree`)],
+			],
+			{...resumeLaneOptions},
+		);
+		expect(out.code).toBe(PRECONDITION_UNKNOWN);
+		expect(out.stderr.at(-1)).toContain("the prior lane's worktree is likely still standing on it");
+	});
+
+	it("refuses --resume-lane beside --resume on 10 — a child has no PR to resume", async () => {
+		const out = await run([], {number: null, slug: null, resume: 4310, resumeLane: true});
+		expect(out.code).toBe(OFF_VOCABULARY);
+		expect(out.stderr.at(-1)).toContain("it cannot be combined with --resume <pr>");
+	});
+
+	it("refuses --resume-lane beside --slug on 10 — the slug comes off the branch", async () => {
+		const out = await run([], {resumeLane: true});
+		expect(out.code).toBe(OFF_VOCABULARY);
+		expect(out.stderr.at(-1)).toContain("reads the slug off the branch it takes over");
 	});
 });

--- a/packages/fabrika-cli/src/build/branch-verb.unit.test.ts
+++ b/packages/fabrika-cli/src/build/branch-verb.unit.test.ts
@@ -205,14 +205,30 @@ describe("runBranch — --resume-lane", () => {
 	const FOR_EACH_REF = /^git for-each-ref /;
 	const RENAME = /^git branch -m /;
 	const SWITCH = /^git switch build\//;
+	const WORKTREES = /^git worktree list --porcelain$/;
+	const SHOW_CURRENT = /^git branch --show-current$/;
 	const PRIOR = "build/4312-path-surface-config-c4367b0b";
 	const RESUMED = `build/4312-path-surface-config-${NONCE}`;
 	const resumeLaneOptions = {slug: null, resumeLane: true};
+
+	/** Only this tree, on `main` — the branch to take over is free. */
+	const FREE = okOut(`worktree /repo\nHEAD ${HEAD}\nbranch refs/heads/main\n`);
+	/** A second worktree standing on the prior lane's branch — the case --resume-lane exists for. */
+	const HELD = okOut(
+		`worktree /repo\nHEAD ${HEAD}\nbranch refs/heads/main\n\nworktree /repo/lane-a\nHEAD ${HEAD}\nbranch refs/heads/${PRIOR}\n`,
+	);
+	const ON_MAIN = okOut("main\n");
+	/** What every take-over asks before it renames: who holds the branch, and am I them. */
+	const SAFE_TO_REKEY = [
+		[WORKTREES, FREE],
+		[SHOW_CURRENT, ON_MAIN],
+	] as ReadonlyArray<readonly [RegExp, ExecResult]>;
 
 	it("re-keys the prior lane's branch to this claim's nonce and checks it out", async () => {
 		const shell = fakeShell([
 			...CLAIMED,
 			[FOR_EACH_REF, okOut(`main\n${PRIOR}\nepic/5631\n`)],
+			...SAFE_TO_REKEY,
 			[RENAME, okOut("")],
 			[SWITCH, okOut("")],
 		]);
@@ -232,6 +248,7 @@ describe("runBranch — --resume-lane", () => {
 		const shell = fakeShell([
 			...CLAIMED,
 			[FOR_EACH_REF, okOut(`${PRIOR}\n`)],
+			...SAFE_TO_REKEY,
 			[RENAME, okOut("")],
 			[SWITCH, okOut("")],
 		]);
@@ -254,12 +271,15 @@ describe("runBranch — --resume-lane", () => {
 		expect(shell.calls.some((line) => RENAME.test(line))).toBe(false);
 	});
 
-	it("refuses on 7 when no local branch was cut for the number", async () => {
+	it("refuses on 7 when no branch in the clone's refs was cut for the number", async () => {
 		const out = await run([...CLAIMED, [FOR_EACH_REF, okOut("main\nepic/5631\n")]], {
 			...resumeLaneOptions,
 		});
 		expect(out.code).toBe(ZERO_SCOPE);
-		expect(out.stderr.at(-1)).toContain("no local branch in this tree was cut for #4312");
+		// Refs are shared clone-wide, so "not in this tree" would name a state that cannot arise —
+		// if the branch exists at all, every worktree of the clone sees it.
+		expect(out.stderr.at(-1)).toContain("no branch anywhere in this clone's refs");
+		expect(out.stderr.at(-1)).not.toContain("resume from that tree");
 	});
 
 	it("refuses on 11 when several branches were cut for the number", async () => {
@@ -271,17 +291,72 @@ describe("runBranch — --resume-lane", () => {
 		expect(out.stderr.at(-1)).toContain("which one this lane resumes is not derivable here");
 	});
 
-	it("refuses on 11 when the re-key fails, naming the worktree that holds the branch", async () => {
+	/**
+	 * Measured against git 2.40.1, not reasoned about: `git branch -m` on a branch a second worktree
+	 * holds exits 0 and retargets that worktree's HEAD; only the `git switch` after it fails, 128. So
+	 * the refusal has to come BEFORE the rename, or it reports "nothing was changed" over a rename
+	 * that landed under another lane (#6386, review round 1).
+	 */
+	it("refuses on 11 BEFORE renaming when another worktree holds the branch, naming that worktree", async () => {
+		const shell = fakeShell([
+			...CLAIMED,
+			[FOR_EACH_REF, okOut(`${PRIOR}\n`)],
+			[WORKTREES, HELD],
+			[SHOW_CURRENT, ON_MAIN],
+		]);
+		const out = await Effect.runPromise(
+			Effect.provide(runBranch({...options, ...resumeLaneOptions}), shell.layer),
+		);
+		expect(out.code).toBe(PRECONDITION_UNKNOWN);
+		expect(out.stderr.at(-1)).toContain("is checked out in the worktree /repo/lane-a");
+		expect(out.stderr.at(-1)).toContain("Nothing was changed.");
+		expect(shell.calls.some((line) => RENAME.test(line))).toBe(false);
+	});
+
+	it("re-keys anyway when the tree holding the branch is this one — nobody else's HEAD moves", async () => {
+		const shell = fakeShell([
+			...CLAIMED,
+			[FOR_EACH_REF, okOut(`${PRIOR}\n`)],
+			[WORKTREES, okOut(`worktree /repo\nHEAD ${HEAD}\nbranch refs/heads/${PRIOR}\n`)],
+			[SHOW_CURRENT, okOut(`${PRIOR}\n`)],
+			[RENAME, okOut("")],
+			[SWITCH, okOut("")],
+		]);
+		const out = await Effect.runPromise(
+			Effect.provide(runBranch({...options, ...resumeLaneOptions}), shell.layer),
+		);
+		expect(out.code).toBe(0);
+		expect(shell.calls).toContain(`git branch -m ${PRIOR} ${RESUMED}`);
+	});
+
+	it("refuses on 11 when who holds the branch cannot be read — never 'free'", async () => {
+		const shell = fakeShell([
+			...CLAIMED,
+			[FOR_EACH_REF, okOut(`${PRIOR}\n`)],
+			[WORKTREES, errOut("fatal: not a git repository")],
+		]);
+		const out = await Effect.runPromise(
+			Effect.provide(runBranch({...options, ...resumeLaneOptions}), shell.layer),
+		);
+		expect(out.code).toBe(PRECONDITION_UNKNOWN);
+		expect(out.stderr.at(-1)).toContain("could silently retarget another lane's HEAD");
+		expect(shell.calls.some((line) => RENAME.test(line))).toBe(false);
+	});
+
+	it("says the rename stands when the switch fails after it — never 'nothing was changed'", async () => {
 		const out = await run(
 			[
 				...CLAIMED,
 				[FOR_EACH_REF, okOut(`${PRIOR}\n`)],
-				[RENAME, errOut(`fatal: '${PRIOR}' is checked out at another worktree`)],
+				...SAFE_TO_REKEY,
+				[RENAME, okOut("")],
+				[SWITCH, errOut(`fatal: '${RESUMED}' is already checked out at '/repo/lane-b'`)],
 			],
 			{...resumeLaneOptions},
 		);
 		expect(out.code).toBe(PRECONDITION_UNKNOWN);
-		expect(out.stderr.at(-1)).toContain("the prior lane's worktree is likely still standing on it");
+		expect(out.stderr.at(-1)).toContain(`${PRIOR} WAS re-keyed to ${RESUMED}`);
+		expect(out.stderr.at(-1)).not.toContain("nothing was changed");
 	});
 
 	it("refuses --resume-lane beside --resume on 10 — a child has no PR to resume", async () => {

--- a/packages/fabrika-cli/src/build/claim-verb.ts
+++ b/packages/fabrika-cli/src/build/claim-verb.ts
@@ -213,6 +213,10 @@ type PriorBuildRead =
  * over a graded artifact, the other would try to resume a branch no reviewer has ruled on. Neither
  * refusal is overridable by `--override`, which admits an issue the *scope* fence barred; this is
  * not a question about whether the issue is in scope.
+ *
+ * Three answers, then, not two: `FAIL`, no `FAIL`, and **unreadable** — an unreachable comment page
+ * and a marker that reaches for the range format and misses it both land in the third, refuse on
+ * `11`, and are never folded into the second.
  */
 const readPriorBuild = (
 	repo: string,
@@ -240,11 +244,25 @@ const readPriorBuild = (
 					? ""
 					: `: ${read.standing.map((v) => `${v.namespace} ${v.polarity}`).join(", ")}`
 			}.`,
-			...read.malformed.map(
-				(reason) =>
-					`${CLAIM}: a comment on #${number} reaches for a verdict marker and is not a range one — ${reason}`,
-			),
 		];
+		// Fail-closed on the same axis as an unreadable comment page above, and for the same reason: a
+		// FAIL posted in a broken format is exactly the verdict this gate exists to see, and counting
+		// it on stderr while admitting the claim resolves "unreadable" to "no prior build" — the one
+		// reading the module's docblock names as the failure to avoid. Only a comment whose first line
+		// opens with a gate namespace can land here (`../wire/marker-line.ts`), so ordinary discussion
+		// on a child never trips it.
+		if (read.malformed.length > 0) {
+			return {
+				_tag: "Refused" as const,
+				outcome: refuse(
+					PRECONDITION_UNKNOWN,
+					`${CLAIM}: ${read.malformed.length} comment(s) on #${number} reach for a verdict marker and are not readable range ones — ${read.malformed.join(
+						"; ",
+					)}. A verdict that cannot be read is UNKNOWN, never "no prior build"; repost or delete the comment(s), then claim again. Nothing was written.`,
+					[...lines, ...notes],
+				),
+			};
+		}
 		if (failed.length > 0 && !resume) {
 			return {
 				_tag: "Refused" as const,

--- a/packages/fabrika-cli/src/build/claim-verb.ts
+++ b/packages/fabrika-cli/src/build/claim-verb.ts
@@ -82,10 +82,12 @@ import {
 	CLAIM_NOT_MINE,
 	OFF_VOCABULARY,
 	PRECONDITION_UNKNOWN,
+	PRIOR_BUILD_MISMATCH,
 	READBACK_MISMATCH,
 	WRITE_UNKNOWN,
 } from "./codes.ts";
 import {composeToken, nonceOf, parseToken} from "./lane.ts";
+import {failing, readRangeVerdicts} from "./range-verdicts.ts";
 import {
 	admissionOf,
 	admissionRefusal,
@@ -135,11 +137,23 @@ export interface ClaimOptions {
 	 * only be asked of the session, which is exactly the question #6037 proved a lane must not ask.
 	 */
 	readonly token: string | null;
+	/**
+	 * Whether this lane is resuming an epic child's build rather than starting one — see
+	 * {@link readPriorBuild}.
+	 *
+	 * It is a word rather than a derivation because there is nothing to derive it *from*: repair is
+	 * read off an open PR (founder ruling on #5866, #5914) and an epic child opens none. The ruling's
+	 * objection to a typed mode was that a flag is passable in a state where it means nothing, and
+	 * that objection is answered here rather than dodged — `--resume` is checked against the very
+	 * fact it asserts, so it refuses on a child carrying no standing `FAIL` exactly as its absence
+	 * refuses on one that does.
+	 */
+	readonly resume: boolean;
 }
 
 export type ProtocolOptions = Omit<
 	ClaimOptions,
-	"uuid" | "at" | "purpose" | "override" | "overrideLane" | "cites" | "token"
+	"uuid" | "at" | "purpose" | "override" | "overrideLane" | "cites" | "token" | "resume"
 > & {
 	/** The token `build claim` handed this lane — the identity it is asking under (#6037). */
 	readonly token: string;
@@ -181,6 +195,94 @@ const readOverride = (reason: string | null, lane: string | null): OverrideRead 
 	}
 	return {_tag: "Read", override: {lane: lane.trim(), reason: reason.trim()}};
 };
+
+type PriorBuildRead =
+	| {readonly _tag: "Refused"; readonly outcome: VerbOutcome}
+	| {readonly _tag: "Read"; readonly notes: ReadonlyArray<string>};
+
+/**
+ * The gate a fresh build claim on an epic child clears: has this child already been built and graded?
+ *
+ * "No lane holds this number" and "this number has no reviewed build" are different facts, and the
+ * claim protocol only ever asked the first — so a child released after a `FAIL` was handed to the
+ * next lane as ordinary work and re-implemented from scratch, twice on epic #5631 (#6386). The
+ * second fact lives in the child's range-scoped verdict comments (`./range-verdicts.ts`), which is
+ * the only place it *can* live: a child opens no PR (ADR 0285).
+ *
+ * Both directions refuse, because both are a lane about to do the wrong work — one would rebuild
+ * over a graded artifact, the other would try to resume a branch no reviewer has ruled on. Neither
+ * refusal is overridable by `--override`, which admits an issue the *scope* fence barred; this is
+ * not a question about whether the issue is in scope.
+ */
+const readPriorBuild = (
+	repo: string,
+	number: number,
+	resume: boolean,
+	lines: ReadonlyArray<string>,
+): Effect.Effect<PriorBuildRead, never, ChildProcessSpawner.ChildProcessSpawner> =>
+	Effect.gen(function* () {
+		const listed = yield* listComments(repo, number);
+		if (listed._tag === "Failure") {
+			return {
+				_tag: "Refused" as const,
+				outcome: refuse(
+					PRECONDITION_UNKNOWN,
+					`${CLAIM}: cannot read the comments on #${number}: ${listed.reason} — whether it already carries a graded build is UNKNOWN, never "no"; nothing was written.`,
+					lines,
+				),
+			};
+		}
+		const read = readRangeVerdicts(listed.value);
+		const failed = failing(read);
+		const notes = [
+			`${CLAIM}: read ${listed.value.length} comment(s) on #${number}; ${read.standing.length} standing range verdict(s)${
+				read.standing.length === 0
+					? ""
+					: `: ${read.standing.map((v) => `${v.namespace} ${v.polarity}`).join(", ")}`
+			}.`,
+			...read.malformed.map(
+				(reason) =>
+					`${CLAIM}: a comment on #${number} reaches for a verdict marker and is not a range one — ${reason}`,
+			),
+		];
+		if (failed.length > 0 && !resume) {
+			return {
+				_tag: "Refused" as const,
+				outcome: refuse(
+					PRIOR_BUILD_MISMATCH,
+					`${CLAIM}: #${number} already carries a build a reviewer failed — ${failed
+						.map((v) => `${v.namespace} FAIL over ${v.range} (comment ${v.commentId})`)
+						.join(
+							"; ",
+						)}. A fresh build would re-implement it; run "fabrika build claim ${number} --resume" to take the repair lane instead, then "fabrika build branch ${number} --resume-lane --token <token>" to stand on the branch that build left. Nothing was written.`,
+					[...lines, ...notes],
+				),
+			};
+		}
+		if (failed.length === 0 && resume) {
+			return {
+				_tag: "Refused" as const,
+				outcome: refuse(
+					PRIOR_BUILD_MISMATCH,
+					`${CLAIM}: --resume says #${number} holds a build to repair, and no gate holds a standing FAIL over it — drop --resume and claim it as the fresh build it is. Nothing was written.`,
+					[...lines, ...notes],
+				),
+			};
+		}
+		return {
+			_tag: "Read" as const,
+			notes: resume
+				? [
+						...notes,
+						`${CLAIM}: resuming the build #${number} already carries — repair the ${failed
+							.map((v) => `${v.namespace} FAIL over ${v.range}`)
+							.join(
+								", ",
+							)} on the branch that build left ("fabrika build branch ${number} --resume-lane"), never a fresh one.`,
+					]
+				: notes,
+		};
+	});
 
 const preflight = (
 	verb: string,
@@ -352,6 +454,16 @@ export const runClaim = (
 				);
 			}
 			gateNotes.push(scannedLine(CLAIM, gate.scanned, "blocked_by edge", "none open"));
+
+			// Last of the three IO gates, and last for the same reason blockedness is second: it costs a
+			// comment page, and a number the pure axes already refused should never pay for it. Only a
+			// fresh build-purpose claim asks — `plan` and `gate` claim epics, and a repair claim names a
+			// PR, whose own verdicts `build verdicts` already folds.
+			if (purpose === "build" && repair._tag === "NotRepair") {
+				const prior = yield* readPriorBuild(repo, number, options.resume, lines);
+				if (prior._tag === "Refused") return prior.outcome;
+				gateNotes.push(...prior.notes);
+			}
 		}
 
 		const token = composeToken(session, options.uuid);

--- a/packages/fabrika-cli/src/build/claim-verb.unit.test.ts
+++ b/packages/fabrika-cli/src/build/claim-verb.unit.test.ts
@@ -12,6 +12,7 @@ import {
 	OFF_VOCABULARY,
 	OUT_OF_SCOPE,
 	PRECONDITION_UNKNOWN,
+	PRIOR_BUILD_MISMATCH,
 	READBACK_MISMATCH,
 	TYPE_NOT_BUILDABLE,
 	WRITE_UNKNOWN,
@@ -102,6 +103,7 @@ const options = {
 	override: null as string | null,
 	overrideLane: null as string | null,
 	cites: null as string | null,
+	resume: false,
 };
 
 const run = (
@@ -244,6 +246,7 @@ describe("runClaim", () => {
 		const out = await run(runClaim, [
 			[ISSUE, CLAIMABLE],
 			unclaimed(),
+			unclaimed(),
 			[POST, errOut("gh: Gateway timeout (HTTP 504)")],
 		]);
 		expect(out.code).toBe(WRITE_UNKNOWN);
@@ -260,6 +263,7 @@ describe("runClaim", () => {
 		const out = await run(runClaim, [
 			[ISSUE, CLAIMABLE],
 			unclaimed(),
+			unclaimed(),
 			[POST, POSTED],
 			[GET_COMMENT, okOut(JSON.stringify({body: "something else"}))],
 		]);
@@ -269,6 +273,7 @@ describe("runClaim", () => {
 	it("refuses an unreadable marker set on 11 — never 'unclaimed'", async () => {
 		const out = await run(runClaim, [
 			[ISSUE, CLAIMABLE],
+			unclaimed(),
 			unclaimed(),
 			[POST, POSTED],
 			[GET_COMMENT, ECHO],
@@ -1561,5 +1566,116 @@ describe("runClaim — the blockedness gate", () => {
 		);
 		expect(out.code).toBe(OUT_OF_SCOPE);
 		expect(shell.calls.some((line) => EDGES.test(line))).toBe(false);
+	});
+});
+
+/**
+ * The FAIL-then-respawn path (#6386): an epic child released after a `FAIL` was offered to the next
+ * lane as ordinary work, because "no lane holds this number" and "this number has no reviewed build"
+ * are different facts and the protocol only ever asked the first. It reproduced twice on epic #5631,
+ * each time costing a whole build lane and, on #6298, producing two divergent implementations of one
+ * criterion.
+ */
+describe("runClaim — the prior-build gate on an epic child", () => {
+	const RANGE =
+		"9f2c1ab4d5e6f708192a3b4c5d6e7f8091a2b3c4..03135b917283a4b5c6d7e8f90a1b2c3d4e5f6071";
+	const rangeVerdict = (polarity: string) =>
+		`review-code: ${polarity} range:${RANGE} content:2f1a9c4e0b7d — the child's range`;
+
+	it("refuses a fresh build claim on a child whose newest range verdict is FAIL", async () => {
+		const out = await run(runClaim, [
+			[ISSUE, CLAIMABLE],
+			unclaimed(),
+			[COMMENTS, comments({id: 8801, body: rangeVerdict("FAIL")})],
+		]);
+		expect(out.code).toBe(PRIOR_BUILD_MISMATCH);
+		expect(out.stderr.join("\n")).toContain("review-code FAIL over");
+		expect(out.stderr.join("\n")).toContain("comment 8801");
+		expect(out.stderr.join("\n")).toContain('"fabrika build claim 4312 --resume"');
+		expect(out.stderr.join("\n")).toContain("--resume-lane");
+	});
+
+	it("writes no marker when it refuses — the claim path leaves nothing to retract", async () => {
+		const shell = unblocked([
+			[ISSUE, CLAIMABLE],
+			unclaimed(),
+			[COMMENTS, comments({id: 8801, body: rangeVerdict("FAIL")})],
+		]);
+		await Effect.runPromise(
+			Effect.provide(runClaim(options), Layer.merge(shell.layer, NO_CAMPAIGNS.layer)),
+		);
+		expect(shell.calls.some((line) => POST.test(line))).toBe(false);
+	});
+
+	it("admits the claim under --resume, so the refusal points at a route that exists", async () => {
+		const out = await run(
+			runClaim,
+			[
+				[ISSUE, CLAIMABLE],
+				unclaimed(),
+				[once(COMMENTS), comments({id: 8801, body: rangeVerdict("FAIL")})],
+				[POST, POSTED],
+				[GET_COMMENT, ECHO],
+				[COMMENTS, comments({id: 9001, body: MINE})],
+				[perm("agent"), okOut("write\n")],
+			],
+			{resume: true},
+		);
+		expect(out.code).toBe(0);
+		expect(JSON.parse(out.stdout)).toMatchObject({answer: "won", purpose: "build"});
+		expect(out.stderr.join("\n")).toContain("--resume-lane");
+	});
+
+	it("refuses --resume on a child holding no standing FAIL — the flag is checked, not trusted", async () => {
+		const out = await run(
+			runClaim,
+			[
+				[ISSUE, CLAIMABLE],
+				unclaimed(),
+				[COMMENTS, comments({id: 8801, body: rangeVerdict("PASS")})],
+			],
+			{resume: true},
+		);
+		expect(out.code).toBe(PRIOR_BUILD_MISMATCH);
+		expect(out.stderr.join("\n")).toContain("drop --resume");
+	});
+
+	it("admits an ordinary fresh claim on a child whose verdicts all PASS", async () => {
+		const out = await run(runClaim, [
+			[ISSUE, CLAIMABLE],
+			unclaimed(),
+			[once(COMMENTS), comments({id: 8801, body: rangeVerdict("PASS")})],
+			[POST, POSTED],
+			[GET_COMMENT, ECHO],
+			[COMMENTS, comments({id: 9001, body: MINE})],
+			[perm("agent"), okOut("write\n")],
+		]);
+		expect(out.code).toBe(0);
+	});
+
+	it("refuses on 11 when the comments cannot be read — never 'no prior build'", async () => {
+		const out = await run(runClaim, [
+			[ISSUE, CLAIMABLE],
+			unclaimed(),
+			[COMMENTS, errOut("gh: Bad gateway (HTTP 502)")],
+		]);
+		expect(out.code).toBe(PRECONDITION_UNKNOWN);
+		expect(out.stderr.at(-1)).toContain('UNKNOWN, never "no"');
+	});
+
+	it("does not run for a plan-purpose claim — an epic is not a child", async () => {
+		const out = await run(
+			runClaim,
+			[
+				[ISSUE, issue({labels: labelled("type:epic", "p1", "status:triaged")})],
+				unclaimed(),
+				[POST, POSTED],
+				[GET_COMMENT, ECHO],
+				[COMMENTS, comments({id: 9001, body: MINE})],
+				[perm("agent"), okOut("write\n")],
+			],
+			{purpose: "plan"},
+		);
+		expect(out.code).toBe(0);
 	});
 });

--- a/packages/fabrika-cli/src/build/claim-verb.unit.test.ts
+++ b/packages/fabrika-cli/src/build/claim-verb.unit.test.ts
@@ -644,6 +644,20 @@ describe("runClaim — a PR number is judged by the issue it serves", () => {
 		expect(shell.calls.some((line) => POST.test(line))).toBe(false);
 	});
 
+	/**
+	 * The prior-build gate asks "has this child been built and graded", which a repair lane has
+	 * already answered by naming a PR — `build verdicts` folds that PR's own verdicts. So the gate
+	 * must not fire here: it would cost a comment page for nothing, and a PR thread carrying a range
+	 * marker or a broken one would refuse the very repair it was written to route to (#6386).
+	 */
+	it("never runs the prior-build gate on a PR target — repair has already answered its question", async () => {
+		const {out, shell} = await claimPull("Fixes #5553\n", served(44));
+		expect(out.code).toBe(0);
+		expect(out.stderr.join("\n")).not.toContain("standing range verdict");
+		// Two comment reads on the admitting path: the existing-claim scan, and the marker read-back.
+		expect(shell.calls.filter((line) => COMMENTS.test(line))).toHaveLength(2);
+	});
+
 	it("judges the audience on the served issue too, so a repair lane is not refused at 21", async () => {
 		const {out} = await claimPull(
 			"Fixes #5553\n",
@@ -1661,6 +1675,54 @@ describe("runClaim — the prior-build gate on an epic child", () => {
 		]);
 		expect(out.code).toBe(PRECONDITION_UNKNOWN);
 		expect(out.stderr.at(-1)).toContain('UNKNOWN, never "no"');
+	});
+
+	it("refuses on 11 when a comment reaches for a verdict marker and misses — never 'no prior build'", async () => {
+		const out = await run(runClaim, [
+			[ISSUE, CLAIMABLE],
+			unclaimed(),
+			[
+				COMMENTS,
+				comments({
+					id: 8802,
+					body: `review-code: FAIL range:${RANGE} — the child's range`,
+				}),
+			],
+		]);
+		// A FAIL missing its content binding is still a reviewer saying no. Counting it and admitting
+		// the claim anyway would read a broken verdict as "the reviewer never ran" (#6386, criterion 6).
+		expect(out.code).toBe(PRECONDITION_UNKNOWN);
+		expect(out.stderr.join("\n")).toContain('UNKNOWN, never "no prior build"');
+		expect(out.stderr.join("\n")).toContain("#8802");
+	});
+
+	it("refuses a malformed marker under --resume too — the flag cannot read what the gate cannot", async () => {
+		const out = await run(
+			runClaim,
+			[
+				[ISSUE, CLAIMABLE],
+				unclaimed(),
+				[
+					COMMENTS,
+					comments({id: 8803, body: "review-code: SHIPPED range:x..y content:2f1a9c4e0b7d — ?"}),
+				],
+			],
+			{resume: true},
+		);
+		expect(out.code).toBe(PRECONDITION_UNKNOWN);
+	});
+
+	it("leaves ordinary discussion alone — only a gate-namespace first line can be malformed", async () => {
+		const out = await run(runClaim, [
+			[ISSUE, CLAIMABLE],
+			unclaimed(),
+			[once(COMMENTS), comments({id: 8804, body: "note: this range looks wrong to me"})],
+			[POST, POSTED],
+			[GET_COMMENT, ECHO],
+			[COMMENTS, comments({id: 9001, body: MINE})],
+			[perm("agent"), okOut("write\n")],
+		]);
+		expect(out.code).toBe(0);
 	});
 
 	it("does not run for a plan-purpose claim — an epic is not a child", async () => {

--- a/packages/fabrika-cli/src/build/codes.ts
+++ b/packages/fabrika-cli/src/build/codes.ts
@@ -156,3 +156,17 @@ export const LOCAL_LANE_UNWRITTEN = 29;
  * re-label a decision `ready-for:agent` would satisfy `21` and still be building the wrong artifact.
  */
 export const TYPE_NOT_BUILDABLE = 30;
+/**
+ * Proven: the claim's mode and the child's standing range verdict disagree (#6386).
+ *
+ * Two directions, one seat, because one fact is established either way — *this number's build state
+ * is not what the claim says it is* — and the remedy is the same act in both: re-run the claim in the
+ * mode the board already recorded, adding `--resume` on a child holding a `FAIL`, dropping it on one
+ * holding none. That is unlike every neighbouring seat: `20`/`21`/`30` are about whether an issue
+ * may be built at all, and this one is about whether it has been built already.
+ *
+ * Never {@link PRECONDITION_UNKNOWN}: the comments were read in full and the standing verdicts folded,
+ * so the refusal is a fact about the child. A read that *failed* stays `11`, and a fence that could
+ * not read its input must never resolve to "no prior build".
+ */
+export const PRIOR_BUILD_MISMATCH = 31;

--- a/packages/fabrika-cli/src/build/command.ts
+++ b/packages/fabrika-cli/src/build/command.ts
@@ -20,11 +20,12 @@ import {leafCommand} from "../excess-operand.ts";
 import {readFile} from "../io/fs.ts";
 import {readStdin} from "../io/stdin.ts";
 import {DEFAULT_LANES_ROOT} from "../lane/store.ts";
-import type {VerbOutcome} from "../verb.ts";
+import {refuse, type VerbOutcome} from "../verb.ts";
 import {runBranch} from "./branch-verb.ts";
 import {runCheck} from "./check-verb.ts";
 import {runAdopt, runClaim, runConfirm, runRelease} from "./claim-verb.ts";
 import {type DocumentRead, runClear} from "./clear-verb.ts";
+import {OFF_VOCABULARY} from "./codes.ts";
 import {runCommit} from "./commit-verb.ts";
 import {runEligible} from "./eligible-verb.ts";
 import {runIssue} from "./issue-verb.ts";
@@ -43,7 +44,7 @@ import {
 } from "./scope-admission.ts";
 import {runScratch} from "./scratch-verb.ts";
 import {runTree} from "./tree-verb.ts";
-import {runVerdicts} from "./verdicts-verb.ts";
+import {runChildVerdicts, runVerdicts} from "./verdicts-verb.ts";
 
 /** Write the outcome and exit on its code — stdout is the answer, everything else is stderr. */
 const emit = (outcome: VerbOutcome): Effect.Effect<void> =>
@@ -176,9 +177,14 @@ const claim = leafCommand(
 				`the founder ruling comment this build transcribes, as ${CITATION_GRAMMAR} — the type axis's one arm, and only on a ${DECISION_TYPE_LABEL}`,
 			),
 		),
+		resume: Flag.boolean("resume").pipe(
+			Flag.withDescription(
+				"take the repair lane of an epic child that already carries a standing range FAIL, rather than building it fresh; refused on a child holding no such FAIL, exactly as its absence is refused on one that does",
+			),
+		),
 		repo: repoFlag,
 	},
-	Effect.fn(function* ({number, token, purpose, override, overrideLane, cites, repo}) {
+	Effect.fn(function* ({number, token, purpose, override, overrideLane, cites, resume, repo}) {
 		yield* emit(
 			yield* runClaim({
 				number,
@@ -191,13 +197,14 @@ const claim = leafCommand(
 				override: Option.getOrNull(override),
 				overrideLane: Option.getOrNull(overrideLane),
 				cites: Option.getOrNull(cites),
+				resume,
 			}),
 		);
 	}),
 ).pipe(
 	Command.withShortDescription("Race the claim marker on an issue and win it or name the winner."),
 	Command.withDescription(
-		`Race the earliest AUTHORIZED claim marker on an issue: post this session's token (build:<CLAUDE_CODE_SESSION_ID>:<uuid>), re-read, and win or name the winner. Authorization is the author's repository permission (ADR 0055) — marker text confers nothing. The admission test runs FIRST, before any marker is written, so a refused claim leaves no trace to retract. --purpose says why this lane claims (${CLAIM_PURPOSES.join(" | ")}, default ${DEFAULT_CLAIM_PURPOSE}): the audience axis (${READY_FOR_AGENT}) binds a build claim only, because an epic earns that label AFTER it is planned and gated (#5175); the scope axis binds every purpose, and an off-enum --purpose refuses on 10 rather than falling back. --override "<reason>" admits a proven refusal and REQUIRES --override-lane "<lane>"; both are recorded on the marker, and an UNKNOWN admission is never overridable. The type axis binds a build claim against an ISSUE only, so ${DECISION_TYPE_LABEL} and ${EPIC_TYPE_LABEL} refuse before any marker is written; --cites ${CITATION_GRAMMAR} opens it on a decision whose choice a founder already recorded on that issue, and the URL must name this repository and the issue being judged. It is not an override: it says the refusal does not apply, and it is never accepted for an epic. Prints {"answer":"won","number":n,"token":"…","purpose":"…"}, plus "override":{"lane","reason"} when one was used and "cites" when a ruling was cited. --token makes the re-claim idempotent per LANE: handed the token this lane already holds, a number that lane already owns answers won with that same marker and writes nothing (#5782), while a same-session marker under another nonce is a sibling lane and races normally. A lost race retracts this run's own marker and exits 15, never 0 — including when the winner is another lane of THIS session, since ownership turns on the whole token and never the session id (#6037); an unset CLAUDE_CODE_SESSION_ID, a --token that is not a claim token of this session, an empty --override reason, an --override with no lane, or an --override-lane with no override, is 1. After the admission test, and only against an ISSUE, a blockedness gate reads the native blocked_by graph (ADR 0301): a number with any blocker still open refuses on 16 naming every one of them, and an edge list that could not be read is 11 — never "not blocked". It is not overridable, because the remedy is waiting rather than an edit. Exits 7 (issue proven absent or closed), 8 (the marker write failed — UNKNOWN; run confirm), 9 (the marker landed but does not read back), 10 (--purpose is off-enum), 15 (proven lost), 16 (proven blocked), and from the admission test: ${admissionExits}. Example: fabrika build claim 4312 --purpose gate`,
+		`Race the earliest AUTHORIZED claim marker on an issue: post this session's token (build:<CLAUDE_CODE_SESSION_ID>:<uuid>), re-read, and win or name the winner. Authorization is the author's repository permission (ADR 0055) — marker text confers nothing. The admission test runs FIRST, before any marker is written, so a refused claim leaves no trace to retract. --purpose says why this lane claims (${CLAIM_PURPOSES.join(" | ")}, default ${DEFAULT_CLAIM_PURPOSE}): the audience axis (${READY_FOR_AGENT}) binds a build claim only, because an epic earns that label AFTER it is planned and gated (#5175); the scope axis binds every purpose, and an off-enum --purpose refuses on 10 rather than falling back. --override "<reason>" admits a proven refusal and REQUIRES --override-lane "<lane>"; both are recorded on the marker, and an UNKNOWN admission is never overridable. The type axis binds a build claim against an ISSUE only, so ${DECISION_TYPE_LABEL} and ${EPIC_TYPE_LABEL} refuse before any marker is written; --cites ${CITATION_GRAMMAR} opens it on a decision whose choice a founder already recorded on that issue, and the URL must name this repository and the issue being judged. It is not an override: it says the refusal does not apply, and it is never accepted for an epic. Prints {"answer":"won","number":n,"token":"…","purpose":"…"}, plus "override":{"lane","reason"} when one was used and "cites" when a ruling was cited. --token makes the re-claim idempotent per LANE: handed the token this lane already holds, a number that lane already owns answers won with that same marker and writes nothing (#5782), while a same-session marker under another nonce is a sibling lane and races normally. A lost race retracts this run's own marker and exits 15, never 0 — including when the winner is another lane of THIS session, since ownership turns on the whole token and never the session id (#6037); an unset CLAUDE_CODE_SESSION_ID, a --token that is not a claim token of this session, an empty --override reason, an --override with no lane, or an --override-lane with no override, is 1. After the admission test, and only against an ISSUE, a blockedness gate reads the native blocked_by graph (ADR 0301): a number with any blocker still open refuses on 16 naming every one of them, and an edge list that could not be read is 11 — never "not blocked". It is not overridable, because the remedy is waiting rather than an edit. Then, on a fresh build-purpose claim only, a prior-build gate reads the number's range-scoped verdict comments — where an epic child's review lands, since a child opens no PR (ADR 0285/0276): a child whose newest verdict in any gate is FAIL refuses on 31 naming that FAIL and pointing at "--resume", and --resume on a child holding no standing FAIL refuses on 31 too. Unreadable comments are 11, never "no prior build", and neither direction is overridable — --override admits a scope refusal, and this is not one. Exits 7 (issue proven absent or closed), 8 (the marker write failed — UNKNOWN; run confirm), 9 (the marker landed but does not read back), 10 (--purpose is off-enum), 15 (proven lost), 16 (proven blocked), 31 (the claim's mode and the child's standing verdict disagree), and from the admission test: ${admissionExits}. Example: fabrika build claim 4312 --purpose gate`,
 	),
 );
 
@@ -261,16 +268,22 @@ const branch = leafCommand(
 				"repair mode: a PR number whose head branch to publish back to; exclusive with <number>",
 			),
 		),
+		resumeLane: Flag.boolean("resume-lane").pipe(
+			Flag.withDescription(
+				"child-repair mode: take over the local branch a prior lane built <number> on, re-keyed to this claim's nonce; for an epic child, which opens no PR — takes no --slug and is exclusive with --resume",
+			),
+		),
 		token: tokenFlag,
 		repo: repoFlag,
 	},
-	Effect.fn(function* ({number, slug, base, resume, token, repo}) {
+	Effect.fn(function* ({number, slug, base, resume, resumeLane, token, repo}) {
 		yield* emit(
 			yield* runBranch({
 				number: Option.getOrNull(number),
 				slug: Option.getOrNull(slug),
 				base,
 				resume: Option.getOrNull(resume),
+				resumeLane,
 				token,
 				repo: Option.getOrNull(repo),
 				env: process.env,
@@ -280,7 +293,7 @@ const branch = leafCommand(
 ).pipe(
 	Command.withShortDescription("Cut or resume the lane's branch off a freshly fetched base."),
 	Command.withDescription(
-		"Cut (or resume) the lane's nonce branch off a FRESHLY FETCHED base, never a stale local ref. Prints the checked-out branch name: build/<number>-<slug>-<nonce> in create mode, build/pr-<pr>-<nonce> in resume mode, where <nonce> is the first 8 hex of --token's UUID — the token THIS lane holds, proven against the live claim before the name is composed, so a lane cannot cut a branch on a nonce that holds nothing (#6037). The branch name IS the lane record — there is no stamp file. Exits 1 (--token is not a claim token of this session), 7 (--resume's PR is proven absent, closed or merged), 10 (--slug is not kebab-case, exceeds 5 words, or is flag-shaped), 11 (the fetch failed, or the tree root or claim state could not be read), 15 (proven: the claim is held by another lane). Example: fabrika build branch 4312 --slug editor-focus-loss --token build:s-9f2e:c1a4d6f8-…",
+		"Cut (or resume) the lane's nonce branch off a FRESHLY FETCHED base, never a stale local ref. Prints the checked-out branch name: build/<number>-<slug>-<nonce> in create mode, build/pr-<pr>-<nonce> in resume mode, where <nonce> is the first 8 hex of --token's UUID — the token THIS lane holds, proven against the live claim before the name is composed, so a lane cannot cut a branch on a nonce that holds nothing (#6037). The branch name IS the lane record — there is no stamp file. --resume-lane is resume mode for an epic child, which opens no PR (ADR 0285): it finds the one local branch this grammar says was cut for <number>, RE-KEYS it to this claim's nonce and checks it out, so the child's commits carry forward and exactly one branch keeps naming it — cutting a second is the underivable range lane prove refuses on (#6386). It fetches nothing, takes no --slug, and re-keys nothing when the name already matches. Exits 1 (--token is not a claim token of this session), 7 (--resume's PR is proven absent, closed or merged, or --resume-lane found no local branch cut for <number>), 10 (--slug is not kebab-case, exceeds 5 words, or is flag-shaped, or --resume-lane was combined with --resume or --slug), 11 (the fetch failed, the tree root or claim state could not be read, or --resume-lane found several candidate branches or could not re-key the one it found — the prior lane's worktree is likely still on it, which only an operator can release), 15 (proven: the claim is held by another lane). Example: fabrika build branch 4312 --slug editor-focus-loss --token build:s-9f2e:c1a4d6f8-…",
 	),
 );
 
@@ -491,17 +504,43 @@ const verdicts = leafCommand(
 	"verdicts",
 	{
 		pr: Flag.integer("pr").pipe(
+			Flag.optional,
 			Flag.withDescription("the pull request whose verdict state is folded"),
+		),
+		issue: Flag.integer("issue").pipe(
+			Flag.optional,
+			Flag.withDescription(
+				"the epic child whose range-scoped verdicts are folded; it opens no PR, so its verdicts live on the issue — exclusive with --pr",
+			),
 		),
 		repo: repoFlag,
 	},
-	Effect.fn(function* ({pr: number, repo}) {
-		yield* emit(yield* runVerdicts({pr: number, repo: Option.getOrNull(repo), env: process.env}));
+	Effect.fn(function* ({pr, issue, repo}) {
+		const number = Option.getOrNull(pr);
+		const child = Option.getOrNull(issue);
+		if ((number === null) === (child === null)) {
+			yield* emit(
+				refuse(
+					OFF_VOCABULARY,
+					"build verdicts: give either --pr <n> or --issue <n>, never both and never neither.",
+				),
+			);
+			return;
+		}
+		yield* emit(
+			number === null
+				? yield* runChildVerdicts({
+						issue: child as number,
+						repo: Option.getOrNull(repo),
+						env: process.env,
+					})
+				: yield* runVerdicts({pr: number, repo: Option.getOrNull(repo), env: process.env}),
+		);
 	}),
 ).pipe(
 	Command.withShortDescription("The latest gate verdict per namespace at a PR's live head."),
 	Command.withDescription(
-		'The paginated, current-head, per-gate verdict fold on a PR: every comment and every review, the latest marker per gate namespace bound to the live head, native reviews as their OWN row kind (never coerced), the per-head FAIL round count, capReached, and the criteria frozen after round 2. Prints one JSON object with head, rows, rounds, capReached and frozenCriteria; {"rows":[]} on exit 0 is a proven "no verdicts", readable against the scope line. A stale marker prints as stale, never dropped. Exits 7 (PR proven absent or closed), 11 (the head, any comment page or any review page could not be read — UNKNOWN, never "none"). Example: fabrika build verdicts --pr 4310',
+		'The paginated, current-head, per-gate verdict fold on a PR: every comment and every review, the latest marker per gate namespace bound to the live head, native reviews as their OWN row kind (never coerced), the per-head FAIL round count, capReached, and the criteria frozen after round 2. Prints one JSON object with head, rows, rounds, capReached and frozenCriteria; {"rows":[]} on exit 0 is a proven "no verdicts", readable against the scope line. A stale marker prints as stale, never dropped. --issue <n> folds an epic child instead, whose verdicts are range-bound comments on the issue because a child opens no PR (ADR 0285/0276): each row names the range it was formed over rather than a head, a round is one graded tip, and clearances are empty with the reason on stderr — a clearance is recorded against a PR\'s base branch, and a child has none. Exits 7 (PR or issue proven absent or closed, or --issue names a PR), 10 (neither or both of --pr and --issue), 11 (the head, any comment page or any review page could not be read — UNKNOWN, never "none"). Example: fabrika build verdicts --pr 4310',
 	),
 );
 

--- a/packages/fabrika-cli/src/build/git.ts
+++ b/packages/fabrika-cli/src/build/git.ts
@@ -75,6 +75,20 @@ export const switchToNew = (name: string, start: string): Shell<Attempt<void>> =
 		return r.ok ? ok(undefined) : fail(r.reason);
 	});
 
+/**
+ * Re-key an existing local branch to a new name — how a repair lane takes over an epic child's branch.
+ *
+ * Renaming rather than cutting a second branch off the first is the whole point: two branches
+ * carrying one child's commits is what `lane prove` reports as an underivable range, and that
+ * refusal is unresolvable from inside a worktree (#6386). git refuses when the branch is checked out
+ * elsewhere, which is the honest answer — the prior lane's worktree is still standing on it.
+ */
+export const renameBranch = (from: string, to: string): Shell<Attempt<void>> =>
+	Effect.gen(function* () {
+		const r = yield* execCapture("git", ["branch", "-m", from, to]);
+		return r.ok ? ok(undefined) : fail(r.reason);
+	});
+
 /** Point a local branch's upstream at `<remote>/<ref>` — how resume mode publishes to the PR's head. */
 export const setUpstream = (name: string, remote: string, ref: string): Shell<Attempt<void>> =>
 	Effect.gen(function* () {

--- a/packages/fabrika-cli/src/build/git.ts
+++ b/packages/fabrika-cli/src/build/git.ts
@@ -80,14 +80,55 @@ export const switchToNew = (name: string, start: string): Shell<Attempt<void>> =
  *
  * Renaming rather than cutting a second branch off the first is the whole point: two branches
  * carrying one child's commits is what `lane prove` reports as an underivable range, and that
- * refusal is unresolvable from inside a worktree (#6386). git refuses when the branch is checked out
- * elsewhere, which is the honest answer — the prior lane's worktree is still standing on it.
+ * refusal is unresolvable from inside a worktree (#6386).
+ *
+ * **It does not refuse a branch another worktree has checked out**, which is the trap the caller
+ * guards with {@link worktreeCheckouts}: `git branch -m` exits 0 there and silently retargets that
+ * worktree's `HEAD` to the new name — only the `git switch` afterwards fails, by which point the
+ * rename has already landed under a lane that is not this one. Measured against git 2.40.1 rather
+ * than reasoned about (#6386, review round 1).
  */
 export const renameBranch = (from: string, to: string): Shell<Attempt<void>> =>
 	Effect.gen(function* () {
 		const r = yield* execCapture("git", ["branch", "-m", from, to]);
 		return r.ok ? ok(undefined) : fail(r.reason);
 	});
+
+/** One worktree of this repo, and the branch it holds checked out. */
+export interface WorktreeCheckout {
+	readonly path: string;
+	readonly branch: string;
+}
+
+/**
+ * Every worktree of this repo that holds a branch, paired with the branch it holds.
+ *
+ * The proof {@link renameBranch} needs and cannot make for itself. A detached worktree contributes
+ * no row: it holds no branch name, so it can collide with none.
+ */
+export const worktreeCheckouts: Shell<Attempt<ReadonlyArray<WorktreeCheckout>>> = Effect.gen(
+	function* () {
+		const r = yield* execCapture("git", ["worktree", "list", "--porcelain"]);
+		if (!r.ok) return fail(r.reason);
+		const held: Array<WorktreeCheckout> = [];
+		let path = "";
+		for (const line of r.stdout.split("\n")) {
+			if (line.startsWith("worktree ")) path = line.slice("worktree ".length).trim();
+			else if (line.startsWith("branch refs/heads/") && path !== "") {
+				held.push({path, branch: line.slice("branch refs/heads/".length).trim()});
+			}
+		}
+		return ok(held);
+	},
+);
+
+/** The branch this tree holds, or `null` when its HEAD is detached. */
+export const currentBranch: Shell<Attempt<string | null>> = Effect.gen(function* () {
+	const r = yield* execCapture("git", ["branch", "--show-current"]);
+	if (!r.ok) return fail(r.reason);
+	const name = r.stdout.trim();
+	return ok(name === "" ? null : name);
+});
 
 /** Point a local branch's upstream at `<remote>/<ref>` — how resume mode publishes to the PR's head. */
 export const setUpstream = (name: string, remote: string, ref: string): Shell<Attempt<void>> =>

--- a/packages/fabrika-cli/src/build/lane.ts
+++ b/packages/fabrika-cli/src/build/lane.ts
@@ -98,6 +98,22 @@ export const parseLaneBranch = (name: string): LaneBranch | null => {
 export const laneNumber = (lane: LaneBranch): number =>
 	lane._tag === "Create" ? lane.number : lane.pr;
 
+/**
+ * The local branches this grammar says were cut for one issue's build — every reader's one source.
+ *
+ * It lives beside the grammar rather than beside its callers because there are now three of them —
+ * `lane prove`'s range read, `lane brief`'s, and `build branch --resume-lane` — and a second filter
+ * spelled from the same regex is how one of them comes to see a branch the others do not.
+ */
+export const childLaneBranches = (
+	issue: number,
+	branches: ReadonlyArray<string>,
+): ReadonlyArray<string> =>
+	branches.filter((name) => {
+		const lane = parseLaneBranch(name);
+		return lane !== null && lane._tag === "Create" && lane.number === issue;
+	});
+
 export const createBranchName = (number: number, slug: string, nonce: string): string =>
 	`build/${number}-${slug}-${nonce}`;
 

--- a/packages/fabrika-cli/src/build/range-verdicts.ts
+++ b/packages/fabrika-cli/src/build/range-verdicts.ts
@@ -1,0 +1,74 @@
+/**
+ * Whether an epic child already carries a reviewed build — the fact the claim path could not see.
+ *
+ * An epic child opens no pull request (ADR 0285), so its review lands as range-bound comments on the
+ * child issue itself (ADR 0276) — the one surface neither `build eligible` (which reads the
+ * `blocked_by` graph) nor `build claim` (which reads claim markers) ever looked at. A child whose
+ * newest verdict was `FAIL` therefore passed both gates and was handed to a fresh lane as ordinary
+ * work, which built a second, independent implementation of a criterion the FAIL already named
+ * (#6386, reproduced on #6296 and #6298).
+ *
+ * The fold is `lane prove`'s, deliberately: newest write stamp wins per namespace, so a `FAIL`
+ * upserted after a `PASS` still wins (#4200). What it does **not** do is ask whether the claim still
+ * binds. That question needs the range's content digest, which needs the child's branch in this tree
+ * (`../lane/range.ts`), and a claim has no tree yet — but more than that, staleness is the wrong
+ * question here. "Does this verdict still bind" is what a repair lane asks before it re-reviews;
+ * "has this child been built and reviewed at all" is what a *fresh* claim asks, and a stale `FAIL`
+ * answers that one yes.
+ *
+ * A comment reaching for the range format and missing it is counted, never dropped: a verdict posted
+ * in a broken format is the one failure that would otherwise present as "the reviewer never ran".
+ */
+
+import type {CommentRecord} from "../io/issues.ts";
+import type {Polarity} from "../wire/marker-line.ts";
+import {read as readMarker, renderRange} from "../wire/range-verdict-marker.ts";
+
+/** One namespace's newest range-scoped verdict claim on a child issue. */
+export interface RangeVerdict {
+	readonly namespace: string;
+	readonly polarity: Polarity;
+	readonly commentId: number;
+	/** The `<base>..<tip>` the verdict was formed over, as the marker spells it. */
+	readonly range: string;
+}
+
+/** What a child's comment thread says about it — the standing verdicts, and the markers that broke. */
+export interface RangeVerdictRead {
+	/** Newest-per-namespace, ordered by namespace so a refusal names them the same way every run. */
+	readonly standing: ReadonlyArray<RangeVerdict>;
+	/** `#<comment id>: <why>` per body that reaches for a range marker and is not one. */
+	readonly malformed: ReadonlyArray<string>;
+}
+
+export const readRangeVerdicts = (comments: ReadonlyArray<CommentRecord>): RangeVerdictRead => {
+	const latest = new Map<string, RangeVerdict>();
+	const stamps = new Map<string, string>();
+	const malformed: string[] = [];
+	for (const comment of comments) {
+		const parsed = readMarker(comment.body);
+		if (parsed._tag === "Malformed") {
+			malformed.push(`#${comment.id}: ${parsed.reason}`);
+			continue;
+		}
+		if (parsed._tag !== "Found") continue;
+		const marker = parsed.value;
+		const seen = stamps.get(marker.namespace);
+		if (seen !== undefined && seen > comment.updatedAt) continue;
+		stamps.set(marker.namespace, comment.updatedAt);
+		latest.set(marker.namespace, {
+			namespace: marker.namespace,
+			polarity: marker.polarity,
+			commentId: comment.id,
+			range: renderRange(marker.range),
+		});
+	}
+	return {
+		standing: [...latest.values()].sort((a, b) => a.namespace.localeCompare(b.namespace)),
+		malformed,
+	};
+};
+
+/** The standing verdicts a fresh build claim must not build over. */
+export const failing = (read: RangeVerdictRead): ReadonlyArray<RangeVerdict> =>
+	read.standing.filter((verdict) => verdict.polarity === "FAIL");

--- a/packages/fabrika-cli/src/build/range-verdicts.ts
+++ b/packages/fabrika-cli/src/build/range-verdicts.ts
@@ -16,8 +16,12 @@
  * "has this child been built and reviewed at all" is what a *fresh* claim asks, and a stale `FAIL`
  * answers that one yes.
  *
- * A comment reaching for the range format and missing it is counted, never dropped: a verdict posted
- * in a broken format is the one failure that would otherwise present as "the reviewer never ran".
+ * A comment reaching for the range format and missing it is reported separately, never dropped and
+ * never folded into `standing`: a verdict posted in a broken format is the one failure that would
+ * otherwise present as "the reviewer never ran". Reporting it is all this module does — the claim
+ * path refuses on it (`./claim-verb.ts`), because a gate that counted the break and then admitted
+ * the claim anyway would resolve unreadable to "no prior build", which is that same failure wearing
+ * a stderr line.
  */
 
 import type {CommentRecord} from "../io/issues.ts";

--- a/packages/fabrika-cli/src/build/range-verdicts.unit.test.ts
+++ b/packages/fabrika-cli/src/build/range-verdicts.unit.test.ts
@@ -1,0 +1,77 @@
+import {describe, expect, it} from "vitest";
+import type {CommentRecord} from "../io/issues.ts";
+import {failing, readRangeVerdicts} from "./range-verdicts.ts";
+
+const BASE = "9f2c1ab4d5e6f708192a3b4c5d6e7f8091a2b3c4";
+const TIP = "03135b917283a4b5c6d7e8f90a1b2c3d4e5f6071";
+const LATER_TIP = "5c6d7e8f90a1b2c3d4e5f60718293a4b5c6d7e8f";
+const DIGEST = "2f1a9c4e0b7d";
+
+const marker = (namespace: string, polarity: string, tip = TIP) =>
+	`${namespace}: ${polarity} range:${BASE}..${tip} content:${DIGEST} — read it`;
+
+const comment = (id: number, body: string, updatedAt = "2026-08-19T12:00:00Z"): CommentRecord => ({
+	id,
+	author: "a-gate",
+	createdAt: updatedAt,
+	updatedAt,
+	body,
+});
+
+describe("readRangeVerdicts folds a child issue's range verdicts", () => {
+	it("answers no standing verdict on a thread that carries none", () => {
+		const read = readRangeVerdicts([comment(1, "just a note")]);
+		expect(read.standing).toEqual([]);
+		expect(read.malformed).toEqual([]);
+		expect(failing(read)).toEqual([]);
+	});
+
+	it("keeps the newest write per namespace, so a FAIL upserted after a PASS wins (#4200)", () => {
+		const read = readRangeVerdicts([
+			comment(1, marker("review-code", "PASS"), "2026-08-19T12:00:00Z"),
+			comment(2, marker("review-code", "FAIL"), "2026-08-19T12:30:00Z"),
+		]);
+		expect(read.standing).toEqual([
+			{namespace: "review-code", polarity: "FAIL", commentId: 2, range: `${BASE}..${TIP}`},
+		]);
+	});
+
+	it("keeps the newest write per namespace when the PASS is the later one", () => {
+		const read = readRangeVerdicts([
+			comment(1, marker("review-code", "FAIL"), "2026-08-19T12:00:00Z"),
+			comment(2, marker("review-code", "PASS", LATER_TIP), "2026-08-19T12:30:00Z"),
+		]);
+		expect(failing(read)).toEqual([]);
+	});
+
+	/** #6296's shape: one gate failed the child while another passed it, and the FAIL is what stands. */
+	it("reports a FAIL in one namespace beside a PASS in another", () => {
+		const read = readRangeVerdicts([
+			comment(1, marker("governance", "PASS")),
+			comment(2, marker("review-code", "FAIL")),
+		]);
+		expect(read.standing.map((row) => `${row.namespace} ${row.polarity}`)).toEqual([
+			"governance PASS",
+			"review-code FAIL",
+		]);
+		expect(failing(read).map((row) => row.namespace)).toEqual(["review-code"]);
+	});
+
+	it("counts a body reaching for the format and missing it, never drops it", () => {
+		const read = readRangeVerdicts([
+			comment(1, "review-code: FAIL @ 03135b91 — a PR-scoped marker on a child issue"),
+		]);
+		expect(read.standing).toEqual([]);
+		expect(read.malformed).toHaveLength(1);
+		expect(read.malformed[0]).toContain("#1:");
+	});
+
+	/**
+	 * A verdict formed over a range the branch has since moved past is stale, and staleness is not
+	 * this reader's question: a fresh claim asks whether the child was built and graded at all.
+	 */
+	it("stands a FAIL over an older range — a graded build is a graded build", () => {
+		const read = readRangeVerdicts([comment(1, marker("review-code", "FAIL", LATER_TIP))]);
+		expect(failing(read).map((row) => row.range)).toEqual([`${BASE}..${LATER_TIP}`]);
+	});
+});

--- a/packages/fabrika-cli/src/build/verdicts-verb.ts
+++ b/packages/fabrika-cli/src/build/verdicts-verb.ts
@@ -26,13 +26,15 @@ import {getIssue, listComments} from "../io/issues.ts";
 import {CAP_ROUND} from "../retry-budget.ts";
 import {answer, refuse, type VerbOutcome} from "../verb.ts";
 import {read as readCriteria} from "../wire/acceptance-criteria.ts";
+import {read as readRangeMarker} from "../wire/range-verdict-marker.ts";
 import {bindToHead, read as readMarker} from "../wire/verdict-marker.ts";
 import {clearancesOn, grantedFrom} from "./clearances.ts";
-import {PRECONDITION_UNKNOWN} from "./codes.ts";
+import {PRECONDITION_UNKNOWN, ZERO_SCOPE} from "./codes.ts";
 import {contentOf, gate} from "./content-gate.ts";
 import {listReviews} from "./github.ts";
 import {closingTargets, proseOf} from "./pr-body.ts";
-import {roundsOn} from "./rounds.ts";
+import {readRangeVerdicts} from "./range-verdicts.ts";
+import {countRounds, roundsOn} from "./rounds.ts";
 import {openPull, resolveTargetRepo} from "./target.ts";
 
 const VERB = "build verdicts";
@@ -42,6 +44,13 @@ const PROVENANCE_RE = /<!--\s*ac:review\s+pr:#(\d+)\s+round:(\d+)\s*-->/;
 
 export interface VerdictsOptions {
 	readonly pr: number;
+	readonly repo: string | null;
+	readonly env: Readonly<Record<string, string | undefined>>;
+}
+
+export interface ChildVerdictsOptions {
+	/** The epic child issue whose range-scoped verdicts are folded — it opens no PR (ADR 0285). */
+	readonly issue: number;
 	readonly repo: string | null;
 	readonly env: Readonly<Record<string, string | undefined>>;
 }
@@ -151,6 +160,91 @@ export const runVerdicts = (
 			[
 				`${VERB}: head ${head}; scanned ${listed.value.length} comment(s) and ${reviews.value.length} review(s) on #${pr}.`,
 				`${VERB}: ${capNote(granted)}, from ${cleared.rows.length} marker(s).`,
+			],
+		);
+	});
+
+/**
+ * The same fold asked of an epic child, whose verdicts are range-bound comments on the issue itself.
+ *
+ * It exists because the repair route has to be walkable: `build claim --resume` refuses a fresh build
+ * over a child's standing `FAIL`, and a lane sent to repair needs the findings through a verb rather
+ * than a raw fetch (#6386). The rows carry the range each verdict was formed over instead of a head,
+ * and a round is one graded tip — the range analogue of one graded head, folded through the same
+ * `countRounds`.
+ *
+ * **It reports no clearance, and says so.** A cap clearance is recorded against a PR's base branch
+ * (`./clearances.ts`), and a child has no PR — so the budget here is the declared cap, unmodified,
+ * and a lane that needs another round escalates to the operator rather than reading a grant that has
+ * nowhere to live.
+ */
+export const runChildVerdicts = (
+	options: ChildVerdictsOptions,
+): Effect.Effect<VerbOutcome, never, ChildProcessSpawner.ChildProcessSpawner> =>
+	Effect.gen(function* () {
+		const {issue} = options;
+		const resolved = yield* resolveTargetRepo(VERB, options.repo, options.env);
+		if (resolved._tag === "Refused") return resolved.outcome;
+		const repo = resolved.repo;
+
+		const target = yield* getIssue(repo, issue);
+		if (target._tag === "Unknown") {
+			return refuse(
+				PRECONDITION_UNKNOWN,
+				`${VERB}: cannot read #${issue}: ${target.reason} — the verdict state is UNKNOWN, never "none".`,
+			);
+		}
+		if (target._tag === "Absent") {
+			return refuse(ZERO_SCOPE, `${VERB}: #${issue} is proven absent in ${repo}.`);
+		}
+		if (target.value.isPullRequest) {
+			return refuse(
+				ZERO_SCOPE,
+				`${VERB}: #${issue} is a pull request — its verdicts are head-bound; drop --issue and pass --pr.`,
+			);
+		}
+
+		const listed = yield* listComments(repo, issue);
+		if (listed._tag === "Failure") {
+			return refuse(
+				PRECONDITION_UNKNOWN,
+				`${VERB}: cannot read the comments on #${issue} (page 1): ${listed.reason} — the verdict state is UNKNOWN, never "none".`,
+			);
+		}
+
+		const byId = new Map(listed.value.map((comment) => [comment.id, comment]));
+		const read = readRangeVerdicts(listed.value);
+		const rows = read.standing.map((verdict) => ({
+			gate: verdict.namespace,
+			polarity: verdict.polarity,
+			range: verdict.range,
+			commentId: verdict.commentId,
+			kind: "range-marker" as const,
+			body: contentOf(
+				gate(
+					"comment-body",
+					`comment ${verdict.commentId}`,
+					byId.get(verdict.commentId)?.body ?? "",
+				),
+			),
+		}));
+		const rounds = countRounds(
+			listed.value.flatMap((comment) => {
+				const parsed = readRangeMarker(comment.body);
+				return parsed._tag === "Found" && parsed.value.polarity === "FAIL"
+					? [{sha: parsed.value.range.tip, createdAt: comment.createdAt}]
+					: [];
+			}),
+		);
+		return answer(
+			JSON.stringify({rows, rounds, capReached: capReached(rounds, []), clearances: []}),
+			[
+				`${VERB}: scanned ${listed.value.length} comment(s) on #${issue}; ${rows.length} standing range verdict(s), ${rounds} graded range(s).`,
+				`${VERB}: ${capNote([])} — a clearance is recorded against a PR's base branch, and a child has no PR, so this budget takes none.`,
+				...read.malformed.map(
+					(reason) =>
+						`${VERB}: a comment on #${issue} reaches for a verdict marker and is not a range one — ${reason}`,
+				),
 			],
 		);
 	});

--- a/packages/fabrika-cli/src/build/verdicts-verb.unit.test.ts
+++ b/packages/fabrika-cli/src/build/verdicts-verb.unit.test.ts
@@ -4,7 +4,7 @@ import {errOut, fakeShell, okOut} from "../fakes.test-support.ts";
 import type {ExecResult} from "../io/exec.ts";
 import {PRECONDITION_UNKNOWN, ZERO_SCOPE} from "./codes.ts";
 import {comments, HEAD, issue, OLD_HEAD, PRIOR_HEADS, pull} from "./fixtures.test-support.ts";
-import {runVerdicts} from "./verdicts-verb.ts";
+import {runChildVerdicts, runVerdicts} from "./verdicts-verb.ts";
 
 const PULL = /^gh api repos\/o\/r\/pulls\/4310$/;
 const COMMENTS = /^gh api --paginate repos\/o\/r\/issues\/4310\/comments/;
@@ -403,5 +403,88 @@ describe("runVerdicts", () => {
 			expect(out.code).toBe(PRECONDITION_UNKNOWN);
 			expect(out.stdout).toBe("");
 		});
+	});
+});
+
+/**
+ * The child arm — where a lane sent to repair by `build claim --resume` reads its findings. A child
+ * opens no PR (ADR 0285), so the whole fold is the range-bound comments on the issue.
+ */
+describe("runChildVerdicts", () => {
+	const BASE = "9f2c1ab4d5e6f708192a3b4c5d6e7f8091a2b3c4";
+	const TIP = "03135b917283a4b5c6d7e8f90a1b2c3d4e5f6071";
+	const NEXT_TIP = "5c6d7e8f90a1b2c3d4e5f60718293a4b5c6d7e8f";
+	const CHILD_COMMENTS = /^gh api --paginate repos\/o\/r\/issues\/4312\/comments/;
+	const range = (polarity: string, tip = TIP) =>
+		`review-code: ${polarity} range:${BASE}..${tip} content:2f1a9c4e0b7d — the child's range`;
+
+	const runChild = (script: ReadonlyArray<readonly [RegExp, ExecResult]>) =>
+		Effect.runPromise(
+			Effect.provide(
+				runChildVerdicts({
+					issue: 4312,
+					repo: null,
+					env: {CLAUDE_PIPELINE_REPO: "o/r"} as Record<string, string | undefined>,
+				}),
+				fakeShell(script).layer,
+			),
+		);
+
+	it("folds the standing verdict per gate with the range it was formed over", async () => {
+		const out = await runChild([
+			[ISSUE, issue()],
+			[CHILD_COMMENTS, comments({id: 8801, body: `${range("FAIL")}\n\nthe finding's text`})],
+		]);
+		expect(out.code).toBe(0);
+		const answered = JSON.parse(out.stdout);
+		expect(answered.rows).toMatchObject([
+			{
+				gate: "review-code",
+				polarity: "FAIL",
+				range: `${BASE}..${TIP}`,
+				commentId: 8801,
+				kind: "range-marker",
+			},
+		]);
+		expect(answered.rows[0].body).toContain("the finding's text");
+	});
+
+	it("counts one round per graded tip, so two gates over one range stay one round", async () => {
+		const out = await runChild([
+			[ISSUE, issue()],
+			[
+				CHILD_COMMENTS,
+				comments(
+					{id: 1, body: range("FAIL")},
+					{id: 2, body: `governance: FAIL range:${BASE}..${TIP} content:2f1a9c4e0b7d — no`},
+					{id: 3, body: range("FAIL", NEXT_TIP)},
+				),
+			],
+		]);
+		expect(JSON.parse(out.stdout).rounds).toBe(2);
+	});
+
+	it("reports no clearance and says why — a grant is recorded against a base branch", async () => {
+		const out = await runChild([
+			[ISSUE, issue()],
+			[CHILD_COMMENTS, comments({id: 8801, body: range("PASS")})],
+		]);
+		expect(JSON.parse(out.stdout).clearances).toEqual([]);
+		expect(out.stderr.join("\n")).toContain("a child has no PR");
+	});
+
+	it("refuses a PR on 7 — its verdicts are head-bound", async () => {
+		const out = await runChild([[ISSUE, issue({pull_request: {}})]]);
+		expect(out.code).toBe(ZERO_SCOPE);
+		expect(out.stderr.at(-1)).toContain("drop --issue and pass --pr");
+	});
+
+	it("refuses an unreadable comment page on 11 — never 'none'", async () => {
+		const out = await runChild([
+			[ISSUE, issue()],
+			[CHILD_COMMENTS, errOut("gh: Bad gateway (HTTP 502)")],
+		]);
+		expect(out.code).toBe(PRECONDITION_UNKNOWN);
+		expect(out.stdout).toBe("");
 	});
 });

--- a/packages/fabrika-cli/src/lane/claim-verb.unit.test.ts
+++ b/packages/fabrika-cli/src/lane/claim-verb.unit.test.ts
@@ -417,6 +417,7 @@ describe("a driver's claim and the builder it spawns", () => {
 					override: null,
 					overrideLane: null,
 					cites: null,
+					resume: false,
 				}),
 				fakeShell([
 					[BUILD_ISSUE, claimable],

--- a/packages/fabrika-cli/src/lane/prove.ts
+++ b/packages/fabrika-cli/src/lane/prove.ts
@@ -25,8 +25,10 @@
  */
 
 import {issueRefsIn} from "../build/commit-message.ts";
-import {parseLaneBranch} from "../build/lane.ts";
 import type {ParentedCommit} from "../io/git.ts";
+
+/** The branch grammar's own reader, re-exported so this module's callers take one derivation. */
+export {childLaneBranches} from "../build/lane.ts";
 
 /** The leaf state a builder runs in — a `DONE` out of it claims the built work exists. */
 export const BUILD_STATE = "build";
@@ -152,16 +154,6 @@ export type RangeTrace =
 	  }
 	| {readonly _tag: "None"; readonly why: string}
 	| {readonly _tag: "Many"; readonly branches: ReadonlyArray<string>};
-
-/** The local branches a lane branch's own grammar says were cut for this child (`build branch`). */
-export const childLaneBranches = (
-	issue: number,
-	branches: ReadonlyArray<string>,
-): ReadonlyArray<string> =>
-	branches.filter((name) => {
-		const lane = parseLaneBranch(name);
-		return lane !== null && lane._tag === "Create" && lane.number === issue;
-	});
 
 /**
  * The one range a child's `DONE` out of `build` stands on.

--- a/packages/fabrika-cli/src/lane/range.ts
+++ b/packages/fabrika-cli/src/lane/range.ts
@@ -3,7 +3,7 @@
  *
  * Off the tree rather than off a search index because a child's work is never published: nothing on
  * GitHub knows it exists until the epic's single PR opens at the tail (ADR 0285). The branch is
- * nominated by `build branch`'s own grammar (`./prove.ts`'s `childLaneBranches`, never a second
+ * nominated by `build branch`'s own grammar (`../build/lane.ts`'s `childLaneBranches`, never a second
  * regex) and the range is then the evidence — a branch is only a name until commits naming this
  * child sit on it.
  *

--- a/packages/fabrika-cli/src/wire/lane-brief.ts
+++ b/packages/fabrika-cli/src/wire/lane-brief.ts
@@ -207,6 +207,9 @@ your own worktree on a local branch cut from \`branch\`, and never push or open 
 child state — the merge happens once, after the epic review. A child's build that lands its commit
 ends on \`BUILT-NO-PR\`, whose branch disposition is exactly that: left local and unpushed for this
 lane to fold (#6019).
+A child re-entering \`build\` after a \`FAIL\` is a repair, not a second build: \`build claim\` refuses
+the fresh claim naming that FAIL, and the route it points at takes over the branch the prior lane
+built on rather than cutting another (#6386).
 A child's build discloses its deviations — the section a PR body would carry — as a
 \`build-deviations\` marker comment on the child issue, composed through
 \`node <fabrika> wire emit --format build-deviations\`; the epic-tail review


### PR DESCRIPTION
An epic child that already carries a `FAIL` was offered to the next build lane as ordinary work, and
the lane rebuilt it from scratch. It happened twice on epic #5631 — #6296 (48 files) and #6298 (21
files) — and on #6298 the two lanes picked different config-key shapes for one criterion, so the cost
was not just a wasted lane but a near-miss on folding the wrong branch into the assembly.

The cause: `build eligible` reads the `blocked_by` graph and `build claim` reads claim markers.
Neither reads verdicts. "No lane holds this number" and "this number has no reviewed build" are
different facts, and only the first was ever checked. A child opens no PR (ADR 0285), so its verdicts
live as range-bound comments on the child issue (ADR 0276) — exactly the surface neither gate looked
at.

## What changed

**The fence.** A new `build/range-verdicts.ts` folds a child issue's comments the way `lane prove`
folds them (newest write per namespace, so a `FAIL` upserted after a `PASS` wins). `build claim`
consults it on a fresh build-purpose claim only, after the pure axes and the blockedness gate, and
refuses on a new exit `31` naming the standing `FAIL`, its range, its comment, and the repair route.
An unreadable comment page is `11`, never "no prior build". Staleness is deliberately not asked: a
stale `FAIL` still proves the child was built and graded, which is the fact a fresh claim is missing.

**The repair route, which did not exist.** `build branch --resume` takes a PR number and a child has
none, so a refusal would have stranded the child. Three additions make the route real:

- `build claim <n> --resume` admits the claim over a standing `FAIL` — and refuses on `31` over a
  child holding none, so the word is checked against the fact it asserts rather than trusted. That is
  how it sits with the "repair is derived from the target, never typed" ruling (#5866, #5914): the
  objection there was a mode passable in a state where it means nothing.
- `build branch <n> --resume-lane` takes over the branch the prior lane built on by **re-keying** it
  to this claim's nonce, rather than cutting a second branch off it. Two branches carrying one
  child's commits is the range `lane prove` calls underivable, and that refusal cannot be cleared
  from inside a worktree — `git branch -D` refuses a branch another worktree holds. When the re-key
  hits that same wall it is `11` naming git's reason, which is an operator's to release.
- `build verdicts --issue <n>` folds a child's range verdicts so the repair lane reads its findings
  through a verb. Rows carry the range instead of a head, a round is one graded tip, and `clearances`
  is always empty with the reason on stderr — a grant is recorded against a PR's base branch.

`childLaneBranches` moved from `lane/prove.ts` to `build/lane.ts`, beside the branch grammar it reads,
because there are now three callers and a second filter spelled from the same regex is how one comes
to see a branch the others do not.

## Reviewer's first look

`packages/fabrika-cli/src/build/claim-verb.ts`'s `readPriorBuild` — the two refusal directions and
their placement after the blockedness gate. Then `branch-verb.ts`'s `--resume-lane` arm: the rename
is the load-bearing choice, and its failure mode is the operator escalation the issue's
"recovery-path rabbit-hole" section describes.

Fixes #6386

## Deviations

- **Out-of-scope change** — **Said:** #6386 names the claim path and the repair-expressibility
  question. **Did:** also added `build verdicts --issue`, which the issue does not ask for.
  **Why:** criterion 3 requires the refusal to point at a reachable route, and a repair lane that
  cannot read the FAIL's findings through a verb has no route — the skill forbids raw-fetching a
  comment. **Disposition:** stated here.
- **Out-of-scope change** — **Said:** nothing about `lane/prove.ts`. **Did:** moved
  `childLaneBranches` into `build/lane.ts` and re-exported it. **Why:** `--resume-lane` is a third
  caller of that derivation, and importing `lane/prove.ts` from `build/` would have made
  build→lane→build a cycle. **Disposition:** stated here.
- **Known defect left unfixed** — **Said:** the issue's rabbit-hole section asks whether a superseded
  lane branch can be retired from inside a worktree. **Did:** did not build a retirement act.
  **Why:** re-keying means a repair lane never creates the second branch in the first place, so the
  deadlock is prevented rather than recovered from; a tree that is *already* in the two-branch state
  still needs an operator, and that is now a named `11` refusal instead of a silent `lane prove`
  stall. **Disposition:** filed as follow-up.
- **Pre-existing test or fixture changed** — **Said:** nothing about existing claim tests.
  **Did:** three `runClaim` tests gained a second `unclaimed()` script entry. **Why:** the fence adds
  one paginated comment read to a fresh build claim, and those scripts served exactly one.
  **Disposition:** stated here; no assertion changed.
