### PR TITLE
fix: doc-links reds every PR: two dead links in the campaign-skill v1 snapshot report

### DIFF
--- a/reports/2026-08-19-campaign-skill-v1-snapshot.md
+++ b/reports/2026-08-19-campaign-skill-v1-snapshot.md
@@ -26,8 +26,8 @@ the repo it would land in:
   them, and nobody has ruled whether a plain campaign is the same ritual minus the wave gate or a
   second mode the skill carries.
 - **The shell is v1's, and the deterministic half outlived it.**
-  [`packages/pipeline-cli/src/tools/campaign/`](../packages/pipeline-cli/src/tools/campaign/) and
-  [`.../roadmap/`](../packages/pipeline-cli/src/tools/roadmap/) survived the retirement. The nine
+  `packages/pipeline-cli/src/tools/campaign/` and
+  `.../roadmap/` survived the retirement. The nine
   scripts below are the glue those verbs were meant to replace, not code to re-home.
 
 The port itself is not this file's business, and neither is it a builder's: a fabrika skill reaches


### PR DESCRIPTION
The repo-wide `doc-links` job (lychee, offline) was failing on two dead links in a dated report that
no open PR touches, so every PR inherited a red rollup. Both links pointed into
`packages/pipeline-cli/src/tools/`, and that whole package was deleted in #6326 — there is no valid
target to repoint them at.

This converts the two markdown links at lines 29–30 of
`reports/2026-08-19-campaign-skill-v1-snapshot.md` into inline code spans, matching how line 154 of
the same file already cites that path. lychee masks code spans, so the references stay readable and
stop being checked. The visible text is unchanged and no claim in the snapshot's prose is altered.

Reviewer: the whole diff is two lines in one report file. Worth confirming the `doc-links` check is
green on this head.

Fixes #6390

## Deviations

None.
