### PR TITLE
feat: enable the Geçit product-push campaign

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -45,6 +45,7 @@ flowchart TD
 		camp_switching_to_fabrika["switching to fabrika"]:::done
 		camp_fabrika_fast_follows["fabrika fast follows"]:::done
 		camp_fabrika_everywhere["fabrika everywhere"]:::active
+		camp_ge_it_product_push["Geçit product push"]:::active
 	end
 	ext_3642["#3642"]:::external
 	ext_3833["#3833"]:::external
@@ -102,6 +103,7 @@ Campaigns are bounded, milestone-backed pushes that run *concurrently* with the 
 | switching to fabrika | #45 | done |
 | fabrika fast follows | #46 | done |
 | fabrika everywhere | #47 | active |
+| Geçit product push | #24 | active |
 
 **The table is a parsed contract.** It is the single source whatever writes a campaign row (appending it `paused` and later flipping its state) and the lifecycle guard that reads it both bind to, so the grammar is pinned here rather than re-derived at either end:
 


### PR DESCRIPTION
Adds the Geçit product-push campaign row (milestone #24, state active) to the Campaigns table and its mermaid node, so Geçit product lanes pass the ADR 0304 dispatch check.

Founder-directed 2026-08-19: start building product through fabrika to surface rough edges; Geçit features ship behind flags, which also exercises the dark-ship check. New rows default paused — this one is minted active on the founder's explicit in-conversation word ("let's also enable that"), recorded here.

roadmap-guard verified green locally (I1–I5, 2 campaigns active).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Deviations

- **Governing-ADR departure** — **Said:** ROADMAP.md's pinned `## Campaigns` grammar and the
  founder ruling on #6289 require a newly added row to land `paused`, with the flip to `active` a
  separate explicit act. **Did:** Minted the Geçit row `active` in the same commit that names it.
  **Why:** Explicit founder flip, recorded verbatim and citable at
  https://github.com/kamp-us/phoenix/pull/6417#issuecomment-5347095221 — the "enable that" in that
  ruling is this campaign's dispatch permission. **Disposition:** Accepted for this row on that
  citation. The paused-default is unchanged and binds every row not carrying one.
