### PR TITLE
chore: Both fabrika READMEs carry ruling history instead of a front door

### DIFF
--- a/claude-plugins/fabrika/README.md
+++ b/claude-plugins/fabrika/README.md
@@ -1,113 +1,59 @@
 # fabrika
 
-> Copy from the already-battle-tested external workflow (mattpocock/skills — the skill theory,
-> surveyed with receipts on #4644) and from our own already-battle-tested one (the pipeline's
-> verbs, gates, and 74-incident scar tissue) — and **build fabrika for the next generation of
-> software building with agents.** Neither source arrives on authority: every borrowed idea
-> re-earns its place against the eval bar.
->
-> — the founder mission statement, recorded on epic [#4648](https://github.com/kamp-us/phoenix/issues/4648)
+**fabrika** is the kamp.us agent pipeline, shipped as a Claude Code plugin. You file an issue; a
+chain of agents triages it, plans it, builds it, reviews it, and merges it. Every stage leaves its
+record on the issue or the pull request, not in a chat log. It works in any GitHub repo, and it is
+for anyone who wants agents doing real work on a repo with that work reviewable afterwards.
 
-**fabrika** is the kamp.us agent pipeline, rebuilt from first principles as its own plugin. It
-grew beside the v1 baseline (`claude-plugins/kampus-pipeline/`), a deliberate experiment that
-succeeded at its own goal and ran its course (wayfinder:map #4631); that tree was kept frozen as
-the measuring stick while fabrika earned its place, then retired and deleted once fabrika became
-the one pipeline (ADR 0303, #5937).
+Turkish for "factory", styled lowercase like the sibling brand nouns `sozluk` and `pano`. fabrika
+replaced the v1 `kampus-pipeline` plugin, which is deleted
+(ADR [0303](../../.decisions/0303-retire-kampus-pipeline-plugin.md)).
 
-Turkish for "factory". The name is sealed (#4631) and styled lowercase, like the sibling brand
-nouns `sozluk` and `pano`.
-
-## The route in: writing-for-agents
-
-**Every skill in `skills/` is written under
-[`writing-for-agents`](skills/writing-for-agents/SKILL.md), against the [fabrika skill
-conventions](docs/skill-conventions.md)** — founder ruling of 2026-08-18, recorded on
-[#5945](https://github.com/kamp-us/phoenix/issues/5945) and carried by
-[#5953](https://github.com/kamp-us/phoenix/issues/5953). It is one route for three cases that used
-to be graded differently: a new skill, an edit to a skill already here, and a port of a v1 skill.
-fabrika still builds no authoring tool of its own ([#4648 scope
-correction](https://github.com/kamp-us/phoenix/issues/4648#issuecomment-5152523719)); what fabrika
-owns here is the discipline.
-
-That ruling retires the earlier posture, which made a `/skill-creator` session the only door and
-named a port a defect by construction ([#4637-C](https://github.com/kamp-us/phoenix/issues/4637)).
-A port that meets the discipline now enters the same way anything else does, so no skill needs a
-per-PR ruling to get through the gate.
-
-What did not change: nothing is dropped into `skills/` unread. The text still has to pass the
-conventions, and it is the text that is graded rather than the session that produced it.
+**Read [guide/README.md](guide/README.md) next.** It maps every page to the question it answers,
+and points at the other fabrika surfaces.
 
 ## Layout
 
 ```
 claude-plugins/fabrika/
 ├── .claude-plugin/plugin.json   the plugin manifest (no version — ADR 0110, continuous ship)
-├── README.md                    this file: the mission, the route in, the layout
+├── README.md                    this file
 ├── agents/                      builder, reviewer, shipper, operator (see docs/agent-shells.md)
-├── docs/                        the canonical convention + contract docs (see docs/README.md)
+├── docs/                        the agent-facing convention + contract docs (see docs/README.md)
 ├── guide/                       the human-facing pages, one Diátaxis mode each (see guide/README.md)
-└── skills/                      one dir per skill, each written under writing-for-agents
+└── skills/                      one dir per skill, each a SKILL.md under a per-skill directory
 ```
 
-A person reading fabrika starts at [guide/README.md](guide/README.md), which maps every page to
-the question it answers and says which of the five fabrika surfaces to open next.
+`agents/` holds exactly four **agent shells** — behaviour-free spawn targets that each preload one
+skill. The shell names the actor, never the skill, so the `builder` shell runs the `build` skill.
+The rules are in [docs/agent-shells.md](docs/agent-shells.md).
 
-`agents/` holds exactly four **agent shells** — `builder`, `reviewer`, `shipper`, `operator` —
-behaviour-free spawn targets that each preload one skill. The shell names the actor and never the
-skill it loads, so the `builder` shell runs the `build` skill — and the shell is addressed by that
-bare name, not by `fabrika:builder`. What a shell may hold, why there are four, why its name is
-a noun, and why a shell that grows opinions is a defect are all in
-[docs/agent-shells.md](docs/agent-shells.md).
-
-`skills/` carries no `README` and no loose files: the fabrika layout law is `SKILL.md` under a
-per-skill directory and nothing else at the `skills/` root. A `.gitkeep` remains from when the
-directory was empty; it is harmless and can go with any later change.
+Every skill is written under [`writing-for-agents`](skills/writing-for-agents/SKILL.md) and must
+meet [docs/skill-conventions.md](docs/skill-conventions.md). Nothing lands in `skills/` unread, and
+it is the text that is graded, not the session that produced it.
 
 ## Install
 
-**External consumers** install fabrika from the `kampus` marketplace on GitHub.
+From the `kampus` marketplace on GitHub:
 
 ```
 /plugin marketplace update kampus
 /plugin install fabrika@kampus
 ```
 
-**Refresh first.** The install reads a locally cached catalog. A cache that predates fabrika's
-entry refuses by name — `Plugin "fabrika" not found in marketplace "kampus"` — instead of saying
-it is out of date, and the same message comes back when the marketplace was never registered on
-the machine at all, so the refusal does not tell you which of the two you hit. Updating first
-clears the common one.
+Update first. The install reads a cached catalog, and a stale cache refuses with
+`Plugin "fabrika" not found in marketplace "kampus"` — the same message you get when the
+marketplace was never registered at all.
 
-**Working inside the repo that authors the plugin**, register the checkout itself as the
-marketplace source instead, so a local or just-merged plugin change is live on the next
-`/reload-plugins` (ADR [0273](../../.decisions/0273-fabrika-ships-as-an-installed-plugin.md)'s
-2026-08-16 amendment). From the repo root, once per machine:
+Inside the repo that authors the plugin, register the checkout as the source instead, so a local
+change is live on the next `/reload-plugins`
+(ADR [0273](../../.decisions/0273-fabrika-ships-as-an-installed-plugin.md)). Once per machine:
 
 ```bash
 claude plugin marketplace add ./
 claude plugin install fabrika@kampus
 ```
 
-Both lines are needed. Registering the marketplace installs nothing — verified on Claude Code
-2.1.234 against a fresh clone with no prior `kampus` registration: after the `add`,
-`claude plugin list` reported no plugins installed. Skipping the install leaves `/reload-plugins`
-with zero fabrika skills and no error naming the cause.
-
-**Already on the GitHub `kampus` marketplace?** Run the same `marketplace add ./` — on 2.1.234 it
-overwrites the existing `kampus` entry's source in place and the installed plugin survives, so no
-reinstall is needed. Do not reach for `claude plugin marketplace remove kampus` first: removing a
-marketplace also uninstalls its plugins, which is what turns a one-command switch into three.
-
-## What is deliberately absent
-
-- **No dependency on v1.** fabrika calls `pipeline-cli` nowhere — not from a skill, not from a verb.
-  Its own verbs live in `packages/fabrika-cli/`. v1 is a reference to read, never a runtime to call,
-  because a fabrika that calls the old tree can never be the thing that replaces it.
-
-  The rule is **re-implement calls, pin formats** (ADR
-  [0251](../../.decisions/0251-shared-formats-are-pinned-not-reimplemented.md)). Where fabrika and
-  another program must agree on the same bytes on a GitHub artifact, neither side can re-implement
-  its way out: fabrika owns that wire format and commits its canonical bytes as a golden fixture, and
-  the other side conforms by pinning the fixture in a test of its own. Nothing about that is a call,
-  and it points the dependency at fabrika rather than away from it. Tests follow the same line — a
-  test asserting a fabrika property lives in `packages/fabrika-cli/`.
+Both lines are needed — registering a marketplace installs nothing. Already on the GitHub `kampus`
+marketplace? The same `add ./` overwrites that entry's source in place, and the installed plugin
+survives. Do not `claude plugin marketplace remove kampus` first: that uninstalls its plugins.

--- a/packages/fabrika-cli/README.md
+++ b/packages/fabrika-cli/README.md
@@ -1,57 +1,32 @@
 # @kampus/fabrika-cli
 
-The deterministic verb package [fabrika](../../claude-plugins/fabrika/) skills call.
-`fabrika <group> <verb> …` dispatches to a registered verb group. The registered groups are
-`adr`, the six verbs the `/adr` skill's derived contract specifies; `report`,
-the three the `/report` contract specifies; `triage`, the intake-queue group the `/triage`
-contract specifies; `build`, the fourteen the `/build` contract specifies; `plan`, the epic-plan
-gate's; `review`, the eight the `/review` contract specifies; `review-ui`, the three the
-`/review-ui` contract specifies
-(capture a PR's preview, emit the `review-ui` verdict, or post a typed blocker note);
-`ship`, the thirteen the `/ship` contract specifies; `map`, the eight the `/wayfinding`
-contract specifies (chart one destination's fog, and drain its frontier); `spend`, what one fabrika run cost in
-tokens; `lane`, the lane ledger the operator loop drives — a @demlik/tea machine
-folded fresh from an append-only `events.jsonl` on every invocation; `wire`, which owns the
-byte-level formats two skills meet through on a GitHub
-artifact; `status`, the six the `/fabrika` front door's contract specifies (what state the
-factory is in); and `hook`, which reads the envelope Claude Code writes to a hook's stdin — the group
-[fabrika's hook surface](../../claude-plugins/fabrika/hooks.json) declares against.
-`fabrika --help` lists them from the registry, so that index is never a second
-hand-maintained list.
+The deterministic verb package the [fabrika](../../claude-plugins/fabrika/) skills call.
+`fabrika <group> <verb> …` dispatches to a registered verb group. fabrika's architecture is a
+two-layer split: deterministic work is pushed into CLI verbs, and each skill is a thin wrapper
+carrying only the judgment that cannot be mechanized. This package is the deterministic layer. It
+is internal tooling for the kamp.us agent pipeline, not a general-purpose CLI.
 
-## Who it's for
+This file is the **verb reference**: what each group does and what its exit codes mean. For what
+fabrika is and how to run it, read [the guide](../../claude-plugins/fabrika/guide/README.md).
 
-fabrika's architecture is a two-layer split: deterministic work is pushed maximally into
-CLI verbs, and each skill is a thin wrapper carrying only irreducible judgment. This
-package is the deterministic layer. It is internal tooling for the kamp.us agent pipeline,
-not a general-purpose CLI.
-
-## It calls nothing outside fabrika
-
-**`fabrika` invoked the v1 CLI nowhere** — no import, no subprocess
-([ADR 0238](../../.decisions/0238-fabrika-reimplements-v1-never-calls-it.md)). That package is
-deleted now (#6100), so the rule is history rather than a live constraint; what it bought is that
-nothing here needs porting or unhooking.
-
-The reason is the deletion test: a fabrika that calls v1 can never be the thing that
-replaces it, because every call is a tether keeping the old tree alive. Duplication costs a
-second implementation during the transition; a tether costs the ability to ever delete
-anything.
-
-## How it is delivered
-
-`fabrika` is installed **globally**, once, and the binary decides for itself which copy runs:
+## Install
 
 ```bash
 pnpm add --global @kampus/fabrika-cli
 ```
 
-On startup it finds the **repo root** above the working directory, asks **Node's own resolver** what
-copy of `@kampus/fabrika-cli` that root has installed, and hands the invocation to it. This is the
-shape [turbo](https://turborepo.com) ships (`crates/turborepo-shim/`), reimplemented here in
-TypeScript ([#4784](https://github.com/kamp-us/phoenix/issues/4784)).
+> [!IMPORTANT]
+> **The package is not published yet, so the line above does not work today.** It answers a
+> registry 404. Publishing needs npm Trusted Publishing registered against this repo plus a
+> one-time bootstrap publish, tracked by
+> [#4791](https://github.com/kamp-us/phoenix/issues/4791). Until then a bare `fabrika` exits `127`
+> on a machine with no global install, and inside a phoenix checkout the fallback is
+> `node packages/fabrika-cli/src/bin.ts …`.
 
-**No outcome is both silent and wrong**:
+`fabrika` is installed globally once, and the binary decides for itself which copy runs. On startup
+it finds the **repo root** above the working directory, asks **Node's own resolver** what copy of
+`@kampus/fabrika-cli` that root has installed, and hands the invocation to it — the shape
+[turbo](https://turborepo.com) ships, reimplemented here in TypeScript.
 
 | Where you are | What runs | Warning |
 | --- | --- | --- |
@@ -62,113 +37,54 @@ TypeScript ([#4784](https://github.com/kamp-us/phoenix/issues/4784)).
 | In no repo at all | the global | no — deliberately |
 | Running a copy from a **different repository** by path | nothing — it refuses, exit `126` | **yes**, naming both checkouts |
 
-Rows four and five are the original design. Running the global outside any repo is a normal,
-correct invocation, so it stays quiet. Running the global *inside a repo that asked for a specific
-version* is the quietly-wrong case, so it says so out loud and names the global's version beside the
-one the root manifest declared. Set `FABRIKA_GLOBAL_WARNING_DISABLED=1` to silence it.
+No outcome is both silent and wrong. Running the global outside any repo is a correct invocation,
+so it stays quiet; running it inside a repo that pinned a version is the quietly-wrong case, so it
+says so and names both versions. `FABRIKA_GLOBAL_WARNING_DISABLED=1` silences that one.
 
-The last row closes the one case that used to be quietly wrong ([#4956](https://github.com/kamp-us/phoenix/issues/4956)).
-`node <other-repo>/packages/fabrika-cli/src/bin.ts` run from a cwd inside *this* repo looked
-exactly like a global install on `PATH`, so it delegated — and answered from a repository you did
-not name, with no warning at all. It is a live hazard for anyone reviewing from a second checkout: the CLI
-reports the state of `main` while you are reading a branch. The two are separated by asking which
-repository the *invoked copy* belongs to; an installed copy (anything under `node_modules`) belongs to
-none, which is what keeps the global-install delegation exactly as it was. Either run it from inside
-its own repository, or pass `--skip-infer` to make the copy you named serve the invocation.
+Four rules make those rows hold:
 
-Row two is the carve-out that refusal needed ([#5679](https://github.com/kamp-us/phoenix/issues/5679)).
-A `pnpm link --global` install puts a checkout's own copy on `PATH`, so an agent standing in a
-worktree who types the bare `fabrika` invokes the primary checkout's copy — a different checkout, and
-the refusal swallowed it, leaving the bare command unusable from every worktree. `git worktree` gives
-one repository several working trees, so the comparison is the repository, not the checkout: the two
-trees' `$GIT_COMMON_DIR` is read off disk (`.git` directory, else the `.git` file's `gitdir:` and that
-dir's `commondir`, per `gitrepository-layout(5)`) and equal common dirs delegate. A tree whose
-repository cannot be established is treated as a different one, so the refusal is what an unreadable
-answer falls back to.
+- **A copy invoked by path from another repository is refused, not delegated to.** Otherwise it
+  answers about a repository you did not name — the live hazard when you review from a second
+  checkout ([#4956](https://github.com/kamp-us/phoenix/issues/4956)). Pass `--skip-infer` to make
+  the copy you named serve the invocation.
+- **Worktrees of one repository delegate to each other** (row two). The comparison is the
+  repository, not the checkout: two trees' `$GIT_COMMON_DIR` is read off disk and equal common
+  dirs delegate. A tree whose repository cannot be established counts as a different one.
+- **A resolved install must live at or under the repo root.** Node falls back to `NODE_PATH` after
+  the `node_modules` walk, and pnpm's global shim exports a `NODE_PATH` chain rooted at the
+  checkout it was installed from — so anything resolved outside the repo is `absent`, whatever
+  Node found.
+- **Two recursion guards, both read before any filesystem work.** The parent passes `--skip-infer`
+  to the child (stripped before any verb sees it), and `FABRIKA_SKIP_INFER` does the same for a
+  caller that cannot alter argv.
 
-Row three needs one more rule to hold, because the probe asks Node and Node answers about more than
-the repo ([#5768](https://github.com/kamp-us/phoenix/issues/5768)). After the `node_modules` walk
-fails, Node falls back to `NODE_PATH` — and the pnpm-generated global `fabrika` shim exports an
-absolute `NODE_PATH` chain rooted at the checkout it was installed from. So a repo with no install
-of its own still resolved one: the global's own copy, which read as "the repo-local install is this
-copy" and swallowed the warning row three exists for. The probe therefore requires the resolved
-install to live at or under the repo root; anything outside is `absent`, whatever Node found. The
-same rule drops a copy hoisted into a directory above the repo, which is not that repo's install
-either.
+The child's cwd is the **repo root**, not yours; your cwd travels as `FABRIKA_INVOCATION_DIR`, so
+an older local binary cannot choke on it the way it would on an unknown flag. `FABRIKA_DEBUG=1`
+prints one stderr line naming which copy served the invocation.
 
-The property this buys is a **repo-pinned version**. phoenix carries `@kampus/fabrika-cli` in its
-root `devDependencies`, so a bare `fabrika` anywhere in a phoenix checkout runs the version this
-repo pins — and because pnpm links the workspace package, that means the **working tree**: edit
-`src/`, the next invocation runs the edit. This supersedes `pnpm link --global`, which is
-machine-wide and has to be remembered and undone.
-
-`FABRIKA_DEBUG=1` prints one stderr line naming which copy served the invocation:
-
-```
-$ FABRIKA_DEBUG=1 fabrika --version
-fabrika: global at …/pnpm/global/5/…/@kampus/fabrika-cli — delegating to the repo-local install at …/packages/fabrika-cli (…/src/bin.ts, v0.1.0)
-fabrika v0.1.0
-```
-
-**Two independent recursion guards**, both read before any filesystem work: the parent always passes
-`--skip-infer` to the child (stripped before any verb sees it), and `FABRIKA_SKIP_INFER` does the
-same for a caller that cannot alter argv. turbo needs both because a missed guard would re-enter the
-shim; we need them *more*, because for us the global and the local are the same JS file shape.
-
-The child's cwd is the **repo root**, not yours; your cwd travels as `FABRIKA_INVOCATION_DIR`. That
-is deliberate — an older local binary cannot choke on an env var it never reads, whereas it would
-refuse an unknown flag.
-
-> [!IMPORTANT]
-> **`@kampus/fabrika-cli` is not published yet, so the install above does not work today.** It
-> answers a registry 404 (`npm error code E404`, exit `1`, nothing on stdout). Publishing needs npm
-> Trusted Publishing registered against this repo plus a one-time bootstrap publish — a human action
-> outside the repo, tracked by [#4791](https://github.com/kamp-us/phoenix/issues/4791). Until it
-> lands, a bare `fabrika` exits `127` on a machine with no global install, which the interface
-> convention reserves for exactly that: the verb never ran. Inside a phoenix checkout the fallback
-> is `node packages/fabrika-cli/src/bin.ts …`.
-
-> [!NOTE]
-> **The published artifact is compiled; the development loop is not.** Node refuses to strip types
-> for any file whose resolved path is under `node_modules` — `stripTypeScriptModuleTypes` throws
-> `ERR_UNSUPPORTED_NODE_MODULES_TYPE_STRIPPING` unconditionally on `isUnderNodeModules(filename)`
-> (read from Node 24.4.1 and 26.2.0's own bundled source) — so a `.ts` `bin` cannot start from an
-> installed copy, which is what a real `pnpm add --global` produces. `publishConfig` is what lets
-> both halves be true at once: the manifest's `bin` stays `./src/bin.ts` for the workspace, where
-> pnpm's link resolves *outside* `node_modules` and an edit to `src/` is live on the next
-> invocation, and npm rewrites `bin`/`main`/`types`/`exports`/`engines` onto the compiled `dist/` at
-> publish time. `files` is `["dist", "scripts"]` and `prepublishOnly` runs the build, so a tarball
-> can neither miss `dist/` nor ship a stale one (#4784).
+The property this buys is a **repo-pinned version**: phoenix carries `@kampus/fabrika-cli` in its
+root `devDependencies`, so a bare `fabrika` in a phoenix checkout runs the working tree — edit
+`src/`, the next invocation runs the edit.
 
 ### The two Node floors
 
-The two entry points need different Nodes, so the manifest carries two floors and never one number
-(#5943):
+The two entry points need different Nodes, so the manifest carries two floors:
 
 | Floor | Where it lives | What it is | Who reads it |
 | --- | --- | --- | --- |
 | `>=22.12` | `publishConfig.engines.node` | what the compiled `dist/` runs on | consumers, via the tarball |
 | `>=24` | top-level `engines.node` | what the `.ts` `bin` needs for type stripping | this workspace |
 
-`publishConfig.engines` is a real field replacement, not a hopeful one: packing this package with
-pnpm 10.27.0 (the `packageManager` pin `publish.yml` runs on) emits a tarball `package.json` whose
-`engines.node` is `>=22.12` and whose `publishConfig` is stripped to `{"access": "public"}` — pnpm
-copies a whitelisted field onto the manifest and deletes it from `publishConfig`, and `access` is a
-publish setting rather than a manifest field, so it stays behind. So the dev floor never reaches a
-consumer, and a Node-22 repo installs and runs with no `Unsupported engine` warning —
-including under `engine-strict=true`, where `>=24` was a hard install failure rather than noise.
+Node refuses to strip types for any file under `node_modules`, so a `.ts` `bin` cannot start from
+an installed copy. `publishConfig` is what lets both halves be true: the manifest's `bin` stays
+`./src/bin.ts` for the workspace, where pnpm's link resolves outside `node_modules`, and npm
+rewrites `bin`/`main`/`types`/`exports`/`engines` onto the compiled `dist/` at publish time.
+`files` is `["dist", "scripts"]` and `prepublishOnly` runs the build.
 
-`>=22.12` is what the bundle was measured to need, not what it was assumed to need. Running
-`dist/bin.js` down the Node ladder: 22.12 and up is clean; 22.11 works but warns
-(`ExperimentalWarning: Importing JSON modules`, from [`src/version.ts`](./src/version.ts)'s
-`import pkg from "../package.json" with {type: "json"}` — import attributes for JSON stopped being
-experimental in 22.12); Node 20 and 18 throw, because `undici` in the dependency tree calls
-`webidl.util.markAsUncloneable`, which lands in Node 22.
-
-The dev floor stays `>=24` and is deliberately conservative — the `.ts` `bin` in fact starts on
-22.18+, where native type stripping was backported, but nothing in this repo runs below 24. It is
-also not the only home for that number: `volta.node` pins `26.2.0` here and at the root, and CI
-reads `node-version-file: package.json`.
+`>=22.12` is measured, not assumed: `dist/bin.js` is clean on 22.12 and up, warns on 22.11
+(`ExperimentalWarning: Importing JSON modules`), and throws on Node 20 and 18, where `undici`'s
+`webidl.util.markAsUncloneable` does not exist. The dev floor `>=24` is conservative — the `.ts`
+`bin` starts on 22.18+ — and `volta.node` pins `26.2.0` here and at the root.
 
 ## Quickstart
 
@@ -183,9 +99,9 @@ node src/bin.ts adr --help
 node src/bin.ts adr next
 ```
 
-The `--help` index is derived from [`src/registry.ts`](./src/registry.ts) — a group appears
-by being registered and nowhere else, so a parallel hand-written list cannot drift out of
-step with what actually dispatches.
+The `--help` index is derived from [`src/registry.ts`](./src/registry.ts) — a group appears by
+being registered and nowhere else. Each verb's own `--help` states its flags and every exit code it
+can produce, so the per-verb detail lives there rather than here.
 
 ## The interface every verb meets
 
@@ -193,422 +109,135 @@ Governed by
 [`claude-plugins/fabrika/docs/cli-interface-convention.md`](../../claude-plugins/fabrika/docs/cli-interface-convention.md).
 Four rules matter most to a caller:
 
-- **Stdout is the answer; everything else is stderr.** Scope lines, refusal reasons and
-  progress are diagnostics.
-- **The positive answer is a positive token, never an absence.** `adr sweep` prints
-  `no-overlap`, not an empty shortlist — a verb whose "nothing found" answer is empty
-  stdout is byte-identical to a verb that never ran.
-- **The exit status is the answer; empty stdout never is.** `0` = the answer is on stdout,
-  `1` = usage error or the verb failed to run, `126` = the binary started but could not resolve an
+- **Stdout is the answer; everything else is stderr.** Scope lines, refusal reasons and progress
+  are diagnostics.
+- **The positive answer is a positive token, never an absence.** `adr sweep` prints `no-overlap`,
+  not an empty shortlist — a verb whose "nothing found" answer is empty stdout is byte-identical to
+  a verb that never ran.
+- **The exit status is the answer; empty stdout never is.** `0` = the answer is on stdout, `1` =
+  usage error or the verb failed to run, `126` = the binary started but could not resolve an
   implementation, `127` = the verb never ran, `3`+ = the verb's own proven outcomes. **A non-zero
-  exit is UNKNOWN** — read the status before the bytes. `2` is allocated by nothing: it is the one
-  code a `PreToolUse` hook blocks the tool call on, so a fabrika exit seated there would deny a
-  spawn as a side effect of its status ([#5423](https://github.com/kamp-us/phoenix/issues/5423)).
-- **Fail closed on missing scope or state.** A zero-record scan is a failed read, not an
-  answer ([ADR 0092](../../.decisions/0092-gates-fail-closed-on-zero-scope.md)); an
-  unreadable input resolves to a refusal, never to a permissive default.
+  exit is UNKNOWN** — read the status before the bytes. `2` is allocated by nothing: it is the code
+  a `PreToolUse` hook blocks a tool call on, so a fabrika exit there would deny a spawn as a side
+  effect of its status.
+- **Fail closed on missing scope or state.** A zero-record scan is a failed read, not an answer
+  ([ADR 0092](../../.decisions/0092-gates-fail-closed-on-zero-scope.md)); an unreadable input
+  resolves to a refusal, never to a permissive default.
+
+### The shared exit table
+
+Most groups seat `3`–`11` on one imported table, so a code means the same thing whichever group
+produced it. Each group section below lists only what it adds on top, plus any seat it uses
+differently.
+
+| Code | Meaning |
+| --- | --- |
+| `3` | stdin was read and held nothing (a read that *failed* is `1`) |
+| `4` | a required section or document is missing, out of order, empty, or does not parse |
+| `5` | the authored text carries a machine-local path |
+| `6` | the authored text is a bare `@` path reference — not redactable, so a second code |
+| `7` | zero scope: the target is proven absent or closed, or there is nothing to judge |
+| `8` | a write was attempted and its outcome could not be proven — UNKNOWN |
+| `9` | the write landed and the read-back does not match |
+| `10` | a value is off its closed vocabulary, or claims a classification it may not |
+| `11` | a precondition read failed — nothing was written and no outcome is proven |
+
+A group that does not perform a given kind of work leaves its seat as a **deliberate gap** rather
+than reusing the number, so the alignment holds across groups a caller drives in one sweep.
 
 ## The `adr` group
 
-The contract these seven implement is
-[`claude-plugins/fabrika/skills/adr/contract.md`](../../claude-plugins/fabrika/skills/adr/contract.md).
+Record one architecture decision, from id to citations. Contract:
+[`skills/adr/contract.md`](../../claude-plugins/fabrika/skills/adr/contract.md).
 
 | Verb | Answers |
 |---|---|
 | `adr next` | the next unused id — `max(fetched merged set ∪ open-PR claims) + 1` |
 | `adr new` | scaffolds `.decisions/NNNN-slug.md` from the canonical template |
-| `adr mint` | `next` and `new` in one call — allocates the id and writes the record with no gap between |
+| `adr mint` | `next` and `new` in one call — allocates the id and writes the record with no gap |
 | `adr resolve` | each id's real filename and state: `live` / `landed` / `in-flight` / `absent` |
-| `adr supersede` | rewrites an older record's `status:` line to a `superseded by` link to the newer record |
+| `adr supersede` | rewrites an older record's `status:` line to a `superseded by` link |
 | `adr amend-in-part` | appends this id to an older record's `amended-in-part by` list |
 | `adr sweep` | ranks the uncited live-accepted records this one may contradict |
 
-Four behaviours are worth knowing before you call them:
+**Exit codes.** `7` the named record is absent · `11` the record directory could not be read ·
+`12` the target path already exists · `13` `--by` has no record · `14` no single rewritable
+`status:` line · `15` the rewrite would touch a line other than `status:`, aborted before writing ·
+`16` already superseded · `17` `--base` unfetchable · `18` open PRs unenumerable · `19` a record
+filename with no readable id · `20` two records claim one id · `21` the `origin` remote could not
+be read. `5` is a vacated seat and must not be reused.
 
-- **`--base` is fetched before it is read.** Reading a stale local ref is the defect class
-  the contract exists to close — it is how two lanes both minted ADR 0198, and how a stale
-  checkout applied a withdrawn ADR 86 minutes after the withdrawal landed.
-- **`mint` exists because an id read in one call is stale by the next.** `next` then `new` leaves
-  the author's whole drafting turn between the read and the write, which put ADR 0284 on two pull
-  requests ([#5841](https://github.com/kamp-us/phoenix/issues/5841)). It is still not a reservation
-  — no id is visible to another lane until its pull request opens — and nothing catches a duplicate
-  downstream: `decisions-index`'s `merge_group` run reports one on the batched ref, but it is not a
-  required context, so the batch merges and `main` goes red until someone renumbers
-  ([#5869](https://github.com/kamp-us/phoenix/issues/5869)). Still run the step-6 re-check.
+Three behaviours are worth knowing:
+
+- **`--base` is fetched before it is read.** A stale local ref is the defect class this closes.
+- **`mint` exists because an id read in one call is stale by the next.** It is still not a
+  reservation — no id is visible to another lane until its pull request opens — so keep the
+  re-check before you push.
 - **`live` and `landed` are different answers.** `landed` means present on the base ref but
-  `proposed`, `superseded` or `retired`; 36 of the 233 records on `main` are in that state,
-  and citing one as settled law is the failure this split exists to prevent.
-- **`supersede` / `amend-in-part` assert a one-line diff before writing.** An accepted ADR's
-  decision text is immutable, so a rewrite that would touch any line but `status:` aborts
-  with exit 15 and writes nothing.
-
-## The `report` group
-
-The contract these three implement is
-[`claude-plugins/fabrika/skills/report/contract.md`](../../claude-plugins/fabrika/skills/report/contract.md).
-
-| Verb | Answers |
-|---|---|
-| `report dedup` | ranks the open issues that may already cover an observation — `candidates` / `none` / `indeterminate`, all three at exit 0 |
-| `report file` | composes the intake issue from the six sections on stdin, guards it, creates it, and reads back what landed |
-| `report note` | adds a note to an existing issue over the same guarded path, and reads the comment back |
-
-Four behaviours are worth knowing before you call them:
-
-- **The body is a value, never a path.** The two writing verbs take it on **stdin only** —
-  no `--body`, no `--body-file`, no temp file. A flag that accepts a path turns the body
-  into a string the verb could post verbatim, which is exactly how a machine-local path
-  reached a public artifact while the poster read success. A shell redirect is fine: the
-  *shell* reads the file, so what reaches the verb is already the bytes.
-- **An empty stdin is a refusal, not an empty body.** A read that failed exits `1` (the body
-  is UNKNOWN) and a pipe that was read and held nothing exits `3` (a proven refusal). They
-  are never the same answer.
-- **A missing `--label` is a refusal on `dedup` too, not a `none`.** `GET /issues?labels=…`
-  answers HTTP 200 with `[]` for a label that does not exist, so an unchecked `dedup` would
-  print a proven negative over a scope of zero — the fail-open ADR 0092 forbids. Both
-  writing and reading verbs check the label first and exit `7` when it is absent
-  ([#4752](https://github.com/kamp-us/phoenix/issues/4752)).
-- **The write is not finished until it is read back.** A create call's own response is the
-  server echoing the request; exit `9` is the landed artifact failing to match what was
-  composed.
-
-Intake applies **no type and no priority**, and that is defended mechanically rather than in
-prose: exit `10` refuses a `--label` or a title prefix that resolves to the target repo's own
-type/priority vocabulary.
-
-## The `triage` group
-
-The contract is
-[`claude-plugins/fabrika/skills/triage/contract.md`](../../claude-plugins/fabrika/skills/triage/contract.md).
-The group's nine verbs (`queue`, `claim`, `provenance`, `homes`, `split`, `enrich`, `apply`,
-`park`, `kill`) landed in the slices of
-[#4831](https://github.com/kamp-us/phoenix/issues/4831); `repair-criteria` joined as the
-corpus-repair verb ([#5744](https://github.com/kamp-us/phoenix/issues/5744)).
-
-| Verb | Answers |
-|---|---|
-| `triage codes` | the exit taxonomy every verb in the group allocates from, one `<code>\t<meaning>` line per code |
-| `triage apply` | stamp type, priority, audience, status and home as one owned-facet reconcile, read back positively. `--ready-for agent` additionally asserts the issue's live body carries an acceptance-criteria block the wire reader answers `Found` on, refusing on `16` before any label is written — an absent block routes back to `enrich`, a malformed one to `repair-criteria`. `--type epic` is exempt (its criteria arrive per child from the plan ledger) and `--ready-for human` is unaffected ([#6025](https://github.com/kamp-us/phoenix/issues/6025)) |
-| `triage repair-criteria` | repair an acceptance-criteria block's shape — two repairs, composed in one pass: a level-drifted `## Acceptance criteria` heading rewritten to the conforming `###`, and, when the block carries no checkbox at all, its list items rewritten to unchecked checkboxes with each item's text byte-for-byte unchanged — plain bullets ([#6001](https://github.com/kamp-us/phoenix/issues/6001)) or an ordered `1.` list, one family per block ([#5981](https://github.com/kamp-us/phoenix/issues/5981)). One issue, or `--sweep` over every open issue with a per-issue outcome line; `--dry-run` plans everything and writes nothing, answering `would-repair` with the repairs it would make, so the set of bodies about to be edited is reviewable first. Every repaired body gets one disclosure comment naming its repairs, posted after the read-back — an in-place edit of a filed body GitHub keeps no history of leaves no other record. Authored region only, and anything that is not a pure shape rewrite is refused on `14`, never guessed — a drifted heading text, a section mixing the two list families, prose or another block standing between the list's items, an empty item, a checkbox already beside the items, or a converted item the reader counts no criterion at (the repaired block must read back exactly one criterion per line it rewrote) |
-
-Three properties of that substrate are worth knowing:
-
-- **Every verb in the group allocates from one table** ([`src/triage/codes.ts`](./src/triage/codes.ts)),
-  so a code means one thing across this group. Where it overlaps the two `report` writing
-  verbs — `3`, `5`, `6`, `7`, `8`, `9`, `10`, `11` — the meanings match **code for code**, so
-  a caller driving both groups in one sweep reads one meaning. `report dedup` used to break that
-  inside its own group, seating *queue unreadable* / *search index unreadable* on `3`/`4` from a verb
-  file the alignment check could not see; they are `27`/`28` in the group table now, and a check over
-  every verb file keeps the next one from hiding the same way
-  ([#5296](https://github.com/kamp-us/phoenix/issues/5296)).
-- **`4` is a deliberate gap.** It once fused "the target issue is proven absent" with "the
-  target issue could not be read". `7` and `11` took the halves, and the slot is left
-  unallocated rather than compacted — a gap is cheaper than a collision, and it keeps the
-  alignment with `report file`, where `4` is a body-section failure no verb here performs.
-- **Every list read pages and reports its scanned count** on stderr
-  ([`src/triage/scope.ts`](./src/triage/scope.ts)). A verdict driven by a silently truncated
-  read is a verdict over unknown scope; pagination fixes the reach, and printing what was
-  scanned is what makes the reach checkable from outside the process.
+  `proposed`, `superseded` or `retired`. Citing one as settled law is what the split prevents.
 
 ## The `build` group
 
-Everything one construction lane needs, from the candidate pool to the opened pull request. The
-group implements
-[`claude-plugins/fabrika/skills/build/contract.md`](../../claude-plugins/fabrika/skills/build/contract.md).
-
-| Verb | What it answers |
-|---|---|
-| `build pick` | the ranked candidate pool, with every excluded issue reported beside it under the axis that refused it. Four axes report: `out-of-scope` and `audience-not-agent` from the shared admission test, `unreadable`, and `no-acceptance-criteria` — a body with no block the wire reader answers `Found` on, which is a lane that could otherwise only fail at `review criteria` once a whole build was spent. The body rides the listing read the filter already performs, so the axis costs no second call ([#6025](https://github.com/kamp-us/phoenix/issues/6025)) |
-| `build issue` | the claimed issue's body and its criteria, transporting the wire read's three arms — `found` / `absent` / `malformed` — as distinct facts on exit 0. It is a read verb and refuses none of them; the refusals live at the stamp and the pick |
-
-## The `review` group
-
-Everything a text review needs off one pull request, plus the one sanctioned way to write a
-verdict back. The group implements
-[`claude-plugins/fabrika/skills/review/contract.md`](../../claude-plugins/fabrika/skills/review/contract.md).
-
-| Verb | What it answers |
-|---|---|
-| `review scope` | head SHA, linked issue, the code / doc / skill partition of the changed files, and the `self` / `harness` flags — the list read at the printed commit, never beside it |
-| `review diff` | the diff bytes at the bound commit, with truncation refused rather than passed through |
-| `review criteria` | the linked issue's acceptance-criteria block, through the registered wire format |
-| `review ci` | the live check-run rollup at a head, fail-closed on incomplete enumeration |
-| `review verdicts` | every verdict marker on the PR, each with its `current` / `stale` / `unbindable` binding |
-| `review deviations` | the PR body's `## Deviations` state, its entries, and the Tier-M token scan over the diff at the bound commit |
-| `review post` | the single sanctioned verdict emit — compose, bind, one comment per namespace, read back |
-| `review append-criterion` | one reviewer-authored criterion appended under ADR 0079's four fences |
-
-- **A check that cannot see what it is looking for does not return a plausible value.** An
-  unreadable response, a provably short read and a non-conforming payload each resolve to
-  their own loud refusal — `11`, `13` and `7` — and never to a clean pass. That is the whole
-  reason `13` exists beside the other two ([`src/review/codes.ts`](./src/review/codes.ts)).
-- **The overlapping exit codes are imported, not restated** — `3`, `5`, `6`, `7`, `8`, `9`,
-  `10` and `11` come from `../report/codes.ts` and `../triage/codes.ts` by re-export, so they
-  cannot drift from the shipped values.
-- **`current` / `stale` / `unbindable` stay three outcomes.** `review verdicts` is the first
-  consumer of [`verdict-marker.ts`](./src/wire/verdict-marker.ts)'s `bindToHead`, and folding
-  any two of them together is how a stale PASS reads as a current one.
-- **Four modules are imported rather than re-derived**: the AC parser, the verdict-marker
-  parser, `normalizeForReadback`, and the machine-local-path predicate.
-- **Every guard is demonstrated failing.**
-  [`src/review/mutation.unit.test.ts`](./src/review/mutation.unit.test.ts) plants a
-  counterexample per guard, breaks exactly that guard, and asserts the verb returns the
-  specific wrong answer instead — a guard that cannot be shown failing is not demonstrated.
-
-## The `ship` group
-
-Everything the merge path needs off one pull request, plus the four writes that arm, watch,
-disarm and record it. The group implements
-[`claude-plugins/fabrika/skills/ship/contract.md`](../../claude-plugins/fabrika/skills/ship/contract.md).
-
-| Verb | What it answers |
-|---|---|
-| `ship scope` | head, lifecycle state, linked issue, artifact classes with their required namespaces, and the three-state §CP classification |
-| `ship cp-approval` | the ADR 0175 cardinality discharge — `discharge` / `stop` / `n/a`, from head-bound signals only |
-| `ship gate` | the verdict conjunction over every required namespace, advisory and native-review fold included |
-| `ship checks` | the head CI rollup, with the running-vs-wedged split and the zero-checkset facts |
-| `ship evidence` | the SHA-bound run-evidence bundle as `present` / `pending` / `absent` / `unknown` |
-| `ship threads` | every unresolved review thread, both pagination layers count-proved, with its class facts |
-| `ship resolve` | the sanctioned thread-resolution write, refusing any thread not positively bot-classed |
-| `ship enqueue` | the queue arm at a pinned head, method-flag-free by construction, proven landed |
-| `ship reconcile` | the bounded post-enqueue watch — `landed` / `ejected` / `unresolved` / `parked` |
-| `ship disarm` | the four-site merge-intent lifecycle (ADR 0198), read-back-verified |
-| `ship nudge` | the at-most-once dropped-trigger remedy, precondition re-derived here |
-| `ship note` | the durable stop-path comment, leak-scanned and read back |
-| `ship release` | dark-ship detection and the `status:awaiting-release` label |
-
-- **The §CP boundary is derived from `.github/CODEOWNERS` itself**, read at the base branch,
-  so this group and the merge gate read one artifact and cannot disagree. A *trivial* boundary
-  — no team-owned rows, or a row that covers everything — is a printed hold, never a
-  match-everything verdict; an *unreadable* one is `11` ([`src/ship/codeowners.ts`](./src/ship/codeowners.ts)).
-- **Three modules are extended rather than forked**: the class map and the check-run rollup
-  are the `review` group's own ([`src/review/classes.ts`](./src/review/classes.ts),
-  [`src/review/rollup.ts`](./src/review/rollup.ts)), and `normalizeForReadback` and the leak
-  predicate come from `report`. Ship and review cannot disagree about what a file is.
-- **`16` and `17` are this group's own proven refusals.** `16` is the write-side state guard —
-  the verb re-derives its own precondition and declines without touching the PR. `17` says the
-  nudge's close landed and its reopen is unconfirmed, a state so much worse than a failed write
-  that folding it into `8` would hide the one fact an operator must act on now.
-- **Exactly two verbs use GraphQL** (`threads`, `resolve`), because review-thread resolution
-  state has no REST equivalent. Every other verb is `gh api` REST, paginated, with the
-  platform's declared count carried beside what arrived.
-
-## The `map` group
-
-Charting one destination's fog. The group implements
-[`claude-plugins/fabrika/skills/wayfinding/contract.md`](../../claude-plugins/fabrika/skills/wayfinding/contract.md).
-The map is a GitHub issue carrying `wayfinding:map`; its frontier is that issue's **sub-issues**,
-and the topology between them is GitHub's **native issue-dependency edges** — never prose in a body.
-
-| Verb | What it answers |
-|---|---|
-| `map open` | the map for a destination — minted or resumed, refusing one that is not fog |
-| `map read` | the whole state: five sections, one row per frontier ticket, the frontier token, the digest |
-| `map ticket` | one frontier ticket, filed and linked and edged and spliced onto the map, as one act |
-| `map lane` | a research lane on one ticket, claimed under this run's nonce |
-| `map finding` | a lane closed with an outcome from a closed set of three |
-| `map fork` | where a question is being answered instead — a `grilling` session or a `prototyping` spike |
-| `map record` | the lockstep: the answer under `## Decisions`, the row off the frontier, the ticket closed |
-| `map descope` | a rejected direction appended to the never-graduating out-of-scope section |
-
-- **A line's section is not its state.** State is resolved from the ticket's marker, its `state` on
-  GitHub and its edges; the body rows are re-rendered from that answer
-  ([`src/map/frontier.ts`](./src/map/frontier.ts)). v1 encoded state as which heading a bullet sat
-  under, in a body no shipped tool wrote, and then had to read "tolerantly" to cope with its own
-  drift.
-- **All four frontier tokens exit `0`.** `awaiting-founder`, `lanes-pending`, `clear` and `empty` are
-  four answers. A frontier holding open questions is the skill working, and seating it on a non-zero
-  code would make `[ $? -ne 0 ]` read "the fog is not cleared yet" as "the verb never ran".
-- **Every body write is a compare-and-set slice.** `--digest` guards the write and the write replaces
-  one section's bytes, so a concurrent edit to another section survives even when the guard admits
-  the write ([`src/map/body.ts`](./src/map/body.ts)).
-- **Lane traffic goes to the ticket, never to the map body.** `map finding` writes a comment and
-  releases the lane; only `map record` touches the body, so a parallel burndown sees one body write
-  per *resolution* rather than one per lane event.
-- **The lane key is the caller's run nonce**, eight lowercase hex, passed explicitly. A session id is
-  pane-constant and shared across sibling subagents, so two lanes of one run would key onto one
-  namespace and each would read the other's claim as its own.
-- **A `404` on a dependency read is a verdict about the issue, not about its edges**
-  ([`src/io/edges.ts`](./src/io/edges.ts)). Every edge read is preceded by an existence read, every
-  list pages, and an empty read that cannot be *proven* empty is `11` — never an empty frontier.
-- **`10` is a deliberate gap.** No `map` verb accepts a label flag or writes a classification, so the
-  base's `10` is unreachable here rather than merely unused
-  ([`src/map/codes.ts`](./src/map/codes.ts)).
-
-## The `grill` group
-
-The contract is
-[`claude-plugins/fabrika/skills/grilling/contract.md`](../../claude-plugins/fabrika/skills/grilling/contract.md).
-A **grilling session** is one GitHub issue carrying the `grilling:session` label; rounds of
-questions, the answers an agent establishes and the rulings the founder makes all live in its
-comments.
+Everything one construction lane needs, from the candidate pool to the opened pull request.
+Contract: [`skills/build/contract.md`](../../claude-plugins/fabrika/skills/build/contract.md).
 
 | Verb | Answers |
 |---|---|
-| `grill open` | opens, or resumes, the session issue for a topic — `created` says which |
-| `grill round` | validates one round read from stdin, posts it, and returns its number, digest, ids and comment ids |
-| `grill answer` | records an agent-established answer to a `fact` question, behind a kind guard |
-| `grill rule` | records a founder ruling, refusing without a verbatim dated authorization |
-| `grill read` | per-question state, ACL-resolved and digest-checked, plus the frontier token and every disregarded marker |
+| `build tree` | whether the ground is clean and this lane's, wherever it sits |
+| `build pick` | the ranked candidate pool, with every excluded issue under the axis that refused it |
+| `build eligible` | whether one issue's dependency gate is open |
+| `build claim` / `confirm` / `release` / `adopt` | the lane's claim on an issue: race it, re-prove it, retract it, or take a dead session's |
+| `build issue` | the claimed issue's body and its criteria — `found` / `absent` / `malformed`, all on exit 0 |
+| `build branch` / `scratch` | the lane's branch off a fresh base, and its scratch directory |
+| `build commit` / `push` | the commit whose message is proven this lane's, and the push whose ref is proven moved |
+| `build check` | this surface's validators, run here with the build cache bypassed |
+| `build pr` / `pr-body` / `note` | the guarded, read-back PR write surfaces |
+| `build verdicts` | the latest gate verdict per namespace at a PR's live head |
+| `build clear` | the founder's clearance of one extra repair round |
 
-Four properties are worth knowing before you call them:
+**Exit codes.** The shared table, plus: `13` uncommitted changes at a `--require-clean` open ·
+`14` the checked-out branch is not this lane's · `15` this session does not hold the claim ·
+`16` the issue is blocked · `17` the push ran and the remote ref did not move · `18` this tree's
+validation is red · `19` the push is unsafe (detached HEAD, or non-fast-forward with no lease) ·
+`20` out of scope · `21` the `ready-for:` audience is not agent · `22` every changed file falls
+outside all three surfaces' validators · `23` the local head would drop published commits ·
+`24` `git commit` ran and HEAD did not move · `25` this account may not clear a cap · `26` the
+quoted authorization is empty or undated · `29` the grant is on the PR and the local lane did not
+take it · `30` the deliverable is not a pull request a build lane produces · `31` the claim's mode
+and the child's standing verdict disagree. `12` is a retired seat.
 
-- **A recorded ruling is bound to an authority, not to a string.** Every marker's author is
-  resolved against repository permissions
-  ([ADR 0055](../../.decisions/0055-acl-sourced-review-authz.md)), and a permission read that
-  *fails* is UNKNOWN, never a demotion. No verb decides authority from what a comment says
-  about itself.
-- **A ruling is bound to the text it ruled.** The round digest covers the round's question text
-  and nothing else, so re-wording a question makes the recomputed digest differ and `grill read`
-  reports it `stale` — un-ruled again. That neutrality rests on a prohibition: no verb ever edits
-  an existing comment.
-- **All four frontier tokens exit `0`.** `awaiting-founder`, `facts-pending`, `clear` and `empty`
-  are four answers. An open frontier is this skill working, not a failure.
-- **A malformed marker is visible, never absent.** `grill read` never refuses on marker content:
-  a marker that is malformed, unauthorized or bound to nothing is a `disregarded` row at exit `0`.
-  Refusing would let one bad comment suppress the whole frontier answer.
+## The `ci` group
 
-This group records no merge-gating verdict and computes no second answer to control-plane
-membership, pitch approval or triage classification — each is already enforced at its own gate.
-
-## The `spike` group
-
-The contract is
-[`claude-plugins/fabrika/skills/prototyping/contract.md`](../../claude-plugins/fabrika/skills/prototyping/contract.md).
-A **spike** is one GitHub issue carrying the `prototyping:spike` label, bound to a throwaway
-workspace that lives under the OS temp root — **never inside the repository** — and keyed on a
-per-run nonce.
+The release path and the build path — the workflow plumbing, not guards. A mistake here breaks
+cutting a release or breaks the evidence a merge gate reads.
 
 | Verb | Answers |
 |---|---|
-| `spike open` | mints the spike issue and this run's workspace, and binds the two in a manifest |
-| `spike run` | executes one command in the workspace and appends an immutable evidence record |
-| `spike capture` | posts the decision plus the log's own run table, reads it back, and closes the spike |
-| `spike dispose` | proves the tree is unchanged and the capture still covers the log, removes the workspace, and proves it is gone |
-| `spike status` | one run's spike state, workspace presence and evidence count |
+| `ci changelog` | one Keep-a-Changelog release section derived from a range's closed-issue/merged-PR metadata (ADR [0069](../../.decisions/0069-derived-changelog-from-shipped-work.md)) |
+| `ci pr-body` | a standing Release PR body with every stray HTML tag neutralized, so release-please can parse its own PR back |
+| `ci annotate` | a typecheck's output echoed through unchanged, each tsc diagnostic re-emitted as a `::error` workflow command |
+| `ci evidence` | the ADR [0054](../../.decisions/0054-run-evidence-bundle.md) §2 run-evidence manifest for a crabbox run, which `ship evidence` binds to a head SHA |
 
-Five properties are worth knowing before you call them:
+**Exit codes.** `3` empty stdin · `4` an input document parsed and violated its schema · `8` the
+output file could not be written · `11` a read the answer rests on failed.
 
-- **"Ran and answered no" and "could not run" are opposite answers.** `spike run` exits `0`
-  whatever the command returned — the command's own status rides in the payload as `commandExit`
-  — and exits `11` only when the command could not be executed at all. This is the one place in
-  the group where the exit code and the answer are deliberately about different things.
-- **The key is a per-run nonce, minted from a cryptographic source.** No verb reads
-  `CLAUDE_CODE_SESSION_ID` or any session variable, and no verb asks a caller to invent a value,
-  so two concurrent spikes cannot collide on a workspace ([#4544](https://github.com/kamp-us/phoenix/issues/4544)).
-- **Disposability is a property, not an intention.** `spike open` records a digest of
-  `git status --porcelain=v1 --untracked-files=all --ignored=matching`, and `spike dispose`
-  recomputes it *before* it removes or posts anything — so a leak refuses on `17` with the
-  workspace intact. `--ignored=matching` is load-bearing: a build cache or a `node_modules/` is
-  exactly where a prototype writes.
-- **A decision with no recorded run is a self-report.** `spike capture` reds on a log holding zero
-  runs (`14`, ADR [0092](../../.decisions/0092-gates-fail-closed-on-zero-scope.md)), and the
-  comment it posts transcribes each run's command and status rather than summarising them.
-- **`spike status` is near-total on purpose.** Its consumer is a session resuming cold, so an
-  absent workspace is a **fact** at exit `0` while the same absence is a refusal (`12`) in the
-  mutating verbs. The bound is still ADR 0092: an unparseable record is `4` and an unreadable
-  state is `11`.
+Two things here do not follow the ordinary verb shape, and both are forced:
 
-This group gates no merge, judges no pull request and emits no verdict, so it registers in no
-verdict namespace and no wire format — a `spike` marker there would be one `wire read` could never
-read back.
-
-## The `handoff` group
-
-The contract is
-[`claude-plugins/fabrika/skills/handoff/contract.md`](../../claude-plugins/fabrika/skills/handoff/contract.md).
-A **pack** is one comment on the work's issue, carrying two halves: the four sections the model
-wrote, and the ground state the verb derived. It is how one session hands its work to the next when
-the two share no memory, no checkout and possibly no machine.
-
-| Verb | Answers |
-|---|---|
-| `handoff capture` | the ground state — branch, head, reachability, tree, base, issue and pull-request state — as one JSON object |
-| `handoff take` | composes the pack from stdin plus a fresh capture, leak-scans it, posts it as one comment, and reads it back |
-| `handoff read` | the latest sealed pack, its two halves, and the drift field by field against the ground re-derived now |
-| `handoff claim` | claims that pack, keyed on the run nonce — `held` or `resumed`, and a refusal on anyone else's |
-
-Five properties are worth knowing before you call them:
-
-- **The caller cannot supply the proven half.** `take` derives it itself, because a
-  caller-supplied ground state is the premise-inheritance the two-half split exists to prevent
-  (#4133). The body arrives on stdin only: there is no `--body` and no `--body-file`, so a
-  machine-local path has no route into a posted artifact (#3086, #3173).
-- **The section set is closed.** A fifth heading, prose before the first heading, or text after the
-  JSON fence is a refusal on the way in and on the way out. An artifact whose section set is open
-  can steer its receiver past the artifact, and the receiver cannot tell the format's own words
-  from someone else's.
-- **There is no way to read a pack without its drift.** `read` re-derives the ground against the
-  **packed** branch, never the successor's `HEAD`, and reports the sixteen observable fields of the
-  nineteen it digests. A caller who could skip the drift check would sometimes skip it, and a pack
-  read as current while stale is the failure this group is built against (#3330).
-- **Unreachable work refuses rather than warns.** An unpushed commit and a modified tracked file are
-  both invisible to a fresh checkout, so `take` refuses `12` and names the remedy — which is the
-  caller's, outside this group. `--declare-unreachable` records the loss instead of silencing it.
-- **The same fact is `0` on `read` and `13` on `claim`.** An issue with no pack is `read`'s ordinary
-  `none` token, because most issues have none; `claim` *acts*, so claiming a pack that does not
-  exist is a request it cannot honour.
-
-This group applies no label, closes nothing, opens no pull request, emits no verdict marker, and
-pushes nothing. Nothing it records can block a merge — a session state that gated one would make
-every interrupted session a blocked one.
-
-## The `heal-ci` group
-
-The contract is `claude-plugins/fabrika/skills/heal-ci/contract.md`, which this group was written
-against. It has not landed yet — that path is where the contract will live, so it is left unlinked
-rather than pointing at a file that is not there.
-This is the repair lane: it takes a stranded or red pull request and drives it back toward green
-without a human reading logs. A **strand** is a PR nobody is moving; a **signature** is the one row
-of a closed table a failure log matches.
-
-| Verb | Answers |
-|---|---|
-| `heal-ci diagnose` | one PR's stall class from an ordered, total predicate chain, with the evidence that proves it |
-| `heal-ci sweep` | every open PR classified with its strand age — the scheduled surface |
-| `heal-ci surface` | declared required contexts against the runs that actually post at the head |
-| `heal-ci logs` | the failed-job log text for **every** failing gating context at a head |
-| `heal-ci classify` | pure: log text on stdin → one signature from a ten-row ordered table, default-deny |
-| `heal-ci rerun` | the at-most-once transient rerun, precondition re-derived inside the verb |
-| `heal-ci note` | the durable stop-path comment |
-
-Six properties are worth knowing before you call them:
-
-- **Every classification is an exit-`0` answer**, `red` and `wedged` and `not-open` included. A
-  non-zero exit means the verb could not produce an answer — v1's green head exited `3`, which made
-  its most successful outcome a failure to every caller using the toolkit's own `|| exit 1` idiom.
-- **The chain is ordered, and the order is the contract.** `check-surface` fires above `red` because
-  a required context no run produces cannot be healed by anything a log classifier does, and
-  `attended` sits above every strand class because a PR whose author pushed two minutes ago is not
-  abandoned.
-- **`unprobeable` is not `no-requirements`.** The branch-protection endpoint answers `404` both when
-  a branch is unprotected and when the token cannot see it, so `no-requirements` additionally needs a
-  successful rules read that returned nothing. Where the surface is unprobeable, `diagnose` skips
-  that arm with a notice rather than passing it — a permission the token lacks never reads as a
-  surface that is clean.
-- **`unclassified` is a third token, deliberately.** Fusing "I recognise a deterministic bug" with "I
-  recognise nothing" means a caller can never count how often the classifier is guessing, and the
-  routing differs. There is no path from ambiguous input to `transient`.
-- **The rerun guard lives in the verb.** `rerun` re-derives the head binding, the failure state and
-  at-most-once — from two independent, fully paginated signals — then requires a **read-back new
-  attempt** before any marker is written. v1 wrote its marker on the strength of the dispatch
-  response and thereby blocked every future rerun of a run that never re-ran. Exit `16` is the loud
-  one: the rerun landed and the record did not.
-- **`sweep` writes nothing.** It files no issue, assigns nobody and spawns nothing (ADR 0205): a
-  detector emits claimable work and normal pull adopts it. A board it could not read whole is a
-  refusal, never a shorter list.
-
-Filing is `report file`'s and is not respecified here, which is why `4` stays a deliberate gap in
-this group's table.
+- **`ci annotate` writes its own streams** instead of returning a `VerbOutcome`, because the whole
+  point of a pass-through filter is that the CI log stays live. It always exits `0`: the
+  typecheck's redness rides on the producer's exit code through `set -o pipefail`.
+- **`ci-required` is a bare bin, not a verb** — [`src/ci/required-bin.ts`](./src/ci/required-bin.ts),
+  the aggregator deciding whether every should-have-run gating job actually ran (ADR
+  [0092](../../.decisions/0092-gates-fail-closed-on-zero-scope.md)). Its job runs on every PR and
+  installs no dependencies, so nothing on its entry path may import `effect`. The job set it covers
+  is declared once, in `ci.yml`'s `CI_REQUIRED_JOBS`, beside the `needs:` list it must match.
 
 ## The `glossary` group
 
-The contract is
-[`claude-plugins/fabrika/skills/glossary/contract.md`](../../claude-plugins/fabrika/skills/glossary/contract.md).
-A **register** is one of the two markdown files the repo's canonical vocabulary lives in —
-`.glossary/TERMS.md` for the domain nouns and `.glossary/LANGUAGE.md` for the architecture
-vocabulary — and every verb here resolves it against the **target** repo's root, never against the
-installed plugin.
+Maintain the repo's canonical vocabulary registers — `.glossary/TERMS.md` for the domain nouns and
+`.glossary/LANGUAGE.md` for the architecture vocabulary. Every verb resolves the register against
+the **target** repo's root, never the installed plugin. Contract:
+[`skills/glossary/contract.md`](../../claude-plugins/fabrika/skills/glossary/contract.md).
 
 | Verb | Answers |
 |---|---|
@@ -619,72 +248,117 @@ installed plugin.
 | `glossary add` | inserts or replaces one row, alphabetically placed and byte-preserving elsewhere |
 | `glossary check` | row-shape, duplicate-key, cross-register, ordering and citation-liveness defects |
 
-Five properties are worth knowing before you call them:
+**Exit codes.** The shared table, plus `12` a term collision · `13` the named section is absent ·
+`14` a row's shape is invalid · `15` the edit would have changed a line beyond its own row. `5` is
+a deliberate gap.
 
-- **Absent and present-and-empty are different facts and never share a code.** An absent register
-  is `bootstrap` on exit `0` — day one in an adopting repo
-  ([#4776](https://github.com/kamp-us/phoenix/issues/4776)) — while a register that is present and
-  holds zero rows reds `check` on `7`, because a scan of nothing must never report `clean`
-  (ADR [0092](../../.decisions/0092-gates-fail-closed-on-zero-scope.md)). A register that could not
-  be *read* is `11` throughout.
+Three behaviours are worth knowing:
+
+- **Absent and present-and-empty are different facts.** An absent register is `bootstrap` at exit
+  `0` — day one in an adopting repo — while a present register holding zero rows reds `check` on
+  `7`, because a scan of nothing must never report `clean`.
 - **The whole first cell is one key.** `Database (tag)` and `tag` are different terms that
-  *overlap*; a parenthetical is a disambiguating qualifier, not an alias, and splitting one produced
-  three false duplicates the last time it was tried
-  ([#4206](https://github.com/kamp-us/phoenix/issues/4206)). `lookup` reports the overlap and leaves
+  *overlap*; a parenthetical is a qualifier, not an alias. `lookup` reports the overlap and leaves
   the judgement to the skill.
-- **`add` changes one line and proves it.** It asserts the composed text differs from the original in
-  exactly its own splice before writing (`15` aborts with nothing written), then re-reads the row
-  that landed and refuses on `9` when it is not what was composed — a different fact from a write
-  that failed, which is `8`.
-- **Suppression is equality on the normalized key.** v1 suppressed a drift candidate when a declared
-  term contained it *or* it contained a declared term, which against a 226-row register measured
-  about 10% precision ([#4481](https://github.com/kamp-us/phoenix/issues/4481)). And the tokenizer is
-  Unicode-classed rather than ASCII, so the Turkish product nouns the glossary exists for are visible
-  at all.
-- **Two defect classes are deliberately not computed.** Machine-local paths in a register and dead
-  internal links are each decided by a merge-blocking gate, so `check` states the expectation and
-  leaves the verdict where it is enforced — a second answer could report `clean` while the gate reds.
-  Exit seats `5` and `6` are held empty for exactly that reason rather than left unallocated.
+- **Two defect classes are deliberately not computed.** Machine-local paths and dead internal links
+  are each decided by a merge-blocking gate, so `check` states the expectation and leaves the
+  verdict where it is enforced. Seats `5` and `6` are held empty for that reason.
 
-This group reaches no network and touches no GitHub artifact: every read is the local tree. It gates
-no merge and emits no verdict, so it registers in no verdict namespace and no wire format.
+This group reaches no network: every read is the local tree. It gates no merge and emits no verdict.
 
-## The `ci` group
+## The `governance` group
 
-The workflow plumbing, migrated here from the v1 CLI alongside the guards
-([#6099](https://github.com/kamp-us/phoenix/issues/6099)). These are **not** guards: they are the
-release path and the build path, where a mistake breaks cutting a release or breaks the evidence a
-merge gate reads, rather than breaking a check.
+Keep the governance corpus honest across a diff. The **governance namespace** is derived from a
+diff — named by a PR or by a `--base`/`--tip` range — and is required when any changed path sits
+under one of four harness roots (`.decisions/`, `.claude/`, `.github/`, `claude-plugins/`).
+Contract:
+[`skills/governance/contract.md`](../../claude-plugins/fabrika/skills/governance/contract.md).
 
 | Verb | Answers |
 |---|---|
-| `ci changelog` | one Keep-a-Changelog release section derived from a range's closed-issue/merged-PR metadata (ADR [0069](../../.decisions/0069-derived-changelog-from-shipped-work.md)) |
-| `ci pr-body` | a standing Release PR body with every stray HTML tag neutralized, so release-please can parse its own PR back ([#5946](https://github.com/kamp-us/phoenix/issues/5946)) |
-| `ci annotate` | a typecheck's output echoed through unchanged, with each tsc diagnostic re-emitted as a `::error` workflow command ([#3873](https://github.com/kamp-us/phoenix/issues/3873)) |
-| `ci evidence` | the ADR [0054](../../.decisions/0054-run-evidence-bundle.md) §2 run-evidence manifest for a crabbox run, which `ship evidence` reads back and binds to the head SHA |
+| `governance scope` | whether the diff derives the namespace, over which roots, with the bound head or range |
+| `governance sweep` | the uncited live-`accepted` records whose domain a subject touches, ranked |
+| `governance guards` | the anchored invariants the bound diff removes or modifies |
+| `governance base` | this skill's own text at the subject's merge base — the self fence's bytes |
+| `governance post` | the single sanctioned emit of the `governance` namespace verdict |
+| `governance digest` | the decision records that landed in a window, with each landing commit |
+| `governance readout` | the digest-publishing protocol: compose, upsert, read back |
 
-Two things in the group do not follow the ordinary verb shape, and both are forced:
+**Exit codes.** The shared table, plus `12` the `--sha` given is not the PR's head · `13` a read
+completed and its scope is provably incomplete · `14` this diff derives no governance namespace.
+`4` is a deliberate gap.
 
-- **`ci annotate` writes its own streams** instead of returning a `VerbOutcome`. The outcome shape
-  buffers stdout until the verb finishes, and the whole point of a pass-through filter is that the
-  CI log stays live while the typecheck runs. It also always exits `0` — it is a reporter, and the
-  typecheck's redness rides on the producer's exit code through `set -o pipefail`, so a non-zero
-  exit here would only ever mask which side of the pipe actually failed.
-- **`ci-required` is a bare bin, not a verb** —
-  [`src/ci/required-bin.ts`](./src/ci/required-bin.ts), the aggregator that decides whether every
-  should-have-run gating job actually ran (ADR
-  [0092](../../.decisions/0092-gates-fail-closed-on-zero-scope.md)). Its gate job runs on every PR
-  and installs no dependencies, so nothing on its entry path may import `effect`; a registered
-  `Command` would put the whole CLI dependency tree on the always-on aggregator's critical path. The
-  job set it covers is declared once, in `ci.yml`'s `CI_REQUIRED_JOBS`, beside the `needs:` list it
-  must match — a declared job whose `env:` keys are absent reds rather than reading as not-required.
+Three behaviours are worth knowing:
+
+- **This is not the §CP answer, and `governance scope` says so on stderr on every run.** fabrika's
+  §CP model is CODEOWNERS-only, so a second answer here could contradict a merge-gating verdict.
+- **No outcome here is a clearance.** `sweep`'s `no-overlap` carries that sentence verbatim in its
+  `reason`, and `guards`'s `no-anchors-in-reach` is the mechanical floor reporting its own silence:
+  a guard weakened in prose carrying no anchor is invisible to the scan by construction.
+- **The anchor inventory lives in the guarded file.** An anchor is the `<!-- anchor: NAME -->`
+  comment a skill already carries, so the set cannot rot while the guards move.
+
+## The `graduate` group
+
+Turn a cleared decision trail — a grilling session or a wayfinding map — into one buildable spec
+issue. Contract:
+[`skills/graduate/contract.md`](../../claude-plugins/fabrika/skills/graduate/contract.md).
+
+| Verb | Answers |
+|---|---|
+| `graduate trail` | one source resolved into a provenance-tagged decision trail |
+| `graduate compose` | the four-section spec body, rendered from the trail plus stdin |
+| `graduate emit` | the one spec issue filed, and the emission recorded on the source |
+| `graduate read` | whether this source already graduated, and into what |
+
+**Exit codes.** The shared table, plus `12` the source carries neither `grilling:session` nor
+`wayfinding:map`, or both · `13` the trail holds an unresolved decision · `14` a decision entry has
+no digested field · `15` this spec digest already emitted an issue · `16` the trail holds zero
+decisions · `17` the stdin body carries a `## Decisions` heading of its own · `18` a ref the spec
+carries is absent from the re-derived trail, or its text changed.
+
+## The `grill` group
+
+Run a grilling session on a GitHub issue. A session is one issue carrying `grilling:session`;
+rounds, the answers an agent establishes and the rulings the founder makes all live in its
+comments. Contract:
+[`skills/grilling/contract.md`](../../claude-plugins/fabrika/skills/grilling/contract.md).
+
+| Verb | Answers |
+|---|---|
+| `grill open` | opens, or resumes, the session issue for a topic — `created` says which |
+| `grill round` | validates one round from stdin, posts it, and returns its number, digest and ids |
+| `grill answer` | records an agent-established answer to a `fact` question, behind a kind guard |
+| `grill rule` | records a founder ruling, refusing without a verbatim dated authorization |
+| `grill read` | per-question state, ACL-resolved and digest-checked, plus the frontier token |
+
+**Exit codes.** The shared table, plus `12` the invoking token is below `write` · `13` the question
+id names no question · `14` the round could not be digested · `15` `--authorization` is missing,
+empty or undated · `16` more than one open session matches the topic · `17` the question's kind
+does not admit this verb · `18` the question was retired by a later round · `19` a `## Came from`
+section is present and does not conform. `10` is a deliberate gap.
+
+Three behaviours are worth knowing:
+
+- **A recorded ruling is bound to an authority, not to a string.** Every marker's author is
+  resolved against repository permissions
+  ([ADR 0055](../../.decisions/0055-acl-sourced-review-authz.md)), and a permission read that
+  *fails* is UNKNOWN, never a demotion.
+- **A ruling is bound to the text it ruled.** The round digest covers the round's question text, so
+  re-wording a question makes `grill read` report it `stale` — un-ruled again. That rests on a
+  prohibition: no verb ever edits an existing comment.
+- **A malformed marker is visible, never absent.** `grill read` never refuses on marker content: a
+  malformed, unauthorized or unbound marker is a `disregarded` row at exit `0`, so one bad comment
+  cannot suppress the whole frontier answer.
+
+All four frontier tokens exit `0`: `awaiting-founder`, `facts-pending`, `clear` and `empty` are
+four answers, and an open frontier is this skill working.
 
 ## The `guard` group
 
-The repo's fail-closed CI gates, migrating here from the v1 CLI (epic
-[#5720](https://github.com/kamp-us/phoenix/issues/5720)). Unlike every other group this one nests —
-a guard is its own subcommand and `check` is its leaf — so a workflow step and a human reproducing
-its red type the same thing:
+The repo's fail-closed CI gates. Unlike every other group this one nests — a guard is its own
+subcommand and `check` is its leaf — so a workflow step and a human reproducing its red type the
+same thing:
 
 ```bash
 node packages/fabrika-cli/src/bin.ts guard readme-guard check
@@ -692,89 +366,272 @@ node packages/fabrika-cli/src/bin.ts guard readme-guard check
 
 | Verb | Answers |
 |---|---|
-| `guard readme-guard check` | whether every real `packages/*` workspace member carries a `README.md` |
-| `guard skill-lint check` | whether the `claude-plugins/` skill + agent corpus holds a GraphQL-path `gh` call, an unparseable frontmatter block, a bare `git push` in a runnable block, or a plugin path literal that only resolves inside this repo |
-| `guard path-filter-guard check` | whether `deploy.yml`'s `deploy:` run-set still matches `ci.yml`'s `e2e:` one, globs and `token`/`base` diff basis alike |
-| `guard change-detect-guard check` | whether change detection is still on API-free git mode (`token: ''`) rather than the flaky API-HTML path |
-| `guard codeowners-cp check` | whether every path the §CP boundary marks control-plane is owned by a human team in `.github/CODEOWNERS` |
-| `guard decisions-index validate` | whether the ADR corpus holds a duplicate id, a filename that disagrees with its frontmatter, or a missing index field |
-| `guard design-token-guard check` | whether component CSS holds a dead `var()` ref, a raw hex outside the raw-scale layer, or an off-grid px over its file's ceiling |
-| `guard design-inventory check` / `generate` | whether the committed component inventory still matches the JSDoc it is extracted from, and the one write mode that regenerates it |
+| `guard readme-guard` | whether every real `packages/*` workspace member carries a `README.md` |
+| `guard skill-lint` | whether the `claude-plugins/` skill + agent corpus obeys its four mechanical rules |
+| `guard homing-guard` | whether every triaged issue leaves triage with exactly one home |
+| `guard pitch-guard` | whether lane-entering work became pickable only with an approved pitch |
+| `guard roadmap-guard` | whether `ROADMAP.md` and the milestone projection are in sync |
+| `guard unresolved-threads-guard` | whether any unaccounted unresolved review thread reaches merge-ready |
+| `guard settings-env-guard` | whether a `settings.json` env value expects an expansion that never runs |
+| `guard catalog-guard` | whether every dependency is on `catalog:` or `workspace:` |
+| `guard fanout-guard` | whether every fanned mutation publishes its `/fate/live` invalidation |
+| `guard patch-guard` | whether every maintained pnpm patch is pinned by a behavior test |
+| `guard pointer-guard` | whether backticked `CLAUDE.md` path pointers still resolve |
+| `guard publish-isolation-guard` | whether every published package installs from a clean registry |
+| `guard leak-guard` | whether a machine-local path reaches a shared artifact |
+| `guard path-filter-guard` | whether `deploy`'s run-set stays a superset of `e2e`'s |
+| `guard change-detect-guard` | whether change detection is still API-free git mode |
+| `guard codeowners-cp` | whether every §CP path is owned by a human team in `.github/CODEOWNERS` |
+| `guard decisions-index` | whether the ADR corpus holds a colliding or mismatched number |
+| `guard design-token-guard` | whether component CSS consumes the design-token seam |
+| `guard design-inventory` | whether the committed component inventory still matches its JSDoc (`check`), and the one write mode that regenerates it (`generate`) |
 
-Three things are shared by the group rather than rebuilt per guard, which is the point of it
-([#6093](https://github.com/kamp-us/phoenix/issues/6093)):
+**Exit codes.** `0` clean · `7` zero scope (ADR
+[0092](../../.decisions/0092-gates-fail-closed-on-zero-scope.md)) · `11` a read the verdict rests
+on failed, so the answer is UNKNOWN · `12` the scan ran over real scope and the rule is broken.
+Three refusal numbers rather than one, because CI reds on all of them and a human fixing one needs
+to know which.
 
-`skill-lint` also owns its own walk, and that is deliberate: in the v1 CLI the corpus walk, the
-zero-scope floor and the per-plugin coverage assertion lived in forty lines of workflow bash, which
-put four fail-closed decisions where no test could reach them and made a local repro a retyped
-`find`. They are verb code now ([#6098](https://github.com/kamp-us/phoenix/issues/6098)).
+Three things are shared by the group rather than rebuilt per guard, which is the point of it:
 
 - **Scope.** `members.ts` resolves real workspace members — a directory under a declared
   `pnpm-workspace.yaml` glob that carries a `package.json`. A dead-shell directory is not a member,
   and a read that fails is never an empty scan.
 - **The change.** `changed-files.ts` resolves what a change-scoped guard diffs against, per CI leg:
   a PR's target branch, the merge queue's batch base (ADR
-  [0132](../../.decisions/0132-merge-queue-for-base-freshness.md)), a dispatch's default branch, or no
-  baseline at all on `push`. An event it cannot read is `Unresolvable` — never an empty diff.
-- **The verdict.** `verdict.ts` seats every guard on one taxonomy: `0` clean, `12` violation, `7`
-  zero scope (ADR [0092](../../.decisions/0092-gates-fail-closed-on-zero-scope.md)), `11` a read
-  failed so the answer is UNKNOWN. Three numbers, not one, because CI reds on all of them and a
-  human fixing one needs to know which. The report goes to stderr, with GitHub `::error`
-  annotations beside it under Actions — the runner feeds both a step's streams into one command
-  parser, so an annotation on stderr renders exactly as one on stdout, and stdout stays empty on
-  every refusal the way the interface convention requires.
+  [0132](../../.decisions/0132-merge-queue-for-base-freshness.md)), a dispatch's default branch, or
+  no baseline on `push`. An event it cannot read is `Unresolvable` — never an empty diff.
+- **The verdict.** `verdict.ts` seats every guard on the taxonomy above. The report goes to stderr
+  with GitHub `::error` annotations beside it, and stdout stays empty on every refusal.
 
-## The `governance` group
+## The `handoff` group
 
-The contract is
-[`claude-plugins/fabrika/skills/governance/contract.md`](../../claude-plugins/fabrika/skills/governance/contract.md).
-The **governance namespace** is derived from a diff, named either by a PR or by a `--base`/`--tip`
-commit range (an epic child has no PR mid-run) — required when any changed path sits under
-one of four harness roots (`.decisions/`, `.claude/`, `.github/`, `claude-plugins/`) — and this group
-answers the mechanical half of the judgment a governance verdict rests on.
+Hand one session's work to the next when the two share no memory, no checkout and possibly no
+machine. A **pack** is one comment on the work's issue carrying two halves: the four sections the
+model wrote, and the ground state the verb derived. Contract:
+[`skills/handoff/contract.md`](../../claude-plugins/fabrika/skills/handoff/contract.md).
 
 | Verb | Answers |
 |---|---|
-| `governance scope` | whether the diff derives the namespace, over which roots, with the bound head or the named range, the `self` flag and the records in the diff |
-| `governance sweep` | the uncited live-`accepted` records whose domain a subject touches, ranked, for a subject in a bound commit or in the corpus |
-| `governance guards` | the anchored invariants the bound diff removes or modifies, and the guard-bearing files it touches |
-| `governance base` | this skill's own text at the subject's merge base, whether the subject is a PR or a range — the self fence's bytes |
-| `governance post` | the single sanctioned emit of the `governance` namespace verdict |
-| `governance digest` | the decision records that landed in a window, with each landing commit and its anchor delta |
-| `governance readout` | the digest-publishing protocol: compose, upsert, read back |
+| `handoff capture` | the ground state — branch, head, reachability, tree, base, issue and PR state |
+| `handoff take` | composes the pack from stdin plus a fresh capture, leak-scans it, posts it, reads it back |
+| `handoff read` | the latest sealed pack, its two halves, and its drift field by field |
+| `handoff claim` | claims that pack, keyed on the run nonce — `held` or `resumed` |
 
-Five properties are worth knowing before you call them:
+**Exit codes.** The shared table, plus `12` the work is unreachable by a successor and the loss was
+not declared · `13` the issue carries no sealed pack · `14` a pack exists and does not parse, or
+its digest disagrees with its fields · `15` another nonce holds the latest pack's claim. `10` is a
+deliberate gap.
 
-- **This is not the §CP answer, and `governance scope` says so on stderr on every run.** fabrika's
-  §CP model is CODEOWNERS-only with no semantic detection, so a second answer here could contradict a
-  merge-gating verdict. What this derives is a separate namespace whose *verdict* is the skill's
-  judgment.
-- **Nothing is re-derived that already ships.** The root list and its predicate come from
-  [`review/classes.ts`](src/review/classes.ts) — one derivation, read by `ship scope`, `ship gate`'s
-  required-set floor and `governance scope` alike; the ranking core comes from
-  [`adr/sweep.ts`](src/adr/sweep.ts); the commit binding, the leak predicate and the read-back
-  normalizer are all imports.
-- **No outcome here is a clearance.** `sweep`'s `no-overlap` carries that sentence verbatim in its
-  `reason`, and `guards`'s `no-anchors-in-reach` is the mechanical floor reporting its own silence: a
-  guard weakened in prose carrying no anchor is invisible to the scan by construction.
-- **The anchor inventory lives in the guarded file.** An anchor is the `<!-- anchor: NAME -->` comment
-  a skill already carries, so the set cannot rot while the guards move — which is the whole design
-  difference from v1's hardcoded prose list inside the reviewing skill.
-- **The readout gates nothing.** `governance readout` writes one comment and nothing else: no label,
-  no PR, and no exit code meaning "the corpus is in a bad state", because a digest that could red
-  would be the human gate the [#4927](https://github.com/kamp-us/phoenix/issues/4927) ruling retired
-  under a new name.
+Four behaviours are worth knowing:
 
-The group emits the `governance` namespace through the shipped
-[`verdict-marker`](src/wire/verdict-marker.ts) format and publishes its digest through
-[`governance-digest`](src/wire/governance-digest.ts).
+- **The caller cannot supply the proven half.** `take` derives it itself; the body arrives on stdin
+  only, so a machine-local path has no route into a posted artifact.
+- **The section set is closed.** A fifth heading, prose before the first heading, or text after the
+  JSON fence is refused on the way in and on the way out — an artifact whose section set is open
+  can steer its receiver past the artifact.
+- **There is no way to read a pack without its drift.** `read` re-derives the ground against the
+  **packed** branch, never the successor's `HEAD`.
+- **Unreachable work refuses rather than warns.** An unpushed commit and a modified tracked file
+  are invisible to a fresh checkout. `--declare-unreachable` records the loss instead of silencing
+  it.
+
+This group applies no label, closes nothing, opens no PR and pushes nothing. Nothing it records can
+block a merge.
+
+## The `heal-ci` group
+
+The repair lane: take a stranded or red pull request and drive it toward green without a human
+reading logs. A **strand** is a PR nobody is moving; a **signature** is the one row of a closed
+table a failure log matches. Contract:
+[`skills/heal-ci/contract.md`](../../claude-plugins/fabrika/skills/heal-ci/contract.md).
+
+| Verb | Answers |
+|---|---|
+| `heal-ci diagnose` | one PR's stall class from an ordered, total predicate chain, with its evidence |
+| `heal-ci sweep` | every open PR classified with its strand age — the scheduled surface |
+| `heal-ci surface` | declared required contexts against the runs that actually post at the head |
+| `heal-ci logs` | the failed-job log text for **every** failing gating context at a head |
+| `heal-ci classify` | pure: log text on stdin → one signature from a ten-row ordered table, default-deny |
+| `heal-ci rerun` | the at-most-once transient rerun, precondition re-derived inside the verb |
+| `heal-ci note` | the durable stop-path comment |
+
+**Exit codes.** The shared table, plus `12` the live head moved past the inspected `--sha` · `13` a
+read completed and its scope is provably incomplete · `14` proven not in the state this write acts
+on · `15` the run's logs are proven expired or purged · `16` the rerun provably landed and its
+durable marker could not be written. `4` is a deliberate gap.
+
+Five behaviours are worth knowing:
+
+- **Every classification is an exit-`0` answer**, `red` and `wedged` and `not-open` included. A
+  non-zero exit means the verb could not produce an answer at all.
+- **The chain is ordered, and the order is the contract.** `check-surface` fires above `red`
+  because a required context no run produces cannot be healed by a log classifier, and `attended`
+  sits above every strand class because a PR whose author pushed two minutes ago is not abandoned.
+- **`unprobeable` is not `no-requirements`.** The branch-protection endpoint answers `404` both
+  when a branch is unprotected and when the token cannot see it, so `no-requirements` also needs a
+  successful rules read that returned nothing.
+- **`unclassified` is a third token, deliberately.** There is no path from ambiguous input to
+  `transient`, and fusing the two would make it impossible to count how often the classifier is
+  guessing.
+- **`sweep` writes nothing.** It files no issue, assigns nobody and spawns nothing (ADR 0205): a
+  detector emits claimable work and normal pull adopts it. Filing is `report file`'s, which is why
+  `4` stays a deliberate gap here.
+
+## The `hook` group
+
+The envelope Claude Code writes to a hook's stdin, read once here instead of in every hook. This is
+the group [fabrika's hook surface](../../claude-plugins/fabrika/hooks.json) declares against; the
+surface's convention lives in
+[`docs/hook-surface.md`](../../claude-plugins/fabrika/docs/hook-surface.md).
+
+| Verb | Answers |
+|---|---|
+| `hook check` | whether the envelope on stdin is one fabrika can act on |
+| `hook codes` | the exit taxonomy every verb in the group allocates from |
+| `hook spawn` | whether the subagent spawn on stdin may run on the model it asked for |
+
+**Exit codes.** `3` stdin held nothing · `12` bytes arrived and are provably not an envelope ·
+`13` fd 0 could not be read · `14` a readable envelope arrived and is not the event this verb
+judges. Three failure codes rather than one, so an unread pipe cannot pass for a bad payload.
+
+- **The required fields are captured, not assumed.** They are the keys present in both real
+  envelopes committed at `src/hook/__fixtures__/`, with their capture method and harness version
+  beside them (ADR 0180). The golden test runs the argv it reads out of the committed `hooks.json`,
+  so a green test cannot be exercising a verb the surface does not declare.
+- **`hook spawn` is a decision, wrapped thinly.** The allow / allow-inherit / deny outcome is a
+  pure function of `(requested model, WORKFLOW_MODEL pin)` in
+  [`src/hook/spawn.ts`](./src/hook/spawn.ts), over the one model vocabulary in
+  [`src/models.ts`](./src/models.ts).
+
+## The `lane` group
+
+The lane ledger the operator loop drives. A lane is a directory —
+`.fabrika/lanes/<n>/workflow.json` plus an append-only `events.jsonl` — and **fold = state**: every
+verb is a fresh process that re-folds the whole log through a
+[@demlik/tea](https://github.com/kamp-us/demlik) Transitions machine. No resident process, no
+snapshot. Lane state is local and never committed.
+
+| Verb | Answers |
+|---|---|
+| `lane status` | the derived state: compound `stateValue`, active/done, per-task context, tripped tasks |
+| `lane transition` | records one operator event after the machine accepts it |
+| `lane report` | a shell's terminal token, mapped to one operator event |
+| `lane prove` | whether the board agrees with a lane event, before it is recorded |
+| `lane history` | the log verbatim, one `{task, event, at}` per event |
+| `lane print` | the compiled topology: phases, terminals, and each state's legal events |
+| `lane open` / `emit` | boot a lane from a committed template, or generate an epic's machine from its board topology |
+| `lane brief` | the spawn prompt for one task's current leaf state |
+| `lane assembly` / `push` | an epic run's assembly worktree, and its published branch |
+| `lane stale` | which lanes have gone quiet with something owed on them |
+| `lane claim` / `release` | who is driving this lane |
+
+**Exit codes.** `4` the lane read in full and is not the shape · `7` the lane is absent · `8` the
+append or claim write did not land · `9` a claim marker landed and does not read back · `11` the
+lane could not be read · `12` the event is refused and the log is left unappended · `13` the task
+is unknown or `--task` was omitted on a multi-task lane · `14` the lane directory already exists ·
+`15` no readable `## Dependencies` topology · `16` the topology names a non-child · `17` the
+topology holds a cycle · `18` the leaf state routes to no shell · `19` the task's issue could not
+be resolved · `20` several open PRs claim the task's issue · `21` the lane key is malformed ·
+`22`–`25` the proof `lane prove` needed is absent, in flight, contradicted or ambiguous · `26` the
+tree is not on the run's assembly branch · `29` the push would not fast-forward · `30` the push ran
+and the ref did not move · `31` this session does not hold the driver's claim · `32` the terminal
+token is no shell's · `33` an assembly git write was aimed at the main working tree.
+
+To open a lane, copy a template in and speak the operator's six events — `DONE` / `PASS` / `FAIL` /
+`BLOCKED` / `WIP` / `UNBLOCKED`:
+
+```bash
+mkdir -p .fabrika/lanes/5673
+cp packages/fabrika-cli/src/lane/templates/coder.workflow.json .fabrika/lanes/5673/workflow.json
+fabrika lane transition 5673 WIP     # queued → build (--task is implied on a single-task lane)
+fabrika lane status 5673
+```
+
+Three behaviours are worth knowing:
+
+- **An invalid event refuses loudly and appends nothing.** An event the current state holds no cell
+  for surfaces tea's own `NoCellError` verbatim at exit `12`, and `events.jsonl` is left
+  byte-identical — where XState silently swallows an unhandled event, this machine names it.
+- **The compiler recognizes shapes, never guard names.** An array on an event reads structurally as
+  `[retry-while-retries-remain, else-fallthrough]`; a transition targeting a `history` node resumes
+  the state the task left; a phase's `onDone` pair names the workflow terminals. `guard`/`actions`
+  strings in `workflow.json` are inert data.
+- **One committed template today.**
+  [`src/lane/templates/coder.workflow.json`](./src/lane/templates/coder.workflow.json) is the
+  single-issue coder machine: `queued → build → review → ship`, review `FAIL` retried on a budget
+  of 2 then frozen, `BLOCKED`/`UNBLOCKED` suspend-resume from any working state, and ship `BLOCKED`
+  parking in `human:cp-approval` until the approval lands as `UNBLOCKED`.
+
+## The `ledger` group
+
+Author an epic's plan and its children — the write half of epic planning. Contract:
+[`skills/plan-epic/contract.md`](../../claude-plugins/fabrika/skills/plan-epic/contract.md).
+
+| Verb | Answers |
+|---|---|
+| `ledger open` | the ground proved and the plan run opened for an epic |
+| `ledger draft` | the plan block on stdin, validated and staged |
+| `ledger child` | one child issue minted with every birth attribute at once |
+| `ledger topology` | the declared topology validated, and its Dependencies block rendered |
+| `ledger write` | the staged plan and topology spliced into the epic body |
+| `ledger supersede` | a child the re-plan no longer contains, retired |
+
+**Exit codes.** The shared table and the `build` lane seats (`13`–`19`), plus `20` the ground moved
+under the run · `21` the epic body moved — the recomputed digest differs from `--body-digest` ·
+`22` the plan region is unresolvable — a duplicated anchor, or a mode the body contradicts ·
+`23` the child was created and its sub-issue link could not be proven · `24` the declared topology
+is invalid — a cycle, a dangling ref, or an unplaced child · `25` a document this verb must splice
+was never staged in this run · `26` a child was created and the run manifest could not record it.
+
+## The `map` group
+
+Chart one destination's fog. The map is a GitHub issue carrying `wayfinding:map`; its frontier is
+that issue's **sub-issues**, and the topology between them is GitHub's **native issue-dependency
+edges**, never prose in a body. Contract:
+[`skills/wayfinding/contract.md`](../../claude-plugins/fabrika/skills/wayfinding/contract.md).
+
+| Verb | Answers |
+|---|---|
+| `map open` | the map for a destination — minted or resumed, refusing one that is not fog |
+| `map read` | the whole state: five sections, one row per frontier ticket, the frontier token, the digest |
+| `map ticket` | one frontier ticket, filed and linked and edged and spliced onto the map, as one act |
+| `map lane` | a research lane on one ticket, claimed under this run's nonce |
+| `map finding` | a lane closed with an outcome from a closed set of three |
+| `map fork` | where a question is being answered instead — a `grilling` session or a `spike` |
+| `map record` | the lockstep: the answer under `## Decisions`, the row off the frontier, the ticket closed |
+| `map descope` | a rejected direction appended to the never-graduating out-of-scope section |
+
+**Exit codes.** The shared table, plus `12` the body moved since `--digest` was taken · `13` the
+number names no frontier ticket · `14` an edge target is not a ticket of this map, or would close a
+cycle · `15` the nonce does not hold this ticket's lane · `16` more than one open map matches ·
+`17` no supplied line is stated as a question, so the destination is not fog · `18` the ticket
+already left the frontier · `19` already descoped · `20` the ticket's kind does not admit this verb
+· `21` the lane returned no answer. `10` is a deliberate gap.
+
+Five behaviours are worth knowing:
+
+- **A line's section is not its state.** State is resolved from the ticket's marker, its `state` on
+  GitHub and its edges; the body rows are re-rendered from that answer
+  ([`src/map/frontier.ts`](./src/map/frontier.ts)).
+- **All four frontier tokens exit `0`.** `awaiting-founder`, `lanes-pending`, `clear` and `empty`
+  are four answers; a frontier holding open questions is the skill working.
+- **Every body write is a compare-and-set slice.** `--digest` guards the write and the write
+  replaces one section's bytes, so a concurrent edit to another section survives.
+- **Lane traffic goes to the ticket, never to the map body.** Only `map record` touches the body,
+  so a parallel burndown sees one body write per *resolution* rather than one per lane event.
+- **The lane key is the caller's run nonce**, eight lowercase hex, passed explicitly. A session id
+  is shared across sibling subagents, so two lanes of one run would key onto one namespace.
+
+A `404` on a dependency read is a verdict about the issue, not about its edges: every edge read is
+preceded by an existence read, every list pages, and an empty read that cannot be *proven* empty is
+`11`, never an empty frontier.
 
 ## The `pattern` group
 
-The contract these five implement is
-[`claude-plugins/fabrika/skills/write-pattern/contract.md`](../../claude-plugins/fabrika/skills/write-pattern/contract.md).
-A **pattern doc** is one flat `<slug>.md` under a doc directory (`.patterns` by default),
-registered by one row in that directory's `index.md`.
+Read and write the pattern library. A **pattern doc** is one flat `<slug>.md` under a doc directory
+(`.patterns` by default), registered by one row in that directory's `index.md`. Contract:
+[`skills/write-pattern/contract.md`](../../claude-plugins/fabrika/skills/write-pattern/contract.md).
 
 | Verb | Answers |
 |---|---|
@@ -784,266 +641,235 @@ registered by one row in that directory's `index.md`.
 | `pattern new` | scaffolds `<dir>/<slug>.md` from the canonical template |
 | `pattern register` | inserts the doc's row into `<dir>/index.md` under a named section |
 
-Five properties are worth knowing before you call them:
+**Exit codes.** `8`–`11` from the shared table, plus `12` the named slug has no doc file · `13` the
+target path already exists · `14` the edit would have changed a line beyond the one row, aborted
+before writing · `15` the index is absent or holds no parseable table · `16` the named section
+matches more than one heading.
+
+Four behaviours are worth knowing:
 
 - **Every outcome exits `0`, including the empty ones.** `corpus` answers `absent` for a directory
-  that is not in the tree and `none` for one that is and holds nothing; `drift` answers
-  `unanchored`; `anchor` answers `unanchored`. Exit `7` is deliberately unseated — no verb here
-  judges over a corpus, so none has a vacuous pass to prevent, and refusing on an empty library
-  would leave a repo adopting fabrika unable to write its first pattern doc
-  ([#5254](https://github.com/kamp-us/phoenix/issues/5254)).
+  that is not in the tree and `none` for one that holds nothing. Exit `7` is deliberately unseated:
+  no verb here judges over a corpus, so none has a vacuous pass to prevent, and refusing on an
+  empty library would leave a repo adopting fabrika unable to write its first doc.
 - **`unanchored` is not a clearance.** It says the doc cites nothing the verb can follow, so drift
-  there is *unanswerable* — read the source by hand. Reporting it as `current` would be a clean pass
-  over nothing, the shape ADR [0092](../../.decisions/0092-gates-fail-closed-on-zero-scope.md)
-  forbids; the group says so in vocabulary rather than in an exit code, because a verb that refused
-  would break the pipe its answer crosses.
+  is *unanswerable* — read the source by hand.
 - **Registration is three-valued.** `unknown` — the index is absent, or holds no markdown table —
-  is its own value, because rendering it as `unregistered` would report a defect the verb never
-  proved and send a caller to add rows to a file that cannot hold them. A doc counts as registered
-  only when a table row's **first cell** links its filename; a mention in prose is not a
-  registration.
+  is its own value. A doc counts as registered only when a table row's **first cell** links its
+  filename; a mention in prose is not a registration.
 - **An unresolved citation is counted, never a finding.** Pattern prose legitimately cites external
   dependency source trees, and such a path is indistinguishable from a deleted in-repo one by
-  resolution alone. `drift` names each on stderr and excludes it from the moved set, inheriting
-  `pointer-guard`'s `.patterns/**` exclusion rather than repeating the false positive it escaped.
-- **`register` proves its diff before it writes.** The index is hand-curated, carries prose between
-  its tables, and is edited by lanes this verb cannot see, so an insertion that changed any line
-  beyond the new row aborts on `14` with nothing written — and the row is read back after.
+  resolution alone.
 
-The two reads are deliberately different: `corpus`, `drift` and `anchor` read at a fetched `--base`,
-because the question they answer is what the repository already holds; `new` and `register` write the
-**working tree**. A doc created by `new` is therefore invisible to `corpus` until it is committed.
+`corpus`, `drift` and `anchor` read at a fetched `--base`; `new` and `register` write the **working
+tree**, so a doc created by `new` is invisible to `corpus` until it is committed.
 
-This group is an authoring surface: it emits no verdict marker, joins no gate or ship namespace,
-registers no wire format, needs no repository token and writes to no board surface. A `.patterns/*.md`
-diff gates on the doc review namespace like any other doc change.
+## The `plan` group
 
-## The `wire` group
-
-A **wire format** is the byte-level agreement two skills meet through on a GitHub artifact —
-the acceptance-criteria block on a sub-issue body, the verdict marker on a PR, the
-handoff pack one session leaves the next. Each one is
-owned by a typed schema module under [`src/wire/`](./src/wire/) with an `emit` and a
-`read`, registered as one row in [`src/wire/registry.ts`](./src/wire/registry.ts). The
-formats used to live as prose in a skill body, which is why fabrika could not pin one: the
-`### Acceptance criteria` heading was named in no code at all.
+Gate an epic's plan before its children build — the read-and-verdict half of epic planning, where
+`ledger` is the write half. Contract:
+[`skills/check-epic-plan/contract.md`](../../claude-plugins/fabrika/skills/check-epic-plan/contract.md).
 
 | Verb | Answers |
 |---|---|
-| `wire formats` | the registered formats, derived from the registry — key, purpose, producers, consumers |
-| `wire codes` | the exit taxonomy every verb in the group allocates from |
-| `wire emit` | the format's bytes, composed from the fields on stdin |
-| `wire read` | the format's fields, read out of the artifact on stdin |
-| `wire check` | whether the artifact on stdin carries a conforming block, without the fields |
-| `wire doc-section` | one markdown section of the document on stdin (or `--file`), by ATX heading — a shell's single-section contract lookup instead of a whole-file read (#5966) |
-| `wire index` | whether the index doc agrees with the registry — and, with `--write`, the doc's generated table, rendered from it |
+| `plan read` | the epic, its children and its parsed ledger |
+| `plan check` | the deterministic floor over the thirteen hard defect types |
+| `plan flip` | every planned child flipped to triaged, re-gated first |
+| `plan verdict` | the plan gate's verdict, posted bound to the scope digest |
 
-Three properties are worth knowing before you call them:
-
-- **`read` is total, and `found` is its only answer.** The return type is
-  `Found | Absent | Malformed` and nothing else, with `Found` carrying a non-empty list by
-  construction. A heading that drifted — a different spelling, a different level, a section
-  with no checkbox items — is `Malformed`, never a `Found` holding nothing. That is the whole
-  point: the prose-owned era's failure was not a crash, it was a *plausible* empty answer, and
-  a grader reading it passed over nothing without an error.
-- **Absent, malformed and never-seen are three different exit codes.** `3` is a proven
-  negative over an artifact that was read in full; `4` is a proven defect; `6` means fd 0
-  carried nothing readable, so nothing is proven at all. Fusing any pair is what lets an
-  unread artifact pass for a clean one.
-- **The artifact arrives on stdin only.** No `--body`, no `--body-file` — the same reason the
-  `report` and `triage` writing verbs take theirs there: a flag that accepts a path turns the
-  artifact into a string the verb could echo back onto a public surface.
-- **A `found` verdict marker is well-formed, not current.** `verdict-marker` carries the head
-  SHA the reviewer inspected, and a marker bound to a head that has since moved is *stale*, not
-  passing. Whether a marker binds the head you hold is
-  [`verdict-marker.ts`](./src/wire/verdict-marker.ts)'s `bindToHead` — three answers again
-  (`Current` / `Stale` / `Unbindable`), because a head the caller could not resolve is not a
-  comparison anyone made.
-- **`handoff-pack`'s read side refuses instructions it does not own.** Its sections are
-  closed, so a pack carrying an extra heading or a sentence outside every section reads `Malformed`
-  rather than `Found` — coordination output that cannot steer its receiver past the artifact
-  ([`handoff-pack.ts`](./src/wire/handoff-pack.ts)).
-- **The index doc's per-format table is generated, not typed.** `claude-plugins/fabrika/docs/wire-formats.md`
-  used to carry a hand-copied projection of each row's owner module, producers and consumers, which
-  is a second source of truth that agrees until someone lands a format and forgets a line. The table
-  is now rendered from the registry by `wire index --write` and reconciled by `wire index`, which
-  reds on a registered format with no section, a section for no registered format, and a stale
-  region ([`index-doc.ts`](./src/wire/index-doc.ts), #4968). The protocol narrative under each
-  heading stays hand-written — it is the half no row holds.
-- **A registered format is a conforming format.** A registry row carries the fixtures its laws
-  are driven from and the brands its value is built from, and both are required by the row
-  type — so adding a format means filling them in, and
-  [`conformance.ts`](./src/wire/conformance.ts) then holds it to the same laws as every other
-  row without naming it. Weakening one of those brands to a bare `string` stops the *row* from
-  compiling, which is how the type-level half is inherited rather than re-written per format.
-
-```bash
-printf 'the read is total\n[x] the registry is the seam\n' \
-  | node src/bin.ts wire emit --format acceptance-criteria \
-  | node src/bin.ts wire check --format acceptance-criteria
-```
-
-## The `hook` group
-
-The envelope Claude Code writes to a hook's stdin, read once here instead of in every hook.
-This is the group [fabrika's hook surface](../../claude-plugins/fabrika/hooks.json) declares
-against ([#5074](https://github.com/kamp-us/phoenix/issues/5074)); the surface's convention and
-its one interim dispatch-failure policy point live in
-[`claude-plugins/fabrika/docs/hook-surface.md`](../../claude-plugins/fabrika/docs/hook-surface.md).
-
-| Verb | Answers |
-|---|---|
-| `hook check` | whether the envelope on stdin is one fabrika can act on — `conforms\t<hook_event_name>\t<field-count>` |
-| `hook codes` | the exit taxonomy every verb in the group allocates from |
-| `hook spawn` | whether the subagent spawn on stdin may run on the model it asked for — the `PreToolUse` permission decision, denying an off-allowlist model |
-
-Three things shape it:
-
-- **Three failures, three codes.** "Stdin held nothing" (`3`), "bytes arrived and are provably
-  not an envelope" (`12`) and "fd 0 could not be read" (`13`) are different claims, and fusing
-  any two lets an unread pipe pass for a bad payload (ADR 0092).
-- **The required fields are captured, not assumed.** They are the keys present in both real
-  envelopes committed at `src/hook/__fixtures__/`, with their capture method and harness version
-  beside them (ADR 0180). The golden test runs the argv it reads out of the committed
-  `hooks.json`, so a green test cannot be exercising a verb the surface does not declare.
-- **`hook spawn` is a decision, wrapped thinly.** The allow / allow-inherit / deny outcome is a pure
-  function of `(requested model, WORKFLOW_MODEL pin)` in [`src/hook/spawn.ts`](./src/hook/spawn.ts),
-  over the one model vocabulary in [`src/models.ts`](./src/models.ts) — the allowlist, the harness
-  alias map and the committed default pin, which are one table because the request is canonicalized
-  through the aliases *before* the allowlist sees it.
-
-## The `lane` group
-
-The minimal lane ledger the operator loop drives by hand
-([#5673](https://github.com/kamp-us/phoenix/issues/5673); engine direction recorded on
-[#5570](https://github.com/kamp-us/phoenix/issues/5570), de-risked by the recorded-run spikes
-[#5671](https://github.com/kamp-us/phoenix/issues/5671)/[#5672](https://github.com/kamp-us/phoenix/issues/5672)).
-A lane is a directory — `.fabrika/lanes/<n>/workflow.json` plus an append-only `events.jsonl` —
-and **fold = state**: every verb is a fresh process that re-folds the whole log through a
-[@demlik/tea](https://github.com/kamp-us/demlik) Transitions machine; no resident process, no
-snapshot. Lane state is local and never committed (the repo's `/.fabrika/` gitignore entry).
-
-| Verb | Answers |
-|---|---|
-| `lane status` | the derived state: compound `stateValue` (active phase → per-task leaf, future phases `"waiting"`), `status` active/done, per-task `{retries, maxRetries, …}` context and the tripped tasks in `errors` |
-| `lane transition` | records one operator event after the machine accepts it — `{previous, event, current, taskAffected}` |
-| `lane history` | the log verbatim, one `{task, event, at}` per event — `from`/`to` are reconstructible by folding, never stored |
-| `lane print` | the compiled topology: phases, the two workflow terminals, and each state's legal events |
-| `lane stale` | every lane on disk with the age of its last event and one verdict — which lanes are non-terminal, unparked and silent past `--older-than` (default 60 minutes), so a dead operator is detectable instead of invisible |
-| `lane claim` / `lane release` | who is driving this lane: the same detect-then-tiebreak race `build claim` runs, in the driver's own `lane-claim:` namespace, so the builder a driver spawns claims the same issue and wins ([#5761](https://github.com/kamp-us/phoenix/issues/5761)). A `chore:<name>` key carries no board number and answers `unclaimable`/`inert` at exit 0 |
-
-To open a lane, copy a template in and speak the operator's six events —
-`DONE` / `PASS` / `FAIL` / `BLOCKED` / `WIP` / `UNBLOCKED`:
-
-```bash
-mkdir -p .fabrika/lanes/5673
-cp packages/fabrika-cli/src/lane/templates/coder.workflow.json .fabrika/lanes/5673/workflow.json
-fabrika lane transition 5673 WIP     # queued → build (--task is implied on a single-task lane)
-fabrika lane status 5673
-```
-
-Three behaviours are worth knowing before you call it:
-
-- **An invalid event refuses loudly and appends nothing.** An event the current state holds no
-  cell for surfaces tea's own `NoCellError` verbatim at exit `12`, and `events.jsonl` is left
-  byte-identical — where XState silently swallows an unhandled event, the machine here names it
-  (#5671, run 8). The six-event vocabulary, the active-phase check and the finished-workflow
-  check refuse the same way.
-- **The compiler recognizes shapes, never guard names.** An array on an event is read
-  structurally as `[retry-while-retries-remain, else-fallthrough]`; a transition targeting a
-  `history` node resumes the state the task left, carried as a `was` field in the folded state;
-  a phase's `onDone` pair names the workflow terminals. `guard`/`actions` strings in
-  `workflow.json` are inert data — there is no name-normalization anywhere.
-- **One committed template today.** [`src/lane/templates/coder.workflow.json`](./src/lane/templates/coder.workflow.json)
-  is the static single-issue coder machine: `queued → build → review → ship`, review `FAIL`
-  retried on a budget of 2 then frozen (freeze-after-2 as data), `BLOCKED`/`UNBLOCKED`
-  suspend-resume from any working state, and ship `BLOCKED` parking in `human:cp-approval`
-  until the approval lands as `UNBLOCKED`. Per-type templates beyond it are deliberately out of
-  scope until a real lane snaps against the six-event vocabulary (#5570).
+**Exit codes.** The shared table, plus `15` this session does not hold the claim · `20` the floor
+found a hard defect · `21` the recomputed scope digest differs from the `--digest` the caller
+carried · `22` at least one child is `unchanged` — the flip did not fully apply · `23` a label the
+flip must write is absent from the repository's taxonomy.
 
 ## The `recipe` group
 
-The standing driver recipes, versioned once instead of retyped nightly
-([#5840](https://github.com/kamp-us/phoenix/issues/5840)). A recipe is one deterministic verb with
-named exits over a fixed sequence that has no judgment in it: it relays a decision another verb
-already owns and never derives one (ADR
+The standing driver recipes, versioned once instead of retyped nightly. A recipe is one
+deterministic verb with named exits over a fixed sequence that has no judgment in it: it relays a
+decision another verb already owns and never derives one (ADR
 [0228](../../.decisions/0228-scripts-relay-never-derive.md)). Every mutation is proven by a
-read-back before the verb reports success.
+read-back.
 
 | Verb | Answers |
 |---|---|
-| `recipe unpark` | whether a parked lane's park is a known recipe, and on a known one clears it — `lane transition … UNBLOCKED`, emitted only after a second fold reads the task out of the park |
-| `recipe rerun` | the failed workflow runs at a PR's live head, rerequested only behind a `governance` PASS bound to that head, each proven by re-reading its own run record |
-| `recipe route` | which recipe a chore-lane state applies, and which of the machine's six events one of that recipe's exits folds to |
+| `recipe unpark` | whether a parked lane's park is a known recipe, and on a known one clears it |
+| `recipe rerun` | the failed workflow runs at a PR's live head, rerequested only behind a head-bound `governance` PASS |
+| `recipe route` | which recipe a chore-lane state applies, and which of the six events one exit folds to |
 
-Each verb's `--help` is its interface — the exit table lives there, not here:
+**Exit codes.** `4` a record read in full is not the shape · `7` the target is absent · `8` the
+fix's own write did not land · `9` the write landed and the read-back contradicts it · `11` a
+precondition read failed · `12` the park's cause is outside the known-recipe set · `13` a known
+recipe whose clearing condition is not met yet · `14` the task's leaf state is not a park · `15`
+the task could not be resolved · `16`–`18` the `governance` verdict is absent, stale, or FAIL ·
+`19` no run at the head concluded in failure · `20` the machine refused the `UNBLOCKED` · `21` the
+rerun was requested and its outcome could not be re-read · `22` the state applies no recipe.
 
-```bash
-node packages/fabrika-cli/src/bin.ts recipe unpark --help
-```
+**Known clears, novel escalates, and both are exit codes.** `12` is nothing-written, route it to a
+human; `13` is wait. `recipe route --exit` folds the first to `BLOCKED` and the second to `WIP`, so
+how autonomous a chore drive is never depends on a caller's reading.
 
-Two behaviours are worth knowing before you call it:
+## The `report` group
 
-- **Known clears, novel escalates, and both are exit codes.** `unpark`'s `12` is a park whose cause
-  is outside the recipe table — nothing written, route it to a human — while `13` is a known recipe
-  whose clearing condition is simply not met yet. `recipe route --exit` folds the first to `BLOCKED`
-  and the second to `WIP`, so how autonomous a chore drive is never depends on a caller's reading.
-- **Two recipes are deliberately absent.** The acceptance-criteria heading repair is
-  [`triage repair-criteria`](#the-triage-group), landed with its producer fix
-  ([#5744](https://github.com/kamp-us/phoenix/issues/5744) /
-  [#5565](https://github.com/kamp-us/phoenix/issues/5565)); orphaned-worktree reclamation is
-  [#5197](https://github.com/kamp-us/phoenix/issues/5197)'s port. Neither is re-implemented here —
-  a recipe for work another ticket owns buys a workaround and pays twice.
+File one follow-up observation into the intake queue. Contract:
+[`skills/report/contract.md`](../../claude-plugins/fabrika/skills/report/contract.md).
+
+| Verb | Answers |
+|---|---|
+| `report dedup` | ranks the open issues that may already cover an observation — `candidates` / `none` / `indeterminate`, all three at exit 0 |
+| `report file` | composes the intake issue from the six sections on stdin, guards it, creates it, and reads back what landed |
+| `report note` | adds a note to an existing issue over the same guarded path, and reads the comment back |
+
+**Exit codes.** The shared table this group defines, plus `27` the intake queue could not be read ·
+`28` the search index could not be read.
+
+Four behaviours are worth knowing:
+
+- **The body is a value, never a path.** The two writing verbs take it on **stdin only** — no
+  `--body`, no `--body-file`. A flag that accepts a path turns the body into a string the verb
+  could post verbatim. A shell redirect is fine: the *shell* reads the file.
+- **An empty stdin is a refusal, not an empty body.** A read that failed exits `1` (the body is
+  UNKNOWN) and a pipe read that held nothing exits `3` (a proven refusal).
+- **A missing `--label` is a refusal on `dedup` too, not a `none`.** `GET /issues?labels=…` answers
+  HTTP 200 with `[]` for a label that does not exist, so an unchecked `dedup` would print a proven
+  negative over a scope of zero. Both reading and writing verbs check the label first and exit `7`.
+- **The write is not finished until it is read back.** A create call's own response is the server
+  echoing the request; exit `9` is the landed artifact failing to match what was composed.
+
+Intake applies **no type and no priority**, defended mechanically: exit `10` refuses a `--label` or
+a title prefix that resolves to the target repo's own type/priority vocabulary.
+
+## The `review` group
+
+Everything a text review needs off one pull request, plus the one sanctioned way to write a verdict
+back. Contract:
+[`skills/review/contract.md`](../../claude-plugins/fabrika/skills/review/contract.md).
+
+| Verb | Answers |
+|---|---|
+| `review scope` | head SHA, linked issue, the code / doc / skill partition of the changed files, and the `self` / `harness` flags |
+| `review diff` | the diff bytes at the bound commit, with truncation refused rather than passed through |
+| `review criteria` | the linked issue's acceptance-criteria block, through the registered wire format |
+| `review ci` | the live check-run rollup at a head, fail-closed on incomplete enumeration |
+| `review verdicts` | every verdict marker on the PR, each with its `current` / `stale` / `unbindable` binding |
+| `review deviations` | the PR body's `## Deviations` state, its entries, and the Tier-M token scan |
+| `review post` | the single sanctioned verdict emit — compose, bind, one comment per namespace, read back |
+| `review append-criterion` | one reviewer-authored criterion appended under ADR 0079's four fences |
+
+**Exit codes.** The shared table, plus `12` the live head moved past the inspected `--sha` · `13`
+the read completed and its scope is provably incomplete · `14` the invoking token is below `write`,
+or the ACL lookup failed (ADR 0055) · `15` the write is not provably the prior rows plus one — the
+append-only fence. `4` is a deliberate gap.
+
+- **A check that cannot see what it is looking for does not return a plausible value.** An
+  unreadable response, a provably short read and a non-conforming payload each resolve to their own
+  refusal — `11`, `13` and `7` — and never to a clean pass.
+- **The overlapping exit codes are imported, not restated**, so they cannot drift from the shipped
+  values.
+- **`current` / `stale` / `unbindable` stay three outcomes.** Folding any two together is how a
+  stale PASS reads as a current one.
+- **Four modules are imported rather than re-derived**: the AC parser, the verdict-marker parser,
+  `normalizeForReadback`, and the machine-local-path predicate.
+- **Every guard is demonstrated failing.**
+  [`src/review/mutation.unit.test.ts`](./src/review/mutation.unit.test.ts) plants a counterexample
+  per guard, breaks exactly that guard, and asserts the verb returns the specific wrong answer.
+
+## The `review-ui` group
+
+Judge a UI pull request over its preview deployment. Contract:
+[`skills/review-ui/contract.md`](../../claude-plugins/fabrika/skills/review-ui/contract.md).
+
+| Verb | Answers |
+|---|---|
+| `review-ui render` | the named surfaces captured from a PR's preview deployment |
+| `review-ui post` | the `review-ui` verdict on stdin, posted as one comment |
+| `review-ui note` | a typed blocker note when the surfaces cannot be seen |
+
+**Exit codes.** The shared table (with `4` a required file that does not parse or violates its
+schema), plus `12` the artifact is not the PR's current tree · `13` a surface threw an uncaught
+page error · `14` a surface is unreachable — status ≥ 400 or a failed navigation · `15` a capture
+was produced and is invalid — zero bytes, undecodable, or zero area · `16` no preview deployment
+exists for this PR, the skill's CANT-SEE route · `17` an evidence upload or its verification
+failed, with **nothing posted**.
+
+## The `ship` group
+
+Everything the merge path needs off one pull request, plus the writes that arm, watch, disarm and
+record it. Contract:
+[`skills/ship/contract.md`](../../claude-plugins/fabrika/skills/ship/contract.md).
+
+| Verb | Answers |
+|---|---|
+| `ship scope` | head, lifecycle state, linked issue, artifact classes with their required namespaces, and the three-state §CP classification |
+| `ship cp-approval` | the ADR 0175 cardinality discharge — `discharge` / `stop` / `n/a`, from head-bound signals only |
+| `ship gate` | the verdict conjunction over every required namespace |
+| `ship floor` | whether a governance-root diff carries its head-bound `governance` verdict |
+| `ship checks` | the head CI rollup, with the running-vs-wedged split and the zero-checkset facts |
+| `ship evidence` | the SHA-bound run-evidence bundle as `present` / `pending` / `absent` / `unknown` |
+| `ship threads` | every unresolved review thread, both pagination layers count-proved |
+| `ship resolve` | the sanctioned thread-resolution write, refusing any thread not positively bot-classed |
+| `ship enqueue` | the queue arm at a pinned head, method-flag-free by construction, proven landed |
+| `ship merge` | the landing on a base no merge queue governs, proof read back |
+| `ship reconcile` | the bounded post-enqueue watch — `landed` / `ejected` / `unresolved` / `parked` |
+| `ship disarm` | the four-site merge-intent lifecycle (ADR 0198), read-back-verified |
+| `ship nudge` | the at-most-once dropped-trigger remedy, precondition re-derived here |
+| `ship note` | the durable stop-path comment, leak-scanned and read back |
+| `ship release` | dark-ship detection and the `status:awaiting-release` label |
+
+**Exit codes.** The shared table, plus `12` the live head moved past the inspected `--sha` · `13` a
+read completed and its scope is provably incomplete · `16` proven not in the state this write acts
+on, nothing mutated · `17` the nudge's close landed and its reopen is unconfirmed — the PR may be
+left closed · `18` a governance-root diff has no head-bound `governance` PASS · `19` the repository
+permits no merge method at all · `23` a label this run would POST is absent from the taxonomy.
+`4` is a deliberate gap.
+
+- **The §CP boundary is derived from `.github/CODEOWNERS` itself**, read at the base branch, so this
+  group and the merge gate read one artifact and cannot disagree. A *trivial* boundary — no
+  team-owned rows, or a row covering everything — is a printed hold, never a match-everything
+  verdict; an *unreadable* one is `11`.
+- **Three modules are extended rather than forked**: the class map and the check-run rollup are the
+  `review` group's own, and `normalizeForReadback` and the leak predicate come from `report`. Ship
+  and review cannot disagree about what a file is.
+- **`17` is the loud one.** It says the nudge's close landed and its reopen is unconfirmed, a state
+  so much worse than a failed write that folding it into `8` would hide the one fact an operator
+  must act on now.
+- **Exactly two verbs use GraphQL** (`threads`, `resolve`), because review-thread resolution state
+  has no REST equivalent. Every other verb is `gh api` REST, paginated, with the platform's
+  declared count carried beside what arrived.
 
 ## The `spend` group
 
-What one fabrika run cost, in tokens, read from its transcript
-([#5007](https://github.com/kamp-us/phoenix/issues/5007), epic
-[#4779](https://github.com/kamp-us/phoenix/issues/4779)).
-
-The meter is fabrika's own ([`src/spend/token-spend.ts`](./src/spend/token-spend.ts)), not v1's.
-`billed` is *specified* by ADR 0112 §2, not chosen, so the two implementations are held to one
-ruler by a committed transcript fixture both packages' unit tiers assert against —
-`src/spend/fixtures/one-ruler/`.
+What one fabrika run cost, in tokens, read from its transcript. `billed` is *specified* by ADR 0112
+§2, not chosen, so the implementation is held to that ruler by a committed transcript fixture the
+unit tier asserts against ([`src/spend/token-spend.ts`](./src/spend/token-spend.ts)).
 
 | Verb | Answers |
 |---|---|
 | `spend read` | one run's billed token spend, its four `usage` components, the ex-cache-read comparator, its billed turn count and its model |
 | `spend rollup` | what **all** of fabrika's recorded runs cost, summed out of the durable ledger and broken down by day, by skill and by stage-and-arm |
 
-Three behaviours are worth knowing before you call it:
+**Exit codes.** `7` the input is proven absent · `11` the input could not be read, or its absence
+could not be established · `12` the input was read in full and carries nothing to measure · `13`
+the ledger holds rows and this window selects none.
 
-- **The cache-read share stays its own number.** It dominates `billed` and grows with turn
-  count, which makes it the context-bloat signal; folding it into one total is what hides the
-  thing the measurement exists to show.
-- **"I could not measure it" is never a zero.** Exit `7` is a transcript that is provably not
-  there, `11` is one that could not be read (or whose absence could not be established — the
-  spend is UNKNOWN), and `12` is a transcript read in full that carries zero billed assistant
-  turns. That third state is a real transcript a failed run writes, and reporting it as a
-  measured zero would price a broken run as a free one.
-- **It cannot block anything.** No threshold, no budget flag, and no exit code that varies
-  with a spend magnitude — the no-gate ruling on epic #4779, asserted by a test that a
-  very large total still exits `0` rather than left as a note here.
+Three behaviours are worth knowing:
+
+- **The cache-read share stays its own number.** It dominates `billed` and grows with turn count,
+  which makes it the context-bloat signal; folding it into one total hides what the measurement
+  exists to show.
+- **"I could not measure it" is never a zero.** `12` is a real transcript a failed run writes, and
+  reporting it as a measured zero would price a broken run as a free one.
+- **It cannot gate.** No threshold, no budget flag, and no exit code that varies with a spend
+  magnitude — asserted by a test that a very large total still exits `0`.
 
 ### The spend ledger
 
-`spend read` prices one transcript on demand; the ledger is where measured runs *survive*
-([#5009](https://github.com/kamp-us/phoenix/issues/5009)). A producer appends one **JSON Lines**
-row per completed run to `.fabrika/spend-ledger.jsonl` (repo-relative, gitignored,
-`--spend-ledger` overrides it) — each line carrying that run's spend and the identity of the work
-it measured. **There is no in-repo producer today:** the eval runner was the only caller of
-`appendSpendLedger` and went out with the eval tooling
-([#5510](https://github.com/kamp-us/phoenix/issues/5510)), so `spend rollup` reads whatever an
-operator or a future producer wrote and reports an empty ledger otherwise. The core is
-[`src/spend/ledger.ts`](./src/spend/ledger.ts): `appendSpendLedger` writes, `readSpendLedger`
-reads back the well-formed rows **and the count of lines it skipped**, so a truncated tail
-costs one line rather than the file. Every line stamps its own `v`, which is the seam a later
-row shape evolves through.
-
-The module imports from `spend/` and `io/` only, so a reader of the ledger drags in nothing but
-the meter.
-
-### `spend rollup` — the epic's acceptance test, as one command
+`spend read` prices one transcript on demand; the ledger is where measured runs survive. A producer
+appends one **JSON Lines** row per completed run to `.fabrika/spend-ledger.jsonl` (repo-relative,
+gitignored, `--spend-ledger` overrides it). **There is no in-repo producer today**, so `spend
+rollup` reads whatever an operator or a future producer wrote and reports an empty ledger
+otherwise. The core is [`src/spend/ledger.ts`](./src/spend/ledger.ts): `readSpendLedger` reads back
+the well-formed rows **and the count of lines it skipped**, so a truncated tail costs one line
+rather than the file. Every line stamps its own `v`.
 
 ```bash
 fabrika spend rollup                                    # everything recorded so far
@@ -1051,14 +877,8 @@ fabrika spend rollup --since 2026-08-01 --until 2026-08-09
 fabrika spend rollup --json
 ```
 
-This is the one output epic [#4779](https://github.com/kamp-us/phoenix/issues/4779) exists to
-produce ([#5010](https://github.com/kamp-us/phoenix/issues/5010)): a number a human or an agent
-reads on demand. It reads persisted rows only — it spawns nothing, re-parses no transcript, and
-slows no lane. `--ledger` points it at a ledger other than the default; `--since`/`--until` are
-**inclusive at both edges**, and a bare `YYYY-MM-DD` widens to that whole UTC day, so
-`--until 2026-08-09` means "through the 9th" rather than "up to its midnight".
-
-stdout is one record per line, the first field naming the kind:
+`--since`/`--until` are **inclusive at both edges**, and a bare `YYYY-MM-DD` widens to that whole
+UTC day. stdout is one record per line, the first field naming the kind:
 
 ```
 billed        <n>          exCacheRead <n>   assistantTurns <n>
@@ -1070,37 +890,60 @@ skill      <name>              …
 stage-arm  <stage> <arm>       …
 ```
 
-Four things about it are load-bearing:
+Two things about that output are load-bearing:
 
 - **Every number it could not count is a number it reports.** The unread-line counts ride on the
-  answer itself (and in `--json`), not just on stderr, because a total that quietly omits 40
-  unreadable lines is worse than an error — it is wrong and looks whole. `undatedRows` is the same
-  rule for a bounded window: a row whose timestamp does not parse cannot be *proven* inside the
-  window, so it is excluded and counted rather than silently kept or dropped.
-- **The skipped count is split, because the two halves ask for opposite things.**
-  `skippedMalformed` is damage — those measurements are gone. `skippedNewerVersion` is intact data
-  written by a newer row shape: the rows are still there and the fix is to upgrade this CLI.
-  Reporting both as one "40 lines lost" is a false alarm in one direction and a missed data loss in
-  the other.
-- **Four refusals, none of them a zero.** `7` is no ledger at that path (nothing recorded yet), `11`
-  is a ledger that could not be read (the spend is UNKNOWN), `12` is one read in full that yielded no
-  rows at all, and `13` is a ledger that *does* hold rows where the given window selects none — an
-  empty window is a different fact from an empty ledger, so it gets its own code. Each refuses with
-  empty stdout.
-- **It cannot gate.** No threshold flag, no budget option, and no exit code that varies with the
-  size of a total — the no-gate ruling on epic #4779, asserted by a test that an arbitrarily large
-  total still exits `0`.
+  answer itself, not just on stderr, because a total that quietly omits 40 unreadable lines is
+  wrong and looks whole. `undatedRows` is the same rule for a bounded window.
+- **The skipped count is split, because the halves ask for opposite things.** `skippedMalformed` is
+  damage — those measurements are gone. `skippedNewerVersion` is intact data written by a newer row
+  shape, and the fix is to upgrade this CLI.
 
-The core is [`src/spend/rollup.ts`](./src/spend/rollup.ts), pure and total: it sums a
-`readSpendLedger` result over a resolved window and groups it three ways.
-[`src/spend/rollup-verb.ts`](./src/spend/rollup-verb.ts) is the IO around it.
+## The `spike` group
+
+Settle one empirical question by building a throwaway. A **spike** is one GitHub issue carrying
+`prototyping:spike`, bound to a workspace under the OS temp root — **never inside the repository** —
+and keyed on a per-run nonce. Contract:
+[`skills/prototyping/contract.md`](../../claude-plugins/fabrika/skills/prototyping/contract.md).
+
+| Verb | Answers |
+|---|---|
+| `spike open` | mints the spike issue and this run's workspace, and binds the two in a manifest |
+| `spike run` | executes one command in the workspace and appends an immutable evidence record |
+| `spike capture` | posts the decision plus the log's own run table, reads it back, and closes the spike |
+| `spike dispose` | proves the tree is unchanged and the capture still covers the log, removes the workspace, and proves it is gone |
+| `spike status` | one run's spike state, workspace presence and evidence count |
+
+**Exit codes.** The shared table (with `11` covering a failed read *or* execution), plus `12` no
+workspace for this nonce · `13` the resolved workspace path is inside the working tree, refused
+before any write · `14` the evidence log holds zero runs · `15` disposal asked on an uncaptured
+spike · `16` the workspace was removed and is still present on re-probe · `17` the working tree
+does not match what `spike open` recorded · `18` this nonce's workspace belongs to different work ·
+`19` the capture author is below `write` (ADR 0055) · `20` the issue landed and its manifest could
+not be completed · `21` the log moved after the decision was captured.
+
+Four behaviours are worth knowing:
+
+- **"Ran and answered no" and "could not run" are opposite answers.** `spike run` exits `0`
+  whatever the command returned — the command's own status rides in the payload as `commandExit` —
+  and exits `11` only when the command could not be executed at all.
+- **The key is a per-run nonce, minted from a cryptographic source.** No verb reads a session
+  variable and no verb asks a caller to invent a value, so two concurrent spikes cannot collide.
+- **Disposability is a property, not an intention.** `spike open` records a digest of
+  `git status --porcelain=v1 --untracked-files=all --ignored=matching`, and `spike dispose`
+  recomputes it *before* it removes or posts anything. `--ignored=matching` is load-bearing: a
+  build cache or a `node_modules/` is exactly where a prototype writes.
+- **A decision with no recorded run is a self-report.** `spike capture` reds on a log holding zero
+  runs, and the comment it posts transcribes each run's command and status.
+
+`spike status` is near-total on purpose: its consumer is a session resuming cold, so an absent
+workspace is a fact at exit `0` while the same absence is a refusal in the mutating verbs.
 
 ## The `status` group
 
-What state the factory is in — the six verbs
-[`front-door`](../../claude-plugins/fabrika/skills/front-door/SKILL.md) drives
-([#5214](https://github.com/kamp-us/phoenix/issues/5214), spec:
-[`contract.md`](../../claude-plugins/fabrika/skills/front-door/contract.md)).
+What state the factory is in — the verbs the
+[front door](../../claude-plugins/fabrika/skills/front-door/SKILL.md) drives. Contract:
+[`skills/front-door/contract.md`](../../claude-plugins/fabrika/skills/front-door/contract.md).
 
 ```
 status open                       # the composite five-field readout the skill injects
@@ -1111,110 +954,201 @@ status board                      # counts of the board's decided buckets
 status bootstrap readout-artifact # create one missing surface, then read it back
 ```
 
-Three things about it are load-bearing:
+**Exit codes.** The shared table (with `7` an **explicitly passed** `--skills-dir` proven absent),
+plus `12` the named surface is not in `status bootstrap`'s buildable-surface registry. `4` is a
+deliberate gap.
+
+Three things are load-bearing:
 
 - **The three-state law.** Every field, row and bucket is a live value, a **proven negative**
   (`empty` / `absent` / `missing` / `unprobeable` / `malformed`), or **`unknown`** with its reason —
-  and the third never renders as the second. An absent label is `unknown`, never `0`; an
-  unregistered decoder is `unknown`, never `absent`.
-- **`status open` is total.** It is injected before a session reads a token, and
-  [`src/verb.ts`](./src/verb.ts)'s `refuse()` hardcodes empty stdout — so a refusal would leave the
-  front door silent on exactly the cold start it exists for. Every source it cannot read becomes a
-  field state; its one refusal seat is a bad `--field`. It composes by **importing** the sibling
-  cores, never by spawning a verb and reading its exit code. The fifth field, `lanes`, renders the
-  `lane stale` sweep ([`src/lane/stale-verb.ts`](./src/lane/stale-verb.ts)) over both default roots
-  at that verb's documented 60-minute threshold, so a dead operator's silent lane surfaces on every
-  cold session without anyone typing the command (#5908): stale lanes are named with their ages,
-  zero stale lanes — including zero lanes on disk — is the proven negative `empty`, and an
-  unreadable root or lane record is `unknown` with its reason. It reports; it never resumes.
-- **`7` and `11` are the pair.** `7` is an **explicitly passed** `--skills-dir` proven absent; `11`
-  is a failed read. An *implicitly* resolved roster holding zero skills is neither — it is `empty`
-  at exit `0`.
+  and the third never renders as the second. An absent label is `unknown`, never `0`.
+- **`status open` is total.** It is injected before a session reads a token, and `refuse()`
+  hardcodes empty stdout — so a refusal would leave the front door silent on exactly the cold start
+  it exists for. Every source it cannot read becomes a field state; its one refusal seat is a bad
+  `--field`. It composes by **importing** the sibling cores, never by spawning a verb. The `lanes`
+  field renders the `lane stale` sweep at that verb's 60-minute threshold, so a dead operator's
+  silent lane surfaces on every cold session. It reports; it never resumes.
+- **`7` and `11` are the pair.** An *implicitly* resolved roster holding zero skills is neither —
+  it is `empty` at exit `0`.
 
 The roster resolves in four tiers — an explicit `--skills-dir`, the installed plugin's own skills
-tree, `claude-plugins/fabrika/skills` in-repo, then that same path in the checkout the CLI itself
-runs from — and prints which one served, `explicit` · `plugin` · `repo` · `checkout`
-([`src/status/roster.ts`](./src/status/roster.ts)).
+tree, `claude-plugins/fabrika/skills` in-repo, then that same path in the checkout the CLI runs
+from — and prints which one served.
+
+## The `triage` group
+
+Take one intake-queue issue from arrival to triaged. Contract:
+[`skills/triage/contract.md`](../../claude-plugins/fabrika/skills/triage/contract.md).
+
+| Verb | Answers |
+|---|---|
+| `triage codes` | the exit taxonomy every verb in the group allocates from |
+| `triage queue` | the claimable intake queue, oldest first |
+| `triage claim` | one lane's claim on one issue |
+| `triage provenance` | whether an issue was reported by an agent or a human |
+| `triage homes` | the assignable homes: open milestones and standing lanes |
+| `triage split` | one child of a bundled report, created exactly once |
+| `triage enrich` | an issue body replaced with the rewrite on stdin |
+| `triage apply` | type, priority, audience, status and home stamped as one owned-facet reconcile, read back |
+| `triage park` | an issue demoted to needs-info with the questions on stdin |
+| `triage kill` | an agent-filed issue closed not-planned, with a reason |
+| `triage repair-criteria` | an acceptance-criteria block's shape repaired mechanically |
+
+**Exit codes.** The shared table, plus `12` the issue is human-filed · `13` agent-filed and
+close-eligible, but the kill is unconfirmed (ADR 0159) · `14` the criteria block is drifted in a
+way no mechanical repair covers · `15` the composed body's authored region carries a `Malformed`
+criteria block · `16` `--ready-for agent` over a body whose criteria block does not read `Found` ·
+`17` a live claim marker names another session. `4` is a deliberate gap.
+
+Two repairs are worth spelling out, because they are what `repair-criteria` will and will not do.
+It rewrites a level-drifted `## Acceptance criteria` heading to the conforming `###`, and, when the
+block carries no checkbox at all, rewrites its list items to unchecked checkboxes with each item's
+text byte-for-byte unchanged. `--sweep` runs it over every open issue; `--dry-run` plans everything
+and writes nothing. Every repaired body gets one disclosure comment naming its repairs, because
+GitHub keeps no history of an in-place body edit. Anything that is not a pure shape rewrite is
+refused on `14`, never guessed.
+
+Three properties of the substrate are worth knowing:
+
+- **Every verb in the group allocates from one table**
+  ([`src/triage/codes.ts`](./src/triage/codes.ts)), and where it overlaps the two `report` writing
+  verbs the meanings match **code for code**, so a caller driving both groups in one sweep reads
+  one meaning. A check over every verb file keeps a verb from seating its own numerals unseen.
+- **`4` is a deliberate gap.** It once fused "the target issue is proven absent" with "the target
+  issue could not be read". `7` and `11` took the halves, and the slot is left unallocated rather
+  than compacted — a gap is cheaper than a collision.
+- **Every list read pages and reports its scanned count** on stderr
+  ([`src/triage/scope.ts`](./src/triage/scope.ts)). Printing what was scanned is what makes the
+  reach checkable from outside the process.
+
+`--ready-for agent` additionally asserts the issue's live body carries a criteria block the wire
+reader answers `Found` on, refusing on `16` before any label is written. `--type epic` is exempt
+(its criteria arrive per child from the plan ledger) and `--ready-for human` is unaffected.
 
 ## The `ui` group
 
 What the visual modality adds to a construction lane — the verbs
-[`build-ui`](../../claude-plugins/fabrika/skills/build-ui/SKILL.md) drives
-([#5061](https://github.com/kamp-us/phoenix/issues/5061), spec:
-[`contract.md`](../../claude-plugins/fabrika/skills/build-ui/contract.md)). The lane mechanics are
-the `build` group's, reused as-is; this group is only what rendering adds.
+[`build-ui`](../../claude-plugins/fabrika/skills/build-ui/SKILL.md) drives. The lane mechanics are
+the `build` group's, reused as-is. Contract:
+[`skills/build-ui/contract.md`](../../claude-plugins/fabrika/skills/build-ui/contract.md).
 
 ```
 ui manifest                                   # the repo's design surfaces, by convention
 ui law                                        # the typed prohibition registry, schema-validated
 ui render --out after --surface /pano         # render + capture one validated PNG per surface
-ui golden --surface /pano [--candidate <png>]  # resolve the blessed golden, diff a candidate
+ui golden --surface /pano [--candidate <png>] # resolve the blessed golden, diff a candidate
 ui evidence --pr 4318 --before before --after after   # upload, verify, post, read back
 ```
 
-Four things about it are load-bearing:
+**Exit codes.** The shared table, plus `12` no design manifest at the convention path — the repo is
+un-bootstrapped · `13` the manifest exists and no typed prohibition registry does — the law is
+untyped · `14` a surface rendered with an uncaught page error · `15` a surface is unreachable ·
+`16` a capture was produced and is invalid · `17` an evidence upload failed, nothing posted · `18`
+this session does not hold the claim the checked-out lane branch names · `19` no render harness is
+declared. `3` is a deliberate gap.
+
+Four things are load-bearing:
 
 - **A verb's ceiling is the golden diff.** No `ui` verb emits a PASS/FAIL token, a composition
-  score, or any judgement over pixels — the rendered-surface verdict is `review-ui`'s gate
-  ([#4718](https://github.com/kamp-us/phoenix/issues/4718)), and everything that *looks* at an image
-  is the skill's, not a verb's (founder ruling, 2026-08-09). `ui golden` measures; it never decides.
+  score, or any judgement over pixels — the rendered-surface verdict is `review-ui`'s gate. `ui
+  golden` measures; it never decides.
 - **Everything the group reads is a convention path in the repo it runs in** —
   `design-system-manifest.md`, `design-prohibitions.json`, `design-harness.json`,
   `packages/design-capture/golden-pointer.json` — never a hardcoded URL. That is what makes the
-  group portable: phoenix is one instance of a repo it reads, not the repo it knows.
+  group portable.
 - **The headless browser is provisioned by installing the package.** `postinstall` runs
-  [`scripts/provision-browser.mjs`](./scripts/provision-browser.mjs), so no operator and no agent
-  ever runs a browser-install step by hand. It is best-effort and never fails the install; it skips
-  when the browser is already there, when `PLAYWRIGHT_BROWSERS_PATH` names a managed install, when
-  `CI` is set (CI images bake their own), or on `FABRIKA_SKIP_BROWSER_PROVISION=1`. A run that then
-  finds no browser exits `11` **carrying the exact remediation command** — never a silent skip.
-- **Absence is answered three ways, never one.** A missing manifest is `12` (un-bootstrapped, route
-  to front-door), a missing registry is `13` (the law is untyped, prose is the source), and an
-  unreadable one is `11` (UNKNOWN) — the skill's prose fallback is legal only in the middle case.
-  The same split runs through `ui golden`: a pointer that could not be read is never an empty
-  blessed set ([#4501](https://github.com/kamp-us/phoenix/issues/4501)).
+  [`scripts/provision-browser.mjs`](./scripts/provision-browser.mjs), so no operator ever runs a
+  browser-install step by hand. It is best-effort and never fails the install; it skips when the
+  browser is already there, when `PLAYWRIGHT_BROWSERS_PATH` names a managed install, when `CI` is
+  set, or on `FABRIKA_SKIP_BROWSER_PROVISION=1`. A run that then finds no browser exits `11`
+  **carrying the exact remediation command**.
+- **Absence is answered three ways, never one.** `12`, `13` and `11` are different facts, and the
+  skill's prose fallback is legal only in the middle case.
 
-`ui render` and `ui evidence` both guard the lane precondition (`18` proven-not-mine, `11`
-unreadable); `ui manifest`, `ui law` and `ui golden` are pure reads and take none. Evidence is
-all-or-nothing: one failed upload or upload-verification is `17` with **nothing posted**
-([#3925](https://github.com/kamp-us/phoenix/issues/3925)).
+`ui render` and `ui evidence` both guard the lane precondition; `ui manifest`, `ui law` and `ui
+golden` are pure reads and take none. Evidence is all-or-nothing: one failed upload or verification
+is `17` with **nothing posted**.
+
+## The `wire` group
+
+A **wire format** is the byte-level agreement two skills meet through on a GitHub artifact — the
+acceptance-criteria block on a sub-issue body, the verdict marker on a PR, the handoff pack one
+session leaves the next. Each is owned by a typed schema module under [`src/wire/`](./src/wire/)
+with an `emit` and a `read`, registered as one row in
+[`src/wire/registry.ts`](./src/wire/registry.ts). The formats used to live as prose in a skill
+body, which is why fabrika could not pin one.
+
+| Verb | Answers |
+|---|---|
+| `wire formats` | the registered formats, derived from the registry — key, purpose, producers, consumers |
+| `wire codes` | the exit taxonomy every verb in the group allocates from |
+| `wire emit` | the format's bytes, composed from the fields on stdin |
+| `wire read` | the format's fields, read out of the artifact on stdin |
+| `wire check` | whether the artifact on stdin carries a conforming block, without the fields |
+| `wire doc-section` | one markdown section of the document on stdin (or `--file`), by ATX heading |
+| `wire index` | whether the index doc agrees with the registry — and, with `--write`, the doc's table rendered from it |
+
+**Exit codes.** This group seats its own table, deliberately not the shared one: `3` the block is
+proven absent · `4` the block is present and does not conform · `5` stdin was read and held nothing
+· `6` fd 0 carried nothing readable, or the read failed · `7` `--format` names no registered
+format, or the registry holds no rows · `8` the fields on stdin hold nothing this format can
+compose from.
+
+Five behaviours are worth knowing:
+
+- **`read` is total, and `found` is its only positive answer.** The return type is
+  `Found | Absent | Malformed`, with `Found` carrying a non-empty list by construction. A heading
+  that drifted is `Malformed`, never a `Found` holding nothing — the prose-owned era's failure was
+  not a crash, it was a *plausible* empty answer a grader read as a pass over nothing.
+- **Absent, malformed and never-seen are three different exit codes.** `3` is a proven negative
+  over an artifact read in full; `4` is a proven defect; `6` means nothing is proven at all.
+- **The artifact arrives on stdin only.** No `--body`, no `--body-file` — a flag that accepts a
+  path turns the artifact into a string the verb could echo onto a public surface.
+- **A `found` verdict marker is well-formed, not current.** Whether a marker binds the head you
+  hold is [`verdict-marker.ts`](./src/wire/verdict-marker.ts)'s `bindToHead` — `Current` / `Stale`
+  / `Unbindable`, because a head the caller could not resolve is not a comparison anyone made.
+- **A registered format is a conforming format.** A registry row carries the fixtures its laws are
+  driven from and the brands its value is built from, both required by the row type, so
+  [`conformance.ts`](./src/wire/conformance.ts) holds every row to the same laws without naming it.
+
+The per-format table in `claude-plugins/fabrika/docs/wire-formats.md` is rendered from the registry
+by `wire index --write` and reconciled by `wire index`, which reds on a registered format with no
+section, a section for no registered format, and a stale region. The protocol narrative under each
+heading stays hand-written.
+
+```bash
+printf 'the read is total\n[x] the registry is the seam\n' \
+  | node src/bin.ts wire emit --format acceptance-criteria \
+  | node src/bin.ts wire check --format acceptance-criteria
+```
 
 ## The capture machinery
 
-Not a verb group — a **library subpath**, `@kampus/fabrika-cli/capture`. It is the
-screenshot / render / golden-diff machinery `build-ui` and `review-ui` drive: shoot a
-surface over a preview or a local build, store and resolve a blessed golden, and diff
-rendered-vs-golden. Its own docs are [`src/capture/README.md`](./src/capture/README.md).
+Not a verb group — a **library subpath**, `@kampus/fabrika-cli/capture`. It is the screenshot /
+render / golden-diff machinery `build-ui` and `review-ui` drive: shoot a surface over a preview or
+a local build, store and resolve a blessed golden, and diff rendered-vs-golden. Its own docs are
+[`src/capture/README.md`](./src/capture/README.md).
 
 ```ts
 import {captureAndUpload, diffRasters, loadGoldenPointer} from "@kampus/fabrika-cli/capture";
 ```
 
-It moved here from phoenix's `packages/design-capture` by founder ruling
-([#5063](https://github.com/kamp-us/phoenix/issues/5063)), so an adopter gets it with
-fabrika rather than through a second release train. **The repo-specific data did not move**:
-golden bytes stay in depo and the pointer naming them stays in the consuming repo
-([ADR 0183](../../.decisions/0183-golden-screen-storage-depo-git-pointer.md)) — this package
-ships the machine, never a repo's goldens.
+**The repo-specific data is not here**: golden bytes live in the consuming repo's asset store and
+the pointer naming them stays in that repo
+([ADR 0183](../../.decisions/0183-golden-screen-storage-depo-git-pointer.md)). This package ships
+the machine, never a repo's goldens.
 
 Three consequences worth knowing before you install it:
 
-- **`@playwright/test` is a hard dependency**, inherited from the machinery, so a fabrika
-  install pulls it in even for a caller that never captures. The browser binary rides the
-  install too — see [the `ui` group](#the-ui-group)'s provisioning note — and a run on a machine
-  where that did not complete fails loudly, with the remediation command, rather than silently.
-- **Storing golden bytes is an injected `StoreLeg`, not a dependency.** A repo's goldens live
-  in its own asset store, so anything naming a host or a credential stayed with the consuming
-  repo. This package owns the shape and
-  the diff, never the store. It is also what keeps the package installable: a published artifact
-  may depend only on what a clean registry resolves
-  ([ADR 0201](../../.decisions/0201-pipeline-tenant-phoenix-first.md) §3), and phoenix's depo client is
-  private.
-- **The adopter-facing surface is the `ui` verb group**
-  ([#5061](https://github.com/kamp-us/phoenix/issues/5061)) — see
-  [the `ui` group](#the-ui-group). Phoenix's v1 `design-capture` bin was the other caller; it was
-  deleted unused in [#6346](https://github.com/kamp-us/phoenix/issues/6346), and the move here
-  deliberately changed no behavior.
+- **`@playwright/test` is a hard dependency**, inherited from the machinery, so a fabrika install
+  pulls it in even for a caller that never captures. The browser binary rides the install too — see
+  [the `ui` group](#the-ui-group)'s provisioning note.
+- **Storing golden bytes is an injected `StoreLeg`, not a dependency.** Anything naming a host or a
+  credential stays with the consuming repo. That is also what keeps the package installable: a
+  published artifact may depend only on what a clean registry resolves (ADR
+  [0201](../../.decisions/0201-pipeline-tenant-phoenix-first.md) §3).
+- **The adopter-facing surface is the `ui` verb group** — see [the `ui` group](#the-ui-group).
 
 ## Development
 
@@ -1225,38 +1159,32 @@ pnpm --filter @kampus/fabrika-cli build       # tsc -> dist/, for the published 
 ```
 
 **The development loop has no build step.** `bin` points at `./src/bin.ts` and Node ≥ 24 strips the
-types natively, so an edit to `src/` is live on the next invocation — which is the entire point of
-the workspace `devDependencies` line in the root `package.json`. `build` emits `dist/` for the
-published tarball and nothing else reads it; see [the two Node floors](#the-two-node-floors) for why
-that `≥ 24` is this workspace's number and not the published package's. Emit and type-check now run
-the same binary — the stable native `tsc` (ADR 0271) — so the published artifact and the gate can no
-longer disagree about the compiler.
+types natively, so an edit to `src/` is live on the next invocation. `build` emits `dist/` for the
+published tarball and nothing else reads it; see [the two Node floors](#the-two-node-floors) for
+why `≥ 24` is this workspace's number and not the published package's. Emit and type-check run the
+same binary — the stable native `tsc` (ADR 0271) — so the published artifact and the gate cannot
+disagree about the compiler.
 
-A verb is a **pure function of its dependencies** — the `*-verb.ts` modules compute a
-`VerbOutcome` (exit code, stdout, stderr) and never write a stream or exit. The Effect CLI
-layer in each group's `command.ts` does both. That split is what makes
-each refusal as deterministically testable as each answer, which is why the tests can drive
-an unreadable directory, a `gh` that exits 0 with the wrong bytes, and a base ref that
-cannot be fetched — inputs a real tree cannot be asked to produce on demand.
+A verb is a **pure function of its dependencies** — the `*-verb.ts` modules compute a `VerbOutcome`
+(exit code, stdout, stderr) and never write a stream or exit. The Effect CLI layer in each group's
+`command.ts` does both. That split is what makes each refusal as deterministically testable as each
+answer, which is why the tests can drive an unreadable directory, a `gh` that exits 0 with the
+wrong bytes, and a base ref that cannot be fetched.
 
 Those dependencies are the **Effect platform services**, never a raw `node:*` import: the
 filesystem is `FileSystem` / `Path` from `effect`
 ([.patterns/effect-platform-access.md](../../.patterns/effect-platform-access.md)) and the
 subprocess is `ChildProcess` / `ChildProcessSpawner` from `effect/unstable/process`
 ([.patterns/effect-process-cli-shell.md](../../.patterns/effect-process-cli-shell.md)), both
-satisfied by the one `NodeServices.layer` [`src/run.ts`](./src/run.ts) provides. A test
-substitutes those same services rather than a hand-rolled double, so the seam under test is
-the seam production uses. A read that could not be performed fails on the `E` channel — it
-never resolves to an empty value a caller could forget to distinguish from a real one.
+satisfied by the one `NodeServices.layer` [`src/run.ts`](./src/run.ts) provides. A test substitutes
+those same services rather than a hand-rolled double, so the seam under test is the seam production
+uses. A read that could not be performed fails on the `E` channel — it never resolves to an empty
+value a caller could forget to distinguish from a real one.
 
-One raw `node:*` read survives, named by that pattern doc rather than overlooked. **fd 0** stays a
-raw `node:fs` read at the boundary in [`src/io/stdin.ts`](./src/io/stdin.ts) — the standing ruling,
-where `Stdio.stdin` is a considered-and-declined stream swap rather than a missing service; the
-verbs take the read as an injected effect, so the `EAGAIN` and TTY paths stay testable without a
-real descriptor.
-
-The delegation layer reads `process` — `cwd()`, `argv`, `execPath`, `env`, `exit()` — and that is
-confined to [`src/delegate/entry.ts`](./src/delegate/entry.ts), the boundary the bin bootstrap calls.
-The walk and the decision it feeds are Effects over `FileSystem` / `Path` / `ChildProcessSpawner`,
-so every branch — including "an ancestor could not be probed" and "the spawn faulted" — is driven by
-substituted services rather than by a real tree.
+Two raw boundaries survive, both named rather than overlooked. **fd 0** stays a raw `node:fs` read
+in [`src/io/stdin.ts`](./src/io/stdin.ts), with the verbs taking that read as an injected effect so
+the `EAGAIN` and TTY paths stay testable. And the delegation layer reads `process` — `cwd()`,
+`argv`, `execPath`, `env`, `exit()` — confined to
+[`src/delegate/entry.ts`](./src/delegate/entry.ts); the walk and the decision it feeds are Effects
+over the platform services, so every branch is driven by substituted services rather than a real
+tree.

--- a/packages/fabrika-cli/README.md
+++ b/packages/fabrika-cli/README.md
@@ -1165,6 +1165,10 @@ why `≥ 24` is this workspace's number and not the published package's. Emit an
 same binary — the stable native `tsc` (ADR 0271) — so the published artifact and the gate cannot
 disagree about the compiler.
 
+This package re-implements v1's work and never calls into it (ADR
+[0238](../../.decisions/0238-fabrika-reimplements-v1-never-calls-it.md)); v1 is deleted, so that is
+history rather than a live constraint.
+
 A verb is a **pure function of its dependencies** — the `*-verb.ts` modules compute a `VerbOutcome`
 (exit code, stdout, stderr) and never write a stream or exit. The Effect CLI layer in each group's
 `command.ts` does both. That split is what makes each refusal as deterministically testable as each


### PR DESCRIPTION
Both fabrika READMEs opened with history instead of telling a reader what fabrika is.

**`claude-plugins/fabrika/README.md`** now opens with what fabrika is and who it is for, points at
`guide/README.md` as the next page, and collapses the mission quote, the v1 retirement story and
the writing-for-agents ruling history to one-line pointers (ADR 0303 for the retirement,
`docs/skill-conventions.md` for the authoring rule). 113 lines → 59.

**`packages/fabrika-cli/README.md`** is a verb reference again rather than an incident log:

- Opens with what the package is, the install, and the delegation rules — no narration above them.
- Every one of the 27 groups `fabrika --help` lists now has a section stating what the group does,
  its verbs, and its exit codes. Four groups had no section at all before: `graduate`, `ledger`,
  `plan`, `review-ui`.
- The shared `3`–`11` exit table is stated once, so each group section lists only what it adds.
  Codes were read out of each group's `codes.ts`, not from prose.
- `## It calls nothing outside fabrika` is gone — the package it described is deleted, and the rule
  it stated lives in the plugin README beside ADR 0251.
- Citations dropped from 81 lines carrying one to 22 total, and only two issue links survive: the
  unpublished-package note (#4791) and the reason a by-path invocation from another repo is refused
  (#4956). Both are the reason a live behaviour is shaped the way it is.

Verified: `build check --surface prose` green (link + leak scan), the group list matches
`fabrika --help` (27/27), and every contract path linked resolves.

Fixes #6429

## Deviations

- **Out-of-scope change** — **Said:** #6429 names the `## It calls nothing outside fabrika` section
  and the per-group narration. **Did:** also rewrote the delivery/Node-floors and Development
  sections. **Why:** those sections carried the same incident narration the criteria target
  ("the last row closes the one case that used to be quietly wrong", the `pnpm link --global`
  story), so leaving them would have failed the plain-language criterion on the file's first
  screen. **Disposition:** stated here; behaviour claims kept, stories cut.
- **Scope narrowing** — **Said:** the CLI README opens "with no incident narration above that
  content". **Did:** kept the delegation table and its four rules between the install command and
  the quickstart. **Why:** they are behaviour a caller needs before running anything — which copy
  serves an invocation — not narration. **Disposition:** stated here.
- **Known defect left unfixed** — **Said:** nothing about the file's length. **Did:** the CLI
  README is still 1,190 lines. **Why:** the issue's triage note rules the verb reference stays and
  wholesale deletion of the verb tables is out of scope; adding an exit-code table per group and
  four missing group sections costs lines that the deleted narration returns. **Disposition:**
  stated here.
