### PR TITLE
chore: deslop comments in apps/web/worker

### DIFF
--- a/apps/web/worker/config.ts
+++ b/apps/web/worker/config.ts
@@ -1,28 +1,16 @@
 /**
- * The worker's `effect/Config` surface (see
- * `.patterns/worker-environment-pattern.md`). Each var is declared ONCE as a
- * `Config` constant, and its binding NAME is declared ONCE in `ENV_BINDINGS`
- * below — so neither the value nor the name can drift across the bind↔read seam:
- * the `env:` block (`index.ts`) binds it (alchemy resolves it from deploy-time
- * `process.env`), and runtime code reads it via `yield* AppConfig` off the
- * ConfigProvider alchemy auto-wires from the bound env.
- *
- * The deploy-time state-store selector stays in `env.ts` — it runs in the
+ * The worker's `effect/Config` surface — see `.patterns/worker-environment-pattern.md`.
+ * The deploy-time state-store selector deliberately stays in `env.ts`: it runs in the
  * alchemy CLI process, a different moment from these runtime reads.
  */
 import * as Config from "effect/Config";
 import {DEFAULT_ENVIRONMENT, ENVIRONMENTS, type Environment} from "./environment.ts";
 
 /**
- * The worker env binding NAMES, declared once (#1432). Both halves of the bind↔read
- * seam reference these: the `Config` constructors below read under them, and the
- * `env:` block in `index.ts` binds under them as computed keys (via `envBindings`),
- * so each name lives in exactly ONE place. Key↔name drift is unrepresentable, not
- * merely caught — a rename here changes both the binding and the read in lockstep.
- *
- * The roster of CI-provisioned secrets (`BETTER_AUTH_SECRET` is the only worker
- * binding that overlaps it) is documented separately in the provisioner —
- * `infra/ci-credentials/github.ts` — because GitHub Actions and turbo can't import TS.
+ * The one home for the worker env binding NAMES (#1432): both halves of the bind↔read
+ * seam reference these, so key↔name drift is unrepresentable rather than merely caught.
+ * The CI-provisioned secret roster is duplicated in `infra/ci-credentials/github.ts`
+ * because GitHub Actions and turbo can't import TS.
  */
 export const ENV_BINDINGS = {
 	environment: "ENVIRONMENT",
@@ -31,64 +19,38 @@ export const ENV_BINDINGS = {
 } as const;
 
 /**
- * The deploy environment — the deploy classes (ADR 0088), the taxonomy owned by
- * `environment.ts`. Non-redacted (→ `plain_text` binding), fail-closed: defaults to
- * "production" when unset, so a missing var closes every dev gate. `development` is local
- * `alchemy dev`; `preview` is a deployed per-PR stage on `*.kampusinfra.workers.dev`;
- * `production` is prod; `audit` is the isolated rite-audit stage (#1511).
- *
- * The `withDefault` is kept deliberately (#1432). Its job is fail-closed-to-prod for a
- * genuinely *unset* var (ADR 0088), NOT masking a name typo: with the binding name now
- * single-sourced via `ENV_BINDINGS.environment` there is no second name literal that can
- * drift, so the default can no longer hide a key↔name mismatch (there is none to hide).
- * A deploy-time *unknown* value still fails loud at the deploy gate (`environment.ts`
- * `UnknownEnvironmentError`, #1433).
+ * The deploy environment (ADR 0088; taxonomy owned by `environment.ts`). The
+ * `withDefault` is deliberate and fail-closed: an unset var reads "production", closing
+ * every dev gate. It cannot mask a name typo — `ENV_BINDINGS.environment` leaves no
+ * second literal to drift — and an unknown value still fails loud at the deploy gate.
  */
 export const environment = Config.literals(ENVIRONMENTS, ENV_BINDINGS.environment).pipe(
 	Config.withDefault(DEFAULT_ENVIRONMENT),
 );
 
-/** Re-exported from the taxonomy owner (`environment.ts`) for the runtime read sites. */
 export type {Environment};
 
 /**
- * The better-auth session-signing secret. Redacted → `secret_text` binding (a
- * `Config.redacted` resolves to a Cloudflare secret). Read at RUNTIME via
- * `yield* betterAuthSecret` (`better-auth-live.ts`).
- *
- * This must travel as a binding, NOT via `alchemy/Random`: `Random` is a
- * deploy-time resource with no value in the workerd isolate (`SECRET.text` is
- * `undefined` there), so the secret could never be read back at request time. No
- * default — REQUIRED at deploy, so a missing secret fails closed rather than
- * silently signing cookies with a blank key.
+ * The better-auth session-signing secret. It must travel as a binding, NOT via
+ * `alchemy/Random`: `Random` is a deploy-time resource with no value in the workerd
+ * isolate (`SECRET.text` is `undefined` there), so it could never be read back at request
+ * time. No default, so a missing secret fails closed instead of signing with a blank key.
  */
 export const betterAuthSecret = Config.redacted(ENV_BINDINGS.betterAuthSecret);
 
 /**
- * The Sentry DSN (ADR 0118), read as an OPTION so the worker Sentry path is inert
- * when unset — `Config.option` yields `None` and the request seam returns the base
- * fetch untouched (unlike `betterAuthSecret`, which is required and `orDie`s).
- *
- * NOT in `envBindings` below: the binding is added conditionally at deploy
- * (`index.ts` env block) only when a DSN is provisioned, so an unset DSN produces
- * NO binding at all — reading via `Config.option` then resolves `None`. Bound
- * `secret_text` (a redacted value) when present; read here as a plain string
- * because workerd exposes the binding as a string on `env` and the DSN is handed
- * verbatim to `@sentry/cloudflare`.
+ * The Sentry DSN (ADR 0118). Deliberately absent from `envBindings` below: `index.ts`
+ * adds the binding only when a DSN is provisioned, so an unset DSN produces no binding
+ * and `Config.option` resolves `None`, leaving the Sentry path inert. Read as a plain
+ * string (not redacted) because workerd exposes it as one and it is handed verbatim to
+ * `@sentry/cloudflare`.
  */
 export const sentryDsn = Config.string(ENV_BINDINGS.sentryDsn).pipe(Config.option);
 
-/**
- * The Config-backed worker env bindings, keyed by their binding NAME (the computed keys
- * resolve from `ENV_BINDINGS`, so the key the worker binds under and the name the `Config`
- * reads under are the SAME literal). The `env:` block in `index.ts` spreads this in, so the
- * binding names are never restated there — a key↔name mismatch is impossible by
- * construction (#1432). `index.ts` adds the non-Config `Flagship` resource binding alongside.
- */
+// Spread into the `env:` block in `index.ts`, so binding names are never restated there.
 export const envBindings = {
 	[ENV_BINDINGS.environment]: environment,
 	[ENV_BINDINGS.betterAuthSecret]: betterAuthSecret,
 };
 
-/** The single yieldable read surface. `yield* AppConfig` returns `{ environment }`. */
 export const AppConfig = Config.all({environment});

--- a/apps/web/worker/config.unit.test.ts
+++ b/apps/web/worker/config.unit.test.ts
@@ -1,14 +1,8 @@
 /**
- * Guards the single-sourced worker env binding NAMES (#1432): the binding key the
- * worker `env:` block uses and the name the `Config` constructor reads under are the
- * SAME `ENV_BINDINGS` literal, so a key↔name drift can't sneak in. Two halves:
- *
- *  - `envBindings` (the object `index.ts` spreads into `env:`) is keyed by exactly the
- *    declared binding names — so the worker binds under nothing else.
- *  - each `Config` constant actually RESOLVES a value provided under that same name —
- *    so the read and the bind agree end to end. If a constructor's name string ever
- *    drifted from `ENV_BINDINGS`, the value provided under the binding name would not
- *    reach the read (environment falls back to its default; the secret errors).
+ * Guards the single-sourced worker env binding NAMES (#1432): the key the worker
+ * `env:` block binds under and the name the `Config` constructor reads under must be
+ * the SAME `ENV_BINDINGS` literal. If one drifted, the bound value would silently not
+ * reach the read — environment would fall back to its default, the secret would error.
  */
 import {assert, describe, it} from "@effect/vitest";
 import {Effect} from "effect";
@@ -35,9 +29,8 @@ describe("ENV_BINDINGS — the single binding-name source", () => {
 	});
 
 	it("envBindings binds only the always-on names (SENTRY_DSN is bound conditionally, not here)", () => {
-		// `sentryDsn` is in ENV_BINDINGS (single-sourced name) but deliberately NOT in
-		// `envBindings`: it's added to the env block conditionally at deploy (index.ts)
-		// only when a DSN is provisioned, so an unset DSN produces no binding (ADR 0118).
+		// `sentryDsn` is deliberately NOT in `envBindings`: it is added to the env block
+		// conditionally at deploy, so an unset DSN produces no binding (ADR 0118).
 		assert.deepStrictEqual(
 			Object.keys(envBindings).sort(),
 			[ENV_BINDINGS.environment, ENV_BINDINGS.betterAuthSecret].sort(),

--- a/apps/web/worker/db/Database.ts
+++ b/apps/web/worker/db/Database.ts
@@ -9,17 +9,11 @@ import * as Cloudflare from "alchemy/Cloudflare";
 import {Context, Effect, Layer} from "effect";
 import {PhoenixDb} from "./resources.ts";
 
-/**
- * @example
- *   const raw = yield* Database;
- *   const db = createDrizzle(raw);
- */
 export class Database extends Context.Service<Database, D1Database>()("@kampus/Database") {}
 
 /**
- * Resolved once and provided as a worker-level layer (the binding is stable for
- * the isolate's life). No finalizer: a Cloudflare binding is not a resource the
- * worker owns or closes.
+ * Resolved once for the isolate's life. No finalizer: a Cloudflare binding is not a
+ * resource the worker owns or closes.
  */
 export const DatabaseLive = Layer.effect(
 	Database,

--- a/apps/web/worker/db/Drizzle.ts
+++ b/apps/web/worker/db/Drizzle.ts
@@ -1,12 +1,8 @@
 /**
  * Drizzle service — the trust boundary between D1 and Effect-native feature code
- * (ADR 0011). The Tag's value is a `DrizzleAccess` record carrying two bound
- * methods, `run` and `batch`; they are NOT static effects on the class, because
- * that shape forced every caller's `R` channel to include `Drizzle`.
- *
- * Service idiom (`.patterns/feature-services.md`): destructure `{run, batch}` at
- * layer build, call them directly in method bodies — method types stay
- * `Effect<A, E, never>`, the dep is owned by the service layer.
+ * (ADR 0011). `run` and `batch` are bound methods on the Tag's value, NOT static
+ * effects on the class: that shape forced every caller's `R` to include `Drizzle`.
+ * Destructure `{run, batch}` at layer build (`.patterns/feature-services.md`).
  */
 import type {BatchItem, BatchResponse} from "drizzle-orm/batch";
 import {drizzle} from "drizzle-orm/d1";
@@ -18,41 +14,29 @@ import * as schema from "../db/drizzle/schema.ts";
 
 /**
  * RQB v2 (drizzle 1.0) drives `db.query.<table>` off a relations definition, not
- * `schema` alone — passing only `{schema}` leaves `db.query` empty (`{}`).
- * phoenix uses no cross-table `.with` traversal, so the single-arg
- * `defineRelations(schema)` (empty relations) is enough to register every table
- * so `db.query.<table>` is typed.
+ * `schema` alone — passing only `{schema}` leaves `db.query` empty (`{}`). phoenix
+ * uses no cross-table `.with` traversal, so empty relations are enough.
  */
 export const relations = defineRelations(schema);
 
-/** Carries both `schema` and `relations` generics so `db.query` and `db.select()` are typed. */
 export type DrizzleDb = ReturnType<typeof drizzle<typeof relations>>;
 
 /**
- * The schema-agnostic surface the FTS dual-write builders need: just
- * `delete`/`insert` against the FTS shim tables (`fts-sync.ts`), which carry their
- * own table arg and so don't depend on the db's schema generic. Both the worker's
- * full `DrizzleDb` and the backfill CLI's narrow-schema db satisfy it — so the
- * `@kampus/fts-backfill` consumer can replay the same builders without pulling the
- * worker's full schema graph (the preview-seed narrow-schema idiom).
+ * Deliberately schema-agnostic: both the worker's full `DrizzleDb` and the backfill
+ * CLI's narrow-schema db satisfy it, so `@kampus/fts-backfill` can replay the same
+ * builders without pulling the worker's whole schema graph.
  */
 export type FtsSyncDb = Pick<DrizzleDb, "delete" | "insert">;
 
-/**
- * Raised when a drizzle promise rejects inside `run` / `batch`. The `cause` is
- * preserved for logs but never reaches the user.
- */
+/** The `cause` is preserved for logs but never reaches the user. */
 export class DrizzleError extends Schema.TaggedErrorClass<DrizzleError>()("@kampus/Drizzle/Error", {
 	cause: Schema.Defect(),
 }) {}
 
 /**
- * Collapse the `DrizzleError` channel into the defect channel — the
- * infra-failures-are-defects rule (`.patterns/effect-errors.md`). A
- * domain-boundary policy applied INSIDE the feature services (via
- * {@link orDieAccess} at layer build), not at fate-handler call sites: service
- * public signatures carry domain errors only, and the fate layer never names
- * Drizzle. Domain errors in the same union pass through untouched.
+ * The infra-failures-are-defects rule (`.patterns/effect-errors.md`), applied
+ * INSIDE the feature services via {@link orDieAccess} at layer build, never at
+ * fate-handler call sites. Domain errors in the same union pass through untouched.
  */
 export const orDieDrizzle = <A, E, R>(self: Effect.Effect<A, E, R>) =>
 	Effect.catchIf(
@@ -69,17 +53,16 @@ export type BatchResult<T extends Readonly<[Stmt, ...Stmt[]]>> = BatchResponse<T
 export interface DrizzleAccess {
 	readonly run: <A>(fn: (db: DrizzleDb) => Promise<A>) => Effect.Effect<A, DrizzleError>;
 
-	/** Atomic multi-statement write via D1's native batch API: every statement commits or none do. */
+	/** D1's native batch API: every statement commits or none do. */
 	readonly batch: <T extends Readonly<[Stmt, ...Stmt[]]>>(
 		fn: (db: DrizzleDb) => T,
 	) => Effect.Effect<BatchResult<T>, DrizzleError>;
 }
 
 /**
- * {@link DrizzleAccess} with the `DrizzleError` channel already collapsed into
- * the defect channel (via {@link orDieDrizzle}). Feature services destructure
- * THIS, so every internal DB call dies on infra failure and public method
- * signatures carry domain errors only (`.patterns/feature-services.md`).
+ * Feature services destructure THIS, not {@link DrizzleAccess}, so every internal
+ * DB call dies on infra failure and public method signatures carry domain errors
+ * only (`.patterns/feature-services.md`).
  */
 export interface DrizzleAccessOrDie {
 	readonly run: <A>(fn: (db: DrizzleDb) => Promise<A>) => Effect.Effect<A>;
@@ -88,34 +71,15 @@ export interface DrizzleAccessOrDie {
 	) => Effect.Effect<BatchResult<T>>;
 }
 
-/** The one construction site of the domain-boundary policy. */
 export const orDieAccess = (access: DrizzleAccess): DrizzleAccessOrDie => ({
 	run: (fn) => orDieDrizzle(access.run(fn)),
 	batch: (fn) => orDieDrizzle(access.batch(fn)),
 });
 
-/**
- * @example
- *   const {run, batch} = yield* Drizzle;
- *   const term = yield* run((db) =>
- *     db.query.termRecord.findFirst({where: eq(schema.termRecord.slug, slug)}),
- *   );
- *
- * @example
- *   yield* batch((db) => [
- *     db.insert(schema.definitionVote).values({...}),
- *     db.update(schema.definitionRecord).set({...}).where(...),
- *   ] as const);
- */
 export class Drizzle extends Context.Service<Drizzle, DrizzleAccess>()("@kampus/Drizzle") {}
 
-/** The single place `drizzle(db, {schema, relations})` is called (worker init + tests). */
 export const createDrizzle = (db: D1Database): DrizzleDb => drizzle(db, {relations});
 
-/**
- * The single home of the `run` / `batch` bodies — the promise → Effect boundary
- * and the tagged `DrizzleError` catch live here, in exactly one place.
- */
 export const makeDrizzleAccess = (db: DrizzleDb): DrizzleAccess => ({
 	run: <A>(fn: (db: DrizzleDb) => Promise<A>) =>
 		Effect.tryPromise({
@@ -130,19 +94,16 @@ export const makeDrizzleAccess = (db: DrizzleDb): DrizzleAccess => ({
 });
 
 /**
- * Per ADR 0029 / `.patterns/fate-effect-worker-wiring.md`: the D1 binding is
- * stable for the isolate's life, so `drizzle()` is built ONCE in worker init and
- * provided as a worker-level layer. `db` arrives as an argument so neither this
- * layer nor its consumers read a per-request `CloudflareEnv`.
+ * `db` arrives as an argument so neither this layer nor its consumers read a
+ * per-request `CloudflareEnv` (ADR 0029, `.patterns/fate-effect-worker-wiring.md`).
  */
 export const makeDrizzleLayer = (db: DrizzleDb): Layer.Layer<Drizzle> =>
 	Layer.succeed(Drizzle, makeDrizzleAccess(db));
 
 /**
- * The `Drizzle` layer derived from the `Database` seam (ADR 0040). Because both
- * this layer and the better-auth adapter derive from the SAME `Database` tag,
- * they share one underlying handle — the one-`sqlite` invariant is type-enforced
- * by the layer graph (`R = Database`), not test-owned.
+ * Both this layer and the better-auth adapter derive from the SAME `Database` tag,
+ * so they share one underlying handle — the one-`sqlite` invariant is type-enforced
+ * by the layer graph (`R = Database`), not test-owned (ADR 0040).
  */
 export const DrizzleLive: Layer.Layer<Drizzle, never, Database> = Layer.effect(
 	Drizzle,

--- a/apps/web/worker/db/Drizzle.unit.test.ts
+++ b/apps/web/worker/db/Drizzle.unit.test.ts
@@ -1,18 +1,13 @@
 /**
  * Drizzle service contract — the wrapper's promise → Effect conversion in pure
- * isolation: no workerd, no SQL engine (ADR 0082 `unit` tier). A fake `DrizzleDb`
- * and a `db.batch` spy suffice because the wrapper never inspects the builder, it
- * just forwards it; these tests are wrong only if the wrapper is wrong, never if a
- * database differs.
+ * isolation: no workerd, no SQL engine (ADR 0082 `unit` tier).
  *
- * The generic `db.batch` atomicity-rollback property ("a mid-batch failure rolls
- * back the whole tuple — no partial write") used to live here over the banned
- * `node:sqlite` fake. It is a real-D1 fidelity fact, but it has no
- * integration-reachable surface: the integration tier is black-box HTTP over the
- * deployed worker (no in-process `db.batch` handle), and no fate mutation has a
- * reachable mid-batch fault (every `Vote.cast` batch statement is
- * collision-tolerant by construction). So it is a tracked, accepted irreducible —
- * see #614 — not satisfied by inventing a non-production fault-injection mutation.
+ * The generic `db.batch` atomicity-rollback property ("a mid-batch failure rolls back
+ * the whole tuple") used to live here over the banned `node:sqlite` fake. It is a
+ * real-D1 fact with no integration-reachable surface — the integration tier is
+ * black-box HTTP, and no fate mutation has a reachable mid-batch fault — so it is a
+ * tracked, accepted irreducible (#614), not a reason to invent a fault-injection
+ * mutation.
  */
 import {assert, describe, it} from "@effect/vitest";
 import type {BatchItem} from "drizzle-orm/batch";
@@ -28,17 +23,14 @@ import {
 // biome-ignore lint/plugin: `DrizzleDb` is a fully-typed drizzle client that can't be structurally constructed in a fake; the wrapper passes this sentinel through untouched.
 const FAKE_DB = {__phoenix_test_db__: true} as unknown as DrizzleDb;
 
-/**
- * Delegates to the production {@link makeDrizzleAccess} so the tests exercise the
- * real `run` / `batch` bodies, while letting each test supply its own `db`.
- */
+// Delegates to the production `makeDrizzleAccess`, so the real bodies are exercised.
 const makeAccess = (db: DrizzleDb): DrizzleAccess => makeDrizzleAccess(db);
 
 const TestDrizzleLayer = Layer.succeed(Drizzle, makeAccess(FAKE_DB));
 
 /**
- * Sentinel `BatchItem<"sqlite">`: the real one is an opaque `RunnableQuery` that
- * can't be built without a live builder. Keeps the tuple shape concrete so
+ * Sentinel `BatchItem<"sqlite">`: the real one is an opaque `RunnableQuery` that cannot
+ * be built without a live builder. Keeps the tuple shape concrete so
  * `T extends Readonly<[U, ...U[]]>` infers a length-typed tuple, not `never`.
  */
 const fakeStmt = (id: number) =>
@@ -96,8 +88,8 @@ describe("Drizzle.run", () => {
 	);
 
 	it.effect("type inference: callback's promised type is the Effect's success type", () =>
-		// Compile-time assertion: if `run` widened the return to `unknown`, these
-		// typed bindings would fail tsc.
+		// Compile-time assertion: if `run` widened the return to `unknown`, these typed
+		// bindings would fail tsc.
 		Effect.gen(function* () {
 			const {run} = yield* Drizzle;
 			const n: number = yield* run(() => Promise.resolve(7));
@@ -109,8 +101,6 @@ describe("Drizzle.run", () => {
 });
 
 describe("Drizzle.batch", () => {
-	// Stubs `db.batch` to record its calls and return a sentinel, so the
-	// wrapper's forwarding behavior is observable.
 	function makeBatchSpy() {
 		const calls: Array<readonly unknown[]> = [];
 		// biome-ignore lint/plugin: spy fake — `DrizzleDb` is a fully-typed drizzle client that can't be structurally built; only `db.batch` is exercised here.

--- a/apps/web/worker/db/drizzle.config.ts
+++ b/apps/web/worker/db/drizzle.config.ts
@@ -1,16 +1,9 @@
 import {defineConfig} from "drizzle-kit";
 
-// `dbCredentials` is consumed only by `drizzle-kit migrate` (the `pnpm db:migrate`
-// escape hatch for applying pending migrations short of a full `alchemy deploy`).
-// alchemy resolves the D1 database by name and never reads this block.
-// `D1_DATABASE_ID` is the D1 UUID (Cloudflare dashboard / `wrangler d1 list`); the
-// account id + token reuse alchemy's own deploy credentials (see deploy.yml). Missing
-// values surface as drizzle-kit's own "Please provide required params" error on migrate;
-// `generate` never reads this block, so it works without credentials.
-//
-// CI-secret roster: `CLOUDFLARE_ACCOUNT_ID` + `CLOUDFLARE_API_TOKEN` are two of the four
-// CI secrets enumerated canonically in `infra/ci-credentials/github.ts` (the provisioner);
-// keep these names in sync with that roster (#1432).
+// `dbCredentials` is read ONLY by `drizzle-kit migrate` — alchemy resolves the D1
+// database by name and never reads this block, and `generate` works without credentials.
+// `CLOUDFLARE_ACCOUNT_ID` + `CLOUDFLARE_API_TOKEN` are two of the four CI secrets
+// enumerated in `infra/ci-credentials/github.ts`; keep the names in sync (#1432).
 export default defineConfig({
 	dialect: "sqlite",
 	driver: "d1-http",

--- a/apps/web/worker/db/drizzle/schema.ts
+++ b/apps/web/worker/db/drizzle/schema.ts
@@ -1,9 +1,7 @@
 /**
- * Phoenix D1 schema (binding `PHOENIX_DB`). Canonical store for every product
- * domain — ADR 0009 (d1-direct): there is no derivation step, the D1 shape *is*
- * the shape. The auth tables (`user`, `session`, `account`, `verification`,
- * `apikey`) are owned by better-auth via its drizzle adapter; everything else by
- * the relevant feature module (sozluk, pano, vote, pasaport).
+ * Phoenix D1 schema (binding `PHOENIX_DB`), D1-direct per ADR 0009. The auth tables
+ * (`user`, `session`, `account`, `verification`, `apikey`) are owned by better-auth
+ * through its drizzle adapter, not by us.
  */
 import {sql} from "drizzle-orm";
 import {index, integer, primaryKey, sqliteTable, text} from "drizzle-orm/sqlite-core";
@@ -14,13 +12,9 @@ import {KARMA_EVENT_REASONS} from "../karma-event.ts";
 import {REACTION_EMOJI} from "../reaction-emoji.ts";
 import {TARGET_KINDS} from "../target-kind.ts";
 
-// The shared read-model tables (`term_record` / `definition_record` /
-// `post_record` / `comment_record`) live in the `@kampus/db-schema` leaf so the
-// worker, preview-seed, and fts-backfill all import ONE declaration — a column
-// rename is one edit there, caught by typecheck, not three hand-mirrored copies
-// that drift (ADR 0096 `removed_at`, ADR 0093 `is_draft`; issues #859/#903).
-// drizzle-kit reads this module for migration generation, so re-exporting feeds
-// migrations exactly as a local declaration would.
+// The shared read-model tables live in `@kampus/db-schema` so worker, preview-seed,
+// and fts-backfill import ONE declaration. drizzle-kit reads this module for migration
+// generation, so re-exporting feeds migrations exactly as a local declaration would.
 export {commentRecord, definitionRecord, postRecord, termRecord} from "@kampus/db-schema";
 
 const timestamp = (name: string) => integer(name, {mode: "timestamp"});
@@ -34,39 +28,26 @@ export const user = sqliteTable("user", {
 	name: text("name"),
 	email: text("email").notNull(),
 	image: text("image"),
-	// `system` is the reserved discriminant of the seeded `@[silinen]` sentinel
-	// user (ADR 0097) — a real row that is neither a human nor a bot; it carries
-	// re-attributed content from deleted accounts. Seeded by migration, never
-	// creatable at runtime.
+	// `system` is the seeded `@[silinen]` sentinel that carries re-attributed content
+	// from deleted accounts (ADR 0097). Seeded by migration, never creatable at runtime.
 	type: text("type", {enum: ["human", "bot", "system"]})
 		.notNull()
 		.default("human"),
-	// Vestigial moderation role (was ADR 0098's authority source). ADR 0107 §4 moved
-	// moderation authority off this column onto the `moderates` relation tuple — read
-	// at the point of use via the `Moderate` capability (`RelationStore`), never
-	// `role`. Declared `input:false` to better-auth (`better-auth-live.ts`), so no
-	// client write can reach it; retained for back-compat, not read as authority.
+	// Vestigial. Moderation authority moved onto the `moderates` relation tuple (ADR
+	// 0107 §4) — never read this column as authority. `input:false` to better-auth.
 	role: text("role", {enum: ["member", "moderator"]})
 		.notNull()
 		.default("member"),
-	// Server-managed authorship tier (ADR 0107 §4) — the GLOBAL account-level
-	// earned standing on the `visitor < çaylak < yazar` ladder. The column holds
-	// only `çaylak | yazar` (an account is always ≥ çaylak; `visitor` is the
-	// no-account read, never stored). Born `çaylak`; promoted to `yazar` only by
-	// the server promotion path (#1206) / founding seed — declared `input:false`
-	// to better-auth (`better-auth-live.ts`), so no client/session write can set
-	// or escalate it. Read at the point of use via `Kunye.tierOf` (through
-	// Pasaport), never trusted from session state.
+	// Server-managed authorship tier (ADR 0107 §4). `visitor` is never stored — it is
+	// the no-account read. Only the server promotion path writes it; `input:false` to
+	// better-auth so no client write can escalate. Read via `Kunye.tierOf`, never from
+	// session state.
 	tier: text("tier", {enum: [...STORED_TIERS]})
 		.notNull()
 		.default("çaylak"),
-	// When the account was promoted `çaylak → yazar` (#1590). Null = never promoted,
-	// or promoted before this column existed (the founding cohort predates it — v1
-	// measures time-to-promotion forward only, no backfill). Stamped atomically inside
-	// `Pasaport.promoteToYazar` in the same batch as the `tier` flip (ADR 0013/0014),
-	// so it can only be set on the exact write that flips the tier — server-only, never
-	// client-writable (declared `input:false` + `returned:false` to better-auth,
-	// `better-auth-live.ts`). A thin nullable signal, NOT an analytics/event stream.
+	// Null = never promoted, OR promoted before this column existed (no backfill — the
+	// founding cohort predates it). Stamped in the same batch as the `tier` flip, so it
+	// can only be set on the write that flips the tier. `input:false`+`returned:false`.
 	promotedAt: timestamp("promoted_at"),
 	emailVerified: integer("email_verified", {mode: "boolean"}),
 	// Public handle: 3–30 chars, lowercase ASCII + digits + `-`, no leading/
@@ -74,11 +55,9 @@ export const user = sqliteTable("user", {
 	username: text("username").unique(),
 	createdAt: timestamp("created_at"),
 	updatedAt: timestamp("updated_at"),
-	// Account-deletion tombstone (ADR 0097). Null = a live account; set ⇒ the row
-	// was scrubbed by `account.delete` (email/name/image nulled) but KEPT so the
+	// Account-deletion tombstone (ADR 0097). Set ⇒ the row was scrubbed but KEPT, so the
 	// `author_id → silinen` redirect and the FKs stay coherent and the email can
-	// re-register fresh. Identity rows (session/account/apikey/verification) are
-	// torn down; this stamp marks the surviving tombstone.
+	// re-register fresh.
 	deletedAt: timestamp("deleted_at"),
 });
 
@@ -124,13 +103,10 @@ export const verification = sqliteTable("verification", {
 
 export const apikey = sqliteTable("apiKey", {
 	id: text("id").primaryKey(),
-	// `configId` + `referenceId` are the property names the pinned @better-auth/api-key
-	// plugin resolves against (its declared `apikey` schema names them, with no
-	// `fieldName` override) — the drizzle adapter's `checkMissingFields` indexes the
-	// table object by those exact keys on every create, so a mismatch 500s the mint
-	// (#108). `referenceId` keeps the SQL column `user_id`: with the plugin's default
-	// user-references config the reference IS the user id, so the column name stays
-	// accurate and no destructive column-rename migration is needed.
+	// `configId` + `referenceId` are the exact property names the pinned
+	// @better-auth/api-key plugin indexes this table object by on every create; a
+	// mismatch 500s the mint (#108). `referenceId` keeps the SQL column `user_id`
+	// because the reference IS the user id — no rename migration needed.
 	configId: text("config_id").notNull().default("default"),
 	name: text("name"),
 	start: text("start"),
@@ -157,19 +133,10 @@ export const apikey = sqliteTable("apiKey", {
 });
 
 /**
- * Append-only ban/unban event log — the SINGLE source of both the audit trail and
- * the current ban-state (ADR 0107 admin-gated moderation, epic #968). Ban-state is
- * NOT a mutable flag on `user` (the never-migrated better-auth `banned`/`banReason`/
- * `banExpires` columns are deliberately not resurrected): it is a projection of the
- * latest event for a user (see `features/pasaport/ban.ts` `resolveBanState`), so
- * "current state diverged from history" is unrepresentable — every ban and every
- * unban is one immutable row carrying its actor, reason, expiry, and time.
- *
- * Enforcement reads the latest row per request at the session boundary
- * (`Pasaport.validateSession`), so a banned user's EXISTING session is refused, not
- * just a flag toggled. The `(user_id, created_at DESC)` index is that hot read's
- * key. `onDelete: cascade` ties the log to the account row (account-deletion is a
- * kept tombstone, ADR 0097, so the row — and this history — survive a deletion).
+ * Append-only ban/unban log. Ban-state is NOT a flag on `user` — it is a projection of
+ * the latest event here (`resolveBanState`), so state can never diverge from history.
+ * `Pasaport.validateSession` reads it per request, so a banned user's EXISTING session
+ * is refused rather than just a flag toggled.
  */
 export const userBanEvent = sqliteTable(
 	"user_ban_event",
@@ -178,16 +145,11 @@ export const userBanEvent = sqliteTable(
 		userId: text("user_id")
 			.notNull()
 			.references(() => user.id, {onDelete: "cascade"}),
-		// The event kind: a `ban` opens/refreshes a ban, an `unban` lifts it. The
-		// projection reads only the latest row, so an `unban` after a `ban` restores
-		// access without mutating or deleting the ban row — full reversibility.
 		action: text("action", {enum: ["ban", "unban"]}).notNull(),
-		// The admin who performed the action (a discharged `Admin` grant's account id).
 		actorId: text("actor_id").notNull(),
-		// Ban reason (required at the mutation boundary for a `ban`); null for an `unban`.
 		reason: text("reason"),
-		// Optional ban expiry; null = permanent (or an `unban`). A past `expiresAt`
-		// projects to not-banned (see `resolveBanState`), so an expired ban self-lifts.
+		// Null = permanent (or an `unban`). A past `expiresAt` projects to not-banned, so
+		// an expired ban self-lifts with no sweep.
 		expiresAt: timestamp("expires_at"),
 		createdAt: timestamp("created_at").notNull(),
 	},
@@ -195,18 +157,10 @@ export const userBanEvent = sqliteTable(
 );
 
 /**
- * Append-only transactional-email delivery-failure log — the SINGLE source of both
- * the audit trail and the current per-address failing-state (email-bounce epic #2687).
- * Failing-state is a projection of the latest event for an address (see
- * `features/pasaport/email-delivery.ts` `resolveEmailDeliveryState`), mirroring
- * {@link userBanEvent}: latest-event-wins, so a stale "bouncing flag" is
- * unrepresentable. Every feed appends here — the send-time capture (Child #2691), the
- * admin mark/clear (Child #2692), and the CF async ingestion (Child #2694).
- *
- * The recipient is keyed by `address` (always known from the send), with `userId` a
- * nullable FK when the address resolves to an account — a send can target an address
- * with no `user` row. `onDelete: set null` keeps the delivery history when the account
- * is deleted (the address remains the stable key).
+ * Append-only email delivery-failure log, latest-event-wins like {@link userBanEvent}
+ * (`resolveEmailDeliveryState`). Keyed by `address`, not user: a send can target an
+ * address with no `user` row, so `userId` is a nullable `set null` FK and the address
+ * stays the stable key across an account deletion.
  */
 export const emailDeliveryEvent = sqliteTable(
 	"email_delivery_event",
@@ -214,17 +168,10 @@ export const emailDeliveryEvent = sqliteTable(
 		id: text("id").primaryKey(),
 		userId: text("user_id").references(() => user.id, {onDelete: "set null"}),
 		address: text("address").notNull(),
-		// A `fail` opens/refreshes a failing-state, a `clear` lifts it. The projection
-		// reads only the latest row, so a `clear` after a `fail` restores deliverability
-		// without mutating or deleting the fail row — full reversibility, as in ban.
 		action: text("action", {enum: ["fail", "clear"]}).notNull(),
-		// The admin who performed a manual mark/clear (the discharged `Admin` grant's account
-		// id, #2734), mirroring {@link userBanEvent}'s `actorId`. NULLABLE, unlike ban's
-		// NOT NULL: this log is multi-writer — the send-time `SendEmailError` capture (#2691)
-		// and the CF async ingestion (#2694) are non-admin appenders with no actor, and
-		// pre-#2734 rows carry none. Only the admin mark/clear stamps it.
+		// NULLABLE, unlike ban's NOT NULL: this log is multi-writer, and the send-time
+		// capture and the CF async ingestion are non-admin appenders with no actor.
 		actorId: text("actor_id"),
-		// The failure detail (a `SendEmailError` message, or an admin note); null for a `clear`.
 		reason: text("reason"),
 		createdAt: timestamp("created_at").notNull(),
 	},
@@ -235,18 +182,9 @@ export const emailDeliveryEvent = sqliteTable(
 );
 
 /**
- * Append-only platform-role assignment log (#3522, admin epic per ADR 0107). The
- * audit trail for the `Admin.over(platform)`-gated `user.setRole` mutation — the
- * SPA-invokable writer for the `moderates` relation tuple that #969/PR #1266's
- * offline mint never gave the console. Same append-only, latest-event-wins shape as
- * {@link userBanEvent}: the newest event's `role` is the current assignment, so the
- * log can never drift from the authoritative `relation_tuple` write the mutation
- * commits alongside it. `role` is the NEW role the action set — `moderator` grants
- * the `(user, "moderates", "platform")` tuple, `member` revokes it — so actor,
- * target, new role, and time are all captured for the audit AC. The `(user_id,
- * created_at DESC)` index serves the per-account latest-event read; `onDelete:
- * cascade` ties the history to the account row (a kept tombstone survives account
- * deletion, ADR 0097).
+ * Append-only platform-role assignment log, latest-event-wins like
+ * {@link userBanEvent}. Written alongside the authoritative `relation_tuple` write in
+ * the same mutation, so the audit trail cannot drift from the grant.
  */
 export const userRoleEvent = sqliteTable(
 	"user_role_event",
@@ -256,10 +194,8 @@ export const userRoleEvent = sqliteTable(
 			.notNull()
 			.references(() => user.id, {onDelete: "cascade"}),
 		// The role this action assigned: `moderator` writes the `moderates` tuple,
-		// `member` clears it. The latest row projects to the account's current role.
+		// `member` clears it.
 		role: text("role", {enum: ["member", "moderator"]}).notNull(),
-		// The admin who performed the action (a discharged `Admin` grant's account id),
-		// mirroring {@link userBanEvent}'s `actorId`.
 		actorId: text("actor_id").notNull(),
 		createdAt: timestamp("created_at").notNull(),
 	},
@@ -268,8 +204,8 @@ export const userRoleEvent = sqliteTable(
 
 /**
  * Per-(definition, voter) up-vote presence row. `user_vote` and
- * `definition_record.score` (COUNT(*) under `WHERE definition_id = ?`) are both
- * denormalized off this, recomputed inline in the same D1 batch as the vote write.
+ * `definition_record.score` are denormalized off this, recomputed inline in the same
+ * D1 batch as the vote write.
  */
 export const definitionVote = sqliteTable(
 	"definition_vote",
@@ -284,10 +220,7 @@ export const definitionVote = sqliteTable(
 	],
 );
 
-/**
- * Single-row stats table for the landing page (id = 1 is the only row).
- * Maintained inline by `recomputeSozlukStats` (D1-direct, see ADR 0009).
- */
+/** Single-row stats table (id = 1 is the only row), maintained by `recomputeSozlukStats`. */
 export const sozlukStats = sqliteTable("sozluk_stats", {
 	id: integer("id").primaryKey().default(1),
 	totalDefinitions: integer("total_definitions").notNull().default(0),
@@ -296,7 +229,6 @@ export const sozlukStats = sqliteTable("sozluk_stats", {
 	updatedAt: timestamp("updated_at").notNull(),
 });
 
-/** Per-(post, voter) up-vote presence row. Mirrors `definitionVote`. */
 export const postVote = sqliteTable(
 	"post_vote",
 	{
@@ -307,13 +239,7 @@ export const postVote = sqliteTable(
 	(t) => [primaryKey({columns: [t.postId, t.voterId]}), index("post_vote_post").on(t.postId)],
 );
 
-/**
- * Per-(post, user) bookmark ("kaydet") presence row. Pure presence — a row
- * means saved, its absence means not; no score or value column (the structural
- * difference from `postVote`, which the score cache reads). The `(user_id,
- * created_at DESC)` index serves a future newest-first saved-posts list, the
- * same `sql` DESC-fragment idiom as `post_record_author_created`.
- */
+/** Per-(post, user) bookmark ("kaydet"). Pure presence — no score or value column. */
 export const postBookmark = sqliteTable(
 	"post_bookmark",
 	{
@@ -327,7 +253,6 @@ export const postBookmark = sqliteTable(
 	],
 );
 
-/** Per-(comment, voter) up-vote presence row. Mirrors `postVote` and `definitionVote`. */
 export const commentVote = sqliteTable(
 	"comment_vote",
 	{
@@ -341,10 +266,7 @@ export const commentVote = sqliteTable(
 	],
 );
 
-/**
- * Single-row stats for the landing page. Maintained inline by
- * `recomputePanoStats` / `makePersistPanoStats` (D1-direct, see ADR 0009).
- */
+/** Single-row stats table, maintained by `recomputePanoStats` / `makePersistPanoStats`. */
 export const panoStats = sqliteTable("pano_stats", {
 	id: integer("id").primaryKey().default(1),
 	totalPosts: integer("total_posts").notNull().default(0),
@@ -354,10 +276,8 @@ export const panoStats = sqliteTable("pano_stats", {
 });
 
 /**
- * Per-user-per-target vote presence table powering the `myVote` view field.
- * Up-only in the MVP — presence of a row means voted, absence means not; there
- * is no `value` column. Maintained inline by `Vote.cast`'s atomic batch (insert
- * on vote, delete on retract; D1-direct, see ADR 0009).
+ * Per-user-per-target vote presence, powering `myVote`. Up-only — a row means voted,
+ * so there is no `value` column and a retract is a delete.
  */
 export const userVote = sqliteTable(
 	"user_vote",
@@ -375,22 +295,11 @@ export const userVote = sqliteTable(
 );
 
 /**
- * Per-(user, target) reaction presence row — the third instance of the
- * polymorphic per-user-presence pattern (after `user_vote` / `post_bookmark`),
- * modeled on the karma-free / ungated `post_bookmark` shape, polymorphic over
- * the same three targets Vote spans (`definition` | `post` | `comment`, the
- * shared `TARGET_KINDS` taxonomy). Social-only and UNGATED: a logged-in çaylak
- * may react — no karma column, no tier gate (the deliberate divergence from
- * Vote). Unlike bookmark (pure presence), a reaction carries a value: the
- * chosen `emoji`, constrained to the curated `REACTION_EMOJI` palette.
- *
- * The composite PK `(user_id, target_kind, target_id)` is the cardinality-one
- * constraint — at most one reaction per user per item, so changing a reaction
- * is an upsert on the `emoji` column (`onConflictDoUpdate`), mirroring the
- * `user_vote` cross-product PK shape. Aggregation is a `COUNT(*)` GROUP BY emoji
- * read (the display child owns the read path) — no per-(target, emoji) count
- * cache row is added here; the count is computed on read, so there is no cache
- * to keep coherent on every react.
+ * Per-(user, target) reaction. Social-only and UNGATED — a logged-in çaylak may react;
+ * no karma, no tier gate, the deliberate divergence from Vote. The composite PK caps it
+ * at one reaction per user per item, so a change is an upsert on `emoji`. Counts are
+ * computed on read (`COUNT(*)` GROUP BY emoji) — deliberately no count-cache row to
+ * keep coherent.
  */
 export const userReaction = sqliteTable(
 	"user_reaction",
@@ -409,13 +318,9 @@ export const userReaction = sqliteTable(
 );
 
 /**
- * One-directional member mute ("sustur") presence row: a row `(muter_id,
- * muted_id)` means muter has muted muted, its absence means not. Pure presence in
- * the `post_bookmark` shape — no value column — but keyed on two users rather than
- * (user, target). The composite PK `(muter_id, muted_id)` is the cardinality-one
- * constraint; the `muted_id` reverse index serves the batched viewer-side presence
- * read (`Mute.readMutedIds`) so read-masking stamps without an N+1. Maintained
- * inline by `Mute.set` (insert on mute, delete on un-mute; D1-direct, see ADR 0009).
+ * One-directional member mute ("sustur"): a row means muter has muted muted. The
+ * `muted_id` reverse index serves the batched `Mute.readMutedIds` read, so read-masking
+ * stamps without an N+1.
  */
 export const userMute = sqliteTable(
 	"user_mute",
@@ -428,10 +333,9 @@ export const userMute = sqliteTable(
 );
 
 /**
- * Per-user denormalized profile row. `total_karma` is the running sum of upvotes
- * received across all of this user's contributions, maintained inline by
- * `Vote.cast`'s atomic batch (D1-direct, see ADR 0009). Its provenance — one row
- * per bump — lives in {@link karmaEvent}, co-committed in that same batch (#2592).
+ * Per-user denormalized profile row. `total_karma` is an accumulator maintained in
+ * `Vote.cast`'s batch; its per-bump provenance lives in {@link karmaEvent}, co-committed
+ * in that same batch.
  */
 export const userProfile = sqliteTable(
 	"user_profile",
@@ -452,16 +356,10 @@ export const userProfile = sqliteTable(
 );
 
 /**
- * Append-only provenance ledger for `user_profile.total_karma` (#2592) — one row
- * per karma bump, co-committed in `Vote.cast`'s atomic batch (via the `KarmaBump`
- * contract's pasaport implementation, `features/pasaport/karma.ts`), so a delta
- * can never land without its event nor an event without its delta. The same
- * append-only-log shape as {@link userBanEvent}: a retraction is a NEGATIVE-`delta`
- * row, never a mutation or deletion of a prior one, so `SUM(delta)` per `user_id`
- * reconstructs the accumulator exactly. `reason` distinguishes the event kind
- * (`vote` cast / `retract`); `(source_kind, source_id)` names the vote target the
- * delta came from. `onDelete: cascade` ties the ledger to the account row (an
- * account deletion is a kept tombstone, ADR 0097, so this history survives it).
+ * Append-only provenance ledger for `user_profile.total_karma`, co-committed in
+ * `Vote.cast`'s batch so a delta can never land without its event. A retraction is a
+ * NEGATIVE-`delta` row, never a mutation or delete, so `SUM(delta)` per user
+ * reconstructs the accumulator exactly.
  */
 export const karmaEvent = sqliteTable(
 	"karma_event",
@@ -480,17 +378,9 @@ export const karmaEvent = sqliteTable(
 );
 
 /**
- * Per-(reporter, target) content-report presence row, polymorphic over the same
- * three targets Vote spans (`post` | `comment` | `definition`). The composite PK
- * `(reporter_id, target_kind, target_id)` makes a re-report by the same user an
- * idempotent no-op (`onConflictDoNothing`), mirroring `user_vote`.
- *
- * `status` is the resolution state machine (ADR 0098): born `'open'`, terminal
- * at `'resolved'` | `'dismissed'`. A terminal transition is the only writer of
- * the audit triad (`resolverId`/`resolvedAt`/`resolution`) — a resolved row is
- * uninhabitable without all three, so "resolved but we don't know who/what" is
- * unrepresentable. No live view publishes off this — a report is private
- * moderation state, not a client-cached entity.
+ * Per-(reporter, target) content report. The composite PK makes a re-report by the same
+ * user an idempotent no-op. `status` is the ADR 0098 resolution machine. No live view
+ * publishes off this — a report is private moderation state, not a client-cached entity.
  */
 export const contentReport = sqliteTable(
 	"content_report",
@@ -499,48 +389,32 @@ export const contentReport = sqliteTable(
 		reporterId: text("reporter_id").notNull(),
 		targetKind: text("target_kind", {enum: [...TARGET_KINDS]}).notNull(),
 		targetId: text("target_id").notNull(),
-		// Optional free-text reason supplied by the reporter.
 		reason: text("reason"),
-		// Status + resolution enums source from the ADR 0098 machine's tuples
-		// (`features/report/resolution.ts`) so the column can't drift from it.
+		// Status + resolution enums source from `features/report/resolution.ts` so the
+		// columns cannot drift from the machine.
 		status: text("status", {enum: [...REPORT_STATUSES]})
 			.notNull()
 			.default("open"),
 		createdAt: timestamp("created_at").notNull(),
-		// Audit triad — written only on a terminal transition, NULL while open.
+		// Audit triad — written only on a terminal transition, all three NULL while open.
 		resolverId: text("resolver_id"),
 		resolvedAt: timestamp("resolved_at"),
-		// The decision the resolver made: 'removed' (target soft-deleted via the
-		// substrate) | 'dismissed' (report unfounded, no action).
 		resolution: text("resolution", {enum: [...RESOLUTIONS]}),
-		// The wave-remove grouping identity (#1855, ADR 0138): ONE shared id stamped
-		// across every target resolved in a single wave gesture, so the batch reopens
-		// as a unit (#1704's restore primitive). NULL on a single-target resolve — a
-		// wave groups a batch, a lone resolve has none.
+		// ONE shared id stamped across every target resolved in a single wave gesture, so
+		// the batch reopens as a unit (ADR 0138). NULL on a single-target resolve.
 		waveId: text("wave_id"),
 	},
 	(t) => [
 		primaryKey({columns: [t.reporterId, t.targetKind, t.targetId]}),
-		// Reverse lookup: reports against a given target (moderation read path +
-		// free repeat-offender count, ADR 0098 §5).
 		index("content_report_target").on(t.targetKind, t.targetId),
-		// Reopen-by-wave lookup: the rows sharing a `wave_id` the restore reopens as a
-		// unit (#1855).
 		index("content_report_wave").on(t.waveId),
 	],
 );
 
 /**
- * ReBAC relation-tuple store (ADR 0107) — the `(subject, relation, object)` triples
- * that back the `Relation` capability axis (`moderates`, `admin`). A tuple's presence
- * IS the grant: `RelationStore` reads the existence check `(subject, relation, object)`,
- * served directly by the composite primary key. There is **no runtime write path** —
- * tuples are minted offline (the founder seed mints the `role='moderator'` cohort as
- * `(id, "moderates", "platform")`), the same fail-closed shape `user.role` has
- * (CLAUDE.md "Sözlük seed"; the deleted `/api/admin/*` fail-open routes). The
- * `(object, relation)` reverse index serves the "subjects holding relation R on object
- * O" listing read (e.g. the platform's moderators), mirroring the reverse-lookup index
- * on `content_report` / `user_vote`.
+ * ReBAC relation-tuple store (ADR 0107). A tuple's presence IS the grant. There is
+ * **no runtime write path** — tuples are minted offline, deliberately fail-closed;
+ * do not add one (CLAUDE.md "Sözlük seed", the deleted fail-open `/api/admin/*`).
  */
 export const relationTuple = sqliteTable(
 	"relation_tuple",
@@ -556,18 +430,10 @@ export const relationTuple = sqliteTable(
 );
 
 /**
- * Authorship-vouch ledger (ADR 0107, #1206) — the recorded act of a `yazar`
- * vouching for a `çaylak`'s promotion. A vouch is a durable record, not a
- * relation_tuple: relation_tuple has NO runtime write path (offline-minted only),
- * whereas a vouch IS a runtime write by a signed-in yazar, so it gets its own
- * table with the vouching actor preserved.
- *
- * The composite PK `(voucher_id, candidate_id)` makes a re-vouch by the same yazar
- * for the same çaylak an idempotent no-op (`onConflictDoNothing`) — and makes
- * "a vouch with no voucher" or "a vouch with no candidate" unrepresentable (both
- * NOT NULL). The `candidate_id` reverse index serves the "who vouched for this
- * çaylak" read. There is no FK to `user` so a later account-anonymize doesn't
- * cascade-erase the historical vouching act (the actor id is kept verbatim).
+ * Authorship-vouch ledger (ADR 0107). Its own table rather than a `relation_tuple`
+ * because a vouch IS a runtime write by a signed-in yazar and that table has no runtime
+ * write path. No FK to `user` — an account anonymize must not cascade-erase the
+ * historical vouching act.
  */
 export const authorshipVouch = sqliteTable(
 	"authorship_vouch",
@@ -583,19 +449,11 @@ export const authorshipVouch = sqliteTable(
 );
 
 /**
- * Per-recipient notification row (#1694, epic #1666) — the bildirim spine's one
- * table. `kind` is a plain text discriminant deliberately WITHOUT a D1 enum: the
- * spine mints no notifications; each sibling emitter (#1695–#1699) introduces its
- * own kinds without a migration. `target_kind`/`target_id` reference the notified
- * entity polymorphically (the `content_report` idiom, widened by `user` — see
- * `features/bildirim/target.ts`); the target may be removed later, so the read
- * path resolves liveness at list time (tombstone), never an FK.
- *
- * Read state is the nullable `read_at` stamp — "read but we don't know when" is
- * unrepresentable. `count` is the aggregate slot ("3 yeni oy", #1698): the spine
- * writes 1, an aggregating emitter bumps it + `updated_at` in place. `actor_id`
- * is kept verbatim with NO FK (the `authorship_vouch` choice) so an account
- * deletion never cascade-erases a recipient's history.
+ * The bildirim spine's one table. `kind` is deliberately WITHOUT a D1 enum, so each
+ * emitter adds its own kinds with no migration. The target may be removed later, so the
+ * read path resolves liveness at list time rather than through an FK. `count` is the
+ * aggregate slot ("3 yeni oy") an aggregating emitter bumps in place. `actor_id` carries
+ * no FK, so an account deletion never cascade-erases a recipient's history.
  */
 export const notification = sqliteTable(
 	"notification",
@@ -612,33 +470,22 @@ export const notification = sqliteTable(
 		updatedAt: timestamp("updated_at").notNull(),
 	},
 	(t) => [
-		// WHERE recipient_id = ? AND read_at IS NULL (the unread-count badge).
 		index("notification_recipient_read").on(t.recipientId, t.readAt),
-		// WHERE recipient_id = ? ORDER BY created_at DESC (the center's keyset list).
 		index("notification_recipient_created").on(t.recipientId, sql`${t.createdAt} DESC`),
 	],
 );
 
 /**
- * One row per mecmua post — mecmua's OWN worker-private long-form authoring store
- * (epic #2467, #2463), NOT a reuse of pano `post_record`. mecmua is markdown
- * long-form authoring, so it carries none of pano's link-sharing columns
- * (`url`/`host`/`score`/`hot_score`/`comment_count`/`tags`) and no çaylak sandbox
- * marker.
- *
- * `published_at` IS the draft/publish lifecycle: null ⇒ an unpublished draft
- * (masked from public reads by `features/mecmua/MecmuaPostVisibility`), non-null ⇒
- * published at that instant. Multiple drafts per author are allowed — the
- * deliberate divergence from pano's one-draft-per-author partial unique index, so
- * there is none here. Worker-private, so it lives in this schema and not the shared
- * `@kampus/db-schema` leaf.
+ * mecmua's own long-form authoring store, deliberately NOT a reuse of pano
+ * `post_record`. `published_at` IS the draft/publish lifecycle: null ⇒ an unpublished
+ * draft, masked from public reads by `MecmuaPostVisibility`. Multiple drafts per author
+ * are allowed — the deliberate divergence from pano, so no partial unique index here.
  */
 export const mecmuaPost = sqliteTable(
 	"mecmua_post",
 	{
 		id: text("id").primaryKey(),
 		title: text("title").notNull(),
-		// Canonical long-form markdown body under D1-direct (ADR 0009).
 		body: text("body").notNull().default(""),
 		slug: text("slug"),
 		authorId: text("author_id").notNull(),
@@ -646,21 +493,12 @@ export const mecmuaPost = sqliteTable(
 		createdAt: timestamp("created_at").notNull(),
 		updatedAt: timestamp("updated_at").notNull(),
 	},
-	(t) => [
-		// WHERE author_id = ? ORDER BY created_at DESC (an author's own posts + drafts).
-		index("mecmua_post_author_created").on(t.authorId, sql`${t.createdAt} DESC`),
-	],
+	(t) => [index("mecmua_post_author_created").on(t.authorId, sql`${t.createdAt} DESC`)],
 );
 
 /**
- * The mecmua subscribed-author edge (#2500, epic #2467) — the reader→author
- * follow relation the subscribed-author time feed reads to select authors. One row
- * per (subscriber, author) pair: `subscriber_id` follows `author_id`. Deliberately
- * MINIMAL (v1) — no display name, no notification prefs, no named-publication scope;
- * just the edge the feed keysets over. A dedicated table (not the generic
- * `relation_tuple`, which has no runtime write path) so the feed join is a plain
- * index read and the subscribe/unsubscribe writes are ordinary D1-direct mutations.
- * Worker-private, so it lives here and not the shared `@kampus/db-schema` leaf.
+ * The mecmua reader→author follow edge. A dedicated table rather than the generic
+ * `relation_tuple`, which has no runtime write path.
  */
 export const mecmuaSubscription = sqliteTable(
 	"mecmua_subscription",
@@ -670,10 +508,8 @@ export const mecmuaSubscription = sqliteTable(
 		createdAt: timestamp("created_at").notNull(),
 	},
 	(t) => [
-		// The edge identity — one subscription per (subscriber, author); a re-subscribe is
-		// an idempotent no-op, not a duplicate row.
+		// One subscription per (subscriber, author) — a re-subscribe is an idempotent no-op.
 		primaryKey({columns: [t.subscriberId, t.authorId]}),
-		// WHERE subscriber_id = ? — the feed's "which authors does this reader follow" read.
 		index("mecmua_subscription_subscriber").on(t.subscriberId, sql`${t.createdAt} DESC`),
 	],
 );

--- a/apps/web/worker/db/hotScore.ts
+++ b/apps/web/worker/db/hotScore.ts
@@ -1,14 +1,10 @@
 /**
- * HN-style hot-score decay — the single source of truth for the ranking formula
- * `floor(score * 1000 / (hoursOld + 2)^1.8)` and its gravity constants, homed
- * below both consumers so neither owns a private copy that can silently drift.
+ * HN-style hot-score decay — the single source of truth for the ranking formula and
+ * its gravity constants, homed below both consumers (Vote never imports `pano/`) so
+ * neither owns a private copy that can drift.
  *
- * Two consumers across the Vote↔Pano seam, both reading from here (Vote never
- * imports `pano/`, so the shared home is `db/`, mirroring `pasaport/karma.ts`):
- *   - Pano calls `computeHotScore` for the integer score it persists.
- *   - Vote calls `hotMultiplier` for the JS-side multiplier it binds into SQL
- *     (SQLite has no `POW`, so the `(hoursOld + 2)^1.8` factor is computed here
- *     and the column is `CAST(count * multiplier AS INTEGER)`).
+ * SQLite has no `POW`, so the `(hoursOld + 2)^1.8` factor is computed in JS here and
+ * bound into SQL as `CAST(count * multiplier AS INTEGER)`.
  */
 
 const GRAVITY = 1.8;
@@ -20,17 +16,12 @@ const MS_PER_HOUR = 3_600_000;
 const hoursOld = (createdAtMs: number, nowMs: number): number =>
 	Math.max(0, (nowMs - createdAtMs) / MS_PER_HOUR);
 
-/**
- * The decay multiplier `1000 / (hoursOld + 2)^1.8` — the per-vote weight at this
- * age. Vote binds this into SQL as `CAST(count * multiplier AS INTEGER)`.
- */
 export const hotMultiplier = (createdAtMs: number, nowMs: number): number =>
 	SCORE_SCALE / (hoursOld(createdAtMs, nowMs) + AGE_OFFSET_HOURS) ** GRAVITY;
 
 /**
- * The persisted integer hot score `floor(score * multiplier)`. Floored so the
- * column stays an integer (D1 indexes integers cheaper than floats; only the
- * relative ordering matters). Equivalent to `count * multiplier` cast to INTEGER.
+ * Floored so the persisted column stays an integer — D1 indexes integers cheaper than
+ * floats, and only the relative ordering matters.
  */
 export const computeHotScore = (score: number, createdAtMs: number, nowMs: number): number =>
 	Math.floor(score * hotMultiplier(createdAtMs, nowMs));

--- a/apps/web/worker/db/hotScoreDecay.ts
+++ b/apps/web/worker/db/hotScoreDecay.ts
@@ -1,24 +1,13 @@
 /**
- * The periodic hot-score decay-refresh core (#2027) — pure, DB-free.
- *
- * `hot_score` is a STORED, indexed integer (`post_record.hot_score`, index
- * `post_record_hot`) that the sıcak/hot feed reads by keyset pagination with no
- * read-time recompute. It is written only at activity sites (create/vote/comment),
- * so the age term of the HN gravity formula (`hotScore.ts`) freezes the moment a
- * post stops getting activity — an inactive post never decays and squats the feed.
- *
- * The fix is a periodic refresh, NOT a read-time recompute: read-time recompute
- * fights both the no-`POW` SQLite constraint (`hotScore.ts`) and the keyset-cursor
- * contract (the cursor needs `hot_score` to stay a stored, indexed, monotonic
- * column). This module owns the pure decision — given the current rows and `now`,
- * which `hot_score` values changed and to what — reusing the ONE `computeHotScore`
- * formula so the scheduled path and the write path can never drift. The DB read of
- * the candidate rows and the write-back are the caller's (`post-operations.ts`);
- * this stays workerd-free and unit-tested.
+ * The pure decay decision behind the periodic hot-score refresh (#2027). A periodic
+ * refresh rather than a read-time recompute, because recompute-on-read fights both the
+ * no-`POW` SQLite constraint (`hotScore.ts`) and the keyset cursor, which needs
+ * `hot_score` to stay a stored, indexed column. The read and write-back are the caller's
+ * (`post-operations.ts`); the `computeHotScore` reuse is what keeps the scheduled path
+ * and the write path from drifting.
  */
 import {computeHotScore} from "./hotScore.ts";
 
-/** The minimal post shape the decay decision reads. */
 export interface HotDecayRow {
 	readonly id: string;
 	readonly score: number;
@@ -26,21 +15,15 @@ export interface HotDecayRow {
 	readonly createdAtMs: number;
 }
 
-/** One post whose stored `hot_score` must be rewritten to `hotScore`. */
 export interface HotDecayUpdate {
 	readonly id: string;
 	readonly hotScore: number;
 }
 
 /**
- * The pure decay decision: recompute each row's `hot_score` at `now` via the shared
- * formula and return ONLY the rows whose stored value actually changed. Filtering to
- * changed rows keeps the write-back a no-op for the (common) steady state where a
- * post's floored score didn't move this pass — the refresh never writes churn.
- *
- * A row with `score === 0` recomputes to `0` and, if already `0`, is dropped — a
- * brand-new post at rest costs no write. `now` is threaded (not read here) so a
- * caller's single clock reading is the source of truth across read + recompute.
+ * Returns ONLY the rows whose stored value actually changed, so the write-back is a no-op
+ * in the common steady state where a post's floored score didn't move. `now` is threaded
+ * in so the caller's single clock reading covers read + recompute.
  */
 export const decayHotScores = (
 	rows: ReadonlyArray<HotDecayRow>,

--- a/apps/web/worker/db/hotScoreDecay.unit.test.ts
+++ b/apps/web/worker/db/hotScoreDecay.unit.test.ts
@@ -1,10 +1,4 @@
-/**
- * Unit coverage for the periodic hot-score decay-refresh core (#2027). Pure — no
- * Effect layer, no DB. Proves the refresh applies the shared formula, decays a stored
- * `hot_score` over elapsed time WITHOUT an activity write, writes only changed rows,
- * and reproduces + guards the reported bug: a fresher post overtaking a stale one
- * once the stale post's frozen score is re-decayed.
- */
+/** The hot-score decay-refresh core, pure — no Effect layer, no DB. */
 import {describe, expect, it} from "vitest";
 import {computeHotScore} from "./hotScore.ts";
 import {decayHotScores} from "./hotScoreDecay.ts";
@@ -15,23 +9,19 @@ describe("decayHotScores", () => {
 	it("recomputes hot_score via the shared computeHotScore formula", () => {
 		const now = Date.UTC(2026, 0, 10, 12, 0, 0);
 		const createdAtMs = now - 5 * HOUR;
-		// Stored value is stale (0); the recompute must equal the formula at `now`.
 		const updates = decayHotScores([{id: "p1", score: 8, hotScore: 0, createdAtMs}], now);
 		expect(updates).toEqual([{id: "p1", hotScore: computeHotScore(8, createdAtMs, now)}]);
 	});
 
 	it("decays a frozen hot_score as the post ages, with no activity write", () => {
 		const created = Date.UTC(2026, 0, 1, 0, 0, 0);
-		// The write-time value: computed when the post was 1h old and then FROZEN.
 		const frozen = computeHotScore(5, created, created + 1 * HOUR);
-		// A refresh pass 24h later re-decays the same score at the later `now`.
 		const later = created + 24 * HOUR;
 		const [update] = decayHotScores(
 			[{id: "p1", score: 5, hotScore: frozen, createdAtMs: created}],
 			later,
 		);
 		expect(update).toBeDefined();
-		// Strictly lower — the age term grew, so the stored rank must have dropped.
 		expect(update?.hotScore).toBeLessThan(frozen);
 		expect(update?.hotScore).toBe(computeHotScore(5, created, later));
 	});
@@ -40,7 +30,6 @@ describe("decayHotScores", () => {
 		const now = Date.UTC(2026, 0, 10, 12, 0, 0);
 		const createdAtMs = now - 10 * HOUR;
 		const current = computeHotScore(3, createdAtMs, now);
-		// Stored value already equals the recompute at `now` → steady state → no update.
 		expect(decayHotScores([{id: "p1", score: 3, hotScore: current, createdAtMs}], now)).toEqual([]);
 	});
 
@@ -52,17 +41,13 @@ describe("decayHotScores", () => {
 	});
 
 	it("reproduces the bug: after a decay pass, a fresh post outranks a stale squatter", () => {
-		// The reported scenario: an old post that earned some votes while young keeps a
-		// "young, high" frozen score and squats above a genuinely fresh post. Once the
-		// refresh re-decays the stale post's stored score at `now`, the fresh post wins.
 		const now = Date.UTC(2026, 0, 20, 0, 0, 0);
 		const staleCreated = now - 16 * 24 * HOUR;
-		// The squatter's FROZEN score: 5 points computed when it was ~1h old (never re-decayed).
+		// Frozen at ~1h old and never re-decayed — that is the bug being reproduced.
 		const staleFrozen = computeHotScore(5, staleCreated, staleCreated + 1 * HOUR);
 		const freshCreated = now - 10 * 60_000; // 10 minutes old
 		const freshScore = computeHotScore(1, freshCreated, now);
 
-		// Before the pass, the frozen squatter outranks the fresher post (the bug).
 		expect(staleFrozen).toBeGreaterThan(freshScore);
 
 		const updates = decayHotScores(
@@ -74,7 +59,6 @@ describe("decayHotScores", () => {
 		);
 		const decayedStale = updates.find((u) => u.id === "stale")?.hotScore;
 		expect(decayedStale).toBeDefined();
-		// After re-decay the stale post drops below the fresher post → ordering fixed.
 		expect(decayedStale ?? 0).toBeLessThan(freshScore);
 	});
 });

--- a/apps/web/worker/db/karma-event.ts
+++ b/apps/web/worker/db/karma-event.ts
@@ -1,15 +1,11 @@
 /**
- * The karma-event **reason** — the closed set of events that move a user's
- * `total_karma`, recorded on every `karma_event` row so an earned balance is
- * reconstructable (issue #2592). Today Vote is the only karma writer, so the set
- * is a cast (`vote`) or its reversal (`retract`); a new karma source adds a member.
+ * The closed set of events that move a user's `total_karma`, recorded on every
+ * `karma_event` row so an earned balance is reconstructable (#2592). A new karma
+ * source adds a member.
  *
- * Lives in `db/` — below both the `vote/` and `pasaport/` feature directories,
- * like {@link ./target-kind.ts} — because `schema.ts` sources the `karma_event.reason`
- * D1 enum from this tuple while `vote/Vote.ts` (the `KarmaBump` contract owner) types
- * its input against the same set. `schema.ts` can't import that vocabulary from
- * `vote/Vote.ts` (Vote imports `schema.ts`, so that edge is a cycle), so the one set
- * both need lives here, imported by both with no cycle.
+ * It lives in `db/`, below the feature directories, because both `schema.ts` and
+ * `vote/Vote.ts` need it and `schema.ts` cannot import from `vote/Vote.ts` — Vote
+ * already imports `schema.ts`, so that edge would be a cycle.
  */
 export const KARMA_EVENT_REASONS = ["vote", "retract"] as const;
 

--- a/apps/web/worker/db/keyset.ts
+++ b/apps/web/worker/db/keyset.ts
@@ -1,22 +1,12 @@
-/**
- * Shared keyset-pagination primitives (ADR 0019). Five service methods page
- * forward over a DB keyset; each used to hand-roll the lexicographic
- * "rows strictly after the cursor" predicate and the `LIMIT first+1` page
- * envelope. The mixed-direction copies (`(score desc, createdAt asc, id asc)`)
- * silently break on a field change, so the predicate is single-sourced here and
- * unit-tested.
- */
+/** Shared keyset-pagination primitives. See ADR 0019. */
 
 import {and, eq, gt, lt, or, type SQL, type SQLWrapper} from "drizzle-orm";
 
 export type KeysetDir = "asc" | "desc";
 
 /**
- * One column of a keyset tuple. A `null` `value` drops the column from the
- * comparison entirely (no inequality arm, no equality term in later arms) —
- * reproducing the term-summary `recent` fallback where a null `lastActivityAt`
- * cursor degrades to the tiebreaker-only predicate. The value type is loose
- * because keyset columns span dates, numbers, and strings.
+ * One column of a keyset tuple. A `null` `value` drops the column from the comparison
+ * entirely — no inequality arm, and no equality term in the later arms either.
  */
 export interface KeysetKey {
 	readonly column: SQLWrapper;
@@ -25,15 +15,8 @@ export interface KeysetKey {
 }
 
 /**
- * Build the lexicographic "strictly after the cursor" predicate for a keyset
- * tuple ordered by `keys`. For columns `(c1 dir1, …, cn dirn)` with cursor
- * values `(v1, …, vn)` the predicate is
- *
- *   OR_i ( c1 = v1 AND … AND c_{i-1} = v_{i-1} AND cmp_i(c_i, v_i) )
- *
- * where `cmp` is `<` for `desc` and `>` for `asc`. Columns whose cursor `value`
- * is `null` are skipped. Returns `undefined` when no cursor column is usable (no
- * keys, or every value null), so callers apply only their base `WHERE`.
+ * The lexicographic "strictly after the cursor" predicate. Returns `undefined` when no
+ * cursor column is usable, so the caller applies only its base `WHERE`.
  */
 export function keysetAfter(keys: ReadonlyArray<KeysetKey>): SQL | undefined {
 	const usable = keys.filter((k) => k.value !== null && k.value !== undefined);
@@ -52,33 +35,13 @@ export function keysetAfter(keys: ReadonlyArray<KeysetKey>): SQL | undefined {
 	return or(...arms) as SQL;
 }
 
-/**
- * The cursor-resolution decision, lifted above the DB read so it is pure and
- * unit-testable with no SQL engine (ADR 0082: cursor resolution is a *port*, the
- * keyset/cursor-miss decision is pure). A keyset page first resolves an opaque
- * `after` cursor to the row's keyset tuple via a thin DB-read port; this type is
- * the *outcome* of that resolution, and `resolveCursor` is the pure decision over
- * `(after, resolved-row-or-null)`:
- *
- *   - no cursor — `after` was absent: page from the head, no predicate.
- *   - miss      — `after` was present but resolved to no row: the shared
- *                 cursor-miss-empty-page semantic (the cursor no longer points at
- *                 a live row / matching doc).
- *   - hit       — `after` resolved to `row`: page strictly after it.
- */
+/** The cursor-resolution outcome, lifted above the DB read so it stays pure (ADR 0082). */
 export type CursorResolution<TRow> =
 	| {readonly kind: "no-cursor"}
 	| {readonly kind: "miss"}
 	| {readonly kind: "hit"; readonly row: TRow};
 
-/**
- * The pure cursor-miss decision. Given the requested `after` and the row the port
- * read for it (`null`/`undefined` when the port found none), decide the branch:
- * absent `after` → `no-cursor` (head page); present `after` + no row → `miss`
- * (caller returns the empty page); present `after` + row → `hit` (caller builds
- * the keyset predicate). The DB read that produces `resolvedRow` stays below the
- * seam as the port; this is the decision, callable with no database.
- */
+/** A present `after` that resolves to no row is a `miss`, not a head page. */
 export function resolveCursor<TRow>(
 	after: string | null | undefined,
 	resolvedRow: TRow | null | undefined,
@@ -88,7 +51,6 @@ export function resolveCursor<TRow>(
 	return {kind: "hit", row: resolvedRow};
 }
 
-/** The page returned on a cursor miss — pure, so the miss branch carries no DB read. */
 export interface EmptyKeysetPage {
 	readonly rows: never[];
 	readonly hasNextPage: false;
@@ -102,11 +64,8 @@ export const emptyKeysetPage: EmptyKeysetPage = {
 };
 
 /**
- * The single assembly point for the `{rows, hasNextPage, endCursor}` forward
- * keyset page envelope — shared by all five keyset methods (each adds its own
- * `totalCount`) and by the `toConnection` adapter, which imports this same
- * declaration (`features/fate/connection.ts`) so producer and adapter agree by a
- * shared type, not by structural coincidence.
+ * The forward page envelope. `features/fate/connection.ts` imports this same
+ * declaration, so producer and adapter agree by type, not structural coincidence.
  */
 export interface KeysetPage<TRow> {
 	readonly rows: TRow[];
@@ -115,13 +74,10 @@ export interface KeysetPage<TRow> {
 }
 
 /**
- * Slice a `LIMIT first + 1` probe into a forward page; `first` is clamped to at
- * least 1 defensively.
+ * Slice a `LIMIT first + 1` probe into a forward page. Two overloads: without `mapRow`
+ * the fetched row IS the page row, so `TRow` collapses to `TFetched` and the identity
+ * default stays well-typed with no cast.
  */
-// Identity-default overload: when no `mapRow` is given the fetched row IS the
-// page row, so `TRow` collapses to `TFetched` and the default identity is
-// well-typed (no cast). The two-type-param overload is for callers that map
-// `TFetched → TRow` and always pass `mapRow` explicitly.
 export function forwardPage<TRow>(
 	fetched: ReadonlyArray<TRow>,
 	first: number,

--- a/apps/web/worker/db/keyset.unit.test.ts
+++ b/apps/web/worker/db/keyset.unit.test.ts
@@ -99,8 +99,7 @@ describe("resolveCursor", () => {
 	});
 
 	it("a resolved row whose keyset values are null is still a hit, not a miss", () => {
-		// the port found the row; a null lead value degrades the predicate (keysetAfter
-		// drops it), it does NOT collapse to the cursor-miss branch.
+		// A null lead value degrades the predicate; it does NOT collapse to a miss.
 		const row = {createdAt: null};
 		expect(resolveCursor("c1", row)).toEqual({kind: "hit", row});
 	});

--- a/apps/web/worker/db/ordering.ts
+++ b/apps/web/worker/db/ordering.ts
@@ -1,13 +1,8 @@
 /**
- * Per-connection ordering as ONE declaration (ADR 0019). A connection's sort is
- * a nominal fate-view `orderBy` (drives cursor round-tripping) AND a Drizzle
- * keyset (`.orderBy(…)` + the `keysetAfter` lead-column tuple); the two used to
- * be copied per connection and kept in lockstep only by a docblock, where a
- * missed edit skips/dupes cursor rows silently. An `Ordering` names each column
- * once — its view-field name, its Drizzle column, and its direction — so the
- * view `orderBy` and the service keyset both DERIVE from it and can no longer
- * disagree. Mirrors `src/lib/panoFeedSort.ts`, which single-sources pano's
- * (per-sort) feed ordering the same way.
+ * Per-connection ordering as ONE declaration (ADR 0019). A connection's sort is both a
+ * fate-view `orderBy` and a Drizzle keyset; copied separately they drift, and a missed
+ * edit skips or dupes cursor rows silently. An `Ordering` names each column once so both
+ * DERIVE from it.
  */
 
 import type {DataViewOrderBy} from "@nkzw/fate/server";
@@ -15,10 +10,8 @@ import {asc, desc, type SQL, type SQLWrapper} from "drizzle-orm";
 import type {KeysetDir, KeysetKey} from "./keyset.ts";
 
 /**
- * One ordering column. `field` is the fate-view field name (what the view
- * `orderBy` keys on); `column` is the Drizzle column the service orders by and
- * keysets on; `dir` is shared by both. Pairing the two names in one place is the
- * whole point — the view field and the DB column can no longer drift apart.
+ * `field` is the fate-view field name; `column` is the Drizzle column the service orders
+ * by and keysets on; `dir` is shared by both.
  */
 export interface OrderingColumn {
 	readonly field: string;
@@ -26,26 +19,18 @@ export interface OrderingColumn {
 	readonly dir: KeysetDir;
 }
 
-/** A connection's ordering tuple — the columns in lexicographic precedence. */
+/** The columns in lexicographic precedence. */
 export type Ordering = ReadonlyArray<OrderingColumn>;
 
-/** The fate-view `orderBy` for this ordering — `[{field: dir}, …]` (nominal). */
 export function viewOrderBy(ordering: Ordering): DataViewOrderBy {
 	return ordering.map((c) => ({[c.field]: c.dir}));
 }
 
-/** The Drizzle `.orderBy(…)` columns for this ordering — `desc(col)` / `asc(col)`. */
 export function orderByColumns(ordering: Ordering): SQL[] {
 	return ordering.map((c) => (c.dir === "desc" ? desc(c.column) : asc(c.column)));
 }
 
-/**
- * The `keysetAfter` lead-column tuple for this ordering, given a `cursorValue`
- * that reads each column's cursor value off the resolved cursor row (by
- * `field`). Column, direction, and precedence come from the SAME `Ordering` the
- * view `orderBy` and `.orderBy(…)` use, so the keyset predicate can't disagree
- * with the sort it pages.
- */
+/** `cursorValue` reads each column's cursor value off the resolved cursor row, by `field`. */
 export function keysetKeys(
 	ordering: Ordering,
 	cursorValue: (field: string) => unknown,

--- a/apps/web/worker/db/reaction-emoji.ts
+++ b/apps/web/worker/db/reaction-emoji.ts
@@ -1,23 +1,13 @@
 /**
- * The curated reaction **palette** — the closed, ordered set of emoji a user may
- * react with. The reaction system is the third instance of the polymorphic
- * per-user-presence pattern (after `user_vote` / `post_bookmark`), and unlike a
- * free emoji picker its palette is a *curated fixed set*: one template shared
- * across pano + sözlük, seeded from the palette decision (sibling ADR, #1859).
- *
- * `REACTION_EMOJI` is the one runtime tuple the reaction table's `emoji` value
- * column and every react/display path source from — the `TARGET_KINDS` idiom
- * (`db/target-kind.ts`), so code and UI never drift from the decision. An
- * arbitrary emoji is structurally unrepresentable at the wire boundary:
- * `ReactionEmojiSchema` decodes only a palette member, so a non-palette string
- * fails to decode.
+ * The curated reaction palette — a closed fixed set, not a free emoji picker. This
+ * tuple is the one source the reaction table's `emoji` column and every react/display
+ * path read from (the `TARGET_KINDS` idiom), so an arbitrary emoji is structurally
+ * unrepresentable at the wire boundary.
  */
 import * as Schema from "effect/Schema";
 
-/** The curated closed palette, ordered — the one runtime tuple the wire schema and D1 value source from. */
 export const REACTION_EMOJI = ["👍", "❤️", "😂", "🤔", "😢", "🔥"] as const;
 
 export type ReactionEmoji = (typeof REACTION_EMOJI)[number];
 
-/** The one wire/decode schema for a reaction emoji — a non-palette string fails to decode. */
 export const ReactionEmojiSchema = Schema.Literals(REACTION_EMOJI);

--- a/apps/web/worker/db/resources.ts
+++ b/apps/web/worker/db/resources.ts
@@ -1,27 +1,18 @@
 /**
- * Resource declarations shared between the alchemy stack (`alchemy.run.ts`) and
- * the worker (`worker/index.ts`): the stack ensures the resource exists before
- * deploy, the worker `bind()`s it at runtime. Replaces the `wrangler.jsonc`
- * `d1_databases` / `migrations_dir` keys (ADR 0026).
- *
- * Owns only the D1 store. The Flagship flag-IaC surface lives beside its
- * evaluator in `features/flagship/resources.ts`.
+ * Resource declarations shared between the alchemy stack and the worker: the stack
+ * ensures the resource exists before deploy, the worker `bind()`s it at runtime
+ * (ADR 0026). Owns only the D1 store; Flagship's IaC lives with its evaluator.
  */
 import * as Cloudflare from "alchemy/Cloudflare";
 import {devDatabaseName} from "../env.ts";
 
 /**
- * The single D1 database — canonical store for every product table (ADR 0009,
- * d1-direct). `migrationsTable: "drizzle_migrations"` matches drizzle-kit's own
- * table name so the applied-set bookkeeping stays compatible; alchemy applies
- * pending migrations on deploy.
+ * The single D1 database (ADR 0009). `migrationsTable` must match drizzle-kit's own
+ * table name so the applied-set bookkeeping stays compatible.
  *
- * `name` is set to a stable, stage-derived value **only on the local-state dev
- * path** (`devDatabaseName`, #2361): a fresh state store (new worktree / deleted
- * `.alchemy/`) then re-adopts the same dev D1 instead of minting a cloud orphan.
- * It stays `undefined` on every hosted-state path so production's auto-generated
- * physical name is unchanged and alchemy's D1 diff produces no replace — the why
- * (and the replace hazard) lives at `devDatabaseName`'s docblock.
+ * `name` is stage-derived only on the local-state dev path, so a fresh state store
+ * re-adopts the same dev D1 instead of minting a cloud orphan. It stays `undefined` on
+ * hosted state — see `devDatabaseName`'s docblock for the replace hazard.
  */
 const devName = devDatabaseName(process.env);
 

--- a/apps/web/worker/db/target-kind.ts
+++ b/apps/web/worker/db/target-kind.ts
@@ -1,44 +1,28 @@
 /**
- * The vote/report **target kind** — the closed set of entities a vote or a
- * report can target (`definition` | `post` | `comment`). One typed source for a
- * taxonomy that spans the vote engine, the report engine, and two D1 columns.
- *
- * Lives in `db/` — below both feature directories — because the `vote/`↔`report/`
- * boundary pins forbid a sibling-feature edge, yet both features and the schema
- * share this one set. `TARGET_KINDS` is the one runtime tuple the
- * `user_vote.target_kind` / `content_report.target_kind` D1 enums source from
- * (so a column can't drift from the union), exactly as `REPORT_STATUSES` /
- * `RESOLUTIONS` anchor `content_report.status` / `.resolution`. A typo
- * (`"defintion"`) can no longer compile and write a corrupt PK.
+ * The closed set of entities a vote or a report can target. It lives in `db/` — below
+ * both feature directories — because the boundary pins forbid a `vote/`↔`report/` edge
+ * while both features and the schema share this one set.
  */
 import * as Schema from "effect/Schema";
 
-/** The closed target set, as the one runtime tuple the D1 enums source from. */
+/** The one runtime tuple the `*.target_kind` D1 enums source from, so no column can drift. */
 export const TARGET_KINDS = ["definition", "post", "comment"] as const;
 
 export type TargetKind = (typeof TARGET_KINDS)[number];
 
-/** The one wire/decode schema for `targetKind` — sourced from {@link TARGET_KINDS}. */
 export const TargetKindSchema = Schema.Literals(TARGET_KINDS);
 
 /**
- * The `<kind>:<id>` composite target key — the load-bearing join key across the
- * vote/report/divan surfaces (a fate view `id`, a merge-map key, a fabricated
- * fallback report id). One codec so every site encodes and decodes the same
- * spelling: a change to the format propagates instead of drifting per feature.
- *
- * `id` may itself contain `:` (a domain row id is opaque), so decode splits on the
- * FIRST separator only — `parseTargetKey(targetKey(k, id)) === {kind: k, id}` for
- * every `TargetKind` and every non-empty `id`.
+ * The `<kind>:<id>` join key used across the vote/report/divan surfaces. One codec, so a
+ * format change propagates instead of drifting per feature. `id` may itself contain `:`,
+ * so {@link parseTargetKey} splits on the FIRST separator only.
  */
 export const targetKey = (kind: TargetKind, id: string): string => `${kind}:${id}`;
 
 /**
- * Split a `<kind>:<id>` key back into its target, or `null` if malformed (no
- * separator, empty kind, or empty id) or the kind is not a {@link TargetKind}. The
- * inverse of {@link targetKey} for a well-formed key. A `null` is an unresolvable
- * target — e.g. the divan collapses it to the invisible `Denied`, keeping a
- * hand-crafted request opaque.
+ * The inverse of {@link targetKey}; `null` on a malformed key or unknown kind. Callers
+ * must treat `null` as unresolvable — the divan collapses it to the invisible `Denied`,
+ * keeping a hand-crafted request opaque.
  */
 export const parseTargetKey = (key: string): {kind: TargetKind; id: string} | null => {
 	const sep = key.indexOf(":");

--- a/apps/web/worker/db/target-kind.unit.test.ts
+++ b/apps/web/worker/db/target-kind.unit.test.ts
@@ -1,10 +1,7 @@
 /**
- * The shared `<kind>:<id>` target-key codec (#2018) — the one encode/decode pair the
- * vote/report/divan surfaces route through. The decisions asserted here: encode is the
- * literal `kind:id` spelling every view id carries; decode is its inverse for a
- * well-formed key, round-tripping every `TargetKind`; and decode rejects the malformed
- * and unknown-kind keys the divan collapses to the invisible `Denied`. Behavior-preserving
- * — these are the same round-trip / rejection semantics the per-feature spellings had.
+ * The shared `<kind>:<id>` target-key codec — the one encode/decode pair the
+ * vote/report/divan surfaces route through. Its rejections are what the divan collapses
+ * to the invisible `Denied`.
  */
 import {assert, describe, it} from "@effect/vitest";
 import {parseTargetKey, TARGET_KINDS, targetKey} from "./target-kind.ts";

--- a/apps/web/worker/db/target-table.ts
+++ b/apps/web/worker/db/target-table.ts
@@ -1,17 +1,11 @@
 /**
- * The per-{@link TargetKind} **target-table descriptor** — the one structure the
- * vote/report engines dispatch through, so the `definition | post | comment`
- * fan-out lives once here instead of as a hand-written `switch (kind)` re-stated
- * at every call site. Each descriptor closes over the kind's own typed drizzle
- * tables/columns, so its bodies stay type-correct while the call sites collapse
- * to `targetTable[kind].<op>(…)`. (Issue #1125 — locality.)
+ * The per-{@link TargetKind} target-table descriptor the vote/report engines dispatch
+ * through, so the `definition | post | comment` fan-out lives once here instead of a
+ * hand-written `switch (kind)` at every call site (#1125).
  *
- * Sits in `db/` beside {@link ./target-kind.ts} — below both feature directories —
- * because the `vote/`↔`report/` boundary pins forbid a sibling-feature edge yet
- * Vote and Report (and the schema) all key off this one taxonomy. The descriptor
- * names only db primitives (`DrizzleDb`, drizzle tables, `Stmt`); it knows
- * nothing of the feature services, so a `report/mutations.ts` *service* fan-out
- * (Sözlük/Pano) is a different seam and stays out of here.
+ * Sits in `db/` because the `vote/`↔`report/` boundary pins forbid a sibling-feature edge yet
+ * Vote, Report and the schema all key off this one taxonomy. It names only db primitives, so
+ * a service-level fan-out is a different seam and stays out of here.
  */
 import {and, eq, exists, notExists, type SQL, sql} from "drizzle-orm";
 import type {DrizzleDb, Stmt} from "./Drizzle.ts";
@@ -19,43 +13,26 @@ import * as schema from "./drizzle/schema.ts";
 import {hotMultiplier} from "./hotScore.ts";
 import type {TargetKind} from "./target-kind.ts";
 
-/** The author + creation instant a vote needs before its write (karma recipient + hot-score age). */
 export interface TargetRecordMeta {
 	authorId: string;
 	createdAtMs: number;
 	/**
-	 * Is the target a still-sandboxed (`sandboxed_at IS NOT NULL`) çaylak item? The
-	 * eligibility split `Vote.cast` reads: the ordinary cast rejects a sandboxed target
-	 * ({@link ./../features/vote/errors.ts VoteTargetSandboxed}); only the divan-gated
-	 * `castOnSandboxed` accepts one (#1288). Live content reads `false`.
+	 * Is the target a still-sandboxed çaylak item? The eligibility split `Vote.cast` reads: an
+	 * ordinary cast rejects a sandboxed target; only the divan-gated `castOnSandboxed` accepts
+	 * one (#1288).
 	 */
 	sandboxed: boolean;
 }
 
-/**
- * One kind's vote/report table operations. Every method takes the live `db` plus
- * the row keys it needs and returns either an awaited query (`probeVote`,
- * `readScore`, `loadMeta`) or an unexecuted `Stmt` for the atomic batch
- * (`voteInsert`/`voteDelete`/`clearVotes`/`scoreCache`). Behaviour is identical to
- * the switch arms it replaces — same tables, same columns, same SQL.
- */
 export interface TargetTableDescriptor {
-	/**
-	 * Live-record lookup (`removed_at IS NULL`) returning the karma recipient + age,
-	 * or `null` when the target is missing or soft-removed. Backs Vote.loadMeta and
-	 * Report.assertTargetLive.
-	 */
 	readonly loadMeta: (db: DrizzleDb, targetId: string) => Promise<TargetRecordMeta | null>;
-	/** Vote-presence point lookup on `(targetId, voterId)` — the idempotency probe. */
 	readonly probeVote: (db: DrizzleDb, targetId: string, voterId: string) => Promise<boolean>;
 	/**
-	 * The karma-change guard: an `SQL` predicate true iff the vote write will
-	 * actually change the row's presence — `NOT EXISTS(vote row)` on a cast,
-	 * `EXISTS(vote row)` on a retract. Threaded into the karma bump + ledger
-	 * statements and ordered ahead of the vote-row write, so it reads PRE-mutation
-	 * state: a duplicate concurrent cast finds the row already present (cast) or
-	 * already gone (retract) and applies the karma delta zero times (#2552). This
-	 * is the in-batch backstop the out-of-batch `probeVote` fast-path can race past.
+	 * An `SQL` predicate true iff the vote write will actually change the row's presence.
+	 * Threaded into the karma bump + ledger statements and ordered ahead of the vote-row
+	 * write, so it reads PRE-mutation state: a duplicate concurrent cast finds the row already
+	 * present (or already gone on a retract) and applies the karma delta zero times (#2552).
+	 * The in-batch backstop the out-of-batch `probeVote` fast-path can race past.
 	 */
 	readonly voteChangeGuard: (
 		db: DrizzleDb,
@@ -63,19 +40,10 @@ export interface TargetTableDescriptor {
 		voterId: string,
 		isCast: boolean,
 	) => SQL;
-	/** The truth-derived score cached on the record row (0 when the row is gone). */
 	readonly readScore: (db: DrizzleDb, targetId: string) => Promise<number>;
-	/** Insert the per-target vote row (idempotent on the PK). */
 	readonly voteInsert: (db: DrizzleDb, targetId: string, voterId: string, now: Date) => Stmt;
-	/** Delete the per-target vote row for `(targetId, voterId)`. */
 	readonly voteDelete: (db: DrizzleDb, targetId: string, voterId: string) => Stmt;
-	/** Delete every per-target vote row for the target (the removal-substrate wipe). */
 	readonly clearVotes: (db: DrizzleDb, targetId: string) => Stmt;
-	/**
-	 * Refresh the record's cached `score` (and, for posts, `hot_score`) from a
-	 * `COUNT(*)` over the truth-source vote table, inside the same batch as the
-	 * vote write.
-	 */
 	readonly scoreCache: (db: DrizzleDb, targetId: string, now: Date, meta: TargetRecordMeta) => Stmt;
 }
 
@@ -89,11 +57,6 @@ const metaOf = (row: {
 	sandboxed: row.sandboxedAt != null,
 });
 
-/**
- * The taxonomy's behaviour, keyed once. Each entry closes over its kind's typed
- * tables; the shared method shape is what lets the generic call sites in
- * Vote/Report dispatch against any `TargetKind`.
- */
 export const targetTable: {readonly [K in TargetKind]: TargetTableDescriptor} = {
 	definition: {
 		loadMeta: (db, targetId) =>

--- a/apps/web/worker/db/target-table.unit.test.ts
+++ b/apps/web/worker/db/target-table.unit.test.ts
@@ -1,18 +1,9 @@
 /**
- * The shared `scoreCache` seam must NOT touch `updated_at` (#1634).
- *
- * `updated_at` is the content-last-edited instant the "düzenlendi" badge reads
- * (`editedAfter`, `definition-fields.ts`). A vote's score refresh is a
- * derived-aggregate write, not a content edit — so bumping `updated_at` on a
- * vote made the badge lie and persistently corrupted the row's true last-edit
- * time. This guards all three target kinds at the one shared seam: the rendered
- * `scoreCache` UPDATE writes `score` (and, for posts, `hot_score` /
- * `last_activity_at`) but never `updated_at`.
- *
- * Rendered with `.toSQL()` against a no-op D1 (the `persist-term-summary` /
- * `VouchLedger` idiom — no engine, ADR 0082/0104/0105): the statement's column
- * SET is inspected, never executed. Row-level behavior on real D1 stays the
- * integration tier's job (`tests/integration/sozluk-mutations.test.ts`).
+ * The shared `scoreCache` seam must NOT touch `updated_at` (#1634). That column is the
+ * content-last-edited instant the "düzenlendi" badge reads; a vote's score refresh is a
+ * derived-aggregate write, not a content edit, so bumping it made the badge lie and
+ * persistently corrupted the row's true last-edit time. Rendered with `.toSQL()` against a
+ * no-op D1 — the column SET is inspected, never executed.
  */
 
 import {drizzle} from "drizzle-orm/d1";

--- a/apps/web/worker/effect-runtime-exports.unit.test.ts
+++ b/apps/web/worker/effect-runtime-exports.unit.test.ts
@@ -1,13 +1,8 @@
 /**
- * Runtime-existence guard for the effect value symbols the backend calls (#1672).
- *
- * The forcing fact: effect is pinned to a fast-moving 4.x beta (`effect@4.0.0-beta.92`,
- * `catalog:` in `pnpm-workspace.yaml`) whose surface churns bump-to-bump — the repo has
- * already ridden several coordinated pins (#1578 / #1582 / #1588). A bump that *drops or
- * renames* a value combinator the backend depends on is the live risk this guard covers:
- * it imports every effect submodule the backend uses and asserts each value symbol it
- * calls is still present at runtime, so such a regression fails the `unit` CI gate here
- * (with the exact missing name) instead of throwing `"X is not a function"` in production.
+ * Runtime-existence guard for the effect value symbols the backend calls (#1672). effect is
+ * pinned to a fast-moving 4.x beta whose surface churns bump-to-bump; a bump that drops or
+ * renames a value combinator the backend depends on fails the `unit` gate here, with the
+ * exact missing name, instead of throwing "X is not a function" in production.
  *
  * On the reported "type↔runtime export skew" (#1672 was filed as an investigation): it does
  * NOT reproduce under the pinned beta.92 + the repo's real typecheck gate. The report's
@@ -22,16 +17,11 @@
  * typecheck can't see — a future beta shipping a `.d.ts` that declares a value symbol its
  * `.js` omits (a mismatched-artifact bump) — not a fix for a live skew (there is none).
  *
- * Scope note: only *runtime-value* symbols are listed. Type-level references the backend
- * writes in annotations (`Effect.Effect<…>`, `Layer.Layer<…>`, `Schema.Schema<…>`,
- * `Match.ts`, …) live solely in `.d.ts` and are correctly `undefined` at runtime — they are
- * excluded, since asserting their runtime presence would false-fail.
+ * Scope note: only *runtime-value* symbols are listed. Type-level references live solely in
+ * `.d.ts` and are correctly `undefined` at runtime, so asserting them would false-fail.
  *
- * Maintenance: the manifest is the backend's effect value surface at authoring time. When a
- * backend module reaches for a new effect combinator, add it to the matching module's list
- * so the bump guard covers it. Regenerate the candidate set by grepping `worker/` for
- * `<Namespace>.<member>` accesses of the imported effect namespaces and keeping those whose
- * `typeof !== "undefined"` under the pinned effect.
+ * Maintenance: when a backend module reaches for a new effect combinator, add it to the
+ * matching module's list so the bump guard covers it.
  */
 import * as Cause from "effect/Cause";
 import * as Config from "effect/Config";
@@ -56,9 +46,8 @@ import * as Stream from "effect/Stream";
 import {describe, expect, it} from "vitest";
 
 // Each entry: [module namespace object, its import specifier, the value symbols the backend
-// calls from it]. `namespace` is asserted `!== "undefined"` — the precise negative of the
-// reported failure mode ("symbol is `undefined` at runtime"), and correct for both function
-// and non-function value exports.
+// calls from it]. Asserted `!== "undefined"`, which is correct for both function and
+// non-function value exports.
 const BACKEND_EFFECT_SURFACE: ReadonlyArray<{
 	readonly module: string;
 	readonly namespace: object;

--- a/apps/web/worker/env.ts
+++ b/apps/web/worker/env.ts
@@ -10,10 +10,8 @@ import * as Schema from "effect/Schema";
 import {isProductionDeploy} from "./environment.ts";
 
 /**
- * The two fields of alchemy's `ALCHEMY_EXEC_OPTIONS` blob we read: `dev` (the
- * offline signal) and `stage` (the deploy target, used to derive the dev D1's
- * stable name). The blob is an untyped trust boundary (a CLI-set env-var JSON
- * string), so it's decoded at the boundary rather than asserted with a cast.
+ * The blob is an untyped trust boundary (a CLI-set env-var JSON string), so it is
+ * decoded here rather than asserted with a cast.
  *
  * @see node_modules/alchemy/lib/Cli/commands/deploy.js — `ExecStackOptions`
  */
@@ -25,52 +23,39 @@ const ExecOptions = Schema.Struct({
 // parse failure into a `None` — so a malformed blob needs no raw `try/catch`.
 const decodeExecOptions = Schema.decodeUnknownOption(Schema.fromJsonString(ExecOptions));
 
-/** The subset of the deploy-time process env the selector reads. */
 export interface DeployEnvInput {
 	readonly ENVIRONMENT?: string | undefined;
 	readonly CI?: string | undefined;
 	/**
-	 * The alchemy `dev` flag, set only by `alchemy dev` (the offline workerd loop)
-	 * in its exec subprocess; `deploy`/`plan`/`destroy` run inline and never set
-	 * it. So a parsed `dev: true` is the genuine dev signal, readable synchronously
-	 * at module-eval before any `AlchemyContext` is in scope.
+	 * Set only by `alchemy dev` in its exec subprocess; `deploy`/`plan`/`destroy` run
+	 * inline and never set it. So a parsed `dev: true` is the genuine dev signal.
 	 *
 	 * @see node_modules/alchemy/lib/Cli/commands/dev.js — sets `ALCHEMY_EXEC_OPTIONS`
 	 */
 	readonly ALCHEMY_EXEC_OPTIONS?: string | undefined;
 	/**
-	 * A coarser dev override (`"1"`/`"true"`) alchemy's test harness honors; treated
-	 * as a dev signal here for parity.
+	 * A coarser dev override alchemy's test harness honors; treated as a dev signal for parity.
 	 *
 	 * @see node_modules/alchemy/lib/Test/Core.js — `resolveDev`
 	 */
 	readonly ALCHEMY_DEV?: string | undefined;
 }
 
-/** Which alchemy state store the stack should use. */
 export type StateMode = "local" | "cloudflare";
 
 /**
- * Is this an offline alchemy path (`alchemy dev`) where file-based `localState()`
- * is required?
- *
- * Keyed off the genuine dev signal alone, NOT `CI` and NOT `VITEST`. `CI` is set
- * for both the deploy workflow and the integration-test job, so it can't tell a
- * real deploy from a test run. `VITEST` is no longer an offline signal either:
- * since ADR 0082 the integration suite deploys to **real remote Cloudflare** via
- * `Test.make` (real D1, real state), so a Vitest run must resolve to the shared
- * Cloudflare store, exactly like a real deploy. Only `alchemy dev` — its `dev`
- * flag in `ALCHEMY_EXEC_OPTIONS` (`deploy` runs inline and never sets it), or the
- * coarser `ALCHEMY_DEV` override `Test.make` honors — is the offline path.
+ * Keyed off the genuine dev signal alone, NOT `CI` and NOT `VITEST`. `CI` is set for both
+ * the deploy workflow and the integration-test job, so it cannot tell a real deploy from a
+ * test run; and since ADR 0082 the integration suite deploys to real remote Cloudflare, so
+ * a Vitest run must resolve to the shared store exactly like a deploy.
  */
 const isOfflinePath = (env: DeployEnvInput): boolean => {
 	const devOverride = env.ALCHEMY_DEV?.toLowerCase();
 	if (devOverride === "1" || devOverride === "true") return true;
 
 	if (env.ALCHEMY_EXEC_OPTIONS) {
-		// A malformed blob decodes to `None`, so it's not a dev signal — fall through
-		// to deploy (shared store). Failing safe toward the shared store keeps
-		// collab/diff intact.
+		// A malformed blob decodes to `None`, so it is not a dev signal — fall through to
+		// deploy. Failing safe toward the shared store keeps collab/diff intact.
 		const parsed = decodeExecOptions(env.ALCHEMY_EXEC_OPTIONS);
 		if (Option.isSome(parsed) && parsed.value.dev === true) return true;
 	}
@@ -78,26 +63,15 @@ const isOfflinePath = (env: DeployEnvInput): boolean => {
 	return false;
 };
 
-/**
- * Resolve which state store the alchemy stack should use.
- *
- * Pure over an injected snapshot so the selector is unit-testable without
- * mutating the real `process.env`.
- */
+// Pure over an injected snapshot so the selector is unit-testable without mutating the
+// real `process.env`.
 export const resolveStateMode = (env: DeployEnvInput): StateMode =>
 	isOfflinePath(env) ? "local" : "cloudflare";
 
 /**
- * The stage the local-state dev path is deploying to, read from the same
- * `ALCHEMY_EXEC_OPTIONS` blob the offline signal comes from (`alchemy dev`
- * always encodes its resolved `stage`, defaulting to `dev_${USER}`).
- *
- * `undefined` off the local dev path, and also `undefined` on a local path with
- * no decodable stage (the coarse `ALCHEMY_DEV`-only harness, or a malformed
- * blob) — a missing stage must NOT pin a name, since a stage-less name would
- * collide across personal stages (stage is the isolation unit, ADR 0057). No
- * stage ⇒ fall back to alchemy's auto-generated per-instance name (today's
- * behavior).
+ * A missing stage must NOT pin a name: a stage-less name would collide across personal
+ * stages (stage is the isolation unit, ADR 0057). No stage ⇒ fall back to alchemy's
+ * auto-generated per-instance name.
  */
 export const resolveDevStage = (env: DeployEnvInput): string | undefined => {
 	if (!isOfflinePath(env) || !env.ALCHEMY_EXEC_OPTIONS) return undefined;
@@ -110,25 +84,15 @@ export const resolveDevStage = (env: DeployEnvInput): string | undefined => {
 };
 
 /**
- * The explicit D1 physical name for the **local-state dev path only** — a
- * stable, stage-derived name so a fresh state store (a new worktree, a deleted
- * `.alchemy/`, a new machine) re-adopts the same dev D1 instead of minting a new
- * cloud orphan (#2361; adoption path grounded in `alchemy@2.0.0-beta.59`
- * `Cloudflare/D1/Database.js` `read` — `name ?? createPhysicalName({id})`).
+ * A stable, stage-derived D1 name for the **local-state dev path only**, so a fresh state
+ * store re-adopts the same dev D1 instead of minting a cloud orphan (#2361).
  *
- * `undefined` on every hosted-state path (production, a real `alchemy deploy`,
- * the `Test.make` integration harness). This is the load-bearing safety
- * constraint: an existing tracked D1's `diff` returns `{action:"replace"}` when
- * the desired name differs from the persisted one, so an *unconditional* name
- * would replace the production D1 with an empty database. Because production's
- * `news.name` stays `undefined`, its diff still resolves the name from the
- * persisted `output.databaseName` — byte-identical, no replace (verified in the
- * pinned alchemy `DatabaseProvider.diff`).
- *
- * Mirrors alchemy's own `${stack}-${id}-${stage}` physical-name prefix
- * (`createPhysicalName`) minus the random per-instance suffix, sanitized to the
- * DNS-safe charset alchemy requires. The `phoenix`/`phoenix_db` literals mirror
- * the stack name (`alchemy.run.ts`) and the D1 logical id (`db/resources.ts`).
+ * Returning `undefined` on every hosted-state path is the load-bearing safety constraint:
+ * an existing tracked D1's `diff` returns `{action:"replace"}` when the desired name
+ * differs from the persisted one, so an *unconditional* name would replace the production
+ * D1 with an empty database. Production's `name` stays `undefined`, so its diff resolves
+ * the name from the persisted `output.databaseName` — byte-identical, no replace (verified
+ * in the pinned alchemy `DatabaseProvider.diff`).
  */
 export const devDatabaseName = (env: DeployEnvInput): string | undefined => {
 	const stage = resolveDevStage(env);
@@ -136,22 +100,13 @@ export const devDatabaseName = (env: DeployEnvInput): string | undefined => {
 	return `phoenix-phoenix_db-${stage}`.replaceAll(/[^a-zA-Z0-9-]/g, "-");
 };
 
-/** The apex the phoenix worker is served under (a Cloudflare Custom Domain). */
 export const PHOENIX_APEX_HOSTNAME = "phoenix.kamp.us" as const;
 
 /**
- * The Cloudflare Custom Domain hostname the worker is served at (issue #594) —
- * PRODUCTION-ONLY. A production deploy serves the apex `phoenix.kamp.us`; every
- * non-prod deploy (ephemeral integration `it-*` stages, preview stages, named dev
- * stages) gets **no** custom domain (`undefined`), so its `worker.url` stays the
- * `*.workers.dev` preview URL.
- *
- * The prod test is the shared `isProductionDeploy` predicate owned by
- * `environment.ts` (ADR 0088) — the ONE gate every deploy/runtime site calls (#1433),
- * not a copied `=== "production"`. A deploy is production iff its `ENVIRONMENT` is the
- * `production` class, independent of the stage name. The `stage` arg is unused (kept for
- * call-site symmetry / future named-stage domains) — there is deliberately NO
- * `<stage>.phoenix.kamp.us` per-stage subdomain anymore.
+ * PRODUCTION-ONLY. Every non-prod deploy gets no custom domain, so its `worker.url` stays
+ * the `*.workers.dev` preview URL. The prod test is the shared `isProductionDeploy`
+ * predicate (ADR 0088), never a copied `=== "production"`. The `stage` arg is unused, kept
+ * for call-site symmetry — there is deliberately NO `<stage>.phoenix.kamp.us` subdomain.
  *
  * Why production-only and not per-stage: #594's AC asked for `<stage>.phoenix.kamp.us`
  * per non-prod stage "so isolated deploys don't collide on the apex", but that itself

--- a/apps/web/worker/env.unit.test.ts
+++ b/apps/web/worker/env.unit.test.ts
@@ -35,10 +35,8 @@ describe("resolveStateMode", () => {
 	});
 
 	it("the integration harness (CI, no dev flag) uses the Cloudflare store — real remote D1 (ADR 0082)", () => {
-		// ADR 0082: integration deploys to real remote Cloudflare via Test.make, so a
-		// Vitest run resolves to the shared store like a real deploy. `VITEST` is no
-		// longer an offline signal (it isn't even read), so a CI test run with no dev
-		// flag resolves to cloudflare exactly like a real deploy.
+		// `VITEST` is deliberately NOT an offline signal (it isn't read): integration
+		// deploys to real remote Cloudflare, so a test run must resolve like a real deploy.
 		expect(resolveStateMode({CI: "true"})).toBe("cloudflare");
 	});
 

--- a/apps/web/worker/environment.ts
+++ b/apps/web/worker/environment.ts
@@ -1,63 +1,36 @@
 /**
- * The deploy-environment taxonomy (ADR 0088) and the predicates the IaC↔CI↔runtime
- * seam shares — the ONE module owning `development | preview | production | audit`, the
- * `stage → ENVIRONMENT` map (the `prod`→`production` spelling), and the fail-closed
- * `isProduction` gate. Before #1433 these were re-derived independently at five sites
- * (deploy.yml, config.ts, email-resources.ts, env.ts, alchemy.run.ts) with no shared
- * predicate, so a `prod`≠`production` drift would fail OPEN: every gate falling through
- * to non-prod on a *green* deploy (no email subdomain, no apex domain, no error).
+ * The deploy-environment taxonomy (ADR 0088) and the predicates the IaC, CI and
+ * runtime share — one owner for the classes, the `stage → ENVIRONMENT` map and the
+ * production gate, because five sites once re-derived them and a `prod`≠`production`
+ * drift failed OPEN on a green deploy (#1433).
  *
- * Pure — no `effect` import — on purpose: this contract is read at THREE distinct
- * moments and must not be tied to any one of them. The worker runtime reads it via the
- * `effect/Config` surface in `config.ts`; the alchemy CLI reads it over `process.env`
- * at deploy time; and `.github/workflows/deploy.yml` runs `environmentForStage` directly
- * under node (which strips the types). An Effect dependency here would bind it to the
- * runtime moment alone.
+ * Deliberately pure, with no `effect` import: this is read at three moments — by the
+ * worker runtime through `config.ts`, by the alchemy CLI over `process.env` at deploy
+ * time, and by `deploy.yml` running `environmentForStage` directly under node. An
+ * Effect dependency would bind it to the runtime moment alone.
  */
 
-/**
- * The deploy classes (ADR 0088), as the canonical literal tuple every site reuses.
- * `audit` is the dedicated isolated stage the rite-audit harness deploys (#1511,
- * epic #1510): a non-production deployed stage, distinct from a per-PR `preview`,
- * that exists so a force-on targeting rule can serve a dark-ship flag ON
- * non-interactively without ever reaching production (such a rule keys on this
- * class). It is NOT production — `isProduction` stays `=== "production"`, so an
- * audit stage provisions no email subdomain / apex domain, exactly like a preview.
- */
+// `audit` is the rite-audit harness's isolated deployed stage (#1511): a force-on
+// targeting rule can serve a dark-ship flag there without ever reaching production. It
+// is not production, so it provisions no email subdomain or apex domain.
 export const ENVIRONMENTS = ["development", "preview", "production", "audit"] as const;
 
-/** The deploy environment — one of the deploy classes (ADR 0088). */
 export type Environment = (typeof ENVIRONMENTS)[number];
 
-/**
- * The dedicated audit deploy class (#1511, epic #1510). Single-sourced here so the
- * stage→ENVIRONMENT map (`environmentForStage`) and any audit-stage force-on
- * targeting rule name the SAME literal — such a rule serves `on` iff the request's
- * `environment` attribute equals this value.
- */
+// Single-sourced so `environmentForStage` and any audit force-on targeting rule name
+// the same literal.
 export const AUDIT_ENVIRONMENT: Environment = "audit";
 
-/** The alchemy stage name that deploys the dedicated audit class (#1511). */
 export const AUDIT_STAGE = "audit";
 
-/**
- * The fail-closed default when `ENVIRONMENT` is unset at runtime (ADR 0088): a missing
- * var lands in production, closing every dev gate. `config.ts` binds this as the
- * `Config.withDefault`.
- */
+// Fail-closed: a missing `ENVIRONMENT` lands in production and closes every dev gate.
 export const DEFAULT_ENVIRONMENT: Environment = "production";
 
-/** Is `value` one of the taxonomy's deploy classes? */
 export const isEnvironment = (value: string): value is Environment =>
 	(ENVIRONMENTS as readonly string[]).includes(value);
 
-/**
- * Thrown when a non-empty `ENVIRONMENT` value is outside the taxonomy — the fail-LOUD
- * guard (#1433). Before this, an unrecognized value (the stage spelling `prod` instead
- * of `production`, say) silently fell through to non-prod, so a green deploy provisioned
- * no email subdomain and no apex domain. Failing loud here is the fail-closed posture of
- * ADR 0092 applied to the env taxonomy: refuse rather than silently downgrade.
- */
+// Fail loud rather than downgrade (ADR 0092): an unrecognized value used to fall
+// through to non-prod, so a green deploy silently provisioned nothing (#1433).
 export class UnknownEnvironmentError extends Error {
 	readonly value: string;
 	constructor(value: string) {
@@ -70,46 +43,23 @@ export class UnknownEnvironmentError extends Error {
 	}
 }
 
-/**
- * Parse a deploy-time `ENVIRONMENT` string into a typed `Environment`.
- *
- * - unset / empty → `undefined`: genuinely absent, so the caller decides the default.
- *   The deploy gates read absence as non-prod, preserving the prior `=== "production"`
- *   behavior for a local `alchemy deploy` with no `ENVIRONMENT`.
- * - a known class → that `Environment`.
- * - a non-empty UNKNOWN value → throws `UnknownEnvironmentError` (fail loud, #1433).
- */
+// Absent stays `undefined` so the caller picks the default — a local `alchemy deploy`
+// with no `ENVIRONMENT` must still read as non-prod.
 export const parseDeployEnvironment = (value: string | undefined): Environment | undefined => {
 	if (value === undefined || value === "") return undefined;
 	if (isEnvironment(value)) return value;
 	throw new UnknownEnvironmentError(value);
 };
 
-/** The fail-closed production gate over a typed `Environment` — the ONE predicate every TS gate shares. */
 export const isProduction = (environment: Environment): boolean => environment === "production";
 
-/**
- * Is this a production deploy? Reads the deploy-time `process.env.ENVIRONMENT` (the same
- * var the worker's `Config` binds at runtime). Fail-closed: an absent value is non-prod,
- * and a non-empty unknown value throws rather than silently downgrading (#1433) — so a CI
- * misconfiguration (e.g. emitting `prod`) fails the deploy loudly instead of quietly
- * skipping the email subdomain and apex domain.
- */
 export const isProductionDeploy = (env: {readonly ENVIRONMENT?: string | undefined}): boolean => {
 	const environment = parseDeployEnvironment(env.ENVIRONMENT);
 	return environment !== undefined && isProduction(environment);
 };
 
-/**
- * Map an alchemy stage name → its deploy `ENVIRONMENT` class — the single owner of the
- * `prod`→`production` spelling. `.github/workflows/deploy.yml` calls this (via node) so
- * the mapping lives here, not inlined in a YAML expression (#1433). The main-push stage
- * `prod` is `production`; the dedicated `audit` stage is `audit` (the rite-audit harness,
- * #1511); every other stage (the per-PR `pr-<n>` previews, ephemeral `it-*` integration
- * stages) is `preview`. Local `alchemy dev` sets `development` via `.env` and is never a
- * deployed stage. `prod`→`production` is the load-bearing invariant: only `prod` maps to
- * `production`, so the audit force-on rule (which keys on `audit`) can never match a prod
- * deploy.
- */
+// The single owner of the `prod`→`production` spelling; `deploy.yml` calls this under
+// node rather than inlining the mapping in YAML (#1433). Only `prod` maps to
+// `production`, which is what keeps the audit force-on rule from matching a prod deploy.
 export const environmentForStage = (stage: string): Environment =>
 	stage === "prod" ? "production" : stage === AUDIT_STAGE ? "audit" : "preview";

--- a/apps/web/worker/environment.unit.test.ts
+++ b/apps/web/worker/environment.unit.test.ts
@@ -1,8 +1,4 @@
-/**
- * Unit tests for the deploy-environment taxonomy module (ADR 0088) — the single
- * owner of `isProduction`, the `stage → ENVIRONMENT` map, and the fail-LOUD
- * unknown-env guard that closes the silent fail-open downgrade (#1433).
- */
+/** The deploy-environment taxonomy (ADR 0088), including the fail-LOUD unknown-env guard. */
 import {describe, expect, it} from "vitest";
 import {
 	AUDIT_ENVIRONMENT,
@@ -46,7 +42,7 @@ describe("isProduction (the one shared predicate)", () => {
 		expect(isProduction("production")).toBe(true);
 		expect(isProduction("preview")).toBe(false);
 		expect(isProduction("development")).toBe(false);
-		// The audit class is NEVER production — the prod-never invariant at the taxonomy layer.
+		// The audit class is NEVER production — the prod-never invariant.
 		expect(isProduction("audit")).toBe(false);
 	});
 });
@@ -60,16 +56,15 @@ describe("parseDeployEnvironment (fail-loud guard, #1433)", () => {
 	});
 
 	it("treats a genuinely absent value as undefined (caller defaults), NOT as a class", () => {
-		// Absence is the local `alchemy deploy` / unset case — the deploy gates read this as
-		// non-prod, preserving the prior `=== "production"` behavior. It is NOT a fail-open
-		// downgrade because the value was never a recognized class to begin with.
+		// Absence is the local `alchemy deploy` case. NOT a fail-open downgrade: the value
+		// was never a recognized class to begin with.
 		expect(parseDeployEnvironment(undefined)).toBeUndefined();
 		expect(parseDeployEnvironment("")).toBeUndefined();
 	});
 
 	it("THROWS on a non-empty unrecognized value instead of silently failing open", () => {
-		// The #1433 hazard: CI emitting the stage spelling `prod` instead of `production`.
-		// Before, every gate fell through to non-prod on a green deploy; now it fails loud.
+		// The #1433 hazard: CI emitting the stage spelling `prod` instead of `production`
+		// once made every gate fall through to non-prod on a green deploy.
 		expect(() => parseDeployEnvironment("prod")).toThrow(UnknownEnvironmentError);
 		expect(() => parseDeployEnvironment("staging")).toThrow(UnknownEnvironmentError);
 		expect(() => parseDeployEnvironment("Production")).toThrow(UnknownEnvironmentError);
@@ -111,8 +106,7 @@ describe("environmentForStage (the single owner of the prod→production map)", 
 	});
 
 	it("never maps a non-prod stage to production (prod-never at the stage layer)", () => {
-		// The audit stage and every preview stay non-production: only `prod` is production,
-		// so the audit force-on rule can never reach a production deploy.
+		// Only `prod` is production, so the audit force-on rule can never reach a prod deploy.
 		expect(environmentForStage(AUDIT_STAGE)).not.toBe("production");
 		expect(environmentForStage("pr-1")).not.toBe("production");
 	});

--- a/apps/web/worker/features/admin-console/fate-module.ts
+++ b/apps/web/worker/features/admin-console/fate-module.ts
@@ -4,8 +4,7 @@ import {adminProbeDataView} from "./probe-view.ts";
 import {queries} from "./queries.ts";
 
 const roots: FateRootsRecord = {
-	// The admin-console open-gate probe (#2740, epic #2711) — `requireAdmin`-gated; the
-	// `admin.probe` resolver owns the gate.
+	// The `admin.probe` resolver owns the `requireAdmin` gate (#2740).
 	"admin.probe": adminProbeDataView,
 };
 

--- a/apps/web/worker/features/admin-console/probe-view.ts
+++ b/apps/web/worker/features/admin-console/probe-view.ts
@@ -1,15 +1,8 @@
 /**
- * `AdminProbe` — the admin-console shell's one data view (#2740, epic #2711): the
- * server-authoritative "may THIS caller open the admin console?" signal the SPA reads to
- * decide whether to mount+fetch the lazy console bundle. A synthetic singleton (there is
- * only ever the one probe row per request, keyed `id: "admin-probe"`), mirroring
- * `stats/LandingStats` / `funnel/FunnelSummary`.
- *
- * Carries ONLY the fact that the gate passed — no identity, no capability list, no admin
- * roster. Producing this row at all is the signal; it is only ever reached past the
- * `requireAdmin` gate (`queries.ts`), so a non-admin
- * gets the invisible `Denied` (indistinguishable from not-signed-in, ADR 0107 / ADR 0098
- * §2) rather than a row that leaks admin-ness.
+ * The server-authoritative "may THIS caller open the admin console?" signal (#2740).
+ * Producing the row at all IS the signal, so it carries no identity, capability list, or
+ * roster — it is only ever reached past the `requireAdmin` gate, and a non-admin gets the
+ * invisible `Denied` instead (ADR 0107 / ADR 0098 §2).
  */
 import {FateDataView, type WorkerEntity} from "@kampus/fate-effect";
 import type {ViewRow} from "../fate/view-types.ts";

--- a/apps/web/worker/features/admin-console/queries.ts
+++ b/apps/web/worker/features/admin-console/queries.ts
@@ -1,20 +1,12 @@
 /**
- * The admin-console root query resolver (#2740, epic #2711) — `admin.probe`, the
- * console's single gated read: it resolves iff the caller may open the admin console, so
- * the SPA can decide whether to mount+fetch the lazy console bundle without shipping any
- * admin-ness to a non-admin.
+ * `admin.probe` — resolves iff the caller may open the admin console, so the SPA can
+ * decide whether to mount the lazy console bundle without shipping any admin-ness to a
+ * non-admin. Its denial is the invisible `Denied`, so a non-admin cannot tell "not an
+ * admin" from "not signed in" (ADR 0107).
  *
- * The gate is enforced HERE (there is no unconditional read path): the {@link requireAdmin}
- * capability gate — `Admin.over(platform)` only. `yield* Admin` makes the row unreachable
- * without the discharged grant, and its denial is the künye {@link Denied}
- * (`UNAUTHORIZED`), so a non-admin cannot distinguish "not an admin" from "not signed in"
- * (the invisible-denial invariant, ADR 0107 / ADR 0098 §2). The dark-ship flag that once
- * sat in front of it was retired at 100% rollout (#3671); this capability check was always
- * the authorization, the flag only a rollout gate on top.
- *
- * A synthetic singleton like `funnel.summary`: the wire type is the NAME string
- * (`"AdminProbe"`), not the view class, so the entity stays off the source-completeness
- * path (this resolver is its only producer, no by-id fetch to leak).
+ * The wire type is the NAME string, not the view class, which keeps the entity off the
+ * source-completeness path — this resolver is its only producer, so there is no by-id
+ * fetch to leak.
  */
 import {Fate} from "@kampus/fate-effect";
 import {Effect} from "effect";
@@ -24,8 +16,8 @@ import {Denied} from "../kunye/errors.ts";
 
 const ADMIN_PROBE_ID = "admin-probe";
 
-// The post-gate probe row — `Admin`-gated in R (`requireAdmin` provides the grant).
-// `yield* Admin` requires the proof; the row is unreachable without a discharged grant.
+// `yield* Admin` demands the proof in R, so the row is unreachable without a discharged
+// grant — a compile-time gate, not an `if`.
 const probeGated = Effect.fn("admin.probeGated")(function* () {
 	yield* Admin;
 	return {__typename: "AdminProbe" as const, id: ADMIN_PROBE_ID, admin: true};

--- a/apps/web/worker/features/bildirim/Notification.testing.ts
+++ b/apps/web/worker/features/bildirim/Notification.testing.ts
@@ -1,8 +1,7 @@
 /**
- * `makeNotificationStub` — the shared {@link Notification} test double, mirroring
- * `Funnel.testing.ts` / `Report.testing.ts`. Every method fails-on-contact
- * (`Effect.die`) by default; a test overrides only the method under test. A
- * **factory, not a shared instance** (`.patterns/effect-testing.md`).
+ * The shared {@link Notification} test double. Every method fails on contact by default; a test
+ * overrides only the method under test. A factory, not a shared instance
+ * (`.patterns/effect-testing.md`).
  */
 import {Effect, Layer} from "effect";
 import {Notification} from "./Notification.ts";

--- a/apps/web/worker/features/bildirim/Notification.ts
+++ b/apps/web/worker/features/bildirim/Notification.ts
@@ -1,15 +1,10 @@
 /**
- * `Notification` — the bildirim spine's domain service (#1694, epic #1666): the
- * one write surface sibling emitters call (`record`) and the recipient-scoped
- * read/mutate surface the fate resolvers consume (`listForRecipient`,
- * `unreadCount`, `markRead`, `markAllRead`, `resolveTargets`).
+ * `Notification` — the bildirim spine's domain service (#1694, epic #1666).
  *
  * Recipient scoping is structural: every read and every write predicate carries
- * `recipient_id` in its WHERE, so "mutate someone else's notification" matches
- * zero rows by construction — the query builders are exported pure (the
- * `tierPopulationQuery` idiom) so that predicate is `.toSQL()`-inspectable with
- * no engine (ADR 0082 T1/T2). Reads reach D1 only through the `Drizzle` seam and
- * die on infra errors (`orDieAccess`), so public signatures carry no error.
+ * `recipient_id` in its WHERE, so "mutate someone else's notification" matches zero
+ * rows by construction — the query builders are exported pure so that predicate is
+ * `.toSQL()`-inspectable with no engine (ADR 0082).
  */
 import {LivePublisher} from "@kampus/fate-effect";
 import {and, count, desc, eq, gte, inArray, isNull, sql} from "drizzle-orm";
@@ -35,13 +30,10 @@ import {
 
 export interface NotificationRecordInput {
 	recipientId: string;
-	/** The closed notification-kind discriminant (single-sourced from `NOTIFICATION_KINDS`). */
 	kind: NotificationKind;
 	targetKind: NotificationTargetKind;
 	targetId: string;
-	/** Who triggered it, or null for system events. */
 	actorId?: string | null;
-	/** Aggregate slot (#1698); defaults to 1. */
 	count?: number;
 }
 
@@ -74,7 +66,6 @@ export interface NotificationRow {
 	createdAt: Date;
 }
 
-/** The unread-count read — recipient-scoped, unread = `read_at IS NULL`. */
 export const unreadCountQuery = (db: DrizzleDb, recipientId: string) =>
 	db
 		.select({count: count()})
@@ -113,7 +104,6 @@ const unreadAggregateWhere = (input: NotificationAggregateInput) =>
 		isNull(schema.notification.readAt),
 	);
 
-/** Bump the existing UNREAD aggregate row (`count + 1`, `updated_at` refreshed). */
 export const bumpUnreadAggregateStatement = (
 	db: DrizzleDb,
 	input: NotificationAggregateInput,
@@ -163,7 +153,6 @@ const openDigestWhere = (input: NotificationDigestInput, since: Date) =>
 		gte(schema.notification.createdAt, since),
 	);
 
-/** Bump the recipient's open digest page for this actor/window (`count + 1`). */
 export const bumpOpenDigestStatement = (
 	db: DrizzleDb,
 	input: NotificationDigestInput,
@@ -199,7 +188,6 @@ export const insertUnlessOpenDigestStatement = (
 		);
 };
 
-/** Flip EVERY unread notification of the recipient read. */
 export const markAllReadStatement = (db: DrizzleDb, recipientId: string, now: Date) =>
 	db
 		.update(schema.notification)
@@ -211,74 +199,50 @@ export const markAllReadStatement = (db: DrizzleDb, recipientId: string, now: Da
 export class Notification extends Context.Service<
 	Notification,
 	{
-		/**
-		 * Record one notification (the emitter siblings' single write surface).
-		 * After the committed insert it republishes the recipient's live unread
-		 * count on the `NotificationChannel` entity topic (#1700) — the ONE publish
-		 * seam every emitter inherits with zero per-emitter code. The publish rides
-		 * the per-request `LivePublisher`, whose methods are `Effect<void>`
-		 * (swallow-with-log, ADR 0039), so it can never fail the recording write.
-		 */
+		/** Record one notification — the emitter siblings' single write surface. */
 		readonly record: (
 			input: NotificationRecordInput,
 		) => Effect.Effect<{id: string}, never, LivePublisher>;
 
 		/**
-		 * Aggregate-upsert (#1695, the anti-hype voice): bump the recipient's
-		 * existing UNREAD row for `(kind, target)` — `count + 1`, `updated_at`
-		 * refreshed — or insert a fresh unread row when none exists (so activity
-		 * after a mark-read surfaces as NEW unread, never a rewrite of read
-		 * history). N repeat events on one target therefore never mint N rows.
-		 * `aggregated: true` ⇔ an existing row was bumped. Republishes the
-		 * recipient's live unread count after the write (#1700), same seam as
-		 * {@link record}.
+		 * Bump the recipient's existing UNREAD row for `(kind, target)` or insert a fresh one, so
+		 * activity after a mark-read surfaces as NEW unread and N repeat events never mint N rows.
+		 * `aggregated: true` ⇔ an existing row was bumped.
 		 */
 		readonly recordAggregate: (
 			input: NotificationAggregateInput,
 		) => Effect.Effect<{aggregated: boolean}, never, LivePublisher>;
 
 		/**
-		 * Windowed digest-upsert (#3641): coalesce every event ONE actor causes inside
-		 * `window` into a single unread page per recipient — bump the open page's count,
-		 * or mint one carrying this event's target when the actor has none. Unlike
-		 * {@link recordAggregate} the target is NOT part of the key, so an actor spraying
-		 * N distinct targets still costs one row per recipient per window: this is the
-		 * fan-out BOUND, not a display roll-up. `digested: true` ⇔ an open page was
-		 * bumped. Same live-publish seam as {@link record}.
+		 * Coalesce every event ONE actor causes inside `window` into a single unread page per
+		 * recipient. The target is NOT part of the key, so an actor spraying N targets still costs
+		 * one row per recipient per window: this is the fan-out BOUND, not a display roll-up.
 		 */
 		readonly recordDigest: (
 			input: NotificationDigestInput,
 			window: Duration.Duration,
 		) => Effect.Effect<{digested: boolean}, never, LivePublisher>;
 
-		/**
-		 * The recipient's notifications, newest-first, forward keyset pagination
-		 * (ADR 0019; cursor = notification id, keyset `(created_at desc, id desc)`).
-		 */
+		/** Newest-first, forward keyset pagination (ADR 0019; cursor = notification id). */
 		readonly listForRecipient: (
 			recipientId: string,
 			opts?: {first?: number | undefined; after?: string | null | undefined},
 		) => Effect.Effect<KeysetPage<NotificationRow>>;
 
-		/** How many of the recipient's notifications are unread. */
 		readonly unreadCount: (recipientId: string) => Effect.Effect<number>;
 
 		/**
-		 * Mark one notification read. `marked: 0` on a foreign, unknown, or
-		 * already-read id — an idempotent no-op, never an existence oracle.
+		 * `marked: 0` on a foreign, unknown, or already-read id — an idempotent no-op, never an
+		 * existence oracle.
 		 */
 		readonly markRead: (
 			recipientId: string,
 			notificationId: string,
 		) => Effect.Effect<{marked: number}>;
 
-		/** Mark every unread notification of the recipient read. */
 		readonly markAllRead: (recipientId: string) => Effect.Effect<{marked: number}>;
 
-		/**
-		 * Batch-resolve target refs to client hrefs (`null` = tombstone) — one
-		 * `IN (...)` read per kind present, folded by `foldTargetHrefs`.
-		 */
+		/** Batch-resolve target refs to client hrefs; `null` = tombstone. */
 		readonly resolveTargets: (
 			refs: ReadonlyArray<TargetRef>,
 		) => Effect.Effect<ReadonlyMap<string, string | null>>;
@@ -289,12 +253,8 @@ export const NotificationLive = Layer.effect(Notification)(
 	Effect.gen(function* () {
 		const {run, batch} = orDieAccess(yield* Drizzle);
 
-		// Republish the recipient's fresh unread count on their entity topic after a
-		// recorded notification — the ONE live seam every emitter inherits (#1700).
-		// Re-reads the count and fans it out inline as the `NotificationChannel`
-		// entity data (the reactions `live.definition.update` idiom). The publish
-		// rides `LivePublisher` (swallow-with-log, ADR 0039), so it can never fail
-		// the recording write — a fan-out failure is logged, not raised.
+		// The ONE live seam every emitter inherits (#1700). Rides `LivePublisher`
+		// (swallow-with-log, ADR 0039), so a fan-out failure can never fail the write.
 		const publishChannel = Effect.fn("Notification.publishChannel")(function* (
 			recipientId: string,
 		) {
@@ -313,10 +273,8 @@ export const NotificationLive = Layer.effect(Notification)(
 			const first = Math.max(1, Math.min(opts.first ?? 20, 100));
 			const after = opts.after ?? null;
 
-			// The DB read is the port; `resolveCursor` is the pure cursor-miss
-			// decision (the Bookmark idiom). The cursor is a notification id,
-			// resolved to its `created_at` for the keyset tuple — recipient-scoped,
-			// so a foreign cursor is a miss, not a probe into someone else's list.
+			// The cursor is a notification id resolved to its `created_at` for the keyset tuple,
+			// recipient-scoped — a foreign cursor is a miss, not a probe into someone else's list.
 			const resolvedRow = after
 				? ((yield* run((db) =>
 						db
@@ -466,9 +424,8 @@ export const NotificationLive = Layer.effect(Notification)(
 				yield* publishChannel(input.recipientId);
 				return {id};
 			}),
-			// Bump-then-guarded-insert in ONE batch (one D1 transaction): if the bump
-			// matched an unread row the insert's NOT EXISTS is false; if none existed
-			// the insert fires — atomic, so concurrent emits can't mint two unread rows.
+			// Bump-then-guarded-insert in ONE batch (one D1 transaction), so concurrent emits
+			// can't mint two unread rows.
 			recordAggregate: Effect.fn("Notification.recordAggregate")(function* (
 				input: NotificationAggregateInput,
 			) {
@@ -484,8 +441,6 @@ export const NotificationLive = Layer.effect(Notification)(
 				yield* publishChannel(input.recipientId);
 				return {aggregated: bumped.meta.changes > 0};
 			}),
-			// The actor/window-keyed twin of `recordAggregate` — same one-batch
-			// bump-then-guarded-insert, so two concurrent emits can't mint two pages.
 			recordDigest: Effect.fn("Notification.recordDigest")(function* (
 				input: NotificationDigestInput,
 				window: Duration.Duration,

--- a/apps/web/worker/features/bildirim/Notification.unit.test.ts
+++ b/apps/web/worker/features/bildirim/Notification.unit.test.ts
@@ -1,19 +1,9 @@
 /**
- * `Notification` domain coverage (#1694) — record / list / unreadCount / markRead
- * scoping, the decisions that are wrong-or-right with no engine (ADR 0040, ADR
- * 0082 T1/T2; `.patterns/effect-testing.md`). The `Drizzle` seam is substituted
- * directly (the `Funnel` idiom):
+ * `Notification` domain coverage (#1694) — the decisions that are wrong-or-right with no engine
+ * (ADR 0082; `.patterns/effect-testing.md`), with the `Drizzle` seam substituted directly.
  *
- *   - **recipient scoping** — the exported pure builders' rendered SQL
- *     (`.toSQL()` over a no-op D1) is asserted to carry `recipient_id` in every
- *     read/write predicate, so "touch someone else's notification" matches zero
- *     rows by construction. This is the scoping AC's test.
- *   - **markRead** — end-to-end over the seam: the update's `changes` surfaces as
- *     `marked` (0 = foreign/unknown/already-read id, an idempotent no-op).
- *   - **list** — newest-first keyset paging: the `first + 1` probe folds into
- *     `{rows, hasNextPage, endCursor}`; a cursor that resolves to no row (foreign
- *     or dead id) is the shared cursor-miss empty page, never a probe.
- *   - **unreadCount / record** — the fold and the insert's field mapping.
+ * Recipient scoping is proven on RENDERED SQL: the exported pure builders' `.toSQL()` over a
+ * no-op D1 must carry `recipient_id` in every read/write predicate.
  */
 
 import {assert, describe, it} from "@effect/vitest";
@@ -33,12 +23,7 @@ import {
 	unreadCountQuery,
 } from "./Notification.ts";
 
-/**
- * A recording `LivePublisher` (#1700): captures every `update(type, id, opts)` so a
- * test can assert the publish seam fired on the recipient's `NotificationChannel`
- * topic. `record`/`recordAggregate` yield `LivePublisher` for the fire-and-forget
- * live fan-out, so the seam is provided here for those cases.
- */
+// Captures every `update(type, id, opts)` so a test can assert the #1700 publish seam fired.
 const recordingPublisher = () => {
 	const updates: Array<{type: string; id: string | number; data: unknown}> = [];
 	const layer = Layer.succeed(LivePublisher)({
@@ -54,8 +39,7 @@ const recordingPublisher = () => {
 	return {updates, layer};
 };
 
-// A real drizzle client over a no-op D1 — used ONLY to render `.toSQL()`; it
-// never executes.
+// A real drizzle client over a no-op D1 — used ONLY to render `.toSQL()`; it never executes.
 // biome-ignore lint/plugin: `D1Database` is a host binding that can't be structurally constructed in a fake; nothing here executes against it.
 const noopD1 = {
 	prepare: () => ({
@@ -173,7 +157,6 @@ describe("Notification.listForRecipient — newest-first keyset paging", () => {
 		}).pipe(
 			Effect.provide(
 				notificationLayer(
-					// One read (no cursor to resolve): the LIMIT 3 probe.
 					scriptedSequence([
 						[row("n3", new Date(3000)), row("n2", new Date(2000)), row("n1", new Date(1000))],
 					]),
@@ -248,8 +231,7 @@ describe("recordAggregate builders — recipient-scoped, unread-only (the anti-h
 });
 
 describe("Notification.recordAggregate — bump-or-insert in one batch", () => {
-	// recordAggregate does one batch (bump+insert) then reads the fresh unread count
-	// for the live publish (#1700) — so the seam is a batch AND a run.
+	// One batch (bump+insert), then a run for the fresh unread count the live publish carries.
 	const aggregateAccess = (
 		batchResults: ReadonlyArray<unknown>,
 		unreadRows: ReadonlyArray<unknown>,
@@ -370,8 +352,7 @@ describe("Notification.recordDigest — bump-or-insert in one batch", () => {
 });
 
 describe("Notification.record — the emitter write surface + the live publish (#1700)", () => {
-	// record does the insert (1 run) then reads the fresh unread count for the live
-	// publish (2nd run): the recipient-scoped `NotificationChannel` fan-out.
+	// The insert is one run; the fresh unread count for the publish is a second.
 	it.effect("inserts, returns a fresh id, and publishes the recipient's fresh unread count", () => {
 		const {updates, layer} = recordingPublisher();
 		return Effect.gen(function* () {
@@ -384,8 +365,6 @@ describe("Notification.record — the emitter write surface + the live publish (
 			});
 			assert.isString(id);
 			assert.isAbove(id.length, 0);
-			// The live publish fired on the recipient's own channel entity, carrying the
-			// re-read unread count — the recipient-scoped seam every emitter inherits.
 			assert.lengthOf(updates, 1);
 			assert.strictEqual(updates[0]?.type, "NotificationChannel");
 			assert.strictEqual(updates[0]?.id, "me");

--- a/apps/web/worker/features/bildirim/channel.ts
+++ b/apps/web/worker/features/bildirim/channel.ts
@@ -1,11 +1,8 @@
 /**
- * The per-recipient live notification channel's identity (#1700). A leaf module —
- * a pure string constant with no fate-view / Drizzle deps — so BOTH the publish
- * seam (`Notification.publishChannel`) and the subscribe-authorization gate
- * (`fate-live/route.ts`) name the SAME entity type without either pulling the
- * other's graph. The channel is keyed by the recipient's user id; the route
- * rejects an entity subscription to this type whose id is not the session user's.
+ * The per-recipient live notification channel's identity (#1700). A leaf module — a pure string
+ * constant, no fate-view / Drizzle deps — so the publish seam and the subscribe-authorization
+ * gate name the SAME entity type without either pulling the other's graph. Keyed by recipient id;
+ * the route rejects a subscription to this type whose id is not the session user's.
  */
 
-/** The fate entity type the live unread signal fans out on — keyed by recipient id. */
 export const NOTIFICATION_CHANNEL_TYPE = "NotificationChannel";

--- a/apps/web/worker/features/bildirim/conversation-emitters.ts
+++ b/apps/web/worker/features/bildirim/conversation-emitters.ts
@@ -1,28 +1,14 @@
 /**
- * Conversation-moment emitters (#1697, epic #1666) — pano's comment activity made
- * audible through the spine's {@link Notification} write surface (stories 4 + 12):
+ * Conversation-moment emitters (#1697, epic #1666): a new comment notifies the post
+ * author, and a threaded reply also notifies the parent-comment author — at most one
+ * notification per person, never the commenter themselves.
  *
- *  - **reply** — a new comment on a post notifies the post author ("someone replied
- *    to your post"); a threaded reply additionally notifies the parent-comment
- *    author ("someone replied to your comment"). {@link replyRecipients} resolves
- *    the recipient set once — deduped and self-suppressed — so one comment event
- *    yields **at most one** notification per person: when the post author and the
- *    parent-comment author coincide they get one, not two, and the commenter is
- *    never notified about their own comment (story 12).
+ * Replies use {@link Notification.record} (one row per recipient), NOT the vote path's
+ * aggregate-upsert: rollup is the anti-hype voice for votes, not for replies.
  *
- * Sözlük is out of scope: definitions under a term are not replies (the brief's
- * "reply to your definition" has no surface today). If sözlük grows a reply
- * primitive, this emitter extends to it then.
- *
- * A reply is a discrete conversation event, so it uses {@link Notification.record}
- * (one row per recipient) — NOT the vote path's aggregate-upsert; "3 yeni oy"
- * aggregation is the anti-hype voice for votes, not for replies.
- *
- * The emit rides AFTER the committed comment mutation and can never fail it: the
- * whole effect — flag read included — is swallowed-with-log (`catchCause`, the
- * ADR 0039 fire-and-forget posture; the rite-emitters idiom), which also absorbs
- * the `orDieAccess` DEFECTS a D1 hiccup raises, not just typed errors. The write
- * is gated on the spine's `phoenix-bildirim` flag (dark by default).
+ * The emit rides AFTER the committed mutation and can never fail it: the whole effect,
+ * flag read included, is swallowed-with-log (ADR 0039), which also absorbs the
+ * `orDieAccess` DEFECTS a D1 hiccup raises — not just typed errors.
  */
 import {Effect} from "effect";
 import {bildirimOn} from "./gate.ts";
@@ -33,13 +19,9 @@ import {Notification} from "./Notification.ts";
 export const REPLY_KIND: NotificationKind = "reply";
 
 /**
- * The deduped, self-suppressed recipient set for one comment event (pure).
- *
- * The post author is a candidate for every comment ("reply to your post"); the
- * parent-comment author is added for a threaded reply ("reply to your comment").
- * A `Set` collapses the coincident-author case to one recipient, and the actor is
- * removed last so the commenter is never notified about their own comment — a
- * self-reply on your own post therefore resolves to nobody (story 12).
+ * The deduped, self-suppressed recipient set for one comment event (pure). A `Set`
+ * collapses the coincident-author case to one recipient, and the actor is removed
+ * last, so a self-reply on your own post resolves to nobody (story 12).
  */
 export const replyRecipients = (input: {
 	postAuthorId: string;
@@ -56,9 +38,8 @@ const swallow = (label: string) =>
 	Effect.catchCause((cause) => Effect.logWarning(`bildirim: ${label} emit swallowed`, cause));
 
 /**
- * Notify the post author (and, for a reply, the parent-comment author) that a new
- * comment landed. The notification target is the new comment for every recipient,
- * so the link lands them on the reply in the thread; the actor is the commenter.
+ * The notification target is the new comment for every recipient, so the link lands
+ * them on the reply in the thread.
  */
 export const notifyCommentReply = (input: {
 	commentId: string;

--- a/apps/web/worker/features/bildirim/conversation-emitters.unit.test.ts
+++ b/apps/web/worker/features/bildirim/conversation-emitters.unit.test.ts
@@ -1,12 +1,9 @@
 /**
- * Conversation-moment emitter coverage (#1697, epic #1666) — the decisions that
- * are wrong-or-right with no database (ADR 0082 T1/T2; `.patterns/effect-testing.md`):
- * recipient resolution (post author + parent-comment author), dedupe when they
- * coincide, self-suppression (story 12), the flag containment (dark by default),
- * and the swallow-at-the-seam guarantee — a DYING `Notification` (the `orDieAccess`
- * defect shape) cannot fail the comment mutation. The `Notification` seam is the
- * fail-on-contact stub with only `record` overridden, so touching any other write
- * surface (e.g. the vote path's `recordAggregate`) is a test failure.
+ * Conversation-moment emitter coverage (#1697): recipient resolution, dedupe,
+ * self-suppression, dark-by-default containment, and the swallow-at-the-seam guarantee —
+ * a DYING `Notification` cannot fail the comment mutation. The `Notification` stub is
+ * fail-on-contact with only `record` overridden, so touching any other write surface
+ * fails the test.
  */
 import {assert, describe, it} from "@effect/vitest";
 import {CurrentUser, LivePublisher} from "@kampus/fate-effect";
@@ -39,10 +36,8 @@ const flagsStub = (on: boolean): Layer.Layer<Flags> =>
 		} as unknown as typeof Flags.Service,
 	);
 
-// A no-op `LivePublisher`: the emitter calls `Notification.record`, which yields the
-// per-request publisher for the fire-and-forget live fan-out (#1700). The stub `record`
-// never touches it, so a do-nothing publisher satisfies the requirement (the live
-// publish is covered in `Notification.unit.test.ts` / the integration tier).
+// The stub `record` never publishes, so a do-nothing publisher satisfies the requirement;
+// the live publish is covered in `Notification.unit.test.ts`.
 const noopLivePublisher = Layer.succeed(LivePublisher)({
 	update: () => Effect.void,
 	delete: () => Effect.void,
@@ -51,10 +46,8 @@ const noopLivePublisher = Layer.succeed(LivePublisher)({
 	},
 } as typeof LivePublisher.Service);
 
-// A `Mute` returning no mutes: the emitter now consults `bildirimMutedBy` per recipient,
-// which reads `readMutedIds` — an empty set means no member is muted, so these cases
-// exercise the unchanged (deliver) path. Muted-suppression itself is covered in
-// mute-suppression.unit.test.ts.
+// An empty set puts every case below on the deliver path; muted-suppression itself is
+// covered in mute-suppression.unit.test.ts.
 const noMutes = Layer.succeed(Mute, {
 	set: () => Effect.die("Mute.set not exercised"),
 	listMine: () => Effect.die("Mute.listMine not exercised"),
@@ -198,7 +191,7 @@ describe("notifyCommentReply — the reply emit", () => {
 		() =>
 			Effect.gen(function* () {
 				// The default stub DIES on contact — the exact defect shape `orDieAccess`
-				// raises on a D1 failure. The emitter must swallow it, not surface it.
+				// raises on a D1 failure.
 				const exit = yield* notifyCommentReply({
 					commentId: "comm-6",
 					postAuthorId: "u-post",

--- a/apps/web/worker/features/bildirim/fate-module.ts
+++ b/apps/web/worker/features/bildirim/fate-module.ts
@@ -17,13 +17,11 @@ import {
 } from "./views.ts";
 
 const roots: FateRootsRecord = {
-	// The current user's notification center list (#1694) — flag-gated, newest-first;
-	// the `bildirim.list` resolver owns the keyset order + recipient scoping.
+	// The resolver owns the keyset order and the recipient scoping.
 	"bildirim.list": list(notificationDataView),
-	// The topbar badge's unread count — a synthetic singleton, `funnel.summary` shape.
+	// A synthetic singleton, in the `funnel.summary` shape.
 	"bildirim.unreadCount": notificationUnreadDataView,
-	// The current user's live notification channel (#1700) — the per-recipient
-	// `NotificationChannel` entity the badge + center subscribe to over `/fate/live`.
+	// The per-recipient entity the badge and center subscribe to over `/fate/live`.
 	"bildirim.channel": notificationChannelDataView,
 };
 

--- a/apps/web/worker/features/bildirim/gate.ts
+++ b/apps/web/worker/features/bildirim/gate.ts
@@ -1,17 +1,13 @@
 /**
- * The bildirim dark-ship gate (#1694, ADR 0083): every bildirim resolver runs
- * only when the `phoenix-bildirim` flag is on for this request. Off (the
- * default, and any Flagship outage — safe read default `false`) ⇒ the invisible
- * {@link Denied}, so nothing user-visible changes and nothing leaks even on a
- * direct wire call — the `funnel.summary` shape. One gate all sibling emitters'
- * surfaces reuse; no per-child flags.
+ * The bildirim dark-ship gate (#1694, ADR 0083). Off — the default, and any Flagship
+ * outage — yields the invisible {@link Denied}, so nothing leaks even on a direct wire
+ * call. One gate for every sibling emitter's surface; no per-child flags.
  *
- * **Release sequencing (#3641, founder ruling on #2562).** `phoenix-bildirim` may not
- * graduate — flip fully on, then retire (#3544) — unless `notifyReportFiled`'s
- * per-reporter/window page coalescing (`REPORT_PAGE_WINDOW` in `mod-emitters.ts`) is
- * live. That aggregation is the abuse control on the moderator pager: without it one
+ * RELEASE SEQUENCING (#3641, founder ruling on #2562): `phoenix-bildirim` may not
+ * graduate unless `notifyReportFiled`'s per-reporter/window page coalescing is live.
+ * That aggregation is the abuse control on the moderator pager — without it one
  * karma-less account pages the whole team once per report per moderator, un-throttled.
- * A karma floor was rejected as the gate (#2562/#3309); the per-actor rate limiter
+ * A karma floor was rejected as the gate (#2562/#3309), and the per-actor rate limiter
  * (#2561) is a companion, not a substitute.
  */
 import {Effect} from "effect";
@@ -20,8 +16,8 @@ import {Flags} from "../flagship/Flags.ts";
 import {provideRequestFlags} from "../flagship/FlagsContext.ts";
 import {Denied} from "../kunye/errors.ts";
 
-/** The raw flag read — the emitter siblings gate their WRITES on this (a silent
- * skip, never the resolver gate's `Denied`). Safe default `false`. */
+// Emitters gate their WRITES on this — a silent skip, never the resolver gate's
+// `Denied`. Safe default `false`.
 export const bildirimOn = Effect.gen(function* () {
 	const flags = yield* Flags;
 	return yield* flags.getBoolean(PHOENIX_BILDIRIM, false).pipe(provideRequestFlags);

--- a/apps/web/worker/features/bildirim/kind.ts
+++ b/apps/web/worker/features/bildirim/kind.ts
@@ -1,26 +1,13 @@
 /**
- * The bildirim **notification kind** — the closed discriminant naming what kind of
- * moment a notification is (`divan-vote` | `kefil` | `terfi` | `reply` | `vote` |
- * `report-filed` | `caylak-pending`), the `TARGET_KINDS` /
- * `NOTIFICATION_TARGET_KINDS` idiom (`target-kind.ts` / `target.ts`).
+ * The closed notification-kind discriminant, and the one runtime tuple every emitter const
+ * and the client copy map source from. The client `KIND_COPY` map is `satisfies
+ * Record<NotificationKind, …>`, so shipping a new kind without its Turkish copy is a compile
+ * error rather than a raw wire identifier rendered to a reader (the `reply` drift, #2016).
  *
- * `NOTIFICATION_KINDS` is the one runtime tuple every emitter const and the client
- * copy map source from, so the kind can no longer be independent string literals
- * that silently drift: the emitters (`REPLY_KIND`, `DIVAN_VOTE_KIND`, `KEFIL_KIND`,
- * `PROMOTION_KIND`, `VOTE_KIND`, `REPORT_FILED_KIND`, `CAYLAK_PENDING_KIND`) type
- * against this union, and the client `KIND_COPY` map is
- * `satisfies Record<NotificationKind, …>` — so shipping a new kind without its
- * Turkish copy is a compile error, not a raw wire identifier rendered to a reader
- * (the `reply` drift, #2016).
- *
- * `vote` (#1698) is the aggregated live-content vote moment — a vote on a member's
- * pano post/comment or sözlük definition — kept DISTINCT from divan's sandboxed
- * `divan-vote` so the two surfaces carry their own product voice ("N yeni oy" vs
- * "divandaki içeriğin oy aldı"). The mod-facing kinds (`report-filed` /
- * `caylak-pending`, #1699) are the moderator queue's heartbeat.
+ * `vote` is the aggregated live-content vote moment, kept DISTINCT from divan's sandboxed
+ * `divan-vote` so the two surfaces carry their own product voice.
  */
 
-/** The closed notification-kind set, as the one runtime tuple emitters + copy source from. */
 export const NOTIFICATION_KINDS = [
 	"divan-vote",
 	"kefil",

--- a/apps/web/worker/features/bildirim/lists.ts
+++ b/apps/web/worker/features/bildirim/lists.ts
@@ -1,11 +1,8 @@
 /**
- * `bildirim.list` — the current user's notifications, newest-first, forward
- * keyset pagination (ADR 0019; the service owns the cursor). Flag-gated
- * ({@link requireBildirimOn}, the invisible `Denied` while dark); signed-out
- * resolves to an empty connection (the read-path "degrade, never throw"
- * convention of `savedPosts`). Each node carries the server-resolved
- * `targetUrl` — `null` for a target that no longer resolves, so the client
- * renders a tombstone, never a broken link.
+ * The current user's notifications (ADR 0019; the service owns the cursor). Signed-out
+ * resolves to an empty connection rather than throwing, and a target that no longer
+ * resolves gets a null `targetUrl`, so the client renders a tombstone instead of a
+ * broken link.
  */
 import {CurrentUser, Fate} from "@kampus/fate-effect";
 import {Effect} from "effect";

--- a/apps/web/worker/features/bildirim/mod-emitters.ts
+++ b/apps/web/worker/features/bildirim/mod-emitters.ts
@@ -1,33 +1,15 @@
 /**
- * Mod-queue emitters (#1699, epic #1666) — the moderator team's pager, through the
- * spine's {@link Notification} write surface (stories 9/10/12):
+ * Mod-queue emitters — the moderator team's pager, through the spine's {@link Notification}
+ * write surface. `report-filed` pages every moderator on a filed content report, coalesced
+ * per reporter per window; `caylak-pending` pages them on a çaylak's FIRST pending item.
  *
- *  - **report-filed** — a freshly-filed content report notifies EVERY moderator, so
- *    the two-person team learns of a new item in the queue without polling it. The
- *    target is the reported content, so the row links a moderator straight to it.
- *    Pages are COALESCED per reporter per window ({@link REPORT_PAGE_WINDOW}) — the
- *    abuse control that bounds how hard one account can page the team (#3641).
- *  - **caylak-pending** — a new çaylak entering the divan review queue notifies every
- *    moderator. Fired by the content-create path only on the çaylak's FIRST currently
- *    pending item (the 0→1 transition — see the divan-side gate), so it is the
- *    "a new çaylak is awaiting review" signal, not one ping per sandboxed item.
+ * The recipient set comes from the authority model, never a hardcoded list: {@link
+ * allModerators} enumerates every subject holding `(moderates, platform)` — the SAME tuple
+ * `Moderate.over(platform)` discharges against (ADR 0107).
  *
- * The recipient set is resolved from the authority model, never a hardcoded list:
- * {@link allModerators} enumerates every subject holding `(moderates, platform)` —
- * the SAME tuple `Moderate.over(platform)` discharges against (ADR 0107). The acting
- * moderator is self-suppressed ({@link modRecipients}): a moderator who files a report
- * is never paged about their own action (story 12). Fan-out is a simple per-recipient
- * loop for the two-person team — no subscription system (the brief).
- *
- * The çaylak moment is discrete, so it uses {@link Notification.record} (one row per
- * recipient); the report page is windowed-coalesced (`recordDigest`) — neither is the
- * vote path's per-target aggregate-upsert.
- *
- * The emits ride AFTER the committed report/create mutation and can never fail it: the
- * whole effect — flag read AND the moderator enumeration included — is swallowed-with-log
- * (`catchCause`, the ADR 0039 fire-and-forget posture; the rite-emitters idiom), which
- * also absorbs the `orDieAccess` DEFECTS a D1 hiccup raises, not just typed errors.
- * Writes are gated on the spine's `phoenix-bildirim` flag (dark by default).
+ * The emits ride AFTER the committed mutation and can never fail it: the whole effect, flag
+ * read and moderator enumeration included, is swallowed-with-log (ADR 0039 fire-and-forget),
+ * which also absorbs the `orDieAccess` DEFECTS a D1 hiccup raises, not just typed errors.
  */
 import {Duration, Effect} from "effect";
 import type {TargetKind} from "../../db/target-kind.ts";
@@ -40,12 +22,8 @@ import {Notification} from "./Notification.ts";
 export const REPORT_FILED_KIND: NotificationKind = "report-filed";
 export const CAYLAK_PENDING_KIND: NotificationKind = "caylak-pending";
 
-/**
- * The self-suppressed moderator recipient set for one mod-queue moment (pure): every
- * moderator except the actor. A moderator who triggered the event (e.g. filed the
- * report) is never paged about their own action; a `null` actor (a system moment with
- * no acting user) suppresses no one. Deterministic order for a stable fan-out.
- */
+// A moderator who triggered the event is never paged about their own action; a `null` actor
+// (a system moment) suppresses no one. Sorted for a stable fan-out.
 export const modRecipients = (
 	moderators: ReadonlySet<string>,
 	actorId: string | null,
@@ -55,27 +33,20 @@ const swallow = (label: string) =>
 	Effect.catchCause((cause) => Effect.logWarning(`bildirim: ${label} emit swallowed`, cause));
 
 /**
- * How long one reporter's mod pages coalesce (#3641, founder ruling on #2562). Every
- * report the SAME reporter files inside this window bumps one open page per moderator
- * instead of minting another row, so the pages a single account can aim at the team is
- * bounded by elapsed time, not by how many targets it reports. Wide enough that a
- * report spree is one page, short enough that a genuinely new burst hours later pages
- * again. This aggregation is a release gate on `phoenix-bildirim` — see `gate.ts`.
+ * How long one reporter's mod pages coalesce (#3641, founder ruling on #2562). Bounds the
+ * pages a single account can aim at the team by elapsed time, not by how many targets it
+ * reports. Wide enough that a report spree is one page, short enough that a genuinely new
+ * burst hours later pages again. A release gate on `phoenix-bildirim` — see `gate.ts`.
  */
 export const REPORT_PAGE_WINDOW = Duration.minutes(30);
 
 /**
- * Notify every moderator that a content report was filed, coalesced per reporter per
- * {@link REPORT_PAGE_WINDOW}: the window's first report mints the page (its target is
- * the reported content, so the row links a moderator straight to it) and every later
- * report by that reporter bumps its count — "N yeni içerik bildirildi", with the queue
- * itself carrying the rest. The actor is the reporter, self-suppressed if they are
- * themselves a moderator. `targetKind` is a report {@link TargetKind}
- * (`definition`/`post`/`comment`), a subset of the notification target taxonomy.
+ * Coalesced per reporter per {@link REPORT_PAGE_WINDOW}: the window's first report mints the
+ * page and every later report by that reporter bumps its count.
  *
- * Idempotency is unchanged and stays at the call site: `report.submit` emits only on a
- * genuinely `created` report, so a re-report of the same target never reaches here —
- * the window bounds DISTINCT reports, it is not a substitute for that guard.
+ * Idempotency stays at the call site: `report.submit` emits only on a genuinely `created`
+ * report, so a re-report of the same target never reaches here — the window bounds DISTINCT
+ * reports, it is not a substitute for that guard.
  */
 export const notifyReportFiled = (input: {
 	reporterId: string;
@@ -101,13 +72,9 @@ export const notifyReportFiled = (input: {
 		}
 	}).pipe(swallow(REPORT_FILED_KIND));
 
-/**
- * Notify every moderator that a new çaylak entered the divan review queue. The target
- * is the çaylak's own account (the roster's unit is the person, not the item); the
- * moment is a system event with no acting user, so `actorId` is null and no moderator
- * is self-suppressed. The çaylak itself is never a recipient (they hold no `moderates`
- * tuple), so the moderator set already excludes them.
- */
+// The target is the çaylak's own account (the roster's unit is the person, not the item).
+// A system event with no acting user, so nobody is self-suppressed; the çaylak holds no
+// `moderates` tuple, so the moderator set already excludes them.
 export const notifyCaylakPending = (input: {caylakId: string}) =>
 	Effect.gen(function* () {
 		if (!(yield* bildirimOn)) return;
@@ -126,13 +93,9 @@ export const notifyCaylakPending = (input: {caylakId: string}) =>
 	}).pipe(swallow(CAYLAK_PENDING_KIND));
 
 /**
- * The content-create wiring for {@link notifyCaylakPending}: page the moderators only
- * when a çaylak's item lands sandboxed AND it is their FIRST currently-pending item —
- * the 0→1 roster entry (`Divan.pendingCountOf === 1` right after the item committed).
- * A live item (`sandboxedAt === null` — flag-off or a yazar) is never a divan entry, so
- * it short-circuits with no read; a çaylak's second+ item leaves the count > 1 and
- * pages nobody. The whole effect (the count read included) is swallowed by
- * {@link notifyCaylakPending}, so it can never fail the committed create.
+ * Page the moderators only when a çaylak's item lands sandboxed AND it is their FIRST
+ * currently-pending item (the 0→1 roster entry). A live item is never a divan entry, so it
+ * short-circuits with no read. The whole effect is swallowed, so it cannot fail the create.
  */
 export const notifyCaylakEntersDivan = (input: {authorId: string; sandboxedAt: Date | null}) =>
 	Effect.gen(function* () {

--- a/apps/web/worker/features/bildirim/mod-emitters.unit.test.ts
+++ b/apps/web/worker/features/bildirim/mod-emitters.unit.test.ts
@@ -1,11 +1,9 @@
 /**
- * Mod-queue emitter coverage (#1699) — the decisions wrong-or-right with no database
- * (ADR 0082 T1/T2; `.patterns/effect-testing.md`): moderator resolution + actor
- * self-suppression, the flag containment (dark by default), the çaylak-entry 0→1
- * transition gate, and the swallow-at-the-seam guarantee — a DYING dependency (the
- * `orDieAccess` defect shape) cannot fail the caller. The `Notification` / `Divan` /
- * `RelationStore` seams are fail-on-contact stubs with only the exercised method
- * overridden, so "touched the wrong surface" is a test failure.
+ * Mod-queue emitter coverage — the decisions wrong-or-right with no database (ADR 0082):
+ * moderator resolution + actor self-suppression, the flag containment, the çaylak-entry 0→1
+ * gate, and the swallow-at-the-seam guarantee (a DYING dependency cannot fail the caller).
+ * The `Notification` / `Divan` / `RelationStore` seams are fail-on-contact stubs with only
+ * the exercised method overridden, so "touched the wrong surface" is a test failure.
  */
 import {assert, describe, it} from "@effect/vitest";
 import {RelationStore} from "@kampus/authz";
@@ -46,9 +44,8 @@ const flagsStub = (on: boolean): Layer.Layer<Flags> =>
 		getObject: () => Effect.die("getObject not exercised"),
 	} as typeof Flags.Service);
 
-// A no-op `LivePublisher`: `Notification.record` yields the per-request publisher for
-// the fire-and-forget live fan-out (#2076). The stub `record` never touches it, so a
-// do-nothing publisher satisfies the requirement without asserting on it.
+// `Notification.record` yields the per-request publisher for the fire-and-forget live
+// fan-out; the stub `record` never touches it.
 const noopLivePublisher = Layer.succeed(LivePublisher)({
 	update: () => Effect.void,
 	delete: () => Effect.void,
@@ -66,8 +63,8 @@ const requestContext = (on: boolean) =>
 		noopLivePublisher,
 	);
 
-// A `RelationStore` where exactly `mods` hold the `(moderates, platform)` tuple — the
-// authority model the recipient set is resolved from (never a hardcoded list).
+// Exactly `mods` hold the `(moderates, platform)` tuple — the authority model the recipient
+// set is resolved from, never a hardcoded list.
 const relationStoreOf = (mods: ReadonlyArray<string>): Layer.Layer<RelationStore> =>
 	Layer.succeed(RelationStore, {
 		has: () => Effect.die(new Error("mod-emitters resolve via subjectsOf, not has")),
@@ -77,7 +74,6 @@ const relationStoreOf = (mods: ReadonlyArray<string>): Layer.Layer<RelationStore
 			Effect.succeed(new Set(relation === "moderates" && object.type === "platform" ? mods : [])),
 	});
 
-// A `Divan` whose `pendingCountOf` answers a scripted count; the other reads die.
 const divanPending = (count: number): Layer.Layer<Divan> =>
 	Layer.succeed(Divan, {
 		roster: () => Effect.die(new Error("Divan.roster not exercised")),
@@ -109,7 +105,6 @@ describe("modRecipients — moderator resolution + actor self-suppression, pure"
 	});
 });
 
-// A `Notification` whose `recordDigest` captures the digest calls (input + window).
 const capturingDigest = () => {
 	const calls: Array<{input: NotificationDigestInput; window: Duration.Duration}> = [];
 	const layer = makeNotificationStub({
@@ -122,12 +117,9 @@ const capturingDigest = () => {
 	return {calls, layer};
 };
 
-/**
- * An in-memory `Notification` whose `recordDigest` mirrors the SQL key (#3641): bump the
- * recipient's page for `(kind, actor)` when one was minted inside the window, else mint a
- * fresh one. The clock is scripted, so the window boundary is decidable with no engine
- * (ADR 0082 T1/T2) — this is what makes "many reports → bounded pages" observable here.
- */
+// Mirrors the SQL key (#3641): bump the recipient's page for `(kind, actor)` when one was
+// minted inside the window, else mint a fresh one. The clock is scripted, so the window
+// boundary is decidable with no engine.
 const digestingNotification = (clock: {now: Date}) => {
 	const pages: Array<{
 		recipientId: string;
@@ -283,8 +275,8 @@ describe("notifyReportFiled — per-reporter/window coalescing (the mod-pager fa
 		Effect.gen(function* () {
 			const clock = {now: new Date("2026-07-22T10:00:00Z")};
 			const {pages, layer} = digestingNotification(clock);
-			// Eight reports, a minute apart, across eight DISTINCT targets — the
-			// amplification shape: un-coalesced this is 16 rows on a two-person team.
+			// Eight reports a minute apart across eight DISTINCT targets — un-coalesced this is 16
+			// rows on a two-person team.
 			for (let i = 0; i < 8; i++) {
 				clock.now = new Date(clock.now.getTime() + 60_000);
 				yield* fileReport("u-spammer", `p${i}`, layer);
@@ -297,7 +289,6 @@ describe("notifyReportFiled — per-reporter/window coalescing (the mod-pager fa
 				pages.map((page) => page.count),
 				[8, 8],
 			);
-			// Each page still links to the window's FIRST reported target.
 			assert.deepStrictEqual(
 				pages.map((page) => page.targetId),
 				["p0", "p0"],

--- a/apps/web/worker/features/bildirim/mutations.ts
+++ b/apps/web/worker/features/bildirim/mutations.ts
@@ -1,15 +1,11 @@
 /**
- * bildirim mutation resolvers (#1694):
+ * bildirim mutation resolvers. Recipient scoping lives in the service predicate
+ * (`WHERE id AND recipient_id AND read_at IS NULL`), so a foreign or unknown id is a
+ * `marked: 0` no-op ack — never an existence oracle, never someone else's row.
  *
- * - `bildirim.markRead` — flip ONE notification read. Recipient scoping lives in
- *   the service predicate (`WHERE id AND recipient_id AND read_at IS NULL`), so a
- *   foreign or unknown id is a `marked: 0` no-op ack — never an existence oracle,
- *   never someone else's row.
- * - `bildirim.markAllRead` — flip every unread notification of the caller.
- *
- * Both are flag-gated ({@link requireBildirimOn}) and `CurrentUser.required`;
- * each ack carries the post-write unread count so the badge settles in the same
- * round-trip. See `.patterns/fate-effect-operations.md`.
+ * Both are flag-gated and `CurrentUser.required`; each ack carries the post-write unread
+ * count so the badge settles in the same round-trip. See
+ * `.patterns/fate-effect-operations.md`.
  */
 import {CurrentUser, Fate, Unauthorized} from "@kampus/fate-effect";
 import {Effect} from "effect";

--- a/apps/web/worker/features/bildirim/mute-suppression.ts
+++ b/apps/web/worker/features/bildirim/mute-suppression.ts
@@ -1,16 +1,10 @@
 /**
  * Bildirim mute-suppression (#3238) — the notification analogue of the content
- * read-mask (`../mute/read-mask.ts`). ADR 0188 ruled v1 mute (sustur) suppresses the
- * bildirim a muted member's interactions would raise to the muter, not merely a
- * content read-mask; this is the seam the interaction emitters consult before they
- * record.
+ * read-mask. See ADR 0188 for why v1 mute suppresses notifications, not just reads.
  *
- * Generation-time, not read-time: the anti-hype vote aggregate stores `actorId: null`
- * (see `vote-emitters.ts` / `rite-emitters.ts`), so the interacting member's identity
- * survives ONLY at emit time — a read-time filter on `notification.actor_id` could
- * never suppress an aggregated vote. The seam is therefore a per-emit predicate keyed
- * on (recipient = the muter, actor = the interacting member): suppress iff the
- * recipient has muted the actor.
+ * Generation-time, NOT read-time: the anti-hype vote aggregate stores `actorId: null`,
+ * so the interacting member's identity survives only at emit time and a read-time
+ * filter on `notification.actor_id` could never suppress an aggregated vote.
  */
 import type {CurrentUser} from "@kampus/fate-effect";
 import type {RuntimeContext} from "alchemy";
@@ -21,15 +15,11 @@ import {provideRequestFlags, type RequestFlagOverrides} from "../flagship/FlagsC
 import {Mute} from "../mute/Mute.ts";
 
 /**
- * True iff a bildirim to `recipientId` about `actorId`'s interaction must be
- * suppressed — the recipient (muter) has muted the actor. A null/absent actor is a
- * system moment with no interacting member (a `terfi`/`caylak-pending` emit), so
- * nothing to suppress, resolved before any flag or DB read. Gated behind the
- * default-off `member-mute` flag the read-mask also uses (safe default `false`: an
- * unflipped default or a Flagship outage both read off) ⇒ `false` ⇒ unchanged
- * delivery. Viewer-scoped through `Mute.readMutedIds(recipientId)` — the muter IS the
- * recipient — the same set the content read-mask reads from, no divergent muted-id
- * source.
+ * A null actor is a system moment with nothing to suppress, resolved before any flag
+ * or DB read. Gated behind the default-off `member-mute` flag, whose safe default
+ * `false` covers both an unflipped flag and a Flagship outage. The muted set is read
+ * through `Mute.readMutedIds(recipientId)` — the same source the content read-mask
+ * uses, never a second one.
  */
 export const bildirimMutedBy = (
 	recipientId: string,

--- a/apps/web/worker/features/bildirim/mute-suppression.unit.test.ts
+++ b/apps/web/worker/features/bildirim/mute-suppression.unit.test.ts
@@ -1,14 +1,8 @@
 /**
- * Bildirim mute-suppression seam (#3238, ADR 0188) — the decisions that are
- * wrong-or-right with no database (ADR 0082 T1/T2): the flag gate (default-off ⇒ no
- * suppression), the null-actor short-circuit (a system moment suppresses nobody), and
- * the viewer-scoped membership test (`recipient` = the muter, suppress iff the
- * recipient muted the actor). Row-level EXCLUSION against real D1 (a muted member's
- * interaction actually raising no bildirim end-to-end) is the integration tier's job,
- * like the content read-mask.
- *
- * The `Mute` stub either returns a fixed set or DIES on contact, so a path that must
- * short-circuit before the read (null actor / flag off) proves it never reaches `Mute`.
+ * Bildirim mute-suppression seam (#3238, ADR 0188) with no database (ADR 0082): the flag gate,
+ * the null-actor short-circuit, and the viewer-scoped membership test (`recipient` = the muter,
+ * suppress iff the recipient muted the actor). Row-level EXCLUSION against real D1 is the
+ * integration tier's job, like the content read-mask.
  */
 import {assert, describe, it} from "@effect/vitest";
 import {CurrentUser} from "@kampus/fate-effect";
@@ -35,8 +29,8 @@ const flagsStub = (on: boolean): Layer.Layer<Flags> =>
 		getObject: () => Effect.die("getObject not exercised"),
 	} as typeof Flags.Service);
 
-// A `Mute` whose `readMutedIds` returns a fixed set — or dies on contact, proving a
-// path that must short-circuit before the read (null actor / flag off) never reaches it.
+// `readMutedIds` returns a fixed set — or dies on contact, so a path that must short-circuit
+// before the read proves it never reaches `Mute`.
 const muteStub = (
 	readMutedIds?: (viewerId: string | null | undefined) => Effect.Effect<Set<string>>,
 ) =>

--- a/apps/web/worker/features/bildirim/queries.ts
+++ b/apps/web/worker/features/bildirim/queries.ts
@@ -1,9 +1,7 @@
 /**
- * `bildirim.unreadCount` — the topbar badge's read: the current user's unread
- * count as the `NotificationUnread` synthetic singleton (`id: "unread"`, the
- * `funnel.summary` idiom — the wire type is the NAME string, so the entity stays
- * off the source-completeness fetch path). Flag-gated; signed-out reads a
- * well-formed 0, never an error — the badge simply doesn't render.
+ * `bildirim.unreadCount` — the topbar badge's read, as the `NotificationUnread` synthetic
+ * singleton (the wire type is the NAME string, so the entity stays off the source-completeness
+ * fetch path). Flag-gated; signed-out reads a well-formed 0, never an error.
  */
 import {CurrentUser, Fate, Unauthorized} from "@kampus/fate-effect";
 import {Effect} from "effect";
@@ -25,11 +23,8 @@ export const queries = {
 		}),
 	),
 
-	// The current user's live notification channel (#1700): the `NotificationChannel`
-	// entity keyed by the user's id, carrying the unread count the topbar badge +
-	// center subscribe to over `/fate/live`. Recording a notification republishes
-	// this entity (`Notification.publishChannel`), so a subscribed client reconciles
-	// without a refresh. Flag-gated; signed-out is `Denied` (the badge doesn't render).
+	// The current user's live channel (#1700): recording a notification republishes this entity
+	// (`Notification.publishChannel`), so a subscribed client reconciles without a refresh.
 	"bildirim.channel": Fate.query(
 		{type: "NotificationChannel", error: Schema.Union([Unauthorized, Denied])},
 		Effect.fn("bildirim.channel")(function* () {

--- a/apps/web/worker/features/bildirim/rite-emitters.ts
+++ b/apps/web/worker/features/bildirim/rite-emitters.ts
@@ -1,27 +1,12 @@
 /**
- * Rite-feedback emitters (#1695/#1696, epic #1666) — the silent rite moments made
- * audible through the spine's {@link Notification} write surface:
+ * Rite-feedback emitters (#1695/#1696) — the silent rite moments made audible
+ * through the spine's {@link Notification} write surface.
  *
- *  - **divan vote** — a divan vote on a çaylak's sandboxed item notifies the
- *    item's author, AGGREGATED per item (`recordAggregate`): repeat votes bump
- *    one unread row's count, never one row per vote (the anti-hype voice). The
- *    aggregate carries no `actor_id` — no per-voter identity drip.
- *  - **kefil** — a recorded vouch notifies the vouched çaylak (one row per
- *    distinct vouch act; an idempotent re-vouch is the caller's `alreadyVouched`
- *    and never reaches here).
- *  - **terfi (promotion)** — the çaylak→yazar tier flip notifies the promoted
- *    member: the single most ceremonial moment in the rite (#1696). Keyed by the
- *    caller on `promoteToYazar`'s `promoted: true`, so a no-op re-promotion
- *    notifies nothing — idempotent by construction. Fired from BOTH promotion
- *    sites (mod-direct and the tandem sweep), the two `promoteToYazar` call sites.
- *
- * Both emitters ride AFTER the committed mutation and can never fail it: the
- * whole effect — flag read included — is swallowed-with-log (`catchCause`, the
- * ADR 0039 fire-and-forget posture; the `persistPanoStats` idiom), which also
- * absorbs the `orDieAccess` DEFECTS a D1 hiccup raises, not just typed errors.
- * Writes are gated on the spine's `phoenix-bildirim` flag (dark by default, one
- * flag for the whole bildirim surface — no per-child flags), and an actor is
- * never notified about their own action ({@link riteRecipient}).
+ * Every emitter rides AFTER the committed mutation and can never fail it: the whole
+ * effect, flag read included, is swallowed with a log (ADR 0039's fire-and-forget
+ * posture), which absorbs the defects a D1 hiccup raises as well as typed errors.
+ * Writes are gated on the one `phoenix-bildirim` flag, and an actor is never notified
+ * about their own action.
  */
 import {Effect} from "effect";
 import type {TargetKind} from "../../db/target-kind.ts";
@@ -34,16 +19,17 @@ export const DIVAN_VOTE_KIND: NotificationKind = "divan-vote";
 export const KEFIL_KIND: NotificationKind = "kefil";
 export const PROMOTION_KIND: NotificationKind = "terfi";
 
-/** Self-suppression, pure: the recipient, or `null` when they ARE the actor. */
+// Self-suppression: `null` when the recipient IS the actor.
 export const riteRecipient = (recipientId: string, actorId: string): string | null =>
 	recipientId === actorId ? null : recipientId;
 
 const swallow = (label: string) =>
 	Effect.catchCause((cause) => Effect.logWarning(`bildirim: ${label} emit swallowed`, cause));
 
-/** Notify a sandboxed item's author of a landed divan vote (aggregated per item). */
+// Aggregated per item, so repeat votes bump one unread row's count instead of dripping
+// one row (and one voter's identity) per vote.
 export const notifyDivanVote = (input: {
-	/** Server-derived item author (`VoteResult.authorId`), never client-supplied. */
+	// Server-derived, never client-supplied.
 	authorId: string;
 	actorId: string;
 	targetKind: TargetKind;
@@ -53,8 +39,8 @@ export const notifyDivanVote = (input: {
 		const recipientId = riteRecipient(input.authorId, input.actorId);
 		if (recipientId === null) return;
 		if (!(yield* bildirimOn)) return;
-		// The aggregate stores `actorId: null`, so the muted check keys on the real
-		// interacting divan voter (`actorId`), the identity that survives only here.
+		// The aggregate stores `actorId: null`, so the mute check has to key on the real
+		// voter here — this is the only place that identity survives.
 		if (yield* bildirimMutedBy(recipientId, input.actorId)) return;
 		const bildirim = yield* Notification;
 		yield* bildirim.recordAggregate({
@@ -66,7 +52,6 @@ export const notifyDivanVote = (input: {
 		});
 	}).pipe(swallow(DIVAN_VOTE_KIND));
 
-/** Notify the vouched çaylak that a yazar vouched for them. */
 export const notifyKefil = (input: {candidateId: string; voucherId: string}) =>
 	Effect.gen(function* () {
 		const recipientId = riteRecipient(input.candidateId, input.voucherId);
@@ -83,13 +68,8 @@ export const notifyKefil = (input: {candidateId: string; voucherId: string}) =>
 		});
 	}).pipe(swallow(KEFIL_KIND));
 
-/**
- * Notify the freshly-promoted member that they crossed çaylak → yazar. No
- * self-suppression question: promotion is a standing the member EARNED, not an
- * act another user did TO them — the recipient IS the subject, `actorId` is null
- * (a ceremonial system event, not a per-actor drip). The target is the member's
- * own account, so the row links to the profile where the new yazar tier shows.
- */
+// No self-suppression here: promotion is a standing the member earned, not something
+// another user did to them, so the recipient is the subject and `actorId` is null.
 export const notifyPromotion = (input: {userId: string}) =>
 	Effect.gen(function* () {
 		if (!(yield* bildirimOn)) return;

--- a/apps/web/worker/features/bildirim/rite-emitters.unit.test.ts
+++ b/apps/web/worker/features/bildirim/rite-emitters.unit.test.ts
@@ -1,11 +1,7 @@
 /**
- * Rite-feedback emitter coverage (#1695) — the decisions that are wrong-or-right
- * with no database (ADR 0082 T1/T2; `.patterns/effect-testing.md`): recipient
- * resolution / self-suppression, the flag containment (dark by default), the
- * aggregate-vs-plain write routing, and the swallow-at-the-seam guarantee — a
- * DYING `Notification` (the `orDieAccess` defect shape) cannot fail the caller.
- * The `Notification` seam is the fail-on-contact stub with only the expected
- * method overridden, so "touched the wrong write surface" is a test failure.
+ * Rite-feedback emitter coverage — the decisions that are wrong-or-right with no
+ * database (ADR 0082 T1/T2). The `Notification` seam is a fail-on-contact stub with
+ * only the expected method overridden, so "touched the wrong write surface" fails.
  */
 import {assert, describe, it} from "@effect/vitest";
 import {CurrentUser, LivePublisher} from "@kampus/fate-effect";
@@ -46,11 +42,8 @@ const flagsStub = (on: boolean): Layer.Layer<Flags> =>
 		} as unknown as typeof Flags.Service,
 	);
 
-// A no-op `LivePublisher`: the emitters call `Notification.record`, which yields the
-// per-request publisher for the fire-and-forget live fan-out (#1700). The emit path is
-// swallowed and the stub `record` never touches it, so a do-nothing publisher satisfies
-// the requirement without asserting anything on it (the live publish itself is covered
-// in `Notification.unit.test.ts` / the integration tier).
+// The stub `record` never publishes, so a do-nothing publisher just satisfies the
+// requirement; the live publish itself is covered in `Notification.unit.test.ts`.
 const noopLivePublisher = Layer.succeed(LivePublisher)({
 	update: () => Effect.void,
 	delete: () => Effect.void,
@@ -59,9 +52,8 @@ const noopLivePublisher = Layer.succeed(LivePublisher)({
 	},
 } as typeof LivePublisher.Service);
 
-// A `Mute` returning no mutes: the divan-vote/kefil emitters now consult `bildirimMutedBy`,
-// which reads `readMutedIds` — an empty set means no member is muted, so these cases exercise
-// the unchanged (deliver) path. Muted-suppression itself is covered in mute-suppression.unit.test.ts.
+// An empty mute set puts every case here on the deliver path; muted-suppression is
+// covered in mute-suppression.unit.test.ts.
 const noMutes = Layer.succeed(Mute, {
 	set: () => Effect.die("Mute.set not exercised"),
 	listMine: () => Effect.die("Mute.listMine not exercised"),
@@ -143,7 +135,7 @@ describe("notifyDivanVote — the aggregated divan-vote emit", () => {
 		() =>
 			Effect.gen(function* () {
 				// The default stub DIES on contact — the exact defect shape `orDieAccess`
-				// raises on a D1 failure. The emitter must swallow it, not surface it.
+				// raises on a D1 failure.
 				const exit = yield* notifyDivanVote({
 					authorId: "u-author",
 					actorId: "u-voter",

--- a/apps/web/worker/features/bildirim/shapers.ts
+++ b/apps/web/worker/features/bildirim/shapers.ts
@@ -1,8 +1,6 @@
 /**
- * bildirim wire-entity shapers — the one spelling of each `{__typename, …}`
- * literal (the report-shaper idiom): every bildirim entity is returned inline
- * (list resolver / mutation ack), so the interpreter never stamps `__typename`;
- * these do. See `.patterns/fate-effect-operations.md`.
+ * Every bildirim entity is returned inline, so the interpreter never stamps `__typename`
+ * — these do, and they are its one spelling (`.patterns/fate-effect-operations.md`).
  */
 import type {NotificationRow} from "./Notification.ts";
 import type {

--- a/apps/web/worker/features/bildirim/sources.ts
+++ b/apps/web/worker/features/bildirim/sources.ts
@@ -1,18 +1,12 @@
 /**
- * bildirim fate sources — every bildirim entity is delivered inline
- * (`Notification` by the `bildirim.list` resolver, `NotificationUnread` by the
- * `bildirim.unreadCount` query, `NotificationMarkReceipt` by the mark mutations,
- * `NotificationChannel` by the `bildirim.channel` query + reconciled live over
- * `/fate/live`) and never read by id, so all are capability-less
- * `Fate.syntheticSource` entries — view-reachable, no fetch path (the `ReportReceipt`
- * escape hatch, `.patterns/fate-effect-sources.md`).
+ * Every bildirim entity is delivered inline by a resolver and never read by id, so
+ * all of them are capability-less synthetic sources: view-reachable, with no fetch
+ * path (see .patterns/fate-effect-sources.md).
  *
  * `NotificationChannel` stays loader-less on purpose: its id IS the recipient's user
- * id, so a `byId(userId)` loader would be a cross-user read path bypassing the
- * recipient-scoped `/fate/live` gate. The client must therefore NEVER issue a `byId`
- * for it — it seeds the ref from the `bildirim.channel` query and subscribes live
- * (`useBildirimUnread`, `BildirimList`); an ungated `readView` on a cache miss fetches a
- * `byId` that 500s through the capability-less arm (#2206).
+ * id, so a `byId(userId)` loader would be a cross-user read path around the
+ * recipient-scoped live gate. The client must therefore never issue a `byId` for it —
+ * an ungated `readView` on a cache miss fetches one and 500s (#2206).
  */
 import {Fate} from "@kampus/fate-effect";
 import {

--- a/apps/web/worker/features/bildirim/target.ts
+++ b/apps/web/worker/features/bildirim/target.ts
@@ -1,17 +1,8 @@
 /**
- * The bildirim **target taxonomy** (#1694, epic #1666) — what a notification can
- * point at: the three content kinds Vote/Report already span ({@link TARGET_KINDS})
- * plus `user` (a promotion/mod notification targets an account, not a content row).
- * `NOTIFICATION_TARGET_KINDS` is the one runtime tuple the `notification.target_kind`
- * D1 enum sources from, the `TARGET_KINDS` idiom — a typo can't compile and write a
- * corrupt row.
- *
- * The pure target→href core lives here too: {@link foldTargetHrefs} decides, per
- * notification target, the client link (`/pano/…`, `/sozluk/…`, `/u/…`) or `null` —
- * the **tombstone**: a target that no longer resolves (removed content, deleted /
- * unbootstrapped account) renders as a dead row, never a broken link. The DB reads
- * that produce the resolved rows stay in the `Notification` service as the port;
- * this fold is the decision, callable with no engine (ADR 0082 T1/T2).
+ * The bildirim target taxonomy (#1694) — the three content kinds plus `user`.
+ * `NOTIFICATION_TARGET_KINDS` is the one runtime tuple the `notification.target_kind` D1
+ * enum sources from, so a typo can't compile and write a corrupt row. A target that no
+ * longer resolves folds to `null` — a dead row, never a broken link.
  */
 import * as Schema from "effect/Schema";
 import {TARGET_KINDS} from "../../db/target-kind.ts";
@@ -22,20 +13,14 @@ export type NotificationTargetKind = (typeof NOTIFICATION_TARGET_KINDS)[number];
 
 export const NotificationTargetKindSchema = Schema.Literals(NOTIFICATION_TARGET_KINDS);
 
-/** One notification's target reference — the `(kind, id)` pair the fold resolves. */
 export interface TargetRef {
 	readonly targetKind: NotificationTargetKind;
 	readonly targetId: string;
 }
 
-/** The map key for a resolved target — `<kind>:<id>`, the `ReportReceipt` id idiom. */
 export const targetRefKey = (kind: NotificationTargetKind, id: string): string => `${kind}:${id}`;
 
-/**
- * The live rows the service's per-kind batch reads produced — only targets that
- * still resolve (`removed_at IS NULL` for content, `deleted_at IS NULL` for users)
- * appear here. A ref absent from its kind's rows is a tombstone.
- */
+/** Only targets that still resolve appear here; a ref absent from its kind's rows is a tombstone. */
 export interface ResolvedTargetRows {
 	readonly post: ReadonlyArray<{id: string}>;
 	readonly comment: ReadonlyArray<{id: string; postId: string}>;
@@ -51,10 +36,8 @@ export const emptyResolvedTargetRows: ResolvedTargetRows = {
 };
 
 /**
- * Resolve every ref to its client href, or `null` (tombstone). A comment links to
- * its post's detail page (a comment has no page of its own); a user without a
- * username (pre-bootstrap) has no profile URL yet, so it tombstones rather than
- * emitting a broken `/u/null`.
+ * A comment links to its post's detail page (it has no page of its own); a pre-bootstrap
+ * user has no username yet, so it tombstones rather than emitting a broken `/u/null`.
  */
 export const foldTargetHrefs = (
 	refs: ReadonlyArray<TargetRef>,

--- a/apps/web/worker/features/bildirim/target.unit.test.ts
+++ b/apps/web/worker/features/bildirim/target.unit.test.ts
@@ -1,8 +1,6 @@
 /**
- * The bildirim target→href fold (#1694) — the tombstone decision asserted with no
- * engine (ADR 0082 T1/T2): a live target maps to its client link, a target absent
- * from the resolved rows (removed / deleted) maps to `null`, and a pre-bootstrap
- * user (no username) tombstones rather than emitting a broken `/u/null`.
+ * The bildirim target→href fold (#1694): a target absent from the resolved rows, or a
+ * pre-bootstrap user with no username, must tombstone rather than emit a broken link.
  */
 import {assert, describe, it} from "@effect/vitest";
 import {emptyResolvedTargetRows, foldTargetHrefs, targetRefKey} from "./target.ts";

--- a/apps/web/worker/features/bildirim/views.ts
+++ b/apps/web/worker/features/bildirim/views.ts
@@ -1,10 +1,8 @@
 /**
- * bildirim data views (#1694). `Notification` is delivered inline by the
- * `bildirim.list` resolver (which stamps `targetUrl` — the server-resolved
- * client link, `null` = tombstone); `NotificationUnread` is a synthetic
- * singleton (`id: "unread"`, the `FunnelSummary` idiom); `NotificationMarkReceipt`
- * is the mark-read ack carrying the fresh unread count so the badge updates on
- * the same round-trip. None is read by id. See `.patterns/fate-effect-data-views.md`.
+ * bildirim data views (#1694). `NotificationUnread` is a synthetic singleton
+ * (`id: "unread"`, the `FunnelSummary` idiom) and `NotificationMarkReceipt` is the
+ * mark-read ack carrying the fresh unread count, so the badge updates on the same
+ * round-trip. None is read by id. See `.patterns/fate-effect-data-views.md`.
  */
 import {FateDataView, type WorkerEntity} from "@kampus/fate-effect";
 import type {ViewRow} from "../fate/view-types.ts";
@@ -20,7 +18,6 @@ export type NotificationViewRow = ViewRow<{
 	actorId: string | null;
 	/** Aggregate count (#1698); 1 for a plain notification. */
 	count: number;
-	/** ISO stamp when read, `null` while unread. */
 	readAt: string | null;
 	createdAt: string;
 }>;
@@ -60,19 +57,14 @@ export type NotificationUnread = WorkerEntity<typeof NotificationUnreadView>;
 export type NotificationChannelViewRow = ViewRow<{
 	/** The recipient's user id — the per-recipient live topic key (#1700). */
 	id: string;
-	/** The recipient's live unread count, republished on every recorded notification. */
 	unreadCount: number;
 }>;
 
 /**
- * `NotificationChannel` — the per-recipient live entity (#1700, epic #1666). Keyed
- * by the recipient's user id, it carries the live unread count the topbar badge +
- * center reconcile to over `/fate/live`: `Notification.record`/`recordAggregate`
- * republishes `live.update("NotificationChannel", recipientId, …)` after the write,
- * so a subscribed client's badge moves without a refresh. The entity topic is
- * recipient-scoped by construction — the id IS the recipient — and the subscribe
- * route rejects an entity subscription whose id is not the session user's own
- * (route.ts), so a user cannot watch another user's channel.
+ * `NotificationChannel` — the per-recipient live entity (#1700). Keyed by the
+ * recipient's user id, so the entity topic is recipient-scoped by construction; the
+ * subscribe route additionally rejects an entity subscription whose id is not the
+ * session user's own, so nobody can watch another user's channel.
  */
 export class NotificationChannelView extends FateDataView<NotificationChannelViewRow>()(
 	"NotificationChannel",
@@ -90,7 +82,6 @@ export type NotificationMarkReceiptViewRow = ViewRow<{
 	id: string;
 	/** How many rows flipped unread→read (0 = idempotent no-op). */
 	marked: number;
-	/** The recipient's unread count AFTER the write. */
 	unreadCount: number;
 }>;
 

--- a/apps/web/worker/features/bildirim/vote-emitters.ts
+++ b/apps/web/worker/features/bildirim/vote-emitters.ts
@@ -1,28 +1,12 @@
 /**
- * Live-content vote emitter (#1698, epic #1666) — the single most common event,
- * silent until now, made audible through the spine's {@link Notification} write
- * surface with the anti-hype aggregated voice:
+ * Live-content vote emitter, with the anti-hype aggregated voice: repeat votes bump ONE
+ * unread row's count ("3 yeni oy"), never a row per vote and never a per-voter drip
+ * (`actorId: null`). Deliberately a distinct kind from divan's `notifyDivanVote` sibling,
+ * because the two carry their own product voice.
  *
- *  - **vote** — a landed upvote on a member's live pano post / pano comment /
- *    sözlük definition notifies the item's author, AGGREGATED per item
- *    (`recordAggregate`): repeat votes bump ONE unread row's count ("3 yeni oy"),
- *    never one row per vote and never a per-voter identity drip (`actorId: null`).
- *    After the recipient reads the aggregate, subsequent votes surface as a fresh
- *    unread row (`insertUnlessUnreadStatement` mints one only when no unread row
- *    exists — read history is never rewritten). Self-votes never notify
- *    ({@link voteRecipient}), and a retraction stays silent — the aggregate is
- *    "attention received", not a live score.
- *
- * This is divan's `notifyDivanVote` sibling with the SAME aggregation rule, kept a
- * distinct `vote` kind (not `divan-vote`) because it is the LIVE-content surface:
- * the two carry their own product voice. Divan votes stay out of scope here
- * (covered by the rite-feedback sibling).
- *
- * The emit rides AFTER the committed cast and can never fail it: the whole effect —
- * flag read included — is swallowed-with-log (`catchCause`, the ADR 0039
- * fire-and-forget posture; the rite-emitters idiom), which also absorbs the
- * `orDieAccess` DEFECTS a D1 hiccup raises, not just typed errors. The write is
- * gated on the spine's `phoenix-bildirim` flag (dark by default).
+ * The emit rides after an already-committed cast, so the whole effect — the flag read
+ * included — is swallowed-with-log via `catchCause`, which also absorbs the DEFECTS a D1
+ * hiccup raises, not just typed errors.
  */
 import {Effect} from "effect";
 import type {TargetKind} from "../../db/target-kind.ts";
@@ -41,9 +25,8 @@ const swallow = (label: string) =>
 	Effect.catchCause((cause) => Effect.logWarning(`bildirim: ${label} emit swallowed`, cause));
 
 /**
- * Notify a live item's author of a landed vote, aggregated per item. The caller
- * fires this ONLY on a cast that changed state (`value && result.changed`), so a
- * retraction and an idempotent no-op stay silent.
+ * The caller fires this ONLY on a cast that changed state, so a retraction and an
+ * idempotent no-op stay silent.
  */
 export const notifyContentVote = (input: {
 	/** Server-derived item author (`VoteResult.authorId`), never client-supplied. */

--- a/apps/web/worker/features/bildirim/vote-emitters.unit.test.ts
+++ b/apps/web/worker/features/bildirim/vote-emitters.unit.test.ts
@@ -1,12 +1,9 @@
 /**
- * Vote-emitter coverage (#1698) — the decisions that are wrong-or-right with no
- * database (ADR 0082 T1/T2; `.patterns/effect-testing.md`): recipient resolution /
- * self-suppression, the flag containment (dark by default), the aggregate write
- * routing ("N yeni oy", never one-per-vote), and the swallow-at-the-seam guarantee —
- * a DYING `Notification` (the `orDieAccess` defect shape) cannot fail the caller.
- * The `Notification` seam is the fail-on-contact stub with only the expected method
- * overridden, so "touched the wrong write surface" (e.g. `record` instead of
- * `recordAggregate`) is a test failure.
+ * Vote-emitter coverage — the decisions that are wrong-or-right with no database: recipient
+ * resolution / self-suppression, the flag containment (dark by default), the aggregate write
+ * routing ("N yeni oy", never one-per-vote), and the swallow-at-the-seam guarantee — a DYING
+ * `Notification` cannot fail the caller. The `Notification` seam is a fail-on-contact stub
+ * with only the expected method overridden, so touching the wrong write surface fails.
  */
 import {assert, describe, it} from "@effect/vitest";
 import {CurrentUser, LivePublisher} from "@kampus/fate-effect";
@@ -39,11 +36,8 @@ const flagsStub = (on: boolean): Layer.Layer<Flags> =>
 		} as unknown as typeof Flags.Service,
 	);
 
-// A no-op `LivePublisher`: `Notification.record`/`recordAggregate` yield the
-// per-request publisher for the fire-and-forget live fan-out (#1700, PR #2076). The
-// `Notification` seam is a stub here, so a do-nothing publisher satisfies the
-// requirement without asserting on it (the live publish is covered at the spine /
-// integration tier). Mirrors the rite-emitters test context.
+// A no-op `LivePublisher`: the `Notification` seam is a stub here, so a do-nothing publisher
+// satisfies the requirement without asserting on it (the live publish is covered further up).
 const noopLivePublisher = Layer.succeed(LivePublisher)({
 	update: () => Effect.void,
 	delete: () => Effect.void,
@@ -52,9 +46,8 @@ const noopLivePublisher = Layer.succeed(LivePublisher)({
 	},
 } as typeof LivePublisher.Service);
 
-// A `Mute` returning no mutes: the emitters now consult `bildirimMutedBy`, which reads
-// `readMutedIds` — an empty set means no member is muted, so these cases exercise the
-// unchanged (deliver) path. Muted-suppression itself is covered in mute-suppression.unit.test.ts.
+// No mutes, so these cases exercise the unchanged deliver path. Muted-suppression itself is
+// covered in mute-suppression.unit.test.ts.
 const noMutes = Layer.succeed(Mute, {
 	set: () => Effect.die("Mute.set not exercised"),
 	listMine: () => Effect.die("Mute.listMine not exercised"),
@@ -131,8 +124,7 @@ describe("notifyContentVote — the aggregated live-content vote emit", () => {
 					targetId: "d1",
 				}).pipe(Effect.provide(Layer.mergeAll(stub, requestContext(true))));
 			}
-			// three votes → three emits, all carrying the SAME (recipient, kind, target)
-			// aggregate key with no per-voter identity — the spine rolls them into one row.
+			// Three votes → three emits on the SAME aggregate key with no per-voter identity.
 			assert.strictEqual(calls.length, 3);
 			for (const c of calls) {
 				assert.deepStrictEqual(c, {
@@ -192,9 +184,8 @@ describe("notifyContentVote — the aggregated live-content vote emit", () => {
 		"a DYING notification write is swallowed — the vote caller still succeeds (the seam AC)",
 		() =>
 			Effect.gen(function* () {
-				// The default stub DIES on contact — the exact defect shape `orDieAccess`
-				// raises on a D1 failure. The emitter must swallow it, not surface it, so a
-				// notification hiccup can never fail the committed vote mutation (ADR 0039).
+				// The default stub DIES on contact — the defect shape `orDieAccess` raises on a D1
+				// failure. The emitter must swallow it, so a hiccup can't fail the committed mutation.
 				const exit = yield* notifyContentVote({
 					authorId: "u-author",
 					voterId: "u-voter",

--- a/apps/web/worker/features/divan/Divan.ts
+++ b/apps/web/worker/features/divan/Divan.ts
@@ -1,22 +1,11 @@
 /**
- * `Divan` — the gated read model behind the çaylak proving ground (#1287, epic
- * #1202). A DESTINATION over the shipped `sandboxBacklogWhere` read model (#1205):
- * it composes the existing `listSandboxed*` reads (Sözlük definitions, pano posts +
- * comments — each already filtered to still-sandboxed, not-removed via
- * `sandboxBacklogWhere`) and groups them by author so the divan's unit is the
+ * The read model behind the çaylak proving ground (#1287), composing the existing
+ * `listSandboxed*` reads and grouping them by author so the divan's unit is the
  * **person**, not loose items.
  *
- * It does NOT re-derive the predicate and does NOT touch `sandboxVisibleWhere` —
- * inline sözlük/pano reads stay `{mod, author}`. A yazar gains visibility into çaylak
- * work ONLY through this service, reached only past the {@link requireDivanAccess}
- * gate (enforced at the fate resolver). The service read itself is unconditional,
- * exactly like the `listSandboxed*` reads it builds on.
- *
- * Two reads:
- *   - {@link Divan.roster} — the pending-çaylak roster (grouped by author, per-kind
- *     counts) across ALL authors.
- *   - {@link Divan.backlogOf} — one çaylak's sandboxed backlog (the items, for the
- *     #1290 detail view), newest first.
+ * It must NOT re-derive the sandbox predicate or touch `sandboxVisibleWhere` — inline
+ * sözlük/pano reads stay `{mod, author}`. These reads are unconditional; the yazar gate
+ * (`requireDivanAccess`) is enforced at the fate resolver, not here.
  */
 import {Context, Effect, Layer} from "effect";
 import {UserId} from "../../lib/ids.ts";
@@ -31,16 +20,13 @@ const preview = (text: string | null | undefined): string => excerpt(text ?? "")
 export class Divan extends Context.Service<
 	Divan,
 	{
-		/** The pending-çaylak roster: every çaylak with ≥1 sandboxed, not-removed item. */
 		readonly roster: () => Effect.Effect<ReadonlyArray<DivanRosterRow>>;
-		/** One çaylak's sandboxed backlog (newest first) — the detail-view items. */
+		/** Newest first. */
 		readonly backlogOf: (authorId: UserId) => Effect.Effect<ReadonlyArray<DivanItem>>;
 		/**
-		 * How many still-pending (sandboxed, not-removed) items one author has across
-		 * all three kinds — the mod-notification transition gate (#1699): a create path
-		 * fires the "new çaylak awaiting review" page only when this count is exactly 1
-		 * right after a çaylak's item committed (their 0→1 entry onto the roster), so a
-		 * çaylak's second and later items don't re-page the team.
+		 * The mod-notification transition gate (#1699): a create path pages the team only
+		 * when this count is exactly 1 right after an item committed — the author's 0→1
+		 * entry onto the roster — so their later items don't re-page.
 		 */
 		// `authorId` stays unbranded `string` (unlike `backlogOf`'s `UserId`): the only
 		// caller is bildirim's `notifyCaylakEntersDivan` (`mod-emitters.ts`), which passes a
@@ -56,9 +42,6 @@ export const DivanLive = Layer.effect(Divan)(
 		const pano = yield* Pano;
 		const pasaport = yield* Pasaport;
 
-		// Fetch the three sandboxed backlogs (optionally one author's) and collapse the
-		// per-domain rows onto the normalized `DivanItem` shape. The `sandboxBacklogWhere`
-		// filter (sandboxed + not-removed) lives in the `listSandboxed*` reads, not here.
 		const collect = Effect.fn("Divan.collect")(function* (opts: {authorId?: string} = {}) {
 			const [definitions, posts, comments] = yield* Effect.all(
 				[
@@ -100,12 +83,9 @@ export const DivanLive = Layer.effect(Divan)(
 			return items;
 		});
 
-		// Join each grouped roster entry to its çaylak's identity (handle + karma) in ONE
-		// batched profile read — so the single `divan.roster` fate request carries every
-		// row's identity in-batch and the client fires NO per-row by-id `Profile` read
-		// (ADR 0021's no-waterfalls contract, #1423). A çaylak with no profile row (or no
-		// username yet) degrades to nulls + 0 karma; the client renders the "çaylak"
-		// fallback label.
+		// ONE batched profile read, so the client fires no per-row by-id `Profile` read
+		// (ADR 0021's no-waterfalls contract). A çaylak with no profile row degrades to
+		// nulls + 0 karma rather than dropping off the roster.
 		const roster = Effect.fn("Divan.roster")(function* () {
 			const entries = buildRoster(yield* collect());
 			const identities = yield* pasaport.getProfileIdentitiesByIds(entries.map((e) => e.authorId));

--- a/apps/web/worker/features/divan/Divan.unit.test.ts
+++ b/apps/web/worker/features/divan/Divan.unit.test.ts
@@ -1,14 +1,10 @@
 /**
- * The `Divan` read-model service (#1287) over stub Sözlük/Pano (ADR 0082 unit tier,
- * no DB). The stubs re-express the `listSandboxed*` contract — they return ONLY
- * sandboxed, not-removed rows, optionally scoped to one author — so the test proves
- * the divan, composing them, yields a person-grouped roster that excludes removed and
- * live content, and that `backlogOf` scopes to one çaylak newest-first.
+ * The `Divan` read-model service (#1287) over stub Sözlük/Pano. Removed-exclusion is
+ * the `sandboxBacklogWhere` predicate's job in the REAL reads; the stubs honor that
+ * contract and what is asserted here is that the divan reflects it faithfully.
  *
- * Removed-exclusion is the `sandboxBacklogWhere` predicate's job in the REAL reads
- * (it carries `removed_at IS NULL`); here the stub honors that contract and the test
- * asserts the divan faithfully reflects it. Each stub is the `definition-mutation`
- * `Proxy`-over-`Partial` idiom: scripted reads, every other method dies on contact.
+ * Each stub is the `Proxy`-over-`Partial` idiom: scripted reads, every other method
+ * dies on contact.
  */
 import {assert, describe, it} from "@effect/vitest";
 import {Effect, Layer} from "effect";
@@ -31,8 +27,6 @@ interface Raw {
 
 const at = (iso: string) => new Date(iso);
 
-// The `sandboxBacklogWhere` contract the real `listSandboxed*` reads enforce:
-// still-sandboxed, not-removed, optionally one author's backlog.
 const backlog = (rows: ReadonlyArray<Raw>, opts: {authorId?: string} = {}) =>
 	rows.filter(
 		(r) =>
@@ -114,16 +108,16 @@ const panoStub = (posts: ReadonlyArray<Raw>, comments: ReadonlyArray<Raw>): Laye
 		) as typeof Pano.Service,
 	);
 
-// The batched identity read the roster joins on: returns only the requested ids that
-// have a profile row, so an author absent here degrades to null handle + 0 karma.
+// Returns only requested ids that have a profile row, so an absent author degrades to
+// null handle + 0 karma.
 const pasaportStub = (identities: ReadonlyArray<ProfileIdentityRow>) =>
 	makePasaportStub({
 		getProfileIdentitiesByIds: (ids) =>
 			Effect.succeed(identities.filter((i) => ids.includes(i.userId))),
 	});
 
-// cyl-a has a full profile; cyl-b is deliberately ABSENT so the roster join exercises
-// the missing-profile degradation (null handle + 0 karma → the "çaylak" label client-side).
+// cyl-b is deliberately ABSENT, so the roster join exercises the missing-profile
+// degradation.
 const IDENTITIES: ReadonlyArray<ProfileIdentityRow> = [
 	{userId: "cyl-a", username: "ada", displayName: "Ada Lovelace", totalKarma: 7},
 ];
@@ -278,8 +272,7 @@ describe("Divan.backlogOf — one çaylak's sandboxed backlog, newest first", ()
 
 	it("excludes a removed item from the scoped backlog", () => {
 		const items = run(Effect.flatMap(Divan, (d) => d.backlogOf(UserId.make("cyl-b"))));
-		// cyl-b has c1 (06:00, sandboxed), c2 (07:00, REMOVED), d3 (03:00, sandboxed):
-		// the removed c2 is absent; the rest newest-first.
+		// The removed c2 must be absent; the rest newest-first.
 		assert.deepStrictEqual(
 			items.map((i) => i.id),
 			["c1", "d3"],
@@ -289,7 +282,7 @@ describe("Divan.backlogOf — one çaylak's sandboxed backlog, newest first", ()
 
 describe("Divan.pendingCountOf — the mod-notification 0→1 transition gate (#1699)", () => {
 	it("counts a çaylak's still-pending items across all kinds (removed & live excluded)", () => {
-		// cyl-a: d1 (sandboxed) + p1 (sandboxed) = 2; d2 (removed) and the yazar's live d4 excluded.
+		// d2 (removed) and the yazar's live d4 are excluded.
 		assert.strictEqual(run(Effect.flatMap(Divan, (d) => d.pendingCountOf("cyl-a"))), 2);
 	});
 

--- a/apps/web/worker/features/divan/divan-vote-mutation.unit.test.ts
+++ b/apps/web/worker/features/divan/divan-vote-mutation.unit.test.ts
@@ -1,16 +1,8 @@
 /**
- * `divan.vote` WIRE-boundary coverage (#1288, epic #1202) — the sandboxed-vote
- * eligibility decision driven through the real external interface (`resolveWire`: input
- * decode + the `encodeWireError` class→wire-code seam), so a denial's wire `code` is what a
- * client gets.
- *
- * The acceptance matrix: a yazar OR a mod (the divan audience) votes a sandboxed item and the
- * cast lands crediting the author; a çaylak / visitor / anonymous actor gets the invisible
- * `UNAUTHORIZED` and NEVER reaches the cast (the non-gated rejection — a compile-error gate,
- * not an `if`, ADR 0107). And the karma-side promotion trigger (#1289): a vote that crosses the bar
- * WITH an active vouch fires `resolveTandem` → the author is promoted; with no active vouch it
- * is not. The yazar/mod disjunction itself is `gate.unit.test.ts`; the score+karma batch is
- * `vote/Vote.unit.test.ts` and the integration tier; the tandem invariant is `tandem.unit.test.ts`.
+ * `divan.vote` WIRE-boundary coverage — the eligibility decision driven through
+ * `resolveWire`, so a denial's wire `code` is what a client actually gets. Neighbours:
+ * the yazar/mod disjunction is `gate.unit.test.ts`, the score+karma batch is
+ * `vote/Vote.unit.test.ts`, the tandem invariant is `tandem.unit.test.ts`.
  */
 import {assert, describe, it} from "@effect/vitest";
 import {
@@ -48,8 +40,7 @@ const runtimeContextStub: BaseRuntimeContext = {
 	set: (id) => Effect.succeed(id),
 };
 
-// The rite-feedback emitter (notifyDivanVote) reads the `phoenix-bildirim` flag, so
-// every case still provides a Flags service — on, so the bildirim deliver path runs.
+// On, so the bildirim deliver path runs in every case.
 const flagsOn: Layer.Layer<Flags> = Layer.succeed(
 	Flags,
 	// biome-ignore lint/plugin: a Flags test double — only getBoolean is exercised here.
@@ -84,12 +75,10 @@ const kunyeOf = (
 		rootOf: (id: string) => Effect.succeed(id),
 	});
 
-// `VouchLedger` answering `hasActiveFor` from a fixed set (the candidates with ≥1 active vouch).
 const vouchActiveFor = (active: ReadonlyArray<string>): Layer.Layer<VouchLedger> =>
 	makeVouchLedgerStub({hasActiveFor: (id: string) => Effect.succeed(active.includes(id))});
 
-// A `Pasaport` whose `promoteToYazar` RECORDS each promoted userId (every other method fails on
-// contact), so "a vote crossed the bar with an active vouch → the çaylak is promoted" is observable.
+// Records each promoted userId, so the tandem promotion is observable.
 const pasaportRecording = (): {layer: Layer.Layer<Pasaport>; promoted: string[]} => {
 	const promoted: string[] = [];
 	const layer = makePasaportStub({
@@ -112,9 +101,7 @@ const pasaportRecording = (): {layer: Layer.Layer<Pasaport>; promoted: string[]}
 	return {layer, promoted};
 };
 
-// A `Vote` whose `castOnSandboxed` RECORDS each cast and returns a receipt naming the (server-
-// derived) `authorId` it credited; every other method fails on contact. The recorded `userId`
-// proves WHO voted and that the gate passed before any write.
+// The recorded `userId` proves WHO voted and that the gate passed before any write.
 const voteStubOf = (casts: VoteInput[], authorId = "u-author"): Layer.Layer<Vote> =>
 	Layer.succeed(Vote, {
 		cast: () => Effect.die(new Error("divan.vote must use castOnSandboxed, not cast")),
@@ -133,8 +120,6 @@ const voteStubOf = (casts: VoteInput[], authorId = "u-author"): Layer.Layer<Vote
 		clearTarget: () => Effect.die(new Error("unused")),
 	});
 
-// A `Notification` whose `recordAggregate` RECORDS each emit (every other method fails on
-// contact), so "a landed divan vote notifies the item's author, aggregated" is observable (#1695).
 const notificationRecording = (): {
 	layer: ReturnType<typeof makeNotificationStub>;
 	emits: NotificationAggregateInput[];
@@ -149,7 +134,7 @@ const notificationRecording = (): {
 	return {layer, emits};
 };
 
-// A Vote that DIES if any cast is attempted — proves a denied path never reaches the write.
+// Dies if any cast is attempted, which is how a denied path proves it never wrote.
 const voteFailOnContact: Layer.Layer<Vote> = Layer.succeed(Vote, {
 	cast: () => Effect.die(new Error("no cast on a denied path")),
 	castOnSandboxed: () => Effect.die(new Error("a non-divan actor must never reach the cast")),
@@ -157,13 +142,8 @@ const voteFailOnContact: Layer.Layer<Vote> = Layer.succeed(Vote, {
 	clearTarget: () => Effect.die(new Error("unused")),
 });
 
-// `divan.vote` fires `resolveTandem`, which reaches the #1886 live-publish on a
-// landed flip — so `LivePublisher` is a static requirement of every case (even a
-// denial). `noopLive` satisfies it universally; the case that actually promotes
-// asserts on nothing published, and the tandem-promote case builds its own record.
-// The divan-vote emit now consults `bildirimMutedBy` (#3238), which reads `Mute` — an
-// empty-set stub means no member is muted, so these cases exercise the deliver path
-// unchanged. Muted-suppression is covered in bildirim/mute-suppression.unit.test.ts.
+// No member is muted, so these cases exercise the deliver path. Muted-suppression is
+// covered in bildirim/mute-suppression.unit.test.ts.
 const noMutes = Layer.succeed(Mute, {
 	set: () => Effect.die("Mute.set not exercised"),
 	listMine: () => Effect.die("Mute.listMine not exercised"),
@@ -177,7 +157,6 @@ const requestContext = (actor: Actor) =>
 		Layer.provideMerge(Layer.succeed(RuntimeContext, runtimeContextStub)),
 	);
 
-// The signed-in id the voter casts under (anonymous → empty, never reaches the cast anyway).
 function actorId(actor: Actor): string {
 	return actor._tag === "Authenticated" && actor.principal._tag === "Human"
 		? actor.principal.id
@@ -252,8 +231,6 @@ describe("divan.vote — gated sandboxed vote", () => {
 			const {layer: pasaport, promoted} = pasaportRecording();
 			return Effect.gen(function* () {
 				yield* castVote("definition:def-1", true);
-				// the vote credited "u-author" (server-derived); with an active vouch + karma ≥ bar the
-				// tandem fires and flips the çaylak → yazar.
 				assert.deepStrictEqual(promoted, ["u-author"]);
 			}).pipe(
 				Effect.provide(
@@ -275,8 +252,8 @@ describe("divan.vote — gated sandboxed vote", () => {
 	it.effect("a bar-crossing vote with NO active vouch does NOT promote (the tandem holds)", () => {
 		const casts: VoteInput[] = [];
 		return Effect.gen(function* () {
-			// the vote lands and credits the author, but with no active vouch the tandem never flips a
-			// tier — `Pasaport.promoteToYazar` fail-on-contact proves it is never reached.
+			// `makePasaportStub()`'s fail-on-contact `promoteToYazar` is the assertion that no
+			// tier flip happened.
 			const receipt = yield* castVote("definition:def-1", true);
 			assert.strictEqual((receipt as {myVote: boolean}).myVote, true);
 		}).pipe(
@@ -338,10 +315,8 @@ describe("divan.vote — gated sandboxed vote", () => {
 	);
 });
 
-// Rite feedback (#1695): a landed divan vote notifies the item's author through the
-// bildirim spine — aggregated per item, self-suppressed, and NEVER able to fail the
-// committed cast. The retraction/self arms use the recording stub and assert ZERO
-// emits (the swallow would hide a die, so absence must be observed, not implied).
+// The silent arms assert ZERO emits against the RECORDING stub, not a dying one: the
+// emitter swallows failures, so absence has to be observed rather than implied.
 describe("divan.vote — rite-feedback bildirim (#1695)", () => {
 	const landedVoteLayers = (
 		notification: ReturnType<typeof makeNotificationStub>,
@@ -389,7 +364,6 @@ describe("divan.vote — rite-feedback bildirim (#1695)", () => {
 		const casts: VoteInput[] = [];
 		const {layer, emits} = notificationRecording();
 		return Effect.gen(function* () {
-			// the cast credits the VOTER as author → no self-notification
 			yield* castVote("definition:def-1", true);
 			assert.deepStrictEqual(emits, []);
 		}).pipe(Effect.provide(landedVoteLayers(layer, casts, "u-yazar")));
@@ -398,7 +372,7 @@ describe("divan.vote — rite-feedback bildirim (#1695)", () => {
 	it.effect("a DYING notification write cannot fail the committed vote (the seam AC)", () => {
 		const casts: VoteInput[] = [];
 		return Effect.gen(function* () {
-			// fail-on-contact Notification: recordAggregate DIES; the receipt still lands.
+			// `makeNotificationStub()` dies on contact; the receipt must still land.
 			const receipt = yield* castVote("definition:def-1", true);
 			assert.strictEqual((receipt as {myVote: boolean}).myVote, true);
 		}).pipe(Effect.provide(landedVoteLayers(makeNotificationStub(), casts, "u-author")));

--- a/apps/web/worker/features/divan/fate-module.ts
+++ b/apps/web/worker/features/divan/fate-module.ts
@@ -7,8 +7,7 @@ import {divanBacklogItemSource, divanCaylakSource, divanVoteReceiptSource} from 
 import {divanBacklogItemDataView, divanCaylakDataView} from "./views.ts";
 
 const roots: FateRootsRecord = {
-	// The divan proving-ground reads (#1287, epic #1202) — yazar-OR-mod-gated; the
-	// `divan.*` resolvers own the order (roster by pending desc, backlog newest-first).
+	// The `divan.*` resolvers own the order: roster by pending desc, backlog newest-first.
 	"divan.roster": list(divanCaylakDataView),
 	"divan.backlog": list(divanBacklogItemDataView),
 };

--- a/apps/web/worker/features/divan/gate.ts
+++ b/apps/web/worker/features/divan/gate.ts
@@ -1,30 +1,16 @@
 /**
- * The divan access gate (#1287, epic #1202) — the capability framework's first
- * **disjunctive** gate (ADR 0107): the right to view the çaylak proving ground is
- * earned by EITHER yazar standing OR platform-moderation authority (collapse-to-allow,
- * mirroring `kunye/sandbox.ts`'s `currentSandboxViewer` probe shape).
+ * The divan access gate — the capability framework's first **disjunctive** gate (ADR
+ * 0107): the right to view the çaylak proving ground is earned by EITHER yazar standing
+ * OR platform-moderation authority.
  *
- * How the OR is modeled (so it reads as a real disjunction, NOT an
- * `if (tier === "yazar" || isMod)` bypass):
+ * The OR is not an `if (tier === "yazar" || isMod)` bypass. {@link standsInDivan} runs
+ * TWO real capability discharges — {@link DivanStanding} and `Moderate.over(platform)` —
+ * each collapsed to a boolean and OR-ed, and {@link ViewDivan}`.authorize` mints one grant
+ * from the result. The read requires that grant in its R channel (ADR 0107 §3), so a divan
+ * read that forgets the gate is a compile error, not a forgotten `if`.
  *
- *   - {@link ViewDivan} is a generic `Capability.Class` — its discharge verb
- *     `.authorize(check)` mints ONE `Grant<ViewDivan>` when a boolean `check`
- *     passes. The disjunction lives in {@link standsInDivan}, the check it runs.
- *   - {@link standsInDivan} runs TWO genuine capability discharges through the real
- *     framework seams — {@link DivanStanding}`.require` (the divan's OWN yazar-floor
- *     `Level`: actor-match + agent-attenuation + `Kunye` standing read) and
- *     `Moderate.over(platform)` (the ReBAC `Relation` discharge over the
- *     `moderates` tuple) — each collapsed to a boolean (`Denied`/`RequiresLevel`
- *     → `false`) and OR-ed: allow if EITHER mints, deny otherwise.
- *
- * So the two axes keep their own real discharge logic; the gate is their union, and
- * the two proof types collapse into one `ViewDivan` grant the read requires in its R
- * channel (enforcement-by-R, ADR 0107 §3) — a divan read that forgets the gate is a
- * compile error, not a forgotten `if`.
- *
- * Denial is the invisible {@link Denied} (`UNAUTHORIZED`): a denied çaylak/visitor
- * cannot distinguish "not standing" from "not signed in" — the divan is a private
- * destination, like the moderation queue.
+ * Denial is the invisible {@link Denied}: the divan is a private destination, like the
+ * moderation queue.
  */
 import {Capability, Grant, type Principal, platform} from "@kampus/authz";
 import {Effect} from "effect";
@@ -38,12 +24,9 @@ const standingOf = (principal: Principal) =>
 	Effect.flatMap(Kunye, (kunye) => kunye.tierOf(principal.id));
 
 /**
- * The divan's OWN yazar-standing right (ADR 0107 §2: one class = one right, the tag
- * IS the right). A `Capability.Level` floored at `yazar` over the same
- * {@link authorshipLadder}, read from {@link Kunye} — but named and owned by the
- * divan, so divan access no longer borrows the sözlük `OpenTerm` write-path right as
- * a yazar litmus. The two yazar-floored rights (sözlük `OpenTerm`, this) now move
- * independently: a later change to one floor leaves the other untouched.
+ * The divan's OWN yazar-standing right (ADR 0107 §2), so divan access no longer borrows
+ * the sözlük `OpenTerm` write-path right as a yazar litmus and the two floors move
+ * independently.
  */
 export class DivanStanding extends Capability.Level<DivanStanding>()("divan/DivanStanding", {
 	scale: authorshipLadder,
@@ -53,10 +36,8 @@ export class DivanStanding extends Capability.Level<DivanStanding>()("divan/Diva
 }) {}
 
 /**
- * The disjunctive check: TRUE iff the current actor discharges the yazar-floor
- * {@link DivanStanding} capability OR holds `Moderate.over(platform)`. Each arm is a
- * real discharge whose denial (`RequiresLevel` / `Denied`) is collapsed to `false` —
- * the collapse-to-allow shape of `currentSandboxViewer`, here OR-ed across two axes.
+ * TRUE iff the actor discharges {@link DivanStanding} OR holds `Moderate.over(platform)`;
+ * each arm's denial collapses to `false`.
  */
 const standsInDivan = Effect.gen(function* () {
 	const asYazar = yield* DivanStanding.require.pipe(
@@ -71,22 +52,14 @@ const standsInDivan = Effect.gen(function* () {
 });
 
 /**
- * The divan-view right, discharged by EITHER axis (see module docblock). A generic
- * `Capability.Class` because the right is a union of two heterogeneous proofs —
- * neither a single `Level` floor nor a single `Relation` can express the OR, so the
- * disjunction is the `.authorize` check and the result is one collapsed grant.
+ * A generic `Capability.Class` because the right is a union of two heterogeneous proofs —
+ * neither a single `Level` floor nor a single `Relation` can express the OR.
  */
 export class ViewDivan extends Capability.Class<ViewDivan>()("divan/ViewDivan", {
 	deny: () => new Denied({message: "Divanı görmek için yazar ya da moderatör olmalısın."}),
 }) {}
 
-/**
- * Gate `body` behind divan access: discharge {@link ViewDivan} (the invisible
- * {@link Denied} on failure) and thread the resulting grant into `body`'s R channel
- * via `Grant.provide`. So `body` reads `yield* ViewDivan` for the gate proof,
- * and "reading the divan without a grant" is a compile error — the same shape as
- * `requireModeration`, here over the disjunctive capability.
- */
+/** Gate `body` behind divan access, threading the grant into its R channel. */
 export const requireDivanAccess = <A, E, R>(body: Effect.Effect<A, E, ViewDivan | R>) =>
 	ViewDivan.authorize(standsInDivan).pipe(
 		Effect.flatMap((grant) => body.pipe(Grant.provide(grant))),

--- a/apps/web/worker/features/divan/gate.unit.test.ts
+++ b/apps/web/worker/features/divan/gate.unit.test.ts
@@ -1,14 +1,8 @@
 /**
- * The divan disjunctive gate (#1287, epic #1202) through the REAL capability seams
- * — not a re-implemented `tier === "yazar" || isMod` check. {@link requireDivanAccess}
- * discharges `ViewDivan`, whose check OR-s two genuine discharges: `DivanStanding.require`
- * (the divan's OWN yazar-floor `Level`) and `Moderate.over(platform)` (the `moderates`
- * `Relation`). The matrix proves both arms AND the disjunction independence: a mod who
- * is NOT a yazar still passes, a yazar who is NOT a mod still passes; a çaylak, a
- * visitor, and the anonymous actor are denied the invisible `Denied`.
- *
- * All four ports are scripted (`Kunye` standing, `RelationStore` the moderates tuple,
- * `AgentAuthority` fail-closed, `CurrentActor` the actor) — no DB.
+ * The divan disjunctive gate through the REAL capability seams, not a re-implemented
+ * `tier === "yazar" || isMod` check. The matrix proves both arms AND their independence: a
+ * mod who is NOT a yazar still passes, a yazar who is NOT a mod still passes; a çaylak, a
+ * visitor and the anonymous actor get the invisible `Denied`. All four ports are scripted.
  */
 import {assert, describe, it} from "@effect/vitest";
 import {
@@ -26,7 +20,6 @@ import {Kunye} from "../kunye/Kunye.ts";
 import type {Tier} from "../kunye/standing.ts";
 import {DivanStanding, requireDivanAccess, ViewDivan} from "./gate.ts";
 
-/** Run the gate over `body = succeed("ok")` for one actor, scripting standing + mods. */
 const access = (
 	actor: Actor,
 	opts: {readonly tier?: Tier; readonly mods?: ReadonlyArray<string>} = {},
@@ -101,8 +94,8 @@ describe("divan gate — yazar OR mod, collapse-to-allow", () => {
 	});
 
 	it("an allowed read threads a ViewDivan grant into the body's R (enforcement-by-R)", () => {
-		// `yield* ViewDivan` would be a compile error without the provided grant — so a
-		// reached "reached" proves the gate supplied the proof, not just returned a boolean.
+		// `yield* ViewDivan` would be a compile error without the provided grant, so reaching
+		// "reached" proves the gate supplied the proof rather than returning a boolean.
 		const exit = Effect.runSyncExit(
 			requireDivanAccess(
 				Effect.gen(function* () {
@@ -128,7 +121,6 @@ describe("divan gate — yazar OR mod, collapse-to-allow", () => {
 	});
 });
 
-/** Discharge `DivanStanding.require` for one actor at the given standing, no mods involved. */
 const standing = (actor: Actor, tier: Tier): Exit.Exit<Grant<DivanStanding>, RequiresLevel> =>
 	Effect.runSyncExit(
 		DivanStanding.require.pipe(

--- a/apps/web/worker/features/divan/lists.ts
+++ b/apps/web/worker/features/divan/lists.ts
@@ -1,14 +1,9 @@
 /**
- * The divan root list resolvers (#1287, epic #1202) — the gated proving-ground read
- * model every other divan slice (voting #1288, vouch/tandem #1289, the `/divan`
- * surface #1290, the çaylak status block #1291) reads off.
+ * The divan root list resolvers. The service reads are unconditional, so the
+ * disjunctive {@link requireDivanAccess} gate (yazar OR mod) is enforced HERE:
+ * `yield* ViewDivan` makes each read unreachable without the discharged grant.
  *
- * The disjunctive {@link requireDivanAccess} capability gate — yazar OR mod — is
- * enforced HERE (the service reads are unconditional): `yield* ViewDivan` makes each
- * read unreachable without the discharged grant.
- *
- * Both are single-page private reads (no live view, no cursor pagination), so the
- * `ConnectionResult` is `hasNext: false`, mirroring `report.listOpen`.
+ * Both are single-page private reads, so the `ConnectionResult` is `hasNext: false`.
  */
 import {Fate} from "@kampus/fate-effect";
 import type {ConnectionResult} from "@nkzw/fate/server";
@@ -36,8 +31,8 @@ const BacklogArgs = Schema.Struct({
 	first: Schema.optional(Schema.Number),
 });
 
-// The handler stamps `__typename` (the inline-resolved entity carries no source that
-// would stamp it) — the one spelling of each literal. See `report/shapers.ts`.
+// The handler stamps `__typename` itself: an inline-resolved entity has no source
+// that would stamp it.
 const toCaylak = (e: DivanRosterRow): DivanCaylak => ({
 	__typename: "DivanCaylak",
 	id: e.authorId,
@@ -60,9 +55,6 @@ const toItem = (i: DivanItem): DivanBacklogItem => ({
 	preview: i.preview,
 });
 
-// The post-gate roster read — `ViewDivan`-gated in R (`requireDivanAccess` provides
-// the grant). `yield* ViewDivan` requires the proof; the roster is unreachable
-// without a discharged grant.
 const rosterGated = Effect.fn("divan.rosterGated")(function* () {
 	yield* ViewDivan;
 	const divan = yield* Divan;

--- a/apps/web/worker/features/divan/mutations.ts
+++ b/apps/web/worker/features/divan/mutations.ts
@@ -1,24 +1,9 @@
 /**
- * The divan vote mutation (#1288, epic #1202) — score a SANDBOXED çaylak item from inside
- * the proving ground, crediting the author's GLOBAL karma so a sandboxed çaylak can earn
- * toward the reduced çaylak→yazar promotion bar (#1289).
- *
- * The gate, exactly the read model's (`lists.ts`): {@link requireDivanAccess} (yazar OR
- * mod) — `yield* ViewDivan` makes the cast unreachable without the discharged grant, so a
- * çaylak / public / anonymous actor is denied the invisible {@link Denied}. This IS the
- * "non-gated actor cannot vote a sandboxed item" guarantee — a compile-error gate, not an
- * `if` (ADR 0107).
- *
- * The cast itself delegates to `Vote.castOnSandboxed` — the ONLY caller of the
- * sandbox-permitting path. The inline sözlük/pano vote paths use `Vote.cast`, which rejects a
- * sandboxed target, so the divan is the only surface that can score sandboxed content. The
- * karma + scoring batch is the shared Vote engine unchanged: GLOBAL `user_profile.total_karma`
- * (D2, ADR 0050) and `+1` per vote with the gate admitting yazar and mod identically (D3).
- *
- * After a vote moves the author's karma it fires `resolveTandem` (#1289) — the karma side of the
- * order-independent çaylak→yazar promotion tandem — so a bar-crossing vote with an already-active
- * vouch auto-promotes. `resolveTandem` holds no authority of its own (it only re-checks the
- * completed-tandem invariant), so it stays inside this same divan-gated path.
+ * The divan vote mutation — score a SANDBOXED çaylak item, crediting the author's global
+ * karma. `yield* ViewDivan` makes the cast unreachable without a discharged grant, so the
+ * "non-gated actor cannot vote a sandboxed item" guarantee is a compile error, not an `if`
+ * (ADR 0107). This is the ONLY caller of `Vote.castOnSandboxed`; every other vote path
+ * uses `Vote.cast`, which rejects a sandboxed target.
  */
 import {CurrentUser, Fate} from "@kampus/fate-effect";
 import {Effect} from "effect";
@@ -34,16 +19,13 @@ import {DivanVoteReceiptView} from "./views.ts";
 const DivanVoteInput = Schema.Struct({
 	/** The backlog item's `<kind>:<itemId>` composite id (see `DivanBacklogItemView`). */
 	id: Schema.String,
-	/** Up-only presence: `true` casts the upvote, `false` retracts it. */
+	/** Up-only presence: `true` casts, `false` retracts. */
 	value: Schema.Boolean,
 });
 
 /**
- * Split a `<kind>:<itemId>` divan item id back into its target, or `null` if malformed /
- * unknown-kind — the shared {@link parseTargetKey} codec, remapped to the vote engine's
- * `{targetKind, targetId}` field names. The backlog read only ever emits well-formed ids,
- * so a `null` here is a hand-crafted request past the gate — the caller collapses it to the
- * invisible `Denied`, keeping the private surface opaque.
+ * The backlog read only ever emits well-formed ids, so a `null` here means a hand-crafted
+ * request — the caller collapses it to the invisible `Denied` rather than a parse error.
  */
 const parseItemId = (id: string): {targetKind: TargetKind; targetId: string} | null => {
 	const parsed = parseTargetKey(id);
@@ -67,13 +49,9 @@ export const mutations = {
 	),
 };
 
-// The post-gate cast body — runnable only with a `ViewDivan` grant in R (`requireDivanAccess`
-// provides it); `yield* ViewDivan` IS the divan audience gate, so casting without a discharged
-// grant is a compile error. The voter is read OPTIONALLY (not `CurrentUser.required`) so an
-// anonymous actor gets the gate's invisible `Denied`, never a "not signed in" leak — though the
-// gate already denied them, since both arms (yazar / mod) need authentication. Delegates to the
-// sandbox-permitting `Vote.castOnSandboxed`; a `VoteTargetNotFound` (raced soft-delete) collapses
-// to the invisible `Denied`, keeping the surface opaque and the error union `{Denied}`.
+// The voter is read OPTIONALLY, not via `CurrentUser.required`, so an anonymous actor gets
+// the invisible `Denied` and never a "not signed in" leak. `VoteTargetNotFound` collapses
+// the same way, keeping this private surface opaque.
 const voteGated = Effect.fn("divan.voteGated")(function* (
 	targetKind: TargetKind,
 	targetId: string,
@@ -90,18 +68,13 @@ const voteGated = Effect.fn("divan.voteGated")(function* (
 				Effect.fail(new Denied({message: "Oy verilecek içerik bulunamadı."})),
 			),
 		);
-	// The karma-side promotion trigger (#1289): a vote that moved the AUTHOR's karma may have
-	// crossed the reduced bar — re-evaluate the order-independent tandem so a bar-crossing vote
-	// with an already-active vouch auto-promotes the çaylak. `resolveTandem` reads both halves
-	// fresh, is idempotent, and holds no authority of its own (it only checks the completed-tandem
-	// invariant), so it stays inside this divan-gated path with no new authority surface. Keyed on
-	// the SERVER-derived `result.authorId`, never a client-supplied id. Only on a real karma move.
+	// A karma move may have crossed the reduced promotion bar. Keyed on the SERVER-derived
+	// author id, never a client-supplied one; idempotent, and it holds no authority of its
+	// own, so it stays inside this gated path.
 	if (result.changed) yield* resolveTandem(result.authorId);
-	// Rite feedback (#1695): a LANDED upvote (not a retraction, not an idempotent
-	// no-op) notifies the item's author — aggregated per item, self-suppressed,
-	// flag-gated and swallowed inside the emitter, so it can never fail this
-	// committed cast. A retraction stays silent (no decrement: the aggregate is
-	// "attention received", not a live score).
+	// Only a LANDED upvote notifies — a retraction stays silent, because the aggregate is
+	// "attention received", not a live score. The emitter swallows its own failures, so it
+	// can never fail this already-committed cast.
 	if (value && result.changed) {
 		yield* notifyDivanVote({
 			authorId: result.authorId,

--- a/apps/web/worker/features/divan/roster.ts
+++ b/apps/web/worker/features/divan/roster.ts
@@ -1,95 +1,57 @@
 /**
- * The pure divan read-model shaping (#1287, epic #1202) — no service, no Effect,
- * so the roster grouping is unit-testable in isolation (ADR 0082 unit tier).
+ * The pure divan read-model shaping (#1287, epic #1202) — no service, no Effect, so
+ * the roster grouping is unit-testable on its own.
  *
- * The divan is the çaylak→yazar proving ground: a yazar-OR-mod-gated DESTINATION
- * over the shipped `sandboxBacklogWhere` read model (#1205), NOT a widening of the
- * inline `{mod, author}` visibility. {@link Divan} fetches each çaylak's
- * still-sandboxed, not-removed backlog through the existing `listSandboxed*`
- * service reads (which compose `sandboxBacklogWhere`); the shaping here groups
- * those loose items by author so the roster's unit is the **person**, not the item.
- *
- * Two shapes:
- *   - {@link DivanItem} — one normalized sandboxed backlog item (the per-kind
- *     definition/post/comment rows collapsed onto a common `{kind, id, authorId,
- *     createdAt, preview}` shape the detail view #1290 renders).
- *   - {@link DivanCaylakEntry} — one roster row: a çaylak with ≥1 pending item plus
- *     the per-kind counts. {@link buildRoster} derives these by grouping items.
+ * The divan is a yazar-OR-mod-gated DESTINATION over the `sandboxBacklogWhere` read
+ * model (#1205), NOT a widening of the inline `{mod, author}` visibility. The grouping
+ * here makes the roster's unit the PERSON, not the item.
  */
 
 import type {TargetKind} from "../../db/target-kind.ts";
 import type {UserId} from "../../lib/ids.ts";
 
-/**
- * The content kind a sandboxed backlog item came from. Aliased to the shared
- * {@link TargetKind} taxonomy so the votable-kind set is declared once — a divan
- * kind outside `TARGET_KINDS` can no longer be introduced here without failing to
- * compile against the vote/report engines the divan casts into.
- */
+// Aliased to {@link TargetKind} so a divan kind outside `TARGET_KINDS` cannot compile
+// against the vote/report engines the divan casts into.
 export type DivanItemKind = TargetKind;
 
-/**
- * One normalized sandboxed backlog item — the per-domain rows
- * (`DefinitionRow`/`PostSummaryRow`/`CommentRow`) collapsed onto the common fields
- * the divan needs. `id` is the domain row id; the fate view keys it `<kind>:<id>`
- * so the three kinds never collide in one connection.
- */
+// `id` is the domain row id; the fate view keys it `<kind>:<id>` so the three kinds
+// never collide in one connection.
 export interface DivanItem {
 	readonly kind: DivanItemKind;
 	readonly id: string;
 	readonly authorId: UserId;
 	readonly createdAt: Date;
-	/** A short text preview for the queue row (body / title), never the full node. */
 	readonly preview: string;
 }
 
-/**
- * One roster row: a çaylak with at least one pending (sandboxed, not-removed) item,
- * plus the per-kind counts. The unit is the **person** — loose items are read
- * separately as that çaylak's backlog (`Divan.backlogOf`).
- */
 export interface DivanCaylakEntry {
 	readonly authorId: UserId;
 	readonly definitionCount: number;
 	readonly postCount: number;
 	readonly commentCount: number;
-	/** definitions + posts + comments — the headline "pending work" count. */
 	readonly totalCount: number;
 }
 
-/**
- * The identity a roster row carries about its çaylak — the display handle
- * (`displayName`/`username`) + their karma-on-others. Joined onto the counts in
- * `Divan.roster` via a SINGLE batched profile read, so the roster's one fate request
- * resolves every row's identity in-batch — no per-row by-id `Profile` read on the
- * client (ADR 0021's no-waterfalls contract, #1423). Deliberately minimal: only the
- * fields the roster row renders, never a widening of `Profile` onto this mod-gated
- * surface. `username`/`displayName` are nullable (a çaylak may not have set a username
- * yet); the client falls back to the bare "çaylak" label.
- */
+// Joined onto the counts by a SINGLE batched profile read, so no per-row by-id
+// `Profile` read happens on the client (ADR 0021's no-waterfalls contract, #1423).
+// Deliberately minimal — never widen `Profile` onto this mod-gated surface. The
+// nullable handles fall back to the bare "çaylak" label client-side.
 export interface CaylakIdentityFields {
 	readonly username: string | null;
 	readonly displayName: string | null;
 	readonly totalKarma: number;
 }
 
-/**
- * A roster row as delivered to the client: the per-kind counts + the çaylak's
- * identity, both resolved in the same batched read.
- */
 export type DivanRosterRow = DivanCaylakEntry & CaylakIdentityFields;
 
 /**
- * Group sandboxed backlog items by author into the pending-çaylak roster. Only
- * authors with ≥1 item appear (a person with no pending work is not on the queue),
- * sorted by total pending desc then authorId for a stable order. Items with a blank
- * authorId are skipped — the moderator-backlog read blanks the author of an
- * author-deleted-but-not-removed row (ADR 0096), which is not a real çaylak's
- * pending work and must not seed an empty-author roster group.
+ * Group backlog items by author. Sorted by total pending desc then authorId, for a
+ * stable order.
  *
- * The caller hands items that already passed `sandboxBacklogWhere` (sandboxed +
- * `removed_at IS NULL`), so removed/live items are excluded upstream, not re-judged
- * here.
+ * A blank authorId is skipped: the moderator-backlog read blanks the author of an
+ * author-deleted-but-not-removed row (ADR 0096), which is not a real çaylak's pending
+ * work and must not seed an empty-author group. Removed/live items are excluded
+ * upstream by `sandboxBacklogWhere`, never re-judged here.
  */
 export const buildRoster = (items: ReadonlyArray<DivanItem>): ReadonlyArray<DivanCaylakEntry> => {
 	const byAuthor = new Map<UserId, {definitions: number; posts: number; comments: number}>();

--- a/apps/web/worker/features/divan/roster.unit.test.ts
+++ b/apps/web/worker/features/divan/roster.unit.test.ts
@@ -1,8 +1,6 @@
 /**
- * The pure divan roster shaping (#1287) — `buildRoster` grouping, with no DB
- * (ADR 0082 unit tier). Proves the unit is the PERSON: items group by author, the
- * per-kind counts are correct, only authors with ≥1 pending item appear, and the
- * blank-author (author-deleted placeholder) row is skipped.
+ * The pure divan roster shaping (#1287): the unit of the roster is the PERSON, not the
+ * item.
  */
 import {assert, describe, it} from "@effect/vitest";
 import {UserId} from "../../lib/ids.ts";

--- a/apps/web/worker/features/divan/views.ts
+++ b/apps/web/worker/features/divan/views.ts
@@ -1,25 +1,18 @@
 /**
- * The divan fate views (#1287, epic #1202) — both private, gated surfaces with NO
- * source fetch path: each is delivered inline by its `divan.*` list resolver (the
- * `report.listOpen` / `OpenReport` shape), so its source is a capability-less
- * `Fate.syntheticSource` (view-reachable, no by-id read).
+ * The divan fate views — both private, gated surfaces with NO source fetch path: each is
+ * delivered inline by its `divan.*` list resolver, so its source is a capability-less
+ * `Fate.syntheticSource`.
  *
- *   - {@link DivanCaylakView} — one roster row: a çaylak with pending work + the
- *     per-kind counts + their inline identity (handle + karma, the
- *     {@link CaylakIdentityFields} sub-shape). `id` is the author id; identity is
- *     resolved IN-BATCH by the `divan.roster` resolver, so the client never fires a
- *     per-row by-id `Profile` read (ADR 0021's no-waterfalls contract, #1423).
- *   - {@link DivanBacklogItemView} — one sandboxed backlog item (the detail-view
- *     payload). `id` is `<kind>:<itemId>` so the three kinds never collide in one
- *     connection.
+ * A roster row's identity is resolved IN-BATCH by the `divan.roster` resolver, so the client
+ * never fires a per-row by-id `Profile` read (ADR 0021's no-waterfalls contract). A backlog
+ * item's `id` is `<kind>:<itemId>` so the three kinds never collide in one connection.
  */
 import {FateDataView, type WorkerEntity} from "@kampus/fate-effect";
 import type {ViewRow} from "../fate/view-types.ts";
 import type {CaylakIdentityFields, DivanItemKind} from "./roster.ts";
 
-// The identity sub-shape spread onto the roster row — only the handle + karma the
-// roster renders (the minimal {@link CaylakIdentityFields}); never a widening of
-// `Profile` onto this mod-gated surface (#1423).
+// Only the handle + karma the roster renders; never a widening of `Profile` onto this
+// mod-gated surface.
 const caylakIdentityFields = {
 	username: true,
 	displayName: true,
@@ -74,11 +67,9 @@ export const divanBacklogItemDataView = DivanBacklogItemView.view;
 export type DivanBacklogItem = WorkerEntity<typeof DivanBacklogItemView>;
 
 /**
- * The receipt a `divan.vote` returns (#1288): the post-cast vote state of one sandboxed
- * backlog item, delivered inline by the mutation (no by-id read), so its source is a
- * capability-less `Fate.syntheticSource` like the other two divan views. `id` is the
- * `<kind>:<itemId>` composite — the same identity as {@link DivanBacklogItemView} — so the
- * #1290 surface keys the rendered up-vote off the item it voted on.
+ * The receipt a `divan.vote` returns, delivered inline by the mutation (no by-id read), so
+ * its source is a capability-less `Fate.syntheticSource` like the other two. `id` is the
+ * `<kind>:<itemId>` composite — the same identity as {@link DivanBacklogItemView}.
  */
 export type DivanVoteReceiptViewRow = ViewRow<{
 	id: string;

--- a/apps/web/worker/features/domain-error-boundary.unit.test.ts
+++ b/apps/web/worker/features/domain-error-boundary.unit.test.ts
@@ -1,16 +1,11 @@
 /**
  * Domain-boundary error pins — infra failures never escape a feature service
- * (`.patterns/feature-services.md`, `.patterns/effect-errors.md`). Each service
- * collapses `DrizzleError` into the defect channel internally (`orDieAccess`),
- * so public method signatures carry DOMAIN errors only and the fate layer never
- * names Drizzle.
+ * (`.patterns/feature-services.md`, `.patterns/effect-errors.md`). Two pins per service:
+ * a sweep proving no method's `E` channel contains `DrizzleError`, and an exact-union pin
+ * catching a silently widened or narrowed domain union.
  *
- * Two pins per service: (1) a SWEEP proving no method's `E` channel contains
- * `DrizzleError`, (2) an exact-union pin catching a silently widened/narrowed
- * domain union. Type-only assertions, unit tier (ADR 0082).
- *
- * Uses expectTypeOf, not `@ts-expect-error` — the effect LSP plugin's TS377003
- * escapes the directive (recurring finding).
+ * Uses `expectTypeOf`, NOT `@ts-expect-error` — the effect LSP plugin's TS377003 escapes
+ * the directive.
  */
 
 import type {Effect} from "effect";
@@ -49,8 +44,8 @@ type ErrorsOf<F> = F extends (...args: never[]) => Effect.Effect<infer _A, infer
 	? E
 	: never;
 
-// Resolves to `never` when the service is leak-free, else to the offending
-// method name(s) — so a re-leak fails the pin AND names the culprit.
+// Resolves to `never` when leak-free, else to the offending method name(s), so a re-leak
+// fails the pin AND names the culprit.
 type InfraLeaks<S> = {
 	[K in keyof S]: [Extract<ErrorsOf<S[K]>, DrizzleError>] extends [never] ? never : K;
 }[keyof S];
@@ -94,9 +89,8 @@ it("Stats: no method leaks DrizzleError", () => {
 it("Vote: no method leaks DrizzleError; exact domain unions hold", () => {
 	type Svc = typeof Vote.Service;
 	expectTypeOf<InfraLeaks<Svc>>().toEqualTypeOf<never>();
-	// `cast` rejects a sandboxed TARGET (inline path) AND a below-floor VOTER
-	// (`VoterNotEligible`, #1810's "earn to vote" gate); `castOnSandboxed` (the divan-gated
-	// path, #1288) permits both, so its only domain error is the not-found race.
+	// `castOnSandboxed` permits both rejections `cast` raises, so its only domain error is
+	// the not-found race.
 	expectTypeOf<ErrorsOf<Svc["cast"]>>().toEqualTypeOf<
 		VoteTargetNotFound | VoteTargetSandboxed | VoterNotEligible
 	>();

--- a/apps/web/worker/features/fate-live/cold-start-retry.ts
+++ b/apps/web/worker/features/fate-live/cold-start-retry.ts
@@ -1,73 +1,17 @@
 /**
- * Cold-start resilience for the cross-DO `LiveDO` RPC seam (#842).
- *
- * Cloudflare evicts idle Durable Objects, so the FIRST `/fate/live` connect or
- * subscribe for an idle user hits a cold `connection:`/`topic:` DO. The alchemy
- * RPC stub (`makeRpcStub`) wraps every cross-DO call in
- * `Effect.tryPromise({catch: … RpcCallError})`, so a sub-second cold-start
- * transport failure surfaces as an `RpcCallError` in the call's FAILURE channel.
- *
- * THE TYPE LIE this module exists to handle: the `LiveDO` RPC surface declares
- * each method `Effect<…, never, never>` (`live-do.ts` `LiveRpcSurface`), but that
- * `never` is the *declared* shape, not the *runtime* one — `makeRpcStub` injects
- * `RpcCallError` into the failure channel that the static type erases. So this is
- * the one seam (the `index.ts` `liveLayer` call sites) where the transport error
- * is actually present at runtime and must be reinterpreted to be caught.
- *
- * The fix: a BOUNDED retry keyed ON THE TRANSPORT CHANNEL ONLY — capped
- * exponential backoff absorbs the warm window; a genuine app error (a typed DO
- * failure that is NOT `RpcCallError`) fails fast and passes through untouched. On
- * exhaustion the surviving transport failure becomes a typed
- * {@link LiveTransportError}, which the route renders as a graceful 503 envelope
- * instead of a defect-500.
- *
- * THE SECOND CHANNEL (#1048): the GET SSE-open path does NOT go through
- * `makeRpcStub`'s `tryPromise`. The stub's `.fetch` is alchemy's
- * `fromCloudflareFetcher.fetch`, whose server-shaped branch wraps the cross-DO
- * call in `Effect.promise(() => fetcher.fetch(request))` with NO catch — so a
- * cold-DO transport rejection surfaces as a DEFECT (die), not an `RpcCallError`
- * failure. The defect slips past {@link withColdStartRetry} (it keys on the
- * FAILURE channel) and the route's `LiveTransportError`→503 boundary, escaping as
- * a raw HTTP 500. {@link withColdStartRetryFetch} closes the seam: it lifts a
- * cold-DO transport defect into the same `RpcCallError`-shaped failure the RPC
- * methods raise, so the ONE bounded-retry + `LiveTransportError` path covers both
- * channels.
- *
- * THE DISCRIMINANT PROBLEM (#1367): the defect channel has NO clean positive
- * discriminant, unlike the RPC channel's `isRpcCallError` tag-check. Grounded in
- * alchemy `Cloudflare/Fetcher.ts` `fromCloudflareFetcher`: the server branch is
- * `pipe(…, Effect.flatMap(Effect.promise(fetcher.fetch)), Effect.map(HttpServerResponse.fromWeb))`
- * with no `Effect.catch`. So TWO unrelated failures both surface here as an
- * indistinct die: (a) the cold-DO transport rejection (the `Effect.promise`
- * rejects), and (b) a marshaling die from the later `Effect.map` step
- * (`HttpServerResponse.fromWeb` throwing on a malformed response). A BLANKET
- * `Effect.catchDefect` that lifts EVERY defect as the transport error would
- * reinterpret (b) as a transient 503 and retry it 5× — re-opening, inverted, the
- * exact failure-masking ADR 0095 closed on the RPC channel. But the promise
- * rejection carries no `_tag` and no documented `.retryable` flag (verified absent
- * from `@cloudflare/workers-types`), so no positive "this IS the cold-DO rejection"
- * predicate exists; and re-raising every *unrecognized* defect would instead
- * re-raise the genuine (also opaque) cold-DO rejection and regress the ADR 0095
- * resilience. The reconciliation is {@link isNonTransportDefect}: a CONSERVATIVE
- * guard that re-raises only the V8 code-defect classes — which a transport layer
- * never throws to signal a rejection — and lifts the residual. See its docblock
- * for the residual this leaves and why it is the safe arm.
- *
- * Schedule shape grounds in effect-smol `LLMS.md` §"Working with Schedules"
- * (`ai-docs/src/06_schedule/10_schedules.ts`): `retryBackoffWithLimit` =
- * `Schedule.both(exponential, recurs(N))` for capped backoff, and the
- * `retryableOnly` pattern (`Schedule.while` / `Retry.Options.while`) to retry only
- * the transport-error channel.
+ * Cold-start resilience for the cross-DO `LiveDO` RPC seam (#842). The RPC surface
+ * declares `never` failure channels, but alchemy's stub injects a runtime
+ * `RpcCallError` the static type erases — see ADR 0095 and
+ * `.patterns/alchemy-durable-objects.md`. The GET SSE-open `.fetch` path is a second
+ * channel: alchemy wraps it in an uncaught `Effect.promise`, so the same cold-DO
+ * rejection arrives as a DEFECT and must be lifted before the shared retry sees it
+ * (#1048). Schedule shape grounds in effect-smol `LLMS.md` §"Working with Schedules".
  */
 import * as Effect from "effect/Effect";
 import * as Schedule from "effect/Schedule";
 import * as Schema from "effect/Schema";
 
-/**
- * A cross-DO call kept failing on the transport channel after the bounded
- * cold-start retry was exhausted. The route maps it to a 503 `liveError` envelope
- * — the live pin retries the whole connect on the next session mount.
- */
+/** The route maps this to a 503 `liveError` envelope, never a defect-500 (ADR 0095). */
 export class LiveTransportError extends Schema.TaggedErrorClass<LiveTransportError>()(
 	"fate-live/LiveTransportError",
 	{
@@ -81,20 +25,11 @@ export class LiveTransportError extends Schema.TaggedErrorClass<LiveTransportErr
 }
 
 /**
- * The runtime shape of alchemy's `RpcCallError`, modeled structurally because the
- * class is internal to alchemy (`Cloudflare/Workers/Rpc`, off the public export
- * path) and cannot be imported as a value or a type.
- *
- * GROUNDED against the dep source: alchemy `Cloudflare/Workers/Rpc.ts` defines
- * `RpcCallError = Data.TaggedError("RpcCallError")<{readonly method: string;
- * readonly cause: unknown}>`, raised by `makeRpcStub`'s
- * `Effect.tryPromise({catch: (cause) => new RpcCallError({method, cause})})`. The
- * `method` field is part of alchemy's real emitted shape — modeled here (not just
- * `{_tag, cause}`) so this interface mirrors the dep's contract faithfully and the
- * unit test can pin against the true field set (#1367 facet 2). Because the class
- * is unexported, an upstream rename/rewrap cannot be a phoenix *compile* failure;
- * the pin is a unit assertion against this grounded fixture, kept in sync with the
- * cited `Rpc.ts` source.
+ * Modeled structurally because alchemy's `RpcCallError` is off its public export path
+ * and cannot be imported as a value or a type. Grounded in alchemy
+ * `Cloudflare/Workers/Rpc.ts`: `Data.TaggedError("RpcCallError")<{method: string; cause:
+ * unknown}>`. An upstream rename can therefore never be a compile failure here — the
+ * unit test pins this fixture against the cited source instead.
  */
 interface RpcCallErrorShape {
 	readonly _tag: "RpcCallError";
@@ -102,35 +37,24 @@ interface RpcCallErrorShape {
 	readonly cause: unknown;
 }
 
-/** Tag check for {@link RpcCallErrorShape} — the only seam an unexported class allows. */
 const isRpcCallError = (error: unknown): error is RpcCallErrorShape =>
 	typeof error === "object" &&
 	error !== null &&
 	(error as {_tag?: unknown})._tag === "RpcCallError";
 
 /**
- * The conservative defect guard for the `.fetch` channel (#1367). Returns `true`
- * for a defect that is PROVABLY not a cold-DO transport rejection, so the caller
- * re-raises it (fail-fast 500) instead of masking it as a retried 503.
+ * The `.fetch` defect channel has no positive discriminant: alchemy's
+ * `fromCloudflareFetcher` server branch passes the cold-DO rejection through opaquely
+ * (no `_tag`, no `.retryable`), and its later `Effect.map(HttpServerResponse.fromWeb)`
+ * step dies the same way on a malformed response. So this guard is deliberately
+ * NEGATIVE (#1367): it re-raises only the V8 code-defect classes — which a transport
+ * layer never throws to signal a rejection — and lets everything else be retried.
  *
- * The match set is the V8 *code-defect* constructors — `RangeError` (stack
- * overflow, invalid length), `ReferenceError` (undefined access), `SyntaxError`
- * (parse, incl. a JSON marshaling die), `EvalError`, `URIError`. These are thrown
- * by buggy code (e.g. alchemy's `Effect.map(HttpServerResponse.fromWeb)` step on a
- * malformed response), never by a transport layer to signal that a cold/unreachable
- * DO rejected — workerd surfaces DO transport/readiness failures as a plain `Error`
- * (e.g. "Network connection lost."), not one of these subclasses. So re-raising
- * them carries ZERO risk of regressing the ADR 0095 cold-start retry.
- *
- * RESIDUAL (documented, not hidden): `TypeError` is deliberately EXCLUDED. A
- * marshaling die can be a `TypeError`, but so can a network-shaped rejection, and
- * since the genuine cold-DO rejection is itself opaque (a bare `Error`/`TypeError`
- * with no discriminant), re-raising `TypeError` would risk regressing AC3 (the
- * cold-start path must still fire). It — and any bare `Error` — therefore stays in
- * the retried bucket. This guard does not make the channel perfectly precise (no
- * predicate can, given alchemy passes the rejection through opaquely); it flips the
- * default from "mask EVERY defect" to "fail fast on the unambiguous code defects",
- * which is the safe, grounded improvement over the prior blanket catch.
+ * `TypeError` is deliberately EXCLUDED even though a marshaling die can be one: the
+ * genuine cold-DO rejection is a bare `Error`/`TypeError` too, so re-raising it would
+ * regress the ADR 0095 cold-start retry. The channel is not perfectly precise and
+ * cannot be; this only flips the default from "mask every defect" to "fail fast on the
+ * unambiguous code defects".
  */
 export const isNonTransportDefect = (cause: unknown): boolean =>
 	cause instanceof RangeError ||
@@ -139,53 +63,34 @@ export const isNonTransportDefect = (cause: unknown): boolean =>
 	cause instanceof EvalError ||
 	cause instanceof URIError;
 
-/**
- * Capped exponential backoff: ~100ms, 200, 400, 800ms across up to 4 retries
- * (5 attempts total, ~1.5s worst case) — bounded well under the request budget,
- * sized to absorb the sub-second DO warm window without holding the connection.
- */
+/** ~1.5s worst case: sized to absorb the sub-second DO warm window, well under the request budget. */
 const coldStartRetrySchedule = Schedule.both(
 	Schedule.exponential("100 millis"),
 	Schedule.recurs(4),
 );
 
 /**
- * Wrap a cross-DO RPC call with the bounded cold-start retry. The runtime
- * `RpcCallError` is absent from the static error channel `E` (the type lie — see
- * module docblock), so we reinterpret to the runtime reality at this single seam,
- * retry ONLY that transport error, and surface a typed {@link LiveTransportError}
- * on exhaustion. Any declared `E` (e.g. `HttpServerError` on the `.fetch`/open
- * path) and any non-transport app error pass through unchanged.
+ * The runtime `RpcCallError` is absent from the static channel `E`, so the cast below
+ * reinterprets `E` to the runtime reality (`E` ∪ the hidden transport error) — the one
+ * seam where that error is actually present. Non-transport errors pass through untouched.
  */
 export const withColdStartRetry = <A, E>(
 	method: string,
 	call: Effect.Effect<A, E, never>,
 ): Effect.Effect<A, E | LiveTransportError, never> =>
-	// Reinterpret the static error channel to the runtime reality (`E` ∪ the hidden
-	// transport error) so the retry + `catchIf` narrow against the real failure.
 	retryTransportFailure(
 		method,
 		call as Effect.Effect<A, E | RpcCallErrorShape, never>,
 	) as Effect.Effect<A, E | LiveTransportError, never>;
 
 /**
- * Wrap the GET SSE-open `.fetch` cross-DO call. Unlike the RPC methods, `.fetch`
- * surfaces a cold-DO transport rejection as a DEFECT (alchemy's
- * `Effect.promise`-wrapped fetcher — see module docblock §"THE SECOND CHANNEL",
- * #1048), so {@link withColdStartRetry}'s failure-channel key never sees it. We
- * lift a transport defect into an `RpcCallError`-shaped FAILURE, then route it
- * through the identical bounded-retry + {@link LiveTransportError} path — so the
- * open path warms up and renders 503 exactly like the RPC seam, never a raw 500.
- *
- * GUARDED, not blanket (#1367): an unambiguous code defect ({@link isNonTransportDefect}
- * — a marshaling/`Effect.map` die, etc.) is RE-RAISED unchanged so it fails fast as
- * a 500, never masked as a retried 503. Only the residual defect is lifted as the
- * transport failure. See §"THE DISCRIMINANT PROBLEM" for why this conservative arm
- * is the safe one and the residual it leaves.
- *
- * The declared `E` (the `.fetch` `HttpServerError`/`RequestError` request-framing
- * channel) passes through untouched: the route deliberately `orDie`s that (a real
- * framing defect), and lifting it would wrongly mask it as a cold-start retry.
+ * The GET SSE-open twin of {@link withColdStartRetry}: `.fetch` surfaces a cold-DO
+ * rejection as a DEFECT, which the failure-channel key never sees (#1048), so it is
+ * lifted into the same `RpcCallError` shape. The lift is guarded, not blanket — an
+ * unambiguous code defect ({@link isNonTransportDefect}) is re-raised so it fails fast
+ * as a 500 rather than being masked as a retried 503. The declared `E` (the
+ * request-framing channel) passes through untouched: the route deliberately `orDie`s
+ * that, and lifting it would mask a real framing defect as a cold start.
  */
 export const withColdStartRetryFetch = <A, E>(
 	method: string,
@@ -202,12 +107,6 @@ export const withColdStartRetryFetch = <A, E>(
 		) as Effect.Effect<A, E | RpcCallErrorShape, never>,
 	) as Effect.Effect<A, E | LiveTransportError, never>;
 
-/**
- * The shared bounded-retry + convert both wrappers above reuse: retry ONLY the
- * `RpcCallError`-shaped transport failure (capped backoff), then map a surviving
- * one to the typed {@link LiveTransportError}. Any other channel member passes
- * through unchanged.
- */
 const retryTransportFailure = <A, E>(
 	method: string,
 	call: Effect.Effect<A, E | RpcCallErrorShape, never>,

--- a/apps/web/worker/features/fate-live/cold-start-retry.unit.test.ts
+++ b/apps/web/worker/features/fate-live/cold-start-retry.unit.test.ts
@@ -1,23 +1,8 @@
 /**
- * `withColdStartRetry` / `withColdStartRetryFetch` — the cold-DO transport
- * resilience seam (#842, #1048). The contract under test:
- *
- *   1. a transport failure that survives the bounded retry becomes a typed
- *      `LiveTransportError` (the route renders 503), NEVER a raw defect/500;
- *   2. the two transport CHANNELS both land there: the RPC methods raise the
- *      `RpcCallError` on the FAILURE channel (`withColdStartRetry`), and the GET
- *      SSE-open `.fetch` raises it on the DEFECT channel (`withColdStartRetryFetch`,
- *      #1048 — alchemy's `Effect.promise`-wrapped fetcher dies on a cold-DO
- *      rejection instead of failing);
- *   3. a non-transport app error (a declared `E`, NOT `RpcCallError`) fails fast
- *      and passes through untouched — the retry/convert never masks it;
- *   4. success passes straight through.
- *
- * The bounded backoff is driven by `TestClock` (no real ~1.5s sleeps): a forked
- * fiber runs the wrapped call, the clock is adjusted past the whole window, then
- * the exit is observed.
- *
- * Unit tier (ADR 0082): pure logic over a stubbed cross-DO call, no platform fake.
+ * The cold-DO transport resilience seam (#842, #1048). The two wrappers differ by
+ * channel: the RPC methods raise `RpcCallError` on the FAILURE channel, while the
+ * SSE-open `.fetch` raises it on the DEFECT channel, because alchemy's
+ * `Effect.promise`-wrapped fetcher dies on a cold-DO rejection instead of failing.
  */
 import {assert, it} from "@effect/vitest";
 import {Cause, Effect, Exit, Fiber} from "effect";
@@ -29,22 +14,15 @@ import {
 	withColdStartRetryFetch,
 } from "./cold-start-retry.ts";
 
-/**
- * Alchemy's real emitted `RpcCallError` shape, GROUNDED against the dep source:
- * `RpcCallError = Data.TaggedError("RpcCallError")<{method, cause}>`
- * (`alchemy/Cloudflare/Workers/Rpc.ts`), raised by `makeRpcStub`'s `tryPromise`
- * catch as `new RpcCallError({method, cause})`. The fixture carries the FULL field
- * set — `_tag` + `method` + `cause` — not just `{_tag, cause}`, so this pins the
- * coupling against alchemy's true contract (#1367 facet 2). The class is unexported,
- * so this is the closest pin available; keep it in sync with the cited `Rpc.ts`.
- */
+// Alchemy's real emitted shape, grounded in `alchemy/Cloudflare/Workers/Rpc.ts`. The
+// class is unexported, so this hand-built fixture is the closest pin available and
+// carries the FULL field set — keep it in sync with that file (#1367).
 const rpcCallError = (cause: unknown, method = "open") => ({
 	_tag: "RpcCallError" as const,
 	method,
 	cause,
 });
 
-/** A non-transport app error — a declared `E` that must NOT be retried/converted. */
 class AppError {
 	readonly _tag = "AppError";
 	readonly detail: string;
@@ -53,17 +31,15 @@ class AppError {
 	}
 }
 
-/** Run `effect` to its `Exit`, advancing past the whole bounded backoff window. */
 const runPastBackoff = <A, E>(effect: Effect.Effect<A, E>) =>
 	Effect.gen(function* () {
 		const fiber = yield* Effect.forkChild(effect);
-		// The schedule is ~100/200/400/800ms across 4 retries (<1.6s total); one
-		// generous adjust drains every sleep so the fiber settles.
+		// The schedule is ~100/200/400/800ms across 4 retries, so one generous adjust
+		// drains every sleep and the fiber settles.
 		yield* TestClock.adjust("10 seconds");
 		return yield* Fiber.join(fiber).pipe(Effect.exit);
 	});
 
-/** The single `Fail` reason's typed error, or `undefined` if the cause isn't one typed failure. */
 const failureValue = (exit: Exit.Exit<unknown, unknown>): unknown => {
 	if (Exit.isSuccess(exit)) {
 		return undefined;
@@ -85,11 +61,8 @@ it.effect("withColdStartRetry: a surviving RpcCallError failure → LiveTranspor
 it.effect(
 	"withColdStartRetry: a cold `topic:`-DO publish retries the RpcCallError, then LiveTransportError (#2551)",
 	() =>
-		// The publish seam now shares the RPC-channel retry (index.ts `LiveTopics.publish`):
-		// a publish to an idle-evicted `topic:` DO fails on the cold first RPC and must be
-		// retried across the bounded window, not dropped bare. Assert the retry FIRES (five
-		// attempts: one + four retries) and the surviving transport failure is the typed
-		// `LiveTransportError` — never an unretried rejection.
+		// A publish to an idle-evicted `topic:` DO fails on the cold first RPC; it must be
+		// retried across the bounded window, not dropped bare.
 		Effect.gen(function* () {
 			let attempts = 0;
 			const coldPublish = Effect.suspend(() => {
@@ -117,10 +90,8 @@ it.effect(
 	"withColdStartRetryFetch: a cold-DO transport DEFECT (bare Error) → LiveTransportError, not a die (#1048)",
 	() =>
 		Effect.gen(function* () {
-			// The cold-DO rejection surfaces as a DEFECT carrying a plain `Error` (alchemy's
-			// `Effect.promise`-wrapped fetcher; workerd rejects an unreachable DO with a bare
-			// `Error`, e.g. "Network connection lost."). It must land as a typed FAILURE
-			// (→ 503), never a defect at the boundary — the ADR 0095 behavior preserved.
+			// workerd rejects an unreachable DO with a bare `Error` ("Network connection
+			// lost."), which alchemy's wrapper turns into a defect. See ADR 0095.
 			const exit = yield* runPastBackoff(
 				withColdStartRetryFetch("open", Effect.die(new Error("cold-do unreachable"))),
 			);
@@ -138,10 +109,8 @@ it.effect(
 	"withColdStartRetryFetch: a non-transport code DEFECT (marshaling SyntaxError) RE-RAISES, not masked (#1367)",
 	() =>
 		Effect.gen(function* () {
-			// A marshaling/`Effect.map` die — here a `SyntaxError`, as a JSON parse failure
-			// while rendering the DO response — is NOT a cold-start signal. The blanket
-			// `catchDefect` used to launder it into a retried 503 (the ADR 0095 lie,
-			// inverted); it must now propagate as a DIE (500-class), never a LiveTransportError.
+			// A marshaling die is not a cold-start signal. The blanket `catchDefect` used to
+			// launder it into a retried 503 — the ADR 0095 lie, inverted.
 			const marshalingDie = new SyntaxError("Unexpected token in response body");
 			const exit = yield* runPastBackoff(
 				withColdStartRetryFetch("open", Effect.die(marshalingDie)),
@@ -162,9 +131,8 @@ it.effect(
 	"withColdStartRetryFetch: a declared HttpServerError-shaped E passes through unconverted",
 	() =>
 		Effect.gen(function* () {
-			// The `.fetch` request-framing channel (`HttpServerError`/`RequestError`) is
-			// NOT a cold-start signal — it stays on its own channel so the route can
-			// `orDie` a real framing defect rather than mask it as a warmup 503.
+			// The framing channel stays its own, so the route can `orDie` a real framing
+			// defect instead of masking it as a warmup 503.
 			const exit = yield* runPastBackoff(
 				withColdStartRetryFetch("open", Effect.fail(new AppError("framing"))),
 			);
@@ -177,10 +145,7 @@ it.effect(
 	"withColdStartRetryFetch: a transport DEFECT against alchemy's grounded RpcCallError shape → LiveTransportError (#1367)",
 	() =>
 		Effect.gen(function* () {
-			// Pin the coupling: a defect whose value is alchemy's REAL emitted shape
-			// (`{_tag:"RpcCallError", method, cause}`, grounded in `Rpc.ts`) must fire the
-			// retry → 503 path, proving the discriminant matches the true field set, not a
-			// truncated copy.
+			// Proves the discriminant matches alchemy's true field set, not a truncated copy.
 			const exit = yield* runPastBackoff(
 				withColdStartRetryFetch("open", Effect.die(rpcCallError(new Error("cold")))),
 			);
@@ -196,11 +161,6 @@ it.effect("withColdStartRetryFetch: success passes straight through", () =>
 	}),
 );
 
-// isNonTransportDefect — the conservative `.fetch` defect discriminant (#1367), both
-// arms: a code defect re-raises (true); an opaque/transport-shaped defect retries as the
-// cold-DO signal (false). The asymmetry IS the residual — see the predicate docblock for
-// why `TypeError`/bare-`Error` stay in the retried bucket.
-
 it("isNonTransportDefect: V8 code-defect classes are re-raised (true)", () => {
 	assert.isTrue(isNonTransportDefect(new RangeError("stack overflow")));
 	assert.isTrue(isNonTransportDefect(new ReferenceError("x is not defined")));
@@ -210,14 +170,12 @@ it("isNonTransportDefect: V8 code-defect classes are re-raised (true)", () => {
 });
 
 it("isNonTransportDefect: cold-DO transport-shaped defects are retried (false)", () => {
-	// A bare `Error` is how workerd surfaces a DO transport/readiness failure — it must
-	// stay in the retried bucket so the ADR 0095 cold-start path still fires.
+	// A bare `Error` is how workerd surfaces a DO transport failure, so it must stay in
+	// the retried bucket for the ADR 0095 cold-start path to fire.
 	assert.isFalse(isNonTransportDefect(new Error("Network connection lost.")));
-	// `TypeError` is the documented residual: ambiguous (marshaling bug OR network), so
-	// excluded from re-raise to protect AC3 — see the predicate docblock.
+	// `TypeError` is the documented residual: ambiguous between a marshaling bug and a
+	// network failure, so it is excluded from re-raise. See the predicate's docblock.
 	assert.isFalse(isNonTransportDefect(new TypeError("Cannot read properties of undefined")));
-	// alchemy's structural `RpcCallError` value and non-Error rejections are not code
-	// defects either.
 	assert.isFalse(isNonTransportDefect(rpcCallError(new Error("cold"))));
 	assert.isFalse(isNonTransportDefect("opaque string rejection"));
 	assert.isFalse(isNonTransportDefect(undefined));

--- a/apps/web/worker/features/fate-live/do-state.testing.ts
+++ b/apps/web/worker/features/fate-live/do-state.testing.ts
@@ -1,12 +1,7 @@
 /**
- * A node-pool platform fake of `Cloudflare.DurableObjectState["Service"]`,
- * KV-only — the slice {@link makeLiveInstance} touches. Backs the flat KV API
- * with one `Map` + a single alarm slot; `state.id.name` is the instance name
- * `resolveRole` reads. One non-obvious contract: `delete` MUST accept both a
- * single key and an array (publish bulk-deletes rows).
- *
- * A factory `*.testing.ts` module never imported by the worker graph
- * (`.patterns/effect-testing.md`).
+ * A KV-only platform fake of `Cloudflare.DurableObjectState["Service"]` — the slice
+ * {@link makeLiveInstance} touches, backed by one `Map` plus a single alarm slot.
+ * Never imported by the worker graph (`.patterns/effect-testing.md`).
  */
 import * as Effect from "effect/Effect";
 import type {LiveDoState} from "./live-do.ts";
@@ -17,18 +12,12 @@ export interface DurableObjectStateForTest {
 	readonly hasAlarm: () => boolean;
 }
 
-/** Build a test DO state with its own KV `Map` + single alarm slot. */
 export function makeDurableObjectStateForTest(options?: {
 	readonly id?: string;
 }): DurableObjectStateForTest {
 	const kv = new Map<string, unknown>();
 	let alarm: number | null = null;
 
-	// A KV-only structural fake of the host DO `Storage` binding. alchemy beta.59
-	// colored the storage methods with `RuntimeContext` and added an options overload
-	// this fake does not model, so the built object can't be assigned member-by-member;
-	// it is widened ONCE through `unknown` (the widen-once idiom the makeD1Rest/sqlite-d1
-	// fakes use), the same host-binding-fake case the repo discharges with `lint/plugin`.
 	type Storage = LiveDoState["storage"];
 
 	// biome-ignore lint/plugin: `Storage` is a host DO binding that can't be structurally constructed in a fake — beta.59's `RuntimeContext`-colored, overloaded signatures don't model in a plain KV Map; only the flat KV slice `makeLiveInstance` touches is exercised, nothing executes against the real binding.

--- a/apps/web/worker/features/fate-live/do.test.ts
+++ b/apps/web/worker/features/fate-live/do.test.ts
@@ -1,12 +1,7 @@
 /**
- * `LiveDO` (the unified, KV-backed live fan-out DO) on the Effect DO model.
- *
- * Drives the real {@link makeLiveInstance} builder over the KV-only `do-state`
- * fake, wiring `connection:`- and `topic:`-named instances as in-process
- * siblings. The `live` fake's `getByName` routes by name prefix to the matching
- * instance's {@link LiveRpcSurface}, exactly as the worker's cross-role RPC does —
- * so a topic→connection `deliver` and a connection→topic `register` hop between
- * the real instances, proving the acceptance criteria without workerd.
+ * `LiveDO` on the Effect DO model, driven over the KV-only `do-state` fake: the `live`
+ * fake's `getByName` routes by name prefix, so a topic→connection `deliver` and a
+ * connection→topic `register` hop between real instances without workerd.
  */
 import {RuntimeContext} from "alchemy";
 import {Effect} from "effect";
@@ -29,11 +24,9 @@ import type {
 } from "./protocol.ts";
 import {topicsForPublish, topicsForSubscribe} from "./protocol.ts";
 
-// alchemy beta.59 colored the DO storage methods (and every `LiveRpcSurface`
-// method that touches `state.storage` or hops cross-role) with `RuntimeContext`
-// (ADR 0124). The KV-only `do-state` fake is pure `Effect.sync`, so nothing
-// actually reads the context at runtime — `RuntimeContext.phantom` discharges the
-// type requirement so these in-process unit runs stay `Effect.runPromise`-able.
+// alchemy beta.59 colors the DO storage methods with `RuntimeContext` (ADR 0124). The
+// KV-only fake never reads it, so `RuntimeContext.phantom` discharges the type
+// requirement and keeps these in-process runs `Effect.runPromise`-able.
 const run = <A>(effect: Effect.Effect<A, never, RuntimeContext>): Promise<A> =>
 	Effect.runPromise(Effect.provide(effect, RuntimeContext.phantom));
 
@@ -51,9 +44,8 @@ const LIMITS: LiveLimits = {
 type LiveInstance = ReturnType<typeof makeLiveInstance>;
 
 /**
- * An in-process `live` namespace fake. An unknown name resolves to a stub whose
- * every method dies, so a topic probing an unregistered connection sees "couldn't
- * reach" (not "confirmed stale").
+ * An unknown name resolves to a stub whose every method dies, so a topic probing an
+ * unregistered connection sees "couldn't reach", not "confirmed stale".
  */
 interface LiveCell {
 	readonly live: {readonly getByName: (name: string) => LiveRpcSurface};
@@ -175,15 +167,12 @@ describe("LiveDO live fan-out (KV model)", () => {
 		expect(sub.ok).toBe(true);
 
 		const pub = await run(topic.publish({topicKey, frame: entityFrame, limits: LIMITS}));
-		// `delivered > 0` proves the topic→connection cross-role path fired (a
-		// wrong namespace-routing fake would silently pass with delivered 0).
 		expect(pub.delivered).toBeGreaterThan(0);
 
 		const frame = await stream.next();
 		expect(frame).toContain("event: next");
 		const payload = payloadOf(frame);
 		expect(payload.kind).toBe("next");
-		// Per-subscriber id: stamped at delivery from the row's subId, not publish.
 		expect(payload.id).toBe(subId);
 
 		await stream.cancel();
@@ -205,7 +194,6 @@ describe("LiveDO live fan-out (KV model)", () => {
 		);
 		await run(connection.subscribe({subId, topics: [topicKey], ownerId, limits: LIMITS}));
 
-		// Reconnect: generation bumps; the topic still holds the old-generation row.
 		await run(
 			connection.openStream({
 				ownerId,
@@ -222,8 +210,7 @@ describe("LiveDO live fan-out (KV model)", () => {
 		const topicKey = "Term:t-1";
 		const {instance: topic, fake} = makeTopic(cell, topicKey);
 
-		// Register a row directly for a connection that is NOT in the cell, so any
-		// probe of `connection:gone` dies → "couldn't reach".
+		// A connection that is NOT in the cell, so any probe of it dies → "couldn't reach".
 		const row: SubscriberRow = {
 			topicKey,
 			connectionId: "gone",
@@ -236,8 +223,7 @@ describe("LiveDO live fan-out (KV model)", () => {
 		expect(reg.ok).toBe(true);
 		expect(fake.hasAlarm()).toBe(true);
 
-		// First failed probe reaps ALL that connection's rows (void-faithful — no
-		// consecutive-miss counter).
+		// The first failed probe reaps ALL that connection's rows (no consecutive-miss counter).
 		await run(topic.alarm());
 
 		const pub = await run(topic.publish({topicKey, frame: entityFrame, limits: LIMITS}));
@@ -289,10 +275,8 @@ describe("LiveDO live fan-out (KV model)", () => {
 	});
 
 	it("connection sub under specific+global topics gets ONE frame per publish (no double-delivery)", async () => {
-		// A connection subscription registers under BOTH the args-scoped and global
-		// wildcard topic. The bug: `topicsForPublish` fanned a single publish out to
-		// both keys, so the connection (in both topic DOs) was `deliver`ed twice.
-		// Drive the FULL path (subscribe → register, publish) to assert real wiring.
+		// The subscription registers under BOTH the args-scoped and the global wildcard topic;
+		// the bug was `topicsForPublish` fanning one publish out to both keys.
 		const cell = makeLiveCell();
 		const connection = makeConnection(cell, "conn-dd");
 
@@ -341,7 +325,6 @@ describe("LiveDO live fan-out (KV model)", () => {
 			},
 		};
 		const publishTopics = topicsForPublish(message);
-		// The fix: a connection publish with args resolves to EXACTLY ONE key, not both.
 		expect(publishTopics.length).toBe(1);
 
 		let delivered = 0;
@@ -358,15 +341,13 @@ describe("LiveDO live fan-out (KV model)", () => {
 			delivered += pub.delivered;
 		}
 
-		// The connection was reached exactly once across the whole publish.
 		expect(delivered).toBe(1);
 
 		const first = await stream.next();
 		expect(first).toContain("event: connection");
 		expect(payloadOf(first).id).toBe(subControl.subId);
 
-		// No second frame: race `next()` against a short idle window. A pre-fix
-		// duplicate would already be buffered and returned immediately.
+		// A pre-fix duplicate would already be buffered, so race `next()` against an idle window.
 		const second = await Promise.race([
 			stream.next(),
 			new Promise<"idle">((resolve) => setTimeout(() => resolve("idle"), 50)),
@@ -392,8 +373,6 @@ describe("LiveDO live fan-out (KV model)", () => {
 		const sub = await run(connection.subscribe({subId, topics: [topicKey], ownerId, limits}));
 		expect(sub.ok).toBe(true);
 
-		// Publish past the cap: the queue fills, the next deliver is refused, the
-		// connection closes, and the row goes stale (void's 410 on queue full).
 		let sawStale = false;
 		for (let i = 0; i < cap + 5; i++) {
 			const pub = await run(topic.publish({topicKey, frame: entityFrame, limits}));
@@ -404,7 +383,6 @@ describe("LiveDO live fan-out (KV model)", () => {
 		}
 		expect(sawStale).toBe(true);
 
-		// Stream closed: a subsequent deliver finds no queue → stale.
 		const after = await run(topic.publish({topicKey, frame: entityFrame, limits}));
 		expect(after.delivered).toBe(0);
 	});
@@ -414,8 +392,7 @@ describe("LiveDO live fan-out (KV model)", () => {
 		const topicKey = "Post:post-hung";
 		const {instance: topic} = makeTopic(cell, topicKey);
 
-		// A connection whose `deliver` never resolves — a wedged isolate. Full
-		// `LiveInstance` (the rest die if touched) so no cast is needed.
+		// A connection whose `deliver` never resolves — a wedged isolate.
 		const hung: LiveInstance = {
 			openStream: () => Effect.die("unused"),
 			subscribe: () => Effect.die("unused"),
@@ -440,23 +417,18 @@ describe("LiveDO live fan-out (KV model)", () => {
 		const reg = await run(topic.register({row, limits: LIMITS, subscribedAt: Date.now()}));
 		expect(reg.ok).toBe(true);
 
-		// A tight budget: the hung deliver must NOT wedge publish — the
-		// `Effect.timeout(deliveryAttemptTimeoutMs)` fires, the attempt is "couldn't
-		// reach" (delivered 0), and publish settles within the budget.
+		// The hung deliver must not wedge publish: the attempt times out and publish settles.
 		const limits: LiveLimits = {...LIMITS, deliveryAttemptTimeoutMs: 50};
 		const started = Date.now();
 		const pub = await run(topic.publish({topicKey, frame: entityFrame, limits}));
 		const elapsed = Date.now() - started;
 
 		expect(pub.delivered).toBe(0);
-		// Settled near the budget, not hung forever (generous ceiling for CI jitter).
 		expect(elapsed).toBeLessThan(2000);
 		expect(elapsed).toBeGreaterThanOrEqual(40);
 	});
 
-	// The #714 race: a publish fires before the subscriber's `register` commits, so
-	// fan-out delivers to an empty registry. The storage-backed catch-up buffer must
-	// replay the missed frame to the connection when its register finally lands.
+	// The #714 publish-vs-register race: .patterns/fate-live-consistency.md
 	it("register after publish replays the buffered frame (the #714 catch-up)", async () => {
 		const cell = makeLiveCell();
 		const connection = makeConnection(cell, "conn-late");
@@ -474,12 +446,9 @@ describe("LiveDO live fan-out (KV model)", () => {
 		const stream = await reader(res);
 		expect(await stream.next()).toContain("connected");
 
-		// Publish BEFORE the subscriber registers — fan-out finds an empty registry.
 		const pub = await run(topic.publish({topicKey, frame: entityFrame, limits: LIMITS}));
 		expect(pub.delivered).toBe(0);
 
-		// Now the subscribe→register lands (the slow RPC of #714). Replay must deliver
-		// the buffered frame to this just-registered connection.
 		const sub = await run(
 			connection.subscribe({subId, topics: [topicKey], ownerId, limits: LIMITS}),
 		);
@@ -492,10 +461,7 @@ describe("LiveDO live fan-out (KV model)", () => {
 		await stream.cancel();
 	});
 
-	// The dedup boundary: an already-registered connection receives a publish via
-	// fan-out; a SECOND connection registering afterward gets the same frame via
-	// replay. Neither connection ever sees the frame twice — fan-out reaches only the
-	// already-registered, replay only the just-registering.
+	// Fan-out reaches only the already-registered, replay only the just-registering.
 	it("no double-apply: fan-out and replay deliver each frame to a connection at most once", async () => {
 		const cell = makeLiveCell();
 		const topicKey = "Post:post-dedup";
@@ -521,7 +487,6 @@ describe("LiveDO live fan-out (KV model)", () => {
 		expect(await streamEarly.next()).toContain("connected");
 		expect(await streamLate.next()).toContain("connected");
 
-		// Only the early connection is registered when the publish fires.
 		await run(
 			connEarly.subscribe({
 				subId: "sub-early",
@@ -531,9 +496,8 @@ describe("LiveDO live fan-out (KV model)", () => {
 			}),
 		);
 		const pub = await run(topic.publish({topicKey, frame: entityFrame, limits: LIMITS}));
-		expect(pub.delivered).toBe(1); // fan-out reached ONLY the early connection
+		expect(pub.delivered).toBe(1);
 
-		// The early connection got it via fan-out — exactly one frame, no replay echo.
 		expect(payloadOf(await streamEarly.next()).id).toBe("sub-early");
 		const earlyEcho = await Promise.race([
 			streamEarly.next(),
@@ -541,8 +505,6 @@ describe("LiveDO live fan-out (KV model)", () => {
 		]);
 		expect(earlyEcho).toBe("idle");
 
-		// The late connection registers AFTER the publish → gets the frame via replay,
-		// exactly once (fan-out could not have reached it).
 		await run(
 			connLate.subscribe({
 				subId: "sub-late",
@@ -562,10 +524,7 @@ describe("LiveDO live fan-out (KV model)", () => {
 		await streamLate.cancel();
 	});
 
-	// `lastEventId` bounds the replay: a resubscribe carrying the per-topic `seq` it
-	// already saw replays ONLY the strictly-newer frames, not the whole window. The
-	// topic owns the SSE `id:` (it stamps `eventId = String(seq)` on publish, #731),
-	// so the cursor the client carries on reconnect is that seq — here `"1"`.
+	// The topic stamps the SSE `id:` as the per-topic `seq` (#731), so the cursor is that seq.
 	it("lastEventId bounds replay to frames newer than the last one the subscriber saw", async () => {
 		const cell = makeLiveCell();
 		const topicKey = "Post:post-lei";
@@ -581,13 +540,11 @@ describe("LiveDO live fan-out (KV model)", () => {
 		const stream = await reader(res);
 		expect(await stream.next()).toContain("connected");
 
-		// Two frames published before any register; the topic stamps seq 1, then 2.
 		const frameOld: DeliverFrame = {kind: "next", id: "", event: {data: {n: 1}}};
 		const frameNew: DeliverFrame = {kind: "next", id: "", event: {data: {n: 2}}};
 		await run(topic.publish({topicKey, frame: frameOld, limits: LIMITS}));
 		await run(topic.publish({topicKey, frame: frameNew, limits: LIMITS}));
 
-		// Resubscribe declaring it already saw seq 1 → replay must skip seq 1, deliver seq 2.
 		const sub = await run(
 			connection.subscribe({
 				subId: "sub-lei",
@@ -600,7 +557,6 @@ describe("LiveDO live fan-out (KV model)", () => {
 		expect(sub.ok).toBe(true);
 
 		const frame = await stream.next();
-		// Only the newer frame replays — its SSE `id:` header carries seq 2.
 		expect(frame).toContain("id: 2");
 		expect(frame).not.toContain("id: 1\n");
 
@@ -613,18 +569,9 @@ describe("LiveDO live fan-out (KV model)", () => {
 		await stream.cancel();
 	});
 
-	// The #731 fix, at the cursor that exposes it: the reconnect `lastEventId` is the
-	// last per-topic `seq` the client saw, and replay must skip `seq <= cursor` and
-	// deliver STRICTLY-newer — even when the cursor frame itself has aged out of the
-	// window. The old string-equality scan walked the window looking for the exact
-	// `eventId === lastEventId`; when that frame is gone it never matches, so it
-	// wrongly DROPS every newer frame too — the client never catches up and its scalar
-	// is stuck at the stale value it last applied (the #731 clobber, replay side).
-	//
-	// Drive register directly (deterministic `subscribedAt`) over a SEPARATE topic with
-	// no fan-out row, so the only path a frame can arrive is replay. Publish seq 1, then
-	// seq 2; age seq 1 out of the window; reconnect with cursor `"1"`. The numeric skip
-	// replays seq 2 (`2 > 1`); the string scan, never finding seq 1, drops it.
+	// The #731 replay-side clobber: the old string-equality scan looked for the exact
+	// `eventId === lastEventId` in the window, so once the cursor frame aged out it matched
+	// nothing and dropped every newer frame too. Replay must skip `seq <= cursor` numerically.
 	it("replay delivers strictly-newer even when the cursor frame aged out (the #731 clobber, replay side)", async () => {
 		const cell = makeLiveCell();
 		const topicKey = "Post:post-clobber";
@@ -644,8 +591,7 @@ describe("LiveDO live fan-out (KV model)", () => {
 		const stream = await reader(res);
 		expect(await stream.next()).toContain("connected");
 
-		// Activate `subId` on the connection via the decoy (so the replayed deliver isn't
-		// stale), generation 1 / revision 1 — matching the manual row below.
+		// Activate `subId` via the decoy so the replayed deliver isn't stale (generation 1 / revision 1).
 		await run(connection.subscribe({subId, topics: [decoyKey], ownerId, limits: LIMITS}));
 
 		// A short TTL: seq 1 is published, then aged past its window; seq 2 lands fresh.
@@ -653,12 +599,11 @@ describe("LiveDO live fan-out (KV model)", () => {
 		const frameOld: DeliverFrame = {kind: "next", id: "", event: {data: {score: 1}}};
 		const frameNew: DeliverFrame = {kind: "next", id: "", event: {data: {score: 2}}};
 		const beforePublish = Date.now();
-		await run(topic.publish({topicKey, frame: frameOld, limits})); // seq 1 (the cursor frame)
+		await run(topic.publish({topicKey, frame: frameOld, limits}));
 		await new Promise((resolve) => setTimeout(resolve, 50)); // seq 1 ages past the 30ms TTL
-		await run(topic.publish({topicKey, frame: frameNew, limits})); // seq 2 (strictly newer, fresh)
+		await run(topic.publish({topicKey, frame: frameNew, limits}));
 
-		// Reconnect carrying cursor `"1"` — the seq it last saw, now aged out of the window.
-		// Register from BEFORE either publish so the `subscribedAt` floor admits seq 2.
+		// Reconnect with cursor `"1"` (now aged out); register from before either publish.
 		const row: SubscriberRow = {
 			topicKey,
 			connectionId: "conn-clobber",
@@ -672,9 +617,6 @@ describe("LiveDO live fan-out (KV model)", () => {
 		);
 		expect(reg.ok).toBe(true);
 
-		// seq 2 replays (strictly newer than the cursor), carrying its SSE `id: 2`. The
-		// old string scan would have dropped it (cursor frame seq 1 is gone), stranding
-		// the client on the stale score-1 it last applied.
 		const frame = await stream.next();
 		expect(frame).toContain("id: 2");
 		expect(payloadOf(frame).id).toBe(subId);
@@ -688,14 +630,9 @@ describe("LiveDO live fan-out (KV model)", () => {
 		await stream.cancel();
 	});
 
-	// The PRIMARY replay bound is `subscribedAt`: replay delivers ONLY frames
-	// published at/after the subscriber's intent instant. These two tests drive
-	// `register` directly with an explicit `subscribedAt` so the window edge is
-	// deterministic (no wall-clock race). To isolate the REPLAY path from fan-out,
-	// the connection subscribes to a DECOY topic (activating the subId on the
-	// connection so the replayed deliver isn't stale) while the frame is published to
-	// a SEPARATE topic with NO registered row — so fan-out reaches nothing and the
-	// only way the frame can arrive is replay on the manual `register`.
+	// Replay's primary `subscribedAt` bound: .patterns/fate-live-views.md. These drive `register`
+	// directly for a deterministic window edge, and isolate replay from fan-out by subscribing to a
+	// DECOY topic while publishing to a SEPARATE topic with no registered row.
 	it("a frame published at/after subscribedAt replays (the #714 catch-up window)", async () => {
 		const cell = makeLiveCell();
 		const topicKey = "Post:post-after";
@@ -718,9 +655,7 @@ describe("LiveDO live fan-out (KV model)", () => {
 		// Activate `subId` on the connection via the decoy (revision 1, generation 1).
 		await run(connection.subscribe({subId, topics: [decoyKey], ownerId, limits: LIMITS}));
 
-		// Publish to the REAL topic (no registered row → fan-out delivers nothing),
-		// then register a row with `subscribedAt` set BEFORE the frame's publish time:
-		// the frame is at/after intent → replay must deliver it.
+		// `subscribedAt` set BEFORE the frame's publish time → the frame is at/after intent.
 		const beforePublish = Date.now();
 		await run(topic.publish({topicKey, frame: entityFrame, limits: LIMITS}));
 		const row: SubscriberRow = {
@@ -762,10 +697,7 @@ describe("LiveDO live fan-out (KV model)", () => {
 
 		await run(connection.subscribe({subId, topics: [decoyKey], ownerId, limits: LIMITS}));
 
-		// Publish to the REAL topic, then register (epoch-absent, `subscribedAt`-fallback
-		// path) with `subscribedAt` set WELL AFTER the frame's publish time — the frame
-		// predates the subscriber's intent, the regression's stale-history case. It must NOT
-		// replay.
+		// `subscribedAt` set WELL AFTER the publish (epoch-absent fallback path) → must not replay.
 		await run(topic.publish({topicKey, frame: entityFrame, limits: LIMITS}));
 		const row: SubscriberRow = {
 			topicKey,
@@ -787,8 +719,6 @@ describe("LiveDO live fan-out (KV model)", () => {
 		await stream.cancel();
 	});
 
-	// The buffer is bounded by TTL: a register that lands past the window gets no
-	// replay — the race window is a few seconds, not unbounded retention.
 	it("a register past the TTL window replays nothing (bounded buffer)", async () => {
 		const cell = makeLiveCell();
 		const topicKey = "Post:post-ttl";
@@ -804,10 +734,8 @@ describe("LiveDO live fan-out (KV model)", () => {
 		const stream = await reader(res);
 		expect(await stream.next()).toContain("connected");
 
-		// A 1ms TTL + a real gap before register: the buffered frame is past its
-		// window by the time replay runs, so nothing replays. (A 0ms TTL would race
-		// the clock — a same-millisecond publish+register is `now - at === 0`, still
-		// inside the `<= ttl` window.)
+		// A 1ms TTL + a real gap: a 0ms TTL would race the clock, since a same-millisecond
+		// publish+register is `now - at === 0` and still inside the `<= ttl` window.
 		const limits: LiveLimits = {...LIMITS, bufferedFrameTtlMs: 1};
 		await run(topic.publish({topicKey, frame: entityFrame, limits}));
 		await new Promise((resolve) => setTimeout(resolve, 20));
@@ -821,7 +749,6 @@ describe("LiveDO live fan-out (KV model)", () => {
 		);
 		expect(sub.ok).toBe(true);
 
-		// No replay frame — only the idle timeout resolves.
 		const echo = await Promise.race([
 			stream.next(),
 			new Promise<"idle">((resolve) => setTimeout(() => resolve("idle"), 50)),
@@ -841,11 +768,8 @@ describe("LiveDO live fan-out (KV model)", () => {
 // beat — while a #714 register-race frame (published after `openStream`) still clears it. The
 // wall-clock grace that once sat below this floor was itself the #1903 leak and is gone.
 describe("LiveDO replay epoch fence (#1072/#1903)", () => {
-	// Driven via direct `register` with explicit `subscribedAt` + `epochStartedAt` so the
-	// window edges are deterministic (no wall-clock race), mirroring the `subscribedAt`-floor
-	// tests: subscribe to a DECOY topic to activate the subId on the connection, publish to a
-	// SEPARATE topic with NO registered row (fan-out reaches nothing), so replay is the only
-	// path the frame could arrive by.
+	// Direct `register` with explicit `subscribedAt` + `epochStartedAt` for a deterministic window
+	// edge; decoy topic + separate publish topic isolate replay from fan-out, as above.
 	it("a pre-epoch frame inside the clock grace does NOT replay (epoch fence)", async () => {
 		const cell = makeLiveCell();
 		const topicKey = "Post:post-epoch-fence";
@@ -873,10 +797,8 @@ describe("LiveDO replay epoch fence (#1072/#1903)", () => {
 		await run(topic.publish({topicKey, frame: entityFrame, limits: LIMITS}));
 		const afterPublish = Date.now();
 
-		// The epoch began strictly AFTER the frame was buffered (a reconnect past the
-		// publish), while `subscribedAt` sits INSIDE the 1s grace — so the time-grace floor
-		// alone (`subscribedAt - 1000` ≈ `afterPublish - 900` ≤ buffered.at) WOULD admit it
-		// (the pre-fix leak). The epoch floor (`epochStartedAt` > buffered.at) excludes it.
+		// The epoch begins strictly AFTER the frame was buffered, while `subscribedAt` sits inside
+		// the old 1s grace — the pre-fix leak the epoch floor now excludes.
 		const epochStartedAt = afterPublish + 1;
 		const subscribedAt = afterPublish + 100;
 		const row: SubscriberRow = {
@@ -921,9 +843,7 @@ describe("LiveDO replay epoch fence (#1072/#1903)", () => {
 
 		await run(connection.subscribe({subId, topics: [decoyKey], ownerId, limits: LIMITS}));
 
-		// The epoch began BEFORE the frame was published (the stream was already open when
-		// the race frame fired) and `subscribedAt` is at the epoch start — the #714 catch-up
-		// case. `buffered.at >= epochStartedAt`, so the fence does NOT exclude it.
+		// The epoch begins BEFORE the publish (stream already open) — the #714 case the fence keeps.
 		const epochStartedAt = Date.now();
 		const subscribedAt = epochStartedAt;
 		await run(topic.publish({topicKey, frame: entityFrame, limits: LIMITS}));
@@ -945,11 +865,7 @@ describe("LiveDO replay epoch fence (#1072/#1903)", () => {
 		await stream.cancel();
 	});
 
-	// The real-client flake shape end to end: a cursorless reconnect under a reused
-	// connectionId, driven through `openStream` → `subscribe` (which threads the recorded
-	// `epochStartedAt`), not a direct `register`. A small real gap before the reconnect makes
-	// `epochStartedAt` strictly later than the buffered frame yet far inside the 1s grace, so
-	// pre-fix the time-grace floor would leak the prior frame onto the reconnected stream.
+	// The same shape end to end through `openStream` → `subscribe`, not a direct `register`.
 	it("a frame buffered before a cursorless reconnect's epoch does not leak onto the new stream", async () => {
 		const cell = makeLiveCell();
 		const topicKey = "Post:posts-reconnect";
@@ -957,8 +873,7 @@ describe("LiveDO replay epoch fence (#1072/#1903)", () => {
 		const connection = makeConnection(cell, "conn-reconnect");
 		const ownerId = "owner-reconnect";
 
-		// First connect (epoch 1): a connection exists so the frame is realistic, but no
-		// subscription yet — the published frame lands only in the buffer.
+		// First connect (epoch 1), no subscription yet — the frame lands only in the buffer.
 		await run(
 			connection.openStream({
 				ownerId,
@@ -967,12 +882,9 @@ describe("LiveDO replay epoch fence (#1072/#1903)", () => {
 		);
 		await run(topic.publish({topicKey, frame: entityFrame, limits: LIMITS}));
 
-		// A real gap so the reconnect's `epochStartedAt` is strictly after the buffered
-		// frame's `at`, yet far inside the 1s grace (pre-fix, the grace floor still admits it).
+		// A real gap so the reconnect's epoch is strictly after the buffered frame's `at`.
 		await new Promise((resolve) => setTimeout(resolve, 5));
 
-		// Reconnect under the SAME connectionId (epoch 2): generation bumps, a fresh
-		// `epochStartedAt` is recorded — strictly after the buffered frame.
 		const res = await run(
 			connection.openStream({
 				ownerId,
@@ -982,8 +894,6 @@ describe("LiveDO replay epoch fence (#1072/#1903)", () => {
 		const stream = await reader(res);
 		expect(await stream.next()).toContain("connected");
 
-		// Cursorless resubscribe on the reconnected stream → register (generation 2) →
-		// replay. The buffered frame predates epoch 2, so the epoch fence excludes it.
 		const sub = await run(
 			connection.subscribe({subId: "sub-reconnect", topics: [topicKey], ownerId, limits: LIMITS}),
 		);
@@ -1031,35 +941,28 @@ describe("LiveDO replay epoch fence (#1072/#1903)", () => {
 		const stream = await reader(res);
 		expect(await stream.next()).toContain("connected");
 
-		// Activate `subId` on the connection via the decoy so a replayed deliver to the
-		// real topic is non-stale (generation 1 / revision 1).
+		// Activate `subId` via the decoy so a replayed deliver to the real topic isn't stale.
 		await run(connection.subscribe({subId, topics: [decoyKey], ownerId, limits: LIMITS}));
 
-		// (b) STALE PRE-VOTE frame (score:0): buffered BEFORE the reload's epoch begins.
-		// `buffered.at` is stamped `Date.now()` inside `publish` (live-do.ts:713); a real gap
-		// on either side of the epoch makes the two frames' `at` fall on opposite sides of
-		// `epochStartedAt` deterministically (no same-millisecond ambiguity).
+		// (b) STALE PRE-VOTE frame (score:0), buffered BEFORE the reload's epoch. The real gaps on
+		// either side put the two frames' `at` on opposite sides of `epochStartedAt`.
 		const preVoteFrame: DeliverFrame = {kind: "next", id: "", event: {data: {score: 0}}};
 		const staleAt = Date.now();
 		await run(topic.publish({topicKey, frame: preVoteFrame, limits: LIMITS}));
 
-		// The reload's epoch begins strictly AFTER the stale frame was buffered — this is the
-		// causal boundary `openStream` (live-do.ts:264) stamps on the page-reload reconnect.
+		// The reload's epoch: the causal boundary `openStream` stamps on the reconnect.
 		await new Promise((resolve) => setTimeout(resolve, 5));
 		const epochStartedAt = Date.now();
 		await new Promise((resolve) => setTimeout(resolve, 5));
 
-		// (a) #714 REGISTER-RACE frame (score:1): fires AFTER the epoch (stream already open)
-		// but BEFORE `register` commits. Post-epoch ⇒ must be KEPT for #714.
+		// (a) #714 REGISTER-RACE frame (score:1): post-epoch ⇒ must be KEPT.
 		const raceFrame: DeliverFrame = {kind: "next", id: "", event: {data: {score: 1}}};
 		const raceAt = Date.now();
 		await run(topic.publish({topicKey, frame: raceFrame, limits: LIMITS}));
 		const afterRace = Date.now();
 
-		// The cursorless (`lastEventId: undefined`) register lands. `subscribedAt` sits so BOTH
-		// frames would have been inside the OLD 1s wall-clock grace (`subscribedAt - 1000 <
-		// staleAt`) — proving the removed grace admitted the stale frame, so ONLY the
-		// `epochStartedAt` causal floor discriminates now.
+		// `subscribedAt` sits so BOTH frames were inside the OLD 1s grace, leaving the epoch floor
+		// as the only discriminator.
 		const subscribedAt = afterRace;
 		expect(subscribedAt - 1000).toBeLessThan(staleAt); // the removed grace would KEEP the stale frame
 		expect(staleAt).toBeLessThan(epochStartedAt); // pre-vote frame is pre-epoch ⇒ DROP
@@ -1076,15 +979,12 @@ describe("LiveDO replay epoch fence (#1072/#1903)", () => {
 		const reg = await run(topic.register({row, limits: LIMITS, subscribedAt, epochStartedAt}));
 		expect(reg.ok).toBe(true);
 
-		// The KEEP frame (#714 race, score:1) replays — and it is the ONLY frame that arrives.
 		const kept = await stream.next();
 		expect(kept).toContain("event: next");
 		expect(payloadOf(kept).id).toBe(subId);
 		expect((payloadOf(kept).event.data as {score: number}).score).toBe(1);
 
-		// No second frame: the stale pre-vote (score:0) was fenced by the epoch floor, so it
-		// never reaches the reconnected stream to clobber the correct value. The fence cleanly
-		// separated KEEP (post-epoch) from DROP (pre-epoch) with no wall-clock grace beneath it.
+		// No second frame: the stale pre-vote was fenced by the epoch floor.
 		const echo = await Promise.race([
 			stream.next(),
 			new Promise<"idle">((resolve) => setTimeout(() => resolve("idle"), 50)),
@@ -1095,18 +995,11 @@ describe("LiveDO replay epoch fence (#1072/#1903)", () => {
 	});
 });
 
-// The OTHER buffer bound is the count cap (`maxBufferedFramesPerTopic`): the ring
-// stays small so a topic DO's storage can't grow without limit under a publish
-// storm with no subscriber to drain it. Prune runs INLINE on every publish
-// (`appendToBuffer`) and on register (`replayBuffer`), with no background sweep.
-//
-// Non-obvious shape exercised here: prune is "prune-then-append" — `appendToBuffer`
-// prunes the EXISTING buffer (to the cap) and then writes the new frame, so storage
-// settles at cap+1 frames, while the read path (`pruneBuffer` inside `replayBuffer`)
-// prunes again and only ever hands replay the newest `cap` survivors. The cap is the
-// thing under test, so these drive it directly with a small `maxBufferedFramesPerTopic`.
+// Buffer bounds: .patterns/fate-live-views.md. Non-obvious shape exercised here: prune is
+// "prune-then-append" — `appendToBuffer` prunes the EXISTING buffer to the cap and then writes
+// the new frame, so storage settles at cap+1, while the read path (`pruneBuffer` inside
+// `replayBuffer`) prunes again and hands replay only the newest `cap` survivors.
 describe("LiveDO replay buffer count-cap overflow prune", () => {
-	/** The seqs currently retained in a topic's storage-backed ring, ascending. */
 	const bufferedSeqs = (
 		fake: ReturnType<typeof makeDurableObjectStateForTest>,
 		topicKey: string,
@@ -1122,26 +1015,19 @@ describe("LiveDO replay buffer count-cap overflow prune", () => {
 		const topicKey = "Post:post-cap-overflow";
 		const {instance: topic, fake} = makeTopic(cell, topicKey);
 
-		// Cap of 3, no registered subscriber: every publish only writes the ring.
 		const cap = 3;
 		const limits: LiveLimits = {...LIMITS, maxBufferedFramesPerTopic: cap};
 
-		// Publish far past the cap (seq 1..10). Prune-then-append settles storage at
-		// cap+1: the prune (which runs BEFORE the append) trims the existing ring to
-		// `cap`, then the new frame lands → `cap + 1` retained.
 		const total = 10;
 		for (let i = 0; i < total; i++) {
 			await run(topic.publish({topicKey, frame: entityFrame, limits}));
 		}
 
 		const retained = await bufferedSeqs(fake, topicKey);
-		// (a) bounded: never grows with publish count — exactly cap+1, not `total`.
 		expect(retained.length).toBe(cap + 1);
-		// (b)+(c) the SURVIVORS are the newest contiguous window: seqs 7,8,9,10. The
-		// oldest (1..6) were pruned, lowest-seq-first.
 		expect(retained).toEqual([total - cap, total - cap + 1, total - cap + 2, total]);
-		expect(retained[0]).toBe(total - cap); // oldest survivor
-		expect(retained[retained.length - 1]).toBe(total); // newest survivor retained
+		expect(retained[0]).toBe(total - cap);
+		expect(retained[retained.length - 1]).toBe(total);
 	});
 
 	it("the cap bounds the replay WINDOW to the newest `cap` frames (overflow not replayed)", async () => {
@@ -1163,14 +1049,11 @@ describe("LiveDO replay buffer count-cap overflow prune", () => {
 		const stream = await reader(res);
 		expect(await stream.next()).toContain("connected");
 
-		// Activate the subId on the connection via a decoy topic (revision 1 /
-		// generation 1), so the replayed deliver to the REAL topic isn't stale.
+		// Activate the subId via a decoy topic so the replayed deliver to the REAL topic isn't stale.
 		await run(connection.subscribe({subId, topics: [decoyKey], ownerId, limits: LIMITS}));
 
-		// Cap of 3; publish seq 1..6 to the real topic (no registered row → fan-out
-		// reaches nothing, so replay is the only delivery path). A `subscribedAt` from
-		// before any publish admits the whole surviving window, isolating the COUNT cap
-		// from the `subscribedAt` bound.
+		// No registered row on the real topic → replay is the only delivery path; a `subscribedAt`
+		// from before any publish isolates the COUNT cap from the `subscribedAt` bound.
 		const cap = 3;
 		const limits: LiveLimits = {...LIMITS, maxBufferedFramesPerTopic: cap};
 		const beforePublish = Date.now();
@@ -1190,9 +1073,7 @@ describe("LiveDO replay buffer count-cap overflow prune", () => {
 		const reg = await run(topic.register({row, limits, subscribedAt: beforePublish}));
 		expect(reg.ok).toBe(true);
 
-		// Replay hands back exactly the newest `cap` frames, in order — the read-path
-		// prune drops the cap+1th oldest survivor from the window. SSE `id:` carries the
-		// per-topic seq, so we assert the exact retained seq range: 4, 5, 6.
+		// SSE `id:` carries the per-topic seq, so assert the exact retained range.
 		const seqs: Array<number> = [];
 		for (let i = 0; i < cap; i++) {
 			const frame = await stream.next();
@@ -1200,9 +1081,8 @@ describe("LiveDO replay buffer count-cap overflow prune", () => {
 			const idLine = frame.split("\n").find((l) => l.startsWith("id: "))!;
 			seqs.push(Number(idLine.slice("id: ".length)));
 		}
-		expect(seqs).toEqual([total - cap + 1, total - cap + 2, total]); // 4, 5, 6 — never seq 1..3
+		expect(seqs).toEqual([total - cap + 1, total - cap + 2, total]);
 
-		// No further frame: the overflow (seq 1..3) was pruned, not replayed.
 		const echo = await Promise.race([
 			stream.next(),
 			new Promise<"idle">((resolve) => setTimeout(() => resolve("idle"), 50)),
@@ -1233,12 +1113,8 @@ describe("LiveDO replay buffer count-cap overflow prune", () => {
 
 		await run(connection.subscribe({subId, topics: [decoyKey], ownerId, limits: LIMITS}));
 
-		// Cap of 3; publish seq 1..6 — survivors are 4,5,6 (per the prune above). The
-		// client reconnects carrying cursor "2": a seq that has been EVICTED by the
-		// count cap (it's < the oldest survivor 4). The numeric-cursor semantics (#731)
-		// must resolve this to "replay everything still buffered strictly newer than 2"
-		// — i.e. the whole surviving window 4,5,6 — never deliver a pruned frame, never
-		// crash on a cursor it can't find in the window.
+		// Cursor "2" is a seq EVICTED by the count cap (< the oldest survivor 4): the #731 numeric
+		// semantics must replay the whole surviving window, never a pruned frame, never crash.
 		const cap = 3;
 		const limits: LiveLimits = {...LIMITS, maxBufferedFramesPerTopic: cap};
 		const beforePublish = Date.now();
@@ -1260,8 +1136,6 @@ describe("LiveDO replay buffer count-cap overflow prune", () => {
 		);
 		expect(reg.ok).toBe(true);
 
-		// Survivors 4,5,6 all satisfy `seq > 2`, so the whole window replays in order;
-		// the pruned seqs (1,2,3) are simply gone — none is delivered.
 		const seqs: Array<number> = [];
 		for (let i = 0; i < cap; i++) {
 			const frame = await stream.next();
@@ -1269,7 +1143,7 @@ describe("LiveDO replay buffer count-cap overflow prune", () => {
 			const idLine = frame.split("\n").find((l) => l.startsWith("id: "))!;
 			seqs.push(Number(idLine.slice("id: ".length)));
 		}
-		expect(seqs).toEqual([total - cap + 1, total - cap + 2, total]); // 4, 5, 6
+		expect(seqs).toEqual([total - cap + 1, total - cap + 2, total]);
 
 		const echo = await Promise.race([
 			stream.next(),
@@ -1282,9 +1156,7 @@ describe("LiveDO replay buffer count-cap overflow prune", () => {
 });
 
 describe("LiveDO role-guard: a misrouted RPC no-ops without mutating storage (#1368)", () => {
-	// Mirror live-do.ts's internal KV-key contract so the test can assert storage
-	// was (not) touched directly: GENERATION_KEY is the connection-role generation
-	// slot; subscriberKey is the topic-role subscriber row key.
+	// Mirror live-do.ts's KV-key contract so the test can assert storage was (not) touched.
 	const GENERATION_KEY = "connection:generation";
 	const subscriberKey = (row: SubscriberRow): string =>
 		`sub:${row.topicKey}:${row.connectionId}:${row.subId}:${row.generation}:${row.revision}`;
@@ -1317,13 +1189,10 @@ describe("LiveDO role-guard: a misrouted RPC no-ops without mutating storage (#1
 			}),
 		);
 
-		// No-op shape: not the `text/event-stream` a connection's openStream returns.
 		const web = HttpServerResponse.toWeb(res);
 		expect(web.status).toBe(404);
 		expect(web.headers.get("content-type") ?? "").not.toContain("text/event-stream");
 
-		// No mutation: the generation slot was never written (a connection's
-		// openStream would have persisted 1).
 		expect(await run(fake.state.storage.get<number>(GENERATION_KEY))).toBeUndefined();
 	});
 
@@ -1349,8 +1218,7 @@ describe("LiveDO role-guard: a misrouted RPC no-ops without mutating storage (#1
 		const {instance: connection, fake} = makeConnectionWithState(cell, "conn-unreg");
 		const row = guardRow("Post:guard-unreg", "conn-unreg");
 		const key = subscriberKey(row);
-		// Seed the connection's OWN KV with the row's key — an unguarded unregister
-		// would `delete` it on this wrong-role call.
+		// Seed the connection's OWN KV with the row's key — an unguarded unregister would delete it.
 		await run(fake.state.storage.put(key, row));
 
 		const res = await run(connection.unregister({row}));
@@ -1374,13 +1242,8 @@ describe("LiveDO role-guard: a misrouted RPC no-ops without mutating storage (#1
 	});
 });
 
-// The platform-fired reap `alarm()` is a deep module (probe → partial-reap → reschedule)
-// whose reachable branches the fan-out tests above never reach: `do.test.ts`'s pre-#1369
-// alarm coverage hit only the unreachable→reap-all (die) path. These exercise the
-// connection-reports-stale partial reap, the reschedule-while-rows-remain re-arm, and
-// `check` itself (call-only-from-alarm), against the real instance over the DO-state fake.
+// Branches the fan-out tests never reach: the partial reap, the re-arm, and `check` itself.
 describe("LiveDO alarm reap branches (#1369)", () => {
-	// How many subscriber rows the topic still holds (the set the alarm reaps off).
 	const subRowCount = (
 		fake: ReturnType<typeof makeDurableObjectStateForTest>,
 		topicKey: string,
@@ -1396,8 +1259,7 @@ describe("LiveDO alarm reap branches (#1369)", () => {
 		const topicKey = "Term:partial-reap";
 		const {instance: topic, fake} = makeTopic(cell, topicKey);
 
-		// A reachable connection with ONE live subscription. Its `check` reports
-		// staleness per-row, so the alarm must reap only the rows it names.
+		// A reachable connection with ONE live subscription; `check` reports staleness per-row.
 		const connection = makeConnection(cell, "conn-partial");
 		const ownerId = "owner-partial";
 		await run(
@@ -1410,9 +1272,8 @@ describe("LiveDO alarm reap branches (#1369)", () => {
 			connection.subscribe({subId: "sub-keep", topics: [topicKey], ownerId, limits: LIMITS}),
 		);
 
-		// A second row for the SAME connection whose subId has no live subscription: same
-		// generation (clears the generation gate), so the staleness verdict is the
-		// subscription miss — a partial reap, NOT the reach-failure reap-all.
+		// A second row for the SAME connection with no live subscription and the same generation:
+		// the verdict is the subscription miss, so a partial reap — not the reach-failure reap-all.
 		const staleRow: SubscriberRow = {
 			topicKey,
 			connectionId: "conn-partial",
@@ -1426,7 +1287,6 @@ describe("LiveDO alarm reap branches (#1369)", () => {
 
 		await run(topic.alarm());
 
-		// Exactly the stale row is gone; the live one survives (a reap-all clears both).
 		expect(await subRowCount(fake, topicKey)).toBe(1);
 		const pub = await run(topic.publish({topicKey, frame: entityFrame, limits: LIMITS}));
 		expect(pub.delivered).toBe(1);
@@ -1465,7 +1325,7 @@ describe("LiveDO alarm reap branches (#1369)", () => {
 		await run(fake.state.storage.setAlarm(1));
 		await run(topic.alarm());
 
-		expect(await subRowCount(fake, topicKey)).toBe(1); // the live row remains
+		expect(await subRowCount(fake, topicKey)).toBe(1);
 		const rearmed = await run(fake.state.storage.getAlarm());
 		expect(rearmed).not.toBeNull();
 		expect(rearmed as number).toBeGreaterThan(1);
@@ -1491,7 +1351,6 @@ describe("LiveDO alarm reap branches (#1369)", () => {
 		await run(topic.alarm());
 
 		expect(await subRowCount(fake, topicKey)).toBe(0);
-		// Nothing remains, so the handler must NOT reschedule — the sentinel stands.
 		expect(await run(fake.state.storage.getAlarm())).toBe(1);
 	});
 
@@ -1582,7 +1441,6 @@ describe("LiveDO open-owner fence (#2563)", () => {
 		expect(await run(fake.state.storage.get<number>(GENERATION_KEY))).toBe(1);
 		expect(await run(fake.state.storage.get<string>(OWNER_KEY))).toBe(ownerA);
 
-		// A different session user re-opens the SAME connectionId.
 		const hostile = await run(
 			connection.openStream({
 				ownerId: "attacker",
@@ -1593,9 +1451,7 @@ describe("LiveDO open-owner fence (#2563)", () => {
 		expect(web.status).toBe(403);
 		expect(web.headers.get("content-type") ?? "").not.toContain("text/event-stream");
 
-		// Nothing was disturbed: generation not bumped, owner unchanged, and A's
-		// subscription is still live — a publish reaches A. A missing fence would have
-		// bumped the generation and cleared A's row, so `delivered` would be 0.
+		// Nothing disturbed: generation, owner, and A's live subscription all survive.
 		expect(await run(fake.state.storage.get<number>(GENERATION_KEY))).toBe(1);
 		expect(await run(fake.state.storage.get<string>(OWNER_KEY))).toBe(ownerA);
 		const pub = await run(topic.publish({topicKey, frame: entityFrame, limits: LIMITS}));

--- a/apps/web/worker/features/fate-live/event-bus.ts
+++ b/apps/web/worker/features/fate-live/event-bus.ts
@@ -1,14 +1,11 @@
 /**
- * The build-time `LiveEventBus` stub fate's config holds (ADR 0023/0039,
- * `.patterns/fate-live-views.md`).
+ * The build-time `LiveEventBus` stub fate's config holds (ADR 0023/0039).
  *
- * fate's built-in `createLiveEventBus()` is an in-memory `EventEmitter` that
- * can't fan out across the isolates a Worker spreads requests over, so phoenix
- * moves publish (→ the per-request `LivePublisher`) and subscribe (→ `/fate/live`
- * + `LiveDO`) off it entirely. The only thing fate does with this value is the
- * build-time `"subscribe" in live` check (custom-bus detection, `fate/config.ts`).
- * Nothing calls any method, so every method THROWS: a call would mean a publish
- * or subscribe leaked onto the config bus, and that must fail loudly.
+ * fate's `createLiveEventBus()` is an in-memory `EventEmitter` that can't fan out across the
+ * isolates a Worker spreads requests over, so phoenix moves publish (→ `LivePublisher`) and
+ * subscribe (→ `/fate/live` + `LiveDO`) off it entirely. All fate does with this value is the
+ * build-time `"subscribe" in live` check, so every method THROWS: a call would mean a publish or
+ * subscribe leaked onto the config bus, and that must fail loudly.
  */
 
 import type {LiveEventBus} from "@nkzw/fate/server";
@@ -21,7 +18,6 @@ const neverSubscribed = (): never => {
 	throw new Error("live subscriptions are served by LiveDO, not the bus");
 };
 
-/** The bus handed to fate at worker init (`createFateServer`'s `live` option). */
 export const liveBusConfig: LiveEventBus = {
 	update: neverPublished,
 	delete: neverPublished,

--- a/apps/web/worker/features/fate-live/fanned-mutations.ts
+++ b/apps/web/worker/features/fate-live/fanned-mutations.ts
@@ -1,62 +1,28 @@
 /**
- * The fanned-mutation manifest (ADR 0155) — the single, declared source of the
- * fanned/not-fanned decision for every `Fate.mutation` in the worker.
+ * The fanned-mutation manifest — the declared fanned/not decision for every
+ * `Fate.mutation` in the worker. See ADR 0155 for the why and
+ * `.patterns/fate-live-views.md` §Server for the publish shape.
  *
- * A mutation is **fanned** when it writes an entity that lives in a subscribed
- * `/fate/live` connection (`Post` / `Comment` / `Definition`, the entities in the
- * `posts` / `Post.comments` / `Term.definitions` topics) — so after its DB write it
- * MUST publish the invalidation through `WorkerLivePublisher`, or every other
- * client's open live view goes stale until a manual refresh
- * (`.patterns/fate-live-views.md` §Server). Omitting that publish is invisible at the
- * mutation site (the publisher's error channel is `never`, ADR 0039), which is the
- * whole reason for this manifest + the `fanout-guard` CI check.
- *
- * Every `entity.verb` mutation key MUST appear here with a `fanned` flag and a
- * one-line rationale; every `fanned: true` row MUST also declare its `topics`.
- * `fabrika guard fanout-guard check` enforces three invariants:
- *
- *   1. Drift — the set of keys here EQUALS the set discovered in
- *      `apps/web/worker/features/*.mutations.ts`. A new mutation with no row here
- *      fails the build (the conscious fanned/not decision is forced at authoring).
- *   2. Publish — every `fanned: true` mutation's feature references a
- *      `WorkerLivePublisher` publish. A fanned mutation whose feature omits the
- *      publish fails the build.
- *   3. Topic aim — every `fanned: true` row declares the `/fate/live` target(s) it
- *      publishes to, and each declared target is reachable from the feature's
- *      `live.ts` binding. A fanned row with no `topics`, or a `topics` value the
- *      feature's `live.ts` no longer targets (a mis-aimed publish, #2554), fails the
- *      build. Invariant 2 proves a publish EXISTS; this proves it AIMS correctly.
- *
- * A `topics` value is either a connection topic (a `LiveTopic` value — `posts` /
- * `Post.comments` / `Term.definitions`) or an entity-update typename (`Post` /
- * `Comment` / `Definition` / `User`) — the two shapes a publish takes. Declare EVERY
- * target the mutation fans into (a delete that drops an edge AND touches a parent field
- * lists both). The rationale field is for the human reader (and the guard's report);
- * the guard keys on `fanned` and `topics`.
+ * Every `entity.verb` key MUST appear here with a `fanned` flag and a rationale;
+ * every `fanned: true` row MUST also declare its `topics` — a `LiveTopic` value or
+ * an entity typename, listing EVERY target the mutation fans into.
+ * `fabrika guard fanout-guard check` fails the build on a missing key, a fanned
+ * mutation whose feature omits the publish, or a `topics` value the feature's
+ * `live.ts` no longer targets (a mis-aimed publish, #2554).
  */
 
-/** One mutation's fanned classification, its publish target(s), and the rationale. */
 export interface FannedMutationEntry {
-	/** The `entity.verb` mutation key, exactly as it appears in `Fate.mutation("<key>", …)`. */
+	/** The `entity.verb` key, exactly as it appears in `Fate.mutation("<key>", …)`. */
 	readonly key: string;
-	/** True ⇒ writes a fanned entity ⇒ must publish a `/fate/live` invalidation. */
 	readonly fanned: boolean;
-	/**
-	 * The `/fate/live` target(s) a `fanned: true` mutation publishes to — a `LiveTopic`
-	 * value or an entity typename (see the module docblock). Omitted on a not-fanned row.
-	 */
+	/** Required on a `fanned: true` row; omitted otherwise. */
 	readonly topics?: ReadonlyArray<string>;
-	/** One line: WHY it does / does not fan (which subscribed connection it touches, or why none). */
+	/** One line: WHY it does / does not fan. */
 	readonly rationale: string;
 }
 
-/**
- * The manifest, grouped by feature for readability. The guard flattens it; grouping
- * is cosmetic. Keep each group in sync with its `features/<name>/mutations.ts`.
- */
+/** Grouped by feature for readability only — the guard flattens it. */
 export const FANNED_MUTATIONS: ReadonlyArray<FannedMutationEntry> = [
-	// pano — the post/comment feed. Membership + field changes fan into `posts` and
-	// `Post.comments`; drafts are per-user private state in no subscribed connection.
 	{
 		key: "post.submit",
 		fanned: true,
@@ -166,8 +132,6 @@ export const FANNED_MUTATIONS: ReadonlyArray<FannedMutationEntry> = [
 			"re-appends the Comment edge into `Post.comments` and updates the parent Post's commentCount",
 	},
 
-	// sözlük — terms + definitions. Definition membership + field changes fan into
-	// `Term.definitions`.
 	{
 		key: "definition.add",
 		fanned: true,
@@ -211,17 +175,13 @@ export const FANNED_MUTATIONS: ReadonlyArray<FannedMutationEntry> = [
 		rationale: "re-appends the Definition edge into `Term.definitions`",
 	},
 
-	// report — moderation. A remove/restore/restoreWave acts on a fanned target
-	// (post/comment/definition) and must publish the same invalidation the content
-	// features' own delete/restore paths do (#1895). A submit only writes a report row.
 	{
 		key: "report.submit",
 		fanned: false,
 		rationale: "writes a report row on the moderation queue — no subscribed content connection",
 	},
-	// report publishes THROUGH pano/sözlük's bindings (report/live.ts delegates to
-	// `panoLive`/`sozlukLive`), so its target set is their union — the moderated target
-	// may be any fanned kind. The guard resolves the delegation to reach these topics.
+	// report publishes THROUGH pano/sözlük's bindings (report/live.ts delegates), so its
+	// target set is their union and the guard must resolve the delegation to reach them.
 	{
 		key: "report.resolve",
 		fanned: true,
@@ -242,8 +202,6 @@ export const FANNED_MUTATIONS: ReadonlyArray<FannedMutationEntry> = [
 		rationale: "re-enters every fanned entity in the restored wave into its subscribed connection",
 	},
 
-	// bildirim — per-user notifications. A read flip touches only the caller's own
-	// notification rows, which live in no cross-client subscribed connection.
 	{
 		key: "bildirim.markRead",
 		fanned: false,
@@ -256,8 +214,6 @@ export const FANNED_MUTATIONS: ReadonlyArray<FannedMutationEntry> = [
 		rationale: "flips the caller's own unread notifications — per-user, no subscribed connection",
 	},
 
-	// divan — the sandboxed proving ground. A vote scores a SANDBOXED item that is
-	// deliberately absent from the public feed, so it fans nothing public.
 	{
 		key: "divan.vote",
 		fanned: false,
@@ -265,8 +221,6 @@ export const FANNED_MUTATIONS: ReadonlyArray<FannedMutationEntry> = [
 			"scores a sandboxed çaylak item that is deliberately excluded from the public feed connection",
 	},
 
-	// pasaport — identity. Username/vouch/promotion/deletion mutate identity + karma,
-	// none of which is a fanned entity in a subscribed content connection.
 	{
 		key: "user.setUsername",
 		fanned: false,
@@ -329,9 +283,6 @@ export const FANNED_MUTATIONS: ReadonlyArray<FannedMutationEntry> = [
 			"appends a `clear` event to the email-delivery log — no fanned content entity (mirrors emailDelivery.mark)",
 	},
 
-	// mecmua — long-form posts (#2497, epic #2467). mecmua Post does NOT yet live in a
-	// subscribed `/fate/live` connection (no mecmua root is wired), so neither write fans;
-	// if a mecmua mutation is later classified fanned it must publish via `WorkerLivePublisher`.
 	{
 		key: "mecmua.publish",
 		fanned: false,
@@ -356,12 +307,6 @@ export const FANNED_MUTATIONS: ReadonlyArray<FannedMutationEntry> = [
 			"clears the caller's private reader→author subscription edge; per-viewer `mecmuaFeed` connection, same no-leak rationale as `mecmua.subscribe`",
 	},
 
-	// mute — member-mute (sustur) presence (#3112, epic #2035). A mute masks ONLY the
-	// muter's OWN reads (the read-mask is a sibling slice), so it writes no
-	// Post/Comment/Definition in a subscribed cross-client connection — and its own
-	// views (feed/thread/manage-mutes) are per-viewer, so a publish onto the login-blind
-	// shared topic would over-fan/leak to every viewer. The `post.save` / `mecmua.subscribe`
-	// per-viewer-private-relation precedent: no cross-viewer fan-out.
 	{
 		key: "mute.set",
 		fanned: false,

--- a/apps/web/worker/features/fate-live/live-do.ts
+++ b/apps/web/worker/features/fate-live/live-do.ts
@@ -1,27 +1,9 @@
 /**
- * `LiveDO` — the unified live fan-out Durable Object (ADR 0037), a void-aligned
- * rewrite of the split `ConnectionDO`/`TopicDO` pair onto ONE class that plays
- * both roles, distinguished by instance-name prefix (mirrors void's
- * `VoidLiveStreamDurableObject`).
- *
- * An instance is named either `connection:<connectionId>` (owns one client's
- * held SSE stream + its subscription list) or `topic:<topicKey>` (owns that
- * topic's durable subscriber registry + publish fan-out + reap alarm).
- * {@link resolveRole} reads `state.id.name` to pick the role at request time;
- * instances are addressed ONLY via {@link connectionOf}/{@link topicOf}.
- *
- * Cross-role calls go through the DO's OWN namespace, resolved once in the outer
- * (per-instance) init and held in the closure. Same class referencing its own
- * namespace = no sibling cycle, so the Layer requires only `Worker` (ADR 0124 —
- * the beta.59 self-namespace resolution). The RPC methods' `R` is `RuntimeContext`
- * (beta.59 colored DO storage + cross-role stubs), discharged at the worker call
- * seam and, in unit tests, via `RuntimeContext.phantom`.
- *
- * Storage is `state.storage`'s flat KV API (no SQLite), void-faithful. The
- * void-faithful stale model rides two counters: per-connection `generation`
- * (bumped on each (re)connect, survives eviction) and per-subscription
- * `revision`. The reap alarm deletes ALL a connection's rows on the FIRST
- * failed probe — no consecutive-miss counter.
+ * `LiveDO` — the unified live fan-out Durable Object. One class plays both roles,
+ * picked from the instance name: `connection:<id>` (one client's held SSE stream)
+ * or `topic:<key>` (subscriber registry + publish fan-out + reap alarm). Address
+ * instances only via {@link connectionOf}/{@link topicOf}. See ADR 0037 (unified
+ * DO, storage/stale model) and ADR 0124 (self-namespace resolution).
  */
 import type {RuntimeContext} from "alchemy";
 import * as Cloudflare from "alchemy/Cloudflare";
@@ -34,37 +16,23 @@ import {defaultLiveLimits, encodeFrame, SSE_HEADERS} from "./protocol.ts";
 
 const GENERATION_KEY = "connection:generation";
 
-/**
- * Connection-role: the persisted owner user id. Bound on the first open and read by
- * {@link openStream} to fence a foreign re-open (#2563) — persisted (like
- * `generation`) so the owner-isolation guard survives eviction, not only while the
- * held stream pins the DO warm.
- */
+// Persisted (not just closure-held) so the foreign-re-open fence in `openStream`
+// survives eviction (#2563).
 const OWNER_KEY = "connection:owner";
 
-/** Topic-role: the monotonic per-topic publish ordinal backing the replay buffer. */
 const BUFFER_SEQ_KEY = "topic:buffer:seq";
 
 const PRUNE_ALARM_DELAY_MS = 60_000;
 
-/**
- * KV key under which the topic role stamps the probe timeout the request path
- * threaded. The platform-fired `alarm()` has no worker call to thread `LiveLimits`
- * through, so the most recent `register` persists `deliveryAttemptTimeoutMs` here for
- * the alarm to read back — closing the decision-2B hole ("the DO never invents its
- * own", see {@link LiveLimits}) at the alarm seam instead of duplicating the
- * literal. See ADR 0037.
- */
+// The platform-fired `alarm()` has no worker call to thread `LiveLimits` through, so
+// the last `register` persists its probe budget here rather than the DO inventing one.
+// See ADR 0037.
 const REAP_PROBE_TIMEOUT_KEY = "topic:reap:probe-timeout-ms";
 
 type DurableObjectStateValue = Cloudflare.DurableObjectState["Service"];
 
-/**
- * The slice of `DurableObjectState` the instance builder touches: `id.name` +
- * the KV `storage`. Typed against this slice (not the whole `DurableObjectState`)
- * so the node-pool fake (`do-state.testing.ts`) satisfies it structurally with no
- * cast, while the real superset value still flows in unchanged.
- */
+// A slice, not the whole `DurableObjectState`, so the node-pool fake
+// (`do-state.testing.ts`) satisfies it structurally with no cast.
 export type LiveDoState = Pick<DurableObjectStateValue, "id" | "storage">;
 
 interface DeliverInput {
@@ -78,21 +46,9 @@ interface DeliverResult {
 	readonly stale: boolean;
 }
 
-/**
- * The unified LiveDO RPC surface — both roles' typed methods plus the SSE
- * `fetch`. Each method belongs to one role: connection-role (`openStream`/`fetch`,
- * `subscribe`, `unsubscribe`, `deliver`, `check`) vs topic-role (`register`,
- * `unregister`, `publish`, `alarm`). A misrouted call returns the method's no-op
- * shape WITHOUT mutating storage — and this holds *uniformly*: the topic-role
- * methods early-return on `role.kind !== "topic"`, `openStream`/`subscribe`/
- * `unsubscribe` on `role.kind !== "connection"`, and `deliver`/`check` on the
- * absent connection queue (only a connection's `openStream` sets `framesQueue`).
- * The real invariant is addressing-correctness: production reaches an instance
- * only via {@link connectionOf}/{@link topicOf}, which always target the matching
- * role, so a misroute is unreachable in practice — the role guards make the
- * documented no-op total and refactor-proof rather than convention-only. See
- * ADR 0037.
- */
+// Both roles' methods on one surface. Every method no-ops without touching storage
+// when called against the wrong role — unreachable in production (addressing always
+// matches), kept total so a refactor cannot break it. See ADR 0037.
 export interface LiveRpcSurface {
 	readonly subscribe: (input: {
 		readonly subId: string;
@@ -112,10 +68,8 @@ export interface LiveRpcSurface {
 		readonly row: SubscriberRow;
 		readonly limits: LiveLimits;
 		readonly subscribedAt: number;
-		// Connection-DO internal state (NOT a persisted row/frame field): the instant
-		// the subscribing connection's current epoch began. It is the authoritative replay
-		// floor, fencing pre-epoch frames (#1072/#1903). Optional so a direct `register`
-		// (tests) that doesn't model an epoch falls back to the `subscribedAt` bound.
+		// The replay floor, fencing pre-epoch frames (#1072/#1903). Optional so a direct
+		// `register` (tests) with no epoch falls back to the `subscribedAt` bound.
 		readonly epochStartedAt?: number;
 		readonly lastEventId?: string;
 	}) => Effect.Effect<{readonly ok: boolean}, never, RuntimeContext>;
@@ -141,24 +95,14 @@ type Role =
 const CONNECTION_PREFIX = "connection:";
 const TOPIC_PREFIX = "topic:";
 
-/**
- * Build a connection-role instance name. Production code never calls the name
- * builders directly — addressing goes through {@link connectionOf}/{@link topicOf},
- * so "always address via those, never hand-roll a name" is a greppable convention,
- * NOT a compiler guarantee: `getByName` accepts any string, and a malformed name
- * is what {@link resolveRole} maps to `unknown` (a silently no-op RPC). Exported
- * for `do.test.ts`'s platform fake.
- */
+// Never call the name builders directly — address via `connectionOf`/`topicOf`. That
+// is a convention, not a compiler guarantee: `getByName` takes any string, and a
+// malformed name resolves to the `unknown` role (a silently no-op RPC).
 export const makeConnectionName = (connectionId: string): `connection:${string}` =>
 	`${CONNECTION_PREFIX}${connectionId}`;
 
 export const makeTopicName = (topicKey: string): `topic:${string}` => `${TOPIC_PREFIX}${topicKey}`;
 
-/**
- * Address a connection-role instance: name grammar + `getByName` in one step.
- * Generic over the namespace's structural shape, so the worker namespace, the
- * DO's own scope handle, and the test fake all use the same addressing seam.
- */
 export const connectionOf = <T>(
 	live: {readonly getByName: (name: string) => T},
 	connectionId: string,
@@ -192,21 +136,14 @@ function bufferPrefix(topicKey: string): string {
 	return `frame:${topicKey}:`;
 }
 
-/**
- * The replay-buffer key for one published frame. `seq` is zero-padded so the KV
- * `list({prefix})` lexical order matches publish order (the store sorts by key
- * string, not by the numeric `seq` field) — replay must hand frames back in the
- * order they were published.
- */
+// `seq` is zero-padded because KV `list({prefix})` sorts by key string, not by the
+// numeric `seq` — replay must hand frames back in publish order.
 function bufferKey(topicKey: string, seq: number): string {
 	return `${bufferPrefix(topicKey)}${seq.toString().padStart(20, "0")}`;
 }
 
-/**
- * Build the unified LiveDO's per-instance methods. The builder takes `state` and
- * the DO's own namespace `live` (for cross-role addressing) as plain args so the
- * same algorithm is unit-testable without workerd.
- */
+// `state` and the DO's own namespace come in as plain args so the algorithm is
+// unit-testable without workerd.
 export const makeLiveInstance = (state: LiveDoState, live: LiveNamespace) => {
 	const encoder = new TextEncoder();
 	const CONNECTED_FRAME = encoder.encode(": connected\n\n");
@@ -214,16 +151,13 @@ export const makeLiveInstance = (state: LiveDoState, live: LiveNamespace) => {
 
 	const role = resolveRole(state.id.name);
 
-	// Connection-role per-instance state, closure-held; the open SSE stream pins
-	// this DO in memory. `subscriptions` tracks each live subscription's revision
-	// + active flag so deliver/check detect staleness without reaching back.
+	// Closure-held connection-role state; the open SSE stream pins this DO in memory.
 	let framesQueue: Queue.Queue<Uint8Array> | undefined;
 	let ownerId: string | undefined;
 	let generation: number | undefined;
-	// Wall-clock instant this connection's CURRENT epoch began (set when `openStream`
-	// bumps `generation`). The authoritative replay floor: a frame published before the
-	// epoch — already in a cursorless reconnect's query result — can't leak onto the new
-	// stream and clobber it. See {@link replayBuffer} (#1072/#1903).
+	// Instant this connection's current epoch began. The replay floor: a pre-epoch frame
+	// is already in a cursorless reconnect's query result, so replaying it would clobber
+	// the fresh value. See {@link replayBuffer} (#1072/#1903).
 	let epochStartedAt: number | undefined;
 	const subscriptions = new Map<
 		string,
@@ -237,8 +171,8 @@ export const makeLiveInstance = (state: LiveDoState, live: LiveNamespace) => {
 		return generation;
 	});
 
-	// The bound owner, read from storage on first miss so the open-time fence (#2563)
-	// holds after eviction — the closure var is undefined on a fresh wake.
+	// Read from storage on first miss: the closure var is undefined on a fresh wake, and
+	// the open-time fence (#2563) must still hold after eviction.
 	const loadOwner = Effect.gen(function* () {
 		if (ownerId === undefined) {
 			ownerId = yield* state.storage.get<string>(OWNER_KEY);
@@ -262,23 +196,16 @@ export const makeLiveInstance = (state: LiveDoState, live: LiveNamespace) => {
 			if (role.kind !== "connection") {
 				return HttpServerResponse.empty({status: 404});
 			}
-			// Owner-isolation fence on OPEN (#2563): a re-open whose session user
-			// differs from the connection's bound owner is refused WITHOUT disturbing
-			// the prior holder — no generation bump, no owner overwrite, no
-			// subscription clear, no stream teardown. `subscribe` already enforces this
-			// invariant (:owner check below), but it compared against whatever the
-			// latest open wrote, so a hostile re-open reset the holder before any
-			// subscribe ran. The fence lives here at the DO seam because the DO must not
-			// trust the caller-supplied `ownerId` to self-authorize a takeover; a first
-			// open (no bound owner) and a same-owner reconnect both pass through.
+			// Owner fence on OPEN (#2563): refuse a foreign re-open before touching
+			// anything — no generation bump, no owner overwrite, no subscription clear, no
+			// teardown. `subscribe`'s owner check runs too late; a hostile re-open had
+			// already reset the holder by then.
 			const boundOwner = yield* loadOwner;
 			if (boundOwner !== undefined && boundOwner !== input.ownerId) {
 				return HttpServerResponse.empty({status: 403});
 			}
-			// A (re)connect bumps the persisted generation so any subscriber row a
-			// topic DO still holds from the prior stream is detected stale on the next
-			// deliver/check. The counter survives eviction, so a reconnect after
-			// eviction still lands strictly higher than any stale row.
+			// Persisted, so a reconnect after eviction still lands strictly higher than any
+			// subscriber row a topic DO still holds from the prior stream.
 			const next = (yield* loadGeneration) + 1;
 			generation = next;
 			epochStartedAt = Date.now();
@@ -290,10 +217,8 @@ export const makeLiveInstance = (state: LiveDoState, live: LiveNamespace) => {
 			subscriptions.clear();
 			yield* closeStream;
 
-			// DROPPING strategy (not bounded): `Queue.offer` returns false the moment
-			// it's full instead of blocking the producer, and `deliver` reads that
-			// false to close the connection + report the row stale (void's 410 on queue
-			// full). The connected frame counts against the cap.
+			// Dropping, not bounded: `offer` must return false instead of blocking the
+			// producer, so `deliver` can close the connection and report the row stale.
 			const queue = yield* Queue.dropping<Uint8Array>(input.maxQueuedEventsPerConnection);
 			framesQueue = queue;
 			yield* Queue.offer(queue, CONNECTED_FRAME);
@@ -310,7 +235,6 @@ export const makeLiveInstance = (state: LiveDoState, live: LiveNamespace) => {
 			return HttpServerResponse.stream(merged, {headers: SSE_HEADERS});
 		});
 
-	/** Is a topic-held subscriber row stale relative to this connection's state? */
 	const isStale = (row: SubscriberRow): boolean => {
 		if (generation === undefined || row.generation !== generation) {
 			return true;
@@ -321,10 +245,8 @@ export const makeLiveInstance = (state: LiveDoState, live: LiveNamespace) => {
 
 	const subscribe: LiveRpcSurface["subscribe"] = (input) =>
 		Effect.gen(function* () {
-			// The intent timestamp that bounds replay: only frames published at/after
-			// this instant catch up (the register-race window of #714), never the
-			// topic's prior history. One reading for the whole call, shared across all
-			// its topics. See {@link replayBuffer}.
+			// One reading shared across all this call's topics: it bounds replay to the
+			// register-race window (#714), never the topic's prior history.
 			const subscribedAt = Date.now();
 			// A control message cannot subscribe on another user's behalf.
 			if (ownerId !== input.ownerId) {
@@ -360,11 +282,7 @@ export const makeLiveInstance = (state: LiveDoState, live: LiveNamespace) => {
 							revision,
 							updatedAt: Date.now(),
 						};
-						// Thread `subscribedAt` (the primary replay bound), `epochStartedAt`
-						// (raises the floor to this connection's current epoch, fencing
-						// pre-epoch frames — #1072), and `lastEventId` (an additional
-						// tightening on a cursored resubscribe) so the topic replays only
-						// frames from this subscriber's current-epoch intent forward (#714).
+						// The three replay bounds the topic needs; see {@link replayBuffer}.
 						yield* topicOf(live, topicKey).register({
 							row,
 							limits: input.limits,
@@ -386,8 +304,8 @@ export const makeLiveInstance = (state: LiveDoState, live: LiveNamespace) => {
 			}
 			sub.active = false;
 			subscriptions.delete(input.subId);
-			// Failure here is swallowed best-effort — the reap alarm catches what an
-			// unreachable topic instance misses.
+			// Failure is swallowed on purpose: the reap alarm catches what an unreachable
+			// topic instance misses.
 			const gen = yield* loadGeneration;
 			yield* Effect.forEach(
 				sub.topics,
@@ -424,8 +342,8 @@ export const makeLiveInstance = (state: LiveDoState, live: LiveNamespace) => {
 				// Oversized event: drop it (not stale — the subscription is fine).
 				return {delivered: false, stale: false};
 			}
-			// `offer` returns false when the dropping queue is full: close the stream
-			// and treat the row as stale (void's 410 on queue full).
+			// A full dropping queue means the client fell behind: tear the stream down and
+			// report the row stale.
 			const accepted = yield* Queue.offer(queue, encoded);
 			if (!accepted) {
 				yield* closeStream;
@@ -438,7 +356,6 @@ export const makeLiveInstance = (state: LiveDoState, live: LiveNamespace) => {
 		Effect.gen(function* () {
 			yield* loadGeneration;
 			if (framesQueue === undefined) {
-				// No open stream — every probed row is stale.
 				return {stale: input.subscriptions.map((_, index) => index)};
 			}
 			const stale: Array<number> = [];
@@ -467,9 +384,7 @@ export const makeLiveInstance = (state: LiveDoState, live: LiveNamespace) => {
 
 	const ensureAlarm = (limits: LiveLimits) =>
 		Effect.gen(function* () {
-			// Stamp the threaded probe budget so the platform-fired `alarm()` reaps on the
-			// same `deliveryAttemptTimeoutMs` the request path uses (decision 2B), never a
-			// DO-invented literal — see {@link REAP_PROBE_TIMEOUT_KEY}.
+			// See {@link REAP_PROBE_TIMEOUT_KEY}.
 			yield* state.storage.put(REAP_PROBE_TIMEOUT_KEY, limits.deliveryAttemptTimeoutMs);
 			const existing = yield* state.storage.getAlarm();
 			if (existing == null) {
@@ -482,12 +397,8 @@ export const makeLiveInstance = (state: LiveDoState, live: LiveNamespace) => {
 			...map,
 		]);
 
-	/**
-	 * Drop buffer entries past the TTL or beyond the count cap, returning the
-	 * surviving window (newest-last). Called on every publish and register so the ring
-	 * stays bounded by both dimensions with no background sweep. `now` is passed so a
-	 * caller's clock reading is the single source of truth across prune+append.
-	 */
+	// Runs on every publish and register, so the ring stays bounded with no background
+	// sweep. `now` is passed in so one clock reading covers prune + append.
 	const pruneBuffer = (
 		entries: ReadonlyArray<readonly [string, BufferedFrame]>,
 		limits: LiveLimits,
@@ -495,8 +406,7 @@ export const makeLiveInstance = (state: LiveDoState, live: LiveNamespace) => {
 	) =>
 		Effect.gen(function* () {
 			const unexpired = entries.filter(([, value]) => now - value.at <= limits.bufferedFrameTtlMs);
-			// `entries` is lexically ordered (zero-padded seq), so the newest are the
-			// tail; drop the oldest overflow past the count cap.
+			// `entries` is lexically ordered (zero-padded seq), so the newest are the tail.
 			const overCap = Math.max(0, unexpired.length - limits.maxBufferedFramesPerTopic);
 			const expired = entries.filter(([, value]) => now - value.at > limits.bufferedFrameTtlMs);
 			const dropKeys = [
@@ -509,20 +419,15 @@ export const makeLiveInstance = (state: LiveDoState, live: LiveNamespace) => {
 			return unexpired.slice(overCap);
 		});
 
-	/** Allocate the next monotonic per-topic publish ordinal (persisted). */
 	const nextSeq = Effect.gen(function* () {
 		const seq = ((yield* state.storage.get<number>(BUFFER_SEQ_KEY)) ?? 0) + 1;
 		yield* state.storage.put(BUFFER_SEQ_KEY, seq);
 		return seq;
 	});
 
-	/**
-	 * Append an already-seq-stamped frame to the ring buffer (after a prune). The
-	 * caller allocated the `seq` (via {@link nextSeq}) and stamped it onto the frame's
-	 * `eventId` BEFORE fan-out, so the live-delivered frame, the buffered frame, and
-	 * its `BufferedFrame.eventId` all carry the SAME ordinal — replay resumes against
-	 * the exact id the client already saw on the wire.
-	 */
+	// The frame arrives already seq-stamped: the caller stamped `eventId` before fan-out,
+	// so the buffered copy carries the same ordinal the client saw on the wire and replay
+	// resumes against it exactly.
 	const appendToBuffer = (
 		topicKey: string,
 		frame: DeliverFrame,
@@ -574,22 +479,13 @@ export const makeLiveInstance = (state: LiveDoState, live: LiveNamespace) => {
 			const now = Date.now();
 			const entries = yield* loadBuffer(row.topicKey);
 			const window = yield* pruneBuffer(entries, limits, now);
-			// The replay floor is the CAUSAL epoch boundary, not a wall-clock guess: a #714
-			// register-race frame is published after `openStream` (`at >= epochStartedAt`, KEEP);
-			// a stale pre-vote frame published before the subscribe intent is pre-epoch
-			// (`at < epochStartedAt`, DROP). Production always sets `epochStartedAt` (openStream);
-			// the `subscribedAt` fallback is only the epoch-absent direct-`register` (test) path.
-			// No wall-clock grace: it once absorbed cross-DO skew, but `epochStartedAt` and
-			// `subscribedAt` are the SAME connection-DO clock, so there is no skew to absorb — and
-			// that grace was itself the #1903 leak (it admitted the pre-vote frame the epoch fence
-			// now drops). See #1903.
+			// No wall-clock grace here: `epochStartedAt` and `subscribedAt` come off the same
+			// connection-DO clock, so there is no skew to absorb — and the grace was itself
+			// the #1903 leak.
 			const floor = epochStartedAt ?? subscribedAt;
-			// The cursor is the last per-topic `seq` the subscriber saw (every delivered frame
-			// now carries `eventId === String(seq)`, primary fan-out and replay alike). Compare
-			// numerically against `buffered.seq` and replay only STRICTLY-newer frames — robust
-			// even when the cursor frame itself has aged out of the window (a string-equality
-			// scan would never find it and wrongly drop everything newer). A non-numeric/absent
-			// cursor leaves the whole at/after-intent window eligible (#714/#731).
+			// Compare the cursor numerically against `buffered.seq` and replay only strictly
+			// newer frames. A string-equality scan would never find a cursor frame that had
+			// aged out of the window, and would then wrongly drop everything newer (#731).
 			const cursorSeq = lastEventId === undefined ? undefined : Number(lastEventId);
 			const sinceSeq =
 				cursorSeq !== undefined && Number.isFinite(cursorSeq) ? cursorSeq : undefined;
@@ -622,8 +518,8 @@ export const makeLiveInstance = (state: LiveDoState, live: LiveNamespace) => {
 			}
 			const row = input.row;
 			const entries = yield* loadRows(row.topicKey);
-			// Supersede this connection's older rows (lower generation) and the
-			// prior-revision row for this exact subscription — void's register prune.
+			// Supersede this connection's older-generation rows and the prior-revision row
+			// for this exact subscription.
 			const stale: Array<string> = [];
 			for (const [key, value] of entries) {
 				if (value.connectionId === row.connectionId && value.generation < row.generation) {
@@ -635,8 +531,7 @@ export const makeLiveInstance = (state: LiveDoState, live: LiveNamespace) => {
 				}
 			}
 			const survivors = entries.filter(([key]) => !stale.includes(key));
-			// Topic subscription cap (void returns 409 "topic full"; here a no-op
-			// `{ok: false}` is the equivalent rejection — the connection records it).
+			// Topic full: `{ok: false}` is the rejection, and the connection records it.
 			if (survivors.length >= input.limits.maxSubscriptionsPerTopic) {
 				return {ok: false};
 			}
@@ -645,9 +540,8 @@ export const makeLiveInstance = (state: LiveDoState, live: LiveNamespace) => {
 			}
 			yield* state.storage.put(subscriberKey(row), row);
 			yield* ensureAlarm(input.limits);
-			// Catch up the just-registered connection on frames a publish that beat this
-			// register would have missed it on (#714). Replay reaches ONLY this
-			// connection, which fan-out could not have — see {@link replayBuffer}.
+			// Catch up on frames a publish that beat this register would have missed
+			// (#714) — see {@link replayBuffer}.
 			yield* replayBuffer(
 				row,
 				input.limits,
@@ -672,18 +566,14 @@ export const makeLiveInstance = (state: LiveDoState, live: LiveNamespace) => {
 			if (role.kind !== "topic") {
 				return {delivered: 0};
 			}
-			// Stamp the topic's monotonic ordinal as this frame's `eventId` BEFORE fan-out,
-			// so the live-delivered frame, the buffered copy, and every replay all carry the
-			// SAME per-topic-monotonic SSE `id:` — the client only ever sees in-order,
-			// non-stale frames and its last-frame-wins apply is correct (#731). The topic owns
-			// the id (overriding any inbound `frame.eventId`): per-topic monotonicity is the
-			// invariant, and in production nothing upstream sets one.
+			// Stamp the ordinal BEFORE fan-out so the live frame, the buffered copy, and
+			// every replay carry the same SSE `id:` and last-frame-wins stays correct
+			// (#731). The topic owns the id and overrides any inbound one.
 			const seq = yield* nextSeq;
 			const frame: DeliverFrame = {...input.frame, eventId: String(seq)};
 			const entries = yield* loadRows(input.topicKey);
-			// Fan out per-connection deliver passes concurrently (connections are
-			// independent). The inner per-row loop stays sequential because it
-			// short-circuits on the first unreachable item.
+			// Connections fan out concurrently; the inner per-row loop stays sequential
+			// because it short-circuits on the first unreachable item.
 			const grouped = groupByConnection(entries);
 			const perConnection = yield* Effect.forEach(
 				grouped,
@@ -694,9 +584,8 @@ export const makeLiveInstance = (state: LiveDoState, live: LiveNamespace) => {
 						let reachable = true;
 						let delivered = 0;
 						for (const item of items) {
-							// Any failure/defect/timeout on the cross-role deliver = "couldn't
-							// reach" → reap the whole group (void deletes ALL a connection's
-							// rows on a 410/404/no response). First failure flips `reachable`.
+							// Any failure, defect or timeout counts as unreachable and reaps ALL
+							// that connection's rows, not just this one.
 							const result = yield* connection
 								.deliver({
 									frame: {...frame, id: item.row.subId},
@@ -727,9 +616,8 @@ export const makeLiveInstance = (state: LiveDoState, live: LiveNamespace) => {
 					}),
 				{concurrency: "unbounded"},
 			);
-			// Retain the SAME seq-stamped frame for a subscriber whose register lands after
-			// this publish (#714). After fan-out, so the ring reflects what already went out
-			// live — buffered `eventId` === the live wire `id:`, so replay resumes exactly.
+			// After fan-out, and the same seq-stamped frame, so a subscriber whose register
+			// lands later replays exactly what went out live (#714).
 			yield* appendToBuffer(input.topicKey, frame, seq, input.limits, Date.now());
 			return {delivered: perConnection.reduce((sum, n) => sum + n, 0)};
 		});
@@ -741,9 +629,8 @@ export const makeLiveInstance = (state: LiveDoState, live: LiveNamespace) => {
 			}
 			const entries = yield* loadRows(role.topicKey);
 			const grouped = groupByConnection(entries);
-			// The probe budget the last `register` threaded (decision 2B); the shared
-			// `defaultLiveLimits` is the fallback when no row has armed the alarm yet —
-			// never a DO-invented literal. See {@link REAP_PROBE_TIMEOUT_KEY}.
+			// See {@link REAP_PROBE_TIMEOUT_KEY}; the shared default covers the case where no
+			// row has armed the alarm yet.
 			const probeTimeout =
 				(yield* state.storage.get<number>(REAP_PROBE_TIMEOUT_KEY)) ??
 				defaultLiveLimits.deliveryAttemptTimeoutMs;
@@ -751,9 +638,9 @@ export const makeLiveInstance = (state: LiveDoState, live: LiveNamespace) => {
 				grouped,
 				([connectionId, items]) =>
 					Effect.gen(function* () {
-						// First failed probe → reap ALL that connection's rows (void-faithful:
-						// no consecutive-miss counter). A reachable connection reports which
-						// of its rows are stale; we reap exactly those.
+						// One failed probe reaps ALL that connection's rows — no
+						// consecutive-miss counter. A reachable connection instead names its
+						// own stale rows, and only those go.
 						const result = yield* connectionOf(live, connectionId)
 							.check({subscriptions: items.map((item) => item.row)})
 							.pipe(
@@ -781,8 +668,8 @@ export const makeLiveInstance = (state: LiveDoState, live: LiveNamespace) => {
 			if (staleKeys.length > 0) {
 				yield* state.storage.delete(staleKeys);
 			}
-			// Reschedule while rows remain so an evicted connection's orphans are
-			// eventually reaped even with no publish traffic.
+			// Reschedule while rows remain, so an evicted connection's orphans are reaped
+			// even with no publish traffic.
 			const remaining = yield* loadRows(role.topicKey);
 			if (remaining.length > 0) {
 				yield* state.storage.setAlarm(Date.now() + PRUNE_ALARM_DELAY_MS);
@@ -802,33 +689,15 @@ export const makeLiveInstance = (state: LiveDoState, live: LiveNamespace) => {
 	};
 };
 
-/**
- * The `LiveDO` implementation Layer (ADR 0028). The DO's OWN namespace is
- * resolved once in the outer (per-instance) init for cross-role addressing —
- * void's `this.env[binding]` pattern — via `Cloudflare.DurableObject`, the
- * beta.59 self-namespace yield (ADR 0124, superseding ADR 0037's removed
- * `DurableObjectNamespaceScope`). The requirement is discharged at the yield
- * site (see below), so the Layer stays `Layer<LiveDO, never, Worker>`; the RPC
- * methods themselves are `RuntimeContext`-colored (beta.59) and discharged at
- * the worker call seam / in tests via `RuntimeContext.phantom`.
- */
+// See ADR 0028 (the DO model) and ADR 0124 (self-namespace resolution).
 export const LiveDOLive = LiveDO.make(
 	Effect.gen(function* () {
-		// Resolve the DO's OWN namespace once (outer, per-instance init — runs on the
-		// platform when the DO boots, NOT at stack build), for cross-role addressing.
-		// Must be the OUTER init, not a handler: `.make` provides `DurableObjectScope`
-		// to the constructor (alchemy DurableObject.js:640), and the bridge runs the
-		// constructor per-instance but does NOT thread the scope into the inner
-		// handlers, so a handler-level yield would die at runtime. NOT
-		// `LiveDO.from(Self)`: it needs the host `Worker`, reintroducing the worker↔DO
-		// cycle this scope avoids. The cast discharges the phantom `Req`: `.make<Req>`
-		// leaves the self-scope in `Req` (it's not a `DurableObjectServices` member)
-		// even though it's provided at runtime, so we narrow the whole Effect to
-		// `Effect<LiveNamespace>` (success widened to this DO's namespace, `R` narrowed
-		// to `never`), grounded in that runtime provision (ADR 0124). `DurableObjectClass`
-		// and `Effect` don't structurally overlap, so a lone `as` won't convert — the
-		// double cast is the only spelling, and it's laundering a KNOWN-provided service,
-		// not an unverified value.
+		// Must be the OUTER init, not a handler: `.make` provides `DurableObjectScope` to
+		// the constructor (alchemy DurableObject.js:640) but does not thread it into the
+		// inner handlers, so a handler-level yield dies at runtime. Not `LiveDO.from(Self)`
+		// either — that needs the host `Worker` and reintroduces the worker↔DO cycle. The
+		// double cast is the only spelling that discharges the phantom `Req`, since
+		// `DurableObjectClass` and `Effect` do not structurally overlap.
 		// biome-ignore lint/plugin: discharges the self-scope `Req` that `.make` provides at runtime (alchemy DurableObject.js:640) but leaves in the type — the beta.59 typing gap ADR 0124 records; no value is fabricated, the runtime yield is unchanged.
 		const live = yield* Cloudflare.DurableObject as unknown as Effect.Effect<LiveNamespace>;
 		// The shared-init gen RETURNS the per-instance Effect (run once per instance
@@ -838,12 +707,9 @@ export const LiveDOLive = LiveDO.make(
 			const state = yield* Cloudflare.DurableObjectState;
 			const instance = makeLiveInstance(state, live);
 			return {
-				// The SSE upgrade stays a `fetch` (request-shaped).
 				fetch: Effect.gen(function* () {
 					const raw = yield* Cloudflare.Request;
 					const url = new URL(raw.url);
-					// The route threads the per-request queue cap on the URL; fall back to
-					// a safe default if the param is missing/unparseable.
 					const capParam = Number(url.searchParams.get("maxQueuedEventsPerConnection"));
 					const maxQueuedEventsPerConnection =
 						Number.isInteger(capParam) && capParam > 0

--- a/apps/web/worker/features/fate-live/live-publisher.ts
+++ b/apps/web/worker/features/fate-live/live-publisher.ts
@@ -1,26 +1,17 @@
 /**
- * The worker-side live implementation of `@kampus/fate-effect`'s `LivePublisher`
- * per-request service (its tag identity is load-bearing, see
- * `.patterns/fate-effect-server.md`).
+ * The worker-side implementation of `@kampus/fate-effect`'s `LivePublisher`
+ * per-request service — its tag identity is load-bearing, see
+ * `.patterns/fate-effect-server.md`.
  *
- * THE frame-building code path: each publish method resolves its `PublishMessage`
- * frame + topic keys here, byte-identical to the retired bridge event-bus (pinned
- * by `live-publisher.unit.test.ts`'s fixtures).
- *
- * "A publish cannot fail the mutation" is the service's TYPE (every method is
- * `Effect<void>`), with both failure modes handled here, once: scheduling hands
- * the topic call to `waitUntil` as fire-and-forget (CF's ONLY way to extend work
- * past the response — no shutdown hook, ADR 0029/0041), and swallowing catches a
- * rejection on the detached promise / a sync throw via `Effect.try`, logged at
- * `Warn` (ADR 0039's use/useIgnore law, inside the layer not at every call site).
+ * "A publish cannot fail the mutation" is the service's TYPE (every method returns
+ * `Effect<void>`), and both failure modes are handled here once: `waitUntil` is CF's
+ * only way to extend work past the response (no shutdown hook, ADR 0029/0041), and
+ * the swallow wrappers log at `Warn` per ADR 0039 rather than at every call site.
  *
  * Known asymmetry: the detached `Effect.runPromise` starts a FRESH fiber with no
- * ambient tracer context, so publish spans surface as roots, not nested under the
- * request span. Accepted — the fan-out is fire-and-forget by design.
+ * ambient tracer context, so publish spans surface as roots. Accepted.
  *
- * No worker-level layer provides this service: the `/fate` route builds the value
- * per request (from the execution context + the worker-init `LiveTopics`) and
- * hands it to the interpreter, where it hands `currentUser`.
+ * No worker-level layer provides this: the `/fate` route builds the value per request.
  */
 import type {LivePublisher} from "@kampus/fate-effect";
 import * as Effect from "effect/Effect";
@@ -35,10 +26,8 @@ import {
 } from "./protocol.ts";
 
 /**
- * A publish failed inside the swallow wrapper below. Never reaches the fate
- * boundary: the publisher maps it away (logged at `Warn`) in its `never` error
- * channel, since a publish runs after the DB write and must not fail the
- * committed mutation (ADR 0039).
+ * A publish failed inside the swallow wrapper below. Never reaches the fate boundary:
+ * a publish runs after the DB write and must not fail the committed mutation (ADR 0039).
  */
 export class LivePublishError extends Schema.TaggedErrorClass<LivePublishError>()(
 	"fate-live/LivePublishError",
@@ -47,31 +36,26 @@ export class LivePublishError extends Schema.TaggedErrorClass<LivePublishError>(
 	},
 ) {}
 
-/** The two per-request capabilities the live publisher closes over. */
 export interface LivePublisherOptions {
 	/**
-	 * Deliver one resolved topic publish — in production the worker-init
-	 * `LiveTopics.publish`, in tests a recording/failing/slow stub. Its only failure
-	 * is `LiveTransportError`, the cold-start-retry-exhausted publish (#842, #2551);
-	 * it is swallowed-and-logged on the detached promise below, never reaching the
-	 * committed mutation.
+	 * Deliver one resolved topic publish. Its only failure is `LiveTransportError` (a
+	 * cold-start-retry-exhausted publish), swallowed-and-logged on the detached promise
+	 * below so it never reaches the committed mutation.
 	 */
 	readonly publish: (
 		topicKey: string,
 		message: PublishMessage,
 	) => Effect.Effect<void, LiveTransportError>;
-	/** The request's `ExecutionContext.waitUntil`. */
 	readonly waitUntil: (promise: Promise<unknown>) => void;
 }
 
-/** Build the fate entity frame for an update/delete publish (fate's `livePayload` shape). */
+/** fate's `livePayload` shape. */
 const entityFrame = (
 	type: "update" | "delete",
 	id: string | number,
 	options?: {readonly data?: unknown},
 ): EntityFrame => (type === "delete" ? {delete: true, id} : {data: options?.data});
 
-/** Build the connection edge frame for an appendNode/prependNode publish. */
 const nodeFrame = (
 	type: "appendNode" | "prependNode",
 	nodeType: string,
@@ -82,13 +66,9 @@ const nodeFrame = (
 	edge: {node: options?.node, ...(options?.cursor ? {cursor: options.cursor} : {})},
 });
 
-/** Build the per-request `LivePublisher` service value. */
 export function livePublisherFor(options: LivePublisherOptions): typeof LivePublisher.Service {
-	// One topic publish = one detached promise. `ignoreCause({log: "Warn"})` is the
-	// async half of the swallow-with-log contract: it collapses the whole failure
-	// cause (an exhausted-cold-start `LiveTransportError` OR a defect) to `void` and
-	// logs it at Warn through the Effect logger — so an exhausted publish reaches the
-	// logger and Sentry breadcrumbs, not a bare `console.error` nothing watches (#2551).
+	// Async half of the swallow-with-log contract. Logging through the Effect logger
+	// (not `console.error`) is what gets an exhausted publish into Sentry breadcrumbs (#2551).
 	const schedule: PublishToTopic = (topicKey, message) => {
 		options.waitUntil(
 			Effect.runPromise(
@@ -107,9 +87,8 @@ export function livePublisherFor(options: LivePublisherOptions): typeof LivePubl
 		}
 	};
 
-	// Sync half of the swallow-with-log contract: frame building + the `waitUntil`
-	// call run inside `Effect.try`, and `ignore` collapses any failure to the
-	// `Effect<void>` the service's types promise (ADR 0039, once in the layer).
+	// Sync half: frame building + the `waitUntil` call collapse to the `Effect<void>`
+	// the service's types promise (ADR 0039).
 	const swallow = (publishSync: () => void): Effect.Effect<void> =>
 		Effect.try({try: publishSync, catch: (cause) => new LivePublishError({cause})}).pipe(
 			Effect.ignore({log: "Warn"}),
@@ -135,10 +114,9 @@ export function livePublisherFor(options: LivePublisherOptions): typeof LivePubl
 				}),
 			),
 		topic: (procedure, args) => {
-			// Carry the topic's filter args into the match so `topicsForPublish`
-			// resolves the SAME args-scoped key the subscriber registered under, instead
-			// of the procedure-wide global wildcard (which would fan one term's new
-			// definition out to every `Term.definitions` subscriber across all slugs).
+			// The args must ride into the match so `topicsForPublish` resolves the SAME
+			// args-scoped key the subscriber registered under; the global wildcard would fan
+			// one term's new definition out to every `Term.definitions` subscriber.
 			const match = {procedure, ...(args !== undefined ? {args} : {})};
 			const emit = (frame: ConnectionFrame, eventId?: string) =>
 				publish({

--- a/apps/web/worker/features/fate-live/live-publisher.unit.test.ts
+++ b/apps/web/worker/features/fate-live/live-publisher.unit.test.ts
@@ -1,18 +1,4 @@
-/**
- * `livePublisherFor` — the worker-side live implementation of the package's
- * `LivePublisher` per-request service. The contract under test:
- *
- *   1. every publish method's error channel is `never` ("a publish cannot fail
- *      the mutation" is a TYPE);
- *   2. the published `(topicKey, PublishMessage)` pairs match the wire shape —
- *      pinned against literal fixtures (the drift guard), including the no-`data`
- *      update frame;
- *   3. a rejecting topic call cannot fail the calling effect;
- *   4. publishes are scheduled through `waitUntil`, never awaited on the request
- *      path.
- *
- * Unit tier (ADR 0082): stubs at the topic seam, zero storage, no platform fake.
- */
+/** Unit tier (ADR 0082): stubs at the topic seam, zero storage, no platform fake. */
 
 import {assert, it} from "@effect/vitest";
 import type {LivePublisher} from "@kampus/fate-effect";
@@ -24,7 +10,6 @@ import {LiveTransportError} from "./cold-start-retry.ts";
 import {livePublisherFor} from "./live-publisher.ts";
 import type {PublishMessage} from "./protocol.ts";
 
-/** A rejection from a test harness thunk (flush / gated publish) — dies the fiber. */
 class PromiseRejected extends Schema.TaggedErrorClass<PromiseRejected>()("test/PromiseRejected", {
 	cause: Schema.Unknown,
 }) {}
@@ -35,9 +20,8 @@ interface Recorded {
 }
 
 /**
- * Build a `LivePublisher` over stubbed seams: `publish` defaults to a recorder,
- * `waitUntil` collects the scheduled promises so a test can `flush` (or
- * deliberately NOT flush) the fire-and-forget work.
+ * `waitUntil` collects the scheduled promises so a test can `flush` — or
+ * deliberately NOT flush — the fire-and-forget work.
  */
 function makeHarness(
 	publish?: (topicKey: string, message: PublishMessage) => Effect.Effect<void, LiveTransportError>,
@@ -69,8 +53,6 @@ it("every publish method's error channel is `never` — the no-fail contract is 
 	expectTypeOf<Effect.Error<ReturnType<Topic["deleteEdge"]>>>().toEqualTypeOf<never>();
 	expectTypeOf<Effect.Error<ReturnType<Topic["invalidate"]>>>().toEqualTypeOf<never>();
 
-	// The live value implements exactly the package's service shape — a drift in
-	// either direction is a compile error here.
 	const {live} = makeHarness();
 	expectTypeOf(live).toEqualTypeOf<typeof LivePublisher.Service>();
 });
@@ -79,15 +61,13 @@ it.effect("publishes the bridge's exact wire frames (literal fixtures)", () =>
 	Effect.gen(function* () {
 		const {live, recorded, flush} = makeHarness();
 
-		// `changed` is accepted but does NOT reach the wire — the update frame carries
-		// `data` only (no `select` mask); pinned by the fixture below.
+		// `changed` is accepted but does NOT reach the wire.
 		yield* live.update("Definition", "d1", {
 			data: {id: "d1", body: "updated"},
 			changed: ["body"],
 			eventId: "e1",
 		});
-		// An update with no `data` still carries the `data` key on the wire
-		// (`frame: {data: undefined}`) — asserted by the fixture below.
+		// An update with no `data` still carries the `data` key on the wire.
 		yield* live.update("Definition", "d9", {eventId: "e9"});
 		yield* live.delete("Post", 7, {eventId: "e2"});
 		const definitions = live.topic("Term.definitions", {slug: "effect"});
@@ -186,8 +166,7 @@ it.effect("publishes the bridge's exact wire frames (literal fixtures)", () =>
 );
 
 it.effect("a rejecting topic publish cannot fail the calling effect", () => {
-	// Silence the publisher's Warn failure log (the `ignoreCause({log: "Warn"})` default sink
-	// is `console.log`) so the run stays quiet.
+	// Silence the publisher's Warn failure log so the run stays quiet.
 	const logSpy = vi.spyOn(console, "log").mockImplementation(() => {});
 	return Effect.gen(function* () {
 		const {live, flush} = makeHarness(() => Effect.die(new Error("DO unreachable")));
@@ -212,14 +191,10 @@ it.effect("a rejecting topic publish cannot fail the calling effect", () => {
 it.effect(
 	"an exhausted-cold-start publish is logged through the Effect logger, never a bare console.error or a silent drop (#2551)",
 	() => {
-		// The bug: the detached publish's terminal catch routed an exhausted-cold-start
-		// LiveTransportError to a bare `console.error` — invisible to the Effect logger and
-		// Sentry breadcrumbs, so the lost invalidation was silent by construction. It now
-		// flows through `Effect.ignoreCause({log: "Warn"})`: logged at Warn through the Effect
-		// logger (whose default runtime sink emits one `console.log` line; a Sentry logger
-		// layer routes it to breadcrumbs), OFF the bare `console.error`, and still swallowed
-		// (the calling mutation never fails). The detached fiber runs on the default runtime,
-		// so its logger writes to the real `console.log` this test captures.
+		// The regression: a bare `console.error` on the detached publish's terminal catch
+		// was invisible to the Effect logger and to Sentry breadcrumbs, so a lost
+		// invalidation was silent by construction. The detached fiber runs on the default
+		// runtime, whose logger sink is the real `console.log` this test captures.
 		const logged: Array<string> = [];
 		const logSpy = vi.spyOn(console, "log").mockImplementation((...args: Array<unknown>) => {
 			logged.push(args.map(String).join(" "));
@@ -271,8 +246,8 @@ it.effect("a slow publish does not block the request path — waitUntil carries 
 			}).pipe(Effect.orDie),
 		);
 
-		// The publish effect completes NOW, while the topic call is still hung —
-		// nothing on the request path awaits it.
+		// Completes NOW, while the topic call is still hung — nothing on the request
+		// path awaits it.
 		yield* live.update("Definition", "d1", {data: {id: "d1"}});
 		assert.isFalse(settled);
 

--- a/apps/web/worker/features/fate-live/protocol.ts
+++ b/apps/web/worker/features/fate-live/protocol.ts
@@ -1,12 +1,10 @@
 /**
  * Shared live wire types + topic helpers for the SSE fan-out (ADR 0023).
  *
- * Import-safe in a plain Node runner (no `cloudflare:workers`): the per-request
- * publisher and the fate codegen graph depend on it, while only `live-do.ts` and
- * the worker entry pull in the Workers runtime. The frame shapes mirror fate's
- * native `livePayload` / `liveConnectionPayload` / `sse()` exactly, so the
- * browser's native fate SSE client parses them unchanged — phoenix only swaps
- * WHERE the frames are produced (the DO), not their shape.
+ * Must stay import-safe in a plain Node runner (no `cloudflare:workers`) — the fate
+ * codegen graph depends on it. Frame shapes mirror fate's native `livePayload` /
+ * `liveConnectionPayload` / `sse()` exactly, so the browser's fate SSE client parses
+ * them unchanged; phoenix swaps only WHERE frames are produced, not their shape.
  */
 
 import {LivePublisher} from "@kampus/fate-effect";
@@ -21,35 +19,24 @@ import * as Schema from "effect/Schema";
 import {brandedId} from "../../lib/ids.ts";
 
 /**
- * A LiveDO connection id — the client's stream identity the connection role is
- * addressed by (`connection:<connectionId>`). Branded distinctly from {@link EntityId}
- * so the two live-protocol ids can't be transposed at a call site (they are both bare
- * strings on the wire, and the LiveDO plays both the connection and topic roles).
- * Type-only, so the SSE wire form decodes byte-identically. Shared brand idiom + the
- * cross-feature `UserId` live in `lib/ids.ts` (epic #2700); the two ids branded here are
- * fate-live-owned, so they stay feature-local.
+ * A LiveDO connection id (`connection:<connectionId>`). Branded distinctly from
+ * {@link EntityId} so the two can't be transposed at a call site — both are bare
+ * strings on the wire. Type-only, so the wire form decodes byte-identically.
  */
 export const ConnectionId = brandedId("ConnectionId");
 export type ConnectionId = typeof ConnectionId.Type;
 
 /**
- * A fate protocol entity id — fate's `isProtocolId` admits a string OR a number, so the
- * brand is applied to the *union* (not a branded string with a discarded number arm):
- * `(string | number) & Brand<"EntityId">` keeps both wire arms while staying nominally
- * distinct from {@link ConnectionId}. Brand is type-only, so the union decodes/serializes
- * byte-identically.
+ * A fate protocol entity id. fate's `isProtocolId` admits a string OR a number, so the
+ * brand goes on the *union* — a branded string would silently discard the number arm.
  */
 export const EntityId = Schema.Union([Schema.String, Schema.Number]).pipe(Schema.brand("EntityId"));
 export type EntityId = typeof EntityId.Type;
 
 /**
- * The ONE source of every live topic name: the string is
- * authored here once, and the union, the subscribe-side decode schema, and every
- * publish call site all derive from / reference this object. A topic key can no
- * longer be mistyped at a call site (publish and subscribe can't miss each other
- * via a stray literal). Add a topic by adding ONE entry here — the union and
- * the schema literal pick it up automatically, and publish sites reference
- * `LiveTopic.<name>` instead of restating the string.
+ * The ONE source of every live topic name — the union, the subscribe-side decode
+ * schema, and every publish site derive from this object, so publish and subscribe
+ * can't miss each other via a stray literal. Add a topic by adding ONE entry here.
  */
 export const LiveTopic = {
 	/** pano feed (no-args, global). */
@@ -59,34 +46,22 @@ export const LiveTopic = {
 	/** sözlük term → definitions (args: `{id: termSlug}`). */
 	termDefinitions: "Term.definitions",
 	/**
-	 * pano viewer's saved posts (per-viewer). Registered so the saved view's
-	 * connection-level subscribe DECODES instead of 400ing (`SavedConnectionView`
-	 * carries no `live:` config, so it wants no connection prepends — only a valid
-	 * subscribe). Deliberately has NO cross-client publish target: the saved list is
-	 * viewer-private, so a publish onto this login-blind shared topic would leak one
-	 * viewer's saved membership (and per-viewer `isSaved`) to every other subscriber.
-	 * Live save-state is carried per-row by the entity `Post` subscribe (`isSaved`)
-	 * + the client's local `savedReconcile`, not a connection fan-out.
+	 * pano viewer's saved posts (per-viewer). Registered only so the saved view's
+	 * subscribe DECODES instead of 400ing. Deliberately has NO publish target: this
+	 * topic is login-blind and shared, so publishing onto it would leak one viewer's
+	 * saved membership to every other subscriber. Live save-state rides the entity
+	 * `Post` subscribe (`isSaved`) plus the client's `savedReconcile`.
 	 */
 	savedPosts: "savedPosts",
 } as const;
 
-/**
- * The closed set of live topic keys phoenix publishes to / subscribes
- * on, derived from {@link LiveTopic}'s values. The subscribe side is gated by
- * {@link LiveTopicKeySchema}; the publish side by
- * {@link WorkerLivePublisher}.
- */
 export type LiveTopicKey = (typeof LiveTopic)[keyof typeof LiveTopic];
 
 /**
- * The package `LivePublisher` service surface with `topic`'s procedure
- * narrowed to {@link LiveTopicKey} — the publish-side typo gate. The
- * package takes a plain `string` by design; narrowing it here makes a misspelled
- * procedure a compile error instead of a silent dead topic. Parameters are
- * contravariant, so the package value is assignable with no cast/wrapper, and
- * everything but the narrowed parameter is structural (`Omit`/`Parameters`/
- * `ReturnType`) so the two surfaces can't drift.
+ * The package `LivePublisher` surface with `topic`'s procedure narrowed to
+ * {@link LiveTopicKey} — the publish-side typo gate. The package takes a plain
+ * `string`; narrowing makes a misspelled procedure a compile error instead of a
+ * silent dead topic. Parameters are contravariant, so no cast or wrapper is needed.
  */
 export type WorkerLivePublisher = Omit<typeof LivePublisher.Service, "topic"> & {
 	readonly topic: (
@@ -96,11 +71,9 @@ export type WorkerLivePublisher = Omit<typeof LivePublisher.Service, "topic"> & 
 };
 
 /**
- * The ONE seam where the package tag is narrowed to the typo-gated surface:
- * worker mutations write `const live = yield* WorkerLivePublisher` and never the
- * package tag directly. The un-narrowed `yield* LivePublisher` also compiles but
- * has no gate, so "import the worker accessor, not the package tag" is the
- * greppable convention. Same tag, retyped by plain assignability.
+ * The one place the package tag is narrowed to the typo-gated surface. Worker
+ * mutations must yield THIS, never `LivePublisher` directly — the package tag also
+ * compiles but has no gate.
  */
 export const WorkerLivePublisher: Effect.Effect<WorkerLivePublisher, never, LivePublisher> =
 	LivePublisher;
@@ -129,9 +102,8 @@ export type ConnectionFrame =
 
 /**
  * A publish to a topic DO. The mutation side resolves the topic string and the
- * per-event payload (already inline-resolved `data`/`node`), so the topic DO
- * relays it with no re-resolution. `procedure` is a plain `string` here (wire
- * data); the publish-side typo gate lives at the caller, {@link WorkerLivePublisher}.
+ * payload, so the topic DO relays with no re-resolution. `procedure` is a plain
+ * `string` here (wire data); the typo gate lives at {@link WorkerLivePublisher}.
  */
 export type PublishMessage =
 	| {
@@ -151,19 +123,16 @@ export type PublishMessage =
 	  };
 
 /**
- * A pre-bound per-request topic publish: one resolved topic key + message fires
- * the typed `LiveDO.publish` RPC, fired-and-forgotten via the request's
- * `waitUntil`. Reaches the DO via the typed RPC stub, not an
- * `env`-lookup/`idFromName`/string-URL `stub.fetch` (ADR 0028/0029).
+ * A pre-bound per-request topic publish, fired-and-forgotten via the request's
+ * `waitUntil`. Reaches the DO through the typed RPC stub, never a string-URL
+ * `stub.fetch` (ADR 0028/0029).
  */
 export type PublishToTopic = (topicKey: string, message: PublishMessage) => void;
 
 /**
- * A control message a connection DO records as a subscription. `lastEventId` is
- * the last SSE `id:` the client saw on this subscription before this (re)subscribe
- * — threaded through to `register` as an extra tightening on top of the primary
- * `subscribedAt` replay bound (the topic replays only frames from the subscriber's
- * intent forward, never the topic's prior history; see `live-do.ts` `replayBuffer`).
+ * A control message a connection DO records as a subscription. `lastEventId` tightens
+ * replay on top of the primary `subscribedAt` bound — the topic replays only frames
+ * from the subscriber's intent forward (see `live-do.ts` `replayBuffer`).
  */
 export type SubscribeControl =
 	| {
@@ -183,11 +152,7 @@ export type SubscribeControl =
 
 const OptionalArgs = Schema.optional(Schema.Record(Schema.String, Schema.Unknown));
 
-/**
- * The subscribe-side schema for {@link LiveTopicKey}, derived from
- * {@link LiveTopic}'s values so it can't drift from the union. An unknown
- * procedure fails decode (→ `BAD_REQUEST`) rather than registering a dead topic.
- */
+/** Derived from {@link LiveTopic} so an unknown procedure fails decode instead of registering a dead topic. */
 const LiveTopicKeySchema = Schema.Literals(Object.values(LiveTopic));
 
 const SubscribeOp = Schema.Struct({
@@ -216,7 +181,6 @@ const UnsubscribeOp = Schema.Struct({
 	kind: Schema.Literal("unsubscribe"),
 });
 
-/** The schema is the single source of truth; the types below derive from it. */
 const LiveControlOperationSchema = Schema.Union([
 	SubscribeOp,
 	SubscribeConnectionOp,
@@ -234,11 +198,9 @@ export type LiveControlOperation = Schema.Schema.Type<typeof LiveControlOperatio
 export type LiveControlRequest = Schema.Schema.Type<typeof LiveControlRequestSchema>;
 
 /**
- * Decode an untrusted fate live control request body, mirroring fate's native
- * `assertLiveControlRequest` (a malformed body fails with a `BAD_REQUEST`
- * `FateRequestError` rather than coercing — e.g. a missing/non-id `entityId` is
- * rejected, not turned into a dead empty-string subscription). Any `ParseError`
- * collapses to the same `FateRequestError` the route maps to `liveError(...)`.
+ * Decode an untrusted live control body, mirroring fate's `assertLiveControlRequest`:
+ * a malformed body fails rather than coercing — a missing `entityId` must be rejected,
+ * not turned into a dead empty-string subscription.
  */
 export const parseLiveControlRequest = (
 	value: unknown,
@@ -303,9 +265,9 @@ export function topicsForSubscribe(control: SubscribeControl): ReadonlyArray<str
 }
 
 /**
- * Per-request fan-out budgets (void's `LiveLimits`), threaded onto the LiveDO's
- * RPC inputs rather than hardcoded in the DO (decision 2B): the worker/route
- * supplies these on each call, the DO never invents its own.
+ * Per-request fan-out budgets, threaded onto the LiveDO's RPC inputs rather than
+ * hardcoded in the DO: the worker supplies these on each call, the DO never invents
+ * its own.
  */
 export interface LiveLimits {
 	readonly maxSubscriptionsPerConnection: number;
@@ -320,10 +282,8 @@ export interface LiveLimits {
 }
 
 /**
- * The default per-request fan-out budgets (void's `DEFAULT_LIMITS`). Lives HERE,
- * beside {@link LiveLimits}, so neither publishing/subscribing route imports
- * config out of a sibling ROUTE module. void's `maxOperationsPerControlRequest`
- * is a control-request cap, not a `LiveLimits` DO budget field, so it is omitted.
+ * The default budgets. Live here beside {@link LiveLimits} so neither route imports
+ * config out of a sibling ROUTE module.
  */
 export const defaultLiveLimits: LiveLimits = {
 	maxSubscriptionsPerConnection: 256,
@@ -338,13 +298,10 @@ export const defaultLiveLimits: LiveLimits = {
 };
 
 /**
- * A persisted topic-role subscriber row (the value under a `sub:` KV key, void's
- * flat-key model). `connectionId` is the name the topic re-addresses the instance
- * from (`connectionOf`); `subId` is the client's subscription id. The stale model
- * rides two counters: `generation` (the connection's stream lifetime at register
- * time) and `revision` (the subscription's lifetime). On deliver/check a reachable
- * connection compares both against live state; a mismatch means the topic prunes
- * the row. (See `live-do.ts` header.)
+ * A persisted topic-role subscriber row (the value under a `sub:` key). Staleness
+ * rides two counters — `generation` (the connection's stream lifetime at register
+ * time) and `revision` (the subscription's) — and a mismatch on deliver prunes the
+ * row. See `live-do.ts` header.
  */
 export interface SubscriberRow {
 	readonly topicKey: string;
@@ -356,17 +313,13 @@ export interface SubscriberRow {
 }
 
 /**
- * A frame the topic role retains in its storage-backed ring buffer (under a
- * `frame:<topicKey>:<seq>` key) so a subscriber whose `register` lands AFTER the
- * publish can still catch up — the publish-vs-register race fix (#714). The buffer
- * is storage-backed, not in-memory: a topic DO is not pinned by any open stream
- * (only connection DOs are), so it evicts between a publish and a later register,
- * and an in-memory buffer would be gone exactly when replay needs it. `seq` is the
- * monotonic per-topic publish ordinal (replay order, and dedup when frames carry no
- * `eventId`); `eventId` is the optional wire id that tightens replay by the
- * subscriber's `lastEventId`; `at` is the publish timestamp — both the TTL bound
- * and the primary `subscribedAt` replay bound (only frames at/after the
- * subscriber's intent replay; see `live-do.ts` `replayBuffer`).
+ * A frame the topic role retains in its ring buffer so a subscriber whose `register`
+ * lands AFTER the publish can still catch up (#714). Storage-backed, not in-memory:
+ * a topic DO is not pinned by any open stream (only connection DOs are), so it evicts
+ * between a publish and a later register — an in-memory buffer would be gone exactly
+ * when replay needs it. `seq` is the per-topic publish ordinal (replay order + dedup
+ * when frames carry no `eventId`); `at` bounds both the TTL and the `subscribedAt`
+ * replay window.
  */
 export interface BufferedFrame {
 	readonly seq: number;

--- a/apps/web/worker/features/fate-live/protocol.unit.test.ts
+++ b/apps/web/worker/features/fate-live/protocol.unit.test.ts
@@ -1,11 +1,8 @@
 /**
- * `parseLiveControlRequest` decode contract for the closed live-topic set. The
- * one non-obvious guarantee under test: a `subscribeConnection` on a REGISTERED
- * procedure (`savedPosts`, the per-viewer saved list) decodes instead of failing
- * with the `BAD_REQUEST` the unregistered procedure returned (#2214), while an
- * unknown procedure still fails closed.
- *
- * Unit tier (ADR 0082): pure decode, no storage, no platform fake.
+ * `parseLiveControlRequest` decode contract. The non-obvious guarantee: a
+ * `subscribeConnection` on a REGISTERED procedure decodes rather than returning the
+ * `BAD_REQUEST` an unregistered one did (#2214), while an unknown procedure still fails
+ * closed.
  */
 
 import {assert, it} from "@effect/vitest";
@@ -56,19 +53,12 @@ it.effect("rejects a subscribeConnection on an unregistered procedure with BAD_R
 	}),
 );
 
-// A connectionId/entityId swap fails typecheck: the two live-protocol ids carry
-// distinct nominal brands, so neither is assignable to the other and the decoded
-// `LiveControlRequest`/subscribe-op surfaces expose the branded types. Pinned with
-// expectTypeOf, not `@ts-expect-error` — the effect LSP plugin's TS377003 escapes the
-// directive (see vote-boundary.unit.test.ts). This is the type-level half of the guard;
-// the decode tests above cover the byte-identical runtime.
+// Pinned with expectTypeOf, not `@ts-expect-error` — the effect LSP plugin's TS377003
+// escapes the directive (see vote-boundary.unit.test.ts).
 vit("connectionId and entityId are distinct branded surfaces", () => {
-	// Each id is branded, not a bare string / bare union (the brand is what a swap trips).
 	expectTypeOf<ConnectionId>().not.toEqualTypeOf<string>();
 	expectTypeOf<EntityId>().not.toEqualTypeOf<string | number>();
-	// The two brands are distinct, so a connectionId can't stand in for an entityId.
 	expectTypeOf<ConnectionId>().not.toEqualTypeOf<EntityId>();
-	// The decoded protocol surfaces expose the branded types (not bare strings/unions).
 	expectTypeOf<LiveControlRequest["connectionId"]>().toEqualTypeOf<ConnectionId>();
 	expectTypeOf<
 		Extract<LiveControlOperation, {kind: "subscribe"}>["entityId"]

--- a/apps/web/worker/features/fate-live/route.ts
+++ b/apps/web/worker/features/fate-live/route.ts
@@ -2,20 +2,14 @@
  * The `* /fate/live` route — the SSE transport endpoint (ADR 0023/0028,
  * `.patterns/alchemy-http-router.md`).
  *
- * Serves fate's native SSE live protocol from the unified `LiveDO` rather than
- * fate's in-Worker `handleLiveRequest` (which can't fan out across isolates). It
- * builds NO per-request runtime: the session check rides the worker-level
- * `Pasaport`, and the connection is reached through the worker-init `LiveDO`
- * namespace via typed RPC + a forwarded `fetch`, never
+ * Serves fate's native SSE live protocol from the unified `LiveDO` rather than fate's
+ * in-Worker `handleLiveRequest`, which cannot fan out across isolates. It builds no
+ * per-request runtime, and reaches the connection through the worker-init `LiveDO`
+ * namespace via typed RPC plus a forwarded `fetch` — never
  * `idFromName`/`get`/`stub.fetch(string)`.
  *
- *   - `GET  /fate/live?connectionId=…` → validate cookie, forward to the
- *     connection DO's `fetch` to open the SSE stream (401 without a session).
- *   - `POST /fate/live` → a `subscribe`/`subscribeConnection`/`unsubscribe`
- *     control message; validate cookie, drive the connection DO's typed RPC.
- *
- * The session cookie rides the request automatically (fate's `EventSource` uses
- * `withCredentials: true`, same-origin), so there's no token in the URL/header.
+ * There is no token in the URL or headers: the session cookie rides the request
+ * automatically, since fate's `EventSource` is same-origin with `withCredentials`.
  */
 import {FateRequestError} from "@nkzw/fate/server";
 import * as Cloudflare from "alchemy/Cloudflare";
@@ -34,7 +28,6 @@ import {
 } from "./protocol.ts";
 import {LiveConnections} from "./topics.ts";
 
-/** The fate live error envelope (`{results: [{error}], version: 1}`). */
 function liveError(code: string, message: string, status: number) {
 	return HttpServerResponse.jsonUnsafe(
 		{results: [{error: {code, message}, id: "live", ok: false}], version: 1},
@@ -64,9 +57,8 @@ export const handleLive = Effect.gen(function* () {
 			`https://live/connect?connectionId=${encodeURIComponent(connectionId)}&ownerId=${encodeURIComponent(ownerId)}&maxQueuedEventsPerConnection=${defaultLiveLimits.maxQueuedEventsPerConnection}`,
 			{headers: raw.headers},
 		);
-		// A cold-DO transport failure that survived the worker-seam retry is a
-		// graceful 503 (the live pin retries on the next mount), NOT a defect — only
-		// a genuine `HttpServerError` (request framing) stays an `orDie` defect.
+		// A cold-DO transport failure that survived the retry renders a graceful 503 (the
+		// live pin retries on the next mount); only a real framing error stays a defect.
 		return yield* connections.open(connectionId, HttpServerRequest.fromWeb(forward)).pipe(
 			Effect.catchTag("fate-live/LiveTransportError", (error) =>
 				Effect.succeed(liveError("LIVE_UNAVAILABLE", error.message, 503)),
@@ -76,8 +68,6 @@ export const handleLive = Effect.gen(function* () {
 	}
 
 	if (raw.method === "POST") {
-		// A bad-JSON body and a schema `FateRequestError` both become a `liveError`
-		// Response here (recovered via `Effect.result`), never threaded onward.
 		const decoded = yield* Effect.tryPromise({
 			try: () => raw.json(),
 			catch: () => new FateRequestError("BAD_REQUEST", "Body must be valid JSON."),
@@ -95,12 +85,10 @@ export const handleLive = Effect.gen(function* () {
 				results.push({id: operation.id, ok: true, data: null});
 				continue;
 			}
-			// Recipient-scoped topic gate (#1700): the `NotificationChannel` entity topic
-			// is keyed by a recipient's user id, so a subscription whose entity id is not
-			// the session user's own would watch ANOTHER user's notification stream. The
-			// entity id is client-supplied, and the DO's owner check only guards the
-			// CONNECTION owner (not the entity id), so this is the authorization seam —
-			// reject the cross-user subscribe here rather than register a foreign topic.
+			// This is the authorization seam for recipient-scoped topics (#1700). The
+			// entity id is client-supplied and the DO's owner check guards only the
+			// CONNECTION owner, so without this a subscribe could watch another user's
+			// notification stream.
 			if (
 				operation.kind === "subscribe" &&
 				operation.type === NOTIFICATION_CHANNEL_TYPE &&
@@ -125,10 +113,9 @@ export const handleLive = Effect.gen(function* () {
 							...(operation.args ? {args: operation.args} : {}),
 							...(operation.lastEventId !== undefined ? {lastEventId: operation.lastEventId} : {}),
 						};
-			// Resolve the control's topic keys + per-request limits here, so the DO
-			// records the subscription with a budget it never invents (decision 2B).
-			// `lastEventId` rides through so the topic replays only frames newer than
-			// the last one this subscription saw (#714 catch-up).
+			// Limits are resolved here so the DO records the subscription with a budget it
+			// never invents, and `lastEventId` rides through so the topic replays only
+			// frames newer than the last one this subscription saw (#714).
 			const res = yield* connections.subscribe(connectionId, {
 				subId: operation.id,
 				topics: topicsForSubscribe(control),
@@ -146,9 +133,8 @@ export const handleLive = Effect.gen(function* () {
 
 	return liveError("BAD_REQUEST", "Invalid live request.", 400);
 }).pipe(
-	// A cold-DO transport failure from the POST control loop (`subscribe`/
-	// `unsubscribe`) that survived the worker-seam retry renders a graceful 503
-	// envelope, NOT a defect-500 (#842). The GET path handles its own locally.
+	// Same 503-not-500 handling for the POST control loop (#842); the GET path handles
+	// its own locally.
 	Effect.catchTag("fate-live/LiveTransportError", (error: LiveTransportError) =>
 		Effect.succeed(liveError("LIVE_UNAVAILABLE", error.message, 503)),
 	),

--- a/apps/web/worker/features/fate-live/topics.ts
+++ b/apps/web/worker/features/fate-live/topics.ts
@@ -1,10 +1,9 @@
 /**
- * `LiveTopics` — the worker-level handle the `/fate` route uses to fan a publish
- * out to the `LiveDO` namespace's topic-role instances (ADR 0028/0029). The
- * namespace is resolved once in worker init, wrapped as a `Context.Service` so the
- * per-request route reaches it without an `env`-based lookup. `publish` is a typed
- * RPC addressed through `live-do.ts`'s seam — no `idFromName`, no string-URL
- * `stub.fetch` — run inside `waitUntil` so the fan-out doesn't block the response.
+ * `LiveTopics` — the worker-level handle the `/fate` route fans a publish out
+ * through (ADR 0028/0029). The namespace resolves once in worker init, so the
+ * per-request route needs no `env` lookup. Publishes are typed RPC addressed through
+ * `live-do.ts` (never `idFromName` or a string-URL `stub.fetch`), run inside
+ * `waitUntil` so the fan-out doesn't block the response.
  */
 import * as Context from "effect/Context";
 import type * as Effect from "effect/Effect";
@@ -17,15 +16,11 @@ import type {LiveLimits, PublishMessage} from "./protocol.ts";
 export class LiveTopics extends Context.Service<
 	LiveTopics,
 	{
-		/**
-		 * Fire the typed `LiveDO.publish` RPC for one resolved topic key.
-		 * `LiveTransportError` is the truthful channel the alchemy stub's `never`
-		 * hides (#842, #2551): a publish to an idle-evicted `topic:` DO can fail on
-		 * the cold first RPC, so the worker seam wraps this in `withColdStartRetry`
-		 * (the same bounded retry the sibling `subscribe`/`unsubscribe` use) and
-		 * surfaces this on exhaustion. The publisher swallows-and-logs it best-effort
-		 * off the request path — a publish still must not fail the committed mutation.
-		 */
+		// `LiveTransportError` is the truthful channel the alchemy stub's `never` hides
+		// (#842, #2551): a publish to an idle-evicted `topic:` DO can fail on the cold
+		// first RPC, so the worker seam retries and surfaces this on exhaustion. The
+		// publisher then swallows-and-logs it — a publish must never fail a committed
+		// mutation.
 		readonly publish: (
 			topicKey: string,
 			message: PublishMessage,
@@ -34,21 +29,12 @@ export class LiveTopics extends Context.Service<
 	}
 >()("@kampus/LiveTopics") {}
 
-/**
- * `LiveConnections` — the worker-level handle the `/fate/live` route uses to
- * reach the `LiveDO` namespace's connection-role instances (ADR 0028). Opens the
- * SSE stream by forwarding the inbound request to a connection's `fetch`, and
- * records/drops subscriptions via typed RPC. Connections are addressed through
- * `connectionOf(live, connectionId)` — no `idFromName`/`get` on the alchemy stub.
- */
+// The `/fate/live` counterpart (ADR 0028). Connections are addressed through
+// `connectionOf(live, connectionId)`, never `idFromName`/`get` on the alchemy stub.
 export class LiveConnections extends Context.Service<
 	LiveConnections,
 	{
-		/**
-		 * Forward the (request-shaped) SSE upgrade to a connection DO's `fetch`.
-		 * `LiveTransportError` is the bounded-retry-exhausted cold-start failure
-		 * (#842); the worker seam wraps the cross-DO call in `withColdStartRetry`.
-		 */
+		// `LiveTransportError` is the bounded-retry-exhausted cold-start failure (#842).
 		readonly open: (
 			connectionId: string,
 			request: HttpServerRequest.HttpServerRequest,
@@ -57,12 +43,8 @@ export class LiveConnections extends Context.Service<
 			HttpServerError | LiveTransportError,
 			never
 		>;
-		/**
-		 * Record a subscription on a connection (typed RPC). `LiveTransportError` is
-		 * the truthful error channel the alchemy stub's `never` hid (#842): the
-		 * worker seam retries a cold-DO transport failure and surfaces this on
-		 * exhaustion, so the route renders a 503 envelope instead of a defect-500.
-		 */
+		// On retry exhaustion the route renders a 503 envelope rather than a
+		// defect-500 (#842).
 		readonly subscribe: (
 			connectionId: string,
 			input: {
@@ -73,7 +55,6 @@ export class LiveConnections extends Context.Service<
 				readonly lastEventId?: string;
 			},
 		) => Effect.Effect<{readonly ok: boolean}, LiveTransportError, never>;
-		/** Drop a subscription on a connection (typed RPC). */
 		readonly unsubscribe: (
 			connectionId: string,
 			subId: string,

--- a/apps/web/worker/features/fate/author-identity.ts
+++ b/apps/web/worker/features/fate/author-identity.ts
@@ -1,52 +1,33 @@
 /**
- * `stampAuthorIdentity` — the author-identity analogue of `stampReactionAggregate`
- * (`reaction-aggregate.ts`) and `stampViewerScalars` (`viewer-scalars.ts`), for the
- * two live-identity wire fields the `definition` / `post` / `comment` fate views
- * expose so the denormalized author surfaces render the author's CURRENT handle
- * rather than the write-time `authorName` snapshot (#2139, completing #2126's
- * display-consistency AC for the surfaces #2126/#2130 deferred).
+ * `stampAuthorIdentity` — stamps the live `{username, displayName}` onto denormalized
+ * author surfaces so they render the author's CURRENT handle, not the write-time
+ * `authorName` snapshot (#2139). ONE batched read for the whole page, never per row.
  *
- * The write-time `authorName` snapshot exists to avoid a per-row user join, so
- * resolving the LIVE `{username, displayName}` is a join — but a BATCHED one, the
- * same N+1-avoidance shape the sibling stampers use: ONE `Pasaport.getProfileIdentitiesByIds`
- * read (`SELECT … FROM user_profile WHERE user_id IN (…)`) for the whole page,
- * keyed by `authorId`, never a per-row read. This is the exact idiom Divan's
- * `roster` and report's `resolveResolverHandles` already use (`getProfileIdentitiesByIds`).
- *
- * A row whose author has no profile row (or no username/displayName yet) is stamped
- * with nulls; the client's `actorLabel(displayName, username, fallback)` then degrades
- * to `@username` → the fixed fallback noun. The account-deletion `@[silinen]` sentinel
- * (ADR 0097) carries its own `displayName`, so it resolves through this path with no
- * special-casing — it renders its own live handle like any other author.
+ * A row whose author has no profile (or no handle yet) is stamped with nulls, and the
+ * client's `actorLabel` degrades to `@username` → the fallback noun. The deletion
+ * `@[silinen]` sentinel (ADR 0097) carries its own `displayName`, so it needs no
+ * special-casing here.
  */
 import type {Effect} from "effect";
 import {Effect as Eff} from "effect";
 import type {ProfileIdentityRow} from "../pasaport/Pasaport.ts";
 
 /**
- * The batched author-identity reader this stamp needs — the `Pasaport` method that
- * reads `{username, displayName}` for a set of author ids in one `IN (…)` query. Taken
- * as a narrow function dep (not the whole `Pasaport` service) so the stamp stays
- * unit-testable with a plain stub, mirroring how `stampReactionAggregate` takes the
- * reaction service handle.
+ * Taken as a narrow function dep, not the whole `Pasaport` service, so the stamp stays
+ * unit-testable with a plain stub.
  */
 export type ReadProfileIdentities = (
 	userIds: ReadonlyArray<string>,
 ) => Effect.Effect<ProfileIdentityRow[]>;
 
-/** The two live-identity fields the stamp adds to a row keyed by `authorId`. */
 export interface AuthorIdentityFields {
 	readonly authorUsername: string | null;
 	readonly authorDisplayName: string | null;
 }
 
 /**
- * Run the one batched identity read over `rows`' distinct `authorId`s, then stamp
- * `authorUsername` + `authorDisplayName` onto each row from the live `user_profile`
- * row (or nulls when the author has no profile / no handle yet). One read for the
- * whole batch — never per row. The stamped fields are *added* to the input row
- * shape, so a read that wants live identity must route through here (a path that
- * skips the stamp never produces the fields).
+ * The stamped fields are *added* to the input row shape, so a path that skips the stamp
+ * never produces them.
  */
 export const stampAuthorIdentity = <R extends {authorId: string}>(
 	read: ReadProfileIdentities,

--- a/apps/web/worker/features/fate/author-identity.unit.test.ts
+++ b/apps/web/worker/features/fate/author-identity.unit.test.ts
@@ -1,22 +1,12 @@
 /**
- * `stampAuthorIdentity` — the batched live-author-identity stamp (#2139). Proves the
- * three facets #2126's display-consistency AC needs on the denormalized surfaces:
- *
- *  1. A user who RENAMED after posting reflects the NEW `displayName` (the live-resolve
- *     proof — the stamp reads current `user_profile`, not the write-time `authorName`
- *     snapshot), so `actorLabel` on the stamped fields renders the current name.
- *  2. A null-`displayName` author resolves to `@username` (via the client `actorLabel`).
- *  3. A both-null author (no profile / no handle) resolves to the fixed fallback noun.
- *
- * Plus the N+1-avoidance contract: ONE batched read for the whole page, keyed by
- * distinct `authorId`, and a blank `authorId` (the `[silindi]` tombstone) is never read.
+ * `stampAuthorIdentity` — the batched live-author-identity stamp (#2139), covering the
+ * display-consistency AC of #2126 plus the N+1-avoidance contract.
  */
 import {describe, expect, it} from "@effect/vitest";
 import {Effect} from "effect";
-// `authorDisplayLabel` is the worker-side parity twin of the SPA's `actorLabel` (same
-// display-name → @username → fallback rule; the worker cannot import the SPA module — the
-// no-worker→src boundary). Asserting the client render through it proves the stamped
-// fields resolve to the same label the surfaces show, without crossing that boundary.
+// `authorDisplayLabel` is the worker-side parity twin of the SPA's `actorLabel`; the
+// worker cannot import the SPA module, so asserting the render through it is how the
+// label is checked without crossing that boundary.
 import {AUTHOR_FALLBACK_LABEL, authorDisplayLabel} from "../pasaport/author-label.ts";
 import type {ProfileIdentityRow} from "../pasaport/Pasaport.ts";
 import {stampAuthorIdentity} from "./author-identity.ts";
@@ -31,9 +21,9 @@ const identity = (over: Partial<ProfileIdentityRow> & {userId: string}): Profile
 describe("stampAuthorIdentity — live author identity on the denormalized read surfaces (#2139)", () => {
 	it.effect("a RENAMED user reflects the new displayName, not the write-time snapshot", () =>
 		Effect.gen(function* () {
-			// The row's `authorName` snapshot is the OLD label baked in at write time.
+			// `author` is the OLD label baked in at write time; the read below returns the
+			// CURRENT one.
 			const rows = [{id: "def-1", authorId: "u-1", author: "Eski Ad"}];
-			// The live profile read returns the CURRENT display name (the user renamed since).
 			const read = (ids: ReadonlyArray<string>) =>
 				Effect.succeed(
 					ids.map((userId) => identity({userId, username: "ada", displayName: "Yeni Ad"})),
@@ -43,8 +33,6 @@ describe("stampAuthorIdentity — live author identity on the denormalized read 
 
 			expect(stamped?.authorDisplayName).toBe("Yeni Ad");
 			expect(stamped?.authorUsername).toBe("ada");
-			// The client renders the live name (parity twin of `actorLabel`) — the new name,
-			// never the "Eski Ad" snapshot.
 			expect(
 				authorDisplayLabel({name: stamped?.authorDisplayName, username: stamped?.authorUsername}),
 			).toBe("Yeni Ad");
@@ -70,7 +58,6 @@ describe("stampAuthorIdentity — live author identity on the denormalized read 
 	it.effect("a both-null author resolves to the fixed fallback noun", () =>
 		Effect.gen(function* () {
 			const rows = [{id: "c-1", authorId: "u-3", author: AUTHOR_FALLBACK_LABEL}];
-			// No profile row for this author (an id absent from the batched read).
 			const read = () => Effect.succeed<ProfileIdentityRow[]>([]);
 
 			const [stamped] = yield* stampAuthorIdentity(read, rows);
@@ -98,10 +85,8 @@ describe("stampAuthorIdentity — live author identity on the denormalized read 
 
 			const stamped = yield* stampAuthorIdentity(read, rows);
 
-			// Exactly one read, over the two DISTINCT ids (u-1 once, not twice).
 			expect(calls.length).toBe(1);
 			expect([...(calls[0] ?? [])].sort()).toEqual(["u-1", "u-2"]);
-			// Both rows of u-1 get the same live identity from the single read.
 			expect(stamped[0]?.authorDisplayName).toBe("Ad u-1");
 			expect(stamped[2]?.authorDisplayName).toBe("Ad u-1");
 		}),
@@ -118,7 +103,6 @@ describe("stampAuthorIdentity — live author identity on the denormalized read 
 
 			const [stamped] = yield* stampAuthorIdentity(read, rows);
 
-			// No id to resolve ⇒ the reader is never invoked (empty-id short-circuit).
 			expect(called).toBe(false);
 			expect(stamped?.authorUsername).toBeNull();
 			expect(stamped?.authorDisplayName).toBeNull();

--- a/apps/web/worker/features/fate/codegen-schema.fixture.ts
+++ b/apps/web/worker/features/fate/codegen-schema.fixture.ts
@@ -1,10 +1,8 @@
 /**
- * Codegen fixture — the `schema.ts` shape of the fate-effect era, fed to the
- * REAL fate Vite plugin in `codegen-vite.test.ts`. Mirrors `schema.ts`'s shape
- * but is self-contained (no live feature imports), so it pins the module SHAPE
- * against the plugin, not the live config's content. Handlers close over a
- * throw-on-touch Proxy standing in for D1: if the codegen path executed
- * anything, generation would fail loudly — the "no D1 at build time" proof.
+ * Codegen fixture fed to the REAL fate Vite plugin in `codegen-vite.test.ts`. Self-contained
+ * (no live feature imports), so it pins the module SHAPE against the plugin, not the live
+ * config's content. Handlers close over a throw-on-touch Proxy standing in for D1: if the
+ * codegen path executed anything, generation would fail loudly.
  */
 
 import {type Entity, Fate, FateDataView, FateExecutor, FateServer} from "@kampus/fate-effect";
@@ -26,20 +24,16 @@ class DefinitionView extends FateDataView<DefinitionRow>()("Definition")({
 	term: true,
 }) {}
 
-/** The kernel views the plugin's schema walk picks up (`isDataView` filter). */
 export const termDataView = TermView.view;
 export const definitionDataView = DefinitionView.view;
 
-/** The entity types the generated client imports by manifest type name. */
 export type Term = Entity<typeof TermView>;
 export type Definition = Entity<typeof DefinitionView>;
 
-/** Client-exposed roots (the `views.ts` convention: annotated for nameability). */
 export const Root: Record<string, unknown> = {
 	term: termDataView,
 };
 
-/** The build-time stand-in for a D1 binding: ANY access throws. */
 const d1: Record<string, unknown> = new Proxy(
 	{},
 	{
@@ -114,5 +108,4 @@ const config = FateServer.config({
 	sources: [termSource, definitionSource],
 });
 
-/** What the fate Vite plugin requires: a `fateServer` value with `.manifest`. */
 export const fateServer = FateExecutor.toCodegenServer(config);

--- a/apps/web/worker/features/fate/codegen-vite.test.ts
+++ b/apps/web/worker/features/fate/codegen-vite.test.ts
@@ -1,13 +1,7 @@
 /**
- * The REAL fate Vite plugin generates a native client from a
- * `FateExecutor.toCodegenServer(...)` schema module, end to end through its
- * actual `runnerImport` path (a programmatic `vite build` in a temp root).
- *
- * Unit-tier in spirit (no worker, no storage), but lives here because the plugin
- * (`react-fate/vite`) and Vite are this app's dependencies — the same plugin
- * instance `vite.config.ts` runs in the real build. The schema module is
- * `codegen-schema.fixture.ts`, whose handlers close over a throw-on-touch Proxy
- * database, so successful generation doubles as the "no D1 at build time" proof.
+ * The REAL fate Vite plugin, driven end to end by a programmatic `vite build` in a temp
+ * root. The fixture's handlers close over a throw-on-touch Proxy database, so successful
+ * generation doubles as the "no D1 at build time" proof.
  */
 import {mkdtemp, readFile, rm, writeFile} from "node:fs/promises";
 import {tmpdir} from "node:os";

--- a/apps/web/worker/features/fate/config.ts
+++ b/apps/web/worker/features/fate/config.ts
@@ -1,30 +1,16 @@
 /**
- * The one fate server config, consumed at both edges from this single
- * declaration: the `/fate` serving path (`layers.ts` → native interpreter,
- * ADR 0043) and build-time codegen (`schema.ts` → inert handlers, no database).
- * See `.patterns/fate-effect-server.md`, `.patterns/fate-effect-compiler.md`.
+ * The one fate server config, consumed at both edges from this single declaration: the
+ * `/fate` serving path (ADR 0043) and build-time codegen. See
+ * `.patterns/fate-effect-server.md`, `.patterns/fate-effect-compiler.md`,
+ * `.patterns/per-feature-fate-aggregators.md`.
  *
- * Each feature contributes its whole fate surface as one `fateModule` (its own
- * `queries`/`lists`/`mutations`/`sources`); the root merges the `modules` array
- * once (`mergeFateModules`) instead of threading every feature through a separate
- * central barrel per category. Registering a feature is this one array entry —
- * see `.patterns/per-feature-fate-aggregators.md`.
+ * Import-pure by construction: the modules capture resolver functions only (services are
+ * reached per request), so importing this evaluates pure data — codegen depends on that.
  *
- * Import-pure by construction: the record modules capture resolver functions
- * (services are reached per request through the runtime), so importing this
- * module evaluates pure data — the codegen path depends on that.
- *
- * `live` is the publish-only `LiveEventBus` (ADR 0023): fate detects a custom
- * bus by `"subscribe" in live` (the property exists but throws — the SSE
- * protocol is served by the `/fate/live` route + DO, not by fate's
- * `handleLiveRequest`).
- *
- * Sources carry NO `connection` executor or `orderBy` contract: every connection
- * — root and nested — is delivered by a custom resolver in a feature's
- * `queries.ts` / `lists.ts` calling the service keyset method directly (ADR
- * 0019). `Contribution`/`ReportReceipt`/`OpenReport`/`ResolveReceipt` are
- * capability-less `Fate.syntheticSource` entries (view-reachable, no fetch path).
- * See `.patterns/fate-connections.md`, `.patterns/fate-effect-sources.md`.
+ * `live` is the publish-only `LiveEventBus` (ADR 0023): fate detects a custom bus by
+ * `"subscribe" in live` — the property exists but throws, since SSE is served by the
+ * `/fate/live` route + DO. Sources carry NO `connection` executor or `orderBy`: every
+ * connection is delivered by a feature resolver calling the service keyset method (ADR 0019).
  */
 import {FateServer} from "@kampus/fate-effect";
 import {fateModule as adminConsoleModule} from "../admin-console/fate-module.ts";
@@ -43,9 +29,8 @@ import {fateModule as statsModule} from "../stats/fate-module.ts";
 import {fateModule as userAdminModule} from "../user-admin/fate-module.ts";
 import {mergeFateModules} from "./module.ts";
 
-// The one feature registry. Drives BOTH the served config (`mergeFateModules` below)
-// and the client `Root` map (`views.ts` → `mergeFateRoots`), so registering a feature
-// is this single array entry — its queries/lists/mutations/sources AND its roots.
+// The one feature registry, driving BOTH the served config and the client `Root` map, so
+// registering a feature is this single array entry.
 export const modules = [
 	statsModule,
 	adminConsoleModule,

--- a/apps/web/worker/features/fate/connection.ts
+++ b/apps/web/worker/features/fate/connection.ts
@@ -1,9 +1,7 @@
 /**
- * Cross-feature connection envelope — a leaf module (imports no feature code,
- * so no feature's import graph transitively pulls another's shapers). Services
- * page forward only, so `hasPrevious` is always `false` and the cursor is the
- * opaque service keyset. See `.patterns/fate-connections.md`,
- * `.patterns/fate-effect-operations.md`.
+ * Cross-feature connection envelope — a leaf module: it imports no feature code, so no feature's
+ * import graph transitively pulls another's shapers. Services page forward only, so `hasPrevious`
+ * is always `false`. See `.patterns/fate-connections.md`.
  */
 
 import type {ConnectionResult} from "@nkzw/fate/server";
@@ -21,10 +19,7 @@ export type ConnectionArgs = Schema.Schema.Type<typeof ConnectionArgsSchema> | u
 
 export const connectionArgs = () => Schema.optional(ConnectionArgsSchema);
 
-/**
- * `after` is spread in only when the client actually paged, so services see the
- * cursor key only when one exists.
- */
+/** `after` is spread in only when the client actually paged, so services see no phantom cursor. */
 export const keysetInput = (
 	cArgs: ConnectionArgs,
 	defaultFirst: number,

--- a/apps/web/worker/features/fate/connection.unit.test.ts
+++ b/apps/web/worker/features/fate/connection.unit.test.ts
@@ -1,8 +1,7 @@
 /**
- * Unit coverage for the `toConnection` adapter — the `hasNextPage`/`endCursor` →
- * `pagination` mapping reachable elsewhere only through a fuller list path
- * (ADR 0019). Forward-only, so `hasPrevious` is always `false` and `nextCursor`
- * is spread in only when `endCursor` is non-null.
+ * The `toConnection` adapter's `hasNextPage`/`endCursor` → `pagination` mapping (ADR 0019).
+ * Forward-only, so `hasPrevious` is always `false` and `nextCursor` is spread in only when
+ * `endCursor` is non-null.
  */
 
 import {describe, expect, it} from "vitest";

--- a/apps/web/worker/features/fate/fate-flags-dev-override.unit.test.ts
+++ b/apps/web/worker/features/fate/fate-flags-dev-override.unit.test.ts
@@ -1,21 +1,12 @@
 /**
- * The fate data-plane `Flags` layer installs the #622 local-override wrapper — so a
- * flag-gated fate resolver/mutation honors an `overrides` entry in its per-request
- * `FlagsContext`. This is the #1868 regression guard (before it, `makeFateLayer` baked
- * the PLAIN `FlagsLive`, so the decorator was never on the fate path and the flag-flip
- * cookie had no effect on a mutation).
+ * The #1868 regression guard: the fate data-plane `Flags` layer must install the
+ * local-override wrapper (before it, `makeFateLayer` baked the PLAIN `FlagsLive`, so the
+ * flag-flip cookie had no effect on a mutation). Whether an override is AUTHORIZED is a
+ * different question, proven in `flagship/override-authz.unit.test.ts`.
  *
- * As of #2741 the wrapper is installed UNCONDITIONALLY (not env-selected): whether an
- * override is HONORED is decided upstream, per request, by `overridesAuthorized` (dev,
- * or an admin) which populates `FlagsContext.overrides`.
- * That gate — including the prod fail-closed "a non-admin's cookie is inert" invariant —
- * is proven in `flagship/override-authz.unit.test.ts`. This test proves only the
- * mechanism it feeds: given an override in context, the fate layer honors it.
- *
- * No binding / no I/O — `FateFlagsLive` over a stub `Flagship` whose real eval always
- * returns the supplied default (dark-ship OFF for `phoenix-reactions`): the only way the
- * flag reads ON is the override decorator short-circuiting on `FlagsContext.overrides`,
- * so a passing ON assertion proves the wrapper is installed — not that real eval flipped.
+ * The stub `Flagship`'s real eval always returns the supplied default, so the only way a
+ * flag can read ON is the override decorator — a passing ON assertion proves the wrapper
+ * is installed, not that real eval flipped.
  */
 import {assert, describe, it} from "@effect/vitest";
 import {type BaseRuntimeContext, RuntimeContext} from "alchemy";
@@ -60,9 +51,6 @@ const withEnvironment = (environment: string) =>
 		ConfigProvider.fromUnknown({ENVIRONMENT: environment}),
 	);
 
-// Read `phoenix-reactions` (default OFF) through the fate `Flags` layer with a given
-// `FlagsContext` — `overrides` populated or not — mirroring what `provideRequestFlags`
-// hands a resolver once `overridesAuthorized` has decided.
 const resolveWith = (context: {environment: string; overrides?: Record<string, boolean>}) =>
 	Effect.gen(function* () {
 		const flags = yield* Flags;
@@ -83,7 +71,6 @@ describe("fate Flags layer — the override wrapper is installed (#1868/#2741)",
 				environment: "production",
 				overrides: {[PHOENIX_REACTIONS]: true},
 			});
-			// The ON result can only come from the installed override wrapper.
 			assert.strictEqual(value, true);
 		}),
 	);

--- a/apps/web/worker/features/fate/layers.ts
+++ b/apps/web/worker/features/fate/layers.ts
@@ -1,15 +1,9 @@
 /**
- * Worker-level fate layers (ADR 0041/0043;
- * `.patterns/fate-effect-worker-wiring.md`).
+ * Worker-level fate layers. See ADR 0041/0043,
+ * `.patterns/fate-effect-worker-wiring.md` and `.patterns/effect-layer-composition.md`.
  *
- * There is no runtime on the request path. The feature services are worker-level
- * layers built once in worker init and carried by ONE isolate-level
- * `ManagedRuntime` ({@link WorkerRuntime}) that acts purely as the LAYER-BUILD
- * VEHICLE: routes take the built context off it (discharged per request by
- * `HttpRouter.provideRequest`), and the interpreter provides the per-request pair
- * (`CurrentUser`, `LivePublisher`) onto each handler effect itself. The layer
- * graph is `.patterns/effect-layer-composition.md`; only *where* it's provided
- * moved here, from a per-request runtime.
+ * There is no runtime on the request path: the one isolate-level `ManagedRuntime`
+ * is a layer-build vehicle only.
  */
 import * as BetterAuth from "@alchemy.run/better-auth";
 import {CurrentActor} from "@kampus/authz";
@@ -49,35 +43,16 @@ import {throttleMutations} from "../throttle/throttle-mutations.ts";
 import {KarmaBump, VoteLive, VoterStanding} from "../vote/Vote.ts";
 import {fateConfig} from "./config.ts";
 
-/**
- * The worker's fate service list — DERIVED from {@link makeFateLayer}'s
- * `Layer.mergeAll(...)` success channel so the list is declared exactly ONCE (the
- * runtime composition is the single source of truth; #1340). Adding/removing a
- * feature service is now one edit — its `*Live` in `makeFateLayer` — not a union
- * member kept in lockstep with the composition by eye.
- *
- * The per-service rationale (which ADR/issue each service answers to) lives at its
- * `*Live` entry in `makeFateLayer`'s body. `CurrentActor` is deliberately absent
- * from this set: it is per-request, registered separately on {@link PhoenixFateLive}
- * (`[CurrentActor]`, ADR 0107 §7), so it never enters the build-time success channel.
- */
 export type WorkerFateServices = Layer.Success<typeof makeFateLayer>;
 
 export type WorkerRuntime = ManagedRuntime.ManagedRuntime<WorkerFateServices | FateServer, never>;
 
 /**
- * Build the ONE worker-level {@link WorkerRuntime} plus the route-context layer
- * derived from its built context. The single construction point shared by
- * `index.ts` and `app.test.ts`.
+ * The shared `memoMap` keeps the runtime and its derived `contextLayer` on one
+ * memoization scope, so worker singletons are built exactly once.
  *
- * The shared `memoMap` (effect-smol "Integrating Effect into existing
- * applications" idiom, `ai-docs/src/03_integration/10_managed-runtime.ts`) keeps
- * memoization correct across the runtime and the `contextLayer` derived from it:
- * the worker singletons are built exactly once and shared by every route.
- *
- * NEVER DISPOSED IN THE WORKER: a Cloudflare isolate has no shutdown hook, so the
- * deployed worker never calls `runtime.dispose()` and Drizzle/D1 holds no poolable
- * socket to release (ADR 0041).
+ * Never disposed in the worker: a Cloudflare isolate has no shutdown hook, so
+ * `runtime.dispose()` is never called and nothing pooled leaks (ADR 0041).
  */
 export const makeFateRuntime = (
 	layer: Layer.Layer<WorkerFateServices | FateServer>,
@@ -98,10 +73,8 @@ export const makeFateRuntime = (
  * inert stub to keep `makeFateLayer`'s `R` exactly `Database | BetterAuth`. The
  * worker still provides the real `RuntimeContext` to `/api/auth/*` via `makeAppLive`.
  *
- * The stub's runtime-safety is pinned by `pasaport-from-tag.test.ts`: if the fork
- * (or an alchemy better-auth dep bump) ever reads `RuntimeContext` during `auth`
- * resolution, that test fails in-process instead of a prod session silently
- * mis-resolving — the fix then is to widen `R`, not delete the test.
+ * `pasaport-from-tag.test.ts` pins that the stub is never actually read; if it
+ * starts failing, widen `R` — do not delete the test.
  */
 const inertRuntimeContext: BaseRuntimeContext = {
 	Type: "fate-layer",
@@ -121,23 +94,15 @@ const PasaportFromTag = Layer.unwrap(
 	}),
 );
 
-/**
- * Pasaport's implementation of the `KarmaBump` contract Vote owns (dependency
- * inversion). Wired HERE — the composition root — so the `vote/ → pasaport/`
- * arrow exists only at this seam, never inside Vote; künye later swaps this for a
- * DO-backed bump without touching Vote.
- */
+/** Vote owns the `KarmaBump` contract; the `vote/ → pasaport/` arrow lives only here. */
 const KarmaBumpFromPasaport = Layer.succeed(KarmaBump, {statements: karmaBumpStatements});
 
 /**
- * Künye's implementation of the `VoterStanding` contract Vote owns (dependency
- * inversion — the `vote/ → kunye/` arrow lives ONLY at this seam, #1810). The
- * predicate is the "earn to vote" floor: the voter must be **above the çaylak
- * newcomer tier** on the `authorshipLadder` (`visitor < çaylak < yazar`, ADR 0107
- * §4). `authorshipLadder.gte(tier, "yazar")` is `true` only for a promoted `yazar`
- * (or any future higher rank), so a fresh `çaylak` — every open-registration signup —
- * and a `visitor` are both refused. Keeping the tier comparison here (not in Vote)
- * is what lets the ladder move without touching Vote.
+ * Vote owns the `VoterStanding` contract; the `vote/ → kunye/` arrow lives only here.
+ *
+ * `isAboveNewcomer` is `gte(tier, "yazar")` on purpose: the ladder is
+ * `visitor < çaylak < yazar` (ADR 0107 §4), so a fresh çaylak — every
+ * open-registration signup — is refused. Do not relax it to `gte(…, "çaylak")`.
  */
 const VoterStandingFromKunye = Layer.effect(VoterStanding)(
 	Effect.gen(function* () {
@@ -150,161 +115,64 @@ const VoterStandingFromKunye = Layer.effect(VoterStanding)(
 ).pipe(Layer.provide(KunyeLive));
 
 /**
- * The `Flags` layer for the fate data plane: the local-override wrapper
- * (`FlagsDevOverrideLive`) installed UNCONDITIONALLY (#2741, epic #2711). The wrapper
- * is a no-op unless the per-request `FlagsContext.overrides` is populated, and that
- * population is now the load-bearing gate — resolved per request by
- * `overridesAuthorized` (dev, or an admin) and threaded
- * through `provideRequestFlags`. So a non-admin request on a deployed stage carries no
- * `overrides` and reads exactly as the plain `FlagsLive` did (#1868 kept intact: the
- * decorator is on the fate mutation path so a flag-gated resolver honors an authorized
- * cookie; before this the env gate lived here, but admin-ness is per-request and cannot
- * be selected at layer build). Needs only `Flagship`, discharged at the composition root.
+ * The dev-override wrapper is installed unconditionally on purpose (#2741): it is
+ * inert unless the per-request `FlagsContext.overrides` is populated, and THAT is
+ * the gate (`overridesAuthorized` — dev, or an admin). Admin-ness is per-request,
+ * so it cannot be selected at layer build.
  */
 export const FateFlagsLive = FlagsDevOverrideLive;
 
 /**
- * The worker-level data-plane layer (ADR 0029, ADR 0040). Derives everything from
- * the two seams in its `R` channel — `Database` (behind `DrizzleLive`) and
- * `BetterAuth` — so features and auth provably share one handle.
+ * The worker-level data-plane layer (ADR 0029, ADR 0040).
  *
- * `SozlukLive` and `PanoLive` both depend on `Vote`, so they merge first and
- * `provideMerge(VoteLive)` once — with Vote's two internal seams, `KarmaBump` and
- * `VoterStanding`, discharged by {@link KarmaBumpFromPasaport} and
- * {@link VoterStandingFromKunye} via `Layer.provide` (not `provideMerge`: these are
- * Vote's internal contracts, not worker services the routes see).
- *
- * `PanoLive` also depends on `Bookmark` (it stamps the `isSaved` viewer scalar
- * from `Bookmark.readMine` alongside `myVote`), so `BookmarkLive` joins the same
- * group via `provideMerge` — discharging Pano's requirement while keeping
- * `Bookmark` in {@link WorkerFateServices} for the routes that resolve it directly.
+ * `Layer.provide` vs `provideMerge` is meaningful here: `provide` discharges a
+ * layer's *internal* contract (Vote's `KarmaBump`/`VoterStanding`, Telemetry),
+ * `provideMerge` keeps the service in {@link WorkerFateServices} for the routes.
  */
 export const makeFateLayer = Layer.mergeAll(
-	// `DivanLive` composes the Sözlük + pano sandboxed reads (#1287), so it is provided
-	// THIS content group's `Sozluk`/`Pano` outputs via `provideMerge` (which keeps them
-	// in the output for the routes too) — one built instance, not a second copy.
 	DivanLive.pipe(
 		Layer.provideMerge(
 			Layer.mergeAll(SozlukLive, PanoLive).pipe(
 				Layer.provideMerge(VoteLive),
 				Layer.provideMerge(BookmarkLive),
-				// Both `SozlukLive` and `PanoLive` stamp the reaction aggregate on their
-				// definition/post/comment reads (`Reaction.readAggregate`, #1862), so
-				// `ReactionLive` joins the same group via `provideMerge` — discharging that
-				// requirement while keeping `Reaction` in `WorkerFateServices` for the
-				// wiring children (#1863/#1864/#1865) that resolve it directly.
 				Layer.provideMerge(ReactionLive),
-				// `Reaction.react` emits a product-usage event on a committed reaction
-				// (the reference instrument #2, ADR 0153 / #2069), so `ReactionLive` now
-				// requires `Telemetry`. Discharge it here with `Layer.provide` (like
-				// Vote's internal seams — Telemetry is a dependency of the nested reaction
-				// layer, not a routed service the content group re-exports; the top-level
-				// `TelemetryLive` below keeps `Telemetry` in `WorkerFateServices`). Its
-				// `TelemetryClient`/`RuntimeContext` requirements bubble to the root, where
-				// they are init-provided on `PhoenixFateLive`.
 				Layer.provide(TelemetryLive),
 				Layer.provide(KarmaBumpFromPasaport),
-				// Vote's voter-tier gate ("earn to vote", #1810), discharged by Künye — same
-				// internal-seam idiom as `KarmaBumpFromPasaport` (`Layer.provide`, not a routed
-				// service). Its `Pasaport` requirement bubbles to the root `PasaportFromTag`.
 				Layer.provide(VoterStandingFromKunye),
-				// Vote's telemetry instrument (ADR 0153, epic #2065, #2068): `Vote.cast` emits a
-				// `vote` event after a committed cast, so `VoteLive` gains a build-time `Telemetry`
-				// requirement. Discharged HERE with the SAME `TelemetryLive` merged flat below — the
-				// shared layer value memoizes to one isolate instance via `makeFateRuntime`'s memoMap,
-				// so `Telemetry` stays a worker output for future instruments (#2069) while Vote's
-				// requirement is satisfied in-group; `TelemetryClient`/`RuntimeContext` bubble to the
-				// same root that discharges the flat `TelemetryLive`.
+				// The repeat is deliberate: the same layer value memoizes to one isolate
+				// instance via `makeFateRuntime`'s memoMap.
 				Layer.provide(TelemetryLive),
 			),
 		),
 	),
 	StatsLive,
-	// The product-usage telemetry seam (ADR 0153, epic #2065) — the isolate-level
-	// `Telemetry` service every instrument (#2068/#2069) emits through. Merges flat
-	// like `Stats`: it resolves the init-provided `TelemetryClient` (the AE write
-	// client, resolved once where the binding graph is ambient — like `Database`'s
-	// D1 handle) and captures `RuntimeContext` at build (already an R seam here);
-	// `emit` itself carries no R (both channels discharged in `TelemetryLive`).
 	TelemetryLive,
-	// SearchLive and ReportLive depend only on Drizzle (the FTS read / the report
-	// write), so they merge flat alongside the other domain layers and are
-	// discharged by `provideMerge(DrizzleLive)`.
 	SearchLive,
 	ReportLive,
-	// The conversion-funnel read model (#1589) — a humans-only tier-population count
-	// over the `user` table, depending only on `Drizzle` (discharged below), so it
-	// merges flat like `Stats`/`Search`/`Report`.
 	FunnelLive,
-	// The bildirim spine's notification store + recipient-scoped read model (#1694,
-	// epic #1666), depending only on `Drizzle` (discharged below) — merges flat.
 	NotificationLive,
-	// The mecmua long-form write service (#2497, epic #2467) — the publish + save-draft
-	// acts, depending only on `Drizzle` (discharged below), so it merges flat like the
-	// other domain layers. The publish yazar-floor is discharged at the mutation via
-	// `PublishMecmua` (CurrentActor/AgentAuthority/Kunye already in this graph), not here.
 	MecmuaLive,
-	// The member-mute (sustur) write service (#3112, epic #2035) — the `mute.set` /
-	// `mute.remove` presence writes, depending only on `Drizzle` (discharged below), so
-	// it merges flat like the other domain layers.
 	MuteLive,
-	// The authz ports the moderation gate (`report.resolve`/`restore`/`listOpen`)
-	// discharges `Moderate.over(platform)` against: `RelationStoreLive` reads the
-	// `moderates` tuple off the same `Drizzle` seam (discharged below), and
-	// `AgentAuthorityV1` fills the dormant agent-attenuation port fail-closed.
 	RelationStoreLive,
 	AgentAuthorityV1,
-	// Künye standing (ADR 0107 §4), the çaylak sandbox's tier source (#1205). Reads
-	// through `Pasaport`, discharged by the `provideMerge(PasaportFromTag)` below
-	// (which keeps `Pasaport` an output for the routes too).
 	KunyeLive,
-	// The authorship-vouch ledger (#1206) — the `user.vouch` recorded-act store.
-	// Reads/writes the `authorship_vouch` table off the same `Drizzle` seam below.
 	VouchLedgerLive,
-	// The per-actor mutation throttle (ADR 0177) — a cross-cutting service bounding
-	// each actor's write volume, applied over the merged mutations record in
-	// `PhoenixFateLive` (`throttleMutations`). Its `RateLimitStore` backing is
-	// discharged HERE with `Layer.provide` (the storage swap point, in-isolate for
-	// v1) so `RateLimiter` reaches the composition root's captured services with no
-	// external R — the same internal-seam idiom as `KarmaBumpFromPasaport`.
 	RateLimiterLive.pipe(Layer.provide(InIsolateRateLimitStoreLive)),
-	// `Flags` is the dark-ship read surface fate resolvers/mutations gate on (#746,
-	// #1868). {@link FateFlagsLive} installs the local-override wrapper unconditionally
-	// (#2741) — the #622 cookie is honored on the fate mutation path whenever the
-	// per-request `overridesAuthorized` verdict allows it (dev, or admin + flag), and is
-	// inert otherwise. Needs only `Flagship` (a new R seam, discharged at the composition
-	// root like `Database`); `getBoolean`'s `RuntimeContext`/`FlagsContext` are per-call,
-	// supplied by the resolver, not at layer build.
 	FateFlagsLive,
 ).pipe(Layer.provideMerge(PasaportFromTag), Layer.provideMerge(DrizzleLive));
 
 /**
- * The composed fate-server layer (`.patterns/fate-effect-server.md`):
- * `FateServer.layer(fateConfig)` over the domain layers — what
- * {@link makeFateRuntime} builds the one isolate runtime from.
+ * The composed fate-server layer. See `.patterns/fate-effect-server.md`.
  *
- * `provideMerge` (not `provide`) keeps the {@link WorkerFateServices} in the
- * output alongside `FateServer` so routes still yield them directly; and because
- * `FateServer.layer`'s own R is discharged by the same domain layers, a record
- * needing a forgotten service is a compile error HERE, the composition site.
- *
- * `[CurrentActor, RequestFlagOverrides, PanoFeedCache]` registers the per-request
- * services (ADR 0107 §7): the authz actor, the raw `Cookie` header the dev-override
- * flag path reads (#622), and the base-feed edge-cache purger a fanned pano mutation
- * fires alongside its live publish (ADR 0170 / #2324). All are excluded from build-time
- * R and fulfilled per request from the session/request/execution-context in `route.ts`
- * (`requestServices`), never provided by a worker-level layer.
+ * The third argument registers the per-request services (ADR 0107 §7); they are
+ * excluded from build-time R and fulfilled per request in `route.ts`.
  */
 export const PhoenixFateLive: Layer.Layer<
 	WorkerFateServices | FateServer,
 	never,
 	Database | BetterAuth.BetterAuth | Flagship | TelemetryClient | RuntimeContext
 > = FateServer.layer(
-	// The served config, with every mutation's `resolve` wrapped by the per-actor
-	// throttle (ADR 0177). Only the serving path is throttled — the codegen path
-	// (`schema.ts`) consumes the plain `fateConfig`, so build-time codegen is
-	// untouched. `RateLimiter`/`CurrentActor` are provided at run time (worker
-	// layer / per-request), so the wrapped config keeps `fateConfig`'s type.
+	// Only the serving path is throttled; codegen (`schema.ts`) uses the plain `fateConfig`.
 	{...fateConfig, mutations: throttleMutations(fateConfig.mutations)},
 	[CurrentActor, RequestFlagOverrides, PanoFeedCache],
 ).pipe(Layer.provideMerge(makeFateLayer));

--- a/apps/web/worker/features/fate/module.ts
+++ b/apps/web/worker/features/fate/module.ts
@@ -1,16 +1,10 @@
 /**
  * The per-feature fate manifest — a feature's whole contribution to the one
- * `FateServer.config` as a single value, so the composition root registers a
- * feature once (`config.ts`'s `modules` array) instead of threading it through a
- * separate barrel per operation category. See `.patterns/fate-effect-server.md`.
+ * `FateServer.config` as a single value, so the composition root registers a feature
+ * once. See `.patterns/fate-effect-server.md`.
  *
- * Every field is optional: a feature contributes only the categories it has
- * (stats is queries-only, search is lists-only). `mergeFateModules` is generic
- * over the modules tuple so the merged value keeps each entry's precise type —
- * the `FateServer.config` R-channel math (`FateServerRequirements`) is inferred
- * exactly as it was from the hand-written barrels. Order is not load-bearing
- * (fate's registry is keyed by entry identity, and `collectConfigIssues` flags
- * duplicates regardless of order), so the merge resolves identically.
+ * Every field is optional, and merge order is not load-bearing: fate's registry is keyed
+ * by entry identity and `collectConfigIssues` flags duplicates regardless of order.
  */
 import type {
 	FateListsRecord,
@@ -20,10 +14,9 @@ import type {
 } from "@kampus/fate-effect";
 
 /**
- * The client-exposed root map a feature contributes — its slice of `fate/views.ts`'s
- * `Root`. Annotated `Record<string, unknown>` (never the precise `dataView`/`list`
- * literal) so a feature's `roots` doesn't surface fate's internal `DataView` symbol
- * across its `fateModule` export (TS2883/TS4023), matching `Root`'s own annotation.
+ * Annotated `Record<string, unknown>` (never the precise `dataView`/`list` literal) so a
+ * feature's `roots` doesn't surface fate's internal `DataView` symbol across its
+ * `fateModule` export (TS2883/TS4023).
  */
 export type FateRootsRecord = Record<string, unknown>;
 
@@ -37,26 +30,22 @@ export interface FateModule<
 	readonly lists?: L;
 	readonly mutations?: M;
 	readonly sources?: S;
-	// The feature's client roots. Merged into `Root` by `mergeFateRoots` for codegen,
-	// NOT threaded into `FateServer.config` (`mergeFateModules` ignores it — `roots`
-	// stays empty on `createFateServer`, see `views.ts`).
+	// Merged into `Root` by `mergeFateRoots` for codegen, NOT threaded into
+	// `FateServer.config` — `mergeFateModules` ignores it.
 	readonly roots?: FateRootsRecord;
 }
 
-/** One module's record for category `K`, or `never` if it omits that category. */
 type ModuleRecord<M, K extends "queries" | "lists" | "mutations"> = M extends {
 	readonly [P in K]: infer R;
 }
 	? R
 	: never;
 
-/** Intersect one category across the modules tuple (records merge by spread). */
 type MergedRecord<
 	Modules extends ReadonlyArray<FateModule>,
 	K extends "queries" | "lists" | "mutations",
 > = UnionToIntersection<ModuleRecord<Modules[number], K>>;
 
-/** Union of every module's source-element types (sources concatenate). */
 type SourceElement<M> = M extends {readonly sources: infer S}
 	? S extends ReadonlyArray<infer E>
 		? E
@@ -84,28 +73,21 @@ const mergeCategory = (
 	key: "queries" | "lists" | "mutations",
 ) => Object.assign({}, ...modules.map((m) => m[key] ?? {}));
 
-// Typed to the wide base (`FateSourcesList`) — not the concrete `flatMap` element
-// type — so the per-call narrowing to `MergedSources<Modules>` overlaps in one
-// `as`, matching the three category casts and staying single-cast (TS2352 would
-// fire on a direct cast from the concrete `flatMap` result; see `no-type-assertions`).
+// Typed to the wide base, not the concrete `flatMap` element type: TS2352 fires on a
+// direct cast from the concrete result, so this keeps the narrowing to one `as`.
 const mergeSources = (modules: ReadonlyArray<FateModule>): FateSourcesList =>
 	modules.flatMap((m) => m.sources ?? []);
 
-// `Root` is the cross-feature client-root map (`createSchema(views, Root)`); each
-// feature owns its slice on its `fateModule`, so registering a feature in `config.ts`'s
-// `modules` array is the single source that drives both the served config and `Root`.
-// Spread (not concat) — a feature's roots are keyed by their resolver names, which
-// `collectConfigIssues` already pins for uniqueness, so order is not load-bearing.
+// Spread, not concat: roots are keyed by resolver name and `collectConfigIssues` already
+// pins those for uniqueness, so order is not load-bearing.
 export const mergeFateRoots = (modules: ReadonlyArray<FateModule>): FateRootsRecord =>
 	Object.assign({}, ...modules.map((m) => m.roots ?? {}));
 
 export const mergeFateModules = <const Modules extends ReadonlyArray<FateModule>>(
 	modules: Modules,
 ): MergedFateConfig<Modules> => ({
-	// Each merged field's precise type is recovered structurally by the type
-	// params (`MergedRecord`/`MergedSources`); the runtime spread/concat below
-	// produces the same value with the wide base type, narrowed once per field —
-	// a single narrowing cast, the form code review owns (`no-type-assertions`).
+	// The runtime spread produces the same value with the wide base type, narrowed once
+	// per field — one cast each, the form `no-type-assertions` allows.
 	queries: mergeCategory(modules, "queries") as MergedRecord<Modules, "queries">,
 	lists: mergeCategory(modules, "lists") as MergedRecord<Modules, "lists">,
 	mutations: mergeCategory(modules, "mutations") as MergedRecord<Modules, "mutations">,

--- a/apps/web/worker/features/fate/reaction-aggregate.ts
+++ b/apps/web/worker/features/fate/reaction-aggregate.ts
@@ -1,19 +1,10 @@
 /**
- * `stampReactionAggregate` — the reaction analogue of `stampViewerScalars`
- * (`viewer-scalars.ts`), for the ONE reaction aggregate field the `post` /
- * `comment` / `definition` fate views expose (#1862). Where `stampViewerScalars`
- * stamps a `boolean | null` presence scalar, this stamps a structured
- * `ReactionAggregate` (per-emoji counts + the viewer's own emoji) — reactions
- * carry a VALUE (the emoji) and a per-target COUNT, so a boolean scalar can't
- * carry them.
+ * The reaction analogue of `stampViewerScalars` (`viewer-scalars.ts`), stamping a
+ * structured `ReactionAggregate` where that one stamps a boolean presence scalar.
  *
- * The N+1-avoidance contract is structural, exactly as the viewer-scalar helper:
- * one batched `Reaction.readAggregate` (a single `GROUP BY` read + one `readMine`)
- * for the whole page, never a per-row read. A target absent from the batch (no
- * reactions, and the viewer hasn't reacted) is stamped with the empty aggregate,
- * so the field is ALWAYS present on the wire — a reader (human or agent) sees
- * `reactions` on every row the way it sees `score`, never a missing field. The
- * anonymous-viewer / empty-page short-circuit lives in `readAggregate`.
+ * The N+1-avoidance contract is structural: one batched `readAggregate` per page,
+ * never a per-row read. A target absent from the batch is stamped with the empty
+ * aggregate, so the field is ALWAYS present on the wire, never missing.
  */
 import type {Effect} from "effect";
 import {Effect as Eff} from "effect";
@@ -26,16 +17,11 @@ import {
 } from "../reaction/Reaction.ts";
 
 /**
- * Run the one batched aggregate read over `rows`' ids, then stamp `reactions`
- * onto each row as its aggregate (or the empty aggregate when the target has
- * none). One read for the whole batch — never per row. The stamped field is
- * *added* to the input row shape, so a read that wants the aggregate must route
- * through here (a path that skips the stamp never produces the field).
+ * The stamped field is *added* to the input row shape, so a read that wants the
+ * aggregate must route through here — a path that skips the stamp cannot produce it.
  *
- * `readAggregate` itself issues TWO D1 reads (the per-target `GROUP BY` + the
- * viewer's `readMine`); pass `{concurrency: "unbounded"}` to fan those two out so
- * this stamp is a single wave phase when run inside `parallelStampWave`. Default
- * (absent) keeps them sequential — today's behavior for every non-opted caller.
+ * `readAggregate` issues TWO D1 reads; pass `{concurrency: "unbounded"}` to fan them
+ * out so this stamp is a single wave phase inside `parallelStampWave`.
  */
 export const stampReactionAggregate = <R extends {id: string}>(
 	reactionSvc: typeof Reaction.Service,

--- a/apps/web/worker/features/fate/reaction-aggregate.unit.test.ts
+++ b/apps/web/worker/features/fate/reaction-aggregate.unit.test.ts
@@ -1,16 +1,9 @@
 /**
- * `stampReactionAggregate` — the fate-view stamping seam (#1862). These pin the
- * two properties the acceptance criteria name, above any SQL engine (ADR 0082):
+ * `stampReactionAggregate` (#1862). Two properties, above any SQL engine: the
+ * aggregate lands on EVERY row, and a target absent from the batch gets the EMPTY
+ * aggregate rather than a hole — so the wire field is never missing.
  *
- *   - the aggregate lands on EVERY row alongside its intrinsic fields (a `score`
- *     twin) — an agent reading the view sees `reactions` the same way it sees
- *     `score`, never a missing field;
- *   - a target absent from the batch (no reactions, no viewer reaction) gets the
- *     EMPTY aggregate, not a hole — so the wire field is always present.
- *
- * The batched `Reaction.readAggregate` is substituted by a recording double that
- * asserts ONE read over the whole page (the N+1-avoidance contract) — the real
- * `GROUP BY` fidelity lives on `Reaction.unit.test.ts` / integration.
+ * The real `GROUP BY` fidelity lives in `Reaction.unit.test.ts` / integration.
  */
 import {assert, describe, it} from "@effect/vitest";
 import {Effect} from "effect";
@@ -18,9 +11,7 @@ import type {ReactionAggregate} from "../reaction/Reaction.ts";
 import {EMPTY_REACTION_AGGREGATE, type Reaction} from "../reaction/Reaction.ts";
 import {stampReactionAggregate} from "./reaction-aggregate.ts";
 
-// A `Reaction` double whose `readAggregate` answers from a fixed per-id map and
-// records the ids it was called with, so the "one read for the whole batch" and
-// "empty aggregate for an absent target" contracts are asserted with no engine.
+// Answers from a fixed per-id map and records the ids it was called with.
 const stubReaction = (
 	answers: ReadonlyMap<string, ReactionAggregate>,
 	calls: string[][],
@@ -60,8 +51,6 @@ describe("stampReactionAggregate — the fate-view aggregate stamp (#1862)", () 
 			assert.strictEqual(calls.length, 1, "exactly one batched aggregate read");
 			assert.deepStrictEqual(calls[0], ["d1", "d2"], "the read covers the whole page's ids");
 
-			// The aggregate rides alongside the intrinsic `score` — an agent sees
-			// `reactions` the same way it sees `score`.
 			assert.deepStrictEqual(stamped[0], {
 				id: "d1",
 				score: 5,
@@ -76,7 +65,6 @@ describe("stampReactionAggregate — the fate-view aggregate stamp (#1862)", () 
 	});
 
 	it.effect("a target ABSENT from the batch gets the empty aggregate, never a hole", () => {
-		// Only `d1` has reactions; `d2` is absent from the aggregate map.
 		const answers = new Map<string, ReactionAggregate>([
 			["d1", agg([{emoji: "😂", count: 4}], null)],
 		]);

--- a/apps/web/worker/features/fate/resolve-wire.testing.ts
+++ b/apps/web/worker/features/fate/resolve-wire.testing.ts
@@ -1,27 +1,7 @@
 /**
- * `resolveWire` — drive ONE fate operation through its real external interface
- * (`resolve` → `encodeWireError(failureOf(cause))`), the same two seams the
- * `/fate` route crosses, with NO database and NO `ManagedRuntime`.
- *
- * A per-feature unit test that calls `op.handler(...)` and asserts the typed
- * failure CLASS (`Unauthorized`) stops one layer beneath the interface a client
- * sees: it never crosses the seam that maps the class to its wire `code`
- * (`UNAUTHORIZED`) via the `FateWireCode` annotation. A mis-annotated handler error
- * (wrong/missing `[FateWireCode]`) passes such a test. Driving through `resolveWire`
- * exercises both seams — the definition's input/args Schema decode AND
- * `encodeWireError` — so the class→wire-code translation is proven locally.
- *
- * This is the no-DB slice of `Executor.ts`'s `runResolve` (`resolve` → `Effect.exit`
- * → on failure `encodeWireError(failureOf(cause))`) lifted to an `it.effect`-native
- * shape — no worker runtime / Effect→Promise conversion, since those carry nothing
- * for a no-DB gate assertion. It is the in-process resolve/wire seam — the
- * app-level fate-op unit surface (see effect-testing.md).
- *
- * The op's real `R` is preserved (`FateQuery`/`FateList`/`FateMutation`, not the
- * type-erased `Any*` shapes) so the caller's `provideService` / `Effect.provide`
- * discharges it to `never` — exactly as it did when driving `.handler`. The wire
- * failure stays a typed `FateRequestError` (the `E` channel), so `Effect.exit` +
- * `Cause.findErrorOption` reads its `.code`.
+ * Drive ONE fate op through the two seams a client crosses — input decode and
+ * `encodeWireError` — with no DB and no `ManagedRuntime`. Why this rather than
+ * `.handler`: .patterns/effect-testing.md §"Per-feature op tests".
  */
 import {encodeWireError, failureOf} from "@kampus/fate-effect";
 import type {FateRequestError} from "@nkzw/fate/server";
@@ -30,62 +10,34 @@ import {RequestFlagOverrides} from "../flagship/FlagsContext.ts";
 import {PanoFeedCache} from "../pano/feed-cache.ts";
 
 /**
- * The no-cookie {@link RequestFlagOverrides} default a flag-gated unit test
- * discharges. A flag-gated resolver's `provideRequestFlags` requires this
- * per-request transport service (#622); the `/fate` route fulfills it live from
- * the raw `Cookie` header (`fate/route.ts`), but a unit test drives one op with NO
- * real request, so it carries no override cookie. `null` is simply "no local
- * override" — the environment gate stays in `makeRequestFlagsContext`, so this is
- * never a capability, and it mirrors how `CurrentUser`/`CurrentActor` are stubbed
- * per request (ADR 0107 §7).
- *
- * {@link resolveWire} discharges it automatically (the driver seam), so a
- * `resolveWire`-based test needs nothing. A test that drives a flag-gated domain
- * effect DIRECTLY (not through `resolveWire`) merges {@link noRequestFlagOverrides}
- * into its context layer instead.
+ * A unit test drives one op with no real request, so it carries no override cookie
+ * (#622). `null` is "no local override" — the environment gate stays in
+ * `makeRequestFlagsContext`, so this is never a capability.
  */
 const NO_COOKIE_OVERRIDES = RequestFlagOverrides.of({
 	cookieHeader: null,
 	overridesAllowed: false,
 });
 
-/** The shared no-cookie {@link RequestFlagOverrides} stub layer — see {@link NO_COOKIE_OVERRIDES}. */
+/** For a test that drives a flag-gated effect directly, not through {@link resolveWire}. */
 export const noRequestFlagOverrides: Layer.Layer<RequestFlagOverrides> = Layer.succeed(
 	RequestFlagOverrides,
 	NO_COOKIE_OVERRIDES,
 );
 
 /**
- * The no-op base-feed purger a fanned pano mutation resolves (#2324, ADR 0170) — the
- * cache twin of {@link noRequestFlagOverrides}. `resolveWire` discharges it
- * automatically; a test that drives a fanned pano mutation DIRECTLY (not through
- * `resolveWire`) merges this layer into its context instead. A unit test drives one op
- * with no real execution context, so the purge is a no-op (the real purger is built
- * per request off `ctx.cache` in `fate/route.ts`).
+ * The cache twin of {@link noRequestFlagOverrides} (#2324, ADR 0170). A unit test has no
+ * real execution context, so the purge is a no-op.
  */
 export const noopPanoFeedCache: Layer.Layer<PanoFeedCache> = Layer.succeed(PanoFeedCache, {
 	purge: () => Effect.void,
 });
 
-/**
- * The external interface of any fate op (query/list/mutation): its `resolve`
- * decode-then-run wrapper. Captured structurally over the op's `resolve` so a
- * caller passes the op record itself (`queries.me`, `mutations["x.y"]`) and the
- * op's real success `A`, error `E`, services `R`, and wire-input shape `In` all
- * infer — `R` discharges through the caller's `provideService`/`Effect.provide`
- * exactly as it did when driving `.handler`.
- */
+/** Structural over `resolve` so a caller passes the op record itself and every type infers. */
 interface ResolvableOp<In, A, E, R> {
 	readonly resolve: (input: In) => Effect.Effect<A, E, R>;
 }
 
-/**
- * Run `op.resolve(rawWireInput)` and return its `Exit` mapped through the wire
- * seam: on success the handler value, on failure the `FateRequestError`
- * `encodeWireError` derives — exactly what a client receives. The caller still
- * provides the same per-request services (`CurrentUser`, the substituted
- * `Drizzle`/service seams) it provided to `.handler`.
- */
 export const resolveWire = <In, A, E, R>(
 	op: ResolvableOp<In, A, E, R>,
 	raw: In,
@@ -97,9 +49,6 @@ export const resolveWire = <In, A, E, R>(
 				? Effect.succeed(exit.value)
 				: Effect.fail(encodeWireError(failureOf(exit.cause))),
 		),
-		// Discharge the two per-request driver-seam services in one merged provide so the
-		// residual `R` is a single-union `Exclude`: `RequestFlagOverrides` (the #622
-		// no-cookie override a flag-gated resolver's `provideRequestFlags` requires) and
-		// the base-feed purger a fanned pano mutation fires (#2324) as a no-op.
+		// One merged provide, so the residual `R` stays a single-union `Exclude`.
 		Effect.provide(Layer.mergeAll(noRequestFlagOverrides, noopPanoFeedCache)),
 	);

--- a/apps/web/worker/features/fate/route.ts
+++ b/apps/web/worker/features/fate/route.ts
@@ -1,14 +1,11 @@
 /**
- * The `POST /fate` route. Since the v2 cutover (ADR 0043) it serves through the
- * native interpreter on its own request fiber — no per-request runtime, no
- * Effect→Promise hop. The `FateServer` service and worker singletons reach the
- * handler through the runtime-derived context layer (`HttpRouter.provideRequest`,
- * `http/app.ts`). See `.patterns/alchemy-http-router.md`,
- * `.patterns/fate-effect-interpreter.md`.
+ * The `POST /fate` route. Since the v2 cutover (ADR 0043) it serves through the native
+ * interpreter on its own request fiber — no per-request runtime, no Effect→Promise hop.
+ * See `.patterns/fate-effect-interpreter.md`.
  *
- * The route edge owns abort→interruption ({@link interruptOnAbort}): alchemy's
- * worker bridge runs the request fiber without abort wiring, so a disconnected
- * client wouldn't interrupt the resolver fibers unless the edge wires it.
+ * The route edge owns abort→interruption ({@link interruptOnAbort}): alchemy's worker
+ * bridge runs the request fiber without abort wiring, so a disconnected client would
+ * not interrupt the resolver fibers unless the edge wires it.
  */
 import {FateInterpreter, type FateRequestContext} from "@kampus/fate-effect";
 import * as Cloudflare from "alchemy/Cloudflare";
@@ -38,18 +35,15 @@ export const handleFate = Effect.gen(function* () {
 
 	const session = yield* pasaport.validateSession(raw.headers);
 
-	// `waitUntil` keeps the best-effort live fan-out from blocking the response
-	// (ADR 0028/0029/0039).
+	// `waitUntil` keeps the best-effort live fan-out from blocking the response (ADR 0039).
 	const publishToTopic = (topicKey: string, message: PublishMessage) =>
 		liveTopics.publish(topicKey, message, defaultLiveLimits);
 	const waitUntil = (promise: Promise<unknown>) => {
 		executionCtx.waitUntil(promise);
 	};
 
-	// The base-feed edge-cache purger a fanned pano mutation fires alongside its live
-	// publish (ADR 0170 / #2324). `ctx.cache.purge` is the worker's OWN scoped purge
-	// capability (no zone purge, no API token); it is absent offline / in dev (`cache?`),
-	// where the purge degrades to a no-op.
+	// `ctx.cache.purge` is the worker's OWN scoped purge capability (no zone purge, no API
+	// token); it is absent offline / in dev (`cache?`), where the purge degrades to a no-op.
 	const flagsContext = yield* makeRequestFlagsContext(
 		anonymousFlagsContext,
 		raw.headers.get("cookie"),
@@ -59,21 +53,15 @@ export const handleFate = Effect.gen(function* () {
 		waitUntil,
 	});
 
-	// May this request honor its `phoenix_flag_overrides` cookie (#2741)? Resolved ONCE
-	// at the edge (dev, or an admin) over the request's actor, then threaded on
-	// `RequestFlagOverrides` so `provideRequestFlags` gates every resolver's flag read off
-	// it — the admin verdict can't be recomputed per resolver.
+	// May this request honor its `phoenix_flag_overrides` cookie (#2741)? Resolved ONCE at
+	// the edge, then threaded — the admin verdict cannot be recomputed per resolver.
 	const overridesAllowed = yield* overridesAuthorized(flagsContext).pipe(
 		Effect.provide(currentActorContext(session?.user)),
 	);
 
-	// ONE context object for the whole request — never copy or rebuild it per
-	// resolver. No `signal` field: interruption is wired at this edge (below).
-	// `requestServices` fulfills the `[CurrentActor, RequestFlagOverrides]`
-	// registered in `layers.ts`: `CurrentActor` derived from the validated session
-	// (ADR 0107 §7), `RequestFlagOverrides` carrying the raw `Cookie` header + the
-	// `overridesAllowed` verdict so a flag-gated resolver's `provideRequestFlags` can
-	// source the #622 cookie only when authorized (dev, or admin + flag; #2741).
+	// ONE context object for the whole request — never copy or rebuild it per resolver.
+	// No `signal` field: interruption is wired at this edge (below). This fulfills the
+	// per-request services registered in `layers.ts` (ADR 0107 §7).
 	const requestServices = Context.merge(
 		currentActorContext(session?.user),
 		Context.merge(

--- a/apps/web/worker/features/fate/schema.ts
+++ b/apps/web/worker/features/fate/schema.ts
@@ -1,15 +1,10 @@
 /**
- * The fate codegen entry module — the single module the fate Vite plugin reads
- * at build time (`fate({module: ".../fate/schema.ts", transport: "native"})`):
- * the data-view objects + entity types (re-exported from `views.ts`) and the
- * `fateServer` value (its manifest + `InferFateAPI` for the typed client).
- *
- * `fateServer` is the BUILD-TIME form of `config.ts`'s one config:
- * `toCodegenServer` calls `createFateServer` over the same records (so the
- * manifest matches the served wire contract) with every executor INERT —
- * importing this module constructs pure data, no handler/database/bindings
- * (`.patterns/fate-effect-compiler.md`). The worker entry never imports this
- * file; it serves through the native interpreter (`route.ts`, ADR 0043).
+ * The fate codegen entry module: the one module the fate Vite plugin reads at build
+ * time. `fateServer` is the BUILD-TIME form of `config.ts`'s config, built over the
+ * same records so the manifest matches the served wire contract, but with every
+ * executor inert — importing this constructs pure data, no handlers or bindings (see
+ * .patterns/fate-effect-compiler.md). The worker entry never imports this file; it
+ * serves through the native interpreter (ADR 0043).
  */
 import {FateExecutor} from "@kampus/fate-effect";
 import {fateConfig} from "./config.ts";

--- a/apps/web/worker/features/fate/stamp-wave.ts
+++ b/apps/web/worker/features/fate/stamp-wave.ts
@@ -1,34 +1,21 @@
 /**
- * `parallelStampWave` — collapse a read's serial stamp chain into one concurrent
- * wave. A finalized read (`Definition`, `Comment`) is stamped with several
- * independent facets — viewer scalars (`stampViewerScalars`), the reaction
- * aggregate (`stampReactionAggregate`), live author identity (`stampAuthorIdentity`).
- * Each is independent GIVEN the already-fetched rows: it reads only the base row's
- * `id` / `authorId` and ADDS a disjoint field set, never another stamp's output.
- * Chaining them with `yield*` therefore pays N cross-region D1 round trips strictly
- * in sequence for no ordering reason (the #2567 baseline). This runs every stamp
- * over the SAME base rows and merges their added fields back index-wise.
+ * `parallelStampWave` — run a read's independent stamps over the SAME base rows and merge
+ * their added fields index-wise, instead of chaining them for N serial D1 round trips
+ * (#2567).
  *
- * The `concurrency` option is the whole point, and it is NOT optional cosmetics:
- * `Effect.all` defaults to sequential execution — effect@4.0.0-beta.92's `Effect.all`
- * (an iterable delegates to `forEach`) documents "Concurrency: … By default, the
+ * Independence is the CALLER's contract: a stamp that read another stamp's added field
+ * would need the chain, not this wave.
+ *
+ * `Effect.all` defaults to sequential — effect@4.0.0-beta.92 documents "By default, the
  * operations are performed sequentially" (`Effect.ts` JSDoc), backed by
- * `internal/effect.ts` `forEach` (`concurrency ?? 1` → `if (concurrency === 1)
- * return forEachSequential`). So a wave that omits `{concurrency}` changes nothing.
- * Pass `"unbounded"` to actually fan the stamps out; the default `1` reproduces
- * today's serial phase count byte-for-byte (same reads, same order, same merged
- * rows) — the safe default the sözlük containment flag flips.
- *
- * Merge correctness: every stamp returns the base rows in input order, each row
- * extended with its own disjoint fields, so `Object.assign({}, …outsAtIndex)`
- * rebuilds `base ∪ every stamp's fields` with the same key order the serial chain
- * produced. Independence is the caller's contract — a stamp that READ another
- * stamp's added field would need the chain, not this wave.
+ * `internal/effect.ts` `forEach` (`concurrency ?? 1` → `forEachSequential`). So a wave
+ * that omits `{concurrency}` changes nothing; the default `1` here reproduces today's
+ * serial phase count byte-for-byte, and `"unbounded"` is what actually fans out.
  */
 import {Effect} from "effect";
 import type {Concurrency} from "effect/Types";
 
-/** A row stamp: given the base page, return each row extended with its own fields. */
+/** Given the base page, return each row extended with its own fields. */
 export type RowStamp<R> = (rows: ReadonlyArray<R>) => Effect.Effect<ReadonlyArray<R>>;
 
 type UnionToIntersection<U> = (U extends unknown ? (x: U) => void : never) extends (

--- a/apps/web/worker/features/fate/stamp-wave.unit.test.ts
+++ b/apps/web/worker/features/fate/stamp-wave.unit.test.ts
@@ -1,20 +1,8 @@
 /**
- * `parallelStampWave` — the read-path stamp-chain collapse (#2709, epic #2567).
- * These pin the three properties the acceptance criteria name, above any SQL engine
- * (ADR 0082):
- *
- *   - the wave issues its independent stamps CONCURRENTLY when opted in, and
- *     SEQUENTIALLY by default — proven by the observed start/end interleaving, not
- *     merely by matching results (a serial wave would match results too, so a
- *     result-only test could not tell the collapse happened);
- *   - the merged row is byte-for-byte identical whichever way it runs — same fields,
- *     same values, same key order — so the flag flips wall time and nothing else;
- *   - the empty page short-circuits to an empty result while still invoking each
- *     stamp once (each reader owns its own no-op read).
- *
- * The stamps here are in-memory doubles: a real stamp's D1 read is substituted by a
- * `yieldNow`-punctuated recorder, so "did the reads overlap" is decidable with no
- * database — the real reads' fidelity lives on the per-stamp unit tests.
+ * `parallelStampWave` (#2709). Concurrency is proven by the observed start/end
+ * interleaving, not by matching results — a serial wave matches results too, so a
+ * result-only test could not tell the collapse happened. The stamps are `yieldNow`-
+ * punctuated recorders, so overlap is decidable with no database.
  */
 import {assert, describe, it} from "@effect/vitest";
 import {Effect} from "effect";
@@ -22,12 +10,6 @@ import {parallelStampWave, type RowStamp} from "./stamp-wave.ts";
 
 type Row = {id: string; authorId: string};
 
-/**
- * A stamp that records `start-i` / `end-i` around a cooperative `yieldNow`, then adds
- * one disjoint field `fI`. Under `concurrency: 1` each stamp completes before the next
- * begins (`start-0, end-0, start-1, …`); under `"unbounded"` all three reach `start`
- * before any reaches `end` — the interleaving IS the concurrency proof.
- */
 const recordingStamp =
 	(i: number, log: string[]): RowStamp<Row> =>
 	(rows) =>
@@ -67,8 +49,6 @@ describe("parallelStampWave — concurrency is opt-in (the #2709 collapse knob)"
 			const log: string[] = [];
 			const rows: Row[] = [{id: "d1", authorId: "u1"}];
 			return Effect.gen(function* () {
-				// No `{concurrency}` → the wave defaults to 1 (effect's `concurrency ?? 1`), the
-				// safe default the flag-off path relies on to reproduce today's serial reads.
 				yield* parallelStampWave(rows, [
 					recordingStamp(0, log),
 					recordingStamp(1, log),
@@ -94,10 +74,8 @@ describe("parallelStampWave — concurrency is opt-in (the #2709 collapse knob)"
 });
 
 describe("parallelStampWave — the merge is byte-for-byte identical whichever way it runs", () => {
-	// Three stamps adding disjoint fields in the same chain order a real read uses
-	// (myVote → reactions → identity), so the merge reproduces the serial chain's shape.
 	// Left un-annotated (not `RowStamp<Row>`) so each stamp's ADDED field type is inferred
-	// and flows through the combinator's merge — the exact way the real stampers do.
+	// and flows through the merge, the way the real stampers do.
 	const stampA = (rows: ReadonlyArray<Row>) =>
 		Effect.succeed(rows.map((r) => ({...r, myVote: true})));
 	const stampB = (rows: ReadonlyArray<Row>) =>

--- a/apps/web/worker/features/fate/view-types.ts
+++ b/apps/web/worker/features/fate/view-types.ts
@@ -4,8 +4,7 @@
  */
 
 /**
- * Identity row mapping. Interfaces don't satisfy `FateDataView`'s
- * `Record<string, unknown>` item bound (no implicit index signature); this
- * mapped type does, without repeating the row's fields.
+ * Interfaces don't satisfy `FateDataView`'s `Record<string, unknown>` item bound (no
+ * implicit index signature); this mapped type does, without repeating the row's fields.
  */
 export type ViewRow<Row> = {[K in keyof Row]: Row[K]};

--- a/apps/web/worker/features/fate/viewer-scalars.ts
+++ b/apps/web/worker/features/fate/viewer-scalars.ts
@@ -1,25 +1,12 @@
 /**
- * `stampViewerScalars` — the one finalize step that turns a batch-read presence
- * `Set` into a per-row viewer scalar (`myVote` / `isSaved`), replacing the
- * `voteSvc.readMine(...)` + `viewerId ? set.has(id) : null` choreography that was
- * re-inlined verbatim at every list/byIds read site (#1126).
- *
- * The N+1-avoidance contract is now *structural*, not copy-paste: a spec names
- * the field and the batched presence reader once, the helper does the single
- * `IN (...)` read per spec and stamps `viewerId ? set.has(id) : null` uniformly.
- * Anonymous viewer / empty rows short-circuit inside each reader (`readMine`
- * returns an empty Set with no read), so the scalar degrades to `null` and never
- * throws — the read-path convention.
+ * Turns a batch-read presence `Set` into a per-row viewer scalar (`myVote` / `isSaved`),
+ * making the N+1-avoidance contract structural rather than copy-paste (#1126). An
+ * anonymous viewer degrades the scalar to `null` and never throws.
  */
 import type {Effect} from "effect";
 import {Effect as Eff} from "effect";
 
-/**
- * A viewer scalar to stamp: the wire field it lands on, and the batched presence
- * reader (`Vote.readMine` bound to a kind, `Bookmark.readMine`) that returns the
- * subset of ids the viewer has the row for. The reader owns the
- * missing-viewer/empty short-circuit.
- */
+/** The `read` reader owns the missing-viewer / empty-ids short-circuit. */
 export interface ViewerScalarSpec<F extends string> {
 	readonly field: F;
 	readonly read: (
@@ -29,11 +16,8 @@ export interface ViewerScalarSpec<F extends string> {
 }
 
 /**
- * Run every spec's batched presence read once over `rows`' ids, then stamp each
- * named field onto each row as `viewerId ? set.has(row.id) : null`. One read per
- * spec for the whole batch — never per row. The stamped fields are *added* to the
- * input row shape, so a read that wants the scalar must route through here to
- * obtain it (a path that skips the stamp simply never produces the field).
+ * One read per spec for the WHOLE batch, never per row. The stamped fields are added to
+ * the input row shape, so a path that skips this helper simply never produces them.
  */
 export const stampViewerScalars = <R extends {id: string}, F extends string>(
 	rows: ReadonlyArray<R>,

--- a/apps/web/worker/features/fate/views.ts
+++ b/apps/web/worker/features/fate/views.ts
@@ -1,16 +1,11 @@
 /**
- * fate data views — the SPA's one stable type-import surface: a barrel
- * re-exporting every feature's entity types + view consts. The cross-feature
- * client-exposed `Root` is no longer hand-listed here — it derives from the same
- * `config.ts` feature registry that drives the served config, so a feature's roots
- * are named once (on its `fate-module.ts`), not twice (barrel + `Root`). See
+ * fate data views — the SPA's one stable type-import surface. See
  * `.patterns/fate-data-views.md`, `.patterns/per-feature-fate-aggregators.md`.
  */
 
 import type {AssertFieldMapResolved} from "@kampus/fate-effect";
-// Every client-facing entity's View class, imported (type-only) so the loud-fail
-// field-map guard can be asserted over the full shipping surface at the bottom of
-// this file. See the `AssertFieldMapResolved` block below (#2808/#2811).
+// Every View class is imported type-only so the field-map guard at the bottom of this
+// file can assert over the full shipping surface.
 import type {AdminProbeView} from "../admin-console/probe-view.ts";
 import type {
 	NotificationChannelView,
@@ -124,39 +119,26 @@ export type {UserAdminEntity as UserAdmin, UserAdminRole} from "../user-admin/vi
 export {userAdminDataView} from "../user-admin/views.ts";
 
 /**
- * The client-exposed root map the fate Vite plugin turns into typed client roots
- * at build time (`createSchema(views, Root)`); a `list(...)`-wrapped entry is a
- * `list` root, a bare view is a `query` root. Each feature owns its slice on its
- * `fate-module.ts` `roots`, and this merges them off the `config.ts` registry — so
- * a root's custom name + load-bearing constraints (the request-key→root-name
- * mapping, the reused Term/Post search views) live next to the feature's views.
- * Only custom-resolver roots appear — byId roots are generated from the source
- * registry, and `Root` is not passed to `createFateServer` (`roots` stays empty
- * there; `mergeFateModules` does not thread it).
+ * The client-exposed root map the fate Vite plugin turns into typed client roots at
+ * build time. Only custom-resolver roots appear — byId roots are generated from the
+ * source registry.
  *
- * Annotated `Record<string, unknown>` to stay nameable: a precise type would
- * surface fate's internal `DataView` symbol (TS2883/TS4023); the plugin only
- * inspects this value at runtime.
+ * Annotated `Record<string, unknown>` to stay nameable: a precise type would surface
+ * fate's internal `DataView` symbol (TS2883/TS4023). The plugin only inspects this
+ * value at runtime.
  */
 export const Root: Record<string, unknown> = mergeFateRoots(modules);
 
-// --- Loud-fail field-map guard, adopted onto every shipping entity (#2808/#2811) ---
+// The loud-fail field-map guard. `AssertFieldMapResolved` resolves to the view itself
+// while fate's `dataViewFieldsKey` symbol recovery is healthy, or to a named
+// `FieldMapRecoveryFailed<Name>` brand when the symbol identity slips. The
+// `Guarded extends Resolved` slot turns that brand into a NAMED compile error here,
+// instead of a silent `never` at a far-away `view<>()` selection (#2805).
 //
-// `AssertFieldMapResolved<typeof XView>` (the #2810 machinery) resolves to the view
-// itself when fate's `dataViewFieldsKey` symbol recovery is healthy, or to the named
-// `FieldMapRecoveryFailed<Name>` brand when the symbol identity slips and the field map
-// degrades to the wide `Record<string, DataField>` fallback (the #2805 failure). The
-// `Guarded extends Resolved` slot below makes that brand a NAMED compile error HERE, at
-// the barrel next to the entity — instead of a silent `never` at a far-away `view<>()`
-// selection, which is exactly the silent degrade that cost the #2805 investigation cycle.
-//
-// This is intentionally NOT exported: surfacing fate's internal `DataView` types on this
-// composite worker project's declaration boundary would trip the TS2883/TS4020 nameability
-// checks (the same portability cost that keeps `Root` above annotated `Record<string,
-// unknown>`). Kept local, the assertions type-check without emitting any declaration.
+// Must NOT be exported: surfacing fate's internal `DataView` types on this composite
+// project's declaration boundary trips the TS2883/TS4020 nameability checks.
 type AssertResolved<Resolved, Guarded extends Resolved> = Guarded;
 
-// One entry per client-exposed entity; a slip on any one fails this list loudly.
 type _FateViewsFieldMapResolved = [
 	AssertResolved<typeof AdminProbeView, AssertFieldMapResolved<typeof AdminProbeView>>,
 	AssertResolved<typeof NotificationView, AssertFieldMapResolved<typeof NotificationView>>,

--- a/apps/web/worker/features/fate/wireCodes-per-class.unit.test.ts
+++ b/apps/web/worker/features/fate/wireCodes-per-class.unit.test.ts
@@ -1,30 +1,16 @@
 /**
- * Per-class wire-code pin (unit tier), consolidated.
+ * Per-class wire-code pin — which class carries WHICH code, the binding the aggregate
+ * guards do not assert. See `.patterns/fate-effect-wire-errors.md`.
  *
- * Every annotated domain error class reachable from `fateConfig` is pinned to
- * the exact wire `code` it must carry, so the annotation-derived codec
- * (`.patterns/fate-effect-wire-errors.md`) and the SPA's `FATE_WIRE_CODES`
- * vocabulary can't drift through the migration — and an annotated instance
- * round-trips through `encodeWireError` to that code with its own message.
+ * `EXPECTED_CODE` must stay a hand-authored literal, never read back from
+ * `wireCodeOfClass`: codes are legitimately shared across classes (`UNAUTHORIZED` ×4,
+ * `BODY_TOO_LONG` ×3), so a set-membership check still passes when a class is
+ * mis-annotated to another valid code. The annotation is the sole class→code author
+ * site, so asserting it against itself is a tautology.
  *
- * The expected code is a *hand-authored* literal (`EXPECTED_CODE` below), an
- * oracle independent of the `FateWireCode` annotation under test — never read
- * back from `wireCodeOfClass`. That independence is load-bearing: codes are
- * legitimately shared across classes (`UNAUTHORIZED` ×4, `BODY_TOO_LONG` ×3),
- * so a set-membership check (each class carries *some* declared code) passes
- * even when a class is mis-annotated to *another* valid code. Only an oracle
- * stating which class carries WHICH code catches that. Since the annotation is
- * the sole class→code author site, asserting it against itself is a tautology;
- * the oracle is the second, independent statement of intent the pin needs.
- *
- * This is the exact code-per-class binding the aggregate guards do NOT assert:
- * `wireCodes.unit.test.ts` proves the SPA list covers `declaredWireCodes`, and
- * `packages/fate-effect/src/Server.unit.test.ts` owns the AST-walk that derives
- * those codes — neither pins WHICH class carries WHICH code. The staleness
- * guard at the bottom binds the oracle to `fateConfig` so a feature added with
- * an unpinned annotated code fails CI here instead of silently escaping
- * per-class coverage. The round-trip cases reuse the oracle's codes (single
- * source for each code) and only choose WHICH classes to instantiate.
+ * The staleness guard at the bottom binds the oracle to `fateConfig`, so a feature
+ * added with an unpinned annotated code fails CI here instead of silently escaping
+ * per-class coverage.
  */
 
 import {
@@ -74,17 +60,7 @@ import {
 import {SelfVoteNotAllowed, VoterNotEligible} from "../vote/errors.ts";
 import {fateConfig} from "./config.ts";
 
-/**
- * The independent oracle: every annotated domain error class `fateConfig` can
- * emit, pinned to its specific wire code by a hand-authored literal. This is
- * the test's second statement of intent — the assertion compares each class's
- * `FateWireCode` annotation against THIS, never against itself. The staleness
- * guard below proves these keys cover every code in `declaredWireCodes`
- * (modulo the package-intrinsic codes), so a newly-declared annotated error
- * can't escape this per-class coverage.
- */
 const EXPECTED_CODE = new Map<new (...args: never[]) => unknown, string>([
-	// pano
 	[TitleRequired, "TITLE_REQUIRED"],
 	[TitleTooLong, "TITLE_TOO_LONG"],
 	[UrlInvalid, "URL_INVALID"],
@@ -99,22 +75,15 @@ const EXPECTED_CODE = new Map<new (...args: never[]) => unknown, string>([
 	[CommentNotFound, "COMMENT_NOT_FOUND"],
 	[UnauthorizedPostMutation, "UNAUTHORIZED"],
 	[UnauthorizedCommentMutation, "UNAUTHORIZED"],
-	// mecmua write path (#2497) — reachable from fateConfig via `mecmua.publish` /
-	// `mecmua.saveDraft`. All message-only, so also round-trip representatives below;
-	// `MecmuaTitleRequired` shares the `TITLE_REQUIRED` code with pano's `TitleRequired`.
 	[MecmuaDisabled, "MECMUA_DISABLED"],
 	[MecmuaPostNotFound, "MECMUA_POST_NOT_FOUND"],
 	[MecmuaTitleRequired, "TITLE_REQUIRED"],
-	// member-mute write path (#3112) — reachable from fateConfig via `mute.set` /
-	// `mute.remove`. Both message-only, so also round-trip representatives below.
 	[MuteDisabled, "MUTE_DISABLED"],
 	[SelfMuteRejected, "SELF_MUTE_REJECTED"],
-	// sozluk
 	[BodyRequired, "BODY_REQUIRED"],
 	[BodyTooLong, "BODY_TOO_LONG"],
 	[DefinitionNotFound, "DEFINITION_NOT_FOUND"],
 	[UnauthorizedDefinitionMutation, "UNAUTHORIZED"],
-	// pasaport
 	[UsernameInvalidFormat, "INVALID_FORMAT"],
 	[UsernameTooShort, "TOO_SHORT"],
 	[UsernameTooLong, "TOO_LONG"],
@@ -122,48 +91,25 @@ const EXPECTED_CODE = new Map<new (...args: never[]) => unknown, string>([
 	[UsernameAlreadySet, "ALREADY_SET"],
 	[UserNotFound, "USER_NOT_FOUND"],
 	[DisplayNameEmpty, "DISPLAY_NAME_EMPTY"],
-	// pasaport ban-reason floor (#970) — reachable from fateConfig via `user.banUser`'s
-	// error union. Message-only, so also a round-trip representative below.
 	[BanReasonRequired, "BAN_REASON_REQUIRED"],
-	// pasaport email-failing-mark floor (#2692) — reachable via `emailDelivery.mark`'s
-	// error union. Message-only, so also a round-trip representative below.
 	[EmailFailingReasonRequired, "EMAIL_FAILING_REASON_REQUIRED"],
-	// künye moderation gate + the package-side gate the SPA already decodes for writes
 	[Denied, "UNAUTHORIZED"],
 	[Unauthorized, "UNAUTHORIZED"],
-	// künye earned-ladder denial — first reachable from fateConfig via `user.vouch` (#1206).
-	// Has an extra required field (`need`), so it is pinned here but NOT in ROUND_TRIP_CLASSES.
+	// The five below carry extra required fields, so they are pinned here but cannot be
+	// generically instantiated in ROUND_TRIP_CLASSES.
 	[RequiresLevel, "FORBIDDEN"],
-	// künye concurrent-vouch cap (D5, #1289) — reachable via `user.vouch` past the floor.
-	// Has an extra required field (`cap`), so pinned here but NOT in ROUND_TRIP_CLASSES.
 	[VouchLimitReached, "VOUCH_LIMIT_REACHED"],
-	// vote earn-to-vote denial — reachable from fateConfig via the inline cast paths
-	// (pano post/comment + sözlük definition), #1810/#1828/#1879. Its own distinct code
-	// (not the overloaded FORBIDDEN). Has extra required fields (`voterId`, `need`), so it
-	// is pinned here but NOT in ROUND_TRIP_CLASSES.
 	[VoterNotEligible, "VOTE_REQUIRES_YAZAR"],
-	// vote self-vote denial — reachable from fateConfig via the inline cast paths (pano
-	// post + sözlük definition), #2216. Its own distinct code. Has an extra required field
-	// (`voterId`), so pinned here but NOT in ROUND_TRIP_CLASSES.
 	[SelfVoteNotAllowed, "SELF_VOTE_NOT_ALLOWED"],
-	// künye karma-VALUE privilege floor (#150) — reachable from fateConfig via the
-	// content-creation mutations (`post.submit` / `comment.add` / `definition.add`) and
-	// `report.submit`. Its OWN code (not the tier-ladder FORBIDDEN). Has extra required
-	// fields (`need`, `have`), so pinned here but NOT in ROUND_TRIP_CLASSES.
 	[InsufficientKarma, "INSUFFICIENT_KARMA"],
 ]);
 
 const ORACLE_ENTRIES = [...EXPECTED_CODE.entries()] as ReadonlyArray<[unknown, string]>;
 
 /**
- * The subset of oracle classes whose only required field is `message`, so an
- * instance can be constructed generically here for the `encodeWireError`
- * round-trip. The codec reads the same annotation regardless of payload, so one
- * message-only representative per distinct code proves the mechanism; classes
- * with extra required fields (`postId`, `definitionId`, …) are still pinned for
- * their code by the oracle above. This list authors only WHICH classes to
- * instantiate — each expected code is looked up in the oracle (the single
- * source), never re-listed here.
+ * The oracle classes whose only required field is `message`, so an instance can be
+ * constructed generically for the `encodeWireError` round-trip. This list authors only
+ * WHICH classes to instantiate — codes are looked up in the oracle, never re-listed.
  */
 const ROUND_TRIP_CLASSES = [
 	TitleRequired,
@@ -189,12 +135,7 @@ const ROUND_TRIP_CLASSES = [
 	Unauthorized,
 ] as const satisfies ReadonlyArray<new (props: {message: string}) => unknown>;
 
-/**
- * Codes the package emits independent of any declaration — defects /
- * un-annotated failures (`INTERNAL_WIRE_CODE`) and Schema rejections
- * (`InputValidationError`'s `VALIDATION_ERROR`). They have no domain class to
- * pin, so the staleness guard exempts them from oracle coverage.
- */
+/** Codes the package emits with no domain class to pin, so the staleness guard exempts them. */
 const PACKAGE_INTRINSIC_CODES: ReadonlySet<string> = new Set([
 	INTERNAL_WIRE_CODE,
 	"VALIDATION_ERROR",

--- a/apps/web/worker/features/fate/wireCodes.unit.test.ts
+++ b/apps/web/worker/features/fate/wireCodes.unit.test.ts
@@ -1,19 +1,8 @@
 /**
- * SPA wire-code list ⇄ server config guard (unit tier).
- *
- * The server derives wire codes from each error class's `FateWireCode`
- * annotation (`.patterns/fate-effect-wire-errors.md`); the SPA's
- * `FATE_WIRE_CODES` (`src/lib/fateWireCodes.ts`) is the literal authored source
- * the decoder narrows to. The two ends are bound by this guard, not by hope: if
- * the SPA list omits a code the server can emit, `decodeFateWireCode` would drift
- * that code to its `INTERNAL_SERVER_ERROR` fallback at runtime — so this test
- * fails CI on that drift before it ships. The closed server set comes from the
- * package walker `declaredWireCodes(fateConfig)`; the AST walk and its drift
- * canary live package-side (`Server.unit.test.ts`), so this owns only the
- * phoenix-level assertions.
- *
- * The worker tsconfig cross-includes `src/lib/`, so this worker-side test imports
- * the SPA constant + decoder directly.
+ * SPA wire-code list ⇄ server config guard. If the SPA list omits a code the server
+ * can emit, `decodeFateWireCode` silently drifts that code to its
+ * `INTERNAL_SERVER_ERROR` fallback at runtime — this fails CI on that drift instead.
+ * The AST walk behind `declaredWireCodes` is tested package-side.
  */
 
 import * as FateEffect from "@kampus/fate-effect";
@@ -26,29 +15,24 @@ import {fateConfig} from "./config.ts";
 describe("wire-code contract", () => {
 	const spaCodes: ReadonlySet<string> = new Set(FATE_WIRE_CODES);
 
-	// The server can emit two flavors: codes from a mutation's DECLARED error union
-	// (what `declaredWireCodes` walks) PLUS the throttle codes injected at the fate
-	// composition seam (ADR 0177) — the latter have no declared union to walk, so
-	// they are unioned in here so the SPA-coverage assertion still binds them.
+	// The throttle codes are injected at the fate composition seam (ADR 0177) and have
+	// no declared error union to walk, so they must be unioned in by hand.
 	const serverCodes: ReadonlySet<string> = new Set([
 		...declaredWireCodes(fateConfig),
 		...THROTTLE_WIRE_CODES,
 	]);
 
 	it("the annotation key is exported under its one canonical name `FateWireCode`", () => {
-		// Names drift under a value-only guard (#1032): the codec reads the
-		// annotation by the `FateWireCode` *symbol* every author site spells, so a
-		// rename of the export — back to `ErrorCode` or any other — must fail CI
-		// here, not just silently work because the underlying string is unchanged.
+		// A value-only guard would let the export be renamed while the string stays
+		// the same, and every author site spells the symbol (#1032).
 		expect(FateEffect).toHaveProperty("FateWireCode");
 		expect(FateEffect.FateWireCode).toBe("fate-effect/wireCode");
 		expect(FateEffect).not.toHaveProperty("ErrorCode");
 	});
 
 	it("the walk finds phoenix's declared vocabulary (sanity floor)", () => {
-		// One code per error surface (package gate, sozluk, pano, pasaport): if a
-		// feature's error union drops from a registered operation, this names the
-		// hole instead of the subset check below passing over a shrunken set.
+		// One code per error surface, so a dropped error union names the hole instead
+		// of the subset check below quietly passing over a shrunken set.
 		for (const floor of [
 			"UNAUTHORIZED",
 			"VALIDATION_ERROR",
@@ -66,16 +50,12 @@ describe("wire-code contract", () => {
 	});
 
 	it("every server-emittable code decodes to itself, never the INTERNAL_SERVER_ERROR fallback", () => {
-		// The behavioral pin behind the coverage check: a real wire code must
-		// render as its OWN code, not drift to the generic fallback. `UNAUTHORIZED`
-		// is the canonical case — a known domain code the SPA must surface verbatim.
 		expect(decodeFateWireCode("UNAUTHORIZED")).toBe("UNAUTHORIZED");
 		for (const code of serverCodes) {
 			expect(decodeFateWireCode(code)).toBe(code);
 		}
-		// An unknown code is the ONLY thing that falls through to null (the
-		// `?? "INTERNAL_SERVER_ERROR"` fallback at the call site) — proving the
-		// fallback is reserved for genuinely-unrecognized codes, not real ones.
+		// An unknown code must be the ONLY thing reaching the call site's
+		// `?? "INTERNAL_SERVER_ERROR"` fallback.
 		expect(decodeFateWireCode("DEFINITELY_NOT_A_WIRE_CODE")).toBeNull();
 	});
 });

--- a/apps/web/worker/features/flagship/Flags.ts
+++ b/apps/web/worker/features/flagship/Flags.ts
@@ -1,25 +1,9 @@
 /**
- * `Flags` — the domain-facing feature-flag service (epic #488, child #508): the
- * boolean dark-ship primitive. Server code reads `flags.getBoolean(key, default)`
- * to gate a code path behind a flag.
+ * `Flags` — the domain-facing feature-flag read surface: .patterns/feature-flags.md.
  *
- * Two contracts are load-bearing here:
- *
- * 1. **Safe-default, baked in.** The caller MUST pass a `default`, and that
- *    default is the off/old/safe path. The read NEVER fails: a `FlagshipError`
- *    (a misconfigured binding, an unreachable Flagship) is caught and collapsed
- *    to the supplied default, so a Flagship outage degrades safe rather than
- *    breaking the request. The public method's error channel is therefore
- *    `never` — no `FlagshipError` leaks to callers.
- * 2. **Clean OpenFeature seam.** Domain code depends on THIS interface, not on
- *    alchemy's `Cloudflare.Flagship*` types, so a future provider swap
- *    (OpenFeature is the hedge — #506) re-wires only `FlagsLive`, not the
- *    call-sites. The alchemy `FlagshipClient` stays an implementation detail
- *    consumed under the `Flagship` Tag (the #507 seam — this never re-binds it).
- *
- * Scope is the read surface — the boolean dark-ship primitive plus the typed
- * variations (string/number/object, #509). The React hook is #510,
- * targeting/percentage is #511.
+ * Every read takes a `default` that is the off/old/safe path, and any evaluation error
+ * collapses to it — so the error channel is `never` and a Flagship outage degrades safe.
+ * Domain code depends on THIS interface, never on alchemy's `Cloudflare.Flagship*` types.
  */
 import type {RuntimeContext} from "alchemy";
 import {type Cause, Context, Effect, Layer} from "effect";
@@ -27,45 +11,27 @@ import {tagFlag} from "../../lib/sentry.ts";
 import {FlagsContext, toEvaluationContext} from "./FlagsContext.ts";
 import {Flagship} from "./Flagship.ts";
 
-/** The domain-facing flag service value — provider-agnostic by construction. */
 export interface FlagsAccess {
 	/**
-	 * Read a boolean flag for the current request, falling back to `defaultValue`
-	 * on any evaluation error. The per-request {@link FlagsContext} (user identity
-	 * for stable bucketing) is read from the environment — supplied per request
-	 * alongside `Auth` (ADR 0029), not captured at isolate scope. `RuntimeContext`
-	 * is the alchemy binding's intrinsic ambient requirement, discharged at worker
-	 * scope (#507); it is generic alchemy, not a leaked Flagship type.
+	 * The per-request {@link FlagsContext} is read from the environment, not captured at
+	 * isolate scope (ADR 0029). `RuntimeContext` is the alchemy binding's ambient
+	 * requirement, discharged at worker scope — generic alchemy, not a leaked Flagship type.
 	 */
 	readonly getBoolean: (
 		key: string,
 		defaultValue: boolean,
 	) => Effect.Effect<boolean, never, FlagsContext | RuntimeContext>;
 
-	/**
-	 * Read a string flag for the current request. Same safe-default/never-throws
-	 * contract as {@link getBoolean}: any evaluation error collapses to
-	 * `defaultValue`, so the error channel is `never`.
-	 */
 	readonly getString: (
 		key: string,
 		defaultValue: string,
 	) => Effect.Effect<string, never, FlagsContext | RuntimeContext>;
 
-	/**
-	 * Read a number flag for the current request. Same safe-default/never-throws
-	 * contract as {@link getBoolean}.
-	 */
 	readonly getNumber: (
 		key: string,
 		defaultValue: number,
 	) => Effect.Effect<number, never, FlagsContext | RuntimeContext>;
 
-	/**
-	 * Read a JSON-object flag for the current request. `T` is constrained to
-	 * `object` to match the provider's typed read; same safe-default/never-throws
-	 * contract as {@link getBoolean}.
-	 */
 	readonly getObject: <T extends object>(
 		key: string,
 		defaultValue: T,
@@ -75,14 +41,9 @@ export interface FlagsAccess {
 export class Flags extends Context.Service<Flags, FlagsAccess>()("@kampus/Flags") {}
 
 /**
- * Collapse any evaluation failure to the caller's safe default — the single site
- * of contract 1 (safe-default, error channel `never`). `catchCause` (not a typed
- * `catch`) so a binding DEFECT degrades safe too, matching the fire-and-forget
- * swallow-with-log idiom of the bildirim emitters (`swallow`). The discarded cause
- * is now LOGGED (`logWarning`) before the default is returned, so a misconfigured
- * or unreachable Flagship binding is observable instead of silently absorbed
- * (#2685) — the safe-default behavior is unchanged, only the silence is removed.
- * A telemetry counter is deliberately out of scope here (it rides #1821).
+ * The single site of the safe-default contract. `catchCause`, not a typed `catch`, so a
+ * binding DEFECT degrades safe too; the discarded cause is logged so a misconfigured or
+ * unreachable Flagship binding is observable instead of silently absorbed.
  */
 const swallowToDefault = <A>(key: string, defaultValue: A) =>
 	Effect.catchCause((cause: Cause.Cause<unknown>) =>
@@ -91,12 +52,7 @@ const swallowToDefault = <A>(key: string, defaultValue: A) =>
 		),
 	);
 
-/**
- * Build the real {@link FlagsAccess} over a resolved `Flagship` client — the
- * per-isolate read surface, captured at layer build so each read's only
- * per-request requirement is the `FlagsContext` it reads at call time. Extracted
- * from the layer so `FlagsDevOverrideLive` can decorate the same surface (#622).
- */
+/** Extracted from the layer so `FlagsDevOverrideLive` can decorate the same surface. */
 const buildRealFlags = (flagship: Flagship["Service"]): FlagsAccess => ({
 	getBoolean: (key, defaultValue) =>
 		Effect.gen(function* () {
@@ -105,15 +61,9 @@ const buildRealFlags = (flagship: Flagship["Service"]): FlagsAccess => ({
 				.getBooleanValue(key, defaultValue, toEvaluationContext(context))
 				.pipe(swallowToDefault(key, defaultValue));
 		}).pipe(
-			// Worker-tier feature-flag error attribution (#1821, the worker half of the SPA
-			// contract PR #2843 established). Stamp the effective gate value as the Sentry tag
-			// `flag.<key>`:`on`/`off` so a flag's worker-side error rate is isolable in the #1822
-			// graduation query, uniformly with the client tier. This is THE per-request boolean
-			// resolution choke point every worker flag gate flows through, so an error in any
-			// flag-gated worker path is attributed — not just the `/api/flags/evaluate` delivery
-			// seam. The tag is the resolved value the request actually saw (including a
-			// degrade-safe default). Inert when Sentry has no active client (`tagFlag` gates on
-			// `Sentry.isEnabled()`); non-PII, orthogonal to the ADR 0118 `dataCollection` scrub.
+			// THE per-request boolean choke point, so stamping the resolved value as the Sentry tag
+			// `flag.<key>` attributes an error in ANY flag-gated worker path, not just the
+			// `/api/flags/evaluate` seam. Inert without an active Sentry client; non-PII.
 			Effect.tap((value) => Effect.sync(() => tagFlag(key, value))),
 		),
 	getString: (key, defaultValue) =>
@@ -139,11 +89,7 @@ const buildRealFlags = (flagship: Flagship["Service"]): FlagsAccess => ({
 		}),
 });
 
-/**
- * Resolved once per isolate from the init-bound `Flagship` client (the #507
- * seam). The client is captured at layer build, so `getBoolean`'s only
- * per-request requirement is the `FlagsContext` it reads at call time.
- */
+/** The client is captured at layer build, so a read's only per-request need is `FlagsContext`. */
 export const FlagsLive = Layer.effect(
 	Flags,
 	Effect.gen(function* () {
@@ -153,16 +99,9 @@ export const FlagsLive = Layer.effect(
 );
 
 /**
- * Decorate a real {@link FlagsAccess} with the dev-only local override (#622): a
- * boolean read whose key is present in the per-request `FlagsContext.overrides`
- * returns the forced value; every other read (and every typed/non-boolean read)
- * delegates unchanged to `inner`. Overrides are boolean-only — the local-flip
- * surface forces a dark-ship boolean on/off; typed variations stay on real eval.
- *
- * Pure decorator (no Layer) so the short-circuit is unit-testable over a stub
- * `FlagsAccess` without a binding. The wrapper this powers (`FlagsDevOverrideLive`)
- * is installed ONLY in development (`http/app.ts`); `inner.getBoolean` still reads
- * `FlagsContext`, so the decorated read's per-request requirement is unchanged.
+ * Dev-only local override: a boolean read whose key is present in `FlagsContext.overrides`
+ * returns the forced value; every other read delegates to `inner`. Overrides are
+ * boolean-only. A pure decorator (no Layer) so the short-circuit is unit-testable.
  */
 export const withDevOverrides = (inner: FlagsAccess): FlagsAccess => ({
 	...inner,
@@ -175,12 +114,9 @@ export const withDevOverrides = (inner: FlagsAccess): FlagsAccess => ({
 });
 
 /**
- * The dev-only override `Flags` layer (#622): `FlagsLive`'s surface decorated with
- * {@link withDevOverrides}. Built from the same init-bound `Flagship` client, so it
- * is a drop-in replacement for `FlagsLive` in the per-request set — `http/app.ts`
- * picks this layer instead of `FlagsLive` ONLY when `environment === "development"`.
- * In any deployed stage this layer is never built, so the override branch is
- * structurally absent from the prod flag path (the load-bearing #622 gate).
+ * `http/app.ts` picks this over `FlagsLive` ONLY when `environment === "development"`, so
+ * in any deployed stage the layer is never built and the override branch is structurally
+ * absent from the prod flag path.
  */
 export const FlagsDevOverrideLive = Layer.effect(
 	Flags,

--- a/apps/web/worker/features/flagship/Flags.unit.test.ts
+++ b/apps/web/worker/features/flagship/Flags.unit.test.ts
@@ -1,14 +1,4 @@
-/**
- * Unit coverage for the `Flags` domain service — the boolean dark-ship
- * primitive (#508). Drives `FlagsLive` over a stubbed `Flagship` client (no
- * binding, no I/O) and asserts the two load-bearing contracts:
- *
- *   - on/off branching: a flag returning true/false surfaces that value;
- *   - safe-default fallback: a `FlagshipError` from the client collapses to the
- *     supplied default, and the public `getBoolean` error channel is `never`;
- *   - observability (#2685): the swallowed cause is LOGGED at warn before the
- *     default is returned, so a misconfigured binding is no longer silent.
- */
+/** Drives `FlagsLive` over a stubbed `Flagship` client — no binding, no I/O. */
 import {assert, describe, it} from "@effect/vitest";
 import {type BaseRuntimeContext, RuntimeContext} from "alchemy";
 import {Flagship as CfFlagship} from "alchemy/Cloudflare";
@@ -17,8 +7,8 @@ import {Flags, type FlagsAccess, FlagsLive, withDevOverrides} from "./Flags.ts";
 import {anonymousFlagsContext, FlagsContext} from "./FlagsContext.ts";
 import {Flagship} from "./Flagship.ts";
 
-// `RuntimeContext` is the alchemy binding's intrinsic ambient requirement
-// (discharged at worker scope in production, #507); the stub satisfies it here.
+// `RuntimeContext` is the alchemy binding's ambient requirement, discharged at worker
+// scope in production; the stub satisfies it here.
 const runtimeContext: BaseRuntimeContext = {
 	Type: "test",
 	id: "test",
@@ -32,11 +22,9 @@ const unexercised = (method: string) => () =>
 	Effect.die(`Flagship.${method} not exercised in Flags.unit.test`);
 
 /**
- * Capture warn-level log lines into `lines` for the duration of `effect` (#2685):
- * a scoped {@link Logger.layer} whose logger pushes each warn message's head
- * string, so a test can assert the swallowed cause was actually logged rather than
- * silently absorbed. The head is the first `logWarning` argument (its message
- * template); the `Cause` argument is not serialized.
+ * Capture warn-level log lines, so a test can assert a swallowed cause was actually
+ * logged. Only the message head (the first `logWarning` argument) is captured — the
+ * `Cause` argument is not serialized.
  */
 const captureWarnings = <A, E, R>(
 	effect: Effect.Effect<A, E, R>,
@@ -55,11 +43,7 @@ const captureWarnings = <A, E, R>(
 		);
 	});
 
-/**
- * A `Flagship` stub whose `getBooleanValue` is supplied by the test; every other
- * method dies so an accidental call is loud. `boolean` reads either return a
- * value or fail with a `FlagshipError` (the misconfigured-binding signal).
- */
+/** Every method but `getBooleanValue` dies, so an accidental call is loud. */
 const stubFlagship = (
 	getBooleanValue: Flagship["Service"]["getBooleanValue"],
 ): Layer.Layer<Flagship> =>
@@ -107,7 +91,6 @@ describe("Flags.getBoolean", () => {
 	it.effect("a FlagshipError collapses to the supplied default (degrade safe)", () =>
 		Effect.gen(function* () {
 			const flags = yield* Flags;
-			// default `false` is the safe/off path; an eval error must fall back to it.
 			const enabled = yield* flags
 				.getBoolean("feature-erroring", false)
 				.pipe(Effect.provideService(FlagsContext, anonymousFlagsContext));
@@ -126,8 +109,6 @@ describe("Flags.getBoolean", () => {
 	it.effect("a FlagshipError is LOGGED at warn before the default is returned (#2685)", () =>
 		Effect.gen(function* () {
 			const flags = yield* Flags;
-			// The swallow must be OBSERVABLE: the default is still returned (degrade
-			// safe), AND a warn line naming the failing key was emitted — no longer silent.
 			const {value, warnings} = yield* captureWarnings(
 				flags
 					.getBoolean("feature-erroring", false)
@@ -186,11 +167,7 @@ describe("Flags.getBoolean", () => {
 const flagshipError = () =>
 	Effect.fail(new CfFlagship.FlagshipError({message: "binding unavailable", cause: undefined}));
 
-/**
- * The typed-read analog of `stubFlagship`: the boolean read dies (these suites
- * exercise only the typed surface) and the supplied typed reads override the
- * unexercised defaults. Each surfaces a value or fails with a `FlagshipError`.
- */
+/** The typed-read analog of `stubFlagship`: the boolean read dies here. */
 const stubTypedFlagship = (overrides: {
 	getStringValue?: Flagship["Service"]["getStringValue"];
 	getNumberValue?: Flagship["Service"]["getNumberValue"];
@@ -272,8 +249,7 @@ describe("Flags.getObject", () => {
 			assert.deepStrictEqual(value, {theme: "dark"});
 		}).pipe(
 			Effect.provide(
-				// `getObjectValue` is generic (`<T extends object>`), so the stub returns the
-				// evaluated object cast to the call-site `T` — the contract this read surfaces.
+				// `getObjectValue` is generic, so the stub must cast to the call-site `T`.
 				typedFlagsOver({
 					getObjectValue: <T extends object>() => Effect.succeed({theme: "dark"} as T),
 				}),
@@ -294,9 +270,8 @@ describe("Flags.getObject", () => {
 });
 
 /**
- * A real-`Flags` stand-in for the override decorator tests: a boolean read returns
- * its supplied default and typed reads return sentinels, so a passed-through read
- * is distinguishable from a short-circuited override.
+ * The typed reads return sentinels so a passed-through read is distinguishable from a
+ * short-circuited override.
  */
 const realFlagsStub: FlagsAccess = {
 	getBoolean: (_key, defaultValue) => Effect.succeed(defaultValue),
@@ -308,7 +283,6 @@ const realFlagsStub: FlagsAccess = {
 describe("withDevOverrides (#622)", () => {
 	it.effect("returns the forced-on override instead of the real read", () =>
 		Effect.gen(function* () {
-			// default is `false` (the safe path); the override forces it on.
 			const value = yield* withDevOverrides(realFlagsStub)
 				.getBoolean("flag-a", false)
 				.pipe(Effect.provideService(FlagsContext, {overrides: {"flag-a": true}}));
@@ -330,7 +304,6 @@ describe("withDevOverrides (#622)", () => {
 			const value = yield* withDevOverrides(realFlagsStub)
 				.getBoolean("flag-b", true)
 				.pipe(Effect.provideService(FlagsContext, {overrides: {"flag-a": false}}));
-			// no override for flag-b → the real stub answers with the supplied default
 			assert.strictEqual(value, true);
 		}).pipe(Effect.provide(RuntimeContextStub)),
 	);

--- a/apps/web/worker/features/flagship/FlagsContext.ts
+++ b/apps/web/worker/features/flagship/FlagsContext.ts
@@ -1,16 +1,10 @@
 /**
- * `FlagsContext` — the per-request flag evaluation context (epic #488, #508).
+ * `FlagsContext` — the per-request flag evaluation context, supplied per request
+ * alongside `Auth` (ADR 0029) rather than captured at isolate scope.
  *
- * Carries the request's identity for stable per-user bucketing, supplied per
- * request alongside `Auth` (ADR 0029) rather than captured at isolate scope —
- * the same identity an `Auth` session yields, lifted into flag evaluation so a
- * given user lands in a stable bucket across requests. Targeting/percentage
- * rules that consume it land in #511; this child supplies the seam.
- *
- * The domain shape (`userId`) is deliberately NOT alchemy's
- * `Flagship.EvaluationContext` — `toEvaluationContext` maps it at the boundary so
- * the provider's wire shape never leaks into the domain surface (the clean
- * OpenFeature seam, #506).
+ * The domain shape is deliberately NOT alchemy's `Flagship.EvaluationContext` —
+ * `toEvaluationContext` maps it at the boundary so the provider's wire shape never
+ * leaks into the domain surface. See [.patterns/feature-flags-targeting.md](../../../../../.patterns/feature-flags-targeting.md).
  */
 import {CurrentUser} from "@kampus/fate-effect";
 import type {Flagship} from "alchemy/Cloudflare";
@@ -18,36 +12,17 @@ import {Context, Effect} from "effect";
 import {AppConfig} from "../../config.ts";
 import {type FlagOverrides, parseOverrideCookie} from "./dev-override.ts";
 
-/** The domain-facing per-request evaluation context. */
 export interface FlagsContextValue {
 	/** Stable identity for per-user bucketing; absent for an anonymous request. */
 	readonly userId?: string;
-	/**
-	 * Roles the request's identity holds (e.g. `["internal", "beta"]`). Flattened
-	 * by `encodeRoles` into a pipe-framed wire string (`["internal"]` →
-	 * `"|internal|"`) and targeted with the `contains` operator against a framed
-	 * needle (`"|internal|"`) — see the `demoTargetingFlag` rule; absent or empty
-	 * for a request with no roles. The targeting taxonomy is in
-	 * [.patterns/feature-flags-targeting.md](../../../../../.patterns/feature-flags-targeting.md).
-	 */
 	readonly roles?: readonly string[];
-	/**
-	 * Deployment environment the request runs in (e.g. `"production"`,
-	 * `"development"`). Feeds environment-scoped targeting rules so one flag can
-	 * resolve differently per stage with no code change at the call-site. Sourced
-	 * from the `ENVIRONMENT` config var — the per-app deploy stage (ADR 0057) — by
-	 * {@link makeRequestFlagsContext}, never hand-passed (#512).
-	 */
+	/** Sourced from `ENVIRONMENT` by {@link makeRequestFlagsContext}, never hand-passed (#512). */
 	readonly environment?: string;
 	/**
-	 * Per-browser local flag overrides (#622), read from the request's
-	 * `phoenix_flag_overrides` cookie. Populated by the request path ONLY when the
-	 * request may honor overrides — `environment === "development"`, OR an admin
-	 * request (#2741, `overridesAuthorized`);
-	 * every other request leaves it `undefined` (fail-closed), so an attacker-supplied
-	 * cookie is a no-op for a non-admin on a deployed stage. Carried here — not mapped
-	 * into the provider wire shape (`toEvaluationContext` ignores it) — because it is a
-	 * local short-circuit, not a targeting attribute.
+	 * Per-browser local flag overrides (#622). Populated ONLY when the request may honor
+	 * them — `development`, or an admin request (#2741); every other request leaves it
+	 * `undefined` (fail-closed), so an attacker-supplied cookie is a no-op on a deployed
+	 * stage. Not a targeting attribute, so `toEvaluationContext` ignores it.
 	 */
 	readonly overrides?: FlagOverrides;
 }
@@ -57,20 +32,12 @@ export class FlagsContext extends Context.Service<FlagsContext, FlagsContextValu
 ) {}
 
 /**
- * The request's raw `Cookie` header, carried as a per-request service so a
- * flag-gated fate resolver's `provideRequestFlags` can source the dev-override
- * cookie (#622) the SAME way the flagship route does — the fate `/fate` route edge
- * has the raw request, a resolver deep in the tree does not. Fulfilled per request
- * from the session-bearing request in `fate/route.ts` (`requestServices`) and
- * declared to `FateServer.layer` (`layers.ts`), so — like `CurrentActor` — it is
- * excluded from build-time `R` and never provided by a worker-level layer.
+ * The request's raw `Cookie` header plus the per-request override-authorization verdict
+ * (#2741), carried as a service because the `/fate` route edge has the raw request and a
+ * resolver deep in the tree does not. Fulfilled per request in `fate/route.ts` and declared
+ * to `FateServer.layer`, so — like `CurrentActor` — it is excluded from build-time `R`.
  *
- * `cookieHeader` is `null` when the request carries no `Cookie` header.
- * `overridesAllowed` is the per-request authorization verdict (#2741) resolved once
- * at the `/fate` route edge by {@link overridesAuthorized} — `true` under
- * `development` or for an admin request. The service
- * grants no capability of its own: it merely transports the header + the verdict, and
- * {@link makeRequestFlagsContext} is the single site that decides (from both) whether
+ * Transport only: {@link makeRequestFlagsContext} is the single site that decides whether
  * to parse the cookie.
  */
 export class RequestFlagOverrides extends Context.Service<
@@ -78,30 +45,15 @@ export class RequestFlagOverrides extends Context.Service<
 	{readonly cookieHeader: string | null; readonly overridesAllowed: boolean}
 >()("@kampus/RequestFlagOverrides") {}
 
-/** The anonymous request context — no identity to bucket on. */
 export const anonymousFlagsContext: FlagsContextValue = {};
 
 /**
- * Build the per-request {@link FlagsContextValue}, sourcing the `environment`
- * attribute from the deploy stage rather than letting a call-site hand-pass it
- * (#512). The environment comes from `ENVIRONMENT` via `yield* AppConfig` — the
- * same per-app-stage signal (`alchemy deploy --stage <name>`, ADR 0057) the
- * health route reads — resolved off the `ConfigProvider` alchemy auto-wires at
- * worker scope. So a flag with an environment-targeting rule resolves per stage
- * (development vs production) with no code change at any call-site.
+ * `environment` always comes from the deploy stage (ADR 0057), never from a call-site
+ * (#512). Pass `anonymousFlagsContext` as `identity` for an unauthenticated request.
  *
- * `identity` carries the request's session-derived attributes (user id for
- * bucketing, roles for attribute targeting); pass `anonymousFlagsContext` for an
- * unauthenticated request. The environment is always populated from the stage —
- * it is a deploy-time fact about the request, not a per-user one.
- *
- * `cookieHeader` is the request's raw `Cookie` header (#622). Overrides are parsed
- * from it ONLY when `environment === "development"` OR `overridesAllowed` — the
- * latter the per-request admin verdict (#2741). The load-bearing fail-closed gate:
- * since `ENVIRONMENT` defaults to `"production"` (`config.ts`) and `overridesAllowed`
- * defaults `false`, a deployed non-admin request never reads the cookie, so
- * `overrides` stays `undefined` and an attacker-supplied `phoenix_flag_overrides`
- * cookie can never flip a flag in prod.
+ * Fail-closed gate: `ENVIRONMENT` defaults to `"production"` and `overridesAllowed` to
+ * `false`, so a deployed non-admin request never reads the override cookie and an
+ * attacker-supplied `phoenix_flag_overrides` can never flip a flag in prod.
  */
 export const makeRequestFlagsContext = (
 	identity: FlagsContextValue,
@@ -109,13 +61,10 @@ export const makeRequestFlagsContext = (
 	overridesAllowed = false,
 ) =>
 	Effect.gen(function* () {
-		// `orDie`: a `ConfigError` (value outside the two literals) is a malformed
-		// env, unrecoverable — match the health route's read of the same var.
+		// `orDie`: a `ConfigError` here means a malformed env, unrecoverable.
 		const {environment} = yield* AppConfig.pipe(Effect.orDie);
-		// THE GATE: overrides exist only under `development` (the #622 dev convenience)
-		// or for an authorized admin-on-prod request (#2741). Any other request drops the
-		// cookie entirely. An empty map (no cookie / a cleared one) is dropped too, so the
-		// context carries `overrides` only when there's an actual local flip to apply.
+		// THE GATE: overrides exist only under `development` (#622) or for an authorized
+		// admin-on-prod request (#2741). Any other request drops the cookie entirely.
 		const honorOverrides = environment === "development" || overridesAllowed;
 		const parsed = honorOverrides ? parseOverrideCookie(cookieHeader) : undefined;
 		const overrides = parsed && Object.keys(parsed).length > 0 ? parsed : undefined;
@@ -127,26 +76,16 @@ export const makeRequestFlagsContext = (
 	});
 
 /**
- * Provide the per-request {@link FlagsContext} to a flag-reading effect, sourcing
- * the identity from the request's `CurrentUser` (the same per-request session the
- * fate edge provides, ADR 0029) and the environment from the deploy stage. THE
- * ONE place flag bucketing is wired for fate resolvers: a flag-gated resolver
- * reads `flags.getBoolean(key, default)` directly and discharges the context with
- * a single `.pipe(provideRequestFlags)`, so a change to what the context carries
- * is an edit here, not at every gating site. Swaps the `FlagsContext` requirement
- * for `CurrentUser`, which gated resolvers already hold and which `FateServer.layer`
- * excludes from the layer R — so it never surfaces as a build-time requirement.
+ * THE ONE place flag bucketing is wired for fate resolvers, so a change to what the
+ * context carries is an edit here, not at every gating site. Swaps the `FlagsContext`
+ * requirement for `CurrentUser`, which `FateServer.layer` excludes from the layer `R`.
  */
 export const provideRequestFlags = <A, E, R>(
 	effect: Effect.Effect<A, E, R>,
 ): Effect.Effect<A, E, Exclude<R, FlagsContext> | CurrentUser | RequestFlagOverrides> =>
 	Effect.gen(function* () {
 		const {user} = yield* CurrentUser;
-		// The override cookie (#622) rides the per-request `RequestFlagOverrides` service,
-		// fulfilled at the `/fate` route edge — so a flag-gated resolver's override is
-		// honored on the mutation path, not only on the flagship route. `overridesAllowed`
-		// is the admin-on-prod verdict the edge resolved once (#2741); the gate itself
-		// lives in `makeRequestFlagsContext`, so this stays a thin pass-through.
+		// A thin pass-through — the gate itself lives in `makeRequestFlagsContext`.
 		const {cookieHeader, overridesAllowed} = yield* RequestFlagOverrides;
 		const context = yield* makeRequestFlagsContext(
 			user ? {userId: user.id} : anonymousFlagsContext,
@@ -157,27 +96,18 @@ export const provideRequestFlags = <A, E, R>(
 	});
 
 /**
- * Delimiter framing each role in the flattened `roles` wire attribute. The
- * leading+trailing pipes let a `contains "|internal|"` rule match a whole role
+ * The leading+trailing pipes let a `contains "|internal|"` rule match a whole role
  * without a substring false-positive (`"|internal|"` ⊄ `"|internal-admin|"`).
  */
 const ROLE_DELIMITER = "|";
 
-/** Frame a role list as a single `contains`-targetable wire string. */
 export const encodeRoles = (roles: readonly string[]): string =>
 	roles.length === 0 ? "" : `${ROLE_DELIMITER}${roles.join(ROLE_DELIMITER)}${ROLE_DELIMITER}`;
 
 /**
- * Map the domain context to the provider's evaluation-context wire shape. Kept
- * here, at the one boundary, so the alchemy/cf type stays out of the `Flags`
- * public surface — only `FlagsLive` calls it.
- *
- * `userId → targetingKey` is the consistent-hash bucketing key: the mapping is
- * deterministic, so a given `userId` always yields the same `targetingKey` and
- * thus the same percentage-rollout bucket across requests (no flicker). Role and
- * environment attributes feed attribute-targeting rules; the wire shape is a flat
- * `Record<string, string | number | boolean>` (no arrays), so a role list is
- * flattened to a single delimited `roles` string targeted with `contains`.
+ * Kept at this one boundary so the alchemy/cf type stays out of the `Flags` public
+ * surface. The wire shape admits no arrays, so a role list is flattened to a single
+ * delimited string targeted with `contains`.
  */
 export function toEvaluationContext(
 	context: FlagsContextValue,
@@ -187,7 +117,6 @@ export function toEvaluationContext(
 	if (context.roles !== undefined && context.roles.length > 0)
 		wire.roles = encodeRoles(context.roles);
 	if (context.environment !== undefined) wire.environment = context.environment;
-	// An empty context carries no targeting signal — match the prior `userId`-only
-	// contract and return undefined so the provider buckets anonymously.
+	// An empty context carries no targeting signal, so the provider buckets anonymously.
 	return Object.keys(wire).length === 0 ? undefined : wire;
 }

--- a/apps/web/worker/features/flagship/FlagsContext.unit.test.ts
+++ b/apps/web/worker/features/flagship/FlagsContext.unit.test.ts
@@ -1,11 +1,9 @@
 /**
- * Unit coverage for the environment / per-app-stage mapping (#512): the
- * per-request `FlagsContext` sources its `environment` attribute from the deploy
- * stage (`ENVIRONMENT` config / ADR 0057), and a flag with an environment rule
- * resolves per stage over the `Flags` service — degrading safe on error.
+ * Unit coverage for the environment / per-app-stage mapping (#512): the per-request
+ * `FlagsContext` sources its `environment` from the deploy stage (ADR 0057), and a
+ * flag with an environment rule resolves per stage — degrading safe on error.
  *
- * `makeRequestFlagsContext` reads `AppConfig` off the `ConfigProvider` alchemy
- * auto-wires at worker scope; here we mirror that with `ConfigProvider.fromUnknown`
+ * The worker-scope `ConfigProvider` is mirrored here with `ConfigProvider.fromUnknown`
  * over a fixed `ENVIRONMENT`, so the stage source is the thing under test.
  */
 import {assert, describe, it} from "@effect/vitest";
@@ -65,7 +63,6 @@ describe("makeRequestFlagsContext — environment sourced from the deploy stage"
 		Effect.gen(function* () {
 			const context = yield* makeRequestFlagsContext({userId: "u-1"});
 			assert.strictEqual(context.environment, "development");
-			// the supplied identity is preserved alongside the sourced environment
 			assert.strictEqual(context.userId, "u-1");
 		}).pipe(withStage("development")),
 	);
@@ -85,10 +82,9 @@ describe("makeRequestFlagsContext — environment sourced from the deploy stage"
 	);
 });
 
-// The load-bearing #622 gate: the override cookie is read into the context ONLY
-// under `development`. Any other stage (incl. the fail-closed `production`
-// default) drops it, so a hand-set cookie can never flip a flag in a deployed
-// stage — the override branch is unreachable there.
+// The load-bearing #622 gate: the override cookie is read into the context ONLY under
+// `development`. Any other stage (including the fail-closed `production` default) drops
+// it, so a hand-set cookie can never flip a flag in a deployed stage.
 describe("makeRequestFlagsContext — dev-only override gate (#622)", () => {
 	const overrideCookie = `${FLAG_OVERRIDE_COOKIE}=${encodeOverrideCookieValue({"flag-a": true})}`;
 
@@ -129,9 +125,8 @@ describe("makeRequestFlagsContext — dev-only override gate (#622)", () => {
 });
 
 describe("environment-targeting flag resolves per stage (no call-site change)", () => {
-	// One flag, one stub rule: ON only in development. The call-site is identical
-	// across stages — only the sourced `environment` differs, so the same flag
-	// resolves differently per stage with no code change.
+	// One flag, one stub rule: ON only in development. The call-site is identical across
+	// stages — only the sourced `environment` differs.
 	const devOnlyFlag = (_key: string, defaultValue: boolean, context?: {environment?: string}) =>
 		Effect.succeed(context?.environment === "development" ? true : defaultValue);
 
@@ -164,8 +159,8 @@ describe("environment-targeting degrades safe on error", () => {
 		Effect.gen(function* () {
 			const flags = yield* Flags;
 			const context = yield* makeRequestFlagsContext(anonymousFlagsContext);
-			// default `false` is the off/safe path; an eval error must fall back to it
-			// regardless of the environment attribute carried in the context.
+			// An eval error must fall back to the supplied default regardless of the
+			// environment attribute carried in the context.
 			const enabled = yield* flags
 				.getBoolean("dev-only-feature", false)
 				.pipe(Effect.provideService(FlagsContext, context));

--- a/apps/web/worker/features/flagship/FlagsTargeting.unit.test.ts
+++ b/apps/web/worker/features/flagship/FlagsTargeting.unit.test.ts
@@ -1,19 +1,7 @@
 /**
- * Unit coverage for targeting + percentage rollout (epic #488, #511). Two
- * layers are exercised without a binding or any I/O:
- *
- *   - `toEvaluationContext` — the domain→wire mapping: `userId → targetingKey`
- *     (the stable bucketing key), the role-list flattening, and `environment`.
- *   - `FlagsLive` over a stub `Flagship` whose `getBooleanValue` implements the
- *     real targeting/bucketing *semantics* (first-match rule, then a
- *     deterministic consistent-hash on `targetingKey`). This proves the three
- *     #511 contracts at the seam: a targeted user gets the variation and an
- *     untargeted one the default; a fixed `userId` lands in a STABLE bucket
- *     across repeated evaluations; and an eval error degrades to the safe default.
- *
- * The rule *configuration* (the live `FlagshipFlag` IaC) is system-tier and
- * declared in `resources.ts`; what's unit-testable — the bucketing stability
- * and the mapping/contract — is asserted here, per #511's TDD note.
+ * Targeting + percentage-rollout coverage, with no binding and no I/O. The rule
+ * *configuration* is system-tier and lives in `resources.ts`; what is unit-testable —
+ * the domain→wire mapping and the bucketing stability — is asserted here.
  */
 import {assert, describe, it} from "@effect/vitest";
 import {type BaseRuntimeContext, RuntimeContext} from "alchemy";
@@ -59,11 +47,9 @@ const flagsOver = (
 	Layer.mergeAll(FlagsLive.pipe(Layer.provide(stubFlagship(getBooleanValue))), RuntimeContextStub);
 
 /**
- * A deterministic stand-in for Flagship's evaluation engine: a first-match
- * targeting rule (internal role → on) followed by a consistent-hash percentage
- * rollout on `targetingKey`. Mirrors the `demoTargetingFlag` IaC config so the
- * test asserts the same semantics the live flag declares — no real hashing, just
- * a deterministic function of the bucketing key (the property that matters).
+ * A deterministic stand-in for Flagship's evaluation engine, mirroring the
+ * `demoTargetingFlag` IaC config. No real hashing — just a deterministic function of the
+ * bucketing key, which is the only property these tests turn on.
  */
 const INTERNAL_ROLE_MARKER = "|internal|";
 const fnv1a = (s: string): number => {
@@ -74,15 +60,13 @@ const fnv1a = (s: string): number => {
 	}
 	return h >>> 0;
 };
-/** Stable bucket in [0, 100) for a targeting key — pure function of the key. */
 const bucketOf = (targetingKey: string): number => fnv1a(targetingKey) % 100;
 
 const demoEval: Flagship["Service"]["getBooleanValue"] = (_key, defaultValue, context) => {
 	if (context === undefined) return Effect.succeed(defaultValue);
-	// rule 1: attribute targeting on the flattened role string.
 	if (typeof context.roles === "string" && context.roles.includes(INTERNAL_ROLE_MARKER))
 		return Effect.succeed(true);
-	// rule 2: 25% consistent-hash rollout on the (stable) bucketing key.
+	// 25% consistent-hash rollout on the bucketing key.
 	if (typeof context.targetingKey === "string" && bucketOf(context.targetingKey) < 25)
 		return Effect.succeed(true);
 	return Effect.succeed(defaultValue);
@@ -135,8 +119,7 @@ describe("Flags — attribute targeting (#511)", () => {
 	it.effect("an untargeted user with a non-rollout bucket gets the default", () =>
 		Effect.gen(function* () {
 			const flags = yield* Flags;
-			// pick a userId whose bucket is >= 25 (outside the rollout) and no role.
-			const outside = "user-2"; // bucketOf asserted below
+			const outside = "user-2";
 			assert.isAtLeast(bucketOf(outside), 25);
 			const enabled = yield* flags
 				.getBoolean("targeting-demo", false)
@@ -155,8 +138,7 @@ describe("Flags — percentage rollout, stable bucketing (#511)", () => {
 					.getBoolean("targeting-demo", false)
 					.pipe(Effect.provideService(FlagsContext, {userId: "u-repeat"}));
 			const first = yield* evalOnce();
-			// repeat many times — a stable bucket means an identical result every time
-			// (no flicker), which is the #511 anti-flicker contract.
+			// Identical result every time IS the anti-flicker contract.
 			for (let i = 0; i < 50; i++) {
 				const again = yield* evalOnce();
 				assert.strictEqual(again, first);

--- a/apps/web/worker/features/flagship/Flagship.ts
+++ b/apps/web/worker/features/flagship/Flagship.ts
@@ -1,12 +1,8 @@
 /**
- * `Flagship` service — the single seam holding the init-resolved
- * Effect-native `FlagshipClient` for the Cloudflare Flagship binding (epic #488).
- *
- * Mirrors `db/Database.ts`: the binding is resolved once per isolate via
- * `Cloudflare.Flagship.ReadFlags(Flagship)` (the init-phase alias, like
- * `Cloudflare.D1.QueryDatabase(PhoenixDb)`) and wrapped behind a Tag so the
- * runtime never re-binds per request. This child wires the binding only; the flag
- * Effect service that consumes the client lands in #508.
+ * `Flagship` service — the single seam holding the init-resolved Effect-native
+ * `FlagshipClient` for the Cloudflare Flagship binding. Mirrors `db/Database.ts`: the binding
+ * is resolved once per isolate and wrapped behind a Tag so the runtime never re-binds per
+ * request.
  */
 import * as Cloudflare from "alchemy/Cloudflare";
 import {Context, Effect, Layer} from "effect";
@@ -16,11 +12,8 @@ export class Flagship extends Context.Service<Flagship, Cloudflare.Flagship.Read
 	"@kampus/Flagship",
 ) {}
 
-/**
- * Resolved once and provided as a worker-level layer (the binding is stable for
- * the isolate's life). No finalizer: a Cloudflare binding is not a resource the
- * worker owns or closes.
- */
+// Resolved once and provided as a worker-level layer (the binding is stable for the
+// isolate's life). No finalizer: a Cloudflare binding is not a resource the worker closes.
 export const FlagshipLive = Layer.effect(
 	Flagship,
 	Effect.gen(function* () {

--- a/apps/web/worker/features/flagship/bildirim.invariant.test.ts
+++ b/apps/web/worker/features/flagship/bildirim.invariant.test.ts
@@ -1,8 +1,6 @@
 /**
- * The dark-ship default-=-safe-state invariant for the bildirim (notification
- * system) flag (#1694, epic #1666). Inspected off the exported `BILDIRIM_FLAG`
- * record (the same object the factory spreads into `FlagshipFlag`), so no alchemy
- * resource is constructed — mirrors `member-mute.invariant.test.ts`.
+ * The dark-ship default-is-the-safe-state invariant for the bildirim flag. Inspected
+ * off the exported flag record, so no alchemy resource is constructed.
  */
 import {assert, describe, it} from "@effect/vitest";
 import {PHOENIX_BILDIRIM} from "../../../src/flags/keys.ts";

--- a/apps/web/worker/features/flagship/dev-override.ts
+++ b/apps/web/worker/features/flagship/dev-override.ts
@@ -1,62 +1,39 @@
 /**
- * Dev-only flag-override store (#622) — the local-flip surface that lets a dev
- * exercise the flag-*on* path under offline `alchemy dev`, where the Flagship
- * binding doesn't resolve to a live evaluator and every read degrades to its
- * safe default.
+ * Dev-only flag-override store (#622) — a `phoenix_flag_overrides` cookie carrying
+ * a JSON `{key: boolean}` map, so a dev can exercise the flag-*on* path under
+ * offline `alchemy dev` where every read degrades to its safe default.
  *
- * The store is a `phoenix_flag_overrides` cookie carrying a JSON map of
- * `{key: boolean}` — the dev settings page (`route-dev.ts`) sets it; the dev-only
- * override `Flags` wrapper (`FlagsDevOverrideLive`, `Flags.ts`) reads the map off
- * the per-request `FlagsContext` and short-circuits a `getBoolean` read whose key
- * is present, otherwise delegating to the real `Flags`.
- *
- * **HARD INVARIANT (load-bearing, the #622 review's primary check):** this whole
- * surface is unreachable in any deployed stage. The wrapper is only installed and
- * the route only mounts when `environment === "development"` (`http/app.ts` /
- * `route-dev.ts`), gated on the same `ENVIRONMENT` config that fail-closes to
- * `"production"` (`config.ts`). This module is a pure cookie codec — it carries no
- * gate of its own; the gate lives at the two install sites and is the thing to
- * verify. Even so, an override only ever forces a flag *on or off locally*; it
- * never reaches Flagship or another request's state.
+ * **HARD INVARIANT:** this whole surface must stay unreachable in any deployed
+ * stage. This module is a pure cookie codec and carries NO gate of its own — the
+ * gate lives at the two install sites (`http/app.ts` / `route-dev.ts`, both on
+ * `environment === "development"`), which is the thing to verify.
  */
 
 import {DEMO_TARGETING_FLAG_KEY} from "./resources.ts";
 
-/** The cookie the dev override map travels in. Dev-only; never set in any deployed stage. */
 export const FLAG_OVERRIDE_COOKIE = "phoenix_flag_overrides";
 
-/** The per-request override map: a declared flag key forced to a local boolean value. */
 export type FlagOverrides = Readonly<Record<string, boolean>>;
 
-/** No overrides — the request carries no override cookie (or a malformed one). */
 export const emptyOverrides: FlagOverrides = {};
 
 /**
- * The boolean flags the dev settings page lists with on/off/clear toggles (#622).
- * The override surface is boolean-only (the dark-ship primitive), so the typed
- * `phoenix-flags-probe-variant`/percentage demos are out. A key here is just a flag
- * the dev wants to flip locally; an override key absent from this list still works
- * (the wrapper short-circuits any key), the list only seeds the UI.
+ * Seeds the dev settings page's toggles only — the wrapper short-circuits ANY key,
+ * so an override key absent from this list still works. Boolean-only, so the typed
+ * variant/percentage demo flags are out.
  */
 export const DEV_OVERRIDABLE_FLAGS: readonly string[] = [
 	DEMO_TARGETING_FLAG_KEY,
 	"phoenix-flags-probe",
 ];
 
-/** A flag's tri-state on the dev page: forced on, forced off, or no local override. */
 export type OverrideState = "on" | "off" | "clear";
 
-/** The override action a dev settings POST carries: force a key on/off, or clear it. */
 export interface OverrideAction {
 	readonly key: string;
 	readonly state: OverrideState;
 }
 
-/**
- * Apply one tri-state action to an override map: `on`/`off` set the key, `clear`
- * removes it. Pure — the new map is what `route-dev.ts` re-serializes into the
- * Set-Cookie value.
- */
 export function applyOverride(
 	overrides: FlagOverrides,
 	{key, state}: OverrideAction,
@@ -68,11 +45,7 @@ export function applyOverride(
 	return {...overrides, [key]: state === "on"};
 }
 
-/**
- * Parse a dev settings POST body (`application/x-www-form-urlencoded`: `key` +
- * `state`) into an {@link OverrideAction}, or `null` if malformed. The page POSTs a
- * single key/state pair per toggle; a bad body yields `null` and the route no-ops.
- */
+/** `null` on a malformed body, which the route treats as a no-op. */
 export function parseOverrideAction(form: URLSearchParams): OverrideAction | null {
 	const key = form.get("key");
 	const state = form.get("state");
@@ -82,11 +55,8 @@ export function parseOverrideAction(form: URLSearchParams): OverrideAction | nul
 }
 
 /**
- * Parse the `phoenix_flag_overrides` value out of a raw `Cookie` header. Returns
- * `{}` for an absent header or absent cookie — the no-override case. Untrusted
- * input: anything that isn't a well-formed `{[key]: boolean}` JSON object yields
- * `{}`, so a malformed cookie degrades to "no override" (the real `Flags` answers)
- * rather than throwing.
+ * Untrusted input: anything that isn't a well-formed `{[key]: boolean}` JSON object
+ * yields `{}`, so a malformed cookie degrades to "no override" rather than throwing.
  */
 export function parseOverrideCookie(cookieHeader: string | null | undefined): FlagOverrides {
 	if (!cookieHeader) return emptyOverrides;
@@ -95,7 +65,6 @@ export function parseOverrideCookie(cookieHeader: string | null | undefined): Fl
 	return decodeOverrides(raw);
 }
 
-/** Pull one cookie's raw value out of a `name=value; name2=value2` header. */
 function readCookieValue(cookieHeader: string, name: string): string | undefined {
 	for (const part of cookieHeader.split(";")) {
 		const eq = part.indexOf("=");
@@ -105,7 +74,6 @@ function readCookieValue(cookieHeader: string, name: string): string | undefined
 	return undefined;
 }
 
-/** Decode a URL-encoded JSON override map, keeping only boolean-valued entries. */
 function decodeOverrides(raw: string): FlagOverrides {
 	let parsed: unknown;
 	try {
@@ -121,7 +89,6 @@ function decodeOverrides(raw: string): FlagOverrides {
 	return out;
 }
 
-/** Serialize an override map to the cookie's URL-encoded JSON value (no attributes). */
 export function encodeOverrideCookieValue(overrides: FlagOverrides): string {
 	return encodeURIComponent(JSON.stringify(overrides));
 }

--- a/apps/web/worker/features/flagship/dev-override.unit.test.ts
+++ b/apps/web/worker/features/flagship/dev-override.unit.test.ts
@@ -1,11 +1,6 @@
 /**
- * Unit coverage for the dev-only flag-override codec (#622) — the pure cookie
- * parse/serialize + tri-state apply that the dev settings route and the override
- * `Flags` wrapper rest on. No worker, no binding, no DOM: just the codec contract.
- *
- * The codec carries NO environment gate (that lives at the two install sites,
- * `makeRequestFlagsContext` + `http/app.ts`); these tests cover the parse/apply
- * surface, the malformed-input degrade-safe behavior, and the round-trip.
+ * The dev-only flag-override codec (#622). The codec itself carries NO environment gate —
+ * that lives at the two install sites, `makeRequestFlagsContext` + `http/app.ts`.
  */
 import {describe, expect, it} from "vitest";
 import {

--- a/apps/web/worker/features/flagship/email-delivery-admin.invariant.test.ts
+++ b/apps/web/worker/features/flagship/email-delivery-admin.invariant.test.ts
@@ -1,8 +1,7 @@
 /**
- * The dark-ship default-=-safe-state invariant for the admin email-delivery
- * (failing-address) surface (#2692, epic #2687). Inspected off the exported
- * `EMAIL_DELIVERY_ADMIN_FLAG` record (the same object the factory spreads into
- * `FlagshipFlag`), so no alchemy resource is constructed — mirrors `mod-queue.invariant.test.ts`.
+ * The dark-ship default-is-the-safe-state invariant for the admin email-delivery
+ * surface. Inspected off the exported flag record, the same object the factory spreads
+ * into `FlagshipFlag`, so no alchemy resource is constructed.
  */
 import {assert, describe, it} from "@effect/vitest";
 import {PHOENIX_EMAIL_DELIVERY_ADMIN} from "../../../src/flags/keys.ts";

--- a/apps/web/worker/features/flagship/email-delivery-notice.invariant.test.ts
+++ b/apps/web/worker/features/flagship/email-delivery-notice.invariant.test.ts
@@ -1,8 +1,6 @@
 /**
  * The dark-ship default-=-safe-state invariant for the failing-email membrane notice
- * (#2693, epic #2687). Inspected off the exported `EMAIL_DELIVERY_NOTICE_FLAG` record
- * (the same object the factory spreads into `FlagshipFlag`), so no alchemy resource is
- * constructed — mirrors `email-delivery-admin.invariant.test.ts`.
+ * (#2693). Inspected off the exported record, so no alchemy resource is constructed.
  */
 import {assert, describe, it} from "@effect/vitest";
 import {PHOENIX_EMAIL_DELIVERY_NOTICE} from "../../../src/flags/keys.ts";

--- a/apps/web/worker/features/flagship/evaluate-contract.ts
+++ b/apps/web/worker/features/flagship/evaluate-contract.ts
@@ -1,39 +1,26 @@
 /**
- * The wire contract for `POST /api/flags/evaluate` (epic #488, #510) — the SPA's
- * flag-delivery seam. The client names the flags it needs as `{key, default}`
- * pairs; the Worker returns the server-evaluated boolean for each. Both halves of
- * the parse/project edge live here as pure functions so they're unit-testable
- * without a worker (server side) or a DOM (client side), mirroring the
- * `toProfileStatsState` idiom (`src/pages/useProfileStats.ts`).
+ * The wire contract for `POST /api/flags/evaluate`. Both halves of the parse/project
+ * edge live here as pure functions so they are unit-testable without a worker or a DOM.
  *
- * The default rides the request and is the safe path on every failure: a
- * malformed request collapses to zero keys, and a key missing from the response
- * resolves to its default ({@link resolveFlag}) — so a bad request or a flaky
- * server leaves the client at its defaults, never crashes it.
+ * The default rides the request and is the safe path on every failure: a malformed
+ * request collapses to zero keys, and a missing key resolves to its default — so a bad
+ * request or a flaky server leaves the client at its defaults, never crashes it.
  */
 
-/** One requested flag: the key to evaluate and its safe-default fallback. */
 export interface FlagRequest {
 	readonly key: string;
 	readonly default: boolean;
 }
 
-/** The evaluate request body the client sends. */
 export interface FlagEvaluateRequest {
 	readonly keys: ReadonlyArray<FlagRequest>;
 }
 
-/** The evaluate response body: each requested key mapped to its server value. */
 export interface FlagEvaluateResult {
 	readonly flags: Record<string, boolean>;
 }
 
-/**
- * Parse an untrusted request body into the requested flag keys, dropping any
- * malformed entry. Anything that isn't a well-formed `{keys: [{key, default}]}`
- * yields `[]` — the server then returns `{flags:{}}` and the client stays at its
- * defaults, so a bad request degrades safe rather than 500ing.
- */
+/** Anything not well-formed yields `[]`, so a bad request degrades safe rather than 500ing. */
 export function parseFlagEvaluateRequest(body: unknown): ReadonlyArray<FlagRequest> {
 	if (typeof body !== "object" || body === null) return [];
 	const keys = (body as {keys?: unknown}).keys;
@@ -47,12 +34,8 @@ export function parseFlagEvaluateRequest(body: unknown): ReadonlyArray<FlagReque
 }
 
 /**
- * Resolve one flag's value from a server response, falling back to `defaultValue`
- * when the response didn't return the key or returned a non-boolean. The input is
- * `unknown` on purpose — it is parsed from untrusted JSON (`res.json()`), so the
- * structural guard here, not a cast at the call site, is what enforces the
- * client's safe-default guarantee: until the server says otherwise — and only
- * with a genuine boolean — the default holds.
+ * The input is `unknown` on purpose — it comes from untrusted JSON, so the structural
+ * guard here, not a cast at the call site, is what enforces the safe-default guarantee.
  */
 export function resolveFlag(result: unknown, key: string, defaultValue: boolean): boolean {
 	if (typeof result !== "object" || result === null) return defaultValue;

--- a/apps/web/worker/features/flagship/evaluate-contract.unit.test.ts
+++ b/apps/web/worker/features/flagship/evaluate-contract.unit.test.ts
@@ -1,25 +1,16 @@
 /**
- * The pure parse/project edge of the `/api/flags/evaluate` contract (#510). Both
- * halves are unit-tested without a worker or a DOM — the same testable-pure-core
- * idiom as `toProfileStatsState` (`src/pages/useProfileStats.test.ts`).
- *
- * `resolveFlag` is the gated-path-vs-default-path decision the React hook and
- * `FlagGate` both route through: a server `true` yields the gated value, and
- * every safe-default case (missing key / null response / non-boolean) yields the
- * caller's default — exactly AC #4's "gated path on a true/non-default value, the
- * default path otherwise."
+ * The pure parse/project edge of the `/api/flags/evaluate` contract (#510), unit-tested
+ * without a worker or a DOM.
  */
 import {describe, expect, it} from "vitest";
 import {parseFlagEvaluateRequest, resolveFlag} from "./evaluate-contract.ts";
 
 describe("resolveFlag", () => {
 	it("returns the server value when it is true — the gated path on a non-default value", () => {
-		// Default is false (off); the server evaluated the flag on, so the gated path wins.
 		expect(resolveFlag({flags: {"new-ui": true}}, "new-ui", false)).toBe(true);
 	});
 
 	it("returns the server value when it differs from a true default", () => {
-		// Default true, server says false — the server value still wins over the default.
 		expect(resolveFlag({flags: {"kill-switch": false}}, "kill-switch", true)).toBe(false);
 	});
 
@@ -33,8 +24,7 @@ describe("resolveFlag", () => {
 	});
 
 	it("falls back to the default when the server value is not a boolean", () => {
-		// `resolveFlag` takes untrusted JSON (`unknown`), so a runtime-malformed
-		// value needs no cast — the structural guard must reject the non-boolean.
+		// `resolveFlag` takes untrusted JSON, so the structural guard must reject this.
 		expect(resolveFlag({flags: {"new-ui": "yes"}}, "new-ui", false)).toBe(false);
 	});
 });

--- a/apps/web/worker/features/flagship/flag-tag.ts
+++ b/apps/web/worker/features/flagship/flag-tag.ts
@@ -1,26 +1,16 @@
 /**
- * The Sentry feature-flag attribution contract (#1821), shared verbatim by BOTH tiers. A
- * flag a request/session resolves becomes the Sentry tag `flag.<key>` with value
- * `"on"`/`"off"`, so a single flag's on-path error rate is isolable for the
- * dark→release→burn-in→graduate gate the flag lifecycle depends on (#1822 consumes this):
- * the graduation query is `flag.<key>:on` — e.g. `flag.phoenix-bildirim:on` counts errors
- * captured while `phoenix-bildirim` was on, and `flag.<key>:off` the comparison off-path.
+ * The Sentry feature-flag attribution contract (#1821): a resolved flag becomes the tag
+ * `flag.<key>` = `"on"`/`"off"`, which is what makes the graduation query
+ * `flag.<key>:on` isolate a single flag's on-path error rate (#1822).
  *
- * SDK-free on purpose. This pure naming contract is imported by the SPA tagger
- * (`src/lib/sentry.ts`, `@sentry/react`) AND the worker tagger (`worker/lib/sentry.ts`,
- * `@sentry/cloudflare`), so both tiers stamp an IDENTICAL `flag.<key>`:`on`/`off` shape and
- * the #1822 graduation query reads uniformly across client and worker — one definition, no
- * drift. Keys are the `flags/keys.ts` constants (non-PII), so tagging is orthogonal to the
- * ADR 0118 `dataCollection` PII scrub and touches none of it.
+ * SDK-free on purpose — both the SPA tagger and the worker tagger import this one
+ * definition, so the two tiers cannot drift into different tag shapes. Keys are the
+ * non-PII `flags/keys.ts` constants, so this is orthogonal to the ADR 0118 PII scrub.
  */
 
-/** The tag-key namespace: a resolved flag `key` maps to `flag.<key>`. */
 export const FLAG_TAG_PREFIX = "flag.";
 
-/**
- * The `(tagKey, tagValue)` a resolved flag maps to — pure, so the shared tag-naming contract
- * is unit-testable without either Sentry SDK and both tiers provably agree on the shape.
- */
+// Pure, so the naming contract is unit-testable without either Sentry SDK.
 export function flagTag(key: string, value: boolean): {tagKey: string; tagValue: "on" | "off"} {
 	return {tagKey: `${FLAG_TAG_PREFIX}${key}`, tagValue: value ? "on" : "off"};
 }

--- a/apps/web/worker/features/flagship/flag-tag.unit.test.ts
+++ b/apps/web/worker/features/flagship/flag-tag.unit.test.ts
@@ -1,8 +1,7 @@
 /**
- * Pins the shared Sentry flag-attribution naming contract (#1821): a resolved flag maps to
- * `flag.<key>` = `on`/`off`, so the #1822 graduation query is `flag.<key>:on`. One definition
- * feeds both the SPA tagger (`src/lib/sentry.ts`) and the worker tagger (`worker/lib/sentry.ts`),
- * so this is the single place the shape is proven — both tiers inherit it and cannot drift.
+ * Pins the Sentry flag-attribution naming contract: `flag.<key>` = `on`/`off`, so the
+ * graduation query is `flag.<key>:on`. One definition feeds both the SPA and worker
+ * taggers, so proving it here is what stops the two drifting.
  */
 import {describe, expect, it} from "vitest";
 import {FLAG_TAG_PREFIX, flagTag} from "./flag-tag.ts";

--- a/apps/web/worker/features/flagship/karma-gates.invariant.test.ts
+++ b/apps/web/worker/features/flagship/karma-gates.invariant.test.ts
@@ -1,8 +1,7 @@
 /**
- * The dark-ship default-=-safe-state invariant for the karma-gated privileges
- * feature (#150, künye epic #41). Inspected off the exported `KARMA_GATES_FLAG`
- * record (the same object the factory spreads into `FlagshipFlag`), so no alchemy
- * resource is constructed — mirrors `reactions.invariant.test.ts` (#1863).
+ * The dark-ship default-is-the-safe-state invariant for the karma-gated privileges
+ * feature (#150). Inspected off the exported record rather than the factory, so no
+ * alchemy resource is constructed.
  */
 import {assert, describe, it} from "@effect/vitest";
 import {PHOENIX_KARMA_GATES} from "../../../src/flags/keys.ts";

--- a/apps/web/worker/features/flagship/mecmua-feed.invariant.test.ts
+++ b/apps/web/worker/features/flagship/mecmua-feed.invariant.test.ts
@@ -1,8 +1,7 @@
 /**
- * The dark-ship default-=-safe-state invariant for the mecmua subscribed-author feed
- * flag (#2500, epic #2467). Inspected off the exported `MECMUA_FEED_FLAG` record (the
- * same object the factory spreads into `FlagshipFlag`), so no alchemy resource is
- * constructed — mirrors `mecmua-write.invariant.test.ts`.
+ * The dark-ship default-is-the-safe-state invariant for the mecmua subscribed-author
+ * feed flag. Inspected off the exported flag record, the same object the factory
+ * spreads into `FlagshipFlag`, so no alchemy resource is constructed.
  */
 import {assert, describe, it} from "@effect/vitest";
 import {MECMUA_FEED} from "../../../src/flags/keys.ts";

--- a/apps/web/worker/features/flagship/mecmua-public-read.invariant.test.ts
+++ b/apps/web/worker/features/flagship/mecmua-public-read.invariant.test.ts
@@ -1,8 +1,6 @@
 /**
- * The dark-ship default-=-safe-state invariant for mecmua public read (#2498, epic
- * #2467). Inspected off the exported `MECMUA_PUBLIC_READ_FLAG` record (the same object
- * the factory spreads into `FlagshipFlag`), so no alchemy resource is constructed —
- * mirrors `funnel-readout.invariant.test.ts` (#1589).
+ * The dark-ship default-is-the-safe-state invariant for mecmua public read (#2498).
+ * Inspected off the exported record, so no alchemy resource is constructed.
  */
 import {assert, describe, it} from "@effect/vitest";
 import {MECMUA_PUBLIC_READ} from "../../../src/flags/keys.ts";

--- a/apps/web/worker/features/flagship/member-mute.invariant.test.ts
+++ b/apps/web/worker/features/flagship/member-mute.invariant.test.ts
@@ -1,8 +1,7 @@
 /**
- * The dark-ship default-=-safe-state invariant for the member-mute (sustur) flag
- * (#3112, epic #2035). Inspected off the exported `MEMBER_MUTE_FLAG` record (the same
- * object the factory spreads into `FlagshipFlag`), so no alchemy resource is
- * constructed — mirrors `mecmua-write.invariant.test.ts`.
+ * The dark-ship default-is-the-safe-state invariant for the member-mute (sustur) flag
+ * (#3112). Inspected off the exported record the factory spreads into `FlagshipFlag`, so
+ * no alchemy resource is constructed.
  */
 import {assert, describe, it} from "@effect/vitest";
 import {MEMBER_MUTE} from "../../../src/flags/keys.ts";

--- a/apps/web/worker/features/flagship/override-authz.ts
+++ b/apps/web/worker/features/flagship/override-authz.ts
@@ -1,22 +1,12 @@
 /**
- * `overridesAuthorized` — may THIS request honor its per-browser
- * `phoenix_flag_overrides` cookie (#622)? The per-request gate that un-gates the
- * local-override read-wrapper to production for an admin (#2741, epic #2711),
- * replacing #622's isolate-wide `environment === "development"` install gate.
+ * `overridesAuthorized` — may THIS request honor its per-browser `phoenix_flag_overrides`
+ * cookie? `true` iff `environment === "development"` or the request actor holds platform
+ * {@link Admin} authority.
  *
- * `true` iff either:
- *   - `environment === "development"` — the #622 local-dev convenience, unchanged; OR
- *   - the request actor holds platform {@link Admin} authority.
- *
- * Fail-safe by construction: a non-admin (the invisible `Denied` from `Admin.over`) and
- * an anonymous request both resolve `false`, so `makeRequestFlagsContext` drops the cookie
- * and the override wrapper no-ops — byte-identical to a plain `FlagsLive` read. The
- * verdict is derived ONLY from the environment and the actor's stored platform-admin
- * relation, never from anything the request carries, so an attacker-supplied cookie can
- * never self-authorize the gate (the load-bearing #622 / `FlagsContext.ts` invariant).
- * The admin-console dark-ship flag that once ANDed into the admin arm was retired at 100%
- * rollout (#3671) — it was a rollout gate on top of the admin check, never the
- * authorization itself.
+ * Fail-safe by construction: a non-admin and an anonymous request both resolve `false`, so
+ * the cookie is dropped and the override wrapper no-ops. The verdict is derived ONLY from
+ * the environment and the actor's stored platform-admin relation, never from anything the
+ * request carries, so an attacker-supplied cookie can never self-authorize the gate.
  */
 import {Effect} from "effect";
 import {Admin, platform} from "../kunye/admin.ts";

--- a/apps/web/worker/features/flagship/override-authz.unit.test.ts
+++ b/apps/web/worker/features/flagship/override-authz.unit.test.ts
@@ -1,18 +1,11 @@
 /**
  * `overridesAuthorized` — the per-request gate that un-gates the #622 local-override
- * read-wrapper to production for an admin (#2741, epic #2711). Proven here with NO
- * binding / NO I/O: a `CurrentActor` stub and a `RelationStore` stub whose `has` fixes the
- * `(actor, "admin", platform)` verdict `Admin.over` reads.
+ * wrapper to production for an admin (#2741). Proven with NO binding and NO I/O.
  *
- * The truth table the load-bearing prod fail-closed invariant rests on:
- *   - `development` — always authorized (the #622 dev convenience, unchanged).
- *   - prod, admin     — authorized (the admin-on-prod path).
- *   - prod, non-admin — NOT authorized (an attacker cookie stays inert).
- *   - prod, anonymous — NOT authorized (`Admin.over` denies the anon arm).
- *
- * The second block proves the verdict is consumed: `makeRequestFlagsContext` populates
- * `overrides` from the cookie ONLY when the verdict is `true` — so on prod a non-admin's
- * `phoenix_flag_overrides` cookie yields no overrides at all.
+ * The prod fail-closed invariant: development is always authorized; on production only
+ * an admin is, so a non-admin's or an anonymous visitor's `phoenix_flag_overrides`
+ * cookie stays inert. The second block proves the verdict is actually consumed by
+ * `makeRequestFlagsContext`.
  */
 import {assert, describe, it} from "@effect/vitest";
 import {

--- a/apps/web/worker/features/flagship/pano-stamp-wave.invariant.test.ts
+++ b/apps/web/worker/features/flagship/pano-stamp-wave.invariant.test.ts
@@ -1,12 +1,9 @@
 /**
- * The dark-ship default-=-safe-state invariant for the pano parallel-stamp-wave read
- * collapse (#2710, epic #2567). Inspected off the exported `PANO_STAMP_WAVE_FLAG` record
- * (the same object the factory spreads into `FlagshipFlag`), so no alchemy resource is
- * constructed — mirrors `sozluk-stamp-wave.invariant.test.ts`.
+ * The dark-ship default-is-the-safe-state invariant for the pano stamp-wave collapse
+ * (#2710). Inspected off the exported record, so no alchemy resource is constructed.
  *
- * Load-bearing: with the default OFF the pano thread/comment reads run their stamp wave at
- * `concurrency: 1` (serial, byte-for-byte today) — so the containment is real, the
- * concurrent wave only reachable after a human flips the flag.
+ * Load-bearing: with the default OFF the reads stay serial and byte-for-byte as today,
+ * so the concurrent wave is only reachable after a human flips the flag.
  */
 import {assert, describe, it} from "@effect/vitest";
 import {PHOENIX_PANO_STAMP_WAVE} from "../../../src/flags/keys.ts";

--- a/apps/web/worker/features/flagship/profile-canvas.invariant.test.ts
+++ b/apps/web/worker/features/flagship/profile-canvas.invariant.test.ts
@@ -1,9 +1,7 @@
 /**
- * The dark-ship default-=-safe-state invariant for the profile free-paint canvas (duvar)
- * flag (#3103, epic #2035). Inspected off the exported `PROFILE_CANVAS_FLAG` record (the
- * same object the factory spreads into `FlagshipFlag`), so no alchemy resource is
- * constructed — mirrors `member-mute.invariant.test.ts` (#3112). Off ⇒ the profile is
- * exactly as today (no canvas surface, owner-only mutations denied).
+ * The dark-ship default-is-the-safe-state invariant for the profile canvas flag (#3103).
+ * Inspected off the exported record the factory spreads into `FlagshipFlag`, so no
+ * alchemy resource is constructed.
  */
 import {assert, describe, it} from "@effect/vitest";
 import {PROFILE_CANVAS} from "../../../src/flags/keys.ts";

--- a/apps/web/worker/features/flagship/reactions.invariant.test.ts
+++ b/apps/web/worker/features/flagship/reactions.invariant.test.ts
@@ -1,8 +1,6 @@
 /**
- * The dark-ship default-=-safe-state invariant for the reactions (emoji tepki)
- * feature (#1863, epic #1840). Inspected off the exported `REACTIONS_FLAG` record
- * (the same object the factory spreads into `FlagshipFlag`), so no alchemy resource
- * is constructed — mirrors `mod-queue.invariant.test.ts` (#1701).
+ * The dark-ship default-is-safe-state invariant for reactions. Inspected off the exported
+ * `REACTIONS_FLAG` record, so no alchemy resource is constructed.
  */
 import {assert, describe, it} from "@effect/vitest";
 import {PHOENIX_REACTIONS} from "../../../src/flags/keys.ts";

--- a/apps/web/worker/features/flagship/request-flags-context.ts
+++ b/apps/web/worker/features/flagship/request-flags-context.ts
@@ -1,11 +1,8 @@
 /**
- * The per-request {@link FlagsContext} resolution shared by `/api/flags/evaluate`
- * (`route.ts`) and the edge `window.__BOOT__` injection (`shell-boot-route.ts`) — the
- * ONE override-authz seam (#2741) both consume, so an admin with an authorized
- * `phoenix_flag_overrides` cookie gets IDENTICAL
- * flag values from the API and in `__BOOT__` (ADR 0179 AC2; the #2984 parity fix). A single
- * function makes the two consumers structurally unable to drift on the third
- * `makeRequestFlagsContext` override-authz arg (the divergence #2984 caught).
+ * The per-request {@link FlagsContext} resolution shared by `/api/flags/evaluate` and the
+ * edge `window.__BOOT__` injection — the ONE override-authz seam both consume, so an admin
+ * with an authorized `phoenix_flag_overrides` cookie gets IDENTICAL flag values from either
+ * path (ADR 0179 AC2). One function makes the two consumers unable to drift.
  */
 import type {CurrentUserInfo} from "@kampus/fate-effect";
 import {Effect} from "effect";
@@ -18,9 +15,9 @@ import {
 import {overridesAuthorized} from "./override-authz.ts";
 
 /**
- * The session shape both routes carry from `pasaport.validateSession`. `user` is typed to
- * {@link CurrentUserInfo} — the structural subset {@link currentActorContext} reads — so the
- * real `Session` (a superset) is assignable and a test can build one without a full session.
+ * `user` is typed to {@link CurrentUserInfo} — the structural subset
+ * {@link currentActorContext} reads — so the real `Session` (a superset) is assignable and a
+ * test can build one without a full session.
  */
 export type FlagsSession = {readonly user: CurrentUserInfo} | null;
 
@@ -29,11 +26,9 @@ export const contextFromSession = (session: FlagsSession): FlagsContextValue =>
 	session ? {userId: session.user.id} : anonymousFlagsContext;
 
 /**
- * Resolve the per-request context WITH the #2741 override-authz verdict: discharge
- * platform-admin authority from the session actor against the caller's BASELINE (no-cookie)
- * context, then
- * pass the verdict as the third `makeRequestFlagsContext` arg — so an authorized admin's
- * `phoenix_flag_overrides` cookie is honored and any other request's cookie stays inert.
+ * Discharges platform-admin authority against the caller's BASELINE (no-cookie) context,
+ * then passes the verdict on — so an authorized admin's cookie is honored and any other
+ * request's cookie stays inert.
  */
 export const resolveRequestFlagsContext = (session: FlagsSession, cookieHeader: string | null) =>
 	Effect.gen(function* () {

--- a/apps/web/worker/features/flagship/resources.ts
+++ b/apps/web/worker/features/flagship/resources.ts
@@ -1,12 +1,8 @@
 /**
- * The Flagship flag-IaC surface — the `Flagship` app and every flag declaration,
- * homed beside their evaluator (`Flags.ts`/`Flagship.ts`) instead of in
- * `db/resources.ts` (ADR 0081, epic #488). The alchemy stack (`alchemy.run.ts`)
- * `bind()`s the app and yields the flag factories; the worker `bind()`s the app
- * in init. Declared in-stack (not on the Flagship dashboard) so each rule is
- * reproducible and reviewable — see
- * [.patterns/feature-flags-targeting.md](../../../../../.patterns/feature-flags-targeting.md)
- * for which flags are IaC vs dashboard-managed and the sanctioned rule taxonomy.
+ * The Flagship flag-IaC surface — the `Flagship` app and every flag declaration (ADR 0081).
+ * Flags are declared in-stack, not on the dashboard; which flags are IaC vs dashboard-managed
+ * and the sanctioned rule taxonomy live in
+ * [.patterns/feature-flags-targeting.md](../../../../../.patterns/feature-flags-targeting.md).
  */
 import type {Input} from "alchemy";
 import * as Cloudflare from "alchemy/Cloudflare";
@@ -28,29 +24,15 @@ import {
 	PROFILE_CANVAS,
 } from "../../../src/flags/keys.ts";
 
-/**
- * The Cloudflare Flagship app — the container the worker's feature flags live in
- * (epic #488). Alchemy provisions it on deploy and assigns the `appId`; there is
- * no dashboard step. The worker `bind()`s it in init (see `Flagship.ts`) to
- * resolve a typed Effect-native `FlagshipClient`.
- */
 export const Flagship = Cloudflare.Flagship.App("phoenix_flags", {});
 
 /**
- * The IaC-declared demo flag for targeting + percentage rollout (epic #488,
- * #511).
+ * Rules evaluate in ascending `priority`, first match wins: the `internal` role gets `on`
+ * outright, then 25% of the rest by consistent hash on `targetingKey`.
  *
- * Two rules, evaluated in ascending `priority` (first match wins):
- *   1. an attribute-targeting rule — any request whose `roles` carries the
- *      `internal` role gets `on` outright (the named-subset release);
- *   2. a consistent-hash percentage rollout — 25% of the remaining users, bucketed
- *      stably on `targetingKey` (the request's `userId`), get `on`.
- * Everyone else falls through to `defaultVariation: "off"`.
- *
- * `appId` is the app's server-generated id, available only once the app resource
- * is yielded in the stack — hence a factory the stack calls with `app.appId`
- * (an alchemy `Input<string>`/`Output`, resolved at deploy), not a module-scope
- * constant (the app attribute isn't resolved at import).
+ * A factory, not a module constant: `appId` is an alchemy `Input`/`Output` resolved at deploy,
+ * so it only exists once the stack has yielded the app resource. Every flag factory below is a
+ * factory for this same reason.
  */
 export const DEMO_TARGETING_FLAG_KEY = "phoenix-flags-targeting-demo";
 export const DEMO_TARGETING_INTERNAL_ROLE = "internal";
@@ -87,21 +69,10 @@ export const demoTargetingFlag = (appId: Input<string>) =>
 export {PHOENIX_BILDIRIM, PHOENIX_KARMA_GATES};
 
 /**
- * The mecmua write-path dark-ship flag config (#2497, epic #2467). The SINGLE seam
- * the mecmua write surface gates behind — `mecmua.publish` + `mecmua.saveDraft` fail
- * `MECMUA_DISABLED` with it off, so the write path reaches production dark; flipping
- * it on is the human release act (ADR 0083).
- *
- * Exported as a plain object so the default-=-safe-state invariant is unit-inspectable
- * WITHOUT constructing the alchemy resource: the factory spreads it into `FlagshipFlag`;
- * the test asserts `defaultVariation`/`variations.off` on this same record. Every flag
- * config below is exported the same way for the same reason.
- *
- * Per-flag metadata (`.patterns/feature-flags-schema-lifecycle.md`):
- *   - owner:           mecmua
- *   - originating:     #2497 (epic: mecmua v1 post feature, #2467)
- *   - removal trigger: once the mecmua write path is on at 100% and stable for one
- *                      release, retire the flag and delete its gate.
+ * Every flag config below is exported as a plain object so the default-=-safe-state invariant
+ * is unit-inspectable WITHOUT constructing the alchemy resource; the factory spreads it into
+ * `FlagshipFlag`. Default-OFF ships the path to production dark — flipping it on is the human
+ * release act (ADR 0083).
  */
 export const MECMUA_WRITE_FLAG = {
 	key: MECMUA_WRITE,
@@ -111,28 +82,9 @@ export const MECMUA_WRITE_FLAG = {
 	variations: {off: false, on: true},
 } as const;
 
-/**
- * No targeting rules — a plain boolean kill-switch. `appId` is resolved at deploy.
- */
 export const mecmuaWriteFlag = (appId: Input<string>) =>
 	Cloudflare.Flagship.Flag("mecmua_write", {appId, ...MECMUA_WRITE_FLAG});
 
-/**
- * The mecmua subscribed-author feed dark-ship flag config (#2500, epic #2467). The
- * SINGLE seam the feed surface gates behind — the `mecmuaFeed` list root (empty when
- * off), the `mecmua.subscribe` / `mecmua.unsubscribe` mutations, and the `/mecmua` feed
- * page. Default-OFF so the whole feed path reaches production dark; flipping it on is the
- * human release act (ADR 0083).
- *
- * Exported as a plain object so the default-=-safe-state invariant is unit-inspectable
- * WITHOUT constructing the alchemy resource (mirrors `MECMUA_WRITE_FLAG`).
- *
- * Per-flag metadata (`.patterns/feature-flags-schema-lifecycle.md`):
- *   - owner:           mecmua (the long-form feed surface)
- *   - originating:     #2500 (epic: mecmua v1 post feature, #2467)
- *   - removal trigger: once the mecmua feed is on at 100% and stable for one release,
- *                      retire the flag and inline the feed root + page.
- */
 export const MECMUA_FEED_FLAG = {
 	key: MECMUA_FEED,
 	description:
@@ -141,33 +93,9 @@ export const MECMUA_FEED_FLAG = {
 	variations: {off: false, on: true},
 } as const;
 
-/**
- * A plain boolean kill-switch, no targeting rules. `appId` is resolved at deploy
- * (mirrors `mecmuaWriteFlag`).
- */
 export const mecmuaFeedFlag = (appId: Input<string>) =>
 	Cloudflare.Flagship.Flag("mecmua_feed", {appId, ...MECMUA_FEED_FLAG});
 
-/**
- * The bildirim (notification system) dark-ship flag config (#1694, epic #1666).
- * The SINGLE seam the whole notification surface gates behind: the spine's badge +
- * center page and each sibling emitter's surface (#1695–#1700) reuse this one key
- * rather than minting per-child flags. Default-OFF so the system reaches production
- * dark — with it off, nothing user-visible changes (the resolvers deny invisibly,
- * the badge and `/bildirimler` route are absent); flipping it on is the human
- * release act (ADR 0083).
- *
- * Exported as a plain object so the default-=-safe-state invariant is
- * unit-inspectable WITHOUT constructing the alchemy resource (mirrors
- * `MECMUA_WRITE_FLAG`).
- *
- * Per-flag metadata (the IaC ownership record `feature-flags-schema-lifecycle.md`
- * asks for):
- *   - owner:           bildirim (the notification system, epic #1666)
- *   - originating:     #1694 (the bildirim spine)
- *   - removal trigger: once the notification system is on at 100% and stable for
- *                      one release, retire the flag and inline the surface.
- */
 export const BILDIRIM_FLAG = {
 	key: PHOENIX_BILDIRIM,
 	description:
@@ -176,33 +104,9 @@ export const BILDIRIM_FLAG = {
 	variations: {off: false, on: true},
 } as const;
 
-/**
- * A plain boolean kill-switch, no targeting rules. `appId` is resolved at deploy
- * (see `demoTargetingFlag` for why it's a factory, not a module constant).
- */
 export const bildirimFlag = (appId: Input<string>) =>
 	Cloudflare.Flagship.Flag("phoenix_bildirim", {appId, ...BILDIRIM_FLAG});
 
-/**
- * The reactions (emoji tepki) dark-ship flag config (#1863, epic #1840). The
- * SINGLE seam the whole reaction feature gates behind — the react/change/retract
- * mutations plus the `reactions` view field on pano post/comment + sözlük
- * definition reuse this one cross-cutting key rather than minting a per-surface
- * flag. Default-OFF so the ungated social-signal affordance reaches production dark
- * (the product behaves exactly as today, no reaction surface); flipping it on is
- * the human release act (ADR 0083).
- *
- * Exported as a plain object so the default-=-safe-state invariant is
- * unit-inspectable WITHOUT constructing the alchemy resource (mirrors
- * `MECMUA_WRITE_FLAG`).
- *
- * Per-flag metadata (the IaC ownership record `feature-flags-schema-lifecycle.md`
- * asks for):
- *   - owner:           reaction (the karma-free, ungated social-signal engine)
- *   - originating:     #1863 (epic: emoji reactions, #1840)
- *   - removal trigger: once reactions graduate to on at 100% and stable for one
- *                      release, retire the flag and inline the now-permanent path.
- */
 export const REACTIONS_FLAG = {
 	key: PHOENIX_REACTIONS,
 	description:
@@ -211,34 +115,12 @@ export const REACTIONS_FLAG = {
 	variations: {off: false, on: true},
 } as const;
 
-/**
- * A plain boolean kill-switch, no targeting rules. `appId` is resolved at deploy
- * (see `demoTargetingFlag` for why it's a factory, not a module constant).
- */
 export const reactionsFlag = (appId: Input<string>) =>
 	Cloudflare.Flagship.Flag("phoenix_reactions", {appId, ...REACTIONS_FLAG});
 
 /**
- * The karma-gated privileges dark-ship flag config (#150, künye epic #41). The
- * SINGLE seam the karma-VALUE privilege gates ride behind — the post-floor
- * (`karma ≥ −4`, on pano post/comment + sözlük definition creation) and the
- * flag-floor (`karma ≥ 50`, on `report.submit`). Default-OFF so the gates reach
- * production dark: with it off the karma read never runs and every write behaves
- * exactly as today; flipping it on is the human release act (ADR 0083).
- *
- * A separate axis from the çaylak→yazar tier gating and the mod-queue flag (ADR
- * 0098 moderation) — these are anti-abuse karma-value floors, not a second tier
- * ladder (no double-gating, #150 rescope 2026-07-02).
- *
- * Exported as a plain object so the default-=-safe-state invariant is
- * unit-inspectable WITHOUT constructing the alchemy resource (mirrors
- * `REACTIONS_FLAG`).
- *
- * Per-flag metadata (`feature-flags-schema-lifecycle.md`):
- *   - owner:           künye (the earned-standing / privilege surface)
- *   - originating:     #150 (epic: künye reputation, #41)
- *   - removal trigger: once the karma gates graduate to on at 100% and stable for
- *                      one release, retire the flag and inline the now-permanent gate.
+ * A separate axis from the çaylak→yazar tier gating and the mod-queue flag (ADR 0098): these
+ * are anti-abuse karma-VALUE floors, not a second tier ladder — no double-gating (#150).
  */
 export const KARMA_GATES_FLAG = {
 	key: PHOENIX_KARMA_GATES,
@@ -248,31 +130,9 @@ export const KARMA_GATES_FLAG = {
 	variations: {off: false, on: true},
 } as const;
 
-/**
- * A plain boolean kill-switch, no targeting rules. `appId` is resolved at deploy
- * (see `demoTargetingFlag` for why it's a factory, not a module constant).
- */
 export const karmaGatesFlag = (appId: Input<string>) =>
 	Cloudflare.Flagship.Flag("phoenix_karma_gates", {appId, ...KARMA_GATES_FLAG});
 
-/**
- * The user ban/unban dark-ship flag config (#970, admin epic #968). The SINGLE seam
- * the ban surface gates behind — the `user.banUser` / `user.unbanUser` admin
- * mutations, the `user.banState` admin read, and the moderator-UI ban controls.
- * Default-OFF so the whole ban path reaches production dark: with it off the
- * mutations/read fail the invisible `Denied` and the client controls render nothing,
- * so an unreleased feature can never refuse a real user's session. Flipping it on is
- * the human release act (ADR 0083).
- *
- * Exported as a plain object so the default-=-safe-state invariant is
- * unit-inspectable WITHOUT constructing the alchemy resource (mirrors `MECMUA_WRITE_FLAG`).
- *
- * Per-flag metadata (`feature-flags-schema-lifecycle.md`):
- *   - owner:           pasaport (the identity + session-boundary surface)
- *   - originating:     #970 (epic: admin dashboard, #968)
- *   - removal trigger: once ban graduates to on at 100% and stable for one release,
- *                      retire the flag and inline the now-permanent ban path.
- */
 export const USER_BAN_FLAG = {
 	key: PHOENIX_USER_BAN,
 	description:
@@ -281,29 +141,9 @@ export const USER_BAN_FLAG = {
 	variations: {off: false, on: true},
 } as const;
 
-/**
- * A plain boolean kill-switch, no targeting rules. `appId` is resolved at deploy
- * (see `demoTargetingFlag` for why it's a factory, not a module constant).
- */
 export const userBanFlag = (appId: Input<string>) =>
 	Cloudflare.Flagship.Flag("phoenix_user_ban", {appId, ...USER_BAN_FLAG});
 
-/**
- * The platform-role assignment dark-ship flag config (#3522, admin epic per ADR 0107).
- * Default-OFF so the whole role-assign path reaches production dark: with it off the
- * `Admin.over(platform)`-gated `user.setRole` mutation fails the invisible `Denied` (like
- * a non-admin call), so an unreleased role-grant can never mint a moderator. Flipping it
- * on is the human release act (ADR 0083).
- *
- * Exported as a plain object so the default-=-safe-state invariant is unit-inspectable
- * WITHOUT constructing the alchemy resource (mirrors `USER_BAN_FLAG`).
- *
- * Per-flag metadata (`feature-flags-schema-lifecycle.md`):
- *   - owner:           pasaport (the identity + authority surface)
- *   - originating:     #3522 (epic: admin dashboard, per ADR 0107)
- *   - removal trigger: once role-assign graduates to on at 100% and stable for one
- *                      release, retire the flag and inline the now-permanent path.
- */
 export const USER_ROLE_ASSIGN_FLAG = {
 	key: PHOENIX_USER_ROLE_ASSIGN,
 	description:
@@ -312,30 +152,9 @@ export const USER_ROLE_ASSIGN_FLAG = {
 	variations: {off: false, on: true},
 } as const;
 
-/**
- * A plain boolean kill-switch, no targeting rules. `appId` is resolved at deploy
- * (see `demoTargetingFlag` for why it's a factory, not a module constant).
- */
 export const userRoleAssignFlag = (appId: Input<string>) =>
 	Cloudflare.Flagship.Flag("phoenix_user_role_assign", {appId, ...USER_ROLE_ASSIGN_FLAG});
 
-/**
- * The admin email-delivery (failing-address) surface dark-ship flag config (#2692,
- * email-bounce epic #2687). Default-OFF so the whole admin path reaches production dark:
- * with it off the `emailDelivery.mark` / `emailDelivery.clear` mutations and the
- * `emailDelivery.failing` roll-up read fail the invisible `Denied` (like a non-admin
- * call), so no manual failing-mark or roll-up leaks. Flipping it on is the human release
- * act (ADR 0083).
- *
- * Exported as a plain object so the default-=-safe-state invariant is unit-inspectable
- * WITHOUT constructing the alchemy resource (mirrors `USER_BAN_FLAG`).
- *
- * Per-flag metadata (`feature-flags-schema-lifecycle.md`):
- *   - owner:           pasaport (the identity + email-delivery surface)
- *   - originating:     #2692 (epic: email-bounce, #2687)
- *   - removal trigger: once the admin failing-address surface graduates to on at 100%
- *                      and stable for one release, retire the flag and inline the path.
- */
 export const EMAIL_DELIVERY_ADMIN_FLAG = {
 	key: PHOENIX_EMAIL_DELIVERY_ADMIN,
 	description:
@@ -344,29 +163,10 @@ export const EMAIL_DELIVERY_ADMIN_FLAG = {
 	variations: {off: false, on: true},
 } as const;
 
-/**
- * A plain boolean kill-switch, no targeting rules. `appId` is resolved at deploy
- * (see `demoTargetingFlag` for why it's a factory, not a module constant).
- */
 export const emailDeliveryAdminFlag = (appId: Input<string>) =>
 	Cloudflare.Flagship.Flag("phoenix_email_delivery_admin", {appId, ...EMAIL_DELIVERY_ADMIN_FLAG});
 
-/**
- * The failing-email membrane notice dark-ship flag config (#2693, email-bounce epic
- * #2687). The seam the user-facing notice gates behind — with it off the membrane mount
- * renders nothing, so the surface ships dark until a human flips it at release (ADR 0083).
- * Its OWN key, not the admin seam (#2692): the user-facing notice is a distinct surface
- * from the admin failing-address console, with its own release lifecycle.
- *
- * Exported as a plain object so the default-=-safe-state invariant is unit-inspectable
- * WITHOUT constructing the alchemy resource (mirrors `EMAIL_DELIVERY_ADMIN_FLAG`).
- *
- * Per-flag metadata (`feature-flags-schema-lifecycle.md`):
- *   - owner:           pasaport (the identity + email-delivery surface)
- *   - originating:     #2693 (epic: email-bounce, #2687)
- *   - removal trigger: once the notice graduates to on at 100% and stable for one
- *                      release, retire the flag and inline the membrane mount.
- */
+// Its own key, not the #2692 admin seam: the user-facing notice releases separately.
 export const EMAIL_DELIVERY_NOTICE_FLAG = {
 	key: PHOENIX_EMAIL_DELIVERY_NOTICE,
 	description:
@@ -375,31 +175,9 @@ export const EMAIL_DELIVERY_NOTICE_FLAG = {
 	variations: {off: false, on: true},
 } as const;
 
-/**
- * A plain boolean kill-switch, no targeting rules. `appId` is resolved at deploy
- * (see `demoTargetingFlag` for why it's a factory, not a module constant).
- */
 export const emailDeliveryNoticeFlag = (appId: Input<string>) =>
 	Cloudflare.Flagship.Flag("phoenix_email_delivery_notice", {appId, ...EMAIL_DELIVERY_NOTICE_FLAG});
 
-/**
- * The mecmua public-read dark-ship flag config (#2498, epic #2467). The SINGLE seam
- * the anonymous read surface gates behind — the `GET /fate/mecmua/post/:slug` route
- * (404 until flipped) + the `/mecmua/:slug` reader page (self-404). Default-OFF so
- * the whole public-read path reaches production dark: with it off the route 404s and
- * the page renders the 404, so no unpublished-feature surface is reachable; flipping
- * it on is the human release act (ADR 0083). Its own `mecmua-` key, scoped to reads —
- * the authoring/publish path (#2497) ships behind its own seam.
- *
- * Exported as a plain object so the default-=-safe-state invariant is unit-inspectable
- * WITHOUT constructing the alchemy resource (mirrors `MECMUA_WRITE_FLAG`).
- *
- * Per-flag metadata (`feature-flags-schema-lifecycle.md`):
- *   - owner:           mecmua (the long-form read surface)
- *   - originating:     #2498 (epic: mecmua, #2467)
- *   - removal trigger: once mecmua public read graduates to on at 100% and stable for
- *                      one release, retire the flag and inline the route + page.
- */
 export const MECMUA_PUBLIC_READ_FLAG = {
 	key: MECMUA_PUBLIC_READ,
 	description:
@@ -408,30 +186,11 @@ export const MECMUA_PUBLIC_READ_FLAG = {
 	variations: {off: false, on: true},
 } as const;
 
-/**
- * A plain boolean kill-switch, no targeting rules. `appId` is resolved at deploy
- * (see `demoTargetingFlag` for why it's a factory, not a module constant).
- */
 export const mecmuaPublicReadFlag = (appId: Input<string>) =>
 	Cloudflare.Flagship.Flag("mecmua_public_read", {appId, ...MECMUA_PUBLIC_READ_FLAG});
 
-/**
- * The sözlük parallel-stamp-wave containment flag config (#2709, epic #2567).
- * Default-OFF so the read-path collapse reaches production dark: with it off the
- * sözlük definition reads run their stamp wave at `concurrency: 1` (serial, exactly
- * today); flipping it on passes `"unbounded"` so the independent stamps fan out into
- * one concurrent wave. Wire output is identical either way — only wall time changes.
- * Flipping it on is the human release act (ADR 0083).
- *
- * Exported as a plain object so the default-=-safe-state invariant is unit-inspectable
- * WITHOUT constructing the alchemy resource (mirrors `MECMUA_WRITE_FLAG`).
- *
- * Per-flag metadata (`feature-flags-schema-lifecycle.md`):
- *   - owner:           sözlük (the definition read path)
- *   - originating:     #2709 (epic: collapse the serial stamp chain, #2567)
- *   - removal trigger: once the wave graduates to on at 100% and stable for one
- *                      release, retire the flag and inline `"unbounded"`.
- */
+// `on` passes `"unbounded"` to the sözlük read's stamp wave, `off` keeps `concurrency: 1`.
+// Wire output is identical either way — only wall time changes.
 export const SOZLUK_STAMP_WAVE_FLAG = {
 	key: PHOENIX_SOZLUK_STAMP_WAVE,
 	description:
@@ -440,32 +199,11 @@ export const SOZLUK_STAMP_WAVE_FLAG = {
 	variations: {off: false, on: true},
 } as const;
 
-/**
- * A plain boolean kill-switch, no targeting rules. `appId` is resolved at deploy
- * (see `demoTargetingFlag` for why it's a factory, not a module constant).
- */
 export const sozlukStampWaveFlag = (appId: Input<string>) =>
 	Cloudflare.Flagship.Flag("phoenix_sozluk_stamp_wave", {appId, ...SOZLUK_STAMP_WAVE_FLAG});
 
-/**
- * The pano parallel-stamp-wave containment flag config (#2710, epic #2567) — the pano
- * sibling of `SOZLUK_STAMP_WAVE_FLAG`, behind its own seam. Default-OFF so the read-path
- * collapse reaches production dark: with it off the pano thread/comment reads
- * (`getCommentsByIds` / `listCommentsKeyset`) run their stamp wave at `concurrency: 1`
- * (serial, exactly today); flipping it on passes `"unbounded"` so the independent stamps
- * fan out into one concurrent wave. Wire output is identical either way — only wall time
- * changes. Flipping it on is the human release act (ADR 0083). Scoped to the thread read,
- * not the pano feed (the #2322 base/overlay split).
- *
- * Exported as a plain object so the default-=-safe-state invariant is unit-inspectable
- * WITHOUT constructing the alchemy resource (mirrors `MECMUA_WRITE_FLAG`).
- *
- * Per-flag metadata (`feature-flags-schema-lifecycle.md`):
- *   - owner:           pano (the thread/comment read path)
- *   - originating:     #2710 (epic: collapse the serial stamp chain, #2567)
- *   - removal trigger: once the wave graduates to on at 100% and stable for one
- *                      release, retire the flag and inline `"unbounded"`.
- */
+// The pano twin of `SOZLUK_STAMP_WAVE_FLAG`, on its own seam: `on` fans the thread/comment
+// stamp wave out `"unbounded"`, `off` keeps it serial. Scoped to the thread read, not the feed.
 export const PANO_STAMP_WAVE_FLAG = {
 	key: PHOENIX_PANO_STAMP_WAVE,
 	description:
@@ -474,30 +212,9 @@ export const PANO_STAMP_WAVE_FLAG = {
 	variations: {off: false, on: true},
 } as const;
 
-/**
- * A plain boolean kill-switch, no targeting rules. `appId` is resolved at deploy
- * (see `demoTargetingFlag` for why it's a factory, not a module constant).
- */
 export const panoStampWaveFlag = (appId: Input<string>) =>
 	Cloudflare.Flagship.Flag("phoenix_pano_stamp_wave", {appId, ...PANO_STAMP_WAVE_FLAG});
 
-/**
- * The kullanıcılar (user-roster) admin-console module dark-ship flag config (#3200, admin
- * epic). The SINGLE seam the gated user-list read view gates behind — the `userAdmin.list`
- * admin fate resolver AND the `kullanıcılar` console panel. Default-OFF so the whole roster
- * surface reaches production dark — with it off the server read fails the invisible `Denied`
- * (like a non-admin call) and the panel renders nothing; flipping it on is the human release
- * act (ADR 0083).
- *
- * Exported as a plain object so the default-=-safe-state invariant is unit-inspectable
- * WITHOUT constructing the alchemy resource (mirrors `MEMBER_MUTE_FLAG`).
- *
- * Per-flag metadata (`feature-flags-schema-lifecycle.md`):
- *   - owner:           user-admin (the gated user-roster surface, hosted by the console shell)
- *   - originating:     #3200 (admin epic; supersedes the shell half of #968)
- *   - removal trigger: once the roster + its per-user actions graduate to on at 100% and
- *                      stable for one release, retire the flag and inline the module.
- */
 export const USER_ADMIN_FLAG = {
 	key: PHOENIX_USER_ADMIN,
 	description:
@@ -506,30 +223,9 @@ export const USER_ADMIN_FLAG = {
 	variations: {off: false, on: true},
 } as const;
 
-/**
- * A plain boolean kill-switch, no targeting rules. `appId` is resolved at deploy
- * (see `demoTargetingFlag` for why it's a factory, not a module constant).
- */
 export const userAdminFlag = (appId: Input<string>) =>
 	Cloudflare.Flagship.Flag("phoenix_user_admin", {appId, ...USER_ADMIN_FLAG});
 
-/**
- * The profile free-paint canvas (duvar) dark-ship flag config (#3103, epic #2035). The
- * SINGLE seam the whole profile-canvas feature gates behind — the fate read view + visitor
- * render (#3105), the owner enable/toggle mutation (#3108), and the paint/save surface
- * (#3109). Default-OFF so the whole feature reaches production dark: with it off no canvas
- * surface renders and the owner-only mutations fail `CANVAS_DISABLED`, so the profile is
- * exactly as today; flipping it on is the human release act (ADR 0083).
- *
- * Exported as a plain object so the default-=-safe-state invariant is unit-inspectable
- * WITHOUT constructing the alchemy resource (mirrors `MEMBER_MUTE_FLAG`).
- *
- * Per-flag metadata (`feature-flags-schema-lifecycle.md`):
- *   - owner:           pasaport (the profile surface)
- *   - originating:     #3103 (epic: free-paint canvas space, #2035)
- *   - removal trigger: once the profile canvas graduates to on at 100% and stable for one
- *                      release, retire the flag and inline the now-permanent path.
- */
 export const PROFILE_CANVAS_FLAG = {
 	key: PROFILE_CANVAS,
 	description:
@@ -538,29 +234,9 @@ export const PROFILE_CANVAS_FLAG = {
 	variations: {off: false, on: true},
 } as const;
 
-/**
- * A plain boolean kill-switch, no targeting rules. `appId` is resolved at deploy
- * (see `demoTargetingFlag` for why it's a factory, not a module constant).
- */
 export const profileCanvasFlag = (appId: Input<string>) =>
 	Cloudflare.Flagship.Flag("profile_canvas", {appId, ...PROFILE_CANVAS_FLAG});
 
-/**
- * The member-mute (sustur) write-path dark-ship flag config (#3112, epic #2035). The
- * SINGLE seam the mute write path gates behind — `mute.set` / `mute.remove` fail
- * `MUTE_DISABLED` with it off, so the whole primitive reaches production dark; flipping
- * it on is the human release act (ADR 0083). The read-mask (sibling) and the manage UI
- * (reachability child) ship behind their own slices.
- *
- * Exported as a plain object so the default-=-safe-state invariant is unit-inspectable
- * WITHOUT constructing the alchemy resource (mirrors `PROFILE_CANVAS_FLAG`).
- *
- * Per-flag metadata (`feature-flags-schema-lifecycle.md`):
- *   - owner:           mute (the member-mute relation surface)
- *   - originating:     #3112 (epic: free-paint canvas space / member-mute, #2035)
- *   - removal trigger: once member-mute graduates to on at 100% and stable for one
- *                      release, retire the flag and inline the now-permanent path.
- */
 export const MEMBER_MUTE_FLAG = {
 	key: MEMBER_MUTE,
 	description:
@@ -569,9 +245,5 @@ export const MEMBER_MUTE_FLAG = {
 	variations: {off: false, on: true},
 } as const;
 
-/**
- * A plain boolean kill-switch, no targeting rules. `appId` is resolved at deploy
- * (see `demoTargetingFlag` for why it's a factory, not a module constant).
- */
 export const memberMuteFlag = (appId: Input<string>) =>
 	Cloudflare.Flagship.Flag("member_mute", {appId, ...MEMBER_MUTE_FLAG});

--- a/apps/web/worker/features/flagship/route-dev.ts
+++ b/apps/web/worker/features/flagship/route-dev.ts
@@ -1,20 +1,11 @@
 /**
- * Dev-only flag-override settings surface (#622):
+ * The dev-only flag-override settings page + its apply POST (#622).
  *
- * - `GET  /api/flags/dev` — an HTML page listing the declared boolean flags with
- *   on / off / clear toggles, reflecting the current `phoenix_flag_overrides`
- *   cookie state.
- * - `POST /api/flags/dev` — applies one toggle (`key` + `state`) to the override
- *   map and replays it into the cookie, then redirects back to the page.
- *
- * **HARD INVARIANT (load-bearing, the #622 review's primary check):** both verbs
- * fail-closed to `404` unless `environment === "development"`. The route is
- * statically mounted (it lives in `worker-routes.ts` so the SPA-shadow glob can't
- * drift, #861), but it answers nothing in any deployed stage: `ENVIRONMENT`
- * defaults to `"production"` (`config.ts`), so an unset/any non-`development` env
- * never reaches the page or sets the cookie. This is the same gate
- * `makeRequestFlagsContext` uses to decide whether to read the override cookie at
- * all — so even a hand-set cookie is inert in prod.
+ * **HARD INVARIANT:** both verbs fail-closed to `404` unless
+ * `environment === "development"`. The route is statically mounted, so the gate is
+ * the only thing keeping it dark in a deployed stage; `ENVIRONMENT` defaults to
+ * `"production"`. `makeRequestFlagsContext` uses the same gate to decide whether to
+ * read the override cookie, so even a hand-set cookie is inert in prod.
  */
 import * as Cloudflare from "alchemy/Cloudflare";
 import * as Effect from "effect/Effect";
@@ -34,19 +25,17 @@ import {
 
 const DEV_ROUTE_PATH = "/api/flags/dev";
 
-/** Reading the request form body failed — an unexpected infra failure, so it dies. */
 class RequestBodyReadError extends Schema.TaggedErrorClass<RequestBodyReadError>()(
 	"flagship/RequestBodyReadError",
 	{cause: Schema.Defect()},
 ) {}
 
-/** A `404` body that names why — the route exists but is dev-only. */
 const notInDevelopment = HttpServerResponse.text(
 	"flag dev overrides are available only under `alchemy dev` (ENVIRONMENT=development)",
 	{status: 404},
 );
 
-/** Is this request running under local `alchemy dev`? The fail-closed gate for the whole surface. */
+/** The fail-closed gate for this whole surface. */
 const isDevelopment = Effect.gen(function* () {
 	const {environment} = yield* AppConfig.pipe(Effect.orDie);
 	return environment === "development";
@@ -74,9 +63,8 @@ export const handleFlagsDevApply = Effect.gen(function* () {
 	const action = parseOverrideAction(form);
 	const current = parseOverrideCookie(raw.headers.get("cookie"));
 	const next = action ? applyOverride(current, action) : current;
-	// `Path=/` so the override cookie rides every request (the flag reads happen on
-	// `/api/flags/evaluate`, not this path). `SameSite=Lax`; no `Secure` — local dev
-	// is plain http. Dev-only, so no hardening beyond keeping it same-site.
+	// `Path=/` because the flag reads happen on `/api/flags/evaluate`, not this path.
+	// No `Secure` — local dev is plain http, and this surface is dev-only.
 	const cookie = `${FLAG_OVERRIDE_COOKIE}=${encodeOverrideCookieValue(next)}; Path=/; SameSite=Lax`;
 	return HttpServerResponse.redirect(DEV_ROUTE_PATH, {
 		status: 303,
@@ -86,7 +74,6 @@ export const handleFlagsDevApply = Effect.gen(function* () {
 
 export const flagsDevApplyRoute = HttpRouter.add("POST", DEV_ROUTE_PATH, handleFlagsDevApply);
 
-/** Render the dev settings page — declared flags with their current override state + toggles. */
 function renderDevPage(overrides: FlagOverrides): string {
 	const rows = DEV_OVERRIDABLE_FLAGS.map((key) => renderRow(key, overrides[key])).join("\n");
 	return `<!doctype html>
@@ -123,7 +110,6 @@ ${rows}
 </html>`;
 }
 
-/** One flag's row: its key, current override state, and the on/off/clear toggle forms. */
 function renderRow(key: string, override: boolean | undefined): string {
 	const state =
 		override === undefined
@@ -138,7 +124,6 @@ function renderRow(key: string, override: boolean | undefined): string {
 </tr>`;
 }
 
-/** A single-button form that POSTs one `{key, state}` toggle back to the route. */
 function toggle(key: string, state: "on" | "off" | "clear"): string {
 	return `<form method="post" action="${DEV_ROUTE_PATH}">
 	<input type="hidden" name="key" value="${escapeHtml(key)}" />
@@ -147,7 +132,6 @@ function toggle(key: string, state: "on" | "off" | "clear"): string {
 </form>`;
 }
 
-/** Escape a flag key for safe HTML interpolation (keys are code-declared, but cheap insurance). */
 function escapeHtml(value: string): string {
 	return value
 		.replace(/&/g, "&amp;")

--- a/apps/web/worker/features/flagship/route.ts
+++ b/apps/web/worker/features/flagship/route.ts
@@ -1,20 +1,9 @@
 /**
- * Flag HTTP routes (epic #488):
- *
- * - `GET  /api/flags/probe`    — the #508 dark-ship demonstrator: reads one
- *   boolean flag through `Flags` and branches on it.
- * - `POST /api/flags/evaluate` — the #510 SPA delivery seam: the browser names
- *   the flags it needs (`{key, default}` pairs) and the Worker returns the
- *   **server-evaluated** value for each. Evaluation stays in-isolate via `Flags`;
- *   the targeting context (user identity) is derived here from the session and
- *   never travels from or to the browser — the client sees only resolved booleans.
- *
- * Both build the per-request {@link FlagsContext} via `makeRequestFlagsContext`
- * (the session's user id for stable bucketing, plus the deploy `environment`
- * sourced from the stage — #512) and provide it inline — supplied alongside
- * `Auth` (ADR 0029), not at isolate scope. With no session they fall back to the
- * anonymous identity. Reads never throw: an undeclared flag or a Flagship outage
- * collapses to the caller's supplied default (the `Flags` safe-default contract).
+ * Flag HTTP routes (epic #488). Evaluation stays in-isolate: the targeting context is
+ * derived here from the session and never travels to or from the browser, which sees only
+ * resolved booleans. The per-request {@link FlagsContext} is provided at the handler edge,
+ * not at isolate scope (ADR 0029). Reads never throw — an undeclared flag or a Flagship
+ * outage collapses to the caller's supplied default.
  */
 import * as Cloudflare from "alchemy/Cloudflare";
 import * as Effect from "effect/Effect";
@@ -36,7 +25,7 @@ class FlagEvaluateBodyError extends Schema.TaggedErrorClass<FlagEvaluateBodyErro
 /** The dark-ship flag this probe gates on — undeclared, so it reads its default. */
 const PROBE_FLAG = "phoenix-flags-probe";
 
-/** A typed (string) variation the probe reads to demonstrate the non-boolean reads (#509). */
+/** Demonstrates the non-boolean reads (#509). */
 const PROBE_VARIANT_FLAG = "phoenix-flags-probe-variant";
 
 export const handleFlagsProbe = Effect.gen(function* () {
@@ -45,29 +34,19 @@ export const handleFlagsProbe = Effect.gen(function* () {
 	const flags = yield* Flags;
 
 	const session = yield* pasaport.validateSession(raw.headers);
-	// The environment attribute is sourced from the deploy stage (`ENVIRONMENT`,
-	// ADR 0057), not hand-passed — so an environment-targeting rule resolves per
-	// stage with no change here (#512). The cookie carries any dev-only local
-	// override (#622), applied by `makeRequestFlagsContext` ONLY under `development`.
+	// The cookie carries any dev-only local override (#622), which
+	// `makeRequestFlagsContext` applies ONLY under `development`.
 	const context = yield* makeRequestFlagsContext(
 		contextFromSession(session),
 		raw.headers.get("cookie"),
 	);
 
-	// `FlagsContext` is the per-request service every read needs; provide it ONCE at
-	// this handler edge (alongside the session-derived identity, ADR 0029) so the
-	// reads below call `flags.get*` directly with no inline provision.
 	const {enabled, variant} = yield* Effect.gen(function* () {
-		// The dark-ship read: the safe default is the off path; bucketing comes from
-		// the provided per-request identity context.
 		const enabled = yield* flags.getBoolean(PROBE_FLAG, false);
-		// A typed (non-boolean) read through the same service — the safe default is the
-		// fallback variant; a server with the flag declared would return its value (#509).
 		const variant = yield* flags.getString(PROBE_VARIANT_FLAG, "control");
 		return {enabled, variant};
 	}).pipe(Effect.provideService(FlagsContext, context));
 
-	// Branch on the flag — the whole point of the primitive.
 	return HttpServerResponse.jsonUnsafe({
 		flag: PROBE_FLAG,
 		enabled,
@@ -92,15 +71,11 @@ export const handleFlagsEvaluate = Effect.gen(function* () {
 	const keys = parseFlagEvaluateRequest(body);
 
 	const session = yield* pasaport.validateSession(raw.headers);
-	// The per-request context: session-derived identity plus the stage `environment` (#512),
-	// with the #2741 override-authz verdict applied so an authorized admin's cookie is honored.
-	// The SAME seam the edge `__BOOT__` injection uses, so the two never diverge (ADR 0179 AC2).
+	// The SAME seam the edge `__BOOT__` injection uses, so the two never diverge
+	// (ADR 0179 AC2), including the #2741 override-authz verdict.
 	const context = yield* resolveRequestFlagsContext(session, raw.headers.get("cookie"));
 
-	// Evaluate every requested flag server-side under the session-derived context.
-	// Each `getBoolean` honors its own supplied default and never throws. The
-	// per-request `FlagsContext` is provided ONCE over the whole batch (ADR 0029)
-	// rather than per key, so the loop reads `flags.getBoolean` directly.
+	// `FlagsContext` is provided ONCE over the whole batch, not per key (ADR 0029).
 	const entries = yield* Effect.forEach(
 		keys,
 		({key, default: defaultValue}) =>

--- a/apps/web/worker/features/flagship/sandbox-restore-escape.invariant.test.ts
+++ b/apps/web/worker/features/flagship/sandbox-restore-escape.invariant.test.ts
@@ -1,28 +1,13 @@
 /**
- * The çaylak sandbox-escape-via-restore security invariant (#1811). A çaylak
- * escapes the #1205 mod-only sandbox for their OWN content by deleting then
- * restoring it: the old `restore : Removed → Live` was unconditional and both
- * `toColumns(Removed)`/`toColumns(Live)` nulled `sandboxedAt`, so a delete→restore
- * round-trip cleared the sandbox marker AND broadcast the node to the always-Live
- * public feed — no moderator in the loop. This defeats the sandbox for all three
- * content types through the ONE shared `EntityLifecycle.restore` seam.
+ * The çaylak sandbox-escape-via-restore security invariant (#1811): a çaylak used to
+ * escape the #1205 mod-only sandbox by deleting then restoring their own content, since
+ * `restore` cleared `sandboxedAt` and broadcast the node to the always-Live public feed
+ * with no moderator in the loop.
  *
- * The fix (state-preserving, ADR 0096 extended): `Removed` carries the pre-removal
- * `sandboxedAt`, so `restore` is sandbox-FAITHFUL — sandboxed content returns to
- * `Sandboxed`, only live content returns to `Live`. The pure lifecycle proof lives
- * in `../lifecycle/EntityLifecycle.unit.test.ts` (`restore : Removed → Sandboxed`,
- * the column round-trip). This file proves the RESOLVER consequence directly: the
- * restore broadcast is routed through the #1205/#1280 `decidePublish` gate, so a
- * sandboxed restore is SUPPRESSED from the viewer-blind public topic — for post,
- * comment, AND definition, the three call sites of the one fix.
- *
- * Wire-boundary unit test (ADR 0082): the `Pano`/`Sozluk`/`LivePublisher` seams are
- * substituted directly — no DB. The service's restore returns the `sandboxedAt` the
- * content landed back at; a recording `LivePublisher` captures which topic keys the
- * resolver actually published, so "a sandboxed restore does not reach the public
- * feed" is asserted as the ABSENCE of the node-append topic. Mirrors the
- * handler-over-stubs seam of `../pano/draft-save.invariant.test.ts` and
- * `../sozluk/definition-mutation.unit.test.ts`.
+ * The pure lifecycle proof (`restore : Removed → Sandboxed`) lives in
+ * `../lifecycle/EntityLifecycle.unit.test.ts`. This file proves the RESOLVER consequence
+ * for post, comment AND definition: a sandboxed restore is asserted as the ABSENCE of the
+ * node-append topic on a recording `LivePublisher` (wire-boundary, no DB — ADR 0082).
  */
 import {assert, describe, it} from "@effect/vitest";
 import {CurrentUser, LivePublisher} from "@kampus/fate-effect";
@@ -44,11 +29,8 @@ import {Sozluk, type TermPage} from "../sozluk/Sozluk.ts";
 const AUTHOR = {id: "caylak-1", email: "caylak@example.com", name: "çaylak"};
 const AT = new Date("2026-07-03T00:00:00.000Z");
 
-// A recording `LivePublisher`: `publish` captures the topic key the resolver's
-// `live.*` chose; `waitUntil` collects the fire-and-forget work so it can be
-// drained. The gated `appendNode` publishes NOTHING when `decidePublish` suppresses
-// it (`broadcastIf` returns `Effect.void`), so a suppressed restore leaves the topic
-// absent from `recorded` — exactly the escape-prevention assertion.
+// The gated `appendNode` publishes NOTHING when `decidePublish` suppresses it, so a
+// suppressed restore leaves the topic absent from `recorded` — the assertion itself.
 const recordingLive = () => {
 	const recorded: Array<string> = [];
 	const scheduled: Array<Promise<unknown>> = [];
@@ -64,13 +46,11 @@ const recordingLive = () => {
 				},
 			}),
 		),
-		// The base-feed purger a fanned pano mutation fires (#2324) — no-op here.
 		noopPanoFeedCache,
 	);
 	return {recorded, scheduled, layer};
 };
 
-/** A rejection while draining scheduled `waitUntil` work — dies the fiber. */
 class DrainRejected extends Schema.TaggedErrorClass<DrainRejected>()("test/DrainRejected", {
 	cause: Schema.Unknown,
 }) {}
@@ -81,11 +61,8 @@ const drain = (scheduled: Array<Promise<unknown>>) =>
 		catch: (cause) => new DrainRejected({cause}),
 	}).pipe(Effect.orDie);
 
-// Service stubs (the `definition-mutation.unit.test.ts` proxy idiom): only the
-// methods the restore resolver reaches are scripted; every other method dies on
-// contact, so a passing test proves the resolver touched only the restore
-// round-trip + the re-resolve reads. `sandboxedAt` is what the service's restore
-// reports (non-null ⇒ landed back in the sandbox).
+// Every unscripted method dies on contact, so a passing test proves the resolver touched
+// only the restore round-trip + the re-resolve reads.
 const panoStub = (methods: Partial<typeof Pano.Service>): Layer.Layer<Pano> =>
 	Layer.succeed(
 		Pano,
@@ -160,14 +137,12 @@ const termPage = (): TermPage => ({
 	definitions: [definitionRow()],
 });
 
-// The gated node-append topic each restore path routes through — the viewer-blind
-// public topic a sandbox escape would leak the node onto.
+// The viewer-blind public topics a sandbox escape would leak the node onto.
 const POST_FEED_TOPIC = liveGlobalConnectionTopic("posts");
 const COMMENT_THREAD_TOPIC = liveConnectionTopic("Post.comments", {id: "post-1"});
 const DEFINITION_TERM_TOPIC = liveConnectionTopic("Term.definitions", {id: "term-1"});
 
 describe("çaylak sandbox-escape via delete→restore is structurally prevented (#1811)", () => {
-	// POST — the restore broadcast is gated; sandboxed ⇒ suppressed, live ⇒ published.
 	const runPostRestore = (restoreSandboxedAt: Date | null) =>
 		Effect.gen(function* () {
 			const {recorded, scheduled, layer} = recordingLive();
@@ -207,8 +182,8 @@ describe("çaylak sandbox-escape via delete→restore is structurally prevented 
 		}),
 	);
 
-	// COMMENT — `live.post.update` (commentCount) always fires; the GATED signal is the
-	// thread appendNode, so filter to it.
+	// `live.post.update` (commentCount) always fires; the GATED signal is the thread
+	// appendNode, so the assertions filter to it.
 	const runCommentRestore = (restoreSandboxedAt: Date | null) =>
 		Effect.gen(function* () {
 			const {recorded, scheduled, layer} = recordingLive();
@@ -256,7 +231,6 @@ describe("çaylak sandbox-escape via delete→restore is structurally prevented 
 		}),
 	);
 
-	// DEFINITION
 	const runDefinitionRestore = (restoreSandboxedAt: Date | null) =>
 		Effect.gen(function* () {
 			const {recorded, scheduled, layer} = recordingLive();

--- a/apps/web/worker/features/flagship/shell-boot-never-hang.unit.test.ts
+++ b/apps/web/worker/features/flagship/shell-boot-never-hang.unit.test.ts
@@ -1,37 +1,24 @@
 /**
- * The never-hang / safe-default-on-outage invariant (#2931, epic #2926, ADR 0179 §4):
- * `withNeverHangFallback` bounds the per-request boot resolve and degrades to the untransformed
- * asset — never hanging, never 500-ing the shell. The three arms under test:
+ * The never-hang / safe-default-on-outage invariant (ADR 0179 §4): `withNeverHangFallback`
+ * bounds the per-request boot resolve and degrades to the untransformed asset — never
+ * hanging, never 500-ing the shell — while passing a healthy resolve straight through.
  *
- *   1. a resolve that never completes (a dead/slow Flagship or D1) is bounded by
- *      SHELL_BOOT_READ_TIMEOUT and yields the untransformed asset;
- *   2. a resolve that FAILS (a Flagship/D1 error) also degrades to the untransformed asset;
- *   3. a resolve that succeeds passes its value straight through — the fallback is inert on the
- *      healthy path.
- *
- * The bound is driven by `TestClock` (no real 1s sleep): a forked fiber runs the guarded resolve,
- * the clock is adjusted past the timeout, then the exit is observed — the `cold-start-retry`
- * idiom. Unit tier (ADR 0082): pure Effect logic, no deployed worker / platform fake.
+ * The bound is driven by `TestClock` (no real 1s sleep): a forked fiber runs the guarded
+ * resolve, the clock is adjusted past the timeout, then the exit is observed.
  */
 import {assert, it} from "@effect/vitest";
 import {Effect, Exit, Fiber} from "effect";
 import {TestClock} from "effect/testing";
 import {withNeverHangFallback} from "./shell-boot-route.ts";
 
-/** The untransformed asset stand-in — the byte-identical fallback the guard must degrade to. */
 const UNTRANSFORMED = "untransformed-asset";
-/** The injected shell stand-in — what a healthy resolve produces instead of the fallback. */
 const INJECTED = "injected-boot-shell";
 
-/** A tagged stand-in for a Flagship/D1 resolve failure — the `E`-channel value the guard degrades on. */
 class BootResolveError {
 	readonly _tag = "BootResolveError";
 }
 
-/**
- * Run `effect` to its `Exit`, advancing the clock well past `SHELL_BOOT_READ_TIMEOUT` (1s) so a
- * never-completing resolve is bounded and settles — the `cold-start-retry` TestClock idiom.
- */
+/** Advances the clock well past `SHELL_BOOT_READ_TIMEOUT` so a never-completing resolve settles. */
 const runPastTimeout = <A, E>(effect: Effect.Effect<A, E>) =>
 	Effect.gen(function* () {
 		const fiber = yield* Effect.forkChild(effect);

--- a/apps/web/worker/features/flagship/shell-boot-parity.unit.test.ts
+++ b/apps/web/worker/features/flagship/shell-boot-parity.unit.test.ts
@@ -1,17 +1,11 @@
 /**
- * AC2 parity (#2984, ADR 0179): the shell flags injected into `window.__BOOT__` resolve to the
- * EXACT same values as `/api/flags/evaluate` across the #2741 override-authz path. Both consume
- * the one {@link resolveRequestFlagsContext} seam, so an authorized admin's `phoenix_flag_overrides`
- * cookie is honored identically on the API and in `__BOOT__`, and an unauthorized cookie is inert
- * identically. This is the regression guard for the divergence the review caught: the `__BOOT__`
- * path called `makeRequestFlagsContext` with 2 args (override-authz off) while the API passed the
- * 3-arg verdict — a prod admin got baseline values in `__BOOT__` but overridden values from the API.
+ * AC2 parity (#2984, ADR 0179): the shell flags injected into `window.__BOOT__` must resolve to
+ * the EXACT same values as `/api/flags/evaluate` across the #2741 override-authz path, because
+ * both consume the one {@link resolveRequestFlagsContext} seam.
  *
- * Proven with NO binding / NO I/O: `Flags` is the unconditional override wrapper
- * (`FlagsDevOverrideLive`, wired for every stage since #2741) over a stub `Flagship`, plus the same
- * `CurrentActor` (derived from the session) / `RelationStore` / `AgentAuthority` stubs
- * `override-authz.unit.test` uses. The two reads compared are the actual seams: the API's per-key
- * `flags.getBoolean` and the shell's {@link readShellFlags}, both over the ONE resolved context.
+ * The regression this guards: the `__BOOT__` path called `makeRequestFlagsContext` with 2 args
+ * (override-authz off) while the API passed the 3-arg verdict, so a prod admin got baseline
+ * values in `__BOOT__` but overridden values from the API.
  */
 import {assert, describe, it} from "@effect/vitest";
 import {AgentAuthority, RelationStore} from "@kampus/authz";
@@ -56,8 +50,8 @@ const flagshipStub: Layer.Layer<Flagship> = Layer.succeed(Flagship)(
 
 const harness = (opts: {isAdmin: boolean}) =>
 	Layer.mergeAll(
-		// The unconditional override wrapper (prod-installed since #2741) over the stub, so an
-		// authorized request's `overrides` short-circuit is exercised without a binding.
+		// The unconditional override wrapper (prod-installed since #2741), so an authorized request's
+		// `overrides` short-circuit is exercised without a binding.
 		FlagsDevOverrideLive.pipe(Layer.provide(flagshipStub)),
 		Layer.succeed(AgentAuthority, {admits: () => Effect.succeed(true)}),
 		Layer.succeed(RelationStore, {has: () => Effect.succeed(opts.isAdmin)} as never),
@@ -68,11 +62,8 @@ const harness = (opts: {isAdmin: boolean}) =>
 const SHELL_KEY = SHELL_FLAG_KEYS[0];
 const overrideCookie = `${FLAG_OVERRIDE_COOKIE}=${encodeOverrideCookieValue({[SHELL_KEY]: true})}`;
 
-/**
- * Resolve the shared context under the harness, then read `SHELL_KEY` the TWO ways production
- * does: the API's per-key `flags.getBoolean` (`handleFlagsEvaluate`) and the shell's
- * `readShellFlags` (`handleShellBoot`). Both flow through `resolveRequestFlagsContext`.
- */
+// Reads `SHELL_KEY` the TWO ways production does — the API's per-key `flags.getBoolean` and the
+// shell's `readShellFlags` — both over the one resolved context.
 const parity = (session: FlagsSession, cookie: string, opts: {isAdmin: boolean}) =>
 	Effect.gen(function* () {
 		const context = yield* resolveRequestFlagsContext(session, cookie);

--- a/apps/web/worker/features/flagship/shell-boot-route.ts
+++ b/apps/web/worker/features/flagship/shell-boot-route.ts
@@ -1,21 +1,11 @@
 /**
- * The worker-first shell route (ADR 0179, epic #2926, child #2929): the catch-all
- * (`* /*`) that serves the SPA shell through the worker and injects `window.__BOOT__`
- * at the edge.
+ * The worker-first shell route (ADR 0179): the catch-all that proxies the SPA shell
+ * from the `ASSETS` binding and injects `window.__BOOT__` at the edge. The specific
+ * worker routes win by find-my-way precedence; this handles the rest.
  *
- * With the CF spa-shell recipe (`["/*", "!/assets/*"]`, `worker-routes.ts`) every
- * non-asset request now reaches the worker; the specific worker routes (`/fate`,
- * `/api/*`, `/rss.xml`) win by find-my-way precedence and this catch-all handles the
- * rest. It is a transparent proxy to the `ASSETS` binding — byte-identical to the
- * edge-direct shell (ADR 0168 amended) — that transforms ONLY an HTML `GET`.
- *
- * The payload is resolved per request, non-cached, full (founder ruling #2833): the session
- * is validated and the shell flags are evaluated under the userId targeting context through
- * {@link resolveRequestFlagsContext} — the EXACT override-authz seam `/api/flags/evaluate`
- * uses (the #2741 third arg), so an authorized admin's override yields identical values here
- * and from the API (ADR 0179 AC2). A non-HTML asset or a non-`GET` passes through untouched,
- * and the never-hang guard ({@link withNeverHangFallback}) degrades a slow or failing resolve
- * to the untransformed asset, so `__BOOT__` is absent-or-complete, never partial.
+ * `__BOOT__` must be absent-or-complete, never partial — a non-HTML asset or a
+ * non-`GET` passes through untouched, and {@link withNeverHangFallback} degrades a
+ * slow or failing resolve to the untransformed asset.
  */
 import * as Cloudflare from "alchemy/Cloudflare";
 import * as Duration from "effect/Duration";
@@ -32,7 +22,6 @@ import {FlagsContext, type FlagsContextValue} from "./FlagsContext.ts";
 import {resolveRequestFlagsContext} from "./request-flags-context.ts";
 import {buildBootPayload, injectBootScript} from "./shell-boot.ts";
 
-/** A rejection from the `ASSETS` binding fetch — an infra defect (the never-hang fallback is #2931). */
 class ShellAssetFetchError extends Schema.TaggedErrorClass<ShellAssetFetchError>()(
 	"flagship/ShellAssetFetchError",
 	{cause: Schema.Defect()},
@@ -46,9 +35,8 @@ const toWebResponse = (response: unknown): HttpServerResponse.HttpServerResponse
 	HttpServerResponse.fromWeb(response as Parameters<typeof HttpServerResponse.fromWeb>[0]);
 
 /**
- * Project the wire `User` down to the client `BootUser` for `__BOOT__.user` — the same fields
- * `useMe` exposes as `MeUser`, minus fate's transport-only `__typename` (ADR 0185). An explicit
- * field list (not an `Omit` spread) so a wire-shape change surfaces here as a compile error.
+ * An explicit field list, not an `Omit` spread, so a wire-shape change surfaces here
+ * as a compile error (ADR 0185).
  */
 const toBootUser = (user: User): BootUser => ({
 	id: user.id,
@@ -62,9 +50,8 @@ const toBootUser = (user: User): BootUser => ({
 });
 
 /**
- * Resolve the shell flag values under an already-resolved per-request context. Exported so
- * the parity test can read the `__BOOT__` shell flags through the exact seam the handler uses
- * (mirroring `/api/flags/evaluate`'s per-key read over the SAME context, ADR 0179 AC2).
+ * Exported so the parity test reads the `__BOOT__` shell flags through the exact seam
+ * the handler uses (ADR 0179 AC2).
  */
 export const readShellFlags = (context: FlagsContextValue) =>
 	Effect.gen(function* () {
@@ -78,20 +65,14 @@ export const readShellFlags = (context: FlagsContextValue) =>
 	});
 
 /**
- * The never-hang ceiling on the per-request boot resolve — session validation (3 serial D1
- * queries when signed in) + shell-flag evaluation (ADR 0179 §2). A healthy resolve is well
- * under this; the cap bounds a slow or dead Flagship/D1 so the edge degrades rather than hangs.
- * Tunable — the invariant is that a bound EXISTS, not its exact value.
+ * Tunable — the invariant is that a bound EXISTS, not its exact value (ADR 0179 §2).
  */
 export const SHELL_BOOT_READ_TIMEOUT = Duration.seconds(1);
 
 /**
- * The never-hang / safe-default-on-outage guard (ADR 0179 §4): bound the boot resolve with
- * {@link SHELL_BOOT_READ_TIMEOUT} and, on timeout OR any Flagship/D1 failure, fall back to the
- * untransformed asset — byte-identical to the flag-off / edge-direct shell, with no partial
- * `__BOOT__`. Only expected failures (the `E` channel) + the timeout degrade; a genuine defect
- * still propagates. Exported so the never-hang invariant is unit-testable (TestClock) without a
- * deployed worker.
+ * The never-hang / safe-default-on-outage guard (ADR 0179 §4). Only expected failures
+ * (the `E` channel) and the timeout degrade to the untransformed asset; a genuine
+ * defect still propagates.
  */
 export const withNeverHangFallback = <A, E, R>(
 	resolve: Effect.Effect<A, E, R>,
@@ -105,38 +86,28 @@ export const withNeverHangFallback = <A, E, R>(
 export const handleShellBoot = Effect.gen(function* () {
 	const raw = yield* Cloudflare.Request;
 	const env = yield* Cloudflare.WorkerEnvironment;
-	// The `ASSETS` Fetcher binding, typed off the untyped worker env (`Record<string, any>`) so
-	// no cast is needed; `fetch` takes the request as-is and returns the workers-types `Response`.
 	const assets: {fetch(request: typeof raw): Promise<Response>} = env.ASSETS;
-	// The untransformed shell/asset — the same bytes the edge-direct binding served before this
-	// route existed, and the response the never-hang fallback degrades to (#2931). A rejection stays
-	// an infra defect (`orDie`) — it is the fallback SOURCE, so if it fails there is nothing to
-	// serve. The never-hang timeout wraps the boot READS (session + flags) below, not this fetch.
+	// A rejection stays an infra defect (`orDie`): this response is the fallback SOURCE,
+	// so if it fails there is nothing to serve. The never-hang timeout wraps the boot
+	// READS (session + flags) below, not this fetch.
 	const assetResponse = yield* Effect.tryPromise({
 		try: () => assets.fetch(raw),
 		catch: (cause) => new ShellAssetFetchError({cause}),
 	}).pipe(Effect.orDie);
 
-	// Only an HTML GET is a shell navigation to inject into; a non-GET or a non-HTML asset
-	// (favicon, manifest) passes through byte-identical — no session/flag work at all.
 	const isHtml = (assetResponse.headers.get("content-type") ?? "").includes("text/html");
 	if (raw.method !== "GET" || !isHtml) return toWebResponse(assetResponse);
 
-	// Validate the session and resolve the full context through the SAME override-authz seam
-	// `/api/flags/evaluate` uses (the #2741 third arg), read the shell flags under it, and inject
-	// the payload. The whole resolve is wrapped in the never-hang guard: on a slow/dead Flagship or
-	// D1 (timeout) or any resolve failure it degrades to the untransformed asset — never a hung or
-	// 500-ing shell (ADR 0179 §4).
+	// Resolves the context through the SAME override-authz seam `/api/flags/evaluate`
+	// uses, so an authorized admin's override yields identical values here and from the
+	// API (ADR 0179 AC2).
 	const resolveAndInject = Effect.gen(function* () {
 		const pasaport = yield* Pasaport;
 		const session = yield* pasaport.validateSession(raw.headers);
 		const context = yield* resolveRequestFlagsContext(session, raw.headers.get("cookie"));
 		const shellFlags = yield* readShellFlags(context);
-		// Edge-resolve the current user through the SAME session→user seam the `/fate` `me` view
-		// uses (ADR 0185), so first-paint surfaces read identity synchronously off `__BOOT__.user`
-		// instead of the async `useMe`; `null` when signed out. Projected off the wire `User` (drop
-		// fate's `__typename`) to the client `BootUser` shape. These extra D1 reads sit inside the
-		// never-hang guard below, so a slow/dead resolve degrades to the untransformed asset (#2931).
+		// The SAME session→user seam the `/fate` `me` view uses (ADR 0185), so first paint
+		// reads identity synchronously off `__BOOT__.user` instead of the async `useMe`.
 		const user = session ? toBootUser(yield* resolveMeUser(session.user)) : null;
 		const payload = buildBootPayload(user, shellFlags);
 		return injectBootScript(assetResponse, payload);

--- a/apps/web/worker/features/flagship/shell-boot.ts
+++ b/apps/web/worker/features/flagship/shell-boot.ts
@@ -1,11 +1,8 @@
 /**
- * The edge-render pure core — building the `window.__BOOT__` payload and injecting it
- * into the SPA shell (ADR 0179, the `__BOOT__` contract; epic #2926). Kept separate
- * from the Effect route (`shell-boot-route.ts`) so the payload shape, the script tag,
- * and the single-source drift guard are unit-testable without a worker runtime.
- *
- * The one workerd dependency is {@link injectBootScript}'s `HTMLRewriter` — a runtime
- * global, exercised in the integration tier, not here.
+ * The edge-render pure core — building the `window.__BOOT__` payload and injecting it into
+ * the SPA shell (ADR 0179). Kept separate from the Effect route so it is unit-testable
+ * without a worker runtime; the one workerd dependency is {@link injectBootScript}'s
+ * `HTMLRewriter`.
  */
 import {
 	assertShellBootKeysSingleSourced,
@@ -15,19 +12,15 @@ import {
 } from "../../../src/flags/shell-keys.ts";
 
 /**
- * The `window.__BOOT__` payload: the shell flag keys → boolean, plus the edge-resolved current
- * `user` (`BootUser | null`) carried for synchronous first-paint identity (ADR 0185, amending
- * 0179 — supersedes #2933's presence-only `signedIn` boolean). The boolean member keys are
- * exactly {@link BOOT_MEMBER_KEYS}, single-sourced from the manifest so the injected boolean
- * shape can't drift from what the client reads (#2928); `user` is a distinct typed field,
- * single-sourced via {@link BootUser}.
+ * The `window.__BOOT__` payload. `user` is carried for synchronous first-paint identity
+ * (ADR 0185, amending 0179). The boolean member keys are single-sourced from the manifest
+ * so the injected shape can't drift from what the client reads (#2928).
  */
 export type BootPayload = Record<ShellFlagKey, boolean> & {user: BootUser | null};
 
 /**
- * Assemble the payload from the edge-resolved current user + the resolved shell-flag values.
- * `user` is the per-request identity (`null` when signed out), resolved through the SAME
- * session→user seam the `/fate` `me` view uses, not evaluated through the flag service.
+ * `user` comes through the SAME session→user seam the `/fate` `me` view uses, never through
+ * the flag service.
  */
 export const buildBootPayload = (
 	user: BootUser | null,
@@ -35,28 +28,20 @@ export const buildBootPayload = (
 ): BootPayload => ({...shellFlags, user});
 
 /**
- * The inline `<script>` that seeds `window.__BOOT__` before the app module runs. `<`
- * is escaped to `<` so a value can never close the tag / open a comment — XSS-safe
- * by construction. Load-bearing now that the payload carries the `user` object's strings
- * (name/handle/email), not only booleans: a `<` in any user-controlled field can never break
- * out of the tag.
+ * `<` is escaped to `<` so a value can never close the tag or open a comment. Load-bearing
+ * now that the payload carries user-controlled strings (name/handle/email), not only booleans.
  */
 export const bootScriptTag = (payload: BootPayload): string =>
 	`<script>window.__BOOT__=${JSON.stringify(payload).replace(/</g, "\\u003c")}</script>`;
 
 /**
- * Stream the untransformed shell through `HTMLRewriter`, appending the `__BOOT__` script
- * to `<head>` so it runs before the deferred app module reads it. The response carries
- * **no `Cache-Control`** (ADR 0179 / founder ruling #2833): the injected shell is
- * viewer-dependent and per-request, so any cache directive the asset binding stamped is
- * stripped and none is added — viewer-dependent HTML is never cached (ADR 0170).
- *
- * The injected key set is verified against the manifest at this seam — the fail-closed
- * drift guard #2928 owns — so a shell key added here without the manifest throws.
+ * Appends the `__BOOT__` script to `<head>` so it runs before the deferred app module reads
+ * it. The response carries **no `Cache-Control`** (ADR 0179 / ADR 0170): the injected shell
+ * is viewer-dependent, so the asset binding's directive is stripped and none is added.
  */
 export const injectBootScript = (assetResponse: Response, payload: BootPayload): Response => {
-	// The single-source drift guard covers the boolean flag members only; `user` is a distinct
-	// typed field (ADR 0185), not a manifest member key, so it is excluded from the key-set check.
+	// The drift guard covers the boolean flag members only — `user` is a typed field (ADR
+	// 0185), not a manifest member key.
 	const flagKeys = Object.keys(payload).filter((key) => key !== "user");
 	assertShellBootKeysSingleSourced(flagKeys, [...BOOT_MEMBER_KEYS]);
 	const script = bootScriptTag(payload);

--- a/apps/web/worker/features/flagship/shell-boot.unit.test.ts
+++ b/apps/web/worker/features/flagship/shell-boot.unit.test.ts
@@ -1,8 +1,6 @@
 /**
- * Unit coverage for the edge-render pure core (#2929, ADR 0179; #3030/ADR 0185 for the `user`
- * field): the `window.__BOOT__` payload shape, the inline-script serialization, and the
- * single-source drift guard the inject seam calls. `injectBootScript`'s `HTMLRewriter` streaming
- * is a workerd global, exercised in the integration tier — not here.
+ * Unit coverage for the edge-render pure core (ADRs 0179/0185). `injectBootScript`'s
+ * `HTMLRewriter` streaming is a workerd global, exercised in the integration tier.
  */
 import {describe, expect, it} from "vitest";
 import {MECMUA_FEED, MECMUA_PUBLIC_READ} from "../../../src/flags/keys.ts";
@@ -19,8 +17,6 @@ const shellFlags = {
 	[MECMUA_FEED]: true,
 } as const;
 
-// The edge-resolved current user (`__BOOT__.user`, ADR 0185) — the exact `BootUser` shape the
-// client `useMe` seeds from, carrying the trusted tier + moderator standing.
 const bootUser: BootUser = {
 	id: "user-42",
 	email: "elif@kamp.us",
@@ -50,7 +46,6 @@ describe("buildBootPayload", () => {
 		);
 		expect([...flagKeys].sort()).toEqual([...BOOT_MEMBER_KEYS].sort());
 		expect(BOOT_MEMBER_KEYS).not.toContain("user");
-		// The seam the worker actually calls before injecting — proven to pass for our flag keys.
 		expect(() => assertShellBootKeysSingleSourced(flagKeys, [...BOOT_MEMBER_KEYS])).not.toThrow();
 	});
 });
@@ -67,8 +62,8 @@ describe("bootScriptTag", () => {
 	});
 
 	it("escapes `<` so a payload can never break out of the script tag", () => {
-		// A `<`-bearing user field (e.g. an attacker display name) must not survive raw in the JSON
-		// body — the escape (`<` -> <) is what keeps the injected object XSS-safe.
+		// A `<`-bearing user field (an attacker display name) must not survive raw in the
+		// JSON body — this escape is what keeps the injected object XSS-safe.
 		const tag = bootScriptTag(
 			buildBootPayload({...bootUser, name: "</script><script>evil"}, shellFlags),
 		);

--- a/apps/web/worker/features/flagship/sozluk-stamp-wave.invariant.test.ts
+++ b/apps/web/worker/features/flagship/sozluk-stamp-wave.invariant.test.ts
@@ -1,12 +1,9 @@
 /**
- * The dark-ship default-=-safe-state invariant for the sözlük parallel-stamp-wave
- * read collapse (#2709, epic #2567). Inspected off the exported `SOZLUK_STAMP_WAVE_FLAG`
- * record (the same object the factory spreads into `FlagshipFlag`), so no alchemy
- * resource is constructed — mirrors `funnel-readout.invariant.test.ts`.
+ * The dark-ship default-is-the-safe-state invariant for the sözlük stamp wave.
+ * Inspected off the exported flag record, so no alchemy resource is constructed.
  *
- * Load-bearing: with the default OFF the definition reads run their stamp wave at
- * `concurrency: 1` (serial, byte-for-byte today) — so the containment is real, the
- * concurrent wave only reachable after a human flips the flag.
+ * With the default OFF the definition reads stay serial, so the concurrent wave is
+ * reachable only after a human flips the flag.
  */
 import {assert, describe, it} from "@effect/vitest";
 import {PHOENIX_SOZLUK_STAMP_WAVE} from "../../../src/flags/keys.ts";

--- a/apps/web/worker/features/flagship/user-admin.invariant.test.ts
+++ b/apps/web/worker/features/flagship/user-admin.invariant.test.ts
@@ -1,8 +1,6 @@
 /**
- * The dark-ship default-=-safe-state invariant for the kullanıcılar (user-roster) read view
- * (#3200). Inspected off the exported `USER_ADMIN_FLAG` record (the same object the factory
- * spreads into `FlagshipFlag`), so no alchemy resource is constructed — mirrors
- * `member-mute.invariant.test.ts`.
+ * The dark-ship default-=-safe-state invariant for the kullanıcılar read view (#3200).
+ * Inspected off the exported record, so no alchemy resource is constructed.
  */
 import {assert, describe, it} from "@effect/vitest";
 import {PHOENIX_USER_ADMIN} from "../../../src/flags/keys.ts";

--- a/apps/web/worker/features/flagship/user-role-assign.invariant.test.ts
+++ b/apps/web/worker/features/flagship/user-role-assign.invariant.test.ts
@@ -1,8 +1,7 @@
 /**
- * The dark-ship default-=-safe-state invariant for the platform role-assign surface
- * (#3522, admin epic per ADR 0107). Inspected off the exported `USER_ROLE_ASSIGN_FLAG`
- * record (the same object the factory spreads into `FlagshipFlag`), so no alchemy resource
- * is constructed — mirrors `email-delivery-admin.invariant.test.ts`.
+ * The dark-ship default-is-the-safe-state invariant for the platform role-assign surface
+ * (#3522). Inspected off the exported record rather than the factory, so no alchemy
+ * resource is constructed.
  */
 import {assert, describe, it} from "@effect/vitest";
 import {PHOENIX_USER_ROLE_ASSIGN} from "../../../src/flags/keys.ts";

--- a/apps/web/worker/features/funnel/Funnel.testing.ts
+++ b/apps/web/worker/features/funnel/Funnel.testing.ts
@@ -1,13 +1,7 @@
 /**
- * `makeFunnelStub` — the shared {@link Funnel} test double, mirroring
- * `Report.testing.ts` / `Kunye.testing.ts`. Every read fails-on-contact
- * (`Effect.die`) by default; a test overrides only the read under test, returning
- * the `Layer.succeed(Funnel, …)` layer. The one place the `Funnel` shape lives for
- * tests — adding a read is a single edit here, not shotgun surgery across stubs.
- *
- * A `layerStub` (fail-on-contact), not a `layerNoop`: an un-overridden read, if
- * reached, dies and fails the test. A **factory, not a shared instance**
- * (`.patterns/effect-testing.md`).
+ * `makeFunnelStub` — the shared {@link Funnel} test double. Fail-on-contact, not a noop:
+ * an un-overridden read that gets reached dies and fails the test. A factory, not a
+ * shared instance (`.patterns/effect-testing.md`).
  */
 import {Effect, Layer} from "effect";
 import {Funnel} from "./Funnel.ts";

--- a/apps/web/worker/features/funnel/Funnel.ts
+++ b/apps/web/worker/features/funnel/Funnel.ts
@@ -1,113 +1,56 @@
 /**
- * `Funnel` — the conversion-funnel read model (#1589, the çaylak→yazar readout's
- * tracer bullet). Its one read, {@link Funnel.tierPopulation}, is the current tier
- * population — how many accounts sit at each rung of the authorship ladder
- * (`çaylak`, `yazar`) — the simplest funnel number the Phase-2 rate/time metrics
- * extend off this same service. {@link promotionRate} (#1593) derives the loop's
- * headline number from that population — the share of the human earned-authorship
- * population that has crossed to `yazar`; {@link Funnel.firstContribution} (#1591)
- * adds the first-contribution rate — the share of human çaylaks with ≥ 1 sandboxed
- * contribution, the newcomer-engagement signal. {@link Funnel.vouchRate} (#1592)
- * adds the vouch rate — the share of human çaylaks who received ≥ 1 vouch (kefil),
- * the signal of whether the established community sponsors newcomers.
+ * `Funnel` — the çaylak→yazar conversion-funnel read model.
  *
- * Humans-only by construction: the count filters `user.type = 'human'`, so the
- * seeded `system` sentinel (ADR 0097) and any `bot` account (agents, v1.1) never
- * enter the funnel — a conversion metric measures the human çaylak→yazar journey,
- * not machine rows. The filter is single-sourced in {@link tierPopulationQuery} so
- * the humans-only predicate can't drift from what the service reads.
- *
- * Reads go through `run`/`orDieAccess`, so infra failures die here (the
- * domain-boundary rule, `.patterns/effect-errors.md`) and the public signature
- * carries no error — the gate + flag live at the fate resolver, not in the read.
+ * Humans-only by construction: every query filters `user.type = 'human'`, so the
+ * seeded `system` sentinel (ADR 0097) and any `bot` account never enter the funnel.
+ * The gate + flag live at the fate resolver, not in these reads.
  */
 import {and, count, eq, inArray, isNotNull, or} from "drizzle-orm";
 import {Context, Effect, Layer} from "effect";
 import {Drizzle, type DrizzleDb, orDieAccess} from "../../db/Drizzle.ts";
 import * as schema from "../../db/drizzle/schema.ts";
 
-/** The two counted rungs of the stored authorship ladder (`STORED_TIERS`). */
 export interface TierPopulation {
-	/** Human accounts still at the `çaylak` floor. */
 	readonly caylakCount: number;
-	/** Human accounts promoted to `yazar`. */
 	readonly yazarCount: number;
 }
 
-/** One grouped row of the tier-population read: a stored tier and its human count. */
 export interface TierCountRow {
 	readonly tier: string;
 	readonly count: number;
 }
 
-/**
- * The first-contribution metric (#1591): among human çaylaks, how many have made
- * ≥ 1 sandboxed contribution — the engagement signal answering "do newcomers
- * contribute at all, or lurk?" (the epic's named risk).
- */
 export interface FirstContribution {
-	/** The denominator: human accounts at the `çaylak` floor. */
 	readonly caylakCount: number;
-	/** The numerator: human çaylaks with ≥ 1 sandboxed contribution. */
 	readonly contributingCount: number;
-	/**
-	 * `contributingCount / caylakCount`, in `[0, 1]`. `0` when there are no çaylaks
-	 * (an empty population is a well-formed 0% rate, never a divide-by-zero).
-	 */
 	readonly rate: number;
 }
 
 /**
- * The vouch metric (#1592): among human çaylaks, how many have received ≥ 1 vouch
- * (kefil) — appearing as a `candidate_id` in the `authorship_vouch` ledger. Reads
- * whether the established community is sponsoring newcomers. A row's mere existence
- * is enough for "received a vouch" — this counts "was ever vouched for while çaylak",
- * not an active/live-vouch lifecycle concern (that is `VouchLedger`'s).
+ * A row's mere existence in `authorship_vouch` is enough for "received a vouch" —
+ * this counts "was ever vouched for while çaylak", not an active/live-vouch
+ * lifecycle concern (that is `VouchLedger`'s).
  */
 export interface VouchRate {
-	/** The denominator: human accounts at the `çaylak` floor. */
 	readonly caylakCount: number;
-	/** The numerator: human çaylaks with ≥ 1 `authorship_vouch` candidate row. */
 	readonly vouchedCount: number;
-	/**
-	 * `vouchedCount / caylakCount`, in `[0, 1]`. `0` when there are no çaylaks
-	 * (an empty population is a well-formed 0% rate, never a divide-by-zero).
-	 */
 	readonly rate: number;
 }
 
 /**
- * The time-to-promotion metric (#1594): how long the loop takes from registration
- * to yazar, measured `promoted_at − created_at` over human yazars that carry a
- * non-null `promoted_at` (i.e. promoted since instrumentation landed, #1590). A
- * single legible product number — the **median** — not a histogram engine.
- *
- * Founding-cohort / pre-instrumentation yazars carry a null `promoted_at` (no
- * source of truth back-computes their promotion time — that is why #1590 stamps
- * forward only) and are **excluded from the median** and surfaced as an explicit
- * {@link notYetMeasurableCount}, never silently dropped.
+ * Founding-cohort / pre-instrumentation yazars carry a null `promoted_at` (nothing
+ * back-computes their promotion time — #1590 stamps forward only). They are excluded
+ * from the median and surfaced as `notYetMeasurableCount`, never silently dropped.
  */
 export interface TimeToPromotion {
-	/**
-	 * The median of `promoted_at − created_at` in milliseconds over measurable
-	 * yazars, or `null` when none are measurable yet (empty measured population —
-	 * a well-formed "no number yet", never a `NaN`).
-	 */
 	readonly medianMs: number | null;
-	/** The measured population: human yazars with a non-null `promoted_at`. */
 	readonly measuredCount: number;
-	/**
-	 * Human yazars excluded for a null `promoted_at` (founding-cohort /
-	 * pre-instrumentation) — the "not yet measurable" count, surfaced not dropped.
-	 */
 	readonly notYetMeasurableCount: number;
 }
 
 /**
- * The humans-only tier-population query — a `GROUP BY tier` count over the `user`
- * table filtered to `type = 'human'`. Extracted as a pure builder (not inlined in
- * the service) so the humans-only filter is unit-inspectable via `.toSQL()` with no
- * engine, exactly the `promotion-sweep` render idiom (ADR 0082 T1/T2).
+ * The query builders below are extracted from the service, not inlined, so each
+ * predicate is `.toSQL()`-inspectable in a unit test with no engine (ADR 0082 T1/T2).
  */
 export const tierPopulationQuery = (db: DrizzleDb) =>
 	db
@@ -116,11 +59,6 @@ export const tierPopulationQuery = (db: DrizzleDb) =>
 		.where(eq(schema.user.type, "human"))
 		.groupBy(schema.user.tier);
 
-/**
- * Fold the grouped rows onto the {@link TierPopulation} shape. A tier absent from
- * the rows (no human at that rung yet) reads as `0`, so a fresh DB or an all-çaylak
- * population is a well-formed answer, never a missing field.
- */
 export const foldTierPopulation = (rows: ReadonlyArray<TierCountRow>): TierPopulation => {
 	const byTier = new Map(rows.map((r) => [r.tier, r.count]));
 	return {
@@ -129,25 +67,14 @@ export const foldTierPopulation = (rows: ReadonlyArray<TierCountRow>): TierPopul
 	};
 };
 
-/**
- * The loop's headline number (#1593): the share of the earned-authorship human
- * population that crossed to `yazar` — `yazar / (çaylak + yazar)`, a fraction in
- * `[0, 1]`. An empty population (`çaylak + yazar === 0`) reads as `0` rather than a
- * `NaN` division-by-zero, so a fresh DB is a well-formed `0%`, not a broken number.
- */
 export const promotionRate = ({caylakCount, yazarCount}: TierPopulation): number => {
 	const earned = caylakCount + yazarCount;
 	return earned === 0 ? 0 : yazarCount / earned;
 };
 
 /**
- * Count the human çaylaks with ≥ 1 sandboxed contribution — a `çaylak`-tier human
- * whose id authors any `sandboxed_at IS NOT NULL` row across the three content
- * tables (definition / post / comment). The sandbox marker is the çaylak-sandbox
- * seam of `kunye/sandbox.ts` (`sandboxedAtForAuthor`); this reuses that existing
- * column and adds no new write. Extracted as a pure builder (the `tierPopulationQuery`
- * idiom) so the humans-only + çaylak-only + sandboxed-authorship predicate is
- * `.toSQL()`-inspectable with no engine (ADR 0082 T1/T2).
+ * The sandbox marker is the çaylak-sandbox seam of `kunye/sandbox.ts`
+ * (`sandboxedAtForAuthor`); this reuses that column and adds no new write.
  */
 export const contributingCaylaksQuery = (db: DrizzleDb) =>
 	db
@@ -183,10 +110,6 @@ export const contributingCaylaksQuery = (db: DrizzleDb) =>
 			),
 		);
 
-/**
- * Fold the two counts onto {@link FirstContribution}, guarding the zero-population
- * edge: with no çaylaks the rate is `0`, never a divide-by-zero (ADR 0040 seam).
- */
 export const computeFirstContribution = (
 	caylakCount: number,
 	contributingCount: number,
@@ -196,13 +119,6 @@ export const computeFirstContribution = (
 	rate: caylakCount === 0 ? 0 : contributingCount / caylakCount,
 });
 
-/**
- * Count the human çaylaks with ≥ 1 vouch — a `çaylak`-tier human whose id appears
- * as a `candidate_id` in the `authorship_vouch` ledger (mere row existence, per
- * #1592). Extracted as a pure builder (the `tierPopulationQuery` idiom) so the
- * humans-only + çaylak-only + vouched predicate is `.toSQL()`-inspectable with no
- * engine (ADR 0082 T1/T2). No new write: it reads the existing ledger table.
- */
 export const vouchedCaylaksQuery = (db: DrizzleDb) =>
 	db
 		.select({count: count()})
@@ -218,10 +134,6 @@ export const vouchedCaylaksQuery = (db: DrizzleDb) =>
 			),
 		);
 
-/**
- * Fold the two counts onto {@link VouchRate}, guarding the zero-population edge:
- * with no çaylaks the rate is `0`, never a divide-by-zero (ADR 0040 seam).
- */
 export const computeVouchRate = (caylakCount: number, vouchedCount: number): VouchRate => ({
 	caylakCount,
 	vouchedCount,
@@ -229,12 +141,8 @@ export const computeVouchRate = (caylakCount: number, vouchedCount: number): Vou
 });
 
 /**
- * Select the promotion/registration timestamps of every human yazar — the raw input
- * to the median fold. Extracted as a pure builder (the `tierPopulationQuery` idiom)
- * so the humans-only + yazar-only predicate is `.toSQL()`-inspectable with no engine
- * (ADR 0082 T1/T2). The median itself lives in TS ({@link computeTimeToPromotion}),
- * not SQLite — there is no portable median aggregate, and the population is small
- * (yazars, not all users), so pulling the timestamps and folding is the simpler seam.
+ * The median lives in TS ({@link computeTimeToPromotion}), not SQLite — there is no
+ * portable median aggregate, and the yazar population is small enough to pull whole.
  */
 export const yazarPromotionTimesQuery = (db: DrizzleDb) =>
 	db
@@ -242,14 +150,11 @@ export const yazarPromotionTimesQuery = (db: DrizzleDb) =>
 		.from(schema.user)
 		.where(and(eq(schema.user.type, "human"), eq(schema.user.tier, "yazar")));
 
-/** One human-yazar row for the time-to-promotion fold: its two nullable stamps. */
 export interface YazarPromotionTimeRow {
 	readonly promotedAt: Date | null;
 	readonly createdAt: Date | null;
 }
 
-/** The median of a numeric list, or `null` when empty. Even population ⇒ the mean of
- * the two central values (the input need not be pre-sorted). */
 const median = (values: ReadonlyArray<number>): number | null => {
 	if (values.length === 0) return null;
 	const sorted = [...values].sort((a, b) => a - b);
@@ -262,12 +167,9 @@ const median = (values: ReadonlyArray<number>): number | null => {
 };
 
 /**
- * Fold the human-yazar timestamp rows onto {@link TimeToPromotion}: measure
- * `promoted_at − created_at` (ms) for yazars with a non-null `promoted_at`, take
- * the median, and count the null-`promoted_at` yazars as `notYetMeasurableCount`.
  * A yazar with a non-null `promoted_at` but a null `created_at` is a data anomaly
- * (registration stamp is always set) — it yields no measurable duration, so it is
- * defensively skipped from the median without being counted as pre-instrumentation.
+ * (the registration stamp is always set) — it yields no measurable duration, so it
+ * is skipped from the median without counting as pre-instrumentation.
  */
 export const computeTimeToPromotion = (
 	rows: ReadonlyArray<YazarPromotionTimeRow>,
@@ -292,13 +194,9 @@ export const computeTimeToPromotion = (
 export class Funnel extends Context.Service<
 	Funnel,
 	{
-		/** The current human tier population (çaylak + yazar counts). */
 		readonly tierPopulation: () => Effect.Effect<TierPopulation>;
-		/** The first-contribution rate over the human-çaylak population (#1591). */
 		readonly firstContribution: () => Effect.Effect<FirstContribution>;
-		/** The vouch rate over the human-çaylak population (#1592). */
 		readonly vouchRate: () => Effect.Effect<VouchRate>;
-		/** The median registration→yazar time over measurable yazars (#1594). */
 		readonly timeToPromotion: () => Effect.Effect<TimeToPromotion>;
 	}
 >()("@kampus/funnel/Funnel") {}

--- a/apps/web/worker/features/funnel/Funnel.unit.test.ts
+++ b/apps/web/worker/features/funnel/Funnel.unit.test.ts
@@ -1,23 +1,7 @@
 /**
- * `Funnel` read-model coverage (#1589, #1593, #1591, #1592) — the tier-population
- * counts, the headline promotion rate, the first-contribution rate, the vouch rate,
- * and the humans-only filter, the decisions that are wrong-or-right with no engine
- * (ADR 0082 T1/T2). The
- * `Drizzle` seam is substituted directly (the `Report` / `promotion-sweep` idiom):
- *
- *   - **counts** — a scripted `run` feeds grouped rows to `foldTierPopulation`
- *     THROUGH the real `FunnelLive` service, proving çaylak/yazar map to the right
- *     fields and an absent tier reads `0`.
- *   - **promotion rate** — `promotionRate` derives yazar / (çaylak + yazar) from the
- *     population, both directly and end-to-end over the seam, covering the
- *     zero-population edge (`0`, never a `NaN`).
- *   - **first-contribution rate** — `computeFirstContribution` folds the çaylak count
- *     and contributing-çaylak count into the rate (zero-population edge → `0`), read
- *     end-to-end through the two-call seam; `contributingCaylaksQuery`'s rendered SQL
- *     is asserted to gate on human çaylaks with a `sandboxed_at IS NOT NULL` row.
- *   - **humans-only** — the query's rendered SQL (`.toSQL()` over a no-op D1) is
- *     asserted to filter `type = 'human'` and group by `tier`, so bot/system rows
- *     are excluded by construction. No engine executes.
+ * `Funnel` read-model coverage — the counts, rates, and humans-only filter, all decided
+ * with no engine (ADR 0082). The `Drizzle` seam is substituted directly and the SQL
+ * assertions render `.toSQL()` over a no-op D1.
  */
 import {assert, describe, it} from "@effect/vitest";
 import {drizzle} from "drizzle-orm/d1";
@@ -45,8 +29,7 @@ const yazarAfterDays = (d: number, base = 0) => ({
 	promotedAt: new Date(base + d * DAY),
 });
 
-// A real drizzle client over a no-op D1 — used ONLY to render the query's `.toSQL()`;
-// it never executes.
+// A real drizzle client over a no-op D1, used ONLY to render `.toSQL()`; nothing executes.
 // biome-ignore lint/plugin: `D1Database` is a host binding that can't be structurally constructed in a fake; nothing here executes against it.
 const noopD1 = {
 	prepare: () => ({
@@ -72,8 +55,7 @@ const noopD1 = {
 } as unknown as D1Database;
 const renderDb = drizzle(noopD1, {relations});
 
-// A scripted `Drizzle` seam: `run` ignores its builder and returns the queued rows
-// (no engine); `batch` dies — the read issues none.
+// `run` ignores its builder and returns queued rows; `batch` dies, as the read issues none.
 const scriptedRows = (rows: ReadonlyArray<TierCountRow>): DrizzleAccess => ({
 	run: <A>(_fn: (db: never) => Promise<A>) => Effect.succeed(rows as A),
 	batch: () => Effect.die(new Error("Funnel.tierPopulation issues no batch")),
@@ -82,9 +64,8 @@ const scriptedRows = (rows: ReadonlyArray<TierCountRow>): DrizzleAccess => ({
 const funnelLayer = (access: DrizzleAccess) =>
 	FunnelLive.pipe(Layer.provide(Layer.succeed(Drizzle, access)));
 
-// A `Drizzle` seam that dispenses queued responses in order — `firstContribution`
-// issues two reads (the tier population, then the contributing-çaylak count), so it
-// needs a distinct payload per call, not the single-shape `scriptedRows` above.
+// Dispenses queued responses in order, for the reads that issue two queries and so need a
+// distinct payload per call rather than the single-shape `scriptedRows` above.
 const scriptedSequence = (responses: ReadonlyArray<ReadonlyArray<unknown>>): DrizzleAccess => {
 	let call = 0;
 	return {

--- a/apps/web/worker/features/funnel/fate-module.ts
+++ b/apps/web/worker/features/funnel/fate-module.ts
@@ -4,8 +4,7 @@ import {queries} from "./queries.ts";
 import {funnelSummaryDataView} from "./views.ts";
 
 const roots: FateRootsRecord = {
-	// The conversion-funnel readout (#1589) — founder/mod-gated; the
-	// `funnel.summary` resolver owns the capability gate.
+	// The `funnel.summary` resolver owns the capability gate, not this declaration.
 	"funnel.summary": funnelSummaryDataView,
 };
 

--- a/apps/web/worker/features/funnel/gate.ts
+++ b/apps/web/worker/features/funnel/gate.ts
@@ -1,22 +1,10 @@
 /**
- * The funnel-readout access gate (#1589) — the founder/mod destination gate for
- * the aggregate conversion metrics, built on the divan gate seam (`divan/gate.ts`):
- * a `ViewFunnel` `Capability.Class` whose `.authorize(check)` mints ONE
- * `Grant<ViewFunnel>` the read requires in its R channel (enforcement-by-R, ADR
- * 0107 §3), so a funnel read that forgets the gate is a compile error, not a
- * forgotten `if`.
+ * The funnel-readout access gate — enforcement-by-R (ADR 0107 §3), so a funnel read
+ * that forgets the gate is a compile error, not a forgotten `if`.
  *
- * The check {@link standsInFunnel} discharges `Moderate.over(platform)` — the ReBAC
- * `moderates` relation over the platform scope (the same tuple founders are seeded
- * with, so "founder/mod" is the one `moderates`-platform holder, not a second axis)
- * — collapsed to a boolean, mirroring the divan gate's mod arm. Aggregate platform
- * metrics are a private founder/mod destination, so the gate lives here as its own
- * capability rather than reusing `ViewDivan` (whose disjunction admits any yazar):
- * the funnel is mod-only, the divan is yazar-OR-mod.
- *
- * Denial is the invisible {@link Denied} (`UNAUTHORIZED`): a non-mod / signed-out
- * read cannot distinguish "not a moderator" from "not signed in" — exactly the
- * divan/moderation-queue destination shape.
+ * Its own capability rather than a reuse of `ViewDivan`: the funnel is mod-only, the
+ * divan is yazar-OR-mod. Denial is the invisible {@link Denied}, so a non-mod read
+ * cannot distinguish "not a moderator" from "not signed in".
  */
 import {Capability, Grant, platform} from "@kampus/authz";
 import {Effect} from "effect";
@@ -24,34 +12,18 @@ import {Denied} from "../kunye/errors.ts";
 import {Moderate} from "../kunye/moderate.ts";
 
 /**
- * TRUE iff the current actor holds `Moderate.over(platform)`. The single arm of the
- * funnel gate: a real capability discharge whose denial (`Denied`) is collapsed to
- * `false` — the collapse-to-allow shape, kept as a named check so a later founder
- * arm (if founders ever diverge from the `moderates` tuple) OR-s in here without
- * touching the callers.
+ * Named rather than inlined so a later founder arm — if founders ever diverge from
+ * the `moderates` tuple — OR-s in here without touching the callers.
  */
 const standsInFunnel = Moderate.over(platform).pipe(
 	Effect.as(true),
 	Effect.catch(() => Effect.succeed(false)),
 );
 
-/**
- * The funnel-view right, discharged by platform-moderation authority (see module
- * docblock). A generic `Capability.Class` so the gate carries its own tag/right
- * distinct from `ViewDivan` — the funnel is a mod-only destination, not the divan's
- * yazar-OR-mod one.
- */
 export class ViewFunnel extends Capability.Class<ViewFunnel>()("funnel/ViewFunnel", {
 	deny: () => new Denied({message: "Dönüşüm metriklerini görmek için moderatör olmalısın."}),
 }) {}
 
-/**
- * Gate `body` behind funnel access: discharge {@link ViewFunnel} (the invisible
- * {@link Denied} on failure) and thread the resulting grant into `body`'s R channel
- * via `Grant.provide`. So `body` reads `yield* ViewFunnel` for the gate proof, and
- * "reading the funnel without a grant" is a compile error — the same shape as
- * `requireDivanAccess`, here over the mod-only capability.
- */
 export const requireFunnelAccess = <A, E, R>(body: Effect.Effect<A, E, ViewFunnel | R>) =>
 	ViewFunnel.authorize(standsInFunnel).pipe(
 		Effect.flatMap((grant) => body.pipe(Grant.provide(grant))),

--- a/apps/web/worker/features/funnel/gate.unit.test.ts
+++ b/apps/web/worker/features/funnel/gate.unit.test.ts
@@ -1,13 +1,7 @@
 /**
- * The funnel access gate (#1589) through the REAL capability seams — not a
- * re-implemented `isMod` check. {@link requireFunnelAccess} discharges
- * {@link ViewFunnel}, whose check runs a genuine `Moderate.over(platform)` discharge
- * (the `moderates` `Relation`) collapsed to a boolean. The matrix proves the mod arm
- * grants and every non-mod (a signed-in non-mod, the anonymous actor) is denied the
- * invisible `Denied`.
- *
- * The ports are scripted (`RelationStore` the moderates tuple, `AgentAuthority`
- * fail-closed, `CurrentActor` the actor) — no DB.
+ * The funnel access gate (#1589) through the REAL capability seams, not a re-implemented
+ * `isMod` check. Every non-mod — signed-in or anonymous — must get the same invisible
+ * `Denied`.
  */
 import {assert, describe, it} from "@effect/vitest";
 import {
@@ -22,7 +16,6 @@ import {Effect, Exit} from "effect";
 import type {Denied} from "../kunye/errors.ts";
 import {requireFunnelAccess, ViewFunnel} from "./gate.ts";
 
-/** Run the gate over `body = succeed("ok")` for one actor, scripting the mod set. */
 const access = (
 	actor: Actor,
 	opts: {readonly mods?: ReadonlyArray<string>} = {},
@@ -76,8 +69,8 @@ describe("funnel gate — platform-moderation only", () => {
 	});
 
 	it("an allowed read threads a ViewFunnel grant into the body's R (enforcement-by-R)", () => {
-		// `yield* ViewFunnel` would be a compile error without the provided grant — so
-		// reaching "reached" proves the gate supplied the proof, not just a boolean.
+		// `yield* ViewFunnel` would not compile without the provided grant, so reaching
+		// "reached" proves the gate supplied the proof rather than just a boolean.
 		const exit = Effect.runSyncExit(
 			requireFunnelAccess(
 				Effect.gen(function* () {

--- a/apps/web/worker/features/funnel/queries.ts
+++ b/apps/web/worker/features/funnel/queries.ts
@@ -1,16 +1,10 @@
 /**
- * The funnel root query resolver (#1589) — `funnel.summary`, the founder/mod
- * conversion readout's single gated read.
+ * `funnel.summary` — the founder/mod conversion readout's single gated read. The
+ * {@link requireFunnelAccess} capability gate (platform-moderation only) guards it, so a
+ * non-mod read fails the invisible {@link Denied}.
  *
- * The {@link requireFunnelAccess} capability gate — platform-moderation only —
- * guards the read: `yield* ViewFunnel` makes it unreachable without the discharged
- * grant, so a non-mod read fails the invisible {@link Denied}.
- *
- * A synthetic singleton like `stats.landingStats`: the wire type is the NAME string
- * (`"FunnelSummary"`), not the view class, so the entity stays off the source-
- * completeness path (the resolver is its only producer, no by-id fetch). Codegen is
- * unchanged — the client root types off `Root`'s `funnelSummaryDataView` + this
- * handler.
+ * A synthetic singleton like `stats.landingStats`: the wire type is the NAME string, not the
+ * view class, so the entity stays off the source-completeness path.
  */
 import {Fate} from "@kampus/fate-effect";
 import {Effect} from "effect";
@@ -21,9 +15,8 @@ import {requireFunnelAccess, ViewFunnel} from "./gate.ts";
 
 const FUNNEL_SUMMARY_ID = "summary";
 
-// The post-gate summary read — `ViewFunnel`-gated in R (`requireFunnelAccess`
-// provides the grant). `yield* ViewFunnel` requires the proof; the counts are
-// unreachable without a discharged grant.
+// `yield* ViewFunnel` requires the proof, so the counts are unreachable without a discharged
+// grant.
 const summaryGated = Effect.fn("funnel.summaryGated")(function* () {
 	yield* ViewFunnel;
 	const funnel = yield* Funnel;

--- a/apps/web/worker/features/funnel/views.ts
+++ b/apps/web/worker/features/funnel/views.ts
@@ -1,13 +1,8 @@
 /**
- * `FunnelSummary` — the conversion-funnel readout's one data view (#1589): the
- * current tier population (çaylak + yazar counts) plus the headline promotion rate
- * (#1593) and the first-contribution rate (#1591) as a singleton entity the mod front
- * page reads with `useRequest`. The
- * client normalizes by `record.id`, so the
- * entity carries a stable synthetic `id` (`"summary"`, stamped by
- * `queries.funnelSummary`) — there's only ever one row, so it collapses to a single
- * cache record, exactly like `stats/LandingStats`. See
- * `.patterns/fate-effect-data-views.md`.
+ * `FunnelSummary` — the conversion-funnel readout's one data view. The client
+ * normalizes by `record.id`, so this singleton carries a stable synthetic `id`
+ * (`"summary"`) and collapses to a single cache record, like `stats/LandingStats`.
+ * See `.patterns/fate-effect-data-views.md`.
  */
 import {FateDataView, type WorkerEntity} from "@kampus/fate-effect";
 import type {ViewRow} from "../fate/view-types.ts";
@@ -16,18 +11,12 @@ interface FunnelSummaryRow {
 	id: string;
 	caylakCount: number;
 	yazarCount: number;
-	/** The headline promotion rate (#1593), a fraction in `[0, 1]`. */
+	/** The three rates are fractions in `[0, 1]`. */
 	promotionRate: number;
-	/** First-contribution rate (#1591): share of human çaylaks with ≥ 1 sandboxed contribution, in `[0, 1]`. */
 	firstContributionRate: number;
-	/** Vouch rate (#1592): share of human çaylaks who received ≥ 1 vouch (kefil), in `[0, 1]`. */
 	vouchRate: number;
-	/**
-	 * Median registration→yazar time in ms (#1594), or `null` when no yazar is yet
-	 * measurable (empty measured population).
-	 */
+	/** `null` when no yazar is measurable yet (empty measured population). */
 	timeToPromotionMedianMs: number | null;
-	/** Human yazars excluded from the median for a null `promoted_at` (#1594). */
 	timeToPromotionNotYetMeasurable: number;
 }
 

--- a/apps/web/worker/features/kunye/AgentAuthorityV1.ts
+++ b/apps/web/worker/features/kunye/AgentAuthorityV1.ts
@@ -1,14 +1,8 @@
 /**
- * `AgentAuthorityV1` — the fail-closed v1 fill of the `AgentAuthority` port
- * (ADR 0107 §6). v1 is humans-only, so `admits` denies every agent: the
- * capability discharge verbs route their `Agent` arm through this port (a `Human`
- * passes directly, unattenuated), so a `false` here grants agents zero standing
- * even when their human root would itself pass.
- *
- * The whole point of the seam is that v1.1's real attenuation (agent authority ⊆
- * its human root) is **this one Layer swapped**, with no edit to `packages/authz`
- * — the framework's completeness litmus. Keep this Layer the sole implementation
- * point of the port; do not grow agent policy here.
+ * The fail-closed v1 fill of the `AgentAuthority` port (ADR 0107 §6): v1 is humans-only,
+ * so `admits` denies every agent even when their human root would pass. v1.1's real
+ * attenuation is THIS ONE LAYER swapped, with no edit to `packages/authz` — so keep it
+ * the sole implementation point and do not grow agent policy here.
  */
 import {AgentAuthority} from "@kampus/authz";
 import {Effect, Layer} from "effect";

--- a/apps/web/worker/features/kunye/AgentAuthorityV1.unit.test.ts
+++ b/apps/web/worker/features/kunye/AgentAuthorityV1.unit.test.ts
@@ -1,10 +1,8 @@
 /**
- * Unit — `AgentAuthorityV1` is fail-closed: `admits` denies every agent input,
- * so a capability discharged through the seam grants an agent nothing while a
- * human passes through unattenuated. The swap-without-editing-authz litmus is
- * asserted structurally — a program requiring the port is fully discharged by
- * this Layer alone (`Effect<…, never, never>`), so the port has exactly one
- * implementation point.
+ * `AgentAuthorityV1` is fail-closed: `admits` denies every agent input, so a
+ * capability discharged through the seam grants an agent nothing while a human passes
+ * through unattenuated. The swap-without-editing-authz litmus is asserted
+ * structurally: this Layer alone fully discharges a program requiring the port.
  */
 import {
 	type Actor,
@@ -45,10 +43,9 @@ class Denied {
 
 const ladder = Scale(["visitor", "çaylak", "yazar"]);
 
-/** Standing fixture: account id → earned rank (the agent root "yzr" is a yazar). */
+// The agent root "yzr" is a yazar.
 const standings: Record<string, "visitor" | "çaylak" | "yazar"> = {yzr: "yazar"};
 
-/** A `Level` right floored at çaylak, discharged through the agent seam. */
 class OpenTerm extends Capability.Level<OpenTerm>()("kunye/OpenTerm", {
 	scale: ladder,
 	min: "çaylak",

--- a/apps/web/worker/features/kunye/Authorship.ts
+++ b/apps/web/worker/features/kunye/Authorship.ts
@@ -1,25 +1,17 @@
 /**
- * `Authorship` — the earned-ladder capability-per-right instances (ADR 0107
- * §2-3): `OpenTerm` (floor `yazar`) and `AddEntry` (floor `çaylak`). Each is a
- * single `Capability.Level` class — the tag IS the right, yielding the proof
- * tag, its `Grant` type, `.require`, and `.provide` from one name — that floors
- * the GLOBAL account-level standing read from {@link Kunye} against the
- * {@link authorshipLadder} and denies with {@link RequiresLevel} (`FORBIDDEN`).
- *
- * #1203 makes the floored standing a server-managed `user.tier` column (read via
- * {@link Kunye.tierOf}); wiring these capabilities into the sözlük term/entry create
- * paths is a separate follow-up child. This module is the capability definitions only.
+ * The earned-ladder capability-per-right instances (ADR 0107 §2-3). Each is one
+ * `Capability.Level` class whose tag IS the right, floored against the account-level
+ * standing {@link Kunye} reads. Definitions only — wiring them into the sözlük create
+ * paths happens elsewhere.
  */
 import {Capability, type Principal} from "@kampus/authz";
 import {Effect} from "effect";
 import {RequiresLevel} from "./errors.ts";
 import {authorshipLadder, Kunye} from "./Kunye.ts";
 
-/** Read a principal's global account-level rank off the {@link Kunye} standing service. */
 const standingOf = (principal: Principal) =>
 	Effect.flatMap(Kunye, (kunye) => kunye.tierOf(principal.id));
 
-/** Open a new sözlük başlık — requires `yazar` earned standing. */
 export class OpenTerm extends Capability.Level<OpenTerm>()("kunye/OpenTerm", {
 	scale: authorshipLadder,
 	min: "yazar",
@@ -27,7 +19,6 @@ export class OpenTerm extends Capability.Level<OpenTerm>()("kunye/OpenTerm", {
 	deny: () => new RequiresLevel({message: "Başlık açmak için yazar olmalısın.", need: "yazar"}),
 }) {}
 
-/** Add an entry under a başlık — requires `çaylak`+ earned standing. */
 export class AddEntry extends Capability.Level<AddEntry>()("kunye/AddEntry", {
 	scale: authorshipLadder,
 	min: "çaylak",

--- a/apps/web/worker/features/kunye/Authorship.typetest.ts
+++ b/apps/web/worker/features/kunye/Authorship.typetest.ts
@@ -1,11 +1,7 @@
 /**
- * Type-level assertion (no runtime — checked by `tsgo`, not vitest): an op that
- * declares `OpenTerm` / `AddEntry` in its requirements channel **fails to
- * compile** unless the matching `Grant` is provided via `Grant.provide` (ADR 0107
- * §1, the "forgot to authorize is a compile error" guarantee). Falsifiable by
- * reading the R channel — omit `Grant.provide` and the capability stays required;
- * provide it and R collapses to `never`. Mirrors `packages/authz`'s
- * `Capability.typetest.ts`, here over the real künye instances.
+ * Type-level assertion (no runtime — checked by `tsgo`, not vitest): an op declaring `OpenTerm` /
+ * `AddEntry` in its requirements channel fails to compile unless the matching `Grant` is provided
+ * (ADR 0107 §1, the "forgot to authorize is a compile error" guarantee).
  */
 import {type AgentAuthority, type CurrentActor, Grant} from "@kampus/authz";
 import {Effect} from "effect";
@@ -14,25 +10,21 @@ import {AddEntry, OpenTerm} from "./Authorship.ts";
 import type {RequiresLevel} from "./errors.ts";
 import type {Kunye} from "./Kunye.ts";
 
-/** The requirements (R) channel of an effect type. */
 type RequirementsOf<T> = [T] extends [Effect.Effect<unknown, unknown, infer R>] ? R : never;
 
 declare const openTermGrant: Grant<OpenTerm>;
 declare const addEntryGrant: Grant<AddEntry>;
 
-/** An op that opens a başlık declares the `OpenTerm` proof and reads it back. */
 const openOp: Effect.Effect<string, never, OpenTerm> = Effect.gen(function* () {
 	const proof = yield* OpenTerm;
 	return proof.scope.capability;
 });
 
-/** An op that adds an entry declares the `AddEntry` proof. */
 const addOp: Effect.Effect<string, never, AddEntry> = Effect.gen(function* () {
 	const proof = yield* AddEntry;
 	return proof.scope.capability;
 });
 
-/** Providing each proof discharges its requirement — R collapses to `never`. */
 export const openDischarged: Effect.Effect<string, never, never> = openOp.pipe(
 	Grant.provide(openTermGrant),
 );
@@ -40,13 +32,11 @@ export const addDischarged: Effect.Effect<string, never, never> = addOp.pipe(
 	Grant.provide(addEntryGrant),
 );
 
-// Omit `Grant.provide` → the capability stays required in R; provide it → R is `never`.
 expectTypeOf<RequirementsOf<typeof openOp>>().toEqualTypeOf<OpenTerm>();
 expectTypeOf<RequirementsOf<typeof openDischarged>>().toEqualTypeOf<never>();
 expectTypeOf<RequirementsOf<typeof addOp>>().toEqualTypeOf<AddEntry>();
 expectTypeOf<RequirementsOf<typeof addDischarged>>().toEqualTypeOf<never>();
 
-/** Each discharge verb requires the ports + standing read, never the proof it mints. */
 export const openRequired: Effect.Effect<
 	Grant<OpenTerm>,
 	RequiresLevel,

--- a/apps/web/worker/features/kunye/Authorship.unit.test.ts
+++ b/apps/web/worker/features/kunye/Authorship.unit.test.ts
@@ -1,13 +1,8 @@
 /**
- * Unit — the `Authorship` rights through the real `Capability.Level` seam: a
- * yazar clears `OpenTerm`, a çaylak is denied `OpenTerm` but clears the
- * çaylak-floored `AddEntry` (ordered-ladder `gte`), and a visitor / the
- * anonymous actor are denied both. Standing is read off the real {@link Kunye}
- * service (a {@link makeKunyeStub} keyed by account id), the actor flows through
- * {@link CurrentActor}, and the agent arm routes the fail-closed
- * {@link AgentAuthorityV1}, so the denial paths are the real discharge, not a
- * re-implemented check. Insufficient standing fails {@link RequiresLevel}
- * (`FORBIDDEN`), carrying the needed rank.
+ * The `Authorship` rights through the REAL `Capability.Level` seam — the denial paths
+ * are the real discharge, not a re-implemented check. Standing is read off the real
+ * {@link Kunye} service, the actor flows through {@link CurrentActor}, and the agent
+ * arm routes the fail-closed {@link AgentAuthorityV1}.
  */
 import {
 	type Actor,
@@ -26,12 +21,10 @@ import {RequiresLevel} from "./errors.ts";
 import {makeKunyeStub} from "./Kunye.testing.ts";
 import type {Kunye, Tier} from "./Kunye.ts";
 
-/** Account id → earned rank, the standing the real `Kunye.tierOf` read resolves. */
 const standings: Record<string, Tier> = {yzr: "yazar", cyl: "çaylak", vis: "visitor"};
 
 const kunye = makeKunyeStub({tierOf: (id) => Effect.succeed(standings[id] ?? "visitor")});
 
-/** Discharge a right against an actor through all three real ports (one merged Layer). */
 const require = <Self>(
 	gate: Effect.Effect<Grant<Self>, RequiresLevel, CurrentActor | AgentAuthority | Kunye>,
 	actor: Actor,
@@ -42,7 +35,6 @@ const require = <Self>(
 		),
 	);
 
-/** The `RequiresLevel` a denied discharge failed with. */
 const denial = (exit: Exit.Exit<unknown, RequiresLevel>): RequiresLevel => {
 	const failure = Exit.isFailure(exit) ? Cause.findErrorOption(exit.cause) : Option.none();
 	if (Option.isNone(failure)) throw new Error("expected a RequiresLevel denial, got a grant");

--- a/apps/web/worker/features/kunye/CurrentActorLive.ts
+++ b/apps/web/worker/features/kunye/CurrentActorLive.ts
@@ -1,32 +1,22 @@
 /**
- * `CurrentActorLive` — the adapter that realizes the authz {@link CurrentActor}
- * port from the per-request pasaport session (ADR 0107 §5/§7). It derives the
- * {@link Actor} from fate's {@link CurrentUser} and hands it to the app through
- * the generic fate-effect provision seam (#1230), never a worker-level `Layer`:
- * the actor is per-request (it depends on the request's session), so it belongs
- * in `FateRequestContext.requestServices`, fulfilled at the `/fate` route edge.
+ * `CurrentActorLive` — realizes the authz {@link CurrentActor} port from the
+ * per-request pasaport session (ADR 0107 §5/§7). Provided through fate-effect's
+ * per-request seam, never a worker-level `Layer`, because the actor depends on the
+ * request's session.
  *
- * **v1 is humans-only:** the derivation yields only `Unauthenticated` (anonymous
- * traffic) or `Human` (a signed-in account), never `Agent`. The agent arm is the
- * dormant seam — there is no agent identity on the session in v1, so an
- * authenticated request is always a `Human`.
+ * v1 is humans-only: `Unauthenticated` or `Human`, never `Agent`. There is no agent
+ * identity on the session yet, so the agent arm is a dormant seam.
  */
 import {type Actor, CurrentActor, human, unauthenticated} from "@kampus/authz";
 import type {CurrentUserInfo} from "@kampus/fate-effect";
 import {Context} from "effect";
 
-/**
- * Derive the request's {@link Actor} from the session user: `undefined` (anonymous)
- * → `Unauthenticated`, otherwise the signed-in account → `Human`. Never `Agent` (v1).
- */
 export const currentActorOf = (user: CurrentUserInfo | undefined): Actor =>
 	user === undefined ? unauthenticated : human(user.id);
 
 /**
- * The per-request {@link CurrentActor} value, ready to drop into
- * `FateRequestContext.requestServices` (`Context.make(CurrentActor, …)`). The
- * `/fate` route edge calls this with the validated session user; the seam
- * provides it innermost so capability checks `yield* CurrentActor` resolve it.
+ * The per-request {@link CurrentActor} value for
+ * `FateRequestContext.requestServices`, built at the `/fate` route edge.
  */
 export const currentActorContext = (
 	user: CurrentUserInfo | undefined,

--- a/apps/web/worker/features/kunye/CurrentActorLive.unit.test.ts
+++ b/apps/web/worker/features/kunye/CurrentActorLive.unit.test.ts
@@ -1,9 +1,4 @@
-/**
- * `CurrentActorLive` derivation (ADR 0107 §5): anonymous session → `Unauthenticated`,
- * a signed-in account → `Human` keyed by its id, NEVER an `Agent` (v1 humans-only).
- * `currentActorContext` packages that actor into the per-request `CurrentActor`
- * value the fate-effect seam fulfills.
- */
+/** `CurrentActorLive` derivation (ADR 0107 §5). Never an `Agent` — v1 is humans-only. */
 import {assert, describe, it} from "@effect/vitest";
 import {CurrentActor} from "@kampus/authz";
 import type {CurrentUserInfo} from "@kampus/fate-effect";

--- a/apps/web/worker/features/kunye/Kunye.testing.ts
+++ b/apps/web/worker/features/kunye/Kunye.testing.ts
@@ -1,9 +1,6 @@
 /**
- * `makeKunyeStub` — the shared {@link Kunye} test double, mirroring
- * `Pasaport.testing.ts`. Every standing read fails-on-contact (`Effect.die`) by
- * default; a test overrides only the read(s) under test. The one place the
- * `Kunye` shape lives for tests — the capability instances (#1235) that gate on
- * standing stub it here, not by hand.
+ * The shared {@link Kunye} test double. Every standing read fails-on-contact by default,
+ * so a test overrides only the read under test and an unexpected read is a failure.
  */
 import {Effect, Layer} from "effect";
 import {Kunye} from "./Kunye.ts";

--- a/apps/web/worker/features/kunye/Kunye.ts
+++ b/apps/web/worker/features/kunye/Kunye.ts
@@ -1,19 +1,9 @@
 /**
- * `Kunye` — the GLOBAL account-level earned-standing service (ADR 0107 §4): an
- * account's authorship `tier` on the `visitor < çaylak < yazar` ladder, its
- * `karma`, and the agent-attenuation `root` seam. Standing is read **fresh at
- * the point of use** from pasaport, never trusted from session state — the
- * "richer reads behind a domain service" rule, so a `CurrentUserInfo` carrying
- * only id/email/name/image cannot smuggle a stale rank.
- *
- * `tierOf` reads the **server-managed `user.tier` column** (#1203) — an
- * authenticated account is `≥ çaylak`, a no-account principal is `visitor`. (The
- * karma→tier derivation it once used is retired from this read; that math now
- * belongs to the promotion (#1206) / karma (#1208) children — see `standing.ts`.)
- *
- * It is the read side the `Capability.Level` instances (#1235's `Authorship`)
- * discharge against: their `read: (principal) => Effect<rank>` thunk is
- * {@link Kunye.tierOf} keyed by the principal's account id.
+ * The account-level earned-standing service (ADR 0107 §4): authorship tier, karma,
+ * and the agent-attenuation root seam. Standing is read fresh from pasaport at the
+ * point of use and never trusted from session state, so a session user object cannot
+ * smuggle a stale rank. It is the read side the `Capability.Level` instances
+ * discharge against.
  */
 import {Context, Effect, Layer} from "effect";
 import {Pasaport} from "../pasaport/Pasaport.ts";
@@ -31,15 +21,11 @@ export {
 export class Kunye extends Context.Service<
 	Kunye,
 	{
-		/** The account's authorship rank on the `visitor < çaylak < yazar` ladder. */
+		// The rank on the `visitor < çaylak < yazar` ladder.
 		readonly tierOf: (id: string) => Effect.Effect<Tier>;
-		/** The account's earned karma (`user_profile.total_karma`; 0 when no profile row). */
 		readonly karmaOf: (id: string) => Effect.Effect<number>;
-		/**
-		 * The human root an account's authority attenuates to. **v1 is humans-only**,
-		 * so an account's root is itself; v1.1 resolves an agent id to its human root
-		 * through the agent registry, with no edit to this signature (the dormant seam).
-		 */
+		// The human root an account's authority attenuates to. v1 is humans-only, so an
+		// account's root is itself; the signature is the dormant seam for agent ids.
 		readonly rootOf: (id: string) => Effect.Effect<string>;
 	}
 >()("kunye/Kunye") {}
@@ -55,8 +41,7 @@ export const KunyeLive = Layer.effect(Kunye)(
 
 		return {
 			karmaOf,
-			// The stored `user.tier` column read fresh through pasaport (#1203). No
-			// account row ⇒ `visitor`; an account is its stored `çaylak | yazar`.
+			// No account row means `visitor`; an account carries its stored tier (#1203).
 			tierOf: (id) => Effect.map(pasaport.getUserById(id), (user): Tier => user?.tier ?? "visitor"),
 			rootOf: (id) => Effect.succeed(id),
 		};

--- a/apps/web/worker/features/kunye/Kunye.unit.test.ts
+++ b/apps/web/worker/features/kunye/Kunye.unit.test.ts
@@ -1,13 +1,7 @@
 /**
- * `Kunye` standing reads (ADR 0107 §4):
- *   - `tierForKarma` — the pure karma→tier derivation across every rank boundary
- *     (retired from `tierOf`, now the promotion/karma children's input).
- *   - `KunyeLive.tierOf` — reads the **stored `user.tier` column** FRESH off pasaport
- *     (a scripted `getUserById`): an account is its stored `çaylak | yazar`, a
- *     no-account principal is `visitor`. The whole point is that standing comes from
- *     D1 at the point of use, never session state.
- *   - `KunyeLive.karmaOf` — reads `total_karma` off the profile surface.
- *   - `rootOf` — the v1 humans-only identity seam.
+ * `Kunye` standing reads (ADR 0107 §4). The load-bearing one is `tierOf`: it reads the
+ * stored `user.tier` column FRESH off pasaport, so standing comes from D1 at the point
+ * of use, never from session state. A principal with no account row is `visitor`.
  */
 import {assert, describe, it} from "@effect/vitest";
 import {Effect, Layer} from "effect";
@@ -35,11 +29,9 @@ const userRow = (tier: StoredTier): UserRow => ({
 	tier,
 });
 
-/** Stub the karma surface (`lookupProfileById`) for the `karmaOf` reads. */
 const kunyeOverProfile = (row: ProfileRow | null): Layer.Layer<Kunye> =>
 	KunyeLive.pipe(Layer.provide(makePasaportStub({lookupProfileById: () => Effect.succeed(row)})));
 
-/** Stub the stored-tier surface (`getUserById`) for the `tierOf` reads. */
 const kunyeOverUser = (row: UserRow | null): Layer.Layer<Kunye> =>
 	KunyeLive.pipe(Layer.provide(makePasaportStub({getUserById: () => Effect.succeed(row)})));
 

--- a/apps/web/worker/features/kunye/RelationStore.ts
+++ b/apps/web/worker/features/kunye/RelationStore.ts
@@ -1,10 +1,7 @@
 /**
- * `RelationStoreLive` — the D1 adapter for `@kampus/authz`'s `RelationStore` port,
- * answering the ReBAC existence question over the `relation_tuple` table (ADR 0107).
- *
- * The port declares only `has`: the tuple's presence IS the grant, and there is no
- * runtime write path — tuples are minted offline (`@kampus/founder-seed`), the same
- * fail-closed shape `user.role` had.
+ * `RelationStoreLive` — the D1 adapter for `@kampus/authz`'s `RelationStore` port (ADR 0107).
+ * The port declares only `has`: the tuple's presence IS the grant, and there is no runtime
+ * write path — tuples are minted offline, the same fail-closed shape `user.role` had.
  */
 import {key as objectKey, RelationStore} from "@kampus/authz";
 import {and, eq, inArray} from "drizzle-orm";
@@ -12,10 +9,9 @@ import {Effect, Layer} from "effect";
 import {Drizzle, orDieAccess} from "../../db/Drizzle.ts";
 import * as schema from "../../db/drizzle/schema.ts";
 
-// The `relation_tuple.object` key IS `@kampus/authz`'s canonical `key` — re-exported
-// under the worker-side name so the integration seed and the store read encode the
-// object identically to the offline mint (`@kampus/founder-seed`). One key, no
-// divergence: a seeded tuple is found by a discharge over the same node.
+// The `relation_tuple.object` key IS `@kampus/authz`'s canonical `key`, re-exported under
+// the worker-side name so the integration seed and the store read encode the object
+// identically to the offline mint. One key, no divergence.
 export {objectKey};
 
 export const RelationStoreLive = Layer.effect(RelationStore)(

--- a/apps/web/worker/features/kunye/RelationStore.unit.test.ts
+++ b/apps/web/worker/features/kunye/RelationStore.unit.test.ts
@@ -1,13 +1,7 @@
 /**
- * `RelationStoreLive` unit coverage — the port-contract decisions that are
- * wrong-or-right with no database (ADR 0082): a present row → `has === true`, an
- * absent row → `has === false`, the read runs fresh on every call (no cached
- * authority), and the `object` column key is the resource's `(type, id)` pair.
- *
- * The `Drizzle` seam is substituted directly (the `Report.unit.test.ts` idiom): a
- * scripted `run` returns the queued lookup result verbatim without an engine. Whether
- * the WHERE actually resolves the composite-PK existence against real D1 is
- * only-wrong-if-the-DB-differs and lives in the integration tier
+ * `RelationStoreLive` unit coverage — the port-contract decisions that hold with no database
+ * (ADR 0082), with the `Drizzle` seam substituted directly. Whether the WHERE actually resolves
+ * the composite-PK existence against real D1 is the integration tier's job
  * (`tests/integration/kunye-relation-store.test.ts`).
  */
 
@@ -19,9 +13,8 @@ import {createDrizzle, Drizzle, type DrizzleAccess, type DrizzleDb} from "../../
 import * as schema from "../../db/drizzle/schema.ts";
 import {objectKey, RelationStoreLive} from "./RelationStore.ts";
 
-// A `run` that returns the queued lookup result verbatim (the callback is never
-// invoked, so no engine is needed) and counts how many times it was called — the
-// counter pins the fresh-per-call read.
+// Returns the queued result verbatim (the callback is never invoked, so no engine is needed)
+// and counts calls — the counter pins the fresh-per-call read.
 function countingAccess(result: unknown): {access: DrizzleAccess; calls: () => number} {
 	const state = {n: 0};
 	return {
@@ -178,9 +171,6 @@ describe("RelationStore.subjectsOf — the open-set enumeration for one (relatio
 });
 
 describe("RelationStore.has — query shape (statement pin, no engine)", () => {
-	// The production lookup compiles to an existence read over `relation_tuple`,
-	// filtered by the three tuple columns with the `objectKey` serialization. The real
-	// engine resolving it is the integration tier's job; this pins the SQL contract.
 	it("filters subject/relation/object on relation_tuple, limit 1", () => {
 		const db: DrizzleDb = createDrizzle({} as D1Database);
 		const {sql, params} = db

--- a/apps/web/worker/features/kunye/VouchLedger.testing.ts
+++ b/apps/web/worker/features/kunye/VouchLedger.testing.ts
@@ -1,9 +1,7 @@
 /**
- * `makeVouchLedgerStub` — the shared {@link VouchLedger} test double. Defaults every
- * method to fail-on-contact (`Effect.die`) and takes a partial override of the
- * method(s) under test (`.patterns/effect-testing.md`, the `makePasaportStub` idiom).
- * A `layerStub`, not a `layerNoop`: an un-overridden method, if reached, dies and
- * fails the test — proving the path touched only the method(s) it was scripted with.
+ * The shared {@link VouchLedger} double. Fail-on-contact by default, not a noop: an
+ * un-overridden method that gets reached dies, proving the path touched only what it
+ * was scripted with (`.patterns/effect-testing.md`).
  */
 import {Effect, Layer} from "effect";
 import {VouchLedger} from "./VouchLedger.ts";

--- a/apps/web/worker/features/kunye/VouchLedger.ts
+++ b/apps/web/worker/features/kunye/VouchLedger.ts
@@ -1,24 +1,12 @@
 /**
- * `VouchLedger` — the D1-backed store of the authorship-vouch act (#1206, extended in
- * #1289): records a yazar's vouch for a çaylak (preserving the vouching actor), reads
- * back whether a vouch exists, counts a yazar's active vouches for the cap, and
- * withdraws a vouch. The recorded act is the `authorship_vouch` table; the AUTHORITY
- * to vouch (the yazar floor) is the {@link ./vouch.ts | Vouch} capability discharged
- * at the resolver, never here — this service is the persistence seam only (ADR 0013:
- * domain write in the service, the authority check at the gate).
+ * `VouchLedger` — the persistence seam for the authorship-vouch act (#1206/#1289). The
+ * AUTHORITY to vouch is the {@link ./vouch.ts | Vouch} capability discharged at the
+ * resolver, never here (ADR 0013).
  *
- * **Active-by-existence (#1289).** A vouch's lifecycle is encoded in the *presence* of
- * its row plus the candidate's tier — no `withdrawn`/`active` column, so #1289 reuses
- * the #1206 (migration 0013) schema with no migration. A vouch is **active** iff its
- * row exists *and* the candidate is still a `çaylak` (pending): `withdraw` deletes the
- * row (the slot returns), and a promotion flips the candidate to `yazar` (the row
- * persists as the successful-vouch record but no longer counts as active — the slot
- * also returns). "A withdrawn vouch" is therefore unrepresentable; the active set is
- * exactly `{rows whose candidate is still çaylak}`.
- *
- * Idempotency lives in the table: the composite PK `(voucher_id, candidate_id)` +
- * `onConflictDoNothing` makes a re-vouch by the same yazar a no-op success (the
- * `content_report` / `user_vote` precedent).
+ * **Active-by-existence (#1289).** There is no `withdrawn`/`active` column: a vouch is
+ * active iff its row exists AND the candidate is still a `çaylak`. `withdraw` deletes the
+ * row and a promotion flips the tier — either way the slot returns, and "a withdrawn
+ * vouch" is unrepresentable.
  */
 import {and, eq, sql} from "drizzle-orm";
 import {Context, Effect, Layer} from "effect";
@@ -32,16 +20,9 @@ export interface VouchKey {
 }
 
 /**
- * The three outcomes of {@link VouchLedger.castVouch}, the single cap-enforcing write:
- *
- *  - `recorded` — a NEW vouch row was inserted (the voucher was under the cap).
- *  - `alreadyVouched` — the row already existed: an idempotent re-vouch, a success that
- *    consumes no fresh slot (so it is allowed even when the voucher is at the cap).
- *  - `capReached` — no row existed and the cap blocked the insert; the caller surfaces
- *    {@link ./errors.ts | VouchLimitReached}.
- *
- * The split lets the resolver map `capReached` to the denial and `recorded`/`alreadyVouched`
- * to a success — without the resolver ever re-deriving the cap arithmetic (ADR 0013).
+ * `alreadyVouched` consumes no fresh slot, so it succeeds even when the voucher is at the
+ * cap. The split lets the resolver map outcomes without re-deriving the cap arithmetic
+ * (ADR 0013).
  */
 export type VouchOutcome = "recorded" | "alreadyVouched" | "capReached";
 
@@ -49,14 +30,9 @@ export class VouchLedger extends Context.Service<
 	VouchLedger,
 	{
 		/**
-		 * Record `voucherId` vouching for `candidateId`, **enforcing the
-		 * {@link ./standing.ts | VOUCH_CONCURRENT_CAP} as part of the write** — the
-		 * single, atomic vouch-insertion seam (#1362). The cap-check and the insert are
-		 * one guarded `INSERT … SELECT … WHERE active_count < cap` statement, so two
-		 * concurrent vouches can never both pass the cap and both insert (the
-		 * check-then-act race the inline resolver enforcement had). Idempotent on the
-		 * composite PK — a re-vouch is `alreadyVouched`, never a fresh slot. The cap
-		 * invariant lives here, not at the resolver (ADR 0013); see {@link VouchOutcome}.
+		 * Enforces {@link ./standing.ts | VOUCH_CONCURRENT_CAP} as part of the write: one
+		 * guarded statement, so two concurrent vouches can never both pass the cap and both
+		 * insert (#1362). The cap invariant lives here, not at the resolver (ADR 0013).
 		 */
 		readonly castVouch: (input: {
 			voucherId: string;
@@ -64,52 +40,30 @@ export class VouchLedger extends Context.Service<
 			now: Date;
 		}) => Effect.Effect<{outcome: VouchOutcome}>;
 
-		/** Whether `voucherId` has already vouched for `candidateId` (the row exists). */
 		readonly has: (input: VouchKey) => Effect.Effect<boolean>;
 
-		/**
-		 * The number of **active** vouches `voucherId` currently holds (the cap input,
-		 * D5). Active = a vouch row whose candidate is still a `çaylak`; a promoted
-		 * candidate's vouch is excluded (its slot returned), so the count rations only
-		 * the yazar's *pending* stake. A withdrawn vouch has no row, so it isn't counted.
-		 */
+		/** The cap input: vouches whose candidate is still `çaylak`. */
 		readonly activeCountFor: (voucherId: string) => Effect.Effect<number>;
 
-		/**
-		 * Whether `candidateId` has **≥1 active vouch** from any yazar — the vouch half
-		 * of the order-independent tandem (#1289). Active mirrors {@link activeCountFor}:
-		 * a vouch row names this candidate AND the candidate is still `çaylak`, so an
-		 * already-promoted (`yazar`) candidate reads `false` (its row persists but no
-		 * longer counts as active).
-		 */
+		/** The vouch half of the order-independent tandem (#1289); active as above. */
 		readonly hasActiveFor: (candidateId: string) => Effect.Effect<boolean>;
 
-		/**
-		 * Withdraw `voucherId`'s vouch for `candidateId` — delete the row, returning the
-		 * slot. Idempotent: withdrawing an absent/already-withdrawn vouch is a no-op
-		 * (`withdrawn: false`).
-		 */
+		/** Idempotent: withdrawing an absent vouch is a no-op (`withdrawn: false`). */
 		readonly withdraw: (input: VouchKey) => Effect.Effect<{withdrawn: boolean}>;
 	}
 >()("@kampus/kunye/VouchLedger") {}
 
 export const VouchLedgerLive = Layer.effect(VouchLedger)(
 	Effect.gen(function* () {
-		// `orDieAccess`: infra failures die as defects, so public signatures carry no
-		// `DrizzleError` and `R` stays `never` (`.patterns/feature-services.md`).
+		// `orDieAccess`: see .patterns/feature-services.md.
 		const {run, batch} = orDieAccess(yield* Drizzle);
 
-		// The cap-enforcing insert is ONE guarded statement, so the cap check and the
-		// insert are not separable round-trips another vouch can interleave between
-		// (#1362's check-then-act race). The guard is `INSERT … SELECT <values> WHERE
-		// (active-count subquery) < cap`: SQLite evaluates the count subquery and
-		// performs the insert inside a single write statement, and D1 serializes writers
-		// onto its one primary SQLite — so a concurrent vouch's statement runs after this
-		// one commits and its subquery sees this row. Same single-statement-guard family
-		// as `Pasaport.promoteToYazar`'s conditional `UPDATE … WHERE tier = 'çaylak'`
-		// (ADR 0014). It runs in a batch with an existence probe so the zero-insert case
-		// — cap-blocked vs. idempotent re-vouch — is disambiguated atomically, in the same
-		// transaction, without a second round-trip that could read a different world.
+		// The cap check and the insert are ONE guarded `INSERT … SELECT … WHERE
+		// (active-count subquery) < cap` statement, closing #1362's check-then-act race:
+		// SQLite evaluates the subquery and inserts inside a single write statement, and D1
+		// serializes writers onto one primary. The existence probe rides the same batch so
+		// the zero-insert case is disambiguated without a second round-trip that could read
+		// a different world.
 		const castVouch = Effect.fn("VouchLedger.castVouch")(function* (input: {
 			voucherId: string;
 			candidateId: string;
@@ -148,9 +102,8 @@ export const VouchLedgerLive = Layer.effect(VouchLedger)(
 				return [guardedInsert, existenceProbe] as const;
 			});
 			if (insertResult.meta.changes > 0) return {outcome: "recorded" as const};
-			// Zero rows inserted: the row already existed (idempotent re-vouch) or the cap
-			// blocked a new one. The cap was already enforced atomically above — this only
-			// labels which zero-insert case occurred, so it can't reopen the race.
+			// The cap was already enforced atomically above — this only labels which
+			// zero-insert case occurred, so it can't reopen the race.
 			return {outcome: existing.length > 0 ? ("alreadyVouched" as const) : ("capReached" as const)};
 		});
 
@@ -174,10 +127,8 @@ export const VouchLedgerLive = Layer.effect(VouchLedger)(
 				return row !== undefined;
 			}),
 
-			// Active = the vouch row exists AND the candidate is still `çaylak`. The
-			// inner-join to `user` is what makes a promotion *return the slot* without
-			// touching the vouch row: once the candidate is `yazar` the row no longer
-			// matches `tier = 'çaylak'`, so it drops out of the cap count.
+			// The inner-join to `user` is what makes a promotion return the slot without
+			// touching the vouch row: a `yazar` candidate drops out of the cap count.
 			activeCountFor: Effect.fn("VouchLedger.activeCountFor")(function* (voucherId: string) {
 				const row = yield* run((db) =>
 					db
@@ -192,8 +143,8 @@ export const VouchLedgerLive = Layer.effect(VouchLedger)(
 				return row?.n ?? 0;
 			}),
 
-			// Tier-filtered like `activeCountFor` (same inner-join): an already-promoted
-			// (`yazar`) candidate's persisted row no longer counts as active (#1324).
+			// Tier-filtered like `activeCountFor`: a promoted candidate's persisted row no
+			// longer counts as active (#1324).
 			hasActiveFor: Effect.fn("VouchLedger.hasActiveFor")(function* (candidateId: string) {
 				const row = yield* run((db) =>
 					db

--- a/apps/web/worker/features/kunye/VouchLedger.unit.test.ts
+++ b/apps/web/worker/features/kunye/VouchLedger.unit.test.ts
@@ -1,20 +1,11 @@
 /**
- * `VouchLedger.castVouch` coverage (#1362) — the load-bearing concern is that the
- * concurrent-vouch cap (D5, {@link VOUCH_CONCURRENT_CAP}) is enforced *atomically with
- * the insert*, not as a separable check-then-act the resolver re-derives. Proven by
- * rendering the statements' `.toSQL()` over a no-op D1 (the `promotion-sweep.unit.test.ts`
- * idiom) — no engine, so this is a unit test; real-D1 concurrency fidelity (two near-
- * simultaneous vouches → exactly one lands at the boundary) is the integration tier.
+ * `VouchLedger.castVouch` — the load-bearing concern is that the concurrent-vouch cap is
+ * enforced *atomically with the insert*, not as a separable check-then-act. The cap check
+ * and the insert compile to a single `INSERT … SELECT <values> WHERE (active-count
+ * subquery) < cap`, so no concurrent vouch can interleave between the two.
  *
- * The two structural guarantees asserted here:
- *   - **One guarded statement.** The cap check and the insert compile to a single
- *     `INSERT … SELECT <values> WHERE (active-count subquery) < cap` — NOT a `count`
- *     read followed by a separate insert. Because it is one statement (run in a batch
- *     with only an existence probe, never via `run`), no concurrent vouch can interleave
- *     between the cap check and the insert, so the cap can't be exceeded by a race.
- *   - **Outcome mapping.** `recorded` when the insert changed a row, `alreadyVouched`
- *     when zero rows changed but the row already exists (idempotent re-vouch), and
- *     `capReached` when zero rows changed and no row exists (the cap blocked it).
+ * Proven by rendering `.toSQL()` over a no-op D1 — no engine, so this is a unit test;
+ * real-D1 concurrency fidelity is the integration tier.
  */
 import {assert, describe, it} from "@effect/vitest";
 import {drizzle} from "drizzle-orm/d1";
@@ -30,8 +21,7 @@ import {
 import {VOUCH_CONCURRENT_CAP} from "./standing.ts";
 import {VouchLedger, VouchLedgerLive} from "./VouchLedger.ts";
 
-// A real drizzle client over a no-op D1 — used ONLY to render the batch statements'
-// `.toSQL()`; it never executes.
+// A real drizzle client over a no-op D1, used ONLY to render `.toSQL()`; it never executes.
 // biome-ignore lint/plugin: `D1Database` is a host binding that can't be structurally constructed in a fake; nothing here executes against it.
 const noopD1 = {
 	prepare: () => ({
@@ -57,10 +47,8 @@ const noopD1 = {
 } as unknown as D1Database;
 const renderDb = drizzle(noopD1, {relations});
 
-// Captures the batch's two rendered statements (guarded insert, existence probe) and
-// answers with a scripted result: the insert's `meta.changes` and whether the existence
-// probe finds the row. `run` is fail-on-contact — `castVouch` must batch, never split
-// the cap check off into its own single statement.
+// Captures the batch's two rendered statements and answers with a scripted result. `run` is
+// fail-on-contact — `castVouch` must batch, never split the cap check into its own statement.
 function capturingBatch(opts: {changes: number; existing: boolean}): {
 	access: DrizzleAccess;
 	statements: () => {sql: string; params: unknown[]}[];
@@ -164,9 +152,8 @@ describe("VouchLedger.castVouch — the cap is enforced atomically with the inse
 	);
 });
 
-// A no-op D1 that records the rendered `{sql, params}` of the statement `.get()` prepares
-// and binds — `hasActiveFor` runs a real drizzle read over it, so this captures the actual
-// compiled SQL at the binding boundary without an engine (ADR 0082/0104/0105).
+// Records the rendered `{sql, params}` the statement `.get()` prepares and binds, so a real
+// drizzle read is captured at the binding boundary without an engine.
 function capturingRun(): {
 	access: DrizzleAccess;
 	statement: () => {sql: string; params: unknown[]};
@@ -225,9 +212,8 @@ const hasActiveFor = (cap: ReturnType<typeof capturingRun>, candidateId: string)
 
 describe("VouchLedger.hasActiveFor — active is tier-filtered, symmetric with activeCountFor (#1324)", () => {
 	// The behavioral contract — a yazar candidate whose only vouch row is leftover yields
-	// `false` — is pinned structurally here: the read inner-joins `user` and binds the
-	// `çaylak` tier, so a `tier = 'yazar'` row can't match the join filter and drops out,
-	// exactly as it does for `activeCountFor`. No engine runs (ADR 0082/0104/0105).
+	// `false` — is pinned structurally: the read inner-joins `user` and binds the `çaylak`
+	// tier, so a `tier = 'yazar'` row drops out of the join, exactly as in `activeCountFor`.
 	it.effect("the read inner-joins `user` and filters tier = 'çaylak' on the candidate", () => {
 		const cap = capturingRun();
 		return Effect.gen(function* () {

--- a/apps/web/worker/features/kunye/admin.ts
+++ b/apps/web/worker/features/kunye/admin.ts
@@ -1,17 +1,11 @@
 /**
- * `Admin` — the platform-administration capability (ADR 0107 §4), the `admin`
- * sibling of {@link Moderate} on the `Relation` axis. `Admin.over(platform)`
- * discharges to a `Grant` iff the actor holds `(actor, "admin", platform)` (or an
- * ancestor) in the `relation_tuple` store (`RelationStoreLive`), checked fresh per
- * call. Admin authority is this ONE relation-backed capability — never better-auth's
- * AC model: ADR 0107 supersedes ADR 0102's better-auth-AC authorization substrate
- * (better-auth stays for authn + the user-management UI). See ADR 0107.
+ * `Admin` — the platform-administration capability (ADR 0107 §4). Admin authority is this
+ * ONE relation-backed capability, never better-auth's AC model (better-auth stays for
+ * authn + the user-management UI).
  *
- * Denial is the künye {@link Denied} (`UNAUTHORIZED`), so a non-admin cannot
- * distinguish "not an admin" from "not signed in" (the invisible-denial invariant,
- * ADR 0098 §2 carried forward). The instance lives here — künye owns the kamp.us
- * capability instances; the vocab-free mechanism is `@kampus/authz`. Tuples are
- * minted offline (`@kampus/admin-grant`), never by a runtime worker route.
+ * Denial is the künye {@link Denied} (`UNAUTHORIZED`), so a non-admin cannot distinguish
+ * "not an admin" from "not signed in" (the invisible-denial invariant, ADR 0098 §2).
+ * Tuples are minted offline (`@kampus/admin-grant`), never by a runtime worker route.
  */
 import {Capability, Grant, matchActor, platform} from "@kampus/authz";
 import {Effect} from "effect";
@@ -27,21 +21,16 @@ export class Admin extends Capability.Relation<Admin>()("kunye/Admin", {
 export {platform};
 
 /**
- * Gate `body` behind platform-admin authority: discharge `Admin.over(platform)`
- * (the invisible {@link Denied} on failure) and thread the resulting `Grant` into
- * `body`'s R-channel via `Grant.provide`. So `body` can read `yield* Admin` for the
- * authority-checked admin identity, and "running an admin op without a `Grant`" is a
- * compile error — the proof is required by R, not a forgeable field (ADR 0107 §3).
+ * Threads the discharged `Grant` into `body`'s R-channel, so "running an admin op without
+ * a `Grant`" is a compile error — the proof is required by R, not a forgeable field
+ * (ADR 0107 §3).
  */
 export const requireAdmin = <A, E, R>(body: Effect.Effect<A, E, Admin | R>) =>
 	Admin.over(platform).pipe(Effect.flatMap((grant) => body.pipe(Grant.provide(grant))));
 
 /**
- * The admin's account id from a discharged `Admin` grant — the authority-checked
- * identity an admin write stamps, minted as the shared branded {@link UserId} (see
- * `lib/ids.ts`). A discharged grant is never anonymous (`Admin.over` fails `Denied`
- * on the `Unauthenticated` arm before minting), so the anonymous arm is unreachable
- * and dies as the defect it would be.
+ * A discharged grant is never anonymous (`Admin.over` denies the `Unauthenticated` arm
+ * first), so that arm is unreachable and dies as the defect it would be.
  */
 export const adminOf = (grant: Grant<Admin>): Effect.Effect<UserId> =>
 	matchActor(grant.actor, {

--- a/apps/web/worker/features/kunye/admin.typetest.ts
+++ b/apps/web/worker/features/kunye/admin.typetest.ts
@@ -1,11 +1,8 @@
 /**
- * Type-level assertion (no runtime — checked by `tsgo`, not vitest): an admin-gated
- * op that declares `Admin` in its requirements channel **fails to compile** unless
- * the matching `Grant` is provided via `Grant.provide` (ADR 0107 §1, the "forgot to
- * authorize is a compile error" guarantee — acceptance criterion #2). Falsifiable by
- * reading the R channel — omit `Grant.provide` and the capability stays required; provide
- * it (or gate through `requireAdmin`) and R collapses, leaving only the discharge
- * ports. Mirrors `Authorship.typetest.ts`, here over the `Admin` instance.
+ * Type-level assertion (no runtime — checked by `tsgo`, not vitest): an admin-gated op that
+ * declares `Admin` in its requirements channel fails to compile unless the matching `Grant`
+ * is provided (ADR 0107 §1). Falsifiable by reading the R channel: omit `Grant.provide` and
+ * the capability stays required; provide it and R collapses to the discharge ports.
  */
 import {type AgentAuthority, type CurrentActor, Grant, type RelationStore} from "@kampus/authz";
 import {Effect} from "effect";
@@ -13,40 +10,32 @@ import {expectTypeOf} from "vitest";
 import {Admin, platform, requireAdmin} from "./admin.ts";
 import type {Denied} from "./errors.ts";
 
-/** The requirements (R) channel of an effect type. */
 type RequirementsOf<T> = [T] extends [Effect.Effect<unknown, unknown, infer R>] ? R : never;
 
 declare const adminGrant: Grant<Admin>;
 
-/** An admin-gated op declares the `Admin` proof and reads it back. */
 const adminOp: Effect.Effect<string, never, Admin> = Effect.gen(function* () {
 	const proof = yield* Admin;
 	return proof.scope.capability;
 });
 
-/** Providing the proof discharges its requirement — R collapses to `never`. */
 export const adminDischarged: Effect.Effect<string, never, never> = adminOp.pipe(
 	Grant.provide(adminGrant),
 );
 
-// Omit `Grant.provide` → `Admin` stays required in R; provide it → R is `never`.
 expectTypeOf<RequirementsOf<typeof adminOp>>().toEqualTypeOf<Admin>();
 expectTypeOf<RequirementsOf<typeof adminDischarged>>().toEqualTypeOf<never>();
 
-/** `requireAdmin` discharges the gated op's `Admin`, leaving the discharge ports in R. */
 export const adminGated: Effect.Effect<
 	string,
 	Denied,
 	CurrentActor | RelationStore | AgentAuthority
 > = requireAdmin(adminOp);
 
-// The gate consumes `Admin` from R (it provides the minted proof itself) — the op's
-// `Admin` requirement is gone, only the `.over` discharge ports remain.
 expectTypeOf<RequirementsOf<typeof adminGated>>().toEqualTypeOf<
 	CurrentActor | RelationStore | AgentAuthority
 >();
 
-/** The discharge verb requires the ports, never the proof it mints. */
 export const adminRequired: Effect.Effect<
 	Grant<Admin>,
 	Denied,

--- a/apps/web/worker/features/kunye/admin.unit.test.ts
+++ b/apps/web/worker/features/kunye/admin.unit.test.ts
@@ -1,11 +1,8 @@
 /**
- * `Admin` capability coverage (ADR 0107 §4, carrying ADR 0098 §2 forward) — the
- * `admin` twin of `moderate.unit.test.ts`: a holder of the `admin` relation
- * discharges `Admin.over(platform)` to a `Grant`; a non-holder and the anonymous
- * actor both fail the SAME invisible `Denied` (`UNAUTHORIZED`), so a non-admin
- * cannot tell itself apart from anonymous. The three ports are scripted
- * (`RelationStore` the tuple set, `AgentAuthority` fail-closed, `CurrentActor` the
- * actor) — no DB; the real-D1 write→read seam lives in
+ * `Admin` capability coverage (ADR 0107 §4, ADR 0098 §2) — the `admin` twin of
+ * `moderate.unit.test.ts`: a non-holder and the anonymous actor must fail the SAME
+ * invisible `Denied`, so a non-admin cannot tell itself apart from anonymous. Ports are
+ * scripted, no DB; the real-D1 seam is
  * `apps/web/tests/integration/kunye-admin-seam.test.ts`.
  */
 import {assert, describe, it} from "@effect/vitest";
@@ -24,8 +21,6 @@ import {Effect, Exit} from "effect";
 import {Admin, adminOf} from "./admin.ts";
 import {Denied} from "./errors.ts";
 
-// Provide the three ports off a fixture (the holder set the `admin` tuple proves
-// membership against) and run `Admin.over(platform)` to an Exit.
 const discharge = (actor: Actor, holders: ReadonlyArray<string>): Exit.Exit<Grant<Admin>, Denied> =>
 	Effect.runSyncExit(
 		Admin.over(platform).pipe(

--- a/apps/web/worker/features/kunye/errors.ts
+++ b/apps/web/worker/features/kunye/errors.ts
@@ -1,17 +1,14 @@
 /**
- * The künye wire-coded authz denials (ADR 0107 §5) — `Schema.TaggedErrorClass`
- * with a `FateWireCode` annotation, so `encodeWireError` derives the wire shape
- * with no registry edit, the same path as `fate-effect/Unauthorized` and
- * `report/NotAModerator`. Their two codes are the deliberate asymmetry of the
- * two authority axes (per-class below).
+ * The künye wire-coded authz denials (ADR 0107 §5). The `FateWireCode` annotation lets
+ * `encodeWireError` derive the wire shape with no registry edit; the codes below differ
+ * deliberately, one per authority axis.
  */
 import {FateWireCode} from "@kampus/fate-effect";
 import * as Schema from "effect/Schema";
 
 /**
- * An assigned-authority (ReBAC) check failed — the actor lacks the relation, or
- * is anonymous. `UNAUTHORIZED` so the denial is indistinguishable from the
- * anonymous case (the invisible-denial invariant, ADR 0098 §2 carried forward).
+ * An assigned-authority (ReBAC) check failed. `UNAUTHORIZED` so the denial is
+ * indistinguishable from the anonymous case (ADR 0098 §2's invisible denial).
  */
 export class Denied extends Schema.TaggedErrorClass<Denied>()(
 	"kunye/Denied",
@@ -20,9 +17,8 @@ export class Denied extends Schema.TaggedErrorClass<Denied>()(
 ) {}
 
 /**
- * An earned-ladder (Level) check failed — the actor's standing is below the
- * floor, or is anonymous. `FORBIDDEN`, carrying the `need`ed rank so the public
- * ladder is a visible progression.
+ * An earned-ladder (Level) check failed. `FORBIDDEN`, carrying the `need`ed rank so the
+ * public ladder stays a visible progression.
  */
 export class RequiresLevel extends Schema.TaggedErrorClass<RequiresLevel>()(
 	"kunye/RequiresLevel",
@@ -31,12 +27,8 @@ export class RequiresLevel extends Schema.TaggedErrorClass<RequiresLevel>()(
 ) {}
 
 /**
- * The concurrent-vouch cap (D5, `VOUCH_CONCURRENT_CAP`) is reached — a yazar already
- * holds the maximum active vouches and is denied a further one until a slot frees
- * (the vouched çaylak is promoted, or the voucher withdraws). Distinct from the two
- * authority denials above: the actor IS a yazar (they cleared the `Vouch` floor),
- * the act is just rate-limited, so it carries its own `VOUCH_LIMIT_REACHED` code and
- * the `cap` so the surface can show "you've used all N of your vouches."
+ * The concurrent-vouch cap is reached. Not an authority denial — the actor IS a yazar,
+ * the act is rate-limited — so it carries its own code and the `cap` for the copy.
  */
 export class VouchLimitReached extends Schema.TaggedErrorClass<VouchLimitReached>()(
 	"kunye/VouchLimitReached",
@@ -45,17 +37,10 @@ export class VouchLimitReached extends Schema.TaggedErrorClass<VouchLimitReached
 ) {}
 
 /**
- * A karma-VALUE privilege floor (#150) failed — the actor's earned `total_karma`
- * is below a right's minimum. Distinct from {@link RequiresLevel}, which floors
- * the çaylak→yazar authorship *tier*: this floors a raw karma count (post ≥ −4,
- * flag ≥ 50), an anti-abuse gate orthogonal to the tier ladder — so it carries
- * its OWN `INSUFFICIENT_KARMA` code (not the overloaded `FORBIDDEN`) and the
- * `need`ed floor + the actor's current `have`, so the surface can name the bar
- * ("−4 karmanın altındasın") without mislabelling a tier denial. Visible (a
- * FORBIDDEN-family public-progression denial), never the invisible {@link Denied}
- * — a downvoted-into-the-ground poster deserves a clear reason, not a silent
- * no-op. Reconciled with the tier model + ADR 0098 (no double-gating): the karma
- * floors are a separate axis from authorship-tier and from moderation authority.
+ * A karma-VALUE privilege floor failed. Distinct from {@link RequiresLevel}, which floors
+ * the çaylak→yazar tier: this floors a raw karma count, an anti-abuse gate orthogonal to
+ * the ladder — so it carries its OWN code plus `need`/`have` for the copy. Visible, never
+ * the invisible {@link Denied}: a downvoted poster deserves a reason, not a silent no-op.
  */
 export class InsufficientKarma extends Schema.TaggedErrorClass<InsufficientKarma>()(
 	"kunye/InsufficientKarma",

--- a/apps/web/worker/features/kunye/id-brand.typetest.ts
+++ b/apps/web/worker/features/kunye/id-brand.typetest.ts
@@ -1,14 +1,5 @@
 /**
- * Type-level assertions (no runtime — checked by `tsgo`, not vitest) for the #2715
- * branding slice (epic #2700):
- *
- *   1. `PublishDecision` is nominally branded via effect-smol's `Brand` vocabulary —
- *      a bare `{broadcast}` struct is NOT assignable to it, so the value is
- *      unconstructible outside `sandbox.ts` (only {@link decidePublish} /
- *      {@link alwaysLive} mint one). This is the #1280 guarantee, now carried by
- *      `Brand.Branded` instead of a hand-rolled `unique symbol`.
- *   2. The künye actor-id producers (`adminOf` / `moderatorOf` / `voucherOf`) yield
- *      the shared branded {@link UserId}, not a bare `string`.
+ * Type-level assertions — no runtime, checked by `tsgo`, not vitest.
  *
  * Falsifiable: revert `PublishDecision` to a plain interface and assertion (1) fails;
  * drop a `UserId.make` wrap and assertion (2) fails.
@@ -21,18 +12,17 @@ import type {moderatorOf} from "./moderate.ts";
 import {alwaysLive, decidePublish, type PublishDecision} from "./sandbox.ts";
 import type {voucherOf} from "./vouch.ts";
 
-/** The success (A) channel of an effect type. */
 type SuccessOf<T> = [T] extends [Effect.Effect<infer A, unknown, unknown>] ? A : never;
 
-// (1) The two exported constructors mint a `PublishDecision`…
+// (1) Only these two constructors mint a `PublishDecision`…
 expectTypeOf(decidePublish(null)).toEqualTypeOf<PublishDecision>();
 expectTypeOf(alwaysLive).toEqualTypeOf<PublishDecision>();
 
-// …but a bare struct with the same shape is NOT — the brand keeps it unconstructible
-// outside the module (the #1280 guarantee, now via `Brand.Branded`).
+// …and a bare struct of the same shape is NOT assignable, which is what keeps the
+// value unconstructible outside `sandbox.ts`.
 expectTypeOf<{readonly broadcast: boolean}>().not.toMatchTypeOf<PublishDecision>();
 
-// (2) The grant-derived actor ids are the shared branded `UserId`, not bare `string`.
+// (2) Grant-derived actor ids must be the shared branded `UserId`, not bare `string`.
 expectTypeOf<SuccessOf<ReturnType<typeof adminOf>>>().toEqualTypeOf<UserId>();
 expectTypeOf<SuccessOf<ReturnType<typeof moderatorOf>>>().toEqualTypeOf<UserId>();
 expectTypeOf<SuccessOf<ReturnType<typeof voucherOf>>>().toEqualTypeOf<UserId>();

--- a/apps/web/worker/features/kunye/moderate.ts
+++ b/apps/web/worker/features/kunye/moderate.ts
@@ -1,15 +1,10 @@
 /**
- * `Moderate` — the platform-moderation capability (ADR 0107 §4), carrying ADR
- * 0098 §2's invisible denial forward. A `Capability.Relation` over the `moderates`
- * verb: `Moderate.over(platform)` discharges to a `Grant` iff the actor holds
- * `(actor, "moderates", platform)` (or an ancestor) in the `relation_tuple` store
- * (`RelationStoreLive`), checked fresh per call. It replaces `report/Moderator`'s
- * `user.role` read — authority is now an assigned relation tuple, never a column.
+ * `Moderate` — the platform-moderation capability (ADR 0107 §4). A
+ * `Capability.Relation` over the `moderates` verb, checked fresh per call against the
+ * `relation_tuple` store: authority is an assigned tuple, never a `user.role` column.
  *
- * Denial is the künye {@link Denied} (`UNAUTHORIZED`), so a non-moderator cannot
- * distinguish "not a moderator" from "not signed in" (the invisible-denial
- * invariant). The instance lives here — künye owns the kamp.us capability
- * instances; the vocab-free mechanism is `@kampus/authz`.
+ * Denial is the künye {@link Denied} (`UNAUTHORIZED`), so a non-moderator cannot tell
+ * "not a moderator" from "not signed in" (ADR 0098 §2's invisible denial).
  */
 import {
 	Capability,
@@ -24,16 +19,12 @@ import {UserId} from "../../lib/ids.ts";
 import {Denied} from "./errors.ts";
 
 /**
- * The `relation_tuple.relation` verb the moderator role rides on — the SINGLE source
- * every moderator read, discharge, and the `user.setRole` runtime write share, so the
- * read/discharge key and the write key can't drift (#3522).
+ * The single relation verb every moderator read, discharge, and `user.setRole` write
+ * shares, so the read/discharge key and the write key can't drift.
  */
 export const MODERATES_RELATION = "moderates";
 
-/**
- * The two platform roles the admin roster surfaces (#3200): `moderator` iff the
- * `moderates` tuple is held, else `member`. The value `user.setRole` assigns (#3522).
- */
+/** `moderator` iff the `moderates` tuple is held, else `member`. */
 export type PlatformRole = "member" | "moderator";
 
 export class Moderate extends Capability.Relation<Moderate>()("kunye/Moderate", {
@@ -41,17 +32,12 @@ export class Moderate extends Capability.Relation<Moderate>()("kunye/Moderate", 
 	deny: () => new Denied({message: "Moderation authority required"}),
 }) {}
 
-// Re-export the platform scope so a moderation surface gates with one import.
 export {platform};
 
 /**
- * The stored `relation_tuple` row for `(subject, "moderates", platform)` — the SAME
- * key {@link isModerator} / {@link moderatorsAmong} read and `Moderate.over(platform)`
- * discharges against, resolved through `@kampus/authz`'s canonical `objectKey` (as
- * `RelationStoreLive` does). The `Admin.over(platform)`-gated `user.setRole` writer
- * (#3522) inserts/deletes exactly this row, so the runtime WRITE of the moderator
- * relation can never encode the tuple differently from the read — the read-key-can't-
- * drift invariant, now extended to the write.
+ * The stored row for `(subject, "moderates", platform)` — the SAME key the reads below
+ * and `Moderate.over(platform)` resolve, so the runtime write of the moderator relation
+ * can never encode the tuple differently from the read.
  */
 export const moderatorTuple = (
 	subject: string,
@@ -62,16 +48,10 @@ export const moderatorTuple = (
 });
 
 /**
- * Is `subject` a platform moderator? The SELF-status read behind the trusted `me`
- * view's `isModerator` (#1320): the SAME `(subject, "moderates", platform)` tuple
- * `Moderate.over(platform)` discharges against, read straight off the
- * {@link RelationStore} port keyed by an account id. It takes a subject id (NOT
- * `CurrentActor`), so it answers "is THIS account a moderator" for the viewer's own
- * id and never another's — the `me` resolver passes `CurrentUser`'s id. The frontend
- * gates the divan "yazar yap" (promote) affordance on it, because a dual-role
- * yazar+moderator account reads `tier: "yazar"` and the mod axis can't ride on
- * `tier`. The encoding lives here, next to {@link Moderate}, so the read key can't
- * drift from the discharge key.
+ * Is `subject` a platform moderator? Takes a subject id (NOT `CurrentActor`), so the `me`
+ * resolver passes `CurrentUser`'s id and it can never answer for another account. The
+ * frontend gates the divan promote affordance on it, because a dual-role yazar+moderator
+ * reads `tier: "yazar"` and the mod axis can't ride on `tier`.
  */
 export const isModerator = (subject: string): Effect.Effect<boolean, never, RelationStore> =>
 	Effect.gen(function* () {
@@ -80,11 +60,8 @@ export const isModerator = (subject: string): Effect.Effect<boolean, never, Rela
 	});
 
 /**
- * The batched form of {@link isModerator}: which of `subjects` are platform
- * moderators, answered in ONE {@link RelationStore} set-membership read over the
- * `(moderates, platform)` tuple — the by-id loader's join, without the per-row
- * `has` that would make it an in-batch N+1. Same direct-tuple key as `isModerator`,
- * so the batched and single reads can't drift.
+ * The batched form of {@link isModerator}: ONE set-membership read over the
+ * `(moderates, platform)` tuple, so a by-id loader's join is not an in-batch N+1.
  */
 export const moderatorsAmong = (
 	subjects: ReadonlyArray<string>,
@@ -95,13 +72,8 @@ export const moderatorsAmong = (
 	});
 
 /**
- * EVERY platform moderator's account id — the mod-fan-out recipient set (#1699):
- * every subject holding `(subject, "moderates", platform)`, read off the same
- * direct tuple {@link isModerator} / {@link moderatorsAmong} key. Where those two
- * ANSWER membership for a known candidate, this ENUMERATES the open set a `notify
- * every moderator` emit needs — a recipient set with no candidate ids up front, so
- * neither `has` nor `hasSubjects` can produce it. The tuple key lives here next to
- * {@link Moderate} so the enumeration key can't drift from the discharge key.
+ * EVERY platform moderator's account id. Where the two reads above ANSWER membership for
+ * a known candidate, this ENUMERATES the open recipient set a mod fan-out needs.
  */
 export const allModerators = (): Effect.Effect<ReadonlySet<string>, never, RelationStore> =>
 	Effect.gen(function* () {
@@ -110,23 +82,15 @@ export const allModerators = (): Effect.Effect<ReadonlySet<string>, never, Relat
 	});
 
 /**
- * Gate `body` behind platform-moderation authority: discharge
- * `Moderate.over(platform)` (the invisible {@link Denied} on failure) and thread
- * the resulting `Grant` into `body`'s R-channel via `Grant.provide`. So `body`
- * can read `yield* Moderate` for the authority-checked moderator identity, and
- * "moderating without a `Grant`" is a compile error — the proof is required by R,
- * not a forgeable field (ADR 0107 §3).
+ * Gate `body` behind moderation authority, threading the `Grant` into its R channel — so
+ * moderating without a grant is a compile error, not a forgeable field (ADR 0107 §3).
  */
 export const requireModeration = <A, E, R>(body: Effect.Effect<A, E, Moderate | R>) =>
 	Moderate.over(platform).pipe(Effect.flatMap((grant) => body.pipe(Grant.provide(grant))));
 
 /**
- * The moderator's account id from a discharged `Moderate` grant — the
- * authority-checked identity a moderation write stamps as `resolver_id` /
- * `removed_by`, minted as the shared branded {@link UserId} (see `lib/ids.ts`). A
- * discharged grant is never anonymous (`Moderate.over` fails `Denied` on the
- * `Unauthenticated` arm before minting), so the anonymous arm is unreachable and
- * dies as the defect it would be.
+ * The moderator's account id from a discharged grant. `Moderate.over` fails `Denied` on
+ * the anonymous arm before minting, so that arm here is unreachable and dies as a defect.
  */
 export const moderatorOf = (grant: Grant<Moderate>): Effect.Effect<UserId> =>
 	matchActor(grant.actor, {

--- a/apps/web/worker/features/kunye/moderate.unit.test.ts
+++ b/apps/web/worker/features/kunye/moderate.unit.test.ts
@@ -1,12 +1,7 @@
 /**
- * `Moderate` capability coverage (ADR 0107 §4, carrying ADR 0098 §2 forward) — the
- * prior-art contract of the retired `report/Moderator.unit.test.ts`, re-expressed
- * over the relation tuple instead of `user.role`: a holder of the `moderates`
- * relation discharges `Moderate.over(platform)` to a `Grant`; a non-holder and the
- * anonymous actor both fail the SAME invisible `Denied` (`UNAUTHORIZED`), so a
- * non-moderator cannot tell itself apart from anonymous. The three ports are
- * scripted (`RelationStore` the tuple set, `AgentAuthority` fail-closed,
- * `CurrentActor` the actor) — no DB; the real-D1 write→read seam lives in
+ * `Moderate` capability coverage (ADR 0107 §4, ADR 0098 §2): a non-holder and the
+ * anonymous actor must fail the SAME invisible `Denied`, so a non-moderator cannot tell
+ * itself apart from anonymous. Ports are scripted, no DB; the real-D1 write→read seam is
  * `apps/web/tests/integration/kunye-moderate-seam.test.ts`.
  */
 import {assert, describe, it} from "@effect/vitest";
@@ -25,8 +20,6 @@ import {Effect, Exit} from "effect";
 import {Denied} from "./errors.ts";
 import {allModerators, Moderate, moderatorOf, moderatorsAmong} from "./moderate.ts";
 
-// Provide the three ports off a fixture (the holder set the `moderates` tuple
-// proves membership against) and run `Moderate.over(platform)` to an Exit.
 const discharge = (
 	actor: Actor,
 	holders: ReadonlyArray<string>,
@@ -97,11 +90,8 @@ describe("Moderate.over(platform)", () => {
 	});
 });
 
-// `moderatorsAmong` is the batched form of `isModerator` (#1360): ONE
-// `RelationStore.hasSubjects` read over the `(moderates, platform)` tuple, so the
-// by-id loader joins moderator standing without a per-row probe. The fixture
-// answers membership off the same holder set `has` proves against, keyed on the
-// `moderates` relation and the platform object, so batch and single reads agree.
+// The fixture answers membership off the same holder set `has` proves against, so the
+// batched and single reads agree.
 describe("moderatorsAmong", () => {
 	const storeOf = (holders: ReadonlyArray<string>) =>
 		Effect.provideService(RelationStore, {
@@ -141,10 +131,8 @@ describe("moderatorsAmong", () => {
 	});
 });
 
-// `allModerators` is the OPEN-set enumeration (#1699) the membership pair can't
-// answer: the whole `(moderates, platform)` subject set with no candidates up front —
-// the mod fan-out recipient set. The fixture returns exactly the holders for the
-// moderates/platform tuple, so the enumeration reads off the same key `has` proves.
+// The OPEN-set enumeration (#1699) the membership pair can't answer: the whole subject
+// set with no candidates up front.
 describe("allModerators", () => {
 	const storeOf = (holders: ReadonlyArray<string>) =>
 		Effect.provideService(RelationStore, {

--- a/apps/web/worker/features/kunye/privilege.ts
+++ b/apps/web/worker/features/kunye/privilege.ts
@@ -1,32 +1,13 @@
 /**
- * Karma-VALUE privilege gates (#150, künye epic #41) — the capability-as-Effect
- * instances (ADR 0107) that floor a right on the actor's earned `total_karma`,
- * read fresh from {@link Kunye.karmaOf} (the #149 D1-direct write-path source of
- * truth, ADR 0050). Two rights:
+ * Karma-VALUE privilege gates — capabilities-as-Effect (ADR 0107) that floor a right
+ * on the actor's earned `total_karma`, read fresh from {@link Kunye.karmaOf}.
  *
- *   - {@link CanPost}  — create content (post / comment / definition), floor ≥ −4.
- *   - {@link CanFlag}  — file a report (`report.submit`), floor ≥ 50.
+ * A separate axis from the çaylak→yazar tier ladder: `Authorship` `Level` floors an
+ * ordered rank, these floor a raw count. The two never gate the same fact, so stacking
+ * a karma floor onto a tier-gated mutation is additive, not double-gating.
  *
- * **A separate axis from the çaylak→yazar tier ladder and from ADR 0098
- * moderation — no double-gating (#150 rescope, 2026-07-02).** The `Authorship`
- * `Level` capabilities floor the authorship *tier* (an ordered rank); these floor
- * a raw karma *count*, an anti-abuse bar (a poster downvoted below −4 is muted; a
- * reporter needs 50 earned karma to flag). The two never gate the same fact, so
- * wiring a karma floor onto a mutation that already tier-gates is additive, not a
- * second check of one thing.
- *
- * Both are generic `Capability.Class` rights (not `Level`): karma is a continuous
- * integer, not a named ladder rank, so the floor is a numeric comparison the
- * `.authorize` check runs — the divan `ViewDivan` shape (`features/divan/gate.ts`),
- * here over a karma read. The richer {@link InsufficientKarma} (carrying the live
- * `have` + the `need` floor) is failed by the helper BEFORE the mint, so the
- * surface can name the bar; the class's own generic `deny()` is the unreachable
- * fallback the R-channel seal still requires.
- *
- * The gates ride behind the default-off `phoenix-karma-gates` flag: the mutation
- * decides whether to run the gate (with the flag off the karma read never runs and
- * the write behaves exactly as today — dark-ship, ADR 0083). These helpers gate
- * unconditionally; the flag check lives at the callsite.
+ * Both ride behind the default-off `phoenix-karma-gates` dark-ship flag (ADR 0083) —
+ * the `gate*OnKarma` wrappers read it, the `require*` helpers gate unconditionally.
  */
 import {Capability, CurrentActor, Grant, type Principal} from "@kampus/authz";
 import {Effect} from "effect";
@@ -37,52 +18,37 @@ import {InsufficientKarma} from "./errors.ts";
 import {Kunye} from "./Kunye.ts";
 
 /**
- * The v1 karma floors (#150 brief, reconciled 2026-07-02). Named constants, not
- * magic numbers at the check site — a floor move is a one-token edit here that
- * carries into both the gate and its `InsufficientKarma.need` field.
+ * The v1 karma floors.
  *
- * - `post: -4` — content creation is muted only once an author is downvoted well
- *   below zero (an anti-abuse floor, deliberately negative so a fresh 0-karma
- *   account posts freely).
- * - `flag: 50` — filing a report is an earned privilege (anti-spam-report), so a
- *   flagger must have accrued real standing.
+ * - `post: -4` — deliberately negative so a fresh 0-karma account posts freely; only
+ *   an author downvoted well below zero is muted.
+ * - `flag: 50` — filing a report is an earned privilege (anti-spam-report).
  */
 export const KARMA_FLOORS = {post: -4, flag: 50} as const;
 
 const POST_DENIAL = "İçerik paylaşmak için karman çok düşük.";
 const FLAG_DENIAL = "Şikayet etmek için yeterli karman yok.";
 
-/** Read a principal's earned `total_karma` off the {@link Kunye} standing service. */
 const karmaOf = (principal: Principal) =>
 	Effect.flatMap(Kunye, (kunye) => kunye.karmaOf(principal.id));
 
 /**
- * Create content (pano post/comment, sözlük definition) — floored at
- * `KARMA_FLOORS.post` earned karma. A `Capability.Class`: the karma read + numeric
- * floor is the gate the helper runs (see {@link requireCanPost}); the generic
- * `deny()` is the unreachable fallback (the helper fails the richer
- * {@link InsufficientKarma} first).
+ * Create content — floored at `KARMA_FLOORS.post`. The floor check runs in
+ * {@link requireCanPost}, which fails the richer {@link InsufficientKarma} first, so
+ * this generic `deny()` is an unreachable fallback the R-channel seal still requires.
  */
 export class CanPost extends Capability.Class<CanPost>()("kunye/CanPost", {
 	deny: () =>
 		new InsufficientKarma({message: POST_DENIAL, need: KARMA_FLOORS.post, have: KARMA_FLOORS.post}),
 }) {}
 
-/**
- * File a report (`report.submit`, the ADR 0098 flagging surface) — floored at
- * `KARMA_FLOORS.flag` earned karma. Same `Capability.Class` shape as
- * {@link CanPost}; the floor differs.
- */
+/** File a report — floored at `KARMA_FLOORS.flag`. Same shape as {@link CanPost}. */
 export class CanFlag extends Capability.Class<CanFlag>()("kunye/CanFlag", {
 	deny: () =>
 		new InsufficientKarma({message: FLAG_DENIAL, need: KARMA_FLOORS.flag, have: KARMA_FLOORS.flag}),
 }) {}
 
-/**
- * The current actor's earned karma, or `null` when there is no authenticated
- * principal. Reads `CurrentActor` for the principal and {@link Kunye.karmaOf} for
- * its live count — the fresh-read rule (never trust a stale session value).
- */
+/** The current actor's karma, or `null` when unauthenticated. Always a fresh read — never a stale session value. */
 const currentActorKarma: Effect.Effect<
 	{principal: Principal; have: number} | null,
 	never,
@@ -96,13 +62,9 @@ const currentActorKarma: Effect.Effect<
 });
 
 /**
- * The floor decision for a karma-gated right: `check === true` ⇒ enforce the
- * numeric floor against the fresh karma read; `check === false` ⇒ auto-pass
- * (mint unconditionally, no karma read). The auto-pass arm is what keeps the
- * enforcement-by-R property (ADR 0107 §3) TRUE even with the gate dark — the
- * proof `body`'s R channel requires is ALWAYS minted, so `body`'s requirement
- * collapses whether the flag is on or off. A flag-off request is not "skip the
- * check"; it is "grant the right freely" — the same R shape, a different policy.
+ * The floor decision for a karma-gated right. `enforce === false` auto-passes by
+ * minting the grant unconditionally — NOT "skip the check" but "grant the right
+ * freely", which is what keeps enforcement-by-R (ADR 0107 §3) true with the gate dark.
  */
 const dischargeKarma = <Self, A, E, R>(
 	authorize: (
@@ -126,53 +88,32 @@ const dischargeKarma = <Self, A, E, R>(
 		return yield* body.pipe(Grant.provide(grant));
 	});
 
-/**
- * Discharge {@link CanPost} and thread its `Grant` into `body`'s R channel — the
- * shape of `requireModeration` / `requireDivanAccess`, here over a numeric karma
- * floor read fresh from {@link Kunye}. On a below-floor read the richer
- * {@link InsufficientKarma} (`INSUFFICIENT_KARMA`, carrying `need = -4` and the
- * live `have`) is failed here, so the wire error names the actual gap; on a pass
- * `CanPost.authorize` mints the proof the R channel requires (a gated `body` that
- * forgets the check is a compile error, ADR 0107 §3).
- */
+/** Discharge {@link CanPost} into `body`'s R channel; below the floor fails {@link InsufficientKarma} naming the gap. */
 export const requireCanPost = <A, E, R>(body: Effect.Effect<A, E, CanPost | R>) =>
 	dischargeKarma((c) => CanPost.authorize(c), KARMA_FLOORS.post, POST_DENIAL, true, body);
 
-/**
- * Discharge {@link CanFlag} and thread its `Grant` into `body`'s R channel — the
- * flag-floor twin of {@link requireCanPost}. Fails the visible
- * {@link InsufficientKarma} (`need = 50`, live `have`) below the floor.
- */
+/** The flag-floor twin of {@link requireCanPost}. */
 export const requireCanFlag = <A, E, R>(body: Effect.Effect<A, E, CanFlag | R>) =>
 	dischargeKarma((c) => CanFlag.authorize(c), KARMA_FLOORS.flag, FLAG_DENIAL, true, body);
 
 /**
- * Is the `phoenix-karma-gates` dark-ship flag on for this request? Read fresh from
- * {@link Flags} with the safe-default `false` — a Flagship outage degrades to
- * gates-OFF (today's behavior), never a spurious denial. The single flag-read
- * site the flag-aware helpers below share so the key can't drift.
+ * The single `phoenix-karma-gates` read site, so the key can't drift. Safe-default
+ * `false`: a Flagship outage degrades to gates-OFF, never a spurious denial.
  */
 const karmaGatesOn = Flags.pipe(
 	Effect.flatMap((flags) => flags.getBoolean(PHOENIX_KARMA_GATES, false).pipe(provideRequestFlags)),
 );
 
 /**
- * The dark-ship wrapper for the post-floor gate: enforce {@link CanPost}'s karma
- * floor only when `phoenix-karma-gates` is on, else auto-pass (mint freely, no
- * karma read — today's behavior). The one-line callsite the content-creation
- * mutations (`post.submit`, `comment.add`, `definition.add`) use. The `CanPost`
- * grant is minted either way, so `body`'s R still collapses (enforcement-by-R
- * holds with the gate dark).
+ * The dark-ship wrapper content-creation mutations call: enforce {@link CanPost}'s
+ * floor only when `phoenix-karma-gates` is on, else mint freely.
  */
 export const gateContentOnKarma = <A, E, R>(body: Effect.Effect<A, E, CanPost | R>) =>
 	Effect.flatMap(karmaGatesOn, (enforce) =>
 		dischargeKarma((c) => CanPost.authorize(c), KARMA_FLOORS.post, POST_DENIAL, enforce, body),
 	);
 
-/**
- * The dark-ship wrapper for the flag-floor gate: the {@link gateContentOnKarma}
- * twin over {@link CanFlag}, used by `report.submit`.
- */
+/** The {@link gateContentOnKarma} twin over {@link CanFlag}, used by `report.submit`. */
 export const gateFlagOnKarma = <A, E, R>(body: Effect.Effect<A, E, CanFlag | R>) =>
 	Effect.flatMap(karmaGatesOn, (enforce) =>
 		dischargeKarma((c) => CanFlag.authorize(c), KARMA_FLOORS.flag, FLAG_DENIAL, enforce, body),

--- a/apps/web/worker/features/kunye/privilege.unit.test.ts
+++ b/apps/web/worker/features/kunye/privilege.unit.test.ts
@@ -1,18 +1,8 @@
 /**
- * The karma-VALUE privilege gates (#150) through the REAL capability seams — not a
- * re-implemented `karma >= floor` check. {@link requireCanPost} / {@link requireCanFlag}
- * discharge `CanPost` / `CanFlag` (`Capability.Class`, ADR 0107) over a fresh
- * {@link Kunye.karmaOf} read, threading the minted `Grant` into the gated body's R
- * channel — so a reached body proves the proof was supplied (enforcement-by-R), and a
- * below-floor read fails the visible {@link InsufficientKarma} (`INSUFFICIENT_KARMA`).
- *
- * The flag-aware wrappers ({@link gateContentOnKarma} / {@link gateFlagOnKarma}) are the
- * dark-ship seam: with `phoenix-karma-gates` OFF the karma read never runs and the body
- * passes freely (today's behavior); ON, the floor is enforced. The floors are read off
- * {@link KARMA_FLOORS} so a floor move can't drift from the test.
- *
- * All ports are scripted (`CurrentActor` the actor, `Kunye` the karma, `AgentAuthority`
- * admit-all, `Flags` the gate switch, `CurrentUser` for `provideRequestFlags`) — no DB.
+ * The karma-VALUE privilege gates driven through the REAL capability seams (ADR 0107),
+ * never a re-implemented `karma >= floor` check. Floors are read off
+ * {@link KARMA_FLOORS} so a floor move can't drift from the test. All ports are
+ * scripted — no DB.
  */
 import {assert, describe, it} from "@effect/vitest";
 import {type Actor, AgentAuthority, CurrentActor, human, unauthenticated} from "@kampus/authz";
@@ -33,7 +23,7 @@ import {
 	requireCanPost,
 } from "./privilege.ts";
 
-/** A `Kunye` that answers only `karmaOf` (fixed) — every other read fails-on-contact. */
+/** Every read other than `karmaOf` fails on contact. */
 const kunyeWithKarma = (karma: number): Layer.Layer<Kunye> =>
 	Layer.succeed(Kunye, {
 		karmaOf: () => Effect.succeed(karma),
@@ -41,7 +31,6 @@ const kunyeWithKarma = (karma: number): Layer.Layer<Kunye> =>
 		rootOf: (id: string) => Effect.succeed(id),
 	});
 
-/** A `Flags` whose `getBoolean` returns a fixed value — the gate switch. */
 const flagsStub = (on: boolean): Layer.Layer<Flags> =>
 	Layer.succeed(Flags, {
 		getBoolean: () => Effect.succeed(on),
@@ -52,10 +41,6 @@ const flagsStub = (on: boolean): Layer.Layer<Flags> =>
 
 const userInfo = (id: string): CurrentUserInfo => ({id, email: `${id}@kamp.us`, name: id});
 
-/**
- * Run one gate over `body = succeed("ok")` for an actor at a karma value, with the flag
- * on/off. Provides every port the gate touches; `user` feeds `provideRequestFlags`.
- */
 const run = (
 	gate: <A, E, R>(body: Effect.Effect<A, E, R>) => Effect.Effect<A, E | InsufficientKarma, unknown>,
 	opts: {
@@ -67,12 +52,8 @@ const run = (
 ): Exit.Exit<"ok", InsufficientKarma> =>
 	Effect.runSyncExit(
 		(gate(Effect.succeed("ok" as const)) as Effect.Effect<"ok", InsufficientKarma, unknown>).pipe(
-			// One combined provide (a single merged layer), never a chain of provides —
-			// `@effect/language-service` flags chained provides (`multipleEffectProvide`).
-			// `provideRequestFlags` (the flag-aware wrappers) reads the per-request override
-			// seam + `AppConfig` for the stage; a non-development stage reads no cookie, so a
-			// null-cookie override + a bare config provider is all the flag path needs under
-			// `runSyncExit`.
+			// One combined provide, never a chain — `@effect/language-service` flags chained
+			// provides (`multipleEffectProvide`).
 			Effect.provide(
 				Layer.mergeAll(
 					Layer.succeed(CurrentActor, {actor: opts.actor}),
@@ -90,7 +71,6 @@ const run = (
 		) as Effect.Effect<"ok", InsufficientKarma, never>,
 	);
 
-/** The failure's `InsufficientKarma`, or `null` if the exit succeeded / died. */
 const denial = (exit: Exit.Exit<"ok", InsufficientKarma>): InsufficientKarma | null => {
 	if (!Exit.isFailure(exit)) return null;
 	const found = Cause.findErrorOption(exit.cause);

--- a/apps/web/worker/features/kunye/sandbox-publish.unit.test.ts
+++ b/apps/web/worker/features/kunye/sandbox-publish.unit.test.ts
@@ -1,17 +1,12 @@
 /**
- * The create-time live-broadcast gate (#1205 AC#2, hardened #1280) — proves the
- * `PublishDecision` gate suppresses the public fate-live fan-out for a sandboxed row,
- * lets a live row through, and always broadcasts a restore (`alwaysLive`). This is
- * the leak surface the visibility matrix does NOT cover: the static read paths filter
- * sandboxed content, but the create-time broadcast is viewer-blind (ADRs
- * 0023/0025/0037), so without this gate a sandboxed çaylak's node would be pushed live
- * to non-author/anonymous subscribers (review-code FAIL on PR #1277).
+ * The create-time live-broadcast gate — proves the `PublishDecision` gate suppresses the
+ * public fate-live fan-out for a sandboxed row, lets a live row through, and always
+ * broadcasts a restore. This is the leak surface the visibility matrix does NOT cover: the
+ * static read paths filter sandboxed content, but the create-time broadcast is viewer-blind,
+ * so without this gate a sandboxed çaylak's node would be pushed to anonymous subscribers.
  *
- * The publish argument here stands in for the real
- * `live.{definition.term,post.feed,comment.thread}.{append,prepend}Node({node}, …)`
- * effect (the full-payload broadcast) — `broadcastIf` is the one place each `live.ts`
- * wrapper consumes the decision. We record whether it ran rather than inspect a frame:
- * "the create published a public node" is exactly "the publish effect ran".
+ * We record whether the publish effect ran rather than inspect a frame: "the create
+ * published a public node" is exactly "the publish effect ran".
  */
 import {assert, describe, it} from "@effect/vitest";
 import {Effect} from "effect";
@@ -19,7 +14,6 @@ import {alwaysLive, broadcastIf, decidePublish} from "./sandbox.ts";
 
 const at = new Date("2026-06-25T00:00:00.000Z");
 
-/** A publish stand-in that records whether it was run. */
 const recordingPublish = () => {
 	let ran = false;
 	const effect = Effect.sync(() => {

--- a/apps/web/worker/features/kunye/sandbox.ts
+++ b/apps/web/worker/features/kunye/sandbox.ts
@@ -1,22 +1,7 @@
 /**
- * The çaylak-sandbox policy seam (#1205) — where the authorship tier (künye) and
- * the moderation capability (ADR 0107) meet the content paths, kept out of the
- * sözlük/pano domain services so they stay vocabulary-free about authorship.
- *
- * Three helpers, all resolver-level:
- *   - {@link sandboxedAtForAuthor} — the create-time decision: should a new piece
- *     of content by this author land sandboxed? Decided by tier (çaylak ⇒ sandboxed,
- *     yazar ⇒ live).
- *   - {@link currentSandboxViewer} — the read-time viewer: the signed-in id plus a
- *     non-throwing moderator probe of `Moderate.over(platform)`, resolved once per
- *     read and handed to the `SandboxVisibility` predicates.
- *   - {@link PublishDecision} / {@link decidePublish} / {@link alwaysLive} — the
- *     create-time live-broadcast gate, type-level: a node broadcast to a public
- *     fate-live topic requires a `PublishDecision`, constructible only from the
- *     sandbox state (gated) or the explicit always-Live restore hatch, so sandboxed
- *     content cannot leak to non-author/anonymous subscribers via the (viewer-blind)
- *     live topics — and a create path cannot *forget* the check (ADR 0107's
- *     make-the-mistake-untypeable, applied to the sandbox/fate-live boundary, #1280).
+ * The çaylak-sandbox policy seam (#1205) — where the authorship tier (künye) and the
+ * moderation capability (ADR 0107) meet the content paths, kept out of the sözlük/pano
+ * domain services so they stay vocabulary-free about authorship.
  */
 
 import {CurrentUser} from "@kampus/fate-effect";
@@ -26,11 +11,6 @@ import {Kunye} from "./Kunye.ts";
 import {requireModeration} from "./moderate.ts";
 import {sandboxesNewContent} from "./standing.ts";
 
-/**
- * The `sandboxed_at` timestamp a new piece of content by `authorId` is created
- * with, or `null` to create it live. Sandboxed only when the author is a `çaylak`;
- * a yazar's content is always live.
- */
 export const sandboxedAtForAuthor = (
 	authorId: string,
 	now: Date,
@@ -41,19 +21,10 @@ export const sandboxedAtForAuthor = (
 		return sandboxesNewContent(tier) ? now : null;
 	});
 
-/**
- * Resolve the sandbox viewer for the current request: the signed-in account id
- * (null = anonymous) plus whether they hold platform-moderation authority. The
- * moderator check is a non-throwing probe — `Moderate.over(platform)` discharges
- * to a `Grant` for a moderator and fails `Denied` otherwise; we collapse that to a
- * boolean so a non-moderator reads as `canSeeSandboxed: false` rather than erroring
- * the read.
- */
 export const currentSandboxViewer = Effect.gen(function* () {
 	const {user} = yield* CurrentUser;
-	// A non-throwing probe of the moderation gate: `requireModeration` discharges
-	// `Moderate.over(platform)` and fails `Denied` for a non-moderator, which we
-	// collapse to `false` rather than erroring the read.
+	// A non-throwing probe of the moderation gate: `requireModeration` fails `Denied` for
+	// a non-moderator, collapsed to `false` here rather than erroring the whole read.
 	const canSeeSandboxed = yield* requireModeration(Effect.succeed(true)).pipe(
 		Effect.catch(() => Effect.succeed(false)),
 	);
@@ -62,67 +33,37 @@ export const currentSandboxViewer = Effect.gen(function* () {
 
 /**
  * Whether a brand-new content node may be broadcast to a public (viewer-blind)
- * fate-live topic. The type-level form of the #1205 gate: every node-broadcasting
- * publish (`appendNode` / `prependNode`, in each feature's `live.ts`) takes one, and
- * it is constructible ONLY from {@link decidePublish} (the sandbox-gated create path)
- * or {@link alwaysLive} (the explicit always-Live escape hatch). So a future create
- * mutation cannot broadcast a node without first discharging the sandbox check —
- * ADR 0107's make-the-mistake-untypeable, applied here (the #1280 hardening).
- *
- * Branded via effect-smol's standard `Brand` vocabulary (`Brand.Branded`, grounded
- * in effect-smol `Brand.ts`) — NOT a hand-rolled `unique symbol` phantom. The brand
- * is type-only: a `PublishDecision` is byte-identical to `{broadcast}` at runtime,
- * nominal only at the type level. Unconstructibility rests on the private
- * {@link makePublishDecision} constructor below staying module-local, so
- * {@link decidePublish} / {@link alwaysLive} remain the only exported constructors.
+ * fate-live topic. Every node-broadcasting publish takes one, and it is constructible
+ * ONLY from {@link decidePublish} or {@link alwaysLive} — so a create mutation cannot
+ * broadcast without first discharging the sandbox check (#1280, ADR 0107's
+ * make-the-mistake-untypeable). That rests on {@link makePublishDecision} staying
+ * module-local.
  */
 export type PublishDecision = Brand.Branded<{readonly broadcast: boolean}, "PublishDecision">;
 
-// `Brand.nominal` is the type-only constructor, kept PRIVATE so the module retains the
-// only two exported ways to mint a `PublishDecision` (decidePublish / alwaysLive). It
-// applies no runtime check (per effect-smol `Brand.ts`) — it returns its input.
+// Kept PRIVATE: it is the only way to mint a `PublishDecision`, and `Brand.nominal`
+// applies no runtime check (effect-smol `Brand.ts`) — it returns its input.
 const makePublishDecision = Brand.nominal<PublishDecision>();
 const branded = (broadcast: boolean): PublishDecision => makePublishDecision({broadcast});
 
 /**
- * The sandbox-gated decision a create path discharges: broadcast iff the new row is
- * live (`sandboxedAt === null`); a sandboxed row resolves to suppress.
- *
- * The fate-live fan-out is the leak surface (#1205 AC#2): a node publish relays a
- * full-payload frame to EVERY subscriber of a public topic — keyed only by
- * `{id: slug}` / `{id: postId}` / the global feed, never by viewer identity, with no
- * per-viewer re-resolution (ADRs 0023/0025/0037). The static read paths filter
- * sandboxed content (`sandboxVisibleWhere` / `isVisibleTo`), but the create-time
- * broadcast bypasses them, so a sandboxed çaylak's node would reach non-author
- * members and anonymous viewers. Routing every node broadcast through a
- * `PublishDecision` makes that unreachable by type.
- *
- * The author and moderators still see sandboxed content through the sandbox-aware
- * READ paths and the promotion-backlog queue (`listSandboxed*`); the live echo is an
- * optimization, not the source of truth. Suppressing it for sandboxed rows costs the
- * author an instant own-content echo (they see it on next read) — a deliberate
- * trade: the viewer-blind topic model can't deliver an author-only live push without
- * also leaking to others, and correctness outranks the echo. A viewer-keyed live
- * delivery is a deferred optimization, not in scope for #1205.
+ * The fate-live fan-out is the leak surface (#1205): a node publish relays a full
+ * payload to EVERY subscriber of a public topic, keyed by id and never by viewer
+ * (ADRs 0023/0025/0037), so it bypasses the read paths' sandbox filters. Suppressing
+ * the broadcast costs a sandboxed author their instant own-content echo — a deliberate
+ * trade, since a viewer-blind topic cannot push to the author alone.
  */
 export const decidePublish = (sandboxedAt: Date | null): PublishDecision =>
 	branded(sandboxedAt === null);
 
 /**
- * The always-Live escape hatch — a node broadcast that has no sandbox state to
- * discharge because it is Live by construction: the `Removed → Live` restore paths
- * (`EntityLifecycle.restore`, ADR 0096 §4), which re-enter already-public content.
- * Named + greppable on purpose: it is the deliberate, reviewable opt-out, not an
- * omission a create path can fall into (a create path has a `sandboxedAt` and must
- * route through {@link decidePublish}).
+ * The escape hatch for content that is Live by construction — the `Removed → Live`
+ * restore paths (ADR 0096 §4), which re-enter already-public content. Named + greppable
+ * on purpose: a deliberate, reviewable opt-out, never something a create path falls into.
  */
 export const alwaysLive: PublishDecision = branded(true);
 
-/**
- * Run a node broadcast only when the decision permits it; suppress otherwise. The
- * `appendNode` / `prependNode` wrappers in each feature's `live.ts` gate every
- * create-time broadcast through this — the one place the decision is consumed.
- */
+/** The one place a `PublishDecision` is consumed — every feature's `live.ts` gates through it. */
 export const broadcastIf = (
 	decision: PublishDecision,
 	publish: Effect.Effect<void>,

--- a/apps/web/worker/features/kunye/standing.ts
+++ b/apps/web/worker/features/kunye/standing.ts
@@ -1,14 +1,7 @@
 /**
- * The earned-authorship ladder and its rank vocabulary — the names the rest of
- * künye and the `Authorship` capability (#1235) share. Kept pure (no service, no
- * Effect) so the ladder ordering and the stored-tier value-set are unit-testable
- * in isolation.
- *
- * Since #1203 the authorship tier is a **server-managed `user.tier` column** read
- * through pasaport (not derived from karma), so `Kunye.tierOf` reads {@link Tier}
- * off the stored {@link StoredTier} (visitor = the no-account case). The karma→tier
- * math below (`tierForKarma`/`KARMA_THRESHOLDS`) no longer feeds `tierOf`; it is
- * kept as the future promotion/karma surface's input — see its docstring.
+ * The earned-authorship ladder and its rank vocabulary. The live tier is the
+ * server-managed `user.tier` column (#1203), NOT derived from karma — the karma→tier
+ * math here feeds only the promotion path, never `Kunye.tierOf`.
  */
 import {Scale} from "@kampus/authz";
 
@@ -16,43 +9,31 @@ import {Scale} from "@kampus/authz";
 export type Tier = "visitor" | "çaylak" | "yazar";
 
 /**
- * The two **stored** account-level authorship tiers — the value-set of the
- * server-managed `user.tier` column (#1203). `visitor` is deliberately absent: it
- * is never stored, only the read-time rank of a no-account / `Unauthenticated`
- * principal. An authenticated account is therefore always `≥ çaylak`. This is the
- * "make invalid states unrepresentable" split — the column cannot hold `visitor`.
+ * The value-set of the `user.tier` column. `visitor` is deliberately absent — it is
+ * never stored, only the read-time rank of a no-account principal, so an
+ * authenticated account is always `≥ çaylak`.
  */
 export const STORED_TIERS = ["çaylak", "yazar"] as const;
 export type StoredTier = (typeof STORED_TIERS)[number];
 
 /**
- * Whether content authored at this tier lands in the mod-only sandbox (#1205): a
- * çaylak's does, a yazar's is live. Pure and dependency-free so the SAME rule serves
- * both sides of the create — the server's `sandboxedAtForAuthor` (`kunye/sandbox.ts`)
- * and the client's optimistic comment node, which must predict the server's answer or
- * the çaylak's own comment flashes as published before reconciliation (#4282).
+ * Whether content authored at this tier lands in the mod-only sandbox (#1205). Kept
+ * dependency-free so the server's `sandboxedAtForAuthor` and the client's optimistic
+ * node run the SAME rule — a client that guesses differently flashes the çaylak's own
+ * comment as published before reconciliation (#4282).
  */
 export const sandboxesNewContent = (tier: Tier | undefined): boolean => tier === "çaylak";
 
-/**
- * The `visitor < çaylak < yazar` ladder (ADR 0107 §4) — the canonical kamp.us
- * `Scale` the `Authorship` `Capability.Level` instances (#1235) floor against
- * (`AddEntry` = çaylak, `OpenTerm` = yazar).
- */
+/** See ADR 0107 §4. */
 export const authorshipLadder = Scale(["visitor", "çaylak", "yazar"]);
 
 /**
- * Provisional earned-ladder boundaries: the minimum `total_karma` for each rank.
- *
- * **Ownership (since #1203):** these no longer derive the live tier — `Kunye.tierOf`
- * reads the stored `user.tier` column. The karma→tier math survives as the input the
- * karma-triggered **promotion** path (#1206) uses to decide *when* to flip the stored
- * column, and the **karma surface** (#1208) refines the real thresholds. Kept here so
- * that math lives in one pure, testable place rather than being re-derived later.
+ * Minimum `total_karma` per rank. These do NOT derive the live tier (that is the
+ * stored `user.tier` column since #1203) — they only decide when the promotion path
+ * flips that column.
  */
 export const KARMA_THRESHOLDS = {çaylak: 1, yazar: 100} as const;
 
-/** Map earned karma onto the ladder rank — the promotion (#1206) / karma (#1208) input. */
 export const tierForKarma = (karma: number): Tier =>
 	karma >= KARMA_THRESHOLDS.yazar
 		? "yazar"
@@ -61,40 +42,22 @@ export const tierForKarma = (karma: number): Tier =>
 			: "visitor";
 
 /**
- * The **reduced** karma bar a vouched çaylak must clear for a yazar's vouch to
- * promote them to yazar (#1206 — the author-vouch tandem). Deliberately far below
- * the unassisted `KARMA_THRESHOLDS.yazar` bar: a yazar putting their standing
- * behind a çaylak buys down the karma cost, so the tandem (vouch + this reduced
- * bar) is an easier path than grinding karma alone. The vouch is required — this
- * bar never auto-promotes on its own (no karma-AUTO-promotion; North Star #1194).
- *
- * Provisional product-tunable (D4, epic #1202) — #1289 pins it at the confirmed
- * `≈15 net` (was `10` in #1206). A named constant, not a magic number inline at the
- * check site; the order-independent tandem resolver (#1289) reads it from here.
+ * The reduced karma bar a *vouched* çaylak clears to reach yazar (#1289). Deliberately
+ * far below `KARMA_THRESHOLDS.yazar` — the yazar's vouch buys down the karma cost. The
+ * vouch is always required; this bar never auto-promotes on its own (#1194).
  */
 export const VOUCH_PROMOTION_KARMA_BAR = 15 as const;
 
 /**
- * The karma bar a çaylak must clear to reach yazar, given whether they hold an
- * active vouch. A vouched çaylak clears the reduced tandem bar
- * ({@link VOUCH_PROMOTION_KARMA_BAR}); an unvouched one faces the full unassisted
- * `KARMA_THRESHOLDS.yazar`. Pure so the "which bar applies" rule is the single
- * testable source the çaylak-self standing read (#1316) reads — the frontend never
- * hardcodes a bar, because *which* bar is live depends on vouch-exists.
+ * Which bar applies depends on vouch-exists, so the frontend must read it from here
+ * rather than hardcode either constant (#1316).
  */
 export const promotionBarFor = (vouchExists: boolean): number =>
 	vouchExists ? VOUCH_PROMOTION_KARMA_BAR : KARMA_THRESHOLDS.yazar;
 
 /**
- * The **concurrent-vouch cap** (D5, epic #1202 / #1289): the maximum number of
- * *active* vouches a single yazar may hold at once. A vouch is "spent" while its
- * çaylak is still pending (the row exists and the candidate is still çaylak) and
- * "returns" a slot on promotion (the candidate becomes yazar) or on withdrawal (the
- * row is deleted). A yazar already holding this many active vouches is denied a
- * further one until a slot frees — so a yazar's stake is rationed and a single
- * actor can't blanket-vouch the whole roster.
- *
- * Provisional product-tunable, pinned in code (not a magic number) like
- * {@link VOUCH_PROMOTION_KARMA_BAR}.
+ * Max *active* vouches one yazar may hold at once (#1289). A vouch is spent while its
+ * çaylak is still çaylak, and returns a slot on promotion or withdrawal — so no single
+ * actor can blanket-vouch the roster.
  */
 export const VOUCH_CONCURRENT_CAP = 3 as const;

--- a/apps/web/worker/features/kunye/standing.unit.test.ts
+++ b/apps/web/worker/features/kunye/standing.unit.test.ts
@@ -1,9 +1,7 @@
 /**
- * The pure promotion-bar rule (#1316) — `promotionBarFor` decides WHICH karma bar a
- * çaylak faces from a single fact: do they hold an active vouch. Kept pure (no
- * service, no Effect) so the "which bar applies" rule the çaylak-self standing read
- * exposes is testable in isolation (ADR 0082 unit tier) — the frontend never
- * hardcodes a bar because the live bar depends on vouch-exists.
+ * `promotionBarFor` decides WHICH karma bar a çaylak faces from one fact: whether they
+ * hold an active vouch (#1316). The frontend must never hardcode a bar, since the live
+ * bar depends on vouch-exists.
  */
 import {describe, it} from "@effect/vitest";
 import {assert} from "vitest";
@@ -29,10 +27,9 @@ describe("promotionBarFor", () => {
 });
 
 /**
- * The create-time sandbox rule, shared by BOTH sides of a write (#4282): the server's
- * `sandboxedAtForAuthor` and the client's optimistic comment node. They must agree —
- * a client that guesses differently renders a çaylak's comment as published for the
- * whole optimistic window, which is exactly the false-publish being closed.
+ * The create-time sandbox rule is shared by BOTH sides of a write (#4282). They must
+ * agree: a client that guesses differently renders a çaylak's comment as published for
+ * the whole optimistic window — the false-publish this closes.
  */
 describe("sandboxesNewContent", () => {
 	it("a çaylak's new content lands sandboxed", () => {
@@ -43,9 +40,8 @@ describe("sandboxesNewContent", () => {
 		assert.strictEqual(sandboxesNewContent("yazar"), false);
 	});
 
-	// A visitor authors nothing, and an unresolved tier (the `me` read still settling on
-	// the client) must not guess `true` — an unwarranted `incelemede` on a yazar's comment
-	// is as dishonest as the missing one on a çaylak's.
+	// An unresolved tier must not guess `true` — an unwarranted `incelemede` on a
+	// yazar's comment is as dishonest as a missing one on a çaylak's.
 	it("a visitor and an unresolved tier both read false", () => {
 		assert.strictEqual(sandboxesNewContent("visitor"), false);
 		assert.strictEqual(sandboxesNewContent(undefined), false);

--- a/apps/web/worker/features/kunye/vouch.ts
+++ b/apps/web/worker/features/kunye/vouch.ts
@@ -1,18 +1,12 @@
 /**
- * `Vouch` — the author-vouch capability (ADR 0107 §2-3, #1206). A `Capability.Level`
- * floored at `yazar`, the per-RIGHT sibling of {@link ../kunye/Authorship.ts | OpenTerm}:
- * vouching for a çaylak's promotion is its OWN right (capabilities are named by what
- * they authorize, ADR 0107 §2) even though it shares OpenTerm's yazar floor — a vouch
- * is not opening a term. `Vouch.require` discharges to a `Grant` iff the actor's GLOBAL
- * account standing (read fresh via {@link Kunye.tierOf}) is `gte yazar`; a çaylak,
- * visitor, or anonymous actor fails the public {@link RequiresLevel} (`FORBIDDEN`),
- * carrying the needed rank so the ladder stays a visible progression.
+ * `Vouch` — the author-vouch capability (ADR 0107 §2-3, #1206). Its own right even
+ * though it shares OpenTerm's yazar floor: capabilities are named by what they
+ * authorize, and a vouch is not opening a term.
  *
- * Modeling the vouch authority THROUGH the framework (not an ad-hoc `if (tier===yazar)`)
- * is what makes self-promotion structurally impossible: a çaylak cannot discharge
- * `Vouch` (below the floor) and cannot discharge {@link ../kunye/moderate.ts | Moderate}
- * (no tuple), and a yazar "promoting themselves" is a no-op (already yazar). The two
- * authority paths are the only triggers, both gated by the framework.
+ * Modeling the authority THROUGH the framework (not an ad-hoc `if (tier===yazar)`) is
+ * what makes self-promotion structurally impossible: a çaylak can discharge neither
+ * `Vouch` (below the floor) nor `Moderate` (no tuple), and a yazar promoting
+ * themselves is a no-op.
  */
 import {Capability, Grant, matchActor, type Principal} from "@kampus/authz";
 import {Effect} from "effect";
@@ -20,11 +14,9 @@ import {UserId} from "../../lib/ids.ts";
 import {RequiresLevel} from "./errors.ts";
 import {authorshipLadder, Kunye} from "./Kunye.ts";
 
-/** Read a principal's global account-level rank off the {@link Kunye} standing service. */
 const standingOf = (principal: Principal) =>
 	Effect.flatMap(Kunye, (kunye) => kunye.tierOf(principal.id));
 
-/** Vouch for a çaylak's promotion to yazar — requires `yazar` earned standing. */
 export class Vouch extends Capability.Level<Vouch>()("kunye/Vouch", {
 	scale: authorshipLadder,
 	min: "yazar",
@@ -33,22 +25,17 @@ export class Vouch extends Capability.Level<Vouch>()("kunye/Vouch", {
 }) {}
 
 /**
- * Gate `body` behind yazar standing: discharge `Vouch.require` (the public
- * {@link RequiresLevel} on failure) and thread the resulting `Grant` into `body`'s
- * R-channel via `Grant.provide`. So `body` can read `yield* Vouch` for the
- * authority-checked voucher identity, and "vouching without a `Grant`" is a compile
- * error — the proof is required by R, not a forgeable field (ADR 0107 §3). Mirrors
- * {@link ../kunye/moderate.ts | requireModeration}.
+ * Gate `body` behind yazar standing and thread the resulting `Grant` into `body`'s
+ * R-channel, so "vouching without a `Grant`" is a compile error — the proof is
+ * required by R, not a forgeable field (ADR 0107 §3).
  */
 export const requireVouch = <A, E, R>(body: Effect.Effect<A, E, Vouch | R>) =>
 	Vouch.require.pipe(Effect.flatMap((grant) => body.pipe(Grant.provide(grant))));
 
 /**
- * The voucher's account id from a discharged `Vouch` grant — the vouching actor the
- * vouch record preserves, minted as the shared branded {@link UserId} (see
- * `lib/ids.ts`). A discharged grant is never anonymous (`Vouch.require` fails on the
- * `Unauthenticated` arm before minting), so the anonymous arm is unreachable and
- * dies as the defect it would be.
+ * The voucher's account id from a discharged `Vouch` grant. A discharged grant is
+ * never anonymous (`Vouch.require` fails on the `Unauthenticated` arm first), so the
+ * anonymous arm is unreachable and dies as the defect it would be.
  */
 export const voucherOf = (grant: Grant<Vouch>): Effect.Effect<UserId> =>
 	matchActor(grant.actor, {

--- a/apps/web/worker/features/kunye/vouch.unit.test.ts
+++ b/apps/web/worker/features/kunye/vouch.unit.test.ts
@@ -1,14 +1,9 @@
 /**
- * `Vouch` capability coverage (ADR 0107 §2-3, #1206) — the author-vouch right, a
- * `Capability.Level` floored at `yazar`. A yazar discharges `Vouch.require` to a
- * `Grant`; a çaylak, a visitor, and the anonymous actor all fail the public
- * `RequiresLevel` (`FORBIDDEN`, `need: "yazar"`). This is the structural reason a
- * çaylak cannot vouch — and, with a yazar self-vouch being inert (already yazar),
- * the reason self-promotion is impossible across both authority paths.
+ * `Vouch` — the author-vouch right, a `Capability.Level` floored at `yazar`. This is the
+ * structural reason a çaylak cannot vouch and — with a yazar self-vouch being inert (already
+ * yazar) — the reason self-promotion is impossible across both authority paths.
  *
- * The two ports are scripted (`Kunye` the standing read, `AgentAuthority` fail-closed,
- * `CurrentActor` the actor) — no DB; the real-D1 tier read lives behind `Kunye.tierOf`
- * (its own integration coverage).
+ * The ports are scripted, no DB; the real-D1 tier read lives behind `Kunye.tierOf`.
  */
 import {assert, describe, it} from "@effect/vitest";
 import {
@@ -26,8 +21,7 @@ import {Kunye} from "./Kunye.ts";
 import type {Tier} from "./standing.ts";
 import {Vouch, voucherOf} from "./vouch.ts";
 
-// A `Kunye` whose `tierOf` answers the scripted standing for every id; the other
-// reads are unreached on the `Vouch.require` path.
+// The other `Kunye` reads are unreached on the `Vouch.require` path.
 const kunyeAt = (tier: Tier): Layer.Layer<Kunye> =>
 	Layer.succeed(Kunye, {
 		tierOf: () => Effect.succeed(tier),

--- a/apps/web/worker/features/lifecycle/EntityLifecycle.ts
+++ b/apps/web/worker/features/lifecycle/EntityLifecycle.ts
@@ -1,32 +1,14 @@
 /**
- * The uniform removal substrate's domain model (ADR 0096): a deletable entity's
- * lifecycle as a closed type, not a nullable-flag soup.
- *
- * `EntityLifecycle = Live | Removed({removedAt, removedBy, reason})` is the
- * in-memory **projection** of three persisted columns (`removed_at`,
- * `removed_by`, `removed_reason`) carried on every content table. Services branch
- * on the type via {@link EntityLifecycle.$match} / {@link isRemoved}; they never
- * read the raw columns directly. `Removed` is uninhabitable without its audit
- * triad, so "removed but we don't know by whom/why" is unrepresentable; `restore`
- * is defined only on `Removed`, so restoring a `Live` entity does not typecheck.
- *
- * `RemovalReason` handling is `Match.tagsExhaustive` (effect-smol
- * `packages/effect/src/Match.ts:1095` — a missing case is a compile error), so a
- * fourth reason later forces every call site to address it. ADR 0097 passes
- * `Anonymized`, ADR 0098 passes `Moderated({reportId})`; both build on this.
+ * A deletable entity's lifecycle as a closed type — the in-memory projection of the
+ * persisted `removed_at` / `removed_by` / `removed_reason` / `sandboxed_at` columns.
+ * Services branch on the type, never on the raw columns. See ADR 0096; the sandbox
+ * dimension is mapped in .patterns/caylak-content-containment.md.
  */
 import * as Data from "effect/Data";
 import * as Match from "effect/Match";
 import * as Schema from "effect/Schema";
 import {ReportId} from "../report/ids.ts";
 
-/**
- * Why a piece of content was removed — the audit's "why". A `Schema.Union` of
- * tagged structs so it round-trips through the `removed_reason` text column as
- * JSON (`{_tag, …payload}`), carrying e.g. the originating `reportId` for a
- * moderator action. The three members are the three forcing functions of ADR
- * 0096: author self-delete, account anonymization (0097), moderation (0098).
- */
 export class AuthorDeletion extends Schema.Class<AuthorDeletion>("lifecycle/AuthorDeletion")({
 	_tag: Schema.tag("AuthorDeletion"),
 }) {}
@@ -37,41 +19,24 @@ export class Anonymized extends Schema.Class<Anonymized>("lifecycle/Anonymized")
 
 export class Moderated extends Schema.Class<Moderated>("lifecycle/Moderated")({
 	_tag: Schema.tag("Moderated"),
-	// The originating report, branded (#2820, deferred slice of #2721): the content
-	// features mint it via `ReportId.make(...)` at the report→service boundary
-	// (`report/mutations.ts`), so a report/target/user id swap is a compile error here.
+	// Branded so a report/target/user id swap is a compile error; minted via
+	// `ReportId.make(...)` at the report→service boundary (`report/mutations.ts`).
 	reportId: ReportId,
 }) {}
 
 export const RemovalReason = Schema.Union([AuthorDeletion, Anonymized, Moderated]);
 export type RemovalReason = typeof RemovalReason.Type;
 
-/**
- * The persisted-form codec for the `removed_reason` column: the union encoded as
- * a JSON string. `decodeReason`/`encodeReason` are the only seam between the
- * column and the domain reason; the column is never parsed ad-hoc elsewhere.
- */
+// The only seam between the `removed_reason` column and the domain reason — the
+// column is never parsed ad-hoc elsewhere.
 const ReasonFromJson = Schema.fromJsonString(RemovalReason);
 export const decodeReason = Schema.decodeUnknownSync(ReasonFromJson);
 export const encodeReason = Schema.encodeSync(ReasonFromJson);
 
 /**
- * The lifecycle state of a deletable entity (ADR 0096, extended by #1205). A
- * closed union of exactly three states, so an entity is *one* of them — which is
- * what makes the çaylak-sandbox invariant hold by construction: a `Sandboxed`
- * cannot also be `Removed` (they are distinct tags), so "sandboxed-AND-removed" is
- * unrepresentable, no flag-pair to fall into a contradictory combination.
- *
- * - `Live` — public, the default; carries no audit.
- * - `Sandboxed` — çaylak content held in the mod-only sandbox (#1205): visible to
- *   its author + moderators only, until promotion (#1206) transitions it to `Live`.
- * - `Removed` — soft-deleted, carrying the full audit triad; there is no `Removed`
- *   without `removedAt` + `removedBy` + `reason`. It also carries the pre-removal
- *   `sandboxedAt` (null if the content was `Live` when removed) so a remove→restore
- *   round-trip is *faithful*: restoring sandboxed content returns it to `Sandboxed`,
- *   not `Live` — the çaylak sandbox-escape fix (#1811). A `Removed`-with-`sandboxedAt`
- *   is still `Removed` (the removal is the live fact); the marker is carried, not
- *   projected, so promotion to `Live` stays the mod-only path (#1206).
+ * Exactly three states, so "sandboxed-AND-removed" is unrepresentable. `Removed`
+ * still carries the pre-removal `sandboxedAt` (null if it was `Live`) so a
+ * remove→restore round-trip is faithful — see {@link restore}.
  */
 export type EntityLifecycle = Data.TaggedEnum<{
 	// biome-ignore lint/complexity/noBannedTypes: Data.taggedEnum needs the literal `{}` for a payload-less member; `Record<string, never>` makes `Live()` demand an arg.
@@ -97,13 +62,6 @@ export const isRemoved = $is("Removed");
 export const isLive = $is("Live");
 export const isSandboxed = $is("Sandboxed");
 
-/**
- * The persisted lifecycle columns, exactly as they sit on a content row: the ADR
- * 0096 removal triad plus the #1205 `sandboxedAt` marker. `removedAt` AND
- * `sandboxedAt` both null ⇒ `Live`. This is the only shape the projection reads.
- * `RemovalColumns` stays as a name alias for the `removal.ts` call sites that
- * predate the sandbox dimension.
- */
 export interface LifecycleColumns {
 	readonly removedAt: Date | null;
 	readonly removedBy: string | null;
@@ -113,16 +71,10 @@ export interface LifecycleColumns {
 export type RemovalColumns = LifecycleColumns;
 
 /**
- * Reconstitute the lifecycle union from a row's raw columns — the single
- * projection seam ADR 0096 §2 mandates (services call this, never branch on the
- * columns). Removal takes precedence over sandbox: a removed row reads `Removed`
- * *and carries its `sandboxedAt`* (the pre-removal sandbox marker, #1811) so
- * {@link restore} can round-trip it faithfully — a removed-AND-sandboxed row is a
- * çaylak's deleted sandboxed content, still `Removed` (the removal is the live
- * fact), with the sandbox marker preserved for restore, not projected. A row with
- * `removedAt` set but a missing `removedBy`/`removedReason` is a corrupt
- * half-removal the domain can't represent; we surface it loudly rather than
- * projecting a fabricated audit.
+ * The single projection seam (ADR 0096 §2). Removal takes precedence over sandbox: a
+ * removed row reads `Removed` and carries its `sandboxedAt` for {@link restore}. A
+ * `removedAt` with a missing `removedBy`/`removedReason` is a corrupt half-removal the
+ * domain can't represent, so it throws rather than projecting a fabricated audit.
  */
 export const fromColumns = (cols: LifecycleColumns): EntityLifecycle => {
 	if (cols.removedAt !== null) {
@@ -143,16 +95,8 @@ export const fromColumns = (cols: LifecycleColumns): EntityLifecycle => {
 };
 
 /**
- * The inverse: the column values a lifecycle persists to. `Live` clears
- * everything (what {@link promote} writes, and what {@link restore} writes for
- * content that was live before removal); `Sandboxed` stamps only `sandboxedAt`
- * (what {@link restore} writes for content that was sandboxed before removal);
- * `Removed` stamps the triad **plus** the preserved pre-removal `sandboxedAt`
- * (null if it was live) so the marker survives the round-trip (#1811). The
- * `removed`-AND-`sandboxed` column pair is not a contradiction — it is a removed
- * row remembering it was sandboxed; the removal-precedence in {@link fromColumns}
- * still projects it to `Removed`, and only a mod's promotion clears the marker to
- * reach `Live`.
+ * A `removed`-AND-`sandboxed` column pair is not a contradiction — it is a removed row
+ * remembering it was sandboxed. {@link fromColumns} still projects it to `Removed`.
  */
 export const toColumns = (lifecycle: EntityLifecycle): LifecycleColumns =>
 	$match(lifecycle, {
@@ -172,14 +116,8 @@ export const toColumns = (lifecycle: EntityLifecycle): LifecycleColumns =>
 	});
 
 /**
- * Construct the removed state from its audit triad plus the pre-removal
- * `sandboxedAt` — the one constructor a delete path uses, so it cannot forget an
- * audit field. `sandboxedAt` is the marker the row carried *before* the delete
- * (null if it was `Live`); carrying it through `Removed` is what lets
- * {@link restore} round-trip sandboxed çaylak content back to `Sandboxed` instead
- * of leaking it to `Live` (#1811). A delete path derives it from the row's current
- * lifecycle — `isSandboxed(current) ? current.sandboxedAt : null` — via
- * {@link sandboxedAtOf}.
+ * The one constructor a delete path uses, so it cannot forget an audit field. Derive
+ * `sandboxedAt` from the row's current lifecycle via {@link sandboxedAtOf}.
  */
 export const remove = (input: {
 	readonly removedAt: Date;
@@ -188,12 +126,8 @@ export const remove = (input: {
 	readonly sandboxedAt: Date | null;
 }): Removed => Removed(input);
 
-/**
- * The `sandboxedAt` a {@link remove} should preserve for `current`'s pre-removal
- * lifecycle: the marker if it was `Sandboxed`, else `null`. The one seam a delete
- * path reads so it can't hand-derive the marker wrong (#1811). A `Removed` input
- * (already deleted) keeps its carried marker — idempotent under a re-delete guard.
- */
+// A `Removed` input (already deleted) keeps its carried marker, so a re-delete is
+// idempotent.
 export const sandboxedAtOf = (current: EntityLifecycle): Date | null =>
 	$match(current, {
 		Live: () => null,
@@ -215,85 +149,41 @@ export const sandboxedAtOf = (current: EntityLifecycle): Date | null =>
 export const restore = (removed: Removed): EntityLifecycle =>
 	removed.sandboxedAt !== null ? Sandboxed({sandboxedAt: removed.sandboxedAt}) : Live();
 
-/**
- * Construct the sandboxed state — the one constructor a çaylak create path uses to
- * hold new content in the mod-only sandbox (#1205).
- */
 export const sandbox = (input: {readonly sandboxedAt: Date}): Sandboxed => Sandboxed(input);
 
-/**
- * `promote : Sandboxed → Live`. Defined **only** on `Sandboxed` — promoting a
- * `Live`/`Removed` entity is not expressible because the parameter type excludes
- * them. This is the seam the çaylak→yazar promotion (#1206) flips a sandboxed
- * backlog through; it lives here so the transition is one place, symmetric with
- * {@link restore}.
- */
+// Typed `Sandboxed → Live` on purpose: promoting a `Live`/`Removed` entity must not
+// be expressible.
 export const promote = (_sandboxed: Sandboxed): EntityLifecycle => Live();
 
 /**
- * The viewer a sandbox-visibility decision is made against. `viewerId` is the
- * signed-in account id (null = anonymous/public); `canSeeSandboxed` is true only
- * for a moderator (the discharged {@link Moderate} authority — ADR 0107), who sees
- * the full sandbox. A non-moderator member sees only the sandboxed content they
- * authored. Deliberately a plain value, not a service: the visibility decision is
- * pure, so the resolver resolves the viewer once and the read layer + the matrix
- * test both apply the same rule.
+ * `canSeeSandboxed` is true only for a moderator holding the discharged `Moderate`
+ * authority (ADR 0107). Deliberately a plain value, not a service — the decision is
+ * pure, so the read layer and the matrix test apply the same rule.
  */
 export interface SandboxViewer {
 	readonly viewerId: string | null;
 	readonly canSeeSandboxed: boolean;
 }
 
-/** An anonymous/public viewer — sees only `Live`. The safe default. */
 export const anonymousViewer: SandboxViewer = {viewerId: null, canSeeSandboxed: false};
 
-/**
- * The tag of an {@link EntityLifecycle} state — the closed discriminant both the
- * in-memory decision ({@link isVisibleTo}) and the SQL mirror
- * (`SandboxVisibility.sandboxVisibleWhere`) key their visibility rule on. Exported so
- * the SQL side can iterate the SAME tag set exhaustively (a new tag then has no SQL
- * arm and fails to compile), instead of re-deriving the rule from booleans (#2013).
- */
+// Exported so the SQL mirror (`SandboxVisibility.sandboxVisibleWhere`) iterates the SAME
+// tag set: a new tag then has no SQL arm and fails to compile.
 export type LifecycleTag = EntityLifecycle["_tag"];
 
-/**
- * The per-state visibility rule as a closed union of exactly three arms — the
- * single-sourced shape both encodings interpret (#2013). A lifecycle state permits a
- * viewer by one of:
- *
- * - `Everyone` — the state is public (`Live`).
- * - `NoOne` — the state is hidden from content reads (`Removed`; moderators review it
- *   through a separate queue, not these reads).
- * - `AuthorOrModerator` — visible only to a moderator (`canSeeSandboxed`) or the
- *   authoring account (`Sandboxed`, the #1205 çaylak rule).
- *
- * Making the rule a value — not inline logic duplicated per encoding — is what lets
- * `isVisibleTo` (runtime) and `sandboxVisibleWhere` (SQL) both read it, so they cannot
- * silently diverge for a state.
- */
+// A value, not inline logic per encoding, so `isVisibleTo` (runtime) and
+// `sandboxVisibleWhere` (SQL) cannot silently diverge for a state.
 export type LifecycleVisibilityRule = "Everyone" | "NoOne" | "AuthorOrModerator";
 
-/**
- * The single source of the çaylak-sandbox visibility boundary (#1205, #2013): each
- * lifecycle tag → its {@link LifecycleVisibilityRule}, keyed by the closed
- * {@link LifecycleTag} discriminant. This `Record` over the tag union is exhaustive by
- * its type — a new lifecycle tag with no entry is a **compile error here**, forcing
- * both encodings (which derive from this map) to gain the state rather than one
- * silently mis-filtering. This replaces the old two-place encoding where the SQL
- * builder branched on booleans and a 4th tag would have compiled clean at the DB.
- */
+// The single source of the çaylak-sandbox visibility boundary. Exhaustive by its type:
+// a new lifecycle tag with no entry is a compile error here, forcing both encodings to
+// gain the state rather than one silently mis-filtering.
 export const lifecycleVisibilityRule: Record<LifecycleTag, LifecycleVisibilityRule> = {
 	Live: "Everyone",
 	Removed: "NoOne",
 	Sandboxed: "AuthorOrModerator",
 };
 
-/**
- * Interpret a {@link LifecycleVisibilityRule} against a viewer + the content's author
- * — the one place a rule becomes a boolean, shared by {@link isVisibleTo} and (via the
- * SQL arm builder) the read-query predicate. `AuthorOrModerator` is visible to a
- * moderator (`canSeeSandboxed`) or the author (`viewerId === authorId`).
- */
 export const ruleVisibleTo = (
 	rule: LifecycleVisibilityRule,
 	authorId: string,
@@ -309,34 +199,14 @@ export const ruleVisibleTo = (
 	}
 };
 
-/**
- * The pure visibility decision (#1205) — the rule the read queries' SQL predicate
- * mirrors and the visibility-matrix test targets directly. A piece of content with
- * `lifecycle`/`authorId` is visible to `viewer` iff its state's
- * {@link lifecycleVisibilityRule} permits them:
- *
- * - `Live` (`Everyone`) — visible to everyone.
- * - `Removed` (`NoOne`) — hidden from the content reads (the existing
- *   `removed_at IS NULL` guard, unchanged — moderators review removed content through a
- *   different queue).
- * - `Sandboxed` (`AuthorOrModerator`) — visible only to a moderator
- *   (`canSeeSandboxed`) or the author (`viewerId === authorId`); hidden from anonymous
- *   + every other member.
- *
- * Reads the rule off {@link lifecycleVisibilityRule} keyed by the lifecycle tag, so
- * this and the SQL encoding share ONE source of the rule.
- */
+// The pure visibility decision the read queries' SQL predicate mirrors and the
+// visibility-matrix test targets directly.
 export const isVisibleTo = (
 	lifecycle: EntityLifecycle,
 	authorId: string,
 	viewer: SandboxViewer,
 ): boolean => ruleVisibleTo(lifecycleVisibilityRule[lifecycle._tag], authorId, viewer);
 
-/**
- * Exhaustive reason handling via `Match.tagsExhaustive` — the call site that adds
- * a fourth `RemovalReason` without a new branch fails to compile. Returns the
- * Turkish product label a tombstone/moderator surface renders.
- */
 export const reasonLabel: (reason: RemovalReason) => string = Match.type<RemovalReason>().pipe(
 	Match.tagsExhaustive({
 		AuthorDeletion: () => "yazar tarafından silindi",
@@ -345,7 +215,6 @@ export const reasonLabel: (reason: RemovalReason) => string = Match.type<Removal
 	}),
 );
 
-/** The originating report of a `Moderated` removal, else null — `Match` exhaustive. */
 export const reasonReportId: (reason: RemovalReason) => ReportId | null =
 	Match.type<RemovalReason>().pipe(
 		Match.tagsExhaustive({

--- a/apps/web/worker/features/lifecycle/EntityLifecycle.unit.test.ts
+++ b/apps/web/worker/features/lifecycle/EntityLifecycle.unit.test.ts
@@ -1,9 +1,7 @@
 /**
- * EntityLifecycle unit coverage (ADR 0082 unit tier — pure, no DB): the removal
- * substrate's type transitions, the column↔lifecycle projection round-trip, the
- * reason codec, and the `Match.tagsExhaustive` reason handlers. The make-invalid-
- * states-unrepresentable guarantees (`Removed` needs its triad; `restore` only on
- * `Removed`) are enforced at compile time — asserted here with `expectTypeOf`.
+ * EntityLifecycle unit coverage. The make-invalid-states-unrepresentable guarantees
+ * (`Removed` needs its triad; `restore` only on `Removed`) are compile-time, so they
+ * are asserted here with `expectTypeOf` rather than at runtime.
  */
 import {assert, describe, it} from "@effect/vitest";
 import {expectTypeOf} from "vitest";
@@ -52,10 +50,8 @@ describe("EntityLifecycle — type transitions", () => {
 		L.restore(L.Live());
 	});
 
-	// The çaylak sandbox-escape fix (#1811): a restore is sandbox-faithful — content
-	// that was sandboxed before removal returns to Sandboxed, NOT Live, so a
-	// delete→restore round-trip can never self-escape a çaylak's content to the
-	// always-Live broadcast without a mod's promotion.
+	// A restore is sandbox-faithful, so a delete→restore round-trip can never
+	// self-escape a çaylak's content to the always-Live broadcast (#1811).
 	it("restore : Removed → Sandboxed for content sandboxed before removal (#1811)", () => {
 		const removed = L.remove({
 			removedAt: fixedNow,
@@ -151,9 +147,8 @@ describe("EntityLifecycle — column projection round-trip", () => {
 		});
 	});
 
-	// #1811: a sandboxed-then-removed row PRESERVES its `sandboxedAt` through the
-	// Removed columns (so restore can round-trip it), and restore persists it back as
-	// a Sandboxed row — never a Live row with the marker cleared.
+	// A sandboxed-then-removed row must PRESERVE `sandboxedAt` through the Removed
+	// columns, or restore silently produces a Live row (#1811).
 	it("toColumns(remove(...)) preserves the pre-removal sandboxedAt column (#1811)", () => {
 		const removed = L.remove({
 			removedAt: fixedNow,
@@ -217,8 +212,7 @@ describe("EntityLifecycle — sandbox (#1205)", () => {
 		});
 		// A removed-AND-sandboxed row reads as Removed (the removal is the live fact)…
 		assert.isTrue(L.isRemoved(lifecycle));
-		// …but the pre-removal sandbox marker is carried, not dropped — so restore
-		// round-trips it back to the sandbox (the çaylak-escape fix).
+		// …but the pre-removal sandbox marker is carried, not dropped.
 		if (L.isRemoved(lifecycle)) assert.strictEqual(lifecycle.sandboxedAt, fixedNow);
 	});
 

--- a/apps/web/worker/features/lifecycle/SandboxVisibility.agreement.unit.test.ts
+++ b/apps/web/worker/features/lifecycle/SandboxVisibility.agreement.unit.test.ts
@@ -1,36 +1,21 @@
 /**
  * The cross-encoding AGREEMENT oracle (#2013): the çaylak-sandbox visibility boundary
- * is encoded twice — the in-memory `EntityLifecycle.isVisibleTo` (a decision over the
- * lifecycle tags) and its SQL mirror `SandboxVisibility.sandboxVisibleWhere` (a drizzle
- * predicate composed with the caller's `isNull(removedAt)` guard, i.e. `publicLiveWhere`).
- * They must agree for EVERY lifecycle state; before #2013 nothing linked them, so a new
- * lifecycle tag could compile clean on the SQL side and silently mis-filter at the DB.
+ * is encoded twice — in-memory (`EntityLifecycle.isVisibleTo`) and as SQL
+ * (`SandboxVisibility.sandboxVisibleWhere`). They must agree for EVERY lifecycle state.
  *
- * Both encodings now derive from ONE source — `lifecycleVisibilityRule`, keyed by the
- * closed `LifecycleTag`, interpreted by `ruleVisibleTo` on the in-memory side and by the
- * exhaustive `sandboxArm` switch on the SQL side — so a new lifecycle tag is a compile
- * error at the map and at `sandboxArm`. This test is the RUNTIME oracle for that
- * compile-time tie: it iterates every `LifecycleTag` (exhaustive over the discriminant —
- * a new tag lands here with no expected verdict and its cell fails) and, for each viewer ×
- * ownership cell, evaluates the SQL predicate by APPLYING it to that row's concrete column
- * values and asserts the row is admitted iff `isVisibleTo` marks the state visible.
- *
- * ADR 0082 bans a faked in-process SQL engine (`node:sqlite`) at the unit tier — an
- * in-process engine is more permissive than real D1, so a faked-D1 unit suite can pass
- * while real D1 rejects it. Row-level filtering against real D1 is the integration tier's
- * job. So this unit oracle does NOT execute SQL: it evaluates the drizzle predicate
- * against a row with a small, faithful interpreter over exactly the operators these
- * predicates emit (`IS NULL` / `IS NOT NULL` / `=` / `AND` / `OR`), reading the operator
- * and operands off drizzle's own compiled `{sql, params}`. The interpreter is
- * rule-agnostic — it knows SQL, not the visibility rule — so agreement is not circular.
+ * ADR 0082 bans a faked in-process SQL engine at the unit tier, so this does NOT
+ * execute SQL: it evaluates the drizzle predicate against a row with a small,
+ * rule-agnostic interpreter over exactly the operators these predicates emit
+ * (`IS NULL` / `IS NOT NULL` / `=` / `AND` / `OR`), read off drizzle's compiled
+ * `{sql, params}`. Row-level filtering against real D1 is the integration tier's job.
  */
 import {assert, describe, it} from "@effect/vitest";
 import {integer, SQLiteDialect, sqliteTable, text} from "drizzle-orm/sqlite-core";
 import * as L from "./EntityLifecycle.ts";
 import {publicLiveWhere} from "./SandboxVisibility.ts";
 
-// A throwaway drizzle table carrying exactly the lifecycle columns the predicates read;
-// used only to render `publicLiveWhere` to `{sql, params}` with stable column names.
+// A throwaway drizzle table, only so `publicLiveWhere` renders to `{sql, params}`
+// with stable column names.
 const content = sqliteTable("content", {
 	id: text("id").primaryKey(),
 	authorId: text("author_id").notNull(),
@@ -44,17 +29,14 @@ const AUTHOR = "the-author";
 const OTHER = "someone-else";
 const at = 1_750_000_000_000; // epoch millis; a non-null timestamp marker
 
-/** A content row's concrete column values, over exactly the columns the predicate reads. */
 interface Row {
 	readonly author_id: string;
 	readonly sandboxed_at: number | null;
 	readonly removed_at: number | null;
 }
 
-// The persisted-column shape for each lifecycle state. Exhaustive over `LifecycleTag`
-// (a `Record` — a new tag is a compile error here, mirroring `lifecycleVisibilityRule`),
-// so the oracle's row set tracks the discriminant. The in-memory `EntityLifecycle` value
-// is rebuilt from these same columns via `fromColumns`, so both encodings see one input.
+// Exhaustive over `LifecycleTag` (a `Record`, so a new tag is a compile error here).
+// The in-memory value is rebuilt from these same columns, so both encodings see one input.
 const columnsForTag: Record<
 	L.LifecycleTag,
 	{sandboxedAt: number | null; removedAt: number | null}
@@ -78,19 +60,16 @@ const rowForTag = (tag: L.LifecycleTag, authorId: string): Row => {
 };
 
 /**
- * A faithful, rule-AGNOSTIC evaluator of the compiled drizzle SQL predicate against a
- * `Row`, over exactly the operators `publicLiveWhere` emits. Positional `?` params are
- * substituted in order; a column reference resolves off the row by its snake_case name.
- * Uses SQL three-valued logic only where it can differ from JS: `col = value` is false
- * when the column is null (never matches), matching SQLite. This is NOT a SQL engine —
- * it interprets the small closed operator set drizzle rendered, so it cannot drift from
- * the actual predicate the way a hand-written boolean re-encoding would.
+ * A rule-AGNOSTIC evaluator of the compiled drizzle predicate against a `Row`, over
+ * exactly the operators `publicLiveWhere` emits. SQL three-valued logic where it can
+ * differ from JS: `col = value` is false when the column is null, matching SQLite.
+ * Interpreting what drizzle rendered — rather than re-encoding the rule by hand — is
+ * what keeps the agreement non-circular.
  */
 const evalPredicate = (rendered: {sql: string; params: unknown[]}, row: Row): boolean => {
 	let cursor = 0;
 	const params = rendered.params;
-	// Substitute positional params left-to-right into unique sentinels so tokenizing is
-	// unambiguous, then walk a fully-parenthesized boolean expression.
+	// Unique sentinels make tokenizing unambiguous.
 	const withParams = rendered.sql.replace(/\?/g, () => JSON.stringify(params[cursor++]));
 
 	const colValue = (name: string): string | number | null => {
@@ -106,8 +85,7 @@ const evalPredicate = (rendered: {sql: string; params: unknown[]}, row: Row): bo
 		}
 	};
 
-	// Tokenize into columns, literals, operators, parens. Column refs render as
-	// `"content"."sandboxed_at"`; string literals as `'x'` (from JSON we get `"x"`).
+	// Column refs render as `"content"."sandboxed_at"`; string literals as `'x'`.
 	const tokens = withParams.match(
 		/"[^"]+"\."[^"]+"|"[^"]*"|\bis not null\b|\bis null\b|[()=]|\S+/gi,
 	);
@@ -117,7 +95,7 @@ const evalPredicate = (rendered: {sql: string; params: unknown[]}, row: Row): bo
 	const peek = () => tokens[i];
 	const next = () => tokens[i++];
 
-	// Grammar (fully parenthesized by drizzle): expr := or ; or := and ("or" and)* ;
+	// Grammar (drizzle fully parenthesizes): expr := or ; or := and ("or" and)* ;
 	// and := not ("and" not)* ; not := "(" or ")" | comparison
 	const parseComparison = (): boolean => {
 		const lhs = next() ?? "";
@@ -176,9 +154,7 @@ const evalPredicate = (rendered: {sql: string; params: unknown[]}, row: Row): bo
 	return result;
 };
 
-// The SQL encoding's verdict for a cell: does `publicLiveWhere` (the removal guard AND
-// `sandboxVisibleWhere` — how content reads compose it) admit this row? `undefined` ⇒
-// no restriction ⇒ admitted.
+// The SQL encoding's verdict for a cell. `undefined` ⇒ no restriction ⇒ admitted.
 const sqlAdmitsRow = (tag: L.LifecycleTag, authorId: string, viewer: L.SandboxViewer): boolean => {
 	const where = publicLiveWhere(
 		{sandboxedAt: content.sandboxedAt, authorId: content.authorId, removedAt: content.removedAt},
@@ -188,7 +164,7 @@ const sqlAdmitsRow = (tag: L.LifecycleTag, authorId: string, viewer: L.SandboxVi
 	return evalPredicate(dialect.sqlToQuery(where), rowForTag(tag, authorId));
 };
 
-// The in-memory encoding's verdict for the same cell, rebuilt from the SAME columns.
+// The in-memory verdict for the same cell, rebuilt from the SAME columns.
 const inMemoryVisible = (
 	tag: L.LifecycleTag,
 	authorId: string,
@@ -205,9 +181,6 @@ const inMemoryVisible = (
 };
 
 describe("çaylak-sandbox visibility — SQL mirror agrees with isVisibleTo for every lifecycle state (#2013)", () => {
-	// Exhaustive over the lifecycle discriminant: a new tag added to `EntityLifecycle`
-	// forces a `columnsForTag` entry (compile error otherwise), so it is automatically
-	// covered here — the runtime companion to the compile-time single-source.
 	const tags = Object.keys(columnsForTag) as L.LifecycleTag[];
 
 	for (const tag of tags) {

--- a/apps/web/worker/features/lifecycle/SandboxVisibility.ts
+++ b/apps/web/worker/features/lifecycle/SandboxVisibility.ts
@@ -1,14 +1,8 @@
 /**
- * The SQL side of the çaylak sandbox (#1205): the read-query predicates that mirror
- * `EntityLifecycle.isVisibleTo` at the persisted layer — applied at the SAME place
- * the ADR 0096 `removed_at IS NULL` guard already lives in each content read, so a
- * viewer never sees sandboxed content they aren't entitled to.
- *
- * Two predicates, both pure (no service): {@link sandboxVisibleWhere} is the
- * per-viewer read filter; {@link sandboxBacklogWhere} is the moderator
- * sandbox-queue / promotion-backlog read model (#1206's read seam). Neither carries
- * the `removed_at IS NULL` clause — callers keep their own (the removal guard is
- * orthogonal), `and()`-ing this predicate beside it.
+ * The SQL side of the çaylak sandbox — the read predicates mirroring
+ * `EntityLifecycle.isVisibleTo` at the persisted layer. Neither predicate carries the
+ * ADR 0096 `removed_at IS NULL` clause: removal is orthogonal, so callers `and()` their
+ * own guard beside these.
  */
 import {and, eq, isNotNull, isNull, or, type SQL, type SQLWrapper} from "drizzle-orm";
 import {
@@ -19,11 +13,9 @@ import {
 } from "./EntityLifecycle.ts";
 
 /**
- * Resolve the {@link SandboxViewer} a domain read applies from its options. A read
- * that was handed a fully-resolved `sandboxViewer` (the resolver probed moderator
- * authority) uses it; otherwise it degrades to a non-moderator viewer keyed by the
- * threaded `viewerId` — so an author still sees their OWN sandboxed content on a
- * plain `{viewerId}` re-read, while a missing identity safely reads as anonymous.
+ * Without a resolved `sandboxViewer` this degrades to a NON-moderator viewer keyed by
+ * `viewerId` — an author still sees their own sandboxed content on a plain re-read, and
+ * a missing identity falls back to anonymous.
  */
 export const resolveSandboxViewer = (opts: {
 	readonly viewerId?: string | null | undefined;
@@ -32,29 +24,15 @@ export const resolveSandboxViewer = (opts: {
 	opts.sandboxViewer ??
 	(opts.viewerId != null ? {viewerId: opts.viewerId, canSeeSandboxed: false} : anonymousViewer);
 
-/** The two lifecycle columns a content read filters the sandbox dimension on. */
 export interface SandboxColumns {
 	readonly sandboxedAt: SQLWrapper;
 	readonly authorId: SQLWrapper;
 }
 
 /**
- * The reusable per-tag SQL arm builder {@link sandboxVisibleWhere} folds together — the
- * sandbox-dimension read arm each lifecycle state contributes for a **non-moderator**
- * viewer, the SQL half of that state's {@link lifecycleVisibilityRule}, keyed by the
- * closed {@link LifecycleTag} discriminant so the SQL encoding is tied to the SAME
- * exhaustive tag set the TS `isVisibleTo` uses (#2013). An exhaustive `switch`: a new
- * lifecycle tag has no case, so this **fails to compile** until its sandbox arm is
- * stated — closing the latent gap where a 4th state would branch on booleans and
- * silently mis-filter at the DB. Returns the predicate admitting the rows of that state
- * this viewer may see, or `undefined` when the state adds no arm (`Removed` is filtered
- * by the caller's orthogonal `isNull(removedAt)` guard, so it is not selected here):
- *
- * - `Live` (`Everyone`) — `sandboxed_at IS NULL`: the public base, visible to all.
- * - `Sandboxed` (`AuthorOrModerator`) — a signed-in viewer additionally sees their own
- *   sandboxed rows (`author_id = :viewerId`); a moderator is handled by the
- *   `canSeeSandboxed` short-circuit in {@link sandboxVisibleWhere} (no restriction).
- * - `Removed` (`NoOne`) — `undefined`: not selected in the sandbox dimension.
+ * The per-tag SQL arm for a **non-moderator** viewer. The `switch` is exhaustive on
+ * purpose: a new lifecycle tag fails to compile here until its sandbox arm is stated,
+ * rather than compiling clean and silently mis-filtering at the DB.
  */
 export const sandboxArm = (
 	tag: LifecycleTag,
@@ -65,9 +43,8 @@ export const sandboxArm = (
 		case "Live":
 			return isNull(cols.sandboxedAt);
 		case "Sandboxed":
-			// Only the AuthorOrModerator rule's author branch survives here for a
-			// non-moderator (the moderator branch is the caller's `canSeeSandboxed`
-			// short-circuit): a signed-in viewer sees their OWN sandboxed rows.
+			// Only the author branch survives here; the moderator branch is the caller's
+			// `canSeeSandboxed` short-circuit.
 			return viewer.viewerId !== null ? eq(cols.authorId, viewer.viewerId) : undefined;
 		case "Removed":
 			return undefined;
@@ -75,19 +52,8 @@ export const sandboxArm = (
 };
 
 /**
- * The per-viewer sandbox read filter, the SQL mirror of `isVisibleTo` for the
- * `Live`/`Sandboxed` split (the `Removed` arm is the caller's own
- * `isNull(removedAt)` guard, kept beside this). Derived from the same exhaustive
- * lifecycle discriminant `isVisibleTo` uses (#2013): a moderator sees everything, else
- * the row is visible iff any lifecycle state's {@link sandboxArm} admits it — so a new
- * lifecycle tag forces a `sandboxArm` case (and a `lifecycleVisibilityRule` entry)
- * rather than compiling clean and mis-filtering. Emits the same SQL as before:
- *
- * - moderator (`canSeeSandboxed`) — `undefined`: no sandbox restriction, the full
- *   set is visible (drizzle `and()` drops an `undefined` term).
- * - signed-in member — `sandboxed_at IS NULL OR author_id = :viewerId`: public
- *   content plus their own sandboxed content.
- * - anonymous/public (`viewerId` null) — `sandboxed_at IS NULL`: public only.
+ * The per-viewer sandbox read filter. `undefined` means NO restriction (drizzle's
+ * `and()` drops an undefined term), which is how a moderator sees the full set.
  */
 export const sandboxVisibleWhere = (
 	cols: SandboxColumns,
@@ -101,50 +67,32 @@ export const sandboxVisibleWhere = (
 	return arms.length === 1 ? arms[0] : or(...arms);
 };
 
-/**
- * The columns the public-live aggregate predicate filters on: the sandbox pair plus
- * the ADR 0096 `removed_at`, so the removal guard folds into the same predicate
- * rather than being hand-written beside it at every count call site.
- */
 export interface PublicLiveColumns extends SandboxColumns {
 	readonly removedAt: SQLWrapper;
 }
 
 /**
- * The single public-live aggregate filter (#1359 seam): removed-excluded AND
- * sandbox-masked-for-this-viewer, in one predicate. This is the `and()` of the
- * caller's former `isNull(removedAt)` guard with {@link sandboxVisibleWhere} — for an
- * anonymous viewer it reduces to exactly `removed_at IS NULL AND sandboxed_at IS NULL`,
- * the form the landing-count paths (#1407) re-derive by hand today and fold onto this.
- *
- * For the **post** table the draft dimension is excluded too — that arm is pano-local
- * (ADR 0113: `is_draft` lives only on `post_record`), so the post-aware aggregate
- * `publicLivePostWhere` in `features/pano/PostVisibility.ts` `and()`s the draft arm onto
- * this. Definition/comment reads, which have no draft concept, route through this directly.
+ * Removed-excluded AND sandbox-masked, in one predicate. Carries NO draft arm: `is_draft`
+ * is pano-local (ADR 0113), so `publicLivePostWhere` `and()`s that arm onto this.
  */
 export const publicLiveWhere = (cols: PublicLiveColumns, viewer: SandboxViewer): SQL | undefined =>
 	and(isNull(cols.removedAt), sandboxVisibleWhere(cols, viewer));
 
-/** The two record fields the owner-scoped in-review flag reads. */
 export interface OwnerSandboxRecord {
 	readonly sandboxedAt: Date | null;
 	readonly authorId: string;
 }
 
 /**
- * The in-memory owner-scoped in-review flag (#2200): `true` iff the row is still
- * sandboxed (#1205) AND the viewer is its author — the `sandboxed` wire signal a
- * çaylak sees on their OWN in-review content. Owner-only by construction: any other
- * viewer (anonymous, another member, a moderator) reads `false`, so the flag never
- * leaks review state beyond the author. The in-memory dual of {@link sandboxArm}'s
- * `Sandboxed` author branch, for the read paths that have already fetched the record.
+ * The `sandboxed` wire signal a çaylak sees on their OWN in-review content. Owner-only
+ * by construction — every other viewer, moderators included, reads `false`, so the flag
+ * never leaks review state beyond the author.
  */
 export const ownSandboxed = (
 	record: OwnerSandboxRecord,
 	viewerId: string | null | undefined,
 ): boolean => record.sandboxedAt != null && viewerId != null && record.authorId === viewerId;
 
-/** The lifecycle columns the moderator sandbox queue reads. */
 export interface SandboxBacklogColumns {
 	readonly sandboxedAt: SQLWrapper;
 	readonly removedAt: SQLWrapper;
@@ -152,10 +100,8 @@ export interface SandboxBacklogColumns {
 }
 
 /**
- * The moderator sandbox-queue / promotion-backlog read model (#1206 seam): the
- * still-sandboxed, not-removed content — optionally scoped to one author's backlog
- * (what the promotion path flips on çaylak→yazar). Carries its own `removed_at IS
- * NULL` because it is a standalone queue read, not layered on a content read.
+ * The moderator sandbox queue. Unlike the predicates above it DOES carry its own
+ * `removed_at IS NULL`, because it is a standalone read and not layered on a content read.
  */
 export const sandboxBacklogWhere = (
 	cols: SandboxBacklogColumns,

--- a/apps/web/worker/features/lifecycle/SandboxVisibility.unit.test.ts
+++ b/apps/web/worker/features/lifecycle/SandboxVisibility.unit.test.ts
@@ -1,14 +1,9 @@
 /**
- * The çaylak-sandbox visibility matrix (#1205) — the core deliverable (ADR 0082
- * unit tier: pure, no DB). Asserts `EntityLifecycle.isVisibleTo` over the full
- * cross-product the acceptance criteria name: every viewer kind
- * {çaylak-author, yazar, moderator, other-member, anonymous} × content ownership
- * {own, others'} × lifecycle {Live, Sandboxed, Removed}.
+ * The çaylak-sandbox visibility matrix (#1205): every viewer kind × content ownership ×
+ * lifecycle.
  *
- * The viewer rank (çaylak vs yazar) carries NO sandbox-visibility weight on its
- * own — only `canSeeSandboxed` (moderator) and authorship do. A yazar is modeled
- * here exactly as any non-moderator member to prove that: a yazar gains no view
- * into another member's sandbox just by being a yazar.
+ * Viewer RANK carries no sandbox-visibility weight — only `canSeeSandboxed` and
+ * authorship do — so a yazar is modeled here exactly as any non-moderator member.
  */
 import {assert, describe, it} from "@effect/vitest";
 import * as L from "./EntityLifecycle.ts";
@@ -32,8 +27,6 @@ const removed = L.remove({
 	sandboxedAt: null,
 });
 
-// The five viewer kinds. çaylak-author and yazar are both non-moderator members;
-// the matrix proves visibility turns on moderator-authority + authorship, not rank.
 const viewers = {
 	caylakAuthor: {viewerId: AUTHOR, canSeeSandboxed: false},
 	yazar: {viewerId: "a-yazar", canSeeSandboxed: false},
@@ -154,8 +147,8 @@ describe("publicLiveWhere — the removed+sandbox aggregate predicate", () => {
 	const cols = {sandboxedAt: {} as never, authorId: {} as never, removedAt: {} as never};
 
 	it("is defined for every viewer kind — the removal guard always restricts", () => {
-		// even a moderator (no sandbox restriction) still gets `isNull(removedAt)`, so the
-		// aggregate is never undefined — it always excludes removed content.
+		// Even a moderator still gets `isNull(removedAt)`, so the aggregate is never
+		// undefined.
 		for (const viewer of Object.values(viewers)) {
 			assert.isDefined(publicLiveWhere(cols, viewer));
 		}

--- a/apps/web/worker/features/lifecycle/apply-removal-transition.ts
+++ b/apps/web/worker/features/lifecycle/apply-removal-transition.ts
@@ -1,42 +1,20 @@
 /**
- * The remove/restore *ceremony*, single-sourced (#2012). `removal.ts` already owns the
- * write SEQUENCE ({@link Removal.removeEntity}/{@link Removal.restoreEntity}, #1129); this
- * module owns the CALLER-side wrapper that every public remove/restore method (pano post,
- * pano comment, sözlük definition — author path + moderator path) had hand-inlined and
- * silently drifted:
+ * The caller-side remove/restore wrapper every public remove/restore method shares;
+ * `removal.ts` owns the write sequence itself.
  *
- *   `fromColumns` → `isRemoved` short-circuit → `remove`/`restore` + `toColumns` →
- *   `removeEntity`/`restoreEntity` → (plane side-effects) → recomputable-cache refresh
- *
- * The three arms differed only in the authorization gate, the `RemovalReason`, and the
- * result envelope — all of which stay at the call site. What is invariant — the state
- * guard, the column stamp, the substrate write, and the **stats-refresh policy** — lives
- * here, so a site can no longer forget a step or drift a policy.
- *
- * The refresh policy is uniform and load-bearing (#2012, #1639): the removal/restore is
- * committed BEFORE the refresh, and the refresh is a recomputable cache (ADR 0011/0117)
- * running over `DrizzleAccessOrDie` — a D1 hiccup there *dies*, and that must NOT flip an
- * already-committed transition into a raw 500 (the partial-commit-then-500). So the refresh
- * is swallowed-and-logged for EVERY arm (it was swallowed only in `deletePost`, bare in the
- * other eleven — the exact drift copy-pasted ceremony breeds). Totals recompute next write.
+ * The refresh policy is load-bearing: the transition commits BEFORE the refresh, and the
+ * refresh runs over `DrizzleAccessOrDie`, so a D1 hiccup there dies. Swallowing it in
+ * EVERY arm is what stops an already-committed transition turning into a raw 500; totals
+ * reconverge on the next write.
  */
 import {Effect} from "effect";
 import * as Removal from "./removal.ts";
 
-/**
- * A load→guard→transition subject: the already-loaded row's lifecycle columns plus the
- * pre-transition `sandboxedAt` marker the substrate preserves for a faithful round-trip
- * (#1811). The caller loads the row (its not-found + authority envelopes are its own);
- * this is the slice the transition reads.
- */
 export type TransitionSubject = Removal.RemovalColumns;
 
 /**
- * The uniform outcome of {@link applyRemovalTransition}. `committed` distinguishes the
- * no-op (already in the target state — the `isRemoved` short-circuit) from the applied
- * transition, and carries the stamped `sandboxedAt` a restore's broadcast decision reads.
- * A caller maps this to its result envelope; it cannot reach the transition without going
- * through the state guard.
+ * `committed: false` is the no-op — the row was already in the target state. The
+ * `sandboxedAt` on the committed arm is what a restore's broadcast decision reads.
  */
 export type RemovalTransitionOutcome =
 	| {readonly committed: false}
@@ -45,11 +23,8 @@ export type RemovalTransitionOutcome =
 const noop: RemovalTransitionOutcome = {committed: false};
 
 /**
- * Wrap a recomputable-cache refresh in the uniform swallow-and-log (#2012, #1639): the
- * write it follows has already committed, so a refresh die (a recomputable cache over
- * `DrizzleAccessOrDie`, ADR 0011/0117) must not flip it into a raw 500 — totals reconverge
- * on the next write. One place, so the removal/restore arms AND the create paths that
- * committed-then-refresh (`addDefinition`, `submitPost`, #2556) share the single policy.
+ * The swallow-and-log policy above, shared by the removal/restore arms and the create
+ * paths that commit-then-refresh.
  */
 export const swallowRefresh = (label: string, refresh: Effect.Effect<void>): Effect.Effect<void> =>
 	refresh.pipe(
@@ -57,15 +32,10 @@ export const swallowRefresh = (label: string, refresh: Effect.Effect<void>): Eff
 	);
 
 /**
- * Apply a remove/restore onto the substrate for one already-loaded, already-authorized
- * entity: state-guard → column stamp → `removeEntity`/`restoreEntity` → plane side-effects
- * → swallowed cache refresh. Returns {@link RemovalTransitionOutcome}; the no-op short-circuit
- * returns before any write.
- *
- * `afterCommit` runs after the substrate write and before the refresh — the plane-specific
- * bookkeeping that is NOT part of the invariant (pano's post `comment_count` adjustment,
- * sözlük's term-summary rebuild); pass `Effect.void` where there is none. `refresh` is the
- * recomputable stats/cache refresh, swallowed uniformly.
+ * Apply a remove/restore for one already-loaded, already-authorized entity. The caller
+ * owns the not-found and authority envelopes; this owns the state guard, the column
+ * stamp, the substrate write, and the refresh policy. `afterCommit` is the plane-specific
+ * bookkeeping that is NOT part of that invariant, run after the write, before the refresh.
  */
 export const applyRemovalTransition = <E = never, R = never>(
 	args: {

--- a/apps/web/worker/features/lifecycle/apply-removal-transition.unit.test.ts
+++ b/apps/web/worker/features/lifecycle/apply-removal-transition.unit.test.ts
@@ -1,15 +1,10 @@
 /**
  * `applyRemovalTransition` — the shared remove/restore ceremony single-sourced across
- * the pano post/comment + sözlük definition planes (#2012). This asserts the INVARIANT
- * the twelve public methods used to hand-inline and drift on, directly at the helper:
- *
- *   - the `isRemoved` state guard short-circuits (no-op, no substrate write, no refresh);
- *   - a `remove`/`restore` stamps the substrate and reports the round-tripped `sandboxedAt`;
- *   - `afterCommit` runs AFTER the substrate write and BEFORE the refresh (the ordering the
- *     comment plane's post-`comment_count` adjustment depends on);
- *   - the refresh is swallowed-and-logged UNIFORMLY (#1639) — a refresh die never flips an
- *     already-committed transition into a failure. This is the drift the issue names: the
- *     swallow existed only in `deletePost`, bare in the other eleven; now one place owns it.
+ * the pano post/comment + sözlük definition planes (#2012). Asserts, at the helper,
+ * the invariant twelve public methods used to hand-inline and drift on: the
+ * already-in-that-state guard short-circuits; `afterCommit` runs after the substrate
+ * write and before the refresh; and the refresh is swallowed-and-logged UNIFORMLY
+ * (#1639), so a refresh die never flips a committed transition into a failure.
  */
 import {assert, describe, it} from "@effect/vitest";
 import {Effect, Exit} from "effect";
@@ -19,8 +14,7 @@ import * as Removal from "./removal.ts";
 
 const now = new Date("2026-07-04T00:00:00.000Z");
 
-// A `RemovalSequence` that records what it was asked to write — the substrate write is a
-// black box here (its own tests target `removal.ts`); this only proves the ceremony calls it.
+// Records what it was asked to write; the substrate write itself is `removal.ts`'s.
 const recordingSeq = () => {
 	const calls: Array<{op: "remove" | "restore"; kind: TargetKind}> = [];
 	const seq: Removal.RemovalSequence = {
@@ -31,7 +25,6 @@ const recordingSeq = () => {
 	return {seq, calls};
 };
 
-// The live/removed column shapes the caller loads and hands the helper as `subject`.
 const liveColumns: Removal.RemovalColumns = {
 	removedAt: null,
 	removedBy: null,

--- a/apps/web/worker/features/lifecycle/create-path-refresh-swallow.unit.test.ts
+++ b/apps/web/worker/features/lifecycle/create-path-refresh-swallow.unit.test.ts
@@ -1,18 +1,11 @@
 /**
- * Create-path partial-failure guard (#2556, the create twin of #2012). A create's
- * post-commit cache refresh is a recomputable cache (ADR 0011/0117), so a die there must
- * NOT flip an already-committed insert into a raw 500: the id is minted server-side per
- * call, so a caller that retries the 500 (agent clients retry mechanically) mints a SECOND
- * row — a duplicate that reads as user intent. Both create paths — sözlük `addDefinition`
- * and pano `submitPost` — route their post-commit refresh through the shared
- * `swallowRefresh` ceremony, so a refresh die returns success and no retry (hence no
- * duplicate) is provoked.
+ * Create-path partial-failure guard (#2556). A post-commit cache refresh is
+ * recomputable (ADR 0011/0117), so a die there must NOT flip an already-committed
+ * insert into a 500: ids are minted server-side per call, so a caller that retries
+ * the 500 mints a SECOND row that reads as user intent.
  *
- * Driven at the SERVICE seam over a scripted `Drizzle` whose commit lands but whose
- * post-commit refresh dies (the same shape as `post-delete-undeclared-failure` part b).
- * The teeth: a client that retries on failure is modeled explicitly and the committed-row
- * counter is asserted to stay at 1 — without the swallow the first attempt would 500, the
- * client would retry, and the counter would climb past 1 (the duplicate).
+ * The teeth: a retrying client is modeled explicitly and the committed-row counter
+ * must stay at 1. Without the swallow it climbs past 1 — that is the duplicate.
  */
 import {assert, describe, it} from "@effect/vitest";
 import {type Context, Effect, Exit, Layer} from "effect";
@@ -25,15 +18,13 @@ import {Reaction} from "../reaction/Reaction.ts";
 import {Sozluk, SozlukLive} from "../sozluk/Sozluk.ts";
 import {Vote} from "../vote/Vote.ts";
 
-// A refresh over the raw `Drizzle` fails with `DrizzleError`, which `orDieAccess` collapses
-// to a die inside the feature service — the exact channel `swallowRefresh` must absorb.
+// `orDieAccess` collapses this `DrizzleError` to a die inside the feature service —
+// the exact channel `swallowRefresh` must absorb.
 const refreshDies = <A>(): Effect.Effect<A, DrizzleError> =>
 	Effect.fail(new DrizzleError({cause: new Error("post-commit cache refresh dies")}));
 
-// Sözlük `addDefinition` reaches the DB as: run#1 existing-term lookup → run#2 the
-// `definitionRecord` insert (the commit) → run#3+ the `persistTermSummary` /
-// `recomputeSozlukStats` refresh. Fresh per attempt so the order counter resets; the shared
-// `onCommit` accumulates committed rows across a client's retries.
+// run#1 term lookup → run#2 the insert (the commit) → run#3+ the refresh. Fresh per
+// attempt so the counter resets; `onCommit` accumulates across a client's retries.
 const sozlukCommitThenRefreshDies = (onCommit: () => void): DrizzleAccess => {
 	let runs = 0;
 	return {
@@ -50,9 +41,8 @@ const sozlukCommitThenRefreshDies = (onCommit: () => void): DrizzleAccess => {
 	} as DrizzleAccess;
 };
 
-// Pano `submitPost` commits through its only `batch` (the `postRecord` insert + `post_search`
-// dual-write) and refreshes through `persistPanoStats`' `run` — so method alone discriminates
-// commit from refresh, no order counter needed.
+// Pano `submitPost` commits through its only `batch` and refreshes through a `run`, so
+// the method alone discriminates commit from refresh — no order counter needed.
 const panoCommitThenRefreshDies = (onCommit: () => void): DrizzleAccess =>
 	({
 		run: () => refreshDies<never>(),
@@ -84,8 +74,7 @@ const panoLayer = (access: DrizzleAccess) =>
 		Layer.provide(inertPasaport),
 	);
 
-// A caller that retries a failed create up to `maxAttempts` (an agent client's mechanical
-// retry), returning the first success or the last failure.
+// Models an agent client's mechanical retry of a failed create.
 const clientRetries = <A, E>(
 	attempt: () => Effect.Effect<A, E>,
 	maxAttempts: number,

--- a/apps/web/worker/features/lifecycle/removal.ts
+++ b/apps/web/worker/features/lifecycle/removal.ts
@@ -1,30 +1,10 @@
 /**
- * The removal substrate (ADR 0096) — the ONE seam owning a deletable entity's full
- * lifecycle: its read projection, its write builders, and the remove/restore
- * *sequence* (#1129). The read side (`EntityLifecycle` projection + `RemovalReason`
- * codec) is authored in `EntityLifecycle.ts` and re-exported below so a call site
- * reaches read + write through this one module, never a column-by-column split.
- *
- * The write builders own the statement lockstep a removal/restore holds (ADR 0080):
- * stamp the `removed_at`/`removed_by`/`removed_reason` triad onto the content row
- * AND move its FTS row all-or-none in ONE `Drizzle.batch`.
- *
- * Two entity shapes:
- *   - **FTS-bearing** (post): the summary row and its `post_search` row move
- *     together, so a remove/restore is a TWO-statement batch (stamp + FTS) — the
- *     lockstep ADR 0080 stakes the design on. The FTS items come from
- *     `fts-sync.ts` (never reinvented): drizzle query-builders that `_prepare()`
- *     to a bound D1 `.stmt` the batch driver binds — a raw `db.run(sql)` 500s
- *     in-batch (#863/#920), so the builders stay query-builder-shaped.
- *   - **FTS-free** (definition, comment): no search row, so a remove/restore is a
- *     SINGLE `update` — the same triad stamp, no batch.
- *
- * The full SEQUENCE is owned by {@link removeEntity}/{@link restoreEntity}: the vote
- * wipe (`Vote.clearTarget`, karma KEPT — ADR 0096 §3) is its OWN atomic batch in
- * `Vote.ts`, committed BEFORE the stamp (it was never one batch with the stamp), then
- * the triad-stamp + FTS lockstep. Callers pass intent; the ordering can no longer be
- * hand-wired wrong. The recomputable caches (score/hot/commentCount/stats, ADR 0011)
- * the caller still refreshes outside.
+ * The removal substrate (ADR 0096) — the one seam owning a deletable entity's read
+ * projection, write builders, and remove/restore sequence (#1129). An FTS-bearing
+ * entity (post) moves its content row and its `post_search` row all-or-none in ONE
+ * batch (the ADR 0080 lockstep); the FTS-free kinds are a single update. The FTS items
+ * must come from `fts-sync.ts` query-builders — a raw `db.run(sql)` 500s in-batch
+ * (#863/#920). Recomputable caches (ADR 0011) still refresh at the call site.
  */
 import {eq} from "drizzle-orm";
 import {Effect} from "effect";
@@ -34,25 +14,14 @@ import type {TargetKind} from "../../db/target-kind.ts";
 import {removePostSearch, syncPostSearch} from "../search/fts-sync.ts";
 import type * as Lifecycle from "./EntityLifecycle.ts";
 
-// The removal read projection (ADR 0096 §2) is authored in `EntityLifecycle.ts` and
-// re-exported so read + write live behind this one seam (#1129): `EntityLifecycle`,
-// `RemovalColumns`, `fromColumns`/`toColumns`, `remove`/`restore`, the `RemovalReason`
-// codec, `isRemoved`/`isLive`, and the reason labels. Its own unit tests still target
-// `EntityLifecycle.ts` directly; this module is the consolidated front door.
+// Re-exported so read + write live behind this one seam (#1129).
 export * from "./EntityLifecycle.ts";
 
-/** The removed triad + score-zeroing every record table shares on a removal stamp. */
 const removedSet = (removed: Lifecycle.RemovalColumns, now: Date) =>
 	({...removed, score: 0, updatedAt: now}) as const;
 
-/** The cleared triad + bumped `updatedAt` every record table shares on a restore. */
 const liveSet = (live: Lifecycle.RemovalColumns, now: Date) => ({...live, updatedAt: now}) as const;
 
-/**
- * The post remove batch: stamp the `Removed` triad + zero score/hot, and drop the
- * `post_search` row — ONE all-or-none batch (ADR 0080 lockstep). Votes are cleared
- * by {@link removeEntity}'s `clearTarget` (its own batch) before this.
- */
 const removePostStatements = (
 	db: DrizzleDb,
 	postId: string,
@@ -66,11 +35,7 @@ const removePostStatements = (
 	removePostSearch(db, postId),
 ];
 
-/**
- * The post restore batch: clear the triad and re-enter the `post_search` row from
- * the title — ONE all-or-none batch (ADR 0080 lockstep). Votes wiped on removal
- * are not resurrected (ADR 0096 §4).
- */
+/** Votes wiped on removal are not resurrected here (ADR 0096 §4). */
 const restorePostStatements = (
 	db: DrizzleDb,
 	postId: string,
@@ -85,7 +50,6 @@ const restorePostStatements = (
 	...syncPostSearch(db, postId, title),
 ];
 
-/** The comment remove update (FTS-free): stamp the triad + zero score. */
 const removeCommentStatement = (
 	db: DrizzleDb,
 	commentId: string,
@@ -97,7 +61,6 @@ const removeCommentStatement = (
 		.set(removedSet(removed, now))
 		.where(eq(schema.commentRecord.id, commentId));
 
-/** The comment restore update (FTS-free): clear the triad. */
 const restoreCommentStatement = (
 	db: DrizzleDb,
 	commentId: string,
@@ -109,7 +72,6 @@ const restoreCommentStatement = (
 		.set(liveSet(live, now))
 		.where(eq(schema.commentRecord.id, commentId));
 
-/** The definition remove update (FTS-free): stamp the triad + zero score. */
 const removeDefinitionStatement = (
 	db: DrizzleDb,
 	definitionId: string,
@@ -121,7 +83,6 @@ const removeDefinitionStatement = (
 		.set(removedSet(removed, now))
 		.where(eq(schema.definitionRecord.id, definitionId));
 
-/** The definition restore update (FTS-free): clear the triad. */
 const restoreDefinitionStatement = (
 	db: DrizzleDb,
 	definitionId: string,
@@ -133,45 +94,27 @@ const restoreDefinitionStatement = (
 		.set(liveSet(live, now))
 		.where(eq(schema.definitionRecord.id, definitionId));
 
-/**
- * The drizzle write handles + the vote-wipe the sequence owner drives. A service
- * passes its own `{run, batch}` ({@link DrizzleAccessOrDie}) and `Vote.clearTarget`
- * so the sequence runs inside the caller's wiring without {@link removeEntity}
- * reaching for the `Drizzle`/`Vote` tags itself (the per-feature stat/cache refresh
- * stays at the call site).
- */
+/** Passed in by the caller so the sequence never reaches for the `Drizzle`/`Vote` tags itself. */
 export interface RemovalSequence {
 	readonly run: DrizzleAccessOrDie["run"];
 	readonly batch: DrizzleAccessOrDie["batch"];
 	readonly clearTarget: (kind: TargetKind, targetId: string) => Effect.Effect<void>;
 }
 
-/**
- * Remove intent, tagged by entity kind. The kind selects both the vote-target kind
- * and the write shape (post = stamp+FTS batch; comment/definition = single update);
- * an invalid kind/data pairing is unrepresentable.
- */
 export type RemoveTarget =
 	| {readonly kind: "post"; readonly id: string}
 	| {readonly kind: "comment"; readonly id: string}
 	| {readonly kind: "definition"; readonly id: string};
 
-/**
- * Restore intent, tagged by entity kind. `post` carries the `title` its FTS row is
- * re-indexed from; the FTS-free kinds don't, so a title-less post restore — or a
- * title on a comment/definition restore — does not typecheck.
- */
+/** `post` carries the `title` its FTS row is re-indexed from; the FTS-free kinds have none. */
 export type RestoreTarget =
 	| {readonly kind: "post"; readonly id: string; readonly title: string}
 	| {readonly kind: "comment"; readonly id: string}
 	| {readonly kind: "definition"; readonly id: string};
 
 /**
- * The full remove SEQUENCE, single-owned (#1129): the vote wipe (its OWN batch, karma
- * KEPT — ADR 0096 §3) committed BEFORE the triad stamp + FTS lockstep (ADR 0080). A
- * call site passes the `removed` columns it stamped from `Lifecycle.remove(...)`; it
- * cannot get the vote-wipe→stamp ordering or the batch boundaries wrong because they
- * are not its to wire. Stats/caches refresh at the call site, after.
+ * The vote wipe is its OWN batch (karma KEPT — ADR 0096 §3) and must commit BEFORE the
+ * triad stamp + FTS lockstep. Owned here so no call site can wire that order wrong (#1129).
  */
 export const removeEntity = (
 	seq: RemovalSequence,
@@ -194,12 +137,7 @@ export const removeEntity = (
 		}
 	});
 
-/**
- * The full restore SEQUENCE, single-owned (#1129): clear the triad (post = stamp+FTS
- * batch, FTS re-entered from `title`; comment/definition = single update). No vote
- * wipe — votes cleared on removal are not resurrected (ADR 0096 §4). The `live`
- * columns come from `Lifecycle.restore(...)` at the call site; stats refresh after.
- */
+/** No vote wipe on this side: votes cleared on removal are not resurrected (ADR 0096 §4). */
 export const restoreEntity = (
 	seq: RemovalSequence,
 	target: RestoreTarget,

--- a/apps/web/worker/features/lifecycle/removal.unit.test.ts
+++ b/apps/web/worker/features/lifecycle/removal.unit.test.ts
@@ -1,30 +1,11 @@
 /**
- * The removal SUBSTRATE ({@link Removal.removeEntity}/{@link Removal.restoreEntity}, #1129)
- * driven directly through its own `RemovalSequence` port — the interface-level coverage the
- * substrate lacked (#2017). Its headline invariants (ADR 0096 §3, ADR 0080) were asserted only
- * by prose and exercised indirectly through the plane callers; the caller-side ceremony that
- * wraps it (`apply-removal-transition.unit.test.ts`, #2012) uses an INERT `RemovalSequence`, so
- * nothing drove the substrate's own ordering / batch-shape / FTS decisions.
+ * The removal SUBSTRATE driven directly through its own `RemovalSequence` port. A RECORDING
+ * port renders every `run`/`batch` builder's `.toSQL()` over a `drizzle(noopD1)` and appends
+ * each call to one ordered stream, so the ordering, the run-vs-batch routing and the FTS
+ * shape are all assertable without an engine (ADR 0082/0104/0105).
  *
- * The port is purpose-built for substitution, so this substitutes a RECORDING `RemovalSequence`
- * — the `Vote.clearTarget`-batch-shape idiom (`vote/Vote.unit.test.ts`) crossed with the
- * `.toSQL()` render double (`sozluk/persist-term-summary.unit.test.ts`, ADR 0082/0104/0105: no
- * engine, no revived `node:sqlite` fake). Every `run`/`batch` builder is invoked against a
- * `drizzle(noopD1)` so the produced statements render to real SQL, and every call (including
- * `clearTarget`) is appended to one ordered event stream. That lets us assert THROUGH the
- * interface:
- *
- *   (a) `clearTarget` (the vote wipe, karma KEPT) fires BEFORE any content stamp on a remove,
- *       and NOT AT ALL on a restore (ADR 0096 §3/§4);
- *   (b) `post` routes via `batch` (stamp + FTS lockstep, ADR 0080) while `comment`/`definition`
- *       route via a single `run` (FTS-free);
- *   (c) a `post` restore re-enters `post_search` FROM the title (delete + insert bound to it),
- *       a `post` remove drops it (delete only) — the FTS re-entry is asymmetric by direction;
- *   (d) an illegal transition intent is unrepresentable (title-less post restore / a title on a
- *       comment restore / a stray kind do not typecheck).
- *
- * Row-level fidelity on real D1 (the batch actually commits all-or-none) stays the integration
- * tier's job; this proves the substrate ASKS the port for the right shape, in the right order.
+ * Row-level fidelity on real D1 stays the integration tier's job; this proves the substrate
+ * ASKS the port for the right shape, in the right order.
  */
 import {assert, describe, it} from "@effect/vitest";
 import {drizzle} from "drizzle-orm/d1";
@@ -63,9 +44,7 @@ const renderDb = drizzle(noopD1, {relations});
 
 type Rendered = {sql: string; params: unknown[]};
 
-// One ordered event per port call. `clearTarget` records the (kind,id) the vote wipe targets;
-// `run`/`batch` record the mode + the rendered SQL of every statement the builder produced, so
-// the ordering, the run-vs-batch routing, and the FTS shape are all readable off `events`.
+// One ordered event per port call, carrying the mode + the rendered SQL of every statement.
 type Event =
 	| {readonly op: "clearTarget"; readonly kind: TargetKind; readonly id: string}
 	| {readonly op: "run"; readonly stmts: ReadonlyArray<Rendered>}
@@ -75,8 +54,6 @@ const render = (stmt: unknown): Rendered =>
 	// drizzle's `BatchItem`/`Stmt` carries `.toSQL()` at runtime but doesn't expose it on the type.
 	(stmt as {toSQL: () => Rendered}).toSQL();
 
-// A recording `RemovalSequence`: the substrate calls it exactly as it would the real Drizzle
-// seam, but every builder is rendered instead of executed and every call is appended to `events`.
 const recordingSeq = () => {
 	const events: Event[] = [];
 	const seq: Removal.RemovalSequence = {
@@ -86,10 +63,8 @@ const recordingSeq = () => {
 			}),
 		run: <A>(fn: (db: DrizzleDb) => Promise<A>) =>
 			Effect.sync(() => {
-				// `run` takes a single-statement builder; render it as a one-element list so the
-				// two modes share one shape. The substrate's `run` builder returns the drizzle
-				// statement synchronously (it's `db.update(...)`), never a resolved promise — we
-				// render its `.toSQL()`, we do not execute the query.
+				// `run` takes a single-statement builder; render it as a one-element list so the two
+				// modes share one shape. Nothing executes — only `.toSQL()` is read.
 				const stmt = fn(renderDb as never) as unknown;
 				events.push({op: "run", stmts: [render(stmt)]});
 				return undefined as A;
@@ -104,9 +79,8 @@ const recordingSeq = () => {
 	return {seq, events};
 };
 
-// The stamped-columns a caller loads from `Lifecycle.remove(...)`/`restore(...)` and hands the
-// substrate. The substrate does not compute these — it writes whatever it is given — so a fixed
-// pair suffices; the ordering/shape is what varies by intent.
+// The substrate does not compute the stamped columns — it writes whatever it is given — so
+// one fixed pair suffices; the ordering/shape is what varies by intent.
 const removedColumns: Removal.RemovalColumns = {
 	removedAt: now,
 	removedBy: "mod-1",
@@ -301,9 +275,8 @@ describe("post FTS lockstep — remove drops the search row, restore re-enters i
 						/insert into .*post_search/i,
 						"then re-inserts the FTS row",
 					);
-					// The re-indexed norm is derived FROM the title the caller passed — the restore
-					// re-enters search from the title (not from a stale/empty value). The title is
-					// normalized before binding, so assert the bound param derives from POST_TITLE.
+					// The re-indexed norm derives FROM the title the caller passed, not from a stale or
+					// empty value; the title is normalized before binding.
 					assert.isTrue(
 						(insert?.params ?? []).some(
 							(p) => typeof p === "string" && p.includes("kelime") && p.includes("baslik"),
@@ -318,13 +291,10 @@ describe("post FTS lockstep — remove drops the search row, restore re-enters i
 describe("removeEntity / restoreEntity — illegal transitions are unrepresentable (compile-time)", () => {
 	it("a post restore without its title does not typecheck; a comment restore with a title does not either", () => {
 		const {seq} = recordingSeq();
-		// A post restore MUST carry the title its FTS row is rebuilt from.
 		// @ts-expect-error — a title-less post restore is missing `title`.
 		void Removal.restoreEntity(seq, {kind: "post", id: "p1"}, liveColumns, now);
-		// The FTS-free kinds carry NO title — a title on a comment restore is not part of the intent.
 		// @ts-expect-error — `title` is not a member of a comment `RestoreTarget`.
 		void Removal.restoreEntity(seq, {kind: "comment", id: "c1", title: "x"}, liveColumns, now);
-		// A stray kind is not a valid target at all.
 		// @ts-expect-error — "reaction" is not a removable entity kind.
 		void Removal.removeEntity(seq, {kind: "reaction", id: "r1"}, removedColumns, now);
 

--- a/apps/web/worker/features/mecmua/Mecmua.ts
+++ b/apps/web/worker/features/mecmua/Mecmua.ts
@@ -1,22 +1,11 @@
 /**
- * `Mecmua` — the mecmua long-form write service (#2497, epic #2467, #2463). The
- * domain-object home for the two write acts, reached only through the `Drizzle` seam
- * and dying on infra errors via `orDieAccess` (the `Report`/`Pano` service idiom):
- * validation + the DB write live here, never in the fate resolver (ADR 0013).
+ * `Mecmua` — the mecmua long-form write service (epic #2467). Validation + the DB write
+ * live here, never in the fate resolver (ADR 0013).
  *
- * Two acts:
- *   - {@link MecmuaService.saveDraft} — insert a NEW draft row (`publishedAt = null`).
- *     Multiple drafts per author are allowed (the deliberate divergence from pano's
- *     one-draft-per-author partial-unique index, #2463), so this always inserts a
- *     fresh id — never a probe-then-upsert.
- *   - {@link MecmuaService.publish} — stamp `publishedAt` on the caller's own draft
- *     (the yazar-floored act, gated at the mutation by `PublishMecmua`). The write is
- *     scoped `where id = ? AND author_id = ?`, so a yazar can only publish their OWN
- *     draft; a miss is {@link MecmuaPostNotFound}.
- *
- * There is no `authorName` column — the byline is the LIVE identity resolved from
- * `authorId` at read time (#2463), so a publish stamps only `publishedAt`; the byline
- * follows the author's current identity, never a snapshot.
+ * Multiple drafts per author are allowed — the deliberate divergence from pano's
+ * one-draft-per-author unique index (#2463) — so `saveDraft` always inserts a fresh id.
+ * There is no `authorName` column either: the byline is the LIVE identity resolved from
+ * `authorId` at read time, never a snapshot.
  */
 
 import {id} from "@usirin/forge";
@@ -40,9 +29,7 @@ import {anonymousMecmuaViewer, mecmuaPostVisibleWhere} from "./MecmuaPostVisibil
 import {MECMUA_FEED_ORDERING, MECMUA_MINE_ORDERING} from "./ordering.ts";
 import {type MecmuaPostRow, toMecmuaPostRow} from "./post-fields.ts";
 
-// The write-path input ids carry their brands (MecmuaPostId / UserId) so a
-// transposed `{id, authorId}` is a compile error at the resolver call site — the
-// brands are type-only, so the DB where/values still see plain strings (#2700).
+// Branded ids so a transposed `{id, authorId}` is a compile error at the call site (#2700).
 export interface SaveMecmuaDraftInput {
 	authorId: UserId;
 	/** Optional on a draft — a half-filled form persists (empty ⇒ stored as ""). */
@@ -52,7 +39,6 @@ export interface SaveMecmuaDraftInput {
 }
 
 export interface PublishMecmuaInput {
-	/** The draft to publish. */
 	id: MecmuaPostId;
 	/** The caller — the write is scoped to their OWN draft. */
 	authorId: UserId;
@@ -60,30 +46,24 @@ export interface PublishMecmuaInput {
 
 /** One reader→author subscription edge (#2500). */
 export interface MecmuaSubscriptionInput {
-	/** The reader who follows. */
 	subscriberId: UserId;
-	/** The author followed. */
 	authorId: UserId;
 }
 
-/** The subscribed-author feed page request — `subscriberId` + forward keyset window. */
 export interface MecmuaFeedInput {
 	subscriberId: string;
 	first?: number;
 	after?: string | null;
 }
 
-/** The author's own-posts page request (#2544) — `authorId` + forward keyset window. */
 export interface MecmuaOwnPostsInput {
 	authorId: string;
 	first?: number;
 	after?: string | null;
 }
 
-/** A forward page of the subscribed-author feed — plain `MecmuaPostRow`s, keyset-ordered. */
 export type MecmuaFeedPage = KeysetPage<MecmuaPostRow>;
 
-/** The feed page size default + clamp bound (mirrors the pano feed clamp). */
 const FEED_DEFAULT_FIRST = 20;
 const FEED_MAX_FIRST = 100;
 
@@ -95,34 +75,28 @@ export class Mecmua extends Context.Service<
 			input: PublishMecmuaInput,
 		) => Effect.Effect<MecmuaPostRow, MecmuaPostNotFound | MecmuaTitleRequired>;
 
-		/** Follow an author (#2500). Idempotent — a re-subscribe is a no-op, never a dup row. */
+		/** Idempotent — a re-subscribe is a no-op, never a dup row. */
 		readonly subscribe: (input: MecmuaSubscriptionInput) => Effect.Effect<void>;
 
-		/** Unfollow an author (#2500). A miss is a no-op. */
+		/** A miss is a no-op. */
 		readonly unsubscribe: (input: MecmuaSubscriptionInput) => Effect.Effect<void>;
 
-		/** The author ids a reader is subscribed to — the feed's author-selection edge read. */
 		readonly listSubscribedAuthorIds: (
 			subscriberId: string,
 		) => Effect.Effect<ReadonlyArray<string>>;
 
-		/** Whether `subscriberId` follows `authorId` — the subscribe-affordance state read (#2527). */
 		readonly isSubscribed: (subscriberId: UserId, authorId: UserId) => Effect.Effect<boolean>;
 
 		/**
-		 * The subscribed-author time feed (#2500): a forward keyset page of PUBLISHED
-		 * mecmua posts from the reader's subscribed authors, ordered `publishedAt desc, id
-		 * desc` (newest-first). Drafts never appear (the `MecmuaPostVisibility` published
-		 * mask); a reader with no subscriptions gets an empty page.
+		 * The subscribed-author time feed (#2500), newest-first. Drafts never appear; a
+		 * reader with no subscriptions gets an empty page.
 		 */
 		readonly listFeedConnection: (input: MecmuaFeedInput) => Effect.Effect<MecmuaFeedPage>;
 
 		/**
-		 * The author's OWN posts (#2544): a forward keyset page of the caller's posts —
-		 * BOTH drafts (`publishedAt is null`) and published — ordered `createdAt desc, id
-		 * desc` (newest-started first). This is the PRIVATE complement of the draft-masked
-		 * public reads: it is scoped `where author_id = ?`, so only the caller's own rows
-		 * ever resolve and no other author's drafts are exposed.
+		 * The author's OWN posts (#2544), drafts included — the PRIVATE complement of the
+		 * draft-masked public reads. Scoped `where author_id = ?`, so no other author's
+		 * drafts are ever exposed.
 		 */
 		readonly listOwnPostsConnection: (input: MecmuaOwnPostsInput) => Effect.Effect<MecmuaFeedPage>;
 	}
@@ -130,8 +104,7 @@ export class Mecmua extends Context.Service<
 
 export const MecmuaLive = Layer.effect(Mecmua)(
 	Effect.gen(function* () {
-		// `orDieAccess`: every internal DB call dies on `DrizzleError` (infra failures are
-		// defects, `.patterns/effect-errors.md`), so method signatures carry domain errors only.
+		// `orDieAccess`: see .patterns/effect-errors.md.
 		const {run} = orDieAccess(yield* Drizzle);
 
 		const saveDraft = Effect.fn("Mecmua.saveDraft")(function* (input: SaveMecmuaDraftInput) {
@@ -152,8 +125,8 @@ export const MecmuaLive = Layer.effect(Mecmua)(
 		});
 
 		const publish = Effect.fn("Mecmua.publish")(function* (input: PublishMecmuaInput) {
-			// Ownership-scoped read: only the caller's OWN row resolves, so a yazar can't
-			// publish another author's draft (a foreign/absent id is MECMUA_POST_NOT_FOUND).
+			// Ownership-scoped: a foreign or absent id is `MecmuaPostNotFound`, so a yazar
+			// can't publish another author's draft.
 			const existing = yield* run((db) =>
 				db.query.mecmuaPost.findFirst({
 					where: {id: input.id, authorId: input.authorId},
@@ -180,8 +153,7 @@ export const MecmuaLive = Layer.effect(Mecmua)(
 		});
 
 		const subscribe = Effect.fn("Mecmua.subscribe")(function* (input: MecmuaSubscriptionInput) {
-			// Idempotent: the (subscriber, author) primary key makes a re-subscribe a no-op
-			// rather than a duplicate-key failure — one follow edge, at most.
+			// The (subscriber, author) primary key makes a re-subscribe a no-op.
 			yield* run((db) =>
 				db
 					.insert(schema.mecmuaSubscription)
@@ -245,20 +217,19 @@ export const MecmuaLive = Layer.effect(Mecmua)(
 			const after = input.after ?? null;
 
 			const authorIds = yield* listSubscribedAuthorIds(input.subscriberId);
-			// No subscriptions ⇒ no feed. Short-circuit before any post read (and avoid an
-			// empty `IN ()`), returning the shared empty page.
+			// Short-circuit before any post read, and avoid an empty `IN ()`.
 			if (authorIds.length === 0) return emptyKeysetPage satisfies MecmuaFeedPage;
 
-			// The published mask (drafts excluded for everyone, author included) reused from
-			// `MecmuaPostVisibility` against the anonymous viewer — a feed is a reading surface.
+			// The anonymous viewer even for the subscriber: a feed is a reading surface, so
+			// drafts are excluded for everyone including their own author.
 			const publishedWhere = mecmuaPostVisibleWhere(
 				{publishedAt: schema.mecmuaPost.publishedAt, authorId: schema.mecmuaPost.authorId},
 				anonymousMecmuaViewer,
 			);
 			const baseWhere = and(inArray(schema.mecmuaPost.authorId, authorIds), publishedWhere);
 
-			// Resolve the `after` cursor to its `publishedAt` anchor, gated by the SAME
-			// published mask so a cursor naming a now-draft/absent row misses → empty page.
+			// Gated by the SAME published mask, so a cursor naming a now-draft or absent row
+			// misses → empty page.
 			const resolvedRow = after
 				? ((yield* run((db) =>
 						db
@@ -272,8 +243,8 @@ export const MecmuaLive = Layer.effect(Mecmua)(
 			if (cursor.kind === "miss") return emptyKeysetPage satisfies MecmuaFeedPage;
 			const cursorRow = cursor.kind === "hit" ? cursor.row : null;
 
-			// Predicate + `orderBy` both derive from `MECMUA_FEED_ORDERING`; the opaque `id`
-			// cursor value is the `after` string (the anchor row carries only `publishedAt`).
+			// The opaque `id` cursor value is the `after` string — the anchor row carries
+			// only `publishedAt`.
 			const cursorPredicate = keysetAfter(
 				keysetKeys(MECMUA_FEED_ORDERING, (field) =>
 					field === "id" ? after : (cursorRow?.publishedAt ?? null),
@@ -289,9 +260,8 @@ export const MecmuaLive = Layer.effect(Mecmua)(
 					.limit(first + 1),
 			);
 
-			// The published-mask + ordering are enforced authoritatively in JS here (the SQL
-			// above mirrors them for an index-friendly pre-filter), so the feed's two ACs hold
-			// on the served path, not only in the query planner — see `feed-selection.ts`.
+			// The mask + ordering are enforced authoritatively here, not in the query planner;
+			// the SQL above only mirrors them as an index-friendly pre-filter.
 			const selected = selectMecmuaFeed(fetched.map(toMecmuaPostRow), new Set(authorIds));
 			return forwardPage(selected, first, (r) => r.id) satisfies MecmuaFeedPage;
 		});
@@ -302,14 +272,11 @@ export const MecmuaLive = Layer.effect(Mecmua)(
 			const first = Math.max(1, Math.min(input.first ?? FEED_DEFAULT_FIRST, FEED_MAX_FIRST));
 			const after = input.after ?? null;
 
-			// Own posts only — `author_id = ?` includes drafts (null `publishedAt`), so no
-			// visibility mask is applied: the author always sees their own rows, and the
-			// scoping guarantees another author's rows never resolve (rides the
-			// `mecmua_post_author_created` index).
+			// No visibility mask deliberately: the author scope is what keeps other authors'
+			// rows out, and drafts (null `publishedAt`) must stay in.
 			const baseWhere = eq(schema.mecmuaPost.authorId, input.authorId);
 
-			// Resolve the `after` cursor to its `createdAt` anchor, gated by the SAME author
-			// scope so a cursor naming a foreign/absent row misses → empty page.
+			// Gated by the SAME author scope, so a cursor naming a foreign row misses.
 			const resolvedRow = after
 				? ((yield* run((db) =>
 						db

--- a/apps/web/worker/features/mecmua/Mecmua.unit.test.ts
+++ b/apps/web/worker/features/mecmua/Mecmua.unit.test.ts
@@ -1,11 +1,9 @@
 /**
- * Unit — the `Mecmua` write acts over a scripted `Drizzle` seam (the `Bookmark` /
- * `Vote.unit.test.ts` idiom, ADR 0082): `run` replays queued results so the pure
- * decisions are provable with no engine. Proves the ticket's write ACs (#2497):
- * `saveDraft` writes a PRIVATE draft (`publishedAt === null`) and allows MULTIPLE
- * drafts (distinct ids, never a probe-then-upsert), and `publish` STAMPS
- * `publishedAt` on the caller's own draft — refusing a foreign/absent id
- * (`MecmuaPostNotFound`) and an empty-title publish (`MecmuaTitleRequired`).
+ * Unit — the `Mecmua` write acts over a scripted `Drizzle` seam (ADR 0082): `run`
+ * replays queued results, so the pure decisions are provable with no engine. Covers
+ * #2497's write ACs: `saveDraft` writes a PRIVATE draft and allows MULTIPLE (distinct
+ * ids, never a probe-then-upsert); `publish` stamps `publishedAt` on the caller's own
+ * draft and refuses a foreign/absent id or an empty title.
  */
 import {assert, describe, it} from "@effect/vitest";
 import {Effect, Layer} from "effect";

--- a/apps/web/worker/features/mecmua/MecmuaPostVisibility.ts
+++ b/apps/web/worker/features/mecmua/MecmuaPostVisibility.ts
@@ -1,52 +1,33 @@
 /**
- * mecmua's post-visibility seam — the draft/publish mask (epic #2467, #2463).
+ * mecmua's post-visibility seam — the draft/publish mask.
  *
- * Deliberately SIMPLER than pano's `PostVisibility`: mecmua has no çaylak sandbox,
- * so there is NO sandbox arm and no moderator exemption to compose. Visibility is a
- * single axis — published vs. draft. A post is public once `published_at` is set;
- * while it is null the post is a draft, private to its author and no one else.
- *
- * Two pure layers (no service), mirroring the pano pair:
- * - {@link mecmuaPostVisibleTo} — the in-memory decision.
- * - {@link mecmuaPostVisibleWhere} — its SQL mirror.
+ * Deliberately SIMPLER than pano's `PostVisibility`: mecmua has no çaylak sandbox, so
+ * there is NO sandbox arm and no moderator exemption. One axis — published vs. draft.
  */
 import {eq, or, type SQL, type SQLWrapper, sql} from "drizzle-orm";
 
-/**
- * The viewer a mecmua visibility decision is made against — just the signed-in
- * account id (null = anonymous/public). No `canSeeSandboxed`: mecmua has no
- * sandbox, so the draft gate is author-only with no moderator branch.
- */
+/** `viewerId` null = anonymous. No `canSeeSandboxed`: the draft gate is author-only. */
 export interface MecmuaPostViewer {
 	readonly viewerId: string | null;
 }
 
-/** An anonymous/public viewer — sees only published posts. The safe default. */
 export const anonymousMecmuaViewer: MecmuaPostViewer = {viewerId: null};
 
-/**
- * The in-memory visibility decision: a post is visible to `viewer` iff it is
- * published (`publishedAt !== null`) OR the viewer authored it. A null
- * `publishedAt` (draft) is masked from everyone but its author.
- */
+/** Visible iff published OR the viewer authored it — a draft is masked from everyone else. */
 export const mecmuaPostVisibleTo = (
 	publishedAt: Date | null,
 	authorId: string,
 	viewer: MecmuaPostViewer,
 ): boolean => publishedAt !== null || viewer.viewerId === authorId;
 
-/** The `published_at` + `author_id` columns {@link mecmuaPostVisibleWhere} reads. */
 export interface MecmuaPostVisibleColumns {
 	readonly publishedAt: SQLWrapper;
 	readonly authorId: SQLWrapper;
 }
 
 /**
- * The per-row SQL mirror of {@link mecmuaPostVisibleTo}. `published_at IS NOT NULL`
- * is the null-safe published test — a null draft yields false, correctly masking it,
- * with no `= 1`-style comparison that a NULL would defeat. A signed-in viewer
- * additionally sees their own drafts via `author_id = :viewerId`; an anonymous read
- * reduces to the bare published test.
+ * The per-row SQL mirror of {@link mecmuaPostVisibleTo}. `IS NOT NULL` is the null-safe
+ * test — a `= 1`-style comparison would be defeated by a NULL.
  */
 export const mecmuaPostVisibleWhere = (
 	cols: MecmuaPostVisibleColumns,

--- a/apps/web/worker/features/mecmua/MecmuaPostVisibility.unit.test.ts
+++ b/apps/web/worker/features/mecmua/MecmuaPostVisibility.unit.test.ts
@@ -1,9 +1,7 @@
 /**
- * The mecmua post-visibility matrix (#2463) — the draft/publish mask over the
- * cross-product {published, draft} × {anonymous, author, other-member}. The
- * load-bearing cell: a null-`publishedAt` draft is hidden from a public read and
- * from every non-author, while a published row is exposed to all. mecmua has NO
- * sandbox arm, so there is no moderator-exemption cell to pin.
+ * The mecmua draft/publish visibility matrix. The load-bearing cell: a null-`publishedAt`
+ * draft is hidden from every non-author. mecmua has NO sandbox arm, so there is no
+ * moderator-exemption cell to pin.
  */
 import {assert, describe, it} from "@effect/vitest";
 import {
@@ -23,8 +21,6 @@ const viewers = {
 	otherMember: {viewerId: OTHER},
 } satisfies Record<string, MecmuaPostViewer>;
 
-// Each cell is the expected `mecmuaPostVisibleTo(publishedAt, AUTHOR, viewer)` —
-// content authored by AUTHOR, viewed by each viewer kind.
 const matrix: Record<
 	string,
 	{publishedAt: Date | null; expect: Record<keyof typeof viewers, boolean>}
@@ -34,7 +30,6 @@ const matrix: Record<
 		expect: {anonymous: true, author: true, otherMember: true},
 	},
 	Draft: {
-		// null publishedAt ⇒ draft — author ONLY, hidden from anonymous + other members.
 		publishedAt: null,
 		expect: {anonymous: false, author: true, otherMember: false},
 	},

--- a/apps/web/worker/features/mecmua/PublishMecmua.ts
+++ b/apps/web/worker/features/mecmua/PublishMecmua.ts
@@ -1,20 +1,9 @@
 /**
- * `PublishMecmua` — the mecmua write-gate capability (#2497, epic #2467, #2463).
- *
- * A `Capability.Level` floored at `yazar`, modeled verbatim on `OpenTerm`
- * (`features/kunye/Authorship.ts`): the tag IS the right, it reads the GLOBAL
- * account-level standing off {@link Kunye.tierOf} against the {@link authorshipLadder}
- * and denies with {@link RequiresLevel} (`FORBIDDEN`). The yazar floor is
- * load-bearing and non-optional — a çaylak CANNOT publish (ADR 0107 §7: one global
- * künye identity, earned authorship, not per-product). mecmua has NO çaylak sandbox
- * (yazar is above the sandbox), so this is the whole publish authority.
- *
- * {@link requirePublishMecmua} is the enforcement-by-R wrapper (ADR 0107 §3, the
- * divan `requireDivanAccess` idiom): it discharges the capability and threads the
- * minted grant into `body`'s R channel, so `body` reads `yield* PublishMecmua` for
- * the proof and "publishing without the gate" is a compile error, not a forgotten
- * `if`. Draft-save is deliberately NOT gated by this floor (a private draft write is
- * normal-auth only, #2497).
+ * `PublishMecmua` — the mecmua write-gate capability: a `Capability.Level` floored at
+ * `yazar`, modeled verbatim on `OpenTerm`. The yazar floor is load-bearing and non-optional
+ * — a çaylak CANNOT publish (ADR 0107 §7), and mecmua has NO çaylak sandbox, so this is the
+ * whole publish authority. Draft-save is deliberately NOT gated by this floor: a private
+ * draft write is normal-auth only.
  */
 import {Capability, Grant, type Principal} from "@kampus/authz";
 import {Effect} from "effect";
@@ -34,11 +23,8 @@ export class PublishMecmua extends Capability.Level<PublishMecmua>()("mecmua/Pub
 }) {}
 
 /**
- * Gate `body` behind {@link PublishMecmua}: discharge the yazar floor (denying a
- * çaylak/visitor/anonymous with the `FORBIDDEN` {@link RequiresLevel}) and thread the
- * resulting grant into `body`'s R channel via `Grant.provide`. So `body` reads
- * `yield* PublishMecmua` for the gate proof, and publishing without a grant is a
- * compile error (enforcement-by-R, ADR 0107 §3).
+ * Gate `body` behind the yazar floor, threading the grant into its R channel — so publishing
+ * without a grant is a compile error (ADR 0107 §3).
  */
 export const requirePublishMecmua = <A, E, R>(body: Effect.Effect<A, E, PublishMecmua | R>) =>
 	PublishMecmua.require.pipe(Effect.flatMap((grant) => body.pipe(Grant.provide(grant))));

--- a/apps/web/worker/features/mecmua/PublishMecmua.unit.test.ts
+++ b/apps/web/worker/features/mecmua/PublishMecmua.unit.test.ts
@@ -1,13 +1,9 @@
 /**
- * Unit — the `PublishMecmua` write-gate through the real `Capability.Level` seam
- * (#2497, epic #2467, #2463). The load-bearing, non-optional guarantee: a **çaylak
- * is REFUSED publish** and a **yazar is allowed** — the earned-authorship floor (ADR
- * 0107 §7, one global künye identity). Standing is read off the real {@link Kunye}
- * service (a {@link makeKunyeStub} keyed by account id), the actor flows through
- * {@link CurrentActor}, and the agent arm routes the fail-closed
- * {@link AgentAuthorityV1}, so the denial path is the real discharge — not a
- * re-implemented check. A denied çaylak/visitor/anonymous fails {@link RequiresLevel}
- * (`FORBIDDEN`) carrying the needed `yazar` rank.
+ * The `PublishMecmua` write-gate through the real `Capability.Level` seam. The load-bearing,
+ * non-optional guarantee: a **çaylak is REFUSED publish** and a **yazar is allowed** (ADR
+ * 0107 §7). Standing is read off the real {@link Kunye} service and the agent arm routes the
+ * fail-closed {@link AgentAuthorityV1}, so the denial path is the real discharge — not a
+ * re-implemented check.
  */
 import {
 	type Actor,
@@ -26,7 +22,6 @@ import {makeKunyeStub} from "../kunye/Kunye.testing.ts";
 import type {Kunye, Tier} from "../kunye/Kunye.ts";
 import {PublishMecmua} from "./PublishMecmua.ts";
 
-/** Account id → earned rank, the standing the real `Kunye.tierOf` read resolves. */
 const standings: Record<string, Tier> = {yzr: "yazar", cyl: "çaylak", vis: "visitor"};
 
 const kunye = makeKunyeStub({tierOf: (id) => Effect.succeed(standings[id] ?? "visitor")});
@@ -39,7 +34,6 @@ const require = (actor: Actor): Exit.Exit<Grant<PublishMecmua>, RequiresLevel> =
 		),
 	);
 
-/** The `RequiresLevel` a denied discharge failed with. */
 const denial = (exit: Exit.Exit<unknown, RequiresLevel>): RequiresLevel => {
 	const failure = Exit.isFailure(exit) ? Cause.findErrorOption(exit.cause) : Option.none();
 	if (Option.isNone(failure)) throw new Error("expected a RequiresLevel denial, got a grant");
@@ -78,8 +72,8 @@ describe("the agent arm routes the fail-closed v1 seam", () => {
 	});
 });
 
-// The declared R channel — parity with `Authorship.typetest.ts`'s discharge assertion:
-// `.require` needs the ports + the standing read, never the proof it mints.
+// Parity with `Authorship.typetest.ts`: `.require` needs the ports + the standing read,
+// never the proof it mints.
 const _requiresTheThreePorts: Effect.Effect<
 	Grant<PublishMecmua>,
 	RequiresLevel,

--- a/apps/web/worker/features/mecmua/errors.ts
+++ b/apps/web/worker/features/mecmua/errors.ts
@@ -1,20 +1,15 @@
 /**
- * mecmua write-path errors (#2497). Each is a `Schema.TaggedErrorClass` carrying its
- * wire `code` as an `FateWireCode` annotation `encodeWireError` reads at the fate
- * boundary (`.patterns/fate-effect-wire-errors.md`), the same shape as pano's.
+ * mecmua write-path errors (#2497); see `.patterns/fate-effect-wire-errors.md`.
  *
- * The publish yazar-floor denial is NOT here — it is the shared künye
- * {@link ../kunye/errors.ts | RequiresLevel} (`FORBIDDEN`) minted by
- * {@link ../mecmua/PublishMecmua.ts | PublishMecmua}, so the earned-ladder denial
- * copy lives once at the capability, not duplicated per feature.
+ * The publish yazar-floor denial is NOT here — it is künye's shared `RequiresLevel`, so
+ * the earned-ladder denial copy lives once at the capability.
  */
 import {FateWireCode} from "@kampus/fate-effect";
 import * as Schema from "effect/Schema";
 
 /**
- * The mecmua flag is off (dark-ship, ADR 0083). Both `mecmua.publish` and
- * `mecmua.saveDraft` fail this with the flag off, so the write path is unreachable
- * even if a client bypasses the (not-yet-built) UI — the load-bearing containment.
+ * Dark-ship containment (ADR 0083): both write mutations fail this with the flag off, so
+ * the write path is unreachable even if a client bypasses the UI.
  */
 export class MecmuaDisabled extends Schema.TaggedErrorClass<MecmuaDisabled>()(
 	"mecmua/MecmuaDisabled",
@@ -22,14 +17,13 @@ export class MecmuaDisabled extends Schema.TaggedErrorClass<MecmuaDisabled>()(
 	{[FateWireCode]: "MECMUA_DISABLED"},
 ) {}
 
-/** A publish target draft doesn't exist, or isn't the caller's own — the ownership-scoped miss. */
+/** The draft doesn't exist, or isn't the caller's own — the ownership-scoped miss. */
 export class MecmuaPostNotFound extends Schema.TaggedErrorClass<MecmuaPostNotFound>()(
 	"mecmua/MecmuaPostNotFound",
 	{message: Schema.String},
 	{[FateWireCode]: "MECMUA_POST_NOT_FOUND"},
 ) {}
 
-/** A publish with an empty title — a published yazı needs a başlık. */
 export class MecmuaTitleRequired extends Schema.TaggedErrorClass<MecmuaTitleRequired>()(
 	"mecmua/MecmuaTitleRequired",
 	{message: Schema.String},

--- a/apps/web/worker/features/mecmua/fate-module.ts
+++ b/apps/web/worker/features/mecmua/fate-module.ts
@@ -14,24 +14,18 @@ import {
 	mecmuaSubscriptionReceiptDataView,
 } from "./views.ts";
 
-// The write path + feed both return `MecmuaPostView` inline, so the entity needs a
-// source to be view-reachable in codegen. A `syntheticSource` (no by-id fetch path) is
-// the minimal footprint — the mutation/feed resolver delivers the rows in its response.
+// Both paths return `MecmuaPostView` inline, so the entity needs a source to be
+// view-reachable in codegen; a `syntheticSource` (no by-id fetch path) is the minimum.
 const mecmuaPostSource = Fate.syntheticSource(MecmuaPostView);
 // The subscribe/unsubscribe receipt is delivered inline by its mutation (#2500).
 const mecmuaSubscriptionReceiptSource = Fate.syntheticSource(MecmuaSubscriptionReceiptView);
 
 const roots: FateRootsRecord = {
-	// The subscribed-author time feed (#2500). The `mecmuaFeed` resolver owns the order
-	// (`publishedAt desc, id desc`, single-sourced from `MECMUA_FEED_ORDERING`) + the
-	// published mask + the subscribed-author selection.
+	// The subscribed-author time feed (#2500).
 	mecmuaFeed: list(mecmuaPostDataView, {orderBy: viewOrderBy(MECMUA_FEED_ORDERING)}),
-	// The author's own posts — drafts + published (#2544). `CurrentUser`-scoped, ordered
-	// `createdAt desc, id desc` (single-sourced from `MECMUA_MINE_ORDERING`), so the
-	// private drafts list has a stable retrieval surface.
+	// The author's own posts — drafts + published (#2544), `CurrentUser`-scoped.
 	mecmuaMyPosts: list(mecmuaPostDataView, {orderBy: viewOrderBy(MECMUA_MINE_ORDERING)}),
-	// The subscribe-affordance state read (#2527) — whether the reader follows a given
-	// author. Resolved inline by the `mecmuaSubscription` query keyed on `CurrentUser`.
+	// Resolved inline by the `mecmuaSubscription` query, keyed on `CurrentUser`.
 	mecmuaSubscription: mecmuaSubscriptionReceiptDataView,
 };
 

--- a/apps/web/worker/features/mecmua/feed-selection.ts
+++ b/apps/web/worker/features/mecmua/feed-selection.ts
@@ -1,25 +1,14 @@
 /**
- * The subscribed-author feed's pure selection decision (#2500) — DB-free, so the
- * two load-bearing feed ACs are unit-provable with no SQL engine (ADR 0082, the
- * `src/lib/panoFeedSort.ts` role): given a candidate row set and the reader's
- * subscribed author ids, keep only the PUBLISHED posts authored by a subscribed
- * author and order them newest-published-first (`publishedAt desc, id desc`).
+ * The subscribed-author feed's selection decision, kept DB-free so the feed's
+ * published-mask and ordering are unit-provable with no SQL engine (ADR 0082). The
+ * keyset SQL's `WHERE`/`ORDER BY` mirror this; this is the enforcing copy.
  *
- * `Mecmua.listFeedConnection` runs this over the rows its keyset SQL fetched, so the
- * feed's published-mask + ordering are enforced HERE (in JS), the same guarantee the
- * SQL `WHERE`/`ORDER BY` (derived from `MecmuaPostVisibility` + `MECMUA_FEED_ORDERING`)
- * mirror. Draft exclusion reuses `mecmuaPostVisibleTo` against the anonymous viewer —
- * a null `publishedAt` (draft) is masked from the feed for everyone, its author
- * included (the feed is a reading surface, not a drafts list).
+ * A draft (null `publishedAt`) is masked from the feed for EVERYONE, its own author
+ * included — the feed is a reading surface, not a drafts list.
  */
 import {anonymousMecmuaViewer, mecmuaPostVisibleTo} from "./MecmuaPostVisibility.ts";
 import type {MecmuaPostRow} from "./post-fields.ts";
 
-/**
- * Select the subscribed-author feed from `rows`: published posts whose author is in
- * `subscribedAuthorIds`, newest-published first (ties broken by descending `id`).
- * Pure and total — no DB, no clock.
- */
 export const selectMecmuaFeed = (
 	rows: ReadonlyArray<MecmuaPostRow>,
 	subscribedAuthorIds: ReadonlySet<string>,
@@ -28,16 +17,14 @@ export const selectMecmuaFeed = (
 		.filter(
 			(row) =>
 				subscribedAuthorIds.has(row.authorId) &&
-				// The published mask — a draft (null `publishedAt`) never appears in the feed,
-				// reusing the same decision the public read applies (`MecmuaPostVisibility`).
 				mecmuaPostVisibleTo(row.publishedAt, row.authorId, anonymousMecmuaViewer),
 		)
 		.sort(compareFeedRows);
 
 /**
- * The `publishedAt desc, id desc` comparator — the JS mirror of `MECMUA_FEED_ORDERING`.
- * A filtered feed row always has a non-null `publishedAt` (the mask dropped the drafts),
- * so the `?? 0` fallbacks are unreachable defense, never a live branch.
+ * The JS mirror of `MECMUA_FEED_ORDERING`. A filtered feed row always has a non-null
+ * `publishedAt` (the mask dropped the drafts), so the `?? 0` fallbacks are
+ * unreachable defense, never a live branch.
  */
 const compareFeedRows = (a: MecmuaPostRow, b: MecmuaPostRow): number => {
 	const at = a.publishedAt?.getTime() ?? 0;

--- a/apps/web/worker/features/mecmua/ids.ts
+++ b/apps/web/worker/features/mecmua/ids.ts
@@ -1,20 +1,9 @@
 /**
- * mecmua's feature-local branded id — `MecmuaPostId`, the nominal tag for a
- * `mecmua_post` row's worker-private id (epic #2700). Lives here beside the
- * feature rather than in the shared `lib/ids.ts` because it is mecmua's OWN
- * entity, not a cross-feature id: `mecmua_post` is a distinct brand from pano's
- * `PostId` (a `mecmua_post` id and a `pano_post` id are never interchangeable),
- * and keeping it feature-local keeps sibling id slices from colliding on the
- * shared module. The cross-feature `UserId` (a mecmua author IS a user) is
- * imported read-only from `lib/ids.ts`; mecmua does not re-mint it.
- *
- * The brand is type-only (`brandedId` = effect-smol `SCHEMA.md` §Branding): it
- * decodes byte-identically, so the D1/wire bytes are unchanged — only the type
- * checker gains the nominal distinction that makes an `authorId`/`postId` swap a
- * compile error.
+ * Feature-local rather than in the shared `lib/ids.ts` because it is mecmua's OWN
+ * entity, not a cross-feature id. The brand is type-only, decoding byte-identically —
+ * only the type checker gains the nominal distinction.
  */
 import {brandedId} from "../../lib/ids.ts";
 
-/** A `mecmua_post` row id — mecmua's own entity, distinct from pano's `PostId`. */
 export const MecmuaPostId = brandedId("MecmuaPostId");
 export type MecmuaPostId = typeof MecmuaPostId.Type;

--- a/apps/web/worker/features/mecmua/index-route.ts
+++ b/apps/web/worker/features/mecmua/index-route.ts
@@ -1,21 +1,12 @@
 /**
- * `GET /fate/mecmua/index` (#2512, epic #2467) — the PUBLIC chronological index of
- * published mecmua posts, newest-first by `published_at`. A raw `HttpRouter.add` route
- * following the anonymous-read idiom of `public-read-route.ts` / pano's
- * `base-feed-route.ts`: it never validates a session and never reads `CurrentUser`, so
- * an anon GET does zero identity work. It applies `mecmuaPostVisibleWhere` (#2496) under
- * the `anonymousMecmuaViewer`, so a draft (null `published_at`) is structurally masked —
- * only published posts appear in the index, no auth required.
+ * `GET /fate/mecmua/index` — the PUBLIC chronological index of published mecmua posts. A raw
+ * `HttpRouter.add` route on the anonymous-read idiom: it never validates a session and never
+ * reads `CurrentUser`, so an anon GET does zero identity work. Drafts are structurally
+ * masked by `mecmuaPostVisibleWhere` under the anonymous viewer.
  *
- * This is the PUBLIC index (all published posts) — distinct from the personalized
- * subscribed-author feed (#2500). The list is lean (id + slug + başlık + publishedAt),
- * not the full markdown body, since the reader (`/mecmua/:slug`) fetches the body on
- * demand.
- *
- * Dark behind `MECMUA_PUBLIC_READ` (default-off), the same seam the read route gates on:
- * with the flag off the route 404s, so the whole discovery surface ships dark until a
- * human flips the flag at release (ADR 0083). The flag is read under the anonymous flags
- * context (no identity), so the gate itself does no session work either.
+ * Dark behind `MECMUA_PUBLIC_READ` (default-off): flag off ⇒ 404, so the discovery surface
+ * ships dark until a human flips it at release (ADR 0083). The flag is read under the
+ * anonymous flags context, so the gate does no session work either.
  */
 import * as Cloudflare from "alchemy/Cloudflare";
 import {desc, type SQL} from "drizzle-orm";
@@ -33,14 +24,11 @@ import {
 } from "../flagship/FlagsContext.ts";
 import {anonymousMecmuaViewer, mecmuaPostVisibleWhere} from "./MecmuaPostVisibility.ts";
 
-/** The default (and max) index page size — a lean first page, no cursor pagination in v1. */
+// The default (and max) index page size — no cursor pagination in v1.
 const DEFAULT_LIMIT = 50;
 
-/**
- * The lean wire row for the index — identity + slug + başlık + the publish marker, but
- * NOT the markdown body (the reader fetches that per-slug). `publishedAt` is non-null in
- * practice because the WHERE masks drafts; the `Date | null` type just mirrors the column.
- */
+// Lean on purpose: NOT the markdown body, which the reader fetches per-slug. `publishedAt`
+// is non-null in practice because the WHERE masks drafts; `Date | null` mirrors the column.
 export interface MecmuaIndexRow {
 	readonly id: string;
 	readonly slug: string | null;
@@ -48,17 +36,13 @@ export interface MecmuaIndexRow {
 	readonly publishedAt: Date | null;
 }
 
-/**
- * The index WHERE: the `mecmuaPostVisibleWhere` published gate (#2496) under the
- * anonymous viewer — `published_at is not null`, with NO `author_id = :viewer` ownership
- * escape (there is no viewer). So a draft never appears in the public index.
- */
+// No `author_id = :viewer` ownership escape (there is no viewer), so a draft never appears
+// in the public index.
 export const mecmuaPublishedIndexWhere: SQL | undefined = mecmuaPostVisibleWhere(
 	{publishedAt: schema.mecmuaPost.publishedAt, authorId: schema.mecmuaPost.authorId},
 	anonymousMecmuaViewer,
 );
 
-/** List the published mecmua posts newest-first by `published_at`, lean rows only. */
 export const listPublishedMecmuaPosts = (
 	run: DrizzleAccessOrDie["run"],
 	limit = DEFAULT_LIMIT,
@@ -80,8 +64,8 @@ export const listPublishedMecmuaPosts = (
 export const handleMecmuaIndex = Effect.gen(function* () {
 	const raw = yield* Cloudflare.Request;
 
-	// The dark-ship gate under the ANONYMOUS flags context — an anon GET does zero
-	// identity work even to decide the flag. Off => 404, the shipped-dark default.
+	// The dark-ship gate under the ANONYMOUS flags context — an anon GET does zero identity
+	// work even to decide the flag. Off ⇒ 404, the shipped-dark default.
 	const flags = yield* Flags;
 	const flagsContext = yield* makeRequestFlagsContext(
 		anonymousFlagsContext,

--- a/apps/web/worker/features/mecmua/index-route.unit.test.ts
+++ b/apps/web/worker/features/mecmua/index-route.unit.test.ts
@@ -1,9 +1,7 @@
 /**
- * The mecmua public-index draft-mask + ordering (#2512, epic #2467). The public index
- * must (a) route the draft decision through the one `MecmuaPostVisibility` seam
- * (`mecmuaPostVisibleWhere`) so an anonymous visitor never sees an unpublished post, and
- * (b) order newest-first by `published_at`. Both are offline-reachable off `.toSQL()`
- * (no query runs) plus a scripted-`run` mapping check.
+ * The public index must route its draft decision through the one
+ * `mecmuaPostVisibleWhere` seam, so an anonymous visitor never sees an unpublished
+ * post (#2512). Checked off `.toSQL()` — no query runs.
  */
 import {assert, describe, it} from "@effect/vitest";
 import {desc} from "drizzle-orm";
@@ -42,7 +40,6 @@ const noopD1 = {
 } as unknown as D1Database;
 const renderDb = drizzle(noopD1, {relations});
 
-/** A `run` that ignores its query and resolves the scripted rows — the mapping fixtures never touch D1. */
 const scriptedRun =
 	(rows: ReadonlyArray<unknown>): DrizzleAccessOrDie["run"] =>
 	<A>(_fn: (db: DrizzleDb) => Promise<A>) =>

--- a/apps/web/worker/features/mecmua/lists.ts
+++ b/apps/web/worker/features/mecmua/lists.ts
@@ -1,14 +1,9 @@
 /**
- * mecmua root list resolvers (#2500, epic #2467). `mecmuaFeed` is the subscribed-author
- * time feed: a `CurrentUser`-scoped connection of PUBLISHED `MecmuaPostView` edges from
- * the reader's subscribed authors, ordered `publishedAt desc` (newest-first). Per ADR
- * 0019 the service owns the keyset + cursor (`Mecmua.listFeedConnection`); this layer
- * only reshapes the page into a `ConnectionResult`, mirroring pano's `savedPosts`
- * (per-viewer, signed-out → empty). See `.patterns/fate-connections.md`.
+ * mecmua root list resolvers. `mecmuaFeed` is the subscribed-author time feed: a
+ * `CurrentUser`-scoped connection of PUBLISHED posts, newest-first. Per ADR 0019 the service
+ * owns the keyset + cursor; this layer only reshapes the page (.patterns/fate-connections.md).
  *
- * Dark behind the default-off `MECMUA_FEED` flag (ADR 0083): with it off the resolver
- * serves an empty connection, so the whole feed surface ships dark until a human flips
- * the flag at release — the same containment the mecmua write/read paths use.
+ * Dark behind the default-off `MECMUA_FEED` flag (ADR 0083): off ⇒ an empty connection.
  */
 import {CurrentUser, Fate} from "@kampus/fate-effect";
 import {Effect} from "effect";
@@ -28,7 +23,6 @@ const MecmuaFeedArgs = Schema.Struct({
 	after: Schema.optional(Schema.String),
 });
 
-/** Stamp the wire `__typename` onto a feed row — the one feed-read shaper. */
 const toMecmuaPost = (r: MecmuaPostRow): MecmuaPost => ({__typename: "MecmuaPost", ...r});
 
 const feedConnection = (page: MecmuaFeedPage) =>
@@ -38,13 +32,11 @@ const feedConnection = (page: MecmuaFeedPage) =>
 		(row) => toMecmuaPost(row),
 	);
 
-/** Is the mecmua feed on for this request? Safe-default `false` (ships dark). */
 const feedOn = Effect.gen(function* () {
 	const flags = yield* Flags;
 	return yield* flags.getBoolean(MECMUA_FEED, false).pipe(provideRequestFlags);
 });
 
-/** Is the mecmua write path on for this request? Safe-default `false` (ships dark). */
 const writeOn = Effect.gen(function* () {
 	const flags = yield* Flags;
 	return yield* flags.getBoolean(MECMUA_WRITE, false).pipe(provideRequestFlags);
@@ -54,8 +46,7 @@ export const lists = {
 	mecmuaFeed: Fate.list(
 		{args: MecmuaFeedArgs, type: MecmuaPostView},
 		Effect.fn("mecmuaFeed")(function* ({args}) {
-			// Flag off OR signed-out ⇒ empty feed: the surface is dark until release, and an
-			// anonymous reader subscribes to no one, so there is nothing to serve either way.
+			// Flag off OR signed-out ⇒ empty feed: an anonymous reader subscribes to no one.
 			const {user} = yield* CurrentUser;
 			if (!user || !(yield* feedOn)) return feedConnection(emptyKeysetPage);
 
@@ -68,14 +59,12 @@ export const lists = {
 			return feedConnection(page);
 		}),
 	),
-	// The author's OWN posts — drafts + published (#2544), the private retrieval surface
-	// for the write path. Scoped to `CurrentUser`, so it never exposes another author's
-	// drafts; gated behind the same `MECMUA_WRITE` seam as the editor, so it ships dark.
+	// The author's OWN posts, drafts included — scoped to `CurrentUser`, so it never exposes
+	// another author's drafts; gated behind the same `MECMUA_WRITE` seam as the editor.
 	mecmuaMyPosts: Fate.list(
 		{args: MecmuaFeedArgs, type: MecmuaPostView},
 		Effect.fn("mecmuaMyPosts")(function* ({args}) {
-			// Flag off OR signed-out ⇒ empty: the write surface is dark until release, and an
-			// anonymous reader authored nothing, so there is nothing of theirs to serve.
+			// Flag off OR signed-out ⇒ empty: an anonymous reader authored nothing.
 			const {user} = yield* CurrentUser;
 			if (!user || !(yield* writeOn)) return feedConnection(emptyKeysetPage);
 

--- a/apps/web/worker/features/mecmua/mecmua-feed.unit.test.ts
+++ b/apps/web/worker/features/mecmua/mecmua-feed.unit.test.ts
@@ -1,11 +1,8 @@
 /**
- * Unit — the subscribed-author feed's two load-bearing ACs (#2500), proven with no DB
- * (ADR 0082): (a) the feed returns PUBLISHED posts from SUBSCRIBED authors ordered by
- * `publishedAt` newest-first, and (b) draft/unpublished posts NEVER appear. Both are
- * proven twice: on the pure `selectMecmuaFeed` decision (the DB-free spec) AND on the
- * served `Mecmua.listFeedConnection` path over a scripted `Drizzle` seam (the `Bookmark`
- * / `Mecmua.unit.test.ts` idiom), so the guarantee holds where the feed is served, not
- * only in a helper.
+ * The subscribed-author feed's two load-bearing ACs, proven with no DB (ADR 0082) and
+ * proven TWICE: on the pure `selectMecmuaFeed` decision and on the served
+ * `Mecmua.listFeedConnection` path, so the guarantee holds where the feed is actually
+ * served, not only in a helper.
  */
 import {assert, describe, it} from "@effect/vitest";
 import {Effect, Layer} from "effect";
@@ -31,8 +28,8 @@ const post = (over: Partial<MecmuaRecord> & {id: string}): MecmuaRecord => ({
 
 const AT = (iso: string) => new Date(iso);
 
-// Author A (subscribed) + B (subscribed) publish; A also has a draft; C (NOT subscribed)
-// publishes. The feed should be [B-May, A-Mar] — newest published first, drafts + C gone.
+// A + B are subscribed and publish; A also has a draft; C is NOT subscribed. The feed
+// should be [b-may, a-mar].
 const rows: MecmuaRecord[] = [
 	post({id: "a-mar", authorId: "A", publishedAt: AT("2026-03-01T00:00:00.000Z")}),
 	post({id: "b-may", authorId: "B", publishedAt: AT("2026-05-01T00:00:00.000Z")}),
@@ -80,7 +77,7 @@ describe("selectMecmuaFeed — the pure feed decision (ordering + draft mask)", 
 	});
 });
 
-/** A `Drizzle` whose `run` replays a queued result sequence; `batch` is unused here. */
+/** Replays a queued result sequence, so a script must match the method's read order. */
 const scriptedAccess = (results: ReadonlyArray<unknown>): DrizzleAccess => {
 	const state = {i: 0};
 	return {

--- a/apps/web/worker/features/mecmua/mecmua-own-posts.unit.test.ts
+++ b/apps/web/worker/features/mecmua/mecmua-own-posts.unit.test.ts
@@ -1,11 +1,8 @@
 /**
- * Unit — the author's own-posts read (#2544), the PRIVATE complement of the draft-masked
- * public reads. Proven on the served `Mecmua.listOwnPostsConnection` path over a scripted
- * `Drizzle` seam (the `mecmua-feed.unit.test.ts` idiom): the load-bearing AC is that a
- * DRAFT (null `publishedAt`) is INCLUDED — unlike the feed, this surface applies NO
- * published mask, so the author sees both their drafts and their published posts. The
- * author-scoping itself is the SQL `where author_id = ?` (the trusted `publish` ownership
- * idiom), so a foreign row never reaches this JS.
+ * The author's own-posts read, the private complement of the draft-masked public reads.
+ * The load-bearing case is that a DRAFT is INCLUDED — this surface applies no published
+ * mask. Author-scoping is the SQL `where author_id = ?`, so a foreign row never reaches
+ * this JS.
  */
 import {assert, describe, it} from "@effect/vitest";
 import {Effect, Layer} from "effect";
@@ -26,7 +23,6 @@ const post = (over: Partial<MecmuaRecord> & {id: string}): MecmuaRecord => ({
 	...over,
 });
 
-/** A `Drizzle` whose `run` replays a queued result sequence; `batch` is unused here. */
 const scriptedAccess = (results: ReadonlyArray<unknown>): DrizzleAccess => {
 	const state = {i: 0};
 	return {
@@ -42,8 +38,7 @@ const mecmuaLayer = (access: DrizzleAccess) =>
 	MecmuaLive.pipe(Layer.provide(Layer.succeed(Drizzle, access)));
 
 describe("Mecmua.listOwnPostsConnection — the author's own drafts + published", () => {
-	// Author A's own rows as the `author_id = ?` fetch would return them (createdAt desc):
-	// a published post AND a draft. No `after`, so `run` is called once (the fetch only).
+	// A published post AND a draft, as the `author_id = ?` fetch would return them.
 	const ownRows: MecmuaRecord[] = [
 		post({
 			id: "a-2",

--- a/apps/web/worker/features/mecmua/mutations.ts
+++ b/apps/web/worker/features/mecmua/mutations.ts
@@ -1,18 +1,10 @@
 /**
- * mecmua write-path mutation resolvers (#2497, epic #2467, #2463) — the publish +
- * save-draft acts, gated behind the default-off `mecmua-write` flag (ADR 0083, the
- * pano `post.saveDraft` dark-ship shape): with the flag off both fail
- * {@link MecmuaDisabled}, so the write path is unreachable even if a client bypasses
- * the (not-yet-built) UI. Domain validation + the DB write live in {@link Mecmua}
- * (ADR 0013); this layer resolves the identity, the flag, and the capability.
+ * mecmua write-path mutation resolvers, gated behind the default-off `mecmua-write`
+ * flag (ADR 0083) so the path is unreachable even if a client bypasses the UI.
  *
- * The authority split is the ticket's load-bearing rule:
- *   - `mecmua.publish` is floored at **yazar** via {@link requirePublishMecmua} — a
- *     çaylak is refused with the `FORBIDDEN` `RequiresLevel` (the earned-authorship
- *     gate, ADR 0107 §7). It stamps `publishedAt`; the byline is the LIVE identity
- *     resolved from `authorId` at read (#2463), not a snapshot.
- *   - `mecmua.saveDraft` is NOT yazar-gated — a private draft write is normal-auth
- *     only (`CurrentUser.required`), and multiple drafts per author are allowed.
+ * The authority split is load-bearing: `publish` is floored at YAZAR via
+ * {@link requirePublishMecmua} (ADR 0107 §7), while `saveDraft` is NOT yazar-gated —
+ * a private draft write is normal-auth only, and multiple drafts per author are fine.
  *
  * Neither publishes a `/fate/live` invalidation: mecmua Post lives in no subscribed
  * connection yet, so both are `fanned: false` in `fate-live/fanned-mutations.ts`.
@@ -33,22 +25,20 @@ import type {MecmuaPostRow} from "./post-fields.ts";
 import type {MecmuaPost, MecmuaSubscriptionReceipt} from "./views.ts";
 import {MecmuaPostView, MecmuaSubscriptionReceiptView} from "./views.ts";
 
-/** Is the mecmua write path on for this request? Safe-default `false` (ships dark). */
+// Safe-default `false` — ships dark.
 const mecmuaOn = Effect.gen(function* () {
 	const flags = yield* Flags;
 	return yield* flags.getBoolean(MECMUA_WRITE, false).pipe(provideRequestFlags);
 });
 
-/** Is the mecmua feed (subscribe/unsubscribe) on for this request? Safe-default `false`. */
+// Safe-default `false`.
 const feedOn = Effect.gen(function* () {
 	const flags = yield* Flags;
 	return yield* flags.getBoolean(MECMUA_FEED, false).pipe(provideRequestFlags);
 });
 
-/** Stamp the wire `__typename` onto a service row — the one mecmua write-path shaper. */
 const toMecmuaPost = (r: MecmuaPostRow): MecmuaPost => ({__typename: "MecmuaPost", ...r});
 
-/** The subscribe/unsubscribe receipt shaper — the target author + the post-write edge state. */
 const toSubscriptionReceipt = (
 	authorId: UserId,
 	subscribed: boolean,
@@ -92,9 +82,8 @@ export const mutations = {
 			if (!(yield* mecmuaOn)) {
 				return yield* new MecmuaDisabled({message: "mecmua şu an kapalı"});
 			}
-			// The yazar floor: `requirePublishMecmua` discharges `PublishMecmua` and threads
-			// the grant into the body, so `yield* PublishMecmua` is the compile-error gate —
-			// a çaylak is refused the `FORBIDDEN` `RequiresLevel` before any write (ADR 0107 §3).
+			// `yield* PublishMecmua` IS the gate: without the grant threaded in by
+			// `requirePublishMecmua` this is a compile error (ADR 0107 §3).
 			return yield* requirePublishMecmua(
 				Effect.gen(function* () {
 					yield* PublishMecmua;

--- a/apps/web/worker/features/mecmua/ordering.ts
+++ b/apps/web/worker/features/mecmua/ordering.ts
@@ -1,31 +1,20 @@
 /**
- * mecmua connection orderings the view `orderBy` and the service keyset share
- * (ADR 0019; see `db/ordering.ts`). Mirrors `features/pano/ordering.ts`, but the
- * subscribed-author feed is a TIME feed: it orders on `published_at` (newest-first),
- * not pano's `hot_score`.
+ * mecmua connection orderings the view `orderBy` and the service keyset share (ADR
+ * 0019). Unlike pano, the subscribed-author feed is a TIME feed: it orders on
+ * `published_at`, not a hot score.
  */
 
 import * as schema from "../../db/drizzle/schema.ts";
 import type {Ordering} from "../../db/ordering.ts";
 
-/**
- * The subscribed-author feed (`mecmuaFeed`): `publishedAt desc, id desc` — newest
- * published post first, `id` breaking ties for a stable keyset cursor. Consumed by
- * the `mecmuaFeed` root's view `orderBy` and `Mecmua.listFeedConnection`'s keyset.
- */
+// `id` breaks ties, which is what keeps the keyset cursor stable.
 export const MECMUA_FEED_ORDERING: Ordering = [
 	{field: "publishedAt", column: schema.mecmuaPost.publishedAt, dir: "desc"},
 	{field: "id", column: schema.mecmuaPost.id, dir: "desc"},
 ];
 
-/**
- * The author's own-posts list (`mecmuaMyPosts`, #2544): `createdAt desc, id desc` —
- * most-recently-started post/draft first, `id` breaking ties for a stable keyset
- * cursor. Ordered on `createdAt` (not `publishedAt`) because the list includes
- * drafts (null `publishedAt`), and it rides the `mecmua_post_author_created`
- * index. Consumed by the `mecmuaMyPosts` root's view `orderBy` and
- * `Mecmua.listOwnPostsConnection`'s keyset.
- */
+// Ordered on `createdAt`, not `publishedAt`, because the author's own list includes
+// drafts, whose `publishedAt` is null. Rides the `mecmua_post_author_created` index.
 export const MECMUA_MINE_ORDERING: Ordering = [
 	{field: "createdAt", column: schema.mecmuaPost.createdAt, dir: "desc"},
 	{field: "id", column: schema.mecmuaPost.id, dir: "desc"},

--- a/apps/web/worker/features/mecmua/post-fields.ts
+++ b/apps/web/worker/features/mecmua/post-fields.ts
@@ -1,12 +1,7 @@
 /**
- * `MecmuaPost`'s one column→field map — the single structure the view field
- * declaration (`MecmuaPostView` in `views.ts`) and the record→row mapper
- * (`toMecmuaPostRow`) both derive from, so a one-field change touches this map
- * instead of two hand-synced restatements (the pano `post-fields.ts` idiom, #1166).
- *
- * mecmua carries none of pano's link-sharing / viewer-scalar fields — it is a lean
- * long-form row: identity + başlık + markdown body + the `publishedAt` lifecycle
- * marker.
+ * `MecmuaPost`'s one column→field map — the single structure the view field declaration and
+ * the record→row mapper both derive from, so a one-field change touches this map instead of
+ * two hand-synced restatements.
  */
 import type * as schema from "../../db/drizzle/schema.ts";
 
@@ -24,12 +19,8 @@ export interface MecmuaPostRow {
 	updatedAt: Date;
 }
 
-/**
- * The view/wire field selection — a static literal fate reads off `MecmuaPostView`.
- * `satisfies Record<keyof MecmuaPostRow, true>` pins it to exactly the row's fields:
- * dropping one here (or adding one to the row without listing it) is a compile
- * error, so the view can't drift from the row mapper.
- */
+// `satisfies Record<keyof MecmuaPostRow, true>` pins this to exactly the row's fields:
+// dropping one (or adding one to the row without listing it) is a compile error.
 export const mecmuaPostViewFields = {
 	id: true,
 	slug: true,
@@ -41,7 +32,6 @@ export const mecmuaPostViewFields = {
 	updatedAt: true,
 } as const satisfies Record<keyof MecmuaPostRow, true>;
 
-/** Map a `mecmua_post` record onto its wire row — the single record→row seam. */
 export const toMecmuaPostRow = (p: MecmuaPostRecord): MecmuaPostRow => ({
 	id: p.id,
 	slug: p.slug,

--- a/apps/web/worker/features/mecmua/public-read-route.ts
+++ b/apps/web/worker/features/mecmua/public-read-route.ts
@@ -1,16 +1,10 @@
 /**
- * `GET /fate/mecmua/post/:slug` (#2498, epic #2467) — the PUBLIC read of a single
- * published mecmua post, by slug or id. A raw `HttpRouter.add` route following the
- * anonymous-read idiom of `features/pano/base-feed-route.ts`: it never validates a
- * session and never reads `CurrentUser`, so an anon GET does zero identity work. It
- * reads the `anonymousMecmuaViewer` and applies `mecmuaPostVisibleWhere` (#2496), so a
- * draft (null `published_at`) is masked from the public — only published posts are
- * readable, no auth required. See `.patterns/alchemy-http-router.md`.
+ * `GET /fate/mecmua/post/:slug` (#2498) — the PUBLIC read of a single published mecmua
+ * post, by slug or id. It never validates a session and never reads `CurrentUser`, so an
+ * anon GET does zero identity work; a draft is masked by `mecmuaPostVisibleWhere` (#2496).
+ * See `.patterns/alchemy-http-router.md`.
  *
- * Dark behind `MECMUA_PUBLIC_READ` (default-off): with the flag off the route 404s, so
- * the whole surface ships dark until a human flips the flag at release (ADR 0083). The
- * flag is read under the anonymous flags context (no identity), so the gate itself does
- * no session work either.
+ * Dark behind `MECMUA_PUBLIC_READ` (default-off, ADR 0083): flag off ⇒ 404.
  */
 import * as Cloudflare from "alchemy/Cloudflare";
 import {and, eq, or, type SQL} from "drizzle-orm";
@@ -30,10 +24,8 @@ import {anonymousMecmuaViewer, mecmuaPostVisibleWhere} from "./MecmuaPostVisibil
 import {type MecmuaPostRow, toMecmuaPostRow} from "./post-fields.ts";
 
 /**
- * The WHERE for the public read: match the requested key against slug OR id, gated by
- * the `mecmuaPostVisibleWhere` anonymous-visibility clause (#2496) — `published_at is
- * not null`, with NO `author_id = :viewer` ownership escape (there is no viewer). So a
- * draft is never disclosed publicly, whichever key names it.
+ * Deliberately NO `author_id = :viewer` ownership escape — there is no viewer here, so a
+ * draft is never disclosed publicly whichever key names it (#2496).
  */
 export const mecmuaPublicReadWhere = (key: string): SQL | undefined =>
 	and(
@@ -44,11 +36,7 @@ export const mecmuaPublicReadWhere = (key: string): SQL | undefined =>
 		),
 	);
 
-/**
- * Read the single published mecmua post named by `key` (slug or id), or null when no
- * published post matches (a draft, or a genuine miss — both mask to null, which the
- * route renders as a 404).
- */
+/** A draft and a genuine miss both mask to null, which the route renders as a 404. */
 export const readPublishedMecmuaPost = (
 	run: DrizzleAccessOrDie["run"],
 	key: string,
@@ -60,10 +48,8 @@ export const readPublishedMecmuaPost = (
 export const handleMecmuaPublicRead = Effect.gen(function* () {
 	const raw = yield* Cloudflare.Request;
 
-	// The dark-ship gate, evaluated under the ANONYMOUS flags context so it reads no
-	// session — an anon GET does zero identity work even to decide the flag. Off ⇒ 404,
-	// the shipped-dark default; in local dev the `phoenix_flag_overrides` cookie can
-	// force it on (#622).
+	// Evaluated under the ANONYMOUS flags context, so an anon GET does zero identity work
+	// even to decide the flag.
 	const flags = yield* Flags;
 	const flagsContext = yield* makeRequestFlagsContext(
 		anonymousFlagsContext,

--- a/apps/web/worker/features/mecmua/public-read-route.unit.test.ts
+++ b/apps/web/worker/features/mecmua/public-read-route.unit.test.ts
@@ -1,14 +1,8 @@
 /**
- * The mecmua public-read draft-mask gate (#2498, epic #2467). The anonymous read must
- * route the draft decision through the one `MecmuaPostVisibility` seam
- * (`mecmuaPostVisibleWhere`), so a visitor holding a draft's slug/id never reads an
- * unpublished post. Two tiers, both offline-reachable:
- *
- *   - the SQL PREDICATE (`mecmuaPublicReadWhere`) carries `published_at is not null`
- *     (the published gate) and NO `author_id = ?` ownership escape — so a draft is
- *     structurally undisclosable to the public, whichever key names it;
- *   - `readPublishedMecmuaPost` resolves null when no published row matches (a draft or
- *     a genuine miss), which the route renders as a 404 — the masked case.
+ * The mecmua public-read draft-mask gate: a visitor holding a draft's slug or id must
+ * never read an unpublished post. The predicate carries `published_at is not null` and NO
+ * `author_id = ?` ownership escape, so a draft is structurally undisclosable whichever key
+ * names it.
  */
 import {assert, describe, it} from "@effect/vitest";
 import {drizzle} from "drizzle-orm/d1";
@@ -43,7 +37,7 @@ const noopD1 = {
 } as unknown as D1Database;
 const renderDb = drizzle(noopD1, {relations});
 
-/** A `run` that ignores its query and resolves the scripted rows — the leak/mask fixtures never touch D1. */
+/** Ignores the query and resolves scripted rows; these fixtures never touch D1. */
 const scriptedRun =
 	(rows: ReadonlyArray<unknown>): DrizzleAccessOrDie["run"] =>
 	<A>(_fn: (db: DrizzleDb) => Promise<A>) =>
@@ -75,8 +69,7 @@ describe("mecmuaPublicReadWhere — the anonymous read masks drafts (the visibil
 describe("readPublishedMecmuaPost — masked/miss resolves null (the route's 404 path, #2498)", () => {
 	it.effect("a draft (masked by the WHERE ⇒ no row) resolves null", () =>
 		Effect.gen(function* () {
-			// The published gate drops the draft in SQL, so the query returns no rows —
-			// the read maps that to null, which the route renders as a 404.
+			// No rows: the read maps that to null, which the route renders as a 404.
 			const got = yield* readPublishedMecmuaPost(scriptedRun([]), "draft-slug");
 			assert.isNull(got, "a draft must not be publicly readable — masked to null (404)");
 		}),

--- a/apps/web/worker/features/mecmua/queries.ts
+++ b/apps/web/worker/features/mecmua/queries.ts
@@ -1,15 +1,10 @@
 /**
- * mecmua root query resolvers (#2527, epic #2467). `mecmuaSubscription` is the
- * subscribe-affordance state read: whether the signed-in reader already follows a
- * given author — the initial state the post reader's "abone ol / takip ediliyor"
- * toggle reflects. A signed-out reader or the flag-off state resolves
- * `subscribed: false` (nothing to reflect) rather than throwing, since the toggle
- * only renders for a signed-in reader with the feed on and the write mutations are
- * gated the same way. See `.patterns/fate-effect-operations.md`.
+ * mecmua root query resolvers (#2527, epic #2467). A signed-out reader or the flag-off
+ * state resolves `subscribed: false` rather than throwing — the toggle only renders
+ * for a signed-in reader with the feed on, and the writes are gated the same way.
  *
- * Dark behind the default-off `MECMUA_FEED` flag (ADR 0083): with it off the read
- * reports `false`, so no subscription state leaks until a human flips the flag at
- * release — the same containment `mecmua.subscribe` / `mecmua.unsubscribe` use.
+ * Dark behind the default-off `MECMUA_FEED` flag (ADR 0083), so no subscription state
+ * leaks until a human flips it at release.
  */
 import {CurrentUser, Fate} from "@kampus/fate-effect";
 import {Effect} from "effect";
@@ -22,13 +17,13 @@ import {Mecmua} from "./Mecmua.ts";
 import type {MecmuaSubscriptionReceipt} from "./views.ts";
 import {MecmuaSubscriptionReceiptView} from "./views.ts";
 
-// `authorId` decodes byte-identically but arrives typed as UserId, so the
-// receipt + the `isSubscribed` read below carry the brand end-to-end (#2700).
+// `authorId` decodes byte-identically but arrives branded, so the receipt and the
+// read below carry the brand end-to-end (#2700).
 const SubscriptionStateArgs = Schema.Struct({
 	authorId: UserId,
 });
 
-/** Is the mecmua feed on for this request? Safe-default `false` (ships dark). */
+// Safe-default `false` — ships dark.
 const feedOn = Effect.gen(function* () {
 	const flags = yield* Flags;
 	return yield* flags.getBoolean(MECMUA_FEED, false).pipe(provideRequestFlags);

--- a/apps/web/worker/features/mecmua/views.ts
+++ b/apps/web/worker/features/mecmua/views.ts
@@ -1,39 +1,31 @@
 /**
- * mecmua fate data views (epic #2467, #2463). `MecmuaPostView` is the read model
- * for a long-form mecmua post — its static `view` is the kernel `dataView()` output
- * and `WorkerEntity<>` derives the worker-side type. Mirrors the pano
- * `PostView`/`FateDataView` idiom (`features/pano/views.ts`). Data views are the
- * schema (ADR 0018); see `.patterns/fate-effect-data-views.md`.
+ * mecmua fate data views. Data views are the schema (ADR 0018); see
+ * `.patterns/fate-effect-data-views.md`.
  */
 import {FateDataView, type WorkerEntity} from "@kampus/fate-effect";
 import type {ViewRow} from "../fate/view-types.ts";
 import {type MecmuaPostRow, mecmuaPostViewFields} from "./post-fields.ts";
 
-// `Record<string, unknown>`-assignable restatement of the service row (the plain
-// row interface is not), so `Fate.source` declarations over this view can name the
-// row type (TS2883 portability), mirroring pano's `PostViewRow`.
+// A `Record<string, unknown>`-assignable restatement of the service row (the plain row
+// interface is not), so `Fate.source` declarations can name the row type (TS2883).
 export type MecmuaPostViewRow = ViewRow<MecmuaPostRow>;
 
-// The field set derives from `post-fields.ts`'s column→field map, so it can't drift
-// from the row mapper (#1166).
+// Fields derive from `post-fields.ts`'s column→field map, so they can't drift from the
+// row mapper (#1166).
 export class MecmuaPostView extends FateDataView<MecmuaPostViewRow>()("MecmuaPost")(
 	mecmuaPostViewFields,
 ) {}
 
-// Kernel view value for the fate `Root` map + cross-feature surfaces (as pano's
-// `postDataView`). The `mecmuaFeed` root (#2500) is a `list(mecmuaPostDataView, …)`.
 export const mecmuaPostDataView = MecmuaPostView.view;
 
 /**
- * The subscribe/unsubscribe write receipt (#2500) — the minimal shape the
- * `mecmua.subscribe` / `mecmua.unsubscribe` mutations return (the `NotificationMarkReceipt`
- * idiom): `id` is the target author, `subscribed` the edge state AFTER the write. A
- * synthetic view (no fetch path) — the mutation delivers it inline, never re-fetched.
+ * The subscribe/unsubscribe write receipt (#2500). Synthetic — no fetch path; the
+ * mutation delivers it inline and it is never re-fetched.
  */
 export type MecmuaSubscriptionReceiptViewRow = ViewRow<{
-	/** The target author id — the receipt's identity. */
+	/** The target author id. */
 	id: string;
-	/** The edge state after the write: true ⇒ subscribed, false ⇒ unsubscribed. */
+	/** The edge state AFTER the write. */
 	subscribed: boolean;
 }>;
 
@@ -47,9 +39,7 @@ export class MecmuaSubscriptionReceiptView extends FateDataView<MecmuaSubscripti
 export const mecmuaSubscriptionReceiptDataView = MecmuaSubscriptionReceiptView.view;
 export type MecmuaSubscriptionReceipt = WorkerEntity<typeof MecmuaSubscriptionReceiptView>;
 
-// `createdAt`/`updatedAt`/`publishedAt` ride the standard timestamp correction (wire
-// `string` / `string | null` → `Date` / `Date | null`); `StringToDate` preserves the
-// draft-`null` on `publishedAt`, so no `Override` slot is needed.
+// `StringToDate` preserves the draft-`null` on `publishedAt`, so no `Override` is needed.
 export type MecmuaPost = WorkerEntity<
 	typeof MecmuaPostView,
 	"createdAt" | "updatedAt" | "publishedAt"

--- a/apps/web/worker/features/mute/Mute.ts
+++ b/apps/web/worker/features/mute/Mute.ts
@@ -1,21 +1,8 @@
 /**
- * Mute — member-side mute ("sustur") service. Pure presence over a one-directional
- * `(muter, muted)` relationship, the {@link ../pano/Bookmark Bookmark} shape keyed
- * on two users instead of (user, post): a `user_mute` row means the muter has muted
- * the muted member, its absence means not. No value column, no karma, no fanout.
- *
- * `set` is idempotent (probe-then-write, like `Bookmark.toggle`): re-muting an
- * already-muted member — or un-muting an unmuted pair — is a no-op that writes
- * nothing and returns `changed: false`. Self-mute is rejected in the domain object:
- * a member cannot mute themselves (`SelfMuteRejected`, checked before any read).
- *
- * `readMutedIds` is the batched viewer-side read that downstream read-masking stamps
- * from without an N+1: one query over the composite PK's leading `muter_id` column
- * returns the whole set of ids the viewer has muted. A missing viewer short-circuits
- * to an empty set with no read.
- *
- * Scope: storage + domain seam only. No fate/mutation exposure, no read-masking, no
- * UI, no *block* (mutual interaction-ban) semantics — those are siblings.
+ * Mute ("sustur") — pure presence over a one-directional `(muter, muted)` relationship,
+ * the `Bookmark` shape keyed on two users. No value column, no karma, no fanout. This is
+ * the storage + domain seam only: no read-masking, no UI, and NOT *block* (mutual
+ * interaction-ban) semantics.
  */
 import {and, desc, eq, type SQL} from "drizzle-orm";
 import {Context, Effect, Layer} from "effect";
@@ -31,28 +18,22 @@ import {
 import {UserId} from "../../lib/ids.ts";
 import {SelfMuteRejected} from "./errors.ts";
 
-/** One entry of the viewer's own muted-members list — the muted member id (the row
- * identity + keyset cursor) and when the mute was set (the newest-first order key).
- * Hydrated with the muted member's profile handle in the `mute.listMine` resolver
- * (the domain service stays over its own table; identity is joined at the fate seam). */
+/** The profile handle is joined at the fate seam; this service stays over its own table. */
 export interface MutedMemberRow {
 	mutedId: string;
 	mutedAt: Date;
 }
 
-/** Options for {@link Mute.listMine} — `first` page size (clamped 1..100, default 20),
- * `after` the opaque forward keyset cursor (a muted member id). */
+/** `first` is clamped 1..100 (default 20); `after` is an opaque cursor (a muted member id). */
 export interface MutedMemberListOpts {
 	first?: number | undefined;
 	after?: string | null | undefined;
 }
 
 /**
- * The viewer's muted-members page read, scoped to `muter_id = muterId` and ordered
- * newest-mute-first (`created_at desc`, `muted_id desc` as the stable tiebreaker).
- * Exported pure so the ownership predicate is `.toSQL()`-inspectable with no engine
- * (the `unreadCountQuery` idiom, ADR 0082): `muter_id` rides every read predicate, so
- * "list someone else's mutes" matches zero rows by construction.
+ * Exported pure so the ownership predicate is `.toSQL()`-inspectable with no engine (the
+ * `unreadCountQuery` idiom, ADR 0082): `muter_id` rides every read predicate, so "list
+ * someone else's mutes" matches zero rows by construction.
  */
 export const mutedMembersQuery = (db: DrizzleDb, muterId: string, cursorPredicate?: SQL) =>
 	db
@@ -68,13 +49,12 @@ export const mutedMembersQuery = (db: DrizzleDb, muterId: string, cursorPredicat
 export interface MuteSetInput {
 	muterId: string;
 	mutedId: string;
-	/** Presence intent: `true` mutes, `false` un-mutes (mirrors `BookmarkToggleInput.value`). */
+	/** `true` mutes, `false` un-mutes. */
 	value: boolean;
 }
 
 export interface MuteSetResult {
 	mutedId: string;
-	/** The muter's mute presence over `mutedId` after the write. */
 	isMuted: boolean;
 	/** `false` on an idempotent no-op (state already matched intent). */
 	changed: boolean;
@@ -83,25 +63,13 @@ export interface MuteSetResult {
 export class Mute extends Context.Service<
 	Mute,
 	{
-		/**
-		 * Set the muter's mute presence over `mutedId` to `value`, idempotently
-		 * (probe-then-write). A matching state is a no-op (`changed: false`, no
-		 * write). Self-mute (`muterId === mutedId`) is rejected before any read.
-		 */
+		/** Idempotent (probe-then-write). Self-mute is rejected before any read. */
 		readonly set: (input: MuteSetInput) => Effect.Effect<MuteSetResult, SelfMuteRejected>;
-		/**
-		 * The full set of member ids the viewer has muted, in one read over the
-		 * `(muter_id, muted_id)` PK's leading column so read-masking stamps without
-		 * an N+1. Missing viewer short-circuits to an empty Set with no read.
-		 */
+		/** ONE read over the PK's leading column, so read-masking stamps without an N+1. */
 		readonly readMutedIds: (viewerId: string | null | undefined) => Effect.Effect<Set<string>>;
 		/**
-		 * The viewer's own muted members, newest-mute-first, forward keyset-paginated
-		 * over the `(muter_id, muted_id)` PK's leading column. A missing viewer short-
-		 * circuits to the empty page with no read; a foreign/dead cursor is the shared
-		 * cursor-miss empty page (never a probe into another muter's rows). The muter
-		 * scope is structural — every read carries `muter_id`, so a member only ever
-		 * pages their own mutes.
+		 * The muter scope is structural: every read carries `muter_id`, so a foreign cursor
+		 * is a miss rather than a probe into another muter's rows.
 		 */
 		readonly listMine: (
 			viewerId: string | null | undefined,
@@ -137,10 +105,6 @@ export const MuteLive = Layer.effect(Mute)(
 			const first = Math.max(1, Math.min(opts.first ?? 20, 100));
 			const after = opts.after ?? null;
 
-			// The DB read is the port; `resolveCursor` is the pure cursor-miss decision
-			// (the bildirim idiom). The cursor is a muted member id, resolved to its
-			// `created_at` for the keyset tuple — muter-scoped, so a foreign cursor is a
-			// miss, not a probe into another muter's list.
 			const resolvedRow = after
 				? ((yield* run((db) =>
 						db

--- a/apps/web/worker/features/mute/Mute.unit.test.ts
+++ b/apps/web/worker/features/mute/Mute.unit.test.ts
@@ -1,30 +1,22 @@
 /**
- * Mute unit coverage — the decisions that are wrong-or-right with no database
- * (ADR 0082, the `Bookmark.unit.test.ts` idiom): the `Drizzle` seam is substituted
- * directly. A `run`/`batch` that THROWS proves a short-circuit never touched the DB;
- * a stubbed `run` feeds the pre-write decision its inputs without an engine.
- *
- * Mute's real-D1 fidelity — composite-PK presence idempotency, the set/readMutedIds
- * round-trip over real rows — lands at the integration tier once a sibling wires the
- * fate/mutation surface this storage slice intentionally omits (there is no HTTP/fate
- * surface yet to drive Mute black-box over).
+ * Mute unit coverage over a substituted `Drizzle` seam (ADR 0082). Mute's real-D1 fidelity —
+ * composite-PK presence idempotency, the set/readMutedIds round-trip — lands at the
+ * integration tier once a sibling wires the fate/mutation surface this slice omits.
  */
 import {assert, describe, it} from "@effect/vitest";
 import {Effect, Layer} from "effect";
 import {Drizzle, type DrizzleAccess, type DrizzleDb} from "../../db/Drizzle.ts";
 import {Mute, MuteLive} from "./Mute.ts";
 
-// A `Drizzle` whose every call throws — any path that actually reaches the DB seam
-// fails the test. A guard that short-circuits before reading runs to completion
-// against it, which is exactly the "no read" proof.
+// Every call throws, so any path that actually reaches the DB seam fails the test. A guard
+// that short-circuits before reading runs to completion against it.
 const throwingAccess: DrizzleAccess = {
 	run: () => Effect.die(new Error("Mute read the DB on a path that must short-circuit")),
 	batch: () => Effect.die(new Error("Mute wrote a batch on a path that must short-circuit")),
 };
 
-// A `Drizzle` whose `run` replays a queued sequence of results and whose `batch`
-// throws — drives `set`'s pre-write presence probe while proving the idempotent
-// no-op never reaches `batch`.
+// Replays a queued sequence of `run` results while `batch` throws — drives `set`'s pre-write
+// presence probe while proving the idempotent no-op never reaches `batch`.
 function scriptedAccess(results: ReadonlyArray<unknown>): {access: DrizzleAccess; runs: number} {
 	const state = {i: 0};
 	const access: DrizzleAccess = {
@@ -59,7 +51,7 @@ describe("Mute.set — self-mute rejection (mocked Drizzle seam)", () => {
 
 describe("Mute.set — pre-write idempotency (mocked Drizzle seam)", () => {
 	it.effect("re-muting an already-muted member is an idempotent no-op — no batch", () => {
-		// run #1 presence probe → already muted. The `batch` stub throws, so reaching it fails.
+		// Presence probe → already muted. The `batch` stub throws, so reaching it fails.
 		const {access} = scriptedAccess([{mutedId: "u2"}]);
 		return Effect.gen(function* () {
 			const mute = yield* Mute;
@@ -71,7 +63,6 @@ describe("Mute.set — pre-write idempotency (mocked Drizzle seam)", () => {
 	});
 
 	it.effect("un-muting a never-muted pair is an idempotent no-op — no batch", () => {
-		// run #1 presence probe → not muted.
 		const {access} = scriptedAccess([undefined]);
 		return Effect.gen(function* () {
 			const mute = yield* Mute;
@@ -101,7 +92,6 @@ describe("Mute.readMutedIds — no-read short-circuit + batched read (mocked Dri
 	);
 
 	it.effect("a viewer's muted ids come back as a Set from one batched read", () => {
-		// a single read returns the whole muted set for the viewer (keyed on muter_id).
 		const {access, runs} = ((): {access: DrizzleAccess; runs: () => number} => {
 			const state = {i: 0};
 			return {

--- a/apps/web/worker/features/mute/errors.ts
+++ b/apps/web/worker/features/mute/errors.ts
@@ -1,16 +1,8 @@
 /**
- * Tagged errors raised by the Mute service + its fate write path.
- *
- * `SelfMuteRejected` is the domain object refusing an invalid state — a member
- * muting themselves — at the write boundary (make-invalid-states-unrepresentable).
- * It now carries its `FateWireCode` because the `mute.set` / `mute.remove` mutation
- * surface (#3112) is the consuming boundary that landed: `encodeWireError` reads the
- * annotation at the fate seam (`.patterns/fate-effect-wire-errors.md`), the same shape
- * as pano's / mecmua's.
- *
- * `MuteDisabled` is the dark-ship containment (ADR 0083): with the `member-mute` flag
- * off both mutations fail this before any read/write, so the primitive is unreachable
- * even if a client bypasses the (not-yet-built) UI — mirrors `MecmuaDisabled`.
+ * Mute's tagged errors. `MuteDisabled` is the dark-ship containment (ADR 0083): with the
+ * `member-mute` flag off both mutations fail this before any read or write, so the
+ * primitive is unreachable even if a client bypasses the UI. Wire codes:
+ * `.patterns/fate-effect-wire-errors.md`.
  */
 import {FateWireCode} from "@kampus/fate-effect";
 import * as Schema from "effect/Schema";

--- a/apps/web/worker/features/mute/fate-module.ts
+++ b/apps/web/worker/features/mute/fate-module.ts
@@ -6,17 +6,15 @@ import {lists} from "./lists.ts";
 import {mutations} from "./mutations.ts";
 import {MutedMemberView, MuteReceiptView, mutedMemberDataView} from "./views.ts";
 
-// Both mute entities are delivered inline (never read by id): `MuteReceipt` by the
-// `mute.set` / `mute.remove` mutations, `MutedMember` by the `mute.listMine` list root
-// (#3114). A `syntheticSource` (no by-id fetch path) makes each view-reachable in codegen
-// with zero capabilities — the mecmua `MecmuaSubscriptionReceiptView` / `ReportReceipt`
-// escape hatch (`.patterns/fate-effect-sources.md`).
+// Both mute entities are delivered inline, never read by id, so a `syntheticSource`
+// makes each view-reachable in codegen with zero capabilities
+// (.patterns/fate-effect-sources.md).
 const muteReceiptSource = Fate.syntheticSource(MuteReceiptView);
 const mutedMemberSource = Fate.syntheticSource(MutedMemberView);
 
 const roots: FateRootsRecord = {
-	// The viewer's manage-my-mutes list (#3114) — a `CurrentUser`-gated, flag-dark list
-	// root; the `mute.listMine` resolver owns the newest-first keyset order + muter scoping.
+	// `CurrentUser`-gated and flag-dark; the resolver owns the keyset order and muter
+	// scoping (#3114).
 	"mute.listMine": list(mutedMemberDataView),
 };
 

--- a/apps/web/worker/features/mute/lists.ts
+++ b/apps/web/worker/features/mute/lists.ts
@@ -1,17 +1,11 @@
 /**
  * `mute.listMine` — the manage-my-mutes read model (#3114, epic #2035): the viewer's
- * own muted members, newest-mute-first, forward keyset-paginated. Gated on
- * `CurrentUser` (an anonymous caller is rejected the invisible `Unauthorized` before
- * any read) and behind the default-off `member-mute` flag (off ⇒ `MuteDisabled`, so
- * the whole mute surface stays dark uniformly — the same containment the `mute.set` /
- * `mute.remove` write path uses, see `errors.ts`).
+ * own muted members, newest-first, forward keyset-paginated. Behind the default-off
+ * `member-mute` flag (off ⇒ `MuteDisabled`), so the whole mute surface stays dark
+ * uniformly with the write path.
  *
  * A member only ever pages their OWN mutes: the muter scope is structural in
- * `Mute.listMine` (`muter_id` rides every predicate). Each row is hydrated with the
- * muted member's profile handle joined from pasaport in ONE batched read (the divan
- * roster idiom) — enough for a UI to render the row and offer a per-row unmute
- * (`mute.remove` keyed on the row `id`). The read model only; the list UI + the
- * unmute button are the reachability sibling, the unmute write is `mute.remove`.
+ * `Mute.listMine` — `muter_id` rides every predicate.
  */
 import {CurrentUser, Fate, Unauthorized} from "@kampus/fate-effect";
 import {Effect} from "effect";
@@ -56,9 +50,8 @@ export const lists = {
 				...(args.after !== undefined ? {after: args.after} : {}),
 			});
 
-			// One batched identity read for the whole page (never a per-row by-id): a
-			// member absent from `user_profile` simply has no entry and renders with a
-			// null handle client-side.
+			// One batched identity read for the whole page (never a per-row by-id): a member
+			// absent from `user_profile` renders with a null handle.
 			const pasaport = yield* Pasaport;
 			const identities = yield* pasaport.getProfileIdentitiesByIds(
 				page.rows.map((row) => row.mutedId),

--- a/apps/web/worker/features/mute/mutations.ts
+++ b/apps/web/worker/features/mute/mutations.ts
@@ -1,22 +1,13 @@
 /**
- * Member-mute (sustur) write-path mutation resolvers (#3112, epic #2035) — the
- * `mute.set` / `mute.remove` acts, gated behind the default-off `member-mute` flag
- * (ADR 0083, the mecmua write-path dark-ship shape): with the flag off both fail
- * {@link MuteDisabled}, so the write path is unreachable even if a client bypasses
- * the (not-yet-built) UI. Domain validation + the DB write live in {@link Mute} (ADR
- * 0013); this layer resolves the identity, the flag, and delegates to `Mute.set`.
+ * Member-mute (sustur) write-path mutation resolvers (#3112, epic #2035), gated behind the
+ * default-off `member-mute` flag (ADR 0083) so the write path is unreachable even if a client
+ * bypasses the UI. Domain validation + the DB write live in {@link Mute} (ADR 0013).
  *
- * The muter is always the authenticated caller acting on themselves — `CurrentUser`
- * is the muter (`muterId`), never a wire input, so a client cannot mute *on behalf
- * of* another member. An anonymous caller is rejected `Unauthorized` before any read.
- * `mute.set` mutes (`value: true`), `mute.remove` un-mutes (`value: false`); both are
- * idempotent (a matching state is a `changed: false` no-op, decided in `Mute.set`).
+ * The muter is always the authenticated caller — `CurrentUser`, never a wire input, so a client
+ * cannot mute *on behalf of* another member.
  *
- * NOT fanned: a mute masks only the muter's OWN reads (the read-mask is a sibling
- * slice), so it writes no Post/Comment/Definition in a subscribed cross-client
- * connection and publishes no `/fate/live` invalidation — classified `fanned: false`
- * with that rationale in `fate-live/fanned-mutations.ts` (the `post.save` per-viewer
- * precedent). See ADR 0155.
+ * NOT fanned: a mute masks only the muter's OWN reads, so it publishes no `/fate/live`
+ * invalidation — classified `fanned: false` in `fate-live/fanned-mutations.ts` (ADR 0155).
  */
 import {CurrentUser, Fate, Unauthorized} from "@kampus/fate-effect";
 import {Effect} from "effect";
@@ -29,13 +20,11 @@ import {MuteDisabled, SelfMuteRejected} from "./errors.ts";
 import {Mute, type MuteSetResult} from "./Mute.ts";
 import {type MuteReceipt, MuteReceiptView} from "./views.ts";
 
-/** Is the member-mute write path on for this request? Safe-default `false` (ships dark). */
 const memberMuteOn = Effect.gen(function* () {
 	const flags = yield* Flags;
 	return yield* flags.getBoolean(MEMBER_MUTE, false).pipe(provideRequestFlags);
 });
 
-/** Stamp the wire `__typename` onto the service result — the one mute write-path shaper. */
 const toReceipt = (r: MuteSetResult): MuteReceipt => ({
 	__typename: "MuteReceipt",
 	id: r.mutedId,
@@ -49,7 +38,6 @@ const MuteInput = Schema.Struct({
 	mutedId: UserId,
 });
 
-/** Resolve one mute presence write to `value`, shared by `mute.set` / `mute.remove`. */
 const setPresence = (value: boolean) =>
 	Effect.fn(value ? "mute.set" : "mute.remove")(function* ({input}: {input: {mutedId: UserId}}) {
 		const user = yield* CurrentUser.required;

--- a/apps/web/worker/features/mute/mute-fanout.unit.test.ts
+++ b/apps/web/worker/features/mute/mute-fanout.unit.test.ts
@@ -1,18 +1,7 @@
 /**
- * The live-invalidation classification for the member-mute mutations (#3112, ADR
- * 0155). A mute masks only the muter's OWN reads (the read-mask is a sibling), so it
- * writes no Post/Comment/Definition in a subscribed cross-client connection — it is
- * `fanned: false`, the `post.save` per-viewer-private-relation precedent. This pins
- * two things the classification asserts:
- *
- *   1. `mute.set` / `mute.remove` are declared in the manifest as `fanned: false`,
- *      each with a rationale — so `fanout-guard`'s drift invariant passes and the
- *      conscious not-fanned decision is recorded (`fanned-mutations.ts`).
- *   2. The write path carries NO cross-viewer publish: the resolved mutation depends
- *      on no `LivePublisher`, so muting/unmuting can never fan an invalidation to
- *      another viewer's live view — exactly "the muter's own affected views, not a
- *      cross-viewer fan". The muter's own live views re-mask once the read-mask
- *      sibling lands; there is no subscribed connection to invalidate in this slice.
+ * The live-invalidation classification for the member-mute mutations (ADR 0155). A mute
+ * masks only the muter's OWN reads, so it writes no fanned entity — `fanned: false`, on
+ * the `post.save` per-viewer-private-relation precedent.
  */
 import {assert, describe, it} from "@effect/vitest";
 import {FANNED_MUTATIONS} from "../fate-live/fanned-mutations.ts";

--- a/apps/web/worker/features/mute/mute-list.unit.test.ts
+++ b/apps/web/worker/features/mute/mute-list.unit.test.ts
@@ -1,19 +1,7 @@
 /**
- * `mute.listMine` coverage (#3114, epic #2035) — the manage-my-mutes read model,
- * split across the two seams the ACs live on (ADR 0082):
- *
- *   - **the domain read** (`Mute.listMine`) over the substituted `Drizzle` seam: the
- *     muter-ownership predicate is asserted on the rendered SQL (`.toSQL()` over a
- *     no-op D1 — the `Notification.unit.test.ts` idiom), so "list someone else's
- *     mutes" carries `muter_id` by construction; the newest-first keyset paging folds
- *     the `first + 1` probe into `{rows, hasNextPage, endCursor}`, and a foreign/dead
- *     cursor is the shared cursor-miss empty page (never a probe into another muter's
- *     rows). A null viewer short-circuits with no read.
- *   - **the WIRE boundary** (the `mute.listMine` list resolver) through `resolveWire`
- *     (decode → `encodeWireError`): an anonymous caller is rejected `UNAUTHORIZED`
- *     before any read; with the `member-mute` flag OFF an authed caller is refused
- *     `MUTE_DISABLED` (the dark-ship containment); with the flag ON the page is
- *     hydrated with the muted member's profile handle in ONE batched pasaport read.
+ * `mute.listMine` coverage across its two seams (ADR 0082): the domain read over a
+ * substituted `Drizzle`, where the muter-ownership predicate is asserted on the rendered
+ * SQL, and the wire boundary through `resolveWire`.
  */
 import {assert, describe, it} from "@effect/vitest";
 import {CurrentUser} from "@kampus/fate-effect";
@@ -28,8 +16,7 @@ import type {ProfileIdentityRow} from "../pasaport/Pasaport.ts";
 import {lists} from "./lists.ts";
 import {Mute, MuteLive, mutedMembersQuery} from "./Mute.ts";
 
-// A real drizzle client over a no-op D1 — used ONLY to render `.toSQL()`; it never
-// executes (the `Notification.unit.test.ts` render seam).
+// A real drizzle client over a no-op D1, used ONLY to render `.toSQL()`; nothing executes.
 // biome-ignore lint/plugin: `D1Database` is a host binding that can't be structurally constructed in a fake; nothing here executes against it.
 const noopD1 = {
 	prepare: () => ({
@@ -55,14 +42,12 @@ const noopD1 = {
 } as unknown as D1Database;
 const renderDb = drizzle(noopD1, {relations});
 
-// A `Drizzle` whose every call throws — any path that reaches the DB seam fails the
-// test, so a no-read short-circuit runs to completion against it (the "no read" proof).
+// Every call throws, so a short-circuit that runs to completion against it proves no read.
 const throwingAccess: DrizzleAccess = {
 	run: () => Effect.die(new Error("Mute read the DB on a path that must short-circuit")),
 	batch: () => Effect.die(new Error("Mute wrote a batch on a path that must short-circuit")),
 };
 
-// A `Drizzle` seam that dispenses queued responses in order (the Funnel idiom).
 const scriptedSequence = (responses: ReadonlyArray<unknown>): DrizzleAccess => {
 	let call = 0;
 	return {
@@ -111,7 +96,6 @@ describe("Mute.listMine — newest-first keyset paging", () => {
 			assert.isTrue(page.hasNextPage);
 			assert.strictEqual(page.endCursor, "u2");
 		}).pipe(
-			// One read (no cursor to resolve): the LIMIT 3 probe returns 3 rows.
 			Effect.provide(
 				muteLayer(
 					scriptedSequence([
@@ -133,7 +117,6 @@ describe("Mute.listMine — newest-first keyset paging", () => {
 			assert.deepStrictEqual(page.rows, []);
 			assert.isFalse(page.hasNextPage);
 			assert.isNull(page.endCursor);
-			// The cursor-resolve read returned no row → miss → no second read issued.
 		}).pipe(Effect.provide(muteLayer(scriptedSequence([undefined])))),
 	);
 
@@ -148,7 +131,6 @@ describe("Mute.listMine — newest-first keyset paging", () => {
 			assert.isFalse(page.hasNextPage);
 			assert.strictEqual(page.endCursor, "u1");
 		}).pipe(
-			// read #1 resolves the cursor to its created_at; read #2 is the keyset page.
 			Effect.provide(
 				muteLayer(
 					scriptedSequence([
@@ -160,8 +142,6 @@ describe("Mute.listMine — newest-first keyset paging", () => {
 		),
 	);
 });
-
-// --- WIRE boundary: the `mute.listMine` list resolver through `resolveWire` ---
 
 const VIEWER = {id: "u-viewer", email: "kaan@example.com", name: "kaan"};
 
@@ -183,8 +163,7 @@ const flagsStub = (on: boolean): Layer.Layer<Flags> =>
 
 type ListMine = (typeof Mute.Service)["listMine"];
 
-// A `Mute` whose `listMine` runs `impl` (or dies on contact) — a denied path that must
-// short-circuit before the read proves it by failing the fail-on-contact default.
+// Dies on contact unless `impl` is given, so a denied path proves it never read.
 const muteStub = (impl?: ListMine) =>
 	Layer.succeed(Mute, {
 		listMine:

--- a/apps/web/worker/features/mute/mute-mutation.unit.test.ts
+++ b/apps/web/worker/features/mute/mute-mutation.unit.test.ts
@@ -1,20 +1,7 @@
 /**
- * `mute.set` / `mute.remove` WIRE-boundary coverage (#3112, epic #2035) — the
- * decisions that are wrong-or-right with no database (ADR 0082), driven through the
- * real external interface (`resolveWire`: decode + the `encodeWireError`
- * class→wire-code seam), so a denial's wire `code` is what a client gets.
- *
- * The load-bearing ACs:
- *   - gated on `CurrentUser`: an anonymous caller is rejected the invisible
- *     `UNAUTHORIZED` before any read (the `Mute` stub is fail-on-contact);
- *   - dark-ship: with the `member-mute` flag OFF both fail `MUTE_DISABLED` before the
- *     write, so an unreleased mute never runs;
- *   - with the flag ON an authed muter's set/remove reaches `Mute.set` and the receipt
- *     carries the post-write presence; a self-mute surfaces `SELF_MUTE_REJECTED`.
- *
- * The real-D1 presence idempotency + set/readMutedIds round-trip live in
- * `Mute.unit.test.ts` (the domain seam) and the integration tier once the read-mask +
- * manage UI siblings wire an HTTP/fate surface to drive Mute black-box over.
+ * `mute.set` / `mute.remove` WIRE-boundary coverage (#3112, ADR 0082), driven through
+ * `resolveWire` so a denial's wire `code` is what a client gets. The domain round-trip
+ * lives in `Mute.unit.test.ts`.
  */
 import {assert, describe, it} from "@effect/vitest";
 import {CurrentUser} from "@kampus/fate-effect";
@@ -45,8 +32,8 @@ const flagsStub = (on: boolean): Layer.Layer<Flags> =>
 		getObject: () => Effect.die("getObject not exercised"),
 	} as typeof Flags.Service);
 
-// A `Mute` whose `set` runs `impl` (or dies on contact) — so a denied path that must
-// short-circuit before the write proves it by failing the fail-on-contact default.
+// Fail-on-contact by default, so a denied path that must short-circuit before the write
+// proves it by dying.
 const muteStub = (impl?: (input: MuteSetInput) => Effect.Effect<MuteSetResult, SelfMuteRejected>) =>
 	Layer.succeed(Mute, {
 		set: impl ?? (() => Effect.die("Mute.set reached on a path that must short-circuit")),

--- a/apps/web/worker/features/mute/read-mask.ts
+++ b/apps/web/worker/features/mute/read-mask.ts
@@ -1,20 +1,8 @@
 /**
- * Mute read-mask (#3113) — the seam that makes a muted member's content disappear
- * from the muter's reads across pano + sözlük, the mute analogue of the çaylak
- * sandbox's viewer-scoped read filter (`SandboxVisibility.sandboxVisibleWhere`,
- * #1205). Three pieces, all viewer-scoped and off-by-default:
- *
- *   - {@link mutedAuthorsWhere} — the SQL read arm the connection/by-id reads `and()`
- *     beside their existing sandbox + removal guards: `author_id NOT IN (:muted)`.
- *     An empty/absent set contributes NO clause, so a flag-off read is byte-for-byte
- *     today's read.
- *   - {@link isMutedAuthor} — the in-memory dual for the single-row reads (`getPost`)
- *     that decide visibility after fetching one record.
- *   - {@link currentMutedIds} — the resolver-level read that resolves the muter's
- *     muted-id set once per request, gated behind the default-off `member-mute` flag
- *     (ADR 0083): off ⇒ the empty set ⇒ no mask. The mask is fully hidden, not a
- *     "muted" placeholder — matching the sandbox filter's hide (the issue's stated
- *     mask-vs-collapse choice).
+ * Mute read-mask (#3113) — makes a muted member's content disappear from the muter's
+ * reads, the mute analogue of the sandbox's viewer-scoped filter (#1205). Viewer-scoped
+ * and off-by-default: an empty set contributes no clause, so a flag-off read is
+ * byte-for-byte today's read. Muted content is fully hidden, never a "muted" placeholder.
  */
 import {CurrentUser} from "@kampus/fate-effect";
 import type {RuntimeContext} from "alchemy";
@@ -26,10 +14,9 @@ import {provideRequestFlags, type RequestFlagOverrides} from "../flagship/FlagsC
 import {Mute} from "./Mute.ts";
 
 /**
- * The read arm masking a muted member's rows: `author_id NOT IN (:muted)`, or
- * `undefined` when nothing is muted so drizzle's `and()` drops the term and the
- * read is unchanged. Kept beside the caller's own sandbox/removal guards, never
- * folded into them (the mute dimension is orthogonal, like the removal guard).
+ * Returns `undefined` when nothing is muted so drizzle's `and()` drops the term. Keep it
+ * beside the caller's sandbox/removal guards, never folded into them — mute is an
+ * orthogonal dimension.
  */
 export const mutedAuthorsWhere = (
 	authorId: SQLWrapper,
@@ -37,22 +24,15 @@ export const mutedAuthorsWhere = (
 ): SQL | undefined =>
 	mutedIds && mutedIds.size > 0 ? notInArray(authorId, [...mutedIds]) : undefined;
 
-/**
- * The in-memory dual of {@link mutedAuthorsWhere} for a read that has already
- * fetched one record (`getPost`): `true` iff the row's author is in the muter's
- * muted set, so the caller masks it to not-found.
- */
+/** The in-memory dual of {@link mutedAuthorsWhere}, for reads that fetch one record. */
 export const isMutedAuthor = (
 	authorId: string,
 	mutedIds: ReadonlySet<string> | undefined,
 ): boolean => mutedIds != null && mutedIds.has(authorId);
 
 /**
- * The muter's muted-id set for this request — the viewer-scoped mask the content
- * resolvers thread into their reads. Gated behind the default-off `member-mute`
- * flag (safe-default: a Flagship outage or the unflipped default both read `false`,
- * so reads are exactly as today). An anonymous viewer (no `CurrentUser`) has no
- * mutes, short-circuiting to the empty set with no DB read.
+ * Safe-default `false`: a Flagship outage and the unflipped default both leave reads
+ * exactly as today.
  */
 export const currentMutedIds: Effect.Effect<
 	Set<string>,

--- a/apps/web/worker/features/mute/read-mask.unit.test.ts
+++ b/apps/web/worker/features/mute/read-mask.unit.test.ts
@@ -1,17 +1,8 @@
 /**
- * Mute read-mask (#3113) — the decisions that are wrong-or-right with no database
- * (ADR 0082): the SQL arm {@link mutedAuthorsWhere} folds beside a read's existing
- * guards, the in-memory {@link isMutedAuthor} dual, and the {@link currentMutedIds}
- * flag gate. Row-level EXCLUSION against real D1 (each content surface actually
- * hiding a muted author's rows) is the integration tier's job, like the sandbox
- * filter (`SandboxVisibility.agreement` leaves execution to integration).
- *
- * The masked-read coverage per surface (present-without-mute / absent-with-mute /
- * flag-off-unchanged) is anchored on the two invariants those reds reduce to:
- *   - the arm is `undefined` (no clause) exactly when nothing is muted — so a
- *     flag-off read (empty set) is byte-for-byte today's read on every surface;
- *   - the arm is `author_id NOT IN (…)` when the muter has mutes — the one predicate
- *     the pano feed, pano thread, and sözlük definition reads all `and()` in.
+ * Mute read-mask (#3113, ADR 0082). Per-surface coverage reduces to two invariants: the
+ * arm is `undefined` (no clause) exactly when nothing is muted — so a flag-off read is
+ * byte-for-byte today's read — and `author_id NOT IN (…)` otherwise. Row-level exclusion
+ * against real D1 is the integration tier's job.
  */
 import {assert, describe, it} from "@effect/vitest";
 import {CurrentUser} from "@kampus/fate-effect";
@@ -23,7 +14,6 @@ import {RequestFlagOverrides} from "../flagship/FlagsContext.ts";
 import {Mute} from "./Mute.ts";
 import {currentMutedIds, isMutedAuthor, mutedAuthorsWhere} from "./read-mask.ts";
 
-// A throwaway table carrying the one column the mask reads, for a stable rendered name.
 const content = sqliteTable("content", {
 	id: text("id").primaryKey(),
 	authorId: text("author_id").notNull(),
@@ -76,8 +66,8 @@ const flagsStub = (on: boolean): Layer.Layer<Flags> =>
 		getObject: () => Effect.die("getObject not exercised"),
 	} as typeof Flags.Service);
 
-// `Mute` whose `readMutedIds` returns a fixed set — or dies on contact, proving a
-// path that must short-circuit before the read (flag off / anonymous) never reaches it.
+// Fail-on-contact by default, proving a path that must short-circuit before the read
+// (flag off / anonymous) never reaches it.
 const muteStub = (
 	readMutedIds?: (viewerId: string | null | undefined) => Effect.Effect<Set<string>>,
 ) =>

--- a/apps/web/worker/features/mute/views.ts
+++ b/apps/web/worker/features/mute/views.ts
@@ -1,20 +1,15 @@
 /**
- * Mute fate data view (#3112) — the write receipt the `mute.set` / `mute.remove`
- * mutations return inline (the mecmua `MecmuaSubscriptionReceiptView` idiom): a
- * synthetic view with no fetch path, delivered by the mutation, never re-fetched.
- * `id` is the muted member (the receipt's identity), `isMuted` the muter's presence
- * over them AFTER the write, `changed` false on an idempotent no-op. Data views are
- * the schema (ADR 0018); see `.patterns/fate-effect-data-views.md`.
+ * Mute fate data views (#3112). `MuteReceipt` is synthetic — no fetch path, delivered inline by
+ * the `mute.set` / `mute.remove` mutations, never re-fetched: `id` is the muted member,
+ * `isMuted` the muter's presence over them AFTER the write, `changed` false on an idempotent
+ * no-op. Data views are the schema (ADR 0018); see `.patterns/fate-effect-data-views.md`.
  */
 import {FateDataView, type WorkerEntity} from "@kampus/fate-effect";
 import type {ViewRow} from "../fate/view-types.ts";
 
 export type MuteReceiptViewRow = ViewRow<{
-	/** The muted member id — the receipt's identity. */
 	id: string;
-	/** The muter's mute presence over `id` after the write. */
 	isMuted: boolean;
-	/** `false` on an idempotent no-op (state already matched intent). */
 	changed: boolean;
 }>;
 
@@ -28,22 +23,16 @@ export const muteReceiptDataView = MuteReceiptView.view;
 export type MuteReceipt = WorkerEntity<typeof MuteReceiptView>;
 
 /**
- * `MutedMember` — one entry of the viewer's own manage-my-mutes list (#3114),
- * delivered inline by the `mute.listMine` list root (no by-id fetch path — a mute is
- * the muter's private state). `id` is the muted member id (the row identity + the
- * unmute target the UI passes to `mute.remove`); `username`/`displayName` are the
- * profile handle joined at the resolver so a row renders + offers an unmute, both
- * nullable for an un-bootstrapped member. `mutedAt` (ISO-8601) is the newest-first
- * order key. See `.patterns/fate-effect-data-views.md`.
+ * One entry of the viewer's own manage-my-mutes list (#3114), delivered inline by the
+ * `mute.listMine` list root — a mute is the muter's private state, so there is no by-id fetch
+ * path. `id` is the unmute target `mute.remove` takes; `username`/`displayName` are the profile
+ * handle joined at the resolver, both null for an un-bootstrapped member; `mutedAt` (ISO-8601)
+ * is the newest-first order key.
  */
 export type MutedMemberViewRow = ViewRow<{
-	/** The muted member id — the row identity + the `mute.remove` unmute target. */
 	id: string;
-	/** The muted member's username (`null` for an un-bootstrapped member). */
 	username: string | null;
-	/** The muted member's display name (`null` when unset). */
 	displayName: string | null;
-	/** When the mute was set (ISO-8601) — the newest-first order key. */
 	mutedAt: string;
 }>;
 

--- a/apps/web/worker/features/pano/Bookmark.ts
+++ b/apps/web/worker/features/pano/Bookmark.ts
@@ -1,19 +1,10 @@
 /**
- * Bookmark — per-user post bookmark ("kaydet") service. The structural twin of
- * {@link Vote} stripped to pure presence: no score, no karma, no hot-score
- * recompute. A `post_bookmark` row means saved; its absence means not.
+ * Bookmark — per-user post bookmark ("kaydet"). The structural twin of {@link Vote}
+ * stripped to pure presence: a `post_bookmark` row means saved, its absence means not.
+ * `toggle` is idempotent (probe-then-write, like `Vote.cast`).
  *
- * `toggle` is idempotent (probe-then-write, like `Vote.cast`): re-saving an
- * already-saved post — or un-saving an unsaved one — is a no-op that writes
- * nothing and returns `changed: false`. `readMine` is the batched presence read
- * the post hydration stamps `isSaved` from without an N+1.
- *
- * Lexeme (the `Vote` twin, #1138): the wire viewer-scalar is `isSaved` (the
- * `myVote` twin, the deliberate `is*` convention shared with `isDraft`), so the
- * toggle's presence-intent input is `value` (mirrors `VoteInput.value`) and its
- * result presence field is `isSaved` (mirrors `VoteResult.myVote`). The brand
- * term stays Turkish (`kaydet`) and the table stays `post_bookmark` (the
- * `post_vote` twin) — both deliberate, not drift.
+ * The naming mirrors Vote deliberately and is not drift (#1138): `value` in, `isSaved`
+ * out (the `myVote` twin), the brand term Turkish, the table `post_bookmark`.
  */
 import {and, desc, eq, inArray, isNull} from "drizzle-orm";
 import {Context, Effect, Layer} from "effect";
@@ -25,25 +16,18 @@ import {PostNotFound} from "./errors.ts";
 export interface BookmarkToggleInput {
 	userId: string;
 	postId: string;
-	/** Presence intent: `true` saves, `false` un-saves (mirrors `VoteInput.value`). */
 	value: boolean;
 }
 
 export interface BookmarkToggleResult {
 	postId: string;
-	/** Viewer's save presence after the write — the wire `isSaved` lexeme (the `VoteResult.myVote` twin). */
 	isSaved: boolean;
-	/** `false` on an idempotent no-op (state already matched intent). */
 	changed: boolean;
 }
 
-/**
- * A keyset page of the viewer's saved post ids, newest save first. Carries the
- * ordered ids only — hydration (the `isSaved`/`myVote` batch stamp + post shape)
- * stays in `Pano.getPostsByIds`, so `Bookmark` owns the `post_bookmark` keyset
- * and `Pano` owns the post row. The cursor is the bookmark's `post_id` (unique
- * per user, the `(post_id, user_id)` PK).
- */
+// Ordered ids only — hydration stays in `Pano.getPostsByIds`, so `Bookmark` owns the
+// `post_bookmark` keyset and `Pano` owns the post row. The cursor is the bookmark's
+// `post_id`, unique per user by the `(post_id, user_id)` PK.
 export interface SavedPostsPage {
 	ids: string[];
 	hasNextPage: boolean;
@@ -56,21 +40,14 @@ export class Bookmark extends Context.Service<
 		readonly toggle: (
 			input: BookmarkToggleInput,
 		) => Effect.Effect<BookmarkToggleResult, PostNotFound>;
-		/**
-		 * Batched presence read: the subset of `postIds` the viewer has saved, in
-		 * one `IN (...)` read so #128 stamps `isSaved` without an N+1. Missing
-		 * viewer or empty `postIds` short-circuits to an empty Set with no read.
-		 */
+		// One `IN (...)` read, so `isSaved` is stamped without an N+1. Missing viewer
+		// or empty `postIds` short-circuits with no read at all.
 		readonly readMine: (
 			viewerId: string | null | undefined,
 			postIds: ReadonlyArray<string>,
 		) => Effect.Effect<Set<string>>;
-		/**
-		 * Keyset page of the viewer's saved post ids, ordered by save time
-		 * (`post_bookmark.created_at DESC, post_id DESC`) over the
-		 * `(user_id, created_at DESC)` index (#127). Inner-joins `post_record` so
-		 * a soft-deleted post never appears. Missing viewer → empty page, no read.
-		 */
+		// Ordered by save time over the `(user_id, created_at DESC)` index (#127).
+		// Inner-joins `post_record` so a soft-deleted post never appears.
 		readonly listSavedConnection: (
 			viewerId: string | null | undefined,
 			opts?: {first?: number | undefined; after?: string | null | undefined},
@@ -80,8 +57,6 @@ export class Bookmark extends Context.Service<
 
 export const BookmarkLive = Layer.effect(Bookmark)(
 	Effect.gen(function* () {
-		// `orDieAccess`: DB failures are defects (domain-boundary rule), so the
-		// public signature carries `PostNotFound` only and `R` stays `never`.
 		const {run, batch} = orDieAccess(yield* Drizzle);
 
 		const readMine = Effect.fn("Bookmark.readMine")(function* (
@@ -112,9 +87,8 @@ export const BookmarkLive = Layer.effect(Bookmark)(
 			const first = Math.max(1, Math.min(opts.first ?? 20, 100));
 			const after = opts.after ?? null;
 
-			// The DB read is the port; `resolveCursor` is the pure cursor-miss
-			// decision (see `Pano.listPostsConnection`). `after` is a bookmark
-			// `post_id`; resolve it to its `created_at` for the keyset tuple.
+			// `after` is a bookmark `post_id`; resolve it to its `created_at` for the
+			// keyset tuple. The DB read is the port, `resolveCursor` the pure decision.
 			const resolvedRow = after
 				? ((yield* run((db) =>
 						db

--- a/apps/web/worker/features/pano/Bookmark.unit.test.ts
+++ b/apps/web/worker/features/pano/Bookmark.unit.test.ts
@@ -1,31 +1,20 @@
 /**
- * Bookmark unit coverage — the decisions that are wrong-or-right with no database
- * (ADR 0082). The `Drizzle` seam is substituted
- * directly (`Vote.unit.test.ts` idiom): a `run`/`batch` that THROWS proves a
- * short-circuit never touched the DB, and a stubbed `run` feeds the decision its
- * inputs without an engine.
- *
- * Bookmark's real-D1 fidelity — composite-PK presence idempotency, the
- * toggle/readMine round-trip over real rows — lands at the integration tier once
- * `#128` wires the fate view field + toggle mutation this child intentionally
- * omits (there is no HTTP/fate surface yet to drive Bookmark black-box over).
+ * The Bookmark decisions that are wrong-or-right with no database (ADR 0082): a
+ * `run`/`batch` that THROWS proves a short-circuit never touched the DB, and a stubbed
+ * `run` feeds the decision its inputs without an engine.
  */
 import {assert, describe, it} from "@effect/vitest";
 import {Effect, Layer} from "effect";
 import {Drizzle, type DrizzleAccess, type DrizzleDb} from "../../db/Drizzle.ts";
 import {Bookmark, BookmarkLive} from "./Bookmark.ts";
 
-// A `Drizzle` whose every call throws — any path that actually reaches the DB
-// seam fails the test. A guard that short-circuits before reading runs to
-// completion against it, which is exactly the "no read" proof.
 const throwingAccess: DrizzleAccess = {
 	run: () => Effect.die(new Error("Bookmark read the DB on a path that must short-circuit")),
 	batch: () => Effect.die(new Error("Bookmark wrote a batch on a path that must short-circuit")),
 };
 
-// A `Drizzle` whose `run` replays a queued sequence of results and whose `batch`
-// throws — used to drive `toggle`'s pre-write decision (post probe + presence
-// probe) while proving the idempotent no-op never reaches `batch`.
+// `run` replays a queued sequence; `batch` throws, so an idempotent no-op that reaches
+// the write fails the test.
 function scriptedAccess(results: ReadonlyArray<unknown>): {access: DrizzleAccess; runs: number} {
 	const state = {i: 0};
 	const access: DrizzleAccess = {
@@ -77,7 +66,6 @@ describe("Bookmark.toggle — pre-write decisions (mocked Drizzle seam)", () => 
 	it.effect("a missing/soft-deleted post raises PostNotFound before any write", () =>
 		Effect.gen(function* () {
 			const bookmark = yield* Bookmark;
-			// the postRecord probe's findFirst resolves to `undefined` → not-found, no batch.
 			const exit = yield* Effect.exit(
 				bookmark.toggle({userId: "u1", postId: "ghost", value: true}),
 			);
@@ -88,7 +76,6 @@ describe("Bookmark.toggle — pre-write decisions (mocked Drizzle seam)", () => 
 
 	it.effect("re-saving an already-saved post is an idempotent no-op — no batch", () => {
 		// run #1 post probe → a live post row; run #2 presence probe → already saved.
-		// The `batch` stub throws, so reaching it fails the test.
 		const {access} = scriptedAccess([{id: "p1"}, {postId: "p1"}]);
 		return Effect.gen(function* () {
 			const bookmark = yield* Bookmark;

--- a/apps/web/worker/features/pano/Pano.connection.unit.test.ts
+++ b/apps/web/worker/features/pano/Pano.connection.unit.test.ts
@@ -1,22 +1,10 @@
 /**
- * Pano connection-resolver pagination DECISIONS, unit-reachable over the
- * substituted-`Drizzle` seam (ADR 0082 litmus: "could this be wrong even if the
- * database behaved perfectly?" → unit). `listPostsConnection`'s `first` clamp,
- * the single-direction keyset (all `desc`) whose lead column varies by sort, the
- * `id desc` tiebreak, the draft-exclusion predicate, and the cursor-miss →
- * empty-page branch are all wrong-or-right with no SQL engine — driven here over
- * a `Drizzle` double, never real D1.
+ * Pano connection-resolver pagination decisions over a substituted `Drizzle` seam, never
+ * real D1 (ADR 0082). Two doubles: `throwingAccess` (every `run` dies, so any path that
+ * reaches the DB seam fails the test) and `scriptedAccess` (replays queued `run` results
+ * in call order and captures the fetch builder's rendered SQL via `.toSQL()`).
  *
- * Two doubles, the `Vote.unit.test.ts` idiom:
- *   - `throwingAccess` — every `run` dies, so any path that actually reaches the
- *     DB seam fails the test (the cursor-miss-no-second-read proof).
- *   - `scriptedAccess` — replays a queued sequence of `run` results in call order
- *     (count, [cursor-resolve], fetch) AND captures the fetch builder's rendered
- *     SQL via `.toSQL()`, so the keyset predicate + `orderBy` + `LIMIT first+1`
- *     are asserted as the actual operators/columns, not a structural shape.
- *
- * Real-D1 keyset EXECUTION fidelity (collation, NULL tiebreaks, the paged walk)
- * stays integration-tier (`tests/integration/`), per ADR 0082's irreducible core.
+ * Real-D1 keyset EXECUTION fidelity stays integration-tier, per ADR 0082.
  */
 import {assert, describe, it} from "@effect/vitest";
 import {drizzle} from "drizzle-orm/d1";
@@ -31,9 +19,8 @@ import {Vote} from "../vote/Vote.ts";
 import {Bookmark} from "./Bookmark.ts";
 import {Pano, PanoLive} from "./Pano.ts";
 
-// A real drizzle/D1 client over a no-op D1 — used ONLY to run the fetch builder
-// the resolver returns from `run`, so we can render its `.toSQL()`. It never
-// executes (the scripted `run` resolves with queued rows, not the builder).
+// A real drizzle/D1 client over a no-op D1 — used ONLY to render the fetch builder's
+// `.toSQL()`. It never executes (the scripted `run` resolves with queued rows).
 // biome-ignore lint/plugin: `D1Database` is a host binding that can't be structurally constructed in a fake; only `prepare`/`batch` are exercised, and the scripted `run` never lets the no-op queries execute.
 const noopD1 = {
 	prepare: () => ({
@@ -63,11 +50,8 @@ const hasToSQL = (v: unknown): v is {toSQL: () => {sql: string; params: unknown[
 	typeof v === "object" && v !== null && typeof (v as {toSQL?: unknown}).toSQL === "function";
 
 /**
- * Replays `run` results in call order and records each call's rendered SQL when
- * the resolver's `fn` returns a renderable builder (the fetch). The count and
- * cursor-resolve calls chain `.get()/.then()` against the real `renderDb` (no-op
- * D1 → empty), so their queued value is what the resolver folds over; the fetch
- * call returns the builder directly, which we render and answer with rows.
+ * Replays `run` results in call order and records each call's rendered SQL when the
+ * resolver's `fn` returns a renderable builder (the fetch).
  */
 function scriptedAccess(results: ReadonlyArray<unknown>): {
 	access: DrizzleAccess;
@@ -110,14 +94,11 @@ const panoLayer = (access: DrizzleAccess, pasaport: Layer.Layer<Pasaport> = Pasa
 		Layer.provide(Layer.succeed(Drizzle, access)),
 	);
 
-// The fetch query is the LAST recorded one (count is first, cursor-resolve —
-// when `after` is present — is between). On a head page it is `queries[1]`
-// (count, fetch); with a cursor it is `queries[2]`.
+// The fetch query is the LAST recorded one (count is first, cursor-resolve — when `after`
+// is present — is between).
 const fetchQuery = (queries: {sql: string; params: unknown[]}[]) => queries.at(-1)!;
 
 describe("Pano.listPostsConnection — `first` clamp [1,100] (no SQL engine booted)", () => {
-	// The clamp surfaces as the `LIMIT first+1` param on the fetch query, so a
-	// head page (count + fetch) is enough — no cursor read, no real engine.
 	const clampCase = (input: number | undefined, expectedLimit: number) =>
 		it.effect(`first=${String(input)} → LIMIT ${expectedLimit}`, () => {
 			const {access, queries} = scriptedAccess([0 /* count */, [] /* fetch */]);
@@ -151,7 +132,6 @@ describe("Pano.listPostsConnection — single-direction keyset, lead column by s
 		});
 
 	const run = (sort: "hot" | "new" | "top" | "discuss") => {
-		// count, cursor-resolve (the row), fetch.
 		const {access, queries} = scriptedAccess([1, cursorRow, []]);
 		return Effect.runPromise(sqlOf(sort).pipe(Effect.provide(panoLayer(access)))).then(() =>
 			fetchQuery(queries),
@@ -162,7 +142,6 @@ describe("Pano.listPostsConnection — single-direction keyset, lead column by s
 		const {sql, params} = await run("top");
 		assert.match(sql, /"post_record"\."score" < \?/, "score is the lead keyset column, desc → `<`");
 		assert.match(sql, /order by "post_record"\."score" desc, "post_record"\."id" desc/);
-		// keyset params: (score<v) or (score=v and id<v) → [5,5,"p9"], then LIMIT 11.
 		assert.deepStrictEqual(params, [5, 5, "p9", 11]);
 	});
 
@@ -200,8 +179,7 @@ describe("Pano.listPostsConnection — single-direction keyset, lead column by s
 
 describe("Pano.listPostsConnection — cursor-miss → empty page, NO second DB read", () => {
 	it.effect("present `after` resolving to no row → empty page; throwing seam never dies", () => {
-		// count → total, cursor-resolve → null (the miss). The fetch `run` would die
-		// on `throwingAccess`, so reaching it fails the test. We compose: count +
+		// The fetch `run` would die on `throwingAccess`, so reaching it fails the test: count +
 		// cursor-resolve are scripted, the fetch seam throws.
 		let i = 0;
 		const access: DrizzleAccess = {
@@ -230,7 +208,6 @@ describe("Pano.listPostsConnection — cursor-miss → empty page, NO second DB 
 	});
 
 	it.effect("a head page (no `after`) never reads a cursor row", () => {
-		// No `after` → resolveCursor short-circuits to no-cursor: count + fetch only.
 		// Inject a marker after two calls so a stray cursor-resolve read would die.
 		let i = 0;
 		const {access: scripted} = scriptedAccess([0, []]);
@@ -251,8 +228,6 @@ describe("Pano.listPostsConnection — cursor-miss → empty page, NO second DB 
 });
 
 describe("Pano.listPostsConnection — stamps the LIVE author identity on the page (#2151)", () => {
-	// The keyset fetch projects exactly `PostKeysetRow` (post-fields.ts): the resolver
-	// reads only these columns, so a scripted fetch row must carry the same subset.
 	const fetchRow = {
 		id: "post-1",
 		slug: "baslik",
@@ -261,7 +236,6 @@ describe("Pano.listPostsConnection — stamps the LIVE author identity on the pa
 		host: "kamp.us",
 		bodyExcerpt: "özet",
 		authorId: "user-1",
-		// The write-time snapshot — the STALE handle the pre-fix feed rendered.
 		authorName: "eski-ad",
 		score: 3,
 		commentCount: 2,
@@ -269,9 +243,8 @@ describe("Pano.listPostsConnection — stamps the LIVE author identity on the pa
 		tags: "show",
 	};
 
-	// The LIVE `user_profile` identity for `user-1` — deliberately DIVERGENT from the
-	// write-time `authorName` snapshot above, so a stamped row proves the feed read the
-	// current handle rather than echoing the snapshot.
+	// Deliberately DIVERGENT from the write-time `authorName` snapshot above, so a stamped
+	// row proves the feed read the current handle rather than echoing the snapshot.
 	const liveIdentity: ProfileIdentityRow = {
 		userId: "user-1",
 		username: "umut",
@@ -291,7 +264,6 @@ describe("Pano.listPostsConnection — stamps the LIVE author identity on the pa
 		"landingPosts / signed-out feed path: the page row carries the LIVE username + displayName, not the write-time snapshot",
 		() => {
 			readSpy.ids = null;
-			// count + fetch (head page, no cursor). The fetch returns the one live row.
 			const {access} = scriptedAccess([1 /* count */, [fetchRow] /* fetch */]);
 			return Effect.gen(function* () {
 				const pano = yield* Pano;
@@ -299,9 +271,8 @@ describe("Pano.listPostsConnection — stamps the LIVE author identity on the pa
 				assert.strictEqual(page.rows.length, 1, "head page returns the one row");
 				const row = page.rows[0];
 				assert.isDefined(row, "head page returns the one row");
-				// The stamp — the fix's whole point: the resolver paths that DON'T re-hydrate
-				// through `getPostsByIds` (landingPosts, signed-out posts) now get the live
-				// identity here, so `actorLabel` renders the current display name.
+				// The resolver paths that DON'T re-hydrate through `getPostsByIds` get the live
+				// identity here.
 				assert.strictEqual(
 					row.authorDisplayName,
 					"Umut Şirin",
@@ -312,8 +283,7 @@ describe("Pano.listPostsConnection — stamps the LIVE author identity on the pa
 					"umut",
 					"the live username is stamped onto the feed row",
 				);
-				// The write-time `authorName` snapshot still rides as `author` (the intrinsic
-				// field) — the stamp ADDS the live identity, it does not overwrite the snapshot.
+				// The stamp ADDS the live identity; it does not overwrite the write-time snapshot.
 				assert.strictEqual(
 					row.author,
 					"eski-ad",
@@ -328,7 +298,6 @@ describe("Pano.listPostsConnection — stamps the LIVE author identity on the pa
 		const rows = [
 			{...fetchRow, id: "post-1", authorId: "user-1"},
 			{...fetchRow, id: "post-2", authorId: "user-2"},
-			// Two posts by the same author collapse to one id in the batch.
 			{...fetchRow, id: "post-3", authorId: "user-1"},
 		];
 		const {access} = scriptedAccess([3 /* count */, rows /* fetch */]);
@@ -345,16 +314,11 @@ describe("Pano.listPostsConnection — stamps the LIVE author identity on the pa
 });
 
 describe("Pano — authed feed: parallelized listPostsConnection composes with the getPostsByIds re-hydrate (#2275)", () => {
-	// #2275 parallelizes the total-count and keyset-page reads inside
-	// `listPostsConnection`; the per-viewer scalars (`myVote`/`isSaved`) and the
-	// reaction aggregate are deliberately NOT read there — they come from the
-	// batched `getPostsByIds` re-hydrate the `posts` resolver runs for a signed-in
-	// viewer (lists.ts). This drives that exact composition end to end over the
-	// substituted seams and proves a viewer with a vote + a save + a reaction still
-	// sees all three after the parallelization — i.e. the re-hydrate stamps survive.
+	// The per-viewer scalars (`myVote`/`isSaved`) and the reaction aggregate are NOT read
+	// inside `listPostsConnection` — they come from the batched `getPostsByIds` re-hydrate
+	// the `posts` resolver runs for a signed-in viewer.
 	const VIEWER = "user-viewer";
 
-	// The keyset-page projection `listPostsConnection` returns (post-fields subset).
 	const keysetRow = {
 		id: "post-1",
 		slug: "baslik",
@@ -370,8 +334,6 @@ describe("Pano — authed feed: parallelized listPostsConnection composes with t
 		tags: "show",
 	};
 
-	// The full `post_record` the re-hydrate re-reads by id (getPostsByIds does a
-	// `select()` of the whole row, then stamps the viewer scalars + reactions onto it).
 	// biome-ignore lint/plugin: a row fixture standing in for a full `post_record` select; getPostsByIds reads the lifecycle/draft columns + the `toPostSummaryRow` field set off it, enumerating every column adds nothing.
 	const fullRecord = {
 		id: "post-1",
@@ -402,8 +364,6 @@ describe("Pano — authed feed: parallelized listPostsConnection composes with t
 		myReaction: "🔥",
 	};
 
-	// The viewer's state: a vote (Vote.readMine → the id), a save (Bookmark.readMine
-	// → the id), and a reaction (Reaction.readAggregate → the non-empty aggregate).
 	// biome-ignore lint/plugin: a service double — only `readMine` is on the re-hydrate path.
 	const VotedStub = Layer.succeed(Vote, {
 		cast: () => Effect.die(new Error("feed re-hydrate must not cast a vote")),
@@ -437,9 +397,6 @@ describe("Pano — authed feed: parallelized listPostsConnection composes with t
 	it.effect(
 		"a signed-in viewer with a vote + a save + a reaction sees all three on the composed feed row",
 		() => {
-			// The composed authed-feed read order: count + keyset fetch (the two now
-			// parallelized in listPostsConnection), then the getPostsByIds re-hydrate
-			// fetch — the scripted double replays these in call order.
 			const {access} = scriptedAccess([
 				1 /* count */,
 				[keysetRow] /* keyset page fetch */,
@@ -468,8 +425,7 @@ describe("Pano — authed feed: parallelized listPostsConnection composes with t
 });
 
 // Mute read-mask (#3113): the muted-author SQL arm is `and()`ed into the pano feed +
-// thread fetch. Rendered over the same `.toSQL()` seam — present-with-mute emits
-// `author_id not in (…)`, absent/off emits nothing (byte-for-byte today's read).
+// thread fetch — present-with-mute emits `author_id not in (…)`, absent/off emits nothing.
 describe("Pano feed + thread — mute read-mask (author_id NOT IN …)", () => {
 	it.effect("listPostsConnection masks a muted author when `mutedIds` is non-empty", () => {
 		const {access, queries} = scriptedAccess([1 /* count */, [] /* fetch */]);

--- a/apps/web/worker/features/pano/Pano.ts
+++ b/apps/web/worker/features/pano/Pano.ts
@@ -1,22 +1,9 @@
 /**
- * Pano — the link aggregator / discussion feature service. Resolver-facing
- * surface for post + comment CRUD, vote delegation, and connection-shaped
- * pagination.
- *
- * The service is one `Pano` tag with a single public surface, but its two planes
- * live apart: the posts plane in `post-operations.ts`, the comments plane in
- * `comment-operations.ts`, and the cross-plane `pano_stats` cache in
- * `pano-stats.ts`. `PanoLive` is the thin wiring seam — it builds the shared deps
- * once and hands them to each plane's factory, then spreads the two closure sets
- * into the one service object, so the wire surface is identical to when both planes
- * shared this file.
- *
- * Vote mutations delegate to `Vote.cast` rather than reimplementing the batched
- * vote / karma / score-cache logic; the Pano-side wrappers re-load the target
- * row for the canonical resolver shape and translate `VoteTargetNotFound` into
- * `PostNotFound` / `CommentNotFound` so the resolver codec keeps producing
- * `POST_NOT_FOUND` / `COMMENT_NOT_FOUND`.
- *
+ * Pano — the link aggregator / discussion feature service. One service tag, two planes
+ * implemented apart (`post-operations.ts` / `comment-operations.ts`) and spread back
+ * into one object here, so the wire surface is unchanged by the split. Vote mutations
+ * delegate to `Vote.cast` and translate `VoteTargetNotFound` into
+ * `PostNotFound` / `CommentNotFound` so the resolver codec keeps its wire codes.
  * Validation lives in the service methods, not resolvers (ADR 0013).
  */
 import {Context, Effect, Layer} from "effect";
@@ -84,9 +71,8 @@ import {
 	type VoteOnPostResult,
 } from "./post-operations.ts";
 
-// The tag enum + label aliases have a single typed home in `src/lib/panoTags.ts`,
-// cross-included by the worker tsconfig (#1030); re-exported here so the long-lived
-// server-side names (consumed by `sources.ts` etc.) keep resolving.
+// The tags' single typed home is `src/lib/panoTags.ts`; re-exported so the long-lived
+// server-side names keep resolving.
 export {tagLabel};
 export const ALLOWED_POST_TAG_KINDS = POST_TAG_KINDS;
 export type AllowedPostTagKind = PostTagKind;
@@ -128,9 +114,6 @@ export type {
 	VoteOnPostInput,
 	VoteOnPostResult,
 };
-// Constants, the stats fold, and the per-plane input/result types keep their
-// long-lived `Pano.ts` import paths via these re-exports, so callers (resolvers,
-// tests, the cross-feature consumers) are untouched by the post/comment split.
 export {COMMENT_BODY_MAX, POST_BODY_MAX, POST_TITLE_MAX, recomputePanoStats, SILINDI_PLACEHOLDER};
 
 export class Pano extends Context.Service<
@@ -152,15 +135,10 @@ export class Pano extends Context.Service<
 			after?: string | null;
 			host?: string | null;
 			sandboxViewer?: SandboxViewer | undefined;
-			/** Mute read-mask (#3113): the muter's muted authors, hidden from the feed. */
 			mutedIds?: ReadonlySet<string> | undefined;
 		}) => Effect.Effect<PostConnectionPage>;
 
-		/**
-		 * Keyset page over a post's comments, `(created_at asc, id asc)` (ADR 0019).
-		 * `viewerId` stamps `myVote` for the whole page in one `user_vote` read;
-		 * `sandboxViewer` filters the çaylak sandbox (#1205) per the same viewer.
-		 */
+		/** Keyset page over a post's comments, `(created_at asc, id asc)` (ADR 0019). */
 		readonly listCommentsKeyset: (
 			postId: string,
 			opts?: {
@@ -168,7 +146,6 @@ export class Pano extends Context.Service<
 				after?: string | null | undefined;
 				viewerId?: string | null | undefined;
 				sandboxViewer?: SandboxViewer | undefined;
-				/** Mute read-mask (#3113): muted authors' comments hidden from the thread. */
 				mutedIds?: ReadonlySet<string> | undefined;
 				/** Collapse the finalize stamps into one concurrent wave (#2710). Default off. */
 				parallelStamps?: boolean | undefined;
@@ -181,16 +158,13 @@ export class Pano extends Context.Service<
 			opts?: {
 				viewerId?: string | null | undefined;
 				sandboxViewer?: SandboxViewer | undefined;
-				/** Mute read-mask (#3113): muted authors' posts dropped from the batch. */
 				mutedIds?: ReadonlySet<string> | undefined;
 			},
 		) => Effect.Effect<ReadonlyArray<PostSummaryRow>>;
 
 		/**
-		 * The viewer overlay (#2322, epic #2316 leg B): the per-viewer `myVote`/`isSaved`
-		 * slice the GET-able base feed omits, keyed by the base feed's post ids. Reuses
-		 * the same batched `user_vote` / `post_bookmark` presence readers `getPostsByIds`
-		 * uses (one `IN (...)` per scalar, never per-row), reading no `post_record`.
+		 * The per-viewer `myVote`/`isSaved` slice the cacheable base feed omits. Reads no
+		 * `post_record` — one `IN (...)` per scalar, never per-row.
 		 */
 		readonly readViewerOverlay: (
 			ids: ReadonlyArray<string>,
@@ -205,7 +179,6 @@ export class Pano extends Context.Service<
 			opts?: {
 				viewerId?: string | null | undefined;
 				sandboxViewer?: SandboxViewer | undefined;
-				/** Mute read-mask (#3113): muted authors' comments dropped from the batch. */
 				mutedIds?: ReadonlySet<string> | undefined;
 				/** Collapse the finalize stamps into one concurrent wave (#2710). Default off. */
 				parallelStamps?: boolean | undefined;
@@ -213,9 +186,8 @@ export class Pano extends Context.Service<
 		) => Effect.Effect<ReadonlyArray<CommentRow>>;
 
 		/**
-		 * The moderator sandbox-queue / promotion-backlog read models (#1205, #1206
-		 * seam): a çaylak's still-sandboxed, not-removed posts/comments — scoped to one
-		 * author when promotion flips their backlog.
+		 * A çaylak's still-sandboxed, not-removed content — scoped to one author when a
+		 * promotion flips their backlog.
 		 */
 		readonly listSandboxedPosts: (opts?: {
 			authorId?: string | undefined;
@@ -224,7 +196,6 @@ export class Pano extends Context.Service<
 			authorId?: string | undefined;
 		}) => Effect.Effect<ReadonlyArray<CommentRow>>;
 
-		/** Resolve a comment's parent post id (for re-resolving on delete). */
 		readonly lookupCommentPostId: (commentId: string) => Effect.Effect<string | null>;
 
 		readonly submitPost: (
@@ -245,18 +216,16 @@ export class Pano extends Context.Service<
 
 		/**
 		 * Un-remove a `Removed` post (ADR 0096 §4); re-enters search, votes stay wiped.
-		 * Sandbox-faithful (#1811): the result's `sandboxedAt` is non-null iff the post
-		 * returned to the çaylak sandbox, so the mutation can suppress the live echo.
+		 * `sandboxedAt` is non-null iff the post returned to the çaylak sandbox, so the
+		 * mutation can suppress the live echo.
 		 */
 		readonly restorePost: (
 			input: DeletePostInput,
 		) => Effect.Effect<RestorePostResult, UnauthorizedPostMutation>;
 
 		/**
-		 * Moderator soft-delete (ADR 0098 §6) — the same 0096 substrate write as
-		 * `deletePost`, gated on discharged moderator authority (NOT author ownership):
-		 * `removed_by` is the resolver, reason `Moderated({reportId})`. A missing target
-		 * is a no-op.
+		 * Moderator soft-delete (ADR 0098 §6) — same substrate write as `deletePost` but
+		 * gated on moderator authority, NOT author ownership. A missing target is a no-op.
 		 */
 		readonly moderateRemovePost: (input: {
 			postId: string;
@@ -266,18 +235,15 @@ export class Pano extends Context.Service<
 
 		/**
 		 * Moderator restore (ADR 0098 §3) — reopens the report at the resolve layer.
-		 * `sandboxedAt` is the target's round-tripped sandbox marker (#1811): non-null
-		 * iff the restored post is still sandboxed, so report's live re-append gates the
-		 * public-feed broadcast (a sandboxed restore stays suppressed, #1205/#1280).
+		 * `sandboxedAt` non-null means the restored post is still sandboxed, so report's
+		 * live re-append keeps it out of the public feed.
 		 */
 		readonly moderateRestorePost: (input: {
 			postId: string;
 		}) => Effect.Effect<{restored: boolean; sandboxedAt: Date | null}>;
 
-		// `VoterNotEligible` (#1810): a çaylak newcomer's cast is rejected — the "earn to vote"
-		// gate lives in `Vote.castImpl`. `SelfVoteNotAllowed` (#2216): a cast on one's own post
-		// is rejected at the cast site. Both surface on the cast path only — retraction raises
-		// neither (nothing to retract), so `retractPostVote` keeps its `PostNotFound` channel.
+		// The two cast-only failures: the "earn to vote" gate (`Vote.castImpl`) and the
+		// self-vote refusal. Retraction raises neither, so its channel stays narrower.
 		readonly voteOnPost: (
 			input: VoteOnPostInput,
 		) => Effect.Effect<VoteOnPostResult, PostNotFound | VoterNotEligible | SelfVoteNotAllowed>;
@@ -287,11 +253,8 @@ export class Pano extends Context.Service<
 		) => Effect.Effect<VoteOnPostResult, PostNotFound>;
 
 		/**
-		 * React to a post — the karma-free, ungated twin of `voteOnPost` (#1863).
-		 * Delegates to `Reaction.react` (kind `post`): a palette `emoji` sets/changes
-		 * the viewer's single reaction, `null` retracts it. Re-resolves the post so the
-		 * result carries the fresh `reactions` aggregate. NO tier gate (a çaylak may
-		 * react) and NO karma write — the only failure is a missing/removed target.
+		 * The karma-free, ungated twin of `voteOnPost`: `null` emoji retracts, a çaylak may
+		 * react, and no karma is written. The only failure is a missing/removed target.
 		 */
 		readonly reactToPost: (
 			input: ReactToPostInput,
@@ -324,17 +287,12 @@ export class Pano extends Context.Service<
 			reportId: ReportId;
 		}) => Effect.Effect<{removed: boolean}>;
 
-		/**
-		 * Moderator restore of a comment (ADR 0098 §3) — reopens the report at the resolve
-		 * layer. `sandboxedAt` is the round-tripped sandbox marker (#1811) so report's live
-		 * re-append gates the thread broadcast (a sandboxed restore stays suppressed).
-		 */
+		/** Moderator restore of a comment — the `moderateRestorePost` shape, for the thread. */
 		readonly moderateRestoreComment: (input: {
 			commentId: string;
 		}) => Effect.Effect<{restored: boolean; sandboxedAt: Date | null}>;
 
-		// `VoterNotEligible` (#1810) + `SelfVoteNotAllowed` (#2216) — see `voteOnPost`. Both
-		// fire on the cast path only; retraction is exempt.
+		// Cast-only failures — see `voteOnPost`.
 		readonly voteOnComment: (
 			input: VoteOnCommentInput,
 		) => Effect.Effect<
@@ -346,28 +304,16 @@ export class Pano extends Context.Service<
 			input: VoteOnCommentInput,
 		) => Effect.Effect<VoteOnCommentResult, CommentNotFound>;
 
-		/**
-		 * React to a comment — the karma-free, ungated twin of `voteOnComment` (#1864),
-		 * the direct mirror of `reactToPost`. Delegates to `Reaction.react` (kind
-		 * `comment`): a palette `emoji` sets/changes the viewer's single reaction,
-		 * `null` retracts it. Re-resolves the comment so the result carries the fresh
-		 * `reactions` aggregate. NO tier gate (a çaylak may react) and NO karma write —
-		 * the only failure is a missing/removed target.
-		 */
+		/** The comment mirror of `reactToPost`. */
 		readonly reactToComment: (
 			input: ReactToCommentInput,
 		) => Effect.Effect<ReactToCommentResult, CommentNotFound>;
 
 		/**
-		 * Periodic sıcak/hot decay-refresh (#2027, windowless since #2133, keyset-chunked in
-		 * #2559): recompute the stored `hot_score` for EVERY live, non-draft post at `now` and
-		 * write back the changed rows, so an inactive post's ranking decays with age at any age
-		 * without an activity write. Driven by the cron trigger (`index.ts`). The decay stays a
-		 * stored-column refresh with no read-time recompute, so the FEED's read-path keyset-cursor
-		 * pagination design is preserved (that read-path design is what "keyset-cursor" names here
-		 * — NOT the sweep's own scan shape). The sweep itself reads in ascending-id keyset chunks
-		 * (`post-operations.ts`), a distinct write-path bound. Returns the pass's scanned/updated
-		 * counts for observability.
+		 * Cron-driven sıcak/hot decay refresh: recompute the stored `hot_score` for every
+		 * live, non-draft post at `now`, so an inactive post decays without an activity
+		 * write. Deliberately a stored-column refresh and never a read-time recompute —
+		 * that is what keeps the feed's keyset pagination valid.
 		 */
 		readonly refreshHotScores: (
 			now: Date,
@@ -377,25 +323,20 @@ export class Pano extends Context.Service<
 
 export const PanoLive = Layer.effect(Pano)(
 	Effect.gen(function* () {
-		// `orDieAccess`: every internal DB call site dies on `DrizzleError`
-		// (infra failures are defects — the domain-boundary rule), so public
-		// signatures carry domain errors only and `R` stays `never`.
+		// `orDieAccess` dies on `DrizzleError`, so public signatures carry domain errors
+		// only and `R` stays `never`.
 		const {run, batch} = orDieAccess(yield* Drizzle);
 		const voteSvc = yield* Vote;
 		const bookmarkSvc = yield* Bookmark;
 		const reactionSvc = yield* Reaction;
-		// Live author-identity resolver (#2139): one batched `user_profile` read per page
-		// (`getProfileIdentitiesByIds`) stamps the CURRENT `{username, displayName}` so the
-		// post/comment read surfaces render via `actorLabel`, not the `authorName` snapshot.
+		// Reads the CURRENT `{username, displayName}` per page, so the read surfaces render
+		// live identity rather than the stale `authorName` snapshot on the row.
 		const pasaport = yield* Pasaport;
 
-		// The removal-sequence owner (#1129): the vote-wipe→stamp→FTS ordering is the
-		// module's to enforce, not this service's to hand-wire.
+		// The vote-wipe→stamp→FTS ordering is the removal module's to enforce, not this
+		// service's to hand-wire.
 		const removalSeq: Removal.RemovalSequence = {run, batch, clearTarget: voteSvc.clearTarget};
 
-		// The cross-plane `pano_stats` port (post + comment + author totals), refreshed
-		// after every write that could move them — passed to both planes so the fold has
-		// one home (`pano-stats.ts`).
 		const persistPanoStats = makePersistPanoStats(run);
 
 		const postOps = makePostOperations({

--- a/apps/web/worker/features/pano/PostVisibility.ts
+++ b/apps/web/worker/features/pano/PostVisibility.ts
@@ -1,23 +1,9 @@
 /**
  * The pano-local composition layer of the visibility seam (ADR 0113). `EntityLifecycle`
- * stays the closed 3-state union (Live | Sandboxed | Removed); the fourth content state,
- * draft-private-to-author, is a `post_record`-only concept (`is_draft`), so it composes
- * HERE — layered on the shared lifecycle decision — rather than as a fourth union arm.
- *
- * Two layers, both pure (no service), mirroring the shared `EntityLifecycle.isVisibleTo`
- * / `SandboxVisibility.sandboxVisibleWhere` pair:
- *
- * - {@link postVisibleTo} — the in-memory decision, the shared `isVisibleTo` `&&`'d with
- *   the author-only draft gate.
- * - {@link postVisibleWhere} — its SQL mirror, `sandboxVisibleWhere` `and()`'d with the
- *   draft arm; like the sandbox predicate it carries NO `removed_at IS NULL` guard (the
- *   caller `and()`s its own, or uses {@link publicLivePostWhere}).
- * - {@link publicLivePostWhere} — the post-aware public-live aggregate: `publicLiveWhere`
- *   (removed + sandbox) `and()`'d with the draft arm, the single predicate #1407's post
- *   landing-count paths fold their hand-written removed/sandboxed/draft re-derivations onto.
- *
- * The draft gate has NO moderator exemption — unlike the sandbox arm, an unpublished draft
- * is not moderation-relevant, so it is private to its author and no one else (ADR 0113 §2).
+ * stays the closed 3-state union; draft-private-to-author is a `post_record`-only concept
+ * (`is_draft`), so it layers on here rather than becoming a fourth union arm. The draft
+ * gate has NO moderator exemption — unlike the sandbox arm, an unpublished draft is
+ * private to its author and no one else (ADR 0113 §2).
  */
 import {and, eq, or, type SQL, type SQLWrapper, sql} from "drizzle-orm";
 import {
@@ -32,13 +18,6 @@ import {
 	sandboxVisibleWhere,
 } from "../lifecycle/SandboxVisibility.ts";
 
-/**
- * The in-memory post visibility decision (ADR 0113): the shared 3-state lifecycle
- * decision composed with the author-only draft gate. A post is visible to `viewer` iff
- * its lifecycle is visible to them AND (it is not a draft OR they authored it) — drafts
- * are author-only with NO moderator exemption, the one place this diverges from the
- * sandbox arm's author-or-moderator rule.
- */
 export const postVisibleTo = (
 	lifecycle: EntityLifecycle,
 	isDraft: boolean,
@@ -47,20 +26,14 @@ export const postVisibleTo = (
 ): boolean =>
 	isVisibleTo(lifecycle, authorId, viewer) && (!isDraft || viewer.viewerId === authorId);
 
-/** The sandbox columns plus the `post_record`-only `is_draft` marker. */
 export interface PostVisibleColumns extends SandboxColumns {
 	readonly isDraft: SQLWrapper;
 }
 
 /**
- * The SQL draft arm — the `is_draft` half of {@link postVisibleTo}. `is_draft IS NOT 1`
- * (not `= 0`) is the null-safe "not a draft" test: published rows store `is_draft` as
- * NULL (the taslak marker is nullable, no default), so `= 0` would wrongly exclude every
- * published post — `IS NOT 1` is the exact form the pre-seam public feed already used
- * (post-operations.ts, #746), keeping behavior unchanged. No moderator branch (ADR 0113).
- *
- * - anonymous (`viewerId === null`) → `is_draft IS NOT 1`
- * - signed-in → `is_draft IS NOT 1 OR author_id = :viewerId`
+ * `is_draft IS NOT 1` (not `= 0`) is the null-safe "not a draft" test: published rows
+ * store `is_draft` as NULL, so `= 0` would wrongly exclude every published post (#746).
+ * No moderator branch (ADR 0113).
  */
 const draftArm = (cols: PostVisibleColumns, viewer: SandboxViewer): SQL | undefined => {
 	const notDraft = sql`${cols.isDraft} is not 1`;
@@ -69,25 +42,21 @@ const draftArm = (cols: PostVisibleColumns, viewer: SandboxViewer): SQL | undefi
 };
 
 /**
- * The per-row SQL mirror of {@link postVisibleTo}: {@link sandboxVisibleWhere} `and()`'d
- * with the draft arm. Carries no `removed_at IS NULL` guard — the caller keeps its own
- * beside this (like `sandboxVisibleWhere`), or routes through {@link publicLivePostWhere}.
+ * The SQL mirror of {@link postVisibleTo}. Carries no `removed_at IS NULL` guard — the
+ * caller keeps its own beside this, or routes through {@link publicLivePostWhere}.
  */
 export const postVisibleWhere = (
 	cols: PostVisibleColumns,
 	viewer: SandboxViewer,
 ): SQL | undefined => and(sandboxVisibleWhere(cols, viewer), draftArm(cols, viewer));
 
-/** The public-live aggregate columns plus the `post_record`-only `is_draft` marker. */
 export interface PublicLivePostColumns extends PublicLiveColumns {
 	readonly isDraft: SQLWrapper;
 }
 
 /**
- * The post-aware public-live aggregate (#1407 seam): {@link publicLiveWhere} (removed +
- * sandbox) `and()`'d with the draft arm — the single predicate a post landing-count path
- * folds its hand-written `removed_at IS NULL AND sandboxed_at IS NULL AND is_draft IS NOT 1`
- * re-derivation onto. For an anonymous viewer it reduces to exactly that conjunction.
+ * The one predicate a post landing-count path folds its hand-written
+ * removed/sandboxed/draft re-derivation onto (#1407).
  */
 export const publicLivePostWhere = (
 	cols: PublicLivePostColumns,

--- a/apps/web/worker/features/pano/PostVisibility.unit.test.ts
+++ b/apps/web/worker/features/pano/PostVisibility.unit.test.ts
@@ -1,13 +1,10 @@
 /**
- * The pano post-visibility matrix (ADR 0113) — the seam test that lets the Phase-3
- * per-surface predicates be deleted on migration without each re-testing the rule.
- * Asserts `postVisibleTo` over the full cross-product the acceptance criteria name:
- * four content states {Live, Sandboxed, Removed, Draft-private-to-author} × four viewer
- * kinds {anonymous, author, other-member, moderator}.
+ * The pano post-visibility matrix (ADR 0113) — the seam test that lets the per-surface
+ * predicates be deleted on migration without each re-testing the rule.
  *
  * The load-bearing cell that distinguishes draft from sandbox: a moderator sees a
- * Sandboxed post (sandbox review) but NOT a Draft — an unpublished draft is author-only
- * with no moderator exemption. The matrix pins both.
+ * Sandboxed post but NOT a Draft — an unpublished draft is author-only with no moderator
+ * exemption.
  */
 import {assert, describe, it} from "@effect/vitest";
 import * as L from "../lifecycle/EntityLifecycle.ts";
@@ -33,8 +30,7 @@ const viewers = {
 	moderator: {viewerId: "a-mod", canSeeSandboxed: true},
 } satisfies Record<string, L.SandboxViewer>;
 
-// Each cell is the expected `postVisibleTo(state.lifecycle, state.isDraft, AUTHOR, viewer)`
-// — content authored by AUTHOR, viewed by each viewer kind.
+// Content is always authored by AUTHOR; each cell is the expectation per viewer kind.
 const matrix: Record<
 	string,
 	{lifecycle: L.EntityLifecycle; isDraft: boolean; expect: Record<keyof typeof viewers, boolean>}
@@ -47,7 +43,6 @@ const matrix: Record<
 	Sandboxed: {
 		lifecycle: sandboxed,
 		isDraft: false,
-		// author + moderator (sandbox review); hidden from anonymous + other members.
 		expect: {anonymous: false, author: true, otherMember: false, moderator: true},
 	},
 	Removed: {
@@ -58,7 +53,7 @@ const matrix: Record<
 	DraftPrivateToAuthor: {
 		lifecycle: live,
 		isDraft: true,
-		// author ONLY — NO moderator exemption (the cell that separates draft from sandbox).
+		// Author ONLY — no moderator exemption; this is the cell separating draft from sandbox.
 		expect: {anonymous: false, author: true, otherMember: false, moderator: false},
 	},
 };
@@ -88,8 +83,8 @@ describe("postVisibleWhere — the SQL mirror's predicate shape", () => {
 	const cols = {sandboxedAt: {} as never, authorId: {} as never, isDraft: {} as never};
 
 	it("a moderator still gets a restricting predicate (drafts gated even for mods)", () => {
-		// sandbox arm is undefined for a mod, but the draft arm is not — so the
-		// composition is defined, proving mods do not see drafts via this seam.
+		// The sandbox arm is undefined for a mod but the draft arm is not, so a defined
+		// composition proves mods do not see drafts via this seam.
 		assert.isDefined(postVisibleWhere(cols, viewers.moderator));
 	});
 

--- a/apps/web/worker/features/pano/base-feed-route.ts
+++ b/apps/web/worker/features/pano/base-feed-route.ts
@@ -1,25 +1,14 @@
 /**
- * `GET /fate/pano/feed?sort=…&host=…&first=…&after=…` (#2322, epic #2316 leg B) —
- * the GET-able **base feed**: the pano feed connection served WITHOUT the per-viewer
- * scalar stamp, so its bytes are identical for anon and every signed-in viewer and it
- * can sit behind an edge cache (#2324). `sort` / `host` / pagination ride the URL (the
- * cache key falls out of path+query, per the leg-B spike #2320), so each subfeed
- * variant is its own entry. A raw `HttpRouter.add` route (like `rssRoute` /
- * `linkMetadataRoute`) reaching `Pano` through the runtime-derived context layer. See
- * `.patterns/alchemy-http-router.md`.
+ * The GET-able base pano feed (#2322): the feed connection served WITHOUT the
+ * per-viewer scalar stamp, so its bytes are identical for anon and every signed-in
+ * viewer and it can sit behind an edge cache. Sort, host and pagination ride the URL,
+ * so the cache key falls out of path+query and each subfeed variant is its own entry.
+ * See .patterns/alchemy-http-router.md.
  *
- * One load-bearing property this route exists to hold:
- *   - **No session validation, no per-viewer work.** It never validates a session and
- *     never reads `CurrentUser`; it reads the ANONYMOUS sandbox viewer, so an anon GET
- *     pays nothing for identity. The per-viewer `myVote`/`isSaved` arrive via the
- *     separate authed `PostOverlay` read on `POST /fate` (ADR 0169 untouched — nothing
- *     session-derived becomes cacheable).
- *
- * Edge-cache headers (leg B, #2324, ADR 0170): the 200 carries `Cache-Control` (the TTL
- * backstop) + `Cache-Tag: pano-feed`, so the per-Worker edge cache serves repeat anon GETs
- * without re-running the D1 read; the fanned-mutation seam purges the tag on a feed-visible
- * write. The purge lives at the mutation seam (`feed-cache.ts`), NOT here — this route only
- * stamps the cache metadata.
+ * The load-bearing property: it never validates a session and never reads
+ * `CurrentUser`, so nothing session-derived can become cacheable (ADR 0169). The
+ * per-viewer scalars arrive through the separate authed read on `POST /fate`. The
+ * cache-tag purge lives at the mutation seam in `feed-cache.ts`, not here.
  */
 import * as Cloudflare from "alchemy/Cloudflare";
 import * as Effect from "effect/Effect";
@@ -32,7 +21,7 @@ import {baseFeedCacheControl, PANO_FEED_CACHE_TAG} from "./feed-cache.ts";
 import {Pano, type PostSummaryRow} from "./Pano.ts";
 import {type BasePost, toBasePost} from "./shapers.ts";
 
-/** The base-feed page size, matching the `posts` list resolver's default. */
+// Matches the `posts` list resolver's default.
 const DEFAULT_FIRST = 20;
 
 export const handleBaseFeed = Effect.gen(function* () {
@@ -52,9 +41,8 @@ export const handleBaseFeed = Effect.gen(function* () {
 		first: Number.isNaN(first) ? DEFAULT_FIRST : first,
 		...(after !== null ? {after} : {}),
 		...(host !== null && host.length > 0 ? {host} : {}),
-		// The anonymous sandbox viewer: viewer-invariant + no moderator probe, so the
-		// base bytes never depend on who asked (a çaylak's sandboxed post is filtered out
-		// for everyone, exactly as the public `landingPosts` column already reads).
+		// Viewer-invariant and no moderator probe, so the base bytes never depend on who
+		// asked: a sandboxed post is filtered out for everyone.
 		sandboxViewer: anonymousViewer,
 	});
 
@@ -63,8 +51,8 @@ export const handleBaseFeed = Effect.gen(function* () {
 		(row) => row.id,
 		(row) => toBasePost(row),
 	);
-	// The per-Worker edge cache serves repeat anon GETs off these; the fanned-mutation seam
-	// purges `Cache-Tag: pano-feed` on a feed-visible write (ADR 0170).
+	// The per-Worker edge cache serves repeat anon GETs off these headers; the
+	// fanned-mutation seam purges the tag on a feed-visible write (ADR 0170).
 	return HttpServerResponse.jsonUnsafe(connection, {
 		headers: {"cache-control": baseFeedCacheControl, "cache-tag": PANO_FEED_CACHE_TAG},
 	});

--- a/apps/web/worker/features/pano/base-post.unit.test.ts
+++ b/apps/web/worker/features/pano/base-post.unit.test.ts
@@ -1,11 +1,8 @@
 /**
- * `toBasePost` — the viewer-invariant base projection (#2322, epic #2316 leg B): the
- * wire `Post` MINUS the two viewer scalars (`myVote`/`isSaved`). Pure shaping, so it is
- * unit-reachable (no DB). The load-bearing AC is byte-identity: because the base strips
- * the only viewer-derived fields, its output is the SAME for any viewer-scalar input —
- * which is exactly what makes the GET-able base feed cacheable and identical for anon vs
- * signed-in. Proven here at the shaper (the route serializes this verbatim), with the
- * anon-vs-authed round-trip left to the integration tier.
+ * `toBasePost` is the wire `Post` minus the two viewer scalars (#2322). The
+ * load-bearing property is byte-identity: stripping the only viewer-derived fields
+ * makes the output the same for any viewer-scalar input, which is what makes the
+ * GET-able base feed cacheable. The anon-vs-authed round-trip is integration's job.
  */
 import {assert, describe, it} from "@effect/vitest";
 import type {PostFields} from "./post-fields.ts";
@@ -44,8 +41,7 @@ describe("toBasePost — viewer-invariant base projection (#2322)", () => {
 	});
 
 	it("is byte-identical regardless of the viewer scalar input (the cacheable-base guarantee)", () => {
-		// The same post as it would be stamped for a voter, for a non-voter, and unstamped:
-		// the base projection collapses all three to ONE serialization.
+		// The base projection must collapse all three stampings to one serialization.
 		const voter = toBasePost(baseFields({myVote: true, isSaved: true}));
 		const nonVoter = toBasePost(baseFields({myVote: false, isSaved: false}));
 		const anon = toBasePost(baseFields({myVote: null, isSaved: null}));

--- a/apps/web/worker/features/pano/comment-count-sandbox-gate.unit.test.ts
+++ b/apps/web/worker/features/pano/comment-count-sandbox-gate.unit.test.ts
@@ -1,21 +1,12 @@
 /**
- * The public `commentCount` bookkeeping is sandbox-symmetric across create AND
- * delete (#1831). `addComment` gates its `+1` on `sandboxedAt` (a sandboxed çaylak
- * comment (#1205) never bumps the PUBLIC count), but `deleteComment` used to
- * decrement `-1` UNCONDITIONALLY — so deleting a sandboxed comment that was never
- * counted at create drove the public count BELOW the true public total, compounding
- * per deletion (floored at 0 by `Math.max`).
+ * The public `commentCount` must be sandbox-symmetric across create AND delete
+ * (#1831): a sandboxed comment never bumps `+1` at create, so its delete must not
+ * decrement `-1`, or the public count drifts below truth, compounding per deletion.
  *
- * The fix mirrors the create-gate on the delete path: the decrement fires only when
- * the deleted comment was NOT sandboxed. This file proves the SERVICE-level count
- * arithmetic directly by driving `addComment`/`deleteComment` (from
- * `makeCommentOperations`) over a recording fake `db` that captures the
- * `post_record.comment_count` each write persists — the sandbox-gated integration
- * suites can't seed a sandboxed comment (the `sandboxedAt` stamp is resolver-decided
- * from the authorship flag, dark today), so the symmetry is asserted at this tier.
- *
- * COUNT-accuracy only: the sandbox boundary itself (containment/visibility) is
- * unchanged and proven elsewhere (#1811, `../flagship/sandbox-restore-escape.invariant.test.ts`).
+ * Asserted at the unit tier over a recording fake `db` because the integration suites
+ * cannot seed a sandboxed comment — the `sandboxedAt` stamp is resolver-decided from
+ * the authorship flag, dark today. Count accuracy only; the sandbox boundary itself is
+ * proven in `../flagship/sandbox-restore-escape.invariant.test.ts`.
  */
 import {assert, describe, it} from "@effect/vitest";
 import {Effect} from "effect";
@@ -70,10 +61,7 @@ const commentRow = (over: Partial<CommentRow> = {}): CommentRow => ({
 	...over,
 });
 
-// A recording fake `db`: the four chained shapes `deleteComment` reaches, each
-// returning scripted data and capturing the `post_record` count the update
-// persists. `commentCount` starts at `startCount`; the captured value is the last
-// `.set()` written to `postRecord`.
+// The captured value is the last `.set()` written to `postRecord`.
 const fakeDb = (opts: {comment: CommentRow; startCount: number; childCount?: number}) => {
 	const captured: {postCommentCount: number | null} = {postCommentCount: null};
 	const post = {id: POST_ID, commentCount: opts.startCount, score: 0, createdAt: NOW};
@@ -98,9 +86,6 @@ const fakeDb = (opts: {comment: CommentRow; startCount: number; childCount?: num
 	return {db, captured};
 };
 
-// `deleteComment` reaches only `removalSeq.clearTarget` + `removalSeq.run` (the
-// comment removal stamp) — both inert here; the count write happens at the call
-// site over the fake `db.update(postRecord)`, which we capture instead.
 const inertRemovalSeq: Removal.RemovalSequence = {
 	run: () => Effect.succeed(undefined as never),
 	batch: () => Effect.succeed(undefined as never),
@@ -113,8 +98,8 @@ const deps = (run: DrizzleAccessOrDie["run"]): CommentOperationsDeps => ({
 	reactionSvc: {} as typeof Reaction.Service,
 	removalSeq: inertRemovalSeq,
 	persistPanoStats: () => Effect.void,
-	// The delete path never re-resolves live author identity (it stamps a count, not a
-	// read row), so a fail-on-contact reader proves that: reaching it fails the test.
+	// Fail-on-contact: the delete path stamps a count, never re-resolves author identity,
+	// so reaching this reader must fail the test.
 	readProfileIdentities: () =>
 		Effect.die(new Error("comment delete-count path must not read author identity")),
 });
@@ -191,8 +176,6 @@ describe("commentCount is sandbox-symmetric across create/delete (#1831)", () =>
 		}),
 	);
 
-	// The create side of the symmetry: addComment is already sandbox-gated (#1205);
-	// pinning it here keeps the create/delete mirror visible in one file.
 	it.effect("adding a SANDBOXED comment does not bump the public count (+0)", () =>
 		Effect.gen(function* () {
 			const {db, captured} = fakeDb({comment: commentRow(), startCount: 5});
@@ -225,8 +208,7 @@ describe("commentCount is sandbox-symmetric across create/delete (#1831)", () =>
 });
 
 // A removed row as it sits after a mod-remove: the ADR 0096 triad stamped, plus the
-// preserved pre-removal `sandboxedAt` marker (null if it was live). `Removal.fromColumns`
-// projects this to `Removed`, and `Removal.restore` round-trips the marker back.
+// preserved pre-removal `sandboxedAt` marker (null if it was live).
 const removedRow = (sandboxedAt: Date | null): CommentRow =>
 	commentRow({
 		removedAt: NOW,
@@ -237,11 +219,8 @@ const removedRow = (sandboxedAt: Date | null): CommentRow =>
 		sandboxedAt,
 	});
 
-// The MODERATOR remove/restore pair is sandbox-gated on the same arithmetic as the author
-// paths (#1835): a mod path that touches a SANDBOXED comment — a public count that never
-// counted it — must not drift the public `comment_count`. The pair is internally symmetric
-// (`-1`/`+1`), so the drift only appears against a sandboxed comment or across a now-gated
-// author path (mod-remove sandboxed `-0` then author-restore `+0`).
+// The mod pair is internally symmetric (`-1`/`+1`), so drift only shows against a
+// sandboxed comment or across a now-gated author path — hence the cross-path case.
 describe("commentCount is sandbox-gated across the MODERATOR remove/restore pair (#1835)", () => {
 	it.effect("mod-removing a SANDBOXED comment leaves the public count unchanged (-0, not -1)", () =>
 		Effect.gen(function* () {
@@ -301,7 +280,6 @@ describe("commentCount is sandbox-gated across the MODERATOR remove/restore pair
 
 	it.effect("a sandboxed mod-remove → mod-restore round-trip nets zero (never drifts)", () =>
 		Effect.gen(function* () {
-			// mod-remove of the sandboxed live comment: -0
 			const remove = fakeDb({comment: commentRow({sandboxedAt: NOW}), startCount: 5});
 			const opsRemove = makeCommentOperations(deps(runOverDb(remove.db)));
 			yield* opsRemove.moderateRemoveComment({
@@ -311,7 +289,6 @@ describe("commentCount is sandbox-gated across the MODERATOR remove/restore pair
 			});
 			assert.strictEqual(remove.captured.postCommentCount, 5, "mod-remove of sandboxed is -0");
 
-			// mod-restore of the now removed-AND-sandboxed row: +0 — the public count is back where it started
 			const restore = fakeDb({comment: removedRow(NOW), startCount: 5});
 			const opsRestore = makeCommentOperations(deps(runOverDb(restore.db)));
 			yield* opsRestore.moderateRestoreComment({commentId: "comm_1"});
@@ -327,7 +304,6 @@ describe("commentCount is sandbox-gated across the MODERATOR remove/restore pair
 		"cross-path: mod-remove SANDBOXED (-0) then author restoreComment (+0) never drifts",
 		() =>
 			Effect.gen(function* () {
-				// mod-remove of a sandboxed comment: -0 (the ungated bug would have made this -1)
 				const remove = fakeDb({comment: commentRow({sandboxedAt: NOW}), startCount: 5});
 				const opsRemove = makeCommentOperations(deps(runOverDb(remove.db)));
 				yield* opsRemove.moderateRemoveComment({
@@ -337,7 +313,6 @@ describe("commentCount is sandbox-gated across the MODERATOR remove/restore pair
 				});
 				assert.strictEqual(remove.captured.postCommentCount, 5, "mod-remove of sandboxed is -0");
 
-				// author restoreComment of the removed-AND-sandboxed row: +0 (author-gated, #1811)
 				const restore = fakeDb({comment: removedRow(NOW), startCount: 5});
 				const opsRestore = makeCommentOperations(deps(runOverDb(restore.db)));
 				yield* opsRestore.restoreComment({
@@ -353,10 +328,8 @@ describe("commentCount is sandbox-gated across the MODERATOR remove/restore pair
 	);
 });
 
-// The author `restoreComment` +1 (live) branch — the last arithmetic branch not asserted
-// directly (its +0 sandboxed arm is covered by the cross-path test above, #1811). Pins the
-// non-sandboxed restore to +1 so the shared delta rule (`nextCommentCount`) stays honest on
-// the create-mirror arm for the author path too.
+// The last arithmetic branch not asserted directly; its +0 sandboxed arm is covered by
+// the cross-path test above.
 describe("commentCount is sandbox-gated on the author restoreComment path (#1811)", () => {
 	it.effect("author-restoring a NON-sandboxed comment bumps the public count by one (+1)", () =>
 		Effect.gen(function* () {

--- a/apps/web/worker/features/pano/comment-fields.ts
+++ b/apps/web/worker/features/pano/comment-fields.ts
@@ -1,34 +1,18 @@
 /**
- * `Comment`'s one column→field map — the single structure the row mapper
- * (`toCommentRow` / `rowToCommentRow` in `Pano.ts`), the wire shaper (`toComment`
- * in `shapers.ts`), and the view field declaration (`CommentView` in `views.ts`)
- * all derive from, so a one-field change touches this map instead of three
- * hand-synced restatements (#1166, the Pano half of #1126 AC#1).
+ * `Comment`'s one column→field map — the single structure the row mapper (`toCommentRow` /
+ * `rowToCommentRow` in `Pano.ts`), the wire shaper (`toComment` in `shapers.ts`) and the view
+ * field declaration (`CommentView` in `views.ts`) all derive from, instead of three hand-synced
+ * restatements (#1166).
  *
- * The map absorbs the per-source naming divergence: the DB record calls the
- * author `authorName` and may leave the timestamps null, while the wire field is
- * `author` / a non-null `Date`. Each intrinsic reader maps a `comment_record` row
- * onto its wire value, so the divergence lives in the map, not at every call site.
- *
- * The `Removed` tombstone (`[silindi]` placeholder, author elided — ADR 0096 §5)
- * is a presentation override the map does NOT carry: `rowToCommentRow` runs this
- * map for the live shape, then substitutes the tombstone fields. `myVote` is the
- * viewer scalar — part of the view/wire field set (`commentViewFields`) but *not*
- * read from the record here: it is stamped by `stampViewerScalars` after the
- * batched `user_vote` read (#1159, `viewer-scalars.ts`).
+ * The map absorbs the per-source naming divergence (`authorName`→`author`, nullable timestamps).
+ * It does NOT carry the `Removed` tombstone override (ADR 0096 §5) or the viewer scalars — those
+ * are stamped by the callers after their batched reads.
  */
 import type * as schema from "../../db/drizzle/schema.ts";
 import type {ReactionAggregate} from "../reaction/Reaction.ts";
 
 type CommentRecord = typeof schema.commentRecord.$inferSelect;
 
-/**
- * The intrinsic (record-derived) wire fields, in `CommentView` order, each
- * mapping a `comment_record` row onto its live wire value. The keys ARE the wire
- * field names; the readers absorb the `authorName`→`author` + null-timestamp
- * divergence. `deletedAt` is the removal timestamp (`null` for a live comment);
- * the tombstone override in `rowToCommentRow` supplies it for a `Removed` row.
- */
 const intrinsicFields = {
 	id: (c) => c.id,
 	parentId: (c) => c.parentId,
@@ -44,45 +28,30 @@ const intrinsicFields = {
 type IntrinsicRow = {[K in keyof typeof intrinsicFields]: ReturnType<(typeof intrinsicFields)[K]>};
 
 /**
- * `CommentRow` — the record-derived row the comment reads share, plus the
- * `myVote` viewer scalar that `stampViewerScalars` adds downstream (`null` for an
- * anonymous viewer; `undefined` when not requested — never read from the record).
+ * `myVote` is `null` for an anonymous viewer and `undefined` when the read didn't request it —
+ * never read from the record; `stampViewerScalars` adds it downstream.
  */
 export interface CommentRow extends IntrinsicRow {
 	myVote?: boolean | null;
 	/**
-	 * The owner-scoped in-review flag (#4282, the `Comment` leg of #2200) — the twin of
-	 * `PostSummaryRow.sandboxed`: stamped by the read paths via `ownSandboxed`, so it is
-	 * `true` only for the author's own still-sandboxed comment. `undefined` when a read
-	 * doesn't stamp it; the shaper then defaults `false`.
+	 * The owner-scoped in-review flag (#4282): stamped via `ownSandboxed`, so it is `true` only
+	 * for the author's OWN still-sandboxed comment. `undefined` when unstamped; shaper defaults false.
 	 */
 	sandboxed?: boolean;
 	/**
-	 * The author's LIVE handle (`user_profile.username` / `.displayName`), stamped by
-	 * `stampAuthorIdentity` after the batched `getProfileIdentitiesByIds` read (#2139)
-	 * so the client renders the CURRENT display name via `actorLabel`, not the write-time
-	 * `authorName` snapshot (#2126's AC). `undefined` when not requested; `null` when the
-	 * author has no profile/handle (or the `Removed` tombstone blanked `authorId`) —
-	 * `actorLabel` then degrades to `@username` → fallback.
+	 * The author's LIVE handle, stamped by `stampAuthorIdentity` (#2139) so the client renders the
+	 * CURRENT display name, not the write-time `authorName` snapshot. `null` when the author has no
+	 * profile/handle (or the tombstone blanked `authorId`).
 	 */
 	authorUsername?: string | null;
 	authorDisplayName?: string | null;
-	/**
-	 * The reaction aggregate (per-emoji counts + the viewer's own reaction), stamped
-	 * by `stampReactionAggregate` after the batched `user_reaction` read (#1862) —
-	 * `undefined` when not requested; the shaper fills the empty aggregate.
-	 */
+	/** Per-emoji counts + the viewer's own reaction (#1862); the shaper fills the empty aggregate. */
 	reactions?: ReactionAggregate;
 }
 
 /**
- * `CommentFields` — the wire shaper's input (`toComment` in `shapers.ts`): the
- * intrinsic wire-named fields derived from this one column→field map so the wire
- * shaper's field set can't drift from the row mapper / `commentViewFields` (the third
- * hand-synced restatement #1126 AC#1 collapses). A fresh write/vote carries no
- * `updatedAt`, and `deletedAt` / `myVote` are stamped at the call site (the tombstone
- * override + the viewer scalar), so those ride as optional — the map stays the single
- * source for the field set.
+ * The wire shaper's input, derived from the same map so its field set can't drift. `updatedAt`,
+ * `deletedAt` and `myVote` ride optional because they are stamped at the call site.
  */
 export type CommentFields = Omit<IntrinsicRow, "updatedAt" | "deletedAt"> & {
 	updatedAt?: Date | null;
@@ -102,12 +71,8 @@ export interface CommentConnectionPage {
 }
 
 /**
- * The view/wire field selection (`{id: true, …}`) — a static literal (fate's
- * `FateDataView` reads the literal field map off this, so it can't be a
- * dynamically-built object). `satisfies Record<keyof CommentRow, true>` pins it
- * to exactly the row's fields: dropping a field here (or adding one to
- * `CommentRow` without listing it here) is a compile error, so the view stays in
- * lockstep with the row mapper.
+ * A static literal, not a built object: fate's `FateDataView` reads the literal field map off
+ * this. `satisfies Record<keyof CommentRow, true>` makes a missing field a compile error.
  */
 export const commentViewFields = {
 	id: true,
@@ -126,12 +91,6 @@ export const commentViewFields = {
 	reactions: true,
 } as const satisfies Record<keyof CommentRow, true>;
 
-/**
- * Map a live `comment_record` row onto its intrinsic `CommentRow` fields by
- * running every reader in the column→field map — the single place the live
- * record→row mapping lives. The `Removed` tombstone override and `myVote` viewer
- * scalar are applied by the callers in `Pano.ts`, not here.
- */
 export const toCommentRow = (c: CommentRecord): IntrinsicRow =>
 	Object.fromEntries(
 		(Object.keys(intrinsicFields) as Array<keyof typeof intrinsicFields>).map((f) => [

--- a/apps/web/worker/features/pano/comment-operations.ts
+++ b/apps/web/worker/features/pano/comment-operations.ts
@@ -1,14 +1,8 @@
 /**
- * Pano's **comments plane** — the comment half of the `Pano` service: the threaded
- * comment CRUD, vote delegation, the moderator soft-delete/restore pair, and the
- * keyset/by-id reads (with the `[silindi]` tombstone projection). `makeCommentOperations`
- * is the layer-build factory: `PanoLive` hands it the shared runtime deps and spreads
- * the returned closures into the service object, so the wire surface is unchanged from
- * when these lived inline in `Pano.ts`.
- *
- * Validation lives in the service methods, not resolvers (ADR 0013); `validateCommentBody`
- * is the module-private pure gate, tested off-DB THROUGH `addComment`/`editComment`
- * (`submit-validation.unit.test.ts`).
+ * Pano's comments plane: threaded comment CRUD, vote/reaction delegation, the moderator
+ * soft-delete/restore pair, and the keyset/by-id reads. `makeCommentOperations` is the
+ * layer-build factory `PanoLive` spreads into the service object. Validation lives in
+ * the service methods, not resolvers (ADR 0013).
  */
 import {id} from "@usirin/forge";
 import {and, desc, eq, inArray, isNull, sql} from "drizzle-orm";
@@ -56,11 +50,8 @@ import type {PersistPanoStats} from "./pano-stats.ts";
 
 export const COMMENT_BODY_MAX = 5_000;
 
-/**
- * Tombstone body the view layer renders for a `Removed` comment (ADR 0096 §5) —
- * not a body the delete path writes. The canonical body stays in the row for
- * restore + moderator review; `rowToCommentRow` substitutes this for display.
- */
+// Rendered for a `Removed` comment; never written by the delete path. The canonical
+// body stays in the row for restore + moderator review (ADR 0096 §5).
 export const SILINDI_PLACEHOLDER = "[silindi]";
 
 export interface AddCommentInput {
@@ -69,10 +60,8 @@ export interface AddCommentInput {
 	authorName: string;
 	body: string;
 	parentId?: CommentId | null | undefined;
-	/**
-	 * The çaylak mod-only sandbox stamp (#1205), decided by the resolver from the
-	 * authorship flag + author tier. `null`/absent ⇒ created live (today's behavior).
-	 */
+	// The çaylak mod-only sandbox stamp, decided by the resolver from the authorship flag +
+	// author tier. `null`/absent ⇒ created live.
 	sandboxedAt?: Date | null | undefined;
 }
 
@@ -86,17 +75,10 @@ export interface AddCommentResult {
 	score: number;
 	commentCount: number;
 	createdAt: Date;
-	/**
-	 * The post author — the recipient of a "someone replied to your post" moment
-	 * (#1697). Carried on the result so the resolver can emit the conversation
-	 * notification without re-reading the post.
-	 */
+	// Carried so the resolver can emit the reply notification without re-reading the post.
 	postAuthorId: string;
-	/**
-	 * The parent-comment author for a threaded reply, or `null` for a top-level
-	 * comment — the recipient of a "someone replied to your comment" moment
-	 * (#1697), resolved off the parent row already loaded for the existence check.
-	 */
+	// `null` for a top-level comment; resolved off the parent row already loaded for the
+	// existence check.
 	parentAuthorId: string | null;
 }
 
@@ -121,21 +103,11 @@ export interface VoteOnCommentResult {
 export interface ReactToCommentInput {
 	commentId: CommentId;
 	userId: UserId;
-	/**
-	 * The reaction intent: a curated-palette member sets/changes the user's single
-	 * reaction; `null` retracts it (toggle off). Already decoded against
-	 * `ReactionEmojiSchema` at the wire boundary, so the service never sees a
-	 * non-palette string.
-	 */
+	// `null` retracts (toggle off). Already decoded against `ReactionEmojiSchema` at the
+	// wire boundary, so the service never sees a non-palette string.
 	emoji: ReactionEmoji | null;
 }
 
-/**
- * `reactToComment` re-resolves the affected comment like a read (the `getCommentsByIds`
- * idiom), so the returned row carries the freshly-stamped `reactions` aggregate the
- * mutation echoes back. `changed` is the service's idempotency signal (a re-react of
- * the same emoji, or a retract-when-none, is `false`).
- */
 export interface ReactToCommentResult {
 	comment: CommentRow;
 	changed: boolean;
@@ -162,7 +134,7 @@ export interface EditCommentResult {
 export interface DeleteCommentInput {
 	commentId: CommentId;
 	actorId: UserId;
-	/** Why the comment is removed (ADR 0096). Defaults to `AuthorDeletion`. */
+	// Defaults to `AuthorDeletion`.
 	reason?: Removal.RemovalReason;
 }
 
@@ -171,12 +143,9 @@ export interface DeleteCommentResult {
 	deleted: boolean;
 	hasReplies: boolean;
 	placeholder: CommentRow | null;
-	/**
-	 * On a restore, the `sandboxedAt` the comment landed back at (#1811): `null` ⇒
-	 * restored to `Live` (broadcast `alwaysLive`); non-null ⇒ restored to the çaylak
-	 * sandbox, so the mutation suppresses the live echo via `decidePublish`. Absent on
-	 * a delete result.
-	 */
+	// On a restore, where the comment landed: null ⇒ `Live` (broadcast `alwaysLive`),
+	// non-null ⇒ back in the çaylak sandbox, so the mutation suppresses the live echo.
+	// Absent on a delete result.
 	sandboxedAt?: Date | null;
 }
 
@@ -197,17 +166,9 @@ const validateCommentBody = Effect.fn("Pano.validateCommentBody")(function* (
 	return rawBody;
 });
 
-/**
- * The single source of truth for a post's public `comment_count` after one
- * comment lifecycle step — the delta rule every add / delete / restore /
- * mod-remove / mod-restore path routes through, so the count is derived here
- * once and never re-hand-written per method. A sandboxed çaylak comment (#1205)
- * is never in the public count, so a sandboxed step moves it by 0 — the
- * create-gate the delete path must mirror (#1831/#1811). The `Math.max(0, …)`
- * floor keeps a raced double-remove from driving the public count negative
- * (the #1831 class this rule makes unrepresentable). A create bumps the count
- * the same +1 as a `restore`.
- */
+// The one delta rule every add/delete/restore path routes through. A sandboxed çaylak
+// comment is never in the public count, so a sandboxed step moves it by 0; the
+// `Math.max(0, …)` floor keeps a raced double-remove from driving the count negative.
 export const nextCommentCount = (
 	current: number,
 	sandboxedAt: Date | null,
@@ -217,26 +178,21 @@ export const nextCommentCount = (
 	return Math.max(0, current + step);
 };
 
-/** The shared runtime deps `PanoLive` threads into the comments plane. */
 export interface CommentOperationsDeps {
 	readonly run: DrizzleAccessOrDie["run"];
 	readonly voteSvc: typeof Vote.Service;
 	readonly reactionSvc: typeof Reaction.Service;
 	readonly removalSeq: Removal.RemovalSequence;
 	readonly persistPanoStats: PersistPanoStats;
-	/** Batched live author-identity reader (`Pasaport.getProfileIdentitiesByIds`, #2139). */
 	readonly readProfileIdentities: ReadProfileIdentities;
 }
 
 export const makeCommentOperations = (deps: CommentOperationsDeps) => {
 	const {run, voteSvc, reactionSvc, removalSeq, persistPanoStats, readProfileIdentities} = deps;
 
-	// The parent post's PUBLIC `comment_count` bookkeeping every comment remove/restore
-	// shares — the plane-specific `afterCommit` the four transition methods run after the
-	// substrate write. The delta rule itself lives in `nextCommentCount`; this only loads
-	// the post, applies it, and persists. `hotScore` is an explicit opt-in: only the author
-	// `deleteComment` refreshes it (`recomputeHot`), so the mod + restore arms leave it
-	// untouched — a deliberate per-caller decision, not an incidental divergence.
+	// The delta rule itself lives in `nextCommentCount`; this only loads the post, applies it,
+	// and persists. `hotScore` is an explicit opt-in: only the author `deleteComment`
+	// refreshes it, so the mod + restore arms leave it untouched — deliberate, not drift.
 	const adjustPostCommentCount = (
 		postId: string,
 		sandboxedAt: Date | null,
@@ -264,22 +220,16 @@ export const makeCommentOperations = (deps: CommentOperationsDeps) => {
 			);
 		});
 
-	// `Comment`'s one viewer scalar: `myVote` from the batched `user_vote` presence
-	// read (#1126). Every comment read finalizes through `stampViewerScalars` with
-	// this spec — one `IN (...)` read for the whole batch, never a per-row N+1.
+	// One `IN (...)` read for the whole batch, never a per-row N+1.
 	const commentVoteScalar = {
 		field: "myVote",
 		read: (viewerId: string | null | undefined, ids: ReadonlyArray<string>) =>
 			voteSvc.readMine(viewerId, "comment", ids),
 	} as const;
 
-	// The three independent finalize stamps every comment read shares — `myVote` (viewer
-	// scalar), the reaction aggregate, live author identity — each independent given the
-	// fetched rows. `parallelStampWave` runs them over the SAME rows and merges; the
+	// `parallelStampWave` runs the three finalize stamps over the SAME rows and merges. The
 	// `parallelStamps` flag picks the concurrency: off ⇒ `1` (serial, byte-for-byte today),
-	// on ⇒ `"unbounded"` (one wave, the #2710 collapse). The reaction stamp's own two D1
-	// reads inherit the same knob so the whole wave is one phase when on. Mirrors sözlük's
-	// `stampDefinitions` (#2709), reusing the same combinator behind pano's own seam.
+	// on ⇒ `"unbounded"`. The reaction stamp's own two D1 reads inherit the same knob.
 	const stampComments = <R extends {id: string; authorId: string}>(
 		rows: ReadonlyArray<R>,
 		viewerId: string | null,
@@ -297,17 +247,12 @@ export const makeCommentOperations = (deps: CommentOperationsDeps) => {
 		);
 	};
 
-	// The tombstone is rendered HERE, from the lifecycle projection — not written
-	// into the canonical body by the delete path (ADR 0096 §5). A `Removed`
-	// comment surfaces as the `[silindi]` placeholder with author elided; its real
-	// body stays in the row for restore + moderator review. `deletedAt` on the
-	// wire-facing `CommentRow` is the removal timestamp (presentation contract).
-	// The live shape comes from the `comment-fields.ts` column→field map; the
-	// tombstone overrides the four presentation fields it elides.
-	// `viewerId` is a REQUIRED parameter, not an optional with a default: `sandboxed` is
-	// owner-scoped, so every call site must state whose view it is shaping. A viewer-blind
-	// call site (the moderator queue, a broadcast payload) passes `null` deliberately and
-	// gets `false` — the one safe answer for a row that may reach a non-author (#4282).
+	// The tombstone is rendered HERE, from the lifecycle projection — never written into the
+	// canonical body by the delete path (ADR 0096 §5).
+	// `viewerId` is REQUIRED, not optional-with-a-default: `sandboxed` is owner-scoped, so
+	// every call site must state whose view it is shaping. A viewer-blind call site (the
+	// moderator queue, a broadcast payload) passes `null` and gets `false` — the one safe
+	// answer for a row that may reach a non-author (#4282).
 	const rowToCommentRow = (
 		row: typeof schema.commentRecord.$inferSelect,
 		viewerId: string | null,
@@ -335,12 +280,8 @@ export const makeCommentOperations = (deps: CommentOperationsDeps) => {
 			viewerId?: string | null | undefined;
 			sandboxViewer?: SandboxViewer | undefined;
 			mutedIds?: ReadonlySet<string> | undefined;
-			/**
-			 * Route the finalize stamps through the concurrent {@link parallelStampWave}
-			 * instead of the serial chain (#2710). Default/off ⇒ the wave runs at
-			 * `concurrency: 1` — byte-for-byte today. The resolver resolves it from the
-			 * default-off `phoenix-pano-stamp-wave` flag.
-			 */
+			// Off ⇒ the wave runs at `concurrency: 1`, byte-for-byte today. Resolved from the
+			// default-off `phoenix-pano-stamp-wave` flag.
 			parallelStamps?: boolean | undefined;
 		} = {},
 	) {
@@ -348,18 +289,13 @@ export const makeCommentOperations = (deps: CommentOperationsDeps) => {
 		const after = opts.after ?? null;
 		const viewerId = opts.viewerId ?? null;
 
-		// A removed comment stays in the thread ONLY to preserve reply structure
-		// (ADR 0096 §5): keep it when it still has a live child (rendered as the
-		// `[silindi]` tombstone by `rowToCommentRow`), otherwise omit it. A live
-		// comment is always shown.
+		// A removed comment stays in the thread ONLY to preserve reply structure (ADR 0096
+		// §5): keep it when it still has a live child, otherwise omit it.
 		const visible = sql`(${schema.commentRecord.removedAt} IS NULL OR EXISTS (SELECT 1 FROM ${schema.commentRecord} AS child WHERE child.parent_id = ${schema.commentRecord.id} AND child.removed_at IS NULL))`;
-		// A çaylak-sandboxed comment (#1205) is filtered for this viewer beside the
-		// removal/reply-structure guard above.
 		const sandboxClause = sandboxVisibleWhere(
 			{sandboxedAt: schema.commentRecord.sandboxedAt, authorId: schema.commentRecord.authorId},
 			resolveSandboxViewer(opts),
 		);
-		// Mute read-mask (#3113): hide muted authors' comments from the muter's thread.
 		const muteClause = mutedAuthorsWhere(schema.commentRecord.authorId, opts.mutedIds);
 		const baseWhere = and(
 			eq(schema.commentRecord.postId, postId),
@@ -376,11 +312,9 @@ export const makeCommentOperations = (deps: CommentOperationsDeps) => {
 				.then((r) => r?.n ?? 0),
 		);
 
-		// Resolve the (created_at) cursor tuple. The DB read is the port;
-		// `resolveCursor` is the pure cursor-miss decision (see `listPostsConnection`).
-		// The anchor lookup carries `visible`, so an invisible row (a removed leaf with
-		// no live child) is no anchor at all — resolving to null → miss → empty page,
-		// exactly as the old hard-delete made the cursor row vanish (ADR 0096 §5).
+		// The anchor lookup carries `visible`, so an invisible row (a removed leaf with no live
+		// child) is no anchor at all — resolving to null → miss → empty page, exactly as the old
+		// hard-delete made the cursor row vanish (ADR 0096 §5).
 		const resolvedRow = after
 			? ((yield* run((db) =>
 					db
@@ -396,9 +330,6 @@ export const makeCommentOperations = (deps: CommentOperationsDeps) => {
 		}
 		const cursorRow = cursor.kind === "hit" ? cursor.row : null;
 
-		// The predicate and `orderBy` derive from `COMMENT_ORDERING`; the `id`
-		// cursor value is the opaque `after` (the resolved row carries only
-		// `createdAt`).
 		const cursorPredicate = keysetAfter(
 			keysetKeys(COMMENT_ORDERING, (field) =>
 				field === "id" ? after : (cursorRow?.createdAt ?? null),
@@ -451,7 +382,6 @@ export const makeCommentOperations = (deps: CommentOperationsDeps) => {
 							},
 							resolveSandboxViewer(opts),
 						),
-						// Mute read-mask (#3113): drop muted authors' comments from the batch.
 						mutedAuthorsWhere(schema.commentRecord.authorId, opts.mutedIds),
 					),
 				),
@@ -463,10 +393,8 @@ export const makeCommentOperations = (deps: CommentOperationsDeps) => {
 		);
 	});
 
-	// The moderator sandbox-queue / promotion-backlog read model (#1205, the #1206
-	// seam): a çaylak's still-sandboxed, not-removed comments — scoped to one author
-	// when promotion flips their backlog. Authority is gated at the resolver; the
-	// service read is unconditional.
+	// A çaylak's still-sandboxed, not-removed comments, scoped to one author when promotion
+	// flips their backlog. Authority is gated at the resolver; the service read is unconditional.
 	const listSandboxedComments = Effect.fn("Pano.listSandboxedComments")(function* (
 		opts: {authorId?: string | undefined} = {},
 	) {
@@ -486,8 +414,8 @@ export const makeCommentOperations = (deps: CommentOperationsDeps) => {
 				)
 				.orderBy(desc(schema.commentRecord.createdAt)),
 		);
-		// The moderator queue is viewer-blind by construction — it reads OTHER people's
-		// pending comments, so the owner-scoped flag is `false` for every row here.
+		// Viewer-blind by construction — it reads OTHER people's pending comments, so the
+		// owner-scoped flag is `false` for every row here.
 		return fetched.map((row) => rowToCommentRow(row, null));
 	});
 
@@ -555,9 +483,7 @@ export const makeCommentOperations = (deps: CommentOperationsDeps) => {
 			}),
 		);
 
-		// A create bumps the public count the same +1 as a `restore`, gated on the
-		// sandbox by the shared delta rule (a sandboxed çaylak comment (#1205) stays
-		// pending and is recomputed into the count on promotion, #1206).
+		// A create bumps the public count +1, gated on the sandbox by the shared delta rule.
 		const newCommentCount = nextCommentCount(
 			post.commentCount,
 			input.sandboxedAt ?? null,
@@ -680,10 +606,8 @@ export const makeCommentOperations = (deps: CommentOperationsDeps) => {
 		const hasReplies = (childCountRow?.n ?? 0) > 0;
 
 		const now = new Date();
-		// SOFT remove for every comment now (ADR 0096 §1 — no hard delete). The canonical
-		// body is KEPT (the `[silindi]` tombstone is rendered by `rowToCommentRow`, not
-		// written here), so restore + moderator review have the real text. `hasReplies`
-		// only shapes the result placeholder, not the strategy.
+		// SOFT remove for every comment (ADR 0096 §1 — no hard delete): the canonical body is
+		// KEPT so restore + moderator review have the real text.
 		yield* applyRemovalTransition({
 			label: "Pano.deleteComment",
 			transition: "remove",
@@ -818,11 +742,6 @@ export const makeCommentOperations = (deps: CommentOperationsDeps) => {
 		return {restored: true, sandboxedAt: outcome.sandboxedAt};
 	});
 
-	/**
-	 * Shared body for `voteOnComment` / `retractCommentVote`. Delegates to
-	 * `Vote.cast`. Translates `VoteTargetNotFound` from Vote into
-	 * `CommentNotFound`.
-	 */
 	const applyCommentVote = Effect.fn("Pano.applyCommentVote")(function* (
 		input: VoteOnCommentInput,
 		isVote: boolean,
@@ -839,10 +758,8 @@ export const makeCommentOperations = (deps: CommentOperationsDeps) => {
 			});
 		}
 
-		// Self-vote guard (#2216, founder-ruled) — the comment twin of `applyPostVote`'s
-		// guard: a cast on one's OWN comment is rejected at the domain, so an inflated
-		// self-score is unrepresentable rather than caught downstream. Cast-only (a
-		// retraction is exempt because a blocked cast leaves nothing to retract).
+		// Self-vote guard (#2216, founder-ruled): a cast on one's OWN comment is rejected at
+		// the domain. Cast-only — a blocked cast leaves nothing to retract.
 		if (isVote && row.authorId === input.voterId) {
 			return yield* new SelfVoteNotAllowed({
 				voterId: input.voterId,
@@ -889,10 +806,9 @@ export const makeCommentOperations = (deps: CommentOperationsDeps) => {
 	const retractCommentVote = Effect.fn("Pano.retractCommentVote")(function* (
 		input: VoteOnCommentInput,
 	) {
-		// See `retractPostVote`: the tier gate and the self-vote guard both fire on the cast
-		// direction only, so a retraction never raises `VoterNotEligible` /
-		// `SelfVoteNotAllowed` — die if one somehow does, keeping this method's channel to
-		// `CommentNotFound`.
+		// The tier gate and the self-vote guard fire on the cast direction only, so a
+		// retraction never raises them — die if one somehow does, keeping this method's
+		// channel to `CommentNotFound`.
 		return yield* applyCommentVote(input, false).pipe(
 			Effect.catchTags({
 				"vote/VoterNotEligible": (e) => Effect.die(e),
@@ -901,14 +817,8 @@ export const makeCommentOperations = (deps: CommentOperationsDeps) => {
 		);
 	});
 
-	// Reaction delegation — the karma-free, ungated twin of `voteOnComment` (#1864),
-	// the direct mirror of `reactToPost`. Delegates the write to `Reaction.react`
-	// (kind `comment`), translates the internal `ReactionTargetNotFound` into the
-	// wire-facing `CommentNotFound`, then RE-RESOLVES the comment via the same batched
-	// `getCommentsByIds` read the comment views use so the returned row carries the
-	// fresh `reactions` aggregate + `myReaction`. Unlike `voteOnComment` there is NO
-	// tier arm (`VoterNotEligible`) and NO karma path: a çaylak may react, and nothing
-	// writes karma — the settled ungated/social-only model (epic #1840).
+	// The karma-free, ungated twin of `voteOnComment`: no tier arm and no karma path — a
+	// çaylak may react (the settled ungated/social-only model).
 	const reactToComment = Effect.fn("Pano.reactToComment")(function* (input: ReactToCommentInput) {
 		const result = yield* reactionSvc
 			.react({
@@ -928,10 +838,7 @@ export const makeCommentOperations = (deps: CommentOperationsDeps) => {
 				),
 			);
 
-		// Re-resolve like a read so the echoed row carries the freshly-stamped
-		// `reactions` aggregate (counts + the viewer's own `myReaction`). The react
-		// write already asserted the target is live, so a missing row here is a raced
-		// removal — surface it as `CommentNotFound`, same as the post path.
+		// A missing row here is a raced removal — surface it as `CommentNotFound`.
 		const [row] = yield* getCommentsByIds([input.commentId], {viewerId: input.userId});
 		if (!row) {
 			return yield* new CommentNotFound({

--- a/apps/web/worker/features/pano/comment-sandboxed-wire.unit.test.ts
+++ b/apps/web/worker/features/pano/comment-sandboxed-wire.unit.test.ts
@@ -1,22 +1,8 @@
 /**
- * The `Comment` owner-scoped in-review flag on the wire (#4282) — the third leg of
- * #2200, which threaded `sandboxed` onto `Post` and `Definition` and left `Comment`
- * out. Without it a çaylak's own comment renders identically to a published one and
- * they quietly believe they contributed.
- *
- * Three things are pinned here, in the order a value travels:
- *   1. the derivation is the SHARED `ownSandboxed` helper — owner-only by
- *      construction, so no other viewer (member, anonymous, moderator) ever reads
- *      `true` off someone else's comment;
- *   2. the field is in the closed `commentViewFields` literal, so the fate view
- *      actually carries it (the `satisfies Record<keyof CommentRow, true>` pin means
- *      an omission is a compile error, but a *present* field is worth asserting —
- *      that literal is what `CommentView` derives from);
- *   3. the wire shaper defaults an unstamped row to `false`, matching `toPost`.
- *
+ * The `Comment` owner-scoped in-review flag on the wire (#4282, the third leg of #2200).
  * The stamping call sites are compile-locked rather than tested here: `rowToCommentRow`
- * takes `viewerId` as a REQUIRED parameter, so a read path cannot forget to state whose
- * view it is shaping.
+ * takes `viewerId` as a REQUIRED parameter, so a read path cannot forget whose view it is
+ * shaping.
  */
 import {assert, describe, it} from "@effect/vitest";
 import {ownSandboxed} from "../lifecycle/SandboxVisibility.ts";

--- a/apps/web/worker/features/pano/comment-self-vote-guard.unit.test.ts
+++ b/apps/web/worker/features/pano/comment-self-vote-guard.unit.test.ts
@@ -1,14 +1,9 @@
 /**
- * `Pano.applyCommentVote` self-vote guard (#2216, founder-ruled) — the comment twin of
- * `self-vote-guard.unit.test.ts`, proven over the real `makeCommentOperations` closures
- * with a substituted `Drizzle` `run` (the comment load) + a RECORDING `Vote`, so three
- * things are wrong-or-right with no SQL engine:
- *
- *   1. self-cast rejected — `voteOnComment` where `voterId === comment.authorId` fails
- *      `SelfVoteNotAllowed` and NEVER reaches `Vote.cast` (no score/karma write).
- *   2. other-author cast lands — a non-author vote reaches `Vote.cast` exactly as before.
- *   3. self-retract exempt — `retractCommentVote` on one's own comment reaches `Vote.cast`
- *      (the guard is cast-only; a blocked cast leaves nothing to retract).
+ * `Pano.applyCommentVote` self-vote guard (#2216, founder-ruled), proven over the real
+ * `makeCommentOperations` closures with a substituted `Drizzle` `run` and a RECORDING
+ * `Vote`: a self-cast is rejected and never reaches `Vote.cast`, a non-author cast
+ * lands, and a self-RETRACT is exempt (the guard is cast-only — a blocked cast leaves
+ * nothing to retract).
  */
 import {assert, describe, it} from "@effect/vitest";
 import {Cause, Effect, Exit} from "effect";
@@ -22,8 +17,7 @@ const AUTHOR = UserId.make("u-author");
 const OTHER = UserId.make("u-other");
 const COMMENT_ID = CommentId.make("comment_1");
 
-// The `comment_record` the up-front load returns. Only `authorId` drives the guard; the
-// rest satisfy the fields the return projection reads.
+// Only `authorId` drives the guard; the rest satisfy the return projection.
 const commentRow = {
 	id: COMMENT_ID,
 	postId: "post_1",
@@ -36,9 +30,8 @@ const commentRow = {
 	removedAt: null,
 };
 
-// A `Vote` double that RECORDS every cast and replays a no-op result — so "did the cast
-// path run" is observable with no engine. Only `cast` is on the vote path; every other
-// method dies on contact via the Proxy, so an off-path call is loud (the post twin's idiom).
+// A `Vote` double that RECORDS every cast, so "did the cast path run" is observable
+// with no engine. Every other method dies on contact via the Proxy.
 const recordingVote = (casts: VoteInput[]): typeof Vote.Service =>
 	new Proxy(
 		{
@@ -62,8 +55,8 @@ const recordingVote = (casts: VoteInput[]): typeof Vote.Service =>
 		},
 	) as typeof Vote.Service;
 
-// Only `run` (the comment load) + `voteSvc` are on the vote path; the other deps are captured
-// but never invoked, so they die on contact if the guard ever falls through to them.
+// Only `run` (the comment load) + `voteSvc` are on the vote path; the other deps are
+// captured but never invoked, so they die on contact if the guard falls through.
 const deps = (voteSvc: typeof Vote.Service): CommentOperationsDeps =>
 	({
 		run: (<A>(_fn: unknown) => Effect.succeed(commentRow as A)) as DrizzleAccessOrDie["run"],

--- a/apps/web/worker/features/pano/comment-stamp-wave.unit.test.ts
+++ b/apps/web/worker/features/pano/comment-stamp-wave.unit.test.ts
@@ -1,20 +1,8 @@
 /**
- * The pano thread/comment stamp-wave collapse (#2710, epic #2567) — behavior equivalence
- * + the concurrency plumbing, over the real `makeCommentOperations` closures with a
- * substituted `Drizzle` `run` + recording service doubles (ADR 0082 litmus: wrong-or-right
- * with no SQL engine → unit). The pano twin of `sozluk/definition-stamp-wave.unit.test.ts`,
- * reusing the same shared `parallelStampWave` combinator behind pano's own seam.
- *
- * Two properties the acceptance criteria name:
- *
- *   - **byte-for-byte equivalence.** `getCommentsByIds` / `listCommentsKeyset` produce the
- *     identical stamped rows whether the wave runs serial (flag off) or concurrent (flag
- *     on) — `myVote`, `reactions`, live author identity all unchanged. The flag flips wall
- *     time and nothing else.
- *   - **the concurrency actually threads through.** With `parallelStamps: true` the reaction
- *     aggregate's own two D1 reads receive `{concurrency: "unbounded"}` (so the wave is one
- *     phase, not one-plus-the-reaction-arm's-two); with it off/absent they receive
- *     `{concurrency: 1}` — today's serial behavior every non-opted caller keeps.
+ * The pano stamp-wave collapse (#2710). Two properties: the flag flips wall time and
+ * NOTHING else (byte-for-byte identical rows serial vs concurrent), and the concurrency
+ * actually reaches the reaction aggregate's own two reads rather than stopping one level
+ * up. Pano twin of `sozluk/definition-stamp-wave.unit.test.ts`.
  */
 import {assert, describe, it} from "@effect/vitest";
 import {Effect} from "effect";
@@ -25,7 +13,6 @@ import type {Reaction, ReactionAggregate} from "../reaction/Reaction.ts";
 import type {Vote} from "../vote/Vote.ts";
 import {type CommentOperationsDeps, makeCommentOperations} from "./comment-operations.ts";
 
-// A `comment_record` shaped just enough for `toCommentRow` + `Removal.fromColumns`.
 const commentRecord = (id: string, authorId: string) => ({
 	id,
 	postId: "post_1",
@@ -57,8 +44,7 @@ const VoteStub = {
 	clearTarget: () => Effect.void,
 } as unknown as typeof Vote.Service;
 
-// Reaction double that RECORDS the `options` (the concurrency knob) each `readAggregate`
-// call received, and answers a fixed aggregate for `comment_1`.
+// Records the `options` (the concurrency knob) each `readAggregate` call received.
 const reactionRecorder = (
 	calls: Array<{readonly concurrency?: Concurrency} | undefined>,
 ): typeof Reaction.Service =>
@@ -72,12 +58,11 @@ const reactionRecorder = (
 		},
 	}) satisfies typeof Reaction.Service;
 
-// Pasaport identity double: `comment_1`'s author has a live handle, `_2`'s has none.
+// `comment_1`'s author has a live handle, `_2`'s deliberately has none.
 const readProfileIdentities = () =>
 	Effect.succeed([{userId: "u1", username: "anka", displayName: "Anka Kadın", totalKarma: 0}]);
 
-// Replays `run` results in call order (the sözlük test's `scriptedAccess` shape); each
-// answer is a single `as A` — `run` ignores its query fn (no engine), returning the script.
+// Replays results in call order; `run` ignores its query fn since there is no SQL engine.
 const scriptedRun = (results: ReadonlyArray<unknown>): DrizzleAccessOrDie["run"] => {
 	let i = 0;
 	return (<A>(_fn: unknown) => Effect.succeed(results[i++] as A)) as DrizzleAccessOrDie["run"];
@@ -95,7 +80,7 @@ const deps = (
 	readProfileIdentities,
 });
 
-// `getCommentsByIds` issues exactly one `run` (the fetch); answer it with two records.
+// `getCommentsByIds` issues exactly one `run` (the fetch).
 const byIdRun = () =>
 	scriptedRun([[commentRecord("comment_1", "u1"), commentRecord("comment_2", "u2")]]);
 
@@ -122,7 +107,7 @@ describe("Pano.getCommentsByIds — stamp-wave behavior equivalence (#2710)", ()
 				serial.map((r) => JSON.stringify(r)),
 				"identical serialized bytes (fields, values, key order)",
 			);
-			// Spot the stamps actually landed (not a vacuous equality of two empty pages).
+			// Guards against a vacuous equality of two empty pages.
 			assert.strictEqual(parallel[0]?.myVote, true, "comment_1 viewer upvote stamped");
 			assert.strictEqual(parallel[1]?.myVote, false, "comment_2 no viewer upvote");
 			assert.deepStrictEqual(
@@ -147,7 +132,7 @@ describe("Pano.getCommentsByIds — stamp-wave behavior equivalence (#2710)", ()
 				viewerId: "v",
 				parallelStamps: false,
 			});
-			// No `parallelStamps` → the default-off path (today's behavior).
+			// No `parallelStamps` at all → the default-off path.
 			yield* makeCommentOperations(deps(byIdRun(), offCalls)).getCommentsByIds(["comment_1"], {
 				viewerId: "v",
 			});
@@ -162,7 +147,7 @@ describe("Pano.getCommentsByIds — stamp-wave behavior equivalence (#2710)", ()
 	});
 });
 
-// `listCommentsKeyset` (no cursor) issues: totalCount → fetch. Script both in order.
+// `listCommentsKeyset` (no cursor) issues totalCount then fetch, in that order.
 const keysetRun = () =>
 	scriptedRun([
 		2 /* count */,

--- a/apps/web/worker/features/pano/draft-save.invariant.test.ts
+++ b/apps/web/worker/features/pano/draft-save.invariant.test.ts
@@ -1,13 +1,7 @@
 /**
- * `post.saveDraft` returns a `Post` carrying `isDraft: true` — the taslak write's
- * wire contract (#746; the dark-ship flag that once gated it is retired, ADR 0136).
- *
- * Wire-boundary unit test (ADR 0082): the `Pano`/`LivePublisher` seams are
- * substituted directly — no DB, no Flagship binding. The mutation runs through
- * `resolveWire` (its real external interface — `resolve` decode + the
- * `encodeWireError` class→wire-code seam) rather than `.handler`, so the decode
- * of the returned selection is part of what's proven. Mirrors
- * `report-mutation.unit.test.ts` (`resolveWire` + `CurrentUser`).
+ * `post.saveDraft` returns a `Post` carrying `isDraft: true` — the taslak write's wire
+ * contract. Driven through `resolveWire` rather than `.handler`, so the decode of the
+ * returned selection is part of what is proven.
  */
 import {assert, describe, it} from "@effect/vitest";
 import {CurrentUser, LivePublisher} from "@kampus/fate-effect";
@@ -28,14 +22,13 @@ const runtimeContextStub: BaseRuntimeContext = {
 	set: (id) => Effect.succeed(id),
 };
 
-// A `LivePublisher` that records nothing — the publish is fire-and-forget and its
-// error channel is `never`, so it can never fail the mutation.
+// The publish is fire-and-forget with a `never` error channel, so it cannot fail the
+// mutation and nothing needs recording.
 const liveStub = Layer.succeed(LivePublisher)(
 	livePublisherFor({publish: () => Effect.void, waitUntil: () => {}}),
 );
 
-// A `Pano` stub whose `saveDraft` is scripted; every other method dies, so an
-// unexpected service call is loud rather than silently satisfied.
+// Every other method dies, so an unexpected service call is loud rather than satisfied.
 const panoStub = (saveDraft: (typeof Pano.Service)["saveDraft"]): Layer.Layer<Pano> =>
 	Layer.succeed(
 		Pano,

--- a/apps/web/worker/features/pano/errors.ts
+++ b/apps/web/worker/features/pano/errors.ts
@@ -1,14 +1,10 @@
 /**
- * Tagged errors raised by the Pano service layer. Each carries its wire `code`
- * as an `FateWireCode` annotation that `encodeWireError` reads at the fate boundary
- * (`.patterns/fate-effect-wire-errors.md`).
- *
- * The retired bridge's `PostValidation` / `CommentValidation` carried a dynamic
- * `code` field the registry upcased per instance; `FateWireCode` is one static code
- * per class, so each former sub-code is now its own class. {@link PostValidation}
- * / {@link CommentValidation} survive as the union aliases the `Pano` signatures
- * name. Wire codes are preserved verbatim from the bridge so SPA pattern-matching
- * keeps working; `errors.unit.test.ts` pins each pair.
+ * Tagged errors raised by the Pano service layer. Each carries its wire `code` as a
+ * `FateWireCode` annotation that `encodeWireError` reads at the fate boundary
+ * (`.patterns/fate-effect-wire-errors.md`). One static code per class, so each former dynamic
+ * sub-code of the retired bridge is its own class; {@link PostValidation} /
+ * {@link CommentValidation} survive as union aliases. Wire codes are preserved verbatim from the
+ * bridge so SPA pattern-matching keeps working — `errors.unit.test.ts` pins each pair.
  */
 import {FateWireCode} from "@kampus/fate-effect";
 import * as Schema from "effect/Schema";
@@ -49,8 +45,7 @@ export class TagInvalid extends Schema.TaggedErrorClass<TagInvalid>()(
 	{[FateWireCode]: "TAG_INVALID"},
 ) {}
 
-// Spread into mutation `error:` unions; {@link PostValidation} is derived from
-// this tuple, so the two can't drift.
+// {@link PostValidation} is derived from this tuple, so the two can't drift.
 export const PostValidationErrors = [
 	TitleRequired,
 	TitleTooLong,
@@ -125,13 +120,10 @@ export class UnauthorizedCommentMutation extends Schema.TaggedErrorClass<Unautho
 ) {}
 
 /**
- * A post's removal WRITE failed at the D1 layer — the vote-clear / triad-stamp / FTS
- * commit (`Removal.removeEntity`, over `DrizzleAccessOrDie`) threw. Declared so a
- * genuine removal-commit failure surfaces as a typed, user-readable error the SPA can
- * show, instead of escaping `post.delete`'s union as a squashed defect (a raw
- * `INTERNAL_SERVER_ERROR`, #1639). The post-commit stats refresh is a recomputable
- * cache (ADR 0011/0117) swallowed at its call site — it cannot fail an already-
- * committed removal — so this error means the removal itself did not commit.
+ * The removal WRITE itself failed at D1. Declared so a genuine removal-commit failure surfaces as
+ * a typed, user-readable error instead of escaping `post.delete`'s union as a squashed
+ * `INTERNAL_SERVER_ERROR` (#1639). The post-commit stats refresh is a recomputable cache swallowed
+ * at its call site, so this error never means "the removal committed but something after it".
  */
 export class PostDeleteFailed extends Schema.TaggedErrorClass<PostDeleteFailed>()(
 	"pano/PostDeleteFailed",

--- a/apps/web/worker/features/pano/excerpt.ts
+++ b/apps/web/worker/features/pano/excerpt.ts
@@ -1,8 +1,4 @@
-/**
- * The tweet-sized body excerpt both planes derive — a post's `bodyExcerpt` and a
- * comment's `bodyExcerpt` share the one length, so it has a single home rather than
- * being duplicated across the post/comment operation modules.
- */
+/** Post and comment `bodyExcerpt` share one length, so it lives here rather than in both. */
 import {excerpt as excerptText} from "../text/index.ts";
 
 const POST_EXCERPT_LEN = 280; // tweet-sized

--- a/apps/web/worker/features/pano/fate-module.ts
+++ b/apps/web/worker/features/pano/fate-module.ts
@@ -9,17 +9,12 @@ import {postDataView} from "./views.ts";
 
 const roots: FateRootsRecord = {
 	post: postDataView,
-	// The feed with no filter args is the registered root list a `post.submit`
-	// `insert` reaches (filtered feeds are distinct, independently-paginated
-	// connections). See `.patterns/fate-mutations-client.md`.
+	// The feed with NO filter args is the registered root list a `post.submit` `insert`
+	// reaches; filtered feeds are distinct, independently-paginated connections.
 	posts: list(postDataView, {orderBy: [{createdAt: "desc"}, {id: "desc"}]}),
-	// The viewer's saved posts; the `savedPosts` resolver owns the order (the
-	// `post_bookmark` keyset, ADR 0019). Reuses `postDataView` so `isSaved`/`myVote`
-	// come for free.
+	// The viewer's saved posts; the resolver owns the `post_bookmark` keyset (ADR 0019).
 	savedPosts: list(postDataView),
-	// The public landing posts (#1424) — live-only recent posts, batched into the
-	// landing screen's one `useRequest` beside `landingStats` (ADR 0021). The
-	// `landingPosts` resolver owns the recency order + the sandbox mask.
+	// The public landing posts (#1424); the resolver owns the recency order + sandbox mask.
 	landingPosts: list(postDataView, {orderBy: [{createdAt: "desc"}, {id: "desc"}]}),
 };
 

--- a/apps/web/worker/features/pano/feed-cache.ts
+++ b/apps/web/worker/features/pano/feed-cache.ts
@@ -1,78 +1,54 @@
 /**
- * The base-feed edge-cache purger — leg B of the "instant reload" epic (#2316,
- * child #2324, ADR 0170). Its one job: after a feed-visible pano write, purge the
- * per-Worker edge cache entry the base-feed GET populated, tagged `pano-feed`.
+ * The base-feed edge-cache purger (ADR 0170, #2324): after a feed-visible pano write,
+ * purge the edge entry the base-feed GET populated, tagged `pano-feed`.
  *
- * It is the cache-side twin of `WorkerLivePublisher`: the SAME fanned-mutation seam
- * (ADR 0155) that publishes the `/fate/live` invalidation also fires this purge, so
- * one write drives two invalidations. Both are best-effort and fire-and-forget via
- * `waitUntil` (CF's only post-response work extension — no shutdown hook, ADR
- * 0028/0039), and both have a `never` error channel so a failed purge can never fail
- * the committed mutation — the swallow-with-log contract lives here, once, exactly as
- * `live-publisher.ts` holds it for the live fan-out.
+ * The cache-side twin of `WorkerLivePublisher` — same fanned-mutation seam (ADR 0155),
+ * same fire-and-forget `waitUntil`, same `never` error channel so a failed purge can
+ * never fail the committed mutation. A lost purge self-heals within the TTL backstop.
  *
- * A lost purge self-heals within the base feed's TTL backstop (`baseFeedCacheControl`),
- * so correctness never depends on a purge landing.
- *
- * Containment: the purge is the worker's OWN runtime capability (`ctx.cache.purge`,
- * injected as `purge` here), scoped to this worker — no zone-level purge, no standing
- * API token (ADR 0170 honors the prod-cred-free invariant).
+ * The purge is the worker's OWN capability (`ctx.cache.purge`), scoped to this worker:
+ * no zone-level purge and no standing API token.
  */
 import {Context} from "effect";
 import * as Effect from "effect/Effect";
 import * as Schema from "effect/Schema";
 
-/** The `Cache-Tag` the base-feed GET stamps and this purger targets. */
 export const PANO_FEED_CACHE_TAG = "pano-feed";
 
 /**
- * The base-feed edge TTL backstop (seconds). Bounds staleness when a purge is lost:
- * the cached entry expires on its own within this window, so the feed self-heals
- * (ADR 0170, AC#3). Kept short — the live overlay (`POST /fate`) already reconciles
- * the per-viewer scalars, so the cached base only needs to be roughly fresh.
+ * The edge TTL backstop (seconds): bounds staleness when a purge is lost, so the feed
+ * self-heals on its own (ADR 0170, AC#3).
  */
 export const BASE_FEED_CACHE_TTL_SECONDS = 30;
 
 /**
- * The `Cache-Control` the base-feed GET response carries when the leg-B cache flag is
- * on. `s-maxage` targets the shared per-Worker edge cache (the TTL backstop) without
- * pinning the doc in the browser, since the client reconciles the live overlay anyway.
+ * `s-maxage` targets the shared per-Worker edge cache without pinning the doc in the
+ * browser, since the client reconciles the live overlay anyway.
  */
 export const baseFeedCacheControl = `public, s-maxage=${BASE_FEED_CACHE_TTL_SECONDS}`;
 
 /**
- * A purge failed inside the swallow wrapper. Never reaches the mutation: the purger
- * maps it away (logged at `Warn`) in its `never` error channel, since the purge runs
- * after the DB write and must not fail the committed mutation (ADR 0039) — the exact
- * contract `LivePublishError` holds for the live fan-out.
+ * A purge failed inside the swallow wrapper. Never reaches the mutation: the purge
+ * runs after the DB write and must not fail a committed mutation (ADR 0039).
  */
 export class FeedCachePurgeError extends Schema.TaggedErrorClass<FeedCachePurgeError>()(
 	"pano/FeedCachePurgeError",
 	{cause: Schema.Defect()},
 ) {}
 
-/** The per-request purger the fanned pano seam fires alongside its live publish. */
 export interface WorkerPanoFeedCache {
-	/** Purge the base-feed edge entry (tag `pano-feed`). `Effect<void>` by contract. */
 	readonly purge: () => Effect.Effect<void>;
 }
 
-/** The two per-request capabilities the purger closes over. */
 export interface PanoFeedCacheOptions {
-	/**
-	 * Deliver one tag purge — in production `ctx.cache.purge` (the worker's own cache
-	 * capability), in tests a recording/failing/slow stub. A rejection is caught on the
-	 * detached promise below.
-	 */
+	/** In production `ctx.cache.purge`; in tests a recording/failing/slow stub. */
 	readonly purge: (options: {tags: string[]}) => Promise<unknown>;
-	/** The request's `ExecutionContext.waitUntil`. */
 	readonly waitUntil: (promise: Promise<unknown>) => void;
 }
 
-/** Build the per-request base-feed purger. */
 export function panoFeedCacheFor(options: PanoFeedCacheOptions): WorkerPanoFeedCache {
 	// One purge = one detached promise; the terminal `.catch` is the async half of the
-	// swallow-with-log contract, mirroring `livePublisherFor`'s `schedule`.
+	// swallow-with-log contract.
 	const schedule = (): void => {
 		options.waitUntil(
 			Promise.resolve(options.purge({tags: [PANO_FEED_CACHE_TAG]})).catch((error: unknown) => {
@@ -82,9 +58,8 @@ export function panoFeedCacheFor(options: PanoFeedCacheOptions): WorkerPanoFeedC
 	};
 
 	return {
-		// Sync half of the swallow-with-log contract: the `waitUntil` schedule runs inside
-		// `Effect.try`, and `ignore` collapses any failure (e.g. a gone execution context)
-		// to the `Effect<void>` the contract promises (ADR 0039, once here).
+		// Sync half of the swallow-with-log contract: `ignore` collapses any failure (e.g. a
+		// gone execution context) to the `Effect<void>` the contract promises (ADR 0039).
 		purge: () =>
 			Effect.try({try: schedule, catch: (cause) => new FeedCachePurgeError({cause})}).pipe(
 				Effect.ignore({log: "Warn"}),
@@ -93,11 +68,8 @@ export function panoFeedCacheFor(options: PanoFeedCacheOptions): WorkerPanoFeedC
 }
 
 /**
- * The per-request purger service, provided per request from `route.ts` (built off the
- * execution context + the leg-B flag) exactly as `CurrentActor` / `RequestFlagOverrides`
- * are, and registered on `PhoenixFateLive`'s per-request list. A fanned pano mutation
- * resolves it (`yield* PanoFeedCache`) and hands it to `panoLive` so the publish seam
- * fires the purge alongside the live invalidation.
+ * The per-request purger service, built in `route.ts` off the execution context and
+ * registered on `PhoenixFateLive`'s per-request list like `CurrentActor`.
  */
 export class PanoFeedCache extends Context.Service<PanoFeedCache, WorkerPanoFeedCache>()(
 	"pano/PanoFeedCache",

--- a/apps/web/worker/features/pano/feed-cache.unit.test.ts
+++ b/apps/web/worker/features/pano/feed-cache.unit.test.ts
@@ -1,13 +1,6 @@
 /**
- * `panoFeedCacheFor` — the base-feed edge-cache purger (leg B, #2324, ADR 0170). The
- * contract under test mirrors `live-publisher.unit.test.ts` (its cache-side twin):
- *
- *   1. `purge()` schedules ONE `cache.purge({tags: ["pano-feed"]})` through `waitUntil`,
- *      never awaited on the mutation path;
- *   2. `purge()`'s error channel is `never` — a rejecting purge cannot fail the caller;
- *   3. a synchronously-throwing execution context (`waitUntil` throws) is swallowed too.
- *
- * Unit tier (ADR 0082): stubs at the `purge`/`waitUntil` seam, zero platform fake.
+ * `panoFeedCacheFor` — the base-feed edge-cache purger (ADR 0170). Stubs at the
+ * `purge`/`waitUntil` seam, no platform fake.
  */
 import {assert, it} from "@effect/vitest";
 import {Effect, Exit} from "effect";
@@ -15,7 +8,6 @@ import * as Schema from "effect/Schema";
 import {expectTypeOf, vi} from "vitest";
 import {PANO_FEED_CACHE_TAG, panoFeedCacheFor} from "./feed-cache.ts";
 
-/** A rejection from the test harness flush thunk — dies the fiber. */
 class FlushRejected extends Schema.TaggedErrorClass<FlushRejected>()("test/FlushRejected", {
 	cause: Schema.Unknown,
 }) {}
@@ -24,10 +16,7 @@ interface PurgeCall {
 	readonly tags: string[];
 }
 
-/**
- * Build a purger over stubbed seams: `purge` defaults to a recorder, `waitUntil`
- * collects the scheduled promises so a test can `flush` the fire-and-forget work.
- */
+/** `waitUntil` collects the scheduled promises so a test can `flush` the deferred work. */
 function makeHarness(opts?: {purge?: (options: {tags: string[]}) => Promise<unknown>}) {
 	const purges: Array<PurgeCall> = [];
 	const scheduled: Array<Promise<unknown>> = [];
@@ -51,7 +40,6 @@ it.effect("one tag purge scheduled through waitUntil", () =>
 		const {cache, purges, scheduled, flush} = makeHarness();
 
 		yield* cache.purge();
-		// scheduled synchronously, but the delivery is not awaited on the caller path
 		assert.strictEqual(scheduled.length, 1);
 		yield* Effect.tryPromise({try: flush, catch: (cause) => new FlushRejected({cause})}).pipe(
 			Effect.orDie,

--- a/apps/web/worker/features/pano/hot-score-decay-cron.ts
+++ b/apps/web/worker/features/pano/hot-score-decay-cron.ts
@@ -1,39 +1,26 @@
 /**
- * The sıcak/hot decay-refresh cron wiring (#2027) — a Cloudflare Cron Trigger that
- * periodically re-decays the stored `post_record.hot_score` so the hot feed keeps
- * decaying with age WITHOUT a read-time recompute (the keyset-cursor contract + the
- * no-`POW` SQLite constraint both need `hot_score` to stay a stored, indexed column).
+ * The sıcak/hot decay-refresh cron (#2027): a Cron Trigger that periodically re-decays the stored
+ * `post_record.hot_score`, because the keyset-cursor contract and SQLite's missing `POW` both
+ * need `hot_score` to stay a stored, indexed column rather than a read-time recompute.
  *
- * The mechanism is alchemy's idiomatic scheduled-worker seam
- * (`Cloudflare.cron(expr, handler)`, `alchemy/Cloudflare/Workers/CronEventSource`, beta.59):
- * it registers a runtime `scheduled` listener AND attaches the cron expression to the
- * deployed worker at deploy time. The DO-alarm alternative (the fate-live prune alarm)
- * is per-instance and event-driven — wrong for a table-wide periodic sweep that must run
- * with no live DO pinned in memory — so a Cron Trigger is the established fit here.
+ * A Cron Trigger, not a DO alarm: the alarm seam is per-instance and event-driven, wrong for a
+ * table-wide periodic sweep that must run with no live DO pinned in memory.
  *
- * Cadence: every 15 minutes (`HOT_SCORE_DECAY_CRON`). The decay is gradual — the gravity
- * formula moves a young post's floored score by a meaningful step only over tens of
- * minutes — so a 15-minute pass keeps the visible feed fresh without over-writing the
- * `hot_score` column. Each pass re-decays ALL live non-draft posts (windowless since
- * #2133), so an aged squatter keeps decaying at any age; the sweep reads in ascending-id
- * keyset chunks (#2559) so no single tick materializes the whole table at once — see
- * `Pano.refreshHotScores`.
+ * Every 15 minutes: the gravity formula moves a young post's floored score by a meaningful step
+ * only over tens of minutes. Each pass re-decays ALL live non-draft posts (windowless since
+ * #2133) in ascending-id keyset chunks (#2559), so no tick materializes the whole table.
  */
 import * as Cloudflare from "alchemy/Cloudflare";
 import * as Effect from "effect/Effect";
 import type * as Layer from "effect/Layer";
 import {Pano} from "./Pano.ts";
 
-/** Every 15 minutes (standard 5-field cron). */
 export const HOT_SCORE_DECAY_CRON = "*/15 * * * *";
 
 /**
- * The worker-init effect that subscribes the decay refresh to the cron trigger. `fateLayer`
- * is the built worker context (`makeFateRuntime`'s `contextLayer`) carrying `Pano`; the
- * handler runs `Pano.refreshHotScores` provided by it, at the controller's scheduled instant
- * (so the pass's clock is the trigger's, not a fresh `Date.now()`). Failures are already
- * swallowed by `CronEventSource` (`Effect.catchCause`), so a bad pass never crashes the
- * scheduled invocation.
+ * `fateLayer` is the built worker context carrying `Pano`. The pass runs at the controller's
+ * scheduled instant, not a fresh `Date.now()`. `CronEventSource` already swallows failures, so a
+ * bad pass never crashes the scheduled invocation.
  */
 export const subscribeHotScoreDecay = (fateLayer: Layer.Layer<Pano>) =>
 	Cloudflare.cron(HOT_SCORE_DECAY_CRON, (controller) =>

--- a/apps/web/worker/features/pano/hot-score-decay-scan.unit.test.ts
+++ b/apps/web/worker/features/pano/hot-score-decay-scan.unit.test.ts
@@ -1,42 +1,29 @@
 /**
- * The keyset-chunk decay sweep (`scanDecayChunks`, #2559), unit-reachable over in-memory
- * ports — the cursor-advance + full-coverage control flow is wrong-or-right with no SQL
- * engine (ADR 0082 litmus), so it is driven here over a JS-array table, never real D1. The
- * pure decay math (`decayHotScores`) has its own unit test; the real-D1 chunk EXECUTION
- * (the paged walk over `post_record`) stays integration-tier (`pano-hot-score-decay.test.ts`).
- *
- * The two properties this guards, both the point of #2559:
- *   - WINDOWLESS coverage (#2133 preserved): the sweep visits EVERY row across its pages, so
- *     a post beyond the first chunk is still decayed — chunking is not a recency window.
- *   - BOUNDED pages: each `fetchChunk` asks for at most `chunkSize` rows and resumes at a
- *     cursor strictly past the previous page's last id — no single unbounded scan.
+ * The keyset-chunk decay sweep (`scanDecayChunks`) over in-memory ports, never real D1 (ADR
+ * 0082). Guards the two properties of #2559: WINDOWLESS coverage — the sweep visits EVERY row
+ * across its pages, so chunking is not a recency window — and BOUNDED pages, each `fetchChunk`
+ * asking for at most `chunkSize` rows and resuming strictly past the previous page's last id.
  */
 import {assert, describe, it} from "@effect/vitest";
 import {Effect} from "effect";
 import type {HotDecayRow, HotDecayUpdate} from "../../db/hotScoreDecay.ts";
 import {type HotDecayScanPorts, scanDecayChunks} from "./post-operations.ts";
 
-/** A row that decays: `score 0` recomputes to `hot_score 0`, so a stored `5` always changes. */
+// A row that decays: `score 0` recomputes to `hot_score 0`, so a stored `5` always changes.
 const changing = (id: string): HotDecayRow => ({id, score: 0, hotScore: 5, createdAtMs: 0});
-/** A row at rest: stored `hot_score 0` already equals the recompute, so it never writes. */
+// A row at rest: stored `hot_score 0` already equals the recompute, so it never writes.
 const steady = (id: string): HotDecayRow => ({id, score: 0, hotScore: 0, createdAtMs: 0});
 
 interface Harness {
 	readonly ports: HotDecayScanPorts;
-	/** Every `fetchChunk(afterId, limit)` call, in order — the paging trace. */
 	readonly fetchCalls: Array<{afterId: string | null; limit: number}>;
-	/** Every id passed to `writeBack`, across all pages — the coverage trace. */
 	readonly written: string[];
-	/** How many times `writeBack` was invoked (a no-change page issues none). */
+	// A no-change page issues none.
 	readonly writeBackCalls: {count: number};
 }
 
-/**
- * In-memory ports over a fixed, id-sorted table: `fetchChunk` serves the keyset page
- * (`id > afterId`, capped at `limit`) and records the cursor + limit it was asked for;
- * `writeBack` records every rewritten id. This is the exact contract `makeRefreshHotScores`
- * wires D1 into — so the driver's paging behavior is proven without a database.
- */
+// In-memory ports over a fixed, id-sorted table — the exact contract `makeRefreshHotScores`
+// wires D1 into, so the driver's paging behavior is proven without a database.
 function harness(table: ReadonlyArray<HotDecayRow>): Harness {
 	const sorted = [...table].sort((a, b) => (a.id < b.id ? -1 : a.id > b.id ? 1 : 0));
 	const fetchCalls: Array<{afterId: string | null; limit: number}> = [];

--- a/apps/web/worker/features/pano/ids.ts
+++ b/apps/web/worker/features/pano/ids.ts
@@ -1,11 +1,8 @@
 /**
- * Pano's feature-local branded id schemas (epic #2700). `PostId` / `CommentId`
- * are nominal string tags minted from the shared `brandedId` factory, so a
- * `postId`/`commentId` transposition at a write call site is a compile error
- * while wire and D1 bytes stay identical (the brand is type-only — see
- * `../../lib/ids.ts`). They live here, beside the pano feature, because only
- * pano references them; the cross-feature `UserId` is imported read-only from
- * the shared module. Idiom + tracer precedent: `features/sozluk` (#2712).
+ * Pano's feature-local branded id schemas: `PostId` / `CommentId` from the shared `brandedId`
+ * factory, so a transposition at a write call site is a compile error while wire and D1 bytes
+ * stay identical. They live here because only pano references them; the cross-feature
+ * `UserId` is imported from `../../lib/ids.ts`.
  */
 import {brandedId} from "../../lib/ids.ts";
 

--- a/apps/web/worker/features/pano/link-metadata-contract.ts
+++ b/apps/web/worker/features/pano/link-metadata-contract.ts
@@ -1,30 +1,19 @@
 /**
- * The wire contract for `GET /api/pano/link-metadata` (#1642) — the pano
- * submit form's title/description prefill seam. The client passes a `url`
- * query param; the worker fetches it server-side (the browser can't fetch
- * cross-origin HTML), parses the page metadata, and returns this shape.
- *
- * Like `evaluate-contract.ts`, the shared type + the client-side response
- * parse live here as pure functions so they're unit-testable without a DOM.
- * The response is always safe-default: any fetch failure, timeout, SSRF
- * rejection, or a page with no usable metadata yields `{}` (a graceful no-op,
- * never a surfaced error), and a missing/non-string field parses to absent —
- * so a flaky target page can only ever leave the form fields untouched.
+ * The wire contract for `GET /api/pano/link-metadata` (#1642), the submit form's prefill
+ * seam. The fetch is server-side because a browser can't fetch cross-origin HTML. Always
+ * safe-default: a fetch failure, timeout, SSRF rejection, or a page with no usable
+ * metadata all yield `{}`, never a surfaced error, so a flaky target page can only leave
+ * the form untouched.
  */
 
-/** The parsed page metadata the prefill route returns. Both fields optional. */
 export interface LinkMetadata {
 	readonly title?: string;
 	readonly description?: string;
 }
 
 /**
- * Parse an untrusted `/api/pano/link-metadata` response body into
- * {@link LinkMetadata}, dropping any non-string field. The input is `unknown`
- * on purpose — it comes from `res.json()` — so this structural guard, not a
- * cast at the call site, is what enforces the client's safe-default contract:
- * only a genuine non-empty string survives; everything else collapses to
- * absent, and the field is then never prefilled.
+ * The input is `unknown` on purpose — it comes from `res.json()` — so this structural
+ * guard, not a cast at the call site, is what enforces the safe-default contract.
  */
 export function parseLinkMetadataResponse(body: unknown): LinkMetadata {
 	if (typeof body !== "object" || body === null) return {};

--- a/apps/web/worker/features/pano/link-metadata-contract.unit.test.ts
+++ b/apps/web/worker/features/pano/link-metadata-contract.unit.test.ts
@@ -1,9 +1,7 @@
 /**
- * The client-side safe-default parse of the `/api/pano/link-metadata` response
- * (#1642) — tested without a DOM, the same pure-core idiom as
- * `evaluate-contract.unit.test.ts`. `parseLinkMetadataResponse` is what
- * enforces "a flaky page can only ever leave the form untouched": a non-string,
- * empty, or absent field must parse to absent so it is never prefilled.
+ * `parseLinkMetadataResponse` is what enforces "a flaky page can only ever leave the
+ * form untouched" (#1642): a non-string, empty, or absent field must parse to absent
+ * so it is never prefilled.
  */
 import {describe, expect, it} from "vitest";
 import {parseLinkMetadataResponse} from "./link-metadata-contract.ts";

--- a/apps/web/worker/features/pano/link-metadata-route.ts
+++ b/apps/web/worker/features/pano/link-metadata-route.ts
@@ -1,16 +1,10 @@
 /**
- * `GET /api/pano/link-metadata?url=…` (#1642) — the pano submit form's
- * title/description prefill seam. The browser can't fetch cross-origin HTML,
- * so the worker does it: given an SSRF-safe `http(s)` URL it fetches the page
- * (timeout- and size-bounded, following redirects manually so every hop is
- * re-screened for SSRF), parses its metadata, and returns {@link LinkMetadata}
- * as JSON. See `.patterns/alchemy-http-router.md`.
+ * `GET /api/pano/link-metadata?url=…` — the pano submit form's title/description
+ * prefill seam, fetched worker-side because the browser can't fetch cross-origin
+ * HTML. See `.patterns/alchemy-http-router.md`.
  *
- * Every failure mode is a graceful no-op, never a 5xx: an unsafe/rejected URL,
- * a fetch error, a timeout, an over-cap body, a non-2xx upstream, or a page
- * with no usable metadata all return `{}` (200) — the client then leaves the
- * form fields untouched. The route holds no per-request services; it only
- * reads the raw `Request` for the `url` query param.
+ * Every failure mode is a graceful no-op, never a 5xx: unsafe URL, fetch error,
+ * timeout, over-cap body, non-2xx upstream, or no usable metadata all return `{}`.
  */
 import * as Cloudflare from "alchemy/Cloudflare";
 import * as Effect from "effect/Effect";
@@ -27,20 +21,14 @@ import {
 } from "./link-metadata.ts";
 import type {LinkMetadata} from "./link-metadata-contract.ts";
 
-/** The empty result — the safe-default this route returns on every failure. */
 const EMPTY: LinkMetadata = {};
 
-/** An unexpected `fetchMetadata` rejection — mapped then recovered to {@link EMPTY}. */
 class LinkMetadataFetchError extends Schema.TaggedErrorClass<LinkMetadataFetchError>()(
 	"pano/LinkMetadataFetchError",
 	{cause: Schema.Defect()},
 ) {}
 
-/**
- * Read up to {@link MAX_METADATA_BYTES} of the response body as UTF-8, then
- * stop — never buffer an unbounded body. Returns the decoded prefix (enough to
- * hold the `<head>` metadata for any sane page).
- */
+/** Stops at {@link MAX_METADATA_BYTES} — never buffer an unbounded body. */
 async function readCapped(res: Response): Promise<string> {
 	const reader = res.body?.getReader();
 	if (!reader) return "";
@@ -61,14 +49,10 @@ async function readCapped(res: Response): Promise<string> {
 }
 
 /**
- * Fetch `start` following up to {@link MAX_REDIRECT_HOPS} 3xx redirects
- * MANUALLY (`redirect: "manual"`), re-screening every hop's `Location` through
- * {@link isSafeFetchUrl} BEFORE following it. `redirect: "follow"` would chase a
- * `302 Location: http://169.254.169.254/…` blindly, defeating the initial-URL
- * guard — so each hop is resolved against the current URL and re-validated, and
- * a hop that fails the guard (or a chain past the cap) returns `null` (refused).
- * The single `signal` spans the whole chain, so the route's 5s timeout bounds
- * every hop. `fetchImpl` is injectable so the loop is unit-testable offline.
+ * Redirects are followed MANUALLY so every hop's `Location` is re-screened through
+ * {@link isSafeFetchUrl} BEFORE it is followed. `redirect: "follow"` would chase a
+ * `302 Location: http://169.254.169.254/…` blindly, defeating the initial-URL guard.
+ * The single `signal` spans the whole chain, so one timeout bounds every hop.
  */
 async function fetchFollowingSafeRedirects(
 	start: URL,
@@ -95,7 +79,7 @@ async function fetchFollowingSafeRedirects(
 	}
 }
 
-/** Fetch + parse a safe URL's metadata. Any failure collapses to `{}` (no throw). */
+/** Any failure collapses to `{}` — this never throws. */
 async function fetchMetadata(url: URL): Promise<LinkMetadata> {
 	const controller = new AbortController();
 	const timer = setTimeout(() => controller.abort(), FETCH_TIMEOUT_MS);
@@ -120,9 +104,8 @@ export const handleLinkMetadata = Effect.gen(function* () {
 	const requested = new URL(raw.url).searchParams.get("url") ?? "";
 	const safe = isSafeFetchUrl(requested);
 	if (safe === null) return HttpServerResponse.jsonUnsafe(EMPTY);
-	// `fetchMetadata` never rejects — it maps every failure to `EMPTY` — so the
-	// mapped-then-recovered `catch` is unreachable and the route can't surface a
-	// defect to the client.
+	// `fetchMetadata` never rejects, so this `catch` is unreachable — it is here so
+	// the route structurally cannot surface a defect to the client.
 	const metadata = yield* Effect.tryPromise({
 		try: () => fetchMetadata(safe),
 		catch: (cause) => new LinkMetadataFetchError({cause}),

--- a/apps/web/worker/features/pano/link-metadata-route.unit.test.ts
+++ b/apps/web/worker/features/pano/link-metadata-route.unit.test.ts
@@ -1,21 +1,15 @@
 /**
- * The SSRF-safe redirect loop of the pano link-metadata route (#1642). The
- * initial-URL guard (`isSafeFetchUrl`) is unit-tested in
- * `link-metadata.unit.test.ts`; this file covers the OTHER SSRF surface — a
- * public URL that 3xx-redirects to a private/metadata target. `fetch` is
- * injected, so the manual-redirect loop is exercised offline: a redirect to a
- * private IP is refused, a chain past {@link MAX_REDIRECT_HOPS} is refused, and
- * a single normal public redirect still resolves.
+ * The SSRF surface the initial-URL guard does NOT cover: a public URL that
+ * 3xx-redirects to a private/metadata target. (`isSafeFetchUrl` itself is covered in
+ * `link-metadata.unit.test.ts`.) `fetch` is injected so the loop runs offline.
  */
 import {describe, expect, it, vi} from "vitest";
 import {MAX_REDIRECT_HOPS} from "./link-metadata.ts";
 import {fetchFollowingSafeRedirects} from "./link-metadata-route.ts";
 
-/** A 3xx redirect Response carrying a `Location` header. */
 const redirectTo = (location: string, status = 302): Response =>
 	new Response(null, {status, headers: {location}});
 
-/** A terminal 200 HTML Response. */
 const ok = (body = "<title>ok</title>"): Response =>
 	new Response(body, {status: 200, headers: {"content-type": "text/html"}});
 

--- a/apps/web/worker/features/pano/link-metadata.ts
+++ b/apps/web/worker/features/pano/link-metadata.ts
@@ -1,48 +1,33 @@
 /**
- * The pure core of the pano link-metadata prefill route (#1642): the SSRF
- * guard that decides whether a user-supplied URL is safe to fetch, and the
- * HTML metadata parser that lifts `og:title`/`<title>` and
- * `og:description`/`meta[name=description]` out of a fetched page. Both are
- * pure and unit-testable without a worker or a live network.
+ * The pure core of the pano link-metadata prefill route (#1642): the SSRF guard and
+ * the HTML metadata parser.
  *
- * A public worker that fetches arbitrary user-supplied URLs is the classic
- * SSRF surface, so {@link isSafeFetchUrl} is fail-closed: it admits ONLY
- * `http(s)` URLs whose host is not a private/loopback/link-local/CGNAT/
- * cloud-metadata address (IPv4 or IPv6 literal) and not a local-only hostname
- * (`localhost`, `*.localhost`, `*.local`, `*.internal`). A hostname that is
- * not an IP literal still can't be pre-resolved to an IP from inside the
- * worker, so the DNS-rebinding residue is accepted as a known bound — the
- * literal-IP + local-suffix screen blocks the direct-address SSRF vectors,
- * and the fetch itself is timeout- and size-bounded by the route.
+ * {@link isSafeFetchUrl} is fail-closed: it admits only `http(s)` URLs whose host is
+ * not a private/loopback/link-local/CGNAT/cloud-metadata literal and not a local-only
+ * hostname. A non-literal hostname cannot be pre-resolved inside the worker, so the
+ * DNS-rebinding residue is a known, accepted bound.
  */
 
 import type {LinkMetadata} from "./link-metadata-contract.ts";
 
-/** Max bytes of the response body the route buffers before giving up (a graceful no-op). */
 export const MAX_METADATA_BYTES = 512 * 1024;
 
-/** How long the server-side fetch may run before it's aborted (a graceful no-op). */
 export const FETCH_TIMEOUT_MS = 5_000;
 
 /**
- * Max 3xx redirects the server-side fetch follows before giving up. The route
- * follows redirects MANUALLY and re-screens every hop's `Location` through
- * {@link isSafeFetchUrl}, so a public URL that 302s to `169.254.169.254` (or any
- * private/loopback/link-local/metadata target) is refused — the SSRF-via-redirect
- * vector a blind `redirect: "follow"` would chase. A chain longer than this cap
- * is also refused (a graceful no-op).
+ * Max 3xx redirects the server-side fetch follows. The route follows redirects
+ * MANUALLY and re-screens every hop through {@link isSafeFetchUrl}, so a public URL
+ * that 302s to `169.254.169.254` is refused — the SSRF-via-redirect vector a blind
+ * `redirect: "follow"` would chase.
  */
 export const MAX_REDIRECT_HOPS = 5;
 
-/** Longest title/description the route returns — prefill stays editable and bounded. */
 export const MAX_FIELD_LEN = 300;
 
-/** Hostname suffixes that only ever resolve to a local/internal host. */
 const LOCAL_HOST_SUFFIXES = [".localhost", ".local", ".internal"];
 
 const isDottedIPv4 = (host: string): boolean => /^\d{1,3}(\.\d{1,3}){3}$/.test(host);
 
-/** A private/loopback/link-local/CGNAT/broadcast/unspecified IPv4 literal. */
 function isBlockedIPv4(host: string): boolean {
 	const parts = host.split(".").map((p) => Number(p));
 	if (parts.length !== 4 || parts.some((n) => !Number.isInteger(n) || n < 0 || n > 255)) {
@@ -63,10 +48,8 @@ function isBlockedIPv4(host: string): boolean {
 }
 
 /**
- * The IPv4 embedded in an IPv4-mapped IPv6 tail, as dotted-quad. The tail is
- * either dotted (`127.0.0.1`) or the two hex hextets WHATWG normalizes it to
- * (`7f00:1`). An unrecognized tail returns `"256.0.0.0"` — an out-of-range
- * sentinel {@link isBlockedIPv4} treats as blocked (fail-closed).
+ * The IPv4 embedded in an IPv4-mapped IPv6 tail, as dotted-quad. An unrecognized tail
+ * returns the out-of-range sentinel `"256.0.0.0"`, which {@link isBlockedIPv4} blocks.
  */
 function mappedTailToIPv4(tail: string): string {
 	if (/^\d{1,3}(\.\d{1,3}){3}$/.test(tail)) return tail;
@@ -78,12 +61,6 @@ function mappedTailToIPv4(tail: string): string {
 	return [(hi >> 8) & 255, hi & 255, (lo >> 8) & 255, lo & 255].join(".");
 }
 
-/**
- * A blocked IPv6 literal (as it appears inside `URL.hostname`, i.e. without the
- * `[...]` brackets). Covers loopback, unspecified, unique-local (`fc00::/7`),
- * link-local (`fe80::/10`), and IPv4-mapped addresses whose embedded IPv4 is
- * itself blocked.
- */
 function isBlockedIPv6(host: string): boolean {
 	const h = host.toLowerCase();
 	if (h === "::1" || h === "::") return true; // loopback / unspecified
@@ -98,13 +75,9 @@ function isBlockedIPv6(host: string): boolean {
 }
 
 /**
- * Parse `raw` and return the {@link URL} only if it parses AND carries an
- * `http:`/`https:` scheme; otherwise `null`. This is the **protocol allowlist**
- * alone — no host screen — so a `javascript:`/`data:`/`file:` URL (or an
- * unparseable one) is rejected while a public-host `http(s)` URL passes. It is
- * the shared source of the http(s) rule reused by {@link isSafeFetchUrl} (which
- * layers the SSRF host screen on top) and by pano's submit-URL persistence gate,
- * which needs the protocol allowlist without the fetch-time host block.
+ * The **protocol allowlist alone** — no host screen. Rejects `javascript:`/`data:`/
+ * `file:` and unparseable URLs. {@link isSafeFetchUrl} layers the SSRF host screen on
+ * top; pano's submit-URL persistence gate wants this one without it.
  */
 export function isHttpUrl(raw: string): URL | null {
 	let url: URL;
@@ -118,11 +91,8 @@ export function isHttpUrl(raw: string): URL | null {
 }
 
 /**
- * Resolve a (possibly relative) redirect `Location` against `base`, returning
- * `null` for an unparseable ref. Lives here (a non-Effect helper) so the base-aware
- * `new URL` parse — which throws on a malformed ref — stays a plain guarded parse
- * rather than an `Effect.try` in the route; the caller re-screens the result through
- * {@link isSafeFetchUrl}.
+ * Resolve a (possibly relative) redirect `Location` against `base`; `null` if
+ * unparseable. The caller MUST re-screen the result through {@link isSafeFetchUrl}.
  */
 export function resolveUrl(location: string, base: URL): URL | null {
 	try {
@@ -133,10 +103,8 @@ export function resolveUrl(location: string, base: URL): URL | null {
 }
 
 /**
- * Parse `raw` and return the {@link URL} only if it is safe to fetch
- * server-side; otherwise `null`. Fail-closed: an unparseable URL, a
- * non-`http(s)` scheme, or a private/loopback/link-local/CGNAT/metadata IP
- * literal or local-only hostname all return `null`.
+ * Parse `raw` and return the {@link URL} only if it is safe to fetch server-side.
+ * Fail-closed: unparseable, non-`http(s)`, or a blocked host all return `null`.
  */
 export function isSafeFetchUrl(raw: string): URL | null {
 	const url = isHttpUrl(raw);
@@ -146,8 +114,7 @@ export function isSafeFetchUrl(raw: string): URL | null {
 	if (host === "" || host === "localhost") return null;
 	if (LOCAL_HOST_SUFFIXES.some((s) => host.endsWith(s))) return null;
 
-	// `URL.hostname` keeps the `[...]` around an IPv6 literal (WHATWG URL) —
-	// strip them before the address screen.
+	// `URL.hostname` keeps the `[...]` around an IPv6 literal (WHATWG URL).
 	if (host.startsWith("[") && host.endsWith("]")) {
 		return isBlockedIPv6(host.slice(1, -1)) ? null : url;
 	}
@@ -156,7 +123,6 @@ export function isSafeFetchUrl(raw: string): URL | null {
 	return url;
 }
 
-/** Decode the handful of HTML entities that show up in title/description text. */
 function decodeEntities(text: string): string {
 	return text
 		.replace(/&#x([0-9a-fA-F]+);/g, (_, hex) => String.fromCodePoint(Number.parseInt(hex, 16)))
@@ -169,12 +135,10 @@ function decodeEntities(text: string): string {
 		.replace(/&amp;/g, "&");
 }
 
-/** Normalize extracted text: decode entities, collapse whitespace, trim, cap length. */
 function clean(text: string): string {
 	return decodeEntities(text).replace(/\s+/g, " ").trim().slice(0, MAX_FIELD_LEN);
 }
 
-/** Parse one `<meta …>` tag's attributes into a lowercase-keyed map. */
 function metaAttrs(tag: string): Record<string, string> {
 	const attrs: Record<string, string> = {};
 	const re = /([a-zA-Z:_-]+)\s*=\s*("([^"]*)"|'([^']*)')/g;
@@ -187,10 +151,8 @@ function metaAttrs(tag: string): Record<string, string> {
 }
 
 /**
- * The first non-empty `<meta>` content matching a key, honoring KEY PRIORITY
- * over document order: each key in `keys` is tried in turn (`og:*` before the
- * plain fallback), and the whole document is scanned per key. Attribute order
- * within a tag is irrelevant — `content` may precede or follow `property`.
+ * The first non-empty `<meta>` content matching a key, honoring KEY PRIORITY over
+ * document order: the whole document is scanned once per key, in `keys` order.
  */
 function metaContent(html: string, keys: readonly string[]): string | undefined {
 	const tags = html.match(/<meta\b[^>]*>/gi) ?? [];
@@ -211,10 +173,9 @@ function metaContent(html: string, keys: readonly string[]): string | undefined 
 }
 
 /**
- * Lift the page title and description out of raw HTML. Title prefers
- * `og:title`, falling back to `<title>`; description prefers `og:description`,
- * falling back to `meta[name=description]`. A field with no source is absent —
- * the client then leaves that form field untouched.
+ * Lift title + description out of raw HTML: `og:title` then `<title>`;
+ * `og:description` then `meta[name=description]`. A field with no source is absent,
+ * so the client leaves that form field untouched.
  */
 export function parseLinkMetadata(html: string): LinkMetadata {
 	const result: {title?: string; description?: string} = {};

--- a/apps/web/worker/features/pano/link-metadata.unit.test.ts
+++ b/apps/web/worker/features/pano/link-metadata.unit.test.ts
@@ -1,15 +1,8 @@
 /**
- * The pure core of the pano link-metadata prefill route (#1642): the SSRF guard
- * (`isSafeFetchUrl`) and the HTML metadata parser (`parseLinkMetadata`). Both
- * are tested here without a worker or a live network — the same testable-pure-
- * core idiom as `evaluate-contract.unit.test.ts`.
- *
- * `isSafeFetchUrl` is the security surface: it must admit only public `http(s)`
- * targets and reject every private/loopback/link-local/CGNAT/metadata address
- * and local-only hostname (AC: "rejects non-http(s) schemes and private/…IPs").
- * `parseLinkMetadata` must prefer `og:*` and fall back to `<title>` / `meta
- * description`, and yield an absent field (never a throw) when a source is
- * missing.
+ * The pure core of the pano link-metadata prefill route (#1642), tested without a worker
+ * or a live network. `isSafeFetchUrl` is the security surface: it must admit only public
+ * `http(s)` targets and reject every private/loopback/link-local/CGNAT/metadata address
+ * and local-only hostname.
  */
 import {describe, expect, it} from "vitest";
 import {isSafeFetchUrl, MAX_FIELD_LEN, parseLinkMetadata} from "./link-metadata.ts";

--- a/apps/web/worker/features/pano/lists.ts
+++ b/apps/web/worker/features/pano/lists.ts
@@ -1,17 +1,9 @@
 /**
- * Pano root list resolvers. Per ADR 0019, root lists map a service keyset page
- * onto a `ConnectionResult`: the service owns the cursor and keyset SQL, this
- * layer only reshapes. `sort` is a plain validated string (no fate enum, ADR
- * 0018). See `.patterns/fate-connections.md`.
+ * Pano root list resolvers. The service owns the cursor and keyset SQL, this layer
+ * only reshapes (ADR 0019; .patterns/fate-connections.md).
  *
- * - `posts` — the public feed. For a signed-in viewer the keyset page is
- *   re-hydrated through `Pano.getPostsByIds`, so `myVote`/`isSaved` ride the same
- *   batch as `savedPosts` and feed rows reflect the viewer's real vote/save state;
- *   signed-out skips the extra read and resolves to neutral state.
- * - `savedPosts` — the viewer's bookmarks, ordered by save time, `CurrentUser`-
- *   scoped; signed-out resolves to an empty connection (the read-path "viewer
- *   scalar degrades, never throws" convention). Hydrated through
- *   `Pano.getPostsByIds`, so `isSaved`/`myVote` ride the same batch as the feed.
+ * Signed-out reads degrade rather than throw: `savedPosts` resolves to an empty
+ * connection and `posts` skips the hydration pass, serving neutral viewer scalars.
  */
 
 import {CurrentUser, Fate} from "@kampus/fate-effect";
@@ -45,11 +37,8 @@ const LANDING_POSTS_DEFAULT = 5;
 const LandingPostsArgs = Schema.Struct({first: Schema.optional(Schema.Number)});
 
 export const lists = {
-	// The public landing "panoda son 24 saat" column (#1424) — most-recent posts,
-	// pinned to the ANONYMOUS sandbox viewer so the front door shows LIVE content
-	// only (`sandboxed_at IS NULL`, via `listPostsConnection`'s `sandboxVisibleWhere`),
-	// matching the public `landingStats` counts (#1391); a signed-in çaylak's own
-	// sandboxed post never surfaces here. Display-only — no `myVote`/`isSaved` stamping.
+	// Pinned to the ANONYMOUS sandbox viewer, so the front door shows LIVE content only
+	// and a signed-in çaylak's own sandboxed post never surfaces here (#1424/#1391).
 	landingPosts: Fate.list(
 		{args: LandingPostsArgs, type: PostView},
 		Effect.fn("landingPosts")(function* ({args}) {
@@ -69,12 +58,12 @@ export const lists = {
 	posts: Fate.list(
 		{args: PostsArgs, type: PostView},
 		Effect.fn("posts")(function* ({args}) {
-			// Resolve the sandbox viewer once (identity + moderator probe); the feed
-			// hides çaylak-sandboxed posts from anyone but their author + a mod (#1205).
+			// Resolved once (identity + moderator probe): the feed hides çaylak-sandboxed
+			// posts from anyone but their author + a mod (#1205).
 			const sandboxViewer = yield* currentSandboxViewer;
 			const viewerId = sandboxViewer.viewerId;
-			// Mute read-mask (#3113): the muter's muted authors, gated behind the
-			// default-off `member-mute` flag (empty set off ⇒ today's feed unchanged).
+			// Gated behind the default-off `member-mute` flag — empty set means unchanged
+			// feed (#3113).
 			const mutedIds = yield* currentMutedIds;
 			const pano = yield* Pano;
 			const page = yield* pano.listPostsConnection({
@@ -86,7 +75,6 @@ export const lists = {
 				mutedIds,
 			});
 
-			// Signed-out: serve the keyset page as-is (neutral `myVote`/`isSaved`).
 			if (!viewerId) {
 				return toConnection<PostSummaryRow, Post>(
 					page,
@@ -95,9 +83,7 @@ export const lists = {
 				);
 			}
 
-			// Signed-in: re-hydrate the page ids through `getPostsByIds` to batch-stamp
-			// the viewer's `myVote`/`isSaved`, then re-order to the keyset (the `inArray`
-			// fetch loses the sort), mirroring `savedPosts`.
+			// The `inArray` re-hydration loses the sort, so re-order back to the keyset.
 			const ids = page.rows.map((row) => row.id);
 			const hydrated = yield* pano.getPostsByIds(ids, {viewerId, sandboxViewer});
 			const byId = new Map(hydrated.map((row) => [row.id, row]));
@@ -134,8 +120,8 @@ export const lists = {
 				...(args.after !== undefined ? {after: args.after} : {}),
 			});
 
-			// `getPostsByIds` stamps `isSaved`/`myVote` in one batch but loses the
-			// save-time order (`inArray`), so re-order to the bookmark keyset.
+			// `getPostsByIds` loses the save-time order (`inArray`), so re-order to the
+			// bookmark keyset.
 			const hydrated = yield* pano.getPostsByIds(page.ids, {viewerId});
 			const byId = new Map(hydrated.map((row) => [row.id, row]));
 			const rows = page.ids.flatMap((id) => {

--- a/apps/web/worker/features/pano/live.ts
+++ b/apps/web/worker/features/pano/live.ts
@@ -1,33 +1,15 @@
 /**
- * Pano live-publish targets — the ONE place that answers "what does mutating a
- * Post / Comment publish to?" Each target binds the entity's wire `__typename`
- * (read off the view's `typeName`, never an inline `"Post"`/`"Comment"` literal)
- * to the topic(s) it participates in, so a resolver names the fan-out target
- * instead of restating the magic-string seam (#1127).
+ * Pano live-publish targets — the ONE place that answers "what does mutating a Post /
+ * Comment publish to?" Each target binds the entity's wire `__typename` (read off the
+ * view's `typeName`, never an inline literal) to the topics it participates in.
  *
- * No behavior change: the bound calls forward verbatim to `WorkerLivePublisher`,
- * so the published frames are byte-identical to the prior inline wiring — the
- * typename is the SAME string (`PostView.typeName === "Post"`), just sourced from
- * the view. The `changed` hint stays a per-resolver argument: it is mutation-
- * specific (which fields a write touched), not a property of the entity, and it
- * does not reach the wire (`live-publisher.ts` builds `{data}` only).
+ * `appendNode` / `prependNode` take a `PublishDecision` and gate through `broadcastIf`, so
+ * a resolver cannot broadcast a node to these viewer-blind public topics without
+ * discharging the sandbox check. `deleteEdge` carries no node payload, so it stays ungated.
  *
- * `appendNode` / `prependNode` (the create-time node broadcasts, the #1205 leak
- * surface) take a `PublishDecision` and gate through `broadcastIf` — so a resolver
- * cannot broadcast a node to these viewer-blind public topics without discharging the
- * sandbox check (#1280). `deleteEdge` carries no node payload, so it stays ungated.
- *
- * Every one of these publish methods ALSO fires the base-feed edge-cache purge
- * (`feedCache.purge`, ADR 0170 / #2324): a fanned pano write is by construction a
- * feed-visible write (the base feed carries each post's score/reactions/body +
- * `commentCount`), so the SAME seam that publishes the `/fate/live` invalidation
- * purges the cached base feed — one write, two invalidations. The purge is best-effort
- * (`never` channel, `waitUntil`) and gated off the leg-B cache flag inside the purger,
- * so it is a pure no-op until release. The one benign over-fire: the dark-shipped
- * `taslak` path (`post.saveDraft`/`discardDraft`) publishes a private entity update
- * through `post.update`/`post.delete` and thus also purges — harmless (a purge only
- * ever forces a re-fill of an unchanged feed, never serves stale) and unreachable until
- * the draft flag itself is on.
+ * Every publish here ALSO purges the base-feed edge cache (ADR 0170): a fanned pano write
+ * is by construction a feed-visible write, so one seam fires both invalidations. The purge
+ * is best-effort and flag-gated inside the purger, so it is a no-op until release.
  */
 
 import {Effect} from "effect";
@@ -40,11 +22,7 @@ import {CommentView, PostView} from "./views.ts";
 const POST = PostView.typeName;
 const COMMENT = CommentView.typeName;
 
-/**
- * Run a publish, then fire the base-feed purge alongside it (both `Effect<void>`,
- * `never` channel). `zipRight` sequences the two best-effort invalidations; neither
- * can fail the mutation.
- */
+/** Sequences the two best-effort invalidations; neither can fail the mutation. */
 const withPurge = (feedCache: WorkerPanoFeedCache, publish: Effect.Effect<void>) =>
 	publish.pipe(Effect.flatMap(() => feedCache.purge()));
 
@@ -69,10 +47,8 @@ const onTopic = (
 });
 
 /**
- * Bind pano's publish targets to the per-request publisher + the base-feed purger.
  * `feed` is the global `posts` connection; `comments(postId)` is the args-scoped
- * `Post.comments` connection keyed by the parent post. Every method fires
- * `feedCache.purge` alongside its live publish (see the module docblock).
+ * `Post.comments` connection keyed by the parent post.
  */
 export const panoLive = (live: WorkerLivePublisher, feedCache: WorkerPanoFeedCache) => ({
 	post: {

--- a/apps/web/worker/features/pano/live.unit.test.ts
+++ b/apps/web/worker/features/pano/live.unit.test.ts
@@ -1,10 +1,7 @@
 /**
- * `panoLive` — the pano publish seam (ADR 0155). AC#2 of #2324 (ADR 0170): every
- * fanned pano publish method fires the base-feed edge-cache purge ALONGSIDE its
- * `/fate/live` publish, the cache-side twin of the live fan-out. This pins that
- * one write drives BOTH invalidations at the seam, mirroring the live-publisher tests.
- *
- * Unit tier (ADR 0082): stubs at the publisher + purger seam, zero storage.
+ * `panoLive` — the pano publish seam. Pins that every fanned publish method fires the
+ * base-feed edge-cache purge ALONGSIDE its `/fate/live` publish, so one write drives both
+ * invalidations (ADR 0155 / ADR 0170).
  */
 import {assert, it} from "@effect/vitest";
 import {Effect} from "effect";
@@ -13,12 +10,10 @@ import {alwaysLive} from "../kunye/sandbox.ts";
 import type {WorkerPanoFeedCache} from "./feed-cache.ts";
 import {panoLive} from "./live.ts";
 
-/** A real (typed) publisher whose delivery is a no-op — only the purge count matters here. */
 function recordingPublisher() {
 	return livePublisherFor({publish: () => Effect.void, waitUntil: () => {}});
 }
 
-/** A purger that counts `purge()` invocations. */
 function countingFeedCache() {
 	let purges = 0;
 	const feedCache: WorkerPanoFeedCache = {

--- a/apps/web/worker/features/pano/mutations.ts
+++ b/apps/web/worker/features/pano/mutations.ts
@@ -1,15 +1,7 @@
 /**
- * Pano mutation resolvers — the post + comment write path. Per ADR 0020, each
- * calls a `Pano` method then returns the **re-resolved affected entity** shaped
- * like a read: `comment.delete` returns the parent `Post` (so the cache updates
- * the surrounding thread); `post.delete` returns the deleted post's `{id}` (a
- * post has no parent — evict by id). Domain validation stays in the service
- * (ADR 0013); infra failures die there, never reaching this layer.
- *
- * `CurrentUser.required` gates every write (anonymous → `UNAUTHORIZED`). Live
- * publishes go through `WorkerLivePublisher`, whose every method's error channel
- * is `never` — a failed publish can never fail the mutation
- * (`.patterns/fate-effect-server.md`). See `.patterns/fate-effect-operations.md`.
+ * Pano mutation resolvers — the post + comment write path. Each returns the
+ * re-resolved affected entity shaped like a read (ADR 0020); a delete returns a bare
+ * `{id}` eviction ref. See `.patterns/fate-effect-operations.md`.
  */
 
 import {CurrentUser, Fate, Unauthorized} from "@kampus/fate-effect";
@@ -80,10 +72,8 @@ const PostIdInput = Schema.Struct({
 	id: PostId,
 });
 
-// `emoji` decodes against the curated `REACTION_EMOJI` palette (or `null` to
-// retract): a non-palette string FAILS to decode here, at the wire boundary, so a
-// bad emoji never reaches `Reaction.react` — the rejection is structural, not a
-// service error (the settled curated-fixed-palette model, #1859/#1863).
+// An off-palette emoji FAILS to decode here, at the wire boundary, so it never reaches
+// `Reaction.react` — the rejection is structural, not a service error (#1859).
 const ReactToPostInput = Schema.Struct({
 	id: PostId,
 	emoji: Schema.NullOr(ReactionEmojiSchema),
@@ -105,10 +95,6 @@ const CommentIdInput = Schema.Struct({
 	id: CommentId,
 });
 
-// `emoji` decodes against the curated `REACTION_EMOJI` palette (or `null` to
-// retract): a non-palette string FAILS to decode here, at the wire boundary, so a
-// bad emoji never reaches `Reaction.react` — the rejection is structural, not a
-// service error (the settled curated-fixed-palette model, #1859/#1864).
 const ReactToCommentInput = Schema.Struct({
 	id: CommentId,
 	emoji: Schema.NullOr(ReactionEmojiSchema),
@@ -119,9 +105,6 @@ const EditCommentInput = Schema.Struct({
 	body: Schema.String,
 });
 
-// `Pano` write results name the id `postId`/`commentId` and the author
-// `authorName`, so map those keys to the shapers' wire field names. `slug` is
-// `null` on a write result (the detail read carries it).
 const shapePost = (r: {
 	postId: string;
 	slug?: string | null;
@@ -159,10 +142,9 @@ const shapePost = (r: {
 		tags: r.tags,
 	});
 
-// `sandboxed` is REQUIRED here, never optional-with-a-default: it is owner-scoped
-// (#4282), and every one of these results is either returned to a specific viewer or
-// broadcast to the viewer-blind thread topic. Forcing each call site to state the value
-// is what keeps a broadcast payload from silently inheriting an author's review state.
+// `sandboxed` is REQUIRED, never optional-with-a-default: it is owner-scoped (#4282)
+// and these results are also broadcast to the viewer-blind thread topic. Forcing each
+// call site to state it keeps a broadcast from inheriting an author's review state.
 const shapeComment = (r: {
 	commentId: string;
 	parentId: string | null;
@@ -200,7 +182,6 @@ export const mutations = {
 			const submit = Effect.fn("post.submitBody")(function* () {
 				const pano = yield* Pano;
 				const live = panoLive(yield* WorkerLivePublisher, yield* PanoFeedCache);
-				// A çaylak's new post lands sandboxed; a yazar's is live (#1205).
 				const sandboxedAt = yield* sandboxedAtForAuthor(user.id, new Date());
 				const r = yield* pano.submitPost({
 					title: input.title,
@@ -212,24 +193,14 @@ export const mutations = {
 					sandboxedAt,
 				});
 				const post = shapePost({...r, myVote: null});
-				// New post leads the feed: prepend to the `posts` topic (every
-				// feed-sort variant, via the global topic). Inline node, no DB work —
-				// but only when the post is live: the feed topic is viewer-blind, so a
-				// sandboxed node would leak to non-author/anonymous subscribers (#1205 AC#2).
+				// The feed topic is viewer-blind, so a sandboxed node would leak to non-author
+				// subscribers — hence the `decidePublish` gate (#1205).
 				yield* live.post.feed.prependNode(post.id, {node: post}, decidePublish(sandboxedAt));
-				// Mod-queue heartbeat (#1699): if this sandboxed post is the çaylak's FIRST
-				// pending item, page the moderators that a new çaylak awaits review. Gated,
-				// transition-guarded and swallowed inside the emitter — never fails the post.
 				yield* notifyCaylakEntersDivan({authorId: user.id, sandboxedAt});
 				return post;
 			});
-			// Post-value karma gate (#150), dark behind the default-off
-			// `phoenix-karma-gates` flag: ON ⇒ `CanPost` floors the author's karma at
-			// ≥ −4 before the post lands (a downvoted-into-the-ground author is muted
-			// with `INSUFFICIENT_KARMA`); OFF ⇒ inert, the post behaves as today. A
-			// SEPARATE axis from the çaylak→yazar sandbox tier above — the sandbox
-			// contains a new author's REACH, this floors an abused author's karma
-			// (no double-gating, #150 rescope).
+			// Karma floor (#150), dark behind default-off `phoenix-karma-gates`: ON ⇒ the author
+			// must be at ≥ −4. A separate axis from the sandbox tier above (reach vs abuse).
 			return yield* gateContentOnKarma(submit());
 		}),
 	),
@@ -254,9 +225,7 @@ export const mutations = {
 					: {}),
 			});
 			const post = shapePost({...r, myVote: null});
-			// A draft is private: re-resolve the affected entity (so the author's cache
-			// updates with `isDraft: true`), but never prepend it to the public `posts`
-			// topic.
+			// A draft is private: re-resolve for the author, never prepend to the public topic.
 			yield* live.post.update(post.id, {changed: ["isDraft"], data: post});
 			return post;
 		}),
@@ -282,11 +251,7 @@ export const mutations = {
 		{
 			input: PostIdInput,
 			type: PostView,
-			// `VoterNotEligible` (wire `VOTE_REQUIRES_YAZAR`) — the "earn to vote" gate: a çaylak newcomer
-			// is rejected at cast, never a silent no-op (#1810). `SelfVoteNotAllowed` (wire
-			// `SELF_VOTE_NOT_ALLOWED`) — the founder-ruled self-vote block (#2216). Both are
-			// cast-only: `retractVote` needs neither (a newcomer never cleared the cast, and a
-			// blocked self-cast leaves nothing to retract).
+			// Both tier gates are cast-only; `retractVote` needs neither.
 			error: Schema.Union([Unauthorized, PostNotFound, VoterNotEligible, SelfVoteNotAllowed]),
 		},
 		Effect.fn("post.vote")(function* ({input}) {
@@ -294,21 +259,14 @@ export const mutations = {
 			const pano = yield* Pano;
 			const live = panoLive(yield* WorkerLivePublisher, yield* PanoFeedCache);
 			const r = yield* pano.voteOnPost({postId: input.id, voterId: UserId.make(user.id)});
-			// Re-resolve the affected post via the same batched read `post.save`/`post.unsave`
-			// use, so the returned AND published projection carries the real `isSaved` + live
-			// author identity. The write result (`VoteOnPostResult`) has neither, and its
-			// null-bearing shape clobbered the client cache — and the fanned live frame — of an
-			// already-saved post (#2213).
+			// Re-resolve via the batched read: the write result carries no `isSaved`, and its
+			// null-bearing shape clobbered the cache of an already-saved post (#2213).
 			const [row] = yield* pano.getPostsByIds([input.id], {viewerId: user.id});
 			if (!row) {
 				return yield* new PostNotFound({postId: input.id, message: `post ${input.id} not found`});
 			}
 			const post = toPost(row);
 			yield* live.post.update(post.id, {changed: ["score"], data: post});
-			// Aggregated vote notification (#1698): a LANDED upvote (not an idempotent
-			// no-op) notifies the post author — rolled up per item, self-suppressed,
-			// flag-gated and swallowed inside the emitter, so it can never fail this
-			// committed cast. `r.authorId` is server-derived, never client-supplied.
 			if (r.changed) {
 				yield* notifyContentVote({
 					authorId: r.authorId,
@@ -331,8 +289,7 @@ export const mutations = {
 			const pano = yield* Pano;
 			const live = panoLive(yield* WorkerLivePublisher, yield* PanoFeedCache);
 			yield* pano.retractPostVote({postId: input.id, voterId: UserId.make(user.id)});
-			// Re-resolve like `post.vote` above so the returned/published projection keeps the
-			// real `isSaved` + author identity instead of the null-bearing write shape (#2213).
+			// Re-resolve like `post.vote` so the projection keeps real `isSaved` + author (#2213).
 			const [row] = yield* pano.getPostsByIds([input.id], {viewerId: user.id});
 			if (!row) {
 				return yield* new PostNotFound({postId: input.id, message: `post ${input.id} not found`});
@@ -342,16 +299,8 @@ export const mutations = {
 			return post;
 		}),
 	),
-	// `post.react` — the karma-free, ungated reaction twin of `post.vote` (#1863,
-	// epic #1840). It delegates to `Reaction.react` (kind `post`), decoding the
-	// emoji against the curated `REACTION_EMOJI` palette at the wire boundary
-	// (`ReactToPostInput`) — a non-palette emoji fails to decode and never reaches
-	// the service. A palette emoji sets/changes the viewer's single reaction; a
-	// `null` emoji retracts it (the cardinality-one change/retract contract). Unlike
-	// `post.vote` there is deliberately NO `VoterNotEligible` tier arm and NO karma
-	// path: any signed-in user — including a çaylak — may react. The re-resolved post
-	// carries the fresh `reactions` aggregate; `live.update` flips every open card's
-	// reaction bar.
+	// Karma-free and ungated on purpose: any signed-in user, including a çaylak, may
+	// react — no `VoterNotEligible` arm, unlike `post.vote` (#1863).
 	"post.react": Fate.mutation(
 		{
 			input: ReactToPostInput,
@@ -361,11 +310,8 @@ export const mutations = {
 		Effect.fn("post.react")(function* ({input}) {
 			const user = yield* CurrentUser.required;
 			const pano = yield* Pano;
-			// Dark-ship gate (ADR 0083): default-off `phoenix-reactions`. Off ⇒ inert — the
-			// react never lands (the write is the new path, unreachable until release);
-			// re-resolve the post unchanged so the caller's cache stays consistent (the
-			// `comment.react` / `definition.react` dark-ship inert-receipt shape). On a
-			// Flagship outage the safe read default (`false`) keeps the path dark.
+			// Dark-ship gate (ADR 0083). Off ⇒ the react never lands; re-resolve unchanged so
+			// the caller's cache stays consistent. A Flagship outage reads `false` = dark.
 			const flags = yield* Flags;
 			const on = yield* flags.getBoolean(PHOENIX_REACTIONS, false).pipe(provideRequestFlags);
 			if (!on) {
@@ -386,12 +332,6 @@ export const mutations = {
 			return post;
 		}),
 	),
-	// `post.save` / `post.unsave` mirror `post.vote` / `post.retractVote`: gate on a
-	// signed-in viewer, toggle the bookmark (idempotent in the service), then
-	// re-resolve the post via the same batched `getPostsByIds` read so the returned
-	// entity carries an accurate, freshly-stamped `isSaved`. `live.update` flips
-	// every open card. Both reject a missing/deleted post with `POST_NOT_FOUND`
-	// (raised by `Bookmark.toggle`).
 	"post.save": Fate.mutation(
 		{
 			input: PostIdInput,
@@ -473,10 +413,8 @@ export const mutations = {
 			const user = yield* CurrentUser.required;
 			const pano = yield* Pano;
 			const live = panoLive(yield* WorkerLivePublisher, yield* PanoFeedCache);
-			// The removal commit runs over `DrizzleAccessOrDie` — a D1-layer write failure
-			// dies as a defect, which would escape this union as a raw `INTERNAL_SERVER_ERROR`
-			// (#1639). Catch that defect into the declared, user-readable `PostDeleteFailed`;
-			// the typed `UnauthorizedPostMutation` (a failure, not a defect) passes through.
+			// The removal commit runs over `DrizzleAccessOrDie`, so a D1 write failure DIES as a
+			// defect and would escape this union as `INTERNAL_SERVER_ERROR` (#1639).
 			const r = yield* pano
 				.deletePost({postId: input.id, actorId: UserId.make(user.id)})
 				.pipe(
@@ -486,13 +424,11 @@ export const mutations = {
 				);
 			yield* live.post.delete(r.postId);
 			yield* live.post.feed.deleteEdge(r.postId);
-			// Bare id-only eviction ref: the post is hidden, so there's no row to run
-			// through `toPost` and it stays a `{__typename, id}` the client drops.
+			// Bare id-only eviction ref: the post is hidden, so there is no row to shape.
 			return {__typename: "Post", id: r.postId};
 		}),
 	),
-	// Restore (un-delete) a removed post (ADR 0096 §4). Re-enters the feed; votes
-	// stay wiped (score 0). Returns the re-resolved `Post`.
+	// Restore a removed post (ADR 0096 §4). Re-enters the feed; votes stay wiped.
 	"post.restore": Fate.mutation(
 		{
 			input: PostIdInput,
@@ -517,10 +453,8 @@ export const mutations = {
 					authorDisplayName: stamped?.authorDisplayName ?? null,
 				},
 			);
-			// Sandbox-faithful restore (#1811): a çaylak's sandboxed post round-trips
-			// back to Sandboxed, so route the broadcast through the #1205/#1280 gate
-			// (decidePublish) instead of the always-Live hatch — a sandboxed restore is
-			// suppressed from the public feed; a Live restore broadcasts as before.
+			// Sandbox-faithful restore (#1811): a sandboxed post round-trips back to sandboxed,
+			// so the broadcast goes through `decidePublish`, not an always-live hatch.
 			yield* live.post.feed.appendNode(post.id, {node: post}, decidePublish(restored.sandboxedAt));
 			return post;
 		}),
@@ -541,7 +475,6 @@ export const mutations = {
 			const add = Effect.fn("comment.addBody")(function* () {
 				const pano = yield* Pano;
 				const live = panoLive(yield* WorkerLivePublisher, yield* PanoFeedCache);
-				// A çaylak's new comment lands sandboxed; a yazar's is live (#1205).
 				const sandboxedAt = yield* sandboxedAtForAuthor(user.id, new Date());
 				const r = yield* pano.addComment({
 					postId: input.postId,
@@ -551,37 +484,28 @@ export const mutations = {
 					sandboxedAt,
 					...(input.parentId ? {parentId: input.parentId} : {}),
 				});
-				// Safe to stamp the owner-scoped flag on this value even though it is also the
-				// broadcast node (#4282): the append below is `decidePublish`-gated, so a node
-				// whose flag is `true` is exactly the node that is never broadcast.
+				// Safe to stamp the owner-scoped flag on the broadcast node: the append below is
+				// `decidePublish`-gated, so a `true` node is exactly the one never broadcast (#4282).
 				const comment = shapeComment({
 					...r,
 					myVote: null,
 					sandboxed: ownSandboxed({sandboxedAt, authorId: r.authorId}, user.id),
 				});
-				// Append to the `Post.comments` topic keyed by the parent post id — but
-				// only when the comment is live: the thread topic is viewer-blind, so a
-				// sandboxed node would leak to non-author/anonymous subscribers (#1205 AC#2).
+				// The thread topic is viewer-blind, so a sandboxed node would leak to non-author
+				// subscribers — hence the `decidePublish` gate (#1205).
 				yield* live.comment
 					.thread(input.postId)
 					.appendNode(comment.id, {node: comment}, decidePublish(sandboxedAt));
-				// Conversation-moment notification (#1697): notify the post author (and,
-				// for a reply, the parent-comment author) — deduped, self-suppressed,
-				// flag-gated and swallowed inside the emitter, so it can never fail this
-				// committed comment.
 				yield* notifyCommentReply({
 					commentId: r.commentId,
 					postAuthorId: r.postAuthorId,
 					parentAuthorId: r.parentAuthorId,
 					actorId: user.id,
 				});
-				// Mod-queue heartbeat (#1699): a sandboxed comment that is the çaylak's FIRST
-				// pending item pages the moderators — same transition gate as post.submit.
 				yield* notifyCaylakEntersDivan({authorId: user.id, sandboxedAt});
 				return comment;
 			});
-			// Post-value karma gate (#150), dark behind `phoenix-karma-gates` — the same
-			// ≥ −4 floor as `post.submit`, applied to the comment write path.
+			// Karma floor (#150), dark behind `phoenix-karma-gates` — same as `post.submit`.
 			return yield* gateContentOnKarma(add());
 		}),
 	),
@@ -589,9 +513,7 @@ export const mutations = {
 		{
 			input: CommentIdInput,
 			type: CommentView,
-			// `VoterNotEligible` (wire `VOTE_REQUIRES_YAZAR`) — the "earn to vote" gate (#1810), same as
-			// `post.vote`. `SelfVoteNotAllowed` (wire `SELF_VOTE_NOT_ALLOWED`, #2216) — a cast on one's
-			// own comment is rejected, mirroring `post.vote`. Retraction is exempt for the same reason.
+			// Both tier gates are cast-only; `retractVote` needs neither.
 			error: Schema.Union([Unauthorized, CommentNotFound, VoterNotEligible, SelfVoteNotAllowed]),
 		},
 		Effect.fn("comment.vote")(function* ({input}) {
@@ -603,8 +525,6 @@ export const mutations = {
 			// author and the owner-scoped flag is `false` for them regardless (#4282).
 			const comment = shapeComment({...r, sandboxed: false});
 			yield* live.comment.update(comment.id, {changed: ["score"], data: comment});
-			// Aggregated vote notification (#1698): see `post.vote` — a landed upvote
-			// notifies the comment author, rolled up per item, on a real state change only.
 			if (r.changed) {
 				yield* notifyContentVote({
 					authorId: r.authorId,
@@ -636,18 +556,8 @@ export const mutations = {
 			return comment;
 		}),
 	),
-	// `comment.react` — set / change / retract the viewer's single reaction on a
-	// comment (epic #1840, #1864), the direct twin of `post.react` and the karma-free,
-	// ungated mirror of `comment.vote`. `CurrentUser.required` is the ONLY gate (a
-	// signed-out reactor is `Unauthorized`) — deliberately NO `VoterNotEligible` tier
-	// arm and NO karma path: any signed-in user, including a çaylak, may react. The
-	// emoji decodes against the curated `REACTION_EMOJI` palette at the wire boundary
-	// (`ReactToCommentInput`) — an off-palette emoji fails to decode and never reaches
-	// the service. The re-resolved comment carries the fresh `reactions` aggregate, and
-	// `live.comment.update({changed: ["reactions"]})` fans that aggregate out to every
-	// open subscriber so a reader watching the thread sees the count move (#1868) — the
-	// reaction twin of `comment.vote`'s score publish, through the same never-failing
-	// `WorkerLivePublisher`.
+	// Karma-free and ungated on purpose: any signed-in user, including a çaylak, may
+	// react — no `VoterNotEligible` arm, unlike `comment.vote` (#1864).
 	"comment.react": Fate.mutation(
 		{
 			input: ReactToCommentInput,
@@ -657,11 +567,8 @@ export const mutations = {
 		Effect.fn("comment.react")(function* ({input}) {
 			const user = yield* CurrentUser.required;
 			const pano = yield* Pano;
-			// Dark-ship gate (ADR 0083): default-off `phoenix-reactions`. Off ⇒ inert — the
-			// react never lands (the write is the new path, unreachable until release);
-			// re-resolve the comment unchanged so the caller's cache stays consistent (the
-			// `definition.react` dark-ship inert-receipt shape). On a Flagship outage the
-			// safe read default (`false`) keeps the path dark.
+			// Dark-ship gate (ADR 0083). Off ⇒ the react never lands; re-resolve unchanged so
+			// the caller's cache stays consistent. A Flagship outage reads `false` = dark.
 			const flags = yield* Flags;
 			const on = yield* flags.getBoolean(PHOENIX_REACTIONS, false).pipe(provideRequestFlags);
 			if (!on) {
@@ -711,9 +618,8 @@ export const mutations = {
 				myVote: fresh?.myVote ?? null,
 				sandboxed: fresh?.sandboxed ?? false,
 			});
-			// The thread topic is viewer-blind (#1205), so the broadcast payload is stripped of
-			// the owner-scoped flag while the author's own returned node keeps it — an edit must
-			// not fan a çaylak's review state out to subscribers (#4282).
+			// The thread topic is viewer-blind, so the broadcast payload drops the owner-scoped
+			// `sandboxed` flag while the author's own returned node keeps it (#4282).
 			yield* live.comment.update(comment.id, {
 				changed: ["body"],
 				data: {...comment, sandboxed: false},
@@ -751,13 +657,9 @@ export const mutations = {
 					authorDisplayName: stamped?.authorDisplayName ?? null,
 				},
 			);
-			// Removal is always soft now (ADR 0096); the reply-aware decision only
-			// shapes the live signal:
-			//  - leaf (no replies): the service returns no placeholder, so `deleteEdge`
-			//    drops it from every open `Post.comments` thread without a reload.
-			//  - has replies: the row stays as a `[silindi]` tombstone (view-rendered).
-			//    The edge must NOT leave the connection — that would orphan the subtree;
-			//    instead publish the tombstoned comment so threads re-render it in place.
+			// Removal is always soft (ADR 0096); the reply-aware branch only shapes the live
+			// signal. A leaf comment leaves the connection; one with replies must NOT — that
+			// would orphan the subtree — so its `[silindi]` tombstone is published in place.
 			if (result.placeholder) {
 				const placeholder = toComment(result.placeholder);
 				yield* live.comment.update(input.id, {
@@ -767,13 +669,11 @@ export const mutations = {
 			} else {
 				yield* live.comment.thread(post.id).deleteEdge(input.id);
 			}
-			// Either way the parent post's `commentCount` changes — publish it.
 			yield* live.post.update(post.id, {changed: ["commentCount"], data: post});
 			return post;
 		}),
 	),
-	// Restore (un-delete) a removed comment (ADR 0096 §4). Re-appends it to the
-	// thread; votes stay wiped. Returns the re-resolved parent `Post`.
+	// Restore a removed comment (ADR 0096 §4). Votes stay wiped.
 	"comment.restore": Fate.mutation(
 		{
 			input: CommentIdInput,
@@ -793,10 +693,8 @@ export const mutations = {
 			const [comment] = yield* pano.getCommentsByIds([input.id], {viewerId: user.id});
 			if (comment) {
 				const node = toComment(comment);
-				// Sandbox-faithful restore (#1811): a çaylak's sandboxed comment round-trips
-				// back to Sandboxed, so route the thread broadcast through the #1205/#1280
-				// gate — a sandboxed restore is suppressed from the viewer-blind thread
-				// topic; a Live restore broadcasts as before.
+				// Sandbox-faithful restore (#1811): route the thread broadcast through the
+				// #1205 gate so a sandboxed restore is not fanned to the viewer-blind topic.
 				yield* live.comment
 					.thread(postId)
 					.appendNode(node.id, {node}, decidePublish(restored.sandboxedAt ?? null));

--- a/apps/web/worker/features/pano/ordering.ts
+++ b/apps/web/worker/features/pano/ordering.ts
@@ -1,17 +1,13 @@
 /**
- * Pano connection orderings the view `orderBy` and the service keyset share
- * (ADR 0019; see `db/ordering.ts`). The post-feed sort lives in
- * `src/lib/panoFeedSort.ts` (per-sort, DB-free so the SPA shares it); this is
+ * Pano connection orderings the view `orderBy` and the service keyset share (ADR 0019). The
+ * post-feed sort lives in `src/lib/panoFeedSort.ts` (DB-free so the SPA shares it); this is
  * the comment-thread ordering, which has no SPA half.
  */
 
 import * as schema from "../../db/drizzle/schema.ts";
 import type {Ordering} from "../../db/ordering.ts";
 
-/**
- * `Post.comments` (the comment thread): `createdAt asc, id asc`. Consumed by
- * `Post.comments`' view `orderBy` and the `Pano.listCommentsKeyset` keyset.
- */
+/** `Post.comments`: `createdAt asc, id asc`, shared by the view `orderBy` and the keyset. */
 export const COMMENT_ORDERING: Ordering = [
 	{field: "createdAt", column: schema.commentRecord.createdAt, dir: "asc"},
 	{field: "id", column: schema.commentRecord.id, dir: "asc"},

--- a/apps/web/worker/features/pano/pano-stats.ts
+++ b/apps/web/worker/features/pano/pano-stats.ts
@@ -1,11 +1,7 @@
 /**
- * The pano-wide `pano_stats` cache — the one read model that spans both planes
- * (post + comment + author totals), so it lives apart from either plane's
- * operations. A pure fold (`recomputePanoStats`) decides the row from the three
- * live COUNTs + the write clock (ADR 0082), and `makePersistPanoStats` is the thin
- * port that gathers the COUNTs and upserts.
- *
- * Write owned by the source-mutation path, not the query-only stats feature (ADR 0117).
+ * The pano-wide `pano_stats` cache — the one read model spanning both planes (post + comment
+ * + author totals), so it lives apart from either plane's operations. Written by the
+ * source-mutation path, not the query-only stats feature (ADR 0117).
  */
 import {sql} from "drizzle-orm";
 import {Effect} from "effect";
@@ -15,14 +11,12 @@ import {anonymousViewer} from "../lifecycle/EntityLifecycle.ts";
 import {publicLiveWhere} from "../lifecycle/SandboxVisibility.ts";
 import {publicLivePostWhere} from "./PostVisibility.ts";
 
-/** The three live COUNTs the pano-stats fold reads. */
 export interface PanoStatsCounts {
 	totalPosts: number;
 	totalComments: number;
 	totalAuthors: number;
 }
 
-/** The `pano_stats` row the upsert persists — fully derived from the counts + `now`. */
 export interface PanoStats {
 	totalPosts: number;
 	totalComments: number;
@@ -30,11 +24,7 @@ export interface PanoStats {
 	updatedAt: number;
 }
 
-/**
- * Pure stats fold: `pano_stats` is fully derived from the three live COUNTs + the
- * write clock (ADR 0082 — the decision lifted above the Drizzle seam). `updatedAt`
- * is unix seconds, matching the column.
- */
+// `updatedAt` is unix seconds, matching the column.
 export const recomputePanoStats = (counts: PanoStatsCounts, now: Date): PanoStats => ({
 	totalPosts: counts.totalPosts,
 	totalComments: counts.totalComments,
@@ -42,17 +32,11 @@ export const recomputePanoStats = (counts: PanoStatsCounts, now: Date): PanoStat
 	updatedAt: Math.floor(now.getTime() / 1000),
 });
 
-/**
- * Build the `persistPanoStats` port: gather the three live COUNTs via `run`, call
- * the pure `recomputePanoStats` fold, persist via the upsert. Runs after every write
- * that could affect totals. The closure keeps the `Pano.recomputePanoStats` span name.
- */
 export const makePersistPanoStats = (run: DrizzleAccessOrDie["run"]) =>
 	Effect.fn("Pano.recomputePanoStats")(function* (now: Date) {
-		// Public counts are LIVE-only for the anonymous viewer, sourced from the shared
-		// seam (#1359/#1407): posts route through the post-aware predicate so drafts are
-		// excluded too (a draft-only author never inflates the totals); comments have no
-		// draft dimension and use the base public-live predicate.
+		// Public counts are LIVE-only for the anonymous viewer. Posts route through the
+		// post-aware predicate so drafts are excluded too (a draft-only author never inflates the
+		// totals); comments have no draft dimension.
 		const postWhere = publicLivePostWhere(
 			{
 				removedAt: schema.postRecord.removedAt,
@@ -110,5 +94,4 @@ export const makePersistPanoStats = (run: DrizzleAccessOrDie["run"]) =>
 		);
 	});
 
-/** The `persistPanoStats` port type, shared by both plane operation factories. */
 export type PersistPanoStats = ReturnType<typeof makePersistPanoStats>;

--- a/apps/web/worker/features/pano/persist-pano-stats-public-live.unit.test.ts
+++ b/apps/web/worker/features/pano/persist-pano-stats-public-live.unit.test.ts
@@ -1,17 +1,10 @@
 /**
- * `makePersistPanoStats` public-live count wiring (#1407). The per-product
- * `pano_stats` totals (`total_posts`, `total_comments`, `total_authors`) count LIVE
- * content only: a sandboxed çaylak row is excluded like a removed one, and a draft
- * post is excluded too — a draft-only author must never inflate the totals.
+ * `pano_stats` totals count LIVE content only: a sandboxed row is excluded like a
+ * removed one, and a draft-only author must never inflate the totals (#1407).
  *
- * #1407 folds these counts onto the shared seam: posts route through the post-aware
- * `publicLivePostWhere` (removed + sandbox + draft) and comments through
- * `publicLiveWhere` (removed + sandbox), for the anonymous viewer — replacing the
- * hand-written `removed_at IS NULL AND sandboxed_at IS NULL` clauses.
- *
- * Unit-tier per ADR 0082: what THIS proves is that each count WIRES the seam
- * predicate. The counts execute against a RECORDING D1 binding whose `prepare(sql)`
- * records every statement, so their compiled WHERE clauses are inspectable.
+ * What this proves is that each count WIRES the shared seam predicate rather than a
+ * hand-written clause. The counts execute against a RECORDING D1 binding, so their
+ * compiled WHERE clauses are inspectable.
  */
 import {assert, describe, it} from "@effect/vitest";
 import {Effect} from "effect";
@@ -52,8 +45,8 @@ function recordingD1(): {binding: D1Database; recorded: {sql: string}[]} {
 
 const recordCounts = Effect.gen(function* () {
 	const {binding, recorded} = recordingD1();
-	// `makePersistPanoStats` takes the OR-DIE run (error channel `never`); compose
-	// `orDieAccess` over the raw access so the test's `run` matches that signature.
+	// `makePersistPanoStats` takes the OR-DIE run, so compose `orDieAccess` over the
+	// raw access to match that signature.
 	const access = orDieAccess(makeDrizzleAccess(createDrizzle(binding)));
 	yield* makePersistPanoStats(access.run)(new Date("2024-06-01T00:00:00.000Z"));
 	return recorded.map((q) => q.sql.toLowerCase());

--- a/apps/web/worker/features/pano/persist-pano-stats.unit.test.ts
+++ b/apps/web/worker/features/pano/persist-pano-stats.unit.test.ts
@@ -1,15 +1,8 @@
 /**
- * Coverage for the `recomputePanoStats` → row-write coupling (#1337) — the seam
- * the fold-only `recompute-pano-stats.unit.test.ts` leaves untested. The pure fold
- * is proven in isolation there; what THIS file proves is that the fold's output is
- * wired into the `pano_stats` upsert by its thin port (`makePersistPanoStats`).
- *
- * `makePersistPanoStats(run)` is exercised directly with a scripted `run`: the
- * three live COUNTs replay canned totals, and the final upsert's `sql` template is
- * captured (not executed) and rendered with the SQLite dialect — no engine, ADR
- * 0082/0104/0105 (no revived `node:sqlite` fake, no `runFateOp`). Row-level
- * behavior on real D1 stays the integration tier's job; the column LANDING is what
- * is unit-reachable here.
+ * The `recomputePanoStats` → row-write coupling (#1337) — the seam the fold-only
+ * `recompute-pano-stats.unit.test.ts` leaves untested. The upsert's `sql` template is
+ * captured and rendered with the SQLite dialect, never executed (ADR 0082/0104/0105);
+ * row-level behavior on real D1 stays the integration tier's job.
  */
 import {describe, it} from "@effect/vitest";
 import {SQLiteDialect} from "drizzle-orm/sqlite-core";
@@ -18,7 +11,6 @@ import * as Schema from "effect/Schema";
 import {assert} from "vitest";
 import type {DrizzleAccessOrDie, DrizzleDb} from "../../db/Drizzle.ts";
 
-/** A rejection from the stubbed `run` thunk — dies, matching `run`'s `never` channel. */
 class RunRejected extends Schema.TaggedErrorClass<RunRejected>()("test/RunRejected", {
 	cause: Schema.Unknown,
 }) {}
@@ -27,9 +19,8 @@ import {makePersistPanoStats} from "./pano-stats.ts";
 
 const dialect = new SQLiteDialect();
 
-// makePersistPanoStats issues four `run`s in order: the three live COUNTs (posts,
-// comments, authors) then the `pano_stats` upsert. The first three replay canned
-// totals; the upsert's `sql` template is captured and rendered — never executed.
+// Four `run`s in order: the three live COUNTs (posts, comments, authors), then the
+// `pano_stats` upsert.
 function scriptedRun(counts: readonly [number, number, number]): {
 	run: DrizzleAccessOrDie["run"];
 	upsert: () => {sql: string; params: unknown[]};
@@ -39,8 +30,6 @@ function scriptedRun(counts: readonly [number, number, number]): {
 	const run = (<A>(fn: (db: DrizzleDb) => Promise<A>) => {
 		const idx = state.i++;
 		if (idx < 3) return Effect.succeed(counts[idx] as A);
-		// The upsert: a capturing `db.run` records the `sql` template; the dialect
-		// renders it to `{sql, params}` without touching a real binding.
 		// biome-ignore lint/plugin: a capturing DrizzleDb stub — only `.run` is exercised to record the rendered upsert; no query executes against a binding.
 		const captureDb = {
 			run: (query: unknown) => {
@@ -73,8 +62,6 @@ describe("makePersistPanoStats — the recomputePanoStats → pano_stats row-wri
 
 			const {sql: upsertSql, params} = scripted.upsert();
 			assert.match(upsertSql, /pano_stats/, "the upsert targets pano_stats");
-			// recomputePanoStats({posts:5, comments:12, authors:3}, now) ⇒ the three
-			// counts passed through + `now` floored to unix seconds, in column order.
 			assert.deepStrictEqual(
 				params,
 				[5, 12, 3, updatedAt],

--- a/apps/web/worker/features/pano/post-by-id-draft-visibility.unit.test.ts
+++ b/apps/web/worker/features/pano/post-by-id-draft-visibility.unit.test.ts
@@ -1,15 +1,10 @@
 /**
- * The by-id / batch-by-id draft-ownership gate (#1405, ADR 0113). `getPost` and
- * `getPostsByIds` must route the draft decision through the one PostVisibility seam
- * (`postVisibleTo` / `postVisibleWhere`), so a viewer holding a draft's id never reads
- * another author's unpublished draft while the author still reads their own
- * (read-your-writes). Two tiers, both unit-reachable over a substituted `Drizzle`:
+ * The by-id / batch-by-id draft-ownership gate (ADR 0113): a viewer holding a draft's
+ * id must never read another author's unpublished draft, while the author still reads
+ * their own.
  *
- *   - `getPost` decides in memory (relational query builder), so the leak case and
- *     read-your-writes are asserted as the actual returned value.
- *   - `getPostsByIds` decides in SQL, so the leak/own-draft behavior is the rendered
- *     `.toSQL()` predicate: the draft arm (`is_draft is not 1`) plus the signed-in
- *     ownership disjunction (`author_id = :viewerId`) the seam composes.
+ * `getPost` decides in memory, so it is asserted on the returned value; `getPostsByIds`
+ * decides in SQL, so it is asserted on the rendered `.toSQL()` predicate.
  */
 import {assert, describe, it} from "@effect/vitest";
 import {drizzle} from "drizzle-orm/d1";
@@ -95,7 +90,6 @@ const panoLayer = (access: DrizzleAccess) =>
 
 const now = new Date("2026-06-27T00:00:00.000Z");
 
-// A live (not removed, not sandboxed) draft `post_record` authored by AUTHOR.
 // biome-ignore lint/plugin: a row fixture standing in for a `post_record` select — getPost only reads the lifecycle/draft/author columns + the `toPostPage` field set off it; enumerating every column adds nothing.
 const draftRow = {
 	id: "post_draft1",

--- a/apps/web/worker/features/pano/post-delete-undeclared-failure.unit.test.ts
+++ b/apps/web/worker/features/pano/post-delete-undeclared-failure.unit.test.ts
@@ -1,24 +1,10 @@
 /**
- * `post.delete` has no undeclared failure channel (#1639).
- *
- * The mutation declared only `Unauthorized | UnauthorizedPostMutation`, but its
- * removal commit runs over `DrizzleAccessOrDie` — a D1-layer write failure *dies*,
- * and a defect is not a member of that union, so it escaped the handler as a raw
- * `INTERNAL_SERVER_ERROR` (the squashed-defect wire code, `WireError.ts`). Two
- * regressions pin the closure:
- *
- *   (a) WIRE boundary — driven through `resolveWire` (`resolve` decode +
- *       `encodeWireError` class→wire-code, the same seams `/fate` crosses):
- *         - own-post delete → success (the id-only eviction ref, never a 500);
- *         - missing / already-removed post → success (the graceful `deleted:false`);
- *         - a removal-commit *die* → the DECLARED, annotated `POST_DELETE_FAILED`,
- *           NOT `INTERNAL_SERVER_ERROR`. Without the handler's `catchDefect` this
- *           asserts `INTERNAL_SERVER_ERROR` and fails.
- *
- *   (b) SERVICE — the post-commit stats refresh is a recomputable cache (ADR
- *       0011/0117): a refresh die must NOT flip an already-committed removal into a
- *       failure (the partial-commit-then-500). Driven over a scripted `Drizzle`
- *       whose stamp batch commits but whose later stats `run` dies.
+ * `post.delete` has no undeclared failure channel (#1639). Its removal commit runs over
+ * `DrizzleAccessOrDie`, so a D1 write failure DIES — and a defect is in no declared
+ * error union, so it used to escape as a raw `INTERNAL_SERVER_ERROR`. Two regressions
+ * pin the closure: (a) a removal-commit die must reach the wire as the declared
+ * `POST_DELETE_FAILED`; (b) a post-commit stats-refresh die must not flip an
+ * already-committed removal into a failure (ADR 0011/0117 — a recomputable cache).
  */
 import {assert, describe, it} from "@effect/vitest";
 import {CurrentUser, LivePublisher} from "@kampus/fate-effect";
@@ -46,13 +32,11 @@ const runtimeContextStub: BaseRuntimeContext = {
 	set: (id) => Effect.succeed(id),
 };
 
-// Fire-and-forget publish (error channel `never`); it can never fail the mutation.
 const liveStub = Layer.succeed(LivePublisher)(
 	livePublisherFor({publish: () => Effect.void, waitUntil: () => {}}),
 );
 
-// A `Pano` stub whose `deletePost` is scripted; every other method dies loud — the
-// handler path only ever reaches `deletePost`.
+// Every method but `deletePost` dies loud, so an unexpected call is caught.
 const panoStub = (deletePost: (typeof Pano.Service)["deletePost"]): Layer.Layer<Pano> =>
 	Layer.succeed(
 		Pano,
@@ -109,7 +93,6 @@ describe("post.delete — (a) no undeclared failure channel at the wire boundary
 	);
 });
 
-// The stamp batch commits (source of truth), then the post-commit stats refresh dies.
 const ownerId = UserId.make(AUTHOR.id);
 const removalCommitsThenStatsDie = (): DrizzleAccess => {
 	let runs = 0;
@@ -135,8 +118,7 @@ const removalCommitsThenStatsDie = (): DrizzleAccess => {
 	} as DrizzleAccess;
 };
 
-// `Vote.clearTarget` is the only Vote method `removeEntity` reaches; succeed inertly.
-// Every other method dies loud (mirrors `panoStub`), so an unexpected call is caught.
+// `clearTarget` is the only Vote method `removeEntity` reaches; the rest die loud.
 const voteStub = Layer.succeed(
 	Vote,
 	new Proxy({clearTarget: () => Effect.void} as Partial<Context.Service.Shape<typeof Vote>>, {

--- a/apps/web/worker/features/pano/post-fields.ts
+++ b/apps/web/worker/features/pano/post-fields.ts
@@ -1,18 +1,12 @@
 /**
- * `Post`'s one column→field map — the single structure the row mappers
- * (`rowToPostPage` + the by-id summary projection in `Pano.ts`), the wire shaper
- * (`toPost` in `shapers.ts`), and the view field declaration (`PostView` in
- * `views.ts`) all derive from, so a one-field change touches this map instead of
- * three hand-synced restatements (#1166, the Pano half of #1126 AC#1).
+ * `Post`'s one column→field map. The row mappers, the wire shaper and the view
+ * field declaration all derive from it, so a one-field change lands here instead of
+ * in three hand-synced restatements (#1166).
  *
- * Post diverges more than `Definition`: it has two record sources — the detail
- * `PostPage` reads the canonical `body`, the feed summary reads `bodyExcerpt`
- * (the `bodySource` knob is the only field that varies). `myVote` / `isSaved` are
- * viewer scalars — part of the view/wire field set (`postViewFields`) but *not*
- * read from the record here: they are stamped by `stampViewerScalars` after the
- * batched `user_vote` / `post_bookmark` reads (#1159, `viewer-scalars.ts`).
- * `isDraft`, by contrast, IS a record column (the taslak marker), so it rides the
- * intrinsic map.
+ * Two things to know: the detail page reads the canonical `body` while the feed
+ * summary reads `bodyExcerpt` (the `bodySource` knob), and the viewer scalars
+ * (`myVote` / `isSaved`) are stamped downstream from batched reads, never read from
+ * the record here.
  */
 
 import {tagLabel} from "../../../src/lib/panoTags.ts";
@@ -29,7 +23,6 @@ export interface PostTagRow {
 /** Empty body collapses to `null` so every path yields the same wire shape. */
 const normalizeBody = (raw: string | null): string | null => (raw && raw.length > 0 ? raw : null);
 
-/** Parse the comma-separated `post_record.tags` CSV into `{kind, label}` scalars. */
 export const parseTags = (csv: string): PostTagRow[] => {
 	if (!csv) return [];
 	return csv
@@ -39,14 +32,8 @@ export const parseTags = (csv: string): PostTagRow[] => {
 		.map((kind) => ({kind, label: tagLabel(kind)}));
 };
 
-/**
- * The intrinsic (record-derived) wire fields, in `PostView` order, each mapping a
- * `post_record` row onto its wire value. The keys ARE the wire field names; the
- * readers absorb the `authorName`→`author` rename, the null-timestamp fallback,
- * the `tags` CSV parse, and the `body` vs `bodyExcerpt` source split (the one
- * divergence between the detail-page and feed-summary mappers, selected by
- * `bodySource`).
- */
+// The keys ARE the wire field names, so the readers absorb the `authorName`→`author`
+// rename, the null-timestamp fallback, the CSV parse and the body-source split.
 const intrinsicFields = {
 	id: (p) => p.id,
 	slug: (p) => p.slug,
@@ -70,44 +57,21 @@ type IntrinsicRow = {
 	[K in keyof typeof intrinsicFields]: ReturnType<(typeof intrinsicFields)[K]>;
 };
 
-/**
- * `PostSummaryRow` — the feed/keyset row: the record-derived intrinsic fields
- * plus the `myVote` / `isSaved` viewer scalars that `stampViewerScalars` adds
- * downstream. `updatedAt` and `isDraft` are optional here: the keyset projection
- * (`listPostsKeyset`) and the search projection select a column subset that omits
- * them, while the by-id read (`toPostSummaryRow`) supplies both. The viewer
- * scalars are `undefined` when not requested — never read from the record.
- */
+// `updatedAt` and `isDraft` are optional because the keyset and search projections
+// select a column subset that omits them; the by-id read supplies both.
 export interface PostSummaryRow extends Omit<IntrinsicRow, "updatedAt" | "isDraft"> {
 	updatedAt?: Date;
-	/** Draft (taslak) marker; stamped from `post_record.is_draft` (null = published). */
 	isDraft?: boolean | null;
-	/** Viewer's upvote presence (`true` voted); `undefined`/`null` when not requested or anonymous. */
 	myVote?: boolean | null;
-	/** Viewer's bookmark presence; `undefined` (unset) for reads that don't request it. */
 	isSaved?: boolean | null;
-	/**
-	 * The owner-scoped in-review flag (#2200): `true` iff this post is still sandboxed
-	 * (#1205) AND the viewer is its author, stamped by the read paths via `ownSandboxed`.
-	 * Owner-only by construction, so it never leaks review state to another viewer; a
-	 * read that doesn't stamp it leaves it `undefined` → the shaper defaults `false`.
-	 */
+	// Owner-scoped in-review flag (#2200): true only when the viewer is the author, so
+	// it never leaks review state to anyone else. Unstamped reads leave it `undefined`
+	// and the shaper defaults it false.
 	sandboxed?: boolean;
-	/**
-	 * The author's LIVE handle (`user_profile.username` / `.displayName`), stamped by
-	 * `stampAuthorIdentity` after the batched `getProfileIdentitiesByIds` read (#2139)
-	 * so the client renders the CURRENT display name via `actorLabel`, not the write-time
-	 * `authorName` snapshot (#2126's AC). `undefined` when not requested; `null` when the
-	 * author has no profile/handle — `actorLabel` then degrades to `@username` → fallback.
-	 */
+	// The author's LIVE handle, stamped from a batched profile read so the client shows
+	// the current display name rather than the write-time `authorName` snapshot (#2139).
 	authorUsername?: string | null;
 	authorDisplayName?: string | null;
-	/**
-	 * The reaction aggregate (per-emoji counts + the viewer's own reaction), stamped
-	 * by `stampReactionAggregate` after the batched `user_reaction` read (#1862) —
-	 * `undefined` for reads that don't request it; the shaper fills the empty
-	 * aggregate so the wire field is always present.
-	 */
 	reactions?: ReactionAggregate;
 }
 
@@ -118,23 +82,10 @@ export interface PostConnectionPage {
 	totalCount: number;
 }
 
-/**
- * `PostPage` — the detail-page shape: the intrinsic fields read from the
- * canonical `body`, minus `isDraft` and the viewer scalars (a page read threads
- * `myVote` / `isSaved` in separately at the call site). `updatedAt` is required.
- */
 export type PostPage = Omit<IntrinsicRow, "isDraft">;
 
-/**
- * `PostFields` — the wire shaper's input (`toPost` in `shapers.ts`): the intrinsic
- * wire-named fields a shaper call supplies, derived from this one column→field map
- * so the wire shaper's field set can't drift from the row mappers / `postViewFields`
- * (the third hand-synced restatement #1126 AC#1 collapses). The shaper tolerates the
- * looser write/vote nullability — a fresh write/vote carries no `updatedAt`, and
- * `isDraft` + the `myVote` / `isSaved` viewer scalars are stamped late — so those ride
- * as optional; `tags` widens to a `ReadonlyArray`. The map stays the single source:
- * rename a column reader here and `PostFields` follows, no fourth restatement to sync.
- */
+// The wire shaper's input. Nullability is looser than the row's because a fresh
+// write or vote carries no `updatedAt` and the late-stamped fields are not there yet.
 export type PostFields = Omit<IntrinsicRow, "updatedAt" | "isDraft" | "tags"> & {
 	updatedAt?: Date | null;
 	isDraft?: boolean | null;
@@ -147,16 +98,10 @@ export type PostFields = Omit<IntrinsicRow, "updatedAt" | "isDraft" | "tags"> & 
 	tags: ReadonlyArray<PostTagRow>;
 };
 
-/**
- * The view/wire field selection (`{id: true, …}`) — a static literal (fate's
- * `FateDataView` reads the literal field map off this, so it can't be a
- * dynamically-built object). `satisfies Record<keyof PostSummaryRow, true>` pins
- * the scalar fields to exactly the row's fields: dropping one here (or adding one
- * to `PostSummaryRow` without listing it) is a compile error, so the view stays
- * in lockstep with the row mapper. `tags` and `comments` are non-scalar (`tags`
- * is an embedded-scalar array, `comments` a list relation); the `Omit` over them
- * lets `views.ts` declare those two structurally while pinning the rest.
- */
+// Must stay a static literal — fate's `FateDataView` reads the field map off it, so a
+// dynamically-built object won't do. The `satisfies` is what keeps the view in lockstep
+// with the row: dropping a field here, or adding one to `PostSummaryRow` without
+// listing it, is a compile error.
 export const postViewFields = {
 	id: true,
 	slug: true,
@@ -184,29 +129,14 @@ const fieldKeys = Object.keys(intrinsicFields) as Array<keyof typeof intrinsicFi
 const toRow = (p: PostRecord, bodySource: BodySource): IntrinsicRow =>
 	Object.fromEntries(fieldKeys.map((f) => [f, intrinsicFields[f](p, bodySource)])) as IntrinsicRow;
 
-/**
- * Map a `post_record` row onto the detail `PostPage` (canonical `body`) — the
- * single record→page mapping, shared by `getPost` and the delete-refresh.
- */
 export const toPostPage = (p: PostRecord): PostPage => toRow(p, "body");
 
-/**
- * Map a `post_record` row onto the feed `PostSummaryRow` (feed `bodyExcerpt`) —
- * the single record→summary mapping. `myVote` / `isSaved` are stamped by
- * `stampViewerScalars`, not here.
- */
 export const toPostSummaryRow = (p: PostRecord): PostSummaryRow => toRow(p, "bodyExcerpt");
 
-/**
- * The keyset/feed projection (`listPostsConnection`) selects a column SUBSET of
- * `post_record` — it omits `body`, `updatedAt`, `isDraft` — yet the summary row
- * it builds must agree with the by-id path field-for-field: `body` collapses to
- * `null` for an empty excerpt, not `""` (#1170). The subset is exactly the
- * `bodyExcerpt`-source intrinsic columns, so this routes it through the SAME
- * `intrinsicFields` map (the by-id path's `toPostSummaryRow`), instead of letting
- * the projection hand-sync its own divergent `body`. `updatedAt`/`isDraft` ride
- * as `undefined` — the optional `PostSummaryRow` fields the subset omits.
- */
+// The keyset projection selects a column subset, yet its rows must agree with the
+// by-id path field-for-field — an empty excerpt has to collapse to `null`, not `""`
+// (#1170). So it runs through the same `intrinsicFields` map instead of hand-syncing
+// its own body handling.
 export type PostKeysetRow = Pick<
 	PostRecord,
 	| "id"

--- a/apps/web/worker/features/pano/post-operations.ts
+++ b/apps/web/worker/features/pano/post-operations.ts
@@ -1,19 +1,7 @@
 /**
- * Pano's **posts plane** — the post half of the `Pano` service: post CRUD, the
- * draft lifecycle, vote delegation, the moderator soft-delete/restore pair, and the
- * connection-shaped feed/by-id reads. `makePostOperations` is the layer-build
- * factory: `PanoLive` hands it the shared runtime deps and spreads the returned
- * closures into the service object, so the wire surface is unchanged from when these
- * lived inline in `Pano.ts`.
- *
- * Submit-validation lives here as module-private pure functions (ADR 0013 for
- * *where* validation belongs, ADR 0082 for *why* it's lifted off the service): each
- * is wrong-or-right on its input with no DB. The wire codes unit-test off-DB THROUGH
- * the mutation (`submit-validation.unit.test.ts` drives `submitPost` / `saveDraft` /
- * `editPost` over a throwing `Drizzle`, proving the gate fires before any DB call),
- * and the integration tier keeps only the real-DB-miss cases.
- *
- * Validation lives in the service methods, not resolvers (ADR 0013).
+ * Pano's posts plane — post CRUD, drafts, vote/reaction delegation, the moderator
+ * soft-delete/restore pair, and the connection-shaped feed/by-id reads. Validation
+ * lives in the service methods, not resolvers (ADR 0013).
  */
 import {id} from "@usirin/forge";
 import {and, asc, desc, eq, gt, inArray, isNull, sql} from "drizzle-orm";
@@ -76,7 +64,6 @@ import {
 export const POST_TITLE_MAX = 200;
 export const POST_BODY_MAX = 10_000;
 
-/** Raw tag shape on submit/draft input — `label` is optional until normalized. */
 export interface PostTagInput {
 	kind: string;
 	label?: string | undefined;
@@ -89,10 +76,7 @@ export interface SubmitPostInput {
 	tags: ReadonlyArray<{kind: string; label?: string | undefined}>;
 	authorId: UserId;
 	authorName: string;
-	/**
-	 * The çaylak mod-only sandbox stamp (#1205), decided by the resolver from the
-	 * authorship flag + author tier. `null`/absent ⇒ posted live (today's behavior).
-	 */
+	/** Decided by the resolver from authorship + author tier (#1205); `null`/absent ⇒ posted live. */
 	sandboxedAt?: Date | null | undefined;
 }
 
@@ -119,7 +103,6 @@ export interface SaveDraftInput {
 	tags?: ReadonlyArray<{kind: string; label?: string | undefined}> | undefined;
 }
 
-/** A draft re-resolves like a fresh post; `isDraft` rides the wire as `true`. */
 export interface SaveDraftResult extends SubmitPostResult {
 	isDraft: true;
 }
@@ -157,21 +140,11 @@ export interface VoteOnPostResult {
 export interface ReactToPostInput {
 	postId: PostId;
 	userId: UserId;
-	/**
-	 * The reaction intent: a curated-palette member sets/changes the user's single
-	 * reaction; `null` retracts it (toggle off). Already decoded against
-	 * `ReactionEmojiSchema` at the wire boundary, so the service never sees a
-	 * non-palette string.
-	 */
+	/** Sets/changes the user's single reaction; `null` retracts it. */
 	emoji: ReactionEmoji | null;
 }
 
-/**
- * `reactToPost` re-resolves the affected post like a read (the `post.save` idiom),
- * so the returned entity carries the freshly-stamped `reactions` aggregate the
- * mutation echoes back. `changed` is the service's idempotency signal (a re-react
- * of the same emoji, or a retract-when-none, is `false`).
- */
+/** `changed` is the idempotency signal: a re-react of the same emoji, or a retract-when-none, is `false`. */
 export interface ReactToPostResult {
 	post: PostSummaryRow;
 	changed: boolean;
@@ -213,11 +186,9 @@ export interface DeletePostResult {
 }
 
 /**
- * A restore's result: whether it acted, and — for the live-broadcast decision — the
- * `sandboxedAt` the content landed back at (#1811). `null` ⇒ restored to `Live`
- * (broadcast via `alwaysLive`); non-null ⇒ restored to the çaylak sandbox, so the
- * mutation must suppress the live echo through `decidePublish`, matching the
- * create-time #1205 gate. Never broadcast a sandboxed restore to a public topic.
+ * `sandboxedAt` drives the live-broadcast decision (#1811): `null` ⇒ restored to `Live`,
+ * non-null ⇒ restored to the çaylak sandbox and the mutation must suppress the live echo
+ * through `decidePublish`. Never broadcast a sandboxed restore to a public topic.
  */
 export interface RestorePostResult {
 	postId: string;
@@ -225,7 +196,6 @@ export interface RestorePostResult {
 	sandboxedAt: Date | null;
 }
 
-/** Returns the normalized body (`null` for empty), or fails `PostBodyTooLong`. */
 const validatePostBody = Effect.fn("Pano.validatePostBody")(function* (rawBody: string) {
 	if (rawBody.length > POST_BODY_MAX) {
 		return yield* new PostBodyTooLong({
@@ -250,11 +220,7 @@ const validatePostTitle = Effect.fn("Pano.validatePostTitle")(function* (raw: st
 	return trimmed;
 });
 
-/**
- * Draft title gate — `saveDraft` has no required title (a half-filled form
- * persists), only the length cap. Returns the trimmed title or fails
- * `TitleTooLong`.
- */
+/** A draft has no required title (a half-filled form persists), only the length cap. */
 const validateDraftTitle = Effect.fn("Pano.validateDraftTitle")(function* (raw: string) {
 	const trimmed = raw.trim();
 	if (trimmed.length > POST_TITLE_MAX) {
@@ -266,16 +232,10 @@ const validateDraftTitle = Effect.fn("Pano.validateDraftTitle")(function* (raw: 
 });
 
 /**
- * Parse an optional submit/draft URL to its normalized form + host. An empty or
- * absent URL yields `{host: null, urlNormalized: null}`; a malformed URL OR one
- * whose scheme isn't `http(s)` fails `UrlInvalid`. Shared by `submitPost` and
- * `saveDraft`.
- *
  * The `http(s)`-only allowlist (via {@link isHttpUrl}) is defense-in-depth at the
- * PERSISTENCE layer: it keeps a `javascript:`/`data:`/`file:` URL from ever
- * reaching `post_record.url`, closing a stored-invariant gap so no consumer —
- * present or future, React or not — can ever read a non-http(s) href back out
- * (#1890). The bare-`new URL()` guard here previously admitted them.
+ * persistence layer: it keeps a `javascript:`/`data:`/`file:` URL from ever reaching
+ * `post_record.url`, so no consumer can read a non-http(s) href back out (#1890). A
+ * bare `new URL()` guard admits them.
  */
 const parseSubmitUrl = Effect.fn("Pano.parseSubmitUrl")(function* (url: string | null | undefined) {
 	if (url == null || url.length === 0) {
@@ -288,11 +248,6 @@ const parseSubmitUrl = Effect.fn("Pano.parseSubmitUrl")(function* (url: string |
 	return {host: parsed.host, urlNormalized: parsed.toString()} as const;
 });
 
-/**
- * `submitPost` tag normalization: at least one tag is required, every kind must
- * be in the fixed enum, duplicate kinds collapse. Fails `TagsRequired` /
- * `TagInvalid`.
- */
 const normalizeSubmitTags = Effect.fn("Pano.normalizeSubmitTags")(function* (
 	tags: ReadonlyArray<PostTagInput> | null | undefined,
 ) {
@@ -317,11 +272,7 @@ const normalizeSubmitTags = Effect.fn("Pano.normalizeSubmitTags")(function* (
 	return normalizedTags;
 });
 
-/**
- * `saveDraft` tag normalization: tags are optional (empty kinds skipped, not
- * rejected), but a non-empty kind outside the fixed enum still fails
- * `TagInvalid`.
- */
+/** Unlike submit, a draft's tags are optional — an empty kind is skipped, not rejected. */
 const normalizeDraftTags = Effect.fn("Pano.normalizeDraftTags")(function* (
 	tags: ReadonlyArray<PostTagInput> | null | undefined,
 ) {
@@ -340,7 +291,6 @@ const normalizeDraftTags = Effect.fn("Pano.normalizeDraftTags")(function* (
 	return normalizedTags;
 });
 
-/** The shared runtime deps `PanoLive` threads into the posts plane. */
 export interface PostOperationsDeps {
 	readonly run: DrizzleAccessOrDie["run"];
 	readonly batch: DrizzleAccessOrDie["batch"];
@@ -349,27 +299,16 @@ export interface PostOperationsDeps {
 	readonly reactionSvc: typeof Reaction.Service;
 	readonly removalSeq: Removal.RemovalSequence;
 	readonly persistPanoStats: PersistPanoStats;
-	/** Batched live author-identity reader (`Pasaport.getProfileIdentitiesByIds`, #2139). */
 	readonly readProfileIdentities: ReadProfileIdentities;
 }
 
 /**
- * Max live-non-draft rows a single decay SELECT materializes before the sweep advances
- * its keyset cursor (#2559). Bounds the isolate's per-query working set so a growing table
- * never loads an unbounded result set into memory in one shot — the sweep still visits
- * EVERY post each tick (windowless, #2133), just in id-ordered pages. Sized well above the
- * v1 cohort's tens-of-posts so today's pass is a single short page (no behavior change at
- * current scale) while the bound holds as the table grows; a named constant, tunable.
+ * Bounds one decay SELECT's working set (#2559). Paging is NOT a recency window — the
+ * sweep still visits every live non-draft post each tick (#2133).
  */
 export const HOT_SCORE_DECAY_CHUNK = 200;
 
-/**
- * The DB seam the chunked decay sweep drives, factored out so {@link scanDecayChunks}'s
- * cursor-advance + full-coverage (windowless) logic is unit-testable with in-memory ports
- * — no D1, mirroring the pure/`decayHotScores` split. `fetchChunk(afterId, limit)` returns
- * up to `limit` live-non-draft rows with `id > afterId` in ascending id order (`afterId`
- * `null` ⇒ from the head); `writeBack` persists the changed `hot_score`s of one page.
- */
+/** `fetchChunk` returns live non-draft rows with `id > afterId` ascending (`null` ⇒ from the head). */
 export interface HotDecayScanPorts {
 	readonly fetchChunk: (
 		afterId: string | null,
@@ -379,13 +318,9 @@ export interface HotDecayScanPorts {
 }
 
 /**
- * Keyset-chunk the windowless decay sweep: page id-ordered slices of at most `chunkSize`
- * rows, decaying + writing back each page before fetching the next, so no single query
- * scans the whole table in one shot (#2559). The sweep still covers every live non-draft
- * post per call — chunking is a mechanical batching of the same full pass, NOT a recency
- * window (#2133): the id-keyset cursor only bounds each page, it never excludes a post by
- * age. Loops until a short (`< chunkSize`) page marks the tail; an exact-multiple table
- * takes one extra empty page to terminate. Returns the pass's scanned/updated totals.
+ * The id-keyset cursor bounds each page only — it never excludes a post by age, so this
+ * covers every live non-draft post per call (#2133) while no single query scans the whole
+ * table (#2559).
  */
 export const scanDecayChunks = (
 	ports: HotDecayScanPorts,
@@ -401,8 +336,6 @@ export const scanDecayChunks = (
 			if (rows.length === 0) break;
 			scanned += rows.length;
 			const updates = decayHotScores(rows, nowMs);
-			// Nothing changed ⇒ no write (the common steady state) — writeBack is skipped, not
-			// called with an empty batch.
 			if (updates.length > 0) {
 				yield* ports.writeBack(updates);
 				updated += updates.length;
@@ -415,31 +348,13 @@ export const scanDecayChunks = (
 	});
 
 /**
- * The periodic sıcak/hot decay-refresh (#2027, WINDOWLESS since #2133, keyset-chunked in
- * #2559), factored to the ONE dep it reads (`run`) so it builds standalone. `hot_score` is
- * a stored, keyset-read column written only at activity sites, so an inactive post's age
- * term freezes and it squats the hot feed. This re-decays the stored column on a schedule
- * (the cron trigger in `index.ts`) so ranking keeps decaying with age WITHOUT a read-time
- * recompute — the READ-PATH keyset-cursor contract and the no-`POW` constraint both need
- * `hot_score` to stay a stored, indexed, monotonic-per-snapshot column. Scoped only to
- * live, non-draft posts (a removed post's `hot_score` is already zeroed by the removal
- * batch); the pure decision (formula reuse + changed-only filter) lives in
- * `db/hotScoreDecay.ts`, and the chunk-sweep control flow in {@link scanDecayChunks}.
- *
- * WINDOWLESS (#2133): earlier this pass scanned only a 72h recency window, so a post that
- * froze high and drifted past 72h was never re-selected and squatted the feed forever (the
- * ~18-day, hot_score=285 post the founder observed). Every live non-draft post is now
- * re-decayed each pass, so age keeps eroding rank at any age.
- *
- * KEYSET-CHUNKED SCAN (#2559): the sweep is bounded by an ascending-id keyset cursor into
- * `HOT_SCORE_DECAY_CHUNK`-sized pages rather than one unbounded SELECT, so the isolate
- * never materializes the whole table at once. The chunking is a WRITE/SCAN-path bound and
- * is distinct from the read-path feed pagination above — it does NOT reintroduce a window:
- * the cursor pages through EVERY post each tick, preserving #2133.
- *
- * Exported (not inlined in `makePostOperations`) so the AC4 integration test can drive the
- * SHIPPED method against real remote D1 built from just a `run` — no full
- * `PostOperationsDeps` graph, no re-implementation of the query.
+ * The periodic sıcak/hot decay-refresh (#2027), driven by the cron trigger in `index.ts`.
+ * `hot_score` is a stored, keyset-read column written only at activity sites, so an
+ * inactive post's age term freezes and it squats the hot feed; the read-path keyset
+ * contract and the no-`POW` constraint both need it to stay stored, so it is re-decayed
+ * on a schedule rather than at read time. Windowless since #2133 — an earlier 72h window
+ * left a frozen-high post squatting the feed forever. Exported so the integration test can
+ * drive the shipped method off just a `run`.
  */
 export const makeRefreshHotScores = (run: DrizzleAccessOrDie["run"]) =>
 	Effect.fn("Pano.refreshHotScores")(function* (now: Date) {
@@ -481,8 +396,6 @@ export const makeRefreshHotScores = (run: DrizzleAccessOrDie["run"]) =>
 							})),
 					),
 				),
-			// One UPDATE per changed row of the page, all in the caller's single clock reading.
-			// `Effect.forEach` sequences them.
 			writeBack: (updates) =>
 				Effect.forEach(
 					updates,
@@ -511,11 +424,8 @@ export const makePostOperations = (deps: PostOperationsDeps) => {
 		readProfileIdentities,
 	} = deps;
 
-	// The viewer scalars for `Post` (#1126): `myVote` (batched `user_vote`) +
-	// `isSaved` (batched `post_bookmark`). Every read finalizes through
-	// `stampViewerScalars` with these specs — one `IN (...)` read per scalar for the
-	// whole batch, never a per-row N+1 — so a new read path can't silently ship an
-	// always-`null` scalar.
+	// Every read finalizes through `stampViewerScalars` with these specs — one `IN (...)`
+	// read per scalar for the whole batch, never a per-row N+1 (#1126).
 	const postViewerScalars = [
 		{
 			field: "myVote",
@@ -545,14 +455,9 @@ export const makePostOperations = (deps: PostOperationsDeps) => {
 			}),
 		);
 		if (!meta) return null;
-		// Mute read-mask (#3113): a muted author's post reads as not-found for the
-		// muter, the in-memory dual of the feed's `mutedAuthorsWhere` SQL arm.
 		if (isMutedAuthor(meta.authorId, opts.mutedIds)) return null;
-		// The in-memory visibility decision via the ADR 0113 seam (`postVisibleTo`) —
-		// the mirror of the SQL `postVisibleWhere` the batch read uses, applied here
-		// because this single-row read uses the relational query builder. It composes
-		// the lifecycle + sandbox gate with the author-only draft arm, so a draft the
-		// viewer doesn't own reads as not-found while the author reads their own.
+		// The in-memory mirror of the SQL `postVisibleWhere` the batch read uses (ADR 0113),
+		// because this single-row read goes through the relational query builder.
 		if (
 			!postVisibleTo(
 				Removal.fromColumns(meta),
@@ -588,13 +493,11 @@ export const makePostOperations = (deps: PostOperationsDeps) => {
 			sql`${schema.postRecord.isDraft} is not 1`,
 		];
 		if (host) baseConditions.push(eq(schema.postRecord.host, host));
-		// Filter the çaylak sandbox (#1205) for this viewer at the same layer.
 		const sandboxClause = sandboxVisibleWhere(
 			{sandboxedAt: schema.postRecord.sandboxedAt, authorId: schema.postRecord.authorId},
 			resolveSandboxViewer(opts),
 		);
 		if (sandboxClause) baseConditions.push(sandboxClause);
-		// Mute read-mask (#3113): hide muted authors' posts from the muter's feed.
 		const muteClause = mutedAuthorsWhere(schema.postRecord.authorId, opts.mutedIds);
 		if (muteClause) baseConditions.push(muteClause);
 
@@ -606,18 +509,9 @@ export const makePostOperations = (deps: PostOperationsDeps) => {
 			createdAt: Date | null;
 		};
 
-		// The total count and the keyset page are INDEPENDENT reads over the same
-		// base predicate — the page query never consumes the count — so they run
-		// concurrently instead of serially, collapsing two cross-region D1
-		// round-trips into one overlapped batch and cutting the feed's latency floor
-		// (#2275). The combinator is the repo's `Effect.all([...], {concurrency:
-		// "unbounded"})` parallel-reads idiom (Divan.collect). NOT folded into a
-		// single `count(*) OVER()` window: the keyset query's WHERE carries the
-		// cursor predicate (`id < cursor`), so a window count there would total only
-		// the post-cursor slice, not the whole feed — a different result the fold is
-		// forbidden to change. Per-viewer scalars (myVote/isSaved) + reaction
-		// aggregates are NOT read here; they come from the batched `getPostsByIds`
-		// re-hydrate in the resolver, left untouched.
+		// Do NOT fold this into a `count(*) OVER()` window on the keyset query: that WHERE
+		// carries the cursor predicate (`id < cursor`), so the window would count only the
+		// post-cursor slice, not the whole feed (#2275).
 		const countEffect = run((db) =>
 			db
 				.select({n: sql<number>`count(*)`})
@@ -627,9 +521,6 @@ export const makePostOperations = (deps: PostOperationsDeps) => {
 				.then((r) => r?.n ?? 0),
 		);
 
-		// The keyset page path: resolve the cursor (a DB read only when `after` is
-		// present), short-circuit to `null` on a cursor miss (the caller renders the
-		// empty page), else fetch the page and stamp the live author identity.
 		const pageEffect = Effect.gen(function* () {
 			const resolvedRow = after
 				? ((yield* run((db) =>
@@ -650,9 +541,7 @@ export const makePostOperations = (deps: PostOperationsDeps) => {
 			if (cursor.kind === "miss") return null;
 			const cursorRow = cursor.kind === "hit" ? cursor.row : null;
 
-			// Both the keyset cursor predicate and `orderBy` derive from the one
-			// `POST_SORT_LEAD_COLUMN` map: an optional lead column (descending) +
-			// `id` desc tiebreaker; `new` (no lead column) orders by `id` alone.
+			// The cursor predicate and `orderBy` derive from one map so they cannot drift apart.
 			const leadKey = POST_SORT_LEAD_COLUMN[sort];
 			const leadColumn = leadKey
 				? {column: schema.postRecord[leadKey], value: cursorRow?.[leadKey]}
@@ -696,26 +585,17 @@ export const makePostOperations = (deps: PostOperationsDeps) => {
 					.limit(first + 1),
 			);
 
-			// Route the keyset projection through the same `post-fields.ts` column→field
-			// map the by-id path uses, so `body` collapses to `null` for an empty excerpt
-			// (not `""`) — the divergence is unrepresentable, not hand-synced (#1170).
 			const page = forwardPage(fetched, first, (r) => r.id, toPostSummaryKeysetRow);
 
-			// Stamp the LIVE author identity onto the page — one batched
-			// `getProfileIdentitiesByIds` read for the whole page (never per-row), the same
-			// idiom `getPostsByIds` uses. This is the feed's convergence point: the resolver
-			// paths that serve this page WITHOUT re-hydrating through `getPostsByIds` —
-			// `landingPosts` (always anon) and the signed-OUT `posts` feed — would otherwise
-			// render the write-time `authorName` snapshot and degrade to `@username` (#2151,
-			// the last unstamped pano read path from #2139's `stampAuthorIdentity` rollout).
+			// Without this, the paths that serve the page without re-hydrating through
+			// `getPostsByIds` (`landingPosts`, the signed-out `posts` feed) render the
+			// write-time `authorName` snapshot and degrade to `@username` (#2151).
 			const stampedRows = yield* stampAuthorIdentity(readProfileIdentities, page.rows);
 			return {...page, rows: stampedRows};
 		});
 
-		// `countEffect` is element 0 so its read is issued first — the parallelized
-		// reads are order-independent for correctness (each is fully consumed), but
-		// keeping count first preserves the deterministic call order the scripted
-		// unit doubles replay against (count, [cursor], fetch).
+		// `countEffect` stays element 0: correctness is order-independent, but the scripted
+		// unit doubles replay against the call order (count, [cursor], fetch).
 		const [totalCount, pageResult] = yield* Effect.all([countEffect, pageEffect], {
 			concurrency: "unbounded",
 		});
@@ -751,20 +631,12 @@ export const makePostOperations = (deps: PostOperationsDeps) => {
 							},
 							resolveSandboxViewer(opts),
 						),
-						// Mute read-mask (#3113): drop muted authors' posts from the muter's batch.
 						mutedAuthorsWhere(schema.postRecord.authorId, opts.mutedIds),
 					),
 				),
 		);
-		// `myVote`/`isSaved` are the viewer scalars, finalized via `stampViewerScalars`
-		// (one `user_vote` + one `post_bookmark` read for the whole batch); the row's
-		// intrinsic fields come from the `post-fields.ts` column→field map. The
-		// draft/ownership gate is enforced in SQL by `postVisibleWhere` above — a draft
-		// the viewer doesn't own never reaches this batch — so a surviving `isDraft` row
-		// is the author's own: read-your-writes, now verified rather than assumed.
-		// `sandboxed` is the owner-scoped in-review flag (#2200): computed off the fetched
-		// record (`sandboxed_at` + `author_id`) against the viewer, so it lands `true` only
-		// for the author's own still-in-review post and never leaks to another viewer.
+		// `sandboxed` is owner-scoped (#2200): it lands `true` only for the author's own
+		// still-in-review post and must never leak to another viewer.
 		const intrinsic = fetched.map((p) => ({
 			...toPostSummaryRow(p),
 			sandboxed: ownSandboxed(p, viewerId),
@@ -774,15 +646,9 @@ export const makePostOperations = (deps: PostOperationsDeps) => {
 		return yield* stampAuthorIdentity(readProfileIdentities, reacted);
 	});
 
-	// The viewer overlay (#2322, epic #2316 leg B): given the base feed's post ids,
-	// return ONLY the per-viewer scalars (`myVote`/`isSaved`) — the exact slice the
-	// GET-able base projection omits so it can be viewer-invariant + cacheable. Reuses
-	// the SAME `postViewerScalars` batch readers as `getPostsByIds` (one `user_vote` +
-	// one `post_bookmark` `IN (...)` read for the whole id batch, never per-row), so the
-	// split adds no N+1. It reads no `post_record` at all — presence is a property of
-	// the viewer's own vote/bookmark rows, so an id the viewer never touched degrades to
-	// `false` (or `null` for an anonymous viewer, the read-path convention). Nothing here
-	// is viewer-cross-visible: a reader only ever learns its OWN vote/save state.
+	// The per-viewer slice the GET-able base projection omits so it can stay
+	// viewer-invariant + cacheable (#2322). Reads no `post_record` at all, so a reader only
+	// ever learns its OWN vote/save state.
 	const readViewerOverlay = Effect.fn("Pano.readViewerOverlay")(function* (
 		ids: ReadonlyArray<string>,
 		opts: {viewerId?: string | null | undefined} = {},
@@ -797,10 +663,8 @@ export const makePostOperations = (deps: PostOperationsDeps) => {
 		return stamped.map((row) => ({id: row.id, myVote: row.myVote, isSaved: row.isSaved}));
 	});
 
-	// The moderator sandbox-queue / promotion-backlog read model (#1205, the #1206
-	// seam): a çaylak's still-sandboxed, not-removed posts — scoped to one author when
-	// promotion flips their backlog. Authority is gated at the resolver; the service
-	// read is unconditional.
+	// The moderator sandbox-queue read model (#1205). Authority is gated at the resolver;
+	// this service read is unconditional.
 	const listSandboxedPosts = Effect.fn("Pano.listSandboxedPosts")(function* (
 		opts: {authorId?: string | undefined} = {},
 	) {
@@ -835,9 +699,8 @@ export const makePostOperations = (deps: PostOperationsDeps) => {
 		const bodyExcerpt = body ? excerpt(body) : null;
 		const tagsCsv = normalizedTags.map((t) => t.kind).join(",");
 
-		// Summary insert + its FTS dual-write in ONE batch — all-or-none, so a
-		// crash mid-write can't orphan a `post_search` row against a missing
-		// `post_record` row (the ADR 0080 lockstep invariant).
+		// Insert + FTS dual-write in ONE batch: all-or-none, so a crash mid-write can't
+		// orphan a `post_search` row (the ADR 0080 lockstep invariant).
 		yield* batch((db) => [
 			db.insert(schema.postRecord).values({
 				id: postId,
@@ -862,9 +725,9 @@ export const makePostOperations = (deps: PostOperationsDeps) => {
 			...syncPostSearch(db, postId, title),
 		]);
 
-		// The post row committed in the batch above; its stats refresh is a recomputable
-		// cache, so swallow-and-log a die rather than 500 the mutation and provoke a retry
-		// that mints a duplicate row (#2556, the create-path twin of #2012).
+		// The row is already committed and the stats refresh is a recomputable cache, so a
+		// die is swallowed rather than 500ing the mutation into a duplicate-minting retry
+		// (#2556).
 		yield* swallowRefresh("Pano.submitPost", persistPanoStats(now));
 
 		return {
@@ -882,9 +745,7 @@ export const makePostOperations = (deps: PostOperationsDeps) => {
 		} satisfies SubmitPostResult;
 	});
 
-	// A draft is a partial post: the only gates are submit's length/sanity caps
-	// (no required title/tags), so a half-filled form persists. One draft per
-	// author is enforced by the partial unique index + this probe-then-upsert.
+	// One draft per author, enforced by the partial unique index + this probe-then-upsert.
 	const saveDraft = Effect.fn("Pano.saveDraft")(function* (input: SaveDraftInput) {
 		const rawTitle = yield* validateDraftTitle(input.title ?? "");
 		const body = yield* validatePostBody(input.body ?? "");
@@ -949,9 +810,8 @@ export const makePostOperations = (deps: PostOperationsDeps) => {
 			);
 		}
 
-		// A draft is never in the public FTS table (it never lists publicly), so
-		// no `syncPostSearch` dual-write and no `recomputePanoStats` — both are
-		// public-surface bookkeeping that a private draft must not touch.
+		// No `syncPostSearch` and no `recomputePanoStats` on purpose: both are public-surface
+		// bookkeeping a private draft must not touch.
 
 		return {
 			postId,
@@ -1031,9 +891,8 @@ export const makePostOperations = (deps: PostOperationsDeps) => {
 		const createdAtMs = meta.createdAt ? meta.createdAt.getTime() : now.getTime();
 		const hotScore = computeHotScore(meta.score, createdAtMs, now.getTime());
 
-		// Summary update + its FTS re-sync in ONE batch so they move all-or-none
-		// (ADR 0080). The body is out of v1 search scope, so a body-only edit
-		// leaves the FTS row untouched — only the summary update batches alone.
+		// Update + FTS re-sync in ONE batch so they move all-or-none (ADR 0080). The body is
+		// out of v1 search scope, so a body-only edit leaves the FTS row untouched.
 		yield* batch((db) => [
 			db
 				.update(schema.postRecord)
@@ -1066,9 +925,8 @@ export const makePostOperations = (deps: PostOperationsDeps) => {
 		} satisfies EditPostResult;
 	});
 
-	// SOFT delete onto the ADR 0096 substrate: stamp the `Removed` triad, wipe
-	// votes via `Vote.clearTarget` (karma KEPT — the pano karma-reversal is
-	// deleted), drop the FTS row, recompute stats outside. Restore is the inverse.
+	// SOFT delete onto the ADR 0096 substrate. Votes are wiped but karma is KEPT — the pano
+	// karma-reversal is deleted, not forgotten.
 	const deletePost = Effect.fn("Pano.deletePost")(function* (input: DeletePostInput) {
 		const meta = yield* run((db) => db.query.postRecord.findFirst({where: {id: input.postId}}));
 		if (!meta) {
@@ -1172,15 +1030,11 @@ export const makePostOperations = (deps: PostOperationsDeps) => {
 		});
 		if (!outcome.committed) return {restored: false, sandboxedAt: null};
 
-		// The round-tripped sandbox marker (#1811): a çaylak's post restores to Sandboxed,
-		// so report's live re-append gates the public-feed broadcast on it.
+		// A çaylak's post restores to Sandboxed, so report's live re-append gates the
+		// public-feed broadcast on this marker (#1811).
 		return {restored: true, sandboxedAt: outcome.sandboxedAt};
 	});
 
-	/**
-	 * Shared body for `voteOnPost` / `retractPostVote`. Delegates to
-	 * `Vote.cast` and translates `VoteTargetNotFound` into `PostNotFound`.
-	 */
 	const applyPostVote = Effect.fn("Pano.applyPostVote")(function* (
 		input: VoteOnPostInput,
 		isVote: boolean,
@@ -1222,8 +1076,6 @@ export const makePostOperations = (deps: PostOperationsDeps) => {
 			);
 
 		const now = new Date();
-		// Vote.cast wrote score + hot_score inside its batch; re-read for the
-		// converged values.
 		const refreshed = voteResult.changed
 			? yield* run((db) => db.query.postRecord.findFirst({where: {id: input.postId}}))
 			: meta;
@@ -1252,14 +1104,9 @@ export const makePostOperations = (deps: PostOperationsDeps) => {
 		return yield* applyPostVote(input, true);
 	});
 
-	// Reaction delegation — the karma-free, ungated twin of `voteOnPost` (#1863).
-	// Delegates the write to `Reaction.react` (kind `post`), translates the internal
-	// `ReactionTargetNotFound` into the wire-facing `PostNotFound` (the vote path's
-	// `translateVoteMiss` analogue), then RE-RESOLVES the post via the same batched
-	// `getPostsByIds` read as `post.save` so the returned entity carries the fresh
-	// `reactions` aggregate + `myReaction`. Unlike `voteOnPost` there is NO tier arm
-	// (`VoterNotEligible`) and NO karma path: a çaylak may react, and nothing writes
-	// karma — the settled ungated/social-only model (epic #1840, ADR-referenced).
+	// The karma-free, ungated twin of `voteOnPost` (#1863). Unlike voting there is NO tier
+	// arm and NO karma path on purpose: a çaylak may react, and nothing writes karma — the
+	// settled ungated/social-only model (epic #1840).
 	const reactToPost = Effect.fn("Pano.reactToPost")(function* (input: ReactToPostInput) {
 		const result = yield* reactionSvc
 			.react({
@@ -1279,10 +1126,8 @@ export const makePostOperations = (deps: PostOperationsDeps) => {
 				),
 			);
 
-		// Re-resolve like a read so the echoed entity carries the freshly-stamped
-		// `reactions` aggregate (counts + the viewer's own `myReaction`). The react
-		// write already asserted the target is live, so a missing row here is a raced
-		// removal — surface it as `PostNotFound`, same as `post.save`.
+		// The react write already asserted the target is live, so a missing row here is a
+		// raced removal, not a bad input.
 		const [row] = yield* getPostsByIds([input.postId], {viewerId: input.userId});
 		if (!row) {
 			return yield* new PostNotFound({

--- a/apps/web/worker/features/pano/post-wire-convergence.unit.test.ts
+++ b/apps/web/worker/features/pano/post-wire-convergence.unit.test.ts
@@ -1,18 +1,8 @@
 /**
- * The Pano `Post` wire shaper (`toPost`) and its two summary sources both trace to
- * the one `post-fields.ts` column→field map (#1126 AC#1, the Pano parallel of the
- * Definition slice). This pins that at the wire-shaper seam: it generalizes #1170's
- * `body`-only convergence to the WHOLE `{__typename, …}` object.
- *
- * - The by-id summary (`toPostSummaryRow`) and the keyset/feed summary
- *   (`toPostSummaryKeysetRow`) feed `toPost` and must agree, wire field for wire
- *   field, on every column the keyset projection carries — never `""` on one and
- *   `null` on the other (the #1170 class), and never a renamed/dropped field once the
- *   shaper's `PostFields` input derives from the same map as the mappers.
- *   (`updatedAt` / `isDraft` are excluded: the keyset projection selects a column
- *   subset that omits them, so they legitimately fall back to `createdAt` / `null`.)
- * - The shaper emits the canonical wire shape: exactly the `Post` key set, with the
- *   `myVote` / `isSaved` / `isDraft` viewer-scalar defaults stamped to `null`.
+ * Pins that the by-id summary and the keyset/feed summary agree wire field for wire
+ * field, so neither drifts to `""` where the other says `null` (#1170). `updatedAt` /
+ * `isDraft` are excluded because the keyset projection omits those columns and they
+ * legitimately fall back.
  */
 import {assert, describe, it} from "@effect/vitest";
 import type * as schema from "../../db/drizzle/schema.ts";
@@ -46,8 +36,7 @@ const baseRecord = (bodyExcerpt: string | null): PostRecord => ({
 	isDraft: null,
 });
 
-// The keyset path selects exactly this column subset (the `listPostsConnection`
-// fetch); project the same record onto it so both mappers read one source row.
+// The exact column subset `listPostsConnection` selects, so both mappers read one row.
 const keysetRowOf = (r: PostRecord): PostKeysetRow => ({
 	id: r.id,
 	slug: r.slug,
@@ -63,8 +52,6 @@ const keysetRowOf = (r: PostRecord): PostKeysetRow => ({
 	tags: r.tags,
 });
 
-// The wire fields the keyset projection's column subset can populate — every `Post`
-// field except the ones the subset omits (`updatedAt` / `isDraft`).
 const KEYSET_WIRE_FIELDS = [
 	"__typename",
 	"id",
@@ -120,9 +107,8 @@ describe("Pano Post wire shaper — by-id and keyset summaries converge (#1161, 
 	it("non-empty `bodyExcerpt` → rides the wire verbatim through the shaper", () => {
 		const record = baseRecord("ilk birkaç kelime…");
 
-		// Pin the literal value (not merely cross-path agreement): a mapper that
-		// mangled a non-empty excerpt identically on both paths would pass the
-		// field-agreement case yet must fail here.
+		// The literal value, not just cross-path agreement — a mapper mangling the excerpt
+		// identically on both paths would pass the agreement case.
 		assert.strictEqual(toPost(toPostSummaryRow(record)).body, "ilk birkaç kelime…");
 		assert.strictEqual(
 			toPost(toPostSummaryKeysetRow(keysetRowOf(record))).body,
@@ -157,14 +143,12 @@ describe("Pano Post wire shaper — by-id and keyset summaries converge (#1161, 
 			"url",
 		]);
 		assert.strictEqual(wire.__typename, "Post");
-		// No viewer scalars requested on a bare summary read → defaulted to `null`.
 		assert.strictEqual(wire.myVote, null);
 		assert.strictEqual(wire.isSaved, null);
 		assert.strictEqual(wire.isDraft, null);
-		// The owner-scoped in-review flag is stamped only by the read path (#2200); a
-		// bare summary shape defaults it `false`, never leaking review state.
+		// The owner-scoped in-review flag is stamped only by the read path, so a bare
+		// summary must default it `false` rather than leak review state.
 		assert.strictEqual(wire.sandboxed, false);
-		// No reactions requested on a bare summary read → the empty aggregate.
 		assert.deepStrictEqual(wire.reactions, EMPTY_REACTION_AGGREGATE);
 	});
 });

--- a/apps/web/worker/features/pano/queries.ts
+++ b/apps/web/worker/features/pano/queries.ts
@@ -1,9 +1,8 @@
 /**
- * Pano root query resolver — `post(idOrSlug)`, the detail page. Query resolvers
- * return shaped output directly (NOT masked through a source), so this builds
- * the exact wire shape the client selected, including the nested `comments`
- * connection. See `.patterns/fate-effect-operations.md`,
- * `.patterns/fate-connections.md`.
+ * Pano root query resolver — `post(idOrSlug)`, the detail page. Query resolvers return
+ * shaped output directly (NOT masked through a source), so this builds the exact wire
+ * shape the client selected, including the nested `comments` connection. See
+ * `.patterns/fate-effect-operations.md`, `.patterns/fate-connections.md`.
  */
 
 import {Fate} from "@kampus/fate-effect";
@@ -35,18 +34,15 @@ export const queries = {
 		{args: PostArgs, type: PostView},
 		Effect.fn("post")(function* ({args, select}) {
 			const pano = yield* Pano;
-			// Resolve the sandbox viewer once (identity + moderator probe); a
-			// sandboxed post is hidden from anyone but its author + a moderator (#1205).
+			// A sandboxed post is hidden from anyone but its author + a moderator (#1205).
 			const sandboxViewer = yield* currentSandboxViewer;
 			const viewerId = sandboxViewer.viewerId;
-			// Mute read-mask (#3113): a muted author's post + its thread read as
-			// not-found for the muter (default-off `member-mute` ⇒ empty set ⇒ unchanged).
+			// Mute read-mask (#3113): default-off `member-mute` ⇒ empty set ⇒ unchanged.
 			const mutedIds = yield* currentMutedIds;
 			const page = yield* pano.getPost(args.idOrSlug, {sandboxViewer, mutedIds});
 			if (!page) return null;
 
-			// Stamp `myVote` + `isSaved` by batching the single post through the same
-			// `user_vote` / `post_bookmark` read — no per-row resolver.
+			// Batch the single post through the same read — no per-row resolver.
 			const [stamped] = yield* pano.getPostsByIds([page.id], {viewerId, sandboxViewer, mutedIds});
 
 			const base = toPostFromPage(
@@ -61,16 +57,14 @@ export const queries = {
 				stamped?.sandboxed ?? false,
 			);
 
-			// The native path doesn't auto-invoke a nested relation's `connection`
-			// executor for a hand-built source, so deliver `comments` inline; the
-			// keyset, cursor, and node shape match the source executor exactly (see
-			// fate-connections.md).
+			// The native path does not auto-invoke a nested relation's `connection` executor for
+			// a hand-built source, so `comments` is delivered inline; the keyset, cursor and node
+			// shape match the source executor exactly (`.patterns/fate-connections.md`).
 			if (!hasNestedSelection(select, "comments")) {
 				return base;
 			}
 
-			// The thread read's stamp collapse is contained behind its default-off flag
-			// (#2710): off ⇒ the stamps run serially (today), on ⇒ one concurrent wave.
+			// Off ⇒ the thread stamps run serially (today); on ⇒ one concurrent wave (#2710).
 			const flags = yield* Flags;
 			const parallelStamps = yield* flags
 				.getBoolean(PHOENIX_PANO_STAMP_WAVE, false)

--- a/apps/web/worker/features/pano/reaction-comment-mutation.unit.test.ts
+++ b/apps/web/worker/features/pano/reaction-comment-mutation.unit.test.ts
@@ -1,26 +1,8 @@
 /**
- * `comment.react` WIRE-boundary coverage (epic #1840, #1864) — the pano-comment
- * reaction mutation driven through its real external interface (`resolveWire`: the
- * input decode + the `encodeWireError` class→wire-code seam), over a stub `Pano` + a
- * `Flags` double. No database. The direct twin of `definition-reaction-mutation`
- * (#1865) and the comment mirror of `reaction-mutation` (#1863):
- *
- *   - **flag ON delegates.** The resolver hands `{commentId, userId, emoji}` to
- *     `Pano.reactToComment` and echoes the re-resolved comment's `reactions`
- *     aggregate. Cast / change / retract are the three intents threaded (a palette
- *     emoji, a different palette emoji, `null`).
- *   - **flag OFF is inert (dark ship, ADR 0083).** The react never lands
- *     (`reactToComment` fail-on-contact); the resolver re-resolves the unchanged
- *     comment via `getCommentsByIds`, so a merged-but-unflipped feature is invisible.
- *   - **auth-only gate.** A signed-out reactor gets the invisible `UNAUTHORIZED`,
- *     never reaching the service — NO voter-tier gate, so a çaylak reacts like anyone.
- *   - **palette decode.** A non-`REACTION_EMOJI` emoji fails to decode at the wire
- *     boundary (`ReactionEmojiSchema`), so an arbitrary emoji is structurally
- *     unrepresentable and never reaches the service (#1864 AC#1).
- *
- * The react/change/retract write semantics themselves (probe-then-write, cardinality
- * one, NO karma, NO tier gate) are proven over the real service in
- * `../reaction/Reaction.unit.test.ts` (#1861); here we prove the MUTATION wiring.
+ * `comment.react` wire-boundary coverage (#1864): the mutation driven through
+ * `resolveWire` over a stub `Pano` and a `Flags` double, no database. What is proven
+ * here is the MUTATION wiring — the write semantics themselves live in
+ * `../reaction/Reaction.unit.test.ts`.
  */
 import {assert, describe, it} from "@effect/vitest";
 import {CurrentUser, LivePublisher} from "@kampus/fate-effect";
@@ -37,7 +19,7 @@ import {CommentId} from "./ids.ts";
 import {mutations} from "./mutations.ts";
 import {Pano} from "./Pano.ts";
 
-// A plain member — the newcomer/çaylak the ungated proof needs (no tier fields).
+// A plain member with no tier fields: the ungated proof needs a newcomer.
 const CAYLAK = {id: "u-caylak", email: "yeni@example.com", name: "yeni"};
 
 const runtimeContextStub: BaseRuntimeContext = {
@@ -48,8 +30,7 @@ const runtimeContextStub: BaseRuntimeContext = {
 	set: (id) => Effect.succeed(id),
 };
 
-// A `Flags` whose `getBoolean` returns a fixed value — the only method the gate
-// calls; every typed read dies so an accidental call is loud.
+// Every typed read dies, so an accidental call is loud.
 const flagsStub = (on: boolean): Layer.Layer<Flags> =>
 	Layer.succeed(Flags, {
 		getBoolean: () => Effect.succeed(on),
@@ -58,15 +39,13 @@ const flagsStub = (on: boolean): Layer.Layer<Flags> =>
 		getObject: () => Effect.die("getObject not exercised"),
 	} as typeof Flags.Service);
 
-// A `LivePublisher` that records nothing — the flag-ON path's reaction-count publish
-// (#1868) is fire-and-forget with an error channel of `never`, so it can never fail the
-// mutation; the stub just satisfies the requirement.
+// Records nothing: the publish is fire-and-forget and can never fail the mutation.
 const liveStub = Layer.succeed(LivePublisher)(
 	livePublisherFor({publish: () => Effect.void, waitUntil: () => {}}),
 );
 
-// A `Pano` whose named methods are scripted; every OTHER method dies on contact, so
-// a passing test proves the resolver reached only the method its path routes to.
+// Every unscripted method dies on contact, so a pass proves the resolver reached only
+// the method its path routes to.
 const panoProxy = (methods: Partial<typeof Pano.Service>): Layer.Layer<Pano> =>
 	Layer.succeed(
 		Pano,
@@ -78,8 +57,6 @@ const panoProxy = (methods: Partial<typeof Pano.Service>): Layer.Layer<Pano> =>
 		}) as typeof Pano.Service,
 	);
 
-// A `CommentRow` the scripted paths re-resolve — the reaction bar it carries (counts
-// + the viewer's own `myReaction`) is what the mutation echoes.
 const commentRowWith = (reactions: ReactionAggregate): CommentRow => ({
 	id: "comment_1",
 	parentId: null,
@@ -94,8 +71,6 @@ const commentRowWith = (reactions: ReactionAggregate): CommentRow => ({
 	reactions,
 });
 
-// Drive `comment.react` through its real external interface (`resolveWire`), selecting
-// the `reactions` aggregate so the echoed field is asserted on the wire shape.
 const react = (
 	pano: Layer.Layer<Pano>,
 	on: boolean,
@@ -200,7 +175,6 @@ describe("comment.react — (2) flag OFF is inert (dark ship)", () => {
 				{id: "comment_1", emoji: "👍"},
 			);
 			assert.strictEqual((comment as {id: string}).id, "comment_1");
-			// The current, unreacted aggregate — the react write never happened while dark.
 			assert.deepStrictEqual(
 				(comment as {reactions?: unknown}).reactions,
 				EMPTY_REACTION_AGGREGATE,
@@ -232,8 +206,8 @@ describe("comment.react — (3) a non-palette emoji is rejected at the wire boun
 describe("comment.react — (4) reactions are ungated (a çaylak reacts, no tier gate)", () => {
 	it.effect("a signed-out reactor gets UNAUTHORIZED — never reaches the service", () =>
 		Effect.gen(function* () {
-			// A genuinely-anonymous request: `{user: undefined}` provided EXPLICITLY (not via
-			// the `react` helper, whose defaulted param would coerce `undefined` back to CAYLAK).
+			// Provided explicitly, not through the `react` helper, whose defaulted param
+			// would coerce `undefined` back to CAYLAK.
 			const exit = yield* resolveWire(mutations["comment.react"], {
 				input: {id: "comment_1", emoji: "👍"},
 				select: ["id"],
@@ -259,8 +233,7 @@ describe("comment.react — (4) reactions are ungated (a çaylak reacts, no tier
 			const comment = yield* react(
 				panoProxy({
 					reactToComment: (i) => {
-						// The mutation carries no tier gate: a plain user's react reaches the
-						// service exactly like any other — the ungated/social-only model.
+						// No tier gate: a plain user's react reaches the service like any other.
 						assert.strictEqual(i.userId, CAYLAK.id);
 						return Effect.succeed({
 							comment: commentRowWith({counts: [{emoji: "❤️", count: 1}], myReaction: "❤️"}),

--- a/apps/web/worker/features/pano/reaction-mutation.unit.test.ts
+++ b/apps/web/worker/features/pano/reaction-mutation.unit.test.ts
@@ -1,28 +1,10 @@
 /**
- * `post.react` wire-boundary unit coverage (#1863, epic #1840) — the pano-post
- * reaction mutation's four AC proofs, driven through its real external interface
- * (`resolveWire`: the `resolve` decode + the `encodeWireError` class→wire-code
- * seam), so a decode rejection surfaces as a WIRE `code` (an off-palette emoji →
- * `VALIDATION_ERROR`). The `Pano` / `Flags` /
- * `LivePublisher` seams are substituted directly — no DB, no Flagship binding. The
- * react/change/retract write semantics themselves (probe-then-write, cardinality
- * one, NO karma, NO tier gate) are proven over the real service in
- * `../reaction/Reaction.unit.test.ts` (#1861); here we prove the MUTATION wiring:
+ * `post.react` wire-boundary unit coverage (#1863, epic #1840) — the mutation WIRING only,
+ * driven through its real external interface (`resolveWire`), so a decode rejection surfaces as a
+ * wire `code`. The `Pano` / `Flags` / `LivePublisher` seams are substituted: no DB, no Flagship.
  *
- *   1. delegation — `post.react` calls `Pano.reactToPost` with `targetKind: post`
- *      threading the decoded emoji, and echoes the re-resolved post's `reactions`
- *      aggregate. Cast / change / retract are the three intents threaded (a palette
- *      emoji, a different palette emoji, `null`).
- *   2. non-palette rejection — an off-palette emoji FAILS to decode at the wire
- *      boundary (`ReactionEmojiSchema`), so the service is NEVER reached.
- *   3. flag gate (dark ship, ADR 0083) — with `Flags` OFF the mutation is inert: no
- *      react lands (`Pano.reactToPost` is never called), the post is re-resolved
- *      unchanged via `getPostsByIds` and returned with no error — a merged-but-
- *      unflipped feature is invisible, matching `comment.react` / `definition.react`;
- *      with it ON the delegation runs.
- *   4. ungated — a çaylak/newcomer (any authenticated user) reacts with no tier
- *      gate: the mutation carries no `VOTE_REQUIRES_YAZAR` arm, so a plain user
- *      succeeds exactly like any other.
+ * The react/change/retract write semantics live over the real service in
+ * `../reaction/Reaction.unit.test.ts` (#1861). The four describe blocks below are the four ACs.
  */
 import {assert, describe, it} from "@effect/vitest";
 import {CurrentUser, LivePublisher} from "@kampus/fate-effect";
@@ -35,7 +17,6 @@ import {EMPTY_REACTION_AGGREGATE, type ReactionAggregate} from "../reaction/Reac
 import {mutations} from "./mutations.ts";
 import {Pano, type PostSummaryRow, type ReactToPostResult} from "./Pano.ts";
 
-// A plain member — the newcomer/çaylak the ungated proof needs (no tier fields).
 const CAYLAK = {id: "u-caylak", email: "yeni@example.com", name: "yeni"};
 
 const runtimeContextStub: BaseRuntimeContext = {
@@ -46,8 +27,7 @@ const runtimeContextStub: BaseRuntimeContext = {
 	set: (id) => Effect.succeed(id),
 };
 
-// A `Flags` whose `getBoolean` returns a fixed value — the only method the gate
-// calls; every typed read dies so an accidental call is loud.
+// `getBoolean` returns a fixed value; every other typed read dies so a stray call is loud.
 const flagsStub = (value: boolean): Layer.Layer<Flags> =>
 	Layer.succeed(Flags, {
 		getBoolean: () => Effect.succeed(value),
@@ -56,15 +36,13 @@ const flagsStub = (value: boolean): Layer.Layer<Flags> =>
 		getObject: () => Effect.die("getObject not exercised"),
 	} as typeof Flags.Service);
 
-// A `LivePublisher` that records nothing — the publish is fire-and-forget and its
-// error channel is `never`, so it can never fail the mutation.
+// The publish is fire-and-forget with a `never` error channel — it can never fail the mutation.
 const liveStub = Layer.succeed(LivePublisher)(
 	livePublisherFor({publish: () => Effect.void, waitUntil: () => {}}),
 );
 
-// A `Pano` whose named methods are scripted; every OTHER method dies on contact, so
-// a passing test proves the resolver reached only the method its path routes to (the
-// flag-ON path routes to `reactToPost`, the inert flag-OFF path to `getPostsByIds`).
+// Named methods are scripted; every OTHER method dies on contact, so a passing test proves the
+// resolver reached only the method its path routes to.
 const panoProxy = (methods: Partial<typeof Pano.Service>): Layer.Layer<Pano> =>
 	Layer.succeed(
 		Pano,
@@ -76,8 +54,6 @@ const panoProxy = (methods: Partial<typeof Pano.Service>): Layer.Layer<Pano> =>
 		}) as typeof Pano.Service,
 	);
 
-// A `PostSummaryRow` the scripted `reactToPost` re-resolves — the reaction bar it
-// carries (counts + the viewer's own `myReaction`) is what the mutation echoes.
 const postRowWith = (reactions: ReactionAggregate): PostSummaryRow => ({
 	id: "post_1",
 	slug: "post-1",
@@ -98,8 +74,6 @@ const postRowWith = (reactions: ReactionAggregate): PostSummaryRow => ({
 	reactions,
 });
 
-// Drive `post.react` through its real external interface (`resolveWire`), selecting
-// the `reactions` aggregate so the echoed field is asserted on the wire shape.
 const react = (
 	pano: Layer.Layer<Pano>,
 	flags: Layer.Layer<Flags>,
@@ -212,8 +186,7 @@ describe("post.react — (3) flag OFF is inert (dark ship)", () => {
 	it.effect("inert: no react lands, the unchanged post is re-resolved and returned", () =>
 		Effect.gen(function* () {
 			const post = yield* react(
-				// reactToPost fail-on-contact: the write must never land when dark; the inert
-				// path re-resolves the current post via `getPostsByIds`.
+				// `reactToPost` is absent, so it dies on contact: the write must never land while dark.
 				panoProxy({
 					getPostsByIds: () => Effect.succeed([postRowWith(EMPTY_REACTION_AGGREGATE)]),
 				}),
@@ -221,7 +194,6 @@ describe("post.react — (3) flag OFF is inert (dark ship)", () => {
 				{id: "post_1", emoji: "👍"},
 			);
 			assert.strictEqual((post as {id: string}).id, "post_1");
-			// The current, unreacted aggregate — the react write never happened while dark.
 			assert.deepStrictEqual((post as {reactions?: unknown}).reactions, EMPTY_REACTION_AGGREGATE);
 		}),
 	);
@@ -235,8 +207,6 @@ describe("post.react — (4) reactions are ungated (a çaylak reacts, no tier ga
 				const post = yield* react(
 					panoProxy({
 						reactToPost: (i) => {
-							// The mutation carries no tier gate: a plain user's react reaches the
-							// service exactly like any other — the ungated/social-only model.
 							assert.strictEqual(i.userId, CAYLAK.id);
 							return Effect.succeed({
 								post: postRowWith({counts: [{emoji: "❤️", count: 1}], myReaction: "❤️"}),

--- a/apps/web/worker/features/pano/read-viewer-overlay.unit.test.ts
+++ b/apps/web/worker/features/pano/read-viewer-overlay.unit.test.ts
@@ -1,14 +1,9 @@
 /**
- * `Pano.readViewerOverlay` — the per-viewer overlay read (#2322, epic #2316 leg B):
- * post ids in → `myVote`/`isSaved` out. Unit-reachable because the whole decision is
- * "batch the presence readers once and stamp `viewerId ? set.has(id) : null`" — no SQL
- * engine (ADR 0082 litmus: wrong-even-if-the-DB-behaved-perfectly → unit).
- *
- * The load-bearing AC is **no N+1**: each `ViewerScalarSpec` reader (`Vote.readMine` /
- * `Bookmark.readMine`) must be called EXACTLY ONCE for the whole id batch, never per
- * row. The doubles here record every call, so the test asserts the call count is 1 per
- * spec with the full id set — the batched-read contract, proven structurally. A throwing
- * `Drizzle` under `PanoLive` proves the overlay reads no `post_record` at all.
+ * `Pano.readViewerOverlay` — post ids in → `myVote`/`isSaved` out. The load-bearing AC is
+ * **no N+1**: each `ViewerScalarSpec` reader must be called EXACTLY ONCE for the whole id
+ * batch, never per row, so the doubles record every call and the test asserts one call per
+ * spec with the full id set. A throwing `Drizzle` under `PanoLive` proves the overlay reads
+ * no `post_record` at all.
  */
 import {assert, describe, it} from "@effect/vitest";
 import {Effect, Layer} from "effect";
@@ -87,8 +82,7 @@ describe("Pano.readViewerOverlay — batched per-viewer scalars, no N+1 (#2322)"
 					{id: "p3", myVote: false, isSaved: false},
 				]);
 
-				// No N+1: ONE vote read + ONE bookmark read for the 3-id batch, each carrying
-				// the full id set (never one read per row).
+				// ONE vote read + ONE bookmark read for the 3-id batch, each carrying the full id set.
 				assert.strictEqual(voteCalls.length, 1, "one batched user_vote read");
 				assert.strictEqual(bookmarkCalls.length, 1, "one batched post_bookmark read");
 				assert.deepStrictEqual(voteCalls[0], {

--- a/apps/web/worker/features/pano/recompute-pano-stats.unit.test.ts
+++ b/apps/web/worker/features/pano/recompute-pano-stats.unit.test.ts
@@ -1,8 +1,5 @@
-/**
- * Unit coverage for `recomputePanoStats` — the pure fold that shapes the
- * `pano_stats` row from the three live COUNTs + the write clock (ADR 0082).
- * No Effect layer, no DB.
- */
+// The pure fold that shapes the `pano_stats` row from the three live COUNTs plus the
+// write clock. No Effect layer, no DB.
 import {describe, expect, it} from "vitest";
 import {type PanoStatsCounts, recomputePanoStats} from "./Pano.ts";
 

--- a/apps/web/worker/features/pano/self-vote-guard.unit.test.ts
+++ b/apps/web/worker/features/pano/self-vote-guard.unit.test.ts
@@ -1,14 +1,8 @@
 /**
- * `Pano.applyPostVote` self-vote guard (#2216, founder-ruled) — the cast-site domain
- * guard proven over the real `makePostOperations` closures with a substituted `Drizzle`
- * `run` (the post load) + a RECORDING `Vote`, so three things are wrong-or-right with no
- * SQL engine:
- *
- *   1. self-cast rejected — `voteOnPost` where `voterId === post.authorId` fails
- *      `SelfVoteNotAllowed` and NEVER reaches `Vote.cast` (no score/karma write).
- *   2. other-author cast lands — a non-author vote reaches `Vote.cast` exactly as before.
- *   3. self-retract exempt — `retractPostVote` on one's own post reaches `Vote.cast`
- *      (the guard is cast-only; a blocked cast leaves nothing to retract).
+ * The cast-site self-vote guard (#2216), proven over the real `makePostOperations`
+ * closures with a substituted `run` and a RECORDING `Vote` — no SQL engine. The guard
+ * is cast-only: a self-RETRACT stays allowed, since a blocked cast leaves nothing to
+ * retract.
  */
 import {assert, describe, it} from "@effect/vitest";
 import {Cause, Effect, Exit} from "effect";
@@ -22,8 +16,7 @@ const AUTHOR = UserId.make("u-author");
 const OTHER = UserId.make("u-other");
 const POST_ID = PostId.make("post_1");
 
-// The `post_record` the up-front load returns. Only `authorId` drives the guard; the
-// rest satisfy the row shape the return projection reads.
+// Only `authorId` drives the guard; the rest satisfy the return projection's row shape.
 const postRow = {
 	id: POST_ID,
 	slug: "post-1",
@@ -45,10 +38,8 @@ const postRow = {
 	isDraft: null,
 };
 
-// A `Vote` double that RECORDS every cast and replays a no-op result — so "did the cast
-// path run" is observable with no engine. Only `cast` is on the vote path; every other
-// method dies on contact via the Proxy, so an off-path call is loud (the `reaction-mutation`
-// `panoStub` idiom).
+// Records every cast so "did the cast path run" is observable; every other method dies
+// on contact through the Proxy, so an off-path call is loud.
 const recordingVote = (casts: VoteInput[]): typeof Vote.Service =>
 	new Proxy(
 		{
@@ -72,8 +63,8 @@ const recordingVote = (casts: VoteInput[]): typeof Vote.Service =>
 		},
 	) as typeof Vote.Service;
 
-// Only `run` (the post load) + `voteSvc` are on the vote path; the other deps are captured
-// but never invoked, so they die on contact if the guard ever falls through to them.
+// Only `run` and `voteSvc` are on the vote path; the rest die on contact if the guard
+// ever falls through to them.
 const deps = (voteSvc: typeof Vote.Service): PostOperationsDeps =>
 	({
 		run: (<A>(_fn: unknown) => Effect.succeed(postRow as A)) as DrizzleAccessOrDie["run"],

--- a/apps/web/worker/features/pano/shapers.ts
+++ b/apps/web/worker/features/pano/shapers.ts
@@ -1,19 +1,8 @@
 /**
- * Pano wire-entity shapers — `Post` / `Comment`. Every `{__typename, …}` literal
- * is built here once so the read/list/write paths can't drift. The wire field set is
- * NOT restated here: `PostFields` / `CommentFields` derive from the one column→field
- * map per entity (`post-fields.ts` / `comment-fields.ts`), so the row mapper, this
- * wire shaper, and the `*View` field list all trace back to a single structure —
- * rename a column reader in the map and every site follows (#1126 AC#1, the Pano
- * parallel of the Definition slice in `sozluk/definition-fields.ts`).
- *
- * The map's keys ARE the wire field names, so a shaper just stamps `__typename` + the
- * `updatedAt ?? createdAt` fallback + the `myVote` / `isSaved` / `isDraft` viewer-scalar
- * defaults onto the map's already-wire-named values; the per-source row→wire NAMING
- * lives in the map, not at each call site. The detail-page / write / vote results that
- * carry their own field names map onto `PostFields` at their call site (`toPostFromPage`,
- * the mutation shapers). See `.patterns/fate-connections.md`,
- * `.patterns/fate-effect-operations.md`.
+ * Pano wire-entity shapers — every `{__typename, …}` literal is built here once so
+ * the read/list/write paths can't drift. The row→wire NAMING lives in the per-entity
+ * column→field maps (`post-fields.ts` / `comment-fields.ts`), never at a call site,
+ * so renaming a column reader there carries every site with it.
  */
 
 import {EMPTY_REACTION_AGGREGATE, type ReactionAggregate} from "../reaction/Reaction.ts";
@@ -49,13 +38,11 @@ export const toPost = (r: PostFields): Post => ({
 });
 
 /**
- * The viewer-invariant BASE post (#2322, epic #2316 leg B): `toPost` minus the two
- * viewer scalars (`myVote`/`isSaved`). The GET-able base feed serves this so its bytes
- * are identical for anon and every signed-in viewer — the per-viewer scalars ride the
- * separate authed `PostOverlay` read instead. `sandboxed` stays but is structurally
- * `false` on the base path (the route reads the ANONYMOUS sandbox viewer, and any
- * sandboxed post is filtered out of the feed before it reaches here), so it carries no
- * viewer-derived value.
+ * The viewer-invariant BASE post: the cacheable base feed serves this, so its bytes
+ * must be identical for anon and every signed-in viewer. `sandboxed` stays but is
+ * structurally `false` here (the base route reads the ANONYMOUS sandbox viewer), so
+ * it carries no viewer-derived value; the real per-viewer scalars ride the separate
+ * authed `PostOverlay` read.
  */
 export type BasePost = Omit<Post, "myVote" | "isSaved">;
 
@@ -64,13 +51,9 @@ export const toBasePost = (r: PostFields): BasePost => {
 	return base;
 };
 
-// The single `PostPage` → `Post` mapping shared by the read resolver
-// (`queries.post`) and the delete-refresh (`comment.delete`) so they can't drift.
-// `myVote`/`isSaved`/`reactions` and the live `authorUsername`/`authorDisplayName`
-// identity (#2139) are stamped separately (the page row carries no viewer scalar,
-// aggregate, nor resolved identity), so the caller threads each in — `reactions`
-// defaults to the empty aggregate and `identity` to nulls for callers that don't
-// hydrate them (`actorLabel` then degrades on the client).
+// A `PostPage` row carries no viewer scalar, aggregate, nor resolved identity, so the
+// caller threads each in. Callers that don't hydrate `identity` get nulls, and
+// `actorLabel` degrades on the client.
 export const toPostFromPage = (
 	page: PostPage,
 	myVote: boolean | null,

--- a/apps/web/worker/features/pano/sources.ts
+++ b/apps/web/worker/features/pano/sources.ts
@@ -1,10 +1,8 @@
 /**
- * Pano fate sources — `Post` / `Comment` / `Tag` Effect-backed loaders. fate is
- * pure transport (ADR 0016): every handler delegates to a `Pano` method.
- * `byId`/`byIds` are the only capabilities (connections come from custom
- * resolvers, ADR 0019). Reads are silent (absence = `null`/fewer rows) and
- * `E = never` — infra failures die inside the domain service (the boundary rule
- * in `.patterns/feature-services.md`). See `.patterns/fate-effect-sources.md`.
+ * Pano fate sources. fate is pure transport (ADR 0016), so every handler delegates to
+ * a `Pano` method. Reads are silent — absence is `null`/fewer rows, and `E = never`
+ * because infra failures die inside the domain service.
+ * See .patterns/fate-effect-sources.md.
  */
 import {CurrentUser, Fate} from "@kampus/fate-effect";
 import {PHOENIX_PANO_STAMP_WAVE} from "../../../src/flags/keys.ts";
@@ -32,13 +30,9 @@ export const postSource = Fate.source(
 	},
 );
 
-/**
- * The per-viewer overlay source (#2322, epic #2316 leg B): given the base feed's post
- * ids, return each viewer's own `myVote`/`isSaved`. Session-gated by construction — it
- * reads `CurrentUser` off the authed `POST /fate` edge (ADR 0169 untouched: nothing
- * session-derived rides the cacheable base). An anonymous viewer gets `null` scalars
- * for every id (the read-path convention).
- */
+// Session-gated by construction: it reads `CurrentUser` off the authed `POST /fate`
+// edge, so nothing session-derived rides the cacheable base (ADR 0169). An anonymous
+// viewer gets `null` scalars for every id.
 export const postOverlaySource = Fate.source(
 	PostOverlayView,
 	{id: "id"},
@@ -63,8 +57,8 @@ export const commentSource = Fate.source(
 			const pano = yield* Pano;
 			const sandboxViewer = yield* currentSandboxViewer;
 			const mutedIds = yield* currentMutedIds;
-			// The read-path collapse is contained behind its default-off flag (#2710): off ⇒
-			// the stamps run serially (today), on ⇒ one concurrent wave. Same wire output.
+			// Contained behind a default-off flag (#2710); both arms produce the same wire
+			// output, serially or in one concurrent wave.
 			const flags = yield* Flags;
 			const parallelStamps = yield* flags
 				.getBoolean(PHOENIX_PANO_STAMP_WAVE, false)
@@ -79,9 +73,8 @@ export const commentSource = Fate.source(
 	},
 );
 
-// Tags are embedded scalars (no standalone table); `byIds` maps kinds to
-// `{kind, label}` via the same static label map the service uses, so `Tag` is
-// fetchable by kind for relation callers. `Post.tags` rides the parent row.
+// Tags are embedded scalars with no standalone table; `byIds` maps kinds through the
+// same static label map the service uses, so `Tag` stays fetchable by kind.
 export const tagSource = Fate.source(
 	TagView,
 	{id: "kind"},

--- a/apps/web/worker/features/pano/sources.unit.test.ts
+++ b/apps/web/worker/features/pano/sources.unit.test.ts
@@ -1,15 +1,7 @@
 /**
- * Unit coverage for the pano fate **loader** seam (#1361). `tagSource.byIds` is the
- * one logic-bearing handler here: `Tag` is an embedded scalar with no table, so the
- * `kind → {kind, label: tagLabel(kind)}` map IS the whole fetch — it lives ONLY in
- * `sources.ts` and is exercised by no other test through the source interface.
- *
- * `postSource`/`commentSource` are pure pass-throughs to `Pano` (covered transitively
- * by their service tests — the deletion test), so they get no redundant seam test
- * here. The membership-stability invariant (ADR 0016 — `byIds` rows a pure function
- * of the id SET) is asserted on `tagSource`; the silent-read flavor for `Tag` is the
- * total kind→label map (an unknown kind falls back to its raw value, never a raised
- * miss). `tagSource.byIds` needs no service — the map is pure.
+ * The pano fate loader seam. Only `tagSource.byIds` is covered: `Tag` has no table, so
+ * its kind→label map IS the whole fetch, while `postSource`/`commentSource` are pure
+ * pass-throughs their service tests already cover.
  */
 
 import {it} from "@effect/vitest";
@@ -17,7 +9,6 @@ import {Effect} from "effect";
 import {assert} from "vitest";
 import {tagSource} from "./sources.ts";
 
-/** Narrow an optional handler without a non-null assertion (mirrors Source.unit.test.ts). */
 const required = <T>(value: T | undefined): T => {
 	if (value === undefined) {
 		throw new Error("expected the handler to be present");
@@ -26,8 +17,6 @@ const required = <T>(value: T | undefined): T => {
 };
 
 const tagByIds = required(tagSource.handlers.byIds);
-
-// --- tagSource.byIds: the kind → {kind, label} map --------------------------
 
 it.effect("tagSource.byIds maps each canonical kind to its label via tagLabel", () =>
 	Effect.gen(function* () {
@@ -41,34 +30,25 @@ it.effect("tagSource.byIds maps each canonical kind to its label via tagLabel", 
 
 it.effect("tagSource.byIds resolves a legacy English alias to its canonical Turkish label", () =>
 	Effect.gen(function* () {
-		// `tagLabel` normalizes the seed-era alias `show` → `göster`; the `kind` field
-		// stays the raw requested key (the ref the caller asked by).
 		const rows = yield* tagByIds(["show"]);
 		assert.deepStrictEqual(rows, [{kind: "show", label: "göster"}]);
 	}),
 );
-
-// --- tagSource.byIds: silent-read — an unknown kind falls back, never fails --
 
 it.effect("tagSource.byIds is silent on an unknown kind: it falls back to the raw value", () =>
 	Effect.gen(function* () {
 		const exit = yield* tagByIds(["nonexistent-kind"]).pipe(Effect.exit);
 		assert.isTrue(exit._tag === "Success");
 		if (exit._tag === "Success") {
-			// Unknown kind → raw value as label, a row not a raised miss (silent-read).
 			assert.deepStrictEqual(exit.value, [{kind: "nonexistent-kind", label: "nonexistent-kind"}]);
 		}
 	}),
 );
 
-// --- tagSource.byIds: membership-stability (ADR 0016) -----------------------
-
 it.effect("tagSource.byIds is membership-stable: a reordered kind set yields the same rows", () =>
 	Effect.gen(function* () {
 		const forward = yield* tagByIds(["göster", "soru", "meta"]);
 		const reversed = yield* tagByIds(["meta", "soru", "göster"]);
-		// Rows are a function of the kind SET, not its order — sorting both by kind
-		// must collapse them to the same rows.
 		const byKey = (rows: ReadonlyArray<{kind: string}>) =>
 			[...rows].sort((a, b) => a.kind.localeCompare(b.kind));
 		assert.deepStrictEqual(byKey(forward), byKey(reversed));

--- a/apps/web/worker/features/pano/submit-validation.unit.test.ts
+++ b/apps/web/worker/features/pano/submit-validation.unit.test.ts
@@ -1,26 +1,16 @@
 /**
- * Pano submit-validation WIRING coverage (ADR 0082) — the post/draft/comment
- * input checks driven THROUGH their only caller, the mutation, not the extracted
- * helper in isolation.
+ * Pano submit-validation WIRING coverage (ADR 0082) — the input checks driven THROUGH
+ * the mutation, never by importing the module-private validators directly.
  *
- * `submitPost` / `saveDraft` / `addComment` run their validators BEFORE any DB
- * read, so a throwing `Drizzle` (every `run`/`batch` `die`s) is the "no DB call"
- * proof: a typed validation failure surfacing instead of a defect means the gate
- * fired before the seam was reached. A refactor that reorders a `validate*` call
- * after a DB read, or drops it, would die (or succeed) here instead of
- * rejecting — closing the interface-as-test-surface hole the
- * `pasaport/username-validation.unit.test.ts` pattern already closes.
+ * The proof shape: every `Drizzle` call `die`s, so a typed validation failure means the
+ * gate fired before the seam was reached. A refactor that reorders a `validate*` after a
+ * DB read, or drops it, dies here instead of rejecting.
  *
- * `editPost` is the one mutation whose validation runs AFTER its existence/auth
- * read (it validates against the persisted row), so its wiring is proven over a
- * scripted `Drizzle` that returns an owned post on the read and `die`s on the
- * write batch: the validator must reject before that write.
+ * `editPost` validates AFTER its existence/auth read, so it runs over a scripted access
+ * that resolves an owned post once and dies on the write.
  *
- * The DB-state-dependent rejections of the same mutations (`POST_NOT_FOUND`,
- * `PARENT_NOT_FOUND`, `UNAUTHORIZED`) stay on real D1 in
- * `tests/integration/pano-*.test.ts` — those are only-wrong-if-the-DB-differs.
- * The validator helpers are module-private; this file reaches them only through
- * the mutation, never by direct import.
+ * DB-state-dependent rejections (`POST_NOT_FOUND`, `PARENT_NOT_FOUND`, `UNAUTHORIZED`)
+ * stay on real D1 in `tests/integration/pano-*.test.ts`.
  */
 
 import {it} from "@effect/vitest";
@@ -35,18 +25,12 @@ import {Bookmark} from "./Bookmark.ts";
 import {type CommentId, PostId} from "./ids.ts";
 import {COMMENT_BODY_MAX, Pano, PanoLive, POST_BODY_MAX, POST_TITLE_MAX} from "./Pano.ts";
 
-// Every DB call dies, so any path that reaches the seam fails the test: the
-// validation gate short-circuits before any read/write, and running to a typed
-// failure against this access is the "no DB call" proof.
 const throwingAccess: DrizzleAccess = {
 	run: () => Effect.die(new Error("a pano mutation read the DB on a path that must short-circuit")),
 	batch: () =>
 		Effect.die(new Error("a pano mutation wrote a batch on a path that must short-circuit")),
 };
 
-// `editPost` validates AFTER its existence/auth read, so its wiring is proven
-// over a `run` that resolves an owned post once and dies on any later write: the
-// title/body gate must reject before the write batch is ever built.
 const editPostReadThenDieAccess = (postRow: unknown): DrizzleAccess => {
 	const state = {firstRunDone: false};
 	return {
@@ -63,9 +47,8 @@ const editPostReadThenDieAccess = (postRow: unknown): DrizzleAccess => {
 	};
 };
 
-// Pano's validation gate touches neither Vote nor Bookmark (they're consulted
-// only on the read/aggregate paths), so never-cast inert instances satisfy the
-// layer's dependency types without a real implementation.
+// The validation gate touches none of these services — they are consulted only on the
+// read/aggregate paths — so inert casts satisfy the layer's dependency types.
 const inertVote = Layer.succeed(Vote, {} as Context.Service.Shape<typeof Vote>);
 const inertBookmark = Layer.succeed(Bookmark, {} as Context.Service.Shape<typeof Bookmark>);
 const inertReaction = Layer.succeed(Reaction, {} as Context.Service.Shape<typeof Reaction>);
@@ -94,10 +77,8 @@ const expectTag = (exit: Exit.Exit<unknown, unknown>, tag: string) => {
 	}
 };
 
-// The inverse of `expectTag`: a URL that PASSES the protocol allowlist runs on
-// past the gate into the throwing `Drizzle`, so the mutation `die`s (a defect,
-// not a typed failure). Reaching the DB is the "URL accepted" proof — the
-// http(s) case must land here, never at a `UrlInvalid`.
+// The inverse of `expectTag`: a URL that PASSES the allowlist runs past the gate into
+// the throwing `Drizzle`, so reaching the DB is the "URL accepted" proof.
 const expectReachedDb = (exit: Exit.Exit<unknown, unknown>) => {
 	assert.isTrue(Exit.isFailure(exit), "expected the mutation to reach the throwing DB");
 	if (Exit.isFailure(exit)) {
@@ -282,8 +263,7 @@ it.effect("addComment: an over-long body rejects with CommentBodyTooLong before 
 	}),
 );
 
-// An owned, live post the existence/auth read resolves before editPost reaches
-// its validation gate — only the columns the mutation reads need be present.
+// Only the columns the mutation reads need be present.
 const ownedPostRow = {
 	id: "post_1",
 	title: "eski başlık",

--- a/apps/web/worker/features/pano/views.ts
+++ b/apps/web/worker/features/pano/views.ts
@@ -10,19 +10,16 @@ import {type CommentRow, commentViewFields} from "./comment-fields.ts";
 import {COMMENT_ORDERING} from "./ordering.ts";
 import {type PostSummaryRow, type PostTagRow, postViewFields} from "./post-fields.ts";
 
-// `Record<string, unknown>`-assignable restatements of the service rows (the
-// plain row interfaces are not). Exported so `Fate.source` declarations over
-// these views can name the row type (TS2883 portability).
+// `Record<string, unknown>`-assignable restatements of the service rows. Exported so
+// `Fate.source` declarations can name the row type (TS2883 portability).
 export type TagViewRow = ViewRow<PostTagRow>;
 export type CommentViewRow = ViewRow<CommentRow>;
 export type PostViewRow = ViewRow<PostSummaryRow>;
 
 /**
- * `PostOverlay` — the per-viewer scalar slice (#2322, epic #2316 leg B), keyed by the
- * post id. The GET-able base feed (`PostView` served without the viewer stamp) is
- * viewer-invariant; the client fetches this overlay by the base feed's ids and composes
- * `myVote`/`isSaved` on top (#2323). A distinct entity — not a `PostView` field set —
- * so the base projection and the per-viewer read are separately cacheable/session-gated.
+ * The per-viewer scalar slice (#2322), keyed by post id. A distinct entity rather than
+ * a `PostView` field set so the viewer-invariant base projection and the per-viewer
+ * read stay separately cacheable and session-gated.
  */
 export interface PostOverlayRow {
 	id: string;
@@ -31,48 +28,36 @@ export interface PostOverlayRow {
 }
 export type PostOverlayViewRow = ViewRow<PostOverlayRow>;
 
-// `Tag` is an embedded scalar on the post row (parsed from `post_record.tags`
-// CSV), not a standalone table; `kind` is the natural key.
+// `Tag` is an embedded scalar on the post row, keyed by `kind` — not a table.
 export class TagView extends FateDataView<TagViewRow>()("Tag")({
 	kind: true,
 	label: true,
 }) {}
 
-// The field list derives from `comment-fields.ts`'s column→field map, so it can't
-// drift from the row mapper / wire shaper (#1166). `myVote` is the viewer's vote,
-// batched in one `user_vote` read and stamped as a scalar — no per-row resolver.
+// The field list derives from `comment-fields.ts`'s column→field map, so it cannot
+// drift from the row mapper / wire shaper (#1166).
 export class CommentView extends FateDataView<CommentViewRow>()("Comment")(commentViewFields) {}
 
 /**
- * `tags` is an embedded scalar array, NOT a `FateDataView.list(TagView)`
- * relation: fate's vite codegen hardcodes the default `getId` (reads `.id`) for
- * every relation entity, but `Tag` is keyed by `kind` (no `id`), so a list
- * relation would throw `Missing 'id' on entity record` when the client
- * normalizes feed/post nodes. A scalar passes the array through verbatim. See
- * `.patterns/fate-data-views.md` (embedded-scalar note).
- *
- * `comments`'s `orderBy` derives from `COMMENT_ORDERING` (`ordering.ts`), so it
- * can't drift from the service's comment-thread keyset (ADR 0019).
+ * `tags` is an embedded scalar array, NOT a `FateDataView.list(TagView)` relation:
+ * fate's vite codegen hardcodes the default `getId` (reads `.id`) for every relation
+ * entity, but `Tag` is keyed by `kind`, so a list relation throws
+ * `Missing 'id' on entity record` when the client normalizes feed/post nodes. See
+ * `.patterns/fate-data-views.md`.
  */
 export class PostView extends FateDataView<PostViewRow>()("Post")({
-	// The scalar fields derive from `post-fields.ts`'s column→field map (incl.
-	// `myVote` / `isSaved` viewer scalars + the `isDraft` taslak marker), so they
-	// can't drift from the row mapper / wire shaper (#1166).
 	...postViewFields,
 	tags: true,
 	comments: FateDataView.list(CommentView, {orderBy: viewOrderBy(COMMENT_ORDERING)}),
 }) {}
 
-// The per-viewer overlay view (#2322): three scalars, no relation. `myVote`/`isSaved`
-// are stamped by `Pano.readViewerOverlay` off the batched presence readers.
+// The per-viewer overlay view (#2322): three scalars, no relation.
 export class PostOverlayView extends FateDataView<PostOverlayViewRow>()("PostOverlay")({
 	id: true,
 	myVote: true,
 	isSaved: true,
 }) {}
 
-// Kernel views for cross-feature surfaces that want fate's plain `dataView()`
-// value (the `fate/views.ts` `Root` map + barrel re-exports).
 export const tagDataView = TagView.view;
 export const commentDataView = CommentView.view;
 export const postDataView = PostView.view;
@@ -80,16 +65,15 @@ export const postOverlayDataView = PostOverlayView.view;
 
 export type Tag = WorkerEntity<typeof TagView>;
 export type PostOverlay = WorkerEntity<typeof PostOverlayView>;
-// `deletedAt` is `Date | null` (the source row types it `deletedAt?: Date | null`, but
-// the corrected worker type drops the unset `undefined`) — an `Override`, not a `DateKeys`
-// member, which would preserve the optional and widen to `Date | null | undefined`.
+// `deletedAt` is an `Override`, not a `DateKeys` member: a `DateKeys` member would
+// preserve the source row's optional and widen to `Date | null | undefined`.
 export type Comment = WorkerEntity<
 	typeof CommentView,
 	"createdAt" | "updatedAt",
 	{deletedAt: Date | null}
 >;
-// `updatedAt` is `Date` for the same reason: `PostSummaryRow.updatedAt?: Date` is optional,
-// the corrected type pins it non-optional `Date`, so it rides the `Override` slot.
+// `updatedAt` rides the `Override` slot for the same reason: the source row types it
+// optional, the corrected worker type pins it non-optional `Date`.
 export type Post = WorkerEntity<
 	typeof PostView,
 	"createdAt",

--- a/apps/web/worker/features/pano/vote-preserves-saved-state.unit.test.ts
+++ b/apps/web/worker/features/pano/vote-preserves-saved-state.unit.test.ts
@@ -1,20 +1,11 @@
 /**
- * `post.vote` / `post.retractVote` wire-boundary regression coverage (#2213) —
- * proof that voting an already-SAVED post no longer clobbers its saved state or
- * author identity in the client cache (nor in the fanned `/fate/live` frame).
+ * Regression coverage for #2213: voting an already-saved post must not clobber its
+ * saved state or author identity, in the client cache or the fanned live frame.
  *
- * The defect: both resolvers shaped their return from the write result
- * (`VoteOnPostResult`), which carries NO `isSaved` and NO resolved author
- * identity — so the returned/published `Post` reported `isSaved: null` +
- * `authorUsername/authorDisplayName: null`, and the client cache-merge overwrote
- * the true saved state (and identity) of a saved post. The fix re-resolves the
- * post via the same batched `getPostsByIds` read `post.save`/`post.unsave` use, so
- * BOTH the return value and the published live frame carry the real projection.
- *
- * Driven through the real external interface (`resolveWire`), with `Pano` +
- * `LivePublisher` substituted directly (no DB): the recording publisher captures
- * the published `/fate/live` frame so the fanned projection is asserted, not just
- * the return.
+ * The defect was that both resolvers shaped their return from the write result, which
+ * carries neither `isSaved` nor resolved author identity, so the client cache-merge
+ * overwrote the real values with nulls. The fix re-resolves the post through the same
+ * batched read `post.save`/`post.unsave` use.
  */
 import {assert, describe, it} from "@effect/vitest";
 import {CurrentUser, LivePublisher} from "@kampus/fate-effect";
@@ -39,9 +30,8 @@ const runtimeContextStub: BaseRuntimeContext = {
 	set: (id) => Effect.succeed(id),
 };
 
-// The write result `voteOnPost`/`retractPostVote` return — deliberately carries
-// NEITHER `isSaved` NOR resolved author identity, exactly the shape that used to
-// leak `null` into the cache. `authorName` is only the write-time snapshot.
+// Deliberately carries neither `isSaved` nor resolved author identity: this is the
+// exact shape that used to leak nulls into the cache.
 const writeResult = (overrides: Partial<VoteOnPostResult> = {}): VoteOnPostResult => ({
 	postId: "post_1",
 	title: "başlık",
@@ -60,9 +50,7 @@ const writeResult = (overrides: Partial<VoteOnPostResult> = {}): VoteOnPostResul
 	...overrides,
 });
 
-// The re-resolved row `getPostsByIds` returns for the SAVED post: a real
-// `isSaved: true` plus the live-stamped author identity — the projection the fix
-// must echo back (return + publish) instead of the null-bearing write shape.
+// The projection the fix must echo back on both the return and the publish.
 const savedRow = (): PostSummaryRow => ({
 	id: "post_1",
 	slug: "post-1",
@@ -84,9 +72,8 @@ const savedRow = (): PostSummaryRow => ({
 	isDraft: null,
 });
 
-// A `Pano` stub whose vote + re-resolve reads are scripted; every other method
-// dies loudly. The vote path only ever reaches `voteOnPost`/`retractPostVote`
-// then `getPostsByIds`.
+// Every unscripted method dies loudly, pinning the vote path to `voteOnPost` /
+// `retractPostVote` then `getPostsByIds`.
 const panoStub = (methods: Partial<typeof Pano.Service>): Layer.Layer<Pano> =>
 	Layer.succeed(
 		Pano,
@@ -98,9 +85,8 @@ const panoStub = (methods: Partial<typeof Pano.Service>): Layer.Layer<Pano> =>
 		}) as typeof Pano.Service,
 	);
 
-// A recording `LivePublisher` — captures each published frame so the fanned
-// `/fate/live` projection is asserted, not just the return. Pushing in the
-// `publish` builder body captures synchronously (before `waitUntil` detaches it).
+// Pushing inside the `publish` builder body captures synchronously, before
+// `waitUntil` detaches the work.
 const recordingLive = (frames: PublishMessage[]): Layer.Layer<LivePublisher> =>
 	Layer.succeed(LivePublisher)(
 		livePublisherFor({
@@ -118,10 +104,8 @@ const publishedData = (frames: PublishMessage[]): Record<string, unknown> | unde
 	return entity.frame.data as Record<string, unknown> | undefined;
 };
 
-// The vote path fires the flag-gated `notifyContentVote` emitter, so the resolver's
-// residual context carries `Flags` + `Notification`. Flag ON exercises the emit; the
-// recording stub swallows it — the notification wiring is proven elsewhere
-// (`bildirim/vote-emitters.unit.test.ts`), here it just discharges the context.
+// The vote path fires the flag-gated notify emitter, so these just discharge the
+// context; the notification wiring is proven in `bildirim/vote-emitters.unit.test.ts`.
 const flagsOn: Layer.Layer<Flags> = Layer.succeed(Flags, {
 	getBoolean: () => Effect.succeed(true),
 	getString: () => Effect.die("getString not exercised"),
@@ -133,8 +117,7 @@ const notificationStub = makeNotificationStub({
 	recordAggregate: () => Effect.succeed({aggregated: false}),
 });
 
-// The vote emit now consults `bildirimMutedBy` (#3238), which reads `Mute` — an
-// empty-set stub means no member is muted, so the deliver path is unchanged.
+// An empty-set `Mute` stub means nobody is muted, so the deliver path is unchanged.
 const noMutes = Layer.succeed(Mute, {
 	set: () => Effect.die("Mute.set not exercised"),
 	listMine: () => Effect.die("Mute.listMine not exercised"),

--- a/apps/web/worker/features/pasaport/Pasaport.testing.ts
+++ b/apps/web/worker/features/pasaport/Pasaport.testing.ts
@@ -1,15 +1,8 @@
 /**
- * `makePasaportStub` — the shared `Pasaport` test double. Defaults every one of
- * the `Pasaport` methods to fail-on-contact (`Effect.die`) and takes a partial
- * override of the method(s) under test, returning the `Layer.succeed(Pasaport, …)`
- * layer. One place the interface shape lives — adding a method to `Pasaport` is a
- * single edit here, not shotgun surgery across every hand-rolled stub.
- *
- * A `layerStub` (fail-on-contact), not a `layerNoop` (silently-succeed): an
- * un-overridden method, if reached, dies and fails the test — the discipline that
- * proves the path under test touched only the method(s) it was scripted with.
- *
- * A **factory, not a shared instance** (`.patterns/effect-testing.md`).
+ * The shared `Pasaport` test double. Fail-on-contact, not silently-succeed: an
+ * un-overridden method dies if reached, which is what proves the path under test touched
+ * only the methods it was scripted with. A factory, not a shared instance
+ * (`.patterns/effect-testing.md`).
  */
 import {Effect, Layer} from "effect";
 import {Pasaport} from "./Pasaport.ts";
@@ -50,15 +43,9 @@ export const makePasaportStub = (overrides: Partial<PasaportShape> = {}): Layer.
 	Layer.succeed(Pasaport, {...failOnContact, ...overrides});
 
 /**
- * `PasaportIdentityStub` — the `Pasaport` double for unit tests that build
- * `PanoLive` / `SozlukLive` over a substituted `Drizzle` seam. Those services now
- * stamp the live author identity on their reads (`getProfileIdentitiesByIds`, #2139,
- * mirroring the `ReactionStub` shape for `Reaction.readAggregate`, #1862), so a test
- * that provides only `Vote`/`Bookmark`/`Reaction`/`Drizzle` leaves `Pasaport`
- * unsatisfied in `R`. This stub discharges it: `getProfileIdentitiesByIds` returns
- * `[]`, so the stamp leaves `authorUsername`/`authorDisplayName` null and the client
- * `actorLabel` degrades. Every other method dies if reached — the resolve/identity
- * write paths are the pasaport domain tests' concern, not these connection tests.
+ * The double for tests that build `PanoLive` / `SozlukLive` over a substituted `Drizzle`
+ * seam, which need `Pasaport` only for the author-identity stamp. Returning `[]` leaves
+ * the identity fields null and the client label degraded, which those tests do not assert.
  */
 export const PasaportIdentityStub: Layer.Layer<Pasaport> = makePasaportStub({
 	getProfileIdentitiesByIds: () => Effect.succeed([]),

--- a/apps/web/worker/features/pasaport/Pasaport.ts
+++ b/apps/web/worker/features/pasaport/Pasaport.ts
@@ -1,12 +1,7 @@
 /**
- * Pasaport — the user identity + profile service. Validation lives inside the
- * methods as closure helpers (ADR 0013). Infrastructure failures are NOT raised:
- * every internal DB call dies on `DrizzleError` (`orDieAccess` at layer build —
- * the domain-boundary rule), so the public signatures carry domain errors only.
- *
- * The auth instance is supplied by `BetterAuthLive` (`better-auth-live.ts`); the
- * `/api/auth/*` route reads `BetterAuth.fetch` from the same Context tag, so
- * `Pasaport` no longer mounts the handler itself.
+ * Pasaport — the user identity + profile service. Every internal DB call dies on
+ * `DrizzleError` (`orDieAccess` at layer build), so the public signatures carry
+ * domain errors only. Validation lives inside the methods (ADR 0013).
  */
 import type {Auth as BetterAuth} from "better-auth";
 import {and, desc, eq, inArray, isNull, like, or, type SQL, sql} from "drizzle-orm";
@@ -62,25 +57,16 @@ import type {ProfileRow} from "./profile-fields.ts";
 import {toUserRow, type UserRow} from "./user-fields.ts";
 import {checkUsername, normalizeUsername} from "./username-rule.ts";
 
-// `UserRow`/`ProfileRow` are single-sourced in their field-map modules (#1545);
-// re-exported here so cross-feature callers keep their `./Pasaport.ts` import.
 export type {ProfileRow} from "./profile-fields.ts";
 export type {UserRow} from "./user-fields.ts";
 
-// The worker-level better-auth instance handle (NOT the per-request session — that
-// is `CurrentUser`, ADR 0042). Phoenix never specializes the better-auth options at
-// the type level, so this is the unparameterized better-auth `Auth` — matching the
-// `BetterAuth` tag's `auth` field.
+// The worker-level better-auth handle, NOT the per-request session — that is
+// `CurrentUser` (ADR 0042).
 export type BetterAuthInstance = BetterAuth;
 export type Session = NonNullable<Awaited<ReturnType<BetterAuthInstance["api"]["getSession"]>>>;
 
-/**
- * The minimal identity tuple a batched roster read needs per çaylak — the display
- * handle + karma, keyed by `userId`. A projection of {@link ProfileRow} (no counts,
- * no image) for callers that join identity onto many users in ONE read; `username` is
- * nullable here (an un-bootstrapped çaylak has no username yet). See
- * `getProfileIdentitiesByIds`.
- */
+// Identity-only projection of {@link ProfileRow} for batched roster reads;
+// `username` is null for an un-bootstrapped çaylak.
 export interface ProfileIdentityRow {
 	userId: string;
 	username: string | null;
@@ -102,13 +88,8 @@ export interface SetDisplayNameResult {
 	image: string | null;
 }
 
-// The shared discriminant + identity fields every contribution variant carries.
-// `sandboxed` is the per-item review-state flag (#1316) — `sandboxed_at IS NOT NULL`,
-// true only for a çaylak's still-in-review content (and only ever surfaced to the
-// author themselves + a moderator, since the feed filters sandboxed rows for anyone
-// else). It carries NO reviewer identity — just the item's own lifecycle state — so
-// #1291 can key an "incelemede" badge. Always `false` while the authorship loop is
-// dark (nothing is sandboxed on create when the flag is off).
+// `sandboxed` = `sandboxed_at IS NOT NULL` (#1316). It carries NO reviewer identity,
+// and the feed only ever surfaces a sandboxed row to its author + a moderator.
 interface ContributionBase {
 	id: string;
 	createdAt: Date;
@@ -116,17 +97,9 @@ interface ContributionBase {
 	sandboxed: boolean;
 }
 
-/**
- * The single source of the contribution-union's variant→fields knowledge (the
- * `Contribution` concept is *either* a definition, post, or comment). Each
- * variant lists ONLY its own fields, above {@link ContributionBase}; every other
- * shape — the discriminated {@link ContributionNode}, the flattened
- * {@link ContributionRow}, the runtime null-padding in `shapers`, and the
- * `ContributionView` field map — derives from this map so a variant (or a
- * per-variant field) is declared once (ADR 0018: fate has no union type, so the
- * variants are flattened onto one nullable row — but the membership fact lives
- * here, not spread across four sites).
- */
+// The single source of variant→fields for the contribution union: every other shape
+// (node, flat row, shaper null-padding, view field map) derives from this map, so add
+// a variant or a field here and nowhere else. See ADR 0018.
 interface ContributionVariants {
 	definition: {bodyExcerpt: string; termSlug: string; termTitle: string};
 	post: {title: string; slug: string | null; bodyExcerpt: string | null};
@@ -135,52 +108,39 @@ interface ContributionVariants {
 
 export type ContributionKind = keyof ContributionVariants;
 
-// `kind` + base + the variant's own fields, per discriminant.
 type ContributionNodeOf<K extends ContributionKind> = {kind: K} & ContributionBase &
 	ContributionVariants[K];
 
 export type ContributionNode = {[K in ContributionKind]: ContributionNodeOf<K>}[ContributionKind];
 
-// Union of every variant's field names — the columns the flat row flattens onto.
 type ContributionVariantField = {
 	[K in ContributionKind]: keyof ContributionVariants[K];
 }[ContributionKind];
 
-// Each variant field's value type, unioned across the variants that declare it
-// (and `null`, since the row nulls every field a given `kind` doesn't own).
 type ContributionVariantValue<F extends ContributionVariantField> = {
 	[K in ContributionKind]: F extends keyof ContributionVariants[K]
 		? ContributionVariants[K][F]
 		: never;
 }[ContributionKind];
 
-// The variant-field columns, all nullable — the flattened half of the row.
 type ContributionVariantColumns = {
 	[F in ContributionVariantField]: ContributionVariantValue<F> | null;
 };
 
-// Flat **discriminant** reshape of {@link ContributionNode} (ADR 0018: fate has
-// no union type). Derived from {@link ContributionVariants}: base fields plus
-// every variant's fields made nullable, populated per `kind`.
+// Flat discriminant reshape of {@link ContributionNode} — see ADR 0018 (fate has no
+// union type).
 export type ContributionRow = {kind: ContributionKind} & ContributionBase &
 	ContributionVariantColumns;
 
-/**
- * The variant→field-names manifest, the runtime witness of
- * {@link ContributionVariants}. `shapers.toContributionRow` reads it to null-pad
- * generically (every variant column starts `null`, then the node's own fields
- * overlay) — so a forgotten field is a compile-time error here, never a silent
- * wrong-shape in a hand-written `case`. The `satisfies` ties the runtime list to
- * the type-level variant map: drop or misspell a field name and it fails to
- * compile.
- */
+// Runtime witness of {@link ContributionVariants} — `shapers.toContributionRow`
+// reads it to null-pad generically. The `satisfies` makes a missed field a compile
+// error rather than a silent wrong-shape row.
 export const CONTRIBUTION_VARIANT_FIELDS = {
 	definition: ["bodyExcerpt", "termSlug", "termTitle"],
 	post: ["title", "slug", "bodyExcerpt"],
 	comment: ["bodyExcerpt", "postId", "postTitle"],
 } as const satisfies {[K in ContributionKind]: ReadonlyArray<keyof ContributionVariants[K]>};
 
-// Every variant column name, deduped — the keys the flat row nulls then overlays.
 export const CONTRIBUTION_VARIANT_FIELD_NAMES: ReadonlyArray<ContributionVariantField> = [
 	...new Set(Object.values(CONTRIBUTION_VARIANT_FIELDS).flat() as ContributionVariantField[]),
 ];
@@ -197,10 +157,8 @@ export interface ContributionConnection {
 	totalCount: number;
 }
 
-// A per-target email-delivery read/write result: the server-resolved `address` (the
-// projection's stable key + the ack's normalization key) paired with its projected
-// `state`. Returned by the mark/clear/read methods so the resolver keys its ack on the
-// address without a second user lookup (epic #2687).
+// `address` is the server-resolved projection key, returned alongside `state` so the
+// resolver keys its ack without a second user lookup (epic #2687).
 export interface EmailDeliveryResult {
 	readonly address: string;
 	readonly state: EmailDeliveryState;
@@ -216,11 +174,8 @@ export class Pasaport extends Context.Service<
 		// Single `WHERE id IN (...)`; order is not guaranteed (fate re-associates by id).
 		readonly getUsersByIds: (userIds: ReadonlyArray<string>) => Effect.Effect<UserRow[]>;
 
-		// Batched identity-only profile read (handle + karma) for many users in ONE
-		// `WHERE user_id IN (...)`; the divan roster joins it onto its grouped rows so
-		// the client never fires a per-row by-id `Profile` read (#1423). Order is not
-		// guaranteed (the caller re-associates by `userId`); users with no profile row
-		// are simply absent.
+		// Order is not guaranteed (the caller re-associates by `userId`); users with no
+		// profile row are simply absent.
 		readonly getProfileIdentitiesByIds: (
 			userIds: ReadonlyArray<string>,
 		) => Effect.Effect<ProfileIdentityRow[]>;
@@ -233,25 +188,16 @@ export class Pasaport extends Context.Service<
 			UsernameInvalid | UsernameTaken | UsernameAlreadySet | UserNotFound
 		>;
 
-		// Change the görünen ad (display name). Writes `user.name` AND
-		// `user_profile.display_name` in ONE atomic D1 batch so the two can never
-		// diverge (#2154): the better-auth field the settings surface reads and the
-		// stamped column every author byline reads are updated in lockstep. The
-		// `user_profile` upsert inserts a fresh row (`username` null) for a user who
-		// never set a username, so a byline resolves the live display name even
-		// pre-bootstrap. Unlike `setUsername`, this is re-runnable — a display name
-		// is mutable.
+		// Writes `user.name` AND `user_profile.display_name` in ONE atomic D1 batch so
+		// the two can never diverge (#2154). Unlike `setUsername`, re-runnable.
 		readonly setDisplayName: (input: {
 			userId: string;
 			value: string;
 		}) => Effect.Effect<SetDisplayNameResult, DisplayNameEmpty | UserNotFound>;
 
-		// `viewer` threads the request viewer so the profile's HEADLINE counts
-		// (`definitionCount`/`postCount`/`commentCount`) apply the #1205 sandbox filter
-		// (#1312): public/anonymous/other-member see counts of the author's LIVE content
-		// only, while the author themselves + a moderator see the full count including
-		// sandboxed. Omitted ⇒ anonymous (public-only), the fail-safe default — so the
-		// headline counts agree with the (#1309-fixed) feed for the same viewer.
+		// `viewer` applies the #1205 sandbox filter to the headline counts (#1312):
+		// only the author + a moderator see sandboxed content counted. Omitted ⇒
+		// anonymous (public-only), the fail-safe default.
 		readonly lookupProfile: (
 			username: string,
 			viewer?: {viewerId?: string | null | undefined; sandboxViewer?: SandboxViewer | undefined},
@@ -262,11 +208,8 @@ export class Pasaport extends Context.Service<
 			viewer?: {viewerId?: string | null | undefined; sandboxViewer?: SandboxViewer | undefined},
 		) => Effect.Effect<ProfileRow | null>;
 
-		// The contribution feed for a profile page. `sandboxViewer`/`viewerId` thread
-		// the request viewer so the feed applies the #1205 sandbox filter (#1309): a
-		// visitor sees only the author's LIVE content, the owner + a moderator also see
-		// the author's sandboxed content. Omitted ⇒ anonymous (public-only), the safe
-		// default.
+		// Same #1205 sandbox filter as `lookupProfile` (#1309). Omitted viewer ⇒
+		// anonymous (public-only), the safe default.
 		readonly listContributions: (input: {
 			authorId: string;
 			after?: string | null | undefined;
@@ -275,46 +218,24 @@ export class Pasaport extends Context.Service<
 			sandboxViewer?: SandboxViewer | undefined;
 		}) => Effect.Effect<ContributionConnection>;
 
-		// The count of an author's OWN content still in review — sandboxed (#1205)
-		// and not removed — the `inReviewCount` aggregate the çaylak-self standing
-		// read (#1316) exposes. A bare count over `sandboxBacklogWhere` scoped to the
-		// author; it carries no per-item or per-reviewer detail (one-way-glass).
+		// Aggregate only — no per-item or per-reviewer detail (one-way-glass, #1316).
 		readonly countInReview: (authorId: string) => Effect.Effect<number>;
 
-		// Account deletion = anonymize-to-`@[silinen]` (ADR 0097). For the calling
-		// user, in ONE atomic D1 batch: re-attribute every authored content row to
-		// the `silinen` sentinel (content stays Live, karma KEPT), tear down the
-		// identity rows (session/account/apikey/verification), and scrub the `user`
-		// row to a kept tombstone (PII nulled, `deleted_at` stamped). Idempotent
-		// for the same user (re-running re-attributes nothing and re-scrubs the
-		// already-scrubbed row). The caller is always the target — there is no
-		// "delete user X".
+		// Account deletion = anonymize-to-`@[silinen]`; see ADR 0097. Idempotent, and
+		// the caller is always the target — there is no "delete user X".
 		readonly anonymizeAccount: (input: {userId: string}) => Effect.Effect<void>;
 
-		// Promote a çaylak to yazar (#1206) — the server-side writer of the
-		// `input:false` `user.tier` column (#1203). In ONE atomic D1 batch (ADR
-		// 0014, the `anonymizeAccount` precedent): flip the tier `çaylak → yazar`
-		// AND resolve the account's sandboxed backlog (#1205) — `sandboxed_at := null`
-		// on its still-sandboxed, not-removed content, so the now-yazar's backlog goes
-		// live. Atomic, so "tier flipped but backlog half-swept" is unrepresentable;
-		// idempotent, because both writes are conditional (tier flips only from çaylak,
-		// the sweep touches only sandboxed-not-removed rows) so re-running is a no-op.
+		// Tier flip + sandbox-backlog sweep in ONE atomic D1 batch, idempotent (#1206).
 		// The AUTHORITY (a mod, or a valid vouch) is discharged at the resolver, never
-		// here — `promoted: true` iff the tier flip actually fired (the account was a
-		// çaylak), `false` on an already-yazar / unknown account.
+		// here. `promoted: true` iff the tier flip actually fired.
 		readonly promoteToYazar: (input: {userId: string}) => Effect.Effect<{promoted: boolean}>;
 
-		// The account's current ban-state, projected from the latest `user_ban_event`
-		// row (epic #968). A fresh read of the append-only log, so it reflects the
-		// authority-checked truth, never a cached session flag. Read at the session
-		// boundary (`validateSession`) and by the admin ban surface.
+		// A FRESH read of the append-only `user_ban_event` log, never a cached session
+		// flag (epic #968).
 		readonly getBanState: (userId: string) => Effect.Effect<BanState>;
 
-		// Ban an account: append a `ban` event (reason + optional expiry), stamped
-		// with the acting admin (`actorId`) and time — the audit record IS the write
-		// (ADR 0107, epic #968). Returns the resulting ban-state. `UserNotFound` on an
-		// unknown target. The AUTHORITY is discharged at the resolver (`requireAdmin`),
-		// never here — this method assumes an authorized caller.
+		// The audit record IS the write (ADR 0107, epic #968). The AUTHORITY is
+		// discharged at the resolver (`requireAdmin`), never here.
 		readonly banUser: (input: {
 			userId: string;
 			actorId: string;
@@ -322,97 +243,68 @@ export class Pasaport extends Context.Service<
 			expiresAt?: Date | null;
 		}) => Effect.Effect<BanState, UserNotFound>;
 
-		// Unban an account: append an `unban` event stamped with the acting admin and
-		// time (the reversal is itself audited). Returns the resulting ban-state
-		// (not-banned). Idempotent — unbanning a not-banned account appends a benign
-		// `unban` and still reads not-banned. `UserNotFound` on an unknown target.
+		// Idempotent — unbanning a not-banned account appends a benign `unban`.
 		readonly unbanUser: (input: {
 			userId: string;
 			actorId: string;
 		}) => Effect.Effect<BanState, UserNotFound>;
 
-		// Assign a target account's platform role (#3522, admin epic per ADR 0107):
-		// `moderator` writes the `(userId, "moderates", platform)` relation tuple,
-		// `member` deletes it — the SPA-invokable writer #969/PR #1266's offline mint
-		// never gave the console. The tuple write IS the authority change (`isModerator`
-		// / `moderatorsAmong` re-read it), and an append to `user_role_event` records the
-		// actor + new role + time. Returns the assigned role. `UserNotFound` on an unknown
-		// target. The AUTHORITY is discharged at the resolver (`requireAdmin`), never here.
+		// The `(userId, "moderates", platform)` tuple write IS the authority change
+		// (`isModerator` / `moderatorsAmong` re-read it); `user_role_event` is the audit
+		// trail. The AUTHORITY to call this is discharged at the resolver
+		// (`requireAdmin`), never here. See ADR 0107.
 		readonly setRole: (input: {
 			userId: string;
 			actorId: string;
 			role: PlatformRole;
 		}) => Effect.Effect<{readonly role: PlatformRole}, UserNotFound>;
 
-		// The target account's current email-delivery state, projected from the latest
-		// `email_delivery_event` row for its address (email-bounce epic #2687). A fresh
-		// read of the append-only log — the same projection the admin roll-up and the
-		// send-time capture feed, so "marked failing" and "reported failing" can't
-		// disagree. Returns the resolved `address` with the `state` so the ack keys on the
-		// server-resolved address. `UserNotFound` on an unknown target.
+		// A fresh read of the append-only `email_delivery_event` log — the same
+		// projection the admin roll-up and the send-time capture feed, so "marked
+		// failing" and "reported failing" can't disagree (epic #2687).
 		readonly getEmailDeliveryState: (
 			userId: string,
 		) => Effect.Effect<EmailDeliveryResult, UserNotFound>;
 
-		// Manually mark the target account's address as failing (Child #2692): append a
-		// `fail` event carrying the admin's reason and the acting admin (`actorId`, #2734),
-		// so an out-of-band bounce report an admin learns of shares the SAME log the
-		// send-time capture writes and attributes who acted. Returns the resolved address +
-		// resulting (failing) state. `UserNotFound` on an unknown target. The AUTHORITY is
-		// discharged at the resolver (`requireAdmin`), never here.
+		// An out-of-band bounce an admin learns of shares the SAME log the send-time
+		// capture writes (#2692/#2734). The AUTHORITY is discharged at the resolver
+		// (`requireAdmin`), never here.
 		readonly markEmailFailing: (input: {
 			userId: string;
 			actorId: string;
 			reason: string;
 		}) => Effect.Effect<EmailDeliveryResult, UserNotFound>;
 
-		// Manually clear the target account's failing address (Child #2692): append a
-		// `clear` event stamped with the acting admin (`actorId`, #2734), lifting the
-		// failing-state without mutating the `fail` row (full reversibility, as in unban).
-		// Returns the resolved address + resulting (deliverable) state. Idempotent —
-		// clearing a deliverable address appends a benign `clear` and still reads
-		// deliverable. `UserNotFound` on an unknown target.
+		// Appends a `clear` without mutating the `fail` row (full reversibility, as in
+		// unban). Idempotent.
 		readonly clearEmailFailing: (input: {
 			userId: string;
 			actorId: string;
 		}) => Effect.Effect<EmailDeliveryResult, UserNotFound>;
 
-		// The admin failing-address roll-up (Child #2692): every address whose latest
-		// event projects to `failing`, newest-first. Read only past `requireAdmin`; the
-		// set is derived from the log, never a stored flag.
+		// Derived from the log, never a stored flag. Read only past `requireAdmin`.
 		readonly listFailingAddresses: () => Effect.Effect<ReadonlyArray<FailingAddress>>;
 
-		// The admin user roster read (#3200): one keyset page of accounts ordered
-		// newest-first (`created_at DESC, id DESC`), optionally narrowed by a `search`
-		// substring over username/email/name. Record-derived fields only (id, username,
-		// email, tier, createdAt) — the ban-state, role, and moderator standing are joined
+		// Record-derived fields only — ban-state, role and moderator standing are joined
 		// by the resolver ({@link banStatesForAdmin} + `moderatorsAmong`), never read off
-		// the retired `user.role` column. Read only past `requireAdmin`; assumes an
-		// authorized caller. `.patterns/fate-connections.md` keyset envelope.
+		// the retired `user.role` column. Read only past `requireAdmin`. Keyset envelope:
+		// .patterns/fate-connections.md
 		readonly listUsersForAdmin: (opts: {
 			search?: string | null;
 			first?: number;
 			after?: string | null;
 		}) => Effect.Effect<KeysetPage<AdminUserRow>>;
 
-		// The BATCHED ban-state read for a roster page (#3200): the current ban-state of
-		// each id, projected from one query over the small append-only `user_ban_event` log
-		// ({@link selectBanStates}), so the roster never runs a per-row `getBanState` (an
-		// in-page N+1). A missing id reads {@link NOT_BANNED} (absent from the map). Read
-		// only past `requireAdmin`.
+		// One query for the whole roster page, so it never runs a per-row `getBanState`
+		// (an in-page N+1). A missing id is absent from the map, meaning {@link NOT_BANNED}.
 		readonly banStatesForAdmin: (
 			ids: ReadonlyArray<string>,
 		) => Effect.Effect<ReadonlyMap<string, BanState>>;
 	}
 >()("@kampus/pasaport/Pasaport") {}
 
-/**
- * The record-derived row of the admin user roster (#3200) — the `user` columns the
- * `userAdmin.list` read exposes, before the resolver joins the ban-state / role. `tier`
- * rides as the stored value; `createdAt` is the raw column (nullable — the founding cohort
- * predates it), converted to an epoch-millis wire scalar by the feature's shaper. Kept next
- * to the query that produces it, mirroring `ProfileRow`.
- */
+// `createdAt` is nullable because the founding cohort predates the column; the
+// feature's shaper converts it to an epoch-millis wire scalar.
 export interface AdminUserRow {
 	readonly id: string;
 	readonly username: string | null;
@@ -421,19 +313,14 @@ export interface AdminUserRow {
 	readonly createdAt: Date | null;
 }
 
-/**
- * The seeded `@[silinen]` sentinel's id + display name (ADR 0097). Migration
- * `0006` seeds the `user` + `user_profile` rows; account-deletion re-attributes
- * content to this id. The reserved username lives in `username-rule.ts`
- * ({@link SILINEN_USERNAME}) — the one place the rule is sourced.
- */
+// The seeded `@[silinen]` sentinel (ADR 0097); migration `0006` seeds its rows. The
+// reserved username itself is sourced in `username-rule.ts`.
 export const SILINEN_USER_ID = "silinen";
 export {SILINEN_USERNAME} from "./username-rule.ts";
 export const SILINEN_DISPLAY_NAME = "@[silinen]";
 
-// The server-authoritative gate: re-runs the shared {@link checkUsername} rule and
-// maps its code onto the typed domain error. The rule (length/charset/reserved) is
-// single-sourced in `username-rule.ts`, consumed identically by the SPA forms.
+// The server-authoritative gate. The rule itself is single-sourced in
+// `username-rule.ts`, consumed identically by the SPA forms.
 function assertUsername(normalized: string): Effect.Effect<void, UsernameInvalid> {
 	switch (checkUsername(normalized)) {
 		case "RESERVED":
@@ -457,14 +344,9 @@ function assertUsername(normalized: string): Effect.Effect<void, UsernameInvalid
 	}
 }
 
-/**
- * Cursor codec for the `(createdAt desc, id desc)` keyset (matches the fate view
- * `orderBy`; `id` is a global ULID tiebreaker). Wire format `<epochSeconds>:<id>`.
- *
- * Encodes epoch **seconds** because D1 stores `created_at` as
- * `integer({mode:"timestamp"})` — seconds is the DB's own granularity, so the
- * keyset round-trips without precision loss and cursors stay stable across deploys.
- */
+// Wire format `<epochSeconds>:<id>` for the `(createdAt desc, id desc)` keyset.
+// Epoch SECONDS, because D1 stores `created_at` as `integer({mode:"timestamp"})` —
+// matching the DB's granularity keeps the keyset lossless across deploys.
 function encodeCursor(node: {createdAt: Date; id: string}): string {
 	return `${Math.floor(node.createdAt.getTime() / 1000)}:${node.id}`;
 }
@@ -479,25 +361,16 @@ function decodeCursor(cursor: string): {createdAt: Date; id: string} | null {
 	return {createdAt: new Date(ts * 1000), id};
 }
 
-/**
- * Build the `Pasaport` Layer over an already-resolved better-auth instance. The
- * worker resolves the `BetterAuth` tag once in init and hands the instance here;
- * sharing the single auth instance with the `/api/auth/*` route keeps session
- * cookies signed and validated by the same secret.
- */
+// Takes the already-resolved better-auth instance: sharing the one instance with the
+// `/api/auth/*` route keeps session cookies signed and validated by the same secret.
 export const makePasaportLive = (auth: BetterAuthInstance) =>
 	Layer.effect(Pasaport)(
 		Effect.gen(function* () {
-			// `orDieAccess`: every DB call site dies on `DrizzleError` (infra
-			// failures are defects — the domain-boundary rule), so public signatures
-			// carry domain errors only and every method's `R` stays `never`.
 			const {run, batch} = orDieAccess(yield* Drizzle);
 
-			// The per-viewer visibility predicate a count routes through — the ONE seam
-			// (ADR 0113), never a by-path-divergent hand-written clause (#1406). The post
-			// table folds in the `post_record`-only draft arm (`postVisibleWhere`), so a
-			// non-author's count excludes the author's unpublished drafts; definition and
-			// comment have no draft dimension and route through `sandboxVisibleWhere`.
+			// The ONE seam every count routes through, never a hand-written clause that
+			// can diverge by path (ADR 0113, #1406). Only `post_record` has a draft
+			// dimension, hence the split.
 			const countVisibleWhere = (
 				table:
 					| typeof schema.definitionRecord
@@ -512,12 +385,9 @@ export const makePasaportLive = (auth: BetterAuthInstance) =>
 						)
 					: sandboxVisibleWhere({sandboxedAt: table.sandboxedAt, authorId: table.authorId}, viewer);
 
-			// `COUNT(*)` of one author's non-removed rows in a contribution table.
-			// Calls `run` directly so callers keep `R = never`. A `viewer` narrows the
-			// count to that viewer's sandbox+draft-visible set via `countVisibleWhere`
-			// (#1309/#1406) — so the feed's `totalCount` matches the rows it actually
-			// returns and never leaks the COUNT of an author's sandboxed/draft content;
-			// omitted ⇒ no narrowing.
+			// A `viewer` narrows the count to that viewer's visible set, so `totalCount`
+			// matches the rows actually returned and never leaks a count of the author's
+			// sandboxed/draft content (#1309/#1406). Omitted ⇒ no narrowing.
 			const countByAuthor = (
 				table:
 					| typeof schema.definitionRecord
@@ -540,10 +410,6 @@ export const makePasaportLive = (auth: BetterAuthInstance) =>
 						.then((r) => Number(r[0]?.n ?? 0)),
 				);
 
-			// `COUNT(*)` of one author's still-in-review rows in a contribution table:
-			// the `sandboxBacklogWhere` read model (#1205) scoped to the author —
-			// sandboxed AND not removed. The çaylak-self `inReviewCount` (#1316) sums
-			// this across the three tables. Aggregate-only, no per-item leak.
 			const countBacklogByAuthor = (
 				table:
 					| typeof schema.definitionRecord
@@ -594,11 +460,8 @@ export const makePasaportLive = (auth: BetterAuthInstance) =>
 				);
 			});
 
-			// `viewer` is REQUIRED (always a resolved {@link SandboxViewer} — the lookup
-			// methods resolve it fail-safe before calling), so the headline counts can
-			// never skip the #1205 sandbox filter (#1312). It is passed straight to
-			// `countByAuthor`, the SAME viewer-aware count the #1309 feed uses for its
-			// `totalCount`, so the header and feed agree per-viewer.
+			// `viewer` is REQUIRED, not optional, so the headline counts can never skip
+			// the #1205 sandbox filter (#1312); callers resolve it fail-safe first.
 			const hydrateProfile = Effect.fn("Pasaport.hydrateProfile")(function* (
 				row: {
 					userId: string;
@@ -626,10 +489,9 @@ export const makePasaportLive = (auth: BetterAuthInstance) =>
 				} satisfies ProfileRow;
 			});
 
-			// The account's current ban-state — a FRESH read of the latest `user_ban_event`
-			// row projected by `resolveBanState` (epic #968). The session boundary and the
-			// admin ban surface both route through this one seam, so "session refused" and
-			// "reported banned" can't disagree. `now` fresh per call so an expiry self-lifts.
+			// The session boundary and the admin ban surface both route through this one
+			// seam, so "session refused" and "reported banned" can't disagree. `now` is
+			// fresh per call so an expiry self-lifts.
 			const readBanState = (userId: string): Effect.Effect<BanState> =>
 				run((db) =>
 					db
@@ -656,11 +518,9 @@ export const makePasaportLive = (auth: BetterAuthInstance) =>
 						}),
 				);
 
-			// The address's current email-delivery state — a FRESH read of the latest
-			// `email_delivery_event` row projected by `resolveEmailDeliveryState` (epic
-			// #2687). Keyed by ADDRESS (the projection's stable key, index-backed by
-			// `email_delivery_event_address_created`), so the admin mark/clear ack, the
-			// per-target read, and the roll-up all resolve the same latest-event-wins truth.
+			// Keyed by ADDRESS, not user id (index-backed by
+			// `email_delivery_event_address_created`), so the mark/clear ack, the
+			// per-target read and the roll-up all resolve the same latest-event-wins truth.
 			const readEmailDeliveryState = (address: string): Effect.Effect<EmailDeliveryState> =>
 				run((db) =>
 					db
@@ -685,13 +545,10 @@ export const makePasaportLive = (auth: BetterAuthInstance) =>
 						}),
 				);
 
-			// Append one `email_delivery_event` for a target account's address, then read
-			// back its projected state. Rejects an unknown target up front so a mark/clear
-			// can't be recorded against a non-existent id (the audit log stays meaningful),
-			// and resolves the target's own `email` as the address the event is keyed by.
-			// The only caller is the admin mark/clear below, so `actorId` is always the acting
-			// admin's id (#2734) — the send-time capture writes its own actor-less rows through
-			// `EmailDeliveryLog` (`email-delivery-log.ts`), not this helper.
+			// Rejects an unknown target up front so a mark/clear can't be recorded against
+			// a non-existent id (the audit log stays meaningful). Only the admin mark/clear
+			// calls this, so `actorId` is always a real admin (#2734) — the send-time
+			// capture writes its actor-less rows through `EmailDeliveryLog` instead.
 			const appendEmailDeliveryEvent = (
 				userId: string,
 				actorId: string,
@@ -737,13 +594,11 @@ export const makePasaportLive = (auth: BetterAuthInstance) =>
 							}),
 						),
 					);
-					// Enforcement at the auth boundary (epic #968): a banned account's session
-					// is REFUSED here, not merely flagged — every session-derived consumer
-					// (fate/`CurrentUser`, `CurrentActor`, the `/api/auth` guard) reads this one
-					// gate, so a banned user with a still-valid cookie is treated as anonymous
-					// on EXISTING sessions, and an unban restores access on the next request. The
-					// ban-state is read FRESH from D1 (never trusted off the session token), the
-					// fail-closed fresh-read invariant ADR 0098 §2 carries forward.
+					// A banned account's session is REFUSED here, not merely flagged — every
+					// session-derived consumer reads this one gate, so a still-valid cookie
+					// reads as anonymous and an unban restores access on the next request. The
+					// ban-state is read FRESH from D1, never trusted off the session token
+					// (the fail-closed fresh-read invariant of ADR 0098 §2).
 					if (session?.user) {
 						const banState = yield* readBanState(session.user.id);
 						if (banState.banned) return null;
@@ -859,12 +714,9 @@ export const makePasaportLive = (auth: BetterAuthInstance) =>
 					}
 
 					const now = new Date();
-					// One atomic batch (the `buildPromotionStatements` precedent): `user.name`
-					// and `user_profile.display_name` move all-or-none, so the better-auth
-					// field the settings surface reads and the stamped column every byline
-					// reads can never diverge (#2154). The profile upsert inserts a fresh row
-					// for a user who never set a username (preserving a null `username`), so a
-					// byline resolves the live display name even pre-bootstrap.
+					// One atomic batch: `user.name` and `user_profile.display_name` move
+					// all-or-none, so a byline can never render a name the settings surface
+					// has already changed (#2154).
 					yield* batch((db) => buildSetDisplayNameStatements(db, userId, trimmed, now));
 
 					return {
@@ -882,10 +734,9 @@ export const makePasaportLive = (auth: BetterAuthInstance) =>
 						sandboxViewer?: SandboxViewer | undefined;
 					},
 				) {
-					// Usernames are stored lowercased at write time (`setUsername`), so the
-					// read must normalize identically or a mixed-case `/u/Rasit` misses the
-					// stored `rasit` row and 404s (#2445). `normalizeUsername` is the one
-					// source read and write share, keeping every entry point case-insensitive.
+					// Usernames are stored lowercased at write time, so the read must
+					// normalize identically or a mixed-case `/u/Rasit` misses the stored
+					// `rasit` row and 404s (#2445).
 					const normalized = normalizeUsername(username);
 					const rows = yield* run((db) =>
 						db
@@ -956,19 +807,14 @@ export const makePasaportLive = (auth: BetterAuthInstance) =>
 					const cursor = input.after ? decodeCursor(input.after) : null;
 					const fetchSize = first + 1;
 
-					// The #1205 sandbox filter, resolved against the request viewer (#1309):
-					// the profile feed shows the author's LIVE content to everyone, but the
-					// author's SANDBOXED content only to the author themselves + a moderator.
-					// A missing viewer resolves to anonymous, so the default is public-only.
+					// A missing viewer resolves to anonymous, so the default is public-only
+					// (#1205/#1309).
 					const viewer = resolveSandboxViewer(input);
 
-					// `after` present but undecodable is a cursor miss → empty page.
 					const cursorMissed = input.after != null && cursor === null;
 
-					// Per-table keyset for the global `(created_at desc, id desc)` merge.
-					// The predicate and the `.orderBy(…)` both derive from the per-table
-					// `contributionOrdering`; null cursor values (no `after`) collapse the
-					// predicate to undefined so only the base author/removed filter applies.
+					// Per-table keyset for the global `(created_at desc, id desc)` merge; a
+					// null cursor collapses the predicate so only the base filter applies.
 					function keysetWhere(
 						table:
 							| typeof schema.definitionRecord
@@ -1098,9 +944,9 @@ export const makePasaportLive = (auth: BetterAuthInstance) =>
 						return 0;
 					});
 
-					// Each table is read with `LIMIT first+1` under the same keyset, so
-					// the merged set holds every candidate for the next `first` slots of
-					// the global order; `forwardPage` slices the probe.
+					// Each table is read with `LIMIT first+1` under the same keyset, so the
+					// merged set holds every candidate for the next `first` slots of the
+					// global order.
 					const page = forwardPage<ContributionNode>(merged, first, encodeCursor);
 
 					return {
@@ -1116,24 +962,20 @@ export const makePasaportLive = (auth: BetterAuthInstance) =>
 				}) {
 					const {userId} = input;
 					const now = new Date();
-					// `verification` keys by `identifier` = the live email, which the batch
-					// is about to scrub — so capture it as a plain value BEFORE the batch
-					// (ADR 0097 §2) and delete by that literal, never a correlated subquery
-					// (D1's batch executor rejects a raw subquery member).
+					// `verification` keys by `identifier` = the live email, which the batch is
+					// about to scrub — so capture it as a plain value BEFORE the batch and
+					// delete by that literal, never a correlated subquery (D1's batch
+					// executor rejects a raw subquery member). See ADR 0097 §2.
 					const user = yield* run((db) => db.query.user.findFirst({where: {id: userId}}));
 					const email = user?.email ?? null;
-					// One atomic batch (ADR 0014/0097 §2): every statement commits or none
-					// does, so the world never sees a half-anonymized account.
 					yield* batch((db) => buildAnonymizeStatements(db, userId, email, now));
 				}),
 
 				promoteToYazar: Effect.fn("Pasaport.promoteToYazar")(function* (input: {userId: string}) {
 					const now = new Date();
-					// One atomic batch (ADR 0014, the `anonymizeAccount` precedent): the
-					// tier flip and the backlog sweep commit together or not at all, so a
-					// half-swept promotion (tier flipped, backlog still sandboxed — or the
-					// reverse) is unrepresentable. The first statement is the conditional
-					// tier UPDATE; its `changes` count is `1` iff the account was a çaylak.
+					// One atomic batch, so a half-swept promotion is unrepresentable (ADR
+					// 0014). The first statement is the conditional tier UPDATE; its
+					// `changes` count is `1` iff the account was a çaylak.
 					const result = yield* batch((db) => buildPromotionStatements(db, input.userId, now));
 					return {promoted: result[0].meta.changes > 0};
 				}),
@@ -1193,14 +1035,12 @@ export const makePasaportLive = (auth: BetterAuthInstance) =>
 					actorId: string;
 					role: PlatformRole;
 				}) {
-					// Reject an unknown target up front so a role is never assigned to a
-					// non-existent id (mirrors `banUser`; the audit log stays meaningful).
+					// Reject an unknown target up front so the audit log stays meaningful.
 					const target = yield* run((db) => db.query.user.findFirst({where: {id: input.userId}}));
 					if (!target) return yield* new UserNotFound({message: "kullanıcı bulunamadı"});
 
-					// The `moderates` tuple IS the authority: `moderator` grants it (idempotent
-					// on re-grant), `member` revokes it. Encoded through kunye's `moderatorTuple`
-					// so the write can't drift from the `isModerator` / `moderatorsAmong` read.
+					// Encoded through kunye's `moderatorTuple` so this write can't drift from
+					// the `isModerator` / `moderatorsAmong` read.
 					const tuple = moderatorTuple(input.userId);
 					yield* run((db) =>
 						input.role === "moderator"
@@ -1216,8 +1056,6 @@ export const makePasaportLive = (auth: BetterAuthInstance) =>
 									),
 					);
 
-					// Audit the assignment (actor, target, new role, time) on the append-only
-					// `user_role_event` log — the same audit shape ban/email-delivery use.
 					yield* run((db) =>
 						db.insert(schema.userRoleEvent).values({
 							id: crypto.randomUUID(),
@@ -1255,9 +1093,8 @@ export const makePasaportLive = (auth: BetterAuthInstance) =>
 
 				listFailingAddresses: Effect.fn("Pasaport.listFailingAddresses")(function* () {
 					// The failure log is small (only send rejections + admin marks land here),
-					// so read it whole and reduce to latest-per-address in the pure projection
-					// (`selectFailingAddresses`) rather than a group-wise-latest SQL — one
-					// projection rule, unit-tested, shared with the per-address read.
+					// so read it whole and reduce in the pure projection rather than write a
+					// second group-wise-latest SQL that could drift from the per-address read.
 					const rows = yield* run((db) =>
 						db
 							.select({
@@ -1290,9 +1127,8 @@ export const makePasaportLive = (auth: BetterAuthInstance) =>
 					const after = opts.after ?? null;
 					const term = opts.search?.trim().toLowerCase();
 
-					// Narrow by a case-insensitive substring over the identity fields when a
-					// search is given; SQLite `LIKE` is case-insensitive for ASCII, and the
-					// username/email columns are ASCII by rule, so no `lower()` wrap is needed.
+					// No `lower()` wrap: SQLite `LIKE` is already case-insensitive for ASCII,
+					// and these columns are ASCII by rule.
 					const searchWhere =
 						term && term.length > 0
 							? or(
@@ -1306,11 +1142,8 @@ export const makePasaportLive = (auth: BetterAuthInstance) =>
 					// a `deleted_at` row is not a real account an admin manages.
 					const baseWhere = and(isNull(schema.user.deletedAt), searchWhere);
 
-					// Resolve the opaque `after` (a user id) to its keyset tuple — the DB read is
-					// the port, `resolveCursor` the pure cursor-miss decision (ADR 0082): a cursor
-					// that no longer points at a live row yields the empty page. `created_at DESC,
-					// id DESC` is the roster order; `created_at` is effectively always stamped by
-					// better-auth, so the null-column degrade in `keysetAfter` never bites.
+					// A cursor that no longer points at a live row yields the empty page; the
+					// DB read is the port, `resolveCursor` the pure decision (ADR 0082).
 					const resolvedRow = after
 						? ((yield* run((db) =>
 								db
@@ -1392,22 +1225,13 @@ export const makePasaportLive = (auth: BetterAuthInstance) =>
 	);
 
 /**
- * The atomic teardown of one account (ADR 0097 §2). In order:
- *  1–3. Re-attribute the user's content (`definition_record` / `post_record` /
- *       `comment_record`): `author_id := silinen`, denormalized `author_name`
- *       overwritten. Content stays Live (`removed_at` untouched) — this is
- *       re-attribution, not removal — so its votes/scores and the karma they
- *       earned ride along untouched.
- *  4–7. Tear down the identity rows: `session` / `account` / `apikey` /
- *       `verification`. `verification` keys by `identifier` = the user's email
- *       (not a FK), so it's deleted by the literal email the caller resolved
- *       before this batch; skipped when the user has no email.
- *  8.   Scrub the `user` row to a kept tombstone: PII (email/name/image) nulled,
- *       `deleted_at` stamped. The row is KEPT so the `author_id → silinen`
- *       redirect and FKs stay coherent and the email can re-register fresh.
+ * The atomic teardown of one account — see ADR 0097 §2 for the why. Two things the
+ * code will not tell you: content is RE-ATTRIBUTED, not removed (`removed_at`
+ * untouched), so votes/scores/karma ride along; and the `user` row is KEPT as a
+ * scrubbed tombstone so the `author_id → silinen` redirect and the FKs stay coherent.
  *
- * Every statement is a query-builder statement (no raw correlated subquery) so
- * D1's `batch()` executor accepts the whole array.
+ * Every statement must be a query-builder statement (no raw correlated subquery), or
+ * D1's `batch()` executor rejects the array.
  */
 function buildAnonymizeStatements(db: DrizzleDb, userId: string, email: string | null, now: Date) {
 	const reattributeDefs = db
@@ -1451,22 +1275,11 @@ function buildAnonymizeStatements(db: DrizzleDb, userId: string, email: string |
 }
 
 /**
- * The atomic çaylak→yazar promotion (#1206). In order:
- *  1.   Flip `user.tier` `çaylak → yazar` and stamp `promoted_at := now` (#1590) in
- *       the SAME statement. The `tier = 'çaylak'` WHERE is the idempotency guard: an
- *       already-yazar (or unknown) account matches 0 rows, so re-running promotes
- *       nothing — and because the `promoted_at` SET rides that same guarded UPDATE, a
- *       non-promoting call stamps nothing (the timestamp is set iff the tier actually
- *       flips). It is the read of `changes` that reports `promoted`.
- *  2–4. Resolve the account's sandboxed backlog (#1205): `sandboxed_at := null` on
- *       its definitions / posts / comments that are still sandboxed and not removed.
- *       The WHERE is exactly the #1205 {@link sandboxBacklogWhere} read model scoped
- *       to this author, so the sweep flips precisely the rows the moderator queue
- *       showed — leaving live rows (already null) and removed rows (`removed_at` set)
- *       untouched, so a mixed backlog lands consistent and a re-run is a no-op.
+ * The atomic çaylak→yazar promotion (#1206). The `tier = 'çaylak'` WHERE is the
+ * idempotency guard — an already-yazar account matches 0 rows — and `promoted_at`
+ * rides that same guarded UPDATE deliberately, so a non-promoting call stamps nothing.
  *
- * Every statement is a query-builder statement (no raw correlated subquery) so D1's
- * `batch()` executor accepts the whole array (the `buildAnonymizeStatements` rule).
+ * Query-builder statements only, per `buildAnonymizeStatements`.
  */
 function buildPromotionStatements(db: DrizzleDb, userId: string, now: Date) {
 	const promoteTier = db
@@ -1496,18 +1309,12 @@ function buildPromotionStatements(db: DrizzleDb, userId: string, now: Date) {
 }
 
 /**
- * The atomic görünen-ad (display-name) write-through (#2154). Two statements:
- *  1. `user.name := <trimmed>` — the better-auth field the settings surface reads.
- *  2. `user_profile.display_name := <trimmed>` — the stamped column every author
- *     byline reads, via an upsert that INSERTS a fresh row (null `username`) for a
- *     user who never bootstrapped a username, and on conflict overwrites ONLY
- *     `display_name` + `updated_at`, preserving `username`/`image`.
+ * The atomic görünen-ad (display-name) write-through (#2154). The upsert INSERTs a
+ * fresh row for a user who never bootstrapped a username, and on conflict overwrites
+ * ONLY `display_name` + `updated_at`, preserving `username`/`image`.
  *
- * Both move in one D1 batch so `user.name` and `user_profile.display_name` are
- * lockstep — a byline can never render a stale name the settings surface has
- * already changed (the one-shot-sync defect this closes). Both are query-builder
- * statements (never a raw `db.run(sql)`, which 500s a real-D1 batch — #863) so the
- * batch executor accepts the array (the `buildPromotionStatements` rule).
+ * Query-builder statements only — a raw `db.run(sql)` member 500s a real-D1 batch
+ * (#863).
  */
 function buildSetDisplayNameStatements(
 	db: DrizzleDb,

--- a/apps/web/worker/features/pasaport/account-deletion.unit.test.ts
+++ b/apps/web/worker/features/pasaport/account-deletion.unit.test.ts
@@ -1,26 +1,10 @@
 /**
  * Account-deletion unit coverage (ADR 0097) — the three decisions that are
- * wrong-or-right with NO database (ADR 0082):
+ * wrong-or-right with NO database (ADR 0082): the typed-confirmation decode gate, the
+ * caller-is-target invariant (there is no target parameter, so "delete user X" is
+ * unrepresentable), and the reserved-username rejection before any DB read.
  *
- *   1. **Typed-confirmation gate.** `DeleteAccountInput.confirmation` is a
- *      `Schema.Literal`, so a wrong/absent token fails input DECODE before the
- *      mutation body runs — "deleted by accident / by a replayed request" is a
- *      validation failure, not a silent execution. Proven by decoding the input
- *      Schema directly (the seam the fate interpreter applies before the handler).
- *   2. **Caller-is-target invariant.** `account.delete` reads `CurrentUser.required`
- *      and anonymizes `user.id` — there is no target parameter in its input, so
- *      "delete user X" is unrepresentable. Asserted structurally (the input Schema
- *      carries only `confirmation`) and behaviorally — anonymous yields the WIRE
- *      `UNAUTHORIZED` before any `Pasaport` call, proven through `resolveWire` (the
- *      op's real external interface: `resolve` decode + the `encodeWireError`
- *      class→wire-code seam), so a mis-annotated `[FateWireCode]` is a unit failure.
- *   3. **Reserved-username rejection.** `Pasaport.setUsername("silinen")` rejects
- *      with `INVALID_FORMAT` BEFORE any DB read, so `@[silinen]` can never collide
- *      with a real account. Proven over a throwing `Drizzle` seam — a reached read
- *      would `die`, not surface the typed error.
- *
- * The anonymize teardown itself (real D1 batch: re-attribution Live, identity rows
- * gone, user scrubbed-but-present, karma kept) is real-D1 fidelity →
+ * The anonymize teardown itself is real-D1 fidelity →
  * `tests/integration/account-deletion.test.ts`.
  */
 
@@ -34,24 +18,21 @@ import {resolveWire} from "../fate/resolve-wire.testing.ts";
 import {ACCOUNT_DELETE_CONFIRMATION, mutations} from "./mutations.ts";
 import {type BetterAuthInstance, makePasaportLive, Pasaport} from "./Pasaport.ts";
 
-// A `Drizzle` whose every call throws — so any path that reaches the DB seam
-// fails the test. The reserved-username guard short-circuits before any read, and
-// running to completion against this is exactly the "no read" proof.
+// A `Drizzle` whose every call throws. Running to completion against it is exactly
+// the "the guard short-circuited before any read" proof.
 const throwingAccess: DrizzleAccess = {
 	run: () => Effect.die(new Error("Pasaport read the DB on a path that must short-circuit")),
 	batch: () => Effect.die(new Error("Pasaport wrote a batch on a path that must short-circuit")),
 };
 
-// `auth` is unused by `setUsername`'s reserved-username guard (it short-circuits
-// before any session/DB use), so a never-cast inert instance satisfies the type.
+// `auth` is unused by the reserved-username guard, which short-circuits first.
 const inertAuth = {} as BetterAuthInstance;
 
 const pasaportLayer = (access: DrizzleAccess) =>
 	makePasaportLive(inertAuth).pipe(Layer.provide(Layer.succeed(Drizzle, access)));
 
-// Fail-on-contact `Pasaport`: any method call dies, so a passing anon-gate test
-// proves the mutation never reached the service (a reached call would `die`, not
-// surface `Unauthorized`).
+// Fail-on-contact `Pasaport`: a passing anon-gate test proves the mutation never
+// reached the service (a reached call would `die`, not surface `Unauthorized`).
 const failOnContactPasaport = {
 	anonymizeAccount: () =>
 		Effect.die("Pasaport.anonymizeAccount must not be reached on the anon gate"),
@@ -76,9 +57,6 @@ it("a wrong confirmation token fails input decode (the body never runs)", () => 
 });
 
 it("the input carries NO target field — the caller is always the target", () => {
-	// "delete user X" is unrepresentable: the input Schema's only field is
-	// `confirmation`. A would-be target key is not part of the decoded value, so
-	// the mutation can only ever act on the authenticated caller's own `user.id`.
 	const fields = Object.keys((inputSchema as {fields: Record<string, unknown>}).fields);
 	assert.deepStrictEqual(fields, ["confirmation"]);
 });

--- a/apps/web/worker/features/pasaport/additional-user-fields.unit.test.ts
+++ b/apps/web/worker/features/pasaport/additional-user-fields.unit.test.ts
@@ -1,12 +1,8 @@
 /**
  * The `input:false` invariant on better-auth's `user.additionalFields` — the
- * structural guard that makes every server-managed user column un-writable by a
- * client/session/registration payload. `tier` (the authorship tier, ADR 0107 §4)
- * is asserted alongside `role` (ADR 0098) and `username`: a fresh registration
- * cannot set or escalate any of them, so `tier` can never be born `yazar` from the
- * wire — it defaults to `çaylak` (the column default) and only the server path
- * promotes it. Testing the declared shape directly is how the `role` invariant is
- * verified — the field is the proof.
+ * structural guard that keeps every server-managed user column un-writable from a
+ * client/session/registration payload. Without it a fresh registration could be born
+ * `yazar` or `moderator` straight off the wire. The declared field IS the proof.
  */
 import {describe, expect, it} from "vitest";
 import {additionalUserFields} from "./better-auth-live.ts";
@@ -24,9 +20,6 @@ describe("additionalUserFields — every server-managed field is input:false", (
 		});
 	}
 
-	// `promotedAt` (#1590) is the yazar-promotion timestamp: a date column, and
-	// `returned:false` so its value stays off the surfaced session/user object — the
-	// readout is a separate concern (epic Child F), out of scope for this write-path field.
 	it("promotedAt is a date field", () => {
 		expect(additionalUserFields.promotedAt.type).toBe("date");
 	});

--- a/apps/web/worker/features/pasaport/api-key-rate-limit.unit.test.ts
+++ b/apps/web/worker/features/pasaport/api-key-rate-limit.unit.test.ts
@@ -1,10 +1,8 @@
 /**
- * The apiKey plugin's per-key `rateLimit` (ADR 0044 Decision 3, #108) — the agent
- * half of the rate mechanism. Asserting the declared config directly is how the
- * "bounded independently" invariant is verified without firing thousands of requests:
- * the shape is the proof. It must be ENABLED with a finite window + max, so a single
- * key's velocity is capped rather than unbounded (a disabled or absent bound would let
- * one runaway key issue without limit). Kept in step with #110's per-user backstop.
+ * The apiKey plugin's per-key `rateLimit` (ADR 0044 Decision 3). Asserting the
+ * declared config IS the proof of the "bounded independently" invariant, without
+ * firing thousands of requests: a disabled or absent bound would let one runaway key
+ * issue without limit.
  */
 import {describe, expect, it} from "vitest";
 import {apiKeyRateLimit} from "./better-auth-live.ts";

--- a/apps/web/worker/features/pasaport/author-label.ts
+++ b/apps/web/worker/features/pasaport/author-label.ts
@@ -1,45 +1,24 @@
 /**
- * The write-boundary author-label rule: the ONE place a signed-in user's identity
- * is flattened into the denormalized `authorName` column persisted on
- * `definition_record` / `post_record` / `comment_record`.
+ * The ONE place a user's identity is flattened into the denormalized `authorName` column.
  *
- * It exists to make an invalid state unrepresentable — an email in a public
- * display column (the #2130 PII-at-rest leak, where the old
- * `authorName: user.name ?? user.email` persisted a null-name account's EMAIL and
- * served it on the public author surfaces). The input is a typed
- * {@link AuthorIdentity} snapshot of `{name, username}` ONLY; `email` is not a
- * field, so no write path can pass it as a fallback here — the leak is closed at
- * the type, not by a spot check at each call site.
+ * The input type carries `{name, username}` ONLY — no `email` field — so the #2130
+ * PII-at-rest leak (the old `user.name ?? user.email` persisting an EMAIL onto public
+ * author surfaces) is closed at the type, not by a spot check per call site.
  *
- * The precedence mirrors the SPA read surface's `actorLabel`
- * (`apps/web/src/components/moderation/actor-identity.ts`) exactly — display name →
- * `@username` → the fixed `kullanıcı` fallback noun — so the persisted string and
- * the optimistic client author (#2129, `actorLabel(user.name, …, "kullanıcı")`)
- * agree by construction. The two rules are kept in parity by
- * `author-label.unit.test.ts`; the worker cannot import the SPA module (no
- * worker→src dependency), so the pure rule is restated here with that test as the
- * lockstep guard. Threading the full `{username, displayName}` snapshot through the
- * fate views so the READ surfaces call `actorLabel` on live identity (finishing
- * #2126 for the denormalized surfaces) is the separately-tracked follow-up.
+ * The precedence mirrors the SPA's `actorLabel` exactly, so the persisted string and the
+ * optimistic client author agree. The worker cannot import the SPA module, so the rule is
+ * restated here with `author-label.unit.test.ts` as the lockstep guard.
  */
 
-/** The fixed fallback noun for an actor with neither a display name nor a username. */
 export const AUTHOR_FALLBACK_LABEL = "kullanıcı";
 
-/**
- * The non-PII identity snapshot a write path flattens into `authorName`. Deliberately
- * carries no `email` field: email is structurally excluded from the display label.
- */
+/** Deliberately carries no `email` field: email is structurally excluded from the label. */
 export interface AuthorIdentity {
 	readonly name?: string | null | undefined;
 	readonly username?: string | null | undefined;
 }
 
-/**
- * Resolve the persisted author display label from a `{name, username}` snapshot:
- * trimmed display name → `@username` → the fixed `kullanıcı` fallback. Whitespace-only
- * is treated as absent. Never returns an email — email is not an input.
- */
+/** Whitespace-only is treated as absent. */
 export function authorDisplayLabel(actor: AuthorIdentity): string {
 	if (actor.name?.trim()) return actor.name.trim();
 	if (actor.username?.trim()) return `@${actor.username.trim()}`;

--- a/apps/web/worker/features/pasaport/author-label.unit.test.ts
+++ b/apps/web/worker/features/pasaport/author-label.unit.test.ts
@@ -20,9 +20,8 @@ describe("authorDisplayLabel — the write-boundary author label (no email at re
 		expect(AUTHOR_FALLBACK_LABEL).toBe("kullanıcı");
 	});
 
-	// The regression this helper exists to prevent (#2130): a null-name account must
-	// NEVER have its email persisted as authorName. Email is not an input to the rule —
-	// a caller with only {email} in scope resolves to the fallback, not the email.
+	// The regression this helper exists to prevent (#2130): a null-name account must NEVER
+	// have its email persisted as `authorName`.
 	it("never emits an email — a null-name actor resolves to @username or the fallback, never PII", () => {
 		expect(authorDisplayLabel({name: null, username: "handle"})).toBe("@handle");
 		const nullNameNoUsername = authorDisplayLabel({name: null, username: null});

--- a/apps/web/worker/features/pasaport/authorship-standing.unit.test.ts
+++ b/apps/web/worker/features/pasaport/authorship-standing.unit.test.ts
@@ -1,19 +1,8 @@
 /**
- * The çaylak-SELF authorship-standing read (`myAuthorshipStanding`, #1316, epic
- * #1202) — the aggregate the #1291 status block consumes about ITSELF.
- *
- * What this proves (ADR 0082 unit tier — no DB; the trusted-source composition and
- * the gates are wrong-or-right independent of D1):
- *   - the read returns the reader's own `{karma, bar, vouchExists, inReviewCount}`
- *     from the trusted sources (`Kunye.karmaOf` / `VouchLedger.hasActiveFor` /
- *     `Pasaport.countInReview`), keyed on `CurrentUser` — never an input arg, so a
- *     çaylak cannot read another user's self-status;
- *   - `bar` is the vouch-aware promotion bar (reduced when vouched, full otherwise),
- *     so the frontend never hardcodes it;
- *   - anonymous ⇒ the wire `UNAUTHORIZED` before any read;
- *   - ONE-WAY-GLASS, structural: the payload TYPE carries ONLY aggregate scalars —
- *     no reviewer/voter/voucher identity field exists to fill (a compile-time guard,
- *     plus a runtime key assertion on the resolved payload).
+ * The self-scoped authorship-standing read (#1316): the aggregate the status block
+ * consumes about ITSELF. The read is keyed on `CurrentUser` and takes no input arg,
+ * so nobody can read another user's self-status, and the payload type carries only
+ * aggregate scalars — there is no identity field to leak.
  */
 
 import {assert, describe, it} from "@effect/vitest";
@@ -29,11 +18,8 @@ import {makePasaportStub} from "./Pasaport.testing.ts";
 import {queries} from "./queries.ts";
 import type {AuthorshipStanding} from "./views.ts";
 
-// ── ONE-WAY-GLASS, enforced in the TYPE (the #1316 hard AC) ──────────────────
-// The standing payload's keys are EXACTLY the aggregate set. Adding ANY
-// reviewer/voter/voucher identity field to `AuthorshipStanding` (a `voucherId`,
-// `reviewers`, a per-person count, …) breaks this `extends` both ways and is a
-// COMPILE error here — the leak is unrepresentable, not merely unsent.
+// Adding any identity field to `AuthorshipStanding` breaks this `extends` both ways
+// and is a COMPILE error here, which is what makes the leak unrepresentable.
 type StandingKeys = keyof Omit<AuthorshipStanding, "__typename">;
 type ExpectedKeys = "id" | "karma" | "bar" | "vouchExists" | "inReviewCount";
 type Exact<A, B> = [A] extends [B] ? ([B] extends [A] ? true : false) : false;
@@ -48,8 +34,7 @@ const runtimeContextStub: BaseRuntimeContext = {
 	set: (id) => Effect.succeed(id),
 };
 
-// A `Kunye` answering karma by id; `tierOf`/`rootOf` die — the standing read never
-// reads them (it reads only `karmaOf`), so a reached call fails the test.
+// `tierOf`/`rootOf` die: the standing read only reads karma, so a reached call fails.
 const kunyeWithKarma = (karmaById: Record<string, number>): Layer.Layer<Kunye> =>
 	Layer.succeed(Kunye, {
 		karmaOf: (id: string) => Effect.succeed(karmaById[id] ?? 0),
@@ -59,7 +44,6 @@ const kunyeWithKarma = (karmaById: Record<string, number>): Layer.Layer<Kunye> =
 
 const SELF: CurrentUserInfo = {id: "u-self", email: "self@kamp.us", name: "Self", image: null};
 
-// Drive `myAuthorshipStanding` over the trusted-source stubs, as `SELF`.
 const standingOf = (input: {
 	user?: CurrentUserInfo | undefined;
 	karma?: number;
@@ -135,8 +119,7 @@ describe("myAuthorshipStanding — the çaylak-self aggregate (#1316)", () => {
 				vouchExists: true,
 				inReviewCount: 1,
 			})) as AuthorshipStanding;
-			// No reviewer/voter/voucher identity field is present at runtime either —
-			// the key set is exactly the aggregate scalars (+ the fate `__typename`).
+			// No identity field is present at runtime either.
 			assert.deepStrictEqual(Object.keys(standing).sort(), [
 				"__typename",
 				"bar",

--- a/apps/web/worker/features/pasaport/ban-mutation.unit.test.ts
+++ b/apps/web/worker/features/pasaport/ban-mutation.unit.test.ts
@@ -1,18 +1,11 @@
 /**
- * `user.banUser` / `user.unbanUser` WIRE-boundary coverage (#970, admin epic #968) —
- * the authority + dark-ship decisions that are wrong-or-right with no database (ADR
- * 0082), driven through the real external interface (`resolveWire`: decode + the
- * `encodeWireError` class→wire-code seam), so a denial's wire `code` is what a client
- * gets.
+ * `user.banUser` / `user.unbanUser` WIRE-boundary coverage (#970, admin epic #968) — the
+ * authority + dark-ship decisions, with no database (ADR 0082).
  *
- * The load-bearing AC (#970): ban and unban each FAIL CLOSED for a non-admin caller
- * — a non-holder of the `admin` relation and the anonymous actor both get the
- * invisible `UNAUTHORIZED` (they can't tell "not admin" from "not signed in", ADR
- * 0098 §2), and neither reaches the write (the `Pasaport` stub is fail-on-contact).
- * Plus the dark-ship: with the `phoenix-user-ban` flag OFF the path is inert (fails
- * `Denied` before any authority check or write), so an unreleased ban never runs. The
- * real-D1 write→read + session-refusal round-trip is
- * `apps/web/tests/integration/pasaport-ban.test.ts`.
+ * The load-bearing AC: both FAIL CLOSED for a non-admin caller — a non-holder of the `admin`
+ * relation and the anonymous actor get the SAME invisible `UNAUTHORIZED` (they can't tell "not
+ * admin" from "not signed in", ADR 0098 §2), and neither reaches the write. The real-D1
+ * write→read round-trip is `apps/web/tests/integration/pasaport-ban.test.ts`.
  */
 import {assert, describe, it} from "@effect/vitest";
 import {

--- a/apps/web/worker/features/pasaport/ban-states-projection.unit.test.ts
+++ b/apps/web/worker/features/pasaport/ban-states-projection.unit.test.ts
@@ -1,9 +1,6 @@
 /**
- * `selectBanStates` — the batched ban-state projection (#3200), the roster's join. Latest
- * event-per-user wins (by `createdAt`, tie-broken by `id`), reusing `resolveBanState`: a
- * user whose newest event is a `ban` is banned; a later `unban` lifts it; an expired ban
- * self-lifts; a user with no event is absent (read as not-banned). No I/O, over hand-built
- * rows — the twin of `email-delivery-admin.unit.test.ts`'s `selectFailingAddresses`.
+ * `selectBanStates` (#3200): latest event-per-user wins, by `createdAt` and tie-broken by
+ * `id`. A user with no event is absent from the map, which reads as not-banned.
  */
 import {assert, describe, it} from "@effect/vitest";
 import {selectBanStates, type UserBanEvent} from "./ban.ts";
@@ -77,7 +74,7 @@ describe("selectBanStates", () => {
 			[event("id-1", "u-a", "ban", at), event("id-2", "u-a", "unban", at)],
 			NOW,
 		);
-		// id-2 > id-1 at the same timestamp ⇒ the unban is the latest ⇒ not banned.
+		// id-2 > id-1 at the same timestamp, so the unban is the latest.
 		assert.strictEqual(states.get("u-a")?.banned, false);
 	});
 });

--- a/apps/web/worker/features/pasaport/ban.ts
+++ b/apps/web/worker/features/pasaport/ban.ts
@@ -1,16 +1,13 @@
 /**
- * Ban-state domain (epic #968, admin-gated per ADR 0107). Pure logic, no I/O: the
- * current ban-state is a PROJECTION of the append-only `user_ban_event` log — the
- * latest event decides, so state can never drift from the audit history and a stale
- * "banned flag" is unrepresentable. Enforcement (`Pasaport.validateSession`) and the
- * ban/unban writes both run this projection over the same rows, so the boundary that
- * refuses a session and the surface that reports ban-state can't disagree.
+ * Ban-state domain (ADR 0107). Pure logic, no I/O: the current ban-state is a
+ * PROJECTION of the append-only `user_ban_event` log — the latest event decides, so a
+ * stale "banned flag" is unrepresentable. Enforcement and the ban/unban writes both run
+ * this projection, so the boundary that refuses a session and the surface that reports
+ * ban-state can't disagree.
  */
 
-/** The two event kinds an admin action appends. */
 export type BanEventAction = "ban" | "unban";
 
-/** One row of the append-only ban log, as the projection needs it (audit fields). */
 export interface BanEvent {
 	readonly action: BanEventAction;
 	readonly reason: string | null;
@@ -18,7 +15,6 @@ export interface BanEvent {
 	readonly createdAt: Date;
 }
 
-/** The projected current ban-state for one account. */
 export interface BanState {
 	readonly banned: boolean;
 	/** The active ban's reason, or null when not banned. */
@@ -27,18 +23,12 @@ export interface BanState {
 	readonly expiresAt: Date | null;
 }
 
-/** The not-banned state — a fresh account, an unbanned one, or an expired ban. */
 export const NOT_BANNED: BanState = {banned: false, reason: null, expiresAt: null};
 
 /**
- * Project the current ban-state from the account's LATEST ban event.
- *
- * The caller passes the single newest event (by `createdAt`) or null when the log
- * is empty. Banned iff that latest event is a `ban` whose `expiresAt` is null
- * (permanent) or still in the future at `now` — so an `unban` lifts a ban and an
- * elapsed `expiresAt` self-lifts it, both without touching the ban row. A time
- * boundary is fail-open on equality (`expiresAt <= now` ⇒ lifted): a ban set to
- * expire "now" is done.
+ * Project the current ban-state from the account's LATEST ban event (or null on an
+ * empty log). An `unban` lifts a ban and an elapsed `expiresAt` self-lifts it, both
+ * without touching the ban row. Fail-open on equality: `expiresAt <= now` ⇒ lifted.
  */
 export const resolveBanState = (latest: BanEvent | null, now: Date): BanState => {
 	if (latest === null || latest.action === "unban") return NOT_BANNED;
@@ -46,22 +36,16 @@ export const resolveBanState = (latest: BanEvent | null, now: Date): BanState =>
 	return {banned: true, reason: latest.reason, expiresAt: latest.expiresAt};
 };
 
-/** One ban-log row tagged with the account it belongs to — the batch projection's input. */
 export interface UserBanEvent extends BanEvent {
-	/** The account the event was appended for. */
 	readonly userId: string;
-	/** The event's own id — the same-instant tiebreak the single read uses (`created_at DESC, id DESC`). */
+	/** The same-instant tiebreak, matching the single read's `ORDER BY created_at DESC, id DESC`. */
 	readonly id: string;
 }
 
 /**
- * The batched form of {@link resolveBanState}: project the current ban-state for MANY
- * accounts from a flat slice of the append-only `user_ban_event` log, so an admin roster
- * reads one query's worth of events and folds it here instead of an N+1 per-row read. The
- * same latest-event-wins rule as the single read — group by `userId`, pick the newest event
- * (by `createdAt`, tie-broken by `id`, matching the single read's `ORDER BY created_at DESC,
- * id DESC`), then {@link resolveBanState}. A user id with no event is simply absent from the
- * map; the caller reads it as {@link NOT_BANNED}.
+ * The batched form of {@link resolveBanState}, so an admin roster folds one query's
+ * events instead of an N+1 per-row read. Same latest-event-wins rule. A user id with no
+ * event is absent from the map; the caller reads that as {@link NOT_BANNED}.
  */
 export const selectBanStates = (
 	events: ReadonlyArray<UserBanEvent>,

--- a/apps/web/worker/features/pasaport/better-auth-live.ts
+++ b/apps/web/worker/features/pasaport/better-auth-live.ts
@@ -1,16 +1,9 @@
 /**
- * Phoenix's `BetterAuth` Layer — a fork of `@alchemy.run/better-auth`'s
- * `CloudflareD1` reference Layer. Why fork instead of reuse it:
- *
- *   - `CloudflareD1` declares its OWN `D1Database("BetterAuth")`; phoenix's
- *     better-auth tables live on the shared `PhoenixDb` D1 (ADR 0009), so this
- *     Layer derives its raw d1 from the `Database` seam (ADR 0040) — the same tag
- *     `DrizzleLive` derives from, so features and auth provably share one handle.
- *   - It needs phoenix-specific plugins (`magicLink`, `bearer`), an
- *     `additionalFields.username`, and dev `baseURL`/`trustedOrigins` (ADR 0031).
- *   - It reads `BETTER_AUTH_SECRET` from a `secret_text` binding instead of minting
- *     via `alchemy/Random` (a deploy-time resource with no runtime value — see the
- *     secret comment inside the Layer).
+ * Phoenix's `BetterAuth` Layer — forked from `@alchemy.run/better-auth`'s
+ * `CloudflareD1` because that one declares its own D1 while phoenix's better-auth
+ * tables live on the shared `PhoenixDb` (ADR 0009), reached through the `Database`
+ * seam so auth and every feature run on one handle. The fork also carries
+ * phoenix-only plugins and reads its secret from a binding, not `alchemy/Random`.
  */
 
 import * as BetterAuth from "@alchemy.run/better-auth";
@@ -45,35 +38,16 @@ import {
 
 type AdditionalUserFields = NonNullable<NonNullable<BetterAuthOptions["user"]>["additionalFields"]>;
 
-/**
- * A rejection from better-auth's own `handler` — an infra failure at the `/api/auth/*`
- * bridge that dies (mirroring the prior `Effect.promise` defect). Shared with the test
- * layer (`better-auth.testing.ts`) so both bridges map the same boundary.
- */
 export class BetterAuthHandlerError extends Schema.TaggedErrorClass<BetterAuthHandlerError>()(
 	"pasaport/BetterAuthHandlerError",
 	{cause: Schema.Defect()},
 ) {}
 
 /**
- * The better-auth `user.additionalFields` shape. **Every field is `input:false`** —
- * server-managed, so no client/session/registration write can set or escalate it:
- *
- *   - `username` — written only by the server-side `setUsername` mutation (through
- *     `Pasaport`), immutable once set.
- *   - `role` — the moderation capability (ADR 0098), granted only by the offline D1
- *     grant script; NOT the better-auth admin plugin.
- *   - `tier` — the authorship tier (ADR 0107 §4), born `çaylak`, promoted to `yazar`
- *     only by the server promotion path (#1206) / founding seed. A fresh registration
- *     defaults to `çaylak` (the `user.tier` column default) — `input:false` is what
- *     keeps it un-escalatable at sign-up.
- *   - `promotedAt` — when the account was promoted to `yazar` (#1590), stamped only by
- *     `Pasaport.promoteToYazar`. `input:false` (like `tier`) keeps it un-writable from
- *     the wire; `returned:false` keeps the value off the surfaced session/user object —
- *     the readout is a separate concern (epic Child F), out of scope here.
- *
- * Extracted as a pure value so the `input:false` invariant is unit-assertable
- * (`additional-user-fields.unit.test.ts`) rather than buried in the Layer's Effect.
+ * Every field here is `input:false`, and that is the security invariant: `role`
+ * (ADR 0098) and `tier` (ADR 0107 §4) are granted only by server-side paths, so no
+ * client, session or registration write may set or escalate them. A pure value so
+ * the invariant is unit-assertable rather than buried in the Layer's Effect.
  */
 export const additionalUserFields = {
 	username: {type: "string", required: false, input: false},
@@ -82,15 +56,9 @@ export const additionalUserFields = {
 	promotedAt: {type: "date", required: false, input: false, returned: false},
 } satisfies AdditionalUserFields;
 
-/**
- * The apiKey plugin's built-in per-key rate limit — the agent half of the rate
- * mechanism (ADR 0044 Decision 3). Each agent credential's request velocity is
- * bounded *independently* on its own rolling window, so one runaway key can't starve
- * the others. Kept deliberately generous — comfortably above a normal agent burst
- * (e.g. a multi-screenshot report) — and coupled to the per-user session-path backstop
- * in #110; keep the two in step. Extracted as a pure value so the numbers are
- * unit-assertable and the test layer (`better-auth.testing.ts`) shares the exact shape.
- */
+// The agent half of the rate mechanism (ADR 0044 Decision 3): each key gets its own
+// rolling window, so a runaway key can't starve the others. Deliberately generous, and
+// coupled to the per-user session-path backstop in #110 — keep the two in step.
 export const apiKeyRateLimit = {
 	enabled: true,
 	timeWindow: 1000 * 60 * 60, // 1 hour
@@ -98,27 +66,17 @@ export const apiKeyRateLimit = {
 } as const;
 
 /**
- * The better-auth origin/cookie config for one deploy class (ADR 0088). Pure over
- * the `environment` literal so the per-env derivation is unit-testable without the
- * alchemy provider stack. Each class gets the origin it actually serves from:
+ * The origin/cookie config per deploy class (ADR 0088), pure over `environment` so
+ * it is unit-testable without the alchemy provider stack.
  *
- *   - development → local `alchemy dev` behind the Vite proxy: the worker sees
- *     `Host: 127.0.0.1:<port>`, NOT the browser origin, so the browser origin must
- *     be named explicitly (`localhost:3000` + Vite's `:5173`). (#704)
- *   - preview → a deployed ephemeral stage on `*.kampusinfra.workers.dev`. #983
- *     keeps the Custom Domain production-only, so a preview is NEVER served at a
- *     `*.phoenix.kamp.us` host — the dynamic `baseURL.allowedHosts` (better-auth's
- *     documented preview-deploy mechanism) resolves per request to the stage's own
- *     served origin and trusts it, scoped to OUR account's workers.dev subdomain.
- *   - production → pin `baseURL` to the apex `phoenix.kamp.us` (the live Custom
- *     Domain, #594/#983), single-sourced from `PHOENIX_APEX_HOSTNAME` so the
- *     auth-trusted origin can't drift from the bound domain. Pinning the apex trusts
- *     exactly that one origin for CSRF and scopes the session cookie to the
- *     `phoenix.kamp.us` HOST: better-auth's default cookie domain is the baseURL
- *     host, and with no `crossSubDomainCookies` it never widens to `.kamp.us`, so the
- *     cookie can't leak to sibling apps on other subdomains (no CSRF widening, ADR
- *     0085). SPA and API are the same same-origin worker, so no `trustedOrigins`
- *     add-on is needed.
+ *   - development → the worker sees `Host: 127.0.0.1:<port>` behind the Vite proxy,
+ *     not the browser origin, so the browser origins must be named explicitly (#704).
+ *   - preview → a preview is never served at a `*.phoenix.kamp.us` host (#983), so
+ *     `allowedHosts` resolves per request, scoped to our own workers.dev subdomain.
+ *   - production → pinning the apex trusts exactly that origin for CSRF and scopes
+ *     the session cookie to the `phoenix.kamp.us` HOST. With no
+ *     `crossSubDomainCookies` it never widens to `.kamp.us`, so the cookie cannot
+ *     leak to sibling apps on other subdomains.
  */
 export const deriveAuthUrlConfig = (environment: Environment): BetterAuthOptions =>
 	environment === "development"
@@ -133,39 +91,26 @@ export const deriveAuthUrlConfig = (environment: Environment): BetterAuthOptions
 			? {baseURL: {allowedHosts: ["*.kampusinfra.workers.dev"]}}
 			: {baseURL: `https://${PHOENIX_APEX_HOSTNAME}`};
 
-// Keeps the reference layer's `Effect.cached` so `makeBetterAuth` runs once per
-// isolate. The secret and `baseURL`/`trustedOrigins` rationale (and the latent
-// prod bug each fixes) live at their sites below.
 export const BetterAuthLive = Layer.effect(
 	BetterAuth.BetterAuth,
 	Effect.gen(function* () {
-		// From the shared `Database` seam (ADR 0040) — the same tag `DrizzleLive`
-		// derives from, so auth and every feature service run on one handle.
 		const raw = yield* Database;
 
-		// Read from the `BETTER_AUTH_SECRET` `secret_text` binding. Replaces the
-		// reference layer's `alchemy/Random`: `Random` is a deploy-time resource
-		// with no value in the workerd runtime isolate, so the minted secret could
-		// never be read back and better-auth signed cookies with an unresolved
-		// Effect. `orDie`: a missing secret is an unrecoverable deploy misconfig.
+		// Not the reference layer's `alchemy/Random`: that is a deploy-time resource with
+		// no value in the workerd isolate, so better-auth signed cookies with an
+		// unresolved Effect. `orDie` — a missing secret is an unrecoverable misconfig.
 		const secret = yield* betterAuthSecret.pipe(Effect.orDie);
 
-		// `Config.withDefault("production")` is fail-closed: a missing `ENVIRONMENT`
-		// lands in prod mode and closes every dev gate below. `orDie`: a value
-		// outside the three literals is a malformed env, unrecoverable.
+		// Fail-closed: a missing `ENVIRONMENT` lands in prod mode and closes every dev
+		// gate below.
 		const {environment} = yield* AppConfig.pipe(Effect.orDie);
 
-		// The transactional-email port (ADR 0101). Resolved once here and closed
-		// over by the better-auth callbacks below, the same way `secret`/`raw` are
-		// threaded. `send` is `Effect<void, never, never>` (the adapter discharged
-		// its RuntimeContext + swallowed failures), so the async callbacks run it
-		// with `Effect.runPromise` — and a delivery failure never throws into
-		// better-auth, which would fail the sign-in/verify flow.
+		// The transactional-email port (ADR 0101). `send` cannot fail, so a delivery
+		// problem never throws into better-auth and fails the sign-in/verify flow.
 		const emailSender = yield* EmailSender;
 		const sendEmail = (message: EmailMessage): Promise<void> =>
 			Effect.runPromise(emailSender.send(message));
 
-		// The per-deploy-class auth-origin/cookie config. See `deriveAuthUrlConfig`.
 		const authUrlConfig = deriveAuthUrlConfig(environment);
 
 		const auth = yield* Effect.gen(function* () {
@@ -181,57 +126,41 @@ export const BetterAuthLive = Layer.effect(
 				database: drizzleAdapter(db, {provider: "sqlite", schema}),
 				secret: Redacted.value(secret),
 				...authUrlConfig,
-				// Verify a new account's email via a delivered link (the `EmailSender`
-				// port; ADR 0101). Was unreachable before — no sender existed.
 				emailVerification: {
-					// Opens the send tap: better-auth fires `sendVerificationEmail` on
-					// every email signup (sign-up.ts gates the send on `sendOnSignUp ??
-					// requireEmailVerification`). We do NOT set `requireEmailVerification`,
-					// so this sends the link without gating sign-in — auto-sign-in still
-					// issues the session (#995).
+					// We deliberately do NOT set `requireEmailVerification`: the link goes out
+					// on signup, but sign-in is not gated on it and auto-sign-in still issues
+					// the session (#995).
 					sendOnSignUp: true,
 					sendVerificationEmail: async ({user, url}) => {
 						await sendEmail(verificationEmail(user.email, url));
 					},
 				},
 				user: {
-					// `changeEmail` is off by default; enabling it + the
-					// `sendChangeEmailConfirmation` callback (sent to the CURRENT address)
-					// is what lets #75 verify the switch before applying it (ADR 0101).
+					// The confirmation goes to the CURRENT address, which is what verifies the
+					// switch before it applies (#75).
 					changeEmail: {
 						enabled: true,
 						sendChangeEmailConfirmation: async ({user, newEmail, url}) => {
 							await sendEmail(changeEmailConfirmationEmail(user.email, newEmail, url));
 						},
 					},
-					// All server-managed, all `input:false` — see `additionalUserFields`.
 					additionalFields: additionalUserFields,
 				},
 				plugins: [
-					// Emits the `set-auth-token` response header that the SPA's `authClient`
-					// (apps/web/src/auth/client.ts) consumes — it sends back as
-					// `Authorization: Bearer <token>` for cross-origin / storage-partitioned
+					// Emits the `set-auth-token` header the SPA's `authClient` sends back as
+					// `Authorization: Bearer <token>` on cross-origin / storage-partitioned
 					// auth paths. Don't remove without `grep "Bearer" apps/web/src/` first.
 					bearer(),
 					magicLink({
-						// Deliver the magic link via the `EmailSender` port (ADR 0101). In
-						// dev/preview the port is the log sink (no real send); in production
-						// it goes through the CF Email Service binding.
 						sendMagicLink: async ({email, url}) => {
 							await sendEmail(magicLinkEmail(email, url));
 						},
 					}),
-					// Durable agent credentials (ADR 0044 Decision 3). Exposes the
-					// session-authenticated create endpoint under `/api/auth/api-key/create`
-					// and, with `enableSessionForAPIKeys`, resolves a session for any request
-					// carrying the `x-api-key` header — so a minted key authenticates as its
-					// owning pasaport user through the same `getSession` path `validateSession`
-					// reads. The flag is load-bearing, not decorative: it defaults `false`, and
-					// the plugin's session-from-key before-hook only registers a matcher for a
-					// config with the flag on (`findApiKeyAndConfig` skips flag-off configs), so
-					// without it an `x-api-key` header never mints a session and every key-auth'd
-					// read resolves anonymous. The apikey table is migrated (`schema.ts`). Rate
-					// limit: `apiKeyRateLimit`.
+					// Durable agent credentials (ADR 0044 Decision 3). `enableSessionForAPIKeys`
+					// is load-bearing, not decorative: it defaults false, and the plugin only
+					// registers its session-from-key hook for a flag-on config, so without it an
+					// `x-api-key` header never mints a session and every key-auth'd read
+					// resolves anonymous.
 					apiKey({rateLimit: apiKeyRateLimit, enableSessionForAPIKeys: true}),
 				],
 			} satisfies BetterAuthOptions);

--- a/apps/web/worker/features/pasaport/better-auth-url-config.unit.test.ts
+++ b/apps/web/worker/features/pasaport/better-auth-url-config.unit.test.ts
@@ -1,19 +1,12 @@
 /**
  * Unit coverage for `deriveAuthUrlConfig` — the per-deploy-class better-auth
- * origin/cookie derivation (#982, follow-on from the #594/#983 Custom Domain).
+ * origin/cookie derivation (#982). Pure over the `environment` literal, so each
+ * class's contract is wrong-or-right with NO alchemy provider stack.
  *
- * The derivation is pure over the `environment` literal, so each class's
- * origin/cookie contract is wrong-or-right with NO alchemy provider stack:
- *
- *   - production pins `baseURL` to the `phoenix.kamp.us` apex (the live Custom
- *     Domain) so better-auth trusts exactly that origin for CSRF and scopes the
- *     session cookie to the apex HOST — NOT broadened to `.kamp.us` (ADR 0085
- *     no-widening; a `.kamp.us` cookie would leak to sibling apps). The apex is
- *     single-sourced from `PHOENIX_APEX_HOSTNAME`, so this test also pins that the
- *     auth-trusted origin can't silently drift from the bound domain.
- *   - preview trusts only the `*.kampusinfra.workers.dev` previews (#983 keeps the
- *     Custom Domain production-only, so no `*.phoenix.kamp.us` preview host exists).
- *   - development names the localhost browser origins behind the Vite proxy (#704).
+ * The load-bearing one is production: the session cookie is scoped to the apex HOST,
+ * never broadened to `.kamp.us` (ADR 0085 — a `.kamp.us` cookie would leak to sibling
+ * apps), and the apex is single-sourced from `PHOENIX_APEX_HOSTNAME` so the
+ * auth-trusted origin cannot drift from the bound domain.
  */
 import {assert, describe, it} from "@effect/vitest";
 import {PHOENIX_APEX_HOSTNAME} from "../../env.ts";
@@ -47,8 +40,8 @@ describe("deriveAuthUrlConfig", () => {
 	it("audit shares preview's deployed workers.dev topology, never the prod apex (#1511)", () => {
 		const config = deriveAuthUrlConfig("audit");
 
-		// The rite-audit stage is served from `*.kampusinfra.workers.dev`, so it must use
-		// the dynamic allowedHosts mechanism — NOT fall through to the production apex pin.
+		// The rite-audit stage is served from `*.kampusinfra.workers.dev`, so it must use the
+		// dynamic allowedHosts mechanism — NOT fall through to the production apex pin.
 		assert.deepStrictEqual(config.baseURL, {
 			allowedHosts: ["*.kampusinfra.workers.dev"],
 		});
@@ -68,8 +61,8 @@ describe("deriveAuthUrlConfig", () => {
 	it("no environment trusts a blanket .kamp.us origin (ADR 0085 no CSRF widening)", () => {
 		for (const environment of ["development", "preview", "production", "audit"] as const) {
 			const serialized = JSON.stringify(deriveAuthUrlConfig(environment));
-			// `phoenix.kamp.us` (production) is allowed; a bare `.kamp.us` / `*.kamp.us`
-			// blanket is the leak ADR 0085 forbids.
+			// `phoenix.kamp.us` (production) is allowed; a bare `.kamp.us` / `*.kamp.us` blanket
+			// is the leak ADR 0085 forbids.
 			assert.isFalse(
 				/["*.]kamp\.us/.test(serialized.replace(/phoenix\.kamp\.us/g, "")),
 				`environment "${environment}" must not trust a blanket .kamp.us origin`,

--- a/apps/web/worker/features/pasaport/better-auth.testing.ts
+++ b/apps/web/worker/features/pasaport/better-auth.testing.ts
@@ -1,11 +1,8 @@
 /**
- * Test stand-ins for the `BetterAuth` Context tag. The deployed worker satisfies
- * it with `BetterAuthLive`, which needs the full alchemy provider stack
- * (`RuntimeContext`, the `secret_text` binding) absent in the node test pool —
- * so these factories build a hand-rolled `BetterAuth` layer over the same tag.
- * `auth` is `Effect.succeed(...)` so its `R` is `never`.
- *
- * A **factory, not a shared instance** (`.patterns/effect-testing.md`).
+ * Test stand-ins for the `BetterAuth` Context tag. `BetterAuthLive` needs the full alchemy
+ * provider stack (`RuntimeContext`, the `secret_text` binding) the node test pool lacks, so these
+ * factories build a hand-rolled layer over the same tag. Factories, not shared instances
+ * (`.patterns/effect-testing.md`).
  */
 import * as BetterAuth from "@alchemy.run/better-auth";
 import {apiKey} from "@better-auth/api-key";
@@ -22,17 +19,11 @@ import * as schema from "../../db/drizzle/schema.ts";
 import {apiKeyRateLimit, BetterAuthHandlerError} from "./better-auth-live.ts";
 
 /**
- * A REAL better-auth instance over a test `D1Database` handle, reproducing
- * `BetterAuthLive`'s construction because that Layer needs the alchemy provider
- * stack the node test pool lacks.
- *
- * MUST stay in lockstep with `BetterAuthLive` (same `emailAndPassword`,
- * `drizzleAdapter`, `bearer()`, `apiKey()`, `additionalFields.username`) — if they
- * drift the guard suites silently test a different shape than production. Test-only
- * diffs, immaterial to the shape under test: literal `secret`/`baseURL`/`trustedOrigins`
- * and no `magicLink` plugin.
- *
- * Returns a concrete `Auth<{…}>`; callers widen to the generic `Auth` (see {@link layerTest}).
+ * A REAL better-auth instance over a test `D1Database` handle. MUST stay in lockstep with
+ * `BetterAuthLive` (same `emailAndPassword`, `drizzleAdapter`, `bearer()`, `apiKey()`,
+ * `additionalFields.username`) — drift means the guard suites silently test a shape production
+ * never runs. Deliberate test-only diffs: literal `secret`/`baseURL`/`trustedOrigins`, no
+ * `magicLink` plugin.
  */
 export function makeRealAuthForTest(d1: D1Database) {
 	const db = drizzle(d1, {relations: defineRelations(schema)});
@@ -52,12 +43,9 @@ export function makeRealAuthForTest(d1: D1Database) {
 }
 
 /**
- * A `BetterAuth` test layer over an already-constructed instance, wiring `auth`
- * (for `Pasaport`) and `fetch` (for `/api/auth/*`).
- *
- * Takes the generic `Auth`; `makeRealAuthForTest` returns a concrete `Auth<{…}>`
- * that doesn't statically overlap it (TS2345), so callers widen with a documented
- * `as unknown as Parameters<typeof layerTest>[0]` hop.
+ * A `BetterAuth` test layer over an already-constructed instance. It takes the generic `Auth`,
+ * which `makeRealAuthForTest`'s concrete `Auth<{…}>` does not statically overlap (TS2345) — hence
+ * the `as unknown as Parameters<typeof layerTest>[0]` hop at the call sites.
  */
 export const layerTest = (instance: Auth): Layer.Layer<BetterAuth.BetterAuth> =>
 	Layer.succeed(BetterAuth.BetterAuth)({
@@ -73,9 +61,8 @@ export const layerTest = (instance: Auth): Layer.Layer<BetterAuth.BetterAuth> =>
 	});
 
 /**
- * A fail-on-contact stub: `auth` is a canned no-op `getSession`, `fetch` is
- * `Effect.die` — for tests that never reach the session path or `/api/auth/*`.
- * A `layerStub` (fail-on-contact), not a `layerNoop` (which silently succeeds).
+ * A fail-on-contact stub (not a `layerNoop`, which would silently succeed) — for tests that never
+ * reach the session path or `/api/auth/*`.
  */
 export const layerStub = (): Layer.Layer<BetterAuth.BetterAuth> =>
 	Layer.succeed(BetterAuth.BetterAuth)({

--- a/apps/web/worker/features/pasaport/contributions-sandbox.unit.test.ts
+++ b/apps/web/worker/features/pasaport/contributions-sandbox.unit.test.ts
@@ -1,30 +1,10 @@
 /**
- * `Pasaport.listContributions` sandbox-visibility wiring (#1309) — the security
- * fix: the public profile contribution feed must NOT leak a çaylak's sandboxed
- * (un-promoted) content to a visitor. The feed unions three content tables
- * (definitions / posts / comments); each per-table read — AND its `totalCount`
- * count — must carry the #1205 {@link sandboxVisibleWhere} predicate beside its
- * existing `removed_at IS NULL` guard, resolved against the request viewer.
- *
- * Unit-tier per ADR 0082: the predicate SEMANTICS (who sees what) are already
- * proven by `SandboxVisibility.unit.test.ts` over `isVisibleTo` /
- * `sandboxVisibleWhere`; what THIS test proves is that `listContributions` WIRES
- * that predicate into every feed read for every viewer kind. Rendered by reading
- * each statement's `.toSQL()` over a no-op D1 (the `Sozluk.connection.unit.test.ts`
- * / `promotion-sweep.unit.test.ts` idiom) — no engine, so the row-level filtering
- * itself is the integration tier's job; the wiring is unit-reachable.
- *
- * The viewer matrix (the leak is closed iff):
- *   - anonymous / public — predicate is `sandboxed_at IS NULL` (live only, no
- *     viewer arm): a logged-out visitor sees only the çaylak's live content.
- *   - other member — `sandboxed_at IS NULL OR author_id = :viewerId`: since the
- *     viewer is NOT the çaylak, the author arm matches none of the çaylak's rows,
- *     so only live content returns.
- *   - the author (viewing own profile) — same predicate, but `author_id =
- *     :viewerId` now matches ALL their own rows, so they DO see their own
- *     sandboxed content.
- *   - moderator — no sandbox restriction at all (`undefined` ⇒ dropped by `and()`):
- *     a moderator sees everything.
+ * `Pasaport.listContributions` sandbox-visibility WIRING (#1309): the public profile
+ * contribution feed must not leak a çaylak's un-promoted content. The predicate semantics
+ * are already proven in `SandboxVisibility.unit.test.ts`; what this proves is that every
+ * per-table feed read carries the predicate, for every viewer kind. Rendered by reading
+ * each statement's `.toSQL()` over a no-op D1 — no engine, so row-level filtering itself
+ * stays integration-tier (ADR 0082).
  */
 import {assert, describe, it} from "@effect/vitest";
 import {drizzle} from "drizzle-orm/d1";
@@ -63,8 +43,7 @@ const inertAuth = {} as BetterAuthInstance;
 const hasToSQL = (v: unknown): v is {toSQL: () => {sql: string; params: unknown[]}} =>
 	typeof v === "object" && v !== null && typeof (v as {toSQL?: unknown}).toSQL === "function";
 
-// Captures every `run` builder's `.toSQL()`; replays scripted results in call order
-// (the three feed SELECTs return [], the three `totalCount` counts return 0).
+// Replays scripted results in call order (three feed SELECTs return [], three counts 0).
 function scriptedAccess(results: ReadonlyArray<unknown>): {
 	access: DrizzleAccess;
 	queries: {sql: string; params: unknown[]}[];
@@ -96,17 +75,11 @@ const viewers = {
 	moderator: {viewerId: MOD, canSeeSandboxed: true},
 } satisfies Record<string, SandboxViewer>;
 
-// listContributions issues, in order: 3 feed SELECTs (def/post/comment) then 3
-// `COUNT(*)` totals. Six no-op `run` results cover both, but only the three feed
-// SELECTs return a renderable query builder — the `COUNT(*)` reads resolve through
-// `.then()` to a Promise (no `.toSQL()`), so they execute harmlessly against the
-// no-op D1 and are not captured here. The feed SELECTs ARE the row-leak surface:
-// the rows a visitor would see. (The `totalCount` count carries the same predicate
-// in the source so the count can't leak either, verified by review.)
+// Only the three feed SELECTs return a renderable query builder; the `COUNT(*)` reads
+// resolve through `.then()` to a Promise (no `.toSQL()`), so they are not captured here.
+// The `totalCount` count carries the same predicate in the source.
 const FEED_RESULTS = [[], [], [], 0, 0, 0] as const;
 
-// Render the three feed SELECTs (definition / post / comment) for `AUTHOR`'s feed
-// as seen by `sandboxViewer`.
 const renderFeed = (sandboxViewer: SandboxViewer) =>
 	Effect.gen(function* () {
 		const {access, queries} = scriptedAccess([...FEED_RESULTS]);
@@ -132,7 +105,6 @@ describe("Pasaport.listContributions — every feed read filters the sandbox (th
 				const s = sql.toLowerCase();
 				assert.match(s, /"removed_at" is null/, "keeps the removal guard");
 				assert.match(s, /"sandboxed_at" is null/, "filters sandboxed content (live only)");
-				// No `OR author_id = :viewer` arm for an anonymous viewer — purely live.
 				assert.notInclude(s, " or ", "anonymous predicate has no viewer-own-content OR arm");
 			}
 		}),
@@ -151,8 +123,8 @@ describe("Pasaport.listContributions — every feed read filters the sandbox (th
 						/"sandboxed_at" is null[)\s]*or[\s(]*"[a-z_]+"\."author_id" = \?/,
 						"sandboxed-or-own predicate is wired",
 					);
-					// The OWN arm is keyed to the VIEWER, not the profiled author — so it
-					// matches none of the çaylak's rows ⇒ the visitor sees only live content.
+					// The OWN arm is keyed to the VIEWER, not the profiled author — so it matches none
+					// of the çaylak's rows.
 					assert.include(params as unknown[], OTHER, "own-content arm bound to the viewer id");
 				}
 			}),
@@ -166,8 +138,8 @@ describe("Pasaport.listContributions — every feed read filters the sandbox (th
 				for (const {sql, params} of queries) {
 					const s = sql.toLowerCase();
 					assert.match(s, /"sandboxed_at" is null[)\s]*or[\s(]*"[a-z_]+"\."author_id" = \?/);
-					// viewerId === authorId, so the `author_id = :viewerId` arm matches ALL the
-					// author's rows — including sandboxed ones — so the owner sees them.
+					// viewerId === authorId, so the own arm matches ALL the author's rows, sandboxed
+					// ones included.
 					assert.include(
 						params as unknown[],
 						AUTHOR,
@@ -183,9 +155,8 @@ describe("Pasaport.listContributions — every feed read filters the sandbox (th
 			for (const {sql} of queries) {
 				const s = sql.toLowerCase();
 				assert.match(s, /"removed_at" is null/, "removal guard still applies");
-				// The column IS projected (for the per-item `sandboxed` flag, #1316), but the
-				// moderator's WHERE carries NO sandbox FILTER — no `sandboxed_at IS NULL` and
-				// no viewer-own-content OR arm — so they see every row.
+				// The column IS projected (for the per-item `sandboxed` flag), but the moderator's
+				// WHERE carries NO sandbox FILTER — so they see every row.
 				assert.notMatch(s, /"sandboxed_at" is null/, "a moderator gets no sandbox filter");
 				assert.notInclude(s, " or ", "no viewer-own-content OR arm for a moderator");
 			}
@@ -206,11 +177,8 @@ describe("Pasaport.listContributions — every feed read filters the sandbox (th
 	);
 });
 
-// The per-item review-state flag (#1316) the #1291 status block badges "incelemede"
-// off. Derived in the feed map as `sandboxed: sandboxed_at != null` — a bare
-// boolean carrying no reviewer identity. Scripts feed rows (a sandboxed + a live
-// one) and asserts each output node's flag, as the AUTHOR viewing their own profile
-// (the only viewer who sees their own sandboxed content, #1309).
+// The per-item review-state flag (#1316) the status block badges "incelemede" off, derived
+// in the feed map as `sandboxed: sandboxed_at != null`.
 describe("Pasaport.listContributions — the per-item sandboxed flag (#1316)", () => {
 	const sandboxedDef = {
 		id: "d-sandboxed",

--- a/apps/web/worker/features/pasaport/email-delivery-admin-mutation.unit.test.ts
+++ b/apps/web/worker/features/pasaport/email-delivery-admin-mutation.unit.test.ts
@@ -1,18 +1,9 @@
 /**
- * `emailDelivery.mark` / `emailDelivery.clear` / `emailDelivery.failing` WIRE-boundary
- * coverage (Child #2692, email-bounce epic #2687) — the authority + dark-ship decisions
- * that are wrong-or-right with no database (ADR 0082), driven through the real external
- * interface (`resolveWire`: decode + the `encodeWireError` class→wire-code seam), so a
- * denial's wire `code` is what a client gets.
- *
- * The load-bearing AC (#2692): mark and clear each FAIL CLOSED for a non-admin caller — a
- * non-holder of the `admin` relation and the anonymous actor both get the invisible
- * `UNAUTHORIZED` (ADR 0098 §2), and neither reaches the append (the `Pasaport` stub is
- * fail-on-contact). Plus the dark-ship: with the `phoenix-email-delivery-admin` flag OFF
- * the path is inert (fails `Denied` before any authority check or write). The mark's
- * reason floor (`EmailFailingReasonRequired`) rejects a blank note even for an admin. The
- * `emailDelivery.failing` admin roll-up read is gated the same way. The real-D1
- * append→projection round-trip is left to integration.
+ * The email-delivery admin ops' WIRE-boundary coverage (#2692, ADR 0082). The
+ * load-bearing AC: mark and clear each FAIL CLOSED for a non-admin — a non-holder and the
+ * anonymous actor both get the invisible `UNAUTHORIZED` (ADR 0098 §2), and neither reaches
+ * the append (the `Pasaport` stub is fail-on-contact). The real-D1 append→projection
+ * round-trip is integration's.
  */
 import {assert, describe, it} from "@effect/vitest";
 import {
@@ -54,7 +45,7 @@ const flagsStub = (on: boolean): Layer.Layer<Flags> =>
 
 const agentAuthorityStub = Layer.succeed(AgentAuthority, {admits: () => Effect.succeed(false)});
 
-// A `RelationStore` where exactly `holders` hold the `admin` relation on platform.
+// Exactly `holders` hold the `admin` relation on platform.
 const adminStoreOf = (holders: ReadonlyArray<string>): Layer.Layer<RelationStore> =>
 	Layer.succeed(RelationStore, {
 		has: (tuple) => Effect.succeed(tuple.relation === "admin" && holders.includes(tuple.subject)),
@@ -100,8 +91,7 @@ const noWriteReached = Layer.mergeAll(makePasaportStub(), agentAuthorityStub);
 
 describe("emailDelivery.mark — admin authority (fail closed)", () => {
 	it.effect("an admin marks a target; the append runs, stamps the actor, reports failing", () => {
-		// Capture the actor threaded to the write (#2734): the mark must stamp the discharged
-		// admin's id (`u-admin`), never a client-supplied identity.
+		// The mark must stamp the discharged admin's id, never a client-supplied one (#2734).
 		const seen: {actorId?: string} = {};
 		return Effect.gen(function* () {
 			const receipt = yield* mark("u-target", "user reports no magic-links");

--- a/apps/web/worker/features/pasaport/email-delivery-admin.unit.test.ts
+++ b/apps/web/worker/features/pasaport/email-delivery-admin.unit.test.ts
@@ -1,9 +1,4 @@
-/**
- * `selectFailingAddresses` — the pure admin failing-address roll-up (Child #2692, epic
- * #2687). Latest-event-per-address wins, reusing `resolveEmailDeliveryState`: an address
- * whose newest event is a `fail` is failing; a later `clear` lifts it; a `fail` on a
- * DIFFERENT address is independent. No I/O, driven over hand-built log rows.
- */
+/** The pure admin failing-address roll-up: latest-event-per-address wins. No I/O. */
 import {assert, describe, it} from "@effect/vitest";
 import {type EmailDeliveryEventRow, selectFailingAddresses} from "./email-delivery.ts";
 
@@ -64,7 +59,6 @@ describe("selectFailingAddresses", () => {
 			row("3", "c@x.co", "u-c", "clear", null, "2025-12-31T09:00:00Z"),
 		];
 		const failing = selectFailingAddresses(rows, NOW);
-		// b (12:00) then a (06:00); c's latest is a clear → excluded.
 		assert.deepStrictEqual(
 			failing.map((f) => f.address),
 			["b@x.co", "a@x.co"],
@@ -79,7 +73,7 @@ describe("selectFailingAddresses", () => {
 			row("id-1", "a@x.co", "u-a", "fail", "older-write", at),
 			row("id-2", "a@x.co", "u-a", "clear", null, at),
 		];
-		// id-2 > id-1 at the same timestamp ⇒ the clear is the latest ⇒ excluded.
+		// id-2 > id-1 at the same timestamp ⇒ the clear is the latest.
 		assert.deepStrictEqual(selectFailingAddresses(rows, NOW), []);
 	});
 });

--- a/apps/web/worker/features/pasaport/email-delivery-log.ts
+++ b/apps/web/worker/features/pasaport/email-delivery-log.ts
@@ -1,14 +1,9 @@
 /**
- * `EmailDeliveryLog` — the append-only write port over `email_delivery_event` (epic
- * #2687). It is the seam the send adapter (`email-sender.ts`) records a send-time
- * rejection through, kept separate from `EmailSender` so the adapter depends on a
- * fakeable port, not on `Drizzle` directly.
+ * The append-only write port over `email_delivery_event`, kept separate from `EmailSender`
+ * so the send adapter depends on a fakeable port rather than `Drizzle`.
  *
- * `recordSendFailure` is fail-soft by contract — its error channel is `never`. The send
- * path it feeds must never throw into better-auth's email callbacks (an email can't fail
- * the auth flow, `email-sender.ts`), so the audit append is best-effort: a D1 failure is
- * logged and swallowed inside the layer rather than surfaced. See `email-delivery.ts` for
- * the projection this log feeds and the honest limit of the send-time signal.
+ * Fail-soft by contract (`E = never`): the send path must never throw into better-auth's
+ * email callbacks, so a D1 failure on this audit append is logged and swallowed.
  */
 import {eq} from "drizzle-orm";
 import {Context, Effect, Layer} from "effect";
@@ -19,9 +14,8 @@ export class EmailDeliveryLog extends Context.Service<
 	EmailDeliveryLog,
 	{
 		/**
-		 * Append a `fail` event for a synchronous send-time rejection. Resolves the
-		 * recipient's `userId` from the address when a `user` row exists (else records the
-		 * event by address alone). Fail-soft — `E = never`.
+		 * Append a `fail` event for a synchronous send-time rejection, resolving `userId`
+		 * from the address when a `user` row exists.
 		 */
 		readonly recordSendFailure: (input: {
 			readonly address: string;
@@ -30,11 +24,7 @@ export class EmailDeliveryLog extends Context.Service<
 	}
 >()("@kampus/pasaport/EmailDeliveryLog") {}
 
-/**
- * The Drizzle-backed adapter. The `userId` lookup and the insert both run against D1; a
- * `DrizzleError` from either is swallowed (`Effect.ignore`) so the public method stays
- * `E = never` — the append is audit, never load-bearing on the send.
- */
+/** The `Effect.ignore` is what keeps the public method at `E = never`. */
 export const EmailDeliveryLogLive: Layer.Layer<EmailDeliveryLog, never, Drizzle> = Layer.effect(
 	EmailDeliveryLog,
 	Effect.gen(function* () {

--- a/apps/web/worker/features/pasaport/email-delivery.ts
+++ b/apps/web/worker/features/pasaport/email-delivery.ts
@@ -1,44 +1,30 @@
 /**
- * Failing-address delivery-state domain (email-bounce epic #2687). Pure logic, no I/O:
- * the current per-address delivery-state is a PROJECTION of the append-only
- * `email_delivery_event` log — the latest event decides, so state can never drift from
- * history and a stale "bouncing flag" is unrepresentable. This mirrors `resolveBanState`
- * (`ban.ts`, ADR 0107) verbatim: a projection over an append-only log.
- *
- * Today's only feed is the send-time capture (Child #2691); the honest limit of that
- * signal is stated where it is captured (`email-sender.ts`). The admin mark/clear (Child
- * #2692) and the CF async ingestion (Child #2694) append to the same log.
+ * Failing-address delivery state (email-bounce epic #2687). Pure logic, no I/O: the
+ * per-address state is a PROJECTION of the append-only `email_delivery_event` log, so it
+ * can never drift from history and a stale "bouncing flag" is unrepresentable. Mirrors
+ * `resolveBanState` (`ban.ts`, ADR 0107).
  */
 
-/** The two event kinds appended to the log: a `fail` opens a failing-state, a `clear` lifts it. */
 export type EmailDeliveryEventAction = "fail" | "clear";
 
-/** One row of the append-only delivery log, as the projection needs it. */
 export interface EmailDeliveryEvent {
 	readonly action: EmailDeliveryEventAction;
 	readonly reason: string | null;
 	readonly createdAt: Date;
 }
 
-/** The projected current delivery-state for one address. */
 export interface EmailDeliveryState {
 	readonly failing: boolean;
 	/** The active failure's reason, or null when deliverable. */
 	readonly reason: string | null;
 }
 
-/** The deliverable state — an address with no events, or one whose latest event is a `clear`. */
 export const DELIVERABLE: EmailDeliveryState = {failing: false, reason: null};
 
 /**
- * Project the current delivery-state from the address's LATEST event.
- *
- * The caller passes the single newest event (by `createdAt`) or null when the log is
- * empty. Failing iff that latest event is a `fail` — so a `clear` after a `fail` restores
- * deliverability without touching the fail row (full reversibility, as in `resolveBanState`).
- * `now` is carried for signature parity with `resolveBanState` and to leave room for a
- * future time-decayed failing-state (Child #2694); today's send-rejection signal has no
- * expiry, so it is not read.
+ * `latest` is the single newest event by `createdAt`, or null on an empty log. A `clear`
+ * after a `fail` restores deliverability without touching the fail row. `now` is unread
+ * today — carried for parity with `resolveBanState` and a future time-decayed state (#2694).
  */
 export const resolveEmailDeliveryState = (
 	latest: EmailDeliveryEvent | null,
@@ -49,18 +35,12 @@ export const resolveEmailDeliveryState = (
 	return {failing: true, reason: latest.reason};
 };
 
-/**
- * One append-only log row as the admin failing-address roll-up (Child #2692) needs it:
- * the projection fields plus the address/user the row is keyed by and the server
- * `id`/`createdAt` ordering pair used to pick the latest event per address.
- */
 export interface EmailDeliveryEventRow extends EmailDeliveryEvent {
 	readonly id: string;
 	readonly address: string;
 	readonly userId: string | null;
 }
 
-/** One currently-failing address in the admin roll-up — the address, who it resolves to, and why. */
 export interface FailingAddress {
 	readonly address: string;
 	readonly userId: string | null;
@@ -69,9 +49,7 @@ export interface FailingAddress {
 	readonly since: Date;
 }
 
-// Latest wins by (createdAt, id) — the same server-assigned ordering the ban read and
-// the per-address index (`email_delivery_event_address_created`) resolve by, so the pure
-// roll-up and a DB `ORDER BY … DESC LIMIT 1` per address agree.
+// Ties break on `id` so this pure roll-up and a DB `ORDER BY … DESC LIMIT 1` agree.
 const isNewer = (a: EmailDeliveryEventRow, b: EmailDeliveryEventRow): boolean => {
 	const at = a.createdAt.getTime();
 	const bt = b.createdAt.getTime();
@@ -79,13 +57,9 @@ const isNewer = (a: EmailDeliveryEventRow, b: EmailDeliveryEventRow): boolean =>
 };
 
 /**
- * The admin failing-address projection (Child #2692): the set of addresses whose LATEST
- * event is a `fail`, derived from the SAME append-only log the send-time capture and the
- * per-address `resolveEmailDeliveryState` read — never a separate stored flag. Reduces the
- * rows to the newest event per address, keeps those that project to `failing`, and orders
- * them newest-failing first. Pure over the full failure log (which is small — only send
- * rejections and admin marks land here, not every send), so the roll-up is unit-testable
- * without D1.
+ * The admin roll-up (#2692), derived from the SAME log as the per-address read — never a
+ * separate stored flag. Pure over the whole log, which is safe because only rejections and
+ * admin marks land there, not every send.
  */
 export const selectFailingAddresses = (
 	rows: ReadonlyArray<EmailDeliveryEventRow>,

--- a/apps/web/worker/features/pasaport/email-delivery.unit.test.ts
+++ b/apps/web/worker/features/pasaport/email-delivery.unit.test.ts
@@ -1,8 +1,6 @@
 /**
- * `resolveEmailDeliveryState` — the pure failing-address projection (epic #2687). Latest
- * event wins, exactly like `resolveBanState`: no events → deliverable, a `fail` →
- * failing, a `fail` then a `clear` → deliverable again. No I/O, driven directly over
- * hand-built latest events.
+ * `resolveEmailDeliveryState` — the pure failing-address projection. Latest event wins,
+ * exactly like `resolveBanState`.
  */
 import {assert, describe, it} from "@effect/vitest";
 import {DELIVERABLE, type EmailDeliveryEvent, resolveEmailDeliveryState} from "./email-delivery.ts";
@@ -29,8 +27,6 @@ describe("resolveEmailDeliveryState", () => {
 	});
 
 	it("fail then clear → deliverable (a clear lifts a fail, latest-event-wins)", () => {
-		// The projection only ever sees the single newest event; a `clear` newer than the
-		// `fail` is what the caller passes, and it projects to deliverable.
 		const latest = event("clear", null, new Date("2026-01-01T06:00:00Z"));
 		assert.deepStrictEqual(resolveEmailDeliveryState(latest, NOW), DELIVERABLE);
 	});

--- a/apps/web/worker/features/pasaport/email-resources.ts
+++ b/apps/web/worker/features/pasaport/email-resources.ts
@@ -1,24 +1,12 @@
 /**
- * The Email Sending IaC surface (ADR 0101) — the `send.kamp.us` sending
- * subdomain, declared production-only.
+ * The Email Sending IaC surface (ADR 0101) — the `send.kamp.us` sending subdomain, declared
+ * production-only. Registering a reputation-isolated subdomain per ephemeral preview stage is
+ * wasteful and wrong, so the stack yields this only for a production deploy; dev/preview use the
+ * `EmailSenderLog` sink. Provisioning auto-creates the DKIM/SPF/return-path DNS records.
  *
- * Provisioning the subdomain auto-creates the DKIM/SPF/return-path DNS records
- * (kamp.us is on Cloudflare DNS, so they validate automatically and `enabled`
- * flips true). It is reputation-isolated on its own subdomain, and it is wasteful
- * + wrong to register one per ephemeral preview stage — so the stack yields this
- * ONLY for a production deploy (`provisionEmailSending`, gated on
- * `process.env.ENVIRONMENT`). dev/preview use the `EmailSenderLog` sink and never
- * touch the binding (see `email-sender.ts`).
- *
- * The `send_email` worker binding itself is not declared here: the production
- * adapter `bind()`s the `EmailSenderBinding` descriptor at worker init, and that
- * adapter is only selected under `ENVIRONMENT=production` — so the binding is
- * recorded for prod deploys and absent everywhere else, the same ENVIRONMENT gate
- * this subdomain is on.
- *
- * The prod gate itself (`isProductionDeploy`) is owned by `worker/environment.ts`
- * (ADR 0088), the single module every deploy/runtime gate shares (#1433); this file
- * only consumes it (via `alchemy.run.ts`).
+ * The `send_email` worker binding is not declared here: the production adapter `bind()`s the
+ * `EmailSenderBinding` descriptor at worker init, behind the same ENVIRONMENT gate
+ * (`isProductionDeploy`, owned by `worker/environment.ts`, ADR 0088).
  */
 import {adopt} from "alchemy/AdoptPolicy";
 import * as Cloudflare from "alchemy/Cloudflare";
@@ -27,17 +15,11 @@ import * as Effect from "effect/Effect";
 /** The apex zone — adopted (already on Cloudflare DNS), never created/deleted by the stack. */
 export const KAMPUS_ZONE_NAME = "kamp.us" as const;
 
-/** The reputation-isolated subdomain transactional mail is sent from. */
 export const SENDING_SUBDOMAIN = "send.kamp.us" as const;
 
-/**
- * Declare the kamp.us zone (adopted) + the `send.kamp.us` sending subdomain.
- * Yielded by the stack only on a production deploy.
- */
 export const provisionEmailSending = Effect.gen(function* () {
-	// Adopt the existing apex zone for its `zoneId`; a zone carries no ownership
-	// markers, so alchemy refuses to take it over without `adopt(true)`. Zones
-	// default to retain on removal — destroying the stack never deletes it.
+	// A zone carries no ownership markers, so alchemy refuses to take it over without
+	// `adopt(true)`. Zones default to retain on removal — destroying the stack never deletes it.
 	const zone = yield* Cloudflare.Zone.Zone("kampus_zone", {name: KAMPUS_ZONE_NAME}).pipe(
 		adopt(true),
 	);

--- a/apps/web/worker/features/pasaport/email-sender.ts
+++ b/apps/web/worker/features/pasaport/email-sender.ts
@@ -1,27 +1,12 @@
 /**
  * `EmailSender` — the provider-agnostic transactional-email port (ADR 0101).
+ * Adapters are picked by the `ENVIRONMENT` gate (ADR 0088); a preview MUST NOT
+ * deliver real mail.
  *
- * One method, `send`, that every better-auth email callback (magic-link,
- * verification, change-email confirmation) routes through. The provider is
- * Cloudflare Email Service (the native `send_email` binding via alchemy's
- * `Cloudflare.SendEmail`), but the port is the seam that keeps a future swap to
- * one adapter — `EmailSenderCloudflare` is the only place that names the
- * binding.
- *
- * Two adapters, selected by the `ENVIRONMENT` gate (ADR 0088), exactly like
- * `authUrlConfig` in `better-auth-live.ts`:
- *   - development + preview → `EmailSenderLog`: logs `{to, subject}` via
- *     `Effect.log`, never sends. A preview MUST NOT deliver real mail.
- *   - production → `EmailSenderCloudflare`: calls the binding's runtime
- *     `.send({from, to, subject, html?, text?})` (the structured Email Service
- *     shape, verified against the CF Workers Email API docs — no raw MIME).
- *
- * `send` is fail-soft by contract: its error channel is `never`. better-auth's
- * email callbacks must not throw (a thrown callback fails the sign-in/verify
- * flow), so a delivery failure is logged and swallowed inside the adapter — the
- * empty error channel makes "an email can't fail the auth flow" a type, not a
- * per-call-site convention (the swallow-inside-the-layer law of
- * `.patterns/effect-context-service.md` §"Wrapping a non-Effect client").
+ * `send` is fail-soft by contract — `E = never`. A thrown better-auth email callback
+ * would fail the sign-in flow, so the adapter swallows delivery failures internally
+ * and "an email can't fail the auth flow" becomes a type rather than a convention
+ * (.patterns/effect-context-service.md, "Wrapping a non-Effect client").
  */
 import {RuntimeContext} from "alchemy";
 import {Email} from "alchemy/Cloudflare";
@@ -30,11 +15,7 @@ import {environment} from "../../config.ts";
 import {type Environment, isProduction} from "../../environment.ts";
 import {EmailDeliveryLog} from "./email-delivery-log.ts";
 
-/**
- * A transactional message. Invalid states are unrepresentable: `to` + `subject`
- * are required, and the body is a `html | text` union — every message carries at
- * least one renderable body, never an empty send.
- */
+// The body is a union, so a message with no renderable body is unrepresentable.
 export type EmailBody = {readonly html: string} | {readonly text: string};
 
 export type EmailMessage = {
@@ -45,19 +26,12 @@ export type EmailMessage = {
 export class EmailSender extends Context.Service<
 	EmailSender,
 	{
-		/** Deliver one transactional email. Fail-soft — `E = never`. */
 		readonly send: (message: EmailMessage) => Effect.Effect<void>;
 	}
 >()("@kampus/pasaport/EmailSender") {}
 
-/** The from-address every transactional email is sent on the `send.kamp.us` sending subdomain. */
 export const EMAIL_FROM = "pasaport@send.kamp.us" as const;
 
-/**
- * Dev/preview adapter — logs the recipient + subject, never sends. This is the
- * old `isLocalDev` `console.log` branch, lifted behind the port (and widened to
- * `preview`, which must never deliver real mail).
- */
 export const EmailSenderLog: Layer.Layer<EmailSender> = Layer.succeed(EmailSender)(
 	EmailSender.of({
 		send: (message) =>
@@ -68,33 +42,21 @@ export const EmailSenderLog: Layer.Layer<EmailSender> = Layer.succeed(EmailSende
 	}),
 );
 
-/**
- * The `send_email` binding descriptor. `allowedSenderAddresses` pins the worker
- * to the one `send.kamp.us` from-address; destination is unrestricted (omit
- * `destinationAddress`/`allowedDestinationAddresses` → send to any verified
- * recipient — every signed-up user's address).
- */
+// Destination is deliberately unrestricted — omitting `destinationAddress` lets the
+// worker reach every signed-up user's verified address.
 export const EmailSenderBinding = Email.SendEmail("EmailSender", {
 	allowedSenderAddresses: [EMAIL_FROM],
 });
 
 /**
- * Production adapter — delivers via the Cloudflare Email Service `send_email`
- * binding (alchemy `Cloudflare.SendEmail`, runtime `.send(...)`). The binding's
- * `send` already wraps any failure in a typed `SendEmailError`; on that rejection
- * the adapter appends a `fail` event to the delivery log (`EmailDeliveryLog`) and
- * swallows the error so the callback never throws and the public method's `E = never`.
+ * Production adapter. What it records has an honest limit (#2687/#2691): a
+ * `SendEmailError` is a send REJECTION caught at send time, NOT an asynchronous hard
+ * bounce or spam complaint — those arrive after the SMTP handshake and need the
+ * CF delivery-event surface (#2694).
  *
- * The captured signal's honest limit (epic #2687, Child #2691): a synchronous
- * `SendEmailError` is a send REJECTION caught at send time — NOT an asynchronous hard
- * bounce or spam complaint, which arrive after the SMTP handshake and need the CF
- * delivery-event surface (Child #2694, CF-gated). That buildable-today vs CF-gated
- * fault line is what the epic splits on; this adapter only records the synchronous half.
- *
- * The binding's `.send` carries `R = RuntimeContext`; it and `EmailDeliveryLog` are
- * resolved once at layer build (ambient/stable for the isolate) and baked into the
- * closure, so the public `send` is `Effect<void, never, never>` — runnable standalone
- * from better-auth's async callbacks without re-threading context.
+ * `RuntimeContext` and `EmailDeliveryLog` are resolved once at layer build and baked
+ * into the closure, so the public `send` is runnable standalone from better-auth's
+ * async callbacks without re-threading context.
  */
 export const EmailSenderCloudflareLive = Layer.effect(
 	EmailSender,
@@ -123,29 +85,21 @@ export const EmailSenderCloudflareLive = Layer.effect(
 	}),
 );
 
-/**
- * The layer factory — reads `ENVIRONMENT` once and picks the adapter, the same
- * shape as `authUrlConfig`. development/preview → log sink (no binding touched);
- * production → the CF Email Service adapter. Pure over an injected env so the
- * selection is unit-testable without a real ConfigProvider.
- */
+// Pure over an injected env, so the selection is unit-testable without a real
+// ConfigProvider.
 export const emailSenderLayerFor = (
 	env: Environment,
 ): Layer.Layer<EmailSender, never, RuntimeContext | Email.Send | EmailDeliveryLog> =>
 	isProduction(env) ? EmailSenderCloudflareLive : EmailSenderLog;
 
-/**
- * The resolved-from-Config layer used at the worker entry. Reads `ENVIRONMENT`
- * (fail-closed default `production`, ADR 0088) and defers to `emailSenderLayerFor`.
- */
+// `ENVIRONMENT` defaults fail-closed to `production` (ADR 0088).
 export const EmailSenderLive: Layer.Layer<
 	EmailSender,
 	never,
 	RuntimeContext | Email.Send | EmailDeliveryLog
 > = Layer.unwrap(
 	Effect.gen(function* () {
-		// `orDie`: a value outside the three literals is a malformed env, unrecoverable
-		// (same stance as `better-auth-live.ts`).
+		// A value outside the three literals is a malformed env, unrecoverable.
 		const env = yield* environment.pipe(Effect.orDie);
 		return emailSenderLayerFor(env);
 	}),

--- a/apps/web/worker/features/pasaport/email-sender.unit.test.ts
+++ b/apps/web/worker/features/pasaport/email-sender.unit.test.ts
@@ -1,16 +1,4 @@
-/**
- * Unit coverage for the `EmailSender` port (ADR 0101). Drives both adapters
- * over substituted seams — no binding, no network:
- *
- *   - `EmailSenderCloudflareLive` over a FAKE `Email.Send`: asserts it
- *     calls the binding's `.send` with the correct from/to/subject/body shape,
- *     and that a binding `SendEmailError` is recorded to the delivery log AND
- *     swallowed (the public `send` is `E = never`, so a delivery failure never
- *     throws into better-auth — epic #2687, Child #2691);
- *   - `EmailSenderLog`: the dev/preview sink resolves without a binding;
- *   - `emailSenderLayerFor`: the ENVIRONMENT gate picks the log sink for
- *     development/preview and the CF adapter for production.
- */
+/** Drives both `EmailSender` adapters (ADR 0101) over substituted seams — no binding, no network. */
 import {assert, describe, it} from "@effect/vitest";
 import {RuntimeContext} from "alchemy";
 import {Email} from "alchemy/Cloudflare";
@@ -34,10 +22,7 @@ const runtimeContext = Layer.succeed(RuntimeContext)({
 
 type RecordedFailure = {address: string; reason: string};
 
-/**
- * A fake `EmailDeliveryLog` that captures every `recordSendFailure` call into `sink`,
- * so the CF adapter's send-time capture is assertable without a `Drizzle`/D1.
- */
+/** Captures `recordSendFailure` calls so the adapter is assertable without a `Drizzle`/D1. */
 const fakeDeliveryLog = (sink: RecordedFailure[]): Layer.Layer<EmailDeliveryLog> =>
 	Layer.succeed(EmailDeliveryLog)(
 		EmailDeliveryLog.of({
@@ -47,11 +32,7 @@ const fakeDeliveryLog = (sink: RecordedFailure[]): Layer.Layer<EmailDeliveryLog>
 
 type SentMessage = Parameters<Email.SendClient["send"]>[0];
 
-/**
- * A fake `Email.Send`: `SendEmail.bind(descriptor)` resolves to a client
- * whose `send` is supplied by the test. `raw`/`sendRaw` die so an accidental
- * call is loud.
- */
+/** `raw`/`sendRaw` die so an accidental call is loud. */
 const fakeBinding = (
 	onSend: (message: SentMessage) => Effect.Effect<{messageId: string}, Email.SendEmailError>,
 ): Layer.Layer<Email.Send> =>
@@ -137,9 +118,8 @@ describe("EmailSenderCloudflareLive", () => {
 				sender.send({to: "user@example.com", subject: "x", text: "y"}),
 			);
 
-			// The send is REJECTED at the binding. The adapter must (1) append the rejection
-			// to the delivery log for that recipient, and (2) still complete with void — the
-			// public `send` is E = never, so a delivery failure never fails the auth flow.
+			// The public `send` is E = never, so a rejected delivery must still complete with
+			// void — it can never fail the auth flow.
 			const result = yield* program.pipe(
 				Effect.provide(
 					EmailSenderCloudflareLive.pipe(

--- a/apps/web/worker/features/pasaport/email-templates.ts
+++ b/apps/web/worker/features/pasaport/email-templates.ts
@@ -1,31 +1,22 @@
 /**
- * Transactional email copy (ADR 0101). Turkish user-facing copy (the
- * product-copy rule in CLAUDE.md); the identifiers + the `EmailMessage` shape
- * stay English. Each builder returns an `EmailMessage` the `EmailSender` port
- * delivers — pure functions of their inputs, so the copy is unit-inspectable
- * without touching the binding.
+ * Transactional email copy (ADR 0101). Turkish for the user-facing copy, English for
+ * identifiers. Pure functions, so the copy is unit-inspectable without the binding.
  */
 import type {EmailMessage} from "./email-sender.ts";
 
-/** The magic-link sign-in email — better-auth's `magicLink.sendMagicLink`. */
 export const magicLinkEmail = (to: string, url: string): EmailMessage => ({
 	to,
 	subject: "kamp.us giriş bağlantın",
 	text: `kamp.us'a giriş yapmak için bu bağlantıya tıkla:\n\n${url}\n\nBu bağlantıyı sen istemediysen bu e-postayı görmezden gelebilirsin.`,
 });
 
-/** The email-verification email — better-auth's `emailVerification.sendVerificationEmail`. */
 export const verificationEmail = (to: string, url: string): EmailMessage => ({
 	to,
 	subject: "kamp.us e-posta adresini doğrula",
 	text: `E-posta adresini doğrulamak için bu bağlantıya tıkla:\n\n${url}\n\nBu hesabı sen oluşturmadıysan bu e-postayı görmezden gelebilirsin.`,
 });
 
-/**
- * The change-email confirmation — better-auth's
- * `user.changeEmail.sendChangeEmailConfirmation`, sent to the CURRENT address so
- * the user approves the switch before it takes effect.
- */
+// Sent to the CURRENT address, so the user approves the switch before it takes effect.
 export const changeEmailConfirmationEmail = (
 	to: string,
 	newEmail: string,

--- a/apps/web/worker/features/pasaport/email-templates.unit.test.ts
+++ b/apps/web/worker/features/pasaport/email-templates.unit.test.ts
@@ -1,15 +1,8 @@
 /**
- * Unit coverage for the transactional email copy + the callback dispatch
- * contract (ADR 0101). The three better-auth callbacks (magic-link, verify,
- * change-email confirmation) each build their `EmailMessage` from these template
- * functions and dispatch it through the `EmailSender` port. This test asserts:
- *
- *   - each template carries the required `to`/`subject` and a body, the recipient
- *     and link the callback was handed, and Turkish subject copy;
- *   - a built message dispatched through a recording `EmailSender` reaches `send`
- *     verbatim — the callback→port wiring;
- *   - the change-email confirmation addresses the CURRENT email (not the new one),
- *     the security-load-bearing detail of the flow #75 needs.
+ * Unit coverage for the transactional email copy + the callback dispatch contract (ADR 0101):
+ * each template's `to`/`subject`/body, that a built message reaches `EmailSender.send`
+ * verbatim, and that the change-email confirmation addresses the CURRENT email, not the new
+ * one — the security-load-bearing detail of the flow.
  */
 import {assert, describe, it} from "@effect/vitest";
 import {Effect, Layer} from "effect";

--- a/apps/web/worker/features/pasaport/errors.ts
+++ b/apps/web/worker/features/pasaport/errors.ts
@@ -1,14 +1,7 @@
 /**
- * Tagged errors raised by the Pasaport service layer. Each class carries its
- * wire `code` as an `FateWireCode` annotation that `encodeWireError` reads at the
- * fate boundary (`.patterns/fate-effect-wire-errors.md`). One static code per
- * class (the codec reads the CONSTRUCTOR annotation), so each username sub-code
- * is its own class and {@link UsernameInvalid} is the union alias the service
- * signatures name. Wire codes are pinned verbatim in `errors.unit.test.ts` so
- * SPA pattern-matching can't drift.
- *
- * The package's `Unauthorized` (annotated `UNAUTHORIZED`) gates the writes via
- * `CurrentUser.required` and is not redeclared here.
+ * Tagged errors raised by the Pasaport service layer. See
+ * `.patterns/fate-effect-wire-errors.md`. The codec reads the CONSTRUCTOR annotation, so
+ * one static code per class — that is why each username sub-code is its own class.
  */
 import {FateWireCode} from "@kampus/fate-effect";
 import * as Schema from "effect/Schema";
@@ -31,16 +24,12 @@ export class UsernameTooLong extends Schema.TaggedErrorClass<UsernameTooLong>()(
 	{[FateWireCode]: "TOO_LONG"},
 ) {}
 
-// Spread into the mutation `error:` union; {@link UsernameInvalid} is derived
-// from this tuple, so the two can never drift.
 export const UsernameInvalidErrors = [
 	UsernameInvalidFormat,
 	UsernameTooShort,
 	UsernameTooLong,
 ] as const;
 
-// The union the `Pasaport` service signatures declare, derived from
-// {@link UsernameInvalidErrors}.
 export type UsernameInvalid = InstanceType<(typeof UsernameInvalidErrors)[number]>;
 
 export class UsernameTaken extends Schema.TaggedErrorClass<UsernameTaken>()(
@@ -68,9 +57,8 @@ export class UserNotFound extends Schema.TaggedErrorClass<UserNotFound>()(
 	{[FateWireCode]: "USER_NOT_FOUND"},
 ) {}
 
-// A display-name change with an empty (or whitespace-only) value. The görünen-ad
-// save is the sole caller; the SPA input is `required` + trimmed, so this is the
-// server-authoritative floor against a blank submit — never a byline-blanking write.
+// The server-authoritative floor against a blank submit; the SPA's `required` input is
+// not trusted to prevent a byline-blanking write.
 export class DisplayNameEmpty extends Schema.TaggedErrorClass<DisplayNameEmpty>()(
 	"pasaport/DisplayNameEmpty",
 	{
@@ -79,9 +67,8 @@ export class DisplayNameEmpty extends Schema.TaggedErrorClass<DisplayNameEmpty>(
 	{[FateWireCode]: "DISPLAY_NAME_EMPTY"},
 ) {}
 
-// A ban with an empty (or whitespace-only) reason. A ban MUST carry a reason (epic
-// #968 — the audit record is meaningless without one), so the server rejects a blank
-// submit as the authoritative floor even though the admin UI marks the field required.
+// A ban MUST carry a reason — the audit record is meaningless without one — so the
+// server rejects a blank submit even though the admin UI marks the field required.
 export class BanReasonRequired extends Schema.TaggedErrorClass<BanReasonRequired>()(
 	"pasaport/BanReasonRequired",
 	{
@@ -90,10 +77,8 @@ export class BanReasonRequired extends Schema.TaggedErrorClass<BanReasonRequired
 	{[FateWireCode]: "BAN_REASON_REQUIRED"},
 ) {}
 
-// An admin `emailDelivery.mark` submitted without a reason. A manual failing-mark MUST
-// carry a reason (Child #2692 — the audit note is why the address was marked out-of-band),
-// so the server rejects a blank submit as the authoritative floor even though the admin UI
-// marks the field required. The `clear` carries no reason and has no such floor.
+// A manual failing-mark MUST carry a reason — it is the audit note for why the address
+// was marked out-of-band. The matching `clear` carries none and has no such floor.
 export class EmailFailingReasonRequired extends Schema.TaggedErrorClass<EmailFailingReasonRequired>()(
 	"pasaport/EmailFailingReasonRequired",
 	{

--- a/apps/web/worker/features/pasaport/fate-module.ts
+++ b/apps/web/worker/features/pasaport/fate-module.ts
@@ -27,15 +27,11 @@ import {
 const roots: FateRootsRecord = {
 	me: userDataView,
 	profile: profileDataView,
-	// The çaylak-self "yazarlığa giden yol" aggregate (#1316, epic #1202) — a query
-	// root keyed on `CurrentUser` (self-only), aggregate-only (one-way-glass).
-	// Resolved inline by the `myAuthorshipStanding` resolver.
+	// Keyed on `CurrentUser` (self-only), aggregate-only — the one-way-glass read (#1316).
 	myAuthorshipStanding: authorshipStandingDataView,
-	// The admin ban-state read (#970, epic #968) — `requireAdmin`-gated + behind
-	// `phoenix-user-ban`; the `user.banState` resolver owns the gate.
+	// `requireAdmin`-gated + behind `phoenix-user-ban`; the resolver gates.
 	"user.banState": banStateDataView,
-	// The admin failing-address roll-up (#2692, epic #2687) — `requireAdmin`-gated + behind
-	// `phoenix-email-delivery-admin`; the `emailDelivery.failing` list resolver owns the gate.
+	// `requireAdmin`-gated + behind `phoenix-email-delivery-admin`; the resolver gates.
 	"emailDelivery.failing": list(failingAddressDataView),
 };
 

--- a/apps/web/worker/features/pasaport/ids.ts
+++ b/apps/web/worker/features/pasaport/ids.ts
@@ -1,18 +1,13 @@
 /**
- * Pasaport feature-local branded ids (epic #2700). The cross-feature `UserId` is
- * imported read-only from the shared `lib/ids.ts` (the #2735 tracer module); only
- * the pasaport-owned `CandidateId` is minted here, feature-locally, so sibling
- * slices don't append-conflict on the shared module.
- *
- * `CandidateId` is a user account id in the vouch (kefil) *candidate* role — the
- * çaylak being vouched. It is a plain string at runtime, but branding it distinctly
- * from `UserId` makes the vouch-flow pairing type-distinct: the acting user's id and
- * the candidate's id can no longer be transposed without a compile error, even though
- * both are user ids. See `../../lib/ids.ts` for the branding idiom (effect-smol
- * `SCHEMA.md` §Branding) — not re-derived here.
+ * Pasaport feature-local branded ids (epic #2700), minted here rather than on the shared
+ * `lib/ids.ts` so sibling slices don't append-conflict. See `../../lib/ids.ts` for the
+ * branding idiom.
  */
 import {brandedId} from "../../lib/ids.ts";
 
-/** A vouch candidate's account id — a user id in the candidate (vouched çaylak) role. */
+/**
+ * A user id in the vouch candidate role. Branded distinctly from `UserId` so the acting
+ * user's id and the candidate's id can't be transposed without a compile error.
+ */
 export const CandidateId = brandedId("CandidateId");
 export type CandidateId = typeof CandidateId.Type;

--- a/apps/web/worker/features/pasaport/karma.ts
+++ b/apps/web/worker/features/pasaport/karma.ts
@@ -1,12 +1,6 @@
 /**
- * Pasaport's implementation of the `KarmaBump` contract VOTE owns (`vote/Vote.ts`,
- * dependency inversion): the **unexecuted** `total_karma` UPDATE PLUS its
- * append-only `karma_event` ledger row (#2592), so every bump leaves a
- * reconstructable origin record co-committed with the balance change.
- * `fate/layers.ts` wraps this in `Layer.succeed(KarmaBump, …)`; the Vote service
- * includes both statements in its `batch((db) => [...])` so bump + event commit
- * atomically with the vote, or not at all. Vote never imports this module — it
- * passes the {@link KarmaBumpInput} context and this side owns the karma schema.
+ * Pasaport's implementation of the `KarmaBump` contract Vote owns. Vote never imports
+ * this module — it passes {@link KarmaBumpInput} and this side owns the karma schema.
  */
 import {and, eq, sql} from "drizzle-orm";
 import type {DrizzleDb, Stmt} from "../../db/Drizzle.ts";
@@ -14,18 +8,14 @@ import * as schema from "../../db/drizzle/schema.ts";
 import type {KarmaBumpInput} from "../vote/Vote.ts";
 
 /**
- * The bump + its provenance event, in that order. `delta` may be negative (a vote
- * retraction records a `-1` `karma_event`, never a deletion of the prior row — the
- * ledger is append-only, so `SUM(delta)` reconciles to `total_karma`). Never call
- * `.run()` on either — they are meant for a `batch((db) => [...])` tuple.
+ * Never call `.run()` on either statement — they belong in a `batch((db) => [...])`.
  *
- * BOTH statements carry `input.guard` — the pre-mutation vote-change predicate — so a
- * duplicate cast that raced the out-of-batch idempotency probe writes NEITHER the delta
- * NOR a ledger row, keeping the two in lockstep (#2552). The event is an
- * `INSERT … SELECT … WHERE guard` (a plain `.values()` can't carry a predicate) — the
- * same guarded-insert idiom as bildirim's `insertUnlessUnreadStatement`; its raw select
- * bypasses drizzle's `{mode:"timestamp"}` codec, so `created_at` is bound as the epoch
- * SECONDS the column stores.
+ * The ledger is append-only: a retraction records a `-1` event, never a deletion, so
+ * `SUM(delta)` reconciles to `total_karma`. BOTH statements must carry `input.guard`, so
+ * a duplicate cast that raced the idempotency probe writes neither (#2552). The event is
+ * an `INSERT … SELECT … WHERE guard` because a plain `.values()` can't carry a predicate;
+ * that raw select bypasses drizzle's `{mode:"timestamp"}` codec, hence the explicit
+ * epoch-SECONDS binding below.
  */
 export function karmaBumpStatements(db: DrizzleDb, input: KarmaBumpInput): readonly [Stmt, Stmt] {
 	const bump = db

--- a/apps/web/worker/features/pasaport/karma.unit.test.ts
+++ b/apps/web/worker/features/pasaport/karma.unit.test.ts
@@ -1,14 +1,9 @@
 /**
- * `karmaBumpStatements` — pasaport's `KarmaBump` implementation (#2592). Proves the
- * two co-committed statements by rendering their `.toSQL()` over a no-op D1 (the
- * `promotion-sweep.unit.test.ts` / `set-display-name.unit.test.ts` idiom) — no engine,
- * so this is a unit test; the execute-and-read-back over real D1 is the integration
- * tier (`tests/integration/pasaport.test.ts` drives the same batch via `totalKarma`).
- *
- * The load-bearing correctness concern is that every bump emits BOTH a `total_karma`
- * UPDATE and a `karma_event` INSERT carrying the same signed delta — so a delta can't
- * land without its provenance row, and `SUM(karma_event.delta)` reconciles to
- * `total_karma`. A retraction is a NEGATIVE-delta INSERT, never a deletion (append-only).
+ * `karmaBumpStatements` (#2592), proved by rendering `.toSQL()` over a no-op D1 — no
+ * engine, so this is a unit test. The concern: every bump emits BOTH a `total_karma`
+ * UPDATE and a `karma_event` INSERT with the same signed delta, so a delta can't land
+ * without its provenance row and `SUM(karma_event.delta)` reconciles to `total_karma`.
+ * A retraction is a NEGATIVE-delta INSERT, never a deletion.
  */
 import {assert, describe, it} from "@effect/vitest";
 import {drizzle} from "drizzle-orm/d1";
@@ -47,8 +42,7 @@ const render = (s: Stmt) =>
 	// biome-ignore lint/plugin: drizzle's `Stmt`/`BatchItem` carries `.toSQL()` at runtime but doesn't expose it on the type; render it to assert the built SQL.
 	(s as unknown as {toSQL: () => {sql: string; params: unknown[]}}).toSQL();
 
-// The pre-mutation vote-change guard the real batch threads in (`targetTable[kind]`),
-// so these render tests exercise the SAME guard SQL production sees, not a stand-in.
+// The guard the real batch threads in, so these render tests see production's SQL.
 const guardFor = (kind: "definition" | "post" | "comment", targetId: string, isCast: boolean) =>
 	targetTable[kind].voteChangeGuard(renderDb, targetId, "voter-1", isCast);
 
@@ -106,9 +100,8 @@ describe("karmaBumpStatements — the bump + its append-only ledger row (#2592)"
 	});
 
 	it("the bump delta and the event delta are the SAME value — they can't diverge", () => {
-		// The reconciliation invariant at the statement level: `total_karma += delta` and
-		// `karma_event.delta = delta` read the one `input.delta`, so SUM(events) tracks the
-		// accumulator by construction (#2592).
+		// Both statements read the one `input.delta`, so SUM(events) tracks the accumulator
+		// by construction (#2592).
 		for (const delta of [1, -1]) {
 			const stmts = karmaBumpStatements(renderDb, {
 				recipientId: "u",
@@ -125,13 +118,9 @@ describe("karmaBumpStatements — the bump + its append-only ledger row (#2592)"
 });
 
 describe("karmaBumpStatements — the pre-mutation guard blocks a raced double-bump (#2552)", () => {
-	// The double-bump defect: `Vote.castImpl` probes idempotency OUTSIDE the batch, so two
-	// concurrent identical casts both see `alreadyCast=false` and both run the batch. Before
-	// #2552 the karma UPDATE was unconditional, so `total_karma` bumped twice (and a second
-	// ledger row landed). The fix gates BOTH statements on `input.guard` — the vote row's
-	// PRE-mutation presence — and Vote orders the pair ahead of the vote write. Here we prove
-	// the statement-level invariant that makes the second cast a no-op: bump and event carry
-	// the SAME `NOT EXISTS(vote row)` predicate, so they commit together or not at all.
+	// The double-bump defect (#2552): `Vote.castImpl` probes idempotency OUTSIDE the batch,
+	// so two concurrent identical casts both run it. Both statements carry the SAME
+	// `NOT EXISTS(vote row)` predicate, which is what makes the second cast a no-op.
 	it("bump AND event are gated by the identical vote-row predicate — they can't diverge", () => {
 		const stmts = karmaBumpStatements(renderDb, {
 			recipientId: "author-1",
@@ -141,9 +130,8 @@ describe("karmaBumpStatements — the pre-mutation guard blocks a raced double-b
 			at: new Date("2026-01-02T03:04:05Z"),
 			guard: guardFor("definition", "def-1", true),
 		});
-		// The one guard subquery, keyed on the exact vote row (target + voter) whose presence
-		// decides whether the cast changed state, appears verbatim in BOTH statements — so a
-		// duplicate that finds the row present writes neither the delta nor the ledger row.
+		// The guard subquery appears verbatim in BOTH statements, so a duplicate that finds
+		// the row present writes neither the delta nor the ledger row.
 		const subquery = 'not exists (select 1 from "definition_vote"';
 		assert.include(render(stmts[0]).sql, subquery, "the bump is gated on the vote row");
 		assert.include(render(stmts[1]).sql, subquery, "the ledger row is gated by the same predicate");

--- a/apps/web/worker/features/pasaport/lists.ts
+++ b/apps/web/worker/features/pasaport/lists.ts
@@ -1,19 +1,7 @@
 /**
- * Pasaport root list resolvers — `emailDelivery.failing`, the admin failing-address
- * roll-up (Child #2692, email-bounce epic #2687). `Fate.list` def + `Effect.fn` pair
- * (`.patterns/fate-effect-operations.md`); the list is delivered inline (no source
- * `connection`), so the resolver builds the wire shape itself.
- *
- * Two gates, both enforced HERE (the service read is unconditional), mirroring
- * `divan/lists.ts`:
- *   1. The `PHOENIX_EMAIL_DELIVERY_ADMIN` dark-ship flag (default-off, ADR 0083). Off ⇒
- *      the invisible `Denied` (the ban-surface stance), so the roll-up never leaks before
- *      release.
- *   2. `requireAdmin` (ADR 0107) — `yield* Admin` makes the read unreachable without the
- *      discharged grant, so a non-admin gets the SAME invisible `Denied`.
- *
- * A single-page private read (no live view, no cursor pagination), so the
- * `ConnectionResult` is `hasNext: false`, mirroring `divan.roster`.
+ * The admin failing-address roll-up. Both gates are enforced HERE, because the service
+ * read is unconditional: the dark-ship flag and `requireAdmin` (ADR 0107). Both denials
+ * are the same invisible `Denied`, so a non-admin cannot tell them apart.
  */
 import {Fate} from "@kampus/fate-effect";
 import type {ConnectionResult} from "@nkzw/fate/server";
@@ -31,14 +19,14 @@ import {FailingAddressView} from "./views.ts";
 
 const FailingArgs = Schema.Struct({});
 
-/** Is the #2692 admin email-delivery flag on for this request? Safe-default `false` (dark). */
+/** Safe-default `false` — the flag reads dark when it cannot be resolved. */
 const emailDeliveryAdminOn = Effect.gen(function* () {
 	const flags = yield* Flags;
 	return yield* flags.getBoolean(PHOENIX_EMAIL_DELIVERY_ADMIN, false).pipe(provideRequestFlags);
 });
 
-// The post-gate roll-up read — `Admin`-gated in R (`requireAdmin` provides the grant).
-// `yield* Admin` requires the proof; the roll-up is unreachable without a discharged grant.
+// `yield* Admin` demands the proof in R, so this read is unreachable without a discharged
+// grant — a compile-time gate, not an `if`.
 const failingGated = Effect.fn("emailDelivery.failingGated")(function* () {
 	yield* Admin;
 	const pasaport = yield* Pasaport;

--- a/apps/web/worker/features/pasaport/live.ts
+++ b/apps/web/worker/features/pasaport/live.ts
@@ -1,22 +1,12 @@
 /**
- * Pasaport live-publish targets — the ONE place that answers "what does a
- * pasaport mutation publish to?" Binds the entity's wire `__typename` (read off
- * the view's `typeName`, never an inline `"User"` literal) to the entity-field
- * topic it participates in, so a resolver names the fan-out target instead of
- * restating the magic-string seam (#1127), mirroring `pano/live.ts` /
- * `sozluk/live.ts`.
+ * Pasaport's live-publish targets — the one place that answers "what does a pasaport
+ * mutation publish to?" The typename is read off the view rather than written as an
+ * inline literal (#1127).
  *
- * The only pasaport live seam today is the çaylak→yazar tier flip (#1886): a
- * committed `promoteToYazar` must publish a `User` entity update so an open
- * profile view reconciles the new `tier` over `/fate/live` without a manual
- * reload. `User` is the entity the app-lifetime global live pin subscribes
- * (`.patterns/fate-live-consistency.md#global-pin`, ADR 0094 — `User.id === CurrentUser.id`),
- * so a `live.update("User", id, …)` reaches every open profile/User view of the
- * promoted member.
- *
- * The bound call forwards verbatim to `WorkerLivePublisher.update`, whose error
- * channel is `never` (`.patterns/fate-effect-server.md`): a failed publish can
- * never fail the committed tier flip.
+ * The only live seam today is the tier flip (#1886). `User` is the entity the
+ * app-lifetime global live pin subscribes (ADR 0094, see
+ * .patterns/fate-live-consistency.md#global-pin), so an update reaches every open
+ * view of the promoted member.
  */
 
 import type {WorkerLivePublisher} from "../fate-live/protocol.ts";

--- a/apps/web/worker/features/pasaport/lookup-profile-case-insensitive.unit.test.ts
+++ b/apps/web/worker/features/pasaport/lookup-profile-case-insensitive.unit.test.ts
@@ -1,14 +1,10 @@
 /**
- * `Pasaport.lookupProfile` normalizes the incoming username the same way the write
- * path does, so a mixed-case `/u/Rasit` resolves the lowercased stored `rasit` row
- * instead of 404ing (#2445). Usernames are written lowercased (`setUsername` →
- * `normalizeUsername`); the read must match that canonical form or the exact `eq`
- * misses. This pins the profile-row SELECT to bind the lowercased handle regardless
- * of the URL casing, and that a genuinely-absent handle still resolves to `null`.
+ * Usernames are written lowercased, so `lookupProfile` must normalize the incoming
+ * handle the same way or the exact `eq` misses and `/u/Rasit` 404s (#2445).
  *
- * Unit-tier per ADR 0082: the query BUILDER is captured off `.toSQL()` (never
- * executed), so `params` exposes the bound `where "username" = ?` value directly —
- * that bound value IS the normalized lookup key, which is exactly what this asserts.
+ * The query builder is captured off `.toSQL()` and never executed, so `params`
+ * exposes the bound `where "username" = ?` value — that bound value IS the
+ * normalized lookup key under test.
  */
 import {assert, describe, it} from "@effect/vitest";
 import {drizzle} from "drizzle-orm/d1";
@@ -30,8 +26,7 @@ const hasToSQL = (v: unknown): v is {toSQL: () => {sql: string; params: unknown[
 const isThenable = (v: unknown): v is PromiseLike<unknown> =>
 	typeof v === "object" && v !== null && typeof (v as {then?: unknown}).then === "function";
 
-// An inert D1 binding: the count reads (`countByAuthor`, a `.then()`) execute here and
-// resolve to empty; only SQL compilation is exercised, results are inert.
+// Only SQL compilation is exercised; the count reads resolve to empty.
 function inertD1(): D1Database {
 	// biome-ignore lint/plugin: `D1Database` is a host binding that can't be structurally constructed; only SQL compilation is exercised, results are inert.
 	return {
@@ -54,10 +49,8 @@ interface CapturedBuilder {
 	params: unknown[];
 }
 
-// Drives `lookupProfile` over scripted `run` results while CAPTURING each query
-// BUILDER's compiled SQL + bound params off `.toSQL()` (without executing it); a count
-// PROMISE is awaited so it resolves inertly. The first captured builder is the
-// profile-row SELECT — its bound param is the normalized lookup key under test.
+// Captures each builder's compiled SQL and bound params without executing it. The
+// first captured builder is the profile-row SELECT.
 function capturingAccess(
 	binding: D1Database,
 	results: ReadonlyArray<unknown>,
@@ -96,11 +89,9 @@ const STORED_ROW = {
 	totalKarma: 0,
 };
 
-// A found profile: 1 profile-row SELECT (builder) then 3 `countByAuthor` reads.
+// One profile-row SELECT, then three `countByAuthor` reads.
 const foundResults = [[STORED_ROW], 0, 0, 0] as const;
 
-// Run `lookupProfile(arg)` over the found script; return the captured profile-row
-// SELECT builder (the first `run`) so its bound `where username = ?` param can be read.
 const runLookup = (arg: string) =>
 	Effect.gen(function* () {
 		const {access, builders} = capturingAccess(inertD1(), [...foundResults]);
@@ -125,8 +116,7 @@ describe("Pasaport.lookupProfile — case-insensitive lookup (#2445)", () => {
 					"rasit",
 					"the lookup normalizes to the stored-lowercased handle before the eq",
 				);
-				// A non-canonical raw arg must never survive to the bound key; skip when the
-				// arg already IS the canonical form (nothing distinct to exclude).
+				// Skipped when the arg already IS canonical: nothing distinct to exclude.
 				if (arg.trim() !== "rasit") {
 					assert.notInclude(
 						profileRow.params as unknown[],
@@ -140,7 +130,6 @@ describe("Pasaport.lookupProfile — case-insensitive lookup (#2445)", () => {
 
 	it.effect("a genuinely-absent handle still resolves to null (normalize ≠ match-any)", () =>
 		Effect.gen(function* () {
-			// Empty profile-row result ⇒ no row ⇒ null, and the counts never fire.
 			const {access} = capturingAccess(inertD1(), [[]]);
 			const row = yield* Effect.gen(function* () {
 				const pasaport = yield* Pasaport;

--- a/apps/web/worker/features/pasaport/mutations.ts
+++ b/apps/web/worker/features/pasaport/mutations.ts
@@ -1,9 +1,6 @@
 /**
- * Mutation resolvers — the pasaport (identity) write path. `Fate.mutation` def +
- * `Effect.fn` pairs named `entity.verb` (ADR 0020;
- * `.patterns/fate-effect-operations.md`). Validation, constraints, and domain
- * errors stay in `Pasaport.setUsername` (ADR 0013); `CurrentUser.required` gates
- * the write (anonymous → `UNAUTHORIZED`).
+ * Mutation resolvers — the pasaport (identity) write path.
+ * See `.patterns/fate-effect-operations.md`; domain rules live in `Pasaport` (ADR 0013).
  */
 
 import {CurrentUser, Fate, Unauthorized} from "@kampus/fate-effect";
@@ -57,33 +54,20 @@ import {
 } from "./views.ts";
 
 /**
- * Is the #970 user-ban dark-ship flag on for this request? Safe-default `false`
- * (dark), the `funnel.summary` idiom: with the flag off (default / Flagship outage)
- * the ban path fails the invisible `Denied` exactly like a non-admin call, so an
- * unreleased ban can never refuse a real user's session (ADR 0083).
+ * Dark-ship flags for the three admin write paths below. Safe-default `false`, so a
+ * Flagship outage fails each path with the invisible `Denied` a non-admin call gets —
+ * an unreleased ban/role-grant/mark can never touch a real account (ADR 0083).
  */
 const userBanOn = Effect.gen(function* () {
 	const flags = yield* Flags;
 	return yield* flags.getBoolean(PHOENIX_USER_BAN, false).pipe(provideRequestFlags);
 });
 
-/**
- * Is the #3522 platform-role-assign dark-ship flag on for this request? Safe-default
- * `false` (dark), the `userBanOn` idiom: with the flag off (default / Flagship outage)
- * the `user.setRole` path fails the invisible `Denied` exactly like a non-admin call, so
- * an unreleased role-grant can never mint a moderator (ADR 0083).
- */
 const userRoleAssignOn = Effect.gen(function* () {
 	const flags = yield* Flags;
 	return yield* flags.getBoolean(PHOENIX_USER_ROLE_ASSIGN, false).pipe(provideRequestFlags);
 });
 
-/**
- * Is the #2692 admin email-delivery dark-ship flag on for this request? Safe-default
- * `false` (dark), the ban `userBanOn` idiom: with the flag off (default / Flagship
- * outage) the mark/clear path fails the invisible `Denied` exactly like a non-admin
- * call, so an unreleased failing-mark can never touch a real address (ADR 0083).
- */
 const emailDeliveryAdminOn = Effect.gen(function* () {
 	const flags = yield* Flags;
 	return yield* flags.getBoolean(PHOENIX_EMAIL_DELIVERY_ADMIN, false).pipe(provideRequestFlags);
@@ -98,11 +82,9 @@ const SetDisplayNameInput = Schema.Struct({
 });
 
 /**
- * The exact phrase the client must echo to fire `account.delete` (ADR 0097 §4).
- * It is a `Schema.Literal`, so an absent or wrong confirmation is an input-DECODE
- * failure — the mutation body never runs on a malformed/replayed request, and
- * "deleted by accident" is unrepresentable rather than a silent execution. Turkish
- * user-facing copy (the SPA shows it; the user types it back verbatim).
+ * The exact phrase the client must echo to fire `account.delete` (ADR 0097 §4). Used as
+ * a `Schema.Literal`, so a wrong or absent confirmation fails input DECODE and the
+ * mutation body never runs.
  */
 export const ACCOUNT_DELETE_CONFIRMATION = "hesabımı kalıcı olarak sil";
 
@@ -110,9 +92,8 @@ const DeleteAccountInput = Schema.Struct({
 	confirmation: Schema.Literal(ACCOUNT_DELETE_CONFIRMATION),
 });
 
-// The two promotion inputs each name a target by account id. No `tier` arg exists,
-// so a client can never request a target tier — `yazar` is the only destination the
-// server writes (#1203), and the path is the only writer.
+// No `tier` arg by design: `yazar` is the only destination the server writes (#1203),
+// so a client can never request a target tier.
 const PromoteInput = Schema.Struct({
 	userId: UserId,
 });
@@ -121,16 +102,15 @@ const VouchInput = Schema.Struct({
 	candidateId: CandidateId,
 });
 
-// Withdraw names the same target as a vouch — the voucher is the discharged-`Vouch`
-// actor, never an arg, so a yazar can only withdraw their OWN vouch for `candidateId`.
+// No voucher arg: the voucher is the discharged-`Vouch` actor, so a yazar can only
+// withdraw their OWN vouch for `candidateId`.
 const WithdrawVouchInput = Schema.Struct({
 	candidateId: CandidateId,
 });
 
-// Ban a target account by id: a `reason` (required — enforced non-empty in the gated
-// body, `BanReasonRequired`) and an OPTIONAL `expiresAt` epoch-millis (null/omitted =
-// permanent). No `actor` arg — the acting admin is the discharged `Admin` grant's id,
-// never client-supplied, so a ban is always audited against its real author.
+// `expiresAt` is epoch-millis; null/omitted means permanent. No `actor` arg — the acting
+// admin comes from the discharged `Admin` grant, so a ban is always audited against its
+// real author.
 const BanUserInput = Schema.Struct({
 	userId: UserId,
 	reason: Schema.String,
@@ -141,19 +121,15 @@ const UnbanUserInput = Schema.Struct({
 	userId: UserId,
 });
 
-// Assign a target account's platform role by id: `role` is a `Schema.Literal` union, so a
-// value outside {member, moderator} is an input-DECODE failure — the body never runs on a
-// malformed request. No `actor` arg — the acting admin is the discharged `Admin` grant's
-// id, never client-supplied, so a role change is always audited against its real author.
+// No `actor` arg — the acting admin comes from the discharged `Admin` grant, so a role
+// change is always audited against its real author.
 const SetRoleInput = Schema.Struct({
 	userId: UserId,
 	role: Schema.Literals(["member", "moderator"]),
 });
 
-// Mark a target account's address as failing: a `reason` (required — enforced non-empty
-// in the gated body, `EmailFailingReasonRequired`). No `actor`/`address` arg — the target
-// is named by id and its address is server-resolved, so an admin can't mark an arbitrary
-// address, and the acting admin is the discharged `Admin` grant (never client-supplied).
+// No `address` arg — the target's address is server-resolved from its id, so an admin
+// can't mark an arbitrary address.
 const MarkEmailFailingInput = Schema.Struct({
 	userId: UserId,
 	reason: Schema.String,
@@ -180,9 +156,6 @@ export const mutations = {
 			const user = yield* CurrentUser.required;
 			const pasaport = yield* Pasaport;
 			const result = yield* pasaport.setUsername({userId: user.id, value: input.value});
-			// email comes from the session, the rest from the service result; the trusted
-			// standing (tier + moderator signal) and the `User` shape come from the one
-			// shared `toTrustedUser` home `me` also routes through (#1297/#1320).
 			return yield* toTrustedUser({
 				id: result.userId,
 				email: user.email,
@@ -193,23 +166,10 @@ export const mutations = {
 		}),
 	),
 
-	// Change the görünen ad (display name). The write-through half of #2154:
-	// `Pasaport.setDisplayName` updates `user.name` AND `user_profile.display_name`
-	// in lockstep, so a display-name edit reaches the stamped column every author
-	// byline reads (the one-shot-sync defect: display_name was only ever written at
-	// setUsername-time). `CurrentUser.required` gates it (anonymous → `UNAUTHORIZED`);
-	// the target is ALWAYS the caller (`user.id`), never an arg, so renaming someone
-	// else is unrepresentable. Domain validation (empty-name floor) lives in the
-	// service (ADR 0013).
-	//
-	// Publishes a `User` entity reconcile so the owner's OWN open profile/`User` view
-	// (the app-lifetime global live pin, ADR 0094 — `User.id === CurrentUser.id`)
-	// reflects the new name over `/fate/live` without a reload — the same channel
-	// `publishPromotion` uses for a tier flip. This is NOT a fanned-content publish:
-	// the write touches the identity row, not a Post/Comment/Definition, so it is
-	// classified `fanned: false` in the manifest. Denormalized bylines re-resolve
-	// their live identity on the next read (`stampAuthorIdentity`), never over a
-	// per-content live frame. Infallible (publisher error channel is `never`).
+	// The target is ALWAYS the caller (`user.id`), never an arg, so renaming someone else
+	// is unrepresentable. Classified `fanned: false`: the publish below reconciles the
+	// owner's own `User` entity, not a Post/Comment/Definition connection — denormalized
+	// bylines re-resolve on the next read via `stampAuthorIdentity`.
 	"user.setDisplayName": Fate.mutation(
 		{
 			input: SetDisplayNameInput,
@@ -227,22 +187,15 @@ export const mutations = {
 				image: result.image,
 				username: result.username,
 			});
-			// `trusted` is already the wire `User` (`toTrustedUser` → `toUser`), so publish
-			// it inline as the reconcile data — the same byte-identical shape a fresh fetch
-			// yields, masked per-client (the inline-data contract).
 			const live = pasaportLive(yield* WorkerLivePublisher);
 			yield* live.user.update(result.userId, {changed: ["name"], data: trusted});
 			return trusted;
 		}),
 	),
 
-	// Account deletion = anonymize-to-`@[silinen]` (ADR 0097). Synchronous, gated
-	// by `CurrentUser.required` (anonymous → `UNAUTHORIZED`); the target is ALWAYS
-	// the caller (`user.id`) — there is no "delete user X" arg, so anonymizing
-	// someone else is unrepresentable at this surface. The typed-confirmation gate
-	// lives in `DeleteAccountInput` (a `Schema.Literal`): a wrong/absent token fails
-	// input decode before the body runs. The teardown is `Pasaport.anonymizeAccount`
-	// (ADR 0013 — domain logic in the service, not the resolver).
+	// Account deletion = anonymize-to-`@[silinen]` (ADR 0097). The target is ALWAYS the
+	// caller — there is no "delete user X" arg, so deleting someone else is
+	// unrepresentable at this surface.
 	"account.delete": Fate.mutation(
 		{
 			input: DeleteAccountInput,
@@ -257,9 +210,6 @@ export const mutations = {
 		}),
 	),
 
-	// Direct moderator promotion (#1206) — the `Moderate` capability gates it
-	// (`requireModeration`): anonymous or non-moderator → the invisible `Denied`
-	// (`UNAUTHORIZED`), so the surface is invisible to non-moderators.
 	"user.promote": Fate.mutation(
 		{
 			input: PromoteInput,
@@ -271,11 +221,8 @@ export const mutations = {
 		}),
 	),
 
-	// Author-vouch promotion (#1206, tandem extended in #1289) — the `Vouch` capability
-	// gates it (`requireVouch`): a non-yazar → the public `RequiresLevel` (`FORBIDDEN`).
-	// A çaylak therefore can't vouch and a yazar self-vouch is inert (already yazar), so
-	// self-promotion is impossible across both paths. The concurrent-vouch cap (D5) adds
-	// `VouchLimitReached` past the floor.
+	// `requireVouch` admits yazars only, so a çaylak can't vouch and a yazar self-vouch is
+	// inert (already yazar) — self-promotion is impossible across both paths.
 	"user.vouch": Fate.mutation(
 		{
 			input: VouchInput,
@@ -287,10 +234,6 @@ export const mutations = {
 		}),
 	),
 
-	// Withdraw a vouch (#1289) — the `Vouch`-gated inverse of `user.vouch`: a yazar
-	// retracts their own active vouch for `candidateId`, deleting the row and returning
-	// the cap slot. Same yazar floor (`requireVouch`); the receipt is a plain ack
-	// (`promoted:false`, `vouchRecorded:false`) — withdrawing never promotes.
 	"user.withdrawVouch": Fate.mutation(
 		{
 			input: WithdrawVouchInput,
@@ -302,12 +245,8 @@ export const mutations = {
 		}),
 	),
 
-	// Ban an account (#970, admin epic #968) — `requireAdmin`-gated, behind the
-	// `phoenix-user-ban` dark-ship flag. With the flag off the mutation fails the
-	// invisible `Denied` (like a non-admin call), so an unreleased ban never refuses a
-	// real session. The write is the AUDIT record (actor from the discharged grant,
-	// target, reason, time); enforcement — refusing the banned user's existing
-	// sessions — happens at `Pasaport.validateSession`, not here.
+	// This write is only the AUDIT record. Enforcement — refusing the banned user's
+	// existing sessions — happens at `Pasaport.validateSession`, not here.
 	"user.banUser": Fate.mutation(
 		{
 			input: BanUserInput,
@@ -322,9 +261,6 @@ export const mutations = {
 		}),
 	),
 
-	// Unban an account (#970) — the `requireAdmin`-gated, flag-gated reversal. Appends
-	// an audited `unban` event; the banned user's next request re-validates to a live
-	// session. Idempotent (unbanning a not-banned account still reads not-banned).
 	"user.unbanUser": Fate.mutation(
 		{
 			input: UnbanUserInput,
@@ -339,15 +275,9 @@ export const mutations = {
 		}),
 	),
 
-	// Assign a platform role (#3522, admin epic per ADR 0107) — `requireAdmin`-gated,
-	// behind the `phoenix-user-role-assign` dark-ship flag. With the flag off the mutation
-	// fails the invisible `Denied` (like a non-admin call), so an unreleased role-grant can
-	// never mint a moderator. The write is the `moderates` relation tuple (`moderator`
-	// grants it, `member` revokes it) — the SPA-invokable writer #969/PR #1266's offline
-	// mint never gave the console — plus an audited `user_role_event`. Not fanned
-	// (`fanned-mutations.ts`): the tuple/log are an identity/authority surface, not a
-	// subscribed content connection (mirrors `user.banUser`). The derived roster `role`
-	// cell re-reads the same tuple through the gated `UserAdmin` view.
+	// Writes the `moderates` relation tuple (`moderator` grants, `member` revokes) plus an
+	// audited `user_role_event`. Classified `fanned: false`: an identity/authority surface,
+	// not a subscribed content connection (mirrors `user.banUser`).
 	"user.setRole": Fate.mutation(
 		{
 			input: SetRoleInput,
@@ -362,13 +292,8 @@ export const mutations = {
 		}),
 	),
 
-	// Manually mark a target account's address as failing (Child #2692, email-bounce epic
-	// #2687) — `requireAdmin`-gated, behind the `phoenix-email-delivery-admin` dark-ship
-	// flag. With the flag off the mutation fails the invisible `Denied` (like a non-admin
-	// call), so an unreleased mark never touches a real address. The write appends to the
-	// SAME `email_delivery_event` log the send-time capture feeds (one audit trail, one
-	// projection). Not fanned (`fanned-mutations.ts`): the log isn't a subscribed content
-	// connection (mirrors `user.banUser`).
+	// Appends to the SAME `email_delivery_event` log the send-time capture feeds — one
+	// audit trail, one projection. Classified `fanned: false` (mirrors `user.banUser`).
 	"emailDelivery.mark": Fate.mutation(
 		{
 			input: MarkEmailFailingInput,
@@ -383,10 +308,6 @@ export const mutations = {
 		}),
 	),
 
-	// Manually clear a target account's failing address (Child #2692) — the
-	// `requireAdmin`-gated, flag-gated reversal. Appends a `clear` event; idempotent
-	// (clearing a deliverable address still reads deliverable). No reason floor — a clear
-	// carries none.
 	"emailDelivery.clear": Fate.mutation(
 		{
 			input: ClearEmailFailingInput,
@@ -402,11 +323,9 @@ export const mutations = {
 	),
 };
 
-// The post-gate ban body — runnable only with an `Admin` `Grant` in R
-// (`requireAdmin` provides it); `yield* adminOf(grant)` reads the authority-checked
-// actor id the audit row is stamped with, so a ban is never attributed to a
-// client-supplied identity. A blank reason fails `BanReasonRequired` (a ban must
-// carry a reason, epic #968); an unknown target fails `UserNotFound`.
+// Post-gate bodies: runnable only with an `Admin` `Grant` in R, and `adminOf(grant)` is
+// the authority-checked actor id the audit row is stamped with — so an admin write is
+// never attributed to a client-supplied identity.
 const banGated = Effect.fn("user.banGated")(function* (input: typeof BanUserInput.Type) {
 	const grant = yield* Admin;
 	const actorId = yield* adminOf(grant);
@@ -424,9 +343,6 @@ const banGated = Effect.fn("user.banGated")(function* (input: typeof BanUserInpu
 	return toBanState(input.userId, state);
 });
 
-// The post-gate unban body — runnable only with an `Admin` `Grant` in R. Appends the
-// audited `unban` (stamped with the discharged admin's id); `UserNotFound` on an
-// unknown target.
 const unbanGated = Effect.fn("user.unbanGated")(function* (input: typeof UnbanUserInput.Type) {
 	const grant = yield* Admin;
 	const actorId = yield* adminOf(grant);
@@ -435,11 +351,6 @@ const unbanGated = Effect.fn("user.unbanGated")(function* (input: typeof UnbanUs
 	return toBanState(input.userId, state);
 });
 
-// The post-gate role-assign body — runnable only with an `Admin` `Grant` in R
-// (`requireAdmin` provides it); `yield* adminOf(grant)` reads the authority-checked actor
-// id the audit row is stamped with (mirroring `banGated`), so a role change is never
-// attributed to a client-supplied identity. `Pasaport.setRole` writes/clears the
-// `moderates` tuple and appends the audit event; `UserNotFound` on an unknown target.
 const setRoleGated = Effect.fn("user.setRoleGated")(function* (input: typeof SetRoleInput.Type) {
 	const grant = yield* Admin;
 	const actorId = yield* adminOf(grant);
@@ -448,12 +359,6 @@ const setRoleGated = Effect.fn("user.setRoleGated")(function* (input: typeof Set
 	return toRoleState(input.userId, role);
 });
 
-// The post-gate mark body — runnable only with an `Admin` `Grant` in R (`requireAdmin`
-// provides it); `yield* adminOf(grant)` reads the authority-checked actor id the audit row
-// is stamped with (#2734, mirroring `banGated`), so a mark is never attributed to a
-// client-supplied identity. A blank reason fails `EmailFailingReasonRequired` (a manual mark
-// must carry the out-of-band note); an unknown target fails `UserNotFound`. The ack is keyed
-// on the server-resolved address, so the roll-up read reconciles it.
 const markEmailFailingGated = Effect.fn("emailDelivery.markGated")(function* (
 	input: typeof MarkEmailFailingInput.Type,
 ) {
@@ -472,8 +377,6 @@ const markEmailFailingGated = Effect.fn("emailDelivery.markGated")(function* (
 	return toEmailDeliveryState(address, state);
 });
 
-// The post-gate clear body — runnable only with an `Admin` `Grant` in R. Appends a
-// `clear` stamped with the discharged admin's id (#2734); `UserNotFound` on an unknown target.
 const clearEmailFailingGated = Effect.fn("emailDelivery.clearGated")(function* (
 	input: typeof ClearEmailFailingInput.Type,
 ) {
@@ -484,21 +387,15 @@ const clearEmailFailingGated = Effect.fn("emailDelivery.clearGated")(function* (
 	return toEmailDeliveryState(address, state);
 });
 
-// The post-gate moderator-promote body — runnable only with a `Moderate` `Grant` in
-// R (`requireModeration` provides it); `yield* Moderate` IS the authority gate, so
-// promoting without a discharged grant is a compile error (ADR 0107). The tier flip
-// + backlog sweep are the atomic `Pasaport.promoteToYazar` (ADR 0013 — domain logic
-// in the service). The mod path never records a vouch.
+// `yield* Moderate` IS the authority gate: promoting without a discharged grant is a
+// compile error (ADR 0107).
 const promoteGated = Effect.fn("user.promoteGated")(function* (input: typeof PromoteInput.Type) {
 	yield* Moderate;
 	const pasaport = yield* Pasaport;
 	const {promoted} = yield* pasaport.promoteToYazar({userId: input.userId});
-	// Promotion ceremony (#1696): the mod-direct half of the two promotion sites —
-	// notify the promoted member, keyed on `promoted` so a no-op (already-yazar) call
-	// notifies nothing. Swallowed inside the emitter, so it can never fail the flip.
-	// Live propagation (#1886): publish the new `User` tier so an open profile view
-	// reconciles over `/fate/live` without a reload — keyed on `promoted` (a no-op
-	// publishes nothing) and infallible (publisher's error channel is `never`).
+	// Both keyed on `promoted`, so an already-yazar no-op notifies and publishes nothing.
+	// Both are infallible (failures swallowed inside the emitter/publisher), so neither
+	// can fail the committed flip.
 	if (promoted) {
 		yield* notifyPromotion({userId: input.userId});
 		yield* publishPromotion(input.userId);
@@ -506,16 +403,10 @@ const promoteGated = Effect.fn("user.promoteGated")(function* (input: typeof Pro
 	return toPromotionReceipt({userId: input.userId, promoted, vouchRecorded: false});
 });
 
-// The post-gate vouch body — runnable only with a `Vouch` `Grant` in R
-// (`requireVouch` provides it). The concurrent-vouch cap (D5) is enforced atomically
-// INSIDE `VouchLedger.castVouch` (#1362, ADR 0013) — the resolver no longer reads the
-// active count and re-derives the cap, it just maps the outcome: `capReached` →
-// `VouchLimitReached`, otherwise the vouch landed (the vouching actor preserved via
-// `voucherOf`) and we run the order-independent `resolveTandem` — the SAME promotion
-// path the karma side (#1288) fires, so a vouch placed while karma is already over the
-// bar promotes immediately and a below-bar vouch is recorded but flips nothing (it waits
-// for the karma-side trigger). `alreadyVouched` is the idempotent re-vouch — a success
-// that consumes no fresh slot, so `vouchRecorded` is false.
+// The concurrent-vouch cap is enforced atomically INSIDE `VouchLedger.castVouch` (#1362);
+// this body only maps the outcome, and must not re-derive the cap from an active count.
+// `resolveTandem` is the SAME promotion path the karma side (#1288) fires, so ordering
+// doesn't matter: an over-bar vouch promotes now, a below-bar one waits for karma.
 const vouchGated = Effect.fn("user.vouchGated")(function* (input: typeof VouchInput.Type) {
 	const grant = yield* Vouch;
 	const voucherId = yield* voucherOf(grant);
@@ -536,9 +427,7 @@ const vouchGated = Effect.fn("user.vouchGated")(function* (input: typeof VouchIn
 	}
 
 	const {promoted} = yield* resolveTandem(input.candidateId);
-	// Rite feedback (#1695): a RECORDED vouch (never the idempotent `alreadyVouched`
-	// re-vouch) notifies the vouched çaylak — self-suppressed, flag-gated and
-	// swallowed inside the emitter, so it can never fail this committed vouch.
+	// Only a RECORDED vouch notifies — the idempotent `alreadyVouched` re-vouch must not.
 	if (outcome === "recorded") {
 		yield* notifyKefil({candidateId: input.candidateId, voucherId});
 	}
@@ -549,10 +438,8 @@ const vouchGated = Effect.fn("user.vouchGated")(function* (input: typeof VouchIn
 	});
 });
 
-// The post-gate withdraw body — runnable only with a `Vouch` `Grant` in R. Deletes the
-// voucher's own vouch for `candidateId` (returning the cap slot); idempotent, and never
-// promotes. Withdrawing the only active vouch before the bar is crossed is what
-// prevents a later karma-side promotion — `resolveTandem` then reads no active vouch.
+// Withdrawing the only active vouch before the karma bar is crossed is what prevents a
+// later karma-side promotion: `resolveTandem` then reads no active vouch.
 const withdrawGated = Effect.fn("user.withdrawGated")(function* (
 	input: typeof WithdrawVouchInput.Type,
 ) {

--- a/apps/web/worker/features/pasaport/ordering.ts
+++ b/apps/web/worker/features/pasaport/ordering.ts
@@ -1,24 +1,18 @@
 /**
- * Pasaport `Profile.contributions` ordering — the single source the view
- * `orderBy` and the service keyset both derive from (ADR 0019; see
- * `db/ordering.ts`). The contributions feed merges three tables
- * (definition/post/comment) under one global `createdAt desc, id desc` order, so
- * the ordering is parameterized over the table whose columns it names. The
- * view's nominal `orderBy` derives from the same declaration (`viewOrderBy`
- * reads only the field name + direction, never the Drizzle column).
+ * The one ordering the `Profile.contributions` view `orderBy` and the service keyset both
+ * derive from (ADR 0019). It is parameterized over the table because the feed merges
+ * three of them under one global order.
  */
 
 import type {DataViewOrderBy} from "@nkzw/fate/server";
 import * as schema from "../../db/drizzle/schema.ts";
 import {type Ordering, viewOrderBy} from "../../db/ordering.ts";
 
-/** A table the contributions feed merges over — each keyset by its own columns. */
 export type ContributionTable =
 	| typeof schema.definitionRecord
 	| typeof schema.postRecord
 	| typeof schema.commentRecord;
 
-/** The contributions ordering for one merged table: `createdAt desc, id desc`. */
 export function contributionOrdering(table: ContributionTable): Ordering {
 	return [
 		{field: "createdAt", column: table.createdAt, dir: "desc"},
@@ -27,9 +21,8 @@ export function contributionOrdering(table: ContributionTable): Ordering {
 }
 
 /**
- * The nominal `Profile.contributions` view `orderBy`, derived from the same
- * ordering the keyset uses (`viewOrderBy` reads only field name + direction, so
- * any merged table yields the identical `[{createdAt: "desc"}, {id: "desc"}]`).
+ * `viewOrderBy` reads only field name + direction, so passing any one of the merged
+ * tables yields the identical view ordering.
  */
 export const CONTRIBUTION_VIEW_ORDER_BY: DataViewOrderBy = viewOrderBy(
 	contributionOrdering(schema.definitionRecord),

--- a/apps/web/worker/features/pasaport/pasaport-ids.typetest.ts
+++ b/apps/web/worker/features/pasaport/pasaport-ids.typetest.ts
@@ -1,19 +1,15 @@
 /**
- * Type-level assertion (no runtime — checked by `tsgo`, not vitest): the pasaport
- * vouch-flow ids `UserId` and `CandidateId` are nominally distinct, so transposing
- * the acting user's id and the vouch candidate's id is a compile error (#2714 AC#2),
- * while both stay plain strings at runtime. Mirrors `../kunye/admin.typetest.ts`.
+ * A type-level assertion with no runtime, checked by `tsgo` rather than vitest:
+ * transposing a `UserId` and a `CandidateId` must be a compile error (#2714), even though
+ * both are plain strings at runtime.
  */
 import {expectTypeOf} from "vitest";
 import type {UserId} from "../../lib/ids.ts";
 import type {CandidateId} from "./ids.ts";
 
-// Both brands erase to `string` at runtime — the brand is type-only (#2735).
 expectTypeOf<UserId>().toMatchTypeOf<string>();
 expectTypeOf<CandidateId>().toMatchTypeOf<string>();
 
-// The distinctness that makes a userId/candidateId swap unrepresentable: neither
-// brand is assignable to the other, so the vouch pairing can't be transposed.
 expectTypeOf<UserId>().not.toEqualTypeOf<CandidateId>();
 expectTypeOf<UserId>().not.toMatchTypeOf<CandidateId>();
 expectTypeOf<CandidateId>().not.toMatchTypeOf<UserId>();

--- a/apps/web/worker/features/pasaport/profile-counts-sandbox.unit.test.ts
+++ b/apps/web/worker/features/pasaport/profile-counts-sandbox.unit.test.ts
@@ -1,33 +1,13 @@
 /**
- * `Pasaport.hydrateProfile` headline-count sandbox-visibility wiring (#1312) — the
- * security fix sibling to #1309. The public profile HEADLINE counts
- * (`definitionCount` / `postCount` / `commentCount` on `ProfileView`) are computed
- * by `hydrateProfile` via `countByAuthor` across the three content tables. Each
- * count must carry the #1205 {@link sandboxVisibleWhere} predicate beside its
- * existing `removed_at IS NULL` guard, resolved against the request viewer — so a
- * visitor never learns HOW MANY un-promoted (sandboxed) contributions a çaylak has,
- * and the header agrees with the (#1309-fixed) feed for the same viewer.
+ * Headline-count sandbox-visibility wiring (#1312) — a visitor must not learn HOW MANY
+ * sandboxed contributions a çaylak has. The predicate SEMANTICS are proven in
+ * `SandboxVisibility.unit.test.ts`; what THIS proves is that every `countByAuthor`
+ * WIRES the predicate in, for every viewer kind, and that the header and the feed's
+ * `totalCount` share one count so they cannot disagree.
  *
- * Unit-tier per ADR 0082: the predicate SEMANTICS (who sees what) are already proven
- * by `SandboxVisibility.unit.test.ts`; what THIS test proves is that the COUNT path
- * WIRES that predicate into every `countByAuthor` for every viewer kind, and that the
- * SAME viewer-aware count backs both the header (`lookupProfile`) and the feed's
- * `totalCount` (`listContributions`), so the two are consistent.
- *
- * `countByAuthor` resolves through `.then()` (a Promise, no `.toSQL()`), so unlike the
- * feed SELECTs its SQL can't be captured off the query builder — instead the count
- * statements execute against a RECORDING D1 binding whose `prepare(sql)` captures the
- * compiled SQL + bound params. The profile-row read (a builder, scripted) never hits
- * the binding, so the recorded set is exactly the three count statements.
- *
- * The viewer matrix (the count leak is closed iff):
- *   - anonymous / public — `sandboxed_at IS NULL` (live only, no viewer arm).
- *   - other member — `sandboxed_at IS NULL OR author_id = :viewerId`: the own arm is
- *     keyed to the VIEWER (not the profiled author), so it counts none of the çaylak's
- *     sandboxed rows ⇒ live-only.
- *   - the author (viewing own profile) — same predicate, but `author_id = :viewerId`
- *     now matches ALL their own rows ⇒ they DO count their own sandboxed content.
- *   - moderator — no sandbox restriction (`undefined` ⇒ dropped by `and()`) ⇒ full count.
+ * `countByAuthor` resolves through `.then()`, so its SQL cannot be captured off the
+ * query builder like the feed SELECTs. Instead the counts execute against a RECORDING
+ * D1 binding; the builder reads never hit it, so `recorded` is exactly the counts.
  */
 import {assert, describe, it} from "@effect/vitest";
 import {drizzle} from "drizzle-orm/d1";
@@ -55,10 +35,8 @@ interface RecordedQuery {
 	params: unknown[];
 }
 
-// A D1 binding that records the SQL + bound params of every statement it EXECUTES.
-// The `countByAuthor` reads resolve through `.then()` ⇒ they execute here, so their
-// compiled SQL lands in `recorded`; the feed/profile-row builders are captured off
-// `.toSQL()` and never executed against this binding.
+// Records the SQL + bound params of every statement it EXECUTES — so the `.then()`
+// counts land in `recorded` and the `.toSQL()` builders never do.
 function recordingD1(): {binding: D1Database; recorded: RecordedQuery[]} {
 	const recorded: RecordedQuery[] = [];
 	// biome-ignore lint/plugin: `D1Database` is a host binding that can't be structurally constructed; only SQL compilation + bind recording is exercised, results are inert.
@@ -93,11 +71,9 @@ function recordingD1(): {binding: D1Database; recorded: RecordedQuery[]} {
 	return {binding, recorded};
 }
 
-// Drives a Pasaport method over scripted `run` results: a query BUILDER (the
-// profile-row / feed SELECT) is captured off `.toSQL()` and resolved to its scripted
-// result without executing; a count PROMISE (`countByAuthor`'s `.then()`) is awaited
-// so it executes against the recording binding (firing `prepare`), then resolved to
-// its scripted result. `batch` is unreachable on these read paths.
+// Drives a Pasaport method over scripted `run` results: a query BUILDER is captured
+// off `.toSQL()` without executing; a count PROMISE is awaited so it executes against
+// the recording binding.
 function scriptedAccess(
 	binding: D1Database,
 	results: ReadonlyArray<unknown>,
@@ -146,17 +122,12 @@ const PROFILE_ROW = {
 	totalKarma: 0,
 };
 
-// `lookupProfile` issues: 1 profile-row SELECT (builder, scripted) then 3
-// `countByAuthor` reads (def/post/comment) — four scripted `run` results. Only the
-// three counts execute against the recording binding.
+// `lookupProfile` issues 1 profile-row SELECT then 3 counts — four scripted results.
 const lookupResults = [[PROFILE_ROW], 0, 0, 0] as const;
 
-// `listContributions` issues: 3 feed SELECTs (builders) then 3 `countByAuthor`
-// totals — six scripted results; only the three totals execute against the binding.
+// `listContributions` issues 3 feed SELECTs then 3 count totals — six scripted results.
 const feedResults = [[], [], [], 0, 0, 0] as const;
 
-// Run `lookupProfile` for `AUTHOR` as seen by `sandboxViewer`; return the three
-// recorded headline-count statements.
 const recordHeaderCounts = (sandboxViewer: SandboxViewer) =>
 	Effect.gen(function* () {
 		const {binding, recorded} = recordingD1();
@@ -168,8 +139,6 @@ const recordHeaderCounts = (sandboxViewer: SandboxViewer) =>
 		return recorded;
 	});
 
-// Run `listContributions` for `AUTHOR` as seen by `sandboxViewer`; return the three
-// recorded `totalCount` statements (the feed SELECTs don't hit the binding).
 const recordFeedCounts = (sandboxViewer: SandboxViewer) =>
 	Effect.gen(function* () {
 		const {binding, recorded} = recordingD1();
@@ -181,11 +150,8 @@ const recordFeedCounts = (sandboxViewer: SandboxViewer) =>
 		return recorded;
 	});
 
-// Run `lookupProfileById` (the by-id relation fetch path the `profileSource.byId`
-// loader drives) for `AUTHOR` as seen by `sandboxViewer`; return the three recorded
-// headline-count statements. Same shape as `recordHeaderCounts` (1 profile-row SELECT
-// then 3 counts) — the SAME `hydrateProfile`/`countByAuthor`, reached by id rather than
-// by username (#1406).
+// The by-id relation fetch path (#1406): same shape as `recordHeaderCounts`, reached
+// by id rather than by username.
 const recordByIdCounts = (sandboxViewer: SandboxViewer) =>
 	Effect.gen(function* () {
 		const {binding, recorded} = recordingD1();
@@ -231,8 +197,8 @@ describe("Pasaport headline counts — every count filters the sandbox (the #131
 					/"sandboxed_at" is null[)\s]*or[\s(]*"[a-z_]+"\."author_id" = \?/,
 					"sandboxed-or-own predicate is wired",
 				);
-				// The own arm is keyed to the VIEWER, not the profiled author — so it counts
-				// none of the çaylak's sandboxed rows ⇒ the visitor's count is live-only.
+				// The own arm binds the VIEWER, not the profiled author, so none of the
+				// çaylak's sandboxed rows are counted.
 				assert.include(params as unknown[], OTHER, "own-content arm bound to the viewer id");
 			}
 		}),
@@ -244,8 +210,7 @@ describe("Pasaport headline counts — every count filters the sandbox (the #131
 			for (const {sql, params} of counts) {
 				const s = sql.toLowerCase();
 				assert.match(s, /"sandboxed_at" is null[)\s]*or[\s(]*"[a-z_]+"\."author_id" = \?/);
-				// viewerId === authorId, so `author_id = :viewerId` matches ALL the author's
-				// rows — including sandboxed — so they count their own sandboxed content.
+				// viewerId === authorId here, so the own arm matches all their rows.
 				assert.include(params as unknown[], AUTHOR, "own-content arm bound to the author");
 			}
 		}),
@@ -280,10 +245,8 @@ describe("Pasaport headline counts — every count filters the sandbox (the #131
 });
 
 describe("Pasaport — headline counts AGREE with the feed totalCount per-viewer (#1312 AC#3)", () => {
-	// The header (`lookupProfile`→`hydrateProfile`) and the feed's `totalCount`
-	// (`listContributions`) both flow through the SAME `countByAuthor(table, author,
-	// viewer)`, so for any given viewer the three count statements are byte-identical —
-	// the header total can never disagree with what the feed exposes.
+	// Header and feed both flow through the SAME `countByAuthor`, so per viewer the three
+	// statements are byte-identical and the two totals cannot disagree.
 	for (const [name, sandboxViewer] of Object.entries(viewers)) {
 		it.effect(`${name} — header count SQL === feed totalCount SQL`, () =>
 			Effect.gen(function* () {
@@ -302,8 +265,7 @@ describe("Pasaport — headline counts AGREE with the feed totalCount per-viewer
 
 const normQuery = (qs: RecordedQuery[]) => qs.map((q) => ({sql: q.sql, params: q.params}));
 
-// Length-guarded indexed access (noUncheckedIndexedAccess): the recorded count set
-// fires in def/post/comment order, so index 0/1/2 is the definition/post/comment read.
+// The recorded counts fire in def/post/comment order, so index 0/1/2 is that read.
 const nthQuery = (qs: RecordedQuery[], i: number): RecordedQuery => {
 	const q = qs[i];
 	if (!q) throw new Error(`expected a recorded count statement at index ${i}`);
@@ -311,12 +273,8 @@ const nthQuery = (qs: RecordedQuery[], i: number): RecordedQuery => {
 };
 
 describe("Pasaport — counts AGREE across fetch paths (root by-username vs by-id, #1406)", () => {
-	// `profileSource.byId` (the relation `.ref` path) computes its counts via the SAME
-	// `lookupProfileById`→`hydrateProfile`→`countByAuthor` as the root `queries.profile`
-	// by-username read, so for any given viewer the three count statements are
-	// byte-identical — the by-id path can never disagree with the root query for the same
-	// viewer+profile. This pins AC#1: byId resolves the same definition/post/comment count
-	// as the root query.
+	// The by-id relation path shares `hydrateProfile`/`countByAuthor` with the root
+	// by-username query, so per viewer the two produce byte-identical count statements.
 	for (const [name, sandboxViewer] of Object.entries(viewers)) {
 		it.effect(`${name} — by-username header count SQL === by-id count SQL`, () =>
 			Effect.gen(function* () {
@@ -333,10 +291,8 @@ describe("Pasaport — counts AGREE across fetch paths (root by-username vs by-i
 });
 
 describe("Pasaport — countByAuthor routes through the #1359/0113 seam (#1406)", () => {
-	// The post count carries the draft arm (`is_draft`) via `postVisibleWhere` (ADR 0113),
-	// while definition/comment counts route through `sandboxVisibleWhere` (no draft
-	// dimension on those tables). The three counts fire in def/post/comment order, so the
-	// MIDDLE statement is the post count.
+	// Only the post count carries the draft arm (`postVisibleWhere`, ADR 0113); the other
+	// two tables have no draft dimension. Counts fire def/post/comment, so post is MIDDLE.
 	it.effect("only the post count carries the draft arm (is_draft); def/comment do not", () =>
 		Effect.gen(function* () {
 			const counts = yield* recordByIdCounts(viewers.otherMember);
@@ -356,9 +312,7 @@ describe("Pasaport — countByAuthor routes through the #1359/0113 seam (#1406)"
 			Effect.gen(function* () {
 				const postCount = nthQuery(yield* recordByIdCounts(viewers.otherMember), 1);
 				const s = postCount.sql.toLowerCase();
-				// The draft arm's own-content branch is keyed to the VIEWER (`author_id =
-				// :viewerId`), bound to OTHER — never the profiled author — so none of the
-				// çaylak's drafts are counted for a visitor.
+				// The draft own-arm binds the VIEWER, so none of the çaylak's drafts count.
 				assert.match(s, /"is_draft" is not 1[)\s]*or[\s(]*"[a-z_]+"\."author_id" = \?/);
 				assert.include(
 					postCount.params as unknown[],
@@ -372,8 +326,7 @@ describe("Pasaport — countByAuthor routes through the #1359/0113 seam (#1406)"
 		Effect.gen(function* () {
 			const postCount = nthQuery(yield* recordByIdCounts(viewers.author), 1);
 			const s = postCount.sql.toLowerCase();
-			// viewerId === authorId, so the draft own-arm `author_id = :viewerId` matches
-			// every one of the author's rows — drafts included — so they count their own.
+			// viewerId === authorId here, so the draft own-arm matches their own rows.
 			assert.match(s, /"is_draft" is not 1[)\s]*or[\s(]*"[a-z_]+"\."author_id" = \?/);
 			assert.include(postCount.params as unknown[], AUTHOR, "draft own-arm bound to the author");
 		}),

--- a/apps/web/worker/features/pasaport/profile-fields.ts
+++ b/apps/web/worker/features/pasaport/profile-fields.ts
@@ -1,21 +1,14 @@
 /**
- * `Profile`'s one field map — the single declaration of `Profile`'s wire field
- * set, which the row's construction site (`Pasaport.hydrateProfile`, pinned
- * `satisfies ProfileRow`), the wire shaper (`toProfile` in `shapers.ts`), and the
- * view field declaration (`ProfileView` in `views.ts`) all derive from, so a
- * one-field change touches this map instead of three hand-synced restatements
- * (#1545, the pasaport half of fate-wire epic #1332). Shaped on
- * `sozluk/definition-fields.ts`.
+ * `Profile`'s one field map — the row construction site, the wire shaper, and the
+ * view field declaration all derive from it, so a one-field change touches this file
+ * instead of three hand-synced restatements.
  *
- * Unlike `User`, a `Profile` row has no single DB record to read from — it is
- * assembled from a `user_profile` identity row plus three computed authored-content
- * counts — so there is no record→row reader map; `ProfileRow` IS the single source.
- * The one read-time divergence is the client normalization key `id` (=== `userId`),
- * stamped by `toProfile`; `id` is therefore not on `ProfileRow` but is part of the
- * pinned view field set below.
+ * A `Profile` has no single DB record behind it (identity row + three computed
+ * counts), so `ProfileRow` IS the source. The one divergence is the client
+ * normalization key `id` (=== `userId`), stamped by `toProfile`: not on the row, but
+ * part of the pinned view field set below.
  */
 
-/** The assembled profile row: the identity tuple plus the three content counts. */
 export interface ProfileRow {
 	userId: string;
 	username: string;
@@ -28,12 +21,9 @@ export interface ProfileRow {
 }
 
 /**
- * The view/wire scalar field selection (`{id: true, …}`) — a static literal (fate's
- * `FateDataView` reads the literal field map off this). `satisfies Record<keyof
- * ProfileRow | "id", true>` pins it to exactly the row's fields plus the `id`
- * normalization key: dropping one here (or adding one to `ProfileRow` without
- * listing it) is a compile error, so the view stays in lockstep with the row.
- * `contributions` is the list relation, declared structurally in `views.ts`.
+ * Must stay a static literal — fate's `FateDataView` reads the field map off it. The
+ * `satisfies` pins it to exactly the row's fields plus `id`, so dropping one here (or
+ * adding one to `ProfileRow` without listing it) is a compile error.
  */
 export const profileViewFields = {
 	id: true,

--- a/apps/web/worker/features/pasaport/promote-live.testing.ts
+++ b/apps/web/worker/features/pasaport/promote-live.testing.ts
@@ -1,25 +1,16 @@
 /**
- * `livePromoteContext` — the shared test layer for the #1886 post-promote
- * live-publish. Any promotion case that reaches a `promoted: true` flip now fires
- * `publishPromotion`, which re-resolves the promoted `User` (`Pasaport.getUsersByIds`
- * + the `moderatorsAmong` `RelationStore.hasSubjects` join) and publishes through
- * `LivePublisher`. This bundles a fail-safe default for all three so an existing
- * case that only ASSERTS on the notification/receipt keeps compiling and passing
- * without re-scripting each seam.
- *
- * A case that ASSERTS on the published frame builds its own recording
- * `LivePublisher` instead (see `promote-live.unit.test.ts`).
+ * The shared test layer for the post-promote live-publish. Any promotion case reaching a
+ * `promoted: true` flip fires `publishPromotion`, which touches three seams; this bundles a
+ * fail-safe default for all of them so a case that only asserts on the notification keeps
+ * passing without re-scripting each seam. A case that ASSERTS on the published frame builds
+ * its own recording `LivePublisher` instead.
  */
 import {RelationStore} from "@kampus/authz";
 import {LivePublisher} from "@kampus/fate-effect";
 import {Effect, Layer} from "effect";
 import {livePublisherFor} from "../fate-live/live-publisher.ts";
 
-/**
- * A silently-succeeding `LivePublisher` — delivery is a no-op and `waitUntil`
- * drops the detached work; a case that reaches a landed flip publishes into the
- * void, so the publish neither fails nor is asserted on here.
- */
+/** Delivery is a no-op and `waitUntil` drops the detached work — a publish into the void. */
 export const noopLive: Layer.Layer<LivePublisher> = Layer.succeed(LivePublisher)(
 	livePublisherFor({
 		publish: () => Effect.void,
@@ -28,9 +19,8 @@ export const noopLive: Layer.Layer<LivePublisher> = Layer.succeed(LivePublisher)
 );
 
 /**
- * A `RelationStore` where nobody moderates — the `isModerator` re-resolve join
- * reads `hasSubjects`; a promoted yazar need not be a moderator, so the empty
- * membership is the realistic default. `has` stays fail-on-contact (unreached).
+ * Nobody moderates: a promoted yazar need not be a moderator, so empty membership is the
+ * realistic default. `has` stays fail-on-contact (unreached).
  */
 export const relationStoreNoModerators: Layer.Layer<RelationStore> = Layer.succeed(RelationStore, {
 	has: () => Effect.die(new Error("moderatorsAmong reads hasSubjects, not has")),
@@ -39,9 +29,8 @@ export const relationStoreNoModerators: Layer.Layer<RelationStore> = Layer.succe
 });
 
 /**
- * The bundle a landed-flip case needs so `publishPromotion`'s three seams resolve:
- * the no-op publisher + the no-moderators relation store. `Pasaport.getUsersByIds`
- * is provided by the case's own `makePasaportStub` (the record the flip promoted).
+ * `Pasaport.getUsersByIds` is provided by the case's own `makePasaportStub` (the record the
+ * flip promoted), so only the other two seams are bundled here.
  */
 export const livePromoteContext: Layer.Layer<LivePublisher | RelationStore> = Layer.mergeAll(
 	noopLive,

--- a/apps/web/worker/features/pasaport/promote-live.ts
+++ b/apps/web/worker/features/pasaport/promote-live.ts
@@ -1,31 +1,14 @@
 /**
- * The shared post-promote live-publish (#1886) — the ONE helper both promotion
- * sites call after a committed çaylak→yazar tier flip so an open profile/`User`
- * view reconciles the new `tier` over `/fate/live` without a manual reload.
+ * The ONE post-promote live publish both promotion sites call after a committed çaylak→yazar
+ * tier flip, so an open profile reconciles the new `tier` over `/fate/live`. Two triggers
+ * flip the same tier — the mod-direct `user.promote` path and the author-vouch tandem — and
+ * MUST propagate identically; do not fix one and leave the other stale.
  *
- * Two triggers flip the same tier through `Pasaport.promoteToYazar` and MUST
- * propagate live identically (do not fix one and leave the other stale):
- *   - the mod-direct `user.promote` path (`mutations.ts` `promoteGated`), and
- *   - the order-independent author-vouch tandem (`tandem.ts` `resolveTandem`),
- *     itself fired from both `user.vouch` and the divan karma vote (#1289).
+ * The frame carries the re-resolved trusted `User` inline, shaped by the SAME `toUser` the
+ * read paths use, so it is byte-identical to a fresh fetch (.patterns/fate-live-views.md).
  *
- * Factoring the publish here (rather than duplicating it at each call site) is
- * the #1886 acceptance's "factor a shared helper so both paths publish".
- *
- * The published frame carries the freshly re-resolved trusted `User` entity
- * inline: `getUsersWithModerationByIds` re-reads the row (the same trusted read
- * the by-id `userSource` uses, with the flipped `tier` + `isModerator` joined),
- * then `toUser` stamps the `__typename`-carrying wire shape — the SAME shaper the
- * read paths use, so the live frame is byte-identical to a fresh fetch and each
- * subscribed client masks it to its own selection with no re-resolution (the
- * inline-data contract, `.patterns/fate-live-views.md`). `changed: ["tier"]`
- * names the field the flip touched.
- *
- * The publish CANNOT fail the tier flip: `WorkerLivePublisher.update`'s error
- * channel is `never` by contract (`.patterns/fate-effect-server.md`), so this
- * helper's whole effect is infallible — a live-seam hiccup never rolls back a
- * committed promotion. Callers key it on `promoted` (a no-op already-yazar flip
- * publishes nothing).
+ * The publish cannot fail the tier flip: `WorkerLivePublisher.update`'s error channel is
+ * `never` by contract (.patterns/fate-effect-server.md).
  */
 
 import {Effect} from "effect";
@@ -34,13 +17,7 @@ import {pasaportLive} from "./live.ts";
 import {toUser} from "./shapers.ts";
 import {getUsersWithModerationByIds} from "./trusted-user.ts";
 
-/**
- * Publish the promoted member's `User` tier update. Re-resolves the trusted
- * `User` row for `userId`, shapes it through `toUser`, and fires
- * `live.update("User", userId, {changed: ["tier"], data})`. A missing row (raced
- * deletion) publishes nothing — `getUsersWithModerationByIds` returns no row, so
- * there is no entity to send.
- */
+// A missing row (raced deletion) publishes nothing.
 export const publishPromotion = Effect.fn("pasaport.publishPromotion")(function* (userId: string) {
 	const rows = yield* getUsersWithModerationByIds([userId]);
 	const row = rows[0];

--- a/apps/web/worker/features/pasaport/promote-live.unit.test.ts
+++ b/apps/web/worker/features/pasaport/promote-live.unit.test.ts
@@ -1,21 +1,9 @@
 /**
- * Post-promote live-publish coverage (#1886) — the çaylak→yazar tier flip must
- * publish a `User` entity update so an open profile view reconciles the new
- * `tier` over `/fate/live` without a manual reload. This pins the shared
- * `publishPromotion` helper BOTH promotion triggers call, driven through a
- * recording `LivePublisher`:
+ * The çaylak→yazar tier flip must publish a `User` entity update so an open profile
+ * view reconciles the new tier over `/fate/live` without a reload.
  *
- *   - the entity topic is the promoted member's `User` topic (`liveEntityTopic`),
- *     so the app-lifetime global live pin's `User` subscription refreshes;
- *   - a no-op flip (already-yazar, `promoted: false`) publishes NOTHING extra
- *     (the caller keys the publish on `promoted`, exactly as `notifyPromotion`);
- *   - a DYING publish CANNOT fail the committed flip (the publisher's error
- *     channel is `never` — the seam swallows and logs, ADR 0039).
- *
- * The publish is fire-and-forget through `waitUntil`; `scheduled` collects the
- * detached work and the test drains it before asserting (the same pattern
- * `sozluk/definition-mutation.unit.test.ts` uses). Ports are scripted stubs — no
- * DB; the real-D1 re-resolution fidelity is the integration tier.
+ * The publish is fire-and-forget through `waitUntil`, so `scheduled` collects the
+ * detached work and each test drains it before asserting.
  */
 import {assert, describe, it} from "@effect/vitest";
 import {RelationStore} from "@kampus/authz";
@@ -32,16 +20,14 @@ class DrainRejected extends Schema.TaggedErrorClass<DrainRejected>()("test/Drain
 	cause: Schema.Unknown,
 }) {}
 
-// A `RelationStore` where nobody moderates — `moderatorsAmong` (the `isModerator`
-// join in `getUsersWithModerationByIds`) reads `hasSubjects`, and a promoted yazar
-// need not be a moderator, so an empty membership is the realistic default.
+// Nobody moderates: a promoted yazar need not be a moderator, so empty membership is
+// the realistic default.
 const relationStoreEmpty: Layer.Layer<RelationStore> = Layer.succeed(RelationStore, {
 	has: () => Effect.succeed(false),
 	hasSubjects: () => Effect.succeed(new Set<string>()),
 	subjectsOf: () => Effect.succeed(new Set<string>()),
 });
 
-// One `user` record the re-resolve reads back — the promoted member, now `yazar`.
 const promotedRecord = {
 	id: "u-target",
 	email: "u-target@kamp.us",
@@ -55,9 +41,6 @@ const pasaportWithUser = makePasaportStub({
 	getUsersByIds: () => Effect.succeed([promotedRecord]),
 });
 
-// A recording `LivePublisher`: `publish` captures the topic key the resolver's
-// `live.update` chose; `waitUntil` collects the fire-and-forget work so the test
-// drains it (the publish is detached off the request path).
 const recordingLive = () => {
 	const recorded: Array<string> = [];
 	const scheduled: Array<Promise<unknown>> = [];
@@ -75,8 +58,7 @@ const recordingLive = () => {
 	return {layer, recorded, scheduled};
 };
 
-// A `LivePublisher` whose delivery DIES — proves the swallow-with-log seam keeps
-// `publishPromotion` infallible (the flip already committed).
+// Delivery DIES — proves the swallow seam keeps `publishPromotion` infallible.
 const dyingLive = () => {
 	const scheduled: Array<Promise<unknown>> = [];
 	const layer = Layer.succeed(LivePublisher)(
@@ -99,9 +81,8 @@ describe("publishPromotion — the shared post-promote live-publish (#1886)", ()
 				try: () => Promise.allSettled(scheduled),
 				catch: (cause) => new DrainRejected({cause}),
 			}).pipe(Effect.orDie);
-			// The `User` entity topic keyed on the promoted id — what the global live pin
-			// (`.patterns/fate-live-consistency.md#global-pin`) subscribes, so the profile view
-			// reconciles the new tier live.
+			// The topic the global live pin subscribes — see
+			// `.patterns/fate-live-consistency.md#global-pin`.
 			assert.deepStrictEqual(recorded, [liveEntityTopic("User", "u-target")]);
 		}).pipe(Effect.provide(Layer.mergeAll(pasaportWithUser, relationStoreEmpty, layer)));
 	});
@@ -129,8 +110,6 @@ describe("publishPromotion — the shared post-promote live-publish (#1886)", ()
 	it.effect("a DYING publish cannot fail the committed flip (the seam AC)", () => {
 		const {layer, scheduled} = dyingLive();
 		return Effect.gen(function* () {
-			// The helper itself must succeed even though delivery dies — the failure is
-			// caught on the detached promise, never surfacing into this effect.
 			yield* publishPromotion("u-target");
 			yield* Effect.tryPromise({
 				try: () => Promise.allSettled(scheduled),

--- a/apps/web/worker/features/pasaport/promotion-mutation.unit.test.ts
+++ b/apps/web/worker/features/pasaport/promotion-mutation.unit.test.ts
@@ -1,15 +1,7 @@
 /**
- * `user.promote` / `user.vouch` WIRE-boundary coverage (#1206) — the promotion
- * authority + tandem decisions that are wrong-or-right with no database (ADR 0082),
- * driven through the real external interface (`resolveWire`: decode + the
- * `encodeWireError` class→wire-code seam), so a denial's wire `code` is what a client
- * gets and a mis-annotated `[FateWireCode]` is a unit failure.
- *
- * Covers the acceptance matrix: direct mod promotion (server-enforced), vouch above
- * the reduced bar (promoted) vs below (recorded, NOT promoted) — the tandem, and that
- * an unprivileged actor cannot self-promote (a non-mod → invisible `UNAUTHORIZED`; a
- * çaylak vouching → public `FORBIDDEN`). The atomic backlog sweep itself is
- * `promotion-sweep.unit.test.ts`; real-D1 fidelity is the integration tier.
+ * `user.promote` / `user.vouch` WIRE-boundary coverage (#1206, ADR 0082): driven through
+ * `resolveWire` so a denial's wire `code` is what a client actually gets and a
+ * mis-annotated `[FateWireCode]` is a unit failure.
  */
 import {assert, describe, it} from "@effect/vitest";
 import {
@@ -36,9 +28,7 @@ import {makePasaportStub} from "./Pasaport.testing.ts";
 import {noopLive, relationStoreNoModerators} from "./promote-live.testing.ts";
 
 // A landed flip re-resolves the promoted `User` for the #1886 live-publish, so a
-// `promoted: true` stub answers `getUsersByIds` (the record it promoted, now
-// `yazar`); these cases already provide their own `RelationStore`, so only the
-// no-op `LivePublisher` (`noopLive`) is added to their layer set.
+// `promoted: true` stub must answer `getUsersByIds`.
 const promotedUsersByIds = (id: string) => ({
 	getUsersByIds: () =>
 		Effect.succeed([
@@ -54,8 +44,8 @@ const runtimeContextStub: BaseRuntimeContext = {
 	set: (id) => Effect.succeed(id),
 };
 
-// The kefil/terfi emitters (notifyKefil / notifyPromotion) read the `phoenix-bildirim`
-// flag, so every case still provides a Flags service — on, so the deliver path runs.
+// The kefil/terfi emitters read the `phoenix-bildirim` flag, so every case needs Flags —
+// on, so the deliver path runs.
 const flagsOn: Layer.Layer<Flags> = Layer.succeed(
 	Flags,
 	// biome-ignore lint/plugin: a Flags test double — only getBoolean is exercised here.
@@ -69,7 +59,6 @@ const flagsOn: Layer.Layer<Flags> = Layer.succeed(
 
 const agentAuthorityStub = Layer.succeed(AgentAuthority, {admits: () => Effect.succeed(false)});
 
-// A `RelationStore` where exactly `holders` hold the `moderates` relation on platform.
 const relationStoreOf = (holders: ReadonlyArray<string>): Layer.Layer<RelationStore> =>
 	Layer.succeed(RelationStore, {
 		has: (tuple) =>
@@ -81,7 +70,6 @@ const relationStoreOf = (holders: ReadonlyArray<string>): Layer.Layer<RelationSt
 		subjectsOf: ({relation}) => Effect.succeed(new Set(relation === "moderates" ? holders : [])),
 	});
 
-// A `Kunye` whose standing/karma answer by id.
 const kunyeOf = (
 	tierById: Record<string, Tier>,
 	karmaById: Record<string, number>,
@@ -92,12 +80,9 @@ const kunyeOf = (
 		rootOf: (id: string) => Effect.succeed(id),
 	});
 
-// Both promotion mutations now reach the #1886 live-publish through their shared
-// promote path, so `LivePublisher` is a static requirement of EVERY case (even a
-// denial that never runs the flip). `noopLive` satisfies it universally here; the
-// vouch/withdraw cases (no `RelationStore` of their own) add `relationStoreNone`.
-// The kefil (vouch) emit now consults `bildirimMutedBy` (#3238), which reads `Mute` —
-// an empty-set stub means no member is muted, so the deliver path is unchanged.
+// `LivePublisher` is a static requirement of EVERY case, even a denial that never runs
+// the flip. The kefil emit consults `bildirimMutedBy` (#3238), so `Mute` is required too;
+// an empty set means nobody is muted and the deliver path is unchanged.
 const noMutes = Layer.succeed(Mute, {
 	set: () => Effect.die("Mute.set not exercised"),
 	listMine: () => Effect.die("Mute.listMine not exercised"),
@@ -180,8 +165,6 @@ describe("user.promote — direct moderator promotion", () => {
 describe("user.vouch — author-vouch tandem", () => {
 	const yazarVoucher = {tier: {"u-yazar": "yazar"} as Record<string, Tier>};
 
-	// The KARMA-FIRST tandem order: karma is already over the bar, so placing the vouch
-	// promotes on the vouch act itself (through the shared `resolveTandem`).
 	it.effect(
 		"karma-first: vouch with karma already over the bar promotes; the vouch is recorded (actor preserved)",
 		() =>
@@ -235,10 +218,8 @@ describe("user.vouch — author-vouch tandem", () => {
 		),
 	);
 
-	// The concurrent-vouch cap (D5): the cap is owned by `VouchLedger.castVouch` (#1362),
-	// so a yazar at the cap gets a `capReached` outcome the resolver maps to the public
-	// VOUCH_LIMIT_REACHED. The default `has`/`activeCountFor` are fail-on-contact, proving
-	// the resolver no longer re-derives the cap from the active count.
+	// The default `has`/`activeCountFor` stay fail-on-contact, proving the resolver no
+	// longer re-derives the cap from the active count (#1362).
 	it.effect("a yazar at the concurrent-vouch cap is denied a 4th — VOUCH_LIMIT_REACHED", () =>
 		Effect.gen(function* () {
 			const exit = yield* vouch("u-fourth").pipe(Effect.exit);
@@ -262,9 +243,6 @@ describe("user.vouch — author-vouch tandem", () => {
 		),
 	);
 
-	// Re-vouching an already-vouched candidate is the idempotent `alreadyVouched` outcome —
-	// a success that consumes no fresh slot, so `vouchRecorded` is false and no tier flips
-	// below the bar.
 	it.effect("re-vouching an already-vouched candidate is allowed (idempotent, no fresh slot)", () =>
 		Effect.gen(function* () {
 			const receipt = yield* vouch("u-existing");
@@ -376,9 +354,6 @@ describe("user.withdrawVouch — releasing the slot", () => {
 	);
 });
 
-// Rite feedback (#1695): a RECORDED vouch notifies the vouched çaylak through the
-// bildirim spine (kind `kefil`, target = the çaylak's own account) — never on the
-// idempotent `alreadyVouched`, and never able to fail the committed vouch.
 describe("user.vouch — kefil bildirimi (#1695)", () => {
 	const yazarVoucher = {tier: {"u-yazar": "yazar"} as Record<string, Tier>};
 
@@ -443,10 +418,6 @@ describe("user.vouch — kefil bildirimi (#1695)", () => {
 	);
 });
 
-// Promotion ceremony (#1696): the mod-direct promotion path — a landed tier flip
-// notifies the promoted member (kind `terfi`, target = their own account, no actor
-// identity), keyed on the flip's `promoted: true` so a no-op notifies nothing, and
-// never able to fail the committed promotion.
 describe("user.promote — terfi bildirimi (#1696)", () => {
 	const promotionRecording = () => {
 		const emits: NotificationRecordInput[] = [];

--- a/apps/web/worker/features/pasaport/promotion-sweep.unit.test.ts
+++ b/apps/web/worker/features/pasaport/promotion-sweep.unit.test.ts
@@ -1,23 +1,8 @@
 /**
- * `Pasaport.promoteToYazar` backlog-sweep coverage (#1206) — the load-bearing
- * correctness concern: the tier flip and the sandbox sweep are ONE atomic D1 batch
- * (ADR 0014), and every statement is *conditional*, which is what makes the
- * promotion idempotent and a mixed backlog land consistent. Proven by rendering the
- * batch's `.toSQL()` over a no-op D1 (the `Pano.connection.unit.test.ts` idiom) —
- * no engine, so this is a unit test; a real-D1 promote-twice / mixed-content
- * fidelity test (the `account-deletion.test.ts` precedent) is a follow-up in the
- * integration tier.
- *
- * The three structural guarantees asserted here:
- *   - **Atomic.** All four writes go through a single `batch`, so the world never
- *     sees a tier flipped with the backlog half-swept (or the reverse).
- *   - **Idempotent.** The tier UPDATE is guarded `tier = 'çaylak'` and the sweep
- *     `sandboxed_at IS NOT NULL` — so a re-run (promote twice) matches zero rows and
- *     `promoted` reads false the second time.
- *   - **Mixed-content-safe.** The sweep WHERE is exactly the #1205 backlog predicate
- *     (`sandboxed_at IS NOT NULL AND removed_at IS NULL AND author_id = ?`), so it
- *     flips only this author's still-sandboxed, not-removed rows — live rows
- *     (`sandboxed_at` already null) and removed rows (`removed_at` set) are untouched.
+ * `Pasaport.promoteToYazar` backlog-sweep coverage — the tier flip and the sandbox sweep
+ * are ONE atomic D1 batch (ADR 0014) and every statement is conditional, which is what
+ * makes a re-promote idempotent and a mixed backlog land consistent. Proven by rendering
+ * the batch's `.toSQL()` over a no-op D1, so no engine runs and this stays unit tier.
  */
 import {assert, describe, it} from "@effect/vitest";
 import {drizzle} from "drizzle-orm/d1";
@@ -31,9 +16,7 @@ import {
 } from "../../db/Drizzle.ts";
 import {type BetterAuthInstance, makePasaportLive, Pasaport} from "./Pasaport.ts";
 
-// A real drizzle client over a no-op D1 — used ONLY to render the batch statements'
-// `.toSQL()`; it never executes (the scripted `batch` renders, then returns a fake
-// per-statement result).
+// A real drizzle client over a no-op D1, used ONLY to render `.toSQL()`; nothing executes.
 // biome-ignore lint/plugin: `D1Database` is a host binding that can't be structurally constructed in a fake; nothing here executes against it.
 const noopD1 = {
 	prepare: () => ({
@@ -61,8 +44,7 @@ const renderDb = drizzle(noopD1, {relations});
 
 const inertAuth = {} as BetterAuthInstance;
 
-// Captures the batch's rendered statements and answers with a scripted per-statement
-// result whose first element's `meta.changes` drives `promoted`.
+// The first result's `meta.changes` is what drives `promoted`.
 function capturingBatch(tierChanges: number): {
 	access: DrizzleAccess;
 	statements: () => {sql: string; params: unknown[]}[];
@@ -77,8 +59,8 @@ function capturingBatch(tierChanges: number): {
 				const renderable = s as unknown as {toSQL: () => {sql: string; params: unknown[]}};
 				captured.push(renderable.toSQL());
 			}
-			// A fake per-statement batch result — the method reads only `.meta.changes`;
-			// the real generic `BatchResult` shape isn't reconstructable in a no-engine double.
+			// The method reads only `.meta.changes`; the real `BatchResult` shape is not
+			// reconstructable in a no-engine double.
 			const result = stmts.map((_, i) => ({meta: {changes: i === 0 ? tierChanges : 0}}));
 			return Effect.succeed(result as never);
 		},
@@ -127,8 +109,6 @@ describe("Pasaport.promoteToYazar — atomic, idempotent backlog sweep", () => {
 				const pasaport = yield* Pasaport;
 				yield* pasaport.promoteToYazar({userId: "u-caylak"});
 
-				// `promoted_at` is stamped inside statement 0 — the tier flip — so it commits
-				// in the same guarded UPDATE (WHERE tier = 'çaylak') and the same atomic batch.
 				const tier = cap.statements()[0];
 				assert.isTrue(tier !== undefined);
 				if (tier === undefined) return;
@@ -136,9 +116,8 @@ describe("Pasaport.promoteToYazar — atomic, idempotent backlog sweep", () => {
 				assert.match(sql, /set[\s\S]*"promoted_at"\s*=\s*\?/); // stamps promoted_at…
 				assert.match(sql, /where[\s\S]*"tier"/); // …only when the tier actually flips (guarded)
 
-				// And it is the ONLY statement that touches promoted_at — no unconditional
-				// write exists, so a non-promoting call (statement 0 matches 0 rows) stamps
-				// nothing and promoted_at stays null.
+				// It must also be the ONLY statement touching promoted_at, or an unconditional
+				// write would stamp on a non-promoting call.
 				const stmtsTouchingPromotedAt = cap
 					.statements()
 					.filter((s) => s.sql.toLowerCase().includes("promoted_at"));
@@ -150,9 +129,7 @@ describe("Pasaport.promoteToYazar — atomic, idempotent backlog sweep", () => {
 	it.effect(
 		"a non-promoting call (already-yazar / unknown) leaves promoted_at null — the only promoted_at write is the guarded UPDATE that matched 0 rows",
 		() => {
-			// `capturingBatch(0)` scripts the guarded tier UPDATE to match 0 rows (already
-			// yazar). The stamp rides that same guarded statement, so 0 changes ⇒ 0 rows
-			// stamped ⇒ promoted_at untouched (null preserved).
+			// 0 = the guarded tier UPDATE matched no rows (already yazar).
 			const cap = capturingBatch(0);
 			return Effect.gen(function* () {
 				const pasaport = yield* Pasaport;

--- a/apps/web/worker/features/pasaport/queries.ts
+++ b/apps/web/worker/features/pasaport/queries.ts
@@ -1,9 +1,7 @@
 /**
- * Pasaport root query resolvers — `me`, `profile(username)`,
- * `myAuthorshipStanding`. `Fate.query` def + `Effect.fn` pairs
- * (`.patterns/fate-effect-operations.md`); they return shaped output directly (not
- * masked through a source), so the resolver builds the selected wire shape including
- * nested connections.
+ * Pasaport's root query resolvers (see .patterns/fate-effect-operations.md). They
+ * return shaped output directly rather than masking through a source, so each
+ * resolver builds the selected wire shape itself, nested connections included.
  */
 
 import {CurrentUser, Fate, Unauthorized} from "@kampus/fate-effect";
@@ -29,7 +27,6 @@ import {AuthorshipStandingView, BanStateView, ProfileView, UserView} from "./vie
 
 const CONTRIBUTIONS_PAGE_SIZE = 20;
 
-/** Is the #970 user-ban dark-ship flag on for this request? Safe-default `false` (dark). */
 const userBanOn = Effect.gen(function* () {
 	const flags = yield* Flags;
 	return yield* flags.getBoolean(PHOENIX_USER_BAN, false).pipe(provideRequestFlags);
@@ -49,34 +46,27 @@ const ProfileArgs = Schema.Struct({
 export const queries = {
 	me: Fate.query(
 		{type: UserView, error: Unauthorized},
-		// The current user, resolved through the shared {@link resolveMeUser} seam (ADR 0185):
-		// the canonical row read fresh (so a just-set `username` round-trips before better-auth's
-		// session inference), the SELF failing-delivery signal (#2693), and the trusted tier +
-		// moderator standing — the SAME resolution the edge `__BOOT__.user` injection reuses.
+		// Shared with the edge `__BOOT__.user` injection (ADR 0185). The row is read fresh
+		// so a just-set `username` round-trips before better-auth infers it.
 		Effect.fn("me")(function* () {
 			const user = yield* CurrentUser.required;
 			return yield* resolveMeUser(user);
 		}),
 	),
-	// `contributions` is delivered inline (not via a source `connection`
-	// capability) because the native path doesn't auto-invoke a hand-built
-	// source's nested `connection` (see fate-connections.md). Returns `null` for
-	// an unknown username; the SPA renders its 404.
+	// `contributions` is delivered inline rather than through a source `connection`
+	// capability, because the native path doesn't auto-invoke a hand-built source's
+	// nested connection. See .patterns/fate-connections.md.
 	profile: Fate.query(
 		{args: ProfileArgs, type: ProfileView},
 		Effect.fn("profile")(function* ({args, select}) {
 			const pasaport = yield* Pasaport;
-			// Resolve the sandbox viewer once (identity + moderator probe) and thread
-			// the SAME viewer into BOTH the headline counts (`lookupProfile` ->
-			// `hydrateProfile`, #1312) and the contribution feed (#1309), so a visitor
-			// never sees this author's sandboxed content and the header counts agree
-			// with the feed for that viewer. Only the author + a moderator see the full
-			// (live + sandboxed) counts.
+			// The SAME viewer must thread into both the headline counts and the
+			// contribution feed, or the header disagrees with the feed for that viewer
+			// (#1309/#1312). Only the author and a moderator see sandboxed content.
 			const sandboxViewer = yield* currentSandboxViewer;
 			const row = yield* pasaport.lookupProfile(args.username, {sandboxViewer});
 			if (!row) return null;
 
-			// `id` === `userId` is stamped once, in `toProfile`.
 			const base = toProfile(row);
 
 			if (!hasNestedSelection(select, "contributions")) {
@@ -97,19 +87,11 @@ export const queries = {
 			return {...base, contributions};
 		}),
 	),
-	// The çaylak-SELF "yazarlığa giden yol" aggregate (#1316, epic #1202) — the
-	// read the #1291 status block consumes. The subject is ALWAYS the authenticated
-	// reader (`CurrentUser.required`, no input arg), so it can only ever describe the
-	// reader's own standing — reading another user's self-status is unrepresentable.
-	//
-	// It is additive and does NOT relax `requireDivanAccess` — a çaylak still cannot
-	// read `divan.roster`/`divan.backlog`.
-	//
-	// One-way-glass is structural (`AuthorshipStanding` carries no identity field):
-	// `vouchExists` is a bare boolean off `VouchLedger.hasActiveFor` (never WHO
-	// vouched), `inReviewCount` a bare count off `Pasaport.countInReview` (never which
-	// items / who is reviewing), `bar` the vouch-aware promotion bar so the frontend
-	// never hardcodes it.
+	// The subject is always the authenticated reader and there is no input arg, so
+	// reading another user's standing is unrepresentable. The one-way glass is
+	// structural too: the view carries no identity field, only a bare `vouchExists`
+	// boolean (never who vouched) and a bare count (never which items, or who is
+	// reviewing them).
 	myAuthorshipStanding: Fate.query(
 		{type: AuthorshipStandingView, error: Unauthorized},
 		Effect.fn("myAuthorshipStanding")(function* () {
@@ -133,10 +115,8 @@ export const queries = {
 		}),
 	),
 
-	// The admin ban-state read (#970, epic #968) — `requireAdmin`-gated, behind the
-	// `phoenix-user-ban` dark-ship flag. The moderator UI reads it to show whether the
-	// focused actor is banned + the reason. With the flag off it fails the invisible
-	// `Denied` (like a non-admin call), so the read never leaks ban-state until release.
+	// With the dark-ship flag off this fails the same invisible `Denied` a non-admin
+	// call gets, so the read leaks no ban-state before release (#970).
 	"user.banState": Fate.query(
 		{args: BanStateArgs, type: BanStateView, error: Schema.Union([Denied])},
 		Effect.fn("user.banState")(function* ({args}) {
@@ -148,9 +128,8 @@ export const queries = {
 	),
 };
 
-// The post-gate ban-state read — runnable only with an `Admin` `Grant` in R
-// (`requireAdmin` provides it); `yield* Admin` requires the proof, so reading an
-// account's ban-state without a discharged grant is a compile error (ADR 0107).
+// `yield* Admin` requires the grant proof in R, so reading an account's ban-state
+// without a discharged grant is a compile error (ADR 0107).
 const banStateGated = Effect.fn("user.banStateGated")(function* (userId: UserId) {
 	yield* Admin;
 	const pasaport = yield* Pasaport;

--- a/apps/web/worker/features/pasaport/queries.unit.test.ts
+++ b/apps/web/worker/features/pasaport/queries.unit.test.ts
@@ -1,15 +1,10 @@
 /**
- * Unit coverage for the pasaport `me` resolver's auth gate — the anonymous →
- * `UNAUTHORIZED` boundary, proven with NO database (ADR 0082). The litmus: the
- * gate is wrong-or-right independent of the DB — `CurrentUser.required` fails
- * before any `Pasaport` read — so it belongs at `unit`, not on a database.
+ * Unit coverage for the pasaport `me` resolver's auth gate — the anonymous → `UNAUTHORIZED`
+ * boundary, proven with NO database (ADR 0082).
  *
- * The `me` op runs through `resolveWire` — its real external interface (`resolve`
- * decode + the `encodeWireError` class→wire-code seam) — over an anonymous
- * `CurrentUser` and a fail-on-contact `Pasaport` sentinel: the sentinel proves the
- * gate short-circuits the DB read (a reached read would `die` → `INTERNAL_SERVER_ERROR`,
- * not `UNAUTHORIZED`). Asserting the WIRE `code` (not the typed `Unauthorized`
- * instance one layer in) is what makes a mis-annotated `[FateWireCode]` a unit failure.
+ * `me` runs through `resolveWire` (decode + the `encodeWireError` class→wire-code seam), so the
+ * assertion is on the WIRE `code`, not the typed `Unauthorized` instance one layer in — that is
+ * what makes a mis-annotated `[FateWireCode]` a unit failure.
  */
 
 import {it} from "@effect/vitest";
@@ -26,34 +21,25 @@ import type {UserRow} from "./Pasaport.ts";
 import {Pasaport} from "./Pasaport.ts";
 import {queries} from "./queries.ts";
 
-// Fail-on-contact `Pasaport`: any method call dies, so a passing test proves the
-// gate never reached the DB (a reached read would `die`, not `Unauthorized`).
-// `as never` widens the partial stub to the full service shape — the anon path
-// touches none of these methods.
+// Fail-on-contact: any method call dies, so a passing test proves the gate never reached the DB.
+// `as never` widens the partial stub — the anon path touches none of these methods.
 const failOnContactPasaport = {
 	getUserById: () => Effect.die("Pasaport.getUserById must not be reached on the anon gate"),
 } as never;
 
-// Same intent for `Kunye`: the anon gate fails at `CurrentUser.required` before
-// any tier read, so a reached `tierOf` would `die` (not `Unauthorized`).
 const failOnContactKunye = {
 	tierOf: () => Effect.die("Kunye.tierOf must not be reached on the anon gate"),
 } as never;
 
-// Same intent for `RelationStore`: the anon gate short-circuits before the
-// `isModerator` read (#1320), so a reached `has` would `die` (not `Unauthorized`).
 const failOnContactRelationStore = {
 	has: () => Effect.die("RelationStore.has must not be reached on the anon gate"),
 } as never;
 
-// A `RelationStore` answering a fixed moderator verdict for any tuple — the
-// `(subject, "moderates", platform)` membership the `me` resolver reads `isModerator`
-// off (#1320). `true` ⇒ the subject is a platform moderator, `false` ⇒ not.
+// A fixed verdict for the `(subject, "moderates", platform)` membership `me` reads (#1320).
 const relationStoreReturning = (isMod: boolean) => ({has: () => Effect.succeed(isMod)}) as never;
 
-// A stored account row carrying a given authorship tier. The `me` resolver reads
-// `getUserById` twice — once for the canonical row, once inside `Kunye.tierOf` —
-// so this single stub backs both reads.
+// The `me` resolver reads `getUserById` twice — canonical row, then inside `Kunye.tierOf` — so
+// this single stub backs both reads.
 const storedUser = (tier: StoredTier): UserRow => ({
 	id: "u1",
 	email: "u1@kamp.us",
@@ -63,9 +49,7 @@ const storedUser = (tier: StoredTier): UserRow => ({
 	tier,
 });
 
-// The `me` resolver also reads the SELF failing-delivery signal (#2693) via
-// `getEmailDeliveryState`; deliverable by default so the tier/isModerator paths run
-// unaffected. `deliveryState` overrides it for the emailFailing coverage below.
+// Deliverable by default so the tier/isModerator paths run unaffected (#2693).
 const pasaportWithStoredTier = (
 	tier: StoredTier,
 	deliveryState: {failing: boolean; reason: string | null} = DELIVERABLE,
@@ -75,10 +59,8 @@ const pasaportWithStoredTier = (
 		getEmailDeliveryState: () => Effect.succeed({address: "u1@kamp.us", state: deliveryState}),
 	}) as never;
 
-// Drive `me` to the resolved wire object's `tier` scalar over the REAL `Kunye`
-// (KunyeLive) layered on a stored-tier Pasaport stub — exercising the trusted
-// `getUserById → Kunye.tierOf → view` read path end to end. A non-moderator
-// `RelationStore` backs the orthogonal `isModerator` read so the `tier` path runs.
+// Drives `me` over the REAL `Kunye` on a stored-tier Pasaport stub — the trusted
+// `getUserById → Kunye.tierOf → view` path end to end.
 const resolveMeTier = (user: CurrentUserInfo, pasaport: never) =>
 	resolveWire(queries.me, {args: undefined, select: ["id", "tier"]}).pipe(
 		Effect.provideService(CurrentUser, {user}),
@@ -88,10 +70,6 @@ const resolveMeTier = (user: CurrentUserInfo, pasaport: never) =>
 		Effect.map((me) => (me as {tier: string}).tier),
 	);
 
-// Drive `me` to the resolved wire object's `isModerator` scalar (#1320) — the SELF
-// moderator signal read off the `moderates` relation tuple via `RelationStore`,
-// keyed on the current user. The `relationStore` stub fixes the membership verdict;
-// `tier` rides the same stored-tier Pasaport stub so a dual-role case is expressible.
 const resolveMeIsModerator = (user: CurrentUserInfo, pasaport: never, relationStore: never) =>
 	resolveWire(queries.me, {args: undefined, select: ["id", "isModerator"]}).pipe(
 		Effect.provideService(CurrentUser, {user}),
@@ -112,9 +90,6 @@ it.effect(
 				Effect.provideService(RelationStore, failOnContactRelationStore),
 				Effect.exit,
 			);
-			// The wire `UNAUTHORIZED` a client sees — derived by `encodeWireError` from the
-			// `Unauthorized` class's `[FateWireCode]` annotation, not the typed instance one
-			// layer in. A defect from a reached DB read would be `INTERNAL_SERVER_ERROR`.
 			assert.isTrue(Exit.isFailure(exit));
 			if (Exit.isFailure(exit)) {
 				const error = Cause.findErrorOption(exit.cause);
@@ -128,8 +103,6 @@ it.effect(
 
 it.effect("me carries tier from the stored column via Kunye.tierOf, NOT the session field", () =>
 	Effect.gen(function* () {
-		// Session claims `yazar`; the stored column says `çaylak`. The trusted read
-		// must win — proving the resolver ignores the `input:false` session tier (#1297).
 		const sessionUserClaimingYazar = {
 			id: "u1",
 			email: "u1@kamp.us",
@@ -163,10 +136,8 @@ it.effect("me ranks a row-missing principal as visitor (Kunye.tierOf fallback)",
 			name: "U One",
 			image: null,
 		} satisfies CurrentUserInfo;
-		// No stored row → both the canonical read and Kunye.tierOf see null → visitor,
-		// the read-time rank the column can never store. `getEmailDeliveryState` fails
-		// `UserNotFound` for the row-missing address, which the `me` resolver catches to a
-		// deliverable signal (proving the catch keeps the read from crashing).
+		// No stored row → visitor, the read-time rank the column can never store. `getEmailDeliveryState`
+		// fails `UserNotFound` here, which the resolver catches to a deliverable signal.
 		const noRowPasaport = {
 			getUserById: () => Effect.succeed(null),
 			getEmailDeliveryState: () => new UserNotFound({message: "kullanıcı bulunamadı"}),
@@ -176,10 +147,8 @@ it.effect("me ranks a row-missing principal as visitor (Kunye.tierOf fallback)",
 	}),
 );
 
-// #1320 — the SELF moderator signal, read off the `moderates` relation tuple (the
-// trusted source `Moderate.over(platform)` checks), self-only, never inferred from
-// `tier`. The dual-role case is the founding author-mod (#1207): `tier: "yazar"` AND
-// `isModerator: true` — exactly what `tier` alone cannot express.
+// #1320 — the SELF moderator signal, read off the `moderates` tuple, never inferred from `tier`:
+// the founding author-mod (#1207) is `tier: "yazar"` AND `isModerator: true`.
 const u1: CurrentUserInfo = {id: "u1", email: "u1@kamp.us", name: "U One", image: null};
 
 it.effect("me carries isModerator true for a dual-role yazar+moderator (the #1207 cohort)", () =>
@@ -215,8 +184,7 @@ it.effect("me carries isModerator false for a yazar who holds no moderates tuple
 	}),
 );
 
-// #2693 — the SELF failing-delivery signal the membrane notice reads. Stamped on the
-// `me` read from #2691's projection, self-scoped so it can only describe the reader.
+// #2693 — the SELF failing-delivery signal, self-scoped so it can only describe the reader.
 const resolveMeEmailFailing = (pasaport: never) =>
 	resolveWire(queries.me, {args: undefined, select: ["id", "emailFailing"]}).pipe(
 		Effect.provideService(CurrentUser, {user: u1}),

--- a/apps/web/worker/features/pasaport/role-mutation.unit.test.ts
+++ b/apps/web/worker/features/pasaport/role-mutation.unit.test.ts
@@ -1,18 +1,11 @@
 /**
- * `user.setRole` WIRE-boundary coverage (#3522, admin epic per ADR 0107) — the
- * authority + dark-ship decisions that are wrong-or-right with no database (ADR 0082),
- * driven through the real external interface (`resolveWire`: decode + the
- * `encodeWireError` class→wire-code seam), so a denial's wire `code` is what a client
- * gets. Mirrors `ban-mutation.unit.test.ts`.
+ * `user.setRole` WIRE-boundary coverage (#3522), driven through `resolveWire` so the
+ * assertions are on the wire `code` a client actually gets.
  *
- * The load-bearing AC (#3522): setRole FAILS CLOSED for a non-admin caller — a
- * non-holder of the `admin` relation and the anonymous actor both get the invisible
- * `UNAUTHORIZED` (they can't tell "not admin" from "not signed in", ADR 0098 §2), and
- * neither reaches the write (the `Pasaport` stub is fail-on-contact). Plus the dark-ship:
- * with the `phoenix-user-role-assign` flag OFF the path is inert (fails `Denied` before
- * any authority check or write), so an unreleased role-grant never runs. The admin path
- * reaches `Pasaport.setRole` and echoes the assigned role. The real-D1 tuple write→read
- * round-trip (the roster re-reading the `moderates` tuple) is an integration concern.
+ * The load-bearing AC: setRole FAILS CLOSED. A non-admin and the anonymous actor get the
+ * SAME invisible `UNAUTHORIZED` — neither can tell "not admin" from "not signed in" (ADR
+ * 0098 §2) — and neither reaches the write. With the dark-ship flag off the path is inert
+ * before any authority check. The real-D1 tuple round-trip is an integration concern.
  */
 import {assert, describe, it} from "@effect/vitest";
 import {
@@ -53,7 +46,6 @@ const flagsStub = (on: boolean): Layer.Layer<Flags> =>
 
 const agentAuthorityStub = Layer.succeed(AgentAuthority, {admits: () => Effect.succeed(false)});
 
-// A `RelationStore` where exactly `holders` hold the `admin` relation on platform.
 const adminStoreOf = (holders: ReadonlyArray<string>): Layer.Layer<RelationStore> =>
 	Layer.succeed(RelationStore, {
 		has: (tuple) => Effect.succeed(tuple.relation === "admin" && holders.includes(tuple.subject)),
@@ -82,7 +74,7 @@ const wireCodeOf = (cause: Cause.Cause<unknown>): unknown => {
 	return error._tag === "Some" ? (error.value as {code?: unknown}).code : undefined;
 };
 
-// A `Pasaport` that fails on ANY contact — proving a denied path never reached the write.
+// Fails on ANY contact, so a denied path that reached the write fails the test.
 const noWriteReached = Layer.mergeAll(makePasaportStub(), agentAuthorityStub);
 
 describe("user.setRole — admin authority (fail closed)", () => {
@@ -159,7 +151,7 @@ describe("user.setRole — admin authority (fail closed)", () => {
 		Effect.gen(function* () {
 			const exit = yield* setRole("u-target", "moderator").pipe(Effect.exit);
 			assert.isTrue(Exit.isFailure(exit));
-			// Flag-off is the invisible Denied (UNAUTHORIZED), the same code a non-admin sees.
+			// Flag-off must be indistinguishable from a non-admin denial.
 			if (Exit.isFailure(exit)) assert.strictEqual(wireCodeOf(exit.cause), "UNAUTHORIZED");
 		}).pipe(
 			Effect.provide(

--- a/apps/web/worker/features/pasaport/route.ts
+++ b/apps/web/worker/features/pasaport/route.ts
@@ -1,7 +1,6 @@
 /**
- * `* /api/auth/*` — better-auth, as a raw-`Request` `HttpRouter.add` route (ADR
- * 0027). Delegates to the `BetterAuth` tag's `.fetch` `HttpEffect`, which forwards
- * the request to `auth.handler(...)` — same auth realm and D1 tables as
+ * `* /api/auth/*` — better-auth, as a raw-`Request` `HttpRouter.add` route (ADR 0027). Delegates
+ * to the `BetterAuth` tag's `.fetch`, so it shares the auth realm and D1 tables with
  * `Pasaport.validateSession`.
  */
 import * as BetterAuth from "@alchemy.run/better-auth";

--- a/apps/web/worker/features/pasaport/set-display-name.unit.test.ts
+++ b/apps/web/worker/features/pasaport/set-display-name.unit.test.ts
@@ -1,20 +1,11 @@
 /**
- * `Pasaport.setDisplayName` — the görünen-ad write-through (#2154). The load-bearing
- * correctness concern is LOCKSTEP: the better-auth field the settings surface reads
- * (`user.name`) and the stamped column every author byline reads
- * (`user_profile.display_name`) move in ONE atomic D1 batch, so they can never
- * diverge — the one-shot-sync defect this closes (display_name was written only at
- * `setUsername`-time and never re-synced).
+ * `Pasaport.setDisplayName` — the görünen-ad write-through. The load-bearing concern is
+ * LOCKSTEP: the better-auth field the settings surface reads (`user.name`) and the stamped
+ * column every author byline reads (`user_profile.display_name`) move in ONE atomic D1
+ * batch, so they can never diverge — the one-shot-sync defect this closes.
  *
- * Proven by rendering the batch's `.toSQL()` over a no-op D1 (the
- * `promotion-sweep.unit.test.ts` idiom) — no engine, so this is a unit test; the
- * execute-and-read-back byline convergence over real D1 is the integration tier
- * (`tests/integration/pasaport.test.ts`).
- *
- * This test fails WITHOUT the write-through: with no `setDisplayName` the service
- * shape doesn't compile, and a write that touched only `user.name` (the old
- * `authClient.updateUser` path) would emit a single statement, never the
- * `user_profile.display_name` write this pins.
+ * Proven by rendering the batch's `.toSQL()` over a no-op D1; the execute-and-read-back
+ * convergence over real D1 is the integration tier.
  */
 import {assert, describe, it} from "@effect/vitest";
 import {drizzle} from "drizzle-orm/d1";
@@ -29,8 +20,7 @@ import {
 import {DisplayNameEmpty} from "./errors.ts";
 import {type BetterAuthInstance, makePasaportLive, Pasaport} from "./Pasaport.ts";
 
-// A real drizzle client over a no-op D1 — used ONLY to render the batch statements'
-// `.toSQL()`; it never executes (the `promotion-sweep.unit.test.ts` renderer).
+// A real drizzle client over a no-op D1, used ONLY to render `.toSQL()`; it never executes.
 // biome-ignore lint/plugin: `D1Database` is a host binding that can't be structurally constructed in a fake; nothing here executes against it.
 const noopD1 = {
 	prepare: () => ({
@@ -58,9 +48,8 @@ const renderDb = drizzle(noopD1, {relations});
 
 const inertAuth = {} as BetterAuthInstance;
 
-// A `run` that replays the single `user.findFirst` read the method makes before the
-// batch, and a `batch` that captures the rendered statements. `existingUser` scripts
-// the pre-read (null ⇒ the UserNotFound path, which never reaches the batch).
+// Replays the single pre-batch `user.findFirst` read and captures the rendered batch
+// statements. `existingUser` scripts that read (null ⇒ the UserNotFound path, no batch).
 function capturing(
 	existingUser: {id: string; username: string | null; image: string | null} | null,
 ): {
@@ -113,9 +102,8 @@ describe("Pasaport.setDisplayName — lockstep display-name write-through (#2154
 			assert.match(u, /"name"\s*=\s*\?/);
 			assert.include(userUpdate.params as unknown[], "Yeni Ad");
 
-			// Statement 1: the STAMPED column every author byline reads — the write that
-			// was missing before this fix. An upsert (insert…on conflict) so a user with
-			// no profile row still gets a populated display_name.
+			// Statement 1: the STAMPED column every author byline reads — the write that was missing
+			// before this fix. An upsert, so a user with no profile row still gets a display_name.
 			const p = profileUpsert.sql.toLowerCase();
 			assert.match(p, /insert\s+into\s+"user_profile"/);
 			assert.match(p, /on\s+conflict/);

--- a/apps/web/worker/features/pasaport/shapers.ts
+++ b/apps/web/worker/features/pasaport/shapers.ts
@@ -1,7 +1,7 @@
 /**
- * Pasaport wire-entity shapers. Every `{__typename, …}` literal is built here,
- * once, so the read/write paths can't drift out of byte-for-byte agreement
- * (`.patterns/fate-effect-operations.md`).
+ * Pasaport wire-entity shapers. Every `{__typename, …}` literal is built here, once,
+ * so the read and write paths can't drift apart
+ * (.patterns/fate-effect-operations.md).
  */
 
 import type {PlatformRole} from "../kunye/moderate.ts";
@@ -26,10 +26,8 @@ import type {
 	User,
 } from "./views.ts";
 
-// `emailFailing` (#2693) rides here like the other resolver-stamped fields: truthful on
-// the self `me` read, a flat `false` on every other `User` (the by-id batch stamps it),
-// so a non-self row never carries another account's delivery-state. Its single home is
-// `user-fields.ts`'s `UserFields.emailFailing`.
+// `emailFailing` is truthful only on the self `me` read and a flat `false` on every
+// other `User`, so a row never carries another account's delivery-state (#2693).
 export const toUser = (r: UserFields): User => ({
 	__typename: "User",
 	id: r.id,
@@ -42,9 +40,8 @@ export const toUser = (r: UserFields): User => ({
 	emailFailing: r.emailFailing,
 });
 
-// Stamps the client normalization key `id` === `userId` (a `Profile` is
-// one-to-one with its user; codegen hardcodes `getId` to `record.id`). This is
-// the one and only spelling of that invariant.
+// `id` === `userId`: a `Profile` is one-to-one with its user, and codegen hardcodes
+// `getId` to `record.id`. This is the only spelling of that invariant.
 export const toProfile = (r: ProfileRow): Profile => ({
 	__typename: "Profile",
 	id: r.userId,
@@ -58,16 +55,14 @@ export const toProfile = (r: ProfileRow): Profile => ({
 	commentCount: r.commentCount,
 });
 
-// The single spelling of the `account.delete` ack literal. The `id` is constant
-// (`account:deleted`) — the receipt carries no per-user payload to leak.
+// The `id` is constant on purpose — the receipt carries no per-user payload to leak.
 export const toAccountDeletionReceipt = (): AccountDeletionReceipt => ({
 	__typename: "AccountDeletionReceipt",
 	id: "account:deleted",
 	deleted: true,
 });
 
-// The single spelling of the çaylak→yazar promotion ack (#1206). The `id` carries
-// the target user so two targets resolve as distinct receipts.
+// The `id` carries the target user, so two targets resolve as distinct receipts.
 export const toPromotionReceipt = (r: {
 	userId: string;
 	promoted: boolean;
@@ -80,10 +75,8 @@ export const toPromotionReceipt = (r: {
 	vouchRecorded: r.vouchRecorded,
 });
 
-// The single spelling of the çaylak-self authorship-standing aggregate (#1316).
-// `id` === the user id (the client normalization key). Aggregate scalars only — the
-// one-way-glass invariant is structural in `AuthorshipStanding` (no identity field
-// exists to fill here).
+// Aggregate scalars only — the one-way-glass invariant is structural in
+// `AuthorshipStanding`, which has no identity field to fill (#1316).
 export const toAuthorshipStanding = (r: {
 	userId: string;
 	karma: number;
@@ -99,11 +92,8 @@ export const toAuthorshipStanding = (r: {
 	inReviewCount: r.inReviewCount,
 });
 
-// The single spelling of the ban-state entity (epic #968) — the admin read AND the
-// ban/unban ack resolve the SAME entity, keyed on the target user id, so a mutation
-// ack reconciles the surface's earlier read. `expiresAt` crosses the wire as
-// epoch-millis (or null = permanent / not-banned), so the domain `Date | null`
-// projects to a plain scalar here at the one seam.
+// The admin read and the ban/unban ack resolve the SAME entity, keyed on the target
+// user id, so an ack reconciles the surface's earlier read (epic #968).
 export const toBanState = (userId: string, state: BanState): BanStateEntity => ({
 	__typename: "BanState",
 	id: userId,
@@ -112,19 +102,16 @@ export const toBanState = (userId: string, state: BanState): BanStateEntity => (
 	expiresAt: state.expiresAt === null ? null : state.expiresAt.getTime(),
 });
 
-// The single spelling of the role-assignment ack (#3522) — keyed on the target user
-// id, so the `user.setRole` ack reconciles the SAME account the roster (`UserAdmin`)
-// lists. Carries only the newly-assigned `role`.
+// Keyed on the target user id, so the ack reconciles the SAME account the roster
+// lists (#3522).
 export const toRoleState = (userId: string, role: PlatformRole): RoleStateEntity => ({
 	__typename: "RoleState",
 	id: userId,
 	role,
 });
 
-// The single spelling of the email-delivery-state ack (epic #2687) — the mark AND the
-// clear resolve the SAME entity, keyed on the target address, so a mutation ack
-// reconciles the roll-up's earlier read. Carries only the projected state (`failing` +
-// `reason`), never the log rows.
+// Mark and clear resolve the SAME entity, keyed on the target address, so an ack
+// reconciles the roll-up's earlier read. Never the log rows (epic #2687).
 export const toEmailDeliveryState = (
 	address: string,
 	state: EmailDeliveryState,
@@ -135,9 +122,7 @@ export const toEmailDeliveryState = (
 	reason: state.reason,
 });
 
-// The single spelling of one failing-address roll-up item (epic #2687). `id` === the
-// address (the client normalization key); `since` crosses the wire as epoch-millis, so
-// the domain `Date` projects to a plain scalar here at the one seam.
+// `id` === the address, the client normalization key.
 export const toFailingAddress = (row: FailingAddress): FailingAddressEntity => ({
 	__typename: "FailingAddress",
 	id: row.address,
@@ -147,11 +132,9 @@ export const toFailingAddress = (row: FailingAddress): FailingAddressEntity => (
 	since: row.since.getTime(),
 });
 
-// Flatten a discriminated `ContributionNode` onto the flat `ContributionRow`
-// (ADR 0018: fate has no union type). Every variant column starts `null`, then
-// the node's own fields overlay — so the null-padding is derived from the
-// `CONTRIBUTION_VARIANT_FIELD_NAMES` manifest, not hand-written per `case`. A
-// forgotten field is a compile error at the manifest, not a silent wrong shape.
+// Null-padding is derived from the `CONTRIBUTION_VARIANT_FIELD_NAMES` manifest, never
+// hand-written per `case`, so a forgotten field is a compile error at the manifest
+// rather than a silent wrong shape. See ADR 0018.
 export function toContributionRow(node: ContributionNode): ContributionRow {
 	const variantColumns = Object.fromEntries(
 		CONTRIBUTION_VARIANT_FIELD_NAMES.map((name) => [name, null]),

--- a/apps/web/worker/features/pasaport/sources.ts
+++ b/apps/web/worker/features/pasaport/sources.ts
@@ -1,9 +1,6 @@
 /**
- * Pasaport fate sources — `User` / `Profile` Effect-backed loaders. fate is pure
- * transport (ADR 0016); every handler delegates to a `Pasaport` method, so read
- * logic stays in the domain layer. `Profile` is fetched by `userId` (the root
- * `profile`/`me` resolvers build the full shape inline, so this `byId` exists for
- * relation/by-id callers). See `.patterns/fate-effect-sources.md`.
+ * Pasaport fate sources — `User` / `Profile` Effect-backed loaders. fate is pure transport
+ * (ADR 0016). See `.patterns/fate-effect-sources.md`.
  */
 import {Fate} from "@kampus/fate-effect";
 import {currentSandboxViewer} from "../kunye/sandbox.ts";
@@ -27,11 +24,8 @@ export const userSource = Fate.source(
 	UserView,
 	{id: "id"},
 	{
-		// Pure transport (ADR 0016): delegate to the domain compose, which joins the
-		// `isModerator` (#1320) `(id, "moderates", platform)` membership onto the user
-		// rows in ONE `RelationStore` read — never a per-row probe in this loader. The
-		// moderator signal is an aggregate boolean, not secret, so reading it for a
-		// by-id load is honest, not a leak.
+		// The domain compose joins `isModerator` (#1320) onto the rows in ONE
+		// `RelationStore` read — never a per-row probe in this loader.
 		byIds: (ids) => getUsersWithModerationByIds(ids),
 	},
 );
@@ -42,68 +36,44 @@ export const profileSource = Fate.source(
 	{
 		byId: function* (userId) {
 			const pasaport = yield* Pasaport;
-			// Thread the SAME request sandbox viewer the root `queries.profile` resolves,
-			// so the by-id relation path computes identical sandbox/draft-aware headline
-			// counts — counts agree on every fetch path (#1406).
+			// The SAME viewer the root `queries.profile` resolves, so headline counts agree
+			// on every fetch path (#1406).
 			const sandboxViewer = yield* currentSandboxViewer;
 			const row = yield* pasaport.lookupProfileById(userId, {sandboxViewer});
-			// `toProfile` stamps the client normalization key `id` (=== `userId`);
-			// the service row carries only `userId`.
+			// `toProfile` stamps the client normalization key `id`; the service row carries
+			// only `userId`.
 			return row ? toProfile(row) : row;
 		},
 	},
 );
 
-// `Contribution` has no fetch path — rows are synthetic and the connection is
-// delivered inline by `queries.profile` (ADR 0019). `syntheticSource` registers
-// the entity so source-completeness validation accepts it (it's view-reachable
-// via `Profile.contributions`) with ZERO capabilities; any capability call fails
-// loudly (`.patterns/fate-effect-sources.md`, the escape hatch).
+// `Contribution` has no fetch path — rows are synthetic and delivered inline by
+// `queries.profile` (ADR 0019). `syntheticSource` registers the entity with ZERO
+// capabilities so source-completeness accepts it; see
+// `.patterns/fate-effect-sources.md`. The same shape repeats for every synthetic
+// source below.
 export const contributionSource = Fate.syntheticSource(ContributionView);
 
-// `AccountDeletionReceipt` has no fetch path — it is the `account.delete` ack,
-// returned inline by the mutation and never read by id (ADR 0097). Registered
-// with ZERO capabilities so source-completeness accepts the view-reachable result
-// type; mirrors `reportReceiptSource`.
+// The `account.delete` ack, returned inline by the mutation (ADR 0097).
 export const accountDeletionReceiptSource = Fate.syntheticSource(AccountDeletionReceiptView);
 
-// `PromotionReceipt` has no fetch path — it is the `user.promote` / `user.vouch`
-// ack, returned inline by the mutation and never read by id (#1206). Registered with
-// ZERO capabilities so source-completeness accepts the view-reachable result type;
-// mirrors `accountDeletionReceiptSource`.
+// The `user.promote` / `user.vouch` ack, returned inline by the mutation (#1206).
 export const promotionReceiptSource = Fate.syntheticSource(PromotionReceiptView);
 
-// `AuthorshipStanding` has no fetch path — it is the çaylak-self standing aggregate
-// (#1316), delivered inline by the `myAuthorshipStanding` resolver and never read by
-// id (it is per-viewer, keyed on `CurrentUser`, not a global entity). Registered with
-// ZERO capabilities so source-completeness accepts the view-reachable result type;
-// mirrors `promotionReceiptSource`.
+// Per-viewer, keyed on `CurrentUser` rather than a global entity (#1316).
 export const authorshipStandingSource = Fate.syntheticSource(AuthorshipStandingView);
 
-// `BanState` has no by-id fetch path — it is produced ONLY past the `requireAdmin`
-// gate (epic #968), by the `user.banState` admin read and the `user.banUser` /
-// `user.unbanUser` mutation acks, never a public by-id load (a by-id source would be
-// an ungated leak of an account's ban-state). Registered with ZERO capabilities so
-// source-completeness accepts the view-reachable result type; mirrors
-// `promotionReceiptSource`.
+// Produced ONLY past the `requireAdmin` gate (epic #968); a by-id source here would be an
+// ungated leak of an account's ban-state.
 export const banStateSource = Fate.syntheticSource(BanStateView);
 
-// `RoleState` has no by-id fetch path — it is produced ONLY past the `requireAdmin`
-// gate (#3522), by the `user.setRole` mutation ack, never a public by-id load (the
-// derived role IS re-readable via the gated `UserAdmin` roster). Registered with ZERO
-// capabilities so source-completeness accepts the view-reachable result type; mirrors
-// `banStateSource`.
+// Produced ONLY past the `requireAdmin` gate (#3522); the derived role IS re-readable via
+// the gated `UserAdmin` roster.
 export const roleStateSource = Fate.syntheticSource(RoleStateView);
 
-// `EmailDeliveryState` has no by-id fetch path — it is produced ONLY past the
-// `requireAdmin` gate (epic #2687), by the `emailDelivery.mark` / `emailDelivery.clear`
-// mutation acks, never a public by-id load (a by-id source would be an ungated leak of an
-// address's delivery-state). Registered with ZERO capabilities so source-completeness
-// accepts the view-reachable result type; mirrors `banStateSource`.
+// Produced ONLY past the `requireAdmin` gate (epic #2687); a by-id source here would be an
+// ungated leak of an address's delivery-state.
 export const emailDeliveryStateSource = Fate.syntheticSource(EmailDeliveryStateView);
 
-// `FailingAddress` has no by-id fetch path — the roll-up rows are delivered INLINE by the
-// `emailDelivery.failing` list resolver (a private admin surface), never read by id.
-// Registered with ZERO capabilities so source-completeness accepts the view-reachable
-// result type; mirrors divan's list-item synthetic sources.
+// Delivered inline by the `emailDelivery.failing` list resolver, a private admin surface.
 export const failingAddressSource = Fate.syntheticSource(FailingAddressView);

--- a/apps/web/worker/features/pasaport/sources.unit.test.ts
+++ b/apps/web/worker/features/pasaport/sources.unit.test.ts
@@ -1,19 +1,6 @@
 /**
- * Unit coverage for the pasaport fate **loader** seam — the logic that lives ONLY
- * in `sources.ts` and is exercised by no other test through the source interface
- * (#1361). Two handlers carry source-local logic:
- *
- *   - `userSource.byIds` — the per-row `isModerator` merge (ADR 0107): joins the
- *     `(id, "moderates", platform)` membership read onto each `UserRow`. Its tested
- *     twin is the self `me` path (`queries.unit.test.ts`), a DIFFERENT code path.
- *   - `profileSource.byId` — the `toProfile`-wrap (stamps the client-normalization
- *     `id === userId`) plus the silent-miss return.
- *
- * Plus the two loader-contract invariants the seam exists to uphold (ADR 0016):
- * **membership-stability** (`byIds` rows are a pure function of the id SET — reorder
- * the ids, get the same rows) and **silent-read** (a miss is `null`/fewer rows,
- * never a raised failure). `Pasaport` and `RelationStore` are substituted; no DB,
- * no live worker (ADR 0082 — the unit tier).
+ * Unit coverage for the pasaport fate loader seam, plus the two loader-contract
+ * invariants it upholds (ADR 0016): membership-stability and silent-read.
  */
 
 import {it} from "@effect/vitest";
@@ -26,7 +13,6 @@ import type {ProfileRow, UserRow} from "./Pasaport.ts";
 import {Pasaport} from "./Pasaport.ts";
 import {profileSource, userSource} from "./sources.ts";
 
-/** Narrow an optional handler without a non-null assertion (mirrors Source.unit.test.ts). */
 const required = <T>(value: T | undefined): T => {
 	if (value === undefined) {
 		throw new Error("expected the handler to be present");
@@ -46,17 +32,14 @@ const storedUser = (id: string): UserRow => ({
 	tier: "çaylak",
 });
 
-// An IN-shaped `getUsersByIds`: returns the rows that exist for the requested id
-// set, in the corpus's order — the membership-stable shape every real loader has.
+// Returns rows in the CORPUS's order, not the request's — the membership-stable shape
+// every real loader has.
 const corpus: ReadonlyArray<UserRow> = [storedUser("u1"), storedUser("u2"), storedUser("u3")];
 const pasaportWithCorpus = {
 	getUsersByIds: (ids: ReadonlyArray<string>) =>
 		Effect.succeed(corpus.filter((row) => ids.includes(row.id))),
 } as never;
 
-// A `RelationStore` answering the `(subject, "moderates", platform)` membership per
-// subject — the tuple `isModerator` reads (`kunye/moderate.ts`). Membership in
-// `moderatorIds` ⇒ `true`.
 const relationStoreFor = (moderatorIds: ReadonlySet<string>) =>
 	({
 		has: ({subject}: {subject: string}) => Effect.succeed(moderatorIds.has(subject)),
@@ -78,9 +61,6 @@ const profileRow = (userId: string): ProfileRow => ({
 const pasaportWithProfile = (row: ProfileRow | null) =>
 	({lookupProfileById: () => Effect.succeed(row)}) as never;
 
-// A `Pasaport` whose `lookupProfileById` records the `viewer` option it was handed,
-// so a test can assert `profileSource.byId` threads the resolved sandbox viewer
-// (#1406) rather than calling the loader sandbox-blind.
 const pasaportCapturingViewer = (row: ProfileRow | null) => {
 	// `viewer` admits `undefined` (exactOptionalPropertyTypes) since the loader's option
 	// arg is itself optional — the anonymous case threads `{sandboxViewer: anonymous}`,
@@ -95,8 +75,6 @@ const pasaportCapturingViewer = (row: ProfileRow | null) => {
 	return {pasaport, captured};
 };
 
-// A `moderates`-tuple `RelationStore` (the `Moderate.over(platform)` probe shape, per
-// `moderate.unit.test.ts`): a subject in `holders` holds the platform-moderation tuple.
 const moderatesStore = (holders: ReadonlySet<string>) =>
 	({
 		has: (tuple: {relation: string; object: {type: string}; subject: string}) =>
@@ -123,10 +101,6 @@ const moderatesStore = (holders: ReadonlySet<string>) =>
 			),
 	}) as never;
 
-// The full request context `currentSandboxViewer` resolves from: the signed-in user
-// (`CurrentUser`), the actor + moderation ports the `Moderate.over(platform)` probe
-// discharges against (`CurrentActor`/`AgentAuthority`/`RelationStore`). Anonymous ⇒
-// `{user: undefined}` + the `unauthenticated` actor.
 const withRequestViewer = <A, E, R>(
 	effect: Effect.Effect<A, E, R>,
 	user: CurrentUserInfo | undefined,
@@ -139,12 +113,10 @@ const withRequestViewer = <A, E, R>(
 		Effect.provideService(RelationStore, moderatesStore(moderatorIds)),
 	);
 
-// --- userSource.byIds: the per-row moderator merge --------------------------
-
 it.effect("userSource.byIds joins isModerator per row off the moderates tuple (ADR 0107)", () =>
 	Effect.gen(function* () {
-		// u1 holds the moderates tuple, u2 does not — the merge must be per-row, not
-		// a single batch-wide verdict.
+		// u1 holds the moderates tuple, u2 does not — the merge must be per-row, never a
+		// single batch-wide verdict.
 		const rows = yield* userByIds(["u1", "u2"]).pipe(
 			Effect.provideService(Pasaport, pasaportWithCorpus),
 			Effect.provideService(RelationStore, relationStoreFor(new Set(["u1"]))),
@@ -167,8 +139,6 @@ it.effect("userSource.byIds carries through the underlying row fields unchanged"
 	}),
 );
 
-// --- userSource.byIds: membership-stability (ADR 0016) ----------------------
-
 it.effect("userSource.byIds is membership-stable: a reordered id set yields the same rows", () =>
 	Effect.gen(function* () {
 		const moderators = relationStoreFor(new Set(["u2"]));
@@ -180,16 +150,11 @@ it.effect("userSource.byIds is membership-stable: a reordered id set yields the 
 			Effect.provideService(Pasaport, pasaportWithCorpus),
 			Effect.provideService(RelationStore, moderators),
 		);
-		// The rows are a function of the id SET, not its order — sorting both by id
-		// must collapse them to the same rows (the masking the interpreter's merged
-		// batch window relies on, `.patterns/fate-effect-sources.md`).
 		const byKey = (rows: ReadonlyArray<{id: string}>) =>
 			[...rows].sort((a, b) => a.id.localeCompare(b.id));
 		assert.deepStrictEqual(byKey(forward), byKey(reversed));
 	}),
 );
-
-// --- userSource.byIds: silent-read (ADR 0016) -------------------------------
 
 it.effect(
 	"userSource.byIds is silent on a miss: an absent id yields fewer rows, never a failure",
@@ -202,7 +167,6 @@ it.effect(
 			);
 			assert.isTrue(exit._tag === "Success");
 			if (exit._tag === "Success") {
-				// Two ids requested, one exists — fewer rows is success, not a raised miss.
 				assert.deepStrictEqual(
 					exit.value.map((row) => row.id),
 					["u1"],
@@ -210,8 +174,6 @@ it.effect(
 			}
 		}),
 );
-
-// --- profileSource.byId: the toProfile-wrap + silent miss -------------------
 
 it.effect("profileSource.byId wraps the row via toProfile (stamps id === userId)", () =>
 	Effect.gen(function* () {
@@ -221,8 +183,8 @@ it.effect("profileSource.byId wraps the row via toProfile (stamps id === userId)
 			),
 			{id: "u1", email: "u1@kamp.us", name: "U One", image: null},
 		);
-		// `toProfile` stamps `__typename` (not on the handler's view-row return type) and
-		// `id === userId`; widen to a record to assert the full runtime shape.
+		// Widened to a record because `toProfile` stamps `__typename`, which is not on the
+		// handler's view-row return type.
 		assert.deepStrictEqual(profile as Record<string, unknown>, {
 			__typename: "Profile",
 			id: "u1",
@@ -253,15 +215,12 @@ it.effect(
 		}),
 );
 
-// --- profileSource.byId: threads the resolved sandbox viewer (#1406) ---------
-
 it.effect(
 	"profileSource.byId threads the resolved currentSandboxViewer into lookupProfileById",
 	() =>
 		Effect.gen(function* () {
-			// The author is signed in but NOT a moderator ⇒ the resolved viewer is keyed to
-			// their id with `canSeeSandboxed: false`. Threading this (vs. calling the loader
-			// sandbox-blind) is what makes the by-id counts agree with the root query (#1406).
+			// Threading the viewer (vs. calling the loader sandbox-blind) is what makes the
+			// by-id counts agree with the root query (#1406).
 			const {pasaport, captured} = pasaportCapturingViewer(profileRow("u1"));
 			yield* withRequestViewer(profileById("u1").pipe(Effect.provideService(Pasaport, pasaport)), {
 				id: "u1",

--- a/apps/web/worker/features/pasaport/tandem.ts
+++ b/apps/web/worker/features/pasaport/tandem.ts
@@ -1,23 +1,11 @@
 /**
- * The **order-independent tandem resolver** (#1289, epic #1202) — the single code path
- * that flips a çaylak → yazar the moment *both* halves of the author-vouch tandem hold:
- * `(≥1 active vouch) AND (net karma ≥ VOUCH_PROMOTION_KARMA_BAR)`. It reads both halves
- * **fresh** from their stores and is **idempotent** (the flip is the atomic, guarded
- * `Pasaport.promoteToYazar`), so it is safe to call from *either* trigger in *either*
- * arrival order:
+ * The order-independent tandem resolver (#1289): flips çaylak → yazar once both halves
+ * hold — `(≥1 active vouch) AND (karma ≥ VOUCH_PROMOTION_KARMA_BAR)`. It reads both fresh
+ * and is idempotent, so BOTH triggers (the vouch act, and the karma-moving vote of #1288)
+ * call it and promotion never depends on which landed first.
  *
- *   - the **vouch act** (`user.vouch`, this slice) — fired after a vouch is recorded, so
- *     a vouch placed while karma is already over the bar promotes immediately; and
- *   - the **karma side** (the vote-on-sandboxed path, #1288) — fired after a vote moves
- *     a çaylak's karma, so a bar-crossing vote with an already-active vouch promotes too.
- *
- * Both call THIS resolver, so promotion never depends on whether the vouch or the
- * bar-crossing vote landed first (the correctness property the two symmetric #1289
- * acceptance paths pin). The resolver holds **no authority of its own** — it is not a
- * capability; its only promotion trigger is the completed-tandem invariant it checks
- * here, exactly the "the yazar never holds a promote capability" rule (`.glossary/TERMS.md`:
- * the çaylak→yazar `Level` flip is not a yazar-held right). The resolver itself is
- * unconditional, like the service reads it composes.
+ * It holds no authority of its own — the completed tandem is the only trigger, keeping
+ * "the yazar never holds a promote capability" true (`.glossary/TERMS.md`).
  */
 import {Effect} from "effect";
 import {notifyPromotion} from "../bildirim/rite-emitters.ts";
@@ -27,12 +15,7 @@ import {VouchLedger} from "../kunye/VouchLedger.ts";
 import {Pasaport} from "./Pasaport.ts";
 import {publishPromotion} from "./promote-live.ts";
 
-/**
- * Re-evaluate the tandem for `candidateId` and promote iff both halves hold. Returns
- * `{promoted}` — `true` only when this call's flip fired (a no-op for an already-yazar
- * candidate, since `Pasaport.promoteToYazar` is guarded on `tier = 'çaylak'`). Short-
- * circuits on the vouch half first so a candidate with no active vouch never reads karma.
- */
+/** `promoted` is `true` only when THIS call's flip fired, never for an already-yazar. */
 export const resolveTandem = Effect.fn("pasaport.resolveTandem")(function* (candidateId: string) {
 	const ledger = yield* VouchLedger;
 	if (!(yield* ledger.hasActiveFor(candidateId))) return {promoted: false};
@@ -43,13 +26,8 @@ export const resolveTandem = Effect.fn("pasaport.resolveTandem")(function* (cand
 
 	const pasaport = yield* Pasaport;
 	const {promoted} = yield* pasaport.promoteToYazar({userId: candidateId});
-	// Promotion ceremony (#1696): the tandem-sweep half of the two promotion sites —
-	// notify the freshly-promoted çaylak, keyed on `promoted` so an already-yazar
-	// re-fire (the idempotent no-op above) notifies nothing. Swallowed inside the
-	// emitter, so a bildirim hiccup can never fail this committed tier flip.
-	// Live propagation (#1886): the tandem half of the shared post-promote publish —
-	// the SAME `publishPromotion` the mod-direct path fires, so both triggers refresh
-	// the profile view live. Keyed on `promoted`; infallible (error channel `never`).
+	// Both keyed on `promoted`, so an idempotent re-fire notifies and publishes nothing.
+	// Both are infallible, so neither can fail this committed tier flip.
 	if (promoted) {
 		yield* notifyPromotion({userId: candidateId});
 		yield* publishPromotion(candidateId);

--- a/apps/web/worker/features/pasaport/tandem.unit.test.ts
+++ b/apps/web/worker/features/pasaport/tandem.unit.test.ts
@@ -1,16 +1,7 @@
 /**
- * `resolveTandem` coverage (#1289) — the order-independent tandem resolver, the single
- * promotion code path BOTH triggers share (the vouch act `user.vouch`, and the karma
- * side a vote-on-sandboxed #1288 will call). These cases pin the correctness property
- * that promotion is independent of whether the vouch or the bar-crossing vote landed
- * first, plus the negative (no active vouch ⇒ no promotion) and idempotency (a re-fire
- * over an already-yazar candidate is a safe no-op).
- *
- * The three ports are scripted stubs (`VouchLedger` the vouch half, `Kunye` the karma
- * half, `Pasaport` the atomic flip) — no DB; the real-D1 fidelity of the ledger queries
- * and the atomic promotion batch is the integration tier. Each stub method NOT on the
- * path under test is fail-on-contact, so a case proves exactly which reads it touched
- * (e.g. the no-vouch case never reads karma).
+ * `resolveTandem` coverage (#1289). The property under test: promotion is independent of
+ * whether the vouch or the bar-crossing vote landed first. Each stub method NOT on the
+ * path under test is fail-on-contact, so a case proves exactly which reads it touched.
  */
 import {assert, describe, it} from "@effect/vitest";
 import {CurrentUser} from "@kampus/fate-effect";
@@ -27,9 +18,8 @@ import {makePasaportStub} from "./Pasaport.testing.ts";
 import {livePromoteContext} from "./promote-live.testing.ts";
 import {resolveTandem} from "./tandem.ts";
 
-// A landed flip (`promoted: true`) re-resolves the promoted `User` (#1886), so its
-// stub must answer `getUsersByIds` (the record the flip promoted, now `yazar`) —
-// the publish's inline data. `promoted: false` cases never reach it (unchanged).
+// A landed flip re-resolves the promoted `User` (#1886), so the stub must answer
+// `getUsersByIds`. `promoted: false` cases never reach it.
 const promotedYazar = (id: string) =>
 	makePasaportStub({
 		promoteToYazar: () => Effect.succeed({promoted: true}),
@@ -39,11 +29,9 @@ const promotedYazar = (id: string) =>
 			]),
 	});
 
-// resolveTandem emits the promotion-ceremony bildirimi on a landed flip (#1696), so
-// it now needs the bildirim seam (Notification + Flags + CurrentUser + RuntimeContext)
-// in R. The default `bildirimContext` provides a flag-ON, fail-on-contact Notification
-// (the emit is swallowed at the seam, so a DYING write can't fail these promotion cases)
-// — a case that ASSERTS on the emit passes its own recording Notification stub instead.
+// Flag-ON with a fail-on-contact Notification: the emit is swallowed at the seam, so a
+// dying write can't fail these promotion cases (#1696). A case that ASSERTS on the emit
+// passes its own recording stub instead.
 const runtimeContextStub: BaseRuntimeContext = {
 	Type: "tandem-test",
 	id: "tandem-test",
@@ -73,8 +61,7 @@ const bildirimContext = (notification = makeNotificationStub(), on = true) =>
 		noRequestFlagOverrides,
 	);
 
-// A `Kunye` whose `karmaOf` answers `karma`; `tierOf`/`rootOf` are unreached on the
-// resolver path (it reads karma only), so they fail-on-contact.
+// `tierOf`/`rootOf` are unreached on the resolver path, so they fail-on-contact.
 const kunyeKarma = (karma: number): Layer.Layer<Kunye> =>
 	Layer.succeed(Kunye, {
 		karmaOf: () => Effect.succeed(karma),
@@ -89,9 +76,8 @@ const kunyeUnreached: Layer.Layer<Kunye> = Layer.succeed(Kunye, {
 });
 
 describe("resolveTandem — order-independent promotion", () => {
-	// VOUCH-FIRST order: the vouch was already placed below the bar; now a vote crosses
-	// the bar and the karma side fires the resolver → promote. This is the case #1285's
-	// vouch-act-only re-eval misses; the karma-side trigger is what closes it.
+	// VOUCH-FIRST order: the vouch was placed below the bar, then a vote crosses it. This
+	// is the case #1285's vouch-act-only re-eval missed.
 	it.effect("vouch-first: an active vouch + a bar-crossing karma → promotes", () =>
 		Effect.gen(function* () {
 			const {promoted} = yield* resolveTandem("u-caylak");
@@ -127,9 +113,8 @@ describe("resolveTandem — order-independent promotion", () => {
 		),
 	);
 
-	// The withdraw negative: with no active vouch (the only one was withdrawn before the
-	// bar was crossed), a bar-crossing karma is inert — the resolver short-circuits on the
-	// vouch half and never even reads karma (Kunye fail-on-contact) or promotes.
+	// The withdraw negative: the resolver short-circuits on the vouch half and never even
+	// reads karma (Kunye fail-on-contact).
 	it.effect("no active vouch (withdrawn) ⇒ a bar-crossing karma does NOT promote", () =>
 		Effect.gen(function* () {
 			const {promoted} = yield* resolveTandem("u-caylak");
@@ -147,9 +132,8 @@ describe("resolveTandem — order-independent promotion", () => {
 		),
 	);
 
-	// Idempotency: both halves hold but the candidate is already a yazar, so the guarded
-	// flip matches 0 rows (`promoted:false`). Re-firing the resolver is a safe no-op — the
-	// property the karma side relies on (a vote after promotion can't double-promote).
+	// Idempotency: the guarded flip matches 0 rows for an already-yazar candidate, so a
+	// vote after promotion can't double-promote.
 	it.effect("re-firing over an already-yazar candidate is an idempotent no-op", () =>
 		Effect.gen(function* () {
 			const {promoted} = yield* resolveTandem("u-already-yazar");
@@ -168,9 +152,8 @@ describe("resolveTandem — order-independent promotion", () => {
 	);
 });
 
-// Promotion ceremony (#1696): a landed tandem flip emits ONE `terfi` bildirimi to the
-// promoted çaylak (recipient = the çaylak's own account, no actor identity); an
-// idempotent no-op flip (already-yazar) emits nothing — the emit is keyed on `promoted`.
+// The emit is keyed on `promoted`: a landed flip emits ONE `terfi` bildirimi, an
+// idempotent no-op flip emits nothing (#1696).
 describe("resolveTandem — promotion ceremony bildirimi (#1696)", () => {
 	const promotionRecording = () => {
 		const emits: NotificationRecordInput[] = [];

--- a/apps/web/worker/features/pasaport/trusted-user.ts
+++ b/apps/web/worker/features/pasaport/trusted-user.ts
@@ -1,13 +1,8 @@
 /**
- * Trusted-`User` composition — the one home for "resolve the server-authoritative
- * standing (tier + moderator signal) and attach it". `me` and `user.setUsername`
- * stamp the wire `User` here through `toTrustedUser`; the by-id loader joins the same
- * moderator/tier standing via `getUsersWithModerationByIds` (its `UserView` masks the
- * row to `User`). So the masking decision (trusted reads vs the `input:false` session
- * fields, #1297/#1320) has a single source and a third trusted field is a one-site
- * change. The leaf record-stamper stays `toUser` (`shapers.ts`); this is the
- * read-then-attach layer above it, in the domain (ADR 0013), never inline in a fate
- * transport handler (ADR 0016).
+ * Trusted-`User` composition — the one home for "resolve the server-authoritative standing
+ * (tier + moderator signal) and attach it", so the masking decision (trusted reads vs the
+ * `input:false` session fields, #1297/#1320) has a single source. The leaf record-stamper stays
+ * `toUser` (`shapers.ts`); this is the read-then-attach layer above it, in the domain (ADR 0013).
  */
 import type {RelationStore} from "@kampus/authz";
 import {Effect} from "effect";
@@ -17,24 +12,20 @@ import {Pasaport} from "./Pasaport.ts";
 import {toUser} from "./shapers.ts";
 import type {User} from "./views.ts";
 
-/** The non-standing fields of a `User` — id + the email-ish fields the session carries. */
 export interface TrustedUserBase {
 	id: string;
 	email: string;
 	name: string | null;
 	image: string | null;
 	username: string | null;
-	// The SELF failing-delivery signal (#2693). Only `queries.me` sets it (from #2691's
-	// projection); every other caller omits it and `toTrustedUser` defaults it `false`, so a
-	// non-self trusted `User` never carries real delivery-state (see `user-fields.ts`).
+	// The SELF failing-delivery signal (#2693): only `queries.me` sets it; every other caller omits
+	// it and it defaults `false`, so a non-self trusted `User` never carries real delivery-state.
 	emailFailing?: boolean;
 }
 
 /**
- * The SELF trusted `User`: the subject's OWN tier (`Kunye.tierOf`, the stored
- * column, never the session field) + OWN moderator signal (`isModerator`, the
- * `moderates` tuple) stamped onto `toUser`. `me` and `setUsername` route through
- * here so their `User` shape can't drift.
+ * The SELF trusted `User`: the subject's OWN tier (the stored column, never the session field)
+ * + OWN moderator signal stamped onto `toUser`.
  */
 export const toTrustedUser = (
 	base: TrustedUserBase,
@@ -46,7 +37,6 @@ export const toTrustedUser = (
 		return toUser({...base, tier, isModerator: isMod, emailFailing: base.emailFailing ?? false});
 	});
 
-/** The validated session identity {@link resolveMeUser} resolves the trusted `User` from. */
 export interface MeSessionUser {
 	id: string;
 	email: string;
@@ -55,12 +45,9 @@ export interface MeSessionUser {
 }
 
 /**
- * The ONE session→user resolution shared by the `/fate` `me` query and the edge
- * `__BOOT__.user` injection (ADR 0185), so both read the same canonical row + trusted
- * standing. Reads the canonical `user` row fresh (so a just-set `username` round-trips before
- * better-auth's session inference catches up), falling back to the session identity when the
- * row is absent; projects the SELF failing-delivery signal (#2693); then attaches the trusted
- * tier + moderator standing via {@link toTrustedUser}.
+ * The ONE session→user resolution shared by the `/fate` `me` query and the edge `__BOOT__.user`
+ * injection (ADR 0185). The canonical row is read FRESH so a just-set `username` round-trips
+ * before better-auth's session inference catches up; the session identity is the fallback.
  */
 export const resolveMeUser = (
 	sessionUser: MeSessionUser,
@@ -91,12 +78,9 @@ export const resolveMeUser = (
 	});
 
 /**
- * The BATCHED by-id user rows with moderator standing joined on: fetch the user
- * rows, then ONE `RelationStore` set-membership read (`moderatorsAmong`) decides
- * which of them moderate — no per-row `isModerator` call. Each row already carries
- * its stored `tier`, so the batch needs no per-row tier fetch. This is the domain
- * method `userSource.byIds` delegates to, restoring fate pure transport at the loader
- * (ADR 0016); the loader's `UserView` masks the row down to the wire `User`.
+ * The BATCHED by-id rows: ONE `RelationStore` set-membership read decides which of them
+ * moderate — no per-row `isModerator` call, and no per-row tier fetch (each row carries its
+ * stored `tier`). `userSource.byIds` delegates here, keeping fate transport pure (ADR 0016).
  */
 export const getUsersWithModerationByIds = (ids: ReadonlyArray<string>) =>
 	Effect.gen(function* () {

--- a/apps/web/worker/features/pasaport/trusted-user.unit.test.ts
+++ b/apps/web/worker/features/pasaport/trusted-user.unit.test.ts
@@ -1,15 +1,7 @@
 /**
- * `trusted-user` compose coverage (#1360) — the one home for the trusted `User`
- * wire shape (`me` / `setUsername` / the by-id loader all route through it):
- *
- * - `toTrustedUser` resolves the SELF standing (tier via `Kunye.tierOf`, the
- *   moderator signal via the `moderates` tuple) and stamps the `toUser` shape.
- * - `getUsersWithModerationByIds` joins moderator standing onto a batch of user
- *   rows through ONE `RelationStore.hasSubjects` read — no per-row probe — and each
- *   row already carries its stored `tier`.
- *
- * The three ports are scripted (`Pasaport` the rows, `Kunye` the tier, `RelationStore`
- * the membership); the real D1 reads live in their own integration/adapter tiers.
+ * `trusted-user` compose coverage (#1360) — the one home for the trusted `User` wire
+ * shape. The batch join goes through ONE `RelationStore.hasSubjects` read, never a
+ * per-row probe.
  */
 import {assert, describe, it} from "@effect/vitest";
 import {RelationStore} from "@kampus/authz";
@@ -27,22 +19,19 @@ const row = (over: Partial<UserRow> & {id: string}): UserRow => ({
 	...over,
 });
 
-// A `Pasaport` answering `getUsersByIds` off a fixed row set, in id order.
 const pasaportOf = (rows: ReadonlyArray<UserRow>): Layer.Layer<Pasaport> =>
 	Layer.succeed(Pasaport, {
 		getUsersByIds: (ids: ReadonlyArray<string>) =>
 			Effect.succeed(ids.flatMap((id) => rows.filter((r) => r.id === id))),
 	} as never);
 
-// A `Kunye` whose `tierOf` answers by id (visitor when absent), exercising the SELF
-// trusted-tier read; the other methods are unreached.
+// `tierOf` answers by id (visitor when absent); the other methods are unreached.
 const kunyeOf = (tierById: Record<string, "çaylak" | "yazar">): Layer.Layer<Kunye> =>
 	Layer.succeed(Kunye, {
 		tierOf: (id: string) => Effect.succeed(tierById[id] ?? "visitor"),
 	} as never);
 
-// A `RelationStore` where exactly `mods` hold the `(moderates, platform)` tuple,
-// answering both the single `has` and the batched `hasSubjects`.
+// Exactly `mods` hold the `(moderates, platform)` tuple.
 const relationStoreOf = (mods: ReadonlyArray<string>): Layer.Layer<RelationStore> =>
 	Layer.succeed(RelationStore, {
 		has: (tuple) => Effect.succeed(tuple.relation === "moderates" && mods.includes(tuple.subject)),

--- a/apps/web/worker/features/pasaport/user-fields.ts
+++ b/apps/web/worker/features/pasaport/user-fields.ts
@@ -1,30 +1,19 @@
 /**
- * `User`'s one column→field map — the single structure the row mapper
- * (`toUserRow`, used by `Pasaport.getUserById`/`getUsersByIds`), the wire shaper
- * (`toUser` in `shapers.ts`), and the view field declaration (`UserView` in
- * `views.ts`) all derive from, so a one-field change touches this map instead of
- * three hand-synced restatements (#1545, the pasaport half of fate-wire epic
- * #1332). Mirrors `sozluk/definition-fields.ts`.
+ * `User`'s one column→field map. The row mapper, the wire shaper and the view field
+ * declaration all derive from it, so a one-field change lands here (#1545).
  *
- * `tier` and `isModerator` are the trusted-read fields stamped by the resolver,
- * not read from the `user` record here: `tier` is widened from the stored
- * `StoredTier` (`çaylak | yazar`) to the read-time `Tier` (`visitor` for a
- * row-missing principal) via `Kunye.tierOf`, and `isModerator` (#1320) is joined
- * off the `moderates` relation tuple (`trusted-user.ts`). So they ride on
- * `UserFields` (the view/shaper row) but are absent from `UserRow` (the
- * record-derived row).
+ * `tier` and `isModerator` are stamped by the resolver, not read from the record:
+ * `tier` widens the stored value to the read-time one (`visitor` for a principal with
+ * no row) and `isModerator` joins off the `moderates` relation tuple. That is why they
+ * ride on `UserFields` but are absent from `UserRow`.
  */
 import type * as schema from "../../db/drizzle/schema.ts";
 import type {Tier} from "../kunye/standing.ts";
 
 type UserRecord = typeof schema.user.$inferSelect;
 
-/**
- * The intrinsic (record-derived) wire fields, each mapping a `user` row onto its
- * wire value. The keys ARE the wire field names; the readers absorb the
- * nullable-column fallback. `tier` rides as the stored `StoredTier` here — the
- * resolver widens it to `Tier`.
- */
+// The keys ARE the wire field names. `tier` rides as the stored value here; the
+// resolver widens it.
 const intrinsicFields = {
 	id: (u) => u.id,
 	email: (u) => u.email,
@@ -34,38 +23,21 @@ const intrinsicFields = {
 	tier: (u) => u.tier,
 } satisfies Record<string, (u: UserRecord) => unknown>;
 
-/** `UserRow` — the record-derived row the user reads share (`tier` still stored). */
 export type UserRow = {
 	[K in keyof typeof intrinsicFields]: ReturnType<(typeof intrinsicFields)[K]>;
 };
 
-/**
- * `UserFields` — the wire shaper's input (`toUser`) and the `UserView` wire row:
- * the record-derived fields with `tier` widened to the read-time `Tier` and the
- * `isModerator` relation-tuple signal stamped by the resolver (`trusted-user.ts`),
- * never read from the record. Derived from `UserRow` so the field set can't drift.
- *
- * `emailFailing` is the SELF-scoped failing-delivery signal (#2693, epic #2687),
- * stamped by the resolver like `tier`/`isModerator` and, like them, ALWAYS present:
- * the `queries.me` resolver projects the reader's own state from #2691's
- * `resolveEmailDeliveryState`, and every other `User` resolution (the by-id
- * `userSource` batch) stamps a flat `false` — a non-self row never carries another
- * account's real delivery-state, so nothing leaks. The client reads it through the
- * `emailFailing?` seam (`emailDeliveryNoticeGate.ts`).
- */
+// `emailFailing` is SELF-scoped (#2693): only the `queries.me` resolver projects the
+// reader's own state; every other `User` resolution stamps a flat `false`, so a non-self
+// row never carries another account's delivery state.
 export interface UserFields extends Omit<UserRow, "tier"> {
 	tier: Tier;
 	isModerator: boolean;
 	emailFailing: boolean;
 }
 
-/**
- * The view/wire field selection (`{id: true, …}`) — a static literal (fate's
- * `FateDataView` reads the literal field map off this). `satisfies Record<keyof
- * UserFields, true>` pins it to exactly the wire row's fields: dropping one here
- * (or adding one to `UserFields` without listing it) is a compile error, so the
- * view stays in lockstep with the shaper.
- */
+// Must stay a static literal — fate's `FateDataView` reads the field map off it. The
+// `satisfies` makes any drift from `UserFields` a compile error.
 export const userViewFields = {
 	id: true,
 	email: true,
@@ -77,12 +49,6 @@ export const userViewFields = {
 	emailFailing: true,
 } as const satisfies Record<keyof UserFields, true>;
 
-/**
- * Map a `user` record onto its `UserRow` fields by running every reader in the
- * column→field map — the single place the record→row mapping lives. `tier`
- * widening + `isModerator` are stamped by the resolver (`trusted-user.ts`), not
- * here.
- */
 export const toUserRow = (u: UserRecord): UserRow =>
 	Object.fromEntries(
 		(Object.keys(intrinsicFields) as Array<keyof typeof intrinsicFields>).map((f) => [

--- a/apps/web/worker/features/pasaport/username-rule.ts
+++ b/apps/web/worker/features/pasaport/username-rule.ts
@@ -1,38 +1,24 @@
 /**
- * The single source of the username rule — the pure string predicate behind both
- * the server-authoritative `assertUsername` (`Pasaport.ts`) and the SPA's
- * client-side pre-flight (signup + bootstrap forms). No Effect/DO/worker coupling,
- * so `src/` can import it directly into the client bundle (the same neutral-pure
- * idiom as `flagship/evaluate-contract.ts`).
- *
- * `checkUsername` returns a {@link UsernameRuleCode} (or `null` when valid) keyed
- * to the same vocabulary the wire codes use, so the client maps a local rejection
- * and a server rejection through one `messageForCode` table — the rule and its
- * messaging never fork. The server stays authoritative: this is UX pre-flight; the
- * real gate is `setUsername` re-running `assertUsername` over the same rule.
+ * The single source of the username rule, shared by the server's `assertUsername` and the
+ * SPA's pre-flight. No Effect/DO/worker coupling, so `src/` can import it into the client
+ * bundle. The codes match the wire vocabulary, so a local and a server rejection map
+ * through one message table. The server stays authoritative — this is UX pre-flight only.
  */
 
 // 3-30 chars; lowercase ASCII letters, digits, and `-`; must start/end with a
 // letter or digit (no leading/trailing `-`, no `--`).
 const USERNAME_REGEX = /^[a-z0-9](?:[a-z0-9]|-(?=[a-z0-9])){1,28}[a-z0-9]$|^[a-z0-9]{3,30}$/;
 
-/**
- * The seeded `@[silinen]` sentinel handle (ADR 0097 §1) — nobody may register it,
- * so it can never collide with the deletion tombstone. Rejected with the
- * `RESERVED` surface (the server maps it onto INVALID_FORMAT).
- */
+/** Unregisterable so it can never collide with the deletion tombstone (ADR 0097 §1). */
 export const SILINEN_USERNAME = "silinen";
 
 const RESERVED_USERNAMES: ReadonlySet<string> = new Set([SILINEN_USERNAME]);
 
-/** The non-valid outcomes of {@link checkUsername}, one per rejection reason. */
 export type UsernameRuleCode = "RESERVED" | "TOO_SHORT" | "TOO_LONG" | "INVALID_FORMAT";
 
 /**
- * Apply the username rule to an ALREADY-normalized (trimmed + lowercased) value.
- * Returns `null` when the value is a legal handle, or the first failing rule's
- * {@link UsernameRuleCode}. Order matches `assertUsername` so the local and server
- * verdicts agree on which reason wins.
+ * Takes an ALREADY-normalized value. The check order matches `assertUsername` so the
+ * local and server verdicts agree on which reason wins.
  */
 export function checkUsername(normalized: string): UsernameRuleCode | null {
 	if (RESERVED_USERNAMES.has(normalized)) return "RESERVED";
@@ -48,11 +34,8 @@ export function normalizeUsername(raw: string): string {
 }
 
 /**
- * Derive a default handle from an email local-part for the bootstrap fallback:
- * drop the `+tag` suffix (so a `+tag` address doesn't leak its tag into the public
- * handle), lowercase, map any non-`[a-z0-9-]` to `-`, strip leading/trailing and
- * collapse repeated `-`, and clamp to 30 chars. Best-effort — the result is only a
- * prefill; the user can edit it and the rule is still enforced on submit.
+ * The `+tag` suffix is dropped so a tagged address doesn't leak its tag into the public
+ * handle. Best-effort prefill only — the rule is still enforced on submit.
  */
 export function deriveUsernameFromEmail(email: string): string {
 	const localPart = email.split("@")[0] ?? "";

--- a/apps/web/worker/features/pasaport/username-rule.unit.test.ts
+++ b/apps/web/worker/features/pasaport/username-rule.unit.test.ts
@@ -1,8 +1,6 @@
 /**
- * The single-source username rule (`username-rule.ts`) — the pure predicate behind
- * both `assertUsername` (server) and the SPA forms (client). Pinning the boundaries
- * here keeps the one rule honest; `assertUsername`'s mapping onto typed errors and
- * the no-DB-read proof stay in `username-validation.unit.test.ts`.
+ * The pure username predicate behind both `assertUsername` on the server and the SPA
+ * forms. Its mapping onto typed errors lives in `username-validation.unit.test.ts`.
  */
 import {describe, expect, it} from "vitest";
 import {

--- a/apps/web/worker/features/pasaport/username-validation.unit.test.ts
+++ b/apps/web/worker/features/pasaport/username-validation.unit.test.ts
@@ -1,19 +1,10 @@
 /**
- * Username-validation unit coverage (ADR 0082) — the `setUsername` input checks
- * that are wrong-or-right with NO database.
+ * The `setUsername` input checks that are wrong-or-right with NO database (ADR 0082).
+ * Every `Drizzle` call dies, so a typed error rather than a die is the "no DB read"
+ * proof. The reserved-`silinen` branch is pinned in `account-deletion.unit.test.ts`.
  *
- * `Pasaport.setUsername` runs `assertUsername(value.trim().toLowerCase())` BEFORE
- * its first DB read (the uniqueness / already-set lookups), so the length and
- * format rejections are pure logic on the input value — they could never be wrong
- * just because the database differed (ADR 0082 litmus). The reserved-`silinen`
- * branch of the same gate is pinned in `account-deletion.unit.test.ts`; this file
- * pins the other two non-reserved branches (too-short, illegal-format) over the
- * same throwing-`Drizzle` seam, so a reached read would `die` rather than surface
- * the typed error — which is the "no DB read" proof.
- *
- * The DB-state-dependent rejections of the same mutation (`TAKEN` against a
- * persisted row, `ALREADY_SET` against a persisted username) stay on real D1 in
- * `tests/integration/pasaport.test.ts` — those are only-wrong-if-the-DB-differs.
+ * The DB-state-dependent rejections (`TAKEN`, `ALREADY_SET`) stay on real D1 in
+ * `tests/integration/pasaport.test.ts`.
  */
 
 import {it} from "@effect/vitest";
@@ -22,16 +13,12 @@ import {assert} from "vitest";
 import {Drizzle, type DrizzleAccess} from "../../db/Drizzle.ts";
 import {type BetterAuthInstance, makePasaportLive, Pasaport} from "./Pasaport.ts";
 
-// Every DB call dies, so any path that reaches the seam fails the test: the
-// length/format gate short-circuits before any read, and running to completion
-// against this access is the "no read" proof.
 const throwingAccess: DrizzleAccess = {
 	run: () => Effect.die(new Error("setUsername read the DB on a path that must short-circuit")),
 	batch: () => Effect.die(new Error("setUsername wrote a batch on a path that must short-circuit")),
 };
 
-// `setUsername`'s validation gate uses neither the session nor the DB, so a
-// never-cast inert instance satisfies the type.
+// The validation gate uses neither the session nor the DB, so an inert cast suffices.
 const inertAuth = {} as BetterAuthInstance;
 
 const pasaportLayer = makePasaportLive(inertAuth).pipe(

--- a/apps/web/worker/features/pasaport/views.ts
+++ b/apps/web/worker/features/pasaport/views.ts
@@ -15,45 +15,26 @@ import {type ProfileRow, profileViewFields} from "./profile-fields.ts";
 import {type UserFields, userViewFields} from "./user-fields.ts";
 
 // Exported because the `Fate.source` entries surface the row type in their
-// declarations (TS2883 portability). The `User` wire row is `UserFields`
-// (`user-fields.ts`, which carries the `tier` widening + the `isModerator`
-// relation-tuple join); the `Profile` view row adds the client normalization key
-// `id` (=== `userId`, stamped by the resolver).
+// declarations (TS2883 portability).
 export type UserViewRow = ViewRow<UserFields>;
 export type ProfileViewRow = ViewRow<ProfileRow & {id: string}>;
 export type ContributionViewRow = ViewRow<ContributionRow>;
 
 // `username` is `null` until the bootstrap step sets it.
-// `tier` is the GLOBAL account-level authorship rank (ADR 0107 §4), exposed on
-// the TRUSTED read path: the resolver fills it from `Kunye.tierOf` (the stored
-// `user.tier` column read fresh through pasaport), NEVER from the `input:false`
-// better-auth session additionalField (#1203/#1297). Always present — the value
-// is not secret; the frontend gates rendering of authorship affordances on the
-// trusted tier, not on the field's presence.
-//
-// `isModerator` is the SELF moderator signal (#1320): the resolver reads it
-// server-side off the `moderates` `relation_tuple` (`kunye/moderate.ts`'s
-// `isModerator`, the same tuple `Moderate.over(platform)` checks — never a
-// retired `user.role` column, ADR 0107), keyed on the CURRENT user, so it is only
-// ever the viewer's OWN mod status. Like `tier` it is always present (the divan
-// "yazar yap" affordance is gated frontend-side); a dual-role yazar+moderator reads
-// `tier: "yazar"` + `isModerator: true`, which `tier` alone cannot express.
+// `tier` must be filled from `Kunye.tierOf` (the stored `user.tier` column read
+// fresh), NEVER from the `input:false` better-auth session additionalField
+// (#1203/#1297). `isModerator` is keyed on the CURRENT user, so it is only ever the
+// viewer's OWN mod status, read off the `moderates` relation tuple (ADR 0107 §4).
 export class UserView extends FateDataView<UserViewRow>()("User")(userViewFields) {}
 
-// The **discriminant** view for the profile contributions feed: fate has no
-// union type, so the variants' fields are flattened onto one row keyed by a
-// `kind` discriminant (ADR 0018; flattened by `shapers.toContributionRow`).
-// The field map IS the keys of `ContributionRow`, which derives from the
-// `ContributionVariants` manifest in `Pasaport.ts` — `ContributionViewRow` is
-// `ViewRow<ContributionRow>`, so a field added there (or dropped here) is a
-// compile error, never a silent flatten drift.
+// fate has no union type, so the variants' fields are flattened onto one row keyed
+// by a `kind` discriminant (ADR 0018).
 export class ContributionView extends FateDataView<ContributionViewRow>()("Contribution")({
 	kind: true,
 	id: true,
 	score: true,
 	createdAt: true,
-	// The per-item review-state flag (#1316): `true` for a still-sandboxed item, so
-	// #1291 can badge "incelemede". Carries no reviewer identity (one-way-glass).
+	// Carries no reviewer identity (one-way-glass, #1316).
 	sandboxed: true,
 	bodyExcerpt: true,
 	termSlug: true,
@@ -64,22 +45,19 @@ export class ContributionView extends FateDataView<ContributionViewRow>()("Contr
 	postTitle: true,
 } satisfies {[K in keyof ContributionViewRow]: true}) {}
 
-// `id` is the client's normalization key (codegen hardcodes `getId` to
-// `record.id`); a `Profile` is one-to-one with its user, so `id` === `userId`,
-// stamped by `queries.profile`. Without it the client throws `Missing 'id' on
-// entity record` when normalizing (see `.patterns/fate-data-views.md`). `userId`
-// stays for callers reading the raw per-type id (the source `byId` is keyed by it).
-// `contributions.orderBy` derives from `contributionOrdering` (ADR 0019).
+// Every view here needs an `id`: it is the client's normalization key (codegen
+// hardcodes `getId` to `record.id`), and without it the client throws `Missing 'id'
+// on entity record` when normalizing (see `.patterns/fate-data-views.md`). A
+// `Profile` is one-to-one with its user, so `id` === `userId`, and `userId` stays
+// for callers reading the raw per-type id.
 export class ProfileView extends FateDataView<ProfileViewRow>()("Profile")({
 	...profileViewFields,
 	contributions: FateDataView.list(ContributionView, {orderBy: CONTRIBUTION_VIEW_ORDER_BY}),
 }) {}
 
-// The `account.delete` acknowledgement (ADR 0097) — NOT a re-resolved entity. The
-// deleting user's `User` row is scrubbed to a tombstone, so re-resolving it would
-// leak the half-emptied row; the mutation returns a small typed ack instead. The
-// synthetic `id` is the `account:deleted` literal — one receipt shape, no per-user
-// payload to leak. Mirrors `ReportReceipt`; see `.patterns/fate-effect-data-views.md`.
+// NOT a re-resolved entity: the deleting user's `User` row is scrubbed to a
+// tombstone, so re-resolving it would leak the half-emptied row (ADR 0097). The
+// synthetic `id` is the `account:deleted` literal — no per-user payload to leak.
 export type AccountDeletionReceiptViewRow = ViewRow<{id: string; deleted: boolean}>;
 
 export class AccountDeletionReceiptView extends FateDataView<AccountDeletionReceiptViewRow>()(
@@ -89,13 +67,8 @@ export class AccountDeletionReceiptView extends FateDataView<AccountDeletionRece
 	deleted: true,
 } satisfies {[K in keyof AccountDeletionReceiptViewRow]: true}) {}
 
-// The çaylak→yazar promotion acknowledgement (#1206) — NOT a re-resolved entity
-// (the promotion's effects, the flipped tier + the swept backlog, are read through
-// the existing `Profile` / content views). The mutation returns a small typed ack:
 // `promoted` = did the tier flip this call; `vouchRecorded` = was a new vouch
-// persisted this call (vouch path only — the mod path never records a vouch). The
-// `id` carries the target so two targets resolve as distinct receipts. Mirrors
-// `AccountDeletionReceipt`; see `.patterns/fate-effect-data-views.md`.
+// persisted this call (vouch path only — the mod path never records a vouch).
 export type PromotionReceiptViewRow = ViewRow<{
 	id: string;
 	userId: string;
@@ -112,13 +85,8 @@ export class PromotionReceiptView extends FateDataView<PromotionReceiptViewRow>(
 	vouchRecorded: true,
 } satisfies {[K in keyof PromotionReceiptViewRow]: true}) {}
 
-// The admin ban-state readout / ban-unban acknowledgement (epic #968) — the
-// projected current ban-state for one account. `id` === the target user id (the
-// client normalization key), so the admin ban surface reads and the ban/unban
-// mutation ack reconcile the SAME entity. `expiresAt` is epoch-millis (or null =
-// permanent / not-banned) to keep the wire scalar plain; `reason` is null when not
-// banned. It carries ONLY the ban-state — no session, no PII — and is only ever
-// produced past the `requireAdmin` gate + the dark-ship flag, so it never leaks.
+// `expiresAt` is epoch-millis (or null = permanent / not-banned) to keep the wire
+// scalar plain. Carries ONLY the ban-state — no session, no PII.
 export type BanStateViewRow = ViewRow<{
 	id: string;
 	banned: boolean;
@@ -133,12 +101,8 @@ export class BanStateView extends FateDataView<BanStateViewRow>()("BanState")({
 	expiresAt: true,
 } satisfies {[K in keyof BanStateViewRow]: true}) {}
 
-// The admin email-delivery-state ack (email-bounce epic #2687) — the projected current
-// delivery-state for one address, returned by the `emailDelivery.mark` / `emailDelivery.clear`
-// mutations. `id` === the target address (the client normalization key), so the mark and the
-// clear reconcile the SAME entity. It carries ONLY the delivery-state (`failing` + the active
-// `reason`) — no session, no PII beyond the address the admin already targeted — and is only
-// ever produced past the `requireAdmin` gate + the dark-ship flag, so it never leaks.
+// `id` === the target address, so `emailDelivery.mark` and `emailDelivery.clear`
+// reconcile the SAME entity.
 export type EmailDeliveryStateViewRow = ViewRow<{
 	id: string;
 	failing: boolean;
@@ -153,11 +117,8 @@ export class EmailDeliveryStateView extends FateDataView<EmailDeliveryStateViewR
 	reason: true,
 } satisfies {[K in keyof EmailDeliveryStateViewRow]: true}) {}
 
-// One currently-failing address in the admin roll-up (`emailDelivery.failing`, epic #2687)
-// — the address, who it resolves to (nullable: a send can fail to an address with no account
-// row), why, and when it started failing (`since`, epoch-millis to keep the wire scalar
-// plain). `id` === the address (the client normalization key). Only ever produced past the
-// `requireAdmin` gate + the dark-ship flag, so the roll-up never leaks.
+// `userId` is nullable: a send can fail to an address with no account row. `since`
+// is epoch-millis to keep the wire scalar plain.
 export type FailingAddressViewRow = ViewRow<{
 	id: string;
 	address: string;
@@ -174,13 +135,8 @@ export class FailingAddressView extends FateDataView<FailingAddressViewRow>()("F
 	since: true,
 } satisfies {[K in keyof FailingAddressViewRow]: true}) {}
 
-// The admin role-assignment ack (#3522, admin epic per ADR 0107) — the projected
-// role returned by the `user.setRole` mutation. `id` === the target user id (the
-// client normalization key), so the ack reconciles the SAME account the roster
-// (`UserAdmin`) lists; `role` is the newly-assigned platform role (`moderator` iff
-// the `moderates` tuple was granted, else `member`). It carries ONLY the role — no
-// session, no PII — and is only ever produced past the `requireAdmin` gate + the
-// dark-ship flag, so it never leaks. Mirrors `BanStateView`.
+// `role` is `moderator` iff the `moderates` tuple was granted, else `member`
+// (ADR 0107). Carries ONLY the role — no session, no PII.
 export type RoleStateViewRow = ViewRow<{
 	id: string;
 	role: PlatformRole;
@@ -191,19 +147,12 @@ export class RoleStateView extends FateDataView<RoleStateViewRow>()("RoleState")
 	role: true,
 } satisfies {[K in keyof RoleStateViewRow]: true}) {}
 
-// The çaylak-SELF authorship-standing aggregate (#1316, epic #1202) — the
-// "yazarlığa giden yol" read the #1291 status block consumes about ITSELF. The
-// subject is always the authenticated çaylak (the `myAuthorshipStanding` resolver
-// keys it on `CurrentUser`, never an input arg), so it can only ever describe the
-// reader's own progress.
-//
 // ONE-WAY-GLASS, ENFORCED IN THE TYPE (#1316 hard AC): the row carries ONLY
-// aggregate scalars — `karma`/`bar` (numbers), `vouchExists` (a bare boolean, NOT
-// who vouched), `inReviewCount` (a bare count, NOT which items or who is reviewing).
-// There is deliberately NO reviewer / voter / voucher identity field, so a leak is
-// structurally unrepresentable, not merely unsent — the reason this is a NEW
-// self-scoped view and not a widening of the identity-carrying divan roster / vouch
-// ledger. `id` === the user id (the client normalization key).
+// aggregate scalars — `vouchExists` is a bare boolean, NOT who vouched;
+// `inReviewCount` a bare count, NOT which items or who is reviewing. Adding any
+// reviewer / voter / voucher identity field here breaks the invariant, which is why
+// this is a self-scoped view rather than a widening of the divan roster or the
+// vouch ledger. The subject is always `CurrentUser`, never an input arg.
 export type AuthorshipStandingViewRow = ViewRow<{
 	id: string;
 	karma: number;
@@ -222,8 +171,6 @@ export class AuthorshipStandingView extends FateDataView<AuthorshipStandingViewR
 	inReviewCount: true,
 } satisfies {[K in keyof AuthorshipStandingViewRow]: true}) {}
 
-// The plain kernel `dataView()` values, for cross-feature surfaces (the
-// `fate/views.ts` `Root` map + barrel re-exports).
 export const userDataView = UserView.view;
 export const contributionDataView = ContributionView.view;
 export const profileDataView = ProfileView.view;

--- a/apps/web/worker/features/reaction/Reaction.testing.ts
+++ b/apps/web/worker/features/reaction/Reaction.testing.ts
@@ -1,13 +1,8 @@
 /**
- * `ReactionStub` — a no-reactions `Reaction` service double for the unit tests that
- * build `PanoLive` / `SozlukLive` over a substituted `Drizzle` seam. Those services
- * now stamp the reaction aggregate on their reads (`Reaction.readAggregate`, #1862),
- * so a test that provides only `Vote`/`Bookmark`/`Drizzle` leaves `Reaction`
- * unsatisfied in `R`. This stub discharges it: `readAggregate` / `readMine` return
- * empty (no reactions), so the aggregate field degrades to the empty aggregate and no
- * extra DB read happens through the reaction service — the react/change/retract write
- * paths are the domain tests' concern (`Reaction.unit.test.ts`), never these
- * connection/validation tests, so they die if reached.
+ * A no-reactions `Reaction` double, discharging the `R` requirement that `PanoLive` /
+ * `SozlukLive` reads pick up from stamping the reaction aggregate (#1862). The write
+ * paths die if reached — they belong to `Reaction.unit.test.ts`, not to the
+ * connection/validation tests this serves.
  */
 import {Effect, Layer} from "effect";
 import type {ReactionEmoji} from "../../db/reaction-emoji.ts";

--- a/apps/web/worker/features/reaction/Reaction.ts
+++ b/apps/web/worker/features/reaction/Reaction.ts
@@ -1,34 +1,11 @@
 /**
- * Reaction — the karma-free, ungated vote-engine twin. One canonical write
- * surface (`Reaction.react`) for the three reaction targets (`definition` |
- * `post` | `comment`), the third instance of the polymorphic per-user-presence
- * pattern (after `user_vote` / `post_bookmark`). Modeled on the pure-presence
- * {@link ../pano/Bookmark.ts Bookmark} shape rather than {@link ../vote/Vote.ts
- * Vote}: no score, no hot-score recompute, and — deliberately — no karma.
+ * Reaction — the karma-free, ungated vote-engine twin: one write surface
+ * (`Reaction.react`) over the three targets (`definition` | `post` | `comment`),
+ * with the composite PK `(user_id, target_kind, target_id)` as the one-per-user
+ * cardinality constraint, so a change is an upsert on `emoji`.
  *
- * UNGATED, deliberately (the settled divergence from Vote, #1861): a reaction is
- * a pure social signal that carries no karma, so ANY authenticated user —
- * including a çaylak newcomer — may react. There is NO `VoterStanding`/tier gate
- * (the #1810 "earn to vote" floor is Vote's alone) and NO `KarmaBump`
- * collaborator: the karma-bearing vote stays the sole karma lever, untouched.
- * A future reader must NOT "fix" this by wiring the tier gate — the ungatedness
- * is the point.
- *
- * Unlike bookmark (pure presence, no value), a reaction carries a value: the
- * chosen `emoji`, constrained to the curated `REACTION_EMOJI` palette. The
- * composite PK `(user_id, target_kind, target_id)` on `user_reaction` is the
- * cardinality-one constraint — at most one reaction per user per item — so
- * CHANGING a reaction is an upsert on the `emoji` column (`onConflictDoUpdate`).
- * `react` mirrors `Vote.cast`/`Bookmark.toggle` probe-then-write idempotency and
- * the `changed`-returning result: a new emoji replaces the prior one; re-reacting
- * the SAME emoji is a no-op (`changed: false`); a `null` emoji retracts (removes
- * the row).
- *
- * The `definition | post | comment` fan-out for the target-liveness check
- * dispatches through the shared `targetTable` descriptor seam
- * ({@link ../../db/target-table.ts}) — no re-stated per-kind switch. The
- * `user_reaction` cross-product table itself is Reaction-owned (the `user_vote`
- * twin Vote owns), so its reads/writes address `schema.userReaction` directly.
+ * Ungated and karma-free deliberately (ADR 0139): no `VoterStanding` tier gate and
+ * no `KarmaBump` — a future reader must NOT "fix" this by wiring the vote's gate in.
  */
 import {and, eq, inArray, sql} from "drizzle-orm";
 import {Context, Effect, Layer} from "effect";
@@ -42,80 +19,57 @@ import {TargetId} from "../../lib/ids.ts";
 import {Telemetry} from "../telemetry/Telemetry.ts";
 import {ReactionTargetNotFound} from "./errors.ts";
 
-// Re-exported from `db/target-kind.ts` (its source-of-truth home) for callers
-// that prefer importing it from `./Reaction`.
 export type {TargetKind};
 
 export interface ReactInput {
 	userId: string;
 	targetKind: TargetKind;
 	targetId: string;
-	/**
-	 * The reaction intent, a curated-palette member or a retract. A palette emoji
-	 * sets/changes the user's single reaction; `null` retracts it (toggle off).
-	 * The type only admits a `ReactionEmoji`, so a non-palette string is already
-	 * rejected upstream by `ReactionEmojiSchema` at the wire boundary — the
-	 * service never sees one.
-	 */
+	/** A palette emoji sets or replaces the reaction; `null` retracts it. */
 	emoji: ReactionEmoji | null;
 }
 
 export interface ReactResult {
 	targetKind: TargetKind;
 	targetId: string;
-	/** The viewer's reaction after the write — the chosen palette emoji, or `null` if none/retracted. */
 	myReaction: ReactionEmoji | null;
 	/** `false` on an idempotent no-op (state already matched intent). */
 	changed: boolean;
 }
 
-/** One palette member's tally on a target — the non-zero cell of the reaction bar. */
 export interface ReactionCount {
 	emoji: ReactionEmoji;
 	count: number;
 }
 
 /**
- * A target's reaction aggregate — the read half the fate views expose (the
- * `score`/`isSaved` twin, #1862). `counts` are the per-emoji `COUNT(*)` tallies
- * ORDERED by the curated `REACTION_EMOJI` palette (so every reader — human or
- * agent — sees the bar in one canonical order), and only palette members with a
- * non-zero tally appear (a target with no reactions has an empty `counts`).
- * `myReaction` is the viewer's own current emoji (the `readMine` value), or
- * `null` when the viewer is anonymous or has not reacted — the reaction twin of
- * `myVote`.
+ * A target's reaction aggregate. `counts` holds only palette members with a non-zero
+ * tally, ordered by the curated `REACTION_EMOJI` palette so every reader sees the bar
+ * in one canonical order; `myReaction` is `null` for an anonymous or non-reacting viewer.
  */
 export interface ReactionAggregate {
 	counts: ReadonlyArray<ReactionCount>;
 	myReaction: ReactionEmoji | null;
 }
 
-/** The empty aggregate — no reactions, no viewer reaction. The neutral fill for a target absent from a batch read. */
 export const EMPTY_REACTION_AGGREGATE: ReactionAggregate = {counts: [], myReaction: null};
 
-// Palette member → its position, so a batched aggregate row set can be sorted
-// into the one canonical `REACTION_EMOJI` order regardless of GROUP BY row order.
+// Palette member → its position, so a batched aggregate can be sorted into the one
+// canonical `REACTION_EMOJI` order regardless of GROUP BY row order.
 const PALETTE_ORDER = new Map<string, number>(REACTION_EMOJI.map((emoji, i) => [emoji, i]));
 
 export class Reaction extends Context.Service<
 	Reaction,
 	{
 		/**
-		 * Upsert the user's single reaction on a target (cardinality one-per-(user,
-		 * target)). A palette `emoji` sets or REPLACES the prior reaction; passing
-		 * the same emoji already held is an idempotent no-op (`changed: false`); a
-		 * `null` emoji RETRACTS (removes the row). Rejects a missing/removed target
-		 * with {@link ReactionTargetNotFound}. UNGATED and karma-free: no tier gate,
-		 * no karma write — anyone logged in may react.
+		 * A palette `emoji` sets or REPLACES the prior reaction; the same emoji already
+		 * held is an idempotent no-op (`changed: false`); `null` RETRACTS. Rejects a
+		 * missing/removed target with {@link ReactionTargetNotFound}.
 		 */
 		readonly react: (input: ReactInput) => Effect.Effect<ReactResult, ReactionTargetNotFound>;
 		/**
-		 * Batched presence read: for each of `targetIds` the viewer has a reaction
-		 * on, its current emoji — returned as a `Map<targetId, ReactionEmoji>` so
-		 * hydration stamps the viewer's reaction without an N+1 (the
-		 * `Vote.readMine` / `Bookmark.readMine` twin, extended to carry the emoji
-		 * value). Missing viewer or empty `targetIds` short-circuits to an empty Map
-		 * with no read.
+		 * Batched presence read: the viewer's current emoji per target, so hydration stamps
+		 * a page without an N+1. Missing viewer or empty `targetIds` reads nothing.
 		 */
 		readonly readMine: (
 			viewerId: string | null | undefined,
@@ -123,19 +77,10 @@ export class Reaction extends Context.Service<
 			targetIds: ReadonlyArray<string>,
 		) => Effect.Effect<Map<string, ReactionEmoji>>;
 		/**
-		 * Batched aggregate read: for a page of `targetIds` of one `kind`, each
-		 * target's per-emoji `COUNT(*)` tallies (ordered by `REACTION_EMOJI`) plus the
-		 * viewer's own current reaction — returned as a `Map<targetId,
-		 * ReactionAggregate>` so a whole page hydrates in ONE `GROUP BY` read + one
-		 * `readMine`, never an N+1. This is the fate-view read half (#1862): the
-		 * `score`/`isSaved` twin, exposed on the `post`/`comment`/`definition` views.
-		 * A target with no reactions is ABSENT from the map (the caller fills the empty
-		 * aggregate). Missing/empty `targetIds` short-circuits to an empty Map with no
-		 * read.
-		 *
-		 * The two reads (the `GROUP BY` tally + the viewer's `readMine`) are independent;
-		 * `options.concurrency` opts them into concurrent execution (`"unbounded"` for the
-		 * stamp-wave collapse, #2709). Absent ⇒ sequential, the unchanged default.
+		 * Batched aggregate read: one `GROUP BY` tally plus the viewer's `readMine` for a whole
+		 * page. A target with no reactions is ABSENT from the map (the caller fills the empty
+		 * aggregate). The two reads are independent; `options.concurrency` opts them into
+		 * concurrent execution — absent ⇒ sequential.
 		 */
 		readonly readAggregate: (
 			viewerId: string | null | undefined,
@@ -143,35 +88,21 @@ export class Reaction extends Context.Service<
 			targetIds: ReadonlyArray<string>,
 			options?: {readonly concurrency?: Concurrency},
 		) => Effect.Effect<Map<string, ReactionAggregate>>;
-		/**
-		 * The single reaction-cleanup home for the removal substrate (ADR 0096 §3,
-		 * the `Vote.clearTarget` twin): wipe the `user_reaction` rows for one target
-		 * in one D1 batch (ADR 0014). No score/karma cache to touch — reactions have
-		 * none — so a removed entity never carries orphan reaction rows.
-		 */
+		/** Wipes one target's `user_reaction` rows for the removal substrate (ADR 0096 §3). */
 		readonly clearTarget: (kind: TargetKind, targetId: string) => Effect.Effect<void>;
 	}
 >()("@kampus/reaction/Reaction") {}
 
 export const ReactionLive = Layer.effect(Reaction)(
 	Effect.gen(function* () {
-		// `orDieAccess`: DB failures are defects (domain-boundary rule), so the
-		// public signature carries `ReactionTargetNotFound` only and `R` stays `never`.
 		const {run, batch} = orDieAccess(yield* Drizzle);
 
-		// The product-usage telemetry seam (ADR 0153, epic #2065). Resolved once at
-		// layer build (isolate-level, discharged at the `makeFateLayer` merge) so
-		// `react` gains no per-request wiring. `emit` is fire-and-forget best-effort:
-		// its error + requirement channels are discharged inside `TelemetryLive`, so a
-		// telemetry failure can never fail the reaction it observes (ADR 0153 fail-safe).
+		// Resolved once at layer build so `react` gains no per-request wiring. `emit` is
+		// fire-and-forget: its failure is swallowed in `TelemetryLive` (ADR 0153 fail-safe).
 		const telemetry = yield* Telemetry;
 
-		// Target-liveness lookup through the shared descriptor seam — the same
-		// `definition | post | comment` fan-out Vote/Report dispatch through, so
-		// the per-kind switch lives once in `db/target-table.ts`, not here. We only
-		// need existence (a removed/missing target is `null`); the descriptor's
-		// karma/sandbox fields are Vote's concern and go unread — reactions are
-		// ungated, so a sandboxed target is reactable like any other live row.
+		// Existence only — the descriptor's karma/sandbox fields are Vote's concern and go
+		// unread, since a sandboxed target is reactable like any other live row.
 		const assertTargetLive = Effect.fn("Reaction.assertTargetLive")(function* (
 			kind: TargetKind,
 			targetId: string,
@@ -230,12 +161,9 @@ export const ReactionLive = Layer.effect(Reaction)(
 			const out = new Map<string, ReactionAggregate>();
 			if (targetIds.length === 0) return out;
 
-			// One GROUP BY over the whole page — per (target, emoji) COUNT(*), served
-			// by the `user_reaction_target` index (schema.ts). Anonymous viewer's own
-			// reaction is `null` (readMine short-circuits with no read). The two reads
-			// are independent; `Effect.all` runs them sequentially by default (effect's
-			// `concurrency ?? 1`), so `options.concurrency` is what collapses them into
-			// one wave phase for the #2709 stamp-wave — omitted ⇒ unchanged sequential.
+			// One GROUP BY over the whole page, served by the `user_reaction_target` index.
+			// `Effect.all` defaults to `concurrency: 1`, so passing one is what collapses the two
+			// reads into a single wave phase.
 			const [rows, mine] = yield* Effect.all(
 				[
 					run((db) =>
@@ -259,7 +187,6 @@ export const ReactionLive = Layer.effect(Reaction)(
 				{concurrency: options?.concurrency ?? 1},
 			);
 
-			// Fold the flat (target, emoji, count) rows into per-target count arrays.
 			const byTarget = new Map<string, ReactionCount[]>();
 			for (const row of rows) {
 				const list = byTarget.get(row.targetId) ?? [];
@@ -267,9 +194,7 @@ export const ReactionLive = Layer.effect(Reaction)(
 				byTarget.set(row.targetId, list);
 			}
 
-			// A target appears in the result iff it has reactions OR the viewer reacted
-			// on it — the union of the count keys and the viewer's own reactions, each
-			// stamped with the viewer's emoji and the palette-ordered counts.
+			// A target appears iff it has reactions OR the viewer reacted on it.
 			const targets = new Set<string>([...byTarget.keys(), ...mine.keys()]);
 			for (const targetId of targets) {
 				const counts = (byTarget.get(targetId) ?? []).sort(
@@ -288,9 +213,7 @@ export const ReactionLive = Layer.effect(Reaction)(
 
 				const existing = yield* probeExisting(input.targetKind, input.targetId, input.userId);
 
-				// State already matches intent → no write. Covers both the
-				// re-react-same-emoji no-op (existing === emoji) and the
-				// retract-when-none no-op (both null).
+				// Covers both the re-react-same-emoji and the retract-when-none no-op.
 				if (existing === input.emoji) {
 					return {
 						targetKind: input.targetKind,
@@ -315,9 +238,8 @@ export const ReactionLive = Layer.effect(Reaction)(
 									),
 							] as const)
 						: ([
-								// Upsert on the composite PK: a first react inserts, a change
-								// overwrites the `emoji` in place — exactly one row per
-								// (user, target) always holds (cardinality one).
+								// Upsert on the composite PK: a first react inserts, a change overwrites
+								// `emoji` in place, so exactly one row per (user, target) always holds.
 								db
 									.insert(schema.userReaction)
 									.values({
@@ -338,14 +260,8 @@ export const ReactionLive = Layer.effect(Reaction)(
 							] as const),
 				);
 
-				// Fire-and-forget product-usage emit, AFTER the write commits and only
-				// on a real state change — the early `changed: false` return above means
-				// a no-op re-react/retract emits nothing (ADR 0153, #2069). `action`
-				// distinguishes a set/change (`react`) from the null-emoji toggle-off
-				// (`retract`); `surface` is the target kind; `emoji` rides the trailing
-				// blob slot (retract carries none). `emit` is `Effect<void>` with its
-				// failure swallowed in `TelemetryLive`, so this can never fail or delay
-				// the reaction (ADR 0153 fail-safe, S4).
+				// After the write commits and only on a real change — the `changed: false` return
+				// above means a no-op emits nothing (ADR 0153).
 				yield* telemetry.emit({
 					feature: "reaction",
 					action: input.emoji === null ? "retract" : "react",
@@ -371,12 +287,7 @@ export const ReactionLive = Layer.effect(Reaction)(
 	}),
 );
 
-/**
- * The one statement clearing a target's reactions: the `user_reaction` rows for
- * that (kind, target). Wrapped as a batch tuple for the same all-or-nothing
- * shape as `Vote.clearTarget` (ADR 0014); there is no score/karma cache to
- * co-mutate, so it is a single-statement batch.
- */
+/** One statement, wrapped as a batch tuple for the `Vote.clearTarget` shape (ADR 0014). */
 function buildClearTargetStatements(db: DrizzleDb, kind: TargetKind, targetId: string) {
 	return [
 		db

--- a/apps/web/worker/features/reaction/Reaction.unit.test.ts
+++ b/apps/web/worker/features/reaction/Reaction.unit.test.ts
@@ -1,18 +1,11 @@
 /**
- * Reaction unit coverage — the decisions that are wrong-or-right with no
- * database (ADR 0082). The `Drizzle` seam is substituted directly (the
- * `Vote.unit.test.ts` idiom): a `run`/`batch` that THROWS proves a short-circuit
- * never touched the DB, a stubbed `run` feeds the decision its inputs, and a
- * recording `batch` captures the produced statement array so the write SHAPE is
- * asserted without an engine. Reaction's real-D1 fidelity — composite-PK upsert
- * (the emoji changes in place, still one row), retract removes the row,
- * soft-delete not-found — lives on real D1 in `tests/integration/`.
+ * Reaction unit coverage — the decisions that are wrong-or-right with no database (ADR 0082);
+ * real-D1 fidelity lives in `tests/integration/`. The `Drizzle` seam is substituted directly
+ * (the `Vote.unit.test.ts` idiom).
  *
- * The load-bearing divergence from Vote is proven structurally here: the
- * `ReactionLive` layer is built with NO `KarmaBump` and NO `VoterStanding`
- * dependency — the react tests below drive `react` to completion against a layer
- * that provides only `Drizzle`, so a çaylak (any user) reacting reaches the write
- * with no tier gate and no karma statement. Reactions are ungated and karma-free.
+ * The load-bearing divergence from Vote is proven structurally: `ReactionLive` is built with NO
+ * `KarmaBump` and NO `VoterStanding`, so a çaylak reaching the write proves reactions are
+ * ungated and karma-free.
  */
 import {assert, describe, it} from "@effect/vitest";
 import {Effect, Layer} from "effect";
@@ -25,17 +18,14 @@ import {dyingTelemetry, recordingTelemetry} from "../telemetry/Telemetry.testing
 import type {Telemetry} from "../telemetry/Telemetry.ts";
 import {Reaction, ReactionLive} from "./Reaction.ts";
 
-// A `Drizzle` whose every call throws — any path that actually reaches the DB
-// seam fails the test. A guard that short-circuits before reading runs to
-// completion against it, the "no read" proof.
+// Every call throws: a path that short-circuits before the DB runs to completion against it.
 const throwingAccess: DrizzleAccess = {
 	run: () => Effect.die(new Error("Reaction read the DB on a path that must short-circuit")),
 	batch: () => Effect.die(new Error("Reaction wrote a batch on a path that must short-circuit")),
 };
 
-// A `Drizzle` whose `run` replays a queued sequence of results and whose `batch`
-// throws — drives `react`'s pre-batch decision (assertTargetLive + probe) while
-// proving the idempotent no-op never reaches `batch`.
+// `run` replays a queued sequence of results; `batch` throws, so a no-op that reaches the
+// write fails the test.
 function scriptedAccess(results: ReadonlyArray<unknown>): DrizzleAccess {
 	const state = {i: 0};
 	return {
@@ -47,10 +37,8 @@ function scriptedAccess(results: ReadonlyArray<unknown>): DrizzleAccess {
 	};
 }
 
-// A recording write-path seam: `run` replays the pre-batch reads (assertTargetLive
-// meta, probe) and `batch` records the produced statement array against a chainable
-// db proxy, so a state-changing react is asserted (it reaches the write, its batch
-// carries exactly one statement) without a real engine.
+// `run` replays the pre-batch reads, `batch` records the produced statement array against a
+// chainable db proxy — the write SHAPE without a real engine.
 function recordingAccess(reads: ReadonlyArray<unknown>): {
 	access: DrizzleAccess;
 	batches: ReadonlyArray<unknown>[];
@@ -72,29 +60,21 @@ function recordingAccess(reads: ReadonlyArray<unknown>): {
 	return {access, batches};
 }
 
-// The Reaction layer under test. It provides `Drizzle` and `Telemetry` (the
-// product-usage seam `Reaction.react` emits through, #2069). There is still NO
-// KarmaBump and NO VoterStanding to provide, because Reaction declares neither
-// (the ungated, karma-free divergence from Vote) — that the layer builds without
-// them IS the "no tier gate, no karma" proof at the seam. `telemetry` defaults to
-// a discarding recording sink so the react/change/no-op/retract write tests need
-// no telemetry setup; the emit tests pass a recording sink or the dying double.
+// There is NO KarmaBump and NO VoterStanding to provide, because Reaction declares neither —
+// that the layer builds without them IS the "no tier gate, no karma" proof at the seam.
 const reactionLayer = (
 	access: DrizzleAccess,
 	telemetry: Layer.Layer<Telemetry> = recordingTelemetry([]),
 ) => ReactionLive.pipe(Layer.provide(Layer.mergeAll(Layer.succeed(Drizzle, access), telemetry)));
 
-// A live target meta the descriptor's loadMeta returns (author/createdAt/sandboxed
-// are Vote's fields; Reaction reads none of them — it only needs existence).
+// `authorId`/`sandboxed` are Vote's fields; Reaction reads none of them, only existence.
 const liveMeta = {authorId: "author-1", createdAtMs: 0, sandboxed: false};
-// A sandboxed target — Reaction reacts to it like any other live row (ungated).
 const sandboxedMeta = {authorId: "caylak-1", createdAtMs: 0, sandboxed: true};
 
 describe("Reaction.react — target liveness (mocked Drizzle seam)", () => {
 	it.effect("a missing/removed target raises ReactionTargetNotFound before any write", () =>
 		Effect.gen(function* () {
 			const reaction = yield* Reaction;
-			// assertTargetLive's loadMeta resolves to `undefined` → not-found, no batch.
 			const exit = yield* Effect.exit(
 				reaction.react({userId: "u1", targetKind: "definition", targetId: "ghost", emoji: "👍"}),
 			);
@@ -108,9 +88,6 @@ describe("Reaction.react — react / change / no-op / retract (mocked Drizzle se
 	it.effect(
 		"a first react on a fresh target writes one upsert statement — ungated, no karma",
 		() => {
-			// reads: assertTargetLive → live meta; probe → no existing reaction (null).
-			// Any user reaches the write: the layer has NO tier gate, and the single-statement
-			// batch has NO karma statement (there is no KarmaBump to produce one).
 			const {access, batches} = recordingAccess([liveMeta, null]);
 			return Effect.gen(function* () {
 				const reaction = yield* Reaction;
@@ -133,8 +110,6 @@ describe("Reaction.react — react / change / no-op / retract (mocked Drizzle se
 	);
 
 	it.effect("changing an existing reaction replaces the emoji (still one upsert, one row)", () => {
-		// probe → the user already holds 👍; the new emoji ❤️ differs, so it is a real
-		// change writing the upsert (onConflictDoUpdate overwrites in place — cardinality one).
 		const {access, batches} = recordingAccess([liveMeta, "👍"]);
 		return Effect.gen(function* () {
 			const reaction = yield* Reaction;
@@ -151,8 +126,6 @@ describe("Reaction.react — react / change / no-op / retract (mocked Drizzle se
 	});
 
 	it.effect("re-reacting the SAME emoji is an idempotent no-op — no batch", () => {
-		// probe → the user already holds 👍 and reacts 👍 again: state matches intent,
-		// so no write. The throwing `batch` in scriptedAccess proves the no-op path.
 		const access = scriptedAccess([liveMeta, "👍"]);
 		return Effect.gen(function* () {
 			const reaction = yield* Reaction;
@@ -168,8 +141,6 @@ describe("Reaction.react — react / change / no-op / retract (mocked Drizzle se
 	});
 
 	it.effect("retract (emoji: null) on an existing reaction removes the row — one delete", () => {
-		// probe → the user holds 😂; retract intent (null) differs, so it is a real change
-		// writing the single delete statement.
 		const {access, batches} = recordingAccess([liveMeta, "😂"]);
 		return Effect.gen(function* () {
 			const reaction = yield* Reaction;
@@ -186,7 +157,6 @@ describe("Reaction.react — react / change / no-op / retract (mocked Drizzle se
 	});
 
 	it.effect("retract when NONE held is an idempotent no-op — no batch", () => {
-		// probe → no existing reaction (null); retract intent (null) matches, so no write.
 		const access = scriptedAccess([liveMeta, null]);
 		return Effect.gen(function* () {
 			const reaction = yield* Reaction;
@@ -202,8 +172,7 @@ describe("Reaction.react — react / change / no-op / retract (mocked Drizzle se
 	});
 
 	it.effect("a sandboxed target is reactable — reactions are ungated (no sandbox gate)", () => {
-		// The descriptor returns a still-sandboxed meta; Vote would REJECT it, but Reaction
-		// reads no sandbox flag and reaches the write. This is the deliberate divergence.
+		// Vote would REJECT a still-sandboxed target; Reaction reads no sandbox flag. Deliberate.
 		const {access, batches} = recordingAccess([sandboxedMeta, null]);
 		return Effect.gen(function* () {
 			const reaction = yield* Reaction;
@@ -223,9 +192,6 @@ describe("Reaction.react — product-usage telemetry (ADR 0153, #2069)", () => {
 	it.effect(
 		"a committed react emits one {feature, action: react, surface, emoji, userId} event",
 		() => {
-			// probe → no existing reaction; a fresh react commits, then emits. `surface` is
-			// the target kind (`post`), `emoji` rides the trailing blob slot, `userId` is
-			// the reacting user (approximate blob).
 			const {access} = recordingAccess([liveMeta, null]);
 			const events: TelemetryEvent[] = [];
 			return Effect.gen(function* () {
@@ -244,8 +210,6 @@ describe("Reaction.react — product-usage telemetry (ADR 0153, #2069)", () => {
 	);
 
 	it.effect("a change (different emoji) emits action: react with the NEW emoji", () => {
-		// probe → the user holds 👍; ❤️ differs → a real change. Set/change both map to
-		// `action: react` (only the null-emoji toggle-off is `retract`).
 		const {access} = recordingAccess([liveMeta, "👍"]);
 		const events: TelemetryEvent[] = [];
 		return Effect.gen(function* () {
@@ -258,8 +222,6 @@ describe("Reaction.react — product-usage telemetry (ADR 0153, #2069)", () => {
 	});
 
 	it.effect("a retract (emoji: null) emits action: retract with NO emoji", () => {
-		// probe → the user holds 😂; retract (null) differs → a real change removing the row.
-		// `action` is `retract` and the event carries no `emoji` (there is no emoji to record).
 		const {access} = recordingAccess([liveMeta, "😂"]);
 		const events: TelemetryEvent[] = [];
 		return Effect.gen(function* () {
@@ -272,8 +234,6 @@ describe("Reaction.react — product-usage telemetry (ADR 0153, #2069)", () => {
 	});
 
 	it.effect("a no-op re-react (changed: false) emits NOTHING", () => {
-		// probe → the user already holds 👍 and reacts 👍 again: the state matches intent,
-		// so `react` returns early with `changed: false` BEFORE the emit — no event.
 		const events: TelemetryEvent[] = [];
 		return Effect.gen(function* () {
 			const reaction = yield* Reaction;
@@ -291,7 +251,6 @@ describe("Reaction.react — product-usage telemetry (ADR 0153, #2069)", () => {
 	});
 
 	it.effect("a no-op retract-when-none-held emits NOTHING", () => {
-		// probe → no existing reaction; retract (null) matches → early `changed: false`, no emit.
 		const events: TelemetryEvent[] = [];
 		return Effect.gen(function* () {
 			const reaction = yield* Reaction;
@@ -309,8 +268,6 @@ describe("Reaction.react — product-usage telemetry (ADR 0153, #2069)", () => {
 	});
 
 	it.effect("a failed target-liveness check emits nothing (no react, no event)", () => {
-		// loadMeta → undefined → ReactionTargetNotFound before probe/write, so the emit
-		// (which sits after the committed write) is never reached.
 		const events: TelemetryEvent[] = [];
 		return Effect.gen(function* () {
 			const reaction = yield* Reaction;
@@ -323,11 +280,9 @@ describe("Reaction.react — product-usage telemetry (ADR 0153, #2069)", () => {
 	});
 
 	it.effect("the emit is off the commit path — the write commits before the emit runs", () => {
-		// The `Telemetry` double's `emit` DIES. The write is sequenced BEFORE the emit, so
-		// its statement is already recorded in `batches` (the reaction committed) even as the
-		// emit blows up — proving the emit is downstream of the commit, never a gate on it.
-		// (The production fail-safe that also swallows the failure lives in `TelemetryLive`
-		// and is pinned in `Telemetry.unit.test.ts`; here the double lets us see the ordering.)
+		// The `Telemetry` double's `emit` DIES, yet the statement is already in `batches` — the
+		// emit is downstream of the commit, never a gate on it. (The production fail-safe that
+		// swallows the failure lives in `TelemetryLive`, pinned in `Telemetry.unit.test.ts`.)
 		const {access, batches} = recordingAccess([liveMeta, null]);
 		return Effect.gen(function* () {
 			const reaction = yield* Reaction;
@@ -358,7 +313,6 @@ describe("Reaction.readMine — presence read (mocked Drizzle seam)", () => {
 	);
 
 	it.effect("returns each target's current emoji keyed by target id", () => {
-		// `run` replays the selected rows; readMine folds them into a Map<targetId, emoji>.
 		const rows = [
 			{targetId: "def-1", emoji: "👍"},
 			{targetId: "def-2", emoji: "❤️"},
@@ -387,9 +341,6 @@ describe("Reaction.readAggregate — per-emoji counts + viewer's own (mocked Dri
 	it.effect(
 		"no reactions on the page → every target absent (empty aggregate for the caller)",
 		() => {
-			// `run` replays: GROUP BY rows (none), then readMine rows (none) for the
-			// signed-in viewer. A target with no reactions and no viewer reaction is
-			// ABSENT from the map — the caller fills the empty aggregate.
 			const access = scriptedAccess([[], []]);
 			return Effect.gen(function* () {
 				const reaction = yield* Reaction;
@@ -413,10 +364,8 @@ describe("Reaction.readAggregate — per-emoji counts + viewer's own (mocked Dri
 	});
 
 	it.effect("a multi-emoji target → counts ORDERED by the REACTION_EMOJI palette", () => {
-		// The GROUP BY rows arrive in a NON-palette order; the aggregate must re-order
-		// them to the curated `REACTION_EMOJI` sequence (👍 ❤️ 😂 🤔 😢 🔥). The
-		// anonymous viewer's readMine short-circuits with NO read, so only the GROUP BY
-		// run is scripted here.
+		// The anonymous viewer's readMine short-circuits with NO read, so only the GROUP BY run
+		// is scripted here.
 		const groupBy = [
 			{targetId: "p1", emoji: "🔥", count: 1},
 			{targetId: "p1", emoji: "👍", count: 5},
@@ -447,7 +396,6 @@ describe("Reaction.readAggregate — per-emoji counts + viewer's own (mocked Dri
 			{targetId: "p1", emoji: "❤️", count: 1},
 			{targetId: "p2", emoji: "🔥", count: 4},
 		];
-		// The viewer reacted on p2 (not p1) and on p3 (which has no other reactions).
 		const mine = [
 			{targetId: "p2", emoji: "🔥"},
 			{targetId: "p3", emoji: "😢"},
@@ -468,16 +416,14 @@ describe("Reaction.readAggregate — per-emoji counts + viewer's own (mocked Dri
 				counts: [{emoji: "🔥", count: 4}],
 				myReaction: "🔥",
 			});
-			// p3 has the viewer's reaction but no aggregated counts — it still appears,
-			// with an empty `counts` and the viewer's emoji.
 			assert.deepStrictEqual(agg.get("p3"), {counts: [], myReaction: "😢"});
 		}).pipe(Effect.provide(reactionLayer(access)));
 	});
 });
 
 describe("Reaction.clearTarget — cleanup batch shape (ADR 0096 §3, mocked Drizzle seam)", () => {
-	// A recording batch seam whose db proxy makes every chained call return a marker,
-	// so we can count the produced statements without a real engine.
+	// A batch seam whose db proxy returns a marker for every chained call, so statements are
+	// countable without a real engine.
 	function recordingBatchAccess(): {access: DrizzleAccess; batches: ReadonlyArray<unknown>[]} {
 		const batches: ReadonlyArray<unknown>[] = [];
 		const chainable: Record<string, (...a: unknown[]) => unknown> = {};

--- a/apps/web/worker/features/reaction/errors.ts
+++ b/apps/web/worker/features/reaction/errors.ts
@@ -1,17 +1,10 @@
 /**
- * Tagged errors raised by the Reaction service layer.
+ * `ReactionTargetNotFound` carries NO `FateWireCode` by design: it never reaches the
+ * wire — a consuming service translates it at its own boundary.
  *
- * `ReactionTargetNotFound` carries NO `FateWireCode` by design (the
- * {@link ../vote/errors.ts VoteTargetNotFound} twin): it never reaches the wire.
- * A consuming service translates it at its own boundary via `Effect.catchTag`
- * (→ `DefinitionNotFound` / `PostNotFound` / `CommentNotFound`), so fate
- * handlers only ever emit the feature-level not-found errors.
- *
- * There is deliberately NO voter-tier / sandbox error here — reactions are
- * ungated and karma-free (the settled divergence from Vote, #1861): any
- * authenticated user, including a çaylak newcomer, may react. The only failure
- * mode is a missing/removed target; a non-palette emoji is rejected structurally
- * by `ReactionEmojiSchema` at the wire boundary, not by a service error.
+ * There is deliberately NO voter-tier or sandbox error here. Reactions are ungated and
+ * karma-free (the settled divergence from Vote, #1861), so any authenticated user
+ * including a çaylak may react.
  */
 import * as Schema from "effect/Schema";
 import {TargetKindSchema} from "../../db/target-kind.ts";

--- a/apps/web/worker/features/report/Report.testing.ts
+++ b/apps/web/worker/features/report/Report.testing.ts
@@ -1,15 +1,8 @@
 /**
- * `makeReportStub` — the shared `Report` test double. Defaults every one of the
- * `Report` methods to fail-on-contact (`Effect.die`) and takes a partial override
- * of the method(s) under test, returning the `Layer.succeed(Report, …)` layer. One
- * place the interface shape lives — adding a method to `Report` is a single edit
- * here, not shotgun surgery across every hand-rolled stub.
- *
- * A `layerStub` (fail-on-contact), not a `layerNoop` (silently-succeed): an
- * un-overridden method, if reached, dies and fails the test — the discipline that
- * proves the path under test touched only the method(s) it was scripted with.
- *
- * A **factory, not a shared instance** (`.patterns/effect-testing.md`).
+ * The shared `Report` test double. Fail-on-contact, not silently-succeed: an
+ * un-overridden method dies if reached, which is what proves the path under test touched
+ * only the methods it was scripted with. A factory, not a shared instance
+ * (`.patterns/effect-testing.md`).
  */
 import {Effect, Layer} from "effect";
 import {Report} from "./Report.ts";

--- a/apps/web/worker/features/report/Report.ts
+++ b/apps/web/worker/features/report/Report.ts
@@ -1,14 +1,8 @@
 /**
- * Report — the polymorphic content-report service. One canonical write surface
- * (`Report.submit`) for the three report targets: `definition`, `post`,
- * `comment`. Structurally mirrors {@link ../vote/Vote.ts | Vote} (a shared
- * low-level service over the same three targets, reached only through the
- * `Drizzle` seam, dying on infra errors via `orDieAccess`) minus the
- * `KarmaBump` contract — a report has no karma side-effect.
- *
- * Idempotency lives in the table: `content_report`'s composite PK
- * `(reporter_id, target_kind, target_id)` + `onConflictDoNothing` makes a
- * re-report by the same user a no-op success (the `user_vote` precedent). No
+ * Report — the polymorphic content-report service over the three targets
+ * (`definition` / `post` / `comment`). Idempotency lives in the table:
+ * `content_report`'s composite PK `(reporter_id, target_kind, target_id)` +
+ * `onConflictDoNothing` makes a re-report by the same user a no-op success. No
  * live view publishes off a write — a report is private moderation state.
  */
 import {and, eq, inArray, isNotNull, isNull, sql} from "drizzle-orm";
@@ -21,15 +15,12 @@ import {TargetId} from "../../lib/ids.ts";
 import {ReportTargetNotFound} from "./errors.ts";
 import * as Resolution from "./resolution.ts";
 
-// Re-exported from `db/target-kind.ts` (its source-of-truth home) for callers
-// that prefer importing it from `./Report`.
 export type {TargetKind};
 
 export interface ReportInput {
 	reporterId: string;
 	targetKind: TargetKind;
 	targetId: string;
-	/** Optional free-text reason. */
 	reason?: string | null;
 }
 
@@ -40,12 +31,7 @@ export interface ReportResult {
 	created: boolean;
 }
 
-/**
- * One row of the moderation queue (ADR 0098 §5): an open-reported target grouped
- * by `(targetKind, targetId)`, with the distinct-reporter count — the
- * repeat-offender / pile-on signal that comes free off the `content_report_target`
- * index. `reportCount` doubles as the count of open reports the resolve collapses.
- */
+/** One row of the moderation queue — open reports grouped by target. See ADR 0098 §5. */
 export interface OpenReportGroup {
 	targetKind: TargetKind;
 	targetId: string;
@@ -53,38 +39,22 @@ export interface OpenReportGroup {
 	reportCount: number;
 	/** The earliest open report's reason (representative free-text), or null. */
 	reason: string | null;
-	/** When the first open report on this target landed (oldest-first queue order). */
 	firstReportedAt: Date;
 }
 
 /**
- * One row of the shared decision feed (#1704, the two-person team-ledger): a
- * resolved/dismissed target grouped by `(targetKind, targetId)`, carrying the audit
- * triad `content_report` stamps on a terminal transition — the decision
- * (`removed`/`dismissed`), the **resolver** (which moderator), and when. Because
- * `resolveTarget` stamps every open row on a target with one uniform triad (and
- * `reopenForTarget` clears it), a target's terminal rows share a single decision, so
- * the group carries one resolver/resolution/resolvedAt. `resolvedAt` is the group's
- * most-recent terminal stamp — the decision feed's newest-first order.
+ * One row of the shared decision feed: a resolved/dismissed target with the audit
+ * triad. A target's terminal rows share one uniform triad (`resolveTarget` stamps
+ * them together), so the group carries a single resolver/resolution/waveId.
  */
 export interface ResolvedReportGroup {
 	targetKind: TargetKind;
 	targetId: string;
-	/** The decision the resolver made — `removed` (content soft-deleted) | `dismissed`. */
 	resolution: Resolution.Resolution;
-	/** The moderator who decided — first-class in the two-person ledger, never a footnote. */
 	resolverId: string;
-	/** When the decision landed (most-recent terminal stamp; newest-first feed order). */
 	resolvedAt: Date;
-	/** How many reports the decision collapsed on this target. */
 	reportCount: number;
-	/**
-	 * The wave grouping id (#1855, ADR 0138) shared across a batch's targets, or `null`
-	 * on a lone removal. A target's terminal rows share one `waveId` (`resolveTarget`
-	 * stamps them together), so the group carries the single value — the decision feed's
-	 * restore-as-a-unit key (rows sharing a `waveId` render as one entry whose restore
-	 * calls `reopenForWave`).
-	 */
+	/** Shared across a wave's targets, `null` on a lone removal — the restore-as-a-unit key (ADR 0138). */
 	waveId: string | null;
 }
 
@@ -99,12 +69,7 @@ export interface ResolveTargetInput {
 	/** The moderator's chosen action; the state machine derives the persisted outcome. */
 	action: Resolution.ResolveAction;
 	resolvedAt: Date;
-	/**
-	 * The wave-remove grouping identity (#1855, ADR 0138): the shared id stamped on
-	 * this resolve when it is one target of a wave gesture, so the batch reopens as a
-	 * unit (`reopenForWave`). Omitted/`null` on a single-target resolve — a wave
-	 * groups a batch, a lone resolve has none.
-	 */
+	/** The shared wave-grouping id when this resolve is one target of a wave gesture (ADR 0138). */
 	waveId?: string | null;
 }
 
@@ -126,142 +91,79 @@ export class Report extends Context.Service<
 	Report,
 	{
 		readonly submit: (input: ReportInput) => Effect.Effect<ReportResult, ReportTargetNotFound>;
-		/**
-		 * Batched presence read: the subset of `targetIds` the viewer already has a
-		 * `content_report` row for, of the given `kind`, in one `IN (...)` read so
-		 * callers stamp "already reported" without an N+1. Missing viewer or empty
-		 * `targetIds` short-circuits to an empty Set with no read.
-		 */
+		/** Which of `targetIds` the viewer already reported, in one batched read (no N+1). */
 		readonly readByReporter: (
 			viewerId: string | null | undefined,
 			kind: TargetKind,
 			targetIds: ReadonlyArray<string>,
 		) => Effect.Effect<Set<string>>;
 
-		/**
-		 * The moderation queue (ADR 0098 §5): open reports grouped by target,
-		 * oldest-first, each carrying its distinct-reporter (repeat-offender) count.
-		 * Private moderation state — the resolver gates it behind the `Moderate`
-		 * capability (`requireModeration`, ADR 0107 §4).
-		 */
+		/** Moderation queue: open reports grouped by target, oldest-first. Gated behind `Moderate` in the resolver (ADR 0098 §5, ADR 0107 §4). */
 		readonly listOpen: (opts?: {limit?: number}) => Effect.Effect<ReadonlyArray<OpenReportGroup>>;
 
-		/**
-		 * The shared decision feed (#1704): recently resolved/dismissed targets grouped
-		 * by target, newest-decision-first, each carrying the audit triad (decision,
-		 * resolver, resolved-at). Bounded single-page like {@link listOpen} (no cursor).
-		 * Private moderation state — the resolver gates it behind `Moderate`.
-		 */
+		/** Decision feed: resolved/dismissed targets, newest-first. Bounded single page, no cursor. */
 		readonly listResolved: (opts?: {
 			limit?: number;
 		}) => Effect.Effect<ReadonlyArray<ResolvedReportGroup>>;
 
 		/**
-		 * Terminal transition (ADR 0098 §3/§4): collapse EVERY open report on
-		 * `(targetKind, targetId)` to the decided terminal status in one batch,
-		 * stamping the audit triad (`resolverId`/`resolvedAt`/`resolution`) on each.
-		 * Idempotent: zero open reports ⇒ `collapsed: 0`, no write. The author-side
-		 * authority check lives in the resolver (`requireModeration` discharging the
-		 * `Moderate` capability), not here.
+		 * Collapse EVERY open report on the target to its terminal status in one batch,
+		 * stamping the audit triad. Idempotent. The authority check lives in the
+		 * resolver, not here. See ADR 0098 §3/§4.
 		 */
 		readonly resolveTarget: (input: ResolveTargetInput) => Effect.Effect<ResolveTargetResult>;
 
-		/**
-		 * Reopen (ADR 0098 §3): flip every resolved/dismissed report on the target
-		 * back to `open`, clearing its audit triad — the restore-reopens-its-report
-		 * edge (ADR 0096 §4). Returns how many reports were reopened.
-		 */
+		/** Flip every terminal report on the target back to `open`, clearing its audit triad (ADR 0098 §3, ADR 0096 §4). */
 		readonly reopenForTarget: (input: {
 			targetKind: TargetKind;
 			targetId: string;
 		}) => Effect.Effect<{reopened: number}>;
 
-		/**
-		 * Reopen a whole wave as a unit (#1855, ADR 0138): flip every resolved/dismissed
-		 * report sharing `waveId` back to `open`, clearing its audit triad + the wave
-		 * grouping — the restore-as-a-unit primitive #1704's restore mutation calls. One
-		 * shared id, so the batch reopens together and nothing outside it is touched.
-		 * Returns how many reports were reopened.
-		 */
+		/** Reopen every terminal report sharing `waveId` as a unit, clearing the grouping (ADR 0138). */
 		readonly reopenForWave: (waveId: string) => Effect.Effect<{reopened: number}>;
 
-		/**
-		 * The distinct terminal targets sharing `waveId` (#1855, ADR 0138): every
-		 * `(targetKind, targetId)` a wave gesture removed, still resolved/dismissed. The
-		 * restore-as-a-unit mutation reads this to bring each target's content back live
-		 * before `reopenForWave` flips the reports — one shared id, so the batch is exactly
-		 * the wave and nothing outside it. Empty when the wave has already been reopened.
-		 */
+		/** The distinct still-terminal targets sharing `waveId`; empty once the wave has been reopened (ADR 0138). */
 		readonly waveTargets: (
 			waveId: string,
 		) => Effect.Effect<ReadonlyArray<{targetKind: TargetKind; targetId: string}>>;
 
-		/**
-		 * Resolve a single report id to its `(targetKind, targetId)` — so the resolve
-		 * mutation accepts a `reportId` and acts on its whole target group (ADR 0098).
-		 * `null` when no such report exists.
-		 */
+		/** The `(targetKind, targetId)` behind a report id, so a resolve keyed on one report acts on its whole target group (ADR 0098). */
 		readonly lookupReportTarget: (
 			reportId: string,
 		) => Effect.Effect<{targetKind: TargetKind; targetId: string} | null>;
 
-		/**
-		 * The earliest OPEN report id on a target — the representative report the
-		 * `Moderated({reportId})` removal reason links to, so a later restore reopens
-		 * the whole group. `null` when no open report exists on the target.
-		 */
+		/** The earliest OPEN report id — the one a `Moderated({reportId})` removal links to, so a later restore reopens the whole group. */
 		readonly firstOpenReportId: (
 			targetKind: TargetKind,
 			targetId: string,
 		) => Effect.Effect<string | null>;
 
-		/**
-		 * The moderation-queue reputation join (#1703, ADR 0138): for each author id,
-		 * how many of their content targets a moderator has previously removed
-		 * (`removed_by IS NOT NULL` across the post/comment/definition record tables).
-		 * One batched read over the page's authors, keyed by author id — the
-		 * repeat-offender signal the triage row surfaces. Absent authors carry 0.
-		 */
+		/** Per author, how many of their targets a moderator previously removed. Absent authors carry 0 (ADR 0138). */
 		readonly countRemovalsByAuthors: (
 			authorIds: ReadonlyArray<string>,
 		) => Effect.Effect<ReadonlyMap<string, number>>;
 
 		/**
-		 * The pile-on's reporter-diversity numerator (#1703): per target, the total open
-		 * reports and the DISTINCT reporters behind them, keyed by `<kind>:<id>`. The
-		 * composite report PK collapses them for content targets today (one reporter,
-		 * one target), so the counts equal — the shape is threaded now for #1855's
-		 * remove-the-wave, which distinguishes a real wave from a grudge-reporter.
+		 * Per target, open reports + DISTINCT reporters, keyed `<kind>:<id>`. The composite
+		 * report PK makes the two equal today; both are read so the shape is honest for the
+		 * wave-vs-grudge-reporter slice (ADR 0138).
 		 */
 		readonly reporterDiversity: (
 			targets: ReadonlyArray<{targetKind: TargetKind; targetId: string}>,
 		) => Effect.Effect<ReadonlyMap<string, {reportCount: number; distinctReporters: number}>>;
 
-		/**
-		 * The actor-drawer's üretim counts (#1852, ADR 0138): per author, how many
-		 * definition / post / comment records they authored (`removed_at IS NULL` — live
-		 * production only). One grouped read per kind over the page's authors, keyed by
-		 * author id; absent authors carry a zeroed triple. The künye-join actor-drawer
-		 * renders these as the actor's content footprint alongside their standing.
-		 */
+		/** Per author, live (`removed_at IS NULL`) definition/post/comment counts; absent authors carry a zeroed triple. */
 		readonly productionCountsByAuthors: (
 			authorIds: ReadonlyArray<string>,
 		) => Effect.Effect<ReadonlyMap<string, ProductionCounts>>;
 
-		/**
-		 * The actor-drawer's "bu aktör" tell (#1852, ADR 0138): per author, how many
-		 * DISTINCT of their targets carry an open report — the count behind "this actor
-		 * has N reported targets", the entry point #1855's remove-the-wave grows from.
-		 * Joined via the author id the content read captured; one grouped read per kind
-		 * over the page's authors. Absent authors carry 0.
-		 */
+		/** Per author, how many DISTINCT of their targets carry an open report. Absent authors carry 0. */
 		readonly countOpenReportedTargetsByAuthors: (
 			authorIds: ReadonlyArray<string>,
 		) => Effect.Effect<ReadonlyMap<string, number>>;
 	}
 >()("@kampus/report/Report") {}
 
-/** The actor's live content footprint (#1852) — per-kind production counts. */
 export interface ProductionCounts {
 	definitionCount: number;
 	postCount: number;
@@ -270,13 +172,9 @@ export interface ProductionCounts {
 
 export const ReportLive = Layer.effect(Report)(
 	Effect.gen(function* () {
-		// `orDieAccess`: every internal DB call site dies on `DrizzleError` (infra
-		// failures are defects), so public signatures carry domain errors only and
-		// `R` stays `never`. See ADR 0013/0014, `.patterns/feature-services.md`.
+		// `orDieAccess`: infra failures are defects. See ADR 0013/0014, `.patterns/feature-services.md`.
 		const {run} = orDieAccess(yield* Drizzle);
 
-		// Validate the target exists and is not soft-deleted. Surfaces
-		// `ReportTargetNotFound` rather than letting the insert fail FK-shaped.
 		const assertTargetLive = Effect.fn("Report.assertTargetLive")(function* (
 			kind: TargetKind,
 			targetId: string,
@@ -336,8 +234,7 @@ export const ReportLive = Layer.effect(Report)(
 						targetId: r.targetId,
 						reportCount: Number(r.reportCount),
 						reason: r.reason ?? null,
-						// D1 stores `created_at` as integer seconds (timestamp mode); MIN
-						// returns that raw value, so reconstruct the Date from seconds.
+						// D1 timestamp mode stores integer seconds; MIN returns the raw value.
 						firstReportedAt: new Date(Number(r.firstReportedAt) * 1000),
 					}) satisfies OpenReportGroup,
 			);
@@ -352,13 +249,10 @@ export const ReportLive = Layer.effect(Report)(
 						targetId: schema.contentReport.targetId,
 						reportCount: sql<number>`COUNT(*)`,
 						resolvedAt: sql<number>`MAX(${schema.contentReport.resolvedAt})`,
-						// A target's terminal rows share one uniform triad (resolveTarget stamps
-						// them together), so MIN over the group returns that single value.
+						// A target's terminal rows share one uniform triad + waveId, so MIN over
+						// the group returns that single value.
 						resolverId: sql<string>`MIN(${schema.contentReport.resolverId})`,
 						resolution: sql<Resolution.Resolution>`MIN(${schema.contentReport.resolution})`,
-						// A target's terminal rows share one waveId (resolveTarget stamps them
-						// together), so MIN over the group returns that single value (null on a
-						// lone removal).
 						waveId: sql<string | null>`MIN(${schema.contentReport.waveId})`,
 					})
 					.from(schema.contentReport)
@@ -374,8 +268,7 @@ export const ReportLive = Layer.effect(Report)(
 						targetId: r.targetId,
 						resolution: r.resolution as Resolution.Resolution,
 						resolverId: r.resolverId,
-						// D1 stores `resolved_at` as integer seconds (timestamp mode); MAX
-						// returns that raw value, so reconstruct the Date from seconds.
+						// D1 timestamp mode stores integer seconds; MAX returns the raw value.
 						resolvedAt: new Date(Number(r.resolvedAt) * 1000),
 						reportCount: Number(r.reportCount),
 						waveId: r.waveId ?? null,
@@ -384,15 +277,9 @@ export const ReportLive = Layer.effect(Report)(
 		});
 
 		const resolveTarget = Effect.fn("Report.resolveTarget")(function* (input: ResolveTargetInput) {
-			// The terminal status AND the persisted outcome are decided by the state
-			// machine (open → resolved/removed | dismissed/dismissed); the `status='open'`
-			// WHERE guard below is the SQL-level counterpart that makes the transition
-			// apply only to open rows.
-			// The machine now returns the transition as a typed `Result` so a bad source
-			// status surfaces in the type, never a bare throw/defect-500 (#2560). Here the
-			// source is the hardcoded-legal `"open"`, so the `Result` is always a success;
-			// `orDie` discharges the impossible `IllegalTransition` as a defect — it can only
-			// fire if this `"open"` literal is ever changed to a non-open source.
+			// The `"open"` source is hardcoded-legal, so the `Result` is always a success;
+			// `orDie` discharges the impossible `IllegalTransition` — reachable only if this
+			// literal is later changed to a non-open source (#2560).
 			const {status, resolution} = yield* Effect.orDie(
 				Effect.fromResult(Resolution.resolve("open", input.action)),
 			);
@@ -404,9 +291,7 @@ export const ReportLive = Layer.effect(Report)(
 						resolverId: input.resolverId,
 						resolvedAt: input.resolvedAt,
 						resolution,
-						// A wave gesture stamps ONE shared id across its targets (#1855); a
-						// single-target resolve leaves it null. Always set explicitly so a
-						// re-resolve never inherits a stale wave grouping.
+						// Always set explicitly so a re-resolve never inherits a stale wave grouping.
 						waveId: input.waveId ?? null,
 					})
 					.where(
@@ -426,18 +311,14 @@ export const ReportLive = Layer.effect(Report)(
 			targetKind: TargetKind;
 			targetId: string;
 		}) {
-			// The target status AND the terminal-source guard are decided by the state
-			// machine (terminal → open); the SQL guard below is the counterpart that
-			// applies the reopen only to terminal rows. The machine returns a typed `Result`
-			// (#2560); the hardcoded-terminal `"resolved"` source is always legal, so `orDie`
-			// discharges the impossible `IllegalTransition` — reachable only if this literal
-			// is later changed to a non-terminal source.
+			// The hardcoded-terminal `"resolved"` source is always legal, so `orDie` discharges
+			// the impossible `IllegalTransition` — reachable only if this literal is later
+			// changed to a non-terminal source (#2560).
 			const status = yield* Effect.orDie(Effect.fromResult(Resolution.reopen("resolved")));
 			const result = yield* run((db) =>
 				db
 					.update(schema.contentReport)
-					// Clearing `waveId` too keeps the invariant: an OPEN report never carries
-					// a stale wave grouping (#1855).
+					// Clearing `waveId` too holds the invariant: an OPEN report never carries a wave grouping.
 					.set({
 						status,
 						resolverId: null,
@@ -458,9 +339,8 @@ export const ReportLive = Layer.effect(Report)(
 		});
 
 		const reopenForWave = Effect.fn("Report.reopenForWave")(function* (waveId: string) {
-			// Reopen is a machine transition (terminal → open). The machine returns a typed
-			// `Result` (#2560); the hardcoded-terminal `"resolved"` source is always legal, so
-			// `orDie` discharges the impossible `IllegalTransition` (see `reopenForTarget`).
+			// Hardcoded-legal source; `orDie` discharges the impossible `IllegalTransition`
+			// (see `reopenForTarget`).
 			const status = yield* Effect.orDie(Effect.fromResult(Resolution.reopen("resolved")));
 			const result = yield* run((db) =>
 				db
@@ -539,9 +419,6 @@ export const ReportLive = Layer.effect(Report)(
 			return row?.id ?? null;
 		});
 
-		// Per-author moderator-removal count across the three content record tables
-		// (`removed_by IS NOT NULL`). One grouped read per kind over the page's authors,
-		// summed into a single author→count map. Empty input short-circuits with no read.
 		const countRemovalsByAuthors = Effect.fn("Report.countRemovalsByAuthors")(function* (
 			authorIds: ReadonlyArray<string>,
 		) {
@@ -562,10 +439,6 @@ export const ReportLive = Layer.effect(Report)(
 			return counts;
 		});
 
-		// Per-target open-report total + distinct-reporter count, keyed `<kind>:<id>`.
-		// The composite report PK makes `COUNT(*)` and `COUNT(DISTINCT reporter_id)`
-		// equal for content targets, but both are read so the shape is honest for the
-		// #1855 wave slice. One grouped read over the page's targets.
 		const reporterDiversity = Effect.fn("Report.reporterDiversity")(function* (
 			targets: ReadonlyArray<{targetKind: TargetKind; targetId: string}>,
 		) {
@@ -598,9 +471,6 @@ export const ReportLive = Layer.effect(Report)(
 			return diversity;
 		});
 
-		// Per-author live production counts across the three record tables
-		// (`removed_at IS NULL`). One grouped read per kind; each table maps to its
-		// `ProductionCounts` field. Empty input short-circuits with no read.
 		const productionCountsByAuthors = Effect.fn("Report.productionCountsByAuthors")(function* (
 			authorIds: ReadonlyArray<string>,
 		) {
@@ -632,10 +502,6 @@ export const ReportLive = Layer.effect(Report)(
 			return counts;
 		});
 
-		// The "bu aktör" count (#1852): per author, how many DISTINCT of their targets
-		// carry an open report. Joins `content_report` (open) to each record table by
-		// target id per kind, groups by author. One read per kind over the page's
-		// authors; a target's kind decides which record table carries its author.
 		const countOpenReportedTargetsByAuthors = Effect.fn("Report.countOpenReportedTargetsByAuthors")(
 			function* (authorIds: ReadonlyArray<string>) {
 				const counts = new Map<string, number>();
@@ -689,9 +555,7 @@ export const ReportLive = Layer.effect(Report)(
 			submit: Effect.fn("Report.submit")(function* (input: ReportInput) {
 				yield* assertTargetLive(input.targetKind, input.targetId);
 
-				// Idempotent on the composite PK: a re-report by the same reporter on
-				// the same target is a no-op success (`changes === 0`). A fresh `id`
-				// on a conflicting insert never lands, so it's harmless.
+				// Idempotent on the composite PK; the fresh `id` on a conflicting insert never lands.
 				const result = yield* run((db) =>
 					db
 						.insert(schema.contentReport)

--- a/apps/web/worker/features/report/Report.unit.test.ts
+++ b/apps/web/worker/features/report/Report.unit.test.ts
@@ -1,18 +1,11 @@
 /**
  * Report unit coverage — the decisions that are wrong-or-right with no database
- * (ADR 0082). The `Drizzle` seam is substituted directly (`Drizzle.test.ts`
- * half-A idiom): a `run` that THROWS proves a short-circuit never touched the
- * DB; a stubbed `run` feeds `assertTargetLive`'s presence read and the insert's
- * `meta.changes` envelope to the decision without an engine.
+ * (ADR 0082). A `run` that THROWS proves a short-circuit never touched the DB.
  *
- * Report has no fate/HTTP surface yet (`report.submit` is a future epic-#82
- * child — see `report/errors.ts`), so the engine-fidelity assertions the old
- * faked-engine suite ran — that real D1 actually returns `changes === 0`
- * on the composite-PK `onConflictDoNothing`, and that `deletedAt IS NULL`
- * filters a soft-deleted row — have no integration-reachable surface and move to
- * real D1 once that mutation lands (tracked follow-up). What is testable today is
- * the pure decision layer over a mocked seam: which `meta.changes` value maps to
- * `created`, and which presence read maps to `ReportTargetNotFound`.
+ * Report has no fate/HTTP surface yet, so the engine-fidelity assertions (real D1's
+ * `changes === 0` on the composite-PK `onConflictDoNothing`, `deletedAt IS NULL`
+ * filtering a soft-deleted row) have nowhere integration-reachable to live and move
+ * to real D1 once `report.submit` lands.
  */
 import {assert, describe, it} from "@effect/vitest";
 import {Effect, Layer} from "effect";
@@ -46,12 +39,8 @@ function scriptedAccess(results: ReadonlyArray<unknown>): DrizzleAccess {
 const reportLayer = (access: DrizzleAccess) =>
 	ReportLive.pipe(Layer.provide(Layer.succeed(Drizzle, access)));
 
-// A capturing `Drizzle` seam over a fake D1 that records every `prepare(sql).bind(...)`:
-// the REAL `ReportLive` write path (drizzle's update builder) renders against it, so the
-// captured `{sql, params}` is the actual statement the service issues — the wave-grouping
-// column landing (#1855) proven without an engine, the `pano-stats` capturing idiom (ADR
-// 0082) generalized to `.update().set().where().run()` (executeMethod "run" ⇒
-// `stmt.bind(...params).run()`, drizzle-orm/d1 session).
+// The REAL write path renders against this fake D1, so the captured `{sql, params}` is
+// the actual statement the service issues (#1855).
 function capturingDrizzle(): {
 	access: DrizzleAccess;
 	captured: Array<{sql: string; params: unknown[]}>;
@@ -112,7 +101,6 @@ describe("Report.submit — target-liveness decision (mocked Drizzle seam)", () 
 	it.effect("a missing target raises ReportTargetNotFound before the insert", () =>
 		Effect.gen(function* () {
 			const report = yield* Report;
-			// assertTargetLive's presence read resolves `undefined` → not-found.
 			const exit = yield* Effect.exit(
 				report.submit({reporterId: "r1", targetKind: "post", targetId: "ghost"}),
 			);
@@ -122,9 +110,8 @@ describe("Report.submit — target-liveness decision (mocked Drizzle seam)", () 
 	);
 
 	it.effect("a soft-deleted target reads as absent → ReportTargetNotFound", () =>
-		// The `deletedAt IS NULL` predicate is the engine's job (integration, once a
-		// surface exists); the DECISION is: a presence read that returns nothing →
-		// not-found. Modeling the filtered row as absent (`undefined`) proves it.
+		// The predicate itself is the engine's job; the DECISION under test is that a
+		// presence read returning nothing means not-found.
 		Effect.gen(function* () {
 			const report = yield* Report;
 			const exit = yield* Effect.exit(
@@ -140,9 +127,8 @@ describe("Report.listResolved — row→group mapping decision (mocked Drizzle s
 	it.effect(
 		"maps each aggregate row to a ResolvedReportGroup (seconds→Date, Number coercions)",
 		() =>
-			// The engine's GROUP BY / ORDER BY is integration-tier; the DECISION here is the
-			// pure row→group shape: `resolved_at` seconds reconstruct a Date, COUNT coerces to
-			// number, and the resolution/resolver pass through verbatim.
+			// The engine's GROUP BY / ORDER BY is integration-tier; what is under test is
+			// the pure row→group shape.
 			Effect.gen(function* () {
 				const report = yield* Report;
 				const groups = yield* report.listResolved({limit: 10});
@@ -206,7 +192,6 @@ describe("Report.listResolved — row→group mapping decision (mocked Drizzle s
 
 describe("Report.submit — created/no-op decision maps meta.changes (mocked Drizzle seam)", () => {
 	it.effect("changes > 0 → created", () =>
-		// run #1 assertTargetLive → a live row; run #2 the insert → its meta envelope.
 		Effect.gen(function* () {
 			const report = yield* Report;
 			const result = yield* report.submit({
@@ -233,9 +218,7 @@ describe("Report.submit — created/no-op decision maps meta.changes (mocked Dri
 	);
 });
 
-// AC4 (#1855): a wave-remove resolves every selected target AND writes ONE grouping
-// identity that restores as a unit. The write-side stamping + the reopen-as-a-unit
-// primitive, proven over the real render (capturing D1).
+// A wave-remove must write ONE grouping identity that restores as a unit (#1855).
 describe("Report.resolveTarget — wave grouping stamp (#1855, captured render)", () => {
 	it.effect("a resolve carrying a waveId stamps wave_id with that shared id (batch)", () =>
 		Effect.gen(function* () {

--- a/apps/web/worker/features/report/enrich.ts
+++ b/apps/web/worker/features/report/enrich.ts
@@ -1,11 +1,7 @@
 /**
- * The moderation-queue enrichment merge (#1702) — the pure decision layer that
- * folds each open-report group together with its reported target's context
- * (excerpt/title, author, in-situ routing ref). The batched content reads live in
- * the `Moderate`-gated `report.listOpen` resolver (`lists.ts`, dispatching to the
- * owning content service per `targetKind`); this module is engine-free so the
- * merge — which context lands on which group, and the missing-context fallback — is
- * a T1 unit (`*.unit.test.ts` precedent).
+ * The pure moderation-queue enrichment merge: fold each report group with its target's
+ * context. Engine-free on purpose — the batched content reads live in the `Moderate`-gated
+ * `report.listOpen` resolver, so the merge stays a unit test.
  */
 import {type TargetKind, targetKey} from "../../db/target-kind.ts";
 import type {OpenReportGroup, ResolvedReportGroup} from "./Report.ts";
@@ -13,50 +9,28 @@ import {type RowReputation, rowReputationOf} from "./reputation.ts";
 import {toOpenReport, toResolvedReport} from "./shapers.ts";
 import type {OpenReport, ResolvedReport} from "./views.ts";
 
-/**
- * The reported target's in-situ context: a content excerpt/title, the author handle,
- * and the routing reference the client links from (post id for post & comment→parent
- * post, term slug for definition). Kind-neutral so the queue row renders context
- * without re-branching per `targetKind`.
- */
 export interface ReportTargetContext {
 	excerpt: string;
 	author: string;
 	/** post id (post, comment→parent post) or term slug (definition). */
 	ref: string;
-	/**
-	 * The target author's account id — the join key for the #1703 reputation cluster
-	 * (künye tier/karma + prior-removals). Carried off the same batched content read
-	 * that resolves the excerpt/author, so the row's author standing joins from this id
-	 * without a second target lookup.
-	 */
+	// The join key for the reputation cluster, carried off the same batched content read that
+	// resolves the excerpt/author, so author standing joins without a second target lookup.
 	authorId: string;
 }
 
-/** The `<kind>:<id>` key an `OpenReport`/context map is keyed by (matches the view `id`). */
 export const contextKeyOf = (targetKind: TargetKind, targetId: string): string =>
 	targetKey(targetKind, targetId);
 
-/**
- * Clamp a body to a single-line queue excerpt: collapse whitespace and cut to
- * `max` graphemes-ish (code units suffice for the ASCII/Turkish copy), appending an
- * ellipsis when truncated. An already-short title/body passes through untouched.
- */
 export const toExcerpt = (text: string, max = 140): string => {
 	const collapsed = text.replace(/\s+/g, " ").trim();
 	if (collapsed.length <= max) return collapsed;
 	return `${collapsed.slice(0, max).trimEnd()}…`;
 };
 
-/**
- * Fold each report group with its resolved target context AND its reputation cluster
- * (both keyed by `<kind>:<id>`), producing the enriched `OpenReport` rows the resolver
- * returns. A group with no matching context — an unresolved/hidden target — keeps null
- * context fields rather than being dropped, so the queue never loses a row to a missing
- * excerpt; the reputation cluster's author fields are likewise null when the author is
- * unresolved (`rowReputationOf`), while `distinctReporters` always resolves (it falls
- * back to the group's report count).
- */
+// A group with no matching context — an unresolved/hidden target — keeps null context
+// fields rather than being dropped, so the queue never loses a row. `distinctReporters`
+// always resolves: it falls back to the group's report count.
 export const enrichOpenReports = (
 	groups: ReadonlyArray<OpenReportGroup>,
 	contexts: ReadonlyMap<string, ReportTargetContext>,
@@ -71,16 +45,9 @@ export const enrichOpenReports = (
 		);
 	});
 
-/**
- * The decision-feed enrichment merge (#1704) — fold each resolved-report group with its
- * decided target's context (`<kind>:<id>`-keyed) AND its resolver's display handle
- * (keyed by `resolverId`), producing the `ResolvedReport` rows `report.listResolved`
- * returns. A group with no matching context — a removed/hidden target — keeps null
- * context fields rather than being dropped (the feed never loses a decision to a missing
- * excerpt); an unresolved resolver handle folds to null (the client falls back to the
- * raw id). Pure so the fold is a T1 unit; the batched content/identity reads live in the
- * gated resolver.
- */
+// A group with no matching context — a removed/hidden target — keeps null context fields
+// rather than being dropped, so the feed never loses a decision to a missing excerpt; an
+// unresolved resolver handle folds to null.
 export const enrichResolvedReports = (
 	groups: ReadonlyArray<ResolvedReportGroup>,
 	contexts: ReadonlyMap<string, ReportTargetContext>,

--- a/apps/web/worker/features/report/enrich.unit.test.ts
+++ b/apps/web/worker/features/report/enrich.unit.test.ts
@@ -1,19 +1,15 @@
 /**
- * Moderation-queue enrichment merge — the T1 worker-seam unit (#1702), no engine.
- * The decisions asserted: each group is folded with its `<kind>:<id>`-keyed target
- * context onto the right `target*` fields; a group with no context keeps null
- * context (never dropped); and the excerpt clamp collapses whitespace + truncates.
- * The batched content READS (Pano/Sozluk SQL) are integration-tier, per the report
- * feature's stated split (`Report.unit.test.ts` docblock) — what's wrong-or-right
- * without D1 is this pure merge.
+ * The pure moderation-queue enrichment merge, no engine: each group folded with its
+ * `<kind>:<id>`-keyed context, a group with no context keeping null fields rather than being
+ * dropped, and the excerpt clamp. The batched content READS are integration-tier.
  */
 import {assert, describe, it} from "@effect/vitest";
 import {contextKeyOf, enrichOpenReports, type ReportTargetContext, toExcerpt} from "./enrich.ts";
 import type {OpenReportGroup} from "./Report.ts";
 import type {RowReputation} from "./reputation.ts";
 
-// The reputation cluster is folded by a sibling merge (`reputation.unit.test.ts`); here
-// the enrich merge only routes it by key, so an empty map exercises the fallback path.
+// The reputation cluster is folded by a sibling merge; here the enrich merge only routes it
+// by key, so an empty map exercises the fallback path.
 const noReputations = new Map<string, RowReputation>();
 
 const group = (

--- a/apps/web/worker/features/report/errors.ts
+++ b/apps/web/worker/features/report/errors.ts
@@ -1,10 +1,7 @@
 /**
- * Tagged errors raised by the Report service layer.
- *
  * `ReportTargetNotFound` carries NO `FateWireCode` by design: it never reaches the
- * wire. The `report.submit` mutation (next epic-#82 child) translates it at its
- * own boundary via `Effect.catchTag` into the feature-level not-found wire error,
- * exactly as the vote mutations translate `VoteTargetNotFound`.
+ * wire. The `report.submit` mutation translates it at its own boundary, exactly as the
+ * vote mutations translate `VoteTargetNotFound`.
  */
 import * as Schema from "effect/Schema";
 import {TargetKindSchema} from "../../db/target-kind.ts";

--- a/apps/web/worker/features/report/fate-module.ts
+++ b/apps/web/worker/features/report/fate-module.ts
@@ -12,13 +12,10 @@ import {
 import {openReportDataView, resolvedReportDataView} from "./views.ts";
 
 const roots: FateRootsRecord = {
-	// The moderation queue (ADR 0098) — a `Moderate`-capability-gated list root (the
-	// `moderates` relation tuple, ADR 0107 §4); the
-	// `report.listOpen` resolver owns the oldest-first order.
+	// Both roots are `Moderate`-capability-gated (the `moderates` relation tuple, ADR 0107 §4);
+	// each resolver owns its own order — oldest-first for the queue, newest-decision-first for
+	// the feed (ADR 0098, #1704).
 	"report.listOpen": list(openReportDataView),
-	// The shared decision feed (#1704) — a `Moderate`-gated list root over recently
-	// resolved/dismissed targets; the `report.listResolved` resolver owns the
-	// newest-decision-first order.
 	"report.listResolved": list(resolvedReportDataView),
 };
 

--- a/apps/web/worker/features/report/ids.ts
+++ b/apps/web/worker/features/report/ids.ts
@@ -1,26 +1,17 @@
 /**
- * Report feature-local branded ids (epic #2700). The cross-feature polymorphic
- * `TargetId` (a report's post/definition/comment target) is imported read-only from
- * the shared `lib/ids.ts` (#2723/#2735); only the report-owned `ReportId` / `WaveId`
- * are minted here, feature-locally, so sibling slices don't append-conflict on the
- * shared module.
- *
- * Branding these distinctly from `TargetId` makes the moderation-flow triad
- * type-distinct: a report id, a wave-grouping id, and a target id can no longer be
- * transposed without a compile error, even though all three are plain strings at
- * runtime. See `../../lib/ids.ts` for the branding idiom (effect-smol `SCHEMA.md`
- * §Branding) — not re-derived here.
+ * Report-owned branded ids, minted feature-locally so sibling slices don't
+ * append-conflict on the shared `lib/ids.ts`. Branding them distinctly from `TargetId`
+ * is what makes transposing the moderation triad a compile error, even though all three
+ * are plain strings at runtime.
  */
 import {brandedId} from "../../lib/ids.ts";
 
-/** A `content_report` row id — one filed report. */
 export const ReportId = brandedId("ReportId");
 export type ReportId = typeof ReportId.Type;
 
 /**
- * A remove-the-wave grouping id (#1855, ADR 0138): the client stamps ONE per wave
- * gesture and threads the same id through every fanned-out resolve, so the batch
- * reopens/restores as a unit. Distinct from `ReportId` — a wave groups many reports.
+ * A remove-the-wave grouping id (#1855): the client stamps ONE per wave gesture and
+ * threads it through every fanned-out resolve, so the batch restores as a unit.
  */
 export const WaveId = brandedId("WaveId");
 export type WaveId = typeof WaveId.Type;

--- a/apps/web/worker/features/report/lists.ts
+++ b/apps/web/worker/features/report/lists.ts
@@ -1,16 +1,9 @@
 /**
- * Report root list resolver — `report.listOpen`, the moderation queue (ADR 0098
- * §5). Gated behind the `Moderate` capability (`requireModeration`): a
- * non-moderator (or anonymous) caller gets the invisible `Denied` (`UNAUTHORIZED`)
- * and the queue is invisible to them. The queue is a bounded, private read (no live
- * view, no cursor pagination — the service caps it), so the `ConnectionResult` is
- * single-page (`hasNext: false`).
+ * The moderation queue's root list resolvers (ADR 0098 §5). The queue is a bounded,
+ * private read — the service caps it, so the `ConnectionResult` is single-page.
  *
- * Each row is enriched (#1702) with the reported target's in-situ context —
- * excerpt/title, author, and a routing ref — resolved by dispatching to the owning
- * content service per `targetKind` (the `moderateRemove` dispatch shape in
- * `mutations.ts`). The enrichment stays INSIDE this `Moderate`-gated path, so no
- * new public read exposes reported-target aggregation.
+ * All target-context enrichment stays INSIDE the `Moderate`-gated path, so no new
+ * public read exposes reported-target aggregation.
  */
 import {Fate} from "@kampus/fate-effect";
 import type {ConnectionResult} from "@nkzw/fate/server";
@@ -69,10 +62,8 @@ export const lists = {
 	),
 };
 
-// The post-gate queue read — `Moderate`-gated in R (`requireModeration` provides
-// the grant). `yield* Moderate` requires the proof; the read is a private surface
-// unreachable without a discharged grant. The target-context enrichment dispatches
-// to Pano/Sozluk under the same gate.
+// `yield* Moderate` puts the grant in R, so this read is unreachable without a
+// discharged proof — that is the gate, not a branch in the body.
 const listOpenGated = Effect.fn("report.listOpenGated")(function* (args: typeof ListOpenArgs.Type) {
 	yield* Moderate;
 	const report = yield* Report;
@@ -88,11 +79,6 @@ const listOpenGated = Effect.fn("report.listOpenGated")(function* (args: typeof 
 	} satisfies ConnectionResult<OpenReport>;
 });
 
-// The decision-feed read (#1704) — `Moderate`-gated like the open queue. `yield* Moderate`
-// requires the proof; the read is a private surface unreachable without a discharged
-// grant. Each decided target is enriched with the SAME target-context dispatch the open
-// queue uses, plus the resolver's display handle joined from pasaport — so the resolver
-// is first-class, not a bare id.
 const listResolvedGated = Effect.fn("report.listResolvedGated")(function* (
 	args: typeof ListResolvedArgs.Type,
 ) {
@@ -112,9 +98,8 @@ const listResolvedGated = Effect.fn("report.listResolvedGated")(function* (
 	} satisfies ConnectionResult<ResolvedReport>;
 });
 
-// Join each decision's resolver id to its display handle in ONE batched identity read
-// (pasaport), keyed by resolver id. An unresolved id simply has no entry — the merge
-// then renders that row with a null handle (the client falls back to the raw id).
+// An unresolved id simply has no entry — the merge then renders that row with a null
+// handle, never drops it.
 const resolveResolverHandles = Effect.fn("report.resolveResolverHandles")(function* (
 	groups: ReadonlyArray<ResolvedReportGroup>,
 ) {
@@ -129,11 +114,8 @@ const resolveResolverHandles = Effect.fn("report.resolveResolverHandles")(functi
 	return handles;
 });
 
-// Resolve each group's reported-target context by dispatching a batched read to the
-// content service that owns the kind, keyed by `<kind>:<id>`. A target the batched
-// read doesn't return (missing / sandbox-hidden) simply has no entry — the merge
-// then renders that row with null context (never dropped). Kind/id-structural so both
-// the open queue and the decision feed (#1704) share one dispatch.
+// A target the batched read doesn't return (missing / sandbox-hidden) simply has no
+// entry — the merge renders that row with null context, never drops it.
 const resolveTargetContexts = Effect.fn("report.resolveTargetContexts")(function* (
 	groups: ReadonlyArray<{targetKind: TargetKind; targetId: string}>,
 ) {
@@ -151,7 +133,6 @@ const resolveTargetContexts = Effect.fn("report.resolveTargetContexts")(function
 	if (idsByKind.post.length > 0) {
 		const rows = yield* pano.getPostsByIds(idsByKind.post);
 		for (const r of rows) {
-			// A post links to its own detail page (`/pano/<id>`); its title is the excerpt.
 			contexts.set(contextKeyOf("post", r.id), {
 				excerpt: r.title,
 				author: r.author,
@@ -164,7 +145,7 @@ const resolveTargetContexts = Effect.fn("report.resolveTargetContexts")(function
 	if (idsByKind.comment.length > 0) {
 		const rows = yield* pano.getCommentsByIds(idsByKind.comment);
 		for (const r of rows) {
-			// A comment links to its PARENT post detail; resolve the post id per row.
+			// A comment routes to its PARENT post's detail page.
 			const postId = yield* pano.lookupCommentPostId(r.id);
 			if (postId === null) continue;
 			contexts.set(contextKeyOf("comment", r.id), {
@@ -179,7 +160,7 @@ const resolveTargetContexts = Effect.fn("report.resolveTargetContexts")(function
 	if (idsByKind.definition.length > 0) {
 		const rows = yield* sozluk.getDefinitionsByIds(idsByKind.definition);
 		for (const r of rows) {
-			// A definition links to its term page (`/sozluk/<slug>`); resolve the slug per row.
+			// A definition routes to its term page, keyed by slug.
 			const slug = yield* sozluk.lookupDefinitionTermSlug(r.id);
 			if (slug === null) continue;
 			contexts.set(contextKeyOf("definition", r.id), {
@@ -194,14 +175,8 @@ const resolveTargetContexts = Effect.fn("report.resolveTargetContexts")(function
 	return contexts;
 });
 
-// Join each group's reputation + actor cluster (#1703/#1852, ADR 0138) INSIDE the gated
-// read: the reported target author's künye standing (tier + karma), prior removals, and
-// — for the actor-drawer — their live production footprint, kefil (vouch) status, and
-// "bu aktör" open-reported-target count, plus the pile-on's distinct-reporter count.
-// Author fields are keyed by the `authorId` the context resolution captured; a group
-// whose author is unresolved folds to a null author cluster. Every per-page aggregate
-// is one batched read (removals / production / reported-targets / diversity), so the
-// join stays a MODE over the same gated surface, never a per-row waterfall.
+// A group whose author is unresolved folds to a null author cluster. Every per-page
+// aggregate must stay ONE batched read, never a per-row waterfall (ADR 0138).
 const resolveRowReputations = Effect.fn("report.resolveRowReputations")(function* (
 	groups: ReadonlyArray<OpenReportGroup>,
 	contexts: ReadonlyMap<string, ReportTargetContext>,
@@ -218,15 +193,14 @@ const resolveRowReputations = Effect.fn("report.resolveRowReputations")(function
 		),
 	];
 
-	// The per-page batched aggregates — one read each, all bounded by the page size.
 	const priorRemovals = yield* report.countRemovalsByAuthors(authorIds);
 	const production = yield* report.productionCountsByAuthors(authorIds);
 	const reportedTargets = yield* report.countOpenReportedTargetsByAuthors(authorIds);
 	const diversity = yield* report.reporterDiversity(
 		groups.map((g) => ({targetKind: g.targetKind, targetId: g.targetId})),
 	);
-	// Kefil status is a per-author lookup (no batched read on the ledger yet); resolved
-	// once per distinct author, not per row, so the page stays a bounded fan-out.
+	// No batched read on the ledger yet, so this is per-author — resolved once per
+	// DISTINCT author, not per row, to keep the fan-out bounded.
 	const kefilByAuthor = new Map<string, boolean>();
 	for (const id of authorIds) kefilByAuthor.set(id, yield* vouches.hasActiveFor(id));
 

--- a/apps/web/worker/features/report/live.ts
+++ b/apps/web/worker/features/report/live.ts
@@ -1,30 +1,11 @@
 /**
- * Report's live-publish targets — the ONE place that answers "what does a moderator
- * resolve/restore of a reported target publish to?" (#1895, audit #1892).
+ * What a moderator resolve/restore publishes to (#1895). It deliberately owns NO topic of
+ * its own — a report is private moderation state with no live view (ADR 0082) — and
+ * instead dispatches to the SAME content topics the user delete/restore paths use.
  *
- * A `report.resolve` (remove) / `report.restore` hides or un-hides a `Post` /
- * `Comment` / `Definition` through the 0096 moderate substrate — the exact three
- * entities that live in the subscribed `posts` / `Post.comments` / `Term.definitions`
- * connections and every other client's normalized cache. The user-initiated deletes
- * publish their invalidation (`pano`/`sozluk` `*.delete` / `*.restore`); the
- * moderator-initiated path went through the parallel `moderateRemove*` service
- * methods and fanned out NOTHING, so a moderator's remove left every other client
- * rendering the removed content live until a manual reload. This binding closes that
- * gap by dispatching report's per-kind publish to the SAME content topics the user
- * paths use — no new report-owned topic (a report is private moderation state with no
- * live view, ADR 0082; `report.listOpen` is a bounded gated read, not a live topic).
- *
- * The typename is sourced off each entity's view (via `panoLive` / `sozlukLive`, which
- * read `PostView.typeName` / `CommentView.typeName` / `DefinitionView.typeName`), never
- * an inline `"Post"` literal (#1127). `deleteEdge` carries no node payload, so the
- * remove fan-out is ungated; the restore re-append is a node broadcast to a viewer-blind
- * public topic (the #1205/#1280 leak surface), so it routes through `decidePublish` on
- * the target's round-tripped sandbox marker — a moderator restore of a sandboxed target
- * is suppressed from the public connection exactly as the user restore paths suppress it.
- *
- * Every bound call forwards to `WorkerLivePublisher`, whose method error channel is
- * `never` — so a failed publish can never fail the moderation action (the fail-safe
- * contract, preserved by construction, same as pano/sozluk).
+ * `deleteEdge` carries no node payload, so the remove fan-out is ungated. The restore
+ * re-append broadcasts a node to a viewer-blind public topic (the #1205/#1280 leak
+ * surface), so it must route through `decidePublish` on the target's sandbox marker.
  */
 
 import {Effect} from "effect";
@@ -37,62 +18,32 @@ import {sozlukLive} from "../sozluk/live.ts";
 import type {Definition} from "../sozluk/views.ts";
 
 /**
- * Bind report's moderator-path publish targets to the per-request publisher. Each
- * helper dispatches to the content feature's own live binding by the reported target's
- * kind, so the fan-out lands on the same topic (and same view-sourced typename) the
- * user delete/restore paths publish to. A moderator remove/restore of a `Post`/`Comment`
- * is a feed-visible write, so `feedCache` rides `panoLive` to purge the base feed
- * exactly as the user paths do (ADR 0170 / #2324); sözlük targets never touch the pano
- * feed, so `sozlukLive` takes no purger.
+ * `feedCache` rides `panoLive` because a moderator remove/restore of a `Post`/`Comment` is
+ * a feed-visible write and must purge the base feed (ADR 0170). Sözlük targets never touch
+ * the pano feed, so `sozlukLive` takes no purger.
  */
 export const reportLive = (live: WorkerLivePublisher, feedCache: WorkerPanoFeedCache) => {
 	const pano = panoLive(live, feedCache);
 	const sozluk = sozlukLive(live);
 	return {
-		/**
-		 * A moderator removed a reported `Post`: evict the entity from every cache
-		 * holding it and drop its edge from the global `posts` feed — the inverse of
-		 * `post.delete`'s publish.
-		 */
 		postRemoved: (postId: string) =>
 			Effect.gen(function* () {
 				yield* pano.post.delete(postId);
 				yield* pano.post.feed.deleteEdge(postId);
 			}),
-		/**
-		 * A moderator restored a `Post`: re-enter the `posts` feed with the full node,
-		 * gated on the target's round-tripped sandbox marker (a sandboxed restore stays
-		 * out of the public feed), mirroring `post.restore`.
-		 */
 		postRestored: (post: Post, sandboxedAt: Date | null) =>
 			pano.post.feed.appendNode(post.id, {node: post}, decidePublish(sandboxedAt)),
-		/**
-		 * A moderator removed a reported `Comment`: drop its edge from the parent post's
-		 * `Post.comments` thread — the inverse of `comment.delete`'s `deleteEdge`.
-		 */
 		commentRemoved: (commentId: string, postId: string) =>
 			pano.comment.thread(postId).deleteEdge(commentId),
-		/**
-		 * A moderator restored a `Comment`: re-append it to the parent post's thread,
-		 * sandbox-gated, mirroring `comment.restore`.
-		 */
 		commentRestored: (comment: Comment, postId: string, sandboxedAt: Date | null) =>
 			pano.comment
 				.thread(postId)
 				.appendNode(comment.id, {node: comment}, decidePublish(sandboxedAt)),
-		/**
-		 * A moderator removed a reported `Definition`: evict the entity and drop its edge
-		 * from the term's `Term.definitions` connection — the inverse of `definition.delete`.
-		 */
 		definitionRemoved: (definitionId: string, termSlug: string) =>
 			Effect.gen(function* () {
 				yield* sozluk.definition.delete(definitionId);
 				yield* sozluk.definition.term(termSlug).deleteEdge(definitionId);
 			}),
-		/**
-		 * A moderator restored a `Definition`: re-enter the term's connection with the
-		 * full node, sandbox-gated, mirroring `definition.restore`.
-		 */
 		definitionRestored: (definition: Definition, termSlug: string, sandboxedAt: Date | null) =>
 			sozluk.definition
 				.term(termSlug)

--- a/apps/web/worker/features/report/mutations.ts
+++ b/apps/web/worker/features/report/mutations.ts
@@ -1,22 +1,6 @@
 /**
- * Report mutation resolvers (ADR 0098):
- *
- * - `report.submit` — the capture-side write. `CurrentUser.required` gates it; the
- *   handler returns a `ReportReceipt` ack and translates the service's kind-blind
- *   `ReportTargetNotFound` into the per-feature not-found the wire knows.
- * - `report.resolve` — the moderation-side write. The `Moderate` capability gates
- *   it (`requireModeration`): anonymous or non-moderator → the invisible `Denied`
- *   (`UNAUTHORIZED`), so the surface is invisible to non-moderators; the discharged
- *   `Grant` threads through the R-channel, so the resolve stamps `resolver_id` /
- *   `removed_by` from the authority-checked identity (`moderatorOf`) and resolving
- *   without a `Grant` does not typecheck (ADR 0107). On `removed` it calls the
- *   content service's moderator-remove, reusing the 0096 substrate with reason
- *   `Moderated({reportId})`, then collapses EVERY open report on the target with
- *   the audit triad. The state machine in `resolution.ts` keeps an illegal
- *   transition unrepresentable.
- *
- * Both acks are returned inline (the interpreter stamps `__typename` only on
- * source-resolved entities), so the handlers shape them through the shapers.
+ * Report mutation resolvers (ADR 0098). The moderation-side writes thread a discharged
+ * `Moderate` grant through R, so resolving without one does not typecheck (ADR 0107).
  * See `.patterns/fate-effect-operations.md`.
  */
 
@@ -51,12 +35,9 @@ const SubmitReportInput = Schema.Struct({
 	reason: Schema.optional(Schema.NullOr(Schema.String)),
 });
 
-// Either name the target directly (the moderation queue surfaces `targetKind` +
-// `targetId`), or pass a `reportId` and the resolve acts on its whole target group.
-// `waveId` is the remove-the-wave grouping id (#1855): the client generates ONE per
-// wave gesture and threads the SAME id through every fanned-out resolve, so the batch
-// reopens as a unit. Absent on a single-target resolve. The three ids are distinct
-// brands (ReportId / TargetId / WaveId), so transposing them here is a compile error.
+// `waveId` is the remove-the-wave grouping id (#1855): the client generates ONE per wave
+// gesture and threads the SAME id through every fanned-out resolve, so the batch reopens
+// as a unit. Absent on a single-target resolve.
 const ResolveReportInput = Schema.Struct({
 	reportId: Schema.optional(ReportId),
 	targetKind: Schema.optional(TargetKindSchema),
@@ -71,15 +52,10 @@ const RestoreReportInput = Schema.Struct({
 	targetId: Schema.optional(TargetId),
 });
 
-// Restore a whole wave-removal (#1855) as a unit: the `waveId` names the one grouping id
-// the wave gesture stamped across its targets, so restore brings EVERY target in the batch
-// back live and reopens every report sharing the id together.
 const RestoreWaveReportInput = Schema.Struct({
 	waveId: WaveId,
 });
 
-// Translate the service's kind-blind not-found into the feature-level error its
-// `targetKind` names — the wire-facing not-found the client already knows.
 const toFeatureNotFound = (e: ReportTargetNotFound) => {
 	switch (e.targetKind) {
 		case "post":
@@ -120,10 +96,8 @@ export const mutations = {
 							Effect.fail(toFeatureNotFound(e)),
 						),
 					);
-				// Mod-queue heartbeat (#1699): page every moderator that a report was filed —
-				// but only on a GENUINELY new report (`created`), never an idempotent re-report.
-				// Flag-gated, moderator-resolved and swallowed inside the emitter, so it can
-				// never fail this committed report.
+				// Only a GENUINELY new report pages the moderators — never an idempotent
+				// re-report. Swallowed inside the emitter, so it can't fail the committed report.
 				if (result.created) {
 					yield* notifyReportFiled({
 						reporterId: user.id,
@@ -133,12 +107,8 @@ export const mutations = {
 				}
 				return toReportReceipt(result);
 			});
-			// Flag-value karma gate (#150), dark behind the default-off
-			// `phoenix-karma-gates` flag: ON ⇒ `CanFlag` floors the reporter's karma at
-			// ≥ 50 before the submit runs (a below-floor flagger is denied
-			// `INSUFFICIENT_KARMA`); OFF ⇒ inert, every report behaves as today. A
-			// SEPARATE axis from the ADR 0098 moderation surface (which gates report
-			// *resolution*), not a re-gate of the same fact (#150 rescope).
+			// Karma floor on FILING (#150), dark by default — a separate axis from the ADR
+			// 0098 moderation surface, which gates report *resolution*.
 			return yield* gateFlagOnKarma(submit());
 		}),
 	),
@@ -154,9 +124,8 @@ export const mutations = {
 		}),
 	),
 
-	// The reopen edge (ADR 0098 §3 / 0096 §4): a moderator restore of a removed
-	// target brings the content back live AND reopens its reports (the bounded
-	// reopen). `Moderate`-gated, like resolve.
+	// The reopen edge (ADR 0098 §3 / 0096 §4): a restore brings the content back live AND
+	// reopens its reports.
 	"report.restore": Fate.mutation(
 		{
 			input: RestoreReportInput,
@@ -168,9 +137,7 @@ export const mutations = {
 		}),
 	),
 
-	// Restore a wave-removal as a unit (#1855, ADR 0138): reopen every report sharing the
-	// `waveId` AND bring each of the batch's targets back live — the restore-as-a-unit
-	// counterpart to a wave `report.resolve`. `Moderate`-gated, like restore.
+	// Restore a wave-removal as a unit (#1855, ADR 0138).
 	"report.restoreWave": Fate.mutation(
 		{
 			input: RestoreWaveReportInput,
@@ -183,10 +150,8 @@ export const mutations = {
 	),
 };
 
-// The post-gate resolve body — runnable only with a `Moderate` `Grant` in R
-// (`requireModeration` provides it). It reads the grant for the authority-checked
-// moderator id (`moderatorOf`) it stamps as `resolver_id`/`removed_by`, so
-// resolving without a discharged grant is a compile error.
+// `moderatorOf(grant)` is the authority-checked id stamped as `resolver_id`/`removed_by` —
+// never a client-supplied one.
 const resolveGated = Effect.fn("report.resolveGated")(function* (
 	input: typeof ResolveReportInput.Type,
 ) {
@@ -195,16 +160,14 @@ const resolveGated = Effect.fn("report.resolveGated")(function* (
 	const report = yield* Report;
 	const live = reportLive(yield* WorkerLivePublisher, yield* PanoFeedCache);
 
-	// Resolve the target: a `reportId` resolves to its `(targetKind, targetId)`;
-	// otherwise `targetKind` + `targetId` are taken directly.
 	let target: {targetKind: TargetKind; targetId: string} | null = null;
 	if (input.reportId !== undefined) {
 		target = yield* report.lookupReportTarget(input.reportId);
 	} else if (input.targetKind !== undefined && input.targetId !== undefined) {
 		target = {targetKind: input.targetKind, targetId: input.targetId};
 	}
-	// A stale/unknown target is a benign no-op (nothing to collapse) — the
-	// moderation surface never leaks "exists/doesn't" beyond UNAUTHORIZED.
+	// A stale/unknown target acks benignly on purpose: the moderation surface must never
+	// leak "exists/doesn't".
 	if (target === null) {
 		return toResolveReceipt({
 			targetKind: input.targetKind ?? "post",
@@ -218,43 +181,33 @@ const resolveGated = Effect.fn("report.resolveGated")(function* (
 	const now = new Date();
 	let targetRemoved = false;
 
-	// Capture the representative open report id BEFORE the stamp (below) flips
-	// open → terminal: the removal links its `Moderated` reason to it so a later
-	// restore reopens the group, and after the stamp there are no open rows left to
-	// read. Only the remove leg consumes it.
+	// Must be read BEFORE the stamp below flips open → terminal: afterwards there are no
+	// open rows left to read, and the removal needs this id to link its `Moderated` reason.
 	const firstOpenId =
 		input.action === "remove"
 			? yield* report.firstOpenReportId(target.targetKind, target.targetId)
 			: null;
 
-	// Stamp first, then remove only if this resolve WON the transition (#2555): the
-	// terminal stamp is the single arbiter of open → terminal, so keying the removal on
-	// `wonTransition` makes the two legs unable to disagree. A concurrent moderator who
-	// stamped the report terminal first leaves `wonTransition` false, so the removal is
-	// skipped — content is never removed under their (e.g. dismissed) verdict.
+	// Stamp first, remove only if this resolve WON the transition (#2555). A concurrent
+	// moderator who stamped terminal first leaves `wonTransition` false, so the removal is
+	// skipped and content is never removed under their (e.g. dismissed) verdict.
 	const {collapsed, wonTransition} = yield* report.resolveTarget({
 		targetKind: target.targetKind,
 		targetId: target.targetId,
 		resolverId: moderatorId,
 		action: input.action,
 		resolvedAt: now,
-		// Stamp the wave grouping when this resolve is one target of a wave gesture
-		// (#1855); null on a single-target resolve.
 		waveId: input.waveId ?? null,
 	});
 
 	if (input.action === "remove" && wonTransition) {
-		// Act on the target via the 0096 substrate (reason `Moderated`), keyed to the
-		// first open report id captured above.
 		const reportId = ReportId.make(
 			firstOpenId ?? input.reportId ?? targetKey(target.targetKind, target.targetId),
 		);
 		targetRemoved = yield* moderateRemove(target, moderatorId, reportId);
-		// The moderator-remove hides content that lives in the subscribed
-		// `posts` / `Post.comments` / `Term.definitions` connections; publish the
-		// same invalidation the user-delete paths do so every other client's open
-		// view reconciles live (#1895, audit #1892). Only fan out on an actual
-		// removal — a no-op (already-removed / missing) changed no subscribed state.
+		// The removed content lives in a subscribed connection, so it needs the same
+		// invalidation the user-delete paths publish (#1895). Only on an ACTUAL removal —
+		// a no-op changed no subscribed state.
 		if (targetRemoved) {
 			yield* publishRemoved(live, target);
 		}
@@ -269,9 +222,7 @@ const resolveGated = Effect.fn("report.resolveGated")(function* (
 	});
 });
 
-// The post-gate restore body — `Moderate`-gated in R like {@link resolveGated}.
-// `reopenForTarget` clears the audit triad (no moderator id stamped on reopen), so
-// the grant is read only to require the proof; `yield* Moderate` IS that gate.
+// `reopenForTarget` stamps no moderator id, so the grant is yielded purely as the gate.
 const restoreGated = Effect.fn("report.restoreGated")(function* (
 	input: typeof RestoreReportInput.Type,
 ) {
@@ -296,9 +247,7 @@ const restoreGated = Effect.fn("report.restoreGated")(function* (
 	}
 
 	const restored = yield* moderateRestore(target);
-	// Mirror the remove fan-out: re-enter the target into the subscribed connection so
-	// every other client's open view re-populates live (#1895). Only on an actual
-	// restore — a no-op restored nothing.
+	// Mirrors the remove fan-out (#1895); only on an actual restore.
 	if (restored.restored) {
 		yield* publishRestored(live, target, restored.sandboxedAt);
 	}
@@ -313,11 +262,7 @@ const restoreGated = Effect.fn("report.restoreGated")(function* (
 	});
 });
 
-// The post-gate wave-restore body — `Moderate`-gated in R like {@link restoreGated}. It
-// generalizes the single-target restore across the batch: bring EVERY target sharing the
-// waveId back live (the same per-target `moderateRestore` + live re-append the lone restore
-// runs), then reopen the whole batch as a unit (`reopenForWave`). The batch is exactly the
-// wave — one shared id — so nothing outside it is touched. `yield* Moderate` IS the gate.
+// The batch is exactly the wave — one shared id — so nothing outside it is touched.
 const restoreWaveGated = Effect.fn("report.restoreWaveGated")(function* (
 	input: typeof RestoreWaveReportInput.Type,
 ) {
@@ -325,8 +270,7 @@ const restoreWaveGated = Effect.fn("report.restoreWaveGated")(function* (
 	const report = yield* Report;
 	const live = reportLive(yield* WorkerLivePublisher, yield* PanoFeedCache);
 
-	// The batch's still-terminal targets — each gets its content brought back live, exactly
-	// as the single restore does, before the reports flip open.
+	// Content comes back live BEFORE the reports flip open.
 	const targets = yield* report.waveTargets(input.waveId);
 	for (const target of targets) {
 		const restored = yield* moderateRestore(target);
@@ -335,11 +279,9 @@ const restoreWaveGated = Effect.fn("report.restoreWaveGated")(function* (
 		}
 	}
 
-	// Reopen every report sharing the waveId together — the restore-as-a-unit primitive.
 	const {reopened} = yield* report.reopenForWave(input.waveId);
 
-	// A result-only ack (like the single restore): the wave carries no single target, so the
-	// receipt names the wave (`waveId` as the id) and reports how many reports reopened.
+	// A wave has no single target, so the receipt names the wave itself as the id.
 	const first = targets[0];
 	return toResolveReceipt({
 		targetKind: first?.targetKind ?? "post",
@@ -350,7 +292,6 @@ const restoreWaveGated = Effect.fn("report.restoreWaveGated")(function* (
 	});
 });
 
-/** Dispatch act-on-target to the content service that owns the target kind. */
 const moderateRemove = Effect.fn("report.moderateRemove")(function* (
 	target: {targetKind: TargetKind; targetId: string},
 	resolverId: string,
@@ -388,10 +329,8 @@ const moderateRemove = Effect.fn("report.moderateRemove")(function* (
 });
 
 /**
- * Dispatch the moderator restore to the content service that owns the target kind.
- * `sandboxedAt` is the round-tripped sandbox marker (#1811) the caller feeds to the
- * live re-append's `decidePublish` gate — a sandboxed restore stays out of the public
- * connection.
+ * Returns the round-tripped `sandboxedAt` marker (#1811) the caller must feed to the live
+ * re-append's `decidePublish` gate — a sandboxed restore stays out of the public connection.
  */
 const moderateRestore = Effect.fn("report.moderateRestore")(function* (target: {
 	targetKind: TargetKind;
@@ -413,14 +352,7 @@ const moderateRestore = Effect.fn("report.moderateRestore")(function* (target: {
 	}
 });
 
-/**
- * Publish the remove-side invalidation for a moderator-removed target: evict the entity
- * + drop its edge from the connection it lives in (`posts` / `Post.comments` /
- * `Term.definitions`), resolving the parent ref (post id for a comment, term slug for a
- * definition) the same way the content features' delete paths do. A ref the lookup can't
- * resolve (already gone) simply skips its connection edge — the entity eviction still
- * fires. Publisher errors are `never`, so this can never fail the moderation action.
- */
+/** A parent ref that no longer resolves skips its connection edge on purpose. */
 const publishRemoved = Effect.fn("report.publishRemoved")(function* (
 	live: ReturnType<typeof reportLive>,
 	target: {targetKind: TargetKind; targetId: string},
@@ -446,12 +378,8 @@ const publishRemoved = Effect.fn("report.publishRemoved")(function* (
 });
 
 /**
- * Publish the restore-side invalidation for a moderator-restored target: re-resolve the
- * full node (via the content service's batched by-id read) and re-append it to the
- * connection, gated on the round-tripped `sandboxedAt` so a still-sandboxed restore
- * stays suppressed from the viewer-blind public topic (#1205/#1280 leak surface),
- * mirroring the user restore paths. A node that no longer resolves is skipped. Publisher
- * errors are `never`.
+ * Gated on `sandboxedAt` so a still-sandboxed restore stays suppressed from the
+ * viewer-blind public topic (#1205/#1280 leak surface).
  */
 const publishRestored = Effect.fn("report.publishRestored")(function* (
 	live: ReturnType<typeof reportLive>,

--- a/apps/web/worker/features/report/report-boundary.unit.test.ts
+++ b/apps/web/worker/features/report/report-boundary.unit.test.ts
@@ -1,26 +1,11 @@
 /**
- * Report feature-boundary pins — `Report` is a shared low-level service over the
- * three content targets, so it sits below the feature directories and must import
- * none of them. Unlike `Vote`, it owns no inverted contract (no `KarmaBump`), so
- * `ReportLive` requires exactly the `Drizzle` seam. The type-level pin enforces
- * that boundary by asserting what `ReportLive` REQUIRES (its `R` channel) — the
- * service's actual requirement, refactor-proof: a sibling-feature import that
- * widened `R` would fail the pin.
+ * `Report` sits below the feature directories and must import none of them, so the pin
+ * asserts what `ReportLive` REQUIRES: a sibling-feature import that widened `R` fails it.
+ * The pin scopes to the SERVICE only — the wire/gate layer composes OVER the features by
+ * design.
  *
- * The pin scopes to the SERVICE (`Report.ts`); the wire/gate layer
- * (`mutations.ts`, `lists.ts`, `views.ts`, `fate-module.ts`) composes OVER the
- * features by design and is not part of `ReportLive`'s `R` — the
- * `report.submit`/`report.resolve` resolvers translate the service's
- * `ReportTargetNotFound` into the per-feature not-found errors and dispatch
- * act-on-target to the sibling content services, the moderation gate discharges
- * künye's `Moderate` capability over the `moderates` relation (ADR 0107, carrying
- * ADR 0098 §2's invisible denial), and `fate-module.ts` aggregates this feature's
- * fate contribution. The boundary that matters is that the service stays
- * feature-clean; the wire/gate layer reaching siblings is the point of the layer,
- * exactly as `pano/`/`sozluk/` own their vote mutation files.
- *
- * Type pins use expectTypeOf, not `@ts-expect-error` — the effect LSP plugin's
- * TS377003 escapes the directive (recurring finding; the `vote/` precedent).
+ * Type pins use `expectTypeOf`, not `@ts-expect-error`: the effect LSP plugin's TS377003
+ * escapes the directive.
  */
 import type {Layer} from "effect";
 import {describe, expectTypeOf, it} from "vitest";

--- a/apps/web/worker/features/report/report-ids.typetest.ts
+++ b/apps/web/worker/features/report/report-ids.typetest.ts
@@ -1,9 +1,7 @@
 /**
- * Type-level assertion (no runtime — checked by `tsgo`, not vitest): the moderation
- * id surfaces `ReportId` (a filed report), `WaveId` (a remove-the-wave grouping), and
- * the shared polymorphic `TargetId` (the report's post/definition/comment target) are
- * nominally distinct, so transposing any two is a compile error (#2721 AC#4), while all
- * three stay plain strings at runtime. Mirrors `../vote/vote-ids.typetest.ts`.
+ * Type-level assertion, checked by `tsgo` rather than vitest: `ReportId`, `WaveId` and
+ * the polymorphic `TargetId` are nominally distinct, so transposing any two is a
+ * compile error (#2721 AC#4) while all three stay plain strings at runtime.
  */
 import {expectTypeOf} from "vitest";
 import type {TargetId} from "../../lib/ids.ts";
@@ -14,8 +12,7 @@ expectTypeOf<ReportId>().toMatchTypeOf<string>();
 expectTypeOf<WaveId>().toMatchTypeOf<string>();
 expectTypeOf<TargetId>().toMatchTypeOf<string>();
 
-// The distinctness that makes a reportId/targetId/waveId swap unrepresentable: no brand
-// is assignable to another, so a moderation flow can't confuse the three ids.
+// No brand is assignable to another, so a moderation flow cannot confuse the three.
 expectTypeOf<ReportId>().not.toEqualTypeOf<TargetId>();
 expectTypeOf<ReportId>().not.toMatchTypeOf<TargetId>();
 expectTypeOf<TargetId>().not.toMatchTypeOf<ReportId>();

--- a/apps/web/worker/features/report/report-live-fanout.unit.test.ts
+++ b/apps/web/worker/features/report/report-live-fanout.unit.test.ts
@@ -1,20 +1,12 @@
 /**
- * `report.resolve` / `report.restore` LIVE-FANOUT unit coverage (#1895, audit #1892).
+ * Live-fanout coverage for `report.resolve` / `report.restore` (#1895). A moderator
+ * remove/restore hides content that lives in subscribed connections, and the moderator
+ * path once fanned out nothing, so every other client kept rendering removed content
+ * until a manual reload.
  *
- * A moderator remove/restore hides or un-hides a `Post` / `Comment` / `Definition` —
- * the exact three entities that live in the subscribed `posts` / `Post.comments` /
- * `Term.definitions` connections. Before #1895 the moderator path fanned out NOTHING,
- * so a second connected moderator (and every other client) kept rendering the removed
- * content live until a manual reload. This drives the REAL resolve/restore handlers over
- * stub `Report` / `Pano` / `Sozluk` services and a recording `LivePublisher`, asserting
- * the resolver publishes the SAME invalidation the user-delete paths do — the
- * handler-over-stubs + recording-publisher seam `sozluk/definition-mutation.unit.test.ts`
- * uses. The publisher's key-MATH is pinned in `../fate-live/live-publisher.unit.test.ts`;
- * this asserts the resolver's routing CHOICE.
- *
- * The moderation gate is discharged the same way `divan/divan-vote-mutation.unit.test.ts`
- * does: a `RelationStore` holding the actor's `moderates` tuple + `CurrentActor` mints the
- * `Moderate` grant, so the gated body runs.
+ * These drive the real handlers over stub services and a recording `LivePublisher`, so
+ * what is asserted is the resolver's routing CHOICE; the publisher's key math is pinned
+ * in `../fate-live/live-publisher.unit.test.ts`.
  */
 
 import {assert, describe, it} from "@effect/vitest";
@@ -51,8 +43,7 @@ const relationStoreOf = (holders: ReadonlyArray<string>): Layer.Layer<RelationSt
 
 const agentAuthorityStub = Layer.succeed(AgentAuthority, {admits: () => Effect.succeed(false)});
 
-// The mod-emitter deps `report.submit` gained (#1699): `Flags` OFF ⇒ `bildirimOn` is
-// false ⇒ the report-filed page no-ops before the moderator read / notification write.
+// `Flags` OFF, so the report-filed page no-ops before the moderator read (#1699).
 const runtimeContextStub: BaseRuntimeContext = {
 	Type: "report-live-fanout-test",
 	id: "report-live-fanout-test",
@@ -69,14 +60,11 @@ const bildirimOffStub = Layer.mergeAll(
 	} as typeof Flags.Service),
 	Layer.succeed(RuntimeContext, runtimeContextStub),
 	noRequestFlagOverrides,
-	// The base-feed purger a fanned pano mutation fires alongside its publish (#2324):
-	// a no-op here, so the fanout assertions below are unchanged.
 	noopPanoFeedCache,
 	makeNotificationStub(),
 	relationStoreOf([]),
-	// The karma flag-gate deps `report.submit` gained (#150): `Flags` OFF ⇒ the
-	// `CanFlag` gate auto-passes without a karma read, so `Kunye.karmaOf` dies on
-	// contact (unexercised); the proof still stamps off the per-test `CurrentActor`.
+	// With the flag off the `CanFlag` gate auto-passes without a karma read, so these
+	// die on contact to prove they are never reached (#150).
 	Layer.succeed(Kunye, {
 		karmaOf: () => Effect.die("Kunye.karmaOf not exercised in report-live-fanout (flag off)"),
 		tierOf: () => Effect.die("Kunye.tierOf not exercised in report-live-fanout"),
@@ -86,9 +74,7 @@ const bildirimOffStub = Layer.mergeAll(
 
 const actorContext = (actor: Actor) => Layer.succeed(CurrentActor, {actor});
 
-// A `Report` scripted so a `remove`/restore resolves its target and collapses/reopens
-// one report — every unlisted method fail-on-contact, so the test proves the path
-// touched only these.
+// Every unlisted method fails on contact, so the test proves the path touched only these.
 const reportStub = (target: {targetKind: "post" | "comment" | "definition"; targetId: string}) =>
 	makeReportStub({
 		lookupReportTarget: () => Effect.succeed(target),
@@ -97,8 +83,6 @@ const reportStub = (target: {targetKind: "post" | "comment" | "definition"; targ
 		reopenForTarget: () => Effect.succeed({reopened: 1}),
 	});
 
-// Proxy stubs over `Pano`/`Sozluk`: scripted methods answer, every other dies on
-// contact — mirrors `definition-mutation.unit.test.ts`'s `sozlukStub`.
 const panoStub = (impl: Partial<typeof Pano.Service>): typeof Pano.Service =>
 	proxyOver("Pano", impl);
 const sozlukStub = (impl: Partial<typeof Sozluk.Service>): typeof Sozluk.Service =>
@@ -153,8 +137,6 @@ const commentRow = (id: string) => ({
 	myVote: null,
 });
 
-// A recording `LivePublisher`: `publish` captures the topic key the resolver's `live.*`
-// chose; `waitUntil` collects the detached publish work so `flush` drains it.
 const recordingPublisher = () => {
 	const recorded: Array<string> = [];
 	const scheduled: Array<Promise<unknown>> = [];
@@ -170,14 +152,11 @@ const recordingPublisher = () => {
 				},
 			}),
 		),
-		// The base-feed purger a fanned pano moderation path fires (#2324) — no-op here,
-		// so the recorded live topics below are the sole fan-out assertion.
 		noopPanoFeedCache,
 	);
 	return {recorded, scheduled, layer};
 };
 
-/** A rejection while draining scheduled `waitUntil` work — dies the fiber. */
 class DrainRejected extends Schema.TaggedErrorClass<DrainRejected>()("test/DrainRejected", {
 	cause: Schema.Unknown,
 }) {}
@@ -354,8 +333,7 @@ describe("report.restore — re-enters the target so a second moderator reconcil
 					select: ["id"],
 				});
 				yield* flush(scheduled);
-				// The round-tripped sandbox marker gates the re-append via decidePublish — a
-				// sandboxed restore broadcasts NOTHING to the viewer-blind public feed.
+				// A sandboxed restore broadcasts nothing to the viewer-blind public feed.
 				assert.deepStrictEqual(recorded, []);
 			}).pipe(
 				Effect.provide(
@@ -479,9 +457,8 @@ describe("fail-safe — a failed publish does not fail the moderation action", (
 	});
 });
 
-// #1855: the wave grouping the client generates rides the SAME `report.resolve` input,
-// threaded to `resolveTarget` so the batch's rows carry one shared id. A capturing stub
-// records what the handler passed down (a dismiss avoids the remove/publish detour).
+// The wave grouping id rides the same `report.resolve` input, so the batch's rows carry
+// one shared id (#1855).
 describe("report.resolve — threads the wave grouping id to resolveTarget (#1855)", () => {
 	const capturingReport = (sink: {waveId?: string | null}) =>
 		makeReportStub({
@@ -492,8 +469,7 @@ describe("report.resolve — threads the wave grouping id to resolveTarget (#185
 				}),
 		});
 
-	// Pano/Sozluk are in the handler's static R (the remove branch), never reached on a
-	// dismiss — empty stubs die on contact, proving the dismiss path never touches them.
+	// Empty stubs die on contact, proving the dismiss path never touches Pano/Sozluk.
 	const gate = <ROut>(extra: Layer.Layer<ROut, never, never>) =>
 		Layer.mergeAll(
 			extra,
@@ -534,12 +510,8 @@ describe("report.resolve — threads the wave grouping id to resolveTarget (#185
 	});
 });
 
-// #1704 AC3: restoring a wave-removal (one ledger event, #1855) restores EVERY target in
-// the batch as a unit. The handler reads the wave's targets, brings each back live (the same
-// per-target restore + live re-append the lone restore runs), then reopens the whole batch.
 describe("report.restoreWave — restores the batch as a unit (#1704 AC3)", () => {
-	// A `Report` scripted for a two-target wave: `waveTargets` names the batch, `reopenForWave`
-	// reopens it. Every other method fail-on-contact — the path touches only these.
+	// Every other method fails on contact, so the path touches only these two.
 	const waveReportStub = (
 		targets: ReadonlyArray<{targetKind: "post" | "comment" | "definition"; targetId: string}>,
 	) =>
@@ -556,12 +528,10 @@ describe("report.restoreWave — restores the batch as a unit (#1704 AC3)", () =
 				select: ["id", "collapsed"],
 			});
 			yield* flush(scheduled);
-			// Each target re-enters its subscribed connection — the batch restored as a unit.
 			assert.deepStrictEqual(recorded, [
 				liveGlobalConnectionTopic("posts"),
 				liveConnectionTopic("Term.definitions", {id: "effect"}),
 			]);
-			// The ack reports how many reports reopened across the wave.
 			assert.strictEqual((receipt as {collapsed: number}).collapsed, 2);
 		}).pipe(
 			Effect.provide(
@@ -633,14 +603,13 @@ describe("report.restoreWave — restores the batch as a unit (#1704 AC3)", () =
 			);
 			assert.isTrue(exit._tag === "Failure", "a non-moderator restoreWave is denied");
 			if (exit._tag === "Failure") {
-				// The künye invisible denial — never leaks the wave exists.
+				// The denial must not leak that the wave exists.
 				assert.match(String(Cause.pretty(exit.cause)), /Denied|UNAUTHORIZED/);
 			}
 		}).pipe(
 			Effect.provide(
 				Layer.mergeAll(
-					// fail-on-contact Report/Pano/Sozluk: the gate denies BEFORE the body, so a
-					// reached `waveTargets`/restore would die and fail the test.
+					// The gate denies BEFORE the body, so any reach into these dies and fails.
 					makeReportStub({}),
 					Layer.succeed(Pano, panoStub({})),
 					Layer.succeed(Sozluk, sozlukStub({})),
@@ -658,10 +627,8 @@ describe("report.submit — the audit refuted submit; the CONTENT path fans out 
 	it.effect(
 		"submit never publishes to a CONTENT topic (a private report row changes no subscribed content)",
 		() =>
-			// The submit handler never touches `WorkerLivePublisher` on the content path — a
-			// report is private moderation state. Its ONLY live dependency is the bildirim
-			// spine's per-recipient `Notification.record` delivery (#2076/#1699), gated OFF
-			// here (`bildirimOffStub`), so the recording publisher captures NOTHING.
+			// A report is private moderation state. Its only live dependency is the
+			// per-recipient notification delivery, gated off here, so nothing is captured.
 			Effect.gen(function* () {
 				const {recorded, scheduled, layer} = recordingPublisher();
 				const receipt = yield* mutations["report.submit"]

--- a/apps/web/worker/features/report/report-mutation.unit.test.ts
+++ b/apps/web/worker/features/report/report-mutation.unit.test.ts
@@ -1,15 +1,7 @@
 /**
- * `report.submit` WIRE-boundary unit coverage (ADR 0082) — the parts that are
- * wrong-or-right with no database: the `CurrentUser.required` auth gate, the
- * `ReportTargetNotFound` → per-feature not-found translation by `targetKind`, and
- * the `ReportReceipt` shape (its `__typename` discriminant + `<kind>:<id>` id). The
- * `Report` seam is substituted directly (`Layer.succeed(Report, …)`) with a stub
- * whose `submit` returns a scripted `ReportResult` or fails `ReportTargetNotFound` —
- * no engine, so this is a unit test.
- *
- * The persistence / idempotency / all-three-kinds facts that are only wrong if real
- * D1 differs live in `apps/web/tests/integration/report.test.ts`; the `Report.submit`
- * service decisions (created/no-op, target liveness) live in `Report.unit.test.ts`.
+ * `report.submit` WIRE-boundary unit coverage (ADR 0082). Persistence/idempotency facts
+ * live in `tests/integration/report.test.ts`; the service's own decisions live in
+ * `Report.unit.test.ts`.
  */
 
 import {assert, describe, it} from "@effect/vitest";
@@ -38,10 +30,8 @@ const runtimeContextStub: BaseRuntimeContext = {
 	set: (id) => Effect.succeed(id),
 };
 
-// The mod-emitter deps `report.submit` gained (#1699): the report-filed page rides
-// AFTER the committed submit. `Flags` OFF ⇒ `bildirimOn` is false ⇒ the emit no-ops
-// before the moderator read or any notification write, so the Notification /
-// RelationStore stubs exist only to satisfy the type and die if ever reached.
+// `Flags` OFF ⇒ the mod emit (#1699) no-ops before any moderator read or notification
+// write, so the stubs below exist only to satisfy the type and die if ever reached.
 const bildirimOffStub = Layer.mergeAll(
 	Layer.succeed(Flags, {
 		getBoolean: () => Effect.succeed(false),
@@ -52,19 +42,13 @@ const bildirimOffStub = Layer.mergeAll(
 	Layer.succeed(RuntimeContext, runtimeContextStub),
 	noRequestFlagOverrides,
 	makeNotificationStub(),
-	// `Notification.record` rides `LivePublisher` (the per-recipient live delivery seam,
-	// #2076) — a static requirement of the mod emit even though the flag-off path never
-	// records. A no-op publisher satisfies it; it is never reached.
 	Layer.succeed(LivePublisher)(livePublisherFor({publish: () => Effect.void, waitUntil: () => {}})),
 	Layer.succeed(RelationStore, {
 		has: () => Effect.die("RelationStore.has not exercised in report-mutation"),
 		hasSubjects: () => Effect.die("RelationStore.hasSubjects not exercised in report-mutation"),
 		subjectsOf: () => Effect.die("RelationStore.subjectsOf not exercised in report-mutation"),
 	}),
-	// The karma flag-gate deps `report.submit` gained (#150): `Flags` OFF ⇒ the
-	// `CanFlag` gate auto-passes without a karma read, so `Kunye.karmaOf` is never
-	// exercised (it dies on contact); `CanFlag.authorize` still stamps its proof off
-	// `CurrentActor`, provided per-call in `submit`.
+	// Flag off ⇒ the `CanFlag` gate auto-passes without a karma read (#150).
 	Layer.succeed(Kunye, {
 		karmaOf: () => Effect.die("Kunye.karmaOf not exercised in report-mutation (flag off)"),
 		tierOf: () => Effect.die("Kunye.tierOf not exercised in report-mutation"),
@@ -72,11 +56,6 @@ const bildirimOffStub = Layer.mergeAll(
 	} as typeof Kunye.Service),
 );
 
-// Drive the op through its real external interface (`resolveWire`: `resolve`
-// decode + the `encodeWireError` class→wire-code seam), not `.handler` — so the
-// failure assertions see the WIRE `code` a client gets, and a mis-annotated
-// `[FateWireCode]` (e.g. on `PostNotFound`) is a unit failure, not just an
-// integration-tier one.
 const submit = (
 	input: {targetKind: "post" | "comment" | "definition"; targetId: string; reason?: string | null},
 	user?: typeof REPORTER,
@@ -90,17 +69,13 @@ const submit = (
 		Effect.provide(bildirimOffStub),
 	);
 
-// The wire `code` carried by a `resolveWire` failure `Cause` (the `FateRequestError`
-// `encodeWireError` produced), or `undefined` if the cause holds no error / on success.
 const wireCodeOf = (cause: Cause.Cause<unknown>): unknown => {
 	const error = Cause.findErrorOption(cause);
 	return error._tag === "Some" ? (error.value as {code?: unknown}).code : undefined;
 };
 
-// A `Report` stub that hands `submit` whatever the test scripts — a landed
-// `ReportResult` or a `ReportTargetNotFound`. Every other method fails-on-contact
-// via the shared stub: this boundary only ever touches `submit`, so a reached
-// presence read / idempotency path (`Report.unit.test.ts`'s job) fails the test.
+// Every method but `submit` fails-on-contact, so a reached presence/idempotency path
+// (`Report.unit.test.ts`'s job) fails the test instead of passing quietly.
 const reportStub = (
 	respond: (input: ReportInput) => Effect.Effect<ReportResult, ReportTargetNotFound>,
 ): Layer.Layer<Report> => makeReportStub({submit: respond});
@@ -136,9 +111,8 @@ describe("report.submit wire boundary — auth gate (no DB)", () => {
 });
 
 describe("report.submit wire boundary — ReportTargetNotFound translates by targetKind", () => {
-	// The per-feature not-found WIRE codes — what `encodeWireError` derives from each
-	// translated class's `[FateWireCode]`. Asserting the code (not the class name in the
-	// cause string) is what catches a mis-annotated `PostNotFound` etc.
+	// Asserting the wire code, not the class name in the cause string, is what catches a
+	// mis-annotated `[FateWireCode]`.
 	const cases = [
 		{targetKind: "post" as const, wireCode: "POST_NOT_FOUND"},
 		{targetKind: "comment" as const, wireCode: "COMMENT_NOT_FOUND"},
@@ -154,8 +128,6 @@ describe("report.submit wire boundary — ReportTargetNotFound translates by tar
 				);
 				assert.isTrue(exit._tag === "Failure");
 				if (exit._tag === "Failure") {
-					// The translated per-feature code, never `INTERNAL_SERVER_ERROR` (which an
-					// un-translated, un-annotated `ReportTargetNotFound` would have encoded to).
 					assert.strictEqual(wireCodeOf(exit.cause), wireCode);
 				}
 			}),

--- a/apps/web/worker/features/report/reputation.ts
+++ b/apps/web/worker/features/report/reputation.ts
@@ -1,60 +1,37 @@
 /**
- * The triage-loop's reputation-in-row merge (#1703, ADR 0138) — the pure decision
- * layer that folds each open-report group's reported-target author standing
- * (tier + karma + prior moderator-removals) and the pile-on's reporter-diversity
- * signal onto the enriched `OpenReport` row. This is the künye-join seam the actor
- * drawer (#1852) and the remove-the-wave slice (#1855) both dock into: the row
- * query joins künye NOW so the shape is modelled, not a later backend redo.
- *
- * Kept engine-free (the batched künye/removal reads live in the `Moderate`-gated
- * `report.listOpen` resolver, `lists.ts`), so the merge — which reputation lands on
- * which group, the missing-standing fallback, and the diversity ratio — is a T1
- * unit (`*.unit.test.ts` precedent), the same split `enrich.ts` follows.
+ * The pure reputation-in-row merge (ADR 0138): fold each open-report group's target-author
+ * standing and the pile-on's reporter-diversity signal onto the enriched `OpenReport` row.
+ * Engine-free — the batched künye/removal reads live in the `Moderate`-gated resolver.
  */
 import {type TargetKind, targetKey} from "../../db/target-kind.ts";
 import type {Tier} from "../kunye/standing.ts";
 import type {OpenReportGroup} from "./Report.ts";
 
-/**
- * The reported target's author standing, keyed by author id and resolved inside the
- * gated read. `null`-safe upstream: a target whose author can't be resolved (missing
- * context / anonymized) carries no reputation and the row renders the neutral
- * fallback rather than a fabricated tier.
- */
+// A target whose author cannot be resolved (missing context / anonymized) carries no
+// reputation, and the row renders the neutral fallback rather than a fabricated tier.
 export interface AuthorReputation {
-	/** The author's account id — the actor-drawer's cross-mode hop key (#1852). */
 	authorId: string;
 	tier: Tier;
 	karma: number;
-	/** How many of this author's targets a moderator has previously removed (0 = clean). */
+	// How many of this author's targets a moderator has previously removed (0 = clean).
 	priorRemovals: number;
-	/** The author's live content footprint (#1852): tanım / gönderi / yorum counts. */
 	definitionCount: number;
 	postCount: number;
 	commentCount: number;
-	/** Whether someone actively vouches (kefil) this author (#1852). */
 	kefil: boolean;
-	/** How many DISTINCT targets of this author are open-reported (the "bu aktör" count, #1852). */
 	reportedTargets: number;
 }
 
-/**
- * The pile-on's reporter-diversity signal (ADR 0138): the total open reports on the
- * target and how many DISTINCT reporters filed them. `9 rapor · 7 farklı kişi` reads
- * as a real wave; `9 rapor · 1 kişi` reads as one grudge-reporter. Threaded now so
- * #1855's remove-the-wave has the contrast even though the composite report PK makes
- * `distinctReporters === reportCount` for content targets today.
- */
+// The pile-on's reporter-diversity signal (ADR 0138): `9 rapor · 7 farklı kişi` reads as a
+// real wave, `9 rapor · 1 kişi` as one grudge-reporter. The composite report PK makes
+// `distinctReporters === reportCount` for content targets today.
 export interface ReporterDiversity {
 	reportCount: number;
 	distinctReporters: number;
 }
 
-/**
- * The reputation-enriched fields folded onto an `OpenReport` row. All author-standing
- * fields are nullable together — an unresolvable author leaves the whole cluster null
- * so the row never claims a partial (tier-without-karma) reputation.
- */
+// All author-standing fields are nullable together — an unresolvable author leaves the
+// whole cluster null so the row never claims a partial (tier-without-karma) reputation.
 export interface RowReputation {
 	authorId: string | null;
 	authorTier: Tier | null;
@@ -68,17 +45,12 @@ export interface RowReputation {
 	authorReportedTargets: number | null;
 }
 
-/** The `<kind>:<id>` key an author-reputation map is keyed by (mirrors the view `id`). */
 export const reputationKeyOf = (targetKind: TargetKind, targetId: string): string =>
 	targetKey(targetKind, targetId);
 
-/**
- * Fold a group with its resolved author reputation + distinct-reporter count into the
- * row-reputation cluster. A group with no reputation (unresolved author) keeps every
- * author field null; `distinctReporters` falls back to the group's `reportCount` when
- * the diversity read didn't separate it (the PK-collapsed default), never below 1 for
- * a real reported target.
- */
+// A group with no reputation (unresolved author) keeps every author field null;
+// `distinctReporters` falls back to the group's `reportCount` when the diversity read did
+// not separate it.
 export const rowReputationOf = (
 	group: OpenReportGroup,
 	reputation: AuthorReputation | undefined,

--- a/apps/web/worker/features/report/reputation.unit.test.ts
+++ b/apps/web/worker/features/report/reputation.unit.test.ts
@@ -1,11 +1,8 @@
 /**
- * The triage-loop reputation-in-row merge — the T1 worker-seam unit (#1703, ADR
- * 0138), no engine. The decisions asserted: an author's tier/karma/prior-removals
- * fold onto the row's reputation cluster; an unresolved author leaves the WHOLE
- * cluster null (never a partial reputation); distinct-reporter count folds through,
- * falling back to the group's report count when the diversity read didn't separate
- * it (the PK-collapsed default). The batched künye / removal-count READS are
- * integration-tier; what's wrong-or-right without D1 is this pure merge.
+ * The triage-loop reputation-in-row merge (#1703, ADR 0138). The two decisions worth
+ * naming: an unresolved author leaves the WHOLE cluster null rather than a partial
+ * reputation, and the distinct-reporter count falls back to the group's report count
+ * when the diversity read did not separate it. The batched reads are integration-tier.
  */
 import {assert, describe, it} from "@effect/vitest";
 import type {OpenReportGroup} from "./Report.ts";

--- a/apps/web/worker/features/report/resolution.ts
+++ b/apps/web/worker/features/report/resolution.ts
@@ -1,52 +1,35 @@
 /**
- * The report resolution state machine (ADR 0098 §3) as pure domain logic — the
- * transition rules, with no database or Effect. `content_report.status` is a
- * closed three-state set; a terminal transition is the only writer of the audit
- * triad, so "resolved but we don't know who/what" is unrepresentable.
+ * The report resolution state machine (ADR 0098 §3) as pure domain logic — no database, no
+ * Effect. A terminal transition is the only writer of the audit triad, so "resolved but we
+ * don't know who/what" is unrepresentable.
  *
  *   open ──resolve(remove)──▶ resolved   (target removed via the 0096 substrate)
  *   open ──resolve(dismiss)─▶ dismissed (report unfounded, no action)
  *   resolved  ──reopen──▶ open            (a restore re-opens; bounded)
  *   dismissed ──reopen──▶ open
  *
- * Transitions are decided by `Match.tagsExhaustive` over the source status, which
- * forces every status to be addressed. A transition from a *dynamic* source status
- * that is illegal (e.g. re-resolving a terminal report) surfaces as a typed
- * `Result.Failure(IllegalTransition)` — a value in the caller's error channel, never a
- * bare `throw`: inside `Effect.fn` callers a throw becomes an untyped defect/500, so the
- * domain condition must ride the typed channel instead (#2560).
+ * An illegal transition is a typed `Result.Failure(IllegalTransition)`, never a `throw`: inside
+ * an `Effect.fn` caller a throw becomes an untyped defect/500 (#2560).
  */
 import {Match, Result} from "effect";
 
-/**
- * The closed status set, as the one runtime tuple the `content_report.status`
- * D1 enum sources from (so the column can't drift from the machine). `open` is
- * the only non-terminal state.
- */
+/** The one runtime tuple the `content_report.status` D1 enum sources from. */
 export const REPORT_STATUSES = ["open", "resolved", "dismissed"] as const;
 export type ReportStatus = (typeof REPORT_STATUSES)[number];
 
 /**
- * The outcome a terminal transition records — the persisted `resolution` column
- * value (a state the report reached; past tense), as the one runtime tuple the
- * `content_report.resolution` D1 enum sources from. A distinct axis from
- * {@link ResolveAction}: `removed` is the outcome under `status:"resolved"`,
- * `dismissed` the outcome under `status:"dismissed"`.
+ * The persisted `resolution` column value (the outcome reached; past tense) — a distinct axis
+ * from {@link ResolveAction}, and the one runtime tuple that D1 enum sources from.
  */
 export const RESOLUTIONS = ["removed", "dismissed"] as const;
 export type Resolution = (typeof RESOLUTIONS)[number];
 
 /**
- * The verb a moderator chooses on an open report (the action they take; present
- * tense) — the wire/input axis. Deliberately off the `removed`/`dismissed`
- * outcome tokens AND the `dismissed` status token: a bare `remove`/`dismiss`
- * reads as an action, never an outcome or a status. `remove` soft-deletes the
- * target. The action→outcome map is `remove → removed` (status `resolved`) and
- * `dismiss → dismissed` (status `dismissed`).
+ * The verb a moderator chooses (present tense) — the wire/input axis, deliberately off the
+ * outcome and status tokens so a bare `remove`/`dismiss` can't read as either.
  */
 export type ResolveAction = "remove" | "dismiss";
 
-/** A `Match`-able tagged view of a row's current status. */
 type StatusTag =
 	| {readonly _tag: "open"}
 	| {readonly _tag: "resolved"}
@@ -68,12 +51,7 @@ export class IllegalTransition extends Error {
 	}
 }
 
-/**
- * `resolve(action)` is legal only from `open`. The `Match.tagsExhaustive` forces
- * every status to be addressed; re-resolving an already-terminal report is a
- * `Result.Failure(IllegalTransition)` — the caller threads it through the typed error
- * channel rather than silently re-stamping the audit (#2560).
- */
+/** Legal only from `open`; re-resolving a terminal report fails rather than re-stamping the audit. */
 export const resolve = (
 	from: ReportStatus,
 	action: ResolveAction,
@@ -89,11 +67,7 @@ export const resolve = (
 		dismissed: () => Result.fail(new IllegalTransition(from, `resolve(${action})`)),
 	});
 
-/**
- * `reopen` is legal only from a terminal state (`resolved` | `dismissed`) — a
- * restore of a moderated entity reopens its report (ADR 0096 §4 ↔ 0098 §3).
- * Reopening an already-open report is a `Result.Failure(IllegalTransition)` (#2560).
- */
+/** Legal only from a terminal state — a restore reopens its report (ADR 0096 §4 ↔ 0098 §3). */
 export const reopen = (from: ReportStatus): Result.Result<ReportStatus, IllegalTransition> =>
 	Match.valueTags(tagged(from), {
 		open: () => Result.fail(new IllegalTransition(from, "reopen")),
@@ -104,15 +78,12 @@ export const reopen = (from: ReportStatus): Result.Result<ReportStatus, IllegalT
 export const isTerminal = (status: ReportStatus): boolean => status !== "open";
 
 /**
- * The terminal statuses a report can be reopened from, derived from the machine
- * ({@link isTerminal}) rather than hand-typed — so the SQL `reopen` guard sources
- * its "reopen only from a terminal state" set from the one machine, not a literal
- * that could drift from it (ADR 0098 §3). Narrowed to the terminal subtype.
+ * Derived from {@link isTerminal} rather than hand-typed, so the SQL `reopen` guard sources its
+ * terminal set from the one machine (ADR 0098 §3).
  */
 export const TERMINAL_STATUSES = REPORT_STATUSES.filter(isTerminal) as ReadonlyArray<
 	Exclude<ReportStatus, "open">
 >;
 
-/** The outcome an action records, independent of any transition — the action→outcome map. */
 export const outcomeOf = (action: ResolveAction): Resolution =>
 	action === "remove" ? "removed" : "dismissed";

--- a/apps/web/worker/features/report/resolution.unit.test.ts
+++ b/apps/web/worker/features/report/resolution.unit.test.ts
@@ -1,11 +1,4 @@
-/**
- * Resolution state-machine unit coverage (ADR 0098 §3) — the legal vs illegal
- * transitions, with no database. The compile-time guarantee (a missing branch is a
- * `Match.tagsExhaustive` error) is enforced by the type-checker; this proves the
- * runtime behavior: `open` resolves, terminals reject re-resolve, terminals reopen,
- * `open` rejects reopen. An illegal transition is a typed `Result.Failure`, not a
- * bare `throw` (#2560).
- */
+/** Resolution state-machine coverage (ADR 0098 §3) — legal vs illegal transitions. */
 import {assert, describe, it} from "@effect/vitest";
 import {Result} from "effect";
 import {

--- a/apps/web/worker/features/report/resolved.unit.test.ts
+++ b/apps/web/worker/features/report/resolved.unit.test.ts
@@ -1,11 +1,8 @@
 /**
- * Decision-feed enrichment merge — the T1 worker-seam unit (#1704), no engine. The
- * decisions asserted: each resolved group is folded with its `<kind>:<id>`-keyed target
- * context onto the right `target*` fields; the resolver id joins to its display handle
- * (the resolver is first-class); a group with no context keeps null context (never
- * dropped); and an unresolved resolver handle folds to null. The batched content /
- * identity READS live in the `Moderate`-gated `report.listResolved` resolver — what's
- * wrong-or-right without D1 is this pure fold.
+ * The decision-feed enrichment fold (#1704). Load-bearing: a group whose context or
+ * resolver handle won't resolve keeps nulls and is NEVER dropped — the decision itself
+ * always survives. The batched reads it folds over live in the gated
+ * `report.listResolved` resolver.
  */
 import {assert, describe, it} from "@effect/vitest";
 import {enrichResolvedReports, type ReportTargetContext} from "./enrich.ts";
@@ -80,7 +77,6 @@ describe("enrichResolvedReports — fold decisions with target context + resolve
 		assert.strictEqual(rows[0]?.targetExcerpt, null);
 		assert.strictEqual(rows[0]?.targetAuthor, null);
 		assert.strictEqual(rows[0]?.targetRef, null);
-		// The decision itself still resolves — the resolver stays first-class.
 		assert.strictEqual(rows[0]?.resolverHandle, "founder");
 	});
 

--- a/apps/web/worker/features/report/shapers.ts
+++ b/apps/web/worker/features/report/shapers.ts
@@ -1,10 +1,7 @@
 /**
- * Report wire-entity shaper. `ReportReceipt` is returned inline by the
- * `report.submit` mutation (no re-resolution through a source), so the interpreter
- * never stamps `__typename` for it — the handler must. This is the one and only
- * spelling of the `{__typename, …}` literal, so the receipt carries the same
- * discriminant every other fate entity does and the client can normalize it by
- * `__typename` (`.patterns/fate-effect-operations.md`).
+ * `ReportReceipt` is returned inline by `report.submit`, so the interpreter never stamps
+ * `__typename` for it — the handler must. This is the one and only spelling of that
+ * literal (`.patterns/fate-effect-operations.md`).
  */
 
 import {type TargetKind, targetKey} from "../../db/target-kind.ts";
@@ -23,12 +20,8 @@ export const toReportReceipt = (r: ReportResult): ReportReceipt => ({
 	created: r.created,
 });
 
-// `context` is the reported target's in-situ enrichment (#1702), resolved in the
-// `Moderate`-gated `report.listOpen` path; absent (`undefined`) for a target whose
-// content couldn't be read, in which case the `target*` fields are null. `reputation`
-// is the #1703 künye-join cluster (author standing + reporter diversity); it always
-// carries a `distinctReporters` (falling back to the group's report count upstream)
-// and null author fields when the author is unresolved.
+// `context` is absent for a target whose content couldn't be read, in which case the
+// `target*` fields are null (#1702).
 export const toOpenReport = (
 	g: OpenReportGroup,
 	context: ReportTargetContext | undefined,
@@ -56,11 +49,8 @@ export const toOpenReport = (
 	authorReportedTargets: reputation.authorReportedTargets,
 });
 
-// `context` is the decided target's in-situ enrichment, resolved in the
-// `Moderate`-gated `report.listResolved` path; absent (`undefined`) for a target whose
-// content couldn't be read (removed/sandboxed), in which case the `target*` fields are
-// null. `resolverHandle` is the resolver's display handle joined from the same gated
-// read; null when the identity couldn't be resolved.
+// As above: `context` is absent when the target's content couldn't be read
+// (removed/sandboxed), and the `target*` fields are then null.
 export const toResolvedReport = (
 	g: ResolvedReportGroup,
 	context: ReportTargetContext | undefined,

--- a/apps/web/worker/features/report/sources.ts
+++ b/apps/web/worker/features/report/sources.ts
@@ -1,11 +1,8 @@
 /**
- * Report fate source — `ReportReceipt` has NO fetch path: it is the
- * `report.submit` ack, returned inline by the mutation and never read by id (a
- * report is private moderation state, ADR 0082). `syntheticSource` registers the
- * entity so source-completeness validation accepts it (it's view-reachable as
- * the mutation's result type) with ZERO capabilities; any capability call fails
- * loudly. Mirrors `Contribution` — the escape hatch in
- * `.patterns/fate-effect-sources.md`.
+ * Every report entity is delivered inline by a resolver or mutation and never read by
+ * id, so all four are capability-less `syntheticSource`s — registered for
+ * source-completeness validation, with any capability call failing loudly. See the
+ * escape hatch in `.patterns/fate-effect-sources.md`.
  */
 import {Fate} from "@kampus/fate-effect";
 import {
@@ -16,10 +13,6 @@ import {
 } from "./views.ts";
 
 export const reportReceiptSource = Fate.syntheticSource(ReportReceiptView);
-// `OpenReport` is delivered inline by the `report.listOpen` list resolver, `ResolvedReport`
-// inline by the `report.listResolved` list resolver (#1704), and `ResolveReceipt` by the
-// `report.resolve`/`report.restore` mutations — none is read by id, so all are
-// capability-less synthetic sources (view-reachable, no fetch path).
 export const openReportSource = Fate.syntheticSource(OpenReportView);
 export const resolvedReportSource = Fate.syntheticSource(ResolvedReportView);
 export const resolveReceiptSource = Fate.syntheticSource(ResolveReceiptView);

--- a/apps/web/worker/features/report/views.ts
+++ b/apps/web/worker/features/report/views.ts
@@ -1,12 +1,7 @@
 /**
- * `ReportReceipt` — the `report.submit` acknowledgement, NOT a re-resolved
- * entity. A report is private moderation state with no public read view (ADR
- * 0082), so the mutation returns a small typed ack instead of a cached entity:
- * which target was reported and whether this call created a fresh row (`false`
- * on the idempotent re-report no-op). The synthetic `id` is the
- * `<targetKind>:<targetId>` key, stable per target so the client normalizes the
- * receipt to one record. Mirrors `LandingStats` — a result-only data view with
- * no source/fetch path. See `.patterns/fate-effect-data-views.md`.
+ * The `report.submit` ack — NOT a re-resolved entity: a report is private moderation
+ * state with no public read view (ADR 0082). Result-only, no source/fetch path; see
+ * `.patterns/fate-effect-data-views.md`. `id` is the stable `<targetKind>:<targetId>` key.
  */
 import {FateDataView, type WorkerEntity} from "@kampus/fate-effect";
 import type {TargetKind} from "../../db/target-kind.ts";
@@ -32,35 +27,11 @@ export const reportReceiptDataView = ReportReceiptView.view;
 export type ReportReceipt = WorkerEntity<typeof ReportReceiptView>;
 
 /**
- * `OpenReport` — one moderation-queue entry (ADR 0098 §5): an open-reported target
- * with its distinct-reporter (repeat-offender) count. Private moderation state, so
- * the `report.listOpen` root list is gated behind the `Moderate` capability (the
- * `moderates` relation tuple, ADR 0107 §4); no source
- * fetch path (the list resolver returns it inline). `id` is `<targetKind>:<targetId>`.
- *
- * The `target*` fields carry the reported target's in-situ context (#1702), enriched
- * inside the same `Moderate`-gated `report.listOpen` path (never a new public read):
- * a content excerpt/title, the author's handle, and the routing reference the client
- * turns into an in-situ link (post/comment → `/pano/<ref>`, definition →
- * `/sozluk/<ref>`). All three are nullable — a target whose context can't be resolved
- * (e.g. a sandboxed row hidden from the batched content read) renders the row without
- * context rather than blocking the queue.
- *
- * The `author*` reputation cluster + `distinctReporters` (#1703, ADR 0138) carry the
- * reported target author's standing (tier / karma / prior moderator-removals) and the
- * pile-on's reporter-diversity signal, joined from künye INSIDE this same gated read.
- * The author cluster is null together for an unresolvable author (never a partial
- * reputation); `distinctReporters` mirrors `reportCount` today (the composite report
- * PK collapses them for content targets) but is threaded as the seam #1852's actor
- * drawer and #1855's remove-the-wave dock into.
- *
- * The `authorId`, `authorProduction*` counts, `authorKefil`, and `authorReportedTargets`
- * (#1852, ADR 0138) complete the actor-drawer's join: the actor's account id (the
- * cross-mode hop key), their live content footprint (tanım / gönderi / yorum), their
- * kefil (vouch) status, and the "bu aktör" count of how many of their targets are
- * open-reported — all joined INSIDE this same gated read (a MODE over
- * `report.listOpen`, never a second data path). They are null together with the author
- * cluster when the author is unresolved.
+ * One moderation-queue entry (ADR 0098 §5). Every `target*` and `author*` field is
+ * enriched INSIDE the `Moderate`-gated `report.listOpen` read — never a second, public
+ * data path. All are nullable, and the `author*` cluster nulls together (never a partial
+ * reputation); a target whose context won't resolve renders bare rather than blocking
+ * the queue. `id` is `<targetKind>:<targetId>`.
  */
 export type OpenReportViewRow = ViewRow<{
 	id: string;
@@ -69,31 +40,22 @@ export type OpenReportViewRow = ViewRow<{
 	reportCount: number;
 	reason: string | null;
 	firstReportedAt: string;
-	/** A content excerpt or title identifying the reported target (`null` when unresolved). */
 	targetExcerpt: string | null;
-	/** The reported target's author handle (`null` when unresolved). */
 	targetAuthor: string | null;
-	/** The in-situ routing reference: post id (post & comment→parent post) or term slug (definition). */
+	/** Post id (post & comment→parent post) or term slug (definition). */
 	targetRef: string | null;
-	/** The reported target author's account id — the actor-drawer's cross-mode hop key (`null` when unresolved). */
 	authorId: string | null;
-	/** Distinct reporters filing open reports on this target (reporter-diversity numerator). */
 	distinctReporters: number;
-	/** The reported target author's authorship tier (`null` when the author is unresolved). */
 	authorTier: string | null;
-	/** The author's earned karma (`null` when unresolved). */
 	authorKarma: number | null;
-	/** How many of the author's targets a moderator previously removed (`null` when unresolved). */
+	/** How many of the author's targets a moderator previously removed. */
 	authorPriorRemovals: number | null;
-	/** The author's live tanım (definition) production count (`null` when unresolved). */
 	authorDefinitionCount: number | null;
-	/** The author's live gönderi (post) production count (`null` when unresolved). */
 	authorPostCount: number | null;
-	/** The author's live yorum (comment) production count (`null` when unresolved). */
 	authorCommentCount: number | null;
-	/** The author's kefil (active-vouch) status — `true` when someone actively vouches them (`null` when unresolved). */
+	/** `true` when someone actively vouches for the author. */
 	authorKefil: boolean | null;
-	/** How many DISTINCT targets of this author are open-reported (the "bu aktör" count; `null` when unresolved). */
+	/** How many DISTINCT targets of this author are open-reported (the "bu aktör" count). */
 	authorReportedTargets: number | null;
 }>;
 
@@ -123,11 +85,6 @@ export const openReportDataView = OpenReportView.view;
 
 export type OpenReport = WorkerEntity<typeof OpenReportView>;
 
-/**
- * `ResolveReceipt` — the `report.resolve` acknowledgement (ADR 0098 §3): the
- * decided `resolution`, whether the target was removed, and how many open reports
- * the resolve collapsed. Result-only view, like `ReportReceipt`.
- */
 export type ResolveReceiptViewRow = ViewRow<{
 	id: string;
 	targetKind: TargetKind;
@@ -151,45 +108,30 @@ export const resolveReceiptDataView = ResolveReceiptView.view;
 export type ResolveReceipt = WorkerEntity<typeof ResolveReceiptView>;
 
 /**
- * `ResolvedReport` — one entry of the shared decision feed (#1704, the two-person
- * team-ledger): a recently resolved/dismissed target with the audit triad the schema
- * stamps — the `resolution` (removed/dismissed), the **resolver** (which moderator,
- * first-class), and `resolvedAt`. Private moderation state, so the `report.listResolved`
- * root list is `Moderate`-gated (invisible denial, no live view, no cursor), like
- * `report.listOpen`. `id` is `<targetKind>:<targetId>`.
- *
- * The `target*` fields carry the decided target's in-situ context, enriched inside the
- * same gated read (never a new public read): a content excerpt/title, the author handle,
- * and the routing ref (post/comment → `/pano/<ref>`, definition → `/sozluk/<ref>`). All
- * three are nullable — a target whose content can't be resolved (removed/sandboxed)
- * renders the row without context rather than dropping it. `resolverHandle` is likewise
- * nullable (an unresolved resolver identity falls back to the raw id client-side).
+ * One entry of the shared decision feed (#1704). `Moderate`-gated like `OpenReport`, with
+ * its `target*` context enriched inside that same read; every nullable field renders bare
+ * rather than dropping the row. `id` is `<targetKind>:<targetId>`.
  */
 export type ResolvedReportViewRow = ViewRow<{
 	id: string;
 	targetKind: TargetKind;
 	targetId: string;
-	/** The decision: `removed` (content soft-deleted) | `dismissed` (report unfounded). */
+	/** `removed` (content soft-deleted) | `dismissed` (report unfounded). */
 	resolution: Resolution;
-	/** The moderator's account id who decided. */
 	resolverId: string;
-	/** The resolver's display handle (`null` when the identity couldn't be resolved). */
 	resolverHandle: string | null;
-	/** When the decision landed (ISO-8601). */
+	/** ISO-8601. */
 	resolvedAt: string;
 	/** How many reports the decision collapsed on this target. */
 	reportCount: number;
 	/**
-	 * The wave grouping id (#1855) shared across a batch's targets, or `null` on a lone
-	 * removal — the decision feed's restore-as-a-unit key. Rows sharing a `waveId` render
-	 * as one entry whose restore reopens the whole batch (`report.restoreWave`).
+	 * Shared across a wave batch's targets (#1855), `null` on a lone removal. Rows sharing
+	 * one render as a single entry whose restore reopens the whole batch.
 	 */
 	waveId: string | null;
-	/** A content excerpt or title identifying the decided target (`null` when unresolved). */
 	targetExcerpt: string | null;
-	/** The decided target's author handle (`null` when unresolved). */
 	targetAuthor: string | null;
-	/** The in-situ routing reference: post id (post & comment→parent post) or term slug (definition). */
+	/** Post id (post & comment→parent post) or term slug (definition). */
 	targetRef: string | null;
 }>;
 

--- a/apps/web/worker/features/rss/feed.ts
+++ b/apps/web/worker/features/rss/feed.ts
@@ -1,15 +1,8 @@
-/**
- * Pure RSS 2.0 rendering — no Effect, no I/O. The route (`route.ts`) loads recent
- * pano posts and hands them here as {@link FeedItem}s; this module renders a
- * well-formed `<rss>` document. Kept side-effect-free so the channel/item shaping
- * and XML escaping are unit-testable without a worker.
- */
+/** Pure RSS 2.0 rendering, kept side-effect-free so it is unit-testable without a worker. */
 
 export interface FeedItem {
-	/** Stable item identity → `<guid>`. The post id (also the permalink basis). */
 	readonly id: string;
 	readonly title: string;
-	/** Absolute permalink → `<link>`/`<guid>`. */
 	readonly link: string;
 	readonly description: string | null;
 	readonly pubDate: Date;
@@ -19,7 +12,6 @@ export interface FeedChannel {
 	readonly title: string;
 	readonly link: string;
 	readonly description: string;
-	/** Absolute self-reference for `<atom:link rel="self">`. */
 	readonly feedUrl: string;
 	readonly items: ReadonlyArray<FeedItem>;
 }
@@ -55,11 +47,7 @@ function renderItem(item: FeedItem): string {
 	return `<item>${parts.join("")}</item>`;
 }
 
-/**
- * Render a channel as an RSS 2.0 document string. Declares the `atom` namespace
- * for the `rel="self"` link (a feed-validator best practice) while staying RSS
- * 2.0 at the root.
- */
+/** The `atom` namespace is declared for the `rel="self"` link; the root stays RSS 2.0. */
 export function renderFeed(channel: FeedChannel): string {
 	const head = [
 		`<title>${escapeXml(channel.title)}</title>`,

--- a/apps/web/worker/features/rss/route.ts
+++ b/apps/web/worker/features/rss/route.ts
@@ -1,14 +1,9 @@
 /**
- * `GET /rss.xml` — the site RSS feed (the footer's `rss` link target). A raw
- * `HttpRouter.add` route (not typed-JSON: the body is an XML document, not a
- * schema-shaped JSON value) that reads recent pano posts off `Pano` and renders
- * an RSS 2.0 document. `Pano` reaches the handler through the runtime-derived
- * context layer (`HttpRouter.provideRequest`, `http/app.ts`), same as `/fate`.
- * See `.patterns/alchemy-http-router.md`.
+ * `GET /rss.xml` — the site RSS feed. A raw `HttpRouter.add` route (the body is an XML document,
+ * not a schema-shaped JSON value); see `.patterns/alchemy-http-router.md`.
  *
- * Links are absolute, derived from the request origin — the worker has no
- * configured canonical site URL, and the origin the feed was fetched from is the
- * correct base per environment (dev vs deployed) without a new binding.
+ * Links are absolute, derived from the request origin: the worker has no configured canonical site
+ * URL, and the fetched-from origin is the correct base per environment without a new binding.
  */
 import * as Cloudflare from "alchemy/Cloudflare";
 import * as Effect from "effect/Effect";
@@ -17,10 +12,8 @@ import * as HttpServerResponse from "effect/unstable/http/HttpServerResponse";
 import {Pano} from "../pano/Pano.ts";
 import {type FeedChannel, type FeedItem, renderFeed} from "./feed.ts";
 
-/** How many recent posts the feed carries. */
 const FEED_SIZE = 30;
 
-/** The SPA permalink for a post (`PanoPostCard`/`PanoPostDetail` use `slug ?? id`). */
 const postPath = (slug: string | null, id: string): string => `/pano/${slug ?? id}`;
 
 export const handleRss = Effect.gen(function* () {

--- a/apps/web/worker/features/search/Search.sandbox.unit.test.ts
+++ b/apps/web/worker/features/search/Search.sandbox.unit.test.ts
@@ -1,39 +1,12 @@
 /**
- * `Search.searchPosts` visibility wiring — site search must NOT leak a çaylak's
- * sandboxed (pre-review) post nor another author's draft to a searcher not entitled to
- * see it. `searchPosts` is a fourth read into `post_record`; like the other three pano
- * reads it sources its mask from the one pano seam — {@link postVisibleWhere} (ADR
- * 0113), the sandbox arm AND the author-only draft arm — resolved against the request
- * viewer. This subsumes the #1358 hand-written sandbox-only mask: the sandbox masking
- * is now sourced from the seam (not a search-local predicate) and the draft dimension
- * rides along with it.
+ * Proves `searchPosts` WIRES `postVisibleWhere` (ADR 0113) into BOTH the count and the
+ * keyset — not just the hydrate, or `totalCount` and pagination would count rows the
+ * viewer can't see (the #1312 leak). The predicate's semantics are proven elsewhere
+ * (`SandboxVisibility.unit.test.ts`, `PostVisibility.unit.test.ts`); only the wiring is
+ * under test here.
  *
- * The FTS index keeps sandboxed/draft rows (so an author CAN find their own via
- * search), so the mask is a read-time filter — and it must ride EVERY query over the
- * FTS table, not just the hydrate: `totalCount` and the keyset would otherwise count
- * and slot rows the viewer can't see (the #1312 count/pagination leak). This test
- * drives the real `SearchLive` service over a recording D1 *client* (no SQL engine,
- * ADR 0082) and asserts the rendered SQL of the count + keyset queries carries the
- * viewer's predicate. The predicate SEMANTICS (who sees what) are already proven by
- * `SandboxVisibility.unit.test.ts` and `PostVisibility.unit.test.ts`; what THIS proves
- * is that `searchPosts` WIRES that predicate into both the count and the keyset for
- * every viewer kind.
- *
- * The sandbox viewer matrix (the leak is closed iff):
- *   - anonymous / public — `sandboxed_at IS NULL` (live only, no viewer arm).
- *   - other member — `sandboxed_at IS NULL OR author_id = :viewerId`; the viewer is
- *     not the çaylak, so the author arm matches none of their rows → live only.
- *   - the author — same predicate, but `author_id = :viewerId` now matches their own
- *     rows → they DO find their own sandboxed posts.
- *   - moderator — no sandbox arm at all (`canSeeSandboxed` ⇒ `undefined`, dropped by
- *     `and()`) → sees everything. The always-on filter is a no-op for them; every
- *     viewer still excludes removed posts.
- *
- * The draft arm rides the SAME read but has NO moderator exemption (ADR 0113 §2): a
- * draft is `is_draft IS NOT 1` (public) OR `author_id = :viewerId` (own) for every
- * signed-in viewer including a moderator, and `is_draft IS NOT 1` for anonymous — so a
- * moderator does NOT surface another author's draft, the cell that distinguishes draft
- * from sandbox.
+ * The FTS index deliberately KEEPS sandboxed/draft rows so an author can find their own,
+ * which is why the mask has to be a read-time filter.
  */
 import {Effect, Layer} from "effect";
 import {describe, expect, it} from "vitest";
@@ -42,9 +15,9 @@ import type {SandboxViewer} from "../lifecycle/EntityLifecycle.ts";
 import {Search, SearchLive} from "./Search.ts";
 
 /**
- * A recording D1 *client* (no SQL engine, ADR 0082): it records the SQL string of
- * every statement drizzle's d1 driver prepares and returns empty results, so the
- * service runs to completion (empty page) while we inspect the rendered queries.
+ * A recording D1 client with NO SQL engine (ADR 0082): it records each prepared SQL
+ * string and returns empty results, so the service runs to completion while we inspect
+ * the rendered queries.
  */
 const recordingD1 = () => {
 	const prepared: string[] = [];
@@ -79,7 +52,6 @@ const recordingD1 = () => {
 	return {db, prepared};
 };
 
-/** Render the SQL the searchPosts service emits for `query` under `viewer`. */
 const renderSearchSql = async (viewer: SandboxViewer, query = "yazilim"): Promise<string[]> => {
 	const {db, prepared} = recordingD1();
 	const layer = SearchLive.pipe(Layer.provide(makeDrizzleLayer(db as DrizzleDb)));
@@ -110,7 +82,6 @@ describe("searchPosts — sandbox read-mask wired into BOTH count and keyset (#1
 		for (const q of [count!, keyset!]) {
 			expect(q).toMatch(/in \(+select .*"post_record"/i);
 			expect(q).toMatch(/"sandboxed_at" is null/i);
-			// no per-viewer author arm for an anonymous searcher
 			expect(q).not.toMatch(/"author_id" =/i);
 		}
 	});
@@ -135,9 +106,8 @@ describe("searchPosts — sandbox read-mask wired into BOTH count and keyset (#1
 		const keyset = keysetQuery(sqls);
 		for (const q of [count, keyset]) {
 			expect(q).toBeDefined();
-			// the sandbox dimension is unrestricted for a moderator
 			expect(q).not.toMatch(/"sandboxed_at"/i);
-			// but the removal guard (ADR 0096) holds for every viewer
+			// the removal guard (ADR 0096) holds for every viewer, moderator included
 			expect(q).toMatch(/"removed_at" is null/i);
 		}
 	});

--- a/apps/web/worker/features/search/Search.tag-canonical.unit.test.ts
+++ b/apps/web/worker/features/search/Search.tag-canonical.unit.test.ts
@@ -1,16 +1,10 @@
 /**
- * `Search.searchPosts` hydrates through the SHARED pano mapper, so a post tagged
- * with a legacy seed-era alias (`show`) renders the canonical Turkish label
- * (`göster`) in search — exactly as the feed does (#2015). Before the fix, the
- * search hydrator kept a private `parsePostTags` that set `label = kind` (the raw
- * value), so `show` rendered as `show` in search while `tagLabel` resolved it to
- * `göster` everywhere else — a real user-visible drift. Routing the hydrate through
- * `toPostSummaryKeysetRow` (which calls `parseTags` → `tagLabel`) is the fix; this
- * test is the drift regression, asserting the resolved label off the real service.
+ * The drift regression for #2015: search must hydrate through the SHARED pano mapper,
+ * so a legacy alias (`show`) renders its canonical Turkish label (`göster`) exactly as
+ * the feed does. A private search-side tag parser once set `label = kind`, and the two
+ * surfaces disagreed.
  *
- * Driven over a recording D1 *client* (no SQL engine, ADR 0082) that returns a
- * single matching post row carrying `tags: "show"`, so the service runs the real
- * hydrate and shapes the row through the shared mapper.
+ * Driven over a recording D1 *client* — no SQL engine, ADR 0082.
  */
 import {Effect, Layer} from "effect";
 import {describe, expect, it} from "vitest";
@@ -19,17 +13,11 @@ import {Search, SearchLive} from "./Search.ts";
 
 const POST_ID = "post-1";
 
-/**
- * A recording D1 client that answers each query shape the searchPosts read issues:
- * the `count(*)` (1 match), the keyset keys fetch (one key = POST_ID), and the
- * hydrate select (one `post_record` row tagged with the legacy `show` alias). The
- * cursor-rank query never runs (no `after`).
- */
+/** Answers each query shape the searchPosts read issues; the cursor-rank query never runs. */
 const taggedPostD1 = (tagsCsv: string) => {
-	// The hydrate row, in the exact select-column order the searchPosts hydrate lists
-	// (id, slug, title, url, host, bodyExcerpt, authorId, authorName, score,
-	// commentCount, createdAt, tags) — drizzle's d1 select reads it column-mode via
-	// `.raw()`, so it's returned as a value array in that order.
+	// Must stay in the searchPosts hydrate's exact select-column order (id, slug, title,
+	// url, host, bodyExcerpt, authorId, authorName, score, commentCount, createdAt,
+	// tags): drizzle's d1 select reads column-mode via `.raw()`, positionally.
 	const hydrateRow = [
 		POST_ID,
 		"a-post",
@@ -48,7 +36,6 @@ const taggedPostD1 = (tagsCsv: string) => {
 		/from\s+"post_record"/i.test(sql) && / as key /i.test(sql) === false;
 	const answer = (sql: string): {results: unknown[]} => {
 		if (/count\(\*\)/i.test(sql)) return {results: [{n: 1}]};
-		// keyset keys fetch: `SELECT id AS key ... ORDER BY ... LIMIT`
 		if (/ as key /i.test(sql)) return {results: [{key: POST_ID}]};
 		return {results: []};
 	};
@@ -64,7 +51,6 @@ const taggedPostD1 = (tagsCsv: string) => {
 			return {...answer(stmt._sql), success: true, meta: {}};
 		},
 		async raw() {
-			// drizzle's d1 `.select()` reads column-mode via `.raw()` (arrays of values).
 			return isHydrate(stmt._sql) ? [hydrateRow] : [];
 		},
 		async first() {

--- a/apps/web/worker/features/search/Search.ts
+++ b/apps/web/worker/features/search/Search.ts
@@ -1,19 +1,11 @@
 /**
- * Search — the lexical site-search service (ADR 0080). Owns the FTS5 read path:
- * a bm25-ranked, keyset-paginated MATCH over the `term_search` / `post_search`
- * virtual tables, joined back to `term_record` / `post_record` for the row
- * shape the existing `Term` / `Post` views already render.
+ * Search — the lexical site-search service (ADR 0080). A bm25-ranked,
+ * keyset-paginated MATCH over the `term_search` / `post_search` virtual tables,
+ * joined back to `term_record` / `post_record`. The write-side FTS sync lives in
+ * `fts-sync.ts` (dual-write from the mutation handlers, not triggers).
  *
- * Scope v1 is term titles + post titles (ADR 0080); definition/comment bodies and
- * users are deferred. The write-side sync that keeps the FTS tables current lives
- * in `fts-sync.ts`, called from the Sozluk/Pano mutation handlers (dual-write, not
- * triggers).
- *
- * Pagination keyset: `(bm25 rank asc, key asc)` — bm25 returns more-negative for a
- * better match, so ascending rank IS relevance-first (ADR 0019 keyset shape, with
- * the FTS rank as the lead column and the slug/id as the stable tiebreaker). The
- * cursor is the row key; an `after` whose key no longer matches the query is a
- * cursor miss → empty page (the shared connection semantic).
+ * Keyset is `(bm25 rank asc, key asc)`: bm25 returns more-negative for a better
+ * match, so ASCENDING rank is relevance-first.
  */
 
 import {and, isNull, type SQL, sql} from "drizzle-orm";
@@ -58,11 +50,9 @@ export interface SearchOpts {
 }
 
 /**
- * `searchPosts` carries a {@link SandboxViewer} so the FTS read masks posts through
- * the pano visibility seam (ADR 0113) the same way every other pano read does —
- * sandboxed and draft posts excluded per viewer. Omitted reads as the least-privileged
- * {@link anonymousViewer} (public-only), the fail-safe default. Terms have no sandbox
- * or draft dimension, so `searchTerms` needs no viewer.
+ * Omitting `viewer` reads as the least-privileged {@link anonymousViewer}
+ * (public-only) — the fail-safe default. Terms have no sandbox or draft dimension,
+ * so `searchTerms` needs no viewer.
  */
 export interface SearchPostsOpts extends SearchOpts {
 	viewer?: SandboxViewer | undefined;
@@ -71,25 +61,15 @@ export interface SearchPostsOpts extends SearchOpts {
 export class Search extends Context.Service<
 	Search,
 	{
-		/**
-		 * bm25-ranked keyset page of term-title matches. Returns full
-		 * `TermSummaryRow`s so the resolver reuses the `Term` shaper. A query below
-		 * the min length (or matching nothing) yields an empty connection.
-		 */
 		readonly searchTerms: (opts: SearchOpts) => Effect.Effect<TermSearchPage>;
 
-		/**
-		 * bm25-ranked keyset page of post-title matches (full `PostSummaryRow`s),
-		 * masked to the viewer's visible set via the pano seam — see {@link SearchPostsOpts}.
-		 */
 		readonly searchPosts: (opts: SearchPostsOpts) => Effect.Effect<PostSearchPage>;
 	}
 >()("@kampus/search/Search") {}
 
 /**
- * Resolve the cursor row's bm25 rank for the same MATCH (bm25 is stable for a
- * given doc + query), so the keyset predicate selects rows strictly after it. A
- * key that no longer matches is a cursor miss → `null` (caller returns empty).
+ * The cursor row's bm25 rank for the same MATCH (bm25 is stable for a given doc +
+ * query). A key that no longer matches is a cursor miss → `null`.
  */
 const resolveCursorRank = async (
 	db: DrizzleDb,
@@ -109,10 +89,8 @@ const resolveCursorRank = async (
 };
 
 /**
- * The shared FTS read: count matches, resolve the cursor (if any), then fetch the
- * keyed page ordered `(bm25 asc, key asc)`. Returns the ranked list of keys + the
- * `hasNextPage`/`endCursor` envelope; the caller hydrates rows from the summary
- * table (keeping summary-row shaping in one place per domain).
+ * The shared FTS read: count, resolve the cursor, fetch the keyed page ordered
+ * `(bm25 asc, key asc)`. Returns keys only; the caller hydrates rows.
  */
 const ftsKeysetKeys = async (
 	db: DrizzleDb,
@@ -126,11 +104,9 @@ const ftsKeysetKeys = async (
 	totalCount: number;
 }> => {
 	const {match, first, after, visibleFilter} = opts;
-	// The viewer's visibility predicate rides EVERY query over the FTS table — count,
-	// cursor-rank, and the keyed fetch — not just the hydrate. Masking the hydrate
-	// alone would leave `totalCount` and the keyset counting/slotting rows the viewer
-	// can't see (the #1312 count/pagination leak); applied here, count, cursor, keys,
-	// and rows all reflect the same visible set (#1358).
+	// The viewer's visibility predicate must ride EVERY query over the FTS table — count,
+	// cursor-rank and the keyed fetch — not just the hydrate. Masking the hydrate alone
+	// left `totalCount` and the keyset counting rows the viewer cannot see (#1312/#1358).
 	const visible = visibleFilter ? sql` AND ${visibleFilter}` : sql``;
 
 	const totalCount = await db
@@ -139,8 +115,8 @@ const ftsKeysetKeys = async (
 		)
 		.then((r) => Number((r.results[0] as {n: number} | undefined)?.n ?? 0));
 
-	// The DB read (resolveCursorRank) is the port; `resolveCursor` is the pure
-	// cursor-miss decision (ADR 0082). bm25 rank `0` is a valid hit, not a miss.
+	// `resolveCursor` is the pure cursor-miss decision (ADR 0082). A bm25 rank of `0` is
+	// a valid hit, not a miss.
 	const cursor = resolveCursor<number>(
 		after,
 		after ? await resolveCursorRank(db, ftsTable, keyColumn, match, after, visibleFilter) : null,
@@ -150,8 +126,7 @@ const ftsKeysetKeys = async (
 	}
 	const cursorRank = cursor.kind === "hit" ? cursor.row : null;
 
-	// `(rank asc, key asc)` strictly-after predicate. bm25() can't be referenced by
-	// its SELECT alias in WHERE, so it's re-spelled inline.
+	// bm25() cannot be referenced by its SELECT alias in WHERE, so it is re-spelled inline.
 	const rankExpr = sql`bm25(${sql.raw(ftsTable)})`;
 	const after_ =
 		cursorRank !== null
@@ -169,14 +144,10 @@ const ftsKeysetKeys = async (
 };
 
 /**
- * The viewer's post read-mask as an FTS-query predicate: the post id must be in the
- * set of non-removed, visible posts for this viewer. `post_search` holds only
- * `id`/`norm` (no lifecycle columns), so the mask is expressed as `id IN (<visible
- * post ids>)` joining back to `post_record`. The visibility predicate is sourced from
- * the one pano seam — {@link postVisibleWhere} (ADR 0113): the shared sandbox arm AND
- * the author-only draft arm, so a çaylak's sandboxed post and another author's draft
- * are both excluded unless the viewer is its author (sandbox: or a moderator). The
- * caller keeps the orthogonal `removed_at IS NULL` removal guard (ADR 0096) beside it.
+ * The viewer's post read-mask as an FTS-query predicate. `post_search` holds only
+ * `id`/`norm` (no lifecycle columns), so the mask joins back to `post_record` as
+ * `id IN (<visible post ids>)`, sourced from the one pano seam {@link postVisibleWhere}
+ * (ADR 0113). The orthogonal `removed_at IS NULL` removal guard stays with the caller.
  */
 const postVisibleFilter = (db: DrizzleDb, viewer: SandboxViewer): SQL => {
 	const visibleIds = db
@@ -216,8 +187,7 @@ export const SearchLive = Layer.effect(Search)(
 				return {rows: [], hasNextPage, endCursor, totalCount} satisfies TermSearchPage;
 			}
 
-			// Hydrate summary rows, then re-order to the FTS rank order (a keyed
-			// `IN (...)` read returns no guaranteed order).
+			// Re-order to the FTS rank order: a keyed `IN (...)` read returns no guaranteed order.
 			const summaries = yield* run((db) =>
 				db
 					.select(termSummaryColumns)
@@ -253,14 +223,10 @@ export const SearchLive = Layer.effect(Search)(
 				return {rows: [], hasNextPage, endCursor, totalCount} satisfies PostSearchPage;
 			}
 
-			// Hydrate only live (non-deleted) posts through the SHARED pano mapper
-			// (`toPostSummaryKeysetRow`) so post_record→PostSummaryRow — including the
-			// `tags` CSV parse via `tagLabel` — is the single mapping the feed and
-			// keyset already cross (#2015). The local shaping drifted: it rendered the
-			// raw tag value (`show`) where the shared mapper resolves the legacy alias
-			// to the canonical Turkish label (`göster`). The select is the exact
-			// `PostKeysetRow` column subset the mapper reads. `removed_at` is the WHERE
-			// guard only (ADR 0096), spelled against the table — not a hydrated field.
+			// Hydrate through the SHARED pano mapper (`toPostSummaryKeysetRow`) — the local
+			// shaping had drifted, rendering the raw tag value where the shared mapper resolves
+			// the legacy alias to the canonical Turkish label (#2015). The select is exactly the
+			// `PostKeysetRow` column subset it reads; `removed_at` is a WHERE guard only.
 			const summaries = yield* run((db) =>
 				db
 					.select({

--- a/apps/web/worker/features/search/fate-module.ts
+++ b/apps/web/worker/features/search/fate-module.ts
@@ -5,9 +5,8 @@ import {postDataView} from "../pano/views.ts";
 import {termDataView} from "../sozluk/views.ts";
 import {lists} from "./lists.ts";
 
-// Search roots (ADR 0080) — per-type, reusing the Term/Post views from sözlük/pano
-// (search owns no entity of its own). The search service ranks by bm25 and owns the
-// keyset (the resolver owns the order).
+// Search owns no entity of its own, so these roots reuse the sözlük/pano views (ADR
+// 0080). The search service ranks by bm25 and owns the keyset.
 const roots: FateRootsRecord = {
 	searchTerms: list(termDataView),
 	searchPosts: list(postDataView),

--- a/apps/web/worker/features/search/fts-sync.ts
+++ b/apps/web/worker/features/search/fts-sync.ts
@@ -1,31 +1,18 @@
 /**
- * Dual-write FTS sync (ADR 0080). The FTS5 virtual tables `term_search` /
- * `post_search` are kept in lockstep with `term_record` / `post_record` from
- * the application write path — NOT D1 triggers — so the worker that owns every
- * write to a summary row writes its search row in the same place.
+ * Dual-write FTS sync (ADR 0080): the FTS5 virtual tables are kept in lockstep with the
+ * summary tables from the application write path, not D1 triggers. This module only builds
+ * statements; the caller spreads them into ONE `Drizzle.batch` alongside the summary write,
+ * so a crash can never desync the two. Each sync is delete-then-insert (FTS5 has no
+ * `ON CONFLICT`).
  *
- * Each sync is a delete-then-insert upsert (FTS5 has no `ON CONFLICT`, so a
- * re-sync removes the old row by key first). The module stays shallow (ADR 0080):
- * it builds statements and never crosses a service boundary — the caller spreads
- * the returned items, alongside the summary write, into ONE `Drizzle.batch` so the
- * summary row and its FTS row move all-or-none (the lockstep invariant ADR 0080
- * stakes the design on; a crash between the two can never desync them).
+ * Why drizzle query builders and NOT `sql`/`db.run(sql)`: a batch item must `_prepare()` to
+ * a `D1PreparedQuery` carrying a bound `.stmt`, because D1's batch driver calls
+ * `preparedQuery.stmt.bind(...params)`. `db.run(sql`…`)` yields a `SQLiteRaw` whose
+ * `_prepare()` returns itself with NO `.stmt`, so a parametrized raw statement throws
+ * `undefined.bind` and 500s the whole write the moment it rides in a batch (#863).
  *
- * Why drizzle query builders and NOT `sql`/`db.run(sql)`: a `Drizzle.batch` item
- * must `_prepare()` to a `D1PreparedQuery` carrying a bound `.stmt` — D1's batch
- * driver does `preparedQuery.stmt.bind(...params)` for every statement that has
- * params. `db.run(sql\`…\`)` yields a `SQLiteRaw`, whose `_prepare()` returns
- * itself with NO `.stmt`, so a parametrized raw statement throws
- * `undefined.bind` and 500s the whole write the moment it rides in a batch (#863
- * regression). A `db.insert(...)/.delete(...)` builder prepares to a real
- * `D1PreparedQuery`, so it is batch-safe. The FTS5 tables can't be drizzle-kit
- * generated (no virtual-table DSL — see `migrations/0002_search_fts.sql`), so we
- * declare minimal `sqliteTable` shims here purely to build batch-safe statements;
- * they are statement shapes, not a migration source.
- *
- * The indexed `norm` column is the Turkish-normalized title (see `normalize.ts`);
- * the `slug`/`id` column is `UNINDEXED`, carried only to join the match back to
- * the summary row.
+ * The indexed `norm` column is the Turkish-normalized title; the `slug`/`id` column is
+ * `UNINDEXED`, carried only to join the match back to the summary row.
  */
 
 import {eq} from "drizzle-orm";
@@ -45,22 +32,18 @@ const postSearch = sqliteTable("post_search", {
 	norm: text("norm").notNull(),
 });
 
-/** Upsert a term's FTS row (keyed by slug). Indexes the normalized title. */
 export const syncTermSearch = (db: FtsSyncDb, slug: string, title: string): [Stmt, Stmt] => [
 	db.delete(termSearch).where(eq(termSearch.slug, slug)),
 	db.insert(termSearch).values({slug, norm: normalizeSearchText(title)}),
 ];
 
-/** Remove a term's FTS row (term deleted / no longer searchable). */
 export const removeTermSearch = (db: FtsSyncDb, slug: string): Stmt =>
 	db.delete(termSearch).where(eq(termSearch.slug, slug));
 
-/** Upsert a post's FTS row (keyed by id). Indexes the normalized title. */
 export const syncPostSearch = (db: FtsSyncDb, id: string, title: string): [Stmt, Stmt] => [
 	db.delete(postSearch).where(eq(postSearch.id, id)),
 	db.insert(postSearch).values({id, norm: normalizeSearchText(title)}),
 ];
 
-/** Remove a post's FTS row (post deleted). */
 export const removePostSearch = (db: FtsSyncDb, id: string): Stmt =>
 	db.delete(postSearch).where(eq(postSearch.id, id));

--- a/apps/web/worker/features/search/fts-sync.unit.test.ts
+++ b/apps/web/worker/features/search/fts-sync.unit.test.ts
@@ -1,21 +1,9 @@
 /**
- * Unit tests for the FTS dual-write sync (ADR 0080) — no workerd. Pins three
- * invariants the live write→sync→read loop depends on:
- *
- *  1. The symmetric write/query fold: the `norm` text written into the FTS row
- *     folds the SAME way `normalizeSearchText` folds the resolver's query string,
- *     so a write and a later query meet on one token form.
- *  2. The statement shape: each sync is a delete-then-insert upsert (FTS5 has no
- *     `ON CONFLICT`), keyed by slug/id.
- *  3. Batch-safety against drizzle's REAL d1 batch builder (#863): the sync items
- *     must `_prepare()` to a `D1PreparedQuery` carrying a bound `.stmt`, so D1's
- *     `session.batch()` (`preparedQuery.stmt.bind(...params)`) builds them without
- *     throwing. The earlier `db.run(sql\`…\`)` shape yields a `SQLiteRaw` with no
- *     `.stmt`, which 500s the whole batch on real D1 — the prior unit fake (a
- *     recording `db.run`) never reached that builder path, so it sailed past. This
- *     test drives the real drizzle-d1 `batch()` over a recording D1 *client* (no
- *     SQL engine — ADR 0082), so a regression to a non-batchable item shape fails
- *     here, not only in remote integration.
+ * FTS dual-write sync coverage (ADR 0080) — the write/query fold symmetry, the
+ * delete-then-insert upsert shape, and batch-safety against drizzle's REAL d1 batch
+ * builder. That last one matters because a sync item that prepares without a bound
+ * `.stmt` 500s the whole batch on real D1, and a recording-`db.run` fake never reaches
+ * the builder path where that shows up (#863).
  */
 
 import {SQLiteDialect} from "drizzle-orm/sqlite-core";
@@ -28,15 +16,10 @@ const dialect = new SQLiteDialect();
 const renderStmt = (stmt: {getSQL: () => never}) => dialect.sqlToQuery(stmt.getSQL());
 
 /**
- * A recording D1 *client* — NOT a SQL engine, so this stays a unit test under ADR
- * 0082's "no faked engine" rule: it executes no SQL and asserts no FTS5/tokenizer/
- * collation behavior (those remain integration-tier facts). It records only the
- * statements drizzle's real d1 `batch()` builder *prepares and binds*, which is the
- * exact seam the #863 regression broke: a batch item must `_prepare()` to a
- * `D1PreparedQuery` whose `.stmt` the builder binds params onto. A query-builder
- * item has that `.stmt`; a `db.run(sql\`…\`)` `SQLiteRaw` does not, so the builder
- * throws before recording. The earlier recording-`db.run` fake never reached this
- * driver path, which is why the break sailed past unit and only 500'd on real D1.
+ * A recording D1 *client*, NOT a SQL engine — it executes nothing and asserts no
+ * FTS5/tokenizer/collation behavior, so this stays a unit test under ADR 0082. It
+ * records what drizzle's real `batch()` builder prepares and binds, which is the seam
+ * the #863 regression broke.
  */
 const recordingD1 = () => {
 	const built: {sql: string; params: unknown[]}[] = [];
@@ -66,7 +49,6 @@ describe("syncTermSearch / syncPostSearch — symmetric write/query fold", () =>
 		const [, insert] = syncTermSearch(db as DrizzleDb, "istanbul-sisli", title);
 		const {sql, params} = renderStmt(insert as never);
 		expect(sql).toBe('insert into "term_search" ("slug", "norm") values (?, ?)');
-		// the indexed text === what the resolver's query fold produces for the same input
 		expect(params).toEqual(["istanbul-sisli", normalizeSearchText(title)]);
 		expect(params[1]).toBe("istanbul sisli");
 	});
@@ -96,11 +78,8 @@ describe("syncTermSearch / syncPostSearch — symmetric write/query fold", () =>
 describe("ftsBatchItems shape — batch-safe against D1's real batch builder (#863)", () => {
 	it("composes the term sync into a single all-or-none D1 batch WITHOUT throwing", async () => {
 		const {db, built} = recordingD1();
-		// Build the batch tuple the way Sozluk/Pano now do (no `db.run(sql)` items),
-		// run through the REAL drizzle-d1 `batch()` (which binds params onto `.stmt`).
 		const items = syncTermSearch(db as DrizzleDb, "t", "Başlık");
 		await expect(db.batch([items[0], items[1]] as never)).resolves.toBeDefined();
-		// the FTS delete+insert reached D1's batch (params bound, not dropped)
 		expect(built).toHaveLength(2);
 		expect(built[0]?.sql).toBe('delete from "term_search" where "term_search"."slug" = ?');
 		expect(built[0]?.params).toEqual(["t"]);
@@ -111,11 +90,9 @@ describe("ftsBatchItems shape — batch-safe against D1's real batch builder (#8
 	it("a parametrized db.run(sql) item is batch-safe under drizzle rc.4 (the #863 rc.3 defect, fixed upstream)", async () => {
 		const {db, built} = recordingD1();
 		const {sql} = await import("drizzle-orm");
-		// #863 was an rc.3 defect: `db.run(sql)`'s SQLiteRaw prepared WITHOUT a `.stmt`,
-		// so D1's batch builder threw on `preparedQuery.stmt.bind(...)` for a parametrized
-		// item (a 500 on real D1). rc.4's `d1/session.ts` `prepareQuery` ALWAYS prepares
-		// `stmt = client.prepare(query.sql)`, so the raw now carries a real `.stmt` and
-		// binds in `batch()` like any query-builder item — the hazard is fixed upstream.
+		// The rc.3 defect: `db.run(sql)` prepared without a `.stmt`, so the batch builder
+		// threw on a parametrized item. rc.4's `prepareQuery` always prepares one, so this
+		// pins the upstream fix we now depend on.
 		const raw = db.run(sql`INSERT INTO term_search (slug, norm) VALUES (${"t"}, ${"n"})`);
 		await expect(db.batch([raw] as never)).resolves.toBeDefined();
 		expect(built).toHaveLength(1);
@@ -129,7 +106,6 @@ describe("ftsBatchItems shape — batch-safe against D1's real batch builder (#8
 		expect(built).toHaveLength(1);
 		expect(built[0]?.sql).toBe('delete from "post_search" where "post_search"."id" = ?');
 		expect(built[0]?.params).toEqual(["post_1"]);
-		// removeTermSearch mirrors it for the term side
 		expect(renderStmt(removeTermSearch(db as DrizzleDb, "t") as never).sql).toBe(
 			'delete from "term_search" where "term_search"."slug" = ?',
 		);

--- a/apps/web/worker/features/search/lists.ts
+++ b/apps/web/worker/features/search/lists.ts
@@ -1,10 +1,7 @@
 /**
- * Search root list resolvers — `searchTerms` / `searchPosts` (ADR 0080). Per-type
- * roots (no unified `SearchResult`), each reusing the existing `Term` / `Post`
- * view + shaper so #122 renders results with the verbatim `TermRow` / post-card
- * components. The service owns the FTS5 MATCH + bm25 keyset SQL (ADR 0019); this
- * layer validates the `query` arg and reshapes the page onto a `ConnectionResult`.
- * See `.patterns/fate-connections.md`.
+ * Search root list resolvers (ADR 0080). Per-type roots with no unified `SearchResult`,
+ * each reusing the existing `Term` / `Post` view + shaper so results render with the
+ * verbatim components. See `.patterns/fate-connections.md`.
  */
 
 import {Fate} from "@kampus/fate-effect";
@@ -41,9 +38,8 @@ export const lists = {
 	searchPosts: Fate.list(
 		{args: SearchArgs, type: PostView},
 		Effect.fn("searchPosts")(function* ({args}) {
-			// Resolve the sandbox viewer once (identity + moderator probe); search masks
-			// posts through the pano visibility seam (ADR 0113) — çaylak-sandboxed posts
-			// hidden from anyone but their author + a mod, and drafts from any non-author.
+			// Search masks posts through the pano visibility seam (ADR 0113), so it must
+			// resolve the viewer rather than reading sandbox-blind.
 			const sandboxViewer = yield* currentSandboxViewer;
 			const search = yield* Search;
 			const page = yield* search.searchPosts({

--- a/apps/web/worker/features/search/normalize.ts
+++ b/apps/web/worker/features/search/normalize.ts
@@ -1,18 +1,13 @@
 /**
- * Turkish-aware search normalization (ADR 0080). Folds a title into the ASCII
- * token stream the FTS5 `norm` column is indexed on — applied SYMMETRICALLY at
- * write time (when syncing the FTS row) and at query time (when building the
- * MATCH string), so search is both diacritic-insensitive and dotted-`i`
- * insensitive.
+ * Turkish-aware search normalization (ADR 0080). Must be applied SYMMETRICALLY at
+ * write time and at query time, or the two token streams stop matching.
  *
- * Why an app-side fold and not `unicode61` alone: `unicode61` case-folds ASCII
- * the English way (`I → i`), which is wrong for Turkish — `I` is the dotless `ı`
- * and `İ` is the dotted `i`. We lowercase Turkish-correctly first, then strip the
- * five Turkish diacritics + circumflex to ASCII, so `İstanbul`/`ISTANBUL`/
- * `istanbul` and `Şişli`/`sisli` all collapse to one token form.
+ * Why an app-side fold and not `unicode61` alone: `unicode61` case-folds ASCII the
+ * English way (`I → i`), which is wrong for Turkish — `I` is the dotless `ı` and `İ`
+ * is the dotted `i`.
  */
 
-/** Turkish-correct lowercase: `İ → i`, `I → ı` before the locale-blind fold. */
+// Turkish-correct lowercase, run BEFORE the locale-blind fold.
 const turkishLower = (s: string): string => s.replace(/İ/g, "i").replace(/I/g, "ı").toLowerCase();
 
 const DIACRITIC_FOLD: Record<string, string> = {
@@ -27,12 +22,6 @@ const DIACRITIC_FOLD: Record<string, string> = {
 	û: "u",
 };
 
-/**
- * Fold one piece of text to its normalized search form: Turkish-correct
- * lowercase, then the five Turkish diacritics + circumflex → ASCII, then strip
- * any residual combining marks (NFKD). Collapses internal whitespace so the token
- * stream is stable.
- */
 export const normalizeSearchText = (input: string): string =>
 	turkishLower(input)
 		.replace(/[ışğçöüâîû]/g, (c) => DIACRITIC_FOLD[c] ?? c)
@@ -41,18 +30,14 @@ export const normalizeSearchText = (input: string): string =>
 		.replace(/\s+/g, " ")
 		.trim();
 
-/** Minimum query length below which search returns an empty connection (ADR 0080). */
 export const MIN_QUERY_LENGTH = 2;
 
 /**
- * Build the FTS5 `MATCH` expression for a user query, or `null` when the
- * normalized query is below the min length (the caller returns an empty page).
+ * Build the FTS5 `MATCH` expression, or `null` below the min length.
  *
- * Each token is wrapped in double quotes (so FTS5 operator words like `OR`/`NOT`
- * and punctuation become literal string tokens — no MATCH-grammar injection) and
- * suffixed with `*` for prefix matching (the poor-man's stemmer for Turkish
- * agglutination, ADR 0080). Embedded quotes are doubled per FTS5 string-literal
- * escaping.
+ * Every token is double-quoted so FTS5 operator words like `OR`/`NOT` and punctuation
+ * become literal tokens — that quoting is what stops MATCH-grammar injection. The `*`
+ * suffix is the poor-man's stemmer for Turkish agglutination (ADR 0080).
  */
 export const toMatchExpression = (query: string): string | null => {
 	const normalized = normalizeSearchText(query);

--- a/apps/web/worker/features/search/normalize.unit.test.ts
+++ b/apps/web/worker/features/search/normalize.unit.test.ts
@@ -1,6 +1,6 @@
 /**
- * Unit tests for the Turkish search normalization (ADR 0080) — the fold
- * applied symmetrically at write and query time. Pure functions, no SQL.
+ * The Turkish search normalization fold (ADR 0080), applied symmetrically at write and query
+ * time. Pure functions, no SQL.
  */
 import {describe, expect, it} from "vitest";
 import {MIN_QUERY_LENGTH, normalizeSearchText, toMatchExpression} from "./normalize";
@@ -42,7 +42,6 @@ describe("toMatchExpression", () => {
 	});
 
 	it("neutralizes FTS5 operator words and punctuation (no MATCH injection)", () => {
-		// `OR`/`NOT`/`(` become literal quoted tokens, not FTS5 operators.
 		const expr = toMatchExpression("foo OR bar");
 		expect(expr).toBe('"foo"* "or"* "bar"*');
 		const escaped = toMatchExpression('a"b');

--- a/apps/web/worker/features/sozluk/Sozluk.connection.unit.test.ts
+++ b/apps/web/worker/features/sozluk/Sozluk.connection.unit.test.ts
@@ -1,20 +1,9 @@
 /**
- * Sözlük connection-resolver pagination DECISIONS, unit-reachable over the
- * substituted-`Drizzle` seam (ADR 0082 litmus: "could this be wrong even if the
- * database behaved perfectly?" → unit). Two resolvers, both pure above the
- * cursor-read port:
- *
- *   - `listDefinitionsKeyset` — the `first` clamp `[1,200]`, the MIXED-direction
- *     keyset tuple (`score desc, created_at asc, id asc`), the cursor-miss →
- *     empty-page branch, the page envelope. The `id` cursor value is the opaque
- *     `after` itself (the resolved row carries only `score`/`created_at`).
- *   - `listTermSummariesConnection` — the `first` clamp `[1,100]`.
- *
- * Doubles follow `Vote.unit.test.ts`: a `scriptedAccess` that replays `run`
- * results in call order and renders the fetch builder's `.toSQL()`, and a
- * fetch-seam-throws composition that proves the cursor miss takes no further
- * read. Real-D1 keyset EXECUTION (collation, NULL tiebreaks, the paged walk)
- * stays integration-tier per ADR 0082's irreducible core.
+ * Sözlük connection-resolver pagination DECISIONS over a substituted `Drizzle` seam (ADR
+ * 0082). `scriptedAccess` replays `run` results in call order and renders the fetch
+ * builder's `.toSQL()`; a throwing fetch seam proves the cursor miss takes no further
+ * read. Real-D1 keyset EXECUTION (collation, NULL tiebreaks, the paged walk) stays
+ * integration-tier.
  */
 import {assert, describe, it} from "@effect/vitest";
 import {drizzle} from "drizzle-orm/d1";
@@ -71,9 +60,8 @@ function scriptedAccess(results: ReadonlyArray<unknown>): {
 	return {access, queries};
 }
 
-// `listDefinitionsKeyset` finalizes the page through `stampViewerScalars`, which
-// reads `Vote.readMine`; the stub returns an empty Set so no `myVote` is stamped
-// and no extra DB read happens through the vote service.
+// The empty Set means no `myVote` is stamped and no extra DB read happens through the
+// vote service.
 // biome-ignore lint/plugin: a service double — `Vote.Service` carries methods the connection resolver never reaches (only the stubbed `readMine` is on this path).
 const VoteStub = Layer.succeed(Vote, {
 	cast: () => Effect.die(new Error("connection resolver must not cast a vote")),
@@ -149,10 +137,8 @@ describe("Sozluk.listDefinitionsKeyset — MIXED-direction keyset (score desc, c
 					/order by "definition_record"\."score" desc, "definition_record"\."created_at" asc, "definition_record"\."id" asc/,
 					"orderBy mirrors the keyset tuple directions",
 				);
-				// Param order: the base `WHERE termSlug = ?` first, then the keyset arms,
-				// then LIMIT. `createdAt` renders as epoch SECONDS (the column's timestamp
-				// mode). The `id` cursor value is the opaque `after` ("d7"), NOT carried on
-				// the resolved row (which holds only score/createdAt).
+				// `createdAt` renders as epoch SECONDS (the column's timestamp mode), and the
+				// `id` cursor value is the opaque `after` ("d7"), not a resolved-row field.
 				const sec = Math.floor(created.getTime() / 1000);
 				assert.deepStrictEqual(
 					params,
@@ -192,10 +178,6 @@ describe("Sozluk.listDefinitionsKeyset — cursor-miss → empty page, NO furthe
 	});
 });
 
-// Mute read-mask (#3113): the muted-author SQL arm is `and()`ed into the definition
-// fetch, so a muted member's definitions are absent from the muter's definition reads.
-// Rendered over the same `.toSQL()` seam — present-with-mute emits `author_id not in
-// (…)`, absent/off emits nothing (byte-for-byte today's definition read).
 describe("Sozluk.listDefinitionsKeyset — mute read-mask (author_id NOT IN …)", () => {
 	it.effect("masks a muted author when `mutedIds` is non-empty", () => {
 		const {access, queries} = scriptedAccess([1 /* count */, [] /* fetch */]);

--- a/apps/web/worker/features/sozluk/Sozluk.ts
+++ b/apps/web/worker/features/sozluk/Sozluk.ts
@@ -1,11 +1,6 @@
 /**
  * Sozluk — the dictionary feature service: term reads + definition CRUD +
- * connection-shaped pagination.
- *
- * Vote mutations delegate to the shared `Vote.cast` (atomic vote write + karma)
- * and only recompute `term_record` aggregates afterward, rather than
- * reimplementing the batch-vote logic. Pure validation/derivation is module-private;
- * its wire codes unit-test off-DB THROUGH the mutation (ADR 0013 / 0082).
+ * connection-shaped pagination. See ADR 0013 / 0082.
  */
 import {id} from "@usirin/forge";
 import {and, asc, desc, eq, gt, inArray, isNull, sql} from "drizzle-orm";
@@ -63,22 +58,9 @@ import {
 export type {DefinitionConnectionPage, DefinitionRow, TermPage} from "./definition-fields.ts";
 export type {TermConnectionPage, TermSummaryRow} from "./term-fields.ts";
 
-/** Body length cap for definitions — surfaced as `BODY_TOO_LONG` on overflow. */
 export const DEFINITION_BODY_MAX = 10_000;
 
-// Pure validation/derivation lifted off the service (ADR 0013 for *where*, ADR
-// 0082 for *why*): each is wrong-or-right on its input with no DB. They're
-// module-private; the wire codes unit-test off-DB THROUGH the mutation
-// (`definition-validation.unit.test.ts` drives `addDefinition` / `editDefinition`
-// over a throwing `Drizzle`, proving the gate fires before any DB call).
-// `addDefinition` / `editDefinition` call these at the same point the in-factory
-// closure / inline `replace` ran, so observable behavior is unchanged.
-
-/**
- * Per ADR 0013, body validation lives in the domain, not the resolver. Returns
- * the body when valid (empty after trim ⇒ `BodyRequired`, over the cap ⇒
- * `BodyTooLong`).
- */
+/** See ADR 0013 — body validation lives in the domain, not the resolver. */
 const validateBody = Effect.fn("Sozluk.validateBody")(function* (body: string | null | undefined) {
 	const rawBody = body ?? "";
 	if (rawBody.trim().length === 0) {
@@ -93,14 +75,12 @@ const validateBody = Effect.fn("Sozluk.validateBody")(function* (body: string | 
 	return rawBody;
 });
 
-/** Fallback term title when none is supplied: the slug with dashes as spaces. */
 const titleFromSlug = (slug: string): string => slug.replace(/-/g, " ");
 
 const DEFINITION_EXCERPT_LEN = 140;
 
 const excerpt = (body: string): string => excerptText(body, DEFINITION_EXCERPT_LEN);
 
-/** Earliest `createdAt` across a slice (the term's `first_at`), or `null`. */
 const earliestCreatedAt = (defs: ReadonlyArray<{createdAt: Date | null}>): Date | null =>
 	defs.reduce<Date | null>((acc, d) => {
 		const c = d.createdAt;
@@ -108,7 +88,6 @@ const earliestCreatedAt = (defs: ReadonlyArray<{createdAt: Date | null}>): Date 
 		return acc && acc < c ? acc : c;
 	}, null);
 
-/** Latest `updatedAt ?? createdAt` across a slice (the term's `last_edit_at`), or `null`. */
 const latestEditAt = (
 	defs: ReadonlyArray<{createdAt: Date | null; updatedAt: Date | null}>,
 ): Date | null =>
@@ -118,7 +97,6 @@ const latestEditAt = (
 		return acc && acc > u ? acc : u;
 	}, null);
 
-/** One live-definition row the term-summary fold reads (the `recomputeTermSummary` select). */
 export interface TermSummaryDefRow {
 	id: string;
 	body: string;
@@ -128,7 +106,6 @@ export interface TermSummaryDefRow {
 	updatedAt: Date | null;
 }
 
-/** The fully-derived `term_record` aggregate the upsert consumes — no DB, no Effect. */
 export interface TermSummary {
 	slug: string;
 	title: string;
@@ -142,11 +119,9 @@ export interface TermSummary {
 }
 
 /**
- * Pure convergent fold: a term's `term_record` aggregate is fully derived from
- * its live definitions + title (ADR 0082 — the decision lifted above the Drizzle
- * seam). `rows` MUST already be in term-page order `(score desc, created_at asc)`
- * so `rows[0]` is the top definition. `now` is the empty-slice fallback for
- * `firstAt` / `lastEditAt`.
+ * `rows` MUST already be in term-page order `(score desc, created_at asc)` so `rows[0]`
+ * is the top definition. `now` is the empty-slice fallback for `firstAt` / `lastEditAt`.
+ * See ADR 0082.
  */
 export const recomputeTermSummary = (
 	rows: ReadonlyArray<TermSummaryDefRow>,
@@ -168,25 +143,18 @@ export const recomputeTermSummary = (
 	};
 };
 
-/**
- * The backstop-reconciliation chunk size (#2558): the slug-keyset page width the periodic
- * sweep pages `term_record` in. Sized well above the v1 cohort so today's pass is a single
- * short page, while the bound holds as the table grows — mirrors `HOT_SCORE_DECAY_CHUNK`.
- */
+/** Slug-keyset page width for the reconcile sweep (#2558); mirrors `HOT_SCORE_DECAY_CHUNK`. */
 export const SOZLUK_RECONCILE_CHUNK = 200;
 
-/** One term the reconciliation sweep re-converges: the slug + its stored title. */
 export interface TermRef {
 	readonly slug: string;
 	readonly title: string;
 }
 
 /**
- * The DB seam the reconciliation sweep drives (#2558), factored so {@link scanReconcileChunks}'s
- * cursor-advance + full-coverage control flow is unit-testable over in-memory ports (ADR 0082
- * litmus — wrong-or-right with no SQL engine). `fetchChunk(afterSlug, limit)` returns up to
- * `limit` term rows with `slug > afterSlug` in ascending slug order (`null` ⇒ from the head);
- * `refreshTerm` re-runs the convergent cache refresh for one term.
+ * `fetchChunk(afterSlug, limit)` returns up to `limit` term rows with `slug > afterSlug` in
+ * ascending slug order (`null` ⇒ from the head). Factored so {@link scanReconcileChunks} is
+ * unit-testable over in-memory ports (ADR 0082).
  */
 export interface SozlukReconcileScanPorts {
 	readonly fetchChunk: (
@@ -197,12 +165,9 @@ export interface SozlukReconcileScanPorts {
 }
 
 /**
- * Keyset-chunk the backstop reconciliation sweep (#2558): page slug-ordered slices of at most
- * `chunkSize` terms, re-running the convergent refresh for each before fetching the next, so no
- * single query materializes the whole `term_record` table (mirrors the #2559 decay-sweep bound).
- * Every term is visited each pass — the slug-keyset cursor bounds each page, it never excludes a
- * term. Loops until a short (`< chunkSize`) page marks the tail; an exact-multiple table takes
- * one extra empty page to terminate. Returns the pass's scanned count.
+ * Page the sweep in slug-keyset chunks so no single query materializes the whole `term_record`
+ * table (#2558). Every term is visited each pass; a short (`< chunkSize`) page marks the tail,
+ * so an exact-multiple table takes one extra empty page to terminate.
  */
 export const scanReconcileChunks = (
 	ports: SozlukReconcileScanPorts,
@@ -225,7 +190,6 @@ export const scanReconcileChunks = (
 		return {scanned};
 	});
 
-// The term-summary list sort — defined with the orderings it selects (`ordering.ts`).
 export type ListSort = TermSummarySort;
 
 export interface AddDefinitionInput {
@@ -233,12 +197,9 @@ export interface AddDefinitionInput {
 	authorId: UserId;
 	authorName: string;
 	body: string;
-	/** Optional human title. Falls back to slug-with-spaces. */
+	/** Falls back to slug-with-spaces. */
 	termTitle?: string | undefined;
-	/**
-	 * The çaylak mod-only sandbox stamp (#1205), decided by the resolver from the
-	 * authorship flag + author tier. `null`/absent ⇒ created live (today's behavior).
-	 */
+	/** Çaylak sandbox stamp (#1205), decided by the resolver. `null`/absent ⇒ created live. */
 	sandboxedAt?: Date | null | undefined;
 }
 
@@ -253,9 +214,7 @@ export interface AddDefinitionResult {
 	updatedAt: Date;
 }
 
-// `definitionId` and `voterId` are distinct brands (DefinitionId vs UserId), so
-// transposing them at a call site is a compile error — the #2712 arg-swap the
-// bare-`string` shape allowed is now unrepresentable.
+// Distinct brands, so transposing them at a call site is a compile error (#2712).
 export interface VoteDefinitionInput {
 	definitionId: DefinitionId;
 	voterId: UserId;
@@ -269,7 +228,6 @@ export interface VoteDefinitionResult {
 	authorName: string;
 	createdAt: Date;
 	updatedAt: Date;
-	/** `true` if the voter holds an upvote on this definition after the write. */
 	myVote: boolean;
 	/** `true` if the vote-row state changed; `false` on idempotent no-op. */
 	changed: boolean;
@@ -278,12 +236,7 @@ export interface VoteDefinitionResult {
 export interface ReactDefinitionInput {
 	definitionId: DefinitionId;
 	reactorId: UserId;
-	/**
-	 * The reaction intent, a curated-`REACTION_EMOJI` member or a retract. A palette
-	 * emoji sets/changes the reactor's single reaction; `null` retracts it. The type
-	 * only admits a palette member, so a non-palette string is already rejected by
-	 * `ReactionEmojiSchema` at the wire boundary — this method never sees one.
-	 */
+	/** A palette emoji sets/changes the reactor's single reaction; `null` retracts it. */
 	emoji: ReactionEmoji | null;
 }
 
@@ -306,11 +259,7 @@ export interface EditDefinitionResult {
 export interface DeleteDefinitionInput {
 	definitionId: DefinitionId;
 	actorId: UserId;
-	/**
-	 * Why the definition is being removed (ADR 0096). Defaults to `AuthorDeletion`
-	 * — the author-delete mutation passes nothing; account-deletion (0097) and
-	 * moderation (0098) pass `Anonymized` / `Moderated({reportId})`.
-	 */
+	/** Why the definition is being removed (ADR 0096). Defaults to `AuthorDeletion`. */
 	reason?: Removal.RemovalReason;
 }
 
@@ -319,10 +268,8 @@ export interface DeleteDefinitionResult {
 	/** `true` if the row was soft-deleted; `false` on idempotent no-op. */
 	deleted: boolean;
 	/**
-	 * On a restore, the `sandboxedAt` the definition landed back at (#1811): `null` ⇒
-	 * restored to `Live` (broadcast `alwaysLive`); non-null ⇒ restored to the çaylak
-	 * sandbox, so the mutation suppresses the live echo via `decidePublish`. Absent on
-	 * a delete result.
+	 * On a restore, where the definition landed back (#1811): `null` ⇒ `Live`; non-null ⇒ the
+	 * çaylak sandbox, so the mutation suppresses the live echo. Absent on a delete result.
 	 */
 	sandboxedAt?: Date | null;
 }
@@ -336,12 +283,8 @@ export class Sozluk extends Context.Service<
 		) => Effect.Effect<TermPage | null>;
 
 		/**
-		 * DB-keyset page of a term's live definitions in the canonical
-		 * `(score desc, created_at asc, id asc)` term-page order. The cursor is a
-		 * definition id and the keyset predicate fetches the rows after it, so a
-		 * page is a bounded `WHERE … LIMIT`, not a full load. `viewerId` batches
-		 * `myVote` for the whole page in one `user_vote` read; `sandboxViewer`
-		 * filters the çaylak sandbox (#1205) per the same viewer.
+		 * Keyset page of a term's live definitions in `(score desc, created_at asc, id asc)`
+		 * order; the cursor is a definition id.
 		 */
 		readonly listDefinitionsKeyset: (
 			slug: string,
@@ -353,20 +296,15 @@ export class Sozluk extends Context.Service<
 				/** Mute read-mask (#3113): muted authors' definitions hidden from the muter. */
 				mutedIds?: ReadonlySet<string> | undefined;
 				/**
-				 * Route the page's independent stamps (viewer scalars + reaction aggregate +
-				 * author identity) through the concurrent {@link parallelStampWave} instead of
-				 * the serial chain (#2709). Default/off ⇒ the wave runs at `concurrency: 1`
-				 * (serial, byte-for-byte today); the resolver flips it from the containment
-				 * flag. Output is identical either way — only wall time collapses.
+				 * Run the page's independent stamps concurrently (#2709). Output is identical
+				 * either way — only wall time collapses.
 				 */
 				parallelStamps?: boolean | undefined;
 			},
 		) => Effect.Effect<DefinitionConnectionPage>;
 
 		/**
-		 * Batched read of definitions by id (the `Definition` source's `byIds`
-		 * workhorse — avoids the relation N+1). `viewerId` stamps `myVote` for the
-		 * whole batch in one query. Soft-deleted rows skipped; order not guaranteed
+		 * Batched read of definitions by id. Soft-deleted rows skipped; order not guaranteed
 		 * (fate re-associates by id).
 		 */
 		readonly getDefinitionsByIds: (
@@ -382,16 +320,15 @@ export class Sozluk extends Context.Service<
 		) => Effect.Effect<DefinitionRow[]>;
 
 		/**
-		 * The moderator sandbox-queue / promotion-backlog read model (#1205, the
-		 * #1206 seam): a çaylak's still-sandboxed, not-removed definitions — scoped to
-		 * one author when promotion flips their backlog. Authority (moderator) is
-		 * gated at the resolver; the service read itself is unconditional.
+		 * The moderator sandbox-queue read (#1205/#1206): a çaylak's still-sandboxed,
+		 * not-removed definitions. Moderator authority is gated at the resolver; this read
+		 * is unconditional.
 		 */
 		readonly listSandboxedDefinitions: (opts?: {
 			authorId?: string | undefined;
 		}) => Effect.Effect<DefinitionRow[]>;
 
-		/** Batched read of term summaries by slug; order not guaranteed (fate re-associates by id). */
+		/** Order not guaranteed (fate re-associates by id). */
 		readonly getTermSummariesByIds: (
 			slugs: ReadonlyArray<string>,
 		) => Effect.Effect<TermSummaryRow[]>;
@@ -402,11 +339,8 @@ export class Sozluk extends Context.Service<
 		}) => Effect.Effect<TermSummaryRow[]>;
 
 		/**
-		 * The paginated term lists behind `terms` / `recentTerms` / `popularTerms`.
-		 * Viewer-masked: a term surfaces only when the viewer can read at least one of
-		 * its definitions (`termHasVisibleDefinitionWhere`, #3724) — the same live-content
-		 * gate `getLandingTerms` carries, so a çaylak's sandbox-only term never reaches
-		 * the public /sozluk front door as a dead-end page.
+		 * Viewer-masked: a term surfaces only when the viewer can read at least one of its
+		 * definitions (#3724), so a sandbox-only term is never a dead-end page.
 		 */
 		readonly listTermSummariesConnection: (opts?: {
 			sort?: ListSort;
@@ -417,12 +351,9 @@ export class Sozluk extends Context.Service<
 		}) => Effect.Effect<TermConnectionPage>;
 
 		/**
-		 * The public landing "sözlüğe son eklenenler" read (#1424): the most recent
-		 * terms, scoped to LIVE content. A term surfaces only via a not-removed,
-		 * not-sandboxed definition — the same record-level `removed_at IS NULL AND
-		 * sandboxed_at IS NULL` mask the public `landingStats` counts carry (#1391,
-		 * #1205) — so a çaylak's sandbox-only term never leaks onto the public front
-		 * door, even one whose `term_record` summary row exists with a zero live count.
+		 * Public landing terms (#1424), scoped to LIVE content: a term surfaces only via a
+		 * not-removed, not-sandboxed definition, so a sandbox-only term never leaks onto the
+		 * public front door even when its `term_record` row exists with a zero live count.
 		 */
 		readonly getLandingTerms: (limit: number) => Effect.Effect<TermSummaryRow[]>;
 
@@ -449,12 +380,9 @@ export class Sozluk extends Context.Service<
 		) => Effect.Effect<DeleteDefinitionResult, DefinitionNotFound | UnauthorizedDefinitionMutation>;
 
 		/**
-		 * Moderator soft-delete (ADR 0098 §6) — the same 0096 substrate write as
-		 * `deleteDefinition`, but gated on discharged moderator authority (the caller
-		 * holds a `Moderate` grant — the `moderates` relation tuple, ADR 0107 §4), NOT
-		 * author ownership: `removed_by` is the
-		 * resolver and the reason is `Moderated({reportId})`. A missing target is a
-		 * no-op (`removed: false`), so resolving a stale report can't fail.
+		 * Moderator soft-delete (ADR 0098 §6) — gated on a `Moderate` grant, not author
+		 * ownership. A missing target is a no-op (`removed: false`), so resolving a stale
+		 * report can't fail.
 		 */
 		readonly moderateRemoveDefinition: (input: {
 			definitionId: string;
@@ -463,19 +391,15 @@ export class Sozluk extends Context.Service<
 		}) => Effect.Effect<{removed: boolean}>;
 
 		/**
-		 * Moderator restore (ADR 0098 §3) — reopens the report at the resolve layer.
-		 * `sandboxedAt` is the round-tripped sandbox marker (#1811) so report's live
-		 * re-append gates the term-connection broadcast (a sandboxed restore stays
-		 * suppressed, #1205/#1280).
+		 * Moderator restore (ADR 0098 §3). `sandboxedAt` round-trips the sandbox marker
+		 * (#1811) so a sandboxed restore stays suppressed on the live broadcast.
 		 */
 		readonly moderateRestoreDefinition: (input: {
 			definitionId: string;
 		}) => Effect.Effect<{restored: boolean; sandboxedAt: Date | null}>;
 
-		// `VoterNotEligible` (#1810): a çaylak newcomer's cast is rejected by the "earn to
-		// vote" gate in `Vote.castImpl`. `SelfVoteNotAllowed` (#2216): a cast on one's own
-		// definition is rejected at the cast site. Both cast path only — retraction raises
-		// neither, so `retractDefinitionVote` keeps its `DefinitionNotFound` channel.
+		// `VoterNotEligible` (#1810) and `SelfVoteNotAllowed` (#2216) fire on the cast path
+		// only, so `retractDefinitionVote` keeps its `DefinitionNotFound` channel.
 		readonly voteDefinition: (
 			input: VoteDefinitionInput,
 		) => Effect.Effect<
@@ -488,33 +412,17 @@ export class Sozluk extends Context.Service<
 		) => Effect.Effect<VoteDefinitionResult, DefinitionNotFound>;
 
 		/**
-		 * Set / change / retract the reactor's single reaction on a definition (epic
-		 * #1840, #1865) — the cross-product twin of `voteDefinition`, delegating to the
-		 * shared {@link Reaction} engine instead of {@link Vote}. UNGATED and karma-free
-		 * by construction: it takes no voter tier, writes no karma, and dispatches
-		 * through `Reaction.react` (the settled divergence from vote — a çaylak may
-		 * react, #1861). A palette `emoji` sets or replaces the reaction; `null`
-		 * retracts it; cardinality-one (one reaction per (reactor, definition)) is the
-		 * `user_reaction` PK, enforced in the engine. Returns the re-resolved
-		 * `DefinitionRow` carrying the FRESH reaction aggregate + the reactor's own
-		 * reaction (the `myVote`/`reactions` stamps every definition read shares).
-		 * Translates the engine's target-miss into this surface's `DefinitionNotFound`.
+		 * Set / change / retract the reactor's single reaction on a definition (#1865).
+		 * UNGATED and karma-free, unlike `voteDefinition` — a çaylak may react (#1861).
 		 */
 		readonly reactToDefinition: (
 			input: ReactDefinitionInput,
 		) => Effect.Effect<DefinitionRow, DefinitionNotFound>;
 
 		/**
-		 * Backstop reconciliation (#2558): re-run the recomputable-cache refresh
-		 * (`persistTermSummary` — the term summary + its `term_search` FTS dual-write — and
-		 * `recomputeSozlukStats`) for EVERY sözlük term, so a term/stat left stale by a
-		 * swallowed last-write refresh (`swallowRefresh`, #2012) is eventually re-converged
-		 * WITHOUT waiting for a next user write. Driven by a periodic cron trigger
-		 * (`sozluk-reconcile-cron.ts`); the request-path swallow is unchanged — this is the
-		 * additive long-tail backstop. The sweep pages `term_record` in slug-keyset chunks
-		 * (`scanReconcileChunks`). Idempotent: `persistTermSummary` is a pure convergent fold,
-		 * so re-running it on an already-fresh term rewrites the identical row. Returns the
-		 * pass's scanned count for observability.
+		 * Backstop reconciliation (#2558), driven by a cron trigger: re-converge every term's
+		 * cached summary + stats, so anything left stale by a swallowed refresh (#2012) is
+		 * fixed without waiting for a next user write. Idempotent.
 		 */
 		readonly reconcileCaches: (now: Date) => Effect.Effect<{readonly scanned: number}>;
 	}
@@ -522,37 +430,22 @@ export class Sozluk extends Context.Service<
 
 export const SozlukLive = Layer.effect(Sozluk)(
 	Effect.gen(function* () {
-		// Drizzle is taken through `orDieAccess`: every DB call site dies on
-		// `DrizzleError` (infra failures are defects — the domain-boundary rule),
-		// so public signatures carry domain errors only and every method's `R`
-		// stays `never`.
+		// `orDieAccess`: DB failures are defects, so public signatures carry domain errors only.
 		const {run, batch} = orDieAccess(yield* Drizzle);
 		const voteSvc = yield* Vote;
 		const reactionSvc = yield* Reaction;
-		// Live author-identity resolver (#2139): one batched `user_profile` read per page
-		// (`getProfileIdentitiesByIds`) stamps the CURRENT `{username, displayName}` so the
-		// read surfaces render via `actorLabel`, not the write-time `authorName` snapshot.
+		// Live author identity (#2139): reads render the CURRENT profile, never the
+		// write-time `authorName` snapshot.
 		const pasaport = yield* Pasaport;
 
-		// The removal-sequence owner (#1129): the vote-wipe→stamp ordering is the
-		// module's to enforce, not this service's to hand-wire.
 		const removalSeq: Removal.RemovalSequence = {run, batch, clearTarget: voteSvc.clearTarget};
 
-		// `Definition`'s one viewer scalar: `myVote` from the batched `user_vote`
-		// presence read. Every definition read finalizes through `stampViewerScalars`
-		// with this spec, so the batch-read-then-stamp contract can't be forgotten (#1126).
 		const definitionVoteScalar = {
 			field: "myVote",
 			read: (viewerId: string | null | undefined, ids: ReadonlyArray<string>) =>
 				voteSvc.readMine(viewerId, "definition", ids),
 		} as const;
 
-		// The three independent finalize stamps every definition read shares — `myVote`
-		// (viewer scalar), the reaction aggregate, live author identity — each independent
-		// given the fetched rows. `parallelStampWave` runs them over the SAME rows and
-		// merges; `parallelStamps` picks the concurrency: off ⇒ `1` (serial, byte-for-byte
-		// today), on ⇒ `"unbounded"` (one wave, the #2709 collapse). The reaction stamp's
-		// own two D1 reads inherit the same knob so the whole wave is one phase when on.
 		const stampDefinitions = <R extends {id: string; authorId: string}>(
 			rows: ReadonlyArray<R>,
 			viewerId: string | null,
@@ -570,9 +463,6 @@ export const SozlukLive = Layer.effect(Sozluk)(
 			);
 		};
 
-		// Recompute one slug's `term_record` row from its live `definition_record`
-		// slice. The closure is just the port: read rows via `run`, call the pure
-		// `recomputeTermSummary` fold (module scope), write via `batch`.
 		const persistTermSummary = Effect.fn("Sozluk.recomputeTermSummary")(function* (
 			slug: string,
 			title: string,
@@ -593,9 +483,8 @@ export const SozlukLive = Layer.effect(Sozluk)(
 						and(
 							eq(schema.definitionRecord.termSlug, slug),
 							isNull(schema.definitionRecord.removedAt),
-							// The public term card (excerpt / top definition / count) must
-							// reflect only LIVE content — a sandboxed çaylak definition (#1205)
-							// is pending, never surfaced in the public denormalized aggregate.
+							// The public term card reflects LIVE content only — a sandboxed
+							// definition (#1205) is pending, never in the public aggregate.
 							isNull(schema.definitionRecord.sandboxedAt),
 						),
 					)
@@ -604,15 +493,10 @@ export const SozlukLive = Layer.effect(Sozluk)(
 
 			const summary = recomputeTermSummary(defs, slug, title, now);
 
-			// Summary upsert + its FTS dual-write in ONE batch so they move
-			// all-or-none (ADR 0080 lockstep): a crash between the two can never
-			// desync `term_search` from `term_record`. This is the single convergent
-			// point every term write funnels through, so this keeps `term_search`
-			// current across add/edit/delete/vote with one wiring.
-			// Both items are drizzle query builders, NOT `db.run(sql)`: a batch item
-			// must `_prepare()` to a `D1PreparedQuery` with a bound `.stmt`, which a
-			// parametrized `db.run(sql\`…\`)` (a `SQLiteRaw`) lacks — it 500s the whole
-			// batch on real D1 (#863). The builder prepares batch-safe.
+			// Summary upsert + its FTS dual-write in ONE batch so they move all-or-none
+			// (ADR 0080). Both items must be drizzle query builders, NOT `db.run(sql)`: a
+			// batch item must `_prepare()` to a `D1PreparedQuery` with a bound `.stmt`, which
+			// a parametrized `SQLiteRaw` lacks — it 500s the whole batch on real D1 (#863).
 			yield* batch((db) => [
 				db
 					.insert(schema.termRecord)
@@ -645,8 +529,7 @@ export const SozlukLive = Layer.effect(Sozluk)(
 			]);
 		});
 
-		// Refresh `sozluk_stats` totals; runs after every write that could affect them
-		// (write owned by the source-mutation path, not the query-only stats feature — ADR 0117).
+		// The write is owned by the mutation path, not the query-only stats feature (ADR 0117).
 		const recomputeSozlukStats = Effect.fn("Sozluk.recomputeSozlukStats")(function* (now: Date) {
 			const totalTermsRow = yield* run((db) =>
 				db
@@ -654,9 +537,8 @@ export const SozlukLive = Layer.effect(Sozluk)(
 					.from(schema.termRecord)
 					.then((r) => Number(r[0]?.n ?? 0)),
 			);
-			// Public counts are LIVE-only for the anonymous viewer — sourced from the
-			// shared seam (#1359/#1407), not re-derived here. Definitions carry no draft
-			// dimension, so `publicLiveWhere` (removed + sandbox) is the full rule.
+			// Public counts are LIVE-only, from the shared seam (#1359/#1407) rather than
+			// re-derived here.
 			const publicDefWhere = publicLiveWhere(
 				{
 					removedAt: schema.definitionRecord.removedAt,
@@ -694,24 +576,13 @@ export const SozlukLive = Layer.effect(Sozluk)(
 			);
 		});
 
-		// The recomputable-cache refresh (ADR 0011) every definition remove/restore runs
-		// after the substrate write — the term summary + sözlük stats, the `refresh` the
-		// shared transition swallows uniformly (#2012). Sequenced summary-then-stats, as
-		// each arm did inline before the factoring.
+		// The recomputable-cache refresh (ADR 0011) the shared removal transition swallows.
 		const refreshSozlukCaches = (slug: string, title: string, now: Date) =>
 			Effect.gen(function* () {
 				yield* persistTermSummary(slug, title, now);
 				yield* recomputeSozlukStats(now);
 			});
 
-		// The backstop reconciliation sweep (#2558): re-run the convergent cache refresh for
-		// EVERY term so a term/stat left stale by a swallowed last-write refresh
-		// (`swallowRefresh`, #2012) is eventually re-converged without a next user write. Pages
-		// `term_record` in slug-keyset chunks (bounded scan, mirrors #2559) refreshing each term
-		// summary + its FTS row, then refreshes `sozluk_stats` once for the whole pass. Driven by
-		// the cron trigger (`index.ts` → `sozluk-reconcile-cron.ts`). Idempotent by construction —
-		// `persistTermSummary` is a pure convergent fold, so an already-fresh term rewrites the
-		// identical row, meaning a full sweep needs no persisted "refresh failed" flag to target.
 		const reconcileCaches = Effect.fn("Sozluk.reconcileCaches")(function* (now: Date) {
 			const ports: SozlukReconcileScanPorts = {
 				fetchChunk: (afterSlug, limit) =>
@@ -726,8 +597,7 @@ export const SozlukLive = Layer.effect(Sozluk)(
 				refreshTerm: (term) => persistTermSummary(term.slug, term.title, now),
 			};
 			const {scanned} = yield* scanReconcileChunks(ports, SOZLUK_RECONCILE_CHUNK);
-			// One stats refresh for the whole pass — `sozluk_stats` totals are table-wide, not
-			// per-term, so re-deriving them once after the term sweep is sufficient and cheapest.
+			// `sozluk_stats` totals are table-wide, so one refresh per pass suffices.
 			yield* recomputeSozlukStats(now);
 			return {scanned};
 		});
@@ -813,7 +683,6 @@ export const SozlukLive = Layer.effect(Sozluk)(
 					.then((r) => r?.n ?? 0),
 			);
 
-			// Resolve the opaque `after` to its keyset tuple. The DB read is the port;
 			// `resolveCursor` is the pure cursor-miss decision (ADR 0082).
 			const resolvedRow = after
 				? ((yield* run((db) =>
@@ -833,10 +702,8 @@ export const SozlukLive = Layer.effect(Sozluk)(
 			}
 			const cursorRow = cursor.kind === "hit" ? cursor.row : null;
 
-			// Mixed-direction keyset; `keysetAfter` builds the lexicographic predicate.
-			// Both the predicate and `orderBy` derive from `DEFINITION_ORDERING`: the
-			// `id` cursor value is the opaque `after` itself (the resolved row carries
-			// only `score`/`createdAt`).
+			// The `id` cursor value is the opaque `after` itself — the resolved row carries
+			// only `score`/`createdAt`.
 			const cursorPredicate = keysetAfter(
 				keysetKeys(DEFINITION_ORDERING, (field) =>
 					field === "id" ? after : ((cursorRow as Record<string, unknown> | null)?.[field] ?? null),
@@ -852,9 +719,8 @@ export const SozlukLive = Layer.effect(Sozluk)(
 					.limit(first + 1),
 			);
 
-			// `sandboxed` is the owner-scoped in-review flag (#2200): computed off the fetched
-			// record against the viewer, so a çaylak sees the "incelemede" signal on their OWN
-			// still-in-review definition and no other viewer ever receives it.
+			// `sandboxed` is owner-scoped (#2200): only the author ever receives the
+			// "incelemede" signal on their own in-review definition.
 			const page = forwardPage(
 				fetched,
 				first,
@@ -1013,9 +879,7 @@ export const SozlukLive = Layer.effect(Sozluk)(
 			}
 			const cursorRow = cursor.kind === "hit" ? cursor.row : null;
 
-			// Lead column + `slug` asc tiebreaker, single-sourced per sort: both the
-			// keyset predicate and `orderBy` derive from `TERM_SUMMARY_ORDERING[sort]`.
-			// A null lastActivityAt cursor value drops the lead column → slug-only keyset.
+			// A null `lastActivityAt` cursor value drops the lead column → slug-only keyset.
 			const ordering = TERM_SUMMARY_ORDERING[sort];
 			const cursorPredicate = keysetAfter(
 				keysetKeys(
@@ -1040,11 +904,9 @@ export const SozlukLive = Layer.effect(Sozluk)(
 
 		const getLandingTerms = Effect.fn("Sozluk.getLandingTerms")(function* (limit: number) {
 			const n = Math.max(1, Math.min(limit, 50));
-			// Rank terms by their most recent LIVE definition. The mask lives on the
-			// `definition_record` arm (`removed_at IS NULL AND sandboxed_at IS NULL`),
-			// mirroring `landingStats` (#1391): a term with only sandboxed definitions
-			// contributes no row here, so its `term_record` summary (which can persist
-			// with a zero live count) never reaches the public front door (#1205, #1424).
+			// The mask lives on the `definition_record` arm, mirroring `landingStats` (#1391):
+			// a term with only sandboxed definitions contributes no row, so its `term_record`
+			// summary never reaches the public front door (#1205, #1424).
 			const slugRows = yield* run((db) =>
 				db
 					.select({
@@ -1123,9 +985,8 @@ export const SozlukLive = Layer.effect(Sozluk)(
 				}),
 			);
 
-			// The definition row committed above; its convergent cache refreshes are
-			// recomputable, so swallow-and-log a die here rather than 500 the mutation and
-			// provoke a retry that mints a duplicate row (#2556, the create-path twin of #2012).
+			// The row is already committed, so swallow a refresh die rather than 500 the
+			// mutation and provoke a retry that mints a duplicate row (#2556).
 			yield* swallowRefresh(
 				"Sozluk.addDefinition",
 				Effect.gen(function* () {
@@ -1192,11 +1053,8 @@ export const SozlukLive = Layer.effect(Sozluk)(
 			} satisfies EditDefinitionResult;
 		});
 
-		// Remove → restore both flow through the ADR 0096 substrate: stamp the
-		// `Removed` triad (`Vote.clearTarget` wipes votes, karma KEPT), or clear it
-		// back to `Live`. The lifecycle is the projection of the three columns
-		// (`Removal.fromColumns`); the term summary + sözlük stats are recomputable
-		// caches refreshed outside the cleanup batch (ADR 0011).
+		// Remove → restore both flow through the ADR 0096 substrate; votes are wiped and
+		// karma KEPT. Caches refresh outside the cleanup batch (ADR 0011).
 		const deleteDefinition = Effect.fn("Sozluk.deleteDefinition")(function* (
 			input: DeleteDefinitionInput,
 		) {
@@ -1320,23 +1178,16 @@ export const SozlukLive = Layer.effect(Sozluk)(
 				});
 				if (!outcome.committed) return {restored: false, sandboxedAt: null};
 
-				// `outcome.sandboxedAt` is the round-tripped marker (#1811) — report's live
-				// re-append gates the term-connection broadcast (a sandboxed restore stays
-				// suppressed).
+				// The round-tripped marker (#1811): a sandboxed restore stays suppressed on
+				// the term-connection broadcast.
 				return {restored: true, sandboxedAt: outcome.sandboxedAt};
 			},
 		);
 
-		// Shared body for `voteDefinition` / `retractDefinitionVote`. Delegates to
-		// `Vote.cast` for the atomic batch, then recomputes `term_record`
-		// aggregates after a state change. Translates `VoteTargetNotFound` into
-		// `DefinitionNotFound` so this surface keeps emitting `DEFINITION_NOT_FOUND`.
 		const applyVote = Effect.fn("Sozluk.applyVote")(function* (
 			input: VoteDefinitionInput,
 			isVote: boolean,
 		) {
-			// Load meta up-front so we can return the canonical resolver shape
-			// regardless of the changed/no-op path.
 			const definition = yield* run((db) =>
 				db.query.definitionRecord.findFirst({
 					where: {id: input.definitionId, removedAt: {isNull: true}},
@@ -1349,10 +1200,8 @@ export const SozlukLive = Layer.effect(Sozluk)(
 				});
 			}
 
-			// Self-vote guard (#2216, founder-ruled): a cast on one's OWN definition is
-			// rejected at the domain, so an inflated self-score is unrepresentable rather
-			// than caught downstream. Cast-only (mirrors the `VoterNotEligible` tier gate) —
-			// a retraction is exempt because a blocked cast leaves nothing to retract.
+			// Self-vote guard (#2216, founder-ruled). Cast-only: a retraction is exempt
+			// because a blocked cast leaves nothing to retract.
 			if (isVote && definition.authorId === input.voterId) {
 				return yield* new SelfVoteNotAllowed({
 					voterId: input.voterId,
@@ -1360,8 +1209,7 @@ export const SozlukLive = Layer.effect(Sozluk)(
 				});
 			}
 
-			// A Vote miss (raced soft-delete or sandboxed) collapses to this
-			// surface's DefinitionNotFound — see translateVoteMiss.
+			// A Vote miss (raced soft-delete or sandboxed) collapses to `DefinitionNotFound`.
 			const voteResult = yield* voteSvc
 				.cast({
 					userId: input.voterId,
@@ -1381,8 +1229,6 @@ export const SozlukLive = Layer.effect(Sozluk)(
 
 			const now = new Date();
 			if (voteResult.changed) {
-				// Vote already wrote definition_record.score in its batch; this re-reads
-				// it to refresh the term aggregates.
 				yield* persistTermSummary(definition.termSlug, definition.termTitle, now);
 			}
 
@@ -1393,8 +1239,7 @@ export const SozlukLive = Layer.effect(Sozluk)(
 				authorId: definition.authorId,
 				authorName: definition.authorName,
 				createdAt: definition.createdAt ?? now,
-				// A vote is not a content edit, so report the definition's genuine
-				// `updatedAt` — never the vote instant, which would trip the
+				// A vote is not a content edit: the vote instant here would trip the
 				// "düzenlendi" badge on the live-push (#1634).
 				updatedAt: definition.updatedAt ?? definition.createdAt ?? now,
 				myVote: voteResult.myVote,
@@ -1411,9 +1256,8 @@ export const SozlukLive = Layer.effect(Sozluk)(
 		const retractDefinitionVote = Effect.fn("Sozluk.retractDefinitionVote")(function* (
 			input: VoteDefinitionInput,
 		) {
-			// `VoterNotEligible` + `SelfVoteNotAllowed` both fire on the cast direction only
-			// (`isVote`/`value: true`), so a retraction never raises either — die if one
-			// somehow does, keeping this method's channel to `DefinitionNotFound`.
+			// Both fire on the cast direction only, so a retraction never raises either —
+			// die if one somehow does, keeping this channel to `DefinitionNotFound`.
 			return yield* applyVote(input, false).pipe(
 				Effect.catchTags({
 					"vote/VoterNotEligible": (e) => Effect.die(e),
@@ -1425,9 +1269,8 @@ export const SozlukLive = Layer.effect(Sozluk)(
 		const reactToDefinition = Effect.fn("Sozluk.reactToDefinition")(function* (
 			input: ReactDefinitionInput,
 		) {
-			// Load the target up-front so a missing/removed definition is this surface's
-			// DefinitionNotFound. No sandbox filter — reactions are ungated, so a live
-			// target is reactable regardless of the reactor's tier.
+			// No sandbox filter — reactions are ungated, so a live target is reactable
+			// regardless of the reactor's tier.
 			const definition = yield* run((db) =>
 				db.query.definitionRecord.findFirst({
 					where: {id: input.definitionId, removedAt: {isNull: true}},
@@ -1440,9 +1283,8 @@ export const SozlukLive = Layer.effect(Sozluk)(
 				});
 			}
 
-			// Delegate to the ungated, karma-free Reaction engine — no tier gate, no karma
-			// write on this path (the settled #1861 divergence from Vote). A raced
-			// target-miss collapses to this surface's DefinitionNotFound.
+			// No tier gate and no karma write on this path (the settled #1861 divergence
+			// from Vote).
 			yield* reactionSvc
 				.react({
 					userId: input.reactorId,
@@ -1461,10 +1303,8 @@ export const SozlukLive = Layer.effect(Sozluk)(
 					),
 				);
 
-			// Re-resolve with the FRESH reaction aggregate + the reactor's own reaction,
-			// through the same batched stamps every definition read shares (`myVote` via
-			// stampViewerScalars, `reactions` via stampReactionAggregate, live identity via
-			// stampAuthorIdentity) — so the wire row is shape-identical to a plain read.
+			// Re-resolve through the same stamps every definition read shares, so the wire
+			// row is shape-identical to a plain read.
 			const scalared = yield* stampViewerScalars([toDefinitionRow(definition)], input.reactorId, [
 				definitionVoteScalar,
 			]);

--- a/apps/web/worker/features/sozluk/TermVisibility.ts
+++ b/apps/web/worker/features/sozluk/TermVisibility.ts
@@ -2,12 +2,9 @@
  * The sözlük term-list read mask: a `term_record` row is visible to a viewer only when
  * at least one of its definitions is (#3724).
  *
- * `term_record` is a recomputable summary cache, not content — it carries no lifecycle
- * columns of its own, so it cannot be masked directly. Visibility is therefore *derived*
- * from the definitions the row summarizes, which is where the çaylak sandbox (#1205) and
- * the ADR 0096 removal guard actually live. `Sozluk.getLandingTerms` derives the same fact
- * by ranking on live definitions; this is the reusable, viewer-aware form the paginated
- * term lists apply.
+ * `term_record` is a recomputable summary cache with no lifecycle columns of its own, so
+ * it cannot be masked directly. Visibility is derived from the definitions it summarizes,
+ * which is where the çaylak sandbox and the ADR 0096 removal guard actually live.
  */
 import {and, eq, exists, type SQL, sql} from "drizzle-orm";
 import type {DrizzleDb} from "../../db/Drizzle.ts";
@@ -16,16 +13,11 @@ import type {SandboxViewer} from "../lifecycle/EntityLifecycle.ts";
 import {publicLiveWhere} from "../lifecycle/SandboxVisibility.ts";
 
 /**
- * `EXISTS (SELECT 1 FROM definition_record WHERE term_slug = term_record.slug AND
- * <publicLiveWhere>)` — the correlated existence probe that gates a `term_record` row on
- * the viewer's own definition visibility, sourced from the shared `publicLiveWhere` seam
- * (#1359/#1407) rather than a re-derived mask.
- *
- * Viewer-aware by construction, which is the load-bearing property: an anonymous visitor
- * never reaches a term whose only definitions are a newcomer's sandboxed ones (both a
- * dead-end public page and a partial sandbox-containment leak — the term title escapes),
- * while the author still finds their own not-yet-public term, and a moderator sees the
- * full backlog.
+ * Sourced from the shared `publicLiveWhere` seam rather than a re-derived mask, and
+ * viewer-aware by construction — that is the load-bearing property. An anonymous visitor
+ * must never reach a term whose only definitions are a newcomer's sandboxed ones (a
+ * dead-end page AND a sandbox leak: the term title escapes), while the author still finds
+ * their own not-yet-public term and a moderator sees the full backlog.
  */
 export const termHasVisibleDefinitionWhere = (db: DrizzleDb, viewer: SandboxViewer): SQL =>
 	exists(

--- a/apps/web/worker/features/sozluk/definition-fields.ts
+++ b/apps/web/worker/features/sozluk/definition-fields.ts
@@ -1,32 +1,19 @@
 /**
- * `Definition`'s one column→field map — the single structure the row mapper
- * (`toDefinitionRow`), the wire shaper (`toDefinition` in `shapers.ts`), and the
- * view field declaration (`DefinitionView` in `views.ts`) all derive from, so a
- * one-field change touches this map instead of three hand-synced restatements
- * (#1126 AC#1, deferred from #1159).
+ * `Definition`'s one column→field map — the row mapper, the wire shaper, and the
+ * view field declaration all derive from it, so a one-field change lands here
+ * instead of in three hand-synced restatements.
  *
- * The map absorbs the per-source naming divergence the `shapers.ts` docblock
- * named: the DB record calls the author `authorName` and may leave the
- * timestamps null, while the wire field is `author` / a non-null `Date`. Each
- * intrinsic field carries a reader that maps a `definition_record` row onto its
- * wire value, so the divergence lives in the map, not at every call site.
- *
- * `myVote` is the viewer scalar — part of the view/wire field set (`definitionViewFields`)
- * but *not* read from the record here: it is stamped by `stampViewerScalars` after
- * the batched `user_vote` read (#1159, `viewer-scalars.ts`), the row→viewer-scalar
- * split that keeps the N+1-avoidance contract structural.
+ * The readers absorb the record→wire naming divergence (`authorName`→`author`,
+ * nullable timestamps→non-null `Date`). Viewer-scoped fields are NOT read here —
+ * they are stamped downstream after their batched reads, which is what keeps the
+ * N+1-avoidance split structural.
  */
 import type * as schema from "../../db/drizzle/schema.ts";
 import type {ReactionAggregate} from "../reaction/Reaction.ts";
 
 type DefinitionRecord = typeof schema.definitionRecord.$inferSelect;
 
-/**
- * The intrinsic (record-derived) wire fields, in `DefinitionView` order, each
- * mapping a `definition_record` row onto its wire value. The keys ARE the wire
- * field names; the readers absorb the `authorName`→`author` + null-timestamp
- * divergence.
- */
+/** The record-derived wire fields, in `DefinitionView` order. The keys ARE the wire field names. */
 const intrinsicFields = {
 	id: (d) => d.id,
 	body: (d) => d.body,
@@ -40,33 +27,22 @@ const intrinsicFields = {
 type IntrinsicRow = {[K in keyof typeof intrinsicFields]: ReturnType<(typeof intrinsicFields)[K]>};
 
 /**
- * `DefinitionRow` — the record-derived row the definition reads share, plus the
- * `myVote` viewer scalar that `stampViewerScalars` adds downstream (`null` for an
- * anonymous viewer; `undefined` when not requested — never read from the record).
+ * The record-derived row the definition reads share, plus the viewer-scoped fields
+ * stamped downstream. Each optional field is `undefined` when the read didn't request it.
  */
 export interface DefinitionRow extends IntrinsicRow {
 	myVote?: boolean | null;
 	/**
-	 * The owner-scoped in-review flag (#2200): `true` iff this definition is still
-	 * sandboxed (#1205) AND the viewer is its author, stamped by the read paths via
-	 * `ownSandboxed`. Owner-only by construction, so it never leaks review state to
-	 * another viewer; a read that doesn't stamp it leaves it `undefined` → default `false`.
+	 * `true` iff this definition is still sandboxed AND the viewer is its author.
+	 * Owner-only by construction, so it never leaks review state to another viewer.
 	 */
 	sandboxed?: boolean;
 	/**
-	 * The author's LIVE handle (`user_profile.username` / `.displayName`), stamped by
-	 * `stampAuthorIdentity` after the batched `getProfileIdentitiesByIds` read (#2139)
-	 * so the client renders the CURRENT display name via `actorLabel`, not the write-time
-	 * `authorName` snapshot (#2126's AC). `undefined` when not requested; `null` when the
-	 * author has no profile/handle — `actorLabel` then degrades to `@username` → fallback.
+	 * The author's LIVE handle, not the write-time `authorName` snapshot, so the client
+	 * renders the current display name. `null` when the author has no profile handle.
 	 */
 	authorUsername?: string | null;
 	authorDisplayName?: string | null;
-	/**
-	 * The reaction aggregate (per-emoji counts + the viewer's own reaction), stamped
-	 * by `stampReactionAggregate` after the batched `user_reaction` read (#1862) —
-	 * `undefined` when not requested; the shaper fills the empty aggregate.
-	 */
 	reactions?: ReactionAggregate;
 }
 
@@ -89,12 +65,9 @@ export interface DefinitionConnectionPage {
 }
 
 /**
- * The view/wire field selection (`{id: true, …}`) — a static literal (fate's
- * `FateDataView` / `WorkerEntity` read the literal field map off this, so it
- * can't be a dynamically-built object). `satisfies Record<keyof DefinitionRow, true>`
- * pins it to exactly the row's fields: dropping a field here (or adding one to
- * `DefinitionRow` without listing it here) is a compile error, so the view stays
- * in lockstep with the row mapper.
+ * Must stay a static literal — fate's `FateDataView` / `WorkerEntity` read the field
+ * map off it, so a dynamically-built object breaks them. The `satisfies` pins it to
+ * exactly `DefinitionRow`'s fields, making a drifted view a compile error.
  */
 export const definitionViewFields = {
 	id: true,
@@ -111,13 +84,7 @@ export const definitionViewFields = {
 	reactions: true,
 } as const satisfies Record<keyof DefinitionRow, true>;
 
-/**
- * Map a `definition_record` row onto its intrinsic `DefinitionRow` fields by
- * running every reader in the column→field map — the single place the
- * record→row mapping lives. `myVote` is the viewer scalar, stamped by
- * `stampViewerScalars` (#1159), not here — the row→viewer-scalar split keeps the
- * N+1-avoidance contract structural.
- */
+/** The single place the record→row mapping lives; viewer scalars are stamped elsewhere. */
 export const toDefinitionRow = (d: DefinitionRecord): IntrinsicRow =>
 	Object.fromEntries(
 		(Object.keys(intrinsicFields) as Array<keyof typeof intrinsicFields>).map((f) => [

--- a/apps/web/worker/features/sozluk/definition-mutation.unit.test.ts
+++ b/apps/web/worker/features/sozluk/definition-mutation.unit.test.ts
@@ -1,21 +1,11 @@
 /**
- * `definition.add` ROUTING-boundary unit coverage (ADR 0039 / 0082) — the one
- * thing that is wrong-or-right with no database: does the resolver in
- * `mutations.ts` publish the new node to the term's **args-scoped**
- * `Term.definitions` topic (`{id: termSlug}`), or does it leak to the
- * procedure-wide global wildcard?
+ * `definition.add` ROUTING-boundary coverage (ADR 0039 / 0082): does the resolver
+ * publish to the term's args-scoped `Term.definitions` topic (`{id: termSlug}`), or
+ * leak to the procedure-wide global wildcard?
  *
- * This drives the REAL resolver (`mutations["definition.add"].handler`) over a
- * stub `Sozluk` and a recording `LivePublisher` — the same handler-over-stubs
- * seam `report/report-mutation.unit.test.ts` and `pano/draft-save.invariant.test.ts`
- * use. The resolver owns the `live.topic("Term.definitions", {id:
- * input.termSlug})` call; if it ever dropped the args (→ wildcard, the ADR 0039
- * mis-route), the recorded topic key is the global one and this test fails. The
- * publisher's key-MATH (the `(procedure, args)` → topic computation) is pinned
- * exhaustively against literal fixtures in
- * `../fate-live/live-publisher.unit.test.ts`; this asserts the resolver's routing
- * CHOICE — the contract that file's two deleted cases pretended to test by
- * re-spelling the publisher call inline (never crossing the resolver).
+ * Drives the REAL resolver over a stub `Sozluk` and a recording `LivePublisher`. The
+ * publisher's key MATH is pinned separately in
+ * `../fate-live/live-publisher.unit.test.ts`; this asserts the resolver's routing CHOICE.
  */
 
 import {assert, it} from "@effect/vitest";
@@ -36,7 +26,6 @@ import {mutations} from "./mutations.ts";
 import type {AddDefinitionResult} from "./Sozluk.ts";
 import {Sozluk} from "./Sozluk.ts";
 
-/** A rejection while draining scheduled `waitUntil` work — dies the fiber. */
 class DrainRejected extends Schema.TaggedErrorClass<DrainRejected>()("test/DrainRejected", {
 	cause: Schema.Unknown,
 }) {}
@@ -51,8 +40,7 @@ const runtimeContextStub: BaseRuntimeContext = {
 	set: (id) => Effect.succeed(id),
 };
 
-// A `Flags` stub with every flag OFF — the karma-gates dep the resolver reads (#150):
-// off ⇒ the add path is today's live-create, no karma read.
+// Every flag OFF ⇒ the karma-gates dep (#150) is inert and no karma is read.
 const flagsOffStub = Layer.succeed(Flags, {
 	getBoolean: () => Effect.succeed(false),
 	getString: () => Effect.die("getString not exercised"),
@@ -60,16 +48,14 @@ const flagsOffStub = Layer.succeed(Flags, {
 	getObject: () => Effect.die("getObject not exercised"),
 } as typeof Flags.Service);
 
-// A yazar author ⇒ `sandboxedAtForAuthor` returns null (yazar content is always live),
-// so the add path is a live-create.
+// A yazar author ⇒ `sandboxedAtForAuthor` returns null, so the add is a live-create.
 const kunyeStub = Layer.succeed(Kunye, {
 	tierOf: () => Effect.succeed("yazar" as const),
 	karmaOf: () => Effect.succeed(0),
 	rootOf: (id: string) => Effect.succeed(id),
 } as typeof Kunye.Service);
 
-// The mod-emitter deps the resolver gained (#1699). A yazar author ⇒ `sandboxedAtForAuthor`
-// returns null ⇒ `notifyCaylakEntersDivan` short-circuits before touching any of these,
+// A yazar author ⇒ `notifyCaylakEntersDivan` short-circuits before touching these,
 // so they exist only to satisfy the type and die on contact if ever reached.
 const notificationStub = makeNotificationStub();
 const divanStub = Layer.succeed(Divan, {
@@ -83,11 +69,9 @@ const relationStoreStub = Layer.succeed(RelationStore, {
 	subjectsOf: () => Effect.die("RelationStore.subjectsOf not exercised in definition-mutation"),
 });
 
-// A `Sozluk` stub whose `addDefinition` is scripted; every other method dies on
-// contact, so a passing test proves `definition.add` reached only the write it
-// routes around. Mirrors `draft-save.invariant.test.ts`'s `panoStub`. `capture`
-// (when passed) records the write input so a test can assert the persisted
-// `authorName` the resolver chose (#2130 — never the user's email).
+// Every method other than `addDefinition` dies on contact, so a passing test proves
+// `definition.add` reached only the write it routes around. `capture` records the write
+// input so a test can assert the persisted `authorName` (#2130 — never the user's email).
 const sozlukStub = (
 	result: AddDefinitionResult,
 	capture?: (input: {authorName: string}) => void,
@@ -127,9 +111,8 @@ it.effect(
 		Effect.gen(function* () {
 			const slug = "fate-read";
 
-			// A recording `LivePublisher`: `publish` captures the topic key the resolver's
-			// `live.*` chose, `waitUntil` collects the fire-and-forget work so `flush`
-			// drains it (the publish is detached off the request path).
+			// `waitUntil` collects the fire-and-forget work so it can be drained below — the
+			// publish is detached off the request path.
 			const recorded: Array<string> = [];
 			const scheduled: Array<Promise<unknown>> = [];
 			const liveStub = Layer.succeed(LivePublisher)(
@@ -168,23 +151,16 @@ it.effect(
 				catch: (cause) => new DrainRejected({cause}),
 			}).pipe(Effect.orDie);
 
-			// The contract: the resolver routes the new node to the term's args-scoped
-			// connection topic (keyed by `{id: slug}`), so only that term's open page
-			// updates live.
 			assert.deepStrictEqual(recorded, [liveConnectionTopic("Term.definitions", {id: slug})]);
-			// The ADR 0039 mis-route guard: a regression where the resolver called
-			// `topic("Term.definitions")` with NO args would land on the
-			// procedure-wide global wildcard (fanning one term's definition out to every
-			// `Term.definitions` subscriber across all slugs). That topic must be absent.
+			// The ADR 0039 mis-route guard: dropping the args would land on the procedure-wide
+			// wildcard, fanning one term's definition to every `Term.definitions` subscriber.
 			assert.isFalse(recorded.includes(liveGlobalConnectionTopic("Term.definitions")));
 		}),
 );
 
 // #2130 (PII-at-rest): a null-name account must NEVER have its EMAIL persisted as the
 // denormalized `authorName` — the old `user.name ?? user.email` fallback did exactly
-// that, and the flattened string renders publicly on the author surfaces. The resolver
-// now flattens identity through `authorDisplayLabel` (name → @username → fallback), so a
-// null-name / no-username actor persists the fixed fallback noun, never the email.
+// that, and the flattened string renders publicly.
 it.effect("definition.add never persists a null-name author's email as authorName", () =>
 	Effect.gen(function* () {
 		const nullNameUser = {id: "u-nameless", email: "leak@example.com", name: null, username: null};

--- a/apps/web/worker/features/sozluk/definition-reaction-mutation.unit.test.ts
+++ b/apps/web/worker/features/sozluk/definition-reaction-mutation.unit.test.ts
@@ -1,18 +1,9 @@
 /**
- * `definition.react` WIRE-boundary coverage (epic #1840, #1865) — the reaction
- * mutation driven through its real external interface (`resolveWire`: input decode +
- * the `encodeWireError` class→wire-code seam), over a stub `Sozluk` + a `Flags`
- * double. Four things are wrong-or-right with no database:
- *
- *   - **flag ON delegates.** The resolver hands `{definitionId, reactorId, emoji}` to
- *     `Sozluk.reactToDefinition` and returns the fresh-aggregate `Definition`.
- *   - **flag OFF is inert (dark ship, ADR 0083).** The react never lands
- *     (`reactToDefinition` fail-on-contact); the resolver re-resolves the unchanged
- *     definition, so a merged-but-unflipped feature is invisible.
- *   - **auth-only gate.** A signed-out reactor gets the invisible `UNAUTHORIZED` —
- *     never reaching the service (no voter-tier gate; that is Vote's alone).
- *   - **palette decode.** A non-`REACTION_EMOJI` emoji fails to decode at the wire
- *     boundary, so an arbitrary emoji is structurally unrepresentable (#1865 AC#1).
+ * `definition.react` WIRE-boundary coverage (epic #1840, #1865) — the mutation driven through
+ * its real external interface (`resolveWire`: input decode + the `encodeWireError` class→wire-code
+ * seam), over a stub `Sozluk` + a `Flags` double. Four things are wrong-or-right with no database:
+ * flag-ON delegation, flag-OFF inertness (dark ship, ADR 0083), the auth-only gate (no voter-tier
+ * gate — that is Vote's alone), and palette decode at the wire boundary.
  */
 import {assert, describe, it} from "@effect/vitest";
 import {CurrentUser, LivePublisher} from "@kampus/fate-effect";
@@ -49,9 +40,8 @@ const flagsStub = (on: boolean): Layer.Layer<Flags> =>
 		} as unknown as typeof Flags.Service,
 	);
 
-// A `Sozluk` whose named methods are scripted; every OTHER method dies on contact, so
-// a passing test proves the resolver reached only the method its path routes to
-// (mirrors `definition-mutation.unit.test.ts`'s `sozlukStub`).
+// Named methods are scripted; every OTHER method dies on contact, so a passing test proves the
+// resolver reached only the method its path routes to.
 const sozlukProxy = (methods: Partial<typeof Sozluk.Service>): Layer.Layer<Sozluk> =>
 	Layer.succeed(
 		Sozluk,
@@ -64,8 +54,6 @@ const sozlukProxy = (methods: Partial<typeof Sozluk.Service>): Layer.Layer<Sozlu
 		}) as typeof Sozluk.Service,
 	);
 
-// A wire-shaped definition row (post-react) the stub returns; `reactions` is the fresh
-// aggregate the resolver forwards onto the `Definition`.
 const REACTED_ROW: DefinitionRow = {
 	id: "def-1",
 	body: "bir tanım",
@@ -78,12 +66,9 @@ const REACTED_ROW: DefinitionRow = {
 	reactions: {counts: [{emoji: "👍", count: 1}], myReaction: "👍"},
 };
 
-// The CURRENT (unreacted) row the inert flag-off path re-resolves: empty aggregate.
 const CURRENT_ROW: DefinitionRow = {...REACTED_ROW, reactions: EMPTY_REACTION_AGGREGATE};
 
-// A `LivePublisher` that records nothing — the flag-ON path's reaction-count publish
-// (#1868) is fire-and-forget with an error channel of `never`, so it can never fail the
-// mutation; the stub just satisfies the requirement.
+// The publish is fire-and-forget with a `never` error channel — it can never fail the mutation.
 const liveStub = Layer.succeed(LivePublisher)(
 	livePublisherFor({publish: () => Effect.void, waitUntil: () => {}}),
 );
@@ -148,7 +133,6 @@ describe("definition.react — dark-ship + delegation", () => {
 				select: ["id", "reactions"],
 			});
 			assert.strictEqual((def as {id: string}).id, "def-1");
-			// The current, unreacted aggregate — the react write never happened while dark.
 			assert.deepStrictEqual((def as {reactions: unknown}).reactions, EMPTY_REACTION_AGGREGATE);
 		}).pipe(
 			Effect.provide(

--- a/apps/web/worker/features/sozluk/definition-stamp-wave.unit.test.ts
+++ b/apps/web/worker/features/sozluk/definition-stamp-wave.unit.test.ts
@@ -1,21 +1,7 @@
 /**
- * The sözlük stamp-wave collapse (#2709, epic #2567) — behavior equivalence + the
- * concurrency plumbing, over the substituted-`Drizzle`/service seams (ADR 0082 litmus:
- * wrong-or-right with no SQL engine → unit).
- *
- * Two properties the acceptance criteria name:
- *
- *   - **byte-for-byte equivalence.** `getDefinitionsByIds` / `listDefinitionsKeyset`
- *     produce the identical stamped rows whether the wave runs serial (flag off) or
- *     concurrent (flag on) — `myVote`, `reactions`, live author identity all unchanged.
- *     The flag flips wall time and nothing else.
- *   - **the concurrency actually threads through.** With `parallelStamps: true` the
- *     reaction aggregate's own two D1 reads receive `{concurrency: "unbounded"}` (so the
- *     wave is one phase, not one-plus-the-reaction-arm's-two); with it off/absent they
- *     receive `{concurrency: 1}` — today's serial behavior every non-opted caller keeps.
- *
- * The stamps' batched reads are substituted by recording doubles (the feature's
- * scripted-double idiom) — real read fidelity lives on the per-stamp + integration tiers.
+ * The sözlük stamp-wave collapse (#2709): the `parallelStamps` flag must flip wall
+ * time and nothing else. Unit tier per ADR 0082 — the stamps' batched reads are
+ * recording doubles, so real read fidelity lives on the integration tier.
  */
 import {assert, describe, it} from "@effect/vitest";
 import {Effect, Layer} from "effect";
@@ -27,7 +13,6 @@ import {Reaction, type ReactionAggregate} from "../reaction/Reaction.ts";
 import {Vote} from "../vote/Vote.ts";
 import {Sozluk, SozlukLive} from "./Sozluk.ts";
 
-// A `definition_record` shaped just enough for `toDefinitionRow` + `ownSandboxed`.
 const defRecord = (id: string, authorId: string) => ({
 	id,
 	body: `body of ${id}`,
@@ -59,8 +44,7 @@ const agg = (myReaction: ReactionAggregate["myReaction"]): ReactionAggregate => 
 	myReaction,
 });
 
-// Reaction double that RECORDS the `options` (the concurrency knob) each `readAggregate`
-// call received, and answers a fixed aggregate for `d1`.
+// Records the `options` (the concurrency knob) each `readAggregate` call received.
 const reactionRecorder = (calls: Array<{readonly concurrency?: Concurrency} | undefined>) =>
 	Layer.succeed(Reaction, {
 		react: () => Effect.die(new Error("read path must not react")),
@@ -72,7 +56,7 @@ const reactionRecorder = (calls: Array<{readonly concurrency?: Concurrency} | un
 		},
 	} satisfies typeof Reaction.Service);
 
-// Pasaport double: `d1`'s author has a live handle, `d2`'s has none (→ null identity).
+// `d1`'s author has a live handle, `d2`'s has none (→ null identity).
 const PasaportStub = makePasaportStub({
 	getProfileIdentitiesByIds: () =>
 		Effect.succeed([{userId: "u1", username: "anka", displayName: "Anka Kadın", totalKarma: 0}]),
@@ -89,8 +73,8 @@ const sozlukLayer = (
 		Layer.provide(Layer.succeed(Drizzle, access)),
 	);
 
-// Replays `run` results in call order (the connection test's `scriptedAccess` shape);
-// `results` is `unknown`, so each answer is a single `as A` — no `as unknown as` cast.
+// Replays `run` results in call order, so each test's script must match the read
+// sequence of the method under test.
 const scriptedAccess = (results: ReadonlyArray<unknown>): DrizzleAccess => {
 	let i = 0;
 	return {
@@ -99,7 +83,7 @@ const scriptedAccess = (results: ReadonlyArray<unknown>): DrizzleAccess => {
 	};
 };
 
-// `getDefinitionsByIds` issues exactly one `run` (the fetch); answer it with two records.
+// `getDefinitionsByIds` issues exactly one `run` (the fetch).
 const byIdAccess = (): DrizzleAccess =>
 	scriptedAccess([[defRecord("d1", "u1"), defRecord("d2", "u2")]]);
 
@@ -130,7 +114,7 @@ describe("Sozluk.getDefinitionsByIds — stamp-wave behavior equivalence (#2709)
 				serial.map((r) => JSON.stringify(r)),
 				"identical serialized bytes (fields, values, key order)",
 			);
-			// Spot the stamps actually landed (not a vacuous equality of two empty pages).
+			// Guards against a vacuous equality of two empty pages.
 			assert.strictEqual(parallel[0]?.myVote, true, "d1 viewer upvote stamped");
 			assert.strictEqual(parallel[1]?.myVote, false, "d2 no viewer upvote");
 			assert.deepStrictEqual(parallel[0]?.reactions, agg("👍"), "d1 reaction aggregate stamped");
@@ -167,7 +151,7 @@ describe("Sozluk.getDefinitionsByIds — stamp-wave behavior equivalence (#2709)
 	});
 });
 
-// `listDefinitionsKeyset` (no cursor) issues: totalCount → fetch. Script both in order.
+// `listDefinitionsKeyset` (no cursor) issues: totalCount → fetch.
 const keysetAccess = (): DrizzleAccess =>
 	scriptedAccess([2 /* count */, [defRecord("d1", "u1"), defRecord("d2", "u2")] /* fetch */]);
 

--- a/apps/web/worker/features/sozluk/definition-validation.unit.test.ts
+++ b/apps/web/worker/features/sozluk/definition-validation.unit.test.ts
@@ -1,20 +1,11 @@
 /**
- * Sozluk definition-validation WIRING coverage (ADR 0082) — the definition body
- * checks driven THROUGH their only caller, the mutation, not the extracted
- * `validateBody` helper in isolation.
+ * Definition-body validation driven THROUGH its only caller, the mutation, not the extracted
+ * helper in isolation. `addDefinition` / `editDefinition` run `validateBody` BEFORE any DB
+ * read, so a throwing `Drizzle` is the proof: a refactor that reorders the call after a read,
+ * or drops it, dies here instead of rejecting.
  *
- * `addDefinition` / `editDefinition` run `validateBody` BEFORE any DB read, so a
- * throwing `Drizzle` (every `run`/`batch` `die`s) is the "no DB call" proof: a
- * typed validation failure surfacing instead of a defect means the gate fired
- * before the seam was reached. A refactor that reorders the `validateBody` call
- * after a DB read, or drops it, would die here instead of rejecting — closing
- * the interface-as-test-surface hole the
- * `pasaport/username-validation.unit.test.ts` pattern already closes.
- *
- * The DB-state-dependent rejections of the same mutations
- * (`DEFINITION_NOT_FOUND`, `UNAUTHORIZED`) and the slug→title fallback derivation
- * stay on real D1 in `tests/integration/sozluk-mutations.test.ts`. The validator
- * helpers are module-private; this file reaches them only through the mutation.
+ * The DB-state-dependent rejections of the same mutations stay on real D1 in
+ * `tests/integration/sozluk-mutations.test.ts`.
  */
 
 import {it} from "@effect/vitest";
@@ -27,9 +18,8 @@ import {Reaction} from "../reaction/Reaction.ts";
 import {Vote} from "../vote/Vote.ts";
 import {DEFINITION_BODY_MAX, Sozluk, SozlukLive} from "./Sozluk.ts";
 
-// Every DB call dies, so any path that reaches the seam fails the test: the
-// `validateBody` gate short-circuits before any read/write, and running to a
-// typed failure against this access is the "no DB call" proof.
+// Every DB call dies, so any path that reaches the seam fails the test: running to a typed
+// failure against this access is the "no DB call" proof.
 const throwingAccess: DrizzleAccess = {
 	run: () =>
 		Effect.die(new Error("a sozluk mutation read the DB on a path that must short-circuit")),
@@ -37,9 +27,8 @@ const throwingAccess: DrizzleAccess = {
 		Effect.die(new Error("a sozluk mutation wrote a batch on a path that must short-circuit")),
 };
 
-// Sozluk's validation gate doesn't touch Vote (it's consulted only on the
-// vote/aggregate paths), so a never-cast inert instance satisfies the layer's
-// dependency type without a real implementation.
+// Sozluk's validation gate doesn't touch Vote, so an inert never-cast instance satisfies the
+// layer's dependency type.
 const inertVote = Layer.succeed(Vote, {} as Context.Service.Shape<typeof Vote>);
 const inertReaction = Layer.succeed(Reaction, {} as Context.Service.Shape<typeof Reaction>);
 const inertPasaport = Layer.succeed(Pasaport, {} as Context.Service.Shape<typeof Pasaport>);

--- a/apps/web/worker/features/sozluk/definition-wire-convergence.unit.test.ts
+++ b/apps/web/worker/features/sozluk/definition-wire-convergence.unit.test.ts
@@ -1,12 +1,7 @@
 /**
- * The sözlük `Definition` wire shaper (`toDefinition`) takes the map-derived
- * `DefinitionRow` from the one `definition-fields.ts` column→field map (#1126
- * AC#1; the sözlük mirror of pano's #1161 collapse in PR #1265, the last #1161
- * remainder — #1268). This pins that seam: the record → `toDefinitionRow` →
- * `toDefinition` path yields the byte-identical canonical `{__typename, …}` wire
- * object, with the `myVote` viewer-scalar default stamped to `null` — so
- * divergence between the map and the wire shaper is unrepresentable, generalizing
- * #1170 from one field to the whole object.
+ * Pins the sözlük `Definition` seam: record → `toDefinitionRow` → `toDefinition` yields the
+ * byte-identical canonical wire object, so divergence between the one `definition-fields.ts`
+ * column→field map and the wire shaper is unrepresentable (#1268, the sözlük mirror of #1265).
  */
 import {assert, describe, it} from "@effect/vitest";
 import type * as schema from "../../db/drizzle/schema.ts";
@@ -44,15 +39,13 @@ describe("Sözlük Definition wire shaper — derived from the one column→fiel
 			score: 5,
 			author: "umut",
 			authorId: "user-1",
-			// No live identity stamped on a bare row read (`stampAuthorIdentity` runs on the
-			// service read path, #2139) → both default to null; the client `actorLabel` degrades.
+			// `stampAuthorIdentity` runs on the service read path (#2139), not on a bare row read.
 			authorUsername: null,
 			authorDisplayName: null,
 			createdAt: new Date(1000),
 			updatedAt: new Date(2000),
 			myVote: null,
-			// Owner-scoped in-review flag (#2200): stamped only by the read path, so a bare
-			// row shape defaults it `false` and never leaks review state to another viewer.
+			// Owner-scoped in-review flag (#2200): defaults `false` so a bare row never leaks review state.
 			sandboxed: false,
 			reactions: EMPTY_REACTION_AGGREGATE,
 		});
@@ -77,11 +70,8 @@ describe("Sözlük Definition wire shaper — derived from the one column→fiel
 			"updatedAt",
 		]);
 		assert.strictEqual(wire.__typename, "Definition");
-		// No viewer scalar stamped on a bare row read → defaulted to `null`.
 		assert.strictEqual(wire.myVote, null);
-		// Owner-scoped in-review flag defaults `false` on a bare row shape (#2200).
 		assert.strictEqual(wire.sandboxed, false);
-		// No reactions stamped on a bare row read → the empty aggregate.
 		assert.deepStrictEqual(wire.reactions, EMPTY_REACTION_AGGREGATE);
 	});
 

--- a/apps/web/worker/features/sozluk/errors.ts
+++ b/apps/web/worker/features/sozluk/errors.ts
@@ -1,21 +1,17 @@
 /**
- * Tagged errors raised by the Sozluk service layer. Each carries its wire `code`
- * as an `FateWireCode` annotation, which `encodeWireError` reads at the fate
- * boundary (`.patterns/fate-effect-wire-errors.md`). The codes are preserved
- * verbatim from the retired bridge registry so SPA pattern-matching keeps
- * working unchanged; `errors.unit.test.ts` pins each class→code pair.
+ * Each error's `FateWireCode` annotation is what `encodeWireError` reads at the fate
+ * boundary (`.patterns/fate-effect-wire-errors.md`). The codes are SPA-visible, so
+ * `errors.unit.test.ts` pins each class→code pair.
  */
 import {FateWireCode} from "@kampus/fate-effect";
 import * as Schema from "effect/Schema";
 
-/** `body` was empty after trimming. */
 export class BodyRequired extends Schema.TaggedErrorClass<BodyRequired>()(
 	"sozluk/BodyRequired",
 	{message: Schema.String},
 	{[FateWireCode]: "BODY_REQUIRED"},
 ) {}
 
-/** `body` exceeded `DEFINITION_BODY_MAX`. */
 export class BodyTooLong extends Schema.TaggedErrorClass<BodyTooLong>()(
 	"sozluk/BodyTooLong",
 	{
@@ -34,7 +30,6 @@ export class DefinitionNotFound extends Schema.TaggedErrorClass<DefinitionNotFou
 	{[FateWireCode]: "DEFINITION_NOT_FOUND"},
 ) {}
 
-/** Caller is not the definition's author. */
 export class UnauthorizedDefinitionMutation extends Schema.TaggedErrorClass<UnauthorizedDefinitionMutation>()(
 	"sozluk/UnauthorizedDefinitionMutation",
 	{

--- a/apps/web/worker/features/sozluk/fate-module.ts
+++ b/apps/web/worker/features/sozluk/fate-module.ts
@@ -14,10 +14,8 @@ const roots: FateRootsRecord = {
 	// `terms` resolver (which the request-key→root-name mapping forbids).
 	recentTerms: list(termDataView, {orderBy: [{slug: "asc"}]}),
 	popularTerms: list(termDataView, {orderBy: [{slug: "asc"}]}),
-	// The public landing terms (#1424) — live-only recent terms, batched into the
-	// landing screen's one `useRequest` beside `landingStats` (ADR 0021). The
-	// `landingTerms` resolver owns the recency order + the sandbox mask
-	// (`Sozluk.getLandingTerms`, the #1205 definition-arm mask).
+	// The `landingTerms` resolver owns the recency order + the sandbox mask; the
+	// `orderBy` here is only the root's declared shape.
 	landingTerms: list(termDataView, {orderBy: [{slug: "asc"}]}),
 };
 

--- a/apps/web/worker/features/sozluk/landing-terms-sandbox.unit.test.ts
+++ b/apps/web/worker/features/sozluk/landing-terms-sandbox.unit.test.ts
@@ -1,15 +1,11 @@
 /**
- * `Sozluk.getLandingTerms` sandbox-visibility wiring (#1424) — the security fix for
- * the public landing "sözlüğe son eklenenler" column. The read ranks terms by their
- * most recent LIVE definition, so the `definition_record` arm MUST carry the #1205
- * mask (`removed_at IS NULL AND sandboxed_at IS NULL`) beside the public `landingStats`
- * counts (#1391): a çaylak's sandbox-only term — whose `term_record` summary row can
- * persist with a zero live count — must never surface on the anonymous front door.
+ * Sandbox-visibility wiring for the public landing column (#1424). The read ranks
+ * terms by their most recent LIVE definition, so the `definition_record` arm must
+ * carry the sandbox mask: a sandbox-only term, whose summary row can persist with a
+ * zero live count, must never surface on the anonymous front door.
  *
- * Unit-tier per ADR 0082: row-level filtering is integration's job; what THIS proves is
- * that the read WIRES the sandbox clause into the recency query. The compiled SQL is
- * captured off a substituted `Drizzle` seam that renders each builder's `.toSQL()`
- * (the `Sozluk.connection.unit.test.ts` scripted-access idiom).
+ * Row-level filtering is integration's job; what this proves is that the read WIRES
+ * the clause in. The compiled SQL is captured off a substituted `Drizzle` seam.
  */
 import {assert, describe, it} from "@effect/vitest";
 import {drizzle} from "drizzle-orm/d1";
@@ -84,7 +80,7 @@ const sozlukLayer = (access: DrizzleAccess) =>
 describe("Sozluk.getLandingTerms — public landing terms exclude sandbox-only terms (#1424)", () => {
 	it.effect("the recency query masks removed_at AND sandboxed_at on the definition arm", () =>
 		Effect.gen(function* () {
-			// run #1: the grouped recency scan over definition_record; run #2: the summary fetch.
+			// Run 1 is the grouped recency scan; run 2 is the summary fetch.
 			const {access, queries} = scriptedAccess([[{termSlug: "race-condition"}], []]);
 			yield* Effect.gen(function* () {
 				const sozluk = yield* Sozluk;
@@ -96,7 +92,7 @@ describe("Sozluk.getLandingTerms — public landing terms exclude sandbox-only t
 			const sql = (recency as {sql: string}).sql.toLowerCase();
 			assert.match(sql, /"definition_record"\."removed_at" is null/, "removed_at guard present");
 			assert.match(sql, /"definition_record"\."sandboxed_at" is null/, "sandboxed_at mask present");
-			// Never the inverted mask — that would drop the live terms the column is meant to show.
+			// The inverted mask would drop the live terms the column exists to show.
 			assert.notMatch(sql, /sandboxed_at" is not null/, "mask is IS NULL, never IS NOT NULL");
 			assert.match(sql, /group by "definition_record"\."term_slug"/, "grouped by term");
 		}),

--- a/apps/web/worker/features/sozluk/lists.ts
+++ b/apps/web/worker/features/sozluk/lists.ts
@@ -1,13 +1,10 @@
 /**
- * Sözlük root list resolvers — `terms`, `recentTerms`, `popularTerms`. Root
- * lists map a service keyset page onto a `ConnectionResult` (ADR 0019; the
- * service owns the cursor + keyset SQL, this layer only reshapes). `sort` is a
- * plain validated string since fate has no enum type (ADR 0018).
+ * Sözlük root list resolvers. A root list maps a service keyset page onto a
+ * `ConnectionResult` (ADR 0019); the service owns the cursor + keyset SQL.
  *
- * `recentTerms` / `popularTerms` exist as fixed-sort duplicates of `terms`
- * because fate's `useRequest` keys map 1:1 to root names — one `terms` resolver
- * can't be aliased under two keys, so the home page (recent + popular side by
- * side) needs two resolvers to batch them in one request without a waterfall.
+ * `recentTerms` / `popularTerms` are fixed-sort duplicates of `terms` because fate's
+ * `useRequest` keys map 1:1 to root names — one resolver can't be aliased under two keys, so
+ * the home page needs two to batch them in one request without a waterfall.
  */
 
 import {Fate} from "@kampus/fate-effect";
@@ -43,8 +40,7 @@ const listTerms = (
 ) =>
 	Effect.gen(function* () {
 		const sozluk = yield* Sozluk;
-		// Resolve the sandbox viewer (identity + moderator probe) so the list hides terms
-		// whose only definitions this viewer can't read (#3724).
+		// So the list hides terms whose only definitions this viewer can't read.
 		const sandboxViewer = yield* currentSandboxViewer;
 		const page = yield* sozluk.listTermSummariesConnection({
 			sort,
@@ -74,8 +70,7 @@ export const lists = {
 			return yield* listTerms("popular", args);
 		}),
 	),
-	// The public landing "son eklenenler" column (#1424) — live-only recent terms,
-	// masked in `Sozluk.getLandingTerms`; a single non-paginated page.
+	// The public landing "son eklenenler" column — live-only, a single non-paginated page.
 	landingTerms: Fate.list(
 		{args: LandingTermsArgs, type: TermView},
 		Effect.fn("landingTerms")(function* ({args}) {

--- a/apps/web/worker/features/sozluk/live.ts
+++ b/apps/web/worker/features/sozluk/live.ts
@@ -1,20 +1,13 @@
 /**
- * Sözlük live-publish targets — the ONE place that answers "what does mutating a
- * Definition publish to?" Binds the entity's wire `__typename` (read off the
- * view's `typeName`, never an inline `"Definition"` literal) to the
- * `Term.definitions` topic, so a resolver names the fan-out target instead of
- * restating the magic-string seam (#1127).
+ * Sözlük's live-publish targets — the one place that answers "what does mutating a
+ * Definition publish to?" The typename is read off the view rather than written as an
+ * inline literal, so a resolver names its fan-out target instead of restating the
+ * magic string (#1127).
  *
- * No behavior change: the bound calls forward verbatim to `WorkerLivePublisher`,
- * so the published frames are byte-identical to the prior inline wiring — the
- * typename is the SAME string (`DefinitionView.typeName === "Definition"`), just
- * sourced from the view. The `changed` hint stays a per-resolver argument (it is
- * mutation-specific and does not reach the wire; see `fate-live/live-publisher.ts`).
- *
- * `appendNode` (the create-time node broadcast, the #1205 leak surface) takes a
- * `PublishDecision` and gates through `broadcastIf` — so a resolver cannot broadcast
- * a node to this viewer-blind public topic without discharging the sandbox check
- * (#1280). `deleteEdge` carries no node payload, so it stays ungated.
+ * `appendNode` takes a `PublishDecision` and gates through `broadcastIf`, so a
+ * resolver cannot broadcast a node to this viewer-blind public topic without
+ * discharging the sandbox check (#1280). `deleteEdge` carries no node payload and
+ * stays ungated.
  */
 
 import type {WorkerLivePublisher} from "../fate-live/protocol.ts";
@@ -24,16 +17,11 @@ import {DefinitionView} from "./views.ts";
 
 const DEFINITION = DefinitionView.typeName;
 
-/**
- * Bind sözlük's publish targets to the per-request publisher. `term(slug)` is the
- * args-scoped `Term.definitions` connection keyed by the parent term.
- */
 export const sozlukLive = (live: WorkerLivePublisher) => ({
 	definition: {
 		update: (id: string | number, options?: {changed?: ReadonlyArray<string>; data?: unknown}) =>
 			live.update(DEFINITION, id, options),
 		delete: (id: string | number) => live.delete(DEFINITION, id),
-		/** The args-scoped `Term.definitions` connection for one parent term. */
 		term: (slug: string) => {
 			const topic = live.topic(LiveTopic.termDefinitions, {id: slug});
 			return {

--- a/apps/web/worker/features/sozluk/mutations.ts
+++ b/apps/web/worker/features/sozluk/mutations.ts
@@ -1,12 +1,9 @@
 /**
- * Mutation resolvers — the sozluk write path (ADR 0020). Each mutation calls a
- * `Sozluk` service method then returns the re-resolved affected entity shaped
- * like a read; a delete returns the re-resolved parent (`Term`) so the client's
- * normalized cache updates the surrounding list. Domain validation stays in the
- * service (ADR 0013); `CurrentUser.required` gates every write.
+ * Mutation resolvers — the sozluk write path (ADR 0020). Each mutation calls a `Sozluk`
+ * service method then returns the re-resolved affected entity; a delete returns the
+ * re-resolved parent `Term` so the client's normalized cache updates the surrounding list.
  *
- * Live publishes go through `WorkerLivePublisher`, whose publish methods have
- * `E = never`, so a failed publish can never fail the mutation
+ * A live publish has `E = never`, so it can never fail the mutation
  * (`.patterns/fate-effect-server.md`).
  */
 
@@ -38,9 +35,8 @@ import {toDefinition, toTermFromPage} from "./shapers.ts";
 import type {Definition} from "./views.ts";
 import {DefinitionView, TermView} from "./views.ts";
 
-// Branded id schemas decode byte-identically (the brand is type-only) but carry
-// the nominal tag downstream, so `input.id` / `input.termSlug` arrive already
-// typed as DefinitionId / TermSlug for the service-call surface below.
+// Branded id schemas decode byte-identically (the brand is type-only) but carry the
+// nominal tag downstream, so the service-call surface below gets typed ids for free.
 const AddDefinitionInput = Schema.Struct({
 	termSlug: TermSlug,
 	termTitle: Schema.optional(Schema.NullOr(Schema.String)),
@@ -56,17 +52,14 @@ const DefinitionIdInput = Schema.Struct({
 	id: DefinitionId,
 });
 
-// The reaction intent decodes against the curated `REACTION_EMOJI` palette at the
-// wire boundary: a palette member sets/changes the reactor's single reaction, `null`
-// retracts it, and a NON-palette string fails to decode — so an arbitrary emoji is
-// structurally unrepresentable, never reaching the service (#1865 AC#1).
+// A NON-palette string fails to decode at the wire boundary, so an arbitrary emoji is
+// structurally unrepresentable and never reaches the service.
 const ReactDefinitionInput = Schema.Struct({
 	id: DefinitionId,
 	emoji: Schema.NullOr(ReactionEmojiSchema),
 });
 
-// Service results name the id `definitionId` / author `authorName`; the
-// `toDefinition` shaper takes wire field names, so remap those two keys first.
+// Service results name the id `definitionId` / author `authorName`; remap to wire names.
 const shapeDefinition = (r: {
 	definitionId: string;
 	body: string;
@@ -110,23 +103,17 @@ export const mutations = {
 					sandboxedAt,
 					...(input.termTitle ? {termTitle: input.termTitle} : {}),
 				});
-				// Fresh write: not yet voted by anyone.
 				const definition = shapeDefinition({...result, myVote: null});
-				// Append the node to the term's `Term.definitions` topic (same key
-				// `definition.delete` removes from) so every open term page updates live —
-				// but only when the definition is live: the topic is viewer-blind, so a
-				// sandboxed node would leak to non-author/anonymous subscribers (#1205 AC#2).
+				// The term topic is viewer-blind, so a sandboxed node would leak to non-author and
+				// anonymous subscribers — hence the `decidePublish` gate.
 				yield* live.definition
 					.term(input.termSlug)
 					.appendNode(definition.id, {node: definition}, decidePublish(sandboxedAt));
-				// Mod-queue heartbeat (#1699): a sandboxed definition that is the çaylak's
-				// FIRST pending item pages the moderators — same transition gate as pano.
+				// A sandboxed definition that is the çaylak's FIRST pending item pages the moderators.
 				yield* notifyCaylakEntersDivan({authorId: user.id, sandboxedAt});
 				return definition;
 			});
-			// Post-value karma gate (#150), dark behind `phoenix-karma-gates` — the same
-			// ≥ −4 floor as pano's `post.submit` / `comment.add`, applied to the sözlük
-			// definition write path.
+			// Post-value karma gate, dark behind `phoenix-karma-gates` — the same ≥ −4 floor as pano's.
 			return yield* gateContentOnKarma(add());
 		}),
 	),
@@ -134,9 +121,8 @@ export const mutations = {
 		{
 			input: DefinitionIdInput,
 			type: DefinitionView,
-			// `VoterNotEligible` (wire `VOTE_REQUIRES_YAZAR`) — the "earn to vote" gate (#1810): a çaylak
-			// newcomer is rejected at cast. `SelfVoteNotAllowed` (wire `SELF_VOTE_NOT_ALLOWED`) — the
-			// founder-ruled self-vote block (#2216). Both cast-only; retraction is exempt for each.
+			// `VoterNotEligible` is the "earn to vote" gate, `SelfVoteNotAllowed` the founder-ruled
+			// self-vote block. Both cast-only; retraction is exempt for each.
 			error: Schema.Union([Unauthorized, DefinitionNotFound, VoterNotEligible, SelfVoteNotAllowed]),
 		},
 		Effect.fn("definition.vote")(function* ({input}) {
@@ -150,9 +136,7 @@ export const mutations = {
 			const definition = shapeDefinition(result);
 			// `myVote` is viewer-specific, so it's omitted from `changed`.
 			yield* live.definition.update(definition.id, {changed: ["score"], data: definition});
-			// Aggregated vote notification (#1698): see pano's `post.vote` — a landed
-			// upvote notifies the definition author, rolled up per item, on a real
-			// state change only. `result.authorId` is server-derived.
+			// A landed upvote notifies the author, rolled up per item, on a real state change only.
 			if (result.changed) {
 				yield* notifyContentVote({
 					authorId: result.authorId,
@@ -183,12 +167,8 @@ export const mutations = {
 			return definition;
 		}),
 	),
-	// Set / change / retract the viewer's single reaction on a definition (epic #1840,
-	// #1865) — the cross-product twin of `definition.vote`, delegating to the ungated,
-	// karma-free `Reaction` engine via `Sozluk.reactToDefinition`. `CurrentUser.required`
-	// is the ONLY gate (a signed-out reactor is `Unauthorized`, same as vote's signed-out
-	// gate) — deliberately NO voter-tier gate and NO karma write, so a çaylak may react
-	// (#1861). Ships dark behind the default-off `phoenix-reactions` flag.
+	// `CurrentUser.required` is the ONLY gate — deliberately NO voter-tier gate and NO karma
+	// write, so a çaylak may react. Ships dark behind the default-off `phoenix-reactions`.
 	"definition.react": Fate.mutation(
 		{
 			input: ReactDefinitionInput,
@@ -198,11 +178,8 @@ export const mutations = {
 		Effect.fn("definition.react")(function* ({input}) {
 			const user = yield* CurrentUser.required;
 			const sozluk = yield* Sozluk;
-			// Dark-ship gate (ADR 0083): default-off `phoenix-reactions`. Off ⇒ inert — the
-			// react never lands (the write is the new path, unreachable until release);
-			// re-resolve the definition unchanged so the caller's cache stays consistent,
-			// the divan.vote dark-ship inert-receipt shape. On a Flagship outage the safe
-			// read default (`false`) keeps the path dark.
+			// Dark-ship gate (ADR 0083). Off ⇒ inert: re-resolve the definition unchanged so the
+			// caller's cache stays consistent. A Flagship outage reads `false` and stays dark.
 			const flags = yield* Flags;
 			const on = yield* flags.getBoolean(PHOENIX_REACTIONS, false).pipe(provideRequestFlags);
 			if (!on) {
@@ -215,11 +192,8 @@ export const mutations = {
 				}
 				return toDefinition(current);
 			}
-			// The mutation return re-resolves the fresh aggregate for the reactor, and
-			// `live.definition.update({changed: ["reactions"]})` fans that aggregate out to
-			// every open subscriber so a reader watching the term sees the count move (#1868)
-			// — the reaction twin of `definition.vote`'s score publish, through the same
-			// never-failing `WorkerLivePublisher`.
+			// The publish fans the fresh aggregate out to every open subscriber, so a reader
+			// watching the term sees the count move.
 			const live = sozlukLive(yield* WorkerLivePublisher);
 			const row = yield* sozluk.reactToDefinition({
 				definitionId: input.id,
@@ -252,8 +226,7 @@ export const mutations = {
 				actorId: UserId.make(user.id),
 				body: input.body,
 			});
-			// Re-read the viewer's vote so the edit doesn't drop `myVote` (edit
-			// leaves vote state untouched but must not blank it).
+			// Re-read the viewer's vote so the edit doesn't blank `myVote`.
 			const [fresh] = yield* sozluk.getDefinitionsByIds([result.definitionId], {viewerId: user.id});
 			const definition = shapeDefinition({...result, myVote: fresh?.myVote ?? null});
 			yield* live.definition.update(definition.id, {changed: ["body"], data: definition});
@@ -262,8 +235,7 @@ export const mutations = {
 	),
 	"definition.delete": Fate.mutation(
 		{
-			// A delete returns the re-resolved **parent** `Term` so the client's
-			// normalized cache updates the surrounding definitions list (ADR 0020).
+			// A delete returns the re-resolved **parent** `Term` (ADR 0020).
 			input: DefinitionIdInput,
 			type: TermView,
 			error: Schema.Union([Unauthorized, DefinitionNotFound, UnauthorizedDefinitionMutation]),
@@ -286,8 +258,7 @@ export const mutations = {
 		}),
 	),
 
-	// Restore (un-delete) a previously removed definition (ADR 0096 §4). Returns
-	// the re-resolved parent `Term`; the definition re-enters the term's list.
+	// Restore (un-delete) a removed definition (ADR 0096 §4); returns the parent `Term`.
 	"definition.restore": Fate.mutation(
 		{
 			input: DefinitionIdInput,
@@ -308,8 +279,7 @@ export const mutations = {
 			if (!page) return null;
 			const restored = page.definitions.find((d) => d.id === input.id);
 			if (restored) {
-				// Re-enter the term's `Term.definitions` topic — the inverse of
-				// the `deleteEdge` the delete path published.
+				// Re-enter the term topic — the inverse of the delete path's `deleteEdge`.
 				const node = toDefinition({
 					id: restored.id,
 					body: restored.body,
@@ -320,10 +290,8 @@ export const mutations = {
 					updatedAt: restored.updatedAt,
 					myVote: restored.myVote ?? null,
 				});
-				// Sandbox-faithful restore (#1811): a çaylak's sandboxed definition
-				// round-trips back to Sandboxed, so route the broadcast through the
-				// #1205/#1280 gate — a sandboxed restore is suppressed from the
-				// viewer-blind term topic; a Live restore broadcasts as before.
+				// Sandbox-faithful restore: a çaylak's definition round-trips back to sandboxed, so a
+				// sandboxed restore stays suppressed from the viewer-blind term topic.
 				yield* live.definition
 					.term(slug)
 					.appendNode(restored.id, {node}, decidePublish(restoreResult.sandboxedAt ?? null));

--- a/apps/web/worker/features/sozluk/ordering.ts
+++ b/apps/web/worker/features/sozluk/ordering.ts
@@ -1,35 +1,22 @@
 /**
- * Sözlük connection orderings — the single source each connection's fate-view
- * `orderBy` and service Drizzle keyset both derive from (ADR 0019; see
- * `db/ordering.ts`). The view-field name and the Drizzle column for each sort
- * column are named together here, so a sort change is a one-site edit and the
- * view/keyset can't drift.
+ * Sözlük connection orderings — the single source each connection's fate-view `orderBy` and
+ * service Drizzle keyset both derive from (ADR 0019), so a sort change is a one-site edit.
  */
 
 import * as schema from "../../db/drizzle/schema.ts";
 import type {Ordering} from "../../db/ordering.ts";
 
-/**
- * `Term.definitions` (the term-page definition list): `score desc, createdAt
- * asc, id asc`. Consumed by `Term.definitions`' view `orderBy` and the
- * `Sozluk.listDefinitionsKeyset` keyset.
- */
 export const DEFINITION_ORDERING: Ordering = [
 	{field: "score", column: schema.definitionRecord.score, dir: "desc"},
 	{field: "createdAt", column: schema.definitionRecord.createdAt, dir: "asc"},
 	{field: "id", column: schema.definitionRecord.id, dir: "asc"},
 ];
 
-/** The term-summary list sorts (`Sozluk.listTermSummariesConnection`). */
 export type TermSummarySort = "recent" | "popular";
 
-/**
- * The term-summary connection orderings by sort — a lead column (descending)
- * plus the `slug` asc tiebreaker. The view roots (`recentTerms`/`popularTerms`)
- * are custom-resolver lists whose `orderBy` is nominal (the resolver owns the
- * order), so this single-sources the keyset's lead-tuple against its own
- * `.orderBy(…)`, not a view `orderBy`.
- */
+// A lead column (descending) plus the `slug` asc tiebreaker. The view roots are
+// custom-resolver lists whose `orderBy` is nominal, so this single-sources the keyset's
+// lead-tuple against its own `.orderBy(…)`, not a view `orderBy`.
 export const TERM_SUMMARY_ORDERING: Record<TermSummarySort, Ordering> = {
 	popular: [
 		{field: "totalScore", column: schema.termRecord.totalScore, dir: "desc"},

--- a/apps/web/worker/features/sozluk/persist-term-summary.unit.test.ts
+++ b/apps/web/worker/features/sozluk/persist-term-summary.unit.test.ts
@@ -1,17 +1,11 @@
 /**
- * Coverage for the `recomputeTermSummary` → row-write coupling (#1337) — the seam
- * the fold-only `recompute-term-summary.unit.test.ts` leaves untested. The pure
- * fold is proven in isolation there; what THIS file proves is that the fold's
- * output is wired into the `term_record` upsert (and its `term_search` FTS
- * dual-write) in the one convergent call-site every term write funnels through
- * (`persistTermSummary`, module-private).
+ * Coverage for the `recomputeTermSummary` → row-write coupling (#1337). The pure fold
+ * is proven in `recompute-term-summary.unit.test.ts`; what this proves is that its
+ * output reaches the `term_record` upsert and the `term_search` dual-write.
  *
- * Driven THROUGH the public mutation (`editDefinition`) against a scripted
- * `Drizzle` double whose `batch` renders each statement's `.toSQL()` — the
- * `contributions-sandbox.unit.test.ts` / `VouchLedger.unit.test.ts` idiom (no
- * engine, ADR 0082/0104/0105: no revived `node:sqlite` fake, no `runFateOp`). The
- * batch is captured, not executed, so the row/column LANDING is unit-reachable;
- * row-level behavior on real D1 stays the integration tier's job.
+ * The scripted `Drizzle` double renders each batched statement's `.toSQL()` rather
+ * than executing it, so the row/column landing is unit-reachable with no engine (ADR
+ * 0082/0104/0105); real-D1 behavior stays the integration tier's job.
  */
 import {describe, it} from "@effect/vitest";
 import {drizzle} from "drizzle-orm/d1";
@@ -49,16 +43,13 @@ const noopD1 = {
 } as unknown as D1Database;
 const renderDb = drizzle(noopD1, {relations});
 
-// editDefinition doesn't touch Vote (it's consulted on the vote/aggregate paths),
-// so an inert instance satisfies the layer dependency without an implementation.
+// `editDefinition` never touches Vote, so an inert instance satisfies the dependency.
 const inertVote = Layer.succeed(Vote, {} as Context.Service.Shape<typeof Vote>);
 
 type Rendered = {sql: string; params: unknown[]};
 
-// Replays `run` results in call order; captures every `batch` statement's `.toSQL()`.
-// editDefinition's run order: (0) findFirst definition, (1) update body,
-// (2) persistTermSummary's live-defs SELECT — then ONE batch (term_record upsert +
-// the two `term_search` FTS statements).
+// Replays `run` results in call order, so the script depends on `editDefinition`'s
+// order: findFirst definition, update body, then the live-defs SELECT.
 function scriptedAccess(runResults: ReadonlyArray<unknown>): {
 	access: DrizzleAccess;
 	batched: Rendered[];
@@ -90,8 +81,7 @@ const SLUG = "kelime";
 const TITLE = "Kelime";
 const OWNER = UserId.make("u1");
 
-// The definition `editDefinition` resolves first (its findFirst result) — author
-// matches the actor so the mutation proceeds to the summary recompute.
+// The author matches the actor, so the mutation proceeds to the summary recompute.
 const editedDefinition = {
 	id: "def_1",
 	authorId: OWNER,
@@ -102,8 +92,7 @@ const editedDefinition = {
 	createdAt: new Date("2024-01-01T00:00:00.000Z"),
 };
 
-// The live-definition slice the summary fold reads (term-page order: score desc).
-// Distinctive values so each landed column is unambiguous in the rendered params.
+// Distinctive values, so each landed column is unambiguous in the rendered params.
 const def = (over: Partial<TermSummaryDefRow> & {id: string}): TermSummaryDefRow => ({
 	body: "body",
 	bodyExcerpt: "excerpt",
@@ -117,7 +106,6 @@ const liveDefs: TermSummaryDefRow[] = [
 	def({id: "runner-up", score: 7, bodyExcerpt: "runner"}),
 ];
 
-// Run editDefinition through the scripted seam and hand back the captured batch.
 const renderUpsert = () =>
 	Effect.gen(function* () {
 		const {access, batched} = scriptedAccess([editedDefinition, {}, liveDefs]);
@@ -139,8 +127,7 @@ describe("persistTermSummary — the recomputeTermSummary → term_record row-wr
 			Effect.gen(function* () {
 				const batched = yield* renderUpsert();
 
-				// One batch: the summary upsert + the two `term_search` FTS statements,
-				// all-or-none (ADR 0080 lockstep).
+				// One batch, so the upsert and the FTS writes land all-or-none (ADR 0080).
 				assert.strictEqual(
 					batched.length,
 					3,
@@ -155,9 +142,7 @@ describe("persistTermSummary — the recomputeTermSummary → term_record row-wr
 					"the FTS dual-write to term_search rides the same batch",
 				);
 
-				// recomputeTermSummary([top score 10, runner score 7], "kelime", "Kelime") ⇒
-				// count 2, totalScore 17, top "top-def", excerpt "the winning excerpt",
-				// firstLetter "k" — each must appear in the rendered upsert params.
+				// The fold over the two live defs yields count 2 and totalScore 17.
 				const p = upsert.params;
 				assert.include(p, SLUG, "slug column");
 				assert.include(p, TITLE, "title column");

--- a/apps/web/worker/features/sozluk/queries.ts
+++ b/apps/web/worker/features/sozluk/queries.ts
@@ -1,10 +1,8 @@
 /**
- * Sözlük root query resolvers — `term(slug)`, the detail page.
- *
- * Query resolvers return shaped output directly (not masked through a source),
- * so the resolver builds the exact wire shape the client selected, including the
- * nested `definitions` connection paged by the DB keyset (ADR 0019; see
- * `.patterns/fate-effect-operations.md`, `.patterns/fate-connections.md`).
+ * Sözlük root query resolvers — `term(slug)`, the detail page. Query resolvers return shaped
+ * output directly (not masked through a source), so the resolver builds the exact wire shape the
+ * client selected, including the nested `definitions` keyset connection (ADR 0019; see
+ * `.patterns/fate-connections.md`).
  */
 
 import {Fate} from "@kampus/fate-effect";
@@ -24,8 +22,7 @@ import {TermView} from "./views.ts";
 
 const DEFINITIONS_PAGE_SIZE = 50;
 
-// Nested connection args are scoped under the field path
-// (`args.definitions.{first,after}`), matching fate's `getScopedArgs`.
+// Nested connection args are scoped under the field path, matching fate's `getScopedArgs`.
 const TermArgs = Schema.Struct({
 	slug: Schema.String,
 	definitions: connectionArgs(),
@@ -36,8 +33,7 @@ export const queries = {
 		{args: TermArgs, type: TermView},
 		Effect.fn("term")(function* ({args, select}) {
 			const sozluk = yield* Sozluk;
-			// Resolve the sandbox viewer once (identity + moderator probe) so the
-			// term + its definitions filter çaylak-sandboxed content per #1205.
+			// Resolved once (identity + moderator probe) for both the term and its definitions (#1205).
 			const sandboxViewer = yield* currentSandboxViewer;
 			const viewerId = sandboxViewer.viewerId;
 			const page = yield* sozluk.getTerm(args.slug, {sandboxViewer});
@@ -45,21 +41,18 @@ export const queries = {
 
 			const base = toTermFromPage(page);
 
-			// The native path won't auto-invoke a nested relation's `connection`
-			// executor for a hand-built source, so the resolver delivers the
-			// connection inline when selected (see `.patterns/fate-connections.md`).
+			// The native path won't auto-invoke a nested relation's `connection` executor for a
+			// hand-built source, so the resolver delivers it inline (`.patterns/fate-connections.md`).
 			if (!hasNestedSelection(select, "definitions")) {
 				return base;
 			}
 
-			// Contained behind the default-off flag (#2709): off ⇒ serial stamps (today), on
-			// ⇒ one concurrent wave. Identical wire output — only wall time collapses.
+			// #2709: off ⇒ serial stamps, on ⇒ one concurrent wave. Identical wire output.
 			const flags = yield* Flags;
 			const parallelStamps = yield* flags
 				.getBoolean(PHOENIX_SOZLUK_STAMP_WAVE, false)
 				.pipe(provideRequestFlags);
-			// Mute read-mask (#3113): hide muted authors' definitions from the muter
-			// (default-off `member-mute` ⇒ empty set ⇒ today's definition reads unchanged).
+			// Mute read-mask (#3113); default-off `member-mute` ⇒ empty set ⇒ today's reads unchanged.
 			const mutedIds = yield* currentMutedIds;
 			const connection = yield* sozluk.listDefinitionsKeyset(args.slug, {
 				...keysetInput(args.definitions, DEFINITIONS_PAGE_SIZE),

--- a/apps/web/worker/features/sozluk/reaction-definition.unit.test.ts
+++ b/apps/web/worker/features/sozluk/reaction-definition.unit.test.ts
@@ -1,19 +1,9 @@
 /**
- * `Sozluk.reactToDefinition` service-seam coverage (epic #1840, #1865) — the
- * cross-product wiring that proves the one reaction template spans sözlük. Driven
- * over a substituted `Drizzle` (the definition load) + a RECORDING `Reaction` double
- * + a fail-on-contact `Vote`, so three things are wrong-or-right with no SQL engine:
- *
- *   - **cast / change / retract on the definition path.** The reactor's intent
- *     (`👍` set, `❤️` change, `null` retract) is delegated verbatim to
- *     `Reaction.react` as `{userId, targetKind: "definition", targetId, emoji}`, and
- *     the re-resolved row carries the FRESH aggregate the engine returned. The
- *     cardinality-one write itself is `Reaction.unit.test.ts`; this pins the
- *     definition-path DELEGATION + re-hydration.
- *   - **ungated + karma-free.** `Vote.cast` fail-on-contact: a passing test proves the
- *     react path never casts a vote or writes karma (the settled #1861 divergence).
- *   - **target-miss → `DefinitionNotFound`.** A missing/removed definition is this
- *     surface's not-found, never the engine's `ReactionTargetNotFound`.
+ * `Sozluk.reactToDefinition` service-seam coverage, over a substituted `Drizzle` + a
+ * RECORDING `Reaction` double + a fail-on-contact `Vote`. Pins the definition-path
+ * DELEGATION and re-hydration (the cardinality-one write itself is `Reaction.unit.test.ts`),
+ * that the path never casts a vote or writes karma, and that a target miss surfaces as
+ * `DefinitionNotFound` rather than the engine's `ReactionTargetNotFound`.
  */
 import {assert, describe, it} from "@effect/vitest";
 import {Effect, Exit, Layer} from "effect";
@@ -34,9 +24,6 @@ import {Sozluk, SozlukLive} from "./Sozluk.ts";
 const DEF_ID = DefinitionId.make("def-1");
 const REACTOR = UserId.make("u-reactor");
 
-// The scripted `definition_record` the up-front load returns (or `undefined` for the
-// not-found path). The reads only touch `toDefinitionRow`'s columns; the rest satisfy
-// the row shape without being exercised.
 const definitionRow = {
 	id: DEF_ID,
 	body: "bir tanım",
@@ -52,8 +39,8 @@ const definitionRow = {
 	bodyExcerpt: "bir tanım",
 };
 
-// One `run` (the definition load) is the only DB touch; a direct `batch` would mean
-// the react path wrote SQL itself instead of delegating to the engine — die on it.
+// A direct `batch` would mean the react path wrote SQL itself instead of delegating to the
+// engine — die on it.
 const definitionAccess = (row: unknown): DrizzleAccess => ({
 	run: () => Effect.succeed(row as never),
 	batch: () =>
@@ -62,8 +49,7 @@ const definitionAccess = (row: unknown): DrizzleAccess => ({
 		),
 });
 
-// A `Vote` that DIES on any cast — proves the react path is karma-free / ungated
-// (`readMine` alone is on the `myVote` stamp path and returns empty, no DB read).
+// Dies on any cast — proves the react path is karma-free / ungated.
 // biome-ignore lint/plugin: a service double — only `readMine` is reached; `cast` fail-on-contact is the karma-free proof.
 const VoteStub = Layer.succeed(Vote, {
 	cast: () =>
@@ -72,9 +58,8 @@ const VoteStub = Layer.succeed(Vote, {
 	clearTarget: () => Effect.void,
 } as unknown as typeof Vote.Service);
 
-// A `Reaction` that RECORDS every `react` input and replays a scripted aggregate on
-// `readAggregate` — so the delegated `{targetKind, targetId, emoji}` and the
-// re-hydrated aggregate are both observable with no engine/DB.
+// Records every `react` input and replays a scripted aggregate on `readAggregate`, so the
+// delegated input and the re-hydrated aggregate are both observable with no engine.
 const recordingReaction = (
 	reactCalls: ReactInput[],
 	aggregateById: ReadonlyMap<string, ReactionAggregate>,
@@ -123,11 +108,9 @@ describe("Sozluk.reactToDefinition — cast / change / retract delegate to the R
 					reactorId: REACTOR,
 					emoji,
 				});
-				// The intent is delegated verbatim to the ungated, karma-free engine.
 				assert.deepStrictEqual(reactCalls, [
 					{userId: REACTOR, targetKind: "definition", targetId: DEF_ID, emoji},
 				]);
-				// The re-resolved row carries the FRESH aggregate the engine returned.
 				assert.strictEqual(row.id, DEF_ID);
 				assert.deepStrictEqual(row.reactions, aggregate);
 			}).pipe(Effect.provide(sozlukLayer(definitionRow, reactCalls, aggregateById)));
@@ -147,8 +130,7 @@ describe("Sozluk.reactToDefinition — cast / change / retract delegate to the R
 		new Map([[DEF_ID, {counts: [{emoji: "❤️", count: 1}], myReaction: "❤️"}]]),
 	);
 
-	// Retract: the target drops out of the aggregate map, so the stamp fills the empty
-	// aggregate — no counts, no viewer reaction.
+	// Retract: the target drops out of the aggregate map, so the stamp fills the empty one.
 	delegationCase(
 		"retract: null is delegated and the row falls back to the empty aggregate",
 		null,

--- a/apps/web/worker/features/sozluk/recompute-sozluk-stats-public-live.unit.test.ts
+++ b/apps/web/worker/features/sozluk/recompute-sozluk-stats-public-live.unit.test.ts
@@ -1,18 +1,11 @@
 /**
- * `recomputeSozlukStats` public-live count wiring (#1407). The per-product
- * `sozluk_stats` totals (`total_definitions`, `total_authors`) count LIVE content
- * only: a sandboxed çaylak definition is excluded like a removed one, so a
- * sandbox-only author never inflates `total_authors`. Definitions carry no draft
- * dimension, so the seam's removed+sandbox reduction is the full rule.
+ * `recomputeSozlukStats` public-live count wiring. The `sozluk_stats` totals count LIVE
+ * content only: a sandboxed çaylak definition is excluded like a removed one, so a
+ * sandbox-only author never inflates `total_authors`.
  *
- * #1407 folds these counts onto the shared `publicLiveWhere` for the anonymous
- * viewer, replacing the hand-written `removed_at IS NULL AND sandboxed_at IS NULL`.
- *
- * `recomputeSozlukStats` is a private closure run at the end of `addDefinition`;
- * the counts execute through `.select(...).where(...).then(...)` (Promises, no
- * `.toSQL()`), so the compiled WHERE is captured by driving `SozlukLive.addDefinition`
- * over a RECORDING D1 binding whose `prepare(sql)` records every statement (ADR 0082:
- * row-level behavior is integration's job; the seam WIRING is what's unit-reachable).
+ * The counts execute through `.select(...).where(...).then(...)` (Promises, no `.toSQL()`),
+ * so the compiled WHERE is captured by driving `SozlukLive.addDefinition` over a RECORDING
+ * D1 binding whose `prepare(sql)` records every statement.
  */
 import {assert, describe, it} from "@effect/vitest";
 import {Effect, Layer} from "effect";

--- a/apps/web/worker/features/sozluk/recompute-term-summary.unit.test.ts
+++ b/apps/web/worker/features/sozluk/recompute-term-summary.unit.test.ts
@@ -1,8 +1,4 @@
-/**
- * Unit coverage for `recomputeTermSummary` — the pure convergent fold that derives
- * a `term_record` row from its live definitions (ADR 0082). No Effect layer, no DB:
- * the fold is exercised directly over plain rows.
- */
+/** `recomputeTermSummary` — the pure fold deriving a `term_record` row from live definitions. */
 import {describe, expect, it} from "vitest";
 import {recomputeTermSummary, type TermSummaryDefRow} from "./Sozluk.ts";
 

--- a/apps/web/worker/features/sozluk/self-vote-guard.unit.test.ts
+++ b/apps/web/worker/features/sozluk/self-vote-guard.unit.test.ts
@@ -1,13 +1,8 @@
 /**
- * `Sozluk.applyVote` self-vote guard (#2216, founder-ruled) — the cast-site domain guard
- * proven over the REAL `SozlukLive` with a substituted `Drizzle` (the definition load) + a
- * RECORDING `Vote`, so three things are wrong-or-right with no SQL engine:
- *
- *   1. self-cast rejected — `voteDefinition` where `voterId === definition.authorId` fails
- *      `SelfVoteNotAllowed` and NEVER reaches `Vote.cast` (no score/karma write).
- *   2. other-author cast lands — a non-author vote reaches `Vote.cast` exactly as before.
- *   3. self-retract exempt — `retractDefinitionVote` on one's own definition reaches
- *      `Vote.cast` (the guard is cast-only; a blocked cast leaves nothing to retract).
+ * The self-vote guard (#2216), proven over the real `SozlukLive` with a substituted
+ * `Drizzle` and a recording `Vote`, so no SQL engine is needed. The guard is
+ * cast-only: retracting a vote on one's own definition still reaches `Vote.cast`,
+ * because a blocked cast leaves nothing to retract.
  */
 import {assert, describe, it} from "@effect/vitest";
 import {Effect, Exit, Layer} from "effect";
@@ -23,9 +18,8 @@ const AUTHOR = UserId.make("u-author");
 const OTHER = UserId.make("u-other");
 const DEF_ID = DefinitionId.make("def-1");
 
-// The `definition_record` the up-front load returns. Only `authorId` drives the guard; the
-// rest satisfy the row shape the return projection reads. `changed:false` from the Vote
-// double keeps `persistTermSummary` (and its DB writes) off the path, so one read is enough.
+// Only `authorId` drives the guard. `changed:false` from the Vote double keeps
+// `persistTermSummary` off the path, so one read is enough.
 const definitionRow = {
 	id: DEF_ID,
 	body: "bir tanım",
@@ -46,9 +40,8 @@ const definitionAccess = (row: unknown): DrizzleAccess => ({
 	batch: () => Effect.die(new Error("the vote path takes no direct batch in self-vote-guard")),
 });
 
-// A `Vote` that RECORDS every cast and replays a no-op result — so "did the cast path run"
-// is observable with no engine. Only `cast` is on the vote WRITE path; every other method
-// dies on contact via the Proxy (the `reaction-mutation` `panoStub` idiom).
+// Records every cast, so "did the cast path run" is observable with no engine. Every
+// other method dies on contact.
 const recordingVote = (casts: VoteInput[]): Layer.Layer<Vote> =>
 	Layer.succeed(
 		Vote,
@@ -76,8 +69,7 @@ const recordingVote = (casts: VoteInput[]): Layer.Layer<Vote> =>
 		) as typeof Vote.Service,
 	);
 
-// The vote path never reacts, so a fail-on-contact `Reaction` proves it — every method dies
-// on contact via the Proxy.
+// The vote path never reacts, so a fail-on-contact `Reaction` proves it.
 const reactionStub = Layer.succeed(
 	Reaction,
 	new Proxy({} as Partial<typeof Reaction.Service>, {

--- a/apps/web/worker/features/sozluk/shapers.ts
+++ b/apps/web/worker/features/sozluk/shapers.ts
@@ -1,17 +1,8 @@
 /**
- * Sözlük wire-entity shapers — `Term` / `Definition`. Every
- * `{__typename, …}` literal is built here once so the read/list/write paths
- * can't drift out of agreement.
- *
- * Both entities take their wire-named field set from a single column→field map —
- * `Definition` from `definition-fields.ts` (#1126), `Term` from `term-fields.ts`
- * (#1544) — so the row mapper (`toDefinitionRow` / `toTermSummaryRow`), the wire
- * shaper's input type (`DefinitionRow` / `TermSummaryRow`), and the view field
- * list all derive from one declaration: a one-field change touches that map, not a
- * parallel restatement. Each `toX` here takes the map-derived row and stamps
- * `__typename` (+ `Definition`'s `myVote` viewer-scalar default) onto the
- * already-wire-named fields. `toTermFromPage` adapts the detail `TermPage` source
- * onto the same row shape at the call site.
+ * Sözlük wire-entity shapers — `Term` / `Definition`. Every `{__typename, …}` literal is
+ * built here once so the read/list/write paths can't drift out of agreement. Both entities
+ * take their wire-named field set from a single column→field map (`definition-fields.ts` /
+ * `term-fields.ts`), so a one-field change touches that map, not a parallel restatement.
  */
 
 import {EMPTY_REACTION_AGGREGATE} from "../reaction/Reaction.ts";
@@ -22,10 +13,8 @@ import type {Definition, Term} from "./views.ts";
 
 export type {DefinitionRow};
 
-// `toTerm`'s input is the map-derived `TermSummaryRow` (the intrinsic wire-named
-// fields) — not a parallel interface — so the wire shaper's field set can't drift
-// from the row mapper (`toTermSummaryRow`) or `termViewFields`. `id` === `slug`
-// (the client's normalization key for a term is its slug).
+// Input is the map-derived `TermSummaryRow`, not a parallel interface, so the wire shaper's
+// field set can't drift from `toTermSummaryRow` or `termViewFields`. `id` === `slug`.
 export const toTerm = (r: TermSummaryRow): Term => ({
 	__typename: "Term",
 	id: r.id,
@@ -41,12 +30,9 @@ export const toTerm = (r: TermSummaryRow): Term => ({
 	lastActivityAt: r.lastActivityAt,
 });
 
-/**
- * Map a detail `TermPage` onto the `Term` wire entity — shared by the read
- * resolver (`queries.term`) and the delete-refresh so they can't drift. The
- * detail page has no `excerpt`, derives `firstLetter` from title/slug, and uses
- * `totalDefinitions` for both counts; `lastActivityAt` mirrors `lastEdit`.
- */
+// Shared by the read resolver and the delete-refresh so they can't drift. The detail page has
+// no `excerpt`, derives `firstLetter` from title/slug, and uses `totalDefinitions` for both
+// counts; `lastActivityAt` mirrors `lastEdit`.
 export const toTermFromPage = (page: TermPage): Term =>
 	toTerm({
 		id: page.slug,
@@ -62,11 +48,8 @@ export const toTermFromPage = (page: TermPage): Term =>
 		lastActivityAt: page.lastEdit,
 	});
 
-// `toDefinition`'s input is the map-derived `DefinitionRow` (the intrinsic
-// wire-named fields + the optional `myVote` viewer scalar) — not a parallel
-// interface — so the wire shaper's field set can't drift from the row mapper
-// (`toDefinitionRow`) or `definitionViewFields`. This stamps `__typename` + the
-// `myVote` viewer-scalar default onto the map's already-wire-named values.
+// Input is the map-derived `DefinitionRow`, not a parallel interface, so the wire shaper's
+// field set can't drift from `toDefinitionRow` or `definitionViewFields`.
 export const toDefinition = (r: DefinitionRow): Definition => ({
 	__typename: "Definition",
 	id: r.id,

--- a/apps/web/worker/features/sozluk/sources.ts
+++ b/apps/web/worker/features/sozluk/sources.ts
@@ -1,9 +1,7 @@
 /**
- * Sözlük fate sources — `Term` / `Definition` Effect-backed loaders. fate is
- * pure transport (ADR 0016); every handler delegates to a `Sozluk` method. Only
- * `byId`/`byIds` are implemented (the relation workhorse that avoids the N+1);
- * connections come from custom resolvers (ADR 0019). Reads are silent and
- * `E = never` — see `.patterns/fate-effect-sources.md`.
+ * Sözlük fate sources — `Term` / `Definition` Effect-backed loaders. fate is pure transport (ADR
+ * 0016); every handler delegates to a `Sozluk` method. Only `byId`/`byIds` are implemented (the
+ * relation workhorse that avoids the N+1); connections come from custom resolvers (ADR 0019).
  */
 import {Fate} from "@kampus/fate-effect";
 import {PHOENIX_SOZLUK_STAMP_WAVE} from "../../../src/flags/keys.ts";
@@ -22,8 +20,7 @@ export const definitionSource = Fate.source(
 			const sozluk = yield* Sozluk;
 			const sandboxViewer = yield* currentSandboxViewer;
 			const mutedIds = yield* currentMutedIds;
-			// The read-path collapse is contained behind its default-off flag (#2709): off ⇒
-			// the stamps run serially (today), on ⇒ one concurrent wave. Same wire output.
+			// #2709: off ⇒ the stamps run serially, on ⇒ one concurrent wave. Same wire output.
 			const flags = yield* Flags;
 			const parallelStamps = yield* flags
 				.getBoolean(PHOENIX_SOZLUK_STAMP_WAVE, false)

--- a/apps/web/worker/features/sozluk/sozluk-reconcile-cron.ts
+++ b/apps/web/worker/features/sozluk/sozluk-reconcile-cron.ts
@@ -3,32 +3,14 @@
  * periodically re-runs the recomputable-cache refresh for every sözlük term, so a term/stat
  * left stale by a SWALLOWED last-write refresh is eventually re-converged.
  *
- * The gap it closes (#2558): the remove/restore + create ceremony swallows-and-logs a
- * cache-refresh die (`swallowRefresh`, #2012/#1639 — the substrate write already committed,
- * so a recomputable-cache die must not 500 the request). That swallow is correct and stays.
- * But the convergence contract is only "heals on the NEXT write", and no reconciliation job
- * existed — so a low-traffic term whose LAST write's refresh died stayed stale indefinitely
- * (wrong count/excerpt, stale `term_search` FTS row), on exactly the corners nobody revisits
- * and invisible to Sentry (the failure was swallowed). This backstop is ADDITIVE: the request
- * path is untouched.
+ * The gap it closes: `swallowRefresh` (#2012) makes the convergence contract "heals on the
+ * NEXT write", so a low-traffic term whose LAST write's refresh died stayed stale forever —
+ * and invisibly, since the failure was swallowed.
  *
- * The mechanism is alchemy's idiomatic scheduled-worker seam (`Cloudflare.cron(expr, handler)`,
- * beta.59), the SAME substrate the sıcak/hot decay refresh rides (`hot-score-decay-cron.ts`) —
- * not a new bespoke scheduler. Two crons coexist cleanly: each `cron()` attaches its own
- * `Cron(<expr>)` binding, and the runtime `scheduled` listener dispatches by
- * `controller.cron === expression`, so the 15-minute decay tick runs only the decay and this
- * 6-hourly tick runs only the reconcile (`CronEventSource.ts`).
- *
- * Cadence + strategy (#2558 AC4): every 6 hours, a FULL sweep — `Sozluk.reconcileCaches`
- * re-runs `persistTermSummary` for every `term_record` row (slug-keyset chunked, bounded scan)
- * plus one `recomputeSozlukStats`. A full re-run (not sampled, not failure-flagged) is the
- * simplest correct backstop: there is no persisted "refresh failed" flag to target — adding one
- * would put a write back on the swallow path the #2012 trade deliberately keeps clean — and
- * `persistTermSummary` is a pure convergent fold, so re-running it on an already-fresh term
- * rewrites the identical row. A full sweep is therefore idempotent and self-correcting with no
- * failure bookkeeping. Six hours is far coarser than hot-decay's 15 minutes because staleness
- * here is a rare long-tail event (a refresh die on a term's LAST write), not a continuous drift,
- * and each pass rewrites every term row.
+ * The sweep is deliberately FULL, not sampled or failure-flagged: there is no persisted
+ * "refresh failed" flag to target, and adding one would put a write back on the swallow
+ * path #2012 keeps clean. `persistTermSummary` is a convergent fold, so re-running it on a
+ * fresh term rewrites the identical row — idempotent, with no failure bookkeeping.
  */
 import * as Cloudflare from "alchemy/Cloudflare";
 import * as Effect from "effect/Effect";
@@ -39,12 +21,8 @@ import {Sozluk} from "./Sozluk.ts";
 export const SOZLUK_RECONCILE_CRON = "0 */6 * * *";
 
 /**
- * The worker-init effect that subscribes the reconciliation sweep to the cron trigger.
- * `fateLayer` is the built worker context (`makeFateRuntime`'s `contextLayer`) carrying
- * `Sozluk`; the handler runs `Sozluk.reconcileCaches` at the controller's scheduled instant (so
- * the pass's clock is the trigger's, not a fresh `Date.now()`). `CronEventSource` already
- * swallows handler failures (`Effect.catchCause`), so a bad pass never crashes the scheduled
- * invocation. `subscribe` only registers a listener (no async/timer work), so it is init-safe.
+ * The pass's clock is the controller's scheduled instant, not a fresh `Date.now()`.
+ * Registering a listener does no async/timer work, so this is init-safe.
  */
 export const subscribeSozlukReconcile = (fateLayer: Layer.Layer<Sozluk>) =>
 	Cloudflare.cron(SOZLUK_RECONCILE_CRON, (controller) =>

--- a/apps/web/worker/features/sozluk/sozluk-reconcile-scan.unit.test.ts
+++ b/apps/web/worker/features/sozluk/sozluk-reconcile-scan.unit.test.ts
@@ -1,15 +1,11 @@
 /**
- * The backstop-reconciliation keyset-chunk sweep (`scanReconcileChunks`, #2558), unit-reachable
- * over in-memory ports — the cursor-advance + full-coverage control flow is wrong-or-right with
- * no SQL engine (ADR 0082 litmus), so it is driven here over a JS-array table, never real D1.
- * The real-D1 chunk EXECUTION (the paged walk over `term_record` + the actual re-convergence of
- * a term left stale by a swallowed refresh) stays integration-tier (`sozluk-cache-reconcile.test.ts`).
+ * The backstop-reconciliation keyset-chunk sweep (`scanReconcileChunks`, #2558): the
+ * cursor-advance + full-coverage control flow is wrong-or-right with no SQL engine
+ * (ADR 0082), so it is driven over a JS-array table. Real-D1 chunk EXECUTION stays
+ * integration-tier (`sozluk-cache-reconcile.test.ts`).
  *
- * The two properties this guards, both the point of #2558's bounded full sweep:
- *   - FULL coverage: the sweep visits EVERY term across its pages, so a term beyond the first
- *     chunk is still re-refreshed — chunking is not a recency/subset window.
- *   - BOUNDED pages: each `fetchChunk` asks for at most `chunkSize` rows and resumes at a cursor
- *     strictly past the previous page's last slug — no single unbounded scan.
+ * Two properties: FULL coverage (a term beyond the first chunk is still refreshed —
+ * chunking is not a recency window) and BOUNDED pages (no single unbounded scan).
  */
 import {assert, describe, it} from "@effect/vitest";
 import {Effect} from "effect";
@@ -19,17 +15,13 @@ const term = (slug: string): TermRef => ({slug, title: slug});
 
 interface Harness {
 	readonly ports: SozlukReconcileScanPorts;
-	/** Every `fetchChunk(afterSlug, limit)` call, in order — the paging trace. */
 	readonly fetchCalls: Array<{afterSlug: string | null; limit: number}>;
-	/** Every slug passed to `refreshTerm`, across all pages — the coverage trace. */
 	readonly refreshed: string[];
 }
 
 /**
- * In-memory ports over a fixed, slug-sorted table: `fetchChunk` serves the keyset page
- * (`slug > afterSlug`, capped at `limit`) and records the cursor + limit it was asked for;
- * `refreshTerm` records every re-refreshed slug. This is the exact contract `reconcileCaches`
- * wires D1 into — so the driver's paging behavior is proven without a database.
+ * In-memory ports over a fixed, slug-sorted table — the exact contract `reconcileCaches`
+ * wires D1 into, so the driver's paging behavior is proven without a database.
  */
 function harness(table: ReadonlyArray<string>): Harness {
 	const sorted = [...table].sort((a, b) => (a < b ? -1 : a > b ? 1 : 0));
@@ -73,8 +65,7 @@ describe("scanReconcileChunks — keyset-chunks the full reconciliation sweep (#
 			const h = harness(["a", "b", "c", "d", "e"]);
 			yield* scanReconcileChunks(h.ports, 2);
 
-			// Pages of [a,b],[c,d],[e] — the short third page (1 < 2) marks the tail, so no fourth
-			// fetch. Each call asks for at most `chunkSize`, resuming at the prior last slug.
+			// Pages of [a,b],[c,d],[e] — the short third page marks the tail, so no fourth fetch.
 			assert.deepStrictEqual(
 				h.fetchCalls,
 				[

--- a/apps/web/worker/features/sozluk/term-fields.ts
+++ b/apps/web/worker/features/sozluk/term-fields.ts
@@ -1,21 +1,11 @@
 /**
- * `Term`'s one column→field map — the single structure the row mapper
- * (`toTermSummaryRow`), the wire shaper (`toTerm` in `shapers.ts`), and the view
- * field declaration (`TermView` in `views.ts`) all derive from, so a one-field
- * change touches this map instead of three hand-synced restatements (#1544, the
- * sözlük slice of the fate-wire collapse #1332; the `Term` mirror of
- * `definition-fields.ts`).
- *
- * The map absorbs `Term`'s per-source naming divergence: the `term_record`
- * projection names the count `definitionCount` and the last-edit `lastEditAt`,
- * while the wire carries `count` (mirrored by `definitionCount`), `lastEdit`, and
- * an `id` that IS the slug (a term's client normalization key). Each intrinsic
- * field carries a reader that maps a `TermSummarySelection` row onto its wire
- * value, so the divergence lives in the map, not at every call site.
+ * `Term`'s one column→field map — the row mapper, the wire shaper, and the view field
+ * declaration all derive from it, so a one-field change lands in one place. It also
+ * absorbs the record/wire naming divergence (`definitionCount`→`count`,
+ * `lastEditAt`→`lastEdit`, and an `id` that IS the slug).
  */
 import * as schema from "../../db/drizzle/schema.ts";
 
-// Pass to `db.select(...)`; pairs with `toTermSummaryRow`.
 export const termSummaryColumns = {
 	slug: schema.termRecord.slug,
 	title: schema.termRecord.title,
@@ -40,12 +30,7 @@ export interface TermSummarySelection {
 	lastEditAt: Date | null;
 }
 
-/**
- * The intrinsic (record-derived) wire fields, in `TermView` order, each mapping a
- * `TermSummarySelection` row onto its wire value. The keys ARE the wire field
- * names; the readers absorb the `definitionCount`→`count`, `lastEditAt`→`lastEdit`,
- * and slug-as-`id` divergence.
- */
+/** The keys ARE the wire field names, in `TermView` order. */
 const intrinsicFields = {
 	id: (r) => r.slug,
 	slug: (r) => r.slug,
@@ -60,7 +45,6 @@ const intrinsicFields = {
 	lastActivityAt: (r) => r.lastActivityAt,
 } satisfies Record<string, (r: TermSummarySelection) => unknown>;
 
-/** The record-derived row: every reader's return type under its wire field name. */
 export type TermSummaryRow = {
 	[K in keyof typeof intrinsicFields]: ReturnType<(typeof intrinsicFields)[K]>;
 };
@@ -73,13 +57,9 @@ export interface TermConnectionPage {
 }
 
 /**
- * The view/wire field selection (`{id: true, …}`) — a static literal (fate's
- * `FateDataView` reads the literal field map off this, so it can't be a
- * dynamically-built object). `satisfies Record<keyof TermSummaryRow, true>` pins
- * it to exactly the row's fields: dropping a field here (or adding one to the row
- * type without listing it) is a compile error, so the view stays in lockstep with
- * the row mapper. `definitions` is the list relation, declared structurally in
- * `views.ts` (no record column to collapse from).
+ * Must stay a static literal — fate's `FateDataView` reads the field map off it, so it
+ * cannot be built dynamically. The `satisfies` pins it to exactly the row's fields, so a
+ * missing or extra field is a compile error rather than a silent wire drift.
  */
 export const termViewFields = {
 	id: true,
@@ -95,11 +75,6 @@ export const termViewFields = {
 	lastActivityAt: true,
 } as const satisfies Record<keyof TermSummaryRow, true>;
 
-/**
- * Map a `term_record` projection row onto its `TermSummaryRow` fields by running
- * every reader in the column→field map — the single place the record→row mapping
- * lives.
- */
 export const toTermSummaryRow = (r: TermSummarySelection): TermSummaryRow =>
 	Object.fromEntries(
 		(Object.keys(intrinsicFields) as Array<keyof typeof intrinsicFields>).map((f) => [

--- a/apps/web/worker/features/sozluk/term-list-sandbox.unit.test.ts
+++ b/apps/web/worker/features/sozluk/term-list-sandbox.unit.test.ts
@@ -1,17 +1,11 @@
 /**
- * `Sozluk.listTermSummariesConnection` sandbox-visibility wiring (#3724) — the security
- * fix for the /sozluk root lists (`terms` / `recentTerms` / `popularTerms`). The list
- * selects from `term_record`, a summary cache with no lifecycle columns of its own, so
- * visibility must be derived from the definitions it summarizes: BOTH the page query and
- * `totalCount` carry an `EXISTS` over `definition_record` masked by `publicLiveWhere`.
- * Without it a çaylak's sandbox-only term lands at the top of the anonymous /sozluk front
- * door and its term page renders zero definition cards (#1205/#1424).
+ * `Sozluk.listTermSummariesConnection` sandbox-visibility wiring. `term_record` is a
+ * summary cache with no lifecycle columns, so visibility has to be derived from the
+ * definitions it summarizes — without that, a çaylak's sandbox-only term lands at the top
+ * of the anonymous /sozluk front door.
  *
- * Unit-tier per ADR 0082: row-level filtering is integration's job; what THIS proves is
- * that both reads WIRE the mask in, and that it is viewer-aware (the author's own arm
- * appears only for a signed-in viewer, and a moderator drops the sandbox arm entirely).
- * The compiled SQL is captured off a substituted `Drizzle` seam that renders each
- * builder's `.toSQL()` (the `Sozluk.connection.unit.test.ts` scripted-access idiom).
+ * Unit-tier per ADR 0082: row-level filtering is integration's job, so what this proves
+ * is only that both reads wire the mask in and that it is viewer-aware.
  */
 import {assert, describe, it} from "@effect/vitest";
 import {drizzle} from "drizzle-orm/d1";
@@ -27,10 +21,10 @@ const hasToSQL = (v: unknown): v is {toSQL: () => {sql: string; params: unknown[
 	typeof v === "object" && v !== null && typeof (v as {toSQL?: unknown}).toSQL === "function";
 
 /**
- * The two reads land on DIFFERENT capture surfaces, which is why this harness has two.
- * The page read hands `run` the un-awaited builder, so it renders via `.toSQL()`. The
- * `totalCount` read finalizes inside the callback (`.get().then(…)`), so `run` only ever
- * sees a promise — its SQL is recoverable solely at the D1 binding, off `prepare`/`bind`.
+ * Two capture surfaces, because the two reads land differently: the page read hands `run`
+ * an un-awaited builder that renders via `.toSQL()`, while `totalCount` finalizes inside
+ * its callback, so `run` sees only a promise and its SQL is recoverable solely at the D1
+ * binding.
  */
 function scriptedAccess(results: ReadonlyArray<unknown>): {
 	access: DrizzleAccess;
@@ -97,7 +91,6 @@ const sozlukLayer = (access: DrizzleAccess) =>
 		Layer.provide(Layer.succeed(Drizzle, access)),
 	);
 
-/** The connection's two rendered reads: the masked `totalCount` and the masked page. */
 const runList = (opts: {
 	sort?: ListSort;
 	after?: string;
@@ -137,7 +130,6 @@ describe("Sozluk.listTermSummariesConnection — the /sozluk lists exclude sandb
 			assert.match(page, EXISTS_OVER_DEFINITIONS, "correlated EXISTS over definition_record");
 			assert.match(page, /"definition_record"\."removed_at" is null/, "removal guard present");
 			assert.match(page, /"definition_record"\."sandboxed_at" is null/, "sandbox mask present");
-			// Never the inverted mask — that would show ONLY the sandboxed terms.
 			assert.notMatch(page, /sandboxed_at" is not null/, "mask is IS NULL, never IS NOT NULL");
 		}),
 	);

--- a/apps/web/worker/features/sozluk/views.ts
+++ b/apps/web/worker/features/sozluk/views.ts
@@ -1,10 +1,7 @@
 /**
- * Sözlük fate data views — `Term`, `Definition` (ADR 0018; see
- * `.patterns/fate-effect-data-views.md`).
- *
- * `Term.definitions`' `orderBy` and the service's term-page keyset both derive
- * from `DEFINITION_ORDERING` (`ordering.ts`), so they can't drift (ADR 0019; see
- * `.patterns/fate-connections.md`).
+ * Sözlük fate data views (ADR 0018/0019; see `.patterns/fate-effect-data-views.md` and
+ * `.patterns/fate-connections.md`). Everything derives from one source so the view and
+ * the service keyset can't drift.
  */
 import {FateDataView, type WorkerEntity} from "@kampus/fate-effect";
 import {viewOrderBy} from "../../db/ordering.ts";
@@ -14,24 +11,18 @@ import {DEFINITION_ORDERING} from "./ordering.ts";
 import type {DefinitionRow} from "./Sozluk.ts";
 import {type TermSummaryRow, termViewFields} from "./term-fields.ts";
 
-// Mapped restatements of the service rows so they're `Record<string, unknown>`-
-// assignable (the plain row interfaces are not). Exported because the
-// `Fate.source` entries surface the row type in their declarations (TS2883).
+// Mapped restatements so the rows are `Record<string, unknown>`-assignable (the plain row
+// interfaces are not). Exported because `Fate.source` surfaces the row type (TS2883).
 export type DefinitionViewRow = ViewRow<DefinitionRow>;
 export type TermViewRow = ViewRow<TermSummaryRow>;
 
-// The field list derives from `definition-fields.ts`'s column→field map, so it
-// can't drift from the row mapper / wire shaper (#1126 AC#1).
 export class DefinitionView extends FateDataView<DefinitionViewRow>()("Definition")(
 	definitionViewFields,
 ) {}
 
 /**
- * `Term` — a dictionary headword. The scalar fields derive from
- * `term-fields.ts`'s column→field map, so they can't drift from the row mapper /
- * wire shaper (#1544). The view is over `TermSummaryRow`; the detail-page
- * `term(slug)` resolver reshapes its `TermPage` into the same shape.
- * `definitions.orderBy` derives from `DEFINITION_ORDERING` (ADR 0019).
+ * The view is over `TermSummaryRow`; the detail-page `term(slug)` resolver reshapes its
+ * `TermPage` into the same shape.
  */
 export class TermView extends FateDataView<TermViewRow>()("Term")({
 	...termViewFields,

--- a/apps/web/worker/features/stats/Stats.ts
+++ b/apps/web/worker/features/stats/Stats.ts
@@ -1,11 +1,7 @@
 /**
- * Stats — the landing-page aggregate service. One read-only method,
- * `getLandingStats`, returns the SPA's four counters: three from per-product
- * single-row tables (`sozluk_stats`, `pano_stats`, maintained inline by the
- * feature services), the fourth a distinct-author UNION across the record tables.
- *
- * Reads go through `run`/`orDieAccess`, so infra failures die here (the
- * domain-boundary rule) and the public signature carries no error.
+ * Stats — the landing-page aggregate service. Three counters come from the per-product
+ * single-row tables the feature services maintain; the fourth is a distinct-author UNION
+ * across the record tables.
  */
 import {sql} from "drizzle-orm";
 import {Context, Effect, Layer} from "effect";
@@ -35,8 +31,7 @@ export const StatsLive = Layer.effect(Stats)(
 
 		return {
 			getLandingStats: Effect.fn("Stats.getLandingStats")(function* () {
-				// The single-row tables can be missing on a fresh DB — coalesce to
-				// zero (below) so the resolver always has a non-null shape.
+				// The single-row tables can be missing on a fresh DB, hence the coalesce below.
 				const sozlukRow = yield* run((db) =>
 					db
 						.run(sql`SELECT total_definitions FROM sozluk_stats WHERE id = 1`)
@@ -50,12 +45,9 @@ export const StatsLive = Layer.effect(Stats)(
 								(r.results[0] as {total_posts: number; total_comments: number} | undefined) ?? null,
 						),
 				);
-				// Distinct-author UNION across the record tables: cheaper than reading
-				// both per-product `total_authors` columns, since neither is a strict
-				// subset of the other. Each arm sources the public-live filter from the
-				// shared seam (#1359/#1407) for the anonymous viewer — definition/comment
-				// via `publicLiveWhere` (removed + sandbox), the post arm via the
-				// post-aware `publicLivePostWhere` so a draft-only author is excluded too.
+				// A UNION rather than summing the per-product `total_authors` columns, since
+				// neither is a strict subset of the other. The post arm uses the post-aware
+				// `publicLivePostWhere` so a draft-only author is excluded too (#1359/#1407).
 				const defWhere = publicLiveWhere(
 					{
 						removedAt: schema.definitionRecord.removedAt,

--- a/apps/web/worker/features/stats/landing-stats-authors-sandbox.unit.test.ts
+++ b/apps/web/worker/features/stats/landing-stats-authors-sandbox.unit.test.ts
@@ -1,21 +1,8 @@
 /**
- * `Stats.getLandingStats` author-UNION public-live wiring (#1407, subsuming #1391).
- * The public landing `totalAuthors` counter is a distinct-author UNION across the
- * three record tables; every arm must reflect LIVE content only, so a çaylak with
- * only sandboxed rows — and a pano author with only draft posts — must NOT count.
- *
- * #1407 folds this onto the shared visibility seam: each arm now sources its filter
- * from `publicLiveWhere`/`publicLivePostWhere` for the anonymous viewer instead of a
- * hand-written `removed_at IS NULL AND sandboxed_at IS NULL` clause (#1391's point
- * fix, now replaced — not layered). For the anonymous viewer `publicLiveWhere`
- * reduces to removed+sandbox, and the post arm's `publicLivePostWhere` adds the
- * draft exclusion, so the post arm carries `is_draft IS NOT 1` on top.
- *
  * Unit-tier per ADR 0082: row-level filtering is the integration tier's job; what
- * THIS test proves is that the author UNION WIRES the seam predicate into every arm.
- * The counter reads resolve through `db.run(sql).then()` (a Promise, no `.toSQL()`),
- * so the compiled SQL is captured off a RECORDING D1 binding whose `prepare(sql)`
- * records every executed statement.
+ * THIS test proves is that the author UNION WIRES the public-live seam predicate
+ * into every arm. The counter reads resolve through `db.run(sql).then()` (a Promise,
+ * no `.toSQL()`), so the compiled SQL is captured off a RECORDING D1 binding.
  */
 import {assert, describe, it} from "@effect/vitest";
 import {Effect, Layer} from "effect";
@@ -26,9 +13,6 @@ interface RecordedQuery {
 	sql: string;
 }
 
-// A D1 binding that records the SQL of every statement it EXECUTES. `getLandingStats`
-// issues three `db.run(sql).then()` reads (sozluk row, pano row, author UNION); each
-// executes here, so its compiled SQL lands in `recorded`.
 function recordingD1(): {binding: D1Database; recorded: RecordedQuery[]} {
 	const recorded: RecordedQuery[] = [];
 	// biome-ignore lint/plugin: `D1Database` is a host binding that can't be structurally constructed; only SQL compilation is exercised, results are inert.
@@ -61,8 +45,7 @@ function recordingD1(): {binding: D1Database; recorded: RecordedQuery[]} {
 	return {binding, recorded};
 }
 
-// Drive `getLandingStats` over a recording binding; return the one recorded statement
-// that is the distinct-author UNION (the only read that references `author_id`).
+// The distinct-author UNION is the only recorded read that references `author_id`.
 const recordAuthorUnion = Effect.gen(function* () {
 	const {binding, recorded} = recordingD1();
 	const access = makeDrizzleAccess(createDrizzle(binding));
@@ -79,9 +62,6 @@ describe("Stats.getLandingStats — public totalAuthors excludes sandbox-only/dr
 	it.effect("every UNION arm sources the public-live filter from the shared seam", () =>
 		Effect.gen(function* () {
 			const sql = (yield* recordAuthorUnion).toLowerCase();
-			// One arm per content table; each carries BOTH the removed and the sandbox
-			// guard (the seam's anonymous-viewer reduction), so a sandbox-only author
-			// drops out of every arm ⇒ out of the distinct-author count.
 			const removed = sql.match(/"removed_at" is null/g) ?? [];
 			const sandboxed = sql.match(/"sandboxed_at" is null/g) ?? [];
 			assert.strictEqual(removed.length, 3, "all three arms carry the removed_at guard");
@@ -95,8 +75,6 @@ describe("Stats.getLandingStats — public totalAuthors excludes sandbox-only/dr
 	it.effect("the post arm additionally excludes drafts (draft-only author not counted)", () =>
 		Effect.gen(function* () {
 			const sql = (yield* recordAuthorUnion).toLowerCase();
-			// The post-aware seam (`publicLivePostWhere`) adds the draft gate, so a pano
-			// author whose only post is an unpublished draft contributes no author_id.
 			assert.include(sql, `"post_record"."is_draft" is not 1`);
 		}),
 	);
@@ -104,8 +82,8 @@ describe("Stats.getLandingStats — public totalAuthors excludes sandbox-only/dr
 	it.effect("a live author still counts — no arm inverts the sandbox mask", () =>
 		Effect.gen(function* () {
 			const sql = (yield* recordAuthorUnion).toLowerCase();
-			// The mask is `sandboxed_at IS NULL` (keep live), never `IS NOT NULL` (which
-			// would invert it and drop the live authors the counter is meant to count).
+			// `IS NOT NULL` would invert the mask and drop the live authors this counter
+			// exists to count.
 			assert.notInclude(sql, "sandboxed_at is not null");
 			assert.match(sql, /count\(distinct author_id\)/, "still a distinct-author count");
 		}),
@@ -113,12 +91,9 @@ describe("Stats.getLandingStats — public totalAuthors excludes sandbox-only/dr
 });
 
 describe("Stats.getLandingStats — the author counter's UNION structure (#2031, AC4)", () => {
-	// Guards the query SHAPE the prior suite doesn't: three arms combined by `UNION`
-	// (deduplicating, not `UNION ALL`), one per record table in a fixed order, wrapped in
-	// a `COUNT(DISTINCT author_id)` subquery. Distinct from the rendered-string guard
-	// checks above (which assert the per-arm filters are wired): this asserts the arms
-	// compose into the intended set operation, so a regression that dropped an arm, split
-	// the count across separate reads, or swapped `UNION`→`UNION ALL` fails here.
+	// The suite above asserts the per-arm filters are wired; this one asserts the arms
+	// compose into the intended set operation, so a dropped arm, a count split across
+	// separate reads, or a `UNION`→`UNION ALL` swap fails here.
 	const flatten = (s: string) => s.replace(/\s+/g, " ").trim().toLowerCase();
 
 	it.effect("three arms are joined by two deduplicating UNION operators (not UNION ALL)", () =>

--- a/apps/web/worker/features/stats/queries.ts
+++ b/apps/web/worker/features/stats/queries.ts
@@ -1,11 +1,6 @@
 /**
- * Stats root query resolvers — `health`, `landingStats`
- * (`.patterns/fate-effect-operations.md`).
- *
- * `health` is string-typed (no data view by design) so it stays off `Root`
- * but still dispatches over the native transport. Both roots are anonymous
- * reads (no `CurrentUser`); infra failures die inside `Stats`, never reaching
- * this layer (`.patterns/feature-services.md`).
+ * Stats root query resolvers (`.patterns/fate-effect-operations.md`). Both are anonymous
+ * reads; `health` is string-typed by design so it stays off `Root`.
  */
 
 import {Fate} from "@kampus/fate-effect";
@@ -19,8 +14,7 @@ export interface Health {
 
 const PHOENIX_BUILD_VERSION = "v0.3";
 
-// Stable id for the singleton entity, so the client normalizes it to one cache
-// record (see views.ts).
+// Stable, so the client normalizes the singleton to one cache record.
 const LANDING_STATS_ID = "landing";
 
 export const queries = {
@@ -33,11 +27,9 @@ export const queries = {
 		}),
 	),
 	landingStats: Fate.query(
-		// Wire type-name STRING, not `LandingStatsView`: a view-typed query would
-		// make the entity view-reachable and trip source-completeness validation,
-		// but `LandingStats` is a synthetic singleton with no fetch path (the
-		// resolver is its only producer). Codegen is unchanged — the client root
-		// still types off `Root`'s `landingStatsDataView` + this handler.
+		// A type-name STRING, not `LandingStatsView`: a view-typed query would make the
+		// entity view-reachable and trip source-completeness validation, but this is a
+		// synthetic singleton whose only producer is the resolver below.
 		{type: "LandingStats"},
 		Effect.fn("landingStats")(function* () {
 			const stats = yield* Stats;

--- a/apps/web/worker/features/stats/views.ts
+++ b/apps/web/worker/features/stats/views.ts
@@ -1,9 +1,7 @@
 /**
- * `LandingStats` — the landing-page counters card, a standalone data view the
- * SPA reads with `useRequest`. The client normalizes by `record.id`, so the
- * entity carries a stable synthetic `id` (`"landing"`, stamped by
- * `queries.landingStats`) — there's only ever one row, so it collapses to a
- * single cache record. See `.patterns/fate-effect-data-views.md`.
+ * `LandingStats` — the landing-page counters card. The client normalizes by `record.id`, so
+ * the entity carries a stable synthetic `id` (`"landing"`); there is only ever one row.
+ * See `.patterns/fate-effect-data-views.md`.
  */
 import {FateDataView, type WorkerEntity} from "@kampus/fate-effect";
 import type {ViewRow} from "../fate/view-types.ts";
@@ -28,8 +26,6 @@ export class LandingStatsView extends FateDataView<LandingStatsViewRow>()("Landi
 	version: true,
 }) {}
 
-// The kernel view, for cross-feature surfaces wanting fate's plain `dataView()`
-// value (the `fate/views.ts` barrel + `Root`).
 export const landingStatsDataView = LandingStatsView.view;
 
 export type LandingStats = WorkerEntity<typeof LandingStatsView>;

--- a/apps/web/worker/features/telemetry/Telemetry.testing.ts
+++ b/apps/web/worker/features/telemetry/Telemetry.testing.ts
@@ -1,27 +1,11 @@
 /**
- * `Telemetry` test doubles for the instruments that emit through the seam (the
- * `Reaction.react`/`Vote.cast` reference instruments, ADR 0153 / #2068 / #2069).
- * An instrument's unit test substitutes the `Telemetry` tag directly
- * (`.patterns/effect-testing.md`) to assert WHICH event it emits, and to pin the
- * fail-safe (S4) — a telemetry failure never fails the mutation it observes.
- *
- *   - {@link recordingTelemetry} records every emitted event so a test asserts the
- *     exact `{feature, action, surface, emoji?}` shape (and its absence on a no-op).
- *   - {@link dyingTelemetry} makes `emit` DIE, so a test proves the instrument's
- *     write already committed before the (best-effort) emit — the emit is off the
- *     commit path. The production fail-safe (the `DatasetError` swallow) lives in
- *     `TelemetryLive` and is pinned in `Telemetry.unit.test.ts`; this double lets an
- *     instrument test show the emit's failure mode can't unwind the mutation.
+ * `Telemetry` test doubles (ADR 0153). The pinned invariant: a telemetry failure never
+ * fails the mutation it observes.
  */
 import {Effect, Layer} from "effect";
 import type {TelemetryEvent} from "./schema.ts";
 import {Telemetry} from "./Telemetry.ts";
 
-/**
- * A `Telemetry` whose `emit` records each event into `sink` and succeeds — the
- * recording double for asserting an instrument emitted the expected event (or, by
- * an empty `sink`, that it emitted nothing on a no-op).
- */
 export const recordingTelemetry = (sink: TelemetryEvent[]) =>
 	Layer.succeed(Telemetry, {
 		emit: (event) => {
@@ -31,11 +15,8 @@ export const recordingTelemetry = (sink: TelemetryEvent[]) =>
 	} satisfies typeof Telemetry.Service);
 
 /**
- * A `Telemetry` whose `emit` DIES — the misbehaving-emit double. `emit`'s
- * production type is `Effect<void>` (its channels are discharged in
- * `TelemetryLive`), so a real emit never fails; this double deliberately breaks
- * that to prove an instrument's commit is sequenced BEFORE the emit and is not
- * unwound by an emit that blows up.
+ * A real `emit` never fails (its channels are discharged in `TelemetryLive`); this double
+ * deliberately breaks that to prove an instrument's commit is sequenced BEFORE the emit.
  */
 export const dyingTelemetry = Layer.succeed(Telemetry, {
 	emit: () => Effect.die(new Error("telemetry emit must never fail the mutation it observes")),

--- a/apps/web/worker/features/telemetry/Telemetry.ts
+++ b/apps/web/worker/features/telemetry/Telemetry.ts
@@ -1,29 +1,11 @@
 /**
- * `Telemetry` service — the single product-usage telemetry seam (ADR 0153, epic
- * #2065). One narrow surface, `emit(event)`, that every instrument calls; the
- * service owns the fixed positional Analytics Engine event-schema internally so
- * no feature ever constructs a raw AE data point or names Analytics Engine.
+ * `Telemetry` — the single product-usage telemetry seam (ADR 0153, epic #2065). It
+ * owns the positional Analytics Engine event schema internally, so no feature ever
+ * constructs a raw AE data point or names Analytics Engine.
  *
- * Mirrors the `Flagship`/`Database` binding-as-service idiom (ADR 0028): the AE
- * write client is resolved ONCE per isolate in worker init (where the
- * `WriteDataset` binding is ambient) and carried on the {@link TelemetryClient}
- * seam — the `Database` tag-holds-the-resolved-handle idiom — so `TelemetryLive`'s
- * build-time R is just that client seam plus `RuntimeContext`, never the binding
- * graph (which never resolves at the fate runtime scope). Two channels are
- * discharged inside the layer so call-sites get a clean `Effect<void>`:
- *   - `writeDataPoint`'s ambient `RuntimeContext` requirement — captured once and
- *     `provideService`'d, the same pattern `LiveTopics.publish` uses (`index.ts`).
- *   - the WHOLE failure `Cause` — swallowed with a log (fire-and-forget
- *     best-effort). A telemetry failure — a typed `DatasetError` OR a *defect* —
- *     can NEVER fail the mutation it observes (ADR 0153 fail-safe invariant, S4).
- *     `Effect.ignoreCause` (not `Effect.ignore`) is what makes this a SEAM property:
- *     it discards defects and interruptions too, so `emit: Effect<void>` genuinely
- *     cannot fail OR die and every caller gets S4 by construction — no per-call-site
- *     `ignoreCause` an instrument must remember.
- *
- * The `Context.Service` + `Layer.effect` idiom is grounded in effect-smol
- * `LLMS.md` §"Writing Effect services" → "Context.Service" and
- * `.patterns/effect-context-service.md`.
+ * The AE write client is resolved ONCE per isolate in worker init (the `Database`
+ * binding-as-service idiom, ADR 0028) and carried on {@link TelemetryClient}, which
+ * keeps the binding graph out of the fate runtime's R, where it would never resolve.
  */
 
 import {RuntimeContext} from "alchemy";
@@ -31,14 +13,8 @@ import type * as Cloudflare from "alchemy/Cloudflare";
 import {Context, Effect, Layer} from "effect";
 import {type TelemetryEvent, toDataPoint} from "./schema.ts";
 
-/**
- * The init-resolved AE write client seam. Holds the `DatasetClient` resolved once
- * in worker init via `Cloudflare.AnalyticsEngine.WriteDataset(Events)` — where the
- * binding graph is ambient — and provided dependency-free to the fate runtime,
- * exactly as the `Database` tag holds the raw D1 handle (ADR 0040). Keeping the
- * binding resolution in init (not in `TelemetryLive`) is what keeps the fate
- * runtime's R free of `WorkerEnvironment`/`Worker`.
- */
+// Resolved in worker init, not in `TelemetryLive` — that is what keeps the fate
+// runtime's R free of `WorkerEnvironment`/`Worker` (ADR 0040).
 export class TelemetryClient extends Context.Service<
 	TelemetryClient,
 	Cloudflare.AnalyticsEngine.DatasetClient
@@ -47,22 +23,13 @@ export class TelemetryClient extends Context.Service<
 export class Telemetry extends Context.Service<
 	Telemetry,
 	{
-		/**
-		 * Record one product-usage event. Fire-and-forget best-effort: no error and
-		 * no requirement channel at the call-site (both discharged in the layer), so
-		 * a telemetry failure never surfaces to — or fails — the caller (ADR 0153).
-		 */
+		// Fire-and-forget: both channels are discharged in the layer, so a telemetry
+		// failure can never fail the caller (ADR 0153).
 		readonly emit: (event: TelemetryEvent) => Effect.Effect<void>;
 	}
 >()("@kampus/worker/Telemetry") {}
 
-/**
- * The isolate-level `Telemetry` layer. Resolves the init-provided
- * {@link TelemetryClient} and captures `RuntimeContext` at build; both are
- * discharged inside `emit` so its own error and requirement channels are empty
- * (`Effect<void>`). No finalizer: a Cloudflare binding is not a worker-owned
- * resource.
- */
+// No finalizer: a Cloudflare binding is not a worker-owned resource.
 export const TelemetryLive = Layer.effect(
 	Telemetry,
 	Effect.gen(function* () {
@@ -72,13 +39,10 @@ export const TelemetryLive = Layer.effect(
 			emit: (event) =>
 				client.writeDataPoint(toDataPoint(event)).pipe(
 					Effect.provideService(RuntimeContext, runtimeContext),
-					// Swallow-with-log the WHOLE Cause: telemetry is best-effort, never a
-					// source of truth, and must not fail the mutation it observes (ADR 0153
-					// S4). `ignoreCause` (not `ignore`) discards defects/interruptions too,
-					// so a DEFECT thrown inside emit — a sync throw in `writeDataPoint`, an
-					// `orDie`, a `toDataPoint` bug — is contained AT THE SEAM. That makes S4
-					// a property of the seam for every instrument, so callers emit BARE and
-					// never repeat a call-site `ignoreCause` (ADR 0153, #2085).
+					// `ignoreCause`, NOT `ignore`: it discards defects and interruptions too,
+					// so a defect thrown inside emit is contained AT THE SEAM and telemetry
+					// can never fail the mutation it observes. That makes the fail-safe a
+					// property of the seam, so instruments emit BARE (ADR 0153 S4, #2085).
 					Effect.ignoreCause({log: "Warn"}),
 				),
 		});

--- a/apps/web/worker/features/telemetry/Telemetry.unit.test.ts
+++ b/apps/web/worker/features/telemetry/Telemetry.unit.test.ts
@@ -1,19 +1,9 @@
 /**
- * `Telemetry` unit coverage (ADR 0153, #2067) — the decisions that are wrong-or-
- * right with no database and no real Analytics Engine (ADR 0082). Two facts:
- *
- *   1. the fixed positional `TelemetryEvent -> DataPoint` map (`toDataPoint`)
- *      lands each field in its exact slot — the guard against the silent
- *      column-misalignment failure AE's positional schema makes possible;
- *   2. the fail-safe (S4) invariant — a `DatasetError` from the underlying write
- *      client is discharged INSIDE `TelemetryLive`, so `emit` still succeeds
- *      (`Effect.void`) and never surfaces an error to its caller.
- *
- * The AE client seam is substituted directly at the `TelemetryClient` tag
- * (`.patterns/effect-testing.md`): a recording client to inspect the mapped data
- * point, and a failing client to prove the swallow. No real AE, and the emit path
- * carries no `R` (both channels discharged in the layer), so both run at the
- * `unit` tier.
+ * `Telemetry` unit coverage (ADR 0153, #2067), with the AE client substituted at the
+ * `TelemetryClient` tag. Two facts: the fixed positional `TelemetryEvent -> DataPoint` map lands
+ * each field in its exact slot (AE's positional schema makes column-misalignment silent), and the
+ * S4 fail-safe — a failure from the write client is discharged INSIDE `TelemetryLive`, so `emit`
+ * never surfaces an error to its caller.
  */
 import {assert, describe, it} from "@effect/vitest";
 import {RuntimeContext} from "alchemy";
@@ -22,9 +12,8 @@ import {Effect, Exit, Layer} from "effect";
 import {toDataPoint} from "./schema.ts";
 import {Telemetry, TelemetryClient, TelemetryLive} from "./Telemetry.ts";
 
-// An inert `RuntimeContext` — the ambient context `writeDataPoint` needs, captured
-// by the layer at build. The substitute clients below ignore it, so a stub with
-// no-op accessors is enough to build the layer.
+// The ambient context `writeDataPoint` needs, captured by the layer at build; the substitute
+// clients ignore it.
 const inertRuntimeContext = Layer.succeed(RuntimeContext)({
 	Type: "telemetry-test",
 	id: "telemetry-test",
@@ -33,8 +22,6 @@ const inertRuntimeContext = Layer.succeed(RuntimeContext)({
 	set: (id: string) => Effect.succeed(id),
 });
 
-// A `TelemetryClient` whose `writeDataPoint` records the mapped data point — so a
-// test can assert the exact `{indexes, blobs, doubles}` `emit` produced.
 const recordingClient = (sink: Cloudflare.AnalyticsEngine.DataPoint[]) =>
 	Layer.succeed(TelemetryClient)(
 		TelemetryClient.of({
@@ -46,8 +33,6 @@ const recordingClient = (sink: Cloudflare.AnalyticsEngine.DataPoint[]) =>
 		}),
 	);
 
-// A `TelemetryClient` whose `writeDataPoint` always fails with a `DatasetError` —
-// drives the S4 fail-safe proof: `emit` must still succeed.
 const failingClient = Layer.succeed(TelemetryClient)(
 	TelemetryClient.of({
 		raw: Effect.die(new Error("raw unused")),
@@ -61,10 +46,8 @@ const failingClient = Layer.succeed(TelemetryClient)(
 	}),
 );
 
-// A `TelemetryClient` whose `writeDataPoint` DIES (a defect, not a typed error) —
-// drives the seam-contains-a-defect proof (#2085): `emit` must still succeed even
-// though a defect slipped into the emit path, because the seam swallows the whole
-// Cause (`Effect.ignoreCause`), not just the typed `E` (`Effect.ignore`).
+// A DEFECT, not a typed error (#2085): the seam swallows the whole Cause (`Effect.ignoreCause`),
+// not just the typed `E` (`Effect.ignore`).
 const dyingClient = Layer.succeed(TelemetryClient)(
 	TelemetryClient.of({
 		raw: Effect.die(new Error("raw unused")),
@@ -161,9 +144,7 @@ describe("Telemetry.emit", () => {
 	it.effect(
 		"contains a DEFECT in the write path — emit still succeeds (seam-level S4, #2085)",
 		() =>
-			// The whole point of moving containment into the seam: a defect (a die, a sync
-			// throw) inside emit must NOT propagate to the caller. `Effect.ignore` would let
-			// this exit die; `Effect.ignoreCause` swallows the whole Cause, so emit succeeds.
+			// `Effect.ignore` would let this exit die; `Effect.ignoreCause` swallows the whole Cause.
 			Effect.gen(function* () {
 				const telemetry = yield* Telemetry;
 				const exit = yield* Effect.exit(

--- a/apps/web/worker/features/telemetry/export-contract.unit.test.ts
+++ b/apps/web/worker/features/telemetry/export-contract.unit.test.ts
@@ -1,15 +1,11 @@
 /**
- * The build-time-verify guard for the Analytics Engine seam (ADR 0153's grounding
- * mandate, kept as a permanent CI test — not a one-off plan-time spike).
+ * Freezes the fact that the pinned alchemy really exports
+ * `Cloudflare.AnalyticsEngine.Dataset` / `WriteDataset`, so a future bump that drops
+ * or renames it fails HERE rather than in a prod deploy.
  *
- * ADR 0153 requires confirming the *pinned* alchemy (`2.0.0-beta.59`,
- * `pnpm-workspace.yaml`) actually exports `Cloudflare.AnalyticsEngine.Dataset` /
- * `WriteDataset`. The SPIKE resolved native at plan time; this test freezes that
- * resolution so a future alchemy bump that drops or renames the export fails HERE,
- * in CI, instead of in a prod deploy. If it ever goes red, the fix is the
- * `host.bind` fallback (identical wire contract,
- * `{ bindings: [{ type: "analytics_engine", name, dataset }] }`), re-opened as
- * follow-up — never silent breakage (ADR 0153 §Consequences).
+ * If it goes red, the fix is the `host.bind` fallback — identical wire contract,
+ * `{bindings: [{type: "analytics_engine", name, dataset}]}` — reopened as follow-up,
+ * never silent breakage (ADR 0153 §Consequences).
  */
 import {assert, describe, it} from "@effect/vitest";
 import * as Cloudflare from "alchemy/Cloudflare";

--- a/apps/web/worker/features/telemetry/resources.ts
+++ b/apps/web/worker/features/telemetry/resources.ts
@@ -1,21 +1,11 @@
 /**
- * The Analytics Engine telemetry-IaC surface — the `Events` dataset the
- * product-usage telemetry seam writes to (ADR 0153). Homed beside its future
- * service (`Telemetry.ts`, #2067) instead of in `db/resources.ts`, mirroring
- * `features/flagship/resources.ts` (ADR 0081).
+ * The Analytics Engine telemetry-IaC surface (ADR 0153), homed beside its service rather
+ * than in `db/resources.ts`, mirroring `features/flagship/resources.ts`.
  *
- * An AE dataset is a Worker binding, not an API-provisioned resource: it is
- * created on first `writeDataPoint`, so there is no provisioning or dashboard
- * step. The alchemy stack (`alchemy.run.ts`) `bind()`s it onto the worker (its
- * `env` block); the worker init resolves the Effect-native client via
- * `Cloudflare.AnalyticsEngine.WriteDataset(Events)` — the same declare→bind→
- * resolve shape as the Flagship app.
+ * An AE dataset is a Worker binding, not an API-provisioned resource: it is created on first
+ * `writeDataPoint`, so there is no provisioning or dashboard step.
  */
 import * as Cloudflare from "alchemy/Cloudflare";
 
-/**
- * The single Analytics Engine dataset — the `app_events` store every product-usage
- * instrument writes to (ADR 0153). One dataset, partitioned by the positional
- * index + blobs the `Telemetry` service (#2067) owns, not per-domain datasets.
- */
+/** One dataset, partitioned by the positional index + blobs, never per-domain datasets. */
 export const Events = Cloudflare.AnalyticsEngine.Dataset("Events", {dataset: "app_events"});

--- a/apps/web/worker/features/telemetry/schema.ts
+++ b/apps/web/worker/features/telemetry/schema.ts
@@ -1,25 +1,17 @@
 /**
- * The fixed positional Analytics Engine event-schema (ADR 0153 §"The event-schema
- * convention") — the single owner of the `TelemetryEvent -> DataPoint` mapping.
+ * The fixed positional Analytics Engine event-schema (ADR 0153) — the single owner of the
+ * `TelemetryEvent -> DataPoint` mapping.
  *
- * AE columns are POSITIONAL (`index1`, `blob1..`, `double1..`; no named schema),
- * so fields must be written in identical order across every event or columns
- * misalign SILENTLY. The `toDataPoint` map below is therefore the ONE place any
- * field lands in a slot — a second mapping site is the exact failure mode this
- * module exists to prevent. The fixed layout:
+ * AE columns are POSITIONAL (`index1`, `blob1..`, `double1..`; no named schema), so fields
+ * written in a different order misalign columns SILENTLY. A second mapping site is the
+ * exact failure mode this module exists to prevent. The fixed layout:
  *
- *   indexes: [feature]                                 — the one sampling/grouping key
+ *   indexes: [feature]                                  — the one sampling/grouping key
  *   blobs:   [feature, action, surface, userId?, emoji?] — string dimensions
  *   doubles: [1]                                        — the count
- *
- * `TelemetryEvent` is a CLOSED discriminated union on `feature` (make-invalid-
- * states-unrepresentable): the members are the per-feature event shapes, each
- * carrying its typed fields — no open string bag. Event vocabulary is English/
- * technical (glossary rule — telemetry is not product-facing copy).
  */
 import type * as Cloudflare from "alchemy/Cloudflare";
 
-/** The `vote` product-usage event (the karma-bearing ranking signal). */
 export interface VoteEvent {
 	readonly feature: "vote";
 	readonly action: string;
@@ -28,12 +20,8 @@ export interface VoteEvent {
 }
 
 /**
- * The `reaction` product-usage event (the karma-free social signal). Carries the
- * chosen `emoji` — the one dimension a reaction has over a vote (ADR 0153
- * §"First instrument": `Reaction.* emits {feature, action, surface, emoji}`). It
- * rides the trailing blob slot after `userId`; a `retract` has no emoji, so the
- * field is optional and omitted then (see {@link toDataPoint} for the positional
- * rule that keeps it aligned).
+ * The `reaction` event. `emoji` rides the trailing blob slot after `userId`; a `retract`
+ * has none, so it is optional (see {@link toDataPoint} for the alignment rule).
  */
 export interface ReactionEvent {
 	readonly feature: "reaction";
@@ -43,21 +31,13 @@ export interface ReactionEvent {
 	readonly emoji?: string;
 }
 
-/**
- * The closed telemetry event union. A non-member `feature` is a compile error —
- * every instrument emits one of these shapes, never a raw data point (ADR 0153).
- */
+/** The closed event union: a non-member `feature` is a compile error. */
 export type TelemetryEvent = VoteEvent | ReactionEvent;
 
 /**
- * The single positional `TelemetryEvent -> DataPoint` map. `userId` is a
- * deliberately-approximate blob (ADR 0153 — distinct-user counts are estimates
- * under sampling); `emoji` is the reaction-only trailing dimension (absent on a
- * `vote` and on a reaction `retract`). Both are optional and land at FIXED slots
- * (userId=blob4, emoji=blob5): a trailing optional is dropped when absent, but a
- * present `emoji` with an absent `userId` fills userId with an empty placeholder
- * so `emoji` never slides into blob4 and misaligns the column — the exact silent
- * misalignment this single mapping site exists to prevent.
+ * `userId` and `emoji` are optional but land at FIXED slots (blob4, blob5). A trailing
+ * optional is dropped when absent, so a present `emoji` with an absent `userId` fills
+ * userId with an empty placeholder — otherwise `emoji` slides into blob4 and misaligns.
  */
 export function toDataPoint(event: TelemetryEvent): Cloudflare.AnalyticsEngine.DataPoint {
 	const emoji = event.feature === "reaction" ? event.emoji : undefined;

--- a/apps/web/worker/features/text/index.ts
+++ b/apps/web/worker/features/text/index.ts
@@ -1,15 +1,13 @@
 /**
- * Tiny text utilities shared by feature services. Pure and Effect-free — called
- * from inside `Effect.fn` bodies, not effects themselves; keep it that way (no
- * services, no IO).
+ * Tiny text utilities shared by feature services. Pure and Effect-free — called from inside
+ * `Effect.fn` bodies, not effects themselves; keep it that way (no services, no IO).
  */
 
 const DEFAULT_EXCERPT_LEN = 280;
 
 /**
- * Collapse whitespace and truncate to `max`, appending an ellipsis when cut.
- * Idempotent. Callers pass an explicit cap per their legacy DO contract: sözlük
- * definitions 140, pano posts/comments 280.
+ * Collapse whitespace and truncate to `max`, appending an ellipsis when cut. Idempotent.
+ * Callers pass an explicit cap: sözlük definitions 140, pano posts/comments 280.
  */
 export function excerpt(body: string, max: number = DEFAULT_EXCERPT_LEN): string {
 	const flat = body.replace(/\s+/g, " ").trim();

--- a/apps/web/worker/features/throttle/RateLimitStore.ts
+++ b/apps/web/worker/features/throttle/RateLimitStore.ts
@@ -1,25 +1,15 @@
 /**
- * `RateLimitStore` — the dependency-inverted backing-store port for the token
- * bucket (ADR 0177). The `RateLimiter` service owns the algorithm (the pure
- * `TokenBucket`); the store owns only *where the state lives and how the
- * read-modify-write is made atomic*. That split is the storage swap point: the
- * in-isolate `Map` ships today; a per-actor Durable Object (ADR 0037) drops in
- * behind this same port at the composition root when registration opens, without
- * touching `RateLimiter` — the same inversion idiom as Vote's `KarmaBump` /
- * `VoterStanding` (`.patterns/feature-services.md`).
+ * The backing-store port for the token bucket (ADR 0177). `RateLimiter` owns the
+ * algorithm; the store owns only where the state lives and how the read-modify-write
+ * is made atomic. That split is the swap point: a per-actor Durable Object drops in
+ * behind this same port without touching `RateLimiter`.
  */
 import {Context, Effect, Layer} from "effect";
 import type {TokenBucketState} from "./TokenBucket.ts";
 
 export interface RateLimitStoreAccess {
-	/**
-	 * Atomically read the bucket state for `key`, apply the pure `transition`,
-	 * persist the returned state, and yield the transition's result. The per-key
-	 * atomicity of this read-apply-write IS the store's whole contract — an
-	 * interleaved RMW would let two concurrent mutations both spend the last
-	 * token. Each backing guarantees it at its own seam: the isolate's single
-	 * event loop below, a Durable Object's single-threaded execution later.
-	 */
+	// Per-key atomicity of this read-apply-write IS the store's whole contract: an
+	// interleaved cycle would let two concurrent mutations both spend the last token.
 	readonly transition: <R>(
 		key: string,
 		transition: (state: TokenBucketState | undefined) => readonly [TokenBucketState, R],
@@ -30,12 +20,9 @@ export class RateLimitStore extends Context.Service<RateLimitStore, RateLimitSto
 	"@kampus/throttle/RateLimitStore",
 ) {}
 
-/**
- * The in-isolate backing: a per-isolate `Map` built once per isolate (via the
- * fate runtime's memoMap). JS's single-threaded event loop makes the synchronous
- * read-apply-write atomic per key with no lock. Its bound is per-isolate, not
- * global — ADR 0177 records that as the v1→Durable-Object upgrade trigger.
- */
+// JS's single-threaded event loop makes the synchronous read-apply-write atomic per key
+// with no lock. The bound is per-isolate, not global — ADR 0177 records that as the
+// trigger for moving to a Durable Object.
 export const InIsolateRateLimitStoreLive = Layer.sync(RateLimitStore)(() => {
 	const buckets = new Map<string, TokenBucketState>();
 	return {

--- a/apps/web/worker/features/throttle/RateLimiter.ts
+++ b/apps/web/worker/features/throttle/RateLimiter.ts
@@ -1,10 +1,9 @@
 /**
  * `RateLimiter` — the per-actor mutation-volume throttle (ADR 0177). It owns the
- * token-bucket algorithm ({@link TokenBucket}) and the actor→budget-key mapping;
- * the state's home and RMW atomicity are the {@link RateLimitStore} port's job
- * (the DO-vs-in-isolate swap point). Wired once at the fate composition root
- * (`fate/layers.ts`) over the merged mutations record, so it bounds every
- * feature's mutation path without touching a single feature.
+ * token-bucket algorithm and the actor→budget-key mapping; the state's home and RMW
+ * atomicity belong to the {@link RateLimitStore} port. Wired once at the fate
+ * composition root over the merged mutations record, so it bounds every feature's
+ * mutation path without touching a single feature.
  */
 import {type Actor, matchActor} from "@kampus/authz";
 import {Clock, Context, Effect, Layer, Option} from "effect";
@@ -13,22 +12,15 @@ import {RateLimitStore} from "./RateLimitStore.ts";
 import {type TokenBucketPolicy, tokenBucketPolicy, tryConsume} from "./TokenBucket.ts";
 
 /**
- * The per-actor mutation budget: one default class covers every mutation — 60
- * tokens of burst refilling 1/s (≈60 writes/minute sustained). Chosen well clear
- * of a human's real write cadence (a fast reader voting/reacting rarely nears
- * one write/second sustained) yet tight enough to bound a scripted flood — the
- * abuse the audit named (sandbox floods, report spam, reaction churn). ADR 0177
- * records why a single aggregate bucket (not per-mutation-class sub-buckets) is
- * the v1 shape and where per-class values would slot in.
+ * One aggregate bucket covers every mutation — 60 tokens of burst refilling 1/s.
+ * ADR 0177 records why that beats per-mutation-class sub-buckets for v1.
  */
 export const DEFAULT_MUTATION_POLICY: TokenBucketPolicy = tokenBucketPolicy(60, 1);
 
 export interface RateLimiterAccess {
 	/**
-	 * Spend one token of the actor's mutation budget; fail with
-	 * {@link RateLimitExceeded} when the bucket is empty. Anonymous actors carry
-	 * no budget key — their writes are refused by each mutation's own auth gate —
-	 * so they pass through untouched.
+	 * Anonymous actors carry no budget key and pass through untouched — their writes
+	 * are refused by each mutation's own auth gate.
 	 */
 	readonly check: (actor: Actor) => Effect.Effect<void, RateLimitExceeded>;
 }
@@ -37,7 +29,6 @@ export class RateLimiter extends Context.Service<RateLimiter, RateLimiterAccess>
 	"@kampus/throttle/RateLimiter",
 ) {}
 
-/** The per-actor budget key; `None` for anonymous traffic (not throttled here). */
 const actorKey = (actor: Actor): Option.Option<string> =>
 	matchActor(actor, {
 		onUnauthenticated: () => Option.none(),

--- a/apps/web/worker/features/throttle/TokenBucket.ts
+++ b/apps/web/worker/features/throttle/TokenBucket.ts
@@ -1,30 +1,23 @@
 /**
- * The token-bucket rate-limit algorithm as a pure domain object (ADR 0177):
- * state + policy + the two transitions (refill-by-elapsed-time, try-consume).
- * No clock, no store, no Effect — `nowMs` is passed in, so the algorithm is
- * exhaustively unit-testable and byte-identical whether its state lives in an
- * isolate `Map` today or a per-actor Durable Object when registration opens.
+ * The token-bucket rate-limit algorithm as a pure domain object (ADR 0177). No clock,
+ * no store, no Effect: `nowMs` is passed in, so the algorithm behaves identically
+ * whether its state lives in an isolate `Map` today or a per-actor Durable Object
+ * later.
  */
 
-/** A bucket's state: tokens remaining and the wall time they were last refilled. */
 export interface TokenBucketState {
 	readonly tokens: number;
 	readonly lastRefillMs: number;
 }
 
-/**
- * A bucket's fixed shape: `capacity` is the burst ceiling (and the full-bucket
- * start), `refillPerSecond` the sustained rate. Both are positive by
- * construction — {@link tokenBucketPolicy} is the only constructor and rejects a
- * non-positive value, so an unfillable bucket is unrepresentable.
- */
+// Both fields are positive by construction: {@link tokenBucketPolicy} is the only
+// constructor and rejects a non-positive value, so an unfillable bucket cannot exist.
 export interface TokenBucketPolicy {
 	readonly capacity: number;
 	readonly refillPerSecond: number;
 }
 
-/** The only `TokenBucketPolicy` constructor — throws on a non-positive value (a
- * misconfiguration, i.e. a programmer error, never a runtime input). */
+// Throws rather than fails: a bad policy is a misconfiguration, never a runtime input.
 export const tokenBucketPolicy = (capacity: number, refillPerSecond: number): TokenBucketPolicy => {
 	if (!(capacity > 0) || !(refillPerSecond > 0)) {
 		throw new Error(
@@ -34,17 +27,13 @@ export const tokenBucketPolicy = (capacity: number, refillPerSecond: number): To
 	return {capacity, refillPerSecond};
 };
 
-/** A brand-new, full bucket at `nowMs`. */
 export const initialState = (policy: TokenBucketPolicy, nowMs: number): TokenBucketState => ({
 	tokens: policy.capacity,
 	lastRefillMs: nowMs,
 });
 
-/**
- * Refill by elapsed wall time, capped at `capacity`. Clock-skew-safe: a
- * backwards `nowMs` clamps elapsed to 0, so a bucket never loses tokens and
- * `lastRefillMs` only advances.
- */
+// Clock-skew-safe: a backwards `nowMs` clamps elapsed to 0, so a bucket never loses
+// tokens and `lastRefillMs` only advances.
 export const refill = (
 	state: TokenBucketState,
 	policy: TokenBucketPolicy,
@@ -59,19 +48,14 @@ export const refill = (
 	return {tokens: refilled, lastRefillMs: nowMs};
 };
 
-/** The outcome of a {@link tryConsume}: whether it was allowed, the resulting
- * state to persist, and the wait until the next token when denied (0 if allowed). */
 export interface ConsumeResult {
 	readonly allowed: boolean;
 	readonly state: TokenBucketState;
 	readonly retryAfterMs: number;
 }
 
-/**
- * Spend one token: refill first, then consume iff at least one token remains. On
- * denial the state is still the refilled bucket (so the next call sees the
- * elapsed time) and `retryAfterMs` is the wait until one token accrues.
- */
+// On denial the returned state is still the REFILLED bucket, so the next call sees the
+// elapsed time.
 export const tryConsume = (
 	prev: TokenBucketState | undefined,
 	policy: TokenBucketPolicy,

--- a/apps/web/worker/features/throttle/TokenBucket.unit.test.ts
+++ b/apps/web/worker/features/throttle/TokenBucket.unit.test.ts
@@ -1,8 +1,7 @@
 /**
- * The token-bucket domain object (ADR 0177) — the rate-limit algorithm proven
- * store-free: refill-by-elapsed-time, consume, deny-at-empty, clock-skew safety.
- * The `RateLimiter` service and the DO/in-isolate backing reuse this same math,
- * so pinning it here is what lets those higher layers stay thin.
+ * The token-bucket domain object (ADR 0177), proven store-free. The `RateLimiter`
+ * service and the DO/in-isolate backing reuse this same math, so pinning it here is
+ * what lets those higher layers stay thin.
  */
 import {describe, expect, it} from "vitest";
 import {initialState, refill, tokenBucketPolicy, tryConsume} from "./TokenBucket.ts";

--- a/apps/web/worker/features/throttle/errors.ts
+++ b/apps/web/worker/features/throttle/errors.ts
@@ -1,19 +1,10 @@
-/**
- * The throttle wire-coded denial (ADR 0177) — a `Schema.TaggedErrorClass` with a
- * `FateWireCode` annotation, so `encodeWireError` derives the wire shape with no
- * registry edit, the same path as `kunye/VouchLimitReached`. Distinct from that
- * business cap: `VOUCH_LIMIT_REACHED` rations one domain act (concurrent
- * vouches), whereas this bounds an actor's aggregate mutation *volume* across
- * every feature at the fate seam.
- */
 import {FateWireCode} from "@kampus/fate-effect";
 import * as Schema from "effect/Schema";
 
 /**
- * The per-actor mutation budget is exhausted — the actor is issuing writes
- * faster than the token bucket refills. Carries `retryAfterMs` so the surface
- * can name the wait; its own `RATE_LIMIT_EXCEEDED` code (not a generic 500) so a
- * throttled write is a clear, distinguishable denial.
+ * The per-actor mutation budget is exhausted (ADR 0177). Unlike
+ * `kunye/VouchLimitReached`, which rations one domain act, this bounds an actor's
+ * aggregate write volume across every feature at the fate seam.
  */
 export class RateLimitExceeded extends Schema.TaggedErrorClass<RateLimitExceeded>()(
 	"throttle/RateLimitExceeded",

--- a/apps/web/worker/features/throttle/errors.unit.test.ts
+++ b/apps/web/worker/features/throttle/errors.unit.test.ts
@@ -1,10 +1,7 @@
 /**
- * The throttle wire-error annotation pin (ADR 0177) — `RateLimitExceeded` carries
- * `RATE_LIMIT_EXCEEDED` and round-trips through `encodeWireError` with its own
- * message. The aggregate `fate/wireCodes.unit.test.ts` guard proves the SPA list
- * covers this seam-injected code; this pins the class→code binding itself, the
- * throttle twin of `fate/wireCodes-per-class.unit.test.ts` (the seam-injected
- * code has no declared union, so it can't be pinned by that staleness guard).
+ * The throttle wire-error annotation pin (ADR 0177). It lives here rather than in
+ * `fate/wireCodes-per-class.unit.test.ts` because a seam-injected code has no declared
+ * union for that staleness guard to pin against.
  */
 import {encodeWireError, wireCodeOfClass} from "@kampus/fate-effect";
 import {describe, expect, it} from "vitest";

--- a/apps/web/worker/features/throttle/throttle-mutations.ts
+++ b/apps/web/worker/features/throttle/throttle-mutations.ts
@@ -1,25 +1,18 @@
 /**
- * `throttleMutations` — wrap every mutation's `resolve` with the per-actor
- * throttle (ADR 0177), applied ONCE at the fate composition root
- * (`fate/layers.ts`) over the merged mutations record so it reaches every
- * feature's mutation path without touching a single feature. The token is spent
- * BEFORE the handler runs, so a denial fails the mutation with
- * `RATE_LIMIT_EXCEEDED` and the handler — its write AND its `/fate/live` publish
- * — never runs; a throttled mutation is transparent to the fanout invariant
- * because it simply doesn't execute.
+ * Wraps every mutation's `resolve` with the per-actor throttle (ADR 0177), applied
+ * once at the fate composition root so it reaches every feature without touching
+ * one. The token is spent BEFORE the handler runs, so a denied mutation executes
+ * nothing at all — neither its write nor its live publish — which is what keeps a
+ * throttled mutation transparent to the fanout invariant.
  */
 import {CurrentActor} from "@kampus/authz";
 import type {AnyFateMutation, FateMutationsRecord} from "@kampus/fate-effect";
 import {Effect} from "effect";
 import {RateLimiter} from "./RateLimiter.ts";
 
-/**
- * The wrapped `resolve` gains `RateLimiter` + `CurrentActor` in its true
- * requirements; the return type is preserved as the input record `M` because
- * both are provided at run time — `RateLimiter` from the worker layer,
- * `CurrentActor` per request off the session (ADR 0107 §7) — the same re-pin the
- * fate provision pipeline applies to every erased entry effect.
- */
+// The wrapped `resolve` really gains `RateLimiter` + `CurrentActor`, but the return
+// type stays `M` because both are provided at run time (ADR 0107 §7) — the same re-pin
+// the fate provision pipeline applies to every erased entry effect.
 export const throttleMutations = <M extends FateMutationsRecord>(mutations: M): M => {
 	const throttled: Record<string, AnyFateMutation> = {};
 	for (const [name, entry] of Object.entries(mutations)) {

--- a/apps/web/worker/features/throttle/throttle-mutations.unit.test.ts
+++ b/apps/web/worker/features/throttle/throttle-mutations.unit.test.ts
@@ -1,9 +1,7 @@
 /**
- * `throttleMutations` seam coverage (ADR 0177) — the wrapper is transparent to a
- * mutation's handler when the actor is under budget (its write AND its
- * `/fate/live` publish still fire), and short-circuits with `RATE_LIMIT_EXCEEDED`
- * BEFORE the handler when over budget (so a throttled write never publishes — the
- * fanout invariant is preserved because the handler simply doesn't run).
+ * `throttleMutations` seam coverage (ADR 0177). Over budget it short-circuits BEFORE the
+ * handler, which is what preserves the fanout invariant — a throttled write never
+ * publishes because the handler simply does not run.
  */
 import {assert, describe, it} from "@effect/vitest";
 import {CurrentActor, human} from "@kampus/authz";
@@ -22,11 +20,7 @@ import {throttleMutations} from "./throttle-mutations.ts";
 const TestRateLimiter = RateLimiterLive.pipe(Layer.provide(InIsolateRateLimitStoreLive));
 const CAPACITY = DEFAULT_MUTATION_POLICY.capacity;
 
-/**
- * A stand-in fanned mutation whose `resolve` records a "publish" — the
- * `/fate/live` invalidation a real fanned mutation fires after its write. The
- * `published` array is the observable proof of whether the handler ran.
- */
+/** The `published` array is the observable proof of whether the handler ran. */
 const makeFannedMutations = (published: Array<string>): FateMutationsRecord => ({
 	"post.submit": {
 		kind: "mutation",
@@ -41,8 +35,7 @@ const makeFannedMutations = (published: Array<string>): FateMutationsRecord => (
 	},
 });
 
-/** Drive the throttled `post.submit` resolve, re-pinning its erased `R` to the
- * services the wrapper truly needs (both provided by {@link runAsWriter}). */
+/** Re-pins the erased `R` to the services the wrapper actually needs. */
 const submit = (published: Array<string>) => {
 	const entry = throttleMutations(makeFannedMutations(published))["post.submit"] as AnyFateMutation;
 	return entry.resolve({input: {}, select: []}) as Effect.Effect<

--- a/apps/web/worker/features/throttle/wire-codes.ts
+++ b/apps/web/worker/features/throttle/wire-codes.ts
@@ -1,9 +1,6 @@
 /**
- * The wire codes the per-actor mutation throttle (ADR 0177) injects at the fate
- * composition seam — NOT through any feature's declared error union, so
- * `declaredWireCodes(fateConfig)` (which walks declared unions) does not see
- * them. The SPA-coverage guard (`fate/wireCodes.unit.test.ts`) unions this set
- * onto the declared set, so the SPA `FATE_WIRE_CODES` list must still cover it —
- * the single source both the guard and any future throttle code read from.
+ * The throttle (ADR 0177) injects these at the fate composition seam, NOT through a
+ * feature's declared error union, so `declaredWireCodes(fateConfig)` cannot see them.
+ * The SPA-coverage guard unions this set onto the declared one.
  */
 export const THROTTLE_WIRE_CODES = ["RATE_LIMIT_EXCEEDED"] as const;

--- a/apps/web/worker/features/user-admin/lists.ts
+++ b/apps/web/worker/features/user-admin/lists.ts
@@ -1,19 +1,8 @@
 /**
- * The user-admin root list resolver (#3200) — `userAdmin.list`, the gated user roster the
- * `kullanıcılar` console module reads. A paginated (`first`/`after` keyset), searchable
- * (`search` substring) admin read.
- *
- * Two gates, both enforced HERE (the pasaport reads are unconditional), mirroring
- * `pasaport/lists.ts`'s `emailDelivery.failing`:
- *   1. The `PHOENIX_USER_ADMIN` dark-ship flag (default-off, ADR 0083). Off ⇒ the invisible
- *      `Denied`, so the roster never leaks before release.
- *   2. `requireAdmin` (ADR 0107) — `yield* Admin` makes the read unreachable without the
- *      discharged grant, so a non-admin gets the SAME invisible `Denied`.
- *
- * The `role`/`banned` standing is JOINED past the gate, never read off the retired
- * `user.role` column: `banned` from the batched ban-state projection
- * (`Pasaport.banStatesForAdmin`), `role` from the `moderates` relation tuple
- * (`moderatorsAmong`) — one relation read per page, never a per-row `isModerator`.
+ * The user-admin roster read (#3200). Both gates are enforced HERE, because the pasaport
+ * reads are unconditional: the `PHOENIX_USER_ADMIN` dark-ship flag (ADR 0083) and
+ * `requireAdmin` (ADR 0107), each failing with the SAME invisible `Denied`. `role`/`banned`
+ * are joined past the gate, never read off the retired `user.role` column.
  */
 import {Fate} from "@kampus/fate-effect";
 import type {ConnectionResult} from "@nkzw/fate/server";
@@ -39,15 +28,13 @@ export const UserAdminListArgs = Schema.Struct({
 
 type UserAdminListArgsType = Schema.Schema.Type<typeof UserAdminListArgs>;
 
-/** Is the #3200 user-admin dark-ship flag on for this request? Safe-default `false` (dark). */
 const userAdminOn = Effect.gen(function* () {
 	const flags = yield* Flags;
 	return yield* flags.getBoolean(PHOENIX_USER_ADMIN, false).pipe(provideRequestFlags);
 });
 
-// The post-gate roster read — `Admin`-gated in R (`requireAdmin` provides the grant).
-// `yield* Admin` requires the proof; the roster is unreachable without a discharged grant.
-// Exported so the gate + shaping can be exercised end to end in a unit test.
+// `yield* Admin` requires the proof, so the roster is unreachable without a discharged
+// grant. Exported so the gate + shaping can be exercised end to end in a unit test.
 export const userAdminListGated = Effect.fn("userAdmin.listGated")(function* (
 	args: UserAdminListArgsType,
 ) {

--- a/apps/web/worker/features/user-admin/lists.unit.test.ts
+++ b/apps/web/worker/features/user-admin/lists.unit.test.ts
@@ -1,15 +1,8 @@
 /**
- * `userAdmin.list` gate + shaping coverage (#3200) — the roster read run through the REAL
- * `requireAdmin` seam (ADR 0107), not a re-implemented admin check. The post-gate body
- * (`userAdminListGated`) is exercised end to end: an admin discharges the `Admin` grant and
- * gets the mapped roster (role joined off the `moderates` tuple, banned off the batched
- * ban-state); a non-admin and the anonymous actor are denied the invisible `Denied` — and
- * the pasaport reads are NEVER touched, proving the gate blocks before the read (the
- * fail-on-contact stub dies if reached).
- *
- * All ports are scripted (`Pasaport` the roster + ban-state, `RelationStore` the admin +
- * moderates tuples, `AgentAuthority` fail-closed, `CurrentActor` the actor) — no DB; the
- * real-D1 admin write→read seam lives in `apps/web/tests/integration/kunye-admin-seam.test.ts`.
+ * `userAdmin.list` gate + shaping coverage (#3200), run through the REAL `requireAdmin`
+ * seam (ADR 0107) rather than a re-implemented admin check. Denied callers must never
+ * touch the pasaport reads — the fail-on-contact stub dies if the gate let them through.
+ * The real-D1 write→read seam lives in `tests/integration/kunye-admin-seam.test.ts`.
  */
 import {assert, describe, it} from "@effect/vitest";
 import {
@@ -54,9 +47,8 @@ const run = (
 	const rows = opts.rows ?? [];
 	const admins = opts.admins ?? [];
 	const mods = opts.mods ?? [];
-	// One `RelationStore` scripting BOTH the `admin` tuple (the requireAdmin gate) and the
-	// `moderates` tuple (the roster's role join) off two holder sets — inlined so TS infers
-	// the port shape from the tag (the `divan/gate.unit.test.ts` idiom, no cast).
+	// One store scripts BOTH the `admin` tuple (the gate) and the `moderates` tuple (the
+	// role join). Inlined so TS infers the port shape from the tag, with no cast.
 	const holdersFor = (relation: string) => (relation === "admin" ? admins : mods);
 	const relevant = (relation: string, objectType: string) =>
 		(relation === "admin" || relation === "moderates") && objectType === "platform";
@@ -122,7 +114,6 @@ describe("userAdmin.list — requireAdmin gate (ADR 0107)", () => {
 				["u2", "member", true, "çaylak"],
 			],
 		);
-		// Every node carries its wire discriminant + the epoch-millis createdAt.
 		assert.strictEqual(nodes[0]?.__typename, "UserAdmin");
 		assert.strictEqual(nodes[0]?.createdAt, at("2026-01-01T00:00:00Z").getTime());
 		assert.strictEqual(exit.value.pagination.hasNext, false);

--- a/apps/web/worker/features/user-admin/shapers.ts
+++ b/apps/web/worker/features/user-admin/shapers.ts
@@ -1,22 +1,17 @@
 /**
- * user-admin wire shaper (#3200) — map one `AdminUserRow` (the pasaport record-derived
- * row) plus its joined `banned`/`role` standing onto the `UserAdmin` wire entity. Pure and
- * DOM-free: the `role` decision (`moderator` iff in the moderator set) and the epoch-millis
- * `createdAt` conversion are testable without a DB. The resolver joins the standing; this
- * stamps the wire shape. `__typename` is stamped here — the entity is inline-resolved (no
- * source), so nothing else stamps it (the `report/shapers.ts` idiom).
+ * user-admin wire shaper. `__typename` is stamped here because the entity is
+ * inline-resolved — it has no source, so nothing else stamps it.
  */
 import type {AdminUserRow} from "../pasaport/Pasaport.ts";
 import type {UserAdminEntity, UserAdminRole} from "./views.ts";
 
-/** `moderator` iff the account holds the `moderates` tuple, else `member` (never the retired column). */
+/** Reads the `moderates` tuple, never the retired `user.role` column. */
 export const roleOf = (isModerator: boolean): UserAdminRole =>
 	isModerator ? "moderator" : "member";
 
-/** The account's `created_at` as an epoch-millis wire scalar; a null column (pre-column cohort) reads 0. */
+/** A null column (the pre-column cohort) reads 0. */
 export const createdAtMillis = (createdAt: Date | null): number => createdAt?.getTime() ?? 0;
 
-/** Map a roster row + its joined ban/moderator standing onto the `UserAdmin` wire entity. */
 export const toUserAdminRow = (
 	row: AdminUserRow,
 	opts: {readonly banned: boolean; readonly isModerator: boolean},

--- a/apps/web/worker/features/user-admin/sources.ts
+++ b/apps/web/worker/features/user-admin/sources.ts
@@ -1,8 +1,7 @@
 /**
- * user-admin fate source — `UserAdmin` is delivered INLINE by the `userAdmin.list`
- * resolver and never read by id (a private, `requireAdmin`-gated admin surface), so it is a
- * capability-less `Fate.syntheticSource` (view-reachable, no fetch path). Mirrors divan's
- * `DivanCaylak` source. See `.patterns/fate-effect-sources.md`.
+ * `UserAdmin` is delivered INLINE by the `userAdmin.list` resolver and never read by id (a
+ * private, `requireAdmin`-gated surface), so it is a capability-less `Fate.syntheticSource`.
+ * See `.patterns/fate-effect-sources.md`.
  */
 import {Fate} from "@kampus/fate-effect";
 import {UserAdminView} from "./views.ts";

--- a/apps/web/worker/features/user-admin/views.ts
+++ b/apps/web/worker/features/user-admin/views.ts
@@ -1,24 +1,17 @@
 /**
- * user-admin fate data view — `UserAdminView`, one row of the gated admin user roster
- * (#3200). The read view the `kullanıcılar` console module lists: one account's
- * admin-facing standing — id, username, email, `role`, `banned`, `tier`, `createdAt`.
+ * One row of the gated admin user roster (#3200) — an account's admin-facing standing.
  *
- * `id` === the account id (the client normalization key). `role` and `tier` are the
- * standing fields joined by the resolver, NOT read off the retired `user.role` column
- * (ADR 0107 §4): `role` is `moderator` iff the account holds the `moderates` relation
- * tuple (`moderatorsAmong`), `tier` is the stored authorship rank read fresh through
- * pasaport; `banned` is projected from the append-only `user_ban_event` log
- * (`pasaport/ban.ts`). `createdAt` is epoch-millis to keep the wire scalar plain.
+ * `role` and `tier` are joined by the resolver, NOT read off the retired `user.role` column (ADR
+ * 0107 §4): `role` is `moderator` iff the account holds the `moderates` relation tuple, `tier` is
+ * the stored authorship rank; `banned` is projected from the append-only `user_ban_event` log.
  *
- * The row carries only the admin roster fields — no session, no capability list. It is
- * only ever produced past the `requireAdmin` gate + the `phoenix-user-admin` dark-ship
- * flag (`lists.ts`), so a non-admin gets the invisible `Denied` rather than a leaked row.
+ * The row carries only roster fields — no session, no capability list — and is only ever produced
+ * past the `requireAdmin` gate + the `phoenix-user-admin` dark-ship flag (`lists.ts`).
  */
 import {FateDataView, type WorkerEntity} from "@kampus/fate-effect";
 import type {ViewRow} from "../fate/view-types.ts";
 import type {StoredTier} from "../kunye/standing.ts";
 
-/** The admin-facing role signal — `moderator` iff the `moderates` tuple is held, else `member`. */
 export type UserAdminRole = "member" | "moderator";
 
 export type UserAdminViewRow = ViewRow<{

--- a/apps/web/worker/features/vote/Vote.ts
+++ b/apps/web/worker/features/vote/Vote.ts
@@ -1,20 +1,8 @@
 /**
- * Vote — the polymorphic vote service. One canonical write surface
- * (`Vote.cast`) for the three vote targets: `definition`, `post`, `comment`.
- *
- * Voting is up-only in the MVP: a vote is a pure presence — `cast({value: true})`
- * casts, `{value: false}` retracts — so invalid states (down-vote semantics, a
- * vote *weight*) are structurally unrepresentable; there is no number to misuse.
- *
- * The feature-local vote table (`definition_vote`/`post_vote`/`comment_vote`,
- * PK `(target_id, voter_id)`) is the score-truth source; the score cached on
- * the target row is rebuilt from `COUNT(*)` on it. The cross-product
- * `user_vote` table (PK `(user_id, target_kind, target_id)`) powers `myVote`.
- *
- * Atomicity invariant: every state-changing cast lands all four mutations —
- * vote-table upsert/delete, score-cache update, `user_vote` mirror, and karma
- * bump (via {@link KarmaBump}) — in one batch that commits or rolls back as a
- * unit. See ADR 0014 (batch as service method).
+ * Vote — the polymorphic vote service for the three targets (`definition`, `post`,
+ * `comment`). Up-only: a vote is a pure presence, so down-vote semantics and vote
+ * weights are unrepresentable. Every state-changing cast lands all four mutations in
+ * one batch that commits or rolls back as a unit (ADR 0014).
  */
 import {and, eq, inArray, type SQL} from "drizzle-orm";
 import {Context, Effect, Layer} from "effect";
@@ -32,8 +20,6 @@ import {
 	VoteTargetSandboxed,
 } from "./errors.ts";
 
-// Re-exported from `db/target-kind.ts` (its source-of-truth home) for callers
-// that prefer importing it from `./Vote`.
 export type {TargetKind};
 
 export interface VoteInput {
@@ -47,54 +33,34 @@ export interface VoteInput {
 export interface VoteResult {
 	targetKind: TargetKind;
 	targetId: string;
-	/**
-	 * The target's author — the karma recipient of this cast. Surfaced so a caller can
-	 * fire an author-keyed downstream effect (e.g. the divan vote path re-evaluating the
-	 * çaylak→yazar promotion tandem on a bar-crossing vote, #1288/#1289) on the
-	 * **server-derived** author, never a client-supplied one.
-	 */
+	/** Server-derived author (the karma recipient) — never a client-supplied one. */
 	authorId: string;
 	score: number;
-	/** Whether the voter holds an upvote on this target after the write. */
 	myVote: boolean;
 	/** `false` on idempotent no-op. */
 	changed: boolean;
 }
 
-/**
- * The context of one karma bump, passed from Vote (which knows the cast) to the
- * `KarmaBump` implementation (which owns the karma schema) so the implementation
- * can write the provenance ledger row without Vote importing its internals —
- * preserving the dependency inversion (#2592).
- */
 export interface KarmaBumpInput {
-	/** The karma recipient — the vote target's author. */
 	readonly recipientId: string;
-	/** Signed karma delta: `+1` cast, `-1` retraction. */
+	/** Signed: `+1` cast, `-1` retraction. */
 	readonly delta: number;
-	/** The vote target the delta came from — its kind and id. */
 	readonly source: {readonly kind: TargetKind; readonly id: string};
-	/** The event kind driving the bump (`vote` cast / `retract`). */
 	readonly reason: KarmaEventReason;
-	/** Commit timestamp, shared with the rest of the cast batch. */
+	/** Shared with the rest of the cast batch. */
 	readonly at: Date;
 	/**
-	 * The pre-mutation vote-change guard (`targetTable[kind].voteChangeGuard`): an
-	 * `SQL` predicate gating BOTH statements so the karma delta commits only when the
-	 * vote write actually changes the row's presence. A duplicate concurrent cast that
-	 * raced the out-of-batch idempotency probe finds the vote row already present (or
-	 * already gone) and bumps `total_karma` — and appends its ledger row — zero times,
-	 * so `SUM(karma_event.delta)` still reconciles to `total_karma` (#2552).
+	 * Predicate gating BOTH statements, so the karma delta commits only when the vote
+	 * write actually changes the row's presence. A duplicate concurrent cast that raced
+	 * the idempotency probe bumps zero times, keeping `SUM(karma_event.delta)` reconciled
+	 * with `total_karma` (#2552).
 	 */
 	readonly guard: SQL;
 }
 
 /**
- * The karma-bump capability as Vote consumes it: given the bump's context, the
- * **unexecuted** statements to include in the cast batch — the `total_karma`
- * adjustment AND its append-only ledger row (#2592) — so both commit atomically
- * with the vote, or not at all. Two statements, never one: a bump can't land
- * without its provenance event.
+ * Returns **unexecuted** statements for the cast batch. Two, never one: a
+ * `total_karma` bump can't land without its append-only ledger row (#2592).
  */
 export interface KarmaBumpService {
 	readonly statements: (db: DrizzleDb, input: KarmaBumpInput) => readonly [Stmt, Stmt];
@@ -141,47 +107,31 @@ export class Vote extends Context.Service<
 	Vote,
 	{
 		/**
-		 * Score + credit karma for a vote on a **live** target. Two eligibility gates guard the
-		 * write: the *target*-liveness gate rejects a still-sandboxed target with
-		 * {@link VoteTargetSandboxed} (sandboxed çaylak content is votable ONLY through
-		 * {@link castOnSandboxed}, past the divan gate, #1288); the *voter*-tier gate rejects a
-		 * newcomer (çaylak/visitor) voter with {@link VoterNotEligible} — voting on live content
-		 * is earned above the çaylak floor ("earn to vote", #1810). This is the surface the inline
-		 * sözlük/pano vote paths delegate to, so an inline voter can neither score sandboxed
-		 * content nor cast before they are promoted.
+		 * Score + credit karma for a vote on a **live** target — the surface every inline
+		 * sözlük/pano vote path delegates to. Sandboxed targets are votable only through
+		 * {@link castOnSandboxed} (#1288), and a newcomer voter is rejected: voting is
+		 * earned above the çaylak floor (#1810).
 		 */
 		readonly cast: (
 			input: VoteInput,
 		) => Effect.Effect<VoteResult, VoteTargetNotFound | VoteTargetSandboxed | VoterNotEligible>;
 		/**
-		 * The divan-authorized cast (#1288): identical to {@link cast} but ACCEPTS a sandboxed
-		 * target. The only caller is the `features/divan` vote mutation, which reaches this
-		 * past `requireDivanAccess` (`yield* ViewDivan` — the compile-error gate, ADR 0107);
-		 * Vote stays vocabulary-free about the divan, so the authorization lives at that
-		 * resolver, not here. Karma + scoring are the SAME atomic batch as `cast` — the vote
-		 * writes GLOBAL `user_profile.total_karma` (ADR 0050) and a yazar's and a mod's vote
-		 * each weigh `+1` (the divan gate admits both identically).
+		 * The divan-authorized cast (#1288): {@link cast} but ACCEPTS a sandboxed target. Its
+		 * only caller is the `features/divan` vote mutation, which reaches it past
+		 * `requireDivanAccess` (ADR 0107) — the authorization lives at that resolver, so Vote
+		 * stays vocabulary-free about the divan.
 		 */
 		readonly castOnSandboxed: (input: VoteInput) => Effect.Effect<VoteResult, VoteTargetNotFound>;
-		/**
-		 * Batched `myVote` presence read: the subset of `targetIds` the viewer has
-		 * a `user_vote` row for, of the given `kind`, in one `IN (...)` read so
-		 * callers stamp `myVote` without an N+1. Missing viewer or empty
-		 * `targetIds` short-circuits to an empty Set with no read.
-		 */
+		/** The subset of `targetIds` the viewer voted on, in one `IN (...)` read (no N+1). */
 		readonly readMine: (
 			viewerId: string | null | undefined,
 			kind: TargetKind,
 			targetIds: ReadonlyArray<string>,
 		) => Effect.Effect<Set<string>>;
 		/**
-		 * The single vote-cleanup home for the removal substrate (ADR 0096 §3):
-		 * wipe the per-target vote rows (`*_vote`) and the `user_vote` mirror for one
-		 * target, in **one** D1 batch (ADR 0014). Karma is **KEPT** — there is no
-		 * `total_karma` decrement here, so removing content never reverses the karma
-		 * its upvotes earned (sözlük's keep rule, generalized; pano's reversal is
-		 * deleted). The caller stamps `Removed` on the content row and recomputes the
-		 * summary caches outside this batch (recomputable caches, ADR 0011/0096).
+		 * The single vote-cleanup home for the removal substrate (ADR 0096 §3). Karma is
+		 * deliberately **KEPT**: removing content never reverses the karma its upvotes
+		 * earned, so there is no `total_karma` decrement here.
 		 */
 		readonly clearTarget: (kind: TargetKind, targetId: string) => Effect.Effect<void>;
 	}
@@ -189,17 +139,13 @@ export class Vote extends Context.Service<
 
 export const VoteLive = Layer.effect(Vote)(
 	Effect.gen(function* () {
-		// `orDieAccess`: every internal DB call site dies on `DrizzleError`
-		// (infra failures are defects — the domain-boundary rule), so public
-		// signatures carry domain errors only and `R` stays `never`.
+		// `orDieAccess`: infra failures die as defects, so the public signatures below
+		// carry domain errors only.
 		const {run, batch} = orDieAccess(yield* Drizzle);
 		const karmaBump = yield* KarmaBump;
 		const voterStanding = yield* VoterStanding;
 		const telemetry = yield* Telemetry;
 
-		// Per-target metadata lookup. If the row is missing or removed we
-		// surface `VoteTargetNotFound` rather than letting the batch fail with
-		// an FK-shaped error.
 		const loadMeta = Effect.fn("Vote.loadMeta")(function* (kind: TargetKind, targetId: string) {
 			const meta = yield* run((db) => targetTable[kind].loadMeta(db, targetId));
 			if (!meta) {
@@ -212,19 +158,12 @@ export const VoteLive = Layer.effect(Vote)(
 			return meta;
 		});
 
-		// Idempotency probe: one point-lookup against the vote table to decide
-		// if the write would be a no-op, so re-casts/re-retracts stay cheap
-		// reads (the `isCast === alreadyCast` path skips the batch).
 		const probeExisting = (kind: TargetKind, targetId: string, userId: string) =>
 			run((db) => targetTable[kind].probeVote(db, targetId, userId));
 
-		// Read the truth-derived score back from the cache the batch just
-		// refreshed; also serves the idempotent path's tail.
 		const readCachedScore = (kind: TargetKind, targetId: string) =>
 			run((db) => targetTable[kind].readScore(db, targetId));
 
-		// Lives here (not in each consuming feature) because Vote owns the
-		// cross-product `user_vote` table. See the `readMine` interface doc.
 		const readMine = Effect.fn("Vote.readMine")(function* (
 			viewerId: string | null | undefined,
 			kind: TargetKind,
@@ -246,31 +185,19 @@ export const VoteLive = Layer.effect(Vote)(
 			return new Set(rows.map((r) => r.targetId));
 		});
 
-		// Shared cast body carrying the TWO internal eligibility regimes, never exposed — the
-		// public surface is two named methods so a caller can't pass the wrong regime:
-		//   • `allowSandboxed`   — the *target*-liveness regime: `cast` (false → reject sandboxed)
-		//     vs `castOnSandboxed` (true → accept), the divan-authorized path (#1288).
-		//   • `requireVoterTier` — the *voter*-tier regime ("earn to vote", #1810): `cast` (true →
-		//     a newcomer voter is rejected) vs `castOnSandboxed` (false → exempt: the divan gate
-		//     at the resolver already admits only yazar/mod, so re-gating tier here would be
-		//     redundant and would wrongly deny a divan-authorized mod).
-		// The real authorization for the sandboxed path is the divan gate at the resolver, not
-		// these booleans.
+		// Both booleans stay private — the public surface is two named methods so a caller
+		// can't pass the wrong regime. `requireVoterTier` is OFF for `castOnSandboxed`: the
+		// divan gate at the resolver already admits only yazar/mod, and re-gating tier here
+		// would wrongly deny a divan-authorized mod.
 		const castImpl = Effect.fn("Vote.castImpl")(function* (
 			input: VoteInput,
 			allowSandboxed: boolean,
 			requireVoterTier: boolean,
 		) {
-			// Voter-tier gate — the SINGLE choke point for all three inline cast paths (pano
-			// post/comment + sözlük definition all reach here via `cast`). Runs before any read
-			// of the target so a newcomer's cast is refused loudly (a typed `VoterNotEligible`,
-			// wire `VOTE_REQUIRES_YAZAR` — its wire code + `need` tier are single-sourced from
-			// `VOTE_REQUIRED_TIER` in `errors.ts`), never a silent no-op. "Above the çaylak floor"
-			// is resolved by the `VoterStanding` seam (discharged by Kunye at `fate/layers.ts`), keeping the
-			// tier vocabulary out of Vote. Gated on `input.value` (the CAST direction only): a
-			// retraction removes influence, never adds it, and a newcomer never cleared the gate
-			// to hold a vote worth retracting — so retraction stays open (and the retract
-			// mutations' error unions need no `VoterNotEligible` arm).
+			// Deliberately gated on `input.value` — the CAST direction only. A retraction
+			// removes influence rather than adding it, and a newcomer never cleared the gate to
+			// hold a vote worth retracting, so retraction stays open and the retract mutations'
+			// error unions need no `VoterNotEligible` arm.
 			if (requireVoterTier && input.value) {
 				const eligible = yield* voterStanding.isAboveNewcomer(input.userId);
 				if (!eligible) {
@@ -297,7 +224,6 @@ export const VoteLive = Layer.effect(Vote)(
 			const alreadyCast = yield* probeExisting(input.targetKind, input.targetId, input.userId);
 
 			if (isCast === alreadyCast) {
-				// State matches intent: no write, return the cached score.
 				const score = yield* readCachedScore(input.targetKind, input.targetId);
 				return {
 					targetKind: input.targetKind,
@@ -309,21 +235,15 @@ export const VoteLive = Layer.effect(Vote)(
 				} satisfies VoteResult;
 			}
 
-			// State change — see `buildBatchStatements` for the atomic batch.
 			const karmaDelta = isCast ? 1 : -1;
 
 			yield* batch((db) =>
 				buildBatchStatements(db, input, meta, isCast, karmaDelta, now, karmaBump),
 			);
 
-			// Reference instrument #1 (ADR 0153, epic #2065). Emit AFTER the atomic batch
-			// commits, so a rolled-back cast — and every idempotent no-op above, which
-			// returns before reaching here — emits nothing. `surface` is the vote's
-			// `targetKind` (definition|post|comment), `userId` the caster (a
-			// deliberately-approximate blob, ADR 0153). Emitted BARE: `TelemetryLive`
-			// contains the whole failure Cause — a `DatasetError` OR a defect — inside the
-			// seam (`Effect.ignoreCause`, ADR 0153 S4 / #2085), so `emit: Effect<void>`
-			// cannot fail or die and a call-site wrap would be redundant.
+			// Emit AFTER the batch commits, so a rolled-back cast emits nothing. Bare on
+			// purpose: `TelemetryLive` swallows its whole failure Cause inside the seam
+			// (ADR 0153 S4), so wrapping this call site would be redundant.
 			yield* telemetry.emit({
 				feature: "vote",
 				action: isCast ? "cast" : "retract",
@@ -345,12 +265,10 @@ export const VoteLive = Layer.effect(Vote)(
 
 		return {
 			readMine,
-			// `cast`: reject a sandboxed target AND require the voter be above the çaylak floor.
 			cast: (input: VoteInput) => castImpl(input, false, true),
 			castOnSandboxed: (input: VoteInput) =>
-				// `castImpl` with the sandbox gate open (and the voter-tier gate OFF — the divan
-				// resolver already admits only yazar/mod) never surfaces VoteTargetSandboxed or
-				// VoterNotEligible, so the divan path's error channel is VoteTargetNotFound only.
+				// With both gates off, `castImpl` can surface neither VoteTargetSandboxed nor
+				// VoterNotEligible — hence the narrowing cast.
 				castImpl(input, true, false) as Effect.Effect<VoteResult, VoteTargetNotFound>,
 			clearTarget: Effect.fn("Vote.clearTarget")(function* (kind: TargetKind, targetId: string) {
 				yield* batch((db) => buildClearTargetStatements(db, kind, targetId));
@@ -359,11 +277,6 @@ export const VoteLive = Layer.effect(Vote)(
 	}),
 );
 
-/**
- * The two statements clearing one target's votes: the per-target `*_vote` rows
- * and the `user_vote` mirror, no karma touched. `db.batch` commits both or
- * neither (ADR 0014), so a removed entity never carries orphan vote rows.
- */
 function buildClearTargetStatements(db: DrizzleDb, kind: TargetKind, targetId: string) {
 	return [
 		targetTable[kind].clearVotes(db, targetId),
@@ -374,14 +287,9 @@ function buildClearTargetStatements(db: DrizzleDb, kind: TargetKind, targetId: s
 }
 
 /**
- * The tuple of statements making up one atomic state-change, in order:
- * karma bump + its provenance ledger row (both from `KarmaBump`, #2592, guarded on
- * the PRE-mutation vote-row state), then the vote-table mutation (truth source),
- * score-cache update, and `user_vote` mirror. `db.batch([...])` commits all or none
- * (ADR 0014) and runs the tuple in order, so the karma pair is evaluated BEFORE the
- * vote write it credits — the guard reads the row's presence as it was, which is what
- * makes a raced duplicate cast a karma no-op (#2552). The vote/score/mirror writes are
- * each already collision-tolerant (`onConflictDoNothing`, `COUNT(*)` recompute).
+ * Order is load-bearing: `db.batch` runs the tuple in sequence, so the karma pair must
+ * come BEFORE the vote write it credits — its guard reads the row's presence as it was,
+ * which is what makes a raced duplicate cast a karma no-op (#2552).
  */
 function buildBatchStatements(
 	db: DrizzleDb,

--- a/apps/web/worker/features/vote/Vote.unit.test.ts
+++ b/apps/web/worker/features/vote/Vote.unit.test.ts
@@ -1,15 +1,9 @@
 /**
  * Vote unit coverage — the decisions that are wrong-or-right with no database
- * (ADR 0082). The `Drizzle` seam is substituted directly (`Drizzle.test.ts`
- * half-A idiom): a `run`/`batch` that THROWS proves a short-circuit never
- * touched the DB, and a stubbed `run` feeds the decision its inputs without an
- * engine. Vote's real-D1 fidelity — composite-PK idempotency (score stays 1 on
- * re-cast), aggregate counters, soft-delete `VoteTargetNotFound`, the cast
- * round-trip — lives on real D1 over the fate ops in `tests/integration/`
- * (`pano-comments.test.ts` vote idempotency/round-trip, `pano-mutations.test.ts`
- * vote/retract, `pasaport.test.ts` totalKarma 0→1→0); its batch-atomicity
- * rollback is the generic `db.batch` all-or-nothing property proven in
- * `db/Drizzle.test.ts`.
+ * (ADR 0082). Throughout, a `run`/`batch` that THROWS is the proof that a
+ * short-circuit never touched the DB. Vote's real-D1 fidelity (composite-PK
+ * idempotency, aggregate counters, soft-delete, the cast round-trip) lives in
+ * `tests/integration/`.
  */
 import {assert, describe, it} from "@effect/vitest";
 import {wireCodeOfClass} from "@kampus/fate-effect";
@@ -22,10 +16,8 @@ import {Telemetry} from "../telemetry/Telemetry.ts";
 import {VOTE_ELIGIBILITY_WIRE_CODE, VOTE_REQUIRED_TIER, VoterNotEligible} from "./errors.ts";
 import {KarmaBump, type KarmaBumpInput, Vote, VoteLive, VoterStanding} from "./Vote.ts";
 
-// A recording `Telemetry` seam: `emit` pushes each event into `sink` and succeeds,
-// so a test can assert the exact `{feature, action, surface, userId}` a cast emitted
-// — and that a rejected/no-op cast emits nothing (empty sink). Substitutes the
-// `Telemetry` tag directly (`.patterns/effect-testing.md`), no real Analytics Engine.
+// Substitutes the `Telemetry` tag directly (.patterns/effect-testing.md) — an empty
+// `sink` is the proof that a rejected or no-op cast emitted nothing.
 const recordingTelemetry = (sink: TelemetryEvent[]) =>
 	Layer.succeed(Telemetry, {
 		emit: (event) =>
@@ -34,26 +26,22 @@ const recordingTelemetry = (sink: TelemetryEvent[]) =>
 			}),
 	});
 
-// A `Telemetry` whose `emit` DIES — the commit-ordering double. The real `TelemetryLive`
-// discharges the WHOLE Cause internally (`Effect.ignoreCause`, #2085) so `emit` is `Effect<void>`
-// and a defect can never surface; substituting the tag with this dying double bypasses that
-// seam, so it can only prove the cast is committed BEFORE the emit runs (the seam-level S4 proof
-// itself lives in `Telemetry.unit.test.ts`), never fed through the real containment.
+// A `Telemetry` whose `emit` DIES. Substituting the tag bypasses `TelemetryLive`'s own
+// `Effect.ignoreCause` containment (#2085), so this can only prove commit-before-emit
+// ordering — the S4 containment proof itself lives in `Telemetry.unit.test.ts`.
 const failingTelemetry = Layer.succeed(Telemetry, {
 	emit: () => Effect.die(new Error("telemetry emit blew up — off the commit path")),
 });
 
-// A `Drizzle` whose every call throws — provided so that any path which actually
-// reaches the DB seam fails the test. A guard that short-circuits before reading
-// runs to completion against it, which is exactly the "no read" proof.
+// Every call throws on purpose: any path that reaches the DB seam fails the test, so
+// running to completion against it IS the "no read" proof.
 const throwingAccess: DrizzleAccess = {
 	run: () => Effect.die(new Error("Vote read the DB on a path that must short-circuit")),
 	batch: () => Effect.die(new Error("Vote wrote a batch on a path that must short-circuit")),
 };
 
-// A `Drizzle` whose `run` replays a queued sequence of results and whose `batch`
-// throws — used to drive `cast`'s pre-batch decision (loadMeta + probe + cached
-// score) while proving the idempotent no-op never reaches `batch`.
+// `run` replays a queued sequence of results; `batch` throws, so an idempotent no-op
+// that reaches the write fails the test.
 function scriptedAccess(results: ReadonlyArray<unknown>): {access: DrizzleAccess; runs: number} {
 	const state = {i: 0};
 	const access: DrizzleAccess = {
@@ -78,9 +66,8 @@ const KarmaBumpStub = Layer.succeed(KarmaBump, {
 	},
 });
 
-// A `VoterStanding` stub with a fixed eligibility verdict. `eligible` (the default) is
-// the "voter is above the çaylak floor" case, so tests NOT exercising the tier gate see
-// their prior behaviour; `caylak` (below the floor) drives the #1810 gate rejection.
+// `eligible` (the default) is above the çaylak floor; `caylak` is below it and drives
+// the #1810 gate rejection.
 const VoterStandingStub = (aboveNewcomer: boolean) =>
 	Layer.succeed(VoterStanding, {isAboveNewcomer: () => Effect.succeed(aboveNewcomer)});
 
@@ -126,7 +113,6 @@ describe("Vote.cast — pre-write decisions (mocked Drizzle seam)", () => {
 	it.effect("a missing target raises VoteTargetNotFound before any write", () =>
 		Effect.gen(function* () {
 			const vote = yield* Vote;
-			// loadMeta's findFirst resolves to `undefined` → not-found, no batch.
 			const exit = yield* Effect.exit(
 				vote.cast({userId: "u1", targetKind: "definition", targetId: "ghost", value: true}),
 			);
@@ -136,11 +122,8 @@ describe("Vote.cast — pre-write decisions (mocked Drizzle seam)", () => {
 	);
 
 	it.effect("re-casting an already-cast vote is an idempotent no-op — no batch, no karma", () => {
-		// run #1 loadMeta → a live target row; run #2 probeExisting → already cast;
-		// run #3 readCachedScore → the cached score. The `batch` + KarmaBump stubs
-		// throw, so reaching either fails the test.
-		// loadMeta reads the row's `authorId`/`createdAt`; probeExisting + readCachedScore
-		// return a bool + number directly (the queued values ARE each `run` fn's result).
+		// The queued values ARE each `run` fn's result, in call order: loadMeta row,
+		// probeExisting bool, readCachedScore number.
 		const row = {authorId: "author-1", createdAt: new Date()};
 		const {access} = scriptedAccess([row, true, 7]);
 		return Effect.gen(function* () {
@@ -175,14 +158,11 @@ describe("Vote.cast — pre-write decisions (mocked Drizzle seam)", () => {
 	});
 });
 
-// A `Drizzle` that runs the batch builder against a stub db and records the
-// produced statement array, so we can assert clearTarget's batch SHAPE (ADR 0096
-// §3) without a real engine: exactly two statements (votes + user_vote), and —
-// since KarmaBumpStub throws if reached — no karma statement.
+// Records the statement array the batch builder produces, so clearTarget's batch SHAPE
+// (ADR 0096 §3) is assertable without an engine.
 function recordingBatchAccess(): {access: DrizzleAccess; batches: ReadonlyArray<unknown>[]} {
 	const batches: ReadonlyArray<unknown>[] = [];
-	// A db proxy whose every `.delete(...).where(...)` chain returns a marker. We
-	// only count statements, so each chained call yields a chainable stand-in.
+	// Only statement COUNT matters here, so every chained db call yields a stand-in.
 	const chainable: Record<string, (...a: unknown[]) => unknown> = {};
 	const dbProxy: unknown = new Proxy(chainable, {
 		get: () => () => dbProxy,
@@ -198,10 +178,8 @@ function recordingBatchAccess(): {access: DrizzleAccess; batches: ReadonlyArray<
 	return {access, batches};
 }
 
-// A recording write-path seam: `run` replays the pre/post-batch reads (loadMeta,
-// probe, post-batch score) and `batch` records the produced statement array against a
-// chainable db proxy, so a state-changing cast can be asserted (it reaches the write and
-// its batch carries the karma statement) without a real engine.
+// `run` replays the pre/post-batch reads and `batch` records the produced statements,
+// so a state-changing cast is assertable without an engine.
 function recordingCastAccess(reads: ReadonlyArray<unknown>): {
 	access: DrizzleAccess;
 	batches: ReadonlyArray<unknown>[];
@@ -223,11 +201,9 @@ function recordingCastAccess(reads: ReadonlyArray<unknown>): {
 	return {access, batches};
 }
 
-// A KarmaBump that RECORDS each bump's full context and returns the TWO sentinel
-// statements the real contract now emits (the `total_karma` bump + its `karma_event`
-// provenance row, #2592), so a cast's karma credit is observable: who got karma, by how
-// much, from which source, and why. `calls` keeps the recipient+delta shape prior
-// assertions read; `inputs` exposes the source/reason/timestamp the ledger row carries.
+// Returns the TWO sentinel statements the real contract emits (the `total_karma` bump
+// plus its `karma_event` provenance row, #2592). `calls` carries recipient+delta,
+// `inputs` the source/reason/timestamp the ledger row records.
 function recordingKarma(): {
 	layer: Layer.Layer<KarmaBump>;
 	calls: {userId: string; delta: number}[];
@@ -250,8 +226,8 @@ const liveMeta = {authorId: "author-1", createdAtMs: 0, sandboxed: false};
 
 describe("Vote.cast — sandbox eligibility (#1288, mocked Drizzle seam)", () => {
 	it.effect("cast REJECTS a sandboxed target with VoteTargetSandboxed before any write", () =>
-		// loadMeta → a still-sandboxed row; the eligibility guard short-circuits before the
-		// probe/batch (the throwing batch proves no write).
+		// The eligibility guard short-circuits before the probe/batch; the throwing batch
+		// proves no write.
 		Effect.gen(function* () {
 			const vote = yield* Vote;
 			const exit = yield* Effect.exit(
@@ -263,8 +239,7 @@ describe("Vote.cast — sandbox eligibility (#1288, mocked Drizzle seam)", () =>
 	);
 
 	it.effect("castOnSandboxed ACCEPTS a sandboxed target — scores + credits the author", () => {
-		// reads: loadMeta (sandboxed) → probe (not yet cast) → post-batch score. The cast
-		// reaches the atomic batch; the recording karma proves +1 credited to the AUTHOR.
+		// reads: loadMeta (sandboxed) → probe (not yet cast) → post-batch score.
 		const {access, batches} = recordingCastAccess([sandboxedMeta, false, 1]);
 		const {layer: karma, calls, inputs} = recordingKarma();
 		return Effect.gen(function* () {
@@ -288,15 +263,12 @@ describe("Vote.cast — sandbox eligibility (#1288, mocked Drizzle seam)", () =>
 				[{userId: "caylak-1", delta: 1}],
 				"karma credited to the content author, +1 (D2 global karma, D3 equal weight)",
 			);
-			// The provenance the ledger row records: source target + reason (#2592).
 			assert.deepStrictEqual(inputs[0]?.source, {kind: "definition", id: "def-sb"});
 			assert.strictEqual(inputs[0]?.reason, "vote");
 		}).pipe(
 			Effect.provide(
 				VoteLive.pipe(
 					Layer.provide(karma),
-					// Voter above the çaylak floor — the #1810 tier gate is not what these two
-					// tests exercise (divan path has it OFF; the live path is a promoted voter).
 					Layer.provide(VoterStandingStub(true)),
 					Layer.provide(recordingTelemetry([])),
 					Layer.provide(Layer.succeed(Drizzle, access)),
@@ -329,8 +301,6 @@ describe("Vote.cast — sandbox eligibility (#1288, mocked Drizzle seam)", () =>
 			Effect.provide(
 				VoteLive.pipe(
 					Layer.provide(karma),
-					// Voter above the çaylak floor — the #1810 tier gate is not what these two
-					// tests exercise (divan path has it OFF; the live path is a promoted voter).
 					Layer.provide(VoterStandingStub(true)),
 					Layer.provide(recordingTelemetry([])),
 					Layer.provide(Layer.succeed(Drizzle, access)),
@@ -341,10 +311,8 @@ describe("Vote.cast — sandbox eligibility (#1288, mocked Drizzle seam)", () =>
 });
 
 describe("Vote.cast — voter-tier gate ('earn to vote', #1810, mocked Drizzle seam)", () => {
-	// The three inline cast paths (pano post/comment + sözlük definition) all reach the
-	// single `Vote.castImpl` choke point via `cast`. A çaylak (below-floor) voter is
-	// rejected on EACH before any DB read — the throwing `Drizzle` proves the short-circuit
-	// runs ahead of `loadMeta`, so the gate never even looks at the target.
+	// All three inline cast paths funnel through the one `Vote.castImpl` choke point, so
+	// each is checked here; the throwing `Drizzle` proves the gate runs ahead of `loadMeta`.
 	for (const kind of TARGET_KINDS) {
 		it.effect(
 			`${kind}: a çaylak (below-floor) voter is REJECTED with VoterNotEligible — no DB read`,
@@ -359,9 +327,8 @@ describe("Vote.cast — voter-tier gate ('earn to vote', #1810, mocked Drizzle s
 							value: true,
 						}),
 					);
-					// `flip` surfaces the typed error as the success channel so we assert on the
-					// `VoterNotEligible` instance itself — its `need` bar comes from the single
-					// source (Vote no longer re-bakes a raw tier string, the #2021 contract).
+					// `flip` moves the typed error into the success channel so the instance
+					// itself is assertable.
 					assert.isTrue(
 						err instanceof VoterNotEligible,
 						"a çaylak cast fails with VoterNotEligible",
@@ -374,8 +341,8 @@ describe("Vote.cast — voter-tier gate ('earn to vote', #1810, mocked Drizzle s
 	}
 
 	it("VoterNotEligible.need + its wire code are single-sourced from VOTE_REQUIRED_TIER (#2021)", () => {
-		// The tier name and the wire code are ONE fact: the error's `need` is `VOTE_REQUIRED_TIER`
-		// and its `FateWireCode` is derived from it, so a ladder move can't drift them apart.
+		// The tier name and the wire code are ONE fact — the code is derived from `need`, so
+		// a ladder move can't drift them apart.
 		const err = new VoterNotEligible({
 			voterId: UserId.make("u1"),
 			need: VOTE_REQUIRED_TIER,
@@ -386,15 +353,13 @@ describe("Vote.cast — voter-tier gate ('earn to vote', #1810, mocked Drizzle s
 			VOTE_ELIGIBILITY_WIRE_CODE,
 			`VOTE_REQUIRES_${VOTE_REQUIRED_TIER.toUpperCase()}`,
 		);
-		// The annotation on the error class reads back the derived code, not a hand-typed literal.
 		assert.strictEqual(wireCodeOfClass(VoterNotEligible), VOTE_ELIGIBILITY_WIRE_CODE);
-		// With the current ladder rank the derived code is the literal the SPA copy decodes.
+		// At the current ladder rank the derived code is the literal the SPA copy decodes.
 		assert.strictEqual(VOTE_ELIGIBILITY_WIRE_CODE, "VOTE_REQUIRES_YAZAR");
 	});
 
 	it.effect("a promoted (above-floor) voter still casts normally on a live target", () => {
-		// reads: loadMeta (live) → probe (not yet cast) → post-batch score. The eligible voter
-		// clears the gate and the cast reaches the atomic batch (+1 to the author).
+		// reads: loadMeta (live) → probe (not yet cast) → post-batch score.
 		const {access, batches} = recordingCastAccess([liveMeta, false, 1]);
 		const {layer: karma, calls} = recordingKarma();
 		return Effect.gen(function* () {
@@ -423,9 +388,8 @@ describe("Vote.cast — voter-tier gate ('earn to vote', #1810, mocked Drizzle s
 	it.effect(
 		"a çaylak RETRACTING is not tier-gated — a retraction removes influence, never adds",
 		() => {
-			// A çaylak has no cast to retract in practice, but the gate is CAST-direction-only:
-			// `value: false` skips it. Here the retraction is an idempotent no-op (never-cast),
-			// so it returns cleanly with `changed: false` rather than raising VoterNotEligible.
+			// The tier gate is CAST-direction-only, so `value: false` skips it — a çaylak
+			// retraction returns `changed: false` rather than raising VoterNotEligible.
 			const {access} = scriptedAccess([liveMeta, false, 0]);
 			return Effect.gen(function* () {
 				const vote = yield* Vote;
@@ -443,8 +407,7 @@ describe("Vote.cast — voter-tier gate ('earn to vote', #1810, mocked Drizzle s
 	it.effect(
 		"the target-liveness gate still holds — an eligible voter is rejected on a sandboxed target",
 		() =>
-			// An above-floor voter clears the tier gate but the target is sandboxed, so the
-			// EXISTING VoteTargetSandboxed gate (#1288) still fires: both gates compose.
+			// Both gates compose: clearing the tier floor does not clear #1288's sandbox gate.
 			Effect.gen(function* () {
 				const vote = yield* Vote;
 				const exit = yield* Effect.exit(
@@ -463,9 +426,8 @@ describe("Vote.cast — voter-tier gate ('earn to vote', #1810, mocked Drizzle s
 
 describe("Vote.cast — karma provenance ledger (#2592, mocked Drizzle seam)", () => {
 	it.effect("a real retraction co-commits a -1 ledger event with reason 'retract'", () => {
-		// reads: loadMeta (live) → probe (already cast) → post-batch score. `value:false` on an
-		// existing vote is a state change, so it reaches the batch with karmaDelta -1 — and the
-		// ledger row records the negative delta as an event, never a deletion (append-only).
+		// reads: loadMeta (live) → probe (already cast) → post-batch score. The ledger records
+		// the -1 as an event, never a deletion (append-only).
 		const {access, batches} = recordingCastAccess([liveMeta, true, 0]);
 		const {layer: karma, calls, inputs} = recordingKarma();
 		return Effect.gen(function* () {
@@ -496,13 +458,9 @@ describe("Vote.cast — karma provenance ledger (#2592, mocked Drizzle seam)", (
 });
 
 describe("Vote.cast — the guarded karma pair leads the batch (#2552, mocked Drizzle seam)", () => {
-	// The double-bump fix: the karma bump + its ledger row are gated on the vote row's
-	// PRE-mutation presence, so a duplicate cast that raced the out-of-batch probe writes
-	// neither. That guard is only correct if the karma pair is evaluated BEFORE the vote-row
-	// write in the batch — so this pins the ordering. `recordingKarma` returns the two karma
-	// sentinels; the vote/score/mirror statements come from the db proxy, so the sentinels
-	// leading `batches[0]` proves karma is sequenced first, and `inputs[0].guard` proves Vote
-	// threaded the pre-mutation predicate through.
+	// The karma pair is gated on the vote row's PRE-mutation presence, which is only
+	// correct if karma is evaluated BEFORE the vote-row write in the batch. These tests pin
+	// that ordering: the karma sentinels must lead `batches[0]`.
 	it.effect(
 		"karma bump + ledger row are the first two batch statements, and carry the guard",
 		() => {
@@ -561,14 +519,8 @@ describe("Vote.clearTarget — cleanup batch shape (ADR 0096 §3, mocked Drizzle
 	}
 });
 
-// Reference instrument #1 (ADR 0153, epic #2065, #2068): `Vote.cast` emits a `vote`
-// telemetry event after a committed cast. Recording/failing `Telemetry` doubles at the
-// tag prove: the emit carries the right positional fields, fires ONLY on a committed
-// state change (never on a no-op or a rejected cast), distinguishes cast vs retract, and
-// — S4 fail-safe — can never fail the vote even when the seam itself blows up.
+// Reference instrument #1 — see ADR 0153 (epic #2065, #2068).
 describe("Vote.cast — telemetry instrument (ADR 0153, #2068, mocked Drizzle + Telemetry seams)", () => {
-	// Build a VoteLive whose Telemetry is the given double and whose write-path Drizzle is a
-	// recording cast access, so a state-changing cast reaches the emit.
 	const instrumentLayer = (access: DrizzleAccess, telemetry: Layer.Layer<Telemetry>) => {
 		const {layer: karma} = recordingKarma();
 		return VoteLive.pipe(
@@ -653,9 +605,8 @@ describe("Vote.cast — telemetry instrument (ADR 0153, #2068, mocked Drizzle + 
 	});
 
 	it.effect("a rejected cast (voter-not-eligible) emits NOTHING", () => {
-		// Below-floor voter → VoterNotEligible before any DB read, so no emit. The throwing
-		// Drizzle proves the short-circuit; the recording Telemetry proves the reject path
-		// never reaches the emit.
+		// The throwing Drizzle proves the short-circuit; the empty sink proves the reject
+		// path never reaches the emit.
 		const sink: TelemetryEvent[] = [];
 		return Effect.gen(function* () {
 			const vote = yield* Vote;
@@ -677,13 +628,10 @@ describe("Vote.cast — telemetry instrument (ADR 0153, #2068, mocked Drizzle + 
 	});
 
 	it.effect("the emit is off the commit path — the cast commits before the emit runs", () => {
-		// The `Telemetry` double's `emit` DIES. The vote batch is sequenced BEFORE the emit,
-		// so its statement is already in `batches` (the cast committed) even as the emit blows
-		// up — proving the emit is downstream of the commit, never a gate on it. Since #2085
-		// the vote emits BARE (no call-site wrap): the production fail-safe that turns a defect
-		// into a swallowed no-op lives in `TelemetryLive` (`Effect.ignoreCause`) and is pinned
-		// seam-side in `Telemetry.unit.test.ts`; this double substitutes the `Telemetry` tag so
-		// it never reaches that seam, and here we only assert the commit-before-emit ordering.
+		// The batch is already recorded even as the dying emit blows up, which is the proof
+		// that the emit is downstream of the commit. Since #2085 the vote emits BARE — the
+		// fail-safe lives in `TelemetryLive` and is pinned in `Telemetry.unit.test.ts`, so
+		// this substituted double can only show the ordering.
 		const {access, batches} = recordingCastAccess([liveMeta, false, 1]);
 		return Effect.gen(function* () {
 			const vote = yield* Vote;

--- a/apps/web/worker/features/vote/errors.ts
+++ b/apps/web/worker/features/vote/errors.ts
@@ -1,10 +1,9 @@
 /**
  * Tagged errors raised by the Vote service layer.
  *
- * `VoteTargetNotFound` carries NO `FateWireCode` by design: it never reaches the
- * wire. Consuming services translate it at their own boundary via
- * `Effect.catchTag` (→ `DefinitionNotFound` / `PostNotFound` / `CommentNotFound`),
- * so fate handlers only ever emit the feature-level not-found errors.
+ * `VoteTargetNotFound` carries NO `FateWireCode` by design: it never reaches the wire.
+ * Consuming services translate it at their own boundary, so fate handlers only ever emit
+ * the feature-level not-found errors.
  */
 import {FateWireCode} from "@kampus/fate-effect";
 import * as Schema from "effect/Schema";
@@ -21,13 +20,9 @@ export class VoteTargetNotFound extends Schema.TaggedErrorClass<VoteTargetNotFou
 ) {}
 
 /**
- * The target is **sandboxed** (a çaylak's not-yet-promoted content, ADR 0096 §sandbox)
- * and the cast came through the ordinary `Vote.cast` surface, which is not authorized to
- * score sandboxed content. A sandboxed item is votable ONLY through `Vote.castOnSandboxed`,
- * reached past the divan gate (`features/divan`, #1287/#1288). Carries no `FateWireCode`
- * for the same reason as {@link VoteTargetNotFound}: a consuming inline service translates
- * it at its own boundary (→ `DefinitionNotFound` / `PostNotFound` / `CommentNotFound`), so a
- * sandboxed item simply reads as not-found to a non-divan voter.
+ * A sandboxed target is votable ONLY through `Vote.castOnSandboxed`, past the divan gate
+ * (#1287/#1288). Carries no `FateWireCode` for the same reason as {@link VoteTargetNotFound},
+ * so a sandboxed item simply reads as not-found to a non-divan voter.
  */
 export class VoteTargetSandboxed extends Schema.TaggedErrorClass<VoteTargetSandboxed>()(
 	"vote/VoteTargetSandboxed",
@@ -39,40 +34,27 @@ export class VoteTargetSandboxed extends Schema.TaggedErrorClass<VoteTargetSandb
 ) {}
 
 /**
- * The tier a voter must reach to cast on live content ("earn to vote", #1810) — the SINGLE
- * source both the {@link VoterNotEligible} wire code and its `need` field derive from, so the
- * tier name and the wire code can't drift apart across sites. The rejection's rank name lives
- * ONCE here: `Vote.castImpl` reads it for `VoterNotEligible.need` (it no longer re-bakes a raw
- * `"yazar"` string), and {@link VOTE_ELIGIBILITY_WIRE_CODE} is derived from it — a ladder move
- * (a new required rank) is a one-token edit here that moves the `need` field and the wire code
- * together, never an edit that touches Vote's internals.
+ * The tier a voter must reach to cast on live content ("earn to vote", #1810). The SINGLE
+ * source both {@link VoterNotEligible}'s `need` field and its wire code derive from, so a
+ * ladder move is a one-token edit here.
  */
 export const VOTE_REQUIRED_TIER = "yazar" as const;
 
 /**
- * The `FateWireCode` for {@link VoterNotEligible}, DERIVED from {@link VOTE_REQUIRED_TIER} so
- * the required-tier name and the wire code are one fact, not two that can drift. Distinct from
- * the overloaded `FORBIDDEN` (künye vouch denials) so the vote gate carries its own ladder copy
- * ("yazar olunca oy verebilirsin") without recopying `FORBIDDEN` and mislabelling those (#1879).
- * With `VOTE_REQUIRED_TIER = "yazar"` this is the literal `"VOTE_REQUIRES_YAZAR"` the SPA copy
- * (`src/fate/wireMessages.ts`) and the fate wire-code allowlist already decode.
+ * Derived from {@link VOTE_REQUIRED_TIER}, and deliberately distinct from the overloaded
+ * `FORBIDDEN` so the vote gate carries its own ladder copy without mislabelling künye's
+ * denials (#1879). Today it is the literal `"VOTE_REQUIRES_YAZAR"` the SPA copy and the
+ * fate wire-code allowlist decode.
  */
 export const VOTE_ELIGIBILITY_WIRE_CODE =
 	`VOTE_REQUIRES_${VOTE_REQUIRED_TIER.toUpperCase()}` as const;
 
 /**
- * The **voter** is not yet eligible to cast — their account tier is at or below the
- * çaylak newcomer floor, and voting on live content is an earned privilege ("earn to
- * vote", the #1810 containment). Unlike {@link VoteTargetSandboxed} (a *target*-liveness
- * gate that reads as not-found), this is a *voter*-tier rejection and DOES reach the wire
- * as a visible {@link VOTE_ELIGIBILITY_WIRE_CODE} — the same "the ladder is a visible
- * progression" idiom as `kunye/RequiresLevel`, so a çaylak sees a clear "vote once promoted"
- * denial rather than a silent no-op or a mislabelled not-found. Carries the `need`ed tier
- * ({@link VOTE_REQUIRED_TIER}) so the surface can name the bar. The gate is the SINGLE choke
- * point in `Vote.castImpl` (the `requireVoterTier` regime), covering all three inline cast
- * paths — pano post/comment + sözlük definition — and is NOT applied on the divan-authorized
- * `castOnSandboxed` path (a yazar/mod is already above the floor and the divan gate is the
- * authorization there, #1288).
+ * The voter's tier is below the bar (#1810). Unlike {@link VoteTargetSandboxed}, this DOES
+ * reach the wire: the ladder is a visible progression, so a çaylak sees a "vote once
+ * promoted" denial rather than a silent no-op or a mislabelled not-found. Enforced at the
+ * single choke point in `Vote.castImpl`, and NOT on the divan-authorized `castOnSandboxed`
+ * path (the divan gate is the authorization there, #1288).
  */
 export class VoterNotEligible extends Schema.TaggedErrorClass<VoterNotEligible>()(
 	"vote/VoterNotEligible",
@@ -85,24 +67,16 @@ export class VoterNotEligible extends Schema.TaggedErrorClass<VoterNotEligible>(
 ) {}
 
 /**
- * A voter tried to cast on their **own** content (`voterId === authorId`), which the
- * founder has ruled disallowed — a self-vote inflates the author's own score/karma and
- * corrupts every ranking that reads it (#2216). Like {@link VoterNotEligible} this is a
- * genuine *voter* rejection that reaches the wire (its own `SELF_VOTE_NOT_ALLOWED`
- * {@link FateWireCode}, so the SPA can name it), never a target miss. Raised at the cast
- * site (`Pano.applyPostVote` / `Sozluk.applyVote`), which already holds the target's
- * `authorId` — and only on the CAST direction (`isVote === true`): a retraction is exempt,
- * since once the cast is blocked there is no self-vote to retract (the same cast-only shape
- * as {@link VoterNotEligible}).
+ * A cast on one's own content, founder-ruled disallowed because a self-vote inflates the
+ * author's own score and corrupts every ranking reading it (#2216). Raised at the feature
+ * cast sites, which already hold the target's `authorId`, and only on the CAST direction:
+ * a blocked cast leaves no self-vote to retract.
  */
 export class SelfVoteNotAllowed extends Schema.TaggedErrorClass<SelfVoteNotAllowed>()(
 	"vote/SelfVoteNotAllowed",
 	{
-		// Unbranded `Schema.String` (unlike VoterNotEligible's `UserId`) on purpose:
-		// this error is constructed at each feature's own self-vote guard — pano
-		// (post/comment) and sözlük — not inside Vote. Until those features brand
-		// their voter id (pano #2713), a `UserId` here would fail repo-wide typecheck
-		// at the pano call sites, which the epic #2700 forbids (#2723 stays vote-local).
+		// Unbranded on purpose (unlike VoterNotEligible's `UserId`): until pano brands its
+		// voter id (#2713), a `UserId` here fails typecheck at the pano call sites.
 		voterId: Schema.String,
 		message: Schema.String,
 	},

--- a/apps/web/worker/features/vote/translate-vote-miss.ts
+++ b/apps/web/worker/features/vote/translate-vote-miss.ts
@@ -1,50 +1,21 @@
 /**
- * `translateVoteMiss` — the single home for the inline voter's "a `Vote` miss is
- * *this* caller's not-found" rule.
- *
- * The ordinary `Vote.cast` surface fails three ways an inline voter (sözlük/pano)
- * sees. Two are "not there" MISSES that collapse to this caller's own feature
- * not-found: `VoteTargetNotFound` (a raced soft-delete) and `VoteTargetSandboxed`
- * (a çaylak's not-yet-promoted content, which only the divan-gated
- * `castOnSandboxed` path may score, #1288). This combinator maps that two-arm
- * miss union to a caller-supplied not-found thunk once, replacing the
- * byte-identical inline `catchTags` blocks in `Sozluk.applyVote` /
- * `Pano.applyPostVote` / `Pano.applyCommentVote`. A new `Vote` MISS tag is a
- * one-line change here.
- *
- * The third — `VoterNotEligible` (#1810's "earn to vote" gate) — is NOT a miss: a
- * çaylak voter is genuinely REJECTED, so it passes through UNTRANSLATED and reaches
- * the wire as its own code (`VoterNotEligible`'s definition in `errors.ts` owns that
- * `FateWireCode`, single-sourced from `VOTE_REQUIRED_TIER` — this combinator never
- * re-states it). It stays in the combinator's output channel (`E | VoterNotEligible`)
- * deliberately — collapsing it to not-found would mislabel a "vote once promoted"
- * denial as "this doesn't exist".
- *
- * The divan path (`features/divan`) is deliberately NOT a caller: it uses the
- * one-arm `castOnSandboxed → Denied` translation (different method, single tag,
- * opaque target), so it stays out of this two-arm combinator.
- *
- * See ADR 0016 (resolvers translate failures to wire codes at the boundary).
+ * The single home for the inline voter's "a `Vote` miss is *this* caller's not-found"
+ * rule (ADR 0016). The divan path is deliberately NOT a caller — it has its own one-arm
+ * `castOnSandboxed → Denied` translation.
  */
 import {Effect} from "effect";
 import type {VoterNotEligible, VoteTargetNotFound, VoteTargetSandboxed} from "./errors.ts";
 
-/**
- * Map the two-arm `Vote` miss union (`VoteTargetNotFound` + `VoteTargetSandboxed`),
- * the exact error channel of `Vote.cast`, to a caller-supplied not-found error.
- * `makeNotFound` is a thunk so each failure raises a fresh error.
- */
+/** `makeNotFound` is a thunk so each failure raises a fresh error. */
 export const translateVoteMiss =
 	<E>(makeNotFound: () => E) =>
 	<A, R>(
 		self: Effect.Effect<A, VoteTargetNotFound | VoteTargetSandboxed | VoterNotEligible, R>,
 	): Effect.Effect<A, E | VoterNotEligible, R> =>
 		self.pipe(
-			// Only the two "not there" arms collapse to the caller's not-found. `VoterNotEligible`
-			// (#1810's "earn to vote" gate) is a genuine REJECTION, not a miss — it passes through
-			// UNTRANSLATED so the resolver surfaces the wire code `VoterNotEligible` owns (see its
-			// definition in `errors.ts`), never a mislabelled not-found (a çaylak must see "vote
-			// once promoted", not "this doesn't exist").
+			// `VoterNotEligible` (#1810) is deliberately absent: it is a genuine REJECTION, not a
+			// miss, and must pass through untranslated — a çaylak has to see "vote once promoted",
+			// not "this doesn't exist".
 			Effect.catchTags({
 				"vote/VoteTargetNotFound": () => Effect.fail(makeNotFound()),
 				"vote/VoteTargetSandboxed": () => Effect.fail(makeNotFound()),

--- a/apps/web/worker/features/vote/translate-vote-miss.unit.test.ts
+++ b/apps/web/worker/features/vote/translate-vote-miss.unit.test.ts
@@ -1,9 +1,8 @@
 /**
- * `translateVoteMiss` unit pins — the inline voter's "a Vote miss is this
- * caller's not-found" rule has one home now (extracted from the byte-identical
- * `catchTags` blocks in Sozluk/Pano). These prove both Vote miss tags collapse
- * to the supplied not-found, a fresh error is raised per failure, and success
- * passes through untouched — the no-behavior-change contract.
+ * The "a Vote miss is this caller's not-found" rule, extracted from byte-identical
+ * `catchTags` blocks in Sozluk/Pano. Both miss tags must collapse to the supplied
+ * not-found, each failure must raise a FRESH error, and success must pass through
+ * untouched.
  */
 import {assert, describe, it} from "@effect/vitest";
 import {Effect} from "effect";

--- a/apps/web/worker/features/vote/vote-boundary.unit.test.ts
+++ b/apps/web/worker/features/vote/vote-boundary.unit.test.ts
@@ -1,16 +1,12 @@
 /**
- * Vote feature-boundary pins — `Vote` is consumed by both Sozluk and Pano, so
- * it sits below the feature directories and must import none of them. The karma
- * counter lives in pasaport's tables and the voter tier lives in künye's, but Vote
- * OWNS both the `KarmaBump` and `VoterStanding` contracts and pasaport/künye PROVIDE
- * the implementations at composition (`fate/layers.ts`); these type-level pins keep
- * those arrows inverted by asserting what `VoteLive` REQUIRES (its `R` channel) and
- * the shape of each contract surface — the boundary's actual requirement,
- * refactor-proof. A re-imported sibling implementation would widen `R` and fail the
- * pin; nothing sibling-shaped is nameable through either contract.
+ * Vote feature-boundary pins — `Vote` is consumed by both Sozluk and Pano, so it sits
+ * below the feature directories and must import none of them. Vote OWNS the `KarmaBump`
+ * and `VoterStanding` contracts; pasaport/künye PROVIDE the implementations at
+ * composition. Asserting what `VoteLive` REQUIRES is what keeps those arrows inverted:
+ * a re-imported sibling implementation would widen `R` and fail the pin.
  *
- * Type pins use expectTypeOf, not `@ts-expect-error` — the effect LSP plugin's
- * TS377003 escapes the directive (recurring finding).
+ * Pins use `expectTypeOf`, not `@ts-expect-error` — the effect LSP plugin's TS377003
+ * escapes the directive.
  */
 import type {Effect, Layer} from "effect";
 import {describe, expectTypeOf, it} from "vitest";
@@ -21,32 +17,25 @@ import type {KarmaBump, KarmaBumpInput, Vote, VoteLive, VoterStanding} from "./V
 describe("Vote's public surface is feature-clean (type pins)", () => {
 	it("VoteLive requires the db seam + Vote's own KarmaBump + VoterStanding + the shared Telemetry seam", () => {
 		// A re-imported pasaport/künye implementation would bake the dep in and drop
-		// `KarmaBump`/`VoterStanding` from R, failing this pin. `Telemetry` is the ONE shared
-		// cross-cutting seam Vote depends on directly (ADR 0153, #2068 reference instrument):
-		// a low-level service every instrument emits through — not a peer feature, and it
-		// imports nothing from vote — so it rides `R` un-inverted, discharged by the same
-		// `makeFateLayer` merge. A drift that dropped it (an un-instrumented cast) or widened
-		// R with a sibling feature fails this pin.
+		// `KarmaBump`/`VoterStanding` from R, failing this pin. `Telemetry` rides `R`
+		// un-inverted on purpose: it is a low-level seam, not a peer feature (ADR 0153).
 		expectTypeOf<typeof VoteLive>().toEqualTypeOf<
 			Layer.Layer<Vote, never, Drizzle | KarmaBump | VoterStanding | Telemetry>
 		>();
 	});
 
 	it("the KarmaBump contract names only db primitives (DrizzleDb + KarmaBumpInput in, Stmt pair out)", () => {
-		// Nothing pasaport-shaped is nameable through the contract: `KarmaBumpInput` names only
-		// db-level primitives (`TargetKind`/`KarmaEventReason` from `db/`, not a pasaport type),
-		// and the output is the bump + its ledger row as a `[Stmt, Stmt]` pair (#2592). Also
-		// künye's swap point — a DO-backed bump replaces the provided value in `fate/layers.ts`,
-		// never Vote's internals.
+		// Nothing pasaport-shaped is nameable through the contract — only db-level primitives
+		// in, a `[Stmt, Stmt]` bump + ledger pair out (#2592). Also künye's swap point: a
+		// DO-backed bump replaces the provided value at composition, never Vote's internals.
 		expectTypeOf<typeof KarmaBump.Service>().toEqualTypeOf<{
 			readonly statements: (db: DrizzleDb, input: KarmaBumpInput) => readonly [Stmt, Stmt];
 		}>();
 	});
 
 	it("the VoterStanding contract names only a voter id → boolean predicate (no tier vocabulary)", () => {
-		// Nothing künye-shaped (no `Tier`, no ladder) is nameable through the contract —
-		// the "above the çaylak floor" comparison lives at the künye seam (`fate/layers.ts`),
-		// so the ladder can move without touching Vote. #1810.
+		// Nothing künye-shaped (no `Tier`, no ladder) is nameable here: the "above the çaylak
+		// floor" comparison lives at the künye seam, so the ladder can move without Vote (#1810).
 		expectTypeOf<typeof VoterStanding.Service>().toEqualTypeOf<{
 			readonly isAboveNewcomer: (voterId: string) => Effect.Effect<boolean>;
 		}>();

--- a/apps/web/worker/features/vote/vote-ids.typetest.ts
+++ b/apps/web/worker/features/vote/vote-ids.typetest.ts
@@ -1,9 +1,8 @@
 /**
- * Type-level assertion (no runtime — checked by `tsgo`, not vitest): the vote /
- * reaction id surfaces `UserId` (the voter) and `TargetId` (the polymorphic vote /
- * reaction target) are nominally distinct, so transposing a voter id and a target id
- * is a compile error (#2723 AC#3), while both stay plain strings at runtime. Mirrors
- * `../pasaport/pasaport-ids.typetest.ts`.
+ * Type-level assertion (no runtime — checked by `tsgo`, not vitest): `UserId` (the
+ * voter) and `TargetId` (the vote/reaction target) are nominally distinct, so
+ * transposing them is a compile error (#2723 AC#3) while both stay plain strings at
+ * runtime. Mirrors `../pasaport/pasaport-ids.typetest.ts`.
  */
 import {expectTypeOf} from "vitest";
 import type {TargetId, UserId} from "../../lib/ids.ts";
@@ -12,8 +11,7 @@ import type {TargetId, UserId} from "../../lib/ids.ts";
 expectTypeOf<UserId>().toMatchTypeOf<string>();
 expectTypeOf<TargetId>().toMatchTypeOf<string>();
 
-// The distinctness that makes a voterId/targetId swap unrepresentable: neither brand
-// is assignable to the other, so a vote/reaction can't be misrouted across the roles.
+// Neither brand is assignable to the other, so the two roles cannot be transposed.
 expectTypeOf<UserId>().not.toEqualTypeOf<TargetId>();
 expectTypeOf<UserId>().not.toMatchTypeOf<TargetId>();
 expectTypeOf<TargetId>().not.toMatchTypeOf<UserId>();

--- a/apps/web/worker/http/app.ts
+++ b/apps/web/worker/http/app.ts
@@ -1,11 +1,6 @@
 /**
  * `AppLive` — the single router layer the worker's `fetch` is compiled from
- * (ADR 0027, `.patterns/alchemy-http-router.md`). Assembles two kinds of routes,
- * both `Layer`s merged into one: a typed-JSON `HttpApiBuilder` group
- * (`GET /api/health`) and the raw-`Request` `HttpRouter.add` routes, which come
- * from the worker-owned-route manifest (`worker-routes.ts`) that `index.ts` also
- * derives `runWorkerFirst` from — one source, so route and SPA-shadow glob can't
- * drift (#861).
+ * (ADR 0027, `.patterns/alchemy-http-router.md`).
  *
  * The raw routes lift their handler's `R` into route-requirement markers that
  * plain `Layer.provide` does NOT discharge — they must be discharged with
@@ -22,59 +17,29 @@ import type {Flagship} from "../features/flagship/Flagship.ts";
 import {healthApiLayer} from "./health.ts";
 import {rawWorkerRouteLayers} from "./worker-routes.ts";
 
-/** Build the application router layer. Each option's contract is on its property. */
 export const makeAppLive = (options: {
 	/**
-	 * The worker-level fate services PLUS the composed `FateServer`, as a
-	 * DEPENDENCY-FREE context layer (`R = never`): `makeFateRuntime`'s
-	 * `contextLayer` from the one per-isolate runtime. No runtime on the request
-	 * path (ADR 0043). Pinning `R = never` makes the dual-build state
-	 * unrepresentable — raw `makeFateLayer` (`R = Database | BetterAuth | Flagship | RuntimeContext`) no
-	 * longer typechecks here, so `provideRequest` can never silently construct a
-	 * second Drizzle/Pasaport per request (ADR 0041).
+	 * Pinning `R = never` makes the dual-build state unrepresentable — raw
+	 * `makeFateLayer` no longer typechecks here, so `provideRequest` can never
+	 * silently construct a second Drizzle/Pasaport per request (ADRs 0041/0043).
 	 */
 	readonly fateLayer: Layer.Layer<WorkerFateServices | FateServer>;
-	/** The worker-init-resolved DO namespace handles (publish + SSE transport). */
 	readonly liveLayer: Layer.Layer<LiveTopics | LiveConnections>;
 	/**
-	 * The `BetterAuth` Layer, dependency-free (`R = never`). In the deployed
-	 * worker this is the INIT-RESOLVED `Layer.succeed(...)(betterAuth)`
-	 * (`index.ts`) — NOT `BetterAuthLive`: `provideRequest` builds its layer per
-	 * request, so passing `BetterAuthLive` would reconstruct better-auth (the
-	 * secret resolution needs deploy-time alchemy machinery absent in workerd) on
-	 * every request. Tests pass `layerTest` over the same tag; both thread through
-	 * `provideRequest` identically.
+	 * Must be the INIT-RESOLVED `Layer.succeed(...)(betterAuth)`, NOT `BetterAuthLive`:
+	 * `provideRequest` builds its layer per request, and reconstructing better-auth
+	 * needs deploy-time alchemy machinery that is absent in workerd.
 	 */
 	readonly betterAuthLayer: Layer.Layer<BetterAuth.BetterAuth>;
-	/**
-	 * The worker's ambient `RuntimeContext`, captured in init. better-auth's
-	 * `fetch`/`auth` carry it undischarged; `HttpRouter.add` lifts it into the
-	 * `/api/auth/*` route's per-request markers and we discharge it here.
-	 */
 	readonly runtimeContext: BaseRuntimeContext;
-	/**
-	 * The init-resolved Effect-native `FlagshipClient`, dependency-free
-	 * (`R = never`) — `Layer.succeed(Flagship)(client)` from `index.ts` (epic
-	 * #488). The health route reads one flag through it so a system-tier test can
-	 * prove the binding resolves end-to-end; the flag Effect service lands in #508.
-	 */
 	readonly flagshipLayer: Layer.Layer<Flagship>;
 }) => {
-	// The health route's only worker-level requirement is the `Flagship` client
-	// (its `ConfigProvider` is auto-wired at worker scope); discharge it here.
 	const typedJson = healthApiLayer.pipe(Layer.provide(options.flagshipLayer));
 
-	// `Flags` is NOT built a second time here (#1438): the raw flag routes resolve it
-	// from `options.fateLayer`, which already exports the ONE `Flags` build the fate
-	// resolvers read — `FateFlagsLive` in `makeFateLayer`, memoized once per isolate by
-	// `makeFateRuntime` (the #622 override wrapper, unconditional since #2741). A separate
-	// `FlagsDevOverrideLive` build here would be a redundant second singleton the raw
-	// routes read instead of the fate one, so the local flag-flip cookie could diverge
-	// between the two consumer sets — the exact duplicated-wiring smell #1438 removes.
-	//
-	// `provideRequest` discharges the route-requirement markers `HttpRouter.add`
-	// lifts (plain `Layer.provide` does not). All provided layers are
-	// dependency-free (`R = never`), so they merge flat.
+	// Do NOT add a second `Flags` build here (#1438): the raw flag routes resolve it
+	// from `options.fateLayer`, the ONE build the fate resolvers read. A second
+	// singleton would let the local flag-flip cookie diverge between the two
+	// consumer sets.
 	const rawRoutes = Layer.mergeAll(...rawWorkerRouteLayers).pipe(
 		HttpRouter.provideRequest(
 			Layer.mergeAll(

--- a/apps/web/worker/http/health.ts
+++ b/apps/web/worker/http/health.ts
@@ -1,15 +1,8 @@
 /**
- * The readiness probe — `GET /api/health` (ADR 0027,
- * `.patterns/alchemy-http-router.md`). The only typed-JSON `HttpApi` group.
- *
- * Two readiness outcomes, both TYPED (ADR 0156): a **200** `HealthStatus`
- * (`status:"ok"`, `flagshipReachable:true`) when the Flagship binding is
- * reachable, and a **503** `HealthDegraded` (`status:"degraded"`,
- * `flagshipReachable:false`) when a `FlagshipError` proves it unreachable. Flags
- * fail-closed (a Flagship outage → flag defaults, the worker still serves), so
- * Flagship-unreachable is a representable degraded-readiness state, not a handler
- * defect — 503 (not-ready-but-alive) makes it legible to orchestration/alerting.
- * A `ConfigError` (malformed env) STAYS `orDie`→500 — that IS a real defect.
+ * The readiness probe — `GET /api/health` (ADR 0027, `.patterns/alchemy-http-router.md`), the
+ * only typed-JSON `HttpApi` group. Both outcomes are typed (ADR 0156): 200 `HealthStatus`, or
+ * 503 `HealthDegraded` when a `FlagshipError` proves the binding unreachable. A `ConfigError`
+ * (malformed env) stays `orDie`→500 — that IS a real defect.
  */
 import * as Effect from "effect/Effect";
 import * as FileSystem from "effect/FileSystem";
@@ -28,23 +21,16 @@ import {Flagship} from "../features/flagship/Flagship.ts";
 export class HealthStatus extends Schema.Class<HealthStatus>("@kampus/HealthStatus")({
 	status: Schema.String,
 	environment: Schema.NullOr(Schema.String),
-	// System-tier readiness: `true` once the `FlagshipClient` binding resolved
-	// end-to-end through the worker (epic #488, #507). It asserts reachability of
-	// the binding, NOT the value of any feature flag — `true` on a healthy worker,
-	// independent of how any individual flag evaluates. Named `flagshipReachable`
-	// (not `…Bound`) so an operator can't misread it as a did-it-bind boolean whose
-	// `false` reads as "missing/unhealthy" (#864). The `false` (degraded) reading is
-	// its own typed body, `HealthDegraded` (ADR 0156).
+	// Asserts reachability of the binding, NOT the value of any feature flag. Named
+	// `flagshipReachable` (not `…Bound`) so an operator can't misread `false` as
+	// "missing/unhealthy" (#864); that reading is its own typed body, `HealthDegraded`.
 	flagshipReachable: Schema.Boolean,
 }) {}
 
 /**
- * The typed not-ready-but-alive body (HTTP 503, ADR 0156): a `FlagshipError`
- * proved the Flagship binding unreachable. The two fields are pinned to the only
- * values this state can hold — `Literal`, so a degraded body can never claim
- * `"ok"`/`flagshipReachable:true`. The `httpApiStatus: 503` annotation is what the
- * framework encodes the error response as (`HttpApiSchema.getStatusError` reads it;
- * an unannotated error is 500).
+ * The typed not-ready-but-alive body (ADR 0156). Both fields are `Literal`, so a degraded body
+ * can never claim `"ok"`. `httpApiStatus: 503` is what the framework encodes the response as
+ * (`HttpApiSchema.getStatusError` reads it; an unannotated error is 500).
  */
 export class HealthDegraded extends Schema.TaggedErrorClass<HealthDegraded>()(
 	"@kampus/HealthDegraded",
@@ -68,18 +54,12 @@ export class HealthApi extends HttpApi.make("phoenix").add(HealthGroup) {}
 const healthGroup = HttpApiBuilder.group(HealthApi, "health", (h) =>
 	h.handle("health", () =>
 		Effect.gen(function* () {
-			// `orDie`: a `ConfigError` (value outside the two literals) means a
-			// malformed env — a real handler defect, kept narrow at 500 (ADR 0156).
+			// `orDie`: a `ConfigError` means a malformed env — a real handler defect, kept at 500.
 			const {environment} = yield* AppConfig.pipe(Effect.orDie);
-			// Drive one evaluation through the resolved Flagship binding (epic #488):
-			// the read completing at all proves the `FlagshipClient` resolved
-			// end-to-end through the worker, so `flagshipReachable` is `true` once it
-			// returns — the probe asserts reachability, not the flag's value. Flagship
-			// evaluation never throws (it falls back to the default), so a misconfigured
-			// binding surfaces only on the `FlagshipError` channel — which we catch to
-			// the typed 503 degraded body rather than `orDie`→500 (ADR 0156): flags
-			// fail-closed, so an unreachable Flagship is a representable degraded state,
-			// not a crash.
+			// The read completing at all proves the `FlagshipClient` resolved end-to-end, so the probe
+			// asserts reachability, not the flag's value. Evaluation never throws (it falls back to the
+			// default), so an unreachable binding surfaces only on `FlagshipError` — caught to the typed
+			// 503 rather than `orDie`→500, because flags fail closed (ADR 0156).
 			const flagship = yield* Flagship;
 			return yield* flagship.getBooleanValue("phoenix-health-probe", false).pipe(
 				Effect.as(
@@ -103,11 +83,8 @@ const healthGroup = HttpApiBuilder.group(HealthApi, "health", (h) =>
 	),
 );
 
-/**
- * Platform stubs `HttpApiBuilder.layer` requires. Workers serve no files (the SPA
- * comes from the `assets` binding), so the file-serving paths die if hit — safe,
- * since the typed-JSON endpoint never produces a file response.
- */
+// Workers serve no files (the SPA comes from the `assets` binding), so the file-serving paths
+// die if hit — safe, since the typed-JSON endpoint never produces a file response.
 const HttpPlatformStub = Layer.succeed(HttpPlatform.HttpPlatform, {
 	fileResponse: () => Effect.die("HttpPlatform.fileResponse not supported in Workers"),
 	fileWebResponse: () => Effect.die("HttpPlatform.fileWebResponse not supported in Workers"),
@@ -120,11 +97,8 @@ const platformStubs = Layer.mergeAll(
 	FileSystem.layerNoop({}),
 );
 
-/**
- * The health route as a single router layer. The handler's `ConfigProvider`
- * requirement is discharged at the app boundary at worker scope (alchemy
- * auto-wires it, see `app.ts`); this layer only wires the group + platform stubs.
- */
+// The handler's `ConfigProvider` requirement is discharged at the app boundary at worker scope
+// (alchemy auto-wires it, see `app.ts`); this layer only wires the group + platform stubs.
 export const healthApiLayer = HttpApiBuilder.layer(HealthApi).pipe(
 	Layer.provide(healthGroup),
 	Layer.provide(platformStubs),

--- a/apps/web/worker/http/health.unit.test.ts
+++ b/apps/web/worker/http/health.unit.test.ts
@@ -1,16 +1,9 @@
 /**
- * Unit coverage for the `/api/health` readiness contract (ADR 0156). Drives the
- * real `healthApiLayer` router over `HttpRouter.toWebHandler` — no workerd, no
- * binding — with a stubbed `Flagship` client, and asserts the two typed outcomes:
- *
- *   - REACHABLE → 200 `{status:"ok", flagshipReachable:true}`;
- *   - a `FlagshipError` (unreachable/misconfigured binding) → 503
- *     `{status:"degraded", flagshipReachable:false}`, NOT an `orDie`→500.
- *
- * The 503 path is the ADR 0156 decision: flags fail-closed, so Flagship-unreachable
- * is a representable degraded-readiness state (not-ready-but-alive), not a handler
- * defect. The full black-box HTTP path is the CI-only integration tier
- * (`flagship-binding.test.ts`, ADR 0154); this is the local-runnable unit tier.
+ * The `/api/health` readiness contract (ADR 0156), driven over `HttpRouter.toWebHandler`
+ * with a stubbed `Flagship` — no workerd, no binding. A `FlagshipError` must surface as a
+ * 503 `{status:"degraded"}`, NOT an `orDie`→500: flags fail-closed, so Flagship-unreachable
+ * is a representable not-ready-but-alive state. The black-box HTTP path is the integration
+ * tier (ADR 0154).
  */
 import {type BaseRuntimeContext, RuntimeContext} from "alchemy";
 import {Flagship as CfFlagship} from "alchemy/Cloudflare";
@@ -21,14 +14,10 @@ import {describe, expect, it} from "vitest";
 import {Flagship} from "../features/flagship/Flagship.ts";
 import {healthApiLayer} from "./health.ts";
 
-/**
- * The health read the handler exercises: the boolean probe evaluation, either
- * reachable (`succeed`) or a `FlagshipError` (unreachable/misconfigured binding).
- */
 type ProbeRead = Effect.Effect<boolean, CfFlagship.FlagshipError>;
 
-// `RuntimeContext` is the alchemy binding's intrinsic ambient requirement
-// (discharged at worker scope in production, #507); the stub satisfies it here.
+// `RuntimeContext` is the alchemy binding's ambient requirement (discharged at worker scope
+// in production); the stub satisfies it here.
 const runtimeContext: BaseRuntimeContext = {
 	Type: "test",
 	id: "test",
@@ -40,10 +29,7 @@ const runtimeContext: BaseRuntimeContext = {
 const unexercised = (method: string) => () =>
 	Effect.die(`Flagship.${method} not exercised in health.unit.test`);
 
-/**
- * A `Flagship` stub whose `getBooleanValue` runs the supplied probe read; every
- * other method dies so an accidental call is loud (the `Flags.unit.test` idiom).
- */
+/** Every method but `getBooleanValue` dies, so an accidental call is loud. */
 const stubFlagship = (probe: ProbeRead): Layer.Layer<Flagship> =>
 	Layer.succeed(Flagship)(
 		Flagship.of({
@@ -61,9 +47,8 @@ const stubFlagship = (probe: ProbeRead): Layer.Layer<Flagship> =>
 	);
 
 /**
- * Compile the real health router over a stub client into a `Request → Response`.
- * `provideRequest` discharges the group's per-request `Flagship` + `RuntimeContext`
- * markers (plain `Layer.provide` does not lift them — same seam as `app.ts`).
+ * `provideRequest` discharges the group's per-request `Flagship` + `RuntimeContext` markers
+ * — plain `Layer.provide` does not lift them (same seam as `app.ts`).
  */
 const healthHandler = (probe: ProbeRead) =>
 	HttpRouter.toWebHandler(

--- a/apps/web/worker/http/interrupt-on-abort.ts
+++ b/apps/web/worker/http/interrupt-on-abort.ts
@@ -1,28 +1,21 @@
 /**
- * `interruptOnAbort` — the platform-edge abort→interruption wiring for the routes
- * in `app.ts` (ADR 0043). alchemy's worker bridge runs the request handler with
- * `Effect.runPromiseExit` and wires no signal, so the HTTP edge owns abort itself
- * — the same mechanism effect-smol's `HttpEffect.toWebHandlerWith` uses (listen on
- * `request.signal`, interrupt the fiber). Infrastructure, not a route.
+ * `interruptOnAbort` — the platform-edge abort→interruption wiring for the routes in `app.ts`
+ * (ADR 0043). alchemy's worker bridge runs the handler with `Effect.runPromiseExit` and wires no
+ * signal, so the HTTP edge owns abort itself, the way `HttpEffect.toWebHandlerWith` does.
  */
 import * as Effect from "effect/Effect";
 import * as Fiber from "effect/Fiber";
 
 /**
- * The subset of `AbortSignal` the wiring reads. Structural on purpose: a unit
- * test can model an abort dispatched inside the pre-check→listener gap (not
- * deterministically reachable through a real `AbortController`) without a cast.
+ * Structural on purpose: a unit test can model an abort dispatched inside the pre-check→listener
+ * gap (not deterministically reachable through a real `AbortController`) without a cast.
  */
 export type AbortSignalLike = Pick<
 	AbortSignal,
 	"aborted" | "addEventListener" | "removeEventListener"
 >;
 
-/**
- * Run `program` as a child of the current (request) fiber, interrupted when
- * `signal` aborts. The child inherits the fiber context, so spans/services flow
- * through.
- */
+/** The child inherits the fiber context, so spans/services flow through. */
 export const interruptOnAbort =
 	(signal: AbortSignalLike) =>
 	<A, E, R>(program: Effect.Effect<A, E, R>): Effect.Effect<A, E, R> =>

--- a/apps/web/worker/http/interrupt-on-abort.unit.test.ts
+++ b/apps/web/worker/http/interrupt-on-abort.unit.test.ts
@@ -1,8 +1,7 @@
 /**
- * Tests for `interruptOnAbort` (unit: pure helper, no router, no workerd). Run on
- * the Effect runtime (`it.effect`), exercising the combinator the same way
- * production does. Coordination uses a `Latch`, never timers (a fixed tick raced
- * fiber startup on loaded CI runners).
+ * Tests for `interruptOnAbort` (unit: pure helper, no router, no workerd).
+ * Coordination uses a `Latch`, never timers — a fixed tick raced fiber startup on
+ * loaded CI runners.
  */
 import {assert, it} from "@effect/vitest";
 import * as Effect from "effect/Effect";
@@ -36,8 +35,8 @@ describe("interruptOnAbort", () => {
 	it.effect("an abort mid-flight interrupts the program", () =>
 		Effect.gen(function* () {
 			const controller = new AbortController();
-			// Awaiting the latch the program opens first IS the deterministic
-			// "fiber is running" proof — the abort below provably lands mid-flight.
+			// Awaiting the latch the program opens IS the deterministic "fiber is running" proof,
+			// so the abort below provably lands mid-flight.
 			const started = yield* Latch.make();
 			const program = started.open.pipe(Effect.andThen(Effect.never));
 			const fiber = yield* Effect.forkChild(program.pipe(interruptOnAbort(controller.signal)));
@@ -52,10 +51,9 @@ describe("interruptOnAbort", () => {
 		"an abort dispatched in the pre-check→listener gap still interrupts (recheck branch)",
 		() =>
 			Effect.gen(function* () {
-				// A real AbortController can't hit the pre-check→listener gap
-				// deterministically, so simulate the helper's view of it: `aborted`
-				// reads false at the pre-check then true after, and the listener never
-				// fires (event already dispatched) — only the recheck can interrupt.
+				// A real AbortController cannot hit the pre-check→listener gap deterministically, so
+				// simulate the helper's view: `aborted` reads false at the pre-check then true after,
+				// and the listener never fires — only the recheck can interrupt.
 				let aborted = false;
 				const gapSignal: AbortSignalLike = {
 					get aborted() {

--- a/apps/web/worker/http/worker-routes.ts
+++ b/apps/web/worker/http/worker-routes.ts
@@ -1,29 +1,11 @@
 /**
  * The single source of truth for the worker-owned path set (#861, ADR 0027).
  *
- * The set of paths the worker answers — vs. the SPA `assets` binding serving
- * `dist/client` — used to live twice: once as the route layers merged into the
- * `HttpRouter` (`app.ts`), once as the literal `runWorkerFirst` glob (`index.ts`).
- * Coupled only by convention, the two could drift: register a route but forget
- * the glob and `notFoundHandling: "single-page-application"` silently serves the
- * SPA shell on GET (405 on non-GET) — a fail-quiet seam surfacing far from the
- * omission.
- *
- * Here both consumers derive from ONE list. Each {@link WorkerRoute} pairs a
- * raw-`Request` route layer with the `runWorkerFirst` glob that must shadow the
- * SPA for it. The route table reads `.route`; `runWorkerFirst` reads `.glob`
- * (deduplicated, {@link workerFirstGlobs}). Adding a worker-owned route is one
- * edit to {@link rawWorkerRoutes} — the glob can no longer be forgotten, and the
- * lockstep test (`worker-routes.unit.test.ts`) pins that every route's mount path
- * is matched by a derived glob.
- *
- * The edge-render shell route (#2929, ADR 0179) extends this to the CF spa-shell recipe
- * (`["/*", "!/assets/*"]`): a catch-all `/*` glob pulls every non-asset request through
- * the worker, and a `!`-prefixed exception ({@link assetExceptionGlobs}) keeps the built
- * `/assets/*` bundles edge-direct. `globMatches` models a single positive glob;
- * {@link runsWorkerFirst} composes the positives and the `!`-exceptions the way Cloudflare
- * evaluates `run_worker_first` (any positive matches AND no exception matches), so the
- * lockstep test can pin the `!`-exception <-> HTML-route coupling.
+ * Each {@link WorkerRoute} pairs a raw-`Request` route layer with the `runWorkerFirst`
+ * glob that must shadow the SPA for it. They live together because they used to live
+ * apart: register a route but forget the glob and the SPA shell is served instead — a
+ * fail-quiet seam surfacing far from the omission. `worker-routes.unit.test.ts` pins
+ * the lockstep.
  */
 import type {Layer} from "effect/Layer";
 import {fateRoute} from "../features/fate/route.ts";
@@ -39,100 +21,65 @@ import {authRoute} from "../features/pasaport/route.ts";
 import {rssRoute} from "../features/rss/route.ts";
 
 /**
- * A raw route layer with its per-route requirement markers undischarged. Each
- * `HttpRouter.add` lifts its handler's `E`/`R` into route markers (discharged by
- * `provideRequest` in `app.ts`), so the markers vary per route — `any` here is
- * the same element type `Layer.mergeAll` accepts (`Layer<never, any, any>`).
+ * `any` is the element type `Layer.mergeAll` accepts (`Layer<never, any, any>`): each
+ * `HttpRouter.add` lifts its handler's `E`/`R` into per-route markers — discharged by
+ * `provideRequest` in `app.ts` — so the markers vary per route.
  */
 export type WorkerRouteLayer = Layer<never, any, any>;
 
-/**
- * A worker-owned raw route plus the `runWorkerFirst` glob that keeps the SPA
- * shell from shadowing it. `path` mirrors the route's `HttpRouter.add(_, path, _)`
- * mount — the field the lockstep test checks `glob` against, so a mismatched
- * pairing fails CI.
- */
 export interface WorkerRoute {
-	/** The route's mount path, mirroring its `HttpRouter.add(_, path, _)`. */
 	readonly path: string;
-	/** The `runWorkerFirst` glob that must match {@link path}. */
 	readonly glob: string;
-	/** The route layer merged into the `HttpRouter`. */
 	readonly route: WorkerRouteLayer;
 }
 
 /**
- * Every raw worker-owned route, each paired with its covering glob. The typed
- * health route (`GET /api/health`) is owned by the `/api/*` glob below; its
- * coverage is asserted in the lockstep test via {@link typedWorkerPaths}.
- *
- * Typed as a non-empty tuple so {@link rawWorkerRouteLayers} satisfies
- * `Layer.mergeAll`'s `[Layer, ...Layer[]]` arity without a cast.
+ * Every raw worker-owned route, each paired with its covering glob. Typed as a
+ * non-empty tuple so {@link rawWorkerRouteLayers} satisfies `Layer.mergeAll`'s arity
+ * without a cast.
  */
 export const rawWorkerRoutes: readonly [WorkerRoute, ...WorkerRoute[]] = [
 	{path: "/fate", glob: "/fate", route: fateRoute},
 	{path: "/fate/live", glob: "/fate/*", route: liveRoute},
-	// The GET-able base feed (#2322, epic #2316 leg B); the `/fate/*` glob already
-	// shadows the SPA for it.
 	{path: "/fate/pano/feed", glob: "/fate/*", route: baseFeedRoute},
-	// The public read of a single published mecmua post (#2498, epic #2467); the
-	// `/fate/*` glob already shadows the SPA for it. Dark behind `MECMUA_PUBLIC_READ`
-	// (404 until flipped).
+	// Dark behind `MECMUA_PUBLIC_READ` (404 until flipped).
 	{path: "/fate/mecmua/post/:slug", glob: "/fate/*", route: mecmuaPublicReadRoute},
-	// The public chronological index of published mecmua posts (#2512, epic #2467); the
-	// `/fate/*` glob already shadows the SPA for it. Dark behind `MECMUA_PUBLIC_READ`
-	// (404 until flipped).
+	// Dark behind `MECMUA_PUBLIC_READ` (404 until flipped).
 	{path: "/fate/mecmua/index", glob: "/fate/*", route: mecmuaIndexRoute},
 	{path: "/api/auth/*", glob: "/api/*", route: authRoute},
 	{path: "/api/flags/probe", glob: "/api/*", route: flagsProbeRoute},
 	{path: "/api/flags/evaluate", glob: "/api/*", route: flagsEvaluateRoute},
-	// Dev-only flag-override surface (#622) — statically mounted, but both verbs
-	// fail-closed to 404 outside `development` (`route-dev.ts`).
+	// Both verbs fail-closed to 404 outside `development` (`route-dev.ts`).
 	{path: "/api/flags/dev", glob: "/api/*", route: flagsDevPageRoute},
 	{path: "/api/flags/dev", glob: "/api/*", route: flagsDevApplyRoute},
 	{path: "/api/pano/link-metadata", glob: "/api/*", route: linkMetadataRoute},
 	{path: "/rss.xml", glob: "/rss.xml", route: rssRoute},
-	// The edge-render shell catch-all (#2929, ADR 0179): mounted `* /*` so it serves the
-	// SPA shell through the worker and injects `window.__BOOT__`. The `/*` glob pulls every
-	// non-asset path worker-first; the `!/assets/*` exception ({@link assetExceptionGlobs})
-	// keeps the built bundles edge-direct.
-	// Specific routes above win by find-my-way precedence, so this catches only what they don't.
+	// The edge-render shell catch-all (#2929, ADR 0179). Specific routes above win by
+	// find-my-way precedence, so this catches only what they do not.
 	{path: "/*", glob: "/*", route: shellBootRoute},
 ];
 
 /**
  * The `!`-prefixed `run_worker_first` exceptions — globs that keep a matching path
- * edge-direct even though a positive glob would pull it worker-first. Cloudflare's
- * `run_worker_first` reads a `!`-prefixed entry as an exclusion (the spa-shell recipe
- * `["/*", "!/assets/*"]`), so `/assets/*` (the Vite-hashed bundles) stays served by the
- * `ASSETS` binding at the edge while `/*` routes everything else through the worker.
- * Kept a module constant so {@link workerFirstGlobs} carries it into `runWorkerFirst` and
- * {@link runsWorkerFirst} / the lockstep test model it.
+ * edge-direct even though a positive glob would pull it worker-first (the CF
+ * spa-shell recipe `["/*", "!/assets/*"]`).
  */
 export const assetExceptionGlobs: readonly string[] = ["!/assets/*"];
 
-/**
- * The raw route layers as a non-empty tuple — `app.ts` spreads this into
- * `Layer.mergeAll`. Derived from {@link rawWorkerRoutes} so the merged route set
- * and the {@link workerFirstGlobs} can't diverge.
- */
 export const rawWorkerRouteLayers: readonly [WorkerRouteLayer, ...WorkerRouteLayer[]] = [
 	rawWorkerRoutes[0].route,
 	...rawWorkerRoutes.slice(1).map((r) => r.route),
 ];
 
 /**
- * Worker-owned paths NOT served as raw routes — the typed-JSON `HttpApi` group
- * (`health.ts`), which `app.ts` merges separately. Listed here only so the
- * lockstep test proves a glob covers them too.
+ * Worker-owned paths NOT served as raw routes — the typed-JSON `HttpApi` group.
+ * Listed here only so the lockstep test proves a glob covers them too.
  */
 export const typedWorkerPaths: readonly string[] = ["/api/health"];
 
 /**
- * Does one POSITIVE glob's covered path set contain another's? A prefix glob `/p/*` covers any
- * glob whose base (its own prefix, or an exact path) is `/p` or sits under `/p/`; an exact glob
- * covers only itself. `/*` (empty prefix) therefore covers every `/…` glob. Used to drop
- * redundant positives below.
+ * Does one POSITIVE glob's covered path set contain another's? `/*` (empty prefix)
+ * covers every `/…` glob; an exact glob covers only itself.
  */
 const globCovers = (broad: string, narrow: string): boolean => {
 	if (!broad.endsWith("/*")) return narrow === broad;
@@ -142,21 +89,17 @@ const globCovers = (broad: string, narrow: string): boolean => {
 };
 
 /**
- * Cloudflare's `run_worker_first` REJECTS a redundant positive rule — one another positive rule
- * already subsumes (`BadRequest: rule '/fate' is invalid; rule '/*' makes it redundant`, PR #2984).
- * With the catch-all `/*` in the derived set, every specific worker-route glob is redundant, so the
- * config MUST be minimized to the broadest positives before it reaches the CF API. Runtime routing
- * is unchanged: `/*` already routes every non-asset path worker-first (the `!`-exception keeps the
- * built bundles edge-direct), and find-my-way precedence dispatches the specific routes.
+ * Cloudflare's `run_worker_first` REJECTS a redundant positive rule — one another
+ * positive already subsumes (`rule '/fate' is invalid; rule '/*' makes it redundant`,
+ * PR #2984). So the config MUST be minimized before it reaches the CF API; runtime
+ * routing is unchanged.
  */
 const minimizePositiveGlobs = (positives: readonly string[]): string[] =>
 	positives.filter((g) => !positives.some((other) => other !== g && globCovers(other, g)));
 
 /**
- * The `runWorkerFirst` glob set `index.ts` passes to `assets.runWorkerFirst`: the deduplicated
- * positives from {@link rawWorkerRoutes}, MINIMIZED so no positive is redundant under a broader
- * one (CF rejects redundant rules — #2984), followed by the {@link assetExceptionGlobs}
- * `!`-exceptions. With the `/*` catch-all present this collapses to `["/*", "!/assets/*"]`.
+ * The glob set `index.ts` passes to `assets.runWorkerFirst`: deduplicated, minimized
+ * positives (CF rejects redundant rules, #2984) then the `!`-exceptions.
  */
 export const workerFirstGlobs: readonly string[] = [
 	...minimizePositiveGlobs([...new Set(rawWorkerRoutes.map((r) => r.glob))]),
@@ -164,10 +107,8 @@ export const workerFirstGlobs: readonly string[] = [
 ];
 
 /**
- * Does a single POSITIVE `runWorkerFirst` glob match a mount path? Mirrors Cloudflare's
- * matching: a trailing `/*` matches the prefix and anything under it; otherwise an exact
- * path match. Deliberately small (the prod matcher is Cloudflare's, not ours) and
- * exception-blind — a `!`-prefixed glob is composed by {@link runsWorkerFirst}, not here.
+ * Mirrors Cloudflare's matching for a single POSITIVE glob. Exception-blind — a
+ * `!`-prefixed glob is composed by {@link runsWorkerFirst}, not here.
  */
 export const globMatches = (glob: string, path: string): boolean => {
 	if (glob.endsWith("/*")) {
@@ -178,11 +119,8 @@ export const globMatches = (glob: string, path: string): boolean => {
 };
 
 /**
- * Would a path run worker-first under a glob set that may carry `!`-exceptions? Models
- * Cloudflare's `run_worker_first` composition: a path runs worker-first iff some positive
- * glob matches it AND no `!`-exception matches it. So `["/*", "!/assets/*"]` routes every
- * path worker-first except `/assets/*` (the built bundles), which stays edge-direct. The
- * lockstep test uses this to pin the `!`-exception <-> HTML-route coupling.
+ * Models Cloudflare's `run_worker_first` composition: a path runs worker-first iff
+ * some positive glob matches it AND no `!`-exception does.
  */
 export const runsWorkerFirst = (globs: readonly string[], path: string): boolean => {
 	const positives = globs.filter((g) => !g.startsWith("!"));

--- a/apps/web/worker/http/worker-routes.unit.test.ts
+++ b/apps/web/worker/http/worker-routes.unit.test.ts
@@ -1,14 +1,8 @@
 /**
- * The lockstep guard for the worker-owned path set (#861). `app.ts` merges the
- * route layers; `index.ts` derives `runWorkerFirst` from the same manifest. These
- * tests pin that the derived globs actually cover every worker-owned mount path —
- * so a future route added without a matching glob fails CI here, not as the
- * fail-quiet "SPA shell served on GET" symptom in production.
- *
- * Extended for the edge-render shell route (#2929, ADR 0179): the CF spa-shell recipe
- * (`["/*", "!/assets/*"]`) is modelled by {@link runsWorkerFirst} — the positive `/*`
- * pulls every non-asset path worker-first and the `!`-exception keeps `/assets/*`
- * edge-direct — and the HTML route (`* /*`) is pinned coupled to that `!`-exception.
+ * The lockstep guard for the worker-owned path set (#861): the derived globs must
+ * cover every worker-owned mount path, so a route added without a matching glob fails
+ * CI here instead of showing up in production as the fail-quiet "SPA shell served on
+ * GET" symptom. {@link runsWorkerFirst} models the CF spa-shell recipe (ADR 0179).
  */
 import {describe, expect, it} from "vitest";
 import {

--- a/apps/web/worker/index.ts
+++ b/apps/web/worker/index.ts
@@ -1,12 +1,7 @@
 /**
- * The single phoenix worker, on alchemy-effect (ADR 0026–0031).
- *
- * Modular `.make()` form (ADR 0028): the `Phoenix` class is the worker Tag
- * (declaring the hosted `LiveDO` as its `Deps`), `Phoenix.make(body)` is the
- * implementation Layer. Splitting them lets the worker host the DO and provide
- * its `.make()` Layer (the inline-body form can't take a `Deps` type param). The
- * body runs in two phases: init binds resources once per isolate; runtime returns
- * the `fetch` handler.
+ * The single phoenix worker, on alchemy-effect (ADR 0026–0031, see also
+ * .patterns/alchemy-worker.md). The body runs in two phases: init binds resources
+ * once per isolate; runtime returns the `fetch` handler.
  */
 import * as BetterAuth from "@alchemy.run/better-auth";
 import {wrapRequestHandler} from "@sentry/cloudflare";
@@ -47,21 +42,14 @@ import {workerOptions} from "./lib/sentry.ts";
 import {captureUnhandled} from "./lib/sentry-capture.ts";
 import {SentryEffectLive} from "./lib/sentry-effect.ts";
 
-/**
- * A rejection escaping `wrapRequestHandler` past the `captureErrors` backstop — an
- * infra failure at the worker fetch boundary that dies (mirroring the prior
- * `Effect.promise` defect).
- */
 class RequestHandlerError extends Schema.TaggedErrorClass<RequestHandlerError>()(
 	"web/RequestHandlerError",
 	{cause: Schema.Defect()},
 ) {}
 
 /**
- * Lift a publish-side `PublishMessage` to the `DeliverFrame` `LiveDO.publish`
- * enqueues. The frame's `id` (the fate subscription id) is left empty here — one
- * publish fans out to many subscriptions, each stamped with its own id by the
- * topic instance at delivery.
+ * `id` (the fate subscription id) is left empty: one publish fans out to many
+ * subscriptions, each stamped with its own id by the topic instance at delivery.
  */
 function deliverFrameOf(message: PublishMessage): DeliverFrame {
 	return {
@@ -74,127 +62,65 @@ function deliverFrameOf(message: PublishMessage): DeliverFrame {
 
 export class Phoenix extends Cloudflare.Worker<
 	Phoenix,
-	// `{}` is alchemy's empty-RPC-shape sentinel (this worker exposes only
-	// `fetch`); biome bans bare `{}`, but no other type expresses "no extra shape"
-	// without forcing keys to `never`, which `{fetch}` then fails to satisfy.
+	// No other type expresses "no extra shape" without forcing keys to `never`,
+	// which `{fetch}` then fails to satisfy.
 	// biome-ignore lint/complexity/noBannedTypes: alchemy's empty-RPC-shape sentinel
 	{},
-	// The hosted live-fan-out DO, declared as the worker's `Deps` (ADR 0028) so it
-	// can `yield*` the Tag in init and provide `.make()` below.
+	// The hosted live-fan-out DO, declared as the worker's `Deps` (ADR 0028).
 	LiveDO
 >()("phoenix") {}
 
-// Props moved from the Worker constructor to `.make(props, impl)` in alchemy
-// beta.59 (the tag carries name + RPC shape; props live on `.make`).
 const phoenixProps =
-	// Props are an Effect so `domain` can derive from the deploy's `Stage` (issue
-	// #594). `Stage` is a deploy-only PlatformService — alchemy provides it solely in
-	// the stack context (`Stack.make`), NEVER in workerd. But `Phoenix.make()` (the
-	// runtime `PhoenixLive` Layer) re-runs this Effect on every isolate init to resolve
-	// props (`Platform.make` → `SelfLayer`), so a `yield* Stage` here would die at
-	// runtime and 500 every request. We gate the deploy-only derivation on
-	// `ALCHEMY_PHASE === "plan"` (alchemy bakes `ALCHEMY_PHASE: "runtime"` into the
-	// deployed worker; default is `"plan"`) — the same deploy-vs-runtime guard alchemy's
-	// own `Binding.ts` uses. At runtime we return the plain props untouched, so the
-	// fetch handler is identical to a domain-less worker; the Custom Domain (proxied DNS
-	// + TLS on the `kamp.us` zone) is purely a deploy concern.
+	// This props Effect re-runs on every isolate init, so every deploy-only
+	// derivation below is gated on `ALCHEMY_PHASE === "plan"` — a bare `yield* Stage`
+	// here 500s every live request. See .patterns/cloudflare-deploy-time-iac.md.
 	Effect.gen(function* () {
-		// Deploy-time-only DSN source (ADR 0118, #1502): read off `process.env` here in
-		// the alchemy CLI process, NOT via a `Config` — the binding is what carries the
-		// value to workerd. Absent-safe: unset ⇒ no `SENTRY_DSN` binding is added below,
-		// so the runtime read (`sentryDsn`, config.ts) resolves `None` and the worker
-		// Sentry path stays inert.
+		// Deploy-time-only DSN source (ADR 0118): read off `process.env` in the alchemy
+		// CLI process, NOT via a `Config` — the binding carries the value to workerd.
+		// Unset ⇒ no binding below ⇒ the runtime read resolves `None` and Sentry is inert.
 		const sentryDsnValue = process.env[ENV_BINDINGS.sentryDsn];
 
 		const props = {
 			main: import.meta.filename,
-			// Pin the local dev port. `alchemy dev` defaults to 1337 but can silently fall back
-			// to the next free port; if a second app's worker ran alongside, that could make
-			// the Vite proxy in `apps/web/vite.config.ts` point at the wrong worker.
-			// `strictPort: true` makes collisions fail loudly instead of misrouting.
+			// `strictPort` makes a port collision fail loudly; `alchemy dev` otherwise falls
+			// back to the next free port and the Vite proxy silently hits the wrong worker.
 			dev: {port: 1337, strictPort: true},
-			// Env bindings spread from `config.ts`'s `envBindings`, keyed by the
-			// single-sourced binding names (`ENV_BINDINGS`): `ENVIRONMENT` → `plain_text`,
-			// `BETTER_AUTH_SECRET` → `secret_text`. The names are NOT restated here — they
-			// come from the same `as const` the `Config` constructors read under, so a
-			// key↔name mismatch is unrepresentable (#1432). Alchemy resolves each at deploy
-			// and runtime reads the same value off the auto-wired ConfigProvider.
+			// Binding names are NOT restated here — they come from the same `as const` the
+			// `Config` constructors read under, so a key↔name mismatch is unrepresentable (#1432).
 			env: {
 				...envBindings,
-				// The Flagship app resource maps to the native `Flagship` runtime binding
-				// via `InferEnv` (epic #488); the worker `bind()`s it in init below. The
-				// env key matches the `Flagship` Tag/consumer so the name is one across
-				// declare → bind → consume (#1439); runtime resolution is by the app's
-				// `LogicalId` (`phoenix_flags`), not this key, so the rename is behavior-neutral.
+				// Runtime resolution is by the app's `LogicalId` (`phoenix_flags`), not this key.
 				Flagship: FlagshipResource,
-				// The Analytics Engine `app_events` dataset (ADR 0153, epic #2065): bound as
-				// the `Events` runtime binding so worker init can resolve the write client via
-				// `Cloudflare.AnalyticsEngine.WriteDataset(Events)`. No provisioning — an AE
-				// dataset is created on first `writeDataPoint`. The `Telemetry` service that
-				// consumes the client lands in #2067; this child wires the binding only.
+				// No provisioning — an AE dataset is created on first `writeDataPoint` (ADR 0153).
 				Events: TelemetryEvents,
-				// Optional Sentry DSN (ADR 0118, #1502): bound `secret_text` (a redacted
-				// value) ONLY when a DSN is present in the deploy env, so an unset DSN adds
-				// no binding at all. Single-sourced name via `ENV_BINDINGS.sentryDsn` (#1432).
 				...(sentryDsnValue ? {[ENV_BINDINGS.sentryDsn]: Redacted.make(sentryDsnValue)} : {}),
 			},
 			assets: {
-				// The built SPA shell (`vite build` emits `dist/client`, ADR 0030; path is
-				// relative to the alchemy CLI's `apps/web` cwd). At the edge the worker
-				// serves it; the `runWorkerFirst` globs keep the worker-owned paths from
-				// being shadowed by the SPA shell (a missing entry returns the shell for
-				// GET and 405 for POST). Derived from the one worker-owned-route manifest
-				// `app.ts` also consumes (`http/worker-routes.ts`), so route and glob can't
-				// drift (#861).
+				// The `runWorkerFirst` globs keep worker-owned paths from being shadowed by
+				// the SPA shell (a missing entry returns the shell for GET, 405 for POST).
+				// Derived from the one manifest `app.ts` also consumes, so they can't drift (#861).
 				directory: "./dist/client",
 				notFoundHandling: "single-page-application" as const,
 				runWorkerFirst: [...workerFirstGlobs],
 			},
 			compatibility: {flags: ["nodejs_compat"]},
-			// Smart Placement (ADR 0168, amended by ADR 0179): run the worker near its
-			// heaviest upstream — the D1 primary in ENAM — so the authed `/fate` feed's ~11
-			// sequential D1 round-trips collapse from cross-region hops to in-region ones.
-			// ADR 0168's original premise was "no worker code serves assets via
-			// `env.ASSETS.fetch()`, so placement never pulls asset serving off the edge."
-			// The edge-render shell route (#2929) amends that premise: `runWorkerFirst`
-			// (`["/*", "!/assets/*"]`) routes HTML worker-first, so first-byte HTML always takes the
-			// ~70–80ms ENAM hop through the worker, which renders per request, non-cached, and
-			// injects `__BOOT__` — the cost the founder ruling (#2833) accepted for cohesiveness (one
-			// correct-first-paint render over a boot waterfall). The `/assets/*` bundles stay
-			// edge-direct (the `!/assets/*` run-worker-first exception).
-			// Read-replication (D1 Sessions API) stays deferred; verify placement post-deploy
-			// via the `cf-placement` response header.
+			// See ADR 0168, amended by ADR 0179.
 			placement: {mode: "smart" as const},
-			// Workers Observability, declared explicitly rather than leaning on alchemy's
-			// default-on (Worker.ts `observability ?? {enabled, logs:{enabled,invocationLogs}}`)
-			// so the captured-exception behavior is legible in source. `headSamplingRate: 1`
-			// keeps full capture at phoenix's current low volume. Source maps are uploaded
-			// unconditionally by the bundler (`sourcemap: "hidden"` → `.map` parts), so worker
-			// stack traces de-minify with no flag to set here. Field names are the alchemy/CF
-			// camelCase (`WorkerObservability`), not wrangler snake_case.
+			// Field names are the alchemy/CF camelCase (`WorkerObservability`), not
+			// wrangler snake_case.
 			observability: {
 				enabled: true,
 				headSamplingRate: 1,
 				logs: {enabled: true, invocationLogs: true},
 			},
-			// Workers Caching (per-Worker edge cache) enablement (ADR 0170, via the
-			// in-repo alchemy `pnpm patch`). Enabling the platform capability is inert on
-			// its own — Workers Caching caches a GET/HEAD response ONLY when the worker
-			// stamps `Cache-Control`, which the base-feed route does (#2324). So the base
-			// feed is the one cached surface.
+			// Inert on its own — Workers Caching caches a GET/HEAD response ONLY when the
+			// worker stamps `Cache-Control` (ADR 0170).
 			cache: {enabled: true},
 		};
 
-		// The custom domain is deploy-time-only AND production-only: skip it at runtime
-		// (where `Stage` is absent and a `yield* Stage` would 500 every request) and
-		// offline (`alchemy dev` has no real CF zone — mirror the `resolveStateMode` gate
-		// the state store uses). The `ALCHEMY_PHASE === "plan"` guard is the runtime-safety
-		// gate (alchemy bakes `ALCHEMY_PHASE: "runtime"` into the deployed worker), and
-		// `customHostname` is production-only: it yields `phoenix.kamp.us` for a prod deploy
-		// and `undefined` for every non-prod stage. So an ephemeral integration `it-*`
-		// `Test.make` stage attaches NO domain → its `worker.url` stays `*.workers.dev` →
-		// the integration harness's `GET /api/health` hits a valid cert (a `<stage>` custom
-		// domain's TLS cert isn't provisioned yet and broke every integration test, #983).
+		// Deploy-time-only AND production-only. A non-prod stage must attach NO domain:
+		// a `<stage>` custom domain's TLS cert isn't provisioned yet, and the integration
+		// harness's `GET /api/health` needs a valid cert (#983).
 		const phase = yield* ALCHEMY_PHASE;
 		if (phase !== "plan" || resolveStateMode(process.env) === "local") return props;
 
@@ -206,55 +132,31 @@ const phoenixProps =
 export default Phoenix.make(
 	phoenixProps,
 	Effect.gen(function* () {
-		// ── INIT PHASE (deploy time + once per isolate) ──
-		// Bind the resources: at deploy each call records binding metadata for the
-		// Cloudflare API; at runtime it resolves the typed client, in scope for the
-		// isolate's lifetime. `live` stays load-bearing through `liveLayer`'s
-		// closures below — drop this `yield*` and the type checker fails there, so
-		// an unwired binding is a compile error, never a runtime `undefined`.
 		const live = yield* LiveDO;
 
-		// Resolve the raw D1 handle from the `Database` seam ONCE in init (ADR
-		// 0040) and wrap it dependency-free for the runtime build below, so the
-		// routes never rebuild the seams per request (ADR 0041). `DatabaseLive`
-		// (outer `Effect.provide`) resolves `PhoenixDb`; the shared handle feeds
-		// both `DrizzleLive` and `BetterAuthLive`.
+		// Resolve the raw D1 handle ONCE in init and wrap it dependency-free, so the
+		// routes never rebuild the seams per request (ADRs 0040/0041).
 		const raw = yield* Database;
 		const databaseLayer = Layer.succeed(Database)(raw);
 
-		// Resolve the `BetterAuth` service ONCE in init (the cached
-		// `makeBetterAuth(...)` instance from `BetterAuthLive`, provided below) so
-		// `Pasaport.validateSession` and the `/api/auth/*` handler share one
-		// instance — sign + validate with the same secret.
+		// One instance, so `Pasaport.validateSession` and the `/api/auth/*` handler
+		// sign + validate with the same secret.
 		const betterAuth = yield* BetterAuth.BetterAuth;
 		const betterAuthLayer = Layer.succeed(BetterAuth.BetterAuth)(betterAuth);
 
-		// Resolve the Effect-native `FlagshipClient` ONCE in init (epic #488) via the
-		// `Flagship` seam (`Cloudflare.Flagship.ReadFlags(...)`, provided below) and wrap
-		// it dependency-free for the routes — same shape as `Database` above.
 		const flagshipClient = yield* Flagship;
 		const flagshipLayer = Layer.succeed(Flagship)(flagshipClient);
 
-		// Resolve the Analytics Engine write client ONCE in init (ADR 0153, #2067) —
-		// where the `WriteDataset` binding graph is ambient (provided below) — and
-		// wrap it dependency-free on the `TelemetryClient` seam for the fate runtime,
-		// same shape as `Flagship`/`Database` above. Keeping the binding resolution
-		// here (not in `TelemetryLive`) keeps the fate runtime's R free of
-		// `WorkerEnvironment`/`Worker`.
+		// Resolving the binding here rather than in `TelemetryLive` keeps the fate
+		// runtime's R free of `WorkerEnvironment`/`Worker` (ADR 0153).
 		const telemetryClient = yield* Cloudflare.AnalyticsEngine.WriteDataset(TelemetryEvents);
 		const telemetryLayer = Layer.succeed(TelemetryClient)(telemetryClient);
 
-		// The worker's ambient `RuntimeContext`, resolved once. The fate runtime needs
-		// it because every flag gate reads `Flags` (a `RuntimeContext` per-call
-		// requirement); `makeAppLive` reuses it for the `/api/auth/*` route.
 		const runtimeContext = yield* RuntimeContext;
 
-		// The one worker-level runtime (ADR 0041/0043 — init-only wiring): exactly
-		// one per isolate from `PhoenixFateLive` (`R = Database | BetterAuth`, both
-		// provided here). It is a layer-build vehicle only, no runtime on the
-		// request path; the full story (shared memoMap, never-dispose deviation)
-		// lives in `fate/layers.ts`. Its built context reaches the routes as
-		// `fateLayer`.
+		// One worker-level runtime per isolate (ADRs 0041/0043 — init-only wiring). It
+		// is a layer-build vehicle only, never on the request path; the shared memoMap
+		// and never-dispose deviation live in `fate/layers.ts`.
 		const {contextLayer: fateLayer} = makeFateRuntime(
 			PhoenixFateLive.pipe(
 				Layer.provide(
@@ -262,9 +164,6 @@ export default Phoenix.make(
 						databaseLayer,
 						betterAuthLayer,
 						flagshipLayer,
-						// The init-resolved AE write client (ADR 0153, #2067) the `Telemetry`
-						// seam emits through; `RuntimeContext` (below) discharges the ambient
-						// requirement `writeDataPoint` needs, captured once in `TelemetryLive`.
 						telemetryLayer,
 						Layer.succeed(RuntimeContext)(runtimeContext),
 					),
@@ -273,43 +172,22 @@ export default Phoenix.make(
 		);
 
 		// NO init-time warmup (`yield*`-ing the runtime's `contextEffect`) —
-		// deliberately. Workerd disallows async/timer work in init (global) scope,
-		// so forcing the layer build here stalls the worker before it can serve.
-		// The layer builds lazily on the first request instead. Config validation
-		// does NOT wait for it: the same `collectConfigIssues` walk runs at BUILD
-		// time inside `FateExecutor.toCodegenServer` (`schema.ts`), so `vite build`
-		// fails on duplicate wire names / missing sources before the worker exists.
+		// deliberately. Workerd disallows async/timer work in init (global) scope, so
+		// forcing the layer build here stalls the worker before it can serve. It builds
+		// lazily on the first request; the same `collectConfigIssues` walk runs at BUILD
+		// time in `FateExecutor.toCodegenServer`, so config errors still fail `vite build`.
 
-		// The sıcak/hot decay-refresh Cron Trigger (#2027, windowless since #2133): register
-		// the `scheduled` listener (runtime) + attach the cron expression to the worker
-		// (deploy). The handler re-decays every live non-draft post's `post_record.hot_score`
-		// so the hot feed keeps decaying with age at any age without an activity write,
-		// preserving the stored-column + keyset-cursor design (no read-time recompute).
-		// Provided the built `fateLayer` so it resolves `Pano` at dispatch. `subscribe` only
-		// registers a listener (no async/timer work), so it is init-safe.
+		// `subscribe` only registers a listener (no async/timer work), so it is init-safe.
 		yield* subscribeHotScoreDecay(fateLayer);
-
-		// The sözlük backstop-reconciliation Cron Trigger (#2558): re-runs the recomputable
-		// cache refresh (term summary + FTS + sözlük stats) for every term on a 6-hourly
-		// schedule, so a term/stat left stale by a SWALLOWED last-write refresh
-		// (`swallowRefresh`, #2012) is eventually re-converged without waiting for a next
-		// user write. Rides the SAME `CronEventSourceLive` seam as the decay above (a second
-		// `Cron(<expr>)` binding, dispatched at runtime by `controller.cron`, so the two
-		// coexist); the built `fateLayer` resolves `Sozluk` at dispatch. Init-safe.
 		yield* subscribeSozlukReconcile(fateLayer);
 
-		// The live path (ADR 0028/0029): the unified `LiveDO` namespace resolved
-		// once above, wrapped as worker-level services. One namespace plays both
-		// roles, keyed by instance name. Addressing + name grammar live at the
-		// `live-do.ts` seam. Cross-role fan-out rides the DO's OWN namespace
-		// captured in its init closure, so every method's `R` is `never` — nothing
-		// to discharge at this worker call seam.
+		// One `LiveDO` namespace plays both roles, keyed by instance name (ADRs 0028/0029);
+		// addressing + name grammar live at the `live-do.ts` seam.
 		const liveLayer = Layer.mergeAll(
 			Layer.succeed(LiveTopics)(
 				LiveTopics.of({
-					// Cold-start resilience via the same `withColdStartRetry` as the sibling
-					// `subscribe`/`unsubscribe` below (rationale there, #842). Bare, a publish
-					// to an idle-evicted `topic:` DO dropped its invalidation silently (#2551).
+					// Bare, a publish to an idle-evicted `topic:` DO dropped its invalidation
+					// silently (#2551). See ADR 0095.
 					publish: (topicKey, message, limits) =>
 						Effect.asVoid(
 							withColdStartRetry(
@@ -323,11 +201,8 @@ export default Phoenix.make(
 			),
 			Layer.succeed(LiveConnections)(
 				LiveConnections.of({
-					// A cold `connection:`/`topic:` DO's first RPC can fail on the alchemy
-					// transport channel (`RpcCallError`); `withColdStartRetry` absorbs the
-					// warm window and surfaces `LiveTransportError` on exhaustion (#842). The
-					// SSE-open `.fetch` rejection arrives as a DEFECT, not an `RpcCallError`,
-					// so it needs the `*Fetch` variant (#1048).
+					// See ADR 0095. The SSE-open `.fetch` rejection arrives as a DEFECT, not an
+					// `RpcCallError`, so it needs the `*Fetch` variant (#1048).
 					open: (connectionId, request) =>
 						withColdStartRetryFetch("open", connectionOf(live, connectionId).fetch(request)),
 					subscribe: (connectionId, input) =>
@@ -348,11 +223,8 @@ export default Phoenix.make(
 			),
 		);
 
-		// `AppLive` is the whole HTTP surface, Hono-free (ADR 0027). `makeAppLive`
-		// discharges the raw routes' worker-level requirements via
-		// `provideRequest` and wires the health group's platform stubs
-		// (`http/app.ts`). Note this passes the INIT-RESOLVED `betterAuth` service,
-		// not `BetterAuthLive` (why: `makeAppLive`'s `betterAuthLayer` doc).
+		// Passes the INIT-RESOLVED `betterAuth` service, not `BetterAuthLive` (why:
+		// `makeAppLive`'s `betterAuthLayer` doc).
 		const AppLive = makeAppLive({
 			fateLayer,
 			liveLayer,
@@ -361,30 +233,14 @@ export default Phoenix.make(
 			runtimeContext,
 		});
 
-		// The optional Sentry DSN, read once in init off the auto-wired ConfigProvider.
-		// `None` when no `SENTRY_DSN` binding was added at deploy (config.ts) — the gate
-		// that keeps the worker Sentry path structurally inert.
+		// `None` when no `SENTRY_DSN` binding was added at deploy — the gate that keeps
+		// the worker Sentry path structurally inert.
 		const dsn = yield* sentryDsn;
 
-		// ── RUNTIME PHASE (per request) ──
-		// `AppLive.pipe(toHttpEffect)` is an `Effect` yielding the request `HttpEffect`;
-		// alchemy owns the raw request→Response conversion (ADR 0027). There is no
-		// `ExportedHandler` to hand `@sentry/cloudflare` the standard `withSentry`
-		// recipe, so error capture is wired at THIS Effect boundary instead (ADR 0118,
-		// #1502): when a DSN is present, wrap the request `HttpEffect` in
-		// `wrapRequestHandler` (real client init + isolate-safe transport + flush bound
-		// to `ctx.waitUntil`). `Cloudflare.makeRequestEffect` reuses alchemy's OWN
-		// `HttpServerResponse`→web conversion (incl. the SSE scope transfer) so the
-		// wrapped handler returns a web `Response`; `HttpServerResponse.fromWeb` hands it
-		// back for alchemy's outer conversion. No DSN ⇒ the base effect is returned
-		// verbatim, so nothing here runs (mirrors the SPA `sentryEnabled` gate).
-		//
-		// `SentryEffectLive` (the Sentry Tracer/Logger, ADR 0029/0118) is merged into the
-		// router layer here for tracing spans + `Effect.log*` breadcrumbs; it's baked into
-		// the built `httpEffect`, so it survives the re-run inside `wrapRequestHandler`.
-		// Merged unconditionally — inert without a bound client (`sentry-effect.ts`). It
-		// does NOT create issues from unhandled failures (it never calls `captureException`);
-		// that is `captureUnhandled`'s job at the seam below (`sentry-capture.ts`).
+		// There is no `ExportedHandler` to hand `@sentry/cloudflare` the standard
+		// `withSentry` recipe, so error capture is wired at THIS Effect boundary instead
+		// (ADR 0118). `SentryEffectLive` is merged unconditionally — inert without a bound
+		// client — and does NOT create issues itself; that is `captureUnhandled`'s job below.
 		const baseFetch = AppLive.pipe(Layer.provide(SentryEffectLive), HttpRouter.toHttpEffect);
 		const fetch = Option.match(dsn, {
 			onNone: () => baseFetch,
@@ -393,27 +249,21 @@ export default Phoenix.make(
 					Effect.gen(function* () {
 						const request = yield* Cloudflare.Request;
 						const context = yield* Cloudflare.WorkerExecutionContext;
-						// Capture the request-scoped services (HttpServerRequest, Scope, the
-						// route markers) so the inner run inside `wrapRequestHandler`'s Promise
-						// thunk keeps them — a bare `Effect.runPromise` would start on the empty
-						// default context and lose them.
+						// Captured so the inner run inside `wrapRequestHandler`'s Promise thunk
+						// keeps the request-scoped services — a bare `Effect.runPromise` would
+						// start on the empty default context and lose them.
 						const requestContext = yield* Effect.context<Effect.Services<typeof httpEffect>>();
 						// alchemy types `makeRequestEffect` as `=> any` and pins its handler to the
 						// `HttpEffect<Req>` alias, narrower than `toHttpEffect`'s inferred result;
-						// assert its real contract so its OWN `HttpServerResponse`→web conversion
-						// (with the SSE scope transfer) is reused typed rather than re-forked.
+						// the assertion states its real contract so alchemy's own SSE-scope-transfer
+						// conversion is reused typed rather than re-forked.
 						const toWebResponse = Cloudflare.makeRequestEffect as (
 							webRequest: globalThis.Request,
 							handler: typeof httpEffect,
 						) => Effect.Effect<Response, never, Effect.Services<typeof httpEffect>>;
-						// `captureUnhandled` catches the router handler's `Cause` and turns a
-						// 5xx-class failure/defect into a Sentry issue (ADR 0118, #1502) — the
-						// swallow inside alchemy's `Http.safeHttpEffect` is why `captureErrors`
-						// alone never fires. It runs inside this `runPromise` (thus inside
-						// `wrapRequestHandler`'s client scope), captures + flushes inline, and
-						// returns the response as a success value. `captureErrors: true` stays a
-						// backstop for anything that still rejects the thunk. Full rationale + the
-						// flush-on-die finding live in `sentry-capture.ts`.
+						// The swallow inside alchemy's `Http.safeHttpEffect` is why `captureErrors`
+						// alone never fires; it stays a backstop for anything that still rejects
+						// the thunk. Rationale in `sentry-capture.ts` (ADR 0118).
 						const captured = captureUnhandled(httpEffect);
 						const webResponse = yield* Effect.tryPromise({
 							try: () =>
@@ -432,27 +282,14 @@ export default Phoenix.make(
 		});
 		return {fetch};
 	}).pipe(
-		// One combined provide (chaining multiple `Effect.provide` can break layer
-		// lifecycle). `LiveDOLive` registers the unified DO and resolves the
-		// `LiveDO` Tag (no circular Layer dependency, unlike the old
-		// `ConnectionDOLive` ↔ `TopicDOLive` pair it replaces). `BetterAuthLive`
-		// satisfies the `BetterAuth` tag and derives its raw d1 from the `Database`
-		// seam (ADR 0040), so `DatabaseLive` is provided into it.
+		// One combined provide — chaining multiple `Effect.provide` can break layer
+		// lifecycle.
 		Effect.provide(
 			Layer.mergeAll(
 				LiveDOLive,
-				// `provideMerge` keeps both `Database` (yielded in init) and
-				// `BetterAuth` in scope while wiring the dependency in build order (a
-				// flat `mergeAll` would run them in parallel and not wire it).
-				// `EmailSenderLive` (ADR 0101) is provided into it too: the better-auth
-				// email callbacks resolve `EmailSender`. The production adapter binds the
-				// `send_email` descriptor through alchemy's `SendEmailBindingLive`
-				// (`WorkerEnvironment`/`RuntimeContext` ambient), the same binding-graph
-				// shape as Flagship below; dev/preview pick the log sink and never touch
-				// the binding. The CF adapter also records a send-time rejection to the
-				// append-only delivery log (epic #2687), so `EmailDeliveryLogLive` (over its
-				// own `DrizzleLive`/`DatabaseLive`, D1 binding satisfied at the base) is
-				// provided in alongside the send binding.
+				// `provideMerge` keeps both `Database` (yielded in init) and `BetterAuth` in
+				// scope while wiring the dependency in build order — a flat `mergeAll` would
+				// run them in parallel and not wire it.
 				BetterAuthLive.pipe(
 					Layer.provideMerge(DatabaseLive),
 					Layer.provide(
@@ -464,21 +301,8 @@ export default Phoenix.make(
 						),
 					),
 				),
-				// The `Flagship` seam (`bind()`-in-init) resolves through alchemy's
-				// Flagship binding graph: `FlagshipBindingLive` turns the app resource
-				// into the `FlagshipClient`, `FlagshipBindingPolicyLive` registers the
-				// policy it needs (epic #488). `WorkerEnvironment` is ambient.
 				FlagshipLive.pipe(Layer.provide(Cloudflare.Flagship.ReadFlagsBinding)),
-				// The AE `WriteDataset` binding graph (ADR 0153, #2067): resolves the
-				// `WriteDataset` tag `yield* Cloudflare.AnalyticsEngine.WriteDataset(Events)`
-				// reads in init to get the write client. `WorkerEnvironment` is ambient at
-				// the worker scope, the same binding-graph shape as Flagship's `ReadFlagsBinding`.
 				Cloudflare.AnalyticsEngine.WriteDatasetBinding,
-				// The Cron Trigger runtime seam the sıcak/hot decay-refresh subscribes to
-				// (#2027): `subscribeHotScoreDecay` above `yield*`s `Cloudflare.cron(...).subscribe`,
-				// which resolves this `CronEventSource`. Its deploy-time policy
-				// (`CronEventSourcePolicy`) rides `Cloudflare.providers()`; `RuntimeContext` is
-				// ambient at the worker scope.
 				Cloudflare.CronEventSourceLive,
 			).pipe(Layer.provideMerge(Cloudflare.D1.QueryDatabaseBinding)),
 		),

--- a/apps/web/worker/lib/ids.ts
+++ b/apps/web/worker/lib/ids.ts
@@ -1,57 +1,30 @@
 /**
- * Branded ID schemas — the shared home for nominal id types (epic #2700).
+ * Branded ID schemas — the shared home for nominal id types. Two ids that are both `string`
+ * at runtime are indistinguishable to the type checker, so an argument swap compiles (#2712).
+ * `Schema.brand` makes them distinct types while staying plain strings at runtime: the brand
+ * is type-only, so wire and D1 bytes are byte-identical.
  *
- * Two ids that are both `string` at runtime (a user id, a definition id) are
- * indistinguishable to the type checker, so an argument swap like
- * `voteDefinition({definitionId, voterId})` compiles even when the two are
- * transposed (#2712). `Schema.brand` fixes that: it intersects a schema's
- * output type with a nominal `Brand`, so `UserId` and `DefinitionId` become
- * distinct types that can't be passed for one another — while staying plain
- * strings at runtime (the brand is type-only: `.make`/decode return the input
- * unchanged, so wire and D1 bytes are byte-identical).
- *
- * Idiom grounded in effect-smol `SCHEMA.md` §Branding — the top-level
- * `Schema.String.pipe(Schema.brand("UserId"))` form (not a hand-rolled phantom
- * symbol) — and `Brand.ts`. Feature-local ids (sözlük's DefinitionId, TermSlug)
- * live here beside the cross-feature UserId so every Phase-2 child of #2700
- * imports one module.
+ * Idiom grounded in effect-smol `SCHEMA.md` §Branding.
  */
 import * as Schema from "effect/Schema";
 
-/**
- * Mint a branded id schema: a bare string nominally tagged `B`. Type-only — it
- * adds no runtime check or transform (per effect-smol `SCHEMA.md` §Branding,
- * `brand` narrows the output type without validating). This is the API Phase-2
- * children call to declare their own feature ids.
- */
+// Type-only: adds no runtime check or transform (effect-smol `SCHEMA.md` §Branding).
 export const brandedId = <const B extends string>(brand: B) =>
 	Schema.String.pipe(Schema.brand(brand));
 
-/**
- * The authenticated user's id (`CurrentUser.user.id`) — cross-feature, threaded
- * as every write's actor/author/voter/reactor argument. Minted from the session
- * string at each write boundary via `UserId.make(user.id)`.
- */
+// Minted from the session string at each write boundary via `UserId.make(user.id)`.
 export const UserId = brandedId("UserId");
 export type UserId = typeof UserId.Type;
 
-/** A sözlük definition (entry) id. */
 export const DefinitionId = brandedId("DefinitionId");
 export type DefinitionId = typeof DefinitionId.Type;
 
-/** A sözlük term (başlık) slug — the başlık's stable identifier. */
+// A sözlük term (başlık) slug.
 export const TermSlug = brandedId("TermSlug");
 export type TermSlug = typeof TermSlug.Type;
 
-/**
- * A vote/reaction/report **target** id — the row id of the entity being scored or
- * flagged. Cross-feature (vote, reaction, and the moderation surfaces all reference
- * it), so it lives here rather than in one feature. It is *polymorphic* over the
- * `TargetKind` set (`definition` | `post` | `comment`, `db/target-kind.ts`): one broad
- * brand tags the raw id, and the accompanying `targetKind` carries the discriminator —
- * the same (kind, id) pairing already threaded through every target surface. The brand
- * only stops a `TargetId` being confused with a `UserId` (a voter/target swap), not one
- * target kind for another; the kind guard is `TargetKind`'s job.
- */
+// Polymorphic over the `TargetKind` set: one broad brand tags the raw id and the
+// accompanying `targetKind` carries the discriminator. The brand only stops a `TargetId`
+// being confused with a `UserId`, not one target kind for another — that is `TargetKind`'s job.
 export const TargetId = brandedId("TargetId");
 export type TargetId = typeof TargetId.Type;

--- a/apps/web/worker/lib/ids.unit.test.ts
+++ b/apps/web/worker/lib/ids.unit.test.ts
@@ -1,15 +1,7 @@
 /**
- * Branded id pins (#2712, epic #2700). Two tiers:
- *
- *  - TYPE tier: nominal distinctness is compile-enforced — a `UserId` is not
- *    assignable where a `DefinitionId` is expected, and transposing the two at
- *    the `voteDefinition` arg surface fails to type. Assignability is encoded as
- *    a conditional-type boolean checked with `expectTypeOf` (not
- *    `@ts-expect-error`, which the effect LSP plugin's TS377003 escapes — the
- *    recurring finding in `domain-error-boundary.unit.test.ts`).
- *  - RUNTIME tier: the brand is type-only — `.make` and decode return the input
- *    string unchanged, so wire/D1 bytes are byte-identical (no allocation or
- *    serialization delta).
+ * Branded id pins. Assignability is encoded as a conditional-type boolean checked with
+ * `expectTypeOf`, NOT `@ts-expect-error` — the effect LSP plugin's TS377003 escapes
+ * those (the recurring finding in `domain-error-boundary.unit.test.ts`).
  */
 import * as Schema from "effect/Schema";
 import {describe, expect, expectTypeOf, it} from "vitest";
@@ -21,7 +13,6 @@ type Assignable<A, B> = [A] extends [B] ? true : false;
 
 describe("branded ids — nominal distinctness is compile-enforced", () => {
 	it("a wrong-branded id is not assignable where a specific branded id is expected", () => {
-		// The core guarantee: distinct brands are mutually unassignable.
 		expectTypeOf<Assignable<UserId, DefinitionId>>().toEqualTypeOf<false>();
 		expectTypeOf<Assignable<DefinitionId, UserId>>().toEqualTypeOf<false>();
 		expectTypeOf<Assignable<TermSlug, DefinitionId>>().toEqualTypeOf<false>();
@@ -36,8 +27,6 @@ describe("branded ids — nominal distinctness is compile-enforced", () => {
 	});
 
 	it("transposing definitionId/voterId at the voteDefinition surface fails to type", () => {
-		// The correct shape is a VoteDefinitionInput; the swapped shape is not —
-		// this is the #2712 arg-swap, now a compile error at every call site.
 		expectTypeOf<
 			Assignable<{definitionId: DefinitionId; voterId: UserId}, VoteDefinitionInput>
 		>().toEqualTypeOf<true>();

--- a/apps/web/worker/lib/sentry-capture.ts
+++ b/apps/web/worker/lib/sentry-capture.ts
@@ -1,30 +1,20 @@
 /**
  * Explicit unhandled-failure capture at the Effect router seam (ADR 0118, #1502).
  *
- * Why here and not the `@sentry/effect` layer (`sentry-effect.ts`): that layer only
- * mirrors Effect spans to Sentry spans (Tracer) and routes `Effect.log*` to Sentry
- * logs/breadcrumbs (Logger) — it NEVER calls `captureException`, so it cannot turn an
- * unhandled defect into an issue. And alchemy's `makeRequestEffect` wraps the handler in
- * `Http.safeHttpEffect` (`Effect.catchCause`), whose error channel is `never` — it
- * consumes every failure/defect into a 499/500 Response before `wrapRequestHandler`'s
- * `captureErrors` can see it. So issue capture is wired HERE.
+ * Why here and not the `@sentry/effect` layer: that layer never calls
+ * `captureException`, and alchemy's `safeHttpEffect` consumes every failure into a
+ * 499/500 Response before `wrapRequestHandler`'s `captureErrors` can see it.
  *
- * Why CATCH-and-return, not tap-and-re-raise: verified against the live stage, a captured
- * event NEVER ships when the request's fiber ultimately DIES (→ 500) — even with an
- * awaited inline `flush` before the die — whereas a handler that SUCCEEDS ships reliably.
- * The transport buffers the send until `flush`, and a dying fiber's flushed send is lost.
- * So this seam catches the cause, captures + flushes INLINE (the proven path — the manual
- * `captureException` + `flush` that created the first live issue), and RETURNS the
- * response as a SUCCESS value: the fiber never dies past here, so the flush lands.
+ * Why CATCH-and-return rather than tap-and-re-raise: verified against the live stage,
+ * a captured event NEVER ships when the request's fiber ultimately DIES — even with an
+ * awaited inline `flush` — because the transport buffers the send and a dying fiber's
+ * flushed send is lost. So this seam captures + flushes INLINE and returns the response
+ * as a SUCCESS value; the fiber never dies past here, so the flush lands.
  *
- * Because it produces the response for caught causes, it mirrors `safeHttpEffect`'s OWN
- * mapping so the DSN-on and DSN-off (`baseFetch`) paths return identical responses:
- * a pure client abort (interrupt-only) → 499 and is NOT captured; everything else →
- * 500 and IS captured. That split is exactly the "capture defects + 5xx, skip the
- * expected 4xx/499" policy of ADR 0118: at this seam `safeHttpEffect` collapses every
- * non-interrupt failure to a 500, so non-interrupt == 5xx == capture-worthy, and the
- * only 4xx-class thing here is the 499 client abort (SSE disconnects), which is skipped.
- * Only the 5xx path pays the inline-flush latency, and 5xx are rare.
+ * Producing the response means mirroring `safeHttpEffect`'s own mapping, so DSN-on and
+ * DSN-off paths return identical responses: a pure client abort (interrupt-only) → 499,
+ * not captured; everything else → 500 and captured. Only the rare 5xx path pays the
+ * inline-flush latency.
  */
 import {captureException, flush} from "@sentry/cloudflare";
 import * as Cause from "effect/Cause";
@@ -32,35 +22,22 @@ import * as Effect from "effect/Effect";
 import * as Schema from "effect/Schema";
 import * as HttpServerResponse from "effect/unstable/http/HttpServerResponse";
 
-/**
- * A rejection from the inline capture/flush path — an infra failure that dies
- * (mirroring the prior `Effect.promise` defect), keeping this seam's `E` channel
- * `never` as its callers require.
- */
+// Dies rather than failing, keeping this seam's `E` channel `never` as callers require.
 class SentryCaptureError extends Schema.TaggedErrorClass<SentryCaptureError>()(
 	"web/SentryCaptureError",
 	{cause: Schema.Defect()},
 ) {}
 
-/**
- * The pure gate (unit-tested): a real (non-interrupt) failure worth capturing. Mirrors
- * `safeHttpEffect`'s 499-vs-500 split — a pure client abort (interrupt-only) is expected
- * and skipped; any cause carrying a `Fail` or `Die` is a 5xx crash and captured.
- */
+// Mirrors `safeHttpEffect`'s 499-vs-500 split: an interrupt-only cause is an expected
+// client abort and skipped; a `Fail` or `Die` is a 5xx crash and captured.
 export function shouldCaptureCause(cause: Cause.Cause<unknown>): boolean {
 	return cause.reasons.length > 0 && !Cause.hasInterruptsOnly(cause);
 }
 
 /**
- * Wrap the router handler so an unhandled 5xx-class `Cause` reaches Sentry as an issue,
- * returning the same response `safeHttpEffect` would (499 for a client abort, else 500)
- * as a SUCCESS value so the flush can land before the fiber unwinds.
- *
- * The capture, flush, AND response all happen inside ONE `Effect.promise`: verified on
- * the live stage that chaining any effect AFTER the flush (even an `Effect.logError`)
- * loses the event, while returning the response from within the same awaited promise
- * ships it reliably. So the server-side "handler failed" log rides on `console.error`
- * here (Workers Observability captures it) rather than a trailing `Effect.logError`.
+ * The capture, flush, AND response must stay inside ONE `Effect.promise`: verified on
+ * the live stage, chaining any effect after the flush — even an `Effect.logError` —
+ * loses the event. Hence `console.error` here rather than a trailing `Effect.logError`.
  */
 export function captureUnhandled<E, R>(
 	handler: Effect.Effect<HttpServerResponse.HttpServerResponse, E, R>,

--- a/apps/web/worker/lib/sentry-effect.ts
+++ b/apps/web/worker/lib/sentry-effect.ts
@@ -1,16 +1,12 @@
 /**
- * The Sentry Effect Tracer + Logger as an isolate-level layer (ADR 0029, ADR 0118,
- * issue #1502). Captures typed failures AND `Cause` defects as Sentry spans/events —
- * the surface plain exception capture (the `wrapRequestHandler` seam in `index.ts`)
- * does not see. Inert until a client is bound: both leaves route through `@sentry/core`,
- * which no-ops without `getClient()`, so nothing is sent until the DSN path installs
- * the client — correct, per ADR 0118.
+ * The Sentry Effect Tracer + Logger as an isolate-level layer (ADR 0029/0118, #1502).
+ * Captures typed failures AND `Cause` defects — the surface plain exception capture
+ * does not see. Inert until a client is bound: both leaves no-op without `getClient()`.
  *
- * Import surface is deliberately the two clean, `@sentry/core`-only leaves — NOT
- * `init`, `effectLayer`, or any `@sentry/node-core` symbol — so the bundler can
- * tree-shake the workerd-hostile node-core subgraph the `@sentry/effect/server` barrel
- * also re-exports (`export *`, `sideEffects: false`). Kept in its own module so this
- * surface stays auditable. Bundle proof is deploy-time (ADR 0118 impl).
+ * The import surface is deliberately the two `@sentry/core`-only leaves — NOT `init`,
+ * `effectLayer`, or any `@sentry/node-core` symbol — so the bundler can tree-shake the
+ * workerd-hostile node-core subgraph the `@sentry/effect/server` barrel re-exports.
+ * Kept in its own module so that surface stays auditable.
  */
 import {SentryEffectLogger, SentryEffectTracer} from "@sentry/effect/server";
 import * as Layer from "effect/Layer";

--- a/apps/web/worker/lib/sentry.ts
+++ b/apps/web/worker/lib/sentry.ts
@@ -1,36 +1,29 @@
 /**
- * Worker-side Sentry options + the flag-attribution tagger (ADR 0118). The worker copy
- * of the SPA's `src/lib/sentry.ts` — same options shape, but built on `@sentry/cloudflare`
- * (workerd/`nodejs_compat`) rather than `@sentry/react`.
+ * Worker-side Sentry options + the flag-attribution tagger (ADR 0118), on
+ * `@sentry/cloudflare` rather than the SPA's `@sentry/react`.
  *
- * This module holds NO init: the client is created at the request seam in
- * `index.ts` via `@sentry/cloudflare`'s `wrapRequestHandler`, which is the only
- * workerd-safe init path for an Effect-`HttpRouter` worker (there is no
- * `ExportedHandler` in phoenix's source to wrap — ADR 0118 impl, issue #1502).
- * So "inert when no DSN" is structural: `index.ts` returns the base fetch effect
- * untouched, and `wrapRequestHandler` never runs, so no client is ever active —
- * which is exactly what `tagFlag` gates on (`Sentry.isEnabled()`).
+ * This module holds NO init: the client is created at the request seam in `index.ts`
+ * via `wrapRequestHandler`, the only workerd-safe init path for an Effect-`HttpRouter`
+ * worker (#1502). So "inert when no DSN" is structural — `wrapRequestHandler` never
+ * runs, so no client is ever active, which is what `tagFlag` gates on.
  */
 import type {CloudflareOptions} from "@sentry/cloudflare";
 import * as Sentry from "@sentry/cloudflare";
 import {flagTag} from "../features/flagship/flag-tag.ts";
 
 /**
- * Whether a usable DSN is present — the single gate the request seam checks, so
- * the worker integration is provably inert when unset (no client, no capture, no
- * network). Mirrors the SPA's `sentryEnabled`.
+ * The single gate the request seam checks, so the worker integration is provably
+ * inert when the DSN is unset: no client, no capture, no network.
  */
 export function sentryEnabled(dsn: string | undefined): dsn is string {
 	return typeof dsn === "string" && dsn.trim().length > 0;
 }
 
 /**
- * The decided client options (ADR 0118): pure native `dataCollection` (SDK ≥10.57,
- * the granular successor to the removed `sendDefaultPii`), no `beforeSend`. It
- * suppresses the cookies/headers/user/`query_string` PII. Query strings carry no
- * GDPR-PII in this app (only short-lived auth/OAuth tokens, caught by Sentry's
- * server-side default data-scrubbing by field name), so no client-side URL scrub is
- * needed — server-side Advanced Data Scrubbing is the backstop.
+ * The decided client options (ADR 0118): native `dataCollection` (SDK ≥10.57, the
+ * granular successor to the removed `sendDefaultPii`), no `beforeSend`. Query strings
+ * carry no GDPR-PII here — only short-lived auth tokens, which Sentry's server-side
+ * scrubbing catches by field name — so no client-side URL scrub is needed.
  */
 export function workerOptions(dsn: string): CloudflareOptions {
 	return {
@@ -45,17 +38,12 @@ export function workerOptions(dsn: string): CloudflareOptions {
 }
 
 /**
- * Stamp a resolved flag onto the request's Sentry scope as a queryable `flag.<key>`:`on`/`off`
- * tag (#1821) — the worker half of the SPA `tagFlag` (`src/lib/sentry.ts`), over the shared
- * `flagTag` naming contract so both tiers read uniformly in the #1822 graduation query. Called
- * from the per-request flag-resolution seam (`Flags.getBoolean`), which runs inside the request's
- * `wrapRequestHandler` scope (`index.ts`), so `setTag` lands on the isolation scope of every error
- * subsequently captured for that request.
- *
- * `Sentry.isEnabled()` is the worker-tier inert gate mirroring the SPA's `sentryEnabled(dsn)`: with
- * no DSN the request seam never calls `wrapRequestHandler`, so no client is active and this no-ops
- * — no scope mutation, no work. Flag keys/values are non-PII, so tagging is orthogonal to the ADR
- * 0118 `dataCollection` scrub and re-enables no PII collection.
+ * Stamp a resolved flag onto the request's Sentry scope as a queryable
+ * `flag.<key>`:`on`/`off` tag (#1821), over the shared `flagTag` naming contract so the
+ * worker and SPA tiers read uniformly. Called from `Flags.getBoolean`, which runs
+ * inside the request's `wrapRequestHandler` scope, so the tag lands on every error
+ * captured for that request. Flag keys/values are non-PII, so this re-enables none of
+ * the ADR 0118 `dataCollection` scrub.
  */
 export function tagFlag(key: string, value: boolean): void {
 	if (!Sentry.isEnabled()) {

--- a/apps/web/worker/lib/sentry.unit.test.ts
+++ b/apps/web/worker/lib/sentry.unit.test.ts
@@ -1,17 +1,13 @@
 /**
- * Pins ADR 0118's worker-tier invariant (issue #1502): the worker Sentry module ships pure
- * options + the flag-attribution tagger — no init, no client of its own. "Inert when no DSN" is
- * enforced at the request seam (`index.ts`), where `wrapRequestHandler` runs only with a DSN; the
- * module's own `tagFlag` gates on `Sentry.isEnabled()`, which is false without an active client.
- * Mirrors the SPA's `src/lib/sentry.unit.test.ts`. Also pins the DSN gate, the
- * native-`dataCollection` shape, and the worker half of the #1821 `flag.<key>`:`on`/`off` tagging.
+ * Pins ADR 0118's worker-tier invariant: the worker Sentry module ships pure options + the
+ * flag-attribution tagger — no init, no client of its own. "Inert when no DSN" is enforced at
+ * the request seam (`index.ts`); the module's own `tagFlag` gates on `Sentry.isEnabled()`.
  */
 import * as Cause from "effect/Cause";
 import {afterEach, describe, expect, it, vi} from "vitest";
 
-// `@sentry/cloudflare` is stubbed so `tagFlag` can be driven across the inert (`isEnabled=false`)
-// and active (`isEnabled=true`) branches without a real client init — mirrors the SPA test's
-// `@sentry/react` mock. Hoisted so the module under test binds these fns at import.
+// `@sentry/cloudflare` is stubbed so `tagFlag` can be driven across both `isEnabled` branches
+// without a real client init. Hoisted so the module under test binds these fns at import.
 const {isEnabled, setTag} = vi.hoisted(() => ({
 	isEnabled: vi.fn(() => false),
 	setTag: vi.fn(),
@@ -42,8 +38,7 @@ describe("decided defaults (ADR 0118)", () => {
 	it("workerOptions is pure native dataCollection with no beforeSend", () => {
 		const opts = workerOptions("https://abc@o0.ingest.de.sentry.io/1");
 		expect(opts.dsn).toBe("https://abc@o0.ingest.de.sentry.io/1");
-		// dataCollection is the whole story; the deprecated `sendDefaultPii` is gone,
-		// and no hand-rolled `beforeSend` scrub remains (server-side scrubbing is the backstop).
+		// dataCollection is the whole story: no `sendDefaultPii`, no hand-rolled `beforeSend`.
 		expect(opts.sendDefaultPii).toBeUndefined();
 		expect(opts.dataCollection).toEqual({
 			userInfo: false,


### PR DESCRIPTION
Whole-tree `deslop-comments` sweep over `apps/web/worker` (456 TS/TSX files). Phase one fanned 12 readers over disjoint file groups; phase two was a serial pass where I re-read every REHOME candidate at its line myself.

Calibration: brutal. When the one test ("would the next agent be wrong, slower, or surprised without this — in a way the code does not already say?") was borderline, the comment was cut.

## Census

| | comment lines | nonblank | ratio |
| --- | --- | --- | --- |
| before | 16,737 | 59,260 | 28.2% |
| after | 7,641 | 50,286 | **15.2%** |

Net 9,096 comment lines gone — 54% of the comment mass in the scope.

## Verdict tallies

| verdict | count |
| --- | --- |
| CUT | 10,699 comment lines removed |
| COLLAPSE | 1,092 docblocks shrunk to an ADR / pattern pointer |
| KEEP | 239 notable keeps (local invariants, workaround rationale, pragma reasons) |
| REHOME | **0 artifacts minted** |

CUT exceeds the net because a COLLAPSE removes several lines and adds one back.

### On the zero REHOMEs

Phase one flagged 23 candidates and left every one of them untouched in place, as the skill requires. I re-read all 23 at the line. None was an orphaned why: each is a local invariant at its enforcement site, a gotcha the code cannot express, or a deliberate-looking-wrong guard — the skill's KEEP shape — and every broad architectural why already cited a live ADR (0083, 0088, 0095, 0096, 0107, 0118, 0138). So they stayed inline as KEEPs and no `.decisions/` or `.patterns/` file was minted. Nothing was silently deleted.

## Byte-safety of code

- `pnpm typecheck` — green, 20/20 tasks.
- `pnpm biome check apps/web/worker` — clean apart from one `useOptionalChain` warning that fires identically on `origin/main` (verified by stashing).
- Comment-and-whitespace-stripped comparison of every changed file against `origin/main`: no code token changed.
- The only non-comment hunk in the whole diff is biome collapsing one drizzle index array onto a single line after the docblock above it shrank.

Do not merge yet — this is up for a calibration read before the same bar is fanned to `packages/fabrika-cli` and `apps/web/src`.
