### PR TITLE
chore: deslop comments in apps/web/src

### DIFF
--- a/apps/web/src/App.test.tsx
+++ b/apps/web/src/App.test.tsx
@@ -1,31 +1,10 @@
 /**
- * Regression pins for the two load-bearing first-paint invariants PR #2176 (fix for
- * #2160) established, so the review gate catches a regression mechanically instead of
- * a reviewer re-deriving it (#2177). Both invariants guard previously-real, user-visible
- * bugs:
- *
- *   (1) The static `Layout` shell paints FATE-FREE, above the session gate — the chrome
- *       (AppShell/Topbar/Footer, brand/nav/search, the giriş-yap/+gönderi auth split)
- *       renders on the first frame while the session is `isPending`, with NO `FateClient`
- *       mounted, so there is no blank first-paint flash (#2160). The fate-consuming hooks
- *       live in `LayoutContent`, BELOW the `FateProvider` gate.
- *   (2) `FateClient` mounts ONCE on the resolved identity — no anon→id remount. Because
- *       `FateProvider`'s `if (session.isPending) return null` defers the first commit, the
- *       first (and only) `key={userId ?? "anon"}` is the settled identity, so the router
- *       subtree is never remounted across session settle (which would wipe controlled-form
- *       state — the #438 bug).
- *
- * Both are pinned by rendering the REAL `App` (its real `Layout`, real `FateProvider`,
- * real `SetTopbarChipsContext` bridge) and observing the REAL `FateProvider` gate logic
- * through a mount-recording `FateClient` spy. A regression that reaches a fate/session
- * read back into the shell (invariant 1) or re-keys `FateClient` anon→id (invariant 2)
- * fails these — see the two `// REGRESSION:` notes on the assertions.
- *
- * The third block pins the two-tier fate provider (ADR 0167 / #2285): the /pano feed
- * paints over the PUBLIC client above the gate while `get-session` is pending, then hands
- * off to the authed tier once it commits — WITHOUT dragging the authed router subtree
- * through the anon→id re-key remount invariant 2 forbids. The spy tags each mount
- * public/authed so the two tiers are told apart.
+ * Regression pins for two first-paint invariants (#2177), both guarding previously-real bugs:
+ * (1) the `Layout` shell paints FATE-FREE above the session gate, so there is no blank first
+ * paint (#2160), and (2) `FateClient` mounts ONCE on the resolved identity — an anon→id remount
+ * wipes controlled-form state (#438). Both are pinned by rendering the REAL `App` and observing
+ * the REAL `FateProvider` gate through a mount-recording `FateClient` spy; see the two
+ * `// REGRESSION:` notes on the assertions.
  */
 import {act, render, screen} from "@testing-library/react";
 import type {ReactNode} from "react";
@@ -33,27 +12,14 @@ import {MemoryRouter} from "react-router";
 import {afterEach, beforeEach, describe, expect, it, vi} from "vitest";
 import {App} from "./App";
 
-// The two-tier public client (ADR 0167 / #2285): the eager public tier passes this
-// sentinel as its `FateClient` `client`, so the spy can tag a mount as `public` (the
-// always-anonymous tier above the gate) vs `authed` (the identity-keyed tier below it).
 const {PUBLIC_CLIENT} = vi.hoisted(() => ({PUBLIC_CLIENT: {__tier: "public"} as never}));
 
-// The mounts the two-tier fate provider commits, in order. Each entry is one `FateClient`
-// mount: its `key` (the identity it committed under) and its `tier` (public/authed).
-// Invariant 2 / #438 reads the AUTHED tier back: one entry keyed on the resolved identity
-// is correct; a second entry (or a leading "anon" entry) is the anon→id remount.
 type FateMount = {key: string; tier: "public" | "authed"};
 const fateMounts: FateMount[] = [];
 
-// Spy `FateClient` in place of react-fate's real one, driving the REAL `FateProvider`
-// (its real `if (session.isPending) return null` gate + real `key={userId ?? "anon"}`).
-// React consumes `key` itself and never forwards it as a readable prop, so instead of
-// reading the key the spy records, ON MOUNT, the session identity live from the same
-// source the real FateProvider keys on — the mocked `useSession`. React remounts the spy
-// exactly when the committed `key` changes, so one recorded mount == one real key, and a
-// second recorded mount is exactly the anon→id remount invariant 2 forbids. Recording on
-// MOUNT (an empty-dep effect), not per render, is what makes a remount observable. The
-// `tier` is read off the `client` instance — the public tier passes `PUBLIC_CLIENT`.
+// Spy `FateClient`, driving the REAL `FateProvider`. React consumes `key` itself and never
+// forwards it as a readable prop, so the spy instead records the live session identity ON MOUNT
+// — one recorded mount == one committed key, which is what makes a remount observable.
 vi.mock("react-fate", async (importOriginal) => {
 	const actual = await importOriginal<typeof import("react-fate")>();
 	const {useEffect} = await import("react");
@@ -72,23 +38,17 @@ vi.mock("react-fate", async (importOriginal) => {
 	return {...actual, FateClient: FateClientSpy};
 });
 
-// The eager public pano feed (ADR 0167) renders the REAL `PanoFeed` over the public
-// client; stub it inert here so the tree renders offline without a real fate context —
-// its PRESENCE above the gate (the `eager-pano-feed` marker) is what the two-tier tests
-// assert, not its internal fate reads.
+// Stubbed inert so the tree renders offline: the two-tier tests assert the feed's PRESENCE above
+// the gate, not its fate reads.
 vi.mock("./pages/PanoFeed", () => ({
 	PanoFeed: ({host}: {host?: string}) => <div data-testid="eager-pano-feed">{host ?? "all"}</div>,
 }));
 
-// The public tier's client factory — return the sentinel the spy tags as `public`.
 vi.mock("./fate/publicClient", () => ({getPublicFateClient: () => PUBLIC_CLIENT}));
 
-// Controllable, REACTIVE session store. The whole first-paint story is "shell paints
-// while pending, FateProvider commits once settled", so the mock must actually trigger a
-// re-render when the test settles the session — a plain mutated variable wouldn't, and
-// FateProvider would never re-run its gate. `useSyncExternalStore` gives every
-// `useSession` consumer a real subscription; `setSession` (wrapped in `act` by the test)
-// notifies them, so the pending→resolved transition drives the real React commit path.
+// The session mock must be REACTIVE: a plain mutated variable would never re-render, so
+// FateProvider would never re-run its gate and the pending→resolved transition under test
+// wouldn't happen. `useSyncExternalStore` gives each consumer a real subscription.
 type SessionState = {
 	data: {user: {id: string; name: string; email: string}} | null;
 	isPending: boolean;
@@ -115,18 +75,13 @@ vi.mock("./auth/client", async () => {
 	};
 });
 
-// Keep the REAL FateProvider under test (its gate + key are invariant 2), but stub its
-// two network-touching collaborators so it runs offline: the client factory (which would
-// build an HTTP/EventSource transport) and the global live pin (which resolves
-// `useFateClient` from the real context the spied FateClient doesn't provide).
+// Keep the REAL FateProvider under test, but stub its two network-touching collaborators so it
+// runs offline.
 vi.mock("./fate/client", () => ({createClient: () => ({}) as never}));
 vi.mock("./fate/useGlobalLivePin", () => ({useGlobalLivePin: () => undefined}));
 
-// Spy the authed-tier feed-snapshot seam (#2321) so the wiring is observable independent of
-// the (default-off, `window`-bound) flag: FateProvider hydrates at client creation on the
-// resolved id + installs persistence, and tears down the previous identity's snapshot on an
-// identity change / sign-out; App's `onSignOut` tears down eagerly. The pure storage contract
-// is proven in `snapshot.test.ts`; here we assert only that the seam CALLS teardown/hydrate.
+// Spied so the seam is observable independent of the default-off, `window`-bound flag; the pure
+// storage contract is proven in `snapshot.test.ts`.
 const snapshotSpies = vi.hoisted(() => ({
 	hydrateAuthedClient: vi.fn(),
 	installAuthedSnapshotPersistence: vi.fn(() => () => {}),
@@ -134,9 +89,7 @@ const snapshotSpies = vi.hoisted(() => ({
 }));
 vi.mock("./fate/snapshot", () => snapshotSpies);
 
-// The fate-consuming hooks that live BELOW the gate in `LayoutContent`. Stub them inert
-// so `LayoutContent` renders offline once the gate commits — their PRESENCE below the
-// gate is invariant 1's point; here they must simply not touch the wire.
+// The fate-consuming hooks below the gate, stubbed inert so `LayoutContent` renders offline.
 vi.mock("./auth/useMe", () => ({
 	useMe: () => ({me: null, status: "idle", loading: false, refetch: vi.fn()}),
 }));
@@ -144,16 +97,9 @@ vi.mock("./pages/useProfileStats", () => ({useProfileStats: () => ({status: "idl
 vi.mock("./components/divan/useDivanAccess", () => ({useDivanAccess: () => false}));
 vi.mock("./components/bildirim/useBildirimUnread", () => ({useBildirimUnread: () => 0}));
 
-// Controllable flag mock. The mecmua nav entry (#2512) reads `mecmua-public-read`
-// (`flags.mecmua`); the mecmua feed (akış) nav entry (#2547) `mecmua-feed`
-// (`flags.mecmuaFeed`). Every other read (and other flag key) stays off, matching the
-// default the shell rendered under before. `loading: false` on every read models the
-// shell-key-manifest members' SYNCHRONOUS `__BOOT__` resolution (ADR 0179, #2828) — a member
-// carries its final value on the first render, no post-boot flip.
-// `signedIn` drives the mocked `readBootUser` (the `__BOOT__.user` edge identity, ADR 0185):
-// the shell frame reads it to reserve AND seed the signed-in account cluster before `useSession`
-// settles. Default false = `__BOOT__` absent, so the pre-existing shell tests see today's
-// signed-out first paint unchanged.
+// `loading: false` on every read models the shell-key members' synchronous `__BOOT__` resolution
+// (ADR 0179): a member carries its final value on the first render, with no post-boot flip.
+// `signedIn` drives the mocked `readBootUser` below; default false = `__BOOT__` absent.
 const flags = vi.hoisted(() => ({
 	mecmua: false,
 	mecmuaFeed: false,
@@ -169,10 +115,8 @@ vi.mock("./flags/useFlag", async () => {
 		}),
 	};
 });
-// The edge-resolved `__BOOT__.user` (ADR 0185): when `flags.signedIn`, the shell reads the full
-// identity synchronously — the account cluster paints its name (`Elif`) on the first frame, before
-// the session settles. Absent (default) ⇒ null ⇒ the signed-out first paint. `importActual` keeps
-// the real `readBoot`/`readBootMember`; only the user read is faked.
+// The edge-resolved `__BOOT__.user` (ADR 0185). `importActual` keeps the real
+// `readBoot`/`readBootMember`; only the user read is faked.
 vi.mock("./flags/boot", async (importActual) => ({
 	...(await importActual<typeof import("./flags/boot")>()),
 	readBootUser: () =>
@@ -190,11 +134,8 @@ vi.mock("./flags/boot", async (importActual) => ({
 			: null,
 }));
 
-// Render the real App at a chosen route. Invariant 2's tests settle the session, which
-// commits FateProvider and mounts the routed page BELOW it — so they route to a
-// fate-free page (`*` → NotFoundPage) whose render doesn't reach into the spied
-// FateClient's (absent) real context. Invariant 1's tests never settle (FateProvider
-// stays `null`), so the routed Outlet never mounts and the route is immaterial there.
+// A test that settles the session commits FateProvider and mounts the routed page below it, so it
+// must route somewhere fate-free — the spied FateClient provides no real context.
 function renderApp(route = "/") {
 	return render(
 		<MemoryRouter initialEntries={[route]}>
@@ -202,7 +143,6 @@ function renderApp(route = "/") {
 		</MemoryRouter>,
 	);
 }
-// A route that resolves to the fate-free NotFoundPage (`*`), for the post-settle tests.
 const FATE_FREE_ROUTE = "/__no_such_route__";
 
 describe("App first-paint invariants (#2177 — pins #2160 flash + #438 remount)", () => {
@@ -215,17 +155,12 @@ describe("App first-paint invariants (#2177 — pins #2160 flash + #438 remount)
 	});
 
 	it("invariant 1: the shell chrome paints while the session is isPending — with NO FateClient mounted", () => {
-		// First frame: session unresolved (isPending), before any fate client commits.
 		renderApp();
 
-		// The static shell chrome renders — no blank, no crash (#2160). Brand, nav, search,
-		// and the anonymous auth affordance are all present on the fate-free first paint.
 		expect(screen.getByRole("link", {name: /kamp/i})).toBeTruthy();
 		expect(screen.getByRole("link", {name: "sözlük"})).toBeTruthy();
 		expect(screen.getByRole("link", {name: "pano"})).toBeTruthy();
 		expect(screen.getByLabelText("Ara")).toBeTruthy();
-		// The auth split rides `useSession` alone (correct immediately, no fate): signed-out
-		// shows "giriş yap", never the signed-in "+ gönderi".
 		expect(screen.getByRole("button", {name: "giriş yap"})).toBeTruthy();
 		expect(screen.queryByRole("button", {name: "+ gönderi"})).toBeNull();
 
@@ -239,22 +174,15 @@ describe("App first-paint invariants (#2177 — pins #2160 flash + #438 remount)
 
 	it("invariant 1 (bridge): the SetTopbarChipsContext bridge shows anonymous affordances pre-settle — chips=null is not a blank frame", () => {
 		renderApp();
-		// The topbar chip props default to null pre-settle; the frame still paints its full
-		// anonymous chrome rather than a blank/absent topbar. The signed-out affordance is the
-		// observable proof the chip bridge degrades to anonymous, not empty.
 		expect(screen.getByRole("button", {name: "giriş yap"})).toBeTruthy();
 		expect(screen.getByRole("link", {name: /kamp/i})).toBeTruthy();
-		// Still fate-free at this point — chips arrive only after FateProvider commits below.
 		expect(fateMounts).toHaveLength(0);
 	});
 
 	it("invariant 2: FateClient mounts ONCE on the resolved identity — no anon→id remount (#438)", () => {
 		renderApp(FATE_FREE_ROUTE);
-		// Pending first paint → the gate defers, no mount yet.
 		expect(fateMounts).toHaveLength(0);
 
-		// The session settles to an authenticated identity. FateProvider commits for the
-		// first time NOW, under the resolved user id — never under "anon" first.
 		act(() => {
 			setSession({
 				data: {user: {id: "user-42", name: "Elif", email: "elif@kamp.us"}},
@@ -262,10 +190,6 @@ describe("App first-paint invariants (#2177 — pins #2160 flash + #438 remount)
 			});
 		});
 
-		// Exactly ONE mount, and its key is the resolved id — not "anon". This is the #438
-		// guard: had FateProvider committed under isPending, we'd see a first mount keyed
-		// "anon" then a SECOND mount keyed "user-42" (the remount that wipes controlled-form
-		// state).
 		expect(fateMounts).toHaveLength(1);
 		expect(fateMounts[0]?.key).toBe("user-42");
 		// REGRESSION: no anon→id re-key. If the `if (session.isPending) return null` gate were
@@ -278,8 +202,6 @@ describe("App first-paint invariants (#2177 — pins #2160 flash + #438 remount)
 		renderApp(FATE_FREE_ROUTE);
 		expect(fateMounts).toHaveLength(0);
 
-		// Settles with no user (signed-out but resolved). The gate commits once, keyed "anon"
-		// — but only once, because the pending frame committed nothing.
 		act(() => {
 			setSession({data: null, isPending: false});
 		});
@@ -289,11 +211,8 @@ describe("App first-paint invariants (#2177 — pins #2160 flash + #438 remount)
 	});
 });
 
-// Signed-in cluster seeded from __BOOT__.user (ADR 0185, superseding #2933's presence-only bit).
-// The shell frame reads the edge identity at first paint: signed-in ⇒ no giriş-yap CTA and the
-// account cluster's CONTENT (the name) rendered synchronously BEFORE useSession settles, so the
-// giriş-yap↔user-cluster swap + the name content pop-in never happen; absent __BOOT__ ⇒
-// readBootUser() null ⇒ today's session-gated render (the AC-3 no-op).
+// The shell reads the edge identity at first paint (ADR 0185), so the giriş-yap↔user-cluster swap
+// and the name pop-in never happen; absent `__BOOT__` ⇒ today's session-gated render.
 describe("signed-in cluster seeded from __BOOT__.user (ADR 0185)", () => {
 	beforeEach(() => {
 		fateMounts.length = 0;
@@ -308,8 +227,6 @@ describe("signed-in cluster seeded from __BOOT__.user (ADR 0185)", () => {
 	it("__BOOT__ present + user: first paint renders the account name — no giriş-yap flash, before the session settles", () => {
 		flags.signedIn = true;
 		renderApp();
-		// The session is still isPending (no fate, no chips), yet the shell already knows WHO is
-		// signed in from the edge user object: the CTA is gone and the name renders synchronously.
 		expect(screen.queryByRole("button", {name: "giriş yap"})).toBeNull();
 		expect(screen.getByText("Elif")).toBeTruthy();
 		expect(fateMounts).toHaveLength(0);
@@ -318,7 +235,6 @@ describe("signed-in cluster seeded from __BOOT__.user (ADR 0185)", () => {
 	it("__BOOT__ present + user: no content swap when the session settles signed-in", () => {
 		flags.signedIn = true;
 		renderApp(FATE_FREE_ROUTE);
-		// Pre-settle: the signed-in name is already painted, no CTA.
 		expect(screen.queryByRole("button", {name: "giriş yap"})).toBeNull();
 		expect(screen.getByText("Elif")).toBeTruthy();
 		act(() => {
@@ -327,8 +243,6 @@ describe("signed-in cluster seeded from __BOOT__.user (ADR 0185)", () => {
 				isPending: false,
 			});
 		});
-		// Settled signed-in: still no CTA and the same name — the account cluster held its content
-		// across settle, never swapping giriş-yap in then out nor popping the name in (the jank).
 		expect(screen.queryByRole("button", {name: "giriş yap"})).toBeNull();
 		expect(screen.getByText("Elif")).toBeTruthy();
 	});
@@ -341,11 +255,8 @@ describe("signed-in cluster seeded from __BOOT__.user (ADR 0185)", () => {
 	});
 });
 
-// The mecmua nav entry (#2828) gates on `mecmua-public-read`, a shell-key-manifest member —
-// so the unified `useFlag` resolves it synchronously from `__BOOT__` and the link is in its
-// final nav position on the FIRST paint (no false→true pop-in after sözlük/pano). These pin the
-// gating AND the first-paint geometry: on ⇒ mecmua present on the first render, in order after
-// pano; off ⇒ absent (the flag's dark-ship kill-switch is retained, ADR 0179).
+// The mecmua nav entry is a shell-key member, so it resolves synchronously and lands in its final
+// nav position on the FIRST paint — no false→true pop-in (#2828, ADR 0179).
 describe("mecmua nav entry (#2828) — resolves at first paint from __BOOT__, no pop-in", () => {
 	beforeEach(() => {
 		fateMounts.length = 0;
@@ -360,7 +271,6 @@ describe("mecmua nav entry (#2828) — resolves at first paint from __BOOT__, no
 	it("off: the kill-switch dark ⇒ no mecmua nav link (the route's dark-ship posture is preserved)", () => {
 		renderApp();
 		expect(screen.queryByRole("link", {name: "mecmua"})).toBeNull();
-		// sözlük/pano still paint — the ungated siblings are unaffected.
 		expect(screen.getByRole("link", {name: "sözlük"})).toBeTruthy();
 		expect(screen.getByRole("link", {name: "pano"})).toBeTruthy();
 	});
@@ -368,11 +278,8 @@ describe("mecmua nav entry (#2828) — resolves at first paint from __BOOT__, no
 	it("on: mecmua paints on the FIRST render (session still pending), in final position after pano", () => {
 		flags.mecmua = true;
 		renderApp();
-		// Present on the very first paint — no act()/settle needed: the member resolved
-		// synchronously, so there is no false→true flip that would inject it a tick later.
 		const mecmua = screen.getByRole("link", {name: "mecmua"});
 		expect(mecmua.getAttribute("href")).toBe("/mecmua");
-		// Final geometry: mecmua sits after pano, matching its ungated siblings' order.
 		const navLinks = ["sözlük", "pano", "mecmua"].map((label) =>
 			screen.getByRole("link", {name: label}),
 		);
@@ -380,16 +287,12 @@ describe("mecmua nav entry (#2828) — resolves at first paint from __BOOT__, no
 			Array.prototype.indexOf.call(document.querySelectorAll("a"), el),
 		);
 		expect(order).toEqual([...order].sort((a, b) => a - b));
-		// Still fate-free at first paint — the nav geometry is final without a fate mount.
 		expect(fateMounts).toHaveLength(0);
 	});
 });
 
-// The mecmua feed (akış) nav entry (#2547) gates on the SAME `mecmua-feed` seam the
-// `/mecmua/akis` route self-gates on — so the link never points at a dark 404. These
-// pin that gating: absent when the flag is off, present (→ /mecmua/akis) when it flips.
-// Rendered at `/mecmua`, where the entry now lives (the mecmua Subnav zone) — the
-// gating guarantee is unchanged, only its host zone moved.
+// The akış entry gates on the SAME `mecmua-feed` seam its route self-gates on, so the link can
+// never point at a dark 404 (#2547).
 describe("mecmua feed nav entry (#2547) — gated on mecmua-feed, never a dead link", () => {
 	beforeEach(() => {
 		fateMounts.length = 0;
@@ -420,11 +323,8 @@ describe("mecmua feed nav entry (#2547) — gated on mecmua-feed, never a dead l
 	});
 });
 
-// The nav-IA substrate (#2598, epic #2596): each product mounts under a nested layout route
-// rendering a persistent product Subnav zone — the product route resolves under
-// `ProductSubnavLayout`, which paints a `.kp-subnav` zone above the routed page. The routed
-// page (mocked PanoFeed) mounts below the session gate, so these settle the session
-// (signed-out) to commit the routed Outlet.
+// The routed page mounts below the session gate, so these settle the session to commit the
+// Outlet (#2598).
 describe("nav-IA per-product Subnav zone substrate (#2598)", () => {
 	beforeEach(() => {
 		fateMounts.length = 0;
@@ -451,9 +351,8 @@ describe("nav-IA per-product Subnav zone substrate (#2598)", () => {
 	});
 });
 
-// The atomic coupling (#2600, epic #2596): pano/yeni lives in the pano Subnav CTA slot and the
-// topbar carries no `+ gönderi` — the CTA sits in pano's product zone, not the global bar. The
-// signed-out `giriş yap` affordance is untouched.
+// The atomic coupling (#2600): the pano primary action sits in pano's Subnav CTA slot, never the
+// global topbar.
 const SIGNED_IN = {data: {user: {id: "u1", name: "Elif", email: "elif@kamp.us"}}, isPending: false};
 describe("nav-IA coupling: pano/yeni Subnav CTA ↔ topbar + gönderi eviction (#2600)", () => {
 	beforeEach(() => {
@@ -469,10 +368,7 @@ describe("nav-IA coupling: pano/yeni Subnav CTA ↔ topbar + gönderi eviction (
 		act(() => {
 			setSession(SIGNED_IN);
 		});
-		// Eviction half: the topbar no longer carries the pano primary action.
 		expect(screen.queryByRole("button", {name: "+ gönderi"})).toBeNull();
-		// Landing half: the primary action is reachable from the pano product Subnav zone,
-		// not the global topbar.
 		const cta = screen.getByRole("button", {name: "yeni gönderi"});
 		expect(container.querySelector(".kp-subnav")?.contains(cta)).toBe(true);
 		expect(container.querySelector(".kp-topbar")?.contains(cta)).toBe(false);
@@ -485,14 +381,12 @@ describe("nav-IA coupling: pano/yeni Subnav CTA ↔ topbar + gönderi eviction (
 		});
 		expect(screen.getByRole("button", {name: "giriş yap"})).toBeTruthy();
 		expect(screen.queryByRole("button", {name: "yeni gönderi"})).toBeNull();
-		// The pano product zone still paints its Subnav frame — just with an empty CTA slot.
 		expect(container.querySelector(".kp-subnav")).toBeTruthy();
 	});
 });
 
-// The mecmua nav-IA delta (#2603, epic #2596): the akış sub-destination lives in the mecmua
-// Subnav zone, not the global topbar product-noun row — still gated on the mecmua-feed seam
-// (never a dead link).
+// akış lives in the mecmua Subnav zone, not the topbar product-noun row — still gated on its own
+// seam (#2603).
 describe("nav-IA mecmua delta: akış moves from topbar into the mecmua Subnav zone (#2603)", () => {
 	beforeEach(() => {
 		fateMounts.length = 0;
@@ -511,9 +405,7 @@ describe("nav-IA mecmua delta: akış moves from topbar into the mecmua Subnav z
 			setSession({data: null, isPending: false});
 		});
 		const akis = screen.getByRole("link", {name: "akış"});
-		// Eviction half: the topbar product-noun row no longer carries akış.
 		expect(container.querySelector(".kp-topbar")?.contains(akis)).toBe(false);
-		// Landing half: akış lives in the mecmua product Subnav zone.
 		expect(container.querySelector(".kp-subnav")?.contains(akis)).toBe(true);
 	});
 
@@ -526,10 +418,8 @@ describe("nav-IA mecmua delta: akış moves from topbar into the mecmua Subnav z
 	});
 });
 
-// The two-tier fate provider's public first paint (ADR 0167 / #2285): the anon-capable
-// /pano feed paints over the PUBLIC (always-anonymous) client ABOVE the session gate,
-// in parallel with `get-session`, then hands off to the authed feed once the gate
-// commits — WITHOUT an anon→id re-key remount of the authed router subtree (#438).
+// The two-tier public first paint (ADR 0167) — and the hand-off must not drag the authed subtree
+// through an anon→id re-key (#438).
 describe("Two-tier fate provider — /pano public first paint (#2285)", () => {
 	beforeEach(() => {
 		fateMounts.length = 0;
@@ -540,32 +430,23 @@ describe("Two-tier fate provider — /pano public first paint (#2285)", () => {
 	});
 
 	it("AC2/AC5: the /pano feed paints over the public client while the session is isPending — before the authed gate commits", () => {
-		// First frame on /pano: session still resolving. The authed FateProvider gate is
-		// null, yet the public feed paints — proof the first paint does NOT wait on
-		// get-session.
 		renderApp("/pano");
 
 		expect(screen.getByTestId("eager-pano-feed")).toBeTruthy();
-		// It painted over the PUBLIC tier (above the gate)…
 		expect(fateMounts.some((m) => m.tier === "public")).toBe(true);
-		// …while the AUTHED tier has NOT committed (still isPending → null below).
 		expect(fateMounts.some((m) => m.tier === "authed")).toBe(false);
 	});
 
 	it("scoped: a non-pano route paints NO public feed (the eager tier is /pano-only)", () => {
 		renderApp("/sozluk");
 		expect(screen.queryByTestId("eager-pano-feed")).toBeNull();
-		// No public client mounts off the pano routes — the shell stays fate-free there.
 		expect(fateMounts).toHaveLength(0);
 	});
 
 	it("AC4 (#438): after the public first paint, the authed subtree mounts ONCE on the resolved id — no anon→id remount", () => {
 		renderApp("/pano");
-		// Pending: only the public tier has painted; the authed gate is still deferred.
 		expect(fateMounts.filter((m) => m.tier === "authed")).toHaveLength(0);
 
-		// The session settles authenticated → the authed FateProvider commits for the
-		// FIRST time now, under the resolved id — the eager public tier unmounts.
 		act(() => {
 			setSession({
 				data: {user: {id: "user-7", name: "Deniz", email: "deniz@kamp.us"}},
@@ -574,20 +455,14 @@ describe("Two-tier fate provider — /pano public first paint (#2285)", () => {
 		});
 
 		const authed = fateMounts.filter((m) => m.tier === "authed");
-		// Exactly ONE authed mount, keyed on the resolved id — never "anon" first. Had the
-		// public first paint dragged the authed tree through an anon→id re-key, we'd see a
-		// leading {key:"anon"} authed mount (the #438 form-wiping remount).
 		expect(authed).toHaveLength(1);
 		expect(authed[0]?.key).toBe("user-7");
 		expect(authed.map((m) => m.key)).not.toContain("anon");
 	});
 });
 
-// The two-tier decoupling extended to /profile (ADR 0167 / #2188): the identity-scoped
-// Katkıların read can't paint anon data pre-session, so /profile's eager tier paints a
-// SKELETON above the gate while `get-session` resolves, then the authed read below the
-// gate fills it in. Unlike /pano's tier it mounts NO FateClient — which is exactly what
-// keeps #438 preserved (no client above the gate ⇒ nothing to re-key anon→id).
+// /profile's eager tier paints a SKELETON (the identity-scoped read can't show anon data) and,
+// unlike /pano's, mounts NO FateClient — so there is nothing above the gate to re-key (#2188).
 describe("Two-tier fate provider — /profile eager Katkıların skeleton (#2188)", () => {
 	beforeEach(() => {
 		fateMounts.length = 0;
@@ -601,17 +476,11 @@ describe("Two-tier fate provider — /profile eager Katkıların skeleton (#2188
 		renderApp("/profile");
 
 		expect(screen.getByTestId("signal-loading")).toBeTruthy();
-		// It painted ABOVE the gate with NO FateClient committed — the authed tier is
-		// still deferred (isPending → null), and the eager tier mounts no client at all.
 		expect(fateMounts).toHaveLength(0);
 	});
 
 	it("#438: the eager /profile skeleton mounts NO FateClient — nothing to re-key anon→id", () => {
 		renderApp("/profile");
-		// The proof the eager tier can't reintroduce the #438 remount: it commits zero
-		// fate clients above the gate, so there is no anon-keyed client to later re-key to
-		// the resolved id. The authed FateProvider below is untouched (its once-on-settle
-		// mount is pinned by the invariant-2 tests above).
 		expect(fateMounts).toHaveLength(0);
 		expect(screen.getByTestId("signal-loading")).toBeTruthy();
 	});
@@ -623,8 +492,7 @@ describe("Two-tier fate provider — /profile eager Katkıların skeleton (#2188
 	});
 });
 
-// The header search box echoes the active query on the results page (#2199). The
-// box lives in the fate-free shell, so these render without settling the session.
+// The search box lives in the fate-free shell, so these render without settling the session (#2199).
 describe("Topbar search echo (#2199)", () => {
 	beforeEach(() => {
 		fateMounts.length = 0;
@@ -650,11 +518,8 @@ describe("Topbar search echo (#2199)", () => {
 	});
 });
 
-// The authed-tier feed snapshot wiring (#2321): FateProvider hydrates the identity-keyed
-// client at creation on the RESOLVED id (never anon), installs per-identity persistence, and
-// tears down the previous identity's snapshot on an identity change / sign-out — all through
-// the REAL FateProvider gate the invariant-2 tests pin (#438-safe). The snapshot module is
-// spied (snapshotSpies), so these assert the SEAM fires, not the storage effect.
+// The authed-tier snapshot wiring (#2321). The snapshot module is spied, so these assert the SEAM
+// fires, not the storage effect.
 describe("Authed feed snapshot wiring (#2321)", () => {
 	beforeEach(() => {
 		fateMounts.length = 0;
@@ -669,7 +534,6 @@ describe("Authed feed snapshot wiring (#2321)", () => {
 
 	it("AC1/AC4: hydrates the authed client ONCE on the resolved identity (never anon) + installs persistence", () => {
 		renderApp(FATE_FREE_ROUTE);
-		// Pending: the gate is deferred, so no authed client has been created/hydrated yet.
 		expect(snapshotSpies.hydrateAuthedClient).not.toHaveBeenCalled();
 
 		act(() => {
@@ -679,8 +543,6 @@ describe("Authed feed snapshot wiring (#2321)", () => {
 			});
 		});
 
-		// Hydrated exactly once, keyed on the resolved id — never a leading anon hydrate (the
-		// #438 re-key would have produced an anon-keyed pass first).
 		expect(snapshotSpies.hydrateAuthedClient).toHaveBeenCalledTimes(1);
 		expect(snapshotSpies.hydrateAuthedClient).toHaveBeenCalledWith(expect.anything(), "user-42");
 		expect(snapshotSpies.installAuthedSnapshotPersistence).toHaveBeenCalledWith(
@@ -697,7 +559,7 @@ describe("Authed feed snapshot wiring (#2321)", () => {
 				isPending: false,
 			});
 		});
-		expect(snapshotSpies.teardownAuthedSnapshot).not.toHaveBeenCalled(); // first identity, nothing prior
+		expect(snapshotSpies.teardownAuthedSnapshot).not.toHaveBeenCalled();
 
 		act(() => {
 			setSession({
@@ -717,7 +579,7 @@ describe("Authed feed snapshot wiring (#2321)", () => {
 			});
 		});
 		act(() => {
-			setSession({data: null, isPending: false}); // session ends
+			setSession({data: null, isPending: false});
 		});
 		expect(snapshotSpies.teardownAuthedSnapshot).toHaveBeenCalledWith("user-A");
 	});

--- a/apps/web/src/App.tsx
+++ b/apps/web/src/App.tsx
@@ -64,12 +64,6 @@ import {UsernameBootstrap} from "./pages/UsernameBootstrap";
 import {UserProfilePage} from "./pages/UserProfilePage";
 import {useProfileStats} from "./pages/useProfileStats";
 
-/**
- * The fate-dependent topbar chips, computed below the session gate and read by the
- * always-painting shell frame above it. `null` is the pre-settle default — the frame
- * paints its static structure immediately with these absent, and they fill in once
- * `FateProvider` commits and `LayoutContent` publishes them. See #2160.
- */
 type TopbarChips = {
 	userProps: {user?: {name: string; username: string | null}};
 	karma: number | undefined;
@@ -77,13 +71,8 @@ type TopbarChips = {
 	bildirim: {to: string; unread: number} | undefined;
 };
 
-/**
- * The bridge that carries the fate-dependent chips UP from `LayoutContent` (below the
- * session gate, where fate lives) to the always-painting shell frame (above it). The
- * frame owns the chip state and passes the setter down through this context; the
- * gated content sets it once fate settles. This lets the frame render once — no
- * remount of the shell on settle, only the chips fill in (#2160).
- */
+// Carries the chips UP from `LayoutContent` (below the session gate) to the shell frame
+// above it, so the frame renders once and only the chips fill in on settle (#2160).
 const SetTopbarChipsContext = createContext<((chips: TopbarChips | null) => void) | null>(null);
 
 /**
@@ -101,38 +90,22 @@ function Layout() {
 	const location = useLocation();
 	const {choice: themeChoice, setChoice: setThemeChoice} = useTheme();
 	const [chips, setChips] = useState<TopbarChips | null>(null);
-	// mecmua-public-read (#2512) — the same seam the reader/index gate on; off ⇒ mecmua absent.
-	// As a shell-key-manifest member the unified `useFlag` resolves it SYNCHRONOUSLY from
-	// `window.__BOOT__` on the first render (loading:false, no fetch, no repaint), so the nav
-	// paints its final geometry at first paint, killing the false→true pop-in this gate used to
-	// cost every load (#2828). Absent `__BOOT__` (flag off / the #2931 never-hang fallback) ⇒ the
-	// fetch fallback, exactly today's behavior. See ADR 0179.
+	// mecmua-public-read (#2512) resolves synchronously from `window.__BOOT__` so the nav paints
+	// its final geometry on the first frame; absent `__BOOT__` it falls back to the fetch. See ADR 0179.
 	const {value: mecmuaOn} = useFlag(MECMUA_PUBLIC_READ, false);
 
-	// The two-tier fate provider's public first paint (ADR 0167). While `get-session`
-	// is still in flight the authed `FateProvider` gate below returns null, so the
-	// routed `/pano` feed can't paint. So for the anon-capable pano feed routes ONLY,
-	// render an eager copy over the PUBLIC (always-anonymous) fate client above the gate
-	// — it paints in parallel with `get-session` instead of serialized behind it. The
-	// instant the session settles the gate commits, the authed feed (with live +
-	// mutations) takes over, and this eager tier unmounts. This preserves #438 verbatim:
-	// the router-bearing authed subtree still mounts only once, on the resolved identity
-	// — the public client is a distinct, never-re-keyed instance, so there is no
-	// anon→userId re-key remount of the authed tree.
+	// Eager public-tier pano feed above the session gate — see ADR 0167. The public client is a
+	// distinct, never-re-keyed instance, so the authed tree still mounts exactly once (#438).
 	const panoMatch = useMatch("/pano");
 	const panoSiteMatch = useMatch("/pano/site/:host");
 	const eagerPanoHost = panoSiteMatch?.params.host;
 	const showEagerPanoFeed = session.isPending && (panoMatch != null || panoSiteMatch != null);
 
-	// The same two-tier decoupling (ADR 0167) extended to `/profile` (#2188): paint the
-	// Katkıların skeleton above the gate while `get-session` resolves. Why it is a
-	// skeleton (not anon data) and how it stays #438-safe with no fate client lives on
-	// `EagerProfileContributionSkeleton`.
+	// The same two-tier decoupling for `/profile` (#2188) — see ADR 0167; why it is a skeleton
+	// rather than anon data lives on `EagerProfileContributionSkeleton`.
 	const profileMatch = useMatch("/profile");
 	const showEagerProfileSkeleton = session.isPending && profileMatch != null;
 
-	// Echo the active query in the header input, but only on the results page — off
-	// `/search` the box keeps its empty `ara…` placeholder (#2199).
 	const searchQuery =
 		location.pathname === "/search" ? (new URLSearchParams(location.search).get("q") ?? "") : "";
 
@@ -149,12 +122,8 @@ function Layout() {
 	}
 
 	const isSignedIn = !!session.data;
-	// First-paint identity rides the edge-resolved `__BOOT__.user` (ADR 0185, superseding #2933's
-	// presence-only `signedIn` bit): the full user is known synchronously — before `useSession`
-	// settles — so the account cluster both exists AND carries its name/handle from the first
-	// frame, killing the giriş-yap↔user-cluster swap and the name content pop-in. Absent `__BOOT__`
-	// (flag off / the #2931 never-hang fallback) ⇒ `readBootUser()` is null ⇒ the session-gated
-	// `isSignedIn` governs, exactly today's behavior.
+	// First-paint identity rides the edge-resolved `__BOOT__.user` — see ADR 0185. Absent
+	// `__BOOT__` this is null and the session-gated `isSignedIn` governs.
 	const bootUser = readBootUser();
 	const bootSignedIn = bootUser != null;
 	const signedInAtFirstPaint = bootSignedIn || isSignedIn;
@@ -162,10 +131,6 @@ function Layout() {
 	// definitively signed-out session — so an absent `__BOOT__` never reserves (today's render)
 	// and a boot/session divergence collapses cleanly rather than stranding a phantom slot.
 	const reserveSignedInSlots = bootSignedIn && (session.isPending || isSignedIn);
-	// Seed the topbar identity synchronously from `__BOOT__.user` so the name/handle render on the
-	// first frame, before `FateProvider`/`LayoutContent` publish the fate-derived chips below. Once
-	// those chips arrive (session settled) they take over — the same resolved value, so no visible
-	// swap. Absent `__BOOT__` ⇒ `{}` ⇒ the chips-only path, exactly today's render.
 	const bootUserProps = bootUser
 		? {
 				user: {
@@ -212,10 +177,8 @@ function Layout() {
 							onThemeChange={setThemeChoice}
 							onLogout={onSignOut}
 							actions={
-								// giriş-yap rides the first-paint presence bit, not the settling session:
-								// `__BOOT__.user != null` (via signedInAtFirstPaint) suppresses the CTA for a
-								// signed-in user from the first frame, so it never flashes then swaps out
-								// (#2933, ADR 0185). Absent `__BOOT__` ⇒ this reduces to `isSignedIn`, today's split.
+								// Suppressed from the first frame for a signed-in user so the CTA never flashes
+								// then swaps out (#2933) — see ADR 0185.
 								!signedInAtFirstPaint ? (
 									<Button
 										type="button"
@@ -232,19 +195,12 @@ function Layout() {
 							}
 						/>
 						<Main>
-							{/* PUBLIC tier (ADR 0167): the anon-capable pano feed paints over the
-						    always-anonymous public client while `get-session` resolves, then
-						    hands off to the authed feed once the gate below commits. */}
 							{showEagerPanoFeed ? (
 								<PublicFateProvider>
 									<PanoFeed {...(eagerPanoHost ? {host: eagerPanoHost} : {})} />
 								</PublicFateProvider>
 							) : null}
 							{showEagerProfileSkeleton ? <EagerProfileContributionSkeleton /> : null}
-							{/* The routed content + fate-dependent chips live below the session
-						    gate — FateProvider keeps its #438 remount guard (first & only key
-						    is the resolved identity), while the shell frame above already
-						    painted. */}
 							<FateProvider>
 								<SetTopbarChipsContext.Provider value={setChips}>
 									<LayoutContent />
@@ -259,20 +215,14 @@ function Layout() {
 	);
 }
 
-/**
- * Runs below `FateProvider` (so `useMe`/`useProfileStats`/`useDivanAccess`/
- * `useBildirimUnread` have a fate client): computes the auth-dependent topbar chips,
- * publishes them up to the shell frame via the chip-state bridge, and renders the
- * routed `Outlet`. Because `FateProvider` only commits once the session is settled,
- * this never mounts under an "anon" key (#438 preserved).
- */
+// Runs below `FateProvider`, which commits only once the session is settled — so this never
+// mounts under an "anon" key (#438).
 function LayoutContent() {
 	const session = useSession();
 	const {me, refetch} = useMe();
 	const navigate = useNavigate();
 	const location = useLocation();
 	const setChips = useContext(SetTopbarChipsContext);
-	// Ambient self-karma in the topbar (#1208).
 	const karmaState = useProfileStats(me?.username ?? null);
 	const selfKarma = karmaState.status === "ok" ? karmaState.stats.totalKarma : undefined;
 	// The yazar/mod-only divan entry (#1290). `useDivanAccess` probes the server's
@@ -281,9 +231,6 @@ function LayoutContent() {
 	// çaylak/non-mod skips the guaranteed-`UNAUTHORIZED` probe; the ambiguous case
 	// still probes.
 	const showDivan = useDivanAccess(me);
-	// The bildirim entry + unread chip (#1694), dark behind the `phoenix-bildirim`
-	// flag. Gating the fetch on flag+session keeps the flag-off path exactly as
-	// today: disabled ⇒ the read never touches the wire and reports 0.
 	const {value: bildirimOn} = useFlag(PHOENIX_BILDIRIM, false);
 	const bildirimUnread = useBildirimUnread(bildirimOn && !!session.data, me?.id ?? null);
 	// #1888: hold the off-/auth redirect while a chosen-username signup is still
@@ -297,18 +244,12 @@ function LayoutContent() {
 		if (!session.data) return;
 		if (location.pathname !== "/auth") return;
 		if (usernamePending) return;
-		// AuthPage sets `?returnTo=<path>` when redirected from a signed-out
-		// write affordance (T17). Honor it (sanitized to same-origin) so the
-		// user lands back on the page that triggered the auth flow.
 		const params = new URLSearchParams(location.search);
 		const target = safeReturnTo(params.get("returnTo"));
 		navigate(target, {replace: true});
 	}, [session.data, location.pathname, location.search, navigate, usernamePending]);
 
 	const sessionUser = session.data?.user;
-	// The topbar identity, routed through the shared actor-label rule (#2126):
-	// display name, falling back to the @username, never the email local-part the
-	// old `email.split("@")[0]` leaked into the visible name.
 	const username = me?.username ?? null;
 	const isSignedIn = !!session.data;
 	const needsBootstrap = isSignedIn && me !== null && !me.username && location.pathname !== "/auth";
@@ -330,8 +271,6 @@ function LayoutContent() {
 		[sessionUser, me?.name, username, selfKarma, showDivan, bildirimOn, isSignedIn, bildirimUnread],
 	);
 
-	// Publish the computed chips up to the shell frame; clear them on unmount (the
-	// signed-out/re-key transition) so the frame falls back to anonymous affordances.
 	useEffect(() => {
 		setChips?.(chips);
 		return () => setChips?.(null);
@@ -339,8 +278,6 @@ function LayoutContent() {
 
 	return (
 		<>
-			{/* Membrane notice for a signed-in user whose email is failing (epic #2687, #2693) —
-			    dark behind its flag, inert until the worker exposes the failing signal on `me`. */}
 			<EmailDeliveryNoticeMount me={me} />
 			{needsBootstrap && sessionUser ? (
 				<UsernameBootstrap email={sessionUser.email} onComplete={refetch} />
@@ -377,8 +314,6 @@ function ComposerRouteFallback() {
 }
 
 export function App() {
-	// Each product's routes mount under a pathless layout route rendering its persistent
-	// Subnav zone (#2598, epic #2596).
 	const panoRoutes = [
 		<Route key="pano" path="/pano" element={<PanoFeed />} />,
 		<Route key="pano-yeni" path="/pano/yeni" element={<PanoSubmitPage />} />,
@@ -425,8 +360,6 @@ export function App() {
 		<Route key="sozluk" path="/sozluk" element={<SozlukHome />} />,
 		<Route key="sozluk-slug" path="/sozluk/:slug" element={<SozlukTermPage />} />,
 	];
-	// The divan reviewer workspace (#1290) — access is server-authoritative (the gated
-	// `divan.roster` read denies a çaylak/visitor the invisible `UNAUTHORIZED`).
 	const divanRoutes = [<Route key="divan" path="/divan" element={<DivanPage />} />];
 	return (
 		<ThemeProvider>
@@ -434,38 +367,21 @@ export function App() {
 				<Routes>
 					<Route element={<Layout />}>
 						<Route path="/" element={<LandingPage />} />
-						{/* pano's zone hosts feed-scoped filters/meta + the site-filter crumb
-						    (published up from the routed feed) and its primary-action CTA, so it
-						    wraps under its own `PanoSubnavLayout` rather than the generic empty/
-						    cta-only frame (#2601). */}
 						<Route key="pano-zone" element={<PanoSubnavLayout />}>
 							{panoRoutes}
 						</Route>
-						{/* mecmua's zone hosts flag-composed destinations + a primary-action CTA,
-						    so it wraps under its own `MecmuaSubnavLayout` (which composes both)
-						    rather than the generic empty/cta-only frame (#2603). */}
 						<Route key="mecmua-zone" element={<MecmuaSubnavLayout />}>
 							{mecmuaRoutes}
 						</Route>
-						{/* sözlük's zone hosts its persistent go-to-or-create box (the Subnav input
-						    slot) + the URL-driven alphabet filter row, so it wraps under its own
-						    `SozlukSubnavLayout` rather than the generic empty/cta-only frame (#2602). */}
 						<Route key="sozluk-zone" element={<SozlukSubnavLayout />}>
 							{sozlukRoutes}
 						</Route>
-						{/* divan's zone hosts the çaylaklar ↔ raporlar section switch, published up from
-						    the routed page as Subnav filters, so it wraps under its own `DivanSubnavLayout`
-						    rather than the generic empty/cta-only frame (#2604). */}
 						<Route key="divan-zone" element={<DivanSubnavLayout />}>
 							{divanRoutes}
 						</Route>
 						<Route path="/search" element={<SearchPage />} />
 						<Route path="/auth" element={<AuthPage />} />
-						{/* The founder/mod conversion readout (#1589) — access is server-authoritative
-					    (the gated funnel.summary read denies a non-mod), so the route stays mod-only. */}
 						<Route path="/funnel" element={<FunnelPage />} />
-						{/* The notification center (#1694) — the page self-gates on the
-					    phoenix-bildirim flag (off ⇒ 404), so the route is dark by default. */}
 						<Route path="/bildirimler" element={<BildirimlerPage />} />
 						{/* /lab/composer — throwaway tiptap spike (#2465), reachable by URL only,
 						    no nav entry; deletable when the rich-composer phase begins. */}
@@ -477,14 +393,7 @@ export function App() {
 								</Suspense>
 							}
 						/>
-						{/* /lab/atolye — public index of atölye, the museum of craft (epic #2473, #3092).
-						    ASCII route slug (routes-are-English); reachable by URL only, no nav entry,
-						    matching the /lab/composer precedent. */}
 						<Route path="/lab/atolye" element={<AtolyeIndexPage />} />
-						{/* /lab/atolye/:exhibit — the exhibit detail route (#3093): resolves the slug
-						    against the registry, renders it through the knobs harness with knob state
-						    deep-linked into the URL, and self-renders an atölye-scoped not-found on an
-						    unknown slug (never the global 404). ASCII route slug. */}
 						<Route path="/lab/atolye/:exhibit" element={<AtolyeExhibitPage />} />
 						<Route path="/profile" element={<ProfilePage />} />
 						<Route path="/susturduklarim" element={<MutesPage />} />

--- a/apps/web/src/admin/AdminConsole.tsx
+++ b/apps/web/src/admin/AdminConsole.tsx
@@ -1,15 +1,3 @@
-/**
- * `AdminConsole` — the admin-console shell (#2740, epic #2711): the extensible host that
- * renders the module registry as a nav + a panel. This is the lazy-loaded admin-only
- * chunk (`AdminConsoleRoute` mounts it only past the admin probe), so no console/module
- * code reaches a non-admin's bundle.
- *
- * The shell is registry-driven, not per-module wired: it reads `consoleRegistry.list()`
- * (composed by value in `app-modules.ts`) and delegates "which panel is active" to the
- * pure `selectActiveModule`. Adding a module is one registry entry — the shell renders it
- * with zero changes. Its panel is `React.lazy`-wrapped, so a module's chunk loads only
- * when its nav entry is selected. Lowercase-Turkish copy per the design law.
- */
 import {Suspense, useState} from "react";
 import {Button} from "../components/ui/Button";
 import {consoleRegistry} from "./app-modules.ts";

--- a/apps/web/src/admin/AdminConsoleRoute.tsx
+++ b/apps/web/src/admin/AdminConsoleRoute.tsx
@@ -1,27 +1,19 @@
 /**
- * `AdminConsoleRoute` — the `/admin` route element (#2740, epic #2711). It is eagerly in
- * the main bundle (it's a route element), but carries only the admin probe + the lazy
- * console ref — the console shell and every module live behind the `React.lazy` boundary,
- * so a non-admin's bundle never gains console code.
- *
- * Invisible-denial, load-bearing (ADR 0107 / ADR 0098 §2): a caller who isn't a proven
- * admin renders the ORDINARY not-found page — indistinguishable from "this route doesn't
- * exist" — never a 403 or an "you are not an admin" surface. The lazy `AdminConsole`
- * import is reached ONLY in the granted branch, so a non-admin/anonymous visitor's browser
- * never fetches the console chunk.
+ * Invisible denial, load-bearing (ADR 0107, ADR 0098 §2): a caller who isn't a proven admin
+ * renders the ORDINARY not-found page — never a 403 or an "you are not an admin" surface.
+ * The lazy `AdminConsole` import is reached only in the granted branch, so a non-admin's
+ * browser never fetches the console chunk.
  */
 import {lazy, Suspense} from "react";
 import {NotFoundPage} from "../pages/NotFoundPage";
 import {useAdminProbe} from "./useAdminProbe.ts";
 
-// Reached only in the granted branch below — a non-admin never triggers this import.
 const AdminConsole = lazy(() => import("./AdminConsole.tsx"));
 
 export function AdminConsoleRoute() {
 	const {granted, loading} = useAdminProbe();
-	// In flight: render nothing rather than flash the not-found page at a legit admin. A
-	// non-admin's probe resolves to denied and falls through to NotFoundPage below, so this
-	// neutral window leaks nothing.
+	// Render nothing in flight rather than flash not-found at a legit admin; a non-admin's
+	// probe resolves to denied and falls through to NotFoundPage, so this window leaks nothing.
 	if (loading) return null;
 	if (!granted) return <NotFoundPage />;
 	return (

--- a/apps/web/src/admin/app-modules.ts
+++ b/apps/web/src/admin/app-modules.ts
@@ -1,13 +1,3 @@
-/**
- * The app-wide console module composition (#2740, epic #2711) — where the real console
- * modules register into `consoleRegistry` BY VALUE, the client mirror of the worker-side
- * `config.ts` `modules` array. Imported by the lazy console shell only, so no module code
- * reaches a non-admin's bundle; each module's panel is itself `React.lazy`-wrapped, so a
- * module's panel chunk loads only when its nav entry is selected.
- *
- * Registering a module is one entry here. The flags module (#2742) is the first real tenant —
- * its `bayraklar` panel writes the `phoenix_flag_overrides` cookie per-browser.
- */
 import {lazy} from "react";
 import {consoleRegistry} from "./module-registry.ts";
 

--- a/apps/web/src/admin/email-delivery/EmailDeliveryPanel.tsx
+++ b/apps/web/src/admin/email-delivery/EmailDeliveryPanel.tsx
@@ -1,20 +1,7 @@
 /**
- * `EmailDeliveryPanel` — the email-delivery admin console module (#2732, email-bounce epic
- * #2687), the React consumer of the worker admin surface #2731 landed. It lists the
- * currently-failing addresses off the `emailDelivery.failing` roll-up and drives the
- * `emailDelivery.mark` / `emailDelivery.clear` admin mutations.
- *
- * Gated behind the default-off `phoenix-email-delivery-admin` flag via `FlagGate` (the
- * ban-controls stance): with it off nothing renders and no roll-up request fires, so the
- * surface ships dark until a human flips the flag (ADR 0083) — the client half of the
- * two-gate contract whose worker half fails the invisible `Denied`. The mutations are
- * account-keyed (`userId`), so a failing address with no resolved account (`userId: null`)
- * shows in the roll-up but carries no clear affordance — there is no account to target.
- *
- * Render decisions live DOM-free in `email-delivery.ts` (unit-tested); this is the thin
- * shell. a11y: a labelled region + table; the mark form is a real `<form>` with a required
- * `gerekçe`; outcomes are text in a `role="status"` live region, never color; lowercase
- * Turkish copy per the design law.
+ * The `FlagGate` is load-bearing, not cosmetic: with the default-off flag off, nothing renders
+ * and no roll-up request fires, so this surface ships dark until a human flips it (ADR 0083).
+ * It is the client half of a two-gate contract — the worker half fails the invisible `Denied`.
  */
 import {Suspense, useState} from "react";
 import {useFateClient, useListView, useRequest, useView, type ViewRef, view} from "react-fate";
@@ -94,7 +81,6 @@ function EmailDeliveryAdmin() {
 	);
 }
 
-/** The manual mark form — target a user by id + a required reason (mirrors the ban form). */
 function MarkForm({
 	onResult,
 }: {

--- a/apps/web/src/admin/email-delivery/email-delivery-module.test.ts
+++ b/apps/web/src/admin/email-delivery/email-delivery-module.test.ts
@@ -1,10 +1,3 @@
-/**
- * The email-delivery module registers into the admin-console shell (#2732, epic #2687):
- * importing the app-wide composition self-registers the `e-posta-teslimati` module as a nav
- * entry with a Turkish label, and the shell's pure `selectActiveModule` resolves it —
- * asserted DOM-free (the panel chunk is `React.lazy`, never evaluated here). Mirrors
- * `flags-module.test.ts`; proves the console module contract (#2740) for this tenant.
- */
 import {describe, expect, it} from "vitest";
 import {consoleRegistry} from "../app-modules";
 import {selectActiveModule} from "../module-registry";

--- a/apps/web/src/admin/email-delivery/email-delivery.test.ts
+++ b/apps/web/src/admin/email-delivery/email-delivery.test.ts
@@ -1,7 +1,3 @@
-/**
- * `email-delivery` pure-logic coverage (#2732) — the roll-up cell labels + the mark/clear
- * outcome-message mapping, DOM-free (the `ban-controls.ts` idiom).
- */
 import {describe, expect, it} from "vitest";
 import {
 	emailDeliveryOutcomeMessage,

--- a/apps/web/src/admin/email-delivery/email-delivery.ts
+++ b/apps/web/src/admin/email-delivery/email-delivery.ts
@@ -1,21 +1,12 @@
-/**
- * DOM-free render logic for the email-delivery admin module (#2732, email-bounce epic
- * #2687) — the roll-up row labels + the mark/clear outcome-message mapping, pure so they
- * are unit-testable without a DOM (the `ban-controls.ts` idiom). `EmailDeliveryPanel.tsx`
- * is the thin shell.
- */
 import type {FateWireCode} from "../../lib/fateWireCodes";
 
-/** The resolved-account cell — the user id, or the "no account row" note when unresolved. */
 export const resolvedUserLabel = (userId: string | null): string => userId ?? "hesap yok";
 
-/** The active-reason cell, falling back to the not-stated note (mirrors `banStatusLabel`). */
 export const reasonLabel = (reason: string | null): string => reason ?? "belirtilmemiş";
 
-/** The since cell — epoch-millis rendered as a local date/time (text, never color). */
+/** `since` is epoch millis. */
 export const sinceLabel = (since: number): string => new Date(since).toLocaleString("tr-TR");
 
-/** Turkish feedback for a mark/clear mutation outcome, keyed on the wire code. */
 export const emailDeliveryOutcomeMessage = (
 	action: "mark" | "clear",
 	code: FateWireCode | null,

--- a/apps/web/src/admin/flags/FlagsPanel.tsx
+++ b/apps/web/src/admin/flags/FlagsPanel.tsx
@@ -1,19 +1,3 @@
-/**
- * `FlagsPanel` — the flags console module (#2742, epic #2711), the first real tenant of the
- * admin-console shell (#2740). Its ONLY job is to write the `phoenix_flag_overrides` cookie
- * client-side: it lists every declared flag (`src/flags/keys.ts`) with its default + current local
- * override, and a per-flag aç/kapat/temizle toggle writes the cookie via `document.cookie`.
- *
- * No worker route, no `/api` call, no fate mutation, no `useFlag` shim — the panel only writes the
- * cookie; the worker's un-gated #622 read-wrapper (#2741) honors it so `useFlag` reflects the flip
- * natively on the next read. The effect is per-browser only. Render decisions live DOM-free in
- * `flag-overrides.ts` (unit-tested); this is the thin shell. Lowercase-Turkish copy per the design law.
- *
- * a11y: a labelled region; each flag is a `role="group"`; the toggles are shared `Button`s — the
- * 36px hit-area floor + focus ring come from the shared `.kp-btn` styles (`min-height`/`min-width:
- * var(--tap-min)`, #3791), with `aria-pressed` marking the active state; the outcome is text in a
- * `role="status"` live region, never color.
- */
 import {useState} from "react";
 import {Alert} from "../../components/ui/Alert";
 import {Button} from "../../components/ui/Button";
@@ -36,7 +20,6 @@ import {
 
 const TOGGLE_STATES: readonly OverrideState[] = ["on", "off", "clear"];
 
-/** Read the current override map straight off `document.cookie` (SSR-safe: no document ⇒ empty). */
 function readOverrides(): FlagOverrides {
 	if (typeof document === "undefined") return {};
 	return parseOverridesFromCookie(document.cookie);

--- a/apps/web/src/admin/flags/flag-overrides.test.ts
+++ b/apps/web/src/admin/flags/flag-overrides.test.ts
@@ -1,8 +1,3 @@
-/**
- * The flags console module codec (#2742): parse/apply/serialize the `phoenix_flag_overrides`
- * cookie and the Turkish render decisions — DOM-free, so on/off/clear cookie writes and the row
- * labels are proven without a `document` (the `ban-controls.ts` idiom).
- */
 import {describe, expect, it} from "vitest";
 import {
 	actionButtonLabel,

--- a/apps/web/src/admin/flags/flag-overrides.ts
+++ b/apps/web/src/admin/flags/flag-overrides.ts
@@ -1,44 +1,24 @@
 /**
- * DOM-free codec + render logic for the flags console module (#2742, epic #2711) — the
- * per-browser flag-override surface. Pure so every decision (parse, apply, serialize, label)
- * is unit-tested without a `document` (the `ban-controls.ts` idiom); `FlagsPanel.tsx` is the
- * thin shell that reads/writes `document.cookie`.
- *
- * The whole point (#2742): a toggle flips a flag ONLY in the admin's own browser by writing the
- * `phoenix_flag_overrides` cookie — never Flagship, never another request. The worker's un-gated
- * #622 read-wrapper (#2741) honors the cookie natively on the next request, so `useFlag` reflects
- * the flip with no client interception.
- *
- * The cookie wire shape mirrors the worker's #622 codec
- * (`worker/features/flagship/dev-override.ts`): a `phoenix_flag_overrides` cookie carrying
- * `encodeURIComponent(JSON.stringify({[key]: boolean}))`. That worker module can't be imported
- * here (it pulls the alchemy `resources.ts` into the SPA bundle), so the codec is re-stated
- * against the SAME contract — a value written here is read back by the worker's `parseOverrideCookie`
- * verbatim. Keep the two in lockstep.
+ * This is a deliberate duplicate of the worker's cookie codec
+ * (`worker/features/flagship/dev-override.ts`, #622). That module can't be imported here — it
+ * pulls the alchemy `resources.ts` into the SPA bundle — so the same wire shape is re-stated:
+ * `encodeURIComponent(JSON.stringify({[key]: boolean}))`. Keep the two in lockstep; a value
+ * written here must read back through the worker's `parseOverrideCookie` verbatim.
  */
 
-/** The cookie the override map travels in — mirrors `dev-override.ts` `FLAG_OVERRIDE_COOKIE` (#622). */
 export const FLAG_OVERRIDE_COOKIE = "phoenix_flag_overrides";
 
-/** The override map: a declared flag key forced to a local boolean value. */
 export type FlagOverrides = Readonly<Record<string, boolean>>;
 
-/** No overrides — no cookie, or a malformed one. */
 export const emptyOverrides: FlagOverrides = {};
 
-/** A flag's tri-state on the panel: forced on, forced off, or no local override (default holds). */
 export type OverrideState = "on" | "off" | "clear";
 
-/** The override an admin's toggle carries: force a key on/off, or clear it back to the default. */
 export interface OverrideAction {
 	readonly key: string;
 	readonly state: OverrideState;
 }
 
-/**
- * Apply one tri-state action to an override map: `on`/`off` set the key, `clear` removes it. Pure
- * — the returned map is what {@link encodeOverrideCookieValue} re-serializes into the cookie.
- */
 export function applyOverride(
 	overrides: FlagOverrides,
 	{key, state}: OverrideAction,
@@ -50,16 +30,11 @@ export function applyOverride(
 	return {...overrides, [key]: state === "on"};
 }
 
-/** A flag's current override tri-state: present-true ⇒ on, present-false ⇒ off, absent ⇒ clear. */
 export function overrideStateOf(overrides: FlagOverrides, key: string): OverrideState {
 	if (!(key in overrides)) return "clear";
 	return overrides[key] ? "on" : "off";
 }
 
-/**
- * The value a flag reads AS in this browser: the local override if one is set, else the declared
- * default. This is what the worker returns natively once it honors the cookie (#2741).
- */
 export function effectiveValue(
 	defaultValue: boolean,
 	overrides: FlagOverrides,
@@ -69,12 +44,7 @@ export function effectiveValue(
 	return override === undefined ? defaultValue : override;
 }
 
-/**
- * Parse the `phoenix_flag_overrides` map out of a `document.cookie` string (`a=b; c=d`) — the same
- * `name=value` shape as a `Cookie` header, so this mirrors the worker's `parseOverrideCookie`.
- * Untrusted input: an absent cookie, or anything that isn't a well-formed `{[key]: boolean}` JSON
- * object, yields `{}` — a malformed cookie degrades to "no override" rather than throwing.
- */
+/** Untrusted input: anything malformed degrades to "no override" rather than throwing. */
 export function parseOverridesFromCookie(documentCookie: string | null | undefined): FlagOverrides {
 	if (!documentCookie) return emptyOverrides;
 	const raw = readCookieValue(documentCookie, FLAG_OVERRIDE_COOKIE);
@@ -93,7 +63,6 @@ export function parseOverridesFromCookie(documentCookie: string | null | undefin
 	return out;
 }
 
-/** Pull one cookie's raw value out of a `name=value; name2=value2` string. */
 function readCookieValue(documentCookie: string, name: string): string | undefined {
 	for (const part of documentCookie.split(";")) {
 		const eq = part.indexOf("=");
@@ -103,16 +72,14 @@ function readCookieValue(documentCookie: string, name: string): string | undefin
 	return undefined;
 }
 
-/** Serialize an override map to the cookie's URL-encoded JSON value (mirrors the worker codec). */
 export function encodeOverrideCookieValue(overrides: FlagOverrides): string {
 	return encodeURIComponent(JSON.stringify(overrides));
 }
 
 /**
- * The full `document.cookie` assignment string for an override map. `path=/` so the worker sees it
- * on every request; `SameSite=Lax` since it rides same-origin reads. An EMPTY map writes a
- * `max-age=0` deletion so clearing the last override removes the cookie entirely rather than
- * leaving a `{}` husk. NOT `Secure` — it must be writable/readable under local `alchemy dev` (http).
+ * An empty map writes a `max-age=0` deletion, so clearing the last override removes the cookie
+ * instead of leaving a `{}` husk. Deliberately NOT `Secure`: it must be readable under local
+ * `alchemy dev`, which is http.
  */
 export function serializeOverrideCookie(overrides: FlagOverrides): string {
 	const attrs = "path=/; SameSite=Lax";
@@ -123,14 +90,11 @@ export function serializeOverrideCookie(overrides: FlagOverrides): string {
 	return `${FLAG_OVERRIDE_COOKIE}=${encodeOverrideCookieValue(overrides)}; ${attrs}; max-age=31536000`;
 }
 
-/** A boolean rendered as lowercase-Turkish on/off. */
 export const booleanLabel = (value: boolean): string => (value ? "açık" : "kapalı");
 
-/** The declared-default line for a flag row. */
 export const defaultLabel = (defaultValue: boolean): string =>
 	`varsayılan: ${booleanLabel(defaultValue)}`;
 
-/** The local-override line for a flag row — the tri-state, with `clear` reading as "no override". */
 export const overrideLabel = (state: OverrideState): string => {
 	switch (state) {
 		case "on":
@@ -142,10 +106,8 @@ export const overrideLabel = (state: OverrideState): string => {
 	}
 };
 
-/** The effective-value line — what the flag reads as in this browser right now. */
 export const effectiveLabel = (value: boolean): string => `geçerli değer: ${booleanLabel(value)}`;
 
-/** Turkish confirmation after a toggle writes the cookie, keyed on the action. */
 export const overrideOutcomeMessage = ({key, state}: OverrideAction): string => {
 	switch (state) {
 		case "on":
@@ -157,7 +119,6 @@ export const overrideOutcomeMessage = ({key, state}: OverrideAction): string => 
 	}
 };
 
-/** The button label for each tri-state control. */
 export const actionButtonLabel = (state: OverrideState): string => {
 	switch (state) {
 		case "on":

--- a/apps/web/src/admin/flags/flags-module.test.ts
+++ b/apps/web/src/admin/flags/flags-module.test.ts
@@ -1,9 +1,3 @@
-/**
- * The flags module registers into the admin-console shell (#2742, epic #2711): importing the
- * app-wide composition self-registers the `bayraklar` module as a nav entry with a Turkish label,
- * and the shell's pure `selectActiveModule` resolves it — asserted DOM-free (the panel chunk is
- * `React.lazy`, never evaluated here). It proves the console module contract (#2740) end-to-end.
- */
 import {describe, expect, it} from "vitest";
 import {DECLARED_FLAGS, MEMBER_MUTE} from "../../flags/keys";
 import {consoleRegistry} from "../app-modules";

--- a/apps/web/src/admin/kullanicilar/KullanicilarPanel.gating.test.tsx
+++ b/apps/web/src/admin/kullanicilar/KullanicilarPanel.gating.test.tsx
@@ -1,23 +1,17 @@
 /**
- * Kullanıcılar role-assign gating (#3523) — the two-gate contract at the component tier:
- * the panel is behind `phoenix-user-admin`, and the per-row role affordance is behind its
- * own `phoenix-user-role-assign` dark-ship flag. Off ⇒ invisible, as a whole column (header
- * + cells), never an empty one. The read-view dark-ship (whole panel off) is proven
- * in-browser by `tests/e2e/31-kullanicilar-darkship.spec.ts`; this pins the role-column flag.
+ * This pins the role-column flag only. The whole-panel dark-ship is proven in-browser by
+ * `tests/e2e/31-kullanicilar-darkship.spec.ts`.
  */
 import {render, screen} from "@testing-library/react";
 import {afterEach, describe, expect, it, vi} from "vitest";
 import KullanicilarPanel from "./KullanicilarPanel";
 
-// Keyed flag mock — both the panel `FlagGate` (`phoenix-user-admin`) and the role column's
-// `useFlag` (`phoenix-user-role-assign`) read through this, so one map drives both gates.
+// Keyed by flag so one map drives both gates: the panel `FlagGate` and the column's `useFlag`.
 let flags: Record<string, boolean>;
 vi.mock("../../flags/useFlag", () => ({
 	useFlag: (key: string) => ({value: flags[key] ?? false, loading: false}),
 }));
 
-// Keep react-fate's real `view`; stub the read hooks to yield exactly one roster row and the
-// client so no transport is built. The row's derived `role` is what the affordance mutates.
 const ROW = {
 	id: "u-1",
 	username: "anka",

--- a/apps/web/src/admin/kullanicilar/KullanicilarPanel.tsx
+++ b/apps/web/src/admin/kullanicilar/KullanicilarPanel.tsx
@@ -1,23 +1,7 @@
 /**
- * `KullanicilarPanel` — the kullanıcılar (user-roster) admin console module (#3200), the
- * React consumer of the gated `userAdmin.list` read. It lists the paginated, searchable
- * user roster (kullanıcı adı, e-posta, rol, durum, seviye, kayıt) inside the shipped
- * `AdminConsole` shell.
- *
- * Gated behind the default-off `phoenix-user-admin` flag via `FlagGate` (the email-delivery
- * module's stance): with it off nothing renders and no roster request fires, so the surface
- * ships dark until a human flips the flag (ADR 0083) — the client half of the two-gate
- * contract whose worker half fails the invisible `Denied`.
- *
- * Per-row role affordance (#3523): the `rol işlemleri` column wires the `user.setRole`
- * mutation (#3522) behind its OWN default-off `phoenix-user-role-assign` flag, so the whole
- * column is invisible until both that flag and `phoenix-user-admin` are on. The remaining
- * per-user action (yasakla/kaldır) is a sibling child, wired later.
- *
- * Render decisions live DOM-free in `kullanicilar.ts` / `role-controls.ts` (unit-tested);
- * this is the thin shell.
- * a11y: a labelled region + table; search is a real `<form>`; every cell is text, never
- * color; lowercase Turkish copy per the design law.
+ * The `FlagGate` is load-bearing, not cosmetic: with the default-off flag off, nothing renders
+ * and no roster request fires, so this surface ships dark until a human flips it (ADR 0083).
+ * It is the client half of a two-gate contract — the worker half fails the invisible `Denied`.
  */
 import {Suspense, useState} from "react";
 import {useListView, useRequest, useView, type ViewRef, view} from "react-fate";
@@ -54,14 +38,12 @@ export default function KullanicilarPanel() {
 }
 
 function KullanicilarRoster() {
-	// The applied search is separate from the input value so a keystroke doesn't refetch the
-	// roster — only submitting the form (or clearing it) changes the request args.
+	// The applied search is separate from the draft so a keystroke doesn't refetch the roster.
 	const [draft, setDraft] = useState("");
 	const [applied, setApplied] = useState("");
-	// Bumped after a role assignment to remount RosterList, forcing a fresh network-only
-	// re-read so the row's derived `role` re-resolves through the gated view (#3523). A
-	// `RoleState` write doesn't touch the `UserAdmin` entity in the store, so the row can't
-	// self-update — the re-read is what reflects it.
+	// Bumped after a role assignment to remount RosterList and force a fresh network-only
+	// re-read. A `RoleState` write doesn't touch the `UserAdmin` entity in the store, so the
+	// row can't self-update — the re-read is what reflects it.
 	const [reloadNonce, setReloadNonce] = useState(0);
 
 	function onSubmit(event: React.FormEvent) {
@@ -107,11 +89,8 @@ function RosterList({
 	readonly search: string;
 	readonly onRoleChanged: () => void;
 }) {
-	// The role-assign column is gated on its OWN dark-ship flag (#3522), evaluated once
-	// here so the whole column — header + cells — appears or disappears as a unit: flag
-	// off ⇒ no action column at all (not an empty one), the invisible-Denied client half.
-	// The panel already sits inside the `phoenix-user-admin` FlagGate, so both flags must
-	// be on for the controls to render.
+	// Read once here so the whole column — header and cells — appears or disappears as a unit:
+	// flag off means no action column at all, not an empty one.
 	const {value: roleAssignOn} = useFlag(PHOENIX_USER_ROLE_ASSIGN, false);
 	const result = useRequest(
 		{

--- a/apps/web/src/admin/kullanicilar/RoleControls.test.tsx
+++ b/apps/web/src/admin/kullanicilar/RoleControls.test.tsx
@@ -1,16 +1,8 @@
-/**
- * `RoleControls` component contract (#3523) — the per-row role-assign affordance wires the
- * `Admin.over(platform)`-gated `user.setRole` mutation (#3522). Pins: the toggle label per
- * current role, that a click invokes `user.setRole` with the toggled role, that a success
- * re-reads the roster (`onRoleChanged`) and shows the outcome, and that the invisible
- * `Denied` (a non-admin / flag-off refusal) shows the no-authority line and re-reads nothing.
- */
 import {fireEvent, render, screen, waitFor} from "@testing-library/react";
 import {afterEach, describe, expect, it, vi} from "vitest";
 import {RoleControls} from "./RoleControls";
 
-// Keep react-fate's real `view` (used at module load for `RoleStateSelect`); stub the client
-// so no transport is built — `setRole` is the only mutation the affordance touches.
+// `importOriginal` keeps react-fate's real `view`, which `RoleStateSelect` needs at module load.
 let setRoleResult: {result?: {role: string}; error?: unknown};
 const setRoleCalls: {userId: string; role: string}[] = [];
 vi.mock("react-fate", async (importOriginal) => {

--- a/apps/web/src/admin/kullanicilar/RoleControls.tsx
+++ b/apps/web/src/admin/kullanicilar/RoleControls.tsx
@@ -1,24 +1,7 @@
 /**
- * `RoleControls` — the per-row platform-role affordance for the kullanıcılar roster
- * (#3523, split from #3203). One toggle that grants/revokes the moderatör role via the
- * `Admin.over(platform)`-gated `user.setRole` mutation (#3522), which writes the
- * `moderates` relation tuple. The server is the sole authority: a non-admin call comes
- * back the invisible `Denied` and shows the no-authority line, minting nothing.
- *
- * The panel renders this only when BOTH the roster flag `PHOENIX_USER_ADMIN` (the panel's
- * `FlagGate`) and the role-assign dark-ship flag `PHOENIX_USER_ROLE_ASSIGN` (the roster's
- * per-column `useFlag`) are on — the client half of the two-gate ship-dark contract whose
- * worker half fails the invisible `Denied` (ADR 0083).
- *
- * After a successful assignment `onRoleChanged` re-reads the roster through the gated
- * view so the row's derived `role` cell reflects the new value (the `moderates` tuple is
- * re-joined server-side; a `RoleState` write does not update the `UserAdmin` entity in the
- * client store). Render decisions are DOM-free in `role-controls.ts` (unit-tested).
- *
- * a11y: the `Button` primitive carries the focus ring + the 36px hit-area floor from the
- * shared styles (`.kp-btn` now floors `min-height`/`min-width` at `--tap-min`, #3791); the
- * outcome is a `role="status" aria-live="polite"` text region (state as words, never
- * color); copy is lowercase Turkish.
+ * The server is the sole authority here: the `user.setRole` mutation is `Admin.over(platform)`-
+ * gated, so a non-admin call comes back the invisible `Denied` and shows the no-authority line,
+ * minting nothing. The panel renders this only when both dark-ship flags are on (ADR 0083).
  */
 import {useState} from "react";
 import {useFateClient, view} from "react-fate";

--- a/apps/web/src/admin/kullanicilar/kullanicilar-module.test.ts
+++ b/apps/web/src/admin/kullanicilar/kullanicilar-module.test.ts
@@ -1,10 +1,3 @@
-/**
- * The kullanıcılar module registers into the admin-console shell (#3200): importing the
- * app-wide composition self-registers the `kullanicilar` module as a nav entry with a
- * Turkish label, and the shell's pure `selectActiveModule` resolves it — asserted DOM-free
- * (the panel chunk is `React.lazy`, never evaluated here). Mirrors
- * `email-delivery-module.test.ts`; proves the console module contract (#2740) for this tenant.
- */
 import {describe, expect, it} from "vitest";
 import {consoleRegistry} from "../app-modules";
 import {selectActiveModule} from "../module-registry";

--- a/apps/web/src/admin/kullanicilar/kullanicilar.test.ts
+++ b/apps/web/src/admin/kullanicilar/kullanicilar.test.ts
@@ -1,7 +1,3 @@
-/**
- * `kullanicilar` pure-logic coverage (#3200) — the roster cell labels, DOM-free (the
- * `email-delivery.ts` idiom). Turkish user-facing copy; English technical wire values.
- */
 import {describe, expect, it} from "vitest";
 import {banLabel, createdAtLabel, roleLabel, usernameLabel} from "./kullanicilar";
 

--- a/apps/web/src/admin/kullanicilar/kullanicilar.ts
+++ b/apps/web/src/admin/kullanicilar/kullanicilar.ts
@@ -1,21 +1,12 @@
-/**
- * DOM-free render logic for the kullanıcılar (user-roster) admin module (#3200) — the
- * roster cell labels, pure so they are unit-testable without a DOM (the `email-delivery.ts`
- * idiom). `KullanicilarPanel.tsx` is the thin shell. Turkish user-facing copy per the
- * language rule (`.glossary/LANGUAGE.md`); the wire values stay English technical tokens.
- */
 import type {UserAdminRole} from "../../../worker/features/user-admin/views";
 
-/** The public handle cell — the username, or the not-yet-set note. */
 export const usernameLabel = (username: string | null): string => username ?? "belirlenmemiş";
 
-/** The role cell — the moderator/üye label off the relation-sourced `role` (never a column). */
 export const roleLabel = (role: UserAdminRole): string =>
 	role === "moderator" ? "moderatör" : "üye";
 
-/** The ban-state cell — text, never color (design law pillar 4). */
 export const banLabel = (banned: boolean): string => (banned ? "yasaklı" : "aktif");
 
-/** The created-at cell — epoch-millis as a local date; the 0 sentinel (no column) reads unknown. */
+/** `createdAt` is epoch millis; 0 is the no-column sentinel and reads as unknown. */
 export const createdAtLabel = (createdAt: number): string =>
 	createdAt > 0 ? new Date(createdAt).toLocaleDateString("tr-TR") : "bilinmiyor";

--- a/apps/web/src/admin/kullanicilar/role-controls.test.ts
+++ b/apps/web/src/admin/kullanicilar/role-controls.test.ts
@@ -1,8 +1,3 @@
-/**
- * `role-controls` pure-logic coverage (#3523) — the toggle target, its label, and the
- * outcome-message mapping, DOM-free (the `ban-controls.ts` idiom). Turkish user-facing
- * copy; English technical wire values.
- */
 import {describe, expect, it} from "vitest";
 import {nextRole, roleActionLabel, roleOutcomeMessage} from "./role-controls";
 

--- a/apps/web/src/admin/kullanicilar/role-controls.ts
+++ b/apps/web/src/admin/kullanicilar/role-controls.ts
@@ -1,33 +1,21 @@
 /**
- * DOM-free render logic for the kullanıcılar role-assign affordance (#3523) — the
- * grant/revoke toggle target, its label, and the outcome message, pure so they are
- * unit-testable without a DOM (the `ban-controls.ts` idiom). `RoleControls.tsx` is the
- * thin shell. Turkish user-facing copy per the language rule (`.glossary/LANGUAGE.md`);
- * the wire role values stay English technical tokens (`member` / `moderator`).
- *
- * The two platform roles are `member` / `moderator` only — the `user.setRole` mutation's
- * `SetRoleInput` (#3522) writes the `moderates` tuple, so the toggle grants or revokes the
- * moderatör role; there is no SPA-assignable `admin` role.
+ * The two platform roles are `member` / `moderator` only. `user.setRole` writes the `moderates`
+ * tuple, so this toggle grants or revokes moderatör; there is no SPA-assignable `admin` role.
  */
 import type {UserAdminRole} from "../../../worker/features/user-admin/views";
 import type {FateWireCode} from "../../lib/fateWireCodes";
 
-/** The role the toggle assigns next — grant moderatör to a üye, revoke it from a moderatör. */
 export const nextRole = (current: UserAdminRole): UserAdminRole =>
 	current === "moderator" ? "member" : "moderator";
 
-/** The toggle's Turkish label, keyed on the current role and the in-flight state. */
 export const roleActionLabel = (current: UserAdminRole, busy: boolean): string => {
 	if (current === "moderator") return busy ? "alınıyor…" : "moderatörlüğü al";
 	return busy ? "yapılıyor…" : "moderatör yap";
 };
 
 /**
- * Turkish feedback for a `user.setRole` outcome. On success (`code === null`) the
- * message is keyed on the newly-assigned role the mutation returns; on failure it is
- * keyed on the wire code — the invisible `Denied` (`UNAUTHORIZED`/`FORBIDDEN`, i.e. a
- * non-admin call OR the flag off) reads as a plain no-authority line, never leaking
- * which of the two it was.
+ * `UNAUTHORIZED` and `FORBIDDEN` deliberately share one message: a non-admin call and a
+ * flag-off call must read the same, never leaking which of the two it was.
  */
 export const roleOutcomeMessage = (
 	assigned: UserAdminRole | null,

--- a/apps/web/src/admin/module-registry.test.ts
+++ b/apps/web/src/admin/module-registry.test.ts
@@ -1,16 +1,7 @@
-/**
- * The admin-console module-registry contract (#2740, epic #2711): a module plugs in BY
- * VALUE (id + Turkish label + lazy panel), the registry composes modules in nav order and
- * rejects a duplicate id, and the pure `selectActiveModule` decides which panel renders.
- * Asserted DOM-free with fake modules — the pure-extraction idiom (`apps/web/src` has no
- * jsdom in this tier); the shell's React wiring reduces to these decisions.
- */
 import {lazy} from "react";
 import {describe, expect, it} from "vitest";
 import {type ConsoleModule, createConsoleRegistry, selectActiveModule} from "./module-registry";
 
-// A fake module: a real (never-rendered) lazy panel + a value id/label — enough to exercise
-// register/list/select without a DOM.
 function fakeModule(id: string, label = id): ConsoleModule {
 	return {id, label, panel: lazy(async () => ({default: () => null}))};
 }

--- a/apps/web/src/admin/module-registry.ts
+++ b/apps/web/src/admin/module-registry.ts
@@ -1,37 +1,18 @@
-/**
- * The admin-console module registry (#2740, epic #2711) — the typed seam a console
- * module plugs into BY VALUE, modeled on the worker-side `fateModule` registry (features
- * compose into one merged host as values, never bespoke pages; `worker/features/fate/config.ts`).
- * A `ConsoleModule` is a plain value — a stable id, a Turkish nav label, and a lazily
- * rendered panel — so the shell can render the nav (id + label) without ever importing a
- * module's panel chunk until it's selected.
- *
- * The registry is a factory (`createConsoleRegistry`), so a test composes a fresh
- * registry with a fake module and asserts register/render in isolation — no shared mutable
- * singleton to pollute. The app-wide instance (`consoleRegistry`) is the one the real
- * modules register into; the shell reads it (or any injected registry).
- */
 import type {ComponentType, LazyExoticComponent} from "react";
 
 export interface ConsoleModule {
-	/** Stable technical id — the registry key + the nav selection key. */
 	readonly id: string;
-	/** The Turkish nav label shown in the console shell. */
 	readonly label: string;
-	/** The module's panel, `React.lazy`-wrapped so its chunk loads only when selected. */
 	readonly panel: LazyExoticComponent<ComponentType>;
 }
 
 export interface ConsoleRegistry {
-	/** Compose a module into the host. Throws on a duplicate id — two modules can't own one nav key. */
 	register(module: ConsoleModule): void;
-	/** The registered modules, in registration order (nav order). */
+	/** In registration order — that order is the nav order. */
 	list(): readonly ConsoleModule[];
 }
 
 export function createConsoleRegistry(): ConsoleRegistry {
-	// A Map keyed by id: insertion-ordered (nav order) AND collision-detecting in one
-	// structure — a duplicate id is a wiring bug, not a silent last-write-wins.
 	const modules = new Map<string, ConsoleModule>();
 	return {
 		register(module) {
@@ -46,12 +27,7 @@ export function createConsoleRegistry(): ConsoleRegistry {
 	};
 }
 
-/**
- * Resolve the active module from the registry's list + the selected id — the pure render
- * decision the shell delegates to, so "which panel shows" is unit-testable without a DOM.
- * Falls back to the first module when nothing is selected or the selection is unknown
- * (a stale/absent nav key never blanks the console). `null` only when the host is empty.
- */
+/** Falls back to the first module so a stale or absent nav key never blanks the console. */
 export function selectActiveModule(
 	modules: readonly ConsoleModule[],
 	selectedId: string | null,
@@ -59,5 +35,4 @@ export function selectActiveModule(
 	return modules.find((m) => m.id === selectedId) ?? modules[0] ?? null;
 }
 
-/** The app-wide registry the real console modules register into (see `app-modules.ts`). */
 export const consoleRegistry = createConsoleRegistry();

--- a/apps/web/src/admin/useAdminProbe.ts
+++ b/apps/web/src/admin/useAdminProbe.ts
@@ -1,19 +1,10 @@
 /**
- * `useAdminProbe` — the server-authoritative answer to "may THIS user open the admin
- * console?" (#2740, epic #2711), the client signal that decides whether to mount+fetch
- * the lazy console bundle. Modeled on `useDivanAccess`: it probes the `requireAdmin`-gated
- * `admin.probe` read and reports whether it resolved (granted) or denied (the invisible
- * `Denied`), so a non-admin is indistinguishable from not-signed-in and the console chunk
- * is only ever imported in the granted branch.
+ * Fail-closed by construction: it probes only for a signed-in viewer, and any error — the
+ * `Denied` denial or a transport failure — reports not-granted. The grant is the server's
+ * `requireAdmin` verdict and nothing else; this hook cannot widen it.
  *
- * Imperative (`useImperativeView`, not a suspending read), for the same reason as
- * `useMe`/`useDivanAccess`: the probe drives a route element that must resolve to a safe
- * default rather than suspend.
- *
- * Fail-closed by construction: it only probes for a signed-in viewer (an anonymous visitor
- * never hits the wire), and any error — the `Denied` denial, or a transport failure —
- * reports not-granted. The grant is the SERVER's `requireAdmin` verdict and nothing else;
- * this hook cannot widen it.
+ * Imperative (`useImperativeView`, not a suspending read) like `useMe`/`useDivanAccess`: the
+ * probe drives a route element that must resolve to a safe default rather than suspend.
  */
 
 import {view} from "react-fate";
@@ -24,9 +15,7 @@ import {useImperativeView} from "../fate/useImperativeView";
 const AdminProbeView = view<AdminProbe>()({id: true, admin: true});
 
 export interface AdminAccess {
-	/** `true` iff the server probe resolved — the mount-the-console gate. */
 	readonly granted: boolean;
-	/** `true` while the probe is in flight (access not yet decided) — render nothing, don't 404-flash. */
 	readonly loading: boolean;
 }
 

--- a/apps/web/src/auth/client.ts
+++ b/apps/web/src/auth/client.ts
@@ -13,20 +13,9 @@ import type {} from "zod/v4/core";
 const TOKEN_KEY = "phoenix.bearer_token";
 
 export const authClient = createAuthClient({
-	// Type the server-managed `username` additional field (worker
-	// `better-auth-live.ts` `additionalUserFields`, `input:false`, returned on the
-	// session user) onto the client session `user`, so a read of the settled owner
-	// identity can use `session.data.user.username` directly instead of paying a
-	// second canonical-`me` round-trip to learn it (#2188). The plugin is type-only
-	// (its factory returns no endpoints/hooks — no runtime behavior); the schema form
-	// keeps the worker auth instance out of the SPA bundle. `username` is immutable
-	// once set, so this session value equals `me.username` — see `useMe` for the one
-	// transient (right after a `setUsername` write) where the canonical row still wins.
-	// `apiKeyClient` surfaces the minimal documented mint path for a logged-in human to
-	// obtain a durable agent credential (ADR 0044 Decision 3, #108): a session can mint +
-	// copy a key with `await authClient.apiKey.create({name})`, reading the one-time
-	// plaintext off `res.data.key` to hand to an agent (which then sends it as the
-	// `x-api-key` header). The full `kampus auth` PAT UX is the separate CLI epic (#113).
+	// `inferAdditionalFields` is type-only here (its factory returns no endpoints or
+	// hooks): it types the server-managed `username` onto the session user without
+	// pulling the worker auth instance into the SPA bundle (#2188).
 	plugins: [
 		inferAdditionalFields({user: {username: {type: "string", required: false}}}),
 		apiKeyClient(),

--- a/apps/web/src/auth/useMe.ts
+++ b/apps/web/src/auth/useMe.ts
@@ -1,21 +1,9 @@
 /**
- * Reads the canonical `me` row over `/fate` and refetches when the session
- * updates. Reads the worker's own row (not the better-auth session) because the
- * `username` additional field doesn't reliably round-trip through Better Auth's
- * session inference right after a setUsername write.
- *
- * Imperative (`request` + `readView` via `useImperativeView`), not the suspending
+ * Reads the canonical `me` row over `/fate`. Imperative, not the suspending
  * `useRequest`: this runs in the `Layout` shell above any `<Screen>` Suspense
  * boundary, and must NOT query while unauthenticated — fate's `me` throws
  * `UNAUTHORIZED` for anonymous viewers, so the `enabled: !!session.data` gate
  * keeps them off the wire.
- *
- * Returns a discriminated `idle | loading | ok | error` `status` so a failed
- * fetch is distinguishable from a signed-out / not-yet-loaded `me` — both are
- * `null`, but only one is an error (#448). `loading` is retained as a derived
- * convenience for existing consumers, and `me` persists across a `loading`
- * refetch (cleared only on signed-out/error) so a session-update re-read doesn't
- * flash the header to a logged-out state.
  */
 import {useRef} from "react";
 import {view} from "react-fate";
@@ -25,14 +13,7 @@ import {readBootUser} from "../flags/boot";
 import type {BootUser} from "../flags/shell-keys";
 import {useSession} from "./client";
 
-/**
- * The `me` shape — the client identity, single-sourced as {@link BootUser} (the wire `User`
- * minus fate's `__typename`, ADR 0185) so the async `me` read and the synchronous `__BOOT__.user`
- * seed carry the EXACT same fields. `tier` and `isModerator` are trusted account-level signals
- * read server-side (the stored column via `Kunye.tierOf` / the `moderates` relation), never
- * inferred from the session. `emailFailing` is the SELF failing-delivery signal (#2693) the
- * membrane notice reads via the `emailFailing?` seam — a non-self read is treated as deliverable.
- */
+/** Single-sourced as {@link BootUser} so the async read and the `__BOOT__.user` seed match — see ADR 0185. */
 export type MeUser = BootUser;
 
 export type MeStatus = "idle" | "loading" | "ok" | "error";
@@ -57,17 +38,12 @@ export function useMe(): {
 	const session = useSession();
 	const {state, refetch} = useImperativeView("me", MeView, {
 		enabled: !!session.data,
-		// Refetch on every session identity change (e.g. after a setUsername write),
-		// not just on a signed-in/out flip.
 		deps: [session.data],
 	});
 
-	// Seed first paint from the edge-resolved `__BOOT__.user` (ADR 0185): the identity renders
-	// synchronously so the signed-in surfaces never swap in content while the async `me` read
-	// settles. The fate read reconciles on session change; absent `__BOOT__` ⇒ null ⇒ today's
-	// async-only behavior. `me` persists across a `loading` refetch and while the session is still
-	// settling (so the seed survives first paint), cleared only on a read error OR a definitively
-	// signed-out session — never a flash to null.
+	// Seed first paint from `__BOOT__.user` (ADR 0185). `me` is cleared only on a read error or a
+	// definitively signed-out session — it must survive a `loading` refetch, or the header flashes
+	// logged-out mid-session.
 	const meRef = useRef<MeUser | null>(readBootUser());
 	if (state.status === "ok") {
 		meRef.current = state.data;

--- a/apps/web/src/components/Icon.tsx
+++ b/apps/web/src/components/Icon.tsx
@@ -1,18 +1,12 @@
 import type {LucideIcon} from "lucide-react";
 import "./icon.css";
 
-// See ADR 0166 — the one canonical icon idiom. This wrapper pins every functional
-// icon to the ruled delivery so call-sites can't drift: drawn Lucide glyphs on the
-// ruled size scale, Lucide's native per-size optical stroke (never a pinned
-// absoluteStrokeWidth), and monochrome stroke:currentColor driven by role tokens
-// only (icon.css). Pass `label` for a meaningful icon; omit it for a decorative one.
+// See ADR 0166 — the one canonical icon idiom. Deliberately no `absoluteStrokeWidth`:
+// Lucide's native per-size optical stroke is the ruled delivery.
 
 /**
- * 12 and 14 are the dense tier ADR 0240 added to 0166's 16/20/24, and they are legal ONLY
- * beside a text label that already carries the meaning — the topbar's 24px-tall search box,
- * an --t-meta back link. An icon that is the only thing saying what it means, and any
- * icon-only control, stays at >= 16 where the stroke is unambiguous on a dark ground.
- * This union is the enforcement point: a size off the scale is a type error.
+ * See ADR 0240 — 12 and 14 are legal only beside a text label that already carries the
+ * meaning; an icon-only control stays at >= 16. This union is the enforcement point.
  */
 export type IconSize = 12 | 14 | 16 | 20 | 24;
 

--- a/apps/web/src/components/VoteTriangle.tsx
+++ b/apps/web/src/components/VoteTriangle.tsx
@@ -1,12 +1,8 @@
 import {Triangle} from "lucide-react";
 import "./vote-cue.css";
 
-// See ADR 0166 §6 — the vote affordance is a DRAWN triangle (the HN / lobste.rs
-// lineage), not a Unicode △. Shape carries the redundant non-color cue (WCAG 1.4.1):
-// outline when not voted, filled when the ancestor button is aria-pressed — the toggle
-// lives in vote-cue.css so every vote site shares one cue. Stroke is currentColor, so
-// the glyph takes each button's own role-token color (accent on cast). `dir` supplies
-// the up/down symmetry §6 requires.
+// See ADR 0166 §6. The outline/filled toggle lives in vote-cue.css, keyed off the
+// ancestor button's aria-pressed — shape is the non-color cue (WCAG 1.4.1).
 export function VoteTriangle({dir = "up"}: {dir?: "up" | "down"}) {
 	return <Triangle className={`triangle triangle--${dir}`} size={16} aria-hidden="true" />;
 }

--- a/apps/web/src/components/authorship/FirstContributionOnramp.test.ts
+++ b/apps/web/src/components/authorship/FirstContributionOnramp.test.ts
@@ -1,13 +1,7 @@
 /**
- * The on-ramp's gating + copy contracts (#1210), asserted DOM-free — `apps/web/src`
- * has no jsdom, so the gate and the per-surface copy are factored out of the
- * component and tested as pure functions (the pure-extraction idiom of
- * `flagGateChild`).
- *
- * The load-bearing invariant is the gate: the on-ramp shows ONLY for a çaylak,
- * because only a çaylak's first entry is sandboxed — so the honest-framing copy is
- * truthful for a çaylak alone. A gate that showed for a yazar (whose entries publish
- * directly) would falsify the framing; these tests pin it.
+ * The on-ramp's gating + copy contracts (#1210). The load-bearing one is the gate:
+ * showing for a yazar (whose entries publish directly) would falsify the
+ * honest-framing copy.
  */
 import {describe, expect, it} from "vitest";
 import {onrampCopy, shouldShowOnramp} from "./FirstContributionOnramp";

--- a/apps/web/src/components/authorship/FirstContributionOnramp.tsx
+++ b/apps/web/src/components/authorship/FirstContributionOnramp.tsx
@@ -1,52 +1,23 @@
 /**
- * `FirstContributionOnramp` — the çaylak-only nudge on a write surface (#1210,
- * epic #1202). Turns "I just joined" into "I wrote my first thing" with **honest
- * framing**: a freshly-registered çaylak's first contribution — an entry or a
- * comment (#4283) — lands in the mod-only sandbox (#1205) pending promotion to
- * yazar (#1206), so the copy says exactly that: it never promises instant
- * publication.
- *
- * The gate (see {@link shouldShowOnramp}): the trusted account tier read off
- * `useMe().me.tier` (#1297) being `çaylak`. A yazar (whose entries aren't sandboxed)
- * or a visitor is a clean no-op. The tier is read from the fate `me` view, never the
- * untrusted better-auth session field.
- *
- * It does NOT touch the surface's draft autosave (#1214) — the on-ramp only
- * frames the composer sitting right below it, so in-progress writing survives the
- * auth round-trip exactly as before. It carries no CTA: the composer it would
- * "lead" to is already rendered and interactive, so a button that merely focused
- * it was a doubled affordance (#2208) — the honest-framing header is the whole job.
- *
- * a11y: a labelled `<section>` region (`aria-labelledby` → its own heading) and a
- * real `<h2>` (not div-soup); meaning is carried by text, never color alone; copy
- * is lowercase Turkish (çaylak/yazar/karma are brand nouns); no animation —
- * reduced-motion-safe by default, and the global `prefers-reduced-motion` reset
- * (styles/global.css) neutralizes any inherited transition.
+ * `FirstContributionOnramp` — the çaylak-only nudge on a write surface (#1210).
+ * The tier comes from the fate `me` view, never the untrusted better-auth session
+ * field. It carries no CTA on purpose: the composer a button would "lead" to is
+ * already rendered right below, so the button was a doubled affordance (#2208).
  */
 import {useId} from "react";
 import type {Tier} from "../../../worker/features/kunye/standing";
 import {useMe} from "../../auth/useMe";
 import "./FirstContributionOnramp.css";
 
-/** The write surface the on-ramp sits on — selects the per-surface copy noun. */
 export type OnrampSurface = "sozluk" | "pano" | "pano-comment";
 
-/**
- * The on-ramp's gating decision, factored DOM-free so the contract — show iff the
- * viewer is a çaylak — is unit-testable without a DOM (the pure-extraction idiom of
- * `flagGateChild`). Only a çaylak's first entry is sandboxed, so the honest-framing
- * copy is truthful for a çaylak alone; a yazar/visitor read is `false`.
- */
+/** Only a çaylak's first entry is sandboxed, so the honest-framing copy is truthful for a çaylak alone. */
 export function shouldShowOnramp(tier: Tier | undefined): boolean {
 	return tier === "çaylak";
 }
 
-/**
- * Per-surface lowercase-Turkish heading; the body copy is shared, and stays true on
- * the comment surface because the worker sandboxes a çaylak's comment exactly as it
- * sandboxes an entry. Total `Record`, not a ternary chain: a surface added to the
- * union without its copy is a compile error, never another surface's noun.
- */
+// A total `Record`, not a ternary chain: a surface added to the union without its
+// copy is a compile error, never another surface's noun rendered by accident.
 const ONRAMP_HEADINGS: Record<OnrampSurface, string> = {
 	sozluk: "ilk tanımını yazmaya hazırsın",
 	pano: "ilk gönderini paylaşmaya hazırsın",
@@ -58,7 +29,6 @@ export function onrampCopy(surface: OnrampSurface): {heading: string} {
 }
 
 export interface FirstContributionOnrampProps {
-	/** The write surface — picks the copy noun. */
 	readonly surface: OnrampSurface;
 }
 

--- a/apps/web/src/components/bildirim/BildirimList.test.tsx
+++ b/apps/web/src/components/bildirim/BildirimList.test.tsx
@@ -1,17 +1,10 @@
 /**
- * Regression for #2982 (topbar popover "yüklenemedi"). The list's live-reconcile must
- * read the viewer's unread count through the seed-gated, NON-suspending `useBildirimUnread`
- * — NOT a suspending `useLiveView(channelRef)`. The suspending read's `readView` fires a
- * `byId` against the loader-less `NotificationChannel` synthetic source on any cache miss,
- * which 500s as `INTERNAL_ERROR` (#2206) and rendered the popover's generic error. These
- * pin the byId-safe wiring: the count comes from `useBildirimUnread`, and an unread bump
- * refetches the list (network-only) — the #1700 freshness behavior, preserved.
+ * Regression for #2982: the list's live-reconcile must read the unread count through the
+ * seed-gated, NON-suspending `useBildirimUnread`, not a suspending `useLiveView(channelRef)`
+ * whose `byId` 500s (#2206) and rendered the popover's generic error.
  *
- * `react-fate` and `useBildirimUnread` are mocked so this measures BildirimList's reconcile
- * wiring, not the fate cache; the loader-less-source byId-safety of `useBildirimUnread`
- * itself is pinned by its own suite (`useBildirimUnread.test.tsx`, #2206). Mocking
- * `react-fate` WITHOUT a `useLiveView` export also fails the import outright if the
- * suspending channel read is ever reintroduced here.
+ * The `react-fate` mock below deliberately omits a `useLiveView` export, so reintroducing
+ * the suspending channel read fails the import outright.
  */
 import {render} from "@testing-library/react";
 import {afterEach, describe, expect, it, vi} from "vitest";
@@ -29,10 +22,8 @@ vi.mock("./useBildirimUnread", () => ({
 }));
 
 vi.mock("react-fate", () => ({
-	// A view factory usable at module load: `view<T>()(selection)` → the selection object.
 	view: () => (selection: unknown) => selection,
 	useRequest: () => ({"bildirim.list": {}}),
-	// Empty connection → BildirimList renders its empty state (no rows, no useView needed).
 	useListView: () => [[], null],
 	useFateClient: () => ({request: requestSpy}),
 	useView: (_view: unknown, node: unknown) => node,
@@ -53,7 +44,6 @@ describe("BildirimList live-reconcile — byId-safe (#2982 / #2206)", () => {
 	it("reads the live unread count via the seed-gated useBildirimUnread (never a suspending channel read)", () => {
 		liveUnread = 2;
 		render(<BildirimList />);
-		// Enabled when signed in, keyed by the viewer's id — the byId-safe path.
 		expect(useBildirimUnread).toHaveBeenCalledWith(true, "user-1");
 	});
 
@@ -62,7 +52,7 @@ describe("BildirimList live-reconcile — byId-safe (#2982 / #2206)", () => {
 		const {rerender} = render(<BildirimList />);
 		expect(requestSpy).not.toHaveBeenCalled();
 
-		liveUnread = 3; // a recorded notification lands → count rises
+		liveUnread = 3;
 		rerender(<BildirimList />);
 
 		expect(requestSpy).toHaveBeenCalledTimes(1);

--- a/apps/web/src/components/bildirim/BildirimList.tsx
+++ b/apps/web/src/components/bildirim/BildirimList.tsx
@@ -1,12 +1,4 @@
-/**
- * `BildirimList` — the notification center's list (#1694): the `bildirim.list`
- * connection paginated via `useListView`, with per-row mark-read and a
- * mark-all-read header action. Read state folds the server `readAt` stamp with
- * this session's mark actions (`rowUnread`) — the receipt doesn't rewrite listed
- * rows, so the fold is what makes a marked row stop reading as unread without a
- * reload. A dead target (`targetUrl: null`) renders the tombstone row
- * (`bildirimTarget`), never a broken link.
- */
+/** `BildirimList` — the notification center's list (#1694), with per-row and mark-all read actions. */
 import {useEffect, useRef, useState} from "react";
 import {useFateClient, useListView, useRequest, useView, type ViewRef, view} from "react-fate";
 import {Link} from "react-router";
@@ -50,20 +42,13 @@ export function BildirimList() {
 	const fate = useFateClient();
 	const userId = useSession().data?.user?.id ?? null;
 
-	// Live-reconcile the center over `/fate/live` (#1700): when a recorded notification
-	// bumps the viewer's live unread count, refetch the list once (network-only) so the
-	// new row surfaces without a nav or refresh. `bildirim.list` has no per-node live
-	// topic; the per-recipient count is the coarse signal that a re-read is due.
+	// `bildirim.list` has no per-node live topic, so the per-recipient unread count is the
+	// coarse signal that a re-read is due (#1700).
 	//
-	// The count comes from `useBildirimUnread` — the same seed-gated, NON-suspending live
-	// read the shell badge uses — NOT a `useLiveView(channelRef)`. `NotificationChannel` is
-	// a loader-less `Fate.syntheticSource`, so the suspending read's `readView` fires a
-	// `byId` on any cache miss, which 500s through fate's capability-less arm as an
-	// `INTERNAL_ERROR` (#2206). That surfaced as the popover's generic "yüklenemedi": the
-	// popover mounts this list from the shell where the co-bundled hydration isn't a hard
-	// guarantee, so the suspending read hit the `byId`. `useBildirimUnread` never issues a
-	// `byId` (it reads only once its own query seed has hydrated the cache), so the live
-	// count is byId-safe in every mount context (#2982).
+	// The count must come from the seed-gated, NON-suspending `useBildirimUnread`, never a
+	// `useLiveView(channelRef)`: the suspending read's `readView` fires a `byId` against the
+	// loader-less `NotificationChannel` source on a cache miss, which 500s (#2206) and
+	// surfaced as the popover's generic "yüklenemedi" (#2982).
 	const liveUnread = useBildirimUnread(userId != null, userId);
 	const lastUnread = useRef<number | null>(null);
 	useEffect(() => {
@@ -74,8 +59,6 @@ export function BildirimList() {
 		lastUnread.current = liveUnread;
 	}, [liveUnread, userId, fate]);
 
-	// This session's mark state — the receipt confirms the write but doesn't
-	// rewrite the listed rows, so rows fold these into their unread reading.
 	const [markedIds, setMarkedIds] = useState<ReadonlySet<string>>(new Set());
 	const [allMarked, setAllMarked] = useState(false);
 	const [markAllBusy, setMarkAllBusy] = useState(false);

--- a/apps/web/src/components/bildirim/BildirimPopover.test.tsx
+++ b/apps/web/src/components/bildirim/BildirimPopover.test.tsx
@@ -1,10 +1,6 @@
 /**
- * BildirimPopover (#2787) — the interactive status-zone bell. These pin the
- * popover SHELL: the trigger opens on click, the popover renders the reused list
- * body + a "tümünü gör → /bildirimler" footer, Escape closes it, and the unread
- * count is the trigger's accessible name (+ a live region). `BildirimList` is
- * stubbed — its fate-backed data path is covered by its own suite; this measures
- * the disclosure behavior, not the list internals.
+ * The popover SHELL (#2787), with `BildirimList` stubbed — its fate-backed data path is
+ * covered by its own suite.
  */
 import {fireEvent, render, screen, waitFor} from "@testing-library/react";
 import {MemoryRouter} from "react-router";
@@ -32,10 +28,8 @@ describe("BildirimPopover (#2787)", () => {
 		expect(trigger.getAttribute("aria-label")).toBe("3 okunmamış bildirim");
 		expect(trigger.getAttribute("aria-haspopup")).toBe("dialog");
 		expect(trigger.getAttribute("aria-expanded")).toBe("false");
-		// The bell glyph + count are both present; the count is not the accessible name.
 		expect(trigger.querySelector("svg")).not.toBeNull();
 		expect(trigger.textContent).toContain("3");
-		// The live region preserves the #2613 unread announcement now the trigger is a button.
 		expect(screen.getByRole("status").textContent).toBe("3 okunmamış bildirim");
 	});
 
@@ -45,7 +39,6 @@ describe("BildirimPopover (#2787)", () => {
 		fireEvent.click(screen.getByTestId("topbar-bildirim-badge"));
 		const popover = await screen.findByTestId("topbar-bildirim-popover");
 		expect(popover).toBeTruthy();
-		// The popover reuses BildirimList (stubbed here) as its body, under a "bildirimler" title.
 		expect(screen.getByTestId("bildirim-list-stub")).toBeTruthy();
 		expect(screen.getByText("bildirimler")).toBeTruthy();
 		expect(screen.getByTestId("topbar-bildirim-badge").getAttribute("aria-expanded")).toBe("true");

--- a/apps/web/src/components/bildirim/BildirimPopover.tsx
+++ b/apps/web/src/components/bildirim/BildirimPopover.tsx
@@ -1,16 +1,9 @@
 /**
- * `BildirimPopover` — the topbar status-zone bell as an INTERACTIVE disclosure
- * (#2787). #2613 placed a display-only bell + unread count in the status/signal
- * zone; this turns it into a proper button that opens an in-place popover of
- * recent bildirimler (reusing {@link BildirimList} as the body), with a
- * "tümünü gör" footer to the full `/bildirimler` center page — which stays the
- * canonical "see all" destination, not replaced.
+ * `BildirimPopover` — the topbar status-zone bell as an interactive disclosure (#2787).
  *
- * a11y: the trigger keeps the unread count as its accessible NAME (#2613 / ADR
- * 0166), and a polite visually-hidden live region preserves the announcement the
- * old `role="status"` bell gave — a button can't also be a live region, so the
- * two roles split. Manti Popover supplies the rest (aria-haspopup/expanded on
- * the trigger, Escape-to-close, focus trap + restore).
+ * A button can't also be a live region, so the two roles split: the trigger keeps the
+ * unread count as its accessible name, and the separate visually-hidden `role="status"`
+ * span preserves the announcement the old display-only bell gave (#2613).
  */
 import {Bell} from "lucide-react";
 import {useState} from "react";
@@ -33,8 +26,6 @@ export function BildirimPopover({to, unread}: {to: string; unread: number}) {
 
 	return (
 		<>
-			{/* The live-unread announcement #2613's status bell carried — preserved as a
-			    polite region since the interactive trigger below is a button, not a status. */}
 			<span role="status" className="kp-visually-hidden">
 				{label}
 			</span>

--- a/apps/web/src/components/bildirim/bildirim.test.ts
+++ b/apps/web/src/components/bildirim/bildirim.test.ts
@@ -1,9 +1,3 @@
-/**
- * The bildirim render decisions (#1694) asserted without a DOM — the ACs the
- * badge + center rows answer to: badge only when unread > 0; a dead target is a
- * tombstone, never a broken link; a row marked read this session stops reading
- * as unread.
- */
 import {describe, expect, it} from "vitest";
 import {
 	bildirimCopy,

--- a/apps/web/src/components/bildirim/bildirim.ts
+++ b/apps/web/src/components/bildirim/bildirim.ts
@@ -1,50 +1,26 @@
-/**
- * The bildirim surface's render decisions (#1694), factored DOM-free so they are
- * unit-testable without a DOM/React runtime — the pure-extraction idiom of
- * `funnelGating` / `savedReconcile` (`apps/web/src` has no jsdom). These are the
- * ACs the badge + center page live or die on: badge only when unread > 0, a
- * dead target renders a tombstone (never a broken link), and a marked-read row
- * stops counting as unread without a reload.
- */
+/** The bildirim surface's render decisions (#1694), factored out so they test without a DOM. */
 import type {NotificationKind} from "../../../worker/features/bildirim/kind";
 
-/**
- * Show the `/bildirimler` page content iff the bildirim flag is on. Off (and
- * every flag failure mode — loading/error/undeclared resolve to `false`
- * upstream) renders the 404, so with the flag off the route is effectively
- * absent (the dark ship, ADR 0083).
- */
+/** Flag off (and every flag failure mode) renders the 404 — the dark ship, ADR 0083. */
 export function shouldRenderBildirimPage(flagOn: boolean): boolean {
 	return flagOn;
 }
 
-/** The badge renders ONLY when there is something unread — never a `0` chip. */
 export function showUnreadBadge(unread: number): boolean {
 	return unread > 0;
 }
 
-/** The badge stays quiet at scale: `99+` past two digits. */
 export function formatUnreadBadge(unread: number): string {
 	return unread > 99 ? "99+" : String(unread);
 }
 
 export type BildirimTarget = {kind: "link"; href: string} | {kind: "tombstone"};
 
-/**
- * The row's target decision off the server-resolved `targetUrl`: a present href
- * is a working link; `null`/absent (the target no longer resolves) is the
- * tombstone — a dead row, never a broken link or a crash.
- */
 export function bildirimTarget(targetUrl: string | null | undefined): BildirimTarget {
 	return targetUrl ? {kind: "link", href: targetUrl} : {kind: "tombstone"};
 }
 
-/**
- * Is the row unread NOW, folding the server stamp with the session's local
- * mark-read state (the receipt round-trip doesn't rewrite the listed rows):
- * unread iff the server says unread AND neither this row nor "all" was marked
- * read this session.
- */
+/** The mark-read receipt doesn't rewrite the listed rows, so the session's own mark state folds in here. */
 export function rowUnread(
 	readAt: string | null | undefined,
 	markedThisSession: boolean,
@@ -53,33 +29,22 @@ export function rowUnread(
 	return readAt == null && !markedThisSession && !allMarkedThisSession;
 }
 
-// Kind → Turkish row copy (#1695/#1696): kinds stay wire identifiers, the
-// rendered line is product voice. `count` is the aggregate slot ("N oy"). The
-// `terfi` line carries the ceremony — the çaylak→yazar promotion is the single
-// most ceremonial moment in the rite, so it reads as a moment, not a log line.
-//
-// `satisfies Record<NotificationKind, …>` makes the map EXHAUSTIVE over the shared
-// kind union (#2016): a new emitter kind cannot ship without its copy — a missing
-// entry is a compile error, not a raw wire identifier rendered to a reader.
+// `satisfies Record<NotificationKind, …>` keeps the map exhaustive over the shared kind
+// union (#2016): a new emitter kind without its copy is a compile error, not a raw wire
+// identifier rendered to a reader.
 const KIND_COPY = {
 	"divan-vote": (count) =>
 		count > 1 ? `divandaki içeriğin ${count} oy aldı` : "divandaki içeriğin oy aldı",
 	kefil: () => "bir yazar sana kefil oldu",
 	terfi: () => "tebrikler, artık bir yazarsın!",
 	reply: (count) => (count > 1 ? `gönderine ${count} yanıt geldi` : "gönderine yanıt geldi"),
-	// The aggregated live-content vote voice (#1698): the anti-hype "N yeni oy",
-	// one rolled-up line per item — never one-per-vote, never a per-voter identity drip.
 	vote: (count) => (count > 1 ? `içeriğin ${count} yeni oy aldı` : "içeriğin 1 yeni oy aldı"),
-	// The mod-queue heartbeat (#1699): mod-facing lines, not member-facing.
 	"report-filed": (count) =>
 		count > 1 ? `${count} yeni içerik bildirildi` : "yeni bir içerik bildirildi",
 	"caylak-pending": () => "yeni bir çaylak divanda incelenmeyi bekliyor",
 } satisfies Record<NotificationKind, (count: number) => string>;
 
-/**
- * The row's Turkish copy per kind. An unknown kind (a future emitter's, read by
- * an older client) degrades to the raw kind + `×N` — never a crash or a blank row.
- */
+/** An unknown kind — a future emitter's, read by an older client — degrades to the raw kind. */
 export function bildirimCopy(kind: string, count: number): string {
 	const copy = (KIND_COPY as Record<string, (count: number) => string>)[kind];
 	if (copy) return copy(count);
@@ -93,7 +58,6 @@ const TARGET_LINK_LABELS: Record<string, string> = {
 	user: "profile git",
 };
 
-/** The target link's Turkish label per kind; an unknown kind reads generically. */
 export function targetLinkLabel(targetKind: string): string {
 	return TARGET_LINK_LABELS[targetKind] ?? "içeriğe git";
 }

--- a/apps/web/src/components/bildirim/useBildirimUnread.test.tsx
+++ b/apps/web/src/components/bildirim/useBildirimUnread.test.tsx
@@ -1,16 +1,9 @@
 /**
  * Regression pin for #2206: the topbar unread badge must NEVER issue a `byId` against
  * the loader-less `NotificationChannel` synthetic source — a `byId` there 500s through
- * fate's capability-less error arm, and this badge mounts on every authenticated page,
- * so an ungated read was 500-spam on 100% of authed pageviews.
- *
- * `client.readView` is exactly the call that fetches a `byId` on a cache miss (fate's
- * `readView` → `fetchByIdAndNormalize` when `missing.size > 0`). The fix gates the read
- * behind the `bildirim.channel` query seed, so `readView` is only ever called once the
- * channel is hydrated (a pure cache hit, no `byId`). The stub client below records every
- * `readView`, and the load-bearing assertion is that it is NOT invoked before the seed
- * resolves — pre-fix, `getSnapshot` called `readView` on the first synchronous render
- * (empty cache → `byId` → 500).
+ * fate's capability-less error arm, on every authenticated pageview. `client.readView`
+ * is the call that fetches a `byId` on a cache miss, so the load-bearing assertion below
+ * is that `readView` is not invoked before the `bildirim.channel` seed resolves.
  */
 import {act, renderHook, waitFor} from "@testing-library/react";
 import type {ReactNode} from "react";
@@ -42,8 +35,6 @@ function makeClient(unreadCount: number) {
 		data: {unreadCount},
 	};
 	const fulfilled = {status: "fulfilled" as const, value: snapshot};
-	// Unhydrated → a bare pending thenable (fate's cache-miss branch, which fires the byId);
-	// hydrated → the stable fulfilled snapshot (a pure cache hit).
 	const readView = vi.fn(() => (hydrated ? fulfilled : Promise.resolve(null)));
 	const request = vi.fn(() =>
 		seed.then(() => {
@@ -81,15 +72,10 @@ describe("useBildirimUnread — no byId against the loader-less NotificationChan
 			wrapper: wrapperFor(client),
 		});
 
-		// The seed request fired, but the reactive read did NOT — a readView on the empty
-		// cache is exactly the byId that 500s. This is the regression: pre-fix the first
-		// synchronous getSnapshot called readView before any hydration.
 		expect(request).toHaveBeenCalledWith({"bildirim.channel": {view: expect.anything()}});
 		expect(readView).not.toHaveBeenCalled();
 		expect(result.current).toBe(0);
 
-		// Resolve the seed → the cache hydrates → now the read is a pure cache hit and the
-		// badge reflects the live count. The read path still works: no regression to #1700.
 		await act(async () => {
 			resolveSeed();
 			await Promise.resolve();

--- a/apps/web/src/components/bildirim/useBildirimUnread.ts
+++ b/apps/web/src/components/bildirim/useBildirimUnread.ts
@@ -1,18 +1,10 @@
 /**
- * `useBildirimUnread` — the topbar badge's LIVE unread-count read (#1694 read,
- * #1700 live). The count lives on the per-recipient `NotificationChannel` entity
- * (keyed by the viewer's user id); recording a notification republishes that
- * entity over `/fate/live` (`Notification.publishChannel`), so the badge moves the
- * moment a notification lands — no page refresh, no nav.
+ * `useBildirimUnread` — the topbar badge's live unread-count read (#1694, #1700).
  *
  * The badge renders in the `Layout` shell ABOVE any `<Screen>` Suspense boundary,
- * so it can't call react-fate's suspending `useLiveView`. This drives the live
- * read itself, the shape of `useGlobalLivePin` + `useView`'s reactive core: seed
- * the channel ref with one imperative request, subscribe the entity live (which
- * keeps the shared SSE warm and merges every published frame into the cache), and
- * re-read the merged count reactively via `useSyncExternalStore` over the store's
- * per-entity subscription. Disabled (flag off / signed out) reports 0, so the
- * badge simply doesn't render — the safe/off path.
+ * so it can't call react-fate's suspending `useLiveView`. It drives the live read
+ * itself instead: seed the channel ref with one imperative request, subscribe the
+ * entity live, and re-read the merged count via `useSyncExternalStore`.
  */
 import {useCallback, useEffect, useState, useSyncExternalStore} from "react";
 import {useFateClient, view} from "react-fate";
@@ -61,10 +53,8 @@ export function useBildirimUnread(enabled: boolean, userId: string | null): numb
 	// (the seed's own hydrate fires before any store subscriber exists).
 	const [seeded, setSeeded] = useState(0);
 
-	// Seed the channel entity into the cache, then hold the live subscription open
-	// while the badge is enabled: it keeps the shared native SSE warm and merges
-	// each published `NotificationChannel` frame into the store, which the reactive
-	// read below picks up. Torn down when the badge disables (flag off / sign-out).
+	// Holding the subscription open keeps the shared SSE warm and merges each published
+	// `NotificationChannel` frame into the store, which the reactive read below picks up.
 	useEffect(() => {
 		if (!canRead || userId == null) return;
 		let unsubscribe: (() => void) | undefined;
@@ -89,10 +79,6 @@ export function useBildirimUnread(enabled: boolean, userId: string | null): numb
 		};
 	}, [client, canRead, userId]);
 
-	// The reactive read: subscribe the store for every entity the channel snapshot
-	// covers and re-read the merged `unreadCount` on each change — `useView`'s
-	// coverage-driven subscription, hoisted above Suspense (synchronous read; a
-	// not-yet-loaded ref reads 0).
 	const getSnapshot = useCallback(
 		() => (canRead && userId != null ? readChannel(client, userId, seeded > 0) : null),
 		[client, canRead, userId, seeded],

--- a/apps/web/src/components/divan/ActorDrawer.tsx
+++ b/apps/web/src/components/divan/ActorDrawer.tsx
@@ -1,15 +1,8 @@
 /**
- * `ActorDrawer` — the künye actor-drawer (#1852, ADR 0138), the epic-#1665 keystone: a
- * docked side-panel that renders the focused report's ACTOR — the join key across the
- * two divan modes. It surfaces the actor's künye (tier, karma, üretim counts, the two
- * trust tells `kaldırılan`/`bildirilen`, `kefil durumu`, and the "bu aktör"
- * reported-target count) off the SAME `Moderate`-gated `report.listOpen` row the triage
- * loop consumes — a MODE/enrichment, never a re-fetch.
- *
- * The `chamber` prop is which mode the drawer was entered from. In `kefil` mode the
- * moderation record is shown but NEVER auto-verdicts the rite (ADR 0138 §3,
- * `modRecordVerdicts`): it informs the human, it does not gate the vouch. All render +
- * hop decisions live DOM-free in `actor-drawer.ts` (unit-tested); this is the thin shell.
+ * `ActorDrawer` — the künye actor-drawer (#1852, ADR 0138): a docked side-panel rendering
+ * the focused report's actor off the SAME `Moderate`-gated `report.listOpen` row the triage
+ * loop consumes, never a re-fetch. The render + hop decisions live DOM-free in
+ * `actor-drawer.ts`; this is the thin shell.
  */
 import type {OpenReport} from "../../../worker/features/report/views";
 import {FlagGate} from "../../flags/FlagGate";
@@ -29,7 +22,6 @@ import {
 	uretimLabel,
 } from "./actor-drawer";
 
-/** The actor projection off the gated row — the fields the drawer renders. */
 function standingOf(data: OpenReport): ActorStanding {
 	return {
 		tier: data.authorTier,
@@ -61,7 +53,6 @@ export function ActorDrawer({
 	const kaldirilan = kaldirilanLabel(standing.priorRemovals);
 	const kefilDurumu = kefilDurumuLabel(standing.kefil);
 	const buAktor = buAktorLabel(standing.reportedTargets);
-	// The kefil chamber shows the mod record as evidence but never verdicts on it.
 	const recordVerdicts = modRecordVerdicts(chamber);
 
 	return (

--- a/apps/web/src/components/divan/CaylakDetail.tsx
+++ b/apps/web/src/components/divan/CaylakDetail.tsx
@@ -1,21 +1,9 @@
 /**
- * `CaylakDetail` — one çaylak's review surface in the divan (#1290): their
- * sandboxed backlog rendered as it appears live, each item per-item up-votable
- * (`divan.vote`, #1288) and carrying `bildir` (`report.submit`), plus the
- * reviewer's two affordances — the mod **"yazar yap"** (`user.promote`) and the
- * yazar **"kefil ol"** (`user.vouch`, via the stake-confirm {@link VouchSheet}).
- *
- * All reads are the gated `divan.backlog` DESTINATION (the `sandboxBacklogWhere`
- * read model, #1205) — the one-way glass: çaylak work is visible ONLY here, never
- * a widening of the inline `{mod, author}` filter. The backlog item view carries
- * no live score, so a per-item upvote shows its count only after the cast returns
- * a receipt; the up-vote is the affordance, the count is the confirmation.
- *
- * a11y: a labelled region per çaylak; the backlog is a real `<ul>`; each item is a
- * group with a Manti Button upvote (full keyboard path, visible focus, AA
- * contrast) whose pressed state is `aria-pressed` (not color); the "incelemede"
- * status is text, never color; copy is lowercase Turkish; mutation outcomes are
- * `role="status"` live regions.
+ * `CaylakDetail` — one çaylak's review surface in the divan (#1290). Every read is the
+ * gated `divan.backlog` destination (#1205) — the one-way glass: çaylak work is visible
+ * ONLY here, never a widening of the inline `{mod, author}` filter. The backlog item view
+ * carries no live score, so a per-item upvote shows its count only after the cast returns a
+ * receipt.
  */
 import {useState} from "react";
 import {useFateClient, useListView, useRequest, useView, type ViewRef, view} from "react-fate";
@@ -120,7 +108,6 @@ export function CaylakDetail({
 	);
 }
 
-/** The mod (yazar-yap) + yazar (kefil-ol) affordances — visibility per the gates. */
 function ReviewerActions({
 	authorId,
 	viewerTier,
@@ -208,7 +195,6 @@ function ReviewerActions({
 	);
 }
 
-/** One sandboxed backlog item: per-item upvote (`divan.vote`) + `bildir`. */
 function BacklogItemRow({node}: {readonly node: ViewRef<"DivanBacklogItem">}) {
 	const data = useView(BacklogItemView, node);
 	const fate = useFateClient();

--- a/apps/web/src/components/divan/CaylakIdentity.tsx
+++ b/apps/web/src/components/divan/CaylakIdentity.tsx
@@ -1,23 +1,10 @@
 /**
- * `CaylakIdentity` — a çaylak's handle + their **karma-on-others** in the divan
- * (#1290 AC). It is the divan-flavoured consumer of the shared moderation actor row
- * {@link ActorIdentity} (ADR 0147): the shared primitive owns the handle + `<Karma>`
- * render (the same reusable atom, #1208), and this wrapper supplies divan's own CSS
- * namespace (`kp-divan__*`), test-id prefix, and the "çaylak" fallback. The admin
- * user-list (#968) consumes the same {@link ActorIdentity} rather than forking a
- * second handle+karma tree.
- *
- * Two shapes, one renderer:
- *   - {@link CaylakIdentity} (presentational) takes the identity fields directly, so
- *     a caller that already resolved them in a BATCHED read (the roster, #1423)
- *     renders with NO per-row by-id `Profile` read — the identity rides the roster's
- *     single `useRequest` (ADR 0021's no-waterfalls contract). A gone profile arrives
- *     as null handle + 0 karma, and the shared {@link actorLabel} degrades it to the
- *     bare "çaylak" label.
- *   - {@link CaylakIdentityById} fetches one profile by id for the single-çaylak
- *     detail surface (`CaylakDetail`), where ONE by-id read is fine (1 row, not N).
- *     The read can suspend (and, for a since-deleted çaylak, fail), so that call site
- *     wraps it in its own {@link Screen} with {@link IdentityFallback}.
+ * `CaylakIdentity` — divan's wrapper over the shared moderation actor row {@link
+ * ActorIdentity} (ADR 0147), supplying divan's CSS namespace, test-id prefix and "çaylak"
+ * fallback. Two shapes: the presentational one takes the identity fields a BATCHED read
+ * already resolved, so the roster renders with no per-row by-id `Profile` read (ADR 0021's
+ * no-waterfalls contract); {@link CaylakIdentityById} fetches one profile for the
+ * single-çaylak detail, where one by-id read is fine and can suspend or fail.
  */
 import {useFateClient, useView, view} from "react-fate";
 import type {Profile} from "../../../worker/features/fate/views";
@@ -82,7 +69,6 @@ export function CaylakIdentityById({
 	);
 }
 
-/** The degraded handle shown while a çaylak's profile loads or if it is gone. */
 export function IdentityFallback() {
 	return (
 		<span className="kp-divan__identity">

--- a/apps/web/src/components/divan/DecisionFeed.tsx
+++ b/apps/web/src/components/divan/DecisionFeed.tsx
@@ -1,21 +1,8 @@
 /**
- * `DecisionFeed` — the shared team-ledger surface (#1704, ADR 0098/0138): a moderator's
- * view of recent decisions off the gated `report.listResolved` read (`Moderate`-gated
- * server-side; a non-moderator's read denies the invisible `UNAUTHORIZED`, caught by the
- * page's `<Screen>`). Each row names the decided target, the decision (kaldırıldı /
- * yoksayıldı), the **resolver** (which mod — first-class, not a footnote), and when —
- * so "what did my brother already decide" is legible across both moderators.
- *
- * A wave-removal (rows sharing a `waveId`, #1855) collapses into ONE feed entry — "N hedef ·
- * dalga" — whose `Geri getir` triggers `report.restoreWave`, restoring the batch as a unit
- * (every target back live + every report reopened). A lone removal (null `waveId`) keeps its
- * single `report.restore`. The pure grouping (`groupDecisionFeed`) is unit-tested DOM-free;
- * each row's `waveId` is lifted off its ref by a hidden `DecisionProbe` (the #1855
- * `WaveProbe` idiom), since a connection node ref exposes only its id. A restored row/wave
- * drops from the feed (it's no longer resolved).
- *
- * a11y (the divan baseline): a real `<ul>` list, decision/resolver/age as text (never
- * color), lowercase Turkish copy.
+ * `DecisionFeed` — the shared team-ledger surface (#1704, ADR 0098/0138) off the gated
+ * `report.listResolved` read. A wave-removal (rows sharing a `waveId`, #1855) collapses into
+ * ONE entry whose `Geri getir` restores the batch as a unit; a lone removal keeps its single
+ * `report.restore`. A restored row/wave drops from the feed — it is no longer resolved.
  */
 import {useCallback, useEffect, useMemo, useState} from "react";
 import {useFateClient, useListView, useRequest, useView, type ViewRef, view} from "react-fate";
@@ -51,9 +38,8 @@ const ResolvedReportRowView = view<ResolvedReport>()({
 
 const ResolvedReportConnectionView = {items: {node: ResolvedReportRowView}} as const;
 
-// The `report.restore` / `report.restoreWave` ack (ADR 0098) — the result-only
-// `ResolveReceipt`. The feed doesn't render the ack (plain round-trip); it's requested to
-// satisfy the mutation view.
+// The ack is requested only to satisfy the mutation's view param; the feed renders nothing
+// from it (plain round-trip, no optimistic UI).
 const ResolveReceiptView = view<ResolveReceipt>()({
 	id: true,
 	targetKind: true,
@@ -70,15 +56,14 @@ export function DecisionFeed() {
 	const [items] = useListView(ResolvedReportConnectionView, result["report.listResolved"]);
 	const fate = useFateClient();
 
-	// Targets restored this session drop from the feed without a re-fetch (a restore reopens
-	// the group, so it's no longer a decision) — the same MODE-over-the-read the triage loop
-	// uses for resolved ids.
+	// Targets restored this session drop from the feed without a re-fetch — a MODE over the
+	// same read.
 	const [restoredIds, setRestoredIds] = useState<ReadonlyArray<string>>([]);
 	const [busyId, setBusyId] = useState<string | null>(null);
 	const [error, setError] = useState<string | null>(null);
 
-	// A connection node ref exposes only its id; each row's `waveId` is lifted off the ref by
-	// a hidden `DecisionProbe` (the #1855 `WaveProbe` idiom) so the parent can group waves.
+	// A connection node ref exposes only its id, so each row's `waveId` is lifted off the ref
+	// by a hidden `DecisionProbe` before the parent can group waves.
 	const [waveById, setWaveById] = useState<Record<string, string | null>>({});
 	const onProbe = useCallback((id: string, waveId: string | null) => {
 		setWaveById((prev) => (prev[id] === waveId ? prev : {...prev, [id]: waveId}));
@@ -90,7 +75,6 @@ export function DecisionFeed() {
 		return map;
 	}, [items]);
 
-	// Group the live (not-yet-restored) rows into feed entries — waves collapse to one entry.
 	const liveRows = items
 		.map(({node}) => ({id: String(node.id), waveId: waveById[String(node.id)] ?? null}))
 		.filter((r) => !restoredIds.includes(r.id));
@@ -119,8 +103,6 @@ export function DecisionFeed() {
 		[fate],
 	);
 
-	// Restore a whole wave as a unit (#1855): one `report.restoreWave` reopens every report
-	// sharing the id AND brings every target back live; all members drop from the feed.
 	const restoreWave = useCallback(
 		async (waveId: string, memberIds: ReadonlyArray<string>) => {
 			setBusyId(waveId);
@@ -197,9 +179,8 @@ export function DecisionFeed() {
 	);
 }
 
-// A hidden data-loader: lifts one decision row's `waveId` off its ref to the feed, so the
-// parent can collapse a wave into one entry without pre-resolving every row (the #1855
-// `WaveProbe` idiom). Renders nothing.
+// A hidden data-loader: lifts one row's `waveId` to the feed so the parent can collapse a
+// wave without pre-resolving every row. Renders nothing.
 function DecisionProbe({
 	node,
 	onProbe,
@@ -279,9 +260,8 @@ function DecisionRow({
 	);
 }
 
-// One wave-removal (#1855) as a single feed entry: "N hedef · dalga". The shared decision +
-// resolver are read off the wave's first member (a wave stamps one uniform triad across its
-// targets), and `Geri getir` restores the whole batch as a unit (`report.restoreWave`).
+// The shared decision + resolver are read off the wave's first member — a wave stamps one
+// uniform triad across its targets.
 function WaveDecisionRow({
 	node,
 	memberCount,

--- a/apps/web/src/components/divan/DivanRoster.tsx
+++ b/apps/web/src/components/divan/DivanRoster.tsx
@@ -1,21 +1,9 @@
 /**
- * `DivanRoster` — the pending-çaylak roster (#1290), the divan's landing list.
- * Reads the gated `divan.roster` DESTINATION (the `sandboxBacklogWhere` read
- * model, #1205) — one row per çaylak with ≥1 sandboxed item, in the server's
- * **"needs your eyes"** order (most-contributed first; the resolver owns the
- * sort, this surface renders it as given). Selecting a row opens that çaylak's
- * detail.
- *
- * Each row surfaces the çaylak's handle + **karma-on-others** through
- * {@link CaylakIdentity}, fed from the identity fields the `divan.roster` view now
- * carries inline (#1423) — so the roster's SINGLE batched `useRequest` resolves every
- * row's identity, with NO per-row by-id `Profile` read and NO per-row Suspense
- * boundary (ADR 0021's no-waterfalls contract). A since-deleted profile arrives as a
- * null handle and degrades to the bare "çaylak" label, never breaking the list.
- *
- * a11y: a real list of Manti Button rows (full keyboard path + visible focus + AA
- * contrast); the selected row carries `aria-current`; the pending counts are
- * text, never color; copy is lowercase Turkish.
+ * `DivanRoster` — the pending-çaylak roster (#1290), off the gated `divan.roster`
+ * destination (#1205) in the server's "needs your eyes" order, which this surface renders as
+ * given. Each row's identity rides the roster's SINGLE batched `useRequest` (#1423) — no
+ * per-row by-id `Profile` read and no per-row Suspense boundary (ADR 0021's no-waterfalls
+ * contract); a since-deleted profile degrades to the bare "çaylak" label.
  */
 import {useListView, useRequest, useView, type ViewRef, view} from "react-fate";
 import type {DivanCaylak} from "../../../worker/features/fate/views";

--- a/apps/web/src/components/divan/DivanSubnavLayout.test.tsx
+++ b/apps/web/src/components/divan/DivanSubnavLayout.test.tsx
@@ -1,15 +1,3 @@
-/**
- * divan's persistent product Subnav zone (#2604, placement law #2587). Pins: (1) the zone is a
- * persistent layout — its `.kp-subnav` node survives a within-divan navigation (no remount); (2)
- * the routed page publishes its çaylaklar ↔ raporlar section switch UP into the zone, where it
- * renders as Subnav filters (`.kp-subnav__filter` — the #2586 taxonomy switcher treatment, never a
- * resting boxed `.kp-divan__nav-tab` pill); (3) a switch click drives the published onFilterChange;
- * (4) a non-mod page (no second section) publishes null and the zone shows the bare substrate bar;
- * (5) with NO zone ancestor (flag off) the publish hook returns null — the signal DivanWorkspace
- * uses to keep painting its own in-page nav byte-identically as today; (6) the switcher renders
- * through SubnavShell INSIDE the bar's `.kp-subnav__filters` row (ADR 0182 destinations zone),
- * never a detached sibling.
- */
 import {fireEvent, render, screen} from "@testing-library/react";
 import {useEffect, useState} from "react";
 import {Link, MemoryRouter, Route, Routes} from "react-router";
@@ -21,7 +9,6 @@ const SECTION_FILTERS = [
 	{id: "raporlar", label: "raporlar"},
 ];
 
-/** A stand-in for DivanWorkspace: publishes the section switch up exactly as the page does. */
 function FakeDivanLeaf({hasSwitch = true}: {hasSwitch?: boolean}) {
 	const setDivanSubnav = useSetDivanSubnavContent();
 	const [section, setSection] = useState("caylaklar");
@@ -67,8 +54,6 @@ describe("DivanSubnavLayout — divan product Subnav zone (#2604)", () => {
 
 	it("renders the switcher through SubnavShell INSIDE the bar's filters row, not a detached sibling (ADR 0182)", () => {
 		const {container} = renderZone();
-		// the destinations zone lives inside the shell's bar — the switcher buttons are descendants
-		// of `.kp-subnav > .kp-subnav__filters`, closing the orphaned-sibling composition class.
 		const inBar = container.querySelectorAll(".kp-subnav .kp-subnav__filters .kp-subnav__filter");
 		expect(inBar).toHaveLength(2);
 	});
@@ -76,7 +61,6 @@ describe("DivanSubnavLayout — divan product Subnav zone (#2604)", () => {
 	it("carries the switchers as taxonomy filters — one taxonomy class, no resting boxed pill (#2586/#2590)", () => {
 		const {container} = renderZone();
 		for (const el of container.querySelectorAll(".kp-subnav__filter")) {
-			// exactly the taxonomy filter class — never the resting-boxed `.kp-divan__nav-tab` pill
 			expect(el.classList.contains("kp-divan__nav-tab")).toBe(false);
 		}
 		expect(container.querySelector(".kp-divan__nav")).toBeNull();

--- a/apps/web/src/components/divan/DivanSubnavLayout.tsx
+++ b/apps/web/src/components/divan/DivanSubnavLayout.tsx
@@ -6,10 +6,8 @@ import {Button} from "../ui/Button";
 
 /**
  * The section-switcher content the routed divan page publishes UP into its persistent Subnav
- * zone (#2604): the çaylaklar ↔ raporlar switch as Subnav filters (#2586 taxonomy — the
- * conformant switcher treatment, no resting boxed chrome). Only a moderator has a second
- * section (raporlar is mod-gated), so a non-mod viewer publishes null and the zone shows the
- * bare substrate bar.
+ * zone (#2604). Only a moderator has a second section (raporlar is mod-gated), so a non-mod
+ * viewer publishes null and the zone shows the bare substrate bar.
  */
 export type DivanSubnavContent = {
 	filters: SubnavFilter[];
@@ -21,19 +19,14 @@ const SetDivanSubnavContent = createContext<((content: DivanSubnavContent | null
 	null,
 );
 
-/**
- * The routed divan page calls this to push its section switchers up to the persistent zone
- * (null when it has no switcher, or on unmount). Returns null when no zone ancestor provides it
- * — the signal DivanWorkspace uses to render its own in-page section nav instead.
- */
+// Returns null when no zone ancestor provides it — the signal DivanWorkspace uses to render
+// its own in-page section nav instead.
 export function useSetDivanSubnavContent() {
 	return useContext(SetDivanSubnavContent);
 }
 
-// The switcher buttons carry the #2586 taxonomy filter treatment themselves (`.kp-subnav__filter`
-// + aria-pressed) — SubnavShell's `destinations` zone only positions them INSIDE the bar (ADR
-// 0182), never a detached sibling row. The shell exposes no typed filters array, so the consumer
-// composes the stateful buttons here.
+// The shell exposes no typed filters array, so the consumer composes the stateful buttons
+// here; SubnavShell's `destinations` zone only positions them INSIDE the bar (ADR 0182).
 function DivanSectionSwitcher({filters, activeFilter, onFilterChange}: DivanSubnavContent) {
 	return (
 		<>
@@ -56,12 +49,10 @@ function DivanSectionSwitcher({filters, activeFilter, onFilterChange}: DivanSubn
 
 /**
  * divan's persistent product Subnav zone (placement law #2587, epic #2596) — the pathless
- * layout-route element that renders divan's Subnav once above the routed `<Outlet>`. Composes
- * through {@link SubnavShell} (ADR 0182): the section switch lands in the `destinations` zone
- * inside the bar, and divan has no promoted verb, so `primaryAction` is absent by design.
- * divan's section switch is page-local state, so the routed page publishes its switchers UP via
- * {@link useSetDivanSubnavContent} (the same publish-up shape pano uses) and this frame holds
- * the state.
+ * layout-route element rendering divan's Subnav once above the routed `<Outlet>`. divan has
+ * no promoted verb, so `primaryAction` is absent by design. The section switch is page-local
+ * state, so the routed page publishes its switchers UP via {@link useSetDivanSubnavContent}
+ * and this frame holds the state.
  */
 export function DivanSubnavLayout() {
 	const [content, setContent] = useState<DivanSubnavContent | null>(null);

--- a/apps/web/src/components/divan/Raporlar.tsx
+++ b/apps/web/src/components/divan/Raporlar.tsx
@@ -1,15 +1,8 @@
 /**
- * `Raporlar` — the moderation queue's first visible surface (#1701, ADR 0098 §5):
- * one row per open-reported target group off the gated `report.listOpen` read
- * (`Moderate`-gated server-side; a non-moderator's read denies the invisible
- * `UNAUTHORIZED`, caught by the page's `<Screen>`). Each row shows the target
- * kind, the report count (the pile-on signal), the reason when present, the
- * first-reported age, and the reported target's in-situ context (#1702): its
- * excerpt/title + author, linked to the target on its own surface. Out of scope:
- * resolve/dismiss, history (sibling slices).
- *
- * a11y (the divan baseline): a real `<ul>` list, counts and ages as text (never
- * color), lowercase Turkish copy.
+ * `Raporlar` — the moderation queue's grid surface (#1701, ADR 0098 §5): one row per
+ * open-reported target group off the gated `report.listOpen` read (`Moderate`-gated
+ * server-side, so a non-moderator's read denies the invisible `UNAUTHORIZED`, caught by the
+ * page's `<Screen>`).
  */
 import {useListView, useRequest, useView, type ViewRef, view} from "react-fate";
 import type {OpenReport} from "../../../worker/features/fate/views";

--- a/apps/web/src/components/divan/TriageLoop.tsx
+++ b/apps/web/src/components/divan/TriageLoop.tsx
@@ -1,18 +1,10 @@
 /**
  * `TriageLoop` — the moderation triage-loop hero (#1703, ADR 0138): a single-item,
- * keyboard-driven review over the SAME `Moderate`-gated `report.listOpen` read the
- * grid (`Raporlar`, #1701) consumes — a MODE, not a re-fetch. One reported target is
- * central at a time; the moderator's hands stay on the keyboard (`j/k` gez, `Y`
- * yoksay, `R` kaldır + confirm, `U` geri al, `O` göster, `Tab` oda, `Esc` çık). Each
- * target carries its reputation-in-row (author standing + the pile-on's reporter
- * diversity), the #1852 actor-drawer seam threaded now.
- *
- * Verdicts wire to the existing `report.resolve` mutation (plain round-trip, no
- * optimistic UI): `Y` dismisses in one keystroke; `R` opens a confirm because remove
- * hides content. A failed resolve surfaces an error and leaves the row actionable —
- * never a silent drop. The pure focus / verdict-key / confirm / Esc-ladder / copy
- * decisions live DOM-free in `triageLoop.ts` (unit-tested); this component is the thin
- * React shell over them.
+ * keyboard-driven review over the SAME `Moderate`-gated `report.listOpen` read the grid
+ * (`Raporlar`, #1701) consumes — a MODE, not a re-fetch. Verdicts wire to the existing
+ * `report.resolve` (plain round-trip, no optimistic UI); a failed resolve leaves the row
+ * actionable rather than dropping it. The pure decisions live DOM-free in `triage-loop.ts`;
+ * this component is the thin React shell over them.
  */
 import {useCallback, useEffect, useState} from "react";
 import {useFateClient, useListView, useRequest, useView, type ViewRef, view} from "react-fate";
@@ -87,9 +79,8 @@ const OpenReportLoopView = view<OpenReport>()({
 
 const OpenReportConnectionView = {items: {node: OpenReportLoopView}} as const;
 
-// The `report.resolve` / `report.restore` acks (ADR 0098) — a client-side selection
-// over the result-only `ResolveReceipt`. The loop doesn't render the ack (plain
-// round-trip, no optimistic UI); it's requested to satisfy the mutation's view param.
+// The ack is requested only to satisfy the mutation's view param; the loop renders nothing
+// from it (plain round-trip, no optimistic UI).
 const ResolveReceiptView = view<ResolveReceipt>()({
 	id: true,
 	targetKind: true,
@@ -99,11 +90,6 @@ const ResolveReceiptView = view<ResolveReceipt>()({
 	collapsed: true,
 });
 
-/**
- * The last decision the loop can undo (`U`): a single-target verdict, or a wave-removal
- * batch (#1855). `U` restores the batch as a unit (`report.restoreWave`) when the last
- * decision was a wave, mirroring the decision feed's wave-restore.
- */
 type LastVerdict =
 	| {
 			readonly kind: "single";
@@ -128,34 +114,23 @@ export function TriageLoop({onExit}: {readonly onExit: () => void}) {
 	const [decisionsToday, setDecisionsToday] = useState(0);
 	const [lastVerdict, setLastVerdict] = useState<LastVerdict | null>(null);
 
-	// The actor-drawer (#1852, ADR 0138): the focused item's actor, docked open by
-	// default on desktop (founder call). `chamber` is which mode it was entered from —
-	// `raporlar` here, `kefil` after a `V` hop; the hop only re-lenses the SAME actor,
-	// it never re-fetches. Desktop is a coarse pointer + wide viewport (no docked panel
-	// on a phone-sized surface).
+	// `chamber` is which mode the drawer was entered from; a hop only re-lenses the SAME actor,
+	// it never re-fetches. Desktop is a coarse pointer + wide viewport.
 	const isDesktop =
 		typeof window !== "undefined" && window.matchMedia?.("(min-width: 900px)").matches === true;
 	const [drawerOpen, setDrawerOpen] = useState(() => drawerDefaultOpen(isDesktop));
 	const [chamber, setChamber] = useState<Chamber>("raporlar");
 
-	// The resolved-target ids the loop has already acted on this session — used to
-	// present the post-collapse queue without a re-fetch (a MODE over the same read).
+	// The ids resolved this session present the post-collapse queue without a re-fetch.
 	const [resolvedIds, setResolvedIds] = useState<ReadonlyArray<string>>([]);
 	const live = items.filter(({node}) => !resolvedIds.includes(String(node.id)));
 
 	const focused = live[Math.min(index, Math.max(0, live.length - 1))] ?? null;
-	// The row's identity is its `<kind>:<id>` view id (the same key `report.resolve`
-	// takes), parsed off the ref without resolving the whole entity — the loop acts on
-	// the focused target's identity, not its rendered fields.
 	const focusedTarget = focused ? parseBacklogItemId(String(focused.node.id)) : null;
 
-	// The focused row's actor id — the join key `Shift-X` grabs a wave for (#1855). The
-	// null-tolerant `useView` subscribes to the focused ref only (the manifest's other
-	// rows load lazily behind the flag, inside `WaveManifest` when it opens).
+	// The null-tolerant `useView` subscribes to the focused ref only; the manifest's other rows
+	// load lazily inside `WaveManifest`.
 	const focusedData = useView(OpenReportLoopView, focused?.node ?? null);
-	// remove-the-wave (#1855): `Shift-X` opens the same-author batch manifest over the
-	// SAME queue read; the manifest owns the keyboard while open (the loop's own handler
-	// yields to it).
 	const [waveOpen, setWaveOpen] = useState(false);
 
 	const resolve = useCallback(
@@ -197,11 +172,8 @@ export function TriageLoop({onExit}: {readonly onExit: () => void}) {
 		setBusy(true);
 		setError(null);
 		try {
-			// Undo is the existing restore/reopen edge (ADR 0098 §3): a removed target comes
-			// back live and its reports reopen; a dismissed group reopens the same way. A
-			// wave-removal (#1855) undoes as a UNIT — `report.restoreWave` reopens the whole
-			// batch — so `U` mirrors the decision feed's wave-restore; a lone verdict is the
-			// single-target restore. Either path rehydrates the affected rows into the queue.
+			// A wave-removal (#1855) undoes as a UNIT via `report.restoreWave`; a lone verdict is the
+			// single-target restore (ADR 0098 §3).
 			if (last.kind === "wave") {
 				const {error: callError} = await fate.mutations.report.restoreWave({
 					input: {waveId: last.waveId},
@@ -234,10 +206,8 @@ export function TriageLoop({onExit}: {readonly onExit: () => void}) {
 		}
 	}, [fate, lastVerdict]);
 
-	// One target's batch resolve (#1855): the SAME single-target `report.resolve` the
-	// loop uses, fanned over the wave selection with the gesture's shared `waveId` so the
-	// batch reopens as a unit. Returns whether it landed so the batch can partition
-	// resolved from failed (no silent partial drop).
+	// Returns whether it landed, so the batch can partition resolved from failed — no silent
+	// partial drop.
 	const resolveTarget = useCallback(
 		async (input: WaveResolveInput, verdict: Verdict): Promise<boolean> => {
 			try {
@@ -258,9 +228,8 @@ export function TriageLoop({onExit}: {readonly onExit: () => void}) {
 		[fate],
 	);
 
-	// A batch collapsed these keys off the queue — mirror the single-verdict bookkeeping
-	// (drop them from the live queue, count each decision) without a re-fetch, and record the
-	// wave as the last verdict so `U` undoes the whole batch as a unit (#1855).
+	// Mirror the single-verdict bookkeeping without a re-fetch, and record the wave as the last
+	// verdict so `U` undoes the whole batch as a unit.
 	const onWaveResolved = useCallback((keys: ReadonlyArray<string>, waveId: string) => {
 		if (keys.length === 0) return;
 		setResolvedIds((prev) => [...prev, ...keys]);
@@ -268,18 +237,16 @@ export function TriageLoop({onExit}: {readonly onExit: () => void}) {
 		setLastVerdict({kind: "wave", waveId, keys});
 	}, []);
 
-	// The one keyboard listener the whole loop is driven by. The pure `keyToAction`
-	// maps the raw key; the switch runs the effect. `Tab`/`Escape` are prevented from
-	// their default so the loop owns them while it's the active surface.
+	// `Tab`/`Escape` are prevented from their default so the loop owns them while it is the
+	// active surface.
 	useEffect(() => {
 		function onKey(e: KeyboardEvent) {
 			if (busy) return;
-			// While the wave manifest is open it owns the keyboard entirely (#1855) — its
-			// own listener handles select/toggle/batch/close, so the loop stands down.
+			// While the wave manifest is open it owns the keyboard entirely; the loop stands down.
 			if (waveOpen) return;
 
-			// `Shift-X` grabs the focused target's author into the wave manifest (#1855) —
-			// only when the actor resolves (an anonymized row has no author to group).
+			// `Shift-X` grabs into the wave manifest only when the actor resolves — an anonymized
+			// row has no author to group.
 			if (pending === null) {
 				const wave = waveKeyToAction({key: e.key, code: e.code, altKey: e.altKey});
 				if (wave?.kind === "grab") {
@@ -289,10 +256,8 @@ export function TriageLoop({onExit}: {readonly onExit: () => void}) {
 				}
 			}
 
-			// The actor-drawer bindings (#1852) take precedence over the loop's own, but
-			// only outside a confirm sheet (a sheet narrows to its own keys). `A` toggles
-			// the drawer; `V`/`M` hop between the kefil and moderation chambers on the SAME
-			// actor — a re-lens, not a re-fetch.
+			// The drawer bindings take precedence over the loop's own, but only outside a confirm sheet
+			// (a sheet narrows to its own keys).
 			if (pending === null) {
 				const drawer = drawerKeyToAction(e.key);
 				if (drawer !== null) {
@@ -313,7 +278,6 @@ export function TriageLoop({onExit}: {readonly onExit: () => void}) {
 			const action = keyToAction(e.key);
 			if (action === null) return;
 
-			// A confirm sheet narrows the bindings: only the verdict's confirm/cancel.
 			if (pending !== null) {
 				if (action.kind === "escape") {
 					e.preventDefault();
@@ -340,7 +304,6 @@ export function TriageLoop({onExit}: {readonly onExit: () => void}) {
 					if (focusedTarget) void resolve(focusedTarget, "dismiss");
 					break;
 				case "remove":
-					// Asymmetric weight: remove opens the confirm sheet, never commits directly.
 					if (focusedTarget) setPending(needsConfirm("remove") ? "remove" : null);
 					break;
 				case "undo":
@@ -476,14 +439,10 @@ export function TriageLoop({onExit}: {readonly onExit: () => void}) {
 	);
 }
 
-// The remove-the-wave manifest (#1855, ADR 0138): the focused actor's open-reported
-// targets, grabbed off the SAME queue read (a MODE, never a re-fetch). It owns the
-// keyboard while open — `T` tümü, `Space` seç, `⌥R` kaldır (blast-radius confirm), `⌥Y`
-// yoksay, `j/k` gez, `Esc` çık — and fans the existing single-target `report.resolve`
-// over the selection, partitioning resolved from failed so a partial failure stays
-// actionable. Each queue row lazily resolves its actor/report projection via a
-// `WaveProbe`; the pure grouping/selection/blast-radius decisions live in
-// `remove-the-wave.ts` (unit-tested).
+// The remove-the-wave manifest (#1855, ADR 0138): the focused actor's open-reported targets
+// off the SAME queue read. It owns the keyboard while open and fans the existing
+// single-target `report.resolve` over the selection; the pure decisions live in
+// `remove-the-wave.ts`.
 function WaveManifest({
 	rows,
 	authorId,
@@ -516,10 +475,9 @@ function WaveManifest({
 
 	const manifest = buildWaveManifest(Object.values(rowsByKey), authorId);
 
-	// Selection stays "auto" (the safe-by-default auto-deselect over whatever has probed)
-	// until the mod first touches it, then it's their explicit set. This tracks
-	// incremental probe arrival correctly: a late-loading row is auto-included until a
-	// `T`/`Space` freezes the selection to the moderator's choice.
+	// Selection stays "auto" (the safe-by-default deselect over whatever has probed) until the
+	// mod first touches it, so a late-loading row is auto-included until `T`/`Space` freezes the
+	// set to their choice.
 	const [explicit, setExplicit] = useState<ReadonlyArray<string> | null>(null);
 	const selected = explicit ?? initialWaveSelection(manifest);
 
@@ -534,9 +492,8 @@ function WaveManifest({
 			if (targets.length === 0) return;
 			setBusy(true);
 			setError(null);
-			// ONE grouping id per gesture, threaded through every fanned-out resolve so the
-			// batch reopens as a unit (#1855). A target that fails to resolve simply never
-			// gets the stamp (its write didn't land), so the wave groups only the successes.
+			// ONE grouping id per gesture, threaded through every fanned resolve so the batch reopens as
+			// a unit. A target that fails never gets the stamp, so the wave groups only the successes.
 			const waveId = crypto.randomUUID();
 			const outcomes: WaveOutcome[] = [];
 			for (const input of waveResolveInputs(targets, waveId)) {
@@ -549,8 +506,7 @@ function WaveManifest({
 			setBusy(false);
 			const failLabel = waveFailureLabel(failed.length);
 			if (failLabel !== null) {
-				// No silent partial drop: keep the failed targets selected + in the manifest
-				// so they stay actionable, and name how many didn't resolve.
+				// No silent partial drop: the failed targets stay selected and in the manifest.
 				setError(failLabel);
 				setExplicit(failed);
 			} else {
@@ -590,8 +546,6 @@ function WaveManifest({
 						if (canApplyWave(selected)) void apply("dismiss");
 						break;
 					case "batchRemove":
-						// Asymmetric weight (like the single verdict): remove opens the
-						// blast-radius confirm, dismiss commits directly.
 						if (canApplyWave(selected)) setPending("remove");
 						break;
 					case "grab":
@@ -708,9 +662,8 @@ function WaveManifest({
 	);
 }
 
-// A hidden data-loader: resolves one queue row's actor/report projection off the shared
-// gated read and lifts it to the manifest, so the parent can group by author + sum the
-// blast radius without the loop pre-resolving every row.
+// A hidden data-loader: resolves one queue row's actor/report projection and lifts it to the
+// manifest, so the parent groups by author without the loop pre-resolving every row.
 function WaveProbe({
 	node,
 	onData,
@@ -731,8 +684,7 @@ function WaveProbe({
 	return null;
 }
 
-// Resolve the focused node's full `OpenReport` view (the same read the card renders off)
-// and hand its actor projection to the drawer — a MODE over the gated row, no re-fetch.
+// A MODE over the gated row — the drawer's actor projection, no re-fetch.
 function TriageActorDrawer({
 	node,
 	chamber,

--- a/apps/web/src/components/divan/VouchSheet.tsx
+++ b/apps/web/src/components/divan/VouchSheet.tsx
@@ -1,22 +1,9 @@
 /**
- * `VouchSheet` — the stake-confirm sheet for the yazar **"kefil ol"** (vouch)
- * affordance (#1290, consumes #1289). Vouching is a stake: the yazar puts their
- * own standing behind the çaylak, and one of their three concurrent vouch slots
- * is held until the çaylak is promoted or the vouch is withdrawn. So the action
- * is never one-click — it opens this sheet, which states the stake plainly and
- * confirms before calling `user.vouch`.
- *
- * The server is the sole authority: `user.vouch` is the `requireVouch` (yazar
- * floor) gate plus the concurrent-vouch cap (#1289). A non-yazar call comes back
- * `FORBIDDEN`, a 4th concurrent vouch `VOUCH_LIMIT_REACHED` — both surfaced as
- * lowercase-Turkish words via {@link vouchOutcome}.
- *
- * a11y: a real modal dialog (`Dialog`, focus-trapped + Esc-closable + labelled
- * title/description from the shared primitive), native `<Button>`s (full keyboard
- * path + visible focus + AA contrast), the outcome a `role="status"
- * aria-live="polite"` text region (state as words, never color); copy is
- * lowercase Turkish; no animation beyond the dialog primitive's own, which the
- * global reduced-motion reset neutralizes.
+ * `VouchSheet` — the stake-confirm sheet for the yazar "kefil ol" (#1290, consumes #1289).
+ * Vouching holds one of the yazar's three concurrent slots until the çaylak is promoted or
+ * the vouch is withdrawn, so the action is never one-click. The server is the sole
+ * authority: a non-yazar call comes back `FORBIDDEN`, a 4th concurrent vouch
+ * `VOUCH_LIMIT_REACHED`.
  */
 import {useState} from "react";
 import {useFateClient, view} from "react-fate";
@@ -42,7 +29,6 @@ export function VouchSheet({
 	readonly open: boolean;
 	readonly onOpenChange: (open: boolean) => void;
 	readonly candidateId: string;
-	/** Run after the vouch resolves, so the surface can react to the outcome. */
 	readonly onResolved?: (outcome: VouchOutcome) => void;
 }) {
 	const fate = useFateClient();

--- a/apps/web/src/components/divan/actor-drawer.test.ts
+++ b/apps/web/src/components/divan/actor-drawer.test.ts
@@ -1,12 +1,3 @@
-/**
- * The künye actor-drawer's interaction + copy contract (#1852, ADR 0138) — the pure
- * key-mapping / hop-target / kefil-guard / drawer-copy decisions asserted without a DOM,
- * per the `triage-loop.test.ts` precedent. The AC the keystone lives or dies on: `A`
- * toggles, `V`/`M` hop between chambers on the same actor, the mod record NEVER
- * auto-verdicts in kefil mode, and every künye field renders its Turkish label (tier,
- * karma, üretim, kaldırılan, bildirilen, kefil durumu, "bu aktör") with faithful zeros
- * and a null-safe unresolved actor.
- */
 import {describe, expect, it} from "vitest";
 import {
 	type ActorStanding,

--- a/apps/web/src/components/divan/actor-drawer.ts
+++ b/apps/web/src/components/divan/actor-drawer.ts
@@ -1,38 +1,16 @@
 /**
- * The künye actor-drawer's render + interaction decisions (#1852, ADR 0138) — the
- * epic-#1665 keystone, factored DOM-free in the `triage-loop.ts` / `raporlarGating.ts`
- * idiom so the drawer's field copy, the two chamber modes, the cross-mode hop mapping,
- * and the "mod record informs but never verdicts" guard are unit-testable without a
- * React runtime (`apps/web/src` has no jsdom).
- *
- * The drawer is the divan's actor-centric spine (ADR 0138): the actor is the JOIN key
- * across the two divan modes. `raporlar` (moderation) and `kefil` (vouch) are two
- * entries into the SAME drawer, opened on the focused item's author. It renders the
- * actor's künye — tier, karma, üretim counts (tanım/gönderi/yorum), the two trust tells
- * (`kaldırılan` = prior removals, `bildirilen` = times reported), `kefil durumu`, and
- * the "bu aktör" other-reported-target count — all already carried on the gated
- * `report.listOpen` row (a MODE over the same read, never a re-fetch).
- *
- * The seam the downstream slices consume is deliberately exposed here: `distinctReporters`
- * (the #1855 remove-the-wave numerator) and `reportedTargets` (#1855's "bu aktör" entry
- * point) ride the same actor projection the drawer renders.
+ * The künye actor-drawer's render + interaction decisions (#1852, ADR 0138), factored
+ * DOM-free because `apps/web/src` has no jsdom.
  */
 
-/** The two chambers the drawer is an entry into (ADR 0138): moderation and vouch. */
 export type Chamber = "raporlar" | "kefil";
 
-/** The keys the actor-drawer binds on top of the triage loop (ADR 0138). */
 export type DrawerAction =
 	| {readonly kind: "toggleDrawer"}
 	| {readonly kind: "hopKefil"}
 	| {readonly kind: "hopModeration"};
 
-/**
- * Map a raw key to a drawer action, or `null` for a key the drawer doesn't own (the
- * loop's own bindings then handle it). `A` toggles the drawer, `V` hops to the actor's
- * kefil rite, `M` hops to their moderation record — the founder-confirmed uppercase
- * bindings, so a lowercase key mid-typing is never a hop.
- */
+// Uppercase-only bindings: a lowercase key mid-typing must never hop.
 export function drawerKeyToAction(key: string): DrawerAction | null {
 	switch (key) {
 		case "A":
@@ -46,12 +24,6 @@ export function drawerKeyToAction(key: string): DrawerAction | null {
 	}
 }
 
-/**
- * The chamber a hop lands in (ADR 0138 — the spine made navigable): `V` from any
- * chamber reaches the actor's kefil rite; `M` reaches their moderation record. The hop
- * is absolute (it targets a chamber, not a toggle) so the same key always lands the
- * same place regardless of where the moderator hopped from.
- */
 export function hopTarget(action: DrawerAction): Chamber | null {
 	switch (action.kind) {
 		case "hopKefil":
@@ -63,47 +35,27 @@ export function hopTarget(action: DrawerAction): Chamber | null {
 	}
 }
 
-/**
- * The drawer's default open state per surface (ADR 0138 — desktop-first founder call):
- * docked open on desktop, closed on a narrow surface where a docked panel would crowd
- * the single-item loop. `A` toggles from whichever default the surface starts at.
- */
 export function drawerDefaultOpen(isDesktop: boolean): boolean {
 	return isDesktop;
 }
 
-/**
- * Whether the mod record may drive a verdict in this chamber (ADR 0138 §3, the
- * agents-deploy/humans-release boundary). In `raporlar` the record IS the thing being
- * judged; in `kefil` the record is VISIBLE evidence for a human vouching a person and
- * MUST NOT auto-decide the rite — always `false` for `kefil`. The record is shown in
- * both chambers; this guard is what keeps showing it in kefil mode from ever verdicting.
- */
+// ADR 0138 §3: in the kefil chamber the mod record informs the human and must never verdict.
 export function modRecordVerdicts(chamber: Chamber): boolean {
 	return chamber === "raporlar";
 }
 
-/** The actor's standing + footprint the drawer renders — the projection off the gated row. */
 export interface ActorStanding {
 	readonly tier: string | null;
 	readonly karma: number | null;
-	/** `kaldırılan` — how many of the actor's targets a moderator previously removed. */
 	readonly priorRemovals: number | null;
-	/** `bildirilen` — how many distinct reporters filed against the focused target. */
 	readonly distinctReporters: number;
 	readonly definitionCount: number | null;
 	readonly postCount: number | null;
 	readonly commentCount: number | null;
 	readonly kefil: boolean | null;
-	/** The "bu aktör" count — how many of the actor's targets are open-reported. */
 	readonly reportedTargets: number | null;
 }
 
-/**
- * The actor's identity line (ADR 0138): `@handle · tier · N karma`, dropping any clause
- * that can't be resolved. `null` when neither a handle nor a tier resolves (an
- * anonymized / hidden actor) so the drawer renders no fabricated identity.
- */
 export function actorIdentityLabel(handle: string | null, standing: ActorStanding): string | null {
 	const parts: string[] = [];
 	const h = handle?.trim();
@@ -113,12 +65,6 @@ export function actorIdentityLabel(handle: string | null, standing: ActorStandin
 	return parts.length > 0 ? parts.join(" · ") : null;
 }
 
-/**
- * The üretim (production) footprint line (ADR 0138): `N tanım · N gönderi · N yorum`,
- * the actor's live content record. `null` when the counts are unresolved (an
- * unresolvable actor), so the drawer shows no fabricated footprint. Zero counts render
- * faithfully (`0 tanım · 0 gönderi · 0 yorum` — a real newcomer, not absence).
- */
 export function uretimLabel(standing: ActorStanding): string | null {
 	if (
 		standing.definitionCount === null ||
@@ -130,45 +76,23 @@ export function uretimLabel(standing: ActorStanding): string | null {
 	return `${standing.definitionCount} tanım · ${standing.postCount} gönderi · ${standing.commentCount} yorum`;
 }
 
-/**
- * The `sicil` trust tell (ADR 0138): `N kaldırıldı` when the actor has prior removals,
- * else the clean `temiz` — read under the `sicil` key, so the value no longer re-states
- * the noun (the old `temiz sicil` doubled it). `null` when unresolved — the drawer then
- * renders no removal line rather than a false "temiz".
- */
 export function kaldirilanLabel(priorRemovals: number | null): string | null {
 	if (priorRemovals === null) return null;
 	if (priorRemovals <= 0) return "temiz";
 	return `${priorRemovals} kaldırıldı`;
 }
 
-/**
- * The `bildiren` trust tell (ADR 0138): `N kişi` — how many distinct reporters stand
- * behind the focused report, the pile-on's real breadth. Read under the `bildiren` key,
- * so the value is the bare count (the old `N kişi bildirdi` re-stated the verb). Clamped
- * to ≥1 for a real reported target; the diversity numerator #1855's wave slice also reads.
- */
+// Clamped to ≥1: a real reported target always has at least one reporter.
 export function bildirilenLabel(distinctReporters: number): string {
 	const n = Math.max(1, Math.floor(distinctReporters));
 	return `${n} kişi`;
 }
 
-/**
- * The `kefil durumu` line (ADR 0138): `kefilli` when the actor is actively vouched,
- * `kefilsiz` when not — the vouch tell the moderation chamber reads and the kefil
- * chamber acts on. `null` when unresolved, so no false status shows.
- */
 export function kefilDurumuLabel(kefil: boolean | null): string | null {
 	if (kefil === null) return null;
 	return kefil ? "kefilli" : "kefilsiz";
 }
 
-/**
- * The "bu aktör" line (ADR 0138): `N raporlu içerik` — the entry point #1855's
- * remove-the-wave grows from (actor-grouped selection). Read under the `bu aktör` key,
- * so the value no longer re-states "bu aktörün" (the old line doubled it). `null` when
- * unresolved. Zero/one renders the clean `başka raporlu içerik yok`.
- */
 export function buAktorLabel(reportedTargets: number | null): string | null {
 	if (reportedTargets === null) return null;
 	if (reportedTargets <= 1) return "başka raporlu içerik yok";

--- a/apps/web/src/components/divan/decisionFeedGating.test.ts
+++ b/apps/web/src/components/divan/decisionFeedGating.test.ts
@@ -1,9 +1,3 @@
-/**
- * Decision-feed render-decision units (#1704) — DOM-free, the `divanGating.test.ts`
- * idiom. The gates asserted: the decision copy maps the closed resolution set, the
- * resolver byline is first-class (handle → `@handle`, unresolved → generic "moderatör",
- * never a raw id), and only a `removed` decision is restorable.
- */
 import {describe, expect, it} from "vitest";
 import {
 	decisionLabel,

--- a/apps/web/src/components/divan/decisionFeedGating.ts
+++ b/apps/web/src/components/divan/decisionFeedGating.ts
@@ -1,22 +1,10 @@
 /**
- * The decision-feed's render decisions (#1704, the two-person team-ledger), factored
- * DOM-free in the `raporlarGating.ts` idiom so each gate is unit-testable without a
- * React runtime. The feed is a moderator-only view inside `/divan`, alongside the
- * queue (`report.listResolved` is `Moderate`-gated server-side, so a forced non-mod
- * read denies the invisible `UNAUTHORIZED`).
- *
- * The feed makes moderation legible BETWEEN two humans: who decided what, when — so the
- * decision and the resolver are first-class copy, never a footnote. A `removed` decision
- * carries the `Geri getir` (restore) disagreement affordance; a `dismissed` one is
- * terminal (nothing to bring back).
+ * The decision-feed's render decisions (#1704), factored DOM-free because `apps/web/src`
+ * has no jsdom. `report.listResolved` is `Moderate`-gated server-side, so a forced non-mod
+ * read denies the invisible `UNAUTHORIZED`.
  */
 import type {Resolution} from "../../../worker/features/report/resolution";
 
-/**
- * The decision cell's lowercase-Turkish copy: `removed` → "kaldırıldı" (content taken
- * down), `dismissed` → "yoksayıldı" (report found unfounded). A closed set, so the
- * switch is exhaustive.
- */
 export function decisionLabel(resolution: Resolution): string {
 	switch (resolution) {
 		case "removed":
@@ -26,41 +14,22 @@ export function decisionLabel(resolution: Resolution): string {
 	}
 }
 
-/**
- * The resolver byline — first-class, so the two-person ledger reads "who decided". The
- * server-resolved handle as `@handle` when present; a generic "moderatör" when the
- * identity couldn't be resolved (never the raw account id — a UUID isn't legible copy).
- */
+// Never the raw account id — a UUID is not legible copy.
 export function resolverLabel(handle: string | null): string {
 	const trimmed = handle?.trim();
 	return trimmed ? `@${trimmed}` : "moderatör";
 }
 
-/**
- * Only a `removed` decision is restorable — restore brings content back live and
- * reopens its reports (`report.restore`). A `dismissed` decision took no action, so
- * there is nothing to bring back and the affordance is absent.
- */
+// Only a removal took an action; a dismissal has nothing to bring back.
 export function isRestorable(resolution: Resolution): boolean {
 	return resolution === "removed";
 }
 
-/**
- * One decision-feed entry: either a single decided target, or a wave-removal (rows sharing
- * a `waveId`, #1855) collapsed into ONE entry. The feed renders a wave as one row whose
- * restore reopens the whole batch (`report.restoreWave`); a lone removal keeps its single
- * "geri getir".
- */
 export type DecisionFeedEntry =
 	| {readonly kind: "single"; readonly id: string}
 	| {readonly kind: "wave"; readonly waveId: string; readonly memberIds: ReadonlyArray<string>};
 
-/**
- * Group the newest-first decision rows into feed entries: a row with a null `waveId` is its
- * own single entry; rows sharing a non-null `waveId` collapse into one wave entry, anchored
- * at the wave's first (newest) occurrence with its members in feed order. Every other row's
- * position is preserved — a wave simply takes the slot of its earliest-seen member.
- */
+// A wave takes the slot of its earliest-seen member; every other row keeps its position.
 export function groupDecisionFeed(
 	rows: ReadonlyArray<{readonly id: string; readonly waveId: string | null}>,
 ): ReadonlyArray<DecisionFeedEntry> {
@@ -85,7 +54,6 @@ export function groupDecisionFeed(
 	return entries;
 }
 
-/** A wave entry's byline: "N hedef · dalga" — one feed row standing in for the batch. */
 export function waveEntryLabel(memberCount: number): string {
 	return `${memberCount} hedef · dalga`;
 }

--- a/apps/web/src/components/divan/divanGating.test.ts
+++ b/apps/web/src/components/divan/divanGating.test.ts
@@ -1,10 +1,3 @@
-/**
- * The divan surface's gating contract (#1290, epic #1202) — the pure render
- * decisions asserted without a DOM (the pure-extraction idiom of `flagGateChild`
- * / `shouldShowOnramp`; `apps/web/src` has no jsdom/testing-library). These are
- * the AC the surface lives or dies on: çaylak/visitor ⇒ no topbar entry; vouch
- * disabled until the detail is opened.
- */
 import {describe, expect, it} from "vitest";
 import {
 	canVouch,

--- a/apps/web/src/components/divan/divanGating.ts
+++ b/apps/web/src/components/divan/divanGating.ts
@@ -1,44 +1,17 @@
 /**
- * The divan surface's render decisions, factored DOM-free so each gate is
- * unit-testable without a DOM/React runtime — the pure-extraction idiom of
- * `flagGateChild` / `shouldShowOnramp` (`apps/web/src` has no jsdom). The divan
- * (#1290, epic #1202) is the yazar/mod proving ground.
- *
- * The role model the gates encode (mirroring the backend `requireDivanAccess`
- * disjunction, divan/gate.ts): the divan is reached by yazar OR mod. The frontend's
- * trusted signals are `useMe().me` — both `tier` and the server-authoritative
- * `isModerator` (#1320, read off the `moderates` relation tuple) — plus the server's
- * own access verdict (the gated `divan.roster` read either resolves or denies with
- * the invisible `UNAUTHORIZED`). So:
- *
- *   - **Access** (topbar entry + page) is server-authoritative: the
- *     `useDivanAccess` probe asks the gated read whether THIS user stands, which
- *     answers the yazar-OR-mod question without a client authority guess.
- *   - **vouch** ("kefil ol") is the yazar power (`requireVouch` = yazar floor), so
- *     it gates on the trusted `tier === "yazar"`.
- *   - **promote** ("yazar yap") is the mod power (`user.promote` is `Moderate`-gated),
- *     so it gates on the trusted `isModerator` signal — NOT on `tier`. Keying off
- *     `tier` ("non-yazar present must be a mod") wrongly hid promote from a dual-role
- *     yazar+moderator, who reads `tier: "yazar"` (#1320, #1207's founding cohort);
- *     `isModerator` shows it to the actual moderator regardless of tier. The server
- *     remains the sole authority (the shipped `PromotionActions` convention, #1206):
- *     an unauthorized call comes back the invisible denial.
+ * The divan surface's render decisions, factored DOM-free because `apps/web/src` has no
+ * jsdom. The gates mirror the backend `requireDivanAccess` disjunction (divan/gate.ts):
+ * the divan is reached by yazar OR mod, and the server stays the sole authority — a
+ * client gate is a courtesy, and an unauthorized call comes back the invisible denial.
  */
 import {TARGET_KINDS, type TargetKind} from "../../../worker/db/target-kind";
 import type {Tier} from "../../../worker/features/kunye/standing";
 import {actorLabel} from "../moderation/actor-identity";
 
 /**
- * Can the CLIENT prove — from its trusted signals alone — that `divan.roster`
- * would deny this viewer, so the guaranteed-`UNAUTHORIZED` probe need never be
- * fired (#2209)? The server grant is the disjunction yazar OR moderator
- * (`requireDivanAccess`, divan/gate.ts), so denial is provable iff BOTH arms are
- * KNOWN-false: the tier is loaded and below yazar (`visitor`/`çaylak`) AND the
- * `isModerator` signal is loaded and false. An `undefined` tier (`me` not yet
- * read) is the AMBIGUOUS case — the client cannot prove anything, so this returns
- * `false` and the server probe still runs, keeping the server the sole authority
- * for the yazar/mod case. The short-circuit is layered ON the server gate, never a
- * replacement: a viewer this returns `false` for is still probed.
+ * Denial is provable only when BOTH arms are KNOWN-false. An `undefined` tier (`me` not
+ * yet read) is the ambiguous case ⇒ `false`, so the server probe still runs and stays the
+ * authority. The short-circuit is layered ON the server gate, never a replacement.
  */
 export function divanAccessDefinitelyDenied(
 	tier: Tier | undefined,
@@ -47,16 +20,6 @@ export function divanAccessDefinitelyDenied(
 	return tier !== undefined && tier !== "yazar" && isModerator === false;
 }
 
-/**
- * Should `useDivanAccess` fire the server-side `divan.roster` wire probe (#2209)?
- * TRUE only when the viewer is signed in and access is NOT client-provably denied.
- * A provably-denied çaylak/non-mod ({@link divanAccessDefinitelyDenied}) returns
- * `false` — the guaranteed-`UNAUTHORIZED` request is never issued — while the
- * AMBIGUOUS case (a not-yet-loaded `me`, a yazar, or a moderator) returns `true`, so
- * the server stays the sole authority for the yazar/mod grant. Factored DOM-free so
- * "the probe fires iff …" is asserted without a React runtime (`apps/web/src` has no
- * jsdom).
- */
 export function shouldProbeDivanRoster(
 	signedIn: boolean,
 	tier: Tier | undefined,
@@ -65,52 +28,27 @@ export function shouldProbeDivanRoster(
 	return signedIn && !divanAccessDefinitelyDenied(tier, isModerator);
 }
 
-/**
- * Show the yazar **"kefil ol"** (vouch) affordance iff the viewer is a yazar — the
- * trusted account tier (`requireVouch` is the yazar floor server-side). A mod who
- * is not a yazar cannot vouch, so the affordance is yazar-tier only.
- */
+// `requireVouch` is the yazar floor server-side, so a mod who is not a yazar cannot vouch.
 export function vouchVisible(tier: Tier | undefined): boolean {
 	return tier === "yazar";
 }
 
-/**
- * Enable the vouch action iff the viewer is a yazar AND has opened the çaylak
- * detail. Staking on a çaylak you have not reviewed is unrepresentable — the
- * detail-open precondition (#1290 AC) is carried as `detailOpened`.
- */
+// Staking on a çaylak you have not opened is unrepresentable — hence `detailOpened`.
 export function canVouch(tier: Tier | undefined, detailOpened: boolean): boolean {
 	return vouchVisible(tier) && detailOpened;
 }
 
-/**
- * Show the mod **"yazar yap"** (promote) affordance iff the viewer is a platform
- * moderator (the trusted server-authoritative `isModerator` signal, #1320). Keyed
- * off `isModerator` — never `tier` — so a dual-role yazar+moderator (who reads
- * `tier: "yazar"`, #1207's founding cohort) still sees promote, while a yazar-only
- * viewer does not. `false`/not-yet-loaded `me` resolves to hidden.
- */
+// Keyed off `isModerator`, never `tier`: a dual-role yazar+moderator reads `tier: "yazar"`
+// (#1320), so a tier check wrongly hid promote from them.
 export function promoteVisible(isModerator: boolean): boolean {
 	return isModerator;
 }
 
-/**
- * The display handle for a çaylak in the divan: their display name, else their
- * `@username`, else the lowercase-Turkish "çaylak" fallback (an anonymized /
- * not-yet-named row). Never the raw user id — the divan reads a person, not an id.
- * The çaylak-specific fallback over the shared actor-row rule (ADR 0147): one tested
- * handle resolver across every mod/admin surface, divan supplying its own noun.
- */
+// See ADR 0147 — one shared handle resolver across the mod surfaces; divan supplies its noun.
 export function caylakLabel(displayName: string | null, username: string | null): string {
 	return actorLabel(displayName, username, "çaylak");
 }
 
-/**
- * Split a backlog item's `<kind>:<itemId>` composite id (the identity
- * `DivanBacklogItemView` emits, the same `divan.vote` takes) back into its report
- * target, or `null` if malformed / unknown-kind — so a `bildir` on a divan item
- * names the underlying definition/post/comment to `report.submit`.
- */
 export function parseBacklogItemId(
 	id: string,
 ): {readonly targetKind: TargetKind; readonly targetId: string} | null {
@@ -121,7 +59,6 @@ export function parseBacklogItemId(
 	return {targetKind: kind as TargetKind, targetId: id.slice(sep + 1)};
 }
 
-/** The lowercase-Turkish per-kind noun for a sandboxed backlog item. */
 export function itemKindLabel(kind: TargetKind): string {
 	switch (kind) {
 		case "definition":
@@ -133,10 +70,8 @@ export function itemKindLabel(kind: TargetKind): string {
 	}
 }
 
-/** The promote-call outcome the detail's status line renders (words, never color). */
 export type PromoteOutcome = "promoted" | "alreadyYazar" | "denied" | "error";
 
-/** Map a `user.promote` `{promoted}` receipt + denial/failure onto its outcome. */
 export function promoteOutcome(
 	promoted: boolean | undefined,
 	denied: boolean,
@@ -147,7 +82,6 @@ export function promoteOutcome(
 	return promoted ? "promoted" : "alreadyYazar";
 }
 
-/** The lowercase-Turkish status line for a promote outcome. */
 export function promoteOutcomeMessage(outcome: PromoteOutcome): string {
 	switch (outcome) {
 		case "promoted":
@@ -161,10 +95,8 @@ export function promoteOutcomeMessage(outcome: PromoteOutcome): string {
 	}
 }
 
-/** The vouch-call outcome the stake-confirm sheet's status line renders. */
 export type VouchOutcome = "promoted" | "recorded" | "limit" | "denied" | "error";
 
-/** Map a `user.vouch` `{promoted}` receipt + denial code onto its outcome. */
 export function vouchOutcome(
 	promoted: boolean | undefined,
 	code: string | null,
@@ -176,7 +108,6 @@ export function vouchOutcome(
 	return promoted ? "promoted" : "recorded";
 }
 
-/** The lowercase-Turkish status line for a vouch outcome. */
 export function vouchOutcomeMessage(outcome: VouchOutcome): string {
 	switch (outcome) {
 		case "promoted":

--- a/apps/web/src/components/divan/raporlarGating.test.ts
+++ b/apps/web/src/components/divan/raporlarGating.test.ts
@@ -1,10 +1,3 @@
-/**
- * The raporlar (moderation-queue) gating contract (#1701) — the pure render
- * decisions asserted without a DOM, per the `divanGating.test.ts` precedent. The
- * moderator-only entry keys on the trusted `isModerator` signal, never `tier`
- * (asserted at the DivanPage call site, since the visibility check is now a plain
- * `isModerator` read).
- */
 import {describe, expect, it} from "vitest";
 import {
 	reasonLabel,

--- a/apps/web/src/components/divan/raporlarGating.ts
+++ b/apps/web/src/components/divan/raporlarGating.ts
@@ -1,12 +1,8 @@
 /**
- * The raporlar (moderation-queue) surface's render decisions (#1701), factored
- * DOM-free in the `divanGating.ts` idiom so each gate is unit-testable without a
- * React runtime. The queue is a moderator-only view inside `/divan`: visibility
- * keys on the trusted server-side `isModerator` signal (`useMe`, #1320) — never on
- * `tier`, so a dual-role yazar+moderator still sees the entry. The client gate is a
- * courtesy only: the `report.listOpen` read stays `Moderate`-gated server-side, so a
- * forced read by a non-moderator denies the invisible `UNAUTHORIZED` (rendered as the
- * divan's "yetkin yok" state).
+ * The raporlar (moderation-queue) surface's render decisions (#1701), factored DOM-free
+ * because `apps/web/src` has no jsdom. The client gate is a courtesy only: `report.listOpen`
+ * stays `Moderate`-gated server-side, so a forced non-mod read denies the invisible
+ * `UNAUTHORIZED`.
  */
 import type {TargetKind} from "../../../worker/db/target-kind";
 
@@ -14,12 +10,8 @@ const MINUTE_MS = 60_000;
 const HOUR_MS = 60 * MINUTE_MS;
 const DAY_MS = 24 * HOUR_MS;
 
-/**
- * The lowercase-Turkish first-reported age for a queue row ("az önce" /
- * "N dakika önce" / "N saat önce" / "N gün önce"), or `null` for a malformed
- * timestamp — the row then renders no age rather than lying "az önce". A clock
- * skew that puts the report in the future clamps to "az önce".
- */
+// `null` for a malformed timestamp — the row renders no age rather than lying "az önce";
+// a clock skew putting the report in the future clamps to "az önce".
 export function reportAgeLabel(firstReportedAt: string, nowMs: number): string | null {
 	const reportedMs = Date.parse(firstReportedAt);
 	if (Number.isNaN(reportedMs)) return null;
@@ -30,18 +22,12 @@ export function reportAgeLabel(firstReportedAt: string, nowMs: number): string |
 	return `${Math.floor(elapsed / DAY_MS)} gün önce`;
 }
 
-/** The reason cell's copy: the reporter's reason when present, else "gerekçe yok". */
 export function reasonLabel(reason: string | null): string {
 	const trimmed = reason?.trim();
 	return trimmed ? trimmed : "gerekçe yok";
 }
 
-/**
- * The in-situ link for a reported target (#1702): a post/comment opens its pano post
- * detail (`/pano/<ref>` — the comment's `ref` is its parent post id), a definition
- * opens its sözlük term page (`/sozluk/<ref>`). `null` when the server couldn't
- * resolve the routing ref, so the row renders context without a broken link.
- */
+// A comment's routing `ref` is its parent post id, so post and comment both open /pano/<ref>.
 export function targetHref(kind: TargetKind, ref: string | null): string | null {
 	const trimmed = ref?.trim();
 	if (!trimmed) return null;
@@ -54,17 +40,11 @@ export function targetHref(kind: TargetKind, ref: string | null): string | null 
 	}
 }
 
-/**
- * The queue row's target-excerpt copy: the server-resolved excerpt/title when
- * present, else the lowercase-Turkish "içerik yüklenemedi" (a target whose content
- * couldn't be read — sandboxed/gone), never an empty cell.
- */
 export function targetExcerptLabel(excerpt: string | null): string {
 	const trimmed = excerpt?.trim();
 	return trimmed ? trimmed : "içerik yüklenemedi";
 }
 
-/** The author byline copy: `@handle` when resolved, else "yazar bilinmiyor". */
 export function targetAuthorLabel(author: string | null): string | null {
 	const trimmed = author?.trim();
 	return trimmed ? `@${trimmed}` : null;

--- a/apps/web/src/components/divan/remove-the-wave.test.ts
+++ b/apps/web/src/components/divan/remove-the-wave.test.ts
@@ -1,12 +1,3 @@
-/**
- * remove-the-wave's interaction + copy contract (#1855, ADR 0138) — the pure
- * grouping / safe-selection / blast-radius / batch-key / partial-failure decisions
- * asserted without a DOM, per the `triage-loop.test.ts` precedent. The AC the wave
- * lives or dies on: `Shift-X` grabs an author's reported targets; the manifest
- * auto-deselects zero-report targets while `T`/`Space` select; `⌥R` opens a
- * blast-radius confirm naming target-count + reports-collapsed + reversibility;
- * `Enter`/`Esc` apply/cancel; a partial failure surfaces which targets did not resolve.
- */
 import {describe, expect, it} from "vitest";
 import {
 	batchVerdict,

--- a/apps/web/src/components/divan/remove-the-wave.ts
+++ b/apps/web/src/components/divan/remove-the-wave.ts
@@ -1,47 +1,29 @@
 /**
- * remove-the-wave (#1855, ADR 0138) — same-author grouping + batch resolution living
- * IN the triage loop. The pure, DOM-free decisions — the wave manifest (an actor's
- * open-reported targets), the safe-by-default selection (auto-deselect zero-report
- * targets), the blast-radius confirm copy, the ⌥R/⌥Y batch keys, and the
- * partial-failure partition — factored out per the `triage-loop.ts` / `actor-drawer.ts`
- * idiom so they're unit-testable without a React runtime (`apps/web/src` has no jsdom).
- *
- * The wave rides the SAME `Moderate`-gated `report.listOpen` read the loop already
- * consumes (a MODE, never a re-fetch): every one of an actor's open-reported targets is
- * already a row in the queue, so grouping is a client-side filter on `authorId`. The
- * batch verdict fans the existing single-target `report.resolve` over the selection —
- * the per-target ledger event #1704 groups into the restore-as-a-unit is out of scope
- * here (this slice stays out of #1704's listResolved read + decision feed).
+ * remove-the-wave (#1855, ADR 0138) — same-author grouping + batch resolution in the
+ * triage loop, factored DOM-free because `apps/web/src` has no jsdom. The wave rides the
+ * SAME `Moderate`-gated `report.listOpen` read the loop already consumes, so grouping is a
+ * client-side filter on `authorId` rather than a re-fetch.
  */
 import type {TargetKind} from "../../../worker/db/target-kind";
 import type {Verdict} from "./triage-loop";
 
-/** One reported target in the wave manifest — the actor's open-reported content. */
 export interface WaveTarget {
 	readonly targetKind: TargetKind;
 	readonly targetId: string;
-	/** A resolved title/excerpt identifying the target (the client resolves the copy). */
 	readonly title: string;
-	/** Open reports standing on this target — the auto-deselect gate and blast-radius addend. */
 	readonly reportCount: number;
 }
 
-/** A live queue row projected to the fields the wave grouping reads. */
 export interface WaveRow extends WaveTarget {
-	/** The reported target author's account id — the grouping key (`null` when unresolved). */
 	readonly authorId: string | null;
 }
 
-/** The stable per-target key (`<kind>:<id>`) — the same identity `report.resolve` acts on. */
 export function waveTargetKey(t: {targetKind: TargetKind; targetId: string}): string {
 	return `${t.targetKind}:${t.targetId}`;
 }
 
-/**
- * The wave manifest: the given actor's open-reported targets, in queue order. An
- * unresolved actor (`authorId === null`) groups nothing — there's no join key, so the
- * manifest is empty rather than lumping every anonymized row together.
- */
+// An unresolved actor (`authorId === null`) groups nothing — with no join key, lumping
+// every anonymized row together would be worse than an empty manifest.
 export function buildWaveManifest(
 	rows: ReadonlyArray<WaveRow>,
 	authorId: string | null,
@@ -57,22 +39,15 @@ export function buildWaveManifest(
 		}));
 }
 
-/**
- * The safe-by-default initial selection (ADR 0138): every target that carries at least
- * one open report is pre-selected; a zero-report target is auto-deselected. The mod
- * removes *reported* content, never censors an actor's whole footprint — a clean target
- * riding along in the manifest is opt-in only (via `T` or `Space`).
- */
+// See ADR 0138 — safe by default: a clean target riding along in the manifest is opt-in only.
 export function initialWaveSelection(targets: ReadonlyArray<WaveTarget>): ReadonlyArray<string> {
 	return targets.filter((t) => t.reportCount > 0).map(waveTargetKey);
 }
 
-/** Every target in the manifest, selected — the explicit `T` (tümü) override. */
 export function selectAllWave(targets: ReadonlyArray<WaveTarget>): ReadonlyArray<string> {
 	return targets.map(waveTargetKey);
 }
 
-/** Toggle one row's membership (`Space`) — add when absent, remove when present. */
 export function toggleWaveRow(selected: ReadonlyArray<string>, key: string): ReadonlyArray<string> {
 	return selected.includes(key) ? selected.filter((k) => k !== key) : [...selected, key];
 }
@@ -81,7 +56,6 @@ export function isWaveSelected(selected: ReadonlyArray<string>, key: string): bo
 	return selected.includes(key);
 }
 
-/** The selected targets, in manifest order — the fan-out domain for the batch verdict. */
 export function selectedWaveTargets(
 	targets: ReadonlyArray<WaveTarget>,
 	selected: ReadonlyArray<string>,
@@ -89,20 +63,14 @@ export function selectedWaveTargets(
 	return targets.filter((t) => selected.includes(waveTargetKey(t)));
 }
 
-/** One target's `report.resolve` input in a wave gesture — carries the shared `waveId`. */
 export interface WaveResolveInput {
 	readonly targetKind: TargetKind;
 	readonly targetId: string;
 	readonly waveId: string;
 }
 
-/**
- * The per-target `report.resolve` inputs for ONE wave gesture (#1855, ADR 0138): every
- * selected target carries the SAME `waveId`, so the server stamps one shared grouping
- * across the batch and #1704's restore reopens it as a unit. The id is generated once per
- * gesture (a wave IS one grouping) and threaded here; a single-target loop resolve passes
- * no waveId, so its row's grouping stays null.
- */
+// One `waveId` per gesture, shared across the batch so #1704's restore reopens it as a
+// unit; a single-target loop resolve passes none, leaving its grouping null.
 export function waveResolveInputs(
 	targets: ReadonlyArray<WaveTarget>,
 	waveId: string,
@@ -110,24 +78,15 @@ export function waveResolveInputs(
 	return targets.map((t) => ({targetKind: t.targetKind, targetId: t.targetId, waveId}));
 }
 
-/** A non-empty selection is required before a batch verdict can apply. */
 export function canApplyWave(selected: ReadonlyArray<string>): boolean {
 	return selected.length > 0;
 }
 
-/** The manifest heading (ADR 0138): `bu aktör · N bildirili hedef` — the wave's breadth. */
 export function waveManifestLabel(targetCount: number): string {
 	const n = Math.max(0, Math.floor(targetCount));
 	return `bu aktör · ${n} bildirili hedef`;
 }
 
-/**
- * The blast-radius confirm copy (ADR 0138): `N hedef · M raporu kapatır · geri
- * alınabilir` — the magnitude in plain Turkish, not a noise "emin misiniz?". `N` is the
- * selected target count, `M` the total open reports the batch collapses; one confirm for
- * the whole batch, never N. Reads off the CURRENT selection so a toggle before confirm
- * restates the real magnitude.
- */
 export function blastRadiusLabel(
 	targets: ReadonlyArray<WaveTarget>,
 	selected: ReadonlyArray<string>,
@@ -137,15 +96,12 @@ export function blastRadiusLabel(
 	return `${chosen.length} hedef · ${reports} raporu kapatır · geri alınabilir`;
 }
 
-/** A key-press the wave manifest interprets while it is open. */
 export interface WaveKeyEvent {
 	readonly key: string;
-	/** The physical key code — the modifier-stable match for the ⌥ combos (see below). */
 	readonly code: string;
 	readonly altKey: boolean;
 }
 
-/** The actions the wave manifest binds — grab (from the loop) plus the manifest's own. */
 export type WaveAction =
 	| {readonly kind: "grab"}
 	| {readonly kind: "selectAll"}
@@ -154,14 +110,9 @@ export type WaveAction =
 	| {readonly kind: "batchDismiss"};
 
 /**
- * Map a key-press to a wave action, or `null` for a key the wave doesn't own. `Shift-X`
- * grabs the focused target's author into the manifest; `T` selects all, `Space` toggles
- * the focused row, `⌥R` batch-removes, `⌥Y` batch-dismisses.
- *
  * The ⌥ combos match on the physical `code` (`KeyR`/`KeyY`), not `key`: on macOS an
- * Option-modified key produces a substituted glyph (`⌥R` → `key === "®"`), so `key`
- * can't recognize the combo. `code` is layout- and modifier-stable, so it is the only
- * reliable match for the founder's ⌥R/⌥Y bindings.
+ * Option-modified key produces a substituted glyph (`⌥R` → `key === "®"`), so `key` cannot
+ * recognize the combo.
  */
 export function waveKeyToAction(ev: WaveKeyEvent): WaveAction | null {
 	if (ev.altKey) {
@@ -181,7 +132,6 @@ export function waveKeyToAction(ev: WaveKeyEvent): WaveAction | null {
 	}
 }
 
-/** The verdict a batch action commits — remove hides content, dismiss reopens-reversibly. */
 export function batchVerdict(action: WaveAction): Verdict | null {
 	switch (action.kind) {
 		case "batchRemove":
@@ -193,29 +143,19 @@ export function batchVerdict(action: WaveAction): Verdict | null {
 	}
 }
 
-/**
- * The blast-radius confirm's keys (ADR 0138 — a wave-remove is confirmed, a dismiss is
- * not): `Enter` applies the batch, `Esc` cancels it. `null` for any other key so the
- * confirm never commits on a stray press.
- */
 export function waveConfirmKey(key: string): "apply" | "cancel" | null {
 	if (key === "Enter") return "apply";
 	if (key === "Escape") return "cancel";
 	return null;
 }
 
-/** One target's batch-resolve outcome — its key and whether the `report.resolve` succeeded. */
 export interface WaveOutcome {
 	readonly key: string;
 	readonly ok: boolean;
 }
 
-/**
- * Partition a batch's per-target outcomes into resolved vs failed (ADR 0138 — no silent
- * partial drop). The failed keys stay actionable: the caller keeps them in the queue and
- * re-selected, so a partial failure surfaces exactly which targets did not resolve rather
- * than swallowing them.
- */
+// The failed keys stay actionable — the caller keeps them queued and re-selected, so a
+// partial failure is never a silent drop.
 export function summarizeWaveBatch(outcomes: ReadonlyArray<WaveOutcome>): {
 	readonly resolved: ReadonlyArray<string>;
 	readonly failed: ReadonlyArray<string>;
@@ -226,11 +166,6 @@ export function summarizeWaveBatch(outcomes: ReadonlyArray<WaveOutcome>): {
 	return {resolved, failed};
 }
 
-/**
- * The partial-failure copy: `N hedef çözülemedi, tekrar dene` when some targets did not
- * resolve, else `null` (a fully-applied batch surfaces no error). Names the count so the
- * mod knows the wave was not fully cleared.
- */
 export function waveFailureLabel(failedCount: number): string | null {
 	const n = Math.max(0, Math.floor(failedCount));
 	if (n === 0) return null;

--- a/apps/web/src/components/divan/triage-loop.test.ts
+++ b/apps/web/src/components/divan/triage-loop.test.ts
@@ -1,11 +1,3 @@
-/**
- * The triage-loop hero's interaction contract (#1703, ADR 0138) — the pure focus /
- * verdict-key / confirm-gate / Esc-ladder decisions asserted without a DOM, per the
- * `raporlarGating.test.ts` precedent. The AC the loop lives or dies on: one target at
- * a time with a real focus-state; `j/k` navigate; `Y` dismisses in one keystroke while
- * `R` gates on a confirm; `U`/`O`/`Esc` bindings; the reputation-in-row + reporter
- * diversity copy.
- */
 import {describe, expect, it} from "vitest";
 import type {TargetKind} from "../../../worker/db/target-kind";
 import {

--- a/apps/web/src/components/divan/triage-loop.ts
+++ b/apps/web/src/components/divan/triage-loop.ts
@@ -1,41 +1,21 @@
 /**
  * The triage-loop hero's render + interaction decisions (#1703, ADR 0138), factored
- * DOM-free in the `divanGating.ts` / `raporlarGating.ts` idiom so the focus-state
- * model, the verdict-key handling, the confirm gate, and the Esc de-escalation ladder
- * are unit-testable without a React runtime (`apps/web/src` has no jsdom).
- *
- * The loop is a MODE over the SAME gated `report.listOpen` read the grid (`Raporlar`,
- * #1701) consumes — never a re-fetch. It presents one reported target at a time with
- * the moderator's hands on the keyboard: `j/k` navigate, `Y` yoksay (dismiss, no
- * confirm — reversible), `R` kaldır (remove, key + confirm — it hides content), `U`
- * undo the last verdict, `O` reveal a masked excerpt, `Tab` switches chambers, `Esc`
- * walks the de-escalation ladder. The reputation-in-row (author standing + the
- * pile-on's reporter diversity) is the #1852 seam, surfaced here now.
+ * DOM-free because `apps/web/src` has no jsdom.
  */
 import type {TargetKind} from "../../../worker/db/target-kind";
 
-/** The two verdicts, asymmetric by weight (ADR 0138): dismiss is one key, remove is key + confirm. */
 export type Verdict = "dismiss" | "remove";
 
-/** The two review chambers `Tab` switches between (ADR 0138): the report queue and the vouch/kefil roster. */
 export type Chamber = "raporlar" | "kefil";
 
-/**
- * The loop's focus is the single reviewable target's identity + queue position — a
- * real state (the seam #1852's drawer and #1855's wave dock into), not a derived
- * scroll offset. `null` when the queue is empty (the earned drained state).
- */
 export interface Focus {
 	readonly index: number;
 	readonly targetKind: TargetKind;
 	readonly targetId: string;
 }
 
-/**
- * Resolve the focus for a queue position, clamped into `[0, length)`. An empty queue
- * has no focus (the drained state); an out-of-range index (past a resolved tail)
- * clamps to the last item so a verdict on the final row lands on a real target.
- */
+// An out-of-range index (past a resolved tail) clamps to the last item, so a verdict on
+// the final row still lands on a real target.
 export function focusAt(
 	items: ReadonlyArray<{targetKind: TargetKind; targetId: string}>,
 	index: number,
@@ -47,29 +27,16 @@ export function focusAt(
 	return {index: clamped, targetKind: item.targetKind, targetId: item.targetId};
 }
 
-/** Next/prev queue position, clamped to the queue bounds (no wrap — the ends are real edges). */
 export function moveFocus(index: number, delta: number, length: number): number {
 	if (length <= 0) return 0;
 	return Math.max(0, Math.min(index + delta, length - 1));
 }
 
-/**
- * After a verdict collapses the focused row, the queue shrinks by one. Keep the focus
- * on the SAME position so the next target slides under the cursor — except at the tail,
- * where the position clamps back to the new last row. `nextLength` is the post-collapse
- * length; a drained queue returns 0 (the caller renders the earned empty state).
- */
 export function focusAfterResolve(index: number, nextLength: number): number {
 	if (nextLength <= 0) return 0;
 	return Math.min(index, nextLength - 1);
 }
 
-/**
- * The keys the loop binds, mapped from a raw key press. Returns `null` for an unbound
- * key (the loop ignores it, never swallowing browser shortcuts it doesn't own). Case
- * matters: the verdict keys are the founder-confirmed uppercase `Y`/`R`, so a lone
- * lowercase `y` (mid-typing) is NOT a dismiss.
- */
 export type LoopAction =
 	| {readonly kind: "next"}
 	| {readonly kind: "prev"}
@@ -80,6 +47,8 @@ export type LoopAction =
 	| {readonly kind: "switchChamber"}
 	| {readonly kind: "escape"};
 
+// The verdict keys are the uppercase `Y`/`R`: a lone lowercase `y` mid-typing must never
+// commit a verdict.
 export function keyToAction(key: string): LoopAction | null {
 	switch (key) {
 		case "j":
@@ -105,26 +74,15 @@ export function keyToAction(key: string): LoopAction | null {
 	}
 }
 
-/**
- * The verdict's confirm posture (ADR 0138 — asymmetric weight): dismiss commits on the
- * first keystroke (low-stakes, reopen-reversible), remove requires a confirm because it
- * hides content. `true` ⇒ the loop opens the confirm sheet instead of committing.
- */
+// See ADR 0138 — asymmetric weight: remove is confirmed because it hides content.
 export function needsConfirm(verdict: Verdict): boolean {
 	return verdict === "remove";
 }
 
-/** The chamber `Tab` toggles to (raporlar ⇄ kefil) — a two-state switch, ADR 0138. */
 export function nextChamber(current: Chamber): Chamber {
 	return current === "raporlar" ? "kefil" : "raporlar";
 }
 
-/**
- * The Esc de-escalation ladder (ADR 0138): a modal sheet closes first, then a
- * selection clears, then the loop yields to the grid. Esc never jumps straight to the
- * grid while a sheet is open — one rung per press, so a moderator's muscle-memory Esc
- * dismisses exactly the innermost layer.
- */
 export type LoopLayer = "sheet" | "selection" | "grid";
 
 export function escapeTo(current: LoopLayer): LoopLayer {
@@ -138,13 +96,8 @@ export function escapeTo(current: LoopLayer): LoopLayer {
 	}
 }
 
-/**
- * The reporter-diversity copy (ADR 0138): `N rapor · M farklı kişi`, the pile-on's
- * shape a moderator reads to tell a real wave (`9 rapor · 7 farklı kişi`) from a
- * grudge-reporter (`9 rapor · 1 kişi`). A single report drops the diversity clause
- * (`1 rapor` — there's no "1 farklı kişi" to contrast). `distinct` is clamped to
- * `[1, count]` so a malformed count never reads more distinct reporters than reports.
- */
+// `distinct` clamps into `[1, count]` so a malformed count never reads more distinct
+// reporters than reports.
 export function reporterDiversityLabel(reportCount: number, distinctReporters: number): string {
 	const count = Math.max(0, Math.floor(reportCount));
 	if (count <= 1) return `${count} rapor`;
@@ -152,13 +105,6 @@ export function reporterDiversityLabel(reportCount: number, distinctReporters: n
 	return `${count} rapor · ${distinct} farklı kişi`;
 }
 
-/**
- * The author-standing copy for the row (ADR 0138): the tier, karma, and prior-removals
- * a moderator weighs — `çaylak · 3 karma · 2 kaldırma` for a repeat offender, `yazar ·
- * 240 karma` for a clean author (the removal clause drops at zero). `null` when the
- * author is unresolved (an anonymized / hidden target), so the row renders no
- * fabricated reputation.
- */
 export function authorReputationLabel(
 	tier: string | null,
 	karma: number | null,
@@ -172,26 +118,13 @@ export function authorReputationLabel(
 	return parts.join(" · ");
 }
 
-/**
- * The masked-excerpt gate (ADR 0138 — a mod isn't force-fed a slur to dismiss it): a
- * reported excerpt is collapsed by default and only shown when the moderator presses
- * `O` for THIS row. Returns the copy to render: the excerpt when revealed, else the
- * masked placeholder. A missing excerpt reads the neutral fallback regardless of the
- * reveal state.
- */
+// See ADR 0138 — a moderator is not force-fed the excerpt in order to dismiss it.
 export function maskedExcerpt(excerpt: string | null, revealed: boolean): string {
 	const trimmed = excerpt?.trim();
 	if (!trimmed) return "içerik yüklenemedi";
 	return revealed ? trimmed : "içerik gizli · O ile göster";
 }
 
-/**
- * The keyboard legend the HUD renders (ADR 0138): one entry per bound gesture — the
- * keycap(s) plus its lowercase-Turkish action. The founder-flagged dense strip is
- * replaced by this structured legend so a moderator can scan the loop's grammar; the
- * keycaps render as `<kbd>` chips (the manifest's key-legend rule). Copy lives here,
- * DOM-free, beside the `keyToAction` map it mirrors.
- */
 export interface LegendEntry {
 	readonly keys: ReadonlyArray<string>;
 	readonly label: string;
@@ -208,12 +141,6 @@ export const triageLegend: ReadonlyArray<LegendEntry> = [
 	{keys: ["X"], label: "dalga"},
 ];
 
-/**
- * The earned drained-queue line (ADR 0138): `raporlar temiz` plus today's decision
- * count, so a cleared queue feels earned rather than a sad empty illustration. Zero
- * decisions today still reads clean (a queue that was already empty), just without the
- * count clause.
- */
 export function drainedLabel(decisionsToday: number): string {
 	const n = Math.max(0, Math.floor(decisionsToday));
 	if (n === 0) return "raporlar temiz";

--- a/apps/web/src/components/divan/useDivanAccess.ts
+++ b/apps/web/src/components/divan/useDivanAccess.ts
@@ -1,26 +1,9 @@
 /**
- * `useDivanAccess` — the server-authoritative answer to "may THIS user see the
- * divan?" (#1290). The divan is reached by yazar OR mod (the disjunctive
- * `requireDivanAccess` gate, divan/gate.ts), so rather than guess authority for the
- * ambiguous case, this probes the gated `divan.roster` read and reports whether it
- * resolved (granted) or denied (the invisible `UNAUTHORIZED`).
- *
- * Client short-circuit (#2209): the `me` row carries the trusted `tier` +
- * `isModerator` signals, so for a viewer whose disjunction is PROVABLY false
- * (`divanAccessDefinitelyDenied` — a loaded non-yazar tier AND a loaded
- * `isModerator: false`, i.e. a çaylak/visitor non-mod) the probe is skipped: it
- * would return `UNAUTHORIZED` on every authed load. The server probe still runs for
- * the AMBIGUOUS case (`me` not yet loaded, a yazar, or a moderator) — the gate stays
- * server-authoritative; the short-circuit only elides a request the client can PROVE
- * is wasted.
- *
- * Imperative (`request` in an effect, not the suspending `useRequest`), for the
- * same reason as `useMe` / `useProfileStats`: it drives the topbar entry, which
- * sits in the `Layout` shell above any `<Screen>` Suspense boundary, so it must
- * resolve to a safe default rather than suspend.
- *
- * Fail-closed: it only probes when the viewer is signed in, and any error (the
- * `UNAUTHORIZED` denial, or a transport failure) ⇒ not granted.
+ * `useDivanAccess` — probes the gated `divan.roster` read to answer "may THIS user see the
+ * divan?" (#1290). Imperative (`request` in an effect, not the suspending `useRequest`)
+ * because it drives the topbar entry, which sits in the `Layout` shell above any `<Screen>`
+ * Suspense boundary, so it must resolve to a safe default rather than suspend. Fail-closed:
+ * it only probes when signed in, and any error ⇒ not granted.
  */
 import {useCallback, useEffect, useState} from "react";
 import {useFateClient, view} from "react-fate";
@@ -37,9 +20,8 @@ export function useDivanAccess(me: MeUser | null): boolean {
 	const fate = useFateClient();
 	const [granted, setGranted] = useState(false);
 	const signedIn = !!session.data;
-	// Fire the wire probe only when signed in AND access isn't client-provably denied
-	// (#2209): a çaylak/non-mod short-circuits off the wire; a not-yet-loaded `me`, a
-	// yazar, or a moderator is ambiguous ⇒ still probed.
+	// Skip the probe only when denial is client-provable (#2209); the ambiguous cases (a
+	// not-yet-loaded `me`, a yazar, a moderator) are still probed.
 	const probeWire = shouldProbeDivanRoster(signedIn, me?.tier, me?.isModerator);
 
 	const probe = useCallback(async () => {
@@ -53,8 +35,7 @@ export function useDivanAccess(me: MeUser | null): boolean {
 			});
 			setGranted(true);
 		} catch {
-			// The invisible `UNAUTHORIZED` denial (çaylak/visitor) or any transport
-			// failure ⇒ no access. Fail-closed: the entry stays hidden.
+			// UNAUTHORIZED or a transport failure ⇒ fail closed, the entry stays hidden.
 			setGranted(false);
 		}
 	}, [probeWire, fate]);

--- a/apps/web/src/components/entry-row-spine.test.tsx
+++ b/apps/web/src/components/entry-row-spine.test.tsx
@@ -1,22 +1,10 @@
 /**
- * The entry-row behavioral spine lock (#2406). This is the tripwire the
- * one-directional design-sync authority contract
- * (`.patterns/design-sync-authority.md`, ADR 0162 pillar 4) runs against: it
- * freezes the code-authoritative a11y/behavioral shell of the primitives the
- * entry-row composite is built from — `Button`, `MetaRow`, `CountToggle`,
- * `ToggleGroup`, `ReactionBar` — so a later visual reskin that drops the spine
- * fails here rather than silently shipping. Each axis asserts a *behavior* a
- * synced reskin must never overwrite: focus-ring presence, aria roles/labels/
- * state, keyboard order/operability, and `prefers-reduced-motion` respect.
+ * The entry-row behavioral spine lock (#2406) — the tripwire for
+ * `.patterns/design-sync-authority.md`.
  *
- * jsdom decidability: name/role/ARIA/focusability/keyboard-order are jsdom-decidable
- * and asserted per render. The focus ring and reduced-motion are CSS/media-query
- * paint facts jsdom cannot compute (no layout engine, no applied CSS) — the same
- * category the a11y harness parks as `warning` (posture.ts). So those two axes are
- * locked at their single load-bearing SOURCE site: the one shared `:focus-visible`
- * ring and the one global reduced-motion reset, both in `styles/global.css`. If
- * either is removed the entire entry-row shell loses that guarantee, so the source
- * assertion is the honest tripwire, not a false jsdom paint gate.
+ * The focus ring and reduced-motion are CSS/media-query facts jsdom cannot compute,
+ * so those two axes assert against the CSS SOURCE (`styles/global.css`) rather than
+ * a rendered node. That is deliberate: a jsdom paint assertion here would be false.
  */
 import {readFileSync} from "node:fs";
 import {fileURLToPath} from "node:url";
@@ -38,10 +26,8 @@ const ICON_CSS = readSource("./icon.css");
 const TOGGLE_GROUP_CSS = readSource("./ui/ToggleGroup.css");
 
 describe("entry-row spine — focus-ring presence", () => {
-	// The ring is painted once, globally, by the single `:focus-visible` rule over
-	// the native-focusable element set (global.css). The per-primitive contract is
-	// therefore "render a native focusable control that rule targets" — never a
-	// non-focusable div, never a hand-rolled per-component outline.
+	// One global `:focus-visible` rule paints every ring, so each primitive's contract
+	// is only "render a native focusable control" — never a hand-rolled outline.
 	it("global.css defines the shared focus-ring token and a single :focus-visible outline rule", () => {
 		expect(GLOBAL_CSS).toMatch(/--focus-ring:/);
 		expect(GLOBAL_CSS).toMatch(/:focus-visible\s*\{[^}]*outline:\s*var\(--focus-ring\)/s);
@@ -137,8 +123,6 @@ describe("entry-row spine — aria roles/labels/state", () => {
 		const {container} = render(
 			<CountToggle icon={<span data-testid="g">g</span>} aria-label="beğen" />,
 		);
-		// The accessible name is the button's own aria-label; the glyph must not
-		// invent a competing name (a reskin dropping the label breaks this).
 		expect(container.querySelector("button")!.getAttribute("aria-label")).toBe("beğen");
 	});
 
@@ -187,9 +171,8 @@ describe("entry-row spine — keyboard order & operability", () => {
 		expect(buttons.length).toBeGreaterThan(1);
 		for (const btn of buttons) {
 			expect(btn.tagName).toBe("BUTTON");
-			// A native button with no positive/removed tabindex keeps natural tab
-			// order — a reskin that sets tabindex to reorder or remove it breaks
-			// keyboard operability. tabIndex is 0 for an untouched native button.
+			// 0 is the value of an untouched native button; anything else means a reskin
+			// reordered or removed the tab stop.
 			expect(btn.tabIndex).toBe(0);
 		}
 	});
@@ -203,8 +186,8 @@ describe("entry-row spine — keyboard order & operability", () => {
 				<CountToggle aria-label="beğen" onClick={onToggle} />
 			</>,
 		);
-		// Native <button> semantics carry Enter/Space activation; a click stands in
-		// for the activation a keyboard user triggers on a focused button.
+		// A click stands in for the Enter/Space activation native <button> semantics give
+		// a keyboard user on a focused button.
 		fireEvent.click(getByText("gönder"));
 		fireEvent.click(getByLabelText("beğen"));
 		expect(onBtn).toHaveBeenCalledOnce();
@@ -247,10 +230,8 @@ describe("entry-row spine — keyboard order & operability", () => {
 });
 
 describe("entry-row spine — prefers-reduced-motion respect", () => {
-	// jsdom applies no CSS and evaluates no media query, so reduced-motion is locked
-	// at its single load-bearing SOURCE site: the one global reset that neutralizes
-	// every primitive's animation/transition (WCAG 2.3.3). Removing it strips
-	// reduced-motion handling from the whole entry-row shell — this goes red.
+	// Locked at the source rather than the render: the one global reset covers every
+	// primitive's animation/transition (WCAG 2.3.3).
 	it("global.css carries the universal prefers-reduced-motion reset over animation and transition", () => {
 		const reset = GLOBAL_CSS.match(
 			/@media\s*\(prefers-reduced-motion:\s*reduce\)\s*\{[\s\S]*?\n\}/,

--- a/apps/web/src/components/funnel/FunnelSummary.tsx
+++ b/apps/web/src/components/funnel/FunnelSummary.tsx
@@ -1,20 +1,11 @@
 /**
- * `FunnelSummary` — the conversion readout's card (#1589): the three headline rates —
- * the promotion rate (#1593), the first-contribution rate (#1591), and the vouch rate
- * (#1592) — over the two tier counts (çaylak, yazar) the founder/mod front page
- * renders. Reads the gated
- * `funnel.summary` DESTINATION (founder/mod only); a non-mod read denies the
- * invisible `UNAUTHORIZED`, caught by the page's `<Screen>`.
- *
- * a11y (#1202 baseline): each headline rate is a labelled figure (`<figure>` +
- * `<figcaption>`), and the counts are a real description list (`<dl>`) so each number
- * carries an accessible label (the term names the tier, the count is its definition);
- * the numbers are text, never color-coded; copy is lowercase Turkish.
+ * `FunnelSummary` — the conversion readout's card (#1589). Reads the gated
+ * `funnel.summary` (founder/mod only); a non-mod read denies with the invisible
+ * `UNAUTHORIZED`, caught by the page's `<Screen>`.
  */
 import {useRequest, useView, view} from "react-fate";
 import type {FunnelSummary as FunnelSummaryEntity} from "../../../worker/features/fate/views";
 
-/** `FunnelSummary` is a singleton entity (constant `id`), served by `funnel.summary`. */
 const FunnelSummaryView = view<FunnelSummaryEntity>()({
 	id: true,
 	caylakCount: true,
@@ -32,13 +23,11 @@ const funnelRequest = {
 	"funnel.summary": {view: FunnelSummaryView},
 } as const;
 
-/** Turkish thousands separator is `.` (e.g. 1.247). */
 function formatCount(n: number): string {
 	if (n < 1000) return String(n);
 	return n.toLocaleString("tr-TR");
 }
 
-/** The `[0, 1]` rate as a Turkish-locale percent with one decimal (e.g. `%12,5`). */
 function formatRate(rate: number): string {
 	return rate.toLocaleString("tr-TR", {
 		style: "percent",
@@ -47,8 +36,6 @@ function formatRate(rate: number): string {
 	});
 }
 
-/** Median time-to-promotion as a Turkish-locale day count (e.g. `12,3 gün`), or a
- * legible "henüz ölçülemiyor" when no yazar is measurable yet (`null`). */
 function formatMedianDays(medianMs: number | null): string {
 	if (medianMs === null) return "henüz ölçülemiyor";
 	const days = medianMs / MS_PER_DAY;

--- a/apps/web/src/components/karma/Karma.test.ts
+++ b/apps/web/src/components/karma/Karma.test.ts
@@ -1,8 +1,3 @@
-/**
- * The Karma atom's accessible-name contract (#1208). `karmaAriaLabel` is the
- * atom's labeling decision factored DOM-free, asserted here — the pure-extraction
- * idiom of `flagGateChild` (`apps/web/src` has no jsdom/testing-library).
- */
 import {describe, expect, it} from "vitest";
 import {karmaAriaLabel} from "./Karma";
 
@@ -12,8 +7,6 @@ describe("karmaAriaLabel — the Karma atom's accessible name", () => {
 	});
 
 	it("reads a zero-karma çaylak honestly as 0, not a placeholder", () => {
-		// AC #1208: a zero-karma çaylak shows the real number, never a "yeni üye"
-		// stand-in that contradicts it.
 		expect(karmaAriaLabel(0, undefined, "karma")).toBe("karma: 0");
 	});
 

--- a/apps/web/src/components/karma/Karma.tsx
+++ b/apps/web/src/components/karma/Karma.tsx
@@ -1,45 +1,23 @@
 /**
  * Karma — the reusable atom that surfaces a user's karma (ADR 0050,
- * `user_profile.total_karma`). One value-driven primitive every authorship-loop
- * surface shares: #1208 renders the signed-in user's own karma in the topbar
- * (`variant="inline"`) and on their own profile (`variant="stat"`), and the
- * downstream divan (#1290, "karma on others") and çaylak-status (#1291, the
- * "karma X / hedef Y" promotion bar) consume the SAME atom — `value` alone for a
- * bare karma, plus an optional `target` that switches it to the progress form.
- *
- * a11y: a visually-hidden span carries the accessible label ("karma: N" /
- * "karma: N / M") while the visual readout + bar are `aria-hidden`, so a screen
- * reader hears the label once, never a doubled "karma karma". State is carried by
- * the number + the "karma" text, never color alone; all colors are AA-contrast
- * role tokens; the bar's fill transition is neutralized by the global
- * prefers-reduced-motion reset (styles/global.css).
+ * `user_profile.total_karma`). The visual readout and bar are `aria-hidden`
+ * behind one visually-hidden label, so a screen reader hears "karma" once
+ * instead of twice.
  */
 import "./Karma.css";
 
 export interface KarmaProps {
-	/** The karma value to surface — `user_profile.total_karma`. 0 (a çaylak) and negatives are valid. */
+	/** 0 (a çaylak) and negatives are valid karma values. */
 	readonly value: number;
-	/**
-	 * Optional promotion target. When provided, the atom renders the
-	 * "value / target" progress form (the çaylak→yazar bar, #1291) — a `<progress>`
-	 * plus the "X / Y" readout — instead of the bare karma number.
-	 */
+	/** Present ⇒ the "value / target" progress form (the çaylak→yazar bar, #1291). */
 	readonly target?: number;
-	/** Visual density: "inline" packs into the topbar; "stat" matches a profile stat block. */
 	readonly variant?: "inline" | "stat";
-	/** The label noun; defaults to "karma" (a lowercase Turkish brand noun). */
 	readonly label?: string;
-	/** Test handle; defaults to "karma". Override so two on-page instances stay distinguishable. */
 	readonly testId?: string;
 	readonly className?: string;
 }
 
-/**
- * The accessible-name string, factored DOM-free so the labeling contract — bare
- * "karma: N" vs the "karma: N / M" progress form, and the honest zero-karma
- * readout — is unit-testable without jsdom (the pure-extraction idiom of
- * `flagGateChild` / `toProfileStatsState`; `apps/web/src` has no testing-library).
- */
+/** Factored out of the component so the labeling contract is testable without a DOM. */
 export function karmaAriaLabel(value: number, target: number | undefined, label: string): string {
 	return target === undefined ? `${label}: ${value}` : `${label}: ${value} / ${target}`;
 }

--- a/apps/web/src/components/layout/PageShell.test.tsx
+++ b/apps/web/src/components/layout/PageShell.test.tsx
@@ -1,10 +1,3 @@
-/**
- * PageShell recipe (#2973, ADR 0182) — the shell names a product page's vertical zone-stack
- * once: the persistent Subnav zone on top, the routed content below. Two properties are
- * load-bearing: (1) the zones render in structural order (subnav ABOVE content) through the
- * shell, and (2) the flat element-props make an undeclared page zone a TYPE error, not a lint
- * finding — the same orphan-as-type-error guarantee SubnavShell has.
- */
 import {render, screen} from "@testing-library/react";
 import {describe, expect, it} from "vitest";
 import {PageShell} from "./PageShell";
@@ -22,11 +15,8 @@ describe("PageShell — the page zone-stack recipe (#2973)", () => {
 		const subnav = screen.getByTestId("subnav");
 		const content = screen.getByTestId("content");
 		expect(shell).toBeTruthy();
-		// Both zones live inside the shell…
 		expect(shell?.contains(subnav)).toBe(true);
 		expect(shell?.contains(content)).toBe(true);
-		// …and the subnav zone precedes the content zone in DOM order — the page anatomy is the
-		// persistent bar on top, the routed content below (DOCUMENT_POSITION_FOLLOWING = 4).
 		const order = subnav.compareDocumentPosition(content) & Node.DOCUMENT_POSITION_FOLLOWING;
 		expect(order).toBeTruthy();
 	});
@@ -47,7 +37,6 @@ describe("PageShell — the page zone-stack recipe (#2973)", () => {
 			/>,
 		);
 		const shell = container.querySelector(".kp-page-shell");
-		// The composed SubnavShell's bar is the top zone, inside the shell.
 		expect(shell?.querySelector(".kp-subnav")).toBeTruthy();
 		expect(shell?.querySelector(".kp-subnav__cta")?.contains(screen.getByTestId("cta"))).toBe(true);
 	});

--- a/apps/web/src/components/layout/PageShell.tsx
+++ b/apps/web/src/components/layout/PageShell.tsx
@@ -1,22 +1,9 @@
 import type * as React from "react";
 import "./PageShell.css";
 
-/**
- * PageShell — the recipe that names a product page's vertical zone-stack once (ADR 0182):
- * the persistent Subnav zone on top, the routed page content below. A product page is a
- * PageShell, so the subnav-plus-content shape is named once, not rebuilt as ad-hoc JSX per
- * surface. It composes `SubnavShell` as that top zone — PageShell owns the page's VERTICAL
- * anatomy (subnav above content); SubnavShell owns the bar's horizontal zones and composes
- * into the `subnav` slot.
- *
- * Same flat element-props idiom as SubnavShell — ONE `ReactNode` prop per zone — so an element
- * assigned to no declared zone has nowhere to go and is a TYPE error, closing the
- * compound-component orphan-slot class at the type level.
- */
+// A page's vertical zone-stack: subnav above content. See ADR 0182.
 export type PageShellProps = {
-	/** The persistent Subnav zone on top — a `SubnavShell` composes here (ADR 0182). */
 	subnav?: React.ReactNode;
-	/** The routed page content below the subnav (typically the router `<Outlet>`). */
 	content?: React.ReactNode;
 };
 

--- a/apps/web/src/components/layout/ProductSubnavLayout.test.tsx
+++ b/apps/web/src/components/layout/ProductSubnavLayout.test.tsx
@@ -1,13 +1,3 @@
-/**
- * The persistent product Subnav zone (#2598, placement law #2587), now composed through
- * `SubnavShell` (#2978, ADR 0182). `ProductSubnavLayout` is a pathless layout-route element
- * that renders the product's subnav above the routed Outlet; React Router keeps that layout
- * element mounted as the user moves within the product's child routes — the "persistent zone,
- * no remount" acceptance criterion, proven by DOM-node identity across a within-product nav.
- * Two further properties are asserted: the substrate renders THROUGH `SubnavShell` (spied
- * below — the shell receives the frame's `cta` as its `primaryAction` zone), and the `cta`
- * contract is preserved unchanged (it still lands in the bar's `.kp-subnav__cta` slot).
- */
 import {fireEvent, render, screen} from "@testing-library/react";
 import {Link, MemoryRouter, Route, Routes} from "react-router";
 import {beforeEach, describe, expect, it, vi} from "vitest";
@@ -73,10 +63,7 @@ describe("ProductSubnavLayout — persistent product Subnav zone (#2598)", () =>
 
 		fireEvent.click(screen.getByRole("link", {name: "detay"}));
 
-		// The routed Outlet swapped to the detail page…
 		expect(screen.getByTestId("product-detail")).toBeTruthy();
-		// …but the layout's Subnav zone is the SAME DOM node — the persistent product zone
-		// stays mounted across the product's child routes (a remount would replace the node).
 		expect(container.querySelector(".kp-subnav")).toBe(before);
 	});
 });
@@ -92,7 +79,6 @@ describe("ProductSubnavLayout — composes through SubnavShell (#2978, ADR 0182)
 				</Routes>
 			</MemoryRouter>,
 		);
-		// The bar is emitted by the shell, not by a directly-wired <Subnav>.
 		expect(subnavShellSpy).toHaveBeenCalled();
 	});
 
@@ -116,9 +102,7 @@ describe("ProductSubnavLayout — composes through SubnavShell (#2978, ADR 0182)
 				</Routes>
 			</MemoryRouter>,
 		);
-		// The frame's cta is routed to the shell's primaryAction zone (ADR 0182's one promoted verb)…
 		expect(subnavShellSpy.mock.calls[0]?.[0]?.primaryAction).toBeTruthy();
-		// …and still lands in the bar's dedicated cta slot — the pre-refactor `cta` contract, unchanged.
 		const bar = container.querySelector(".kp-subnav");
 		expect(bar?.querySelector(".kp-subnav__cta")?.contains(screen.getByTestId("cta"))).toBe(true);
 	});

--- a/apps/web/src/components/layout/ProductSubnavLayout.tsx
+++ b/apps/web/src/components/layout/ProductSubnavLayout.tsx
@@ -2,15 +2,8 @@ import type * as React from "react";
 import {Outlet} from "react-router";
 import {SubnavShell} from "./SubnavShell";
 
-/**
- * The persistent product Subnav zone (placement law #2587, epic #2596) — a pathless
- * layout-route element per product. It renders the product's subnav bar once above the
- * routed `<Outlet>`, so the zone stays mounted as the user moves within `/<product>/*`
- * (no remount between that product's routes). It composes through `SubnavShell` (ADR 0182)
- * rather than wiring `<Subnav>` directly, so any product on this generic frame inherits the
- * shell's flat element-props and the orphan-as-type-error guarantee. The substrate's `cta`
- * is the shell's `primaryAction` zone (the one promoted verb) — the pano delta #2600 fills it.
- */
+// A pathless layout route, so the bar stays mounted across a product's child routes (no
+// remount). See ADR 0182.
 export function ProductSubnavLayout({cta}: {cta?: React.ReactNode}) {
 	return (
 		<>

--- a/apps/web/src/components/layout/Subnav.test.tsx
+++ b/apps/web/src/components/layout/Subnav.test.tsx
@@ -1,9 +1,3 @@
-/**
- * The Subnav CTA slot (#2598, placement law #2587) — the dedicated primary-action
- * position. A passed `cta` node renders in `.kp-subnav__cta`; absent, nothing renders. The
- * slot positions only — it never wraps the node in the utility filter/tab treatment
- * (`.kp-subnav__filter`), per the #2586 taxonomy / #2590 IA rule.
- */
 import {readFileSync} from "node:fs";
 import {fileURLToPath} from "node:url";
 import {render, screen} from "@testing-library/react";
@@ -29,8 +23,6 @@ describe("Subnav CTA slot (#2598)", () => {
 		const slot = container.querySelector(".kp-subnav__cta");
 		expect(slot).toBeTruthy();
 		expect(screen.getByTestId("cta-btn")).toBeTruthy();
-		// The CTA is NOT styled as a utility filter/tab — the slot carries no filter class,
-		// and the substrate paints no filter treatment anywhere on a CTA-only Subnav.
 		expect(slot?.querySelector(".kp-subnav__filter")).toBeNull();
 		expect(container.querySelector(".kp-subnav__filter")).toBeNull();
 	});

--- a/apps/web/src/components/layout/Subnav.tsx
+++ b/apps/web/src/components/layout/Subnav.tsx
@@ -32,12 +32,8 @@ export function Subnav({
 	activeFilter?: string;
 	onFilterChange?: (id: string) => void;
 	links?: SubnavLink[];
-	// Zone slots for the SubnavShell recipe (ADR 0182): `leading` is the context/crumb zone
-	// and `destinations` is the single sub-destinations/filters zone the consumer composes
-	// its route-links or stateful buttons inside. `destinations` renders INSIDE the bar's
-	// filters row — the structural fix for sözlük's orphaned alphabet, which had rendered as
-	// a detached sibling of the bar. Additive over the older typed `filters`/`links` arrays;
-	// the #2973–#2978 migration moves consumers onto these zones.
+	// Zone slots for the SubnavShell recipe, additive over the older `filters`/`links` arrays
+	// the #2973–#2978 migration moves consumers off. See ADR 0182.
 	leading?: React.ReactNode;
 	destinations?: React.ReactNode;
 	crumb?: {label: React.ReactNode; onClear?: () => void};
@@ -49,11 +45,6 @@ export function Subnav({
 	// #2586 taxonomy / #2590 IA rule). Absent ⇒ nothing renders.
 	input?: React.ReactNode;
 	meta?: React.ReactNode;
-	// The primary-action slot (placement law #2587): a product's promoted verb (pano/yeni,
-	// mecmua yaz) renders here in the dedicated primary-action position. The passed node
-	// carries the sanctioned primary-action treatment itself (the `Button` primitive's
-	// `primary` variant per the #2586 taxonomy) — the slot only positions it, never the
-	// utility filter/tab treatment (#2590). Absent ⇒ nothing renders.
 	cta?: React.ReactNode;
 }) {
 	return (

--- a/apps/web/src/components/layout/SubnavShell.test.tsx
+++ b/apps/web/src/components/layout/SubnavShell.test.tsx
@@ -1,9 +1,3 @@
-/**
- * SubnavShell recipe (#2972, ADR 0182) — the shell owns the whole bar, filters row included.
- * Two properties are load-bearing: (1) the sub-destinations zone renders INSIDE the bar (no
- * detached sibling row — the structural fix for sözlük's orphaned alphabet), and (2) the flat
- * element-props make a single-orphan-slot composition a TYPE error, not a lint finding.
- */
 import {render, screen} from "@testing-library/react";
 import {describe, expect, it} from "vitest";
 import {SubnavShell} from "./SubnavShell";
@@ -22,9 +16,7 @@ describe("SubnavShell — the shell owning the whole bar (#2972)", () => {
 		const bar = container.querySelector(".kp-subnav");
 		const alphabet = screen.getByTestId("alphabet");
 		expect(bar).toBeTruthy();
-		// The composed destinations node lives INSIDE the bar (a detached sibling would fail this)…
 		expect(bar?.contains(alphabet)).toBe(true);
-		// …specifically inside the filters row, where the sub-destinations zone belongs.
 		expect(bar?.querySelector(".kp-subnav__filters")?.contains(alphabet)).toBe(true);
 		// It is not the shell's direct sibling — there is no "next to the bar" row to orphan into.
 		expect(container.firstElementChild).toBe(bar);

--- a/apps/web/src/components/layout/SubnavShell.tsx
+++ b/apps/web/src/components/layout/SubnavShell.tsx
@@ -1,38 +1,15 @@
 import type * as React from "react";
 import {Subnav} from "./Subnav";
 
-/**
- * SubnavShell — the blessed shell that owns the whole subnav bar, filters row included.
- *
- * A `recipe` over the `Subnav` primitive that exposes ADR 0176's nav-zone grammar as
- * flat element-props — ONE `ReactNode` prop per zone (ADR 0182). The flat shape is the
- * make-invalid-states-unrepresentable payoff: an element assigned to no declared zone has
- * nowhere to go and is a TYPE error, closing the compound-component orphan-slot class (an
- * element rendered but placed nowhere, detectable only by lint) at the type level — sözlük's
- * alphabet becomes `destinations={…}` inside the bar, never a detached sibling of it.
- *
- * `utility` is deliberately OMITTED (ADR 0182, YAGNI) — re-introducing it is an explicit law
- * change, never a quietly-discovered gap.
- */
+// One ReactNode prop per zone, and `utility` is deliberately omitted — adding it back is a law
+// change, not a gap to fill. See ADR 0182.
 export type SubnavShellProps = {
-	/** Context / crumb zone (e.g. pano's site/host crumb). */
 	leading?: React.ReactNode;
-	/**
-	 * The single sub-destinations zone. The consumer composes the route-links OR stateful
-	 * buttons (mecmua tabs / pano chips / divan sections / sözlük alphabet) inside this one
-	 * node; the shell renders it INSIDE the bar, so there is no "next to the bar" slot to
-	 * orphan into.
-	 */
 	destinations?: React.ReactNode;
-	/** The ONE promoted verb (mecmua / pano). Absent for divan and sözlük is normal, not a gap. */
 	primaryAction?: React.ReactNode;
-	/** Meta / count zone (e.g. pano's `N başlık`). */
 	signal?: React.ReactNode;
 };
 
 export function SubnavShell({leading, destinations, primaryAction, signal}: SubnavShellProps) {
-	// Map the four zones onto the wrapped primitive's slots — `primaryAction`→`cta`,
-	// `signal`→`meta` (ADR 0182's count→signal merge). No consumer touches `Subnav`'s slots
-	// directly; they go through these four zones.
 	return <Subnav leading={leading} destinations={destinations} cta={primaryAction} meta={signal} />;
 }

--- a/apps/web/src/components/layout/ThemeChoicePicker.test.tsx
+++ b/apps/web/src/components/layout/ThemeChoicePicker.test.tsx
@@ -29,8 +29,6 @@ describe("ThemeChoicePicker (#2612)", () => {
 	it("ignores a deselect click on the active option — one choice is always set", () => {
 		const onChange = vi.fn();
 		render(<ThemeChoicePicker choice="dark" onChange={onChange} testId="tp" />);
-		// Clicking the already-active option would empty a Toggle track's value; the
-		// picker drops that so it never resolves to "no theme".
 		fireEvent.click(screen.getByRole("radio", {name: "koyu"}));
 		expect(onChange).not.toHaveBeenCalled();
 	});

--- a/apps/web/src/components/layout/Topbar.test.tsx
+++ b/apps/web/src/components/layout/Topbar.test.tsx
@@ -1,9 +1,3 @@
-/**
- * Nav-IA topbar zone grammar + taxonomy classing (#2611, epic #2595). Pins the structural
- * spine the tema/status/accent-scarcity children (#2612–#2614) build on: every element sits
- * in its one lawful taxonomy zone (destination / utility / status-signal / primary-action,
- * #2586/#2587), each zone stably classed + testid'd.
- */
 import {readFileSync} from "node:fs";
 import {fileURLToPath} from "node:url";
 import {fireEvent, render, screen, waitFor, within} from "@testing-library/react";
@@ -30,13 +24,10 @@ describe("Topbar nav-IA zone grammar (#2611)", () => {
 		const destination = screen.getByTestId("topbar-zone-destination");
 		const utility = screen.getByTestId("topbar-zone-utility");
 		const statusSignal = screen.getByTestId("topbar-zone-status-signal");
-		// The zone class is present on each zone (the headless targeting contract).
 		expect(destination.classList.contains("kp-topbar__zone")).toBe(true);
 		expect(destination.classList.contains("kp-topbar__zone--destination")).toBe(true);
 		expect(utility.classList.contains("kp-topbar__zone--utility")).toBe(true);
 		expect(statusSignal.classList.contains("kp-topbar__zone--status-signal")).toBe(true);
-		// destination = product-noun nav; utility = the ambient search control;
-		// status-signal = the read-only karma + divan affordances.
 		expect(destination.contains(screen.getByRole("link", {name: "sözlük"}))).toBe(true);
 		expect(destination.contains(screen.getByRole("link", {name: "pano"}))).toBe(true);
 		expect(utility.contains(screen.getByRole("textbox", {name: "Ara"}))).toBe(true);
@@ -104,9 +95,6 @@ describe("Topbar accent-scarcity containment law (#2614)", () => {
 	});
 
 	it("no taxonomy zone (utility / status-signal / destination) paints an accent fill", () => {
-		// The accent budget is reserved for the promoted primary action alone; the non-CTA
-		// zones carry neutral role tokens only. (The primary-action zone is empty post-#2600,
-		// so today the reclassed topbar renders zero accent fills.)
 		for (const r of rules.filter((r) => ACCENT_FILL.test(r.body))) {
 			expect(r.selector).not.toMatch(/kp-topbar__zone--(utility|status-signal|destination)/);
 		}
@@ -194,16 +182,10 @@ describe("Topbar status/signal zone (#2613)", () => {
 	it("the unread bildirim renders an INTERACTIVE bell in the status zone, not a bare number (#2787)", () => {
 		const {container} = renderStatus({bildirim: {to: "/bildirimler", unread: 3}});
 		const signal = screen.getByTestId("topbar-bildirim-badge");
-		// Lives in the status-signal zone, not on the user-menu trigger.
 		expect(screen.getByTestId("topbar-zone-status-signal").contains(signal)).toBe(true);
 		expect(container.querySelector(".kp-topbar__user")?.contains(signal)).toBe(false);
-		// A drawn Lucide bell (an <svg>), so the count reads as "unread notifications", not a
-		// bare number; the count text is still present and the accessible name carries it.
 		expect(signal.querySelector("svg")).not.toBeNull();
 		expect(signal.textContent).toContain("3");
-		// #2787 evolves the display-only status bell into a disclosure button: it is now an
-		// interactive popover trigger (aria-haspopup/expanded), and the unread count stays its
-		// accessible name (ADR 0166). The live announcement moves to a sibling role="status".
 		expect(signal.tagName).toBe("BUTTON");
 		expect(signal.getAttribute("aria-haspopup")).toBe("dialog");
 		expect(signal.getAttribute("aria-expanded")).toBe("false");
@@ -221,7 +203,6 @@ describe("Topbar status/signal zone (#2613)", () => {
 		renderStatus({});
 		const karma = screen.getByTestId("topbar-karma");
 		expect(screen.getByTestId("topbar-zone-status-signal").contains(karma)).toBe(true);
-		// A read-only glyph, never a control: not rendered as (nor wrapped by) a button/link.
 		expect(karma.tagName).toBe("SPAN");
 		expect(karma.closest("button")).toBeNull();
 		expect(karma.closest("a")).toBeNull();
@@ -232,8 +213,6 @@ describe("Topbar status/signal zone (#2613)", () => {
 		const divan = screen.getByTestId("topbar-divan-link");
 		expect(screen.getByTestId("topbar-zone-status-signal").contains(divan)).toBe(true);
 		expect(divan.classList.contains("kp-topbar__signal-link")).toBe(true);
-		// A drawn glyph, not a text peer-noun — an <svg>, with "divan" carried as the link's
-		// accessible name so it stays discoverable without reading as a destination noun.
 		expect(divan.querySelector("svg")).not.toBeNull();
 		expect(screen.getByRole("link", {name: "divan"})).toBe(divan);
 	});
@@ -272,14 +251,10 @@ describe("Topbar tema toggle → theme picker (#2612)", () => {
 				/>
 			</MemoryRouter>,
 		);
-		// The Manti popover is portaled — open it, then the tema row appears.
 		fireEvent.click(screen.getByText("Elif"));
-		// `ayarlar` sits directly above the tema row. The panel's rows are real links,
-		// not menuitems: UserMenu is a Popover so the picker can keep radio semantics.
 		expect(await screen.findByRole("link", {name: "ayarlar"})).toBeTruthy();
 		const row = await screen.findByTestId("topbar-theme-row");
 		expect(row.textContent).toContain("tema");
-		// The active choice is a real aria-checked radio, not a ✓ glyph on a command.
 		const picker = within(row).getByTestId("topbar-theme-picker");
 		for (const label of ["açık", "koyu", "otomatik"]) {
 			expect(within(picker).getByRole("radio", {name: label})).toBeTruthy();
@@ -300,7 +275,6 @@ describe("Topbar tema toggle → theme picker (#2612)", () => {
 			/kp-theme-picker/.test(r.selector),
 		);
 		expect(rule).toBeDefined();
-		// A density token, not a pinned px — it must ride compact/normal/spacious.
 		expect(rule?.body).toMatch(/min-height:\s*var\(--letter-size\)/);
 		// Unscoped to either host (no .kp-topbar / .kp-user-menu prefix), and specific enough
 		// to beat ToggleGroup.css's own 0-2-0 item rule without depending on import order.
@@ -354,11 +328,7 @@ describe("Topbar tema toggle → theme picker (#2612)", () => {
 	});
 });
 
-// Reserved signed-in account slot (#2933, ADR 0179 §1). `reserveSignedInSlots` (driven by
-// `__BOOT__.user != null` in the shell frame, ADR 0185) reserves the account cluster's geometry at
-// first paint: with no `user` yet it renders a fixed-geometry placeholder in the account slot, so
-// when fate publishes the real user menu it fills the same slot with zero cluster shift — no
-// giriş-yap↔user-cluster swap, no empty→pop. Off ⇒ the slot stays null (today's render).
+// See ADR 0179 §1 and ADR 0185.
 describe("Topbar reserved signed-in account slot (#2933)", () => {
 	function renderReserved(props: Partial<Parameters<typeof Topbar>[0]>) {
 		return render(
@@ -371,31 +341,24 @@ describe("Topbar reserved signed-in account slot (#2933)", () => {
 	it("reserve on, no user: renders a fixed-geometry account placeholder (inert, not a control)", () => {
 		renderReserved({reserveSignedInSlots: true});
 		const placeholder = screen.getByTestId("topbar-user-placeholder");
-		// Reuses the `.kp-topbar__user` box so the real menu swaps in with no geometry change.
 		expect(placeholder.classList.contains("kp-topbar__user")).toBe(true);
 		expect(placeholder.classList.contains("kp-topbar__user--placeholder")).toBe(true);
-		// A stand-in, never a control: not a button, hidden from assistive tech.
 		expect(placeholder.tagName).toBe("SPAN");
 		expect(placeholder.getAttribute("aria-hidden")).toBe("true");
 		expect(placeholder.closest("button")).toBeNull();
-		// No real user menu yet — the account cluster is reserved, not filled.
 		expect(screen.queryByRole("button", {name: /Elif/})).toBeNull();
 	});
 
 	it("reserve on → user arrives: the placeholder is replaced by the real menu in the SAME account slot (zero cluster shift)", () => {
 		const {container, rerender} = renderReserved({reserveSignedInSlots: true});
 		const header = container.querySelector(".kp-topbar");
-		// The account slot is the header's last child; before fate it holds the placeholder.
 		expect(header?.lastElementChild).toBe(screen.getByTestId("topbar-user-placeholder"));
 
-		// Fate publishes the real user: same reservation, now a real user prop.
 		rerender(
 			<MemoryRouter>
 				<Topbar nav={NAV} reserveSignedInSlots user={{name: "Elif", username: "elif"}} />
 			</MemoryRouter>,
 		);
-		// The placeholder is gone and the real menu trigger occupies the SAME last-child slot —
-		// content filled in place, the cluster position never moved (the AC-4 no-shift proof).
 		expect(screen.queryByTestId("topbar-user-placeholder")).toBeNull();
 		const trigger = container.querySelector(".kp-topbar__user");
 		expect(trigger?.textContent).toContain("Elif");

--- a/apps/web/src/components/layout/Topbar.tsx
+++ b/apps/web/src/components/layout/Topbar.tsx
@@ -35,54 +35,16 @@ export function Topbar({
 	brandName?: string;
 	brandTo?: string;
 	nav?: NavItem[];
-	/**
-	 * The yazar/mod-only divan entry's href (#1290). Rendered only when set — the
-	 * Layout passes it solely when the server granted divan access (yazar OR mod), so
-	 * it is invisible to çaylak/visitor. Kept distinct from `nav` so the gated entry
-	 * never leaks into the always-on nav list.
-	 */
 	divanTo?: string;
-	/** `username` drives the @username link; null means the bootstrap CTA. */
 	user?: {name: string; src?: string; username?: string | null};
-	/**
-	 * The signed-in user's ambient self-karma (#1208). Rendered only when present —
-	 * `undefined` for a signed-out viewer, whose topbar carries no karma.
-	 */
 	karma?: number;
-	/**
-	 * The bildirim entry (#1694). Rendered only when set — the Layout passes it
-	 * solely when the `phoenix-bildirim` flag is on AND the viewer is signed in,
-	 * so with the flag off (the dark default) the topbar is exactly as before.
-	 * The unread signal renders only when `unread > 0`, as the status-zone bell (#2613).
-	 */
 	bildirim?: {to: string; unread: number};
 	actions?: React.ReactNode;
-	/**
-	 * The active search query to echo in the header input on the results page
-	 * (#2199) — seeded from the URL `q` by the Layout only on `/search`, empty
-	 * elsewhere. It keys an uncontrolled `defaultValue` (below), so the field
-	 * stays freely editable and a query→query navigation re-seeds it.
-	 */
 	searchQuery?: string;
 	onSearchSubmit?: (query: string) => void;
-	/**
-	 * The current theme selection + its setter, driving the three-way theme picker
-	 * (light/dark/auto) — the sole theme control (#2612). The picker renders in the user
-	 * menu for a signed-in visitor and in the utility zone for a signed-out one, so every
-	 * visitor keeps exactly one theme control.
-	 */
 	themeChoice?: ThemeChoice;
 	onThemeChange?: (choice: ThemeChoice) => void;
 	onLogout?: () => void;
-	/**
-	 * Reserve the signed-in account cluster's geometry at first paint (#2933, ADR 0179 §1).
-	 * Driven by `__BOOT__.user != null` (`readBootUser`, ADR 0185) in the shell frame: when the
-	 * edge resolved a signed-in session, the account slot holds its geometry from the first frame.
-	 * With `__BOOT__.user` present the shell also seeds the real `user` chip synchronously, so the
-	 * cluster paints its content immediately rather than a placeholder; this placeholder covers the
-	 * residual reserve-without-content window (a boot/session divergence). False (absent `__BOOT__`
-	 * / signed-out) ⇒ the account slot stays null until `user` arrives — today's conditional render.
-	 */
 	reserveSignedInSlots?: boolean;
 }) {
 	// ⌘K (mac) / Ctrl+K (other) focuses search, backing the <Kbd>⌘K</Kbd> hint below.
@@ -101,8 +63,6 @@ export function Topbar({
 	const before = dotAt >= 0 ? brandName.slice(0, dotAt) : brandName;
 	const after = dotAt >= 0 ? brandName.slice(dotAt + 1) : "";
 
-	// The topbar's leaf elements, built once and placed into their zones below — one node
-	// each, never a second drifting copy of the search form or user menu.
 	const brand = (
 		<Link className="kp-topbar__brand" to={brandTo}>
 			{before}
@@ -116,11 +76,8 @@ export function Topbar({
 			{n.label}
 		</NavLink>
 	));
-	// Under the zone grammar divan is a status/signal glyph (#2613): a gated signal, not a
-	// peer product noun, so it sits in the status zone rather than `.kp-topbar__nav` and reads
-	// as the canonical Gavel icon (ADR 0166) under an accessible "divan" name, carrying the
-	// `kp-topbar__signal-link` treatment (grouped in the CSS). Null when the caller passes no
-	// `divanTo` — the access probe (#1290) withholds it from a viewer without divan access.
+	// divan is a status glyph, not a peer product noun, so it belongs in the status zone and not
+	// `.kp-topbar__nav`. See ADR 0176 for the zone law, ADR 0166 for the icon.
 	const divanLink = divanTo ? (
 		<NavLink
 			key={divanTo}
@@ -164,9 +121,6 @@ export function Topbar({
 			/>
 		</form>
 	);
-	// The three-way theme picker (#2612) — the sole theme control. Signed-in ⇒ it lives in
-	// the user menu next to `ayarlar`; signed-out ⇒ in the utility zone, so exactly one
-	// renders either way. Null unless the caller wires both halves of the controlled pair.
 	const themePicker =
 		themeChoice && onThemeChange ? (
 			<ThemeChoicePicker
@@ -179,12 +133,6 @@ export function Topbar({
 		typeof karma === "number" ? (
 			<Karma value={karma} variant="inline" testId="topbar-karma" className="kp-topbar__karma" />
 		) : null;
-	// The unread bildirim signal in the status zone (#2613), now an INTERACTIVE bell that
-	// opens an in-place popover of recent bildirimler (#2787) — the near-universal
-	// bell→dropdown pattern, with the full `/bildirimler` page kept as the "tümünü gör"
-	// destination. The count is still the trigger's accessible name (ADR 0166). Same render
-	// rule as before — only when the `phoenix-bildirim` flag put a `bildirim` here AND
-	// unread > 0.
 	const bildirimSignal =
 		bildirim && showUnreadBadge(bildirim.unread) ? (
 			<BildirimPopover to={bildirim.to} unread={bildirim.unread} />
@@ -198,11 +146,8 @@ export function Topbar({
 			onLogout={onLogout}
 		/>
 	) : null;
-	// The account slot: the real user menu once fate publishes it, else — when `__BOOT__`
-	// reserved a signed-in first paint — a fixed-geometry placeholder that holds the slot open
-	// so the menu late-fills in place with no shift (#2933). Mirrors `.kp-topbar__user`'s box
-	// (avatar + name) and is inert (aria-hidden, not a control). Signed-out / no reservation ⇒
-	// null, exactly today's render.
+	// The placeholder holds the account slot's geometry until fate publishes the real user, so
+	// the menu fills in place with no shift. See ADR 0179 §1 and ADR 0185.
 	const accountSlot =
 		userMenu ??
 		(reserveSignedInSlots ? (
@@ -216,15 +161,8 @@ export function Topbar({
 			</span>
 		) : null);
 
-	// Nav-IA zone grammar (#2611): every element is classed by the #2586 taxonomy and
-	// placed in its one lawful zone (#2587 Model-2). Zones carry a stable class +
-	// data-testid so the structure is headlessly targetable; brand + account (actions /
-	// user menu) are the structural spine, not a taxonomy class. The primary-action zone
-	// is empty/reserved — #2600 relocated the promoted `+ gönderi` verb to the pano
-	// Subnav CTA, so no product-scoped occupant lives in the global bar (it does not
-	// re-add one). The status-signal zone carries the read-only signals reworked in #2613:
-	// the divan glyph, the karma glyph, and the bildirim bell — each a legible affordance in
-	// its lawful zone, none a control or accent.
+	// Every element sits in its one lawful zone (see ADR 0176). The primary-action zone is
+	// empty on purpose — #2600 moved `+ gönderi` to the pano Subnav CTA; do not refill it.
 	return (
 		<header className="kp-topbar">
 			{brand}

--- a/apps/web/src/components/layout/UserMenu.test.tsx
+++ b/apps/web/src/components/layout/UserMenu.test.tsx
@@ -21,7 +21,6 @@ const USER_MENU_CSS = readSource("./UserMenu.css");
 const GLOBAL_CSS = readSource("../../styles/global.css");
 const BUTTON_CSS = readSource("../ui/Button.css");
 
-// The Manti popover panel is portaled and mounts a tick after the trigger click.
 async function openMenu() {
 	render(
 		<MemoryRouter>
@@ -47,13 +46,11 @@ describe("UserMenu row box", () => {
 		expect(logout.tagName).toBe("BUTTON");
 		expect(logout.getAttribute("data-scope")).toBe("button");
 		expect(logout.getAttribute("data-part")).toBe("root");
-		// It still wears the shared row box, so it is indistinguishable from its link siblings.
 		expect(logout.classList.contains("kp-user-menu__item")).toBe(true);
 		expect(logout.classList.contains("kp-user-menu__item--action")).toBe(true);
 		expect(USER_MENU_CSS).toMatch(/\.kp-user-menu__item\s*\{[^}]*padding:\s*0 var\(--s-3\)/);
 	});
 
-	// One hover for both row types, and it has to outrank two separate globals to exist at all.
 	it("the row hover outranks the tertiary-variant hover and drops the a:hover underline", () => {
 		const hoverRule = USER_MENU_CSS.match(
 			/\.kp-user-menu__popup\s+\.kp-user-menu__item:hover:not\(:disabled\)\s*\{([^}]*)\}/,

--- a/apps/web/src/components/layout/UserMenu.tsx
+++ b/apps/web/src/components/layout/UserMenu.tsx
@@ -33,7 +33,6 @@ export function UserMenu({
 	onLogout,
 }: {
 	user: {name: string; src?: string; username?: string | null};
-	/** Present only when the `phoenix-bildirim` flag put a bildirim entry in the topbar. */
 	bildirim?: {to: string};
 	themeChoice?: ThemeChoice;
 	onThemeChange?: (choice: ThemeChoice) => void;

--- a/apps/web/src/components/mecmua/MecmuaPostBody.tsx
+++ b/apps/web/src/components/mecmua/MecmuaPostBody.tsx
@@ -1,15 +1,8 @@
 import {ReadOnlyComposer} from "@kampus/composer";
 
-/**
- * The mecmua reader's body — the published post's stored markdown rendered through
- * `@kampus/composer` in read-only mode (#2581): the reader is the editor with editing switched
- * off (the Medium/Notion editor≈reader parity), so write and read share ONE tiptap render path
- * and can't re-diverge (the two-render-path bug #2578, superseding its bespoke-renderer fix).
- *
- * This module is the tiptap-import boundary: `MecmuaPostPage` `React.lazy`-loads it so tiptap
- * (~156kB gz) stays OFF mecmua public first-paint (the #2523 editor lazy-split, applied to the
- * reader). Default export so `React.lazy(() => import(...))` resolves the component directly.
- */
+// The tiptap-import boundary: `MecmuaPostPage` `React.lazy`-loads this module so tiptap
+// (~156kB gz) stays off mecmua's public first paint (#2523). Default export so
+// `React.lazy(() => import(...))` resolves the component directly.
 export default function MecmuaPostBody({body}: {body: string}) {
 	return <ReadOnlyComposer content={body} className="kp-prose" />;
 }

--- a/apps/web/src/components/mecmua/MecmuaSubnavCta.test.tsx
+++ b/apps/web/src/components/mecmua/MecmuaSubnavCta.test.tsx
@@ -1,11 +1,3 @@
-/**
- * mecmua's primary action in its Subnav CTA slot (#2603, placement law #2587). Pins the
- * gate-parity halves: (1) a yazar with the write flag live reaches `/mecmua/yaz` through the
- * CTA (reachability, verified by actually routing there on click) and sees the sanctioned
- * primary-action treatment; (2) a non-yazar / signed-out / flag-off viewer gets no CTA —
- * the CTA rides the exact {@link shouldShowMecmuaWriteCta} gate the editor does, so it never
- * dead-ends a viewer into a page they'd be publish-gated on.
- */
 import {fireEvent, render, screen} from "@testing-library/react";
 import {MemoryRouter, Route, Routes} from "react-router";
 import {afterEach, describe, expect, it, vi} from "vitest";
@@ -47,7 +39,6 @@ describe("MecmuaSubnavCta — mecmua primary action in the Subnav CTA slot (#260
 		writeFlag = true;
 		renderCta();
 		const cta = screen.getByRole("button", {name: "yeni yazı"});
-		// Sanctioned primary-action treatment (#2586 taxonomy), not the utility filter/tab style.
 		expect(cta.getAttribute("data-variant")).toBe("primary");
 		expect(screen.queryByTestId("mecmua-editor")).toBeNull();
 		fireEvent.click(cta);

--- a/apps/web/src/components/mecmua/MecmuaSubnavCta.tsx
+++ b/apps/web/src/components/mecmua/MecmuaSubnavCta.tsx
@@ -8,15 +8,6 @@ import {useFlag} from "../../flags/useFlag";
 import {shouldShowMecmuaWriteCta} from "../../pages/mecmua-write-gate";
 import {Button} from "../ui/Button";
 
-/**
- * mecmua's primary action in its Subnav CTA slot (placement law #2587, epic #2596): the
- * promoted "yeni yazı" verb, hosted in the mecmua product zone rather than duplicated as
- * in-page buttons (the #2603 CTA de-dup). Shown exactly when the editor would accept the
- * author — the shared {@link shouldShowMecmuaWriteCta} gate (MECMUA_WRITE live + yazar
- * tier, #2532) — so it never dead-ends a çaylak/visitor into a page they'd be publish-
- * gated on. Renders the sanctioned primary-action treatment (`Button` `primary` variant,
- * #2586 taxonomy), never the utility filter/tab styling.
- */
 export function MecmuaSubnavCta() {
 	const session = useSession();
 	const {me} = useMe();

--- a/apps/web/src/components/mecmua/MecmuaSubnavLayout.test.tsx
+++ b/apps/web/src/components/mecmua/MecmuaSubnavLayout.test.tsx
@@ -1,12 +1,3 @@
-/**
- * mecmua's persistent product Subnav zone (#2603, placement law #2587). Pins three things:
- * (1) the zone is a persistent layout — its `.kp-subnav` node survives a within-mecmua
- * navigation (no remount); (2) each destination is flag-composed on the SAME seam its
- * route self-gates on, so a link never points at a dark 404 — keşfet on mecmua-public-read,
- * akış on mecmua-feed, yazılarım on the write path (yazar-gated, #2579's missing home);
- * (3) after the SubnavShell migration (ADR 0182), the destinations render INSIDE the bar's
- * sub-destinations zone and the CTA inside the primary-action zone — behavior unchanged.
- */
 import {fireEvent, render, screen} from "@testing-library/react";
 import {Link, MemoryRouter, Route, Routes} from "react-router";
 import {afterEach, describe, expect, it, vi} from "vitest";
@@ -125,8 +116,6 @@ describe("MecmuaSubnavLayout — mecmua product Subnav zone (#2603)", () => {
 		expect(screen.queryByRole("link", {name: "yazılarım"})).toBeNull();
 	});
 
-	// Zone-through-shell (ADR 0182): the destinations fill the shell's one sub-destinations
-	// zone (inside the bar, never a detached sibling) and the CTA fills the primary-action zone.
 	it("renders the destinations INSIDE the shell's sub-destinations zone — no detached sibling", () => {
 		flags.read = true;
 		const {container} = renderZone();

--- a/apps/web/src/components/mecmua/MecmuaSubnavLayout.tsx
+++ b/apps/web/src/components/mecmua/MecmuaSubnavLayout.tsx
@@ -8,20 +8,9 @@ import type {SubnavLink} from "../layout/Subnav";
 import {SubnavShell} from "../layout/SubnavShell";
 import {MecmuaSubnavCta} from "./MecmuaSubnavCta";
 
-/**
- * mecmua's persistent product Subnav zone (placement law #2587, epic #2596) — the pathless
- * layout-route element that hosts mecmua's product destinations + its primary action, so
- * they live in the product zone instead of leaking into the global topbar (#2603). Composes
- * through `SubnavShell` (ADR 0182): the destination links fill the one `destinations` zone,
- * the CTA the `primaryAction` zone.
- *
- * Each destination is composed on the SAME flag its route/page self-gates on, so a link
- * never points at a dark 404 (the #2547 "never a dead link" rule): keşfet (the public index)
- * on `mecmua-public-read`, akış (the subscribed-author feed) on `mecmua-feed`, yazılarım
- * (the author's own drafts, #2579's missing home) on the write path. yazılarım rides the
- * same {@link shouldShowMecmuaWriteCta} gate as the CTA (yazar + write live) — gate parity
- * with the editor keeps a çaylak/visitor out of an author-scoped page they can't write to.
- */
+// mecmua's product Subnav zone, composed through `SubnavShell` — see ADR 0182.
+// Each destination rides the SAME flag its route self-gates on, so a link never points at
+// a dark 404 (#2547); yazılarım rides the editor's gate for the same reason.
 export function MecmuaSubnavLayout() {
 	const session = useSession();
 	const {me} = useMe();
@@ -40,8 +29,6 @@ export function MecmuaSubnavLayout() {
 				destinations={
 					links.length
 						? links.map((l) => (
-								// NavLink sets aria-current="page" on the active route; the filter treatment is
-								// the utility tab styling (#2586 taxonomy), never the primary-action treatment.
 								<NavLink key={l.to} to={l.to} end={l.end} className="kp-subnav__filter">
 									{l.label}
 								</NavLink>

--- a/apps/web/src/components/mecmua/MecmuaSubscribeButton.test.tsx
+++ b/apps/web/src/components/mecmua/MecmuaSubscribeButton.test.tsx
@@ -1,9 +1,3 @@
-/**
- * The mecmua subscribe toggle's label contract (#2527): not-following ⇒ "abone ol";
- * following ⇒ "takip ediliyor", swapping to "bırak" on hover/focus so the unsubscribe
- * intent reads honestly. Tests the pure `mecmuaSubscribeLabel` core (DOM-free), the way
- * `mecmuaPublishAffordance` is tested.
- */
 import {describe, expect, it} from "vitest";
 import {mecmuaSubscribeLabel} from "./MecmuaSubscribeButton";
 

--- a/apps/web/src/components/mecmua/MecmuaSubscribeButton.tsx
+++ b/apps/web/src/components/mecmua/MecmuaSubscribeButton.tsx
@@ -1,16 +1,5 @@
-/**
- * The mecmua "abone ol / takip ediliyor" subscribe toggle (#2527, epic #2467) — the
- * missing entry point that lets a reader follow a post's author so the subscribed-author
- * feed (#2500) can populate through the product. Rendered on the post reader
- * (`pages/MecmuaPostPage`); wired to the existing `mecmua.subscribe` / `mecmua.unsubscribe`
- * mutations, with the current edge state read off the `mecmuaSubscription` root.
- *
- * Gating mirrors the mutations exactly (`CurrentUser.required`, behind `MECMUA_FEED`):
- * signed-in only — subscribing is not tier-gated (a çaylak may follow), unlike publishing.
- * The toggle only renders when the feed flag is on AND the reader is signed in AND the
- * author isn't the reader themselves, so it appears exactly where it can act. The whole
- * surface stays dark until a human flips `MECMUA_FEED` at release (ADR 0083).
- */
+// Gating mirrors the mutations: signed-in only, NOT tier-gated (a çaylak may follow),
+// unlike publishing. Dark until a human flips `MECMUA_FEED` at release (ADR 0083).
 import {useMemo, useState} from "react";
 import {useFateClient, view} from "react-fate";
 import type {MecmuaSubscriptionReceipt} from "../../../worker/features/fate/views";
@@ -28,12 +17,6 @@ const SubscriptionView = view<MecmuaSubscriptionReceipt>()({
 	subscribed: true,
 });
 
-/**
- * The toggle's label, factored DOM-free so the "takip ediliyor → bırak" hover swap is
- * unit-testable without a DOM (the `mecmuaPublishAffordance` pure-core idiom). Not yet
- * following ⇒ "abone ol"; following ⇒ "takip ediliyor", swapping to "bırak" on
- * hover/focus so the unsubscribe intent reads honestly.
- */
 export function mecmuaSubscribeLabel(subscribed: boolean, hovering: boolean): string {
 	if (!subscribed) return "abone ol";
 	return hovering ? "bırak" : "takip ediliyor";
@@ -44,8 +27,6 @@ export function MecmuaSubscribeButton({authorId}: {authorId: string}) {
 	const session = useSession();
 	const {me} = useMe();
 
-	// The toggle can only act when the feed is on and the reader is signed in; a reader
-	// following themselves is meaningless, so hide it on your own post too.
 	if (flagLoading || !feedOn || !session.data) return null;
 	if (me?.id === authorId) return null;
 

--- a/apps/web/src/components/membrane/EmailDeliveryNotice.test.tsx
+++ b/apps/web/src/components/membrane/EmailDeliveryNotice.test.tsx
@@ -1,9 +1,3 @@
-/**
- * The failing-email membrane notice (epic #2687, Child #2693). Pins the render contract of the
- * presentational notice (Turkish copy + a recovery CTA that actually reaches the change-email
- * surface + dismissal) and the mount gate (dark behind the flag, present only for a failing
- * signed-in user, hidden once dismissed).
- */
 import {readFileSync} from "node:fs";
 import {join} from "node:path";
 import {fireEvent, render, screen} from "@testing-library/react";
@@ -46,7 +40,6 @@ describe("EmailDeliveryNotice — presentational (#2693)", () => {
 		renderNotice(<EmailDeliveryNotice recoveryHref="/profile" />);
 		const notice = screen.getByTestId("email-delivery-notice");
 		expect(notice.textContent).toContain("e-postana ulaşamıyoruz");
-		// The meaning is carried by text, not color alone (four-pillars a11y).
 		expect(notice.textContent).toContain("geri dönüyor");
 	});
 

--- a/apps/web/src/components/membrane/EmailDeliveryNotice.tsx
+++ b/apps/web/src/components/membrane/EmailDeliveryNotice.tsx
@@ -2,16 +2,7 @@ import {Link} from "react-router";
 import {Button} from "../ui/Button";
 import "./EmailDeliveryNotice.css";
 
-/**
- * The membrane notice a signed-in user with a failing email address sees (epic #2687, Child
- * #2693): a plain-language Turkish signal that our mail is bouncing, plus a recovery CTA into
- * the existing change-email flow. Presentational + prop-driven — the flag/failing/dismiss gate
- * lives in {@link EmailDeliveryNoticeMount}, so the render contract is testable in isolation.
- *
- * The state is carried by TEXT, never color alone (four-pillars a11y): a labelled `<section>`
- * landmark with a `role="status"` live region so it is announced when it appears, the CTA is a
- * real navigating anchor, and dismissal is a native button.
- */
+// The failing state is carried by text, never color alone — four-pillars a11y (ADR 0162).
 export function EmailDeliveryNotice({
 	recoveryHref,
 	onDismiss,

--- a/apps/web/src/components/membrane/EmailDeliveryNoticeMount.tsx
+++ b/apps/web/src/components/membrane/EmailDeliveryNoticeMount.tsx
@@ -10,17 +10,8 @@ import {
 	shouldShowEmailDeliveryNotice,
 } from "./emailDeliveryNoticeGate";
 
-/**
- * The membrane mount for the failing-email notice (epic #2687, Child #2693): reads the
- * dark-ship flag and the signed-in user's own failing signal, renders the notice above the
- * routed content, and holds a local per-session dismissal. Dark by default — with the flag off
- * (or no failing signal) it renders nothing, so the membrane is unchanged until a human flips
- * the flag at release (ADR 0083).
- *
- * `me` widens `MeUser` with the forward-compatible `emailFailing` seam ({@link
- * EmailDeliveryReadable}); the caller's plain `me` is assignable, so this is inert until the
- * worker exposes `emailFailing` on the `me` read (Child #2693 AC1).
- */
+// Dark until a human flips the flag at release (ADR 0083). The `me` widening is inert
+// until the worker exposes `emailFailing` — see `emailDeliveryNoticeGate`.
 export function EmailDeliveryNoticeMount({me}: {me: (MeUser & EmailDeliveryReadable) | null}) {
 	const {value: flagOn} = useFlag(PHOENIX_EMAIL_DELIVERY_NOTICE, false);
 	const [dismissed, setDismissed] = useState(false);

--- a/apps/web/src/components/membrane/emailDeliveryNoticeGate.ts
+++ b/apps/web/src/components/membrane/emailDeliveryNoticeGate.ts
@@ -1,38 +1,17 @@
-/**
- * Membrane email-delivery notice — the pure seam (email-bounce epic #2687, Child #2693).
- *
- * A signed-in user whose transactional address is failing gets no magic-link/verification
- * mail and, until now, no signal why. This surfaces that state on the membrane shell with a
- * recovery affordance. The failing signal is the user's OWN projected `email-delivery` state
- * (`resolveEmailDeliveryState`, Child #2691); the recovery CTA reuses the EXISTING change-email
- * flow (no new recovery backend).
- */
-
-/**
- * The forward-compatible shape the notice reads the failing signal off — a widening of the
- * `me` row that is inert until the worker exposes `emailFailing` on the pasaport `User` wire
- * view (Child #2693 AC1, a worker read-surface change sequenced with admin Child #2692). A
- * plain `me` (no such field yet) is structurally assignable here, so `readEmailFailing` reads
- * `false` today and the notice never renders; the moment the worker stamps `emailFailing` onto
- * the `me` row it lights up with no further client change.
- */
+// A widening of the `me` row that stays inert until the worker exposes `emailFailing` on the
+// pasaport `User` wire view: a plain `me` is structurally assignable, so the notice reads
+// `false` and never renders today, and lights up with no client change once the field lands.
 export interface EmailDeliveryReadable {
 	readonly emailFailing?: boolean;
 }
 
-/** The user's own projected failing-delivery signal — absent (not-yet-wired) reads as deliverable. */
 export const readEmailFailing = (me: EmailDeliveryReadable | null): boolean =>
 	me?.emailFailing ?? false;
 
-/**
- * The account surface the recovery CTA routes into: the existing profile/account page, whose
- * `e-posta` row owns the change-email affordance. Reusing it keeps the CTA off a NEW recovery
- * mechanism (epic #2687 non-goal) — the change-email confirmation path itself already exists via
- * better-auth (ADR 0101).
- */
+// The CTA reuses the profile page's existing change-email row — building a NEW recovery
+// mechanism is an epic #2687 non-goal.
 export const EMAIL_RECOVERY_HREF = "/profile";
 
-/** Whether the membrane notice renders: gated on the dark-ship flag, the failing signal, and not-yet-dismissed. */
 export const shouldShowEmailDeliveryNotice = (input: {
 	readonly flagOn: boolean;
 	readonly failing: boolean;

--- a/apps/web/src/components/moderation/ActorIdentity.test.tsx
+++ b/apps/web/src/components/moderation/ActorIdentity.test.tsx
@@ -1,10 +1,3 @@
-/**
- * `ActorIdentity` — the shared moderation actor-row (ADR 0147). Renders an actor's
- * handle + karma-on-others through the same reusable `<Karma>` atom (#1208), with the
- * consuming surface's own CSS namespace + test-id prefix supplied as props. These
- * asserts pin the render contract every mod/admin surface reuses (divan's roster and
- * detail today via `CaylakIdentity`, the admin user-list #968 next).
- */
 import {render, screen} from "@testing-library/react";
 import {describe, expect, it} from "vitest";
 import {ActorIdentity} from "./ActorIdentity";
@@ -25,7 +18,6 @@ describe("ActorIdentity — the shared actor row", () => {
 			/>,
 		);
 		expect(screen.getByText("Ada Lovelace")).toBeTruthy();
-		// the karma atom rides the surface's test-id prefix + the actor id
 		const karma = screen.getByTestId("divan-karma-a1");
 		expect(karma.textContent).toContain("42");
 	});

--- a/apps/web/src/components/moderation/ActorIdentity.tsx
+++ b/apps/web/src/components/moderation/ActorIdentity.tsx
@@ -1,20 +1,6 @@
-/**
- * `ActorIdentity` — the shared moderation/admin **actor row**: an actor's handle plus
- * their karma-on-others, the one primitive every mod surface renders to answer "who is
- * this actor?" (ADR 0147, grounded in the actor-centric spine of ADR 0138).
- *
- * It is the canonical home for the actor/user row across surfaces: divan's roster and
- * çaylak-detail consume it today (via the thin divan-flavoured `CaylakIdentity`
- * wrapper), and the admin user-list (#968) consumes it next — instead of each forking
- * its own handle+karma tree. The label is resolved DOM-free by {@link actorLabel}, and
- * the karma value rides the SAME reusable {@link Karma} atom (#1208) the topbar and
- * profile use.
- *
- * Presentational only: the caller passes already-resolved identity fields (a batched
- * read resolves them with no per-row by-id fetch — ADR 0021's no-waterfalls contract).
- * The class + testId tokens are props so a consuming surface keeps its own CSS
- * namespace (divan uses `kp-divan__*`) while sharing this render.
- */
+// The one actor row every moderation/admin surface renders — see ADR 0147.
+// Presentational only: identity fields arrive already resolved, so no row fetches
+// by id (ADR 0021's no-waterfalls contract).
 import {Karma} from "../karma/Karma";
 import {actorLabel} from "./actor-identity";
 
@@ -23,14 +9,11 @@ export interface ActorIdentityProps {
 	readonly displayName: string | null;
 	readonly username: string | null;
 	readonly totalKarma: number;
-	/** Fallback handle when both name + username are blank (e.g. a deleted profile). */
 	readonly fallbackLabel: string;
 	readonly showKarma?: boolean;
-	/** CSS class on the identity wrapper `<span>` — the consuming surface's namespace. */
 	readonly identityClassName?: string;
 	readonly handleClassName?: string;
 	readonly karmaClassName?: string;
-	/** Karma atom test-id prefix; the atom's testId becomes `${karmaTestIdPrefix}${authorId}`. */
 	readonly karmaTestIdPrefix?: string;
 }
 

--- a/apps/web/src/components/moderation/BanControls.tsx
+++ b/apps/web/src/components/moderation/BanControls.tsx
@@ -1,19 +1,5 @@
-/**
- * `BanControls` — the moderator-UI ban/unban affordance for one actor (#970, epic
- * #1665). Shows the actor's current banned-state + reason and lets an admin ban
- * (reason + optional expiry) or unban. Reads/writes the `requireAdmin`-gated,
- * `phoenix-user-ban`-flagged fate surface, so a non-admin's read/write fails closed
- * server-side (the read degrades to hidden, the write to the "no authority" message).
- *
- * The caller renders this INSIDE a `<FlagGate flag={PHOENIX_USER_BAN}>`, so with the
- * flag off (default / Flagship outage) the whole control is dark — the client half of
- * the ship-dark contract (ADR 0083). Render decisions are DOM-free in
- * `ban-controls.ts` (unit-tested); this is the thin shell.
- *
- * a11y: a labelled region; a real `<form>` with a required `gerekçe` field + an
- * optional `datetime-local` expiry; Manti Button actions; the banned-state + outcome are
- * text in `role="status"` live regions, never color; copy is lowercase Turkish.
- */
+// This control does no flag check of its own: the caller must render it inside a
+// `<FlagGate flag={PHOENIX_USER_BAN}>` so it goes dark by default (ADR 0083).
 import {useState} from "react";
 import {useFateClient, view} from "react-fate";
 import type {BanState} from "../../../worker/features/fate/views";

--- a/apps/web/src/components/moderation/actor-identity.test.ts
+++ b/apps/web/src/components/moderation/actor-identity.test.ts
@@ -1,9 +1,3 @@
-/**
- * The shared moderation actor-row handle rule (ADR 0147), asserted DOM-free — one
- * tested handle resolver every mod/admin surface reuses (divan's `caylakLabel`, the
- * admin user-list #968) instead of each forking its own. Mirrors the divan
- * `caylakLabel` contract, generalized over the fallback noun.
- */
 import {describe, expect, it} from "vitest";
 import {actorLabel} from "./actor-identity";
 
@@ -22,7 +16,6 @@ describe("actorLabel — the shared actor-row display handle", () => {
 	it("degrades to the surface's fallback noun when both are blank/absent", () => {
 		expect(actorLabel(null, null, "çaylak")).toBe("çaylak");
 		expect(actorLabel("", "  ", "çaylak")).toBe("çaylak");
-		// a different surface (e.g. the admin user-list) supplies its own fallback noun
 		expect(actorLabel(null, null, "kullanıcı")).toBe("kullanıcı");
 	});
 
@@ -34,7 +27,6 @@ describe("actorLabel — the shared actor-row display handle", () => {
 	it("returns only the fixed noun when username is absent — never an email leak", () => {
 		expect(actorLabel(null, null, "kullanıcı")).toBe("kullanıcı");
 		expect(actorLabel("  ", null, "kullanıcı")).toBe("kullanıcı");
-		// with a display name present, that name renders — the email is never consulted
 		expect(actorLabel("Ada Lovelace", null, "kullanıcı")).toBe("Ada Lovelace");
 	});
 });

--- a/apps/web/src/components/moderation/actor-identity.ts
+++ b/apps/web/src/components/moderation/actor-identity.ts
@@ -1,22 +1,4 @@
-/**
- * The moderation/admin shared component layer's pure render decisions, factored
- * DOM-free so each is unit-testable without a DOM/React runtime (the `flagGateChild`
- * / `karmaAriaLabel` idiom — `apps/web/src` has no jsdom).
- *
- * Home of the cross-surface actor-identity rule: every moderation/admin surface that
- * shows *who* an actor is (divan roster/detail today, the admin user-list #968 next)
- * renders the SAME handle + karma primitive rather than forking its own — ADR 0147,
- * grounded in ADR 0138's actor-centric spine.
- */
-
-/**
- * The displayed handle for an actor row. Prefers a trimmed display name, falls back
- * to the `@username`, and degrades to the bare `fallback` label when both are
- * blank/absent (a since-deleted profile arrives as two nulls — the row must not
- * break, it shows the fallback noun). Whitespace-only is treated as absent. Pure so
- * the divan's `caylakLabel` and the admin user-list resolve the same handle through
- * one tested rule.
- */
+// One shared handle rule across every moderation/admin surface — see ADR 0147.
 export function actorLabel(
 	displayName: string | null,
 	username: string | null,

--- a/apps/web/src/components/moderation/ban-controls.test.ts
+++ b/apps/web/src/components/moderation/ban-controls.test.ts
@@ -1,7 +1,3 @@
-/**
- * `ban-controls` pure-logic coverage (#970) — the banned-state labels, the
- * outcome-message mapping, and the expiry parse, DOM-free (the divan-gating idiom).
- */
 import {describe, expect, it} from "vitest";
 import {banExpiryLabel, banOutcomeMessage, banStatusLabel, parseExpiry} from "./ban-controls";
 

--- a/apps/web/src/components/moderation/ban-controls.ts
+++ b/apps/web/src/components/moderation/ban-controls.ts
@@ -1,11 +1,6 @@
-/**
- * DOM-free render logic for the ban controls (#970, moderator UI epic #1665).
- * Pure so the label + outcome-message decisions are unit-testable without a DOM,
- * the divan-gating idiom (`divanGating.ts`); `BanControls.tsx` is the thin shell.
- */
+// Split from `BanControls.tsx` so these decisions are unit-testable — `apps/web/src` has no jsdom.
 import type {FateWireCode} from "../../lib/fateWireCodes";
 
-/** The projected ban-state the controls render, as the wire delivers it. */
 export interface BanView {
 	readonly banned: boolean;
 	readonly reason: string | null;
@@ -13,21 +8,15 @@ export interface BanView {
 	readonly expiresAt: number | null;
 }
 
-/** The banned-state summary line — Turkish, text-only (never color-encoded). */
 export const banStatusLabel = (state: BanView): string =>
 	state.banned ? `yasaklı — gerekçe: ${state.reason ?? "belirtilmemiş"}` : "yasaklı değil";
 
-/**
- * The ban expiry line, or null when there's nothing to show (not banned, or a
- * permanent ban). `nowMs` is injected so the "kalıcı" vs dated branch is pure.
- */
 export const banExpiryLabel = (state: BanView): string | null => {
 	if (!state.banned) return null;
 	if (state.expiresAt === null) return "süre: kalıcı";
 	return `süre bitişi: ${new Date(state.expiresAt).toLocaleString("tr-TR")}`;
 };
 
-/** Turkish feedback for a ban/unban mutation outcome, keyed on the wire code. */
 export const banOutcomeMessage = (action: "ban" | "unban", code: FateWireCode | null): string => {
 	if (code === null) {
 		return action === "ban" ? "kullanıcı yasaklandı." : "yasak kaldırıldı.";
@@ -45,11 +34,7 @@ export const banOutcomeMessage = (action: "ban" | "unban", code: FateWireCode | 
 	}
 };
 
-/**
- * Parse the `datetime-local` input value to an epoch-millis expiry, or null when
- * empty (a permanent ban) or unparseable. The mutation takes epoch-millis; an
- * empty field is the deliberate "no expiry" choice, not an error.
- */
+// An empty field is the deliberate "permanent ban" choice, not an error.
 export const parseExpiry = (value: string): number | null => {
 	const trimmed = value.trim();
 	if (trimmed === "") return null;

--- a/apps/web/src/components/mute/MuteButton.tsx
+++ b/apps/web/src/components/mute/MuteButton.tsx
@@ -1,20 +1,13 @@
-/**
- * The inline "sustur" affordance on a member's feed content (#3117, epic #2035). An inline
- * meta-row action (the `ReportButton` / `gizle` idiom — a reset inline `button` styled by
- * `MetaRow`, not a standalone `Button` wrapper), so it reads consistently with the row's
- * other actions. On the feed it is a mute-only action: the instant a member is muted the
- * card unmounts (the overlay hides it), so this control never renders in the muted state —
- * un-muting lives on the manage screen (`MutedMembersList`). The card owns the gating (flag
- * on, signed in, not the viewer's own content) and only mounts this when it can act.
- */
+// Mute-only by design: the card unmounts the instant a member is muted, so there is no
+// muted state to render here — un-muting lives on `MutedMembersList`. The card also owns
+// the gating (flag on, signed in, not the viewer's own content) and only mounts this
+// button when it can act, which is why there is no check for any of that below.
 import {useState} from "react";
 import {Button} from "../ui/Button";
 import {useMemberMute} from "./useMemberMute";
 
 export interface MuteButtonProps {
-	/** The member to mute — the `mute.set` target. */
 	readonly memberId: string;
-	/** The member's displayed handle, for the action's accessible name. */
 	readonly memberLabel: string;
 	readonly testId?: string;
 }

--- a/apps/web/src/components/mute/MutedMembersList.tsx
+++ b/apps/web/src/components/mute/MutedMembersList.tsx
@@ -1,17 +1,5 @@
-/**
- * `MutedMembersList` — the manage-my-mutes surface (#3117, epic #2035): one row per member
- * the viewer has muted, off the `CurrentUser`-scoped `mute.listMine` read model (#3114),
- * newest-first, each row offering a per-row "geri al" (unmute). The `mute.listMine` read is
- * flag-gated server-side (off ⇒ the invisible `MUTE_DISABLED`, caught by the page's
- * `<Screen>`), so this only ever renders under the on-path; the page (`MutesPage`) self-gates
- * the whole route on `member-mute`.
- *
- * Unmuting drives {@link useMemberMute} (which also clears the feed overlay) and drops the row
- * locally on success, so the list reflects the change without a refetch.
- *
- * a11y: a real `<ul>`, the member handle as text, the empty state as a composed treatment
- * (never a bare void), lowercase Turkish copy.
- */
+// No flag check here: `mute.listMine` is flag-gated server-side and `MutesPage` self-gates
+// the whole route, so this only ever renders on the on-path.
 
 import {VolumeX} from "lucide-react";
 import {useState} from "react";

--- a/apps/web/src/components/mute/muteStore.ts
+++ b/apps/web/src/components/mute/muteStore.ts
@@ -1,21 +1,13 @@
-/**
- * Client session-local muted-member overlay for member-mute (sustur, #3117, epic #2035).
- *
- * The SERVER read-mask (#3113) is the source of truth for a viewer's persisted mutes; this
- * store is the optimistic overlay that gives immediate in-session feedback: a member the
- * viewer just muted disappears from the current feed before any refetch, and one just
- * unmuted returns. A tiny external store (read via `useSyncExternalStore`) rather than a
- * context so the feed cards and the manage screen share one muted set across route changes
- * without threading a provider through the app tree.
- *
- * The store holds no flag — an empty overlay is inert, so a session with the default-off
- * `member-mute` flag simply never writes to it (every consumer gates on the flag first).
- */
+// The session-local optimistic overlay on top of the server read-mask, which stays the
+// source of truth. An external store rather than a context so feed cards and the manage
+// screen share one muted set across route changes without a provider in the tree.
+//
+// It holds no flag: an empty overlay is inert, and every consumer gates on the default-off
+// `member-mute` flag before writing.
 
 let mutedIds: ReadonlySet<string> = new Set();
 const listeners = new Set<() => void>();
 
-/** Add a member to a muted set, returning a new set (never mutating the input). */
 export const withMember = (set: ReadonlySet<string>, id: string): ReadonlySet<string> => {
 	if (set.has(id)) return set;
 	const next = new Set(set);
@@ -23,7 +15,6 @@ export const withMember = (set: ReadonlySet<string>, id: string): ReadonlySet<st
 	return next;
 };
 
-/** Remove a member from a muted set, returning a new set (never mutating the input). */
 export const withoutMember = (set: ReadonlySet<string>, id: string): ReadonlySet<string> => {
 	if (!set.has(id)) return set;
 	const next = new Set(set);
@@ -31,20 +22,15 @@ export const withoutMember = (set: ReadonlySet<string>, id: string): ReadonlySet
 	return next;
 };
 
-/** Subscribe to muted-set changes (the `useSyncExternalStore` subscribe half). */
 export const subscribeMuteStore = (listener: () => void): (() => void) => {
 	listeners.add(listener);
 	return () => listeners.delete(listener);
 };
 
-/** The current muted set — a stable reference until the next mutation (getSnapshot half). */
 export const muteStoreSnapshot = (): ReadonlySet<string> => mutedIds;
 
-/**
- * Set a member's muted presence in the overlay. A no-op when the state already matches, so
- * the snapshot reference stays stable (no spurious re-render). Notifies subscribers only on
- * an actual change.
- */
+// The early return keeps the snapshot reference stable on a no-op; `useSyncExternalStore`
+// re-renders on any new reference, so dropping it would churn every subscriber.
 export const setMemberMuted = (id: string, muted: boolean): void => {
 	const next = muted ? withMember(mutedIds, id) : withoutMember(mutedIds, id);
 	if (next === mutedIds) return;
@@ -52,7 +38,6 @@ export const setMemberMuted = (id: string, muted: boolean): void => {
 	for (const listener of listeners) listener();
 };
 
-/** Clear the overlay — test hygiene (each test starts from an empty set). */
 export const resetMuteStore = (): void => {
 	if (mutedIds.size === 0) return;
 	mutedIds = new Set();

--- a/apps/web/src/components/mute/muteStore.unit.test.ts
+++ b/apps/web/src/components/mute/muteStore.unit.test.ts
@@ -1,9 +1,3 @@
-/**
- * The client muted-member overlay (#3117), tested off its pure reducer + the external-store
- * contract — no DOM (`apps/web/src` has no jsdom). Covers the immutable set transforms and
- * the subscribe/snapshot/notify behavior `useSyncExternalStore` relies on: a real change
- * swaps the snapshot reference and notifies; a no-op keeps it stable and stays silent.
- */
 import {afterEach, assert, describe, it} from "@effect/vitest";
 import {
 	muteStoreSnapshot,
@@ -22,7 +16,7 @@ describe("muteStore pure set transforms", () => {
 		const next = withMember(base, "b");
 		assert.notStrictEqual(next, base);
 		assert.deepStrictEqual([...next].sort(), ["a", "b"]);
-		assert.deepStrictEqual([...base], ["a"]); // input untouched
+		assert.deepStrictEqual([...base], ["a"]);
 	});
 
 	it("withMember is identity when the id is already present", () => {

--- a/apps/web/src/components/mute/useMemberMute.ts
+++ b/apps/web/src/components/mute/useMemberMute.ts
@@ -1,27 +1,19 @@
-/**
- * The client seam for member-mute (sustur, #3117): the muted-set read and the mute/unmute
- * dispatch. Consumers gate on the default-off `member-mute` flag first — this hook holds no
- * flag, only the fate write + the optimistic overlay ({@link muteStore}).
- *
- * `mute` / `unmute` write the overlay OPTIMISTICALLY, dispatch the `mute.set` / `mute.remove`
- * fate mutation, and ROLL BACK on failure. Phoenix wire codes are boundary-class, so a
- * rejected mutation THROWS rather than returning `{error}` (see
- * `.patterns/fate-mutations-client.md`); both branches are handled — the `{error}` return and
- * the throw — and either rolls the overlay back.
- */
+// This hook holds no flag; consumers gate on the default-off `member-mute` flag first.
+//
+// A rejected mutation THROWS rather than returning `{error}` (phoenix wire codes are
+// boundary-class — see `.patterns/fate-mutations-client.md`), so both the `{error}` return
+// and the catch below are live paths and both must roll the overlay back.
 import {useCallback, useSyncExternalStore} from "react";
 import {useFateClient, view} from "react-fate";
 import type {MuteReceipt} from "../../../worker/features/fate/views";
 import {muteStoreSnapshot, setMemberMuted, subscribeMuteStore} from "./muteStore";
 
-/** The `mute.set` / `mute.remove` write-back selection — the presence receipt. */
 const MuteReceiptView = view<MuteReceipt>()({
 	id: true,
 	isMuted: true,
 	changed: true,
 });
 
-/** The current muted set + an `isMuted` predicate, re-rendering on any overlay change. */
 export function useMutedMembers(): {
 	readonly isMuted: (id: string) => boolean;
 	readonly mutedIds: ReadonlySet<string>;
@@ -31,7 +23,6 @@ export function useMutedMembers(): {
 	return {isMuted, mutedIds};
 }
 
-/** The mute/unmute dispatch — optimistic overlay write + fate mutation + rollback on failure. */
 export function useMemberMute(): {
 	readonly mute: (memberId: string) => Promise<{readonly ok: boolean}>;
 	readonly unmute: (memberId: string) => Promise<{readonly ok: boolean}>;

--- a/apps/web/src/components/pano/CommentTreeNode.tsx
+++ b/apps/web/src/components/pano/CommentTreeNode.tsx
@@ -1,7 +1,7 @@
 /**
- * View-shaped tree node for the post-detail comment thread. The page assembles
- * the `parentId` → children map and hands each node its children array, so a
- * level renders its subtree without re-walking the flat connection.
+ * View-shaped tree node for the post-detail comment thread. The page hands each
+ * node its children, so a level renders its subtree without re-walking the
+ * flat connection.
  */
 import * as React from "react";
 import {useFateClient, useLiveView, type ViewRef, view} from "react-fate";
@@ -40,31 +40,26 @@ export const CommentTreeNodeView = view<Comment>()({
 	reactions: {counts: true, myReaction: true},
 });
 
-/**
- * Write-back view for a comment vote. Masking is by view identity, so the
- * write-back must reuse a view the node ref carries — `CommentTreeNodeView`
- * already selects these fields, so we reuse it.
- */
+/** Masking is by view identity, so the write-back must reuse the node's own view. */
 const CommentVoteView = CommentTreeNodeView;
 
 export interface CommentTreeNodeProps {
 	comment: ViewRef<"Comment">;
-	/** Parent post's canonical path (`/pano/:slug`); the node appends the `#comment-<id>` anchor. */
+	/** `/pano/:slug` — the node appends the `#comment-<id>` anchor. */
 	postPath: string;
-	/** Direct children, already filtered + ordered by the page. */
+	/** Already filtered + ordered by the page. */
 	children: ReadonlyArray<{id: string; ref: ViewRef<"Comment">}>;
-	/** comment id → its children list, for resolving grandchildren in recursion. */
 	childrenForId: (id: string) => ReadonlyArray<{id: string; ref: ViewRef<"Comment">}>;
 	depth?: number;
-	/** Comment id the URL hash currently targets — that node renders highlighted. */
+	/** The URL hash's target — that node renders highlighted. */
 	activeCommentId?: string | null;
 	currentUserId: string | null;
 	onReply?: (id: string) => void;
 	onEdit?: (id: string) => void;
 	onDelete?: (id: string) => void;
-	/** Reports this comment; the page owns `report.submit` + the signed-out redirect. */
+	/** The page owns `report.submit` + the signed-out redirect. */
 	onReport?: (id: string) => Promise<ReportOutcome>;
-	/** comment id → its own composers, so the root node is not a special case. */
+	/** Per-id, so the root node is not a special case. */
 	composerFor: (id: string) => {
 		replyComposer?: React.ReactNode;
 		editComposer?: React.ReactNode;
@@ -112,15 +107,11 @@ export function CommentTreeNode(props: CommentTreeNodeProps) {
 				{isDeleted ? (
 					<span className="kp-comment__author kp-comment__author--deleted">[silindi]</span>
 				) : (
-					// Live author identity via `actorLabel` (#2139): current displayName → @username,
-					// falling back to the write-time `author` snapshot for an unstamped/legacy row.
-					// The profile link targets the live username when present, else the snapshot.
 					<a className="kp-comment__author" href={`/u/${data.authorUsername ?? data.author}`}>
 						{actorLabel(data.authorDisplayName ?? null, data.authorUsername ?? null, data.author)}
 					</a>
 				)}
-				{/* Owner-only in-review signal (#4282): `sandboxed` is owner-scoped server-side,
-				    re-gated on `isOwner` — same shape as `PanoPostHeader` / `DefinitionCard`. */}
+				{/* `sandboxed` is already owner-scoped server-side; re-gated here on purpose (#4282). */}
 				{isOwner && data.sandboxed ? <ReviewBadge /> : null}
 				<span>{formatAgoTR(toIso(data.createdAt))}</span>
 				<EditedIndicator createdAt={toIso(data.createdAt)} updatedAt={toIso(data.updatedAt)} />

--- a/apps/web/src/components/pano/PanoPost.test.tsx
+++ b/apps/web/src/components/pano/PanoPost.test.tsx
@@ -1,8 +1,6 @@
 /**
- * a11y regression proof (#2215): the pano vote button's accessible name must
- * TOGGLE with vote state — "Oyunu geri al" (undo) when the viewer's vote is
- * active, "Yukarı oy" otherwise — mirroring the sözlük `DefinitionCard` control.
- * A static aria-label leaves screen-reader users with stale toggle feedback.
+ * Regression proof for #2215: a static aria-label on the vote button leaves screen
+ * reader users with stale toggle feedback.
  */
 import {readFileSync} from "node:fs";
 import {fileURLToPath} from "node:url";

--- a/apps/web/src/components/pano/PanoPost.tsx
+++ b/apps/web/src/components/pano/PanoPost.tsx
@@ -7,9 +7,9 @@ import {currentLocationReturnTo, useGatedToggle, useVoteToggle} from "./useVoteT
 import "./PanoPost.css";
 
 /**
- * Presentational vote control; the parent owns the mutation + auth gate. `own`
- * marks the viewer's own content: the control remains visible for stable feed
- * geometry, but is disabled because self-voting is blocked (#2216).
+ * Presentational only — the parent owns the mutation + auth gate. On the viewer's
+ * own content the control stays visible (stable feed geometry) but disabled: self
+ * voting is blocked (#2216).
  */
 export function VoteControl({
 	count,
@@ -52,13 +52,8 @@ export function VoteControl({
 	);
 }
 
-/**
- * Triangle vote button for a single post. Dispatches
- * `fate.mutations.post.{vote,retractVote}` with an optimistic `score`/`myVote`
- * flip written back through `PostVoteView` keyed by `id`, so every card
- * referencing this post (feed + detail) re-renders instantly. The button has no
- * inline error slot, so we surface only `UNAUTHORIZED` (→ auth redirect) and
- * stay silent otherwise — see `.patterns/fate-mutations-client.md`.
+/** Optimistic writes go through `PostVoteView` keyed by `id` so every card referencing
+ * this post re-renders. See `.patterns/fate-mutations-client.md`.
  */
 export function PostVoteWidget({
 	postId,
@@ -69,7 +64,7 @@ export function PostVoteWidget({
 	postId: string;
 	score: number;
 	myVote: boolean | null;
-	/** The viewer authored this post — keep the vote visible but disabled (#2216). */
+	/** Viewer authored this post — visible but disabled (#2216). */
 	own?: boolean;
 }) {
 	const fate = useFateClient();
@@ -99,23 +94,13 @@ export function PostVoteWidget({
 	);
 }
 
-/**
- * Bookmark toggle for a single post — the save twin of `PostVoteWidget`.
- * Dispatches `fate.mutations.post.{save,unsave}` with an optimistic `isSaved`
- * flip written back through `PostSaveView` keyed by `id`, so every card and the
- * detail header referencing this post re-render instantly (and the server's
- * `live.update("Post", id, {changed:["isSaved"]})` reconciles every other open
- * view). Like the vote widget it has no inline error slot, so it surfaces only
- * `UNAUTHORIZED` (→ auth redirect) and stays silent otherwise — see
- * `.patterns/fate-mutations-client.md`.
- */
 export function PostSaveButton({postId, isSaved}: {postId: string; isSaved: boolean | null}) {
 	const fate = useFateClient();
 
 	const saved = isSaved === true;
 
-	// The save delta is a plain `isSaved` flip (no score floor), so it drives the
-	// shared gate directly rather than through the vote specialization.
+	// A plain `isSaved` flip (no score floor), so it drives the shared gate directly
+	// rather than the vote specialization.
 	const onToggle = useGatedToggle({
 		on: saved,
 		returnTo: currentLocationReturnTo,

--- a/apps/web/src/components/pano/PanoPostCard.compose.test.tsx
+++ b/apps/web/src/components/pano/PanoPostCard.compose.test.tsx
@@ -1,10 +1,6 @@
 /**
- * Base + overlay composition on the card (#2323, leg B). Pins the two client-composition
- * ACs at the component level: (1) with compose on, the base row paints while the viewer
- * scalars stay neutral until the overlay lands under the confirmed identity, then patch in
- * place; (2) a signed-in viewer never sees another/stale identity's overlay during the
- * compose window. The leaf vote/save widgets are stubbed to surface the scalars the card
- * feeds them — the pure identity guard is covered separately in `panoFeedOverlay.test.ts`.
+ * Base + overlay composition on the card (#2323). The pure identity guard is covered
+ * separately in `panoFeedOverlay.test.ts`.
  */
 import {render} from "@testing-library/react";
 import {MemoryRouter} from "react-router";
@@ -14,8 +10,7 @@ import {PanoPostCard} from "./PanoPostCard";
 
 type SessionResult = ReturnType<typeof useSessionType>;
 
-// The row `useLiveView` resolves for the post ref, and the session state, both swappable
-// per test through these holders (a live `Post` carrying identity A's own scalars).
+// Holders so a test can swap the resolved row and the session state per case.
 let rowData: Record<string, unknown>;
 let sessionState: SessionResult;
 
@@ -28,8 +23,8 @@ vi.mock("../../auth/client", () => ({
 	useSession: () => sessionState,
 }));
 
-// Stub the mutation-bearing leaf widgets to render the exact scalar the card feeds them,
-// so the assertion reads what the card composed — not the widget's own behavior.
+// The leaf widgets are stubbed to echo the scalar they receive, so an assertion reads
+// what the CARD composed rather than the widget's own behavior.
 vi.mock("./PanoPost", () => ({
 	PostVoteWidget: ({myVote}: {myVote: boolean | null}) => (
 		<span data-testid="vote">{String(myVote)}</span>
@@ -86,7 +81,6 @@ describe("PanoPostCard — base + overlay composition (compose on)", () => {
 				<PanoPostCard post={ref} compose />
 			</MemoryRouter>,
 		);
-		// The base row is on screen (title), but the viewer scalars are held neutral.
 		expect(container.textContent).toContain("başlık");
 		expect(scalars(container)).toEqual({vote: "null", save: "null"});
 	});

--- a/apps/web/src/components/pano/PanoPostCard.routing.test.tsx
+++ b/apps/web/src/components/pano/PanoPostCard.routing.test.tsx
@@ -1,9 +1,4 @@
-/**
- * Title/domain routing on the feed card (#2437, founder ruling). A link-type row's
- * TITLE routes to the post detail (`/pano/:id`) everywhere — never off-site — and the
- * external URL lives on the domain label with an outbound cue. A text row (no `url`)
- * keeps the "yazı" label as a plain span. Mirrors the compose test's fate/session mocks.
- */
+/** Pins the founder ruling on #2437: the title never routes off-site. */
 import {render} from "@testing-library/react";
 import {MemoryRouter} from "react-router";
 import {afterEach, describe, expect, it, vi} from "vitest";

--- a/apps/web/src/components/pano/PanoPostCard.tsx
+++ b/apps/web/src/components/pano/PanoPostCard.tsx
@@ -1,8 +1,6 @@
 /**
- * fate-shaped card for the pano feed. Reads its slice via
- * `useLiveView(PanoPostCardView, ref)`. Rank and hide stay with the parent
- * because they're list-position state, not Post state; save reads `isSaved` off
- * the post itself, so the card owns the bookmark toggle (`PostSaveButton`).
+ * fate-shaped card for the pano feed. Rank and hide belong to the parent —
+ * list-position state, not Post state.
  */
 import {useLiveView, type ViewRef, view} from "react-fate";
 import {Link} from "react-router";
@@ -44,13 +42,7 @@ export const PanoPostCardView = view<Post>()({
 	tags: true,
 });
 
-/**
- * The identity-guarded viewer scalars for one row's controls (leg B compose path). While
- * the session is still resolving the overlay is `pending` → neutral (base painted, overlay
- * not yet landed); once resolved it is a single-row batch tagged with the current identity,
- * which `resolveOverlay` re-checks so a stale/foreign overlay reads neutral. See
- * `panoFeedOverlay`.
- */
+/** Identity-guarded viewer scalars — a stale or foreign overlay reads neutral. See `panoFeedOverlay`. */
 function composedScalars(
 	sessionPending: boolean,
 	viewerId: string | null,
@@ -77,21 +69,12 @@ export function PanoPostCard({
 	rank?: number;
 	onHide?: (id: string) => void;
 	/**
-	 * Base + overlay composition (#2323, leg B). Set on the viewer-invariant base feed
-	 * rows: the viewer scalars (`myVote`/`isSaved`) render through the identity guard
-	 * (`panoFeedOverlay`): neutral while the session is still resolving (base painted,
-	 * overlay pending), then the viewer's own scalars once the session lands under a
-	 * matching identity — so a stale/foreign overlay (e.g. a snapshot's prior-identity
-	 * scalars) never paints. Unset (the default) ⇒ scalars read straight off the post,
-	 * the authed path (`?sort=saved` / detail) whose read already stamps the viewer.
+	 * Set on viewer-invariant base feed rows (#2323): viewer scalars go through the
+	 * identity guard. Unset ⇒ read straight off the post, whose read already stamped
+	 * the viewer.
 	 */
 	compose?: boolean;
-	/**
-	 * Member-mute (#3117, dark behind `member-mute`) — the feed reads the flag once and
-	 * threads it here so a card can hide a muted member's post + render the "sustur"
-	 * affordance without every card evaluating the flag itself. Off (default / flag-off) ⇒
-	 * no mute surface, byte-identical to today.
-	 */
+	/** Threaded down from the feed, which reads the `member-mute` flag once (#3117). */
 	muteEnabled?: boolean;
 }) {
 	const data = useLiveView(PanoPostCardView, post);
@@ -103,12 +86,8 @@ export function PanoPostCard({
 		data.authorUsername ?? null,
 		data.author,
 	);
-	// A muted member's post disappears from the muter's feed the instant it is muted (the
-	// client overlay; the server read-mask #3113 is the persisted source of truth). Only
-	// under the flag — off, the overlay is always empty so this never fires.
+	// Client-side echo of the mute; the server read-mask (#3113) is the source of truth.
 	if (muteEnabled && data.authorId && isMuted(data.authorId)) return null;
-	// The viewer scalars fed to the vote/save controls: flag-off reads them straight off the
-	// post (byte-identical to today); compose routes them through the identity guard below.
 	const {myVote, isSaved} = compose
 		? composedScalars(session.isPending, session.data?.user?.id ?? null, data)
 		: {myVote: data.myVote ?? null, isSaved: data.isSaved ?? null};
@@ -134,10 +113,8 @@ export function PanoPostCard({
 							))}
 						</span>
 					) : null}
-					{/* Title routes to the post detail EVERYWHERE — feed, saved, search — matching
-					    the landing row; the external URL lives on the domain label below + the
-					    detail hero. See the founder ruling on #2437 (discussion-first: the title
-					    lands people on the conversation, the domain label is the source link-out). */}
+					{/* Deliberate: the title routes to the post detail everywhere, never to the
+					    external URL — that link-out lives on the domain label. Founder ruling, #2437. */}
 					<Link className="kp-pano-post__title kp-prose" to={href} title={data.title}>
 						{data.title}
 					</Link>
@@ -155,8 +132,6 @@ export function PanoPostCard({
 					) : null}
 				</div>
 				<MetaRow className="kp-pano-post__meta">
-					{/* Live author identity via `actorLabel` (#2139): current displayName → @username,
-					    falling back to the write-time `author` snapshot for an unstamped/legacy row. */}
 					<span className="author">{authorLabel}</span>
 					<MetaRow.Dot />
 					<span>{agoLabel}</span>

--- a/apps/web/src/components/pano/PanoPostHeader.tsx
+++ b/apps/web/src/components/pano/PanoPostHeader.tsx
@@ -1,7 +1,6 @@
 /**
- * fate-shaped post-detail header. The detail page spreads `PanoPostHeaderView`
- * into `PostDetailView` and hands the `Post` ref down. Edit/delete affordances
- * are gated by `isAuthor`, which the page derives and passes in.
+ * fate-shaped post-detail header. The page derives `isAuthor` and passes it in;
+ * the edit/delete affordances hang off it.
  */
 import {useLiveView, type ViewRef, view} from "react-fate";
 import type {Post} from "../../../worker/features/fate/views";
@@ -21,11 +20,7 @@ import {ReportButton, type ReportOutcome} from "../ui/ReportButton";
 import {ReviewBadge} from "../ui/ReviewBadge";
 import {PostSaveButton, PostVoteWidget} from "./PanoPost";
 
-/**
- * Write-back views for the post vote / save toggles. Defined here rather than
- * next to their widgets (in `PanoPost.tsx`) to keep that module free of a
- * back-edge import to the header.
- */
+/** Defined here, away from their widgets, so `PanoPost.tsx` needs no back-edge import. */
 export const PostVoteView = view<Post>()({
 	id: true,
 	score: true,
@@ -64,7 +59,7 @@ export interface PanoPostHeaderProps {
 	isAuthor: boolean;
 	onEdit?: () => void;
 	onDelete?: () => void;
-	/** Reports this post; the page owns `report.submit` + the signed-out redirect. */
+	/** The page owns `report.submit` + the signed-out redirect. */
 	onReport?: () => Promise<ReportOutcome>;
 }
 
@@ -75,8 +70,7 @@ export function PanoPostHeader(props: PanoPostHeaderProps) {
 		<div>
 			<h1 className="kp-pano-postpage__title kp-prose">
 				{post.title}
-				{/* Owner-only in-review signal (#2200): `sandboxed` is owner-scoped server-side,
-				    re-gated on `isAuthor` so only the author sees their own pending post's state. */}
+				{/* `sandboxed` is already owner-scoped server-side; re-gated here on purpose (#2200). */}
 				{props.isAuthor && post.sandboxed ? <ReviewBadge /> : null}
 			</h1>
 			{post.url ? (
@@ -95,8 +89,6 @@ export function PanoPostHeader(props: PanoPostHeaderProps) {
 						{t.label}
 					</Tag>
 				))}
-				{/* Live author identity via `actorLabel` (#2139): current displayName → @username,
-				    falling back to the write-time `author` snapshot for an unstamped/legacy row. */}
 				<span className="author">
 					{actorLabel(post.authorDisplayName ?? null, post.authorUsername ?? null, post.author)}
 				</span>
@@ -139,8 +131,7 @@ export function PanoPostHeader(props: PanoPostHeaderProps) {
 					))}
 				</div>
 			) : null}
-			{/* Reactions are scoped to the post detail, not the feed row (#2212) — mirroring
-			    how sözlük scopes them to the definition detail, not the term list. */}
+			{/* Reactions live on the detail only, never the feed row (#2212). */}
 			<ReactionBarSlot>
 				<PostReactionBar postId={post.id} reactions={post.reactions} />
 			</ReactionBarSlot>
@@ -153,7 +144,7 @@ export function PanoPostHeaderVote({
 	isAuthor = false,
 }: {
 	post: ViewRef<"Post">;
-	/** The viewer authored this post — keep the vote visible but disabled (#2216). */
+	/** Viewer authored this post — visible but disabled (#2216). */
 	isAuthor?: boolean;
 }) {
 	const data = useLiveView(PanoPostHeaderView, post);

--- a/apps/web/src/components/pano/PanoSkeleton.test.tsx
+++ b/apps/web/src/components/pano/PanoSkeleton.test.tsx
@@ -1,9 +1,6 @@
 /**
- * Height-match regression for #2161: the feed skeleton must reserve one row per
- * post the first page carries, else the footer jumps (~941px, 6 rows under a
- * 20-post page) when content lands. The row count is single-sourced from
- * `PANO_FEED_PAGE_SIZE`, so this pins the skeleton to the same page size the feed
- * request uses — the two can't silently drift back apart.
+ * Regression for #2161: a skeleton with fewer rows than the first page reserves the
+ * wrong height and the footer jumps (~941px) when content lands.
  */
 import {render, screen} from "@testing-library/react";
 import {describe, expect, it} from "vitest";

--- a/apps/web/src/components/pano/PanoSkeleton.tsx
+++ b/apps/web/src/components/pano/PanoSkeleton.tsx
@@ -1,21 +1,17 @@
 /**
- * Layout-preserving loading placeholders for the pano surfaces, composed from the
- * shared `Skeleton` atom (the same primitive the sözlük skeleton uses — #1633/#1636).
- * Each mirrors the real DOM shape (feed row grid / post-detail header) so content
- * arrival swaps in without a layout jump.
+ * Loading placeholders that mirror the real DOM shape, so content arrival swaps in
+ * without a layout jump.
  */
 import {PANO_FEED_PAGE_SIZE} from "../../lib/panoNav";
 import {Skeleton} from "../ui/atoms";
 import "./PanoPost.css";
 import "../../pages/PanoPostDetail.css";
 
-// Match the skeleton row count to the feed's first-page size so it reserves the
-// SAME height the arriving page occupies — a 6-row skeleton under a 20-post page
-// jumped the footer ~941px on arrival (#2161). Single-sourced from `panoNav` so the
-// two can't drift.
+// Single-sourced from `panoNav`: the row count must equal the feed's first page or
+// the skeleton reserves the wrong height (a 6-row skeleton under 20 posts jumped the
+// footer ~941px, #2161).
 const FEED_ROWS = PANO_FEED_PAGE_SIZE;
 
-/** Feed-row skeleton — mirrors `PanoPostCard`'s [rank | vote | body] grid. */
 export function PanoFeedSkeleton() {
 	return (
 		<div
@@ -47,7 +43,6 @@ export function PanoFeedSkeleton() {
 	);
 }
 
-/** Post-detail skeleton — mirrors the `kp-pano-postpage__head` title/url/meta stack. */
 export function PanoPostSkeleton() {
 	return (
 		<div

--- a/apps/web/src/components/pano/PanoSubnavCta.test.tsx
+++ b/apps/web/src/components/pano/PanoSubnavCta.test.tsx
@@ -1,9 +1,6 @@
 /**
- * pano's primary action in its Subnav CTA slot (#2600, placement law #2587). Pins the two
- * behavior-bearing halves: (1) a signed-in user reaches `/pano/yeni` through the CTA
- * (reachability, verified by actually routing there on click); (2) a signed-out visitor
- * gets no CTA — the affordance is a one-for-one replacement of the topbar's signed-in
- * `+ gönderi`, so signed-out stays with the topbar `giriş yap`, not a Subnav CTA.
+ * The signed-out case is deliberate (#2600): the CTA replaces the topbar's signed-in
+ * `+ gönderi` one-for-one, so a signed-out visitor keeps the topbar `giriş yap`.
  */
 import {fireEvent, render, screen} from "@testing-library/react";
 import {MemoryRouter, Route, Routes} from "react-router";
@@ -33,7 +30,6 @@ describe("PanoSubnavCta — pano primary action in the Subnav CTA slot (#2600)",
 		sessionState = {data: {user: {id: "u1"}}, isPending: false} as SessionResult;
 		renderCta();
 		const cta = screen.getByRole("button", {name: "yeni gönderi"});
-		// Sanctioned primary-action treatment (#2586 taxonomy), not the utility filter/tab style.
 		expect(cta.getAttribute("data-variant")).toBe("primary");
 		expect(screen.queryByTestId("pano-submit")).toBeNull();
 		fireEvent.click(cta);

--- a/apps/web/src/components/pano/PanoSubnavCta.tsx
+++ b/apps/web/src/components/pano/PanoSubnavCta.tsx
@@ -4,16 +4,10 @@ import {readBootUser} from "../../flags/boot";
 import {Button} from "../ui/Button";
 
 /**
- * pano's primary action in its Subnav CTA slot (placement law #2587, epic #2596): the
- * promoted "yeni gönderi" verb, relocated out of the global topbar into the pano product
- * zone. Signed-in only — it replaces the topbar's signed-in `+ gönderi` affordance
- * one-for-one, so a signed-out visitor still reaches auth via the topbar `giriş yap` and
- * sees no CTA. Renders the sanctioned primary-action treatment (`Button` `primary`
- * variant, #2586 taxonomy), never the utility filter/tab styling.
- *
- * The signed-in gate reads the edge-resolved `__BOOT__.user` FIRST (ADR 0185) so the CTA
- * renders on the first frame instead of popping in when the session settles; it falls back to
- * the settling session when `__BOOT__` is absent (flag off / the #2931 never-hang fallback).
+ * pano's primary action, signed-in only. The gate reads the edge-resolved
+ * `__BOOT__.user` FIRST (ADR 0185) so the CTA paints on the first frame instead of
+ * popping in when the session settles, and falls back to the session when `__BOOT__`
+ * is absent.
  */
 export function PanoSubnavCta() {
 	const session = useSession();

--- a/apps/web/src/components/pano/PanoSubnavLayout.test.tsx
+++ b/apps/web/src/components/pano/PanoSubnavLayout.test.tsx
@@ -1,14 +1,4 @@
-/**
- * pano's persistent product Subnav zone (#2601, placement law #2587), now composed through
- * SubnavShell (#2975, ADR 0182). Pins: (1) the zone is a persistent layout — its `.kp-subnav`
- * node survives a within-pano navigation (no remount); (2) the routed feed's filters/meta publish
- * UP into that one zone Subnav (the chip-bridge), so there is a single Subnav, not a per-page
- * second one; (3) the active site-filter folds into the zone as a transient crumb with a working
- * `× filtreyi kaldır` clear — and NO resting-chrome `.kp-pano-crumb` strip is painted; (4) pano's
- * content lands in the shell's typed zones — chips in `.kp-subnav__filters`, crumb in
- * `.kp-subnav__leading`, CTA in `.kp-subnav__cta`, count in `.kp-subnav__meta` — with behavior
- * unchanged from the pre-shell rendering.
- */
+/** pano's persistent Subnav zone, composed through SubnavShell. See ADR 0182. */
 import {fireEvent, render, screen} from "@testing-library/react";
 import {useEffect} from "react";
 import {Link, MemoryRouter, Route, Routes} from "react-router";
@@ -20,8 +10,8 @@ vi.mock("../../auth/client", () => ({
 	useSession: () => ({data: signedIn ? {user: {id: "u1"}} : null, isPending: false}),
 }));
 
-// A stand-in feed leaf that publishes a fixed Subnav content up into the zone, the same way
-// PanoFeed's FeedChrome does — so the test exercises the bridge, not PanoFeed's fate wiring.
+// Stands in for PanoFeed's FeedChrome so the test exercises the bridge, not PanoFeed's
+// fate wiring.
 function PublishingLeaf({
 	meta = "3 başlık",
 	host,
@@ -88,21 +78,17 @@ describe("PanoSubnavLayout — pano product Subnav zone through SubnavShell (#29
 		signedIn = true;
 		const {container} = renderZone(<PublishingLeaf host="foo.com" />);
 		const bar = container.querySelector(".kp-subnav");
-		// chips → destinations zone (the filters row inside the bar)
 		const filtersRow = bar?.querySelector(".kp-subnav__filters");
 		expect(filtersRow?.contains(screen.getByRole("button", {name: "sıcak"}))).toBe(true);
 		expect(filtersRow?.contains(screen.getByRole("button", {name: "yeni"}))).toBe(true);
-		// crumb → leading zone
 		expect(
 			bar?.querySelector(".kp-subnav__leading")?.contains(screen.getByText("site / foo.com")),
 		).toBe(true);
-		// CTA → primaryAction zone
 		expect(
 			bar
 				?.querySelector(".kp-subnav__cta")
 				?.contains(screen.getByRole("button", {name: "yeni gönderi"})),
 		).toBe(true);
-		// count → signal zone
 		expect(bar?.querySelector(".kp-subnav__meta")?.textContent).toContain("3 başlık");
 	});
 
@@ -127,14 +113,12 @@ describe("PanoSubnavLayout — pano product Subnav zone through SubnavShell (#29
 		renderZone();
 		expect(screen.getByRole("button", {name: "sıcak"})).toBeTruthy();
 		fireEvent.click(screen.getByRole("link", {name: "detay"}));
-		// content cleared on the feed's unmount: filters gone, CTA still present.
 		expect(screen.queryByRole("button", {name: "sıcak"})).toBeNull();
 		expect(screen.getByRole("button", {name: "yeni gönderi"})).toBeTruthy();
 	});
 
 	it("folds the active site-filter into the zone as a transient crumb with a working clear — no resting-chrome strip", () => {
 		const {container} = renderZone(<PublishingLeaf host="foo.com" />);
-		// Transient crumb paint in the Subnav, not the resting .kp-pano-crumb strip.
 		expect(container.querySelector(".kp-subnav__crumb")).toBeTruthy();
 		expect(container.querySelector(".kp-pano-crumb")).toBeNull();
 		expect(screen.getByText("site / foo.com")).toBeTruthy();

--- a/apps/web/src/components/pano/PanoSubnavLayout.tsx
+++ b/apps/web/src/components/pano/PanoSubnavLayout.tsx
@@ -6,12 +6,8 @@ import {Button} from "../ui/Button";
 import {PanoSubnavCta} from "./PanoSubnavCta";
 
 /**
- * The feed-scoped content the routed pano page publishes UP into its persistent Subnav zone.
- * Per the #2586 taxonomy: `filters` are pano's product filters (the sort subfeeds +
- * kaydedilenler), `meta` is a read-only count signal, `crumb` is the active site-filter shown
- * as transient state paint (legal — it paints only while a `/pano/site/:host` filter is active,
- * like the sözlük active-letter accent), and the CTA slot (below) holds the primary action.
- * Only the pano feed routes publish; on the other `/pano/*` routes the zone shows just its CTA.
+ * What the routed pano page publishes UP into the persistent Subnav zone. Only the
+ * feed routes publish; every other `/pano/*` route leaves the zone with just its CTA.
  */
 export type PanoSubnavContent = {
 	filters: SubnavFilter[];
@@ -26,20 +22,14 @@ const SetPanoSubnavContent = createContext<((content: PanoSubnavContent | null) 
 );
 
 /**
- * The routed pano feed calls this to push its Subnav content up to the persistent zone (null
- * when it unmounts). Returns null when no zone ancestor provides it — the eager public paint
- * above the router (App.tsx) — the signal PanoFeed uses to fall back to rendering its own
- * Subnav.
+ * Returns null when no zone ancestor provides it (the eager paint above the router) —
+ * PanoFeed reads that as the signal to render its own Subnav instead.
  */
 export function useSetPanoSubnavContent() {
 	return useContext(SetPanoSubnavContent);
 }
 
-/**
- * pano's sort/filter chips, composed as one node for the shell's `destinations` zone. The consumer
- * owns rendering its stateful buttons inside that single zone (ADR 0182) — the `kp-subnav__filter`
- * class carries the shared tab treatment, `aria-pressed` marks the active subfeed.
- */
+/** One node for the shell's `destinations` zone; the consumer owns its buttons. See ADR 0182. */
 function PanoSubnavFilters({
 	filters,
 	activeFilter,
@@ -68,10 +58,7 @@ function PanoSubnavFilters({
 	);
 }
 
-/**
- * The active site-filter as a transient crumb for the shell's `leading` (context) zone — plain
- * inline text + the `× filtreyi kaldır` clear, no resting-chrome pill (containment law, #2585).
- */
+/** Plain inline text, deliberately no resting-chrome pill — containment law, #2585. */
 function PanoSubnavCrumb({crumb}: {crumb: {label: ReactNode; onClear: () => void}}) {
 	return (
 		<span className="kp-subnav__crumb">
@@ -90,15 +77,8 @@ function PanoSubnavCrumb({crumb}: {crumb: {label: ReactNode; onClear: () => void
 }
 
 /**
- * pano's persistent product Subnav zone (placement law #2587, epic #2596) — the pathless
- * layout-route element that renders pano's Subnav once above the routed `<Outlet>`, so the zone
- * stays mounted across `/pano/*` (no per-page remount). Composes through {@link SubnavShell}
- * (ADR 0182): pano's feed-scoped content maps onto the shell's typed zones — the crumb into
- * `leading`, the sort/filter chips into `destinations`, `PanoSubnavCta` into `primaryAction`, and
- * the count into `signal`. The routed feed publishes that content UP via
- * {@link useSetPanoSubnavContent} (the same chip-bridge shape App.tsx uses for the topbar) and this
- * frame owns the state — keeping all feed logic (sort / startTransition / saved variant) in
- * PanoFeed rather than duplicating it here.
+ * A pathless layout route so the Subnav stays mounted across `/pano/*` — no per-page
+ * remount. The feed logic stays in PanoFeed and publishes up. See ADR 0182.
  */
 export function PanoSubnavLayout() {
 	const [content, setContent] = useState<PanoSubnavContent | null>(null);

--- a/apps/web/src/components/pano/commentTree.ts
+++ b/apps/web/src/components/pano/commentTree.ts
@@ -1,7 +1,6 @@
 /**
- * Pure comment-tree derivation for the post-detail thread. Pure (no hooks/refs)
- * so it runs synchronously in the render the nodes appear in — no effect
- * round-trip, so a freshly-arrived live node is never dropped for a frame.
+ * Pure (no hooks/refs) so the tree is derived in the same render the nodes appear
+ * in — an effect round-trip would drop a freshly-arrived live node for a frame.
  */
 
 export interface CommentNode<Ref> {
@@ -18,25 +17,18 @@ export interface PlacedComment<Ref> {
 }
 
 export interface CommentTree<Ref> {
-	/** Top-level comments, in connection order. */
 	roots: Array<PlacedComment<Ref>>;
-	/** parentId → its visible children, in connection order. */
 	childrenByParent: Map<string, Array<PlacedComment<Ref>>>;
-	/** id → body, for the inline edit composer's initial value. */
 	bodyById: Map<string, string>;
-	/** id → view ref, for the inline edit composer's write-back. */
 	refById: Map<string, Ref>;
 	visibleCount: number;
 }
 
 /**
- * Build the thread tree from the flat, ordered comment nodes.
- *
- * Visibility: a comment renders iff it isn't soft-deleted, OR it has at least
- * one visible descendant (a soft-deleted parent of a live reply stays as a
- * `[silindi]` tombstone so the reply has somewhere to hang). Computed from
- * leaves upward to a fixed point. A child whose parent isn't visible (or isn't
- * in the page) is promoted to a root so it never disappears.
+ * A comment renders iff it isn't soft-deleted OR has a visible descendant — a
+ * soft-deleted parent stays as a `[silindi]` tombstone so its live reply has
+ * somewhere to hang. A child whose parent isn't visible is promoted to a root so
+ * it never disappears.
  */
 export function buildCommentTree<Ref>(nodes: ReadonlyArray<CommentNode<Ref>>): CommentTree<Ref> {
 	const bodyById = new Map<string, string>();

--- a/apps/web/src/components/pano/reactionBarPlacement.test.ts
+++ b/apps/web/src/components/pano/reactionBarPlacement.test.ts
@@ -1,14 +1,8 @@
 /**
- * Pins the reaction-bar placement decision (#2212, founder ruled option (b)
- * keep-but-relocate): pano reactions live on the post DETAIL surface, not the
- * feed row — mirroring how sözlük scopes reactions to the definition detail
- * (`DefinitionCard`), never the term list. The upvote (△) stays the feed-level
- * signal, so `PostVoteWidget` must remain on the card.
+ * Pins the founder ruling on #2212: reactions on the post detail, never the feed row.
  *
- * A static source assertion (like `styles/focus-layer.test.ts`) rather than a
- * render: the contract is *which surface wires the bar*, which the imports +
- * JSX tag encode directly and stably — no fate client/session harness, and it
- * won't churn when unrelated card work lands.
+ * Deliberately a static source assertion, not a render — the contract is *which
+ * surface wires the bar*, which the imports encode directly and stably.
  */
 import {readFileSync} from "node:fs";
 import {fileURLToPath} from "node:url";

--- a/apps/web/src/components/pano/useToggleAction.test.ts
+++ b/apps/web/src/components/pano/useToggleAction.test.ts
@@ -7,10 +7,8 @@ import {
 } from "./useToggleAction";
 
 /**
- * A controllable harness modelling the hook's refs + a fate dispatch that
- * settles only when we tell it to — so a test can interleave a "supersede"
- * toggle while a dispatch is still in flight, reproducing the #818 / #825 race
- * deterministically (no timers, no DOM).
+ * A dispatch that settles only when the test says so, so the #818 / #825 race can be
+ * interleaved deterministically — no timers, no DOM.
  */
 function harness(initialOn: boolean) {
 	let on = initialOn;
@@ -29,7 +27,6 @@ function harness(initialOn: boolean) {
 				new Promise<void>((resolve) => {
 					calls.push(action);
 					pending = () => {
-						// The optimistic write + server reconcile lands the on-state.
 						on = action === "set";
 						pending = null;
 						resolve();
@@ -43,7 +40,6 @@ function harness(initialOn: boolean) {
 		setDesired: (v: boolean) => {
 			desired = v;
 		},
-		/** Settle the currently in-flight dispatch. */
 		settle: () => {
 			if (!pending) throw new Error("no dispatch in flight to settle");
 			pending();
@@ -70,22 +66,19 @@ describe("runToggleLoop — the #818 / #825 race", () => {
 	it("does NOT drop an unset issued while the set mutation is still in flight", async () => {
 		const h = harness(false);
 
-		// Click 1: set. Starts the loop; first dispatch is now in flight.
 		h.setDesired(true);
 		const loop = h.run();
 		await tick();
 		expect(h.calls).toEqual(["set"]);
 		expect(h.hasPending()).toBe(true);
 
-		// Click 2 lands INSIDE the in-flight window (the bug's exact timing) —
-		// supersede the desired end-state back to "off".
+		// Click 2 lands INSIDE the in-flight window — the bug's exact timing.
 		h.setDesired(false);
 
-		// The set POST resolves only now (its ~370ms round-trip).
 		h.settle();
 		await tick();
 
-		// The unset MUST fire — under the old `if (inFlight) return;` it never did.
+		// Under the old `if (inFlight) return;` guard this unset never fired.
 		expect(h.calls).toEqual(["set", "unset"]);
 		expect(h.hasPending()).toBe(true);
 		h.settle();
@@ -101,8 +94,8 @@ describe("runToggleLoop — the #818 / #825 race", () => {
 		await tick();
 		expect(h.calls).toEqual(["set"]);
 
-		// Two more clicks while in flight: off then on → desired ends at true,
-		// which the in-flight set already achieves, so no corrective dispatch.
+		// off then on → desired ends where the in-flight set already lands it, so no
+		// corrective dispatch.
 		h.setDesired(false);
 		h.setDesired(true);
 
@@ -116,7 +109,6 @@ describe("runToggleLoop — the #818 / #825 race", () => {
 		h.setDesired(true);
 		const loop = h.run();
 		await tick();
-		// A second click while the first is pending must NOT start a parallel POST.
 		h.setDesired(false);
 		await tick();
 		expect(h.calls).toEqual(["set"]); // still just the first, second is queued

--- a/apps/web/src/components/pano/useToggleAction.ts
+++ b/apps/web/src/components/pano/useToggleAction.ts
@@ -19,41 +19,28 @@ import {useCallback, useRef} from "react";
  */
 export type ToggleAction = "set" | "unset";
 
-/** The mutation pair the loop drives toward the desired on-state. */
 export interface ToggleDispatch {
-	/** Current on-state at call time, the source of truth the loop reconciles against. */
 	readonly on: boolean;
-	/** Fire the underlying fate mutation; resolves when it settles (success or rollback). */
+	/** Resolves when the mutation settles — success or rollback. */
 	readonly dispatch: (action: ToggleAction) => Promise<void>;
 }
 
-/**
- * The corrective action to move from `achieved` toward `desired`, or `null`
- * when they already agree (nothing left to send). Pure — part of the
- * load-bearing race logic, unit-tested without a DOM.
- */
 export function nextToggleAction(achieved: boolean, desired: boolean): ToggleAction | null {
 	if (achieved === desired) return null;
 	return desired ? "set" : "unset";
 }
 
-/** What {@link runToggleLoop} reads each turn — supplied by the hook over refs. */
 export interface ToggleLoopState {
-	/** The user's latest intended end-state; `null` means settled. */
+	/** `null` means settled — the loop and a fresh re-entry both stop on it. */
 	readonly desired: boolean | null;
-	/** Mark the intent satisfied so the loop (and a fresh re-entry) stops. */
 	readonly clearDesired: () => void;
-	/** Latest committed dispatch surface — re-read so payloads track current props. */
+	/** Re-read each turn so payloads track current props. */
 	readonly read: () => ToggleDispatch;
 }
 
 /**
- * The serialize-and-supersede loop, extracted hook-free so the race is unit-
- * testable. Dispatches corrective mutations until `achieved` matches `desired`,
- * re-reading `desired` each turn so a toggle issued mid-flight is picked up
- * rather than dropped. `achieved` is seeded from the committed on-state and
- * advanced by each action actually dispatched — the loop never depends on a
- * re-render landing between iterations to observe its own progress. The caller
+ * `achieved` is advanced by each dispatched action, never re-read from props: the
+ * loop must not depend on a re-render landing between iterations. Caller
  * guarantees a single concurrent run.
  */
 export async function runToggleLoop(getState: () => ToggleLoopState): Promise<void> {
@@ -71,12 +58,6 @@ export async function runToggleLoop(getState: () => ToggleLoopState): Promise<vo
 	}
 }
 
-/**
- * Returns a `toggle()` that flips the desired on-state and drives the dispatch
- * loop. Only one loop runs at a time (preserving anti-double-submit), and it
- * always converges on the latest desired state — so a toggle-back issued
- * mid-flight is never dropped.
- */
 export function useToggleAction(read: () => ToggleDispatch): () => void {
 	const readRef = useRef(read);
 	readRef.current = read;

--- a/apps/web/src/components/pano/useVoteToggle.test.ts
+++ b/apps/web/src/components/pano/useVoteToggle.test.ts
@@ -3,17 +3,9 @@ import {WIRE_MESSAGES} from "../../fate/wireMessages";
 import {isAuthRedirectError, voteGateMessage} from "./useVoteToggle";
 
 /**
- * The shared vote-seam error classification (`useVoteToggle` / `useGatedToggle`):
- * a çaylak's earn-to-vote denial (`VOTE_REQUIRES_YAZAR`) is surfaced as a toast
- * instead of a silent no-op (#1879), while the pre-existing `UNAUTHORIZED`→
- * auth-redirect path and the silence of every other code are unchanged.
- *
- * These exercise the REAL exported classifiers — `voteGateMessage` /
- * `isAuthRedirectError`, the same functions the hook's `dispatch` catch routes
- * through — not a re-implemented copy, and model the gate's caught-error branch
- * over the same controllable dispatch idiom the sibling `DefinitionCard.test.ts`
- * uses, so a regression in the classification fails here rather than only in an
- * e2e.
+ * The shared vote-seam error classification (#1879). These run the REAL exported
+ * classifiers, not a re-implemented copy, so a regression fails here and not only
+ * in an e2e.
  */
 
 describe("voteGateMessage — the VOTE_REQUIRES_YAZAR ladder copy (real classifier)", () => {
@@ -38,9 +30,7 @@ describe("voteGateMessage — the VOTE_REQUIRES_YAZAR ladder copy (real classifi
 });
 
 describe("the gate's dispatch catch — redirect vs toast vs silent (real classifiers)", () => {
-	// Model the caught-error branch of useGatedToggle exactly: redirect iff
-	// `isAuthRedirectError`, else toast iff `voteGateMessage`, else stay silent —
-	// using the REAL classifiers so a break in either fails here.
+	// Mirrors useGatedToggle's caught-error branch, over the real classifiers.
 	const guarded = async (
 		dispatch: () => Promise<void>,
 		redirectToAuth: () => void,
@@ -86,8 +76,7 @@ describe("the gate's dispatch catch — redirect vs toast vs silent (real classi
 
 describe("WIRE_MESSAGES exhaustiveness holds for the new code", () => {
 	it("carries a message for VOTE_REQUIRES_YAZAR", () => {
-		// The registry is typed Record<FateWireCode, string>, so a missing entry is a
-		// compile error; this pins the runtime value too (ladder framing, lowercase).
+		// A missing entry is already a compile error; this pins the runtime copy too.
 		expect(WIRE_MESSAGES.VOTE_REQUIRES_YAZAR).toBe("yazar olunca oy verebilirsin");
 	});
 });

--- a/apps/web/src/components/pano/useVoteToggle.ts
+++ b/apps/web/src/components/pano/useVoteToggle.ts
@@ -1,22 +1,7 @@
 /**
- * The shared vote/save-toggle seam, lifted ABOVE {@link useToggleAction} so the
- * three vote sites (`PanoPostCard`, `CommentTreeNode`, `DefinitionCard`) and the pano
- * save toggle no longer hand-copy the same interaction body. `useToggleAction`
- * owns the serialize-and-supersede race (#818/#825); this owns the *semantics*
- * that used to be duplicated at every call site:
- *
- *  - the signed-out gate (a click with no session redirects to auth, never fires
- *    the mutation);
- *  - the `UNAUTHORIZED` → auth-redirect classification on the dispatch error
- *    channel, and the `VOTE_REQUIRES_YAZAR` → toast classification for the
- *    earn-to-vote denial (#1879 — a çaylak's gated vote is no longer a silent
- *    dead-end); the mutations have no inline error slot, so every OTHER code stays
- *    silent — see `.patterns/fate-mutations-client.md`;
- *  - for votes, the optimistic `score`/`myVote` delta with the `Math.max(0, …)`
- *    floor (a retract never renders a negative score).
- *
- * Any future correction to those (the #818 race class, the score floor, the
- * auth-redirect) is now a one-site edit here, not an N-site shotgun edit.
+ * The shared vote/save-toggle seam for every vote site. Error codes other than
+ * `UNAUTHORIZED` / `VOTE_REQUIRES_YAZAR` stay silent: these sites have no inline
+ * error slot — see `.patterns/fate-mutations-client.md`.
  */
 import {useCallback} from "react";
 import {useNavigate} from "react-router";
@@ -28,64 +13,29 @@ import {authRedirectPath} from "../../lib/returnTo";
 import {type ToggleAction, useToggleAction} from "./useToggleAction";
 
 /**
- * Returns the auth-redirect navigation for the current `returnTo`. `returnTo` is
- * a thunk so a site that derives it from `window.location` reads the live value
- * at click time, not at render.
+ * `returnTo` is a thunk so a site deriving it from `window.location` reads the
+ * live value at click time, not at render.
  */
 function useRedirectToAuth(returnTo: () => string): () => void {
 	const navigate = useNavigate();
 	return useCallback(() => navigate(authRedirectPath(returnTo())), [navigate, returnTo]);
 }
 
-/**
- * What a gated toggle drives: the current on-state plus the underlying fate
- * mutation pair. `dispatch` fires the `set`/`unset` mutation; this seam wraps it
- * with the `UNAUTHORIZED`→redirect catch, so call sites pass the bare mutation.
- */
 export interface GatedToggleArgs {
-	/** Current on-state at click time — the source of truth the loop reconciles against. */
 	readonly on: boolean;
-	/** The path a signed-out (or `UNAUTHORIZED`) interaction returns to after auth. */
 	readonly returnTo: () => string;
-	/**
-	 * Fire the underlying fate mutation; may throw — `UNAUTHORIZED` redirects and
-	 * `VOTE_REQUIRES_YAZAR` toasts (both caught here). The resolved value (the
-	 * mutation's `{error, result}`) is ignored: these sites have no inline error
-	 * slot and lean on the boundary-class throw.
-	 */
+	/** The resolved value is ignored — only the thrown code is classified. */
 	readonly dispatch: (action: ToggleAction) => Promise<unknown>;
 }
 
-/**
- * Whether a dispatch error is the auth-boundary class that should redirect to
- * auth rather than stay silent — the `UNAUTHORIZED` mutation throw. Pure and
- * exported so the classification is unit-testable apart from the hook; any other
- * code stays silent (these sites have no inline error slot).
- */
 export function isAuthRedirectError(error: unknown): boolean {
 	return codeOf(error) === "UNAUTHORIZED";
 }
 
-/**
- * The Turkish toast copy for a dispatch error that carries a *legible* gate the
- * user should be told about, or `null` for one that stays silent. Today the only
- * such gate is the earn-to-vote denial: a çaylak casting a vote is rejected with
- * `VOTE_REQUIRES_YAZAR`, and the ladder copy "yazar olunca oy verebilirsin" makes
- * the progression visible instead of a silent no-op (#1879). `UNAUTHORIZED` is
- * NOT surfaced here — it redirects (see {@link isAuthRedirectError}); every other
- * code stays silent (these sites have no inline error slot). Pure and exported so
- * the classification is unit-testable apart from the hook.
- */
 export function voteGateMessage(error: unknown): string | null {
 	return codeOf(error) === "VOTE_REQUIRES_YAZAR" ? WIRE_MESSAGES.VOTE_REQUIRES_YAZAR : null;
 }
 
-/**
- * The serialize-and-supersede toggle (via {@link useToggleAction}) wrapped with
- * the signed-out gate and the `UNAUTHORIZED`→auth-redirect classification. The
- * returned `onToggle` is the click handler: it redirects a signed-out click and
- * otherwise drives the mutation loop.
- */
 export function useGatedToggle(args: GatedToggleArgs): () => void {
 	const session = useSession();
 	const redirectToAuth = useRedirectToAuth(args.returnTo);
@@ -101,11 +51,7 @@ export function useGatedToggle(args: GatedToggleArgs): () => void {
 					redirectToAuth();
 					return;
 				}
-				// A legible gate (today: the earn-to-vote `VOTE_REQUIRES_YAZAR` denial) is
-				// surfaced as a toast instead of a silent no-op — the server deliberately made
-				// this denial wire-visible and the client used to throw it away (#1879). Same id
-				// per gate so N failed taps replace rather than stack. Every other code stays
-				// silent (these sites have no inline error slot).
+				// Same toast id per gate so N failed taps replace rather than stack (#1879).
 				const message = voteGateMessage(error);
 				if (message) show({id: "vote-gate", message, testId: "vote-gate"});
 			}
@@ -121,37 +67,22 @@ export function useGatedToggle(args: GatedToggleArgs): () => void {
 	}, [session.data?.user, redirectToAuth, drive]);
 }
 
-/** The fate mutation pair a vote site supplies — set upvotes, unset retracts. */
 export interface VoteMutations {
-	/** Cast an upvote with the supplied optimistic `{score, myVote}`. */
 	readonly vote: (optimistic: {score: number; myVote: true}) => Promise<unknown>;
-	/** Retract the upvote with the supplied optimistic `{score, myVote}`. */
 	readonly retractVote: (optimistic: {score: number; myVote: false}) => Promise<unknown>;
 }
 
-/** The optimistic `{score, myVote}` payload for one vote/retract action. */
 export type VoteOptimistic =
 	| {readonly score: number; readonly myVote: true}
 	| {readonly score: number; readonly myVote: false};
 
-/**
- * The optimistic vote delta a `set`/`unset` applies to the current score: a vote
- * is `score + 1` / `myVote: true`, a retract is `Math.max(0, score - 1)` /
- * `myVote: false` — the `0` floor so a retract never renders a negative score.
- * Pure and exported so the load-bearing delta is unit-testable without the hook;
- * {@link useVoteToggle} routes its dispatch through it.
- */
+/** The `Math.max(0, …)` floor is deliberate: a retract never renders a negative score. */
 export function voteOptimistic(action: ToggleAction, score: number): VoteOptimistic {
 	return action === "unset"
 		? {score: Math.max(0, score - 1), myVote: false}
 		: {score: score + 1, myVote: true};
 }
 
-/**
- * Vote specialization of {@link useGatedToggle}: owns the optimistic vote delta
- * ({@link voteOptimistic}), so a site supplies only its current `{voted, score}`
- * and the mutation pair. Returns the vote-button click handler.
- */
 export function useVoteToggle(args: {
 	readonly voted: boolean;
 	readonly score: number;
@@ -173,7 +104,6 @@ export function useVoteToggle(args: {
 	});
 }
 
-/** The current-location `returnTo` thunk for sites that return to where they are. */
 export function currentLocationReturnTo(): string {
 	return `${window.location.pathname}${window.location.search}`;
 }

--- a/apps/web/src/components/profile/CaylakStatusBlock.test.ts
+++ b/apps/web/src/components/profile/CaylakStatusBlock.test.ts
@@ -1,9 +1,5 @@
-/**
- * The çaylak status block's gating, copy, and one-way-glass contracts (#1291),
- * asserted DOM-free — `apps/web/src` has no jsdom, so the gate, the vouch readout,
- * and the consumed-shape key set are factored out of the component and tested as
- * pure values (the pure-extraction idiom of `flagGateChild` / `shouldShowOnramp`).
- */
+// `apps/web/src` has no jsdom, so the gate, the vouch readout, and the consumed-shape
+// key set are factored out of the component and asserted as pure values.
 import {describe, expect, it} from "vitest";
 import {
 	caylakPromotionPath,
@@ -71,7 +67,6 @@ describe("caylakPromotionPath — the unvouched-vs-vouched rendering split (#132
 	});
 
 	it("the unvouched copy communicates that a vouch (or a mod action) is required", () => {
-		// the vouch path ('kefil') and the mod alternative are both surfaced
 		expect(VOUCH_NEEDED_COPY.message).toMatch(/kefil/);
 		expect(VOUCH_NEEDED_COPY.hint).toMatch(/moderatör/);
 	});

--- a/apps/web/src/components/profile/CaylakStatusBlock.tsx
+++ b/apps/web/src/components/profile/CaylakStatusBlock.tsx
@@ -1,38 +1,11 @@
 /**
- * `CaylakStatusBlock` — the çaylak's own "yazarlığa giden yol" (path-to-authorship)
- * status block on their OWN profile (#1291, epic #1202). Reads the aggregate-only
- * `myAuthorshipStanding` (#1316): karma vs the promotion bar, whether a vouch
- * exists (a bare boolean — NEVER who vouched), and the count of entries in review.
+ * `CaylakStatusBlock` — the çaylak's own "yazarlığa giden yol" status block on their
+ * OWN profile, off the aggregate-only `myAuthorshipStanding` read.
  *
- * ONE-WAY GLASS — the load-bearing divan privacy invariant: the consumed shape is
- * aggregate-only and carries NO reviewer / voter / voucher identity. The field is
- * structurally absent on the backend `AuthorshipStanding` type (#1316), and this
- * surface selects only the four aggregate scalars ({@link STANDING_FIELDS}), so a
- * leak is unrepresentable at the API boundary AND here — never merely unrendered.
- *
- * Two gates, both required ({@link shouldShowCaylakStatus}): the trusted tier read
- * off `useMe().me.tier` (#1297) being `çaylak`, AND the viewer looking at their OWN
- * profile (`me.id === profileUserId`). A yazar/mod, a visitor, or another user's
- * profile is a clean no-op. A null standing renders nothing — so the block never
- * queries off the safe path.
- *
- * Honest promotion-path framing ({@link caylakPromotionPath}, #1323): an UNVOUCHED
- * çaylak does NOT see a karma progress bar — the unassisted bar is 100 but no amount
- * of karma promotes without a vouch (`resolveTandem` short-circuits on the vouch
- * half), so a 100-karma goal would depict a path that doesn't exist. The unvouched
- * state surfaces the vouch-needed framing instead; once `vouchExists` is true the
- * block draws the real reduced bar (15), the already-honest path.
- *
- * Imperative fetch (`request` + `readView`), not the suspending `useRequest`: the
- * block sits inside the header and must NOT suspend the whole header on a secondary
- * read, and must NOT query unless the three gates pass — the same reasoning as
- * `useMe`. `myAuthorshipStanding` throws `UNAUTHORIZED` for an anonymous viewer, so
- * gating on `me`/own-profile keeps a signed-out viewer off the wire.
- *
- * a11y: a labelled `<section>` region (`aria-labelledby` → its own heading) with a
- * real `<h2>`; vouch state is carried by words ("var"/"yok"), never color; the Karma
- * atom carries its own AA-contrast, reduced-motion-safe progress bar; no animation of
- * its own. Copy is lowercase Turkish (karma is a brand noun).
+ * Fetched imperatively rather than through the suspending `useRequest`: the block
+ * sits inside the header and must not suspend it on a secondary read, and must not
+ * touch the wire at all unless the gates pass — `myAuthorshipStanding` throws
+ * `UNAUTHORIZED` for an anonymous viewer.
  */
 import {useId} from "react";
 import {view} from "react-fate";
@@ -43,48 +16,25 @@ import {useImperativeView} from "../../fate/useImperativeView";
 import {Karma} from "../karma/Karma";
 import "./CaylakStatusBlock.css";
 
-/**
- * The block's gating decision, factored DOM-free so the contract — show iff the
- * viewer is a çaylak AND they are looking at their OWN profile — is unit-testable
- * without a DOM (the pure-extraction idiom of `flagGateChild` / `shouldShowOnramp`).
- * Reused to gate the per-item "incelemede" badge in the contributions feed, so the
- * badge and the block share one gate.
- */
 export function shouldShowCaylakStatus(tier: Tier | undefined, isOwnProfile: boolean): boolean {
 	return tier === "çaylak" && isOwnProfile;
 }
 
-/** The vouch-exists readout — a bare yes/no, NEVER who vouched (one-way glass). */
 export function vouchExistsLabel(vouchExists: boolean): string {
 	return vouchExists ? "var" : "yok";
 }
 
-/**
- * The unvouched çaylak's path-to-yazar copy. Karma is necessary-but-not-sufficient:
- * `resolveTandem` short-circuits on the vouch half (`if (!hasActiveFor) return …`),
- * so an unvouched çaylak's karma is never even read and NO amount of karma promotes
- * them — the only routes are a yazar's vouch (then the reduced 15-bar) or a mod
- * action. Surfacing the unassisted 100-bar here would depict a goal that maps to no
- * live promotion trigger (#1323), so the unvouched state shows this framing instead.
- * Lowercase Turkish; karma is a brand noun.
- */
 export const VOUCH_NEEDED_COPY = {
 	message: "bir yazar sana kefil olmalı",
 	hint: "ya da bir moderatör seni doğrudan yükseltebilir",
 } as const;
 
 /**
- * The çaylak status block's promotion-path rendering split, factored DOM-free so the
- * unvouched-vs-vouched contract is unit-testable without a DOM (the pure-extraction
- * idiom of {@link shouldShowCaylakStatus}). The shape makes the invalid state
- * unrepresentable: the karma bar carries no copy, and the vouch-needed framing only
- * exists where there is no honest bar to draw.
- *
- * - **Unvouched** (`vouchExists === false`): no karma bar — the unassisted 100-bar
- *   would imply karma alone promotes, which it does not (#1323). Show the
- *   vouch-needed framing.
- * - **Vouched** (`vouchExists === true`): the real reduced bar (`standing.bar` is
- *   `VOUCH_PROMOTION_KARMA_BAR` = 15), the already-honest path — unchanged.
+ * An unvouched çaylak deliberately gets NO karma bar: `resolveTandem` short-circuits
+ * on the vouch half, so no amount of karma promotes them and the unassisted 100-bar
+ * would depict a goal that maps to no live promotion trigger (#1323). Only once a
+ * vouch exists is there an honest bar to draw (the reduced `VOUCH_PROMOTION_KARMA_BAR`
+ * = 15).
  */
 export type CaylakPromotionPath =
 	| {readonly kind: "karma-bar"}
@@ -97,11 +47,10 @@ export function caylakPromotionPath(vouchExists: boolean): CaylakPromotionPath {
 }
 
 /**
- * The aggregate-only wire selection: the client normalization key `id` plus the
- * four aggregate scalars. There is deliberately NO reviewer / voter / voucher
- * identity key — the one-way-glass invariant is structural on the backend type
- * (#1316) and mirrored here, so a leak can't be reintroduced by widening the
- * selection.
+ * One-way glass: the `id` normalization key plus the four aggregate scalars, and
+ * deliberately NO reviewer / voter / voucher identity key. The invariant is
+ * structural on the backend type (#1316) and mirrored here, so widening this
+ * selection is what would reintroduce the leak.
  */
 export const STANDING_FIELDS = {
 	id: true,
@@ -113,28 +62,17 @@ export const STANDING_FIELDS = {
 
 const StandingView = view<AuthorshipStanding>()(STANDING_FIELDS);
 
-/**
- * The aggregate-only standing shape, derived from the codegen'd
- * `AuthorshipStanding` Entity (ADR 0022) — a `Pick` over the four aggregate
- * scalars, never a hand-restated interface. The one-way-glass invariant is
- * structural on the backend type (#1316): there is no reviewer/voter/voucher
- * identity field to pick, so a leak stays unrepresentable.
- */
+// See ADR 0022
 type Standing = Pick<AuthorshipStanding, "karma" | "bar" | "vouchExists" | "inReviewCount">;
 
-/**
- * Fetches `myAuthorshipStanding` imperatively, but only when `enabled` (the three
- * gates passed). Disabled ⇒ never touches the wire and reports `null`. Any failure
- * resolves to `null` — the safe/off path, exactly like `useFlag`'s default — so a
- * read error degrades to "no block", never a thrown header.
- */
+// A failed read resolves to `null` on purpose — the safe/off path, so an error
+// degrades to "no block" rather than throwing the whole header.
 function useAuthorshipStanding(enabled: boolean): Standing | null {
 	const {state} = useImperativeView("myAuthorshipStanding", StandingView, {enabled});
 	return state.status === "ok" ? state.data : null;
 }
 
 export interface CaylakStatusBlockProps {
-	/** The profile being viewed — own-profile is `me.id === profileUserId`. */
 	readonly profileUserId: string;
 }
 

--- a/apps/web/src/components/profile/ContributionRow.tsx
+++ b/apps/web/src/components/profile/ContributionRow.tsx
@@ -1,6 +1,5 @@
-// `Contribution` is a single discriminant view (ADR 0018): one node carries `kind`
-// plus the nullable union of all three variants' fields, so this row switches on
-// `kind` with no union type.
+// `Contribution` is one discriminant view carrying every variant's fields as
+// nullables, so this row switches on `kind` with no union type. See ADR 0018.
 import {useView, type ViewRef, view} from "react-fate";
 import {Link} from "react-router";
 import type {Contribution} from "../../../worker/features/fate/views";
@@ -16,10 +15,8 @@ export const ContributionView = view<Contribution>()({
 	id: true,
 	score: true,
 	createdAt: true,
-	// The per-item review-state flag (#1316): `true` for a still-sandboxed item, so
-	// the owner's profile can badge it "incelemede" (#1291). A bare boolean — carries
-	// no reviewer identity (one-way glass). Sent only to the author/moderator, so a
-	// non-owner viewer never receives a sandboxed row in the first place.
+	// A bare boolean carrying no reviewer identity (one-way glass), and sent only to
+	// the author/moderator — a non-owner never receives a sandboxed row at all.
 	sandboxed: true,
 	bodyExcerpt: true,
 	termSlug: true,
@@ -32,11 +29,6 @@ export const ContributionView = view<Contribution>()({
 
 export interface ContributionRowProps {
 	node: ViewRef<"Contribution">;
-	/**
-	 * Render the "incelemede" badge on a still-sandboxed item (#1291). The caller
-	 * gates this on the çaylak-status gate (flag + own profile + çaylak), so the
-	 * badge only appears for the owner's own pending items. Default `false`.
-	 */
 	sandboxBadge?: boolean;
 }
 

--- a/apps/web/src/components/profile/DeleteAccountDialog.test.ts
+++ b/apps/web/src/components/profile/DeleteAccountDialog.test.ts
@@ -4,8 +4,6 @@ import {CONFIRMATION_PHRASE, matchesConfirmation} from "./DeleteAccountDialog";
 
 describe("DeleteAccountDialog confirmation gate", () => {
 	it("the dialog phrase equals the worker's Schema.Literal — a drift would silently un-gate", () => {
-		// The whole "make a wrong confirmation unrepresentable" guarantee rests on the
-		// client phrase matching the mutation's literal exactly; this binds them.
 		expect(CONFIRMATION_PHRASE).toBe(ACCOUNT_DELETE_CONFIRMATION);
 	});
 

--- a/apps/web/src/components/profile/DeleteAccountDialog.tsx
+++ b/apps/web/src/components/profile/DeleteAccountDialog.tsx
@@ -1,14 +1,6 @@
-/**
- * The "tehlikeli alan" account-deletion confirmation dialog. The confirm action
- * is gated behind typing the exact phrase `account.delete` requires
- * (`hesabımı kalıcı olarak sil`, mirrored from the worker's `Schema.Literal`):
- * the confirm button is disabled until the typed text matches, so a destructive
- * call on an unconfirmed dialog is unrepresentable. On success the caller clears
- * the session and the page redirects — see `onConfirmed`.
- *
- * The mutation classifies as boundary, so it may throw OR return `{error}`; we
- * handle both and surface the failure inline (see `.patterns/fate-mutations-client.md`).
- */
+// The account-deletion confirmation dialog. `account.delete` is a boundary mutation,
+// so it may throw OR return `{error}` and both paths are handled below — see
+// `.patterns/fate-mutations-client.md`.
 import {useState} from "react";
 import {useFateClient, view} from "react-fate";
 import type {AccountDeletionReceipt} from "../../../worker/features/fate/views";
@@ -20,7 +12,6 @@ import {Input} from "../ui/Form";
 // types it verbatim and the mutation input re-validates it server-side.
 export const CONFIRMATION_PHRASE = "hesabımı kalıcı olarak sil";
 
-/** The gate: the confirm action is reachable only when the typed text is exact. */
 export const matchesConfirmation = (typed: string): boolean => typed === CONFIRMATION_PHRASE;
 
 const ReceiptView = view<AccountDeletionReceipt>()({
@@ -35,7 +26,6 @@ export function DeleteAccountDialog({
 }: {
 	open: boolean;
 	onOpenChange: (v: boolean) => void;
-	/** Run after the account is anonymized — clears the session and redirects. */
 	onConfirmed: () => Promise<void> | void;
 }) {
 	const fate = useFateClient();

--- a/apps/web/src/components/profile/ProfileContributionSignal.tsx
+++ b/apps/web/src/components/profile/ProfileContributionSignal.tsx
@@ -1,21 +1,13 @@
 /**
- * The thin contribution signal on the owner's own profile (#1209): a lightweight
- * readout of the most recent few contributions so a çaylak sees their track record
- * accumulating toward promotion. Reuses the existing `Contribution` activity view
- * (`ContributionRow` + the `Profile.contributions` connection) — NOT a new query.
+ * The thin contribution signal on the owner's own profile — a capped, recent-first
+ * readout, deliberately not a feed (no in-place pagination, no analytics/streaks).
  *
- * It is intentionally thin (out of scope: a full analytics dashboard / streaks /
- * gamification): a capped, recent-first list with a "tümünü gör" link to the full
- * public feed when there's more — no in-place pagination.
+ * The `Profile.contributions` resolver keys on `authorId` with no sandbox filter, so
+ * the owner sees their OWN still-sandboxed rows here while the public cannot.
  *
- * Sandbox honesty (AC #2): the `Profile.contributions` resolver keys the feed on
- * `authorId` (the profile owner) with no sandbox filter, so the owner sees their OWN
- * still-sandboxed content here — their record stays legible to them while it is hidden
- * from the public.
- *
- * Renders under its own `<Screen>` because the owner `ProfilePage` drives fate
- * imperatively above any Suspense boundary (see `useProfileStats`); the boundary lets
- * this child suspend on its own batched `useRequest` like the public `UserProfilePage`.
+ * It mounts its own `<Screen>` because the owner `ProfilePage` drives fate
+ * imperatively above any Suspense boundary; the boundary is what lets this child
+ * suspend on its own batched `useRequest`.
  */
 import type {ReactNode} from "react";
 import {useListView, useRequest, useView, type ViewRef, view} from "react-fate";
@@ -28,17 +20,14 @@ import {ContributionRow, ContributionView} from "./ContributionRow";
 import {CONTRIBUTIONS_EMPTY, CONTRIBUTIONS_HEADING} from "./profileContributions";
 import "./ProfileContributionSignal.css";
 
-// Thin by design: just enough recent items to read as a track record, never a feed.
 const SIGNAL_SIZE = 5;
 
 const ContributionsConnectionView = {items: {node: ContributionView}} as const;
 
-// Selects the count scalars alongside `contributions` so this read is a SUPERSET
-// of `useProfileStats`'s counts-only `profile` read (#2209): the two share a
-// `profile` root queryKey (root-path args `{username}`), so once this superset
-// populates the record, the sibling counts-only read on `/profile` resolves those
-// scalars from the normalized store instead of a second wire round-trip — the
-// counts read deduped onto this fuller one. The scalars aren't rendered here.
+// The count scalars are not rendered here: they make this a SUPERSET of
+// `useProfileStats`'s counts-only `profile` read, which shares the `profile` root
+// queryKey, so that sibling read dedupes onto this one instead of a second wire
+// round-trip (#2209). Dropping them costs an extra request.
 const SignalView = view<Profile>()({
 	userId: true,
 	postCount: true,
@@ -61,12 +50,8 @@ function SignalShell({children}: {children: ReactNode}) {
 	);
 }
 
-/**
- * The Katkıların loading skeleton — shared by the `<Screen>` fallback below and the
- * eager pre-session paint above the gate (ADR 0167 / #2188), so the skeleton the
- * always-anonymous first paint shows is byte-identical to the one the settled authed
- * read shows: no visual jump as the eager tier hands off to the below-gate read.
- */
+// Shared by the `<Screen>` fallback below and the eager pre-session paint above the
+// gate so the two are byte-identical and the handoff shows no visual jump. See ADR 0167.
 export function ProfileContributionSkeleton() {
 	return (
 		<SignalShell>
@@ -78,14 +63,10 @@ export function ProfileContributionSkeleton() {
 }
 
 /**
- * The eager Katkıların skeleton the `/profile` route paints ABOVE the session gate
- * (mounted by `Layout` while `get-session` is still pending), the two-tier decoupling
- * of ADR 0167 extended to `/profile` (#2188). Unlike `/pano`'s eager tier it carries
- * NO fate client: the owner's own contributions are identity-scoped (the resolver
- * shows the owner their still-sandboxed rows), so the real read must stay on the authed
- * client below the gate — pre-session there is only a skeleton to paint, no anon data.
- * Mounting no `FateClient` is also what makes it #438-safe by construction: with no
- * client above the gate there is nothing to re-key anon→id.
+ * Painted above the session gate, and unlike `/pano`'s eager tier it mounts NO fate
+ * client on purpose: these contributions are identity-scoped, so the real read must
+ * stay on the authed client below the gate, and with no client above there is nothing
+ * to re-key anon→id (#438). See ADR 0167.
  */
 export function EagerProfileContributionSkeleton() {
 	return <ProfileContributionSkeleton />;
@@ -116,9 +97,6 @@ function SignalContent({username}: {username: string}) {
 		profile: {view: SignalView, args: {username, contributions: {first: SIGNAL_SIZE}}},
 	});
 
-	// A null profile (owner not yet bootstrapped) reads as an empty record, not an
-	// error — the honest-empty-state stance of `useProfileStats` (#448). The list
-	// hooks live in `SignalList`, mounted only with a non-null ref.
 	if (!profile) {
 		return (
 			<SignalShell>

--- a/apps/web/src/components/profile/ProfileHeader.tsx
+++ b/apps/web/src/components/profile/ProfileHeader.tsx
@@ -1,18 +1,8 @@
 /**
- * `ProfileHeader` — the shared, presentational profile-header primitive (#2203):
- * avatar (image-or-initials) + display name + `@handle`{+ standing} + the canonical
- * activity tiles. Consumed by BOTH the owner's self-service `/profile`
- * (`ProfilePage`) and the public `/u/:username` (`UserProfileHeader`), which
- * previously hand-derived two headers that drifted (two stat orders, a standing
- * badge on one but not the other). This component owns the DOM; each surface only
- * maps its own data source (imperative `useMe`/`useProfileStats` on `/profile`, the
- * fate `Profile` view on `/u/`) into these plain props.
- *
- * The activity-tile order is the single source `profileStatTiles`; `karma` is the
- * optional owner-only tile (`showKarma`), rendered via the shared `Karma` atom and
- * kept structurally last. `standingLabel`
- * is likewise optional (owner-only — the public view has no viewed-user tier), so a
- * `null` renders handle-only, exactly as before.
+ * The one presentational profile header, owning the DOM for BOTH the owner's
+ * `/profile` and the public `/u/:username`. Each surface only maps its own data
+ * source into these plain props — the two used to hand-derive headers that drifted
+ * apart (#2203).
  */
 import {Karma} from "../karma/Karma";
 import {Alert} from "../ui/Alert";
@@ -30,15 +20,11 @@ export interface ProfileHeaderStats {
 export interface ProfileHeaderProps {
 	readonly displayName: string;
 	readonly handle: string;
-	/** Owner-only trusted-tier subtitle; `null`/absent ⇒ handle-only. */
 	readonly standingLabel?: string | null;
-	/** Avatar image; falls back to display-name initials when absent. */
 	readonly image?: string | null;
-	/** Activity + karma counts. `null` renders the tiles as an error strip. */
 	readonly stats: ProfileHeaderStats | null;
-	/** A failed stats read — renders the error strip, never a misleading `0` (#448). */
+	/** A failed stats read renders the error strip, never a misleading `0` (#448). */
 	readonly statsError?: boolean;
-	/** Emit the karma tile — owner-only, shown on `/profile`. */
 	readonly showKarma?: boolean;
 }
 

--- a/apps/web/src/components/profile/PromotionActions.test.ts
+++ b/apps/web/src/components/profile/PromotionActions.test.ts
@@ -1,11 +1,3 @@
-/**
- * `PromotionActions` decision coverage (#1206) — the mod-direct promote
- * call→outcome→copy mapping, factored DOM-free (the `flagGateChild` /
- * `toProfileStatsState` pure-extraction idiom; `apps/web/src` has no jsdom). Proves
- * `user.promote`'s `{result, error}` lands on the right lowercase-Turkish status,
- * including the authority-denial outcome. (The vouch UI is a deferred slice — only
- * the mod-direct surface is built here.)
- */
 import {describe, expect, it} from "vitest";
 import {
 	promoteOutcome,

--- a/apps/web/src/components/profile/PromotionActions.tsx
+++ b/apps/web/src/components/profile/PromotionActions.tsx
@@ -1,24 +1,11 @@
 /**
- * `PromotionActions` — the thin moderator-facing surface for the çaylak→yazar
- * promotion (#1206). One affordance on a profile: a moderator "yazarlığa yükselt"
- * (direct promote). The server is the sole authority (`user.promote` is
- * `Moderate`-gated) — this surface just calls the mutation and reports the outcome;
- * an unauthorized click comes back denied and shows "yetkin yok".
+ * The moderator-facing çaylak→yazar promote affordance. `user.promote` is
+ * `Moderate`-gated server-side and stays the sole authority — the visibility gate
+ * here is UX only, not a trust boundary.
  *
- * Visibility mirrors the divan's promote gate ({@link shouldShowPromotionActions} →
- * `promoteVisible`, #1841): the mount renders only for a moderator, and never on the
- * viewer's own profile — so the affordance no longer surfaces where it can only be
- * denied. The server stays authoritative; the gate is a UX guard, not a trust guard.
- *
- * Deliberately MOD-DIRECT ONLY: the author-vouch path's UI (a vouch / vouch-discovery
- * surface) is deferred to a separate product slice while its UX — and the open
- * sandbox-visibility-for-yazars question (#1205) — is designed. The vouch *mechanism*
- * ships server-side (`user.vouch`); only its surface is held back here.
- *
- * a11y: a Manti Button (focusable, keyboard-activatable, visible focus from the
- * app's button styles); the section is a labelled landmark; the outcome is a
- * `role="status" aria-live="polite"` text region (state conveyed as words, never
- * color); copy is lowercase Turkish; no animation (reduced-motion-safe by default).
+ * Deliberately MOD-DIRECT ONLY: the vouch mechanism ships server-side
+ * (`user.vouch`), but its UI is held back pending the open
+ * sandbox-visibility-for-yazars question (#1205).
  */
 import {useState} from "react";
 import {useFateClient, view} from "react-fate";
@@ -28,14 +15,6 @@ import {promoteVisible} from "../divan/divanGating";
 import {Alert} from "../ui/Alert";
 import {Button} from "../ui/Button";
 
-/**
- * Gate the profile-page promote mount the way the divan does: mod-only
- * ({@link promoteVisible}, the server-authoritative `isModerator` gate #1320) AND
- * never on the viewer's own profile (self-promotion is nonsensical). Factored
- * DOM-free so the profile mount and the divan share one visibility rule instead of
- * diverging (#1841); the server stays the sole authority (`user.promote` is
- * `Moderate`-gated) — this only stops surfacing a button that can never succeed.
- */
 export function shouldShowPromotionActions(isModerator: boolean, isOwnProfile: boolean): boolean {
 	return promoteVisible(isModerator) && !isOwnProfile;
 }
@@ -46,7 +25,6 @@ const PromotionReceiptView = view<PromotionReceipt>()({
 	vouchRecorded: true,
 });
 
-/** The promotion-surface outcome the status line renders. */
 export type PromotionOutcome = "promoted" | "alreadyYazar" | "denied" | "error";
 
 interface PromotionResult {
@@ -54,13 +32,11 @@ interface PromotionResult {
 	vouchRecorded?: boolean;
 }
 
-/** A denial (authority) error vs any other failure — the two error outcomes. */
 const errorOutcome = (error: unknown): PromotionOutcome => {
 	const code = codeOf(error);
 	return code === "UNAUTHORIZED" || code === "FORBIDDEN" ? "denied" : "error";
 };
 
-/** Map a `user.promote` call's `{result, error}` onto its outcome. */
 export function promoteOutcome(
 	result: PromotionResult | null | undefined,
 	error: unknown,
@@ -69,7 +45,6 @@ export function promoteOutcome(
 	return result?.promoted ? "promoted" : "alreadyYazar";
 }
 
-/** The lowercase-Turkish status line for an outcome — words, never color. */
 export function promotionOutcomeMessage(outcome: PromotionOutcome): string {
 	switch (outcome) {
 		case "promoted":

--- a/apps/web/src/components/profile/UserProfileHeader.tsx
+++ b/apps/web/src/components/profile/UserProfileHeader.tsx
@@ -39,9 +39,6 @@ export function UserProfileHeader(props: UserProfileHeaderProps) {
 				}}
 				showKarma
 			/>
-			{/* The çaylak's own "yazarlığa giden yol" status block (#1291); renders only
-			    for a çaylak on their own profile, off an aggregate-only read (one-way
-			    glass). */}
 			<CaylakStatusBlock profileUserId={profile.userId} />
 		</>
 	);

--- a/apps/web/src/components/profile/profileContributions.ts
+++ b/apps/web/src/components/profile/profileContributions.ts
@@ -1,21 +1,13 @@
-/**
- * The shared contributions copy for the two profile surfaces (#2203). Both `/u/`
- * (public) and `/profile` (self) render the same `EmptyState` card and the same
- * `ContributionRow` cards; the only intentional divergence is the section heading,
- * which stays per-surface-intent: third-person `katkılar` on someone else's public
- * profile, second-person `katkıların` on the owner's own self-service view. Naming
- * them here makes the split intentional rather than the accidental drift #2203
- * observed. Lowercase Turkish (user-facing copy).
- */
+// The two profile surfaces share this copy. The heading is the one intentional
+// divergence — third-person `katkılar` on someone else's profile, second-person
+// `katkıların` on the owner's own — named here so it reads as a choice, not the
+// accidental drift #2203 found.
 
 export const CONTRIBUTIONS_HEADING = {
-	/** `/u/:username` — a third party viewing someone's public contributions. */
 	public: "katkılar",
-	/** `/profile` — the owner viewing their own contributions. */
 	self: "katkıların",
 } as const;
 
-/** The one empty-state card both surfaces render (via the shared `EmptyState`). */
 export const CONTRIBUTIONS_EMPTY = {
 	title: "henüz katkı yok.",
 	description: "ilk tanımını ya da başlığını ekleyince burada görünür.",

--- a/apps/web/src/components/profile/profileStanding.test.ts
+++ b/apps/web/src/components/profile/profileStanding.test.ts
@@ -1,13 +1,3 @@
-/**
- * The profile-header standing-label contract (#1302), asserted DOM-free — the
- * per-tier mapping is factored out of `ProfilePage` and tested as a pure function
- * (the pure-extraction idiom of `shouldShowOnramp`).
- *
- * The load-bearing invariant is honesty: the subtitle must reflect the account's
- * real tier and NEVER fall back to a static lie like the `yeni üye` it replaces.
- * These tests pin both halves — the true per-tier label AND the null (handle-only)
- * fallback for every state with no honest label.
- */
 import {describe, expect, it} from "vitest";
 import {profileStandingLabel} from "./profileStanding";
 

--- a/apps/web/src/components/profile/profileStanding.ts
+++ b/apps/web/src/components/profile/profileStanding.ts
@@ -1,21 +1,8 @@
 /**
- * The profile-header standing label (#1302) — replaces the hard-coded `· yeni üye`
- * subtitle that asserted "new member" for EVERY account regardless of standing.
- *
- * Derived from the trusted account tier (`useMe().me.tier`, exposed on the fate
- * read path by #1297), so the label is true: a yazar reads `yazar`, a çaylak reads
- * `çaylak`, never a static placeholder. Factored DOM-free (the pure-extraction
- * idiom of `shouldShowOnramp` / `shouldShowCaylakStatus`) so the per-tier mapping
- * is unit-testable without a DOM (`apps/web/src` has no jsdom).
- *
- * **No false label, ever.** When there is no honest tier to show — the tier is
- * still loading/errored (`undefined`), or it is the read-time `visitor` rank an
- * authenticated account never legitimately holds — the function returns `null`, and
- * the header renders handle-only. It never substitutes a new placeholder that lies
- * (the exact bug #1302 fixes).
- *
- * Copy is the lowercase-Turkish glossary rank (`çaylak` / `yazar`,
- * `.glossary/TERMS.md`), never an invented label.
+ * The profile-header standing label. No false label, ever: with no honest tier to
+ * show this returns `null` and the header renders handle-only, rather than the
+ * hard-coded `yeni üye` placeholder it replaces, which lied for every account
+ * (#1302).
  */
 import type {Tier} from "../../../worker/features/kunye/standing";
 

--- a/apps/web/src/components/profile/profileStatTiles.test.ts
+++ b/apps/web/src/components/profile/profileStatTiles.test.ts
@@ -1,10 +1,3 @@
-/**
- * The canonical profile activity-tile order (#2203), asserted DOM-free — the ONE
- * ordering shared by `/profile` and `/u/:username` is factored to a pure function
- * and pinned here (the pure-extraction idiom of `profileStandingLabel`). Before
- * this the two hand-derived headers rendered the same scalars in two orders; the
- * test is what keeps them from drifting apart again.
- */
 import {describe, expect, it} from "vitest";
 import {profileStatTiles} from "./profileStatTiles";
 

--- a/apps/web/src/components/profile/profileStatTiles.ts
+++ b/apps/web/src/components/profile/profileStatTiles.ts
@@ -1,15 +1,7 @@
 /**
- * The canonical profile activity-tile order (#2203) — factored DOM-free so the ONE
- * ordering shared by both profile surfaces (`/profile` and `/u/:username`) is
- * unit-testable without a DOM (the pure-extraction idiom of `profileStandingLabel`
- * / `shouldShowCaylakStatus`). Before this the two hand-derived headers rendered
- * the same activity scalars in two different orders (`ProfilePage` had
- * `[başlık, yorum, tanım]`, `UserProfileHeader` had `[tanım, başlık, yorum]`); this
- * is the single source they now share.
- *
- * Canonical order is `[tanım, başlık, yorum]` — sözlük is definition-first, so the
- * tanım count leads. The owner-only `karma` tile is appended by `ProfileHeader` (via
- * the shared `Karma` atom), so it stays structurally last and never enters this
+ * The one activity-tile order both profile surfaces share (#2203). `[tanım, başlık,
+ * yorum]` — sözlük is definition-first, so the tanım count leads. The owner-only
+ * `karma` tile is appended by `ProfileHeader` and deliberately stays out of this
  * reorderable set.
  */
 
@@ -20,12 +12,10 @@ export interface ProfileActivityCounts {
 }
 
 export interface ProfileStatTile {
-	/** Stable React key + the tile's identity. */
 	readonly key: "definitions" | "posts" | "comments";
 	/** The `data-testid` the profile e2e keys on. */
 	readonly testId: string;
 	readonly value: number;
-	/** Lowercase-Turkish tile label. */
 	readonly label: string;
 }
 

--- a/apps/web/src/components/reaction/CommentReactionBar.tsx
+++ b/apps/web/src/components/reaction/CommentReactionBar.tsx
@@ -1,15 +1,9 @@
-/**
- * Comment surface wiring for the shared {@link ReactionBar} (#1867): binds
- * `fate.mutations.comment.react` and the comment's `reactions` write-back view.
- * The pano comment tree node renders this behind the reaction flag.
- */
 import {useFateClient, view} from "react-fate";
 import type {Comment} from "../../../worker/features/fate/views";
 import {currentLocationReturnTo} from "../pano/useVoteToggle";
 import {ReactionBar} from "./ReactionBar";
 import {useReactionBar} from "./useReactionBar";
 
-/** Write-back view for the comment react mutation. */
 export const CommentReactionView = view<Comment>()({
 	id: true,
 	reactions: {counts: true, myReaction: true},

--- a/apps/web/src/components/reaction/DefinitionReactionBar.tsx
+++ b/apps/web/src/components/reaction/DefinitionReactionBar.tsx
@@ -1,16 +1,10 @@
-/**
- * Definition surface wiring for the shared {@link ReactionBar} (#1867): binds
- * `fate.mutations.definition.react` and the definition's `reactions` write-back
- * view. A signed-out (or `UNAUTHORIZED`) tap returns to the term page, not the
- * current location — the card renders inside the `/sozluk/:slug` route, mirroring
- * the definition vote's `returnTo`.
- */
+// `returnTo` is the term page, not the current location like the other two surfaces —
+// the card renders inside `/sozluk/:slug`, mirroring the definition vote.
 import {useFateClient, view} from "react-fate";
 import type {Definition} from "../../../worker/features/fate/views";
 import {ReactionBar} from "./ReactionBar";
 import {useReactionBar} from "./useReactionBar";
 
-/** Write-back view for the definition react mutation. */
 export const DefinitionReactionView = view<Definition>()({
 	id: true,
 	reactions: {counts: true, myReaction: true},

--- a/apps/web/src/components/reaction/PostReactionBar.tsx
+++ b/apps/web/src/components/reaction/PostReactionBar.tsx
@@ -1,17 +1,9 @@
-/**
- * Post surface wiring for the shared {@link ReactionBar} (#1867): binds
- * `fate.mutations.post.react` and the post's `reactions` write-back view, so the
- * pano post card renders the palette + counts and a tap fires the react/change/
- * retract mutation with an optimistic aggregate. The bar itself is
- * surface-agnostic; this is the one post-specific seam.
- */
 import {useFateClient, view} from "react-fate";
 import type {Post} from "../../../worker/features/fate/views";
 import {currentLocationReturnTo} from "../pano/useVoteToggle";
 import {ReactionBar} from "./ReactionBar";
 import {useReactionBar} from "./useReactionBar";
 
-/** Write-back view for the post react mutation — the optimistic `reactions` aggregate flips every open card. */
 export const PostReactionView = view<Post>()({
 	id: true,
 	reactions: {counts: true, myReaction: true},

--- a/apps/web/src/components/reaction/ReactionBar.test.tsx
+++ b/apps/web/src/components/reaction/ReactionBar.test.tsx
@@ -1,11 +1,3 @@
-/**
- * The on-brand controlled-asset render pass (#2165, pillar cohesiveness): the bar
- * paints each palette member as a monochrome inline-SVG line-icon instead of its
- * raw OS emoji glyph (so it renders identically across OSes and coheres with the
- * monochrome-plus-accent palette), and names each button by ADR 0139's Turkish
- * gloss. These assert the render contract the later ReactionBar convergence passes
- * (#2166 contrast/focus, #2169 systematic focus/ARIA) build on.
- */
 import {render} from "@testing-library/react";
 import {describe, expect, it, vi} from "vitest";
 import {REACTION_EMOJI} from "../../../worker/db/reaction-emoji";
@@ -18,10 +10,8 @@ describe("ReactionBar — on-brand controlled-asset render (#2165)", () => {
 		const {container} = render(
 			<ReactionBar aggregate={null} onReact={vi.fn()} testIdSuffix="t1" />,
 		);
-		// One controlled SVG glyph per palette member — the OS-invariant asset.
 		const glyphs = container.querySelectorAll("svg.kp-reaction-bar__glyph");
 		expect(glyphs).toHaveLength(REACTION_EMOJI.length);
-		// The raw emoji text is no longer painted as a glyph (it stays the key/label only).
 		expect(container.querySelector(".kp-reaction-bar__emoji")).toBeNull();
 	});
 

--- a/apps/web/src/components/reaction/ReactionBar.tsx
+++ b/apps/web/src/components/reaction/ReactionBar.tsx
@@ -1,19 +1,6 @@
-/**
- * The presentational curated-palette reaction bar (#1867, epic #1840), reused
- * across the three flag-gated surfaces (pano post/comment, sözlük definition) so
- * the affordance is built once, not copy-pasted three times. It renders the fixed
- * `REACTION_EMOJI` palette (never an open picker): one button per palette member,
- * in palette order, each carrying its aggregate count and highlighted (via
- * `aria-pressed`) when it is the viewer's current reaction. The parent owns the
- * mutation + auth gate ({@link useReactionBar}); this only renders the slots and
- * routes a tap to `onReact`.
- *
- * Each member renders as an on-brand monochrome line-icon ({@link ReactionGlyph}),
- * not its raw OS emoji glyph (#2165): the icon paints in `currentColor` so it
- * inherits the button's token (text, or accent when active) and renders identically
- * across OSes — the palette SET is ADR 0139's, unchanged; only the rendering is
- * controlled. The accessible name is ADR 0139's Turkish gloss (`slot.gloss`).
- */
+// Presentational only — the parent owns the mutation and the auth gate. The palette set
+// and the Turkish accessible names are ADR 0139's; members render as line-icons rather
+// than raw OS emoji so they paint in `currentColor` and look the same on every OS.
 import type {ReactionEmoji} from "../../../worker/db/reaction-emoji";
 import type {ReactionAggregate} from "../../../worker/features/reaction/Reaction";
 import {CountToggle} from "../ui/CountToggle";
@@ -22,11 +9,9 @@ import {reactionSlots} from "./reactionModel";
 import "./ReactionBar.css";
 
 export interface ReactionBarProps {
-	/** The target's reaction aggregate (per-emoji counts + the viewer's `myReaction`), from the view. */
 	readonly aggregate: ReactionAggregate | undefined | null;
-	/** Tap a palette emoji: sets/changes it, or retracts if it's the viewer's current reaction (cardinality-one). */
 	readonly onReact: (emoji: ReactionEmoji) => void;
-	/** Disambiguates test ids when multiple bars render on one page (the target id). */
+	/** Disambiguates test ids when several bars render on one page — the target id. */
 	readonly testIdSuffix: string;
 }
 

--- a/apps/web/src/components/reaction/ReactionBarSlot.test.tsx
+++ b/apps/web/src/components/reaction/ReactionBarSlot.test.tsx
@@ -1,11 +1,5 @@
-/**
- * Pins the CLS fix (#2054): the reaction slot must reserve its height BEFORE the
- * async `phoenix-reactions` gate resolves, so the late-mounting bar swaps into an
- * already-sized slot instead of growing every already-laid-out card at once and
- * shoving the feed downward. The load-bearing property is that the loading/off
- * state renders the sized `.kp-reaction-slot` placeholder — NOT FlagGate's bare
- * `null` (zero height), which is the origin of the jump.
- */
+// Pins the CLS fix (#2054): the loading/off state must render the sized
+// `.kp-reaction-slot` placeholder, never FlagGate's bare zero-height `null`.
 import {render} from "@testing-library/react";
 import {afterEach, describe, expect, it, vi} from "vitest";
 import {ReactionBarSlot} from "./ReactionBarSlot";
@@ -29,9 +23,7 @@ describe("ReactionBarSlot — reserves the reaction row's height before the gate
 				<div data-testid="the-bar">bar</div>
 			</ReactionBarSlot>,
 		);
-		// The reserved-height placeholder is present — height is reserved up front...
 		expect(container.querySelector(".kp-reaction-slot")).not.toBeNull();
-		// ...and the gated bar is NOT shown in the off/safe path.
 		expect(container.querySelector('[data-testid="the-bar"]')).toBeNull();
 	});
 
@@ -43,7 +35,6 @@ describe("ReactionBarSlot — reserves the reaction row's height before the gate
 			</ReactionBarSlot>,
 		);
 		expect(container.querySelector('[data-testid="the-bar"]')).not.toBeNull();
-		// The reserved fallback is gone once the real (also height-reserving) bar mounts.
 		expect(container.querySelector(".kp-reaction-slot")).toBeNull();
 	});
 });

--- a/apps/web/src/components/reaction/ReactionBarSlot.tsx
+++ b/apps/web/src/components/reaction/ReactionBarSlot.tsx
@@ -1,16 +1,7 @@
-/**
- * The reaction row's flag-gated slot, shared by the three surfaces the bar
- * renders on (pano post/comment, sözlük definition). It wraps `FlagGate` with a
- * reserved-height fallback so the slot occupies its final height BEFORE the
- * async `phoenix-reactions` gate resolves — otherwise the bar mounts late across
- * every already-laid-out card at once and shoves the feed downward (#2054).
- *
- * The reserved height (`.kp-reaction-slot`) matches the mounted bar's
- * `min-height` (`.kp-reaction-bar`), both sourced from `--reaction-bar-height`
- * in ReactionBar.css, so the swap is exact — no residual shift once reactions
- * load. FlagGate's shared `null` safe-default is untouched: this passes an
- * explicit sized fallback rather than changing the primitive's default.
- */
+// The sized fallback is not decoration: FlagGate's default `null` has zero height, so the
+// bar mounting after the async `phoenix-reactions` gate resolves shoves every laid-out
+// card downward at once (#2054). `.kp-reaction-slot` and `.kp-reaction-bar` both take
+// their height from `--reaction-bar-height` in ReactionBar.css — keep them in step.
 import type {ReactNode} from "react";
 import {FlagGate} from "../../flags/FlagGate";
 import {PHOENIX_REACTIONS} from "../../flags/keys";

--- a/apps/web/src/components/reaction/ReactionGlyph.tsx
+++ b/apps/web/src/components/reaction/ReactionGlyph.tsx
@@ -1,34 +1,13 @@
-/**
- * The on-brand, OS-invariant glyphs for the curated reaction palette (#2165,
- * pillar cohesiveness; epic #2168). ADR 0139 fixes the reaction SET — the six
- * `REACTION_EMOJI` members and their Turkish glosses — and that membership is
- * SETTLED; this module does not re-open it. What it replaces is the *rendering*:
- * the bar used to paint each member as its raw OS emoji glyph, which (a) renders
- * differently on every OS and (b) drops a full-color glyph into the
- * monochrome-plus-accent palette. Instead every member is drawn as a controlled
- * inline SVG line-icon that strokes/fills in `currentColor`, so it inherits the
- * button's own token (text by default, accent when the viewer's reaction is
- * active) and looks identical everywhere.
- *
- * The icons are the same affective symbols ADR 0139 chose — 👍 beğendim,
- * ❤️ sevdim, 😂 güldüm, 🤔 düşündürdü, 😢 üzüldüm, 🔥 efsane — redrawn as
- * monochrome line-art, not a different reaction set. The palette emoji stays the
- * canonical identity/key everywhere else (wire, storage, ARIA gloss); this is a
- * presentation layer keyed BY that emoji.
- *
- * Kept a pure keyed lookup with no color/size literals of its own: the SVG uses
- * `currentColor` and scales to the button's glyph box, so color + size are driven
- * by ReactionBar.css tokens, never hardcoded here.
- */
+// Rendering only — ADR 0139 fixes the reaction SET and this does not re-open it; the emoji
+// stays the canonical key on the wire, in storage, and in the ARIA gloss.
+//
+// No color or size literals belong here: the SVG paints in `currentColor` and scales to the
+// button's glyph box, so ReactionBar.css tokens drive both.
 import type {ReactNode} from "react";
 import type {ReactionEmoji} from "../../../worker/db/reaction-emoji";
 
-/**
- * Shared per-icon SVG frame: a 24×24 viewBox line-icon that fills the button's
- * glyph box and paints in `currentColor`. `aria-hidden` — the accessible name
- * lives on the parent button's `aria-label` (the ADR-0139 gloss), so the glyph
- * itself is decorative.
- */
+// `aria-hidden` because the accessible name is the parent button's ADR-0139 gloss; naming
+// the glyph too would announce it twice.
 function Glyph({children}: {children: ReactNode}) {
 	return (
 		<svg
@@ -116,7 +95,6 @@ const GLYPHS: Record<ReactionEmoji, () => ReactNode> = {
 	"🔥": Flame,
 };
 
-/** Render the on-brand monochrome line-icon for a palette emoji (keyed by the ADR-0139 member). */
 export function ReactionGlyph({emoji}: {emoji: ReactionEmoji}) {
 	const Icon = GLYPHS[emoji];
 	return <Icon />;

--- a/apps/web/src/components/reaction/reactionDispatch.test.ts
+++ b/apps/web/src/components/reaction/reactionDispatch.test.ts
@@ -5,19 +5,9 @@ import {isAuthRedirectError} from "../pano/useVoteToggle";
 import {nextReaction, type OptimisticReactionAggregate, reactionOptimistic} from "./reactionModel";
 import type {ReactDispatch} from "./useReactionBar";
 
-/**
- * Models the tap→dispatch branch of {@link useReactionBar} exactly — resolve the
- * cardinality-one next reaction ({@link nextReaction}) + the optimistic aggregate
- * ({@link reactionOptimistic}), fire the `*.react` mutation, and on a rejected
- * mutation route through the REAL `isAuthRedirectError` (redirect on
- * `UNAUTHORIZED`, silent otherwise) — over the same controllable-dispatch idiom as
- * `DefinitionCard.test.ts`'s vote harness. The hook itself is a thin
- * `useCallback`/`useSession` wrapper; this drives the real payload + error logic
- * so a regression in the react/change/retract routing or the optimistic-then-
- * reconcile-on-fail path fails here, not only in an e2e. (fate owns the actual
- * cache rollback; the harness asserts the failed mutation reaches the catch so
- * nothing throws past the handler.)
- */
+// The harness below re-models `useReactionBar`'s tap body rather than rendering the hook:
+// the hook is a thin `useCallback`/`useSession` wrapper, and this drives the real payload
+// and error logic. Keep the two in step when either changes.
 function reactHarness(aggregate: ReactionAggregate | null | undefined) {
 	const calls: Array<{emoji: ReactionEmoji | null; optimistic: OptimisticReactionAggregate}> = [];
 	let rejectWith: unknown = null;
@@ -29,7 +19,6 @@ function reactHarness(aggregate: ReactionAggregate | null | undefined) {
 		return {result: {}, error: null};
 	};
 
-	// The hook's tap body, sans React: resolve emoji + optimistic, dispatch, catch.
 	const onReact = async (tapped: ReactionEmoji) => {
 		const current = aggregate?.myReaction ?? null;
 		const emoji = nextReaction(current, tapped);

--- a/apps/web/src/components/reaction/reactionModel.test.ts
+++ b/apps/web/src/components/reaction/reactionModel.test.ts
@@ -3,17 +3,6 @@ import {REACTION_EMOJI} from "../../../worker/db/reaction-emoji";
 import type {ReactionAggregate} from "../../../worker/features/reaction/Reaction";
 import {nextReaction, REACTION_GLOSS, reactionOptimistic, reactionSlots} from "./reactionModel";
 
-/**
- * The load-bearing reaction-bar core the three surfaces ship through
- * ({@link reactionSlots} / {@link nextReaction} / {@link reactionOptimistic}) — the
- * palette-render shape, the cardinality-one tap semantics, and the optimistic
- * aggregate delta. These drive the REAL exported functions the `ReactionBar`
- * component + `useReactionBar` hook route through, so a regression in the palette
- * fill, the retract-vs-change decision, or the count math fails here rather than
- * only in an e2e — the `voteOptimistic` unit-test idiom, extended to a 6-way
- * palette.
- */
-
 describe("reactionSlots — the full curated palette, in order", () => {
 	it("renders every REACTION_EMOJI member exactly once, in palette order, at zero for an empty aggregate", () => {
 		const slots = reactionSlots({counts: [], myReaction: null});
@@ -53,7 +42,6 @@ describe("reactionSlots — the full curated palette, in order", () => {
 		expect(byEmoji.get("👍")).toBe("beğendim");
 		expect(byEmoji.get("🤔")).toBe("düşündürdü");
 		expect(byEmoji.get("🔥")).toBe("efsane");
-		// The gloss map covers every palette member exactly (no drift from the palette).
 		expect(Object.keys(REACTION_GLOSS).sort()).toEqual([...REACTION_EMOJI].sort());
 	});
 });
@@ -101,7 +89,6 @@ describe("reactionOptimistic — the instant-write aggregate after a tap", () =>
 	});
 
 	it("keeps other users' tallies intact — only the viewer's own contribution moves", () => {
-		// 👍 has 5 (incl. the viewer); a retract drops it to 4 (the other 4 stay).
 		const next = reactionOptimistic({counts: [{emoji: "👍", count: 5}], myReaction: "👍"}, "👍");
 		expect(next.counts).toEqual([{emoji: "👍", count: 4}]);
 	});
@@ -113,7 +100,6 @@ describe("reactionOptimistic — the instant-write aggregate after a tap", () =>
 	});
 
 	it("orders the optimistic counts by the palette, matching the server's canonical order", () => {
-		// react 🔥 first, then (fresh aggregate) react 👍: the result must list 👍 before 🔥.
 		const agg: ReactionAggregate = {
 			counts: [
 				{emoji: "🔥", count: 1},

--- a/apps/web/src/components/reaction/reactionModel.ts
+++ b/apps/web/src/components/reaction/reactionModel.ts
@@ -1,40 +1,17 @@
-/**
- * The load-bearing, hook-free core of the curated-palette reaction bar (#1867,
- * epic #1840) — the reaction twin of `voteOptimistic` / `optimisticEdit`. Kept
- * pure and unit-testable apart from React so the palette-render shape, the
- * cardinality-one tap semantics, and the optimistic-aggregate delta are driven
- * by tests, not only by an e2e.
- *
- * The reaction affordance is NOT an open emoji picker: it renders the fixed,
- * curated `REACTION_EMOJI` palette (👍 ❤️ 😂 🤔 😢 🔥) — every palette member is
- * always shown, in palette order, with its aggregate count, and the viewer's own
- * current reaction highlighted. The server's `reactions` aggregate
- * (`ReactionAggregate`) supplies only the members with a non-zero tally plus the
- * viewer's `myReaction`; this core fills the zero-count members so the bar's
- * shape is stable regardless of what the sparse aggregate carries.
- */
+// A fixed curated palette, never an open picker — see ADR 0139. The server's aggregate is
+// SPARSE (non-zero tallies only), so this core fills the zero-count members to keep the
+// bar's shape stable.
 import {REACTION_EMOJI, type ReactionEmoji} from "../../../worker/db/reaction-emoji";
 import type {ReactionAggregate} from "../../../worker/features/reaction/Reaction";
 
-/**
- * The optimistic aggregate shape fate's `optimistic` payload accepts — a MUTABLE
- * `counts` array, structurally the write-back view's `reactions` field. The
- * server-supplied {@link ReactionAggregate} types `counts` as a `ReadonlyArray`
- * (read side), but fate's `OptimisticUpdate` wants a mutable array, so the
- * optimistic producer returns this mutable twin rather than the readonly one.
- */
+// A mutable twin of `ReactionAggregate` purely because fate's `OptimisticUpdate` rejects
+// the readonly `counts` array the read side uses. Don't collapse the two.
 export interface OptimisticReactionAggregate {
 	counts: Array<{emoji: ReactionEmoji; count: number}>;
 	myReaction: ReactionEmoji | null;
 }
 
-/**
- * The Turkish reaction glosses fixed by ADR 0139 — one per palette member, in the
- * same affective order. This is the single in-code seed of the ADR's gloss table;
- * the bar uses it as each reaction's accessible name (ARIA label) so a screen
- * reader announces "beğendim" / "sevdim" / … rather than the raw glyph. Keyed by
- * the canonical `REACTION_EMOJI` member so it can never drift from the palette.
- */
+// The glosses ADR 0139 fixes; they are each button's accessible name, not decoration.
 export const REACTION_GLOSS: Record<ReactionEmoji, string> = {
 	"👍": "beğendim",
 	"❤️": "sevdim",
@@ -44,7 +21,6 @@ export const REACTION_GLOSS: Record<ReactionEmoji, string> = {
 	"🔥": "efsane",
 };
 
-/** One palette slot as the bar renders it: the emoji, its Turkish gloss, its aggregate count, and whether it is the viewer's current reaction. */
 export interface ReactionSlot {
 	readonly emoji: ReactionEmoji;
 	readonly gloss: string;
@@ -52,17 +28,8 @@ export interface ReactionSlot {
 	readonly active: boolean;
 }
 
-/** The empty aggregate the bar falls back to when the view supplies none (a target absent from the batch read). */
 export const EMPTY_AGGREGATE: ReactionAggregate = {counts: [], myReaction: null};
 
-/**
- * Project a (possibly sparse) `ReactionAggregate` onto the full ordered palette:
- * every `REACTION_EMOJI` member appears exactly once, in palette order, carrying
- * its aggregate count (0 when absent from `counts`) and `active` iff it is the
- * viewer's `myReaction`. A missing/undefined aggregate reads as empty — the bar
- * still renders the whole palette at zero, so a target with no reactions shows the
- * affordance rather than nothing.
- */
 export function reactionSlots(aggregate: ReactionAggregate | undefined | null): ReactionSlot[] {
 	const agg = aggregate ?? EMPTY_AGGREGATE;
 	const countOf = new Map<string, number>(agg.counts.map((c) => [c.emoji, c.count]));
@@ -74,12 +41,8 @@ export function reactionSlots(aggregate: ReactionAggregate | undefined | null): 
 	}));
 }
 
-/**
- * The cardinality-one tap semantics as the emoji sent to `react`: tapping the
- * viewer's CURRENT reaction retracts it (`null`); tapping any OTHER palette member
- * sets/changes to it. One tap, one reaction per (viewer, target) — never two.
- * Pure so the retract-vs-change decision is unit-tested apart from the hook.
- */
+// Cardinality-one: one reaction per (viewer, target), so re-tapping the current one
+// retracts rather than adding a second.
 export function nextReaction(
 	current: ReactionEmoji | null,
 	tapped: ReactionEmoji,
@@ -87,15 +50,6 @@ export function nextReaction(
 	return current === tapped ? null : tapped;
 }
 
-/**
- * The optimistic `ReactionAggregate` after a tap, given the current aggregate —
- * the reaction analog of `voteOptimistic`. It moves the viewer's own tally off
- * their prior reaction (if any) and onto the new one (unless the tap retracts),
- * clamps every tally at `0` (a retract never renders a negative count), drops
- * zero-count members (matching the server's sparse, non-zero `counts` shape), and
- * re-orders by the palette. Passed to fate as `optimistic: {reactions}`, so the
- * bar updates instantly and fate reconciles/rolls back on the server response.
- */
 export function reactionOptimistic(
 	aggregate: ReactionAggregate | undefined | null,
 	tapped: ReactionEmoji,
@@ -104,10 +58,8 @@ export function reactionOptimistic(
 	const prior = agg.myReaction;
 	const next = nextReaction(prior, tapped);
 	const tally = new Map<string, number>(agg.counts.map((c) => [c.emoji, c.count]));
-	// Move the viewer's own contribution: -1 off the prior reaction, +1 onto the
-	// new one. A retract (next === null) only decrements; a fresh react only
-	// increments; a change does both. The 0-floor guards a stale aggregate that
-	// under-counts the prior tally.
+	// The 0-floor guards a stale aggregate that under-counts the prior tally; without it
+	// a retract can render a negative count.
 	if (prior !== null) tally.set(prior, Math.max(0, (tally.get(prior) ?? 0) - 1));
 	if (next !== null) tally.set(next, (tally.get(next) ?? 0) + 1);
 	const counts = REACTION_EMOJI.flatMap((emoji) => {

--- a/apps/web/src/components/reaction/useReactionBar.ts
+++ b/apps/web/src/components/reaction/useReactionBar.ts
@@ -1,16 +1,6 @@
-/**
- * The gated dispatch seam for the reaction bar — the reaction analog of
- * `useVoteToggle`/`useGatedToggle`, but over a curated palette (6-way choice +
- * retract) rather than a boolean toggle, so it can't reuse the boolean
- * serialize-and-supersede loop. It owns the same interaction semantics the vote
- * seam owns: the signed-out gate (a tap with no session redirects to auth, never
- * fires the mutation) and the `UNAUTHORIZED` → auth-redirect classification on the
- * dispatch error channel (reusing the shared `isAuthRedirectError`). The
- * optimistic write + reconcile-on-failure is fate's (`optimistic: {reactions}`
- * applies instantly and rolls back on a rejected mutation — see
- * `.patterns/fate-mutations-client.md`); this hook only computes the payload and
- * routes the tap.
- */
+// A palette (6-way choice + retract) rather than a boolean toggle, so this cannot reuse
+// `useVoteToggle`'s serialize-and-supersede loop. The optimistic write and its rollback
+// are fate's — see `.patterns/fate-mutations-client.md`.
 import {useCallback} from "react";
 import {useNavigate} from "react-router";
 import type {ReactionEmoji} from "../../../worker/db/reaction-emoji";
@@ -20,35 +10,19 @@ import {authRedirectPath} from "../../lib/returnTo";
 import {isAuthRedirectError} from "../pano/useVoteToggle";
 import {nextReaction, type OptimisticReactionAggregate, reactionOptimistic} from "./reactionModel";
 
-/**
- * Fire the underlying `*.react` fate mutation for the resolved emoji (a palette
- * member sets/changes, `null` retracts), carrying the supplied optimistic
- * aggregate. Resolves when the mutation settles; may throw the boundary-class
- * `UNAUTHORIZED` the hook catches and redirects on. The `{result, error}` value is
- * ignored — the bar has no inline error slot and leans on fate's optimistic
- * rollback + the boundary throw.
- */
+// `null` emoji retracts. May throw the boundary-class `UNAUTHORIZED` the hook catches.
 export type ReactDispatch = (args: {
 	readonly emoji: ReactionEmoji | null;
 	readonly optimistic: OptimisticReactionAggregate;
 }) => Promise<unknown>;
 
 export interface ReactionBarArgs {
-	/** The target's current reaction aggregate (from the view), or empty when the view supplies none. */
 	readonly aggregate: ReactionAggregate | undefined | null;
 	/** The path a signed-out (or `UNAUTHORIZED`) tap returns to after auth. */
 	readonly returnTo: () => string;
-	/** Fire the `*.react` mutation for the resolved emoji + optimistic aggregate. */
 	readonly dispatch: ReactDispatch;
 }
 
-/**
- * Returns `onReact(tapped)`, the palette-button click handler: it redirects a
- * signed-out tap to auth, otherwise resolves the cardinality-one next reaction
- * ({@link nextReaction}) + the optimistic aggregate ({@link reactionOptimistic})
- * and fires the mutation, catching only `UNAUTHORIZED` (→ auth redirect) and
- * staying silent on every other code (no inline error slot).
- */
 export function useReactionBar(args: ReactionBarArgs): (tapped: ReactionEmoji) => void {
 	const {aggregate, returnTo, dispatch} = args;
 	const session = useSession();

--- a/apps/web/src/components/sozluk/DefinitionCard.test.ts
+++ b/apps/web/src/components/sozluk/DefinitionCard.test.ts
@@ -2,26 +2,8 @@ import {describe, expect, it, vi} from "vitest";
 import {runToggleLoop, type ToggleAction, type ToggleLoopState} from "../pano/useToggleAction";
 import {isAuthRedirectError, type VoteMutations, voteOptimistic} from "../pano/useVoteToggle";
 
-/**
- * Covers the load-bearing vote logic DefinitionCard ships through `useVoteToggle`
- * (`DefinitionCard.tsx` → `useVoteToggle`): the optimistic `{score, myVote}`
- * delta with the `Math.max(0, score - 1)` retract floor, and the
- * `UNAUTHORIZED`→auth-redirect classification on the dispatch error channel.
- *
- * It exercises the REAL exported seam — `voteOptimistic` / `isAuthRedirectError`
- * from `useVoteToggle`, the same functions the hook's `dispatch` routes through —
- * not a re-implemented copy. The earlier version of this file imported
- * `runToggleLoop` and asserted a `useToggleAction` contract DefinitionCard never
- * had (already owned by `useToggleAction.test.ts`), while the vote delta + the
- * auth-redirect shipped green untested; this drives the actual code, so a break
- * in the score floor, the `myVote` boolean, or the redirect classification fails
- * here rather than only in an e2e.
- *
- * The hook (`useGatedToggle`/`useToggleAction`) is a React ref/`useCallback`
- * wrapper around `runToggleLoop`; the loop itself is the real driver, modelled
- * here over the same controllable dispatch idiom as `useToggleAction.test.ts` so
- * the serialize-and-supersede behavior the hook relies on is real, not mocked.
- */
+// The harness drives the REAL exported seam — `voteOptimistic` / `isAuthRedirectError` /
+// `runToggleLoop`, the same functions the hook routes through — never a re-implemented copy.
 function voteHarness(args: {initialVoted: boolean; initialScore: number}) {
 	let voted = args.initialVoted;
 	const score = args.initialScore;
@@ -30,8 +12,6 @@ function voteHarness(args: {initialVoted: boolean; initialScore: number}) {
 	const optimistic: ReturnType<typeof voteOptimistic>[] = [];
 	let pending: (() => void) | null = null;
 
-	// The exact mutation pair DefinitionCard hands `useVoteToggle`, capturing the
-	// optimistic payload the hook computes via `voteOptimistic`.
 	const mutations: VoteMutations = {
 		vote: (o) =>
 			new Promise<void>((resolve) => {
@@ -53,8 +33,6 @@ function voteHarness(args: {initialVoted: boolean; initialScore: number}) {
 			}),
 	};
 
-	// The hook's real dispatch body (useVoteToggle → useGatedToggle): route the
-	// action through the REAL `voteOptimistic`, then fire the matching mutation.
 	const dispatch = async (action: ToggleAction): Promise<void> => {
 		calls.push(action);
 		const o = voteOptimistic(action, score);
@@ -115,7 +93,6 @@ describe("DefinitionCard vote — optimistic delta via the real useVoteToggle", 
 		h.setDesired(false);
 		const loop = h.run();
 		await tick();
-		// Math.max(0, 0 - 1) === 0, not -1.
 		expect(h.optimistic).toEqual([{score: 0, myVote: false}]);
 		h.settle();
 		await loop;
@@ -125,19 +102,17 @@ describe("DefinitionCard vote — optimistic delta via the real useVoteToggle", 
 	it("does NOT drop a retract issued while the vote mutation is still in flight (#818/#865)", async () => {
 		const h = voteHarness({initialVoted: false, initialScore: 3});
 
-		// Click 1: vote. The vote POST is now in flight.
 		h.setDesired(true);
 		const loop = h.run();
 		await tick();
 		expect(h.calls).toEqual(["set"]);
 		expect(h.hasPending()).toBe(true);
 
-		// Click 2 lands INSIDE the in-flight window — supersede back to "not voted".
+		// The second click lands INSIDE the in-flight window — supersede back to "not voted".
 		h.setDesired(false);
 		h.settle();
 		await tick();
 
-		// The retract MUST fire, with its own floored optimistic payload.
 		expect(h.calls).toEqual(["set", "unset"]);
 		expect(h.optimistic).toEqual([
 			{score: 4, myVote: true},
@@ -160,8 +135,6 @@ describe("DefinitionCard vote — the UNAUTHORIZED→auth-redirect classificatio
 	});
 
 	it("redirects on the UNAUTHORIZED path the gate's dispatch catch takes", async () => {
-		// Model the gate's caught-error branch (useGatedToggle): catch the dispatch
-		// throw, redirect iff `isAuthRedirectError` — using the REAL classifier.
 		const redirectToAuth = vi.fn();
 		const guarded = async (dispatch: () => Promise<void>) => {
 			try {
@@ -175,6 +148,6 @@ describe("DefinitionCard vote — the UNAUTHORIZED→auth-redirect classificatio
 		expect(redirectToAuth).toHaveBeenCalledTimes(1);
 
 		await guarded(() => Promise.reject({code: "INTERNAL_SERVER_ERROR"}));
-		expect(redirectToAuth).toHaveBeenCalledTimes(1); // unchanged — stays silent
+		expect(redirectToAuth).toHaveBeenCalledTimes(1);
 	});
 });

--- a/apps/web/src/components/sozluk/DefinitionCard.tsx
+++ b/apps/web/src/components/sozluk/DefinitionCard.tsx
@@ -1,7 +1,5 @@
-// Vote/edit/delete dispatch through `fate.mutations.definition.*` with optimistic
-// updates; the `FateWireCode`s these raise are boundary-class in fate's mutation
-// taxonomy, so mutations throw and we catch per-call-site. See
-// `.patterns/fate-mutations-client.md`.
+// Mutations throw their boundary-class wire errors, so every call site catches.
+// See `.patterns/fate-mutations-client.md`.
 import * as React from "react";
 import {toEntityId, useFateClient, useLiveView, type ViewRef, view} from "react-fate";
 import {useNavigate} from "react-router";
@@ -48,14 +46,12 @@ export const DefinitionView = view<Definition>()({
 
 const BODY_MAX = 10_000;
 
-// `report.submit` ack (ADR 0082 — a report has no read view). `created: false` is the
-// idempotent re-report no-op, which `ReportButton` surfaces as "zaten bildirildi".
+// `created: false` is the idempotent re-report no-op, surfaced as "zaten bildirildi".
 const ReportReceiptView = view<ReportReceipt>()({
 	id: true,
 	created: true,
 });
 
-/** Definition-form copy that overrides the shared {@link WIRE_MESSAGES} base. */
 const DEFINITION_OVERRIDES: WireMessageOverrides = {
 	BODY_REQUIRED: "tanım boş olamaz",
 	BODY_TOO_LONG: `tanım en fazla ${BODY_MAX} karakter olabilir`,
@@ -66,19 +62,11 @@ export interface DefinitionCardProps {
 	definition: ViewRef<"Definition">;
 	rank: number;
 	top: boolean;
-	/** Term slug — passed to the auth redirect so a signed-out vote returns here. */
 	slug: string;
-	/**
-	 * Hands the deleted definition's id to the list's delete-side read-back, so a
-	 * lost `deleteEdge` push self-heals via a network-only refetch (#1687).
-	 */
 	onDeleted?: (definitionId: string) => void;
 }
 
 export function DefinitionCard(props: DefinitionCardProps) {
-	// Live: a definition vote/edit on another client publishes
-	// `live.update("Definition", id, …)` with the re-resolved node inline, so the
-	// score/body re-render here without a refetch.
 	const definition = useLiveView(DefinitionView, props.definition);
 	const fate = useFateClient();
 	const session = useSession();
@@ -158,22 +146,16 @@ export function DefinitionCard(props: DefinitionCardProps) {
 	}
 
 	async function onDeleteConfirm() {
-		// `definition.delete` is a **`Term`** mutation (it returns the re-resolved
-		// parent so counts update), so fate's `delete: true` can't be used — it
-		// would `deleteRecord("Term", definitionId)`, the wrong entity. And the
-		// definition lives in the *nested* `Term.definitions` connection, whose
-		// membership `insert`/`delete` can't touch. The resolver instead publishes
-		// `live.topic("Term.definitions", {id: slug}).deleteEdge`, which the
-		// list's `useLiveListView` consumes — the card drops out in place (this
-		// client's own view included), no reload.
+		// `definition.delete` returns the parent `Term`, so fate's `delete: true` can't
+		// be used — it would `deleteRecord("Term", definitionId)`, the wrong entity. The
+		// card drops out via the resolver's `Term.definitions` `deleteEdge` push instead.
 		await runDelete(
 			() => {
 				const promise = fate.mutations.definition.delete({input: {id: definition.id}});
-				// Optimistic edge-drop (ADR 0125 D1): remove the edge from the nested list
-				// state now so the card disappears instantly. The definition id is already
-				// canonical, so the server `deleteEdge` frame removes an id already gone —
-				// a no-op by canonical id, no reappear. Roll the drop back on any failure
-				// (fate has no record write to restore for this Term-returning mutation).
+				// Optimistic edge-drop (ADR 0125): the id is already canonical, so the server
+				// `deleteEdge` frame removes an id already gone — a no-op, no reappear. Rolled
+				// back by hand on failure; this Term-returning mutation writes no record fate
+				// could restore.
 				const rollback = dropOptimisticDefinitionEdge(
 					fate.store,
 					toEntityId("Term", props.slug),
@@ -306,8 +288,6 @@ export function DefinitionCard(props: DefinitionCardProps) {
 					{/* Owner-only in-review signal (#2200): `sandboxed` is owner-scoped server-side,
 					    re-gated on `isAuthor` so only the author sees their own pending definition's state. */}
 					{isAuthor && definition.sandboxed ? <ReviewBadge /> : null}
-					{/* Live author identity via `actorLabel` (#2139): CURRENT displayName → @username,
-					    falling back to the write-time `author` snapshot for an unstamped/legacy row. */}
 					<span className="author">
 						{actorLabel(
 							definition.authorDisplayName ?? null,

--- a/apps/web/src/components/sozluk/Sozluk.tsx
+++ b/apps/web/src/components/sozluk/Sozluk.tsx
@@ -59,9 +59,6 @@ export type DefinitionData = {
 	id: string;
 	body: React.ReactNode;
 	author: string;
-	// Live identity (#2139): the current `{username, displayName}` so the label resolves
-	// via `actorLabel` and the profile link targets the handle; both optional so an
-	// unstamped caller falls back to the `author` snapshot.
 	authorUsername?: string | null;
 	authorDisplayName?: string | null;
 	agoLabel: string;
@@ -128,20 +125,8 @@ const ALPHABET = [
 	"z",
 ];
 
-/**
- * The A-Z index as real navigable links to `/sozluk?harf=<letter>` (issue #693):
- * each letter is a shareable URL, back-button-correct and middle-clickable. The
- * active letter links back to bare `/sozluk` so it still toggles its filter off.
- * Empty letters stay inert `<span>`s — no destination to navigate to.
- *
- * ARIA (#2169): the `<nav aria-label="Harf">` names the index as a landmark. Each
- * populated letter is a link whose accessible name spells out the letter ("A
- * harfi") — a bare "a" reads ambiguously to a screen reader that spells single
- * chars. Empty letters are inert spans (not announced as links) carrying a
- * visually-hidden "(… harfi, terim yok)" suffix, so an AT user hears the
- * populated/empty distinction the muted color conveys visually. The active letter
- * keeps `aria-current="page"`.
- */
+// A letter's accessible name spells it out ("A harfi") — a bare "a" reads
+// ambiguously to a screen reader that spells single chars.
 export function SozlukAlphabet({
 	value,
 	emptyLetters = [],
@@ -163,11 +148,9 @@ export function SozlukAlphabet({
 					.join(" ");
 				const letterName = `${l.toLocaleUpperCase("tr")} harfi`;
 				if (isEmpty) {
-					// Inert letter — a plain span (no interactive role) so it isn't announced as
-					// a link. The visible glyph reads as the letter; a visually-hidden suffix
-					// spells the name + "(terim yok)" so an AT user hears the empty distinction the
-					// muted color conveys visually. (aria-label/aria-disabled aren't valid on a
-					// generic span; the hidden text carries the semantics instead.)
+					// A plain span so it isn't announced as a link. aria-label/aria-disabled aren't
+					// valid on a generic span, so the visually-hidden suffix carries the "no terms"
+					// distinction the muted color conveys visually.
 					return (
 						<span key={l} className={cls}>
 							{l}

--- a/apps/web/src/components/sozluk/SozlukAlphabet.test.tsx
+++ b/apps/web/src/components/sozluk/SozlukAlphabet.test.tsx
@@ -1,12 +1,3 @@
-/**
- * The A–Z index ARIA contract (#2169, a11y pillar of epic #2168). The alphabet is
- * the sözlük letter index (`SozlukAlphabet`): populated letters are real
- * `/sozluk?harf=<l>` links, empty letters are inert. These pin the accessible
- * semantics an AT user relies on to tell a navigable letter from an empty one and
- * to hear which letter each control is — the muted-color populated/empty
- * distinction and the single-char label ambiguity are both invisible to a screen
- * reader without these attributes.
- */
 import {readFileSync} from "node:fs";
 import {fileURLToPath} from "node:url";
 import {render} from "@testing-library/react";
@@ -37,7 +28,6 @@ describe("SozlukAlphabet — A–Z index ARIA (#2169)", () => {
 		const {container} = renderAlphabet({});
 		const a = container.querySelector("a.kp-sozluk-alphabet__letter");
 		expect(a?.getAttribute("aria-label")).toBe("A harfi");
-		// populated letters are real links (an href), never inert spans
 		expect(a?.tagName.toLowerCase()).toBe("a");
 	});
 
@@ -54,12 +44,9 @@ describe("SozlukAlphabet — A–Z index ARIA (#2169)", () => {
 		const spans = container.querySelectorAll("span.kp-sozluk-alphabet__letter.is-empty");
 		expect(spans).toHaveLength(1);
 		const z = spans[0] as HTMLElement;
-		// an inert span is not a link (no interactive role announced)
 		expect(z.tagName.toLowerCase()).toBe("span");
-		// the AT-only suffix spells the empty distinction the muted color conveys visually
 		const hidden = z.querySelector(".kp-visually-hidden");
 		expect(hidden?.textContent).toBe("(Z harfi, terim yok)");
-		// its full accessible text is the visible glyph + the hidden suffix
 		expect(z.textContent).toBe("z(Z harfi, terim yok)");
 	});
 

--- a/apps/web/src/components/sozluk/SozlukSubnavCta.test.tsx
+++ b/apps/web/src/components/sozluk/SozlukSubnavCta.test.tsx
@@ -1,17 +1,5 @@
-/**
- * #3840 regression — the `+ yeni tanım` create dialog must survive an ancestor unmount.
- *
- * #3600 pinned the closer: with `open` in the CTA's local `useState`, an ancestor unmount
- * (the shape of `FateProvider`'s `key={userId}` re-key or `LayoutContent`'s `needsBootstrap`
- * Outlet swap) silently reset it to `false`, reproducing the CI artifact — dialog gone, no
- * backdrop, no dismiss reason, still on `/sozluk`. NO `onOpenChange` reason fires on that path
- * (React destroys the state, it is not dismissed), which is exactly how the closer is named:
- * absent reason ⇒ ancestor unmount, not `outside-press`/`escape`.
- *
- * The harness below is that unmount: a `key`-flipping boundary between the hoist provider and
- * the CTA forces a real unmount + remount of the CTA subtree. The two tests pin the artifact
- * (without the hoist) and its fix (with it).
- */
+// #3840 regression — the create dialog must survive an ancestor unmount; see
+// `SozlukCreateDialogState` for the why.
 import {act, fireEvent, render, screen} from "@testing-library/react";
 import * as React from "react";
 import {MemoryRouter} from "react-router";
@@ -60,8 +48,6 @@ describe("SozlukSubnavCta — #3840 open-state survives an ancestor unmount", ()
 
 		remountSubtree();
 
-		// The local `useState` was destroyed with the unmounted subtree — the dialog is gone,
-		// exactly the silent close #3600 pinned.
 		expect(screen.queryByLabelText(/Terim/)).toBeNull();
 	});
 
@@ -72,8 +58,6 @@ describe("SozlukSubnavCta — #3840 open-state survives an ancestor unmount", ()
 
 		remountSubtree();
 
-		// `open` lives in the provider above the boundary, so the remounted CTA re-reads a
-		// surviving `true` — the dialog re-appears instead of vanishing.
 		expect(await screen.findByLabelText(/Terim/)).toBeTruthy();
 	});
 });

--- a/apps/web/src/components/sozluk/SozlukSubnavCta.tsx
+++ b/apps/web/src/components/sozluk/SozlukSubnavCta.tsx
@@ -6,22 +6,12 @@ import {Dialog} from "../ui/Dialog";
 import {Form, Input} from "../ui/Form";
 import {useSozlukCreateDialog} from "./SozlukCreateDialogState";
 
-/**
- * sözlük's contextual create CTA — the `+ yeni tanım` promoted verb in its Subnav
- * `primaryAction` zone (design-system-manifest: a product-scoped create CTA is a
- * contextual primary action; placement law #2587). It replaces the old go-to-or-create
- * box, whose "go to a term" search half folded into the global ⌘K `ara` (#2995, the #2412
- * single-search contract) leaving only the create half here as a plain action, never a
- * second search surface.
- *
- * A dialog collects the term name because the composer is slug-addressed (`/sozluk/:slug`):
- * the submit slugifies the typed term (`slugifyTerm`) and routes to the fresh-slug composer
- * branch — the exact target the old box reached, create dead-end handled there (#97).
- */
+// sözlük's create CTA — never a second search surface; the "go to a term" search folded
+// into the global ⌘K `ara` (#2995). The dialog exists because the composer is
+// slug-addressed: submit slugifies the typed term and routes to `/sozluk/:slug`.
 export function SozlukSubnavCta() {
-	// `open` is hoisted above the FateProvider/needsBootstrap unmounting boundary (#3840) —
-	// see `SozlukCreateDialogState`. A component-local `useState` here is the exact fragility
-	// #3600 pinned: an ancestor unmount would silently reset it, vanishing the dialog.
+	// `open` is hoisted above the unmounting boundary — see `SozlukCreateDialogState` (#3840).
+	// A component-local `useState` here is the exact fragility that vanished the dialog.
 	const {open, setOpen} = useSozlukCreateDialog();
 	const navigate = useNavigate();
 	const [term, setTerm] = React.useState("");

--- a/apps/web/src/components/sozluk/SozlukSubnavLayout.test.tsx
+++ b/apps/web/src/components/sozluk/SozlukSubnavLayout.test.tsx
@@ -1,13 +1,3 @@
-/**
- * sözlük's persistent product Subnav zone, composed through `SubnavShell` (ADR 0182, on the
- * #2602 zone / #2587 placement law). Pins: (1) the zone is a persistent layout — its
- * `.kp-subnav` node survives a within-sozluk navigation (no remount); (2) the alphabet fills
- * the shell's `destinations` zone so it renders INSIDE the bar's filters row — never the
- * detached sibling it was before #2974 (the orphan-row regression this file pins closed);
- * (3) there is NO local search box — the "go to a term" search folded into the global ⌘K `ara`
- * (#2995) — only a `+ yeni tanım` create CTA in the `primaryAction` (`.kp-subnav__cta`) zone,
- * which opens a dialog and routes a typed term to the fresh-slug composer (`/sozluk/:slug`).
- */
 import {fireEvent, render, screen} from "@testing-library/react";
 import {Link, MemoryRouter, Route, Routes, useParams} from "react-router";
 import {describe, expect, it} from "vitest";
@@ -74,7 +64,6 @@ describe("SozlukSubnavLayout — sözlük product Subnav zone through SubnavShel
 		const cta = container.querySelector(".kp-subnav__cta");
 		expect(cta).toBeTruthy();
 		expect(cta?.querySelector('[data-scope="button"][data-variant="primary"]')).toBeTruthy();
-		// the CTA slot is not the filter/input slot, and no search input leaks onto the bar
 		expect(container.querySelector(".kp-subnav__cta .kp-subnav__filter")).toBeNull();
 	});
 
@@ -89,16 +78,11 @@ describe("SozlukSubnavLayout — sözlük product Subnav zone through SubnavShel
 		const form = field.closest("form");
 		if (!form) throw new Error("the create field is not inside a form");
 		fireEvent.submit(form);
-		// slugifyTerm("yeni terim") === "yeni-terim" — a mid-browse jump to the fresh-slug composer.
 		expect(screen.getByTestId("term-leaf").textContent).toContain("term:yeni-terim");
 	});
 
-	/**
-	 * #3746: a submit the create flow cannot act on must not dismiss the dialog. `required`
-	 * alone is no defence: a non-empty punctuation term passes native required validation
-	 * on its way to slugifying into
-	 * nothing. That used to close the dialog while navigating nowhere.
-	 */
+	// #3746: `required` alone is no defence — a non-empty punctuation term passes native
+	// validation on its way to slugifying into nothing.
 	it("keeps the create dialog open when the term slugifies to nothing — never a silent dismiss", async () => {
 		renderZone("/sozluk/mevcut-terim");
 		fireEvent.click(screen.getByRole("button", {name: /yeni tanım/i}));
@@ -111,11 +95,6 @@ describe("SozlukSubnavLayout — sözlük product Subnav zone through SubnavShel
 		expect(screen.getByTestId("term-leaf").textContent).toContain("term:mevcut-terim");
 	});
 
-	/**
-	 * #3789: an unslugifiable term is no longer a silent no-op — it surfaces a Turkish field
-	 * error through Manti Input's error affordance, so the user learns why `oluştur`
-	 * did nothing instead of only being able to `vazgeç`.
-	 */
 	it("surfaces a Turkish field error when the term slugifies to nothing — not a silent no-op", async () => {
 		renderZone("/sozluk/mevcut-terim");
 		fireEvent.click(screen.getByRole("button", {name: /yeni tanım/i}));
@@ -125,7 +104,6 @@ describe("SozlukSubnavLayout — sözlük product Subnav zone through SubnavShel
 		if (!form) throw new Error("the create field is not inside a form");
 		fireEvent.submit(form);
 		expect(await screen.findByText("Terim en az bir harf ya da rakam içermeli.")).toBeTruthy();
-		// still no navigation — the dialog stays put on the unusable term
 		expect(screen.getByTestId("term-leaf").textContent).toContain("term:mevcut-terim");
 	});
 

--- a/apps/web/src/components/sozluk/SozlukSubnavLayout.tsx
+++ b/apps/web/src/components/sozluk/SozlukSubnavLayout.tsx
@@ -3,16 +3,8 @@ import {SubnavShell} from "../layout/SubnavShell";
 import {SozlukAlphabet} from "./index";
 import {SozlukSubnavCta} from "./SozlukSubnavCta";
 
-/**
- * sözlük's persistent product Subnav zone (placement law #2587, epic #2596), composed through
- * the blessed `SubnavShell` recipe (ADR 0182) — the pathless layout-route element that renders
- * sözlük's Subnav once above the routed `<Outlet>`, so the zone stays mounted across `/sozluk/*`
- * (no per-page remount). The URL-driven alphabet (`?harf=<letter>`) fills the `destinations`
- * zone so it renders INSIDE the bar's filters row; the `+ yeni tanım` create CTA fills the
- * `primaryAction` zone. There is no `utility`/search slot — sözlük's old go-to-or-create box is
- * gone, its "go to a term" search folded into the global ⌘K `ara` (#2995, the #2412 single-search
- * contract), which is why `SubnavShell` omits a `utility` prop (ADR 0182, YAGNI).
- */
+// sözlük's product Subnav zone, composed through `SubnavShell` — see ADR 0182. No search
+// slot: the "go to a term" search folded into the global ⌘K `ara` (#2995).
 export function SozlukSubnavLayout() {
 	const [params] = useSearchParams();
 	const letter = params.get("harf") ?? undefined;

--- a/apps/web/src/components/ui/Button.test.tsx
+++ b/apps/web/src/components/ui/Button.test.tsx
@@ -11,7 +11,6 @@ describe("Button — the widened primitive (#2163)", () => {
 		expect(btn.getAttribute("type")).toBe("button");
 		expect(btn.classList.contains("kp-btn")).toBe(true);
 		expect(btn.getAttribute("data-variant")).toBe("primary");
-		// unset toggle/busy/icon add nothing
 		expect(btn.hasAttribute("aria-pressed")).toBe(false);
 		expect(btn.hasAttribute("aria-busy")).toBe(false);
 		expect(btn.hasAttribute("disabled")).toBe(false);
@@ -41,7 +40,7 @@ describe("Button — the widened primitive (#2163)", () => {
 		expect(btn.getAttribute("aria-busy")).toBe("true");
 		expect(btn.hasAttribute("disabled")).toBe(true);
 		expect(container.querySelector('[data-part="spinner"]')).not.toBeNull();
-		expect(container.querySelector(".kp-btn__icon")).toBeNull(); // spinner replaces the icon
+		expect(container.querySelector(".kp-btn__icon")).toBeNull();
 		expect(btn.textContent).toContain("kaydet");
 	});
 });

--- a/apps/web/src/components/ui/Button.tsx
+++ b/apps/web/src/components/ui/Button.tsx
@@ -18,7 +18,6 @@ export interface ButtonProps
 	block?: boolean;
 	/** Phoenix compatibility alias for Manti's `leadingIcon`. */
 	icon?: React.ReactNode;
-	/** Optional toggle state for button-shaped app actions. */
 	pressed?: boolean;
 }
 

--- a/apps/web/src/components/ui/Card.test.tsx
+++ b/apps/web/src/components/ui/Card.test.tsx
@@ -8,7 +8,6 @@ describe("Surface / Card — the composite shell primitive (#2163)", () => {
 		const el = container.firstElementChild!;
 		expect(el.classList.contains("kp-surface")).toBe(true);
 		expect(el.classList.contains("kp-surface--tone-default")).toBe(true);
-		// flat / no-radius / no-pad / no-border carry no class
 		expect(el.className).not.toMatch(/kp-surface--elev-/);
 		expect(el.className).not.toMatch(/kp-surface--radius-/);
 		expect(el.className).not.toMatch(/kp-surface--pad-/);

--- a/apps/web/src/components/ui/Card.tsx
+++ b/apps/web/src/components/ui/Card.tsx
@@ -1,25 +1,12 @@
 import type * as React from "react";
 import "./Card.css";
 
-/**
- * The composite surface primitive (#2163, pillar cohesiveness; epic #2168). Every
- * page used to hand-assemble its own bordered/tinted box shell — background,
- * border, radius, padding, elevation — as a near-duplicate copy that drifted from
- * the next. `Surface` is the one parameterized shell those copies collapse onto:
- * it emits only role-token classes (no color/spacing/shadow literal lives here),
- * so a shell reads its background from a `tone`, its lift from an `elevation`
- * (the ADR 0162 four-level ramp), and its border/radius/padding from tokens.
- *
- * `Card` is the opinionated default for NEW surfaces — a bordered, subtly-raised,
- * padded box — so a fresh card reaches for one cohesive shape instead of inventing
- * another. A migration that must preserve an existing shell's exact look uses
- * `Surface` with explicit props (moving the shell declarations off the feature CSS
- * and onto props, leaving only the call-site's own layout behind).
- */
+// The composite surface primitive — see ADR 0162. `Surface` emits only role-token
+// classes: no color/spacing/shadow literal may live here.
 
 /** Background role of the surface — the role token, never a raw scale. */
 export type SurfaceTone = "default" | "raised" | "sunken";
-/** The ADR 0162 four-level elevation ramp (flat · raised · dropdown · overlay). */
+/** The ADR 0162 four-level elevation ramp. */
 export type Elevation = "flat" | "raised" | "dropdown" | "overlay";
 /** Corner radius, off the `--r-*` token scale. */
 export type SurfaceRadius = "none" | "sm" | "md" | "lg";
@@ -27,7 +14,6 @@ export type SurfaceRadius = "none" | "sm" | "md" | "lg";
 export type SurfacePadding = "none" | "sm" | "md" | "lg";
 
 export interface SurfaceProps extends React.HTMLAttributes<HTMLElement> {
-	/** Render element (article/section/aside/li/…). Defaults to `div`. */
 	as?: React.ElementType;
 	tone?: SurfaceTone;
 	elevation?: Elevation;

--- a/apps/web/src/components/ui/CopyLinkButton.tsx
+++ b/apps/web/src/components/ui/CopyLinkButton.tsx
@@ -1,19 +1,6 @@
 import * as React from "react";
 import {Button} from "./Button";
 
-/**
- * Shared `paylaş` (share/copy-link) button — presentation + inline confirmation only.
- * The page passes the item's canonical **path** (`/pano/:id`, `/sozluk/:slug`, or a
- * comment-anchor `/pano/:id#comment-<id>`); the button resolves it to an absolute URL
- * and copies it to the clipboard, locking into visible "kopyalandı" feedback (or
- * "kopyalanamadı" when the clipboard write is denied — insecure context, permission).
- * The native share sheet is used only on a coarse-pointer surface (mobile/PWA), where
- * it is the better affordance; every desktop browser — including Safari macOS, which
- * *implements* the Web Share API on desktop — copies to the clipboard (#1635). Reused
- * by every share surface (pano post/comment, sözlük definition), so no page-specific
- * link logic lives in the shared content components.
- */
-
 export type ShareOutcome = "shared" | "copied" | "error";
 
 function absoluteUrl(path: string): string {
@@ -25,7 +12,6 @@ function absoluteUrl(path: string): string {
  * native branch fires only on a **coarse-pointer** surface (mobile/PWA) that *also*
  * has a usable Web Share API — never on mere API presence, because Safari macOS
  * desktop implements the API yet must copy like every other desktop browser (#1635).
- * Pure over its inputs, so the branch selection is unit-tested without a DOM.
  */
 export function shouldUseNativeShare(input: {
 	hasShare: boolean;
@@ -67,12 +53,6 @@ async function shareOrCopy(url: string): Promise<ShareOutcome> {
 	}
 }
 
-/**
- * The label a {@link CopyLinkButton} shows for each transient feedback state. A
- * `null` outcome (idle) and a `"shared"` (the OS sheet is its own feedback) both
- * fall through to the caller's resting `label`. Pure, so the state→copy mapping is
- * unit-tested without a DOM.
- */
 export function shareFeedbackLabel(
 	outcome: "copied" | "error" | null,
 	restingLabel: string,
@@ -90,7 +70,6 @@ export function shareFeedbackLabel(
 export interface CopyLinkButtonProps {
 	/** Canonical path of the item, e.g. `/pano/:id` or `/pano/:id#comment-<id>`. */
 	path: string;
-	/** Resting label; defaults to `paylaş`. Feedback states replace it transiently. */
 	label?: string;
 	testId?: string;
 	className?: string;
@@ -118,9 +97,7 @@ export function CopyLinkButton({path, label = "paylaş", testId, className}: Cop
 
 	async function onClick() {
 		const outcome = await shareOrCopy(absoluteUrl(path));
-		// A native share leaves the label as-is (the OS sheet is its own feedback); a
-		// clipboard write flashes its outcome — "kopyalandı" on success, "kopyalanamadı"
-		// on a denied/absent clipboard — for two seconds, then resets.
+		// A native share leaves the label as-is: the OS sheet is its own feedback.
 		if (outcome === "shared") return;
 		setFeedback(outcome === "copied" ? "copied" : "error");
 		if (timer.current) clearTimeout(timer.current);

--- a/apps/web/src/components/ui/CountToggle.tsx
+++ b/apps/web/src/components/ui/CountToggle.tsx
@@ -3,13 +3,9 @@ import {Button, type ButtonProps} from "./Button";
 import "./CountToggle.css";
 
 /**
- * The count-pill toggle primitive (#2163, pillar cohesiveness; epic #2168). A
- * pressable pill carrying an icon/label and an optional aggregate count, its
- * on/off state exposed via `aria-pressed` and carried visually by the accent
- * tint (never color alone — the pressed state is in the ARIA + the shape). The
- * reaction bar's per-emoji buttons are the canonical instance; this extracts the
- * pill so the shape is built once instead of re-assembled per surface. Role
- * tokens only; the 24px floor is the WCAG 2.5.8 minimum target size (#2166).
+ * The count-pill toggle primitive — see ADR 0162. Pressed state is carried by
+ * `aria-pressed` and the shape, never by the accent tint alone; role tokens only,
+ * and the 24px floor is the WCAG 2.5.8 minimum target size (#2166).
  *
  * @component CountToggle
  * @whenToUse The pressable count-pill — a reaction/vote/toggle affordance that
@@ -21,16 +17,12 @@ import "./CountToggle.css";
  */
 export interface CountToggleProps
 	extends Omit<ButtonProps, "children" | "pressed" | "count" | "icon"> {
-	/** On/off state → `aria-pressed` + the accent-tinted pressed styling. */
 	pressed?: boolean;
-	/** Aggregate count rendered after the icon/label. Hidden when 0 unless `showZero`. */
+	/** Hidden when 0 unless `showZero`. */
 	count?: number;
-	/** Render a `0` count instead of hiding it. */
 	showZero?: boolean;
-	/** Leading icon/glyph (decorative — name the control via `aria-label`). */
 	icon?: React.ReactNode;
 	children?: React.ReactNode;
-	/** Test id for the count element (the label lives on the button's own props). */
 	countTestId?: string;
 }
 

--- a/apps/web/src/components/ui/DraftRestoreBanner.tsx
+++ b/apps/web/src/components/ui/DraftRestoreBanner.tsx
@@ -2,12 +2,6 @@ import {Button} from "./Button";
 import "./DraftRestoreBanner.css";
 
 /**
- * The "you have a saved draft — restore it?" affordance, shown when a draft survived
- * the auth round-trip. The draft is OFFERED, never silently re-injected (issue #1214):
- * the user explicitly restores or discards it. Real semantics — a labelled `<section>`
- * landmark with two native buttons (full keyboard path + visible focus from `kp-btn`);
- * state is conveyed by text, not color alone. Copy is lowercase Turkish.
- *
  * @component DraftRestoreBanner
  * @whenToUse The saved-draft restore prompt. Reach for it after a flow that may have
  *   stashed a draft across the auth round-trip — it OFFERS restore/discard rather
@@ -19,9 +13,7 @@ export function DraftRestoreBanner({
 	onRestore,
 	onDismiss,
 }: {
-	/** Called when the user accepts — restore the stashed draft. */
 	onRestore: () => void;
-	/** Called when the user declines — discard/ignore the stashed draft. */
 	onDismiss: () => void;
 }) {
 	return (

--- a/apps/web/src/components/ui/EditedIndicator.tsx
+++ b/apps/web/src/components/ui/EditedIndicator.tsx
@@ -2,10 +2,6 @@ import {editedAfter, formatEditedTooltipTR} from "../../lib/datetime";
 import {Tooltip} from "./Tooltip";
 
 /**
- * The muted "düzenlendi" edit marker with an edited-at tooltip. Returns null when
- * `updatedAt` is missing or within the grace window, so callers can render it
- * unconditionally without gating on edit state themselves.
- *
  * @component EditedIndicator
  * @whenToUse The edited-marker glyph. Reach for it on any editable entity's meta row
  *   (post, comment, definition) to signal an edit — render it unconditionally and
@@ -16,9 +12,7 @@ export function EditedIndicator({
 	createdAt,
 	updatedAt,
 }: {
-	/** The entity's creation timestamp — the baseline the edit is measured against. */
 	createdAt: string | null | undefined;
-	/** The entity's last-update timestamp; drives visibility and the tooltip text. */
 	updatedAt: string | null | undefined;
 }) {
 	if (!editedAfter(createdAt, updatedAt)) return null;

--- a/apps/web/src/components/ui/EmptyState.tsx
+++ b/apps/web/src/components/ui/EmptyState.tsx
@@ -2,14 +2,7 @@ import type * as React from "react";
 import "./EmptyState.css";
 
 /**
- * The inline empty-state primitive: a composed, centered block a sparse surface
- * renders in place of a bare void (a "0 yorum" label, a feed with no posts, a
- * profile with no contributions). `NotFoundPage` is its full-page 404 sibling —
- * this one fills a region *within* a page so it reads as intentional, not truncated.
- *
- * Slots, not law: an `icon` glyph slot, a required `title`, an optional
- * `description`, and an `action` CTA slot. Composed from existing spacing/text
- * tokens only — it defines no new design-system primitive.
+ * Composed from existing spacing/text tokens only — it defines no new primitive.
  *
  * @component EmptyState
  * @whenToUse The inline empty-state block. Reach for it to fill a sparse region
@@ -28,13 +21,9 @@ export function EmptyState({
 	action,
 	className = "",
 }: {
-	/** Decorative glyph above the title. */
 	icon?: React.ReactNode;
-	/** The required headline. */
 	title: React.ReactNode;
-	/** Optional supporting line under the title. */
 	description?: React.ReactNode;
-	/** Optional CTA below the copy. */
 	action?: React.ReactNode;
 	className?: string;
 }) {

--- a/apps/web/src/components/ui/MetaRow.tsx
+++ b/apps/web/src/components/ui/MetaRow.tsx
@@ -2,17 +2,8 @@ import type * as React from "react";
 import "./MetaRow.css";
 
 /**
- * The metadata-row primitive (#2163, pillar cohesiveness; epic #2168). Feed rows,
- * post/definition headers, and comment footers each hand-rolled the same inline
- * row — an align-baseline flex-wrap of muted metadata (author · time · a count ·
- * an action or two, dot-separated) — as a near-duplicate copy. `MetaRow` is the
- * one shell those collapse onto: it owns the row layout and the shared child
- * treatment (a bold-secondary `.author`, secondary→accent links, reset inline
- * `button`s), all off role tokens. `MetaRow.Dot` is the shared `·` separator so
- * every surface's separators read identically.
- *
- * A migrating call-site keeps only its own genuine deltas (a bespoke gap, a
- * top-margin) on its own class; the shared shape moves here.
+ * The metadata-row primitive — see ADR 0162. It owns the row layout and the shared
+ * child treatment off role tokens; a migrating call-site keeps only its own deltas.
  *
  * @component MetaRow
  * @whenToUse The muted metadata row shell — author · time · a count · an action,
@@ -21,7 +12,6 @@ import "./MetaRow.css";
  * @slot children The metadata items; separate them with `MetaRow.Dot`.
  */
 export interface MetaRowProps extends React.HTMLAttributes<HTMLElement> {
-	/** Render element (div/footer/header/…). Defaults to `div`. */
 	as?: React.ElementType;
 }
 
@@ -34,7 +24,6 @@ export function MetaRow({as, className = "", children, ...rest}: MetaRowProps) {
 	);
 }
 
-/** The shared dot separator (`·`), decorative — hidden from assistive tech. */
 export function MetaDot() {
 	return (
 		<span className="kp-meta-row__dot" aria-hidden="true">

--- a/apps/web/src/components/ui/ReportButton.tsx
+++ b/apps/web/src/components/ui/ReportButton.tsx
@@ -1,19 +1,10 @@
 import * as React from "react";
 import {Button} from "./Button";
 
-/**
- * Shared `bildir` (report) button — presentation + inline confirmation only.
- * The page passes `onReport`, which performs the actual `report.submit` (plus the
- * signed-out auth redirect) and returns the outcome; the button owns the in-flight
- * lock and the visible "bildirildi" / "zaten bildirildi" feedback. Reused by every
- * report surface (pano post/comment, sözlük definition), so no page-specific report
- * logic lives in the shared content components.
- */
-
 export type ReportOutcome = "reported" | "already" | "redirected" | "error";
 
 export interface ReportButtonProps {
-	/** Performs the report and returns the outcome; the button never calls the mutation itself. */
+	/** The button never calls the report mutation itself; the page's callback does. */
 	onReport: () => Promise<ReportOutcome>;
 	testId?: string;
 	className?: string;

--- a/apps/web/src/components/ui/ReviewBadge.tsx
+++ b/apps/web/src/components/ui/ReviewBadge.tsx
@@ -1,8 +1,4 @@
-// The "incelemede" in-review badge (#2200) — the ONE renderer of that state, on every
-// surface that shows it: the author's own sandboxed content (post-detail, definition,
-// the profile katkıların list) and the divan's review queue. The profile list and divan
-// each carried their own copy until #5228 folded them in. State is carried by the word,
-// not color alone (the AA-contrast tokens).
+// State is carried by the word, not color alone (the AA-contrast tokens).
 import {Badge} from "./Badge";
 import "./ReviewBadge.css";
 

--- a/apps/web/src/components/ui/a11y/a11y-pbt.test.tsx
+++ b/apps/web/src/components/ui/a11y/a11y-pbt.test.tsx
@@ -1,12 +1,4 @@
-/**
- * The property-based a11y promotion loop over the `ui/` primitives (#2175, ADR
- * 0162 pillar 4). For every classified primitive, `fast-check` generates
- * randomized VALID prop combinations, each rendered in jsdom and asserted against
- * the pillar-4 invariants — but only the invariants whose posture is `enforced`
- * (`posture.ts`) fail the gate; `warning`-posture invariants (contrast,
- * tap-target — jsdom cannot compute them) are reported, not enforced. Promoting a
- * warning to enforced is a one-line edit to `posture.ts`, the promotion loop.
- */
+/** The property-based a11y suite — see `.patterns/property-based-a11y.md`. */
 import {render} from "@testing-library/react";
 import fc from "fast-check";
 import {describe, expect, it} from "vitest";
@@ -15,7 +7,6 @@ import {runEnforcedInvariants} from "./check.ts";
 import {POSTURE, postureOf} from "./posture.ts";
 import {type PrimitiveSpec, REGISTRY} from "./registry.tsx";
 
-/** How many randomized prop combinations to generate per primitive. */
 const RUNS_PER_PRIMITIVE = 20;
 
 const testable = (spec: PrimitiveSpec): spec is Exclude<PrimitiveSpec, {kind: "deferred"}> =>
@@ -61,8 +52,6 @@ describe("enforced-invariant teeth (the gate is not vacuous)", () => {
 for (const [name, spec] of Object.entries(REGISTRY)) {
 	if (!testable(spec)) continue;
 	describe(`${name} — property-based a11y (${spec.kind})`, () => {
-		// The warning-posture invariants jsdom cannot decide — surfaced once per
-		// primitive so the warning rung is visible, not silently dropped.
 		const warned = Object.values(POSTURE)
 			.filter((m) => m.posture === "warning")
 			.map((m) => m.id);

--- a/apps/web/src/components/ui/a11y/check.ts
+++ b/apps/web/src/components/ui/a11y/check.ts
@@ -1,15 +1,7 @@
 /**
- * The invariant checker for the property-based a11y loop (#2175, ADR 0162 pillar
- * 4): given one rendered primitive, run the jsdom-decidable pillar-4 invariants
- * and return the violations. The geometry/paint invariants (contrast, tap-target)
- * are NOT run here — jsdom has no layout engine and applies no CSS, so they are
- * reported once per primitive as warnings by the suite (see `posture.ts`), never
- * asserted per render.
- *
- * axe is the engine for name + ARIA correctness; its violations are bucketed onto
- * the `accessible-name` / `valid-aria` invariant ids. `focusable` is a direct DOM
- * probe (focus the control, read `document.activeElement`) — the honest test of
- * keyboard operability, which axe alone does not assert.
+ * The invariant checker for the property-based a11y loop — see
+ * `.patterns/property-based-a11y.md`. Only the jsdom-decidable invariants run here;
+ * the geometry/paint ones (contrast, tap-target) never assert per render.
  */
 import axe from "axe-core";
 import type {InvariantId} from "./posture.ts";
@@ -53,7 +45,6 @@ const ARIA_RULES = [
 
 const ENFORCED_AXE_RULES = [...NAME_RULES, ...ARIA_RULES];
 
-/** Map an axe rule id onto the invariant it belongs to (name rules → accessible-name). */
 const invariantForRule = (ruleId: string): InvariantId =>
 	NAME_RULES.has(ruleId) ? "accessible-name" : "valid-aria";
 
@@ -86,7 +77,6 @@ const checkFocusable = (root: HTMLElement, spec: InteractiveSpec): InvariantViol
 	return null;
 };
 
-/** Run the enforced (jsdom-decidable) pillar-4 invariants; [] means clean. */
 export const runEnforcedInvariants = async (
 	root: HTMLElement,
 	spec: PrimitiveSpec,

--- a/apps/web/src/components/ui/a11y/posture.ts
+++ b/apps/web/src/components/ui/a11y/posture.ts
@@ -1,35 +1,11 @@
 /**
- * The warning-to-enforced posture registry — the promotion half of the
- * property-based a11y loop (#2175, ADR 0162 pillar 4).
- *
- * Each a11y invariant the harness checks carries a `posture`: `enforced` (a
- * violation fails the gate) or `warning` (a violation is reported but does not
- * fail). This is the *promotion loop*: an invariant that a reviewer keeps
- * catching by hand starts as a `warning` here, and is graduated to `enforced` —
- * a one-line, deliberate, reviewed edit to this map — once every current `ui/`
- * primitive holds it, turning a recurring miss into a standing guardrail.
- *
- * WHY two postures, not one: the harness runs in jsdom, which has no layout
- * engine and does not apply real CSS. Name/role/ARIA/focusability are fully
- * decidable there, so they are `enforced` from day one. Contrast and tap-target
- * are geometry/paint facts jsdom cannot compute (getBoundingClientRect is 0,
- * computed colors are unresolved) — asserting them here would be a false gate,
- * so they start `warning` and are promotion candidates for a real-browser
- * (Playwright) a11y pass, not a jsdom flip.
- *
- * PROMOTION PROCEDURE (documented, so a promotion is a conscious ratchet):
- *   1. Confirm every classified `ui/` primitive already satisfies the invariant
- *      (run `pnpm --filter @kampus/web test:a11y` — no warning lines for it).
- *   2. Flip its entry below from `"warning"` to `"enforced"` in one commit.
- *   3. From then on a regression on ANY primitive fails the gate — the miss is
- *      now a permanent guardrail.
- * Demotion (enforced → warning) is the escape hatch and must never be used to
- * route around a real failure; fix the primitive instead.
+ * The warning-to-enforced posture registry — see `.patterns/property-based-a11y.md`
+ * for the promotion loop. Demotion (enforced → warning) must never be used to route
+ * around a real failure; fix the primitive instead.
  */
 
 export type Posture = "enforced" | "warning";
 
-/** The a11y invariants the harness asserts over each primitive's rendered DOM. */
 export type InvariantId =
 	| "accessible-name"
 	| "valid-aria"
@@ -40,16 +16,10 @@ export type InvariantId =
 export interface InvariantMeta {
 	readonly id: InvariantId;
 	readonly posture: Posture;
-	/** One-line description — the ADR 0162 pillar-4 rule this invariant enforces. */
+	/** The ADR 0162 pillar-4 rule this invariant enforces, in one line. */
 	readonly rule: string;
 }
 
-/**
- * The single source of posture for every invariant. Enforced invariants are the
- * jsdom-decidable pillar-4 rules (name, ARIA, focusability); the geometry/paint
- * rules (contrast, tap-target) start as warnings — promotion candidates for a
- * real-browser pass — because jsdom cannot compute them.
- */
 export const POSTURE: Readonly<Record<InvariantId, InvariantMeta>> = {
 	"accessible-name": {
 		id: "accessible-name",

--- a/apps/web/src/components/ui/a11y/registry.tsx
+++ b/apps/web/src/components/ui/a11y/registry.tsx
@@ -1,16 +1,7 @@
 /**
- * The primitive classification registry for the property-based a11y loop (#2175,
- * ADR 0162 pillar 4). Each runtime export of `../index.ts` is classified once as
- * `interactive`, `presentational`, or `deferred`, and the interactive/presentational
- * entries carry a `fast-check` arbitrary that generates a randomized VALID render
- * (a representative prop combination) for the harness to assert invariants over.
- *
- * Auto-coverage: the suite enumerates the barrel's runtime exports and requires
- * every one to appear here (see `a11y-pbt.test.tsx`'s coverage test) — a newly
- * added primitive that no one classified fails the gate, so the covered set can
- * never silently go stale. `deferred` is a conscious, reasoned parking spot (a
- * machine-backed portal primitive, or a control needing composition context to
- * have an accessible name), not an escape hatch — each carries its promotion reason.
+ * The primitive classification registry for the property-based a11y loop — see
+ * `.patterns/property-based-a11y.md`. Arbitraries must generate only VALID props,
+ * and `deferred` is a reason-carrying parking spot, not an escape hatch.
  */
 
 import fc from "fast-check";
@@ -26,7 +17,6 @@ import {MetaRow} from "../MetaRow";
 import {NumberInput} from "../NumberInput";
 import {ScrollArea} from "../ScrollArea";
 
-/** An interactive control: name/focus invariants apply to its `selector` element. */
 export interface InteractiveSpec {
 	readonly kind: "interactive";
 	/** CSS selector for the control inside the render root (button/a/input). */
@@ -34,13 +24,11 @@ export interface InteractiveSpec {
 	readonly arb: fc.Arbitrary<ReactElement>;
 }
 
-/** A decorative/structural primitive: only the structural axe invariants apply. */
 export interface PresentationalSpec {
 	readonly kind: "presentational";
 	readonly arb: fc.Arbitrary<ReactElement>;
 }
 
-/** A primitive not (yet) in the bare-prop harness, with the reason it is parked. */
 export interface DeferredSpec {
 	readonly kind: "deferred";
 	readonly reason: string;
@@ -50,7 +38,6 @@ export type PrimitiveSpec = InteractiveSpec | PresentationalSpec | DeferredSpec;
 
 /** A short, always-present, human-readable label so a control has an accessible name. */
 const label = fc.constantFrom("Beğen", "Yanıtla", "Paylaş", "Gönder", "Kaydet", "Aç");
-/** Prose children for a presentational container. */
 const text = fc.constantFrom("kamp.us", "sözlük", "panolar", "bir başlık", "42");
 
 const buttonArb: fc.Arbitrary<ReactElement> = fc
@@ -179,22 +166,15 @@ const scrollAreaArb: fc.Arbitrary<ReactElement> = text.map((children) => (
 	<ScrollArea orientation="vertical">{children}</ScrollArea>
 ));
 
-/** Reason shared by Manti primitives parked out of the bare-prop harness. */
 const COMPOUND_REASON =
 	"Manti machine primitive — needs required items/trigger/content props or a portal interaction to render a representative surface; covered by composed-usage tests.";
 
-/**
- * The classification of EVERY runtime export of `../index.ts`. The coverage test
- * asserts this key set equals the barrel's runtime export set, so adding or
- * removing a primitive without updating this map fails the gate.
- */
+/** EVERY runtime export of `../index.ts` — the coverage test fails on any drift. */
 export const REGISTRY: Readonly<Record<string, PrimitiveSpec>> = {
-	// Interactive controls — the full name/focus/ARIA invariant set applies.
 	Button: {kind: "interactive", selector: "button", arb: buttonArb},
 	CountToggle: {kind: "interactive", selector: "button", arb: countToggleArb},
 	NumberInput: {kind: "interactive", selector: "input", arb: numberInputArb},
 
-	// Presentational primitives — structural ARIA invariants only.
 	Surface: {kind: "presentational", arb: surfaceArb},
 	Card: {kind: "presentational", arb: cardArb},
 	MetaRow: {kind: "presentational", arb: metaRowArb},
@@ -208,7 +188,6 @@ export const REGISTRY: Readonly<Record<string, PrimitiveSpec>> = {
 	Mark: {kind: "presentational", arb: inlineAtomArb(Mark)},
 	Skeleton: {kind: "presentational", arb: skeletonArb},
 
-	// Deferred — Manti machine / portal / provider-bound primitives.
 	Collapsible: {kind: "deferred", reason: COMPOUND_REASON},
 	Dialog: {kind: "deferred", reason: COMPOUND_REASON},
 	Menu: {kind: "deferred", reason: COMPOUND_REASON},
@@ -219,7 +198,6 @@ export const REGISTRY: Readonly<Record<string, PrimitiveSpec>> = {
 	Tooltip: {kind: "deferred", reason: COMPOUND_REASON},
 	TooltipProvider: {kind: "deferred", reason: COMPOUND_REASON},
 
-	// Deferred — form controls whose accessible name comes from Manti's field-owning props.
 	Form: {
 		kind: "deferred",
 		reason: "native form wrapper — needs labelled Manti controls in a composed fixture.",
@@ -233,7 +211,6 @@ export const REGISTRY: Readonly<Record<string, PrimitiveSpec>> = {
 		reason: "Manti Textarea — accessible name comes from its required composed label prop.",
 	},
 
-	// Deferred — controls with side effects / data props needing a composed fixture.
 	CopyLinkButton: {
 		kind: "deferred",
 		reason: "control with a clipboard side effect + a URL prop — needs a composed fixture.",

--- a/apps/web/src/components/ui/atoms.tsx
+++ b/apps/web/src/components/ui/atoms.tsx
@@ -18,9 +18,7 @@ export function Tag({
 	children,
 	className = "",
 }: {
-	/** Category role driving the chip color (`discuss` · `ask` · `show` · …). */
 	kind?: TagKind;
-	/** When set, render the chip as a link to this URL. */
 	href?: string;
 	children: React.ReactNode;
 	className?: string;
@@ -82,9 +80,9 @@ export function Skeleton({
 	height = 12,
 	className = "",
 }: {
-	/** Placeholder width; a bare number is treated as pixels. */
+	/** A bare number is treated as pixels. */
 	width?: number | string;
-	/** Placeholder height; a bare number is treated as pixels. Defaults to 12. */
+	/** A bare number is treated as pixels. */
 	height?: number | string;
 	className?: string;
 }) {

--- a/apps/web/src/components/useVoteFlash.ts
+++ b/apps/web/src/components/useVoteFlash.ts
@@ -1,11 +1,9 @@
 import {useEffect, useRef, useState} from "react";
 
 /**
- * Pulses `flashing` true for one animation cycle whenever `score` changes — the
- * count-flash retrigger for the vote controls (#1213). Stays false on first
- * render (no flash on initial paint) and re-arms on every later change. Pair
- * with `onAnimationEnd={endFlash}` on the animated element so the class clears
- * and the next cast can replay it.
+ * Pulses `flashing` for one animation cycle on every `score` change after the first
+ * render. Pair with `onAnimationEnd={endFlash}` on the animated element, or the class
+ * never clears and the next cast cannot replay it.
  */
 export function useVoteFlash(score: number): {flashing: boolean; endFlash: () => void} {
 	const [flashing, setFlashing] = useState(false);

--- a/apps/web/src/fate/FateProvider.tsx
+++ b/apps/web/src/fate/FateProvider.tsx
@@ -20,19 +20,14 @@ import {
 } from "./snapshot";
 import {useGlobalLivePin} from "./useGlobalLivePin";
 
-/**
- * The PUBLIC tier of the two-tier fate provider (ADR 0167): mounts the eager,
- * always-anonymous public client ABOVE the session gate. Its subtree reads public
- * views (the /pano feed list) that need no settled session, so they paint in parallel
- * with `get-session`. The client never re-keys (always anon), so this commit never
- * triggers the #438 re-key remount the authed `FateProvider` below defers to avoid.
- */
+/** The PUBLIC tier of the two-tier fate provider, mounted ABOVE the session gate
+ *  (ADR 0167). */
 export function PublicFateProvider({children}: {children: React.ReactNode}) {
 	return <FateClient client={getPublicFateClient()}>{children}</FateClient>;
 }
 
-// Holds the app-lifetime live pin (#711) from inside the FateClient context,
-// where `useFateClient` resolves. Renders nothing.
+// Exists only to hold the app-lifetime live pin (#711) from inside the FateClient
+// context, where `useFateClient` resolves.
 function GlobalLivePin({userId, retryTick}: {userId: string | null; retryTick: number}) {
 	useGlobalLivePin(userId, retryTick);
 	return null;
@@ -42,11 +37,8 @@ export function FateProvider({children}: {children: React.ReactNode}) {
 	const session = useSession();
 	const userId = session.data?.user.id ?? null;
 
-	// ADR 0095 client half: on a cold-start LIVE_UNAVAILABLE/503 the pin re-attempts
-	// the connect on a bounded exponential back-off. `retryTick` re-runs the pin's
-	// subscribe effect; the budget + coalescing live in the controller (which counts
-	// connect attempts, not the per-subscription error fan-out one cold connect
-	// produces — see `createLiveRetryController`, #1738).
+	// `retryTick` re-runs the pin's subscribe effect; the budget lives in the controller
+	// (ADR 0095, `createLiveRetryController`).
 	const [retryTick, setRetryTick] = useState(0);
 	const controllerRef = useRef<LiveRetryController | null>(null);
 	if (controllerRef.current == null) controllerRef.current = createLiveRetryController();
@@ -55,20 +47,16 @@ export function FateProvider({children}: {children: React.ReactNode}) {
 		controllerRef.current?.schedule(() => setRetryTick((tick) => tick + 1));
 	}, []);
 
-	// A new session identity gets a fresh retry budget; cancel any pending retry on
-	// re-key/unmount so a back-off never fires onto a torn-down client.
+	// Cancel on re-key/unmount so a back-off never fires onto a torn-down client.
 	useEffect(() => {
 		const controller = controllerRef.current;
 		controller?.reset();
 		return () => controller?.cancel();
 	}, [userId]);
 
-	// Re-arm the exhausted budget when the browser signals the live plane may be reachable
-	// again — a regained network (`online`) or a foregrounded tab (`visibilitychange`, the
-	// laptop sleep/wake case). Without this the budget is terminal for the session once its
-	// ~7.75s back-off span is spent, leaving the tab silently non-live until reload (#3790).
-	// `rearm` no-ops unless the budget is actually spent, so firing it on every visibility
-	// flip is cheap. Authenticated only — the pin never opens for an anon client.
+	// Without this the budget is terminal once its ~7.75s span is spent, leaving the tab
+	// silently non-live until reload (#3790). `rearm` no-ops unless the budget is spent,
+	// so firing it on every visibility flip is cheap.
 	useEffect(() => {
 		if (userId == null) return;
 		const rearm = () => controllerRef.current?.rearm(() => setRetryTick((tick) => tick + 1));
@@ -83,11 +71,8 @@ export function FateProvider({children}: {children: React.ReactNode}) {
 		};
 	}, [userId]);
 
-	// Identity-change teardown (#2321): when the resolved identity changes — a switch A→B
-	// or a sign-out/account-deletion A→anon (all reduce to the same transition) — drop the
-	// PREVIOUS identity's persisted snapshot, so its private myVote/isSaved overlay never
-	// survives the identity it belonged to. A content-cache eviction, not auth: the session
-	// cookie/validation is untouched.
+	// Drop the PREVIOUS identity's persisted snapshot on any identity change (A→B, or
+	// sign-out A→anon), so its private myVote/isSaved overlay never outlives it (#2321).
 	const prevUserIdRef = useRef<string | null>(null);
 	useEffect(() => {
 		const prev = prevUserIdRef.current;
@@ -102,33 +87,22 @@ export function FateProvider({children}: {children: React.ReactNode}) {
 			authenticated: userId != null,
 			onTransientLiveError: scheduleRetry,
 		});
-		// Feed snapshot (leg A, #2321): restore this identity's persisted authed cache at
-		// client creation — BEFORE any `useRequest` renders under the FateClient below, fate's
-		// hydrate-before-render contract. The anon (userId null) client is the pending/signed-out
-		// tier and owns no authed snapshot, so it is skipped: the authed snapshot is strictly
-		// identity-scoped. No-op when the flag is off. See `snapshot.ts`.
-		// Note a hydrated snapshot so the reload→paint instrument classifies this paint as
-		// the snapshot path (#2326). No-op when the snapshot flag is off (returns false).
+		// Hydrate here, at client creation — BEFORE any `useRequest` renders under the
+		// FateClient below (fate's hydrate-before-render contract).
 		if (userId != null && hydrateAuthedClient(created, userId)) noteSnapshotHydrated();
 		return created;
 	}, [userId, scheduleRetry]);
 
-	// Persist this identity's authed cache on tab-hide for the committed client's lifetime
-	// (#2321). Tied to the client instance so a re-key uninstalls the old client's listeners
-	// before the next installs; anon owns no authed snapshot, so it is skipped. No-op when
-	// the flag is off.
+	// Keyed on the client instance, not just `userId`, so a re-key uninstalls the old
+	// client's listeners before the next installs (#2321).
 	useEffect(() => {
 		if (userId == null) return;
 		return installAuthedSnapshotPersistence(client, userId);
 	}, [client, userId]);
 
-	// `useSession` resolves async ({data:null, isPending:true} → user) with no
-	// synchronous hydration. Committing the keyed client before it settles mounts
-	// the subtree under "anon", then re-keys to the real id once the session lands —
-	// remounting the whole router and wiping any controlled form mounted in the
-	// window (#438). Defer the first commit until settled so the first (and only)
-	// key is the resolved identity; the key still rebuilds the cache on a genuine
-	// login/logout identity change.
+	// Deliberate blank first paint: committing before the session settles mounts the
+	// subtree under "anon" and then re-keys to the real id, remounting the whole router
+	// and wiping any controlled form open in that window (#438).
 	if (session.isPending) return null;
 
 	return (

--- a/apps/web/src/fate/LoadMoreButton.tsx
+++ b/apps/web/src/fate/LoadMoreButton.tsx
@@ -1,4 +1,3 @@
-/** The shared connection pagination control: drives fate's `loadNext`. */
 import {useState} from "react";
 import {Button} from "../components/ui/Button";
 

--- a/apps/web/src/fate/Screen.test.tsx
+++ b/apps/web/src/fate/Screen.test.tsx
@@ -1,9 +1,6 @@
 /**
- * First component/DOM smoke test of the SPA seam (#1419): render the `Screen`
- * error boundary through its real React interface and pin both halves of its
- * code-forwarding contract — the boundary forwards a fate error's `.code`
- * verbatim, and falls a non-fate throw back to `INTERNAL_SERVER_ERROR`. Asserted
- * only by comments before this tier existed (see `Screen.tsx`).
+ * Pins both halves of `Screen`'s code-forwarding contract through its real React
+ * interface (#1419).
  */
 import {render, screen} from "@testing-library/react";
 import {afterEach, beforeEach, describe, expect, it, vi} from "vitest";

--- a/apps/web/src/fate/Screen.tsx
+++ b/apps/web/src/fate/Screen.tsx
@@ -1,27 +1,16 @@
 /**
- * The fate screen rails — `Suspense` + an error boundary, paired, so a screen
- * only declares its fallback + error UI. fate reads suspend and throw a
- * `FateRequestError` on boundary-class failures.
- *
- * This boundary catches **thrown** errors only; mutation errors a call site
- * handles inline never reach here (that split lives in the mutation hooks — see
- * `.patterns/fate-mutations-client.md`). It surfaces the error's `code` so
- * screens can branch on it (e.g. `UNAUTHORIZED` vs `POST_NOT_FOUND`).
- *
- * See `.patterns/fate-client-setup.md`.
+ * The fate screen rails — `Suspense` + an error boundary, paired. Catches **thrown**
+ * errors only; mutation errors a call site handles inline never reach here. See
+ * `.patterns/fate-client-setup.md` and `.patterns/fate-mutations-client.md`.
  */
 import {Component, type ErrorInfo, type ReactNode, Suspense} from "react";
 import type {FateWireCode} from "../lib/fateWireCodes";
 import {captureBoundaryError} from "../lib/sentry";
 
 /**
- * The fate wire `code` a screen branches on — the same {@link FateWireCode}
- * vocabulary, read un-narrowed: the known literals keep autocompletion, but the
- * open `string & {}` arm stays on purpose, because the boundary forwards the
- * thrown `code` verbatim (no `decodeFateWireCode`). A fate-internal throw
- * bypasses the annotation codec and carries fate's own protocol fallback
- * `INTERNAL_ERROR` — a real code `FATE_WIRE_CODES` omits (it lists
- * `INTERNAL_SERVER_ERROR`) — so the read must not be closed to that set.
+ * The open `string & {}` arm stays on purpose: a fate-internal throw bypasses the
+ * annotation codec and carries fate's own `INTERNAL_ERROR`, a code `FATE_WIRE_CODES`
+ * omits, so this read must not be closed to that set.
  */
 type FallbackRender = (error: {code: FateWireCode | (string & {}); error: Error}) => ReactNode;
 
@@ -51,17 +40,15 @@ class ErrorBoundary extends Component<ErrorBoundaryProps, ErrorBoundaryState> {
 
 	override componentDidCatch(error: Error, info: ErrorInfo): void {
 		console.error("[fate Screen] caught error", error, info);
-		// Forward to Sentry too (ADR 0118); inert until a DSN is set, so this is a
-		// no-op alongside the console.error above until then.
+		// ADR 0118; inert until a DSN is set.
 		captureBoundaryError(error, info.componentStack);
 	}
 
 	override render(): ReactNode {
 		const {error} = this.state;
 		if (error) {
-			// Forward the wire `code` verbatim — wider than the SPA's narrowed set
-			// (a fate-internal throw carries `INTERNAL_ERROR`), so this does NOT
-			// narrow through `decodeFateWireCode` the way `wire.codeOf` does.
+			// Deliberately does NOT narrow through `decodeFateWireCode` the way
+			// `wire.codeOf` does — the code is forwarded verbatim.
 			const code = isFateError(error) ? error.code : "INTERNAL_SERVER_ERROR";
 			return this.props.fallback({code, error});
 		}

--- a/apps/web/src/fate/client.ts
+++ b/apps/web/src/fate/client.ts
@@ -38,17 +38,14 @@ export const createClient = ({
 	onTransientLiveError,
 }: {
 	authenticated: boolean;
-	// Fired on the server's graceful cold-start signal (LIVE_UNAVAILABLE/503) so the
-	// global live pin can re-attempt the connect on a bounded back-off (ADR 0095).
 	onTransientLiveError?: (error: unknown) => void;
 }) => {
 	const client = createFateClient({
 		url: "/fate",
 		liveUrl: LIVE_URL,
 		fetch: cookieFetch,
-		// A cold-start LIVE_UNAVAILABLE/503 is a transient back-off signal, not a fatal
-		// drop (ADR 0095): route it to the pin's retry. Every other live error is
-		// out-of-band (the stream is best-effort) and stays on the console surface.
+		// A cold-start 503 is a transient back-off signal, not a fatal drop (ADR 0095):
+		// route it to the pin's retry. Every other live error is out-of-band.
 		onLiveError: (error) =>
 			isTransientLiveError(error)
 				? onTransientLiveError?.(error)

--- a/apps/web/src/fate/globalLivePin.test.ts
+++ b/apps/web/src/fate/globalLivePin.test.ts
@@ -1,16 +1,10 @@
 /**
- * Proves the #711 invariant at the transport seam: while a second always-on
- * operation is held (the app-lifetime global live pin — `useGlobalLivePin`), the
- * shared native SSE `EventSource` is NEVER closed when the only churning view
- * unsubscribes+resubscribes during a write-mutation refetch. With the pin held
- * `operations.size` can't reach 0, so fate's `if (operations.size === 0) {
- * source.close() }` teardown branch can't fire and the `connectionId` stays
- * stable. The first case is the falsification baseline: WITHOUT the pin, the same
- * churn tears the EventSource down (the lost-publish bug). See ADR 0094.
+ * Proves the #711 invariant at the transport seam (ADR 0094): with the pin held,
+ * `operations.size` can't reach 0, so fate's `source.close()` teardown branch can't
+ * fire on mutation churn. The first case is the falsification baseline.
  *
- * Transport-level, no React: the native live client (`createHTTPTransport({live:
- * true})` with no `liveConnector`) is exactly what phoenix grafts onto its client
- * (`client.ts`), and the refcount lives there.
+ * Transport-level, no React: the refcount lives in the native live client, which is
+ * exactly what phoenix grafts onto its client (`client.ts`).
  */
 import {createHTTPTransport} from "react-fate";
 import {describe, expect, it} from "vitest";
@@ -45,7 +39,6 @@ class FakeEventSource {
 	}
 }
 
-// The native client POSTs subscribe/unsubscribe control messages; answer them OK.
 const okFetch: typeof fetch = async () =>
 	new Response(JSON.stringify({results: [], version: 1}), {
 		headers: {"content-type": "application/json"},
@@ -72,8 +65,6 @@ const onlySource = (): FakeEventSource => {
 	return source;
 };
 
-// The churning list view: a connection subscription that unsubscribes during a
-// write mutation's refetch. `subscribeConnection` is optional on `Transport`.
 const subscribeView = (transport: LiveTransport): (() => void) => {
 	if (!transport.subscribeConnection) throw new Error("no subscribeConnection");
 	return transport.subscribeConnection("posts", "Post", undefined, ["id"], undefined, {
@@ -81,7 +72,6 @@ const subscribeView = (transport: LiveTransport): (() => void) => {
 	});
 };
 
-// The app-lifetime pin: one always-on entity subscription on the viewer's User.
 const subscribePin = (transport: LiveTransport): (() => void) => {
 	if (!transport.subscribeById) throw new Error("no subscribeById");
 	return transport.subscribeById("User", "u1", ["id"], undefined, {onData() {}});
@@ -93,30 +83,24 @@ describe("global live pin keeps the SSE stream alive across mutation churn (#711
 		const unsubscribeView = subscribeView(transport);
 		const source = onlySource();
 
-		// The transient unsubscribe a write mutation's refetch causes.
 		unsubscribeView();
 
-		// refcount hit 0 → fate closed the shared stream and dropped its connectionId.
 		expect(source.closed).toBe(true);
 	});
 
 	it("WITH the pin: the same churn never closes the EventSource — refcount stays >= 1", () => {
 		const transport = makeTransport();
-		// The app-lifetime pin: one always-on operation for the session.
 		const releasePin = subscribePin(transport);
 		const unsubscribeView = subscribeView(transport);
 		const source = onlySource();
 
-		// The churning view unsubscribes (mutation refetch) and resubscribes.
 		unsubscribeView();
 		expect(source.closed).toBe(false);
 		const unsubscribeView2 = subscribeView(transport);
 
-		// No new EventSource was built — the connectionId is stable across the churn.
 		expect(onlySource()).toBe(source);
 		expect(source.closed).toBe(false);
 
-		// Teardown: only when BOTH the view and the pin release does the stream close.
 		unsubscribeView2();
 		expect(source.closed).toBe(false);
 		releasePin();

--- a/apps/web/src/fate/liveRetry.ts
+++ b/apps/web/src/fate/liveRetry.ts
@@ -1,38 +1,18 @@
-/**
- * The client half of ADR 0095's cold-start handling: classify a live-error as the
- * server's graceful cold-start back-off signal, and compute the bounded retry
- * back-off the global live pin (ADR 0094) re-attempts the connect on.
- *
- * The server renders an exhausted cold-DO retry as `liveError("LIVE_UNAVAILABLE",
- * …, 503)`. By the time that envelope reaches the SPA, fate's transport has
- * rebuilt it: `responseError` (`@nkzw/fate`) constructs a `FateRequestError` whose
- * `.code` is derived from the HTTP *status* (`errorCodeFromStatus(503)` →
- * `"INTERNAL_ERROR"`), discarding the payload's `LIVE_UNAVAILABLE` code and keeping
- * only the message. So the one discriminant that survives the transport is
- * `.status === 503` — keying on the `code` would silently never match. We also
- * accept an explicit `LIVE_UNAVAILABLE` code for the in-band protocol-frame path
- * (`handleLiveMessage` → `protocolError` *does* preserve the server code), so both
- * delivery shapes of the same server signal are covered.
- */
+/** The client half of ADR 0095's cold-start handling. */
 
-/**
- * Bounded retry budget for ONE connectivity window. Past this the pin stops the
- * exponential back-off — but the exhausted budget is no longer terminal for the
- * session: it re-arms on regained connectivity / a foregrounded tab (`rearm`, driven
- * from `online`/`visibilitychange` in `FateProvider`), so an outage longer than the
- * ~7.75s back-off span (a deploy window, a laptop sleep/wake) recovers without a reload
- * (#3790). Sizing the budget itself is a separate question (out of scope, #3788).
- */
+/** Bounded budget for ONE connectivity window; `rearm` restores it. */
 export const LIVE_RETRY_MAX_ATTEMPTS = 5;
 
 const LIVE_RETRY_BASE_MS = 250;
 const LIVE_RETRY_CAP_MS = 5000;
 
 /**
- * True iff `error` is the server's transient cold-start back-off signal — a graceful
- * `LIVE_UNAVAILABLE`/503, never a genuine app error. A real 4xx/app error (status
- * 400/401/403/404) or a defect-500 (status 500, code `INTERNAL_ERROR`) returns
- * false, so it is NOT retried as transient and stays on the `console.error` surface.
+ * `.status === 503` is the only discriminant that survives fate's transport: for an
+ * HTTP-delivered `liveError("LIVE_UNAVAILABLE", …, 503)`, `responseError`
+ * (`@nkzw/fate`) derives `.code` from the status (`errorCodeFromStatus(503)` →
+ * `"INTERNAL_ERROR"`) and discards the payload code, so keying on the code alone would
+ * silently never match. The `LIVE_UNAVAILABLE` arm covers the in-band protocol-frame
+ * path, where `protocolError` does preserve the server code.
  */
 export function isTransientLiveError(error: unknown): boolean {
 	if (error == null || typeof error !== "object") return false;
@@ -40,60 +20,35 @@ export function isTransientLiveError(error: unknown): boolean {
 	return status === 503 || code === "LIVE_UNAVAILABLE";
 }
 
-/**
- * Capped exponential back-off for the next connect re-attempt. `attempt` is the
- * count of attempts already made (0-indexed): 250, 500, 1000, 2000, 4000 ms, capped
- * at 5000. Comfortably spans the sub-second DO warm window across a few mounts.
- */
+/** `attempt` is the count of attempts already made (0-indexed). */
 export function nextLiveRetryDelayMs(attempt: number): number {
 	const exp = LIVE_RETRY_BASE_MS * 2 ** Math.max(0, attempt);
 	return Math.min(exp, LIVE_RETRY_CAP_MS);
 }
 
-/** Injectable timer seam so the budget/coalescing invariant is testable off real time. */
 export interface RetryTimers {
 	readonly setTimeout: (fn: () => void, ms: number) => ReturnType<typeof setTimeout>;
 	readonly clearTimeout: (handle: ReturnType<typeof setTimeout>) => void;
 }
 
 export interface LiveRetryController {
-	/**
-	 * Ask for a bounded back-off reconnect. Coalesces a BURST of transient errors
-	 * from one failed connect into a single scheduled retry, and runs `fireRetry`
-	 * (the reconnect trigger) once the back-off elapses. A call while a retry is
-	 * already pending, or once the budget is spent, is a no-op.
-	 */
 	readonly schedule: (fireRetry: () => void) => void;
 	/**
-	 * Re-arm a SPENT budget and reconnect immediately — the recovery path out of the
-	 * terminal-and-silent exhausted state (#3790). Driven from `online`/`visibilitychange`
-	 * (a regained network, or a foregrounded tab after sleep/wake): if the budget is spent,
-	 * restore it and fire the reconnect NOW; a fresh failure re-enters the normal back-off
-	 * from attempt 0. A no-op while attempts remain — the in-flight back-off already owns
-	 * recovery, and re-arming mid-window would reset its progress on every benign tab focus.
+	 * Re-arm a SPENT budget and reconnect immediately, driven from
+	 * `online`/`visibilitychange` (#3790). A no-op while attempts remain: the in-flight
+	 * back-off already owns recovery, and re-arming mid-window would reset its progress
+	 * on every benign tab focus.
 	 */
 	readonly rearm: (fireRetry: () => void) => void;
-	/** Cancel a pending retry without firing it (unmount). */
 	readonly cancel: () => void;
-	/** Restore the full budget and drop any pending retry (new session identity). */
 	readonly reset: () => void;
 }
 
 /**
- * The bounded cold-start reconnect budget (ADR 0095), extracted from `FateProvider`
- * so its coalescing invariant is unit-testable off the React tree.
- *
- * The invariant: the budget counts CONNECT attempts, not error fan-out. One failed
- * (cold) live connect fans its error out to EVERY mounted live subscription — fate's
- * native client loops all `liveSubscriptions` on a connection error, so the client's
- * `onLiveError` fires once PER subscription, not once per connect. Charging the budget
- * per error drains the N-attempt budget ~N× faster on a page with N live views,
- * exhausting it before the DO warms — the #1738 post-reconnect defect, where a
- * post-detail page (pin + header + comments live views) burned the 5-attempt budget in
- * ~2 cold connects and never re-established the stream, so a vote published after the
- * reload never reached the reconnected client. Coalescing the burst behind a single
- * `pending` timer makes each cold connect cost exactly one attempt, so the five
- * back-offs span five real reconnects (~7.75s) — long enough to outlast a cold DO.
+ * The invariant: the budget counts CONNECT attempts, not error fan-out. One failed cold
+ * connect fires `onLiveError` once PER mounted subscription (fate loops all
+ * `liveSubscriptions`), so charging per error drains the budget ~N× faster on a page
+ * with N live views and exhausts it before the DO warms (#1738).
  */
 export function createLiveRetryController(
 	timers: RetryTimers = {setTimeout, clearTimeout},
@@ -110,8 +65,7 @@ export function createLiveRetryController(
 
 	return {
 		schedule: (fireRetry) => {
-			// A retry is already scheduled for this failed connect → coalesce the error
-			// burst; the fan-out of one connect failure must cost only one attempt.
+			// Coalesce the error burst: one connect failure must cost only one attempt.
 			if (pending != null) return;
 			if (attempt >= LIVE_RETRY_MAX_ATTEMPTS) return;
 			const delay = nextLiveRetryDelayMs(attempt);
@@ -123,8 +77,7 @@ export function createLiveRetryController(
 			}, delay);
 		},
 		rearm: (fireRetry) => {
-			// Only re-arm a spent budget; while attempts remain the pending back-off owns
-			// recovery. `drop()` is defensive — a spent budget holds no pending timer.
+			// `drop()` below is defensive — a spent budget holds no pending timer.
 			if (attempt < LIVE_RETRY_MAX_ATTEMPTS) return;
 			drop();
 			attempt = 0;

--- a/apps/web/src/fate/liveRetry.unit.test.ts
+++ b/apps/web/src/fate/liveRetry.unit.test.ts
@@ -1,9 +1,6 @@
 /**
- * The pure decision core of the ADR-0095 client cold-start handling: which
- * live-errors are the transient `LIVE_UNAVAILABLE`/503 back-off signal (retry) vs a
- * genuine app error (drop to console), and the bounded back-off schedule. The React
- * wiring in `useGlobalLivePin` / `FateProvider` is exercised separately once the SPA
- * has a component-test seam (#1419) — this tier covers the falsifiable logic.
+ * The pure decision core of the ADR-0095 client cold-start handling. The React wiring
+ * in `useGlobalLivePin` / `FateProvider` is covered separately (#1419).
  */
 import {afterEach, beforeEach, describe, expect, it, vi} from "vitest";
 import {
@@ -67,8 +64,7 @@ describe("nextLiveRetryDelayMs", () => {
 });
 
 describe("createLiveRetryController", () => {
-	// Fake timers model the back-off elapsing without wall-clock waits; the controller
-	// uses the global `setTimeout`/`clearTimeout` these replace.
+	// The controller defaults to the global `setTimeout`/`clearTimeout` these replace.
 	beforeEach(() => vi.useFakeTimers());
 	afterEach(() => vi.useRealTimers());
 
@@ -100,9 +96,8 @@ describe("createLiveRetryController", () => {
 		const controller = createLiveRetryController();
 		const fire = vi.fn();
 
-		// Each round = one failed cold connect that reports an error to 3 subscriptions,
-		// then the back-off elapses and the reconnect fires. The budget must last exactly
-		// LIVE_RETRY_MAX_ATTEMPTS rounds regardless of the 3× error fan-out.
+		// Each round = one failed cold connect reporting to 3 subscriptions. The budget
+		// must last exactly LIVE_RETRY_MAX_ATTEMPTS rounds despite the 3× fan-out.
 		for (let round = 0; round < LIVE_RETRY_MAX_ATTEMPTS; round++) {
 			controller.schedule(fire);
 			controller.schedule(fire);
@@ -113,7 +108,6 @@ describe("createLiveRetryController", () => {
 
 		expect(fire).toHaveBeenCalledTimes(LIVE_RETRY_MAX_ATTEMPTS);
 
-		// Budget spent: a further failed connect schedules nothing.
 		controller.schedule(fire);
 		expect(vi.getTimerCount()).toBe(0);
 		expect(fire).toHaveBeenCalledTimes(LIVE_RETRY_MAX_ATTEMPTS);
@@ -153,7 +147,6 @@ describe("createLiveRetryController", () => {
 		const controller = createLiveRetryController();
 		const fire = vi.fn();
 
-		// Spend the whole budget — the exhausted, once-terminal state (#3790).
 		for (let round = 0; round < LIVE_RETRY_MAX_ATTEMPTS; round++) {
 			controller.schedule(fire);
 			vi.advanceTimersByTime(nextLiveRetryDelayMs(round));
@@ -162,11 +155,9 @@ describe("createLiveRetryController", () => {
 		expect(fire).toHaveBeenCalledTimes(LIVE_RETRY_MAX_ATTEMPTS);
 		expect(vi.getTimerCount()).toBe(0);
 
-		// An `online`/`visibilitychange` re-arm: the reconnect fires NOW on a fresh budget.
 		controller.rearm(fire);
 		expect(fire).toHaveBeenCalledTimes(LIVE_RETRY_MAX_ATTEMPTS + 1);
 
-		// The fresh budget is full again — LIVE_RETRY_MAX_ATTEMPTS more back-off attempts.
 		for (let round = 0; round < LIVE_RETRY_MAX_ATTEMPTS; round++) {
 			controller.schedule(fire);
 			vi.advanceTimersByTime(nextLiveRetryDelayMs(round));

--- a/apps/web/src/fate/liveSubscribeBatch.test.ts
+++ b/apps/web/src/fate/liveSubscribeBatch.test.ts
@@ -1,14 +1,8 @@
 /**
- * Regression for #2273: react-fate's HTTP transport (defined in `@nkzw/fate`, re-exported
- * by `react-fate` — the import phoenix uses) must coalesce same-tick live subscribe control
- * messages into ONE `POST /fate/live`. Unpatched 1.3.1 fired a separate `control([op])` per
- * `add()` after the SSE `open`, so a feed load with N `useLiveView` mounts issued N
- * single-operation POSTs, each re-running better-auth session validation (~22 on an authed
- * /pano load). Fixed by `patches/@nkzw__fate@1.3.1.patch` (ADR 0038), which buffers adds and
- * flushes them as one batched control POST — the same batching the reconnect path already
- * did via `control(resubscribe)`. This drives the native live client through a mocked
- * EventSource + fetch and asserts one POST carries every operation, and that a live frame
- * still routes to each subscription afterward.
+ * Regression for #2273: the HTTP transport must coalesce same-tick live subscribe
+ * control messages into ONE `POST /fate/live`. Unpatched 1.3.1 POSTed once per `add()`,
+ * each re-running session validation (~22 on an authed /pano load); fixed by
+ * `patches/@nkzw__fate@1.3.1.patch` (ADR 0038). Reds if that patch is dropped.
  */
 
 import {createHTTPTransport} from "react-fate";
@@ -29,8 +23,8 @@ type ControlBody = {
 
 type Listener = (event: unknown) => void;
 
-// The shape createHTTPTransport's `eventSource` option expects (its EventSourceConstructor
-// type is not exported); MockEventSource is asserted to it once at the call site.
+// createHTTPTransport's EventSourceConstructor type is not exported, so MockEventSource is
+// asserted to this shape once at the call site.
 type EventSourceCtor = new (
 	url: string,
 	options?: {withCredentials?: boolean},
@@ -40,8 +34,6 @@ type EventSourceCtor = new (
 	removeEventListener(type: string, listener: (event: Event) => void): void;
 };
 
-// A synchronous EventSource stub: records listeners so the test can drive `open` and dispatch
-// live frames deterministically, without a real network stream.
 class MockEventSource {
 	static instances: MockEventSource[] = [];
 	readonly url: string;
@@ -78,7 +70,7 @@ class MockEventSource {
 	}
 }
 
-// Drain the microtask + timer queue so the `open.then(flush)` batch flush and its awaited
+// Drains the microtask + timer queue so the `open.then(flush)` batch flush and its awaited
 // fetch/json settle before we assert.
 const settle = () => new Promise((resolve) => setTimeout(resolve, 0));
 
@@ -119,12 +111,10 @@ describe("react-fate live transport — same-tick subscribe batching (#2273)", (
 		const {subscribeById} = makeTransport(fetchMock);
 		const handlers = {a: {onData: vi.fn()}, b: {onData: vi.fn()}, c: {onData: vi.fn()}};
 
-		// Three mounts subscribe in the same synchronous tick, as a feed of PanoPostCards does.
 		subscribeById("Post", "a", ["id", "body"], undefined, handlers.a);
 		subscribeById("Post", "b", ["id", "body"], undefined, handlers.b);
 		subscribeById("Post", "c", ["id", "body"], undefined, handlers.c);
 
-		// Exactly one SSE stream, and no control POST until the stream opens.
 		expect(MockEventSource.instances).toHaveLength(1);
 		expect(fetchMock).not.toHaveBeenCalled();
 
@@ -133,7 +123,6 @@ describe("react-fate live transport — same-tick subscribe batching (#2273)", (
 		source?.emit("open", {});
 		await settle();
 
-		// The batching guarantee: one POST for all three subscribes, not three.
 		expect(fetchMock).toHaveBeenCalledTimes(1);
 		const call = calls.at(0);
 		expect(call?.url).toBe("/fate/live");
@@ -145,7 +134,6 @@ describe("react-fate live transport — same-tick subscribe batching (#2273)", (
 			"c",
 		]);
 
-		// No subscription is lost: a live frame per entity still routes to its handler.
 		source?.emit("next", {
 			data: JSON.stringify({
 				event: {data: {__typename: "Post", body: "updated-a", id: "a"}, select: ["body"]},

--- a/apps/web/src/fate/nkzwFateCoalescePin.test.ts
+++ b/apps/web/src/fate/nkzwFateCoalescePin.test.ts
@@ -1,15 +1,8 @@
 /**
- * Behavior-pin for the `@nkzw/fate` pnpm patch (ADR 0038). The patch makes
- * `createHTTPTransport`'s native live client coalesce same-tick `add` (subscribe)
- * operations into ONE `/fate/live` control POST: upstream 1.3.1 fired its own
- * `control([op])` per `add` after the SSE `open`, so a feed load with N `useLiveView`
- * mounts issued N single-op POSTs, each re-validating the session (phoenix #2273). The
- * patch buffers adds and flushes them once per tick across the `open` microtask
- * boundary, and — on a rejected flush — discards the whole batch as a group and reports
- * the error. This file pins BOTH: N same-tick subscribes ⇒ exactly one control POST, and
- * a rejected coalesced flush drops every batched op (not one) and reports the error. Reds
- * if the patch is dropped: unpatched, each `add` POSTs on its own, so N subscribes issue N
- * POSTs and the count assertions fail.
+ * Behavior-pin for the `@nkzw/fate` pnpm patch (ADR 0038), which coalesces same-tick
+ * `add` operations into ONE `/fate/live` control POST and, on a rejected flush,
+ * discards the whole batch as a group. Reds if the patch is dropped: unpatched, each
+ * `add` POSTs on its own and the count assertions fail.
  */
 // @patch-pin: @nkzw/fate@1.3.1
 
@@ -20,12 +13,11 @@ type ControlOperation = {id: string; kind: string; entityId?: string};
 type ControlBody = {operations: ReadonlyArray<ControlOperation>};
 type Listener = (event: unknown) => void;
 
-// The `fetch` option createHTTPTransport calls for control POSTs — the same narrow shape the
-// sibling batching test passes; assignable to the transport option without a cast.
+// The narrow `fetch` shape the transport option accepts without a cast.
 type FetchLike = (input: string | URL | Request, init?: RequestInit) => Promise<Response>;
 
-// createHTTPTransport's EventSourceConstructor type is not exported; asserted once at the
-// call site.
+// createHTTPTransport's EventSourceConstructor type is not exported, so the stub is
+// asserted to this shape once at the call site.
 type EventSourceCtor = new (
 	url: string,
 	options?: {withCredentials?: boolean},
@@ -35,8 +27,6 @@ type EventSourceCtor = new (
 	removeEventListener(type: string, listener: (event: Event) => void): void;
 };
 
-// Synchronous EventSource stub: records listeners so the test drives `open` deterministically
-// without a real network stream.
 class MockEventSource {
 	static instances: MockEventSource[] = [];
 	readonly url: string;
@@ -111,17 +101,14 @@ describe("@nkzw/fate patch pin — same-tick /fate/live subscribe coalescing (#2
 		});
 		const {subscribeById} = makeTransport(fetchMock);
 
-		// Five mounts subscribe in one synchronous tick, as a feed of cards does.
 		const ids = ["a", "b", "c", "d", "e"];
 		for (const id of ids) subscribeById("Post", id, ["id", "body"], undefined, {onData: vi.fn()});
 
-		// No control POST until the stream opens.
 		expect(fetchMock).not.toHaveBeenCalled();
 
 		onlySource().emit("open", {});
 		await settle();
 
-		// The pin: ONE POST for all five subscribes, not five.
 		expect(fetchMock).toHaveBeenCalledTimes(1);
 		const posted = calls.at(0);
 		expect(posted?.operations).toHaveLength(ids.length);
@@ -157,11 +144,9 @@ describe("@nkzw/fate patch pin — same-tick /fate/live subscribe coalescing (#2
 		subscribeById("Post", "failed-b", ["id"], undefined, failedB);
 		await settle();
 
-		// Coalesced even on the failing path: one POST for both ops, not two.
 		expect(fetchMock).toHaveBeenCalledTimes(2);
 		expect(calls.at(1)?.operations).toHaveLength(2);
 
-		// The error was reported to live subscriptions (reportError → onError).
 		expect(survivor.onError).toHaveBeenCalledWith(expect.any(Error));
 
 		// The whole batch was discarded from `operations`: a reconnect resubscribe carries

--- a/apps/web/src/fate/optimisticCommentAdd.realstore.test.ts
+++ b/apps/web/src/fate/optimisticCommentAdd.realstore.test.ts
@@ -1,30 +1,19 @@
 /**
- * Real-store regression for optimistic `comment.add` reconciliation (#1714, ADR
- * 0125 A1). The shipped unit test (`optimisticCommentAdd.test.ts`) drives a FAKE
- * `CommentListStore` with literal `"temp"` ids, so an id-FORMAT mismatch between the
- * optimistic append and fate's reconcile paths cannot bite — which is exactly why
- * #1714 (a BARE `optimistic:<ts>` appended into a `toEntityId`-qualified list) shipped
- * uncaught. This suite closes that gap by driving the REAL `@nkzw/fate` `Store` (via a
- * minimal `FateClient`) through the reconcile seam the ADR's no-divergence guarantee
- * rests on: the mutation HTTP result — `client.resolveOptimisticEntity(tempId,
- * serverId)`, which rewrites the temp id in every backing list
- * (`store.replaceListEntityId`).
+ * Real-store regression for optimistic `comment.add` reconciliation (#1714, ADR 0125
+ * A1). The sibling unit test drives a FAKE store with literal `"temp"` ids, so an
+ * id-FORMAT mismatch cannot bite there — which is exactly why #1714 shipped uncaught.
+ * This one drives the REAL `@nkzw/fate` `Store`.
  *
  * Grounding for the qualified-id claim (verified against `@nkzw/fate@1.3.1`
- * `lib/index.mjs`): `writeEntity` returns `toEntityId(type, getId(record))` and both
+ * `lib/index.mjs`): `writeEntity` returns `toEntityId(type, getId(record))`, and both
  * the load and the SSE `insertConnectionEdge` path store that qualified id in
- * `list.ids`; `replaceListEntityId(previousId, …)` rewrites only when
- * `list.ids.includes(previousId)`, and the mutation callsite invokes it with the
- * qualified `toEntityId(entity, optimisticRecordId)` (index.mjs L820/842); the SSE
- * append dedups by canonical id `toEntityId(nodeType, id)`. So the list stores
- * `Comment:<id>` and both reconcile paths compare against `Comment:<id>` — a bare temp
- * id reconciles to neither.
+ * `list.ids`; `replaceListEntityId` rewrites only when `list.ids.includes(previousId)`,
+ * and the mutation callsite passes the qualified id (L820/842). A bare temp id
+ * reconciles to neither path.
  *
- * The live SSE `appendNode` dedup is `FateClient.insertConnectionEdge` — a PRIVATE
- * method (untypable from a test). It collapses a redundant append by canonical id:
- * an id already in `list.ids` short-circuits. We model that collapse at the public
- * seam via the production `appendOptimisticEdge`, whose idempotency is the same
- * canonical-id rule (an already-present id returns the list unchanged).
+ * The SSE dedup itself is `FateClient.insertConnectionEdge`, a PRIVATE method untypable
+ * from a test, so its canonical-id short-circuit is modelled through the production
+ * `appendOptimisticEdge`, which is idempotent by the same rule.
  */
 import {ConnectionTag, createClient, type EntityId, type List, toEntityId} from "@nkzw/fate";
 import {describe, expect, it} from "vitest";
@@ -38,12 +27,7 @@ const POST_ID = "post_1";
 const CONNECTION_KEY = `Post:${POST_ID}.comments`;
 const now = new Date("2026-07-02T12:00:00.000Z");
 
-/**
- * A minimal real `FateClient` — enough to exercise the real `Store` + the public
- * `resolveOptimisticEntity` reconcile against fate's actual store, without a live
- * transport. No query/mutation/list resolvers are called by this test's paths, so the
- * transport is a never-invoked stub.
- */
+/** No resolver is reached by this test's paths, so the transport is a never-invoked stub. */
 function realClient() {
 	return createClient({
 		hydrationScope: "test",
@@ -66,7 +50,6 @@ function realClient() {
 	});
 }
 
-/** The store slice `beginOptimisticCommentMembership` drives (the real `client.store` satisfies it). */
 function membershipStore(client: ReturnType<typeof realClient>) {
 	const store = client.store;
 	return {
@@ -82,12 +65,11 @@ function membershipStore(client: ReturnType<typeof realClient>) {
 	};
 }
 
-/** A fate connection carrying the `ConnectionTag` metadata key `connectionKey` reads. */
 function connectionFor(key: string): unknown {
 	return {[ConnectionTag]: {key}};
 }
 
-/** Seed a qualified `Post.comments` list — the runtime shape fate loads (`toEntityId`-qualified). */
+/** Seeds the `toEntityId`-qualified list shape fate loads at runtime. */
 function seedQualifiedList(client: ReturnType<typeof realClient>, ids: ReadonlyArray<EntityId>) {
 	client.store.setList(CONNECTION_KEY, {ids: [...ids]});
 }
@@ -170,9 +152,7 @@ describe("optimistic comment.add — real-store reconciliation (#1714)", () => {
 		);
 		client.resolveOptimisticEntity(tempId, serverId);
 
-		// The live SSE frame appendNode(serverId) dedups by canonical id — modelled here
-		// by the production idempotent append (fate's private insertConnectionEdge uses the
-		// same canonical-id short-circuit). The already-present server id collapses.
+		// Models the SSE appendNode(serverId) dedup with the production idempotent append.
 		const after = appendOptimisticEdge(client.store.getListState(CONNECTION_KEY), serverId);
 		client.store.setList(CONNECTION_KEY, after);
 
@@ -181,9 +161,8 @@ describe("optimistic comment.add — real-store reconciliation (#1714)", () => {
 		expect(ids.filter((id) => id === serverId)).toHaveLength(1);
 	});
 
-	// The regression: the SHIPPED bug — appending a BARE `optimistic:<ts>` — leaves a
-	// non-reconciling, duplicated temp node. This is what the fake-store test could not
-	// catch (#1714) and is the exact failure the qualified fix at the call site prevents.
+	// Reproduces the shipped #1714 bug on purpose: a BARE `optimistic:<ts>` reconciles to
+	// nothing and duplicates. Deliberately wrong input, not a stale test.
 	it("BARE temp id fails to reconcile — the #1714 defect, now guarded against", () => {
 		const client = realClient();
 		seedQualifiedList(client, []);
@@ -197,7 +176,7 @@ describe("optimistic comment.add — real-store reconciliation (#1714)", () => {
 			sandboxed: false,
 			now,
 		});
-		// The pre-fix id: the bare record id, NOT toEntityId-qualified.
+		// The pre-fix id: bare, NOT toEntityId-qualified.
 		const bareTempId = record.id as EntityId;
 		const serverId = toEntityId("Comment", "comm_server");
 		beginOptimisticCommentMembership(
@@ -207,11 +186,8 @@ describe("optimistic comment.add — real-store reconciliation (#1714)", () => {
 			bareTempId,
 		);
 
-		// HTTP result reconcile is invoked with the QUALIFIED previousId (as the mutation
-		// callsite does) — it does not match the bare stored id, so nothing is rewritten.
+		// Called with the QUALIFIED previousId, as the mutation callsite does.
 		client.resolveOptimisticEntity(toEntityId("Comment", record.id), serverId);
-		// The live appendNode(serverId) keys off the qualified id — it does not dedup the
-		// bare temp, so it lands as a SECOND edge.
 		const after = appendOptimisticEdge(client.store.getListState(CONNECTION_KEY), serverId);
 		client.store.setList(CONNECTION_KEY, after);
 

--- a/apps/web/src/fate/optimisticCommentAdd.test.ts
+++ b/apps/web/src/fate/optimisticCommentAdd.test.ts
@@ -9,14 +9,8 @@ import {
 } from "./optimisticCommentAdd";
 
 /**
- * Covers the load-bearing optimistic `comment.add` membership core (ADR 0125, A1,
- * #1678): the temp-node payload shape (server-mirrored initial row), the pure
- * append-into-nested-connection edge (idempotent, so a re-run never doubles vs the
- * later live `appendNode`), and the store-driving membership helper's append +
- * rollback. Inspected off the REAL exported functions the call site routes through.
- * fate's own reconcile (`resolveOptimisticEntity` temp→server dedup) + record
- * rollback are exercised at the integration/e2e tier; this pins the client-owned
- * membership half hook-free.
+ * Pins the client-owned membership half of optimistic `comment.add` (ADR 0125, A1).
+ * fate's own reconcile + record rollback are covered at the integration/e2e tier.
  */
 const fixedNow = new Date("2026-07-02T12:00:00.000Z");
 
@@ -40,18 +34,15 @@ describe("optimisticCommentRecord — the temp node payload", () => {
 			// server initial: score 0, no self-vote (else a phantom self-upvote flash, #707)
 			score: 0,
 			myVote: null,
-			// a yazar's comment is live on arrival — no `incelemede` badge
 			sandboxed: false,
 			createdAt: fixedNow,
 			updatedAt: fixedNow,
-			// live node, not a [silindi] tombstone
 			deletedAt: null,
 		});
 	});
 
-	// The false-publish this whole change exists to close (#4282): without the flag the
-	// çaylak's own node renders identically to a published one for the entire optimistic
-	// window, and the reconciled server row then flips it — a visible lie, then a flicker.
+	// Without the flag a çaylak's own node renders as published for the whole optimistic
+	// window, then flips when the server row reconciles (#4282).
 	it("carries sandboxed for a çaylak author so the temp node never poses as published", () => {
 		const record = optimisticCommentRecord({
 			postId: "post_1",
@@ -121,7 +112,6 @@ describe("connectionKey — resolves the fate metadata key", () => {
 	});
 });
 
-/** A minimal in-memory `CommentListStore` over lists + records for the membership helper. */
 function fakeStore(
 	initial?: List,
 	records?: Record<string, Record<string, unknown>>,

--- a/apps/web/src/fate/optimisticCommentAdd.ts
+++ b/apps/web/src/fate/optimisticCommentAdd.ts
@@ -1,68 +1,31 @@
 /**
- * Optimistic `comment.add` — the nested-connection membership half (ADR 0125, A1).
+ * Optimistic `comment.add`, membership half. See ADR 0125 and
+ * `.patterns/fate-mutations-client.md`.
  *
- * `Post.comments` is a *nested* connection, not a registered root list, so fate's
- * declarative `insert` can't reach it (`.patterns/fate-mutations-client.md`); a new
- * comment joins the thread only via the server `live.comment.thread.appendNode`
- * frame. fate's `optimistic` param still handles the temp *entity* end-to-end —
- * `wrapMutation` writes the temp record, rewrites the temp id to the server id via
- * `resolveOptimisticEntity` on the HTTP result, deletes the temp record, and rolls
- * the record write back on reject — but it never adds the temp id to the nested
- * list. This module owns exactly that gap: append the temp id into the
- * `Post.comments` list state (so the thread shows the comment instantly) and roll
- * that append back on reject.
- *
- * No-divergence (the ADR's core): fate's auto `resolveOptimisticEntity(tempId,
- * serverId)` rewrites the temp id in this list to the server id on the HTTP result
- * (`store.replaceListEntityId`, which also dedups), and the later live
- * `appendNode(serverId)` collapses by canonical id (`live: {append: "visible"}`
- * short-circuits an already-visible id) — so temp-node and server-append are one
- * edge. The only window is a sub-second transient double if the live append lands
- * before the HTTP result resolves temp→server; it collapses the instant it does.
- *
- * çaylak no-leak (AC 4): the optimistic write lives only in the *author's own* fate
- * store — it never crosses the wire, so a sandboxed comment cannot leak to
- * non-authors. Non-author membership comes solely from the server `appendNode`,
- * which stays gated by `decidePublish(sandboxedAt)` (unchanged).
- *
- * The optimistic write is live for every author (#1678, epic #1637; the flag that
- * once dark-shipped it retired at serves-on per ADR 0136): applied at the call site
- * whenever the author identity is known, else it degrades cleanly to the live
- * append / read-back.
+ * `Post.comments` is a nested connection, so fate's `optimistic` param handles the temp
+ * entity but never adds it to the list. This module owns exactly that gap.
  */
 import {ConnectionTag, type EntityId, type List, type Snapshot, toEntityId} from "@nkzw/fate";
 
-/** The source values the optimistic temp Comment node mirrors from the compose form + author. */
 export interface OptimisticCommentInput {
-	/** The parent post id (`comment.add` input `postId`). */
 	readonly postId: string;
-	/** The replied-to comment id in a reply composer, else `null` (top-level). */
 	readonly parentId: string | null;
-	/** The trimmed comment body. */
 	readonly body: string;
-	/** Author display name (`user.name ?? user.email`) — rendered as `@author`. */
 	readonly author: string;
-	/** The author's user id — drives the edit/delete affordance gate on the node. */
 	readonly authorId: string;
 	/**
-	 * Whether this author's new comment lands sandboxed — `sandboxesNewContent(me.tier)`,
-	 * the SAME rule the server's `sandboxedAtForAuthor` applies. Required, not optional:
-	 * a forgotten flag renders a çaylak's comment as published for the whole optimistic
-	 * window, which is the false-publish this exists to prevent (#4282).
+	 * Must be `sandboxesNewContent(me.tier)` — the SAME rule the server's
+	 * `sandboxedAtForAuthor` applies. Required, not optional: a forgotten flag renders a
+	 * çaylak's comment as published for the whole optimistic window (#4282).
 	 */
 	readonly sandboxed: boolean;
-	/** The submit instant — seeds the temp id and `createdAt`/`updatedAt`. */
 	readonly now: Date;
 }
 
 /**
- * Build the optimistic Comment partial passed as fate's `optimistic` payload. The
- * temp `id` is what fate reconciles to the server id (`resolveOptimisticEntity`) when
- * the HTTP result arrives. `score`/`myVote` mirror the server's initial comment row
- * (score 0, no self-vote — `comment-operations.ts` `addComment`), else the reconciled
- * row flashes a phantom self-upvote (the #707 class); `deletedAt: null` renders the
- * node live (not a `[silindi]` tombstone). `sandboxed` mirrors the server's create-time
- * tier rule so a çaylak's node shows `incelemede` from the instant of submit (#4282).
+ * `score`/`myVote` must mirror the server's initial comment row (score 0, no self-vote —
+ * `comment-operations.ts` `addComment`), else the reconciled row flashes a phantom
+ * self-upvote (the #707 class).
  */
 export function optimisticCommentRecord(input: OptimisticCommentInput) {
 	return {
@@ -81,11 +44,8 @@ export function optimisticCommentRecord(input: OptimisticCommentInput) {
 }
 
 /**
- * Append `entityId` to the tail of a nested connection's visible list — comments are
- * chronological and the server `appendNode`s at the end, so the optimistic edge lands
- * where the reconciled server edge will. Pure + idempotent: an id already present
- * returns the list unchanged, so a re-run never doubles. Keeps `cursors` aligned with
- * `ids` when the list tracks them (the temp edge carries no cursor).
+ * Tail, not head: comments are chronological and the server `appendNode`s at the end,
+ * so the optimistic edge lands where the reconciled server edge will.
  */
 export function appendOptimisticEdge(list: List | undefined, entityId: EntityId): List {
 	const base: List = list ?? {ids: []};
@@ -97,11 +57,6 @@ export function appendOptimisticEdge(list: List | undefined, entityId: EntityId)
 	};
 }
 
-/**
- * The slice of the fate client `store` the membership append + rollback drive — the
- * nested-list methods plus the record `read`/`merge`/`snapshot`/`restore` the
- * `Post.commentCount` aggregate bump uses. `fate.store` satisfies it structurally.
- */
 export interface CommentListStore {
 	getListState(key: string): List | undefined;
 	setList(key: string, state: List): void;
@@ -112,11 +67,7 @@ export interface CommentListStore {
 	restore(id: EntityId, snapshot: Snapshot): void;
 }
 
-/**
- * Resolve a nested connection's list key from its fate metadata tag (the same
- * `ConnectionTag` `react-fate`'s `useListView` reads). Throws loudly if the value
- * isn't a fate connection — a mis-wired call site is a bug, not a silent no-op.
- */
+/** Throws rather than no-oping: a mis-wired call site is a bug, not a missing key. */
 export function connectionKey(connection: unknown): string {
 	const metadata =
 		connection != null && typeof connection === "object"
@@ -130,22 +81,13 @@ export function connectionKey(connection: unknown): string {
 }
 
 /**
- * Insert `tempId` into the nested comment connection and return a rollback that
- * restores the prior list state. `tempId` MUST be the `toEntityId("Comment", …)`-
- * qualified entity id (`Comment:optimistic:<ts>`), never the bare record id — runtime
- * `Post.comments.list.ids` are qualified, so both reconcile paths key off the
- * qualified id (#1714; `.patterns/fate-mutations-client.md`). fate's auto
- * `resolveOptimisticEntity` rewrites `tempId` to the server id on success (no manual
- * reconcile here); the returned rollback runs only on reject (callSite `{error}` OR a
- * boundary throw), since fate rolls back the record but not this manually-added
- * nested membership.
+ * `tempId` MUST be the `toEntityId("Comment", …)`-qualified entity id, never the bare
+ * record id — runtime `Post.comments.list.ids` are qualified, so both reconcile paths
+ * key off the qualified id (#1714; `.patterns/fate-mutations-client.md`).
  *
- * Also bumps the parent post's `commentCount` aggregate by one so the post header
- * (`PanoPostHeader`) and feed card (`PanoPostCard`) agree with the rendered thread
- * during the optimistic window — `comment.add` returns a `Comment`, not the parent
- * `Post`, so nothing else reconciles the aggregate until a refetch (#2198); the
- * mirror of `comment.delete`'s decrement (`optimisticCommentDelete`). The bump rolls
- * back with the list edge.
+ * The returned rollback runs only on reject: fate rolls back the record but not this
+ * manually-added nested membership, nor the `commentCount` bump (`comment.add` returns a
+ * `Comment`, not the parent `Post`, so nothing else reconciles the aggregate — #2198).
  */
 export function beginOptimisticCommentMembership(
 	store: CommentListStore,

--- a/apps/web/src/fate/optimisticCommentDelete.test.ts
+++ b/apps/web/src/fate/optimisticCommentDelete.test.ts
@@ -11,12 +11,8 @@ import {
 } from "./optimisticCommentDelete";
 
 /**
- * Covers the load-bearing optimistic `comment.delete` core (ADR 0125 D1, #1680): the
- * reply-aware strategy decision (leaf-drop vs conservative tombstone), the pure
- * edge-removal, the tombstone field partial, and the store-driving apply + rollback
- * (edge-drop, tombstone, and the shared commentCount decrement). Inspected off the
- * REAL exported functions the call site routes through; fate's own snapshot/restore +
- * live-frame reconcile are exercised at the integration/e2e tier.
+ * Pins the optimistic `comment.delete` core (ADR 0125 D1). fate's own
+ * snapshot/restore + live-frame reconcile are covered at the integration/e2e tier.
  */
 const fixedNow = new Date("2026-07-02T12:00:00.000Z");
 
@@ -80,7 +76,6 @@ const COMMENT_ID = "comm_1";
 const COMMENT_ENTITY = toEntityId("Comment", COMMENT_ID);
 const LIST_KEY = "Post:post_1.comments";
 
-/** A minimal in-memory {@link CommentDeleteStore} over records + one comments list. */
 function fakeStore(seed: {
 	records?: Record<string, Record<string, unknown>>;
 	list?: List;
@@ -96,8 +91,7 @@ function fakeStore(seed: {
 	return {
 		read: (id) => records.get(id),
 		merge: (id, partial) => records.set(id, {...(records.get(id) ?? {}), ...partial}),
-		// snapshot/restore round-trip the whole record via the real Snapshot shape
-		// ({record}), so fate's pre-write state is restored on rollback.
+		// Round-trips the real `Snapshot` shape, so rollback is fate's, not a stand-in.
 		snapshot: (id): Snapshot => ({record: {...records.get(id)}}),
 		restore: (id, snap) => records.set(id, {...(snap.record ?? {})}),
 		getListsForField: (ownerId, field) =>

--- a/apps/web/src/fate/optimisticCommentDelete.ts
+++ b/apps/web/src/fate/optimisticCommentDelete.ts
@@ -1,41 +1,18 @@
 /**
- * Optimistic `comment.delete` — the reply-aware nested-connection half (ADR
+ * Optimistic `comment.delete`, mirroring the server's two branches: a leaf's edge drops,
+ * a comment with replies stays as a `[silindi]` tombstone. See ADR
  * [0125](../../../../.decisions/0125-optimistic-reconciliation-live-driven-nested-connections.md)
- * D1, #1680, epic #1637). `comment.delete` returns the parent `Post`, not the
- * comment (so fate's `delete: true` can't be used); the server drives the row live
- * as one of two branches (ADR 0096): a **leaf** publishes `deleteEdge` (the row
- * drops), a comment **with replies** stays as a `[silindi]` tombstone via
- * `live.update` (the edge must NOT leave the connection or the subtree orphans).
- *
- * An optimistic hard-remove is WRONG for the tombstone case, so this mirrors the
- * server branch from the *loaded client tree* — leaf ⇒ edge-drop, has-replies OR an
- * uncertain (incompletely-loaded) tree ⇒ tombstone — with a conservative-tombstone
- * fallback that makes divergence unrepresentable: the only hazard is a stale tree
- * (client thinks leaf, someone else added an unloaded reply) removing a row the
- * server tombstones, and a `live.update` can't re-add a removed edge. Tombstone-on-
- * uncertain removes it — a tombstone is never *wrong*; for a true leaf it lingers a
- * beat until the server `deleteEdge` removes it.
- *
- * No-divergence (the ADR's core): every write is keyed by canonical entity id and is
- * a conservative superset of the authoritative outcome — the server either confirms
- * the tombstone (`live.update`, an idempotent field write over the same `changed`
- * set) or shrinks it (`deleteEdge`), never contradicts. Rollback rides fate's
- * snapshot/restore on reject.
+ * D1 and ADR [0096](../../../../.decisions/0096-uniform-soft-delete-substrate.md).
  */
 import {type EntityId, type List, type Snapshot, toEntityId} from "@nkzw/fate";
 
 /** The `[silindi]` tombstone body — mirrors the server placeholder (`comment-operations.ts`). */
 export const SILINDI_PLACEHOLDER = "[silindi]";
 
-/**
- * The fields the optimistic tombstone writes — exactly the server's `live.update`
- * `changed` set (`comment.delete` publishes `["body", "score", "deletedAt",
- * "updatedAt"]`), so the reconciling frame overwrites the same paths field-for-field
- * and can't diverge. `CommentTreeNode` renders `[silindi]` off `deletedAt != null`.
- */
+/** Must stay exactly the server's `live.update` `changed` set for `comment.delete`, so
+ *  the reconciling frame overwrites the same paths field-for-field and can't diverge. */
 export const TOMBSTONE_CHANGED = ["body", "score", "deletedAt", "updatedAt"] as const;
 
-/** The optimistic tombstone partial for a removed comment at `now`. */
 export function tombstoneFields(now: Date): {
 	body: string;
 	score: number;
@@ -45,23 +22,19 @@ export function tombstoneFields(now: Date): {
 	return {body: SILINDI_PLACEHOLDER, score: 0, deletedAt: now, updatedAt: now};
 }
 
-/** Which server branch the optimistic write mirrors, decided from the loaded tree. */
 export type CommentDeleteStrategy = "edge-drop" | "tombstone";
 
-/** The loaded-tree facts the strategy is decided from (both derivable client-side). */
 export interface CommentDeleteContext {
 	/** Does any LOADED comment name this one as parent (a reply — deleted or not)? */
 	readonly hasLoadedReply: boolean;
-	/** Is the whole comment thread loaded (no further pagination to reveal a reply)? */
+	/** Is the whole thread loaded (no further pagination to reveal a reply)? */
 	readonly threadComplete: boolean;
 }
 
 /**
- * Mirror the server's reply-aware branch from the loaded tree (ADR 0125 D1). Only a
- * client-certain leaf — no loaded reply AND the thread fully loaded — drops its edge;
- * a known reply parent OR an incompletely-loaded thread (the subtree could hide an
- * unloaded reply) tombstones. Tombstone is the safe superset: the server confirms it
- * (`live.update`) or shrinks it to a drop (`deleteEdge`), never the reverse.
+ * Tombstone is the safe superset, so anything short of a client-certain leaf takes it:
+ * the server confirms a tombstone (`live.update`) or shrinks it to a drop
+ * (`deleteEdge`), but a `live.update` can never re-add an edge dropped in error.
  */
 export function decideCommentDelete(ctx: CommentDeleteContext): CommentDeleteStrategy {
 	if (ctx.hasLoadedReply) return "tombstone";
@@ -69,12 +42,6 @@ export function decideCommentDelete(ctx: CommentDeleteContext): CommentDeleteStr
 	return "edge-drop";
 }
 
-/**
- * Remove a qualified entity id from a nested connection's visible list, keeping
- * `cursors` aligned. Pure + idempotent: an absent id returns the list unchanged, so
- * a re-run never double-drops and reconciliation with the server `deleteEdge` (which
- * removes the same canonical id) collapses to one removal.
- */
 export function removeOptimisticEdge(list: List, entityId: EntityId): List {
 	const index = list.ids.indexOf(entityId);
 	if (index === -1) return list;
@@ -85,7 +52,6 @@ export function removeOptimisticEdge(list: List, entityId: EntityId): List {
 	};
 }
 
-/** The slice of the fate client `store` the optimistic delete drives. */
 export interface CommentDeleteStore {
 	read(id: EntityId): Record<string, unknown> | undefined;
 	merge(id: EntityId, partial: Record<string, unknown>, paths: Iterable<string>): void;
@@ -96,24 +62,18 @@ export interface CommentDeleteStore {
 	restoreList(key: string, list?: List): void;
 }
 
-/** The resolved delete to apply — its strategy plus the ids the writes key on. */
 export interface CommentDeletePlan {
 	readonly strategy: CommentDeleteStrategy;
 	readonly commentId: string;
 	readonly postId: string;
-	/** Clock for the tombstone `deletedAt`/`updatedAt` (injectable for deterministic tests). */
 	readonly now: Date;
 }
 
 /**
- * Apply the optimistic delete and return a rollback that restores every write it
- * made (LIFO), for the call site to run on a rejected mutation. `edge-drop` removes
- * the comment's edge from every backing `Post.comments` list (mirroring fate's SSE
- * `deleteConnectionEdge`); `tombstone` merges the `[silindi]` fields onto the comment
- * record, leaving the edge in place so the subtree keeps hanging. Both branches
- * decrement the parent post's `commentCount` by one — the server does so
- * unconditionally (`comment-operations.ts`), and the authoritative `live.post.update`
- * frame reconciles the field either way.
+ * The tombstone branch deliberately leaves the edge in place, so the subtree keeps
+ * hanging. Both branches decrement `commentCount` because the server does so
+ * unconditionally (`comment-operations.ts`). Returns a LIFO rollback for the call site
+ * to run on a rejected mutation.
  */
 export function beginOptimisticCommentDelete(
 	store: CommentDeleteStore,

--- a/apps/web/src/fate/optimisticEdit.test.ts
+++ b/apps/web/src/fate/optimisticEdit.test.ts
@@ -2,13 +2,8 @@ import {describe, expect, it} from "vitest";
 import {bodyEditOptimistic, postEditOptimistic} from "./optimisticEdit";
 
 /**
- * Covers the load-bearing optimistic-edit core the three Class-A edits ship
- * through (`post.edit`/`comment.edit`/`definition.edit` → `postEditOptimistic` /
- * `bodyEditOptimistic`, #1675): the edited field(s) plus a fresh `updatedAt` that
- * drives the "düzenlendi" indicator, inspected off the REAL exported builders —
- * the same functions the call sites route through, not a re-implemented copy.
- * fate's own apply/reconcile/rollback is exercised at the integration tier; this
- * pins the payload shape hook-free.
+ * Pins the optimistic-edit payload shape (#1675). fate's own
+ * apply/reconcile/rollback is covered at the integration tier.
  */
 const fixedNow = () => new Date("2026-07-02T12:00:00.000Z");
 

--- a/apps/web/src/fate/optimisticEdit.ts
+++ b/apps/web/src/fate/optimisticEdit.ts
@@ -1,36 +1,23 @@
 /**
- * Optimistic-edit payload builders for the three Class-A content edits
- * (`post.edit` / `comment.edit` / `definition.edit`). These edits are
- * entity-field write-backs that already re-render in place through their result
- * `view`; passing the partial renders the edited body/title instantly, and fate
- * rolls it back on a rejected mutation and reconciles it against the server
- * `live.update({changed:[…]})` frame (same field → no divergence).
- *
- * Pure + hook-free (mirroring `voteOptimistic` in `useVoteToggle`) so the
- * fresh-`updatedAt` — which drives the "düzenlendi" indicator (`EditedIndicator`)
- * consistently with the reconciled frame — is unit-testable apart from the fate
- * mutation and React. See `.patterns/fate-mutations-client.md`.
+ * Optimistic-edit payload builders for `post.edit` / `comment.edit` /
+ * `definition.edit`. See `.patterns/fate-mutations-client.md`.
  */
 
-/** Injectable now-clock so the optimistic `updatedAt` is deterministic in tests. */
 export type Now = () => Date;
 
 const defaultNow: Now = () => new Date();
 
-/** `post.edit` optimistic partial — the edited title/body + a fresh `updatedAt`. */
 export interface PostEditOptimistic {
 	readonly title: string;
 	readonly body: string;
 	readonly updatedAt: Date;
 }
 
-/** `comment.edit` / `definition.edit` optimistic partial — edited body + fresh `updatedAt`. */
 export interface BodyEditOptimistic {
 	readonly body: string;
 	readonly updatedAt: Date;
 }
 
-/** The optimistic partial for a post edit — the edited title/body + a fresh `updatedAt`. */
 export function postEditOptimistic(
 	fields: {readonly title: string; readonly body: string},
 	now: Now = defaultNow,
@@ -38,7 +25,6 @@ export function postEditOptimistic(
 	return {title: fields.title, body: fields.body, updatedAt: now()};
 }
 
-/** The optimistic partial for a comment/definition body edit (see {@link postEditOptimistic}). */
 export function bodyEditOptimistic(body: string, now: Now = defaultNow): BodyEditOptimistic {
 	return {body, updatedAt: now()};
 }

--- a/apps/web/src/fate/publicClient.ts
+++ b/apps/web/src/fate/publicClient.ts
@@ -1,15 +1,7 @@
 /**
  * The eager, always-anonymous PUBLIC fate client — the top tier of the two-tier fate
- * provider (ADR 0167). One app-lifetime instance mounted ABOVE the session gate so
- * anon-capable public read views (the /pano feed list) can paint in parallel with
- * `/api/auth/get-session` instead of serialized behind it.
- *
- * It is a distinct, never-re-keyed instance (always `authenticated: false`), which is
- * exactly why it can commit pre-session without reintroducing the #438 anon→id re-key
- * remount that the identity-keyed authed client below the gate defers to avoid: this
- * client never becomes authenticated, so it never re-keys. Live SSE is no-op here
- * (an anon `/fate/live` `EventSource` 401-loops); live + mutations + viewer-scoped
- * scalars stay on the authed client below the gate. See ADR 0167.
+ * provider (ADR 0167). It must stay `authenticated: false` forever: never re-keying is
+ * what lets it commit pre-session without the #438 anon→id re-key remount.
  */
 import {noteSnapshotHydrated} from "../lib/feedPerf";
 import {createClient, type FateClientInstance} from "./client";
@@ -17,23 +9,13 @@ import {hydrateAnonPublicClient, installAnonSnapshotPersistence} from "./snapsho
 
 let publicClient: FateClientInstance | null = null;
 
-// A module singleton, not a per-render `useMemo`: the client owns one normalized cache,
-// and a lazily-cached single instance keeps that cache stable across every mount/unmount
-// of the eager public tier (it is torn out of the tree once the session settles and the
-// authed feed takes over, but the instance — and its warm cache — persists for the app
-// lifetime).
+// A module singleton, not a per-render `useMemo`: the tier is torn out of the tree once
+// the session settles, and the cache has to survive that.
 export function getPublicFateClient(): FateClientInstance {
 	if (publicClient == null) {
 		publicClient = createClient({authenticated: false});
-		// Feed snapshot (leg A, #2319): restore the persisted anon cache into this
-		// singleton at creation — BEFORE any `useRequest` renders under
-		// `PublicFateProvider`, fate's hydrate-before-render contract — then persist it
-		// on tab-hide for the app's lifetime (the singleton never tears down, so its
-		// uninstaller is intentionally discarded). Both no-op when the containment flag
-		// is off (flag-off ⇒ no storage reads/writes), so this is byte-identical to today
-		// until #2326 flips it. See `snapshot.ts`.
-		// Note a hydrated snapshot so the reload→paint instrument classifies this paint as
-		// the snapshot path (#2326). No-op when the snapshot flag is off (returns false).
+		// Hydrate here, at creation — fate's hydrate-before-render contract. The
+		// uninstaller is discarded on purpose: the singleton never tears down.
 		if (hydrateAnonPublicClient(publicClient)) noteSnapshotHydrated();
 		installAnonSnapshotPersistence(publicClient);
 	}

--- a/apps/web/src/fate/readback.test.ts
+++ b/apps/web/src/fate/readback.test.ts
@@ -8,7 +8,6 @@ const state = (expectedId: string, probesRemaining: number): ReadbackState => ({
 
 describe("decideReadback", () => {
 	it("settles immediately when the live push already landed the node", () => {
-		// The whole point: if the `appendNode` won the race, never refetch.
 		expect(decideReadback(new Set(["c1", "c2"]), state("c2", 3))).toEqual({action: "settled"});
 	});
 
@@ -45,7 +44,6 @@ describe("decideReadback", () => {
 
 describe("decideConfirmGone", () => {
 	it("settles immediately when the delete push already reconciled the node away", () => {
-		// The whole point: if the `deleteEdge` (or tombstone) won, never refetch.
 		expect(decideConfirmGone(new Set(["c1"]), state("c2", 3))).toEqual({action: "settled"});
 	});
 

--- a/apps/web/src/fate/readback.ts
+++ b/apps/web/src/fate/readback.ts
@@ -1,51 +1,21 @@
 /**
- * Deterministic live read-back — the decision core.
- *
- * A create-mutation's own connection view (a comment thread, a definition list)
- * is driven live by the server's `appendNode` push. That push can be *lost*: the
- * fire-and-forget publish fans out to the topic DO before the subscriber row has
- * been registered, so it delivers to an empty registry and the event vanishes
- * (#714 diagnosis on epic #713). The mutator's own view then waits on a push that
- * never arrives and the new node never appears until a manual refresh.
- *
- * The fix is a bounded read-back: after the mutator's own create succeeds, watch
- * its connection for the new node id; if the live push lands it, do nothing; if it
- * doesn't within a short grace window, refetch the owning request `network-only`
- * so the node lands deterministically. The live subscription stays intact for
- * other clients — this only makes the *mutator's own* view independent of the race.
- *
- * This module is the pure decision: given which ids the connection currently holds,
- * the id we expect, and how many probes are left, decide whether to keep waiting
- * for the push, fire the fallback refetch, or stop. No React, no client — so the
- * race-handling contract is unit-testable without a DOM. See
+ * The pure decision core for deterministic live read-back — the bounded fallback for a
+ * `appendNode` push the mutator's own view can lose to the subscribe race (#714). See
  * `.patterns/fate-live-views.md` ("Deterministic read-back").
  */
 
-/** A pending read-back: the node we're waiting on plus the probe budget left. */
 export interface ReadbackState {
-	/**
-	 * The node id the mutator is watching for: expected to *appear* after a create
-	 * ({@link decideReadback}), expected to *leave* after a delete ({@link decideConfirmGone}).
-	 */
+	/** Expected to *appear* after a create ({@link decideReadback}), to *leave* after a
+	 *  delete ({@link decideConfirmGone}). */
 	readonly expectedId: string;
-	/** Probes left before we stop waiting (each probe is one grace tick). */
 	readonly probesRemaining: number;
 }
 
 export type ReadbackDecision =
-	/** The node is present (the live push won, or the refetch already landed it) — stop. */
 	| {readonly action: "settled"}
-	/** The node isn't present and probes remain — wait one grace tick for the push. */
 	| {readonly action: "wait"; readonly next: ReadbackState}
-	/** The node isn't present and the budget is spent — fire the fallback refetch, then stop. */
 	| {readonly action: "refetch"};
 
-/**
- * Decide the next read-back step. `presentIds` is the set of node ids the
- * connection currently holds (read off the live items). Settles the instant the
- * expected id appears (live push won → no refetch), waits while probes remain, and
- * refetches deterministically on the final probe.
- */
 export function decideReadback(
 	presentIds: ReadonlySet<string>,
 	state: ReadbackState,
@@ -59,13 +29,8 @@ export function decideReadback(
 }
 
 /**
- * The delete-direction twin of {@link decideReadback}: after the mutator's own
- * delete succeeds, the expected id should *leave* `presentIds` (a hard delete's
- * `deleteEdge` drops the row; a soft delete's tombstone removes it from the
- * *visible* set the caller passes). Settles the instant the id is gone, waits
- * while probes remain, and refetches deterministically when the id is still
- * present after the budget — healing every server-side delete-loss mode at once
- * (#1687, the collection-delete analog of the scalar self-heal #731).
+ * The delete-direction twin of {@link decideReadback}. A soft delete counts as gone
+ * because the caller passes the *visible* set, not the raw ids (#1687).
  */
 export function decideConfirmGone(
 	presentIds: ReadonlySet<string>,
@@ -79,5 +44,4 @@ export function decideConfirmGone(
 	};
 }
 
-/** Default probe budget — short grace window for the live push before falling back. */
 export const DEFAULT_READBACK_PROBES = 3;

--- a/apps/web/src/fate/snapshot.test.ts
+++ b/apps/web/src/fate/snapshot.test.ts
@@ -1,19 +1,7 @@
 /**
- * Feed-snapshot module contract (#2319, epic #2316). Two tiers of coverage:
- *
- *   1. The pure persistence layer (read/write/hydrate/save + throttle/installer) against
- *      a fake client + in-memory storage — round-trip fidelity and the four tolerance
- *      paths (corrupt, quota, oversized, scope/version mismatch), each degrading to a
- *      clean no-snapshot boot with no throw.
- *   2. A REAL `@nkzw/fate` client round-trip (the `optimisticCommentAdd.realstore`
- *      idiom): populate a client's store, dehydrate → persist → hydrate into a fresh
- *      client, and assert the fresh client re-dehydrates to an equal state — proving the
- *      persist layer carries fate's dehydrated cache (records + list/pagination state)
- *      without loss, and that fate rejects a scope-mismatched snapshot (which we catch).
- *
- * The "paints without a skeleton" experience is a flag-on behavior the verification
- * child (#2326) measures on a deployed stage — the unit tier proves the module contract
- * the epic's testing strategy scopes here.
+ * Feed-snapshot module contract (#2319): the pure persistence layer against a fake
+ * client, plus a REAL `@nkzw/fate` client round-trip. The "paints without a skeleton"
+ * experience is flag-on behavior measured on a deployed stage instead (#2326).
  */
 import {createClient, type FateDehydratedState} from "@nkzw/fate";
 import {describe, expect, it, vi} from "vitest";
@@ -33,8 +21,7 @@ import {
 	writeSnapshot,
 } from "./snapshot";
 
-/** In-memory `localStorage` stand-in; optionally throws on `setItem`/`getItem` to model
- *  quota-exceeded and access-denied (Safari private mode). */
+/** The throwing modes stand in for quota-exceeded and Safari private mode. */
 function memoryStorage(
 	opts: {throwOnSet?: boolean; throwOnGet?: boolean} = {},
 ): KeyValueStorage & {map: Map<string, string>} {
@@ -57,7 +44,6 @@ function memoryStorage(
 
 const KEY = snapshotKey("v1", ANON_IDENTITY);
 
-/** A fake client returning a fixed dehydrated state and recording hydrate calls. */
 function fakeClient(
 	state: FateDehydratedState,
 ): SnapshotClient & {hydrated: FateDehydratedState[]} {
@@ -72,9 +58,8 @@ function fakeClient(
 }
 
 const sampleState: FateDehydratedState = {
-	// A representative payload carrying list/pagination + connection-identity shaped
-	// fields (the `?sort`/`host` connection args live inside `data`) — the round-trip
-	// must preserve them byte-for-byte.
+	// Carries connection-identity args (`?sort`/`host`) inside `data` on purpose — the
+	// round-trip must preserve them byte-for-byte.
 	data: {
 		rootLists: [["posts", ["Post:1", "Post:2"]]],
 		lists: {
@@ -285,11 +270,8 @@ describe("installSnapshotPersistence — event-driven, throttled, not per-render
 	});
 });
 
-/**
- * Real `@nkzw/fate` client round-trip — the `optimisticCommentAdd.realstore` idiom: a
- * minimal client with a never-invoked transport, driven through the REAL dehydrate /
- * hydrate the persistence layer wraps.
- */
+/** Drives the REAL dehydrate/hydrate through a minimal client whose transport is never
+ *  invoked (the `optimisticCommentAdd.realstore` idiom). */
 function realClient(hydrationScope = "test-scope") {
 	return createClient({
 		hydrationScope,
@@ -324,8 +306,6 @@ describe("real fate client round-trip", () => {
 		const restored = realClient();
 		expect(hydrateFromSnapshot(restored, storage)).toBe(true);
 
-		// A fresh client that re-dehydrates to the same state proves the persist layer
-		// lost nothing fate had encoded (records, lists, coverage, root lists).
 		expect(restored.dehydrate()).toEqual(source.dehydrate());
 	});
 
@@ -342,13 +322,10 @@ describe("real fate client round-trip", () => {
 });
 
 /**
- * The identity-keyed authed tier (#2321): the authed snapshot embeds the viewer's private
- * `myVote`/`isSaved` overlay, so its storage key must be scoped per user id — a snapshot
- * written under user A must NEVER hydrate under user B or under anon (both directions), and
- * an identity's snapshot must be torn down when its session ends (sign-out / identity switch
- * / account deletion). These pin the pure key-scoping + teardown contract the browser-bound
- * `hydrateAuthedClient` / `installAuthedSnapshotPersistence` / `teardownAuthedSnapshot`
- * wrappers (flag-gated, `window`-bound — untested here, as the anon siblings are) delegate to.
+ * The identity-keyed authed tier (#2321). The authed snapshot embeds the viewer's private
+ * `myVote`/`isSaved` overlay, so A's snapshot must NEVER hydrate under B or under anon,
+ * and must be torn down when A's session ends. The browser-bound wrappers are flag-gated
+ * and `window`-bound, so only the pure key-scoping + teardown contract is pinned here.
  */
 describe("authedIdentity — per-user key scoping, disjoint from anon", () => {
 	it("namespaces the identity under `user:` so it cannot collide with anon or another id", () => {
@@ -363,7 +340,6 @@ describe("authedIdentity — per-user key scoping, disjoint from anon", () => {
 describe("authed snapshot — cross-identity hydration is rejected (both directions, #2321 AC2)", () => {
 	it("a snapshot written under user A does NOT hydrate under user B", () => {
 		const storage = memoryStorage();
-		// A's snapshot carries A's private overlay.
 		saveSnapshot(fakeClient(sampleState), storage, {identity: authedIdentity("A")});
 
 		const asB = fakeClient(sampleState);
@@ -399,9 +375,8 @@ describe("authed snapshot — cross-identity hydration is rejected (both directi
 	});
 
 	it("restores the deep-linked subfeed (?sort/host connection state) for the authed tier (AC5)", () => {
-		// `sampleState.data` carries the `posts(sort:hot,host:example.com)` list identity — the
-		// `?sort=…` / `/pano/site/:host` subfeed. Through the authed key it round-trips intact,
-		// so a deep-linked subfeed restores instantly for a signed-in viewer too.
+		// `sampleState.data` carries the `posts(sort:hot,host:example.com)` list identity —
+		// the `?sort=…` / `/pano/site/:host` subfeed.
 		const storage = memoryStorage();
 		saveSnapshot(fakeClient(sampleState), storage, {identity: authedIdentity("A")});
 		const restored = readSnapshot(storage, snapshotKey("v1", authedIdentity("A")));
@@ -416,10 +391,8 @@ describe("authed snapshot teardown — the sign-out / identity-change / deletion
 		saveSnapshot(fakeClient(sampleState), storage, {identity: authedIdentity("B")});
 		saveSnapshot(fakeClient(sampleState), storage, {identity: ANON_IDENTITY});
 
-		// Tear down A (sign-out / switch away from A / A's account deletion).
 		clearSnapshot(storage, {identity: authedIdentity("A")});
 
-		// A is gone; B and anon survive — teardown is strictly identity-scoped.
 		expect(readSnapshot(storage, snapshotKey("v1", authedIdentity("A")))).toBeNull();
 		expect(readSnapshot(storage, snapshotKey("v1", authedIdentity("B")))).not.toBeNull();
 		expect(readSnapshot(storage, snapshotKey("v1", ANON_IDENTITY))).not.toBeNull();

--- a/apps/web/src/fate/snapshot.ts
+++ b/apps/web/src/fate/snapshot.ts
@@ -1,78 +1,42 @@
 /**
- * Feed snapshot — leg A of the "instant /pano reload" epic (#2316, child #2319).
+ * Persist the fate cache to `localStorage` and restore it at boot, so a reload paints
+ * the last-seen feed instead of a skeleton. See `.patterns/fate-hydration.md`.
  *
- * Persist the public (always-anonymous) fate cache to `localStorage` and restore it
- * at boot, so a reload paints the last-seen feed synchronously — before the network
- * revalidate lands — instead of a skeleton. Terms: a *feed snapshot* is the persisted,
- * versioned dehydrated fate cache; the *base feed* it carries is viewer-invariant
- * (leg B); the *viewer overlay* (`myVote`/`isSaved`) is composed on top after the
- * session resolves (the authed tier, #2321 — out of scope here).
- *
- * Uses fate's native `FateClient.dehydrate()`/`hydrate()` (versioned, JSON-safe
- * `FateDehydratedState` with a schema-derived `hydrationScope`) — never a hand-rolled
- * serializer. `localStorage`, not IndexedDB, on purpose: the restore must be
- * synchronous so `hydrate()` runs *before* the first `useRequest` (fate's documented
- * hydrate-before-render contract; `hydrate()` also throws if the client already has
- * requests pending). Every failure mode — quota, corrupt/oversized payload,
- * scope/version mismatch, a client with in-flight requests — degrades to a clean
- * no-snapshot boot: a feed snapshot is a best-effort content cache, never load-bearing.
- *
- * Containment: the whole feature is dark behind `VITE_FEED_SNAPSHOT` (default-off);
- * #2326 flips it on measured evidence. A build-time env flag, NOT the server-evaluated
- * Flagship flag, because boot hydration must resolve synchronously before any async
- * `/api/flags/evaluate` round-trip could return — the `VITE_SENTRY_DSN` precedent
- * (`vite-env.d.ts`). Flag off ⇒ no storage reads or writes, byte-identical to today.
+ * The flag is a build-time Vite env var, NOT the server-evaluated Flagship flag,
+ * because boot hydration resolves synchronously — before any `/api/flags/evaluate`
+ * round-trip could return.
  */
 import type {FateDehydratedState, HydrateOptions} from "react-fate";
 
-/** Build-time containment flag (default-off). See the module docblock for why it is a
- *  Vite env var rather than the Flagship server flag. */
 export const FEED_SNAPSHOT_ENABLED = import.meta.env.VITE_FEED_SNAPSHOT === "on";
 
-/** Storage-key schema segment. fate's payload-embedded `scope` guards the fate schema
- *  itself (an incompatible dehydrated shape is rejected by `hydrate()`); this segment
- *  guards *our* keying/format — bump it to force-invalidate every persisted snapshot on
- *  an incompatible change to this module. */
+/** Guards *our* keying/format (fate's payload-embedded `scope` guards the schema):
+ *  bump it to force-invalidate every persisted snapshot. */
 export const FEED_SNAPSHOT_SCHEMA = "v1";
 
-/** Identity segment for the always-anonymous public tier. The authed tier (#2321) keys
- *  per user-id and tears the snapshot down on identity change / sign-out. */
 export const ANON_IDENTITY = "anon";
 
-/** Identity segment for an authed viewer, keyed per user id (#2321). The `user:` prefix
- *  keeps every authed key disjoint from the anon segment (`anon`) and from every other
- *  user, so a snapshot written under user A lives at a distinct key from user B's and
- *  from anon's — the primary guard that A's private `myVote`/`isSaved` overlay can never
- *  hydrate under another identity (a mismatched key simply finds no snapshot). */
+/** Keying per user id is the guard that A's private `myVote`/`isSaved` overlay can
+ *  never hydrate under B or under anon — a mismatched key simply finds no snapshot. */
 export function authedIdentity(userId: string): string {
 	return `user:${userId}`;
 }
 
-/** Cap a persisted snapshot's serialized length. An oversized payload is neither
- *  written nor read back (dropped to a clean boot), bounding both `localStorage`
- *  pressure and the synchronous boot-time parse cost. */
 export const DEFAULT_MAX_SNAPSHOT_CHARS = 2_000_000;
 
-/** Minimum gap between two persists. The save is event-driven (`pagehide` /
- *  `visibilitychange`), and both can fire back-to-back on the same tab-hide — the
- *  throttle collapses that into one write. */
+/** `pagehide` and `visibilitychange` both fire on the same tab-hide — the throttle
+ *  collapses that into one write. */
 export const DEFAULT_SAVE_THROTTLE_MS = 2_000;
 
-/** The one storage-key shape: `fate-snapshot:<schema>:<identity>`. */
 export function snapshotKey(schema: string, identity: string): string {
 	return `fate-snapshot:${schema}:${identity}`;
 }
 
-/** The slice of a fate client this module drives — just the two persistence primitives,
- *  so the pure functions are testable with a fake and decoupled from the generated
- *  client type. */
 export interface SnapshotClient {
 	dehydrate(): FateDehydratedState;
 	hydrate(state: FateDehydratedState, options?: HydrateOptions): void;
 }
 
-/** The `localStorage`-shaped subset this module needs, injected so the pure functions
- *  run without a DOM. */
 export interface KeyValueStorage {
 	getItem(key: string): string | null;
 	setItem(key: string, value: string): void;
@@ -85,18 +49,12 @@ interface SnapshotScope {
 	maxChars?: number;
 }
 
-/** A structurally-valid dehydrated snapshot is `{data, scope: string, version: 1}`.
- *  Anything else read from storage is treated as absent — fate's own `hydrate()` would
- *  reject it, but we screen here so a malformed blob never reaches the client. */
 function isDehydratedState(value: unknown): value is FateDehydratedState {
 	if (typeof value !== "object" || value === null) return false;
 	const candidate = value as {version?: unknown; scope?: unknown};
 	return candidate.version === 1 && typeof candidate.scope === "string" && "data" in candidate;
 }
 
-/** Read + parse a persisted snapshot, tolerating every failure to `null` (no throw):
- *  a `getItem` that throws, an absent key, an oversized blob, invalid JSON, or a
- *  structurally-wrong payload all degrade to "no snapshot". */
 export function readSnapshot(
 	storage: KeyValueStorage,
 	key: string,
@@ -117,9 +75,6 @@ export function readSnapshot(
 	}
 }
 
-/** Serialize + persist a snapshot, tolerating every failure to `false` (no throw): a
- *  non-serializable state, an oversized payload (not written), or a quota-exceeded
- *  `setItem`. Returns whether the write landed. */
 export function writeSnapshot(
 	storage: KeyValueStorage,
 	key: string,
@@ -141,10 +96,8 @@ export function writeSnapshot(
 	}
 }
 
-/** Restore a snapshot into the client. `hydrate()` throws on a version/scope mismatch,
- *  a payload that fails fate's decode limits, or a client with pending requests — all
- *  caught here so a bad snapshot degrades to a clean no-snapshot boot. Returns whether
- *  a snapshot was applied. */
+/** `hydrate()` throws on a version/scope mismatch, a decode-limit overflow, or a client
+ *  with pending requests; caught so a bad snapshot boots cold. `.patterns/fate-hydration.md` */
 export function hydrateFromSnapshot(
 	client: SnapshotClient,
 	storage: KeyValueStorage,
@@ -164,9 +117,8 @@ export function hydrateFromSnapshot(
 	}
 }
 
-/** Dehydrate the client and persist the snapshot. `dehydrate()` throws while a request
- *  or optimistic update is in flight (fate's contract) — caught here so a save is
- *  always best-effort. Returns whether the write landed. */
+/** `dehydrate()` throws while a request or optimistic update is in flight, so a save is
+ *  best-effort. `.patterns/fate-hydration.md` */
 export function saveSnapshot(
 	client: SnapshotClient,
 	storage: KeyValueStorage,
@@ -185,10 +137,7 @@ export function saveSnapshot(
 	return writeSnapshot(storage, snapshotKey(schema, identity), state, maxChars);
 }
 
-/** Remove a persisted snapshot, tolerating a throwing `removeItem` (Safari private mode)
- *  to a clean no-op. The identity teardown primitive: the snapshot is a content cache,
- *  never an auth artifact, so an identity's persisted feed overlay is dropped the moment
- *  its session ends (#2321). */
+/** `removeItem` throws in Safari private mode. */
 export function clearSnapshot(
 	storage: KeyValueStorage,
 	{schema = FEED_SNAPSHOT_SCHEMA, identity = ANON_IDENTITY}: SnapshotScope = {},
@@ -196,12 +145,10 @@ export function clearSnapshot(
 	try {
 		storage.removeItem(snapshotKey(schema, identity));
 	} catch {
-		// storage unreachable ⇒ nothing to clean up; teardown stays best-effort like every other path
+		// storage unreachable ⇒ nothing to clean up
 	}
 }
 
-/** A leading-edge throttle gate: returns `true` at most once per `throttleMs`. Time is
- *  injected so the throttle is deterministically testable. */
 export function createLeadingThrottle(
 	throttleMs: number,
 	now: () => number = Date.now,
@@ -215,12 +162,9 @@ export function createLeadingThrottle(
 	};
 }
 
-/** The DOM bindings the persistence installer needs, injected so it is testable without
- *  a real `window`/`document`. */
 export interface PersistenceBindings {
 	addEventListener(type: string, handler: () => void): void;
 	removeEventListener(type: string, handler: () => void): void;
-	/** Whether the document is currently hidden (`visibilityState === "hidden"`). */
 	isHidden(): boolean;
 }
 
@@ -229,9 +173,6 @@ interface InstallOptions extends SnapshotScope {
 	now?: () => number;
 }
 
-/** Wire throttled snapshot persistence to `pagehide` and `visibilitychange` (on hide) —
- *  never per-render — and return an uninstaller. These two events fire as the tab is
- *  backgrounded or torn down, the last moment the cache is worth capturing. */
 export function installSnapshotPersistence(
 	client: SnapshotClient,
 	storage: KeyValueStorage,
@@ -254,9 +195,7 @@ export function installSnapshotPersistence(
 	};
 }
 
-/** `localStorage`, or `null` if it is unavailable (Safari private mode throws on access,
- *  SSR/tests without a DOM have no `window`). A `null` storage disables persistence
- *  cleanly. */
+/** `null` when unavailable — Safari private mode throws on `window.localStorage` access. */
 export function browserSnapshotStorage(): KeyValueStorage | null {
 	try {
 		return typeof window === "undefined" ? null : window.localStorage;
@@ -265,8 +204,6 @@ export function browserSnapshotStorage(): KeyValueStorage | null {
 	}
 }
 
-/** Bind persistence to the real DOM: `pagehide` on `window`, `visibilitychange` on
- *  `document`. */
 export function browserPersistenceBindings(): PersistenceBindings {
 	const targetFor = (type: string): EventTarget =>
 		type === "visibilitychange" ? document : window;
@@ -277,10 +214,6 @@ export function browserPersistenceBindings(): PersistenceBindings {
 	};
 }
 
-/** Boot-time hydrate for the always-anonymous public client. No-op when the flag is off
- *  or `localStorage` is unavailable, so the flag-off path performs no storage reads.
- *  Returns whether a snapshot was applied (the reload→paint instrument reads this to
- *  classify the paint as the snapshot path, #2326). */
 export function hydrateAnonPublicClient(client: SnapshotClient): boolean {
 	if (!FEED_SNAPSHOT_ENABLED) return false;
 	const storage = browserSnapshotStorage();
@@ -288,9 +221,6 @@ export function hydrateAnonPublicClient(client: SnapshotClient): boolean {
 	return hydrateFromSnapshot(client, storage, {identity: ANON_IDENTITY});
 }
 
-/** Install anon persistence for the public client's lifetime. No-op (an inert
- *  uninstaller) when the flag is off or `localStorage` is unavailable, so the flag-off
- *  path performs no storage writes. */
 export function installAnonSnapshotPersistence(client: SnapshotClient): () => void {
 	if (!FEED_SNAPSHOT_ENABLED) return () => {};
 	const storage = browserSnapshotStorage();
@@ -300,13 +230,8 @@ export function installAnonSnapshotPersistence(client: SnapshotClient): () => vo
 	});
 }
 
-/** Boot-time hydrate for the identity-keyed authed client (#2321) — the authed sibling of
- *  `hydrateAnonPublicClient`. Runs at client creation in `FateProvider` AFTER the session
- *  resolves, keyed on the resolved `userId`, so a signed-in reload paints the viewer's own
- *  last-seen feed (base feed + private `myVote`/`isSaved`) synchronously before the first
- *  `useRequest`. Keyed per user, so one identity's snapshot never hydrates under another.
- *  No-op when the flag is off or `localStorage` is unavailable. Returns whether a snapshot
- *  was applied (the reload→paint instrument reads this to classify the paint, #2326). */
+/** Must run at client creation in `FateProvider` AFTER the session resolves — before the
+ *  first `useRequest`, and only once the `userId` this snapshot is keyed on is known. */
 export function hydrateAuthedClient(client: SnapshotClient, userId: string): boolean {
 	if (!FEED_SNAPSHOT_ENABLED) return false;
 	const storage = browserSnapshotStorage();
@@ -314,8 +239,6 @@ export function hydrateAuthedClient(client: SnapshotClient, userId: string): boo
 	return hydrateFromSnapshot(client, storage, {identity: authedIdentity(userId)});
 }
 
-/** Install authed persistence for the identity-keyed client's lifetime, keyed per user id
- *  (#2321). Inert uninstaller when the flag is off or `localStorage` is unavailable. */
 export function installAuthedSnapshotPersistence(
 	client: SnapshotClient,
 	userId: string,
@@ -328,10 +251,8 @@ export function installAuthedSnapshotPersistence(
 	});
 }
 
-/** Tear down one authed identity's persisted snapshot (#2321). Wired at the sign-out path,
- *  the identity-change seam, and account deletion so a viewer's private feed overlay never
- *  outlives its session — session validation is untouched, this only drops a content cache.
- *  No-op when the flag is off or `localStorage` is unavailable. */
+/** Must stay wired at sign-out, identity change, and account deletion so a viewer's
+ *  private feed overlay never outlives its session. */
 export function teardownAuthedSnapshot(userId: string): void {
 	if (!FEED_SNAPSHOT_ENABLED) return;
 	const storage = browserSnapshotStorage();

--- a/apps/web/src/fate/useDraftSubmit.test.tsx
+++ b/apps/web/src/fate/useDraftSubmit.test.tsx
@@ -1,10 +1,3 @@
-/**
- * The lifted form-submit envelope (#1421). Drives `useDraftSubmit.run` through its
- * four branches against a fake mutation, pinning the behavior the ~6 migrated sites
- * now share: a returned `{error}` maps through the registry, an `UNAUTHORIZED`
- * throw redirects to auth, any other throw falls to the surface `failureFallback`,
- * and a clean result calls `onSuccess` with the mutation result.
- */
 import {act, renderHook} from "@testing-library/react";
 import {describe, expect, it, vi} from "vitest";
 import {authRedirectPath} from "../lib/returnTo";

--- a/apps/web/src/fate/useDraftSubmit.ts
+++ b/apps/web/src/fate/useDraftSubmit.ts
@@ -1,13 +1,6 @@
 /**
- * The shared form-submit envelope, lifted out of `PanoPostDetail` (#1421) so the
- * uniform mutation forms (pano submit/save-draft, sözlük definition add/edit/delete,
- * pano post edit/delete + comments) no longer hand-roll the same try/catch. It is
- * the write-side analogue of {@link useVoteToggle}'s already-lifted toggle envelope.
- *
- * The envelope: flip `inFlight`, fire the mutation, map a returned `{error}` to its
- * inline message via the shared {@link messageForCode} registry, redirect to auth on
- * an `UNAUTHORIZED` boundary throw, and fall any other throw back to the surface's
- * generic `failureFallback`. See `.patterns/fate-mutations-client.md`.
+ * The shared form-submit envelope for the uniform mutation forms. See
+ * `.patterns/fate-mutations-client.md`.
  *
  * NOT for the divan/profile gating sites (`CaylakDetail`, `VouchSheet`,
  * `PromotionActions`): those classify the error into a *domain outcome*
@@ -21,18 +14,11 @@ import {authRedirectPath} from "../lib/returnTo";
 import {codeOf} from "./wire";
 import {messageForCode, type WireMessageOverrides} from "./wireMessages";
 
-/** The shape a fate mutation call resolves to: an optional `{error}` plus its result. */
 export interface MutationResult<R> {
 	error?: {message: string} | null;
 	result?: R;
 }
 
-/**
- * The "in-flight + error + UNAUTHORIZED-redirect" submit envelope. `run` flips
- * `inFlight`, maps a returned wire error through `overrides`/the shared registry,
- * and on an `UNAUTHORIZED` throw navigates to the auth redirect. `redirectPath`
- * is the post-auth return path; `overrides` is the surface's per-code copy.
- */
 export function useDraftSubmit(options: {
 	overrides?: WireMessageOverrides;
 	redirectPath: () => string;
@@ -73,11 +59,6 @@ export function useDraftSubmit(options: {
 	return {error, setError, inFlight, run};
 }
 
-/**
- * Single-body draft composer (validated textarea over the {@link useDraftSubmit}
- * envelope), used by the comment add/edit forms. `validate` returns one of the
- * surface's inline messages or `null`; messages are not restated here.
- */
 export function useDraft(options: {
 	initialBody: string;
 	validate: (trimmed: string, body: string) => string | null;

--- a/apps/web/src/fate/useGlobalLivePin.ts
+++ b/apps/web/src/fate/useGlobalLivePin.ts
@@ -1,24 +1,9 @@
 /**
- * One always-on live subscription held for the whole authenticated session, so
- * the shared native SSE connection's refcount is NEVER 0 while the app is
- * mounted. This structurally eliminates the transient-0-refcount teardown race
- * (#711): fate's native live client closes the `EventSource` and drops its
- * random `connectionId` the instant `operations.size` reaches 0 (`remove()` runs
- * `if (operations.size === 0) { source.close(); nativeLiveClient = undefined }`),
- * and the next subscribe rebuilds a fresh stream with a new `connectionId`. A
- * write mutation makes the only entity view on the page transiently
- * unsubscribe+resubscribe during its in-flight refetch; with no other operation
- * the refcount hits 0, the stream closes, and the mutation's fire-and-forget
- * publish lands on the now-dead `connectionId` and is LOST. Holding one
- * operation for the session lifetime makes `operations.size === 0` unreachable
- * during that churn, so the EventSource + `connectionId` stay stable and every
- * publish reaches a live connection. See ADR 0091 + `.patterns/fate-live-views.md`.
+ * One always-on live subscription held for the whole authenticated session, so the
+ * shared SSE connection's refcount is never 0 while the app is mounted. See
+ * `.patterns/fate-live-consistency.md#global-pin`.
  *
- * The anchor is the viewer's OWN `User` row, keyed on the better-auth session id
- * — always valid for an authenticated session (the `me` query resolves the same
- * id; `User.id === CurrentUser.id`) and the lightest possible: a single
- * entity-field subscription, no list/connection fan-out, no pagination churn. It
- * never fires for an anonymous client (an anon `EventSource` 401-loops): the
+ * It must never fire for an anonymous client (an anon `EventSource` 401-loops): the
  * caller gates it on a non-null `userId`.
  */
 import {useEffect} from "react";
@@ -27,12 +12,10 @@ import type {User} from "../../worker/features/fate/views";
 
 const PinView = view<User>()({id: true});
 
-// `retryTick` bumps on a cold-start LIVE_UNAVAILABLE/503 back-off (ADR 0095): it is
-// in the effect deps, so each bump tears down the failed subscription and
-// re-subscribes — fate's native client rebuilds the whole EventSource connect when
-// the pin is the only operation, so a bump retries the entire connect on the next
-// mount, exactly as ADR 0095 specifies. The back-off scheduling + bounded budget
-// live in `FateProvider`, which owns both the client and this pin.
+// `retryTick` is an effect dep on purpose: each bump tears down the failed
+// subscription and re-subscribes, which retries the whole EventSource connect
+// because the pin is the only operation (ADR 0095). Back-off scheduling lives in
+// `FateProvider`.
 export function useGlobalLivePin(userId: string | null, retryTick = 0): void {
 	const client = useFateClient();
 

--- a/apps/web/src/fate/useImperativeView.test.tsx
+++ b/apps/web/src/fate/useImperativeView.test.tsx
@@ -1,12 +1,3 @@
-/**
- * Drives `useImperativeView` through its real React interface on the `client`
- * jsdom seam (#1419) — the component/hook-level coverage #1420 wanted but fell back
- * to a pure-core unit test for when the fork OOM'd (#1470). `useImperativeView.unit.test.ts`
- * still covers the pure `readImperativeView` read; this pins the *hook*: the
- * mount effect fires the read, and the discriminated `idle | loading | ok | error`
- * state transitions are observed through `renderHook` against a stubbed `FateClient`.
- */
-
 import {renderHook, waitFor} from "@testing-library/react";
 import type {ReactNode} from "react";
 import {FateClient, view} from "react-fate";
@@ -29,7 +20,6 @@ function makeWrapper(client: ImperativeViewClient) {
 }
 
 describe("useImperativeView — the hook over its React interface", () => {
-	// The error path logs via console.error; silence it so the run stays clean.
 	beforeEach(() => {
 		vi.spyOn(console, "error").mockImplementation(() => {});
 	});

--- a/apps/web/src/fate/useImperativeView.ts
+++ b/apps/web/src/fate/useImperativeView.ts
@@ -1,22 +1,7 @@
 /**
- * `useImperativeView` — the shared imperative `request` + `readView` read for the
- * hooks that run ABOVE the `<Screen>` Suspense boundary (the `Layout`/header
- * shell), so they must drive fate rather than suspend. It collapses the
- * gate → loading → request → readView → cast → discriminated-state body the three
- * above-Suspense read hooks (`useMe`, `useProfileStats`, `useAuthorshipStanding`)
- * each copied (#1420).
- *
- * Two things this centralizes:
- *   - The `ok` payload is typed by DERIVING it from the view — the same
- *     `ViewData<ViewEntity<V> & {__typename}, ViewSelection<V>>` technique
- *     react-fate's own `useView`/`useLiveView` return — so the codegen'd server
- *     Entity stays the single source of truth (ADR 0022). No hand-written
- *     interface restates the wire shape.
- *   - The `as` cast lives here and ONLY here. `readView`'s static return narrows
- *     only the normalization key (`id`/`userId`); the selected scalars are
- *     present at runtime but absent from the static type, so the read crosses the
- *     gap with one derived cast — covered by a test — instead of three copies
- *     (the #448 swallow site).
+ * The shared imperative `request` + `readView` read for the hooks that run ABOVE the
+ * `<Screen>` Suspense boundary (the `Layout`/header shell), so they must drive fate
+ * rather than suspend.
  *
  * `useDivanAccess` is deliberately NOT migrated onto this: it is a request-only
  * grant/deny probe that discards the data and returns `boolean`, so folding it in
@@ -34,12 +19,6 @@ import type {
 import {useCallback, useEffect, useState} from "react";
 import {useFateClient} from "react-fate";
 
-/**
- * The masked data a resolved `view` ref carries, derived from the view itself —
- * the codegen'd Entity (`ViewEntity<V>`) projected through the view's selection
- * (`ViewSelection<V>`), with the `__typename` literal re-attached. Identical to
- * what `useView(view, ref)` returns; this is the imperative counterpart.
- */
 export type ImperativeViewData<V extends View<any, any>> = ViewData<
 	ViewEntity<V> & {__typename: ViewEntityName<V>},
 	ViewSelection<V>
@@ -51,17 +30,13 @@ export type ImperativeViewState<V extends View<any, any>> =
 	| {status: "ok"; data: ImperativeViewData<V> | null}
 	| {status: "error"};
 
-/** The two `FateClient` methods the imperative read needs — the seam the unit test stubs. */
 export type ImperativeViewClient = Pick<FateClient<any, any>, "request" | "readView">;
 
 /**
- * The pure read: `request` the root → resolve its ref → `readView` it → the ONE
- * cast. Extracted from the hook so the cast + null-ref handling are unit-testable
- * without a DOM/React runtime (#1420). `readView` statically narrows only the
- * normalization key; the selected scalars are present at runtime, so the read
- * crosses that gap with the single derived cast (ADR 0022) — the lone home of the
- * cast the three migrated hooks each used to carry (the #448 swallow site). A
- * `null` root ref resolves to `null` data (a successful empty), never throws.
+ * `readView` statically narrows only the normalization key; the selected scalars are
+ * present at runtime but absent from the static type, so the read crosses that gap
+ * with one derived cast (ADR 0022) — and this is its only home. A `null` root ref
+ * resolves to `null` data (a successful empty), never throws.
  */
 export async function readImperativeView<V extends View<any, any>>(
 	fate: ImperativeViewClient,
@@ -78,18 +53,13 @@ export async function readImperativeView<V extends View<any, any>>(
 export interface UseImperativeViewOptions {
 	/** Root args forwarded to `fate.request` (e.g. `{username}`). Memoize a non-empty value at the call site so it's a stable refetch dependency. */
 	readonly args?: Record<string, unknown>;
-	/** Gate: while `false` the hook never touches the wire and reports `idle` — the fail-closed off path. */
 	readonly enabled: boolean;
-	/** Extra refetch triggers beyond `enabled`/`args` — e.g. the session identity, so `useMe` re-reads after a session update even while still signed in. */
 	readonly deps?: ReadonlyArray<unknown>;
 }
 
 /**
- * Drives one imperative fate root read and reports a discriminated
- * `idle | loading | ok | error` state. Disabled ⇒ `idle`, never on the wire. A
- * `null` ref (root resolved to nothing) is a successful `ok` with `data: null`,
- * NOT an error — the caller decides what a null result means (#448). Any thrown
- * read ⇒ `error`.
+ * A `null` ref (root resolved to nothing) is a successful `ok` with `data: null`, NOT
+ * an error — the caller decides what a null result means (#448).
  */
 export function useImperativeView<V extends View<any, any>>(
 	root: string,

--- a/apps/web/src/fate/useImperativeView.unit.test.ts
+++ b/apps/web/src/fate/useImperativeView.unit.test.ts
@@ -1,11 +1,3 @@
-/**
- * Covers `readImperativeView` — the request → readView → cast read body the three
- * above-Suspense hooks used to each copy (#1420). The single `as` cast is the
- * load-bearing thing here (the #448 swallow site): `readView`'s static type drops
- * the selected scalars, so the `ok` case asserts a selected field reads back
- * through the cast. Pure (no DOM/React), per the issue's "pure-core unit test"
- * option.
- */
 import {view} from "react-fate";
 import {describe, expect, it, vi} from "vitest";
 import {type ImperativeViewClient, readImperativeView} from "./useImperativeView";

--- a/apps/web/src/fate/useReadbackRefetch.ts
+++ b/apps/web/src/fate/useReadbackRefetch.ts
@@ -1,23 +1,7 @@
 /**
- * Deterministic live read-back — the React driver.
- *
- * Wraps a live connection's owning request with a self-healing fallback, in both
- * directions of the server's connection push:
- *
- * - `useReadbackRefetch` → `confirm(newNodeId)`: after the mutator's own create
- *   succeeds, watch the connection for the id; if the server's `appendNode` push
- *   doesn't land it within a short grace window, refetch the owning request
- *   `network-only` so the node appears deterministically (#714).
- * - `useConfirmGone` → `confirmGone(deletedNodeId)`: after the mutator's own delete
- *   succeeds, watch for the id to *leave*; if the server's `deleteEdge` (or the
- *   soft-delete tombstone update) doesn't reconcile it away within the window,
- *   refetch the same way (#1687 — the delete-side gap the add-side left open).
- *
- * The live subscription is untouched — this only frees the *mutator's own* view
- * from depending on a push that can be lost under load. The wait/refetch decisions
- * live in the pure `decideReadback`/`decideConfirmGone` cores (`readback.ts`,
- * unit-tested); the hooks are the timer + the one `fate.request` call. See
- * `.patterns/fate-live-views.md` ("Deterministic read-back").
+ * Deterministic live read-back — the React driver. It frees only the *mutator's own*
+ * view from depending on a push that can be lost under load; the live subscription is
+ * untouched. See `.patterns/fate-live-consistency.md#read-back`.
  */
 import * as React from "react";
 import {
@@ -34,17 +18,10 @@ const PROBE_INTERVAL_MS = 1_000;
 export interface ReadbackRefetchOptions {
 	/** Node ids the connection currently holds — pass the live `items` mapped to their ids. */
 	presentIds: ReadonlyArray<string>;
-	/**
-	 * Refetch the owning request through the network so the lost push is reconciled.
-	 * Called at most once per pending read-back, only when the live push didn't win
-	 * the race.
-	 */
 	refetch: () => Promise<unknown>;
-	/** Probe budget before falling back (default {@link DEFAULT_READBACK_PROBES}). */
 	probes?: number;
 }
 
-/** The shared timer/refetch loop; `decide` picks the direction (appear vs gone). */
 function useReadbackDriver(
 	options: ReadbackRefetchOptions,
 	decide: (presentIds: ReadonlySet<string>, state: ReadbackState) => ReadbackDecision,
@@ -82,7 +59,6 @@ function useReadbackDriver(
 					timer.current = setTimeout(() => probe(decision.next), PROBE_INTERVAL_MS);
 					return;
 				}
-				// refetch — fire the network read-back at most once per pending node.
 				if (refetchedFor.current === nodeId) return;
 				refetchedFor.current = nodeId;
 				void refetchRef.current().catch(() => undefined);
@@ -94,22 +70,14 @@ function useReadbackDriver(
 	);
 }
 
-/**
- * Returns `confirm(nodeId)`: call it with the id of the node the mutator just
- * created. Resolves silently the moment the node is present (live push won) or once
- * the fallback refetch has fired. Safe to call repeatedly; the latest expected id
- * wins and an in-flight probe loop is replaced.
- */
 export function useReadbackRefetch(options: ReadbackRefetchOptions): (nodeId: string) => void {
 	return useReadbackDriver(options, decideReadback);
 }
 
 /**
- * Returns `confirmGone(nodeId)`: call it with the id of the node the mutator just
- * deleted. Resolves silently the moment the id has left `presentIds` (the live
- * `deleteEdge`/tombstone won) or once the fallback refetch has fired. Pass the ids
- * a lost delete would leave *stuck* — for a list with soft-delete tombstones, the
- * visible (non-tombstoned) ids, so both server outcomes settle.
+ * `presentIds` here must be the ids a lost delete would leave *stuck* — for a list
+ * with soft-delete tombstones, the visible (non-tombstoned) ids, so both server
+ * outcomes settle.
  */
 export function useConfirmGone(options: ReadbackRefetchOptions): (nodeId: string) => void {
 	return useReadbackDriver(options, decideConfirmGone);

--- a/apps/web/src/fate/useViewPendingDedup.test.tsx
+++ b/apps/web/src/fate/useViewPendingDedup.test.tsx
@@ -1,21 +1,9 @@
 // @patch-pin: react-fate@1.3.1
 /**
  * Behavior pin for `patches/react-fate@1.3.1.patch` (ADR 0038) — `useView`'s
- * pending-thenable dedup. When a view snapshot is non-fulfilled, the patch caches
- * the wrapper thenable in `pendingViewRef` keyed by `(viewRef, source, cacheKey)`
- * and returns that SAME object on every `getSnapshot` call, instead of the
- * unpatched branch's fresh `Promise.resolve(snapshot).then(…)` per call.
- *
- * The observable contract asserted here: for one stable pending source snapshot,
- * `useSyncExternalStore` calls `getSnapshot` multiple times per render (the read +
- * the tearing/consistency re-read), yet the patched hook adopts the source thenable
- * exactly ONCE — `Promise.resolve(source)` (which invokes `source.then`) runs a
- * single time because the second call short-circuits to the cached thenable. Drop
- * the patch and each `getSnapshot` rebuilds the wrapper, adopting the source again
- * (≥ 2 calls) and feeding `useSyncExternalStore` a new snapshot per check → the
- * React #185 re-render loop. Counting `source.then` invocations is the direct proxy
- * for "the same pending thenable is deduped across renders", complementing the
- * loop-symptom pin in `useViewPendingSnapshot.test.tsx` (#1686).
+ * pending-thenable dedup. Counting `source.then` invocations is the proxy for "the
+ * same pending thenable is deduped across renders"; the loop symptom itself is
+ * pinned in `useViewPendingSnapshot.test.tsx` (#1686).
  */
 
 import {act, render, screen} from "@testing-library/react";
@@ -38,8 +26,6 @@ function makePendingSource() {
 			// Never resolve: the snapshot stays pending, so the hook suspends.
 		},
 	);
-	// A `then`-bearing object is exactly fate's non-fulfilled-snapshot shape, read
-	// by React `use()`; the spy count is the dedup probe.
 	return {then} as {then: typeof then};
 }
 
@@ -75,8 +61,6 @@ class Boundary extends React.Component<{children: React.ReactNode}, {error: Erro
 
 describe("useView pending-thenable dedup (patches/react-fate@1.3.1.patch, ADR 0038)", () => {
 	beforeEach(() => {
-		// Unpatched, React logs the "getSnapshot should be cached" warning + the
-		// boundary-caught error via console.error; keep the run output clean.
 		vi.spyOn(console, "error").mockImplementation(() => {});
 	});
 	afterEach(() => {
@@ -97,8 +81,6 @@ describe("useView pending-thenable dedup (patches/react-fate@1.3.1.patch, ADR 00
 			</Boundary>,
 		);
 
-		// It actually took the pending path (suspended to the fallback) and did not
-		// loop into the error boundary.
 		expect(screen.queryByTestId("crashed")).toBeNull();
 		expect(screen.getByTestId("pending")).not.toBeNull();
 
@@ -108,10 +90,9 @@ describe("useView pending-thenable dedup (patches/react-fate@1.3.1.patch, ADR 00
 			await Promise.resolve();
 		});
 
-		// The pin: the dedup cache returns the SAME wrapper thenable on the repeat
-		// getSnapshot calls, so the source is adopted exactly once. Unpatched, every
-		// getSnapshot rebuilds the wrapper and re-adopts the source (≥ 2), or spins
-		// into React #185 before it can settle — either way this is not 1.
+		// Exactly 1: the dedup cache hands back the same wrapper thenable on the repeat
+		// getSnapshot calls. Unpatched, each call re-adopts the source (≥ 2) or spins
+		// into React #185 first.
 		expect(source.then).toHaveBeenCalledTimes(1);
 	});
 });

--- a/apps/web/src/fate/useViewPendingSnapshot.test.tsx
+++ b/apps/web/src/fate/useViewPendingSnapshot.test.tsx
@@ -1,14 +1,7 @@
 /**
- * Regression for #1686: react-fate `useView`'s `getSnapshot` must return a STABLE
- * thenable while a view snapshot is non-fulfilled. Unpatched 1.3.1 built a fresh
- * `Promise.resolve(snapshot).then(…)` on every call in that branch, so
- * `useSyncExternalStore` saw a new snapshot per check → infinite re-render
- * (React #185, "getSnapshot should be cached") → the fate `Screen` boundary swapped
- * the whole term page for its error branch whenever an entity-delete live frame
- * landed while a `DefinitionCard` was still mounted. Fixed by
- * `patches/react-fate@1.3.1.patch` (ADR 0038), which mirrors the deferred branch's
- * `pendingRef` caching. This drives the hook through a mounted component whose
- * record goes non-fulfilled mid-flight and asserts it suspends instead of looping.
+ * Regression for #1686: `useView`'s `getSnapshot` must return a STABLE thenable while
+ * a view snapshot is non-fulfilled, else `useSyncExternalStore` loops (React #185).
+ * Fixed by `patches/react-fate@1.3.1.patch` (ADR 0038).
  */
 
 import {act, render, screen, waitFor} from "@testing-library/react";
@@ -84,8 +77,6 @@ class Boundary extends React.Component<{children: React.ReactNode}, {error: Erro
 
 describe("useView on a record whose snapshot goes non-fulfilled while mounted (#1686)", () => {
 	beforeEach(() => {
-		// React logs the boundary-caught error (and, unpatched, the getSnapshot
-		// caching warning) via console.error; keep the run output clean.
 		vi.spyOn(console, "error").mockImplementation(() => {});
 	});
 	afterEach(() => {

--- a/apps/web/src/fate/wire.ts
+++ b/apps/web/src/fate/wire.ts
@@ -8,12 +8,6 @@ import {LoadMoreButton} from "./LoadMoreButton";
 
 export {LoadMoreButton};
 
-/**
- * Read the `.code` off a thrown / returned fate error and narrow it to a
- * {@link FateWireCode}. Unknown / non-tagged throws fall back to
- * `INTERNAL_SERVER_ERROR`. The boundary-class throw already rolled back
- * optimism — see `.patterns/fate-mutations-client.md`.
- */
 export const codeOf = (error: unknown): FateWireCode => {
 	const code =
 		error && typeof error === "object" && "code" in error ? (error as {code: unknown}).code : null;
@@ -24,6 +18,5 @@ export const codeOf = (error: unknown): FateWireCode => {
 export const toIso = (value: Date | string | null | undefined): string =>
 	value == null ? "" : value instanceof Date ? value.toISOString() : String(value);
 
-/** As {@link toIso}, but preserves an absent date as `null` instead of `""`. */
 export const toIsoOrNull = (value: Date | string | null | undefined): string | null =>
 	value == null ? null : value instanceof Date ? value.toISOString() : String(value);

--- a/apps/web/src/fate/wireMessages.ts
+++ b/apps/web/src/fate/wireMessages.ts
@@ -1,28 +1,13 @@
 /**
- * The shared client code→message adapter: one exhaustive {@link FateWireCode}→
- * Turkish-copy registry, replacing the six scattered `switch (code) { … default }`
- * blocks that used to live one-per-surface (#1421).
+ * The shared client code→message registry (#1421).
  *
- * `WIRE_MESSAGES` is typed `Record<FateWireCode, string>` — **exhaustive by
- * construction**: adding a code to `FATE_WIRE_CODES` without a message here is a
- * compile error, not a silent generic fallback. That is the structural close of
- * the #1422 class (a new code can no longer fall through every site to a `default`).
- *
- * A surface that needs different copy for a code (the char-limit phrasings, the
- * per-entity "boş olamaz"/"bulunamadı" nouns) passes an `overrides` map; the
- * authored per-surface copy wins over the shared base. `messageForCode` is total —
- * it always resolves to a real message, so call sites never thread a fallback for
- * a *known* code. The submit envelope's `failureFallback` (see
- * {@link useDraftSubmit}) is a separate concept: the generic "operation failed"
- * line for an unexpected boundary throw, not a per-code message.
+ * The `Record<FateWireCode, string>` typing is the point: it is exhaustive by
+ * construction, so adding a code to `FATE_WIRE_CODES` without a message here is a
+ * compile error rather than a silent generic fallback (#1422). Never loosen it, and
+ * never give `messageForCode` a `default` arm.
  */
 import {FATE_WIRE_CODES, type FateWireCode} from "../lib/fateWireCodes";
 
-/**
- * The shared base message for every wire code. Exhaustive over `FateWireCode`
- * (the `Record` type enforces it) — a surface overrides an entry only when its
- * copy genuinely differs.
- */
 export const WIRE_MESSAGES: Record<FateWireCode, string> = {
 	UNAUTHORIZED: "bu işlem için giriş yapmalısın",
 	FORBIDDEN: "bunu yapma yetkin yok",
@@ -64,11 +49,6 @@ export const WIRE_MESSAGES: Record<FateWireCode, string> = {
 /** Per-surface copy that wins over {@link WIRE_MESSAGES} for the codes it names. */
 export type WireMessageOverrides = Partial<Record<FateWireCode, string>>;
 
-/**
- * Resolve a wire code to its inline message: the surface `overrides` entry if it
- * has one, else the shared base. Total — every code resolves, so there is no
- * trailing `default` to silently absorb a new code.
- */
 export function messageForCode(code: FateWireCode, overrides?: WireMessageOverrides): string {
 	return overrides?.[code] ?? WIRE_MESSAGES[code];
 }

--- a/apps/web/src/fate/wireMessages.unit.test.ts
+++ b/apps/web/src/fate/wireMessages.unit.test.ts
@@ -1,10 +1,6 @@
 /**
- * The shared code→message registry (#1421). The load-bearing guarantee is
- * **exhaustiveness**: `WIRE_MESSAGES` covers every `FateWireCode`, so a new code
- * added to `FATE_WIRE_CODES` without a message is a *compile* error — but this
- * test also pins it at runtime so the closure of the #1422 class is asserted, not
- * just type-checked. The `messageForCode` resolution order (override wins over
- * base) is pinned too, since the per-surface copy preservation rides on it.
+ * `WIRE_MESSAGES` exhaustiveness is already a compile error when broken; this pins it
+ * at runtime too, so the closure of the #1422 class is asserted, not just type-checked.
  */
 import {describe, expect, it} from "vitest";
 import {FATE_WIRE_CODES, messageForCode, WIRE_MESSAGES} from "./wireMessages";

--- a/apps/web/src/flags/EdgeShellBoot.tsx
+++ b/apps/web/src/flags/EdgeShellBoot.tsx
@@ -1,19 +1,12 @@
 /**
- * The boot-mode observer for the edge-resolved shell (ADR 0179, epic #2926).
- *
- * The worker-first render has no user-facing surface of its OWN — the visible shell geometry
- * rides the `__BOOT__` members (nav flags + `user`) that `App.tsx` already reads. This module
- * reports whether the edge actually injected the payload for this render, exposed as a
- * geometry-inert marker so the first-paint e2e (and future diagnostics) can observe the mode.
+ * The boot-mode observer for the edge-resolved shell (ADR 0179). It has no user-facing surface of
+ * its own: it reports whether the edge injected `__BOOT__` for this render, as a geometry-inert
+ * marker the first-paint e2e can observe.
  */
 import type {ReactElement} from "react";
 import {readBoot} from "./boot.ts";
 
-/**
- * Whether the edge injected `window.__BOOT__` for this render. Absent ⇒ the never-hang fallback
- * (ADR 0179 §4) served an untransformed asset, so the client resolves through its fetch path —
- * a first-class state, not an error.
- */
+/** Absent `__BOOT__` is a first-class state, not an error — see ADR 0179 §4. */
 export function useEdgeShellBootActive(): boolean {
 	return readBoot() !== undefined;
 }

--- a/apps/web/src/flags/FlagGate.test.ts
+++ b/apps/web/src/flags/FlagGate.test.ts
@@ -1,12 +1,6 @@
 /**
- * The `FlagGate` gating contract (#1111) — show the gated `children` iff the
- * resolved value is on, else the safe `fallback`. Before this, the gate was
- * touched only by one e2e; a `FlagGate` that stopped gating on the resolved value
- * (rendered `children` unconditionally) shipped green past everything but it.
- *
- * `flagGateChild` is the gate's decision factored DOM-free, asserted here with
- * sentinel `ReactNode`s — the pure-extraction idiom of `toProfileStatsState`
- * (`apps/web/src` has no jsdom/testing-library).
+ * The `FlagGate` gating contract (#1111), asserted through the DOM-free `flagGateChild` with
+ * sentinel `ReactNode`s — `apps/web/src` has no jsdom/testing-library.
  */
 import {describe, expect, it} from "vitest";
 import {flagGateChild} from "./FlagGate";
@@ -20,8 +14,6 @@ describe("flagGateChild — the FlagGate render decision", () => {
 	});
 
 	it("shows the fallback (the off/old/safe path) when the resolved value is off", () => {
-		// The safe-default-false contract: loading / fetch-error / undeclared flag all
-		// resolve to `false` upstream, so the gate shows the fallback in every one.
 		expect(flagGateChild(false, children, fallback)).toBe(fallback);
 	});
 

--- a/apps/web/src/flags/FlagGate.tsx
+++ b/apps/web/src/flags/FlagGate.tsx
@@ -1,34 +1,19 @@
 /**
- * `FlagGate` — the demonstrated gated UI path for the flag hook (epic #488,
- * #510). Renders `children` only when the named flag's server-evaluated value is
- * on; otherwise renders `fallback` (default `null`). This is the SPA mirror of
- * the server's branch-on-a-flag dark-ship primitive: a component renders the new
- * path only when the flag says so for this request's user, with the safe/off path
- * showing until/unless the server flips it.
- *
- * The gate inherits the hook's safe-default contract wholesale: while the value
- * is loading, on a fetch error, or for an undeclared flag, `value` stays `false`,
- * so the gate shows the fallback (the off/old/safe UI) — a Flagship outage never
- * exposes the gated path.
+ * `FlagGate` — the SPA mirror of the server's branch-on-a-flag dark-ship primitive (#488).
+ * It inherits `useFlag`'s safe-default contract wholesale: loading, fetch error, and undeclared
+ * flag all hold `value` at `false`, so a Flagship outage never exposes the gated path.
  */
 import type {ReactNode} from "react";
 import {useFlag} from "./useFlag";
 
 export interface FlagGateProps {
-	/** The flag key to evaluate server-side. */
 	readonly flag: string;
-	/** The off/old/safe path shown until the flag evaluates on. Defaults to `null`. */
+	/** The off/old/safe path shown until the flag evaluates on. */
 	readonly fallback?: ReactNode;
-	/** The gated UI, rendered only when the flag is on for this request. */
 	readonly children: ReactNode;
 }
 
-/**
- * The gate's render decision, factored out so the gating contract — show the
- * gated `children` iff the resolved value is on, else the safe `fallback` — is
- * unit-testable without a DOM. A gate that stopped gating on the resolved value
- * (rendered `children` unconditionally) would fail exactly this function.
- */
+/** Factored out so the gating contract is unit-testable without a DOM. */
 export function flagGateChild(value: boolean, children: ReactNode, fallback: ReactNode): ReactNode {
 	return value ? children : fallback;
 }

--- a/apps/web/src/flags/boot.test.ts
+++ b/apps/web/src/flags/boot.test.ts
@@ -1,10 +1,7 @@
 /**
- * The optional-`__BOOT__` client contract (#2931, ADR 0179 §4): the shell renders correctly when
- * `window.__BOOT__` is ABSENT — the never-hang outage fallback or a flag-off render served the
- * untransformed asset — by resolving to `undefined` so the caller falls back to its fetch path,
- * never assuming injection happened. Runs in the node unit tier where `window` is undefined by
- * default (the exact absence the contract must tolerate); the present-payload cases set a stub
- * `window` and restore it.
+ * The optional-`__BOOT__` client contract (ADR 0179 §4). Runs in the node unit tier where `window`
+ * is undefined by default — the exact absence the contract must tolerate; the present-payload
+ * cases set a stub `window` and restore it.
  */
 import {afterEach, describe, expect, it} from "vitest";
 import type {BootPayload} from "./boot.ts";

--- a/apps/web/src/flags/boot.ts
+++ b/apps/web/src/flags/boot.ts
@@ -1,20 +1,10 @@
 /**
- * The client half of the `window.__BOOT__` contract, read as OPTIONAL (ADR 0179 §4, #2931).
- *
- * The edge injects `window.__BOOT__` only when the shell renders through the worker with the flag
- * on AND the boot resolve succeeds within the never-hang bound. When it is ABSENT — the flag is
- * off, or a Flagship/session outage tripped the never-hang fallback to the untransformed asset —
- * these readers return `undefined` so the consumer resolves through its existing fetch path. A
- * missing payload is a first-class, non-error state, never an assumption that injection happened;
- * the unified `useFlag` (#2932) consumes this, so the optional contract lives here at its source.
+ * The client half of the `window.__BOOT__` contract, read as OPTIONAL — see ADR 0179 §4. An absent
+ * payload is a first-class, non-error state: every reader here returns `undefined`/`null` so the
+ * consumer resolves through its own fetch path instead (#2931).
  */
 import type {BootMemberKey, BootUser} from "./shell-keys.ts";
 
-/**
- * The edge-injected payload as the client sees it: every boolean member key MAY be present, plus
- * the edge-resolved current `user` (ADR 0185) — absent/`null` for a signed-out viewer or the
- * absent-`__BOOT__` fallback.
- */
 export type BootPayload = Partial<Record<BootMemberKey, boolean>> & {user?: BootUser | null};
 
 declare global {
@@ -23,33 +13,21 @@ declare global {
 	}
 }
 
-/**
- * Read `window.__BOOT__` when the edge injected a well-formed object, else `undefined`. Optional by
- * construction: absence (outage fallback or flag off) is not an error — the caller falls back to
- * its fetch path when this returns `undefined`.
- */
 export function readBoot(): BootPayload | undefined {
 	if (typeof window === "undefined") return undefined;
 	const boot = window.__BOOT__;
 	return typeof boot === "object" && boot !== null ? boot : undefined;
 }
 
-/**
- * Read a single `__BOOT__`-member key. Returns the injected boolean when present, else `undefined`
- * — a missing payload, a missing key, or a non-boolean value all fall back rather than fabricate a
- * value.
- */
 export function readBootMember(key: BootMemberKey): boolean | undefined {
 	const value = readBoot()?.[key];
 	return typeof value === "boolean" ? value : undefined;
 }
 
 /**
- * Read the edge-resolved current user from `window.__BOOT__.user` (ADR 0185, amending 0179):
- * the full identity, so first-paint surfaces (the navbar cluster, the pano CTA, `useMe`'s seed)
- * render the signed-in state SYNCHRONOUSLY instead of the async `useMe` fetch. Returns `null`
- * for a signed-out viewer AND for the absent-`__BOOT__` fallback (flag off / the #2931 never-hang
- * outage) — the caller then resolves through its async path, never assuming injection happened.
+ * The edge-resolved current user — see ADR 0185. `null` covers BOTH a signed-out viewer and the
+ * absent-`__BOOT__` fallback, so the caller resolves through its async path rather than assuming
+ * injection happened.
  */
 export function readBootUser(): BootUser | null {
 	const user = readBoot()?.user;

--- a/apps/web/src/flags/keys.ts
+++ b/apps/web/src/flags/keys.ts
@@ -1,203 +1,122 @@
 /**
- * Flag-key constants shared by both halves of the codec — the client (`FlagGate` /
- * `useFlag`) and the server (the IaC declaration in
- * `worker/features/flagship/resources.ts` + the
- * mutation gate). A plain-string module (no alchemy/React import) so it is safe in
- * the worker bundle AND the SPA bundle, mirroring `src/lib/fateWireCodes.ts`.
- * One home per key means the gate and the declaration can never name different
- * strings.
+ * Flag-key constants shared by the client gates and the server's IaC declaration
+ * (`worker/features/flagship/resources.ts`). Plain strings, no alchemy/React import, so the module
+ * is safe in the worker bundle AND the SPA bundle.
  */
 
 /**
- * Sözlük parallel-stamp-wave containment flag (#2709, epic #2567). Default-off. The
- * sözlük definition reads (`getDefinitionsByIds` / `listDefinitionsKeyset`) always
- * route their independent stamps through the shared `parallelStampWave`; this flag is
- * the concurrency knob it passes — OFF ⇒ the wave runs at `concurrency: 1` (the reads
- * stay serial, byte-for-byte today's behavior), ON ⇒ `"unbounded"` collapses the stamp
- * chain into one concurrent wave (the #2567 win). Flipping it on is the human release
- * act (ADR 0083). Its own `phoenix-` key — the combinator is cross-product (the pano
- * sibling #2710 ships behind its own seam), read-path only.
+ * Concurrency knob the sözlük definition reads pass to the shared `parallelStampWave` (#2709):
+ * off ⇒ `concurrency: 1` (serial, today's behavior), on ⇒ `"unbounded"`. Default-off, ADR 0083.
  *
  * @reachability-exempt: server read-path performance flag, no user-facing surface (identical wire output either way; only wall time changes).
  */
 export const PHOENIX_SOZLUK_STAMP_WAVE = "phoenix-sozluk-stamp-wave";
 
 /**
- * Pano parallel-stamp-wave containment flag (#2710, epic #2567) — the pano sibling of
- * {@link PHOENIX_SOZLUK_STAMP_WAVE}, behind its own seam. The pano thread/comment reads
- * (`getCommentsByIds` / `listCommentsKeyset`) always route their independent stamps
- * through the shared `parallelStampWave`; this flag is the concurrency knob it passes —
- * OFF ⇒ the wave runs at `concurrency: 1` (the reads stay serial, byte-for-byte today's
- * behavior), ON ⇒ `"unbounded"` collapses the stamp chain into one concurrent wave (the
- * #2567 win). Flipping it on is the human release act (ADR 0083). Scoped to the thread
- * read only — NOT the pano feed (`listPostsConnection`), which is the #2322 base/overlay
- * split.
+ * The pano sibling of {@link PHOENIX_SOZLUK_STAMP_WAVE} (#2710), behind its own seam. Scoped to
+ * the thread/comment reads only — NOT the pano feed (`listPostsConnection`), which is the #2322
+ * base/overlay split. Default-off, ADR 0083.
  *
  * @reachability-exempt: server read-path performance flag, no user-facing surface (identical wire output either way; only wall time changes).
  */
 export const PHOENIX_PANO_STAMP_WAVE = "phoenix-pano-stamp-wave";
 
 /**
- * mecmua write-path dark-ship flag (#2497, epic #2467). The single seam the mecmua
- * write surface gates behind — the `mecmua.publish` + `mecmua.saveDraft` mutations
- * fail `MECMUA_DISABLED` with it off, so the whole write path ships dark until a
- * human flips it at release (ADR 0083). Its own `mecmua-` product key.
+ * mecmua write-path dark-ship seam (#2497): `mecmua.publish` + `mecmua.saveDraft` fail
+ * `MECMUA_DISABLED` with it off. Default-off, ADR 0083.
  */
 export const MECMUA_WRITE = "mecmua-write";
 
 /**
- * mecmua public-read dark-ship flag (#2498, epic #2467). The SINGLE seam the
- * anonymous read surface gates behind — the `GET /fate/mecmua/post/:slug` route's
- * existence (404 until flipped) AND the `/mecmua/:slug` reader page (self-404).
- * Default-off so the whole public-read path ships dark until a human flips it at
- * release (ADR 0083). Its own `mecmua-` key, scoped to the read surface — the
- * authoring/publish path (#2497) ships behind its own seam.
+ * mecmua public-read dark-ship seam (#2498): the `GET /fate/mecmua/post/:slug` route's existence
+ * (404 until flipped) AND the `/mecmua/:slug` reader page's self-404. Default-off, ADR 0083.
  */
 export const MECMUA_PUBLIC_READ = "mecmua-public-read";
 
 /**
- * mecmua subscribed-author feed dark-ship flag (#2500, epic #2467). The SINGLE seam
- * the feed surface gates behind — the `mecmuaFeed` list root (empty when off), the
- * `mecmua.subscribe` / `mecmua.unsubscribe` mutations, AND the `/mecmua` feed page
- * (self-404). Default-off so the whole feed path ships dark until a human flips it at
- * release (ADR 0083). Its own `mecmua-` key, scoped to the feed — the read (#2498) and
- * write (#2497) paths ship behind their own seams.
+ * mecmua subscribed-author feed dark-ship seam (#2500): the `mecmuaFeed` list root (empty when
+ * off), the subscribe/unsubscribe mutations, AND the `/mecmua` feed page's self-404. Default-off,
+ * ADR 0083.
  */
 export const MECMUA_FEED = "mecmua-feed";
 
 /**
- * Bildirim (notification system) dark-ship flag (#1694, epic #1666). The SINGLE
- * seam the whole notification surface gates behind — the spine's unread badge +
- * `/bildirimler` center page and every sibling emitter's surface reuse this one
- * key rather than minting per-child flags. Default-off so the system ships dark
- * until a human flips it at release (ADR 0083).
+ * The single seam for the WHOLE notification surface (#1694) — unread badge, `/bildirimler`, and
+ * every emitter reuse this one key rather than minting per-child flags. Default-off, ADR 0083.
  */
 export const PHOENIX_BILDIRIM = "phoenix-bildirim";
 
 /**
- * Reactions (emoji tepki) dark-ship flag (#1863, epic #1840). The SINGLE seam the
- * whole reaction feature gates behind — the react/change/retract mutations and the
- * `reactions` view field on every surface (pano post/comment, sözlük definition)
- * reuse this one key rather than minting a per-surface flag, so one human flip
- * releases the whole ungated social-signal affordance. Default-off so the feature
- * reaches production dark until a human flips it at release (ADR 0083). Its OWN
- * cross-cutting (`phoenix`) key — the template spans both products, mirroring the
- * `phoenix-bildirim` shared-seam precedent.
+ * The single cross-product seam for the WHOLE reaction feature (#1863) — the mutations and the
+ * `reactions` view field on every surface reuse this one key, so one flip releases it all.
+ * Default-off, ADR 0083.
  */
 export const PHOENIX_REACTIONS = "phoenix-reactions";
 
 /**
- * Karma-gated privileges dark-ship flag (#150, künye epic #41). The SINGLE seam
- * the karma-value privilege gates ride behind — the post-floor (`karma ≥ −4`, on
- * content creation) and the flag-floor (`karma ≥ 50`, on `report.submit`). With
- * it OFF the gates are inert: no karma read runs and every write behaves exactly
- * as today, so the gates reach production dark until a human flips the flag at
- * release (ADR 0083). Default-off, its own cross-cutting (`phoenix`) key — the
- * gates span both products (pano/sözlük creation) and the moderation surface, the
- * `phoenix-reactions` shared-seam precedent.
+ * The single seam for the karma-VALUE floors (#150): the post-floor (`karma ≥ −4`) and the
+ * report-floor (`karma ≥ 50`); off ⇒ no karma read runs at all. Default-off, ADR 0083.
  *
- * Deliberately distinct from the çaylak→yazar *tier* gates (authorship level) and
- * the ADR 0098 moderation surface: these are karma-VALUE floors (anti-abuse), not
- * a second tier ladder — no double-gating (#150 rescope, 2026-07-02).
+ * Deliberately NOT the çaylak→yazar tier gates or the ADR 0098 moderation surface — these are
+ * anti-abuse floors, not a second tier ladder, so nothing is double-gated (#150 rescope).
  */
 export const PHOENIX_KARMA_GATES = "phoenix-karma-gates";
 
 /**
- * User ban/unban dark-ship flag (#970, admin epic #968). The SINGLE seam the ban
- * surface gates behind — the `user.banUser` / `user.unbanUser` admin mutations, the
- * `user.banState` admin read, AND the moderator-UI ban controls all read this one
- * key. Default-off so the whole ban path (server + client) reaches production dark
- * until a human flips it at release (ADR 0083): with it off the mutations/read fail
- * the invisible `Denied` (like a non-admin call) and the client controls render
- * nothing, so no session is ever refused by an unreleased feature. Its OWN key, not
- * a shared authz seam — ban is a distinct admin capability with its own lifecycle.
+ * The single seam for ban/unban (#970): the `user.banUser` / `user.unbanUser` mutations, the
+ * `user.banState` read, and the moderator-UI controls. Off ⇒ the invisible `Denied`, so no session
+ * is ever refused by an unreleased feature. Default-off, ADR 0083.
  */
 export const PHOENIX_USER_BAN = "phoenix-user-ban";
 
 /**
- * Platform-role assignment dark-ship flag (#3522, admin epic per ADR 0107). The SINGLE
- * seam the `Admin.over(platform)`-gated `user.setRole` mutation gates behind — the writer
- * for the `moderates` relation tuple #969/PR #1266's offline mint never gave the console.
- * Default-off so the whole role-assign path reaches production dark until a human flips it
- * at release (ADR 0083): with it off the mutation fails the invisible `Denied` (like a
- * non-admin call), so an unreleased role-grant can never mint a moderator. Its OWN key,
- * not the ban/email-admin seam — role-assign is a distinct admin capability with its own
- * lifecycle (the `phoenix-user-ban` / `phoenix-email-delivery-admin` admin-surface
- * precedent). The #3203 roster affordance wires onto this mutation later.
+ * The single seam for the `Admin.over(platform)`-gated `user.setRole` mutation (#3522). Off ⇒ the
+ * invisible `Denied`, so an unreleased role-grant can never mint a moderator. Default-off, ADR 0083.
  */
 export const PHOENIX_USER_ROLE_ASSIGN = "phoenix-user-role-assign";
 
 /**
- * Admin email-delivery (failing-address) surface dark-ship flag (#2692, email-bounce
- * epic #2687). The SINGLE seam the admin failing-address surface gates behind — the
- * `emailDelivery.mark` / `emailDelivery.clear` admin mutations AND the
- * `emailDelivery.failing` admin roll-up read all read this one key. Default-off so the
- * whole admin path reaches production dark until a human flips it at release (ADR 0083):
- * with it off the mutations/read fail the invisible `Denied` (like a non-admin call), so
- * no manual failing-mark or roll-up leaks before release. Its OWN key, not the ban seam —
- * the manual failing-address surface is a distinct admin capability with its own lifecycle
- * (the `phoenix-user-ban` admin-surface precedent).
+ * The single seam for the admin failing-address surface (#2692): the `emailDelivery.mark` /
+ * `emailDelivery.clear` mutations and the `emailDelivery.failing` roll-up read. Off ⇒ the
+ * invisible `Denied`. Default-off, ADR 0083.
  */
 export const PHOENIX_EMAIL_DELIVERY_ADMIN = "phoenix-email-delivery-admin";
 
 /**
- * Failing-email membrane notice dark-ship flag (#2693, email-bounce epic #2687). The seam the
- * user-facing notice gates behind — with it off the membrane mount renders nothing, so the
- * surface ships dark until a human flips it at release (ADR 0083). Default-off, its own
- * `phoenix-` key: the notice is a cross-product membrane element, not scoped to one product.
+ * The seam for the user-facing failing-email notice (#2693): off ⇒ the membrane mount renders
+ * nothing. Default-off, ADR 0083.
  */
 export const PHOENIX_EMAIL_DELIVERY_NOTICE = "phoenix-email-delivery-notice";
 
 /**
- * Kullanıcılar (user-roster) admin-console module dark-ship flag (#3200, admin epic).
- * The SINGLE seam the gated user-list read view gates behind — the `userAdmin.list`
- * admin fate resolver AND the `kullanıcılar` console panel both key off this one string.
- * Default-off so the whole roster surface reaches production dark until a human flips it
- * at release (ADR 0083): with it off the server read fails the invisible `Denied` (like a
- * non-admin call) and the panel renders nothing, so the roster never leaks before release.
- * Its OWN key — the roster is a distinct admin capability (read the user list) with its own
- * lifecycle, hosted BY the shipped console shell (the `phoenix-user-ban` /
- * `phoenix-email-delivery-admin` admin-surface precedent).
- * The per-user actions (role-assign, ban/unban) wire into this roster behind their own
- * seams later — this key gates the read view only.
+ * The single seam for the kullanıcılar roster READ view (#3200): the `userAdmin.list` resolver and
+ * the console panel. The per-user actions (role-assign, ban/unban) ride their own seams.
+ * Default-off, ADR 0083.
  */
 export const PHOENIX_USER_ADMIN = "phoenix-user-admin";
 
 /**
- * Profile free-paint canvas (duvar) dark-ship flag (#3103, epic #2035). The SINGLE seam
- * the whole profile-canvas feature gates behind — the fate read view + visitor render
- * (#3105), the owner enable/toggle mutation (#3108), and the paint/save surface (#3109)
- * all key off this one string rather than minting per-child flags, so one human flip
- * releases the mural as a unit. Default-off so the feature ships dark until a human flips
- * it at release (ADR 0083). Its own `profile-` key, scoped to the profile surface.
+ * The single seam for the WHOLE profile canvas — read view (#3105), owner toggle (#3108),
+ * paint/save (#3109) — rather than per-child flags, so one flip releases the mural.
+ * Default-off, ADR 0083.
  */
 export const PROFILE_CANVAS = "profile-canvas";
 
 /**
- * Member-mute (sustur) write-path dark-ship flag (#3112, epic #2035). The SINGLE seam
- * the mute write path gates behind — the `mute.set` / `mute.remove` fate mutations fail
- * closed (`MUTE_DISABLED`) with it off, so the whole primitive ships dark until a human
- * flips it at release (ADR 0083): with it off no member can mute another even if a client
- * bypasses the (not-yet-built) UI. Default-off, its own `member-` key scoped to the
- * member-relation surface. The read-mask that consumes a mute (sibling) and the manage
- * UI (reachability child) ship behind their own slices.
+ * The seam for the mute WRITE path (#3112): `mute.set` / `mute.remove` fail closed
+ * (`MUTE_DISABLED`) with it off, so no member can mute another even if a client bypasses the UI.
+ * The read-mask and the manage UI ship behind their own slices. Default-off, ADR 0083.
  */
 export const MEMBER_MUTE = "member-mute";
 
-/** A declared flag paired with its default variation — the row the flags console lists (#2742). */
 export interface FlagDeclaration {
 	readonly key: string;
-	/** The declared default variation (mirrors `resources.ts`; every containment flag is off). */
+	/** Mirrors `resources.ts`; every containment flag is off. */
 	readonly defaultValue: boolean;
 }
 
-/**
- * The declared flags enumerated for a UI that must list them all — the flags console module
- * (#2742) reads this to render one on/off/clear row per flag. The plain constants above are the
- * single home for the key *strings*; this array is their enumeration, so the console can never
- * name a flag that isn't declared here. Every entry is a default-off containment flag (each key's
- * docblock above; the server default lives in `worker/features/flagship/resources.ts`).
- */
+// The enumeration the flags console (#2742) renders a row per; the constants above stay the single
+// home for the key strings, so the console can never name an undeclared flag.
 export const DECLARED_FLAGS: readonly FlagDeclaration[] = [
 	{key: PHOENIX_SOZLUK_STAMP_WAVE, defaultValue: false},
 	{key: PHOENIX_PANO_STAMP_WAVE, defaultValue: false},

--- a/apps/web/src/flags/shell-keys.test.ts
+++ b/apps/web/src/flags/shell-keys.test.ts
@@ -1,8 +1,6 @@
 /**
- * The fail-closed drift check for the shell-key manifest (#2928, ADR 0179 §3): the worker
- * injects `window.__BOOT__` and the client reads it, and this proves BOTH key sets derive
- * from the one manifest — a divergence throws. Deliberately an in-app unit test, NOT a
- * CI guard, so this slice stays NON-§CP (#2928).
+ * The fail-closed drift check for the shell-key manifest (ADR 0179 §3). Deliberately an in-app
+ * unit test, NOT a CI guard, so this slice stays NON-§CP (#2928).
  */
 import {describe, expect, it} from "vitest";
 import {MECMUA_FEED, MECMUA_PUBLIC_READ} from "./keys";
@@ -20,8 +18,6 @@ describe("shell-key manifest — the geometry-law member set", () => {
 	});
 
 	it("the __BOOT__ boolean-member keys are exactly the flag keys — the user is not a member key", () => {
-		// ADR 0185 superseded #2933's `signedIn` presence bit with the typed `user` object, so the
-		// boolean member set carries the shell flags and nothing else; `user` is a distinct field.
 		expect([...BOOT_MEMBER_KEYS]).toEqual([...SHELL_FLAG_KEYS]);
 		expect([...BOOT_MEMBER_KEYS]).not.toContain("signedIn");
 		expect([...BOOT_MEMBER_KEYS]).not.toContain("user");
@@ -29,8 +25,6 @@ describe("shell-key manifest — the geometry-law member set", () => {
 });
 
 describe("assertShellBootKeysSingleSourced — fail-closed single-source guard", () => {
-	// The seam both sides derive from the manifest: the worker injects BOOT_MEMBER_KEYS, the
-	// client reads BOOT_MEMBER_KEYS — the shared-source case the guard must accept.
 	const canonical = [...BOOT_MEMBER_KEYS];
 
 	it("accepts when the worker-injected and client-consumed sets both derive from the manifest", () => {

--- a/apps/web/src/flags/shell-keys.ts
+++ b/apps/web/src/flags/shell-keys.ts
@@ -1,57 +1,34 @@
 /**
- * The shell-key manifest — the single declared source of the shell-critical flag keys
- * that the worker resolves at the edge and injects into `window.__BOOT__`, consumed
- * synchronously by the client (ADR 0179, the `__BOOT__` contract). The same
- * single-source idiom as the fanned-mutations classifier (ADR 0155): ONE declared list
- * both bundles import, so the injected key set and the consumed key set can never drift.
+ * The shell-key manifest — the one declared source of the flag keys the worker injects into
+ * `window.__BOOT__` and the client consumes, so the two key sets can never drift. See ADR 0179.
  *
- * A plain-string module (no alchemy/React import) so it is safe in the worker bundle AND
- * the SPA bundle, mirroring the sibling {@link file://./keys.ts} and `src/lib/fateWireCodes.ts`.
- * The key *strings* are single-homed in `keys.ts`; this manifest names the subset that is
- * shell-critical, so it can never name a string the flag registry doesn't declare.
- *
- * The fail-closed drift guard is {@link assertShellBootKeysSingleSourced}. It is a pure,
- * in-app unit-tested check that lives in the same bundle as the manifest — deliberately
- * NOT a CI guard (#2928): a CI guard would move the check into the verb package and out of the
- * bundle it guards. If a CI-level guard is wanted later it is its own child.
- *
- * Inert until the edge-render children consume it (#2929 worker injection, #2932 unified
- * `useFlag`): this module introduces no runtime behavior on its own.
+ * Plain strings, no alchemy/React import, so it is safe in both bundles. The drift guard
+ * ({@link assertShellBootKeysSingleSourced}) is deliberately an in-app unit-tested check rather
+ * than a CI guard (#2928) — a CI guard would live outside the bundle it guards.
  */
 import type {User} from "../../worker/features/fate/views.ts";
 import {MECMUA_FEED, MECMUA_PUBLIC_READ} from "./keys.ts";
 
 /**
- * The shell-critical flag keys — the `__BOOT__`-member flags whose wrong value moves
- * geometry at first paint (ADR 0179 §1, the geometry law). Exactly the mecmua
- * nav-shaping flags and nothing else; below-fold flags stay on the client fetch path.
- * The per-product Subnav zones no longer appear here — their seam graduated at on@100%
- * and was retired (ADR 0136), so the zones are unconditional and no flag shapes them.
+ * Only the flags whose wrong value moves geometry at first paint (ADR 0179 §1); below-fold flags
+ * stay on the client fetch path. The Subnav-zone seam graduated and was retired (ADR 0136), so no
+ * flag shapes those zones any more.
  */
 export const SHELL_FLAG_KEYS = [MECMUA_PUBLIC_READ, MECMUA_FEED] as const;
 
 export type ShellFlagKey = (typeof SHELL_FLAG_KEYS)[number];
 
 /**
- * The edge-resolved current user carried in `window.__BOOT__.user` (ADR 0185, amending 0179):
- * the full identity, so first-paint surfaces read "who is signed in" SYNCHRONOUSLY instead of
- * the async `useMe`. This supersedes #2933's presence-only `signedIn` boolean — the signed-in
- * state is now `user != null`, and the name/handle/avatar/standing ride the object itself, so
- * the navbar cluster and pano CTA render their final content on the first frame.
- *
- * It is the wire `User` minus fate's `__typename` — the exact shape `useMe` exposes as `MeUser`
- * — single-sourced here so the worker-injected object and the client-consumed object can't
- * drift. `null` for a signed-out viewer, and the absent-`__BOOT__` fallback resolves to `null`
- * too (flag off / the #2931 never-hang outage ⇒ today's async `useMe` path).
+ * The edge-resolved current user carried in `window.__BOOT__.user` — see ADR 0185. Single-sourced
+ * here so the injected and consumed objects can't drift; `null` covers both a signed-out viewer
+ * and the absent-`__BOOT__` fallback.
  */
 export type BootUser = Omit<User, "__typename">;
 
 /**
- * The `__BOOT__` boolean-member key set — the shell flag keys the client resolves synchronously
- * (`useFlag`). The worker injection and the client consumption both derive from this one array,
- * enforced by {@link assertShellBootKeysSingleSourced}. The signed-in state is NOT a member key:
- * it is carried by the typed {@link BootUser} `user` field (ADR 0185, superseding #2933's
- * presence-only `signedIn` bit), derivable as `user != null`.
+ * The boolean-member key set both sides derive from, enforced by
+ * {@link assertShellBootKeysSingleSourced}. The signed-in state is NOT a member key — it rides the
+ * typed {@link BootUser} `user` field (ADR 0185).
  */
 export const BOOT_MEMBER_KEYS = [...SHELL_FLAG_KEYS] as const;
 
@@ -76,10 +53,6 @@ export class ShellKeyDriftError extends Error {
 	}
 }
 
-/**
- * Fail-closed: assert a candidate `__BOOT__` key set is EXACTLY the manifest's — any missing
- * or extra key throws {@link ShellKeyDriftError}. `side` names the seam for the error message.
- */
 function assertKeySetIsManifest(side: string, candidate: readonly string[]): void {
 	const canonical = new Set<string>(BOOT_MEMBER_KEYS);
 	const seen = new Set<string>(candidate);
@@ -91,14 +64,9 @@ function assertKeySetIsManifest(side: string, candidate: readonly string[]): voi
 }
 
 /**
- * The single-source drift guard (ADR 0179 §3, fanned-mutations idiom of ADR 0155): assert
- * BOTH the worker-injected `__BOOT__` key set and the client-consumed key set derive from the
- * one manifest. A divergence on either seam throws — so a shell key added/removed on one side
- * without the other is caught, fail-closed, before it can staleness-break the shell.
- *
- * Both sides pass the keys they actually inject / read; each is checked against
- * {@link BOOT_MEMBER_KEYS}. Called at each seam by the consuming children AND unit-tested here,
- * so the invariant holds at authoring time and at runtime.
+ * The fail-closed single-source drift guard (ADR 0179 §3): each side passes the keys it actually
+ * injects / reads, so a shell key added on one side without the other throws before it can
+ * staleness-break the shell.
  */
 export function assertShellBootKeysSingleSourced(
 	injected: readonly string[],

--- a/apps/web/src/flags/useFlag.test.ts
+++ b/apps/web/src/flags/useFlag.test.ts
@@ -1,18 +1,7 @@
 /**
- * The `useFlag` resolution cores — the two pure edges the render-only hook is built on
- * (`apps/web/src` has no jsdom/testing-library, so the hook itself is exercised e2e; these
- * cover the wiring that would otherwise ship green past everything but the e2e).
- *
- * - `resolveFlagResponse` (#1111): the fetch-path safe-default wiring of `resolveFlag` — a
- *   hook that forgot to route the server JSON through `resolveFlag`, or dropped the non-2xx
- *   guard, fails here.
- * - `resolveBootFlag` (#2932, ADR 0179): the synchronous `__BOOT__` member path — member keys
- *   resolve from the injected payload with no fetch, a non-member or an absent `__BOOT__` returns
- *   `undefined` so the hook falls back to fetch. (The signed-in identity moved to the typed
- *   `__BOOT__.user` object, `readBootUser` in `boot.ts`, covered by `boot.test.ts` — ADR 0185.)
- *
- * Node-tested with no DOM/`fetch`, per the repo's pure-extraction idiom
- * (`toProfileStatsState` / `useToggleAction.test.ts`).
+ * The two pure edges `useFlag` is built on: the fetch-path safe-default wiring
+ * (`resolveFlagResponse`) and the synchronous `__BOOT__` member path (`resolveBootFlag`, ADR 0179).
+ * Node-tested with no DOM/`fetch` — the hook itself is exercised e2e.
  */
 import {describe, expect, it} from "vitest";
 import {MECMUA_FEED, MECMUA_PUBLIC_READ} from "./keys";
@@ -20,7 +9,6 @@ import {resolveBootFlag, resolveFlagResponse} from "./useFlag";
 
 describe("resolveFlagResponse — useFlag's safe-default wiring of resolveFlag", () => {
 	it("returns the server value when the response is 2xx and the flag is on (the gated path)", () => {
-		// Default off, server evaluated it on → the gate flips to the gated path.
 		expect(resolveFlagResponse(true, {flags: {"new-ui": true}}, "new-ui", false)).toBe(true);
 	});
 
@@ -31,7 +19,6 @@ describe("resolveFlagResponse — useFlag's safe-default wiring of resolveFlag",
 	});
 
 	it("holds the default on a non-2xx response (the fetch-error path)", () => {
-		// A 500/404 must not flip the gate on — the off/old/safe path holds (#488).
 		expect(resolveFlagResponse(false, {flags: {"new-ui": true}}, "new-ui", false)).toBe(false);
 		expect(resolveFlagResponse(false, null, "new-ui", true)).toBe(true);
 	});
@@ -41,7 +28,6 @@ describe("resolveFlagResponse — useFlag's safe-default wiring of resolveFlag",
 	});
 
 	it("holds the default when the 2xx body is structurally malformed", () => {
-		// The body is untrusted JSON; the resolveFlag guard, not a cast, rejects it.
 		expect(resolveFlagResponse(true, null, "new-ui", false)).toBe(false);
 		expect(resolveFlagResponse(true, {flags: {"new-ui": "yes"}}, "new-ui", false)).toBe(false);
 	});
@@ -49,15 +35,12 @@ describe("resolveFlagResponse — useFlag's safe-default wiring of resolveFlag",
 
 describe("resolveBootFlag — the synchronous __BOOT__ member resolution", () => {
 	it("returns the injected value for a shell-key-manifest member (no fetch, loading:false)", () => {
-		// A member key present in __BOOT__ resolves to its edge-injected value on first render.
 		expect(resolveBootFlag({[MECMUA_PUBLIC_READ]: true}, MECMUA_PUBLIC_READ)).toBe(true);
 		expect(resolveBootFlag({[MECMUA_PUBLIC_READ]: false}, MECMUA_PUBLIC_READ)).toBe(false);
 		expect(resolveBootFlag({[MECMUA_FEED]: true}, MECMUA_FEED)).toBe(true);
 	});
 
 	it("returns undefined for a member when __BOOT__ is absent (the fetch fallback signal)", () => {
-		// The never-hang fallback serves an untransformed asset with no __BOOT__ — the hook must
-		// fall back to fetch, so resolution is undefined rather than a crash or a false default.
 		expect(resolveBootFlag(undefined, MECMUA_PUBLIC_READ)).toBeUndefined();
 	});
 
@@ -72,7 +55,6 @@ describe("resolveBootFlag — the synchronous __BOOT__ member resolution", () =>
 	});
 
 	it("returns undefined for a non-member key regardless of __BOOT__ (always the fetch path)", () => {
-		// A non-member key never resolves synchronously even if __BOOT__ happens to carry it.
 		expect(resolveBootFlag({"mecmua-write": true} as never, "mecmua-write")).toBeUndefined();
 		expect(resolveBootFlag(undefined, "mecmua-write")).toBeUndefined();
 	});

--- a/apps/web/src/flags/useFlag.ts
+++ b/apps/web/src/flags/useFlag.ts
@@ -1,34 +1,12 @@
 /**
- * `useFlag(key, default)` — the SPA's flag surface (epic #488, #510). Exposes a
- * single boolean flag's **server-evaluated** value to a React 19 component, so a
- * screen can render a gated UI path without re-implementing evaluation.
+ * `useFlag(key, default)` — the SPA's server-evaluated flag surface (#488). Two resolution paths,
+ * one hook: a shell-key-manifest member resolves synchronously from `window.__BOOT__`, everything
+ * else POSTs `/api/flags/evaluate`. See ADR 0179.
  *
- * Two resolution paths, one hook (the unified flag surface, ADR 0179, epic #2926):
- *
- * - **Shell-key-manifest member** ({@link BOOT_MEMBER_KEYS}): resolved SYNCHRONOUSLY from
- *   `window.__BOOT__` on the **first render** — `{value, loading: false}`, no `useEffect`
- *   fetch and no post-boot repaint. The worker resolved it at the edge under the full
- *   session context and injected it, so the shell paints its final geometry immediately.
- *   If `__BOOT__` is absent (flag off / the never-hang outage fallback serves an
- *   untransformed asset), the member falls back to the fetch path unchanged — the
- *   optional-`__BOOT__` contract.
- * - **Non-member key**: the fetch path below, exactly as before — the value POSTs the flag
- *   key + its default to `/api/flags/evaluate`, the Worker evaluates it under the
- *   session-derived targeting context, and the hook consumes the resolved boolean.
- *
- * The targeting context (user identity) is never sent from the browser — the request
- * carries only `{key, default}`, and no Flagship binding or flag config ships to the client.
- *
- * Safe-default, always. The returned `value` starts at `defaultValue` and stays
- * there unless a genuine boolean resolves for the key — from `__BOOT__` or the server;
- * any fetch error, non-2xx response, missing key, or absent `__BOOT__` leaves it at the
- * default ({@link resolveFlag}). The hook never throws — a Flagship outage or a missing
- * `__BOOT__` degrades the gated UI to its off/old path rather than breaking the screen.
- *
- * Imperative (`fetch` in an effect), not a suspending fate read: a flag gate can
- * sit anywhere in the tree, including above a `<Screen>` Suspense boundary, so it
- * must resolve to a safe default rather than suspend — the same reasoning as
- * `useMe` / `useProfileStats`.
+ * Two invariants hold across both paths. **Safe-default, never throws**: the value stays at
+ * `defaultValue` unless a genuine boolean resolves, so a Flagship outage degrades the gated UI to
+ * its off path instead of breaking the screen. **Imperative, not a suspending fate read**: a gate
+ * can sit above a Suspense boundary, so it must resolve to a default rather than suspend.
  */
 import {useEffect, useState} from "react";
 import {
@@ -42,31 +20,22 @@ import {
 	type BootMemberKey,
 } from "./shell-keys.ts";
 
-/** A flag read: its current value plus whether the server result is in yet. */
 export interface FlagState {
 	/** The server-evaluated value, or `defaultValue` until/unless the server says otherwise. */
 	readonly value: boolean;
-	/** `true` while the evaluate request is in flight (the value is still the default). */
 	readonly loading: boolean;
 }
 
 /**
- * The client view of `window.__BOOT__`: each manifest member key → boolean, every key
- * optional so a partial or absent payload cleanly falls back to fetch. Mirrors the worker's
- * injected payload (`worker/features/flagship/shell-boot.ts`); both sides derive their key
- * set from the one manifest ({@link BOOT_MEMBER_KEYS}), so the shapes can't drift.
+ * Mirrors the worker's injected payload (`worker/features/flagship/shell-boot.ts`); both sides
+ * derive their key set from the one manifest ({@link BOOT_MEMBER_KEYS}), so the shapes can't drift.
  */
 export type BootPayload = Partial<Record<BootMemberKey, boolean>>;
 
 /**
- * The `__BOOT__`-member key set `useFlag` resolves synchronously — the shell flag keys —
- * single-sourced from the one manifest ({@link BOOT_MEMBER_KEYS}), never re-listed here. (The
- * signed-in identity is the typed `__BOOT__.user` object, read by `boot.ts`, not a member key —
- * ADR 0185.) The consume-side drift guard (ADR 0179 §3) runs once at module load:
- * it proves the key set the client reads derives from the manifest, the same fail-closed
- * check the worker runs at injection. A static self-check only — the never-throw runtime
- * paths below read this set, they never re-assert against live `__BOOT__` data (a drift throw
- * on untrusted per-request data would violate the never-throw contract).
+ * Single-sourced from the one manifest ({@link BOOT_MEMBER_KEYS}), never re-listed here; the
+ * consume-side drift guard runs once at module load (ADR 0179 §3). A STATIC self-check only — it
+ * must never re-assert against live `__BOOT__` data, which would break the never-throw contract.
  */
 const BOOT_MEMBER_KEY_SET: ReadonlySet<string> = ((): ReadonlySet<string> => {
 	const consumed = [...BOOT_MEMBER_KEYS];
@@ -82,11 +51,8 @@ function readBoot(): BootPayload | undefined {
 }
 
 /**
- * The synchronous `__BOOT__` resolution for a member key, factored out pure (takes the
- * payload explicitly) so the member-sync / absent-fallback contract is unit-testable without
- * a DOM. Returns the boot value only when the key is a manifest member AND `boot` carries a
- * boolean for it; `undefined` otherwise (non-member key, absent `__BOOT__`, or a
- * missing/malformed value) — the signal `useFlag` reads to fall back to the fetch path.
+ * Pure (the payload is passed in) so the member-sync / absent-fallback contract is testable
+ * without a DOM. `undefined` is the signal `useFlag` reads to fall back to the fetch path.
  */
 export function resolveBootFlag(boot: BootPayload | undefined, key: string): boolean | undefined {
 	if (!BOOT_MEMBER_KEY_SET.has(key)) return undefined;
@@ -109,13 +75,8 @@ async function fetchFlag(key: string, defaultValue: boolean): Promise<boolean> {
 }
 
 /**
- * The hook's response → value wiring, factored out so the safe-default contract
- * is unit-testable without a `fetch`/DOM (the pure-core idiom of
- * `toProfileStatsState`). A non-2xx response is the fetch-error path → the
- * default holds; a 2xx response routes the untrusted JSON through
- * {@link resolveFlag}, whose structural guard enforces the safe default on a
- * missing key / non-boolean. A gate that forgot to call `resolveFlag` or
- * dropped the non-2xx guard would fail exactly this function.
+ * Factored out so the safe-default contract is testable without a `fetch`/DOM: a non-2xx response
+ * holds the default, a 2xx one routes untrusted JSON through {@link resolveFlag}'s structural guard.
  */
 export function resolveFlagResponse(
 	ok: boolean,
@@ -157,11 +118,8 @@ export function useFlag(key: string, defaultValue: boolean): FlagState {
 			.then((resolved) => {
 				if (!active) return;
 				setState({value: resolved, loading: false});
-				// Attribute captured errors to this flag's resolved state (#1821): once the
-				// server resolves the flag it becomes a queryable Sentry `flag.<key>` tag on the
-				// scope, so a graduation query can isolate its on-path error rate. Inert when
-				// Sentry has no DSN. Only on a genuine server resolution — the catch below holds
-				// the default without a server answer, so nothing is attributed there.
+				// Tag captured errors with this flag's resolved state (#1821). Only on a genuine server
+				// resolution — the catch below holds the default, so nothing is attributed there.
 				tagFlag(key, resolved);
 			})
 			.catch(() => {

--- a/apps/web/src/lab/atolye/AtolyeExhibitPage.test.tsx
+++ b/apps/web/src/lab/atolye/AtolyeExhibitPage.test.tsx
@@ -1,8 +1,3 @@
-/**
- * The /lab/atolye/:exhibit detail route (#3093): slug resolution against the registry, the
- * knob-state ↔ URL round-trip (a shareable/landable component state), and the graceful
- * atölye-scoped not-found on an unknown slug — never the global 404, never a crash.
- */
 import {fireEvent, render, screen, waitFor} from "@testing-library/react";
 import {MemoryRouter, Route, Routes, useLocation} from "react-router";
 import {describe, expect, it} from "vitest";
@@ -15,7 +10,6 @@ if (typeof globalThis.PointerEvent === "undefined") {
 	globalThis.PointerEvent = PointerEventShim as typeof PointerEvent;
 }
 
-// Surfaces the live URL search string so the round-trip assertions can read what a knob wrote.
 function LocationProbe() {
 	const location = useLocation();
 	return <output data-testid="search">{location.search}</output>;
@@ -37,7 +31,6 @@ describe("AtolyeExhibitPage — /lab/atolye/:exhibit detail route (#3093)", () =
 		renderAt("/lab/atolye/button");
 		expect(screen.getByTestId("lab-atolye-detail")).toBeTruthy();
 		expect(screen.getByTestId("exhibit-stage")).toBeTruthy();
-		// the exhibit's own component is mounted (the Button host)
 		expect(screen.getByTestId("lab-atolye-detail").querySelector(".kp-btn")).not.toBeNull();
 	});
 
@@ -50,12 +43,11 @@ describe("AtolyeExhibitPage — /lab/atolye/:exhibit detail route (#3093)", () =
 
 	it("reflects a knob change into the URL (deep-link out)", async () => {
 		const {container} = renderAt("/lab/atolye/button");
-		// default variant is primary → no param until it diverges
 		expect(screen.getByTestId("search").textContent).toBe("");
 		const host = container.querySelector(".kp-btn")!;
 		expect(host.getAttribute("data-size")).toBe("md");
 
-		fireEvent.click(screen.getByText("Large")); // size → lg
+		fireEvent.click(screen.getByText("Large"));
 
 		await waitFor(() =>
 			expect(new URLSearchParams(screen.getByTestId("search").textContent ?? "").get("size")).toBe(
@@ -78,7 +70,7 @@ describe("AtolyeExhibitPage — /lab/atolye/:exhibit detail route (#3093)", () =
 			"lg",
 		);
 
-		fireEvent.click(screen.getByText("Medium")); // size → md, the default
+		fireEvent.click(screen.getByText("Medium"));
 
 		await waitFor(() =>
 			expect(new URLSearchParams(screen.getByTestId("search").textContent ?? "").has("size")).toBe(

--- a/apps/web/src/lab/atolye/AtolyeExhibitPage.tsx
+++ b/apps/web/src/lab/atolye/AtolyeExhibitPage.tsx
@@ -1,12 +1,7 @@
 /**
- * `/lab/atolye/:exhibit` — the exhibit detail route (#3093). Resolves the slug against the
- * headless registry and renders that exhibit through the knobs harness, with knob state reflected
- * into the URL so a specific component state is shareable (story 6). An unknown/stale slug renders
- * a graceful atölye-scoped not-found — in-page, never the global 404 — so a dead deep-link can't
- * crash the harness (story 8).
- *
- * Route/slug are ASCII English (`/lab/atolye/:exhibit`, matching the dir + routes-are-English
- * convention); the visible brand copy stays Turkish (`atölye`, with the ö).
+ * An unknown slug renders an in-page atölye not-found, never the global 404, so a dead deep-link
+ * cannot crash the harness. The route/slug stay ASCII English (routes-are-English convention)
+ * while the visible brand copy stays Turkish (`atölye`, with the ö).
  */
 
 import {Link, useParams} from "react-router";

--- a/apps/web/src/lab/atolye/AtolyeIndexPage.test.tsx
+++ b/apps/web/src/lab/atolye/AtolyeIndexPage.test.tsx
@@ -1,8 +1,3 @@
-/**
- * The /lab/atolye index lists exactly what the headless registry enumerates and deep-links each
- * row to its detail route (#3092). The registry is the seam: the page holds no exhibit list of its
- * own, so it can never drift from `listExhibits()`.
- */
 import {render, screen, within} from "@testing-library/react";
 import {MemoryRouter} from "react-router";
 import {describe, expect, it} from "vitest";

--- a/apps/web/src/lab/atolye/AtolyeIndexPage.tsx
+++ b/apps/web/src/lab/atolye/AtolyeIndexPage.tsx
@@ -1,11 +1,7 @@
 /**
- * `/lab/atolye` — the public index of atölye, the in-product museum of craft (epic #2473).
- * Lists every exhibit the headless registry enumerates; each row deep-links to that exhibit's
- * detail route (#3093). The registry is the seam (`.patterns/atolye-exhibit-harness.md`) — a new
- * exhibit appears here by landing one `*.exhibit.tsx` + one registry line, never a route edit.
- *
- * Route/slug are ASCII English (`/lab/atolye`, matching this dir + the routes-are-English
- * convention); the visible brand copy stays Turkish (`atölye`, with the ö).
+ * The route/slug stay ASCII English (`/lab/atolye`, per the routes-are-English convention) while
+ * the visible brand copy stays Turkish (`atölye`, with the ö).
+ * See .patterns/atolye-exhibit-harness.md
  */
 
 import {Link} from "react-router";

--- a/apps/web/src/lab/atolye/ExhibitStage.test.tsx
+++ b/apps/web/src/lab/atolye/ExhibitStage.test.tsx
@@ -18,7 +18,6 @@ describe("ExhibitStage — knob-value → props plumbing (behavior)", () => {
 		const host = container.querySelector(".kp-btn");
 		expect(host).not.toBeNull();
 		expect(host?.textContent).toContain("Kaydet");
-		// variant default is "primary"
 		expect(host?.getAttribute("data-variant")).toBe("primary");
 		expect(host?.hasAttribute("aria-busy")).toBe(false);
 	});
@@ -48,7 +47,6 @@ describe("ExhibitStage — knob-value → props plumbing (behavior)", () => {
 
 	it("labels every knob control (accessibility)", () => {
 		render(<ExhibitStage exhibit={buttonExhibit} />);
-		// the knob labels are the component's technical (English) prop names
 		expect(screen.getByText("Loading")).toBeTruthy();
 		expect(screen.getByText("Appearance")).toBeTruthy();
 	});

--- a/apps/web/src/lab/atolye/ExhibitStage.tsx
+++ b/apps/web/src/lab/atolye/ExhibitStage.tsx
@@ -13,18 +13,9 @@ const styles = {
 
 export interface ExhibitStageProps {
 	readonly exhibit: AnyExhibit;
-	/**
-	 * Controlled knob state. Omit for a self-contained stage (its own in-memory knobs); the
-	 * detail route passes a URL-backed state (`useUrlKnobs`) so knob twiddling deep-links (#3093).
-	 */
 	readonly knobs?: KnobState;
 }
 
-/**
- * The render harness: mounts an exhibit's component beside its prop-knobs and wires the two
- * so a knob change re-renders the component with the new prop. The knob-value → props seam is
- * a single spread — `{...fixedProps, ...values}` — over the current knob state.
- */
 export function ExhibitStage({exhibit, knobs}: ExhibitStageProps) {
 	// The uncontrolled fallback is always instantiated (hooks run unconditionally) but goes
 	// unused when a controlled `knobs` state is supplied.

--- a/apps/web/src/lab/atolye/PropKnobs.tsx
+++ b/apps/web/src/lab/atolye/PropKnobs.tsx
@@ -19,7 +19,6 @@ export interface PropKnobsProps {
 	readonly onChange: (key: string, value: KnobValue) => void;
 }
 
-/** The prop-knobs panel — one labelled control per knob, controlled by the caller's values. */
 export function PropKnobs({schema, values, onChange}: PropKnobsProps) {
 	const entries = Object.entries(schema);
 	if (entries.length === 0) {

--- a/apps/web/src/lab/atolye/exhibit.ts
+++ b/apps/web/src/lab/atolye/exhibit.ts
@@ -1,30 +1,18 @@
-/**
- * The exhibit contract — one curated entry in atölye: a component + its knob schema +
- * the fixed props knobs don't drive, plus the catalog metadata the index lists by.
- *
- * `defineExhibit` is the seam every exhibit module authors against: it captures the
- * component's props `P` so the knob schema is type-checked against real props at the
- * declaration site, then erases to `AnyExhibit` so heterogeneous exhibits (each with a
- * different `P`) live in one registry array — the existential-type boundary.
- */
+// The exhibit contract and `defineExhibit`. See .patterns/atolye-exhibit-harness.md
 
 import type * as React from "react";
 import type {AnyKnobSchema, KnobSchema} from "./knob";
 
 export interface Exhibit<P> {
-	/** Stable kebab-case slug — the URL segment and the registry key; unique across the registry. */
 	readonly id: string;
 	/** The component's real (English, technical) name shown in the index and as the detail heading. */
 	readonly title: string;
-	/** One-line thesis — the curation note stating why this piece earns an exhibit. */
 	readonly summary?: string;
 	readonly component: React.ComponentType<P>;
 	readonly knobs: KnobSchema<P>;
-	/** Props supplied to every render but not exposed as knobs (children, non-knobbable props). */
 	readonly fixedProps?: Partial<P>;
 }
 
-/** The type-erased exhibit the registry stores and the routes/tests enumerate. */
 export interface AnyExhibit {
 	readonly id: string;
 	readonly title: string;

--- a/apps/web/src/lab/atolye/exhibits/Button.exhibit.tsx
+++ b/apps/web/src/lab/atolye/exhibits/Button.exhibit.tsx
@@ -2,11 +2,6 @@ import type * as React from "react";
 import {Button} from "../../../components/ui/Button";
 import {defineExhibit} from "../exhibit";
 
-/**
- * The worked exemplar — proves the harness end to end: an enum knob per literal-union prop
- * (`variant`/`size`), a boolean knob per flag, and `children` pinned as a fixed prop because
- * `ReactNode` is not knobbable. Every later exhibit (#3094/#3095) follows this shape.
- */
 export const buttonExhibit = defineExhibit<React.ComponentProps<typeof Button>>({
 	id: "button",
 	title: "Button",

--- a/apps/web/src/lab/atolye/exhibits/Composer.exhibit.live.tsx
+++ b/apps/web/src/lab/atolye/exhibits/Composer.exhibit.live.tsx
@@ -1,17 +1,10 @@
-/**
- * The composer exhibit's live demo — the tiptap-import boundary. `Composer.exhibit.tsx`
- * `React.lazy`-loads this module, so `@kampus/composer` (tiptap/ProseMirror) stays out of
- * the atölye registry/index chunk and only loads when the exhibit actually renders — the
- * same performance-pillar split the composer routes make (#2523).
- */
+// The tiptap-import boundary: a separate module so `Composer.exhibit.tsx` can `React.lazy` it and
+// keep ProseMirror out of the atölye index chunk (#2523).
 
 import {Composer, ReadOnlyComposer, useComposerEditor} from "@kampus/composer";
 import {useState} from "react";
 import {Link} from "react-router";
 
-// A compact sample exercising headings, inline marks, a list, and a blockquote — enough to
-// prove the editor is a real rich surface. The exhaustive round-trip fixture lives at the
-// canonical `/lab/composer` playground (linked below), which this exhibit does not touch.
 const SAMPLE_MARKDOWN = [
 	"## Merhaba, atölye",
 	"",
@@ -24,9 +17,8 @@ const SAMPLE_MARKDOWN = [
 ].join("\n");
 
 /**
- * Editable ⇄ read-only share ONE render path (editor≈reader parity, #2581). The parent
- * remounts this on the knob flip (via `key`), so `editable` is fixed per mount and the
- * read-only branch renders through `ReadOnlyComposer` — the same baseKit path, editing off.
+ * `editable` is fixed per mount (the parent remounts via `key`), so both branches run one baseKit
+ * render path — editor≈reader parity, #2581.
  */
 export function ComposerExhibitLive({readOnly = false}: {readOnly?: boolean}) {
 	if (readOnly) {

--- a/apps/web/src/lab/atolye/exhibits/Composer.exhibit.tsx
+++ b/apps/web/src/lab/atolye/exhibits/Composer.exhibit.tsx
@@ -1,12 +1,6 @@
 /**
- * The composer exhibit — atölye's first FEATURE-level exhibit (beyond the UI primitives):
- * the shared `@kampus/composer` editor folded in as a live, knob-driven piece (#3095).
- *
- * This module is deliberately tiptap-free: the heavy demo is `React.lazy`-loaded from
- * `Composer.exhibit.live` so the atölye registry/index chunk never pays for ProseMirror
- * (the #2523 performance-pillar split). The standalone `/lab/composer` route stays the
- * canonical full round-trip playground (documented NOT-throwaway); this exhibit shows a
- * focused live demo and links out to it — it does not embed or regress that proof.
+ * Deliberately tiptap-free: the demo is `React.lazy`-loaded from `Composer.exhibit.live` so the
+ * atölye registry/index chunk never pays for ProseMirror (#2523). A direct import undoes that.
  */
 
 import type * as React from "react";

--- a/apps/web/src/lab/atolye/exhibits/DraftRestoreBanner.exhibit.tsx
+++ b/apps/web/src/lab/atolye/exhibits/DraftRestoreBanner.exhibit.tsx
@@ -2,8 +2,6 @@ import type * as React from "react";
 import {DraftRestoreBanner} from "../../../components/ui/DraftRestoreBanner";
 import {defineExhibit} from "../exhibit";
 
-// `onRestore`/`onDismiss` are callbacks (non-knobbable) — pinned to no-ops so the
-// banner's two-button landmark can be rendered on its own.
 export const draftRestoreBannerExhibit = defineExhibit<
 	React.ComponentProps<typeof DraftRestoreBanner>
 >({

--- a/apps/web/src/lab/atolye/exhibits/EmptyState.exhibit.tsx
+++ b/apps/web/src/lab/atolye/exhibits/EmptyState.exhibit.tsx
@@ -3,8 +3,6 @@ import {Button} from "../../../components/ui/Button";
 import {EmptyState} from "../../../components/ui/EmptyState";
 import {defineExhibit} from "../exhibit";
 
-// Every slot is a ReactNode, so none is knobbable — the prop space is exercised
-// through `fixedProps` (icon + title + description + action), not on-screen knobs.
 export const emptyStateExhibit = defineExhibit<React.ComponentProps<typeof EmptyState>>({
 	id: "empty-state",
 	title: "EmptyState",

--- a/apps/web/src/lab/atolye/exhibits/MetaRow.exhibit.tsx
+++ b/apps/web/src/lab/atolye/exhibits/MetaRow.exhibit.tsx
@@ -1,9 +1,6 @@
 import {MetaRow} from "../../../components/ui/MetaRow";
 import {defineExhibit} from "../exhibit";
 
-// A composed row (author · time · count) so the shared child treatment and the
-// `MetaRow.Dot` separator are shown together; MetaRow's own props are all layout
-// (`as`) or ReactNode children, so there are no knobs — the row is fixed content.
 function MetaRowDemo() {
 	return (
 		<MetaRow>

--- a/apps/web/src/lab/atolye/exhibits/ReportButton.exhibit.tsx
+++ b/apps/web/src/lab/atolye/exhibits/ReportButton.exhibit.tsx
@@ -2,8 +2,6 @@ import type * as React from "react";
 import {ReportButton} from "../../../components/ui/ReportButton";
 import {defineExhibit} from "../exhibit";
 
-// `onReport` is a callback (non-knobbable) — pinned to a stub that resolves
-// `reported`, so the button's in-flight lock and confirmation feedback can be felt.
 export const reportButtonExhibit = defineExhibit<React.ComponentProps<typeof ReportButton>>({
 	id: "report-button",
 	title: "ReportButton",

--- a/apps/web/src/lab/atolye/exhibits/ReviewBadge.exhibit.tsx
+++ b/apps/web/src/lab/atolye/exhibits/ReviewBadge.exhibit.tsx
@@ -2,7 +2,6 @@ import type * as React from "react";
 import {ReviewBadge} from "../../../components/ui/ReviewBadge";
 import {defineExhibit} from "../exhibit";
 
-// A propless badge — it carries its state by word, not color; no knob.
 export const reviewBadgeExhibit = defineExhibit<React.ComponentProps<typeof ReviewBadge>>({
 	id: "review-badge",
 	title: "ReviewBadge",

--- a/apps/web/src/lab/atolye/exhibits/Toast.exhibit.tsx
+++ b/apps/web/src/lab/atolye/exhibits/Toast.exhibit.tsx
@@ -15,8 +15,6 @@ function ToastTrigger({durationMs}: {durationMs: number}) {
 	);
 }
 
-// The toast is imperative (a `useToast().show` call), so the exhibit wraps a
-// trigger in its own `ToastProvider`; `durationMs=0` keeps the toast until dismissed.
 function ToastDemo({durationMs}: {durationMs?: number}) {
 	return (
 		<ToastProvider>

--- a/apps/web/src/lab/atolye/index.ts
+++ b/apps/web/src/lab/atolye/index.ts
@@ -1,8 +1,3 @@
-/**
- * atölye harness core — the public surface the index (#3092) and detail (#3093) routes,
- * the catalog (#3094), and the composer fold-in (#3095) build against.
- */
-
 export type {ExhibitStageProps} from "./ExhibitStage";
 export {ExhibitStage} from "./ExhibitStage";
 export type {AnyExhibit, Exhibit} from "./exhibit";

--- a/apps/web/src/lab/atolye/knob.test.ts
+++ b/apps/web/src/lab/atolye/knob.test.ts
@@ -16,13 +16,10 @@ type Expect<T extends true> = T;
 type Equal<A, B> =
 	(<T>() => T extends A ? 1 : 2) extends <T>() => T extends B ? 1 : 2 ? true : false;
 
-// A prop type maps to exactly one knob kind.
 type _Bool = Expect<Equal<KnobForType<boolean>, BooleanKnob>>;
 type _Num = Expect<Equal<KnobForType<number>, NumberKnob>>;
 type _Str = Expect<Equal<KnobForType<string>, StringKnob>>;
-// A literal union — the enum case — carries its own union as the knob's value type.
 type _Enum = Expect<Equal<KnobForType<ButtonVariant>, EnumKnob<ButtonVariant>>>;
-// A non-KnobValue prop (a callback, a node) is unrepresentable as a knob.
 type _None = Expect<Equal<KnobForType<() => void>, never>>;
 
 interface DemoProps {
@@ -33,7 +30,6 @@ interface DemoProps {
 	onClick?: () => void;
 }
 
-// A well-typed schema over DemoProps compiles; the negative cases below must NOT.
 const demoSchema: KnobSchema<DemoProps> = {
 	variant: {kind: "enum", default: "primary", options: [{value: "primary"}, {value: "secondary"}]},
 	loading: {kind: "boolean", default: false},

--- a/apps/web/src/lab/atolye/knob.ts
+++ b/apps/web/src/lab/atolye/knob.ts
@@ -1,14 +1,5 @@
-/**
- * prop-knobs — the typed knob schema that live-drives an exhibit's props.
- *
- * A knob is one on-screen control (`string`→text · `number`→number · `boolean`→Switch ·
- * `enum`→ToggleGroup) bound to one host-component prop. The one non-obvious thing:
- * `KnobForType` parameterizes each knob over its prop's type so a knob can only target a
- * real prop AND can only carry a value assignable to it — the invalid-states-unrepresentable
- * guarantee lives in this file's type layer, not in a runtime check.
- */
+// prop-knobs — one typed control per host-component prop. See .patterns/atolye-exhibit-harness.md
 
-/** The only value kinds a knob produces — everything reachable through a control. */
 export type KnobValue = string | number | boolean;
 
 export interface StringKnob {
@@ -46,13 +37,7 @@ export interface EnumKnob<V extends KnobValue = KnobValue> {
 	readonly options: readonly EnumOption<V>[];
 }
 
-/**
- * The knob a prop of type `T` admits — the soundness core. A prop can only be knobbed
- * when its type reduces to a `KnobValue`; anything else (`ReactNode`, a callback) maps to
- * `never`, so it is unrepresentable in a schema and must be supplied via `fixedProps`.
- * An open `string` gets a text knob; a string/number literal union gets an enum whose
- * options are drawn from that exact union.
- */
+/** A prop whose type is not a `KnobValue` maps to `never` — unknobbable, so it must go through `fixedProps`. */
 export type KnobForType<T> = [T] extends [boolean]
 	? BooleanKnob
 	: [T] extends [number]
@@ -65,21 +50,16 @@ export type KnobForType<T> = [T] extends [boolean]
 				: EnumKnob<T & KnobValue>
 			: never;
 
-/** A per-prop knob map over a component's props `P` — a knob key must be a real prop of `P`. */
 export type KnobSchema<P> = {
 	readonly [K in keyof P]?: KnobForType<NonNullable<P[K]>>;
 };
 
-/** The type-erased runtime shapes — what the presentational layer switches on. */
 export type AnyKnob = StringKnob | NumberKnob | BooleanKnob | EnumKnob;
 export type AnyKnobSchema = Readonly<Record<string, AnyKnob>>;
 
-/** Current knob values keyed by prop name — the object spread onto the host component. */
 export type KnobValues = Readonly<Record<string, KnobValue>>;
 
 /**
- * The initial value map for a schema: each knob's `default`, keyed by its prop name.
- *
  * The param is `Partial<AnyKnobSchema>`, not `AnyKnobSchema`, so a raw authored
  * `KnobSchema<P>` is accepted at the public boundary without a cast: `KnobSchema<P>` maps
  * each prop optionally (`[K in keyof P]?`), so its erased values are `AnyKnob | undefined` —

--- a/apps/web/src/lab/atolye/registry.test.ts
+++ b/apps/web/src/lab/atolye/registry.test.ts
@@ -26,8 +26,6 @@ describe("exhibit registry — headless enumeration", () => {
 		expect(new Set(ids).size).toBe(ids.length);
 	});
 
-	// The composer (#3095) is atölye's first feature-level exhibit — folded in ahead of the UI
-	// primitives it composes, so it leads the curated order the index route lists by.
 	it("leads the catalog with the composer feature exhibit", () => {
 		const exhibits = listExhibits();
 		expect(exhibits[0]?.id).toBe("composer");

--- a/apps/web/src/lab/atolye/registry.ts
+++ b/apps/web/src/lab/atolye/registry.ts
@@ -1,9 +1,4 @@
-/**
- * The exhibit registry — the headless seam of atölye. A plain typed array the index route
- * (#3092), the detail route (#3093), and a test/agent all import to enumerate or resolve an
- * exhibit without rendering. Adding an exhibit is one colocated `*.exhibit.tsx` module plus
- * one line here; the array order IS the curation order. No route ever edits to gain a piece.
- */
+// The headless registry — the array order IS the curation order. See .patterns/atolye-exhibit-harness.md
 
 import type {AnyExhibit} from "./exhibit";
 import {avatarExhibit} from "./exhibits/Avatar.exhibit";
@@ -54,12 +49,10 @@ const exhibits: readonly AnyExhibit[] = [
 	tooltipExhibit,
 ];
 
-/** Every registered exhibit, in curated order — headless, renders nothing. */
 export function listExhibits(): readonly AnyExhibit[] {
 	return exhibits;
 }
 
-/** Resolve one exhibit by its slug; `undefined` for an unknown id (the detail route's not-found). */
 export function getExhibit(id: string): AnyExhibit | undefined {
 	return exhibits.find((exhibit) => exhibit.id === id);
 }

--- a/apps/web/src/lab/atolye/useKnobs.ts
+++ b/apps/web/src/lab/atolye/useKnobs.ts
@@ -7,11 +7,7 @@ export interface KnobState {
 	readonly reset: () => void;
 }
 
-/**
- * The knob-state primitive: seeds from the schema's defaults and updates one knob at a time.
- * Kept separate from the panel so #3093 can lift this state into the URL (deep-linkable knob
- * state) without re-implementing the plumbing.
- */
+/** Kept separate from the panel so the detail route can swap in URL-backed state (`useUrlKnobs`). */
 export function useKnobs(schema: AnyKnobSchema): KnobState {
 	const [values, setValues] = React.useState<KnobValues>(() => resolveKnobDefaults(schema));
 	const setKnob = React.useCallback((key: string, value: KnobValue) => {

--- a/apps/web/src/lab/atolye/useUrlKnobs.ts
+++ b/apps/web/src/lab/atolye/useUrlKnobs.ts
@@ -4,13 +4,9 @@ import {type AnyKnob, type AnyKnobSchema, type KnobValue, resolveKnobDefaults} f
 import type {KnobState} from "./useKnobs";
 
 /**
- * The URL-backed knob state (#3093): the query string IS the source of truth, so a specific
- * exhibit state is shareable and landable. One source, not two synced ones — reading a URL and
- * reflecting a knob change are the same round-trip, so there is no state↔URL drift to race.
- *
- * Only knobs that differ from their schema default are written, keeping a pristine exhibit's URL
- * param-free; a default-valued knob drops its param. History is `replace`d — twiddling a knob
- * refines the current entry rather than stacking a back-button trap.
+ * The query string is the only copy of knob state — there is no second one to drift. Only knobs
+ * that differ from their default are written, and history is `replace`d so twiddling a knob does
+ * not stack a back-button trap.
  */
 export function useUrlKnobs(schema: AnyKnobSchema): KnobState {
 	const [searchParams, setSearchParams] = useSearchParams();
@@ -61,7 +57,6 @@ function serializeKnobValue(value: KnobValue): string {
 	return String(value);
 }
 
-/** Coerce a raw query-param string back to the knob's typed value, or `undefined` if it doesn't fit. */
 function parseKnobValue(knob: AnyKnob, raw: string): KnobValue | undefined {
 	switch (knob.kind) {
 		case "string":

--- a/apps/web/src/lib/bem.ts
+++ b/apps/web/src/lib/bem.ts
@@ -1,12 +1,7 @@
 /**
- * Maps a flat list of element names to BEM class strings under a single block.
- *
- *   bem('kp-dialog', ['popup', 'head'])
- *     → { root: 'kp-dialog', popup: 'kp-dialog__popup', head: 'kp-dialog__head' }
- *
- * Component CSS files use literal BEM class names (`.kp-dialog__popup`) and are
- * imported as side-effect global stylesheets next to each component, so this
- * helper just gives a typed `styles.popup`-style accessor.
+ * Component CSS files carry literal BEM class names and are imported as side-effect
+ * global stylesheets, so this only gives a typed `styles.popup`-style accessor —
+ * nothing here scopes or hashes a class name.
  */
 export function bem(block: string, elements: string[]): Record<string, string> {
 	const out: Record<string, string> = {root: block};

--- a/apps/web/src/lib/datetime.test.ts
+++ b/apps/web/src/lib/datetime.test.ts
@@ -13,7 +13,6 @@ describe("editedAfter", () => {
 		const updatedFar = "2026-05-09T10:00:30.000Z";
 		expect(editedAfter(created, updatedFar)).toBe(false);
 
-		// Exactly at the boundary (60s) is still inside the grace window.
 		const updatedBoundary = "2026-05-09T10:01:00.000Z";
 		expect(editedAfter(created, updatedBoundary)).toBe(false);
 	});
@@ -46,9 +45,7 @@ describe("editedAfter", () => {
 describe("formatEditedTooltipTR", () => {
 	it("formats a valid iso into Turkish date+time", () => {
 		const out = formatEditedTooltipTR("2026-05-09T13:45:00.000Z");
-		// Locale day/month/year + hour/minute. We assert presence of digits
-		// and Turkish month abbreviation rather than the full literal to keep
-		// the test portable across host TZ.
+		// Asserted loosely on purpose: the full literal is host-TZ dependent.
 		expect(out).toMatch(/2026/);
 		expect(out.length).toBeGreaterThan(8);
 	});

--- a/apps/web/src/lib/datetime.ts
+++ b/apps/web/src/lib/datetime.ts
@@ -1,6 +1,3 @@
-// Turkish date / relative-time helpers. Formatters are cached at module scope
-// to avoid reconstructing an `Intl` formatter per call site.
-
 const dateFmt = new Intl.DateTimeFormat("tr-TR", {
 	day: "numeric",
 	month: "short",
@@ -19,8 +16,7 @@ const dateTimeFmt = new Intl.DateTimeFormat("tr-TR", {
 // edit — defends against sub-second server-side updatedAt drift after insert.
 export const EDITED_GRACE_MS = 60 * 1000;
 
-/* numeric: 'auto' lets the formatter say "şimdi" / "dün" instead of
-   "0 saniye önce" / "1 gün önce" where the locale supports it. */
+// numeric: 'auto' lets the formatter say "şimdi" / "dün" instead of "0 saniye önce".
 const relFmt = new Intl.RelativeTimeFormat("tr-TR", {numeric: "auto"});
 
 const UNITS: Array<[Intl.RelativeTimeFormatUnit, number]> = [
@@ -44,8 +40,6 @@ export function formatAgoTR(iso: string | null | undefined): string {
 	const t = new Date(iso).getTime();
 	if (Number.isNaN(t)) return "";
 
-	/* Negative for past, positive for future — RelativeTimeFormat
-	   handles both directions ("3 saat önce" vs "3 saat sonra"). */
 	const diff = t - Date.now();
 	for (const [unit, ms] of UNITS) {
 		if (Math.abs(diff) >= ms || unit === "second") {
@@ -62,11 +56,6 @@ export function formatEditedTooltipTR(iso: string | null | undefined): string {
 	return dateTimeFmt.format(d);
 }
 
-/**
- * `true` when `updatedAt` is more than `EDITED_GRACE_MS` after `createdAt` —
- * backs the "düzenlendi" indicator. Defensively `false` on missing / invalid
- * inputs so the indicator stays hidden when timestamps are unavailable.
- */
 export function editedAfter(
 	createdAt: string | null | undefined,
 	updatedAt: string | null | undefined,

--- a/apps/web/src/lib/density.test.tsx
+++ b/apps/web/src/lib/density.test.tsx
@@ -4,9 +4,7 @@ import {DensityProvider, useDensity} from "./density";
 import {DENSITY_STORAGE_KEY} from "./densityStorage";
 
 // jsdom in the `client` tier ships no localStorage (Node's is experimental/off), so the
-// provider's persistence seam has nothing to read/write against by default. Install a
-// fake Storage on `window` per test so the mount-read and the setChoice-write are
-// observable — the same fake-Storage shape themeStorage's unit test uses.
+// provider has nothing to read/write against without a fake installed per test.
 function installFakeStorage(initial?: Record<string, string>): Storage {
 	const map = new Map<string, string>(Object.entries(initial ?? {}));
 	const storage: Storage = {

--- a/apps/web/src/lib/density.tsx
+++ b/apps/web/src/lib/density.tsx
@@ -28,8 +28,6 @@ export function DensityProvider({children}: {children: React.ReactNode}) {
 		setChoiceState(next);
 	}, []);
 
-	// tokens.css keys the whole --s-* spacing ramp off [data-density], so the
-	// chosen value lands on the document root here (mirroring theme.tsx).
 	React.useEffect(() => {
 		document.documentElement.dataset.density = choice;
 	}, [choice]);

--- a/apps/web/src/lib/densityStorage.ts
+++ b/apps/web/src/lib/densityStorage.ts
@@ -8,7 +8,6 @@ function isDensity(value: string | null): value is Density {
 	return value !== null && VALID.has(value);
 }
 
-/** Read the persisted density, falling back to `fallback` for missing/garbage/unavailable storage. */
 export function readStoredDensity(storage: Storage | undefined, fallback: Density): Density {
 	if (!storage) return fallback;
 	try {
@@ -19,7 +18,6 @@ export function readStoredDensity(storage: Storage | undefined, fallback: Densit
 	}
 }
 
-/** Persist the density. A throwing/unavailable storage (private mode, quota) is swallowed. */
 export function writeStoredDensity(storage: Storage | undefined, density: Density): void {
 	if (!storage) return;
 	try {

--- a/apps/web/src/lib/draftStorage.ts
+++ b/apps/web/src/lib/draftStorage.ts
@@ -1,26 +1,15 @@
 /**
- * Client-side draft autosave store — persists in-progress writing to localStorage
- * keyed by route, so a signed-out user does not lose a draft across the
- * sign-out → /auth → return round-trip. localStorage only; server-side draft
- * persistence (pano's `saveDraft`) is a separate path, out of scope here.
- *
- * Pure over an injected `Storage` (the themeStorage idiom) so the save → restore →
- * clear lifecycle is unit-testable without a DOM. The React glue is `useDraftAutosave`.
+ * Client-side draft autosave store — keeps a draft alive across the
+ * sign-out → /auth → return round-trip. Server-side draft persistence (pano's
+ * `saveDraft`) is a separate path, not this one. React glue: `useDraftAutosave`.
  */
 
 const DRAFT_KEY_PREFIX = "kampus.draft:";
 
-/** The localStorage key a route's draft lives under. Distinct routes never collide. */
 export function draftKey(route: string): string {
 	return `${DRAFT_KEY_PREFIX}${route}`;
 }
 
-/**
- * Read + validate the persisted draft for `route`, falling back to `null` for a
- * missing entry, unparseable/shape-mismatched JSON, or unavailable/throwing storage.
- * The caller's `isValid` guard keeps a stale or hand-tampered payload from being
- * offered as a draft of the wrong shape.
- */
 export function readDraft<T>(
 	storage: Storage | undefined,
 	route: string,
@@ -37,7 +26,6 @@ export function readDraft<T>(
 	}
 }
 
-/** Persist a draft for `route`. A throwing/unavailable storage (private mode, quota) is swallowed. */
 export function writeDraft<T>(storage: Storage | undefined, route: string, draft: T): void {
 	if (!storage) return;
 	try {
@@ -47,7 +35,6 @@ export function writeDraft<T>(storage: Storage | undefined, route: string, draft
 	}
 }
 
-/** Remove the persisted draft for `route` — on successful submit, or when the offer is dismissed. */
 export function clearDraft(storage: Storage | undefined, route: string): void {
 	if (!storage) return;
 	try {

--- a/apps/web/src/lib/draftStorage.unit.test.ts
+++ b/apps/web/src/lib/draftStorage.unit.test.ts
@@ -43,12 +43,9 @@ describe("draftStorage", () => {
 	});
 
 	it("survives the signed-out → auth-redirect → return round-trip, then clears on submit (AC1+AC2)", () => {
-		// One Storage stands in for localStorage across the whole journey: it persists
-		// while the form unmounts during the auth redirect and remounts on return.
 		const storage = fakeStorage();
 		const route = "/sozluk/effect";
 
-		// 1. The signed-out user types a definition. Autosave persists it as they write.
 		const typed: PanoDraft = {
 			mode: "text",
 			url: "",
@@ -58,12 +55,10 @@ describe("draftStorage", () => {
 		};
 		writeDraft(storage, route, typed);
 
-		// 2. They hit submit, are bounced to /auth, sign in, and are returned — the form
-		//    component fully remounts. The persisted draft is still there to OFFER.
+		// The form fully remounts across the auth redirect; the draft survives to be offered.
 		const offered = readDraft(storage, route, isPanoDraft);
-		expect(offered).toEqual(typed); // restorable — NOT lost across the round-trip
+		expect(offered).toEqual(typed);
 
-		// 3. They restore it and submit successfully → the draft clears.
 		clearDraft(storage, route);
 		expect(readDraft(storage, route, isPanoDraft)).toBeNull();
 	});

--- a/apps/web/src/lib/fateWireCodes.ts
+++ b/apps/web/src/lib/fateWireCodes.ts
@@ -1,65 +1,46 @@
 /**
  * The fate wire-error `code` vocabulary — the one canonical name for the error
- * `code` string that crosses the worker↔SPA boundary.
+ * `code` string that crosses the worker↔SPA boundary. See
+ * `.patterns/fate-effect-wire-errors.md`.
  *
- * The worker derives these from the `FateWireCode` annotations on its error
- * classes (`@kampus/fate-effect`'s `encodeWireError`, `.patterns/fate-effect-wire-errors.md`);
- * the SPA narrows incoming codes to this union with {@link decodeFateWireCode}
- * so UI code can `switch` on a typed value instead of stringly comparing
- * against `"UNAUTHORIZED"` etc. The literal tuple is the authored source — a
- * runtime `Set<string>` (what the server's `declaredWireCodes` walk yields)
- * cannot give an exhaustive-`switch`-able union, so the SPA carries the literal
- * and the worker's `wireCodes.unit.test.ts` derives `declaredWireCodes(fateConfig)`
- * and fails CI if this list omits any code the server can emit — the two ends of
- * the wire contract are bound by that guard, not by hope.
+ * The literal tuple is the authored source on purpose: a runtime `Set<string>`
+ * (what the server's `declaredWireCodes` walk yields) cannot give an
+ * exhaustive-`switch`-able union. The worker's `wireCodes.unit.test.ts` fails CI
+ * if this list omits a code the server can emit, which is what binds the two ends.
  *
- * This module lives under `src/lib/` and is cross-included by the worker
- * tsconfig so both halves of the codec — and the coverage guard — agree on the
- * same constant.
+ * Lives under `src/lib/` and is cross-included by the worker tsconfig so both
+ * halves of the codec — and that guard — read the same constant.
  */
 export const FATE_WIRE_CODES = [
 	"UNAUTHORIZED",
-	// The earned-ladder (Level) denial — actor's standing is below a right's floor
-	// (`kunye/RequiresLevel`, ADR 0107). First surfaced on the wire by `user.vouch`
-	// (#1206): a non-yazar vouch attempt. Distinct from `UNAUTHORIZED` (the invisible
-	// ReBAC/moderation denial) — FORBIDDEN is the visible-progression public ladder.
+	// `kunye/RequiresLevel` (ADR 0107): standing below a right's floor. Distinct from
+	// `UNAUTHORIZED`, which is the invisible ReBAC/moderation denial.
 	"FORBIDDEN",
-	// The earn-to-vote denial — a çaylak (below the yazar floor) cast a vote on live
-	// content (`vote/VoterNotEligible`, ADR 0096 / #1810/#1828). Distinct from the
-	// overloaded `FORBIDDEN` (künye vouch denials) so the vote gate gets its own ladder
-	// copy without mislabelling other forbiddens (#1879): "yazar olunca oy verebilirsin".
+	// `vote/VoterNotEligible` (ADR 0096): a çaylak voted. Split out of `FORBIDDEN` so the
+	// vote gate gets its own copy without mislabelling other denials (#1879).
 	"VOTE_REQUIRES_YAZAR",
-	// The self-vote denial — a voter cast on their OWN content (`vote/SelfVoteNotAllowed`,
-	// #2216, founder-ruled). The client hides the vote control on one's own content, so this
-	// is defense-in-depth: it reaches the wire only if that affordance is bypassed.
+	// `vote/SelfVoteNotAllowed` (#2216). The client hides the control, so this reaches the
+	// wire only when that affordance is bypassed.
 	"SELF_VOTE_NOT_ALLOWED",
-	// The concurrent-vouch cap (D5) is reached — a yazar already holds the maximum
-	// active vouches (`kunye/VouchLimitReached`, #1289). Past the `FORBIDDEN` yazar
-	// floor: the actor IS a yazar, the act is just rationed.
+	// `kunye/VouchLimitReached` (#1289): past the yazar floor — the actor IS a yazar,
+	// the act is just rationed.
 	"VOUCH_LIMIT_REACHED",
-	// A karma-VALUE privilege floor failed — the actor's earned `total_karma` is
-	// below a right's minimum (`kunye/InsufficientKarma`, #150): posting (≥ −4) or
-	// flagging (≥ 50). Distinct from the tier-ladder `FORBIDDEN` — this is a raw
-	// karma-count anti-abuse floor, a separate axis (no double-gating, #150 rescope).
+	// `kunye/InsufficientKarma` (#150): a raw karma-count anti-abuse floor — posting
+	// (≥ −4), flagging (≥ 50). A separate axis from the tier ladder, not double-gating.
 	"INSUFFICIENT_KARMA",
-	// The per-actor mutation throttle tripped — the actor is issuing writes faster
-	// than their token bucket refills (`throttle/RateLimitExceeded`, ADR 0177).
-	// Cross-cutting: injected at the fate mutation seam, so ANY mutation can surface
-	// it. Not in `declaredWireCodes` (no declared union carries it); the coverage
-	// guard unions `THROTTLE_WIRE_CODES` so this list must still cover it.
+	// `throttle/RateLimitExceeded` (ADR 0177), injected at the mutation seam so ANY
+	// mutation can surface it. NOT in `declaredWireCodes` — the coverage guard unions
+	// `THROTTLE_WIRE_CODES`, which is the only reason this list still has to carry it.
 	"RATE_LIMIT_EXCEEDED",
 	"DEFINITION_NOT_FOUND",
 	"POST_NOT_FOUND",
-	// A pano post's removal WRITE failed at the D1 layer (`pano/PostDeleteFailed`,
-	// #1639) — the declared, user-readable failure `post.delete` raises instead of
-	// letting a squashed removal-commit defect escape as `INTERNAL_SERVER_ERROR`.
+	// `pano/PostDeleteFailed` (#1639): declared so a squashed removal-commit defect
+	// cannot escape as `INTERNAL_SERVER_ERROR`.
 	"POST_DELETE_FAILED",
 	"COMMENT_NOT_FOUND",
-	// Schema rejection of an operation's input/args (`InputValidationError`,
-	// the code fate's own schema validation also emits). Pre-handler, so any
-	// mutation can surface it.
+	// `InputValidationError` — pre-handler, so any mutation can surface it.
 	"VALIDATION_ERROR",
-	// Validation codes (per-domain `code` string, upcased).
+	// Per-domain validation `code` strings, upcased.
 	"BODY_REQUIRED",
 	"BODY_TOO_LONG",
 	"TITLE_REQUIRED",
@@ -74,45 +55,30 @@ export const FATE_WIRE_CODES = [
 	"ALREADY_SET",
 	"TAKEN",
 	"USER_NOT_FOUND",
-	// A görünen-ad (display-name) save submitted an empty/whitespace-only value
-	// (`pasaport/DisplayNameEmpty`, #2154) — the server-authoritative floor the
-	// worker `user.setDisplayName` write-through raises against a blank byline.
+	// `pasaport/DisplayNameEmpty` (#2154).
 	"DISPLAY_NAME_EMPTY",
-	// A ban submitted without a reason (`pasaport/BanReasonRequired`, #970) — the
-	// server-authoritative floor the admin `user.banUser` mutation raises against a
-	// blank gerekçe, since a ban's audit record is meaningless without one.
+	// `pasaport/BanReasonRequired` (#970): a ban's audit record is meaningless with no
+	// gerekçe, so the server refuses a blank one.
 	"BAN_REASON_REQUIRED",
-	// A manual failing-address mark submitted without a reason
-	// (`pasaport/EmailFailingReasonRequired`, #2692) — the server-authoritative floor the
-	// admin `emailDelivery.mark` mutation raises against a blank note, since the audit
-	// record of why an address was marked failing out-of-band is meaningless without one.
+	// `pasaport/EmailFailingReasonRequired` (#2692): same audit-record floor for an
+	// out-of-band failing-address mark.
 	"EMAIL_FAILING_REASON_REQUIRED",
-	// mecmua write path is gated on the `mecmua-write` flag; the server raises this
-	// when `mecmua.publish` / `mecmua.saveDraft` run with the flag off (#2497).
+	// The `mecmua-write` flag is off (#2497).
 	"MECMUA_DISABLED",
-	// A `mecmua.publish` target draft doesn't exist or isn't the caller's own
-	// (`mecmua/MecmuaPostNotFound`, #2497) — the ownership-scoped miss.
+	// `mecmua/MecmuaPostNotFound` (#2497) — an ownership-scoped miss, not just absence.
 	"MECMUA_POST_NOT_FOUND",
-	// member-mute write path is gated on the `member-mute` flag; the server raises this
-	// when `mute.set` / `mute.remove` run with the flag off (#3112).
+	// The `member-mute` flag is off (#3112).
 	"MUTE_DISABLED",
-	// A member tried to mute themselves (`mute/SelfMuteRejected`, #3112) — the domain
-	// refuses a self-mute before any write.
+	// `mute/SelfMuteRejected` (#3112).
 	"SELF_MUTE_REJECTED",
 	"BAD_REQUEST",
 	"INTERNAL_SERVER_ERROR",
 ] as const;
 
-/** The fate wire-error `code` — one name for the concept across the seam. */
 export type FateWireCode = (typeof FATE_WIRE_CODES)[number];
 
 const KNOWN_CODES: ReadonlySet<string> = new Set(FATE_WIRE_CODES);
 
-/**
- * Narrow a wire-format `extensions.code` string to a {@link FateWireCode}.
- * Returns `null` for unrecognized codes (including `undefined` / `null`) so
- * the caller can fall through to a generic handler.
- */
 export function decodeFateWireCode(code: unknown): FateWireCode | null {
 	if (typeof code !== "string") return null;
 	return KNOWN_CODES.has(code) ? (code as FateWireCode) : null;

--- a/apps/web/src/lib/feedPerf.ts
+++ b/apps/web/src/lib/feedPerf.ts
@@ -1,39 +1,22 @@
 /**
  * Reload→first-feed-paint instrumentation (#2326, epic #2316 "instant /pano reload").
+ * Emits User Timing marks/measures so the epic's floor is readable in a DevTools trace
+ * with no analytics dependency.
  *
- * Emits User Timing marks/measures around the pano feed's first paint so the epic's
- * founding floor ("reload → feed on screen") is measurable in a DevTools/Performance
- * trace with NO analytics dependency. The epic's three legs create three paths:
- *   - `snapshot` — leg A hydrated the last-seen feed from `localStorage` at boot, so it
- *     paints at ~JS-boot time (the residual floor the epic names), before any network.
- *   - `edge`     — leg B's viewer-invariant base feed served from the CF edge cache
- *     (fresh-device anon), no session/D1. The SPA does not fetch that GET, so this path
- *     is classified from an injected `cf-cache-status` signal (network-layer measured on
- *     `GET /fate/pano/feed`), never from a client render.
- *   - `cold`     — today's path: the full worker→D1 read, gated behind the session.
+ * `performance.timeOrigin` IS the reload's navigation start for the top document, so
+ * `performance.now()` at paint IS the reload→paint duration — that is why the measure
+ * runs from `start: 0`.
  *
- * The measure spans navigation start → paint. `performance.timeOrigin` IS the reload's
- * navigation start for the top document, so `performance.now()` at paint is the
- * reload→paint duration — the measure runs from `start: 0` (i.e. `timeOrigin`) to it.
- *
- * Cost/containment (AC#3): a one-shot mark+measure is negligible, but per the epic's
- * dark-ship ethos it is gated behind `FEED_PERF_ENABLED` — dev builds, plus an opt-in
- * `VITE_FEED_PERF` measurement/stage build — so a production bundle pays nothing by
- * default. Every call is best-effort: an absent or throwing `performance` (SSR, a
- * legacy engine that rejects the L3 options object) degrades to a no-op, never a
- * user-visible effect.
+ * The `edge` path cannot be seen from a client render (the SPA never fetches the base-feed
+ * GET), so it is classified from an injected `cf-cache-status` signal measured at the
+ * network layer, not from anything this module observes.
  */
-
-/** Instrument gate: on in dev, or in a build that opts in via `VITE_FEED_PERF=on`
- *  (a measurement/stage bundle). Off in a default production build ⇒ zero cost. A
- *  build-time env flag, like `VITE_FEED_SNAPSHOT` — see `vite-env.d.ts`. */
+/** Dark-shipped by default: a production build without `VITE_FEED_PERF=on` pays nothing. */
 export const FEED_PERF_ENABLED = import.meta.env.DEV || import.meta.env.VITE_FEED_PERF === "on";
 
-/** Which path produced the first feed paint. */
 export type FeedPaintPath = "snapshot" | "edge" | "cold";
 
-/** The CF edge-cache status of the base-feed GET (leg B), read from its `cf-cache-status`
- *  response header; `null` when unknown/not applicable (the SPA does not fetch that GET). */
+/** The base-feed GET's `cf-cache-status`; `null` when unknown — the SPA cannot see it. */
 export type CacheStatus = "HIT" | "MISS" | null;
 
 export interface FeedPathSignals {
@@ -42,11 +25,8 @@ export interface FeedPathSignals {
 }
 
 /**
- * Classify which path produced the first paint. Snapshot wins whenever a snapshot
- * hydrated — that IS the first paint the user sees (leg A paints before any network),
- * so the edge/cold distinction only applies to the no-snapshot case. Among those, an
- * edge cache HIT on the base feed outranks the cold worker→D1 path; everything else is
- * cold. This is the rule the epic's flag-flip evidence rests on.
+ * Snapshot outranks everything: it paints before any network, so it IS the first paint
+ * the user saw. The edge/cold split only applies when no snapshot hydrated.
  */
 export function classifyFeedPath({snapshotHydrated, cacheStatus}: FeedPathSignals): FeedPaintPath {
 	if (snapshotHydrated) return "snapshot";
@@ -54,12 +34,9 @@ export function classifyFeedPath({snapshotHydrated, cacheStatus}: FeedPathSignal
 	return "cold";
 }
 
-/** Latched at boot when a feed snapshot hydrated (leg A) — read at first paint to
- *  classify the path. A one-way latch: once a snapshot is applied it defined the paint. */
+// One-way latch: once a snapshot is applied it defined the paint, so this never resets.
 let snapshotHydrated = false;
 
-/** Record that a feed snapshot hydrated at boot (leg A). Called from the public/authed
- *  client wiring only when `hydrateFromSnapshot` actually applied a snapshot. */
 export function noteSnapshotHydrated(): void {
 	snapshotHydrated = true;
 }
@@ -68,29 +45,20 @@ export function wasSnapshotHydrated(): boolean {
 	return snapshotHydrated;
 }
 
-/** The one paint-mark name (path-suffixed so each path is a distinct trace entry). */
 export const FEED_PAINT_MARK = "pano:feed-paint";
 
-/** The navigation-start→paint measure name for a path (rendered in the DevTools
- *  Performance/User Timing lane). */
 export function feedPaintMeasureName(path: FeedPaintPath): string {
 	return `pano:reload->feed-paint:${path}`;
 }
 
-/** The `performance` slice this module drives, injected so the recorder is testable
- *  without a real `performance` (and so a partial jsdom impl can be faked precisely). */
 export interface PerformanceLike {
 	now(): number;
 	mark(name: string, options?: {detail?: unknown}): unknown;
 	measure(name: string, options: {start?: number; end?: number; detail?: unknown}): unknown;
 }
 
-/**
- * Emit the paint mark + a navigation-start→paint measure for `path`, returning the
- * reload→paint duration in ms (or `null` when `performance` threw / was unusable).
- * Best-effort: wrapped so a legacy `performance` that rejects the User Timing L3 options
- * object never throws into the render.
- */
+/** Wrapped because a legacy `performance` rejects the User Timing L3 options object —
+ *  an instrument must never throw into the render. */
 export function recordFeedPaint(
 	perf: PerformanceLike,
 	path: FeedPaintPath,
@@ -106,8 +74,6 @@ export function recordFeedPaint(
 	}
 }
 
-/** `globalThis.performance` when it exposes the User Timing surface, else `null`
- *  (SSR / a test env without it) so callers degrade cleanly. */
 export function globalPerformance(): PerformanceLike | null {
 	const perf = (globalThis as {performance?: Partial<PerformanceLike>}).performance;
 	return perf && typeof perf.mark === "function" && typeof perf.measure === "function"
@@ -115,17 +81,10 @@ export function globalPerformance(): PerformanceLike | null {
 		: null;
 }
 
-/** Latched once the first paint is recorded — later feed re-renders (sort swaps,
- *  pagination) must not re-mark; the epic measures the FIRST paint after reload. */
+// Later re-renders (sort swaps, pagination) must not re-mark: the measure is the FIRST
+// paint after reload.
 let recorded = false;
 
-/**
- * Record the first feed paint exactly once for the tab's lifetime. No-op when the
- * instrument is disabled, already recorded, or `performance` is unavailable. `cacheStatus`
- * refines the no-snapshot case to edge vs cold when a caller can observe the base-feed
- * `cf-cache-status`; it defaults to `null` (the SPA render can't see it → the network-layer
- * methodology distinguishes edge from cold on the GET itself).
- */
 export function markFeedPaintOnce(
 	perf: PerformanceLike | null = globalPerformance(),
 	cacheStatus: CacheStatus = null,
@@ -135,7 +94,7 @@ export function markFeedPaintOnce(
 	return recordFeedPaint(perf, classifyFeedPath({snapshotHydrated, cacheStatus}));
 }
 
-/** Test seam: clear the module-level latches so each test starts from a clean instrument. */
+/** Test seam: clear the module-level latches. */
 export function resetFeedPaintInstrumentation(): void {
 	recorded = false;
 	snapshotHydrated = false;

--- a/apps/web/src/lib/feedPerf.unit.test.ts
+++ b/apps/web/src/lib/feedPerf.unit.test.ts
@@ -12,7 +12,6 @@ import {
 	wasSnapshotHydrated,
 } from "./feedPerf";
 
-/** A recording fake of the `performance` slice this module drives. */
 function fakePerformance(now = 812): PerformanceLike & {
 	marks: Array<{name: string; detail: unknown}>;
 	measures: Array<{name: string; start?: number; end?: number; detail: unknown}>;

--- a/apps/web/src/lib/markdown.tsx
+++ b/apps/web/src/lib/markdown.tsx
@@ -1,9 +1,8 @@
 import type * as React from "react";
 
 /**
- * Bare-bones inline markdown — `code`, **strong** only, intentionally simple. A
- * real markdown renderer (react-markdown + sanitizer) replaces this when content
- * gets richer. Shared by sözlük definition bodies and pano post/comment bodies.
+ * Bare-bones inline markdown — `code` and **strong** only, deliberately. A real
+ * renderer (react-markdown + sanitizer) replaces this when content gets richer.
  */
 export function renderMarkdownInline(src: string): React.ReactNode[] {
 	const out: React.ReactNode[] = [];
@@ -43,11 +42,6 @@ export function renderMarkdownInline(src: string): React.ReactNode[] {
 
 export type MarkdownBlock = {kind: "text"; text: string} | {kind: "code"; text: string};
 
-/**
- * Splits markdown into paragraphs and fenced code blocks. Used for definition
- * bodies on the sözlük term page; pano comment bodies use only the inline
- * helper above (no fenced blocks expected mid-thread).
- */
 export function splitMarkdownBlocks(src: string): MarkdownBlock[] {
 	const blocks: MarkdownBlock[] = [];
 	const fence = /```([\s\S]*?)```/g;

--- a/apps/web/src/lib/panoFeedSort.ts
+++ b/apps/web/src/lib/panoFeedSort.ts
@@ -1,36 +1,21 @@
 /**
- * The pano feed **sort** vocabulary — the single home for the closed set of
- * feed sorts and each sort's lead ordering column.
+ * The pano feed sort vocabulary — one home for the sorts and each sort's lead
+ * ordering column, so SPA/server drift is a type error rather than a silent ship.
  *
- * A plain-string/const module (no React, no worker, no DB import) cross-included
- * by the worker tsconfig, so the SPA chip→sort map (`PanoFeed.tsx`), the resolver
- * allow-list (`lists.ts` `toPostSort`), and the service's two keyset branches
- * (`Pano.ts`) all name the same four sorts and the same per-sort lead column.
- * One home per sort means SPA-vs-server drift — and the service's own
- * keyset-vs-`orderBy` disagreement — is a type error, not a silent ship;
- * mirroring `src/lib/panoTags.ts` / `src/lib/fateWireCodes.ts`.
- *
- * Each sort orders by an optional lead column (always descending) plus an `id`
- * desc tiebreaker; `new` has no lead column (`id` alone). The lead column key
- * names a `post_record` column shared by the cursor row and the Drizzle table,
- * so the service resolves the actual column/cursor-value from this one key —
- * this module stays DB-free so both bundles can import it.
+ * Keep this module free of React, worker and DB imports: the worker tsconfig
+ * cross-includes it, so both bundles have to be able to import it.
  */
 
 export const POST_SORTS = ["hot", "new", "top", "discuss"] as const;
 
-/** A typed feed sort — the resolved, in-enum value (not untyped text). */
 export type PostSort = (typeof POST_SORTS)[number];
 
-/** The default sort, served when an arg is absent or unrecognized. */
 export const DEFAULT_POST_SORT: PostSort = "hot";
 
 /**
- * Each sort's lead ordering column — a `post_record` column name shared by the
- * cursor row and the Drizzle table, or `null` for `new` (ordered by `id` alone).
- * Exhaustive over `PostSort`, so adding a sort without a lead column is a compile
- * error. The service derives BOTH its keyset cursor predicate and its `orderBy`
- * from this one map, so the two can no longer silently disagree.
+ * A `post_record` column name shared by the cursor row and the Drizzle table, or `null`
+ * for `new` (`id` alone). The service derives BOTH its keyset cursor predicate and its
+ * `orderBy` from this one map, so the two cannot silently disagree.
  */
 export const POST_SORT_LEAD_COLUMN: Record<PostSort, "score" | "commentCount" | "hotScore" | null> =
 	{
@@ -42,10 +27,6 @@ export const POST_SORT_LEAD_COLUMN: Record<PostSort, "score" | "commentCount" | 
 
 const ALLOWED: ReadonlySet<string> = new Set(POST_SORTS);
 
-/**
- * Narrow a raw `sort` arg to a {@link PostSort}, falling back to
- * {@link DEFAULT_POST_SORT} for an absent or unrecognized value.
- */
 export function toPostSort(value: string | undefined): PostSort {
 	return value !== undefined && ALLOWED.has(value) ? (value as PostSort) : DEFAULT_POST_SORT;
 }

--- a/apps/web/src/lib/panoNav.ts
+++ b/apps/web/src/lib/panoNav.ts
@@ -1,34 +1,25 @@
 /**
- * Shared pano subnav + routing vocabulary. Every pano feed — the sort subfeeds
- * (sıcak / yeni / en iyi / tartışma) AND kaydedilenler — is one `PanoFeed`
- * variant selected by the deep-linkable `?sort=` param, so there's one feed
- * shape and one routing model rather than a bespoke saved page (#2196; #1641: the
- * saved surface once dropped the whole nav row, stranding the viewer).
+ * Shared pano subnav + routing vocabulary. Every feed — the sort subfeeds AND
+ * kaydedilenler — is one `PanoFeed` variant behind `?sort=`, rather than a bespoke
+ * saved page (#2196; in #1641 the saved surface dropped the nav row and stranded
+ * the viewer).
  *
- * The `?sort=` value is the server `PostSort` (English, per URL-routes-are-English)
- * for a sort subfeed, plus one reserved sentinel `saved` for kaydedilenler — a
- * per-viewer collection with a distinct data source (`savedPosts`), not a `posts`
- * sort. `saved` is deliberately NOT a `PostSort`: it never reaches the feed's
- * `sort` arg, it selects the saved variant instead.
+ * `saved` is deliberately NOT a `PostSort`: it is a reserved sentinel for a
+ * per-viewer collection with its own data source, and never reaches the feed's
+ * `sort` arg.
  */
 import {DEFAULT_POST_SORT, type PostSort} from "./panoFeedSort";
 
-/** The query param that carries the active feed variant (deep-linkable). */
 export const PANO_SORT_PARAM = "sort";
 
-/** The reserved `?sort=` sentinel for the kaydedilenler variant — not a `PostSort`. */
 export const SAVED_PANO_SORT = "saved";
 
-/** The subnav filter id for the kaydedilenler variant. */
 export const SAVED_PANO_FILTER_ID = "kaydedilenler";
 
 /**
- * The feed's first-page size — the single source both the feed request
- * (`PanoFeed`'s `first: PANO_FEED_PAGE_SIZE`) and the loading skeleton
- * (`PanoFeedSkeleton`'s row count) read, so the skeleton reserves the SAME height
- * the arriving page occupies. A skeleton row count that under-counts the payload is
- * the height-mismatch that jumps the footer ~941px on arrival (#2161); sourcing both
- * from here makes that drift unrepresentable.
+ * Read by BOTH the feed request and the loading skeleton's row count, so the skeleton
+ * reserves the height the arriving page occupies. A skeleton that under-counts the
+ * payload is what jumped the footer ~941px on arrival (#2161).
  */
 export const PANO_FEED_PAGE_SIZE = 20;
 
@@ -38,7 +29,6 @@ export interface PanoFilter {
 	sort: PostSort;
 }
 
-/** UI sort labels (Turkish) → server `sort` (the shared `PostSort` vocabulary). */
 export const PANO_FILTERS: PanoFilter[] = [
 	{id: "sicak", label: "sıcak", sort: "hot"},
 	{id: "yeni", label: "yeni", sort: "new"},
@@ -46,22 +36,10 @@ export const PANO_FILTERS: PanoFilter[] = [
 	{id: "tartisma", label: "tartışma", sort: "discuss"},
 ];
 
-/** The chip shown when no (or an unrecognized) `?sort=` is present. */
 export const DEFAULT_PANO_FILTER_ID = "sicak";
 
-/**
- * The active `PanoFeed` variant, resolved from the `?sort=` param: a `sort` subfeed
- * carrying its server `PostSort`, or the per-viewer `saved` collection. Modeling this
- * as a discriminated variant (not a bare filter id) is what lets one feed component
- * branch on the data source while sharing the routing model.
- */
 export type PanoVariant = {kind: "sort"; filterId: string; sort: PostSort} | {kind: "saved"};
 
-/**
- * Resolve the `?sort=` param to the active variant. The reserved `saved` sentinel
- * selects the kaydedilenler variant; any other value maps to a sort subfeed
- * (defaulting when absent/unrecognized).
- */
 export function panoVariantFromParam(param: string | null): PanoVariant {
 	if (param === SAVED_PANO_SORT) return {kind: "saved"};
 	const filter = PANO_FILTERS.find((f) => f.sort === param);
@@ -70,28 +48,16 @@ export function panoVariantFromParam(param: string | null): PanoVariant {
 		: {kind: "sort", filterId: DEFAULT_PANO_FILTER_ID, sort: DEFAULT_POST_SORT};
 }
 
-/** The active subnav filter id for a variant — the sort chip, or the saved chip. */
 export function panoActiveFilterId(variant: PanoVariant): string {
 	return variant.kind === "saved" ? SAVED_PANO_FILTER_ID : variant.filterId;
 }
 
-/**
- * The server `sort` a filter id selects, so a chip switch can write its sort back
- * to the `?sort=` param and keep the URL the source of truth. Defaults when the id
- * is unrecognized.
- */
 export function panoSortFromFilterId(id: string): PostSort {
 	return PANO_FILTERS.find((f) => f.id === id)?.sort ?? DEFAULT_POST_SORT;
 }
 
-/**
- * The `?sort=` value a subnav filter id writes to the URL — a server `PostSort` for
- * a sort chip, the `saved` sentinel for the kaydedilenler chip. One inverse of the
- * param resolution so every chip (including saved) drives the same routing model.
- */
 export function panoSortParamFromFilterId(id: string): string {
 	return id === SAVED_PANO_FILTER_ID ? SAVED_PANO_SORT : panoSortFromFilterId(id);
 }
 
-/** The canonical kaydedilenler URL — the saved variant of the shared feed. */
 export const SAVED_HREF = `/pano?${PANO_SORT_PARAM}=${SAVED_PANO_SORT}`;

--- a/apps/web/src/lib/panoSubmitGate.ts
+++ b/apps/web/src/lib/panoSubmitGate.ts
@@ -1,10 +1,9 @@
 /**
- * The pano submit gate: whether "paylaş" is disabled, and — the reason #2201 fixed —
- * whether the missing tag is the *sole* remaining blocker, so the composer can name that
- * silent requirement inline instead of leaving the button dead with no explanation.
+ * The pano submit gate. `tagsAreSoleBlocker` exists so the composer can name the silent
+ * tag requirement inline instead of leaving the button dead with no explanation (#2201).
  */
 
-/** Field-validity inputs. `titleInvalid` folds empty + below-min into one blocker. */
+/** `titleInvalid` folds empty + below-min into one blocker. */
 export interface PanoSubmitFields {
 	inFlight: boolean;
 	titleInvalid: boolean;
@@ -16,7 +15,6 @@ export interface PanoSubmitFields {
 
 export interface PanoSubmitGate {
 	submitDisabled: boolean;
-	/** True iff no tag is selected AND every other field is valid — the reason to surface inline. */
 	tagsAreSoleBlocker: boolean;
 }
 

--- a/apps/web/src/lib/panoTags.ts
+++ b/apps/web/src/lib/panoTags.ts
@@ -1,31 +1,17 @@
 /**
- * The pano **tag** vocabulary — the single home for the closed set of post
- * tags, their CSS-modifier class, and the legacy English aliases.
+ * The pano tag vocabulary — one home for the kinds, their CSS modifier, and the
+ * legacy English aliases, so SPA/server drift is a type error rather than a silent ship.
  *
- * A plain-string/const module (no React, no worker, no DB import) cross-included
- * by the worker tsconfig, so the server allow-list (`Pano.ts`), the SPA submit
- * form (`PanoSubmitPage.tsx`), and the card renderers (`Tag`) all name the same
- * five kinds and the same kind→class map. One home per kind means SPA-vs-server
- * drift is a type error, not a silent ship — mirroring `src/flags/keys.ts` and
- * `src/lib/fateWireCodes.ts`.
- *
- * Tags are stored verbatim (the Turkish kind) on `post_record.tags` as a CSV;
- * this module changes nothing about that wire/stored shape. The English aliases
- * (`show`/`discuss`/…) are normalization-only: a legacy seed value maps to its
- * Turkish kind for display, and each kind's CSS modifier is its English alias.
+ * Tags are stored verbatim (the Turkish kind) as CSV on `post_record.tags`; the English
+ * aliases are normalization-only, for legacy seed values. Keep this module free of
+ * React, worker and DB imports — the worker tsconfig cross-includes it.
  */
 
-/** The closed set of post-tag kinds, stored verbatim on `post_record.tags`. */
 export const POST_TAG_KINDS = ["göster", "tartışma", "soru", "söylenme", "meta"] as const;
 
-/** A typed post-tag kind — the resolved, in-enum value (not untyped text). */
 export type PostTagKind = (typeof POST_TAG_KINDS)[number];
 
-/**
- * Each kind's CSS modifier class (`kp-tag--<cls>`) — the English alias doubling
- * as the styling key. Exhaustive over `PostTagKind`, so adding a kind without a
- * class is a compile error.
- */
+/** `kp-tag--<cls>` — the English alias doubles as the styling key. */
 export const POST_TAG_CLASS: Record<PostTagKind, string> = {
 	göster: "show",
 	tartışma: "discuss",
@@ -34,11 +20,7 @@ export const POST_TAG_CLASS: Record<PostTagKind, string> = {
 	meta: "meta",
 };
 
-/**
- * Legacy English aliases that may exist in seed data, mapped to their canonical
- * Turkish kind. The canonical kinds map to themselves so label resolution is one
- * lookup. Adding a kind without an alias row is a compile error.
- */
+/** The canonical kinds map to themselves so label resolution stays one lookup. */
 const TAG_ALIASES: Record<PostTagKind, PostTagKind> & Record<string, PostTagKind> = {
 	göster: "göster",
 	tartışma: "tartışma",
@@ -53,23 +35,16 @@ const TAG_ALIASES: Record<PostTagKind, PostTagKind> & Record<string, PostTagKind
 
 const ALLOWED: ReadonlySet<string> = new Set(POST_TAG_KINDS);
 
-/** Whether a raw string is one of the five canonical (Turkish) kinds. */
 export function isPostTagKind(kind: string): kind is PostTagKind {
 	return ALLOWED.has(kind);
 }
 
-/**
- * Display label for a stored kind. Resolves a legacy English alias to its
- * Turkish kind; an unknown kind falls back to its raw value so it still renders.
- */
+/** An unknown kind falls back to its raw value so it still renders. */
 export function tagLabel(kind: string): string {
 	return TAG_ALIASES[kind] ?? kind;
 }
 
-/**
- * CSS-modifier class for a stored kind (`göster` → `show`). Resolves legacy
- * aliases first; an unknown kind falls back to `meta` (the neutral styling).
- */
+/** An unknown kind falls back to `meta`, the neutral styling. */
 export function tagClass(kind: string): string {
 	const resolved = TAG_ALIASES[kind];
 	return resolved ? POST_TAG_CLASS[resolved] : "meta";

--- a/apps/web/src/lib/returnTo.ts
+++ b/apps/web/src/lib/returnTo.ts
@@ -1,19 +1,11 @@
 import {useCallback} from "react";
 import {useLocation, useNavigate} from "react-router";
 
-/**
- * Build a `/auth?returnTo=<encoded-path>` URL so a signed-out user returns to
- * the exact same view after sign-in. Hash is dropped — Better Auth's redirect
- * strips it anyway.
- */
+/** The hash is dropped because Better Auth's redirect strips it anyway. */
 export function authRedirectPath(returnTo: string): string {
 	return `/auth?returnTo=${encodeURIComponent(returnTo)}`;
 }
 
-/**
- * Returns `{redirectToAuth}`: routes the signed-out user to the auth page
- * carrying the current path as `returnTo`.
- */
 export function useReturnToAuth(): {redirectToAuth: () => void} {
 	const navigate = useNavigate();
 	const location = useLocation();
@@ -25,9 +17,8 @@ export function useReturnToAuth(): {redirectToAuth: () => void} {
 }
 
 /**
- * Sanitize a returnTo value before navigating. Only same-origin paths are
- * allowed — anything that doesn't start with `/` (or starts with `//`, which
- * is protocol-relative and could land off-site) falls back to `/`.
+ * Open-redirect guard: only same-origin paths pass. `//` is rejected too — it is
+ * protocol-relative and would land off-site.
  */
 export function safeReturnTo(value: string | null | undefined): string {
 	if (!value) return "/";

--- a/apps/web/src/lib/searchShortcut.ts
+++ b/apps/web/src/lib/searchShortcut.ts
@@ -1,11 +1,7 @@
 /**
- * The ⌘/Ctrl+K "ara" shortcut the Topbar advertises with its `<kbd>⌘K</kbd>` hint.
- * Browsers bind ⌘/Ctrl+K to the address bar, so focusing the search input needs this
- * handler to back it — keep the predicate and its Topbar wiring together so the hint
- * and its implementation can't drift apart and leave a dead label again.
+ * Browsers bind ⌘/Ctrl+K to the address bar, so the Topbar's `<kbd>⌘K</kbd>` hint is a
+ * dead label unless this predicate backs it. Keep the two together.
  */
-
-/** Pure predicate: is this a ⌘+K (mac) / Ctrl+K (elsewhere) keystroke? */
 export function isSearchShortcut(e: {key: string; metaKey: boolean; ctrlKey: boolean}): boolean {
 	return (e.metaKey || e.ctrlKey) && e.key.toLowerCase() === "k";
 }

--- a/apps/web/src/lib/searchTarget.test.ts
+++ b/apps/web/src/lib/searchTarget.test.ts
@@ -20,7 +20,6 @@ describe("searchTarget", () => {
 
 	it("returns null for a single-char query (below the 2-char minimum, ADR 0080)", () => {
 		expect(searchTarget("a")).toBeNull();
-		// a query that trims down to one char is also below the floor
 		expect(searchTarget("  x ")).toBeNull();
 	});
 

--- a/apps/web/src/lib/searchTarget.ts
+++ b/apps/web/src/lib/searchTarget.ts
@@ -1,11 +1,6 @@
 /**
- * Build the `/search?q=…` target for a top-bar search submit, or `null` when the
- * query shouldn't navigate. The Topbar's submit handler routes to this and only
- * navigates on a non-null result, so a bare Enter (empty/whitespace) stays put.
- *
- * Below the backend's 2-char minimum (ADR 0080) there's nothing to resolve — the
- * results page would only render its "en az 2 harf" prompt — so a sub-minimum query
- * is a no-op (`null`) rather than a navigation to an empty/dead search.
+ * `null` means "do not navigate": a bare Enter stays put, and a query below the
+ * backend's 2-char minimum (ADR 0080) would only reach a dead results page.
  */
 
 const MIN_QUERY_LENGTH = 2;

--- a/apps/web/src/lib/sentry.ts
+++ b/apps/web/src/lib/sentry.ts
@@ -1,40 +1,26 @@
 /**
- * SPA-side Sentry wiring (ADR 0118). The browser tier is the decisive gap CF-native
- * Workers Observability (#1222) structurally cannot see — SPA crashes that today
- * `console.error` and vanish at the `Screen.tsx` boundary. This captures them, but
- * stays INERT until a DSN is provisioned: an absent/empty DSN skips `init` entirely,
- * so nothing is sent and nothing throws. The maintainer provisions the Sentry account
- * + DSN later (the same parked-on-external-provisioning pattern ADR 0118 names).
+ * SPA-side Sentry wiring — see ADR 0118 for the why and the decided defaults.
  *
- * A Sentry DSN is a public, client-side value, so the SPA reads it from a build-time
- * Vite env var (`VITE_SENTRY_DSN`) baked into the bundle — distinct from the worker's
- * `SENTRY_DSN` secret_text binding. The EU data region is realized by the ingest host
- * the provisioned DSN points at; the decided defaults (EU region, PII scrub) are ADR
- * 0118's and adjustable there.
+ * Ships INERT: with no DSN provisioned, nothing inits, nothing sends, nothing throws.
+ * The DSN is a public value read from the build-time `VITE_SENTRY_DSN`, deliberately
+ * NOT the worker's `SENTRY_DSN` secret binding.
  */
 import * as Sentry from "@sentry/react";
 import {flagTag} from "../../worker/features/flagship/flag-tag";
 
-// The `flag.<key>`:`on`/`off` naming contract now lives in one SDK-free module shared with the
-// worker tagger (`worker/lib/sentry.ts`), so both tiers stamp an identical shape and the #1822
-// graduation query reads uniformly across client + worker — see `flag-tag.ts` for the why (#1821).
+// Re-exported from the SDK-free module the worker tagger also uses, so both tiers stamp an
+// identical `flag.<key>` shape and one graduation query reads across them (#1821).
 export {FLAG_TAG_PREFIX, flagTag} from "../../worker/features/flagship/flag-tag";
 
-/**
- * Whether a usable DSN is present — the single gate every Sentry path checks, so the
- * integration is provably inert when unset (no init, no capture, no network, no throw).
- */
+/** The single gate every Sentry path checks, so the integration is provably inert when unset. */
 export function sentryEnabled(dsn: string | undefined): dsn is string {
 	return typeof dsn === "string" && dsn.trim().length > 0;
 }
 
 /**
- * The decided client options (ADR 0118): pure native `dataCollection` (SDK ≥10.57,
- * the granular successor to the removed `sendDefaultPii`), no `beforeSend`. It
- * suppresses the cookies/headers/user/`query_string` PII. Query strings carry no
- * GDPR-PII in this app (only short-lived auth/OAuth tokens, caught by Sentry's
- * server-side default data-scrubbing by field name), so no client-side URL scrub is
- * needed — server-side Advanced Data Scrubbing is the backstop.
+ * The decided options (ADR 0118): native `dataCollection`, no `beforeSend`. The missing
+ * client-side URL scrub is deliberate — query strings here carry no GDPR-PII, and
+ * server-side Advanced Data Scrubbing is the backstop.
  */
 export function browserOptions(dsn: string): Sentry.BrowserOptions {
 	return {
@@ -50,7 +36,6 @@ export function browserOptions(dsn: string): Sentry.BrowserOptions {
 
 const dsn = import.meta.env.VITE_SENTRY_DSN;
 
-/** Initialize Sentry for the SPA — a no-op when no DSN is provisioned (inert). */
 export function initSentry(): void {
 	if (!sentryEnabled(dsn)) {
 		return;
@@ -58,10 +43,6 @@ export function initSentry(): void {
 	Sentry.init(browserOptions(dsn));
 }
 
-/**
- * Forward an error-boundary catch to Sentry. No-ops when inert, so the boundary's own
- * `console.error` stays the only effect until a DSN is set.
- */
 export function captureBoundaryError(error: unknown, componentStack?: string | null): void {
 	if (!sentryEnabled(dsn)) {
 		return;
@@ -72,11 +53,7 @@ export function captureBoundaryError(error: unknown, componentStack?: string | n
 	);
 }
 
-/**
- * Record a resolved flag on the global Sentry scope so subsequently-captured errors carry its
- * state as a queryable `flag.<key>` tag (#1821). No-ops when inert (no DSN) — no scope mutation,
- * no network, mirroring init/capture — so tagging adds nothing while Sentry is off.
- */
+/** Puts a resolved flag on the global scope so later captures carry it as `flag.<key>` (#1821). */
 export function tagFlag(key: string, value: boolean): void {
 	if (!sentryEnabled(dsn)) {
 		return;

--- a/apps/web/src/lib/sentry.unit.test.ts
+++ b/apps/web/src/lib/sentry.unit.test.ts
@@ -1,11 +1,4 @@
-/**
- * Pins ADR 0118's load-bearing invariant: the SPA Sentry wiring ships INERT. With no
- * `VITE_SENTRY_DSN`, `initSentry`/`captureBoundaryError` never touch `@sentry/react` and
- * never throw — the integration activates only once the maintainer provisions a DSN. The
- * inert block stubs the DSN empty and imports `./sentry` fresh so the invariant is proven
- * deterministically, independent of a developer's local `apps/web/.env` (#1661). Also pins
- * the DSN gate and the native-`dataCollection` shape.
- */
+/** Pins ADR 0118's invariant: with no `VITE_SENTRY_DSN`, the SPA Sentry wiring is inert. */
 import {afterEach, describe, expect, it, vi} from "vitest";
 
 const {init, captureException, setTag} = vi.hoisted(() => ({
@@ -15,14 +8,12 @@ const {init, captureException, setTag} = vi.hoisted(() => ({
 }));
 vi.mock("@sentry/react", () => ({init, captureException, setTag}));
 
-// The inert block imports `initSentry`/`captureBoundaryError`/`tagFlag` dynamically (after stubbing
-// the DSN), so only the DSN-independent helpers are imported statically here.
+// Only the DSN-independent helpers can be imported statically — see `loadInert` below.
 import {browserOptions, flagTag, sentryEnabled} from "./sentry";
 
 afterEach(() => {
 	vi.clearAllMocks();
-	// The inert block stubs VITE_SENTRY_DSN and resets the module registry; restore both so
-	// neither leaks into sibling tests.
+	// The DSN stub and the module-registry reset must not leak into sibling tests.
 	vi.unstubAllEnvs();
 	vi.resetModules();
 });
@@ -40,11 +31,9 @@ describe("sentryEnabled — the inert gate", () => {
 });
 
 describe("inert without a DSN (the whole point of ADR 0118's parked-provisioning ship)", () => {
-	// `sentry.ts` binds `const dsn = import.meta.env.VITE_SENTRY_DSN` at MODULE LOAD, so the
-	// static top-of-file import binds `dsn` to whatever ambient `.env` supplies — a provisioned
-	// local DSN (#1656) would defeat the invariant. Stub the DSN empty, drop the module cache,
-	// and re-import so the fresh evaluation reads the empty stub — proving the gate is inert
-	// BECAUSE it saw no DSN, deterministically regardless of `apps/web/.env` (#1661).
+	// `sentry.ts` binds its `dsn` at MODULE LOAD, so a statically-imported copy would carry
+	// whatever a developer's local `.env` supplies and defeat the invariant (#1656). Stubbing
+	// empty + dropping the module cache proves the gate is inert BECAUSE it saw no DSN (#1661).
 	const loadInert = async () => {
 		vi.stubEnv("VITE_SENTRY_DSN", "");
 		vi.resetModules();
@@ -71,7 +60,6 @@ describe("inert without a DSN (the whole point of ADR 0118's parked-provisioning
 });
 
 describe("flag attribution — the tag-naming contract (#1821)", () => {
-	// The DSN-independent naming: `flag.<key>` = `on|off`, so a graduation query is `flag.<key>:on`.
 	it("flagTag maps a resolved flag to a queryable flag.<key> tag", () => {
 		expect(flagTag("phoenix-bildirim", true)).toEqual({
 			tagKey: "flag.phoenix-bildirim",
@@ -83,8 +71,7 @@ describe("flag attribution — the tag-naming contract (#1821)", () => {
 		});
 	});
 
-	// With a DSN, a resolved flag lands on the global Sentry scope as a queryable tag. The loader
-	// stubs a real DSN + re-imports so `tagFlag` reads the enabled gate (mirrors `loadInert`).
+	// Mirrors `loadInert`, with a real DSN so `tagFlag` reads the enabled gate.
 	const loadEnabled = async () => {
 		vi.stubEnv("VITE_SENTRY_DSN", "https://abc@o0.ingest.de.sentry.io/1");
 		vi.resetModules();
@@ -104,8 +91,6 @@ describe("decided defaults (ADR 0118)", () => {
 	it("browserOptions is pure native dataCollection with no beforeSend", () => {
 		const opts = browserOptions("https://abc@o0.ingest.de.sentry.io/1");
 		expect(opts.dsn).toBe("https://abc@o0.ingest.de.sentry.io/1");
-		// dataCollection is the whole story; the deprecated `sendDefaultPii` is gone,
-		// and no hand-rolled `beforeSend` scrub remains (server-side scrubbing is the backstop).
 		expect(opts.sendDefaultPii).toBeUndefined();
 		expect(opts.dataCollection).toEqual({
 			userInfo: false,

--- a/apps/web/src/lib/slugifyTerm.ts
+++ b/apps/web/src/lib/slugifyTerm.ts
@@ -1,10 +1,7 @@
 /**
- * Slugify a free-text term into the kebab-case slug the sözlük URL/`/sozluk/:slug`
- * route uses. There is no server-side slugifier — a term's slug is whatever lands
- * in the URL, and the existing corpus is lowercase, ASCII-folded, hyphen-joined
- * (`önbellek` → `onbellek`, `yatay ölçekleme` → `yatay-olcekleme`).
- * The create affordance routes to `/sozluk/<slugifyTerm(query)>` so a user-typed
- * term reaches the existing fresh-slug composer with a slug shaped like its peers.
+ * There is no server-side slugifier — a term's slug is whatever lands in the URL. This
+ * matches the existing corpus (lowercase, Turkish folded to ASCII, hyphen-joined) so a
+ * user-typed term reaches a slug shaped like its peers.
  */
 
 const TURKISH_FOLD: Record<string, string> = {

--- a/apps/web/src/lib/sozlukLetterHref.ts
+++ b/apps/web/src/lib/sozlukLetterHref.ts
@@ -1,9 +1,5 @@
-/**
- * The per-letter sözlük index URL: `/sozluk?harf=<letter>` (canonical query-param
- * route like `/search?q=`). A letter that is already active links back to the bare
- * `/sozluk` so the active letter still toggles its filter off — now as a real,
- * shareable navigation rather than client-only state.
- */
+/** An active letter links back to bare `/sozluk` so the filter toggles off by navigation,
+ *  keeping the URL shareable instead of holding the filter in client-only state. */
 export function sozlukLetterHref(letter: string, isActive: boolean): string {
 	return isActive ? "/sozluk" : `/sozluk?harf=${encodeURIComponent(letter)}`;
 }

--- a/apps/web/src/lib/sozlukPageEmptyLabel.test.ts
+++ b/apps/web/src/lib/sozlukPageEmptyLabel.test.ts
@@ -3,8 +3,6 @@ import {sozlukPageEmptyLabel} from "./sozlukPageEmptyLabel";
 
 describe("sozlukPageEmptyLabel", () => {
 	it("scopes a letter-filter miss to the loaded first page, never the corpus", () => {
-		// The invariant: the copy must NOT assert "<letter> harfinde terim yok" as a fact
-		// about the whole corpus — it must name the "ilk sayfada" (first-page) scope.
 		const label = sozlukPageEmptyLabel("k");
 		expect(label).toContain("ilk sayfada");
 		expect(label).not.toBe('"k" harfinde terim yok.');

--- a/apps/web/src/lib/sozlukPageEmptyLabel.ts
+++ b/apps/web/src/lib/sozlukPageEmptyLabel.ts
@@ -1,11 +1,7 @@
 /**
- * The honest empty-state copy for a sözlük-home column whose client-side letter filter
- * excluded every already-loaded row. That filter runs over the loaded FIRST PAGE only
- * (`HOME_PAGE_SIZE`), never the whole corpus — so the copy must name that scope
- * ("ilk sayfada"), and must never assert "<letter> harfinde terim yok" as a fact about
- * the corpus. The old copy was the alphabet-filter lie: a user who filters "k" over five
- * loaded rows and reads "k harfinde terim yok" may sit atop fifty un-loaded k-terms
- * (#1669; DESIGN-AUDIT "the alphabet/search filter lies" finding).
+ * The letter filter runs over the loaded FIRST PAGE only, never the corpus, so this copy
+ * must name that scope ("ilk sayfada") and must never say "<letter> harfinde terim yok" —
+ * a reader filtering "k" over five loaded rows may sit atop fifty un-loaded k-terms (#1669).
  */
 export function sozlukPageEmptyLabel(letter: string | undefined): string {
 	if (letter) return `"${letter}" harfiyle başlayan terim ilk sayfada yok.`;

--- a/apps/web/src/lib/submitShortcut.ts
+++ b/apps/web/src/lib/submitShortcut.ts
@@ -1,23 +1,17 @@
 /**
- * The ⌘/Ctrl+Enter "gönder" shortcut every markdown composer advertises in its
- * footer hint. A multiline text field does not submit its form on ⌘/Ctrl+Enter natively,
- * so the hint needs this handler to back it — keep the two together so the
- * affordance and its implementation can't drift apart again.
+ * A textarea does not submit its form on ⌘/Ctrl+Enter natively, so the composer's footer
+ * hint is a dead label unless this backs it. Keep the two together.
  */
 import type {KeyboardEvent} from "react";
 
-/** Pure predicate: is this a ⌘+Enter (mac) / Ctrl+Enter (elsewhere) keystroke? */
 export function isSubmitShortcut(e: {key: string; metaKey: boolean; ctrlKey: boolean}): boolean {
 	return (e.metaKey || e.ctrlKey) && e.key === "Enter";
 }
 
 /**
- * `onKeyDown` for a composer textarea: ⌘/Ctrl+Enter calls `requestSubmit()` so the
- * keystroke goes through the form's `onSubmit` (validation + in-flight guard) exactly
- * like clicking the submit button. Plain Enter falls through to the textarea's native
- * newline. `requestSubmit()` is no double-submit guard on its own, so the form's
- * `onSubmit` owns the in-flight check; the textarea is also `disabled` while in flight,
- * which stops the keystroke from reaching here at all.
+ * `requestSubmit()` routes through the form's `onSubmit` so validation and the in-flight
+ * guard run exactly as on a button click. It is no double-submit guard on its own: the
+ * form's `onSubmit` owns that check.
  */
 export function submitOnCmdEnter(e: KeyboardEvent<HTMLTextAreaElement>): void {
 	if (!isSubmitShortcut(e)) return;

--- a/apps/web/src/lib/theme.test.tsx
+++ b/apps/web/src/lib/theme.test.tsx
@@ -7,9 +7,8 @@ function Probe() {
 	return <div data-testid="probe" data-choice={choice} data-resolved={resolved} />;
 }
 
-// jsdom ships no matchMedia, so stub one whose `(prefers-color-scheme: light)` match is
-// driven by `prefersLight` — this is what lets an `auto` choice resolve to a *system*
-// value under test rather than systemPrefers()'s dark fallback.
+// jsdom ships no matchMedia; without this stub an `auto` choice resolves to
+// systemPrefers()'s dark fallback instead of a system value.
 function mockMatchMedia(prefersLight: boolean) {
 	vi.stubGlobal("matchMedia", (query: string) => ({
 		matches: query.includes("light") ? prefersLight : !prefersLight,
@@ -29,7 +28,6 @@ describe("theme default resolution (#2612)", () => {
 	});
 
 	it("a first-visit user with no stored choice defaults to auto → the system preference", () => {
-		// No storage is written in this env, so the provider takes its DEFAULT_CHOICE.
 		mockMatchMedia(true); // system prefers light
 		render(
 			<ThemeProvider>

--- a/apps/web/src/lib/theme.tsx
+++ b/apps/web/src/lib/theme.tsx
@@ -13,7 +13,6 @@ function browserStorage(): Storage | undefined {
 }
 
 interface ThemeContextValue {
-	/** The user's selection — the single source of truth both controls drive. */
 	choice: ThemeChoice;
 	/** `choice` with `auto` collapsed to what the system currently prefers. */
 	resolved: ResolvedTheme;
@@ -41,16 +40,13 @@ export function ThemeProvider({children}: {children: React.ReactNode}) {
 	);
 	const [system, setSystem] = React.useState<ResolvedTheme>(systemPrefers);
 
-	// Every choice change persists, so a reload rehydrates it (#697). Both the
-	// explicit picker and `toggle` route through here.
 	const setChoice = React.useCallback((next: ThemeChoice) => {
 		writeStoredChoice(browserStorage(), next);
 		setChoiceState(next);
 	}, []);
 
-	// Track the system preference only while it can actually affect the document
-	// — i.e. while the choice is `auto`. The listener is also what makes an `auto`
-	// page repaint when the OS flips light/dark out from under it.
+	// Subscribed only while the choice is `auto` — that is also what repaints the page
+	// when the OS flips light/dark out from under it.
 	React.useEffect(() => {
 		if (choice !== "auto" || typeof window === "undefined" || !window.matchMedia) return;
 		const mq = window.matchMedia(SYSTEM_LIGHT);
@@ -62,8 +58,8 @@ export function ThemeProvider({children}: {children: React.ReactNode}) {
 
 	const resolved = resolve(choice, system);
 
-	// The DOM is the render target: tokens.css keys every color off
-	// [data-theme="light"|"dark"], so the resolved (never `auto`) value lands here.
+	// tokens.css keys every color off [data-theme], so the resolved (never `auto`) value
+	// has to land on the document root.
 	React.useEffect(() => {
 		document.documentElement.dataset.theme = resolved;
 	}, [resolved]);

--- a/apps/web/src/lib/themeStorage.ts
+++ b/apps/web/src/lib/themeStorage.ts
@@ -8,7 +8,6 @@ function isThemeChoice(value: string | null): value is ThemeChoice {
 	return value !== null && VALID.has(value);
 }
 
-/** Read the persisted choice, falling back to `fallback` for missing/garbage/unavailable storage. */
 export function readStoredChoice(storage: Storage | undefined, fallback: ThemeChoice): ThemeChoice {
 	if (!storage) return fallback;
 	try {
@@ -19,7 +18,6 @@ export function readStoredChoice(storage: Storage | undefined, fallback: ThemeCh
 	}
 }
 
-/** Persist the choice. A throwing/unavailable storage (private mode, quota) is swallowed. */
 export function writeStoredChoice(storage: Storage | undefined, choice: ThemeChoice): void {
 	if (!storage) return;
 	try {

--- a/apps/web/src/lib/useDraftAutosave.ts
+++ b/apps/web/src/lib/useDraftAutosave.ts
@@ -1,7 +1,6 @@
 import * as React from "react";
 import {clearDraft, readDraft, writeDraft} from "./draftStorage";
 
-/** `window.localStorage`, or `undefined` when it's unavailable (SSR, private mode, blocked). */
 function browserStorage(): Storage | undefined {
 	try {
 		return typeof window !== "undefined" ? window.localStorage : undefined;
@@ -11,34 +10,29 @@ function browserStorage(): Storage | undefined {
 }
 
 export interface DraftAutosave<T> {
-	/** A draft found in storage at mount — the one carried across the auth round-trip — or `null`. Offer it, never silently re-inject it. */
+	/** A draft found at mount. Offer it, never silently re-inject it. */
 	readonly offered: T | null;
-	/** Accept the offer: hide the affordance. The value is now in the form, so autosave keeps persisting it. */
+	/** Accept the offer: hide the affordance. Autosave keeps persisting the value. */
 	readonly accept: () => void;
-	/** Discard the offer: drop the persisted draft and hide the affordance. */
 	readonly dismiss: () => void;
-	/** Clear the persisted draft — call on a successful submit. */
+	/** Call on a successful submit. */
 	readonly clear: () => void;
 }
 
 export interface UseDraftAutosaveArgs<T> {
-	/** The route the draft is keyed by — the same path used as `returnTo` in the auth redirect. */
+	/** Keys the draft — the same path used as `returnTo` in the auth redirect. */
 	route: string;
-	/** The current form value, autosaved as it changes. Memoize it so autosave fires only on real edits. */
+	/** Memoize this, or autosave fires on every render rather than on real edits. */
 	value: T;
-	/** Whether `value` is empty — an empty value is never persisted and never offered. */
 	isEmpty: (value: T) => boolean;
-	/** Type guard for a stored payload — a shape mismatch is treated as no draft. */
 	isValid: (value: unknown) => value is T;
-	/** Injectable for tests; defaults to `window.localStorage`. */
 	storage?: Storage | undefined;
 }
 
 /**
- * Autosave in-progress writing to localStorage keyed by route and offer it back after
- * the auth round-trip. The offer is captured ONCE at mount (the draft from before the
- * redirect); autosave only ever *writes* non-empty values, so a fresh empty mount can't
- * clobber that captured draft — clearing is the explicit submit/dismiss act alone.
+ * Autosave keyed by route, offered back after the auth round-trip. The offer is captured
+ * ONCE at mount, and autosave only ever writes non-empty values, so a fresh empty mount
+ * cannot clobber it — clearing is the explicit submit/dismiss act alone.
  */
 export function useDraftAutosave<T>({
 	route,
@@ -53,8 +47,8 @@ export function useDraftAutosave<T>({
 	});
 
 	React.useEffect(() => {
-		// Persist only non-empty writing: never clobber the captured offer on a fresh
-		// (empty) mount, and never clear here — clearing belongs to submit/dismiss.
+		// Never clear here, and never write an empty value: that would clobber the
+		// captured offer on a fresh mount. Clearing belongs to submit/dismiss.
 		if (!isEmpty(value)) writeDraft(storage, route, value);
 	}, [storage, route, value, isEmpty]);
 

--- a/apps/web/src/lib/useLinkMetadata.ts
+++ b/apps/web/src/lib/useLinkMetadata.ts
@@ -1,16 +1,9 @@
 /**
- * `useLinkMetadata()` (#1642) — the one shared implementation both pano submit
- * surfaces (`PanoSubmitPage`, `PanoCreateDialog`) use to prefill `title`/`body`
- * from a pasted link's page metadata. The hook owns the network edge — URL
- * validation, aborting an in-flight request when the URL changes, and the
- * safe-default parse — so neither surface hand-rolls a second copy.
+ * Link-metadata prefill for both pano submit surfaces (#1642).
  *
- * Safe-default, always: an invalid URL or any fetch failure resolves to `{}`
- * (the hook never throws), so prefill is best-effort and can only ever leave
- * the form untouched. The prefill *policy* — write a field ONLY when it is
- * still empty/untouched, so user input is never clobbered — is the pure
- * {@link prefillIfEmpty} helper, shared by both surfaces so the "never
- * overwrite" guarantee has a single definition.
+ * Safe-default, always: an invalid URL or any fetch failure resolves to `{}` and the hook
+ * never throws, so a prefill can only ever leave the form untouched. The "never clobber
+ * user input" rule itself is {@link prefillIfEmpty}, so both surfaces share one definition.
  */
 import {useCallback, useEffect, useRef, useState} from "react";
 import {
@@ -20,12 +13,11 @@ import {
 
 export type {LinkMetadata};
 
-/** Longest prefilled value we write — keeps a prefill within the title bound and editable. */
+/** Keeps a prefill within the title bound and editable. */
 export const PREFILL_MAX_LEN = 200;
 
 const EMPTY: LinkMetadata = {};
 
-/** A well-formed `http(s)` URL — the only shape worth asking the worker to fetch. */
 function isFetchableUrl(url: string): boolean {
 	try {
 		const parsed = new URL(url.trim());
@@ -35,12 +27,7 @@ function isFetchableUrl(url: string): boolean {
 	}
 }
 
-/**
- * Apply `value` to a field via `set` ONLY when the field is still empty/untouched
- * (`current` is blank after trim). This is the "never clobber user input" rule,
- * shared by both submit surfaces. Values are clamped to {@link PREFILL_MAX_LEN}
- * so a prefill stays within the title bound and fully editable.
- */
+/** The "never clobber user input" rule: write only into a field still blank after trim. */
 export function prefillIfEmpty(
 	current: string,
 	value: string | undefined,
@@ -52,9 +39,8 @@ export function prefillIfEmpty(
 }
 
 export interface UseLinkMetadata {
-	/** `true` while a metadata request is in flight. */
 	readonly loading: boolean;
-	/** Fetch metadata for `url`; resolves `{}` on an invalid URL or any failure. */
+	/** Resolves `{}` on an invalid URL or any failure — never rejects. */
 	readonly fetchMetadata: (url: string) => Promise<LinkMetadata>;
 }
 
@@ -62,7 +48,6 @@ export function useLinkMetadata(): UseLinkMetadata {
 	const [loading, setLoading] = useState(false);
 	const abortRef = useRef<AbortController | null>(null);
 
-	// Abort any still-in-flight request on unmount.
 	useEffect(() => () => abortRef.current?.abort(), []);
 
 	const fetchMetadata = useCallback(async (url: string): Promise<LinkMetadata> => {

--- a/apps/web/src/lib/useLinkMetadata.unit.test.ts
+++ b/apps/web/src/lib/useLinkMetadata.unit.test.ts
@@ -1,9 +1,3 @@
-/**
- * The shared prefill policy (#1642): `prefillIfEmpty` is the single definition
- * of "write a form field ONLY when it is still empty/untouched", used by both
- * pano submit surfaces so neither can clobber user input. Tested pure, without a
- * DOM.
- */
 import {describe, expect, it, vi} from "vitest";
 import {PREFILL_MAX_LEN, prefillIfEmpty} from "./useLinkMetadata";
 

--- a/apps/web/src/main.tsx
+++ b/apps/web/src/main.tsx
@@ -12,10 +12,8 @@ initSentry();
 const root = document.getElementById("root");
 if (!root) throw new Error("#root not found");
 
-// FateProvider is no longer at the app root: its `session.isPending → null` remount
-// guard (#438) would blank the entire static shell on every cold load (#2160). It now
-// wraps only the fate-consuming subtree (the routed content + auth-dependent topbar
-// chips) inside the shell frame in App.tsx, so the shell paints on the first frame.
+// Deliberately no FateProvider here: its `session.isPending → null` guard (#438) would blank
+// the whole shell on every cold load, so it wraps only the fate-consuming subtree in App.tsx (#2160).
 createRoot(root).render(
 	<StrictMode>
 		<BrowserRouter>

--- a/apps/web/src/pages/AuthPage.test.tsx
+++ b/apps/web/src/pages/AuthPage.test.tsx
@@ -1,9 +1,6 @@
 /**
- * The signup→setUsername path (#1888). The reported bug: a chosen handle is
- * silently dropped when the post-signup `setUsername` fails, because the session is
- * already established and the redirect buries the failure. These pin the fix — a
- * failure parks on a visible, retryable surface and holds the redirect gate; a
- * success releases it; the chosen handle is never swallowed.
+ * #1888: a chosen handle was silently dropped when the post-signup `setUsername` failed,
+ * because the session already existed and the redirect buried the failure.
  */
 import {fireEvent, render, screen, waitFor} from "@testing-library/react";
 import type {ReactNode} from "react";
@@ -30,8 +27,6 @@ function makeWrapper(setUsername: ReturnType<typeof vi.fn>) {
 	};
 }
 
-// A probe that surfaces the module-level redirect gate into the DOM so a test can
-// assert whether the Layout redirect would be held.
 function GateProbe() {
 	return <span data-testid="gate">{useUsernameResolutionPending() ? "held" : "clear"}</span>;
 }
@@ -77,12 +72,9 @@ describe("AuthPage — signup→setUsername (#1888)", () => {
 		fireEvent.submit(screen.getByRole("button", {name: "hesap aç"}).closest("form")!);
 
 		await waitFor(() => expect(setUsername).toHaveBeenCalledTimes(1));
-		// The failure is visible, not swallowed: the blocking retry surface renders,
-		// naming the chosen handle. (getByText throws if absent — presence is the assert.)
+		// getByText throws if absent — presence is the assert.
 		await waitFor(() => screen.getByText("kullanıcı adı ayarlanamadı"));
 		expect(screen.getByText("elif-kaya")).toBeTruthy();
-		// And the redirect gate is HELD, so the Layout can't carry the user off /auth
-		// into the email-prefill bootstrap while the chosen handle is unresolved.
 		expect(screen.getByTestId("gate").textContent).toBe("held");
 	});
 
@@ -99,7 +91,6 @@ describe("AuthPage — signup→setUsername (#1888)", () => {
 
 		fireEvent.click(screen.getByRole("button", {name: "tekrar dene"}));
 		await waitFor(() => expect(setUsername).toHaveBeenCalledTimes(2));
-		// Handle landed → gate released → the Layout redirect proceeds.
 		await waitFor(() => expect(screen.getByTestId("gate").textContent).toBe("clear"));
 	});
 
@@ -134,8 +125,7 @@ describe("AuthPage — signup→setUsername (#1888)", () => {
 		const setUsername = vi.fn(async () => ({error: null}));
 		renderAuth(setUsername);
 		switchToSignUp();
-		// noValidate → the browser suppresses its English constraint bubble, so an empty
-		// submit reaches onSubmit and the Turkish field message surfaces instead.
+		// `noValidate` is what lets an empty submit reach onSubmit at all.
 		fireEvent.submit(screen.getByRole("button", {name: "hesap aç"}).closest("form")!);
 		await waitFor(() => screen.getByText("görünen ad gerekli"));
 		expect(signUpEmail).not.toHaveBeenCalled();

--- a/apps/web/src/pages/AuthPage.tsx
+++ b/apps/web/src/pages/AuthPage.tsx
@@ -11,7 +11,6 @@ import "./AuthPage.css";
 
 type Mode = "sign-in" | "sign-up";
 
-/** The `User` write-back selection for the post-signup `setUsername` call. */
 const SetUsernameView = view<User>()({
 	id: true,
 	email: true,
@@ -28,17 +27,15 @@ export function AuthPage() {
 	const [mode, setMode] = useState<Mode>("sign-in");
 	const [error, setError] = useState<string | null>(null);
 	const [pending, setPending] = useState(false);
-	// #1888: the chosen handle whose post-signup `setUsername` failed. Non-null ⇒
-	// the account exists but the handle didn't land — render the blocking retry
-	// surface and keep the redirect gate latched until it resolves or is abandoned.
+	// Non-null ⇒ the account exists but the chosen handle didn't land; the redirect gate
+	// stays latched until it resolves or is abandoned (#1888).
 	const [stuckUsername, setStuckUsername] = useState<string | null>(null);
 	const isSignIn = mode === "sign-in";
 	const fate = useFateClient();
 
-	// Route the chosen handle through the `setUsername` mutation (`username` is
-	// better-auth `input: false`, so it can't ride `signUp.email`). Returns the
-	// inline error message on failure, or `null` once the handle lands. Handles
-	// BOTH fate shapes: a returned `{error}` and a thrown boundary error.
+	// A separate mutation because `username` is better-auth `input: false`, so it can't
+	// ride `signUp.email`. Both fate failure shapes reach here: a returned `{error}` and
+	// a thrown boundary error.
 	async function setUsernameOrFail(handle: string): Promise<string | null> {
 		try {
 			const {error: callError} = await fate.mutations.user.setUsername({
@@ -62,8 +59,6 @@ export function AuthPage() {
 				setError(message);
 				return;
 			}
-			// Landed — clear the stuck state and release the gate so the Layout
-			// redirect carries the user into the app with the chosen handle set.
 			setStuckUsername(null);
 			endUsernameResolution();
 		} finally {
@@ -71,10 +66,8 @@ export function AuthPage() {
 		}
 	}
 
-	// The deliberate escape hatch: give up on the chosen handle and fall through to
-	// the null-username bootstrap. Releasing the gate lets the redirect proceed;
-	// the account still has no handle, so `UsernameBootstrap` mounts — but only
-	// after an explicit choice, never as a silent default.
+	// The escape hatch: drop the chosen handle and fall through to the null-username
+	// bootstrap — reachable only by explicit choice, never as a silent default.
 	function abandonStuckUsername() {
 		setStuckUsername(null);
 		setError(null);
@@ -89,8 +82,8 @@ export function AuthPage() {
 		if (isSignIn) {
 			const email = String(data.get("email") ?? "");
 			const password = String(data.get("password") ?? "");
-			// Form is `noValidate` — drive the required/format checks in Turkish through
-			// the `kp-auth__error` surface instead of the browser's locale-default bubble.
+			// The form is `noValidate`, so these hand-rolled checks are the only ones that
+			// run — the browser's bubble would speak the wrong language.
 			const fieldError = validateSignIn(email, password);
 			if (fieldError) {
 				setError(fieldError);
@@ -109,17 +102,13 @@ export function AuthPage() {
 		const name = String(data.get("name") ?? "");
 		const email = String(data.get("email") ?? "");
 		const password = String(data.get("password") ?? "");
-		// Username is optional at signup; when present it must pass the same rule the
-		// server enforces (`assertUsername`). Pre-flight here so a bad handle never
-		// creates the account, then surfaces as a confusing post-signup failure.
-		// Normalize identically to the bootstrap fallback so the two never diverge.
+		// Normalize identically to the bootstrap fallback, or the two paths diverge.
 		const username = String(data.get("username") ?? "")
 			.trim()
 			.toLowerCase();
 
-		// Form is `noValidate` — validate the required/format constraints in Turkish
-		// through the `kp-auth__error` surface (no browser-locale bubble), in visual
-		// field order: görünen ad → e-posta → kullanıcı adı → parola.
+		// Pre-flight the handle against the same rule the server enforces, so a bad one
+		// never creates the account and then fails confusingly after signup.
 		const fieldError =
 			validateName(name) ??
 			validateEmail(email) ??
@@ -138,41 +127,28 @@ export function AuthPage() {
 				return;
 			}
 
-			// `username` is better-auth `input: false`, so it can't ride `signUp.email`;
-			// route the chosen handle through the same `setUsername` mutation the
-			// bootstrap fallback uses (cookie-authenticated by the session signup just
-			// established). A blank field leaves `username === null` so the layout's
-			// bootstrap gate fires as the fallback (AC3).
 			if (username) {
-				// Latch the redirect gate BEFORE the async setUsername: `signUp.email`
-				// already established the session, so the Layout redirect would fire the
-				// instant this handler yields. Holding it keeps AuthPage mounted so a
-				// failure is visible + retryable here — never buried under the redirect,
-				// which is the #1888 silent-drop.
+				// Latch the gate BEFORE the await: `signUp.email` already established the
+				// session, so the Layout redirect fires the instant this handler yields and
+				// a setUsername failure would be buried under it (#1888).
 				beginUsernameResolution();
 				const message = await setUsernameOrFail(username);
 				if (message) {
-					// The handle didn't land. Do NOT release the gate: park in the retry
-					// surface so the chosen handle is never silently dropped into the
-					// email-prefill bootstrap.
+					// Deliberately no `endUsernameResolution()` here: park in the retry surface
+					// rather than dropping the handle into the email-prefill bootstrap.
 					setStuckUsername(username);
 					setError(message);
 					return;
 				}
-				// Landed — release the gate so the Layout redirect proceeds.
 				endUsernameResolution();
 			}
-			// Redirect is intentionally not handled here: the Layout's effect
-			// watches `session.data` and navigates off /auth to `?returnTo=…`
-			// (or `/`) once the session lands (and the gate is clear).
+			// No redirect here by design: the Layout's effect watches `session.data` and
+			// navigates off /auth once the session lands and the gate is clear.
 		} finally {
 			setPending(false);
 		}
 	}
 
-	// #1888: the account exists but the chosen handle failed to set. Block on a
-	// visible, retryable surface — never fall through to the redirect + email
-	// prefill, which is how the chosen handle got silently dropped before.
 	if (stuckUsername != null) {
 		return (
 			<div className="kp-auth">

--- a/apps/web/src/pages/BildirimlerPage.tsx
+++ b/apps/web/src/pages/BildirimlerPage.tsx
@@ -1,11 +1,3 @@
-/**
- * `BildirimlerPage` — the `/bildirimler` notification center (#1694, epic #1666).
- * Ships dark behind the `phoenix-bildirim` flag: with the flag off the route
- * renders the 404 (effectively absent); loading shows a neutral placeholder so
- * the 404 never flashes before the flag resolves (the `FunnelPage` shape).
- * Signed-out redirects to auth with a `returnTo` back here (as `PanoFeed`'s
- * kaydedilenler variant does) — a notification list is a signed-in surface.
- */
 import {Navigate} from "react-router";
 import {useSession} from "../auth/client";
 import {BildirimList} from "../components/bildirim/BildirimList";

--- a/apps/web/src/pages/DivanPage.tsx
+++ b/apps/web/src/pages/DivanPage.tsx
@@ -1,19 +1,10 @@
 /**
- * `DivanPage` — the `/divan` reviewer workspace (#1290, epic #1202): the
- * yazar/mod proving ground where a çaylak's sandboxed work is reviewed toward
- * promotion.
+ * The `/divan` reviewer workspace. Two invariants:
  *
- * Access is SERVER-authoritative — the gated `divan.roster` read denies a
- * çaylak/visitor the invisible `UNAUTHORIZED` (`requireDivanAccess`, yazar OR
- * mod). The roster's `<Screen>` catches that and renders the "yetkin yok" state;
- * no client-side authority guess decides who may enter.
- *
- * It reads ONLY the `sandboxBacklogWhere` DESTINATION (roster + per-çaylak
- * backlog) — never the inline `{mod, author}` filter — so çaylak work stays
- * one-way glass, visible only inside the divan.
- *
- * The moderator-only raporlar section (#1701) sits inside this workspace, shown
- * only for the trusted server-side `isModerator` signal — see `Raporlar.tsx`.
+ * - Access is server-authoritative: `divan.roster` denies a çaylak/visitor `UNAUTHORIZED`,
+ *   which `<Screen>` renders as "yetkin yok". Deliberately no client-side role check.
+ * - It reads ONLY the `sandboxBacklogWhere` destination, never the inline `{mod, author}`
+ *   filter, so çaylak work stays visible only inside the divan.
  */
 import {useEffect, useState} from "react";
 import {useMe} from "../auth/useMe";
@@ -29,8 +20,6 @@ import {Button} from "../components/ui/Button";
 import {Screen} from "../fate/Screen";
 import "../components/divan/Divan.css";
 
-// The çaylaklar ↔ raporlar section switch as Subnav filters (#2604): when the divan Subnav zone
-// is mounted, the switch is published up to it rather than painted in-page.
 const DIVAN_SECTION_FILTERS: SubnavFilter[] = [
 	{id: "caylaklar", label: "çaylaklar"},
 	{id: "raporlar", label: "raporlar"},
@@ -43,23 +32,15 @@ export function DivanPage() {
 function DivanWorkspace() {
 	const {me} = useMe();
 	const [selectedId, setSelectedId] = useState<string | null>(null);
-	// The raporlar (moderation-queue) entry (#1701): rendered only for the trusted
-	// server-side isModerator signal — never tier — so for a non-mod viewer /divan is
-	// exactly the çaylak workspace. The server stays authoritative: report.listOpen
-	// denies a forced non-mod read the invisible UNAUTHORIZED, caught by <Screen> below.
+	// Gate raporlar on the server-side isModerator signal, never on tier.
 	const raporlarVisible = me?.isModerator ?? false;
 	const [section, setSection] = useState<"caylaklar" | "raporlar">("caylaklar");
 	const showRaporlarPane = raporlarVisible && section === "raporlar";
-	// The triage loop is the product; the grid is its Esc fallback (#1703, ADR 0138).
-	// Entering the raporlar section always starts in the loop; Esc's outermost rung
-	// de-escalates to the grid without leaving the section.
+	// The loop is the product, the grid its Esc fallback — see ADR 0138.
 	const [raporlarMode, setRaporlarMode] = useState<"loop" | "grid">("loop");
 
-	// The section switch lives in divan's persistent Subnav zone (#2604, epic #2596). The page owns
-	// the switch state (roster vs raporlar pane below), so it publishes the switchers UP to the zone
-	// (the pano publish-up shape) and drops its own in-page nav. Only a moderator has a second
-	// section, so a non-mod viewer publishes null (a bare Subnav bar). No zone ancestor ⇒ setter
-	// null ⇒ the in-page nav renders instead.
+	// The page owns the switch state, so it publishes the switchers UP into divan's persistent
+	// Subnav zone. No zone ancestor ⇒ setter null ⇒ the in-page nav below renders instead.
 	const setDivanSubnav = useSetDivanSubnavContent();
 	const inZone = setDivanSubnav != null;
 
@@ -82,7 +63,6 @@ function DivanWorkspace() {
 				: null,
 		);
 	}, [inZone, setDivanSubnav, raporlarVisible, section]);
-	// Clear the zone's content on unmount, so the persistent zone falls back to the bare bar.
 	useEffect(() => {
 		return () => setDivanSubnav?.(null);
 	}, [setDivanSubnav]);
@@ -143,8 +123,6 @@ function DivanWorkspace() {
 							</Screen>
 						</section>
 
-						{/* The shared decision feed (#1704) — a DISTINCT section, its own gated
-						    read, so who-decided-what stays legible below the live queue. */}
 						<section className="kp-divan__decisions-pane" aria-label="son kararlar">
 							<h2 className="kp-divan__decisions-title">son kararlar</h2>
 							<Screen
@@ -192,7 +170,6 @@ function DivanWorkspace() {
 	);
 }
 
-/** The divan's denied / failed read state — "yetkin yok" for the invisible gate. */
 function AccessError({code}: {readonly code: string}) {
 	const denied = code === "UNAUTHORIZED" || code === "FORBIDDEN";
 	return (

--- a/apps/web/src/pages/FunnelPage.tsx
+++ b/apps/web/src/pages/FunnelPage.tsx
@@ -1,11 +1,6 @@
 /**
- * `FunnelPage` — the `/funnel` founder/mod conversion readout (#1589): the tracer
- * bullet for the çaylak→yazar metrics, today just the current tier population.
- *
- * Access is SERVER-authoritative — the gated `funnel.summary` read denies a non-mod
- * the invisible `UNAUTHORIZED` (`requireFunnelAccess`). The `<Screen>` catches that
- * and renders the "yetkin yok" state; no client-side authority guess decides who
- * may enter, mirroring `DivanPage`.
+ * Access is server-authoritative: `funnel.summary` denies a non-mod `UNAUTHORIZED`, which
+ * `<Screen>` renders as "yetkin yok". Deliberately no client-side role check here.
  */
 import {FunnelSummary} from "../components/funnel/FunnelSummary";
 import {Alert} from "../components/ui/Alert";
@@ -36,7 +31,6 @@ export function FunnelPage() {
 	);
 }
 
-/** The readout's denied / failed state — "yetkin yok" for the invisible gate. */
 function AccessError({code}: {readonly code: string}) {
 	const denied = code === "UNAUTHORIZED" || code === "FORBIDDEN";
 	return (

--- a/apps/web/src/pages/LabComposerPage.tsx
+++ b/apps/web/src/pages/LabComposerPage.tsx
@@ -1,11 +1,7 @@
 /**
- * `/lab/composer` — the live proof / first consumer of `@kampus/composer`, kept +
- * canonical under the `/lab/*` public convention (#2469 / PR #2474). NOT throwaway:
- * this route stays as the working demonstration of the shared headless composer base,
- * exercising its full markdown round-trip end to end. The editor is wired entirely
- * through `@kampus/composer` — the app supplies only chrome (masthead, panels, CSS);
- * the base owns the tiptap wrapping (StarterKit + `@tiptap/markdown`), so nothing here
- * imports tiptap directly.
+ * `/lab/composer` — NOT throwaway: this route is the permanent working demonstration of
+ * `@kampus/composer`'s markdown round-trip (#2469). Nothing here imports tiptap directly;
+ * the base owns that wrapping and the app supplies only chrome.
  */
 
 import {Composer, renderTestMarkdown, useComposerEditor} from "@kampus/composer";
@@ -13,15 +9,11 @@ import {useState} from "react";
 import {Badge, Button, Textarea} from "../components/ui";
 import "./LabComposerPage.css";
 
-// The canonical render-test content is the shared `renderTestMarkdown` fixture the base
-// exports (#2482) — the single source, so this playground and `@kampus/composer`'s
-// round-trip test can never drift. The panels below double as its live render checklist.
+// Seeded from the base's own round-trip fixture so the playground can't drift from it.
 const SEED_MARKDOWN = renderTestMarkdown;
 
 export function LabComposerPage() {
 	const [pasted, setPasted] = useState(SEED_MARKDOWN);
-	// Bumped on every editor transaction so the read-only round-trip panels below
-	// re-derive `getMarkdown()`/`getJSON()` from the live editor state.
 	const [rev, setRev] = useState(0);
 
 	const composer = useComposerEditor({
@@ -29,7 +21,7 @@ export function LabComposerPage() {
 		onUpdate: () => setRev((n) => n + 1),
 	});
 
-	// `rev` is read to tie the derivation to the latest transaction (see the state above).
+	// Not dead: reading `rev` is what ties the panels below to the latest transaction.
 	void rev;
 	const markdown = composer ? composer.getMarkdown() : "";
 	const json = composer ? JSON.stringify(composer.toJSON(), null, 2) : "";
@@ -102,18 +94,12 @@ export function LabComposerPage() {
 }
 
 /**
- * Storage SKETCH ONLY (#2465 AC) — a shape to *feel*, deliberately inert. There is no
- * wired `Fate.mutation` and no `/fate/live` publish here; a real composer draft would
- * persist through the fate mutation pattern in `apps/web/worker/features/*` and, being a
- * write over a fanned entity, MUST publish the live invalidation + be classified in
- * `apps/web/worker/features/fate-live/fanned-mutations.ts` (CLAUDE.md fanout rule). That
- * wiring is explicitly out of scope for this v1 lab route (baseKit-only, #2464).
+ * A SKETCH, deliberately inert (#2465): no `Fate.mutation`, no `/fate/live` publish. Wiring
+ * one would make this a fanned write owing the live invalidation — out of scope here.
  */
 type ComposerDraftRow = {
 	id: string;
 	authorId: string;
-	// Store BOTH: markdown as the human-editable source of truth, tiptap JSON as the
-	// render-fast structural cache. The round-trip above is what proves they stay in sync.
 	markdown: string;
 	docJson: string;
 	updatedAt: number;
@@ -132,7 +118,7 @@ function StorageSketch() {
 		"// Fate.mutation('composer.saveDraft', { markdown, docJson }) -> upsert row",
 		"//   then publish the live invalidation (fanned-entity rule) — deferred to rich phase.",
 	].join("\n");
-	// Reference the row type so the sketched shape is a real, type-checked artifact.
+	// Not dead: this reference is what type-checks the sketched row shape.
 	const _shape: ComposerDraftRow | null = null;
 	void _shape;
 	return (

--- a/apps/web/src/pages/LandingPage.tsx
+++ b/apps/web/src/pages/LandingPage.tsx
@@ -1,10 +1,4 @@
-/**
- * Landing page (`/`) — the public front door. Stats + the two lists ("panoda son
- * 24 saat", "sözlüğe son eklenenler") all read live through fate, batched into one
- * per-screen `useRequest({landingStats, landingPosts, landingTerms})` under a single
- * `Screen` (ADR 0021). Server types are the source of truth (ADR 0022) — the rows
- * read the `Post`/`Term` views directly, no hand-written shadow shapes.
- */
+/** Landing page (`/`) — one batched `useRequest` under one `Screen`; see ADR 0021, ADR 0022. */
 import {ArrowRight} from "lucide-react";
 import {useListView, useRequest, useView, type ViewRef, view} from "react-fate";
 import {Link} from "react-router";
@@ -20,7 +14,6 @@ import "./LandingPage.css";
 
 const LANDING_LIST_SIZE = 5;
 
-/** `LandingStats` is a singleton entity (constant `id`), served by `queries.landingStats`. */
 const LandingStatsView = view<LandingStats>()({
 	id: true,
 	totalDefinitions: true,
@@ -63,16 +56,11 @@ const landingRequest = {
 
 function formatStat(n: number): string {
 	if (n < 1000) return String(n);
-	// Turkish convention: thousands separator is `.` (e.g. 1.247).
 	return n.toLocaleString("tr-TR");
 }
 
 export function LandingPage() {
-	// Auth-gate the join CTA + rite framing on the SAME signal the topbar reads —
-	// `useMe` over `useSession` (#1784) — so the landing and the topbar can never
-	// disagree about auth state. The three-valued phase suppresses the CTA while
-	// auth is still resolving so it never flashes in/out (#448); the pure decision
-	// lives in `landingGating` (DOM-free, unit-tested).
+	// Gating rules (and why the phase is three-valued) live in `landingGating`.
 	const session = useSession();
 	const {status} = useMe();
 	const phase = landingCtaPhase(session.isPending, status);

--- a/apps/web/src/pages/MecmuaDraftsPage.tsx
+++ b/apps/web/src/pages/MecmuaDraftsPage.tsx
@@ -1,14 +1,7 @@
 /**
- * `/mecmua/yazilarim` — the author's OWN posts (#2544): the private retrieval surface
- * the mecmua write path lacked. It reads the `CurrentUser`-scoped `mecmuaMyPosts` fate
- * root (drafts + published, newest-started first) and lists each as a card linking to
- * the editor at that post's id (`/mecmua/yaz/:id`), so a saved taslak is reopenable —
- * closing the #2429 Story 3 "keep multiple drafts" journey the write-only path broke.
- *
- * The whole surface ships dark behind `MECMUA_WRITE` (default-off): the page self-gates
- * (off ⇒ 404), the same seam the editor gates on, and `mecmuaMyPosts` serves empty while
- * the flag is off — so no unreleased authoring surface leaks (ADR 0083). Signed-out reads
- * are empty (the read is author-scoped), rendered as the empty state.
+ * `/mecmua/yazilarim` — the author's own drafts + published posts, off the `CurrentUser`-scoped
+ * `mecmuaMyPosts` root. Ships dark behind `MECMUA_WRITE` (default-off; ADR 0083); that root
+ * serves empty while the flag is off, so a signed-out or gated read just renders empty.
  */
 import {NotebookPen} from "lucide-react";
 import {useListView, useRequest, useView, type ViewRef, view} from "react-fate";
@@ -40,11 +33,9 @@ const myPostsRequest = {
 
 export function MecmuaDraftsPage() {
 	const {value: flagOn, loading: flagLoading} = useFlag(MECMUA_WRITE, false);
-	// The write CTA lives once in the mecmua Subnav's primary-action slot, so this page paints
-	// no in-page copy (header or empty state) — exactly one mecmua write CTA (#2603 de-dup).
+	// No in-page write CTA on purpose: mecmua's single one lives in the Subnav (#2603).
 
-	// Don't decide 404-vs-page until the flag resolves, or the 404 flashes first (the
-	// MecmuaEditorPage / MecmuaPostPage self-gate idiom).
+	// Don't decide 404-vs-page until the flag resolves, or the 404 flashes first.
 	if (flagLoading) {
 		return (
 			<div className="kp-page">

--- a/apps/web/src/pages/MecmuaEditorPage.tsx
+++ b/apps/web/src/pages/MecmuaEditorPage.tsx
@@ -1,30 +1,9 @@
 /**
- * `/mecmua/yaz` — the mecmua authoring surface (#2499, epic #2467). The first
- * PRODUCT consumer of the shared headless `@kampus/composer` base (`/lab/composer`
- * was the first lab consumer): the composer owns the tiptap-wrapped editing
- * (StarterKit + `@tiptap/markdown`), this page owns only chrome + persistence,
- * wiring the composer's markdown output into `mecmua.saveDraft` / `mecmua.publish`.
- * Nothing here imports tiptap directly and no external editor lib is added.
- *
- * Two authority tiers (the ticket's load-bearing split):
- *   - taslak kaydet — any signed-in user may save a private draft (`mecmua.saveDraft`,
- *     normal-auth). Each save inserts a fresh draft row; multiple drafts per author
- *     are allowed by design (#2463), so there is no edit-in-place here (out of v1).
- *   - yayımla — offered ONLY to a yazar (`me.tier === "yazar"`), the trusted account
- *     tier read off the fate `me` view (never the untrusted session field). A çaylak /
- *     visitor sees the Turkish earned-gate message instead — publish is server-gated by
- *     `PublishMecmua` regardless, this is the honest UI mirror.
- *
- * Two routes reach this page (#2544): `/mecmua/yaz` opens a blank editor; `/mecmua/yaz/:id`
- * loads one of the author's OWN posts (via the `CurrentUser`-scoped `mecmuaMyPosts` read)
- * into the editor so a saved draft is reopenable. Multi-draft is unchanged — a save still
- * mints a fresh row (no edit-in-place), so `taslak kaydet` lands on the just-saved draft's
- * id rather than a blank editor. `taslaklarım` (`/mecmua/yazilarim`) lists them.
- *
- * The whole surface ships dark behind `MECMUA_WRITE` (default-off): the page
- * self-gates (off ⇒ 404), mirroring `MecmuaPostPage` / `DivanPage`, so the route is
- * absent until a human flips the flag at release (ADR 0083). Storage is the markdown
- * STRING the composer emits — no D1 schema change here.
+ * `/mecmua/yaz[/:id]` — the mecmua authoring surface. Two authority tiers: any signed-in
+ * user may save a private draft, but yayımla is offered only to a yazar (read off the fate
+ * `me` view, never the session field) — `PublishMecmua` gates it server-side regardless.
+ * Every save mints a FRESH draft row; there is no edit-in-place (#2463). Nothing here
+ * imports tiptap directly. Ships dark behind `MECMUA_WRITE` (default-off; ADR 0083).
  */
 import {Composer, useComposerEditor} from "@kampus/composer";
 import {useState} from "react";
@@ -40,16 +19,11 @@ import {Screen} from "../fate/Screen";
 import {useDraftSubmit} from "../fate/useDraftSubmit";
 import {MECMUA_WRITE} from "../flags/keys";
 import {useFlag} from "../flags/useFlag";
-// The publish/CTA gate lives in a composer-free module so its consumers (index, nav) don't
-// drag tiptap into the entry chunk — this page lazy-loads behind that split (#2523).
 import {mecmuaPublishAffordance} from "./mecmua-write-gate";
 import {NotFoundPage} from "./NotFoundPage";
 import "./MecmuaEditorPage.css";
 
-/**
- * The write-back selection for both mecmua write mutations. `id` is load-bearing —
- * `saveDraft` returns the fresh draft id that `publish` then references.
- */
+/** `id` is load-bearing: `saveDraft` returns the fresh draft id that `publish` references. */
 const MecmuaEditorView = view<MecmuaPost>()({
 	id: true,
 	slug: true,
@@ -60,8 +34,7 @@ const MecmuaEditorView = view<MecmuaPost>()({
 export function MecmuaEditorPage() {
 	const {value: flagOn, loading: flagLoading} = useFlag(MECMUA_WRITE, false);
 
-	// Don't decide 404-vs-page until the flag resolves, or the 404 flashes first (the
-	// MecmuaPostPage / DivanPage self-gate idiom).
+	// Don't decide 404-vs-page until the flag resolves, or the 404 flashes first.
 	if (flagLoading) {
 		return (
 			<div className="kp-page">
@@ -77,7 +50,6 @@ export function MecmuaEditorPage() {
 	return <MecmuaEditorRoute />;
 }
 
-/** The full-post read used to reopen an author's own draft — body included so the composer seeds. */
 const MecmuaOwnPostView = view<MecmuaPost>()({
 	id: true,
 	title: true,
@@ -90,10 +62,8 @@ const ownPostsRequest = {
 } as const;
 
 /**
- * Route the editor by the `:id` param (#2544): no id ⇒ a blank editor; an id ⇒ load
- * that draft (scoped to the author's own posts) and seed the editor with it. The read
- * runs BEFORE `MecmuaEditor` mounts so the composer's initial content is ready at hook
- * time — the composer seeds content only at creation.
+ * The draft read must finish BEFORE `MecmuaEditor` mounts: the composer seeds its content
+ * only at creation, so a late-arriving body would never reach the editor.
  */
 function MecmuaEditorRoute() {
 	const {id} = useParams<{id: string}>();
@@ -117,8 +87,7 @@ function MecmuaEditorRoute() {
 function MecmuaDraftLoader({draftId}: {draftId: string}) {
 	const {mecmuaMyPosts} = useRequest(ownPostsRequest);
 	const [items] = useListView(OwnPostsConnectionView, mecmuaMyPosts);
-	// `mecmuaMyPosts` returns ONLY the caller's own posts, so a foreign/absent id simply
-	// isn't in the list — it can't disclose another author's draft, it 404s to the author.
+	// The read is author-scoped, so a foreign id simply isn't in the list — no disclosure.
 	const match = items.find(({node}) => String(node.id) === draftId);
 	if (!match) return <MecmuaDraftNotFound />;
 	return <MecmuaDraftEditor node={match.node} />;
@@ -155,18 +124,14 @@ function MecmuaEditor({initialTitle, initialBody}: {initialTitle: string; initia
 
 	const [title, setTitle] = useState(initialTitle);
 	const [notice, setNotice] = useState<string | null>(null);
-	// The composer holds the body; markdown is read on-demand at save/publish time
-	// (`getMarkdown()`), so no per-keystroke rerender is needed here. Seeded with the
-	// loaded draft's markdown (empty for a fresh editor).
+	// The composer holds the body and markdown is read on demand at save time, so the body
+	// is deliberately not React state — no per-keystroke rerender.
 	const composer = useComposerEditor({content: initialBody});
 
 	const {error, setError, inFlight, run} = useDraftSubmit({
 		redirectPath: () => (id ? `/mecmua/yaz/${id}` : "/mecmua/yaz"),
 	});
 
-	// The trusted account tier off the fate `me` view (#1297) decides the publish
-	// affordance: a yazar is offered publish; a çaylak / visitor / signed-out reader
-	// sees the earned-gate message instead.
 	const publishAffordance = mecmuaPublishAffordance(!!session.data, me?.tier);
 	const titleReady = title.trim().length > 0;
 	const bodyMarkdown = () => (composer ? composer.getMarkdown() : "");
@@ -183,8 +148,7 @@ function MecmuaEditor({initialTitle, initialBody}: {initialTitle: string; initia
 			"taslak kaydedilemedi",
 			(result) => {
 				setNotice("taslak kaydedildi");
-				// Land on the just-saved draft (id-addressable), not a blank `/mecmua/yaz`
-				// (#2544). Each save mints a fresh row, so the saved id is new — navigate to it.
+				// Each save mints a fresh row, so land on the new id rather than a blank editor.
 				const savedId = result?.id;
 				if (savedId && String(savedId) !== id) navigate(`/mecmua/yaz/${String(savedId)}`);
 			},
@@ -194,9 +158,7 @@ function MecmuaEditor({initialTitle, initialBody}: {initialTitle: string; initia
 	async function onPublish() {
 		setNotice(null);
 		setError(null);
-		// Publish operates on a draft id, so save the current content as a fresh draft
-		// first, then stamp it published — this guarantees the published post matches
-		// what's on screen (no stale prior-draft publish).
+		// Publish takes a draft id, so save first: publishing an older id would ship stale text.
 		await run(
 			async () => {
 				const saved = await fate.mutations.mecmua.saveDraft({
@@ -244,8 +206,7 @@ function MecmuaEditor({initialTitle, initialBody}: {initialTitle: string; initia
 						fullWidth
 					/>
 
-					{/* The composer is a headless contenteditable region (no native label
-					    slot), so a fieldset/legend names the group around it. */}
+					{/* The composer is headless with no native label slot, so fieldset/legend names it. */}
 					<fieldset className="kp-mecmua-editor__field kp-mecmua-editor__fieldset">
 						<legend className="kp-mecmua-editor__label">metin</legend>
 						<Composer composer={composer} className="kp-mecmua-editor__body" />

--- a/apps/web/src/pages/MecmuaFeedPage.tsx
+++ b/apps/web/src/pages/MecmuaFeedPage.tsx
@@ -1,16 +1,7 @@
 /**
- * `/mecmua/akis` — the subscribed-author feed (#2500, epic #2467): a time-ordered list of
- * published mecmua posts from the authors the reader follows, newest-first by
- * `publishedAt`. Reads the `mecmuaFeed` fate root in one batched `useRequest` and renders
- * each post as a card linking to its reader page (`/mecmua/:slug`) — the same Card /
- * EmptyState / MetaRow shell the public index (#2512) uses, so the two mecmua surfaces read
- * as one family. On-site reading only — there is NO email/bülten path here by design (map
- * #2467/#2466).
- *
- * The whole surface ships dark behind `MECMUA_FEED` (default-off): the page self-gates
- * (off ⇒ 404), mirroring `MecmuaPostPage`, so the route is absent until a human flips the
- * flag at release (ADR 0083). The `mecmuaFeed` root also serves empty while the flag is
- * off, so no unreleased feed content leaks even if the page is reached.
+ * `/mecmua/akis` — the feed of published posts from authors the reader follows. On-site
+ * reading only: there is no email/bülten path here by design. Ships dark behind
+ * `MECMUA_FEED` (default-off; ADR 0083), and the `mecmuaFeed` root serves empty while it is.
  */
 import {Newspaper} from "lucide-react";
 import {useListView, useRequest, useView, type ViewRef, view} from "react-fate";
@@ -49,8 +40,7 @@ const feedRequest = {
 export function MecmuaFeedPage() {
 	const {value: flagOn, loading: flagLoading} = useFlag(MECMUA_FEED, false);
 
-	// Don't decide 404-vs-page until the flag resolves, or the 404 flashes first (the
-	// MecmuaPostPage self-gate idiom).
+	// Don't decide 404-vs-page until the flag resolves, or the 404 flashes first.
 	if (flagLoading) {
 		return (
 			<div className="kp-page">
@@ -110,8 +100,7 @@ function MecmuaFeedList() {
 
 function MecmuaFeedRow({node}: {node: ViewRef<"MecmuaPost">}) {
 	const post = useView(MecmuaFeedPostView, node);
-	// The reader page is keyed by slug or id; a draft-less feed row is always published,
-	// so `slug ?? id` always resolves to a readable `/mecmua/:key`.
+	// A feed row is always published, so `slug ?? id` always resolves to a readable page.
 	const href = `/mecmua/${encodeURIComponent(post.slug ?? String(post.id))}`;
 	const excerpt = post.body.length > 240 ? `${post.body.slice(0, 240).trimEnd()}…` : post.body;
 

--- a/apps/web/src/pages/MecmuaIndexPage.test.tsx
+++ b/apps/web/src/pages/MecmuaIndexPage.test.tsx
@@ -41,8 +41,7 @@ describe("MecmuaIndexPage — write-CTA de-dup (#2603)", () => {
 		flags.read = true;
 		flags.write = true;
 		meTier = "yazar";
-		// A published post so the page renders its list (not the empty state) — isolates the
-		// header CTA as the single in-page write affordance under test.
+		// One published post, so the page renders its list rather than the empty state.
 		vi.stubGlobal(
 			"fetch",
 			vi.fn(
@@ -60,7 +59,6 @@ describe("MecmuaIndexPage — write-CTA de-dup (#2603)", () => {
 
 	it("the in-page write CTA is suppressed — the single CTA lives in the Subnav", async () => {
 		renderPage();
-		// The list still renders (proves we got past the flag gate), but no in-page CTA remains.
 		expect(await screen.findByText("mecmua")).toBeTruthy();
 		expect(screen.queryByTestId("mecmua-write-cta")).toBeNull();
 	});

--- a/apps/web/src/pages/MecmuaIndexPage.tsx
+++ b/apps/web/src/pages/MecmuaIndexPage.tsx
@@ -1,14 +1,7 @@
 /**
- * `/mecmua` — the PUBLIC chronological index of published mecmua posts (#2512, epic
- * #2467), the discovery surface the reader (`/mecmua/:slug`) lacked. It fetches the
- * anonymous `GET /fate/mecmua/index` route (published-only, newest-first) and lists each
- * post as a card linking to its reader. This is the PUBLIC index (all published posts) —
- * distinct from the personalized subscribed-author feed (#2500).
- *
- * The whole surface ships dark behind `MECMUA_PUBLIC_READ` (default-off): the page
- * self-gates (off => 404), mirroring `MecmuaPostPage` / `DivanPage`, so the route is
- * absent until a human flips the flag at release (ADR 0083). The index route itself also
- * 404s while the flag is off — the page gate just avoids a fetch and a flash.
+ * `/mecmua` — the public index of published posts, distinct from the personalized
+ * subscribed-author feed (`/mecmua/akis`). Ships dark behind `MECMUA_PUBLIC_READ`
+ * (default-off; ADR 0083) — the route 404s server-side too, this gate just saves a fetch.
  */
 import {BookOpenText} from "lucide-react";
 import {useEffect, useState} from "react";
@@ -24,12 +17,10 @@ import {formatDateTR} from "../lib/datetime";
 import {NotFoundPage} from "./NotFoundPage";
 import "./MecmuaIndexPage.css";
 
-/** The lean wire shape `GET /fate/mecmua/index` returns — no body, the reader fetches that. */
 interface MecmuaIndexEntry {
 	readonly id: string;
 	readonly slug: string | null;
 	readonly title: string;
-	/** ISO string (a serialized `Date`); always set for a published post. */
 	readonly publishedAt: string | null;
 }
 
@@ -41,8 +32,7 @@ type FetchState =
 export function MecmuaIndexPage() {
 	const {value: flagOn, loading: flagLoading} = useFlag(MECMUA_PUBLIC_READ, false);
 
-	// Don't decide 404-vs-page until the flag resolves, or the 404 flashes first (the
-	// MecmuaPostPage / DivanPage self-gate idiom).
+	// Don't decide 404-vs-page until the flag resolves, or the 404 flashes first.
 	if (flagLoading) {
 		return (
 			<div className="kp-page">

--- a/apps/web/src/pages/MecmuaPostPage.tsx
+++ b/apps/web/src/pages/MecmuaPostPage.tsx
@@ -1,20 +1,8 @@
 /**
- * `/mecmua/:slug` — the PUBLIC reader for a single published mecmua post (#2498, epic
- * #2467). Client-only per the map (#2466 — SEO/prerender explicitly deferred): it
- * fetches the anonymous `GET /fate/mecmua/post/:slug` route and renders the published
- * post's başlık + markdown body through `@kampus/composer` in read-only mode (#2581) —
- * the reader is the editor with editing switched off, so write and read share ONE tiptap
- * render path (editor≈reader parity) and can't re-diverge (the raw-markdown bug #2578).
- * A draft / miss / off-flag all 404 server-side, surfaced here as the shared NotFoundPage.
- *
- * Tiptap is kept OFF public first-paint: the body renders through `MecmuaPostBody`, a
- * `React.lazy` chunk that alone imports the composer (the #2523 lazy-split applied to the
- * reader) — landing/index/other routes carry no tiptap; opening a post loads that chunk.
- *
- * The whole surface ships dark behind `MECMUA_PUBLIC_READ` (default-off): the page
- * self-gates (off ⇒ 404), mirroring `DivanPage`, so the route is absent until a human
- * flips the flag at release (ADR 0083). The route itself also 404s while the flag is
- * off — the page gate just avoids a fetch and a flash.
+ * `/mecmua/:slug` — the public reader for one published post. The body renders through
+ * `@kampus/composer` in read-only mode, so write and read share one tiptap render path and
+ * can't re-diverge (the raw-markdown bug #2578). Client-only; SEO/prerender is deferred.
+ * Ships dark behind `MECMUA_PUBLIC_READ` (default-off; ADR 0083).
  */
 import {lazy, Suspense, useEffect, useState} from "react";
 import {useParams} from "react-router";
@@ -24,14 +12,10 @@ import {MECMUA_PUBLIC_READ} from "../flags/keys";
 import {useFlag} from "../flags/useFlag";
 import {NotFoundPage} from "./NotFoundPage";
 
-// The composer (and tiptap) live behind this dynamic import so they stay off mecmua public
-// first-paint — the reader route's own module graph never statically references tiptap.
+// Lazy on purpose: this is the only reference to the composer, which keeps tiptap off
+// public first-paint. A static import here would pull it into every route's chunk.
 const MecmuaPostBody = lazy(() => import("../components/mecmua/MecmuaPostBody"));
 
-/**
- * The wire shape the anon read route returns. `authorId` is the subscribe target — the
- * follow toggle (#2527) subscribes the reader to this post's author.
- */
 interface MecmuaPostWire {
 	readonly id: string;
 	readonly title: string;
@@ -49,8 +33,7 @@ export function MecmuaPostPage() {
 	const {value: flagOn, loading: flagLoading} = useFlag(MECMUA_PUBLIC_READ, false);
 	const {slug} = useParams<{slug: string}>();
 
-	// Don't decide 404-vs-page until the flag resolves, or the 404 flashes first (the
-	// DivanPage self-gate idiom).
+	// Don't decide 404-vs-page until the flag resolves, or the 404 flashes first.
 	if (flagLoading) {
 		return (
 			<div className="kp-page">
@@ -75,8 +58,7 @@ function MecmuaPostReader({slug}: {slug: string}) {
 		fetch(`/fate/mecmua/post/${encodeURIComponent(slug)}`, {headers: {accept: "application/json"}})
 			.then(async (res) => {
 				if (cancelled) return;
-				// 404 = a draft (masked), a genuine miss, or the flag off — all render as the
-				// not-found state. Any other non-2xx is a transient read error.
+				// 404 covers a masked draft and the flag being off, not just a genuine miss.
 				if (res.status === 404) return setState({kind: "not-found"});
 				if (!res.ok) return setState({kind: "error"});
 				const post = (await res.json()) as MecmuaPostWire;

--- a/apps/web/src/pages/MutesPage.tsx
+++ b/apps/web/src/pages/MutesPage.tsx
@@ -1,14 +1,4 @@
-/**
- * `MutesPage` — the `/susturduklarim` manage-my-mutes route (#3117, epic #2035): the viewer's
- * susturduklarım screen, off the `mute.listMine` read model (#3114). The reachable surface of
- * the member-mute vertical, alongside the feed "sustur" affordance (`MuteButton`).
- *
- * Ships dark behind the default-off `member-mute` flag: with the flag off the route self-404s
- * (the `BildirimlerPage` / `MecmuaIndexPage` self-gate idiom), so it is effectively absent
- * until a human flips the flag at release (ADR 0083); loading shows a neutral placeholder so
- * the 404 never flashes before the flag resolves. Signed-out redirects to auth with a
- * `returnTo` back here — managing your own mutes is a signed-in surface.
- */
+/** `/susturduklarim` — ships dark behind the default-off `member-mute` flag (ADR 0083). */
 import {Navigate} from "react-router";
 import {useSession} from "../auth/client";
 import {MutedMembersList} from "../components/mute/MutedMembersList";

--- a/apps/web/src/pages/NotFoundPage.tsx
+++ b/apps/web/src/pages/NotFoundPage.tsx
@@ -1,11 +1,6 @@
 import {Link} from "react-router";
 import "./NotFoundPage.css";
 
-/**
- * Generic 404 page (feature pages render it on a null query; the catch-all
- * route on an unknown path). Optional `title`/`message` let each call site
- * speak in its own register without forking the component.
- */
 export function NotFoundPage({title, message}: {title?: string; message?: string}) {
 	return (
 		<div className="kp-not-found" data-testid="not-found-page">

--- a/apps/web/src/pages/PanoCreateDialog.tsx
+++ b/apps/web/src/pages/PanoCreateDialog.tsx
@@ -17,10 +17,6 @@ export function PanoCreateDialog({
 	const [mode, setMode] = React.useState<"link" | "text">("link");
 	const {fetchMetadata} = useLinkMetadata();
 
-	// On URL blur, prefill the (still-empty) sibling title from the link's
-	// metadata. Uncontrolled form: reach the title input by name off the shared
-	// <form>, and let `prefillIfEmpty` enforce the never-clobber rule — the same
-	// shared policy `PanoSubmitPage` uses.
 	async function prefillFromUrl(e: React.FocusEvent<HTMLInputElement>) {
 		const form = e.currentTarget.form;
 		const url = e.currentTarget.value;

--- a/apps/web/src/pages/PanoFeed.tsx
+++ b/apps/web/src/pages/PanoFeed.tsx
@@ -1,15 +1,7 @@
 /**
- * Pano feed page — fate. One `PanoFeed` serves every subfeed, selected by the
- * deep-linkable `?sort=` param: the sort subfeeds (sıcak / yeni / en iyi /
- * tartışma) and the per-viewer kaydedilenler collection (`?sort=saved`), one feed
- * shape + one routing model (#2196).
- *
- * The sort subfeeds share `useRequest({posts, args:{sort}})` + `useLiveListView`;
- * connection identity keeps the filter args (`sort`/`host`) but strips pagination,
- * so each combo paginates independently. The saved variant is the same feed shape
- * over a DIFFERENT data source (`savedPosts`) with its own preserved behavior:
- * signed-in-only (auth redirect w/ `returnTo`), live-`isSaved` row-drop via
- * `savedReconcile`, and no ranks (a personal collection has no ordinal meaning).
+ * Pano feed page. One component serves every subfeed off the deep-linkable
+ * `?sort=` param — including `?sort=saved`, which is the same feed shape over a
+ * different data source (`savedPosts`).
  */
 import * as React from "react";
 import {useLiveListView, useLiveView, useRequest, type ViewRef} from "react-fate";
@@ -39,11 +31,7 @@ import {
 import {authRedirectPath} from "../lib/returnTo";
 import {countSavedRows, isRowSaved} from "./savedReconcile";
 
-/**
- * `live: {prepend: "visible"}` makes a server-pushed `prependNode` (a new post
- * from another client) appear at the top immediately, instead of fate's default
- * `"edge"` mode buffering it until a page load. See `.patterns/fate-live-views.md`.
- */
+// `prepend: "visible"` overrides fate's default `"edge"` buffering — see `.patterns/fate-live-views.md`.
 const PostConnectionView = {
 	items: {node: PanoPostCardView},
 	live: {prepend: "visible"},
@@ -56,22 +44,13 @@ const SavedConnectionView = {
 type Chrome = (children: React.ReactNode, meta: React.ReactNode) => React.ReactNode;
 
 export function PanoFeed({host}: {host?: string}) {
-	// The `?sort=` param is the source of truth for the active variant: derived every
-	// render (not seeded once), and switching a chip writes it back to the URL — so
-	// reload, back/forward, and share-current-URL all preserve the active subfeed
-	// instead of resetting to the default (#2072). The saved variant is `?sort=saved`.
 	const [searchParams, setSearchParams] = useSearchParams();
 	const session = useSession();
 	const variant = panoVariantFromParam(searchParams.get(PANO_SORT_PARAM));
 	const filterId = panoActiveFilterId(variant);
-	// Switching a chip swaps to a different connection, so the content re-suspends.
-	// Writing the `?sort=` param inside `startTransition` marks that re-fetch as
-	// non-urgent: React keeps the CURRENT feed committed + interactive under the stable
-	// `<Screen>` boundary instead of hard-swapping to the skeleton, and surfaces the
-	// in-flight swap as `isPending` (#2161). The cold load still shows the skeleton.
+	// A chip swap re-suspends the content; writing `?sort=` inside `startTransition` keeps the
+	// current feed committed instead of hard-swapping to the skeleton.
 	const [isPending, startTransition] = React.useTransition();
-	// Push (not replace) a history entry so browser back/forward step across the
-	// visited subfeeds, per the acceptance criteria.
 	const setFilterId = React.useCallback(
 		(id: string) => {
 			startTransition(() => {
@@ -98,8 +77,6 @@ export function PanoFeed({host}: {host?: string}) {
 		</FeedChrome>
 	);
 
-	// Saved is signed-in only: a signed-out load redirects to auth with a `returnTo`
-	// back to kaydedilenler.
 	if (variant.kind === "saved") {
 		if (session.isPending) return null;
 		if (!signedIn) return <Navigate to={authRedirectPath(SAVED_HREF)} replace />;
@@ -138,14 +115,7 @@ function FeedContent({
 	pending: boolean;
 	chrome: Chrome;
 }) {
-	// Member-mute (#3117), dark behind `member-mute`. Read once here and threaded to every row
-	// so a card can hide a muted member's post + offer the "sustur" action without each card
-	// re-evaluating the flag. Off (default) ⇒ no mute surface, byte-identical to today.
 	const {value: muteEnabled} = useFlag(MEMBER_MUTE, false);
-	// Feed snapshot (leg A, #2319): under the containment flag, run the feed read
-	// stale-while-revalidate so a snapshot hydrated into the public client paints
-	// synchronously and the network patch lands in the background. Flag off ⇒ an
-	// `undefined` options arg, behaviorally identical to today's cache-first default.
 	const {posts} = useRequest(
 		{
 			posts: {
@@ -186,10 +156,7 @@ function FeedRows({
 }) {
 	const [items, loadNext] = useLiveListView(PostConnectionView, connection);
 
-	// Reload→first-feed-paint instrumentation (#2326, epic #2316): mark the first committed
-	// feed rows so the epic's founding floor is readable in a DevTools/Performance trace.
-	// Fires once per tab (the module latches) and classifies the path (snapshot/edge/cold)
-	// from the boot-time snapshot signal; no-op when the instrument is off. See `feedPerf.ts`.
+	// First-feed-paint instrumentation: latches once per tab, no-op when off. See `feedPerf.ts`.
 	React.useEffect(() => {
 		if (items.length > 0) markFeedPaintOnce();
 	}, [items.length]);
@@ -198,10 +165,6 @@ function FeedRows({
 
 	return chrome(
 		<>
-			{/* During a chip-driven sort swap the current rows stay committed but dim +
-			    go inert (`aria-busy`), so the swap reads as "loading the next sort" rather
-			    than a frozen screen — the `startTransition` in the parent keeps them here
-			    instead of unmounting to the skeleton (#2161). */}
 			<div
 				className="kp-pano-list"
 				aria-busy={pending}
@@ -259,8 +222,6 @@ function SavedRows({connection, chrome}: {connection: SavedConnection; chrome: C
 		});
 	}, []);
 
-	// A genuinely deleted entity has no node — that's edge presence (a row can't render),
-	// NOT saved-ness, which is the live `isSaved` below.
 	const nodes = items.flatMap(({node}) => (node ? [node] : []));
 	const count = countSavedRows(
 		nodes.map((node) => node.id),
@@ -289,12 +250,6 @@ function SavedRows({connection, chrome}: {connection: SavedConnection; chrome: C
 	);
 }
 
-/**
- * One saved row. Reads the post's live `isSaved` so an un-save (from this card's own
- * `PostSaveButton`, or another client/tab) drops the row immediately, and reports that
- * same saved-ness up so the list count + empty-state track it. Ranks are omitted — a
- * saved list has no ordinal meaning.
- */
 function SavedRow({
 	post,
 	onReconcile,
@@ -361,8 +316,6 @@ interface ChromeProps {
 }
 
 function FeedChrome({host, filterId, setFilterId, signedIn, meta, children}: ChromeProps) {
-	// kaydedilenler is a per-viewer chip, so it joins the sort chips only signed-in —
-	// same subnav row, driven by the same `onFilterChange` → `?sort=` mechanism (#1641).
 	const filters = React.useMemo<SubnavFilter[]>(
 		() =>
 			signedIn
@@ -370,12 +323,9 @@ function FeedChrome({host, filterId, setFilterId, signedIn, meta, children}: Chr
 				: PANO_FILTERS,
 		[signedIn],
 	);
-	// Per the nav-IA placement law (#2601), pano's Subnav lives in the persistent product zone
-	// (`PanoSubnavLayout`), not per-page here: publish this feed's filters/meta/crumb UP into
-	// that zone rather than painting a second Subnav, and fold the active site-filter into the
-	// zone's crumb slot as transient state paint — so the resting-chrome PanoCrumb strip is
-	// gone. `inZone` requires the zone ancestor's setter, so the eager public paint above the
-	// router (App.tsx, no ancestor) keeps its own Subnav + PanoCrumb strip.
+	// Pano's Subnav lives in the persistent zone (`PanoSubnavLayout`), so this feed publishes UP
+	// into it rather than painting its own. `inZone` is false only for the eager public paint
+	// above the router (App.tsx has no zone ancestor), which keeps the local Subnav fallback.
 	const setPanoSubnav = useSetPanoSubnavContent();
 	const navigate = useNavigate();
 	const inZone = setPanoSubnav != null;

--- a/apps/web/src/pages/PanoPostDetail.tsx
+++ b/apps/web/src/pages/PanoPostDetail.tsx
@@ -1,13 +1,7 @@
 /**
- * Post-detail page — fate. One batched `useRequest` resolves the header + first
- * page of comments; `PostDetailView` spreads `PanoPostHeaderView` and adds the
- * nested `comments` connection (node: `CommentTreeNodeView`), so children mask
- * their slice off the same refs. See `.patterns/fate-connections.md`.
- *
- * One non-obvious mutation: `comment.delete` returns the parent **`Post`** (the
- * leaf-hard-delete vs parent-soft-delete-tombstone decision is the server's), so
- * fate's `delete: true` can't be used and the resolver drives the thread live.
- * Error routing is the call-site catch — see `.patterns/fate-mutations-client.md`.
+ * Post-detail page. One batched `useRequest` resolves the header + first page of
+ * comments; children mask their slice off the same refs — see
+ * `.patterns/fate-connections.md` and `.patterns/fate-mutations-client.md`.
  */
 import {toEntityId, type ViewData, type ViewEntity, type ViewSelection} from "@nkzw/fate";
 import {ArrowLeft} from "lucide-react";
@@ -59,52 +53,31 @@ const TITLE_MAX = 200;
 const BODY_MAX = 10_000;
 const PAGE_SIZE = 50;
 
-/**
- * `live: {append: "visible"}` makes a server-pushed `appendNode` (a comment from
- * another client) appear immediately, instead of fate's default `"edge"` mode
- * buffering it until a page load. See `.patterns/fate-live-views.md`.
- */
+// `append: "visible"` overrides fate's default `"edge"` buffering — see `.patterns/fate-live-views.md`.
 const CommentConnectionView = {
 	items: {node: CommentTreeNodeView},
 	live: {append: "visible"},
 } as const;
 
-/**
- * The masked data a `CommentTreeNodeView` ref resolves to. The page reads this
- * off each node ref synchronously (`client.readView`) to build the tree, so the
- * type must match `useView(CommentTreeNodeView, ref)` exactly.
- */
+// Must stay exactly what `useView(CommentTreeNodeView, ref)` yields — the tree build
+// reads it off each node ref synchronously via `client.readView`.
 type CommentNodeData = ViewData<
 	ViewEntity<typeof CommentTreeNodeView> & {__typename: "Comment"},
 	ViewSelection<typeof CommentTreeNodeView>
 >;
 
-/**
- * The detail-page view. fate masks by view identity, so the page **spreads**
- * `PanoPostHeaderView` and `CommentTreeNodeView` (via the connection) for the
- * children to mask their slice off the same refs.
- */
 const PostDetailView = view<Post>()({
 	...PanoPostHeaderView,
 	comments: CommentConnectionView,
 });
 
-/**
- * Client view for the `report.submit` ack (ADR 0082 — a report has no read view, so
- * the mutation returns this small receipt). `created` is `false` on the idempotent
- * re-report no-op, which the button surfaces as "zaten bildirildi".
- */
+// A report has no read view, so `report.submit` returns this receipt; `created: false`
+// is the idempotent re-report no-op.
 const ReportReceiptView = view<ReportReceipt>()({
 	id: true,
 	created: true,
 });
 
-/**
- * The page's `bildir` handler factory: submits a report for one target, mapping the
- * outcome to the `ReportButton`'s feedback states and routing a signed-out click to
- * auth. The shared content components stay report-logic-free — they only render the
- * button and forward this handler.
- */
 function useReportHandler() {
 	const fate = useFateClient();
 	const navigate = useNavigate();
@@ -141,7 +114,6 @@ function useReportHandler() {
 	);
 }
 
-/** Post-form copy that overrides the shared {@link WIRE_MESSAGES} base. */
 const POST_OVERRIDES: WireMessageOverrides = {
 	TITLE_REQUIRED: "başlık boş olamaz",
 	TITLE_TOO_LONG: `başlık en fazla ${TITLE_MAX} karakter olabilir`,
@@ -149,7 +121,6 @@ const POST_OVERRIDES: WireMessageOverrides = {
 	POST_NOT_FOUND: "başlık bulunamadı",
 };
 
-/** Comment-form copy that overrides the shared {@link WIRE_MESSAGES} base. */
 const COMMENT_OVERRIDES: WireMessageOverrides = {
 	BODY_REQUIRED: "yorum boş olamaz",
 	BODY_TOO_LONG: `yorum en fazla ${COMMENT_BODY_MAX} karakter olabilir`,
@@ -159,27 +130,20 @@ const COMMENT_OVERRIDES: WireMessageOverrides = {
 
 const currentLocationPath = () => `${window.location.pathname}${window.location.search}`;
 
-/**
- * Router-state key the optimistic delete uses to carry a rejection's inline error
- * back to the detail page it navigated away from (see `onDeleteConfirm`).
- */
 const DELETE_ERROR_STATE_KEY = "postDeleteError";
 
-/** Reads a carried delete-error message off opaque router state, or `null`. */
 function readDeleteError(state: unknown): string | null {
 	if (state == null || typeof state !== "object") return null;
 	const value = (state as Record<string, unknown>)[DELETE_ERROR_STATE_KEY];
 	return typeof value === "string" ? value : null;
 }
 
-/** Client-side comment-body validation. Messages come from the shared registry. */
 const validateCommentBody = (trimmed: string, body: string): string | null => {
 	if (trimmed.length === 0) return messageForCode("BODY_REQUIRED", COMMENT_OVERRIDES);
 	if (body.length > COMMENT_BODY_MAX) return messageForCode("BODY_TOO_LONG", COMMENT_OVERRIDES);
 	return null;
 };
 
-/** Client-side post-edit validation. Messages come from the shared registry. */
 const validatePostFields = (trimmedTitle: string, body: string): string | null => {
 	if (trimmedTitle.length === 0) return messageForCode("TITLE_REQUIRED", POST_OVERRIDES);
 	if (trimmedTitle.length > TITLE_MAX) return messageForCode("TITLE_TOO_LONG", POST_OVERRIDES);
@@ -296,14 +260,9 @@ function PostContentInner({post, idOrSlug}: {post: ViewRef<"Post">; idOrSlug: st
 	}
 
 	async function onDeleteConfirm() {
-		// `delete: true` evicts the post by id across all connections (incl. the feed
-		// root list) — declarative, no imperative updater. fate applies the eviction
-		// SYNCHRONOUSLY, before the round-trip, and rolls it back before a boundary
-		// throw (see `.patterns/fate-mutations-client.md`). The sync eviction already
-		// dropped the row, so navigate to /pano at once — the removal is perceived
-		// instantly and the server `feed.deleteEdge` frame reconciles it away for good
-		// (no reappear). Reconcile the outcome in the background; on rejection fate has
-		// restored the post, so return to it with the inline error.
+		// fate applies `delete: true` synchronously, before the round-trip, so navigating
+		// away immediately is safe; on rejection it restores the post and we navigate back
+		// with the inline error. See `.patterns/fate-mutations-client.md`.
 		setConfirmDelete(false);
 		const promise = fate.mutations.post.delete({input: {id: data.id}, delete: true});
 		const path = postRedirectPath();
@@ -451,30 +410,17 @@ function PostContentInner({post, idOrSlug}: {post: ViewRef<"Post">; idOrSlug: st
 interface CommentsProps {
 	post: ViewRef<"Post">;
 	postId: string;
-	/** The `idOrSlug` the page request resolved under — the read-back refetch re-runs it verbatim. */
 	idOrSlug: string;
-	/** Parent post's canonical path; threaded into each node for its comment-anchor share URL. */
 	postPath: string;
 	signedIn: boolean;
 	currentUserId: string | null;
-	/** Author label (`actorLabel`: display name → @username, never email) for the optimistic comment node; null when signed out. */
 	currentUserName: string | null;
 }
 
-/**
- * Resolves the `#comment-<id>` permalink anchor: returns the targeted comment id and
- * scrolls its node into view once it's rendered. Comments arrive async (fate
- * connection), so the native browser hash-jump misses — and the node mounts only when
- * its `CommentTreeNodeView` snapshot *fulfills*, a store update independent of list
- * membership (#649). Keying a retry on `items.length` therefore races: membership can
- * settle before the target node fulfills, and the effect never re-fires. A
- * MutationObserver watches the thread subtree until `#comment-<id>` exists, scrolls it
- * once, then disconnects — so the cold-load path no longer depends on a reactive key
- * happening to change at the right moment.
- *
- * A permalinked comment on a not-yet-loaded pagination page is never observed (it's
- * not in the DOM) — an accepted product limit.
- */
+// A MutationObserver, not a retry keyed on `items.length`: a node mounts when its view
+// snapshot fulfills, which is independent of list membership, so a reactive key can settle
+// before the target exists and never re-fire (#649). A comment on a not-yet-paginated page
+// is never in the DOM and so never scrolled to — an accepted limit.
 function useCommentAnchor(): string | null {
 	const {hash} = useLocation();
 	const activeId = hash.startsWith("#comment-") ? hash.slice("#comment-".length) : null;
@@ -551,12 +497,8 @@ function Comments(props: CommentsProps) {
 		redirectPath: () => `/pano/${props.postId}`,
 	});
 
-	// The connection resolved every node against `CommentTreeNodeView`, so each
-	// node's masked data is already in the store — read it synchronously (no
-	// per-node hook) and build the tree in the same render the nodes arrive in. A
-	// not-yet-fulfilled node is skipped this frame; membership and node data arrive
-	// together in practice. Re-derives only on `items` change: `parentId` is
-	// immutable and a soft-delete reloads the page.
+	// Read each node's masked data synchronously (no per-node hook) so the tree builds in
+	// the same render the nodes arrive in; a not-yet-fulfilled node is skipped this frame.
 	const {roots, childrenByParent, bodyById, refById, visibleCount, visibleIds, repliedToIds} =
 		React.useMemo(() => {
 			const nodes: Array<CommentNode<ViewRef<"Comment">>> = [];
@@ -572,23 +514,20 @@ function Comments(props: CommentsProps) {
 					ref: node,
 				});
 			}
-			// Non-tombstoned ids, for the delete-side read-back: a hard delete drops the
-			// id from membership, a soft delete tombstones it (deletedAt) — either way
-			// the id leaves this set when the delete reconciled.
+			// The delete-side read-back watches this set: a hard delete drops the id from
+			// membership, a soft delete tombstones it — either way it leaves here.
 			const visibleIds = nodes.filter((n) => n.deletedAt == null).map((n) => n.id);
-			// Every id that some LOADED node names as its parent — the optimistic-delete
-			// branch (ADR 0125 D1) reads this to decide edge-drop (leaf) vs tombstone.
-			// Includes deleted parents so the reply-aware branch mirrors the server's.
+			// Every id some LOADED node names as its parent — the optimistic-delete branch
+			// (ADR 0125) reads it to pick edge-drop vs tombstone. Deleted parents are
+			// included so that branch mirrors the server's.
 			const repliedToIds = new Set(
 				nodes.map((n) => n.parentId).filter((id): id is string => id != null),
 			);
 			return {...buildCommentTree(nodes), visibleIds, repliedToIds};
 		}, [items, fate]);
 
-	// Delete-side read-back (#1687): if the `deleteEdge` (or soft-delete tombstone)
-	// push for the author's own delete is lost server-side, the thread keeps rendering
-	// the deleted comment — refetch `network-only` so it reconciles away, mirroring
-	// the add-side self-heal above.
+	// Delete-side twin of the read-back above: a lost `deleteEdge` push would otherwise
+	// leave the deleted comment rendered forever (#1687).
 	const confirmCommentGone = useConfirmGone({
 		presentIds: visibleIds,
 		refetch: refetchPost,
@@ -610,11 +549,9 @@ function Comments(props: CommentsProps) {
 		await runDelete(
 			() => {
 				const promise = fate.mutations.comment.delete({input: {id: deletedId}});
-				// Optimistic (ADR 0125 D1): mirror the server branch from the loaded tree —
-				// a client-certain leaf drops its edge, a reply parent OR an incompletely-
-				// loaded thread (uncertain) tombstones. `loadNext == null` ⇒ the whole
-				// thread is loaded, so an empty reply set is a true leaf. Roll the write
-				// back on any failure — the server frame reconciles it away otherwise.
+				// Mirror the server's branch from the loaded tree (ADR 0125): an empty reply set
+				// only proves a leaf when `loadNext == null` (whole thread loaded); otherwise
+				// tombstone, because the reply may sit on an unloaded page.
 				const strategy = decideCommentDelete({
 					hasLoadedReply: repliedToIds.has(deletedId),
 					threadComplete: loadNext == null,
@@ -641,13 +578,9 @@ function Comments(props: CommentsProps) {
 		);
 	}
 
-	// The optimistic-add bundle both composers share (top-level + every reply insert
-	// into the SAME nested `Post.comments` connection). Null unless the author identity
-	// is known — the temp node mirrors the author, so a missing name/id degrades cleanly
-	// to the non-optimistic round-trip.
-	// `sandboxed` comes from the trusted account tier on the fate `me` view (#1297), the
-	// same signal `FirstContributionOnramp` gates on — so the temp node predicts the
-	// server's create-time answer instead of flashing as published (#4282).
+	// Null unless the author identity is known — the temp node mirrors the author, so a
+	// missing name/id degrades to the plain round-trip. `sandboxed` predicts the server's
+	// create-time answer so a çaylak's comment never flashes as published (#4282).
 	const {me} = useMe();
 	const optimisticComment = React.useMemo(
 		() =>
@@ -790,17 +723,9 @@ function Comments(props: CommentsProps) {
 	);
 }
 
-/**
- * Top-level + nested comment composer — fate. Submits `comment.add`; the server's
- * `appendNode` live event merges the new comment into the thread in place (the
- * author's own view included), since nested-connection membership is server-driven.
- *
- * When `optimistic` is set (the author identity is known, ADR 0125 A1),
- * the temp node also appears in the thread *before* the round-trip: fate's
- * `optimistic` payload writes + reconciles the temp entity, and
- * {@link beginOptimisticCommentMembership} appends the temp id into the nested
- * `Post.comments` connection and rolls it back on reject.
- */
+// Nested-connection membership is server-driven, so the thread updates off the
+// `appendNode` push; the optimistic path (ADR 0125) only front-runs it. See
+// `.patterns/fate-mutations-client.md`.
 function CommentComposer({
 	postId,
 	parentId,
@@ -816,14 +741,11 @@ function CommentComposer({
 	signedIn: boolean;
 	onPosted: () => void;
 	onCancel?: () => void;
-	/** Hands the created comment's id to the deterministic read-back (see {@link useReadbackRefetch}). */
 	onConfirm?: (commentId: string) => void;
-	/** Optimistic-add bundle (flag on + known author); null ⇒ non-optimistic round-trip. */
 	optimistic?: {
 		connection: unknown;
 		author: string;
 		authorId: string;
-		/** Whether this author's comment lands in the çaylak sandbox (#4282). */
 		sandboxed: boolean;
 	} | null;
 	autoFocus?: boolean;
@@ -862,13 +784,9 @@ function CommentComposer({
 			});
 			const rollback =
 				optimistic && optimisticRecord
-					? // Qualify the temp id: runtime `Post.comments.list.ids` are `toEntityId`-
-						// qualified (`Comment:<id>`) — fate stores every list id via `toEntityId`
-						// (writeEntity/insertConnectionEdge), and both reconcile paths key off the
-						// qualified id (`resolveOptimisticEntity` rewrites the qualified `previousId`;
-						// the SSE `appendNode` dedups by `toEntityId(nodeType, id)`). A BARE
-						// `optimistic:<ts>` would neither rewrite nor dedup, leaving a duplicated /
-						// non-reconciling temp node (#1714). Matches #1679 definition.add + #1680 delete.
+					? // The temp id MUST be `toEntityId`-qualified: both reconcile paths key off the
+						// qualified id, so a bare `optimistic:<ts>` neither rewrites nor dedups and
+						// leaves a duplicated temp node (#1714).
 						beginOptimisticCommentMembership(
 							fate.store,
 							optimistic.connection,
@@ -879,13 +797,11 @@ function CommentComposer({
 			try {
 				const {result, error: callError} = await promise;
 				createdId.current = result?.id != null ? String(result.id) : null;
-				// callSite reject: fate rolled the temp record back but not this nested
-				// membership — undo it so no phantom row is left (rollback AC).
+				// fate rolls the temp record back but not this nested membership, so both
+				// failure paths have to undo it by hand or a phantom row is left behind.
 				if (callError) rollback?.();
 				return {error: callError};
 			} catch (caught) {
-				// boundary throw: same — roll the membership back, then let useDraftSubmit
-				// classify the throw (UNAUTHORIZED redirect / inline error).
 				rollback?.();
 				throw caught;
 			}
@@ -972,12 +888,6 @@ function CommentComposer({
 	);
 }
 
-/**
- * Inline comment edit composer — fate. `comment.edit` writes the new body back
- * through `CommentTreeNodeView` (the view the node reads), so it re-renders in
- * place; it also passes an optimistic `{body, updatedAt}` so the edit renders
- * before the round-trip (#1675).
- */
 function CommentEditComposer({
 	commentId,
 	initialBody,

--- a/apps/web/src/pages/PanoSubmitPage.tsx
+++ b/apps/web/src/pages/PanoSubmitPage.tsx
@@ -24,10 +24,9 @@ import "./PanoSubmitPage.css";
 
 type Mode = "link" | "text";
 
-/** The submit route — keys the autosaved draft, matching the auth `returnTo` below (#1214). */
 const PANO_SUBMIT_ROUTE = "/pano/yeni";
 
-/** The client-side autosave draft for the pano submit form (localStorage, not the server `saveDraft`). */
+// The client-side autosave draft (localStorage), not the server-side `saveDraft`.
 interface PanoDraft {
 	mode: Mode;
 	url: string;
@@ -52,9 +51,7 @@ function isPanoDraft(value: unknown): value is PanoDraft {
 const isPanoDraftEmpty = (d: PanoDraft): boolean =>
 	d.url.trim() === "" && d.title.trim() === "" && d.body.trim() === "" && d.tags.length === 0;
 
-// The five kinds + their CSS modifier (`cls`) come from the shared typed home
-// `src/lib/panoTags.ts` (#1030) — the same module the server allow-list imports,
-// so the form can't drift from the producer enum.
+// Sourced from the same module the server allow-list imports, so the form can't drift.
 const TAGS = POST_TAG_KINDS.map((kind) => ({kind, label: tagLabel(kind), cls: tagClass(kind)}));
 
 const URL_RE = /^https?:\/\/[^/]+/i;
@@ -68,7 +65,6 @@ const TITLE_MAX = 200;
 const BODY_MAX = 10_000;
 const TITLE_MIN = 5;
 
-/** Submit-form copy that overrides the shared {@link WIRE_MESSAGES} base. */
 const PANO_SUBMIT_OVERRIDES: WireMessageOverrides = {
 	TITLE_REQUIRED: "başlık boş olamaz",
 	TITLE_TOO_LONG: `başlık en fazla ${TITLE_MAX} karakter olabilir`,
@@ -101,8 +97,6 @@ export function PanoSubmitPage() {
 		run,
 	} = useDraftSubmit({overrides: PANO_SUBMIT_OVERRIDES, redirectPath: () => "/pano/yeni"});
 
-	// Prefill the (still-empty) title/context from the pasted link's metadata on
-	// URL blur — the shared policy in `prefillIfEmpty` never clobbers user input.
 	async function prefillFromUrl() {
 		const meta = await fetchMetadata(url);
 		prefillIfEmpty(title, meta.title, setTitle);
@@ -165,11 +159,9 @@ export function PanoSubmitPage() {
 		const linkUrl = mode === "link" && trimmedUrl ? trimmedUrl : null;
 		await run(
 			() =>
-				// The pano feed is a registered no-filter root list, so `insert: "before"`
-				// declaratively prepends the new post with a temp-id optimistic node fate
-				// reconciles to the server id (the same row `live.post.feed.appendNode`
-				// carries — reconcile dedups by id, so no double-row for the mutator's own
-				// client). See `.patterns/fate-mutations-client.md`.
+				// The optimistic prepend and the `appendNode` push carry the same row; fate's
+				// reconcile dedups by id, so the mutator's own client gets no double-row.
+				// See `.patterns/fate-mutations-client.md`.
 				fate.mutations.post.submit({
 					input: {
 						title: trimmedTitle,
@@ -183,10 +175,8 @@ export function PanoSubmitPage() {
 						url: linkUrl,
 						host: linkUrl ? hostOf(linkUrl) : null,
 						tags: Array.from(selectedTags),
-						// Shared actor-label rule (#2126): display name → fixed noun, never the
-						// email the old `?? user.email` could leak into the optimistic author.
-						// The session user has no typed `username`; the server round-trip
-						// replaces this optimistic author with the stored value.
+						// Never fall back to `user.email` here — it would leak into the rendered
+						// optimistic author (#2126).
 						author: actorLabel(user.name, null, "kullanıcı"),
 						authorId: user.id,
 						now,
@@ -194,7 +184,7 @@ export function PanoSubmitPage() {
 				}),
 			"gönderi paylaşılamadı",
 			(result) => {
-				draft.clear(); // submitted successfully — the autosaved draft is spent
+				draft.clear();
 				const newId = result?.slug ?? result?.id;
 				if (newId) navigate(`/pano/${newId}`);
 			},

--- a/apps/web/src/pages/ProfilePage.test.tsx
+++ b/apps/web/src/pages/ProfilePage.test.tsx
@@ -1,25 +1,14 @@
 /**
- * Precedence pins for `ProfilePage`'s `readUsername` — the load-bearing me-hop removal
- * of #2188 (ADR 0167's two-tier decoupling extended to `/profile`). The counts + Katkıların
- * reads key on the SESSION username the instant `FateProvider` commits, dropping the third
- * serial `me?.username` round-trip that made the reads land ~822ms late.
- *
- * `App.test.tsx` mocks both `useMe` and `useProfileStats` inert, so it never exercises
- * `readUsername`'s precedence — a silent revert to `me?.username` (reintroducing the serial
- * waterfall) would pass every test there. These render the REAL `ProfilePage` and read back
- * which username the two identity-scoped reads actually receive: the counts read via the
- * `useProfileStats` argument, and the contributions read via the `ProfileContributionSignal`
- * `username` prop. The precedence test fails on that revert; the fallback test guards the
- * `me` fallback for the brief post-`setUsername` window the session row lags.
+ * Precedence pins for `ProfilePage`'s `readUsername` (#2188). `App.test.tsx` mocks both
+ * `useMe` and `useProfileStats` inert, so a silent revert to `me?.username` — which
+ * reintroduces the serial waterfall — passes every test there but fails here.
  */
 import {render, screen} from "@testing-library/react";
 import {MemoryRouter} from "react-router";
 import {afterEach, beforeEach, describe, expect, it, vi} from "vitest";
 import {ProfilePage} from "./ProfilePage";
 
-// Controllable session + `me` — the two identity sources `readUsername` chooses between.
-// `sessionUsername === undefined` models the absent session `username` (the post-setUsername
-// lag window); a string models the settled, present-and-correct value.
+// `sessionUsername === undefined` models the post-setUsername lag window.
 let sessionUsername: string | null | undefined;
 let meUsername: string | null;
 
@@ -50,8 +39,6 @@ vi.mock("../auth/useMe", () => ({
 	}),
 }));
 
-// Capture the username the COUNTS read (`useProfileStats`) receives — the arg IS the
-// assertion. Stays `idle` so it touches no wire.
 const statsCalls: (string | null | undefined)[] = [];
 vi.mock("./useProfileStats", () => ({
 	useProfileStats: (username: string | null | undefined) => {
@@ -60,29 +47,24 @@ vi.mock("./useProfileStats", () => ({
 	},
 }));
 
-// Capture the username the CONTRIBUTIONS read receives via the real prop `ProfilePage`
-// passes; rendered inert (its own fate reads are pinned by ProfileContributionSignal's tests).
 vi.mock("../components/profile/ProfileContributionSignal", () => ({
 	ProfileContributionSignal: ({username}: {username: string}) => (
 		<div data-testid="contrib-username">{username}</div>
 	),
 }));
 
-// Inert stubs for the fate-touching / dialog children — not under test here.
 vi.mock("../components/profile/CaylakStatusBlock", () => ({CaylakStatusBlock: () => null}));
 vi.mock("../components/profile/DeleteAccountDialog", () => ({DeleteAccountDialog: () => null}));
 vi.mock("../components/profile/ProfileHeader", () => ({ProfileHeader: () => null}));
 
-// Flag ON so the Katkıların contribution signal renders and its `username` prop is observable;
-// the counts read fires regardless of the flag.
+// Flag ON so the contribution signal renders and its `username` prop is observable.
 vi.mock("../flags/useFlag", () => ({useFlag: () => ({value: true, loading: false})}));
 
-// Appearance controls need their providers; stub the hooks inert — irrelevant to `readUsername`.
 vi.mock("../lib/theme", () => ({useTheme: () => ({choice: "auto", setChoice: vi.fn()})}));
 vi.mock("../lib/density", () => ({useDensity: () => ({choice: "normal", setChoice: vi.fn()})}));
 
-// Keep react-fate's real `view` (used at module load for `SetDisplayNameView`); stub the
-// client hook so no transport is built. `fate.mutations` is only touched by onSaveName, never render.
+// Keep react-fate's real `view` — `SetDisplayNameView` calls it at module load — while
+// stubbing the client hook so no transport is built.
 vi.mock("react-fate", async (importOriginal) => {
 	const actual = await importOriginal<typeof import("react-fate")>();
 	return {...actual, useFateClient: () => ({mutations: {}}) as never};
@@ -105,22 +87,17 @@ describe("ProfilePage readUsername precedence (#2188 — the me-hop removal)", (
 	});
 
 	it("keys the counts + contributions reads on the SESSION username, not the round-tripped me row", () => {
-		// The session username and the canonical `me` row DIVERGE. The win is reading off the
-		// session value (available the instant FateProvider commits), never the later `me` hop.
+		// The two sources DIVERGE, so the assertion names which one won.
 		sessionUsername = "session-uname";
 		meUsername = "stale-me-uname";
 
 		renderProfile();
 
-		// REGRESSION: a silent revert of `readUsername` to `me?.username` reintroduces the serial
-		// waterfall — the counts read would receive "stale-me-uname" and this fails.
 		expect(statsCalls.at(-1)).toBe("session-uname");
 		expect(screen.getByTestId("contrib-username").textContent).toBe("session-uname");
 	});
 
 	it("falls back to me.username when the session username is absent (the post-setUsername lag window)", () => {
-		// Right after a setUsername write the session row still lags the just-written username, so
-		// `session.data.user.username` is absent; the read falls back to the canonical `me` row.
 		sessionUsername = undefined;
 		meUsername = "canonical-me-uname";
 

--- a/apps/web/src/pages/ProfilePage.tsx
+++ b/apps/web/src/pages/ProfilePage.tsx
@@ -16,7 +16,6 @@ import {type ThemeChoice, useTheme} from "../lib/theme";
 import {useProfileStats} from "./useProfileStats";
 import "./ProfilePage.css";
 
-/** The `User` write-back selection for the `setDisplayName` result. */
 const SetDisplayNameView = view<User>()({
 	id: true,
 	email: true,
@@ -39,13 +38,9 @@ export function ProfilePage() {
 	const {me, status: meStatus, refetch: refetchMe} = useMe();
 	const fate = useFateClient();
 	const u = session.data?.user;
-	// The username the profile READS (counts + Katkıların contributions) key on. Prefer
-	// the settled session identity — available the instant `FateProvider` commits — so
-	// the read fires WITHOUT the extra canonical-`me` round-trip that used to gate it,
-	// the third serial hop that made Katkıların land ~1.8s late (#2188). `username` is
-	// server-managed + immutable once set (`better-auth-live.ts`), so the session value
-	// equals `me.username`; fall back to `me` only for the brief post-`setUsername`
-	// window where the session row still lags the just-written username (see `useMe`).
+	// Session first, so the reads don't wait on the canonical `me` round-trip (#2188);
+	// `username` is immutable once set, so `me` is only the fallback for the brief window
+	// where the session row lags a just-written username.
 	const readUsername = u?.username ?? me?.username ?? null;
 	const statsState = useProfileStats(readUsername);
 	// A failed stats (or `me`) fetch must NOT render as `0` — that's the silent
@@ -58,33 +53,19 @@ export function ProfilePage() {
 	const [revokeAllError, setRevokeAllError] = useState<string | null>(null);
 	const [deleteOpen, setDeleteOpen] = useState(false);
 
-	// Route the identity mirror through the shared actor-label rule (#2126): the
-	// display name, falling back to the chosen @username, never the email-derived
-	// local-part the old code leaked. `me` (the canonical row) is the source for the
-	// display username — the session user's `username` can briefly lag right after a
-	// setUsername write (see useMe); `me.name` is the display name.
+	// Both fall back to the fixed noun, never the email local-part (#2126).
 	const username = me?.username ?? null;
 	const name = actorLabel(me?.name ?? u?.name ?? null, username, "kullanıcı");
-	// The handle line is the chosen username; on the settings page the account is
-	// always booted, so `username` is set — the `kullanıcı` fallback is only the
-	// defensive not-yet-booted degenerate, never the email local-part.
 	const handle = username ?? "kullanıcı";
-	// The handle-line standing label, derived from the trusted tier (#1302) instead
-	// of the old hard-coded `· yeni üye` lie. `null` (no honest tier) → handle-only,
-	// never a placeholder.
+	// `null` (no honest tier) renders handle-only rather than a placeholder standing.
 	const standingLabel = profileStandingLabel(me?.tier);
 
 	const [draftName, setDraftName] = useState(name);
 	const [saveState, setSaveState] = useState<SaveState>("idle");
 
-	// better-auth's session atom starts {data:null, isPending:true} and resolves
-	// asynchronously with no synchronous hydration, so on a hard load these hooks run
-	// before the session is known and `name` is the "user" fallback — draftName would
-	// lock to it and never re-seed. Re-seed the draft when the server name changes out
-	// from under the draft we're still showing (initial resolution, or another tab's
-	// edit), so a refresh shows the saved name. A draft the user has since edited away
-	// from the old server name is left alone, and a save's own refetch doesn't fire the
-	// reset because draftName already equals the new name — preserving the "saved" note.
+	// The session resolves after first render, so `name` starts as the fallback and the
+	// draft has to re-seed when the real name lands. Only re-seed an untouched draft: one
+	// the user has edited away from the old server name is left alone.
 	const serverName = useRef(name);
 	useEffect(() => {
 		if (draftName === serverName.current) setDraftName(name);
@@ -97,13 +78,9 @@ export function ProfilePage() {
 	const trimmed = draftName.trim();
 	const canSave = saveState !== "saving" && trimmed.length > 0 && trimmed !== name;
 
-	// Save the görünen ad through the WORKER mutation, not `authClient.updateUser`
-	// (#2154): `user.setDisplayName` writes `user.name` AND the stamped
-	// `user_profile.display_name` in lockstep, so a rename reaches every author
-	// byline. `authClient.updateUser` only touched better-auth `user.name`, which
-	// never propagated to the stamped column — the one-shot-sync bug. Refetch `me`
-	// (the canonical header row) and the session (better-auth's cached `user.name`)
-	// so both surfaces show the saved name.
+	// Must go through the worker mutation, NOT `authClient.updateUser`: only the mutation
+	// also writes the stamped `user_profile.display_name` a rename needs to reach every
+	// byline (#2154). Both `me` and the session cache the name, so both get refetched.
 	async function onSaveName() {
 		const next = draftName.trim();
 		if (!next || next === name) return;
@@ -147,9 +124,8 @@ export function ProfilePage() {
 		clearBearerToken();
 	}
 
-	// account.delete already tore down every session row server-side, so this only
-	// drops the now-dead local bearer + refetches the (now empty) session; the
-	// <Navigate to="/auth"> guard lands the sessionless user on auth.
+	// `account.delete` already tore down every session row server-side; this is only the
+	// local cleanup, and the `<Navigate>` guard above lands the sessionless user on auth.
 	async function onAccountDeleted() {
 		clearBearerToken();
 		setDeleteOpen(false);
@@ -169,15 +145,10 @@ export function ProfilePage() {
 					showKarma
 				/>
 
-				{/* The çaylak's own "yazarlığa giden yol" tracker (#1291), surfaced on the
-				    self-service profile too (#2203) so promotion progress is reachable from
-				    settings, not only the public /u/ page. Reuses the existing block, which
-				    self-gates on own-profile + çaylak. */}
 				{me?.id ? <CaylakStatusBlock profileUserId={me.id} /> : null}
 
-				{/* Thin contribution signal (#1209) — the owner's own track record. The
-				    owner sees their OWN sandboxed content here (the feed keys on authorId
-				    with no sandbox filter). */}
+				{/* The owner sees their OWN sandboxed content here: this feed keys on authorId
+				    with no sandbox filter. */}
 				{readUsername ? <ProfileContributionSignal username={readUsername} /> : null}
 
 				<section className="kp-profile__section">

--- a/apps/web/src/pages/SearchPage.tsx
+++ b/apps/web/src/pages/SearchPage.tsx
@@ -1,13 +1,7 @@
 /**
- * Search-results page — fate (ADR 0080). Reads `q` from the URL (`/search?q=…`)
- * and resolves both per-type search roots in ONE batched
- * `useRequest({searchTerms, searchPosts})` — no unified result type: terms render
- * with the verbatim `TermRow`, posts with `PanoPostCard` (`worker/features/search/lists.ts`).
- * The backend ranks by bm25 and owns the keyset; this page only declares the
- * connections and paginates them via `useListView` `loadNext`.
- *
- * A query shorter than the backend minimum (2 chars) never reaches the resolver —
- * the prompt state renders before `<Screen>`, so no request is issued.
+ * Search-results page — see ADR 0080. Two per-type roots, no unified result type; the
+ * backend ranks and owns the keyset. A query under the backend's minimum renders the
+ * prompt outside `<Screen>`, so it issues no request at all.
  */
 import {useListView, useRequest} from "react-fate";
 import {useSearchParams} from "react-router";
@@ -58,7 +52,6 @@ export function SearchPage() {
 	);
 }
 
-/** Shown when there's no query (or it's below the backend's 2-char minimum). */
 function SearchPrompt() {
 	return <p className="kp-search__rail">aramak için en az {MIN_QUERY_LENGTH} harf girin.</p>;
 }

--- a/apps/web/src/pages/SozlukHome.tsx
+++ b/apps/web/src/pages/SozlukHome.tsx
@@ -1,12 +1,7 @@
 /**
- * Sözlük home page — fate. Two term connections (recent + popular) resolve in one
- * batched `useRequest({recentTerms, popularTerms})`; each maps to a fixed-sort
- * `list` root over the `terms` keyset (see `worker/features/sozluk/lists.ts`).
- * The masthead promotes a `+ yeni tanım` create CTA — the "go to a term" search half
- * folded into the global ⌘K `ara` (#2995, the #2412 single-search contract), so this
- * page carries no local search box. The alphabet's letter filter (`?harf=`) still
- * narrows the already-loaded first page client-side, so the filtered-to-zero copy names
- * that scope ("ilk sayfada"), never the whole corpus.
+ * Sözlük home page. No local search box — that folded into the global ⌘K (#2995). The
+ * `?harf=` letter filter narrows only the already-loaded first page, client-side, which
+ * is why the filtered-to-zero copy names that scope ("ilk sayfada") not the whole corpus.
  */
 import * as React from "react";
 import {useListView, useRequest, useView, type ViewRef} from "react-fate";
@@ -28,9 +23,8 @@ const homeRequest = {
 
 type TermConnection = ReturnType<typeof useRequest<typeof homeRequest>>["recentTerms"];
 
-// The active letter is URL-driven (`/sozluk?harf=<letter>`, issue #693): the
-// alphabet renders real links, so the filter is shareable + back-button-correct
-// rather than transient component state.
+// The letter lives in the URL, not component state, so the filter is shareable and
+// back-button-correct.
 export function SozlukHome() {
 	const [params] = useSearchParams();
 	const letter = params.get("harf") ?? undefined;
@@ -100,15 +94,8 @@ function SozlukHomeChrome({status, errorMessage, children}: ChromeProps) {
 	);
 }
 
-/**
- * Tracks which rows survive the client-side letter filter. Each row reads its own fate
- * view, so match state can only be reported up per-row via `onMatch`; this hook owns the
- * resulting map and derives the column's display state from it.
- *
- * - `empty` — the connection itself has zero terms (genuine-empty).
- * - `no-match` — terms exist but the letter filter excluded every loaded row.
- * - `ok` — at least one row is visible.
- */
+// Each row reads its own fate view, so match state can only travel up per-row; this hook
+// owns the map and separates a genuinely empty connection from a filtered-to-zero one.
 function useFilteredColumn(items: readonly {node: ViewRef<"Term">}[]) {
 	const [matches, setMatches] = React.useState<Record<string, boolean>>({});
 	const onMatch = React.useCallback((id: string, matched: boolean) => {
@@ -153,11 +140,6 @@ function ColumnEmptyState({children}: {children: React.ReactNode}) {
 	return <p className="kp-sozluk-home__empty">{children}</p>;
 }
 
-/**
- * A column row that reads its own title and drops out of the DOM when the active
- * letter excludes it, with the filter colocated. Used by both columns so a letter
- * filters "son eklenenler" and "en çok oylananlar" alike.
- */
 function FilterableTermRow({
 	node,
 	letter,

--- a/apps/web/src/pages/SozlukTermPage.test.tsx
+++ b/apps/web/src/pages/SozlukTermPage.test.tsx
@@ -1,10 +1,3 @@
-/**
- * Anon-affordance regression for the existing-term definition composer (#2211): a
- * logged-out visitor must see a sign-in prompt, never the live composer they can't
- * submit — matching the sözlük new-term branch and pano. The fate read hooks are
- * spied (the composer never mounts on the signed-out path, so its own deep wiring
- * is out of scope); the gate is driven purely by the mocked session.
- */
 import {render, screen} from "@testing-library/react";
 import type {ViewRef} from "react-fate";
 import {MemoryRouter} from "react-router";
@@ -26,8 +19,7 @@ vi.mock("../fate/useReadbackRefetch", () => ({
 	useConfirmGone: () => vi.fn(),
 }));
 
-// Composer leaf deps — stubbed so the signed-in branch mounts the composer without
-// its full fate/flag/draft wiring (the gate, not the composer internals, is under test).
+// Composer leaf deps, stubbed so the signed-in branch mounts without its full wiring.
 vi.mock("../flags/useFlag", () => ({useFlag: () => ({value: false, loading: false})}));
 vi.mock("../components/authorship/FirstContributionOnramp", () => ({
 	FirstContributionOnramp: () => null,

--- a/apps/web/src/pages/SozlukTermPage.tsx
+++ b/apps/web/src/pages/SozlukTermPage.tsx
@@ -1,14 +1,7 @@
 /**
- * Sözlük term page — fate. One batched `useRequest` resolves header + first page
- * of definitions; `TermView` spreads `TermHeaderView` and adds the nested
- * `definitions` connection (see `.patterns/fate-connections.md`). `definition.add`
- * is server-driven live; the fresh-slug branch (no term yet, so no list to append
- * to) forces a `network-only` re-read of `term(slug)` before remounting — the
- * remount's own render-path read reuses the first mount's fulfilled `data:null`
- * handle WITHOUT refetching (#817), so the re-read must precede it — then arms the
- * deterministic read-back with the mutation's own returned id, so the just-created
- * definition is guaranteed to materialize even if the live `appendNode` push was
- * lost (#730/#714, epic #713).
+ * Sözlük term page. One batched `useRequest` resolves the header + first page of
+ * definitions (see `.patterns/fate-connections.md`). The page has two branches: an
+ * existing term, and a slug with no term yet, where the first definition creates it.
  */
 import * as React from "react";
 import {
@@ -47,7 +40,6 @@ import "./SozlukTermPage.css";
 const PAGE_SIZE = 50;
 const BODY_MAX = 10_000;
 
-/** The client-side autosave draft for the definition composer (localStorage, keyed by `/sozluk/<slug>`). */
 interface DefinitionDraft {
 	body: string;
 }
@@ -62,39 +54,24 @@ function isDefinitionDraft(value: unknown): value is DefinitionDraft {
 
 const isDefinitionDraftEmpty = (d: DefinitionDraft): boolean => d.body.trim() === "";
 
-/**
- * `live: {append: "visible"}` makes a server-pushed `appendNode` (a new
- * definition, this client's own included) appear immediately, instead of fate's
- * default `"edge"` mode buffering it until a page load. See `.patterns/fate-live-views.md`.
- */
+// `append: "visible"` overrides fate's default `"edge"` buffering — see `.patterns/fate-live-views.md`.
 const DefinitionConnectionView = {
 	items: {node: DefinitionView},
 	live: {append: "visible"},
 } as const;
 
-/**
- * The term-page view. fate masks by **view identity**: a child's
- * `useView(ChildView, ref)` works only if `ChildView` was **spread** into the
- * view the ref was built from — overlapping field names is not enough.
- */
+// A child's `useView(ChildView, ref)` works only if `ChildView` was SPREAD in here —
+// fate masks by view identity, so matching field names is not enough.
 const TermView = view<Term>()({
 	...TermHeaderView,
 	definitions: DefinitionConnectionView,
 });
 
-/** Definition-composer copy that overrides the shared {@link WIRE_MESSAGES} base. */
 const SOZLUK_OVERRIDES: WireMessageOverrides = {
 	BODY_REQUIRED: "tanım boş olamaz",
 	BODY_TOO_LONG: `tanım en fazla ${BODY_MAX} karakter olabilir`,
 };
 
-/**
- * Layout-preserving Suspense fallback for the term page: a header block (crumbs +
- * title + meta) over a few definition-shaped rows, so the page doesn't jump when the
- * real term resolves into the same {@link SozlukTermHeader} + {@link DefinitionCard}
- * shape. The precedent is `LandingColsSkeleton` — a placeholder mirroring the real
- * content, built from the shared {@link Skeleton} atom.
- */
 function SozlukTermSkeleton() {
 	return (
 		<div role="status" aria-busy="true" aria-label="yükleniyor…" data-testid="sozluk-term-loading">
@@ -126,12 +103,9 @@ function SozlukTermSkeleton() {
 export function SozlukTermPage() {
 	const {slug} = useParams<{slug: string}>();
 	const safeSlug = slug ?? "";
-	// Bumped when the fresh-slug composer auto-creates the term: remounts the content
-	// so it reads the now-existing term and flips to the connection branch — no full
-	// reload. The composer force-refetches `term(slug)` before bumping this, since the
-	// remount's own render read reuses the stale fulfilled-null handle (#817).
-	// `createdDefinitionId` carries the mutation's own authoritative result across the
-	// remount so the now-list branch can arm its deterministic read-back on it (#730).
+	// Bumping `reloadKey` remounts the content onto the now-existing term. The composer
+	// must force-refetch `term(slug)` BEFORE bumping it, or the remount's render read
+	// reuses the stale fulfilled-null handle (#817).
 	const [{reloadKey, createdDefinitionId}, setRemount] = React.useState<{
 		reloadKey: number;
 		createdDefinitionId: string | null;
@@ -186,8 +160,6 @@ function SozlukTermContent({
 	const signedIn = !!session.data?.user;
 
 	if (!term) {
-		// Signed-out viewers can't auto-create a term, so they get the 404;
-		// signed-in viewers get the composer that auto-creates it on first define.
 		if (!signedIn) {
 			return (
 				<NotFoundPage
@@ -207,11 +179,6 @@ function SozlukTermContent({
 	);
 }
 
-/**
- * Header + composer for the slug-doesn't-exist-yet branch. The first definition
- * auto-creates the term, then `onCreated` remounts the content — carrying the new
- * definition's id so the list branch confirms it deterministically (#730).
- */
 function NewTermComposer({
 	slug,
 	onCreated,
@@ -242,12 +209,7 @@ function NewTermComposer({
 interface DefinitionsListProps {
 	term: ViewRef<"Term">;
 	slug: string;
-	/**
-	 * The id `definition.add` returned on the fresh-slug remount, or `null` on a
-	 * plain load. When set, the list arms its read-back on this id at mount so the
-	 * just-created definition materializes even if the live `appendNode` push was
-	 * lost (#730/#714).
-	 */
+	// Set only on the fresh-slug remount: the id the list arms its read-back on (#730).
 	seedDefinitionId: string | null;
 }
 
@@ -275,19 +237,15 @@ export function DefinitionsList(props: DefinitionsListProps) {
 		refetch: refetchTerm,
 	});
 
-	// Delete-side read-back (#1687): if the `deleteEdge` push for the author's own
-	// delete is lost server-side, the row lingers — refetch `network-only` so it
-	// reconciles away, mirroring the add-side self-heal above.
+	// Delete-side twin of the read-back above: a lost `deleteEdge` push would otherwise
+	// leave the deleted row rendered forever (#1687).
 	const confirmDefinitionGone = useConfirmGone({
 		presentIds: items.map(({node}) => String(node.id)),
 		refetch: refetchTerm,
 	});
 
-	// Fresh-slug arrival: this list mounted because a `definition.add` just created the
-	// term (the composer already force-refetched the term, so it resolved non-null).
-	// Confirm the mutation's own returned id once on mount; the read-back settles
-	// instantly if the term re-read already carried the definition, else deterministically
-	// refetches it in. Without this the just-created definition silently dropped (#730).
+	// On the fresh-slug remount, confirm the mutation's own returned id once; without it
+	// the just-created definition silently dropped (#730).
 	const {seedDefinitionId} = props;
 	React.useEffect(() => {
 		if (seedDefinitionId != null) confirmDefinition(seedDefinitionId);
@@ -319,12 +277,6 @@ export function DefinitionsList(props: DefinitionsListProps) {
 	);
 }
 
-/**
- * Anon affordance for an existing term: a logged-out visitor can't add a definition,
- * so the live composer is replaced by a sign-in prompt — mirroring the new-term
- * branch ({@link SozlukTermContent}) and pano, instead of inviting an action anon
- * can't complete (#2211).
- */
 function DefinitionSignInPrompt({slug}: {slug: string}) {
 	return (
 		<div className="kp-sozluk-composer" data-testid="sozluk-composer-signin">
@@ -338,20 +290,9 @@ function DefinitionSignInPrompt({slug}: {slug: string}) {
 	);
 }
 
-/**
- * Definition composer wired to `fate.mutations.definition.add`. Membership in the
- * *nested* `Term.definitions` connection is server-driven (fate's declarative
- * `insert` only targets registered root lists), so an optimistic node is injected
- * by a phoenix client helper rather than `insert` (ADR 0125, #1679): the new
- * definition shows instantly, temp-node reconciled to the server id (dedup by
- * canonical id vs the live append). `onTermCreated` is passed only on the fresh-slug
- * branch, where there's no list yet to append to (so the optimistic append is skipped
- * there); it force-refetches `term(slug)` then carries the new definition's id across
- * the remount so the list branch arms its read-back on it. On the list branch
- * `onConfirm` hands the new id to the same deterministic read-back — narrowed to the
- * append-loss healer, since the optimistic node is already present — so a lost live
- * `appendNode` self-heals (see {@link useReadbackRefetch}).
- */
+// fate's declarative `insert` only targets registered ROOT lists, and `Term.definitions`
+// is nested, so the optimistic node goes in through a client helper instead (ADR 0125).
+// Exactly one of `onTermCreated` (fresh slug) / `onConfirm` (existing term) is passed.
 function Composer({
 	slug,
 	onTermCreated,
@@ -398,16 +339,11 @@ function Composer({
 		}
 		if (disabled) return;
 		const user = session.data.user;
-		// Optimistic nested-append (ADR 0125) only on the existing-term branch: the
-		// fresh-slug branch (onTermCreated) has no loaded definitions list to append
-		// to and drives its own force-refetch + remount, left untouched.
+		// Optimistic append only on the existing-term branch — the fresh-slug branch has no
+		// loaded list to append to.
 		const optimistic = buildOptimisticDefinition(!onTermCreated, {
 			body,
-			// Route through the shared actor-label rule (#2126): display name, falling
-			// back to a fixed noun, NEVER the email — the old `?? user.email` could
-			// surface a user's email in the optimistic author line (a PII leak). The
-			// session user carries no typed `username`, so the middle @username tier is
-			// unreachable here; the server round-trip replaces this optimistic value.
+			// Never fall back to `user.email` here — it would render in the author line (#2126).
 			author: actorLabel(user.name, null, "kullanıcı"),
 			authorId: user.id,
 		});
@@ -419,12 +355,9 @@ function Composer({
 					...(optimistic ? {optimistic, insert: "none" as const} : {}),
 				});
 				if (optimistic) {
-					// fate wrote the temp record synchronously inside `.add`; append its
-					// edge into the nested list now so it renders instantly. The HTTP
-					// result triggers fate's resolveOptimisticEntity (temp→server id),
-					// which dedups against the live appendNode by canonical id. Roll the
-					// edge back on any failure — fate restores its own record write, but
-					// not this nested-list insert.
+					// fate wrote the temp record synchronously inside `.add`, so the edge can go
+					// in now. Roll it back on failure by hand: fate restores its own record
+					// write but not this nested-list insert.
 					const rollback = appendOptimisticDefinitionEdge(
 						fate.store,
 						toEntityId("Term", slug),
@@ -442,22 +375,17 @@ function Composer({
 			"tanım eklenemedi",
 			async (result) => {
 				setBody("");
-				draft.clear(); // submitted successfully — the autosaved draft is spent
+				draft.clear();
 				const createdId = result?.id != null ? String(result.id) : null;
 				if (onTermCreated) {
-					// Fresh-slug branch: the term now exists, but the first mount's render-path
-					// `useRequest({term…}, network-only)` left a fulfilled `data:null` handle for
-					// this requestKey, and the remount's render path (`revalidateExisting:false`)
-					// reuses it WITHOUT refetching — so a bare remount reads back the cached null
-					// and the list branch never mounts (#817). Force a real network re-read first
-					// (imperative `request` passes `revalidateExisting:true`, re-executing the
-					// handle and repopulating the store), THEN remount so it reads the real term.
+					// The first mount left a fulfilled `data:null` handle for this requestKey, and
+					// a remount's render path reuses it WITHOUT refetching — so the re-read has to
+					// be imperative and has to happen BEFORE the remount, or the list branch never
+					// mounts (#817).
 					await fate.request(
 						{term: {view: TermView, args: {slug, definitions: {first: PAGE_SIZE}}}},
 						{mode: "network-only"},
 					);
-					// Carry the mutation's own returned id across the remount so the list branch
-					// arms its deterministic read-back on it (#730).
 					onTermCreated(createdId);
 				} else if (createdId != null) {
 					onConfirm?.(createdId);

--- a/apps/web/src/pages/UserProfilePage.tsx
+++ b/apps/web/src/pages/UserProfilePage.tsx
@@ -1,8 +1,6 @@
 /**
- * Public user profile page — fate. One batched `useRequest` resolves header +
- * first page of contributions; the screen view **spreads** `UserProfileHeaderView`
- * and adds the nested `contributions` connection (node: `ContributionView`), which
- * switches on the `kind` discriminant (ADR 0018). See `.patterns/fate-connections.md`.
+ * Public user profile page. The nested `contributions` connection switches on a `kind`
+ * discriminant (ADR 0018); see `.patterns/fate-connections.md` for the masking rules.
  */
 import {useListView, useRequest, useView, type ViewRef, view} from "react-fate";
 import {useParams} from "react-router";
@@ -73,7 +71,6 @@ function UserProfileContent({username}: {username: string}) {
 		<div className="kp-user-profile" data-testid="user-profile-page">
 			<div className="kp-user-profile__inner">
 				<UserProfileHeader profile={profile} fallbackHandle={username} />
-				{/* The çaylak→yazar promotion surface (#1206); the server is the sole authority. */}
 				<ProfilePromotion profile={profile} />
 				<ContributionsList profile={profile} />
 			</div>
@@ -94,9 +91,7 @@ function ContributionsList({profile}: {profile: ViewRef<"Profile">}) {
 	const data = useView(UserProfileView, profile);
 	const {userId} = useView(UserProfileHeaderView, profile);
 	const {me} = useMe();
-	// Same gate as the status block: the "incelemede" badge shows only for a çaylak
-	// viewing their own profile. A non-owner never receives a sandboxed row from the
-	// server, so this also keeps the badge off others' feeds.
+	// The badge is own-profile only; a non-owner never receives a sandboxed row anyway.
 	const sandboxBadge = shouldShowCaylakStatus(me?.tier, me?.id === userId);
 	const [items, loadNext] = useListView(ContributionsConnectionView, data.contributions);
 

--- a/apps/web/src/pages/UsernameBootstrap.test.tsx
+++ b/apps/web/src/pages/UsernameBootstrap.test.tsx
@@ -1,16 +1,10 @@
-/**
- * The null-username bootstrap fallback (#1888 AC4). A permanent handle must never
- * commit off a reflexive "devam et" on the *unedited* email-derived prefill — that
- * reads to users as "the system chose my email as my username." So an untouched
- * prefill needs a deliberate confirm step; any edit commits directly.
- */
 import {fireEvent, render, screen, waitFor} from "@testing-library/react";
 import type {ReactNode} from "react";
 import {FateClient} from "react-fate";
 import {describe, expect, it, vi} from "vitest";
 import {UsernameBootstrap} from "./UsernameBootstrap";
 
-// `useFateClient` reads the client off `<FateClient>`'s plain context; a stubbed
+// `useFateClient` reads off `<FateClient>`'s plain context, so a stubbed
 // `mutations.user.setUsername` is all the form touches.
 function makeWrapper(setUsername: ReturnType<typeof vi.fn>) {
 	const client = {mutations: {user: {setUsername}}};
@@ -32,10 +26,9 @@ describe("UsernameBootstrap — the deliberate-confirm gate (#1888 AC4)", () => 
 	it("does NOT commit the unedited email prefill on the first submit — it asks to confirm", () => {
 		const setUsername = vi.fn(async () => ({}));
 		renderBootstrap(setUsername);
-		// The prefill for elif@kamp.us is `elif`; the button starts as a confirm ask.
+		// The prefill for elif@kamp.us is `elif`.
 		expect(screen.getByRole("button").textContent).toBe("bu adı onayla");
 		fireEvent.submit(screen.getByRole("button").closest("form")!);
-		// First submit only confirms — no mutation yet.
 		expect(setUsername).not.toHaveBeenCalled();
 	});
 
@@ -56,7 +49,6 @@ describe("UsernameBootstrap — the deliberate-confirm gate (#1888 AC4)", () => 
 		renderBootstrap(setUsername);
 		const input = screen.getByLabelText("kullanıcı adı");
 		fireEvent.change(input, {target: {value: "elif-kaya"}});
-		// An edited value is not the email prefill → the button commits, not confirms.
 		expect(screen.getByRole("button").textContent).toBe("devam et");
 		fireEvent.submit(input.closest("form")!);
 		await waitFor(() => expect(setUsername).toHaveBeenCalledTimes(1));
@@ -71,7 +63,6 @@ describe("UsernameBootstrap — the deliberate-confirm gate (#1888 AC4)", () => 
 		const input = screen.getByLabelText("kullanıcı adı");
 		fireEvent.submit(input.closest("form")!); // confirm the prefill
 		expect(screen.getByRole("button").textContent).toBe("devam et");
-		// Editing away and back to the prefill resets confirmation — no silent commit.
 		fireEvent.change(input, {target: {value: "elif-kaya"}});
 		fireEvent.change(input, {target: {value: "elif"}});
 		expect(screen.getByRole("button").textContent).toBe("bu adı onayla");

--- a/apps/web/src/pages/UsernameBootstrap.tsx
+++ b/apps/web/src/pages/UsernameBootstrap.tsx
@@ -1,17 +1,7 @@
 /**
- * Username bootstrap form — `fate.mutations.user.setUsername`. The FALLBACK for
- * users who skipped the username field at signup (and pre-existing null-username
- * accounts): mounted by the layout when the signed-in user has `username === null`.
- * Client-side pre-flight runs the single-source rule (`checkUsername`,
- * `worker/features/pasaport/username-rule.ts`) that `assertUsername` enforces
- * server-side; the prefill is derived from the email local-part (`+tag` stripped).
- * Because a handle is permanent, the *unedited* email-derived prefill can't commit
- * on a reflexive "devam et": it needs a deliberate confirm step (#1888 AC4). Any
- * edit moves off the prefill and commits normally.
- *
- * Error routing: phoenix codes classify as boundary, so the mutation **throws**
- * for some failures and returns `{error}` for others — we handle BOTH, keying the
- * inline message off the wire `code`. See `.patterns/fate-mutations-client.md`.
+ * Username bootstrap form — the fallback the layout mounts when a signed-in user still
+ * has `username === null`. The mutation THROWS for some failures and returns `{error}`
+ * for others, so both paths are handled below — see `.patterns/fate-mutations-client.md`.
  */
 import {useState} from "react";
 import {useFateClient, view} from "react-fate";
@@ -22,7 +12,6 @@ import {codeOf} from "../fate/wire";
 import {localRuleMessage, messageForCode} from "./usernameMessages";
 import "./AuthPage.css";
 
-/** The `User` write-back selection for the `setUsername` result. */
 const SetUsernameView = view<User>()({
 	id: true,
 	email: true,
@@ -43,17 +32,11 @@ export function UsernameBootstrap({
 	onComplete: () => Promise<void> | void;
 }) {
 	const fate = useFateClient();
-	// The email-derived prefill, captured once. A submit whose value still equals
-	// this untouched prefill is an *email-derived* handle — permanent once set, so
-	// it must not commit on a reflexive "devam et" (#1888 AC4); it needs a
-	// deliberate confirm step. Any edit moves the value away from this and commits
-	// normally.
 	const prefill = deriveUsernameFromEmail(email);
 	const [value, setValue] = useState(() => prefill);
 	const [error, setError] = useState<string | null>(null);
 	const [pending, setPending] = useState(false);
-	// Set once the user has explicitly confirmed committing the unedited email
-	// prefill. Reset the moment they edit the field back away from a confirm.
+	// Resets on any edit, so editing back to the prefill re-arms the confirm step.
 	const [confirmed, setConfirmed] = useState(false);
 
 	const normalized = value.trim().toLowerCase();

--- a/apps/web/src/pages/authValidation.ts
+++ b/apps/web/src/pages/authValidation.ts
@@ -1,19 +1,13 @@
 /**
- * Turkish client-side field validation for the auth form (`AuthPage`). The form
- * carries `noValidate`, so the browser's locale-default constraint bubbles ("Please
- * fill out this field.") never fire — these pure checks drive the same required/format
- * constraints through the existing `kp-auth__error` surface in Turkish instead.
- *
- * Username is validated separately by `localRuleMessage` (`usernameMessages.ts`), the
- * single-source `checkUsername` rule the server also enforces; these cover the plain
- * credential fields (görünen ad · e-posta · parola).
+ * The auth form carries `noValidate` — the browser's English constraint bubbles never
+ * fire — so these hand-rolled checks are the only client-side ones that run. Username is
+ * validated separately, by the single-source rule in `usernameMessages.ts`.
  */
 
-// A pragmatic HTML5-ish email shape: one `@`, a dot-bearing domain, no spaces. It is
-// a UX pre-flight, not the authority — the server still validates on signUp/signIn.
+// Deliberately loose: a UX pre-flight, not the authority. The server still validates.
 const EMAIL_RE = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
 
-/** Minimum password length — mirrors better-auth's signup policy. */
+/** Mirrors better-auth's signup policy. */
 const PASSWORD_MIN = 8;
 
 export function validateName(value: string): string | null {
@@ -27,23 +21,17 @@ export function validateEmail(value: string): string | null {
 	return null;
 }
 
-/**
- * Sign-up enforces the length floor (a new password must clear the policy); sign-in
- * only requires a non-empty value, since an existing password's length is the
- * server's business and revealing the floor to a login attempt is pointless.
- */
+/** Sign-in skips the length floor on purpose: don't reveal the policy to a login attempt. */
 export function validatePassword(value: string, mode: "sign-in" | "sign-up"): string | null {
 	if (!value) return "parola gerekli";
 	if (mode === "sign-up" && value.length < PASSWORD_MIN) return "parola en az 8 karakter olmalı";
 	return null;
 }
 
-/** First failing credential message in field order, or `null` when all pass. */
 export function validateSignIn(email: string, password: string): string | null {
 	return validateEmail(email) ?? validatePassword(password, "sign-in");
 }
 
-/** First failing message for the non-username signup fields, in visual field order. */
 export function validateSignUp(name: string, email: string, password: string): string | null {
 	return validateName(name) ?? validateEmail(email) ?? validatePassword(password, "sign-up");
 }

--- a/apps/web/src/pages/authValidation.unit.test.ts
+++ b/apps/web/src/pages/authValidation.unit.test.ts
@@ -27,7 +27,6 @@ describe("authValidation — Turkish field messages", () => {
 		expect(validatePassword("", "sign-up")).toBe("parola gerekli");
 		expect(validatePassword("short", "sign-up")).toBe("parola en az 8 karakter olmalı");
 		expect(validatePassword("hunter2hunter2", "sign-up")).toBeNull();
-		// Sign-in requires only a non-empty value — the length floor is the server's business.
 		expect(validatePassword("", "sign-in")).toBe("parola gerekli");
 		expect(validatePassword("short", "sign-in")).toBeNull();
 	});

--- a/apps/web/src/pages/definitionAddOptimistic.ts
+++ b/apps/web/src/pages/definitionAddOptimistic.ts
@@ -1,53 +1,27 @@
 /**
- * Optimistic `definition.add` — the A1 client-append for the *nested*
- * `Term.definitions` connection (ADR
- * [0125](../../../../.decisions/0125-optimistic-reconciliation-live-driven-nested-connections.md),
- * #1679, epic #1637). `Term.definitions` is carried on the `term` query, never a
- * registered root list, so fate's declarative `insert`/`optimistic` membership
- * can't reach it (`registerRootList` is gated on `!filterConnectionArgs`). The
- * optimistic node is instead injected by this phoenix client helper, which drives
- * the same list state `insertConnectionEdge` mutates from the SSE `appendNode`.
- *
- * Two pieces, both hook-free so the branch predicate + the temp-node shape are
- * unit-testable apart from fate/React (the pure-core idiom of `postSubmitMembership`
- * / `bodyEditOptimistic`):
- *
- * - {@link buildOptimisticDefinition} builds the temp-id optimistic record (or
- *   `undefined` on the fresh-slug branch), mirroring the server's fresh-write
- *   initial state (`score: 0`, `myVote: null`, `updatedAt === createdAt`) so the
- *   reconciled server node can't diverge from the optimistic one (no phantom
- *   self-upvote, no false "düzenlendi").
- * - {@link appendOptimisticDefinitionEdge} appends the temp entity id to the nested
- *   connection's list state and returns a rollback that restores the pre-insert
- *   snapshot. On the mutation HTTP result fate's `resolveOptimisticEntity` rewrites
- *   the temp id to the server id across list states — so any server `appendNode`
- *   (before or after) dedups by **canonical entity id** and temp-node + server-append
- *   collapse to one edge. The caller rolls back on a rejected add.
- *
- * See `.patterns/fate-mutations-client.md` (§Optimistic nested-connection membership).
+ * Optimistic `definition.add` for the *nested* `Term.definitions` connection. fate's
+ * declarative `insert`/`optimistic` membership cannot reach it — `registerRootList` is
+ * gated on `!filterConnectionArgs`, and this connection is carried on the `term` query —
+ * so the edge is injected here instead, into the same list state the SSE `appendNode`
+ * mutates. See ADR
+ * [0125](../../../../.decisions/0125-optimistic-reconciliation-live-driven-nested-connections.md)
+ * and `.patterns/fate-mutations-client.md` (§Optimistic nested-connection membership).
  */
 import type {EntityId, List, Snapshot} from "@nkzw/fate";
 
-/** Injectable now-clock so the optimistic `createdAt`/temp id are deterministic in tests. */
+/** Injectable so the optimistic `createdAt` and temp id are deterministic in tests. */
 export type Now = () => Date;
 
 const defaultNow: Now = () => new Date();
 
-/** The already-derived author values the optimistic node mirrors. */
 export interface OptimisticDefinitionInput {
-	/** The submitted definition body. */
 	readonly body: string;
 	/** Display name for the author (name, falling back to email). */
 	readonly author: string;
-	/** The author's user id — drives `DefinitionCard`'s is-author edit/delete affordances. */
 	readonly authorId: string;
 }
 
-/**
- * The optimistic `Definition` record, temp-id'd. Carries exactly the
- * `DefinitionView` fields so `useLiveView(DefinitionView, …)` reads it without a
- * missing-field suspend; fate reconciles it to the server node on the HTTP result.
- */
+/** Must carry exactly the `DefinitionView` fields, or `useLiveView` suspends on a missing one. */
 export interface OptimisticDefinition {
 	readonly id: string;
 	readonly body: string;
@@ -60,16 +34,10 @@ export interface OptimisticDefinition {
 }
 
 /**
- * The optimistic definition record, or `undefined` when `enabled` is false — the
- * fresh-slug branch, which has no loaded definitions list to append to and drives
- * its own force-refetch + remount instead. `undefined` lets the call site spread it
- * away under `exactOptionalPropertyTypes` (`...(optimistic ? {optimistic} : {})`),
- * mirroring {@link bodyEditOptimistic}.
- *
- * Mirrors the server's fresh write (`definition.add` shapes `score` from a 0-vote
- * insert with `myVote: null`) so the optimistic node and the reconciled server node
- * hold the same fields — no phantom self-upvote (#707), and `updatedAt === createdAt`
- * so `EditedIndicator` shows no false "düzenlendi".
+ * The shape mirrors the server's fresh write exactly, so the reconciled node can't diverge:
+ * `score: 0` with `myVote: null` (no phantom self-upvote, #707) and `updatedAt === createdAt`
+ * (no false "düzenlendi"). `undefined` rather than null so the call site can spread it away
+ * under `exactOptionalPropertyTypes`.
  */
 export function buildOptimisticDefinition(
 	enabled: boolean,
@@ -90,23 +58,14 @@ export function buildOptimisticDefinition(
 	};
 }
 
-/**
- * The narrow slice of fate's `Store` the edge-injector needs — the three public
- * list methods — so the injector is unit-testable against a fake without a live
- * `FateClient`. `fate.store` satisfies it structurally.
- */
+/** A narrow slice of fate's `Store` so the injector is testable against a fake. */
 export interface DefinitionListStore {
 	getListsForField(ownerId: string, field: string): ReadonlyArray<readonly [string, List]>;
 	setList(key: string, state: List): void;
 	restoreList(key: string, state?: List): void;
 }
 
-/**
- * The add path additionally bumps the term's aggregate count scalars, so it needs
- * the record `read`/`merge`/`snapshot`/`restore` methods on top of the list slice.
- * Kept separate from {@link DefinitionListStore} so the delete path (edge-drop only)
- * stays on the narrower interface. `fate.store` satisfies it structurally.
- */
+/** Kept apart from {@link DefinitionListStore} so the delete path stays on the narrower slice. */
 export interface DefinitionAddStore extends DefinitionListStore {
 	read(id: EntityId): Record<string, unknown> | undefined;
 	merge(id: EntityId, partial: Record<string, unknown>, paths: Iterable<string>): void;
@@ -115,29 +74,13 @@ export interface DefinitionAddStore extends DefinitionListStore {
 }
 
 /**
- * Append `optimisticEntityId` (a `Definition` **entity id**, e.g.
- * `Definition:optimistic:<ts>`) to every list state backing the term's nested
- * `definitions` connection, and return a rollback that restores each list to its
- * pre-insert snapshot.
+ * Appends to the tail, which is where the server `appendNode` lands too: a fresh definition
+ * is `score: 0` and `DEFINITION_ORDERING` is score-desc then createdAt-asc. fate rewrites the
+ * temp id to the server id on the HTTP result, so the later server append dedups by canonical
+ * id — one edge, not two.
  *
- * Appends to the visible window's tail: a fresh definition is `score: 0`, and
- * `DEFINITION_ORDERING` is score-desc then createdAt-asc, so a score-0 newest node
- * sorts to the bottom — the same slot the server `appendNode` targets. The temp id
- * is what fate's `resolveOptimisticEntity` rewrites to the server id on the HTTP
- * result, after which a server `appendNode(serverId)` dedups by canonical id
- * (`removeEntityFromListState` / visible short-circuit) — one edge, no double.
- *
- * Also bumps the term's aggregate definition-count scalars by one so the header
- * (`Term.count`, `SozlukTermHeader`) and the index row (`Term.definitionCount`,
- * `TermRow`/`SozlukHome`) agree with the rendered list during the optimistic window —
- * `definition.add` returns a `Definition`, not the parent `Term`, so nothing else
- * reconciles the aggregate until a refetch (#2198). Both scalars mirror the same
- * server `definitionCount` column (`term-fields.ts`), so each present one is bumped to
- * keep the two surfaces consistent (AC3). The bump rolls back with the list edge.
- *
- * A no-op (empty rollback) when the term has no loaded `definitions` list yet (the
- * fresh-slug branch, where there's nothing to append to) — that flow is driven by
- * the composer's force-refetch + remount, untouched here.
+ * Also bumps the term's two aggregate count scalars: `definition.add` returns a `Definition`,
+ * not the parent `Term`, so nothing else reconciles them until a refetch (#2198).
  */
 export function appendOptimisticDefinitionEdge(
 	store: DefinitionAddStore,

--- a/apps/web/src/pages/definitionAddOptimistic.unit.test.ts
+++ b/apps/web/src/pages/definitionAddOptimistic.unit.test.ts
@@ -1,11 +1,3 @@
-/**
- * The pure cores of the optimistic `definition.add` slice (#1679, epic #1637, ADR
- * 0125), tested without fate/React — the pure-core idiom of `panoSubmitArgs.unit`.
- * Covers the branch predicate + the temp-node's server-mirroring shape
- * ({@link buildOptimisticDefinition}) and the nested-list edge injection + rollback
- * ({@link appendOptimisticDefinitionEdge}) against a fake store.
- */
-
 import {assert, describe, it} from "@effect/vitest";
 import type {EntityId, List, Snapshot} from "@nkzw/fate";
 import {
@@ -54,7 +46,6 @@ describe("buildOptimisticDefinition — the optimistic nested node", () => {
 	});
 });
 
-/** A fake store recording setList/restoreList + the term record, seeded per key/id. */
 function fakeStore(
 	lists: ReadonlyArray<readonly [string, List]>,
 	records?: Record<string, Record<string, unknown>>,

--- a/apps/web/src/pages/definitionDeleteOptimistic.ts
+++ b/apps/web/src/pages/definitionDeleteOptimistic.ts
@@ -1,45 +1,16 @@
 /**
- * Optimistic `definition.delete` — the D1 edge-drop for the *nested*
- * `Term.definitions` connection (ADR
- * [0125](../../../../.decisions/0125-optimistic-reconciliation-live-driven-nested-connections.md),
- * #1681, epic #1637). `definition.delete` is a **`Term`**-returning mutation (it
- * re-resolves the parent for fresh counts), so fate's `delete: true` is the wrong
- * entity — the server instead publishes `live.definition.term(slug).deleteEdge`.
- * And `Term.definitions` is a nested connection carried on the `term` query, never a
- * registered root list, so fate's declarative `delete` membership can't reach it
- * (`registerRootList` is gated on `!filterConnectionArgs`). The edge is instead
- * dropped by this phoenix client helper, which drives the same list state
- * `removeEntityFromListState` mutates from the SSE `deleteEdge`.
- *
- * `definition.delete` has **no reply tree**, so ADR 0125's reply-aware D1 branch
- * collapses to a plain edge-drop — no `[silindi]` tombstone, no conservative-on-
- * uncertain fallback (the `comment.delete` sibling owns those). The definition id is
- * already the **canonical server id** (not a temp id), so reconciliation is trivial:
- * the server `deleteEdge` frame removes an id already absent from the list — a no-op,
- * no reappear, zero divergence. The caller rolls back — restoring the edge — on a
- * rejected delete.
- *
- * See `.patterns/fate-mutations-client.md` (§Optimistic nested-connection membership)
- * and the add-side sibling {@link appendOptimisticDefinitionEdge}.
+ * Optimistic `definition.delete` for the *nested* `Term.definitions` connection. fate's
+ * declarative `delete` membership is wrong twice over here: the mutation returns a **`Term`**
+ * (it re-resolves the parent for fresh counts), and a nested connection is never a registered
+ * root list. So the edge is dropped here instead, and the server's `deleteEdge` frame then
+ * removes an id already gone — a no-op by canonical id, no reappear. See ADR
+ * [0125](../../../../.decisions/0125-optimistic-reconciliation-live-driven-nested-connections.md)
+ * and `.patterns/fate-mutations-client.md` (§Optimistic nested-connection membership).
  */
 import type {List} from "@nkzw/fate";
 import type {DefinitionListStore} from "./definitionAddOptimistic";
 
-/**
- * Drop `definitionEntityId` (a `Definition` **entity id**, e.g. `Definition:<id>`)
- * from every list state backing the term's nested `definitions` connection, and
- * return a rollback that restores each list to its pre-drop snapshot.
- *
- * Removes the id and its aligned cursor (keeping `ids`/`cursors` index-aligned) from
- * each backing list — the same slot the server `deleteEdge` targets. A list that
- * doesn't carry the id is left untouched. On the mutation HTTP result a server
- * `deleteEdge(id)` then removes an id already gone — a no-op by canonical id, so
- * optimistic drop and server frame collapse to one absent edge (no reappear). The
- * caller invokes the returned rollback on a rejected delete to restore the edge.
- *
- * A no-op (empty rollback) when the term has no loaded `definitions` list, or none
- * that carries the id — nothing to drop.
- */
+/** Drops the id and its aligned cursor together — `ids` and `cursors` must stay index-aligned. */
 export function dropOptimisticDefinitionEdge(
 	store: DefinitionListStore,
 	termEntityId: string,

--- a/apps/web/src/pages/definitionDeleteOptimistic.unit.test.ts
+++ b/apps/web/src/pages/definitionDeleteOptimistic.unit.test.ts
@@ -1,18 +1,8 @@
-/**
- * The pure core of the optimistic `definition.delete` slice (#1681, epic #1637, ADR
- * 0125 D1), tested without fate/React — the pure-core idiom of the add-side sibling
- * `definitionAddOptimistic.unit`. Covers the nested-list edge drop + rollback
- * ({@link dropOptimisticDefinitionEdge}) against a fake store: the drop reconciles
- * against the server `deleteEdge` by canonical id (no reappear), and rollback
- * restores the edge on rejection.
- */
-
 import {assert, describe, it} from "@effect/vitest";
 import type {List} from "@nkzw/fate";
 import type {DefinitionListStore} from "./definitionAddOptimistic";
 import {dropOptimisticDefinitionEdge} from "./definitionDeleteOptimistic";
 
-/** A fake store recording setList/restoreList, seeded with per-key list snapshots. */
 function fakeStore(lists: ReadonlyArray<readonly [string, List]>): DefinitionListStore & {
 	readonly current: Map<string, List | undefined>;
 } {
@@ -75,8 +65,7 @@ describe("dropOptimisticDefinitionEdge — nested-list edge drop + rollback", ()
 	});
 
 	it("reconciles by canonical id — a redundant drop of an already-gone id is a no-op (no reappear)", () => {
-		// Models the server `deleteEdge` frame landing after the optimistic drop: the id
-		// is already absent, so removing it again changes nothing — one absent edge.
+		// Models the server `deleteEdge` frame landing after the optimistic drop.
 		const store = fakeStore([["list-1", {ids: ["Definition:a", "Definition:c"]}]]);
 		dropOptimisticDefinitionEdge(store, TERM, TARGET);
 		assert.deepStrictEqual(store.current.get("list-1")?.ids, ["Definition:a", "Definition:c"]);

--- a/apps/web/src/pages/landingGating.test.ts
+++ b/apps/web/src/pages/landingGating.test.ts
@@ -1,16 +1,8 @@
-/**
- * The landing page's auth-gating contract (#1784) — the pure CTA-phase decision
- * asserted without a DOM (the pure-extraction idiom of `divanGating`; `apps/web/src`
- * has no jsdom). These are the AC the fix lives or dies on: a signed-in user never
- * sees the `hesap aç →` join CTA, an anonymous viewer still does, and the CTA never
- * flashes in/out while auth is resolving (#448).
- */
 import {describe, expect, it} from "vitest";
 import {landingCtaPhase, showJoinCta} from "./landingGating";
 
 describe("landingCtaPhase — the three-valued auth phase", () => {
 	it("is `resolving` while the session is pending, regardless of me status", () => {
-		// #448: session starts {data:null, isPending:true} — must not read as anonymous.
 		expect(landingCtaPhase(true, "idle")).toBe("resolving");
 		expect(landingCtaPhase(true, "loading")).toBe("resolving");
 		expect(landingCtaPhase(true, "ok")).toBe("resolving");
@@ -26,13 +18,10 @@ describe("landingCtaPhase — the three-valued auth phase", () => {
 	});
 
 	it("is `resolving` for a signed-in session whose me is still loading — no flash back to the CTA", () => {
-		// A session-update refetch (e.g. after setUsername) re-enters `loading`; the
-		// CTA must stay hidden, not flash the join prompt back in.
 		expect(landingCtaPhase(false, "loading")).toBe("resolving");
 	});
 
 	it("is `resolving` (not anonymous) when an established session's me read errors", () => {
-		// A failed row read must not flash a "create account" prompt at a signed-in user.
 		expect(landingCtaPhase(false, "error")).toBe("resolving");
 	});
 });

--- a/apps/web/src/pages/landingGating.ts
+++ b/apps/web/src/pages/landingGating.ts
@@ -1,58 +1,25 @@
 /**
- * The landing page's auth-gating decision, factored DOM-free so the rule is
- * unit-testable without a DOM/React runtime — the pure-extraction idiom of
- * `divanGating` / `shouldShowOnramp` (`apps/web/src` has no jsdom).
+ * The landing page's join-CTA gating, kept DOM-free so it is unit-testable
+ * (`apps/web/src` has no jsdom).
  *
- * The defect (#1784): `LandingPage` rendered the `hesap aç →` join CTA and the
- * `kapı açık` rite framing unconditionally, so a signed-in user was still shown a
- * "create an account" call-to-action. The fix gates that framing on the SAME auth
- * signal the topbar reads — `useMe` (`../auth/useMe`) over `useSession`
- * (`../auth/client`) — so the landing and the topbar can never disagree about auth
- * state.
- *
- * The flash guard (#448): `useSession` resolves async (`{data:null,
- * isPending:true}` → user), and `useMe` carries its own `idle | loading | ok |
- * error` status. Collapsing those into a bare `signedIn` boolean would flash the
- * CTA on during the load transition (anonymous-looking mid-resolve) and then off.
- * So the decision is a THREE-valued phase — while auth is still resolving we render
- * the neutral state (neither CTA nor a signed-in variant), never a wrong-state CTA.
+ * The phase is three-valued rather than a `signedIn` boolean because auth resolves in two
+ * async steps (`useSession`, then `useMe`): a boolean reads anonymous mid-resolve and
+ * flashes the CTA on and then off (#448). It reads `useMe` — the same signal the topbar
+ * reads — so the two can never disagree about auth state (#1784).
  */
 import type {MeStatus} from "../auth/useMe";
 
-/**
- * The landing CTA's auth phase:
- *  - `anonymous` — session resolved with no user: show the join CTA + rite framing.
- *  - `signedIn`  — session resolved to a user AND `me` loaded: hide the join CTA.
- *  - `resolving` — auth still settling (session pending, or signed in but `me` not
- *    yet loaded): render neither, so nothing flashes in/out during the transition.
- */
 export type LandingCtaPhase = "anonymous" | "signedIn" | "resolving";
 
-/**
- * Derive the CTA phase from the two topbar-shared signals: whether `useSession` is
- * still pending, and `useMe().status`. Mirrors the topbar's reading — a session is
- * "signed in" once established, and `me` (`ok`) carries the loaded row — collapsed
- * into the three-valued phase the landing surface renders on.
- *
- *  - `sessionPending` ⇒ `resolving` (auth unresolved; #448 — don't flash).
- *  - not pending, no session (`meStatus === "idle"`) ⇒ `anonymous`.
- *  - session present, `me` loaded (`meStatus === "ok"`) ⇒ `signedIn`.
- *  - session present, `me` still `loading` (first read / a session-update refetch)
- *    ⇒ `resolving`, so a mid-load refetch never flashes the CTA back in.
- *  - a `me` read `error` for an established session ⇒ `resolving` (treated as
- *    not-yet-authenticated for the CTA rather than flashing the join prompt at a
- *    signed-in user whose row read merely failed).
- */
 export function landingCtaPhase(sessionPending: boolean, meStatus: MeStatus): LandingCtaPhase {
 	if (sessionPending) return "resolving";
 	if (meStatus === "idle") return "anonymous";
 	if (meStatus === "ok") return "signedIn";
-	// `loading` (first read or a session-update refetch) and `error` for an
-	// established session are both unresolved for the CTA — render neither.
+	// `error` lands here on purpose, not in `anonymous`: a failed row read for an
+	// established session must not flash a join prompt at a signed-in user.
 	return "resolving";
 }
 
-/** Show the `hesap aç →` join CTA + `kapı açık` rite framing iff the viewer is anonymous. */
 export function showJoinCta(phase: LandingCtaPhase): boolean {
 	return phase === "anonymous";
 }

--- a/apps/web/src/pages/mecmua-write-gate.test.ts
+++ b/apps/web/src/pages/mecmua-write-gate.test.ts
@@ -1,10 +1,3 @@
-/**
- * The mecmua editor's earned-gate contract (#2499): publish is offered ONLY to a
- * yazar; a çaylak / visitor / signed-out reader sees the Turkish earned-gate copy.
- * Tests the pure `mecmuaPublishAffordance` core (DOM-free), the way `FlagGate`'s
- * `flagGateChild` and the on-ramp's `shouldShowOnramp` are tested. The core lives in
- * its own composer-free module (#2523) so the entry-point CTA can gate without tiptap.
- */
 import {describe, expect, it} from "vitest";
 import {mecmuaPublishAffordance, shouldShowMecmuaWriteCta} from "./mecmua-write-gate";
 

--- a/apps/web/src/pages/mecmua-write-gate.ts
+++ b/apps/web/src/pages/mecmua-write-gate.ts
@@ -1,14 +1,7 @@
 /**
- * The mecmua write-gate pure core, DOM-free AND composer-free (#2523). Held apart from
- * `MecmuaEditorPage` — which pulls in `@kampus/composer` (tiptap/ProseMirror) — so the
- * entry-point CTA consumers (`MecmuaIndexPage`, nav) can decide gating without dragging
- * the heavy editor payload into the entry chunk. That leak is exactly what #2523 removes:
- * lazy-splitting the editor route only helps if nothing eagerly imports it, so the gate
- * helpers live in their own composer-free module.
- *
- * Publish is offered ONLY to a yazar; the tier is the trusted account level read off the
- * fate `me` view. Publish is server-gated by `PublishMecmua` regardless — this only
- * governs what the UI offers.
+ * Keep this module composer-free (#2523): its consumers are the nav and index CTAs, and
+ * folding it back into `MecmuaEditorPage` would drag tiptap into the entry chunk, undoing
+ * the editor route's lazy split. The server gates publish regardless — this is UI only.
  */
 import type {Tier} from "../../worker/features/kunye/standing";
 
@@ -28,11 +21,8 @@ export function mecmuaPublishAffordance(
 }
 
 /**
- * Should the "yeni yazı" entry-point CTA (nav + index) be shown to this viewer (#2532)?
- * Gate parity with the editor is structural, not restated: the CTA appears exactly when
- * the write flag is live AND {@link mecmuaPublishAffordance} would offer publish (yazar
- * tier), so it never dead-ends a çaylak/visitor/signed-out reader into a page they'd be
- * publish-gated on. `MECMUA_WRITE` off, or any non-yazar/undefined tier, resolves false.
+ * Derived from `mecmuaPublishAffordance` rather than restating its rule, so the CTA can
+ * never dead-end a viewer into a page they would be publish-gated on.
  */
 export function shouldShowMecmuaWriteCta(
 	flagOn: boolean,

--- a/apps/web/src/pages/optimisticPostDelete.test.ts
+++ b/apps/web/src/pages/optimisticPostDelete.test.ts
@@ -1,11 +1,3 @@
-/**
- * The optimistic post-delete reconcile contract (#1677) — the terminal-outcome rule
- * asserted without a DOM (the pure-extraction idiom of `savedReconcile`). These are
- * the AC the optimistic flow lives or dies on: a clean resolve stays on the feed
- * (the row already left optimistically and the server `deleteEdge` reconciles it), a
- * lapsed session re-auths, and any rejection returns to the (now-restored) post with
- * the inline error code.
- */
 import {describe, expect, it} from "vitest";
 import {decideOptimisticDelete} from "./optimisticPostDelete";
 

--- a/apps/web/src/pages/optimisticPostDelete.ts
+++ b/apps/web/src/pages/optimisticPostDelete.ts
@@ -1,35 +1,16 @@
 /**
- * The optimistic `post.delete` reconcile core (#1677, epic #1637 Class B) — the one
- * post-delete flow rule asserted without a DOM (the pure-extraction idiom of
- * `savedReconcile` / `useToggleAction`'s `nextToggleAction`).
- *
- * The pano feed is a registered root list, so fate's `delete: true` evicts the post
- * from it **synchronously** (before the round-trip) and rolls the eviction back
- * before a boundary throw (see `.patterns/fate-mutations-client.md`). This core
- * decides only what the call site does *after* the mutation promise settles: on
- * success stay on the feed (the row is already gone, the server `feed.deleteEdge`
- * frame reconciles it away for good); on `UNAUTHORIZED` re-auth; on any other
- * failure the post is already restored, so return to it and surface the existing
- * inline error.
+ * What the `post.delete` call site does once the mutation settles. fate has already
+ * evicted the post synchronously and rolls that back itself on failure, so this only
+ * decides where the user ends up — see `.patterns/fate-mutations-client.md`.
  */
 import type {FateWireCode} from "../lib/fateWireCodes";
 
-/** The terminal outcome of an optimistic post-delete, decided off the wire code. */
 export type OptimisticDeleteOutcome =
-	/** Committed — the feed eviction stands; stay where the optimistic navigation landed. */
 	| {readonly kind: "deleted"}
-	/** `UNAUTHORIZED` — the session lapsed; route through the auth redirect. */
 	| {readonly kind: "auth-redirect"}
-	/** Rejected — fate restored the post; return to it and show the inline error. */
 	| {readonly kind: "restore"; readonly code: FateWireCode};
 
-/**
- * Classify the terminal state of an optimistic `post.delete` from its failure code
- * (`null` ⇒ the mutation resolved cleanly). `UNAUTHORIZED` routes to re-auth; every
- * other code means the write was rejected and fate already rolled the eviction back,
- * so the post is back in the feed and the call site returns to it with the code's
- * inline message.
- */
+// `null` ⇒ the mutation resolved cleanly.
 export function decideOptimisticDelete(failureCode: FateWireCode | null): OptimisticDeleteOutcome {
 	if (failureCode == null) return {kind: "deleted"};
 	if (failureCode === "UNAUTHORIZED") return {kind: "auth-redirect"};

--- a/apps/web/src/pages/panoFeedOverlay.ts
+++ b/apps/web/src/pages/panoFeedOverlay.ts
@@ -23,35 +23,21 @@ export interface ViewerOverlay {
  *  footprint so the later patch causes no layout shift. */
 export const NEUTRAL_OVERLAY: ViewerOverlay = {myVote: null, isSaved: null};
 
-/**
- * A landed overlay batch, tagged with the identity it was read under. `identity` is the
- * resolved viewer id (`null` for anon); `byId` maps each base row's post id to that
- * viewer's scalars. Tagging the batch with its identity is what lets `resolveOverlay`
- * reject a batch that belongs to a previous identity during a re-key/compose window.
- */
+// The batch carries the `identity` it was read under (`null` = anon) so `resolveOverlay`
+// can reject a batch belonging to a previous identity during a re-key window.
 export interface OverlayBatch {
 	readonly identity: string | null;
 	readonly byId: ReadonlyMap<string, ViewerOverlay>;
 }
 
-/** The overlay's lifecycle: `pending` before the viewer's scalars land (base already
- *  painted), then `landed` once they arrive under a known identity. */
 export type OverlayState =
 	| {readonly status: "pending"}
 	| ({readonly status: "landed"} & OverlayBatch);
 
 export const PENDING_OVERLAY: OverlayState = {status: "pending"};
 
-/**
- * Resolve one base row's overlay against the current viewer — the identity guard.
- *
- * Returns the row's scalars ONLY when the overlay has landed AND was read under the
- * SAME identity as the current viewer AND carries this id; otherwise the neutral state.
- * The identity match is the guard: an overlay batch landed under identity A is inert for
- * viewer B (and for anon), so a stale/foreign overlay can never paint — it reads neutral
- * until B's own batch lands. A missing id (a base row the overlay batch didn't cover yet)
- * likewise stays neutral, never borrowing a sibling row's scalars.
- */
+// The identity guard: every non-match falls to neutral, so a stale or foreign overlay
+// can never paint and an uncovered row never borrows a sibling's scalars.
 export function resolveOverlay(
 	state: OverlayState,
 	viewerIdentity: string | null,

--- a/apps/web/src/pages/panoSubmitArgs.ts
+++ b/apps/web/src/pages/panoSubmitArgs.ts
@@ -1,39 +1,20 @@
 /**
- * The optimistic membership args for `post.submit`, factored out of
- * {@link PanoSubmitPage} so the payload is unit-testable without a DOM.
- *
- * The pano feed is a **registered root list** (no filter args), so this is fate's
- * documented happy path (`.patterns/fate-mutations-client.md`): `insert: "before"`
- * prepends a temp-id node that fate reconciles to the server id when the real
- * result arrives — the same server row the `live.post.feed.appendNode` frame
- * carries, so the mutator's own client sees no double-row (reconcile dedups by
- * server id). Shipped optimistic (#1676, epic #1637); a since-retired containment
- * flag once gated a non-optimistic round-trip fallback.
+ * The optimistic membership args for `post.submit`, split out of `PanoSubmitPage` so the
+ * payload is unit-testable without a DOM. The feed is a registered root list, so this is
+ * fate's documented happy path — see `.patterns/fate-mutations-client.md`.
  */
 
-/** The already-derived form + author values the optimistic node mirrors. */
 export interface OptimisticSubmitInput {
-	/** The trimmed post title. */
 	readonly title: string;
-	/** The link url in link mode, else `null`. */
 	readonly url: string | null;
-	/** The link host in link mode, else `null`. */
 	readonly host: string | null;
-	/** The selected tag kinds. */
 	readonly tags: readonly string[];
-	/** Display name for the author (name, falling back to email). */
 	readonly author: string;
-	/** The author's user id. */
 	readonly authorId: string;
-	/** The submit instant — seeds the temp id and `createdAt`. */
+	// Seeds the temp id and `createdAt`.
 	readonly now: Date;
 }
 
-/**
- * The `post.submit` membership args: the optimistic prepend. Returned as a
- * spread-in fragment so the call site stays one
- * `fate.mutations.post.submit({input, view, ...})`.
- */
 export function postSubmitMembership(input: OptimisticSubmitInput) {
 	return {
 		insert: "before" as const,

--- a/apps/web/src/pages/panoSubmitArgs.unit.test.ts
+++ b/apps/web/src/pages/panoSubmitArgs.unit.test.ts
@@ -1,8 +1,3 @@
-/**
- * The optimistic membership payload for `post.submit` (#1676, epic #1637), tested
- * off the pure {@link postSubmitMembership} core — no DOM. Covers the optimistic
- * node shape and its no-phantom-self-upvote contract (#707).
- */
 import {assert, describe, it} from "@effect/vitest";
 import {type OptimisticSubmitInput, postSubmitMembership} from "./panoSubmitArgs";
 

--- a/apps/web/src/pages/savedReconcile.test.ts
+++ b/apps/web/src/pages/savedReconcile.test.ts
@@ -1,10 +1,3 @@
-/**
- * The saved-posts reconcile contract (#1417) — the one saved-ness rule asserted
- * without a DOM (the pure-extraction idiom of `divanGating` / `searchTarget`). These
- * are the AC the page lives or dies on: count + empty-state must track live `isSaved`,
- * not edge-`node` truthiness, so an in-list un-save decrements the count and un-saving
- * the last loaded row trips the empty state.
- */
 import {describe, expect, it} from "vitest";
 import {countSavedRows, isRowSaved} from "./savedReconcile";
 

--- a/apps/web/src/pages/savedReconcile.ts
+++ b/apps/web/src/pages/savedReconcile.ts
@@ -1,27 +1,16 @@
 /**
- * The saved-posts reconcile rule, factored DOM-free so the row drop decision AND the
- * list count + empty-state share ONE predicate (#1417: the count/empty-state had
- * drifted onto edge-`node` truthiness while `SavedRow` read live `isSaved`). An in-list
- * un-save publishes `live.update("Post", …, {changed:["isSaved"]})` with no `deleteEdge`,
- * so the edge/node stay truthy after the row drops — node presence is therefore NOT a
- * saved-ness signal; live `isSaved` is.
+ * The one saved-ness rule, shared by the row drop and the list count + empty-state. An
+ * in-list un-save publishes a live `isSaved` update with no `deleteEdge`, so the edge and
+ * node stay truthy — node presence is NOT a saved-ness signal, live `isSaved` is (#1417).
  */
 
-/**
- * A row counts as saved iff its live `isSaved` is not explicitly `false`. `null`/
- * `undefined` (not-yet-resolved) read as saved, matching `SavedRow`, which only drops
- * on `=== false`.
- */
+// Unresolved (`null`/`undefined`) reads as saved: `SavedRow` only drops on `=== false`.
 export function isRowSaved(isSaved: boolean | null | undefined): boolean {
 	return isSaved !== false;
 }
 
-/**
- * How many of `ids` are still saved, given each row's reported live `isSaved`. An id
- * absent from `savedById` (a row that hasn't reported yet) defaults to saved via
- * `isRowSaved(undefined)`, so the count never under-reports before rows resolve, and a
- * stale report for an id no longer in the connection is ignored.
- */
+// A row that hasn't reported yet defaults to saved, so the count never under-reports
+// while rows resolve; a report for an id no longer in `ids` is ignored.
 export function countSavedRows(
 	ids: ReadonlyArray<string | number>,
 	savedById: ReadonlyMap<string | number, boolean | null | undefined>,

--- a/apps/web/src/pages/signupUsernameGate.test.tsx
+++ b/apps/web/src/pages/signupUsernameGate.test.tsx
@@ -1,9 +1,3 @@
-/**
- * The signup→setUsername redirect gate (#1888). Pins the latch semantics the
- * AuthPage writer and Layout reader share: begin latches (redirect holds), end
- * releases (redirect proceeds), both idempotent, and `useUsernameResolutionPending`
- * re-renders subscribers on each transition.
- */
 import {act, renderHook} from "@testing-library/react";
 import {afterEach, describe, expect, it} from "vitest";
 import {

--- a/apps/web/src/pages/signupUsernameGate.ts
+++ b/apps/web/src/pages/signupUsernameGate.ts
@@ -29,17 +29,13 @@ function emit(): void {
 	for (const l of listeners) l();
 }
 
-/** Latch the gate: a chosen-username signup is resolving — hold the redirect. */
 export function beginUsernameResolution(): void {
 	if (pending) return;
 	pending = true;
 	emit();
 }
 
-/**
- * Release the gate: the handle landed, or the user abandoned the chosen handle.
- * Idempotent — safe to call from a `finally`/cleanup path.
- */
+// Idempotent, so a `finally` or cleanup path can call it unconditionally.
 export function endUsernameResolution(): void {
 	if (!pending) return;
 	pending = false;
@@ -55,7 +51,6 @@ function getSnapshot(): boolean {
 	return pending;
 }
 
-/** `true` while a chosen-username signup is still resolving — the redirect holds. */
 export function useUsernameResolutionPending(): boolean {
 	return useSyncExternalStore(subscribe, getSnapshot, getSnapshot);
 }

--- a/apps/web/src/pages/useProfileStats.test.ts
+++ b/apps/web/src/pages/useProfileStats.test.ts
@@ -8,11 +8,7 @@ describe("toProfileStatsState", () => {
 	});
 
 	it("maps a null snapshot to ok with all-zero counts and zero karma — empty is success, not error", () => {
-		// The regression this guards (#448): a real zero-activity user resolves to a
-		// successful `ok` with zeros, so it stays distinguishable from the hook's
-		// `error` state (which only the catch branch produces). A null snapshot must
-		// NOT collapse into the same value an error would render. A zero-karma çaylak
-		// is likewise an honest 0, not a placeholder (#1208 AC).
+		// #448: a null snapshot must NOT collapse into the value an `error` would render.
 		expect(toProfileStatsState(null)).toEqual({
 			status: "ok",
 			stats: {postCount: 0, commentCount: 0, definitionCount: 0, totalKarma: 0},
@@ -20,9 +16,6 @@ describe("toProfileStatsState", () => {
 	});
 
 	it("only projects the stat scalars, dropping extra snapshot fields", () => {
-		// A snapshot carrying more than the stat scalars (here the selected `userId`)
-		// is a structural ProfileStats supertype, so it passes to the helper with no
-		// cast — and the assertion below proves the extra field is dropped.
 		const data: ProfileStats & {userId: string} = {
 			postCount: 2,
 			commentCount: 4,

--- a/apps/web/src/pages/useProfileStats.ts
+++ b/apps/web/src/pages/useProfileStats.ts
@@ -1,33 +1,15 @@
 /**
- * Reads a user's profile counts (başlık/yorum/tanım) over `/fate` by username.
- * Consumes the same `profile` root + `Profile` view as `/u/:username`
- * (`UserProfilePage`), selecting only the count scalars — no `contributions`
- * connection, so the resolver skips its keyset query.
- *
- * Imperative (`request` + `readView` via `useImperativeView`), not the suspending
- * `useRequest`, for the same reason as `useMe`: `ProfilePage` renders directly
- * under the `Layout` shell, above any `<Screen>` Suspense boundary, so it must
- * drive fate itself rather than suspend. A null/empty username (user not yet
- * bootstrapped) leaves `enabled` false, so the read short-circuits off the wire
- * and the state stays idle.
- *
- * Returns a discriminated `idle | loading | ok | error` state so a failed fetch
- * is distinguishable from a genuine zero-activity user — the consumer renders an
- * honest error instead of a misleading `0` (#448), mirroring the `SozlukHome`
- * `loading | ok | error` status convention.
+ * A user's profile counts by username. Imperative rather than the suspending
+ * `useRequest` because `ProfilePage` renders above any `<Screen>` boundary and so
+ * cannot suspend. The state is discriminated so a failed fetch stays distinguishable
+ * from a genuine zero-activity user, which would otherwise render as a lying `0` (#448).
  */
 import {useMemo} from "react";
 import {view} from "react-fate";
 import type {Profile} from "../../worker/features/fate/views";
 import {useImperativeView} from "../fate/useImperativeView";
 
-/**
- * The projected count shape, derived from the codegen'd `Profile` Entity (ADR
- * 0022) — a `Pick` over the four count scalars, never a hand-restated interface.
- * `totalKarma` is `user_profile.total_karma` (ADR 0050), surfaced ambiently on the
- * owner's profile (#1208). The selected `userId` normalization key is dropped here
- * by projection — `toProfileStatsState` performs that narrowing.
- */
+// A `Pick` over the codegen'd `Profile` entity, never a hand-restated interface.
 export type ProfileStats = Pick<
 	Profile,
 	"postCount" | "commentCount" | "definitionCount" | "totalKarma"
@@ -47,13 +29,8 @@ const ProfileStatsView = view<Profile>()({
 	totalKarma: true,
 });
 
-/**
- * Pure snapshot → `ok` mapping, factored out so the count-projection contract is
- * unit-testable without a DOM/React runtime — the swallow this fixes lived in
- * exactly this un-asserted path. A `null` snapshot (user not found / empty view)
- * is a real, successful zero result, NOT an error: it maps to all-zero counts
- * (and zero karma — an honest çaylak, never a placeholder; #1208 AC).
- */
+// A `null` snapshot is a successful zero result, NOT an error — it maps to all-zero
+// counts, which is the honest answer for a brand-new user.
 export function toProfileStatsState(data: ProfileStats | null): ProfileStatsState {
 	return {
 		status: "ok",

--- a/apps/web/src/pages/usernameMessages.ts
+++ b/apps/web/src/pages/usernameMessages.ts
@@ -1,28 +1,16 @@
 /**
- * Shared Turkish messaging for the username choice — used by BOTH the signup form
- * (`AuthPage`) and the post-signup fallback (`UsernameBootstrap`), so the two
- * surfaces never drift in copy or in the rule they pre-flight against.
- *
- * `localRuleMessage` runs the single-source {@link checkUsername} rule
- * (`worker/features/pasaport/username-rule.ts`, the same one `assertUsername`
- * enforces server-side) for client pre-flight; `messageForCode` maps a server wire
- * `code` back through the same table. The server stays authoritative — these are
- * the UX layer over it.
+ * Shared Turkish messaging for the username choice, used by both the signup form and the
+ * post-signup fallback so the two can't drift in copy or in the rule they pre-flight. The
+ * pre-flight runs the same rule module the server enforces; the server stays authoritative.
  */
 
 import {checkUsername, normalizeUsername} from "../../worker/features/pasaport/username-rule";
 import type {WireMessageOverrides} from "../fate/wireMessages";
 import type {FateWireCode} from "../lib/fateWireCodes";
 
-/**
- * The username surface's per-code copy. Unlike the other write surfaces (which
- * defer non-overridden codes to the shared {@link WIRE_MESSAGES} base, #1421), the
- * username form deliberately collapses *every* non-validation failure to one
- * generic line ({@link USERNAME_GENERIC}) — "couldn't set the username" is the
- * right surface message for an auth/server failure here, so this is a meaningful
- * per-surface default, not the #1422 silent-absorb. Only these five reasons get
- * distinct copy.
- */
+// Deliberately does NOT defer to the shared `WIRE_MESSAGES` base like the other write
+// surfaces: every non-validation failure collapses to one generic line here, because
+// "couldn't set the username" is the right thing to show for any of them (#1421/#1422).
 const USERNAME_OVERRIDES: WireMessageOverrides = {
 	TOO_SHORT: "kullanıcı adı en az 3 karakter olmalı",
 	TOO_LONG: "kullanıcı adı en fazla 30 karakter olabilir",
@@ -33,16 +21,10 @@ const USERNAME_OVERRIDES: WireMessageOverrides = {
 
 const USERNAME_GENERIC = "kullanıcı adı ayarlanamadı";
 
-/** Map a server wire code (or a local rule reason) to its inline Turkish message. */
 export function messageForCode(code: FateWireCode | null): string {
 	return (code != null && USERNAME_OVERRIDES[code]) || USERNAME_GENERIC;
 }
 
-/**
- * Client-side pre-flight: normalize + run the shared rule, returning the inline
- * message for the first failing reason, or `null` when the value is a legal
- * handle. `RESERVED` shares the format message (the server maps it the same way).
- */
 export function localRuleMessage(value: string): string | null {
 	const code = checkUsername(normalizeUsername(value));
 	if (code === null) return null;

--- a/apps/web/src/styles/focus-layer.test.ts
+++ b/apps/web/src/styles/focus-layer.test.ts
@@ -1,16 +1,8 @@
 /**
- * The shared focus layer is defined ONCE (#2169, the discord/focus-rings idiom):
- * `global.css` carries a single `:focus-visible` rule that paints the
- * `--focus-ring` token on every interactive control, and component CSS no longer
- * hand-rolls its own `outline: var(--focus-ring)` copy. These pin that
- * single-source invariant against a regression that reintroduces a per-component
- * ring: a new bespoke `outline: var(--focus-ring)` (or the pre-#2169 divergent
- * `outline: 2px solid var(--accent)`) fails here rather than only under manual
- * review.
- *
- * The one sanctioned exception is the skip-link, which uses `:focus` (not
- * `:focus-visible`) on purpose — it is reached only by keyboard so it must show on
- * any focus — and is allow-listed below.
+ * The focus ring is painted ONCE, in `global.css` (#2169). These pin that
+ * single source: a bespoke per-component `outline: var(--focus-ring)` (or the
+ * pre-#2169 divergent `outline: 2px solid var(--accent)`) fails here rather than
+ * only under manual review.
  */
 import {readdirSync, readFileSync} from "node:fs";
 import {join} from "node:path";
@@ -19,7 +11,6 @@ import {describe, expect, it} from "vitest";
 const SRC = join(import.meta.dirname, "..");
 const GLOBAL_CSS = join(SRC, "styles", "global.css");
 
-/** Recursively collect every `.css` under `src/`. */
 function cssFiles(dir: string): string[] {
 	const out: string[] = [];
 	for (const entry of readdirSync(dir, {withFileTypes: true})) {
@@ -35,7 +26,6 @@ describe("shared focus layer (#2169)", () => {
 		const css = readFileSync(GLOBAL_CSS, "utf8");
 		// zero-specificity :where() selector so component variants override without a fight
 		expect(css).toMatch(/:where\([^)]*\):focus-visible\s*\{[^}]*outline:\s*var\(--focus-ring\)/s);
-		// the offset token rides on the same rule
 		expect(css).toMatch(
 			/:where\([^)]*\):focus-visible\s*\{[^}]*outline-offset:\s*var\(--focus-ring-offset\)/s,
 		);

--- a/apps/web/src/vite-env.d.ts
+++ b/apps/web/src/vite-env.d.ts
@@ -1,26 +1,18 @@
 /// <reference types="vite/client" />
 
-/**
- * Build-time client env (Vite exposes only `VITE_`-prefixed vars to the bundle).
- * `VITE_SENTRY_DSN` is the SPA's Sentry DSN (ADR 0118) — a public, client-side value,
- * absent by default so Sentry ships inert until the maintainer provisions it.
- */
+// Build-time client env. `VITE_SENTRY_DSN` is absent by default so Sentry ships inert
+// until the maintainer provisions it — see ADR 0118.
 interface ImportMetaEnv {
 	readonly VITE_SENTRY_DSN?: string;
 	/**
-	 * Feed-snapshot containment flag (epic #2316, leg A). `"on"` enables the
-	 * boot-time persist+hydrate of the public fate cache; absent/anything else keeps
-	 * it dark (default-off). A build-time flag, not the server-evaluated Flagship
-	 * flag, because boot hydration resolves synchronously before any `/api/flags`
-	 * round-trip — see `src/fate/snapshot.ts`. #2326 flips it on measured evidence.
+	 * `"on"` enables the boot-time persist+hydrate of the public fate cache (`src/fate/snapshot.ts`).
+	 * Build-time rather than a server-evaluated Flagship flag because boot hydration resolves
+	 * synchronously, before any `/api/flags` round-trip.
 	 */
 	readonly VITE_FEED_SNAPSHOT?: string;
 	/**
-	 * Reload→feed-paint instrumentation flag (epic #2316, verification #2326). `"on"`
-	 * emits the User Timing marks/measures in a measurement/stage build; the instrument
-	 * is also on automatically in dev. Absent/anything else keeps it off in a production
-	 * build (zero cost). A build-time flag, like `VITE_FEED_SNAPSHOT` — see
-	 * `src/lib/feedPerf.ts`.
+	 * `"on"` emits the User Timing marks/measures of `src/lib/feedPerf.ts`; also on in dev.
+	 * Build-time, like `VITE_FEED_SNAPSHOT`.
 	 */
 	readonly VITE_FEED_PERF?: string;
 }


### PR DESCRIPTION
Fans the founder-approved worker pilot (#6445) out to the frontend. Same bar, verbatim: cut anything a reader can get from the code, keep what bites (real invariants at their enforcement site, workaround + the constraint forcing it, deliberate-looking-wrong guards, pragma rationale). Borderline = cut. ADR-duplicating docblocks collapse to one pointer line.

## Census

| | comment lines | total lines | density |
| --- | --- | --- | --- |
| before | 7,842 | 37,623 | 20.8% |
| after | 2,938 | 32,707 | 9.0% |

390 TS/TSX files scanned, 328 touched. `-6,393 / +1,477`.

## Verdicts (1,710 comments judged)

| verdict | count |
| --- | --- |
| CUT | 841 |
| COLLAPSE | 561 |
| KEEP | 308 |

Run as 16 disjoint file groups, one subagent per group, each reading the skill directly. REHOME was serial and driver-owned: 16 orphan candidates were flagged, and I read every one at its line. All 16 turned out to be local invariants or workaround+constraint pairs already sitting exactly where they bite (`panoFeedOverlay`'s identity guard, `signupUsernameGate`'s dropped-handle race, `useToggleAction`'s supersede loop, `auth/client.ts`'s type re-anchor, `flag-overrides.ts`'s deliberate worker-codec duplicate, …). Every one stayed inline. Nothing was deleted unhomed, and no ADR was written or invented.

## Five example cuts

- `App.test.tsx` — ~30 in-body narrations restating their own `it(...)` title (`// Eviction half: the topbar no longer carries the pano primary action.`)
- `optimisticEdit.ts` — all five docblocks restating their own signature (`/** The optimistic partial for a post edit — the edited title/body + a fresh updatedAt. */`)
- `LandingPage.tsx` / `FunnelSummary.tsx` — `// Turkish thousands separator is '.' (e.g. 1.247).` over a `toLocaleString("tr-TR")` one-liner, twice
- `CommentTreeNode.tsx` / `PanoPostHeader.tsx` / `PanoPostCard.tsx` — the same "Live author identity via `actorLabel` (#2139)" block copy-pasted at three sites
- `module-registry.ts` — `/** Stable technical id — the registry key + the nav selection key. */` over `readonly id: string`

## Five example keeps

- `client.ts` — `FateRequestError` is only exported from `@nkzw/fate/server`, so the code duck-types on `.code` instead of `instanceof` (workaround + its forcing constraint)
- `PanoPostCard.tsx` — the title routes to the post detail, never the external URL (#2437); someone would otherwise "fix" it
- `a11y/posture.ts` — the "jsdom applies no CSS / has no layout engine" notes at the `posture: "warning"` lines someone would otherwise flip to `enforced`
- `ContributionRow.tsx` — the `sandboxed` privacy invariant: bare boolean, no reviewer identity, author/moderator only
- `App.tsx` — `onSignOut` captures the id first, because `signOut()` nulls the session

Every `@component` / `@whenToUse` / `@slot` / `@agent` block is intact (`design-inventory` reads them, ADR 0194), as are the `@reachability-exempt:` markers in `flags/keys.ts` (ADR 0173) and every pragma.

## Byte-safety

- All 328 changed files esbuild-normalized (comments dropped, formatting normalized) at `origin/main` and at HEAD, then compared: **0 real code differences**.
- `pnpm typecheck` green (forced, no cache).
- `biome check apps/web/src` clean — the single CSS specificity warning in `Divan.css` is pre-existing and that file is untouched (confirmed by re-running against a stashed tree).

## Two things worth knowing

Four ADR citations in the old comments pointed at the wrong file: `0082` twice (it is the two-test-tiers ADR, cited for "a report has no read view"), `0044` (the imge media ADR, cited for an api-key decision), and `0091` (infra-epics, cited for the global live pin — the real home is ADR 0094 / `.patterns/fate-live-consistency.md#global-pin`). The wrong numbers were dropped or repointed at a verified doc; none was replaced with a guess.

Seventeen flag-gated pages carry a near-identical "don't decide 404-vs-page until the flag resolves / ships dark behind FLAG" docblock with no `.patterns/` home. Each is collapsed to one line here; a `.patterns/flag-dark-page-gate.md` would let them all become a single pointer. Filed as a follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
