### PR TITLE
chore: deslop comments in tests + small packages

### DIFF
--- a/apps/web/tests/e2e/00-smoke.spec.ts
+++ b/apps/web/tests/e2e/00-smoke.spec.ts
@@ -24,13 +24,10 @@ const SPA_READY_POLL_MS = 1_500;
 
 async function gotoSpaReady(page: Page, route: string): Promise<void> {
 	const deadline = Date.now() + SPA_READY_DEADLINE_MS;
-	// Poll until the served page is not the typed CF placeholder-404, or the budget lapses — then
-	// leave the last navigation in place so the caller's assertion reports the truth (a genuinely
-	// cold edge past the budget still reds).
 	while (Date.now() < deadline) {
 		const res = await page.goto(route);
-		if (!res || res.status() !== 404) return; // 200 SPA shell, or a non-404 the caller must judge
-		if (!isCloudflarePlaceholder404(res.status(), await res.text())) return; // real worker JSON 404
+		if (!res || res.status() !== 404) return;
+		if (!isCloudflarePlaceholder404(res.status(), await res.text())) return;
 		await page.waitForTimeout(SPA_READY_POLL_MS);
 	}
 }

--- a/apps/web/tests/e2e/01-landing.spec.ts
+++ b/apps/web/tests/e2e/01-landing.spec.ts
@@ -7,18 +7,15 @@ test.describe("LandingPage", () => {
 
 	test("hero brand, tagline, manifesto, rite, join CTA + browse cards", async ({page}) => {
 		await expect(page.locator(".kp-landing__brand")).toContainText("kamp");
-		// dot accent inside the brand
 		await expect(page.locator(".kp-landing__brand .dot")).toBeVisible();
 		await expect(page.locator(".kp-landing__tagline")).toBeVisible();
 		await expect(page.locator(".kp-landing__manifesto")).toBeVisible();
 		await expect(page.locator(".kp-landing__rite")).toBeVisible();
 
-		// join is the figure: the dominant CTA points at /auth
 		const join = page.getByTestId("landing-join-cta");
 		await expect(join).toBeVisible();
 		await expect(join).toHaveAttribute("href", "/auth");
 
-		// browsing is the ground: the two demoted browse cards
 		const browse = page.locator(".kp-landing__browse a");
 		await expect(browse).toHaveCount(2);
 		await expect(browse.nth(0)).toHaveAttribute("href", "/pano");
@@ -44,12 +41,9 @@ test.describe("LandingPage", () => {
 	});
 
 	test("activity columns render rows", async ({page}) => {
-		// LandingPage still uses LANDING_TERMS / POSTS fixtures for both columns;
-		// 5 each per slice(0, 5).
 		const cols = page.locator(".kp-landing__col");
 		await expect(cols).toHaveCount(2);
 		const rows = page.locator(".kp-landing-row");
-		// 5 from pano col + up to 5 from sozluk col
 		expect(await rows.count()).toBeGreaterThan(0);
 	});
 });

--- a/apps/web/tests/e2e/02-topbar.spec.ts
+++ b/apps/web/tests/e2e/02-topbar.spec.ts
@@ -53,7 +53,6 @@ test.describe("Topbar (signed out)", () => {
 
 		await search.fill("hello");
 		await search.press("Enter");
-		// no nav, no error
 		await expect(page.locator(".kp-topbar")).toBeVisible();
 		expect(errors).toHaveLength(0);
 	});

--- a/apps/web/tests/e2e/03-pano-feed.spec.ts
+++ b/apps/web/tests/e2e/03-pano-feed.spec.ts
@@ -3,7 +3,6 @@ import {expect, test} from "@playwright/test";
 test.describe("PanoFeed (/pano)", () => {
 	test.beforeEach(async ({page}) => {
 		await page.goto("/pano");
-		// Wait for at least one post to render before each test.
 		await expect(page.locator(".kp-pano-post").first()).toBeVisible({timeout: 10_000});
 	});
 
@@ -40,7 +39,6 @@ test.describe("PanoFeed (/pano)", () => {
 		await topChip.click();
 		await expect(page).toHaveURL("/pano?sort=top");
 
-		// Reload restores the sort from the URL, not the default.
 		await page.reload();
 		await expect(page.locator(".kp-pano-post").first()).toBeVisible({timeout: 10_000});
 		await expect(page).toHaveURL("/pano?sort=top");
@@ -49,7 +47,6 @@ test.describe("PanoFeed (/pano)", () => {
 			"true",
 		);
 
-		// A second switch pushes a history entry, so back returns to the prior sort.
 		const newChip = page.getByRole("button", {name: /^yeni$/i}).last();
 		await newChip.click();
 		await expect(page).toHaveURL("/pano?sort=new");
@@ -65,7 +62,6 @@ test.describe("PanoFeed (/pano)", () => {
 		const firstPostTitle = page.locator(".kp-pano-post .kp-pano-post__title").first();
 		const href = await firstPostTitle.getAttribute("href");
 		expect(href).toBeTruthy();
-		// Either an absolute external URL or a /pano/<id> path.
 		expect(href).toMatch(/^(https?:\/\/|\/pano\/)/);
 	});
 
@@ -74,7 +70,6 @@ test.describe("PanoFeed (/pano)", () => {
 		// non-navigating <span> with the same class. Target the anchor so the
 		// skip-guard skips on self-only feeds and the click hits a real link.
 		const siteLink = page.locator("a.kp-pano-post__site").first();
-		// Some seed posts are self-posts (no host) — only run if a host link exists.
 		if (!(await siteLink.isVisible().catch(() => false))) {
 			test.skip(true, "no host links on the current page (all self-posts)");
 		}
@@ -90,7 +85,6 @@ test.describe("PanoFeed (/pano)", () => {
 	test("meta line shows author, time, comment count", async ({page}) => {
 		const meta = page.locator(".kp-pano-post .kp-pano-post__meta").first();
 		await expect(meta.locator(".author")).toBeVisible();
-		// "N yorum" link
 		await expect(meta.locator("a", {hasText: /yorum$/})).toBeVisible();
 	});
 });

--- a/apps/web/tests/e2e/04-pano-post.spec.ts
+++ b/apps/web/tests/e2e/04-pano-post.spec.ts
@@ -20,11 +20,9 @@ test.describe("PanoPostDetail", () => {
 	test("renders title, vote control, meta, composer, comment thread", async ({page}) => {
 		await gotoFirstPostDetail(page);
 		await expect(page.locator(".kp-pano-postpage__title")).toBeVisible();
-		// PostVoteWidget renders the .kp-pano-post__vote control
 		await expect(page.locator(".kp-pano-post__vote").first()).toBeVisible();
 		await expect(page.locator(".kp-pano-postpage__meta .author")).toBeVisible();
 		await expect(page.locator(".kp-pano-comment-composer")).toBeVisible();
-		// "N yorum" thread heading
 		await expect(page.locator(".kp-pano-postpage__thread-heading")).toBeVisible();
 	});
 
@@ -40,7 +38,6 @@ test.describe("PanoPostDetail", () => {
 		await completeBootstrap(page);
 		await gotoFirstPostDetail(page);
 		const firstUpvote = page.locator(".kp-comment__upvote").first();
-		// Some seed posts have no comments; skip in that case rather than fail.
 		if (!(await firstUpvote.isVisible().catch(() => false))) {
 			test.skip(true, "no comments on the first seeded post");
 		}

--- a/apps/web/tests/e2e/05-pano-vote.spec.ts
+++ b/apps/web/tests/e2e/05-pano-vote.spec.ts
@@ -4,17 +4,10 @@ import {randomSuffix} from "./_helpers/rand";
 import {expectScoreConsistent} from "./_helpers/wait-for-consistency";
 
 /**
- * Pano post-vote toggle. PostVoteWidget tracks a local optimistic delta on
- * top of the server-provided baseScore — so we read the count, click, expect
- * +1, click again, expect a return to baseline. Both transitions go through
- * the Relay mutation; neither should regress on transient flicker because
- * we update React state synchronously before commit.
- *
- * We submit a FRESH post and vote on it (scoped by its unique title) rather
- * than `.kp-pano-post.first()` — the first feed card is the shared seed post
- * (`post-score-seed-post-tanitim`) whose score is mutated by other specs' live
- * updates mid-assert, which flakes the baseline↔+1 round-trip. A brand-new
- * post starts at a quiet score of 0 only this test touches.
+ * Pano post-vote toggle. It submits a FRESH post and votes on that (scoped by its
+ * unique title) rather than `.kp-pano-post.first()`: the first feed card is the
+ * shared seed post, whose score other specs' live updates mutate mid-assert,
+ * flaking the baseline↔+1 round-trip.
  */
 // QUARANTINED — un-quarantine blocked on #1838 (e2e can't establish yazar tier); see #1903.
 // Vote score-propagation flake tracked at #1903. Tracking: #1885/#1903.
@@ -25,11 +18,9 @@ import {expectScoreConsistent} from "./_helpers/wait-for-consistency";
 // vote-GATE (#1828) coverage lives here. Re-enable = revert to plain test(...).
 test.fixme("upvote increments and toggles back (signed in)", async ({page}) => {
 	await signUp(page);
-	// Clear the username bootstrap gate (a fresh user has no username, so the
-	// Layout would otherwise show the bootstrap form in place of the feed).
+	// A fresh user has no username, so the Layout shows the bootstrap form, not the feed.
 	await completeBootstrap(page);
 
-	// Submit a fresh post so we vote on a card nothing else is touching.
 	await page.goto("/pano/yeni");
 	await expect(page.locator('[data-testid="pano-submit-title"]')).toBeVisible({timeout: 10_000});
 	const title = `vote feed target ${Date.now().toString(36)}${randomSuffix(4)}`;
@@ -43,8 +34,7 @@ test.fixme("upvote increments and toggles back (signed in)", async ({page}) => {
 	await submit.click();
 	await page.waitForURL(/\/pano\/post_[A-Za-z0-9]+$/, {timeout: 15_000});
 
-	// Open the feed, switch to "yeni" (new) so our just-submitted post is on the
-	// first page, then locate OUR post by its unique title (not `.first()`).
+	// "yeni" (new) ordering puts the just-submitted post on the first page.
 	await page.goto("/pano");
 	await page.getByRole("button", {name: "yeni"}).click();
 	const targetPost = page.locator(".kp-pano-post").filter({hasText: title}).first();

--- a/apps/web/tests/e2e/06-sozluk-home.spec.ts
+++ b/apps/web/tests/e2e/06-sozluk-home.spec.ts
@@ -10,9 +10,8 @@ test.describe("SozlukHome (/sozluk)", () => {
 
 	test("masthead title + create CTA + alphabet visible", async ({page}) => {
 		await expect(page.locator(".kp-sozluk-home__title")).toContainText("sözlük");
-		// The local go-to search box is gone — folded into the global ⌘K `ara` (#2995). The
-		// `+ yeni tanım` create CTA and the alphabet both live in sözlük's persistent Subnav
-		// zone (#2602), not the masthead — the page paints neither a second time.
+		// The CTA and the alphabet live in sözlük's persistent Subnav zone (#2602), not the
+		// masthead — the page paints neither a second time.
 		await expect(page.getByRole("button", {name: /yeni tanım/i})).toBeVisible();
 		await expect(page.locator(".kp-sozluk-alphabet")).toBeVisible();
 		// Each non-empty letter is a navigable link to `/sozluk?harf=<letter>` (#693):
@@ -22,30 +21,23 @@ test.describe("SozlukHome (/sozluk)", () => {
 	});
 
 	test("recent and popular columns render rows", async ({page}) => {
-		// At least one term row in "son eklenenler"
 		await expect(page.locator(".kp-sozluk-term-row").first()).toBeVisible({timeout: 10_000});
-		// Popular list with rank + score format
 		const popular = page.locator(".kp-sozluk-popular__row");
 		expect(await popular.count()).toBeGreaterThan(0);
 		await expect(popular.first().locator(".kp-sozluk-popular__rank")).toBeVisible();
 		await expect(popular.first().locator(".kp-sozluk-popular__meta")).toBeVisible();
 	});
 
-	// The in-page real-time typed-query filter was removed by design (#2995): the
-	// "go to a term" search folded into the global ⌘K `ara` → `/search` (covered by
-	// 24-search.spec.ts), leaving only the URL-driven alphabet letter filter below.
+	// There is no typed-query filter test: that search folded into the global ⌘K `ara`
+	// (#2995, covered by 24-search.spec.ts), leaving only the letter filter below.
 
 	test("clicking an alphabet letter navigates to ?harf= and filters the recent column", async ({
 		page,
 	}) => {
-		// Letters are navigable links now (#693): clicking pushes `/sozluk?harf=<letter>`,
-		// and the recent column filters client-side off that URL param.
 		const firstLetter = page.locator('.kp-sozluk-alphabet__letter[href*="harf="]').first();
 		const letter = (await firstLetter.textContent())?.trim().toLowerCase() ?? "";
 		await firstLetter.click();
-		// The click is a real navigation: the active letter is reflected in the URL…
 		await expect(page).toHaveURL(new RegExp(`[?&]harf=${encodeURIComponent(letter)}(&|$)`));
-		// …and marked active (aria-current + .is-active) rather than a transient toggle.
 		const activeLetter = page.locator(".kp-sozluk-alphabet__letter.is-active");
 		await expect(activeLetter).toHaveAttribute("aria-current", "page");
 		await expect(activeLetter).toHaveText(letter);
@@ -58,14 +50,9 @@ test.describe("SozlukHome (/sozluk)", () => {
 });
 
 /**
- * The create-flow #440/#97: the old go-to-or-create box's search half folded into the
- * global ⌘K `ara` (#2995), leaving the create half as the `+ yeni tanım` CTA
- * (`SozlukSubnavCta`). It opens a dialog that slugifies the typed term and routes to the
- * fresh-slug composer at `/sozluk/<slugifyTerm(term)>` — the same target the old box
- * reached. A signed-in user lands on `NewTermComposer` (the `.kp-sozluk-term__head` +
- * composer body), so the test signs up first to assert it genuinely reaches the composer
- * view, not the signed-out 404. The term is per-run unique to keep the slug brand-new (a
- * composer, not an existing term page).
+ * The create-flow (#440/#97). Signs up first because a signed-out fresh slug renders a 404,
+ * not the composer. The term is per-run unique to keep the slug brand-new — an existing slug
+ * would render the term page instead.
  */
 test.describe("SozlukHome create-flow (+ yeni tanım → composer)", () => {
 	test.beforeEach(async ({page}) => {
@@ -84,20 +71,13 @@ test.describe("SozlukHome create-flow (+ yeni tanım → composer)", () => {
 
 		await page.getByRole("button", {name: /yeni tanım/i}).click();
 
-		// The reopen-retry workaround is retired (#3840): #3600 pinned the silent closer as an
-		// ancestor unmount resetting the CTA's local `open` useState, and #3840 hoisted that
-		// state above the unmounting boundary — so the dialog no longer vanishes on an idle
-		// `/sozluk`, and the flow is a straight open → fill → submit → navigate.
-		// The Manti migration made Dialog a straight re-export, so the old `.kp-dialog__popup`
-		// BEM class is emitted by nothing; the role is the stable contract either way.
+		// Matched by role, not a BEM class: the Manti migration made Dialog a straight
+		// re-export, so nothing emits the old `.kp-dialog__popup`.
 		const dialog = page.getByRole("dialog");
 		await expect(dialog).toBeVisible();
-		// The dialog collects the term name (the composer is slug-addressed).
 		await page.getByLabel("Terim").fill(term);
 		await page.getByRole("button", {name: /^oluştur$/i}).click();
-		// The dialog slugifies + navigates to the fresh-slug composer route.
 		await expect(page).toHaveURL(new RegExp(`/sozluk/${slug}$`));
-		// Signed-in fresh slug → NewTermComposer: term head + composer body.
 		await expect(page.locator(".kp-sozluk-term__head")).toBeVisible({timeout: 10_000});
 		await expect(page.locator('[data-testid="sozluk-composer-body"]')).toBeVisible();
 	});

--- a/apps/web/tests/e2e/07-sozluk-term.spec.ts
+++ b/apps/web/tests/e2e/07-sozluk-term.spec.ts
@@ -27,17 +27,13 @@ test.describe("SozlukTermPage", () => {
 		await expect(page.locator(".kp-sozluk-term__title")).toBeVisible();
 		await expect(page.locator(".kp-sozluk-term__meta")).toContainText("tanım");
 
-		// At least one definition card with vote button + body + footer
 		const card = page.locator(".kp-sozluk-definition").first();
 		await expect(card).toBeVisible();
 		await expect(card.locator(".kp-sozluk-definition__vote-btn")).toBeVisible();
 		await expect(card.locator(".kp-sozluk-definition__body")).toBeVisible();
 		await expect(card.locator(".kp-sozluk-definition__foot .author")).toBeVisible();
 
-		// Composer at the bottom
 		await expect(page.locator(".kp-sozluk-composer")).toBeVisible();
-
-		// Top definition has the --top modifier
 		await expect(page.locator(".kp-sozluk-definition--top")).toBeVisible();
 	});
 

--- a/apps/web/tests/e2e/08-auth.spec.ts
+++ b/apps/web/tests/e2e/08-auth.spec.ts
@@ -8,7 +8,6 @@ test.describe("AuthPage (/auth)", () => {
 		await expect(page.getByRole("heading", {name: /giriş yap/i})).toBeVisible();
 		await expect(page.getByLabel("e-posta")).toBeVisible();
 		await expect(page.getByLabel("parola", {exact: true})).toBeVisible();
-		// no görünen ad in sign-in mode
 		await expect(page.getByLabel("görünen ad")).toHaveCount(0);
 	});
 
@@ -27,7 +26,6 @@ test.describe("AuthPage (/auth)", () => {
 		await expect(pill).toContainText(creds.name);
 
 		await signOut(page);
-		// pill should be gone, "giriş yap" button should reappear
 		await expect(page.locator(".kp-topbar__user")).toHaveCount(0);
 		await expect(page.getByRole("button", {name: /giriş yap/i}).first()).toBeVisible();
 	});

--- a/apps/web/tests/e2e/09-profile.spec.ts
+++ b/apps/web/tests/e2e/09-profile.spec.ts
@@ -2,11 +2,7 @@ import {expect, type Page, test} from "@playwright/test";
 import {signUp} from "./_helpers/auth";
 import {randomSuffix} from "./_helpers/rand";
 
-/**
- * Helper: complete the bootstrap form so the signed-in user is past the
- * intercept and `/profile` actually renders. Without this the bootstrap form
- * blocks the Outlet (T13 behaviour).
- */
+/** Without this the bootstrap form blocks the Outlet and `/profile` never renders. */
 async function bootstrapUsername(page: Page): Promise<void> {
 	const handle = `u-${Date.now().toString(36)}${randomSuffix(4)}`;
 	await page.locator("input#bootstrap-username").fill(handle);
@@ -33,16 +29,11 @@ test.describe("ProfilePage (/profile)", () => {
 		await expect(page.getByTestId("user-profile-display-name")).toContainText(creds.name);
 		await expect(page.getByTestId("user-profile-handle")).toBeVisible();
 		await expect(page.locator(".kp-profile-header__stat")).toHaveCount(3);
-		// email row should show the credential email
 		await expect(page.locator(".kp-profile__row.readonly .value")).toContainText(creds.email);
 
-		// Section headings: katkıların / hesap / görünüm / oturum / tehlikeli alan.
-		// `katkıların` (the #1209 contribution signal) leads: it used to be gated on the
-		// authorship-loop flag retired by #3664, and this count encoded that flag's OFF
-		// world even though production served it on@100% — so the 4 was the stale
-		// expectation, not the render. The section is unconditional now, and its
-		// `SignalShell` renders in every state (loading / empty / list), so the count is
-		// stable for a fresh signup with no contributions yet.
+		// The count is 5, not 4: `katkıların` used to be gated on the authorship-loop flag
+		// retired by #3664, and its `SignalShell` renders in every state (loading / empty /
+		// list), so the count is stable for a fresh signup with no contributions yet.
 		const headings = page.locator(".kp-profile__section h3");
 		await expect(headings).toHaveCount(5);
 		await expect(headings.nth(0)).toHaveText("katkıların");
@@ -70,7 +61,6 @@ test.describe("ProfilePage (/profile)", () => {
 		await bootstrapUsername(page);
 		await page.goto("/profile");
 		await page.getByRole("button", {name: /^çıkış yap$/i}).click();
-		// Wait for the topbar to drop the pill (re-renders on session change).
 		await expect(page.locator(".kp-topbar__user")).toHaveCount(0, {timeout: 5_000});
 	});
 });

--- a/apps/web/tests/e2e/10-username-bootstrap.spec.ts
+++ b/apps/web/tests/e2e/10-username-bootstrap.spec.ts
@@ -3,12 +3,8 @@ import {signUp} from "./_helpers/auth";
 import {randomSuffix} from "./_helpers/rand";
 
 /**
- * Username bootstrap + topbar profile link.
- *
- * After signing up, a fresh Pasaport user has `username = NULL`. The Layout
- * intercepts the route and mounts <UsernameBootstrap> in place of <Outlet/>.
- * Once the user submits the form, the topbar swaps the @username link in and
- * routes /u/<username> to the profile page.
+ * Username bootstrap + topbar profile link. A fresh Pasaport user has `username = NULL`, so
+ * the Layout mounts <UsernameBootstrap> in place of <Outlet/> until the form is submitted.
  */
 test.describe("Username bootstrap", () => {
 	test("first sign-in shows the bootstrap form pre-filled with email local-part", async ({
@@ -18,11 +14,9 @@ test.describe("Username bootstrap", () => {
 		const email = `${localPart}@kamp.us`;
 		await signUp(page, {email});
 
-		// The form should be visible at the root (Layout intercepts Outlet).
 		await expect(page.getByRole("heading", {name: /kullanıcı adını seç/i})).toBeVisible();
 		const input = page.locator("input#bootstrap-username");
 		await expect(input).toBeVisible();
-		// Pre-filled with the email local-part, sanitized to kebab/alnum.
 		const sanitized = localPart
 			.toLowerCase()
 			.replace(/[^a-z0-9-]/g, "-")

--- a/apps/web/tests/e2e/11-sozluk-add-definition.spec.ts
+++ b/apps/web/tests/e2e/11-sozluk-add-definition.spec.ts
@@ -5,24 +5,17 @@ import {randomSuffix} from "./_helpers/rand";
 /**
  * Sözlük addDefinition end-to-end.
  *
- * Sign up a fresh user, complete the username bootstrap, navigate to a brand
- * new term URL, write a definition, submit. The new term + definition appear
- * via re-fetched `term(slug)` (auto-create-term behaviour from
- * SozlukTerm.addDefinition).
- *
- * The fresh-slug create is a read-your-own-write seam (#730, epic #713 Family B):
- * the auto-create remounts the content and re-reads `term(slug)` `network-only`,
- * a *second* request that can race the just-committed write. The fix carries
- * `definition.add`'s own returned id across the remount and confirms it via the
- * deterministic read-back, so the **persisted** `definition-card-def_*` card must
- * materialize — asserting on it (not just the body text, which an optimistic echo
- * or a transient render could satisfy) is what guards the race.
+ * The fresh-slug create is a read-your-own-write race (#730): the auto-create remounts
+ * the content and re-reads `term(slug)` `network-only`, a *second* request that can
+ * race the just-committed write. The fix carries `definition.add`'s own returned id
+ * across the remount and confirms it via the deterministic read-back, so the
+ * **persisted** `definition-card-def_*` card must materialize — asserting on it, not
+ * just the body text an optimistic echo could satisfy, is what guards the race.
  */
 test.describe("Sözlük addDefinition", () => {
 	test("adding a definition to a new slug auto-creates the term and renders the entry", async ({
 		page,
 	}) => {
-		// Fresh sign-up + bootstrap so the user is fully authenticated.
 		const localPart = `bs${Date.now().toString(36)}${randomSuffix(4)}`;
 		await signUp(page, {email: `${localPart}@kamp.us`});
 		const handle = `u-${Date.now().toString(36)}${randomSuffix(4)}`;
@@ -32,7 +25,6 @@ test.describe("Sözlük addDefinition", () => {
 			timeout: 10_000,
 		});
 
-		// Navigate to a slug that doesn't exist yet.
 		const slug = `e2e-${Date.now().toString(36)}${randomSuffix(4)}`;
 		await page.goto(`/sozluk/${slug}`);
 
@@ -55,7 +47,6 @@ test.describe("Sözlük addDefinition", () => {
 			timeout: 10_000,
 		});
 
-		// The term head shows the slug-derived title and a "1 tanım" counter.
 		await expect(page.getByRole("heading", {level: 1})).toContainText(slug.replace(/-/g, " "));
 	});
 
@@ -78,14 +69,11 @@ test.describe("Sözlük addDefinition", () => {
 		const submit = page.locator('[data-testid="sozluk-composer-submit"]');
 		await expect(composerBody).toBeVisible({timeout: 5_000});
 
-		// Empty body → submit disabled.
 		await expect(submit).toBeDisabled();
 
-		// Whitespace-only → still disabled (trim).
 		await composerBody.fill("   ");
 		await expect(submit).toBeDisabled();
 
-		// Body length over 10 000 → length warning visible.
 		await composerBody.fill("x".repeat(10_001));
 		await expect(page.getByText(/en fazla 10000 karakter/i)).toBeVisible();
 	});

--- a/apps/web/tests/e2e/12-sozluk-vote.spec.ts
+++ b/apps/web/tests/e2e/12-sozluk-vote.spec.ts
@@ -6,24 +6,9 @@ import {expectScoreConsistent} from "./_helpers/wait-for-consistency";
 /**
  * Sözlük voteDefinition end-to-end.
  *
- * Sign up a fresh user, complete the username bootstrap, navigate to a brand
- * new term URL, write a definition, then exercise the optimistic vote flip:
- *   1. Vote → score becomes 1, button reflects pressed state.
- *   2. Click again → retract vote → score back to 0.
- *   3. Vote again → score 1.
- *
- * The DefinitionCard's optimistic updater flips `myVote` + `score`
- * synchronously; on success the projection lands in <1s and the page reads
- * the new state on subsequent renders.
- *
- * Historical note: this spec previously contained a `page.reload()` between
- * the addDefinition mutation and the vote interactions to escape the
- * Suspense double-mount race triggered by the legacy
- * `setFetchKey`-driven refetch. After the relay-idiom refactor the
- * page tree no longer unmounts on a mutation (idiomatic Relay
- * `@deleteRecord` + manual `updater` for prepends + `commitLocalUpdate`
- * for live updates), so the reload is gone. Its presence would now signal
- * a regression.
+ * There is deliberately no `page.reload()` between the addDefinition mutation and the vote
+ * interactions: the page tree no longer unmounts on a mutation, so a reload reappearing here
+ * would signal a regression.
  */
 test.describe("Sözlük voteDefinition", () => {
 	// QUARANTINED — un-quarantine blocked on #1838 (e2e can't establish yazar tier); see #1903.
@@ -35,7 +20,6 @@ test.describe("Sözlük voteDefinition", () => {
 	// re-vote round-trip. No vote-GATE (#1828) coverage lives here.
 	// Re-enable = revert to plain test(...).
 	test.fixme("vote → unvote → vote round-trip on a fresh definition", async ({page}) => {
-		// Fresh sign-up + bootstrap so the user is fully authenticated.
 		const localPart = `vt${Date.now().toString(36)}${randomSuffix(4)}`;
 		await signUp(page, {email: `${localPart}@kamp.us`});
 		const handle = `u-${Date.now().toString(36)}${randomSuffix(4)}`;
@@ -45,7 +29,6 @@ test.describe("Sözlük voteDefinition", () => {
 			timeout: 10_000,
 		});
 
-		// Navigate to a fresh slug + add a definition.
 		const slug = `vote-${Date.now().toString(36)}${randomSuffix(4)}`;
 		await page.goto(`/sozluk/${slug}`);
 
@@ -81,17 +64,14 @@ test.describe("Sözlük voteDefinition", () => {
 		await expectScoreConsistent(page, score, "0");
 		await expect(voteBtn).toHaveAttribute("aria-pressed", "false");
 
-		// Cast vote — optimistic flip lands first.
 		await voteBtn.click();
 		await expectScoreConsistent(page, score, "1");
 		await expect(voteBtn).toHaveAttribute("aria-pressed", "true", {timeout: 5_000});
 
-		// Retract vote.
 		await voteBtn.click();
 		await expectScoreConsistent(page, score, "0");
 		await expect(voteBtn).toHaveAttribute("aria-pressed", "false");
 
-		// Re-vote.
 		await voteBtn.click();
 		await expectScoreConsistent(page, score, "1");
 		await expect(voteBtn).toHaveAttribute("aria-pressed", "true");

--- a/apps/web/tests/e2e/13-sozluk-edit-delete.spec.ts
+++ b/apps/web/tests/e2e/13-sozluk-edit-delete.spec.ts
@@ -3,28 +3,6 @@ import {signOut, signUp} from "./_helpers/auth";
 import {promoteToYazar} from "./_helpers/promote";
 import {randomSuffix} from "./_helpers/rand";
 
-/**
- * Sözlük editDefinition / deleteDefinition end-to-end.
- *
- * Two flows:
- *   1. Author flow: sign up user A → add a definition → edit it (body
- *      changes) → delete it (card disappears).
- *   2. Cross-user flow: sign up user A → add a definition → sign out →
- *      sign up user B → user B doesn't see edit/delete buttons on user A's
- *      definition.
- *
- * Historical note: this spec previously contained a `page.reload()` between
- * the addDefinition mutation and the edit interactions to escape the
- * Suspense double-mount race triggered by the legacy
- * `setFetchKey`-driven refetch. After the relay-idiom refactor the
- * page tree no longer unmounts on a mutation (idiomatic Relay
- * `@deleteRecord` for delete + manual `updater` for prepends + the new
- * `addDefinition` selection set spreads `DefinitionCardFragment` so the
- * row hydrates without a follow-up read), so the reload is gone. The
- * very first `addDefinition` on a fresh slug still triggers an internal
- * page reload from the app to materialize the Term record (a narrow
- * fresh-slug-only path); subsequent edits / deletes don't.
- */
 test.describe("Sözlük editDefinition / deleteDefinition", () => {
 	test("author can edit and delete their own definition", async ({page}) => {
 		const suffix = `${Date.now().toString(36)}${randomSuffix(4)}`;
@@ -56,24 +34,20 @@ test.describe("Sözlük editDefinition / deleteDefinition", () => {
 			timeout: 10_000,
 		});
 
-		// Edit affordance is visible to the author.
 		const editBtn = page.locator('[data-testid^="definition-edit-"]').first();
 		const deleteBtn = page.locator('[data-testid^="definition-delete-"]').first();
 		await expect(editBtn).toBeVisible();
 		await expect(deleteBtn).toBeVisible();
 
-		// Click edit → an editable textarea appears prefilled with the body.
 		await editBtn.click();
 		const editTextarea = page.locator('[data-testid^="definition-edit-body-"]').first();
 		await expect(editTextarea).toBeVisible();
 		await expect(editTextarea).toHaveValue(originalBody);
 
-		// Replace the body and save.
 		const editedBody = `edited definition ${suffix}`;
 		await editTextarea.fill(editedBody);
 		await page.locator('[data-testid^="definition-edit-save-"]').first().click();
 
-		// Edited body is now visible; original is gone.
 		await expect(page.getByText(editedBody)).toBeVisible({timeout: 10_000});
 		await expect(page.getByText(originalBody, {exact: true})).toHaveCount(0);
 
@@ -83,7 +57,6 @@ test.describe("Sözlük editDefinition / deleteDefinition", () => {
 			timeout: 5_000,
 		});
 
-		// Delete → confirm dialog → confirm.
 		const deleteBtnAgain = page.locator('[data-testid^="definition-delete-"]').first();
 		await expect(deleteBtnAgain).toBeVisible({timeout: 5_000});
 		await deleteBtnAgain.click();
@@ -91,14 +64,12 @@ test.describe("Sözlük editDefinition / deleteDefinition", () => {
 		await expect(confirm).toBeVisible({timeout: 5_000});
 		await confirm.click();
 
-		// Card disappears from the page.
 		await expect(page.getByText(editedBody)).toHaveCount(0, {timeout: 15_000});
 	});
 
 	test("non-author does not see edit/delete buttons on someone else's definition", async ({
 		page,
 	}) => {
-		// User A signs up, bootstraps, writes a definition.
 		const aSuffix = `${Date.now().toString(36)}${randomSuffix(4)}`;
 		const emailA = `aa${aSuffix}@kamp.us`;
 		await signUp(page, {email: emailA});
@@ -121,7 +92,6 @@ test.describe("Sözlük editDefinition / deleteDefinition", () => {
 		await page.locator('[data-testid="sozluk-composer-submit"]').click();
 		await expect(page.getByText(aBody)).toBeVisible({timeout: 15_000});
 
-		// Sign A out, sign B up.
 		await signOut(page);
 		const bSuffix = `${Date.now().toString(36)}${randomSuffix(4)}`;
 		await signUp(page, {email: `bb${bSuffix}@kamp.us`});
@@ -131,15 +101,13 @@ test.describe("Sözlük editDefinition / deleteDefinition", () => {
 			timeout: 10_000,
 		});
 
-		// Navigate B to A's term page.
 		await page.goto(`/sozluk/${slug}`);
 		await expect(page.getByText(aBody)).toBeVisible({timeout: 15_000});
 
-		// User B should NOT see edit / delete affordances on A's definition.
 		await expect(page.locator('[data-testid^="definition-edit-"]')).toHaveCount(0);
 		await expect(page.locator('[data-testid^="definition-delete-"]')).toHaveCount(0);
 
-		// Sanity: B can still see the vote button (read affordance for non-author).
+		// The vote button stays: a non-author keeps the read affordances.
 		await expect(page.locator('[data-testid^="definition-vote-"]').first()).toBeVisible();
 	});
 });

--- a/apps/web/tests/e2e/14-pano-submit-post.spec.ts
+++ b/apps/web/tests/e2e/14-pano-submit-post.spec.ts
@@ -2,16 +2,6 @@ import {expect, test} from "@playwright/test";
 import {signUp} from "./_helpers/auth";
 import {randomSuffix} from "./_helpers/rand";
 
-/**
- * Pano submitPost end-to-end.
- *
- * Sign up a fresh user, complete the username bootstrap, navigate to the
- * `/pano/yeni` page, fill title + url + body + select a tag, submit. The
- * mutation responds with the new post id; the dialog navigates to
- * `/pano/<id>` and the post detail page renders.
- *
- * Mirrors the helper pattern from tests/e2e/12-sozluk-vote.spec.ts.
- */
 test.describe("Pano submitPost", () => {
 	test("submits a link post and lands on /pano/<id>", async ({page}) => {
 		const localPart = `pp${Date.now().toString(36)}${randomSuffix(4)}`;
@@ -37,13 +27,8 @@ test.describe("Pano submitPost", () => {
 
 		await page.locator('[data-testid="pano-submit-submit"]').click();
 
-		// On success the page navigates to /pano/<new-post-id>; assert by URL
-		// pattern + the rendered title on the detail page.
 		await page.waitForURL(/\/pano\/post_[A-Za-z0-9]+$/, {timeout: 15_000});
 
-		// PanoPostDetail renders the new post via the `post(idOrSlug)` query
-		// resolver, which reads the row the `post.submit` mutation persisted to
-		// D1 (`post_record`) — pano has no per-post DO.
 		await expect(page.getByRole("heading", {level: 1})).toContainText(title, {timeout: 10_000});
 	});
 
@@ -63,7 +48,6 @@ test.describe("Pano submitPost", () => {
 		const submit = page.locator('[data-testid="pano-submit-submit"]');
 		await expect(submit).toBeDisabled();
 
-		// Filling out everything except the title still leaves the button disabled.
 		await page.locator('[data-testid="pano-submit-url"]').fill("https://example.com/x");
 		await page.locator('[data-testid="pano-submit-title"]').fill("kısa");
 		await page.locator('[data-testid="pano-submit-tag-discuss"]').click();

--- a/apps/web/tests/e2e/15-pano-vote-post.spec.ts
+++ b/apps/web/tests/e2e/15-pano-vote-post.spec.ts
@@ -4,21 +4,11 @@ import {randomSuffix} from "./_helpers/rand";
 import {expectScoreConsistent} from "./_helpers/wait-for-consistency";
 
 /**
- * Pano voteOnPost end-to-end.
+ * Pano voteOnPost end-to-end. Mirrors `12-sozluk-vote.spec.ts`.
  *
- * Sign up a fresh user, complete the username bootstrap, submit a brand new
- * post, navigate to its detail page, then exercise the optimistic vote flip:
- *   1. Vote → score becomes 1, button reflects pressed state.
- *   2. Click again → retract vote → score back to 0.
- *   3. Vote again → score 1.
- *
- * The PostVoteWidget's `optimisticResponse` flips `myVote` + `score`
- * synchronously; on success the projection lands in <1s and the page reads
- * the new state on subsequent renders.
- *
- * Mirrors `12-sozluk-vote.spec.ts`. After the relay-idiom refactor
- * the page tree no longer unmounts on submitPost / vote mutations,
- * so the historical `page.reload()` Suspense workaround is gone.
+ * After the relay-idiom refactor the page tree no longer unmounts on
+ * submitPost / vote mutations, so the historical `page.reload()` Suspense
+ * workaround is gone.
  */
 test.describe("Pano voteOnPost", () => {
 	// QUARANTINED — un-quarantine blocked on #1838 (e2e can't establish yazar tier); see #1903.
@@ -30,7 +20,6 @@ test.describe("Pano voteOnPost", () => {
 	// re-vote round-trip. No vote-GATE (#1828) coverage lives here.
 	// Re-enable = revert to plain test(...).
 	test.fixme("vote → unvote → vote round-trip on a fresh post", async ({page}) => {
-		// Fresh sign-up + bootstrap so the user is fully authenticated.
 		const localPart = `vp${Date.now().toString(36)}${randomSuffix(4)}`;
 		await signUp(page, {email: `${localPart}@kamp.us`});
 		const handle = `u-${Date.now().toString(36)}${randomSuffix(4)}`;
@@ -40,7 +29,6 @@ test.describe("Pano voteOnPost", () => {
 			timeout: 10_000,
 		});
 
-		// Submit a brand-new post and let the page navigate to /pano/<id>.
 		await page.goto("/pano/yeni");
 		await expect(page.locator('[data-testid="pano-submit-title"]')).toBeVisible({
 			timeout: 10_000,
@@ -70,17 +58,14 @@ test.describe("Pano voteOnPost", () => {
 		await expect(score).toHaveText("0");
 		await expect(voteBtn).toHaveAttribute("aria-pressed", "false");
 
-		// Cast vote — optimistic flip lands first.
 		await voteBtn.click();
 		await expectScoreConsistent(page, score, "1");
 		await expect(voteBtn).toHaveAttribute("aria-pressed", "true", {timeout: 5_000});
 
-		// Retract vote.
 		await voteBtn.click();
 		await expectScoreConsistent(page, score, "0");
 		await expect(voteBtn).toHaveAttribute("aria-pressed", "false");
 
-		// Re-vote.
 		await voteBtn.click();
 		await expectScoreConsistent(page, score, "1");
 		await expect(voteBtn).toHaveAttribute("aria-pressed", "true");

--- a/apps/web/tests/e2e/16-pano-edit-delete-post.spec.ts
+++ b/apps/web/tests/e2e/16-pano-edit-delete-post.spec.ts
@@ -4,19 +4,8 @@ import {promoteToYazar} from "./_helpers/promote";
 import {randomSuffix} from "./_helpers/rand";
 
 /**
- * Pano editPost / deletePost end-to-end.
- *
- * Two flows:
- *   1. Author flow: sign up user A → submit a post → land on /pano/<id> →
- *      edit it (title/body change) → delete it (navigates back to /pano,
- *      post no longer in feed).
- *   2. Cross-user flow: sign up user A → submit a post → sign out → sign up
- *      user B → user B doesn't see edit/delete affordances on user A's post.
- *
- * After the relay-idiom refactor the post detail no longer
- * refetches the page query on a mutation — `editPost` returns the updated
- * scalar fields and Relay's automatic store update handles the rerender, so
- * the historical `page.reload()` Suspense workaround is gone.
+ * The post detail does not refetch on a mutation — `editPost` returns the updated
+ * scalar fields and Relay's store update rerenders, so no `page.reload()` is needed.
  */
 test.describe("Pano editPost / deletePost", () => {
 	test("author can edit and delete their own post", async ({page}) => {
@@ -28,7 +17,6 @@ test.describe("Pano editPost / deletePost", () => {
 			timeout: 10_000,
 		});
 
-		// Submit a post.
 		await page.goto("/pano/yeni");
 		await expect(page.locator('[data-testid="pano-submit-title"]')).toBeVisible({timeout: 5_000});
 
@@ -40,19 +28,16 @@ test.describe("Pano editPost / deletePost", () => {
 		await page.locator('[data-testid="pano-submit-tag-discuss"]').click();
 		await page.locator('[data-testid="pano-submit-submit"]').click();
 
-		// Lands on /pano/<id> with the post title rendered.
 		await page.waitForURL(/\/pano\/post_[A-Za-z0-9]+$/, {timeout: 15_000});
 		await expect(page.getByRole("heading", {level: 1})).toContainText(originalTitle, {
 			timeout: 10_000,
 		});
 
-		// Edit affordance visible to the author.
 		const editBtn = page.locator('[data-testid="post-edit"]');
 		const deleteBtn = page.locator('[data-testid="post-delete"]');
 		await expect(editBtn).toBeVisible();
 		await expect(deleteBtn).toBeVisible();
 
-		// Click edit → title/body inputs appear prefilled.
 		await editBtn.click();
 		const editTitle = page.locator('[data-testid="post-edit-title"]');
 		const editBody = page.locator('[data-testid="post-edit-body"]');
@@ -60,36 +45,29 @@ test.describe("Pano editPost / deletePost", () => {
 		await expect(editTitle).toHaveValue(originalTitle);
 		await expect(editBody).toHaveValue(originalBody);
 
-		// Replace the title/body and save.
 		const editedTitle = `e2e edited ${suffix}`;
 		const editedBody = `edited body ${suffix}`;
 		await editTitle.fill(editedTitle);
 		await editBody.fill(editedBody);
 		await page.locator('[data-testid="post-edit-save"]').click();
 
-		// Edit returns the updated title/body; Relay merges into the store
-		// keyed by id and the page rerenders without a refetch. No reload needed.
 		await expect(page.getByRole("heading", {level: 1})).toContainText(editedTitle, {
 			timeout: 10_000,
 		});
 		await expect(page.getByText(editedBody)).toBeVisible({timeout: 10_000});
 		await expect(page.getByText(originalBody, {exact: true})).toHaveCount(0);
 
-		// Delete → confirm dialog → confirm → navigate back to /pano.
 		await page.locator('[data-testid="post-delete"]').click();
 		const confirm = page.locator('[data-testid="post-delete-confirm"]');
 		await expect(confirm).toBeVisible({timeout: 5_000});
 		await confirm.click();
 
-		// Land back on /pano after the delete.
 		await page.waitForURL(/\/pano(?:\/?$|\?)/, {timeout: 15_000});
 
-		// The edited title is no longer in the feed.
 		await expect(page.getByText(editedTitle, {exact: true})).toHaveCount(0, {timeout: 15_000});
 	});
 
 	test("non-author does not see edit/delete buttons on someone else's post", async ({page}) => {
-		// User A signs up, bootstraps, submits a post.
 		const aSuffix = `${Date.now().toString(36)}${randomSuffix(4)}`;
 		const emailA = `aa${aSuffix}@kamp.us`;
 		await signUp(page, {email: emailA});
@@ -110,14 +88,10 @@ test.describe("Pano editPost / deletePost", () => {
 		await page.locator('[data-testid="pano-submit-title"]').fill(title);
 		await page.locator('[data-testid="pano-submit-tag-discuss"]').click();
 		await page.locator('[data-testid="pano-submit-submit"]').click();
-		// Wait for navigation to the new post id (not /pano/yeni). Post ids
-		// start with `post_` (forge prefix).
 		await page.waitForURL(/\/pano\/post_[A-Za-z0-9]+$/, {timeout: 15_000});
 		const postUrl = page.url();
-		// Confirm A actually sees their post title before signing out.
 		await expect(page.getByRole("heading", {level: 1})).toContainText(title, {timeout: 10_000});
 
-		// Sign A out, sign B up.
 		await signOut(page);
 		const bSuffix = `${Date.now().toString(36)}${randomSuffix(4)}`;
 		await signUp(page, {email: `bb${bSuffix}@kamp.us`});
@@ -127,18 +101,15 @@ test.describe("Pano editPost / deletePost", () => {
 			timeout: 10_000,
 		});
 
-		// Navigate B to A's post page. Go to /pano first so the Layout settles
-		// (signUp lands somewhere generic that may auto-redirect), then visit
-		// the direct post URL.
+		// Go to /pano first so the Layout settles — signUp lands somewhere generic that
+		// may auto-redirect — then visit the direct post URL.
 		await page.goto("/pano");
 		await page.goto(postUrl);
 		await expect(page.getByRole("heading", {level: 1})).toContainText(title, {timeout: 15_000});
 
-		// User B should NOT see edit/delete affordances on A's post.
 		await expect(page.locator('[data-testid="post-edit"]')).toHaveCount(0);
 		await expect(page.locator('[data-testid="post-delete"]')).toHaveCount(0);
 
-		// Sanity: B can still see the vote button (read affordance for non-author).
 		await expect(page.locator(`[data-testid^="post-vote-"]`).first()).toBeVisible();
 	});
 });

--- a/apps/web/tests/e2e/17-pano-add-comment.spec.ts
+++ b/apps/web/tests/e2e/17-pano-add-comment.spec.ts
@@ -2,19 +2,6 @@ import {expect, test} from "@playwright/test";
 import {signUp} from "./_helpers/auth";
 import {randomSuffix} from "./_helpers/rand";
 
-/**
- * Pano addComment end-to-end.
- *
- * Single author flow:
- *   1. sign up → bootstrap username
- *   2. submit a post → land on /pano/<id>
- *   3. add a top-level comment via the composer → it appears in the tree
- *   4. click "yanıtla" under that comment → inline reply composer appears
- *   5. submit the reply → it appears nested under the parent comment
- *
- * Page reload after submitPost dodges the Suspense double-mount race that
- * surfaced earlier in development.
- */
 test.describe("Pano addComment", () => {
 	test("submits a top-level comment, then a nested reply", async ({page}) => {
 		const suffix = `${Date.now().toString(36)}${randomSuffix(4)}`;
@@ -25,7 +12,6 @@ test.describe("Pano addComment", () => {
 			timeout: 10_000,
 		});
 
-		// Submit a post.
 		await page.goto("/pano/yeni");
 		await expect(page.locator('[data-testid="pano-submit-title"]')).toBeVisible({timeout: 5_000});
 
@@ -35,7 +21,6 @@ test.describe("Pano addComment", () => {
 		await page.locator('[data-testid="pano-submit-tag-discuss"]').click();
 		await page.locator('[data-testid="pano-submit-submit"]').click();
 
-		// Land on /pano/<id>.
 		await page.waitForURL(/\/pano\/post_[A-Za-z0-9]+$/, {timeout: 15_000});
 
 		// Post-detail no longer remounts on a mutation —
@@ -49,14 +34,11 @@ test.describe("Pano addComment", () => {
 		// fallback hides the new comment).
 		await expect(page.getByRole("heading", {name: /0 yorum/i})).toBeVisible({timeout: 10_000});
 
-		// Add a top-level comment.
 		const topLevelBody = `top-level comment ${suffix}`;
 		await page.locator('[data-testid="pano-comment-input"]').fill(topLevelBody);
 		await page.locator('[data-testid="pano-comment-submit"]').click();
 
-		// New comment appears in the tree. Wait on the comment count heading
-		// flipping to "1 yorum" — that's the authoritative signal the comments
-		// query refetch landed.
+		// The count heading flipping is the authoritative signal the comments refetch landed.
 		await expect(page.getByRole("heading", {name: /1 yorum/i})).toBeVisible({timeout: 15_000});
 		await expect(page.getByText(topLevelBody, {exact: false}).first()).toBeVisible({
 			timeout: 10_000,
@@ -73,8 +55,7 @@ test.describe("Pano addComment", () => {
 			.first();
 		await expect(ownComment.getByTestId("incelemede-badge")).toBeVisible({timeout: 10_000});
 
-		// Click "yanıtla" on the top-level comment. Pick the first reply trigger
-		// — there's only one comment so this is unambiguous.
+		// `.first()` is unambiguous here: there is exactly one comment at this point.
 		const replyTrigger = page.locator('[data-testid^="pano-comment-reply-trigger-"]').first();
 		await replyTrigger.click();
 
@@ -85,7 +66,6 @@ test.describe("Pano addComment", () => {
 		await replyInput.fill(replyBody);
 		await page.locator('[data-testid^="pano-comment-reply-submit-"]').first().click();
 
-		// Reply lands and appears in the tree as a second comment row.
 		await expect(page.getByText(replyBody, {exact: false})).toBeVisible({timeout: 10_000});
 		await expect(page.getByRole("heading", {name: /2 yorum/i})).toBeVisible({timeout: 10_000});
 	});

--- a/apps/web/tests/e2e/18-pano-vote-comment.spec.ts
+++ b/apps/web/tests/e2e/18-pano-vote-comment.spec.ts
@@ -3,27 +3,7 @@ import {signUp} from "./_helpers/auth";
 import {randomSuffix} from "./_helpers/rand";
 import {expectScoreConsistent} from "./_helpers/wait-for-consistency";
 
-/**
- * Pano voteOnComment end-to-end.
- *
- * Sign up a fresh user, complete the username bootstrap, submit a brand new
- * post, add a comment, then exercise the optimistic comment-vote flip:
- *   1. Vote → score becomes 1, button reflects pressed state.
- *   2. Click again → retract → score back to 0.
- *   3. Vote again → score 1.
- *
- * The PanoComment vote button uses Relay `optimisticResponse` to flip
- * `myVote` + `score` synchronously; on success the projection lands in <1s
- * and the page reads the new state on subsequent renders.
- *
- * Mirrors `15-pano-vote-post.spec.ts` (post-vote round-trip).
- *
- * The historical `page.reload()` workarounds before vote interactions are
- * gone — `usePaginationFragment` +
- * `commitLocalUpdate` keep the post-detail tree mounted on every mutation
- * and live event, so the Suspense double-mount race they were dodging no
- * longer fires.
- */
+/** The comment-vote twin of `15-pano-vote-post.spec.ts`. */
 test.describe("Pano voteOnComment", () => {
 	// QUARANTINED — un-quarantine blocked on #1838 (e2e can't establish yazar tier); see #1903.
 	// Vote score-propagation flake tracked at #1903. Tracking: #1885/#1903.
@@ -34,7 +14,6 @@ test.describe("Pano voteOnComment", () => {
 	// re-vote round-trip. No vote-GATE (#1828) coverage lives here.
 	// Re-enable = revert to plain test(...).
 	test.fixme("vote → unvote → vote round-trip on a fresh comment", async ({page}) => {
-		// Fresh sign-up + bootstrap.
 		const localPart = `vc${Date.now().toString(36)}${randomSuffix(4)}`;
 		await signUp(page, {email: `${localPart}@kamp.us`});
 		const handle = `u-${Date.now().toString(36)}${randomSuffix(4)}`;
@@ -44,7 +23,6 @@ test.describe("Pano voteOnComment", () => {
 			timeout: 10_000,
 		});
 
-		// Submit a brand-new post and let the page navigate to /pano/<id>.
 		await page.goto("/pano/yeni");
 		await expect(page.locator('[data-testid="pano-submit-title"]')).toBeVisible({
 			timeout: 10_000,
@@ -70,7 +48,6 @@ test.describe("Pano voteOnComment", () => {
 			timeout: 10_000,
 		});
 
-		// Add a top-level comment.
 		const commentBody = `vote target yorum ${Date.now().toString(36)}`;
 		await page.locator('[data-testid="pano-comment-input"]').fill(commentBody);
 		await page.locator('[data-testid="pano-comment-submit"]').click();
@@ -92,19 +69,16 @@ test.describe("Pano voteOnComment", () => {
 		// a11y: the accessible name toggles with vote state (#2215).
 		await expect(voteBtn).toHaveAttribute("aria-label", "Yukarı oy");
 
-		// Cast vote — optimistic flip lands first.
 		await voteBtn.click();
 		await expectScoreConsistent(page, score, "1");
 		await expect(voteBtn).toHaveAttribute("aria-pressed", "true", {timeout: 5_000});
 		await expect(voteBtn).toHaveAttribute("aria-label", "Oyunu geri al");
 
-		// Retract.
 		await voteBtn.click();
 		await expectScoreConsistent(page, score, "0");
 		await expect(voteBtn).toHaveAttribute("aria-pressed", "false");
 		await expect(voteBtn).toHaveAttribute("aria-label", "Yukarı oy");
 
-		// Re-vote.
 		await voteBtn.click();
 		await expectScoreConsistent(page, score, "1");
 		await expect(voteBtn).toHaveAttribute("aria-pressed", "true");

--- a/apps/web/tests/e2e/19-pano-edit-delete-comment.spec.ts
+++ b/apps/web/tests/e2e/19-pano-edit-delete-comment.spec.ts
@@ -4,21 +4,8 @@ import {promoteToYazar} from "./_helpers/promote";
 import {randomSuffix} from "./_helpers/rand";
 
 /**
- * Pano editComment / deleteComment end-to-end.
- *
- * Three flows:
- *   1. Author flow: sign up A → submit a post → add a comment → edit it → body
- *      changes; add a reply to that comment → delete the parent → parent shows
- *      `[silindi]`, reply still visible; delete the leaf reply → reply
- *      disappears from the tree.
- *   2. Cross-user flow: sign up B → user B does NOT see the düzenle/sil
- *      affordances on user A's comments.
- *
- * Every historical `page.reload()` workaround after a mutation has been
- * removed. The post-detail page no longer
- * unmounts on `addComment` / `editComment` / `deleteComment` — manual
- * `updater` + `@deleteRecord` keep the tree mounted, so the Suspense
- * double-mount race the reloads were dodging no longer fires.
+ * No `page.reload()` after a mutation: manual `updater` + `@deleteRecord` keep the
+ * comment tree mounted, so the Suspense double-mount race the reloads dodged is gone.
  */
 test.describe("Pano editComment / deleteComment", () => {
 	test("author can edit a comment, delete a parent → [silindi], delete a leaf → removed", async ({
@@ -32,7 +19,6 @@ test.describe("Pano editComment / deleteComment", () => {
 			timeout: 10_000,
 		});
 
-		// Submit a post.
 		await page.goto("/pano/yeni");
 		await expect(page.locator('[data-testid="pano-submit-title"]')).toBeVisible({timeout: 5_000});
 
@@ -48,7 +34,6 @@ test.describe("Pano editComment / deleteComment", () => {
 		await expect(page.getByRole("heading", {level: 1})).toContainText(title, {timeout: 10_000});
 		await expect(page.getByRole("heading", {name: /0 yorum/i})).toBeVisible({timeout: 10_000});
 
-		// Add a top-level comment.
 		const originalBody = `original comment body ${suffix}`;
 		await page.locator('[data-testid="pano-comment-input"]').fill(originalBody);
 		await page.locator('[data-testid="pano-comment-submit"]').click();
@@ -80,7 +65,6 @@ test.describe("Pano editComment / deleteComment", () => {
 		});
 		await expect(page.getByText(originalBody, {exact: true})).toHaveCount(0, {timeout: 10_000});
 
-		// Reply to the (now edited) parent comment.
 		await page.locator(`[data-testid="pano-comment-reply-trigger-${parentCommentId}"]`).click();
 		const replyInput = page.locator(`[data-testid="pano-comment-reply-input-${parentCommentId}"]`);
 		await expect(replyInput).toBeVisible({timeout: 5_000});
@@ -90,8 +74,6 @@ test.describe("Pano editComment / deleteComment", () => {
 		await expect(page.getByRole("heading", {name: /2 yorum/i})).toBeVisible({timeout: 15_000});
 		await expect(page.getByText(replyBody, {exact: false})).toBeVisible({timeout: 10_000});
 
-		// Resolve the reply id. There are now two vote buttons; the second one
-		// is the reply (top-level rendered first by the page's tree builder).
 		await expect(page.getByRole("heading", {name: /2 yorum/i})).toBeVisible({timeout: 10_000});
 		const allVoteBtns = page.locator('[data-testid^="comment-vote-comm_"]');
 		await expect(allVoteBtns).toHaveCount(2, {timeout: 10_000});
@@ -103,17 +85,14 @@ test.describe("Pano editComment / deleteComment", () => {
 			.find((id) => id !== parentCommentId)!;
 		expect(replyCommentId).toBeTruthy();
 
-		// Delete the parent → soft-delete-with-replies → [silindi] placeholder.
 		await page.locator(`[data-testid="pano-comment-menu-${parentCommentId}"]`).click();
 		await page.locator(`[data-testid="pano-comment-delete-trigger-${parentCommentId}"]`).click();
 		const confirm = page.locator('[data-testid="pano-comment-delete-confirm"]');
 		await expect(confirm).toBeVisible({timeout: 5_000});
 		await confirm.click();
 
-		// Parent comment now shows [silindi]; reply still visible.
 		await expect(page.getByText("[silindi]").first()).toBeVisible({timeout: 10_000});
 		await expect(page.getByText(replyBody, {exact: false})).toBeVisible({timeout: 10_000});
-		// The original (edited) body is gone.
 		await expect(page.getByText(editedBody, {exact: false})).toHaveCount(0, {timeout: 10_000});
 
 		// Delete the leaf reply → fully removed (and the [silindi] parent
@@ -125,15 +104,12 @@ test.describe("Pano editComment / deleteComment", () => {
 		await confirm2.click();
 
 		await expect(page.getByText(replyBody, {exact: false})).toHaveCount(0, {timeout: 10_000});
-		// `[silindi]` is gone too — parent had no live children left.
 		await expect(page.getByText("[silindi]")).toHaveCount(0);
 
-		// Sanity: post URL still loads.
 		expect(page.url()).toBe(postUrl);
 	});
 
 	test("non-author does not see edit/delete buttons on someone else's comment", async ({page}) => {
-		// User A signs up, posts, adds a comment.
 		const aSuffix = `${Date.now().toString(36)}${randomSuffix(4)}`;
 		const emailA = `aa${aSuffix}@kamp.us`;
 		await signUp(page, {email: emailA});
@@ -164,7 +140,6 @@ test.describe("Pano editComment / deleteComment", () => {
 		await page.locator('[data-testid="pano-comment-submit"]').click();
 		await expect(page.getByRole("heading", {name: /1 yorum/i})).toBeVisible({timeout: 15_000});
 
-		// Sanity: A sees their own edit/delete trigger.
 		const voteBtn = page.locator('[data-testid^="comment-vote-comm_"]').first();
 		await expect(voteBtn).toBeVisible({timeout: 10_000});
 		const aCommentId = (await voteBtn.getAttribute("data-testid"))!.replace("comment-vote-", "");
@@ -172,7 +147,6 @@ test.describe("Pano editComment / deleteComment", () => {
 			timeout: 10_000,
 		});
 
-		// Sign A out, sign B up.
 		await signOut(page);
 		const bSuffix = `${Date.now().toString(36)}${randomSuffix(4)}`;
 		await signUp(page, {email: `bb${bSuffix}@kamp.us`});
@@ -182,18 +156,15 @@ test.describe("Pano editComment / deleteComment", () => {
 			timeout: 10_000,
 		});
 
-		// B navigates to A's post.
 		await page.goto("/pano");
 		await page.goto(postUrl);
 		await expect(page.getByRole("heading", {level: 1})).toContainText(title, {timeout: 15_000});
 		await expect(page.getByText(aBody, {exact: false})).toBeVisible({timeout: 15_000});
 
-		// B should NOT see the edit/delete menu on A's comment. The Menu.Root
-		// wrapper itself is gated by `comment.isOwner` so the trigger button
-		// is absent from the DOM entirely (not just the popup items).
+		// The Menu.Root wrapper is gated by `comment.isOwner`, so for a non-owner the
+		// trigger button is absent from the DOM entirely — not just the popup items.
 		await expect(page.locator(`[data-testid="pano-comment-menu-${aCommentId}"]`)).toHaveCount(0);
 
-		// Sanity: B can still see the vote button (read affordance).
 		await expect(page.locator(`[data-testid="comment-vote-${aCommentId}"]`)).toBeVisible();
 	});
 });

--- a/apps/web/tests/e2e/20-profile-page.spec.ts
+++ b/apps/web/tests/e2e/20-profile-page.spec.ts
@@ -3,17 +3,8 @@ import {signUp} from "./_helpers/auth";
 import {randomSuffix} from "./_helpers/rand";
 
 /**
- * Profile page (T14) — `/u/<username>` route + GraphQL `profile(username)`
- * query + interleaved contributions feed.
- *
- * Single author flow:
- *   1. sign up + bootstrap username
- *   2. submit a post → land on /pano/<id>
- *   3. add a comment on the post
- *   4. add a definition on a fresh sozluk slug
- *   5. visit /u/<username> → header counters reflect 1/1/1, three
- *      contribution rows in the feed
- *   6. visit /u/<bogus-username> → 404 page renders
+ * Profile page (T14) — `/u/<username>` route + `profile(username)` query + the interleaved
+ * contributions feed, driven by one author contributing one of each kind.
  */
 test.describe("Profile page", () => {
 	test("aggregates 1 definition + 1 post + 1 comment on /u/<username>", async ({page}) => {
@@ -26,7 +17,6 @@ test.describe("Profile page", () => {
 			timeout: 10_000,
 		});
 
-		// 1) Submit a post.
 		await page.goto("/pano/yeni");
 		await expect(page.locator('[data-testid="pano-submit-title"]')).toBeVisible({timeout: 5_000});
 
@@ -45,13 +35,11 @@ test.describe("Profile page", () => {
 		});
 		await expect(page.getByRole("heading", {name: /0 yorum/i})).toBeVisible({timeout: 10_000});
 
-		// 2) Add a comment.
 		const commentBody = `profile test yorum ${suffix}`;
 		await page.locator('[data-testid="pano-comment-input"]').fill(commentBody);
 		await page.locator('[data-testid="pano-comment-submit"]').click();
 		await expect(page.getByRole("heading", {name: /1 yorum/i})).toBeVisible({timeout: 15_000});
 
-		// 3) Add a definition on a fresh slug.
 		const slug = `profile-${suffix}`;
 		await page.goto(`/sozluk/${slug}`);
 		const composerBody = page.locator('[data-testid="sozluk-composer-body"]');
@@ -73,25 +61,21 @@ test.describe("Profile page", () => {
 			timeout: 10_000,
 		});
 
-		// 4) Visit the public profile page.
 		await page.goto(`/u/${handle}`);
 		await expect(page.getByTestId("user-profile-page")).toBeVisible({timeout: 15_000});
 		await expect(page.getByTestId("user-profile-handle")).toContainText(`@${handle}`);
 
-		// Header counters: 1 definition, 1 post, 1 comment. The `profile(username)`
-		// aggregation joins across the pano + sozluk projections, which can lag the
-		// just-completed mutations, so poll each counter rather than reading it
-		// point-in-time.
+		// The `profile(username)` aggregation joins across the pano + sozluk projections, which
+		// can lag the just-completed mutations, so poll rather than read point-in-time.
 		await expect(page.getByTestId("stat-definitions")).toContainText("1", {timeout: 10_000});
 		await expect(page.getByTestId("stat-posts")).toContainText("1", {timeout: 10_000});
 		await expect(page.getByTestId("stat-comments")).toContainText("1", {timeout: 10_000});
 
-		// Feed: three rows, one of each kind. Same aggregation lag — poll each row.
+		// Same aggregation lag — poll each row.
 		await expect(page.getByTestId("contribution-definition")).toHaveCount(1, {timeout: 10_000});
 		await expect(page.getByTestId("contribution-post")).toHaveCount(1, {timeout: 10_000});
 		await expect(page.getByTestId("contribution-comment")).toHaveCount(1, {timeout: 10_000});
 
-		// Each row links to its source.
 		await expect(
 			page.getByTestId("contribution-definition").locator(`a[href="/sozluk/${slug}"]`),
 		).toBeVisible();

--- a/apps/web/tests/e2e/21-landing-stats.spec.ts
+++ b/apps/web/tests/e2e/21-landing-stats.spec.ts
@@ -4,23 +4,18 @@ import {promoteToYazar} from "./_helpers/promote";
 import {randomSuffix} from "./_helpers/rand";
 
 /**
- * Landing stats — `landingStats` GraphQL query feeding the landing-page
- * stats card. Counters maintained inline by the sozluk/pano writer modules
- * (ADR 0009) on every Definition / Post / Comment write. The page also
- * serves as a deep-link smoke check: directly visiting the canonical product
- * URLs should each render without errors.
+ * The landing stats card, whose counters the sozluk/pano writer modules maintain
+ * inline on every write (ADR 0009), plus a deep-link smoke check of the canonical
+ * product URLs.
  */
 test.describe("Landing stats", () => {
 	test("/ renders the live stats card with five values", async ({page}) => {
 		await page.goto("/");
 
-		// QueryBoundary suspense fallback first; the live stats land within a
-		// few hundred ms once the worker responds.
 		await expect(page.getByTestId("kp-landing-stats")).toBeVisible({timeout: 10_000});
 		const stats = page.locator(".kp-landing__stats .kp-landing__stat");
 		await expect(stats).toHaveCount(5);
 
-		// Last cell is the build version label "phoenix" with a non-empty value.
 		const versionLabel = page.locator(".kp-landing__stats .kp-landing__stat .l", {
 			hasText: /^phoenix$/,
 		});
@@ -44,13 +39,11 @@ test.describe("Landing stats", () => {
 		// (ADR 0137). Sandbox coverage lives in the kunye/sandbox suites, untouched.
 		await promoteToYazar(email);
 
-		// Capture totalPosts BEFORE we submit.
 		await page.goto("/");
 		await expect(page.getByTestId("kp-landing-stats")).toBeVisible({timeout: 10_000});
 		const before = await page.getByTestId("stat-başlık").locator(".n").innerText();
 		const beforeCount = parseTrNumber(before);
 
-		// Submit a post.
 		await page.goto("/pano/yeni");
 		await expect(page.locator('[data-testid="pano-submit-title"]')).toBeVisible({timeout: 5_000});
 		await page
@@ -61,10 +54,8 @@ test.describe("Landing stats", () => {
 		await page.locator('[data-testid="pano-submit-submit"]').click();
 		await page.waitForURL(/\/pano\/post_[A-Za-z0-9]+$/, {timeout: 15_000});
 
-		// Reload landing — the stats card should now reflect the new post.
 		// The reload is intentional: a bare `goto("/")` may serve a cached
-		// landingStats query result; reloading forces a fresh fetch. The
-		// `toPass` retry loop below absorbs any remaining lag.
+		// landingStats result; reloading forces a fresh fetch.
 		await page.goto("/");
 		await page.reload();
 		await expect(page.getByTestId("kp-landing-stats")).toBeVisible({timeout: 10_000});
@@ -75,21 +66,16 @@ test.describe("Landing stats", () => {
 	});
 
 	test("canonical routes are deep-linkable", async ({page}) => {
-		// `/sozluk`
 		await page.goto("/sozluk");
 		await expect(page.locator(".kp-page")).toBeVisible({timeout: 10_000});
 
-		// `/pano`
 		await page.goto("/pano");
-		// PanoFeed renders inside the same shell. Just ensure the topbar is
-		// up; the feed itself may be empty on a cold DB.
+		// Assert the topbar, not the feed — the feed may be empty on a cold DB.
 		await expect(page.locator(".kp-topbar")).toBeVisible({timeout: 10_000});
 
-		// `/auth`
 		await page.goto("/auth");
 		await expect(page.getByRole("heading", {name: /giriş yap/i})).toBeVisible({timeout: 10_000});
 
-		// `/u/<unknown>` falls through to the 404 page.
 		await page.goto(`/u/nobody-${Date.now().toString(36)}`);
 		await expect(page.getByTestId("not-found-page")).toBeVisible({timeout: 10_000});
 	});

--- a/apps/web/tests/e2e/22-pano-live.spec.ts
+++ b/apps/web/tests/e2e/22-pano-live.spec.ts
@@ -11,23 +11,11 @@ declare global {
 }
 
 /**
- * Two-client live propagation over SSE.
+ * Two-client live propagation over SSE (see ADR 0023, ADR 0037).
  *
- * fate's live views (`useLiveView`/`useLiveListView`) subscribe a ref to
- * server-pushed `live.*` events. Each phoenix mutation publishes the
- * inline-resolved entity/connection event (`live.update` /
- * `connection().prependNode|appendNode`), which the `LiveDO` fans out over one
- * SSE connection per client. This drives the swapped views without a refetch:
- *
- *   - Client B viewing a post sees a comment Client A adds (`Post.comments`
- *     `appendNode`) and the post's vote count change (`Post` `live.update`).
- *   - Client B with the feed open sees a post Client A submits (`posts`
- *     `prependNode`).
- *
- * Two real browser contexts = two independent logged-in sessions sharing one
- * dev worker, so the events genuinely cross the isolate boundary through the DO
- * (an in-memory bus could not). No `page.reload()` on the observer — if the row
- * appears, it arrived live.
+ * Two real browser contexts, so the events genuinely cross the isolate
+ * boundary through the DO — an in-memory bus could not. No `page.reload()` on
+ * the observer: if the row appears, it arrived live.
  */
 
 /**
@@ -48,7 +36,6 @@ async function signUpAndBootstrap(page: Page): Promise<{email: string}> {
 	return {email};
 }
 
-/** Submit a fresh post as the signed-in user; returns its `/pano/<id>` path. */
 async function submitPost(page: Page, title: string): Promise<string> {
 	await page.goto("/pano/yeni");
 	await expect(page.locator('[data-testid="pano-submit-title"]')).toBeVisible({timeout: 10_000});
@@ -84,8 +71,6 @@ test.describe("Pano live (two clients)", () => {
 			await promoteToYazar(emailA);
 			await promoteToYazar(emailB);
 
-			// Client B creates the post all live action targets and stays on its detail view —
-			// its live SSE connection + comments/header subscriptions are the observer.
 			const stamp = `${Date.now().toString(36)}${randomSuffix(3)}`;
 			const title = `live target ${stamp}`;
 			const postPath = await submitPost(pageB, title);
@@ -93,7 +78,6 @@ test.describe("Pano live (two clients)", () => {
 				timeout: 10_000,
 			});
 
-			// Client A opens the same post to act on it (comment + vote).
 			await pageA.goto(postPath);
 			await expect(pageA.getByRole("heading", {level: 1})).toContainText(title, {
 				timeout: 10_000,
@@ -102,13 +86,10 @@ test.describe("Pano live (two clients)", () => {
 				timeout: 10_000,
 			});
 
-			// --- Comment propagation: A adds a comment, B sees it live. ---
 			const commentBody = `live yorum ${stamp}`;
 			await pageA.locator('[data-testid="pano-comment-input"]').fill(commentBody);
 			await pageA.locator('[data-testid="pano-comment-submit"]').click();
 
-			// B did NOT navigate or reload — the comment appears only via the
-			// server-pushed `appendNode` over SSE.
 			await expect(pageB.getByText(commentBody, {exact: false}).first()).toBeVisible({
 				timeout: 15_000,
 			});
@@ -116,14 +97,11 @@ test.describe("Pano live (two clients)", () => {
 				timeout: 15_000,
 			});
 
-			// --- Post-vote propagation: A votes, B sees the score change live. ---
 			const scoreB = pageB.locator('[data-testid^="post-score-"]').first();
-			// Capture B's current score, then have A vote on the same post.
 			const voteBtnA = pageA.locator('[data-testid^="post-vote-"]').first();
 			await expect(voteBtnA).toBeVisible({timeout: 5_000});
 			await voteBtnA.click();
 
-			// B's post score reflects A's vote without a refetch (`live.update`).
 			await expect(scoreB).toHaveText("1", {timeout: 15_000});
 		} finally {
 			await ctxA.close();
@@ -152,7 +130,6 @@ test.describe("Pano live (two clients)", () => {
 			const title = `reconnect target ${stamp}`;
 			const postPath = await submitPost(pageB, title);
 
-			// A opens B's post to cast the votes; B stays on its own detail view as the observer.
 			await pageA.goto(postPath);
 			await expect(pageA.getByRole("heading", {level: 1})).toContainText(title, {timeout: 10_000});
 
@@ -164,16 +141,11 @@ test.describe("Pano live (two clients)", () => {
 			await expect(voteBtnA).toBeVisible({timeout: 5_000});
 			await voteBtnA.click();
 
-			// Reconnect: a full reload drops B's old SSE connection and opens a fresh
-			// one, resubscribing the post view from scratch. The vote A cast lands via
-			// the reload's re-fetch (cache read), not a replayed live event.
 			await pageB.reload();
 			await expect(pageB.getByRole("heading", {level: 1})).toContainText(title, {timeout: 10_000});
 			const scoreB = pageB.locator('[data-testid^="post-score-"]').first();
 			await expect(scoreB).toHaveText("1", {timeout: 10_000});
 
-			// Now prove the freshly-reconnected stream is live again: a SECOND vote
-			// from A (retract → score 0) reaches B without any refetch.
 			let bFateRequests = 0;
 			pageB.on("request", (req) => {
 				if (req.method() === "POST" && new URL(req.url()).pathname === "/fate") {
@@ -181,7 +153,7 @@ test.describe("Pano live (two clients)", () => {
 				}
 			});
 			await pageB.waitForTimeout(1_000); // let the resubscribe settle
-			await voteBtnA.click(); // retract
+			await voteBtnA.click();
 			await expect(scoreB).toHaveText("0", {timeout: 15_000});
 			// The post-detail also subscribes its comment list + header on mount, so
 			// the only `/fate` request that could fire is a re-fetch — assert none did
@@ -194,17 +166,9 @@ test.describe("Pano live (two clients)", () => {
 	});
 
 	/**
-	 * Nested-connection mutations update the on-screen list LIVE — no full
-	 * reload. `definition.add`/`definition.delete`/`comment.delete` used to call
-	 * `window.location.reload()` because nested-connection membership can't be
-	 * reached by fate's declarative `insert`/`delete`. The resolvers now publish
-	 * `appendNode`/`deleteEdge`/`live.update`, which the page's
-	 * `useLiveListView`/`useLiveView` consume in place.
-	 *
-	 * Single-client (the author's own view is driven by the same server event a
-	 * second client gets), so it sidesteps the two-client SSE flakiness above. The
-	 * no-reload proof is a window sentinel: a `window.location.reload()` wipes the
-	 * page's JS context, so the sentinel set before the mutation would be gone.
+	 * Single-client on purpose: the author's own view is driven by the same
+	 * server event a second client gets, so this sidesteps the two-client SSE
+	 * flakiness above. The no-reload proof is the `__noReload` window sentinel.
 	 */
 	test("definition add/delete + comment delete update in place without a reload", async ({
 		page,
@@ -212,7 +176,6 @@ test.describe("Pano live (two clients)", () => {
 		const suffix = `${Date.now().toString(36)}${randomSuffix(4)}`;
 		await signUpAndBootstrap(page);
 
-		// --- definition.add: the new row appears live on the term page. ---
 		const slug = `live-def-${suffix}`;
 		await page.goto(`/sozluk/${slug}`);
 		await expect(page.locator('[data-testid="sozluk-composer-body"]')).toBeVisible({
@@ -232,8 +195,6 @@ test.describe("Pano live (two clients)", () => {
 			timeout: 10_000,
 		});
 
-		// Drop a sentinel; a full reload would clear it. The term now exists, so a
-		// SECOND add must arrive via the live `appendNode` (no reload).
 		await page.evaluate(() => {
 			window.__noReload = true;
 		});
@@ -241,12 +202,8 @@ test.describe("Pano live (two clients)", () => {
 		await page.locator('[data-testid="sozluk-composer-body"]').fill(secondDef);
 		await page.locator('[data-testid="sozluk-composer-submit"]').click();
 		await expect(page.getByText(secondDef, {exact: false})).toBeVisible({timeout: 15_000});
-		// The new row arrived live: the sentinel survived → no `window.location.reload()`.
 		expect(await page.evaluate(() => window.__noReload === true)).toBe(true);
 
-		// --- definition.delete: the row drops live via `deleteEdge`. ---
-		// Delete the second definition (the author owns both). Resolve its card by
-		// the visible body, open its delete affordance, confirm.
 		const secondCard = page
 			.locator('[data-testid^="definition-card-"]')
 			.filter({hasText: secondDef});
@@ -259,12 +216,9 @@ test.describe("Pano live (two clients)", () => {
 		await expect(defConfirm).toBeVisible({timeout: 5_000});
 		await defConfirm.click();
 		await expect(page.getByText(secondDef, {exact: false})).toHaveCount(0, {timeout: 15_000});
-		// Still no reload — the row dropped via the live edge removal.
 		expect(await page.evaluate(() => window.__noReload === true)).toBe(true);
-		// The other definition is untouched.
 		await expect(page.getByText(firstDef, {exact: false})).toBeVisible();
 
-		// --- comment.delete: a leaf comment drops live via `deleteEdge`. ---
 		const postPath = await submitPost(page, `live target ${suffix}`);
 		await expect(page.locator('[data-testid="pano-comment-input"]')).toBeVisible({
 			timeout: 10_000,
@@ -291,12 +245,9 @@ test.describe("Pano live (two clients)", () => {
 		});
 		await page.locator('[data-testid="pano-comment-delete-confirm"]').click();
 
-		// The leaf comment drops live (hard-delete → `deleteEdge`) and the count
-		// falls — no reload.
 		await expect(page.getByText(commentBody, {exact: false})).toHaveCount(0, {timeout: 15_000});
 		await expect(page.getByRole("heading", {name: /0 yorum/i})).toBeVisible({timeout: 15_000});
 		expect(await page.evaluate(() => window.__noReload === true)).toBe(true);
-		// The URL never changed (no navigation, no reload).
 		expect(new URL(page.url()).pathname).toBe(postPath);
 	});
 
@@ -328,9 +279,6 @@ test.describe("Pano live (two clients)", () => {
 			// can't `waitForLoadState("networkidle")` — the live SSE stream is a
 			// long-lived request, so the page is never network-idle.)
 			await pageB.waitForTimeout(1_500);
-			// Record B's data-request count so we can prove the post arrives WITHOUT a
-			// feed refetch on B (live-driven, not a re-query). The live control POST
-			// to `/fate/live` is excluded — only `/fate` data ops count.
 			let bFateRequests = 0;
 			pageB.on("request", (req) => {
 				if (req.method() === "POST" && new URL(req.url()).pathname === "/fate") {
@@ -338,13 +286,10 @@ test.describe("Pano live (two clients)", () => {
 				}
 			});
 
-			// Client A submits a brand-new post.
 			const stamp = `${Date.now().toString(36)}${randomSuffix(3)}`;
 			const title = `feed live ${stamp}`;
 			await submitPost(pageA, title);
 
-			// The post appears at the top of B's open feed via the server-emitted
-			// `posts` connection event — B never reloaded or re-queried the feed.
 			await expect(
 				pageB.locator(".kp-pano-list").getByText(title, {exact: false}).first(),
 			).toBeVisible({timeout: 15_000});

--- a/apps/web/tests/e2e/23-auth-redirect.spec.ts
+++ b/apps/web/tests/e2e/23-auth-redirect.spec.ts
@@ -4,19 +4,13 @@ import {promoteToYazar} from "./_helpers/promote";
 import {randomSuffix} from "./_helpers/rand";
 
 /**
- * T17 auth-redirect E2E: signed-out vote on a definition routes to
- * `/auth?returnTo=<term-url>`; after sign-up the user lands back on the
- * term page and the vote click now succeeds (score becomes 1).
- *
- * We seed the term by signing up a first user, adding a definition, then
- * signing them out — that leaves a real definition with a real id we can
- * vote on as the second (still-signed-out) user.
+ * T17 auth-redirect E2E. The term is seeded by a first user who adds a definition and then signs
+ * out, which leaves a real definition the second (still-signed-out) user can vote on.
  */
 test.describe("T17 auth-redirect with returnTo", () => {
 	test("signed-out vote → /auth?returnTo=... → sign-up → return → vote succeeds", async ({
 		page,
 	}) => {
-		// --- seed: sign up author A, drop a definition, sign out -------------
 		const slug = `t17-${Date.now().toString(36)}${randomSuffix(4)}`;
 		const emailA = `author-${slug}@kamp.us`;
 		await signUp(page, {email: emailA});
@@ -42,26 +36,23 @@ test.describe("T17 auth-redirect with returnTo", () => {
 		await page.locator('[data-testid="sozluk-composer-submit"]').click();
 		await expect(page.getByText(body)).toBeVisible({timeout: 10_000});
 
-		// Sign A out via the topbar user pill.
 		const pill = page.locator(".kp-topbar__user").first();
 		await pill.click();
 		await page.getByRole("button", {name: /çıkış/i}).click();
 		await expect(page.locator(".kp-topbar__user")).toHaveCount(0, {timeout: 5_000});
 
-		// --- act: signed-out user navigates to the term + clicks vote --------
 		await page.goto(`/sozluk/${slug}`);
 		const voteBtn = page.locator('[data-testid^="definition-vote-"]').first();
 		await expect(voteBtn).toBeVisible({timeout: 5_000});
 		await voteBtn.click();
 
-		// Lands on /auth with `returnTo` = the term URL.
 		await page.waitForURL(/\/auth\?returnTo=/, {timeout: 5_000});
 		const url = new URL(page.url());
 		const returnTo = url.searchParams.get("returnTo");
 		expect(returnTo).toBe(`/sozluk/${slug}`);
 
-		// --- sign up user B from the same /auth page (returnTo is preserved
-		//     through the form submission because the URL doesn't change). --
+		// User B signs up from the same /auth page: `returnTo` survives the submit because the URL
+		// never changes.
 		await page.getByRole("button", {name: /^kayıt ol$/i}).click();
 		const emailB = `voter-${slug}@kamp.us`;
 		await page.getByLabel("görünen ad").fill("voter b");
@@ -69,7 +60,6 @@ test.describe("T17 auth-redirect with returnTo", () => {
 		await page.getByLabel("parola", {exact: true}).fill("hunter222!");
 		await page.getByRole("button", {name: /hesap aç/i}).click();
 
-		// Layout's effect navigates off /auth honoring `returnTo` (T17).
 		await page.waitForURL(`**/sozluk/${slug}`, {timeout: 10_000});
 
 		// Bootstrap form WILL render — voter B has just signed up with no username.
@@ -82,9 +72,8 @@ test.describe("T17 auth-redirect with returnTo", () => {
 			timeout: 10_000,
 		});
 
-		// --- assert: vote click now lands the +1 ------------------------------
-		// Wait for the term heading first — the page may briefly render the
-		// Suspense fallback while the term query lands after the redirect.
+		// Wait for the term heading first — the page may briefly render the Suspense fallback while
+		// the term query lands after the redirect.
 		await expect(page.getByRole("heading", {level: 1})).toContainText(slug.replace(/-/g, " "), {
 			timeout: 10_000,
 		});
@@ -104,11 +93,9 @@ test.describe("T17 auth-redirect with returnTo", () => {
 	});
 
 	test("404 page renders for an unknown profile", async ({page}) => {
-		// Smoke check — the NotFoundPage stays wired through the auth-redirect flow.
 		await page.goto(`/u/nobody-${Date.now().toString(36)}`);
 		await expect(page.getByTestId("not-found-page")).toBeVisible({timeout: 5_000});
 		await expect(page.getByRole("heading", {name: /bulunamadı/i})).toBeVisible();
-		// Three nav links.
 		await expect(page.locator('.kp-not-found__links a[href="/"]')).toBeVisible();
 		await expect(page.locator('.kp-not-found__links a[href="/sozluk"]')).toBeVisible();
 		await expect(page.locator('.kp-not-found__links a[href="/pano"]')).toBeVisible();

--- a/apps/web/tests/e2e/24-search.spec.ts
+++ b/apps/web/tests/e2e/24-search.spec.ts
@@ -24,7 +24,6 @@ const SEED_TERM_TITLE = "merhaba dünya";
 const SEARCH_TERM_SLUG = "isik";
 const SEARCH_TERM_TITLE = "ışık";
 
-/** Submit a query through the topbar search form (the #123 wiring). */
 async function topbarSearch(page: import("@playwright/test").Page, query: string): Promise<void> {
 	const search = page.locator(".kp-topbar__search input[name='q']");
 	await search.fill(query);
@@ -52,7 +51,7 @@ test.describe("Search (/search)", () => {
 		// The seeded title "ışık" indexes (via normalizeSearchText) to "isik". The
 		// crux: an uppercase Turkish casing variant ("IŞIK", dotless-I → dotless-ı)
 		// must normalize to the same token the index holds.
-		const variant = SEARCH_TERM_TITLE.toLocaleUpperCase("tr"); // "ışık" → "IŞIK"
+		const variant = SEARCH_TERM_TITLE.toLocaleUpperCase("tr");
 		expect(variant).not.toBe(SEARCH_TERM_TITLE); // guard: the query genuinely differs
 
 		await page.goto("/");

--- a/apps/web/tests/e2e/26-pano-draft-save.spec.ts
+++ b/apps/web/tests/e2e/26-pano-draft-save.spec.ts
@@ -3,15 +3,10 @@ import {signUp} from "./_helpers/auth";
 import {randomSuffix} from "./_helpers/rand";
 
 /**
- * Pano taslak (draft-save) — the live path proven in-browser.
- *
  * The taslak button used to sit behind a `FlagGate` on the draft-save dark-ship
  * flag (#746); that flag graduated and was retired (ADR 0136), so the button now
  * renders unconditionally on the new-post page. This spec does NOT depend on
  * fate-live, so it is stable to run standalone.
- *
- * Mirrors the signUp + bootstrap + goto `/pano/yeni` pattern of
- * tests/e2e/14-pano-submit-post.spec.ts.
  */
 test.describe("Pano draft-save", () => {
 	test("the taslak draft button renders on the new-post form", async ({page}) => {

--- a/apps/web/tests/e2e/27-delete-account.spec.ts
+++ b/apps/web/tests/e2e/27-delete-account.spec.ts
@@ -26,26 +26,22 @@ test.describe("Delete account (/profile tehlikeli alan)", () => {
 		await bootstrapUsername(page);
 		await page.goto("/profile");
 
-		// 1) A single click only opens the dialog — no destructive call yet.
 		await page.getByTestId("delete-account-btn").click();
 		const confirmBtn = page.getByTestId("delete-account-confirm-btn");
 		await expect(confirmBtn).toBeVisible();
 		await expect(confirmBtn).toBeDisabled();
 
-		// 2) A wrong phrase keeps the confirm action unreachable.
 		const input = page.getByTestId("delete-account-confirm-input");
 		await input.fill("yanlış ifade");
 		await expect(confirmBtn).toBeDisabled();
 
-		// 3) The exact phrase unlocks it.
 		await input.fill(CONFIRMATION);
 		await expect(confirmBtn).toBeEnabled();
 
-		// 4) Confirm → account.delete → session torn down → redirect to /auth.
 		await confirmBtn.click();
 		await expect(page).toHaveURL(/\/auth$/, {timeout: 15_000});
 
-		// 5) The session is genuinely gone: /profile bounces back to /auth.
+		// The session is genuinely gone: /profile bounces back to /auth.
 		await page.goto("/profile");
 		await expect(page).toHaveURL(/\/auth$/, {timeout: 10_000});
 	});
@@ -59,7 +55,6 @@ test.describe("Delete account (/profile tehlikeli alan)", () => {
 		await expect(page.getByTestId("delete-account-confirm-btn")).toBeVisible();
 		await page.getByRole("button", {name: /^vazgeç$/i}).click();
 
-		// Still on the profile page, still signed in.
 		await expect(page.getByTestId("delete-account-btn")).toBeVisible();
 		await page.goto("/profile");
 		await expect(page).toHaveURL(/\/profile$/);

--- a/apps/web/tests/e2e/28-reaction-bar-darkship.spec.ts
+++ b/apps/web/tests/e2e/28-reaction-bar-darkship.spec.ts
@@ -1,30 +1,18 @@
 import {expect, test} from "@playwright/test";
 
 /**
- * Curated-palette reaction bar dark-ship invariant — the off-path proven
- * in-browser (#1867, epic #1840).
+ * The reaction bar's dark-ship invariant (ADR 0083, #1867): with `phoenix-reactions` OFF —
+ * its local/CI default — no `reaction-bar-*` element reaches any gated surface.
  *
- * The `phoenix-reactions` flag defaults OFF in the local/CI env, so the
- * `FlagGate` around the reaction bar renders nothing on every gated surface: the
- * pano feed post cards and the sözlük definition cards are byte-identical to today
- * and no `reaction-bar-*` element appears. This is the dark-ship invariant (ADR
- * 0083) — it does NOT depend on fate-live or a signed-in session, so it's stable
- * to run on the default-off flag.
- *
- * The on-path (flag on → palette + counts render → tap react/change/retract with
- * the optimistic-then-reconcile loop) is covered by the unit tests
- * `src/components/reaction/reactionModel.test.ts` +
- * `reactionDispatch.test.ts` (the flag-on path needs release plumbing / a
- * seeded reaction, landing at release), so this e2e stays on the off-path.
+ * Deliberately off-path only. The flag-on path needs release plumbing and a seeded reaction,
+ * so it is covered by `src/components/reaction/reactionModel.test.ts` + `reactionDispatch.test.ts`.
  */
 // @journey:phoenix-reactions — the registered reachability journey for the reactions
 // vertical (ADR 0173 §2). reachability-guard asserts this tag exists; the e2e job runs it.
 test.describe("Reaction bar (dark-ship, phoenix-reactions default off) @journey:phoenix-reactions", () => {
 	test("no reaction bar renders on pano post cards while the flag defaults off", async ({page}) => {
 		await page.goto("/pano");
-		// The feed rendered (a post card is present)…
 		await expect(page.locator(".kp-pano-post").first()).toBeVisible({timeout: 10_000});
-		// …and no flag-gated reaction bar leaked onto any card.
 		await expect(page.locator('[data-testid^="reaction-bar-"]')).toHaveCount(0);
 	});
 
@@ -35,9 +23,7 @@ test.describe("Reaction bar (dark-ship, phoenix-reactions default off) @journey:
 		const firstRow = page.locator(".kp-sozluk-term-row").first();
 		await expect(firstRow).toBeVisible({timeout: 10_000});
 		await firstRow.click();
-		// A definition card rendered…
 		await expect(page.locator(".kp-sozluk-definition").first()).toBeVisible({timeout: 10_000});
-		// …and no flag-gated reaction bar leaked onto it.
 		await expect(page.locator('[data-testid^="reaction-bar-"]')).toHaveCount(0);
 	});
 });

--- a/apps/web/tests/e2e/29-edge-shell-boot-journey.spec.ts
+++ b/apps/web/tests/e2e/29-edge-shell-boot-journey.spec.ts
@@ -20,7 +20,6 @@ import {expect, type Page, test} from "@playwright/test";
 
 declare global {
 	interface Window {
-		// Set by the injected observer: the cumulative layout shift attributed to the shell.
 		__shellCLS?: number;
 	}
 }
@@ -70,7 +69,6 @@ const BOOT_SIGNED_IN: SeedBoot = {
  */
 const WORKER_BOOT_SCRIPT = /<script>\s*window\.__BOOT__\s*=[\s\S]*?<\/script>/gi;
 
-/** Serialize a payload into the same inline tag the edge injects (mirrors `bootScriptTag`). */
 const bootTag = (boot: SeedBoot): string =>
 	`<script>window.__BOOT__=${JSON.stringify(boot).replace(/</g, "\\u003c")}</script>`;
 
@@ -154,7 +152,6 @@ test.describe("edge-resolved shell boot", () => {
 		const mecmua = page.locator(".kp-topbar__nav a", {hasText: /^mecmua$/i});
 		await expect(mecmua).toBeVisible();
 
-		// The marker observed the edge-boot mode — `__BOOT__` was injected for this render.
 		await expect(page.locator('[data-testid="edge-shell-boot"]')).toHaveAttribute(
 			"data-active",
 			"true",
@@ -214,12 +211,9 @@ test.describe("edge-resolved shell boot", () => {
 		// absent-payload assertions below would be testing the wrong world.
 		expect(rewritten()).toBeGreaterThan(0);
 		await expect(page.locator(".kp-topbar")).toBeVisible({timeout: 10_000});
-		// The base product nav still renders — the untransformed shell is byte-identical to today.
 		await expect(page.locator(".kp-topbar__nav a", {hasText: /^sözlük$/i})).toBeVisible();
 		await expect(page.locator(".kp-topbar__nav a", {hasText: /^pano$/i})).toBeVisible();
-		// __BOOT__ absent ⇒ the client resolves through its fetch fallback, never assuming injection.
 		expect(await page.evaluate(() => window.__BOOT__)).toBeUndefined();
-		// The marker reports the inactive mode — no injection reached this render.
 		await expect(page.locator('[data-testid="edge-shell-boot"]')).toHaveAttribute(
 			"data-active",
 			"false",

--- a/apps/web/tests/e2e/30-lab-atolye-smoke.spec.ts
+++ b/apps/web/tests/e2e/30-lab-atolye-smoke.spec.ts
@@ -9,11 +9,6 @@ import {isCloudflarePlaceholder404} from "../integration/_edge-ready";
  * flag), so ADR-0173 flag-keyed reachability doesn't apply — this e2e is the `/lab`-convention
  * equivalent, keeping the harness reachable and unbroken as exhibits evolve.
  *
- * Route/slug are ASCII English (`/lab/atolye`) per the routes-are-English convention + founder
- * ruling. Only the brand noun stays Turkish (`atölye`); technical chrome — exhibit titles (real
- * component names like `Button`) and knob labels — is English, only in-exhibit demo copy is
- * Turkish (#3230).
- *
  * The Button exhibit (`button`) is the fixed anchor: it's the harness's worked exemplar, first in
  * the registry, with a `variant` enum knob whose value lands on `data-variant` on the rendered
  * button — a directly observable render change and a serializable URL param in one.
@@ -41,7 +36,6 @@ test("atölye smoke journey: index lists exhibits → open exhibit → change kn
 }) => {
 	test.setTimeout(SPA_READY_DEADLINE_MS + 15_000);
 
-	// 1. The index renders and lists exhibits — registry-driven, not a hardcoded route menu.
 	await gotoSpaReady(page, "/lab/atolye");
 	await expect(page.getByTestId("lab-atolye-index")).toBeVisible();
 	const cards = page.locator(".kp-atolye__item");
@@ -49,16 +43,13 @@ test("atölye smoke journey: index lists exhibits → open exhibit → change kn
 	const buttonCard = page.locator('a[href="/lab/atolye/button"]');
 	await expect(buttonCard).toBeVisible();
 
-	// 2. Opening an exhibit deep-links to its detail route and mounts the ExhibitStage.
 	await buttonCard.click();
 	await expect(page).toHaveURL(/\/lab\/atolye\/button$/);
 	await expect(page.getByTestId("lab-atolye-detail")).toBeVisible();
 	const stagedButton = page.locator('[data-testid="exhibit-stage"] .kp-btn');
 	await expect(stagedButton).toBeVisible();
-	// Default variant knob → primary.
 	await expect(stagedButton).toHaveAttribute("data-variant", "primary");
 
-	// 3. Changing the `variant` enum knob re-renders the component AND reflects into the URL.
 	await page.locator('[data-knob="variant"]').getByRole("radio", {name: "Secondary"}).click();
 	await expect(stagedButton).toHaveAttribute("data-variant", "secondary");
 	await expect(page).toHaveURL(/[?&]variant=secondary(&|$)/);
@@ -67,14 +58,12 @@ test("atölye smoke journey: index lists exhibits → open exhibit → change kn
 test("atölye knob state round-trips through the URL (deep-link ↔ live twiddle)", async ({page}) => {
 	test.setTimeout(SPA_READY_DEADLINE_MS + 15_000);
 
-	// URL → state: landing a knob param restores that exhibit state (a shareable deep-link).
 	await gotoSpaReady(page, "/lab/atolye/button?variant=danger");
 	const stagedButton = page.locator('[data-testid="exhibit-stage"] .kp-btn');
 	await expect(stagedButton).toBeVisible();
 	await expect(stagedButton).toHaveAttribute("data-variant", "danger");
 
-	// state → URL: toggling back to the schema default drops the param (a pristine exhibit's URL is
-	// param-free), closing the round-trip in both directions.
+	// Toggling back to the schema default drops the param: a pristine exhibit's URL is param-free.
 	await page.locator('[data-knob="variant"]').getByRole("radio", {name: "Primary"}).click();
 	await expect(stagedButton).toHaveAttribute("data-variant", "primary");
 	await expect(page).not.toHaveURL(/[?&]variant=/);

--- a/apps/web/tests/e2e/30-member-mute-journey.spec.ts
+++ b/apps/web/tests/e2e/30-member-mute-journey.spec.ts
@@ -125,9 +125,7 @@ test.describe("member mute (sustur) @journey:member-mute", () => {
 	}) => {
 		// No interception — the real preview resolves `member-mute` to its safe default (off).
 		await page.goto("/pano");
-		// The feed rendered…
 		await expect(page.locator(".kp-pano-post").first()).toBeVisible({timeout: 10_000});
-		// …and no flag-gated "sustur" action leaked onto any card.
 		await expect(page.locator('[data-testid^="member-mute-"]')).toHaveCount(0);
 
 		// The manage route is absent while the flag is off — it self-404s (the mecmua/bildirim idiom).
@@ -151,8 +149,7 @@ test.describe("member mute (sustur) @journey:member-mute", () => {
 
 		await page.goto("/pano");
 
-		// The flag is seeded on ⇒ the "sustur" action renders on other members' feed cards. Pick
-		// the first and derive the target member id from its testid (`member-mute-<memberId>`).
+		// The flag is seeded on ⇒ the "sustur" action renders on other members' feed cards.
 		const muteButton = page.locator('[data-testid^="member-mute-"]').first();
 		await expect(muteButton).toBeVisible({timeout: 10_000});
 		const testId = await muteButton.getAttribute("data-testid");
@@ -168,7 +165,6 @@ test.describe("member mute (sustur) @journey:member-mute", () => {
 				.catch(() => "")
 		).trim();
 
-		// Mute → the mutation stub records the member; the card unmounts (the client overlay hides it).
 		await muteButton.click();
 		if (authorLabel) {
 			const existing = muted.get(memberId);
@@ -178,18 +174,15 @@ test.describe("member mute (sustur) @journey:member-mute", () => {
 			timeout: 10_000,
 		});
 
-		// Manage screen: the muted member is listed with a per-row unmute.
 		await page.goto("/susturduklarim");
 		await expect(page.locator('[data-testid="mutes-page"]')).toBeVisible({timeout: 10_000});
 		const row = page.locator(`[data-testid="mute-row-${memberId}"]`);
 		await expect(row).toBeVisible({timeout: 10_000});
 
-		// Unmute → the mutation stub drops the member; the row is removed.
 		await page.locator(`[data-testid="mute-unmute-${memberId}"]`).click();
 		await expect(row).toHaveCount(0, {timeout: 10_000});
 		expect(muted.has(memberId)).toBe(false);
 
-		// Back on the feed the member's content is reachable again (their card + "sustur" return).
 		await page.goto("/pano");
 		await expect(page.locator(`[data-testid="member-mute-${memberId}"]`).first()).toBeVisible({
 			timeout: 10_000,

--- a/apps/web/tests/e2e/31-kullanicilar-darkship.spec.ts
+++ b/apps/web/tests/e2e/31-kullanicilar-darkship.spec.ts
@@ -24,9 +24,7 @@ test.describe("Kullanıcılar roster (dark-ship, phoenix-user-admin default off)
 		page,
 	}) => {
 		await page.goto("/admin");
-		// The admin console shell never mounts (the probe denies an anonymous visitor)…
 		await expect(page.locator('[data-testid="admin-console"]')).toHaveCount(0);
-		// …and the kullanıcılar panel / roster is definitively absent.
 		await expect(page.locator('[data-testid="kullanicilar-panel"]')).toHaveCount(0);
 		await expect(page.locator('[data-testid="kullanicilar-table"]')).toHaveCount(0);
 	});

--- a/apps/web/tests/e2e/_helpers/auth.ts
+++ b/apps/web/tests/e2e/_helpers/auth.ts
@@ -8,13 +8,6 @@ export interface Credentials {
 }
 
 /**
- * Sign up a fresh user via the AuthPage. The flow:
- *   1. visit /auth (which defaults to sign-in)
- *   2. flip to sign-up via the "kayıt ol" toggle button
- *   3. fill name/email/password, submit
- *   4. wait for the redirect off /auth (Layout pushes to "/" once
- *      session.data exists)
- *
  * Each call gets a unique email so tests don't collide on Better Auth's
  * unique-email constraint when re-run.
  */
@@ -30,15 +23,9 @@ function freshCredentials(opts?: Partial<Credentials>): Credentials {
 }
 
 /**
- * Sign up a fresh user by POSTing better-auth's `/api/auth/sign-up/email`
- * directly, instead of driving the AuthPage UI. With auto-sign-in on, the
- * response lands a session `Set-Cookie`; using `page.request` shares the page's
- * context, so the cookie is captured by a subsequent `storageState()` (the
- * setup's robust pattern — no nav, no form, no redirect race). This is the
- * SETUP's auth path (ADR 0085); the UI `signUp` above is kept for local specs.
- *
- * Fails loudly with the status + a trimmed body on a non-ok response: if sign-up
- * genuinely fails on the target, we see exactly why instead of a nav timeout.
+ * The SETUP's auth path (ADR 0085): POST better-auth's sign-up route instead of driving the
+ * AuthPage UI. `page.request` shares the page's context, so the session `Set-Cookie` is captured
+ * by a subsequent `storageState()` — no nav, no form, no redirect race.
  */
 export async function signUpViaApi(page: Page, opts?: Partial<Credentials>): Promise<Credentials> {
 	const creds = freshCredentials(opts);
@@ -60,8 +47,6 @@ export async function signUp(page: Page, opts?: Partial<Credentials>): Promise<C
 
 	await page.goto("/auth");
 
-	// AuthPage opens in sign-in mode; the toggle to sign-up is the
-	// "kayıt ol" button at the bottom of the card.
 	await page.getByRole("button", {name: /^kayıt ol$/i}).click();
 	await expect(page.getByRole("heading", {name: /kayıt ol/i})).toBeVisible();
 
@@ -76,30 +61,13 @@ export async function signUp(page: Page, opts?: Partial<Credentials>): Promise<C
 }
 
 /**
- * Complete the username bootstrap gate if it's up, committing the unedited
- * email-derived prefill.
+ * Complete the username bootstrap gate if it's up. A fresh Pasaport user has `username = NULL`, so
+ * the Layout replaces the page content with <UsernameBootstrap> — specs that sign up and then
+ * assert page content must clear this first or they see the form.
  *
- * A fresh Pasaport user has `username = NULL`, so the Layout's `needsBootstrap`
- * gate replaces the page content with <UsernameBootstrap> until a username is
- * set (via `setUsername` over fate). Specs that sign up and then assert page
- * content (the feed, a post) must clear this gate first, or they see the form
- * instead of the content. Submits the pre-filled value (the email local-part,
- * unique per `signUp`). No-op if the gate isn't present (already bootstrapped).
- *
- * #1888 AC4 makes the *unedited* prefill a deliberate two-step confirm: because
- * a handle is permanent, submitting the untouched email-derived value doesn't
- * commit on the first click — it only arms confirm (the submit button reads
- * "bu adı onayla" on mount, not "devam et"), and a *second* submit commits. An
- * *edited* value still commits on the first click. So this helper: (1) selects
- * the submit button by its stable class, not the varying label; (2) clicks it,
- * and if the gate heading is still up after that, clicks once more (the confirm
- * path). That is robust for both paths — an edited handle commits on click one
- * and the second click is skipped; the unedited prefill arms on click one and
- * commits on click two.
- *
- * Specs that need a *specific* handle (e.g. to navigate to `/u/<handle>`) drive
- * the gate themselves with their chosen value instead of calling this — an
- * edited value commits in one click, so they are unaffected by the confirm step.
+ * The double click is #1888 AC4: an *unedited* prefill only ARMS confirm on the first click and
+ * commits on the second, while an edited value commits on click one (so the second click is
+ * skipped). Specs that need a specific handle drive the gate themselves and are unaffected.
  */
 export async function completeBootstrap(page: Page): Promise<void> {
 	const input = page.locator("input#bootstrap-username");
@@ -124,9 +92,6 @@ export async function completeBootstrap(page: Page): Promise<void> {
 	const heading = page.getByRole("heading", {name: /kullanıcı adını seç/i});
 
 	await submit.click();
-	// The unedited prefill only ARMED confirm on click one, so the gate is still
-	// up — a second click commits. An edited value already committed on click one,
-	// so the gate is gone and this branch is skipped.
 	if (await heading.isVisible().catch(() => false)) {
 		await submit.click();
 	}
@@ -134,17 +99,14 @@ export async function completeBootstrap(page: Page): Promise<void> {
 }
 
 /**
- * Click the topbar user pill, then "çıkış" in the account popover. The pill is the
- * Popover trigger wrapping an Avatar + the user's display name; the panel's rows are
- * real links and a real button, NOT menu commands, so çıkış has the button role.
- * Best-effort — if the panel is already gone, we just no-op.
+ * Click the topbar user pill, then "çıkış" in the account popover. The panel's rows are real links
+ * and a real button, NOT menu commands, so çıkış has the button role. Best-effort — no-op if the
+ * pill is already gone.
  */
 export async function signOut(page: Page): Promise<void> {
-	// The user pill is a button containing the user's name text.
 	const pill = page.locator(".kp-topbar__user").first();
 	if (!(await pill.isVisible().catch(() => false))) return;
 	await pill.click();
 	await page.getByRole("button", {name: /çıkış/i}).click();
-	// Pill should disappear once session clears.
 	await expect(pill).toBeHidden({timeout: 5_000});
 }

--- a/apps/web/tests/e2e/_helpers/promote.ts
+++ b/apps/web/tests/e2e/_helpers/promote.ts
@@ -1,33 +1,15 @@
 /**
- * Privileged e2e setup: promote a signed-up user to the `yazar` authorship tier
- * over the Cloudflare D1 REST API (ADR 0137).
+ * Privileged e2e setup: promote a signed-up user to the `yazar` authorship tier over the
+ * Cloudflare D1 REST API (ADR 0137), mirroring the integration harness's setup-only D1 REST path
+ * (`tests/integration/_harness.ts`).
  *
- * The e2e harness is otherwise HTTP-only against the deployed per-PR preview
- * worker — it has no privileged handle to set account state the public seam
- * guards (`user.tier` is `input:false` to better-auth, server-promoted only;
- * `worker/db/drizzle/schema.ts`). Some flows need a `yazar`-tier actor to run at
- * all: the anti-manipulation vote-gate (#1828/#1810) rejects a çaylak newcomer's
- * pano post-vote, so a two-client live spec whose voter is a fresh signup can no
- * longer cast that vote through the UI.
- *
- * This mirrors the integration harness's setup-only D1 REST path exactly
- * (`tests/integration/_harness.ts`: `cloudflareApi` + `runD1Query`): an
- * authenticated `POST /accounts/{accountId}/d1/database/{databaseId}/query` with
- * `Bearer $CLOUDFLARE_API_TOKEN`, run against the preview stage's D1. The account
- * + database id come from the environment the e2e CI job injects
- * (`.github/workflows/ci.yml` `e2e` job): `CLOUDFLARE_ACCOUNT_ID` from the secret,
- * and `E2E_D1_DATABASE_ID` — the preview D1 uuid deploy.yml surfaces in the sticky
- * `<!-- d1:<uuid> -->` token the job already reads for the seed step.
- *
- * Setup-only, never on a black-box assertion path. It is the ONE privileged handle
- * the deployed-preview e2e harness has; it is NOT a runtime route on the public
- * worker (the deleted fail-open `/api/admin/*` seeder is the rejected alternative,
- * ADR 0137 / CLAUDE.md "Sözlük seed").
+ * Setup-only, never on a black-box assertion path. It is the ONE privileged handle the
+ * deployed-preview e2e harness has; it is NOT a runtime route on the public worker (the deleted
+ * fail-open `/api/admin/*` seeder is the rejected alternative — ADR 0137 / CLAUDE.md "Sözlük seed").
  */
 
 const CLOUDFLARE_API_BASE = "https://api.cloudflare.com/client/v4";
 
-/** The CF REST coordinates + bearer the e2e CI job injects (ADR 0137). */
 function d1RestFromEnv(): {accountId: string; databaseId: string; token: string} {
 	const token = process.env.CLOUDFLARE_API_TOKEN;
 	const accountId = process.env.CLOUDFLARE_ACCOUNT_ID;
@@ -43,12 +25,6 @@ function d1RestFromEnv(): {accountId: string; databaseId: string; token: string}
 	return {accountId, databaseId, token};
 }
 
-/**
- * One authenticated D1 REST query against the preview stage's D1. Throws on a
- * non-2xx or a D1-reported SQL error (so a botched setup fails the spec loudly),
- * and returns D1's affected-row count. Mirrors the integration harness's
- * `runD1Query` (`tests/integration/_harness.ts`).
- */
 async function runD1Query(sql: string, params: unknown[]): Promise<number> {
 	const {accountId, databaseId, token} = d1RestFromEnv();
 	const res = await fetch(
@@ -73,13 +49,8 @@ async function runD1Query(sql: string, params: unknown[]): Promise<number> {
 }
 
 /**
- * Promote the user with the given sign-up `email` to the `yazar` tier by a
- * direct D1 `UPDATE` off the worker binding — the privileged state the public
- * seam refuses to set. Keyed by `email` because the e2e UI sign-up flow does not
- * surface the assigned user id; `email` is unique per better-auth signup and the
- * only stable handle a spec holds. Throws if no row matched (a mistyped email or a
- * signup that never landed), so a silent no-promote can't leave the gate red for
- * the wrong reason.
+ * Keyed by `email` because the e2e UI sign-up flow does not surface the assigned user id; it is
+ * unique per better-auth signup and the only stable handle a spec holds.
  */
 export async function promoteToYazar(email: string): Promise<void> {
 	const changes = await runD1Query(`UPDATE "user" SET tier = 'yazar' WHERE email = ?`, [email]);

--- a/apps/web/tests/integration/_cf-api-throttle.ts
+++ b/apps/web/tests/integration/_cf-api-throttle.ts
@@ -32,9 +32,6 @@
  * in #3081 live outside this harness: a GitHub Actions `concurrency:` group (a workflow change)
  * and 429 backoff inside alchemy's own deploy path (a `pnpm patch`, ADR 0038). This throttle is
  * the run-agnostic backoff applied to the slice the harness DOES own — its own D1 REST calls.
- *
- * A pure leaf: `sleep` / `now` / `random` are injectable, no `fetch`/creds dependency, so the
- * pacing logic is unit-testable offline (matches `_d1-rest-retry.ts` / `_deploy-transient.ts`).
  */
 
 /** Max CF API calls this throttle keeps in flight at once (tunable via env). */
@@ -45,15 +42,10 @@ export const CF_API_MIN_SPACING_MS = 100;
 const defaultSleep = (ms: number): Promise<void> => new Promise((r) => setTimeout(r, ms));
 
 export interface CfApiThrottleOptions {
-	/** Cap on concurrently in-flight calls (default {@link CF_API_MAX_CONCURRENT}). */
 	maxConcurrent?: number;
-	/** Minimum spacing between call starts, ms (default {@link CF_API_MIN_SPACING_MS}). */
 	minSpacingMs?: number;
-	/** Injected for tests — real sleep by default. */
 	sleep?: (ms: number) => Promise<void>;
-	/** Injected for tests — `Date.now` by default. */
 	now?: () => number;
-	/** Injected for tests — `Math.random` by default. */
 	random?: () => number;
 }
 

--- a/apps/web/tests/integration/_cf-api-throttle.unit.test.ts
+++ b/apps/web/tests/integration/_cf-api-throttle.unit.test.ts
@@ -61,9 +61,8 @@ describe("createCfApiThrottle", () => {
 				active--;
 			}),
 		);
-		// Let the first wave acquire slots, then release them one at a time.
 		await flush();
-		expect(active).toBe(2); // only two admitted; the other two are queued
+		expect(active).toBe(2);
 		for (const g of gates) {
 			g.resolve();
 			await flush();
@@ -83,7 +82,7 @@ describe("createCfApiThrottle", () => {
 			secondStarted = true;
 		});
 		await flush();
-		expect(secondStarted).toBe(false); // blocked behind the single slot
+		expect(secondStarted).toBe(false);
 		first.resolve();
 		await Promise.all([r1, r2]);
 		expect(secondStarted).toBe(true);
@@ -94,7 +93,7 @@ describe("createCfApiThrottle", () => {
 		let clock = 0;
 		const sleep = vi.fn(async (ms: number) => {
 			waits.push(ms);
-			clock += ms; // advance the injected clock by exactly the slept time
+			clock += ms;
 		});
 		const throttle = createCfApiThrottle({
 			maxConcurrent: 10, // cap out of the way — isolate the pacing knob
@@ -103,7 +102,6 @@ describe("createCfApiThrottle", () => {
 			now: () => clock,
 			random: () => 0.999999, // maximize jitter → widest wait, still < 2·spacing
 		});
-		// Fire three back-to-back; each reserves a start floor spaced by minSpacingMs.
 		await Promise.all([
 			throttle.run(async () => {}),
 			throttle.run(async () => {}),
@@ -138,7 +136,6 @@ describe("start-pacing does not consume the concurrency cap", () => {
 		const throttle = createCfApiThrottle({
 			maxConcurrent: 1,
 			minSpacingMs: 100,
-			// The first call's pace-sleep hangs; every later one returns immediately.
 			sleep: () => (sleeps++ === 0 ? paced : Promise.resolve()),
 			now: () => 0,
 			random: () => 0.5,
@@ -177,7 +174,7 @@ describe("start-pacing does not consume the concurrency cap", () => {
 			(ms) => queued.push(ms),
 		);
 		expect(queued).toHaveLength(2);
-		expect(queued[0]).toBe(0); // first call starts immediately
+		expect(queued[0]).toBe(0);
 		expect(queued[1]).toBe(100); // second waits one spacing — time the HARNESS imposed, not CF
 	});
 });

--- a/apps/web/tests/integration/_cf-rest-transport.ts
+++ b/apps/web/tests/integration/_cf-rest-transport.ts
@@ -50,7 +50,6 @@ export const cfRestSend = (
 ): Promise<Response> =>
 	cfFetchWithRateLimitRetry((queued) => cfApiThrottle.run(send, queued), options);
 
-/** The throttled + 429-retrying `fetch` the REST transport is built on. */
 export const cfRestFetch: typeof globalThis.fetch = rateLimitRetryingFetch((input, init, queued) =>
 	cfApiThrottle.run(() => fetch(input, init), queued),
 );
@@ -65,6 +64,5 @@ export const integrationRestLayer = Layer.merge(
 	FetchHttpClient.layer.pipe(Layer.provide(Layer.succeed(FetchHttpClient.Fetch, cfRestFetch))),
 );
 
-/** `makeD1Rest` over {@link integrationRestLayer} — the integration analogue of `makeD1RestFromEnv`. */
 export const makeIntegrationD1Rest = (target: {accountId: string; databaseId: string}) =>
 	makeD1Rest({...target, layer: integrationRestLayer});

--- a/apps/web/tests/integration/_d1-rest-retry.ts
+++ b/apps/web/tests/integration/_d1-rest-retry.ts
@@ -81,10 +81,7 @@ export const D1_REST_MAX_DELAY_MS = 8_000;
 
 const defaultSleep = (ms: number): Promise<void> => new Promise((r) => setTimeout(r, ms));
 
-/**
- * Why the retry loop stopped. Round 1 of #3548 reported *that* a call gave up; it could not say
- * *where the budget went*, which is why PR #4033's ejection needed the numbers re-derived by hand.
- */
+/** Why the retry loop stopped — the variants say where the budget went (#3548). */
 export type GiveUpReason =
 	/** The CF-facing deadline ran out — CF really did stay 429 for the whole budget. */
 	| "budget-exhausted"
@@ -95,7 +92,6 @@ export type GiveUpReason =
 	/** Wall clock ran out while the CF-facing budget was still unspent — i.e. we were queueing, not rate-limited. */
 	| "wall-clock-ceiling";
 
-/** What a call spent before giving up — the payload that makes an exhausted 429 diagnosable. */
 export interface RateLimitAttrition {
 	/** Caller-supplied name of the round-trip (method + path), for the log line. */
 	readonly label: string;
@@ -114,22 +110,15 @@ export interface RateLimitAttrition {
 	readonly retryAfterMs?: number | undefined;
 }
 
-/** The CF-facing slice of the elapsed time — what {@link RateLimitAttrition.budgetMs} bounds. */
 export const budgetSpentMs = (a: RateLimitAttrition): number => a.elapsedMs - a.queuedMs;
 
-/** Human-readable attrition breakdown, shared by the warn line and {@link CfRateLimitError}. */
 const attritionSummary = (a: RateLimitAttrition): string =>
 	`${a.attempts} attempt${a.attempts === 1 ? "" : "s"} (${a.reason}) — ` +
 	`${budgetSpentMs(a)}ms of the ${a.budgetMs}ms CF-facing retry budget spent over ${a.elapsedMs}ms ` +
 	`wall clock (${a.queuedMs}ms queued in the harness's own throttle, ${a.backoffMs}ms in backoff)` +
 	(a.retryAfterMs === undefined ? "" : `; CF last asked for Retry-After ${a.retryAfterMs}ms`);
 
-/**
- * A CF REST call that stayed rate-limited for its whole budget, carrying WHICH call it was and
- * what it spent. Thrown in place of a bare "failed: 429 <body>" so the next occurrence names the
- * rate-limited round-trip and its attrition instead of being re-diagnosed from scratch (#3548,
- * the same attribution `RequestStallError` gives the worker-HTTP stall path).
- */
+/** Thrown in place of a bare "failed: 429 <body>" so the round-trip names itself (#3548). */
 export class CfRateLimitError extends Error {
 	readonly _tag = "CfRateLimit";
 	readonly method: string;
@@ -162,9 +151,7 @@ export interface RateLimitRetryOptions {
 	wallClockCeilingMs?: number;
 	/** Runaway cap on retries AFTER the first attempt (default {@link D1_REST_MAX_RETRIES}). */
 	maxRetries?: number;
-	/** Base of the exponential backoff, in ms (default 500). */
 	baseDelayMs?: number;
-	/** Ceiling on one backoff wait, in ms (default 8000). */
 	maxDelayMs?: number;
 	/** Names the round-trip in the give-up log line and any raised error. */
 	label?: string;
@@ -174,11 +161,8 @@ export interface RateLimitRetryOptions {
 	 * including one added later that forgets to pass a handler.
 	 */
 	onGiveUp?: (attrition: RateLimitAttrition) => void;
-	/** Injected for tests — real sleep by default. */
 	sleep?: (ms: number) => Promise<void>;
-	/** Injected for tests — `Math.random` by default. */
 	random?: () => number;
-	/** Injected for tests — `Date.now` by default. */
 	now?: () => number;
 }
 
@@ -279,7 +263,7 @@ export const cfFetchWithRateLimitRetry = async (
 			remaining,
 			wallRemaining,
 		);
-		await res.body?.cancel().catch(() => {}); // release the discarded 429 body before re-sending
+		await res.body?.cancel().catch(() => {});
 		await sleep(wait);
 		backoffMs += wait;
 		res = await send(queued);
@@ -327,7 +311,6 @@ export const rateLimitRetryingFetch = (
 			...options,
 		})) as typeof globalThis.fetch;
 
-/** `<METHOD> <url>` for a `fetch` call, across all three `input` shapes, for the give-up line. */
 const fetchLabel = (
 	input: Parameters<typeof globalThis.fetch>[0],
 	init?: Parameters<typeof globalThis.fetch>[1],

--- a/apps/web/tests/integration/_d1-rest-retry.unit.test.ts
+++ b/apps/web/tests/integration/_d1-rest-retry.unit.test.ts
@@ -241,10 +241,9 @@ describe("giving up is self-identifying, and never a silent pass", () => {
 		expect(seen[0]?.reason).toBe("max-retries");
 	});
 
-	// Round 1 said "2 attempts over 45136ms of retry budget" and left WHERE those 45s went to be
-	// re-derived by hand from the job log. The breakdown is what makes the next occurrence
-	// self-diagnosing — 2 attempts with the budget barely touched reads as a queueing problem, not
-	// a Cloudflare one, without anyone reconstructing the backoff arithmetic.
+	// Round 1 said "2 attempts over 45136ms of retry budget" and left WHERE those 45s went to
+	// be re-derived by hand from the job log. With the breakdown, 2 attempts against an
+	// untouched budget reads as a queueing problem rather than a Cloudflare one.
 	it("breaks the elapsed time down into queued / backoff / CF-facing budget spent", async () => {
 		const seen: RateLimitAttrition[] = [];
 		let clock = 0;
@@ -272,16 +271,15 @@ describe("giving up is self-identifying, and never a silent pass", () => {
 		expect(a.queuedMs).toBe(3000); // every attempt's throttle wait, deducted from the budget
 		expect(a.backoffMs).toBe(298);
 		expect(a.budgetMs).toBe(500);
-		// Wall clock far outruns the 500ms budget precisely because most of it was ours, not CF's —
-		// the discrepancy the round-1 line could not show.
+		// Wall clock far outruns the 500ms budget because most of it was ours, not CF's.
 		expect(a.elapsedMs).toBe(3598);
 		expect(budgetSpentMs(a)).toBe(598);
 	});
 
-	// The other half of deducting `queuedMs`: with queueing uncharged, the CF-facing budget alone
-	// stops bounding wall clock, and 24 attempts of deep queueing outlive vitest's 120s testTimeout
-	// — trading the named 429 back for "Hook timed out". Deep queueing must therefore end the loop
-	// on the ceiling, saying so, rather than on the untouched budget.
+	// The other half of deducting `queuedMs`: with queueing uncharged, the CF-facing budget
+	// alone stops bounding wall clock, and 24 attempts of deep queueing outlive vitest's 120s
+	// testTimeout — trading the named 429 back for "Hook timed out". So deep queueing ends the
+	// loop on the ceiling, saying so, rather than on the untouched budget.
 	it("ends on the wall-clock ceiling when queueing (not CF) is what burnt the time", async () => {
 		const seen: RateLimitAttrition[] = [];
 		let clock = 0;

--- a/apps/web/tests/integration/_edge-ready.ts
+++ b/apps/web/tests/integration/_edge-ready.ts
@@ -1,17 +1,8 @@
 /**
- * The ONE cold-start readiness primitive every per-PR-preview probe rides (ADR 0127).
- *
- * The per-file-stage integration model stands up ~24 brand-new `*.workers.dev` hostnames +
- * their DOs per run, so any probe's FIRST request can hit a cold Cloudflare edge / cold worker
- * before the route (or the DO, or the D1 read replica) has propagated. That window surfaces as
- * an HTML edge-placeholder-404, a 503 cold-start envelope, or a transient non-200 — none of them
- * a real failure. Three point-fixes each re-taught one probe to tolerate that window (#1689 the
- * `/fate/live` open, #1717 `h.signUp`, and the `/api/health` warm), drifting into parallel copies
- * of the same idea. This module is the durable shape those point-fixes fold into: ONE typed
- * placeholder-404 signal + ONE bounded readiness poll, parameterized by a per-probe `ready`
- * predicate — so every caller tolerates the cold window uniformly while still fast-failing on a
- * real error (only the placeholder-404 / not-ready signal rides the budget; every other throw
- * escapes at once). See ADR 0127 and `.patterns/alchemy-test-harness.md`.
+ * The ONE cold-start readiness primitive every per-PR-preview probe rides: one typed
+ * placeholder-404 signal + one bounded readiness poll, parameterized by a per-probe `ready`
+ * predicate. Only the placeholder-404 / not-ready signal rides the budget; every other throw
+ * escapes at once. See ADR 0127 and `.patterns/alchemy-test-harness.md`.
  */
 
 // Cloudflare serves an HTML placeholder 404 (an `<h1>` reading "There is nothing here yet",
@@ -94,14 +85,9 @@ export const READINESS_HOOK_MARGIN_MS = 15_000;
 // `awaitWorkerReady` + `warmLiveDO` + `warmFateRead` all draw from this SINGLE deadline — each
 // consuming `deadline - now()` — so their budgets TOGETHER can never push the hook past
 // `HOOK_TIMEOUT_MS`. That makes the >300s worst case UNREPRESENTABLE by construction rather than
-// reasoned about in a sizing comment that had to keep summing every chain member (and silently
-// stopped: the retired per-probe budgets were health 180 + live 60 + fate 60 = 300 ON TOP of the
-// deploy — already over ceiling, the latent #3146 hole this closes). Two consequences fall out for
-// free: the later-propagating `/fate/live`/`POST /fate` warms are no longer capped at a fixed 60s
-// SMALLER than health's budget (#1058) — they use whatever health did not need, typically the bulk
-// of the window; and a probe reached after the window is already spent gets a floored-at-zero budget
-// and fails as its own named diagnostic, never the guillotine. Pure in its anchor + `Date.now()`,
-// so the bound is unit-pinned in `_edge-ready.unit.test.ts` (#3788).
+// reasoned about in a sizing comment that had to keep summing every chain member (the latent #3146
+// hole this closes). A probe reached after the window is already spent gets a floored-at-zero
+// budget and fails as its own named diagnostic, never the guillotine.
 export const perFileReadinessDeadline = (hookStartedAt: number): number =>
 	hookStartedAt + HOOK_TIMEOUT_MS - READINESS_HOOK_MARGIN_MS;
 
@@ -109,12 +95,9 @@ const sleep = (ms: number) => new Promise<void>((r) => setTimeout(r, ms));
 
 /**
  * One `fetch` that converts the Cloudflare edge-placeholder-404 into the typed
- * `CloudflarePlaceholder404Error` the readiness poll rides out — the standalone counterpart of the
- * harness `req` loop's inline placeholder detection, for the deploy-time warm probes that fetch a
- * bare `url` before the harness client exists. On a 404 it peeks a clone's body (only on a 404, so
- * the hot path is untouched) and throws the typed error if it is the placeholder; every other
- * response is returned as-is for the caller's `ready` predicate to classify. A real worker JSON 404
- * never matches, so it is returned unretried.
+ * `CloudflarePlaceholder404Error` the readiness poll rides out — for the deploy-time warm probes
+ * that fetch a bare `url` before the harness client exists. The body peek is gated on a 404 so
+ * the hot path is untouched; a real worker JSON 404 never matches and is returned unretried.
  */
 export const edgeFetch = async (input: string, init?: RequestInit): Promise<Response> => {
 	const res = await fetch(input, init);
@@ -129,21 +112,14 @@ export const edgeFetch = async (input: string, init?: RequestInit): Promise<Resp
 
 /**
  * The shared bounded readiness poll: re-send `send()` until `ready(res)` holds or the deadline
- * lapses. It rides out BOTH cold-edge not-ready shapes on the SAME budget — a not-ready RESPONSE
- * (`!ready(res)`, e.g. a 503 cold-start envelope or a non-200 that hasn't ripened) AND a THROWN
- * `CloudflarePlaceholder404Error` (the edge route not yet propagated). The placeholder tolerance is
- * SCOPED, not blanket: ONLY that typed error is caught-and-retried; every OTHER throw (an
- * abort/timeout, a connection error, a genuine failure) escapes immediately, unretried — so the
- * widened budget can never swallow a real failure. On a RESPONSE exhausting the deadline it returns
- * the last response, so the caller's own assertion still reports the truth (it never classifies a
- * status as terminal and stops early — the #1060 no-early-stop guarantee); on the deadline lapsing
- * while STILL on the placeholder-404 it re-throws that typed error so the edge-not-propagated
- * diagnostic surfaces rather than a synthetic status.
+ * lapses. The placeholder tolerance is SCOPED, not blanket: ONLY the typed
+ * `CloudflarePlaceholder404Error` is caught-and-retried; every OTHER throw escapes immediately,
+ * unretried — so the widened budget can never swallow a real failure. On a RESPONSE exhausting
+ * the deadline it returns the last response rather than classifying a status as terminal and
+ * stopping early (the #1060 no-early-stop guarantee).
  *
- * `ready` may be async (e.g. the `/api/health` probe inspecting the JSON body), and is evaluated
- * against a clone-safe response — a not-ready response's body is released before the next poll so a
- * held SSE stream can't pin the fetch connection across the loop. Deadline/poll are parameters
- * (defaulting to the module bounds) so unit tests drive the logic on a tiny budget.
+ * A not-ready response's body is released before the next poll, so a held SSE stream can't pin
+ * the fetch connection across the loop.
  */
 export const awaitEdgeReady = async (
 	send: () => Promise<Response>,
@@ -154,7 +130,6 @@ export const awaitEdgeReady = async (
 	}: {deadlineMs?: number; pollMs?: number} = {},
 ): Promise<Response> => {
 	const deadline = Date.now() + deadlineMs;
-	// Map ONLY the typed placeholder-404 throw to a retryable value; any other throw propagates.
 	const step = async (): Promise<Response | CloudflarePlaceholder404Error> => {
 		try {
 			return await send();

--- a/apps/web/tests/integration/_edge-ready.unit.test.ts
+++ b/apps/web/tests/integration/_edge-ready.unit.test.ts
@@ -1,19 +1,8 @@
 /**
- * Pins the ONE shared cold-start readiness primitive (`awaitEdgeReady`, ADR 0127) — the durable
- * shape the #1689 (`/fate/live`) and #1717 (`h.signUp`) point-fixes fold into, covering all three
- * probes' load-bearing invariants:
- *
- *   1. A CF edge-placeholder-404 / cold-worker signal rides the bounded budget (retry until it
- *      propagates or the deadline lapses) — for every probe, via ONE typed throw.
- *   2. A real error fast-fails: an abort, a genuine 4xx, a terminal worker JSON 4xx, and the
- *      422-already-exists answer surface at once, never swallowed into the budget.
- *   3. The three probes' `ready` predicates are exercised over the shared primitive: the SSE-open
- *      shape (200 + `text/event-stream`), the signup shape (`() => true`, only a thrown placeholder
- *      retries), the `/api/health` shape (async body inspection), and the `/fate/live`-warm shape
- *      (a terminal worker JSON 4xx stops the poll).
- *
- * This replaces the two per-probe point-fix test files (`_fate-live-readiness.unit.test.ts` #1690,
- * `_auth-signup-readiness.unit.test.ts` #1720) now that their logic is one primitive.
+ * Pins the shared cold-start readiness primitive (`awaitEdgeReady`, ADR 0127) and its two
+ * invariants, referenced by number throughout: (1) a CF edge-placeholder-404 / cold-worker signal
+ * rides the bounded budget; (2) a real error — an abort, a genuine 4xx, a terminal worker JSON 4xx,
+ * the 422-already-exists answer — fast-fails and is never swallowed into the budget.
  */
 
 import * as Effect from "effect/Effect";
@@ -61,7 +50,6 @@ const onFakeTimers = async <T>(start: () => Promise<T>): Promise<T> => {
 
 const okStream = () =>
 	new Response("", {status: 200, headers: {"content-type": "text/event-stream"}});
-// The `/fate/live` SSE-open readiness predicate (200 + event-stream), used across the poll tests.
 const sseReady = (res: Response): boolean =>
 	res.status === 200 && (res.headers.get("content-type") ?? "").includes("text/event-stream");
 
@@ -70,7 +58,6 @@ describe("awaitEdgeReady — the shared cold-start readiness primitive (ADR 0127
 		let call = 0;
 		const send = vi.fn(async () => {
 			call += 1;
-			// The edge is not propagated for the first two opens (the throw `req`/`edgeFetch` raises), then serves.
 			if (call <= 2) throw new CloudflarePlaceholder404Error("/fate/live");
 			return okStream();
 		});
@@ -139,7 +126,6 @@ describe("awaitEdgeReady — the shared cold-start readiness primitive (ADR 0127
 		};
 		const send = vi.fn(async () => {
 			call += 1;
-			// First two: propagating (a 503, then a 200 whose body isn't `ok` yet); then healthy.
 			if (call === 1) return new Response("<html>edge</html>", {status: 503});
 			if (call === 2) return new Response(JSON.stringify({status: "warming"}), {status: 200});
 			return new Response(JSON.stringify({status: "ok"}), {status: 200});
@@ -168,7 +154,6 @@ describe("awaitEdgeReady — the shared cold-start readiness primitive (ADR 0127
 		const res = await awaitEdgeReady(send, liveWarmReady, BUDGET);
 
 		expect(res.status).toBe(401);
-		// Fast-fail: the terminal worker JSON 4xx was ready on the FIRST attempt, never re-polled.
 		expect(send).toHaveBeenCalledTimes(1);
 	});
 });
@@ -191,8 +176,6 @@ describe("awaitAuthRouteReady — the bootstrap auth-route propagation gate (#24
 
 		await Effect.runPromise(awaitAuthRouteReady("https://stage.example.workers.dev"));
 
-		// One call: a real worker 400 (the empty-body probe answer) is READY at once under
-		// `() => true` — a genuine auth 4xx is never swallowed into the readiness budget (invariant 2).
 		expect(fetchMock).toHaveBeenCalledTimes(1);
 		const [input, init] = fetchMock.mock.calls[0]!;
 		expect(input).toBe("https://stage.example.workers.dev/api/auth/sign-up/email");
@@ -203,8 +186,6 @@ describe("awaitAuthRouteReady — the bootstrap auth-route propagation gate (#24
 		let call = 0;
 		const fetchMock = vi.fn(async () => {
 			call += 1;
-			// The auth route is not propagated on the first open (CF HTML placeholder 404 → edgeFetch
-			// throws the typed error the gate rides), then serves a structured 4xx (route propagated).
 			if (call === 1)
 				return new Response("<!DOCTYPE html>There is nothing here yet", {status: 404});
 			return new Response(JSON.stringify({code: "INVALID_EMAIL"}), {status: 400});
@@ -236,8 +217,6 @@ describe("awaitWorkerReady — typed readiness diagnostic (#3146)", () => {
 	});
 
 	it("a worker that never serves healthy JSON within the budget throws the typed diagnostic (not a bare Error, not a hook timeout)", async () => {
-		// A 200 whose body is never `{status:"ok"}` rides the readiness budget and never goes ready;
-		// on deadline `awaitEdgeReady` returns the last (still-not-ready) response, and the gate throws.
 		vi.stubGlobal(
 			"fetch",
 			vi.fn(async () => new Response(JSON.stringify({status: "warming"}), {status: 200})),
@@ -280,9 +259,7 @@ describe("perFileReadinessDeadline — the readiness chain is bounded by the hoo
 
 	it("keeps the whole readiness chain strictly below HOOK_TIMEOUT_MS from the hook start", () => {
 		const deadline = perFileReadinessDeadline(startedAt);
-		// Measured from the hook start, the chain can run at most until `deadline` — which is
-		// READINESS_HOOK_MARGIN_MS short of the ceiling, the headroom the typed throw needs to beat
-		// the vitest guillotine.
+		// The margin is the headroom the typed throw needs to beat the vitest guillotine.
 		expect(deadline - startedAt).toBe(HOOK_TIMEOUT_MS - READINESS_HOOK_MARGIN_MS);
 		expect(deadline - startedAt).toBeLessThan(HOOK_TIMEOUT_MS);
 		expect(READINESS_HOOK_MARGIN_MS).toBeGreaterThan(0);
@@ -290,8 +267,7 @@ describe("perFileReadinessDeadline — the readiness chain is bounded by the hoo
 
 	it("a probe reached after earlier probes spent part of the window gets only what remains (each consumes deadline - now)", () => {
 		const deadline = perFileReadinessDeadline(startedAt);
-		// health consumed 200s of the shared window; the live warm, reached now, sees only the remainder
-		// — strictly less than health got, and the sum can never exceed the window.
+		// 200s stands for what the health probe already spent out of the shared window.
 		const nowAfterHealth = startedAt + 200_000;
 		const liveBudget = Math.max(0, deadline - nowAfterHealth);
 		expect(liveBudget).toBe(HOOK_TIMEOUT_MS - READINESS_HOOK_MARGIN_MS - 200_000);
@@ -458,8 +434,6 @@ describe("h.signUp — cold-edge readiness over the shared primitive (invariants
 	});
 
 	it("replays a transient 422 FAILED_TO_CREATE_USER, then resolves the created session (#3799)", async () => {
-		// Cold-D1 first-write throws once → better-auth 422 FAILED_TO_CREATE_USER; the replay creates
-		// the user, and the `get-session` gate confirms the session before it is handed back.
 		const fetchMock = stubFetch([failedToCreate422, () => authOk("u_created")]);
 		const h = buildHarness();
 

--- a/apps/web/tests/integration/_global-setup.ts
+++ b/apps/web/tests/integration/_global-setup.ts
@@ -3,12 +3,8 @@
  * that deploys the real phoenix `Stack` ONCE per run and `provide`s its handle to forked
  * integration files via `inject` (`_integration.ts`'s `sharedStack()`).
  *
- * This is the deploy-once counterpart to the per-file `integrationStack`: the per-file path
- * stands up ~24 ephemeral stages per run (one `beforeAll(deploy)` each); this stands up ONE
- * and hands every migrated file the same worker URL + D1 coordinates. The two paths share
- * ONE copy of the deploy hardening — `ensureIntegrationEnv` / `runTokenFromEnv` /
- * `deployTransientRetry` / `awaitWorkerReady` / `warmLiveDO` all live in `_integration.ts`
- * and are imported here, never re-implemented.
+ * The deploy hardening is shared with the per-file `integrationStack` path — it lives in
+ * `_integration.ts` and is imported here, never re-implemented.
  *
  * Gated: globalSetup is root-level config, so it runs for ANY invocation of this vitest
  * config — including `test:unit` (`vitest --project unit`), which must deploy nothing. When
@@ -33,9 +29,8 @@ import {
 } from "./_integration.ts";
 import {sharedStageName} from "./_stage-name.ts";
 
-// The injected-context keys the shared stage provides — typed so `inject(...)` in
-// `_integration.ts`'s `sharedStack()` is checked, not `any`. All values are plain
-// strings / a POJO, so `provide`'s `structuredClone` serializability check passes.
+// Every value here must stay a plain string / POJO — `provide` runs a `structuredClone`
+// serializability check on it.
 declare module "vitest" {
 	interface ProvidedContext {
 		integrationWorkerUrl: string;
@@ -63,14 +58,8 @@ export default async function setup(project: TestProject): Promise<() => Promise
 	ensureIntegrationEnv();
 	const stage = sharedStageName(runTokenFromEnv());
 
-	// Deploy ONCE through `Core.run` — the alchemy test runtime (`toEffect`) that
-	// `Test/Vitest.ts` wraps `deploy` with, which provides the full layer stack the per-file
-	// `beforeAll(deploy(...))` runs under (AlchemyContext, state). The readiness probes now ride
-	// the shared `awaitEdgeReady` over a bare `fetch` (ADR 0127), so they need no `HttpClient`
-	// from the runtime. Same hardening the per-file path applies:
-	// `deployTransientRetry`, then `awaitWorkerReady` + `warmLiveDO`. No scope: CI is non-dev,
-	// so there is no workerd sidecar to keep alive (the scope in `Test/Vitest.ts` exists only
-	// for `alchemy dev`).
+	// No scope: CI is non-dev, so there is no workerd sidecar to keep alive (the scope in
+	// `Test/Vitest.ts` exists only for `alchemy dev`).
 	//
 	// The readiness gate proves BOTH the health route AND the auth-provisioning route are past the
 	// CF edge placeholder before `project.provide` releases the URL: edge propagation is per-route,

--- a/apps/web/tests/integration/_harness.ts
+++ b/apps/web/tests/integration/_harness.ts
@@ -1,37 +1,12 @@
 /**
- * Integration-test HTTP harness — the black-box client surface every integration
- * test drives (ADR 0026–0031, ADR 0082, `.patterns/alchemy-test-harness.md`).
- *
- * The harness owns no deploy lifecycle. `integrationStack()` (in `_integration.ts`)
- * deploys the real phoenix stack to **real remote Cloudflare** with a **per-file
- * isolated stage** (`Test.make` + `beforeAll(deploy(Stack, {stage}))` +
- * `afterAll.skipIf(...)(destroy(Stack, {stage}))` + retry-first-request) and hands
- * this factory a `getUrl` accessor resolving to that stage's deployed worker URL.
- * Tests assert **black-box over HTTP** against it. No `cloudflare:test`, no
- * `SELF.fetch`, no `env.PHOENIX_DB`, no `runInDurableObject`, no shared single
- * deploy.
- *
- * D1 is real remote Cloudflare D1, migrated by the existing
- * `D1Database({migrationsDir, migrationsTable: "drizzle_migrations"})` resource
- * (`worker/db/resources.ts`) that `deploy` applies — one migration path, nothing to
- * keep in sync. Per-file isolated stages give every file its own worker + D1, so
- * files run in parallel instead of the prior forced single fork that raced itself
- * (#547 / #220 / #560 — one root cause, ADR 0082).
- *
- * The test-author contract is unchanged from the prior single-shared-deploy harness
- * — `harness(getUrl)` exposes the same surface, only sourced from a per-file URL:
- *   - `h.url()`              — the deployed worker URL for this file's stage
- *   - `h.fate(op, opts)`     — POST one fate operation, return its single result
- *   - `h.fateBatch(...)`     — POST several fate operations at once
- *   - `h.signUp(...)`        — sign up a user through `/api/auth/*`, return cookie
- *   - `h.seedTerm(...)`      — seed a sözlük term+definitions via the PUBLIC fate
- *                             `definition.add` mutation (+ votes for scores)
- *   - `h.setLastActivityAt(...)` — controlled D1 write of a term's `last_activity_at`
- *                             (setup-only, real-D1 REST; the clock the seam can't set)
- *   - `h.execD1(...)`        — one setup-only SQL statement against this stage's real
- *                             D1 (real-D1 REST; e.g. drop an FTS table to inject a fault)
- *   - `h.json(...)` / `h.req(...)` — raw HTTP helpers
- *   - `h.openSse(...)` / `readFrame(...)` — live SSE transport helpers
+ * Integration-test HTTP harness — the black-box client surface every integration test
+ * drives (ADR 0026–0031, ADR 0082, `.patterns/alchemy-test-harness.md`). It owns no
+ * deploy lifecycle; `_integration.ts` deploys the real stack to real remote Cloudflare
+ * on a per-file isolated stage and hands this factory that stage's worker URL. Tests
+ * assert over HTTP only — no `cloudflare:test`, no `SELF.fetch`, no `env.PHOENIX_DB`,
+ * no `runInDurableObject`. Per-file stages give every file its own worker + D1, so
+ * files run in parallel instead of the prior single fork that raced itself (#547 /
+ * #220 / #560 — one root cause, ADR 0082).
  */
 
 import {randomBytes} from "node:crypto";
@@ -50,7 +25,6 @@ import {
 	SAFE_STALL_REPLAYS,
 } from "./_request-stall.ts";
 
-/** A fate wire result for a single operation. */
 export type FateResult =
 	| {ok: true; data: unknown; id: string}
 	| {ok: false; error: {code: string; message?: string}; id: string};
@@ -80,7 +54,6 @@ export type FateOpts =
 	| {cookie?: string; retry?: never; converge: () => Promise<FateResult | undefined>};
 
 export interface Harness {
-	/** The deployed worker URL (published by the global setup). */
 	url(): string;
 	/**
 	 * Raw fetch against the worker; retries transient *connection* failures. Pass
@@ -100,7 +73,6 @@ export interface Harness {
 	fate(op: FateOp, opts?: FateOpts): Promise<FateResult>;
 	/** POST several fate operations; return all results in order. */
 	fateBatch(ops: FateOp[], opts?: {cookie?: string}): Promise<FateResult[]>;
-	/** Sign up a user through better-auth; return `{userId, cookie}`. */
 	signUp(email: string, password: string, name: string): Promise<{userId: string; cookie: string}>;
 	/**
 	 * {@link signUp} + {@link promoteToYazar} — the fixture factory for an ESTABLISHED
@@ -201,9 +173,7 @@ export interface Harness {
 	 * Setup-only, never an assertion.
 	 */
 	d1Target(): Promise<{accountId: string; databaseId: string}>;
-	/** Open a live SSE stream on a connection id (cookie required). */
 	openSse(connectionId: string, cookie: string): Promise<Response>;
-	/** Drive a `/fate/live` control message (subscribe / unsubscribe). */
 	liveControl(
 		connectionId: string,
 		operations: Array<Record<string, unknown>>,
@@ -217,10 +187,6 @@ const sleep = (ms: number) => new Promise<void>((r) => setTimeout(r, ms));
 // `addDefinition`'s converge loop can widen its recovery to it without also swallowing a
 // transport failure (`convergeAfterStall` defaults to stalls only).
 class SeedAddRejected extends Error {}
-
-// The Cloudflare edge-placeholder-404 detector + its typed carrier now live in the shared
-// readiness primitive (`_edge-ready.ts`, ADR 0127) — `req` below imports them so its inline
-// placeholder detection and `awaitEdgeReady`'s scoped tolerance share ONE definition.
 
 // One HTTP request that stalls past this is aborted and retried against a fresh connection
 // where that is sound (see `_request-stall.ts` for the stall classification + recovery, and
@@ -312,10 +278,6 @@ async function cloudflareApi(path: string, init?: RequestInit): Promise<Response
 	return res;
 }
 
-/**
- * Read one SSE event (frames are delimited by a blank line) off a stream reader,
- * buffering across reads. Returns the frame text (without the trailing `\n\n`).
- */
 export async function readFrame(
 	reader: ReadableStreamDefaultReader<Uint8Array>,
 	decoder: TextDecoder,
@@ -354,7 +316,6 @@ export async function readEvent(
 	throw new Error("timed out waiting for an SSE event frame (only comments seen)");
 }
 
-/** Parse the `data: …` line of an SSE frame as JSON. */
 export function frameData<T = unknown>(frame: string): T {
 	const line = frame.split("\n").find((l) => l.startsWith("data: "));
 	if (!line) throw new Error(`SSE frame has no data line:\n${frame}`);
@@ -387,17 +348,11 @@ export const signUpDisposition = (status: number, body: string): SignUpDispositi
 			: "terminal";
 
 /**
- * Build the HTTP harness over a deployed-worker URL accessor. The harness does NOT
- * deploy — `integrationStack()` (`_integration.ts`) owns the per-file `Test.make`
- * lifecycle and supplies `getUrl`, which resolves to this file's stage's worker URL
- * (populated by the `beforeAll(deploy(Stack))` hook before any `it` body runs).
- *
- * `getD1Target` resolves this stage's real D1 REST coordinates —
- * `{accountId, databaseId}` — read straight off the deploy's compiled `Stack`
- * output (alchemy `Cloudflare.D1Database` surfaces `databaseId`/`accountId`), the
- * same hook that populates `getUrl`. The harness no longer reconstructs the D1's
- * physical name and prefix-matches the CF list API (#692, retiring #689's
- * `MAX_STAGE_LEN`); it reads the id the deploy already knows.
+ * `getUrl` and `getD1Target` both resolve off the deploy's compiled `Stack` output and are
+ * only populated once `beforeAll(deploy(Stack))` has run, so build the harness through
+ * `integrationStack()`. The D1 coordinates are read from that output rather than
+ * reconstructed from the D1's physical name and prefix-matched against the CF list API
+ * (#692, retiring #689's `MAX_STAGE_LEN`).
  */
 export function harness(
 	getUrl: () => string,
@@ -495,9 +450,6 @@ export function harness(
 		op.kind === "query" || op.kind === "list" || opts?.retry === true;
 
 	const fate: Harness["fate"] = async (op, opts) => {
-		// A non-idempotent mutation that supplied a landed-probe converges instead of
-		// hard-failing on a stall (see `FateOpts`); the union rules out combining this
-		// with the blind-replay mode below.
 		if (opts?.converge) {
 			const probe = opts.converge;
 			return convergeAfterStall(() => fateBatch([op], opts).then(([r]) => r!), probe);
@@ -510,12 +462,9 @@ export function harness(
 				const [result] = await fateBatch([op], opts);
 				lastResult = result;
 				lastErr = undefined;
-				// Success, or a non-retryable op: take the result as-is. A retryable op
-				// that came back `!ok` is a transient failure → loop and try again.
 				if (result!.ok || attempts === 1) return result!;
 			} catch (err) {
 				lastErr = err;
-				// Only a stall is retryable; a real error (or a non-retryable op) surfaces.
 				if (attempts === 1 || !isStall(err)) throw err;
 			}
 			if (i < attempts - 1) await sleep(300 * (i + 1));
@@ -551,9 +500,6 @@ export function harness(
 		throw lastErr;
 	};
 
-	// Extract the session (`name=value` cookie + user id) from a better-auth
-	// sign-up OR sign-in response — the two share a response shape, so both the
-	// fresh-user and existing-user paths converge here.
 	// A better-auth POST that additionally rides a cold per-PR-preview edge's placeholder-404
 	// (the route not yet propagated) out on the shared readiness budget — the auth-signup caller
 	// of `awaitEdgeReady` (ADR 0127; the #1717 point-fix folded into the primitive). `req` already
@@ -667,14 +613,6 @@ export function harness(
 		await promoteToYazar(session.userId);
 		return session;
 	};
-
-	// Per-harness seeding state. A `definition.add` write is identity-bearing
-	// (author = session user) and scores are vote-derived, so seeding drives the
-	// same public surface the app does: one cached session per distinct
-	// `authorName`, and a shared, lazily-grown pool of throwaway voters that each
-	// cast a single up-vote to realize a definition's `score`. The seed-id counter
-	// (`nextSeedId`) is process-global (module scope, above) — never re-declared here,
-	// so emails stay unique across every file's harness instance (#2116).
 
 	// The seeded author identity is uniquified PER RUN at this source: the stored `author_name`
 	// (`user.name ?? user.email`) is the requested base + the per-process `STAMP_SEED`, so no two
@@ -850,11 +788,6 @@ export function harness(
 		return (voted.data as {score: number}).score;
 	};
 
-	// One setup-only statement against this stage's real D1 over the REST query API.
-	// Returns D1's reported affected-row count (0 for DDL); throws on a D1-side SQL
-	// error so a botched setup statement fails the test loudly, never silently. The
-	// `{accountId, databaseId}` come straight off the deploy's compiled output
-	// (`getD1Target`) — the id the deploy already knows, never a reconstructed name (#692).
 	const runD1Query = async (sql: string, params: unknown[]): Promise<number> => {
 		const {accountId: acct, databaseId} = getD1Target();
 		const res = await cloudflareApi(`/accounts/${acct}/d1/database/${databaseId}/query`, {

--- a/apps/web/tests/integration/_integration.ts
+++ b/apps/web/tests/integration/_integration.ts
@@ -1,28 +1,10 @@
 /**
  * Per-file integration lifecycle — the alchemy `Test.make` substrate (ADR 0082).
  *
- * Each integration test file calls `integrationStack(import.meta.url)` once at
- * module top level. It stands up a per-file `Test.make`, deploys the real phoenix
- * `Stack` to **real remote Cloudflare** under an **isolated stage** derived from the
- * file name, retries the first request through edge propagation, and returns the
- * black-box `harness` (`_harness.ts`) bound to that stage's worker URL. The deploy
- * runs in a `beforeAll(deploy(Stack, {stage}))`; teardown is
- * `afterAll.skipIf(NO_DESTROY)(destroy(Stack, {stage}))`.
- *
- * Per-file isolated stages are the whole point: each file owns its own worker + D1
- * (real, remote), freshly migrated by the existing
- * `D1Database({migrationsTable: "drizzle_migrations"})` resource the deploy applies
- * — one migration path. Files no longer share one long-lived deploy, so they run in
- * parallel instead of the forced single fork that raced itself (#547 / #220 / #560,
- * one root cause). D1 binds remote in `Test.make` (alchemy never emulates D1 — ADR
- * 0032/0082); real creds (`CLOUDFLARE_API_TOKEN` / `CLOUDFLARE_ACCOUNT_ID` /
- * `ALCHEMY_PASSWORD`) come from the environment (CI secrets; a wrangler/alchemy
- * profile locally).
- *
- * `BETTER_AUTH_SECRET` (a required `Config.redacted`, `worker/config.ts`) and
- * `ENVIRONMENT` are self-supplied below when absent — orthogonal to the harness
- * swap, retained from the prior model so the suite stays self-contained on a clean
- * runner.
+ * Per-file isolated stages are the whole point: each file owns its own worker + D1 (real, remote,
+ * freshly migrated by the deploy's own `D1Database` resource), so files run in parallel instead of
+ * the forced single fork that raced itself (#547 / #220 / #560, one root cause). D1 binds remote
+ * (alchemy never emulates D1 — ADR 0032/0082); real creds come from the environment.
  */
 
 import type {Input} from "alchemy";
@@ -57,21 +39,13 @@ import {slugify, stageName} from "./_stage-name.ts";
 // helpers below. The harness client itself (`sharedStack`) is exported at the end.
 
 // All three deploy-time warm probes below ride the ONE shared readiness primitive
-// (`awaitEdgeReady`, ADR 0127): `edgeFetch` converts a cold edge-placeholder-404 into the typed
-// throw the primitive rides out, and each probe supplies a `ready` predicate that stops the poll
-// on its own "warmed" signal while a real terminal answer surfaces at once. The per-probe tagged
-// retry sentinels (`WorkerNotReady`/`LiveDONotReady`/`FateReadNotReady`) + their bespoke
-// `Schedule.spaced` loops are retired into that primitive — this is the #1689/#1717 point-fixes
-// generalized (see ADR 0127).
+// (`awaitEdgeReady`, ADR 0127): each supplies a `ready` predicate that stops the poll on its own
+// "warmed" signal while a real terminal answer surfaces at once.
 
-// `/api/health` is READY only on a 200 whose JSON body is `{status:"ok"}` — so its predicate is
-// async (it inspects a clone's body). A non-200, or a 200 with a non-JSON CF error page / a
-// non-"ok" body, is not ready → retry.
 const healthReady = async (res: Response): Promise<boolean> => {
 	if (res.status !== 200) return false;
 	// `.json()` rejects on a non-JSON CF error page → fold that rejection to `null` (⇒ not ready),
-	// rather than a raw try/catch in an effect-importing file (#2736 no-raw-try-catch). Same
-	// semantics: a non-200, a non-JSON body, or a non-"ok" body is not ready → retry.
+	// rather than a raw try/catch in an effect-importing file (#2736 no-raw-try-catch).
 	const body = (await res
 		.clone()
 		.json()
@@ -86,12 +60,8 @@ const healthReady = async (res: Response): Promise<boolean> => {
 const liveWarmReady = (res: Response): boolean =>
 	res.status === 200 || !isLiveWarmupNotReady(res.status, res.headers.get("content-type") ?? "");
 
-// `POST /fate` (the read path + D1 read replica) is READY only on a 200; a cold PoP / cold replica
-// surfaces a non-200 that hasn't ripened → retry.
 const fateReadReady = (res: Response): boolean => res.status === 200;
 
-// The deploy-probe poll cadence — the ~2s spacing the retired `Schedule.spaced("2 seconds")` used,
-// over `awaitEdgeReady`'s default 60s budget.
 const WARM_POLL_MS = 2_000;
 
 // A readiness/warmup probe's underlying promise rejected. The warm probes (`warmLiveDO`,
@@ -172,8 +142,6 @@ ensureIntegrationEnv();
 type StackOutput =
 	typeof Stack extends Effect.Effect<CompiledStack<infer A>, infer _E, infer _R> ? A : never;
 
-// `afterAll(destroy(...))` is skipped when `NO_DESTROY` is set, so a local iteration
-// loop can keep the per-file deploy alive between runs (matching the alchemy idiom).
 const NO_DESTROY = !!process.env.NO_DESTROY;
 
 // Per-PROCESS token for local default (destroy-on) runs: stable for one vitest
@@ -212,11 +180,6 @@ export const runTokenFromEnv = (): string =>
  *     a per-process LOCAL_TOKEN). `<readable>` is a slug prefix kept only as a human-debug
  *     aid (a CF-dashboard stage traces to its file).
  *
- * Sanitized to the `[a-z0-9-]` Cloudflare resource-name set, no leading/trailing dash, no
- * internal `--`, non-empty — the pure `stageName`/`slugify` of `_stage-name.ts` enforce
- * this for every input (unit-pinned in `_stage-name.unit.test.ts`). The harness reads the
- * deployed D1's uuid off the compiled Stack output, so the stage no longer needs the #689
- * `MAX_STAGE_LEN` length bound (#692).
  */
 const stageFor = (metaUrl: string): string => {
 	const base = (metaUrl.split("/").pop() ?? "integration").replace(/\.test\.ts$/, "");
@@ -286,9 +249,6 @@ export const warmLiveDO = (
 						headers: {accept: "text/event-stream", cookie},
 					}),
 				liveWarmReady,
-				// The caller's budget (the per-file path passes what the shared readiness deadline has
-				// left; the shared-stage path takes the default) — threaded so the exhaustion diagnostic
-				// below cites the number actually spent, never a drifted copy.
 				{pollMs: WARM_POLL_MS, deadlineMs},
 			);
 			await res.body?.cancel().catch(() => {});
@@ -320,9 +280,6 @@ export const warmLiveDO = (
  * (`fts-backfill`'s `before`, `search-error-vs-empty`'s reads) can hit a cold PoP. We
  * front-load that warm here behind the same bounded `spaced` retry as `warmLiveDO`, on the
  * dedicated path only (NOT the shared globalSetup — minimal blast radius). See ADR 0104, #1108.
- *
- * The anonymous `health` query (`Stats.getLandingStats` reads D1) needs no auth; the wire
- * envelope (`{version, operations}`) mirrors the harness `fateBatch`.
  */
 export const warmFateRead = (
 	url: string,
@@ -330,8 +287,6 @@ export const warmFateRead = (
 ): Effect.Effect<void, never, never> =>
 	Effect.tryPromise({
 		try: async () => {
-			// A 200 means the route + D1 read served; a cold PoP placeholder-404 (the thrown edge
-			// transient) / a non-200 that hasn't ripened rides the shared readiness budget → retry.
 			const res = await awaitEdgeReady(
 				() =>
 					edgeFetch(`${url}/fate`, {
@@ -465,14 +420,9 @@ export const awaitAuthRouteReady = (url: string): Effect.Effect<void, never, nev
 	}).pipe(Effect.orDie);
 
 /**
- * Stand up this file's per-file `Test.make` lifecycle and return the black-box
- * `harness` bound to its deployed worker URL. Call once at module top level.
- *
- * The deploy resolves inside a vitest `beforeAll` hook (so the worker exists before
- * any `it` body runs); its resolved URL is stashed in a holder the synchronous
- * `harness()` reads. The first request against a freshly-deployed workers.dev URL
- * 404s for a few seconds while the route propagates, so a probe retries
- * `GET /api/health` on a bounded `spaced` schedule before the suite asserts.
+ * Stand up this file's per-file `Test.make` lifecycle and return the black-box `harness` bound to
+ * its deployed worker URL. Call once at module top level: the deploy resolves inside a vitest
+ * `beforeAll` and stashes its URL in a holder the synchronous `harness()` reads.
  */
 export function integrationStack(metaUrl: string): Harness {
 	const stage = stageFor(metaUrl);
@@ -574,17 +524,12 @@ export function integrationStack(metaUrl: string): Harness {
 }
 
 /**
- * Build the black-box `harness` over the RUN-SCOPED SHARED stage (ADR 0104 step 7, #1027) —
- * the deploy-once counterpart to `integrationStack`. No `beforeAll`/`afterAll`, no deploy:
- * `_global-setup.ts` deploys ONE stage per run in vitest `globalSetup` and `provide`s its
- * handle, so this is a pure HTTP/D1 client over the injected values, built via the SAME
- * `harness(urlAccessor, d1Accessor)` factory the per-file path uses. A file moves onto the
- * shared stage by swapping `integrationStack(import.meta.url)` for `sharedStack()` (no file
- * is migrated in this PR — only the sanity test reads it).
+ * Build the black-box `harness` over the RUN-SCOPED SHARED stage (ADR 0104 step 7, #1027) — the
+ * deploy-once counterpart to `integrationStack`. `_global-setup.ts` deploys ONE stage per run and
+ * `provide`s its handle, so this is a pure client over the injected values.
  *
- * `inject` resolves the values `globalSetup` provided; it throws if globalSetup didn't run
- * (the `integration` project wasn't selected), which is the correct failure for a file that
- * deploys nothing of its own.
+ * `inject` throws if globalSetup didn't run (the `integration` project wasn't selected), which is
+ * the correct failure for a file that deploys nothing of its own.
  */
 export function sharedStack(): Harness {
 	const d1 = inject("integrationD1");

--- a/apps/web/tests/integration/_request-stall.ts
+++ b/apps/web/tests/integration/_request-stall.ts
@@ -89,9 +89,7 @@ export const SAFE_STALL_REPLAYS = 1;
 const defaultSleep = (ms: number): Promise<void> => new Promise((r) => setTimeout(r, ms));
 
 export interface ConvergeOptions {
-	/** Total attempts at `send`, including the first (default 3). */
 	attempts?: number;
-	/** Base of the linear backoff between attempts, ms (default 400). */
 	backoffMs?: number;
 	/**
 	 * Which thrown failures the landed-probe recovers. Default: only a stall — a real error
@@ -99,7 +97,6 @@ export interface ConvergeOptions {
 	 * a duplicate write. A caller whose op is pure setup may widen it.
 	 */
 	recoverable?: (e: unknown) => boolean;
-	/** Injected for tests — real sleep by default. */
 	sleep?: (ms: number) => Promise<void>;
 }
 

--- a/apps/web/tests/integration/_request-stall.unit.test.ts
+++ b/apps/web/tests/integration/_request-stall.unit.test.ts
@@ -88,7 +88,7 @@ describe("convergeAfterStall", () => {
 		});
 		const landed = vi.fn(async () => "adopted" as string | undefined);
 		await expect(convergeAfterStall(send, landed, {sleep: noSleep})).resolves.toBe("adopted");
-		expect(send).toHaveBeenCalledTimes(1); // the stalled one only — never re-sent
+		expect(send).toHaveBeenCalledTimes(1);
 	});
 
 	it("RE-SENDS once the probe proves the write did not land", async () => {

--- a/apps/web/tests/integration/_stage-name.ts
+++ b/apps/web/tests/integration/_stage-name.ts
@@ -32,7 +32,6 @@ export const disc = (seed: string): string => {
 	return (h >>> 0).toString(36).padStart(DISC_LEN, "0").slice(0, DISC_LEN);
 };
 
-/** Sanitize a raw test-file basename to the `[a-z0-9-]` set with no leading/trailing dash. */
 export const slugify = (base: string): string =>
 	base
 		.toLowerCase()

--- a/apps/web/tests/integration/account-deletion.test.ts
+++ b/apps/web/tests/integration/account-deletion.test.ts
@@ -2,16 +2,7 @@
  * Account deletion = anonymize-to-`@[silinen]` (ADR 0097) — black-box against the
  * deployed worker `/fate` route on real remote D1 (ADR 0082 integration tier).
  *
- * Proves the end-to-end anonymize semantics a substituted seam can't reach:
- *   - **Content stays Live, re-attributed to `silinen`.** A deleted user's
- *     definition still lists on its term page after deletion (NOT removed); the
- *     `@[silinen]` profile's counters absorb the re-attributed content.
- *   - **Karma is KEPT.** The up-vote that scored the content is not reversed — the
- *     content keeps its score after the author's account is anonymized.
- *   - **Identity rows are gone.** The author's session no longer authenticates: a
- *     `me` read with the pre-deletion cookie returns `UNAUTHORIZED`.
- *   - **The typed confirmation gates the op.** A wrong/absent confirmation never
- *     deletes (the input fails validation); only the exact phrase fires it.
+ * Proves the end-to-end anonymize semantics a substituted seam can't reach.
  *
  * This file runs on the run-scoped SHARED stage (ADR 0104 step 7, #1027), so its one D1
  * is shared across every migrated file. Every email/slug/username this file seeds is `NS`-
@@ -62,7 +53,6 @@ describe("account.delete — anonymize-to-@[silinen]", () => {
 		const author = await h.signUpYazar(`${NS}-author@test.local`, "hunter2hunter2", "Author");
 		await setUsername(author.cookie, authorUsername);
 
-		// The author writes a definition; a distinct voter up-votes it (author karma → 1).
 		const termSlug = `${NS}-term`;
 		const added = await h.fate(
 			{
@@ -87,20 +77,18 @@ describe("account.delete — anonymize-to-@[silinen]", () => {
 		if (!vote.ok) return;
 		expect((vote.data as {score: number}).score).toBe(1);
 
-		// A wrong confirmation never deletes (input validation rejects it).
 		const wrong = await h.fate(
 			{kind: "mutation", name: "account.delete", input: {confirmation: "sil"}, select: ["deleted"]},
 			{cookie: author.cookie, retry: true},
 		);
 		expect(wrong.ok).toBe(false);
-		// The session is still alive after the rejected attempt — nothing was torn down.
+		// A rejected confirmation must tear nothing down: the session is still alive.
 		const stillMe = await h.fate(
 			{kind: "query", name: "me", select: ["id"]},
 			{cookie: author.cookie},
 		);
 		expect(stillMe.ok).toBe(true);
 
-		// The exact phrase fires the anonymization.
 		const del = await h.fate(
 			{
 				kind: "mutation",
@@ -113,7 +101,6 @@ describe("account.delete — anonymize-to-@[silinen]", () => {
 		expect(del.ok).toBe(true);
 		if (del.ok) expect((del.data as {deleted: boolean}).deleted).toBe(true);
 
-		// Identity torn down: the author's pre-deletion session no longer authenticates.
 		const goneMe = await h.fate(
 			{kind: "query", name: "me", select: ["id"]},
 			{cookie: author.cookie},
@@ -141,8 +128,6 @@ describe("account.delete — anonymize-to-@[silinen]", () => {
 			}
 		}
 
-		// The sentinel profile's live definition counter absorbed the re-attributed
-		// content (it now authors at least this one definition).
 		const silinenAfter = await h.fate({
 			kind: "query",
 			name: "profile",

--- a/apps/web/tests/integration/app.test.ts
+++ b/apps/web/tests/integration/app.test.ts
@@ -1,17 +1,9 @@
 /**
- * Compiled HTTP surface — black-box over the deployed worker (ADR 0027 Hono-free,
- * ADR 0082 two-tier). The retired `worker/http/app.test.ts` drove the *compiled*
- * `HttpRouter.toHttpEffect(makeAppLive(...))` over a `node:sqlite` D1 fake to prove
- * the router mounts every route group. That engine is banned; the same wiring is
- * proven here against real remote D1, asserting on the real `Response`.
+ * Compiled HTTP surface — black-box over the deployed worker (ADR 0027, ADR 0082).
  *
- * Routes whose mounting is already proven black-box elsewhere are NOT duplicated
- * here: `/api/health` (`flagship-binding.test.ts`), the `/fate` seam + anonymous
- * `me` UNAUTHORIZED gate (`seam.test.ts`), the authenticated `me` round-trip
- * (`pasaport.test.ts`), and `/fate/live` 401-without-session + the subscribe
- * control path (`fate-live.test.ts`). What stays is the route wiring NO other
- * integration file exercises: the RSS feed and the server-side flag-evaluation
- * seam (#510).
+ * Scope is only the route wiring NO other integration file exercises: the RSS feed and the
+ * server-side flag-evaluation seam (#510). `/api/health`, the `/fate` seam, the `me` round-trip
+ * and `/fate/live` are proven in their own files and are deliberately not duplicated here.
  *
  * This file runs on the run-scoped SHARED stage (ADR 0104 step 7, #1027), so its one D1
  * is shared with every migrated file. It isolates by NS: the email + post title it seeds
@@ -38,7 +30,6 @@ describe("RSS feed — /rss.xml over the deployed worker", () => {
 		expect(body).toContain('<rss version="2.0"');
 		expect(body).toContain("<channel>");
 		expect(body).toContain("</channel></rss>");
-		// the atom self-link points back at the feed's own absolute URL (request origin)
 		expect(body).toContain('rel="self"');
 	});
 
@@ -66,10 +57,8 @@ describe("RSS feed — /rss.xml over the deployed worker", () => {
 
 describe("server-side flag evaluation — /api/flags/* over the deployed worker (#510)", () => {
 	it("GET /api/flags/probe reads a flag through Flags and takes the safe-off branch", async () => {
-		// The probe route reads one boolean flag via the `Flags` domain service and
-		// branches on it. No flag is declared, so the dark-ship read returns the
-		// default (`false`) and the safe/off branch is taken — the infra→service→
-		// request slice serves end-to-end over real D1.
+		// No flag is declared, so the dark-ship read returns the default (`false`) and the safe/off
+		// branch is taken.
 		const res = await h.req("/api/flags/probe");
 		expect(res.status).toBe(200);
 		const body = (await res.json()) as {flag: string; enabled: boolean; branch: string};
@@ -78,10 +67,7 @@ describe("server-side flag evaluation — /api/flags/* over the deployed worker 
 	});
 
 	it("POST /api/flags/evaluate returns server-evaluated values per requested key", async () => {
-		// The SPA's delivery seam: the browser names keys + defaults, the worker
-		// evaluates each through `Flags` server-side and returns resolved booleans.
-		// Undeclared flags resolve to each call's own default — the safe-default
-		// contract, with the client never re-implementing eval.
+		// Undeclared flags resolve to each call's OWN default — the safe-default contract.
 		const res = await h.json("/api/flags/evaluate", {
 			keys: [
 				{key: "new-ui", default: false},

--- a/apps/web/tests/integration/content-removal-substrate.test.ts
+++ b/apps/web/tests/integration/content-removal-substrate.test.ts
@@ -2,19 +2,12 @@
  * The uniform removal substrate (ADR 0096) — black-box against the deployed
  * worker `/fate` route on real remote D1 (ADR 0082 integration tier).
  *
- * Proves the two substrate guarantees end to end, per entity type
- * (definition / post / comment):
- *   - **Remove → restore round-trip.** A removed entity disappears from public
- *     reads; restoring it brings the content back (reversibility, ADR 0096 §4).
- *   - **Karma is KEPT across removal.** An up-vote bumps the author's
- *     `total_karma`; removing the voted-on content does NOT reverse it (ADR 0096
- *     §3, the pano karma-reversal deleted). The score *cache* drops to 0 (votes
- *     wiped by `Vote.clearTarget`), but the author's karma credential is stable.
+ * Proves the two substrate guarantees per entity type (definition / post / comment):
+ * remove → restore reversibility (ADR 0096 §4), and karma KEPT across removal (§3 — the
+ * score cache drops to 0 as votes are wiped, but the author's karma credential is stable).
  *
- * This file runs on the run-scoped SHARED stage (ADR 0104 step 7, #1027), so its one D1 is
- * shared across every migrated file: every email/slug/username is prefixed with `NS` (this
- * file's deterministic `nsToken`) and karma is asserted per-author off the file's own
- * NS-username, so its rows are uniquely its own.
+ * Runs on the run-scoped SHARED stage (ADR 0104 step 7): every email/slug/username is
+ * `NS`-prefixed and karma is asserted per-author off this file's own NS-username.
  */
 import {beforeAll, describe, expect, it} from "vitest";
 import {sharedStack} from "./_integration.ts";
@@ -80,8 +73,8 @@ describe("removal substrate — definition remove → restore, karma kept", () =
 			return (res.data as ProfileNode).totalKarma;
 		};
 
-		// A distinct voter up-votes the definition → author karma 1. Promoted to yazar
-		// so it clears the #1810 "earn to vote" gate (a fresh çaylak is rejected at cast).
+		// Promoted to yazar so it clears the #1810 "earn to vote" gate (a fresh çaylak is
+		// rejected at cast).
 		const voter = await h.signUp(`${NS}-def-v@test.local`, "hunter2hunter2", "Voter");
 		await h.promoteToYazar(voter.userId);
 		const vote = await h.fate(
@@ -91,7 +84,6 @@ describe("removal substrate — definition remove → restore, karma kept", () =
 		expect(vote.ok).toBe(true);
 		expect(await karmaOf()).toBe(1);
 
-		// The term page lists the live definition.
 		const termBefore = await h.fate({
 			kind: "query",
 			name: "term",
@@ -103,14 +95,12 @@ describe("removal substrate — definition remove → restore, karma kept", () =
 			expect(definitionIds(termBefore.data)).toContain(definitionId);
 		}
 
-		// The author removes it.
 		const del = await h.fate(
 			{kind: "mutation", name: "definition.delete", input: {id: definitionId}, select: ["id"]},
 			{cookie: author.cookie},
 		);
 		expect(del.ok).toBe(true);
 
-		// Gone from the public term page…
 		const termAfter = await h.fate({
 			kind: "query",
 			name: "term",
@@ -122,10 +112,8 @@ describe("removal substrate — definition remove → restore, karma kept", () =
 			expect(definitionIds(termAfter.data)).not.toContain(definitionId);
 		}
 
-		// …but karma is KEPT (the upvote earned is not reversed by removal).
 		expect(await karmaOf()).toBe(1);
 
-		// Restore brings the definition back to the term.
 		const restored = await h.fate(
 			{kind: "mutation", name: "definition.restore", input: {id: definitionId}, select: ["id"]},
 			{cookie: author.cookie},
@@ -142,7 +130,6 @@ describe("removal substrate — definition remove → restore, karma kept", () =
 		if (termRestored.ok) {
 			expect(definitionIds(termRestored.data)).toContain(definitionId);
 		}
-		// Karma still 1 after the whole round-trip.
 		expect(await karmaOf()).toBe(1);
 	});
 });
@@ -191,16 +178,13 @@ describe("removal substrate — post remove → restore, karma kept", () => {
 		expect(vote.ok).toBe(true);
 		expect(await karmaOf()).toBe(1);
 
-		// Remove the post.
 		const del = await h.fate(
 			{kind: "mutation", name: "post.delete", input: {id: postId}, select: ["id"]},
 			{cookie: author.cookie},
 		);
 		expect(del.ok).toBe(true);
 
-		// The post is no longer publicly resolvable — a removed post reads as null
-		// on the normal path (ADR 0096 §1/§5: filtered from public reads), exactly
-		// like an unknown id (pano-read.test.ts "returns null for an unknown id").
+		// A removed post reads as null, exactly like an unknown id (ADR 0096 §1/§5).
 		const gone = await h.fate({
 			kind: "query",
 			name: "post",
@@ -210,10 +194,8 @@ describe("removal substrate — post remove → restore, karma kept", () => {
 		expect(gone.ok).toBe(true);
 		if (gone.ok) expect(gone.data).toBeNull();
 
-		// …karma KEPT.
 		expect(await karmaOf()).toBe(1);
 
-		// Restore re-resolves the post.
 		const restored = await h.fate(
 			{kind: "mutation", name: "post.restore", input: {id: postId}, select: ["id"]},
 			{cookie: author.cookie},
@@ -239,7 +221,6 @@ describe("removal substrate — comment remove → restore, karma kept", () => {
 		const author = await h.signUpYazar(`${NS}-cmt@test.local`, "hunter2hunter2", "Cmt Author");
 		await setUsername(author.cookie, authorUsername);
 
-		// A post to hang the comment on.
 		const submitted = await h.fate(
 			{
 				kind: "mutation",
@@ -299,16 +280,13 @@ describe("removal substrate — comment remove → restore, karma kept", () => {
 				select: ["comments.id"],
 			});
 			if (!res.ok) throw new Error("post read failed");
-			// `comments` is a paginated connection (`{items: [{node}]}`), not a bare
-			// array — same shape as pano-comments.test.ts.
+			// `comments` is a paginated connection (`{items: [{node}]}`), not a bare array.
 			const data = res.data as {comments?: Connection<{id: string}>} | null;
 			return (data?.comments?.items ?? []).map((e) => e.node.id);
 		};
 
-		// Live leaf comment is in the thread.
 		expect(await commentIdsOf()).toContain(commentId);
 
-		// Remove it (leaf → drops out of the thread).
 		const del = await h.fate(
 			{kind: "mutation", name: "comment.delete", input: {id: commentId}, select: ["id"]},
 			{cookie: author.cookie},
@@ -316,10 +294,8 @@ describe("removal substrate — comment remove → restore, karma kept", () => {
 		expect(del.ok).toBe(true);
 		expect(await commentIdsOf()).not.toContain(commentId);
 
-		// Karma KEPT across the comment removal.
 		expect(await karmaOf()).toBe(1);
 
-		// Restore re-appends the comment to the thread.
 		const restored = await h.fate(
 			{kind: "mutation", name: "comment.restore", input: {id: commentId}, select: ["id"]},
 			{cookie: author.cookie},

--- a/apps/web/tests/integration/display-name-convergence.test.ts
+++ b/apps/web/tests/integration/display-name-convergence.test.ts
@@ -8,17 +8,6 @@
  * `display_name` was written only once — at `setUsername`-time — so a later rename
  * never reached the stamped column and every byline showed a stale snapshot.
  *
- * The proof walks the full wire path a substituted seam can't reach:
- *   1. an author sets a username (stamps `display_name = user.name` at that instant),
- *   2. writes a definition,
- *   3. renames via `user.setDisplayName`,
- *   4. re-reads the definition byline (`authorDisplayName`) off its term page and
- *      asserts it is the NEW name — the live-resolve convergence.
- *
- * Fails WITHOUT the write-through: the old `authClient.updateUser` path touched only
- * `user.name`, so `authorDisplayName` would stay pinned to the setUsername-time
- * snapshot and step 4 would read the OLD name.
- *
  * Runs on the run-scoped SHARED stage (ADR 0104 step 7): every email/username/slug is
  * `NS`-prefixed (this file's `nsToken`) and every assertion scopes to this file's own
  * rows (the byline is read off the exact definition id the seed returned), so it holds
@@ -117,12 +106,10 @@ describe("user.setDisplayName — a rename reaches the stamped author byline (#2
 		if (!added.ok) return;
 		const definitionId = (added.data as {id: string}).id;
 
-		// Baseline: the byline resolves the setUsername-time display name ("Eski Ad").
 		const before = await readByline(termSlug, definitionId);
 		expect(before?.authorDisplayName).toBe("Eski Ad");
 		expect(before?.authorUsername).toBe(authorUsername);
 
-		// The görünen-ad change — the write-through under test.
 		const renamed = await h.fate(
 			{
 				kind: "mutation",
@@ -135,9 +122,6 @@ describe("user.setDisplayName — a rename reaches the stamped author byline (#2
 		expect(renamed.ok).toBe(true);
 		if (renamed.ok) expect((renamed.data as {name: string | null}).name).toBe("Yeni Ad");
 
-		// Convergence: the SAME byline now resolves the NEW display name — the stamped
-		// column was re-synced, not frozen at setUsername-time. This is the assertion
-		// that fails without the write-through.
 		const after = await readByline(termSlug, definitionId);
 		expect(after?.authorDisplayName).toBe("Yeni Ad");
 		expect(after?.authorUsername).toBe(authorUsername);

--- a/apps/web/tests/integration/fate-live-bildirim.test.ts
+++ b/apps/web/tests/integration/fate-live-bildirim.test.ts
@@ -1,28 +1,17 @@
 /**
- * Live bildirim delivery over SSE (#1700, epic #1666) — the notification twin of the
- * reaction-count fan-out (`fate-live-reactions.test.ts`), proven end-to-end: a
- * recipient subscribed to their own `NotificationChannel` entity receives the fresh
- * unread count the moment another user's action records a notification, so the badge +
- * center reconcile without a refresh (AC1/AC2/AC4). The cross-user case proves the
- * recipient-scoping AC (AC3): a subscription to ANOTHER user's channel is rejected at
- * the topic-authorization seam (`fate-live/route.ts`), so no user watches another's
- * notification stream.
+ * Live bildirim delivery over SSE (#1700, epic #1666): a recipient subscribed to their
+ * own `NotificationChannel` gets the fresh unread count live, and a subscription to
+ * ANOTHER user's channel is refused at the topic-authorization seam.
  *
- * Runs on the run-scoped SHARED stage (ADR 0104 step 7, #1027) — shared-safe like the
- * reactions case: the notification publish is an ENTITY `update` on the recipient's
- * `NotificationChannel:<recipientId>` topic, and a per-file NS-unique recipient makes
- * that entity topic unique to this file, so a concurrent file's write can't land a
- * frame on this subscription.
+ * Runs on the run-scoped SHARED stage (ADR 0104 step 7, #1027) — shared-safe because
+ * the publish is an ENTITY `update` on `NotificationChannel:<recipientId>` and the
+ * per-file NS-unique recipient makes that topic unique to this file.
  *
- * FLAG GATING. The whole bildirim surface (including this live path) ships dark behind
- * the default-off `phoenix-bildirim` flag: with it off nothing records and nothing
- * publishes. The integration stage runs `ENVIRONMENT=development`, so the dev-only
- * override wrapper (#622) is installed — this test flips the flag on for its own
- * requests via the `phoenix_flag_overrides` cookie. The default-off gate is proven at
- * the unit tier; here we drive the flag-ON live path the override unlocks.
- *
- * The notification is triggered through the PUBLIC seam — a `comment.add` reply to a
- * post notifies the post's author (`notifyCommentReply`) — the same seam the app uses.
+ * FLAG GATING. The bildirim surface ships dark behind the default-off
+ * `phoenix-bildirim` flag: with it off nothing records and nothing publishes. The
+ * integration stage runs `ENVIRONMENT=development`, so the dev-only override wrapper
+ * (#622) is installed and this test flips the flag on for its own requests via the
+ * `phoenix_flag_overrides` cookie. The default-off gate is proven at the unit tier.
  */
 import {beforeAll, describe, expect, it} from "vitest";
 import {frameData, readEvent, readFrame} from "./_harness.ts";
@@ -54,7 +43,6 @@ beforeAll(async () => {
 
 describe("live views — /fate/live (bildirim delivery)", () => {
 	it("subscribe(channel) → a reply to my post → the unread count arrives live", async () => {
-		// The author submits a post; a reply to it records a notification for the author.
 		// `post.submit`'s wire input requires a non-empty `tags` array (`SubmitPostInput`,
 		// `pano/mutations.ts`) and the service rejects an empty tag list with `TagsRequired`
 		// before any DB call (`normalizeSubmitTags`, `pano/post-operations.ts`) — so a
@@ -77,7 +65,7 @@ describe("live views — /fate/live (bildirim delivery)", () => {
 		// for the reply that records the notification; assert its id on the DIRECT response so
 		// a rejected submit (missing/invalid tags, unauth) fails HERE with a named cause in
 		// milliseconds instead of masquerading as a lost-frame delivery timeout downstream.
-		// See ADR: integration-tier-is-ci-only.
+		// See ADR 0154.
 		const postId = (posted.ok ? (posted.data as {id: string}).id : "") as string;
 		expect(
 			postId,
@@ -96,10 +84,6 @@ describe("live views — /fate/live (bildirim delivery)", () => {
 		const connected = await readFrame(reader, decoder, buffer);
 		expect(connected).toContain("connected");
 
-		// Subscribe to the author's OWN NotificationChannel entity — the exact topic
-		// `Notification.record → live.update("NotificationChannel", recipientId, …)`
-		// republishes the unread count to. The id is the author's own user id (the
-		// recipient-scoping the route enforces).
 		const sub = await h.liveControl(
 			connectionId,
 			[
@@ -117,9 +101,6 @@ describe("live views — /fate/live (bildirim delivery)", () => {
 		const subResult = (await sub.json()) as {results: Array<{id: string; ok: boolean}>};
 		expect(subResult.results[0]?.ok).toBe(true);
 
-		// The commenter replies to the author's post — the flag-override cookie unlocks
-		// the dark-shipped record + live-publish path; recording the notification
-		// republishes the author's channel with the fresh unread count.
 		const replied = await h.fate(
 			{
 				kind: "mutation",
@@ -131,10 +112,8 @@ describe("live views — /fate/live (bildirim delivery)", () => {
 		);
 		expect(replied.ok).toBe(true);
 
-		// The subscribed stream delivers the channel update as an entity `next` frame
-		// whose `event.data` carries the author's fresh unread count. Drain until our
-		// own channel frame (unreadCount >= 1) arrives, racing a 10s deadline so a lost
-		// publish fails here in ~10s rather than the full test budget.
+		// Drain until our own channel frame arrives, racing a 10s deadline so a lost
+		// publish fails here rather than eating the full test budget.
 		type ChannelNext = {kind: string; event: {data: {id: string; unreadCount: number}}};
 		const READ_DEADLINE_MS = 10_000;
 		let deadlineTimer: ReturnType<typeof setTimeout> | undefined;
@@ -190,7 +169,6 @@ describe("live views — /fate/live (bildirim delivery)", () => {
 		);
 		expect(sub.status).toBe(200);
 		const subResult = (await sub.json()) as {results: Array<{id: string; ok: boolean}>};
-		// The cross-user subscribe is refused at the topic-authorization seam.
 		expect(subResult.results[0]?.ok).toBe(false);
 
 		await reader.cancel();

--- a/apps/web/tests/integration/fate-live-owner-fence.test.ts
+++ b/apps/web/tests/integration/fate-live-owner-fence.test.ts
@@ -2,17 +2,11 @@
  * Live views over SSE — the owner-isolation fence on OPEN (#2563), on the run-scoped
  * SHARED stage (ADR 0104 step 7, #1027).
  *
- * The invariant `subscribe` already enforces (a control message can't act on another
- * user's connection) was ABSENT on the open path: any authenticated session that
- * re-opened a `connectionId` already held by someone else reset that holder's stream
- * (generation bump + subscription clear + stream teardown). This proves the fence: a
- * foreign session opening the holder's `connectionId` is refused (403) and the holder's
- * live subscription keeps delivering.
- *
- * Shared-safe: the `definition.add` publishes to the ARGS-scoped `Term.definitions`
- * connection keyed on an `NS`-unique slug (never the global wildcard — `protocol.ts`),
- * so a concurrent file's `definition.add` can't land a frame on this subscription (the
- * same isolation `fate-live-scoped.test.ts` documents).
+ * The invariant `subscribe` already enforces (a control message can't act on another user's
+ * connection) was ABSENT on the open path: re-opening someone else's `connectionId` reset
+ * their stream. Shared-safe because `definition.add` publishes to the ARGS-scoped
+ * `Term.definitions` connection keyed on an `NS`-unique slug, never the global wildcard, so
+ * a concurrent file's `definition.add` can't land a frame on this subscription.
  */
 import {beforeAll, describe, expect, it} from "vitest";
 import {frameData, readEvent, readFrame} from "./_harness.ts";
@@ -37,7 +31,6 @@ describe("live views — /fate/live owner-isolation fence (#2563)", () => {
 		const slug = `${NS}-term-${Date.now()}`;
 		const connectionId = `${NS}-conn-${Date.now()}`;
 
-		// Alice opens and holds the SSE stream, subscribed to an args-scoped topic.
 		const connect = await h.openSse(connectionId, alice.cookie);
 		expect(connect.status).toBe(200);
 		const reader = connect.body!.getReader();
@@ -61,9 +54,8 @@ describe("live views — /fate/live owner-isolation fence (#2563)", () => {
 		);
 		expect(sub.status).toBe(200);
 
-		// Mallory (a DIFFERENT session user) opens the SAME connectionId. The DO is warm
-		// (Alice holds it), so the owner fence answers at once — drive it through `req`,
-		// not the ready-poll `openSse`, so the expected non-200 returns immediately
+		// The DO is warm (Alice holds it), so the fence answers at once — drive it through
+		// `req`, not the ready-poll `openSse`, so the expected non-200 returns immediately
 		// instead of riding the readiness budget.
 		const hostile = await h.req(`/fate/live?connectionId=${encodeURIComponent(connectionId)}`, {
 			headers: {accept: "text/event-stream", cookie: mallory.cookie},
@@ -71,9 +63,8 @@ describe("live views — /fate/live owner-isolation fence (#2563)", () => {
 		expect(hostile.status).toBe(403);
 		await hostile.body?.cancel();
 
-		// Alice's stream was not torn down: her subscription still delivers. Without the
-		// fence, Mallory's open would have bumped the generation and cleared Alice's
-		// subscriptions, so this `appendNode` would never arrive.
+		// Without the fence, Mallory's open would have bumped the generation and cleared
+		// Alice's subscriptions, so this `appendNode` would never arrive.
 		const added = await h.fate(
 			{
 				kind: "mutation",

--- a/apps/web/tests/integration/fate-live-posts.test.ts
+++ b/apps/web/tests/integration/fate-live-posts.test.ts
@@ -48,8 +48,6 @@ describe("live views — /fate/live (global topic:posts)", () => {
 		const connected = await readFrame(reader, decoder, buffer);
 		expect(connected).toContain("connected");
 
-		// Subscribe the connection to the global `posts` connection feed. The first
-		// subscribe hits a cold topic-role DO; the worker seam absorbs the warm window.
 		const sub = await h.liveControl(
 			connectionId,
 			[
@@ -65,7 +63,6 @@ describe("live views — /fate/live (global topic:posts)", () => {
 		);
 		expect(sub.status).toBe(200);
 
-		// A new post publishes a prependNode frame to the `posts` connection topic.
 		const submitted = await h.fate(
 			{
 				kind: "mutation",
@@ -77,14 +74,8 @@ describe("live views — /fate/live (global topic:posts)", () => {
 		);
 		expect(submitted.ok).toBe(true);
 
-		// Read until THIS case's own frame arrives. Both cases publish to the ONE global
-		// `posts` topic DO on this shared dedicated stage, so a buffered cross-epoch frame
-		// (a prior run/epoch's prependNode) can be the next frame — the worker does not
-		// epoch-fence old-epoch frames for real clients (the deeper correctness question is
-		// #1072, which stays open). Asserting the very NEXT frame is `live post` is fragile
-		// against such a buffered foreign frame; instead drain frames until we see our OWN
-		// `live post` prependNode, mirroring the reconnect case below. Bounded: a stream that
-		// never delivers `live post` still fails.
+		// Drain to our OWN frame, never the next one: a buffered cross-epoch frame can arrive
+		// first (file header, #1072). Bounded — a stream that never delivers still fails.
 		let payload: {kind: string; event: {type: string; edge: {node: {title: string}}}} | undefined;
 		for (let i = 0; i < 10 && payload?.event.edge.node.title !== "live post"; i++) {
 			const frame = await readEvent(reader, decoder, buffer);
@@ -103,12 +94,11 @@ describe("live views — /fate/live (global topic:posts)", () => {
 	it("reconnect on the same connectionId bumps epoch — frames go to the reconnected stream", async () => {
 		const connectionId = `live-regen-${Date.now()}`;
 
-		// First stream + subscription.
 		const first = await h.openSse(connectionId, user.cookie);
 		const firstReader = first.body!.getReader();
 		const decoder = new TextDecoder();
 		const firstBuf = {value: ""};
-		await readFrame(firstReader, decoder, firstBuf); // : connected
+		await readFrame(firstReader, decoder, firstBuf);
 		await h.liveControl(
 			connectionId,
 			[{kind: "subscribeConnection", id: "sub-a", type: "Post", procedure: "posts", select: []}],
@@ -120,14 +110,13 @@ describe("live views — /fate/live (global topic:posts)", () => {
 		const second = await h.openSse(connectionId, user.cookie);
 		const secondReader = second.body!.getReader();
 		const secondBuf = {value: ""};
-		await readFrame(secondReader, decoder, secondBuf); // : connected
+		await readFrame(secondReader, decoder, secondBuf);
 		await h.liveControl(
 			connectionId,
 			[{kind: "subscribeConnection", id: "sub-b", type: "Post", procedure: "posts", select: []}],
 			user.cookie,
 		);
 
-		// Publish — the reconnected (current-epoch) stream must receive it.
 		const submitted = await h.fate(
 			{
 				kind: "mutation",
@@ -139,14 +128,8 @@ describe("live views — /fate/live (global topic:posts)", () => {
 		);
 		expect(submitted.ok).toBe(true);
 
-		// Read until THIS case's own frame arrives. Both cases publish to the ONE global
-		// `posts` topic DO on this shared dedicated stage, so the prior `post.submit` case's
-		// `live post` prependNode can still be buffered on this stream — the worker does not
-		// epoch-fence old-epoch frames for real clients (the deeper correctness question is
-		// #1072, which stays open). Asserting the very NEXT frame would read that stale frame;
-		// instead drain prior-title frames until we see `regen post`, which preserves the
-		// intent — the reconnected (current-epoch) stream DOES deliver the new frame — without
-		// reading a leaked one. Bounded: a stream that never delivers `regen post` still fails.
+		// Drain to our OWN frame, never the next one: the prior case's `live post` can still be
+		// buffered here (file header, #1072). Bounded — a stream that never delivers still fails.
 		let title: string | undefined;
 		for (let i = 0; i < 10 && title !== "regen post"; i++) {
 			const frame = await readEvent(secondReader, decoder, secondBuf);

--- a/apps/web/tests/integration/fate-live-reactions.test.ts
+++ b/apps/web/tests/integration/fate-live-reactions.test.ts
@@ -68,8 +68,6 @@ describe("live views — /fate/live (reaction-count reconcile)", () => {
 		const connected = await readFrame(reader, decoder, buffer);
 		expect(connected).toContain("connected");
 
-		// Subscribe to the single definition ENTITY — the exact topic
-		// `live.definition.update(id, …)` publishes the reaction-count delta to.
 		const sub = await h.liveControl(
 			connectionId,
 			[
@@ -92,9 +90,7 @@ describe("live views — /fate/live (reaction-count reconcile)", () => {
 		const subResult = (await sub.json()) as {results: Array<{id: string; ok: boolean}>};
 		expect(subResult.results[0]?.ok).toBe(true);
 
-		// React on the definition — the flag-override cookie unlocks the dark-shipped
-		// write + live-publish path; the mutation publishes an entity `update` frame
-		// carrying the fresh per-emoji aggregate to the subscribed connection.
+		// The flag-override cookie unlocks the dark-shipped write + live-publish path.
 		const reacted = await h.fate(
 			{
 				kind: "mutation",

--- a/apps/web/tests/integration/fate-live-scoped.test.ts
+++ b/apps/web/tests/integration/fate-live-scoped.test.ts
@@ -44,10 +44,6 @@ describe("live views — /fate/live (args-scoped)", () => {
 	});
 
 	it("subscribe → definition.add → appendNode arrives — the LivePublisher path end-to-end", async () => {
-		// `definition.add` is a `Fate.mutation`: its publish goes through the
-		// per-request `LivePublisher` value (worker `livePublisherFor`) — this case
-		// proves that surface reaches a subscribed connection through the deployed
-		// DO fan-out.
 		const slug = `${NS}-term-${Date.now()}`;
 		const connectionId = `${NS}-sozluk-${Date.now()}`;
 		const connect = await h.openSse(connectionId, user.cookie);
@@ -59,8 +55,6 @@ describe("live views — /fate/live (args-scoped)", () => {
 		const connected = await readFrame(reader, decoder, buffer);
 		expect(connected).toContain("connected");
 
-		// Subscribe to the ARGS-scoped `Term.definitions` connection for this slug —
-		// the exact topic the mutation's `live.topic(..., {id: slug})` publishes to.
 		const sub = await h.liveControl(
 			connectionId,
 			[

--- a/apps/web/tests/integration/flagship-binding.test.ts
+++ b/apps/web/tests/integration/flagship-binding.test.ts
@@ -1,21 +1,10 @@
 /**
- * Flagship binding — system-tier proof (epic #488, child #507) + the Flag
- * schema-drift PUT-skip patch pin (#3049).
+ * Flagship binding — system-tier proof (#507) + the Flag schema-drift PUT-skip patch pin (#3049).
  *
- * The first describe deploys the real alchemy stack (with the `FlagshipApp`
- * resource declared and `bind()`-resolved in the worker init) to a local workerd
- * and asserts black-box over HTTP. `/api/health` drives one boolean evaluation
- * through the resolved `FlagshipClient`; the read completing at all proves the
- * binding resolved end-to-end through the worker, so the probe reports
- * `flagshipReachable: true` — the system-tier check #507 calls for. The field
- * asserts reachability of the binding, not the value of any feature flag.
+ * `flagshipReachable` asserts the binding resolved, not the value of any feature flag.
  *
- * This file runs on the run-scoped SHARED stage (ADR 0104 step 7, #1027) and needs no
- * namespace token: it is read-only against a deploy-time binding, seeding no data and
- * reading no per-test rows, so there is nothing to collide on the shared DB.
- *
- * The second describe is a hermetic patch pin (below) — it stands up no worker,
- * driving the patched `FlagProvider` reconcile directly against a mock HTTP client.
+ * Runs on the run-scoped SHARED stage (ADR 0104 step 7) with no namespace token: read-only against
+ * a deploy-time binding, seeding no data and reading no per-test rows, so nothing can collide.
  */
 import {fromApiToken} from "@distilled.cloud/cloudflare/Credentials";
 import * as Cloudflare from "alchemy/Cloudflare";
@@ -35,7 +24,6 @@ describe("Flagship binding — /api/health", () => {
 		expect(res.status).toBe(200);
 		const body = (await res.json()) as {status: string; flagshipReachable: boolean};
 		expect(body.status).toBe("ok");
-		// an evaluation returned through the binding ⇒ the client resolved end-to-end
 		expect(body.flagshipReachable).toBe(true);
 	});
 });
@@ -43,17 +31,10 @@ describe("Flagship binding — /api/health", () => {
 // @patch-pin: alchemy@2.0.0-beta.59
 //
 // Pins the Flag schema-drift PUT-skip hunk of `patches/alchemy@2.0.0-beta.59.patch`
-// (`lib/Cloudflare/Flagship/Flag.js` FlagProvider reconcile, ADR 0106). The patch
-// narrows what IaC reconciles: it diffs ONLY the schema/metadata it owns
-// (`{variations, description}`); the serving config (`defaultVariation`, `rules`,
-// `enabled`) is dashboard-owned and carried forward from live, never reconciled.
-// Concretely — a serving-only drift skips the PUT (dashboard-owned serving
-// preserved); a schema drift PUTs the desired schema with live serving preserved.
+// (`lib/Cloudflare/Flagship/Flag.js` FlagProvider reconcile) — ADR 0106.
 //
-// The pin drives the real patched reconcile with a mock HTTP client, so it exercises
-// the actual code path (not a re-derived predicate). It reds if the reconcile reverts
-// to the pre-patch full-shape diff: the pre-patch code compared the whole serving
-// shape (so a serving-only drift would send a PUT) and sent `{...desired}` (so the
+// Reds if the reconcile reverts to the pre-patch full-shape diff: the pre-patch code compared the
+// whole serving shape (so a serving-only drift would send a PUT) and sent `{...desired}` (so the
 // PUT would carry desired serving, not live) — both assertions below would fail.
 
 const ACCOUNT_ID = "acct-pin";
@@ -106,9 +87,6 @@ function driveReconcile(news: Record<string, unknown>): Promise<CapturedRequest[
 		);
 	});
 
-	// The three services reconcile resolves at runtime (HTTP client, credentials,
-	// account) are independent of each other, so they merge in parallel; the provider
-	// layer sits on top via provideMerge (it declares them as requirements).
 	const layer = Cloudflare.Flagship.FlagProvider().pipe(
 		Layer.provideMerge(
 			Layer.mergeAll(
@@ -170,7 +148,6 @@ describe("Flag reconcile — dashboard-owned serving preserved (ADR 0106)", () =
 		expect(put).toBeDefined();
 		const body = put?.body ?? {};
 
-		// IaC owns the schema/metadata — the desired values are sent.
 		expect(body.variations).toEqual({off: false, on: true, maybe: "maybe"});
 		expect(body.description).toBe("desired-desc");
 

--- a/apps/web/tests/integration/fts-backfill-restore.test.ts
+++ b/apps/web/tests/integration/fts-backfill-restore.test.ts
@@ -12,15 +12,8 @@
  * stage. `integrationStack` gives it an isolated D1 (ADR 0104), so the wipe is
  * scoped to this file's rows.
  *
- * What it pins beyond #645, closing #2754's acceptance criteria against the REAL
- * D1 FTS5 engine (≠ `node:sqlite`'s, so an integration-tier fact per ADR 0082):
- *   - row counts: the bin reports ≥1 term AND ≥1 post re-indexed;
- *   - exact MATCH: a full folded token finds the rebuilt term and post;
- *   - prefix MATCH: a 3–4 char prefix finds them too — proving the `prefix='2 3 4'`
- *     index (`0002_search_fts.sql`) is reconstructed from base rows, not just the
- *     full-token postings.
- * The pre-backfill empty-search assertion is the non-vacuity guard: a post-run hit
- * can only be the backfill's doing, never a surviving index row.
+ * It runs against the REAL D1 FTS5 engine, which is not `node:sqlite`'s — so every
+ * fact here is integration-tier per ADR 0082.
  */
 import {execFile} from "node:child_process";
 import {join} from "node:path";
@@ -126,7 +119,6 @@ describe("fts-backfill rebuilds the whole FTS index from restored base rows (#27
 		expect(Number(terms?.[1])).toBeGreaterThanOrEqual(1);
 		expect(Number(posts?.[1])).toBeGreaterThanOrEqual(1);
 
-		// Exact MATCH: a full folded token finds each rebuilt row.
 		expect(await searchTermSlugs(TERM_EXACT)).toContain(TERM_SLUG);
 		expect(await searchPostIds(POST_EXACT)).toContain(postId);
 

--- a/apps/web/tests/integration/fts-backfill.test.ts
+++ b/apps/web/tests/integration/fts-backfill.test.ts
@@ -2,14 +2,11 @@
  * fts-backfill → FTS5 MATCH loop on real D1 (#645, the integration-tier proof ADR
  * 0082 §irreducible-integration names for the write→sync→read dual-write loop).
  *
- * `@kampus/fts-backfill`'s pure core is unit-tested (`buildBackfillStatements`,
- * #534) — byte-correct statements against `SQLiteDialect`, no DB. That proves
- * what the backfill *writes*, never that a backfilled row is *findable* by a query
- * that folds the same way on D1's FTS5 (≠ `node:sqlite`'s). This test runs the REAL
- * shipped bin (`fts-backfill run --database-id <id> --account-id <acct>`) as a
- * subprocess against this file's real remote D1, then asserts `Search.ts`'s
- * `searchTerms` resolver returns the backfilled row for a Turkish-diacritic-folded
- * query — proving backfill → sync → FTS5 MATCH → bm25 end to end (ADR 0080 folding).
+ * The pure core is unit-tested (`buildBackfillStatements`, #534), which proves what
+ * the backfill *writes*, never that a backfilled row is *findable* by a query that
+ * folds the same way on D1's FTS5 (≠ `node:sqlite`'s). So this runs the real shipped
+ * bin as a subprocess against real remote D1, then reads back through `searchTerms`
+ * for a Turkish-diacritic-folded query (ADR 0080 folding).
  *
  * Spawning the bin (not library-importing `backfill()`) is deliberate: it exercises
  * the actual production entrypoint AND keeps `apps/web` from depending on
@@ -33,8 +30,7 @@ import {integrationStack} from "./_integration.ts";
 
 const execFileAsync = promisify(execFile);
 
-// The shipped bin's absolute path — `apps/web/tests/integration/` → repo root is
-// four levels up; the bin is the production CLI entrypoint, run the exact way
+// The production CLI entrypoint, run the exact way
 // `pnpm --filter @kampus/fts-backfill backfill` runs it (`node src/bin.ts run`).
 const BIN_PATH = join(import.meta.dirname, "../../../../packages/fts-backfill/src/bin.ts");
 
@@ -51,8 +47,6 @@ const FOLDED_QUERY = "sisli";
 
 beforeAll(async () => {
 	await h.signUpYazar(`${SLUG}-author@test.local`, "hunter2hunter2", "anka");
-	// Seed through the public dual-write: a real term_record row + its term_search
-	// FTS row land together.
 	await h.seedTerm({
 		slug: SLUG,
 		title: TITLE,
@@ -79,24 +73,17 @@ describe("fts-backfill → FTS5 MATCH on real D1 (#645)", () => {
 			expect(items.some((e) => e.node.slug === SLUG)).toBe(false);
 		}
 
-		// Run the REAL backfill: spawn the shipped bin against this stage's real D1,
-		// passing the resolved `{accountId, databaseId}` as flags. The bin reads
-		// `$CLOUDFLARE_API_TOKEN` from the inherited env (CI secret) — exactly how the
-		// one-time prod data-op runs. A non-zero exit throws and fails the test.
 		const {accountId, databaseId} = await h.d1Target();
 		const {stdout} = await execFileAsync(
 			process.execPath,
 			[BIN_PATH, "run", "--database-id", databaseId, "--account-id", accountId],
 			{env: process.env},
 		);
-		// The bin reports how many term rows it re-indexed; the seeded term is among
-		// them (the backfill scans the whole corpus, so assert it re-indexed ≥ 1).
+		// The backfill scans the whole corpus, so the count is ≥ 1, never exactly 1.
 		const reported = stdout.match(/re-indexed (\d+) term/);
 		expect(reported, `bin output did not report a term count:\n${stdout}`).not.toBeNull();
 		expect(Number(reported?.[1])).toBeGreaterThanOrEqual(1);
 
-		// The loop's payoff: the folded query now MATCHes the backfilled row via the
-		// live resolver — backfill → sync → FTS5 MATCH → bm25, proven on real D1.
 		const after = await h.fate({
 			kind: "list",
 			name: "searchTerms",

--- a/apps/web/tests/integration/kunye-admin-seam.test.ts
+++ b/apps/web/tests/integration/kunye-admin-seam.test.ts
@@ -39,7 +39,6 @@ const RANDO = `${NS}-rando`;
 // `d1` is the one binding both sides share: the admin-grant write path drizzles its
 // own schema slice over it, the worker read path drizzles the full schema over it.
 let d1: D1Database;
-// Discharge `Admin.over(platform)` for a subject over the SAME D1, to an Exit.
 let discharge: (subject: string) => Promise<Exit.Exit<Grant<Admin>, Denied>>;
 
 // Seed the user row the admin-grant selector resolves against (the grant resolves the

--- a/apps/web/tests/integration/kunye-moderate-seam.test.ts
+++ b/apps/web/tests/integration/kunye-moderate-seam.test.ts
@@ -7,14 +7,12 @@
  * `RelationStoreLive` + `AgentAuthorityV1`) is run against the SAME D1 — so a
  * seeded founder mints a `Grant` and a non-founder is denied the invisible `Denied`.
  *
- * Crossing the two packages' object encodings on one real table is exactly what
- * catches a key divergence (the bug this seam closes: a bare `"platform"` write key
- * vs a `type:id` read key); a single-side unit test cannot. Both sides resolve the
- * object through `@kampus/authz`'s canonical `key(platform)`, so they cannot drift.
+ * Crossing the two packages' object encodings on one real table is what catches a
+ * key divergence (the bug this closes: a bare `"platform"` write key vs a `type:id`
+ * read key); a single-side unit test cannot.
  *
- * Runs on the run-scoped SHARED stage (ADR 0104 step 7); every id is `NS`-prefixed
- * (this file's deterministic token) to keep its rows its own, and the seeded
- * founder/tuple are cleaned up after each test.
+ * Runs on the run-scoped SHARED stage (ADR 0104 step 7), so every id is
+ * `NS`-prefixed to keep this file's rows its own.
  */
 import {CurrentActor, type Grant, human, isGrant, platform} from "@kampus/authz";
 import {makeSeedDb, seedFounders} from "@kampus/founder-seed";
@@ -38,7 +36,6 @@ const RANDO = `${NS}-rando`;
 // `d1` is the one binding both sides share: the founder-seed write path drizzles its
 // own schema slice over it, the worker read path drizzles the full schema over it.
 let d1: D1Database;
-// Discharge `Moderate.over(platform)` for a subject over the SAME D1, to an Exit.
 let discharge: (subject: string) => Promise<Exit.Exit<Grant<Moderate>, Denied>>;
 
 const seedFounderUser = (id: string) =>

--- a/apps/web/tests/integration/kunye-relation-store.test.ts
+++ b/apps/web/tests/integration/kunye-relation-store.test.ts
@@ -2,10 +2,8 @@
  * `RelationStoreLive` against **real remote Cloudflare D1** (ADR 0082 integration
  * tier) — runs the production `has` lookup over the shipped REST transport
  * (`makeD1Rest` + `createDrizzle`, the worker's path) against this run's migrated D1
- * (incl. `0010_relation_tuple`), asserting the store's only-wrong-if-the-DB-differs
- * facts: the composite-PK existence read resolves a seeded `(subject, relation,
- * object)` tuple, a non-matching tuple reads absent, and a removed tuple denies on the
- * very next call (fresh per call, no cached authority — ADR 0107). The pure boolean
+ * (incl. `0010_relation_tuple`), asserting only the facts that are wrong if the DB
+ * differs — authority is fresh per call, never cached (ADR 0107). The pure boolean
  * mapping + statement shape stay in the unit tier (`worker/features/kunye/`).
  *
  * The store has no fate/HTTP surface (the `Moderate`/`Admin` consumers are a later

--- a/apps/web/tests/integration/pano-base-feed.test.ts
+++ b/apps/web/tests/integration/pano-base-feed.test.ts
@@ -2,16 +2,6 @@
  * pano base feed / viewer overlay split (#2322, epic #2316 leg B) — black-box against
  * the deployed worker (ADR 0026–0031, ADR 0082).
  *
- * Proves the leg-B server split:
- *   1. The `GET /fate/pano/feed` base feed is served with `sort`/`host`/pagination in
- *      the URL, carries NO viewer-scoped field, and is BYTE-IDENTICAL for an anonymous
- *      request and a signed-in one — the whole point of a viewer-invariant, cacheable
- *      base. An anon GET succeeds with no session (and the response sets no cookie), so
- *      it does no session validation.
- *   2. The base feed and the per-viewer `posts` feed on `POST /fate` are separate
- *      surfaces: the `posts` feed still stamps the signed-in viewer's `myVote`/`isSaved`
- *      (the split changed nothing there).
- *
  * The base feed serves unconditionally — its leg-B dark-ship flag graduated to on@100%
  * and was retired (ADR 0136), so the split is now the source of truth.
  *
@@ -59,7 +49,6 @@ async function seedPost(title: string): Promise<string> {
 	return (r.data as {id: string}).id;
 }
 
-/** GET the base feed over the URL surface; returns the raw Response (caller asserts). */
 function getBaseFeed(query: string, cookie?: string): Promise<Response> {
 	return h.req(`/fate/pano/feed?${query}`, cookie ? {headers: {cookie}} : undefined);
 }
@@ -84,7 +73,6 @@ describe("pano base feed — GET surface + viewer-invariant base (#2322)", () =>
 		const conn = (await res.json()) as Connection<BaseNode>;
 		const titles = conn.items.map((e) => e.node.title).sort();
 		expect(titles).toEqual([`${NS}-alpha`, `${NS}-bravo`, `${NS}-charlie`]);
-		// The base carries NO viewer-scoped field.
 		for (const {node} of conn.items) {
 			expect(Object.hasOwn(node, "myVote")).toBe(false);
 			expect(Object.hasOwn(node, "isSaved")).toBe(false);
@@ -105,7 +93,6 @@ describe("pano base feed — GET surface + viewer-invariant base (#2322)", () =>
 		);
 		expect(second.status).toBe(200);
 		const page2 = (await second.json()) as Connection<BaseNode>;
-		// The three seeded posts split 2 + 1 across the cursor with no overlap.
 		expect(page2.items).toHaveLength(1);
 		const ids1 = page1.items.map((e) => e.node.id);
 		expect(ids1).not.toContain(page2.items[0]!.node.id);
@@ -117,7 +104,6 @@ describe("pano base feed — GET surface + viewer-invariant base (#2322)", () =>
 		const authed = await getBaseFeed(query, viewer.cookie);
 		expect(anon.status).toBe(200);
 		expect(authed.status).toBe(200);
-		// No session validation: the base sets no cookie for either caller.
 		expect(anon.headers.get("set-cookie")).toBeNull();
 		expect(authed.headers.get("set-cookie")).toBeNull();
 		// Byte-identical bodies — the base is viewer-invariant by construction.
@@ -127,9 +113,7 @@ describe("pano base feed — GET surface + viewer-invariant base (#2322)", () =>
 
 describe("pano base feed — the per-viewer posts feed is a separate surface (#2322)", () => {
 	it("leaves the existing POST /fate posts feed stamping myVote", async () => {
-		// Vote a seeded post as the viewer, then read the per-viewer `posts` feed on
-		// `POST /fate`: the split left that stamp untouched — myVote rides as before. (The
-		// author never self-votes; the viewer votes the author's post.)
+		// The viewer votes the AUTHOR's post — a self-vote is a distinct rejection.
 		const target = seeded[0]!;
 		const voted = await h.fate(
 			{kind: "mutation", name: "post.vote", input: {id: target}, select: ["id"]},

--- a/apps/web/tests/integration/pano-bookmarks.test.ts
+++ b/apps/web/tests/integration/pano-bookmarks.test.ts
@@ -4,12 +4,9 @@
  *
  * Drives the `isSaved` viewer scalar + the `post.save` / `post.unsave` mutations
  * #128 adds, the structural twin of `post.vote` / `post.retractVote` with score
- * stripped to pure presence. Everything is observed over HTTP: `isSaved` is read
- * back off `post(id)` per viewer, the mutations are exercised for the toggle round
- * trip, idempotent repeat, the anonymous rejection, and the missing-post error.
- * The no-N+1 batch stamp is asserted indirectly the way `myVote` is — a viewer's
- * saves resolve correctly across a set of posts in one read, with each viewer
- * seeing only their own.
+ * stripped to pure presence. Everything is observed over HTTP. The no-N+1 batch
+ * stamp is asserted indirectly the way `myVote` is — a viewer's saves resolve
+ * correctly across a set of posts in one read, each viewer seeing only their own.
  *
  * This file runs on the run-scoped SHARED stage (ADR 0104 step 7, #1027): its one D1 is
  * shared with every migrated file. It isolates by NS — every email/title it seeds carries
@@ -39,7 +36,6 @@ let other: {userId: string; cookie: string};
 
 const POST_SELECT = ["id", "title", "score", "myVote", "isSaved"];
 
-/** Submit a post under the saver cookie; assert success; return its id. */
 async function seedPost(title: string): Promise<string> {
 	const r = await h.fate(
 		{
@@ -55,7 +51,6 @@ async function seedPost(title: string): Promise<string> {
 	return (r.data as PostNode).id;
 }
 
-/** Re-resolve a post's `isSaved` for the given cookie (anonymous when omitted). */
 async function readIsSaved(id: string, cookie?: string): Promise<boolean | null> {
 	const r = await h.fate(
 		{kind: "query", name: "post", args: {idOrSlug: id}, select: ["id", "isSaved"]},
@@ -87,7 +82,6 @@ describe("pano bookmarks — isSaved view scalar", () => {
 		const b = await seedPost(`${NS} set b`);
 		const c = await seedPost(`${NS} set c`);
 
-		// saver saves a + c; `other` saves b.
 		for (const [id, cookie] of [
 			[a, saver.cookie],
 			[c, saver.cookie],
@@ -100,7 +94,6 @@ describe("pano bookmarks — isSaved view scalar", () => {
 			expect(r.ok).toBe(true);
 		}
 
-		// saver sees a,c saved and b not; `other` sees the mirror image.
 		expect(await readIsSaved(a, saver.cookie)).toBe(true);
 		expect(await readIsSaved(b, saver.cookie)).toBe(false);
 		expect(await readIsSaved(c, saver.cookie)).toBe(true);
@@ -155,7 +148,6 @@ describe("pano bookmarks — post.save / post.unsave", () => {
 		if (!again.ok) return;
 		expect((again.data as PostNode).isSaved).toBe(true);
 
-		// And re-unsaving an already-unsaved post stays false.
 		await h.fate(
 			{kind: "mutation", name: "post.unsave", input: {id}, select: ["id"]},
 			{cookie: saver.cookie},

--- a/apps/web/tests/integration/pano-comments.test.ts
+++ b/apps/web/tests/integration/pano-comments.test.ts
@@ -1,36 +1,17 @@
 /**
  * pano comment lifecycle DEPTH — black-box against the deployed worker `/fate`
- * route (ADR 0026–0031).
+ * route.
  *
- * Ports the depth surface of the pre-alchemy comment suites that drove the
- * `Pano` Effect service directly inside workerd:
- *   - `pano-edit-delete-comment.test.ts` — comment ownership (non-author
- *     edit/delete → UNAUTHORIZED), unknown-id codes, leaf-delete removal,
- *     parent-with-replies soft-delete (`[silindi]` placeholder), idempotent
- *     re-delete.
- *   - `pano-vote-comment.test.ts` — comment vote idempotency, round-trip,
- *     retract-on-never-voted no-op.
- *   - `pano-comments-connection.test.ts` — reply-aware comment feed (leaf
- *     deleted is gone, parent-with-replies stays as a tombstone), stale/ghost
- *     cursor edges, the `after`-row-removed-between-pages edge.
- *   - nested-reply/placeholder bits of `pano-add-comment.test.ts`.
+ * Everything is observed over HTTP. The old service-return flags
+ * (`{deleted, hasReplies, placeholder}`, `changed`) are NOT on the wire, and the
+ * connection envelope carries no `totalCount` — behavior is re-expressed via the
+ * re-resolved entity, the comments feed, and `post(id).commentCount`.
  *
- * Everything is observed over HTTP. Author identity comes from the session
- * (`h.signUp`), so an ownership test signs up an author + an intruder, and a
- * vote-from-another-user test uses a second cookie. The old service-return
- * flags (`{deleted, hasReplies, placeholder}`, `changed`) are NOT on the wire;
- * behavior is re-expressed via the re-resolved entity + the comments feed +
- * `post(id).commentCount` over `/fate`. The connection envelope has NO
- * `totalCount`, so the old `totalCount` assertions are dropped and re-expressed
- * via the id-union of the comments feed.
- *
- * This file runs on the run-scoped SHARED stage (ADR 0104 step 7, #1027), so its one D1 is
- * shared across every migrated file. It isolates by NAMESPACE + POST-SCOPE: every email /
- * sign-up name / post title / synthetic miss-id is prefixed with `NS` (this file's
- * deterministic `nsToken`), and every assertion reads a per-test, NS-owned post's own
- * comment thread (`post(id).comments` / `post(id).commentCount` for THIS post). The comment
- * thread is intrinsically post-scoped, so no assertion ever reads a global comment list or
- * unfiltered feed — each test owns its post and observes only its own seeded comment ids.
+ * This file runs on the run-scoped SHARED stage (ADR 0104), so its one D1 is shared
+ * across every migrated file. It isolates by NAMESPACE + POST-SCOPE: every email /
+ * sign-up name / post title / synthetic miss-id is prefixed with `NS`, and every
+ * assertion reads a per-test, NS-owned post's own comment thread. No assertion may
+ * read a global comment list or unfiltered feed.
  */
 import {beforeAll, describe, expect, it} from "vitest";
 import {sharedStack} from "./_integration.ts";
@@ -66,7 +47,6 @@ let author: {userId: string; cookie: string};
 let intruder: {userId: string; cookie: string};
 let voter: {userId: string; cookie: string};
 
-/** Submit a post under the author cookie; assert success; return its id. */
 async function seedPost(title: string): Promise<string> {
 	const r = await h.fate(
 		{
@@ -82,7 +62,6 @@ async function seedPost(title: string): Promise<string> {
 	return (r.data as PostNode).id;
 }
 
-/** Add a comment under a cookie (default author); assert success; return its id. */
 async function seedComment(
 	postId: string,
 	body: string,
@@ -102,7 +81,6 @@ async function seedComment(
 	return (r.data as CommentNode).id;
 }
 
-/** Read the comments feed for a post (large page); return the comment nodes. */
 async function readComments(postId: string): Promise<CommentNode[]> {
 	const r = await h.fate({
 		kind: "query",
@@ -115,7 +93,6 @@ async function readComments(postId: string): Promise<CommentNode[]> {
 	return (r.data as {comments: Connection<CommentNode>}).comments.items.map((e) => e.node);
 }
 
-/** Re-resolve a post's commentCount over `/fate`. */
 async function commentCount(postId: string): Promise<number> {
 	const r = await h.fate({
 		kind: "query",
@@ -157,7 +134,6 @@ describe("pano comments — ownership (edit/delete)", () => {
 		if (result.ok) return;
 		expect(result.error.code).toBe("UNAUTHORIZED");
 
-		// The body survives: re-resolve it via the comments feed.
 		const comments = await readComments(postId);
 		const row = comments.find((c) => c.id === id);
 		expect(row).toBeDefined();
@@ -176,7 +152,6 @@ describe("pano comments — ownership (edit/delete)", () => {
 		if (result.ok) return;
 		expect(result.error.code).toBe("UNAUTHORIZED");
 
-		// Still present + count unchanged.
 		expect(await commentCount(postId)).toBe(1);
 		const comments = await readComments(postId);
 		expect(comments.some((c) => c.id === id)).toBe(true);
@@ -235,7 +210,6 @@ describe("pano comments — soft-delete placeholder semantics", () => {
 		expect(post.id).toBe(postId);
 		expect(post.commentCount).toBe(1);
 
-		// The leaf row is gone from the feed; the survivor remains.
 		const comments = await readComments(postId);
 		expect(comments.some((c) => c.id === leaf)).toBe(false);
 		expect(comments).toHaveLength(1);
@@ -268,12 +242,10 @@ describe("pano comments — soft-delete placeholder semantics", () => {
 		expect((deleted.data as PostNode).commentCount).toBe(1);
 
 		const comments = await readComments(postId);
-		// Parent stays as a [silindi] tombstone with an empty authorId.
 		const parentRow = comments.find((c) => c.id === parent);
 		expect(parentRow).toBeDefined();
 		expect(parentRow!.body).toBe("[silindi]");
 		expect(parentRow!.authorId).toBe("");
-		// The reply still carries its original body + parent link.
 		const replyRow = comments.find((c) => c.id === reply);
 		expect(replyRow).toBeDefined();
 		expect(replyRow!.body).toBe("the reply that keeps the parent alive");
@@ -296,7 +268,6 @@ describe("pano comments — soft-delete placeholder semantics", () => {
 		);
 		expect(first.ok).toBe(true);
 		if (!first.ok) return;
-		// First soft-delete decrements the count (2 → 1) but keeps the tombstone.
 		expect((first.data as PostNode).commentCount).toBe(1);
 
 		// Second delete on the already-tombstoned parent is an idempotent no-op:
@@ -315,7 +286,6 @@ describe("pano comments — soft-delete placeholder semantics", () => {
 		if (!second.ok) return;
 		expect((second.data as PostNode).commentCount).toBe(1);
 
-		// Still exactly one tombstone in the feed.
 		const comments = await readComments(postId);
 		const tombstones = comments.filter((c) => c.id === parent && c.body === "[silindi]");
 		expect(tombstones).toHaveLength(1);
@@ -434,7 +404,6 @@ describe("pano comments — connection edge cases", () => {
 		const c2 = await seedComment(postId, "comment 2 — will be leaf-deleted");
 		const reply = await seedComment(postId, "child of comment 0", {parentId: c0});
 
-		// Delete a parent-with-replies (soft) and a leaf (hard).
 		await h.fate(
 			{kind: "mutation", name: "comment.delete", input: {id: c0}, select: ["id"]},
 			{cookie: author.cookie},
@@ -446,7 +415,6 @@ describe("pano comments — connection edge cases", () => {
 
 		const comments = await readComments(postId);
 		const ids = comments.map((c) => c.id);
-		// c0 stays as tombstone, c1 live, reply live; c2 (leaf) gone.
 		expect(ids).toContain(c0);
 		expect(ids).toContain(c1);
 		expect(ids).toContain(reply);
@@ -482,7 +450,6 @@ describe("pano comments — connection edge cases", () => {
 		for (let i = 0; i < 4; i++)
 			ids.push(await seedComment(postId, `comment ${i} removed-cursor test`));
 
-		// Page 1: first 2, cursor is the second id.
 		const page1 = await h.fate({
 			kind: "query",
 			name: "post",
@@ -497,13 +464,11 @@ describe("pano comments — connection edge cases", () => {
 		const cursor = conn1.pagination.nextCursor;
 		expect(cursor).toBe(ids[1]);
 
-		// Hard-delete the cursor comment (a leaf → row removed).
 		await h.fate(
 			{kind: "mutation", name: "comment.delete", input: {id: ids[1]!}, select: ["id"]},
 			{cookie: author.cookie},
 		);
 
-		// Page 2 after the now-removed cursor: the keyset finds no anchor row → empty.
 		const page2 = await h.fate({
 			kind: "query",
 			name: "post",
@@ -519,16 +484,7 @@ describe("pano comments — connection edge cases", () => {
 	});
 });
 
-// covered by pano-read.test.ts: chronological keyset paging through every comment
-//   with a stable id cursor (no skips/dupes across pages).
-// covered by pano-mutations.test.ts: comment.add top-level + commentCount bump,
-//   nested reply + commentCount bump, PARENT_NOT_FOUND (missing + cross-post),
-//   POST_NOT_FOUND, anonymous → UNAUTHORIZED, BODY_REQUIRED/BODY_TOO_LONG on add,
-//   comment.vote/retractVote happy path (myVote stamped), comment.edit happy path,
-//   comment.vote on unknown id → COMMENT_NOT_FOUND, leaf comment.delete returning
-//   the re-resolved parent Post with the decremented commentCount.
-// not portable black-box: comment_vote / user_vote row counts, total_karma
-//   read-backs, comment_record body_excerpt + deleted_at columns, the
-//   `{deleted, hasReplies, placeholder}` / `changed` service-return flags —
-//   re-expressed via the re-resolved Comment, the comments feed (tombstone body
-//   `[silindi]` + empty authorId), and `post(id).commentCount` over `/fate`.
+// Elsewhere: keyset paging over comments is in pano-read.test.ts; comment.add /
+// vote / edit happy paths and their error codes are in pano-mutations.test.ts.
+// Not reachable black-box, so untested here: comment_vote / user_vote row counts,
+// total_karma read-backs, and the comment_record body_excerpt + deleted_at columns.

--- a/apps/web/tests/integration/pano-feed-viewer-state.test.ts
+++ b/apps/web/tests/integration/pano-feed-viewer-state.test.ts
@@ -2,19 +2,12 @@
  * pano feed viewer state (`posts` list stamps `myVote`/`isSaved`) — black-box
  * against the deployed worker `/fate` route (ADR 0026–0031, ADR 0082).
  *
- * Drives #695: the main `posts` feed must reflect the signed-in viewer's own
- * vote/save state the same way the post-detail `post` query and `savedPosts`
- * already do — the resolver re-hydrates the keyset page through
- * `Pano.getPostsByIds(ids, {viewerId})` so `myVote`/`isSaved` ride one batch.
- * Everything is observed over HTTP: posts are seeded + voted + saved via `/fate`
- * mutations, then the feed is read back per viewer. Anonymous reads must stay
- * neutral (`null` state).
+ * Drives #695: the main `posts` feed must reflect the signed-in viewer's own vote/save
+ * state the way the post-detail `post` query and `savedPosts` already do.
  *
- * This file runs on the run-scoped SHARED stage (ADR 0104 step 7, #1027): its one D1 is
- * shared with every migrated file. It isolates by NS — every email/title/host it seeds
- * carries the deterministic `${NS}-…` prefix, and the feed read is HOST-scoped to this
- * file's own `${NS}.example.com` host, so the `posts(host)` query returns exactly this
- * file's seeded set and never another file's rows on the shared D1.
+ * On the run-scoped SHARED stage (ADR 0104 step 7, #1027), so isolation is by NS: every
+ * email/title/host carries the `${NS}-…` prefix and the feed read is HOST-scoped to this
+ * file's own `${NS}.example.com`, so `posts(host)` never returns another file's rows.
  */
 import {beforeAll, describe, expect, it} from "vitest";
 import {sharedStack} from "./_integration.ts";
@@ -42,18 +35,13 @@ const FEED_HOST = `${NS}.example.com`;
 let viewer: {userId: string; cookie: string};
 let other: {userId: string; cookie: string};
 
-/** A post the viewer votes + saves. */
 let votedSaved = "";
-/** A post the viewer only votes. */
 let votedOnly = "";
-/** A post the viewer only saves. */
 let savedOnly = "";
-/** A post the viewer neither votes nor saves. */
 let neutral = "";
 
 // Posts are authored by `other`, not the `viewer`: since #2216 blocks self-voting, the
 // viewer's fixture votes below have to land on content it did not write.
-/** Submit a post under the author (`other`) cookie on the shared feed host; return its id. */
 async function seedPost(title: string): Promise<string> {
 	const r = await h.fate(
 		{
@@ -69,7 +57,6 @@ async function seedPost(title: string): Promise<string> {
 	return (r.data as PostNode).id;
 }
 
-/** Read the host-scoped feed for a cookie (anonymous when omitted), as an id→node map. */
 async function feed(cookie?: string): Promise<Map<string, PostNode>> {
 	const r = await h.fate(
 		{
@@ -88,10 +75,8 @@ async function feed(cookie?: string): Promise<Map<string, PostNode>> {
 beforeAll(async () => {
 	viewer = await h.signUp(`${NS}-viewer@test.local`, "hunter2hunter2", "izleyen");
 	other = await h.signUp(`${NS}-other@test.local`, "hunter2hunter2", "öteki");
-	// `viewer` casts real post votes below (voted/voted-saved fixtures) on posts `other`
-	// authored — self-voting is blocked (#2216), so the caster is never the author. Since
-	// #1810's "earn to vote" gate a fresh çaylak is rejected at cast, promote the voter; and
-	// promote `other` so its authored posts are live (not sandboxed) and thus votable/feed-visible.
+	// Since #1810's "earn to vote" gate a fresh çaylak is rejected at cast, so promote the
+	// voter; promote `other` too, or its posts stay sandboxed and never reach the feed.
 	await h.promoteToYazar(viewer.userId);
 	await h.promoteToYazar(other.userId);
 
@@ -135,8 +120,6 @@ describe("pano feed — viewer state stamping (#695)", () => {
 	});
 
 	it("scopes the stamp to the reading viewer (no cross-talk)", async () => {
-		// `other` voted/saved nothing here, so every row is neutral for them — the
-		// stamp follows the cookie, not the post.
 		const rows = await feed(other.cookie);
 
 		for (const id of [votedSaved, votedOnly, savedOnly, neutral]) {

--- a/apps/web/tests/integration/pano-hot-score-decay.test.ts
+++ b/apps/web/tests/integration/pano-hot-score-decay.test.ts
@@ -1,43 +1,16 @@
 /**
  * pano sıcak/hot decay-refresh → the AC4 end-to-end guard for #2027.
  *
- * The bug (#2027): `post_record.hot_score` is a STORED, keyset-read integer written
- * only at activity sites (create/vote/comment), so the age term of the HN gravity
- * formula freezes the instant a post stops getting activity — an inactive post keeps
- * a "young, high" score forever and squats the hot feed above genuinely fresher rows.
- * The fix is `Pano.refreshHotScores` (`post-operations.ts`), driven periodically by
- * the cron trigger (`hot-score-decay-cron.ts`): re-decay the stored column for every
- * live non-draft post (WINDOWLESS since #2133), WITHOUT a read-time recompute (the
- * keyset-cursor contract + the no-`POW` SQLite constraint both need `hot_score` to stay
- * a stored, indexed column).
+ * The bug (#2027): `post_record.hot_score` is a STORED, keyset-read integer written only at
+ * activity sites, so the age term of the HN gravity formula freezes the instant a post stops
+ * getting activity — an inactive post keeps a "young, high" score forever and squats the hot
+ * feed. `Pano.refreshHotScores` re-decays the stored column for every live non-draft post
+ * (WINDOWLESS since #2133), with no read-time recompute (the keyset cursor and SQLite's
+ * missing `POW` both need `hot_score` stored and indexed).
  *
- * The pure decay core (`decayHotScores`) is unit-tested off-DB (`hotScoreDecay.unit.test.ts`).
- * This is the integration tier AC4 names (ADR 0082 §irreducible-integration): the
- * stored-column read → changed-only write-back → keyset feed re-ordering that
- * `decayHotScores`'s unit test can't reach. It:
- *   1. seeds two real posts over `/fate` under one per-file host (so the `posts(hot)`
- *      feed scopes to exactly this test's rows) — a `fresher` post voted young for a
- *      real young-high stored score, and a `stale` post;
- *   2. constructs the exact #2027 bug state on the stale post via a setup-only D1 write
- *      (`execD1`) — a higher score, a `hot_score` FROZEN at the young value, and a
- *      `created_at` aged 17 DAYS into the past (far OUTSIDE the old 72h window that used
- *      to gate the refresh — this is the #2133 case): the "advance time" + frozen-score
- *      the public seam can't set, so the OLD post outranks the fresher one #1;
- *   3. runs the REAL `Pano.refreshHotScores(now)` against this stage's REAL remote D1
- *      (the fts-backfill precedent, #645: the shipped code path over `@kampus/d1-rest`,
- *      NOT a `node:sqlite` oracle — banned by ADR 0082, and NOT a re-implementation of
- *      the query — the worker's own `createDrizzle`/`makeDrizzleAccess`/`makePostOperations`);
- *   4. asserts the stale post's hot rank drops BELOW the fresher post through the `/fate`
- *      hot feed — the re-ordering, driven by the stored column the refresh rewrote;
- *   5. asserts NO activity write was needed: the stale post's `score` / `commentCount`
- *      are unchanged (decay wrote only `hot_score`), and the refresh reports `updated >= 1`.
- *
- * There is no HTTP route to trigger the cron on a deployed worker (the scheduled
- * handler fires on Cloudflare's schedule, not on demand), so — like `fts-backfill` —
- * the test drives the real method directly against this stage's real D1 REST target
- * (`h.d1Target()` + `$CLOUDFLARE_API_TOKEN`, the same creds the integration deploy uses).
- * Per-file `integrationStack`: this file owns its own worker + D1, so the direct-D1
- * refresh and the feed reads see one isolated table.
+ * No HTTP route triggers the cron on a deployed worker, so — like `fts-backfill` (#645) —
+ * this drives the real method against this stage's real D1 REST target. Per-file
+ * `integrationStack`, so the direct-D1 refresh and the feed reads see one isolated table.
  */
 import {Effect} from "effect";
 import {beforeAll, describe, expect, it} from "vitest";
@@ -70,7 +43,6 @@ const HOUR_MS = 3_600_000;
 let author: {userId: string; cookie: string};
 let voter: {userId: string; cookie: string};
 
-/** Submit a real post under `HOST` over `/fate`; return its id. */
 async function seedPost(title: string): Promise<string> {
 	const r = await h.fate(
 		{
@@ -90,7 +62,7 @@ async function seedPost(title: string): Promise<string> {
 	return (r.data as PostNode).id;
 }
 
-/** Read this host's hot feed and return post ids in feed (rank) order. */
+/** Post ids in feed (rank) order. */
 async function hotFeedIds(): Promise<string[]> {
 	const feed = await h.fate({
 		kind: "list",
@@ -103,7 +75,6 @@ async function hotFeedIds(): Promise<string[]> {
 	return (feed.data as Connection<PostNode>).items.map((e) => e.node.id);
 }
 
-/** Re-resolve a post's activity-bearing scalars over `/fate`. */
 async function readPost(id: string): Promise<{score: number; commentCount: number}> {
 	const r = await h.fate({
 		kind: "query",
@@ -118,11 +89,9 @@ async function readPost(id: string): Promise<{score: number; commentCount: numbe
 }
 
 /**
- * Build the REAL `Pano.refreshHotScores` bound to this stage's REAL remote D1 over
- * `@kampus/d1-rest` — the shipped worker code path (`createDrizzle` → `makeDrizzleAccess`
- * → `orDieAccess` → `makeRefreshHotScores`), never a re-implementation of its window query.
- * The method reads only `run`, so `makeRefreshHotScores(run)` builds it standalone against
- * this stage's real D1 — no full `PostOperationsDeps` graph, no cast.
+ * The shipped worker code path bound to this stage's real remote D1, never a
+ * re-implementation of its query. `refreshHotScores` reads only `run`, so it builds
+ * standalone without the full `PostOperationsDeps` graph.
  */
 async function realRefreshHotScores() {
 	const target = await h.d1Target();
@@ -146,9 +115,8 @@ describe("pano sıcak/hot decay-refresh (#2027 AC4) — the stored-column read �
 		const staleId = await seedPost("stale-hot-post");
 		const fresherId = await seedPost("fresher-hot-post");
 
-		// The fresher post earns a young-high stored score by voting it while age≈0 — the
-		// live activity path, score 1 → `hot_score = computeHotScore(1, now, now)` = 287.
-		// Cast by a non-author (self-voting is blocked, #2216).
+		// Voting at age≈0 earns a young-high stored score through the live activity path:
+		// score 1 → `hot_score = computeHotScore(1, now, now)` = 287.
 		const voted = await h.fate(
 			{kind: "mutation", name: "post.vote", input: {id: fresherId}, select: ["id", "score"]},
 			{cookie: voter.cookie},
@@ -174,8 +142,6 @@ describe("pano sıcak/hot decay-refresh (#2027 AC4) — the stored-column read �
 		);
 		expect(changed).toBe(1);
 
-		// Pre-refresh: the frozen-while-young stale score keeps the OLD post ranked above the
-		// fresher one — the bug the feed exhibits (higher stored `hot_score` sorts first).
 		const before = await hotFeedIds();
 		const staleBefore = before.indexOf(staleId);
 		const fresherBefore = before.indexOf(fresherId);
@@ -183,24 +149,19 @@ describe("pano sıcak/hot decay-refresh (#2027 AC4) — the stored-column read �
 		expect(fresherBefore).toBeGreaterThanOrEqual(0);
 		expect(staleBefore).toBeLessThan(fresherBefore); // stale ranks ABOVE fresher (the bug)
 
-		// Grounding (the same formula the refresh applies, not intuition): re-decayed at 17 days the
-		// stale score collapses far below the fresher post's young score, so the refresh MUST flip
-		// the order.
+		// Grounded in the same formula the refresh applies, not intuition: re-decayed at 17 days
+		// the stale score falls below the fresher one, so the refresh MUST flip the order.
 		const staleDecayed = computeHotScore(5, staleCreatedSec * 1000, nowMs);
 		const fresherYoung = computeHotScore(1, nowMs, nowMs);
 		expect(staleDecayed).toBeLessThan(fresherYoung);
 
-		// Run the REAL refresh against real remote D1 — the shipped windowless query + write-back.
-		// The #2133 guard: the 17-day stale post is FAR outside the old 72h window, so a windowed
+		// The #2133 guard: the 17-day stale post is far outside the old 72h window, so a windowed
 		// refresh would never have selected it; the windowless pass re-decays it here.
 		const refreshHotScores = await realRefreshHotScores();
 		const result = await Effect.runPromise(refreshHotScores(new Date(nowMs)));
-		expect(result.scanned).toBeGreaterThanOrEqual(2); // every live non-draft post is scanned
-		expect(result.updated).toBeGreaterThanOrEqual(1); // the stale post's frozen score moved
+		expect(result.scanned).toBeGreaterThanOrEqual(2);
+		expect(result.updated).toBeGreaterThanOrEqual(1);
 
-		// Post-refresh: the aged stale post's re-decayed stored score has collapsed, so the
-		// fresher post now outranks it in the SAME keyset feed — driven purely by the stored
-		// column the refresh rewrote (no read-time recompute).
 		const after = await hotFeedIds();
 		const staleAfter = after.indexOf(staleId);
 		const fresherAfter = after.indexOf(fresherId);
@@ -208,9 +169,8 @@ describe("pano sıcak/hot decay-refresh (#2027 AC4) — the stored-column read �
 		expect(fresherAfter).toBeGreaterThanOrEqual(0);
 		expect(fresherAfter).toBeLessThan(staleAfter); // fresher now ranks ABOVE stale (fixed)
 
-		// No activity write was needed: decay rewrote `hot_score` alone. The stale post's
-		// activity-bearing scalars are untouched — score stays 5, commentCount stays 0. A
-		// vote/comment write (the only pre-fix way a score refreshed) would have moved these.
+		// A vote/comment write — the only pre-fix way a score refreshed — would have moved
+		// these, so unchanged scalars prove decay rewrote `hot_score` alone.
 		const stalePost = await readPost(staleId);
 		expect(stalePost.score).toBe(5);
 		expect(stalePost.commentCount).toBe(0);

--- a/apps/web/tests/integration/pano-mutations.test.ts
+++ b/apps/web/tests/integration/pano-mutations.test.ts
@@ -2,18 +2,6 @@
  * pano mutations — black-box against the deployed worker `/fate` route
  * (ADR 0026–0031).
  *
- * Ports the write surface of three pre-alchemy suites that drove the pano
- * mutation resolvers / `Pano` service directly inside workerd:
- *   - `fate-pano-mutations.test.ts` — post.submit/vote/retractVote/edit/delete,
- *     comment.add/vote/retractVote/edit/delete, and wire-error parity
- *     (`TAGS_REQUIRED`, `POST_NOT_FOUND`, `COMMENT_NOT_FOUND`, `UNAUTHORIZED`).
- *   - `pano-submit-post.test.ts` — submit happy path + post validation codes
- *     (`TITLE_REQUIRED`, `TITLE_TOO_LONG`, `URL_INVALID`, `BODY_TOO_LONG`,
- *     `TAGS_REQUIRED`, `TAG_INVALID`).
- *   - `pano-add-comment.test.ts` — top-level comment + commentCount bump, nested
- *     reply, comment validation codes (`BODY_REQUIRED`, `BODY_TOO_LONG`,
- *     `PARENT_NOT_FOUND` for missing + cross-post parent, `POST_NOT_FOUND`).
- *
  * Everything is observed over HTTP. Author identity comes from the session
  * (`h.signUp`), not explicit `authorId`/`authorName`, so submit input is
  * `{title, url?, body?, tags}`. Wire codes are the UPCASED pano sub-codes
@@ -77,7 +65,6 @@ const POST_SELECT = [
 ];
 const COMMENT_SELECT = ["id", "parentId", "body", "author", "authorId", "score", "myVote"];
 
-/** Submit a post under the author cookie; assert success; return its id. */
 async function seedPost(input: {
 	title: string;
 	url?: string;
@@ -319,7 +306,6 @@ describe("pano mutations — post.edit / post.delete", () => {
 		expect((deleted.data as PostNode).__typename).toBe("Post");
 		expect((deleted.data as PostNode).id).toBe(id);
 
-		// The post is gone: a detail read resolves null.
 		const detail = await h.fate({
 			kind: "query",
 			name: "post",
@@ -378,7 +364,6 @@ describe("pano mutations — comment.add", () => {
 		expect(comment.score).toBe(0);
 		expect(comment.myVote).toBeNull();
 
-		// It bumps the parent post's commentCount (re-resolve the post).
 		const detail = await h.fate({
 			kind: "query",
 			name: "post",
@@ -664,7 +649,6 @@ describe("pano mutations — comment.vote / retractVote / edit", () => {
 		const post = parent.data as PostNode;
 		expect(post.__typename).toBe("Post");
 		expect(post.id).toBe(postId);
-		// Two added, one (leaf) removed → one remains.
 		expect(post.commentCount).toBe(1);
 	});
 });

--- a/apps/web/tests/integration/pano-posts-lifecycle.test.ts
+++ b/apps/web/tests/integration/pano-posts-lifecycle.test.ts
@@ -2,32 +2,11 @@
  * pano post lifecycle DEPTH — black-box against the deployed worker `/fate`
  * route (ADR 0026–0031).
  *
- * Ports the depth surface of the pre-alchemy post suites that drove the `Pano`
- * Effect service directly inside workerd:
- *   - `pano-edit-delete-post.test.ts` — post ownership (covered by Wave 2),
- *     edit validation codes, edit field-subset re-resolution (title-only edit
- *     leaves body intact and vice versa), idempotent re-delete.
- *   - `pano-vote-post.test.ts` — post vote idempotency, round-trip,
- *     retract-on-never-voted no-op.
- *   - remaining `pano-post-connection.test.ts` edges not covered by Wave-2
- *     `pano-read.test.ts` (the `totalCount` row count re-expressed via the
- *     id-union of a host-scoped feed).
- *
- * Everything is observed over HTTP. Author identity comes from the session
- * (`h.signUp`); a vote-from-another-user test uses a second cookie. The old
- * service-return flags (`{deleted, changed}`, `hot_score`, `updatedAt`) are NOT
- * on the wire; behavior is re-expressed via the re-resolved Post + the feed
- * over `/fate`. The connection envelope has NO `totalCount`, so the old
- * `totalCount` assertion is dropped and re-expressed via the id-union size.
- *
- * This file runs on the run-scoped SHARED stage (ADR 0104 step 7, #1027), so its one D1 is
- * shared across every migrated file: every title/host/email/synthetic-id is prefixed with
- * `NS` (this file's deterministic `nsToken`). Isolation on the shared D1 is by READ SHAPE —
- * every lifecycle assertion (after submit/edit/delete/vote) re-resolves THIS test's own post
- * by id (`post(idOrSlug: id)`), never a global feed. The two presence/absence checks that DO
- * read a feed (id-union row count; "deleted post drops out") are scoped by an NS-prefixed
- * HOST, so `posts(host)` returns only this file's (and this test's) rows — the host-scoping IS
- * the namespace. No assertion observes another file's data.
+ * Runs on the run-scoped SHARED stage (ADR 0104 step 7), so its one D1 is shared across every
+ * migrated file. Isolation is by READ SHAPE: every lifecycle assertion re-resolves THIS test's
+ * own post by id, never a global feed. The two checks that DO read a feed are scoped by an
+ * NS-prefixed HOST, so `posts(host)` returns only this test's rows — the host-scoping IS the
+ * namespace.
  */
 import {beforeAll, describe, expect, it} from "vitest";
 import {sharedStack} from "./_integration.ts";
@@ -54,7 +33,6 @@ type Connection<N> = {
 let author: {userId: string; cookie: string};
 let voter: {userId: string; cookie: string};
 
-/** Submit a post under the author cookie; assert success; return its id. */
 async function seedPost(input: {
 	title: string;
 	url?: string;
@@ -75,7 +53,6 @@ async function seedPost(input: {
 	return (r.data as PostNode).id;
 }
 
-/** Re-resolve a post's title + body over `/fate`. */
 async function readPost(id: string): Promise<PostNode | null> {
 	const r = await h.fate({
 		kind: "query",
@@ -116,7 +93,6 @@ describe("pano posts — edit field-subset re-resolution", () => {
 		expect((edited.data as PostNode).title).toBe(`${NS} title-only after`);
 		expect((edited.data as PostNode).body).toBe("untouched body");
 
-		// Re-resolve independently: the body did not change.
 		const post = await readPost(id);
 		expect(post).not.toBeNull();
 		expect(post!.title).toBe(`${NS} title-only after`);
@@ -161,12 +137,9 @@ describe("pano posts — edit validation", () => {
 		expect(result.error.code).toBe("TITLE_REQUIRED");
 	});
 
-	// The pure title/body content codes (TITLE_REQUIRED on a blank title,
-	// TITLE_TOO_LONG, BODY_TOO_LONG) are unit-tested off-DB in
-	// worker/features/pano/submit-validation.unit.test.ts (ADR 0082) — the
-	// validatePostTitle/validatePostBody editPost calls. The neither-field guard
-	// above is kept: it runs after the DB read and is editPost's own structural
-	// rule, not a pure validator.
+	// The pure title/body content codes are unit-tested off-DB in
+	// worker/features/pano/submit-validation.unit.test.ts (ADR 0082). The neither-field guard
+	// above stays here: it runs after the DB read, so it is not a pure validator.
 
 	it("editing an unknown post id surfaces POST_NOT_FOUND", async () => {
 		const result = await h.fate(
@@ -206,7 +179,6 @@ describe("pano posts — vote idempotency / round-trip", () => {
 		expect((second.data as PostNode).score).toBe(1);
 		expect((second.data as PostNode).myVote).toBe(true);
 
-		// Re-resolve: the score holds at 1.
 		const post = await readPost(id);
 		expect(post!.score).toBe(1);
 	});
@@ -273,12 +245,8 @@ describe("pano posts — delete idempotency", () => {
 		expect((first.data as PostNode).__typename).toBe("Post");
 		expect((first.data as PostNode).id).toBe(id);
 
-		// The row is gone; a re-resolve is null.
 		expect(await readPost(id)).toBeNull();
 
-		// Re-deleting the removed post is an idempotent no-op: the resolver still
-		// returns the bare {__typename, id} eviction ref (the service short-circuits
-		// on the missing row without raising).
 		const second = await h.fate(
 			{kind: "mutation", name: "post.delete", input: {id}, select: ["id"]},
 			{cookie: author.cookie},
@@ -288,7 +256,6 @@ describe("pano posts — delete idempotency", () => {
 		expect((second.data as PostNode).__typename).toBe("Post");
 		expect((second.data as PostNode).id).toBe(id);
 
-		// Still gone after the second delete.
 		expect(await readPost(id)).toBeNull();
 	});
 
@@ -332,7 +299,6 @@ describe("pano posts — connection edges", () => {
 		expect(new Set(ids).size).toBe(3);
 		expect([...ids].sort()).toEqual([...seeded].sort());
 		expect(conn.pagination.hasNext).toBe(false);
-		// The last item's cursor is the last node id.
 		expect(conn.items[conn.items.length - 1]!.cursor).toBe(ids[ids.length - 1]);
 	});
 
@@ -360,25 +326,8 @@ describe("pano posts — connection edges", () => {
 		});
 		expect(page.ok).toBe(true);
 		if (!page.ok) return;
-		// The NS-prefixed host scopes the presence/absence check to this test's own rows.
 		const ids = (page.data as Connection<PostNode>).items.map((e) => e.node.id);
 		expect(ids).toContain(keep);
 		expect(ids).not.toContain(gone);
 	});
 });
-
-// covered by pano-mutations.test.ts: post.edit happy path (title alone, body
-//   alone) returning the re-resolved Post, non-author edit → UNAUTHORIZED (title
-//   unchanged), post.delete happy path ({__typename,id} then post(id) null),
-//   non-author delete → UNAUTHORIZED (post survives), post.vote/retractVote happy
-//   path (score + myVote), post.vote on missing id → POST_NOT_FOUND, post.submit
-//   validation codes (TITLE_REQUIRED / TITLE_TOO_LONG / URL_INVALID /
-//   BODY_TOO_LONG / TAGS_REQUIRED / TAG_INVALID) and anonymous → UNAUTHORIZED.
-// covered by pano-read.test.ts: posts connection keyset walk through every row
-//   exactly once (sort:new newest-first, stable id cursor, no skips/dupes) and
-//   the ghost-cursor empty-page edge.
-// not portable black-box: post_vote / user_vote row counts, total_karma
-//   read-backs, post_record body_excerpt columns, hot_score, pano_stats
-//   total_posts decrement, the `{deleted, changed}` service-return flags —
-//   re-expressed via the re-resolved Post (title/body/score/myVote) and the
-//   host-scoped feed over `/fate`.

--- a/apps/web/tests/integration/pano-read.test.ts
+++ b/apps/web/tests/integration/pano-read.test.ts
@@ -1,35 +1,12 @@
 /**
  * pano reads — black-box against the deployed worker `/fate` route (ADR 0026–0031).
  *
- * Ports the read surface of three pre-alchemy suites that drove the `Pano`
- * Effect service / `/fate` route directly inside workerd:
- *   - `fate-pano-read.test.ts` — `posts(sort, host)`, `post(idOrSlug)` detail +
- *     tags, the `Post.comments` keyset, and the `Comment` scalar surface over
- *     `/fate`.
- *   - `pano-post.test.ts` — submit a post and read it back (detail + feed); unknown
- *     id → null; host filter narrows to the requested host.
- *   - `pano-post-connection.test.ts` — `posts` connection paging (every row once,
- *     `new` ordering, ghost cursor).
+ * There is no admin route to inject pano data, so posts + comments are seeded via `/fate`
+ * mutations under a signed-up cookie, and the author of a seeded row is that user.
  *
- * Everything is observed over HTTP: there is no admin route to inject pano data,
- * so posts + comments are seeded via `/fate` mutations under a signed-up cookie
- * (`post.submit`, `comment.add`). The author of a seeded post/comment is the
- * signed-up user's name. Distinct comment authors come from distinct sign-ups.
- *
- * The connection envelope has NO `totalCount` (`{items:[{cursor,node}],
- * pagination:{hasNext, hasPrevious:false, nextCursor?}}`), so the old `totalCount`
- * assertions are dropped and "every row once" is re-expressed by walking
- * `nextCursor` and asserting the union of node ids has the expected size, no dupes.
- * D1 row-shape assertions (post_record / comment_record columns, body_excerpt,
- * the (author_id, created_at) index probe) are not black-box and are dropped;
- * behavior is re-expressed by re-resolving entities over `/fate`.
- *
- * This file runs on the run-scoped SHARED stage (ADR 0104 step 7, #1027), so its one D1 is
- * shared across every migrated file: every host/email is prefixed with `NS` (this file's
- * deterministic `nsToken`). The ordered-feed assertions are scoped by HOST — each seeds its
- * posts under a per-test `${NS}-…` host so the `posts(host)` query filters to exactly this
- * file's (and this test's) rows. The host-scoping IS the namespace: no ordered assertion
- * reads a feed unfiltered by an NS-host.
+ * On the run-scoped SHARED stage (ADR 0104 step 7, #1027), so every host/email is
+ * `NS`-prefixed and every ordered-feed assertion is scoped by HOST: the host-scoping IS the
+ * namespace, and no ordered assertion reads a feed unfiltered by an NS-host.
  */
 import {randomBytes} from "node:crypto";
 import {beforeAll, describe, expect, it} from "vitest";
@@ -74,10 +51,8 @@ let author: {userId: string; cookie: string};
 // is observable per row.
 const commenters: Array<{userId: string; cookie: string}> = [];
 
-// The single seeded read fixture: one post under a unique host, with five
-// chronological comments. The comment ids are forge ULIDs (monotonic with
-// creation order), so the keyset `(created_at asc, id asc)` order equals
-// insertion order.
+// The comment ids are forge ULIDs (monotonic with creation order), so the keyset
+// `(created_at asc, id asc)` order equals insertion order.
 const READ_HOST = `${NS}.example.com`;
 let postId = "";
 const commentIds: string[] = [];
@@ -108,8 +83,6 @@ beforeAll(async () => {
 	if (!submitted.ok) throw new Error("seed post.submit failed");
 	postId = (submitted.data as PostNode).id;
 
-	// Five chronological comments, each from a distinct author. comment.add
-	// returns the re-resolved Comment carrying its id.
 	for (let i = 0; i < 5; i++) {
 		const added = await h.fate(
 			{
@@ -166,8 +139,8 @@ describe("pano reads — /fate", () => {
 			kind: "query",
 			name: "post",
 			args: {idOrSlug: postId},
-			// `tags` is a scalar embedded array (`{kind, label}[]`), selected as a
-			// whole field (no `tags.kind`/`tags.label` relation paths).
+			// `tags` is a scalar embedded array selected as a whole field — there are no
+			// `tags.kind`/`tags.label` relation paths.
 			select: ["id", "title", "url", "host", "score", "commentCount", "tags"],
 		});
 		expect(result.ok).toBe(true);
@@ -194,7 +167,6 @@ describe("pano reads — /fate", () => {
 	});
 
 	it("Post.comments paginates by DB keyset with no skips/dupes across pages", async () => {
-		// Page 1: first 2 in chronological-asc order.
 		const page1 = await h.fate({
 			kind: "query",
 			name: "post",
@@ -209,7 +181,6 @@ describe("pano reads — /fate", () => {
 		const cursor = d1.comments.pagination.nextCursor;
 		expect(cursor).toBe(commentIds[1]); // cursor is the last node id
 
-		// Page 2: after the page-1 cursor.
 		const page2 = await h.fate({
 			kind: "query",
 			name: "post",
@@ -222,7 +193,6 @@ describe("pano reads — /fate", () => {
 		expect(d2.comments.items.map((e) => e.node.id)).toEqual(commentIds.slice(2, 4));
 		expect(d2.comments.pagination.hasNext).toBe(true);
 
-		// Page 3: the last comment, no more.
 		const page3 = await h.fate({
 			kind: "query",
 			name: "post",
@@ -235,7 +205,6 @@ describe("pano reads — /fate", () => {
 		expect(d3.comments.items.map((e) => e.node.id)).toEqual([commentIds[4]]);
 		expect(d3.comments.pagination.hasNext).toBe(false);
 
-		// No skips/dupes: the union of all page ids is exactly the 5 seeded.
 		const allIds = [
 			...d1.comments.items.map((e) => e.node.id),
 			...d2.comments.items.map((e) => e.node.id),
@@ -265,7 +234,6 @@ describe("pano reads — /fate", () => {
 		expect(node.author).toBe("commenter 0");
 		expect(node.authorId).toBe(commenters[0]!.userId);
 		expect(node.score).toBe(0);
-		// Anonymous viewer → myVote null (no cookie on this read).
 		expect(node.myVote).toBeNull();
 	});
 
@@ -309,7 +277,6 @@ describe("pano reads — /fate", () => {
 		expect(post.tags).toHaveLength(1);
 		expect(post.tags[0]!.kind).toBe("göster");
 
-		// Read it back through the feed (filtered to its own host so the row is found).
 		const feed = await h.fate({
 			kind: "list",
 			name: "posts",
@@ -395,7 +362,6 @@ describe("posts connection — keyset walk", () => {
 		const collected: string[] = [];
 		let after: string | undefined;
 		let pages = 0;
-		// Walk the host-scoped connection two at a time until exhausted.
 		for (;;) {
 			const page = await h.fate({
 				kind: "list",
@@ -407,7 +373,6 @@ describe("posts connection — keyset walk", () => {
 			if (!page.ok) return;
 			const conn = page.data as Connection<PostNode>;
 			const ids = conn.items.map((e) => e.node.id);
-			// Each non-empty page's last cursor is the last node id.
 			if (ids.length > 0) {
 				expect(conn.items[ids.length - 1]!.cursor).toBe(ids[ids.length - 1]);
 			}
@@ -418,7 +383,6 @@ describe("posts connection — keyset walk", () => {
 			if (pages > 10) throw new Error("connection walk did not terminate");
 		}
 
-		// Every seeded row appears exactly once, no dupes.
 		expect(new Set(collected).size).toBe(5);
 		expect([...collected].sort()).toEqual([...seededIds].sort());
 		// `sort:new` returns newest-first, i.e. reverse insertion order.
@@ -451,10 +415,3 @@ describe("posts connection — keyset walk", () => {
 		expect(conn.pagination.hasNext).toBe(false);
 	});
 });
-
-// not portable black-box: pano-post-connection.test.ts `totalCount` assertions —
-// the connection envelope has no `totalCount`; "every row once" is re-expressed
-// above by walking `nextCursor` and asserting the union of ids (size 5, no dupes).
-// not portable black-box: pano-submit-post.test.ts D1 row-shape assertions
-// (post_record columns, body_excerpt, tags CSV) and the (author_id, created_at)
-// index probe — re-expressed by re-resolving the Post over `/fate`.

--- a/apps/web/tests/integration/pano-saved-posts.test.ts
+++ b/apps/web/tests/integration/pano-saved-posts.test.ts
@@ -4,13 +4,10 @@
  *
  * Drives the `savedPosts` keyset connection #676 adds: a `Bookmark`-driven page
  * over `post_record`, `CurrentUser`-scoped, ordered by save time
- * (`post_bookmark.created_at DESC, post_id DESC`). Everything is observed over
- * HTTP — saves are made through `post.save`, the list is read back per viewer.
- * The keyset *predicate shape* + cursor-miss/envelope *decision* are pure and
- * unit-tested (`worker/db/keyset.unit.test.ts`); what stays here is the
- * irreducible real-D1 core (ADR 0082): how the engine executes the bookmark
- * keyset across page boundaries, per-viewer scoping, the `isSaved` stamp, and
- * the anonymous empty page.
+ * (`post_bookmark.created_at DESC, post_id DESC`). The keyset predicate shape and
+ * the cursor-miss/envelope decision are pure and unit-tested in
+ * `worker/db/keyset.unit.test.ts`; what stays here is the irreducible real-D1 core
+ * (ADR 0082).
  *
  * Save order is the keyset lead column: saves are stamped `new Date()` in the
  * service, so saving in sequence builds an ascending `created_at` and the list
@@ -47,7 +44,6 @@ type Connection<N> = {
 let saver: {userId: string; cookie: string};
 let other: {userId: string; cookie: string};
 
-/** Submit a post under the saver cookie; return its id. */
 async function seedPost(title: string): Promise<string> {
 	const r = await h.fate(
 		{
@@ -63,7 +59,6 @@ async function seedPost(title: string): Promise<string> {
 	return (r.data as PostNode).id;
 }
 
-/** Save a post under a cookie; assert the toggle landed. */
 async function save(id: string, cookie: string): Promise<void> {
 	const r = await h.fate(
 		{kind: "mutation", name: "post.save", input: {id}, select: ["id", "isSaved"]},
@@ -72,7 +67,7 @@ async function save(id: string, cookie: string): Promise<void> {
 	expect(r.ok).toBe(true);
 }
 
-/** Read a page of the saved-posts list for a cookie (anonymous when omitted). */
+/** Anonymous when `cookie` is omitted. */
 async function savedPage(
 	cookie: string | undefined,
 	args: {first?: number; after?: string} = {},
@@ -111,12 +106,10 @@ describe("pano savedPosts — viewer-scoped saved list", () => {
 		const conn = await savedPage(saver.cookie, {first: 50});
 		const seen = conn.items.map((e) => e.node).filter((n) => mineIds.has(n.id) || n.id === theirs);
 
-		// The saver sees mine1 + mine2, never `theirs` (which `other` saved).
 		expect(seen.map((n) => n.id).sort()).toEqual([mine1, mine2].sort());
 		expect(seen.every((n) => n.isSaved === true)).toBe(true);
 		expect(seen.some((n) => n.id === theirs)).toBe(false);
 
-		// `other` sees the mirror image: `theirs`, never mine1/mine2.
 		const otherConn = await savedPage(other.cookie, {first: 50});
 		const otherSeen = otherConn.items
 			.map((e) => e.node)
@@ -146,7 +139,6 @@ describe("pano savedPosts — viewer-scoped saved list", () => {
 });
 
 describe("pano savedPosts — keyset ordering + pagination on real D1", () => {
-	// Save four fresh posts in sequence; the list returns them newest-save-first.
 	const ORDER_TITLES = [0, 1, 2, 3].map((i) => `${NS} order ${i}`);
 	const orderIds: string[] = [];
 
@@ -166,7 +158,7 @@ describe("pano savedPosts — keyset ordering + pagination on real D1", () => {
 		// Saved 0→1→2→3, so the list leads with 3, 2, 1, 0 among our rows.
 		expect(seen.map((e) => e.node.id)).toEqual([...orderIds].reverse());
 		for (const e of seen) {
-			expect(e.cursor).toBe(e.node.id); // cursor IS the post-id keyset
+			expect(e.cursor).toBe(e.node.id);
 		}
 	});
 
@@ -184,7 +176,6 @@ describe("pano savedPosts — keyset ordering + pagination on real D1", () => {
 			after = conn.pagination.nextCursor;
 			expect(after).toBeDefined();
 		}
-		// Every saved post seen exactly once, in newest-save-first order.
 		expect(seen).toEqual([...orderIds].reverse());
 		expect(new Set(seen).size).toBe(orderIds.length);
 	});

--- a/apps/web/tests/integration/pasaport-api-key.test.ts
+++ b/apps/web/tests/integration/pasaport-api-key.test.ts
@@ -1,20 +1,9 @@
 /**
- * Agent-credential enabler (ADR 0044 Decision 3, #108) — black-box against the
- * deployed worker's `/api/auth/*` + `/fate` routes on real remote D1 (ADR 0082
- * integration tier). Proves the end-to-end apiKey contract a substituted seam can't
- * reach:
+ * Agent-credential enabler (ADR 0044 Decision 3, #108) — black-box against the deployed worker's
+ * `/api/auth/*` + `/fate` routes on real remote D1 (ADR 0082 integration tier), proving the
+ * end-to-end apiKey contract a substituted seam can't reach.
  *
- *   - **A logged-in session mints a key.** `POST /api/auth/api-key/create` under a
- *     session cookie returns the one-time plaintext `key`.
- *   - **The key authenticates as the SAME pasaport user.** A later `me` read carrying
- *     only the `x-api-key` header (no cookie) resolves the identical `user.id` — the
- *     apiKey plugin mock-resolves the session through the same `getSession` path
- *     `Pasaport.validateSession` reads.
- *   - **Create is session-gated (no fail-open).** An unauthenticated create is
- *     rejected, so the mint endpoint never issues a credential to an anonymous caller.
- *
- * Runs on the run-scoped SHARED stage (ADR 0104 step 7). Every email is `NS`-prefixed
- * (this file's deterministic `nsToken`) so its rows can't collide with a sibling file's.
+ * Runs on the run-scoped SHARED stage (ADR 0104), `NS`-prefixed so its rows can't collide.
  */
 import {beforeAll, describe, expect, it} from "vitest";
 import {sharedStack} from "./_integration.ts";
@@ -23,7 +12,6 @@ import {nsToken} from "./_stage-name.ts";
 const h = sharedStack();
 const NS = nsToken(import.meta.url);
 
-// Mint an apiKey under a session cookie; return the one-time plaintext `key`.
 async function createApiKey(cookie: string, name: string): Promise<string> {
 	const res = await h.req(
 		"/api/auth/api-key/create",

--- a/apps/web/tests/integration/pasaport-ban.test.ts
+++ b/apps/web/tests/integration/pasaport-ban.test.ts
@@ -1,28 +1,15 @@
 /**
- * Ban session-refusal enforcement — black-box against the deployed worker `/fate`
- * route over **real remote D1** (ADR 0026–0031 / ADR 0082 integration tier), the
- * security core of #970 (admin epic #968).
+ * Ban session-refusal enforcement — black-box against the deployed worker over real remote D1
+ * (ADR 0082 integration tier), the security core of #970. The load-bearing AC: a ban refuses the
+ * banned user's EXISTING session at the auth boundary, because `Pasaport.validateSession` reads
+ * ban-state fresh from D1 per request.
  *
- * The load-bearing AC (#970): a ban actually **refuses the banned user's existing
- * session at the auth boundary** — not a cosmetic flag. So the round-trip is asserted
- * end to end: sign up → `me` resolves (access) → append a `ban` event → `me` is
- * REFUSED as if signed-out (`UNAUTHORIZED`) even with the SAME valid cookie → append
- * an `unban` event → `me` resolves again (access restored). The enforcement lives in
- * `Pasaport.validateSession`, which reads the ban-state FRESH from D1 per request, so
- * an EXISTING session flips the moment the ban row lands — the whole point.
+ * The ban rows are written DIRECTLY to D1, not through the `user.banUser` mutation: that write
+ * path is dark behind the default-off `phoenix-user-ban` flag (ADR 0083), so this drives the
+ * enforcement read the way a released ban would. The mutation authority is the `unit` tier
+ * (`worker/features/pasaport/ban-mutation.unit.test.ts`), as is the projection (`ban.unit.test.ts`).
  *
- * The ban rows are written DIRECTLY to D1 here (not through the flag-gated
- * `user.banUser` mutation): the write path is dark behind `phoenix-user-ban`
- * (default-off, ADR 0083), so this test drives the enforcement read the way a
- * released ban would, and simultaneously asserts the audit row the enforcement reads
- * carries the actor/target/reason/expiry/time (AC #970). The mutation authority
- * (fail-closed for a non-admin) is the `unit` tier
- * (`worker/features/pasaport/ban-mutation.unit.test.ts`); the projection is
- * `worker/features/pasaport/ban.unit.test.ts`.
- *
- * Runs on the run-scoped SHARED stage (ADR 0104); every id/email is `NS`-prefixed
- * (this file's deterministic token) so its rows are its own, and each user's ban
- * events are cleaned up after the suite.
+ * Runs on the run-scoped SHARED stage (ADR 0104), `NS`-prefixed so its rows are its own.
  */
 import {afterAll, beforeAll, describe, expect, it} from "vitest";
 import {makeIntegrationD1Rest} from "./_cf-rest-transport.ts";
@@ -76,10 +63,8 @@ const insertBanEvent = (row: {
 		.run();
 };
 
-// `me` under a cookie: is the session honored (resolves the User) or refused
-// (UNAUTHORIZED, i.e. treated as anonymous)? D1 read-replica lag means a just-landed
-// ban row can take a beat to be visible to the worker's read, so poll to the expected
-// outcome under a bounded budget rather than assert once and flake.
+// D1 read-replica lag means a just-landed ban row can take a beat to reach the worker's read,
+// so poll to the expected outcome under a bounded budget rather than assert once and flake.
 const meIsHonored = async (cookie: string): Promise<boolean> => {
 	const result = await h.fate({kind: "query", name: "me", select: ["id"]}, {cookie});
 	return result.ok;
@@ -114,10 +99,8 @@ describe("ban enforcement — session refused at the auth boundary (real D1)", (
 		const user = await h.signUp(`${NS}-roundtrip@test.local`, "hunter2hunter2", "Round Trip");
 		userIds.push(user.userId);
 
-		// Before any ban: the session is honored.
 		expect(await meIsHonored(user.cookie)).toBe(true);
 
-		// Ban → the SAME cookie's session is now refused (treated as anonymous).
 		const banAt = nowSec();
 		await insertBanEvent({
 			userId: user.userId,
@@ -129,7 +112,6 @@ describe("ban enforcement — session refused at the auth boundary (real D1)", (
 		});
 		expect(await waitForHonored(user.cookie, false)).toBe(true);
 
-		// Unban (a later event) → access restored on the next request, no re-login.
 		await insertBanEvent({
 			userId: user.userId,
 			action: "unban",
@@ -145,7 +127,6 @@ describe("ban enforcement — session refused at the auth boundary (real D1)", (
 		const user = await h.signUp(`${NS}-expired@test.local`, "hunter2hunter2", "Expired Ban");
 		userIds.push(user.userId);
 
-		// A ban whose `expires_at` is already in the past projects to not-banned.
 		await insertBanEvent({
 			userId: user.userId,
 			action: "ban",
@@ -154,7 +135,6 @@ describe("ban enforcement — session refused at the auth boundary (real D1)", (
 			expiresAtSec: nowSec() - 3600,
 			createdAtSec: nowSec(),
 		});
-		// It never refuses — poll a few times to be sure it doesn't flip late.
 		expect(await waitForHonored(user.cookie, true)).toBe(true);
 	});
 

--- a/apps/web/tests/integration/pasaport-from-tag.test.ts
+++ b/apps/web/tests/integration/pasaport-from-tag.test.ts
@@ -36,11 +36,6 @@ describe("PasaportFromTag — inert RuntimeContext stub guard (real D1)", () => 
 	});
 
 	it("a session round-trips through PasaportFromTag with only the inert stub", async () => {
-		// `me` is the authenticated identity read: it flows through
-		// `Pasaport.validateSession`, which the deployed worker resolves via
-		// `PasaportFromTag` discharging `betterAuth.auth`'s RuntimeContext requirement
-		// with ONLY the inert stub baked into `layers.ts`. A non-null result proves the
-		// stub was sufficient to resolve auth end-to-end against real remote D1.
 		const me = await h.fate(
 			{kind: "query", name: "me", select: ["id", "email"]},
 			{cookie: session.cookie},

--- a/apps/web/tests/integration/pasaport-set-role.test.ts
+++ b/apps/web/tests/integration/pasaport-set-role.test.ts
@@ -2,20 +2,12 @@
  * `Pasaport.setRole` tuple-write fidelity against **real remote D1** (ADR 0082
  * integration tier, #3522) — the security-critical branch the unit tier can't reach.
  *
- * `role-mutation.unit.test.ts` drives the WIRE authority (fail-closed for a non-admin,
- * dark-ship inert) over a STUBBED `Pasaport`, so the domain write itself — the
- * `role === "moderator" ? insert(moderatorTuple).onConflictDoNothing() : delete(...)`
- * ternary inside `Pasaport.setRole` — never runs there, and an inverted ternary would
- * ship green (AC5). This drives the REAL `Pasaport.setRole` over the shipped D1 REST
- * transport and asserts the exact tuple the roster re-reads (`isModerator` /
- * `moderatorsAmong`): `moderator` grants the `(user, "moderates", platform)` tuple
- * (idempotently, `onConflictDoNothing`), `member` revokes it, and every change appends
- * an audited `user_role_event` row.
+ * `role-mutation.unit.test.ts` drives the wire authority over a STUBBED `Pasaport`, so the
+ * grant/revoke ternary inside `Pasaport.setRole` never runs there — an inverted ternary would
+ * ship green (AC5). This drives the REAL `setRole` over the shipped D1 REST transport.
  *
- * Mirrors `kunye-relation-store.test.ts` (the same real-D1 RelationStore primitive over
- * `makeD1Rest` + `createDrizzle`) and `pasaport-ban.test.ts` (the sibling audit-log
- * mutation). Runs on the run-scoped SHARED stage (ADR 0104); every id is `NS`-prefixed
- * (this file's deterministic token) so its rows are its own and are cleaned up after.
+ * Runs on the run-scoped SHARED stage (ADR 0104); every id is `NS`-prefixed so its rows are
+ * its own and are cleaned up after.
  */
 import type {RelationStore} from "@kampus/authz";
 import {readYourWrite} from "@kampus/d1-rest";
@@ -141,14 +133,12 @@ describe("Pasaport.setRole — the real tuple write over real D1 (#3522 AC5)", (
 		const userId = `${NS}-grant`;
 		await createUser(userId);
 
-		// Before: not a moderator.
 		expect(await isModWhen(userId, false)).toBe(false);
 
 		const first = await runSetRole(userId, "moderator");
 		expect(first.role).toBe("moderator");
 		expect(await isModWhen(userId, true)).toBe(true);
 
-		// Re-grant: `onConflictDoNothing` must neither error nor duplicate the tuple.
 		const second = await runSetRole(userId, "moderator");
 		expect(second.role).toBe("moderator");
 		expect(await isModWhen(userId, true)).toBe(true);

--- a/apps/web/tests/integration/pasaport.test.ts
+++ b/apps/web/tests/integration/pasaport.test.ts
@@ -2,48 +2,13 @@
  * pasaport identity + profile — black-box against the deployed worker `/fate`
  * route (ADR 0026–0031).
  *
- * Ports the observable surface of four pre-alchemy suites that drove the
- * resolvers / `Pasaport` service directly inside workerd:
- *   - `fate-pasaport-mutations.test.ts` — `user.setUsername` write + re-resolve,
- *     authenticated `me`, and the username wire-error codes (`TOO_SHORT`,
- *     `INVALID_FORMAT`, `TAKEN`, `ALREADY_SET`, `UNAUTHORIZED`).
- *   - `fate-pasaport-read.test.ts` — `profile(username)` identity + live counters,
- *     null for unknown, the mixed discriminant contributions feed, keyset
- *     pagination.
- *   - `pasaport-username.test.ts` — username validation / uniqueness / immutability
- *     (re-expressed as the wire codes).
- *   - `profile.test.ts` — profile aggregates (1/1/1) + the interleaved
- *     contributions feed + disjoint cursor pages.
+ * Validation is asserted by the wire CODE (`error.code`), never the Turkish message text — the
+ * message may carry TR text but the stable contract is the code.
  *
- * Everything is observed over HTTP. Identity comes from the session
- * (`h.signUp` → cookie). A profile's contributions are seeded by setting a
- * username on the user, then creating one `definition.add` + one `post.submit`
- * + one `comment.add` under that cookie. Validation is asserted by the wire
- * CODE (`error.code`), never the Turkish message text — the message may carry
- * TR text but the stable contract is the code.
- *
- * This file runs on the run-scoped SHARED stage (ADR 0104 step 7, #1027), so its one D1
- * is shared across every migrated file — every email/username/slug is prefixed with `NS`
- * (this file's deterministic `nsToken`); usernames stay within the 3–30 lowercase
- * `[a-z0-9-]` rule, and every assertion (karma is read per-author off the file's own
- * NS-username) scopes to its own rows.
- *
- * not portable black-box: `pasaport-username.test.ts` `user_profile` row
- * read-backs and the Turkish validation message regexes (`/en az 3/`,
- * `/küçük harf/`, `/kullanımda/`, `/zaten/`) — re-expressed as the stable
- * wire codes.
- * not portable black-box: `profile.test.ts` direct `user_profile` seed +
- * `definition_record` / `post_record` / `comment_record` row-landing `waitFor`s
- * (writes are synchronous over `/fate`; just re-resolve) and the `createdAt`
- * timestamp ordering probe (the wire feed exposes a `<sec>:<id>` cursor, not a
- * `Date`) — re-expressed via the keyset cursor order + id-union assertions.
- *
- * moved to unit (ADR 0082): the `TOO_SHORT` / `TOO_LONG` / `INVALID_FORMAT`
- * username codes are the pure `assertUsername` length+format gate, which runs
- * before any DB read — proven with no DB in
- * `worker/features/pasaport/username-validation.unit.test.ts`. The DB-state-
- * dependent `TAKEN` (uniqueness conflict) and `ALREADY_SET` (immutability against
- * a persisted username) stay here on real D1.
+ * Runs on the run-scoped SHARED stage (ADR 0104 step 7), so one D1 is shared across every
+ * migrated file: every email/username/slug is `NS`-prefixed (this file's deterministic
+ * `nsToken`), usernames stay within the 3–30 lowercase `[a-z0-9-]` rule, and every assertion
+ * scopes to its own rows.
  */
 import {beforeAll, describe, expect, it} from "vitest";
 import {sharedStack} from "./_integration.ts";
@@ -106,7 +71,6 @@ const CONTRIB_SELECT = [
 	"contributions.postId",
 ];
 
-/** Set a username on a user (under their cookie); assert success. */
 async function setUsername(cookie: string, value: string): Promise<UserNode> {
 	const result = await h.fate(
 		{
@@ -134,7 +98,6 @@ describe("pasaport — user.setUsername / me", () => {
 		expect(out.email).toBe(`${NS}-setname@test.local`);
 		expect(out.name).toBe("Set Name");
 
-		// `me` (with cookie) now reflects the freshly-set username.
 		const me = await h.fate(
 			{kind: "query", name: "me", select: ["id", "email", "username"]},
 			{cookie: user.cookie},
@@ -146,10 +109,8 @@ describe("pasaport — user.setUsername / me", () => {
 		expect(meData.username).toBe(value);
 	});
 
-	// TOO_SHORT / TOO_LONG / INVALID_FORMAT (the pure `assertUsername` length+format
-	// gate, which runs before any DB read) are unit-tested with no DB in
-	// `worker/features/pasaport/username-validation.unit.test.ts` (ADR 0082). What
-	// stays here is the DB-state-dependent rest of the same mutation.
+	// TOO_SHORT / TOO_LONG / INVALID_FORMAT need no DB, so they live in
+	// `worker/features/pasaport/username-validation.unit.test.ts` (ADR 0082).
 
 	it("a taken username surfaces TAKEN", async () => {
 		const value = uname("taken");
@@ -313,22 +274,14 @@ describe("pasaport — profile reads", () => {
 	});
 
 	it("totalKarma moves 0 → 1 → 0 as a vote on the author's definition is cast then retracted", async () => {
-		// Restores the old 0→1→0 karma read-back the pre-alchemy suites had: a vote
-		// on the author's content bumps the author's `user_profile.total_karma`
-		// atomically (see `pasaport/karma.ts` + `Vote.cast`); retracting reverses it.
-		//
-		// Real-D1 POSITIVE batch-atomicity proof: one cast lands the vote-table write
-		// (score), the `user_vote` mirror (myVote), the score-cache update, and the
-		// karma bump as one unit. The NEGATIVE half (mid-batch rollback / no-partial-
-		// write) has no fate-reachable fault — every `Vote.cast` batch statement is
-		// collision-tolerant by construction — so it stays the generic `db.batch`
-		// property in `db/Drizzle.test.ts`, tracked for real-D1 migration under #582
-		// (see #614; #581 AC3).
+		// The POSITIVE half of `Vote.cast`'s batch atomicity: one cast lands the vote row, the
+		// `user_vote` mirror, the score cache and the karma bump as one unit. The NEGATIVE half
+		// (mid-batch rollback) has no fate-reachable fault — every batch statement is
+		// collision-tolerant by construction — so it stays a `db/Drizzle.test.ts` property (#582).
 		const authorUsername = uname("karma");
 		const author = await h.signUpYazar(`${NS}-karma@test.local`, "hunter2hunter2", "Karma Author");
 		await setUsername(author.cookie, authorUsername);
 
-		// The author writes a definition; a distinct voter will up-vote it.
 		const added = await h.fate(
 			{
 				kind: "mutation",
@@ -358,7 +311,6 @@ describe("pasaport — profile reads", () => {
 			return (res.data as ProfileNode).totalKarma;
 		};
 
-		// Baseline: a freshly-seeded author has zero karma.
 		expect(await karmaOf()).toBe(0);
 
 		// Promoted to yazar so it clears the #1810 "earn to vote" gate (a fresh çaylak is
@@ -370,7 +322,6 @@ describe("pasaport — profile reads", () => {
 			{cookie: voter.cookie},
 		);
 		expect(vote.ok).toBe(true);
-		// The vote bumped the author's karma to 1.
 		expect(await karmaOf()).toBe(1);
 
 		const retract = await h.fate(
@@ -383,7 +334,6 @@ describe("pasaport — profile reads", () => {
 			{cookie: voter.cookie},
 		);
 		expect(retract.ok).toBe(true);
-		// Retracting returns the author's karma to 0.
 		expect(await karmaOf()).toBe(0);
 	});
 
@@ -432,7 +382,6 @@ describe("pasaport — profile reads", () => {
 
 		expect(await karmaOf()).toBe(0);
 
-		// One promoted voter casts the SAME up-vote twice concurrently (two tabs / a retry).
 		const voter = await h.signUp(`${NS}-race-voter@test.local`, "hunter2hunter2", "Race Voter");
 		await h.promoteToYazar(voter.userId);
 		const castOnce = () =>
@@ -442,10 +391,8 @@ describe("pasaport — profile reads", () => {
 			);
 		const casts = await Promise.all([castOnce(), castOnce()]);
 		for (const c of casts) expect(c.ok).toBe(true);
-		// Both casts committed, but the author gained ONE karma, not two.
 		expect(await karmaOf()).toBe(1);
 
-		// Symmetric on retract: two concurrent retractions net a single -1, not -2.
 		const retractOnce = () =>
 			h.fate(
 				{
@@ -462,7 +409,7 @@ describe("pasaport — profile reads", () => {
 	});
 
 	it("Profile.contributions paginates by keyset with no skips/dupes, discriminant preserved", async () => {
-		// Page 1: first 2 in (createdAt desc, id desc) order.
+		// The feed's keyset order is (createdAt desc, id desc).
 		const page1 = await h.fate({
 			kind: "query",
 			name: "profile",
@@ -481,7 +428,6 @@ describe("pasaport — profile reads", () => {
 		const lastNodeId = d1.contributions.items[1]!.node.id;
 		expect(cursor.endsWith(lastNodeId)).toBe(true);
 
-		// Page 2: after the page-1 cursor → the final contribution.
 		const page2 = await h.fate({
 			kind: "query",
 			name: "profile",
@@ -494,8 +440,6 @@ describe("pasaport — profile reads", () => {
 		expect(d2.contributions.items.length).toBe(1);
 		expect(d2.contributions.pagination.hasNext).toBe(false);
 
-		// No skips/dupes: union of all page ids is exactly the 3 seeded; every
-		// node still carries a valid discriminant `kind`.
 		const allNodes = [...d1.contributions.items, ...d2.contributions.items].map((e) => e.node);
 		expect(new Set(allNodes.map((n) => n.id)).size).toBe(3);
 		expect(new Set(allNodes.map((n) => n.kind))).toEqual(

--- a/apps/web/tests/integration/patch-pin-alchemy-cache-options.unit.test.ts
+++ b/apps/web/tests/integration/patch-pin-alchemy-cache-options.unit.test.ts
@@ -1,28 +1,15 @@
 // @patch-pin: alchemy@2.0.0-beta.59
 /**
  * Behavior-pin for the Workers-cache hunk of `patches/alchemy@2.0.0-beta.59.patch`
- * (ADR 0038 + ADR 0170). beta.59 predates alchemy's native per-Worker cache knob,
- * so the patch adds a `cache?: { enabled?: boolean }` prop to `WorkerProps`
- * (`lib/Cloudflare/Workers/Worker.d.ts`) and threads it through `WorkerProvider`
- * (`lib/Cloudflare/Workers/WorkerProvider.js`) as the script-upload metadata's
- * `cache_options` field via the mapping `cache_options: news.cache` — sent only
- * when set, so an unpatched-shaped resource (no `cache`) emits no `cache_options`.
+ * (ADR 0038 + ADR 0170) — beta.59 predates alchemy's native per-Worker cache knob.
  *
- * The provider mapping lives deep inside `LiveWorkerProvider`'s `Effect.gen`
- * closure (the metadata object at construction time), not a pure export, so it is
- * unreachable for a pure characterization call. This pin therefore does two things:
+ * The patched mapping lives inside `LiveWorkerProvider`'s `Effect.gen` closure, not
+ * a pure export, so it can't be called directly. Hence two halves: GROUND reads the
+ * installed artifact's text so a `pnpm install` that drops or rewrites the hunk
+ * reds (the pin's teeth), and CONTRACT models the same mapping to assert both
+ * branches.
  *
- *   1. GROUND — read the real patched artifact off the installed `alchemy` package
- *      and assert the `cache_options: news.cache` threading and the `cache?` prop
- *      are present. If a future `pnpm install` drops or rewrites the hunk (a lost
- *      patch, a native-knob upgrade), these reds — the pin's teeth.
- *   2. CONTRACT — model the `news.cache -> cache_options` mapping the artifact
- *      encodes and assert the prop-threading contract on both branches: `cache`
- *      set threads through, `cache` unset leaves `cache_options` undefined and
- *      drops off the wire under JSON serialization (no accidental emission).
- *
- * Retire this file when a future alchemy release ships the field natively and the
- * patch hunk is removed.
+ * Retire this file when an alchemy release ships the field natively.
  */
 import fs from "node:fs";
 import path from "node:path";
@@ -40,8 +27,6 @@ const propsDts = fs.readFileSync(path.join(workersDir, "Worker.d.ts"), "utf8");
 describe("patch-pin: alchemy cache.enabled -> cache_options (ADR 0170)", () => {
 	describe("grounding — the installed artifact carries the hunk", () => {
 		it("WorkerProvider threads the resource `cache` prop as `cache_options`", () => {
-			// The exact mapping the upload metadata carries. Reds if the threading
-			// line is removed or renamed — acceptance criterion #3.
 			expect(providerSrc).toContain("cache_options: news.cache");
 		});
 
@@ -51,9 +36,8 @@ describe("patch-pin: alchemy cache.enabled -> cache_options (ADR 0170)", () => {
 	});
 
 	describe("contract — the news.cache -> cache_options mapping", () => {
-		// A faithful model of the artifact's single threading line
-		// (`cache_options: news.cache`): the upload metadata's `cache_options`
-		// field IS the resource's `cache` prop, verbatim, whatever its shape.
+		// A faithful model of the artifact's single threading line,
+		// `cache_options: news.cache` — verbatim, whatever the prop's shape.
 		const threadCacheOptions = (news: {cache?: {enabled?: boolean}}) => ({
 			cache_options: news.cache,
 		});

--- a/apps/web/tests/integration/report-moderation.test.ts
+++ b/apps/web/tests/integration/report-moderation.test.ts
@@ -1,17 +1,7 @@
 /**
  * Report moderation (ADR 0098) — black-box against the deployed worker `/fate`
- * route on real remote D1 (ADR 0082 integration tier). The facts that are only
- * right against real D1 + the real substrate:
- *
- *   - **Gate.** `report.listOpen` / `report.resolve` are invisible to a
- *     non-moderator (member or anonymous) — UNAUTHORIZED, never a leak.
- *   - **Act-on-target via the 0096 substrate.** A `resolve(removed)` hides the
- *     target from normal reads (soft-delete, restorable) and stamps the report
- *     `resolved` with the audit triad; it collapses EVERY open report on the target.
- *   - **Repeat-offender count.** `report.listOpen` surfaces the distinct-reporter
- *     count free off the `content_report_target` index.
- *   - **Reopen on restore.** `report.restore` brings the content back AND reopens
- *     its reports (the bounded reopen, ADR 0096 §4 ↔ 0098 §3).
+ * route on real remote D1 (ADR 0082 integration tier). The act-on-target and
+ * bounded-reopen semantics under test are ADR 0096 §4 ↔ 0098 §3.
  *
  * Moderation authority is the `moderates` relation now (ADR 0107, `user.role`
  * retired as an authority source) — granted here via the offline mint path: a
@@ -111,8 +101,6 @@ beforeAll(async () => {
 	reporterB = await h.signUp(`${NS}-rb@test.local`, "hunter2hunter2", "rb");
 	author = await h.signUpYazar(`${NS}-author@test.local`, "hunter2hunter2", "anka");
 
-	// The grant path: mint the moderator's `moderates` tuple directly in D1 (the
-	// offline mint, no runtime endpoint), keyed by canonical `key(platform)`.
 	await h.execD1("INSERT INTO relation_tuple (subject, relation, object) VALUES (?, ?, ?)", [
 		moderator.userId,
 		"moderates",
@@ -185,10 +173,8 @@ describe("report.resolve — act-on-target via substrate + repeat-offender + reo
 		const node = rows.find((e) => e.node.targetId === postId)?.node;
 		expect(node).toBeDefined();
 		if (!node) return;
-		// The join resolved the target's author off the same content read.
 		expect(node.authorId).toBe(author.userId);
 		expect(node.authorTier).not.toBeNull();
-		// The seeded post is one live gönderi by this author — its production footprint.
 		expect(node.authorPostCount).toBeGreaterThanOrEqual(1);
 		// kefil durumu resolves to a concrete boolean (unvouched author ⇒ false).
 		expect(node.authorKefil).toBe(false);
@@ -208,14 +194,11 @@ describe("report.resolve — act-on-target via substrate + repeat-offender + reo
 		const receipt = res.data as {resolution: string; targetRemoved: boolean; collapsed: number};
 		expect(receipt.resolution).toBe("removed");
 		expect(receipt.targetRemoved).toBe(true);
-		// Both open reports on the target collapsed in one batch.
 		expect(receipt.collapsed).toBe(2);
 
-		// Target is hidden from normal reads (soft-deleted via the substrate).
 		const post = await getPost(postId);
 		expect(post.ok && post.data === null).toBe(true);
 
-		// Both report rows are now terminal with the audit triad stamped.
 		const status = await h.execD1(
 			"SELECT 1 FROM content_report WHERE target_kind='post' AND target_id=? AND status='resolved' AND resolution='removed' AND resolver_id=? AND resolved_at IS NOT NULL",
 			[postId, moderator.userId],
@@ -247,11 +230,9 @@ describe("report.resolve — act-on-target via substrate + repeat-offender + reo
 		// `collapsed` carries the reopened-report count on restore.
 		expect((restored.data as {collapsed: number}).collapsed).toBe(2);
 
-		// Content is live again.
 		const post = await getPost(postId);
 		expect(post.ok && post.data !== null).toBe(true);
 
-		// The reports are open again — the queue lists the target with its count.
 		const list = await listOpen(moderator.cookie);
 		expect(list.ok).toBe(true);
 		if (list.ok) {
@@ -287,7 +268,6 @@ describe("report.resolve — a remove that lost the transition removes nothing (
 	});
 
 	it("a dismiss stamps the report terminal first; a later remove leaves the content live", async () => {
-		// The concurrent terminal stamp lands first: the report is now `dismissed`, content present.
 		const dismissed = await resolve(
 			{targetKind: "post", targetId: racePostId, action: "dismiss"},
 			moderator.cookie,
@@ -298,8 +278,6 @@ describe("report.resolve — a remove that lost the transition removes nothing (
 		expect(dismissReceipt.resolution).toBe("dismissed");
 		expect(dismissReceipt.collapsed).toBe(1);
 
-		// The losing `remove` runs against the now-terminal report: it wins no transition, so
-		// the removal leg is skipped — nothing collapses, nothing is removed, no fan-out fires.
 		const removed = await resolve(
 			{targetKind: "post", targetId: racePostId, action: "remove"},
 			moderator.cookie,
@@ -310,7 +288,6 @@ describe("report.resolve — a remove that lost the transition removes nothing (
 		expect(removeReceipt.collapsed).toBe(0);
 		expect(removeReceipt.targetRemoved).toBe(false);
 
-		// The content is still live — NOT removed under the dismissed verdict.
 		const post = await getPost(racePostId);
 		expect(post.ok && post.data !== null).toBe(true);
 

--- a/apps/web/tests/integration/report.test.ts
+++ b/apps/web/tests/integration/report.test.ts
@@ -2,17 +2,12 @@
  * report.submit DEPTH — black-box against the deployed worker `/fate` route
  * (ADR 0026–0031), the real-D1 integration coverage #610 / ADR 0082 call for.
  *
- * The report engine's irreducible real-D1 facts — composite-PK idempotency
- * (`(reporter_id, target_kind, target_id)` + `onConflictDoNothing` ⇒
- * `meta.changes === 0` ⇒ `created === false` on a re-report) and `deletedAt IS
- * NULL` soft-delete rejection — are only otherwise asserted through a `node:sqlite`
- * mock (#581); this suite exercises them over real D1, mirroring
- * `pano-comments.test.ts`'s vote-idempotency shape.
+ * Composite-PK idempotency (`onConflictDoNothing` ⇒ `created === false` on a re-report) and
+ * `deletedAt IS NULL` soft-delete rejection are otherwise asserted only through a
+ * `node:sqlite` mock (#581); this suite exercises them over real D1.
  *
- * This file runs on the run-scoped SHARED stage (ADR 0104 step 7, #1027), so its one
- * D1 is shared across every migrated file: every title/email/target id it seeds is
- * prefixed with `NS` (this file's deterministic `nsToken`) so its rows are uniquely
- * its own and every assertion scopes to them.
+ * On the run-scoped SHARED stage (ADR 0104 step 7, #1027), so every title/email/target id it
+ * seeds is `NS`-prefixed and every assertion scopes to those rows.
  */
 import {beforeAll, describe, expect, it} from "vitest";
 import {sharedStack} from "./_integration.ts";

--- a/apps/web/tests/integration/sanity.shared.test.ts
+++ b/apps/web/tests/integration/sanity.shared.test.ts
@@ -1,12 +1,7 @@
 /**
- * Throwaway sanity test for the run-scoped SHARED stage (ADR 0104 step 7, #1027, PR A).
- *
- * Proves the deploy-once + provide/inject substrate works end-to-end in CI: `_global-setup.ts`
- * deploys ONE stage in vitest `globalSetup`, this file builds the black-box harness over the
- * injected handle via `sharedStack()` (no per-file deploy), and asserts the injected worker
- * URL is a real workers.dev host serving healthy JSON. It migrates nothing — it is the ONLY
- * file on the shared stage in this PR; later PRs move the irreducible real-D1/DO files onto it.
- * Delete (or fold into a real migrated file) once the migration lands.
+ * Throwaway sanity test for the run-scoped SHARED stage (ADR 0104 step 7, #1027): it proves the
+ * deploy-once + inject substrate works in CI and migrates nothing. Delete it (or fold it into a
+ * real migrated file) once the migration lands.
  */
 import {describe, expect, it} from "vitest";
 import {sharedStack} from "./_integration.ts";

--- a/apps/web/tests/integration/seam.test.ts
+++ b/apps/web/tests/integration/seam.test.ts
@@ -1,19 +1,10 @@
 /**
- * fate seam — black-box against the deployed worker `/fate` route (ADR 0026–0031).
+ * fate seam — black-box against the deployed worker `/fate` route.
  *
- * Ported from the pre-alchemy `fate-seam.test.ts`, which drove `SELF.fetch` inside
- * workerd and asserted against `env.PHOENIX_DB`. The new harness deploys the real
- * stack to a local workerd and asserts purely over HTTP. Only the observable seam
- * survives:
- *   - `health` resolves data produced by a real Effect service method
- *     (`Stats.getLandingStats` reading D1) — `definitions` is a number, not a stub.
- *   - `me` resolved anonymously fails the `Auth.required` gate and serializes as
- *     `{ok:false, error:{code:"UNAUTHORIZED"}}` — the wire code the SPA keys off.
- *
- * This file runs on the run-scoped SHARED stage (ADR 0104 step 7, #1027) and needs no
- * namespace token: it seeds nothing. The `health` read touches a global `definitions`
- * count other files seed into, so it asserts the SHAPE (a number ≥ 0), not an exact
- * value; the anonymous-`me` UNAUTHORIZED gate is a fixed route, nothing to scope.
+ * This file runs on the run-scoped SHARED stage (ADR 0104) and needs no namespace
+ * token: it seeds nothing. The `health` read touches a global `definitions` count
+ * other files seed into, so it asserts the SHAPE (a number ≥ 0), not an exact value;
+ * the anonymous-`me` UNAUTHORIZED gate is a fixed route, nothing to scope.
  */
 import {describe, expect, it} from "vitest";
 import {sharedStack} from "./_integration.ts";
@@ -32,10 +23,8 @@ describe("fate seam — /fate", () => {
 		if (!result.ok) return;
 		const data = result.data as {status: string; definitions: number};
 		expect(data.status).toBe("ok");
-		// `definitions` comes from Stats.getLandingStats() reading definition_record —
-		// a number, not a stub/undefined.
-		// not portable black-box: the exact count is a shared-D1 aggregate (other
-		// test files seed definitions), so we assert the type, not a D1 row read-back.
+		// The exact count is a shared-D1 aggregate (other files seed definitions), so
+		// assert the type rather than a value.
 		expect(typeof data.definitions).toBe("number");
 		expect(data.definitions).toBeGreaterThanOrEqual(0);
 	});

--- a/apps/web/tests/integration/search-error-vs-empty.test.ts
+++ b/apps/web/tests/integration/search-error-vs-empty.test.ts
@@ -47,9 +47,6 @@ beforeAll(async () => {
 // isn't tripped here. Remove once #3075's durable ci.yml worker-relevance filter lands.
 describe("search error-vs-empty (#549)", {retry: 2}, () => {
 	it("a legitimate zero-match query succeeds with an empty connection (the 'sonuç yok' branch)", async () => {
-		// A well-formed query that matches nothing: `ok:true` with zero items. This is the
-		// SUCCESS path the page renders as "sonuç yok" — it must stay distinct from the
-		// error path, so a regression that collapses errors into empties is detectable.
 		const res = await h.fate({
 			kind: "list",
 			name: "searchTerms",
@@ -76,9 +73,6 @@ describe("search error-vs-empty (#549)", {retry: 2}, () => {
 			select: ["slug", "title"],
 		});
 
-		// The regression guard: the errored read is an ERROR on the wire (the field
-		// `Screen` discriminates on for the "arama yapılamadı" error rail), never a
-		// successful empty connection that the page would render as "sonuç yok".
 		expect(res.ok).toBe(false);
 		if (!res.ok) {
 			// A non-empty code is what the rail prints (`arama yapılamadı: {code}`); the

--- a/apps/web/tests/integration/search.test.ts
+++ b/apps/web/tests/integration/search.test.ts
@@ -6,43 +6,20 @@
  * the assertions exercise the end-to-end write→FTS-sync→search loop, not a
  * hand-seeded FTS table.
  *
- * This is the real-D1 residue of the retired `worker/features/fate/search.test.ts`
- * suite (#579) — which leaned on the now-deleted `makeSqliteTestDb` in-memory
- * `node:sqlite` D1 fake (gone with the four-tier model, ADR 0082; there is no
- * in-memory SQL tier). The *pure* halves of that suite moved DOWN to
- * `unit`, where they belong and are already proven with no SQL engine:
- *   - Turkish diacritic/dotted-`i` folding + min-length → `normalizeSearchText` /
- *     `toMatchExpression` in `worker/features/search/normalize.unit.test.ts`.
- *   - cursor-miss → empty-page decision → `resolveCursor` in
- *     `worker/db/keyset.unit.test.ts`.
- * What stays here is everything that could only be wrong if the real FTS5 engine
- * differed: bm25 rank order, prefix/`MATCH` honoring, the dual-write sync loop,
- * soft-delete/retitle re-index, title-only scope, and the min-length boundary as
- * it hits the real `searchTerms` op.
+ * What stays here is everything that could only be wrong if the real FTS5 engine differed:
+ * bm25 rank order, prefix/`MATCH` honoring, the dual-write sync loop, soft-delete/retitle
+ * re-index, title-only scope, and the min-length boundary as the real op serves it. The pure
+ * halves live in `worker/features/search/normalize.unit.test.ts` and `worker/db/keyset.unit.test.ts`.
  *
- * This file runs on its OWN DEDICATED per-file stage (`integrationStack`), NOT the run-scoped
- * SHARED stage — because it does multi-request keyset paging walks (`searchTerms first:2 →
- * cursor → after`) whose lead-sort statistic, bm25 rank, is a CROSS-FILE-GLOBAL corpus
- * statistic (total docs / term frequencies over the whole `term_search` table). On a shared
- * D1 a parallel fork's writes BETWEEN two page requests re-rank the corpus mid-walk, skipping
- * or duping a row across the page boundary (CI: search dropped `proje-c`, `Array(2)` vs
- * `Array(3)`). NS-namespacing scopes a single request's RESULT SET but can't fence a global
- * ranking across requests. A dedicated stage gives a stable corpus across the walk — per
- * ADR 0104, paged-walk files stay dedicated (#1027 over-migrated this one; #1143 reverts it).
+ * DEDICATED per-file stage, NOT the run-scoped SHARED one, because the multi-request keyset
+ * walks sort on bm25 rank — a corpus-global statistic over the whole `term_search` table. On
+ * a shared D1 a parallel fork's writes BETWEEN two page requests re-rank the corpus mid-walk
+ * and skip or dupe a row across the page boundary. NS-namespacing scopes one request's result
+ * set but cannot fence a global ranking across requests (ADR 0104: paged-walk files stay
+ * dedicated; #1027 over-migrated this one, #1143 reverts it).
  *
- * The per-file `NS` (this file's deterministic `nsToken`) prefixing is retained from the
- * shared-stage migration: harmless on the dedicated D1, and it keeps the fixtures honest.
- * The FTS index is the normalized TITLE (`fts-sync.ts`) and the `MATCH` builder
- * (`normalize.ts`) ANDs each query token's prefix; every seeded title and FTS query carries
- * the same `NS` token. `NS` is pure ASCII `[a-z0-9-]`, so it folds to itself through
- * `normalizeSearchText` and never perturbs the diacritic fold under test (the `istanbul`
- * token still folds to match a dotted-`İ` title independently), and it's added SYMMETRICALLY
- * to all three `ortak` titles, so the bm25 tie — and the slug-asc page order — is preserved.
- *
- * The min-length boundary (`query: "i"`) is the one query left UN-namespaced: it must short-
- * circuit in `toMatchExpression` (normalized length < MIN_QUERY_LENGTH) BEFORE FTS, and
- * prefixing it with `NS` would push it over the min length and defeat the boundary it proves.
- * It returns `[]` via the short-circuit regardless of the corpus, so it stays correct.
+ * `NS` prefixing is kept anyway: it is pure ASCII `[a-z0-9-]`, so it folds to itself through
+ * `normalizeSearchText` and never perturbs the diacritic fold under test.
  */
 import {key, platform} from "@kampus/authz";
 import {beforeAll, describe, expect, it} from "vitest";
@@ -93,7 +70,6 @@ beforeAll(async () => {
 	author = await h.signUpYazar(`${NS}-${STAMP}-author@test.local`, "hunter2hunter2", "anka");
 });
 
-/** Submit a post under the author cookie; assert success; return its id. */
 async function seedPost(title: string): Promise<string> {
 	const r = await h.fate(
 		{
@@ -111,8 +87,7 @@ async function seedPost(title: string): Promise<string> {
 
 describe("searchTerms — real FTS5 over the deployed worker", () => {
 	// Distinct slug prefixes per concern so one describe's fixtures never leak into
-	// another's result set. (The `NS`-prefixed title + query also scope every match to
-	// this file's rows — retained from the shared-stage era, harmless on the dedicated D1.)
+	// another's result set.
 	const istanbulSlug = `${NS}-${STAMP}-istanbul`;
 	const sisliSlug = `${NS}-${STAMP}-sisli`;
 	const ankaraSlug = `${NS}-${STAMP}-ankara`;
@@ -138,10 +113,8 @@ describe("searchTerms — real FTS5 over the deployed worker", () => {
 	it("an ASCII query matches a diacritic/dotted-i title through the normalized index", async () => {
 		// "istanbul" (ASCII) hits "İstanbul" and "sisli" hits "Şişli" only because the
 		// app-side normalized column is what FTS5 indexes — unicode61's ASCII-wrong
-		// case-fold is sidestepped. (The fold itself is unit-proven in
-		// normalize.unit.test.ts; this proves the engine matches over the folded text.)
-		// The `NS` token only AND-scopes the result set to this file; the diacritic fold
-		// still applies to the `istanbul`/`sisli` token against the dotted-İ/Ş title.
+		// case-fold is sidestepped. The fold itself is unit-proven; this proves the engine
+		// matches over the folded text.
 		const c1 = await searchTerms({query: `${NS} istanbul`});
 		expect(c1.items.map((e) => e.node.slug)).toEqual([istanbulSlug]);
 
@@ -157,10 +130,8 @@ describe("searchTerms — real FTS5 over the deployed worker", () => {
 	});
 
 	it("a below-min-length query returns an empty connection (not everything)", async () => {
-		// The resolver short-circuits (toMatchExpression → null) before touching FTS5;
-		// this asserts that boundary as the real `searchTerms` op serves it end-to-end.
-		// Left UN-namespaced on purpose: the `NS` prefix would push it over the min length
-		// and defeat the short-circuit. It returns `[]` regardless of the corpus.
+		// Left UN-namespaced on purpose: the `NS` prefix would push the query over the min
+		// length and defeat the short-circuit this proves. It returns `[]` for any corpus.
 		const c = await searchTerms({query: "i"});
 		expect(c.items).toEqual([]);
 		expect(c.pagination.hasNext).toBe(false);
@@ -175,10 +146,9 @@ describe("searchTerms — bm25-ranked keyset pagination over real FTS5", () => {
 	];
 
 	beforeAll(async () => {
-		// Three terms sharing the common token "ortak" so bm25 ties make the slug-asc
-		// tiebreaker order the page deterministically across the cursor walk. The `NS`
-		// token is added symmetrically to all three titles, so the bm25 tie (and thus the
-		// slug-asc order) is preserved while the result set is scoped to this file.
+		// Three terms sharing the token "ortak" so bm25 ties, making the slug-asc tiebreaker
+		// order the pages deterministically across the cursor walk. `NS` is added
+		// SYMMETRICALLY to all three titles, or it would break the tie.
 		await h.seedTerm({
 			slug: projectSlugs[0]!,
 			title: `${NS} ortak proje a`,
@@ -258,10 +228,8 @@ describe("searchPosts — FTS5 sync, soft-delete and retitle re-index", () => {
 
 describe("searchTerms — title-only scope (guards against scope creep)", () => {
 	it("excludes a term whose query appears only in its definition body, never the title", async () => {
-		// Scope v1 is titles only: "gövde" appears in every seeded definition body but
-		// never in a title, so a body-only query must return nothing — the real FTS5
-		// index proves the body is not part of the term search document. The `NS` token
-		// scopes the (empty) result to this file: no NS-prefixed title carries `govde`.
+		// Scope v1 is titles only: "gövde" appears in every seeded definition body but never
+		// in a title, so a body-only query must return nothing.
 		await h.seedTerm({
 			slug: `${NS}-${STAMP}-kavram`,
 			title: `${NS} Kavram`,
@@ -273,20 +241,9 @@ describe("searchTerms — title-only scope (guards against scope creep)", () => 
 });
 
 describe("searchPosts — çaylak sandbox read-mask over real FTS5 (#1358 p0 leak)", () => {
-	// The end-to-end half of #1358's AC4 that the rendered-SQL unit test cannot give:
-	// the mask is `id IN (<visible post_record ids>)`, so only a real FTS5 engine
-	// proves a sandboxed row indexed in `post_search` is actually excluded from a
-	// non-author/non-moderator viewer's results AND from the keyset/pagination slots
-	// (the #1312 count/keyset vector), while staying visible to its author and a mod.
-	//
-	// A post is sandboxed by stamping `post_record.sandboxed_at` — the column the
-	// çaylak write path sets via `sandboxedAtForAuthor` (kunye/sandbox.ts). The çaylak
-	// write path has no HTTP handle in the harness, so the sandbox state is minted with
-	// a setup-only `execD1` UPDATE:
-	// the same off-the-binding real-D1 seam `setLastActivityAt` uses for the
-	// server-stamped clock and the founder-seed moderation grant uses for the
-	// `moderates` tuple. The row stays FTS-indexed; only the read-time mask hides it —
-	// exactly the keyset-filter path AC3 documents.
+	// The çaylak write path has no HTTP handle in the harness, so the sandbox state is minted
+	// with a setup-only `execD1` UPDATE on `post_record.sandboxed_at`. The row stays
+	// FTS-indexed; only the read-time mask hides it, which is the path under test.
 	const TOKEN = `${NS} mahzen${STAMP}`;
 	let liveAId = "";
 	let liveBId = "";
@@ -313,9 +270,8 @@ describe("searchPosts — çaylak sandbox read-mask over real FTS5 (#1358 p0 lea
 		liveBId = await seedPost(`${TOKEN} canli b`);
 		sandboxedId = await seedPost(`${TOKEN} karantina`);
 
-		// Stamp the sandbox marker directly. `sandboxed_at` is an epoch-second integer
-		// (timestamp mode); any non-null value sandboxes the row — the predicate only
-		// tests `sandboxed_at IS NULL`.
+		// `sandboxed_at` is an epoch-second integer (timestamp mode); any non-null value
+		// sandboxes the row, since the predicate only tests `sandboxed_at IS NULL`.
 		const changed = await h.execD1("UPDATE post_record SET sandboxed_at = ? WHERE id = ?", [
 			Math.floor(Date.now() / 1000),
 			sandboxedId,
@@ -342,12 +298,10 @@ describe("searchPosts — çaylak sandbox read-mask over real FTS5 (#1358 p0 lea
 	});
 
 	it("allocates no count/pagination slot to the sandboxed row (the #1312 vector)", async () => {
-		// Only the two live posts are visible to anon, so a first:2 page is the FULL set:
-		// `hasNext` must be false. A hydrate-only mask (the bug) would let the sandboxed
-		// row occupy a keyset slot under the `LIMIT first+1` fetch (and the `count(*)`),
-		// flipping `hasNext` true and/or holing the page — the count/keyset leak this
-		// guards. The visible predicate rides count, cursor-rank, and the keyed fetch
-		// alike (Search.ts `ftsKeysetKeys`), so the slot proof is the count proof.
+		// Only the two live posts are visible to anon, so a first:2 page is the FULL set and
+		// `hasNext` must be false. A hydrate-only mask (the bug) would let the sandboxed row
+		// occupy a keyset slot under the `LIMIT first+1` fetch, flipping `hasNext` true or
+		// holing the page.
 		const c = await searchPosts({query: TOKEN, first: 2});
 		const ids = c.items.map((e) => e.node.id);
 		expect(c.items.length).toBe(2);

--- a/apps/web/tests/integration/session-freshness-invariants.test.ts
+++ b/apps/web/tests/integration/session-freshness-invariants.test.ts
@@ -2,26 +2,9 @@
  * Session freshness is a TWO-AXIS invariant (ADR 0169) — black-box against the
  * deployed worker on real remote D1 (ADR 0082 integration tier).
  *
- * ADR 0169 rejects session caching because a session-perf/caching review is a
- * two-axis check, and the first #2263 `cookieCache` review scoped only axis (1) and
- * missed axis (2) — the account-deletion integration test caught the teardown hole by
- * luck, not by the review. This file encodes BOTH axes as REQUIRED, deterministic
- * invariants so the catch lives in the suite, not in one incident:
- *
- *   1. **Capability staleness.** A gated decision (role/tier/karma/ban/kefil) must read
- *      the capability FRESH from Künye on every request — never from a snapshot minted
- *      into the session at login. Proven on the "earn to vote" tier gate (#1810): a
- *      çaylak's cast is rejected, and an out-of-band promotion (no re-login, the SAME
- *      cookie) is honored on the very next cast. A session-cache of the tier would keep
- *      serving the stale çaylak snapshot and fail this. (Its `kunye-admin-seam` /
- *      `kunye-moderate-seam` siblings prove the same fresh-per-call property for the
- *      admin/moderator relation tuples.)
- *   2. **Identity-continuity teardown.** A deleted / logged-out / revoked session must
- *      stop authenticating IMMEDIATELY, never after a TTL. The DELETE path is the
- *      `account-deletion.test` exemplar ADR 0169 keeps as-is; this file covers the
- *      LOGOUT/REVOKE path — sign-out tears the session down so the very next request
- *      under the same cookie is `UNAUTHORIZED`. A `cookieCache` window would keep the
- *      torn-down identity alive for ≤TTL and fail this.
+ * The two axes — capability staleness (#1810, #2263) and identity-continuity teardown —
+ * are encoded here as REQUIRED, deterministic invariants so the catch lives in the suite,
+ * not in one incident. See ADR 0169.
  *
  * Runs on the run-scoped SHARED stage (ADR 0104 step 7). Every email/username is `NS`-
  * prefixed (this file's deterministic token) so its rows can't collide with a
@@ -56,9 +39,6 @@ beforeAll(() => {
 });
 
 describe("ADR 0169 — session freshness is a two-axis invariant", () => {
-	// Axis 1: capability staleness. The tier that gates a vote is read fresh from Künye
-	// on EVERY cast, so a capability change AFTER the cookie was minted is honored under
-	// the SAME cookie — a login-time snapshot would keep the çaylak rejection.
 	it("axis 1 — a capability change (çaylak→yazar) is read FRESH under the same session, not from a login snapshot", async () => {
 		// An eligible author owns a definition the subject can vote on (a self-vote is a
 		// distinct rejection — `SELF_VOTE_NOT_ALLOWED` — so the target must be someone else's).
@@ -87,7 +67,6 @@ describe("ADR 0169 — session freshness is a two-axis invariant", () => {
 		const subject = await h.signUp(`${NS}-subject@test.local`, "hunter2hunter2", "Subject");
 		await setUsername(subject.cookie, uname("subject"));
 
-		// çaylak cast is rejected by the live "earn to vote" tier gate (#1810).
 		const beforePromote = await h.fate(
 			{kind: "mutation", name: "definition.vote", input: {id: definitionId}, select: ["score"]},
 			{cookie: subject.cookie},
@@ -110,18 +89,13 @@ describe("ADR 0169 — session freshness is a two-axis invariant", () => {
 		if (afterPromote.ok) expect((afterPromote.data as {score: number}).score).toBe(1);
 	});
 
-	// Axis 2 (logout/revoke): sign-out tears the session down at once. The DELETE path of
-	// this axis is `account-deletion.test`'s exemplar (ADR 0169 keeps it as-is); this is
-	// its logout/revoke sibling — the same immediate-teardown invariant, different trigger.
 	it("axis 2 — sign-out tears down the session immediately; the very next request is UNAUTHORIZED", async () => {
 		const user = await h.signUp(`${NS}-logout@test.local`, "hunter2hunter2", "Logout");
 		await setUsername(user.cookie, uname("logout"));
 
-		// The session authenticates before logout.
 		const before = await me(user.cookie);
 		expect(before.ok).toBe(true);
 
-		// Log out through the real better-auth endpoint — this revokes the session row.
 		const out = await h.json("/api/auth/sign-out", {}, user.cookie);
 		expect(out.ok).toBe(true);
 
@@ -133,9 +107,8 @@ describe("ADR 0169 — session freshness is a two-axis invariant", () => {
 		if (!after.ok) expect(after.error.code).toBe("UNAUTHORIZED");
 	});
 
-	// Axis 2 (delete): the invariant stated in its dedicated home, not as a side effect of
-	// the anonymize-semantics test — the "caught by luck" gap ADR 0169 closes. The rich
-	// re-attribution semantics stay owned by `account-deletion.test` (unrelaxed).
+	// The rich re-attribution semantics stay owned by `account-deletion.test`; this pins only
+	// the teardown, in its own home rather than as a side effect of that test.
 	it("axis 2 — account deletion tears down the session immediately; the very next request is UNAUTHORIZED", async () => {
 		const user = await h.signUp(`${NS}-delete@test.local`, "hunter2hunter2", "Delete");
 		await setUsername(user.cookie, uname("delete"));

--- a/apps/web/tests/integration/sozluk-cache-reconcile.test.ts
+++ b/apps/web/tests/integration/sozluk-cache-reconcile.test.ts
@@ -1,39 +1,14 @@
 /**
- * sözlük backstop-reconciliation → the AC5 end-to-end guard for #2558.
+ * sözlük backstop-reconciliation — the end-to-end guard for #2558: a term whose LAST write's
+ * cache refresh was swallowed (`swallowRefresh`, #2012) stayed stale forever, because the
+ * convergence contract only promised "heals on the NEXT write". `Sozluk.reconcileCaches` is the
+ * cron-driven backstop. The pure sweep control flow is unit-tested off-DB in
+ * `sozluk-reconcile-scan.unit.test.ts`; this is the irreducible-integration half (ADR 0082).
  *
- * The gap (#2558): the remove/restore + create ceremony SWALLOWS-and-logs a cache-refresh die
- * (`swallowRefresh`, #2012 — the substrate write already committed, so a recomputable-cache die
- * must not 500 the request). That swallow is correct and stays. But the convergence contract is
- * only "heals on the NEXT write", and no reconciliation job existed — so a low-traffic term whose
- * LAST write's refresh died stayed stale indefinitely (wrong `definition_count`/`total_score`/
- * `excerpt`, stale `term_search` FTS row, drifted `sozluk_stats`), invisible to Sentry. The fix
- * is `Sozluk.reconcileCaches` (`Sozluk.ts`), driven periodically by a cron trigger
- * (`sozluk-reconcile-cron.ts`): re-run the convergent cache refresh for EVERY term.
- *
- * The pure sweep control flow (`scanReconcileChunks`) is unit-tested off-DB
- * (`sozluk-reconcile-scan.unit.test.ts`). This is the integration tier AC5 names (ADR 0082
- * §irreducible-integration): the real re-derivation from `definition_record` → the `term_record`
- * + `sozluk_stats` write-back that the unit test can't reach. It:
- *   1. seeds a real term with one definition over the PUBLIC fate seam (`seedTerm`), which
- *      converges `term_record` (`definition_count = 1`) and `sozluk_stats`;
- *   2. constructs the exact #2558 stale state via setup-only D1 writes (`execD1`) — the divergence
- *      a swallowed last-write refresh leaves: `term_record` corrupted to a WRONG summary
- *      (`definition_count = 99`, a bogus `excerpt`) and `sozluk_stats.total_definitions` drifted to
- *      999, while the underlying `definition_record` (the source of truth) is untouched;
- *   3. runs the REAL `Sozluk.reconcileCaches(now)` against this stage's REAL remote D1 (the
- *      fts-backfill / hot-decay precedent, #645/#2027: the SHIPPED service over `@kampus/d1-rest`,
- *      never a `node:sqlite` oracle — banned by ADR 0082 — and never a re-implementation of the
- *      fold; `SozlukLive` built over the real D1 with inert Vote/Reaction/Pasaport stubs, since
- *      the reconcile path touches none of them);
- *   4. asserts `term_record` re-converged to the TRUE summary (`definition_count = 1`, the real
- *      definition's excerpt, not the bogus one) and `sozluk_stats.total_definitions` back to 1 —
- *      the staleness healed with NO user write.
- *
- * There is no HTTP route to trigger the cron on a deployed worker (the scheduled handler fires on
- * Cloudflare's schedule, not on demand), so — like `fts-backfill` / `pano-hot-score-decay` — the
- * test drives the real method directly against this stage's real D1 REST target. Per-file
- * `integrationStack`: this file owns its own worker + D1, so the direct-D1 reconcile and the
- * seeded rows see one isolated table (and `sozluk_stats` counts only this file's definitions).
+ * No HTTP route triggers the cron on a deployed worker, so — like `fts-backfill` /
+ * `pano-hot-score-decay` (#645/#2027) — the test drives the shipped method directly against this
+ * stage's real D1, never a `node:sqlite` oracle (banned by ADR 0082) and never a re-implementation
+ * of the fold. Per-file `integrationStack`, so `sozluk_stats` counts only this file's definitions.
  */
 import {eq} from "drizzle-orm";
 import {type Context, Effect, Layer} from "effect";
@@ -57,12 +32,7 @@ const DEF_BODY = "the one true live definition body for the reconcile term";
 // Vote/Reaction/Pasaport — so inert stubs satisfy the layer without an implementation.
 const inertVote = Layer.succeed(Vote, {} as Context.Service.Shape<typeof Vote>);
 
-/**
- * Build the REAL `Sozluk` service bound to this stage's REAL remote D1 over `@kampus/d1-rest`
- * — the shipped worker code path (`createDrizzle` → `makeDrizzleAccess` → `SozlukLive`), never a
- * re-implementation of its fold. Returns a runner for `reconcileCaches` plus a `read` escape hatch
- * that runs a select against the same real D1 for the assertions.
- */
+/** The shipped `Sozluk` code path bound to this stage's real remote D1, plus a read hatch. */
 async function realSozluk() {
 	const target = await h.d1Target();
 	const db = createDrizzle(makeIntegrationD1Rest(target));
@@ -109,16 +79,14 @@ describe("sözlük backstop-reconciliation (#2558 AC5) — a swallowed-refresh s
 	it("reconcileCaches re-derives term_record + sozluk_stats from definition_record, healing staleness with no user write", async () => {
 		const s = await realSozluk();
 
-		// The seeded true state: one live definition ⇒ term_record.definition_count == 1.
 		const seededTerm = await readTerm(s);
 		expect(seededTerm?.definitionCount).toBe(1);
 		const trueExcerpt = seededTerm?.excerpt;
 		expect(trueExcerpt).toBeTruthy();
 
-		// Construct the exact #2558 stale state the swallowed last-write refresh leaves: the
-		// summary caches diverge from the (untouched) definition_record source of truth. This is
-		// the setup-only fault-injection the public seam can't reach — the swallowed refresh means
-		// term_record/sozluk_stats never caught up to a committed definition write.
+		// Setup-only fault injection the public seam can't reach: the summary caches diverge
+		// from the untouched definition_record, exactly as a swallowed last-write refresh leaves
+		// them.
 		const staleTerm = await h.execD1(
 			"UPDATE term_record SET definition_count = ?, total_score = ?, excerpt = ? WHERE slug = ?",
 			[99, 99, "STALE-SWALLOWED-REFRESH", SLUG],
@@ -130,26 +98,21 @@ describe("sözlük backstop-reconciliation (#2558 AC5) — a swallowed-refresh s
 		);
 		expect(staleStats).toBe(1);
 
-		// Pre-reconcile: the corrupted summary is what a read now surfaces — the bug state.
 		const before = await readTerm(s);
 		expect(before?.definitionCount).toBe(99);
 		expect(before?.excerpt).toBe("STALE-SWALLOWED-REFRESH");
 		const statsBefore = await readStats(s);
 		expect(statsBefore?.totalDefinitions).toBe(999);
 
-		// Run the REAL reconcile against real remote D1 — the shipped full sweep + write-back.
 		const result = await s.reconcile(new Date());
-		expect(result.scanned).toBeGreaterThanOrEqual(1); // the seeded term is swept
+		expect(result.scanned).toBeGreaterThanOrEqual(1);
 
-		// Post-reconcile: term_record re-derived from the untouched definition_record — the true
-		// count and excerpt are back, the bogus values gone. The staleness healed with NO user
-		// write (no add/edit/vote happened between the corruption and here).
+		// Healed with NO user write: nothing added, edited or voted since the corruption.
 		const after = await readTerm(s);
 		expect(after?.definitionCount).toBe(1);
 		expect(after?.excerpt).toBe(trueExcerpt);
 		expect(after?.excerpt).not.toBe("STALE-SWALLOWED-REFRESH");
 
-		// And the stats leg re-converged too: total_definitions back to the one seeded live def.
 		const statsAfter = await readStats(s);
 		expect(statsAfter?.totalDefinitions).toBe(1);
 	});

--- a/apps/web/tests/integration/sozluk-keyset.test.ts
+++ b/apps/web/tests/integration/sozluk-keyset.test.ts
@@ -1,14 +1,11 @@
 /**
  * sözlük keyset EXECUTION verticals on real remote Cloudflare D1 (ADR 0082).
  *
- * The keyset *predicate shape* and the cursor-miss/page-envelope *decision* are
- * pure and unit-tested (`worker/db/keyset.unit.test.ts`: `keysetAfter`,
- * `resolveCursor`, `forwardPage`) — those are deletions from the retired
- * `node:sqlite` fate-op suite, not re-proven here. What stays at `integration`
- * is the irreducible real-D1 core (ADR 0082 "Irreducible integration core"): how
- * the real engine *executes* the keyset — ordering and tie-breaks across page
- * boundaries — plus read-row shaping, the denormalized term_record counters,
- * and the write→read re-resolve loop.
+ * The keyset predicate shape and the cursor-miss/page-envelope decision are pure
+ * and unit-tested in `worker/db/keyset.unit.test.ts`, not re-proven here. What
+ * stays is the irreducible real-D1 core (ADR 0082): how the real engine executes
+ * the keyset across page boundaries, read-row shaping, the denormalized
+ * term_record counters, and the write→read re-resolve loop.
  *
  * Seeded through the PUBLIC fate seam (`h.seedTerm` → `definition.add` +
  * `definition.vote`), so `score` (vote-derived) and `slug` (caller-chosen) are
@@ -88,16 +85,8 @@ const POP: Array<[slug: string, score: number]> = [
 // `keysetAfter` shape, unit-tested).
 const DEFS_SLUG = `${NS}-defs`;
 
-// `terms(recent)` keyset is `(last_activity_at desc, slug asc)`. `last_activity_at`
-// is server-stamped (`recomputeTermSummary` writes `floor(now/1000)`) and never
-// settable through the public seam — so the prior fixture seeded four terms and then
-// raced two back-to-back touches hoping they'd land in the SAME wall-clock second to
-// build the date tie. Against real remote D1 the round-trip latency separates those
-// two writes' seconds far more often than not, so that race lost ~deterministically
-// and reddened unrelated PRs (#643). Instead, seed the four terms and stamp each row's
-// `last_activity_at` to an EXACT whole-second epoch directly (`h.setLastActivityAt`):
-// the activity order is CONSTRUCTED, the 2/3 tie is an identical injected second, and
-// nothing depends on wall-clock alignment.
+// `terms(recent)` keyset is `(last_activity_at desc, slug asc)`; the activity order
+// is stamped directly rather than touched — see the file docblock (#643).
 const R = `${NS}-r`; // recent-fixture slug prefix
 const REC_SLUGS = [`${R}1`, `${R}2`, `${R}3`, `${R}4`] as const;
 
@@ -106,10 +95,10 @@ const REC_SLUGS = [`${R}1`, `${R}2`, `${R}3`, `${R}4`] as const;
 // a prior run's rows, and spaced by 10s so the strict steps can't collapse.
 const REC_BASE_SEC = Math.floor(STAMP / 1000);
 const REC_ACTIVITY_SEC: Record<string, number> = {
-	[`${R}1`]: REC_BASE_SEC, // oldest
-	[`${R}2`]: REC_BASE_SEC + 10, // tie with 3
-	[`${R}3`]: REC_BASE_SEC + 10, // tie with 2
-	[`${R}4`]: REC_BASE_SEC + 20, // newest
+	[`${R}1`]: REC_BASE_SEC,
+	[`${R}2`]: REC_BASE_SEC + 10,
+	[`${R}3`]: REC_BASE_SEC + 10,
+	[`${R}4`]: REC_BASE_SEC + 20,
 };
 
 beforeAll(async () => {
@@ -130,9 +119,6 @@ beforeAll(async () => {
 		],
 	});
 
-	// Seed the four recent-fixture terms, then stamp each one's `last_activity_at` to
-	// its fixed second — no touch, no clock, no race. The 2/3 pair gets an IDENTICAL
-	// second, so the only thing that can order them is the engine's slug-asc tiebreak.
 	for (const slug of REC_SLUGS) {
 		await h.seedTerm({
 			slug,
@@ -166,7 +152,7 @@ describe("sözlük keyset execution — real D1 (terms popular)", () => {
 			// THESE rows' relative order.
 			for (const e of conn.items.filter((x) => x.node.slug.startsWith(P))) {
 				seen.push(e.node.slug);
-				expect(e.cursor).toBe(e.node.slug); // cursor IS the slug keyset
+				expect(e.cursor).toBe(e.node.slug);
 			}
 			if (!conn.pagination.hasNext) break;
 			after = conn.pagination.nextCursor;
@@ -177,7 +163,6 @@ describe("sözlük keyset execution — real D1 (terms popular)", () => {
 	});
 
 	it("holds the (total_score) tie at a page boundary by slug asc", async () => {
-		// Walk straight to the c/d tie pair and assert slug-asc orders them.
 		const all = await h.fate({
 			kind: "list",
 			name: "terms",
@@ -197,8 +182,6 @@ describe("sözlük keyset execution — real D1 (terms popular)", () => {
 });
 
 describe("sözlük keyset execution — real D1 (terms recent)", () => {
-	// Pull THIS fixture's rows (prefix-scoped) from a recent page, preserving the
-	// engine's order, with the `last_activity_at` D1 recorded.
 	const recentOurs = async (
 		args: {first: number; after?: string} = {first: 100},
 	): Promise<{slugs: string[]; rows: TermNode[]; conn: Connection<TermNode>}> => {
@@ -217,8 +200,8 @@ describe("sözlük keyset execution — real D1 (terms recent)", () => {
 
 	it("orders recent by (last_activity_at desc, slug asc) — strict steps + a same-second tie", async () => {
 		const {slugs, rows} = await recentOurs();
-		expect(new Set(slugs)).toEqual(new Set(REC_SLUGS)); // all four present
-		expect(new Set(slugs).size).toBe(REC_SLUGS.length); // no dupes
+		expect(new Set(slugs)).toEqual(new Set(REC_SLUGS));
+		expect(new Set(slugs).size).toBe(REC_SLUGS.length);
 
 		// The engine's order must honor the keyset over whatever timestamps D1
 		// recorded: `last_activity_at` non-increasing, and any same-second run broken
@@ -230,15 +213,13 @@ describe("sözlük keyset execution — real D1 (terms recent)", () => {
 		for (let i = 1; i < rows.length; i++) {
 			const prev = rows[i - 1]!;
 			const cur = rows[i]!;
-			expect(sec(prev)).toBeGreaterThanOrEqual(sec(cur)); // last_activity_at desc
+			expect(sec(prev)).toBeGreaterThanOrEqual(sec(cur));
 			if (sec(prev) === sec(cur)) {
-				expect(prev.slug < cur.slug).toBe(true); // tie → slug asc
+				expect(prev.slug < cur.slug).toBe(true);
 			}
 		}
 
-		// The injected activity seconds (1 oldest | 2 == 3 tie | 4 newest) pin a concrete
-		// expected order on top of the invariant: 4 (newest) → 2 → 3 (the same-second
-		// pair, slug asc) → 1 (oldest).
+		// The injected seconds pin a concrete order on top of the invariant above.
 		expect(slugs).toEqual([`${R}4`, `${R}2`, `${R}3`, `${R}1`]);
 
 		// The 2/3 pair is the date TIE — assert it really shares a second (so the
@@ -249,11 +230,8 @@ describe("sözlük keyset execution — real D1 (terms recent)", () => {
 	});
 
 	it("walks recent across the tie boundary with no skips/dupes (cursor = slug)", async () => {
-		// Walk the whole recent list in pages of 2, collecting THIS fixture's rows in
-		// engine order. Page-prefix-scoped (other terms in D1 may interleave on a
-		// NO_DESTROY re-run); the claim is these four rows' relative order + that the
-		// 2/3 same-second tie survives whatever page boundary it lands on, resolved
-		// slug-asc across the cursor round-trip.
+		// The claim: the 2/3 same-second tie survives whatever page boundary it lands
+		// on, resolved slug-asc across the cursor round-trip.
 		const seen: string[] = [];
 		let after: string | undefined;
 		let safety = 0;
@@ -261,14 +239,14 @@ describe("sözlük keyset execution — real D1 (terms recent)", () => {
 			const {conn} = await recentOurs(after ? {first: 2, after} : {first: 2});
 			for (const e of conn.items.filter((x) => x.node.slug.startsWith(R))) {
 				seen.push(e.node.slug);
-				expect(e.cursor).toBe(e.node.slug); // cursor IS the slug keyset
+				expect(e.cursor).toBe(e.node.slug);
 			}
 			if (seen.length >= REC_SLUGS.length || !conn.pagination.hasNext) break;
 			after = conn.pagination.nextCursor;
 			expect(after).toBeDefined();
 		}
 		expect(seen).toEqual([`${R}4`, `${R}2`, `${R}3`, `${R}1`]);
-		expect(new Set(seen).size).toBe(REC_SLUGS.length); // no skips/dupes across boundaries
+		expect(new Set(seen).size).toBe(REC_SLUGS.length);
 	});
 });
 
@@ -313,7 +291,7 @@ describe("sözlük keyset execution — real D1 (Term.definitions)", () => {
 		expect(d2.pagination.hasNext).toBe(false);
 
 		const all = [...d1.items, ...d2.items].map((e) => e.node.id);
-		expect(new Set(all).size).toBe(3); // no dupes across the boundary
+		expect(new Set(all).size).toBe(3);
 	});
 });
 
@@ -390,9 +368,9 @@ describe("sözlük write→read re-resolve — real D1", () => {
 		expect(t2.ok).toBe(true);
 		if (!t2.ok) return;
 		const term2 = t2.data as {count: number; definitions: Connection<DefNode>};
-		expect(term2.count).toBe(firstCount + 1); // counter re-resolved off the new write
+		expect(term2.count).toBe(firstCount + 1);
 		const ids = term2.definitions.items.map((e) => e.node.id);
-		expect(ids).toContain(created); // the first write still resolves
+		expect(ids).toContain(created);
 		expect(term2.definitions.items.some((e) => e.node.body === "second definition")).toBe(true);
 	});
 });

--- a/apps/web/tests/integration/sozluk-mutations.test.ts
+++ b/apps/web/tests/integration/sozluk-mutations.test.ts
@@ -2,23 +2,10 @@
  * sozluk mutations — black-box against the deployed worker `/fate` route
  * (ADR 0026–0031).
  *
- * Ports the write surface of four pre-alchemy suites that drove the mutation
- * resolvers / `Sozluk` service directly inside workerd:
- *   - `fate-sozluk-mutations.test.ts` — add/vote/retract/edit/delete + wire-error
- *     parity (`BODY_REQUIRED`, `DEFINITION_NOT_FOUND`, `UNAUTHORIZED`).
- *   - `sozluk-add-definition.test.ts` — auto-create term, title-from-slug,
- *     validation (`BODY_REQUIRED`, `BODY_TOO_LONG`), second add extends the term.
- *   - `sozluk-edit-delete-definition.test.ts` — edit happy/validation/ownership,
- *     delete decrements aggregates, ownership, idempotent re-delete.
- *   - `sozluk-vote-definition.test.ts` — vote/idempotency/retract/round-trip/
- *     not-found.
- *
  * Everything is observed over HTTP. Author identity comes from the session
  * (`h.signUp`), not explicit `authorId`/`authorName` — so the add input is
- * `{termSlug, termTitle?, body}`. Direct D1 row assertions (body_excerpt,
- * deleted_at, vote-row counts, total_karma) are dropped; behavior is re-expressed
- * by re-resolving entities over `/fate`. Ownership uses two real users: the author
- * creates, the intruder's cookie attempts edit/delete → `UNAUTHORIZED`.
+ * `{termSlug, termTitle?, body}`, and behavior is re-expressed by re-resolving
+ * entities over `/fate` rather than asserting D1 rows.
  *
  * This file runs on the run-scoped SHARED stage (ADR 0104 step 7, #1027), so its one D1 is
  * shared across every migrated file. Isolation is by `NS` (this file's deterministic
@@ -102,7 +89,6 @@ describe("sozluk mutations — definition.add", () => {
 		expect(def.score).toBe(0);
 		expect(def.myVote).toBeNull();
 
-		// The row really landed (a read-back through the term query sees it).
 		const term = await h.fate({
 			kind: "query",
 			name: "term",
@@ -257,7 +243,6 @@ describe("sozluk mutations — definition.vote / retractVote", () => {
 		};
 
 		const beforeVote = await readUpdatedAt();
-		// The planted baseline really landed (a whole second in the past).
 		expect(beforeVote).toBe(new Date(BASELINE_EPOCH_S * 1000).toISOString());
 
 		const voted = await h.fate(
@@ -267,15 +252,9 @@ describe("sozluk mutations — definition.vote / retractVote", () => {
 		expect(voted.ok).toBe(true);
 		if (!voted.ok) return;
 		expect((voted.data as {score: number}).score).toBe(1);
-		// Persisted updatedAt is unchanged by the vote (DB round-trip) — byte-identical to the
-		// baseline — and the resolver/live-push return reports that same genuine value, not the
-		// vote instant.
 		expect(await readUpdatedAt()).toEqual(beforeVote);
 		expect((voted.data as {updatedAt: unknown}).updatedAt).toEqual(beforeVote);
 
-		// A genuine content edit still bumps updatedAt — edit detection is not disabled. Because
-		// the baseline is a constructed PAST second, the edit's real `now` is deterministically a
-		// later second, so this holds no matter how fast create+vote+edit ran (no second-straddle).
 		const edited = await h.fate(
 			{kind: "mutation", name: "definition.edit", input: {id, body: "edited body"}, select: ["id"]},
 			{cookie: author.cookie},
@@ -283,7 +262,6 @@ describe("sozluk mutations — definition.vote / retractVote", () => {
 		expect(edited.ok).toBe(true);
 		const afterEdit = await readUpdatedAt();
 		expect(afterEdit).not.toEqual(beforeVote);
-		// Not merely different — strictly forward: an edit advances updatedAt past the baseline.
 		expect(new Date(afterEdit as string).getTime()).toBeGreaterThan(
 			new Date(beforeVote as string).getTime(),
 		);
@@ -524,7 +502,6 @@ describe("sozluk mutations — definition.edit", () => {
 		if (result.ok) return;
 		expect(result.error.code).toBe("UNAUTHORIZED");
 
-		// The original body survived.
 		const term = await h.fate({
 			kind: "query",
 			name: "term",
@@ -598,11 +575,9 @@ describe("sozluk mutations — definition.delete", () => {
 		const term = deleted.data as TermNode;
 		expect(term.__typename).toBe("Term");
 		expect(term.slug).toBe(slug);
-		// One definition remains; the deleted one's score is gone.
 		expect(term.count).toBe(1);
 		expect(term.totalScore).toBe(0);
 
-		// The survivor is the only definition left.
 		const remaining = await h.fate({
 			kind: "query",
 			name: "term",
@@ -676,9 +651,6 @@ describe("sozluk mutations — definition.delete", () => {
 		if (!first.ok) return;
 		expect((first.data as TermNode).count).toBe(1);
 
-		// Re-delete: the row is already soft-deleted; the Term is still returned
-		// with the same (unchanged) count. (The old `{deleted:false}` flag is not
-		// on the wire.)
 		const second = await h.fate(
 			{kind: "mutation", name: "definition.delete", input: {id: aId}, select: ["slug", "count"]},
 			{cookie: author.cookie},

--- a/apps/web/tests/integration/sozluk-read.test.ts
+++ b/apps/web/tests/integration/sozluk-read.test.ts
@@ -1,14 +1,8 @@
 /**
  * sozluk reads — system smoke against the deployed worker `/fate` route (ADR 0026–0031).
  *
- * This is the SMOKE residue after the keyset/pagination CORRECTNESS was migrated
- * down to a fate-op integration test (`worker/features/fate/sozluk-keyset.test.ts`):
- * popular/recent ordering across pages, the `Term.definitions` keyset walk, the
- * `endCursor`/`hasNext` semantics, and stale-cursor collapse are all asserted
- * there now, seeded by direct INSERT with explicit `score`/`createdAt`/`id` — no
- * votes, no `sleep`. The flake engine that lived here (HTTP sign-up + per-score
- * `definition.vote` seeding + a `sleep(1100)` to space `last_activity_at` across
- * its second-resolution) is gone with it.
+ * Keyset/pagination CORRECTNESS is not here — it lives in
+ * `worker/features/fate/sozluk-keyset.test.ts`.
  *
  * What stays here is the genuinely system-level claim that fate-op test cannot make: the
  * DEPLOYED worker serves sozluk reads end-to-end over HTTP — the `/fate` route is
@@ -151,7 +145,6 @@ describe("sozluk reads — deployed worker /fate (system smoke)", () => {
 		expect(alpha!.author).toBe(seeded[0]!.authorName);
 		expect(alpha!.authorId).toBe(seeded[0]!.authorId);
 		expect(alpha!.score).toBe(2);
-		// Anonymous viewer → myVote null.
 		expect(alpha!.myVote).toBeNull();
 	});
 });

--- a/apps/web/tests/integration/stats.test.ts
+++ b/apps/web/tests/integration/stats.test.ts
@@ -2,12 +2,6 @@
  * landing stats — black-box against the deployed worker `/fate` route
  * (ADR 0026–0031).
  *
- * Ports `landing-stats.test.ts`, which drove the `Sozluk` / `Pano` / `Stats`
- * services directly inside workerd and asserted the `sozluk_stats` / `pano_stats`
- * single-row aggregates against direct-D1 `COUNT` parity reads. Over HTTP the
- * only observable surface is the `landingStats` query (four counters + the
- * build `version`).
- *
  * This file runs on the run-scoped SHARED stage (ADR 0104 step 7, #1027), so its one D1
  * is shared across every migrated file — concurrent writers can only INFLATE the global
  * `landingStats` counters between this file's snapshots. Every assertion here is a
@@ -17,18 +11,6 @@
  * widens the gap, never narrows it, so no `>=` ever breaks. The delta form is independent
  * of the absolute baseline, which is never fixed (the harness seeds its own author/voter
  * users for sign-up and seeding).
- *
- * not portable black-box: the `landing-stats.test.ts` direct-D1 COUNT parity
- * assertions (`total_definitions === COUNT(*) FROM definition_record`, distinct
- * `total_authors` across view tables, `pano_stats` post/comment parity) — the
- * raw view tables aren't on the wire; re-expressed as observable deltas.
- * not portable black-box: the soft-delete decrement probe (`deleteDefinition`
- * → `total_definitions` ticks down) read the `sozluk_stats` row directly; the
- * raw `sozluk_stats` row isn't on the wire, so here we only assert the delete is
- * accepted and re-resolves its parent Term.
- * not portable black-box: `Stats.getLandingStats` service-method call + its
- * cross-product `COUNT` parity — covered by the `landingStats` fate query delta
- * (the seam test already asserts `health.definitions` flows from this service).
  */
 import {beforeAll, describe, expect, it} from "vitest";
 import {sharedStack} from "./_integration.ts";
@@ -74,7 +56,6 @@ describe("landing stats — /fate", () => {
 	it("each counter increases by AT LEAST the amount added under a fresh author", async () => {
 		const before = await landingStats();
 
-		// 2 definitions on distinct slugs.
 		for (let i = 0; i < 2; i++) {
 			const def = await h.fate(
 				{
@@ -88,7 +69,6 @@ describe("landing stats — /fate", () => {
 			expect(def.ok).toBe(true);
 		}
 
-		// 1 post.
 		const post = await h.fate(
 			{
 				kind: "mutation",
@@ -102,7 +82,6 @@ describe("landing stats — /fate", () => {
 		if (!post.ok) return;
 		const postId = (post.data as {id: string}).id;
 
-		// 3 comments on that post.
 		for (let i = 0; i < 3; i++) {
 			const comment = await h.fate(
 				{
@@ -118,9 +97,6 @@ describe("landing stats — /fate", () => {
 
 		const after = await landingStats();
 
-		// Deltas: at least what we added. These are lower-bound `>=` deltas on the shared
-		// stage's global counters — concurrent writers can only inflate them between our two
-		// snapshots, which only widens the gap, so `>=` holds without depending on a baseline.
 		expect(after.totalDefinitions).toBeGreaterThanOrEqual(before.totalDefinitions + 2);
 		expect(after.totalPosts).toBeGreaterThanOrEqual(before.totalPosts + 1);
 		expect(after.totalComments).toBeGreaterThanOrEqual(before.totalComments + 3);
@@ -148,7 +124,6 @@ describe("landing stats — /fate", () => {
 		if (!added.ok) return;
 		const id = (added.data as {id: string}).id;
 
-		// After our add, the total is at least baseline + our 1.
 		const afterAdd = await landingStats();
 		expect(afterAdd.totalDefinitions).toBeGreaterThanOrEqual(baseline.totalDefinitions + 1);
 

--- a/infra/depo/depo.ts
+++ b/infra/depo/depo.ts
@@ -3,11 +3,9 @@
  * the `depo.kamp.us` custom domain (ADR 0144: depo is kampus's internal asset
  * store / CDN, dumb by mandate).
  *
- * Read path only: objects live in the R2 bucket and are fetched anonymously at
- * `https://depo.kamp.us/<sha256>.<ext>` straight off R2 — no worker sits in the
- * read path (ADR 0144 decision 3). Attaching the custom domain with public access
- * enabled IS the read seam; there is nothing else to serve. The write path (the
- * doorman upload worker) and the `depo` CLI are separate slices of epic #1965.
+ * Read path only: attaching the custom domain with public access enabled IS the read seam, and
+ * there is nothing else to serve (ADR 0144 decision 3). The write path (the doorman upload worker)
+ * and the `depo` CLI are separate slices of epic #1965.
  *
  * A public-read custom domain is FORCED and bounds what depo may hold: anything
  * embeddable in a GitHub PR/issue must be anonymously fetchable (GitHub's Camo
@@ -15,12 +13,9 @@
  * security — unguessable, but readable by anyone holding the URL. depo (for the
  * GitHub-embed path) must never hold read-sensitive assets (ADR 0144).
  *
- * Own stack, own deploy cycle — NOT a route on `apps/web`, NOT an `apps/` worker
- * (ADR 0144 decision 2; the `infra/ci-credentials` standalone-stack precedent,
- * ADR 0057). Deploy is a scripted/manual `pnpm --filter @kampus/depo-infra
- * deploy:depo`, reusing the account-global alchemy state store + the CI Cloudflare
- * secrets — no second bootstrap (ADR 0057). Wiring it into CI deploy automation
- * touches `.github/**` (control-plane) and is a separate follow-up, out of scope.
+ * Own stack, own deploy cycle — NOT a route on `apps/web`, NOT an `apps/` worker (ADR 0144
+ * decision 2, ADR 0057). Deploy is a manual `pnpm --filter @kampus/depo-infra deploy:depo`; wiring
+ * it into CI deploy automation is a separate follow-up.
  */
 import * as Alchemy from "alchemy";
 import * as Cloudflare from "alchemy/Cloudflare";

--- a/infra/depo/worker/domain.ts
+++ b/infra/depo/worker/domain.ts
@@ -31,7 +31,6 @@ export type AllowedExt = (typeof ALLOWED_TYPES)[AllowedContentType];
 /** ~10 MB (ADR 0144 decision 4). Bodies at or under the cap are accepted. */
 export const SIZE_CAP_BYTES = 10 * 1024 * 1024;
 
-/** The public read host — a depo URL is `https://depo.kamp.us/<sha256>.<ext>`. */
 export const PUBLIC_HOST = "https://depo.kamp.us";
 
 /**
@@ -51,13 +50,11 @@ export const allowedContentType = (
 	return Effect.fail(new UnsupportedMediaType({contentType: normalized || "<none>"}));
 };
 
-/** Refuse a body strictly over the cap; at-or-under passes. */
 export const withinSizeCap = (size: number): Effect.Effect<number, PayloadTooLarge> =>
 	size > SIZE_CAP_BYTES
 		? Effect.fail(new PayloadTooLarge({size, cap: SIZE_CAP_BYTES}))
 		: Effect.succeed(size);
 
-/** Lowercase hex of a SHA-256 digest — the content-address stem. */
 export const sha256Hex = (bytes: Uint8Array): Effect.Effect<string> =>
 	Effect.tryPromise({
 		try: () => crypto.subtle.digest("SHA-256", bytes),
@@ -73,12 +70,10 @@ export const sha256Hex = (bytes: Uint8Array): Effect.Effect<string> =>
 		),
 	);
 
-/** The R2 object key for a body of a given type: `<sha256>.<ext>`. */
 export const contentAddressKey = (
 	bytes: Uint8Array,
 	contentType: AllowedContentType,
 ): Effect.Effect<string> =>
 	sha256Hex(bytes).pipe(Effect.map((hex) => `${hex}.${ALLOWED_TYPES[contentType]}`));
 
-/** The permanent public URL for a stored key: `https://depo.kamp.us/<key>`. */
 export const publicUrl = (key: string): string => `${PUBLIC_HOST}/${key}`;

--- a/infra/depo/worker/index.ts
+++ b/infra/depo/worker/index.ts
@@ -1,14 +1,8 @@
 /**
- * The depo doorman — the write path for depo (ADR 0144 decision 4), a standalone
- * alchemy-effect worker (ADRs 0026–0031) on its own stack (`doorman.ts`), separate
- * from `apps/web` (ADR 0057). DUMB BY MANDATE: it authenticates, guards, content-
- * addresses, writes once, and returns the URL — no transforms, no gallery, no read
- * path (reads stay zero-compute off R2 at `depo.kamp.us`, #1969).
- *
- * The single surface is `PUT /` on `up.depo.kamp.us`: raw image bytes in, a
- * `{key,url}` JSON out. The domain rules and both seams (auth, storage) live in
- * their own modules so this file is thin — bind resources, wire the seams, map the
- * one operation's typed failures to HTTP status.
+ * The depo doorman — depo's write path (ADR 0144 decision 4), a standalone
+ * alchemy-effect worker on its own stack. DUMB BY MANDATE: it authenticates,
+ * guards, content-addresses, writes once, returns the URL — no transforms, no
+ * gallery, no read path (reads stay zero-compute off R2 at `depo.kamp.us`, #1969).
  */
 
 import {RuntimeContext} from "alchemy";
@@ -30,11 +24,9 @@ import {Storage} from "./storage.ts";
 import {upload} from "./upload.ts";
 import {ApiKeyVerifier, makeApiKeyVerifier} from "./verifier.ts";
 
-/** The apiKey is presented as an `Authorization: Bearer <key>` or `x-api-key` header. */
 const apiKeyOf = (headers: Headers): string | null =>
 	headers.get("x-api-key") ?? headers.get("authorization")?.replace(/^Bearer\s+/i, "") ?? null;
 
-/** Map a doorman failure to its HTTP response. Domain refusals are 4xx; infra is 500. */
 const toResponse = (error: {readonly _tag: string}): HttpServerResponse.HttpServerResponse => {
 	switch (error._tag) {
 		case "depo/Unauthorized":
@@ -79,7 +71,6 @@ export default Doorman.make(
 		},
 	},
 	Effect.gen(function* () {
-		// ── INIT PHASE ── bind the two adopted resources once per isolate.
 		const rwBucket = yield* Cloudflare.R2.ReadWriteBucket(DepoBucket);
 		const rawDb = yield* (yield* Cloudflare.D1.QueryDatabase(PasaportDb)).raw;
 		// The ambient RuntimeContext R2 ops carry in their `R` (ADR 0124), resolved once.
@@ -113,7 +104,6 @@ export default Doorman.make(
 			ApiKeyVerifier.of(makeApiKeyVerifier(rawDb, Redacted.value(secret))),
 		);
 
-		// ── RUNTIME PHASE ── the one route: PUT / (write-once upload).
 		const routes = HttpRouter.add(
 			"PUT",
 			"/",
@@ -141,7 +131,6 @@ export default Doorman.make(
 							contentType: "application/json",
 						}),
 					),
-					// Every typed failure maps to its HTTP status here (the one place).
 					Effect.catch((error) => Effect.succeed(toResponse(error))),
 				);
 			}),

--- a/infra/depo/worker/resources.ts
+++ b/infra/depo/worker/resources.ts
@@ -19,19 +19,11 @@
  */
 import * as Cloudflare from "alchemy/Cloudflare";
 
-/**
- * The depo R2 bucket. Declared identically to `depo.ts` so the shared desired
- * state never drifts between the read stack and the doorman stack.
- */
 export const DepoBucket = Cloudflare.R2.Bucket("depo", {
 	name: "depo",
 	domains: [{name: "depo.kamp.us"}],
 });
 
-/**
- * The web app's D1 (`phoenix_db`), adopted by name for read-only apiKey lookups.
- * No `migrationsDir`: phoenix_db's schema is owned by `apps/web`, never by depo.
- */
 export const PasaportDb = Cloudflare.D1.Database("phoenix_db", {
 	name: "phoenix_db",
 });

--- a/infra/depo/worker/storage.ts
+++ b/infra/depo/worker/storage.ts
@@ -1,10 +1,8 @@
 /**
- * The storage seam — the doorman's view of R2, narrowed to exactly the two ops
- * write-once needs: `head` (does this content-address already exist?) and `put`
- * (store it). Narrowing to a seam (not the raw R2 client) is what lets the upload
- * orchestrator's write-once decision unit-test with a scripted in-memory store,
- * with no live bucket (`.patterns/effect-testing.md` unit tier; the R2-put seam is
- * the unit-tier Drizzle-seam analogue).
+ * The doorman's view of R2, narrowed to the two ops write-once needs. Narrowing to a
+ * seam rather than taking the raw R2 client is what lets the upload orchestrator's
+ * write-once decision unit-test against a scripted in-memory store, with no live
+ * bucket (`.patterns/effect-testing.md`).
  *
  * The Live implementation wraps the alchemy `ReadWriteBucketClient` and is wired in
  * `worker/index.ts`, where the bucket binding and its `RuntimeContext` are in scope.
@@ -19,9 +17,7 @@ export interface StoredObject {
 }
 
 export interface StorageService {
-	/** The object at `key`, or `null` if the key is free. */
 	readonly head: (key: string) => Effect.Effect<StoredObject | null, StorageError>;
-	/** Write `bytes` at `key` with the given content type. */
 	readonly put: (
 		key: string,
 		bytes: Uint8Array,

--- a/infra/depo/worker/upload.ts
+++ b/infra/depo/worker/upload.ts
@@ -5,14 +5,7 @@
  * seam (`Storage`), so it unit-tests end to end with both seams substituted and no
  * live D1 / R2 (`.patterns/effect-testing.md`).
  *
- * Order is load-bearing and is the acceptance contract:
- *   1. verify the apiKey            → `Unauthorized` stores nothing
- *   2. allowlist the content-type   → `UnsupportedMediaType`
- *   3. size cap                     → `PayloadTooLarge`
- *   4. content-address              → the `<sha256>.<ext>` key
- *   5. write-once                   → existing key: byte-identical re-PUT is a
- *      benign success; differing bytes are refused `ContentAddressConflict`
- *   6. put + return the public URL
+ * The order of the steps below is load-bearing: it IS the acceptance contract.
  */
 import * as Effect from "effect/Effect";
 import {allowedContentType, contentAddressKey, publicUrl, withinSizeCap} from "./domain.ts";
@@ -35,17 +28,15 @@ export interface UploadResult {
 
 export const upload = (req: UploadRequest) =>
 	Effect.gen(function* () {
-		// 1. Auth first — a bad key must never reach storage (nothing is written).
+		// Auth first — a bad key must never reach storage (nothing is written).
 		yield* (yield* ApiKeyVerifier).verify(req.apiKey);
 
-		// 2–3. Domain guards on the raw upload before we touch its bytes further.
 		const contentType = yield* allowedContentType(req.contentType);
 		yield* withinSizeCap(req.body.byteLength);
 
-		// 4. Content-address → the immutable key.
 		const key = yield* contentAddressKey(req.body, contentType);
 
-		// 5. Write-once. The key IS the sha256 of the bytes, so an existing key of the
+		// Write-once. The key IS the sha256 of the bytes, so an existing key of the
 		// same byte length is provably the same content — a benign idempotent re-PUT
 		// (return created:false). A byte-length mismatch under an identical content-
 		// address is a sha256 collision the doorman refuses rather than overwrites.
@@ -58,7 +49,6 @@ export const upload = (req: UploadRequest) =>
 			return {key, url: publicUrl(key), created: false} satisfies UploadResult;
 		}
 
-		// 6. Store and return the permanent public URL.
 		yield* storage.put(key, req.body, contentType);
 		return {key, url: publicUrl(key), created: true} satisfies UploadResult;
 	});

--- a/infra/depo/worker/upload.unit.test.ts
+++ b/infra/depo/worker/upload.unit.test.ts
@@ -1,9 +1,6 @@
 /**
- * Unit tests for the upload orchestrator (`upload.ts`) — the whole write path with
- * both seams substituted (no live D1 / R2), per `.patterns/effect-testing.md`. This
- * is where the issue's acceptance rules are proven at the unit tier: the auth gate,
- * the allowlist + size cap ordering, and write-once (idempotent re-PUT vs refusing a
- * differing body under an existing key).
+ * The whole write path with both seams substituted (no live D1 / R2), per
+ * `.patterns/effect-testing.md`.
  *
  * The `Storage` double is an in-memory map recording puts, so a "no write" claim is
  * provable (a refused upload leaves the map empty); the `ApiKeyVerifier` double is
@@ -19,7 +16,6 @@ import {Storage, type StoredObject} from "./storage.ts";
 import {type UploadRequest, upload} from "./upload.ts";
 import {ApiKeyVerifier} from "./verifier.ts";
 
-/** A recording in-memory storage double: `put`s land in `store`; `head` reads it. */
 const makeStorageDouble = (store: Map<string, StoredObject>) =>
 	Layer.succeed(Storage)(
 		Storage.of({
@@ -31,7 +27,6 @@ const makeStorageDouble = (store: Map<string, StoredObject>) =>
 		}),
 	);
 
-/** A verifier double: accepts any non-null key as `user-1`, rejects null. */
 const acceptingVerifier = Layer.succeed(ApiKeyVerifier)(
 	ApiKeyVerifier.of({
 		verify: (key) =>
@@ -41,7 +36,6 @@ const acceptingVerifier = Layer.succeed(ApiKeyVerifier)(
 	}),
 );
 
-/** A verifier double that rejects everything. */
 const rejectingVerifier = Layer.succeed(ApiKeyVerifier)(
 	ApiKeyVerifier.of({
 		verify: () => Effect.fail(new Unauthorized({reason: "invalid"})),

--- a/infra/depo/worker/verifier.ts
+++ b/infra/depo/worker/verifier.ts
@@ -1,20 +1,13 @@
 /**
- * The auth seam. `ApiKeyVerifier` resolves a presented pasaport `apiKey` to its
- * owning user id, or fails `Unauthorized` (ADR 0144 decision 4; the agent-
- * credential path of ADRs 0044/0045). It is a SEAM so the upload domain unit-tests
- * with a scripted verifier and the production wiring stays out of the pure core.
+ * The auth seam: resolve a presented pasaport `apiKey` to its owning user id
+ * (ADR 0144 decision 4; the agent-credential path of ADRs 0044/0045).
  *
- * `ApiKeyVerifierLive` is the production implementation: it verifies against the
- * SAME better-auth `apiKey` table pasaport owns, on the shared `phoenix_db` D1
- * (`worker/resources.ts` adopts it read-only). Verification is delegated to the
- * `@better-auth/api-key` plugin's own `verifyApiKey` — the doorman never re-derives
- * the key hash or the enabled/expiry rules itself (grounding the credential check
- * in the plugin, not intuition: the plugin hashes with `defaultKeyHasher` =
- * base64url(SHA-256(key)), which is an internal detail the doorman must not copy).
- *
- * Building a minimal better-auth instance (drizzle-adapter + `apiKey()` plugin)
- * bound to phoenix_db keeps depo DUMB: it borrows pasaport's credential store to
- * answer one yes/no question and owns none of pasaport's schema or migrations.
+ * It verifies against the SAME better-auth `apiKey` table pasaport owns, on the
+ * shared `phoenix_db`. Verification is delegated to the `@better-auth/api-key`
+ * plugin's own `verifyApiKey` — the doorman must never re-derive the key hash or
+ * the enabled/expiry rules itself (the plugin's `defaultKeyHasher` is an internal
+ * detail). A minimal better-auth instance over phoenix_db keeps depo dumb: it
+ * borrows pasaport's credential store and owns none of its schema or migrations.
  */
 import {apiKey} from "@better-auth/api-key";
 import type {D1Database} from "@cloudflare/workers-types";
@@ -26,7 +19,6 @@ import * as Effect from "effect/Effect";
 import {Unauthorized} from "./errors.ts";
 
 export interface AuthenticatedCaller {
-	/** The pasaport user id the key belongs to (uploads are attributed to it). */
 	readonly userId: string;
 }
 
@@ -39,14 +31,10 @@ export class ApiKeyVerifier extends Context.Service<ApiKeyVerifier, ApiKeyVerifi
 ) {}
 
 /**
- * Build the production verifier over a raw `phoenix_db` handle. A per-key
- * `auth.api.verifyApiKey` round-trip returns `{valid, key: {referenceId, enabled}}`
- * (`referenceId` is the owning entity — the pasaport user id, per the plugin's
- * default `references`); anything that is not a valid, enabled key — or any thrown
- * error below — is a flat `Unauthorized` (no detail leak to the caller). `secret`
- * is pasaport's `BETTER_AUTH_SECRET`, passed so any secret-dependent apiKey path
- * matches its issuer (the hash lookup itself is secret-independent —
- * `defaultKeyHasher`).
+ * `referenceId` is the plugin's owning entity — the pasaport user id. Anything
+ * that is not a valid, enabled key, and any thrown error, is a flat `Unauthorized`
+ * with no detail leaked to the caller. `secret` is pasaport's own, passed so any
+ * secret-dependent apiKey path matches its issuer.
  */
 export const makeApiKeyVerifier = (db: D1Database, secret: string): ApiKeyVerifierService => {
 	const auth = betterAuth({

--- a/packages/anka-ops/src/analytics.ts
+++ b/packages/anka-ops/src/analytics.ts
@@ -1,14 +1,10 @@
 /**
- * The Analytics Engine read seam — the IO shell the `report` runner resolves its AE query through.
- * ADR 0153 mandates reads go through the external AE SQL API (never from the worker); this is the
- * operator-side client for exactly that. It rides the SAME ambient `Credentials | HttpClient` the
- * Flagship clients do (ADR 0045: one shared scoped operator credential), so `report`
- * inherits the keychain-first least-privilege credential seam and rolls no second token store.
+ * The Analytics Engine read seam — reads go through the external AE SQL API, never from the
+ * worker (ADR 0153), over the same ambient credential the Flagship clients use (ADR 0045).
  *
- * The transport is the CF AE SQL endpoint `POST {apiBaseUrl}/accounts/{id}/analytics_engine/sql`
- * with the raw SQL as the request body, returning a ClickHouse-style JSON envelope `{ data: [...] }`
- * (Cloudflare AE SQL API: https://developers.cloudflare.com/analytics/analytics-engine/sql-api/).
- * The query itself is rendered sampling-correct upstream in `report.ts`; this seam only executes it.
+ * AE answers a raw-SQL POST with a ClickHouse-style `{data: [...]}` envelope
+ * (https://developers.cloudflare.com/analytics/analytics-engine/sql-api/). The query is
+ * rendered sampling-correct upstream in `report.ts`; this seam only executes it.
  */
 
 import {Credentials, type ResolvedCredentials} from "@distilled.cloud/cloudflare/Credentials";
@@ -21,11 +17,7 @@ import type {ReportRow} from "./report.ts";
 
 const accountId = Config.string("CLOUDFLARE_ACCOUNT_ID");
 
-/**
- * Any failure of an AE read, collapsed to one typed `E`-channel fault carrying a human reason —
- * a missing account id, an unresolvable credential, a transport error, a non-2xx from AE, or an
- * unparseable body all surface here rather than a raw stack trace (rendered by `NodeRuntime.runMain`).
- */
+/** Every AE-read failure collapses here, so `NodeRuntime.runMain` renders a reason, not a stack. */
 export class AnalyticsReadError extends Schema.TaggedErrorClass<AnalyticsReadError>()(
 	"@kampus/anka-ops/AnalyticsReadError",
 	{reason: Schema.String},
@@ -35,7 +27,6 @@ export class AnalyticsReadError extends Schema.TaggedErrorClass<AnalyticsReadErr
 	}
 }
 
-/** The `Authorization` header for the resolved credential — Bearer for token/oauth, X-Auth for API-key. */
 const authHeaders = (credentials: ResolvedCredentials): Record<string, string> => {
 	switch (credentials.type) {
 		case "apiToken":
@@ -50,7 +41,6 @@ const authHeaders = (credentials: ResolvedCredentials): Record<string, string> =
 	}
 };
 
-/** Coerce AE's JSON `{ data: [row, …] }` envelope into typed rows, or fail if the shape is wrong. */
 const parseRows = (json: unknown): Effect.Effect<ReadonlyArray<ReportRow>, AnalyticsReadError> => {
 	if (
 		typeof json !== "object" ||
@@ -76,7 +66,6 @@ const parseRows = (json: unknown): Effect.Effect<ReadonlyArray<ReportRow>, Analy
 	return Effect.succeed(rows);
 };
 
-/** `AnalyticsRead` — the injectable AE read seam. `query` runs one SQL read and returns decoded rows. */
 export class AnalyticsRead extends Context.Service<
 	AnalyticsRead,
 	{

--- a/packages/anka-ops/src/bin.ts
+++ b/packages/anka-ops/src/bin.ts
@@ -1,18 +1,10 @@
 #!/usr/bin/env node
 /**
- * `anka-ops` — the operator CLI for anka-built apps (`effect/unstable/cli`, the same shell shape
- * as `@kampus/orphan-sweep`). The framework-tier skeleton (epic #2089, ADR 0045) grown into the
- * `auth`, `flag`, and `report` verb groups.
- *
- *   node src/bin.ts auth login              paste a scoped operator token → OS keychain
- *   node src/bin.ts auth status             report where credentials resolve from + whether they authenticate
- *   node src/bin.ts auth logout             clear the stored credentials
+ * `anka-ops` — the operator CLI for anka-built apps (ADR 0045).
  *
  * Credentials resolve keychain-first (`auth login`), falling back to $CLOUDFLARE_API_TOKEN /
- * $CLOUDFLARE_ACCOUNT_ID — the env path CI keeps using. A missing/unauthorized credential
- * surfaces a typed error on the `E` channel, rendered by `NodeRuntime.runMain` (never a raw
- * stack trace). The command tree, the verb-group registry, and the credential seam live in
- * `cli.ts`; this shell just runs them.
+ * $CLOUDFLARE_ACCOUNT_ID — the env path CI keeps using. The command tree, the verb-group
+ * registry, and the credential seam live in `cli.ts`; this shell just runs them.
  */
 import {NodeRuntime} from "@effect/platform-node";
 import {Effect} from "effect";

--- a/packages/anka-ops/src/cli.ts
+++ b/packages/anka-ops/src/cli.ts
@@ -1,16 +1,8 @@
 /**
- * The `anka-ops` command tree + the shared operator-credential runtime layer.
- *
- * This is the framework-tier skeleton (epic #2089, ADR 0045): the root `anka-ops` command wires
- * the `auth`, `flag`, and `report` verb groups — `auth` reused wholesale from `@kampus/cf-credentials`
- * so anka-ops rolls NO second credential store — and leaves `VERB_GROUPS` as the single extension
- * point children fold their groups into. No product verb (no flag, no report content) lands here.
- *
- * The runtime layer is the credential seam every verb group resolves through: keychain-first
- * (`anka-ops auth login` → OS keychain), falling back to $CLOUDFLARE_API_TOKEN / $CLOUDFLARE_ACCOUNT_ID
- * for CI (the byte-for-byte-unchanged env path). A missing/unauthorized credential surfaces a typed
- * error on the `E` channel, rendered by `NodeRuntime.runMain` in bin.ts — never a raw stack trace.
- * `report` resolves the injected `ReportCatalog` (empty in the core) + the AE read client through it.
+ * The `anka-ops` command tree + the shared operator-credential runtime layer (ADR 0045). No
+ * product verb lands here: this is the framework tier, and children extend it through
+ * `VERB_GROUPS`. Credentials are keychain-first, falling back to $CLOUDFLARE_API_TOKEN /
+ * $CLOUDFLARE_ACCOUNT_ID for CI.
  */
 import {NodeServices} from "@effect/platform-node";
 import {
@@ -29,17 +21,12 @@ import {makeReportCatalog} from "./report.ts";
 import {REPORT_CATALOG} from "./report-catalog.ts";
 import {report} from "./report-command.ts";
 
-/** A verb group folded under the root `anka-ops` command — the ops-language surface descriptor. */
 export interface VerbGroup {
 	readonly name: string;
 	readonly summary: string;
 }
 
-/**
- * The registry of shipped verb groups — the single place a child extends the ops language.
- * `flag` runs on the local Flagship core (#3133); `report` folds the generic AE-read runner over
- * an injected report catalog (#3134). A new group touches both this registry and `withSubcommands`.
- */
+/** A new group touches BOTH this registry and `withSubcommands` below. */
 export const VERB_GROUPS: ReadonlyArray<VerbGroup> = [
 	{
 		name: "auth",
@@ -56,7 +43,6 @@ export const VERB_GROUPS: ReadonlyArray<VerbGroup> = [
 	},
 ];
 
-/** The root command. Extension point: a new group adds its `Command` to `withSubcommands`. */
 export const ankaOps = Command.make("anka-ops").pipe(
 	Command.withSubcommands([auth, flag, report]),
 	Command.withDescription(
@@ -64,16 +50,11 @@ export const ankaOps = Command.make("anka-ops").pipe(
 	),
 );
 
-// The keychain-first credential seam + its account-id ConfigProvider twin, with `KeychainLive`
-// underneath and a Node ChildProcessSpawner (for `security`) + Fetch HTTP client (for the
-// validating read) below (ADR 0045: one shared credential seam across every operator CLI).
 const CredentialLayer = Layer.mergeAll(CredentialsKeychainFirst, AccountIdKeychainConfig).pipe(
 	Layer.provideMerge(KeychainLive),
 );
 
-// The per-verb-group clients, all provided ON TOP of the shared credential seam (ADR 0045: one
-// credential): the Flagship read/write clients for `flag`, the AE read client for `report`, and the
-// injected report catalog (EMPTY in the core — product content is wired via REPORT_CATALOG, ADR 0153).
+// Provided ON TOP of the shared credential seam — one credential across every group (ADR 0045).
 const VerbGroupClients = Layer.mergeAll(
 	FlagshipReadLive,
 	FlagshipWriteLive,
@@ -81,7 +62,6 @@ const VerbGroupClients = Layer.mergeAll(
 	makeReportCatalog(REPORT_CATALOG),
 );
 
-/** The runtime layer bin.ts provides to `anka-ops`; every verb group resolves through it. */
 export const AnkaOpsRuntimeLayer = Layer.provideMerge(
 	VerbGroupClients,
 	CredentialLayer.pipe(Layer.provideMerge(Layer.merge(FetchHttpClient.layer, NodeServices.layer))),

--- a/packages/anka-ops/src/cli.unit.test.ts
+++ b/packages/anka-ops/src/cli.unit.test.ts
@@ -7,7 +7,6 @@
 import {assert, describe, it} from "@effect/vitest";
 import {ankaOps, VERB_GROUPS} from "./cli.ts";
 
-/** Flatten the wired subcommand names off the (group, commands) tree. */
 const wiredSubcommandNames = (): ReadonlyArray<string> =>
 	ankaOps.subcommands.flatMap((entry) => entry.commands.map((command) => command.name)).sort();
 

--- a/packages/anka-ops/src/flag-command.ts
+++ b/packages/anka-ops/src/flag-command.ts
@@ -4,15 +4,8 @@
  * serving-plan math is re-implemented here: the operator-verb → lever mapping is the only new logic
  * and lives in the pure `./flag.ts` adapter.
  *
- *   anka-ops flag list                            enumerate every flag × env and its serving state
- *   anka-ops flag get <key> [--env <env>]         read a flag's live serving state
- *   anka-ops flag open <key> --env <env>          release on (100% no-match split; --percent N to ramp)
- *   anka-ops flag close <key> --env <env>         kill (clear the split + default off)
- *   anka-ops flag graduate <key>                  verify fully open in prod, file the retirement chore
- *
- * `open`/`close` dry-run by default; the live flip happens only under `--execute`, and a TTY human
- * is confirmed first (the ADR 0134 posture, `posture.ts`). `graduate` never flips — it verifies the
- * flag is fully open and files a `report`-idiom chore (dry-run by default, `--execute` to file).
+ * Every verb dry-runs by default: the live flip happens only under `--execute`, and a TTY human is
+ * confirmed first (the ADR 0134 posture, `posture.ts`). `graduate` never flips.
  */
 
 import {execFileSync} from "node:child_process";
@@ -64,7 +57,6 @@ const executeFlag = Flag.boolean("execute").pipe(
 	),
 );
 
-/** Resolve the Flagship app for `env`, or fail `FlagEnvNotFound` listing the envs that DO resolve. */
 const resolveEnvApp = (env: string) =>
 	Effect.gen(function* () {
 		const read = yield* FlagshipRead;
@@ -142,11 +134,6 @@ const confirmFlip = (key: string, env: string) =>
 		}
 	});
 
-/**
- * The shared open/close release body: read-before-plan, render the `current → target` diff, and
- * (only under `--execute` on a changed plan, after the confirm) apply the resolved `ServeTarget`.
- * `open` and `close` differ only in the target they resolve — the plan/write/confirm are identical.
- */
 const applyServing = (key: string, env: string, target: ServeTarget, execute: boolean) =>
 	Effect.gen(function* () {
 		const app = yield* resolveEnvApp(env);
@@ -176,7 +163,6 @@ const open = Command.make(
 	"open",
 	{key: keyArg, env: envFlag, percent: percentFlag, execute: executeFlag},
 	Effect.fn(function* ({key, env, percent, execute}) {
-		// Full 100% open by default (the adapter's `open` lever); `--percent N` ramps the split.
 		if (percent._tag === "Some" && (percent.value < 0 || percent.value > 100)) {
 			return yield* new FlagSetTargetInvalid({
 				reason: `--percent ${percent.value} is outside 0–100`,

--- a/packages/anka-ops/src/flag.ts
+++ b/packages/anka-ops/src/flag.ts
@@ -37,10 +37,6 @@ export type GraduateDecision =
 	| {readonly _tag: "Eligible"; readonly key: string}
 	| {readonly _tag: "Ineligible"; readonly key: string; readonly reason: string};
 
-/**
- * Decide graduation from the flag's per-env rows (the `selectStatesForKey` slice of `flag list`).
- * Eligible only when the prod row exists and its effective serving is a full (100%) no-match split.
- */
 export const decideGraduate = (input: {
 	readonly key: string;
 	readonly states: ReadonlyArray<FlagState>;
@@ -69,10 +65,8 @@ export const decideGraduate = (input: {
 };
 
 /**
- * The retirement chore's title + body, filed via the `report` skill idiom (`status:needs-triage`,
- * type-blind — triage classifies it `type:chore`). The body names the concrete removal work the
- * cycle's §Retirement + step 7 of the feature-flags workflow prescribe, so `write-code` can drain
- * it: delete the declaration, the `getBoolean` read + dead `else`, and inline the now-permanent path.
+ * Filed via the `report` skill idiom: `status:needs-triage` and type-blind, because triage is
+ * what classifies it `type:chore`.
  */
 export const renderRetirementChore = (
 	key: string,

--- a/packages/anka-ops/src/flag.unit.test.ts
+++ b/packages/anka-ops/src/flag.unit.test.ts
@@ -1,9 +1,7 @@
 /**
- * The `flag` verb group's pure adapter — the operator-verb → serving-lever mapping (#3133). The
- * load-bearing contract: `open`/`close` map onto the EXACT `ServeTarget` levers (100%
- * no-match split / kill) so no serving-plan math is duplicated, and `graduate` only greenlights a
- * flag fully open in prod. No IO: the mapping is a pure value, the graduate decision a pure fold
- * over already-listed `FlagState` rows.
+ * Pins the `flag` verb group's contract (#3133): `open`/`close` map onto the EXACT `ServeTarget`
+ * levers so no serving-plan math is duplicated, and `graduate` only greenlights a flag fully open
+ * in prod.
  */
 
 import {assert, describe, it} from "@effect/vitest";

--- a/packages/anka-ops/src/flagship-core.ts
+++ b/packages/anka-ops/src/flagship-core.ts
@@ -1,10 +1,7 @@
 /**
- * `@kampus/anka-ops` Flagship pure core — IO-free, total transforms over already-listed
- * Flagship data. The decodes, the effective-serving computation, the serving-plan model the
- * `flag` release verbs dry-run/apply, and the renderers — so the read/write clients
- * (`flagship.ts`) and the `flag` command wiring (`flag-command.ts`) stay thin and every branch
- * here is unit-testable off-network. Relocated from the retired `@kampus/cf-utils` package when
- * the flag surface's single home moved to anka-ops (ruling #3326).
+ * `@kampus/anka-ops` Flagship pure core — IO-free transforms over already-listed Flagship data,
+ * so the read/write clients (`flagship.ts`) and the `flag` command wiring (`flag-command.ts`) stay
+ * thin and every branch here is unit-testable off-network.
  *
  * The release lever is the **no-match split**, not `defaultVariation` (#1726): real releases
  * are performed as a conditions-empty rule carrying a `rollout: {percentage}` — the wire
@@ -18,11 +15,8 @@
  * doesn't count a conditions-empty rollout rule as a targeting rule. `defaultVariation`
  * stays at its create-time safe value forever and is never used as the release lever.
  *
- * The env↔app mapping is grounded in the same physical-name scheme `orphan-sweep`'s
- * `FLAGSHIP_APP_NAME_PREFIX`/`decodeStage` decode (`packages/orphan-sweep/src/orphan-sweep.ts`)
- * and in `apps/web/worker/features/flagship/resources.ts` (the app is
- * `Cloudflare.FlagshipApp("phoenix_flags")`, so alchemy names it
- * `${stack}-${id}-${stage}-${suffix}`, `_`→`-` lowercased).
+ * The env↔app naming is grounded in `apps/web/worker/features/flagship/resources.ts` and
+ * `packages/orphan-sweep/src/orphan-sweep.ts`.
  */
 
 import * as Schema from "effect/Schema";
@@ -37,11 +31,9 @@ const STACK = "phoenix";
 export const FLAGSHIP_APP_NAME_PREFIX = `${STACK}-${STACK}-flags-`;
 
 /**
- * Decode a Flagship app's physical name back to its stage (the `<stage>` between the
- * prefix and alchemy's last `-<suffix>` segment), or `undefined` when the name is not one
- * of OUR apps — a foreign account app, or a malformed name with no suffix segment. The
- * `undefined` return is the safety hinge every consumer relies on: a name we don't
- * recognize decodes to no env rather than a guessed one.
+ * Decode a Flagship app's physical name back to its stage. `undefined` is the safety hinge every
+ * consumer relies on: a name we don't recognize (a foreign account app, a malformed name) decodes
+ * to no env rather than a guessed one.
  */
 export const decodeEnv = (appName: string): string | undefined => {
 	if (!appName.startsWith(FLAGSHIP_APP_NAME_PREFIX)) {
@@ -56,10 +48,9 @@ export const decodeEnv = (appName: string): string | undefined => {
 };
 
 /**
- * The slice of a Flagship rule this package reads and round-trips — the SDK's
- * `GetAppFlagResponse`/`UpdateAppFlagRequest` rule shape with `conditions` held opaque
- * (rule-condition edits stay out of scope, #1609): we only test `conditions.length` and pass
- * the entries through verbatim on write.
+ * The slice of a Flagship rule this package reads and round-trips. `conditions` is held opaque
+ * (rule-condition edits stay out of scope, #1609): only `conditions.length` is tested, and the
+ * entries pass through verbatim on write.
  */
 export interface FlagRule {
 	readonly conditions: ReadonlyArray<unknown>;
@@ -68,13 +59,6 @@ export interface FlagRule {
 	readonly rollout?: {readonly percentage: number; readonly attribute?: string | null} | null;
 }
 
-/**
- * A Flagship flag reduced to the fields this package reads — the slice of
- * `@distilled.cloud/cloudflare`'s `ListAppFlagsResponse`/`GetAppFlagResponse` item.
- * `variations` maps a variation key to its served value; `defaultVariation` names the
- * variation served when no rule matches or the flag is disabled; `rules` carries the
- * serving config — including the no-match split, the actual release lever (#1726).
- */
 export interface RawFlag {
 	readonly key: string;
 	readonly enabled: boolean;
@@ -94,12 +78,9 @@ export const findNoMatchSplit = (rules: ReadonlyArray<FlagRule>): FlagRule | und
 		.sort((a, b) => a.priority - b.priority)[0];
 
 /**
- * What a flag effectively serves — the answer `flag get`/`flag list` print instead of the
- * lying `defaultVariation` reduction (#1726). `Split` ⇒ the no-match split serves
- * `variation` to `percentage`% (remainder falls to the default); `Default` ⇒ no split, the
- * flag serves `defaultVariation` (also the disabled case — a disabled flag bypasses all
- * rules per the SDK contract). `otherRules` counts the rules that are NOT the resolved
- * split (targeting rules), surfaced as a `+N targeting rules` note.
+ * What a flag effectively serves — the answer `flag get`/`flag list` print instead of the lying
+ * `defaultVariation` reduction (#1726). A disabled flag reads as `Default`: it bypasses all rules
+ * per the SDK contract, split or no split.
  */
 export type EffectiveServing =
 	| {
@@ -124,11 +105,6 @@ export const computeEffectiveServing = (flag: RawFlag): EffectiveServing => {
 	return {_tag: "Default", variation: flag.defaultVariation, otherRules};
 };
 
-/**
- * Render effective serving legibly: `on@100% (split)` for a full split release,
- * `on@N% (ramping)` for a partial one, `off (default)` when no split serves, with a
- * `+N targeting rules` suffix when targeting rules exist beyond the split.
- */
 export const renderEffectiveServing = (serving: EffectiveServing): string => {
 	const base =
 		serving._tag === "Split"
@@ -139,21 +115,15 @@ export const renderEffectiveServing = (serving: EffectiveServing): string => {
 	return serving.otherRules > 0 ? `${base} +${serving.otherRules} targeting rules` : base;
 };
 
-/** One `flag × env` cell: a flag's effective serving state in a single environment. */
 export interface FlagState {
 	readonly key: string;
 	readonly env: string;
 	readonly enabled: boolean;
 	readonly defaultVariation: string;
-	/**
-	 * The value `defaultVariation` resolves to (`variations[defaultVariation]`) — the flag's
-	 * no-split baseline. `undefined` when the named variation is absent (a malformed flag).
-	 */
 	readonly defaultValue: unknown;
 	readonly serving: EffectiveServing;
 }
 
-/** Reduce a raw flag envelope in a given env to its `key × env` effective-serving row. */
 export const decodeFlagState = (env: string, flag: RawFlag): FlagState => ({
 	key: flag.key,
 	env,
@@ -164,21 +134,16 @@ export const decodeFlagState = (env: string, flag: RawFlag): FlagState => ({
 });
 
 /**
- * The `--env` option help text — single-sourced so `get` and `set` describe the env the same
- * way, and so it can't drift from the guard. The valid env set is NOT a closed static enum: an
- * env is a deploy stage decoded from a live Flagship app's physical name (`decodeEnv`), so it's
- * runtime-open — `prod` is the one stable env, previews are `pr-<n>`, integration `it-…`, plus
- * named-dev stages. The authoritative live set is what `flag list` enumerates (the same
- * `decodeEnv`-over-listed-apps source `FlagEnvNotFound` reports), so the help names the stable
- * env and points there rather than hardcoding a divergent list that would rot.
+ * The `--env` option help text. The valid env set is NOT a closed enum — an env is a deploy stage
+ * decoded off a live Flagship app's name, so the help points at `flag list` rather than hardcoding
+ * a list that would rot.
  */
 export const ENV_HELP =
 	"the deploy stage to target, e.g. prod (previews are pr-<n>); run `flag list` to see the valid envs";
 
 /**
- * No Flagship app serves the requested env — the typed, legible not-found `flag set` fails
- * with BEFORE any read/write, so an unknown `--env` never reaches the mutation. Carries the
- * envs that DO resolve, so the message points the operator at a valid one.
+ * No Flagship app serves the requested env. `flag set` fails with this BEFORE any read/write, so
+ * an unknown `--env` never reaches the mutation.
  */
 export class FlagEnvNotFound extends Schema.TaggedErrorClass<FlagEnvNotFound>()(
 	"@kampus/anka-ops/FlagEnvNotFound",
@@ -194,11 +159,9 @@ export class FlagEnvNotFound extends Schema.TaggedErrorClass<FlagEnvNotFound>()(
 }
 
 /**
- * No flag with the requested key exists in ANY env — the typed, legible not-found the
- * env-less `flag get <key>` fails with when its per-key slice of `flag list` is empty, so a
- * mistyped key surfaces loud (never a silent empty table). Carries the keys that DO resolve so
- * the message points the operator at a valid one. The `--env`-scoped `flag get` instead fails
- * with the SDK's `FlagshipFlagNotFound` straight off the single-flag read.
+ * No flag with the requested key exists in ANY env — what the env-less `flag get <key>` fails
+ * with, so a mistyped key surfaces loud instead of as a silent empty table. The `--env`-scoped
+ * `flag get` instead fails with the SDK's `FlagshipFlagNotFound` off the single-flag read.
  */
 export class FlagKeyNotFound extends Schema.TaggedErrorClass<FlagKeyNotFound>()(
 	"@kampus/anka-ops/FlagKeyNotFound",
@@ -213,11 +176,6 @@ export class FlagKeyNotFound extends Schema.TaggedErrorClass<FlagKeyNotFound>()(
 	}
 }
 
-/**
- * `flag set` named neither or both of `on|off` and `--percent N` — the two target forms are
- * mutually exclusive and exactly one is required, enforced with a legible usage error rather
- * than a silent default.
- */
 export class FlagSetTargetInvalid extends Schema.TaggedErrorClass<FlagSetTargetInvalid>()(
 	"@kampus/anka-ops/FlagSetTargetInvalid",
 	{
@@ -230,9 +188,8 @@ export class FlagSetTargetInvalid extends Schema.TaggedErrorClass<FlagSetTargetI
 }
 
 /**
- * The interactive confirm's refusal — `flag set --execute` declined because a human at a terminal
- * did not affirm the `[y/N]` prompt. Surfaces ONLY on the TTY ergonomics path (`decideLeverGuard`,
- * ADR 0134); a non-TTY agent/CI caller is never refused. The message names the recoverable fix.
+ * Surfaces ONLY on the TTY ergonomics path (`decideLeverGuard`, ADR 0134); a non-TTY agent/CI
+ * caller is never refused.
  */
 export class LeverGuardRefused extends Schema.TaggedErrorClass<LeverGuardRefused>()(
 	"@kampus/anka-ops/LeverGuardRefused",
@@ -248,31 +205,15 @@ export class LeverGuardRefused extends Schema.TaggedErrorClass<LeverGuardRefused
 	}
 }
 
-/**
- * The lever confirm's decision for the live-flip `--execute` branch. `Allow` ⇒ the write proceeds
- * (a non-TTY agent/CI caller, or a TTY human who affirmed the prompt — ADR 0134); `Refuse` ⇒ a
- * human at a terminal declined the confirm, carrying the `reason` the `LeverGuardRefused` renders.
- */
 export type LeverGuardDecision =
 	| {readonly _tag: "Allow"}
 	| {readonly _tag: "Refuse"; readonly reason: string};
 
 /**
- * PURE core of the lever's interactive confirm — decide whether `flag set --execute` may flip a
- * flag live, given the two structural inputs the thin IO shell observes: whether stdin is an
- * interactive TTY, and the raw confirm line the operator typed (`undefined` for EOF / no input).
- *
- * Per ADR 0134 (supersedes 0133) the lever is **agent-invokable** — the humans-release boundary
- * (ADR 0083) lives at the `/release` skill + the audit trail, NOT as a structural TTY refuse at
- * the tool. So the confirm is now purely human ergonomics when a terminal is present:
- *
- *  - **No TTY ⇒ Allow** — an agent / CI runner proceeds without a prompt (the IO shell logs the
- *    non-interactive flip for the audit record). This is the 0134 reversal of 0133's non-TTY
- *    hard-refuse.
- *  - **TTY + confirm ⇒ Allow only on an affirmative** — `y`/`yes` (case-insensitive, whitespace
- *    trimmed) — the deliberate "are you sure" before a live prod flip for a human at the terminal.
- *    Empty input, EOF (`undefined`), `n`, and anything else ⇒ Refuse. The default is deny: the
- *    human must type a deliberate keystroke.
+ * Whether `flag set --execute` may flip a flag live. No TTY ⇒ Allow: the lever is agent-invokable
+ * and the humans-release boundary lives at the `/release` skill, not at a structural TTY refuse
+ * here (ADR 0134, superseding 0133). With a TTY the confirm is human ergonomics only, and it
+ * defaults to deny — anything that is not `y`/`yes` refuses.
  */
 export const decideLeverGuard = (input: {
 	readonly isTTY: boolean;
@@ -288,23 +229,18 @@ export const decideLeverGuard = (input: {
 	return {_tag: "Refuse", reason: "the interactive confirmation was not affirmed (expected y/yes)"};
 };
 
-/** The per-key slice of the `flag list` rows — a flag's state in every env it's defined in. */
 export const selectStatesForKey = (
 	rows: ReadonlyArray<FlagState>,
 	key: string,
 ): ReadonlyArray<FlagState> => rows.filter((r) => r.key === key);
 
-/** Every distinct flag key present across the listed rows, sorted — the `known flags` hint. */
 export const distinctKeys = (rows: ReadonlyArray<FlagState>): ReadonlyArray<string> =>
 	[...new Set(rows.map((r) => r.key))].sort();
 
 /**
- * What a `flag set` write aims the serving at. `Percent` sets the no-match split so
- * `percentage`% serves `on` and the remainder falls to the (safe, create-time)
- * `defaultVariation` — `flag set <key> on` is `Percent 100`, the canonical fully-on form.
- * `Kill` is the true kill switch: clear the no-match split AND set `defaultVariation` off,
- * so a split-released flag actually stops serving (#1726's sharp finding — a bare
- * `defaultVariation` flip does NOT turn a split-released flag off).
+ * What a `flag set` write aims the serving at. `Kill` must clear the no-match split AND set
+ * `defaultVariation` off: a bare `defaultVariation` flip does NOT turn a split-released flag off
+ * (#1726).
  */
 export type ServeTarget =
 	| {readonly _tag: "Percent"; readonly percentage: number}
@@ -318,12 +254,9 @@ export const renderServeTarget = (target: ServeTarget): string =>
 			: `on@${target.percentage}% (ramping)`;
 
 /**
- * The next serving state a `ServeTarget` writes: the rules to PUT and the
- * `defaultVariation` to PUT alongside them. `Percent` upserts the no-match split (replacing
- * the existing split in place — preserving its priority and rollout bucketing attribute — or
- * appending one after every existing rule) and leaves `defaultVariation` untouched; `Kill`
- * strips every no-match split rule and moves `defaultVariation` to `off`. Targeting rules
- * pass through verbatim in both (#1609 scope).
+ * The next serving state a `ServeTarget` writes. `Percent` replaces an existing split in place so
+ * its priority and rollout bucketing attribute survive; targeting rules pass through verbatim in
+ * both branches (#1609 scope).
  */
 export const planNextState = (
 	flag: RawFlag,
@@ -402,21 +335,12 @@ export const computeServingPlan = (input: {
 	};
 };
 
-/**
- * Render the serving plan as a legible one-line `current → target` diff. A no-op plan
- * (already at target) reads as such so a dry-run makes the "nothing to do" case obvious.
- */
 export const renderServingPlan = (plan: ServingPlan): string =>
 	plan.changed
 		? `flag ${plan.key} @ ${plan.env}: ${renderEffectiveServing(plan.current)} → ${renderServeTarget(plan.target)}`
 		: `flag ${plan.key} @ ${plan.env}: already ${renderServeTarget(plan.target)} (no change)`;
 
-/**
- * Find the Flagship app serving a given env, keyed on `decodeEnv` of each app's physical
- * name (a foreign app decodes to no env and is never matched). Generic over `{name}` so the
- * pure core stays free of the read client's `FlagshipApp` type. `undefined` ⇒ no app for that
- * env — the caller fails not-found BEFORE any write.
- */
+/** Generic over `{name}` so the pure core stays free of the read client's `FlagshipApp` type. */
 export const findAppForEnv = <T extends {readonly name: string}>(
 	apps: ReadonlyArray<T>,
 	env: string,
@@ -434,11 +358,6 @@ const renderValue = (value: unknown): string => {
 
 const pad = (cell: string, width: number): string => cell + " ".repeat(width - cell.length);
 
-/**
- * Lay flag rows out as a legible `flag × env` table (key, env, enabled, effective serving),
- * sorted by key then env so the same flag's envs sit together. Column widths size to the
- * widest cell so the columns line up.
- */
 export const renderFlagTable = (rows: ReadonlyArray<FlagState>): string => {
 	if (rows.length === 0) {
 		return "no flags found";
@@ -463,12 +382,6 @@ export const renderFlagTable = (rows: ReadonlyArray<FlagState>): string => {
 	return [line(header), ...body.map(line)].join("\n");
 };
 
-/**
- * Render one flag's full state in a single env as a legible key/value block — the
- * `flag get <key> --env <env>` view. `serves` is the effective serving (rules → no-match
- * split → default), `default` the no-split baseline, plus every variation with its value —
- * so the pre-release confirmation read shows exactly what an env serves and could serve.
- */
 export const renderFlagDetail = (env: string, flag: RawFlag): string => {
 	const defaultValue = renderValue(flag.variations[flag.defaultVariation]);
 	const label = (l: string) => pad(`${l}:`, 12);

--- a/packages/anka-ops/src/flagship-core.unit.test.ts
+++ b/packages/anka-ops/src/flagship-core.unit.test.ts
@@ -530,7 +530,6 @@ describe("renderFlagTable", () => {
 		]);
 		const lines = table.split("\n");
 		assert.match(lines[0] ?? "", /FLAG\s+ENV\s+ENABLED\s+SERVES/);
-		// alpha sorts before beta
 		assert.match(lines[1] ?? "", /^alpha\s+pr-1\s+on\s+off \(default\)/);
 		assert.match(lines[2] ?? "", /^beta\s+prod\s+on\s+on@100% \(split\)/);
 	});

--- a/packages/anka-ops/src/flagship.ts
+++ b/packages/anka-ops/src/flagship.ts
@@ -1,22 +1,13 @@
 /**
- * The Flagship read/write clients — the load-bearing seam the anka-ops `flag` verb group runs
- * on (relocated from the retired `@kampus/cf-utils` package, ruling #3326). A
- * typed Effect service wrapping `@distilled.cloud/cloudflare`'s canonical flagship read
- * operations (`listApps`, `listAppFlags`, `getAppFlag`) — the SAME transport
- * `@kampus/d1-rest` runs D1 over (already in the tree via alchemy), so this rolls NO new
- * raw-`curl` client (the third-copy bug class, #941). Schema decoding + typed errors
- * (`FlagshipAppNotFound`/`FlagshipFlagNotFound`, `Unauthorized`, …) come from the SDK; they
- * ride the `E` channel so an unreachable/unauthorized CF surfaces a typed error, never a
- * stack trace.
+ * The Flagship read/write clients the anka-ops `flag` verb group runs on. See ADR 0081.
+ *
+ * Wraps `@distilled.cloud/cloudflare`'s canonical flagship ops — the SAME transport
+ * `@kampus/d1-rest` runs D1 over, so this rolls NO new raw-`curl` client (the third-copy
+ * bug class, #941). Every SDK fault rides the `E` channel; nothing throws.
  *
  * Credentials come from the environment at runtime, NEVER from source: the ambient
- * `Credentials | HttpClient` (`CredentialsFromEnv` reads `$CLOUDFLARE_API_TOKEN`,
- * `FetchHttpClient.layer` the transport) is captured at layer build and re-provided into
- * each op; `$CLOUDFLARE_ACCOUNT_ID` is read per call via `Config`.
- *
- * `listFlagStates` is the enumeration `flag list` prints: it lists every Flagship app,
- * decodes each app's stage as its `env` (`decodeEnv`, skipping foreign apps), lists that
- * app's flags, and reduces each to a `key × env` row (`decodeFlagState`).
+ * `Credentials | HttpClient` is captured at layer build and re-provided into each op;
+ * `$CLOUDFLARE_ACCOUNT_ID` is read per call via `Config`.
  */
 import type {Credentials} from "@distilled.cloud/cloudflare/Credentials";
 import * as flagship from "@distilled.cloud/cloudflare/flagship";
@@ -33,17 +24,11 @@ import {
 
 export {FlagshipAppNotFound, FlagshipFlagNotFound} from "@distilled.cloud/cloudflare/flagship";
 
-/** A Flagship app reduced to the identity the client keys on: `id` is the API key, `name` the stage-bearer. */
 export interface FlagshipApp {
 	readonly id: string;
 	readonly name: string;
 }
 
-/**
- * The read client's error channel: every typed fault the wrapped SDK ops surface
- * (transport/auth `DefaultErrors` + `FlagshipAppNotFound`/`FlagshipFlagNotFound`) plus the
- * `ConfigError` from resolving `$CLOUDFLARE_ACCOUNT_ID`. All typed, all in `E` — no throw.
- */
 export type FlagshipReadError =
 	| flagship.ListAppsError
 	| flagship.ListAppFlagsError
@@ -70,11 +55,6 @@ const toRawFlag = (flag: {
 	rules: flag.rules,
 });
 
-/**
- * `FlagshipRead` — the injectable read seam. `listApps`/`listAppFlags`/`getAppFlag` are the
- * thin wrappers over the SDK ops; `listFlagStates` is the `env`-decoding enumeration the bin
- * renders. Built by `FlagshipReadLive`, whose `R` is the ambient `Credentials | HttpClient`.
- */
 export class FlagshipRead extends Context.Service<
 	FlagshipRead,
 	{
@@ -92,25 +72,16 @@ export class FlagshipRead extends Context.Service<
 
 const accountId = Config.string("CLOUDFLARE_ACCOUNT_ID");
 
-/**
- * The write client's error channel: the `updateAppFlag`/`getAppFlag` typed faults
- * (transport/auth + `FlagshipFlagNotFound`/`FlagshipAppNotFound`) plus the `ConfigError`
- * from resolving `$CLOUDFLARE_ACCOUNT_ID`. All typed, all in `E`.
- */
 export type FlagshipWriteError =
 	| flagship.GetAppFlagError
 	| flagship.UpdateAppFlagError
 	| Config.ConfigError;
 
 /**
- * `FlagshipWrite` — the injectable release seam. `setServing` is the ONE mutation the `flag`
- * performs: it reads the flag's current full envelope (so an unknown key fails
- * `FlagshipFlagNotFound` BEFORE any write), computes the next serving state with the pure
- * core (`planNextState` — the no-match split is the release lever, #1726), and re-writes the
- * envelope. `Percent` moves only the split rule (`defaultVariation` keeps its create-time
- * safe value); `Kill` clears the split AND sets `defaultVariation` off — the true kill
- * switch. `enabled`, `variations`, and targeting rules pass through unchanged (#1609). No
- * new transport: it rides the same ambient `Credentials | HttpClient` as `FlagshipReadLive`.
+ * `setServing` is the ONE mutation the `flag` group performs. `Percent` moves only the split
+ * rule and leaves `defaultVariation` at its create-time safe value; `Kill` clears the split
+ * AND sets `defaultVariation` off — the true kill switch. `enabled`, `variations`, and
+ * targeting rules pass through unchanged (#1609).
  */
 export class FlagshipWrite extends Context.Service<
 	FlagshipWrite,
@@ -170,8 +141,7 @@ export const FlagshipWriteLive: Layer.Layer<FlagshipWrite, never, Credentials | 
 export const FlagshipReadLive: Layer.Layer<FlagshipRead, never, Credentials | HttpClient> =
 	Layer.effect(FlagshipRead)(
 		Effect.gen(function* () {
-			// Capture the ambient transport/credentials ONCE, re-provide into each op so the
-			// public methods carry `R = never` (the same shape orphan-sweep's CloudflareLive uses).
+			// Captured ONCE and re-provided into each op so the public methods carry `R = never`.
 			const context = yield* Effect.context<Credentials | HttpClient>();
 			const withCtx = <A, E>(
 				effect: Effect.Effect<A, E, Credentials | HttpClient>,

--- a/packages/anka-ops/src/flagship.unit.test.ts
+++ b/packages/anka-ops/src/flagship.unit.test.ts
@@ -1,10 +1,7 @@
 /**
  * The read client's flag-state decode over a STUBBED transport — no real CF in the unit
- * tier (ADR 0082), mirroring `orphan-sweep/src/cloudflare.unit.test.ts`. A canned
- * `HttpClient` replays flagship JSON envelopes per URL, so the REAL SDK decode +
- * `listFlagStates` env-enumeration path runs off-network: apps are enumerated, each
- * phoenix app's stage decodes to its env, a foreign app is skipped, and each flag reduces
- * to its `key × env` default-state row.
+ * tier (ADR 0082). A canned `HttpClient` replays flagship JSON envelopes per URL, so the
+ * REAL SDK decode + `listFlagStates` env-enumeration path runs off-network.
  */
 
 import {fromApiToken} from "@distilled.cloud/cloudflare/Credentials";
@@ -155,7 +152,6 @@ describe("FlagshipRead.listFlagStates — decode flags × env over a stubbed tra
 		const pr9NewNav = rows.find((r) => r.env === "pr-9");
 		assert.strictEqual(pr9NewNav?.key, "new-nav");
 
-		// No row ever came from the foreign app.
 		assert.isUndefined(rows.find((r) => r.env === undefined));
 	});
 });
@@ -240,7 +236,6 @@ const runFlagStatesWith = (
 describe("FlagshipRead.listFlagStates — an inaccessible owned app is skipped, not fatal", () => {
 	it("returns the accessible app's rows and skips the FlagshipAppNotFound app without aborting (#1645)", async () => {
 		const exit = await runFlagStatesWith(partialDeps);
-		// The single inaccessible owned app must NOT fail the whole enumeration.
 		assert.strictEqual(exit._tag, "Success");
 		if (exit._tag !== "Success") return;
 		const rows = exit.value as ReadonlyArray<{key: string; env: string}>;
@@ -327,7 +322,6 @@ describe("FlagshipRead.getAppFlag — single-flag resolution over a stubbed tran
 		const exit = await runGetAppFlag("ghost");
 		assert.strictEqual(exit._tag, "Failure");
 		if (exit._tag !== "Failure") return;
-		// The typed not-found rides the E channel — assert its tag surfaced, not a raw throw.
 		const rendered = JSON.stringify(exit.cause);
 		assert.match(rendered, /FlagshipFlagNotFound/);
 	});
@@ -418,7 +412,6 @@ describe("FlagshipWrite.setServing — release/kill over a stubbed transport", (
 		assert.strictEqual(capturedPut?.body.enabled, true);
 		assert.deepStrictEqual(capturedPut?.body.variations, {off: false, on: true});
 
-		// The returned flag decodes to the confirmed effective serving.
 		const updated = exit.value as {defaultVariation: string; rules: ReadonlyArray<unknown>};
 		assert.strictEqual(updated.defaultVariation, "off");
 		assert.strictEqual(updated.rules.length, 1);

--- a/packages/anka-ops/src/posture.ts
+++ b/packages/anka-ops/src/posture.ts
@@ -1,11 +1,8 @@
 /**
- * The ADR 0134 non-TTY posture as a pure decision core — the framework primitive every
- * anka-ops write verb reuses so the humans-release boundary (ADR 0083) lives at the audit
- * trail, not as a structural TTY refuse. A non-interactive caller (agent/CI, no TTY) PROCEEDS
- * without a prompt (the action is logged for the audit record); an interactive human is asked
- * to confirm and only an affirmative answer proceeds. Keeping the decision IO-free is what
- * lets it be exhaustively unit-tested without a real terminal (mirrors the flag lever's
- * `decideLeverGuard` in `flagship-core.ts`).
+ * The ADR 0134 non-TTY posture as a pure decision core. A non-interactive
+ * caller (agent/CI, no TTY) PROCEEDS without a prompt — deliberate, not a
+ * hole: the humans-release boundary (ADR 0083) lives at the audit trail, not
+ * as a structural TTY refuse. IO-free so it unit-tests without a terminal.
  */
 
 export interface ConfirmInput {
@@ -20,11 +17,6 @@ export type ConfirmDecision =
 
 const AFFIRMATIVE = new Set(["y", "yes"]);
 
-/**
- * Decide whether a confirmation-guarded write proceeds. Non-TTY ⇒ always Proceed
- * (`interactive: false`, the caller logs the action); TTY ⇒ Proceed only on an affirmative
- * `y`/`yes`, else Refuse (a bare Enter, EOF, or any other answer is a decline).
- */
 export const decideConfirm = (input: ConfirmInput): ConfirmDecision => {
 	if (!input.isTTY) {
 		return {_tag: "Proceed", interactive: false};

--- a/packages/anka-ops/src/report-catalog.ts
+++ b/packages/anka-ops/src/report-catalog.ts
@@ -1,9 +1,7 @@
 /**
- * The product report registry — the single injection point for report *content*, wired into the
- * runtime by `cli.ts`. It is the mechanism-vs-content boundary (ADR 0153) made concrete: the generic
- * runner in `report.ts` carries no query, and a product's report definitions land here. Each entry is
- * authored as its own content module under `reports/`; this file only lists them, so `report --name
- * <id>` resolves the id against the registered set.
+ * The product report registry — the content side of the mechanism-vs-content
+ * boundary (ADR 0153). The runner in `report.ts` carries no query; each report
+ * is its own module under `reports/` and this file only lists them.
  */
 
 import type {ReportDefinition} from "./report.ts";

--- a/packages/anka-ops/src/report-command.ts
+++ b/packages/anka-ops/src/report-command.ts
@@ -1,15 +1,9 @@
 /**
- * The `report` verb group's `effect/unstable/cli` wiring — the thin IO shell over the generic
- * runner core (`report.ts` resolution + sampling-correct SQL rendering) and the AE read seam
- * (`analytics.ts`). It holds no query and no report content: it resolves `--name` against the
- * injected `ReportCatalog`, renders the resolved definition's query to sampling-correct SQL, runs
- * it over the shared operator credential, and prints the result.
+ * The `report` verb group's CLI wiring — the thin IO shell over `report.ts` and the AE read
+ * seam. It holds no query and no report content of its own.
  *
- *   anka-ops report --name <id>     run a named AE report from the injected catalog
- *
- * A non-TTY caller proceeds and renders headless (a read has nothing to confirm — the ADR 0134
- * posture only guards writes). An unknown `--name` fails loud with the known ids (`ReportNotFound`),
- * never an empty result.
+ * A non-TTY caller proceeds and renders headless: a read has nothing to confirm, and the
+ * ADR 0134 posture only guards writes.
  */
 
 import {Console, Effect} from "effect";

--- a/packages/anka-ops/src/report.ts
+++ b/packages/anka-ops/src/report.ts
@@ -1,43 +1,27 @@
 /**
- * The `report` verb group's mechanism core — framework-generic, product-content-free. This module
- * is the load-bearing mechanism-vs-content seam (epic #2089, ADR 0153): it defines the shape a
- * report *definition* satisfies, resolves one by name out of an injected catalog, and renders the
- * catalog's structured query into sampling-correct AE SQL — but it names **no** concrete report and
- * bakes **no** product-specific query. The first definition (`votes-vs-reactions`) is product content
- * supplied by a separate child; the anka-ops core only carries this generic runner.
- *
- * Sampling-correctness is a MECHANISM guarantee, not left to product content: every measure a
- * definition declares is rendered as `sumIf(_sample_interval, …)` — never `count()` — so a report
- * can't accidentally bake in the count-vs-sample bug ADR 0153 warns about. The definition supplies
- * *which* features to compare (content); this module supplies *how* the read is weighted (mechanism).
+ * The `report` verb group's mechanism core — a generic runner that names no concrete report and
+ * bakes no product query (epic #2089, ADR 0153). Sampling-correctness is a mechanism guarantee:
+ * every measure renders as `sumIf(_sample_interval, …)`, never `count()`, so a product definition
+ * cannot bake in the count-vs-sample bug.
  */
 
 import {Context, Effect, Layer} from "effect";
 import * as Schema from "effect/Schema";
 
-// The fixed `app_events` positional schema from ADR 0153: one index (the sampling/grouping key)
-// holds the feature-key, and reads weight by `_sample_interval` so per-feature counts stay exact
-// under sampling. These are schema constants of the seam, not a product query.
+// The fixed `app_events` positional schema of ADR 0153 — seam constants, not a product query.
 const APP_EVENTS_DATASET = "app_events";
 const FEATURE_INDEX = "index1";
 const SAMPLE_INTERVAL = "_sample_interval";
 
-/**
- * A single measured column of a report: a named count over one feature-key, resolved against the
- * `index1` feature dimension. `feature` is the ADR-0153 feature-key (`vote`, `reaction`, …) — an
- * English/technical identifier; `name` is the output column it renders under (`votes`, `reactions`).
- */
+/** `feature` is the ADR-0153 feature-key (`vote`, …); `name` is the output column it renders under. */
 export interface FeatureMeasure {
 	readonly name: string;
 	readonly feature: string;
 }
 
 /**
- * A report's query, encoded over the fixed positional schema (never raw SQL). The mechanism renders
- * it sampling-correct; the product only declares the axes: which feature counts to compare, over how
- * many trailing days, optionally bucketed per day. This is deliberately narrow — the counts-per-
- * feature comparison ADR 0153's forcing question ("are reactions cannibalising votes") needs — and
- * grows by extension as later reports need more, never by admitting a raw `count()`.
+ * A report's query, encoded over the fixed positional schema — never raw SQL. Deliberately narrow:
+ * it grows by extension as later reports need more, never by admitting a raw `count()`.
  */
 export interface ReportQuery {
 	readonly measures: ReadonlyArray<FeatureMeasure>;
@@ -45,11 +29,7 @@ export interface ReportQuery {
 	readonly groupByDay: boolean;
 }
 
-/**
- * A named, versioned report definition — the catalog-entry interface a product supplies. `version`
- * is the definition's own revision (bump it when the query's shape changes so a cached/consuming
- * surface can tell), `id` is the `--name` handle, `description` is the one-line operator summary.
- */
+/** The catalog-entry interface a product supplies; bump `version` when the query's shape changes. */
 export interface ReportDefinition {
 	readonly id: string;
 	readonly version: number;
@@ -57,29 +37,21 @@ export interface ReportDefinition {
 	readonly query: ReportQuery;
 }
 
-/** A decoded AE result row — the positional-schema query returns named columns, values or null. */
 export type ReportRow = Record<string, string | number | null>;
 
 /**
- * The injected report catalog — the product-supplied content the runner resolves `--name` against.
- * A `Context.Service` so the anka-ops core stays query-free: the framework provides an EMPTY catalog,
- * a product wires its definitions in. The runner never imports a definition; it only reads this seam.
+ * A `Context.Service` so the anka-ops core stays query-free: the framework provides an EMPTY
+ * catalog, a product wires its definitions in. The runner never imports a definition.
  */
 export class ReportCatalog extends Context.Service<
 	ReportCatalog,
 	{readonly entries: ReadonlyArray<ReportDefinition>}
 >()("@kampus/anka-ops/ReportCatalog") {}
 
-/** Wire a concrete catalog into the runtime — the single injection point for product report content. */
 export const makeReportCatalog = (
 	entries: ReadonlyArray<ReportDefinition>,
 ): Layer.Layer<ReportCatalog> => Layer.succeed(ReportCatalog, {entries});
 
-/**
- * An unknown `--name` — fail loud, listing the known ids so the operator can correct the typo rather
- * than stare at an empty result. `knownIds` is empty when no product has wired any report yet (the
- * bare framework), which the message states explicitly instead of an inscrutable blank list.
- */
 export class ReportNotFound extends Schema.TaggedErrorClass<ReportNotFound>()(
 	"@kampus/anka-ops/ReportNotFound",
 	{
@@ -96,14 +68,9 @@ export class ReportNotFound extends Schema.TaggedErrorClass<ReportNotFound>()(
 	}
 }
 
-/** The catalog's ids, sorted — the operator-facing list `ReportNotFound` prints and `report list` uses. */
 export const knownReportIds = (catalog: ReadonlyArray<ReportDefinition>): ReadonlyArray<string> =>
 	catalog.map((entry) => entry.id).sort();
 
-/**
- * Resolve a report id against the injected catalog. Succeeds with the definition; fails
- * `ReportNotFound` (carrying the sorted known ids) on a miss — never returns an empty/blank result.
- */
 export const resolveReport = (
 	catalog: ReadonlyArray<ReportDefinition>,
 	id: string,
@@ -115,10 +82,8 @@ export const resolveReport = (
 };
 
 /**
- * Render a report's structured query into sampling-correct AE SQL. Every measure becomes a
- * `sumIf(_sample_interval, index1 = '<feature>')` weighting (ADR 0153 §"Reads are sampling-correct"
- * — never `count()`), so sampling-correctness is guaranteed by construction, not by the product
- * author remembering it. A `groupByDay` query buckets by `toStartOfDay(timestamp)` and orders by day.
+ * Every measure becomes a `sumIf(_sample_interval, …)` weighting — ADR 0153 §"Reads are
+ * sampling-correct" — so the guarantee holds by construction, not by the product author remembering.
  */
 export const renderReportSql = (query: ReportQuery): string => {
 	const measureColumns = query.measures.map(
@@ -139,16 +104,14 @@ export const renderReportSql = (query: ReportQuery): string => {
 	return lines.join("\n");
 };
 
-/** The columns a report renders, in order: the optional `day` bucket, then each measure. */
 const reportColumns = (definition: ReportDefinition): ReadonlyArray<string> => [
 	...(definition.query.groupByDay ? ["day"] : []),
 	...definition.query.measures.map((measure) => measure.name),
 ];
 
 /**
- * Render an AE result set as a headed text table — the operator-facing output of `report --name`.
- * An empty result renders the header plus an explicit `(no rows in the window)` line rather than a
- * blank, so "the report ran and found nothing" is never confused with "the report failed".
+ * An empty result renders an explicit `(no rows in the window)` line rather than a blank, so
+ * "the report ran and found nothing" is never confused with "the report failed".
  */
 export const renderReportResult = (
 	definition: ReportDefinition,

--- a/packages/anka-ops/src/report.unit.test.ts
+++ b/packages/anka-ops/src/report.unit.test.ts
@@ -1,8 +1,7 @@
 /**
- * The `report` runner's mechanism core: catalog resolution (known/unknown, with the catalog
- * injected) and the sampling-correct SQL shaping. These are the two load-bearing guarantees of
- * #3134 — the runner resolves a product-supplied definition by name and renders it into a read that
- * weights by `_sample_interval` (ADR 0153), never `count()`. Pure transforms, no AE, no keychain.
+ * The `report` runner's two load-bearing guarantees (#3134): it resolves a product-supplied
+ * definition by name, and renders a read that weights by `_sample_interval` (ADR 0153), never
+ * `count()`.
  */
 import {assert, describe, it} from "@effect/vitest";
 import {Effect, Exit} from "effect";

--- a/packages/anka-ops/src/reports/votes-vs-reactions.ts
+++ b/packages/anka-ops/src/reports/votes-vs-reactions.ts
@@ -1,10 +1,8 @@
 /**
- * kamp.us's first report-catalog entry (ADR 0153) — product content, not framework mechanism.
- * It answers ADR 0153's forcing question: are reactions (ungated, karma-free) cannibalising votes
- * (the karma-bearing ranking signal)? Compared on the `feature` axis — the one exact-under-sampling
- * dimension (`index1`) — over the `app_events` seam, bucketed per day across a 30-day window. This
- * only declares the axes; the generic runner (report.ts) renders them sampling-correct (`sumIf` over
- * `_sample_interval`, never `count()`). It is the canonical query ADR 0153 names verbatim.
+ * The canonical query ADR 0153 names verbatim. `feature` is the one exact-under-sampling
+ * dimension (`index1`); this file only declares the axes, and the generic runner
+ * (report.ts) renders them sampling-correct (`sumIf` over `_sample_interval`, never
+ * `count()`).
  */
 
 import type {ReportDefinition} from "../report.ts";

--- a/packages/anka-ops/src/reports/votes-vs-reactions.unit.test.ts
+++ b/packages/anka-ops/src/reports/votes-vs-reactions.unit.test.ts
@@ -1,9 +1,4 @@
-/**
- * kamp.us's reference report-catalog entry: the `votes-vs-reactions` definition is well-formed
- * against child C's catalog-entry interface, is registered so `report --name` resolves it, and
- * renders into the exact sampling-correct AE query ADR 0153 names verbatim (`sumIf` over
- * `_sample_interval`, never `count()`). Pure — no AE, no keychain.
- */
+/** Pins the rendered SQL against the query ADR 0153 names verbatim. Pure — no AE, no keychain. */
 import {assert, describe, it} from "@effect/vitest";
 import {Effect} from "effect";
 import {knownReportIds, renderReportSql, resolveReport} from "../report.ts";

--- a/packages/anka-ops/vitest.config.ts
+++ b/packages/anka-ops/vitest.config.ts
@@ -1,9 +1,4 @@
-/**
- * Vitest config — the unit tier only (ADR 0082's `unit`/`integration` split). The skeleton's
- * pure cores (verb-group registry, the ADR 0134 non-TTY posture) are deterministic transforms
- * with no real keychain or CF, so `*.unit.test.ts` is the whole surface today; a later verb
- * group adds an `integration` project when a read is only-wrong-if-the-real-infra-differs.
- */
+// Unit tier only (ADR 0082) — nothing here touches a real keychain or CF yet.
 import {defineConfig} from "vitest/config";
 
 export default defineConfig({

--- a/packages/authz/src/Actor.ts
+++ b/packages/authz/src/Actor.ts
@@ -3,11 +3,9 @@
  * dispatches on (ADR 0107 §6). Three-armed: `Unauthenticated`, an authenticated
  * `Human`, and an authenticated `Agent` carrying its human `root`.
  *
- * The Human/Agent split is the dormant agent seam: v1 is humans-only, but every
- * discharge verb already routes the `Agent` arm through the {@link AgentAuthority}
- * port, so v1.1's "an agent's authority ⊆ its human root" attenuation is a Layer
- * swap, never an edit to this mechanism. Vocab-free: bare ids, no kamp.us noun —
- * adapters (`features/kunye`) build an `Actor` from the pasaport session.
+ * The Human/Agent split is dormant in v1 (humans-only), but every discharge verb already routes
+ * the `Agent` arm through the {@link AgentAuthority} port, so v1.1's "an agent's authority ⊆ its
+ * human root" attenuation is a Layer swap rather than an edit here.
  */
 
 export interface Human {

--- a/packages/authz/src/Actor.unit.test.ts
+++ b/packages/authz/src/Actor.unit.test.ts
@@ -1,4 +1,3 @@
-/** Unit — `Actor` constructors + the exhaustive `matchActor` dispatch. */
 import {describe, expect, it} from "vitest";
 import {agent, human, matchActor, unauthenticated} from "./Actor.ts";
 

--- a/packages/authz/src/AgentAuthority.ts
+++ b/packages/authz/src/AgentAuthority.ts
@@ -10,7 +10,6 @@
 import {Context, type Effect} from "effect";
 import type {Agent} from "./Actor.ts";
 
-/** Which agent, asking for which capability tag. */
 export interface AgentAuthorityRequest {
 	readonly agent: Agent;
 	readonly capability: string;

--- a/packages/authz/src/Capability.ts
+++ b/packages/authz/src/Capability.ts
@@ -1,22 +1,8 @@
 /**
- * `Capability` — the class-as-capability builders (ADR 0107 §3). One class
- * declaration yields, from a single name, the proof tag (a v4
- * `Context.Key<Self, Grant<Self>>`), the {@link Grant} it proves, and a discharge
- * verb that mints the proof by running a check. The proof flows into an op's R
- * channel via the one canonical `Grant.provide(grant)` (ADR 0107; #1270). The
- * non-obvious part: enforcement is by the R channel, not a domain field — an op
- * that declares the capability in its R fails to compile unless the proof is
- * provided at composition.
- *
- * Three builders, the asymmetric axes of ADR 0107 §4:
- *   - {@link Class} — generic: `.authorize(check)` discharges a boolean check.
- *   - {@link Level} — ordered ladder: `.require` discharges when standing `gte` the floor.
- *   - {@link Relation} — ReBAC: `.over(resource)` discharges over the resource's ancestry.
- *
- * Both specializations dispatch exhaustively on the {@link Actor} via
- * {@link matchActor}, consulting {@link AgentAuthority} (dormant, fail-closed in
- * v1) on the agent arm; the `deny()` thunk is instance-supplied (the mechanism
- * names no wire code). See .patterns/authz-capability-as-effect.md.
+ * `Capability` — the class-as-capability builders (ADR 0107 §3/§4, and
+ * .patterns/authz-capability-as-effect.md). The non-obvious part: enforcement
+ * is by the R channel, not a domain field — an op that declares the capability
+ * in its R fails to compile unless the proof is provided at composition.
  */
 import {Context, Effect} from "effect";
 import {matchActor, type Principal} from "./Actor.ts";
@@ -85,17 +71,14 @@ export interface ClassConfig<DenyError> {
 }
 
 export interface LevelConfig<Name extends string, DenyError, ReadError, ReadReqs> {
-	/** The ordered ladder the `min` floor is compared on. */
 	readonly scale: Scale<Name>;
-	/** The minimum standing this right requires (the floor). */
 	readonly min: Name;
-	/** Read a principal's current standing on the ladder. */
 	readonly read: (principal: Principal) => Effect.Effect<Name, ReadError, ReadReqs>;
 	readonly deny: () => DenyError;
 }
 
 export interface RelationConfig<DenyError> {
-	/** The relation name (the ReBAC verb, e.g. `moderates`). */
+	/** The ReBAC verb, e.g. `moderates`. */
 	readonly relation: string;
 	readonly deny: () => DenyError;
 }
@@ -113,12 +96,6 @@ export interface RelationConfig<DenyError> {
  */
 const sealCapability = <T>(tag: unknown): T => tag as T;
 
-/**
- * `Capability.Class<Self>()(id, { deny })` — the generic base builder. The
- * discharge verb `.authorize(check)` reads the current actor (to stamp the
- * proof), runs the caller's boolean `check`, and mints on success or raises
- * `deny()` otherwise.
- */
 const makeClass =
 	<Self>() =>
 	<const Id extends string, DenyError>(
@@ -142,12 +119,6 @@ const makeClass =
 		return sealCapability(Tag);
 	};
 
-/**
- * `Capability.Level<Self>()(id, { scale, min, read, deny })` — the ordered-ladder
- * builder. The discharge verb `.require` reads the actor's standing and mints
- * when it `gte` the floor; an agent passes only when its human root's standing
- * passes *and* {@link AgentAuthority} admits the attenuation.
- */
 const makeLevel =
 	<Self>() =>
 	<const Id extends string, Name extends string, DenyError, ReadError, ReadReqs>(
@@ -188,13 +159,6 @@ const makeLevel =
 		return sealCapability(Tag);
 	};
 
-/**
- * `Capability.Relation<Self>()(id, { relation, deny })` — the ReBAC builder. The
- * discharge verb `.over(resource)` mints when the actor holds `relation` over
- * the resource or any of its ancestors (checked fresh, once per ancestor); an
- * agent passes only when its human root holds it *and* {@link AgentAuthority}
- * admits the attenuation.
- */
 const makeRelation =
 	<Self>() =>
 	<const Id extends string, DenyError>(

--- a/packages/authz/src/Capability.typetest.ts
+++ b/packages/authz/src/Capability.typetest.ts
@@ -1,13 +1,6 @@
 /**
- * Type-level assertion (no runtime — checked by `tsgo`, not vitest): an op that
- * declares a capability in its requirements channel **fails to compile** unless
- * the proof is discharged via `Grant.provide` at composition. This is the
- * "forgot to authorize is a compile error" guarantee of ADR 0107 §1, made
- * falsifiable by inspecting the **R channel** with `expectTypeOf`: omit
- * `Grant.provide` and the capability stays required in R (≠ `never`); provide it
- * and R collapses to `never`. The assertion is a real `tsgo` error the moment
- * either half stops holding. (#1270 collapsed the per-capability `.provide` to a
- * single generic `Grant.provide`; the forgot-to-provide guarantee is unchanged.)
+ * Type-level assertions (no runtime — checked by `tsgo`, not vitest) that make the
+ * "forgot to authorize is a compile error" guarantee of ADR 0107 §1 falsifiable.
  *
  * It reads R off the effect type rather than asserting an *assignment* (the prior
  * `@ts-expect-error`'d `leaked` form): assigning a service-requiring effect to an
@@ -23,7 +16,6 @@ import type {CurrentActor} from "./CurrentActor.ts";
 import {Grant} from "./Grant.ts";
 import {Scale} from "./Level.ts";
 
-/** The requirements (R) channel of an effect type. */
 type RequirementsOf<T> = [T] extends [Effect.Effect<unknown, unknown, infer R>] ? R : never;
 
 const ladder = Scale(["visitor", "çaylak", "yazar"]);
@@ -46,13 +38,11 @@ class OtherCap extends Capability.Level<OtherCap>()("test/OtherCap", {
 declare const grant: Grant<OpenTerm>;
 declare const wrongGrant: Grant<OtherCap>;
 
-/** A privileged op declares the proof in its R channel and reads it back. */
 const op: Effect.Effect<string, never, OpenTerm> = Effect.gen(function* () {
 	const proof = yield* OpenTerm;
 	return proof.scope.capability;
 });
 
-/** Providing the proof discharges the requirement — R collapses to `never`. */
 export const discharged: Effect.Effect<string, never, never> = op.pipe(Grant.provide(grant));
 
 // The authorization gate, as an R-channel assertion:
@@ -69,7 +59,6 @@ expectTypeOf<RequirementsOf<typeof discharged>>().toEqualTypeOf<never>();
 // tsgo-checked fact.
 expectTypeOf(grant).not.toEqualTypeOf(wrongGrant);
 
-/** The discharge verb requires the ports — never the proof it produces. */
 export const required: Effect.Effect<
 	Grant<OpenTerm>,
 	Error,

--- a/packages/authz/src/Capability.unit.test.ts
+++ b/packages/authz/src/Capability.unit.test.ts
@@ -1,9 +1,3 @@
-/**
- * Unit — the class-as-capability builders end to end: the exhaustive Actor
- * dispatch of each discharge verb, `Level` ordering through `.require`,
- * `Relation` ancestry through `.over`, the dormant `AgentAuthority` seam
- * (fail-closed), and `Grant` provision into the context channel via `Grant.provide`.
- */
 import {Effect, Exit} from "effect";
 import {describe, expect, it} from "vitest";
 import {type Actor, agent, human, unauthenticated} from "./Actor.ts";
@@ -21,14 +15,12 @@ class Denied {
 
 const ladder = Scale(["visitor", "çaylak", "yazar"]);
 
-/** Standing fixture: account id → earned rank. */
 const standings: Record<string, "visitor" | "çaylak" | "yazar"> = {
 	yzr: "yazar",
 	cyl: "çaylak",
 	vis: "visitor",
 };
 
-/** A `Level` capability floored at çaylak. */
 class AddEntry extends Capability.Level<AddEntry>()("test/AddEntry", {
 	scale: ladder,
 	min: "çaylak",
@@ -36,7 +28,6 @@ class AddEntry extends Capability.Level<AddEntry>()("test/AddEntry", {
 	deny: () => new Denied(),
 }) {}
 
-/** A `Relation` capability over the `moderates` verb. */
 class Moderate extends Capability.Relation<Moderate>()("test/Moderate", {
 	relation: "moderates",
 	deny: () => new Denied(),
@@ -53,7 +44,6 @@ interface Env {
 	readonly tuples?: ReadonlyArray<Tuple>;
 }
 
-/** Provide the three ports off a fixture and run to an `Exit`. */
 const run = <A, E>(
 	program: Effect.Effect<A, E, CurrentActor | AgentAuthority | RelationStore>,
 	env: Env,
@@ -196,7 +186,6 @@ describe("Capability.Class — .authorize", () => {
 });
 
 describe("Grant provision into context — Grant.provide", () => {
-	// An op that declares the proof in its R channel and reads it back.
 	const op: Effect.Effect<string, never, AddEntry> = Effect.gen(function* () {
 		const proof = yield* AddEntry;
 		return proof.scope.capability;
@@ -204,7 +193,6 @@ describe("Grant provision into context — Grant.provide", () => {
 
 	it("discharges the requirement: the provided proof flows through R", () => {
 		const grant = grantOf(run(AddEntry.require, {actor: human("yzr")}));
-		// after `Grant.provide(grant)` the op needs nothing — R is `never`, runnable.
 		const discharged: Effect.Effect<string, never, never> = op.pipe(Grant.provide(grant));
 		expect(Effect.runSync(discharged)).toBe("test/AddEntry");
 	});

--- a/packages/authz/src/Grant.ts
+++ b/packages/authz/src/Grant.ts
@@ -19,13 +19,11 @@ const GrantTypeId: unique symbol = Symbol.for("@kampus/authz/Grant");
 // reference is not a decode path, and `mint` is still the sole, package-internal way in.
 const GrantKeyId: unique symbol = Symbol("@kampus/authz/Grant/key");
 
-/** What a {@link Grant} proves: its capability tag and the scope the check covered. */
 export interface GrantScope {
-	/** The capability tag (the right) this grant proves. */
 	readonly capability: string;
-	/** For a `Relation` grant, the resource the authority was proved over. */
+	/** Set for a `Relation` grant: the resource the authority was proved over. */
 	readonly resource?: Resource | undefined;
-	/** For a `Level` grant, the standing rank the actor was found to hold. */
+	/** Set for a `Level` grant: the standing rank the actor was found to hold. */
 	readonly level?: string | undefined;
 }
 
@@ -40,12 +38,10 @@ export interface Grant<out M> {
 }
 
 /**
- * Mint a {@link Grant}. Package-internal — never re-exported, so a consumer can
- * only obtain a `Grant` by discharging a real check. The cast widens the runtime
- * marker into the phantom-branded type (the brand is the seal, not data). The
- * capability's `Context.Key` is stamped **non-enumerable** so {@link Grant.provide}
- * can discharge the proof generically without the key entering the `Grant` type or
- * any decode path — the seal holds.
+ * Package-internal — never re-exported, so a consumer can only obtain a
+ * `Grant` by discharging a real check. The key is stamped **non-enumerable**
+ * so `Grant.provide` can discharge generically without the key entering the
+ * `Grant` type or any decode path — that is what holds the seal.
  */
 export const mint = <M>(
 	actor: Actor,
@@ -57,22 +53,14 @@ export const mint = <M>(
 	return proof as Grant<M>;
 };
 
-/** Structural guard: is `value` a minted {@link Grant}? */
 export const isGrant = (value: unknown): value is Grant<unknown> =>
 	typeof value === "object" && value !== null && GrantTypeId in value;
 
 /**
- * Discharge a proof into an op's requirements channel — the single canonical
- * provide verb (ADR 0107, collapsed from the per-capability `Cap.provide` in #1270).
- * Generic over `Grant<C>`: it reads the capability `Context.Key` the grant carries
- * (stamped by {@link mint}) and `provideService`s the grant under **that** key,
- * removing `C` from the effect's `R` channel. Because it routes by the grant's own
- * key, a grant for capability X discharges only X's requirement — a wrong-capability
- * grant leaves the op's requirement unsatisfied (a fail-loud runtime defect, where
- * the old static verb silently provided any grant under the *named* capability's key).
- * The type-level brand also distinguishes capabilities: the sealed `CapabilityTag` carries
- * each capability's `id` literal, so `Grant<X>` ≢ `Grant<Y>` and a wrong-proof is a compile
- * error too (#1483 — the brand is phantom, no runtime change here).
+ * The single canonical discharge verb (ADR 0107). It routes by the key the
+ * grant itself carries, never by a named capability's key: a wrong-capability
+ * grant therefore leaves the requirement unsatisfied and fails loud, instead
+ * of silently satisfying it the way the old static verb did (#1270, #1483).
  */
 const provide =
 	<C>(grant: Grant<C>) =>
@@ -81,9 +69,4 @@ const provide =
 		return Effect.provideService(self, key, grant);
 	};
 
-/**
- * The `Grant` value namespace (merged with the `Grant<M>` type above): carries the
- * canonical discharge verb {@link provide} and nothing that forges a proof — `mint`
- * stays package-internal, so the seal is unchanged.
- */
 export const Grant = {provide} as const;

--- a/packages/authz/src/Grant.unit.test.ts
+++ b/packages/authz/src/Grant.unit.test.ts
@@ -24,7 +24,6 @@ describe("Grant seal", () => {
 	it("ships no Schema/decode path — a decodable proof would be forgeable", () => {
 		expect("GrantSchema" in surface).toBe(false);
 		expect("decodeGrant" in surface).toBe(false);
-		// the only Grant-named runtime export is the structural guard
 		expect(typeof surface.isGrant).toBe("function");
 	});
 

--- a/packages/authz/src/Level.ts
+++ b/packages/authz/src/Level.ts
@@ -1,29 +1,21 @@
 /**
- * `Level` — an ordered scale with `gte`, the RBAC/MLS-shaped axis backing the
- * earned-authorship ladder (ADR 0107 §4): a {@link Scale} is a list of rank
- * names whose only operation is monotone comparison (a yazar passes any
- * çaylak-floored gate). Vocab-free — the rank names are caller-supplied
- * (`features/kunye` passes `["visitor", "çaylak", "yazar"]`); the `const` scale
- * pins the name literals so `min`/comparison args are checked against the real
- * ladder, not bare `string`.
+ * `Level` — the ordered scale backing the earned-authorship ladder (ADR 0107 §4).
+ * Vocab-free: rank names are caller-supplied (`features/kunye` passes
+ * `["visitor", "çaylak", "yazar"]`).
  */
 
-/** An ordered scale of rank `Name`s, lowest-first, with monotone comparison. */
 export interface Scale<Name extends string> {
-	/** The rank names, lowest-authority first. */
+	/** The rank names, **lowest-authority first**. */
 	readonly order: ReadonlyArray<Name>;
-	/** The 0-based rank of a name (its index in {@link order}). */
 	readonly rank: (name: Name) => number;
-	/** Is `a` at least as high as `b` on the scale? The ladder's whole law. */
 	readonly gte: (a: Name, b: Name) => boolean;
-	/** Narrow an arbitrary string to a known rank of this scale. */
 	readonly has: (name: string) => name is Name;
 }
 
 /**
  * Build a {@link Scale} from its rank names, **lowest-authority first**. The
  * `const` type parameter pins the literal names so a capability's `min` and the
- * standing it compares are checked against the real ladder.
+ * standing it compares are checked against the real ladder, not bare `string`.
  */
 export const Scale = <const Names extends ReadonlyArray<string>>(
 	order: Names,

--- a/packages/authz/src/Level.unit.test.ts
+++ b/packages/authz/src/Level.unit.test.ts
@@ -14,9 +14,8 @@ describe("Scale", () => {
 	it("gte is the ladder's whole law — monotone, reflexive", () => {
 		// a yazar passes any çaylak-floored gate (ADR 0107 §4)
 		expect(ladder.gte("yazar", "çaylak")).toBe(true);
-		expect(ladder.gte("yazar", "yazar")).toBe(true); // reflexive
+		expect(ladder.gte("yazar", "yazar")).toBe(true);
 		expect(ladder.gte("çaylak", "çaylak")).toBe(true);
-		// a çaylak does not clear a yazar floor
 		expect(ladder.gte("çaylak", "yazar")).toBe(false);
 		expect(ladder.gte("visitor", "çaylak")).toBe(false);
 	});

--- a/packages/authz/src/Relation.ts
+++ b/packages/authz/src/Relation.ts
@@ -10,7 +10,6 @@
 import {Context, type Effect} from "effect";
 import type {Resource} from "./Resource.ts";
 
-/** A `(subject, relation, object)` ReBAC tuple — the object is a resource node. */
 export interface Relation {
 	readonly subject: string;
 	readonly relation: string;
@@ -27,22 +26,18 @@ export class RelationStore extends Context.Service<
 	{
 		readonly has: (tuple: Relation) => Effect.Effect<boolean>;
 
-		// The batched form of {@link has} over a set of subjects sharing one
-		// `(relation, object)`: returns the subset that hold the tuple, in ONE store
-		// read instead of N per-subject `has` calls. Same direct-tuple semantics as
-		// `has` (no ancestry walk), so a by-id membership join over `subjects` is a
-		// single round-trip, not an in-batch N+1.
+		// The batched form of {@link has}: ONE store read instead of N per-subject calls, so a
+		// membership join is a single round-trip, not an in-batch N+1. Same direct-tuple semantics
+		// as `has` — no ancestry walk.
 		readonly hasSubjects: (query: {
 			readonly subjects: ReadonlyArray<string>;
 			readonly relation: string;
 			readonly object: Resource;
 		}) => Effect.Effect<ReadonlySet<string>>;
 
-		// Enumerate EVERY subject holding `(relation, object)` — the open-set read the
-		// membership pair (`has`/`hasSubjects`) can't answer, because both need the
-		// candidate ids up front. A mod fan-out (`notify every moderator`, #1699) has no
-		// candidate set: the recipient set IS "who holds `(moderates, platform)`". Same
-		// direct-tuple semantics as `has` (no ancestry walk); one read returns the whole set.
+		// The open-set read `has`/`hasSubjects` can't answer, because both need candidate ids up
+		// front: a mod fan-out (#1699) has none — the recipient set IS who holds the tuple. Same
+		// direct-tuple semantics as `has` — no ancestry walk.
 		readonly subjectsOf: (query: {
 			readonly relation: string;
 			readonly object: Resource;

--- a/packages/authz/src/Resource.ts
+++ b/packages/authz/src/Resource.ts
@@ -1,49 +1,32 @@
 /**
- * `Resource` — a generic recursive tree node, the scope a `Relation`-backed
- * capability is proved *over* (ADR 0107: ReBAC authority is resource-scoped). A
- * node is a `(type, id)` with an optional `parent`, so authority on an ancestor
- * covers its descendants: a `moderates` tuple on `platform` covers a report
- * filed under it (the recursion is also ADR 0107's nested-platform reach —
- * designed-for, not built). Vocab-free: `type`/`id` are caller-supplied strings.
+ * `Resource` — the recursive tree a `Relation`-backed capability is proved over (ADR 0107:
+ * ReBAC authority is resource-scoped). Authority on an ancestor covers its descendants: a
+ * `moderates` tuple on `platform` covers a report filed under it. Vocab-free — `type`/`id`
+ * are caller-supplied strings, never a kamp.us product noun.
  */
 
-/** A node in the resource tree — a `(type, id)` with an optional `parent`. */
 export interface Resource {
 	readonly type: string;
 	readonly id: string;
 	readonly parent?: Resource | undefined;
 }
 
-/** Build a {@link Resource}, optionally under a `parent`. */
 export const resource = (type: string, id: string, parent?: Resource): Resource =>
 	parent === undefined ? {type, id} : {type, id, parent};
 
 /**
- * The canonical storage key for a resource node — its `(type, id)` pair as
- * `type:id`. The ONE encoding both sides of the ReBAC seam agree on: the offline
- * tuple mint (`@kampus/founder-seed`) writes `relation_tuple.object` as this, and
- * `RelationStoreLive` reads it back as this, so a discharge over the node finds
- * the seeded tuple. Centralized here (not duplicated per writer/reader) so the
- * write key and the read key cannot diverge.
+ * The ONE encoding both sides of the ReBAC seam agree on: the offline tuple mint
+ * (`@kampus/founder-seed`) writes `relation_tuple.object` as this and `RelationStoreLive`
+ * reads it back as this, so the write key and the read key cannot diverge.
  */
 export const key = (node: Resource): string => `${node.type}:${node.id}`;
 
-/**
- * The platform root — the top of the resource tree, the scope platform-wide
- * authority (`moderates`, `admin`) is held over. A fixed singleton node so
- * `key(platform)` is one stable string across the offline mint and the runtime
- * read. Vocab-free: a generic structural root, named no kamp.us product noun.
- */
+/** The root platform-wide authority (`moderates`, `admin`) is held over. */
 export const platform: Resource = resource("platform", "platform");
 
-/** Two nodes denote the same resource iff their `(type, id)` match. */
 export const sameNode = (a: Resource, b: Resource): boolean => a.type === b.type && a.id === b.id;
 
-/**
- * The ancestry chain of a node, **self first**, walking `parent` to the root.
- * The set of nodes any of which, held under a relation, authorizes an action on
- * the input node.
- */
+/** The chain from a node to the root, **self first** — holding any step authorizes the node. */
 export const ancestry = (node: Resource): ReadonlyArray<Resource> => {
 	const chain: Array<Resource> = [];
 	let current: Resource | undefined = node;
@@ -54,10 +37,5 @@ export const ancestry = (node: Resource): ReadonlyArray<Resource> => {
 	return chain;
 };
 
-/**
- * Does authority on `ancestor` cover `node`? True iff `ancestor` is `node`
- * itself or one of its ancestors — i.e. `ancestor` appears in `node`'s
- * {@link ancestry} chain.
- */
 export const covers = (ancestor: Resource, node: Resource): boolean =>
 	ancestry(node).some((step) => sameNode(step, ancestor));

--- a/packages/authz/src/Resource.unit.test.ts
+++ b/packages/authz/src/Resource.unit.test.ts
@@ -22,11 +22,11 @@ describe("Resource", () => {
 	});
 
 	it("covers is reflexive and holds up the chain, never down", () => {
-		expect(covers(term, term)).toBe(true); // reflexive
-		expect(covers(platform, term)).toBe(true); // ancestor covers descendant
+		expect(covers(term, term)).toBe(true);
+		expect(covers(platform, term)).toBe(true);
 		expect(covers(board, term)).toBe(true);
-		expect(covers(term, platform)).toBe(false); // descendant never covers ancestor
-		expect(covers(resource("board", "pano"), term)).toBe(false); // unrelated
+		expect(covers(term, platform)).toBe(false);
+		expect(covers(resource("board", "pano"), term)).toBe(false);
 	});
 
 	it("key encodes a node as `type:id` — the one storage key both seam sides agree on", () => {

--- a/packages/authz/src/index.ts
+++ b/packages/authz/src/index.ts
@@ -34,9 +34,6 @@ export {
 	type RelationConfig,
 } from "./Capability.ts";
 export {CurrentActor} from "./CurrentActor.ts";
-// The `Grant` type + the `Grant.provide` discharge verb + `isGrant` escape; `mint`
-// does NOT — the seal. `Grant` is a merged type+value: `Grant<M>` types the proof,
-// `Grant.provide(grant)` discharges it.
 export {Grant, type GrantScope, isGrant} from "./Grant.ts";
 export {Scale} from "./Level.ts";
 export {type Relation, RelationStore} from "./Relation.ts";

--- a/packages/authz/vitest.config.ts
+++ b/packages/authz/vitest.config.ts
@@ -1,11 +1,7 @@
 /**
- * Vitest config — `packages/authz` is a pure mechanism (no DB, no worker), so
- * every test is a colocated `*.unit.test.ts` of a pure primitive (the Grant
- * seal, the Level ordering, Resource ancestry/covers, the class-builders'
- * exhaustive Actor dispatch + Grant provision into context). No integration
- * tier: the package names no storage to integrate against — its adapters
- * (`RelationStoreLive`, `CurrentActorLive`) and their real-D1 tests live in
- * `features/kunye`, not here.
+ * Unit tier only: `packages/authz` is a pure mechanism with no storage to
+ * integrate against — its adapters (`RelationStoreLive`, `CurrentActorLive`)
+ * and their real-D1 tests live in `features/kunye`, not here.
  */
 import {defineConfig} from "vitest/config";
 

--- a/packages/depo/src/client.ts
+++ b/packages/depo/src/client.ts
@@ -1,14 +1,8 @@
 /**
- * The depo client core — content-address a body, present the apiKey, call the
- * doorman, and return the public URL. This is the whole write path (ADR 0144
- * decision 5), and it is the surface server-side products `import` directly (no
- * CLI). The network is behind the `DoormanClient` seam so the core unit-tests end
- * to end with the seam substituted and no live worker (`.patterns/effect-testing.md`
- * unit tier).
- *
- * `putBytes` is the seam-testable core (bytes in); `put(path)` is the fs-reading
- * wrapper the bin calls. The mapping from the doorman's HTTP status to a typed
- * failure is the acceptance contract (#1970); it lives in `putBytes` below.
+ * The depo client core — content-address a body, present the apiKey, call the doorman,
+ * return the public URL. The whole write path (ADR 0144 decision 5), imported directly by
+ * server-side products. The network sits behind the `DoormanClient` seam so the core
+ * unit-tests end to end with no live worker.
  */
 import {readFile} from "node:fs/promises";
 import * as Context from "effect/Context";
@@ -29,7 +23,6 @@ import {
 	UploadFailed,
 } from "./errors.ts";
 
-/** The one PUT the doorman exposes and its outcome — the seam the core is tested against. */
 export interface DoormanRequest {
 	readonly apiKey: string;
 	readonly contentType: AllowedContentType;
@@ -38,16 +31,13 @@ export interface DoormanRequest {
 
 export interface DoormanResponse {
 	readonly status: number;
-	/** The response body text — a JSON `{key,url}` on 2xx, a plain reason on 4xx. */
+	/** A JSON `{key,url}` on 2xx, a plain reason on 4xx. */
 	readonly body: string;
 }
 
 /**
- * The doorman HTTP seam. Its `send` performs the single `PUT` to the doorman host
- * and hands back the raw status + body; all status→error mapping lives in the core
- * (`putBytes`), never in the seam, so the seam is a dumb transport a test can
- * replace with a canned response. `DoormanClientLive` (`live.ts`) implements it
- * over `HttpClient`; the bin provides that layer, a test provides a stub.
+ * All status→error mapping lives in the core (`putBytes`), never in this seam, so the seam
+ * stays a dumb transport a test can replace with a canned response.
  */
 export interface DoormanClientService {
 	readonly send: (req: DoormanRequest) => Effect.Effect<DoormanResponse, UploadFailed>;
@@ -57,7 +47,6 @@ export class DoormanClient extends Context.Service<DoormanClient, DoormanClientS
 	"depo/DoormanClient",
 ) {}
 
-/** The doorman's `{key,url}` success body. */
 interface DoormanSuccessBody {
 	readonly key: string;
 	readonly url: string;
@@ -77,15 +66,10 @@ const parseSuccess = (body: string): DoormanSuccessBody | null => {
 };
 
 /**
- * Upload already-read bytes: content-address, call the doorman, map the status.
- * The `contentType` must already be an allowlisted type (the caller resolved it
- * from the filename via `contentTypeForFile`), so a 415 here means the server's
- * allowlist and the client's disagree — still mapped to `UnsupportedMediaType`.
- *
- * On 2xx the returned URL is the doorman's own `{url}` when present, else the
- * client re-derives `https://depo.kamp.us/<key>` from the content address — the
- * two are equal by construction (the key IS `<sha256>.<ext>`), so a caller can
- * rely on the URL with no live worker in a test.
+ * `contentType` is already allowlisted by the caller, so a 415 here means the server's
+ * allowlist and the client's disagree. On 2xx the doorman's `{url}` and the client-derived
+ * `publicUrl(key)` are equal by construction (the key IS `<sha256>.<ext>`), so a test can
+ * rely on the URL with no live worker.
  */
 export const putBytes = (input: {
 	readonly apiKey: string;
@@ -132,12 +116,6 @@ export const putBytes = (input: {
 		});
 	});
 
-/**
- * Upload a file by path: resolve its content-type from the extension (refusing a
- * non-image before any network call), read the bytes, then `putBytes`. This is the
- * bin's entry point and the server-side `import` surface — it returns the permanent
- * `https://depo.kamp.us/<sha256>.<ext>` URL.
- */
 export const put = (input: {readonly path: string; readonly apiKey: string}) =>
 	Effect.gen(function* () {
 		const filename = input.path.split("/").pop() ?? input.path;

--- a/packages/depo/src/client.unit.test.ts
+++ b/packages/depo/src/client.unit.test.ts
@@ -1,9 +1,6 @@
 /**
- * Unit tests for the client core (`putBytes`) with the doorman behind the
- * `DoormanClient` seam — no live worker (`.patterns/effect-testing.md` unit tier).
- * These assert the acceptance contract: the content-addressed request the client
- * SENDS, and the mapping from each doorman status to a typed outcome (a case per
- * status below).
+ * The client core with the doorman substituted behind the `DoormanClient` seam — no live worker
+ * (`.patterns/effect-testing.md` unit tier).
  */
 import {assert, describe, it} from "@effect/vitest";
 import * as Effect from "effect/Effect";
@@ -16,10 +13,6 @@ const BYTES = new TextEncoder().encode("abc");
 const KEY_ABC_PNG = "ba7816bf8f01cfea414140de5dae2223b00361a396177a9cb410ff61f20015ad.png";
 const URL_ABC_PNG = `https://depo.kamp.us/${KEY_ABC_PNG}`;
 
-/**
- * A seam stub that records the request it was sent and replies with a canned
- * response — the substitution that lets the core run end to end with no HTTP.
- */
 const stubClient = (
 	response: DoormanResponse,
 	recorder?: (req: DoormanRequest) => void,

--- a/packages/depo/src/command.ts
+++ b/packages/depo/src/command.ts
@@ -1,13 +1,7 @@
 /**
- * The `depo put <file>` subcommand (ADR 0144 decision 5). It resolves the apiKey,
- * uploads the file via the client lib (`put`), and prints exactly the public URL
- * to stdout — so a caller can capture `$(depo put shot.png)` and embed it. Every
- * typed failure is turned into a legible stderr line + a non-zero exit; nothing
- * but the URL ever reaches stdout on success.
- *
- * The command self-contains its services (`Command.provide`) so the bin's run
- * boundary stays thin: it bakes in `DoormanClientLive` over `FetchHttpClient.layer`,
- * leaving the registered command's residual requirement at the Node platform union.
+ * The `depo put <file>` subcommand (ADR 0144 decision 5). Nothing but the public URL
+ * ever reaches stdout on success, so a caller can capture `$(depo put shot.png)` and
+ * embed it; every typed failure goes to stderr with a non-zero exit.
  */
 import * as Console from "effect/Console";
 import * as Effect from "effect/Effect";
@@ -26,7 +20,6 @@ import type {
 } from "./errors.ts";
 import {resolveApiKey} from "./live.ts";
 
-/** The full typed-failure union `put` (+ credential resolution) can raise. */
 type PutFailure =
 	| MissingCredential
 	| UnsupportedFile
@@ -49,18 +42,12 @@ const tokenFlag = Flag.string("token").pipe(
 	),
 );
 
-/**
- * Each typed failure → a one-line stderr message + a non-zero exit. The failure is
- * mapped here (not left to `NodeRuntime`'s stack dump) so an operator or a calling
- * skill gets a legible reason, and stdout stays clean for the URL alone.
- */
 const reportAndExit = (message: string) =>
 	Effect.gen(function* () {
 		yield* Console.error(`depo: ${message}`);
 		return yield* Effect.sync(() => process.exit(1));
 	});
 
-/** Map a typed put failure to its operator-legible one-line reason. */
 const reasonOf = (error: PutFailure): string => {
 	switch (error._tag) {
 		case "depo/MissingCredential":

--- a/packages/depo/src/domain.ts
+++ b/packages/depo/src/domain.ts
@@ -1,23 +1,15 @@
 /**
- * depo's client-side domain — the pure rules that turn a local file into the
- * exact upload the doorman (#1970, ADR 0144 decision 4) will accept: the
- * content-type → extension allowlist and the `<sha256>.<ext>` content address.
+ * depo's client-side domain — the content-type allowlist and the `<sha256>.<ext>`
+ * content address. See ADR 0144.
  *
- * This mirrors the doorman's own `domain.ts` (PNG/JPEG/WebP, sha256+ext) so the
- * key the client computes is the key the server stores — a mismatch would only
- * surface as a wasted round-trip. Kept PURE (no HTTP, no fs, no apiKey) so the
- * content-addressing unit-tests with no live worker (`.patterns/effect-testing.md`
- * unit tier).
+ * This mirrors the doorman's own `domain.ts`, so the key the client computes is the
+ * key the server stores. Keep it PURE (no HTTP, no fs, no apiKey) — that is what lets
+ * the content-addressing unit-test with no live worker.
  */
 import * as Effect from "effect/Effect";
 import {DigestError, UnsupportedFile} from "./errors.ts";
 
-/**
- * The content-type allowlist and its extension — the single source the client
- * shares with the doorman (ADR 0144 decision 4). depo holds exactly PNG / JPEG /
- * WebP. A file whose extension is not a key here is refused before any network
- * call, so the CLI never presents a payload the doorman would 415.
- */
+/** The single source the client shares with the doorman — keep the two in step. */
 export const ALLOWED_TYPES = {
 	"image/png": "png",
 	"image/jpeg": "jpg",
@@ -27,10 +19,8 @@ export const ALLOWED_TYPES = {
 export type AllowedContentType = keyof typeof ALLOWED_TYPES;
 export type AllowedExt = (typeof ALLOWED_TYPES)[AllowedContentType];
 
-/** The public read host — a depo URL is `https://depo.kamp.us/<sha256>.<ext>`. */
 export const PUBLIC_HOST = "https://depo.kamp.us";
 
-/** File extension → the allowlisted content-type the doorman keys off of. */
 const EXT_TO_TYPE: Record<string, AllowedContentType> = {
 	png: "image/png",
 	jpg: "image/jpeg",
@@ -38,12 +28,6 @@ const EXT_TO_TYPE: Record<string, AllowedContentType> = {
 	webp: "image/webp",
 };
 
-/**
- * Resolve a filename's extension to an allowlisted content-type, or refuse. The
- * extension is lowercased so `SHOT.PNG` is accepted; a name with no extension, or
- * one outside the allowlist, fails `UnsupportedFile` — the client-side mirror of
- * the doorman's 415, caught before the upload.
- */
 export const contentTypeForFile = (
 	filename: string,
 ): Effect.Effect<AllowedContentType, UnsupportedFile> => {
@@ -56,7 +40,6 @@ export const contentTypeForFile = (
 	return Effect.succeed(type);
 };
 
-/** Lowercase hex of a SHA-256 digest — the content-address stem. */
 export const sha256Hex = (bytes: Uint8Array): Effect.Effect<string, DigestError> =>
 	Effect.tryPromise({
 		// `.slice()` yields a fresh `Uint8Array<ArrayBuffer>` (never a SharedArrayBuffer),
@@ -71,12 +54,10 @@ export const sha256Hex = (bytes: Uint8Array): Effect.Effect<string, DigestError>
 		),
 	);
 
-/** The object key for a body of a given type: `<sha256>.<ext>` — matches the doorman. */
 export const contentAddressKey = (
 	bytes: Uint8Array,
 	contentType: AllowedContentType,
 ): Effect.Effect<string, DigestError> =>
 	sha256Hex(bytes).pipe(Effect.map((hex) => `${hex}.${ALLOWED_TYPES[contentType]}`));
 
-/** The permanent public URL for a stored key: `https://depo.kamp.us/<key>`. */
 export const publicUrl = (key: string): string => `${PUBLIC_HOST}/${key}`;

--- a/packages/depo/src/domain.unit.test.ts
+++ b/packages/depo/src/domain.unit.test.ts
@@ -1,10 +1,7 @@
 /**
- * Unit tests for depo's client-side domain — content-type resolution and the
- * `<sha256>.<ext>` content address. No engine, no I/O (`.patterns/effect-testing.md`
- * unit tier): these rules could be wrong even if the doorman behaved perfectly.
- *
- * The content-address digest is asserted against a known-answer SHA-256 vector so
- * the key the client computes is provably the key the doorman stores.
+ * Unit tests for depo's client-side domain — content-type resolution and the `<sha256>.<ext>`
+ * content address. The digest is asserted against a known-answer SHA-256 vector, so the key the
+ * client computes is provably the key the doorman stores.
  */
 import {assert, describe, it} from "@effect/vitest";
 import * as Effect from "effect/Effect";
@@ -52,7 +49,6 @@ describe("contentTypeForFile", () => {
 describe("sha256Hex (known-answer vector)", () => {
 	it.effect("hashes the empty input to the canonical digest", () =>
 		Effect.gen(function* () {
-			// The SHA-256 of the empty byte string — a fixed vector.
 			assert.strictEqual(
 				yield* sha256Hex(new Uint8Array(0)),
 				"e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",

--- a/packages/depo/src/errors.ts
+++ b/packages/depo/src/errors.ts
@@ -1,22 +1,18 @@
 /**
- * depo client's tagged errors — one file for the whole put path (the
- * `.patterns/effect-errors.md` one-`errors.ts`-per-surface rule). Each is a
- * `Schema.TaggedErrorClass` (the repo-wide error constructor — #2736). These are
- * CLI-only and never reach the fate wire, so they carry no `FateWireCode`
- * annotation. The set is the client-side image of the doorman's HTTP contract
- * (#1970): every 4xx the doorman can return maps to exactly one error here (each
- * class documents its own status below), so a caller `catch`es a typed failure
- * rather than parsing a status code.
+ * depo client's tagged errors — see `.patterns/effect-errors.md`.
+ *
+ * These are CLI-only and never reach the fate wire, so they carry no `FateWireCode`
+ * annotation. The set is the client-side image of the doorman's HTTP contract: every
+ * 4xx the doorman can return maps to exactly one error here, so a caller `catch`es a
+ * typed failure rather than parsing a status code.
  */
 import * as Schema from "effect/Schema";
 
-/** No apiKey could be resolved (flag / `KAMPUS_TOKEN` / stored credential all empty). */
 export class MissingCredential extends Schema.TaggedErrorClass<MissingCredential>()(
 	"depo/MissingCredential",
 	{reason: Schema.String},
 ) {}
 
-/** The local file could not be read (missing / unreadable). */
 export class FileReadError extends Schema.TaggedErrorClass<FileReadError>()("depo/FileReadError", {
 	path: Schema.String,
 	cause: Schema.Unknown,
@@ -54,7 +50,6 @@ export class ContentAddressConflict extends Schema.TaggedErrorClass<ContentAddre
 	{message: Schema.String},
 ) {}
 
-/** The SHA-256 content address could not be computed (`crypto.subtle.digest` rejected). */
 export class DigestError extends Schema.TaggedErrorClass<DigestError>()("depo/DigestError", {
 	cause: Schema.Unknown,
 }) {}

--- a/packages/depo/src/index.ts
+++ b/packages/depo/src/index.ts
@@ -1,11 +1,7 @@
 /**
- * `@kampus/depo` — the depo client library (ADR 0144 decision 5). Server-side
- * products `import` this to upload an asset and get its permanent
+ * `@kampus/depo` — the depo client library (ADR 0144 decision 5). Server-side products
+ * `import` this to upload an asset and get its permanent
  * `https://depo.kamp.us/<sha256>.<ext>` URL, with no CLI in the path.
- *
- * The core (`put` / `putBytes`) talks to the doorman through the `DoormanClient`
- * seam; provide `DoormanClientLive` (over an `HttpClient`) for the real upload, or
- * a stub in a test. `resolveApiKey` is the shared credential-resolution helper.
  */
 export {
 	DoormanClient,

--- a/packages/depo/src/live.ts
+++ b/packages/depo/src/live.ts
@@ -20,15 +20,12 @@ import * as HttpClientRequest from "effect/unstable/http/HttpClientRequest";
 import {DoormanClient} from "./client.ts";
 import {MissingCredential, UploadFailed} from "./errors.ts";
 
-/** The doorman's write host — the single `PUT /` surface (ADR 0144 decision 4). */
 export const DOORMAN_URL = "https://up.depo.kamp.us/";
 
 /**
- * `DoormanClientLive` — the seam over `HttpClient`. It sends the one `PUT` with
- * the apiKey + content-type headers and the raw body, and lowers any transport
- * fault into `UploadFailed` (status `null`); every HTTP *status* is handed back
- * verbatim for the core to map. It reads `HttpClient` from context, so the bin
- * provides `FetchHttpClient.layer` at the run boundary.
+ * Only a TRANSPORT fault lowers into `UploadFailed` (status `null`); every HTTP *status*
+ * is handed back verbatim for the core to map. `HttpClient` comes from context, so the
+ * bin provides `FetchHttpClient.layer` at the run boundary.
  */
 export const DoormanClientLive = Layer.effect(DoormanClient)(
 	Effect.gen(function* () {
@@ -65,15 +62,12 @@ export const DoormanClientLive = Layer.effect(DoormanClient)(
 	}),
 );
 
-/** The stored-credential path (ADR 0045 decision 3): `~/.config/kampus/token`. */
 const storedCredentialPath = (): string =>
 	join(process.env.XDG_CONFIG_HOME ?? join(homedir(), ".config"), "kampus", "token");
 
 /**
- * Resolve the pasaport apiKey in ADR 0045's precedence: an explicit value first,
- * then `KAMPUS_TOKEN`, then the stored `~/.config/kampus/token` credential. A
- * blank result at every rung fails `MissingCredential` — the CLI never sends an
- * empty bearer the doorman would 401.
+ * Resolve the pasaport apiKey in ADR 0045's precedence. A blank result at every rung
+ * fails `MissingCredential` — the CLI never sends an empty bearer the doorman would 401.
  */
 export const resolveApiKey = (
 	explicit?: string | undefined,

--- a/packages/depo/src/run.ts
+++ b/packages/depo/src/run.ts
@@ -1,13 +1,9 @@
 /**
- * The `depo` CLI run boundary — wires the root command and runs it over the Node
- * platform (mirrors `@kampus/anka-ops` / the `epic-ledger` idiom):
- * `effect/unstable/cli` for the typed subcommands, the Node platform, run via
- * `NodeRuntime.runMain`. The `DoormanClient` seam is discharged here with
- * `DoormanClientLive` over `FetchHttpClient.layer` — the one place the real
- * network layer is provided, so `command.ts` stays transport-agnostic.
+ * The `depo` CLI run boundary. This is the ONE place the real network layer is
+ * provided, so `command.ts` stays transport-agnostic.
  *
- * Loaded via a dynamic `import()` from `bin.ts` so an unlinked `catalog:` dep on a
- * fresh checkout surfaces as an actionable message, not a raw module-not-found.
+ * `bin.ts` reaches this through a dynamic `import()` so an unlinked `catalog:` dep on
+ * a fresh checkout surfaces as an actionable message, not a raw module-not-found.
  */
 import {NodeRuntime, NodeServices} from "@effect/platform-node";
 import {Effect, Layer} from "effect";

--- a/packages/depo/src/version.ts
+++ b/packages/depo/src/version.ts
@@ -1,2 +1,1 @@
-/** The `@kampus/depo` CLI version, surfaced at the root `--version`. */
 export const VERSION = "0.1.0";

--- a/packages/fate-effect/src/Codegen.fixture.ts
+++ b/packages/fate-effect/src/Codegen.fixture.ts
@@ -84,5 +84,4 @@ const mutations = {
 
 const config = FateServer.config({queries, lists, mutations, sources: [termSource]});
 
-/** What `schema.ts` exports for the fate Vite plugin's `runnerImport`. */
 export const fateServer = FateExecutor.toCodegenServer(config);

--- a/packages/fate-effect/src/Codegen.test.ts
+++ b/packages/fate-effect/src/Codegen.test.ts
@@ -346,7 +346,6 @@ describe("InferFateAPI fidelity — codegen ≡ live", () => {
 		expectTypeOf<
 			CodegenAPI["mutations"]["definition.add"]["input"]
 		>().toEqualTypeOf<AddDefinitionWire>();
-		// No declared args Schema → no client args.
 		expectTypeOf<CodegenAPI["queries"]["health"]["input"]>().toEqualTypeOf<{
 			args?: undefined;
 			select: Array<string>;

--- a/packages/fate-effect/src/Codegen.ts
+++ b/packages/fate-effect/src/Codegen.ts
@@ -1,17 +1,8 @@
 /**
- * `toCodegenServer` — the BUILD-TIME compile surface, split out of
- * `Executor.ts`: this module is the PRODUCTION build path —
- * `schema.ts` exports its value for Vite codegen on every deploy — while
- * `Executor.ts` keeps only the frozen oracle baseline. The two share the
- * compiled-definition vocabulary through `Compiled.ts` and never import each
- * other; the public `FateExecutor.toCodegenServer` spelling is assembled in
- * the barrel (`index.ts`).
- *
- * The codegen server IS a real fate server — same `createFateServer` call as
- * the live compile, so the client manifest and `InferFateAPI` hold by
- * construction — but every resolver and source executor is INERT: importing
- * the schema module constructs pure data (nothing runs, no database at build
- * time).
+ * `toCodegenServer` — the build-time compile surface. The codegen server IS a real fate
+ * server (same `createFateServer` call as the live compile, so the client manifest and
+ * `InferFateAPI` hold by construction) but every resolver and source executor is INERT:
+ * importing the schema module constructs pure data — nothing runs, no database at build time.
  */
 import type {ConnectionResult, FateServer as KernelFateServer} from "@nkzw/fate/server";
 import {createFateServer} from "@nkzw/fate/server";
@@ -40,41 +31,26 @@ import type {
 } from "./Server.ts";
 import {collectConfigIssues, FateServerConfigError} from "./Server.ts";
 
-/**
- * What `InferFateAPI` must yield for one config QUERY entry — fate's own
- * `QueryAPI` mapping reproduced over the package's entry types: a
- * `Fate.query` entry surfaces the definition's WIRE args (the Schema's
- * ENCODED side — what the client sends before `resolve` decodes) and the
- * handler's success type. A non-entry maps to `never`, exactly as fate's
- * `QueryAPI` does for an uninferrable record.
- */
+/** Args are the Schema's ENCODED side — what the client sends before `resolve` decodes. */
 export type FateCodegenQueryApi<E> =
 	E extends FateQuery<infer D, infer A, infer _E, infer _R>
 		? {input: {args?: DefinitionWireArgs<D>; select: Array<string>}; output: A}
 		: never;
 
-/** As {@link FateCodegenQueryApi}, with fate's `ConnectionResult` envelope. */
 export type FateCodegenListApi<E> =
 	E extends FateList<infer D, infer Item, infer _E, infer _R>
 		? {input: {args?: DefinitionWireArgs<D>; select: Array<string>}; output: ConnectionResult<Item>}
 		: never;
 
-/**
- * As {@link FateCodegenQueryApi}, for mutations: `entity` is the definition's
- * literal wire type name (`DefinitionTypeName` keeps it literal — richer than
- * fate's naturally-widened `string`, and what `MutationAPI` reads from the
- * record's `type` property), `input` is the WIRE input.
- */
+/** `DefinitionTypeName` keeps `entity` literal — richer than fate's naturally-widened `string`. */
 export type FateCodegenMutationApi<E> =
 	E extends FateMutation<infer D, infer A, infer _E, infer _R>
 		? {entity: DefinitionTypeName<D>; input: DefinitionWireInput<D>; output: A}
 		: never;
 
 /**
- * The full `InferFateAPI` surface of a codegen server — structurally fate's
- * `NativeFateAPI<{}, Q, L, M>` (empty roots, ADR 0016/0019) computed from the
- * TYPED config records. `Codegen.test.ts` pins it mutually assignable with
- * fate's own inference over a live reference server.
+ * Structurally fate's `NativeFateAPI<{}, Q, L, M>` (empty roots, ADR 0016/0019). `Codegen.test.ts`
+ * pins it mutually assignable with fate's own inference over a live reference server.
  */
 export interface FateCodegenAPI<
 	Q extends FateQueriesRecord,
@@ -86,29 +62,19 @@ export interface FateCodegenAPI<
 	readonly queries: {readonly [K in keyof Q]: FateCodegenQueryApi<Q[K]>};
 }
 
-/**
- * What {@link toCodegenServer} returns: fate's server value carrying the
- * config-derived API as its `__api` phantom — the type `InferFateAPI` plucks
- * in the generated client.
- */
 export type FateCodegenServer<
 	Q extends FateQueriesRecord,
 	L extends FateListsRecord,
 	M extends FateMutationsRecord,
 > = KernelFateServer<FateCodegenAPI<Q, L, M>, unknown>;
 
-/** An inert resolver: the codegen server is schema/manifest only, never serves. */
 const inertResolve = (category: string, name: string) => (): never => {
 	throw new Error(
 		`fate codegen server is inert — ${category} "${name}" has no executable handler (build-time schema/manifest only).`,
 	);
 };
 
-/**
- * An inert definition: the entry's `type` passed through, nothing executable.
- * The inferred `resolve: () => never` satisfies both the query and list
- * definition shapes, so one helper serves both categories.
- */
+/** `resolve: () => never` satisfies both the query and list shapes, so one helper serves both. */
 const inertDefinition = (
 	entry: {readonly type: string | undefined},
 	category: string,
@@ -119,18 +85,9 @@ const inertDefinition = (
 });
 
 /**
- * Build the CODEGEN server from a typed config: the same `createFateServer`
- * call the live compile step makes — same record keys, same `type` strings,
- * same `roots: {}`, same live option passthrough, so `manifest` matches the
- * live server's — but every resolver and source executor is INERT. `schema.ts`
- * exports this value for the fate Vite plugin's `runnerImport`: importing it
- * constructs pure data (nothing runs, no database at build time), and its
- * declared type carries {@link FateCodegenAPI}, so
- * `InferFateAPI<typeof fateServer>` in the generated client matches the live
- * wire contract (pinned in `Codegen.test.ts`).
- *
- * Invalid configs throw {@link FateServerConfigError} here — the same issues
- * `FateServer.layer` dies with at worker init, surfaced at build time.
+ * Mirrors the live compile step exactly — same record keys, `type` strings, `roots: {}` and
+ * live passthrough — so `manifest` matches the live server's. Invalid configs throw the same
+ * {@link FateServerConfigError} `FateServer.layer` dies with, surfaced at build time.
  */
 export function toCodegenServer<
 	Q extends FateQueriesRecord,

--- a/packages/fate-effect/src/Compiled.ts
+++ b/packages/fate-effect/src/Compiled.ts
@@ -4,18 +4,8 @@
  * baseline (`Executor.ts`, test-harness-only since ADR 0043) and the
  * build-time codegen server (`Codegen.ts`, the production build path every
  * deploy runs through `schema.ts`). Those two lifecycles must never import
- * each other, so what they share lives here:
- *
- *   - the compiled operation-definition shapes (`CompiledQueryDefinition` /
- *     `CompiledListDefinition` / `CompiledMutationDefinition`) — fate's
- *     definition records as the compile step emits them, executable (live
- *     compile) or inert (codegen);
- *   - the identity-keyed source resolver (`buildSourceResolver` →
- *     `CompiledFateSources`) — ONE registry Map keyed by each entry's
- *     definition object, with the executor half supplied by the caller;
- *   - the kernel-type recoveries those need (`toKernelDefinition`, the
- *     `getSource` Item re-pin) — erased→kernel narrowings; the contained-
- *     boundary story lives in `Executor.ts`'s module doc.
+ * each other, so what they share lives here. The contained-boundary story for
+ * the erased→kernel narrowings lives in `Executor.ts`'s module doc.
  */
 import type {ConnectionResult, SourceDefinition, SourceRegistry} from "@nkzw/fate/server";
 import type {FateRequestContext} from "./RequestContext.ts";
@@ -23,11 +13,7 @@ import type {FateSourcesList, SourceDefinitionLike} from "./Server.ts";
 
 export type AnyRow = Record<string, unknown>;
 
-/**
- * Map a record's values, keys preserved — the compile surfaces' ONE
- * entries→record loop (shared so `Executor.ts`/`Codegen.ts` never hand-roll
- * their own `Object.entries` builds).
- */
+/** The compile surfaces' ONE entries→record loop — `Executor.ts`/`Codegen.ts` never hand-roll it. */
 export const mapRecord = <V, R>(
 	record: Record<string, V>,
 	f: (value: V, name: string) => R,
@@ -73,7 +59,6 @@ export interface CompiledArgsInput {
 	readonly args?: AnyRow | undefined;
 }
 
-/** A compiled fate query definition. */
 export interface CompiledQueryDefinition {
 	readonly type?: string;
 	readonly resolve: (options: CompiledResolverOptions<CompiledArgsInput>) => Promise<unknown>;

--- a/packages/fate-effect/src/Connection.ts
+++ b/packages/fate-effect/src/Connection.ts
@@ -1,36 +1,8 @@
 /**
  * The walk's connection plane — fate's `paginationArgsSchema`,
- * `arrayToConnection`, and `getScopedArgs` (`src/server/connection.ts` +
- * `queryArgs.ts`) reimplemented on Effect Schema — removing fate's only
- * runtime zod usage from our graph.
- *
- * ## What is mirrored, byte for byte (the walk oracle enforces it)
- *
- *   - **The accept/reject boundary**: only the four pagination keys are
- *     extracted from the (scoped) args bag before the schema sees it, so
- *     feature args never trip strictness — exactly fate's
- *     `extractPaginationArgs` → `z.strictObject(...)` flow. `after`/`before`
- *     must be strings; `first`/`last` positive integers; the two refines
- *     reject `after`+`before` and `first`+`last` with fate's messages — and
- *     with fate's TRUTHY check (`!(after && before)`), so an empty-string
- *     cursor passes the refine.
- *   - **The windowing defaults**: NO pagination keys → every node, no
- *     windowing, all-false pagination (fate's empty arm); otherwise the page
- *     size is `first ?? last ?? nodes.length`, the cursor index is found IN
- *     the array (`getCursor(node) === cursor`, default `String(node.id)`),
- *     and an unknown cursor falls back to the full array (`findIndex < 0`).
- *   - **The failure arm**: in fate a pagination-args zod throw (or the
- *     `String(node.id)` TypeError on a null node) rides `executeOperation`'s
- *     catch into `toProtocolError` → `INTERNAL_ERROR` / "Internal server
- *     error.". Here both fail with that exact `FateRequestError`, which
- *     `encodeWireError` passes through verbatim — same bytes.
- *
- * fate's `resolveConnection`/`resolveSourceConnection` (the root-list keyset
- * plane, default page size 20) is deliberately NOT reimplemented: it is only
- * reachable through `createFateServer`'s `rootLists`, and phoenix configures
- * no roots (ADR 0016/0019 — lists are resolver-handled, keyset cursors owned
- * by the domain services). The interpreter's list plane is custom lists; an
- * unknown list name is `NOT_FOUND` on both backends.
+ * `arrayToConnection`, and `getScopedArgs` reimplemented on Effect Schema.
+ * What is mirrored byte for byte, and what is deliberately not reimplemented:
+ * .patterns/fate-effect-interpreter.md § "The connection plane".
  */
 import type {FateRequestError} from "@nkzw/fate/server";
 import {Effect} from "effect";
@@ -39,17 +11,13 @@ import {internalArm} from "./WireError.ts";
 
 type AnyRow = Record<string, unknown>;
 
-/** An operation args bag, as the protocol decode types it (readonly). */
 type ArgsBag = {readonly [key: string]: unknown};
 
 /** fate's `isRecord`, exactly (arrays excluded; `Walk.ts` carries its twin). */
 const isRecord = (value: unknown): value is AnyRow =>
 	Boolean(value) && typeof value === "object" && !Array.isArray(value);
 
-/**
- * fate's `getScopedArgs` (`queryArgs.ts`): narrow the operation args to the
- * slice for a selection path — `undefined` past any non-record hop or leaf.
- */
+/** fate's `getScopedArgs` (`queryArgs.ts`), mirrored exactly. */
 export const getScopedArgs = (args: ArgsBag | undefined, path: string): AnyRow | undefined => {
 	if (!args) {
 		return undefined;
@@ -75,11 +43,7 @@ const extractPaginationArgs = (args: ArgsBag | undefined): AnyRow =>
 /** zod's `z.number().int().positive()`: an integer strictly greater than 0. */
 const PositiveInt = Schema.Number.check(Schema.isInt(), Schema.isGreaterThan(0));
 
-/**
- * fate's `paginationArgsSchema` as Effect Schema: every key optional
- * (`.partial()` over already-optional fields collapses to plain optionals),
- * plus the two refines with fate's messages AND fate's truthy predicates.
- */
+/** fate's `paginationArgsSchema`: the refines carry fate's messages AND fate's truthy predicates. */
 export const ConnectionPaginationArgs = Schema.Struct({
 	after: Schema.optional(Schema.String),
 	before: Schema.optional(Schema.String),
@@ -100,9 +64,8 @@ export type ConnectionPaginationArgsValue = (typeof ConnectionPaginationArgs)["T
 const decodePagination = Schema.decodeUnknownEffect(ConnectionPaginationArgs);
 
 /**
- * Decode a (scoped) args bag's pagination slice. The schema failure stays in
- * the error channel for the unit boundary tests; {@link arrayToConnection} maps
- * it onto the wire-visible internal arm.
+ * The schema failure stays in the error channel for the unit boundary tests;
+ * {@link arrayToConnection} maps it onto the wire-visible internal arm.
  */
 export const decodeConnectionPaginationArgs = (
 	args: ArgsBag | undefined,
@@ -188,9 +151,8 @@ const windowNodes = (
 };
 
 /**
- * fate's `arrayToConnection` over a raw array under a selected list-kind
- * field. Pagination args decode from the SCOPED args slice; any boundary
- * rejection (and the nullish-node TypeError) is the wire-visible internal arm.
+ * fate's `arrayToConnection`: any boundary rejection — and the nullish-node
+ * TypeError — masks onto the wire-visible internal arm.
  */
 export const arrayToConnection = (
 	nodes: ReadonlyArray<unknown>,

--- a/packages/fate-effect/src/Connection.unit.test.ts
+++ b/packages/fate-effect/src/Connection.unit.test.ts
@@ -99,7 +99,6 @@ describe("arrayToConnection — fate's in-array windowing, byte-shape included",
 				previousCursor: undefined,
 			},
 		});
-		// Feature args alone do not flip into the windowing arm.
 		expect(wrap({q: "junk"})).toEqual(wrap(undefined));
 	});
 

--- a/packages/fate-effect/src/CurrentUser.ts
+++ b/packages/fate-effect/src/CurrentUser.ts
@@ -1,35 +1,17 @@
 /**
- * `CurrentUser` — the per-request session service, half of the server's
- * per-request contract (`LivePublisher` is the other half).
+ * `CurrentUser` — the per-request session service (ADR 0042), half of the
+ * server's per-request contract with `LivePublisher`. No worker-level layer
+ * provides it; `Provision.ts` provides the pair onto each handler per request,
+ * so `FateServer.layer` excludes both from its R.
  *
- * Handlers `yield*` it like any other service, but no worker-level layer ever
- * provides it: the provision pipeline (`Provision.ts`) provides the pair onto
- * each handler
- * per request — `CurrentUser` from the session, `LivePublisher` from the
- * request's execution context. `FateServer.layer` therefore EXCLUDES both
- * from its R (`FateServerRequirements` in `Server.ts`); a handler's
- * dependency on them is visible in its own type and discharged at the fate
- * edge, never at `Layer.provide` time. This is what makes the bridge's
- * `FateContext` smuggling unnecessary.
- *
- * The shape is deliberately minimal: `user` is `undefined` for anonymous
- * traffic (mirroring the worker's `Auth`), and {@link CurrentUserInfo} carries
- * exactly the identity fields phoenix resolvers consume (`id`/`email`/`name`/
- * `image`/`username`) — a structural subset of the better-auth session user, so
- * the worker provides it from the session value directly. `username` is the
- * public handle (a better-auth `additionalFields.username`, nullable until an
- * account bootstraps it) — it rides on the session so a write path can persist a
- * non-PII display label without a second DB read. Anything richer (karma) is a
- * database read behind a domain service, not session state.
+ * The shape stays minimal on purpose: anything richer than session identity
+ * (karma) is a database read behind a domain service, not session state.
  */
 import {Context, Effect} from "effect";
 import * as Schema from "effect/Schema";
 import {FateWireCode} from "./WireError.ts";
 
-/**
- * The identity of the authenticated user, as resolvers consume it — a
- * structural subset of the better-auth session user.
- */
+/** A structural subset of the better-auth session user. */
 export interface CurrentUserInfo {
 	readonly id: string;
 	readonly email: string;
@@ -62,23 +44,10 @@ export class Unauthorized extends Schema.TaggedErrorClass<Unauthorized>()(
 	{[FateWireCode]: "UNAUTHORIZED"},
 ) {}
 
-/**
- * Per-request session state. `user` is `undefined` for anonymous traffic;
- * writes gate on {@link CurrentUser.required}.
- */
 export class CurrentUser extends Context.Service<
 	CurrentUser,
 	{readonly user: CurrentUserInfo | undefined}
 >()("fate-effect/CurrentUser") {
-	/**
-	 * Require an authenticated user — fails with {@link Unauthorized} otherwise.
-	 *
-	 * @example
-	 *   Effect.fn("definition.add")(function* ({input}) {
-	 *     const user = yield* CurrentUser.required;
-	 *     ...
-	 *   })
-	 */
 	static readonly required: Effect.Effect<CurrentUserInfo, Unauthorized, CurrentUser> = Effect.gen(
 		function* () {
 			const {user} = yield* CurrentUser;

--- a/packages/fate-effect/src/DataView.guard.test.ts
+++ b/packages/fate-effect/src/DataView.guard.test.ts
@@ -1,30 +1,15 @@
 /**
  * Unit — the loud-fail guard for the fate field-map symbol slip (#2808).
  *
- * The guarded failure (diagnosed in #2805): when a view's `dataViewFieldsKey`
- * symbol recovery slips, fate's `ViewFieldConfig` misses its symbol branch and
- * falls to the wide `V['fields']` fallback, dropping every literal field key —
- * and the only downstream signal is a silent `never` at a far-away `view<>()`
- * call, type-indistinguishable from a genuine under-typing defect.
+ * The guarded failure (diagnosed in #2805): when a view's `dataViewFieldsKey` symbol recovery
+ * slips, fate's `ViewFieldConfig` misses its symbol branch and drops every literal field key — and
+ * the only downstream signal is a silent `never` at a far-away `view<>()` call, indistinguishable
+ * from a genuine under-typing defect. `AssertFieldMapResolved` turns that into a named brand at
+ * the entity-definition site.
  *
- * `AssertFieldMapResolved<typeof XView>` turns that silent `never` into the named
- * `FieldMapRecoveryFailed` brand at the entity-definition site. This file proves
- * both halves of the contract:
- *
- * 1. **Healthy → green.** The four #2805 comparands (`BanState`, `DivanCaylak`,
- *    `EmailDeliveryState`, `FailingAddress`) — reproduced here at their exact
- *    authoring shape — resolve to the view unchanged, and their downstream
- *    `view<>()` selection still type-checks with every field (no `never`).
- * 2. **Degraded → loud.** A synthetically-slipped view (its `.view` is a bare
- *    `DataViewOf<Row>`, exactly what fate sees after a symbol slip) resolves to
- *    the named `FieldMapRecoveryFailed` brand, and the mismatch is a real compile
- *    error (the `@ts-expect-error` below), not a silent pass.
- *
- * Like `DataView.unit.test.ts`, the view classes + aliases are **exported** on
- * purpose: the package tsconfig is `composite`, so tsgo runs the
- * declaration-nameability checks (TS2883/TS4020) over the guard's exported
- * surface — if the guard ever reintroduces a portability hazard, `pnpm typecheck`
- * fails here.
+ * Like `DataView.unit.test.ts`, the view classes + aliases are **exported** on purpose: the
+ * package tsconfig is `composite`, so tsgo runs the declaration-nameability checks (TS2883/TS4020)
+ * over the guard's exported surface.
  */
 import {view} from "@nkzw/fate";
 import {describe, expect, expectTypeOf, it} from "vitest";
@@ -99,7 +84,6 @@ export function loudFailProof(
 	healthyAssertion: AssertFieldMapResolved<typeof FailingAddressView>,
 	slippedAssertion: AssertFieldMapResolved<SlippedFailingAddressView>,
 ): void {
-	// A healthy view's assertion IS the view — assignable, no error.
 	const healthy: typeof FailingAddressView = healthyAssertion;
 	void healthy;
 	// @ts-expect-error — the slipped assertion is the `FieldMapRecoveryFailed` brand,
@@ -156,8 +140,6 @@ describe("AssertFieldMapResolved — a symbol slip resolves to the named error b
 		expectTypeOf<AssertFieldMapResolved<SlippedFailingAddressView>>().toEqualTypeOf<
 			FieldMapRecoveryFailed<"FailingAddress">
 		>();
-		// The named brand is distinguishable from both the healthy view AND a bare
-		// `never` — the whole point (a silent `never` is neither).
 		expectTypeOf<AssertFieldMapResolved<SlippedFailingAddressView>>().not.toEqualTypeOf<
 			typeof FailingAddressView
 		>();

--- a/packages/fate-effect/src/DataView.ts
+++ b/packages/fate-effect/src/DataView.ts
@@ -105,11 +105,6 @@ export type KernelDataView<
  */
 export type ListFieldOf<Item extends AnyRow> = DataViewOf<Item> & {kind: "list"};
 
-/**
- * The static side a `FateDataView(...)(...)` class ships: the unchanged
- * kernel view and the literal type name. Instances are meaningless — the
- * class exists to give the view a nameable exported type.
- */
 export interface FateDataViewClass<
 	Item extends AnyRow,
 	Fields extends FieldsConfigOf<Item>,
@@ -143,30 +138,14 @@ const listFieldOf = <Item extends AnyRow>(
 	options?: DataViewListOptions,
 ): ListFieldOf<Item> => list(View.view, options);
 
-/**
- * Class factory for fate data views: `FateDataView<Row>()("Name")({fields})`.
- *
- * The inner call is exactly fate's `dataView("Name")({fields})` curry; the
- * leading `()` is the Effect dummy-call that lets `Row` be explicit while the
- * name still infers as a literal (TypeScript has no partial type-argument
- * inference — the same reason `Schema.TaggedErrorClass<Self>()` takes one).
- *
- * `FateDataView.list(View, options)` declares a list relation field on a
- * sibling view class — fate's `list(view, options)` with a portable type.
- */
+/** Class factory for fate data views — see this module's header for the shape. */
 export const FateDataView = Object.assign(makeFateDataView, {list: listFieldOf});
 
-/**
- * `Entity` over a `FateDataView` class — fate's own `Entity<view, name>`
- * with both arguments read off the class, full field-map fidelity included.
- * `Replacements` passes through to fate's third parameter unchanged.
- */
 export type Entity<
 	View extends {readonly view: DataViewOf<AnyRow>; readonly typeName: string},
 	Replacements extends Record<string, unknown> = Record<never, never>,
 > = KernelEntity<View["view"], View["typeName"], Replacements>;
 
-/** Substitute `Date` for `string` within a union, preserving the rest (`null`). */
 type StringToDate<T> = T extends string ? Date : T;
 
 /** The fate wire shape — the serialized field types `Entity` derives by default. */

--- a/packages/fate-effect/src/DataView.unit.test.ts
+++ b/packages/fate-effect/src/DataView.unit.test.ts
@@ -1,23 +1,12 @@
 /**
- * Unit — `FateDataView` class factory + `Entity` helper (the TS2883
- * workaround).
+ * Unit — `FateDataView` class factory + `Entity` helper (the TS2883 workaround).
  *
- * Two proofs live here:
- *
- * 1. **Runtime**: the class's static `view` IS fate's kernel `dataView()`
- *    output, unchanged — fate's own kernel functions accept it
- *    (`createSourcePlan`), selection masking works over it, and the literal
- *    field map is still stowed under fate's internal symbol key (the property
- *    codegen/`Entity` fidelity hang off).
- *
- * 2. **Type-level / nameability**: this module **exports** several view
- *    classes and `Entity` aliases at top level on purpose — the package's
- *    tsconfig is `composite` (like the worker project), so tsgo runs the
- *    declaration-nameability checks on them. A raw exported
- *    `dataView(...)(...)` const trips TS2883/TS4023 here (the inferred type
- *    references fate's non-exported `DataView` type and `dataViewFieldsKey`
- *    symbol); the exported classes below must not. If the factory's
- *    portability ever regresses, `pnpm typecheck` fails on this file.
+ * This module **exports** several view classes and `Entity` aliases at top level on purpose: the
+ * package's tsconfig is `composite` (like the worker project), so tsgo runs the
+ * declaration-nameability checks on them. A raw exported `dataView(...)(...)` const trips
+ * TS2883/TS4023 here (the inferred type references fate's non-exported `DataView` type and
+ * `dataViewFieldsKey` symbol); the exported classes below must not. If the factory's portability
+ * ever regresses, `pnpm typecheck` fails on this file.
  */
 import {createSourcePlan, dataView, type Entity as KernelEntity, list} from "@nkzw/fate/server";
 import {describe, expect, expectTypeOf, it} from "vitest";
@@ -149,10 +138,8 @@ describe("FateDataView — the static value IS a kernel dataView", () => {
 		expect(definitionsField.kind).toBe("list");
 		expect(definitionsField.typeName).toBe("Definition");
 		expect(TermView.view.fields.definitions).toBe(definitionsField);
-		// Deep-equal with the kernel twin's relation field, internal symbol
-		// properties included — vitest equality covers enumerable symbol keys, so
-		// this pins that the runtime value still carries everything kernel
-		// `list()` attaches (base view + list options under fate's symbols).
+		// Pins that the runtime value still carries everything kernel `list()` attaches (base
+		// view + list options under fate's symbols) — vitest equality covers those symbol keys.
 		expect(definitionsField).toEqual(kernelTermView.fields.definitions);
 		expect(Object.getOwnPropertySymbols(definitionsField).length).toBeGreaterThanOrEqual(3);
 	});

--- a/packages/fate-effect/src/Executor.test.ts
+++ b/packages/fate-effect/src/Executor.test.ts
@@ -1,39 +1,10 @@
 /**
- * `FateExecutor` — the v1 compiler: config → pure `createFateServer` +
- * `toFetchHandler`.
+ * `FateExecutor` — the v1 compiler, exercised end to end over the wire on the
+ * shared sozluk fixture world (`Oracle.fixture.ts`).
  *
- * The contract under test, end to end over the wire (fate's own
- * `handleRequest`), driven over the shared sozluk fixture world
- * (`Oracle.fixture.ts` — the same world the differential oracle runs):
- *
- *   1. **A full operation round-trips** — wire request in → Schema decode →
- *      handler (yielding a domain service from the runtime + the captured
- *      build-time services) → wire result out. The domain service is a
- *      mutable in-memory database, and a mutation's write is visible to a
- *      later read through the same runtime.
- *   2. **Failures map through the `FateWireCode` codec** — a declared
- *      annotated error produces its wire code; an undeclared defect produces
- *      `INTERNAL_SERVER_ERROR` with the fixed message (no detail leak).
- *   3. **The per-request pair are ordinary services** — handlers `yield*`
- *      `CurrentUser` / `LivePublisher`; two CONCURRENT requests observe their
- *      own values (a barrier holds both in flight at once).
- *   4. **Oracle-baseline role** — since the v2 cutover (ADR 0043) this
- *      compiled path serves nothing; it exists as the differential oracle's
- *      v1 baseline (the `Interpreter*.test.ts` suites), so this suite keeps pinning its
- *      behavior.
- *   5. **Spans nest under the runtime's request span** (ADR 0041): the
- *      runtime carries `Tracer.ParentSpan`; a handler's `Effect.fn` span —
- *      operation AND source — parents to it, not to a detached root.
- *   6. **One conversion point** — no static `Effect.run*` anywhere in the
- *      package's non-test, non-fixture sources; the ManagedRuntime promise
- *      runner appears exactly once, inside `Executor.ts` (the LLMS.md
- *      integration idiom). Since the v2 cutover the PRODUCTION conversion
- *      point is the platform layer's boundary (alchemy's worker bridge runs
- *      the request fiber) — the package-side runner exists only because
- *      fate's compiled `(args) => Promise` resolvers (the oracle baseline)
- *      demand one. Test-support `*.fixture.ts` modules sit outside the pin:
- *      the oracle harness's v2 backend runs the interpreter on a
- *      harness-owned runtime, standing in for the platform layer.
+ * Since the v2 cutover (ADR 0043) this compiled path serves nothing: it exists as
+ * the differential oracle's v1 baseline (the `Interpreter*.test.ts` suites), which
+ * is why this suite keeps pinning its behavior.
  */
 import {readdir, readFile} from "node:fs/promises";
 import {dirname, join} from "node:path";
@@ -107,7 +78,6 @@ class BarrierRejected extends Schema.TaggedErrorClass<BarrierRejected>()("test/B
 	cause: Schema.Unknown,
 }) {}
 
-/** Resolve once `count` callers have arrived — holds requests concurrently in flight. */
 const makeBarrier = (count: number): {arrive: () => Promise<void>} => {
 	const waiters: Array<() => void> = [];
 	return {
@@ -210,7 +180,6 @@ describe("FateExecutor.toFetchHandler — round-trip", () => {
 				ok: true,
 				data: {id: "def-1", body: "bir efekt sistemi", term: "effect", author: "umut", votes: 0},
 			});
-			// The live publish went through the per-request LivePublisher value.
 			expect(calls).toEqual(['append Term.definitions({"term":"effect"}) Definition:def-1']);
 
 			const read = await harness.handle(
@@ -374,10 +343,7 @@ describe("FateExecutor — per-request services", () => {
 			{type: "Session"},
 			Effect.fn("whoami")(function* () {
 				const {user: sessionUser} = yield* CurrentUser;
-				// Hold until BOTH requests are in flight — the two resolutions overlap. The
-				// barrier never rejects, and the query declares no errors (E = never), so a
-				// rejection is a defect (orDie) — the faithful object-notation form of the old
-				// `Effect.promise` (#2736).
+				// Hold until BOTH requests are in flight — the two resolutions overlap.
 				yield* Effect.tryPromise({
 					try: () => barrier.arrive(),
 					catch: (cause) => new BarrierRejected({cause}),
@@ -408,7 +374,6 @@ describe("FateExecutor — per-request services", () => {
 			const [resultB] = await resultsOf(resB);
 			expect(resultA?.data).toEqual({id: "user-a"});
 			expect(resultB?.data).toEqual({id: "user-b"});
-			// Each request's publishes landed on ITS publisher value, not the other's.
 			expect(a.calls).toEqual(["update Session:user-a"]);
 			expect(b.calls).toEqual(["update Session:user-b"]);
 		} finally {
@@ -427,12 +392,9 @@ describe("FateExecutor — observability", () => {
 				makeContext(),
 			);
 			expect((await resultsOf(res))[0]?.ok).toBe(true);
-			// The handler's wire-name span (`Effect.fn("term")`) parented to the
-			// runtime's ambient request span — not a detached root (F4/ADR 0041).
+			// Parented to the runtime's ambient span, not a detached root (ADR 0041).
 			expect(spanLog).toEqual([{name: "term", parent: "req-span"}]);
 
-			// The SOURCE handler's constructor-owned span (`Term.byIds`) nests the
-			// same way when its adapted executor runs through the runtime.
 			spanLog.length = 0;
 			const sources = await compiledSourcesOf(harness);
 			const executor = executorOf(sources, termSource.definition);
@@ -457,11 +419,8 @@ describe("compileFateSources", () => {
 		});
 		try {
 			const sources = await compiledSourcesOf(harness);
-			// The registry key IS the entry's definition object (fate's identity
-			// requirement); each entry's adapted executor lands in the Map.
 			expect(executorOf(sources, termSource.definition)).toBeDefined();
 			expect(executorOf(sources, definitionSource.definition)).toBeDefined();
-			// getSource resolves a view OR a definition to the SAME object.
 			expect(sources.getSource(termSource.definition.view)).toBe(termSource.definition);
 			expect(sources.getSource(termSource.definition)).toBe(termSource.definition);
 			expect(() => sources.getSource(definitionSource.definition.view)).not.toThrow();
@@ -549,9 +508,8 @@ describe("the single conversion point", () => {
 			expect(source, name).not.toMatch(/Effect\.run(Promise|Sync|Fork|Callback)/);
 			const conversions = source.match(/\.runPromise(Exit)?\(/g) ?? [];
 			if (name === "Executor.ts") {
-				// Exactly one conversion point — the compiler's runtime promise
-				// runner (oracle-baseline-only since the v2 cutover: the serving
-				// path's conversion is the platform layer's, outside the package).
+				// The compiler's runtime promise runner, oracle-baseline-only since
+				// the v2 cutover — the serving path converts in the platform layer.
 				expect(conversions, name).toHaveLength(1);
 			} else {
 				expect(conversions, name).toHaveLength(0);

--- a/packages/fate-effect/src/Executor.ts
+++ b/packages/fate-effect/src/Executor.ts
@@ -1,67 +1,10 @@
 /**
  * The v1 compile step — a validated `FateServer` service → a pure
- * `createFateServer` call. Exposed
- * publicly as `FateExecutor.compile` / `FateExecutor.toFetchHandler` — the
- * namespace is assembled in the barrel (`index.ts`).
+ * `createFateServer` call.
  *
- * **Since the v2 cutover (ADR 0043) this module no longer serves `/fate`.**
- * The deployed route runs `FateInterpreter.handleRequest` (`Interpreter.ts`)
- * on the request fiber; what remains here has exactly ONE consumer:
- *
- *   - **`compile`/`toFetchHandler` are the differential oracle's BASELINE** —
- *     the oracle suites (`Interpreter*.test.ts`) byte-compare the interpreter against fate's own
- *     `createFateServer` over these compiled executors. The oracle is the
- *     regression net for the native plane, so the v1 side stays exactly as
- *     it served, including its `ManagedRuntime` conversion point.
- *
- * The build-time codegen surface (`toCodegenServer`) lives in `Codegen.ts`:
- * that module is the PRODUCTION build path
- * every deploy runs; this one is the frozen test-harness baseline. They
- * share the compiled-definition vocabulary through `Compiled.ts` and never
- * import each other.
- *
- * The compiled fate server IS a real fate server — the client manifest holds
- * by construction — and every compiled resolver is the same four-step
- * pipeline:
- *
- *   1. **Decode** — the entry's `resolve` (built in `Operation.ts`) runs the
- *      definition's Schema before the handler; a decode failure is the
- *      annotated `InputValidationError`.
- *   2. **Provide** — the two genuinely per-request services come off the
- *      request context as VALUES (`CurrentUser` from the session,
- *      `LivePublisher` from the request's execution context), then the
- *      build-time services captured by `FateServer.layer`
- *      (`service.services`) are provided underneath — the ONE shared
- *      provision pipeline (`provideRequestPair`, `Provision.ts`), the same
- *      one the v2 interpreter and walk apply.
- *   3. **Run** — through the ONE worker-level `ManagedRuntime`, the package's
- *      single Effect→Promise conversion point ({@link FateExecutorRuntime};
- *      effect-smol `LLMS.md` § "Integrating Effect into existing
- *      applications" — fate's `(args) => Promise` resolvers are exactly the
- *      non-Effect callback boundary `ManagedRuntime` targets, ADR 0041).
- *      Because each resolver fiber starts from that runtime, its `Effect.fn`
- *      span nests under the runtime's ambient request span instead of
- *      opening a detached root.
- *   4. **Encode failures** — declared annotated errors and the validation
- *      error map through `encodeWireError` (the `FateWireCode` codec);
- *      defects collapse to the fixed internal error, never leaking details;
- *      a `FateRequestError` passes through verbatim.
- *
- * ## The erased→kernel boundary (the package's F7, contained)
- *
- * The compile step works TYPE-ERASED: `FateServer.layer`'s public R already
- * carried composition correctness (a config whose handlers need a domain
- * service cannot become a dischargeable layer without it), so the erased
- * entry shapes stored on the service carry `R = unknown`, and definition
- * objects sit behind deliberately weak portable types (TS2883 — fate's view
- * symbol must not surface in exported config types). Recovering both is a
- * handful of single named-type narrowings, each a one-direction comparable
- * cast (never `as any` / a laundering double-cast), each marked
- * `erased→kernel` where it lives — the request-pipeline `R: unknown → never`
- * re-pin in `Provision.ts` (shared with the interpreter and walk), the
- * definition/source recoveries in `Compiled.ts` (shared with the codegen
- * build) — the same contained-boundary precedent as `WireError.ts`'s
- * protocol-code widening.
+ * Since the v2 cutover (ADR 0043) this no longer serves `/fate`; its one
+ * consumer is the differential oracle's baseline, so it stays frozen exactly
+ * as it served. See .patterns/fate-effect-compiler.md.
  */
 import type {FateServer as KernelFateServer} from "@nkzw/fate/server";
 import {createFateServer} from "@nkzw/fate/server";
@@ -90,50 +33,35 @@ import {FateServer} from "./Server.ts";
 import {encodeWireError, failureOf} from "./WireError.ts";
 
 /**
- * The worker-level `ManagedRuntime` the compiled server runs on: built ONCE
- * per isolate from `FateServer.layer(config)` with the domain layers
- * provided (`ManagedRuntime` is contravariant in R, so a runtime carrying
- * more services than `FateServer` satisfies this). ADR 0041's runtime
- * doctrine: one runtime, never disposed on CF (no shutdown hook).
+ * One runtime per isolate, never disposed on CF — ADR 0041. Contravariant in
+ * R, so a runtime carrying more services than `FateServer` satisfies this.
  */
 export type FateExecutorRuntime = ManagedRuntime.ManagedRuntime<FateServer, never>;
 
 /**
- * The oracle baseline's request context: the served contract
- * ({@link FateRequestContext}) plus the one field only THIS path consumes —
- * `signal`, handed to the runtime's promise runner in {@link runResolve} so
- * an abort interrupts the resolver fiber. Executor-local on purpose:
- * the serving path (`FateInterpreter`) leaves interruption to the
- * caller (the worker route wires abort→interruption at the platform edge,
- * ADR 0043), so the served contract must not carry an abort knob — a
- * `runPromise`-shaped conversion point is the only place one exists, and the
- * v1 compile path is the only such point in the package.
+ * `signal` is executor-local on purpose: the served contract must carry no
+ * abort knob (the worker route wires abort→interruption at the edge, ADR
+ * 0043), and this `runPromise` path is the only place one exists.
  */
 export interface ExecutorRequestContext extends FateRequestContext {
 	readonly signal?: AbortSignal;
 }
 
-/** The compiled fate server — fate's own value, API type-erased. */
 export type CompiledFateServer = KernelFateServer<unknown, ExecutorRequestContext>;
 
-/** What {@link toFetchHandler} returns: fate's handleRequest, bound. */
 export type FateFetchHandler = (
 	request: Request,
 	context: ExecutorRequestContext,
 ) => Promise<Response>;
 
-/** What every compiled resolver closes over: the runtime + captured services. */
 interface CompileOptions {
 	readonly runtime: FateExecutorRuntime;
 	readonly services: Context.Context<never>;
 }
 
 /**
- * Run one resolver effect: steps 2–4 of the module doc's pipeline —
- * provision (`provideRequestPair`), the worker runtime (the package's ONE
- * Effect→Promise conversion), failure/defect encoding via `encodeWireError`
- * on the `Exit`. fate's `executeOperation` catches the throw and serializes
- * `{ok: false, error: {code, message}}`.
+ * The throw is the contract: fate's `executeOperation` catches it and
+ * serializes `{ok: false, error: {code, message}}`.
  */
 const runResolve = <A>(
 	options: CompileOptions,
@@ -148,16 +76,9 @@ const runResolve = <A>(
 			if (Exit.isSuccess(exit)) {
 				return exit.value;
 			}
-			// `failureOf` (WireError.ts, shared with the interpreter): the typed
-			// failure if one exists, otherwise the squashed defect.
 			throw encodeWireError(failureOf(exit.cause));
 		});
 
-/**
- * One adapter for both args-shaped categories — queries and lists were
- * byte-identical adapters, so the success channel is generic:
- * `unknown` for a query entry, fate's connection envelope for a list entry.
- */
 const adaptArgsEntry = <A>(
 	options: CompileOptions,
 	entry: {
@@ -185,14 +106,6 @@ const adaptMutation = (
 	resolve: ({ctx, input, select}) => runResolve(options, ctx, entry.resolve({input, select})),
 });
 
-/**
- * Adapt a `Fate.source` entry's spanned Effect handlers to fate's
- * promise-shaped `SourceExecutor`: ids/page in, raw rows out (fate masks to
- * the view afterward). `byIds`/`connection` re-spread `ReadonlyArray` rows
- * into the mutable `Array` fate's contract names; `connection` maps fate's
- * options onto the package's page bag (`args` from `plan.args` — the scoped
- * connection args, e.g. a nested connection's parent key).
- */
 const adaptSourceHandlers = (
 	options: CompileOptions,
 	handlers: AnyFateSourceHandlers,
@@ -246,25 +159,12 @@ const adaptSourceHandlers = (
 	};
 };
 
-/**
- * Compile the config's source entries into fate's source resolver: adapted
- * Effect executors in one identity-keyed registry (see
- * `buildSourceResolver`, `Compiled.ts`). A capability-less entry
- * (`handlers: {}`) adapts to an empty executor — registered for `getSource`,
- * loud on any capability call.
- */
 export const compileFateSources = (
 	sources: FateSourcesList,
 	options: CompileOptions,
 ): CompiledFateSources =>
 	buildSourceResolver(sources, (entry) => adaptSourceHandlers(options, entry.handlers));
 
-/**
- * Compile a validated `FateServer` service into a real `createFateServer`
- * value over the worker runtime. Pure construction — no request state; the
- * per-request pair arrives later through each request's adapterContext
- * ({@link ExecutorRequestContext}).
- */
 export const compile = (
 	service: FateServerService,
 	runtime: FateExecutorRuntime,
@@ -302,19 +202,6 @@ export const compile = (
 	});
 };
 
-/**
- * Build the fetch handler over a runtime: resolves the `FateServer` service
- * from the runtime (first call builds the layer — config validation
- * surfaces here), compiles it ONCE, and exposes fate's `handleRequest`
- * bound to the compiled server. Since the v2 cutover this is the oracle
- * harness's baseline entry point, not a serving surface.
- *
- * ```ts
- * const runtime = ManagedRuntime.make(FateServer.layer(config).pipe(Layer.provide(domainLayers)));
- * const handleFate = FateExecutor.toFetchHandler(runtime);
- * // per request: handleFate(request, {currentUser, livePublisher, signal})
- * ```
- */
 export const toFetchHandler = (runtime: FateExecutorRuntime): FateFetchHandler => {
 	let compiled: Promise<CompiledFateServer> | undefined;
 	const compiledServer = () =>

--- a/packages/fate-effect/src/Fate.ts
+++ b/packages/fate-effect/src/Fate.ts
@@ -1,26 +1,9 @@
 /**
- * The `Fate` namespace — the record-value and source constructors plus the
- * authoring type helpers: the whole authoring surface, exactly the exports
- * below.
+ * The `Fate` namespace — the whole authoring surface, exactly the exports below.
  *
- * ```ts
- * import {Fate} from "@kampus/fate-effect";
- *
- * export const termSource = Fate.source(TermView, {id: "slug"}, {...});
- * type Term = Fate.Entity<typeof TermView>;
- * class BodyRequired extends Schema.TaggedErrorClass<BodyRequired>()(
- *   "sozluk/BodyRequired",
- *   {message: Schema.String},
- *   {[Fate.FateWireCode]: "BODY_REQUIRED"},
- * ) {}
- * ```
- *
- * The barrel exposes this module as `export * as Fate` — consumers reach the
- * constructors as `Fate.source` / `Fate.query` / `Fate.list` /
- * `Fate.mutation`. Every member here is ALSO flat-exported from the barrel:
- * the flat names are what tsgo's declaration printer references when a
- * consumer exports a value built from them, and what the WireError
- * enumeration pin discovers over.
+ * Every member here is ALSO flat-exported from the barrel: the flat names are what
+ * tsgo's declaration printer references when a consumer exports a value built from
+ * them, and what the WireError enumeration pin discovers over.
  */
 export type {Entity} from "./DataView.ts";
 export {list, mutation, query} from "./Operation.ts";

--- a/packages/fate-effect/src/Interpreter.batch.test.ts
+++ b/packages/fate-effect/src/Interpreter.batch.test.ts
@@ -309,7 +309,6 @@ describe("FateInterpreter — observability", () => {
 			{id: "id"},
 			{
 				byIds: function* (ids) {
-					// Inside the constructor-owned `Spanned.byIds` span.
 					yield* logSpan;
 					return ids.map((id) => ({id}));
 				},
@@ -323,8 +322,6 @@ describe("FateInterpreter — observability", () => {
 			}),
 		);
 
-		// The runtime context carries the request span — the stand-in for the
-		// route fiber's ambient `ParentSpan`.
 		const runtime = ManagedRuntime.make(
 			Layer.mergeAll(
 				FateServer.layer(FateServer.config({queries: {spanned}, sources: [spannedSource]})),
@@ -350,10 +347,6 @@ describe("FateInterpreter — observability", () => {
 				),
 			);
 			expect(response.status).toBe(200);
-			// Both spans — the operation handler's wire-name span AND the source
-			// handler's constructor-owned span (reached through the
-			// RequestResolver batch window) — parent to the request span, never
-			// a detached root.
 			expect([...spanLog].sort((a, b) => (a.name < b.name ? -1 : 1))).toEqual([
 				{name: "Spanned.byIds", parent: "route-span"},
 				{name: "spanned", parent: "route-span"},

--- a/packages/fate-effect/src/Interpreter.features.test.ts
+++ b/packages/fate-effect/src/Interpreter.features.test.ts
@@ -4,16 +4,8 @@
  * feature, success and error paths. The sozluk corpus
  * (`Interpreter.test.ts`, world in `Oracle.fixture.ts`) carries the
  * query/mutation taxonomy; this file adds the OTHER migrated features'
- * distinctive shapes at the level the oracle needs (in-memory, not D1):
- *
- *   - pano   — `tags` as an EMBEDDED SCALAR array on the post row (never a
- *              list relation), threaded comments as a resolver-owned inline
- *              keyset connection, a keyset-cursored feed list, and a
- *              publishing comment mutation.
- *   - pasaport — `profile` stamping `id` === `userId`, the resolver-owned
- *              `contributions` connection, and the CAPABILITY-LESS
- *              `Contribution` source (no byId/byIds/connection by design).
- *   - stats  — plain string-typed queries (`landingStats` has no data view).
+ * distinctive shapes at the level the oracle needs (in-memory, not D1) —
+ * pano, pasaport and stats, each noted at its fixture below.
  */
 import type {ConnectionResult} from "@nkzw/fate/server";
 import {createFateServer, hasNestedSelection, list} from "@nkzw/fate/server";
@@ -429,7 +421,6 @@ describe("the feature-shaped oracle corpus — pano / pasaport / stats", () => {
 		const v1 = makeFxV1();
 		const v2 = makeFxV2();
 		try {
-			// pano: the embedded-scalar tags array rides the post verbatim.
 			await assertParity(v1, v2, {
 				label: "post query without nested selection keeps tags scalar",
 				operations: [
@@ -440,7 +431,6 @@ describe("the feature-shaped oracle corpus — pano / pasaport / stats", () => {
 				label: "post query miss yields null",
 				operations: [{id: "1", kind: "query", name: "fx.post", args: {slug: "yok"}, select: []}],
 			});
-			// pano: the resolver-owned comments connection round-trips cursors.
 			const commentsPageOne = await assertParity(v1, v2, {
 				label: "post comments page 1",
 				operations: [
@@ -469,7 +459,6 @@ describe("the feature-shaped oracle corpus — pano / pasaport / stats", () => {
 				],
 			});
 			expect(JSON.parse(commentsPageTwo.text).results[0].data.comments.items).toHaveLength(1);
-			// pano: the feed list keysets across pages.
 			const feedPageOne = await assertParity(v1, v2, {
 				label: "posts list page 1",
 				operations: [{id: "1", kind: "list", name: "fx.posts", args: {first: 1}, select: []}],
@@ -489,7 +478,6 @@ describe("the feature-shaped oracle corpus — pano / pasaport / stats", () => {
 				],
 			});
 			expect(JSON.parse(feedPageTwo.text).results[0].data.items[0].cursor).toBe("p2");
-			// pano: the comment mutation — anonymous error, authed write + publish.
 			await assertParity(v1, v2, {
 				label: "anonymous comment.add is UNAUTHORIZED",
 				operations: [
@@ -527,7 +515,6 @@ describe("the feature-shaped oracle corpus — pano / pasaport / stats", () => {
 					},
 				],
 			});
-			// pano: invalid nested page args are the shared VALIDATION_ERROR.
 			await assertParity(v1, v2, {
 				label: "invalid nested page args are VALIDATION_ERROR",
 				operations: [
@@ -540,7 +527,6 @@ describe("the feature-shaped oracle corpus — pano / pasaport / stats", () => {
 					},
 				],
 			});
-			// pasaport: profile stamping + the contributions connection.
 			await assertParity(v1, v2, {
 				label: "profile query stamps id === userId",
 				operations: [
@@ -580,7 +566,6 @@ describe("the feature-shaped oracle corpus — pano / pasaport / stats", () => {
 					{id: "1", kind: "query", name: "fx.profile", args: {username: "kimse"}, select: []},
 				],
 			});
-			// stats: the plain string-typed query.
 			await assertParity(v1, v2, {
 				label: "landingStats parity (string-typed, no data view)",
 				operations: [{id: "1", kind: "query", name: "fx.landingStats", select: []}],
@@ -595,7 +580,6 @@ describe("the feature-shaped oracle corpus — pano / pasaport / stats", () => {
 		const v1 = await makeFxWalkV1();
 		const v2 = makeFxV2();
 		try {
-			// pano: the embedded-scalar tags array passes the MASK verbatim too.
 			await assertParity(v1, v2, {
 				label: "post byId keeps the tags scalar through masking",
 				operations: [
@@ -617,14 +601,12 @@ describe("the feature-shaped oracle corpus — pano / pasaport / stats", () => {
 					},
 				],
 			});
-			// pasaport: the capability-less Contribution source is the internal arm.
 			await assertParity(v1, v2, {
 				label: "capability-less Contribution byId is fate's internal arm",
 				operations: [
 					{id: "1", kind: "byId", type: "FxContribution", ids: ["k1"], select: ["kind"]},
 				],
 			});
-			// pasaport: the profile loads through its byId-only source.
 			await assertParity(v1, v2, {
 				label: "profile byId masks through the byId-only source",
 				operations: [

--- a/packages/fate-effect/src/Interpreter.test.ts
+++ b/packages/fate-effect/src/Interpreter.test.ts
@@ -13,11 +13,7 @@
  * in-memory database, so mutations advance both worlds in lockstep and later
  * reads prove state parity, not just response parity.
  *
- * This file's corpus covers the NAMED operation kinds end to end —
- * successes, every error class (annotated, UNAUTHORIZED, VALIDATION_ERROR,
- * NOT_FOUND, defects, `FateRequestError` passthrough with issues),
- * batching/order, dispatch-time BAD_REQUESTs, request-level
- * malformed-protocol rejections, and fate's acceptance leniency. The other
+ * This file's corpus covers the NAMED operation kinds end to end. The other
  * oracle planes live in siblings: `Interpreter.walk.test.ts` (byId + the
  * selection walk + its connection plane), `Interpreter.features.test.ts`
  * (the pano / pasaport / stats feature-shaped corpus), and

--- a/packages/fate-effect/src/Interpreter.ts
+++ b/packages/fate-effect/src/Interpreter.ts
@@ -1,45 +1,11 @@
 /**
  * `FateInterpreter` — the v2 native dispatch loop: fate's `handleRequest` as
- * an Effect program (ADR 0042 "What v2 changes").
+ * an Effect program. See ADR 0042 and ADR 0043 (the v2 cutover — this is the
+ * serving path; `Executor.ts` survives only as the differential oracle's
+ * baseline).
  *
- * The loop is decode → run → encode, every stage byte-faithful to the v1
- * compiled server (the differential oracle in the `Interpreter*.test.ts` suites enforces
- * it):
- *
- *   1. **Decode** — the request body parses as JSON (fate's exact
- *      `BAD_REQUEST` on failure) and gates through
- *      `decodeProtocolRequest` (fate's `assertProtocolRequest` as staged
- *      Schema decodes, `Protocol.ts`).
- *   2. **Run** — operations dispatch CONCURRENTLY via `Effect.forEach` with
- *      `concurrency: "unbounded"` (effect-smol `Effect.ts` § `forEach` —
- *      the order-preserving collector; fate's own loop is `Promise.all`).
- *      Each operation runs through the ONE shared provision pipeline
- *      (`provideRequestPair`, `Provision.ts`: the per-request pair as VALUES
- *      off the request context, captured build-time services beneath) — the
- *      v1 compiler's `runResolve` minus the Promise hop: no runtime here,
- *      the program stays an Effect and the caller (the worker route's
- *      request fiber; the oracle's test runtime) owns the run.
- *   3. **Encode** — per-operation outcomes map through `encodeWireError`
- *      (the ONE annotation codec both backends share) onto the protocol
- *      error shape, and the response encodes through the canonical
- *      `ProtocolResponse` codec — field order is the schema's, which is
- *      fate's serialization order.
- *
- * Interpreter coverage: the DISPATCH plane — query, mutation, and
- * custom-list operations (phoenix has no root lists — ADR 0016/0019) — plus
- * the BYID plane (`Walk.ts`: the Effect selection walk over
- * `RequestResolver`-batched sources; the walk is constructed once per
- * request, BEFORE the dispatch loop, so its batch window spans every
- * operation in the request) and its CONNECTION plane (`Connection.ts`:
- * Schema-decoded pagination args + fate's in-array windowing for raw arrays
- * under selected list-kind fields).
- *
- * **This IS the serving path since the v2 cutover (ADR 0043)**: the worker's
- * `POST /fate` route yields `handleRequest` on the request fiber — no
- * per-request runtime, spans nest under the platform's request span, and
- * the route wires the request's abort signal to fiber interruption. The v1
- * compiled server (`Executor.ts`) remains only as the differential oracle's
- * baseline.
+ * Every stage is byte-faithful to the v1 compiled server; the oracle in the
+ * `Interpreter*.test.ts` suites enforces it.
  */
 import {FateRequestError} from "@nkzw/fate/server";
 import {Effect, Exit} from "effect";
@@ -95,11 +61,9 @@ const toProtocolErrorValue = (error: unknown): ProtocolErrorValue => {
 };
 
 /**
- * Resolve a named operation to its entry's effect — fate's `executeOperation`
- * dispatch order and NOT_FOUND messages, against the package's config
- * records. `Object.hasOwn` guards the lookup (fate indexes the raw record and
- * would trip over prototype names like `"constructor"`; that divergence is
- * deliberate — a prototype name is NOT a registered operation).
+ * `Object.hasOwn` guards each lookup: fate indexes the raw record and would
+ * trip over prototype names like `"constructor"`. That divergence from fate is
+ * deliberate — a prototype name is NOT a registered operation.
  */
 const namedOperationEffect = (
 	server: FateServerService,
@@ -133,14 +97,12 @@ const namedOperationEffect = (
 	}
 };
 
-/** fate's `executeOperation` preamble: byId first, then the name gate. */
 const operationEffect = (
 	server: FateServerService,
 	walk: FateWalk,
 	operation: DecodedProtocolOperation,
 ): Effect.Effect<unknown, unknown, unknown> => {
 	if (operation.kind === "byId") {
-		// The selection walk: masking, authorize gates, batched source loads.
 		return walk.byId(operation);
 	}
 	if (operation.name === "") {
@@ -152,13 +114,7 @@ const operationEffect = (
 	return namedOperationEffect(server, operation);
 };
 
-/**
- * Run ONE operation to its wire result. Never fails: success carries the
- * handler value; any failure or defect maps through `encodeWireError` (the
- * annotation codec — the v1 path's exact taxonomy: annotated code, fixed
- * internal message for defects, `FateRequestError` passthrough) onto the
- * protocol error arm.
- */
+/** Never fails: every failure and defect maps onto the protocol error arm. */
 const runOperation = (
 	server: FateServerService,
 	walk: FateWalk,
@@ -179,14 +135,12 @@ const runOperation = (
 		),
 	);
 
-/** Parse the request body — fate's `parseJSON`, message and code included. */
 const parseBody = (request: Request): Effect.Effect<unknown, FateRequestError> =>
 	Effect.tryPromise({
 		try: () => request.json(),
 		catch: () => new FateRequestError("BAD_REQUEST", "Request body must be valid JSON."),
 	});
 
-/** Encode results onto the wire response — fate's `Response.json`, bound. */
 const respond = (
 	results: ReadonlyArray<OperationResultValue>,
 	status: number,
@@ -196,16 +150,9 @@ const respond = (
 	);
 
 /**
- * The interpreter's request handler — fate's `handleRequest` as one Effect:
- * decode, dispatch concurrently, encode; a request-level failure (malformed
- * JSON/protocol) serializes as fate's single `id: "request"` error result
- * with the error's own status.
- *
- * No runtime is owned here: the caller runs the program — the worker route
- * yields it on the request fiber (the platform layer's `runPromiseExit` is
- * the conversion point); the oracle runs it through a test ManagedRuntime.
- * Interrupts/abort signals are the caller's concern for the same reason
- * (the route wires the request's abort signal to fiber interruption).
+ * No runtime is owned here: the caller runs the program, so interrupts and
+ * abort signals are the caller's concern too (the worker route wires the
+ * request's abort signal to fiber interruption).
  */
 const handleRequest = (
 	request: Request,
@@ -216,8 +163,6 @@ const handleRequest = (
 		// ONE walk per request — its RequestResolver instance IS the batch
 		// window, so it must exist before the dispatch loop fans out.
 		const walk = makeWalk(server, context);
-		// ONE provision pipeline per request (`Provision.ts` — the pair as
-		// request VALUES over the captured services); every operation applies it.
 		const provide = provideRequestPair(context, server.services);
 		const exit = yield* Effect.exit(
 			Effect.gen(function* () {
@@ -234,8 +179,6 @@ const handleRequest = (
 		if (Exit.isSuccess(exit)) {
 			return exit.value;
 		}
-		// fate's handleRequest catch: toProtocolError + the FateRequestError's
-		// own status (500 for anything else).
 		const failure = failureOf(exit.cause);
 		const status = failure instanceof FateRequestError ? failure.status : 500;
 		return yield* respond(
@@ -244,11 +187,6 @@ const handleRequest = (
 		);
 	});
 
-/**
- * The v2 interpreter surface — the request handler the worker's `/fate`
- * route serves (and the differential oracle exercises against the v1
- * compiled baseline).
- */
 export const FateInterpreter = {
 	handleRequest,
 };

--- a/packages/fate-effect/src/Interpreter.walk.test.ts
+++ b/packages/fate-effect/src/Interpreter.walk.test.ts
@@ -1,14 +1,10 @@
 /**
- * `FateInterpreter` — the WALK plane of the differential oracle: byId
- * operations + nested ref selections, byte-equal against fate's own walk.
+ * The WALK plane of the differential oracle: byId operations + nested ref
+ * selections, byte-equal against fate's own walk.
  *
- * The dual-stack harness (`assertParity` and friends) comes from
- * `Oracle.fixture.ts`; the walk corpus gets its OWN entity family
- * (books/authors) over static in-memory tables, declared here — byId
- * operations never mutate, so no per-backend database service is needed and
- * the shared sozluk world stays untouched. byId rides the selection walk
- * with its connection plane: scoped pagination args, in-array windowing,
- * cursor round-trips across pages.
+ * The corpus gets its OWN entity family (books/authors) over static in-memory
+ * tables: byId operations never mutate, so no per-backend database service is
+ * needed and the shared sozluk world stays untouched.
  */
 import type {ConnectionResult, FieldSelection} from "@nkzw/fate/server";
 import {
@@ -159,7 +155,6 @@ class WalkBookView extends FateDataView<WalkBookRow>()("WalkBook")({
 	id: true,
 	title: true,
 	year: true,
-	// One-kind nested refs: a record-valued ref and an array of refs.
 	author: WalkAuthorView.view,
 	coAuthors: WalkAuthorView.view,
 	// The connection plane: a list-kind field over raw arrays (chapters) and
@@ -284,7 +279,6 @@ const makeWalkV1 = async (): Promise<OracleBackend> => {
 	};
 };
 
-/** The v2 side over the same walk config (the standard interpreter backend). */
 const makeWalkV2 = (): OracleBackend => {
 	const runtime = ManagedRuntime.make(FateServer.layer(walkConfig));
 	return {
@@ -294,15 +288,10 @@ const makeWalkV2 = (): OracleBackend => {
 	};
 };
 
-/** A structural record guard for digging into observed wire JSON. */
 const isWireRecord = (value: unknown): value is Record<string, unknown> =>
 	typeof value === "object" && value !== null && !Array.isArray(value);
 
-/**
- * Read a nested connection envelope off a byId observation's wire text (first
- * result, first row). Throws loudly on shape mismatch — a corpus step that
- * needs this helper is asserting the envelope EXISTS.
- */
+/** Throws loudly on shape mismatch: a step reaching for this asserts the envelope EXISTS. */
 const connectionOf = (
 	observation: OracleObservation,
 	field: string,
@@ -719,7 +708,6 @@ describe("the walk oracle corpus — byId operations + nested ref selections", (
 					},
 				],
 			});
-			// Page 2 is the remaining window (sanity: the round-trip moved).
 			const connection = connectionOf(pageTwo, "chapters");
 			expect(connection.items.map((entry) => entry.cursor)).toEqual(["ch3", "ch4"]);
 			expect(connection.pagination).toEqual({

--- a/packages/fate-effect/src/LivePublisher.ts
+++ b/packages/fate-effect/src/LivePublisher.ts
@@ -1,56 +1,34 @@
 /**
- * `LivePublisher` — the per-request live-publish service, the other half of
- * the server's per-request contract (`CurrentUser` is the first half).
+ * `LivePublisher` — the per-request live-publish CONTRACT only; the layer that
+ * implements it (waitUntil scheduling, error swallowing-with-log, LiveDO topic
+ * targeting) is worker-side, in
+ * `apps/web/worker/features/fate-live/live-publisher.ts`. Every publish
+ * method's error channel is `never`, so "a publish cannot fail the mutation"
+ * is a type rather than a convention.
  *
- * THIS MODULE DEFINES THE CONTRACT ONLY. The live layer — waitUntil
- * scheduling, error swallowing-with-log, the LiveDO topic targeting — is
- * worker-side (`apps/web/worker/features/fate-live/live-publisher.ts`), and
- * it lives there ONCE, so "a publish cannot fail the
- * mutation" is a type, not a convention: every publish method's error channel
- * is `never` (`Effect.Effect<void>`), which is what kills the bridge's
- * per-call-site `useIgnore` boilerplate.
- *
- * The surface mirrors the publish half of the bridge's deleted event-bus
- * (the worker implementation of this contract is `live-publisher.ts`, the
- * module named above; `event-bus.ts` survives only as a build-time throwing
- * stub): entity `update`/
- * `delete` plus the topic edge operations, targeting the existing LiveDO
- * topic role unchanged. Entity/procedure names are plain strings here — the
- * package cannot know phoenix's live entities; the worker may layer its
- * narrowing (the bridge's `TypedLiveUpdate` idea) over this service when it
- * migrates.
- *
- * Like `CurrentUser`, no worker-level layer provides this: the provision
- * pipeline (`Provision.ts`) provides it per request from the request's
- * execution context, and
+ * Entity/procedure names are plain strings: the package cannot know phoenix's
+ * live entities. Like `CurrentUser`, no worker-level layer provides this — the
+ * provision pipeline (`Provision.ts`) provides it per request, and
  * `FateServer.layer` excludes it from R (`FateServerRequirements`).
  */
 import {Context, type Effect} from "effect";
 
-/** Options for an entity `update` publish. */
 export interface LiveUpdateOptions {
 	readonly changed?: ReadonlyArray<string>;
 	readonly data?: unknown;
 	readonly eventId?: string;
 }
 
-/** Options shared by publishes that only carry an event id. */
 export interface LiveEventOptions {
 	readonly eventId?: string;
 }
 
-/** Options for a topic edge publish (`appendNode`/`prependNode`). */
 export interface LiveEdgeOptions {
 	readonly node?: unknown;
 	readonly cursor?: string;
 	readonly eventId?: string;
 }
 
-/**
- * The publish surface of one live topic (procedure + scoped args):
- * append/prepend a node, remove an edge, or invalidate. Every method is
- * `Effect<void>` — failures are swallowed (logged) inside the layer.
- */
 export interface LiveTopicPublisher {
 	readonly appendNode: (
 		nodeType: string,

--- a/packages/fate-effect/src/Operation.ts
+++ b/packages/fate-effect/src/Operation.ts
@@ -1,128 +1,58 @@
 /**
- * `Fate.query` / `Fate.list` / `Fate.mutation` — the record-entry
- * constructors.
- *
- * The resolver half of the loader/resolver split (sources are the loader
- * half, see `Source.ts`): operations carry domain logic, typed errors, and
- * writes. Each constructor pairs a **pure-data definition** with an
- * **`Effect.fn` handler**:
- *
- * - The definition carries the Effect Schema input/args (replacing zod), the
- *   success view (`type:` — a `FateDataView` class or the wire type-name
- *   string), and the declared error union (`error:` — an error class, or
- *   `Schema.Union([...])` of several).
- * - The handler is a user-authored `Effect.fn("<wire name>")` function — the
- *   wire name is the span name, so stack traces point at the operation
- *   (effect-smol `LLMS.md` § "Using Effect.fn"). The handler slot accepts
- *   **Effect-returning functions only**: raw generators do not typecheck.
- *   (This is the deliberate asymmetry with `Fate.source`, which wraps plain
- *   bodies itself: a source capability's span name is fully determined by
- *   entity + capability, while an operation's wire name is author-owned.)
- * - **The error channel is checked against the declared union at the call
- *   site**: the handler's `E` must extend the union's instance type, so
- *   failing with an undeclared error is a compile error, not a runtime
- *   wire-code fallback.
- *
- * Records stay exactly fate's shape — plain objects keyed by dotted wire
- * names:
- *
- * ```ts
- * export const mutations = {
- *   "definition.add": Fate.mutation(
- *     {input: AddDefinitionInput, type: DefinitionView, error: Schema.Union([BodyRequired])},
- *     Effect.fn("definition.add")(function* ({input}) { ... }),
- *   ),
- * };
- * ```
- *
- * Each entry also carries `resolve` — the **decode-then-run wrapper** the
- * compile step adapts to fate's promise-shaped resolvers:
- *
- * - Mutation `input` is decoded by the definition's Schema before the handler
- *   runs; a decode failure is an {@link InputValidationError} (annotated
- *   `VALIDATION_ERROR`, the code fate itself emits for schema failures), so
- *   the wire-error codec derives the wire shape with no extra wiring.
- * - Query/list `args` decode the wire args **including absence**: missing
- *   wire args decode as the empty bag `{}`, so args schemas are structs of
- *   optional fields and handlers never see `undefined` args when a schema is
- *   declared. A definition without an `args` schema passes `undefined` —
- *   stray wire args are not smuggled past the declared contract.
+ * `Fate.query` / `Fate.list` / `Fate.mutation` — the record-entry constructors,
+ * the resolver half of the loader/resolver split (`Source.ts` is the loader half).
+ * See .patterns/fate-effect-operations.md.
  */
 import type {ConnectionResult} from "@nkzw/fate/server";
 import {Effect} from "effect";
 import * as Schema from "effect/Schema";
 import {FateWireCode} from "./WireError.ts";
 
-/** The wire selection fate hands a resolver (`select`). */
 export type OperationSelect = ReadonlyArray<string>;
 
-/**
- * What a definition's `type:` accepts: the wire type-name string, or a
- * `FateDataView` class (anything carrying a literal `typeName`).
- */
 export type TypeRef = string | {readonly typeName: string};
 
-/** The wire type name behind a {@link TypeRef}, kept literal. */
 export type TypeNameOf<T> = T extends string
 	? T
 	: T extends {readonly typeName: infer N extends string}
 		? N
 		: undefined;
 
-/**
- * The normalized `type` of an entry whose definition may omit it. Two-branch
- * on purpose: a present `type` keeps its literal name; a declared-but-
- * optional `type` (the widened `QueryDefinition` shape) widens to
- * `string | undefined`; an absent key (`T` infers `unknown`) maps to
- * `undefined`.
- */
 export type DefinitionTypeName<D> = D extends {readonly type: infer T}
 	? TypeNameOf<T>
 	: D extends {readonly type?: infer T}
 		? TypeNameOf<T> | undefined
 		: undefined;
 
-/**
- * The Schema-derived input-validation failure: what `resolve` fails with when
- * the definition's Schema rejects the wire input/args. Annotated with the
- * `VALIDATION_ERROR` wire code — the code fate's own schema validation emits —
- * so `encodeWireError` derives the wire error with no registry edit. The
- * message is the Schema issue rendering (validation feedback is user-facing
- * by definition; defects stay behind the internal-error wall).
- */
+/** Annotated with the wire code fate's own schema validation emits, so `encodeWireError` needs no registry edit. */
 export class InputValidationError extends Schema.TaggedErrorClass<InputValidationError>()(
 	"fate-effect/InputValidationError",
 	{message: Schema.String},
 	{[FateWireCode]: "VALIDATION_ERROR"},
 ) {}
 
-/** A query definition: optional args Schema, error union, and success view. */
 export interface QueryDefinition {
 	readonly args?: Schema.Top;
 	readonly error?: Schema.Top;
 	readonly type?: TypeRef;
 }
 
-/** A list definition: args Schema (pagination at minimum) + success view. */
 export interface ListDefinition {
 	readonly args: Schema.Top;
 	readonly error?: Schema.Top;
 	readonly type: TypeRef;
 }
 
-/** A mutation definition: input Schema, success view, declared error union. */
 export interface MutationDefinition {
 	readonly input: Schema.Top;
 	readonly error?: Schema.Top;
 	readonly type: TypeRef;
 }
 
-/** The decoded args a query/list handler receives (`undefined` if no schema). */
 export type DefinitionArgs<D> = D extends {readonly args: infer S extends Schema.Top}
 	? S["Type"]
 	: undefined;
 
-/** The decoded input a mutation handler receives. */
 export type DefinitionInput<D> = D extends {readonly input: infer S extends Schema.Top}
 	? S["Type"]
 	: never;
@@ -143,52 +73,40 @@ export type DefinitionWireInput<D> = D extends {readonly input: infer S extends 
 	? S["Encoded"]
 	: never;
 
-/** The declared error union's instance type — the handler's `E` bound. */
 export type DefinitionErrors<D> = D extends {readonly error: infer S extends Schema.Top}
 	? S["Type"]
 	: never;
 
-/** What decoding can fail with: nothing unless a Schema is declared. */
 export type DefinitionDecodeError<D> = D extends
 	| {readonly args: Schema.Top}
 	| {readonly input: Schema.Top}
 	? InputValidationError
 	: never;
 
-/** Services the definition's Schemas require to decode (usually `never`). */
 export type DefinitionDecodingServices<D> =
 	| (D extends {readonly args: infer S extends Schema.Top} ? S["DecodingServices"] : never)
 	| (D extends {readonly input: infer S extends Schema.Top} ? S["DecodingServices"] : never);
 
-/** What a query/list handler receives: decoded args + the wire selection. */
 export interface QueryHandlerInput<D> {
 	readonly args: DefinitionArgs<D>;
 	readonly select: OperationSelect;
 }
 
-/** What a mutation handler receives: decoded input + the wire selection. */
 export interface MutationHandlerInput<D> {
 	readonly input: DefinitionInput<D>;
 	readonly select: OperationSelect;
 }
 
-/** The raw wire bag `resolve` takes for queries/lists (args may be absent). */
 export interface RawArgsInput {
 	readonly args?: unknown;
 	readonly select: OperationSelect;
 }
 
-/** The raw wire bag `resolve` takes for mutations. */
 export interface RawMutationInput {
 	readonly input: unknown;
 	readonly select: OperationSelect;
 }
 
-/**
- * What {@link query} returns: the definition (pure data), the normalized wire
- * `type`, the paired handler, and `resolve` — the decode-then-run wrapper the
- * compile step adapts to fate.
- */
 export interface FateQuery<D extends QueryDefinition, A, E, R> {
 	readonly kind: "query";
 	readonly definition: D;
@@ -199,7 +117,6 @@ export interface FateQuery<D extends QueryDefinition, A, E, R> {
 	) => Effect.Effect<A, E | DefinitionDecodeError<D>, R | DefinitionDecodingServices<D>>;
 }
 
-/** As {@link FateQuery}, with the success pinned to fate's `ConnectionResult`. */
 export interface FateList<D extends ListDefinition, Item, E, R> {
 	readonly kind: "list";
 	readonly definition: D;
@@ -214,7 +131,6 @@ export interface FateList<D extends ListDefinition, Item, E, R> {
 	>;
 }
 
-/** As {@link FateQuery}, for mutations: wire input decoded by the definition. */
 export interface FateMutation<D extends MutationDefinition, A, E, R> {
 	readonly kind: "mutation";
 	readonly definition: D;
@@ -225,33 +141,22 @@ export interface FateMutation<D extends MutationDefinition, A, E, R> {
 	) => Effect.Effect<A, E | DefinitionDecodeError<D>, R | DefinitionDecodingServices<D>>;
 }
 
-/**
- * The services an operation requires — the `R` of its `resolve` (handler
- * services plus any Schema decoding services). `FateServer.layer`
- * unions these across the config, like `FateSourceServices` for sources.
- */
 export type FateOperationServices<Op> = Op extends {
 	readonly resolve: (input: never) => Effect.Effect<infer _A, infer _E, infer R>;
 }
 	? R
 	: never;
 
-/** Normalize a {@link TypeRef} to the wire type-name string. */
 function typeNameOf(ref: TypeRef): string;
 function typeNameOf(ref: TypeRef | undefined): string | undefined;
 function typeNameOf(ref: TypeRef | undefined): string | undefined {
 	return typeof ref === "string" ? ref : ref?.typeName;
 }
 
-/** Map a Schema decode failure onto the annotated wire-coded error. */
 const toValidationError = (error: Schema.SchemaError): InputValidationError =>
 	new InputValidationError({message: error.message});
 
-/**
- * Build the decode-then-run wrapper for query/list args. Absent wire args
- * decode as the empty bag (see the module doc); without a schema the handler
- * gets `undefined` — undeclared wire args never reach it.
- */
+/** Without a schema the handler gets `undefined` — undeclared wire args never reach it. */
 function makeArgsResolve<A>(
 	args: Schema.Top | undefined,
 	handler: (input: {
@@ -270,7 +175,6 @@ function makeArgsResolve<A>(
 		);
 }
 
-/** Build the decode-then-run wrapper for mutation input. */
 function makeInputResolve<A>(
 	input: Schema.Top,
 	handler: (o: {
@@ -286,10 +190,6 @@ function makeInputResolve<A>(
 		);
 }
 
-/**
- * Build a root-query entry from a pure-data definition and an
- * `Effect.fn("<wire name>")` handler. See the module doc for the contract.
- */
 export function query<const D extends QueryDefinition, A, E extends DefinitionErrors<D>, R>(
 	definition: D,
 	handler: (input: QueryHandlerInput<D>) => Effect.Effect<A, E, R>,
@@ -310,10 +210,7 @@ export function query<A>(
 	};
 }
 
-/**
- * Build a root-list entry: same shape as {@link query}, success pinned to
- * fate's `ConnectionResult` (keyset pagination stays service-owned, ADR 0019).
- */
+/** Keyset pagination stays service-owned — see ADR 0019. */
 export function list<const D extends ListDefinition, Item, E extends DefinitionErrors<D>, R>(
 	definition: D,
 	handler: (input: QueryHandlerInput<D>) => Effect.Effect<ConnectionResult<Item>, E, R>,

--- a/packages/fate-effect/src/Operation.unit.test.ts
+++ b/packages/fate-effect/src/Operation.unit.test.ts
@@ -1,26 +1,5 @@
 /**
- * Unit — `Fate.query` / `Fate.list` / `Fate.mutation` (the record-entry
- * constructors).
- *
- * The resolver contract under test:
- *
- *   1. **Definitions are pure data** — Effect Schema input/args (replacing
- *      zod), the success view (class or wire string), the declared error
- *      union. The entry's `type` is the normalized wire type name, as a
- *      literal.
- *   2. **The handler's error channel is checked against the declared union
- *      at the constructor call** — failing with an undeclared error is a
- *      compile error (pinned via the `DefinitionErrors` bound below; the
- *      effect LSP plugin's TS377003 escapes `@ts-expect-error`, the
- *      recurring tsgo hazard).
- *   3. **The wrapper decodes before the handler runs**: mutation input is
- *      validated by the definition's Schema; list/query args decode wire args
- *      including absence. A decode failure is an {@link InputValidationError}
- *      — annotated, so `encodeWireError` derives the `VALIDATION_ERROR` wire
- *      code (the wrapper contract the compiler builds on).
- *   4. **Handlers are Effect-returning functions only** — the documented
- *      authoring form is `Effect.fn("<wire name>")`; raw generators do not
- *      typecheck.
+ * Unit — `Fate.query` / `Fate.list` / `Fate.mutation`.
  *
  * Like the sibling suites, this module **exports** its operation consts on
  * purpose: the package tsconfig is `composite`, so tsgo's declaration
@@ -131,7 +110,6 @@ const provideStore = Effect.provideService(TermStore, {rows});
 describe("Fate.mutation — Schema validates input before the handler", () => {
 	it("decodes valid wire input; the handler receives the DECODED value", async () => {
 		const result = await Effect.runPromise(
-			// `score` arrives as a wire string; the handler sees the number.
 			addTerm.resolve({input: {slug: "effect", score: "42"}, select: []}).pipe(provideStore),
 		);
 		expect(result).toEqual({slug: "effect", title: "Effect", score: 42});
@@ -202,8 +180,6 @@ describe("Fate.query / Fate.list — args Schema decodes wire args", () => {
 
 	it("decodes ABSENT wire args (optional-field schemas see the empty bag)", async () => {
 		const result = await Effect.runPromise(termsList.resolve({select: []}).pipe(provideStore));
-		// No wire args at all: the schema decoded `{}`, the handler used its
-		// own default page size.
 		expect(result.items.map((item) => item.node.slug)).toEqual(["effect", "fate"]);
 		expect(result.pagination).toEqual({hasNext: false, hasPrevious: false});
 	});

--- a/packages/fate-effect/src/Oracle.fixture.ts
+++ b/packages/fate-effect/src/Oracle.fixture.ts
@@ -1,18 +1,11 @@
 /**
- * The shared differential-oracle fixture:
- * the dual-stack harness plus the ONE sozluk-shaped fixture world consumed by
- * every suite that drives a compiled or interpreted fate server.
+ * The shared differential-oracle fixture: the dual-stack harness plus the ONE
+ * sozluk-shaped world every suite that drives a fate server runs over.
  *
- * - `Executor.test.ts` pins the v1 compiled server (the oracle's baseline)
- *   directly over this world.
- * - The `Interpreter*.test.ts` oracle files run every protocol request
- *   through BOTH backends — `makeV1` (fate's own `handleRequest` over
- *   `FateExecutor.toFetchHandler`) and `makeV2` (the native interpreter) —
- *   and `assertParity` requires the raw wire output to be BYTE-EQUAL: same
- *   status, same content-type, same body text, same publishes. Each backend
- *   owns an isolated runtime over its own fresh in-memory database, so
- *   mutations advance both worlds in lockstep and later reads prove state
- *   parity, not just response parity.
+ * `assertParity` requires the raw wire output of both backends to be BYTE-EQUAL:
+ * same status, content-type, body text, publishes. Each backend owns an isolated
+ * runtime over its own fresh in-memory database, so mutations advance both worlds
+ * in lockstep and later reads prove state parity, not just response parity.
  *
  * Not a test file: the vitest glob only collects `*.test.ts`, and the
  * conversion-point enumeration sweeps non-test, non-fixture sources — the
@@ -37,7 +30,6 @@ import {FateWireCode} from "./WireError.ts";
 // observability suites reset `spanLog` and assert nesting. The oracle suites
 // never read it — the pushes are inert there.
 
-/** What the probe handlers observed: span name + parent span id. */
 export const spanLog: Array<{name: string; parent: string | undefined}> = [];
 
 export const logSpan = Effect.gen(function* () {
@@ -260,7 +252,6 @@ export interface OracleBackend {
 	readonly dispose: () => Promise<void>;
 }
 
-/** The v1 side: the compiled fate server over its own runtime + database. */
 export const makeV1 = (): OracleBackend => {
 	const runtime = ManagedRuntime.make(
 		FateServer.layer(sozlukConfig).pipe(Layer.provide(SozlukDbLive)),
@@ -271,7 +262,6 @@ export const makeV1 = (): OracleBackend => {
 	};
 };
 
-/** The v2 side: the native interpreter over its own runtime + database. */
 export const makeV2 = (): OracleBackend => {
 	const runtime = ManagedRuntime.make(
 		FateServer.layer(sozlukConfig).pipe(Layer.provide(SozlukDbLive)),
@@ -283,7 +273,6 @@ export const makeV2 = (): OracleBackend => {
 	};
 };
 
-/** One corpus step: a wire request (or raw body) plus its request context. */
 export interface OracleStep {
 	readonly label: string;
 	readonly operations?: ReadonlyArray<Record<string, unknown>>;
@@ -325,7 +314,6 @@ export const observe = async (
 	};
 };
 
-/** Run one step through both backends and assert byte-equality of the wire. */
 export const assertParity = async (
 	v1: OracleBackend,
 	v2: OracleBackend,

--- a/packages/fate-effect/src/Protocol.ts
+++ b/packages/fate-effect/src/Protocol.ts
@@ -1,55 +1,20 @@
 /**
- * The v2 wire-protocol codecs — fate's protocol as Effect Schema.
+ * The v2 wire-protocol codecs — fate's protocol as Effect Schema. See
+ * .patterns/fate-effect-interpreter.md § "The protocol codecs".
  *
- * Two codec surfaces, deliberately split the way fate itself splits them:
- *
- *   - **The canonical schemas** ({@link ProtocolOperation},
- *     {@link ProtocolRequest}, {@link ProtocolError},
- *     {@link ProtocolOperationResult}, {@link ProtocolResponse}) are fate's
- *     EXPORTED protocol types in Schema form, field for field. They are the
- *     round-trip codecs and the drift pin's subject (`Protocol.unit.test.ts`
- *     pins them against `@nkzw/fate`'s exported types — a fate upgrade that
- *     moves the protocol fails typecheck). Response structs declare fields in
- *     fate's SERIALIZATION order (`{data, id, ok}` / `{error, id, ok}` /
- *     `{code, issues, message}`): Schema encode emits keys in declaration
- *     order, which is what makes the interpreter's output byte-equal to the
- *     v1 compiled server's.
- *
- *   - **{@link decodeProtocolRequest}** is fate's `assertProtocolRequest`
- *     reproduced as a STAGED Schema decode — envelope, per-operation base,
- *     then the kind-conditional fields, each stage failing with fate's own
- *     `FateRequestError("BAD_REQUEST", <fate's exact message>)`. The staging
- *     preserves fate's LENIENCY as much as its strictness: fate checks
- *     `ids`/`type` only for `byId` operations and `name` only for named
- *     kinds, so a query carrying junk in those fields must be accepted
- *     (and ignored) here too, or the differential oracle would diverge on
- *     acceptance. That is why dispatch cannot simply decode the canonical
- *     {@link ProtocolOperation} — it is stricter than fate's runtime gate.
- *
- * The decoded result is a discriminated union ({@link ProtocolByIdOperation}
- * | {@link ProtocolNamedOperation}) so the dispatch loop cannot represent an
- * unvalidated state: a byId operation always carries `type`/`ids`, a named
- * operation always carries its `name` (possibly `""` — fate's assert lets the
- * empty string through and rejects it at dispatch time; the interpreter
- * mirrors that exactly).
- *
- * The wire `code` on {@link ProtocolError} is `Schema.String`, deliberately
- * wider than fate's closed 6-member union: phoenix's annotated wire codes
- * (`BODY_REQUIRED`, `TAKEN`, …) ride the same field (`WireError.ts`'s
- * documented widening). The drift pin substitutes fate's union back in for
- * everything else.
+ * Struct field order IS the serialization order: Schema encode emits keys in
+ * declaration order, and that is what keeps the interpreter's output
+ * byte-equal to the v1 compiled server's. Do not reorder fields.
  */
 import {FateRequestError} from "@nkzw/fate/server";
 import {Effect} from "effect";
 import * as Schema from "effect/Schema";
 
-/** fate's four operation kinds (`FateOperationKind`, not exported by name). */
 export const PROTOCOL_OPERATION_KINDS = ["byId", "list", "mutation", "query"] as const;
 
 /**
- * fate's `FateOperation`, field for field: ONE struct with kind-independent
- * optionality — the canonical wire shape, not the per-kind validation gate
- * (that is {@link decodeProtocolRequest}).
+ * The canonical wire shape, not the per-kind validation gate (that is
+ * {@link decodeProtocolRequest}, which is deliberately more lenient).
  */
 export const ProtocolOperation = Schema.Struct({
 	args: Schema.optionalKey(Schema.Record(Schema.String, Schema.Unknown)),
@@ -62,17 +27,15 @@ export const ProtocolOperation = Schema.Struct({
 	type: Schema.optionalKey(Schema.String),
 });
 
-/** fate's `FateProtocolRequest`: the version-1 operations envelope. */
 export const ProtocolRequest = Schema.Struct({
 	operations: Schema.Array(ProtocolOperation),
 	version: Schema.Literal(1),
 });
 
 /**
- * fate's `FateProtocolError` — `code` deliberately widened to `string` (see
- * the module doc). Field order is fate's `toProtocolError` literal order:
- * `{code, issues, message}` (`path` is in fate's type, never emitted by the
- * error path; kept for the pin and ordered last).
+ * `code` is deliberately wider than fate's closed union — phoenix's annotated
+ * wire codes ride the same field (`WireError.ts`). `path` is never emitted;
+ * it exists for the drift pin, which is why it is ordered last.
  */
 export const ProtocolError = Schema.Struct({
 	code: Schema.String,
@@ -81,30 +44,25 @@ export const ProtocolError = Schema.Struct({
 	path: Schema.optionalKey(Schema.String),
 });
 
-/** The success arm of fate's `FateOperationResult`, in serialization order. */
 export const ProtocolSuccessResult = Schema.Struct({
 	data: Schema.Unknown,
 	id: Schema.String,
 	ok: Schema.Literal(true),
 });
 
-/** The failure arm of fate's `FateOperationResult`, in serialization order. */
 export const ProtocolFailureResult = Schema.Struct({
 	error: ProtocolError,
 	id: Schema.String,
 	ok: Schema.Literal(false),
 });
 
-/** fate's `FateOperationResult`: one per-operation wire outcome. */
 export const ProtocolOperationResult = Schema.Union([ProtocolSuccessResult, ProtocolFailureResult]);
 
-/** fate's `FateProtocolResponse`: the version-1 results envelope. */
 export const ProtocolResponse = Schema.Struct({
 	results: Schema.Array(ProtocolOperationResult),
 	version: Schema.Literal(1),
 });
 
-/** A decoded, dispatch-ready byId operation: `type` and `ids` are guaranteed. */
 export interface ProtocolByIdOperation {
 	readonly kind: "byId";
 	readonly id: string;
@@ -115,9 +73,9 @@ export interface ProtocolByIdOperation {
 }
 
 /**
- * A decoded, dispatch-ready named operation: `name` is guaranteed a string —
- * possibly `""`, which fate (and the interpreter) rejects at dispatch time
- * with the per-operation `BAD_REQUEST`, not at the protocol gate.
+ * `name` is guaranteed a string but possibly `""` — fate (and so the
+ * interpreter) rejects the empty name at dispatch time with a per-operation
+ * `BAD_REQUEST`, not at the protocol gate.
  */
 export interface ProtocolNamedOperation {
 	readonly kind: "list" | "mutation" | "query";
@@ -128,14 +86,9 @@ export interface ProtocolNamedOperation {
 	readonly input?: unknown;
 }
 
-/** What {@link decodeProtocolRequest} yields per operation. */
 export type DecodedProtocolOperation = ProtocolByIdOperation | ProtocolNamedOperation;
 
-/**
- * Stage 1 — the envelope: fate checks `isRecord(value) && value.version === 1
- * && Array.isArray(value.operations)`; members are validated per operation in
- * stage 2, so they stay `Unknown` here.
- */
+/** Stage 1 — members stay `Unknown`; stage 2 validates them per operation. */
 const RequestEnvelope = Schema.Struct({
 	operations: Schema.Array(Schema.Unknown),
 	version: Schema.Literal(1),
@@ -158,13 +111,11 @@ const OperationBase = Schema.Struct({
 	select: Schema.Array(Schema.String),
 });
 
-/** Stage 3a — what fate additionally demands of a byId operation. */
 const ByIdFields = Schema.Struct({
 	ids: Schema.Array(Schema.Union([Schema.String, Schema.Number])),
 	type: Schema.String,
 });
 
-/** Stage 3b — what fate additionally demands of a named operation. */
 const NamedFields = Schema.Struct({
 	name: Schema.String,
 });
@@ -174,7 +125,6 @@ const decodeBase = Schema.decodeUnknownEffect(OperationBase);
 const decodeByIdFields = Schema.decodeUnknownEffect(ByIdFields);
 const decodeNamedFields = Schema.decodeUnknownEffect(NamedFields);
 
-/** Map any failure of one decode stage onto fate's exact wire error. */
 const badRequest = (message: string) => (): FateRequestError =>
 	new FateRequestError("BAD_REQUEST", message);
 
@@ -212,10 +162,9 @@ const decodeOperation = (
 	});
 
 /**
- * fate's `assertProtocolRequest` as an Effect: a parsed request body in,
- * dispatch-ready operations out, or fate's own `FateRequestError` (the
- * interpreter serializes it exactly as fate's `handleRequest` catch does).
- * Operations validate IN ORDER, first failure wins — fate's loop.
+ * fate's `assertProtocolRequest` as an Effect. `concurrency: 1` is required,
+ * not incidental: operations validate in order, first failure wins, matching
+ * fate's loop.
  */
 export const decodeProtocolRequest = (
 	body: unknown,
@@ -229,11 +178,7 @@ export const decodeProtocolRequest = (
 
 const encodeResponse = Schema.encodeEffect(ProtocolResponse);
 
-/**
- * Encode a response value onto the wire shape. Total for values the
- * interpreter constructs (they are built as {@link ProtocolResponse} types);
- * an encode failure is a package bug, so it dies.
- */
+/** Total for values the interpreter constructs, so an encode failure dies. */
 export const encodeProtocolResponse = (
 	value: (typeof ProtocolResponse)["Type"],
 ): Effect.Effect<(typeof ProtocolResponse)["Encoded"]> => encodeResponse(value).pipe(Effect.orDie);

--- a/packages/fate-effect/src/Protocol.unit.test.ts
+++ b/packages/fate-effect/src/Protocol.unit.test.ts
@@ -1,24 +1,8 @@
 /**
- * `Protocol` — the v2 wire-protocol codecs.
- *
- * Three contracts under test:
- *
- *   1. **Round-trip** — the canonical codecs decode every operation kind and
- *      encode back byte-identically. The canonical schemas ARE fate's
- *      exported protocol types in Schema form.
- *   2. **fate-faithful rejection** — `decodeProtocolRequest` is fate's
- *      `assertProtocolRequest` as a staged Schema decode: malformed requests
- *      fail with fate's OWN error shape (`FateRequestError`, `BAD_REQUEST`,
- *      the exact message per stage), and fate's LENIENCY is preserved too —
- *      fields fate does not check per kind (junk `ids` on a query) pass, so
- *      the differential oracle cannot diverge on acceptance.
- *   3. **The drift pin** — type-level `satisfies`-style pins against fate's
- *      EXPORTED protocol types (`FateOperation`, `FateProtocolRequest`,
- *      `FateProtocolResponse` and the result/error members derived from
- *      them). `Wire<>` normalizes mutability only (fate types mutable arrays;
- *      Schema types ReadonlyArray — the wire cannot tell). Keys, optionality,
- *      and value types stay exact, so a fate upgrade that drifts the protocol
- *      fails `tsgo` here before any runtime test runs.
+ * `Protocol` — the v2 wire-protocol codecs: round-trips, fate-faithful
+ * rejection (including fate's leniency, so the differential oracle cannot
+ * diverge on acceptance), and the drift pin that fails `tsgo` when a fate
+ * upgrade moves the protocol.
  */
 import type {FateOperation, FateProtocolRequest, FateProtocolResponse} from "@nkzw/fate";
 import {FateRequestError} from "@nkzw/fate/server";
@@ -42,7 +26,6 @@ const encodeRequest = Schema.encodeUnknownSync(ProtocolRequest);
 const decodeResponse = Schema.decodeUnknownSync(ProtocolResponse);
 const encodeResponse = Schema.encodeUnknownSync(ProtocolResponse);
 
-/** Round-trip a wire value through decode→encode and return the JSON bytes. */
 const roundTrip = (codec: {
 	decode: (value: unknown) => unknown;
 	encode: (value: unknown) => unknown;
@@ -58,7 +41,6 @@ const opTrip = roundTrip({decode: decodeOp, encode: encodeOp});
 const expectRejection = (body: unknown, message: string): void => {
 	const error = Effect.runSync(Effect.flip(decodeProtocolRequest(body)));
 	expect(error).toBeInstanceOf(FateRequestError);
-	// fate's exact error shape: code, message, and the derived 400 status.
 	expect(error.code).toBe("BAD_REQUEST");
 	expect(error.message).toBe(message);
 	expect(error.status).toBe(400);
@@ -71,11 +53,8 @@ const requestOf = (operations: ReadonlyArray<unknown>) => ({version: 1, operatio
 describe("Protocol — canonical round-trips", () => {
 	it("round-trips every operation kind byte-identically", () => {
 		const operations = [
-			// byId: type + ids (string and numeric protocol ids).
 			{id: "1", ids: ["t-1", 2], kind: "byId", select: ["title"], type: "Term"},
-			// list: name + args.
 			{args: {first: 10}, id: "2", kind: "list", name: "terms", select: ["slug", "title"]},
-			// mutation: name + input (+ select).
 			{
 				id: "3",
 				input: {body: "tanım", term: "effect"},
@@ -83,7 +62,6 @@ describe("Protocol — canonical round-trips", () => {
 				name: "definition.add",
 				select: [],
 			},
-			// query: name + args.
 			{args: {slug: "effect", take: "2"}, id: "4", kind: "query", name: "term", select: []},
 		];
 		for (const operation of operations) {

--- a/packages/fate-effect/src/Provision.ts
+++ b/packages/fate-effect/src/Provision.ts
@@ -1,20 +1,11 @@
 /**
- * `provideRequestPair` — THE per-request provision pipeline, spelled once
- * (consumed by `Executor.ts` `runResolve`, `Interpreter.ts` `runOperation`,
- * and `Walk.ts` `provide`).
+ * `provideRequestPair` — THE per-request provision pipeline, spelled once (consumed by
+ * `Executor.ts`, `Interpreter.ts` and `Walk.ts`).
  *
- * The invariant, in one place: the two genuinely per-request services come
- * off the request context as VALUES — `CurrentUser` from the session,
- * `LivePublisher` from the request's execution context — provided innermost
- * so the request values always win; the build-time services captured by
- * `FateServer.layer` (`service.services`) sit beneath. No per-request layer,
- * no runtime rebuild, no context smuggling.
- *
- * Between the pair and the build-time services sits the generic per-request
- * provision seam (ADR 0107 §7): `context.requestServices`, an opaque bag of
- * EXTRA per-request service VALUES the app provides, provided over the
- * build-time `services` so a per-request value wins there too. See
- * `RequestContext.ts` for the contract.
+ * The invariant: the per-request services come off the request context as VALUES and are provided
+ * innermost, so a request value always wins over the build-time services `FateServer.layer`
+ * captured. No per-request layer, no runtime rebuild, no context smuggling. The generic
+ * `context.requestServices` seam between them is ADR 0107 §7; `RequestContext.ts` has the contract.
  *
  * erased→kernel: the trailing cast re-pins the erased entry effect's
  * requirements to `never` so a runtime can run it. The erased shapes carry
@@ -35,20 +26,10 @@ import {CurrentUser} from "./CurrentUser.ts";
 import {LivePublisher} from "./LivePublisher.ts";
 import type {FateRequestContext} from "./RequestContext.ts";
 
-/**
- * The applied form: what one request's provision pipeline looks like to a
- * call site (`Walk.ts` builds it once per request; the dispatch loop and the
- * v1 compiler apply it per operation).
- */
 export type ProvideRequestPair = <A, E>(
 	effect: Effect.Effect<A, E, unknown>,
 ) => Effect.Effect<A, E>;
 
-/**
- * Close over one request's pair + the captured build-time services; the
- * returned function takes an erased entry effect to a runnable one
- * (`R: unknown → never`, see the module doc).
- */
 export const provideRequestPair =
 	(context: FateRequestContext, services: Context.Context<never>): ProvideRequestPair =>
 	<A, E>(effect: Effect.Effect<A, E, unknown>): Effect.Effect<A, E> =>

--- a/packages/fate-effect/src/Provision.unit.test.ts
+++ b/packages/fate-effect/src/Provision.unit.test.ts
@@ -1,28 +1,7 @@
 /**
- * Unit — `provideRequestPair`: THE per-request provision pipeline.
- *
- * The contract under test:
- *
- *   1. **Provision order** — the per-request pair (`CurrentUser`,
- *      `LivePublisher`) is provided as VALUES off the request context, with
- *      the captured build-time services beneath; an effect requiring all
- *      three resolves with no ambient context (R = never, directly
- *      runnable).
- *   2. **Request values WIN** — a captured context that carries the pair
- *      (impossible from `FateServer.layer`, whose `FateServerRequirements`
- *      excludes both, but expressible here through Context contravariance)
- *      loses to the request values. This was vacuously true at every call
- *      site; the helper seam makes it a real, pinned property.
- *   3. **The R re-pin** — the helper accepts the erased shapes'
- *      `R = unknown` and returns `R = never`, preserving A and E. This is
- *      the package's ONE documented `erased→kernel` request-pipeline cast
- *      (`Provision.ts`); Executor/Interpreter/Walk no longer spell it.
- *   4. **The generic per-request provision seam** (ADR 0107 §7) — an app
- *      provides EXTRA per-request service values through
- *      `context.requestServices`; they are visible to a handler, win over the
- *      same tag in the build-time services, and a registered-but-unprovided
- *      one fails loudly at run ("Service not found"), never silently. The
- *      package names no app service — the bag is opaque.
+ * Unit — `provideRequestPair`, the per-request provision pipeline, including the generic
+ * per-request service seam of ADR 0107 §7. The seam is opaque: the package names no app
+ * service, so `Actor` below is a stand-in an app would provide through `requestServices`.
  */
 import {Cause, Context, Effect, Exit} from "effect";
 import {describe, expect, expectTypeOf, it} from "vitest";
@@ -51,7 +30,6 @@ const requestContext = (id: string): FateRequestContext => ({
 	livePublisher: publisherStub(),
 });
 
-/** Reads all three services — the full provision surface in one program. */
 const readAll = Effect.gen(function* () {
 	const current = yield* CurrentUser;
 	const live = yield* LivePublisher;
@@ -82,39 +60,28 @@ describe("provideRequestPair", () => {
 		const result = Effect.runSync(provideRequestPair(ctx, services)(readAll));
 		expect(result.current.user?.id).toBe("request-user");
 		expect(result.live).toBe(ctx.livePublisher);
-		// the domain half of the poisoned context still resolves beneath
 		expect(result.greeting.word).toBe("still-there");
 	});
 
 	it("re-pins R: unknown → never, preserving A and E (the one documented cast seam)", () => {
 		const provide = provideRequestPair(requestContext("u1"), Context.empty());
-		// accepts the erased shapes' covariant-top R…
 		expectTypeOf(provide<number, "boom">)
 			.parameter(0)
 			.toEqualTypeOf<Effect.Effect<number, "boom", unknown>>();
-		// …and returns the runnable re-pin, A and E untouched
 		expectTypeOf(provide<number, "boom">).returns.toEqualTypeOf<Effect.Effect<number, "boom">>();
 	});
 });
 
-/**
- * A stand-in for an app's EXTRA per-request service (the künye `CurrentActor`
- * shape, but the package names none of it — this is the seam's genericity).
- * fate-effect never imports this kind of tag; the app provides its value
- * through `context.requestServices`.
- */
 class Actor extends Context.Service<Actor, {readonly id: string; readonly level: string}>()(
 	"test/Actor",
 ) {}
 
-/** A request context that fills the generic seam with an `Actor` value. */
 const requestContextWithActor = (id: string, actor: typeof Actor.Service): FateRequestContext => ({
 	currentUser: {user: userInfo(id)},
 	livePublisher: publisherStub(),
 	requestServices: Context.make(Actor, actor),
 });
 
-/** Reads the pair + the app per-request service in one program. */
 const readWithActor = Effect.gen(function* () {
 	const current = yield* CurrentUser;
 	const actor = yield* Actor;
@@ -130,8 +97,6 @@ describe("provideRequestPair — generic per-request provision seam (ADR 0107 §
 	});
 
 	it("the per-request seam value WINS over the same tag in the build-time services", () => {
-		// The app's per-request `Actor` is provided INNERMOST of the build-time
-		// services, so it wins — the request value beats a captured default.
 		const ctx = requestContextWithActor("u1", {id: "u1", level: "yazar"});
 		const services = Context.make(Actor, {id: "build", level: "visitor"});
 		const result = Effect.runSync(provideRequestPair(ctx, services)(readWithActor));
@@ -139,9 +104,6 @@ describe("provideRequestPair — generic per-request provision seam (ADR 0107 §
 	});
 
 	it("a registered-but-unprovided per-request service fails loudly at run, never silently", () => {
-		// No `requestServices` on the context AND nothing in the build-time
-		// services — reading `Actor` must surface a loud "Service not found"
-		// defect, not a silent wrong value.
 		const ctx = requestContext("u1");
 		const exit = Effect.runSyncExit(provideRequestPair(ctx, Context.empty())(readWithActor));
 		expect(Exit.isFailure(exit)).toBe(true);
@@ -152,8 +114,6 @@ describe("provideRequestPair — generic per-request provision seam (ADR 0107 §
 	});
 
 	it("the seam stays opaque: a context with no requestServices is unchanged (the pair still resolves)", () => {
-		// Absent `requestServices` ⇒ `Context.empty()`; the existing pair path is
-		// untouched, so a non-seam request behaves exactly as before.
 		const ctx = requestContext("u1");
 		expect(ctx.requestServices).toBeUndefined();
 		const services = Context.make(Greeting, {word: "merhaba"});

--- a/packages/fate-effect/src/RequestContext.ts
+++ b/packages/fate-effect/src/RequestContext.ts
@@ -1,8 +1,6 @@
 /**
- * `FateRequestContext` — the per-request contract, in its own neutral module
- * so the
- * serving path (`Interpreter.ts`, the worker route) and the provision
- * pipeline (`Provision.ts`) depend on the contract alone, never on the
+ * The per-request contract, in its own neutral module so the serving path and
+ * the provision pipeline depend on the contract alone, never on the
  * oracle-baseline compile module.
  */
 import type {Context} from "effect";
@@ -10,28 +8,15 @@ import type {CurrentUser} from "./CurrentUser.ts";
 import type {LivePublisher} from "./LivePublisher.ts";
 
 /**
- * What the caller hands a request handler: the per-request pair as VALUES —
- * `currentUser` from the validated session, `livePublisher` from the
- * request's execution context (built worker-side, e.g. via
- * `livePublisherFor`; the package never imports the implementation).
+ * `requestServices` is the generic per-request provision seam (ADR 0107 §7):
+ * an opaque bag of extra per-request values, provided innermost so it wins
+ * over the build-time services. Opaque on purpose — the package never names
+ * the app's service.
  *
- * `requestServices` is the generic per-request provision seam (ADR 0107 §7): an
- * opaque `Context.Context<never>` bag of EXTRA per-request service values an app
- * provides alongside the pair (e.g. a `CurrentActor` derived from `currentUser`),
- * provided innermost so it wins over the build-time services. Opaque keeps the
- * contract vocab-free — the package never names the app's service. The app
- * DECLARES the tags to `FateServer.layer` (so `FateServerRequirements` excludes
- * them from build-time R) and FULFILLS them by putting their values here; absent
- * ⇒ `Context.empty()`, and a declared-but-unprovided service fails loudly at run
- * ("Service not found"), like a missing `currentUser`.
- *
- * Deliberately NO `signal` field: the serving path
- * (`FateInterpreter`) leaves interruption to the caller — the worker route
- * wires the request's abort signal to fiber interruption at the platform
- * edge (ADR 0043) — so an abort knob on the served contract would only
- * mislead future route authors. The one path that does consume a signal is
- * the oracle baseline's `runPromise` conversion, and it extends this
- * contract locally (`ExecutorRequestContext`, `Executor.ts`).
+ * Deliberately NO `signal` field: the worker route wires abort→interruption at
+ * the platform edge (ADR 0043), so an abort knob here would only mislead
+ * future route authors. Only the oracle baseline consumes one, and it extends
+ * this contract locally (`ExecutorRequestContext`, `Executor.ts`).
  */
 export interface FateRequestContext {
 	readonly currentUser: typeof CurrentUser.Service;

--- a/packages/fate-effect/src/Server.test.ts
+++ b/packages/fate-effect/src/Server.test.ts
@@ -1,33 +1,9 @@
 /**
  * `FateServer` — the tag, `config`, and `layer`.
  *
- * The composite contract under test:
- *
- *   1. **The layer's R is the union of handler/source requirements minus the
- *      per-request pair** (`CurrentUser`, `LivePublisher`) — those two are the
- *      server's per-request contract, provided by the compiler per
- *      request, never by worker-level layers. Type-level pins below.
- *   2. **A forgotten domain layer is a compile error at the `Layer.provide`
- *      composition site** — an undischarged layer is not a
- *      `Layer<FateServer>`. Pinned via `expectTypeOf` bounds, NOT
- *      `@ts-expect-error`: the effect LSP plugin reports the mismatch as
- *      TS377034 (`missingLayerContext`), which escapes the directive under
- *      tsgo — the recurring tsgo hazard, here in layer shape.
- *   3. **Init-time validation fails layer construction with names attached**:
- *      duplicate wire names across the category records (both owners named)
- *      and view-reachable entities without a source (entity named). These are
- *      the layer-construction tests in the integration tier: they build the
- *      layer for real (`Layer.build` through the Effect runtime) — no
- *      storage, but not pure-value unit either.
- *   4. **Every record is constructor-built** — the raw legacy bridge-shaped
- *      arms were removed with the v2 cutover (ADR 0043), so a non-`Fate.*`
- *      record is a compile error at the config site.
- *
  * Like the sibling suites, this module **exports** its config/layer consts on
  * purpose: the package tsconfig is `composite`, so tsgo's declaration
- * nameability checks (TS2883) run over `FateServer.config`'s inferred type
- * with a representative multi-feature config
- * (sozluk-shaped records + a string-typed query).
+ * nameability checks (TS2883) run over `FateServer.config`'s inferred type.
  */
 import {Cause, Context, Effect, Exit, Layer} from "effect";
 import * as Schema from "effect/Schema";
@@ -80,7 +56,6 @@ class BodyRequired extends Schema.TaggedErrorClass<BodyRequired>()(
 	{[FateWireCode]: "BODY_REQUIRED"},
 ) {}
 
-/** sozluk-shaped feature records: `Fate.*` entries over the domain service. */
 export const sozlukQueries = {
 	term: Fate.query(
 		{args: Schema.Struct({slug: Schema.String}), type: TermView},
@@ -105,12 +80,7 @@ export const sozlukLists = {
 	),
 };
 
-/**
- * The per-request pair in action: the handler yields `CurrentUser` (via
- * `required`) and `LivePublisher` like any other service — both must be
- * EXCLUDED from the layer's R (they are provided per request by the
- * compiler).
- */
+/** The handler yields the per-request pair, which must stay OUT of the layer's R. */
 export const sozlukMutations = {
 	"definition.add": Fate.mutation(
 		{
@@ -152,11 +122,7 @@ export const definitionSource = Fate.source(
 	},
 );
 
-/**
- * The representative multi-feature config (exported: the TS2883 watchpoint
- * fixture): two `Fate.*` features' records spread together, exactly fate's
- * options shape.
- */
+/** The representative multi-feature config — the TS2883 watchpoint fixture. */
 export const phoenixConfig = FateServer.config({
 	queries: {
 		...sozlukQueries,
@@ -171,7 +137,6 @@ export const phoenixConfig = FateServer.config({
 
 export const phoenixLayer = FateServer.layer(phoenixConfig);
 
-/** The R channel of a layer, for the type-level pins below. */
 type LayerIn<L> = L extends Layer.Layer<infer _ROut, infer _E, infer RIn> ? RIn : never;
 
 const buildService = (layer: Layer.Layer<FateServer>) =>
@@ -190,23 +155,17 @@ const buildExit = (layer: Layer.Layer<FateServer>) =>
 const defectOf = (exit: Exit.Exit<unknown, unknown>): unknown =>
 	Exit.isFailure(exit) ? Cause.squash(exit.cause) : undefined;
 
-// Type-level: R = handler/source requirements minus the per-request pair.
-
 describe("FateServer.layer — the R channel", () => {
 	it("R is the requirement union minus CurrentUser and LivePublisher", () => {
-		// The mutation handler yields CurrentUser AND LivePublisher; the layer's
-		// R still contains ONLY the domain service — the per-request pair is the
-		// server's contract, not a worker-level layer.
+		// The mutation handler yields both, yet R holds only the domain service:
+		// the per-request pair is the server's contract, not a worker-level layer.
 		expectTypeOf<LayerIn<typeof phoenixLayer>>().toEqualTypeOf<TermStore>();
 	});
 
 	it("an undischarged domain requirement is a compile error at the composition site", () => {
-		// An undischarged layer is NOT a `Layer<FateServer>` (R = never), so
-		// handing it to anything that runs it — `ManagedRuntime.make`, a fully
-		// provided composition — is a compile error. Pinned as an `expectTypeOf`
-		// bound rather than `@ts-expect-error`: the effect LSP plugin reports the
-		// mismatch as TS377034 (`missingLayerContext`), which escapes the
-		// directive under tsgo (the recurring hazard the suite header documents).
+		// Pinned as an `expectTypeOf` bound rather than `@ts-expect-error`: the
+		// effect LSP plugin reports the mismatch as TS377034
+		// (`missingLayerContext`), which escapes the directive under tsgo.
 		expectTypeOf(phoenixLayer).not.toExtend<Layer.Layer<FateServer>>();
 
 		// Positive control: ordinary `Layer.provide` discharges it.

--- a/packages/fate-effect/src/Server.ts
+++ b/packages/fate-effect/src/Server.ts
@@ -1,52 +1,10 @@
 /**
  * `FateServer` — the package-owned service tag, `config`, and `layer`.
  *
- * fate has exactly one composite — the server — so it is the one Effect
- * service (the `HttpRouter` idiom: the package owns the tag, no user-defined
- * class). Composition is ordinary layer
- * algebra:
- *
- *   - **`FateServer.config({queries, lists, mutations, sources, live})`**
- *     mirrors `createFateServer`'s options shape. Record values are
- *     `Fate.query`/`Fate.list`/`Fate.mutation` entries; `sources` is the
- *     package's array of `Fate.source` entries (fate's own `sources` option
- *     is the derived `{getSource, registry}` resolver, which the compile
- *     step builds — the definition objects here are held BY IDENTITY for
- *     fate's identity-keyed registry). Every entry is constructor-built.
- *     `config` is pure data capture: full entry types are preserved on the
- *     value (the codegen surface's `InferFateAPI` fidelity rides on them);
- *     validation happens at layer construction.
- *
- *   - **`FateServer.layer(config)`** returns `Layer<FateServer>` whose R is
- *     the union of handler/source requirements
- *     ({@link FateConfigServices}) MINUS the per-request pair —
- *     `CurrentUser` and `LivePublisher` are the server's documented
- *     per-request contract, provided onto each handler per request by the
- *     provision pipeline (`provideRequestPair`, `Provision.ts` — the
- *     interpreter's serving path since ADR 0043), never by a worker-level
- *     layer
- *     ({@link FateServerRequirements}). Domain layers discharge R with
- *     ordinary `Layer.provide`; a forgotten domain layer is a compile error
- *     at the composition site.
- *
- *   - **Init-time validation**: duplicate wire names across
- *     the category records (both owners named), duplicate sources per
- *     entity, and view-reachable entities without a source (entity + where
- *     it was reached from) fail layer construction with a
- *     {@link FateServerConfigError} defect — composition mistakes are
- *     programmer errors, so they die (E stays `never`) and surface at worker
- *     init in dev, not at request time. Within ONE record, spread collapses
- *     duplicate keys before any code can see them (fate's own
- *     shape) — the check covers collisions ACROSS the
- *     spread category records, exactly what the manifest would otherwise
- *     merge silently.
- *
- * The layer captures the build-time services (`Effect.context()`) into the
- * service value: the per-request provision pipeline (`provideRequestPair`,
- * `Provision.ts`) provides that captured context plus the per-request pair
- * onto each entry's `resolve` — on the request fiber via the interpreter
- * (the serving path since ADR 0043); the compile step applies the same
- * pipeline only as the differential oracle's baseline.
+ * `config` is pure data capture; `layer` validates it and dies on a bad config. The
+ * per-request pair (`CurrentUser`/`LivePublisher`) never comes from a worker-level layer —
+ * `Provision.ts` provides it onto each handler per request. See ADR 0042/0043, and ADR
+ * 0107 §7 for the extra app-registered per-request services.
  */
 import type {ConnectionResult, LiveEventBus} from "@nkzw/fate/server";
 import {Context, Effect, Layer} from "effect";
@@ -67,14 +25,8 @@ import type {FateSourceServices, SourceConnectionInput} from "./Source.ts";
 import {FateWireCode, INTERNAL_WIRE_CODE, wireCodeOfClass} from "./WireError.ts";
 
 /**
- * Any `Fate.query` entry, type-erased: the supertype every
- * `FateQuery<D, A, E, R>` is assignable to (handler parameters at `never`,
- * channels at `unknown`). `resolve` keeps its CONCRETE raw-wire parameter
- * ({@link RawArgsInput} / {@link RawMutationInput}) so the compile step
- * (`Executor.ts`) can call it without recovering the precise entry type. The
- * config record constraints and the stored {@link FateServerService} records
- * are typed in these — the precise entry types live on the
- * {@link FateServerConfig} value itself.
+ * Any `Fate.query` entry, type-erased. `resolve` keeps its CONCRETE raw-wire parameter so
+ * the compile step (`Executor.ts`) can call it without recovering the precise entry type.
  */
 export interface AnyFateQuery {
 	readonly kind: "query";
@@ -84,11 +36,6 @@ export interface AnyFateQuery {
 	readonly resolve: (input: RawArgsInput) => Effect.Effect<unknown, unknown, unknown>;
 }
 
-/**
- * Any `Fate.list` entry, type-erased (see {@link AnyFateQuery}). The success
- * channel keeps fate's `ConnectionResult` envelope (item type erased) — the
- * compiled fate list resolver promises that shape.
- */
 export interface AnyFateList {
 	readonly kind: "list";
 	readonly definition: ListDefinition;
@@ -99,7 +46,6 @@ export interface AnyFateList {
 	) => Effect.Effect<ConnectionResult<unknown>, unknown, unknown>;
 }
 
-/** Any `Fate.mutation` entry, type-erased (see {@link AnyFateQuery}). */
 export interface AnyFateMutation {
 	readonly kind: "mutation";
 	readonly definition: MutationDefinition;
@@ -108,29 +54,16 @@ export interface AnyFateMutation {
 	readonly resolve: (input: RawMutationInput) => Effect.Effect<unknown, unknown, unknown>;
 }
 
-/**
- * The structural shape of a runtime data view this module can walk for the
- * source-completeness check: fate's `DataView` carries plain `typeName` +
- * `fields`, and nested relation views appear as field values of the same
- * shape (fate's own `isDataViewField` checks `"fields" in field`).
- */
 export interface DataViewLike {
 	readonly typeName: string;
 	readonly fields: Record<string, unknown>;
 }
 
-/** A kernel `SourceDefinition` through portable names (id field + view). */
 export interface SourceDefinitionLike {
 	readonly id: string;
 	readonly view: DataViewLike;
 }
 
-/**
- * Any `Fate.source` handlers bag, type-erased. Row types erase to the plain
- * record (`Item` is covariant in the success channel), so the compile step
- * can adapt these to fate's row-typed `SourceExecutor` without recovering
- * the precise source type.
- */
 export interface AnyFateSourceHandlers {
 	readonly byId?: (id: string) => Effect.Effect<Record<string, unknown> | null, never, unknown>;
 	readonly byIds?: (
@@ -141,44 +74,27 @@ export interface AnyFateSourceHandlers {
 	) => Effect.Effect<ReadonlyArray<Record<string, unknown>>, never, unknown>;
 }
 
-/**
- * Any `Fate.source` entry, type-erased: the supertype every
- * `FateSource<Item, Name, R>` is assignable to.
- */
 export interface AnyFateSourceEntry {
 	readonly typeName: string;
 	readonly definition: SourceDefinitionLike;
 	readonly handlers: AnyFateSourceHandlers;
 }
 
-/** What `config.queries` accepts: `Fate.query` entries. */
 export type FateQueriesRecord = Record<string, AnyFateQuery>;
 
-/** What `config.lists` accepts: `Fate.list` entries. */
 export type FateListsRecord = Record<string, AnyFateList>;
 
-/** What `config.mutations` accepts: `Fate.mutation` entries. */
 export type FateMutationsRecord = Record<string, AnyFateMutation>;
 
-/** What `config.sources` accepts: `Fate.source` entries (a capability-less
- * entry — `handlers: {}` — is the registered-but-unfetchable escape hatch). */
+/** A capability-less entry — `handlers: {}` — is the registered-but-unfetchable escape hatch. */
 export type FateSourcesList = ReadonlyArray<AnyFateSourceEntry>;
 
-/**
- * What `config.live` accepts — fate's `live` option through portable names:
- * a `LiveEventBus` (phoenix's publish-only bus), the `{bus, maxQueueSize}`
- * form, or `false`. Passed through to `createFateServer` unchanged.
- */
 export type FateLiveOption =
 	| false
 	| LiveEventBus
 	| {readonly bus: LiveEventBus; readonly maxQueueSize?: number};
 
-/**
- * A validated-shape (not yet validated-content) `FateServer` config: the
- * value `FateServer.config` returns, with full entry types preserved — the
- * compile step and the codegen surface both read them.
- */
+/** Shape-valid, not yet content-valid: `FateServer.layer` runs the content checks. */
 export interface FateServerConfig<
 	Q extends FateQueriesRecord,
 	L extends FateListsRecord,
@@ -192,7 +108,6 @@ export interface FateServerConfig<
 	readonly live: FateLiveOption | undefined;
 }
 
-/** Any config, type-erased — the bound `FateServer.layer` accepts. */
 export interface AnyFateServerConfig {
 	readonly queries: FateQueriesRecord;
 	readonly lists: FateListsRecord;
@@ -201,31 +116,17 @@ export interface AnyFateServerConfig {
 	readonly live: FateLiveOption | undefined;
 }
 
-/** The union of `FateOperationServices` across one record's entries. */
 export type FateRecordServices<Ops> = {[K in keyof Ops]: FateOperationServices<Ops[K]>}[keyof Ops];
 
-/**
- * Everything a config requires: handler requirements (including Schema
- * decoding services) across the three operation records, plus source
- * handler requirements.
- */
 export type FateConfigServices<C extends AnyFateServerConfig> =
 	| FateRecordServices<C["queries"]>
 	| FateRecordServices<C["lists"]>
 	| FateRecordServices<C["mutations"]>
 	| FateSourceServices<C["sources"][number]>;
 
-/**
- * The service identifier a `Context.Key` registers (its R-channel tag) —
- * `typeof CurrentActor` ↦ `CurrentActor`. The provision seam reads it off the
- * keys {@link FateServer.layer} takes, never naming the app's service.
- */
+/** Read off the keys {@link FateServer.layer} takes, so the package never names the app's service. */
 export type RequestServiceId<K> = K extends Context.Key<infer Id, infer _S> ? Id : never;
 
-/**
- * The union of service identifiers a list of per-request `Context.Key`s
- * registers, driving the extra exclusion in {@link FateServerRequirements}.
- */
 export type RegisteredRequestServices<Keys extends ReadonlyArray<unknown>> = {
 	[Index in keyof Keys]: RequestServiceId<Keys[Index]>;
 }[number];
@@ -286,10 +187,8 @@ const viewOfTypeRef = (ref: TypeRef | undefined): DataViewLike | undefined => {
 };
 
 /**
- * Collect every config problem — all of them at once, names attached. Shared
- * by `FateServer.layer` (dies at worker init) and
- * `FateExecutor.toCodegenServer` (throws at build time): the SAME composition
- * mistakes surface at both edges, with the same wording.
+ * Shared by `FateServer.layer` (dies at worker init) and `FateExecutor.toCodegenServer`
+ * (throws at build time) so the same mistake reads the same at both edges.
  */
 export const collectConfigIssues = (config: AnyFateServerConfig): Array<string> => {
 	const issues: Array<string> = [];
@@ -299,8 +198,8 @@ export const collectConfigIssues = (config: AnyFateServerConfig): Array<string> 
 		["mutations", config.mutations],
 	] as const;
 
-	// Duplicate wire names across the spread category records. (Within one
-	// record the spread already collapsed duplicates — fate's own shape.)
+	// Only collisions ACROSS the category records are visible here: within one record the
+	// spread collapsed duplicate keys before this code could see them.
 	const owners = new Map<string, Array<string>>();
 	for (const [category, record] of categories) {
 		for (const name of Object.keys(record)) {
@@ -327,9 +226,8 @@ export const collectConfigIssues = (config: AnyFateServerConfig): Array<string> 
 		}
 	}
 
-	// Duplicate sources per entity: fate resolves a view to ONE definition by
-	// type name, so a second source for the same entity is a silent override
-	// waiting to happen.
+	// fate resolves a view to ONE definition by type name, so a second source for the same
+	// entity is a silent override waiting to happen.
 	const sourceCounts = new Map<string, number>();
 	for (const entry of config.sources) {
 		const name = entry.definition.view.typeName;
@@ -341,9 +239,6 @@ export const collectConfigIssues = (config: AnyFateServerConfig): Array<string> 
 		}
 	}
 
-	// Source completeness: every entity reachable through a view object —
-	// operation success views and nested relation views, recursively — must
-	// have a source.
 	const reachable = new Map<string, string>();
 	const walk = (view: DataViewLike, origin: string): void => {
 		if (reachable.has(view.typeName)) {
@@ -377,12 +272,9 @@ export const collectConfigIssues = (config: AnyFateServerConfig): Array<string> 
 };
 
 /**
- * Collect every `FateWireCode` annotation reachable from one Schema AST node:
- * the node's own annotation plus (for a union) each member's. Structural
- * guards throughout — the walk must not assume AST internals beyond what it
- * reads (the same defensive shape as `wireCodeOfClass`); the package's
- * AST-drift canary (`Server.unit.test.ts`) fails loudly if effect moves
- * either anchor (`ast.annotations`, union members on `ast.types`).
+ * Structural guards throughout: the walk must not assume AST internals beyond what it reads.
+ * The AST-drift canary (`Server.unit.test.ts`) fails loudly if effect moves either anchor
+ * (`ast.annotations`, union members on `ast.types`).
  */
 const collectWireCodes = (ast: unknown, out: Set<string>): void => {
 	if (Predicate.hasProperty(ast, "annotations")) {
@@ -399,23 +291,11 @@ const collectWireCodes = (ast: unknown, out: Set<string>): void => {
 };
 
 /**
- * Every wire code this config can emit through the annotation codec
- * (`encodeWireError`): each operation's DECLARED error union, walked via its
- * Schema AST (annotations land on each class's AST, so the registered config
- * is the single source), plus the two codes the package can always emit
- * independent of any declaration — {@link INTERNAL_WIRE_CODE} for
- * defects/un-annotated failures and `InputValidationError`'s annotated code
- * for Schema rejections.
- *
- * Sources are excluded by construction: loaders have `E = never` (the
- * loader/resolver split), so they declare no errors to walk. fate's own
- * walk-internal arm (`internalArm`: `INTERNAL_ERROR`) is the byId plane's
- * taxonomy, not part of this operation-plane vocabulary.
- *
- * This is the canonical walker a client-coverage guard consumes (the worker's
- * `wireCodes.unit.test.ts`: "the SPA list covers every code the server can
- * emit") — exported so no consumer re-rolls the AST walk against
- * package-private knowledge.
+ * Every wire code this config can emit: each operation's declared error union plus the two
+ * the package always can — {@link INTERNAL_WIRE_CODE} and `InputValidationError`'s code.
+ * Sources are excluded by construction (loaders have `E = never`, so no errors to walk).
+ * The canonical walker the client-coverage guard consumes (`wireCodes.unit.test.ts`) —
+ * exported so no consumer re-rolls the AST walk.
  */
 export const declaredWireCodes = (config: AnyFateServerConfig): ReadonlySet<string> => {
 	const codes = new Set<string>([INTERNAL_WIRE_CODE]);
@@ -430,31 +310,13 @@ export const declaredWireCodes = (config: AnyFateServerConfig): ReadonlySet<stri
 	return codes;
 };
 
-/**
- * What the `FateServer` service holds: the (validated) config records,
- * type-erased, plus the services captured when the layer was built. The
- * provision pipeline (`Provision.ts`) reads both — it provides `services` +
- * the per-request pair onto each entry's `resolve`, on the request fiber via
- * the interpreter (the serving path) and through the worker ManagedRuntime
- * on the oracle's compile step.
- */
 export interface FateServerService extends AnyFateServerConfig {
 	readonly services: Context.Context<never>;
 }
 
-/**
- * The fate server as the one Effect service (package-owned tag — the
- * `HttpRouter` idiom). Use the statics: `FateServer.config(...)` to declare,
- * `FateServer.layer(config)` to compose.
- */
 export class FateServer extends Context.Service<FateServer, FateServerService>()(
 	"fate-effect/FateServer",
 ) {
-	/**
-	 * Capture a server config — `createFateServer`'s options shape with
-	 * `Fate.*` record values. Pure data: entry types are
-	 * preserved on the value; validation runs in {@link FateServer.layer}.
-	 */
 	static config<
 		Q extends FateQueriesRecord = Record<never, never>,
 		L extends FateListsRecord = Record<never, never>,
@@ -483,22 +345,12 @@ export class FateServer extends Context.Service<FateServer, FateServerService>()
 		};
 	}
 
-	/**
-	 * Build the server layer from a config. R is
-	 * {@link FateServerRequirements}: handler/source requirements minus the
-	 * per-request pair — discharge it with ordinary `Layer.provide`. Invalid
-	 * configs (duplicate wire names, missing sources) DIE here with a
-	 * {@link FateServerConfigError} naming the offenders.
-	 */
 	static layer<C extends AnyFateServerConfig>(
 		config: C,
 	): Layer.Layer<FateServer, never, FateServerRequirements<C>>;
 	/**
-	 * The generic per-request provision overload (ADR 0107 §7). Pass the extra
-	 * per-request service KEYS the app fills per request (e.g. `[CurrentActor]`)
-	 * and they drop out of R alongside the pair. The keys are a TYPE-LEVEL witness
-	 * only — they widen {@link FateServerRequirements}; the layer never reads them
-	 * at runtime (hence `_requestServices`), and the app fills their VALUES via
+	 * ADR 0107 §7. The keys are a TYPE-LEVEL witness only — the layer never reads them at
+	 * runtime (hence `_requestServices`); the app fills their VALUES via
 	 * `FateRequestContext.requestServices`.
 	 */
 	static layer<
@@ -519,8 +371,6 @@ export class FateServer extends Context.Service<FateServer, FateServerService>()
 				if (issues.length > 0) {
 					return yield* Effect.die(new FateServerConfigError(issues));
 				}
-				// Capture the build-time services: the provision pipeline provides
-				// them (plus the per-request pair) onto each handler at the fate edge.
 				const services = yield* Effect.context();
 				return {
 					queries: config.queries,

--- a/packages/fate-effect/src/Server.unit.test.ts
+++ b/packages/fate-effect/src/Server.unit.test.ts
@@ -1,25 +1,4 @@
 /**
- * Unit — `declaredWireCodes`: the canonical "every wire code this config can
- * emit" walker.
- *
- * The contract under test:
- *
- *   1. **The package fallbacks are always present** — `INTERNAL_WIRE_CODE`
- *      (defects / un-annotated failures) and `InputValidationError`'s
- *      annotated code (Schema rejections) can be emitted independent of any
- *      declaration, so even an empty config carries them.
- *   2. **Declared error unions are walked across all three category
- *      records** — every union member's `FateWireCode` annotation lands in the
- *      set; a bare (non-union) annotated error class is collected off its own
- *      AST node; entries without an `error:` contribute nothing. Sources are
- *      excluded by construction: loaders have `E = never`, nothing to walk.
- *   3. **The AST-drift canary** (moved here from the worker's
- *      `wireCodes.unit.test.ts`, where it hedged the hand-rolled copy of this
- *      walker): the walk reads annotations off `ast.annotations` and union
- *      members off `ast.types` with structural guards — if an effect Schema
- *      internals change moves either, the canary fails loudly instead of
- *      downstream subset checks passing vacuously over a fallback-only set.
- *
  * Like the sibling suites, this module **exports** its fixture consts on
  * purpose: the package tsconfig is `composite`, so tsgo's declaration
  * nameability checks (TS2883) run over the inferred types.
@@ -157,9 +136,7 @@ describe("declaredWireCodes", () => {
 
 	it("un-annotated union members and error-less entries contribute nothing", () => {
 		const codes = declaredWireCodes(noteConfig);
-		// `Unannotated` is declared on `noteQueries.note` but carries no code;
-		// `health` declares no error at all. The exact-set assertions above
-		// already pin this — this spells the negative space out.
+		// The exact-set assertions above already pin this; this spells the negative space out.
 		expect([...codes].every((code) => typeof code === "string")).toBe(true);
 		expect(codes.size).toBe(5);
 	});
@@ -198,8 +175,6 @@ describe("declaredWireCodes", () => {
 	});
 });
 
-// The generic per-request provision seam (ADR 0107 §7).
-
 /**
  * A stand-in for an app's EXTRA per-request service (the künye `CurrentActor`
  * shape). The package names none of it: it appears here only as a handler
@@ -237,10 +212,7 @@ describe("FateServerRequirements — generic per-request provision exclusion (AD
 	});
 
 	it("a REGISTERED per-request service is excluded from R (provided per request, not at build time)", () => {
-		// `PR = Actor` drops it out alongside the pair…
 		expectTypeOf<FateServerRequirements<typeof actorConfig, Actor>>().toEqualTypeOf<never>();
-		// …and the registration overload infers `PR` from the key list, so the
-		// composed layer needs nothing extra at `Layer.provide` time.
 		expectTypeOf(FateServer.layer(actorConfig, [Actor])).toEqualTypeOf<
 			Layer.Layer<FateServer, never, never>
 		>();

--- a/packages/fate-effect/src/Source.ts
+++ b/packages/fate-effect/src/Source.ts
@@ -1,46 +1,19 @@
 /**
- * `Fate.source` — the per-entity loader constructor.
+ * `Fate.source` — the per-entity loader constructor. See ADR 0043.
  *
- * The loader half of the loader/resolver split:
- * sources LOAD, operations RESOLVE. A source's handlers therefore have a
- * deliberately narrow contract:
+ * Reads are silent: a missing id is `null`, fewer rows than asked is success.
+ * The error channel is pinned `never`, so infrastructure failures are defects.
  *
- * - **At least one of `byId`/`byIds` at the type level** — a source that can't
- *   load is unrepresentable ({@link SourceLoaderContract}).
- * - **Reads are silent**: `byId` returns `null` for a missing id, `byIds`
- *   returns the rows that exist (fewer than asked is success, not failure).
- *   The error channel is pinned `never` — a handler with a typed failure is a
- *   compile error; infrastructure failures are defects (`Effect.die`), exactly
- *   like every other unrecoverable fault.
- * - **`R` is inferred** from the handler bodies and surfaces on the returned
- *   {@link FateSource}, so a source's domain-service requirements participate
- *   in layer composition like any other Effect requirement
- *   ({@link FateSourceServices}, consumed by `FateServer.layer`).
- *
- * Spans come from the constructor, not the author: each provided handler body
- * is passed to `Effect.fn("<Entity>.<capability>")` (effect-smol `LLMS.md` §
- * "Using Effect.fn" — the documented way to get named spans + stack frames on
- * Effect functions). The handler slot accepts exactly what `Effect.fn`'s body
- * parameter accepts — a generator function or an Effect-returning function
- * (`Effect.fn`'s `fn.Traced` body union) — and the span name is derived from
- * the view class's `typeName`, so it cannot drift from the entity.
- *
- * Authoring shape:
- *
- * ```ts
- * export const termSource = Fate.source(TermView, {id: "slug"}, {
- *   byIds: function* (slugs) {
- *     const sozluk = yield* Sozluk;
- *     return yield* sozluk.getTermSummariesByIds(slugs);
- *   },
- * });
- * ```
+ * Spans come from the constructor, not the author: each handler body is passed
+ * to `Effect.fn("<Entity>.<capability>")` (effect-smol `LLMS.md` § "Using
+ * Effect.fn"), so the span name is derived from the view's `typeName` and
+ * cannot drift from the entity.
  *
  * The constructor takes the `FateDataView` **class** and reads the kernel view
  * off it — the class itself is never handed to fate (fate's object-walkers
  * skip functions; see `DataView.ts`). The returned `definition` IS a kernel
- * `SourceDefinition` (`{id, view}`), created once here so fate's
- * identity-keyed source registry has a single stable object from birth.
+ * `SourceDefinition`, created once here so fate's identity-keyed source
+ * registry has a single stable object from birth.
  */
 import type {SourceDefinition} from "@nkzw/fate/server";
 import {Effect} from "effect";
@@ -49,19 +22,12 @@ import type {DataViewOf} from "./DataView.ts";
 /** fate's `AnyRecord` (not exported from the barrel; it is exactly this). */
 type AnyRow = Record<string, unknown>;
 
-/**
- * Options for {@link source}: `id` names the row's primary-key field — the
- * field fate refs the entity by (`"slug"` for Term, `"id"` for most).
- */
+/** `id` names the row's primary-key FIELD — the field fate refs the entity by. */
 export interface SourceOptions {
 	readonly id: string;
 }
 
-/**
- * The page bag a `connection` handler receives. Mirrors the keyset contract
- * (ADR 0019): `cursor` is opaque to the package, `args` carries the
- * connection's scoped args (e.g. the parent key of a nested connection).
- */
+/** The page bag a `connection` handler receives — keyset contract, ADR 0019. */
 export interface SourceConnectionInput {
 	readonly args?: Record<string, unknown>;
 	readonly cursor?: string;
@@ -70,20 +36,10 @@ export interface SourceConnectionInput {
 	readonly take: number;
 }
 
-/**
- * A source handler body: exactly what `Effect.fn(name)` accepts — a generator
- * function or an Effect-returning function — with the error channel pinned
- * `never` (loaders are silent; infra failures are defects).
- */
 export type SourceHandlerBody<Args extends ReadonlyArray<unknown>, A, R> = (
 	...args: Args
 ) => Generator<Effect.Effect<unknown, never, R>, A, never> | Effect.Effect<A, never, R>;
 
-/**
- * The full (capability-optional) handlers bag — the inference constraint of
- * {@link source}'s third parameter. Requiredness of the loading capabilities
- * is layered on by {@link SourceLoaderContract}.
- */
 export interface SourceHandlersInput<Item extends AnyRow> {
 	readonly byId?: SourceHandlerBody<[id: string], Item | null, unknown>;
 	readonly byIds?: SourceHandlerBody<[ids: ReadonlyArray<string>], ReadonlyArray<Item>, unknown>;
@@ -95,19 +51,15 @@ export interface SourceHandlersInput<Item extends AnyRow> {
 }
 
 /**
- * The type-level loader contract: at least one of `byId`/`byIds` must be
- * provided — a source with neither cannot load an entity, so it does not
- * typecheck. (`connection` alone is not loading: refs resolve by id.)
+ * At least one of `byId`/`byIds` must be provided — a source with neither
+ * cannot load an entity, so it does not typecheck. (`connection` alone is not
+ * loading: refs resolve by id.)
  */
 export type SourceLoaderContract<Item extends AnyRow> =
 	| {readonly byId: SourceHandlerBody<[id: string], Item | null, unknown>}
 	| {readonly byIds: SourceHandlerBody<[ids: ReadonlyArray<string>], ReadonlyArray<Item>, unknown>};
 
-/**
- * The services a single handler body requires: `R` recovered from either side
- * of the `Effect.fn` body union (the yielded effects of a generator body, or
- * the returned effect directly).
- */
+/** `R` recovered from either side of the `Effect.fn` body union. */
 export type SourceHandlerServices<F> = F extends (...args: never) => infer Ret
 	? Ret extends Generator<infer Y, infer _A, infer _N>
 		? Y extends Effect.Effect<infer _YA, infer _YE, infer YR>
@@ -118,17 +70,10 @@ export type SourceHandlerServices<F> = F extends (...args: never) => infer Ret
 			: never
 	: never;
 
-/** The union of {@link SourceHandlerServices} across every provided handler. */
 export type SourceHandlersServices<H> = {
 	[K in keyof H]: SourceHandlerServices<H[K]>;
 }[keyof H];
 
-/**
- * The wrapped handlers a {@link FateSource} carries: plain Effect-returning
- * functions, each already spanned `<Entity>.<capability>` via `Effect.fn`.
- * The compile step adapts these to fate's promise-shaped `SourceExecutor`
- * through the worker runtime.
- */
 export interface FateSourceHandlers<Item extends AnyRow, R> {
 	readonly byId?: (id: string) => Effect.Effect<Item | null, never, R>;
 	readonly byIds?: (ids: ReadonlyArray<string>) => Effect.Effect<ReadonlyArray<Item>, never, R>;
@@ -137,29 +82,14 @@ export interface FateSourceHandlers<Item extends AnyRow, R> {
 	) => Effect.Effect<ReadonlyArray<Item>, never, R>;
 }
 
-/**
- * What {@link source} returns: the kernel `SourceDefinition` (handed to fate
- * unchanged — the registry keys it by identity), the literal entity name (for
- * init-time source-completeness checks and span derivation), and the spanned
- * Effect handlers. `R` is the union of the handlers' requirements.
- */
 export interface FateSource<Item extends AnyRow, Name extends string, R> {
 	readonly definition: SourceDefinition<Item>;
 	readonly typeName: Name;
 	readonly handlers: FateSourceHandlers<Item, R>;
 }
 
-/**
- * The services a source requires — the `R` of {@link FateSource}, named the
- * way effect v4 names the extractor (`Effect.Services`). `FateServer.layer`
- * unions these across the config to type its own requirements.
- */
 export type FateSourceServices<S> = S extends FateSource<AnyRow, string, infer R> ? R : never;
 
-/**
- * Build a per-entity loader from a `FateDataView` class, the primary-key
- * field name, and the load handlers. See the module doc for the contract.
- */
 export function source<
 	Item extends AnyRow,
 	Name extends string,
@@ -196,16 +126,11 @@ export function source(
  * flattened from definitions/posts/comments by a custom resolver, delivered
  * inline through a parent connection).
  *
- * {@link source} deliberately makes a loader-less source unrepresentable
- * ({@link SourceLoaderContract}); this is the one sanctioned escape hatch.
- * The entry exists so the server's source-completeness validation accepts the
- * view-reachable entity — and for nothing else: the handlers bag is EMPTY, so
- * any actual capability call fails loudly inside the package. On the serving
- * path the walk's capability-less arm fails the load with fate's internal arm
- * (`Walk.ts` `runGroup`); on the oracle baseline the empty bag adapts to an
- * empty executor that fate itself rejects and masks (`Executor.ts`
- * `adaptSourceHandlers`). Identical bytes to the hand-built erased entry this
- * constructor replaces.
+ * {@link source} deliberately makes a loader-less source unrepresentable; this
+ * is the one sanctioned escape hatch. The entry exists so the server's
+ * source-completeness validation accepts the view-reachable entity — and for
+ * nothing else: the handlers bag is EMPTY, so any actual capability call fails
+ * loudly inside the package.
  *
  * Reserve this for genuinely synthetic entities; if a fetch path exists,
  * implement `byIds`. A root-only synthetic entity (no view nesting reaches

--- a/packages/fate-effect/src/Source.unit.test.ts
+++ b/packages/fate-effect/src/Source.unit.test.ts
@@ -1,23 +1,9 @@
 /**
  * Unit — `Fate.source` (the per-entity loader).
  *
- * The loader contract under test (the loader/resolver split):
- *
- *   1. **At least one of `byId`/`byIds` is required at the type level** — an
- *      unloadable source is unrepresentable (the `@ts-expect-error` pins).
- *   2. **Handlers' `R` is inferred and visible in the source's type**, and it
- *      threads through to composition (`Effect.provideService` discharges it).
- *   3. **Loaders are silent on absence**: `byIds` returns what exists, `byId`
- *      returns `null`; `E` is pinned `never` (a failing handler is a compile
- *      error); infra failures are defects.
- *   4. **Spans come from the constructor, not the author**: each provided
- *      handler is wrapped with `Effect.fn("<Entity>.<capability>")`, so the
- *      span name is derived from the view class and cannot drift.
- *
- * Like `DataView.unit.test.ts`, this module **exports** its source consts on
- * purpose: the package tsconfig is `composite`, so tsgo's declaration
- * nameability checks (TS2883) run over the `Fate.source` return type — the
- * permanent gate that the source surface stays portably nameable.
+ * Like `DataView.unit.test.ts`, this module **exports** its source consts on purpose: the
+ * package tsconfig is `composite`, so tsgo's declaration nameability checks (TS2883) run over
+ * the `Fate.source` return type — the permanent gate that the surface stays portably nameable.
  */
 import {createSourcePlan} from "@nkzw/fate/server";
 import {Context, Effect} from "effect";
@@ -69,7 +55,6 @@ const rows: ReadonlyArray<TermRow> = [
 	{slug: "fate", title: "fate", score: 3},
 ];
 
-/** Narrow an optional handler without a non-null assertion. */
 const required = <T>(value: T | undefined): T => {
 	if (value === undefined) {
 		throw new Error("expected the handler to be present");
@@ -83,8 +68,6 @@ describe("Fate.source — loaders are silent on absence", () => {
 		const result = await Effect.runPromise(
 			byIds(["effect", "fate", "missing-slug"]).pipe(Effect.provideService(TermStore, {rows})),
 		);
-		// Absence is not an error: two of three ids exist, the load succeeds
-		// with exactly the rows that exist.
 		expect(result).toEqual([rows[0], rows[1]]);
 	});
 
@@ -114,7 +97,6 @@ describe("Fate.source — loaders are silent on absence", () => {
 			},
 		);
 		const byIds = required(src.handlers.byIds);
-		// The error channel is `never` — infra failure is a defect, not a value.
 		expectTypeOf(byIds(["x"])).toEqualTypeOf<Effect.Effect<ReadonlyArray<TermRow>, never, never>>();
 		await expect(Effect.runPromise(byIds(["x"]))).rejects.toThrow("D1 is down");
 	});
@@ -222,8 +204,6 @@ describe("Fate.source — type-level contract", () => {
 			ReadonlyArray<TermRow>,
 			unknown
 		>;
-		// A silent handler fits the byIds slot; a failing one is rejected — the
-		// loader error channel is pinned `never`.
 		expectTypeOf<SilentHandler>().toExtend<ByIdsSlot>();
 		expectTypeOf<FailingHandler>().not.toExtend<ByIdsSlot>();
 	});
@@ -252,8 +232,6 @@ describe("Fate.source — type-level contract", () => {
 			},
 		);
 		expectTypeOf<FateSourceServices<typeof src>>().toEqualTypeOf<TermStore | Viewer>();
-		// Composition: providing the services discharges R — a forgotten layer
-		// would be a compile error at the composition site.
 		const provided = required(src.handlers.byIds)(["effect"]).pipe(
 			Effect.provideService(TermStore, {rows}),
 			Effect.provideService(Viewer, {id: "u1"}),
@@ -277,15 +255,9 @@ export const ghostSource = Fate.syntheticSource(GhostView);
 
 describe("Fate.syntheticSource — synthetic entity, no fetch path", () => {
 	it("is byte-identical to the hand-built erased entry it replaces", () => {
-		// The exact shape the first consumer (pasaport's `contributionSource`)
-		// hand-built before this constructor existed: kernel definition with
-		// the conventional `id` PK field, the view BY IDENTITY, and an EMPTY
-		// handlers bag — zero capabilities. The empty bag is the loud-failure
-		// contract: the walk's capability-less arm fails the load with fate's
-		// internal arm (`Interpreter.walk.test.ts` corpus: "a capability-less
-		// source is fate's internal arm"), and the oracle baseline adapts `{}`
-		// to an empty executor that fate masks the same way — both planes are
-		// parity-pinned over a `Fate.syntheticSource` fixture.
+		// The EMPTY handlers bag is the loud-failure contract: fate's walk fails a
+		// capability-less source through its internal arm, and the oracle baseline
+		// masks `{}` the same way. Both planes are parity-pinned over this fixture.
 		expect(ghostSource).toEqual({
 			typeName: "Ghost",
 			definition: {id: "id", view: GhostView.view},

--- a/packages/fate-effect/src/Walk.ts
+++ b/packages/fate-effect/src/Walk.ts
@@ -1,73 +1,8 @@
 /**
- * The selection walk — fate's byId plane (`executeOperation`'s byId arm →
- * `resolveSourceByIds` → `resolveNode`/`filterToViewFields`/
- * `toConnectionResult`) reimplemented as an Effect program, with every source
- * load riding `Request.Class` + `RequestResolver`.
- * This is where N+1 dies: the batch window is ONE protocol request
- * (`makeWalk` is constructed once per `FateInterpreter.handleRequest`, so the
- * resolver instance — and with it the window — never spans requests), and ids
- * are deduplicated before they reach the source.
- *
- * ## What is mirrored, byte for byte (the walk oracle enforces it)
- *
- *   - **Dispatch order**: falsy `type` → fate's `BAD_REQUEST` ("byId
- *     operations require type and ids."), then the source lookup → fate's
- *     `NOT_FOUND`, then `ids.map(String)` — numeric wire ids coerce BEFORE
- *     the source sees them.
- *   - **The selection plan** (fate's `createViewPlan`/`assignPath`): `"id"`
- *     is always selected; resolver/computed fields register at terminal
- *     segments only; a selected ref auto-selects the child view's `id`;
- *     unknown paths and empty segments are ignored.
- *   - **`resolveNode`**: resolver fields run `authorize` first (falsy →
- *     `null`, resolve skipped), `undefined` results stay absent, computed
- *     fields receive select-derived deps, relation nodes recurse into
- *     records, arrays, and already-shaped connection results.
- *   - **`filterToViewFields`**: masking emits keys in the VIEW's field
- *     declaration order — the byId plane's serialization-order mechanism
- *     (the named-operation planes get theirs from the `Protocol.ts` structs).
- *   - **`toConnectionResult`** (the connection plane, `Connection.ts`): a
- *     selected list-kind field holding a RAW array wraps via fate's
- *     `arrayToConnection`, windowed by the operation args scoped to the
- *     field's dotted path (`getScopedArgs`); an already-shaped connection
- *     envelope passes through, recursing per entry node. Pagination args
- *     decode through Effect Schema with fate's exact accept/reject boundary;
- *     a rejected bag is fate's masked internal arm on the wire.
- *   - **The error taxonomy**: a view callback throwing a `FateRequestError`
- *     passes through verbatim; any other callback throw is fate's OWN
- *     `toProtocolError` arm (`INTERNAL_ERROR` / "Internal server error.") —
- *     NOT the annotation codec's arm, because in fate these errors never pass
- *     through `encodeWireError`. Source-handler defects, by contrast, reach
- *     the operation's exit as raw causes and collapse through
- *     `encodeWireError` exactly as the v1 compiled executors do
- *     (`INTERNAL_SERVER_ERROR` / "Something went wrong."). A capability-less
- *     source (the `contributionSource` shape) is fate's internal arm, the
- *     fixed message — fate throws a plain `Error` there and masks it.
- *
- * ## The batching contract
- *
- * One `RequestResolver` per protocol request; one `Request` per byId
- * operation (`{source, ids}`). `runAll` groups entries by source entry
- * (identity), unions their ids (first-arrival order, deduplicated), and
- * mirrors fate's two executor arms:
- *
- *   - **`byIds`-capable**: ONE call with the deduplicated union. A
- *     single-operation batch completes with the source's rows verbatim
- *     (exactly fate's `resolveSourceByIds`); a merged batch completes each
- *     operation with the rows whose primary key (the definition's `id`
- *     field) is in that operation's id set, in SOURCE-RETURN order. This is
- *     byte-equal to fate whenever the source is **membership-stable** (the
- *     returned rows are a function of the id SET — every SQL `IN`-shaped
- *     loader, i.e. every phoenix source, qualifies).
- *   - **`byId`-only**: one call per UNIQUE id across the window (fate calls
- *     per id per operation, duplicates included); each operation's rows are
- *     its own ids' hits in ids order, duplicates preserved, nulls dropped —
- *     fate's `flatMap` arm exactly. A failed id fails exactly the operations
- *     that asked for it.
- *
- * Loads provide the per-request pair + captured services themselves (the
- * ONE shared provision pipeline — `provideRequestPair`, `Provision.ts`), so
- * the resolver fiber needs no ambient context. No runtime is owned here — the conversion-point rule
- * (`Executor.test.ts`) covers this module automatically.
+ * The selection walk — fate's byId plane reimplemented as an Effect program,
+ * with every source load riding `Request.Class` + `RequestResolver`. The
+ * mirrored semantics, the batching contract, the error taxonomy and the
+ * deliberate divergences are owned by `.patterns/fate-effect-interpreter.md`.
  *
  * ## Span design (deliberate)
  *
@@ -80,25 +15,6 @@
  * at the operation/source boundaries (`Fate.*` constructors, the
  * interpreter's dispatch), not inside the walk. Don't "fix" this to
  * `Effect.fn`.
- *
- * ## Deliberately NOT mirrored (documented divergences)
- *
- *   - **Source lookup**: fate populates `sourcesByType` by visiting ROOT
- *     views only; the v1 compiled server passes `roots: {}` (ADR 0016/0019),
- *     leaving its byId plane unreachable dead code. The interpreter resolves
- *     `config.sources` directly — strictly additive on the wire: fate's
- *     client CAN emit `kind: "byId"` (cache-miss node fetches, missing-field
- *     refetches, the live-payload fallback), and v1 served all of those
- *     NOT_FOUND, so the divergence is error→data — live since the v2
- *     cutover (ADR 0043), fixing a latent live-refetch breakage. Pinned
- *     loudly in the oracle suite.
- *   - fate's hidden computed-state stamping (`attachComputedState`, a
- *     module-private symbol) is unreachable for package-authored loaders —
- *     plain rows never carry it — so computed deps derive from the `select`
- *     declaration alone.
- *   - Reference-preservation bookkeeping (fate's `assignIfChanged`) is
- *     skipped: the walk always rebuilds through masking, so identity is
- *     wire-invisible.
  */
 import {FateRequestError} from "@nkzw/fate/server";
 import {Effect, Exit, Request, RequestResolver} from "effect";
@@ -111,7 +27,6 @@ import {internalArm} from "./WireError.ts";
 
 type AnyRow = Record<string, unknown>;
 
-/** The operation-level args bag the walk threads to view callbacks. */
 type WalkArgs = {readonly [key: string]: unknown} | undefined;
 
 /** fate's `isRecord`, exactly (arrays excluded). */
@@ -247,8 +162,8 @@ const buildSelectionPlan = (view: ViewLike, select: ReadonlyArray<string>): Sele
 /**
  * fate's `toProtocolError` mask for walk-internal throws: a
  * `FateRequestError` keeps itself; anything else is fate's OWN internal arm.
- * (These errors never pass through `encodeWireError` in fate — see the
- * module doc's taxonomy.)
+ * (These errors never pass through `encodeWireError` in fate — the taxonomy
+ * is in `.patterns/fate-effect-interpreter.md`.)
  */
 const walkError = (error: unknown): FateRequestError =>
 	error instanceof FateRequestError ? error : internalArm();
@@ -270,8 +185,9 @@ const callViewFunction = (
 		: Effect.fail(internalArm());
 
 /**
- * fate's `getComputedDeps`, minus the hidden computed-state read (module-doc
- * divergence): `count` selections read `_count.<relation>` (default 0),
+ * fate's `getComputedDeps`, minus the hidden computed-state read (a divergence
+ * documented in `.patterns/fate-effect-interpreter.md`): `count` selections
+ * read `_count.<relation>` (default 0),
  * field selections read their dotted path.
  */
 const getComputedDeps = (item: AnyRow, select: unknown): AnyRow => {

--- a/packages/fate-effect/src/WireError.ts
+++ b/packages/fate-effect/src/WireError.ts
@@ -1,8 +1,9 @@
 /**
- * The `FateWireCode` annotation key and the wire-error codec.
+ * The `FateWireCode` annotation key and the wire-error codec. See ADR 0241.
  *
- * One edit per domain error, no registry: a feature defines its error class
- * with the wire code attached as a schema annotation —
+ * One edit per domain error, no registry: a feature attaches its wire code as
+ * a schema annotation and {@link encodeWireError} derives the wire error from
+ * it —
  *
  * ```ts
  * class BodyRequired extends Schema.TaggedErrorClass<BodyRequired>()(
@@ -12,29 +13,15 @@
  * ) {}
  * ```
  *
- * — and {@link encodeWireError} derives the fate wire error
- * (`FateRequestError`, serialized by fate as `{ok: false, error: {code,
- * message}}`) from the annotation. This replaces the bridge's hand-maintained
- * `WIRE_CODE_BY_TAG` registry (three edits per error) with the class
- * declaration itself.
- *
  * Annotations are the documented effect extension point: effect-smol
- * `Schema.ts` › `Annotations` namespace ("Defining your own annotations")
- * shows exactly this shape — a custom string key declared via module
- * augmentation, attached at definition time, read back at runtime. A
+ * `Schema.ts` › `Annotations` namespace ("Defining your own annotations"). A
  * `Schema.TaggedErrorClass`'s annotations land on the class's static
  * `ast.annotations`, so the codec reads them off `instance.constructor` with
  * structural guards — no registry lookup, no type assertion.
  *
- * Failure taxonomy on the wire:
- *
- *   - **annotated error** → its annotated code + its own `message`. Declared
- *     domain errors are user-facing by definition.
- *   - **un-annotated error / defect** → {@link INTERNAL_WIRE_CODE} with a
- *     fixed message. Defects are bugs or infra failures; their details
- *     (driver errors, stack fragments) never leak onto the wire.
- *   - **`FateRequestError`** → passed through verbatim, the escape hatch for
- *     code that already speaks the wire shape (parity with the bridge).
+ * Defect details (driver errors, stack fragments) never leak onto the wire:
+ * anything un-annotated encodes to {@link INTERNAL_WIRE_CODE} plus a fixed
+ * message.
  */
 import {FateRequestError} from "@nkzw/fate/server";
 import * as Cause from "effect/Cause";
@@ -42,91 +29,59 @@ import * as Option from "effect/Option";
 import * as Predicate from "effect/Predicate";
 
 /**
- * The annotation key. Declared on `Schema.Annotations.Annotations` below so
- * definition sites get `string | undefined` typing for the value. The constant
- * is `FateWireCode` — the one canonical noun for this concept across the
- * worker↔SPA seam (#851, #1032); the string value stays `fate-effect/wireCode`
- * because it is the augmentation key the annotation is stored under.
+ * The annotation key. The string value must stay `fate-effect/wireCode` — it
+ * is the augmentation key the annotation is stored under below.
  */
 export const FateWireCode = "fate-effect/wireCode";
 
 declare module "effect/Schema" {
 	namespace Annotations {
 		interface Annotations {
-			/**
-			 * The fate wire `code` this error class maps to. Set it on a
-			 * `Schema.TaggedErrorClass` via the `FateWireCode` key; the
-			 * fate-effect codec derives the wire error from it.
-			 */
 			readonly "fate-effect/wireCode"?: string | undefined;
 		}
 	}
 }
 
 /**
- * The wire code for everything that is not a declared, annotated error:
- * un-annotated failures and defects. `INTERNAL_SERVER_ERROR` (not fate's
- * protocol `INTERNAL_ERROR`) on purpose — it is the code phoenix's bridge has
- * always emitted and the SPA's `FATE_WIRE_CODES` contract decodes, so
- * the package stays wire-identical with what the SPA expects.
+ * `INTERNAL_SERVER_ERROR`, not fate's protocol `INTERNAL_ERROR`, on purpose —
+ * this is the code the SPA's `FATE_WIRE_CODES` contract decodes.
  */
 export const INTERNAL_WIRE_CODE = "INTERNAL_SERVER_ERROR";
 
-/** The fixed internal-error message — defect details never reach the wire. */
 const INTERNAL_WIRE_MESSAGE = "Something went wrong.";
 
 /**
- * fate's OWN internal arm (`toProtocolError`'s fallback): `INTERNAL_ERROR` /
- * "Internal server error.". Distinct from {@link INTERNAL_WIRE_CODE} — that is
- * the annotation codec's arm for per-operation failures; THIS is what fate
- * spells for walk-internal throws and request-level defects. The bytes are
- * pinned by the walk oracle, and this is the ONE construction site — the walk
- * (`Walk.ts`), the connection plane (`Connection.ts`), and the interpreter's
- * request-level fallback (`Interpreter.ts`) all derive from it, so the pinned
- * bytes cannot drift between arms. Package-wide error taxonomy,
- * which is why it lives here and not in the pagination plane.
+ * fate's OWN internal arm, distinct from {@link INTERNAL_WIRE_CODE}: what fate
+ * spells for walk-internal throws and request-level defects. These bytes are
+ * pinned by the walk oracle, and this is the ONE construction site — `Walk.ts`,
+ * `Connection.ts` and `Interpreter.ts` all derive from it so the arms cannot
+ * drift apart.
  */
 export const internalArm = (): FateRequestError =>
 	new FateRequestError("INTERNAL_ERROR", "Internal server error.");
 
-/**
- * The failed/thrown value behind a `Cause` — the v1 compiler's exact branch
- * (`runResolve`): the typed failure if one exists, otherwise the squashed
- * defect. Shared here because both call sites — the interpreter's
- * dispatch loop and the oracle baseline's `runResolve` — feed the result
- * straight into {@link encodeWireError}.
- */
+/** The typed failure behind a `Cause` if there is one, else the squashed defect. */
 export const failureOf = (cause: Cause.Cause<unknown>): unknown =>
 	Option.match(Cause.findErrorOption(cause), {
 		onSome: (error) => error,
 		onNone: () => Cause.squash(cause),
 	});
 
-/**
- * The exact type of `FateRequestError`'s `code` constructor parameter (fate's
- * closed 6-member `FateProtocolErrorCode`, which the package doesn't export
- * by name). Captured structurally so {@link makeWireError} can widen into it.
- */
+/** fate's closed `FateProtocolErrorCode`, which it doesn't export by name. */
 type FateProtocolErrorCode = ConstructorParameters<typeof FateRequestError>[0];
 
 /**
- * Construct a `FateRequestError` with a phoenix wire code. fate types the
- * constructor's `code` as its narrow 6-member protocol union, but at runtime
- * it stores whatever string it is given and forwards it on the wire
- * untouched; phoenix's wire vocabulary (`BODY_REQUIRED`, `TAKEN`, …) is
- * wider. A single comparable narrowing cast to the parameter's own type —
- * the same documented widening the retired bridge used — not a laundering
- * double-cast.
+ * The cast is deliberate: fate types `code` as its narrow protocol union but at
+ * runtime stores and forwards whatever string it is given, and phoenix's wire
+ * vocabulary (`BODY_REQUIRED`, `TAKEN`, …) is wider.
  */
 function makeWireError(code: string, message: string): FateRequestError {
 	return new FateRequestError(code as FateProtocolErrorCode, message);
 }
 
 /**
- * Read the `FateWireCode` annotation off an error *class* (or anything —
- * non-classes and un-annotated classes yield `undefined`). A schema class's
- * annotations live on its static `ast.annotations`; everything here is
- * structural guarding, so arbitrary values are safe inputs.
+ * A schema class's annotations live on its static `ast.annotations`. Structural
+ * guarding throughout, so arbitrary values are safe inputs.
  */
 export function wireCodeOfClass(ctor: unknown): string | undefined {
 	if (typeof ctor !== "function") return undefined;
@@ -139,19 +94,12 @@ export function wireCodeOfClass(ctor: unknown): string | undefined {
 	return typeof code === "string" ? code : undefined;
 }
 
-/**
- * Read the `FateWireCode` annotation off an error *instance*, via its
- * constructor. `undefined` for primitives and un-annotated values.
- */
 export function wireCodeOf(value: unknown): string | undefined {
 	if (typeof value !== "object" || value === null) return undefined;
 	return wireCodeOfClass(value.constructor);
 }
 
-/**
- * Map any failed/thrown value onto the fate wire error. Total: never throws,
- * regardless of input. See the module header for the failure taxonomy.
- */
+/** Total: never throws, whatever the input. */
 export function encodeWireError(error: unknown): FateRequestError {
 	if (error instanceof FateRequestError) return error;
 

--- a/packages/fate-effect/src/WireError.unit.test.ts
+++ b/packages/fate-effect/src/WireError.unit.test.ts
@@ -1,20 +1,9 @@
 /**
  * Unit — the `FateWireCode` annotation key and the wire-error codec.
  *
- * The contract under test — define a domain error once with an `FateWireCode`
- * annotation on the error class and have the wire codec derived from it,
- * one edit instead of three:
- *
- *   1. Annotating a `Schema.TaggedErrorClass` with `FateWireCode` is
- *      *sufficient* for {@link encodeWireError} to produce the correct wire
- *      code + message. No registry, no second edit.
- *   2. Un-annotated errors and defects (arbitrary thrown values) map to the
- *      internal-error wire code without throwing — and without leaking the
- *      original value's details onto the wire.
- *   3. The enumeration suite at the bottom pins every error-class ↔ wire-code
- *      pair the package ships, so silent codec drift is impossible: shipping a
- *      new annotated class (or changing a code) fails the pin until the table
- *      row is updated.
+ * The contract: annotating the error class is SUFFICIENT — no registry, no
+ * second edit. Everything un-annotated collapses to the internal code without
+ * leaking details.
  */
 import {FateRequestError} from "@nkzw/fate/server";
 import * as Schema from "effect/Schema";
@@ -28,21 +17,18 @@ import {
 	wireCodeOfClass,
 } from "./WireError.ts";
 
-/** A representative annotated domain error — the one-edit authoring shape. */
 class BodyRequired extends Schema.TaggedErrorClass<BodyRequired>()(
 	"test/BodyRequired",
 	{message: Schema.String},
 	{[FateWireCode]: "BODY_REQUIRED"},
 ) {}
 
-/** An annotated error with extra fields beyond `message`. */
 class DefinitionNotFound extends Schema.TaggedErrorClass<DefinitionNotFound>()(
 	"test/DefinitionNotFound",
 	{definitionId: Schema.String, message: Schema.String},
 	{[FateWireCode]: "DEFINITION_NOT_FOUND"},
 ) {}
 
-/** A tagged error WITHOUT the annotation — must fall back to internal. */
 class Unannotated extends Schema.TaggedErrorClass<Unannotated>()("test/Unannotated", {
 	message: Schema.String,
 }) {}

--- a/packages/fate-effect/src/index.ts
+++ b/packages/fate-effect/src/index.ts
@@ -1,14 +1,9 @@
 /**
- * `@kampus/fate-effect` — phoenix's Effect-native fate integration: fate's
- * record shapes with Effect semantics. Ships the views, the wire-error
- * codec, the `Fate.*` entry constructors, the `FateServer`
- * tag/config/layer, and the v2 native plane that serves `/fate` (ADR 0043);
- * the v1 compile step (`FateExecutor`) survives as the differential
- * oracle's baseline and the build-time codegen surface.
+ * `@kampus/fate-effect` — phoenix's Effect-native fate integration (ADR 0043).
  *
- * Exports stay flat (every supporting type a consumer's exported value can
- * surface must be nameable through this barrel); the `Fate` namespace is the
- * authoring surface layered over the same flat members.
+ * Exports stay flat: every supporting type a consumer's exported value can surface must be
+ * nameable through this barrel. The `Fate` namespace is the authoring surface layered over
+ * the same flat members.
  */
 import {toCodegenServer} from "./Codegen.ts";
 import {compile, toFetchHandler} from "./Executor.ts";
@@ -144,14 +139,10 @@ export {
 } from "./WireError.ts";
 
 /**
- * The compile-step namespace: `compile`/`toFetchHandler` — the differential
- * oracle's baseline (`Executor.ts`, test-harness-only since ADR 0043) — and
- * `toCodegenServer` — the build-time codegen surface (`Codegen.ts`, what
- * `schema.ts` exports for Vite codegen). Assembled HERE so the frozen
- * oracle-baseline module and the production codegen module never import
- * each other (they share internals through `Compiled.ts` only), while the
- * public spelling (`FateExecutor.toCodegenServer` in `schema.ts`) stays
- * exactly what it was before the split.
+ * Assembled HERE so the frozen oracle-baseline module (`Executor.ts`, test-harness-only since
+ * ADR 0043) and the production codegen module (`Codegen.ts`) never import each other — they
+ * share internals through `Compiled.ts` only — while `FateExecutor.toCodegenServer` keeps the
+ * spelling it had before the split.
  */
 export const FateExecutor = {
 	compile,

--- a/packages/fate-effect/vitest.config.ts
+++ b/packages/fate-effect/vitest.config.ts
@@ -1,11 +1,5 @@
-/**
- * Vitest config — the package hosts unit + integration tests (ADR 0082): pure
- * logic in colocated `*.unit.test.ts` files, plus the layer-construction and
- * compiled-server suites (`Server.test.ts`, `Executor.test.ts`) that build
- * real runtimes over in-memory fixtures — no external storage. Integration
- * coverage of the worker's fate server lives in `@kampus/web`, where the worker
- * layer and test databases are.
- */
+// The suites here build real runtimes over in-memory fixtures — no external
+// storage. Real-D1 coverage of the fate server lives in `@kampus/web` (ADR 0082).
 import {defineConfig} from "vitest/config";
 
 export default defineConfig({

--- a/packages/orphan-sweep/src/bin.ts
+++ b/packages/orphan-sweep/src/bin.ts
@@ -2,11 +2,8 @@
 /**
  * `orphan-sweep sweep` — the operable surface for the integration-stage leak (#690).
  *
- * Lists the account's Worker + D1 + Flagship app/flag resources and the repo's open PRs
- * (behind the injectable `Cloudflare` / `Github` services so the pure core stays IO-free),
- * computes the deletion plan via `computeSweepPlan`, prints it, and — ONLY with `--execute`
- * — deletes the planned set. DRY-RUN by default: with no flag it prints what it WOULD
- * delete and exits 0 without touching the account.
+ * DRY-RUN by default: with no flag it prints what it WOULD delete and exits 0 without touching the
+ * account. Only `--execute` deletes.
  *
  * The catastrophe guard lives in the pure core (`orphan-sweep.ts`): prod, named-dev
  * (`--protect` AND the `dev`/`dev-*` shape), and open-PR resources are NEVER in the plan,
@@ -15,10 +12,6 @@
  * #2340) — across all resource kinds, the Flagship apps/flags included. Credentials
  * come from the environment at runtime (`$CLOUDFLARE_API_TOKEN` / `$CLOUDFLARE_ACCOUNT_ID`),
  * never from source.
- *
- * Wired per effect-smol's CLI guidance: `effect/unstable/cli`
- * for typed args/flags, the live `Cloudflare` + `Github` provided over `NodeServices.layer`
- * (supplying `ChildProcessSpawner`), run via `NodeRuntime.runMain`.
  */
 import {NodeRuntime, NodeServices} from "@effect/platform-node";
 import {Console, Effect, Layer} from "effect";
@@ -32,7 +25,6 @@ const executeFlag = Flag.boolean("execute").pipe(
 	Flag.withDescription("actually delete the planned resources (default: dry-run, print only)"),
 );
 
-// `atLeast(0)` makes `--protect` a 0-or-more repeated flag yielding `string[]`.
 const protectFlag = Flag.string("protect").pipe(
 	Flag.atLeast(0),
 	Flag.withDescription("a named-dev stage to NEVER sweep (repeatable); prod is always protected"),
@@ -66,7 +58,6 @@ const sweep = Command.make(
 		const openPrNumbers = yield* github.openPrNumbers();
 
 		const protection: Protection = {
-			// `prod` is always protected, on top of any `--protect` named-dev stages.
 			protectedStages: ["prod", ...protect],
 			openPrNumbers,
 			sweepClosedPreviews,

--- a/packages/orphan-sweep/src/cloudflare.ts
+++ b/packages/orphan-sweep/src/cloudflare.ts
@@ -1,16 +1,8 @@
 /**
  * The Cloudflare boundary: list the account's Worker scripts + D1 databases + Flagship
  * apps/flags, and (only when the bin asks) delete one. Shells the CF REST API via `curl` over
- * `ChildProcessSpawner` — the SAME transport `.github/workflows/deploy.yml` uses for
- * its `/d1/database?name=` lookup, and the same boundary shape `src/github.ts` uses for
- * `gh`. REST only; Schema decodes the untrusted envelope
- * at the trust boundary (`.patterns/effect-schema-validation.md`); every infra fault is
- * a typed error in the `E` channel (`.patterns/effect-errors.md`).
- *
- * Credentials come from the environment at runtime, NEVER from source: `$CLOUDFLARE_API_TOKEN`
- * (the minted, rotatable CI token) and `$CLOUDFLARE_ACCOUNT_ID`. The pure core
- * (`orphan-sweep.ts`) computes the plan; this shell only fetches the inputs and, with
- * `--execute`, performs the deletes the plan named.
+ * `ChildProcessSpawner`, the same boundary shape `src/github.ts` uses for `gh`. Credentials
+ * come from the environment at runtime, never from source.
  */
 import {Config, Context, Effect, Layer, Schedule, Stream} from "effect";
 import * as Schema from "effect/Schema";
@@ -19,7 +11,6 @@ import {type CfResource, FLAGSHIP_APP_NAME_PREFIX} from "./orphan-sweep.ts";
 
 const CF_API = "https://api.cloudflare.com/client/v4";
 
-/** A `curl`/CF call failed at the process level (network, auth header, non-zero exit). */
 export class CfCommandError extends Schema.TaggedErrorClass<CfCommandError>()(
 	"@kampus/orphan-sweep/CfCommandError",
 	{
@@ -29,7 +20,6 @@ export class CfCommandError extends Schema.TaggedErrorClass<CfCommandError>()(
 	},
 ) {}
 
-/** `curl` output was not the JSON the loader expected. */
 export class CfParseError extends Schema.TaggedErrorClass<CfParseError>()(
 	"@kampus/orphan-sweep/CfParseError",
 	{
@@ -48,12 +38,9 @@ export class CfApiError extends Schema.TaggedErrorClass<CfApiError>()(
 ) {}
 
 /**
- * The CF API returned a non-2xx HTTP status. Carries the status code AND the response
- * body so a genuine failure reports WHAT failed (e.g. a 429 rate-limit, a 403 scope
- * error + its CF error JSON) instead of the opaque empty `CfCommandError` `curl -f`
- * produced (`-s` suppressed the body, `-f` discarded it). `retryable` is set for the
- * transient statuses the fan-out retries (429 + 5xx). No argv is captured here, so there
- * is nothing to redact — `endpoint` is the token-free URL and `body` is the CF response.
+ * A non-2xx HTTP status, carrying the body so a failure reports WHAT failed instead of the
+ * opaque empty `CfCommandError` `curl -f` produced (#1506). No argv is captured, so there is
+ * nothing to redact.
  */
 export class CfHttpError extends Schema.TaggedErrorClass<CfHttpError>()(
 	"@kampus/orphan-sweep/CfHttpError",
@@ -65,7 +52,6 @@ export class CfHttpError extends Schema.TaggedErrorClass<CfHttpError>()(
 	},
 ) {}
 
-/** No account id / token could be resolved from the environment. */
 export class CfCredentialsError extends Schema.TaggedErrorClass<CfCredentialsError>()(
 	"@kampus/orphan-sweep/CfCredentialsError",
 	{
@@ -80,11 +66,8 @@ const CfError = Schema.Union([
 	CfHttpError,
 	CfCredentialsError,
 ]);
-// The methods also surface `ConfigError` (resolving env creds) and Schema's `SchemaError`
-// (decoding the CF envelope) — both infra faults, kept in the typed `E` channel.
 type CfError = (typeof CfError)["Type"] | Config.ConfigError | Schema.SchemaError;
 
-// The CF list envelopes, lenient on every field but the name.
 const ScriptListResponse = Schema.Struct({
 	success: Schema.Boolean,
 	errors: Schema.Array(Schema.Unknown),
@@ -97,10 +80,8 @@ const D1ListResponse = Schema.Struct({
 	result: Schema.NullOr(Schema.Array(Schema.Struct({uuid: Schema.String, name: Schema.String}))),
 });
 
-// Flagship list envelopes (the standard CF `{success, errors, result}` wrapper). Grounded
-// in `@distilled.cloud/cloudflare/flagship` (the SDK alchemy's FlagshipApp/Flag resource
-// uses): apps carry `{id, name}` (id = the appId delete-key, name = the physical name that
-// carries the stage), flags carry `{key}`. Lenient on every field but the ones we key on.
+// Grounded in `@distilled.cloud/cloudflare/flagship` (the SDK alchemy's FlagshipApp/Flag
+// resource uses): `id` is the appId delete-key, `name` the physical name carrying the stage.
 const FlagshipAppListResponse = Schema.Struct({
 	success: Schema.Boolean,
 	errors: Schema.Array(Schema.Unknown),
@@ -126,18 +107,13 @@ const collect = (stream: Stream.Stream<Uint8Array, unknown>): Effect.Effect<stri
 
 const AUTH_HEADER_PREFIX = "Authorization: Bearer ";
 
-// Strip the bearer token before the argv is STORED on an error. The real argv (with the
-// live token) still goes to curl; only the loggable copy captured on CfCommandError /
-// CfParseError is redacted, so a routine curl/parse fault rendered by runMain's logError
-// (util.inspect of the error fields) can never leak the token. The header pair is kept —
-// just its value masked — so diagnostics still show an auth header was present.
+// Strip the bearer token before the argv is STORED on an error: the live argv still goes to
+// curl, but runMain's logError inspects error fields, so a stored raw token would leak.
 const redactArgs = (args: ReadonlyArray<string>): ReadonlyArray<string> =>
 	args.map((arg) => (arg.startsWith(AUTH_HEADER_PREFIX) ? `${AUTH_HEADER_PREFIX}[REDACTED]` : arg));
 
-// `curl -w` appends this marker + the HTTP status to stdout AFTER the body, so a single
-// stdout stream carries both. We split on the LAST occurrence: everything after it is the
-// status code, everything before is the response body. The marker leads with a newline and
-// a fixed sentinel a JSON envelope never contains, so the split is unambiguous.
+// `curl -w` appends this marker + the HTTP status to stdout AFTER the body, so one stream
+// carries both. Split on the LAST occurrence; the sentinel never appears in a JSON envelope.
 const HTTP_STATUS_MARKER = "\nHTTP_STATUS:";
 
 const splitStatus = (raw: string): {body: string; status: number} => {
@@ -149,15 +125,9 @@ const splitStatus = (raw: string): {body: string; status: number} => {
 	return {body: raw.slice(0, idx), status: Number.isNaN(status) ? 0 : status};
 };
 
-/**
- * Run `curl <args>` and return the response body + HTTP status, lowering a non-zero exit
- * (or a spawn `PlatformError`) into `CfCommandError`. Mirrors `src/github.ts`'s `runGh`.
- *
- * Because `curlArgs` drops `-f`, a non-zero exit here now means a genuine PROCESS-level
- * fault (DNS, connection refused, timeout) — an HTTP error (4xx/5xx) keeps `curl` at exit 0
- * and travels in-band as `status`, so the caller (`runCurlOk`) can surface it WITH its body
- * instead of the opaque empty error `-f` produced.
- */
+// Because `curlArgs` drops `-f`, a non-zero exit here means a PROCESS-level fault (DNS,
+// connection refused, timeout); an HTTP error keeps curl at exit 0 and travels in-band as
+// `status`.
 const runCurl = Effect.fn("Cloudflare.runCurl")(
 	function* (args: ReadonlyArray<string>) {
 		const handle = yield* ChildProcess.make("curl", args);
@@ -192,12 +162,9 @@ const parseJson = (
 			}),
 	});
 
-// The flags every call shares. `-s` keeps the progress meter off stdout. `-f` is
-// DELIBERATELY ABSENT (it was the #1506 defect): under `-f`, curl exits non-zero AND
-// discards the body on any HTTP error, so a transient 429 mid-fan-out aborted the whole
-// list as an opaque empty `CfCommandError`. Instead we let curl exit 0 on an HTTP error and
-// capture the status in-band via `-w` (appended after the body), so `runCurlOk` can decide
-// retry-vs-surface on the real status + body.
+// `-f` is DELIBERATELY ABSENT (it was the #1506 defect): under `-f`, curl exits non-zero AND
+// discards the body on any HTTP error, so a transient 429 mid-fan-out aborted the whole list
+// as an opaque empty `CfCommandError`. The status comes back in-band via `-w` instead.
 const curlArgs = (token: string, method: string, url: string): ReadonlyArray<string> => [
 	"-s",
 	"-w",
@@ -209,32 +176,20 @@ const curlArgs = (token: string, method: string, url: string): ReadonlyArray<str
 	`Authorization: Bearer ${token}`,
 ];
 
-// Transient HTTP statuses worth retrying: 429 (rate limit — the #1506 trigger across the
-// ~210-app fan-out) and the 5xx gateway/overload family.
+// 429 was the #1506 trigger across the ~210-app fan-out.
 const RETRYABLE_STATUSES = new Set([429, 500, 502, 503, 504]);
 
 const isRetryableCfHttp = (error: unknown): boolean =>
 	error instanceof CfHttpError && error.retryable;
 
-/**
- * Capped, jittered exponential backoff: ~0.5s, 1, 2, 4, 8s across up to 5 retries (6
- * attempts total), `jittered` to spread the per-app retries so the fan-out doesn't
- * synchronize into a second rate-limit spike. Grounded in effect-smol `LLMS.md`
- * §"Working with Schedules" (`ai-docs/src/06_schedule/10_schedules.ts`):
- * `Schedule.both(exponential, recurs(N))` is capped backoff, mirroring
- * `apps/web/worker/features/fate-live/cold-start-retry.ts`.
- */
+// `jittered` spreads the per-app retries so the fan-out doesn't synchronize into a second
+// rate-limit spike. `Schedule.both(exponential, recurs(N))` as capped backoff is grounded in
+// effect-smol `LLMS.md` §"Working with Schedules" (`ai-docs/src/06_schedule/10_schedules.ts`).
 const cfRetrySchedule = Schedule.jittered(
 	Schedule.both(Schedule.exponential("500 millis"), Schedule.recurs(5)),
 );
 
-/**
- * Run a CF call and enforce a 2xx: a retryable HTTP status (429/5xx) becomes a retryable
- * `CfHttpError`, any other non-2xx surfaces its status + body, and `allow`ed statuses (e.g.
- * a 404 on an idempotent delete) fold to success. The whole thing is wrapped in the bounded
- * backoff `Effect.retry({schedule, while})` — the documented effect-smol retry idiom — so a
- * transient 429 is re-driven instead of aborting the list (#1506).
- */
+// `allow`ed statuses (e.g. a 404 on an idempotent delete) fold to success.
 const runCurlOk = (
 	endpoint: string,
 	args: ReadonlyArray<string>,
@@ -252,12 +207,7 @@ const runCurlOk = (
 		Effect.retry({schedule: cfRetrySchedule, while: isRetryableCfHttp}),
 	);
 
-/**
- * `Cloudflare` — the IO shell. `listResources` returns every Worker script + D1 db +
- * Flagship app/flag on the account as `CfResource[]` (the pure core's input);
- * `deleteResource` removes one (called only on `--execute`, for resources the plan already
- * vetted). Built by `CloudflareLive`, whose `R` is `ChildProcessSpawner`.
- */
+// `deleteResource` is called only on `--execute`, for resources the plan already vetted.
 export class Cloudflare extends Context.Service<
 	Cloudflare,
 	{
@@ -287,8 +237,8 @@ const listWorkers = Effect.fn("Cloudflare.listWorkers")(function* (creds: Creds)
 });
 
 const listD1 = Effect.fn("Cloudflare.listD1")(function* (creds: Creds) {
-	// `?per_page=1000` lifts the default page so a busy account's it-* dbs aren't paged
-	// out of the first page (the leak this sweep bounds is exactly an accumulation).
+	// `?per_page=1000` lifts the default page so a busy account's it-* dbs aren't paged out
+	// of the first page — the leak this sweep bounds is exactly an accumulation.
 	const url = `${CF_API}/accounts/${creds.accountId}/d1/database?per_page=1000`;
 	const args = curlArgs(creds.token, "GET", url);
 	const decoded = yield* decodeD1(yield* parseJson(args, yield* runCurlOk(url, args)));
@@ -297,22 +247,14 @@ const listD1 = Effect.fn("Cloudflare.listD1")(function* (creds: Creds) {
 });
 
 /**
- * List Flagship apps + their flags as `CfResource[]`. Apps enumerate via
- * `GET /accounts/{acct}/flagship/apps`; flags are a per-app sub-resource
- * (`GET /accounts/{acct}/flagship/apps/{appId}/flags`) with no account-wide endpoint, so
- * we fan out one flag-list per app — but ONLY for apps whose physical name carries our
- * `phoenix-phoenix-flags-` prefix, so a foreign account app never costs an extra call.
- * Every app is still emitted as a `flagship-app` resource (a foreign one is kept
- * `unrecognized` by the pure core, exactly like a foreign worker).
+ * Flags have no account-wide endpoint, so this fans out one flag-list per app — but only for
+ * apps carrying our name prefix, so a foreign app never costs an extra call.
  *
  * Each app's flags are emitted BEFORE the app itself, so the bin's in-order delete loop
- * removes a stage's flags before its parent app — a flag delete needs the app to still
- * exist (its path is `apps/{appId}/flags/{key}`), and deleting the app may cascade its
- * flags.
+ * removes a stage's flags before its parent app: a flag delete needs the app to still exist.
  */
 const listFlagship = Effect.fn("Cloudflare.listFlagship")(function* (creds: Creds) {
-	// `?per_page=1000` lifts the default page so an account accumulating leaked preview apps
-	// isn't paged out of the first page (the leak this sweep bounds is exactly accumulation).
+	// `?per_page=1000` lifts the default page — see `listD1`.
 	const appsUrl = `${CF_API}/accounts/${creds.accountId}/flagship/apps?per_page=1000`;
 	const appsArgs = curlArgs(creds.token, "GET", appsUrl);
 	const apps = yield* decodeFlagshipApps(
@@ -325,12 +267,9 @@ const listFlagship = Effect.fn("Cloudflare.listFlagship")(function* (creds: Cred
 		if (app.name.startsWith(FLAGSHIP_APP_NAME_PREFIX)) {
 			const flagsUrl = `${CF_API}/accounts/${creds.accountId}/flagship/apps/${app.id}/flags?per_page=1000`;
 			const flagsArgs = curlArgs(creds.token, "GET", flagsUrl);
-			// `allow: [404]` keeps a flags-sub-resource 404 (an app present in the apps list but
-			// mid-deletion / in a no-flags state) from aborting the whole ~210-app fan-out (#1506):
-			// the 404 envelope (`success:false`, `result:null`) folds to ZERO flags. Only a 2xx
-			// (CF returns `success:true`) or that tolerated 404 reaches the decode — any other
-			// non-2xx already surfaced as a `CfHttpError` in `runCurlOk` — so `result ?? []` is the
-			// empty flag set, and the app itself is still emitted as a `flagship-app` below.
+			// `allow: [404]` keeps a flags 404 (app mid-deletion, or no flags) from aborting the
+			// whole ~210-app fan-out (#1506): its `result:null` envelope folds to zero flags, and
+			// the app is still emitted below.
 			const flags = yield* decodeFlagshipFlags(
 				yield* parseJson(flagsArgs, yield* runCurlOk(flagsUrl, flagsArgs, {allow: [404]})),
 			);
@@ -348,14 +287,9 @@ const listFlagship = Effect.fn("Cloudflare.listFlagship")(function* (creds: Cred
 	return resources;
 });
 
-/**
- * Delete one resource. A worker is keyed by its script name (= its physical name); a D1
- * must be deleted by UUID, so we re-resolve the uuid by name first (the list result
- * carries it, but the plan only carries names to keep the core pure). A Flagship app
- * deletes by its server `appId`, a flag by `(appId, key)` — both already on the resource.
- * Deletes are idempotent-ish: a 404 (already gone) folds to success so a re-run after a
- * partial sweep is safe.
- */
+// A D1 deletes by UUID, so `deleteD1` re-resolves the uuid by name: the plan carries only
+// names, to keep the core pure. Every delete folds a 404 to success, so a re-run after a
+// partial sweep is safe.
 const deleteWorker = Effect.fn("Cloudflare.deleteWorker")(function* (creds: Creds, name: string) {
 	const url = `${CF_API}/accounts/${creds.accountId}/workers/scripts/${name}`;
 	yield* runCurlOk(url, curlArgs(creds.token, "DELETE", url), {allow: [404]});
@@ -367,7 +301,7 @@ const deleteD1 = Effect.fn("Cloudflare.deleteD1")(function* (creds: Creds, name:
 	const decoded = yield* decodeD1(yield* parseJson(listArgs, yield* runCurlOk(listUrl, listArgs)));
 	const match = (decoded.result ?? []).find((d) => d.name === name);
 	if (match === undefined) {
-		return; // already gone — idempotent
+		return;
 	}
 	const url = `${CF_API}/accounts/${creds.accountId}/d1/database/${match.uuid}`;
 	yield* runCurlOk(url, curlArgs(creds.token, "DELETE", url), {allow: [404]});
@@ -392,10 +326,8 @@ const deleteFlagshipFlag = Effect.fn("Cloudflare.deleteFlagshipFlag")(function* 
 
 const resolveCreds = Effect.gen(function* () {
 	const accountId = yield* Config.string("CLOUDFLARE_ACCOUNT_ID").pipe(Config.option);
-	// Read as a string (not Redacted): the token is spliced into the live curl argv, but
-	// every error that CAPTURES that argv stores a `redactArgs`-masked copy (the auth header
-	// value → `[REDACTED]`), so the raw token never reaches a logged/rendered error field —
-	// even when runMain's logError inspects the failing error.
+	// Read as a string (not Redacted) because the token is spliced into the live curl argv;
+	// every error that captures that argv stores a `redactArgs`-masked copy instead.
 	const token = yield* Config.string("CLOUDFLARE_API_TOKEN").pipe(Config.option);
 	if (accountId._tag === "None" || token._tag === "None") {
 		return yield* new CfCredentialsError({
@@ -406,13 +338,8 @@ const resolveCreds = Effect.gen(function* () {
 	return {accountId: accountId.value, token: token.value};
 });
 
-/**
- * The live `Cloudflare` layer. Mirrors this package's `GithubLive`: the
- * `ChildProcessSpawner` is captured at construction and provided into each method (so
- * public methods carry `R = never`); credentials are resolved once, lazily (the layer
- * build is side-effect-free, so `--help` never reads the env). Provide `NodeServices.layer`
- * to satisfy the spawner.
- */
+// Credentials resolve once and lazily, so the layer build stays side-effect-free and
+// `--help` never reads the env.
 export const CloudflareLive: Layer.Layer<
 	Cloudflare,
 	never,

--- a/packages/orphan-sweep/src/github.ts
+++ b/packages/orphan-sweep/src/github.ts
@@ -104,10 +104,6 @@ const resolveRepo = Effect.fn("Github.resolveRepo")(function* () {
 	});
 });
 
-/**
- * `Github` — reads the OPEN PR numbers (the `pr-<n>` previews the sweep must keep).
- * Built by `GithubLive`, whose `R` is `ChildProcessSpawner`. Read-only.
- */
 export class Github extends Context.Service<
 	Github,
 	{
@@ -134,10 +130,6 @@ const loadOpenPrs = Effect.fn("Github.openPrNumbers")(function* (repo: string) {
  */
 const normalizePaginatedJson = (raw: string): string => raw.replaceAll("][", ",");
 
-/**
- * The live `Github` layer: spawner captured at construction, repo resolution
- * `Effect.cached` and deferred to first use.
- */
 export const GithubLive: Layer.Layer<Github, never, ChildProcessSpawner.ChildProcessSpawner> =
 	Layer.effect(Github)(
 		Effect.gen(function* () {

--- a/packages/orphan-sweep/src/index.ts
+++ b/packages/orphan-sweep/src/index.ts
@@ -1,14 +1,9 @@
 /**
- * `@kampus/orphan-sweep` — the orphan integration-stage sweep (part of issue #690). A
- * pure, unit-tested core (`orphan-sweep.ts`) that turns the live set of Cloudflare
- * resources + a protection set (prod, named-dev, open PRs) into a deletion plan that can
- * never touch a protected resource, plus a thin `effect/unstable/cli` bin (`bin.ts`,
- * DRY-RUN by default) that lists CF resources + open PRs behind injectable `Cloudflare`
- * / `Github` services and, with `--execute`, deletes the planned set.
+ * `@kampus/orphan-sweep` — the orphan integration-stage sweep. `bin.ts` is DRY-RUN by default
+ * and only deletes under `--execute`; the plan can never touch a protected resource.
  *
- * Bounds the unbounded leak the #689 run-unique stage names surfaced (#690): a partial
- * integration deploy's orphan `it-*` worker/D1 now accumulates on the shared CF account
- * with no upper bound; this sweep is that bound.
+ * Bounds the leak the #689 run-unique stage names surfaced (#690): a partial integration
+ * deploy's orphan `it-*` worker/D1 accumulates on the shared CF account with no upper bound.
  */
 export {Cloudflare, CloudflareLive} from "./cloudflare.ts";
 export {Github, GithubLive} from "./github.ts";

--- a/packages/orphan-sweep/src/orphan-sweep.ts
+++ b/packages/orphan-sweep/src/orphan-sweep.ts
@@ -6,14 +6,10 @@
  * boundary lives in `cloudflare.ts`/`github.ts`, and this module never deletes
  * anything itself.
  *
- * Why a leak exists (#690, carved out of #689): integration teardown is
- * `afterAll(destroy(...))`. A partial `beforeAll` deploy can orphan its remote D1; the
- * #689 run-unique stage names mean a later run never overwrites it, so orphans
- * ACCUMULATE on the one shared account. This sweep is the bound: it deletes the
- * ephemeral integration (`it-*`) resources, the preview (`pr-<n>`) resources of
- * CLOSED PRs, and — behind a separate opt-in — the stale `test`/`test-*` dev/test
- * stage resources (#2340), and protects everything else. The `dev`/`dev-*` named-dev
- * stages are deny-by-protection and never swept, flag or not.
+ * Why a leak exists: see #690 (carved out of #689). The sweep deletes ephemeral
+ * integration (`it-*`) resources, CLOSED-PR preview (`pr-<n>`) resources, and — behind a
+ * separate opt-in — stale `test`/`test-*` stage resources (#2340). `dev`/`dev-*`
+ * named-dev stages are deny-by-protection and never swept, flag or not.
  *
  * The safety property is the whole point. A sweep that deletes a prod, named-dev, or
  * open-PR resource is catastrophic and irreversible (ADR 0032: these are REAL remote
@@ -22,16 +18,9 @@
  */
 
 /**
- * A Cloudflare resource as listed at the boundary, reduced to what the plan needs — a
- * discriminated union so each kind carries exactly the identity its delete path needs and
- * nothing it doesn't (a flagship-flag can't exist without its parent app's id; a worker
- * never carries one). The pure core only ever reads the stage-bearing name; the extra
- * `appId`/`appName` coordinates are boundary delete-keys it ignores.
- *
- * Worker scripts and D1 databases leak by stage in their OWN physical name. Flagship
- * resources leak the same way per closed PR preview, but a flag's KEY is stage-invariant
- * (the same `key` declared on every stage's app — `apps/web/worker/features/flagship/resources.ts`),
- * so a flag's stage lives in its PARENT app's physical name (`appName`), never in `name`.
+ * A Cloudflare resource as listed at the boundary. The pure core only ever reads the
+ * stage-bearing name; the extra `appId`/`appName` coordinates are boundary delete-keys it
+ * ignores.
  */
 export type CfResource =
 	| {readonly kind: "worker"; readonly name: string}
@@ -51,9 +40,8 @@ export type CfResource =
 	  };
 
 /**
- * The protection set: the resources that must NEVER be deleted, expressed as the
- * stage-shaped facts the matcher needs. The plan is deny-by-default for anything that
- * matches a protected pattern, BEFORE any allow-pattern is consulted.
+ * The protection set. The plan is deny-by-default for anything that matches a protected
+ * pattern, BEFORE any allow-pattern is consulted.
  *
  * Physical name shape (grounded in `.github/workflows/deploy.yml` "Resolve web preview
  * D1 id" + `apps/web/alchemy.run.ts`): alchemy names a resource
@@ -93,7 +81,6 @@ export interface Protection {
 	readonly sweepDevTestStages: boolean;
 }
 
-/** Why a resource is in the plan — the audit trail, so the plan is never an opaque list. */
 export type DeleteReason = "orphan-integration" | "closed-preview" | "stale-dev-test";
 
 export type KeepReason =
@@ -107,7 +94,6 @@ export type KeepReason =
 export interface PlannedDelete {
 	readonly resource: CfResource;
 	readonly reason: DeleteReason;
-	/** The stage the physical name decoded to, for the report. */
 	readonly stage: string;
 }
 
@@ -129,8 +115,6 @@ const D1_PREFIX = `${STACK}-${STACK}-db-`;
  * (`apps/web/worker/features/flagship/resources.ts`), so alchemy's `createPhysicalName`
  * yields the same `${stack}-${id}-${stage}-${suffix}` shape as workers/D1, `_`→`-`
  * lowercased: id `phoenix_flags` → `phoenix-flags`, giving prefix `phoenix-phoenix-flags-`.
- * Both flagship kinds decode their stage off this one app prefix — a flag's stage is its
- * parent app's, never in the flag key.
  */
 export const FLAGSHIP_APP_NAME_PREFIX = `${STACK}-${STACK}-flags-`;
 
@@ -169,43 +153,22 @@ const decodeStage = (resource: CfResource): string | undefined => {
 	return rest.slice(0, lastDash);
 };
 
-/** A stage is an ephemeral integration stage iff it is `it-…` (anchored, never a substring). */
 const isIntegrationStage = (stage: string): boolean => stage.startsWith("it-");
 
-/**
- * If the stage is a preview `pr-<n>`, return `n`; else `undefined`. Anchored so only a
- * literal `pr-<digits>` with NOTHING after the number matches — `pr-12` yes, `prod` no,
- * `pr-12-foo` no, `pr-` no.
- */
 const previewPrNumber = (stage: string): number | undefined => {
 	const m = /^pr-(\d+)$/.exec(stage);
 	return m ? Number(m[1]) : undefined;
 };
 
-/**
- * The two halves of the dev/test stage family (#2340), both anchored (a match on the
- * exact stage or a `<fam>-` prefix, never a substring — `development`/`testing` match
- * neither). See the `sweepDevTestStages` docblock for why the split is where it is.
- */
+/** Why the dev/test family splits here: see the `sweepDevTestStages` docblock (#2340). */
 const isNamedDevStage = (stage: string): boolean => stage === "dev" || stage.startsWith("dev-");
 const isEphemeralTestStage = (stage: string): boolean =>
 	stage === "test" || stage.startsWith("test-");
 
 /**
- * Compute the deletion plan. The order of checks IS the safety policy:
- *
- *   1. Unrecognized (not one of our resources) → KEPT. Nothing foreign is ever swept.
- *   2. The decoded stage is in `protectedStages` (prod, `--protect`-ed) → KEPT. This wins
- *      even over an `it-`/`pr-`/`test-` allow-match, so a stage someone deliberately
- *      protected can never be swept regardless of its name shape.
- *   3. `dev`/`dev-*` named-dev stage → KEPT (`named-dev`). A protection that wins before
- *      any sweep: `dev-usirin`-shaped stages are NEVER deleted, flag or not (#2340).
- *   4. `it-*` integration stage → DELETE (`orphan-integration`).
- *   5. `pr-<n>` preview: open PR → KEPT (`open-pr`). Closed PR → DELETE only if
- *      `sweepClosedPreviews`, else KEPT (`preview-sweep-disabled`).
- *   6. `test`/`test-*` ephemeral stage → DELETE (`stale-dev-test`) only if
- *      `sweepDevTestStages`, else KEPT (`dev-test-sweep-disabled`) (#2340).
- *   7. Anything else recognized but not matched → KEPT (`unrecognized`).
+ * Compute the deletion plan. The order of checks IS the safety policy: every protection
+ * (unrecognized, `protectedStages`, named-dev) is tested BEFORE any allow-match, so a
+ * protected stage can never be swept regardless of its name shape.
  */
 export const computeSweepPlan = (
 	resources: ReadonlyArray<CfResource>,

--- a/packages/orphan-sweep/src/orphan-sweep.unit.test.ts
+++ b/packages/orphan-sweep/src/orphan-sweep.unit.test.ts
@@ -63,7 +63,6 @@ describe("computeSweepPlan — orphan it-* matching", () => {
 	});
 
 	it("decodes the stage off the physical name for the audit trail", () => {
-		// worker("it-pasaport") → phoenix-phoenix-it-pasaport-<suffix>; stage decodes to it-pasaport.
 		const plan = computeSweepPlan([worker("it-pasaport")], protection());
 		assert.strictEqual(plan.toDelete[0]?.stage, "it-pasaport");
 	});
@@ -86,13 +85,11 @@ describe("computeSweepPlan — prod is NEVER swept (the catastrophic case)", () 
 	});
 
 	it("never matches prod via the it- anchor (no false-positive on the prefix)", () => {
-		// A pathological stage literally starting `it` but NOT `it-` must not match.
 		const plan = computeSweepPlan([worker("italy"), worker("items")], protection());
 		assert.strictEqual(plan.toDelete.length, 0);
 	});
 
 	it("a stage merely CONTAINING it- as a substring is not an integration stage", () => {
-		// `prod-it-x` does not START with `it-`, so it is never swept.
 		const plan = computeSweepPlan([worker("prod-it-x")], protection());
 		assert.strictEqual(plan.toDelete.length, 0);
 		assert.strictEqual(keptReasonFor(plan, worker("prod-it-x").name), "unrecognized");
@@ -101,7 +98,7 @@ describe("computeSweepPlan — prod is NEVER swept (the catastrophic case)", () 
 
 describe("computeSweepPlan — named-dev stages are protected", () => {
 	it("keeps any stage in protectedStages even if it otherwise looked sweepable", () => {
-		// A named-dev stage named `it-umut` would match the it- anchor — protection wins FIRST.
+		// `it-umut` matches the it- anchor — protection wins FIRST.
 		const w = worker("it-umut");
 		const plan = computeSweepPlan([w], protection({protectedStages: ["prod", "it-umut"]}));
 		assert.strictEqual(plan.toDelete.length, 0);
@@ -178,7 +175,6 @@ describe("computeSweepPlan — named-dev (dev-*) stages are a protected category
 	});
 
 	it("never matches `dev` via a substring — `development` is not a dev stage", () => {
-		// A stage merely CONTAINING dev is unrecognized, never named-dev, never swept.
 		const w = worker("development");
 		const plan = computeSweepPlan([w], protection({sweepDevTestStages: true}));
 		assert.strictEqual(plan.toDelete.length, 0);
@@ -228,8 +224,6 @@ describe("computeSweepPlan — stale test-* stages sweep only under the opt-in (
 	});
 
 	it("the dev/test opt-in NEVER reaches prod, it-*, or pr-<n> — those keep their own reasons", () => {
-		// The new flag widens coverage to test-* ONLY; it must not perturb the existing
-		// classifications. it-* still deletes (its own mandate), prod stays protected.
 		const resources = [worker("prod"), worker("it-report-aaaa"), worker("pr-5")];
 		const plan = computeSweepPlan(
 			[...resources],
@@ -263,11 +257,9 @@ describe("computeSweepPlan — foreign / unrecognized resources are never touche
 
 	it("a name with no suffix segment is unrecognized (no stage guess)", () => {
 		const w: CfResource = {kind: "worker", name: "phoenix-phoenix-it-report"};
-		// `it-report` has internal dashes; the LAST dash splits stage `it` + suffix
-		// `report`, which still starts with `it-`? No: stage decodes to `it`, not `it-…`.
 		const plan = computeSweepPlan([w], protection());
-		// stage `it` does not start with `it-`, so it is kept unrecognized — a malformed
-		// name never enters the delete set.
+		// The LAST dash splits stage `it` + suffix `report`; stage `it` does not start
+		// with `it-`, so a malformed name never enters the delete set.
 		assert.strictEqual(plan.toDelete.length, 0);
 	});
 });
@@ -371,7 +363,6 @@ describe("computeSweepPlan — Flagship apps/flags flow through the SAME protect
 	});
 
 	it("dev/test classification flows through flagship kinds too (#2340)", () => {
-		// A leaked test-stage flagship app + flag sweep under the opt-in; a named-dev one never does.
 		const testApp = flagshipApp("test");
 		const testFlag = flagshipFlag("test");
 		const devApp = flagshipApp("dev-usirin");

--- a/packages/orphan-sweep/src/report.ts
+++ b/packages/orphan-sweep/src/report.ts
@@ -1,17 +1,14 @@
 /**
- * Pure rendering of a `SweepPlan` into the plain text the bin prints. IO-free: the bin
- * passes the rendered lines to `Console.log`. The `--execute` vs dry-run distinction is
- * the bin's; this only describes the plan.
+ * Pure, IO-free rendering of a `SweepPlan`. The `--execute` vs dry-run distinction is the
+ * bin's; this only describes the plan.
  */
 import type {SweepPlan} from "./orphan-sweep.ts";
 
-/** A one-line summary: how many resources would be deleted vs kept. */
 export const renderSummary = (plan: SweepPlan, execute: boolean): string => {
 	const verb = execute ? "DELETING" : "would delete";
 	return `orphan-sweep: ${verb} ${plan.toDelete.length} resource(s), keeping ${plan.kept.length}`;
 };
 
-/** The delete set, one `kind name (reason, stage)` per line — empty plan renders a clear note. */
 export const renderPlan = (plan: SweepPlan): string => {
 	if (plan.toDelete.length === 0) {
 		return "  (nothing to delete — no orphan it-*, closed-preview, or stale dev/test resources found)";

--- a/packages/preview-seed/src/bin.ts
+++ b/packages/preview-seed/src/bin.ts
@@ -1,24 +1,7 @@
 /**
- * `preview-seed run` — the CI-callable surface for issue #521.
- *
- * Seeds a *deployed* stage's D1 with the minimal sözlük + pano fixtures the
- * unauthenticated read e2e specs sample, so a fresh (empty) per-PR preview D1
- * isn't blank when those specs navigate to /sozluk and /pano. This is the
- * direct-D1 script CLAUDE.md's "Sözlük seed" mandates — NOT a worker route (the
- * admin seeder routes were deleted as a fail-open hole), and NOT Python (the
- * `effect/unstable/cli` tooling idiom, mirroring @kampus/leak-guard).
- *
- * Transport: a `D1Database` adapter (`makeD1Rest`) over the Cloudflare D1 REST
- * query API via alchemy's already-installed `@distilled.cloud/cloudflare` (zero
- * new deps) — so the bin runs the SAME `seed(d1)` path the unit tests exercise
- * against the in-memory fake, no workerd binding needed.
- *
- * Parameterized on the TARGET stage's D1 (never prod-hardcoded):
- *   --database-id  the stage's D1 UUID (from the alchemy state store / `getDatabase`)
- *   --account-id   Cloudflare account id (defaults to $CLOUDFLARE_ACCOUNT_ID)
- *   $CLOUDFLARE_API_TOKEN  the minted CI token (carries D1 Write) — read by CredentialsFromEnv
- *
- *   node src/bin.ts run --database-id <uuid> --account-id <acct>
+ * `preview-seed run` — seeds a deployed stage's D1 with the fixtures the unauthenticated
+ * read e2e specs sample. It talks to D1 over the REST query API, never a worker route:
+ * the admin seeder routes were deleted as a fail-open hole (CLAUDE.md, "Sözlük seed").
  */
 import {CredentialsFromEnv} from "@distilled.cloud/cloudflare/Credentials";
 import {NodeRuntime, NodeServices} from "@effect/platform-node";
@@ -28,7 +11,6 @@ import {Command, Flag} from "effect/unstable/cli";
 import * as FetchHttpClient from "effect/unstable/http/FetchHttpClient";
 import {seed} from "./seed.ts";
 
-/** A D1 REST call (seed over the query API) rejected — network/HTTP fault. */
 class D1RestError extends Schema.TaggedErrorClass<D1RestError>()(
 	"@kampus/preview-seed/D1RestError",
 	{cause: Schema.Defect()},
@@ -38,13 +20,11 @@ const databaseIdFlag = Flag.string("database-id").pipe(
 	Flag.withDescription("the target stage's D1 database UUID to seed"),
 );
 
-// Optional: falls back to $CLOUDFLARE_ACCOUNT_ID so CI passes only the per-stage database id.
 const accountIdFlag = Flag.string("account-id").pipe(
 	Flag.optional,
 	Flag.withDescription("Cloudflare account id (default: $CLOUDFLARE_ACCOUNT_ID)"),
 );
 
-// Credentials (CLOUDFLARE_API_TOKEN) + an HTTP client — the services queryDatabase needs.
 const restLayer = Layer.merge(CredentialsFromEnv, FetchHttpClient.layer);
 
 const run = Command.make(

--- a/packages/preview-seed/src/fixtures.ts
+++ b/packages/preview-seed/src/fixtures.ts
@@ -1,23 +1,16 @@
 /**
- * The fixture content the unauthenticated read e2e specs sample — a pure,
- * deterministic description of the rows the seed writes. No I/O, no DB: this is
- * the unit-testable core. `buildFixtures` returns typed insert values shaped to
- * the three read-model tables (`term_record`, `definition_record`,
- * `post_record`); `seed.ts` turns them into idempotent upserts.
+ * The fixture content the unauthenticated read e2e specs sample — a pure, deterministic
+ * description of the rows the seed writes. `seed.ts` turns them into idempotent upserts.
  *
- * What each row satisfies (the specs in apps/web/tests/e2e):
- *   - term + ≥1 definition → 00-smoke, 07-sozluk-term: a `.kp-sozluk-term-row`
- *     on /sozluk, a `.kp-sozluk-term__title` + a `.kp-sozluk-definition` card on
- *     /sozluk/<slug>, and the first (top-scoring) definition carries `--top`.
- *   - ≥1 pano post → 00-smoke, 03-pano-feed: a `.kp-pano-post` on /pano whose
- *     "N yorum" permalink lands on /pano/<id> and renders `.kp-pano-postpage__title`.
- *   - searchable seeded terms → 24-search: the seed FTS-indexes each term's title
- *     (ADR 0080), so a topbar search over a seeded title finds its row. The
- *     SEARCH_* term's İ/ı-bearing title is the Turkish-fold crux ("ışık" matched
- *     by "IŞIK"); `merhaba dünya` carries the exact-title + prefix assertions.
+ * Which spec needs which row:
+ *   - term + ≥1 definition → 00-smoke, 07-sozluk-term (the top-scoring definition gets `--top`).
+ *   - ≥1 pano post → 00-smoke, 03-pano-feed.
+ *   - searchable seeded terms → 24-search: the SEARCH_* term's İ/ı-bearing title is the
+ *     Turkish-fold crux ("ışık" matched by "IŞIK"); `merhaba dünya` carries the exact-title
+ *     and prefix assertions (ADR 0080).
  *
- * IDs/slugs are stable string literals (not random) so a re-run upserts the same
- * rows — the idempotency contract lives here, in the fixed identity.
+ * IDs/slugs are stable string literals (not random) so a re-run upserts the same rows — the
+ * idempotency contract lives here, in the fixed identity.
  */
 import type {seedSchema} from "./schema.ts";
 

--- a/packages/preview-seed/src/schema.ts
+++ b/packages/preview-seed/src/schema.ts
@@ -1,15 +1,8 @@
 /**
- * The slice of the phoenix D1 schema this seed writes. The read-model tables
- * (`term_record` / `definition_record` / `post_record`) come from the
- * `@kampus/db-schema` leaf — the single canonical declaration the worker also
- * re-exports — so this seed can no longer drift from the real schema (issue
- * #859: the `is_draft`/`removed_at` columns now arrive by construction, not by
- * hand-copy). The leaf is a true leaf (only `drizzle-orm`), so depending on it
+ * The slice of the phoenix D1 schema this seed writes. The read-model tables come
+ * from the canonical `@kampus/db-schema` leaf so this seed can't drift from the
+ * real schema (#859). That leaf depends only on `drizzle-orm`, so pulling it in
  * adds no cycle even though this package already prod-depends on `@kampus/web`.
- *
- * Only the FTS5 search tables are modeled locally (below) — they're a seed-write
- * convenience, not duplicated canonical knowledge (the worker doesn't model them
- * as drizzle tables either).
  */
 import {definitionRecord, postRecord, termRecord} from "@kampus/db-schema";
 import {sqliteTable, text} from "drizzle-orm/sqlite-core";
@@ -17,17 +10,14 @@ import {sqliteTable, text} from "drizzle-orm/sqlite-core";
 export {definitionRecord, postRecord, termRecord};
 
 /**
- * The FTS5 search tables (`term_search` / `post_search`, ADR 0080), modeled as
- * plain drizzle tables over their two columns. The migration declares them as
- * `CREATE VIRTUAL TABLE … USING fts5(…)`; drizzle-kit can't express that, so they
- * are NOT in the canonical `@kampus/db-schema` leaf. The seed only needs to
- * delete+insert two columns, which a plain `sqliteTable` maps cleanly. Modeled
- * here (rather than reusing the worker's raw-`sql` `syncTermSearch` builders) so
- * the seed's FTS writes are real drizzle `insert`/`delete` builders —
- * batch-compatible (`SQLiteRaw` from `db.run(sql)` has no `.stmt`, so it can't
- * ride the D1 `batch`). The indexed `norm` is still the worker's OWN
- * `normalizeSearchText` (imported in seed.ts), so the value is byte-identical to
- * the dual-write's.
+ * The FTS5 search tables (ADR 0080), modeled locally as plain drizzle tables: the
+ * migration declares them `CREATE VIRTUAL TABLE … USING fts5(…)`, which
+ * drizzle-kit can't express, so they are NOT in the `@kampus/db-schema` leaf.
+ * Modeled rather than reusing the worker's raw-`sql` builders because the seed's
+ * writes must ride the D1 `batch`, and `SQLiteRaw` from `db.run(sql)` has no
+ * `.stmt`. The indexed `norm` still comes from the worker's own
+ * `normalizeSearchText` (see seed.ts), so it stays byte-identical to the
+ * dual-write's.
  */
 export const termSearch = sqliteTable("term_search", {
 	slug: text("slug").notNull(),

--- a/packages/preview-seed/src/seed.ts
+++ b/packages/preview-seed/src/seed.ts
@@ -1,21 +1,11 @@
 /**
  * The seed core: given a `D1Database`-shaped binding, write the fixture set as
- * idempotent upserts. This is pure of *transport* — statement-building resolves
- * SQL+params off an inert `D1Database` with no engine (the unit test), and the bin
- * runs the same writes over the Cloudflare D1 REST adapter, because both satisfy
- * the same `D1Database` surface drizzle drives.
+ * idempotent upserts. Transport-free on purpose — statement-building resolves
+ * SQL+params off an inert `D1Database` with no engine (the unit test), while the
+ * bin runs the same writes over the Cloudflare D1 REST adapter.
  *
- * Idempotency (AC: "safely re-runnable"): every insert is an
- * `onConflictDoUpdate` keyed on the row's primary key, so a second run overwrites
- * the same fixed-identity rows rather than duplicate-key-crashing. The whole set
- * is one D1 `batch` — all rows land or none do.
- *
- * The seed ALSO indexes its terms/posts into the FTS5 `term_search` /
- * `post_search` tables (ADR 0080) as a delete-then-insert keyed on slug/id — the
- * same upsert shape the worker's dual-write produces — with the `norm` computed by
- * the worker's OWN `normalizeSearchText` (no fold duplicated). So a seeded term's
- * index value byte-matches what a real query normalizes to, and the search e2e can
- * deterministically query seeded titles (read-model rows alone aren't searchable, #534).
+ * Safely re-runnable: every insert is an `onConflictDoUpdate` on the row's
+ * primary key, and the whole set is one D1 `batch` — all rows land or none do.
  */
 import {normalizeSearchText} from "@kampus/web/features/search/normalize";
 import {eq} from "drizzle-orm";
@@ -40,23 +30,15 @@ export type SeedDb = ReturnType<typeof drizzle<typeof relations>>;
 
 export const makeSeedDb = (d1: D1Database): SeedDb => drizzle(d1, {relations});
 
-/** How many rows of each kind the seed wrote — surfaced by the bin for a legible CI log. */
 export interface SeedReport {
 	readonly terms: number;
 	readonly definitions: number;
 	readonly posts: number;
-	// FTS5 index rows written (ADR 0080): one per term / per post, the dual-write of
-	// the read-model rows above. Surfaced so the log reflects all five seeded tables,
-	// not just the three read-model ones.
 	readonly termsFts: number;
 	readonly postsFts: number;
 }
 
-/**
- * Build the upsert statements for `db` from the fixture set. Split out from
- * {@link seed} so the unit test can assert on the statement set without a live
- * batch, and so the batch tuple is constructed in exactly one place.
- */
+/** Split out from {@link seed} so the unit test can assert the statement set with no live batch. */
 export const buildSeedStatements = (db: SeedDb, now?: Date) => {
 	const {terms, definitions, posts} = buildFixtures(now);
 
@@ -100,7 +82,6 @@ export const buildSeedStatements = (db: SeedDb, now?: Date) => {
 	};
 };
 
-/** Write the fixtures to `d1` as one atomic, idempotent batch. Returns the row counts written. */
 export const seed = async (d1: D1Database, now?: Date): Promise<SeedReport> => {
 	const db = makeSeedDb(d1);
 	const {statements, report} = buildSeedStatements(db, now);

--- a/packages/preview-seed/src/seed.unit.test.ts
+++ b/packages/preview-seed/src/seed.unit.test.ts
@@ -1,14 +1,8 @@
 /**
- * The seed's built statements never bind a null — the pure core, asserted without a
- * DB (ADR 0082 unit tier). `@distilled.cloud/cloudflare`'s `queryDatabase` validates
- * D1 REST `params` as a strict `string[]` and rejects a `null`/`undefined` element, so
- * the seed died on a real D1 before writing anything when a nullable column was bound
- * instead of omitted (#569). This pins the seed-specific half of that contract: every
- * statement `buildSeedStatements` emits is null-free and survives `toRestParams` (the
- * REST-wire transform, now `@kampus/d1-rest`) — which needs no SQL engine, since
- * statement-building resolves SQL+params via `.toSQL()` without touching the binding.
- * The transport's own param/`meta` contract is tested once in `@kampus/d1-rest`; the
- * faithful end-to-end proof that real D1 rejects null lives on the integration tier.
+ * The seed's built statements never bind a null (ADR 0082 unit tier). D1 REST validates
+ * `params` as a strict `string[]` and rejects a `null`/`undefined` element, so the seed
+ * died on a real D1 before writing anything when a nullable column was bound instead of
+ * omitted (#569).
  */
 
 import {assert, describe, it} from "@effect/vitest";
@@ -16,10 +10,8 @@ import {toRestParams} from "@kampus/d1-rest";
 import {drizzle} from "drizzle-orm/d1";
 import {buildSeedStatements, makeSeedDb} from "./seed.ts";
 
-// An inert `D1Database` for building statements only: drizzle's query builders resolve
-// their SQL+params via `.toSQL()` with no session call, so no binding method is ever
-// invoked here — the unit-tier "no SQL engine" shape (same idiom as
-// apps/web/worker/features/search/fts-sync.unit.test.ts's recording client).
+// Inert because drizzle resolves SQL+params via `.toSQL()` with no session call, so no
+// binding method is ever invoked here.
 // biome-ignore lint/plugin: a no-op stand-in (statement-building never touches the binding) can't be structurally typed as the full `D1Database` interface; nothing here calls a binding method.
 const inertD1 = {} as unknown as D1Database;
 
@@ -33,7 +25,6 @@ describe("buildSeedStatements — no statement binds a null/undefined param", ()
 				assert.isNotNull(p, `batch[${i}].params[${j}] is null — D1 REST params is strict string[]`);
 				assert.notTypeOf(p, "undefined", `batch[${i}].params[${j}] is undefined`);
 			});
-			// toRestParams is the exact REST-wire transform; it must yield a clean string[].
 			toRestParams(params).forEach((w, j) => {
 				assert.typeOf(w, "string", `batch[${i}] wire param[${j}] must be a string`);
 			});

--- a/packages/preview-seed/tests/integration/_d1.ts
+++ b/packages/preview-seed/tests/integration/_d1.ts
@@ -1,25 +1,11 @@
 /**
- * Per-file real-D1 substrate for the seed's integration tier — the alchemy
- * `Test.make` idiom of ADR 0082 / `.patterns/alchemy-test-harness.md`, scoped to
- * a **D1-only stack** (this package has no worker; the seed talks to D1 directly).
+ * Per-file real-D1 substrate for the seed's integration tier — the alchemy `Test.make` idiom of
+ * ADR 0082 / `.patterns/alchemy-test-harness.md`, scoped to a D1-only stack (this package has no
+ * worker; the seed talks to D1 directly).
  *
- * Each integration test file calls `seedD1(import.meta.url)` once at module top
- * level. It stands up a per-file `Test.make`, deploys a stack declaring ONLY the
- * phoenix D1 resource under an isolated stage — migrated by the **same** worker
- * migrations dir the production deploy applies (`worker/db/drizzle/migrations`),
- * so the seeded tables (incl. the `0002_search_fts.sql` FTS5 virtual tables) exist
- * exactly as in prod, one migration path — and returns a `seedDb()` accessor that
- * builds a `D1Database` over the production REST transport (`makeD1Rest`) pointed
- * at that stage's real D1. The seed then runs the SAME `seed(d1)` path the bin
- * ships; assertions read back over the same REST seam.
- *
- * Real remote D1 + a shared Cloudflare account are stage-keyed, so two CI runs (or
- * a rerun) must never collide on a stage name — the same isolated-stage derivation
- * apps/web uses (`_stage-name`'s run-unique `it-<readable>-<disc>`). Creds
- * (`CLOUDFLARE_API_TOKEN` / `CLOUDFLARE_ACCOUNT_ID` / `ALCHEMY_PASSWORD`) come from
- * the environment — CI secrets; an alchemy/wrangler profile locally. Without them
- * the deploy fails at `Unauthorized` (expected off-CI; the suite proves itself on
- * CI's integration job).
+ * Creds (`CLOUDFLARE_API_TOKEN` / `CLOUDFLARE_ACCOUNT_ID` / `ALCHEMY_PASSWORD`) come from the
+ * environment; without them the deploy fails at `Unauthorized` — expected off-CI, the suite proves
+ * itself on CI's integration job.
  */
 import {join} from "node:path";
 import {CredentialsFromEnv} from "@distilled.cloud/cloudflare/Credentials";
@@ -33,9 +19,8 @@ import * as Layer from "effect/Layer";
 import * as FetchHttpClient from "effect/unstable/http/FetchHttpClient";
 import {slugify, stageName} from "./_stage-name.ts";
 
-// The worker's canonical migrations dir — the SAME one `apps/web`'s D1 resource
-// applies on deploy (ADR 0082's "one migration path"). Resolved from this file:
-// `packages/preview-seed/tests/integration/` → repo root is four levels up.
+// The SAME migrations dir `apps/web`'s D1 resource applies on deploy — ADR 0082's one migration
+// path, so the seeded tables exist exactly as in prod.
 const MIGRATIONS_DIR = join(
 	import.meta.dirname,
 	"../../../../apps/web/worker/db/drizzle/migrations",
@@ -59,8 +44,6 @@ const phoenixD1Stack = (stage: string) =>
 
 type StackOutput = {databaseId: string; accountId: string};
 
-// Credentials (CLOUDFLARE_API_TOKEN) + an HTTP client — what `queryDatabase` (the
-// REST transport inside makeD1Rest) needs. The same layer the bin assembles.
 const restLayer = Layer.merge(CredentialsFromEnv, FetchHttpClient.layer);
 
 // `afterAll(destroy)` is skipped when `NO_DESTROY` is set, so a local iteration loop
@@ -86,17 +69,14 @@ const stageFor = (metaUrl: string): string => {
 };
 
 export interface SeedD1 {
-	/** A `D1Database` over this stage's real D1 (the production REST transport). */
 	seedDb(): D1Database;
-	/** This stage's real D1 coordinates, for an assertion that needs the raw REST seam. */
 	target(): {accountId: string; databaseId: string};
 }
 
 /**
- * Stand up this file's per-file `Test.make` D1-only deploy and return a `seedDb()`
- * accessor over its real D1. Call once at module top level. The deploy resolves in
- * a vitest `beforeAll` (so the D1 exists + is migrated before any `it` body runs);
- * its `{accountId, databaseId}` is stashed in a holder the synchronous accessors read.
+ * Call once at module top level: the deploy resolves in a vitest `beforeAll`, so the D1 exists and
+ * is migrated before any `it` body runs, and its coordinates are stashed in a holder the
+ * synchronous accessors read.
  */
 export function seedD1(metaUrl: string): SeedD1 {
 	const stage = stageFor(metaUrl);

--- a/packages/preview-seed/tests/integration/_stage-name.ts
+++ b/packages/preview-seed/tests/integration/_stage-name.ts
@@ -1,13 +1,8 @@
 /**
- * Pure per-file stage-name construction for the seed integration harness
- * (`_d1.ts`) — the same invariant + shape apps/web's `tests/integration/_stage-name.ts`
- * upholds (real remote D1 + a shared Cloudflare account are stage-keyed, so a stage
- * name must be run-unique and Cloudflare-resource-name-legal). Kept local to this
- * package because apps/web's copy is test-internal (not a shared export), and the
- * helper is small and pure. Unit-pinned in `_stage-name.unit.test.ts`.
- *
- * The invariant: `[a-z0-9-]` only, no leading/trailing dash, no internal `--`,
- * non-empty, ≤ MAX_STAGE_LEN.
+ * Pure per-file stage-name construction for the seed integration harness (`_d1.ts`). Real
+ * remote D1 on a shared Cloudflare account is stage-keyed, so the name must be run-unique
+ * and resource-name-legal: `[a-z0-9-]` only, no leading/trailing dash, no internal `--`,
+ * non-empty, ≤ MAX_STAGE_LEN. A local copy of apps/web's, whose version is test-internal.
  */
 
 // Stage length is load-bearing: alchemy's `createPhysicalName` hard-caps a D1 name
@@ -19,9 +14,8 @@ export const DISC_LEN = 8;
 
 const STAGE_PREFIX = "it-";
 
-// Deterministic fixed-length discriminator (FNV-1a 32-bit → base36, padded/truncated
-// to DISC_LEN). Fed `${slug}|${runToken}`, it carries BOTH file-distinctness (slug)
-// and run-distinctness (runToken) in a constant width.
+// FNV-1a 32-bit → base36, at a constant width. Fed `${slug}|${runToken}`, so it carries
+// both file-distinctness and run-distinctness.
 export const disc = (seed: string): string => {
 	let h = 0x811c9dc5;
 	for (let i = 0; i < seed.length; i++) {
@@ -31,19 +25,13 @@ export const disc = (seed: string): string => {
 	return (h >>> 0).toString(36).padStart(DISC_LEN, "0").slice(0, DISC_LEN);
 };
 
-/** Sanitize a raw test-file basename to the `[a-z0-9-]` set with no leading/trailing dash. */
 export const slugify = (base: string): string =>
 	base
 		.toLowerCase()
 		.replaceAll(/[^a-z0-9]+/g, "-")
 		.replace(/(^-|-$)/g, "");
 
-/**
- * Build the stage name from an already-sanitized `slug`.
- *
- *   - `NO_DESTROY`: stable `it-<slug>` so a kept-alive local deploy re-adopts by name.
- *   - otherwise: `it-<readable>-<disc>`, always ≤ MAX_STAGE_LEN.
- */
+/** `NO_DESTROY` drops the discriminator so a kept-alive local deploy re-adopts by name. */
 export const stageName = (slug: string, noDestroy: boolean, runToken: string): string => {
 	if (noDestroy) return collapse(`${STAGE_PREFIX}${slug}`);
 

--- a/packages/preview-seed/tests/integration/_stage-name.unit.test.ts
+++ b/packages/preview-seed/tests/integration/_stage-name.unit.test.ts
@@ -1,9 +1,7 @@
 /**
- * Stage-name invariants — the pure core of `_d1.ts`'s isolated-stage derivation,
- * asserted without a deploy. Pins the contract real remote D1 relies on: the name is
- * `[a-z0-9-]` only, no leading/trailing dash, no internal `--`, non-empty, ≤ MAX_STAGE_LEN,
- * and run-unique (two runs of the same file get distinct names so they can't collide
- * on the shared Cloudflare account).
+ * Stage-name invariants, asserted without a deploy. Names must be run-unique: two runs
+ * of the same file get distinct names so they cannot collide on the shared Cloudflare
+ * account.
  */
 import {assert, describe, it} from "@effect/vitest";
 import {DISC_LEN, disc, MAX_STAGE_LEN, slugify, stageName} from "./_stage-name.ts";
@@ -37,7 +35,7 @@ describe("stageName", () => {
 	it("destroy-on yields a run-unique, legal, length-bounded name", () => {
 		const a = stageName("seed", false, "run-1");
 		const b = stageName("seed", false, "run-2");
-		assert.notStrictEqual(a, b); // distinct across runs
+		assert.notStrictEqual(a, b);
 		for (const name of [a, b]) {
 			assert.match(name, LEGAL);
 			assert.isAtMost(name.length, MAX_STAGE_LEN);

--- a/packages/preview-seed/tests/integration/seed.test.ts
+++ b/packages/preview-seed/tests/integration/seed.test.ts
@@ -1,22 +1,9 @@
 /**
- * Seed I/O against **real remote Cloudflare D1** (ADR 0082 integration tier) —
- * runs the production `seed(d1)` over the shipped REST transport (`makeD1Rest`,
- * the bin's path) against a per-file isolated, migrated D1 (`_d1.ts`), and asserts:
- *
- *   - the rows the unauthenticated read e2e specs sample actually land — the term
- *     row, the term page's top-definition sort, the /pano/<id> permalink target;
- *   - the FTS5 dual-write is *findable on D1's own FTS5* — exact-title MATCH, the
- *     Turkish İ/ı fold, a short prefix, and no duplicate index rows on re-seed.
- *     This is precisely why these assertions are integration, not unit: node:sqlite's
- *     FTS5 build/tokenizer/collation are NOT D1's (ADR 0082), so a fold "proven" on
- *     the deleted fake proved nothing about D1;
- *   - the seed is idempotent — a second run is a clean no-op (same report, same counts).
- *
- * Pure-logic invariants (fixture content, the REST-wire param contract) stay in the
- * unit tier (`src/*.unit.test.ts`); they need no DB.
- *
- * Locally (no Cloudflare creds) the `beforeAll` deploy stops at `Unauthorized` —
- * expected; this tier proves itself on CI's integration job.
+ * Seed I/O against real remote Cloudflare D1 (ADR 0082 integration tier). The FTS
+ * assertions have to live here, not in the unit tier: node:sqlite's FTS5
+ * build/tokenizer/collation are NOT D1's, so a Turkish fold "proven" against a fake
+ * proved nothing about D1. Locally (no Cloudflare creds) the `beforeAll` deploy stops
+ * at `Unauthorized` — expected; this tier proves itself on CI's integration job.
  */
 
 import {normalizeSearchText, toMatchExpression} from "@kampus/web/features/search/normalize";
@@ -111,8 +98,6 @@ describe("seed — FTS index on D1's own FTS5 (24-search; ADR 0080)", () => {
 	});
 
 	it("re-seeding does not duplicate FTS rows (idempotent dual-write)", async () => {
-		// Re-seed (the dual-write is delete-then-insert keyed on slug), then assert the
-		// term appears exactly once in the FTS index.
 		await seed(h.seedDb());
 		const db = makeSeedDb(h.seedDb());
 		const slugs = await matchTermSlugs(db, SEED_TERM_SLUG.replace(/-/g, " "));
@@ -122,11 +107,9 @@ describe("seed — FTS index on D1's own FTS5 (24-search; ADR 0080)", () => {
 
 describe("seed — idempotency on real D1 (safely re-runnable)", () => {
 	it("a second run does not error and does not duplicate rows", async () => {
-		const second = await seed(h.seedDb()); // must not duplicate-key-crash
+		const second = await seed(h.seedDb());
 		expect(second).toStrictEqual(report);
 
-		// Re-run wrote no extra rows: each count still equals the fixture set the first
-		// run reported.
 		const db = makeSeedDb(h.seedDb());
 		const termRows = await db.select().from(termRecord);
 		const defRows = await db.select().from(definitionRecord);

--- a/packages/preview-seed/vitest.config.ts
+++ b/packages/preview-seed/vitest.config.ts
@@ -1,18 +1,4 @@
-/**
- * Vitest config — the two test tiers of ADR 0082 (`unit` + `integration`, no
- * middle, no faked engine), `.patterns/alchemy-test-harness.md`.
- *
- *   - `unit` — pure logic, no DB: the `*.unit.test.ts` files (fixture-content
- *     invariants, REST-wire param contract). They boot no SQL engine — ADR 0082
- *     bans the `node:sqlite` stand-in this package's suite used to lean on.
- *   - `integration` — the seed's drizzle writes run against **real remote
- *     Cloudflare D1** over the production REST transport (`makeD1Rest`, the same
- *     path the `preview-seed` bin ships), provisioned per-file by an alchemy
- *     `Test.make` D1-only stack (`tests/integration/_d1.ts`). The FTS5
- *     fold/prefix and row-landing/idempotency assertions live here because they
- *     are only-wrong-if-the-DB-differs — D1's FTS5 build ≠ node:sqlite's (the
- *     exact divergence the ban guards against).
- */
+// The two test tiers of ADR 0082; see .patterns/alchemy-test-harness.md.
 import {defineConfig} from "vitest/config";
 
 export default defineConfig({
@@ -26,11 +12,9 @@ export default defineConfig({
 					// harness substrate (e.g. `_stage-name`) — they deploy nothing, so they
 					// run in the `unit` tier, not these slow forks.
 					exclude: ["tests/integration/**/*.unit.test.ts"],
-					// A file's beforeAll(deploy) provisions a real remote D1 under an
-					// isolated stage, migrates it, then seeds + asserts over the REST API —
-					// so its wall-clock is provision + migrate + seed + assert. Generous
-					// timeouts cover that; forks + no console-intercept match apps/web's
-					// integration tier (the alchemy deploy logs from a child process).
+					// A file's beforeAll(deploy) provisions a real remote D1 under an isolated
+					// stage and migrates it, so the wall clock is provision + migrate + seed +
+					// assert. Console intercept is off because alchemy deploys from a child process.
 					testTimeout: 120_000,
 					hookTimeout: 180_000,
 					pool: "forks",

--- a/packages/worker-relevance/src/bin.ts
+++ b/packages/worker-relevance/src/bin.ts
@@ -1,28 +1,14 @@
 /**
- * `worker-relevance` classify bin — the CI-callable surface for issue #1014, extended
- * with the test-import closure of ADR 0114.
+ * `worker-relevance` classify bin — the IO shell around the pure core, run by
+ * ci.yml's `changes` job (issue #1014, ADR 0114). Exits 0 always: a classifier,
+ * not a gate.
  *
- * Reads the PR's changed-file list + the lockfile diff from `process.env` (set by the
- * `changes` job's classify step in ci.yml), COMPUTES the test-import closure by
- * scanning the real imports under the integration/e2e test trees, runs the pure
- * `classify` core over the union of the worker-import and test-import closures, emits
- * the verdict to the log (ADR 0092 §1 "emit what you scanned"), and writes a
- * `worker_relevant=true|false` line to `$GITHUB_OUTPUT` so the job's
- * `integration_required`/`e2e_required` expressions can AND it in. Exits 0 always —
- * this is a classifier, not a gate; the workflow decides what to do with the verdict.
+ * ZERO runtime dependencies on purpose: the `changes` job runs this with only
+ * checkout + setup-node + node — no `pnpm install`, hence plain Node, no Effect.
  *
- * ZERO runtime dependencies on purpose (the `ci-required` idiom): the
- * `changes` job runs this with only checkout + setup-node + node — no `pnpm install`
- * — so the always-on changed-area detector stays fast. Plain Node (no Effect import)
- * for the same reason. The pure core (`classify` + `inputFromEnv` + the import
- * extractor) is the unit-tested module; this bin is the IO shell — walk the test
- * trees, read env, print, write output.
- *
- * FAIL-SAFE TO RUNNING (ADR 0114): the closure is computed from real imports so it
- * cannot drift, but a scan that THROWS (a tree became unreadable, a resolution error)
- * must not silently yield an empty closure and skip a test-consumed package. On any
- * scan error the bin short-circuits to `worker_relevant=true` — running is the safe
- * verdict when the test-import closure can't be proven.
+ * FAIL-SAFE TO RUNNING (ADR 0114): a scan that THROWS must not silently yield an
+ * empty closure and skip a test-consumed package, so any scan error
+ * short-circuits to `worker_relevant=true`.
  */
 import {appendFileSync, type Dirent, readdirSync, readFileSync} from "node:fs";
 import {dirname, join, resolve} from "node:path";
@@ -30,16 +16,12 @@ import {fileURLToPath} from "node:url";
 
 import {classify, extractKampusPackages, inputFromEnv} from "./worker-relevance.ts";
 
-/** Repo root, derived from this file's location (`packages/worker-relevance/src/bin.ts`). */
 const REPO_ROOT = resolve(dirname(fileURLToPath(import.meta.url)), "..", "..", "..");
 
-/** The integration/e2e test trees whose real imports form the test-import closure (ADR 0114). */
 const TEST_TREES = ["apps/web/tests/integration", "apps/web/tests/e2e"] as const;
 
-/** Extensions the import scanner reads — the TS/JS source shapes a test tree carries. */
 const SOURCE_EXT = /\.(?:[cm]?ts|[cm]?js|tsx|jsx)$/;
 
-/** Recursively collect source-file paths under `dir`; a missing tree yields none. */
 const walkSourceFiles = (dir: string): string[] => {
 	let entries: Dirent[];
 	try {
@@ -59,7 +41,6 @@ const walkSourceFiles = (dir: string): string[] => {
 	return files;
 };
 
-/** Does `packages/<name>` exist as a workspace package named `@kampus/<name>`? */
 const isWorkspacePackage = (name: string): boolean => {
 	try {
 		const pkg = readFileSync(join(REPO_ROOT, "packages", name, "package.json"), "utf8");
@@ -73,12 +54,9 @@ const isWorkspacePackage = (name: string): boolean => {
 };
 
 /**
- * The test-import closure: `packages/<name>` dir-names imported under the two test
- * trees, computed from real imports (ADR 0114). Each `@kampus/<name>` specifier is
- * resolved to a `packages/**` member by confirming `packages/<name>` is a real
- * workspace package; a specifier that resolves to no such dir (an app-level alias, a
- * non-package scope member) is dropped, so the closure is exactly the set of
- * test-consumed `packages/**` members.
+ * The test-import closure (ADR 0114). A specifier resolving to no `packages/<name>`
+ * dir (an app-level alias, a non-package scope member) is dropped, so the closure
+ * is exactly the test-consumed `packages/**` members.
  */
 const computeTestImportedPackages = (): ReadonlySet<string> => {
 	const candidates = new Set<string>();

--- a/packages/worker-relevance/src/worker-relevance.ts
+++ b/packages/worker-relevance/src/worker-relevance.ts
@@ -1,106 +1,59 @@
 /**
  * `@kampus/worker-relevance` core — the pure, IO-free verdict for whether a PR's
- * diff can affect the `apps/web` worker, so the `changes` job can SKIP the slow
- * real-D1 `integration`/`e2e` tiers for a diff confined to packages the worker
- * never imports (issue #1014).
- *
- * Why this exists: the `backend`/`e2e` path filters in ci.yml list `pnpm-lock.yaml`
- * as a trigger, because a lockfile delta *can* bump a worker-imported dep's
- * resolution and that genuinely needs integration. `dorny/paths-filter` can't
- * attribute a lockfile diff to a specific package, so it conservatively runs
- * integration on EVERY lockfile change — and a packages-only PR (every #994
- * tooling-package reorg child) edits the lockfile, so it pays the worker-integration
- * tier (and the #1010/#813 stage-leak flake) despite touching nothing the worker
- * runs. This core distinguishes a lockfile delta confined to non-worker importers
- * from one that touches a worker dep, and decides whether to skip.
+ * diff can affect the `apps/web` worker, so CI can skip the real-D1
+ * `integration`/`e2e` tiers for a diff confined to packages the worker never
+ * imports (issue #1014, ADR 0114).
  *
  * FAIL-SAFE TO RUNNING (the load-bearing invariant): a wrong skip is a missed
- * worker regression, so the verdict is `irrelevant` (safe to skip) ONLY when the
- * WHOLE diff is provably confined to worker-irrelevant surfaces. Anything else —
- * any non-package path, any worker-relevant package, any lockfile change outside a
- * non-worker importer block, any ambiguity or parse failure — is `relevant`
- * (RUN). When unsure, run.
- *
- * GROUNDED worker-import closure (issue #1014, verified against source, not the
- * issue's example list): `apps/web`'s only `@kampus/*` workspace deps are
- * `db-schema` and `fate-effect` (apps/web/package.json), and each of those is a
- * leaf (no `@kampus/*` deps of its own). So the worker's transitive in-repo
- * closure is exactly {db-schema, fate-effect}. `d1-rest` is NOT in it (the issue
- * guessed it was) — it's consumed only by fts-backfill/preview-seed. preview-seed is
- * added to the integration-relevant set anyway: it owns its OWN real-D1 integration
- * tier run by the `integration` job (ADR 0082, #672), so a change to it must still
- * trip integration.
+ * worker regression, so the verdict is `irrelevant` ONLY when the WHOLE diff is
+ * provably confined to worker-irrelevant surfaces. Any ambiguity or parse failure
+ * is `relevant`. When unsure, run.
  */
 
 /**
- * The WORKER-import closure: packages whose change MUST run the worker
- * `integration`/`e2e` tiers because the worker imports them (or they own their own
- * real-D1 integration tier in the `integration` job). This is one of two closures
- * the relevance verdict unions (ADR 0114) — the other, the TEST-import closure, is
- * computed at run time from the real imports under the integration/e2e test trees
- * and passed in via `ClassifyInput.testImportedPackages`. A `packages/<name>/**`
- * change is integration-relevant iff `name` is in EITHER closure; everything else
- * under `packages/**` is dev-tooling neither the worker nor a test imports → not
- * integration-relevant on its own.
+ * The WORKER-import closure — one of the two closures the verdict unions (ADR
+ * 0114); the other is computed per run and arrives as
+ * `ClassifyInput.testImportedPackages`. Grounded against apps/web/package.json:
+ * its only `@kampus/*` deps are `db-schema` and `fate-effect`, both leaves.
  */
 export const INTEGRATION_RELEVANT_PACKAGES: ReadonlySet<string> = new Set([
-	// worker's grounded @kampus/* import closure (apps/web/package.json; both leaves)
 	"db-schema",
 	"fate-effect",
 	// own real-D1 integration tier run by the `integration` job (ADR 0082, #672)
 	"preview-seed",
 ]);
 
-/** The lockfile whose attribution is the hard, fail-safe-to-running case. */
 export const LOCKFILE = "pnpm-lock.yaml";
 
 export type Verdict = "relevant" | "irrelevant";
 
 export interface ClassifyResult {
-	/**
-	 * `relevant` ⇒ the diff can affect the worker ⇒ RUN integration/e2e.
-	 * `irrelevant` ⇒ provably confined to worker-irrelevant surfaces ⇒ safe to SKIP.
-	 */
+	/** `relevant` ⇒ RUN integration/e2e; `irrelevant` ⇒ safe to SKIP. */
 	readonly verdict: Verdict;
-	/** First changed path (or lockfile hunk) that forced `relevant`, else null. */
 	readonly trigger: string | null;
-	/** One-line, log-ready reason (ADR 0092 §1 "emit what you scanned"). */
 	readonly reason: string;
 }
 
 export interface ClassifyInput {
-	/** PR's changed file paths (base...head, repo-root-relative), lockfile included. */
+	/** Changed paths, base...head, repo-root-relative, lockfile included. */
 	readonly changedFiles: ReadonlyArray<string>;
 	/**
-	 * Whether `pnpm-lock.yaml` is among the changed files. When true, `lockfileDiff`
-	 * MUST be the unified diff of the lockfile so its hunks can be attributed; a
-	 * true flag with no/empty diff fails safe to `relevant`.
+	 * When true, `lockfileDiff` MUST carry the lockfile's unified diff so its hunks
+	 * can be attributed; a true flag with no/empty diff fails safe to `relevant`.
 	 */
 	readonly lockfileChanged: boolean;
-	/** Unified diff of `pnpm-lock.yaml` (`git diff base...head -- pnpm-lock.yaml`). */
+	/** `git diff base...head -- pnpm-lock.yaml`. */
 	readonly lockfileDiff: string;
 	/**
-	 * The TEST-import closure (ADR 0114): `packages/**` dir-names imported under
-	 * `apps/web/tests/integration/**` and `apps/web/tests/e2e/**`, computed from the
-	 * REAL imports in those trees (not a maintained list) and unioned with the
-	 * worker-import closure for the relevance check. A change to any member forces
-	 * `relevant`, so the integration tier runs on the PR that introduces a
-	 * test-consumed break rather than the next innocent one. Optional so existing
-	 * callers/tests that only exercise the worker closure keep working; when absent it
-	 * defaults to empty (no test-import members), leaving the pre-0114 behavior intact.
-	 * Per the fail-safe-to-running invariant, the bin resolves an empty/failed scan to
-	 * a superset relevant verdict via `changedFiles`, never a silent narrowing here.
+	 * The TEST-import closure (ADR 0114), computed per run from the real imports
+	 * under the test trees. Optional: absent ⇒ empty ⇒ pre-0114 behavior. Never
+	 * narrowed here — an empty/failed scan fails safe to `relevant` in the bin.
 	 */
 	readonly testImportedPackages?: ReadonlySet<string>;
 }
 
 const PACKAGE_PATH = /^packages\/([^/]+)\//;
 
-/**
- * The integration-relevance set for a run: the worker-import closure unioned with
- * this run's computed test-import closure (ADR 0114). A `packages/<name>` change is
- * integration-relevant iff `name` is in this union.
- */
 const relevantPackages = (input: ClassifyInput): ReadonlySet<string> => {
 	const test = input.testImportedPackages;
 	if (test === undefined || test.size === 0) return INTEGRATION_RELEVANT_PACKAGES;
@@ -108,11 +61,9 @@ const relevantPackages = (input: ClassifyInput): ReadonlySet<string> => {
 };
 
 /**
- * Is a single non-lockfile changed path worker-irrelevant? True ONLY for a file
- * under a `packages/<name>/` dir whose `<name>` is NOT in the union of the worker-
- * import and test-import closures (`relevant`). Every other path — `apps/**`,
- * `infra/**`, root configs, workflows, a relevant-package file, or a bare
- * `packages/foo` with no trailing slash — is worker-relevant (fail safe to running).
+ * True ONLY for a file under a `packages/<name>/` dir outside `relevant`. Every
+ * other path — `apps/**`, `infra/**`, root configs, workflows, even a bare
+ * `packages/foo` with no trailing slash — is worker-relevant (fail safe).
  */
 const isIrrelevantPath = (path: string, relevant: ReadonlySet<string>): boolean => {
 	const m = PACKAGE_PATH.exec(path);
@@ -123,21 +74,14 @@ const isIrrelevantPath = (path: string, relevant: ReadonlySet<string>): boolean 
 
 /**
  * Attribute every changed line of the lockfile diff to a section and decide whether
- * the worker's dependency resolution could have changed.
+ * the worker's dependency resolution could have changed. Returns the offending
+ * section string when relevant, else null.
  *
  * The pnpm v9 lockfile is one `importers:` section of per-package blocks keyed by
- * path (`apps/web:`, `packages/<name>:`, …) over the shared `catalogs:`/`packages:`/
- * `snapshots:`/`patchedDependencies:`/`settings:` sections. A change is provably
- * worker-irrelevant ONLY when every changed line falls inside the importer block of
- * a worker-IRRELEVANT package. Any changed line in a shared section (it can re-pin
- * an already-resolved version that a worker dep also links — fail safe), in the
- * `apps/web` importer block, or in a worker-RELEVANT package's importer block ⇒
- * worker-relevant. The catalog-discipline (CLAUDE.md: every dep via `catalog:`)
- * makes the common tooling-package add land entirely in its own importer block with
- * NO shared-section delta (verified on PR #1012's lockfile diff), so the skip fires
- * exactly for that shape and fails safe for anything richer.
- *
- * Returns the offending header/section string when relevant, else null (irrelevant).
+ * path over the shared `catalogs:`/`packages:`/`snapshots:`/… sections. A change is
+ * provably worker-irrelevant ONLY when every changed line falls inside the importer
+ * block of a worker-IRRELEVANT package: a shared-section line can re-pin a version
+ * a worker dep also links, so it fails safe.
  */
 const lockfileTriggersWorker = (diff: string, relevant: ReadonlySet<string>): string | null => {
 	if (diff.trim() === "") {
@@ -146,39 +90,25 @@ const lockfileTriggersWorker = (diff: string, relevant: ReadonlySet<string>): st
 	}
 
 	const lines = diff.split("\n");
-	// Track which importer block / top-level section the current diff line sits in.
-	// Outside `importers:` (catalogs/packages/snapshots/…) every changed line is
-	// shared ⇒ relevant. Inside `importers:`, a line is safe only when its enclosing
-	// per-package block is a worker-IRRELEVANT package.
-	//
 	// A hunk almost never starts ON a section/importer header: its leading context
 	// lines are mid-block dep entries, and the only nearby section name is the one
-	// `git diff` prints AFTER the `@@ … @@` (the `--show-function`/hunk-header hint,
-	// e.g. `@@ -686,6 +686,34 @@ importers:`). So a hunk header carrying `importers:`
-	// re-seeds `inImporters`; a hunk header carrying any other section name (or a
-	// bare `@@`) drops out of importers — without this the first added importer block
-	// after a section-spanning context reads as shared and (correctly) fails safe,
-	// but the COMMON catalog-confined add (the #1012 shape) would never be skippable.
-	// The importer-IRRELEVANT flag is reset per hunk: a hunk that opens mid-block
-	// can't prove its package, so it starts relevant until an importer header re-proves it.
+	// `git diff` prints AFTER the `@@ … @@` (the hunk-header hint, e.g.
+	// `@@ -686,6 +686,34 @@ importers:`). So that hint seeds `inImporters` — without
+	// it the COMMON catalog-confined add (the #1012 shape) could never be skippable.
+	// The irrelevant flag resets per hunk: a hunk opening mid-block can't prove its
+	// package, so it starts relevant until an importer header re-proves it.
 	let inImporters = false;
 	let currentImporterIrrelevant = false;
 	let currentSectionLabel = "<lockfile preamble / shared section>";
 
 	for (const raw of lines) {
 		if (raw.startsWith("@@")) {
-			// `@@ -a,b +c,d @@ <section-hint>` — the trailing hint is the nearest
-			// enclosing section git found. Use it to seed `inImporters`; we can't know
-			// the specific importer block yet (a header line inside the hunk proves it),
-			// so start the block as NOT-proven-irrelevant ⇒ a changed line before any
-			// in-hunk importer header fails safe to relevant.
 			const hint = raw.replace(/^@@[^@]*@@\s?/, "").trim();
 			inImporters = hint === "importers:";
 			currentImporterIrrelevant = false;
 			currentSectionLabel = inImporters ? "importers:" : hint || "<shared section>";
 			continue;
 		}
-		// Other diff metadata lines carry no attributable content position; skip them.
 		if (
 			raw.startsWith("+++") ||
 			raw.startsWith("---") ||
@@ -190,15 +120,11 @@ const lockfileTriggersWorker = (diff: string, relevant: ReadonlySet<string>): st
 
 		const marker = raw[0];
 		const isChange = marker === "+" || marker === "-";
-		// Line content with the diff marker stripped (context lines have a leading
-		// space; changed lines a +/-).
 		const content = isChange || marker === " " ? raw.slice(1) : raw;
 
-		// Section/importer-block tracking keys off the YAML indentation a diff line
-		// preserves after the marker is stripped: a col-0 `key:` header opens a
-		// top-level section (`importers:` opens importers; any other leaves it for a
-		// shared section); a 2-space-indent `  <path>:` header inside importers opens
-		// one per-package block.
+		// Block tracking keys off the YAML indentation a diff line preserves once the
+		// marker is stripped: col-0 `key:` opens a top-level section, a 2-space-indent
+		// `  <path>:` inside importers opens one per-package block.
 		if (/^[A-Za-z][A-Za-z0-9_-]*:\s*$/.test(content)) {
 			inImporters = content === "importers:";
 			currentImporterIrrelevant = false;
@@ -226,14 +152,10 @@ const lockfileTriggersWorker = (diff: string, relevant: ReadonlySet<string>): st
 };
 
 /**
- * The whole-diff verdict. `irrelevant` (safe to skip integration/e2e) ONLY when
- * EVERY changed non-lockfile path is worker-irrelevant AND the lockfile delta (if
- * any) is confined to worker-irrelevant importer blocks — where "irrelevant" is
- * measured against the union of the worker-import and test-import closures (ADR
- * 0114). Fail-safe: the first worker-relevant signal returns `relevant`. An empty
- * diff is `irrelevant` — but ci.yml only consults this when the path filter already
- * saw a lockfile/package change, so this is the confined-skip path, never a blanket
- * skip.
+ * The whole-diff verdict, fail-safe: the first worker-relevant signal returns
+ * `relevant`. An empty diff is `irrelevant` — safe because ci.yml only consults
+ * this once its path filter already saw a lockfile/package change, so this is the
+ * confined-skip path, never a blanket skip.
  */
 export const classify = (input: ClassifyInput): ClassifyResult => {
 	const relevant = relevantPackages(input);
@@ -267,7 +189,6 @@ export const classify = (input: ClassifyInput): ClassifyResult => {
 	};
 };
 
-/** Split a NUL- or newline-separated changed-file list (from `git diff --name-only`). */
 export const parseChangedFiles = (raw: string): ReadonlyArray<string> =>
 	raw
 		.split(/\0|\n/)
@@ -275,27 +196,14 @@ export const parseChangedFiles = (raw: string): ReadonlyArray<string> =>
 		.filter((s) => s.length > 0);
 
 /**
- * Match every `@kampus/<name>` module specifier in TypeScript/JS source text — the
- * `from "@kampus/x"` of a static `import`/`export`, and the `"@kampus/x"` of a
- * dynamic `import(...)`/`require(...)`. The capture is the bare `<name>` segment
- * after the `@kampus/` scope (up to the next `/` or the closing quote), which under
- * the repo's identity name→dir convention is the `packages/<name>` dir-name.
- *
- * Grammar-lite on purpose: a regex over the whole file text, IO-free and pure, so it
- * needs no TS parser (keeping the zero-runtime-dependency shape). It is deliberately
- * OVER-inclusive — it also matches a specifier inside a comment or string literal —
- * which is the fail-safe direction (ADR 0114): a spurious match only ever WIDENS the
- * test-import closure (running the tier for a package a test doesn't truly import),
- * never narrows it, so it can never cause a missed run. A subpath import
- * (`@kampus/x/sub`) resolves to the same `<name>` = the package dir.
+ * Every `@kampus/<name>` module specifier in TS/JS source text; the capture is the
+ * `packages/<name>` dir-name. A regex, not a TS parse, to keep the package's
+ * zero-runtime-dependency shape — and deliberately OVER-inclusive (it matches a
+ * specifier inside a comment or string too), which is the fail-safe direction (ADR
+ * 0114): a spurious match only widens the closure, never narrows it.
  */
 const KAMPUS_SPECIFIER = /['"]@kampus\/([a-z0-9][a-z0-9._-]*)(?:\/[^'"]*)?['"]/g;
 
-/**
- * Extract the set of `@kampus/<name>` package dir-names referenced by a single
- * source file's text. Pure over the text — the IO (reading the test-tree files) is
- * the bin's job; this is the unit-tested extraction the bin feeds each file into.
- */
 export const extractKampusPackages = (source: string): ReadonlySet<string> => {
 	const names = new Set<string>();
 	for (const m of source.matchAll(KAMPUS_SPECIFIER)) {
@@ -304,7 +212,6 @@ export const extractKampusPackages = (source: string): ReadonlySet<string> => {
 	return names;
 };
 
-/** Parse a NUL-/newline-/comma-separated dir-name list into a set (the bin's env handoff). */
 export const parseTestImportedPackages = (raw: string): ReadonlySet<string> =>
 	new Set(
 		raw
@@ -314,12 +221,8 @@ export const parseTestImportedPackages = (raw: string): ReadonlySet<string> =>
 	);
 
 /**
- * Map the classify step's `env:` to a `ClassifyInput`. `CHANGED_FILES` is the
- * newline/NUL-joined `git diff --name-only` list; `LOCKFILE_DIFF` is the lockfile's
- * unified diff (empty when the lockfile didn't change); `TEST_IMPORTED_PACKAGES` is
- * the bin-computed test-import closure (the `packages/**` dir-names imported under
- * the integration/e2e test trees, ADR 0114). The lockfile-changed flag is derived
- * from the file list so there's one source of truth.
+ * Map the ci.yml classify step's `env:` to a `ClassifyInput`. The lockfile-changed
+ * flag is derived from the file list so there's one source of truth.
  */
 export const inputFromEnv = (e: Record<string, string | undefined>): ClassifyInput => {
 	const changedFiles = parseChangedFiles(e.CHANGED_FILES ?? "");

--- a/packages/worker-relevance/src/worker-relevance.unit.test.ts
+++ b/packages/worker-relevance/src/worker-relevance.unit.test.ts
@@ -9,7 +9,6 @@ import {
 	parseTestImportedPackages,
 } from "./worker-relevance.ts";
 
-/** A classify input with no lockfile change unless explicitly supplied. */
 const input = (over: Partial<ClassifyInput>): ClassifyInput => ({
 	changedFiles: [],
 	lockfileChanged: false,


### PR DESCRIPTION
Fans the `deslop-comments` bar out from the `apps/web/worker` pilot ([#6445](https://github.com/kamp-us/phoenix/pull/6445), founder-approved verbatim "yes, merge it and fan out") to the rest of the TS surface.

**Scope:** `apps/web/tests/**` plus `packages/fate-effect`, `anka-ops`, `orphan-sweep`, `authz`, `worker-relevance`, `depo`, `preview-seed`, and `infra/depo`. `packages/fabrika-cli` is deliberately excluded — it sweeps separately after epic [#5631](https://github.com/kamp-us/phoenix/issues/5631) merges.

## Census

Over the full 231-file scope (198 of them changed):

| | before | after | delta |
|---|---|---|---|
| comment lines | 9508 | 5852 | **-3656 (-38.5%)** |
| total lines | 37391 | 33728 | -3663 |
| comment density | 25.4% | 17.4% | -8.0pt |

## Verdict tallies

All 14 phase-one groups, 2044 comments judged:

| verdict | count |
|---|---|
| CUT | 778 |
| COLLAPSE | 384 |
| KEEP | 882 |
| REHOME | 11 (left in place, see below) |

## What went, with examples

**CUT** — anything a reader gets from the code:

- JSDoc that only mirrors a type. `packages/anka-ops/src/report.ts` was the worst offender; `/** The user id. */` over `userId: string` is the shape.
- Test-step narration. `apps/web/tests/integration/_integration.ts` carried probe narration and history of retired implementations; `apps/web/tests/e2e/03-pano-feed.spec.ts` had `// Reload restores the sort from the URL, not the default.` sitting on `await page.reload()` inside a test literally named "selected sort survives reload".
- Restatements of the line above, and banner bars.

**COLLAPSE** — a docblock re-deriving a why that already has a home, shrunk to a pointer:

- `packages/fate-effect/src/Walk.ts` — a 100-line module docblock re-derived `.patterns/fate-effect-interpreter.md` almost line for line. Collapsed to a pointer, keeping the one paragraph the pattern doc does not own (the deliberate span design, which someone would otherwise "fix" to `Effect.fn`).
- `packages/authz/src/Capability.ts` — collapsed to ADR 0107 §3/§4 plus the pattern doc, keeping the single non-obvious line (enforcement rides the R channel).

Every ADR number cited in a COLLAPSE was verified against a real `.decisions/` filename.

**KEEP** — the notes that bite. Local invariants at their enforcement site, workaround-plus-forcing-constraint pairs, deliberate-looking-wrong guards, and pragma rationale. In test files the bar deliberately favours keeping: a note naming why a fixture is shaped oddly, or which incident a regression pins, stays. Examples kept whole:

- `apps/web/tests/integration/_deploy-transient.ts` and `_cf-rest-transport.unit.test.ts` — untouched; every comment is a grounded transient-signature rationale or an incident pin.
- `packages/authz/src/Capability.ts`'s `CapabilityTag` / `sealCapability` docblocks — the intersection-not-`extends` limit, the single audited cast, the [#1483](https://github.com/kamp-us/phoenix/issues/1483) nominal-distinctness incident.
- `apps/web/tests/integration/_harness.ts` came out mostly KEEP as expected: its retry and readiness notes are pinned to real incidents.

**REHOME — nothing was deleted.** 11 sites carry load-bearing why with no home yet. Each is left inline exactly as it was so this diff stays comments-only; rehoming them is tracked in [#6461](https://github.com/kamp-us/phoenix/issues/6461):

- `apps/web/tests/integration/_cf-rest-transport.ts:1` and `_cf-api-throttle.ts:1` — the throttle/retry composition-order rulings ([#3081](https://github.com/kamp-us/phoenix/issues/3081) inverted by [#3548](https://github.com/kamp-us/phoenix/issues/3548)), cited only to issues.
- `apps/web/tests/integration/_d1-rest-retry.ts:1,49,60`
- `apps/web/tests/integration/_best-effort-teardown.ts:1`, `_request-stall.ts:1`
- `packages/fate-effect/src/Interpreter.ts:33`, `DataView.ts:1`, `Operation.ts:234`
- `packages/anka-ops/src/flagship-core.ts:6`

## Byte-safety

The diff is comments and whitespace only, verified three ways:

1. **Comment-stripped comparison.** Both sides run through a stripper that tracks strings, template literals with nested `${}`, and regex literals, so a `//` inside any of them is never mistaken for a comment. All **198/198 changed files are code-identical**.
2. `pnpm typecheck` — green, 20/20 tasks.
3. `biome check` — clean, 198 files, no fixes applied.

Scope was also re-verified against a freshly generated file list: every changed path is inside the declared scope, zero out-of-scope edits.

## Two stale docblocks worth naming

Both were cut as stale. I checked each against the code afterwards, and in both cases the comment was wrong while the code is coherent — so neither needs follow-up work:

- `packages/depo/src/command.ts` claimed the command self-contains its services via `Command.provide`, baking in `DoormanClientLive` over `FetchHttpClient.layer`. The file contains no `provide`, `Doorman`, or `FetchHttpClient` reference at all. The real wiring lives at the run boundary in `packages/depo/src/run.ts` (`AppLayer = DoormanClientLive.pipe(Layer.provideMerge(...))`), and `packages/depo/src/live.ts:28` already says so. The docblock described an intent that was never implemented.
- `apps/web/tests/e2e/17-pano-add-comment.spec.ts` described a post-submit page reload dodging a Suspense double-mount race. The test performs no reload, and the inline comment at line 28 already records that the workaround is gone.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
