### PR TITLE
fix: triage homes offers phoenix's standing lanes in repos whose labels do not exist

### DIFF
--- a/claude-plugins/fabrika/guide/adopt-fabrika-in-a-new-repo.md
+++ b/claude-plugins/fabrika/guide/adopt-fabrika-in-a-new-repo.md
@@ -131,8 +131,8 @@ inert.
 
 An absent roadmap no longer stops you: `triage homes` degrades on it
 ([#5773](https://github.com/kamp-us/phoenix/issues/5773)). A file proven not to exist is a proven
-negative, so every open milestone lists with no arc name, the standing lanes list beside them, and
-stderr says so:
+negative, so every open milestone lists with no arc name, any standing lane your board carries lists
+beside them, and stderr says so:
 
 ```
 triage homes: no roadmap at ROADMAP.md — every milestone lists with no arc name.
@@ -195,26 +195,28 @@ fabrika triage homes
 Your milestone should appear as a `milestone` row. If it does not, the roadmap row's second cell does
 not match `^#(\d+)$`.
 
-## 8. Ignore the two `lane` rows
+## 8. The `lane` rows, if you get any
 
-`triage homes` will also print these, in your repo, whatever your board looks like:
+`triage homes` also prints a `lane` row per **standing lane** — a label that is a home in its own
+right, for work no milestone owns. You get one only where your repo both declares the lane and
+carries its label. In a fresh repo that is neither, so you get none, and stderr says so:
 
 ```
-lane	wayfinder:backlog	fog — uncharted work upstream of any arc
-lane	axis:pipeline-hardening	the standing pipeline and reliability lane
+triage homes: standing lanes: 0 of 2 declared carry a label in you/your-repo — not offered: wayfinder:backlog, axis:pipeline-hardening.
 ```
 
-Those are phoenix's own standing lanes, compiled into
-[`packages/fabrika-cli/src/triage/homes-verb.ts`](../../../packages/fabrika-cli/src/triage/homes-verb.ts)
-and printed unconditionally. Taking either at its word fails one step later at a different verb
-citing a different missing label.
+That is the correct answer, not a gap to fix. Home everything to a milestone and skip `--lane`.
 
-[ADR 0286](../../../.decisions/0286-standing-lanes-come-from-config.md) ruled that lanes come from
-your repo's own `.fabrika.jsonc` under a `lanes` key, and that a repo declaring none has none. **That
-key is not read yet** — the literal still has three copies in the CLI
-([#5785](https://github.com/kamp-us/phoenix/issues/5785)). Today: treat the two `lane` rows as noise,
-home everything to a milestone, and do not pass `--lane` to `triage apply` unless you have actually
-created those two labels on your board.
+If you do want a standing lane: create the label on your board, then declare it under
+`boardVocabulary.standingLanes` in `.fabrika.jsonc` (next section). Both halves are required — a
+declared lane whose label does not exist is not offered, which is what stops `triage apply --lane`
+from failing a write at the end of a full triage run.
+
+[ADR 0286](../../../.decisions/0286-standing-lanes-come-from-config.md) rules that lanes come from
+your repo, never from a CLI literal. `boardVocabulary.standingLanes` still ships phoenix's pair as
+its default, which 0286 says it should not; evicting that default is
+[#5785](https://github.com/kamp-us/phoenix/issues/5785). Until then the default reaches no board that
+has not created the labels.
 
 ## 9. Add the config file
 

--- a/claude-plugins/fabrika/guide/adopt-fabrika-in-a-new-repo.md
+++ b/claude-plugins/fabrika/guide/adopt-fabrika-in-a-new-repo.md
@@ -199,7 +199,8 @@ not match `^#(\d+)$`.
 
 `triage homes` also prints a `lane` row per **standing lane** — a label that is a home in its own
 right, for work no milestone owns. You get one only where your repo both declares the lane and
-carries its label. In a fresh repo that is neither, so you get none, and stderr says so:
+carries its label. A fresh repo declares both — phoenix's pair is the shipped default — but carries
+neither label, so you get none, and stderr says so:
 
 ```
 triage homes: standing lanes: 0 of 2 declared carry a label in you/your-repo — not offered: wayfinder:backlog, axis:pipeline-hardening.
@@ -212,11 +213,16 @@ If you do want a standing lane: create the label on your board, then declare it 
 declared lane whose label does not exist is not offered, which is what stops `triage apply --lane`
 from failing a write at the end of a full triage run.
 
+If you want none at all, say so: `"standingLanes": []` under `boardVocabulary`. Then `triage homes`
+reads no labels, offers no lane, and prints `standing lanes: this repo declares none.` — every issue
+homes on a milestone, and `triage apply --lane` refuses. Leaving the key out is a different answer:
+it falls to phoenix's pair, which then gets filtered against your board.
+
 [ADR 0286](../../../.decisions/0286-standing-lanes-come-from-config.md) rules that lanes come from
 your repo, never from a CLI literal. `boardVocabulary.standingLanes` still ships phoenix's pair as
-its default, which 0286 says it should not; evicting that default is
-[#5785](https://github.com/kamp-us/phoenix/issues/5785). Until then the default reaches no board that
-has not created the labels.
+the default for an absent key, which 0286 says it should not; evicting that default is
+[#6469](https://github.com/kamp-us/phoenix/issues/6469). Until then the default reaches no board that
+has not created the labels, and the empty declaration is how you opt out of it entirely.
 
 ## 9. Add the config file
 

--- a/claude-plugins/fabrika/guide/getting-started.md
+++ b/claude-plugins/fabrika/guide/getting-started.md
@@ -148,6 +148,7 @@ fabrika triage homes
 
 ```
 triage homes: scanned 5 open milestones in kamp-us/phoenix.
+triage homes: standing lanes: 2 of 2 declared carry a label in kamp-us/phoenix.
 triage homes: campaigns: 2 active — fabrika fast follows (#46), fabrika everywhere (#47).
 homes
 milestone	24	Geçit
@@ -160,9 +161,10 @@ lane	axis:pipeline-hardening	the standing pipeline and reliability lane
 ```
 
 That output is from a repo already set up, so yours will differ: one `milestone` row, the one you
-just created, and a second line reading `campaigns: none active — scope fence inert.` because your
-roadmap has no campaigns table. The two `lane` rows are phoenix's own standing lanes and print in
-every repo — [the how-to](adopt-fabrika-in-a-new-repo.md) explains why you ignore them.
+just created, and a line reading `campaigns: none active — scope fence inert.` because your roadmap
+has no campaigns table. You get no `lane` rows either — those are phoenix's own standing lanes, and a
+lane is offered only where your board carries its label
+([the how-to](adopt-fabrika-in-a-new-repo.md) covers them).
 
 Your milestone should be in that list. Commit `ROADMAP.md`.
 

--- a/claude-plugins/fabrika/skills/triage/contract.md
+++ b/claude-plugins/fabrika/skills/triage/contract.md
@@ -682,11 +682,11 @@ fabrika triage homes [--roadmap <path>] [--repo <owner/name>] [--json]
 | Flag | Type | Required | Default | Description |
 |---|---|---|---|---|
 | `--roadmap` | string | no | `roadmapFile` in `.fabrika.jsonc`, itself defaulting to `ROADMAP.md` | the roadmap file whose `## Arcs` and `## Campaigns` tables the open milestones are joined to. Unflagged, the verb resolves the declared path first; a `.fabrika.jsonc` it could not read refuses `11` rather than falling back to the shipped name |
+| `--repo` | string | no | resolved | the repository |
+| `--json` | boolean | no | `false` | emit the result object |
 
 There is no lane flag: the lane set is `boardVocabulary.standingLanes` in `.fabrika.jsonc`, and a
 config that could not be read or decoded refuses `11` on the same terms as `roadmapFile`.
-| `--repo` | string | no | resolved | the repository |
-| `--json` | boolean | no | `false` | emit the result object |
 
 **Output** — machine channel. The first line is the outcome token `homes`. Then one tab-separated
 line per candidate — `<kind>`, `<key>`, `<label-or-title>` — where `<kind>` is `milestone` or `lane`.
@@ -748,9 +748,15 @@ one, classified the whole issue, and only then hit a failed label write naming a
 the real cause (#6440). So the presence read is the same evidence the later `triage apply --lane`
 write depends on, taken before the menu is printed rather than after the work is done.
 
-A repo that declares no lanes reads no labels at all — there is nothing to filter — and prints no
-lane row. Neither case is a refusal: a home list over milestones alone is the right answer, and
-stderr carries which lanes were declared and which of them the board carries:
+**A repo declares no lanes by writing `"standingLanes": []`**, and then reads no labels at all —
+there is nothing to filter — and prints no lane row. The empty list is the one explicitly-empty
+`boardVocabulary` sub-key that decodes rather than refusing: the other four turn a gate off, while
+zero lanes turns nothing off and says every issue homes on a milestone. An **absent** key is not the
+same declaration — it falls to the shipped pair. `triage apply --lane` refuses over an empty set on
+`10`, naming the empty key rather than enumerating nothing.
+
+Neither case is a refusal: a home list over milestones alone is the right answer, and stderr carries
+which lanes were declared and which of them the board carries:
 
 | Declared set | stderr |
 |---|---|
@@ -768,10 +774,12 @@ no lanes from a repo it could not look at.
 
 This follows ADR 0286's ruling that lanes come from the repo, with one departure it names: 0286 puts
 them under a `lanes` key with **no** shipped default, and the key that exists today is
-`boardVocabulary.standingLanes`, which defaults to phoenix's pair. Evicting that default is
-[#5631](https://github.com/kamp-us/phoenix/issues/5631)/[#5785](https://github.com/kamp-us/phoenix/issues/5785)'s
-slice. Until it lands, the presence filter is what keeps the default from asserting anything about
-someone else's board.
+`boardVocabulary.standingLanes`, which defaults to phoenix's pair on an absent key. Evicting that
+default is [#6469](https://github.com/kamp-us/phoenix/issues/6469), which owns the whole move —
+0286's `lanes` key, the compiled-in label/meaning enumeration, and the readers that go with the set.
+Until it lands, two things contain the default: the presence filter, so it asserts nothing about a
+board that never created the labels, and the empty declaration, so a repo can say outright that it
+runs none.
 
 **The join, stated rather than left to the implementer** — this is the verb's whole split test, so it
 is the one thing that must not be inferred. `ROADMAP.md`'s `## Arcs` and `## Campaigns` tables are

--- a/claude-plugins/fabrika/skills/triage/contract.md
+++ b/claude-plugins/fabrika/skills/triage/contract.md
@@ -30,7 +30,7 @@ makes the implementer guess ([#4734](https://github.com/kamp-us/phoenix/issues/4
 | `triage queue` | the claimable `status:needs-triage` queue, with the count it scanned | paginating a label query and separating a proven-empty queue from a failed read is mechanical; which issue to take is judgment |
 | `triage claim` | take one lane's claim on one issue, proven by read-back | a marker write plus an earliest-claim tiebreak is a protocol, not a decision |
 | `triage provenance` | was this issue reported by an agent or hand-typed by a human | a structural marker test over a fetched body, plus a membership test over the configured operator set — an empty body fails closed to `human`, an unreadable one refuses rather than guessing; what to *do* about a human filing stays in the skill |
-| `triage homes` | the assignable homes — open milestones joined to their ROADMAP rows, plus the standing lanes, with every `active` campaign's milestone marked `running` | the join, the open-milestone filter and reading the campaigns table are mechanical; picking which home fits, and whether an exception applies, is judgment |
+| `triage homes` | the assignable homes — open milestones joined to their ROADMAP rows, plus the standing lanes this repo declares AND carries the labels for, with every `active` campaign's milestone marked `running` | the join, the open-milestone filter and reading the campaigns table are mechanical; picking which home fits, and whether an exception applies, is judgment |
 | `triage split` | create one split child, once, keyed on the parent back-reference | idempotency keyed on a durable reference is mechanical; deciding a report *is* a bundle is judgment |
 | `triage enrich` | replace the body with your rewrite — or, for an epic, your pitch — over a preserved, leak-redacted original | envelope assembly, redaction and read-back are mechanical; what the rewrite says is judgment |
 | `triage apply` | apply the whole triaged transition — type, priority, audience, home — and read it back | closed-vocabulary validation and an atomic label envelope are mechanical; the classification is judgment |
@@ -682,6 +682,9 @@ fabrika triage homes [--roadmap <path>] [--repo <owner/name>] [--json]
 | Flag | Type | Required | Default | Description |
 |---|---|---|---|---|
 | `--roadmap` | string | no | `roadmapFile` in `.fabrika.jsonc`, itself defaulting to `ROADMAP.md` | the roadmap file whose `## Arcs` and `## Campaigns` tables the open milestones are joined to. Unflagged, the verb resolves the declared path first; a `.fabrika.jsonc` it could not read refuses `11` rather than falling back to the shipped name |
+
+There is no lane flag: the lane set is `boardVocabulary.standingLanes` in `.fabrika.jsonc`, and a
+config that could not be read or decoded refuses `11` on the same terms as `roadmapFile`.
 | `--repo` | string | no | resolved | the repository |
 | `--json` | boolean | no | `false` | emit the result object |
 
@@ -689,21 +692,20 @@ fabrika triage homes [--roadmap <path>] [--repo <owner/name>] [--json]
 line per candidate — `<kind>`, `<key>`, `<label-or-title>` — where `<kind>` is `milestone` or `lane`.
 A `milestone` row's `<key>` is its **number** (the value `triage apply --home` takes) and its third
 column is the milestone title; a `lane` row's `<key>` is its label name and its third column is a
-fixed string, exactly one of:
+fixed meaning string:
 
 | Lane | Third column, verbatim |
 |---|---|
 | `wayfinder:backlog` | `fog — uncharted work upstream of any arc` |
 | `axis:pipeline-hardening` | `the standing pipeline and reliability lane` |
+| any other declared lane | `a standing lane this repo declares` |
 
-**This table is the only place in this spec that enumerates the standing lanes.** `triage apply`'s
-`--lane` takes its vocabulary from here rather than restating it; the two labels appear again only as
-bytes the verb itself emits (the facet pattern and the refusal message), never as a second list a
-reader could find drifted from this one.
+**This table is the only place in this spec that enumerates a lane meaning.** The strings are
+constants here rather than the repo's live label descriptions, so a description edit cannot change a
+machine-channel answer — and no source this verb reads can gloss a lane some other repo declared, so
+the third row says that instead of inventing one.
 
-Milestone rows come first, ordered by number, then the two lanes. The lane strings are constants in
-this spec rather than the repo's live label descriptions, so a description edit cannot change a
-machine-channel answer.
+Milestone rows come first, ordered by number, then the lanes in the order the config declares them.
 
 With `--json`, an object with keys `outcome`, `milestones` (array of `{number, title, roadmapRow}`),
 `lanes` (array of `{label, meaning}`), and `scanned`.
@@ -735,8 +737,41 @@ pinning a milestone that is closed or absent from the open set marks no row and 
 
 **Only open milestones appear, and each is joined to its roadmap arc/campaign row.** `roadmapRow` is
 `null` for an open milestone no roadmap row pins, which is itself a signal worth seeing rather than a
-row to hide. The two standing lanes are fixed and are not read from the repo. There is no third, and
-this verb never invents one.
+row to hide.
+
+**A lane row is offered only where this repo BOTH declares the lane and carries its label.** The
+declared set is `boardVocabulary.standingLanes` in `.fabrika.jsonc`, whose shipped default is
+phoenix's pair; the verb then reads the repo's own label set and drops every declared lane the board
+does not carry. Both halves are load-bearing. The declaration alone is a claim about a board — in
+`kamp-us/demlik`, where neither label exists, the pair printed as assignable homes and a triager took
+one, classified the whole issue, and only then hit a failed label write naming a label rather than
+the real cause (#6440). So the presence read is the same evidence the later `triage apply --lane`
+write depends on, taken before the menu is printed rather than after the work is done.
+
+A repo that declares no lanes reads no labels at all — there is nothing to filter — and prints no
+lane row. Neither case is a refusal: a home list over milestones alone is the right answer, and
+stderr carries which lanes were declared and which of them the board carries:
+
+| Declared set | stderr |
+|---|---|
+| empty | `triage homes: standing lanes: this repo declares none.` |
+| all present | `triage homes: standing lanes: 2 of 2 declared carry a label in <repo>.` |
+| some absent | `triage homes: standing lanes: 0 of 2 declared carry a label in <repo> — not offered: wayfinder:backlog, axis:pipeline-hardening.` |
+
+The dropped labels are named, not merely counted: the gap between what the config asserts and what
+the board carries is the defect, and a bare `0 of 2` sends the reader back to the config to find out
+which names it meant.
+
+**An unreadable label list is `11`, never "this repo has no lanes."** That reading silently shortens
+the menu, which is the failure this whole surface is built against — a caller cannot tell a repo with
+no lanes from a repo it could not look at.
+
+This follows ADR 0286's ruling that lanes come from the repo, with one departure it names: 0286 puts
+them under a `lanes` key with **no** shipped default, and the key that exists today is
+`boardVocabulary.standingLanes`, which defaults to phoenix's pair. Evicting that default is
+[#5631](https://github.com/kamp-us/phoenix/issues/5631)/[#5785](https://github.com/kamp-us/phoenix/issues/5785)'s
+slice. Until it lands, the presence filter is what keeps the default from asserting anything about
+someone else's board.
 
 **The join, stated rather than left to the implementer** — this is the verb's whole split test, so it
 is the one thing that must not be inferred. `ROADMAP.md`'s `## Arcs` and `## Campaigns` tables are
@@ -755,7 +790,7 @@ milestone titled `Sözlük — search and discovery`, and the two share no subst
 | Code | Trigger |
 |---|---|
 | `7` | the repository has zero open milestones, **or the roadmap parsed to zero arc rows** — zero scope |
-| `11` | the milestone list or the roadmap file could not be read — the outcome is UNKNOWN |
+| `11` | the milestone list, the repo's label set, the roadmap file or `.fabrika.jsonc` could not be read — the outcome is UNKNOWN |
 
 A malformed `## Campaigns` table is not on this table: it marks no row and names itself on stderr.
 The marker is an annotation on an answer this verb can give without it, so refusing over one would
@@ -766,6 +801,8 @@ withhold the home list a triager needs.
 | Message (stderr) | Code | Kind |
 |---|---|---|
 | `triage homes: cannot read milestones in <repo>: <reason> — the home list is UNKNOWN, never empty.` | 11 | refusal |
+| `triage homes: cannot read the labels in <repo>: <reason> — which standing lanes this board accepts is UNKNOWN, never none.` | 11 | refusal |
+| `triage homes: .fabrika.jsonc is refused — <reason>, so which standing lanes this repo runs is unread; the homes list is UNKNOWN, never short.` | 11 | refusal |
 | `triage homes: cannot probe the roadmap at <path>: <reason> — the home list is UNKNOWN, never empty.` | 11 | refusal |
 | `triage homes: cannot read the roadmap at <path>: <reason> — the home list is UNKNOWN, never empty.` | 11 | refusal |
 | `triage homes: <repo> has 0 open milestones — refusing to answer, since "no home exists" routes to a kill (ADR 0092).` | 7 | refusal |
@@ -783,7 +820,7 @@ passes.
 
 **An ABSENT roadmap is an answer, not either refusal (#5773).** A file that is proven not to exist is
 a proven negative — the join is simply empty — so every open milestone lists with `roadmapRow: null`,
-the standing lanes list beside them, and stderr carries
+any standing lane the board carries lists beside them, and stderr carries
 `triage homes: no roadmap at <path> — every milestone lists with no arc name.` The campaigns fence
 reads the absent file as the empty document, so its scope line says `campaigns: none active — scope
 fence inert.` The zero-arc-rows refusal above is reached only by a roadmap that *exists*, so the
@@ -802,8 +839,8 @@ cwd (see the CLI convention's Delivery section) unless `--roadmap` overrides it.
 milestones is a refusal, not an answer**: an empty candidate list routes the skill toward a standing
 lane or a kill, and a kill driven by a failed read is irreversible.
 
-**On a `7` refusal stdout is empty and `--json` emits nothing** — the two lane constants go to stderr
-with the refusal message. An earlier draft printed the lanes on stdout while withholding the outcome
+**On a `7` refusal stdout is empty and `--json` emits nothing** — the offered lanes go to stderr with
+the refusal message, which is why the label read runs ahead of the milestone read. An earlier draft printed the lanes on stdout while withholding the outcome
 token; that is a partial answer at a non-zero exit, which the shared conventions forbid and which
 hands a byte-reading caller two rows and no token.
 
@@ -1451,7 +1488,7 @@ fabrika triage apply 4312 --type chore --priority p2 --ready-for agent --lane ax
 | `--priority` | enum | yes | — | one of `p0`, `p1`, `p2` |
 | `--ready-for` | enum | yes | — | who picks it up: `human` or `agent` |
 | `--home` | integer | one of | — | the **number** of an open milestone to home the issue in |
-| `--lane` | enum | one of | — | a standing lane, taking its two values from the `lane` rows `triage homes` prints |
+| `--lane` | enum | one of | — | a standing lane, taking its values from the `lane` rows `triage homes` prints |
 | `--repo` | string | no | resolved | the repository |
 | `--json` | boolean | no | `false` | emit the result object |
 

--- a/packages/fabrika-cli/src/config/keys/board-vocabulary.ts
+++ b/packages/fabrika-cli/src/config/keys/board-vocabulary.ts
@@ -6,11 +6,17 @@
  * rather than restated here, so a repo with no `.fabrika.jsonc` reconciles and bootstraps exactly as
  * phoenix does today.
  *
- * **Every sub-key is independently optional, and an explicitly-empty one is refused.** A repo that
- * renames only its lanes declares only `standingLanes`; the other four fall to their defaults like
- * any undeclared key. But `"types": []` would leave `triage apply --type` with nothing to accept and
- * `status bootstrap` with nothing to create — a gate turned off by a settings file, which is the one
- * thing this surface refuses whole.
+ * **Every sub-key is independently optional, and an explicitly-empty one is refused — except
+ * `standingLanes`.** A repo that renames only its lanes declares only `standingLanes`; the other
+ * four fall to their defaults like any undeclared key. But `"types": []` would leave
+ * `triage apply --type` with nothing to accept and `status bootstrap` with nothing to create — a
+ * gate turned off by a settings file, which is the one thing this surface refuses whole.
+ *
+ * `"standingLanes": []` turns nothing off. It says every issue homes on a milestone, which is a
+ * board shape a repo may genuinely have — ADR 0286 rules an absent key and an empty list both mean
+ * zero lanes. Refusing it left `triage homes`'s "this repo declares none" answer unreachable from
+ * any configuration: a documented state no operator could produce (#6440). An **absent** key still
+ * falls to the shipped pair; that departure from 0286 is #6469's.
  *
  * **A sub-key this module does not know is refused too.** `"standingLane": [...]` would otherwise be
  * a declaration the operator believes is configured and is not.
@@ -30,6 +36,9 @@ const STATUS_ROLES = ["needsTriage", "triaged", "needsInfo", "planned", "awaitin
 const LIST_KEYS = ["types", "priorities", "audiences", "standingLanes"] as const;
 
 type ListKey = (typeof LIST_KEYS)[number];
+
+/** The one list key whose empty declaration is an answer rather than a disabled gate — see above. */
+const EMPTY_DECLARABLE: ReadonlyArray<ListKey> = ["standingLanes"];
 
 interface Bad {
 	readonly reason: string;
@@ -54,7 +63,7 @@ const decodeList = (raw: unknown, key: ListKey): ReadonlyArray<string> | Bad => 
 		}
 		values.push(entry.trim());
 	}
-	if (values.length === 0) {
+	if (values.length === 0 && !EMPTY_DECLARABLE.includes(key)) {
 		return {reason: `${named(key)} is empty — a facet with no vocabulary accepts nothing`};
 	}
 	const duplicate = values.find((value, i) => values.indexOf(value) !== i);

--- a/packages/fabrika-cli/src/config/keys/board-vocabulary.unit.test.ts
+++ b/packages/fabrika-cli/src/config/keys/board-vocabulary.unit.test.ts
@@ -74,6 +74,15 @@ describe("a declared vocabulary", () => {
 		expect(resolved.reason).toContain("priorities");
 	});
 
+	/** Zero lanes disables no gate — it says every issue homes on a milestone (#6440). */
+	it("takes an empty standingLanes as a declaration, not as a disabled facet", () => {
+		const resolved = declared({standingLanes: []});
+		expect(resolved._tag).toBe("Declared");
+		if (resolved._tag !== "Declared") return;
+		expect(resolved.value.standingLanes).toEqual([]);
+		expect(resolved.value.priorities).toEqual(PRIORITIES);
+	});
+
 	it("refuses a sub-key nobody reads, rather than ignoring it", () => {
 		const resolved = declared({standingLane: ["team:infra"]});
 		expect(resolved._tag).toBe("Malformed");

--- a/packages/fabrika-cli/src/config/paths.ts
+++ b/packages/fabrika-cli/src/config/paths.ts
@@ -1,21 +1,13 @@
 /**
- * One key of the path surface, read off the checkout a verb is standing in.
+ * The declared paths a verb opens, each read off the checkout it is standing in.
  *
- * Every reader wants the same three things — the value, a sentence naming where it came from, and a
- * refusal it can print verbatim — so the four resolution arms collapse here once instead of at each
- * of the dozen call sites. **`Malformed` and `Unknown` both refuse**: a value nobody could decode
- * and a file nobody could read are equally not an answer, and neither may fall back to the shipped
- * default it did not resolve to. Falling back is how a typo in `.fabrika.jsonc` silently restores
- * phoenix's own paths in a repo that is not phoenix.
- *
- * Per key rather than a whole-surface read: a verb that needs the governed roots has no business
- * refusing over a malformed `cycleDoc` it never opens. The whole-config gate that *does* refuse on
- * any key is `./unusable.ts`, and it stays the write path's gate.
+ * The four-arm collapse every key reader shares lives at `./read-key.ts`; this module is the path
+ * surface's own readers over it, plus the `…Or` shapes that pair a value with the one refusal
+ * sentence its several callers print.
  */
 
 import {Effect, type FileSystem, type Path} from "effect";
 import {CONFIG_PATH} from "./document.ts";
-import type {KeyGroup} from "./key-group.ts";
 import {governedRootsKey} from "./keys/governed-roots.ts";
 import {
 	cycleDocKey,
@@ -25,39 +17,9 @@ import {
 	type PathValue,
 	roadmapFileKey,
 } from "./keys/paths.ts";
-import {resolve} from "./load.ts";
-import {loadRepoConfig} from "./working-root.ts";
+import {type Read, readKey} from "./read-key.ts";
 
-export type Read<A> =
-	/** The value to use, and the sentence a verb prints about where it came from. */
-	| {readonly _tag: "Value"; readonly value: A; readonly note: string}
-	/** No value may be used, and this is the reason, worded by the key that raised it. */
-	| {readonly _tag: "Refused"; readonly reason: string};
-
-const readKey = <A>(
-	cwd: string,
-	group: KeyGroup<A>,
-): Effect.Effect<Read<A>, never, FileSystem.FileSystem | Path.Path> =>
-	Effect.gen(function* () {
-		const resolved = resolve(yield* loadRepoConfig(cwd), group);
-		switch (resolved._tag) {
-			case "Malformed":
-			case "Unknown":
-				return {_tag: "Refused" as const, reason: resolved.reason};
-			case "Declared":
-				return {
-					_tag: "Value" as const,
-					value: resolved.value,
-					note: `\`${group.key}\` as declared in ${CONFIG_PATH}`,
-				};
-			case "Default":
-				return {
-					_tag: "Value" as const,
-					value: resolved.value,
-					note: `the shipped \`${group.key}\` — ${resolved.reason}`,
-				};
-		}
-	});
+export type {Read};
 
 /** The roots a diff derives the `governance` namespace over, for this repo. */
 export const readGovernedRoots = (

--- a/packages/fabrika-cli/src/config/read-key.ts
+++ b/packages/fabrika-cli/src/config/read-key.ts
@@ -1,0 +1,51 @@
+/**
+ * One key of `.fabrika.jsonc`, read off the checkout a verb is standing in.
+ *
+ * Every reader wants the same three things — the value, a sentence naming where it came from, and a
+ * refusal it can print verbatim — so the four resolution arms collapse here once instead of at each
+ * call site. **`Malformed` and `Unknown` both refuse**: a value nobody could decode and a file
+ * nobody could read are equally not an answer, and neither may fall back to the shipped default it
+ * did not resolve to. Falling back is how a typo in `.fabrika.jsonc` silently restores phoenix's own
+ * values in a repo that is not phoenix.
+ *
+ * Per key rather than a whole-surface read: a verb that needs the standing lanes has no business
+ * refusing over a malformed `cycleDoc` it never opens. The whole-config gate that *does* refuse on
+ * any key is `./unusable.ts`, and it stays the write path's gate.
+ */
+
+import {Effect, type FileSystem, type Path} from "effect";
+import {CONFIG_PATH} from "./document.ts";
+import type {KeyGroup} from "./key-group.ts";
+import {resolve} from "./load.ts";
+import {loadRepoConfig} from "./working-root.ts";
+
+export type Read<A> =
+	/** The value to use, and the sentence a verb prints about where it came from. */
+	| {readonly _tag: "Value"; readonly value: A; readonly note: string}
+	/** No value may be used, and this is the reason, worded by the key that raised it. */
+	| {readonly _tag: "Refused"; readonly reason: string};
+
+export const readKey = <A>(
+	cwd: string,
+	group: KeyGroup<A>,
+): Effect.Effect<Read<A>, never, FileSystem.FileSystem | Path.Path> =>
+	Effect.gen(function* () {
+		const resolved = resolve(yield* loadRepoConfig(cwd), group);
+		switch (resolved._tag) {
+			case "Malformed":
+			case "Unknown":
+				return {_tag: "Refused" as const, reason: resolved.reason};
+			case "Declared":
+				return {
+					_tag: "Value" as const,
+					value: resolved.value,
+					note: `\`${group.key}\` as declared in ${CONFIG_PATH}`,
+				};
+			case "Default":
+				return {
+					_tag: "Value" as const,
+					value: resolved.value,
+					note: `the shipped \`${group.key}\` — ${resolved.reason}`,
+				};
+		}
+	});

--- a/packages/fabrika-cli/src/triage/apply-verb.ts
+++ b/packages/fabrika-cli/src/triage/apply-verb.ts
@@ -134,6 +134,15 @@ export const runApply = (
 		// gone and this decode against the resolved list is the whole refusal (#6294).
 		let lane: string | null = null;
 		if (options.lane !== null) {
+			// A repo that declares `standingLanes: []` runs none, so the enumerating message below
+			// would read `--lane must be  — got "x"` and send the caller looking for a value to
+			// type. There is none: the answer is a milestone (#6440).
+			if (standingLanes.length === 0) {
+				return refuse(
+					OFF_VOCABULARY,
+					`triage apply: this repo declares no standing lane — \`boardVocabulary.standingLanes\` in \`.fabrika.jsonc\` is empty, so every issue homes on a milestone. Got "${options.lane}".`,
+				);
+			}
 			lane = decodeMember(standingLanes, options.lane);
 			if (lane === null) {
 				return refuse(

--- a/packages/fabrika-cli/src/triage/apply-verb.unit.test.ts
+++ b/packages/fabrika-cli/src/triage/apply-verb.unit.test.ts
@@ -271,6 +271,25 @@ describe("runApply", () => {
 		expect(shell.calls).toEqual([]);
 	});
 
+	/**
+	 * A repo declaring `standingLanes: []` runs none, so the enumerating message would render
+	 * `--lane must be  — got "x"` and send the caller hunting for a value that does not exist
+	 * (#6440).
+	 */
+	it("refuses --lane over a repo that declares no lane, naming the empty key", async () => {
+		const shell = guardedShell(happy());
+		const out = await Effect.runPromise(
+			Effect.provide(
+				runApply({...options, home: null, lane: "wayfinder:backlog"}),
+				triageContext(shell, JSON.stringify({boardVocabulary: {standingLanes: []}})),
+			),
+		);
+		expect(out.code).toBe(OFF_VOCABULARY);
+		expect(out.stdout).toBe("");
+		expect(out.stderr.at(-1)).toContain("this repo declares no standing lane");
+		expect(shell.calls).toEqual([]);
+	});
+
 	it("refuses a milestone that is not open, on the same code", async () => {
 		const out = await run(happy(), {home: 99});
 		expect(out.code).toBe(OFF_VOCABULARY);

--- a/packages/fabrika-cli/src/triage/command.ts
+++ b/packages/fabrika-cli/src/triage/command.ts
@@ -36,6 +36,7 @@ import {DEFAULT_QUEUE_LABEL, DEFAULT_QUEUE_LIMIT, runQueue} from "./queue-verb.t
 import {runRepairCriteria} from "./repair-criteria-verb.ts";
 import {ROADMAP_FILE} from "./roadmap.ts";
 import {runSplit} from "./split-verb.ts";
+import {readStandingLanes} from "./standing-lanes.ts";
 
 /** Write the outcome and exit on its code — stdout is the answer, everything else is stderr. */
 const emit = (outcome: VerbOutcome): Effect.Effect<void> =>
@@ -351,14 +352,29 @@ const homes = leafCommand(
 			);
 		}
 		const path = named ?? declared?.value ?? ROADMAP_FILE;
+		const lanes = yield* readStandingLanes(process.cwd());
+		if (lanes._tag === "Refused") {
+			return yield* emit(
+				refuse(
+					PRECONDITION_UNKNOWN,
+					`triage homes: ${CONFIG_PATH} is refused — ${lanes.reason.replace(/\.$/, "")}, so which standing lanes this repo runs is unread; the homes list is UNKNOWN, never short.`,
+				),
+			);
+		}
 		yield* emit(
-			yield* runHomes({roadmap: path, repo: Option.getOrNull(repo), json, env: process.env}),
+			yield* runHomes({
+				roadmap: path,
+				standingLanes: lanes.value,
+				repo: Option.getOrNull(repo),
+				json,
+				env: process.env,
+			}),
 		);
 	}),
 ).pipe(
 	Command.withShortDescription("The assignable homes: open milestones and standing lanes."),
 	Command.withDescription(
-		"List the assignable homes: every OPEN milestone joined to its roadmap arc/campaign row by `#<number>`, plus the two standing lanes. First stdout line is `homes`, then one `<kind>\\t<key>\\t<label>` line per candidate; every `active` campaign's milestone carries a fourth column, `running: p0/blocker only` (a `running` field under `--json`) — such a campaign is closed to new intake unless the work is p0 or blocks one of its own in-flight lanes. An ABSENT roadmap is not a refusal: every milestone lists with a null arc row and stderr says no roadmap was found. Exits 7 (zero open milestones, or a roadmap that exists and parsed to 0 arc rows), 11 (the milestone list could not be read, or a roadmap that exists could not be read or probed). Example: fabrika triage homes",
+		"List the assignable homes: every OPEN milestone joined to its roadmap arc/campaign row by `#<number>`, plus every standing lane this repo BOTH declares in `.fabrika.jsonc` (`boardVocabulary.standingLanes`) and carries the label for — a repo whose board lacks a declared lane is offered none, so no listed home can fail a label write later. First stdout line is `homes`, then one `<kind>\\t<key>\\t<label>` line per candidate; every `active` campaign's milestone carries a fourth column, `running: p0/blocker only` (a `running` field under `--json`) — such a campaign is closed to new intake unless the work is p0 or blocks one of its own in-flight lanes. An ABSENT roadmap is not a refusal: every milestone lists with a null arc row and stderr says no roadmap was found. Exits 7 (zero open milestones, or a roadmap that exists and parsed to 0 arc rows), 11 (the milestone list, the repo's label set or a roadmap that exists could not be read or probed, or `.fabrika.jsonc` yielded no usable lane set). Example: fabrika triage homes",
 	),
 );
 

--- a/packages/fabrika-cli/src/triage/homes-verb.ts
+++ b/packages/fabrika-cli/src/triage/homes-verb.ts
@@ -1,6 +1,6 @@
 /**
  * `triage homes` — the assignable homes: every **open** milestone joined to its roadmap arc or
- * campaign row, plus the two standing lanes.
+ * campaign row, plus the standing lanes this repo declares AND carries the labels for.
  *
  * **Zero open milestones is a refusal, not an answer.** An empty candidate list routes the caller
  * toward a standing lane or a close, and a close driven by a failed read is irreversible — so both
@@ -25,30 +25,12 @@
 import {Effect, Result} from "effect";
 import {dispatchMilestones, dispatchScopeLine, readCampaigns} from "../build/scope-admission.ts";
 import {exists, readFile} from "../io/fs.ts";
-import {listOpenMilestones, resolveRepo} from "../io/issues.ts";
+import {listLabels, listOpenMilestones, resolveRepo} from "../io/issues.ts";
 import {answer, FAILED, refuse} from "../verb.ts";
 import {PRECONDITION_UNKNOWN, ZERO_SCOPE} from "./codes.ts";
 import {parseRoadmap, type RoadmapRows, roadmapRowFor} from "./roadmap.ts";
 import {scannedLine} from "./scope.ts";
-
-/** One standing lane: a label that is a home in its own right, and what routing to it means. */
-export interface StandingLane {
-	readonly label: string;
-	readonly meaning: string;
-}
-
-/**
- * The two standing lanes, and **the only place in this package that enumerates them.**
- *
- * `triage apply --lane` takes its vocabulary from here rather than restating it, so the pair cannot
- * drift into two lists a reader has to reconcile. The meanings are constants rather than the repo's
- * live label descriptions, so a description edit cannot change a machine-channel answer. There is no
- * third lane, and this verb never invents one.
- */
-export const STANDING_LANES: ReadonlyArray<StandingLane> = [
-	{label: "wayfinder:backlog", meaning: "fog — uncharted work upstream of any arc"},
-	{label: "axis:pipeline-hardening", meaning: "the standing pipeline and reliability lane"},
-];
+import {offeredLanes, type StandingLane} from "./standing-lanes.ts";
 
 /**
  * The roadmap side of the join: a file that was read and parsed, or one proven absent.
@@ -66,15 +48,35 @@ export const RUNNING_MARKER = "running: p0/blocker only";
 
 export interface HomesOptions {
 	readonly roadmap: string;
+	/** The lanes this repo declares — resolved from `.fabrika.jsonc` by the delivery layer. */
+	readonly standingLanes: ReadonlyArray<string>;
 	readonly repo: string | null;
 	readonly json: boolean;
 	readonly env: Readonly<Record<string, string | undefined>>;
 }
 
 /** The lane rows, on stderr — a `7` refusal withholds stdout entirely, so they go where they fit. */
-const laneNotice = STANDING_LANES.map(
-	(lane) => `triage homes: standing lane ${lane.label} — ${lane.meaning}`,
-);
+const laneNotices = (lanes: ReadonlyArray<StandingLane>): ReadonlyArray<string> =>
+	lanes.map((lane) => `triage homes: standing lane ${lane.label} — ${lane.meaning}`);
+
+/**
+ * What the declared lane set became on this board, as one stderr line.
+ *
+ * It names the dropped labels rather than only the count: an operator in a repo where the lanes were
+ * never created needs to see WHICH names the config asserts and the board lacks — that gap is the
+ * whole defect, and a bare `0 of 2` sends them back to the config to find out.
+ */
+const laneScopeLine = (
+	repo: string,
+	declared: ReadonlyArray<string>,
+	offered: ReadonlyArray<StandingLane>,
+): string => {
+	if (declared.length === 0) return "triage homes: standing lanes: this repo declares none.";
+	const offeredLabels = new Set(offered.map((lane) => lane.label));
+	const dropped = declared.filter((label) => !offeredLabels.has(label));
+	const tail = dropped.length === 0 ? "" : ` — not offered: ${dropped.join(", ")}`;
+	return `triage homes: standing lanes: ${offered.length} of ${declared.length} declared carry a label in ${repo}${tail}.`;
+};
 
 export const runHomes = Effect.fn("runHomes")(function* (options: HomesOptions) {
 	const {roadmap, json} = options;
@@ -87,6 +89,23 @@ export const runHomes = Effect.fn("runHomes")(function* (options: HomesOptions) 
 		);
 	}
 	const repo = repoAttempt.value;
+
+	// The declared set is a candidate list, never the answer: a lane is offered only once this board
+	// is observed to carry its label, which is the same evidence the `triage apply --lane` write it
+	// routes to depends on (#6440). An unreadable label list is UNKNOWN — never "this repo has no
+	// lanes", which is the reading that silently shortens the menu.
+	let lanes: ReadonlyArray<StandingLane> = [];
+	if (options.standingLanes.length > 0) {
+		const labels = yield* listLabels(repo);
+		if (labels._tag === "Failure") {
+			return refuse(
+				PRECONDITION_UNKNOWN,
+				`triage homes: cannot read the labels in ${repo}: ${labels.reason} — which standing lanes this board accepts is UNKNOWN, never none.`,
+			);
+		}
+		lanes = offeredLanes(options.standingLanes, new Set(labels.value));
+	}
+	const laneScope = laneScopeLine(repo, options.standingLanes, lanes);
 
 	const milestones = yield* listOpenMilestones(repo);
 	if (milestones._tag === "Failure") {
@@ -101,7 +120,7 @@ export const runHomes = Effect.fn("runHomes")(function* (options: HomesOptions) 
 		return refuse(
 			ZERO_SCOPE,
 			`triage homes: ${repo} has 0 open milestones — refusing to answer, since "no home exists" routes to a kill (ADR 0092).`,
-			[scope, ...laneNotice],
+			[scope, laneScope, ...laneNotices(lanes)],
 		);
 	}
 
@@ -134,7 +153,7 @@ export const runHomes = Effect.fn("runHomes")(function* (options: HomesOptions) 
 		return refuse(
 			ZERO_SCOPE,
 			`triage homes: the roadmap at ${roadmap} parsed to 0 arc rows — the table grammar changed or the file is truncated; refusing to answer over an unjoinable roadmap.`,
-			[scope, ...laneNotice],
+			[scope, laneScope, ...laneNotices(lanes)],
 		);
 	}
 
@@ -156,6 +175,7 @@ export const runHomes = Effect.fn("runHomes")(function* (options: HomesOptions) 
 		}));
 	const notices = [
 		scope,
+		laneScope,
 		...(side._tag === "Absent"
 			? [`triage homes: no roadmap at ${roadmap} — every milestone lists with no arc name.`]
 			: []),
@@ -167,7 +187,7 @@ export const runHomes = Effect.fn("runHomes")(function* (options: HomesOptions) 
 			JSON.stringify({
 				outcome: "homes",
 				milestones: homes,
-				lanes: STANDING_LANES,
+				lanes,
 				scanned: milestones.value.length,
 			}),
 			notices,
@@ -181,7 +201,7 @@ export const runHomes = Effect.fn("runHomes")(function* (options: HomesOptions) 
 					.filter((cell) => cell !== undefined)
 					.join("\t"),
 			),
-			...STANDING_LANES.map((lane) => `lane\t${lane.label}\t${lane.meaning}`),
+			...lanes.map((lane) => `lane\t${lane.label}\t${lane.meaning}`),
 		].join("\n"),
 		notices,
 	);

--- a/packages/fabrika-cli/src/triage/homes-verb.unit.test.ts
+++ b/packages/fabrika-cli/src/triage/homes-verb.unit.test.ts
@@ -325,6 +325,11 @@ describe("runHomes and the standing lanes the host repo carries", () => {
 		expect(out.stderr.at(-1)).toContain("which standing lanes this board accepts is UNKNOWN");
 	});
 
+	/*
+	 * The empty declared set an operator produces with `"standingLanes": []` — the config half is
+	 * `standing-lanes.unit.test.ts`'s "reads an explicitly empty declaration as zero lanes", and
+	 * `command.ts` passes what it read straight through (#6440).
+	 */
 	it("reads no labels at all when the repo declares no lanes — there is nothing to filter", async () => {
 		const shell = fakeShell([twoMilestones]);
 		await Effect.runPromise(

--- a/packages/fabrika-cli/src/triage/homes-verb.unit.test.ts
+++ b/packages/fabrika-cli/src/triage/homes-verb.unit.test.ts
@@ -3,9 +3,17 @@ import {describe, expect, it} from "vitest";
 import {errOut, fakeFs, fakeShell, okOut} from "../fakes.test-support.ts";
 import {ANSWER, FAILED} from "../verb.ts";
 import {PRECONDITION_UNKNOWN, ZERO_SCOPE} from "./codes.ts";
-import {RUNNING_MARKER, runHomes, STANDING_LANES} from "./homes-verb.ts";
+import {RUNNING_MARKER, runHomes} from "./homes-verb.ts";
+import {offeredLanes} from "./standing-lanes.ts";
 
 const MILESTONES = /repos\/o\/r\/milestones/;
+const LABELS = /repos\/o\/r\/labels/;
+
+/** The shipped default lane set — what a repo declaring no `boardVocabulary` resolves to. */
+const PHOENIX_LANES = ["wayfinder:backlog", "axis:pipeline-hardening"];
+
+/** A board carrying both lane labels, so the presence filter offers both — phoenix's own state. */
+const bothLabels = [LABELS, okOut(["type:bug", ...PHOENIX_LANES].join("\n"))] as const;
 
 const ROADMAP = `## Arcs
 
@@ -22,6 +30,7 @@ const ROADMAP = `## Arcs
 
 const options = {
 	roadmap: "ROADMAP.md",
+	standingLanes: PHOENIX_LANES as ReadonlyArray<string>,
 	repo: null,
 	json: false,
 	env: {CLAUDE_PIPELINE_REPO: "o/r"} as Record<string, string | undefined>,
@@ -39,7 +48,9 @@ const run = (
 	Effect.runPromise(
 		Effect.provide(
 			runHomes({...options, ...overrides}),
-			Layer.merge(fakeShell(script).layer, fakeFs({files, ...fs}).layer),
+			// The label read is appended, never prepended: a case that scripts `LABELS` itself is
+			// asserting on the presence filter, and its entry has to win the first-match lookup.
+			Layer.merge(fakeShell([...script, bothLabels]).layer, fakeFs({files, ...fs}).layer),
 		),
 	);
 
@@ -81,11 +92,6 @@ describe("runHomes", () => {
 		expect(JSON.parse(out.stdout).milestones).toEqual([
 			{number: 99, title: "off-roadmap", roadmapRow: null},
 		]);
-	});
-
-	it("carries the standing lanes into the --json payload from the one enumeration", async () => {
-		const out = await run([twoMilestones], {"ROADMAP.md": ROADMAP}, {json: true});
-		expect(JSON.parse(out.stdout).lanes).toEqual(STANDING_LANES);
 	});
 
 	it("reports the scanned milestone count on stderr", async () => {
@@ -183,15 +189,16 @@ describe("runHomes", () => {
 	});
 
 	it("pages the milestone read and asks only for open ones", async () => {
-		const shell = fakeShell([twoMilestones]);
+		const shell = fakeShell([twoMilestones, bothLabels]);
 		await Effect.runPromise(
 			Effect.provide(
 				runHomes(options),
 				Layer.merge(shell.layer, fakeFs({files: {"ROADMAP.md": ROADMAP}}).layer),
 			),
 		);
-		expect(shell.calls[0]).toContain("--paginate");
-		expect(shell.calls[0]).toContain("state=open");
+		const call = shell.calls.find((line) => line.includes("/milestones")) ?? "";
+		expect(call).toContain("--paginate");
+		expect(call).toContain("state=open");
 	});
 
 	it("reads the roadmap the --roadmap flag names", async () => {
@@ -272,11 +279,67 @@ describe("runHomes and the running-campaign marker", () => {
 	});
 });
 
-describe("STANDING_LANES", () => {
-	it("is the only enumeration of the lanes — two of them, and no third", () => {
-		expect(STANDING_LANES.map((l) => l.label)).toEqual([
-			"wayfinder:backlog",
-			"axis:pipeline-hardening",
+describe("runHomes and the standing lanes the host repo carries", () => {
+	it("offers a declared lane only when the board carries its label — the bare-repo arm", async () => {
+		const out = await run([twoMilestones, [LABELS, okOut("bug\nenhancement")]]);
+		expect(out.code).toBe(ANSWER);
+		expect(out.stdout.trimEnd().split("\n")).toEqual([
+			"homes",
+			"milestone\t24\tSözlük — search and discovery",
+			"milestone\t44\tfabrika",
 		]);
+	});
+
+	it("still offers both in a repo carrying both — the shipped default reproduces phoenix", async () => {
+		const out = await run([twoMilestones]);
+		expect(out.stdout.trimEnd().split("\n").slice(-2)).toEqual([
+			"lane\twayfinder:backlog\tfog — uncharted work upstream of any arc",
+			"lane\taxis:pipeline-hardening\tthe standing pipeline and reliability lane",
+		]);
+	});
+
+	it("drops only the missing lane when the board carries one of the two", async () => {
+		const out = await run([twoMilestones, [LABELS, okOut("wayfinder:backlog")]]);
+		expect(out.stdout).toContain("lane\twayfinder:backlog");
+		expect(out.stdout).not.toContain("axis:pipeline-hardening");
+	});
+
+	it("names the dropped labels on stderr, so the config/board gap is readable at the point it bites", async () => {
+		const out = await run([twoMilestones, [LABELS, okOut("bug")]]);
+		expect(out.stderr.join("\n")).toContain(
+			"standing lanes: 0 of 2 declared carry a label in o/r — not offered: wayfinder:backlog, axis:pipeline-hardening.",
+		);
+	});
+
+	it("carries the offered lanes, not the declared set, into the --json payload", async () => {
+		const out = await run([twoMilestones, [LABELS, okOut("wayfinder:backlog")]], {}, {json: true});
+		expect(JSON.parse(out.stdout).lanes).toEqual(
+			offeredLanes(PHOENIX_LANES, new Set(["wayfinder:backlog"])),
+		);
+	});
+
+	it("refuses an unreadable label list as UNKNOWN — never as `this repo declares no lanes`", async () => {
+		const out = await run([twoMilestones, [LABELS, errOut("gh: Bad gateway (HTTP 502)")]]);
+		expect(out.code).toBe(PRECONDITION_UNKNOWN);
+		expect(out.stdout).toBe("");
+		expect(out.stderr.at(-1)).toContain("which standing lanes this board accepts is UNKNOWN");
+	});
+
+	it("reads no labels at all when the repo declares no lanes — there is nothing to filter", async () => {
+		const shell = fakeShell([twoMilestones]);
+		await Effect.runPromise(
+			Effect.provide(
+				runHomes({...options, standingLanes: []}),
+				Layer.merge(shell.layer, fakeFs({files: {"ROADMAP.md": ROADMAP}}).layer),
+			),
+		);
+		expect(shell.calls.some((line) => line.includes("/labels"))).toBe(false);
+	});
+
+	it("says the repo declares none rather than printing a bare 0-of-0 count", async () => {
+		const out = await run([twoMilestones], {"ROADMAP.md": ROADMAP}, {standingLanes: []});
+		expect(out.code).toBe(ANSWER);
+		expect(out.stdout).not.toContain("lane\t");
+		expect(out.stderr.join("\n")).toContain("standing lanes: this repo declares none.");
 	});
 });

--- a/packages/fabrika-cli/src/triage/standing-lanes.ts
+++ b/packages/fabrika-cli/src/triage/standing-lanes.ts
@@ -10,9 +10,9 @@
  * declared set is a candidate list, never the answer — a lane is offered only once the board is
  * observed to carry its label, which is the same evidence the later write depends on.
  *
- * ADR 0286 rules the source is config with no shipped default; the default survives until the
- * `boardVocabulary` eviction lands (#5631/#5785), and the presence filter is what makes it harmless
- * in the meantime.
+ * ADR 0286 rules the source is config with no shipped default. The default survives until the
+ * `boardVocabulary` eviction lands, which is #6469's — the presence filter is what contains it in
+ * the meantime, and `"standingLanes": []` is how a repo says it runs none.
  */
 
 import {Effect, type FileSystem, type Path} from "effect";

--- a/packages/fabrika-cli/src/triage/standing-lanes.ts
+++ b/packages/fabrika-cli/src/triage/standing-lanes.ts
@@ -1,0 +1,65 @@
+/**
+ * Which standing lanes are assignable homes **in this repo** — the declared set, narrowed to the
+ * labels the board actually carries.
+ *
+ * Two questions, deliberately joined here. `boardVocabulary.standingLanes` says which lanes this
+ * repo runs, and it has a shipped default, so a repo that declares nothing still resolves to
+ * phoenix's pair. That default is a claim about someone else's board: in a repo where neither label
+ * exists, `triage homes` offered both anyway and a triager took one, classified the whole issue, and
+ * only then hit a failed label write naming a label rather than the real cause (#6440). So the
+ * declared set is a candidate list, never the answer — a lane is offered only once the board is
+ * observed to carry its label, which is the same evidence the later write depends on.
+ *
+ * ADR 0286 rules the source is config with no shipped default; the default survives until the
+ * `boardVocabulary` eviction lands (#5631/#5785), and the presence filter is what makes it harmless
+ * in the meantime.
+ */
+
+import {Effect, type FileSystem, type Path} from "effect";
+import {boardVocabularyKey} from "../config/keys/board-vocabulary.ts";
+import {type Read, readKey} from "../config/read-key.ts";
+
+/** One standing lane: a label that is a home in its own right, and what routing to it means. */
+export interface StandingLane {
+	readonly label: string;
+	readonly meaning: string;
+}
+
+/**
+ * What routing to each of phoenix's own lanes means.
+ *
+ * Constants rather than the repo's live label descriptions, so a description edit cannot change a
+ * machine-channel answer. A lane outside this map is one some repo declared, and no source here can
+ * say what it means — {@link DECLARED_MEANING} says exactly that instead of inventing a gloss.
+ */
+const SHIPPED_MEANINGS: Readonly<Record<string, string>> = {
+	"wayfinder:backlog": "fog — uncharted work upstream of any arc",
+	"axis:pipeline-hardening": "the standing pipeline and reliability lane",
+};
+
+export const DECLARED_MEANING = "a standing lane this repo declares";
+
+/** The lanes this repo declares, or the one refusal a reader of them prints. */
+export const readStandingLanes = (
+	cwd: string,
+): Effect.Effect<Read<ReadonlyArray<string>>, never, FileSystem.FileSystem | Path.Path> =>
+	Effect.gen(function* () {
+		const read = yield* readKey(cwd, boardVocabularyKey);
+		return read._tag === "Refused"
+			? read
+			: {_tag: "Value" as const, value: read.value.standingLanes, note: read.note};
+	});
+
+/**
+ * The declared lanes this board can actually accept, in declared order.
+ *
+ * `present` is the repo's label set. A lane the board does not carry is dropped rather than reported
+ * with a caveat: this list is a menu, and a menu row nobody may order is the defect.
+ */
+export const offeredLanes = (
+	declared: ReadonlyArray<string>,
+	present: ReadonlySet<string>,
+): ReadonlyArray<StandingLane> =>
+	declared
+		.filter((label) => present.has(label))
+		.map((label) => ({label, meaning: SHIPPED_MEANINGS[label] ?? DECLARED_MEANING}));

--- a/packages/fabrika-cli/src/triage/standing-lanes.unit.test.ts
+++ b/packages/fabrika-cli/src/triage/standing-lanes.unit.test.ts
@@ -67,9 +67,20 @@ describe("readStandingLanes", () => {
 		expect(lanes).toMatchObject({_tag: "Value", value: ["lane:ops"]});
 	});
 
-	it("REFUSES a config it cannot decode — never a silent fall back to phoenix's lanes", async () => {
+	/**
+	 * The `declares none` arm has to be reachable from a config file, or `triage homes` documents a
+	 * state no operator can produce (#6440). An absent key is a different answer — the default.
+	 */
+	it("reads an explicitly empty declaration as zero lanes, not as the default", async () => {
 		const lanes = await read({
 			"/repo/.fabrika.jsonc": '{"boardVocabulary": {"standingLanes": []}}',
+		});
+		expect(lanes).toMatchObject({_tag: "Value", value: []});
+	});
+
+	it("REFUSES a config it cannot decode — never a silent fall back to phoenix's lanes", async () => {
+		const lanes = await read({
+			"/repo/.fabrika.jsonc": '{"boardVocabulary": {"standingLanes": ["lane:ops", ""]}}',
 		});
 		expect(lanes._tag).toBe("Refused");
 	});

--- a/packages/fabrika-cli/src/triage/standing-lanes.unit.test.ts
+++ b/packages/fabrika-cli/src/triage/standing-lanes.unit.test.ts
@@ -1,0 +1,76 @@
+import {Effect} from "effect";
+import {describe, expect, it} from "vitest";
+import {fakeFs} from "../fakes.test-support.ts";
+import {DECLARED_MEANING, offeredLanes, readStandingLanes} from "./standing-lanes.ts";
+
+const PHOENIX_LANES = ["wayfinder:backlog", "axis:pipeline-hardening"];
+
+const read = (files: Record<string, string | null>) =>
+	Effect.runPromise(Effect.provide(readStandingLanes("/repo"), fakeFs({files}).layer));
+
+describe("offeredLanes", () => {
+	it("offers a declared lane the board carries, with its shipped meaning", () => {
+		expect(offeredLanes(PHOENIX_LANES, new Set(PHOENIX_LANES))).toEqual([
+			{label: "wayfinder:backlog", meaning: "fog — uncharted work upstream of any arc"},
+			{
+				label: "axis:pipeline-hardening",
+				meaning: "the standing pipeline and reliability lane",
+			},
+		]);
+	});
+
+	it("offers NOTHING over a board carrying neither label — the demlik arm (#6440)", () => {
+		expect(offeredLanes(PHOENIX_LANES, new Set(["bug", "enhancement"]))).toEqual([]);
+	});
+
+	it("drops only the absent one when the board carries a subset", () => {
+		expect(offeredLanes(PHOENIX_LANES, new Set(["axis:pipeline-hardening"]))).toEqual([
+			{
+				label: "axis:pipeline-hardening",
+				meaning: "the standing pipeline and reliability lane",
+			},
+		]);
+	});
+
+	it("keeps the declared order, not the board's", () => {
+		const present = new Set(["axis:pipeline-hardening", "wayfinder:backlog"]);
+		expect(offeredLanes(PHOENIX_LANES, present).map((lane) => lane.label)).toEqual(PHOENIX_LANES);
+	});
+
+	it("matches a label whole — a lane is not offered by a longer label that contains it", () => {
+		expect(
+			offeredLanes(["axis:pipeline-hardening"], new Set(["axis:pipeline-hardening-2"])),
+		).toEqual([]);
+	});
+
+	it("says a lane it has no shipped meaning for is one this repo declares, rather than inventing a gloss", () => {
+		expect(offeredLanes(["lane:ops"], new Set(["lane:ops"]))).toEqual([
+			{label: "lane:ops", meaning: DECLARED_MEANING},
+		]);
+	});
+
+	it("offers nothing when the repo declares nothing, whatever the board carries", () => {
+		expect(offeredLanes([], new Set(PHOENIX_LANES))).toEqual([]);
+	});
+});
+
+describe("readStandingLanes", () => {
+	it("resolves the shipped default over a repo declaring no config", async () => {
+		const lanes = await read({});
+		expect(lanes).toMatchObject({_tag: "Value", value: PHOENIX_LANES});
+	});
+
+	it("takes the declared set over the default", async () => {
+		const lanes = await read({
+			"/repo/.fabrika.jsonc": '{"boardVocabulary": {"standingLanes": ["lane:ops"]}}',
+		});
+		expect(lanes).toMatchObject({_tag: "Value", value: ["lane:ops"]});
+	});
+
+	it("REFUSES a config it cannot decode — never a silent fall back to phoenix's lanes", async () => {
+		const lanes = await read({
+			"/repo/.fabrika.jsonc": '{"boardVocabulary": {"standingLanes": []}}',
+		});
+		expect(lanes._tag).toBe("Refused");
+	});
+});


### PR DESCRIPTION
Fixes #6440

`fabrika triage homes` printed phoenix's two standing lanes in every repo, off a constant compiled
into the CLI. In `kamp-us/demlik`, where neither label exists, a triager took one of the offered
lanes, classified the whole issue, and only then hit a failed label write — and the failure named the
missing label, not the fact that the menu was never derived from that board.

## What changed

A lane row is now offered only where the repo **both** declares the lane and carries its label.

- The declared set comes from `boardVocabulary.standingLanes` in `.fabrika.jsonc` (shipped default:
  phoenix's pair), read through the same four-arm collapse the path keys use — a config that cannot
  be read or decoded refuses `11` rather than falling back.
- The verb then reads the repo's own label set and drops every declared lane the board does not
  carry. That is the same evidence the later `triage apply --lane` write depends on, taken before the
  menu is printed instead of after the classification work is spent.
- An unreadable label list is `11`, never "this repo has no lanes". A repo declaring no lanes reads
  no labels at all — nothing to filter.
- stderr carries the outcome either way, naming the dropped labels rather than only counting them:
  `standing lanes: 0 of 2 declared carry a label in you/your-repo — not offered: wayfinder:backlog,
  axis:pipeline-hardening.`

## Round 2 — the empty declaration, and the departure's owner

Round 1 found that the "this repo declares none" answer was documented but unreachable: `[]` was
refused as malformed and an absent key fell to phoenix's pair, so no configuration produced it.

- `boardVocabulary.standingLanes` now decodes an explicit `[]` as zero lanes. It is the one list key
  where empty is an answer rather than a disabled gate: `"types": []` leaves `triage apply --type`
  nothing to accept, while zero lanes just says every issue homes on a milestone. An **absent** key
  still falls to the shipped pair.
- `triage apply --lane` over an empty set refuses on `10` naming the empty key, instead of rendering
  `--lane must be  — got "x"` and sending the caller hunting for a value that does not exist.
- Proven live from a directory declaring `"standingLanes": []`: `triage homes` exits 0 with the four
  milestones, no lane row, and `standing lanes: this repo declares none.`; `triage apply --lane`
  exits 10 with the new message, writing nothing. Phoenix itself still lists both lanes.
- The ADR 0286 departure named #5631/#5785 as its closure path in the contract, the adoption guide
  and the module docblock. All three are closed, and #5785 was never the eviction. Filed #6469 to own
  it and re-pointed all three there.
- The contract's `triage homes` flag table was split by a paragraph inserted mid-table, dropping
  `--repo` and `--json` out of it; the paragraph moved below. The adoption guide's section 8 said a
  fresh repo declares no lane, which is the opposite of the stderr line it introduces — a fresh repo
  declares both through the default and carries neither label.

`packages/fabrika-cli` is green at 6958 tests.

## Structure

`readKey` and `Read<A>` moved out of `config/paths.ts` into `config/read-key.ts` so the lane reader
uses the one four-arm collapse instead of a second copy of it. `paths.ts` re-exports `Read`, so no
caller moved.

## Deviations

- **Governing-ADR departure** — **Said:** ADR 0286 rules that lanes come from a `.fabrika.jsonc`
  `lanes` key with no shipped default, and that no `packages/fabrika-cli/src/**` module may enumerate
  a lane label. **Did:** read the existing `boardVocabulary.standingLanes` key, which ships phoenix's
  pair as the default for an absent key, and left that default in place; the two labels still appear
  in the CLI as the default and as the meaning strings. **Why:** the issue's own triage ruling scopes
  this fix to `triage homes`, and its criteria require the shipped default reproduce today's phoenix
  behaviour; evicting the default touches `triage apply`, `build` scope-admission and `guard homing`.
  **Disposition:** stated here and in the contract, and now owned by #6469 rather than by the closed
  issues round 1 caught it pointing at. Two things contain it in the meantime: the presence filter,
  so the default asserts nothing about a board that never created the labels, and the empty
  declaration, so a repo can opt out of it outright.
- **Out-of-scope change** — **Said:** #6440 names `triage homes`. **Did:** also moved `readKey` out
  of `config/paths.ts` into `config/read-key.ts`. **Why:** the lane reader needs the same four-arm
  resolution, and `paths.ts`'s own docblock says that collapse exists so it is not re-derived per
  caller; copying it would have been the drift it was written to prevent. **Disposition:** stated
  here — pure move, `paths.ts` re-exports `Read` and no call site changed.
- **Pre-existing test or fixture changed** — **Said:** the round-1 body disclosed no test change, and
  the scan reports four removed assertions in `homes-verb.unit.test.ts` plus one rewritten case in
  `standing-lanes.unit.test.ts`. **Did:** `:88`'s `lanes` payload assertion now compares against
  `offeredLanes(...)` rather than the deleted `STANDING_LANES` constant, and `:277`'s enumeration
  assertion over that constant is gone; `:193-194`'s `shell.calls[0]` assertions became
  `shell.calls.find(line => line.includes("/milestones"))`; and `standing-lanes.unit.test.ts`'s
  "REFUSES a config it cannot decode" case swapped its input from `[]` to a list holding an empty
  string. **Why:** the first two lost their subject with the constant, and their coverage moved to
  `standing-lanes.unit.test.ts` and the offered-lanes payload test; the `shell.calls[0]` pair had to
  stop indexing position 0 because the label read now precedes the milestone read, and they assert
  the same two flags on the same call; the last one's old input is no longer a decode failure, since
  `[]` is now a declaration, so it needs an input that still is one. **Disposition:** stated here —
  no assertion was dropped without its coverage landing elsewhere.
