### PR TITLE
fix: status open's roster is still unresolvable in the marketplace install shape — #5775's fix only reached the dev checkout

### DIFF
--- a/claude-plugins/fabrika/skills/front-door/contract.md
+++ b/claude-plugins/fabrika/skills/front-door/contract.md
@@ -182,19 +182,33 @@ itself**, in this order, and print which tier served it on the scope line. (`boo
 this list: it builds from a fixed [registry](#buildable-surfaces) and reads no roster at all.)
 
 1. `--skills-dir <path>`, when given explicitly.
-2. The installed plugin's own skills directory, discovered from the running module's location the
-   way `packages/fabrika-cli/src/delegate/entry.ts` discovers the repo root — by resolution, never by
-   an environment variable, because interface rule 5 forbids a variable-rooted invocation and a verb
-   never requires an env var to locate itself.
-3. `claude-plugins/fabrika/skills/` beneath the repo root, which is the in-repo development case.
-4. That same `claude-plugins/fabrika/skills/` beneath the checkout the CLI itself runs from, found by
+2. `$CLAUDE_PLUGIN_ROOT`, when it is set and holds a plugin manifest — the harness's own answer for
+   which plugin is running, and the only rung that stays correct if the cache layout changes. It is
+   read by the verb, never written into a fence: interface rule 5 constrains the **command string**
+   the model runs, and ADR [0235](../../../../.decisions/0235-fences-carry-zero-expansions.md) puts
+   everything dynamic inside what the fence invokes. It cannot be the only rung, because the harness
+   sets it for plugin hooks and plugin-provided commands and **not** for an ordinary Bash call.
+3. A plugin tree the running module itself sits inside, found by walking up for the manifest. This
+   fires only where a consumer vendors the CLI into its own plugin; neither shape fabrika ships in
+   packages it that way.
+4. `claude-plugins/fabrika/skills/` beneath the repo root, which is the in-repo development case.
+5. That same `claude-plugins/fabrika/skills/` beneath the checkout the CLI itself runs from, found by
    walking up from the running module — the rung that answers when fabrika runs out of a phoenix
-   checkout against a target repo carrying no roster of its own, where tier 2 cannot fire (the CLI at
-   `packages/fabrika-cli/` has no plugin manifest above it) and tier 3 is rooted at that target repo
-   (#5775). Resolution again, never an environment variable.
+   checkout against a target repo carrying no roster of its own, where rung 3 cannot fire (the CLI at
+   `packages/fabrika-cli/` has no plugin manifest above it) and rung 4 is rooted at that target repo
+   (#5775).
+6. The installed fabrika plugin in Claude Code's plugin cache
+   (`<config>/plugins/cache/<marketplace>/<plugin>/<version>/`), matched by the **manifest's declared
+   `name`** rather than the directory, since the path carries a marketplace name and a content hash
+   that both change without the plugin changing. Versions the harness has stamped `.orphaned_at` are
+   skipped and `.in_use` breaks a tie. This is the rung that answers the marketplace shape, where the
+   plugin sits in the cache and the CLI is a separate global npm package, so no walk from either the
+   module or the cwd can reach the roster (#6448). It sits **below** rungs 4 and 5 on purpose: a
+   phoenix developer has both an installed plugin and a checkout, and reading the published roster
+   there would render skills the working tree does not have.
 
-The tier word printed on the scope line is `explicit` · `plugin` · `repo` · `checkout`, one per rung
-in that order.
+The tier word printed on the scope line is `explicit` · `env` · `plugin` · `repo` · `checkout` ·
+`cache`, one per rung in that order.
 
 **A roster that resolves and holds zero skills is `empty` at exit `0`, a fact, not a refusal.** These
 are supplying verbs, and interface convention §4 requires a supplying verb to decide once, in its

--- a/packages/fabrika-cli/README.md
+++ b/packages/fabrika-cli/README.md
@@ -972,9 +972,12 @@ Three things are load-bearing:
 - **`7` and `11` are the pair.** An *implicitly* resolved roster holding zero skills is neither —
   it is `empty` at exit `0`.
 
-The roster resolves in four tiers — an explicit `--skills-dir`, the installed plugin's own skills
-tree, `claude-plugins/fabrika/skills` in-repo, then that same path in the checkout the CLI runs
-from — and prints which one served.
+The roster resolves in six tiers — an explicit `--skills-dir`, `$CLAUDE_PLUGIN_ROOT`'s skills tree,
+a plugin tree the CLI itself sits inside, `claude-plugins/fabrika/skills` in-repo, that same path in
+the checkout the CLI runs from, then the installed fabrika plugin in Claude Code's plugin cache —
+and prints which one served. The cache rung is what answers the marketplace shape, where the plugin
+and the globally-installed CLI share no path at all; it sits last so a phoenix checkout keeps
+reading its own working tree.
 
 ## The `triage` group
 

--- a/packages/fabrika-cli/src/status/command.ts
+++ b/packages/fabrika-cli/src/status/command.ts
@@ -63,7 +63,7 @@ const repoFlag = Flag.string("repo").pipe(
 const skillsDirFlag = Flag.string("skills-dir").pipe(
 	Flag.optional,
 	Flag.withDescription(
-		"the roster root to read (default: $CLAUDE_PLUGIN_ROOT's skills tree, else a plugin the CLI runs from inside of, else the installed fabrika plugin in Claude Code's plugin cache, else claude-plugins/fabrika/skills beneath the repo root, else the same path beneath the checkout the CLI itself runs from)",
+		"the roster root to read (default: $CLAUDE_PLUGIN_ROOT's skills tree, else a plugin the CLI runs from inside of, else claude-plugins/fabrika/skills beneath the repo root, else the same path beneath the checkout the CLI itself runs from, else the installed fabrika plugin under Claude Code's plugin cache at $CLAUDE_CONFIG_DIR/plugins/cache, which is ~/.claude/plugins/cache when $CLAUDE_CONFIG_DIR is unset or empty)",
 	),
 );
 
@@ -77,9 +77,12 @@ const jsonFlag = Flag.boolean("json").pipe(
  */
 const pluginCacheRoot = (): string | null => {
 	const configured = process.env.CLAUDE_CONFIG_DIR;
+	// An empty value reads as unset, not as the relative path `plugins/cache` a bare join would
+	// produce — a rung rooted at the cwd would answer about a directory nobody configured.
+	const root = configured === undefined || configured === "" ? null : configured;
 	const home = homedir();
-	if (configured === undefined && home === "") return null;
-	return join(configured ?? join(home, ".claude"), "plugins", "cache");
+	if (root === null && home === "") return null;
+	return join(root ?? join(home, ".claude"), "plugins", "cache");
 };
 
 /** The roster sources this invocation resolves against — the world the ladder reads. */

--- a/packages/fabrika-cli/src/status/command.ts
+++ b/packages/fabrika-cli/src/status/command.ts
@@ -8,6 +8,8 @@
  * **Every leaf is declared with `leafCommand`, never a bare `Command.make`** — the bare form
  * silently opts out of the excess-operand guard, which `../excess-operand.unit.test.ts` reds on.
  */
+import {homedir} from "node:os";
+import {join} from "node:path";
 import {fileURLToPath} from "node:url";
 import {Effect, type FileSystem, Option, type Path} from "effect";
 import {Argument, Command, Flag} from "effect/unstable/cli";
@@ -61,7 +63,7 @@ const repoFlag = Flag.string("repo").pipe(
 const skillsDirFlag = Flag.string("skills-dir").pipe(
 	Flag.optional,
 	Flag.withDescription(
-		"the roster root to read (default: the installed plugin's own skills tree, else claude-plugins/fabrika/skills beneath the repo root, else the same path beneath the checkout the CLI itself runs from)",
+		"the roster root to read (default: $CLAUDE_PLUGIN_ROOT's skills tree, else a plugin the CLI runs from inside of, else the installed fabrika plugin in Claude Code's plugin cache, else claude-plugins/fabrika/skills beneath the repo root, else the same path beneath the checkout the CLI itself runs from)",
 	),
 );
 
@@ -69,9 +71,22 @@ const jsonFlag = Flag.boolean("json").pipe(
 	Flag.withDescription("emit the full result object on stdout instead of the line grammar"),
 );
 
-/** The roster sources this invocation resolves against — the module's own location and the cwd. */
+/**
+ * Claude Code's plugin cache, honouring `$CLAUDE_CONFIG_DIR` — the harness's own override for where
+ * `~/.claude` lives, so a relocated config directory resolves its cache rather than the home one.
+ */
+const pluginCacheRoot = (): string | null => {
+	const configured = process.env.CLAUDE_CONFIG_DIR;
+	const home = homedir();
+	if (configured === undefined && home === "") return null;
+	return join(configured ?? join(home, ".claude"), "plugins", "cache");
+};
+
+/** The roster sources this invocation resolves against — the world the ladder reads. */
 const rosterSources = (explicit: string | null): RosterSources => ({
 	explicit,
+	pluginRootEnv: process.env.CLAUDE_PLUGIN_ROOT ?? null,
+	pluginCache: pluginCacheRoot(),
 	moduleDir: fileURLToPath(new URL(".", import.meta.url)),
 	cwd: process.cwd(),
 });

--- a/packages/fabrika-cli/src/status/command.ts
+++ b/packages/fabrika-cli/src/status/command.ts
@@ -63,7 +63,7 @@ const repoFlag = Flag.string("repo").pipe(
 const skillsDirFlag = Flag.string("skills-dir").pipe(
 	Flag.optional,
 	Flag.withDescription(
-		"the roster root to read (default: $CLAUDE_PLUGIN_ROOT's skills tree, else a plugin the CLI runs from inside of, else claude-plugins/fabrika/skills beneath the repo root, else the same path beneath the checkout the CLI itself runs from, else the installed fabrika plugin under Claude Code's plugin cache at $CLAUDE_CONFIG_DIR/plugins/cache, which is ~/.claude/plugins/cache when $CLAUDE_CONFIG_DIR is unset or empty)",
+		"the roster root to read (default: $CLAUDE_PLUGIN_ROOT's skills tree, else a plugin the CLI runs from inside of, else claude-plugins/fabrika/skills beneath the repo root, else the same path beneath the checkout the CLI itself runs from, else the installed fabrika plugin under Claude Code's plugin cache, which is plugins/cache beneath $CLAUDE_CONFIG_DIR, or beneath .claude in the home directory when $CLAUDE_CONFIG_DIR is unset or empty)",
 	),
 );
 

--- a/packages/fabrika-cli/src/status/roster.ts
+++ b/packages/fabrika-cli/src/status/roster.ts
@@ -3,7 +3,7 @@
  *
  * **The roster is the plugin's, not the target repo's.** fabrika installs into repos that are not
  * phoenix (#4776), so defaulting to a repo-relative path would make `status menu` empty on
- * precisely the fresh repo this skill onboards. Resolution runs four tiers and prints which one
+ * precisely the fresh repo this skill onboards. Resolution runs six tiers and prints which one
  * served, so a caller can re-run the read instead of adopting the render.
  *
  * **A roster that resolves and holds zero skills is a fact, not a failure**; a roster that could not
@@ -13,9 +13,10 @@
 import {Effect, type FileSystem, Path, Result} from "effect";
 import {ancestors} from "../delegate/root.ts";
 import {exists, isDirectory, readDir, readFile} from "../io/fs.ts";
+import {isRecord, parseJson} from "../io/json.ts";
 
-/** Which of the four tiers served the roster. Printed, never assumed. */
-export type RosterTier = "explicit" | "plugin" | "repo" | "checkout";
+/** Which of the six tiers served the roster. Printed, never assumed. */
+export type RosterTier = "explicit" | "env" | "plugin" | "cache" | "repo" | "checkout";
 
 /** Who can reach a skill — the one routing fact a reader cannot infer from a description. */
 export type InvocationAxis = "model" | "user";
@@ -25,6 +26,26 @@ export const PLUGIN_MANIFEST = ".claude-plugin/plugin.json";
 
 /** The in-repo development location of the roster, relative to the repository root. */
 export const IN_REPO_ROSTER = "claude-plugins/fabrika/skills";
+
+/**
+ * The `name` a cached plugin's manifest must declare to be fabrika's own roster.
+ *
+ * Matched against the manifest rather than the directory: the cache path carries the *marketplace's*
+ * name for the plugin plus a content hash, both of which change without the plugin changing.
+ */
+export const PLUGIN_NAME = "fabrika";
+
+/**
+ * The two markers Claude Code writes beside a cached plugin version, read here and never written.
+ *
+ * `.orphaned_at` is stamped by the harness's cache sweep on every version the live plugin set no
+ * longer references, so its absence is what distinguishes the installed version from the dozens of
+ * superseded copies left beside it (49 of them on the machine #6448 was reproduced on, 48 orphaned).
+ * `.in_use` marks a version some running session holds; it is a tiebreak and not a filter, because
+ * the live version on that same machine carried no `.in_use` at all.
+ */
+const ORPHANED_MARKER = ".orphaned_at";
+const IN_USE_MARKER = ".in_use";
 
 export interface RosterSkill {
 	readonly name: string;
@@ -98,6 +119,19 @@ export const skillFrom = (name: string, text: string): RosterSkill => {
 	};
 };
 
+/**
+ * Whether `path` is there, with a probe that could not be performed reading as "not there".
+ *
+ * Only for the resolution rungs, where a rung that cannot answer is meant to fall through to the
+ * next one. Everything downstream of a resolved roster keeps `../io/fs.ts`'s discrimination: once a
+ * rung has claimed the roster, an unreadable path is UNKNOWN, never empty.
+ */
+const probe = (path: string): Effect.Effect<boolean, never, FileSystem.FileSystem> =>
+	Effect.gen(function* () {
+		const answer = yield* Effect.result(exists(path));
+		return Result.isSuccess(answer) && answer.success;
+	});
+
 /** The nearest ancestor of `from` for which `marker` resolves, or `null`. */
 const nearestAncestorWith = (
 	path: Path.Path,
@@ -106,18 +140,94 @@ const nearestAncestorWith = (
 ): Effect.Effect<string | null, never, FileSystem.FileSystem> =>
 	Effect.gen(function* () {
 		for (const dir of ancestors(path, from)) {
-			const probe = yield* Effect.result(exists(path.join(dir, marker)));
-			if (Result.isSuccess(probe) && probe.success) return dir;
+			if (yield* probe(path.join(dir, marker))) return dir;
 		}
 		return null;
+	});
+
+/** The `name` a plugin manifest declares, or `null` when there is no readable one at `root`. */
+const declaredName = (
+	path: Path.Path,
+	root: string,
+): Effect.Effect<string | null, never, FileSystem.FileSystem> =>
+	Effect.gen(function* () {
+		const text = yield* Effect.result(readFile(path.join(root, PLUGIN_MANIFEST)));
+		if (Result.isFailure(text)) return null;
+		const manifest = parseJson(text.success);
+		if (!isRecord(manifest)) return null;
+		const name = manifest.name;
+		return typeof name === "string" && name !== "" ? name : null;
+	});
+
+/** Base names in `dir`, sorted, or `[]` when it could not be listed — a rung falling through. */
+const listing = (dir: string): Effect.Effect<ReadonlyArray<string>, never, FileSystem.FileSystem> =>
+	Effect.gen(function* () {
+		const entries = yield* Effect.result(readDir(dir));
+		return Result.isSuccess(entries) ? [...entries.success].sort() : [];
+	});
+
+/**
+ * The roster inside a plugin root, displayed by the name its manifest declares.
+ *
+ * The declared name rather than the directory's, because the cache roots this resolves are named
+ * for a content hash that changes on every marketplace update — printing one would hand a reader a
+ * path that is stale by the next install and machine-local in the meantime.
+ */
+const rosterIn = (
+	path: Path.Path,
+	root: string,
+	tier: RosterTier,
+): Effect.Effect<ResolvedRoster, never, FileSystem.FileSystem> =>
+	Effect.gen(function* () {
+		const declared = yield* declaredName(path, root);
+		return {
+			path: path.join(root, "skills"),
+			display: `${declared ?? path.basename(root)}/skills`,
+			tier,
+		};
+	});
+
+/**
+ * The installed fabrika plugin under Claude Code's plugin cache, or `null`.
+ *
+ * Layout is `<cache>/<marketplace>/<plugin>/<version>/`, three levels, which is what the harness's
+ * own cache sweep walks. A candidate must declare {@link PLUGIN_NAME} and carry a `skills`
+ * directory — a half-written cache entry falls through to the repo and checkout rungs rather than
+ * claiming the roster and failing the read.
+ */
+const cachedPluginRoot = (
+	path: Path.Path,
+	cache: string,
+): Effect.Effect<string | null, never, FileSystem.FileSystem> =>
+	Effect.gen(function* () {
+		const held: string[] = [];
+		const live: string[] = [];
+		for (const marketplace of yield* listing(cache)) {
+			const plugins = path.join(cache, marketplace);
+			for (const plugin of yield* listing(plugins)) {
+				const versions = path.join(plugins, plugin);
+				for (const version of yield* listing(versions)) {
+					const root = path.join(versions, version);
+					if (yield* probe(path.join(root, ORPHANED_MARKER))) continue;
+					if ((yield* declaredName(path, root)) !== PLUGIN_NAME) continue;
+					if (!(yield* probe(path.join(root, "skills")))) continue;
+					((yield* probe(path.join(root, IN_USE_MARKER))) ? held : live).push(root);
+				}
+			}
+		}
+		return held[0] ?? live[0] ?? null;
 	});
 
 export interface RosterSources {
 	/** `--skills-dir`, when the caller passed one. */
 	readonly explicit: string | null;
-	/** The directory of the running module — tiers 2 and 4 walk up from here. */
+	/** `$CLAUDE_PLUGIN_ROOT` — the harness's own answer, where this invocation was given one. */
+	readonly pluginRootEnv: string | null;
+	/** Claude Code's plugin cache directory, which the `cache` rung walks. */
+	readonly pluginCache: string | null;
+	/** The directory of the running module — the `plugin` and `checkout` rungs walk up from here. */
 	readonly moduleDir: string;
-	/** The invocation directory — tier 3 walks up from here for the in-repo checkout. */
+	/** The invocation directory — the `repo` rung walks up from here for the in-repo checkout. */
 	readonly cwd: string;
 }
 
@@ -142,14 +252,21 @@ export const resolveRosterPath = (
 		if (sources.explicit !== null) {
 			return {path: sources.explicit, display: sources.explicit, tier: "explicit" as const};
 		}
-		const pluginRoot = yield* nearestAncestorWith(path, sources.moduleDir, PLUGIN_MANIFEST);
-		if (pluginRoot !== null) {
-			return {
-				path: path.join(pluginRoot, "skills"),
-				display: `${path.basename(pluginRoot)}/skills`,
-				tier: "plugin" as const,
-			};
+		// The env rung is the harness's own answer and outranks every probe, but it cannot be the
+		// only one: `CLAUDE_PLUGIN_ROOT` is set for plugin hooks and plugin-provided commands and
+		// NOT for an ordinary Bash tool call, which is how most of these verbs are invoked (#6448).
+		if (
+			sources.pluginRootEnv !== null &&
+			(yield* probe(path.join(sources.pluginRootEnv, PLUGIN_MANIFEST)))
+		) {
+			return yield* rosterIn(path, sources.pluginRootEnv, "env");
 		}
+		// Fires only where the CLI is installed *inside* a plugin tree. Neither shape fabrika ships
+		// in packages it that way — the marketplace install is a separate npm package and the dev
+		// checkout keeps the CLI at `packages/fabrika-cli/` — so this rung is for a consumer that
+		// vendors the CLI into its own plugin, and the ladder below it is what answers at home.
+		const pluginRoot = yield* nearestAncestorWith(path, sources.moduleDir, PLUGIN_MANIFEST);
+		if (pluginRoot !== null) return yield* rosterIn(path, pluginRoot, "plugin");
 		const repoRoot = yield* nearestAncestorWith(path, sources.cwd, IN_REPO_ROSTER);
 		if (repoRoot !== null) {
 			return {
@@ -158,17 +275,25 @@ export const resolveRosterPath = (
 				tier: "repo" as const,
 			};
 		}
-		// Tier 4 walks the same marker up from `moduleDir`, which is the only rung that answers in
-		// the dev shape: the CLI at `packages/fabrika-cli/` has no plugin manifest above it, so tier
-		// 2 cannot fire, and tier 3 is rooted at a target repo that holds no roster at all (#5775).
+		// The checkout rung walks the same marker up from `moduleDir`, and is the only one that
+		// answers in the dev shape: the CLI at `packages/fabrika-cli/` has no plugin manifest above
+		// it, so `plugin` cannot fire, and `repo` is rooted at a target repo holding none (#5775).
 		const checkoutRoot = yield* nearestAncestorWith(path, sources.moduleDir, IN_REPO_ROSTER);
-		return checkoutRoot === null
-			? null
-			: {
-					path: path.join(checkoutRoot, IN_REPO_ROSTER),
-					display: IN_REPO_ROSTER,
-					tier: "checkout" as const,
-				};
+		if (checkoutRoot !== null) {
+			return {
+				path: path.join(checkoutRoot, IN_REPO_ROSTER),
+				display: IN_REPO_ROSTER,
+				tier: "checkout" as const,
+			};
+		}
+		// The rung that answers the marketplace shape: the plugin sits in the harness's cache and the
+		// CLI is a global npm package outside it, so nothing on disk connects the two and no walk from
+		// `moduleDir` or the cwd can reach the roster (#6448). It sits *below* the two walking rungs
+		// on purpose: a phoenix developer has both, and a cache read there would render the published
+		// roster over the working tree's, which is the shape #5775 was fixed to serve.
+		const cached =
+			sources.pluginCache === null ? null : yield* cachedPluginRoot(path, sources.pluginCache);
+		return cached === null ? null : yield* rosterIn(path, cached, "cache");
 	});
 
 /**

--- a/packages/fabrika-cli/src/status/roster.ts
+++ b/packages/fabrika-cli/src/status/roster.ts
@@ -16,7 +16,7 @@ import {exists, isDirectory, readDir, readFile} from "../io/fs.ts";
 import {isRecord, parseJson} from "../io/json.ts";
 
 /** Which of the six tiers served the roster. Printed, never assumed. */
-export type RosterTier = "explicit" | "env" | "plugin" | "cache" | "repo" | "checkout";
+export type RosterTier = "explicit" | "env" | "plugin" | "repo" | "checkout" | "cache";
 
 /** Who can reach a skill — the one routing fact a reader cannot infer from a description. */
 export type InvocationAxis = "model" | "user";

--- a/packages/fabrika-cli/src/status/verbs.unit.test.ts
+++ b/packages/fabrika-cli/src/status/verbs.unit.test.ts
@@ -117,7 +117,45 @@ describe("the roster's resolution ladder", () => {
 	const FOREIGN = "/home/dev/demlik";
 	const SKILL_TEXT = "---\nname: build\ndescription: d\n---\n";
 
+	const CACHE = "/home/dev/.claude/plugins/cache";
+	const manifest = (name: string) => JSON.stringify({name});
+
 	const tree = (over: Parameters<typeof fakeFs>[0]) => fakeFs(over);
+
+	/** Every rung's inputs, so a case names only the one it is about. */
+	const sources = (over: Partial<RosterSources>): RosterSources => ({
+		explicit: null,
+		pluginRootEnv: null,
+		pluginCache: null,
+		moduleDir: MODULE_DIR,
+		cwd: FOREIGN,
+		...over,
+	});
+
+	/** One cached plugin version, as Claude Code lays the cache out: marketplace/plugin/version. */
+	const cached = (version: string, declared: string, markers: ReadonlyArray<string> = []) => {
+		const root = `${CACHE}/kampus/fabrika/${version}`;
+		return {
+			root,
+			files: {
+				[`${root}/${PLUGIN_MANIFEST}`]: manifest(declared),
+				...Object.fromEntries(markers.map((marker) => [`${root}/${marker}`, "1786000000000"])),
+			},
+			directories: [`${root}/skills`],
+		};
+	};
+
+	const cacheTree = (versions: ReadonlyArray<ReturnType<typeof cached>>, over = {}) =>
+		tree({
+			dirs: {
+				[CACHE]: ["kampus"],
+				[`${CACHE}/kampus`]: ["fabrika"],
+				[`${CACHE}/kampus/fabrika`]: versions.map((v) => v.root.split("/").pop() as string),
+			},
+			files: Object.assign({}, ...versions.map((v) => v.files)),
+			directories: versions.flatMap((v) => v.directories),
+			...over,
+		});
 
 	const resolve = (sources: RosterSources, fs: ReturnType<typeof fakeFs>) =>
 		Effect.runPromise(Effect.provide(resolveRosterPath(sources), fs.layer));
@@ -128,49 +166,177 @@ describe("the roster's resolution ladder", () => {
 	const checkoutRoster = `${CHECKOUT}/${IN_REPO_ROSTER}`;
 
 	it("resolves the CLI's own checkout when the cwd is a repo carrying no roster", async () => {
-		const resolved = await resolve(
-			{explicit: null, moduleDir: MODULE_DIR, cwd: FOREIGN},
-			tree({directories: [checkoutRoster]}),
-		);
+		const resolved = await resolve(sources({}), tree({directories: [checkoutRoster]}));
 		expect(resolved?.tier).toBe("checkout");
 		expect(resolved?.path).toBe(checkoutRoster);
 	});
 
 	/** `display` is what a session transcript keeps; an absolute path there is a machine-local leak. */
 	it("prints the checkout rung as a repo-relative path, never the absolute one", async () => {
-		const resolved = await resolve(
-			{explicit: null, moduleDir: MODULE_DIR, cwd: FOREIGN},
-			tree({directories: [checkoutRoster]}),
-		);
+		const resolved = await resolve(sources({}), tree({directories: [checkoutRoster]}));
 		expect(resolved?.display).toBe(IN_REPO_ROSTER);
 		expect(resolved?.display.startsWith("/")).toBe(false);
 	});
 
 	it("keeps the cwd's own roster ahead of the checkout's when both are there", async () => {
 		const resolved = await resolve(
-			{explicit: null, moduleDir: MODULE_DIR, cwd: FOREIGN},
+			sources({}),
 			tree({directories: [checkoutRoster, `${FOREIGN}/${IN_REPO_ROSTER}`]}),
 		);
 		expect(resolved?.tier).toBe("repo");
 		expect(resolved?.path).toBe(`${FOREIGN}/${IN_REPO_ROSTER}`);
 	});
 
-	it("keeps an installed plugin ahead of both implicit checkout rungs", async () => {
-		const installed = "/cache/kampus/fabrika/abc123";
+	/**
+	 * The `plugin` rung's one live shape: a CLI vendored *inside* a plugin tree. Neither shape
+	 * fabrika itself ships in packages it that way, so this is the consumer case the rung is kept
+	 * for, constructed here rather than left as coverage nothing exercises (#6448).
+	 */
+	it("keeps a CLI bundled inside a plugin ahead of both implicit checkout rungs", async () => {
+		const installed = "/vendored/fabrika";
 		const resolved = await resolve(
-			{explicit: null, moduleDir: `${installed}/cli/src/status`, cwd: FOREIGN},
+			sources({moduleDir: `${installed}/cli/src/status`}),
 			tree({
-				directories: [checkoutRoster, `${installed}/${PLUGIN_MANIFEST}`],
-				files: {[`${installed}/${PLUGIN_MANIFEST}`]: "{}"},
+				directories: [checkoutRoster],
+				files: {[`${installed}/${PLUGIN_MANIFEST}`]: manifest("fabrika")},
 			}),
 		);
 		expect(resolved?.tier).toBe("plugin");
 		expect(resolved?.path).toBe(`${installed}/skills`);
+		expect(resolved?.display).toBe("fabrika/skills");
+	});
+
+	/**
+	 * The marketplace shape, where the CLI is a global npm package outside the plugin cache: no walk
+	 * from the module or the cwd can reach the roster, so the cache rung is the only answer (#6448).
+	 */
+	it("resolves the installed plugin out of Claude Code's cache when no walk can reach it", async () => {
+		const live = cached("602283e56c60", "fabrika");
+		const resolved = await resolve(
+			sources({pluginCache: CACHE}),
+			cacheTree([cached("0dd9a537e17c", "fabrika", [".orphaned_at", ".in_use"]), live]),
+		);
+		expect(resolved?.tier).toBe("cache");
+		expect(resolved?.path).toBe(`${live.root}/skills`);
+	});
+
+	/** The cache path carries a content hash that changes on every update — never print one. */
+	it("prints the cache rung by the manifest's declared name, never the hashed path", async () => {
+		const resolved = await resolve(
+			sources({pluginCache: CACHE}),
+			cacheTree([cached("602283e56c60", "fabrika")]),
+		);
+		expect(resolved?.display).toBe("fabrika/skills");
+		expect(resolved?.display.includes("602283e56c60")).toBe(false);
+	});
+
+	/** A cache holds every plugin the machine has installed; only fabrika's own roster is fabrika's. */
+	it("skips a cached plugin whose manifest declares another name", async () => {
+		const resolved = await resolve(
+			sources({pluginCache: CACHE}),
+			cacheTree([cached("aaaaaaaaaaaa", "some-other-plugin")]),
+		);
+		expect(resolved).toBeNull();
+	});
+
+	/**
+	 * The cache sits below both walking rungs: a phoenix developer has an installed plugin *and* a
+	 * checkout, and reading the published roster there would render something the working tree does
+	 * not have — the dev shape #5775 was fixed to serve.
+	 */
+	it("keeps the CLI's own checkout ahead of the installed plugin's cache", async () => {
+		const resolved = await resolve(
+			sources({pluginCache: CACHE}),
+			cacheTree([cached("602283e56c60", "fabrika")], {
+				directories: [checkoutRoster, `${CACHE}/kampus/fabrika/602283e56c60/skills`],
+			}),
+		);
+		expect(resolved?.tier).toBe("checkout");
+		expect(resolved?.path).toBe(checkoutRoster);
+	});
+
+	/** `.in_use` is the tiebreak the harness itself writes; the ordering must not be the hash's. */
+	it("prefers a cached version a live session holds when two are unorphaned", async () => {
+		const held = cached("zzzzzzzzzzzz", "fabrika", [".in_use"]);
+		const resolved = await resolve(
+			sources({pluginCache: CACHE}),
+			cacheTree([cached("aaaaaaaaaaaa", "fabrika"), held]),
+		);
+		expect(resolved?.path).toBe(`${held.root}/skills`);
+	});
+
+	/** A half-written cache entry is not a roster: it must not claim one and then fail the read. */
+	it("skips a cached version carrying no skills directory", async () => {
+		const resolved = await resolve(
+			sources({pluginCache: CACHE}),
+			cacheTree([{...cached("602283e56c60", "fabrika"), directories: []}]),
+		);
+		expect(resolved).toBeNull();
+	});
+
+	/** The harness's own answer where it exists — and it does not exist for a plain Bash call. */
+	it("takes $CLAUDE_PLUGIN_ROOT ahead of the cache when the harness set one", async () => {
+		const injected = "/plugins/fabrika-head";
+		const resolved = await resolve(
+			sources({pluginRootEnv: injected, pluginCache: CACHE}),
+			cacheTree([cached("602283e56c60", "fabrika")], {
+				files: {[`${injected}/${PLUGIN_MANIFEST}`]: manifest("fabrika")},
+			}),
+		);
+		expect(resolved?.tier).toBe("env");
+		expect(resolved?.path).toBe(`${injected}/skills`);
+	});
+
+	/** A variable pointing nowhere is not an answer; the ladder below it still has to run. */
+	it("falls through when $CLAUDE_PLUGIN_ROOT names a directory holding no plugin manifest", async () => {
+		const live = cached("602283e56c60", "fabrika");
+		const resolved = await resolve(
+			sources({pluginRootEnv: "/plugins/gone", pluginCache: CACHE}),
+			cacheTree([live]),
+		);
+		expect(resolved?.tier).toBe("cache");
+		expect(resolved?.path).toBe(`${live.root}/skills`);
+	});
+
+	it("still keeps an explicitly-passed path ahead of the env rung", async () => {
+		const injected = "/plugins/fabrika-head";
+		const resolved = await resolve(
+			sources({explicit: "/mine/skills", pluginRootEnv: injected}),
+			tree({files: {[`${injected}/${PLUGIN_MANIFEST}`]: manifest("fabrika")}}),
+		);
+		expect(resolved?.tier).toBe("explicit");
+		expect(resolved?.path).toBe("/mine/skills");
+	});
+
+	/** The `menu` and `config` fields the front door exists to answer — the defect #6448 reported. */
+	it("renders the marketplace shape's roster rather than the unknown #6448 reported", async () => {
+		const live = cached("602283e56c60", "fabrika");
+		const out = await read(
+			sources({pluginCache: CACHE}),
+			cacheTree([live], {
+				dirs: {
+					[CACHE]: ["kampus"],
+					[`${CACHE}/kampus`]: ["fabrika"],
+					[`${CACHE}/kampus/fabrika`]: ["602283e56c60"],
+					[`${live.root}/skills`]: ["build"],
+				},
+				directories: [`${live.root}/skills`, `${live.root}/skills/build`],
+				files: {
+					...live.files,
+					[`${live.root}/skills/build/SKILL.md`]: SKILL_TEXT,
+				},
+			}),
+		);
+		expect(out._tag).toBe("Resolved");
+		if (out._tag !== "Resolved") return;
+		expect(out.tier).toBe("cache");
+		expect(out.skills.map((s) => s.name)).toEqual(["build"]);
+		expect(runMenu({roster: out, asOf: AS_OF, json: false}).code).toBe(ANSWER);
 	});
 
 	it("reads the checkout roster's skills rather than reporting the target repo bare", async () => {
 		const out = await read(
-			{explicit: null, moduleDir: MODULE_DIR, cwd: FOREIGN},
+			sources({}),
 			tree({
 				directories: [checkoutRoster, `${checkoutRoster}/build`],
 				dirs: {[checkoutRoster]: ["build"]},
@@ -186,7 +352,7 @@ describe("the roster's resolution ladder", () => {
 	/** A resolved roster holding nothing is a fact at exit 0 — the added rung must not change that. */
 	it("keeps a resolved-but-empty checkout roster `empty`, never unknown", async () => {
 		const out = await read(
-			{explicit: null, moduleDir: MODULE_DIR, cwd: FOREIGN},
+			sources({}),
 			tree({directories: [checkoutRoster], dirs: {[checkoutRoster]: []}}),
 		);
 		expect(out._tag).toBe("Resolved");
@@ -198,7 +364,7 @@ describe("the roster's resolution ladder", () => {
 	/** An explicit path is the caller's claim; no implicit rung may rescue it. */
 	it("still seats an explicitly-passed absent --skills-dir on AbsentExplicit", async () => {
 		const out = await read(
-			{explicit: "/nope", moduleDir: MODULE_DIR, cwd: FOREIGN},
+			sources({explicit: "/nope"}),
 			tree({directories: [checkoutRoster], dirs: {[checkoutRoster]: ["build"]}}),
 		);
 		expect(out._tag).toBe("AbsentExplicit");
@@ -206,7 +372,7 @@ describe("the roster's resolution ladder", () => {
 	});
 
 	it("still fails when no rung answers", async () => {
-		const out = await read({explicit: null, moduleDir: MODULE_DIR, cwd: FOREIGN}, tree({}));
+		const out = await read(sources({}), tree({}));
 		expect(out._tag).toBe("Failed");
 		if (out._tag !== "Failed") return;
 		expect(out.reason).toBe("no roster resolved — pass --skills-dir");


### PR DESCRIPTION
`fabrika status open` rendered `menu` and `config` as `unknown` in every repo that is not phoenix
when the CLI is installed globally and the plugin comes from the marketplace. That shape puts the
roster in Claude Code's plugin cache and the CLI in the global npm store, so nothing on disk
connects them and none of the four existing rungs could reach it.

Two rungs added inside `resolveRosterPath`, both printing their tier like the rest:

- **`env`** — `$CLAUDE_PLUGIN_ROOT` when it is set and holds a plugin manifest. The harness's own
  answer, read by the verb rather than written into a fence, so the injected `status open` stays
  literal (ADR 0235). It cannot stand alone: the harness sets it for plugin hooks and
  plugin-provided commands, not for an ordinary Bash call.
- **`cache`** — walks `<config>/plugins/cache/<marketplace>/<plugin>/<version>/` and matches the
  manifest's declared `name`, not the directory, since the path carries a marketplace name and a
  content hash that both change without the plugin changing. Versions the harness stamped
  `.orphaned_at` are skipped and `.in_use` breaks a tie.

Order is `explicit → env → plugin → repo → checkout → cache`. Display for every manifest-rooted
rung is now the declared name (`fabrika/skills`), so the content hash never reaches a reader.

Proven on this machine against the real cache: in the marketplace shape (module dir in the global
pnpm store, cwd outside any repo) `readRoster` returns `Resolved`, tier `cache`, display
`fabrika/skills`, 24 skills. Inside the checkout it still answers `repo`, and from outside it
`checkout` — #5775's coverage intact.

Fixes #6448

## Deviations

- **Declined guidance** — **Said:** the issue proposes the rung order
  `explicit → env → plugin → cache → repo → checkout`. **Did:** put `cache` last, after `repo` and
  `checkout`. **Why:** with `cache` above them, a live run inside this checkout resolved the
  installed plugin's roster instead of the working tree's — every phoenix developer has both, so
  the issue's own third acceptance criterion ("the dev-checkout shape still resolves via the
  checkout tier") fails under its proposed order. Last still answers the marketplace shape, where
  neither walking rung can fire. **Disposition:** stated here.
- **Known defect left unfixed** — **Said:** the issue's "Also found, separable" note about
  `.github/workflows/ci.yml` being declared in `## Required repo files` while no verb reads it.
  **Did:** left it. **Why:** it is outside this issue's acceptance criteria and its triage note
  recommends a separate issue. **Disposition:** stated here; not filed by this lane.
