### PR TITLE
chore: A malformed governedRoots value does not refuse the .fabrika.jsonc load

### DIFF
--- a/.patterns/fabrika-config-key-groups.md
+++ b/.patterns/fabrika-config-key-groups.md
@@ -134,10 +134,12 @@ unit test can point the load at a scripted filesystem.
 ## A gate refuses on a config that never decoded
 
 `loadConfig` answers `Config` for a file nobody could open, a file that is not a JSON object, and a
-key whose value the decoder rejected — those arms live per key in `Resolution`, not on the `Load`,
-because a caller reading one key has no business being stopped by another key's malformity. A gate
-is the opposite case: it is about to write, and it needs *every* key it is judged against to have
-decoded.
+key whose value the decoder rejected *where that key carries no `refuseLoad`* — those arms live per
+key in `Resolution`, not on the `Load`, because a caller reading one key has no business being
+stopped by another key's malformity. The exception is the pair above: a `refuseLoad` key's own
+`Malformed` does stop the load, because a key that can un-govern the config is one every caller is
+stopped by on purpose. A gate is the opposite case: it is about to write, and it needs *every* key
+it is judged against to have decoded.
 
 So a gate never reads `load._tag === "Config"` as "it loaded". It calls `unusableReason(load)`
 (`config/unusable.ts`), which answers the one reason no value of this config may be used, or `null`.

--- a/.patterns/fabrika-config-key-groups.md
+++ b/.patterns/fabrika-config-key-groups.md
@@ -92,6 +92,13 @@ cannot reconcile an issue into a shape nobody asked for (#4285). A convention co
 one, because the config is what the convention would be read from — and a check written at a call
 site is a check the next verb forgets.
 
+Declaring `refuseLoad` also makes that key's own `Malformed` a load refusal, relayed in the
+decoder's words: a value that did not decode leaves the key with nothing to check, and
+`{"governedRoots": []}` un-governs the config exactly as `{"governedRoots": [".decisions/"]}` does
+(#6314). The two document-level arms stay out of it — `Unknown` proves nothing about what the repo
+declared, and a document that is not a JSON object already resolves *every* key `Malformed`, so
+there is no weakened value to read off either one.
+
 **Two keys that answer one question are joined in one module, not read apart.** `boardVocabulary`
 says what each triage facet may *keep*; `triageFacets` says what it may *delete*. Read separately
 they drift into #4285's shape — a declared lane no facet owns is written once and never superseded.

--- a/packages/fabrika-cli/src/config/key-group.ts
+++ b/packages/fabrika-cli/src/config/key-group.ts
@@ -37,6 +37,10 @@ export interface KeyGroup<A> {
 	 * A refusal this key alone can raise over the whole load, or `null`. It exists for the one rule
 	 * a convention cannot hold: a config that edits its own governed-path list can un-govern itself,
 	 * so the check has to run before any key's value is used.
+	 *
+	 * Declaring this also makes the key's *own* malformity a load refusal: a value that did not
+	 * decode leaves the key with nothing to check, which un-governs the config exactly like a value
+	 * this function rejects. {@link register} raises that arm; this function only ever sees a value.
 	 */
 	readonly refuseLoad?: (value: A) => string | null;
 	/**
@@ -116,8 +120,12 @@ export const register = <A>(group: KeyGroup<A>): Registration => ({
 		const refuse = group.refuseLoad;
 		if (refuse === undefined) return null;
 		const resolved = resolveKey(state, group);
-		return resolved._tag === "Declared" || resolved._tag === "Default"
-			? refuse(resolved.value)
-			: null;
+		if (resolved._tag === "Declared" || resolved._tag === "Default") return refuse(resolved.value);
+		// A declared value this key's decoder rejected refuses the load in the decoder's own words: it
+		// leaves the key with no usable value, which un-governs the config exactly like a value
+		// `refuseLoad` rejects. The two document-level arms are not this key's to raise — `Unknown`
+		// proves nothing about what the repo declared, and a document that is not a JSON object
+		// resolves *every* key `Malformed`, so no weakened value is readable off it either way.
+		return resolved._tag === "Malformed" && state._tag === "Record" ? resolved.reason : null;
 	},
 });

--- a/packages/fabrika-cli/src/config/keys/governed-roots.ts
+++ b/packages/fabrika-cli/src/config/keys/governed-roots.ts
@@ -7,7 +7,9 @@
  * **That self-inclusion is enforced at load, not by convention.** A config can edit its own
  * governed-path list, so a config whose roots do not cover `.fabrika.jsonc` could un-govern itself —
  * the one change nobody would ever be asked to justify. {@link governedRootsKey}'s `refuseLoad`
- * refuses the whole load in that case, naming the key.
+ * refuses the whole load in that case, naming the key — and a declared value that does not decode
+ * at all refuses it too, since an unusable root list un-governs the config just as effectively
+ * (#6314).
  *
  * This module ships the key, its default and that refusal. Threading it into `review/classes.ts` and
  * `governance scope`, and the rest of the path surface, is #6296's.

--- a/packages/fabrika-cli/src/config/load.unit.test.ts
+++ b/packages/fabrika-cli/src/config/load.unit.test.ts
@@ -166,6 +166,36 @@ describe("a config cannot un-govern itself", () => {
 	it("does not refuse on an unreadable file — that is UNKNOWN, not a bad config", () => {
 		expect(loadConfig({_tag: "Unreadable", reason: "EIO"})._tag).toBe("Config");
 	});
+
+	it.each([
+		{shape: "an empty list", text: '{"governedRoots": []}', words: "nothing would be governed"},
+		{shape: "a value that is not an array", text: '{"governedRoots": 42}', words: "not an array"},
+	])("refuses the whole load on $shape, in the decoder's words", ({text, words}) => {
+		const load = fromText(text);
+		expect(load._tag).toBe("Refused");
+		if (load._tag !== "Refused") return;
+		expect(load.reason).toContain("governedRoots");
+		expect(load.reason).toContain(words);
+	});
+
+	it("refuses every key off a malformed-value load, the same as a too-narrow one", () => {
+		expect(
+			resolve(fromText('{"governedRoots": [], "capClearAuthors": ["@a"]}'), capClearAuthorsKey)
+				._tag,
+		).toBe("Malformed");
+	});
+
+	it("does not refuse on a document that is not a JSON object — every key is already malformed", () => {
+		const load = fromText("[]");
+		expect(load._tag).toBe("Config");
+		expect(resolve(load, governedRootsKey)._tag).toBe("Malformed");
+	});
+
+	it("leaves a malformed key that raises no load refusal to its own key", () => {
+		const load = fromText('{"docLeakExempt": [7]}');
+		expect(load._tag).toBe("Config");
+		expect(resolve(load, docLeakExemptKey)._tag).toBe("Malformed");
+	});
 });
 
 describe("the registry", () => {

--- a/packages/fabrika-cli/src/config/load.unit.test.ts
+++ b/packages/fabrika-cli/src/config/load.unit.test.ts
@@ -178,6 +178,14 @@ describe("a config cannot un-govern itself", () => {
 		expect(load.reason).toContain(words);
 	});
 
+	it("refuses the load on the other refuseLoad key's malformed value too", () => {
+		const load = fromText('{"triageFacets": "garbage"}');
+		expect(load._tag).toBe("Refused");
+		if (load._tag !== "Refused") return;
+		expect(load.reason).toContain("triageFacets");
+		expect(load.reason).toContain("not an array");
+	});
+
 	it("refuses every key off a malformed-value load, the same as a too-narrow one", () => {
 		expect(
 			resolve(fromText('{"governedRoots": [], "capClearAuthors": ["@a"]}'), capClearAuthorsKey)

--- a/packages/fabrika-cli/src/config/unusable.ts
+++ b/packages/fabrika-cli/src/config/unusable.ts
@@ -3,8 +3,10 @@
  *
  * A load that is not `Refused` is not thereby a load that decoded. `Refused` is the narrow arm a
  * key's `refuseLoad` raises over a config it *could* read; a file nobody could open, a file that is
- * not a JSON object, and a key whose value the decoder rejected all answer `Config`, because the
- * arms live per key in {@link Resolution} rather than on the load. Reading `_tag === "Config"` as
+ * not a JSON object, and a key whose value the decoder rejected — that last one only where the key
+ * carries no `refuseLoad`, since a key that does have one refuses the load on its own `Malformed`
+ * too (#6314) — all answer `Config`, because the arms live per key in {@link Resolution} rather
+ * than on the load. Reading `_tag === "Config"` as
  * "it loaded" is what let `triage apply` reach the label write with the containment check never run
  * (#6292): a gate keyed on the refusal alone is fail-open on exactly the input class this surface
  * exists to keep apart.


### PR DESCRIPTION
Transcribes the founder ruling on #6314 (option 1): a key that carries `refuseLoad` also refuses the whole load when its own declared value does not decode.

Before this, `refuseLoad` ran only on the `Declared` and `Default` arms. `{"governedRoots": []}` and `{"governedRoots": 42}` both resolve `Malformed`, so the refusal never fired and `loadConfig` handed back a usable `Config` off which every other key resolved normally — a config with no readable governance root list, which un-governs itself exactly like the too-narrow list that *is* refused.

`register`'s `loadRefusal` now relays a malformed key's decode reason as the load refusal. It stays scoped to the key's own declared value: `Unknown` still skips (an unreadable file proves nothing about what the repo declared, as the ruling says), and a document that is not a JSON object still skips too, because that arm already resolves *every* key `Malformed` — there is no weakened value to read off it, so refusing there would only restate a refusal already in force.

Both keys carrying `refuseLoad` get the tighter arm: `governedRoots` and `triageFacets`.

Tests: the "a config cannot un-govern itself" block gains the two malformed shapes, the "refuses every key off that load" pairing for a malformed value, and two negative cases pinning the scoping (a not-an-object document, and a malformed key that carries no `refuseLoad`). Full `fabrika-cli` suite green — 6963 tests.

Docs: `.patterns/fabrika-config-key-groups.md`'s load-refusal section and the `governed-roots.ts` docblock both state the widened arm.

Fixes #6314

## Deviations

- **Scope narrowing** — **Said:** the ruling says fire `refuseLoad` on the `Malformed` arm. **Did:** fired it only where the `Malformed` came from the key's own declared value, not where it came from a document-level `NotAnObject`. **Why:** `resolveKey` folds both into one `Malformed` arm, but a `NotAnObject` document already resolves every key `Malformed`, so no value is readable off it and there is nothing to un-govern; refusing there would also have changed the existing "%s refuses a document that is not a JSON object" arm test for all fifteen keys. **Disposition:** stated here, pinned by a test, and written into both the code comment and the pattern doc.
- **Out-of-scope change** — **Said:** #6314 names `governedRoots`. **Did:** the fix sits in `register`, so `triageFacets` — the other key carrying `refuseLoad` — gains the same arm. **Why:** the invariant is the key group's, not one key's; special-casing `governedRoots` would put the rule back at a call site, which is what `refuseLoad` exists to avoid. **Disposition:** stated here; the existing `triageFacets` malformed-value test still passes because `unusableReason` relays a refusal in the same words it relayed the per-key malformity.
