### PR TITLE
fix: An infra rejection at /api/auth/* returns a bare 500 with an empty body — the caller gets zero signal

### DIFF
--- a/apps/web/worker/features/pasaport/auth-bridge.ts
+++ b/apps/web/worker/features/pasaport/auth-bridge.ts
@@ -1,0 +1,57 @@
+/**
+ * The `/api/auth/*` bridge boundary, shared by the live layer and the test layer so both
+ * answer a handler rejection with one shape (#4935).
+ *
+ * A rejection out of better-auth's own `handler` is infra, not a caller mistake, and the
+ * caller must still be able to tell it apart from an auth denial — so it answers `503` with a
+ * stable `code`, while the raw `cause` goes to the worker log only. `/api/auth/*` is
+ * unauthenticated, so nothing driver-shaped may reach the body.
+ */
+import * as Effect from "effect/Effect";
+import * as Schema from "effect/Schema";
+import * as HttpServerRequest from "effect/unstable/http/HttpServerRequest";
+import * as HttpServerResponse from "effect/unstable/http/HttpServerResponse";
+
+export class BetterAuthHandlerError extends Schema.TaggedErrorClass<BetterAuthHandlerError>()(
+	"pasaport/BetterAuthHandlerError",
+	{cause: Schema.Defect()},
+) {}
+
+/** The machine-readable discriminator a caller branches on. */
+export const AUTH_BRIDGE_UNAVAILABLE_CODE = "AUTH_BRIDGE_UNAVAILABLE";
+
+export const AUTH_BRIDGE_UNAVAILABLE_STATUS = 503;
+
+const unavailableResponse = HttpServerResponse.jsonUnsafe(
+	{
+		code: AUTH_BRIDGE_UNAVAILABLE_CODE,
+		message: "Sign-in is temporarily unavailable. Try again in a moment.",
+	},
+	{status: AUTH_BRIDGE_UNAVAILABLE_STATUS},
+);
+
+/**
+ * The `BetterAuth.fetch` body: run `handle` over the raw request, and turn its rejection into
+ * the unavailable response instead of a defect (which died with `content-length: 0`).
+ */
+export const authBridgeFetch = (
+	handle: (request: Request) => Promise<Response>,
+): Effect.Effect<
+	HttpServerResponse.HttpServerResponse,
+	never,
+	HttpServerRequest.HttpServerRequest
+> =>
+	Effect.gen(function* () {
+		const request = yield* HttpServerRequest.HttpServerRequest;
+		return yield* Effect.tryPromise({
+			try: () => handle(request.source as Request),
+			catch: (cause) => new BetterAuthHandlerError({cause}),
+		}).pipe(
+			Effect.map(HttpServerResponse.fromWeb),
+			Effect.catchTag("pasaport/BetterAuthHandlerError", (error) =>
+				Effect.logError("[pasaport.authBridge] better-auth handler rejected", error.cause).pipe(
+					Effect.as(unavailableResponse),
+				),
+			),
+		);
+	});

--- a/apps/web/worker/features/pasaport/auth-bridge.unit.test.ts
+++ b/apps/web/worker/features/pasaport/auth-bridge.unit.test.ts
@@ -1,0 +1,56 @@
+/**
+ * The `/api/auth/*` rejection shape (#4935): a handler that rejects must not answer a bare
+ * `500` with an empty body, and must not put the driver text in it either.
+ */
+import * as Effect from "effect/Effect";
+import * as HttpServerRequest from "effect/unstable/http/HttpServerRequest";
+import * as HttpServerResponse from "effect/unstable/http/HttpServerResponse";
+import {describe, expect, it} from "vitest";
+import {
+	AUTH_BRIDGE_UNAVAILABLE_CODE,
+	AUTH_BRIDGE_UNAVAILABLE_STATUS,
+	authBridgeFetch,
+} from "./auth-bridge.ts";
+
+const D1_REJECTION = "D1_ERROR: Failed to parse body as JSON, got: error code: 1031";
+
+const runBridge = (handle: (request: Request) => Promise<Response>) =>
+	Effect.runPromise(
+		authBridgeFetch(handle).pipe(
+			Effect.map((response) => HttpServerResponse.toWeb(response)),
+			Effect.provideService(
+				HttpServerRequest.HttpServerRequest,
+				HttpServerRequest.fromWeb(new Request("http://localhost:3000/api/auth/sign-up/email")),
+			),
+		),
+	);
+
+describe("authBridgeFetch", () => {
+	it("passes a handler response straight through", async () => {
+		const response = await runBridge(async () => new Response('{"ok":true}', {status: 200}));
+
+		expect(response.status).toBe(200);
+		expect(await response.text()).toBe('{"ok":true}');
+	});
+
+	it("answers a rejection with a discriminable status and a non-empty body", async () => {
+		const response = await runBridge(async () => {
+			throw new Error(D1_REJECTION);
+		});
+		const body = await response.text();
+
+		expect(response.status).toBe(AUTH_BRIDGE_UNAVAILABLE_STATUS);
+		expect(body).not.toBe("");
+		expect(JSON.parse(body).code).toBe(AUTH_BRIDGE_UNAVAILABLE_CODE);
+	});
+
+	it("keeps the driver detail out of the body", async () => {
+		const response = await runBridge(async () => {
+			throw new Error(D1_REJECTION);
+		});
+		const body = await response.text();
+
+		expect(body).not.toContain("D1_ERROR");
+		expect(body).not.toContain("1031");
+	});
+});

--- a/apps/web/worker/features/pasaport/better-auth-live.ts
+++ b/apps/web/worker/features/pasaport/better-auth-live.ts
@@ -21,14 +21,12 @@ import {defineRelations} from "drizzle-orm/relations";
 import * as Effect from "effect/Effect";
 import * as Layer from "effect/Layer";
 import * as Redacted from "effect/Redacted";
-import * as Schema from "effect/Schema";
-import * as HttpServerRequest from "effect/unstable/http/HttpServerRequest";
-import * as HttpServerResponse from "effect/unstable/http/HttpServerResponse";
 import type {} from "zod/v4/core";
 import {AppConfig, betterAuthSecret, type Environment} from "../../config.ts";
 import {Database} from "../../db/Database.ts";
 import * as schema from "../../db/drizzle/schema.ts";
 import {PHOENIX_APEX_HOSTNAME} from "../../env.ts";
+import {authBridgeFetch} from "./auth-bridge.ts";
 import {type EmailMessage, EmailSender} from "./email-sender.ts";
 import {
 	changeEmailConfirmationEmail,
@@ -37,11 +35,6 @@ import {
 } from "./email-templates.ts";
 
 type AdditionalUserFields = NonNullable<NonNullable<BetterAuthOptions["user"]>["additionalFields"]>;
-
-export class BetterAuthHandlerError extends Schema.TaggedErrorClass<BetterAuthHandlerError>()(
-	"pasaport/BetterAuthHandlerError",
-	{cause: Schema.Defect()},
-) {}
 
 /**
  * Every field here is `input:false`, and that is the security invariant: `role`
@@ -169,13 +162,8 @@ export const BetterAuthLive = Layer.effect(
 		return {
 			auth,
 			fetch: Effect.gen(function* () {
-				const request = yield* HttpServerRequest.HttpServerRequest;
 				const authInstance = yield* auth;
-				const response = yield* Effect.tryPromise({
-					try: () => authInstance.handler(request.source as Request),
-					catch: (cause) => new BetterAuthHandlerError({cause}),
-				}).pipe(Effect.orDie);
-				return HttpServerResponse.fromWeb(response);
+				return yield* authBridgeFetch((request) => authInstance.handler(request));
 			}),
 		};
 	}),

--- a/apps/web/worker/features/pasaport/better-auth.testing.ts
+++ b/apps/web/worker/features/pasaport/better-auth.testing.ts
@@ -13,10 +13,9 @@ import {drizzle} from "drizzle-orm/d1";
 import {defineRelations} from "drizzle-orm/relations";
 import * as Effect from "effect/Effect";
 import * as Layer from "effect/Layer";
-import * as HttpServerRequest from "effect/unstable/http/HttpServerRequest";
-import * as HttpServerResponse from "effect/unstable/http/HttpServerResponse";
 import * as schema from "../../db/drizzle/schema.ts";
-import {apiKeyRateLimit, BetterAuthHandlerError} from "./better-auth-live.ts";
+import {authBridgeFetch} from "./auth-bridge.ts";
+import {apiKeyRateLimit} from "./better-auth-live.ts";
 
 /**
  * A REAL better-auth instance over a test `D1Database` handle. MUST stay in lockstep with
@@ -50,14 +49,7 @@ export function makeRealAuthForTest(d1: D1Database) {
 export const layerTest = (instance: Auth): Layer.Layer<BetterAuth.BetterAuth> =>
 	Layer.succeed(BetterAuth.BetterAuth)({
 		auth: Effect.succeed(instance),
-		fetch: Effect.gen(function* () {
-			const request = yield* HttpServerRequest.HttpServerRequest;
-			const response = yield* Effect.tryPromise({
-				try: () => instance.handler(request.source as Request),
-				catch: (cause) => new BetterAuthHandlerError({cause}),
-			}).pipe(Effect.orDie);
-			return HttpServerResponse.fromWeb(response);
-		}),
+		fetch: authBridgeFetch((request) => instance.handler(request)),
 	});
 
 /**


### PR DESCRIPTION
An infra rejection from better-auth's own handler at `/api/auth/*` used to `orDie`, so the request died and the worker answered a bare `500` with `content-length: 0`. The caller got nothing to act on and the real cause lived only in the worker's stdout.

Both bridges now share one boundary, `apps/web/worker/features/pasaport/auth-bridge.ts`:

- a rejection answers `503` with `{"code":"AUTH_BRIDGE_UNAVAILABLE","message":"Sign-in is temporarily unavailable. Try again in a moment."}` — a distinguishable status *and* a stable machine-readable discriminator.
- the raw `cause` goes to `Effect.logError` and nowhere near the body, so the unauthenticated endpoint leaks no driver text, stack, query or connection material.
- `BetterAuthLive.fetch` and `better-auth.testing.ts`'s `layerTest` both call `authBridgeFetch`, so the two bridges cannot drift.
- `auth-bridge.unit.test.ts` forces a handler rejection with the reported `D1_ERROR: … error code: 1031` text and asserts the pass-through case, the non-empty discriminable body, and the absence of driver detail in it.

`BetterAuthHandlerError` moved from `better-auth-live.ts` to the new module with the rest of the boundary; nothing else imported it.

Reviewer's first look: the `503` choice and the body shape. better-auth's own errors use `{code, message}`, so the SPA's `authClient` reads this the same way it reads an auth denial, and the status is what separates "infra is down" from "your credentials are wrong".

Fixes #4935

## Deviations

- **Out-of-scope change** — **Said:** #4935 names the `orDie` site and the test bridge. **Did:** also moved `BetterAuthHandlerError` out of `better-auth-live.ts` into the new `auth-bridge.ts`. **Why:** the criterion asks for one boundary with one shape, and leaving the error class behind would have kept the boundary split across two files. **Disposition:** stated here.
- **Known defect left unfixed** — **Said:** nothing about the test bridge's callers. **Did:** left `makeRealAuthForTest`, `layerTest` and `layerStub` in place though a repo-wide grep finds no consumer of any of them. **Why:** the issue asks the two bridges stay consistent, not that the unused one be deleted; removing it is a separate call. **Disposition:** left as is, noted for triage.
