### PR TITLE
fix: `build check --surface code` hardcodes phoenix's turbo script names, so no code lane can green in a consuming repo

### DIFF
--- a/.fabrika.jsonc
+++ b/.fabrika.jsonc
@@ -28,6 +28,16 @@
 	// key is ever wired up again; what becomes of the key itself is the founder's to rule.
 	"unreadableCodeowners": "refuse",
 
+	// The repo's own commands that compile and lint its code. `fabrika build check --surface code`
+	// runs each one in the lane's tree, and both flags here are phoenix's: `--force` is turbo's
+	// cache-bypass (a bare `tsc` rejects it), and `lint:worktree` is a phoenix script name. Nothing
+	// is compiled into the CLI, so a repo declaring nothing gets a named refusal rather than these
+	// two commands (#6015).
+	"codeValidators": [
+		{ "command": ["pnpm", "typecheck", "--force"] },
+		{ "command": ["pnpm", "lint:worktree"] }
+	],
+
 	// The repo's own commands that machine-read `.github/workflows/**`. `fabrika build check
 	// --surface workflows` runs each one over a workflows-touching diff, on top of `actionlint` when
 	// the tree has one (#5991), and `reads` names the exact workflow files that command opens — the

--- a/.patterns/fabrika-config-key-groups.md
+++ b/.patterns/fabrika-config-key-groups.md
@@ -66,8 +66,10 @@ on one growing reader.
 labels reads as "nothing is governed" / "nothing is required" and turns the gate off. Pick the
 value that reproduces today's behaviour, and make an explicitly-declared empty list `Malformed`
 where empty would disable something. The widen-only keys are the exception and say so in their own
-docblocks: for `capClearAuthors`, `docLeakExempt` and `workflowValidators`, empty **is** the strict
-answer.
+docblocks: for `capClearAuthors`, `docLeakExempt`, `workflowValidators` and `codeValidators`, empty
+**is** the strict answer — the last because a list of commands a verb must run is not a gate's
+scope: nothing to run refuses UNKNOWN, so an empty default withholds a verdict where a populated one
+would have run another repo's script names and called the failure that repo's code (#6015).
 
 `containmentVocabulary` is the other exception, and it is one on purpose: an explicitly-empty half
 turns the containment marker off, because a repo with no deployment story has nothing to contain and
@@ -182,13 +184,17 @@ a `null` path is the shape that gets `?? ".decisions"`-ed back into the default 
 
 ## An empty declared list is the caller's answer, not the decoder's
 
-A key whose shipped default is non-empty has a third state its decoder must not fold away: the repo
-declared the key, and declared it **empty**. That is well-formed data, so `decode` accepts it; what
-it means is the caller's to say. `codeValidators` is the worked example — an empty list means no
-code validator is present, and `build check --surface code` refuses UNKNOWN on it rather than
+A repo may declare a key and declare it **empty**. That is well-formed data, so `decode` accepts it;
+what it means is the caller's to say. `codeValidators` is the worked example — an empty list means
+no code validator is present, and `build check --surface code` refuses UNKNOWN on it rather than
 greening (nothing was checked) or redding (which claims the code failed, #6015). Deciding it in the
 decoder would put one verb's vocabulary in the config module and leave every other reader of the key
 stuck with it.
+
+The caller owes the resolution arm in its message even when both arms carry the same empty value.
+`build check` reads "declares an empty `codeValidators`" off `Declared` and "declares no
+`codeValidators`" off `Default`, because the fix differs: one repo wrote the wrong thing and the
+other wrote nothing.
 
 ## A key over a closed id set merges, and refuses an id it does not know
 

--- a/claude-plugins/fabrika/skills/build/contract.md
+++ b/claude-plugins/fabrika/skills/build/contract.md
@@ -1474,10 +1474,11 @@ Per surface:
   this tree **with the build cache bypassed**. The cache bypass is the design — a cache hit from
   another checkout returned another tree's green three times in one session (#4106) and recurred on
   the review side (#4887) — but the flag expressing it is the repo's, since turbo's `--force` is a
-  hard error to a bare `tsc` (#6015). A repo declaring nothing gets the shipped pair, `pnpm
-  typecheck --force` and `pnpm lint:worktree`. A declared list that is **empty** has nothing to run,
-  which refuses `11`, UNKNOWN — never green, and never the `VALIDATION_RED` that says the code
-  failed.
+  hard error to a bare `tsc` (#6015). Nothing is compiled in for a repo to inherit: phoenix declares
+  `pnpm typecheck --force` and `pnpm lint:worktree` in its own `.fabrika.jsonc` like anyone else. A
+  repo with no list — declared empty, or never declared at all — has nothing to run, which refuses
+  `11`, UNKNOWN naming which of the two it was — never green, and never the `VALIDATION_RED` that
+  says the code failed.
 - **prose** — changed markdown files: every relative link resolves against this tree; no
   machine-local path (the imported `doc-leaks.ts` predicate); every fabrika-doc reference cited by
   id exists.
@@ -1666,7 +1667,7 @@ $ fabrika build check --surface code
 ```
 
 `ran` echoes whatever `codeValidators` resolved to, one `argv.join(" ")` per validator; the two
-above are **phoenix's** shipped pair, not a contract.
+above are what **phoenix's** `.fabrika.jsonc` declares, not a contract.
 
 **Grounding**
 

--- a/claude-plugins/fabrika/skills/build/references/code.md
+++ b/claude-plugins/fabrika/skills/build/references/code.md
@@ -1,8 +1,9 @@
 # Surface rubric — code
 
 Compiled, tested text. `fabrika build check` runs the commands this repo declares under
-`.fabrika.jsonc`'s `codeValidators` here, cache-bypassed, in this tree — in phoenix, the shipped
-pair `pnpm typecheck --force` and `pnpm lint:worktree`.
+`.fabrika.jsonc`'s `codeValidators` here, cache-bypassed, in this tree — in phoenix, the pair it
+declares there, `pnpm typecheck --force` and `pnpm lint:worktree`. A repo that declares none refuses
+UNKNOWN rather than running someone else's script names.
 
 - **Match the surrounding code's idiom** — comment density, naming, bracket style. A diff that
   reads as a different author is a defect before it is a style choice.

--- a/claude-plugins/fabrika/skills/front-door/contract.md
+++ b/claude-plugins/fabrika/skills/front-door/contract.md
@@ -562,13 +562,14 @@ one parse of the file. No pagination: the scope is a registry, not a list read.
 **Examples**
 
 Every transcript below is from phoenix, where the registry holds **15** keys and the file declares
-**4** of them. Row sets are abridged to the ones the example is about; the counts on the header line
+**5** of them. Row sets are abridged to the ones the example is about; the counts on the header line
 are not.
 
 ```
 $ fabrika status settings
-settings	resolved	15	4	0	2026-08-19T20:43:22Z
+settings	resolved	15	5	0	2026-08-19T20:43:22Z
 setting	capClearAuthors	declared	["@usirin","@notusirin","@cansirin"]	-	2026-08-19T20:43:22Z
+setting	codeValidators	declared	[{"command":["pnpm","typecheck","--force"]},{"command":["pnpm","lint:worktree"]}]	-	2026-08-19T20:43:22Z
 setting	docLeakExempt	declared	["/CLAUDE.md",…]	-	2026-08-19T20:43:22Z
 setting	governedRoots	default	[".decisions/",".claude/",".github/","claude-plugins/",".fabrika.jsonc"]	.fabrika.jsonc declares no `governedRoots`	2026-08-19T20:43:22Z
 setting	unreadableCodeowners	declared	"refuse"	-	2026-08-19T20:43:22Z
@@ -579,7 +580,7 @@ With `--surfaces`, the same rows plus one per repo surface (abridged — phoenix
 
 ```
 $ fabrika status settings --surfaces
-settings	resolved	15	4	0	2026-08-19T20:43:22Z
+settings	resolved	15	5	0	2026-08-19T20:43:22Z
 setting	surfaceDispositions	default	{"gh-rest":"fail-loud","git-worktree":"fail-loud",…}	.fabrika.jsonc declares no `surfaceDispositions`	2026-08-19T20:43:22Z
 surface	gh-rest	fail-loud	a GitHub repo reachable over `gh` REST with `issues: write`; every issue-writing verb exits 11 without it, and a run with no board is no answer rather than a narrower one
 surface	roadmap-focus	degrade	the `## Campaigns` table at `roadmapFile`, which declares the campaign in exclusive focus; an absent file and an absent table are the same well-formed default — nothing is active, so `build pick`'s and `build claim`'s fence is inert and admits every issue …
@@ -589,7 +590,7 @@ The same run under `--json` — the notice line stays on stderr, so stdout is th
 
 ```
 $ fabrika status settings --json
-{"outcome":"resolved","path":".fabrika.jsonc","keys":15,"declared":4,"unknown":0,"settings":[{"key":"capClearAuthors","provenance":"declared","value":["@usirin","@notusirin","@cansirin"],"detail":"-","asOf":"2026-08-19T20:43:22Z","asOfKind":"read-now"},…,{"key":"governedRoots","provenance":"default","value":[".decisions/",".claude/",".github/","claude-plugins/",".fabrika.jsonc"],"detail":".fabrika.jsonc declares no `governedRoots`","asOf":"2026-08-19T20:43:22Z","asOfKind":"read-now"},…,{"key":"workflowValidators","provenance":"declared","value":[],"detail":"-","asOf":"2026-08-19T20:43:22Z","asOfKind":"read-now"}]}
+{"outcome":"resolved","path":".fabrika.jsonc","keys":15,"declared":5,"unknown":0,"settings":[{"key":"capClearAuthors","provenance":"declared","value":["@usirin","@notusirin","@cansirin"],"detail":"-","asOf":"2026-08-19T20:43:22Z","asOfKind":"read-now"},…,{"key":"governedRoots","provenance":"default","value":[".decisions/",".claude/",".github/","claude-plugins/",".fabrika.jsonc"],"detail":".fabrika.jsonc declares no `governedRoots`","asOf":"2026-08-19T20:43:22Z","asOfKind":"read-now"},…,{"key":"workflowValidators","provenance":"declared","value":[],"detail":"-","asOf":"2026-08-19T20:43:22Z","asOfKind":"read-now"}]}
 ```
 
 ```

--- a/packages/fabrika-cli/src/build/check-verb.ts
+++ b/packages/fabrika-cli/src/build/check-verb.ts
@@ -476,6 +476,8 @@ type CodeScope =
 			readonly _tag: "Scope";
 			readonly validators: ReadonlyArray<CodeValidator>;
 			readonly note: string;
+			/** How an empty list reads back to whoever has to fix it. */
+			readonly absence: string;
 	  }
 	| {readonly _tag: "Unknown"; readonly reason: string};
 
@@ -491,25 +493,28 @@ const readCodeScope = (root: string): Effect.Effect<CodeScope, never, FileSystem
 					_tag: "Scope",
 					validators: resolved.value,
 					note: `${VERB}: ${resolved.value.length} code validator(s) declared in ${CONFIG_PATH}.`,
+					absence: `${CONFIG_PATH} declares an empty \`${CODE_VALIDATORS}\``,
 				};
 			case "Default":
 				return {
 					_tag: "Scope",
 					validators: resolved.value,
-					note: `${VERB}: ${resolved.value.length} shipped code validator(s) — ${resolved.reason}.`,
+					note: `${VERB}: ${resolved.value.length} code validator(s) — ${resolved.reason}.`,
+					absence: resolved.reason,
 				};
 		}
 	});
 
 /**
  * The `code` surface: the validators the repo **declares**, run in this tree with its own
- * cache-bypass flags, or the shipped pair when it declares none.
+ * cache-bypass flags. There is no shipped pair to fall back on — phoenix declares its own.
  *
  * The three outcomes stay apart, and keeping them apart is the whole point (#6015, #6297). A
  * validator that ran and failed is `VALIDATION_RED`. A validator that could not be spawned proves
- * nothing about the code and refuses UNKNOWN naming it. A repo that declares an explicitly empty
- * list has nothing to run at all, which is neither a red nor a green: reporting "no validator is
- * present" as red says the code is broken, and reporting it as green says it was checked.
+ * nothing about the code and refuses UNKNOWN naming it. A repo with no list at all — declared
+ * empty, or never declared — has nothing to run, which is neither a red nor a green: reporting "no
+ * validator is present" as red says the code is broken, and reporting it as green says it was
+ * checked.
  */
 const runCodeSurface = (
 	root: string,
@@ -533,7 +538,7 @@ const runCodeSurface = (
 		if (declared.validators.length === 0) {
 			return refuse(
 				PRECONDITION_UNKNOWN,
-				`${VERB}: ${CONFIG_PATH} declares an empty \`${CODE_VALIDATORS}\` — no code validator is present here, so nothing ran and the verdict is UNKNOWN, never green and never red.`,
+				`${VERB}: ${declared.absence} — no code validator is present here, so nothing ran and the verdict is UNKNOWN, never green and never red.`,
 				scoped,
 			);
 		}

--- a/packages/fabrika-cli/src/build/check-verb.unit.test.ts
+++ b/packages/fabrika-cli/src/build/check-verb.unit.test.ts
@@ -55,6 +55,19 @@ const LS_TREE = new RegExp(
 const TYPECHECK = /^pnpm typecheck --force$/;
 const LINT = /^pnpm lint:worktree$/;
 
+/** The config path every read of this lane's declarations resolves to. */
+const CONFIG_FILE = `${ROOT}/.fabrika.jsonc`;
+
+/**
+ * The code validators these tests declare — phoenix's own pair, read off a config file the way any
+ * repo's is. The CLI ships no pair to fall back on, so a code-surface test that declared nothing
+ * would be exercising the "no validator is present" refusal rather than the runner (#6015).
+ */
+const CODE_CONFIG: Record<string, string> = {
+	[CONFIG_FILE]:
+		'{"codeValidators": [{"command": ["pnpm", "typecheck", "--force"]}, {"command": ["pnpm", "lint:worktree"]}]}',
+};
+
 const LANE = `build/4312-editor-focus-loss-${NONCE}`;
 
 /** A scripted untracked-file list. Placed ahead of `LANE_OK`, whose default is an empty one. */
@@ -109,7 +122,10 @@ const run = (
 	Effect.runPromise(
 		Effect.provide(
 			runCheck({...options, ...overrides}),
-			Layer.merge(fakeShell(script).layer, fakeFs({files, unreadable}).layer),
+			Layer.merge(
+				fakeShell(script).layer,
+				fakeFs({files: {...CODE_CONFIG, ...files}, unreadable}).layer,
+			),
 		),
 	);
 
@@ -212,7 +228,10 @@ describe("runCheck", () => {
 			[LINT, okOut("")],
 		]);
 		const out = await Effect.runPromise(
-			Effect.provide(runCheck(options), Layer.merge(shell.layer, fakeFs({}).layer)),
+			Effect.provide(
+				runCheck(options),
+				Layer.merge(shell.layer, fakeFs({files: CODE_CONFIG}).layer),
+			),
 		);
 		expect(out.code).toBe(0);
 		expect(JSON.parse(out.stdout)).toEqual({
@@ -758,7 +777,10 @@ describe("the enumeration unions the untracked files with the diff", () => {
 			[LINT, okOut("")],
 		]);
 		const out = await Effect.runPromise(
-			Effect.provide(runCheck(options), Layer.merge(shell.layer, fakeFs({}).layer)),
+			Effect.provide(
+				runCheck(options),
+				Layer.merge(shell.layer, fakeFs({files: CODE_CONFIG}).layer),
+			),
 		);
 		expect(out.code).toBe(0);
 		expect(shell.calls).toContain(UNTRACKED_ARGV);
@@ -1219,17 +1241,26 @@ describe("--surface code reads its validators from the config", () => {
 		expect(calls).not.toContain("pnpm typecheck --force");
 	});
 
-	it("falls back to the shipped pair when the file declares no `codeValidators`", async () => {
-		const {out, calls} = await codeRun(
-			[
-				[TYPECHECK, okOut("")],
-				[LINT, okOut("")],
-			],
-			"{}",
+	// The demlik reproduction on #6015: a repo that never declared these ran phoenix's script names
+	// and got a red, which says its code is broken. Nothing is compiled in for it to inherit.
+	it("refuses UNKNOWN when the file declares no `codeValidators`", async () => {
+		const {out, calls} = await codeRun([], "{}");
+		expect(out.code).toBe(PRECONDITION_UNKNOWN);
+		expect(out.stdout).toBe("");
+		expect(out.stderr.at(-1)).toBe(
+			"build check: .fabrika.jsonc declares no `codeValidators` — no code validator is present here, so nothing ran and the verdict is UNKNOWN, never green and never red.",
 		);
-		expect(out.code).toBe(0);
-		expect(JSON.parse(out.stdout).ran).toEqual(["pnpm typecheck --force", "pnpm lint:worktree"]);
-		expect(calls).toContain("pnpm lint:worktree");
+		expect(calls).not.toContain("pnpm typecheck --force");
+		expect(calls).not.toContain("pnpm lint:worktree");
+	});
+
+	it("refuses UNKNOWN when the repo has no config file at all", async () => {
+		const {out, calls} = await codeRun([], null);
+		expect(out.code).toBe(PRECONDITION_UNKNOWN);
+		expect(out.stderr.at(-1)).toBe(
+			"build check: this repo has no .fabrika.jsonc — no code validator is present here, so nothing ran and the verdict is UNKNOWN, never green and never red.",
+		);
+		expect(calls).not.toContain("pnpm typecheck --force");
 	});
 
 	it("refuses UNKNOWN on an explicitly empty list — never green, never red", async () => {

--- a/packages/fabrika-cli/src/config/key-group.ts
+++ b/packages/fabrika-cli/src/config/key-group.ts
@@ -29,7 +29,11 @@ export type Decoded<A> =
 
 export interface KeyGroup<A> {
 	readonly key: string;
-	/** What an absent file and an absent key both resolve to. Never an empty gate list. */
+	/**
+	 * What an absent file and an absent key both resolve to. Never a value that lets a gate pass on
+	 * less than it should — for a gate's scope that rules out an empty list; for a list of commands a
+	 * verb must run, empty is the strict arm, because nothing to run refuses rather than greens.
+	 */
 	readonly shippedDefault: A;
 	/** Decode a present value. Refuse the whole value rather than skipping a bad entry. */
 	readonly decode: (raw: unknown) => Decoded<A>;

--- a/packages/fabrika-cli/src/config/keys/code-validators.ts
+++ b/packages/fabrika-cli/src/config/keys/code-validators.ts
@@ -10,11 +10,13 @@
  * a declared guard opens a fixed set it names; a code validator is handed no paths and compiles the
  * tree, so a per-file list here would be a claim nothing could hold it to.
  *
- * **The shipped default is phoenix's current pair, and it is deliberately not empty.** An empty
- * default would mean an adopting repo greens without running anything. A repo that declares an
- * explicit empty list has nothing runnable, and `build check --surface code` refuses UNKNOWN on it
- * — never green, and never `VALIDATION_RED`, which stays reserved for a validator that ran and
- * failed.
+ * **The shipped default is empty, and phoenix declares its own pair like any other repo.** Emptiness
+ * costs nothing here that it costs a gate-scope key: an empty list has nothing runnable, so
+ * `build check --surface code` refuses UNKNOWN on it — never green, and never `VALIDATION_RED`,
+ * which stays reserved for a validator that ran and failed. Defaulting to phoenix's pair instead
+ * left an adopting repo running script names it never defined: demlik declared nothing, got
+ * `pnpm typecheck --force`, and `tsc` rejected the turbo flag outright — a red saying its code was
+ * broken when the truth was that no validator was present (#6015).
  */
 
 import {isRecord} from "../../io/json.ts";
@@ -48,11 +50,8 @@ const decode = (raw: unknown): Decoded<ReadonlyArray<CodeValidator>> => {
 	return {_tag: "Value", value: validators};
 };
 
-/** Phoenix's two CI commands, cache-bypassed — what a repo declaring nothing still gets. */
-export const SHIPPED_CODE_VALIDATORS: ReadonlyArray<CodeValidator> = [
-	{argv: ["pnpm", "typecheck", "--force"]},
-	{argv: ["pnpm", "lint:worktree"]},
-];
+/** A repo declaring nothing has no code validator — the refusal, not a guessed command line. */
+export const SHIPPED_CODE_VALIDATORS: ReadonlyArray<CodeValidator> = [];
 
 export const codeValidatorsKey: KeyGroup<ReadonlyArray<CodeValidator>> = {
 	key: CODE_VALIDATORS,

--- a/packages/fabrika-cli/src/config/keys/surface-dispositions.ts
+++ b/packages/fabrika-cli/src/config/keys/surface-dispositions.ts
@@ -231,7 +231,7 @@ export const SURFACE_REGISTRY: ReadonlyArray<SurfaceSpec> = [
 	{
 		id: "code-validators",
 		disposition: "fail-loud",
-		note: "a command `codeValidators` names that can actually be spawned here; `build check --surface code` refuses UNKNOWN on an empty list or a validator it cannot run — never green, never red",
+		note: "a command `codeValidators` names that can actually be spawned here; `build check --surface code` refuses UNKNOWN on a repo that declares none, an empty list, or a validator it cannot run — never green, never red",
 	},
 	{
 		id: "readout-artifact",


### PR DESCRIPTION
`build check --surface code` ran commands that were compiled into the CLI. #6313 moved them behind a
`codeValidators` config key but kept phoenix's pair as the shipped default, so a repo that declares
nothing still runs phoenix's script names: demlik got `error TS5093` off turbo's `--force` and a
`VALIDATION_RED` telling it its own code was broken, when the truth was that no validator was
present.

The shipped default is now empty, and phoenix declares its pair in its own `.fabrika.jsonc` like any
other repo. Nothing to run refuses UNKNOWN either way, and the message names which case it was —
`declares an empty codeValidators` off a declaration, `declares no codeValidators` (or `this repo has
no .fabrika.jsonc`) off the default — because one repo wrote the wrong thing and the other wrote
nothing.

The unit tests declare the pair in a config fixture instead of asserting it as a built-in, so the
strings they pin are a repo's declaration rather than the CLI's.

Verified in this tree: `build check --surface code` green with `2 code validator(s) declared in
.fabrika.jsonc`, `--surface prose` green, `pnpm vitest run` in `packages/fabrika-cli` at 6959 passing.

Fixes #6015

## Deviations

- **Out-of-scope change** — **Said:** #6015 names `check-verb.ts` and its unit test. **Did:** also
  updated `.patterns/fabrika-config-key-groups.md`, `build/contract.md`, `build/references/code.md`
  and `front-door/contract.md`. **Why:** each states the old shipped-pair fallback as current
  behaviour, and the pattern doc's exception list is where a future key learns the rule.
  **Disposition:** stated here.
- **Pre-existing test or fixture changed** — **Said:** nothing about the shared `run` helper.
  **Did:** its fake filesystem now carries a `.fabrika.jsonc` declaring the pair. **Why:** with no
  compiled-in default, every code-surface test would otherwise exercise the "no validator present"
  refusal instead of the runner. **Disposition:** stated here.
- **Declined guidance** — **Said:** the issue's routing note asks that nothing be built here until
  the founder or `plan-epic` settles whether this folds into epic #5631. **Did:** built it. **Why:**
  the driver named #6015 as this lane, and #5631's loader has since landed (#6313), so the competing-
  fix risk that note guarded against is gone — this change sits on top of that loader rather than
  around it. **Disposition:** stated here; re-route if the founder wanted otherwise.
