### PR TITLE
fix: lane assembly sets the epic branch's upstream to main, so lane push targets main

### DIFF
--- a/claude-plugins/fabrika/skills/operate/SKILL.md
+++ b/claude-plugins/fabrika/skills/operate/SKILL.md
@@ -133,7 +133,7 @@ node <fabrika> lane assembly $lane_key
 ```
 
 Its stdout is the absolute path of that worktree — `.claude/worktrees/epic-<lane-key>`, cut off the
-repository's default branch through git's own `origin/HEAD` pointer — and **every git write this run
+repository's default branch through git's own `origin/HEAD` pointer, tracking nothing — and **every git write this run
 performs on the assembly branch happens there, addressed as `git -C <that path>`**. It is idempotent
 from either side: a later pass finding the tree still there resumes it and re-prints the same path,
 and a pass finding the branch alive with its tree gone — what `--remove` at a terminal leaves behind,
@@ -264,6 +264,12 @@ bare push cannot say that, which is why the corpus forbids one ([#4213](https://
 and `build push` cannot serve here because the assembly branch carries no build claim's nonce. There
 is no force flag to reach for: the branch only ever grows, so exit `29` means fetch and re-merge, and
 exit `30` is a proven "the remote did not move" — never a `MOVED` you assume.
+
+**Its target is `refs/heads/epic/<n>`, spelled out, never the branch's recorded upstream.** Reading
+it there aimed every push in a run at `refs/heads/main`, and branch protection was the only thing
+refusing them ([#6435](https://github.com/kamp-us/phoenix/issues/6435)). A seat whose branch still
+tracks another ref is cleared before the push, because a bare `git push` there would fire at that
+branch; exit `34` is that clear failing to take.
 
 **It is also the run's isolation gate, and it is fail-closed.** Invoked in the repository's main
 working tree it refuses on `33` and pushes nothing, whatever the branch says — so an assembly that

--- a/packages/fabrika-cli/README.md
+++ b/packages/fabrika-cli/README.md
@@ -536,7 +536,8 @@ be resolved · `20` several open PRs claim the task's issue · `21` the lane key
 `22`–`25` the proof `lane prove` needed is absent, in flight, contradicted or ambiguous · `26` the
 tree is not on the run's assembly branch · `29` the push would not fast-forward · `30` the push ran
 and the ref did not move · `31` this session does not hold the driver's claim · `32` the terminal
-token is no shell's · `33` an assembly git write was aimed at the main working tree.
+token is no shell's · `33` an assembly git write was aimed at the main working tree · `34` the
+assembly branch tracks another ref and clearing that upstream did not take.
 
 To open a lane, copy a template in and speak the operator's six events — `DONE` / `PASS` / `FAIL` /
 `BLOCKED` / `WIP` / `UNBLOCKED`:

--- a/packages/fabrika-cli/src/exit-code-alignment.ts
+++ b/packages/fabrika-cli/src/exit-code-alignment.ts
@@ -274,7 +274,7 @@ export const PATTERN_SEATS: SharedSeats = {
  * did not land (`APPEND_UNKNOWN`), and the read that failed before any of that could be proven
  * (`LANE_UNREADABLE`). `lane claim` adds the fifth: it posts a marker and reads it back, so alone in
  * this group it can establish *the write landed and the read-back contradicts it* (`MARKER_READBACK`,
- * #5761). The private band runs `12`-`31`, skipping `27` and `28` because the base already speaks for
+ * #5761). The private band runs `12`-`34`, skipping `27` and `28` because the base already speaks for
  * both.
  */
 export const LANE_SEATS: SharedSeats = {

--- a/packages/fabrika-cli/src/lane/assembly-verb.ts
+++ b/packages/fabrika-cli/src/lane/assembly-verb.ts
@@ -149,8 +149,14 @@ export const runAssembly = (
 			"git",
 			resuming
 				? ["worktree", "add", seat.expected, branch]
-				: ["worktree", "add", "-b", branch, seat.expected, "origin/HEAD"],
+				: ["worktree", "add", "--no-track", "-b", branch, seat.expected, "origin/HEAD"],
 		);
+		// A branch cut off `origin/HEAD` without `--no-track` records `refs/heads/main` as its
+		// upstream, which aimed the run's pushes at the default branch (#6435). `--no-track` covers a
+		// fresh cut; a branch cut by an older fabrika carries the config into every resume, so it is
+		// cleared here. There is nothing to unset on a branch that tracks nothing, hence the ignored
+		// result.
+		if (resuming) yield* execCapture("git", ["branch", "--unset-upstream", branch]);
 		const after = yield* seatOf(options.epic, branch);
 		if (after._tag === "Unreadable") {
 			return refuse(

--- a/packages/fabrika-cli/src/lane/assembly-verb.unit.test.ts
+++ b/packages/fabrika-cli/src/lane/assembly-verb.unit.test.ts
@@ -69,7 +69,9 @@ describe("runAssembly", () => {
 
 		expect(outcome.code).toBe(0);
 		expect(outcome.stdout.trim()).toBe(EXPECTED);
-		expect(calls).toContain(`git worktree add -b ${BRANCH} ${EXPECTED} origin/HEAD`);
+		// `--no-track`: cut off `origin/HEAD` without it, the branch records `refs/heads/main` as its
+		// upstream and the run's pushes aim at the default branch (#6435).
+		expect(calls).toContain(`git worktree add --no-track -b ${BRANCH} ${EXPECTED} origin/HEAD`);
 		expect(calls.some((line) => line.startsWith("git switch"))).toBe(false);
 	});
 
@@ -170,6 +172,8 @@ describe("runAssembly", () => {
 		expect(calls).toContain(`git worktree add ${EXPECTED} ${BRANCH}`);
 		expect(calls.some((line) => line.includes("worktree add -b"))).toBe(false);
 		expect(calls.some((line) => line.startsWith("git fetch"))).toBe(false);
+		// A branch cut by an older fabrika carries the #6435 upstream into every resume.
+		expect(calls).toContain(`git branch --unset-upstream ${BRANCH}`);
 	});
 
 	it("clears a worktree record whose directory is gone, then places the branch again (#6163)", async () => {
@@ -190,6 +194,7 @@ describe("runAssembly", () => {
 			"git worktree list --porcelain",
 			"git for-each-ref --format=%(refname:short) refs/heads",
 			`git worktree add ${EXPECTED} ${BRANCH}`,
+			`git branch --unset-upstream ${BRANCH}`,
 			"git worktree list --porcelain",
 		]);
 	});

--- a/packages/fabrika-cli/src/lane/codes.ts
+++ b/packages/fabrika-cli/src/lane/codes.ts
@@ -209,3 +209,16 @@ export const TOKEN_UNRECOGNISED = 32;
  * versus `lane assembly` a worktree of the run's own.
  */
 export const PRIMARY_CHECKOUT = 33;
+
+/**
+ * The assembly branch tracks a ref that is not itself, and clearing that upstream did not take. The
+ * shape `git worktree add -b epic/<n> <seat> origin/HEAD` left it behind, recording
+ * `branch.epic/<n>.merge = refs/heads/main` and aiming the run's pushes at the default branch
+ * (#6435). `lane push` now names its target explicitly, so the config can no longer redirect the
+ * verb; this code says the seat itself is still aimed at that branch, where a bare `git push` would
+ * fire at it.
+ *
+ * Its own seat rather than {@link REF_NOT_MOVED}'s: that one is read after a push ran and says the
+ * remote disagrees, this one is proven before anything is sent.
+ */
+export const MISDIRECTED_PUSH = 34;

--- a/packages/fabrika-cli/src/lane/push-verb.ts
+++ b/packages/fabrika-cli/src/lane/push-verb.ts
@@ -15,6 +15,10 @@
  * There is no force flag. The assembly branch only ever grows, one merge per landed child, so a
  * non-fast-forward push is always a mistake and the flag that would let one through does not exist.
  *
+ * The push target is derived the same way: `HEAD:refs/heads/epic/<n>`, spelled out rather than read
+ * off the branch's recorded upstream. Reading it there aimed every push in an epic run at
+ * `refs/heads/main`, which only branch protection refused (#6435).
+ *
  * It is also the run's fail-closed isolation gate. Every assembly publication passes through here,
  * so this is where "the assembly seat never stands in the main working tree" is proven rather than
  * assumed: a push from the primary checkout is refused on `33` before anything is fetched, read back
@@ -31,6 +35,7 @@ import {
 	remoteSha,
 	upstreamOf,
 } from "../build/git.ts";
+import {execCapture} from "../io/exec.ts";
 import {currentBranch} from "../io/issues.ts";
 import {answer, refuse, type VerbOutcome} from "../verb.ts";
 import {epicBranch} from "../wire/lane-brief.ts";
@@ -38,6 +43,7 @@ import {standingInLinkedWorktree} from "./assembly.ts";
 import {
 	APPEND_UNKNOWN,
 	LANE_UNREADABLE,
+	MISDIRECTED_PUSH,
 	PRIMARY_CHECKOUT,
 	REF_NOT_MOVED,
 	UNSAFE_PUSH,
@@ -103,27 +109,40 @@ export const runPush = (
 
 		const upstream = yield* upstreamOf(branch);
 		const remote = upstream?.remote ?? "origin";
-		const ref = upstream?.ref ?? branch;
+		// An assembly branch tracks nothing, so an upstream naming another ref is the #6435 defect in
+		// the seat: this verb no longer reads its target from it, but a bare `git push` here still
+		// would. Clearing it is the reporter's own fix, and a clear that does not take is refused —
+		// publishing from a seat aimed at the default branch is what the run must never leave behind.
+		if (upstream !== null && upstream.ref !== branch) {
+			yield* execCapture("git", ["branch", "--unset-upstream", branch]);
+			const recheck = yield* upstreamOf(branch);
+			if (recheck !== null && recheck.ref !== branch) {
+				return refuse(
+					MISDIRECTED_PUSH,
+					`${VERB}: ${branch} tracks ${recheck.remote}/${recheck.ref}, not itself, and \`git branch --unset-upstream ${branch}\` did not clear it — a bare push from this seat would fire at ${recheck.ref}. Nothing was pushed.`,
+				);
+			}
+		}
 
-		const before = yield* remoteSha(remote, ref);
+		const before = yield* remoteSha(remote, branch);
 		if (before._tag === "Failure") {
 			return refuse(
 				LANE_UNREADABLE,
-				`${VERB}: cannot read ${remote}/${ref}: ${before.reason} — nothing was pushed.`,
+				`${VERB}: cannot read ${remote}/${branch}: ${before.reason} — nothing was pushed.`,
 			);
 		}
 		if (before.value !== null) {
-			if (!(yield* ensureCommitPresent(remote, ref, before.value))) {
+			if (!(yield* ensureCommitPresent(remote, branch, before.value))) {
 				return refuse(
 					LANE_UNREADABLE,
-					`${VERB}: cannot prove containment — ${remote}/${ref} is at ${before.value}, which this checkout does not hold and could not fetch. Nothing was pushed.`,
+					`${VERB}: cannot prove containment — ${remote}/${branch} is at ${before.value}, which this checkout does not hold and could not fetch. Nothing was pushed.`,
 				);
 			}
 			if (!(yield* isAncestor(before.value, local.value))) {
 				const dropped = yield* commitsDropped(local.value, before.value);
 				return refuse(
 					UNSAFE_PUSH,
-					`${VERB}: the local head does not contain ${remote}/${ref} (${before.value}) — this push would DROP ${
+					`${VERB}: the local head does not contain ${remote}/${branch} (${before.value}) — this push would DROP ${
 						dropped.lines.length === 0
 							? "commits the remote holds and this head does not"
 							: `${dropped.lines.join("; ")}${dropped.truncated ? "; …" : ""}`
@@ -132,8 +151,8 @@ export const runPush = (
 			}
 		}
 
-		const pushed = yield* push(remote, ref, false);
-		const after = yield* remoteSha(remote, ref);
+		const pushed = yield* push(remote, branch, false);
+		const after = yield* remoteSha(remote, branch);
 		if (after._tag === "Failure") {
 			return refuse(
 				APPEND_UNKNOWN,
@@ -149,7 +168,7 @@ export const runPush = (
 		}
 		return answer(
 			[
-				`pushed ${branch} → ${remote}/${ref}`,
+				`pushed ${branch} → ${remote}/${branch}`,
 				`remote ref read back: ${after.value}`,
 				"PUSH-VERDICT: MOVED",
 			].join("\n"),

--- a/packages/fabrika-cli/src/lane/push-verb.unit.test.ts
+++ b/packages/fabrika-cli/src/lane/push-verb.unit.test.ts
@@ -8,6 +8,7 @@ import {
 	APPEND_UNKNOWN,
 	LANE_ABSENT,
 	LANE_UNREADABLE,
+	MISDIRECTED_PUSH,
 	PRIMARY_CHECKOUT,
 	REF_NOT_MOVED,
 	UNSAFE_PUSH,
@@ -30,6 +31,8 @@ const LS_REMOTE = /^git ls-remote origin /;
 const PUSH = /^git push /;
 const ANCESTOR = /^git merge-base --is-ancestor /;
 const LOG = /^git log /;
+const REMOTES = /^git remote$/;
+const UNSET_UPSTREAM = /^git branch --unset-upstream /;
 
 /** `git ls-remote` output for the assembly ref; an absent ref prints nothing. */
 const refRow = (sha: string | null): ExecResult =>
@@ -59,6 +62,7 @@ const GROUND: ReadonlyArray<readonly [RegExp, ExecResult]> = [
 	[PRESENT, okOut(`${OLD_HEAD}\n`)],
 	[ANCESTOR, okOut("")],
 	[PUSH, okOut("")],
+	[UNSET_UPSTREAM, okOut("")],
 ];
 
 const run = (
@@ -178,6 +182,35 @@ describe("runPush", () => {
 		const {outcome, calls} = await run([[LS_REMOTE, errOut("network is unreachable")], ...GROUND]);
 
 		expect(outcome.code).toBe(LANE_UNREADABLE);
+		expect(pushed(calls)).toBe(false);
+	});
+
+	it("pushes the derived branch even when the branch tracks main, and clears that upstream (#6435)", async () => {
+		const {outcome, calls} = await run([
+			[once(UPSTREAM), okOut("origin/main\n")],
+			[UPSTREAM, errOut("fatal: no upstream")],
+			[REMOTES, okOut("origin\n")],
+			...remote(refRow(OLD_HEAD), refRow(HEAD)),
+			...GROUND,
+		]);
+
+		expect(outcome.code).toBe(0);
+		expect(calls).toContain(`git push origin HEAD:refs/heads/${BRANCH}`);
+		expect(calls.some((line) => line.includes("refs/heads/main"))).toBe(false);
+		expect(calls).toContain(`git branch --unset-upstream ${BRANCH}`);
+	});
+
+	it("refuses a seat whose upstream survives the clear, naming the ref a bare push would hit", async () => {
+		const {outcome, calls} = await run([
+			[UPSTREAM, okOut("origin/main\n")],
+			[REMOTES, okOut("origin\n")],
+			...remote(refRow(OLD_HEAD), refRow(HEAD)),
+			...GROUND,
+		]);
+
+		expect(outcome.code).toBe(MISDIRECTED_PUSH);
+		expect(outcome.stdout).toBe("");
+		expect(outcome.stderr.join("\n")).toContain("main");
 		expect(pushed(calls)).toBe(false);
 	});
 


### PR DESCRIPTION
`fabrika lane push` used to resolve its push target from the assembly branch's recorded upstream, and `fabrika lane assembly` cut that branch with `git worktree add -b epic/<n> <seat> origin/HEAD` — which makes git record `branch.epic/<n>.merge = refs/heads/main`. Every push in an epic run was therefore aimed at the default branch, and GitHub's branch protection was the only thing refusing them.

What changed:

- `lane push` names its target itself: `HEAD:refs/heads/epic/<n>`, derived from the epic number, with `upstreamOf` no longer feeding the ref. The remote still comes from the upstream when there is one, defaulting to `origin`.
- A seat whose branch tracks some other ref gets that upstream cleared before anything is sent — this verb no longer reads it, but a human's or an agent's bare `git push` in the assembly worktree still would. If the clear does not take, the verb refuses on a new exit `34` (`MISDIRECTED_PUSH`) naming the ref a bare push would hit, instead of the generic exit-30 "the remote did not move".
- `lane assembly` cuts the branch with `--no-track`, and clears a stale upstream when it resumes a branch an older fabrika cut, so existing `epic/*` branches heal on their next placement.
- Two regression tests in `push-verb.unit.test.ts`: an upstream of `origin/main` still pushes `refs/heads/epic/<n>` (and no call mentions `refs/heads/main`), and a surviving upstream refuses on `34` with nothing pushed. The assembly tests assert the new command shapes.
- Docs: `packages/fabrika-cli/README.md`'s lane exit-code list gains `34`; `operate`'s SKILL.md gains the explicit-target paragraph and drops the implication that the branch tracks anything.

`--no-track` on `git worktree add` was verified against git 2.40.1 in a throwaway clone: no `branch.<name>.merge` is recorded.

## Deviations

- **Declined guidance** — **Said:** acceptance criterion 2 asks `lane push` to refuse whenever the resolved push target is anything other than `epic/<n>`, which reads as a refusal on any mismatched upstream. **Did:** clear the upstream first and refuse only when the clear does not take. **Why:** with the explicit refspec the mismatched upstream can no longer redirect this verb, so refusing on it would stall every epic branch already cut by the old code — the second complaint in the issue — while the criterion's real goal (fail loud, name the cause, never fire at a protected branch) is met either way, and clearing also fixes the bare-`git push` hazard the refusal would only report. Criterion 1's stated test (upstream set to `main`, push still targets `refs/heads/epic/<n>`) exists as written under this reading. **Disposition:** stated here.

Fixes #6435
