### PR TITLE
fix: Manti Switch's hidden input reports a stale checked state after a programmatic flip

### DIFF
--- a/apps/web/src/components/ui/Switch.test.tsx
+++ b/apps/web/src/components/ui/Switch.test.tsx
@@ -1,0 +1,50 @@
+import {fireEvent, render} from "@testing-library/react";
+import {describe, expect, it} from "vitest";
+import {Switch} from "./Switch";
+
+function hiddenInput(container: HTMLElement) {
+	return container.querySelector<HTMLInputElement>('input[role="switch"]')!;
+}
+
+function controlState(container: HTMLElement) {
+	return container.querySelector('[data-part="control"]')!.getAttribute("data-state");
+}
+
+describe("Switch — the hidden input's checked property (#6449)", () => {
+	it("tracks a programmatic flip, not just data-state", () => {
+		const {container, rerender} = render(<Switch checked={false}>görünür</Switch>);
+		const input = hiddenInput(container);
+		expect(input.checked).toBe(false);
+
+		rerender(<Switch checked>görünür</Switch>);
+		expect(input.checked).toBe(true);
+		expect(controlState(container)).toBe("checked");
+	});
+
+	it("restores the property when an optimistic flip is reverted in the same tick", () => {
+		const {container, rerender} = render(<Switch checked={false}>görünür</Switch>);
+		const input = hiddenInput(container);
+
+		// The click flips input.checked in the DOM. The consumer flips its own state
+		// optimistically and reverts it when the write is rejected — if both land in one
+		// batch, the rendered checked prop never moves, so nothing but this wrapper's
+		// re-assertion pulls the property back.
+		fireEvent.click(input);
+		expect(input.checked).toBe(true);
+
+		rerender(<Switch checked={false}>görünür</Switch>);
+
+		expect(input.checked).toBe(false);
+		expect(controlState(container)).toBe("unchecked");
+	});
+
+	it("leaves an uncontrolled switch's property to the machine", () => {
+		const {container, rerender} = render(<Switch defaultChecked>görünür</Switch>);
+		const input = hiddenInput(container);
+		expect(input.checked).toBe(true);
+
+		input.checked = false;
+		rerender(<Switch defaultChecked>görünür</Switch>);
+		expect(input.checked).toBe(false);
+	});
+});

--- a/apps/web/src/components/ui/Switch.tsx
+++ b/apps/web/src/components/ui/Switch.tsx
@@ -1,4 +1,5 @@
 import {Switch as MantiSwitch, type SwitchProps as MantiSwitchProps} from "@manti-ui/react";
+import {useCallback, useEffect, useReducer, useRef} from "react";
 import "./Switch.css";
 
 /**
@@ -8,6 +9,39 @@ import "./Switch.css";
  *   count travels with the state.
  * @slot children The switch's trailing accessible label.
  */
-export function Switch({className = "", ...rest}: MantiSwitchProps) {
-	return <MantiSwitch className={`kp-switch ${className}`.trim()} {...rest} />;
+export function Switch({className = "", checked, onCheckedChange, ...rest}: MantiSwitchProps) {
+	const inputRef = useRef<HTMLInputElement>(null);
+	const [, requestSync] = useReducer((n: number) => n + 1, 0);
+
+	// Zag's switch machine renders its hidden input uncontrolled: getHiddenInputProps()
+	// emits `defaultChecked`, never a React-owned `checked` (@zag-js/switch@1.43.0,
+	// dist/switch.connect.mjs). So a click flips input.checked in the DOM and a later
+	// programmatic change updates every data-state while leaving that property stale —
+	// and the property is what assistive tech reads off role="switch". Re-assert it on
+	// every render, and force a render on every attempted change so a flip the parent
+	// declines (checked prop unchanged, so no render of its own) is corrected too.
+	useEffect(() => {
+		const input = inputRef.current;
+		if (input && checked !== undefined && input.checked !== checked) {
+			input.checked = checked;
+		}
+	});
+
+	const handleCheckedChange = useCallback(
+		(next: boolean) => {
+			requestSync();
+			onCheckedChange?.(next);
+		},
+		[onCheckedChange],
+	);
+
+	return (
+		<MantiSwitch
+			ref={inputRef}
+			className={`kp-switch ${className}`.trim()}
+			checked={checked}
+			onCheckedChange={handleCheckedChange}
+			{...rest}
+		/>
+	);
 }


### PR DESCRIPTION
The shared `Switch` announced a stale checked state to assistive tech after a programmatic change. Zag renders the hidden `role="switch"` input **uncontrolled** — `getHiddenInputProps()` emits `defaultChecked: checked`, never a React-owned `checked` (`@zag-js/switch@1.43.0`, `dist/switch.connect.mjs`, line 94) — so a click dirties `input.checked` in the DOM and React never owns it again. Every `data-state` stays correct; the property a screen reader reads does not.

`apps/web/src/components/ui/Switch.tsx` now re-asserts `input.checked` against the controlled `checked` prop on every render, through a ref that Manti forwards to that input. It also forces a render whenever the machine reports a change, so the case where a consumer *declines* the flip — the prop never moves, so React would not re-render on its own — is corrected too. Uncontrolled switches (`defaultChecked`) are left alone; the machine owns them.

`apps/web/src/components/ui/Switch.test.tsx` is new. The middle test is the regression: click to dirty the property, then re-render with the same `checked={false}` (an optimistic flip and its revert batched into one render), and assert `input.checked` is back to `false`. It fails on the pre-fix wrapper and passes on this one. `PropKnobs` is unchanged and all 290 client tests pass.

While writing the tests I found that a click never reaches the Zag machine at all under jsdom — `onCheckedChange` is never called and `data-state` never moves, for controlled and uncontrolled switches alike. Filed as #6495; it is why these tests drive the component by re-render rather than by clicking, and why the declined-flip path below could not be covered.

Fixes #6449

## Deviations

- **Known defect left unfixed** — **Said:** the acceptance criteria ask that the property match the intended `checked` after a programmatic change. **Did:** the wrapper also corrects the case where a consumer declines a user's flip without changing the prop, but that path has no test. **Why:** clicks never reach the Zag machine under jsdom (#6495), so `onCheckedChange` cannot be triggered from a test. **Disposition:** stated here; the tested paths cover every acceptance criterion, and #6495 tracks the environment gap.
