### PR TITLE
fix: deploy.yml stamps the merge sha in the preview comment, so review-ui render calls every PR preview stale

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -612,12 +612,17 @@ jobs:
           # E2E_FORCED_FLAGS, so darkship OFF-assertion specs can skip/invert against a
           # forced-ON preview. Empty when no `preview-flag:<key>` labels forced anything.
           FORCED_FLAGS: ${{ steps.force-flags.outputs.forced }}
+          # Empty on a push to main; the script falls back to `context.sha` there.
+          PR_HEAD_SHA: ${{ github.event.pull_request.head.sha }}
         with:
           script: |
             const marker = "<!-- preview-deploy -->";
             const app = process.env.APP;
             const appMark = `<!-- preview-deploy:${app} -->`;
-            const sha = context.sha.slice(0, 7);
+            // Under `pull_request` the checkout is refs/pull/N/merge, so `context.sha` names the
+            // merge commit, not the branch head. `review-ui render` compares this stamp to the PR's
+            // live head, and a merge sha never matches it (#6507).
+            const sha = (process.env.PR_HEAD_SHA || context.sha).slice(0, 7);
             // Hidden, machine-parseable tokens the e2e job reads. Only web resolves a D1 id
             // (#522) and a forced-flag set (#2951); other apps omit both. Kept in HTML
             // comments so they don't clutter the human-facing line.


### PR DESCRIPTION
The "Comment preview URL" step stamped `context.sha` into the per-app line. On a `pull_request` event that is the merge commit of `refs/pull/N/merge`, not the branch head. `review-ui render` reads that sha back out of the sticky comment and compares it to the PR's live head, so it exited 12 ("stale preview") on every PR and no UI-class lane could produce a verdict.

The step now reads `github.event.pull_request.head.sha` through an env var and falls back to `context.sha` when there is no pull-request payload, so a push to main stamps exactly what it stamped before. This matches how the no-preview job in the same workflow already reads the head.

The `<sub>(<sha>)</sub>` shape is unchanged, so `DEPLOYED_SHA` in `packages/fabrika-cli/src/capture/resolve.ts` still anchors on it, and the sibling `<!-- d1:… -->` / `<!-- preview-flags:… -->` tokens are untouched.

`.github/workflows/deploy.yml` is inside this workflow's own `deploy:` path filter, so this PR mints a real preview and the fixed stamp proves itself on its own comment. The `review-ui render` evidence lands as a comment once that deploy finishes.

`fabrika build check --surface workflows` is green here (actionlint, nothing unvalidated).

Fixes #6507

## Deviations

- **Scope narrowing** — **Said:** the last acceptance criterion asks that this PR carry a governance verdict. **Did:** changed no file toward it. **Why:** a governance verdict is landed by the gate that reads the PR, not by anything a builder can commit; the diff touches `.github/`, which is what makes the gate fire. **Disposition:** left to the review stage on this PR.
