### PR TITLE
fix: review-ui verdicts cannot post: the evidence upload's verify probe fetches the hosted asset unauthenticated

### DIFF
--- a/packages/fabrika-cli/src/review-ui/post-verb.unit.test.ts
+++ b/packages/fabrika-cli/src/review-ui/post-verb.unit.test.ts
@@ -17,6 +17,7 @@ import {
 } from "./codes.ts";
 import {type CaptureManifest, serializeManifest, sha256Hex} from "./manifest.ts";
 import {runPost, type UploadLeg} from "./post-verb.ts";
+import {classifyProbe} from "./upload-leg.ts";
 
 const HEAD = "03135b91aa04f7e2c9d8b1640a5c22e9f01b7d3c";
 const OLD_HEAD = "0b1c2d3e4f5a6b7c8d9e0f1a2b3c4d5e6f708192";
@@ -254,6 +255,15 @@ describe("runPost", () => {
 		expect(outcome.code).toBe(UPLOAD_FAILED);
 		expect(calls.some((call) => CREATE.test(call))).toBe(false);
 		expect(outcome.stderr.at(-1)).toMatch(/broken evidence channel/);
+	});
+
+	it("still refuses when the AUTHENTICATED probe reads 404 — #6520 does not soften #3925", async () => {
+		const notResolving: UploadLeg = () =>
+			Effect.succeed({_tag: "Failed", reason: classifyProbe(404) ?? ""});
+		const {outcome, calls} = await run(happy(), {upload: notResolving});
+		expect(outcome.code).toBe(UPLOAD_FAILED);
+		expect(calls.some((call) => CREATE.test(call))).toBe(false);
+		expect(outcome.stderr.join("\n")).toMatch(/probed back HTTP 404/);
 	});
 
 	it("edits this namespace's own comment instead of stacking a second marker", async () => {

--- a/packages/fabrika-cli/src/review-ui/upload-leg.ts
+++ b/packages/fabrika-cli/src/review-ui/upload-leg.ts
@@ -7,9 +7,16 @@
  * for the v1 gate hosting was display-only; here the hosted URL is a precondition of the verdict,
  * so an unverified URL is a failure rather than a decoration (#3925).
  *
- * The probe is a real fetch of the returned URL. A 2xx is the only outcome that makes the upload
- * evidence a human can open; everything else — a non-2xx, a transport fault — is `Failed` and the
- * caller refuses on `17` with nothing posted.
+ * The probe is a real fetch of the returned URL, carrying the same token the upload used.
+ *
+ * LOAD-BEARING NOTE — `github.com/user-attachments/assets/<uuid>` is AUTH-GATED ON READ. Probed
+ * against the live endpoint (#6520): anonymous is `404`, `authorization: token <t>` is `302` to the
+ * signed CDN URL, and following that redirect is `200`. So the probe must send the token or it
+ * reads every healthy upload back as missing. A human opening the PR reads the attachment through
+ * their own GitHub session, the same tier every drag-and-dropped screenshot on this repo uses.
+ *
+ * Anything that is not a served response — a 4xx/5xx under that authenticated probe, a transport
+ * fault — is `Failed`, and the caller refuses on `17` with nothing posted.
  */
 import {Effect} from "effect";
 import * as FetchHttpClient from "effect/unstable/http/FetchHttpClient";
@@ -39,13 +46,25 @@ const uploadToken = (env: Readonly<Record<string, string | undefined>>) =>
 		return result.ok && token !== "" ? token : null;
 	});
 
-const verify = (url: string): Effect.Effect<string | null> =>
-	HttpClient.execute(HttpClientRequest.get(url)).pipe(
-		Effect.map((response) =>
-			response.status >= 200 && response.status < 400
-				? null
-				: `the hosted asset probed back HTTP ${response.status}`,
-		),
+/**
+ * PURE: the probe request. The token is a required argument rather than something resolved in
+ * here, so an unauthenticated probe — the shape that read every healthy upload back as `404`
+ * (#6520) — has no way to be constructed.
+ */
+export const probeRequest = (url: string, token: string): HttpClientRequest.HttpClientRequest =>
+	HttpClientRequest.get(url).pipe(HttpClientRequest.setHeaders({authorization: `token ${token}`}));
+
+/**
+ * PURE: classify a probe status. The `302` the authenticated probe answers with is the asset being
+ * served, so the served band runs to 400; a `404` is the asset genuinely not resolving and stays a
+ * failure, which is the #3925 refusal this verify exists to feed.
+ */
+export const classifyProbe = (status: number): string | null =>
+	status >= 200 && status < 400 ? null : `the hosted asset probed back HTTP ${status}`;
+
+const verify = (url: string, token: string): Effect.Effect<string | null> =>
+	HttpClient.execute(probeRequest(url, token)).pipe(
+		Effect.map((response) => classifyProbe(response.status)),
 		Effect.catch((error: unknown) =>
 			Effect.succeed(`the hosted asset could not be probed back: ${String(error)}`),
 		),
@@ -82,7 +101,7 @@ export const githubAttachmentUploadLeg = (
 				reason: outcome.uploadError ?? "the upload returned no hosted URL",
 			} as UploadResult;
 		}
-		const unverified = yield* verify(outcome.hostedUrl);
+		const unverified = yield* verify(outcome.hostedUrl, token);
 		return unverified === null
 			? ({_tag: "Hosted", url: outcome.hostedUrl} as UploadResult)
 			: ({_tag: "Failed", reason: unverified} as UploadResult);

--- a/packages/fabrika-cli/src/review-ui/upload-leg.unit.test.ts
+++ b/packages/fabrika-cli/src/review-ui/upload-leg.unit.test.ts
@@ -1,0 +1,34 @@
+/**
+ * The verify probe's pure core: the request it builds and the statuses it accepts. Both are the
+ * #6520 fix — the probe used to be built with no authorization header, so GitHub answered `404` on
+ * every healthy upload and no `review-ui` verdict could post.
+ */
+import {describe, expect, it} from "@effect/vitest";
+import {classifyProbe, probeRequest} from "./upload-leg.ts";
+
+const HOSTED = "https://github.com/user-attachments/assets/0a1b2c3d-4e5f-6789-abcd-ef0123456789";
+
+describe("probeRequest", () => {
+	it("carries the upload token in the same `token <t>` spelling the upload sends", () => {
+		const request = probeRequest(HOSTED, "ghp_probe");
+		expect(request.headers.authorization).toBe("token ghp_probe");
+	});
+
+	it("probes the hosted URL itself with a GET", () => {
+		const request = probeRequest(HOSTED, "ghp_probe");
+		expect(request.method).toBe("GET");
+		expect(request.url).toBe(HOSTED);
+	});
+});
+
+describe("classifyProbe", () => {
+	it("accepts the 302 the authenticated probe answers with, and the 200 behind it", () => {
+		expect(classifyProbe(302)).toBeNull();
+		expect(classifyProbe(200)).toBeNull();
+	});
+
+	it("keeps a 404 a failure — a URL that does not resolve is not evidence (#3925)", () => {
+		expect(classifyProbe(404)).toMatch(/probed back HTTP 404/);
+		expect(classifyProbe(500)).toMatch(/probed back HTTP 500/);
+	});
+});


### PR DESCRIPTION
`review-ui post` verifies every uploaded evidence image by fetching its hosted URL back before
anything is posted. That probe went out with no `authorization` header, and GitHub no longer serves
`github.com/user-attachments/assets/<uuid>` anonymously — so every healthy upload read back as
`404`, the verb refused on exit `17` under the #3925 broken-evidence-channel rule, and no UI verdict
could land on any PR.

The fix passes the token the leg already resolved for the upload into the probe:

- `probeRequest(url, token)` is a pure request builder that mirrors `uploadAsset`'s
  `authorization: token <t>` spelling. The token is a required argument, so an unauthenticated
  probe cannot be constructed — the missing-token path still fails earlier with its own diagnostic,
  before any network call.
- `classifyProbe(status)` is the pure status classifier, unchanged in behaviour: the served band
  runs to 400, which already covers the `302` the authenticated probe answers with, and a `404`
  stays a failure.

Grounded in a live probe of the endpoint, recorded on the issue: anonymous `404`, `token <t>` `302`,
following that redirect `200`. The `github.com` asset URL being auth-gated on read is now a
load-bearing note in `upload-leg.ts`, so nothing reintroduces an anonymous read.

#3925 is untouched: an asset that genuinely does not resolve still returns `Failed` and `post` still
exits `17` with nothing posted, now pinned by a test through `post-verb.ts`'s injectable `UploadLeg`
seam using the real 404 diagnostic.

Tests: new `upload-leg.unit.test.ts` (the request carries the token, the statuses classify) plus the
new post-verb refusal case. `pnpm typecheck --force` and `pnpm lint:worktree` green in-tree; the
full `packages/fabrika-cli` suite passes (7023 tests).

Fixes #6520

## Deviations

None.
