### PR TITLE
fix: Restoring a still-sandboxed post, comment or definition returns null to its own author

### DIFF
--- a/apps/web/worker/features/pano/mutation-parent-reread-viewer.unit.test.ts
+++ b/apps/web/worker/features/pano/mutation-parent-reread-viewer.unit.test.ts
@@ -1,0 +1,163 @@
+/**
+ * The parent-page re-read in `post.restore`, `comment.delete` and `comment.restore` carries
+ * the acting author's identity (#6473).
+ *
+ * Each handler commits its write, re-reads the parent post through `Pano.getPost` — a read
+ * masked on the sandbox dimension — and answers `null` when the row comes back masked. Handed
+ * no viewer at all, that read resolved anonymously, so a çaylak restoring their OWN still-
+ * sandboxed post got `null` back from a mutation that had already landed at D1.
+ *
+ * The stub does not mimic the mask: it resolves the options through the real
+ * `resolveSandboxViewer` and asks the real `lifecycleVisibilityRule`, so the test moves with
+ * the visibility rule instead of restating it.
+ */
+import {assert, describe, it} from "@effect/vitest";
+import {CurrentUser, LivePublisher} from "@kampus/fate-effect";
+import {type BaseRuntimeContext, RuntimeContext} from "alchemy";
+import {Effect, Layer} from "effect";
+import {resolveWire} from "../fate/resolve-wire.testing.ts";
+import {livePublisherFor} from "../fate-live/live-publisher.ts";
+import {
+	lifecycleVisibilityRule,
+	ruleVisibleTo,
+	type SandboxViewer,
+} from "../lifecycle/EntityLifecycle.ts";
+import {resolveSandboxViewer} from "../lifecycle/SandboxVisibility.ts";
+import {mutations} from "./mutations.ts";
+import {Pano} from "./Pano.ts";
+import type {PostPage} from "./post-fields.ts";
+
+const AUTHOR = {id: "u-caylak", email: "caylak@kamp.us", name: "çaylak"};
+const OTHER_MEMBER = {id: "u-yazar", email: "yazar@kamp.us", name: "yazar"};
+const POST_ID = "post_sb1";
+const COMMENT_ID = "comment_sb1";
+
+const runtimeContextStub: BaseRuntimeContext = {
+	Type: "mutation-parent-reread-viewer",
+	id: "mutation-parent-reread-viewer",
+	env: {},
+	get: () => Effect.succeed(undefined),
+	set: (id) => Effect.succeed(id),
+};
+
+/** The çaylak's own still-sandboxed post — the parent page every handler re-reads. */
+const sandboxedPage: PostPage = {
+	id: POST_ID,
+	slug: "post-sb1",
+	title: "başlık",
+	url: null,
+	host: null,
+	body: "gövde",
+	author: "çaylak",
+	authorId: AUTHOR.id,
+	score: 1,
+	commentCount: 1,
+	createdAt: new Date("2026-01-01T00:00:00Z"),
+	updatedAt: new Date("2026-01-01T00:00:00Z"),
+	tags: [],
+};
+
+const noopLive = Layer.succeed(LivePublisher)(
+	livePublisherFor({publish: () => Effect.void, waitUntil: () => {}}),
+);
+
+const commentRow = {
+	id: COMMENT_ID,
+	postId: POST_ID,
+	parentId: null,
+	body: "yorum",
+	author: "çaylak",
+	authorId: AUTHOR.id,
+	score: 0,
+	createdAt: sandboxedPage.createdAt,
+	updatedAt: sandboxedPage.updatedAt,
+	deletedAt: null,
+	myVote: null,
+};
+
+/**
+ * Every service the three handlers reach. `getPost` applies the REAL sandbox rule to the
+ * viewer the call site resolved, so a call that omits the viewer masks exactly as D1 does.
+ */
+const contextFor = (user: typeof AUTHOR) =>
+	Layer.mergeAll(
+		// biome-ignore lint/plugin: a service double — the writes are scripted and only the parent re-read is under test.
+		Layer.succeed(Pano, {
+			restorePost: () => Effect.succeed({postId: POST_ID, deleted: false, sandboxedAt: new Date()}),
+			lookupCommentPostId: () => Effect.succeed(POST_ID),
+			deleteComment: () =>
+				Effect.succeed({
+					commentId: COMMENT_ID,
+					deleted: true,
+					hasReplies: false,
+					placeholder: null,
+				}),
+			restoreComment: () =>
+				Effect.succeed({
+					commentId: COMMENT_ID,
+					deleted: false,
+					hasReplies: false,
+					placeholder: null,
+					sandboxedAt: new Date(),
+				}),
+			getPost: (_id: string, opts?: {viewerId?: string | null; sandboxViewer?: SandboxViewer}) =>
+				Effect.sync(() =>
+					ruleVisibleTo(
+						lifecycleVisibilityRule.Sandboxed,
+						sandboxedPage.authorId,
+						resolveSandboxViewer(opts ?? {}),
+					)
+						? sandboxedPage
+						: null,
+				),
+			getPostsByIds: () => Effect.succeed([]),
+			getCommentsByIds: () => Effect.succeed([commentRow]),
+		} as unknown as typeof Pano.Service),
+		noopLive,
+		Layer.succeed(CurrentUser, {user}),
+		Layer.succeed(RuntimeContext, runtimeContextStub),
+	);
+
+// Named at each call site rather than looked up from a union: the three carry different
+// error unions, and a union-typed lookup erases what `resolveWire` infers from.
+const HANDLERS = [
+	{
+		name: "post.restore",
+		run: (ctx: ReturnType<typeof contextFor>) =>
+			resolveWire(mutations["post.restore"], {input: {id: POST_ID}, select: ["id"]}).pipe(
+				Effect.provide(ctx),
+			),
+	},
+	{
+		name: "comment.delete",
+		run: (ctx: ReturnType<typeof contextFor>) =>
+			resolveWire(mutations["comment.delete"], {input: {id: COMMENT_ID}, select: ["id"]}).pipe(
+				Effect.provide(ctx),
+			),
+	},
+	{
+		name: "comment.restore",
+		run: (ctx: ReturnType<typeof contextFor>) =>
+			resolveWire(mutations["comment.restore"], {input: {id: COMMENT_ID}, select: ["id"]}).pipe(
+				Effect.provide(ctx),
+			),
+	},
+] as const;
+
+describe("the pano parent-page re-reads carry the acting author (#6473)", () => {
+	for (const handler of HANDLERS) {
+		it.effect(`${handler.name} returns the still-sandboxed page to its own author`, () =>
+			Effect.gen(function* () {
+				const result = yield* handler.run(contextFor(AUTHOR));
+				assert.isNotNull(result, `${handler.name} answered null on a write that landed`);
+				assert.strictEqual(result?.id, POST_ID);
+			}),
+		);
+
+		it.effect(`${handler.name} still masks the sandboxed page from another member`, () =>
+			Effect.gen(function* () {
+				assert.isNull(yield* handler.run(contextFor(OTHER_MEMBER)));
+			}),
+		);
+	}
+});

--- a/apps/web/worker/features/pano/mutations.ts
+++ b/apps/web/worker/features/pano/mutations.ts
@@ -458,7 +458,7 @@ export const mutations = {
 			const pano = yield* Pano;
 			const live = panoLive(yield* WorkerLivePublisher, yield* PanoFeedCache);
 			const restored = yield* pano.restorePost({postId: input.id, actorId: UserId.make(user.id)});
-			const page = yield* pano.getPost(input.id);
+			const page = yield* pano.getPost(input.id, {viewerId: user.id});
 			if (!page) return null;
 			const [stamped] = yield* pano.getPostsByIds([page.id], {viewerId: user.id});
 			const post = toPostFromPage(
@@ -666,7 +666,7 @@ export const mutations = {
 				actorId: UserId.make(user.id),
 			});
 			if (!postId) return null;
-			const page = yield* pano.getPost(postId);
+			const page = yield* pano.getPost(postId, {viewerId: user.id});
 			if (!page) return null;
 			const [stamped] = yield* pano.getPostsByIds([page.id], {viewerId: user.id});
 			const post = toPostFromPage(
@@ -721,7 +721,7 @@ export const mutations = {
 					.thread(postId)
 					.appendNode(node.id, {node}, decidePublish(restored.sandboxedAt ?? null));
 			}
-			const page = yield* pano.getPost(postId);
+			const page = yield* pano.getPost(postId, {viewerId: user.id});
 			if (!page) return null;
 			const [stamped] = yield* pano.getPostsByIds([page.id], {viewerId: user.id});
 			const post = toPostFromPage(

--- a/apps/web/worker/features/sozluk/mutation-term-reread-viewer.unit.test.ts
+++ b/apps/web/worker/features/sozluk/mutation-term-reread-viewer.unit.test.ts
@@ -1,0 +1,133 @@
+/**
+ * The parent-term re-read in `definition.delete` and `definition.restore` carries the acting
+ * author's identity (#6473).
+ *
+ * `Sozluk.getTerm` masks the term's definitions on the sandbox dimension, so a re-read handed
+ * no viewer resolved anonymously and dropped the author's own still-sandboxed rows: the
+ * returned `Term` under-counted them, and `definition.restore`'s `page.definitions.find` then
+ * missed the row it had just restored, skipping the term-topic re-append.
+ *
+ * The term row itself is never sandboxed, so — unlike the pano handlers this shares an issue
+ * with — the page comes back non-null either way; what moves is which definitions it carries.
+ * The stub filters through the real `lifecycleVisibilityRule` rather than restating the mask.
+ */
+import {assert, describe, it} from "@effect/vitest";
+import {CurrentUser, LivePublisher} from "@kampus/fate-effect";
+import {type BaseRuntimeContext, RuntimeContext} from "alchemy";
+import {Effect, Layer} from "effect";
+import {resolveWire} from "../fate/resolve-wire.testing.ts";
+import {livePublisherFor} from "../fate-live/live-publisher.ts";
+import {
+	lifecycleVisibilityRule,
+	ruleVisibleTo,
+	type SandboxViewer,
+} from "../lifecycle/EntityLifecycle.ts";
+import {resolveSandboxViewer} from "../lifecycle/SandboxVisibility.ts";
+import type {DefinitionRow, TermPage} from "./definition-fields.ts";
+import {mutations} from "./mutations.ts";
+import {Sozluk} from "./Sozluk.ts";
+
+const AUTHOR = {id: "u-caylak", email: "caylak@kamp.us", name: "çaylak"};
+const OTHER_MEMBER = {id: "u-yazar", email: "yazar@kamp.us", name: "yazar"};
+const SLUG = "kamp-us";
+const DEFINITION_ID = "def_sb1";
+
+const runtimeContextStub: BaseRuntimeContext = {
+	Type: "mutation-term-reread-viewer",
+	id: "mutation-term-reread-viewer",
+	env: {},
+	get: () => Effect.succeed(undefined),
+	set: (id) => Effect.succeed(id),
+};
+
+/** The çaylak's own still-sandboxed definition, the only row on the term. */
+const sandboxedDefinition: DefinitionRow = {
+	id: DEFINITION_ID,
+	body: "tanım",
+	score: 3,
+	author: "çaylak",
+	authorId: AUTHOR.id,
+	createdAt: new Date("2026-01-01T00:00:00Z"),
+	updatedAt: new Date("2026-01-01T00:00:00Z"),
+};
+
+const termPageFor = (definitions: DefinitionRow[]): TermPage => ({
+	id: SLUG,
+	slug: SLUG,
+	title: "kamp us",
+	totalDefinitions: definitions.length,
+	totalScore: definitions.reduce((s, d) => s + d.score, 0),
+	firstAt: sandboxedDefinition.createdAt,
+	lastEdit: sandboxedDefinition.updatedAt,
+	definitions,
+});
+
+const noopLive = Layer.succeed(LivePublisher)(
+	livePublisherFor({publish: () => Effect.void, waitUntil: () => {}}),
+);
+
+/**
+ * Every service the two handlers reach. `getTerm` applies the REAL sandbox rule to the viewer
+ * the call site resolved, so a call that omits the viewer masks exactly as D1 does.
+ */
+const contextFor = (user: typeof AUTHOR) =>
+	Layer.mergeAll(
+		// biome-ignore lint/plugin: a service double — the writes are scripted and only the term re-read is under test.
+		Layer.succeed(Sozluk, {
+			lookupDefinitionTermSlug: () => Effect.succeed(SLUG),
+			deleteDefinition: () => Effect.succeed({definitionId: DEFINITION_ID, deleted: true}),
+			restoreDefinition: () =>
+				Effect.succeed({definitionId: DEFINITION_ID, deleted: false, sandboxedAt: new Date()}),
+			getTerm: (_slug: string, opts?: {viewerId?: string | null; sandboxViewer?: SandboxViewer}) =>
+				Effect.sync(() => {
+					const viewer = resolveSandboxViewer(opts ?? {});
+					return termPageFor(
+						[sandboxedDefinition].filter((d) =>
+							ruleVisibleTo(lifecycleVisibilityRule.Sandboxed, d.authorId, viewer),
+						),
+					);
+				}),
+		} as unknown as typeof Sozluk.Service),
+		noopLive,
+		Layer.succeed(CurrentUser, {user}),
+		Layer.succeed(RuntimeContext, runtimeContextStub),
+	);
+
+// Named at each call site rather than looked up from a union, so `resolveWire`'s inference
+// survives — matching `../pano/mutation-parent-reread-viewer.unit.test.ts`.
+const HANDLERS = [
+	{
+		name: "definition.delete",
+		run: (ctx: ReturnType<typeof contextFor>) =>
+			resolveWire(mutations["definition.delete"], {
+				input: {id: DEFINITION_ID},
+				select: ["id", "count"],
+			}).pipe(Effect.provide(ctx)),
+	},
+	{
+		name: "definition.restore",
+		run: (ctx: ReturnType<typeof contextFor>) =>
+			resolveWire(mutations["definition.restore"], {
+				input: {id: DEFINITION_ID},
+				select: ["id", "count"],
+			}).pipe(Effect.provide(ctx)),
+	},
+] as const;
+
+describe("the sözlük term re-reads carry the acting author (#6473)", () => {
+	for (const handler of HANDLERS) {
+		it.effect(`${handler.name} returns a term page carrying the author's own sandboxed row`, () =>
+			Effect.gen(function* () {
+				const term = yield* handler.run(contextFor(AUTHOR));
+				assert.isNotNull(term, `${handler.name} answered null on a write that landed`);
+				assert.strictEqual(term?.count, 1);
+			}),
+		);
+
+		it.effect(`${handler.name} still masks the sandboxed row from another member`, () =>
+			Effect.gen(function* () {
+				assert.strictEqual((yield* handler.run(contextFor(OTHER_MEMBER)))?.count, 0);
+			}),
+		);
+	}
+});

--- a/apps/web/worker/features/sozluk/mutations.ts
+++ b/apps/web/worker/features/sozluk/mutations.ts
@@ -252,7 +252,7 @@ export const mutations = {
 				yield* live.definition.term(slug).deleteEdge(input.id);
 			}
 			if (!slug) return null;
-			const page = yield* sozluk.getTerm(slug);
+			const page = yield* sozluk.getTerm(slug, {viewerId: user.id});
 			if (!page) return null;
 			return toTermFromPage(page);
 		}),
@@ -275,7 +275,7 @@ export const mutations = {
 			});
 			const slug = yield* sozluk.lookupDefinitionTermSlug(input.id);
 			if (!slug) return null;
-			const page = yield* sozluk.getTerm(slug);
+			const page = yield* sozluk.getTerm(slug, {viewerId: user.id});
 			if (!page) return null;
 			const restored = page.definitions.find((d) => d.id === input.id);
 			if (restored) {


### PR DESCRIPTION
Fixes #6473

The delete and restore mutations in pano and sözlük re-read their parent page with no viewer, so
the read resolved anonymously and masked out anything still sandboxed. A çaylak restoring their own
sandboxed post got `null` back from a write that had already landed at D1.

Five call sites now pass `{viewerId: user.id}`, matching the `*ByIds` calls already sitting beside
them:

- `pano.getPost` in `post.restore`, `comment.delete`, `comment.restore`
- `sozluk.getTerm` in `definition.delete`, `definition.restore`

The author arm of `sandboxVisibleWhere` admits the viewer's own rows, so this is the whole fix for
the author.

Two new unit test files, one per feature, cover the five handlers. Neither mimics the mask: the
`Pano` / `Sozluk` stubs resolve the call site's options through the real `resolveSandboxViewer` and
ask the real `lifecycleVisibilityRule`, so the test moves with the visibility rule instead of
restating it. Each handler gets both arms — the author round-trips a non-null page, another member
still gets the masked answer. Verified failing on the pre-fix code (3 of 6 pano assertions, 2 of 4
sözlük) before the fix went back in.

## Deviations

- **Out-of-scope change** — **Said:** #6473's acceptance criteria ask for a test asserting the page
  comes back "non-null (not `null`)" for all five handlers. **Did:** the sözlük tests assert the
  returned `Term`'s `count` instead. **Why:** the term row itself is never sandboxed, so
  `sozluk.getTerm` returns a non-null page either way — what the mask actually drops is the author's
  own definitions from `page.definitions`, which surfaces as an under-counted `Term` and as
  `definition.restore`'s `page.definitions.find` missing the row it just restored. A non-null
  assertion there would pass without the fix. **Disposition:** the non-null assertion is kept
  alongside the count one, so both readings of the criterion hold.
- **Known defect left unfixed** — **Said:** #6473 scopes to the author arm and states "no change to
  what a non-author or anonymous viewer sees". **Did:** left the same five reads degraded for the
  #6423 in-place viewer class, which needs the resolved `sandboxViewer` from `currentSandboxViewer`,
  not a bare `{viewerId}`. **Why:** that is the #6424 class the issue explicitly calls independent,
  and widening it here would change what a non-author sees, which the criteria forbid.
  **Disposition:** filed as #6544.
