### PR TITLE
fix: The moderator report queue reads the reported post, comment and definition anonymously

### DIFF
--- a/.patterns/caylak-content-containment.md
+++ b/.patterns/caylak-content-containment.md
@@ -88,6 +88,42 @@ landing column.
 When adding a read over any table whose rows are *derived* rather than authored, ask which
 content table owns its lifecycle, and mask through that.
 
+## A gated read still has to say who it is
+
+Passing no viewer is not neutral. `resolveSandboxViewer({})` returns `anonymousViewer`, so a
+read with no options is a read *as the public* — the strictest mask there is. That is the
+right default for an unauthenticated path and the wrong one everywhere else, and it fails
+silently: the row is simply absent, and the caller renders whatever it renders for "missing".
+
+The trap is a read that already sits behind an authority gate. Being inside a
+`Moderate`-gated resolver does nothing for the mask; the SQL only widens for a viewer that
+carries `canSeeSandboxed`. The moderation report queue spent six reads this way (#6472): the
+`Moderate` grant was discharged, the reads passed no viewer, and every reported çaylak item —
+the ones the sandbox exists to make reviewable — rendered with a null excerpt and no link.
+
+Inside such a path, take the viewer off the grant:
+
+```ts
+const sandboxViewer = yield* moderatorSandboxViewer; // requires Moderate in R
+const rows = yield* pano.getPostsByIds(ids, {sandboxViewer});
+```
+
+`moderatorSandboxViewer` (`apps/web/worker/features/kunye/sandbox.ts`) puts `Moderate` in `R`,
+so a path that never proved moderation authority cannot build the viewer that claims it. Use
+`currentSandboxViewer` instead only on an **ungated** read — it probes the moderation gate and
+collapses a denial to `false`, which inside a gated path is a second relation-store round trip
+for an answer the grant already carries.
+
+Two dimensions stay out of this. `removed_at` is orthogonal: the by-id reads carry their own
+`isNull(removedAt)`, which takes no viewer, so widening the sandbox viewer never surfaces a
+removed row. And the draft arm has no moderator branch at all (ADR 0113) — an unpublished
+draft is private to its author, moderators included.
+
+Widening the read does not widen the broadcast. `decidePublish(sandboxedAt)` still gates every
+node fan-out, so a still-sandboxed target that now comes back off a moderator read reaches that
+gate and is suppressed there, which is where the #1205/#1280 decision belongs — not in a read
+that was masking it by accident.
+
 ## The client side — one badge per item, owner's wins
 
 Once an opted-in yazar can meet sandboxed content in place (#6423), two wire fields describe

--- a/apps/web/worker/features/kunye/sandbox.ts
+++ b/apps/web/worker/features/kunye/sandbox.ts
@@ -3,7 +3,7 @@
  * the moderation capability (ADR 0107) meet the content paths, kept out of the
  * sözlük/pano domain services so they stay vocabulary-free about authorship.
  *
- * Three helpers, all resolver-level:
+ * Four helpers, all resolver-level:
  *   - {@link sandboxedAtForAuthor} — the create-time decision: should a new piece
  *     of content by this author land sandboxed? Decided by tier (çaylak ⇒ sandboxed,
  *     yazar ⇒ live).
@@ -11,6 +11,8 @@
  *     non-throwing moderator probe of `Moderate.over(platform)`, and the flag-gated
  *     in-place opt-in (#6423), resolved once per read and handed to the
  *     `SandboxVisibility` predicates.
+ *   - {@link moderatorSandboxViewer} — the same viewer for an already-`Moderate`-gated
+ *     read, taken off the discharged grant instead of re-probing for it (#6472).
  *   - {@link PublishDecision} / {@link decidePublish} / {@link alwaysLive} — the
  *     create-time live-broadcast gate, type-level: a node broadcast to a public
  *     fate-live topic requires a `PublishDecision`, constructible only from the
@@ -26,7 +28,7 @@ import {CaylakVisibility} from "../caylak-visibility/CaylakVisibility.ts";
 import {caylakVisibilityOn} from "../caylak-visibility/gate.ts";
 import type {SandboxViewer} from "../lifecycle/EntityLifecycle.ts";
 import {Kunye} from "./Kunye.ts";
-import {requireModeration} from "./moderate.ts";
+import {Moderate, moderatorOf, requireModeration} from "./moderate.ts";
 import {sandboxesNewContent} from "./standing.ts";
 
 export const sandboxedAtForAuthor = (
@@ -77,6 +79,35 @@ export const currentSandboxViewer = Effect.gen(function* () {
 	const seesSandboxedInPlace = yield* inPlaceVisibility(viewerId);
 	return {viewerId, canSeeSandboxed, seesSandboxedInPlace} satisfies SandboxViewer;
 });
+
+/**
+ * The sandbox viewer a `Moderate`-gated read runs under (#6472). `Moderate` sits in R,
+ * so this is unreachable without a discharged grant — the viewer that claims
+ * `canSeeSandboxed` cannot be built by a path that never proved moderation authority.
+ *
+ * Distinct from {@link currentSandboxViewer}, which PROBES the moderation gate for an
+ * ungated read and collapses a denial to `false`. Inside a gated path that probe is a
+ * second relation-store round trip for an answer the grant already carries.
+ *
+ * `seesSandboxedInPlace` is `false` on purpose: that axis is the #6423 reader's opt-in to
+ * seeing çaylak work inside the ordinary feed, and a moderation queue is not that feed.
+ * It also never reaches the SQL, since `canSeeSandboxed` short-circuits
+ * `sandboxVisibleWhere` — so leaving it `false` keeps the `sandboxedInPlace` wire marker
+ * off the moderator's rows rather than mislabelling them.
+ *
+ * The `removed_at` dimension is untouched: the by-id reads carry their own
+ * `isNull(removedAt)` guard, which takes no viewer, so a removed target stays out.
+ */
+export const moderatorSandboxViewer: Effect.Effect<SandboxViewer, never, Moderate> = Effect.gen(
+	function* () {
+		const grant = yield* Moderate;
+		return {
+			viewerId: yield* moderatorOf(grant),
+			canSeeSandboxed: true,
+			seesSandboxedInPlace: false,
+		} satisfies SandboxViewer;
+	},
+);
 
 /**
  * Whether a brand-new content node may be broadcast to a public (viewer-blind)

--- a/apps/web/worker/features/report/lists.ts
+++ b/apps/web/worker/features/report/lists.ts
@@ -13,6 +13,7 @@ import type {TargetKind} from "../../db/target-kind.ts";
 import {Denied} from "../kunye/errors.ts";
 import {Kunye} from "../kunye/Kunye.ts";
 import {Moderate, requireModeration} from "../kunye/moderate.ts";
+import {moderatorSandboxViewer} from "../kunye/sandbox.ts";
 import {VouchLedger} from "../kunye/VouchLedger.ts";
 import {Pano} from "../pano/Pano.ts";
 import {Pasaport} from "../pasaport/Pasaport.ts";
@@ -114,8 +115,10 @@ const resolveResolverHandles = Effect.fn("report.resolveResolverHandles")(functi
 	return handles;
 });
 
-// A target the batched read doesn't return (missing / sandbox-hidden) simply has no
-// entry — the merge renders that row with null context, never drops it.
+// A target the batched read doesn't return (missing / removed) simply has no entry — the
+// merge renders that row with null context, never drops it. A still-SANDBOXED target is
+// no longer in that set: these reads run under the moderator's own sandbox viewer, so the
+// çaylak reports the sandbox exists to make reviewable are the ones that hydrate (#6472).
 const resolveTargetContexts = Effect.fn("report.resolveTargetContexts")(function* (
 	groups: ReadonlyArray<{targetKind: TargetKind; targetId: string}>,
 ) {
@@ -129,9 +132,10 @@ const resolveTargetContexts = Effect.fn("report.resolveTargetContexts")(function
 	const contexts = new Map<string, ReportTargetContext>();
 	const pano = yield* Pano;
 	const sozluk = yield* Sozluk;
+	const sandboxViewer = yield* moderatorSandboxViewer;
 
 	if (idsByKind.post.length > 0) {
-		const rows = yield* pano.getPostsByIds(idsByKind.post);
+		const rows = yield* pano.getPostsByIds(idsByKind.post, {sandboxViewer});
 		for (const r of rows) {
 			contexts.set(contextKeyOf("post", r.id), {
 				excerpt: r.title,
@@ -143,7 +147,7 @@ const resolveTargetContexts = Effect.fn("report.resolveTargetContexts")(function
 	}
 
 	if (idsByKind.comment.length > 0) {
-		const rows = yield* pano.getCommentsByIds(idsByKind.comment);
+		const rows = yield* pano.getCommentsByIds(idsByKind.comment, {sandboxViewer});
 		for (const r of rows) {
 			// A comment routes to its PARENT post's detail page.
 			const postId = yield* pano.lookupCommentPostId(r.id);
@@ -158,7 +162,7 @@ const resolveTargetContexts = Effect.fn("report.resolveTargetContexts")(function
 	}
 
 	if (idsByKind.definition.length > 0) {
-		const rows = yield* sozluk.getDefinitionsByIds(idsByKind.definition);
+		const rows = yield* sozluk.getDefinitionsByIds(idsByKind.definition, {sandboxViewer});
 		for (const r of rows) {
 			// A definition routes to its term page, keyed by slug.
 			const slug = yield* sozluk.lookupDefinitionTermSlug(r.id);

--- a/apps/web/worker/features/report/mutations.ts
+++ b/apps/web/worker/features/report/mutations.ts
@@ -14,6 +14,7 @@ import {WorkerLivePublisher} from "../fate-live/protocol.ts";
 import {Denied, InsufficientKarma} from "../kunye/errors.ts";
 import {Moderate, moderatorOf, requireModeration} from "../kunye/moderate.ts";
 import {gateFlagOnKarma} from "../kunye/privilege.ts";
+import {moderatorSandboxViewer} from "../kunye/sandbox.ts";
 import {CommentNotFound, PostNotFound} from "../pano/errors.ts";
 import {PanoFeedCache} from "../pano/feed-cache.ts";
 import {Pano} from "../pano/Pano.ts";
@@ -380,16 +381,23 @@ const publishRemoved = Effect.fn("report.publishRemoved")(function* (
 /**
  * Gated on `sandboxedAt` so a still-sandboxed restore stays suppressed from the
  * viewer-blind public topic (#1205/#1280 leak surface).
+ *
+ * That gate is `decidePublish`'s, and it is the ONLY one: the re-reads run under the
+ * moderator's sandbox viewer (#6472) so a still-sandboxed target comes back and reaches
+ * the gate, instead of being dropped earlier by an anonymous read that silently decided
+ * the same question with none of the same reasoning. `if (row)` is then what it reads as
+ * — the target vanished between restore and re-read.
  */
 const publishRestored = Effect.fn("report.publishRestored")(function* (
 	live: ReturnType<typeof reportLive>,
 	target: {targetKind: TargetKind; targetId: string},
 	sandboxedAt: Date | null,
 ) {
+	const sandboxViewer = yield* moderatorSandboxViewer;
 	switch (target.targetKind) {
 		case "post": {
 			const pano = yield* Pano;
-			const [row] = yield* pano.getPostsByIds([target.targetId]);
+			const [row] = yield* pano.getPostsByIds([target.targetId], {sandboxViewer});
 			if (row) yield* live.postRestored(toPost(row), sandboxedAt);
 			return;
 		}
@@ -397,7 +405,7 @@ const publishRestored = Effect.fn("report.publishRestored")(function* (
 			const pano = yield* Pano;
 			const postId = yield* pano.lookupCommentPostId(target.targetId);
 			if (postId === null) return;
-			const [row] = yield* pano.getCommentsByIds([target.targetId]);
+			const [row] = yield* pano.getCommentsByIds([target.targetId], {sandboxViewer});
 			if (row) yield* live.commentRestored(toComment(row), postId, sandboxedAt);
 			return;
 		}
@@ -405,7 +413,7 @@ const publishRestored = Effect.fn("report.publishRestored")(function* (
 			const sozluk = yield* Sozluk;
 			const slug = yield* sozluk.lookupDefinitionTermSlug(target.targetId);
 			if (slug === null) return;
-			const [row] = yield* sozluk.getDefinitionsByIds([target.targetId]);
+			const [row] = yield* sozluk.getDefinitionsByIds([target.targetId], {sandboxViewer});
 			if (row) yield* live.definitionRestored(toDefinition(row), slug, sandboxedAt);
 			return;
 		}

--- a/apps/web/worker/features/report/report-queue-sandbox.unit.test.ts
+++ b/apps/web/worker/features/report/report-queue-sandbox.unit.test.ts
@@ -1,0 +1,311 @@
+/**
+ * The moderation queue reads its reported targets AS the moderator (#6472). Before this,
+ * all six by-id reads passed no viewer, so `resolveSandboxViewer({})` yielded the
+ * anonymous viewer and `sandboxVisibleWhere` masked every still-sandboxed row — the
+ * çaylak reports the sandbox exists to make reviewable rendered blank.
+ *
+ * The Pano/Sozluk doubles here MODEL that mask rather than ignoring it: a sandboxed row
+ * comes back only for a viewer carrying `canSeeSandboxed`. A double that returned the row
+ * unconditionally would pass against the anonymous read too, which is exactly why the bug
+ * survived the existing fan-out coverage.
+ */
+
+import {assert, describe, it} from "@effect/vitest";
+import {type Actor, AgentAuthority, CurrentActor, human, RelationStore} from "@kampus/authz";
+import {LivePublisher} from "@kampus/fate-effect";
+import {liveGlobalConnectionTopic} from "@nkzw/fate/server";
+import {Effect, Layer} from "effect";
+import * as Schema from "effect/Schema";
+import {TargetId} from "../../lib/ids.ts";
+import {noopPanoFeedCache, resolveWire} from "../fate/resolve-wire.testing.ts";
+import {livePublisherFor} from "../fate-live/live-publisher.ts";
+import {makeKunyeStub} from "../kunye/Kunye.testing.ts";
+import type {Tier} from "../kunye/standing.ts";
+import {makeVouchLedgerStub} from "../kunye/VouchLedger.testing.ts";
+import type {SandboxViewer} from "../lifecycle/EntityLifecycle.ts";
+import {Pano} from "../pano/Pano.ts";
+import {Sozluk} from "../sozluk/Sozluk.ts";
+import {lists} from "./lists.ts";
+import {mutations} from "./mutations.ts";
+import {makeReportStub} from "./Report.testing.ts";
+import type {OpenReportGroup} from "./Report.ts";
+
+const MOD = "u-mod";
+const CAYLAK = "u-caylak";
+const SANDBOXED_AT = new Date("2026-02-01T00:00:00Z");
+const AT = new Date("2026-01-01T00:00:00Z");
+
+/** The one axis under test: does the read carry a viewer the mask yields to? */
+const lifted = (opts?: {sandboxViewer?: SandboxViewer | undefined}): boolean =>
+	opts?.sandboxViewer?.canSeeSandboxed === true;
+
+const postRow = {
+	id: "p1",
+	slug: "caylak-gonderi",
+	title: "çaylak gönderisi",
+	url: null,
+	host: null,
+	body: "gövde",
+	author: "caylak",
+	authorId: CAYLAK,
+	score: 0,
+	commentCount: 0,
+	createdAt: AT,
+	myVote: null,
+	isSaved: null,
+	tags: [] as never[],
+};
+
+const commentRow = {
+	id: "c1",
+	parentId: null,
+	author: "caylak",
+	authorId: CAYLAK,
+	body: "çaylak yorumu",
+	score: 0,
+	createdAt: AT,
+	updatedAt: AT,
+	deletedAt: null,
+	myVote: null,
+};
+
+const definitionRow = {
+	id: "d1",
+	body: "çaylak tanımı",
+	score: 0,
+	author: "caylak",
+	authorId: CAYLAK,
+	createdAt: AT,
+	updatedAt: AT,
+	myVote: null,
+};
+
+const proxyOver = <T extends object>(service: string, impl: Partial<T>): T =>
+	new Proxy(impl, {
+		get(t, prop) {
+			if (prop in t) return (t as Record<string, unknown>)[prop as string];
+			return () => Effect.die(`${service}.${String(prop)} not exercised`);
+		},
+	}) as T;
+
+const relationStoreOf = (holders: ReadonlyArray<string>): Layer.Layer<RelationStore> =>
+	Layer.succeed(RelationStore, {
+		has: (tuple) =>
+			Effect.succeed(tuple.relation === "moderates" && holders.includes(tuple.subject)),
+		hasSubjects: ({subjects, relation}) =>
+			Effect.succeed(
+				new Set(relation === "moderates" ? subjects.filter((s) => holders.includes(s)) : []),
+			),
+		subjectsOf: ({relation}) => Effect.succeed(new Set(relation === "moderates" ? holders : [])),
+	});
+
+const moderatorContext = (actor: Actor = human(MOD)) =>
+	Layer.mergeAll(
+		relationStoreOf([MOD]),
+		Layer.succeed(AgentAuthority, {admits: () => Effect.succeed(false)}),
+		Layer.succeed(CurrentActor, {actor}),
+	);
+
+const group = (targetKind: OpenReportGroup["targetKind"], targetId: string): OpenReportGroup => ({
+	targetKind,
+	targetId,
+	reportCount: 1,
+	reason: "spam",
+	firstReportedAt: AT,
+});
+
+// Every author-standing read answers uniformly — the reputation cluster is not what this
+// file pins, so it stays out of the way of the context assertions.
+const standingStubs = Layer.mergeAll(
+	makeKunyeStub({
+		tierOf: () => Effect.succeed<Tier>("çaylak"),
+		karmaOf: () => Effect.succeed(0),
+	}),
+	makeVouchLedgerStub({hasActiveFor: () => Effect.succeed(false)}),
+);
+
+const reportStubForOpen = (groups: ReadonlyArray<OpenReportGroup>) =>
+	makeReportStub({
+		listOpen: () => Effect.succeed(groups),
+		countRemovalsByAuthors: () => Effect.succeed(new Map()),
+		productionCountsByAuthors: () => Effect.succeed(new Map()),
+		countOpenReportedTargetsByAuthors: () => Effect.succeed(new Map()),
+		reporterDiversity: () => Effect.succeed(new Map()),
+	});
+
+// Each read yields the sandboxed row ONLY to a viewer whose mask is lifted, mirroring
+// `sandboxVisibleWhere`'s `canSeeSandboxed` short-circuit.
+const maskedPano = Layer.succeed(
+	Pano,
+	proxyOver<typeof Pano.Service>("Pano", {
+		getPostsByIds: (_ids, opts) => Effect.succeed(lifted(opts) ? [postRow] : []),
+		getCommentsByIds: (_ids, opts) => Effect.succeed(lifted(opts) ? [commentRow] : []),
+		lookupCommentPostId: () => Effect.succeed("p-parent"),
+	} as Partial<typeof Pano.Service>),
+);
+
+const maskedSozluk = Layer.succeed(
+	Sozluk,
+	proxyOver<typeof Sozluk.Service>("Sozluk", {
+		getDefinitionsByIds: (_ids, opts) => Effect.succeed(lifted(opts) ? [definitionRow] : []),
+		lookupDefinitionTermSlug: () => Effect.succeed("kelime"),
+	} as Partial<typeof Sozluk.Service>),
+);
+
+const listOpen = (groups: ReadonlyArray<OpenReportGroup>) =>
+	resolveWire(lists["report.listOpen"], {
+		args: {},
+		select: ["id", "targetKind", "targetExcerpt", "targetAuthor", "targetRef"],
+	}).pipe(
+		Effect.provide(
+			Layer.mergeAll(
+				reportStubForOpen(groups),
+				maskedPano,
+				maskedSozluk,
+				standingStubs,
+				moderatorContext(),
+			),
+		),
+	);
+
+describe("report.listOpen — a still-sandboxed target hydrates for the moderator (#6472)", () => {
+	it.effect("a reported sandboxed post renders its excerpt, author and target link", () =>
+		Effect.gen(function* () {
+			const result = yield* listOpen([group("post", "p1")]);
+			const node = result.items[0]?.node;
+			assert.deepStrictEqual(
+				{
+					excerpt: node?.targetExcerpt,
+					author: node?.targetAuthor,
+					ref: node?.targetRef,
+					authorId: node?.authorId,
+				},
+				{excerpt: "çaylak gönderisi", author: "caylak", ref: "p1", authorId: CAYLAK},
+			);
+		}),
+	);
+
+	it.effect("a reported sandboxed comment renders and routes to its parent post", () =>
+		Effect.gen(function* () {
+			const result = yield* listOpen([group("comment", "c1")]);
+			const node = result.items[0]?.node;
+			assert.deepStrictEqual(
+				{excerpt: node?.targetExcerpt, author: node?.targetAuthor, ref: node?.targetRef},
+				{excerpt: "çaylak yorumu", author: "caylak", ref: "p-parent"},
+			);
+		}),
+	);
+
+	it.effect("a reported sandboxed definition renders and routes to its term slug", () =>
+		Effect.gen(function* () {
+			const result = yield* listOpen([group("definition", "d1")]);
+			const node = result.items[0]?.node;
+			assert.deepStrictEqual(
+				{excerpt: node?.targetExcerpt, author: node?.targetAuthor, ref: node?.targetRef},
+				{excerpt: "çaylak tanımı", author: "caylak", ref: "kelime"},
+			);
+		}),
+	);
+
+	it.effect("all three kinds hydrate in one queue read", () =>
+		Effect.gen(function* () {
+			const result = yield* listOpen([
+				group("post", "p1"),
+				group("comment", "c1"),
+				group("definition", "d1"),
+			]);
+			assert.deepStrictEqual(
+				result.items.map((i) => i.node.targetExcerpt),
+				["çaylak gönderisi", "çaylak yorumu", "çaylak tanımı"],
+			);
+		}),
+	);
+});
+
+const recordingPublisher = () => {
+	const recorded: Array<string> = [];
+	const scheduled: Array<Promise<unknown>> = [];
+	const layer = Layer.mergeAll(
+		Layer.succeed(LivePublisher)(
+			livePublisherFor({
+				publish: (topicKey) =>
+					Effect.sync(() => {
+						recorded.push(topicKey);
+					}),
+				waitUntil: (promise) => {
+					scheduled.push(promise);
+				},
+			}),
+		),
+		noopPanoFeedCache,
+	);
+	return {recorded, scheduled, layer};
+};
+
+class DrainRejected extends Schema.TaggedErrorClass<DrainRejected>()("test/DrainRejected", {
+	cause: Schema.Unknown,
+}) {}
+
+const restorePost = (sandboxedAt: Date | null, seen: Array<SandboxViewer | undefined>) => {
+	const {recorded, scheduled, layer} = recordingPublisher();
+	const pano = Layer.succeed(
+		Pano,
+		proxyOver<typeof Pano.Service>("Pano", {
+			moderateRestorePost: () => Effect.succeed({restored: true, sandboxedAt}),
+			getPostsByIds: (_ids, opts) =>
+				Effect.sync(() => {
+					seen.push(opts?.sandboxViewer);
+					return lifted(opts) ? [postRow] : [];
+				}),
+		} as Partial<typeof Pano.Service>),
+	);
+	const run = Effect.gen(function* () {
+		yield* mutations["report.restore"].handler({
+			input: {targetKind: "post", targetId: TargetId.make("p1")},
+			select: ["id"],
+		});
+		yield* Effect.tryPromise({
+			try: () => Promise.allSettled(scheduled),
+			catch: (cause) => new DrainRejected({cause}),
+		}).pipe(Effect.orDie);
+		return recorded;
+	}).pipe(
+		Effect.provide(
+			Layer.mergeAll(
+				makeReportStub({
+					lookupReportTarget: () => Effect.succeed({targetKind: "post", targetId: "p1"}),
+					firstOpenReportId: () => Effect.succeed("r1"),
+					reopenForTarget: () => Effect.succeed({reopened: 1}),
+				}),
+				pano,
+				Layer.succeed(Sozluk, proxyOver<typeof Sozluk.Service>("Sozluk", {})),
+				layer,
+				moderatorContext(),
+			),
+		),
+	);
+	return run;
+};
+
+describe("report.publishRestored — the re-read reaches the publish gate (#6472)", () => {
+	it.effect("a still-sandboxed restore re-reads as the moderator, not anonymously", () =>
+		Effect.gen(function* () {
+			const seen: Array<SandboxViewer | undefined> = [];
+			const recorded = yield* restorePost(SANDBOXED_AT, seen);
+			assert.deepStrictEqual(seen, [
+				{viewerId: MOD, canSeeSandboxed: true, seesSandboxedInPlace: false},
+			]);
+			// The row now comes back, and `decidePublish` — not a masked read — is what holds
+			// the broadcast off the viewer-blind public feed (#1205/#1280).
+			assert.deepStrictEqual(recorded, []);
+		}),
+	);
+
+	it.effect("a restore that lands LIVE still re-appends to the public feed", () =>
+		Effect.gen(function* () {
+			const seen: Array<SandboxViewer | undefined> = [];
+			const recorded = yield* restorePost(null, seen);
+			assert.deepStrictEqual(recorded, [liveGlobalConnectionTopic("posts")]);
+		}),
+	);
+});


### PR DESCRIPTION
The moderation report queue hydrated each reported target with no viewer at all. That is not
neutral: `resolveSandboxViewer({})` returns the anonymous viewer, so `sandboxVisibleWhere`
applied `sandboxed_at IS NULL` and every still-sandboxed reported item vanished from the batch.
The row survived (the enrich merge never drops one) but rendered blank — null excerpt, no
author, no target link. The reported çaylak content the sandbox exists to make reviewable was
exactly the content a moderator could not see.

The fix is to read as the moderator. All six call sites already sit behind a discharged
`Moderate` grant, so the viewer comes off that grant rather than being probed for again:

`moderatorSandboxViewer` (`apps/web/worker/features/kunye/sandbox.ts`) puts `Moderate` in `R`,
which makes it unreachable from a path that never proved moderation authority — the viewer
claiming `canSeeSandboxed` cannot be built without the proof. It is threaded into the three
reads in `resolveTargetContexts` (`report/lists.ts`) and the three in `publishRestored`
(`report/mutations.ts`). `currentSandboxViewer` would also have worked, but inside a gated path
it is a second relation-store round trip for an answer the grant already carries, and it drags
the in-place-visibility axis in for a queue that is not the in-place feed.

### `removed_at`: deliberately unchanged

The issue asked this to be settled rather than widened silently. Removed targets stay excluded,
and no code moves: `getPostsByIds` and `getDefinitionsByIds` hardcode `isNull(removedAt)` beside
the sandbox predicate, and that guard takes no viewer, so widening the sandbox viewer cannot
reach it. Surfacing removed targets would mean a new parameter on three service reads and a
policy call about what a moderator sees post-removal — a separate change, not a side effect of
this one. The draft arm is untouched for the same reason: it has no moderator branch by
decision (ADR 0113).

### Tests

`report-queue-sandbox.unit.test.ts` drives the real `report.listOpen` and `report.restore`
handlers. The Pano/Sozluk doubles **model the mask** — a sandboxed row comes back only for a
viewer carrying `canSeeSandboxed` — because a double that returned the row unconditionally
would pass against the anonymous read too, which is why the existing fan-out coverage never
caught this. All six tests fail on the pre-fix source (verified by stashing the two wiring
files and re-running).

`.patterns/caylak-content-containment.md` gains the shape: an authority gate does not widen a
mask, so a gated read still has to say who it is.

## Deviations

- **Declined guidance** — **Said:** acceptance criterion 3 asks that `publishRestored`
  "broadcasts the `/fate/live` restore for a target that is still sandboxed after restore".
  **Did:** the re-read now returns the sandboxed row and reaches `decidePublish(sandboxedAt)`,
  which still suppresses the public broadcast. **Why:** `/fate/live` topics are viewer-blind, so
  broadcasting a sandboxed node relays its full payload to every subscriber — the #1205/#1280
  leak this repo builds the `PublishDecision` brand to prevent. The real defect the criterion
  points at is that two independent guards were stacked and the read silently pre-empted the
  gate; that is fixed, and the suppression decision now lives only where it belongs.
  **Disposition:** stated here; if surfacing sandboxed restores to some audience is wanted, it
  needs a viewer-aware topic, not a widened read.
- **Out-of-scope change** — **Said:** #6472 names `report/lists.ts` and `report/mutations.ts`.
  **Did:** also added the `moderatorSandboxViewer` helper to `kunye/sandbox.ts` and a section to
  `.patterns/caylak-content-containment.md`. **Why:** six call sites needed one viewer, and
  building it inline six times would have re-created the mistake's shape; the pattern doc is the
  documented home for the sandbox seam and CLAUDE.md requires a relied-on pattern be written
  down. **Disposition:** stated here.
- **Known defect left unfixed** — **Said:** criterion 6 covers both test tiers. **Did:** unit
  tier (2585 tests), `pnpm typecheck` and `pnpm lint` are green in this tree; the integration
  tier could not run locally — it provisions real Cloudflare stages and fails at startup with
  `Unauthorized` without API credentials. **Why:** environmental, not code: the same failure
  predates this branch. **Disposition:** stated here; CI owns the integration answer.

Fixes #6472
