### PR TITLE
fix: Published fabrika-cli 0.3.0 ships the pre-#5772 five-label taxonomy — bootstrap reports `exists` on a five-of-sixteen set

### DIFF
--- a/packages/fabrika-cli/src/status/verbs.unit.test.ts
+++ b/packages/fabrika-cli/src/status/verbs.unit.test.ts
@@ -7,12 +7,13 @@
  */
 import {Effect, Layer} from "effect";
 import {describe, expect, it} from "vitest";
+import {audienceLabel, type BoardVocabulary, statusList, typeLabel} from "../config/board.ts";
 import {SURFACE_REGISTRY} from "../config/keys/surface-dispositions.ts";
 import {errOut, fakeFs, fakeShell, okOut} from "../fakes.test-support.ts";
 import type {ExecResult} from "../io/exec.ts";
 import {ok} from "../io/git.ts";
 import type {StdinRead} from "../io/stdin.ts";
-import {AWAITING_RELEASE, PLANNED, STATUSES} from "../labels.ts";
+import {AWAITING_RELEASE, DEFAULT_STATUS_NAMES, PLANNED, STATUSES} from "../labels.ts";
 import {coderTemplateText} from "../lane/fixtures.test-support.ts";
 import {DEFAULT_STALE_MINUTES} from "../lane/stale.ts";
 import {runStale} from "../lane/stale-verb.ts";
@@ -34,10 +35,12 @@ import {
 	findSurface,
 	ISSUE_SHAPE_MARKERS,
 	knownIds,
+	LABEL_DESCRIPTION,
 	MARKER_COLOR,
 	roadmapCount,
 	runBootstrap,
 	TAXONOMY,
+	taxonomy as taxonomyFor,
 } from "./bootstrap-verb.ts";
 import {
 	NOT_BUILDABLE,
@@ -860,6 +863,46 @@ describe("the bootstrap taxonomy is derived from the vocabularies the verbs writ
 	it("carries sixteen labels, each named once", () => {
 		expect(TAXONOMY).toHaveLength(16);
 		expect(names.size).toBe(TAXONOMY.length);
+	});
+
+	it("equals the set computed off the four facet lists, in order", () => {
+		expect(TAXONOMY).toEqual(
+			[
+				...statusList(DEFAULT_STATUS_NAMES),
+				...PRIORITIES,
+				...TYPES.map(typeLabel),
+				...AUDIENCES.map(audienceLabel),
+			].map((name) => ({name, description: LABEL_DESCRIPTION, color: null})),
+		);
+	});
+
+	it("follows the board it is handed, never the shipped default", () => {
+		// #6451: published 0.3.0 restated five names while source derived sixteen, and every
+		// assertion above still passed on the restatement because it happened to spell the default
+		// right. A board whose names phoenix does not use is what a restatement cannot fake.
+		const declared: BoardVocabulary = {
+			statuses: {
+				needsTriage: "state:raw",
+				triaged: "state:ready",
+				needsInfo: "state:asked",
+				planned: "state:planned",
+				awaitingRelease: "state:shipping",
+			},
+			types: ["defect"],
+			priorities: ["sev1"],
+			audiences: ["human"],
+			standingLanes: ["lane:whatever"],
+		};
+		expect(taxonomyFor(declared).map((label) => label.name)).toEqual([
+			"state:raw",
+			"state:ready",
+			"state:asked",
+			"state:planned",
+			"state:shipping",
+			"sev1",
+			"type:defect",
+			"ready-for:human",
+		]);
 	});
 });
 


### PR DESCRIPTION
Two tests binding the bootstrap label taxonomy to the board vocabulary it is handed, so a
restatement cannot pass for a derivation again.

The reported bug was real and is already closed on npm. I unpacked both published tarballs to
check rather than trusting the filing: `@kampus/fabrika-cli@0.3.0` ships a five-name restatement of
`TAXONOMY`, while `0.4.0`, published after this issue was filed, ships
`TAXONOMY = taxonomy(DEFAULT_BOARD_VOCABULARY)` — the derived sixteen. An adopter installing today
gets the sixteen and a `created` answer. So the divergence needs no fix; what it needs is a guard
against its recurrence.

What the existing tests could not catch:

- They assert facts *about* `TAXONOMY` (per-facet counts, keep-set coverage, length 16) but never
  that it equals the computed set. `equals the set computed off the four facet lists, in order`
  closes that.
- Nothing exercised `taxonomy()` with a board other than phoenix's, so a body that ignored its
  argument and returned the default would pass everything. `follows the board it is handed, never
  the shipped default` hands it a vocabulary spelled `state:raw`, `sev1` and `defect` — names a
  restatement cannot fake.

Both are falsified, not just written. Restating `TAXONOMY` as the published 0.3.0 five fails the
first (and four older ones); making `taxonomy()` read `DEFAULT_BOARD_VOCABULARY` instead of its
`board` parameter fails only the second. Each guard covers a hole the other leaves open.

The commit is a `fix` under `packages/fabrika-cli/`, so release-please cuts and republishes a
version carrying today's source — the mechanism the fourth criterion names.

## Deviations

- **Scope narrowing** — **Said:** #6451 asks that the published CLI create all sixteen labels on a
  bare repo, that a repo holding the old five get the remaining eleven, and that the change cut a
  new version rather than leave `0.3.0` divergent. **Did:** shipped only the derivation test; the
  other three I verified as already true rather than building anything for them. **Why:** `0.4.0`
  published between the filing and this build and carries the derived taxonomy — I confirmed it by
  reading `dist/status/bootstrap-verb.js` out of the npm tarballs for both versions. npm versions
  are immutable, so there was nothing left to build for those three. **Disposition:** stated here;
  the criteria are met on the ground, and this commit's conventional-commit type keeps the
  republish mechanism honest going forward.

Fixes #6451
