### PR TITLE
chore: ops/runbook-d1-restore.md still describes the pre-baseline migrations layout

### DIFF
--- a/ops/runbook-d1-restore.md
+++ b/ops/runbook-d1-restore.md
@@ -45,9 +45,42 @@ fix it — you need a point-in-time restore, not another migration:
   [`0002_search_fts.sql`](../apps/web/worker/db/drizzle/migrations/0002_search_fts.sql) —
   already exists. Restore into the scratch stage, verify, then decide on the production
   cutover.
-- **Capture the current state first.** Record the failing migration id and the current
+- **Capture the current state first.** Record the failing migration and the current
   `drizzle_migrations` applied set before you touch anything, so you know exactly which
-  snapshot you are restoring to.
+  snapshot you are restoring to. Copy each one verbatim out of the table's `name` column —
+  after the v7 cutover those names come in two shapes, below.
+
+## Reading `drizzle_migrations` after the v7 cutover
+
+```bash
+pnpm dlx wrangler d1 execute <prod-d1-name> --remote \
+  --command "SELECT id, name, applied_at FROM drizzle_migrations ORDER BY id;"
+```
+
+The journal is wrangler-compatible `(id TEXT PK, name TEXT, applied_at TEXT)`. **`id` is only a
+zero-padded apply counter** (`00001`, `00002`, …); the thing that identifies a migration is
+`name`, which holds its path **relative to `migrationsDir`** — that is the string alchemy
+matches to decide a migration is already applied (`alchemy@2.0.0-beta.59`,
+`lib/Sql/SqlFile.js` `readSqlFile` sets `id: name` from the relative path, and
+`lib/Cloudflare/D1/ApplyMigrations.js` skips on `applied.has(migration.id)`). Since the v7
+cutover (ADR [0309](../.decisions/0309-v7-migrations-baseline-cutover.md)) `name` comes in both
+layouts: the 34 frozen flat files, `0000_d1_baseline.sql` …
+`0033_caylak_visibility_preference.sql`, then one row per post-cutover directory,
+`<prefix>_<name>/migration.sql`, beginning with `20260820113338_v7_baseline/migration.sql`.
+Three consequences bite mid-restore:
+
+- **Take the failing migration's identity from the `name` column, never re-derive it from a
+  filename.** A directory migration's `name` carries the `/migration.sql` suffix; a flat one
+  does not.
+- **The `v7_baseline` row applied nothing** — its
+  [`migration.sql`](../apps/web/worker/db/drizzle/migrations/20260820113338_v7_baseline/migration.sql)
+  is comment-only, seeded so `drizzle-kit generate` has a v7 snapshot to diff against. It is
+  not a schema snapshot and not a restore point: the schema on the database is the flat
+  history plus whatever directories landed after it.
+- **Never repair a bad migration by editing or renaming its file.** The path *is* the identity,
+  so a rename makes alchemy treat the migration as unseen and re-apply it against a database
+  that already holds its objects (ADR 0309). Roll forward with a new `drizzle-kit generate`
+  migration, or restore with this runbook.
 
 ## The FTS5 export tax — why a naive export fails
 


### PR DESCRIPTION
Adds a `## Reading drizzle_migrations after the v7 cutover` section to
`ops/runbook-d1-restore.md`, between Preconditions and the FTS5 export tax.

`#6438`'s PR (#6536) already re-pointed the runbook's grounding sentence at ADR 0309 and
described the two-layout tree, and every path the runbook links still resolves on disk. What it
did not touch is the applied-set narration: the "Capture the current state first" precondition
told an operator to record the applied set but never said what they would be reading. Three
things there can now bite mid-restore:

- The journal's `id` column is only a zero-padded apply counter; `name` is the identity. An
  operator copying the wrong column gets a string alchemy never matches.
- After the cutover `name` carries two shapes — 34 flat `NNNN_*.sql` plus
  `<prefix>_<name>/migration.sql` — so a directory migration's name has a `/migration.sql`
  suffix that is easy to drop when re-deriving it from a filename.
- The newest row, `20260820113338_v7_baseline/migration.sql`, applied nothing (its body is
  comment-only). Read as a schema snapshot or a restore point, it is misleading.

The new section states all three, plus the "never rename a migration to repair it" consequence
that falls out of the path being the identity. The precondition bullet now points at it.

Claims are grounded in `alchemy@2.0.0-beta.59` source rather than intuition:
`lib/Sql/SqlFile.js`'s `readSqlFile` sets `id: name` from the path relative to `migrationsDir`,
`lib/Cloudflare/D1/ApplyMigrations.js` skips on `applied.has(migration.id)` and creates the
table as `(id TEXT PK, name TEXT, applied_at TEXT)` with a `printf('%05d', …)` sequence.

Docs only; no code changed.

Fixes #6540

## Deviations

- **Declined guidance** — **Said:** acceptance criterion 3 asks the narration to account for
  "the baseline snapshot as the new first entry". **Did:** narrated it as the *last* entry —
  the newest applied row, sorting after the 34 flat migrations. **Why:** the criterion was
  written before #6438's shape was known. Founder-ruled shape 1 (and ADR 0309 §Decision) keeps
  the flat history in place and seeds the baseline directory with a timestamp prefix, which
  alchemy's `getPrefix` parses as a number far above 33, so it always sorts after applied
  history. Writing "first entry" would have been false against the tree on disk.
  **Disposition:** stated here; the criterion's intent (the baseline row must be accounted for)
  is met.
- **Scope narrowing** — **Said:** criteria 1, 2 and 4 ask the grounding paragraph, the ADR
  citation and the path references to be re-grounded. **Did:** changed none of them. **Why:**
  #6536 already landed the grounding sentence and the ADR 0309 citation, and I verified all 11
  relative links in the file resolve on disk at `origin/main` — `0002_search_fts.sql` and the
  rest still exist, since shape 1 left the flat files in place. Those three criteria were
  already met before this PR. **Disposition:** stated here; nothing left undone.
