### PR TITLE
fix: Two skill contracts name cycleDoc's and designHarness's defaults as the path the verb opens

### DIFF
--- a/claude-plugins/fabrika/skills/build-ui/contract.md
+++ b/claude-plugins/fabrika/skills/build-ui/contract.md
@@ -101,11 +101,11 @@ Every `ui` verb obeys these; stated once.
 - **Answer channel: machine.** Stdout carries one JSON object and nothing else; scope lines,
   refusal reasons and progress go to stderr. A non-zero exit prints nothing on stdout
   (`refuse` in `packages/fabrika-cli/src/verb.ts`).
-- **Repo-root anchored.** Every convention path below is resolved against the repo root the
-  delivery layer already finds (the shim's repo-root inference, interface convention rule 5) —
-  never against cwd, never against a web URL. v1 fetched the manifest from a hardcoded GitHub
-  URL (`write-code/SKILL.md:972`), which reads the wrong repo's law in any fork and nothing on
-  a network fault; here the law is the tree's own bytes.
+- **Repo-root anchored.** Every path below — the convention paths and the declared `designHarness`
+  path alike — is resolved against the repo root the delivery layer already finds (the shim's
+  repo-root inference, interface convention rule 5) — never against cwd, never against a web URL.
+  v1 fetched the manifest from a hardcoded GitHub URL (`write-code/SKILL.md:972`), which reads the
+  wrong repo's law in any fork and nothing on a network fault; here the law is the tree's own bytes.
 - **GitHub access** per [skill conventions §11 — REST, never GraphQL](../../docs/skill-conventions.md#11-github-access-is-rest-never-graphql),
   paginated. Only `ui evidence` touches GitHub at all.
 - **A non-zero exit is UNKNOWN** to the caller until the code is read. No partial answers.
@@ -152,7 +152,7 @@ the established doctrine (`triage`'s own `codes.ts` states it for `adr`).
 | `16` | proven: a capture was produced but is invalid — zero bytes, undecodable, or zero-area |
 | `17` | proven: at least one evidence upload failed — nothing was posted |
 | `18` | proven: the lane precondition failed — this session does not hold the claim the checked-out lane branch names (foreign, none, or an unparseable branch); detail on stderr |
-| `19` | proven: no render harness is declared at the harness convention path — the repo cannot be rendered headlessly |
+| `19` | proven: no file at the declared `designHarness` path — the repo cannot be rendered headlessly |
 | `127` | the verb never ran at all (unresolved binary — the shell's code) |
 
 **`7` versus `11`** is the same split the whole CLI rests on: a proven absence is a verdict, a
@@ -249,8 +249,8 @@ the law.
 fabrika ui manifest
 ```
 
-**Inputs** — none. The repo root is the delivery layer's; the convention paths are this
-contract's table.
+**Inputs** — none. The repo root is the delivery layer's; four of the five paths are this
+contract's convention table, and the harness path is whatever `designHarness` declares.
 
 **Output** — machine. One JSON object:
 
@@ -275,7 +275,7 @@ The manifest itself is the one surface whose absence refuses: without it there i
 
 | Code | Trigger |
 |---|---|
-| `11` | the repo root could not be resolved, or a convention path's existence could not be determined (permission fault, unreadable dir) |
+| `11` | the repo root could not be resolved, or one of the five paths' existence could not be determined (permission fault, unreadable dir) |
 | `12` | proven: no file at the manifest convention path |
 
 **Errors**
@@ -285,8 +285,9 @@ The manifest itself is the one surface whose absence refuses: without it there i
 | `ui manifest: no design manifest at design-system-manifest.md — this repo is not set up for UI construction. Run /fabrika: front-door's bootstrap drafts one from the repo's own CSS and pages (#4952). Never improvise a design language.` | 12 | refusal |
 | `ui manifest: cannot probe <path>: <reason> — presence is UNKNOWN, never "absent".` | 11 | refusal |
 
-**Scope** — the five convention paths against the repo root. Not a judging verb; presence is the
-supplied fact, and the one refusal (`12`) exists because "no manifest" must route, not report.
+**Scope** — the same five paths against the repo root: four convention, one declared
+(`designHarness`). Not a judging verb; presence is the supplied fact, and the one refusal (`12`)
+exists because "no manifest" must route, not report.
 
 **Examples**
 

--- a/claude-plugins/fabrika/skills/build-ui/contract.md
+++ b/claude-plugins/fabrika/skills/build-ui/contract.md
@@ -194,11 +194,16 @@ and phoenix is one instance.
 | prohibition registry | `design-prohibitions.json` | the law is untyped — exit `13` from `ui law`; manifest prose is the fallback source |
 | component inventory | `design-system-inventory.md` | a fact: the repo ships no inventory; reported as `null`, never an error |
 | golden pointer | `packages/design-capture/golden-pointer.json` where present, else `design-goldens.json` at root | a fact: no goldens; every surface is unblessed |
-| render harness config | `design-harness.json` | the repo cannot be rendered headlessly — exit `19` from `ui render`; reported as `null` by `ui manifest` |
+| render harness config | the **declared** `designHarness` path, whose shipped value here is `design-harness.json` | the repo cannot be rendered headlessly — exit `19` from `ui render`; reported as `null` by `ui manifest` |
+
+The harness row is the one path a repo **declares** rather than inherits: `ui render`, `ui manifest`
+and `ui evidence` resolve the `designHarness` key in `.fabrika.jsonc` and open whatever it names,
+reaching `design-harness.json` only because that is the shipped value. The other four rows are
+convention paths with no key behind them.
 
 ### The harness config schema — canonical here
 
-`design-harness.json` is one JSON object telling the `ui` group how this repo renders and where
+The harness config is one JSON object telling the `ui` group how this repo renders and where
 evidence lives — the portable replacement for v1's phoenix-hardcoded "alchemy dev" knowledge:
 
 | Key | Type | Required | Meaning |
@@ -258,11 +263,12 @@ contract's table.
  "lawSource": "registry"}
 ```
 
-Each key is the surface's repo-root-relative path, or `null` when the convention path holds no
-file. `lawSource` is `"registry"` when the registry file exists, `"manifest-prose"` when only the
-manifest does — the skill writes this token into its PR body verbatim. `registry`, `inventory`,
-`goldenPointer` and `harness` report **presence only**; parsing them is `ui law`'s, `ui golden`'s
-and `ui render`'s.
+Each key is the surface's repo-root-relative path, or `null` when that path holds no file —
+`harness` is the path `designHarness` declares, and the `design-harness.json` above is phoenix's
+shipped value, not a fixed name. `lawSource` is `"registry"` when the registry file exists,
+`"manifest-prose"` when only the manifest does — the skill writes this token into its PR body
+verbatim. `registry`, `inventory`, `goldenPointer` and `harness` report **presence only**; parsing
+them is `ui law`'s, `ui golden`'s and `ui render`'s.
 The manifest itself is the one surface whose absence refuses: without it there is no law at all.
 
 **Exit status** (beyond the universal four)
@@ -392,8 +398,8 @@ implementations guessing differently.
 ```
 
 **The mechanism, in order.** Resolve the lane (shared conventions; the set dir is
-`build scratch`'s allocation for this lane, `<scratch>/<set>/`). Read `design-harness.json`
-(absent `19`, malformed `4`). Start `command` from the repo root; poll `<url><readyPath>` until
+`build scratch`'s allocation for this lane, `<scratch>/<set>/`). Read the declared `designHarness`
+path (absent `19`, malformed `4`). Start `command` from the repo root; poll `<url><readyPath>` until
 HTTP 200, up to the schema row's readiness bound (`11` on timeout, with the server's stderr tail
 in the message); on any exit, kill the started process tree. For each `--surface`, in a headless browser at the
 config's viewport: navigate to `<url><route>`; an HTTP status ≥ 400 or a failed navigation is
@@ -413,14 +419,14 @@ never the tool's silent tolerance.
 
 | Code | Trigger |
 |---|---|
-| `4` | `design-harness.json` exists but violates its schema |
+| `4` | the harness config exists but violates its schema |
 | `10` | `--out` is not kebab-case, or a `--surface` carries the reserved `:state` suffix |
 | `11` | the harness did not become ready, a capture's validity could not be determined, or the claim state could not be read — the render is UNKNOWN |
 | `14` | proven: at least one surface threw an uncaught page error during render |
 | `15` | proven: at least one surface is unreachable — status ≥ 400 or failed navigation (no route, dark flag, gated tier); each named on stderr |
 | `16` | proven: at least one capture was produced but is invalid (zero bytes, undecodable, zero area) |
 | `18` | proven: the lane precondition failed (shared conventions) |
-| `19` | proven: no `design-harness.json` at the convention path |
+| `19` | proven: no file at the declared `designHarness` path |
 
 When outcomes mix, the reported code is the smallest applicable of `14`/`15`/`16` and stderr
 carries every surface's outcome — the code routes, the stderr enumerates.
@@ -435,11 +441,14 @@ carries every surface's outcome — the code routes, the stderr enumerates.
 | `ui render: the render harness could not start: <reason> — every surface is UNKNOWN.` | 11 | refusal |
 | `ui render: the harness did not answer 200 on <readyPath> within the readiness bound — every surface is UNKNOWN; server stderr tail: <tail>.` | 11 | refusal |
 | `ui render: cannot determine the validity of <set>/<file>: <reason> — the capture is UNKNOWN, never valid.` | 11 | refusal |
-| `ui render: no design-harness.json at the repo root — this repo declares no headless render path; add one (see the harness config schema).` | 19 | refusal |
-| `ui render: design-harness.json exists but does not satisfy its schema: <first violation>.` | 4 | refusal |
+| `ui render: no <harness path> at the repo root — this repo declares no headless render path; add one (see the harness config schema).` | 19 | refusal |
+| `ui render: <harness path> exists but does not satisfy its schema: <first violation>.` | 4 | refusal |
 | `ui render: --surface "<id>" carries a :state suffix — states are a reserved grammar, not yet realized; render the bare route.` | 10 | refusal |
 | `ui render: --out "<value>" is not a kebab-case set name.` | 10 | refusal |
 | `ui render: this session does not hold the claim the checked-out branch names (<detail>) — the lane is not yours.` | 18 | refusal |
+
+`<harness path>` is interpolated, not fixed: the verb prints the path `designHarness` declares, so a
+repo that declares its own harness path reads that path back in both refusals.
 
 **Scope** — exactly the `--surface` operands, no more: the verb never scans the diff. Zero
 operands is `1`, so "rendered nothing, found nothing wrong" is unrepresentable (ADR 0092).
@@ -587,7 +596,7 @@ verify each upload individually, before anything posts** — the two-tier store:
 1. **Store tier** — when the harness config declares `evidenceStore`: `PUT` each PNG
    content-addressed (`<store>/<sha256>.png`, the golden-store idiom of ADR 0183), then `GET`
    the same URL back and hash-compare. Any failed PUT, GET, or hash mismatch is `17`. (The
-   tier choice reads `design-harness.json` here too: an absent file selects the attachment
+   tier choice reads the harness config here too: an absent file selects the attachment
    tier — no harness config is a fact, not an error, at evidence time; a file that exists but
    violates its schema is `4`, same whole-file rule as in `ui render`.)
 2. **Attachment tier** — no `evidenceStore` declared: upload each PNG through GitHub's
@@ -616,7 +625,7 @@ another lane's PR is a cross-lane write. PR open (`7`).
 
 | Code | Trigger |
 |---|---|
-| `4` | an after-surface has no before and no `firstRender` mark, a named capture set is missing/empty, a set's `manifest.json` is absent or unparseable, or `design-harness.json` exists but violates its schema |
+| `4` | an after-surface has no before and no `firstRender` mark, a named capture set is missing/empty, a set's `manifest.json` is absent or unparseable, or the harness config exists but violates its schema |
 | `5` | the composed comment carries a machine-local path |
 | `6` | the composed comment is a bare `@` path reference — not redactable |
 | `7` | the PR is proven absent, closed, or merged |

--- a/claude-plugins/fabrika/skills/check-epic-plan/contract.md
+++ b/claude-plugins/fabrika/skills/check-epic-plan/contract.md
@@ -192,7 +192,8 @@ the barrier exists to prevent ([#4637-C](https://github.com/kamp-us/phoenix/issu
 a ruling lands at is this table's row 13.
 
 **When a class cannot be derived, it is named, never dropped.** `MISSING_CONTAINMENT` rests on a
-probe for `product-development-cycle.md`, which is three-valued: `present` (the class is derived),
+probe for the **declared** cycle doc (`cycleDoc`, whose shipped value here is
+`product-development-cycle.md`), which is three-valued: `present` (the class is derived),
 `absent` (the class is derived and evaluates false — no cycle doc, no containment requirement), and
 `unknown` (the probe failed to read). Only `unknown` puts the class in `skipped`. v1 fused `absent`
 and `unknown` through a stderr substring match, so a transient probe failure silently switched the


### PR DESCRIPTION
Two skill contracts printed a config key's shipped default as if it were the path the verb opens. This replaces those literals with the key, keeping `product-development-cycle.md` / `design-harness.json` only where they are marked as phoenix's shipped value.

`check-epic-plan/contract.md` — the `MISSING_CONTAINMENT` paragraph now names the declared cycle doc (`cycleDoc`) and marks the literal as phoenix's value, matching how the rest of that file already reads.

`build-ui/contract.md` — the conventions table's harness row, the schema-section lead, the `ui manifest` output prose, the `ui render` mechanism, both `ui render` exit rows (`4`, `19`), the `ui evidence` tier-choice note and the `ui evidence` `4` row now name `designHarness`. A new paragraph under the conventions table says the harness row is the one declared path among the five; the other four are convention paths with no key behind them.

The two `ui render` refusal templates now read `<harness path>`, with a note that the verb interpolates the declared path. That matches `packages/fabrika-cli/src/ui/render-verb.ts:232,248`, which prints `harnessPath` resolved through `designHarnessOr`, so a repo declaring its own path sees that path in stderr.

Round 2 sweeps the phrase "convention path" off the harness path everywhere else in `build-ui/contract.md`: the shared-conventions repo-root bullet, the group exit table's `19` row (now matching the `ui render` row for the same code), and `ui manifest`'s Inputs line, exit-`11` row and Scope line. `manifest-verb.ts:77` resolves `designHarnessOr` before probing, so one of the five paths that verb reads is declared, not conventional.

No verb source changed.

Where to look first: `build-ui/contract.md:441-452`, the refusal templates and their note — those are the lines a reader compares against stderr verbatim.

Fixes #6454

## Deviations

- **Out-of-scope change** — **Said:** #6454 names the `design-harness.json` literals. **Did:** also re-wrapped three otherwise-untouched lines in the `ui manifest` output paragraph, and in round 2 re-flowed the shared-conventions repo-root bullet and the `ui manifest` Scope paragraph. **Why:** in each case the paragraph's leading line changed length, so the rest had to re-flow to stay inside the 100-column wrap. **Disposition:** stated here.
- **Out-of-scope change** — **Said:** the round-1 finding named `build-ui/contract.md:104`, `:155`, `:252` and `:288`. **Did:** also rewrote `:278`, `ui manifest`'s exit-`11` row, which said "a convention path's existence could not be determined" about the same five paths. **Why:** criterion 5 says the file must not call the harness path a convention path anywhere, and that row covers all five. **Disposition:** stated here.
- **Scope narrowing** — **Said:** criterion 2 lists `build-ui/contract.md:257` and `:289`. **Did:** left the `"harness": "design-harness.json"` value inside both JSON output blocks as-is. **Why:** those are output examples from a run in phoenix, not claims about a fixed path, and the prose directly under the first one now states that `harness` is whatever `designHarness` declares and that the value shown is phoenix's shipped one. **Disposition:** stated here — flag it if the criterion wanted the example values themselves rewritten.
- **Known defect left unfixed** — **Said:** nothing about `check-epic-plan/contract.md:416`. **Did:** left that line's `product-development-cycle.md` literal alone. **Why:** it quotes what an earlier version of that exit row said, inside a note flagging its own premise as stale; rewriting a quotation of past text would make the note incoherent. **Disposition:** stated here.
- **Known defect left unfixed** — **Said:** nothing about `ui render`'s error table completeness. **Did:** left it short of three refusals the verb prints. **Why:** `render-verb.ts:211-217,225,240` emit config-unread refusals at `11` that the table never lists; a different defect from this one. **Disposition:** filed as #6581.
- **Known defect left unfixed** — **Said:** this lane's fence is doc-only, limited to the two contract files. **Did:** left `manifest-verb.ts:108`'s stderr string, which still prints "probed 5 convention paths", disagreeing with the Scope line this PR now writes. **Why:** fixing it means editing verb source, which criterion 4 and the lane's fence both forbid. **Disposition:** filed as #6593.
