### PR TITLE
feat: Nothing verifies the plugin is wired: fabrika ran in demlik for two days with settings.json absent

### DIFF
--- a/claude-plugins/fabrika/guide/adopt-fabrika-in-a-new-repo.md
+++ b/claude-plugins/fabrika/guide/adopt-fabrika-in-a-new-repo.md
@@ -271,8 +271,16 @@ reasoning for each value in comments.
 fabrika status open
 ```
 
-Five fields: the installed skill roster, the config gaps from step 2, your board's counts, the
-decision digest, and any lanes on this machine. The `readout` field reads `absent` with the detail
+Six fields: the installed skill roster, what this repo declares from step 2, whether the plugin
+carrying the skills is enabled here, your board's counts, the decision digest, and any lanes on this
+machine.
+
+**Read the `wiring` field first.** It is the only one that answers about the plugin rather than
+about something the CLI reads, so it is the only one that catches a repo where every verb answers
+and no fabrika skill can load in a session. `unwired` means `.claude/settings.json` does not enable
+`fabrika@<marketplace>`, and until it does nothing in this guide's pipeline can start.
+
+The `readout` field reads `absent` with the detail
 `no readout artifact` until you run `fabrika status bootstrap readout-artifact`, which opens the
 durable issue the digest is upserted into, and then `absent` with `no digest block` until
 `fabrika governance readout` writes one. Both are facts, not failed reads.

--- a/claude-plugins/fabrika/guide/getting-started.md
+++ b/claude-plugins/fabrika/guide/getting-started.md
@@ -59,19 +59,25 @@ fabrika status open
 ```
 
 ```
-status open: roster claude-plugins/fabrika/skills (repo); repo kamp-us/phoenix; 5 field(s) rendered, 0 unknown.
-open	5
+status open: roster claude-plugins/fabrika/skills (repo); repo kamp-us/phoenix; 6 field(s) rendered, 0 unknown.
+open	6
 field	menu	ready	25 skills	claude-plugins/fabrika/skills	2026-08-19T03:23:01Z
-field	config	gaps	20 declared, 3 missing, 5 undeclared	claude-plugins/fabrika/skills	2026-08-19T03:23:01Z
+field	settings	resolved	15 keys, 4 declared	.fabrika.jsonc	2026-08-19T03:23:01Z
+field	wiring	wired	fabrika@kampus is enabled — sessions in this repo load fabrika's skills	.claude/settings.json	2026-08-19T03:23:01Z
 field	board	counted	3 needs-triage, 367 triaged	kamp-us/phoenix	2026-08-19T03:23:02Z
 field	readout	absent	no digest block in kamp-us/phoenix#5616	kamp-us/phoenix#5616	unknown
 field	lanes	empty	no lanes on disk	.fabrika/lanes,.fabrika/chores	2026-08-19T03:23:01Z
 ```
 
 That output is from a repo already set up, so yours will differ — the `board` row will report a
-board with no fabrika labels on it yet, and the `readout` row will say `absent`. Read the five
-fields as: which skills are installed, which repo surfaces they need, what is on the board, whether
-the decision digest exists, and which runs are in flight on this machine.
+board with no fabrika labels on it yet, and the `readout` row will say `absent`. Read the six
+fields as: which skills are installed, what this repo declares, whether the plugin carrying the
+skills is switched on here, what is on the board, whether the decision digest exists, and which runs
+are in flight on this machine.
+
+**Watch the `wiring` row first.** `unwired` means the CLI works and no fabrika skill can load in a
+session in this repo — every other row can read green while that one does, which is how a repo ran
+half-adopted for two days.
 
 ## 4. Create the labels
 

--- a/claude-plugins/fabrika/skills/front-door/contract.md
+++ b/claude-plugins/fabrika/skills/front-door/contract.md
@@ -24,8 +24,9 @@ access per
 
 | Verb | Purpose | Split test |
 |---|---|---|
-| `status open` | the composite front-door readout: five fields, each with its own state, source and freshness | assembling five independent reads and rendering each one's three-state outcome is a total function; deciding what to *do* about a gap is the skill's |
+| `status open` | the composite front-door readout: six fields, each with its own state, source and freshness | assembling six independent reads and rendering each one's three-state outcome is a total function; deciding what to *do* about a gap is the skill's |
 | `status settings` | every key on the `.fabrika.jsonc` config surface, its resolved value, and where that value came from | resolving a key against a shipped default and naming its provenance is a total function; deciding what a repo *should* declare is judgment |
+| `status wiring` | whether `.claude/settings.json` enables the fabrika plugin — the precondition under every other verb | reading one `enabledPlugins` key and reporting what it says is mechanical; deciding to *wire* the repo is the operator's, and creating the file is `status bootstrap`'s |
 | `status menu` | the landed skill roster with each skill's invocation and one-line description | reading a directory and each file's frontmatter is a total function; choosing which skill fits the work at hand is judgment |
 | `status readout` | the landed-decision digest as published in the durable artifact | fetching an artifact and decoding a registered wire format is mechanical; ranking the rows is `governance`'s judgment and is not recomputed here |
 | `status board` | counts of the board's decided buckets, each with its own freshness | counting labelled issues over named REST endpoints is arithmetic; ranking or picking from them is `build pick`'s |
@@ -234,6 +235,9 @@ purpose — keeping proven-empty apart from unread — to chance.
 | `settings` | every key resolved, declared or defaulted | `resolved` | `<n> keys, <d> declared` |
 | `settings` | ≥1 key `unknown` | `unknown` | which keys are unread — a repo whose config will not parse has no known value for anything, and printing the shipped default there is the collapse the surface exists to prevent |
 | `settings` | the surface registers zero keys | `unknown` | `the config surface registers zero keys` — vacuously-resolved is not resolved (ADR 0092) |
+| `wiring` | `enabledPlugins` carries a `fabrika@<marketplace>` key set to `true` | `wired` | which key is enabled |
+| `wiring` | no settings file, no `enabledPlugins` block, no fabrika key, a key switched off, or a key naming no marketplace | `unwired` | which of those it was. **Never `unknown`**: the repo proved each of them, and folding them into `unknown` hides the one gap this field exists to name |
+| `wiring` | the settings file, or the repo root above the cwd, could not be read; the bytes are not a JSON object; `enabledPlugins` is not an object; the fabrika key is neither `true` nor `false` | `unknown` | the raw failure. **Never `unwired`**: a probe nobody could perform proves nothing about what loads |
 | `board` | every bucket counted | `counted` | the two headline counts |
 | `board` | ≥1 bucket `unknown`, or the repo unresolvable/unreadable | `unknown` | the raw failure, or the absent labels |
 | `readout` | digest block found | `found` | `<n> rows` |
@@ -254,7 +258,7 @@ that both yield `absent` are both facts about the repository, and only a failed 
 
 ### The shared exit taxonomy
 
-All six verbs allocate from one internal table (`packages/fabrika-cli/src/status/codes.ts`), so a
+All seven verbs allocate from one internal table (`packages/fabrika-cli/src/status/codes.ts`), so a
 code means one thing across *this group*. Every shared seat is **imported**, never restated as a
 numeral — a restated numeral is a second source that can drift silently, and an import cannot. The
 group registers as an aligned group claiming `SHARED_SEATS`:
@@ -371,7 +375,7 @@ fabrika status open [--field <name>] [--repo <owner/name>] [--skills-dir <path>]
 
 | Flag | Type | Required | Default | Description |
 |---|---|---|---|---|
-| `--field` | string | no | all five | render one field only — `menu`, `settings`, `board`, `readout` or `lanes`; any other value is off-vocabulary |
+| `--field` | string | no | all six | render one field only — `menu`, `settings`, `wiring`, `board`, `readout` or `lanes`; any other value is off-vocabulary |
 | `--repo` | string | no | resolved | the repository the board and digest fields read |
 | `--skills-dir` | string | no | [resolved](#roster-location) | the roster root the menu field reads |
 | `--json` | boolean | no | `false` | emit the result object |
@@ -383,28 +387,30 @@ open	<field-count>
 field	<name>	<state>	<detail>	<source>	<as-of>
 ```
 
-`<name>` ∈ `menu` · `settings` · `board` · `readout` · `lanes`. `<state>` is drawn from that field's closed set,
+`<name>` ∈ `menu` · `settings` · `wiring` · `board` · `readout` · `lanes`. `<state>` is drawn from that field's closed set,
 **every one of which includes `unknown`**, and is produced by [the mapping](#core-to-field):
 
 | Field | Closed state set |
 |---|---|
 | `menu` | `ready` · `empty` · `unknown` |
 | `settings` | `resolved` · `unknown` |
+| `wiring` | `wired` · `unwired` · `unknown` |
 | `board` | `counted` · `unknown` |
 | `readout` | `found` · `absent` · `malformed` · `unknown` |
 
 `<source>` names where the answer came from so the session can re-run one read instead of adopting
-the render: the resolved roster path for `menu`, `.fabrika.jsonc` for `settings`, `<owner>/<name>` for `board`, and
+the render: the resolved roster path for `menu`, `.fabrika.jsonc` for `settings`,
+`.claude/settings.json` for `wiring`, `<owner>/<name>` for `board`, and
 `<owner>/<name>#<issue>` for `readout` when an artifact resolved — otherwise `<owner>/<name>`.
 
-**No aggregate state, deliberately.** A roll-up over five independently-sourced fields would need a
+**No aggregate state, deliberately.** A roll-up over six independently-sourced fields would need a
 rule for "three fine, one unknown", and every such rule either hides the unknown or drowns the three.
 
 **Exit status**
 
 | Code | Trigger |
 |---|---|
-| `10` | `--field` is not one of `menu`, `settings`, `board`, `readout`, `lanes` |
+| `10` | `--field` is not one of `menu`, `settings`, `wiring`, `board`, `readout`, `lanes` |
 
 **That is the whole table, and it is the point** ([why](#open-is-total)). An unresolvable repo, an
 unreachable GitHub, an unreadable roster, an absent roster and an unregistered digest format each
@@ -415,7 +421,7 @@ token; a refusal would write zero bytes on the cold start it exists for.
 
 | Message (stderr) | Code | Kind |
 |---|---|---|
-| `status open: --field "<v>" is not one of menu, settings, board, readout, lanes.` | 10 | usage error |
+| `status open: --field "<v>" is not one of menu, settings, wiring, board, readout, lanes.` | 10 | usage error |
 | `status open: roster <path> (<tier>), <n> skills; repo <owner/name>; <k> field(s) rendered, <u> unknown.` | 0 | notice |
 
 **Scope** — the fields requested, each named on the scope line with the source it resolved and the
@@ -425,20 +431,27 @@ roster tier that served it.
 
 ```
 $ fabrika status open
-open	4
+open	6
 field	menu	ready	12 skills	claude-plugins/fabrika/skills	2026-08-09T14:22:03Z
 field	settings	resolved	15 keys, 4 declared	.fabrika.jsonc	2026-08-09T14:22:03Z
+field	wiring	wired	fabrika@kampus is enabled — sessions in this repo load fabrika's skills	.claude/settings.json	2026-08-09T14:22:03Z
 field	board	counted	7 needs-triage, 23 triaged	kamp-us/phoenix	2026-08-09T14:22:05Z
 field	readout	found	6 rows	kamp-us/phoenix#9412	2026-08-08T09:00:00Z
+field	lanes	empty	no lanes on disk	.fabrika/lanes,.fabrika/chores	2026-08-09T14:22:05Z
 ```
+
+The adopter case, where the CLI answers and no skill can load — the shape that went unseen for two
+days in kamp-us/demlik#26:
 
 ```
 $ fabrika status open
-open	4
+open	6
 field	menu	ready	12 skills	claude-plugins/fabrika/skills	2026-08-09T14:22:03Z
-field	settings	resolved	15 keys, 4 declared	.fabrika.jsonc	2026-08-09T14:22:03Z
+field	settings	resolved	15 keys, 0 declared	.fabrika.jsonc	2026-08-09T14:22:03Z
+field	wiring	unwired	no .claude/settings.json — no fabrika skill can load in a session here	.claude/settings.json	2026-08-09T14:22:03Z
 field	board	unknown	cannot reach api.github.com: EAI_AGAIN — a failed read, not zero issues	kamp-us/phoenix	unknown
 field	readout	unknown	the governance-digest format is not registered — a failed read, not an absent digest	kamp-us/phoenix	unknown
+field	lanes	empty	no lanes on disk	.fabrika/lanes,.fabrika/chores	2026-08-09T14:22:05Z
 $ echo $?
 0
 ```
@@ -628,6 +641,101 @@ $ echo $?
 - #6290 — the loader this verb reads through. The `Default` / `Unknown` split is that module's, and
   is why a readout can say which without re-deriving it.
 - ADR 0092 — zero scope reds; an unread value is UNKNOWN, never a negative answer.
+
+## `status wiring`
+
+**Invocation**
+
+```
+fabrika status wiring [--root <dir>] [--json]
+```
+
+**Inputs**
+
+| Flag | Type | Required | Default | Description |
+|---|---|---|---|---|
+| `--root` | string | no | the repo root above the cwd | the directory holding `.claude/settings.json` |
+| `--json` | boolean | no | `false` | emit the result object |
+
+**Output** — machine channel, [tab-separated](#separator). One line:
+
+```
+wiring	<wired|unwired>	<entry>	<marketplace>	<detail>	<as-of>
+```
+
+`<entry>` is the `enabledPlugins` key naming fabrika and `<marketplace>` is that key's source half;
+each is `-` when the file names none.
+
+<a id="wiring-is-the-other-half"></a>**Every other verb in this group answers about something the
+CLI reads. This one answers about the plugin that carries the skills.** A repo can have the CLI
+installed and answering while no fabrika skill can load in a session there, and nothing said so
+until this verb existed — kamp-us/demlik#26 ran that way for two days with every other status
+surface green ([#6443](https://github.com/kamp-us/phoenix/issues/6443)).
+
+**The gating fact is `enabledPlugins`, and the marketplace source is the key's own suffix.** A
+Claude Code `enabledPlugins` key is `plugin@marketplace`, so one entry carries both halves the
+wiring needs; a bare `fabrika` key names no source and resolves to no plugin, so it is `unwired`.
+`extraKnownMarketplaces` is **deliberately not read**: ADR
+[0273](../../../../.decisions/0273-fabrika-ships-as-an-installed-plugin.md)'s 2026-08-16 amendment
+records that Claude Code never registers a project-scope `extraKnownMarketplaces` block (verified
+live on [#5705](https://github.com/kamp-us/phoenix/issues/5705)), so a repo carrying one is no more
+wired than a repo without, and reading it as evidence would green a session that loads nothing.
+
+**`unwired` is an answer at exit `0`, and `unknown` is a refusal.** A proven-off plugin is a fact
+the caller acts on — the seat `status board`'s proven `0` and `status readout`'s `absent` take —
+while a probe that could not be performed has no answer to seat.
+
+**It detects; it never writes.** Creating `.claude/settings.json` is `status bootstrap`'s registry
+work under epic [#5979](https://github.com/kamp-us/phoenix/issues/5979). A probe that repaired what
+it measured could never report the state it found, and a repo that never ran bootstrap would still
+need this answer.
+
+**Exit status**
+
+| Code | Trigger |
+|---|---|
+| `11` | the repo root could not be resolved; `.claude/settings.json` exists and could not be read; its bytes are not JSON or not a JSON object; `enabledPlugins` is not an object; the fabrika entry is neither `true` nor `false` |
+
+**No `7` seat.** An absent settings file is a *proven* negative and a legitimate answer at exit `0`;
+there is no zero-scope refusal for a verb whose scope is "this repository's settings file".
+
+**Errors**
+
+| Message (stderr) | Code | Kind |
+|---|---|---|
+| `status wiring: <what failed> — whether a session here loads fabrika's skills is UNKNOWN, never unwired and never green.` | 11 | refusal |
+| `status wiring: <how the file was found>; plugin fabrika is <state>.` | 0 | notice |
+
+**Scope** — one file, `.claude/settings.json`, under `--root` or the repository root above the cwd.
+
+**Examples**
+
+```
+$ fabrika status wiring
+wiring	wired	fabrika@kampus	kampus	fabrika@kampus is enabled — sessions in this repo load fabrika's skills	2026-08-20T16:41:45Z
+```
+
+```
+$ fabrika status wiring
+wiring	unwired	-	-	no .claude/settings.json — no fabrika skill can load in a session here	2026-08-20T16:41:58Z
+$ echo $?
+0
+```
+
+```
+$ fabrika status wiring --json
+{"outcome":"unwired","path":".claude/settings.json","entry":"fabrika@kampus","marketplace":"kampus","detail":"enabledPlugins carries fabrika@kampus switched off","asOf":"2026-08-20T16:42:10Z","asOfKind":"read-now"}
+```
+
+**Grounding**
+
+- #6443 / kamp-us/demlik#26 — the CLI half answered and the skill half silently did not exist; no
+  status surface said so for two days.
+- ADR 0273 (2026-08-16 amendment) / #5705 — project-scope `extraKnownMarketplaces` is inert, which
+  is why the marketplace source is read off the `enabledPlugins` key instead.
+- #5979 — the emit side. This verb is its detection companion and stays out of its registry.
+
+---
 
 ## `status menu`
 

--- a/packages/fabrika-cli/src/status/codes.ts
+++ b/packages/fabrika-cli/src/status/codes.ts
@@ -1,5 +1,5 @@
 /**
- * The one exit table all six `status` verbs allocate from, so a code means one thing across this
+ * The one exit table all seven `status` verbs allocate from, so a code means one thing across this
  * group whichever verb produced it
  * (`claude-plugins/fabrika/skills/front-door/contract.md`, "The shared exit taxonomy").
  *

--- a/packages/fabrika-cli/src/status/command.ts
+++ b/packages/fabrika-cli/src/status/command.ts
@@ -40,10 +40,12 @@ import {
 	readoutField,
 	runOpen,
 	settingsField,
+	wiringField,
 } from "./open-verb.ts";
 import {badIssueRefusal, issueNumberOf, readReadout, runReadout} from "./readout-verb.ts";
 import {type RosterSources, readRoster} from "./roster.ts";
 import {runSettings, settingRows} from "./settings-verb.ts";
+import {readWiringSource, repoWiringSource, runWiring, wiringOf} from "./wiring-verb.ts";
 
 /** Write the outcome and exit on its code — stdout is the answer, everything else is stderr. */
 const emit = (outcome: VerbOutcome): Effect.Effect<void> =>
@@ -164,6 +166,32 @@ const settings = leafCommand(
 	Command.withShortDescription("The resolved config surface, every key with its provenance."),
 	Command.withDescription(
 		"Print every key on the config surface with its resolved value and where that value came from — the one place a skill asks what `.fabrika.jsonc` resolves to, so no document has to restate a value. First stdout line is `settings\\t<resolved|unknown>\\t<keys>\\t<declared>\\t<unknown>\\t<as-of>`, then one `setting\\t<key>\\t<declared|default|unknown>\\t<value-as-json>\\t<detail>\\t<as-of>` line each. A repo with no `.fabrika.jsonc` prints the full shipped-default set at exit 0; a key whose value could not be established makes the whole readout a refusal that names each UNKNOWN key on stderr, never the default it did not resolve to. Pass --surfaces to expand `surfaceDispositions` into one `surface\\t<id>\\t<fail-loud|degrade|bootstrap>\\t<what the surface is>` line per repo surface, appended to the same readout — the id-to-word value alone says nothing about what a surface is, and that half is what an operator relays. This verb writes nothing. Exits 7 (the config surface registers zero keys, or --surfaces was passed and no `surfaceDispositions` key is registered — ADR 0092), 11 (the repository root could not be resolved, or `.fabrika.jsonc` exists and could not be read, is not a JSON object, holds a value the surface refuses, or refused the whole load — UNKNOWN, never green). Example: fabrika status settings",
+	),
+);
+
+const wiring = leafCommand(
+	"wiring",
+	{
+		root: Flag.string("root").pipe(
+			Flag.optional,
+			Flag.withDescription(
+				"the directory holding .claude/settings.json (default: the repository root above the cwd)",
+			),
+		),
+		json: jsonFlag,
+	},
+	Effect.fn(function* ({root, json}) {
+		const named = Option.getOrNull(root);
+		const source =
+			named === null ? yield* repoWiringSource(process.cwd()) : yield* readWiringSource(named);
+		yield* emit(
+			runWiring({source, read: wiringOf(source), asOf: readNow(instant(new Date())), json}),
+		);
+	}),
+).pipe(
+	Command.withShortDescription("Whether this repo's sessions load fabrika's skills at all."),
+	Command.withDescription(
+		"Answer whether the fabrika plugin is wired into this repo — the meta-precondition no other status verb covers, because every one of them answers about something the CLI reads and the CLI answers fine in a repo where no fabrika skill can load (#6443). Reads `.claude/settings.json` at the repository root and reports the `enabledPlugins` entry naming fabrika together with the marketplace source that key's `plugin@marketplace` form carries. Stdout is the single line `wiring\t<wired|unwired>\t<entry>\t<marketplace>\t<detail>\t<as-of>`. An absent settings.json, a file declaring no enabledPlugins block, an entry switched off, and a bare `fabrika` key naming no marketplace are all the proven negative `unwired` at exit 0 — a fact the caller acts on, never a green. This verb writes nothing; creating the file is `status bootstrap`'s. Exits 11 (the repository root could not be resolved, or settings.json exists and could not be read, is not JSON, is not an object, declares a non-object enabledPlugins, or carries a fabrika entry that is neither true nor false — UNKNOWN, never unwired). Example: fabrika status wiring",
 	),
 );
 
@@ -292,6 +320,10 @@ const open = leafCommand(
 				const source = yield* configSurface(null);
 				fields.push(settingsField(settingRows(source), CONFIG_PATH, asOf));
 			}
+			if (name === "wiring") {
+				const source = yield* repoWiringSource(process.cwd());
+				fields.push(wiringField(wiringOf(source), asOf));
+			}
 			if (name === "board") {
 				fields.push(
 					boardField(
@@ -333,10 +365,10 @@ const open = leafCommand(
 	}),
 ).pipe(
 	Command.withShortDescription(
-		"The composite front-door readout: menu, settings, board, readout, lanes.",
+		"The composite readout: menu, settings, wiring, board, readout, lanes.",
 	),
 	Command.withDescription(
-		"The composite front-door readout: five fields — menu, settings, board, readout, lanes — each with its own state, source and freshness. The lanes field renders `fabrika lane stale`'s sweep over both default roots at its documented threshold: `stale` names the silent lanes, zero stale lanes is the proven negative `empty` (no lanes on disk is `empty` too), and an unreadable root or lane record is `unknown` with its reason — it reports, it never resumes. Every unreadable source becomes a field state, so this verb has no zero-scope seat and no failed-read seat: it is injected before the session reads a token and a refusal would write zero bytes. First stdout line is `open\\t<field-count>`, then one `field\\t<name>\\t<state>\\t<detail>\\t<source>\\t<as-of>` line each. Exits 10 (--field is off the closed vocabulary). Example: fabrika status open",
+		"The composite front-door readout: six fields — menu, settings, wiring, board, readout, lanes — each with its own state, source and freshness. The wiring field says whether this repo's `.claude/settings.json` enables the fabrika plugin at all, which is what makes the difference between a repo the CLI answers in and a repo whose sessions can load a skill. The lanes field renders `fabrika lane stale`'s sweep over both default roots at its documented threshold: `stale` names the silent lanes, zero stale lanes is the proven negative `empty` (no lanes on disk is `empty` too), and an unreadable root or lane record is `unknown` with its reason — it reports, it never resumes. Every unreadable source becomes a field state, so this verb has no zero-scope seat and no failed-read seat: it is injected before the session reads a token and a refusal would write zero bytes. First stdout line is `open\\t<field-count>`, then one `field\\t<name>\\t<state>\\t<detail>\\t<source>\\t<as-of>` line each. Exits 10 (--field is off the closed vocabulary). Example: fabrika status open",
 	),
 );
 
@@ -346,6 +378,7 @@ export const statusCommand = Command.make("status").pipe(
 		// one. The comment is what keeps the formatter from collapsing the list back.
 		open,
 		settings,
+		wiring,
 		menu,
 		readout,
 		board,
@@ -353,6 +386,6 @@ export const statusCommand = Command.make("status").pipe(
 	]),
 	Command.withShortDescription("Answer what state the factory is in."),
 	Command.withDescription(
-		"Answer what state the factory is in — the composite front-door readout, the resolved `.fabrika.jsonc` config surface, the derived skill roster, the landed-decision digest, the board's bucket counts, and the one primitive that creates a missing surface",
+		"Answer what state the factory is in — the composite front-door readout, the resolved `.fabrika.jsonc` config surface, whether the plugin carrying the skills is enabled here, the derived skill roster, the landed-decision digest, the board's bucket counts, and the one primitive that creates a missing surface",
 	),
 );

--- a/packages/fabrika-cli/src/status/open-verb.ts
+++ b/packages/fabrika-cli/src/status/open-verb.ts
@@ -1,5 +1,5 @@
 /**
- * `status open` — the composite front-door readout: five fields, each with its own state, source
+ * `status open` — the composite front-door readout: six fields, each with its own state, source
  * and freshness.
  *
  * **This verb has no zero-scope seat and no failed-read seat at all.** It is the command the skill
@@ -14,7 +14,7 @@
  * implementer, because that mapping *is* the group's purpose: keeping proven-empty apart from
  * unread.
  *
- * **No aggregate state, deliberately.** A roll-up over four independently-sourced fields would need
+ * **No aggregate state, deliberately.** A roll-up over independently-sourced fields would need
  * a rule for "three fine, one unknown", and every such rule either hides the unknown or drowns the
  * three.
  */
@@ -27,11 +27,12 @@ import {menuState} from "./menu-verb.ts";
 import {type ReadoutRead, readingOf} from "./readout-verb.ts";
 import type {RosterRead} from "./roster.ts";
 import {type SettingRow, settingsState} from "./settings-verb.ts";
+import {SETTINGS_PATH, type WiringRead} from "./wiring-verb.ts";
 
 const VERB = "status open";
 
 /** The closed `--field` vocabulary. Any other value is off-vocabulary. */
-export const FIELDS = ["menu", "settings", "board", "readout", "lanes"] as const;
+export const FIELDS = ["menu", "settings", "wiring", "board", "readout", "lanes"] as const;
 export type FieldName = (typeof FIELDS)[number];
 
 export interface Field {
@@ -97,6 +98,22 @@ export const settingsField = (
 		asOf: rows.length === 0 ? noAsOf : asOf,
 	};
 };
+
+/**
+ * Whether this repo's sessions load fabrika's skills at all — the field the CLI half cannot imply.
+ *
+ * Every other field answers about something the CLI reads, and all of them answered green in the
+ * repo where no skill could load (#6443). A proven-off plugin is `unwired` rather than `unknown`:
+ * the repo proved it, and collapsing it into `unknown` would hide the one gap this field exists to
+ * name.
+ */
+export const wiringField = (read: WiringRead, asOf: AsOf): Field => ({
+	name: "wiring",
+	state: read.state === "unknown" ? UNKNOWN : read.state,
+	detail: read.detail,
+	source: SETTINGS_PATH,
+	asOf: read.state === "unknown" ? noAsOf : asOf,
+});
 
 export const boardField = (read: BoardRead): Field => {
 	if (read._tag === "Failed") {

--- a/packages/fabrika-cli/src/status/wiring-verb.ts
+++ b/packages/fabrika-cli/src/status/wiring-verb.ts
@@ -1,0 +1,250 @@
+/**
+ * `status wiring` — is the fabrika plugin actually enabled in this repo?
+ *
+ * Every other verb in this group answers about something the CLI reads. This one answers about the
+ * *other half*: the plugin that carries the skills. A repo can have the CLI installed and answering
+ * while no fabrika skill can load in a session there, and until this verb existed nothing said so —
+ * demlik ran that way for two days (kamp-us/demlik#26, #6443).
+ *
+ * **The gating fact is `enabledPlugins`, and the marketplace source is the key's own suffix.** A
+ * Claude Code `enabledPlugins` key is `plugin@marketplace`, so one entry names both halves the
+ * wiring needs; a bare `fabrika` key names no source and never resolves. `extraKnownMarketplaces`
+ * is deliberately not read: ADR 0273's 2026-08-16 amendment records that Claude Code never
+ * registers a project-scope `extraKnownMarketplaces` block (verified live on #5705), so a repo
+ * carrying one is no more wired than a repo without, and treating it as evidence would green a
+ * session that loads nothing.
+ *
+ * **It detects and writes nothing.** Creating the file is `status bootstrap`'s registry work
+ * (epic #5979); a probe that repaired what it measured could never report the state it found.
+ */
+
+import {Effect, type FileSystem, type Path, Result} from "effect";
+import {discoverRepoRoot} from "../delegate/root.ts";
+import {exists, readFile} from "../io/fs.ts";
+import {isRecord, parseJsonOrReason} from "../io/json.ts";
+import {answer, refuse, type VerbOutcome} from "../verb.ts";
+import {PRECONDITION_UNKNOWN} from "./codes.ts";
+import {type AsOf, asOfToken, detail, EMPTY_CELL, row} from "./fields.ts";
+
+const VERB = "status wiring";
+
+/** Where a repo declares which plugins its sessions load. */
+export const SETTINGS_PATH = ".claude/settings.json";
+
+/** The plugin half of the `enabledPlugins` key this verb looks for. */
+export const PLUGIN = "fabrika";
+
+/**
+ * The settings file as it was found — the same three arms `../config/source.ts` keeps apart, for a
+ * different file. An absent file is a fact the repo proves; a read that failed proves nothing.
+ */
+export type WiringSource =
+	| {readonly _tag: "Absent"}
+	| {readonly _tag: "Text"; readonly text: string}
+	| {readonly _tag: "Unreadable"; readonly reason: string};
+
+/**
+ * Three states, on the group's three-state law: `wired` is proven on, `unwired` is proven off (an
+ * absent file is proven off — nothing enables a plugin there), and a probe that could not be
+ * performed is `unknown` and never either of the other two.
+ */
+export type WiringState = "wired" | "unwired" | "unknown";
+
+/**
+ * What the probe established. `entry` and `marketplace` are the two halves of the key that decided
+ * it, so a reader can act on the answer without re-opening the file.
+ */
+export interface WiringRead {
+	readonly state: WiringState;
+	/** The `enabledPlugins` key naming fabrika, or `null` when no key names it. */
+	readonly entry: string | null;
+	/** That key's marketplace-source half, or `null` when the key names no source. */
+	readonly marketplace: string | null;
+	/** Why the state is what it is — always populated, including on `wired`. */
+	readonly detail: string;
+}
+
+/** The settings file under `root`. Never fails: an unreadable file is an arm, not an error. */
+export const readWiringSource = (
+	root: string,
+): Effect.Effect<WiringSource, never, FileSystem.FileSystem> =>
+	Effect.gen(function* () {
+		const path = `${root}/${SETTINGS_PATH}`;
+		const probe = yield* Effect.result(exists(path));
+		if (Result.isFailure(probe)) {
+			return {_tag: "Unreadable" as const, reason: `${path}: ${probe.failure.reason}`};
+		}
+		if (!probe.success) return {_tag: "Absent" as const};
+		const text = yield* Effect.result(readFile(path));
+		return Result.isFailure(text)
+			? {_tag: "Unreadable" as const, reason: `${path}: ${text.failure.reason}`}
+			: {_tag: "Text" as const, text: text.success};
+	});
+
+/**
+ * The settings file at the repo root above `cwd`.
+ *
+ * A discovery that *failed* is `Unreadable`, never a fall back to `cwd`: falling back would find no
+ * file there and answer `Absent`, which is the claim "this repo enables nothing" about a repo
+ * nobody located — the same trap `../config/working-root.ts` documents for the config surface.
+ */
+export const repoWiringSource = (
+	cwd: string,
+): Effect.Effect<WiringSource, never, FileSystem.FileSystem | Path.Path> =>
+	Effect.gen(function* () {
+		const root = yield* Effect.result(discoverRepoRoot(cwd));
+		if (root._tag === "Failure") {
+			return {
+				_tag: "Unreadable" as const,
+				reason: `cannot resolve the repo root above ${cwd}: ${root.failure.reason}`,
+			};
+		}
+		return yield* readWiringSource(root.success ?? cwd);
+	});
+
+/** One `enabledPlugins` key, split into the two halves the wiring needs. */
+interface PluginEntry {
+	readonly key: string;
+	readonly marketplace: string | null;
+	readonly value: unknown;
+}
+
+const entriesNamingFabrika = (enabled: Record<string, unknown>): ReadonlyArray<PluginEntry> =>
+	Object.entries(enabled)
+		.map(([key, value]) => {
+			const at = key.indexOf("@");
+			return {
+				key,
+				marketplace: at === -1 ? null : key.slice(at + 1),
+				value,
+				name: at === -1 ? key : key.slice(0, at),
+			};
+		})
+		.filter((one) => one.name === PLUGIN);
+
+const off = (entry: string | null, marketplace: string | null, why: string): WiringRead => ({
+	state: "unwired",
+	entry,
+	marketplace,
+	detail: detail(why),
+});
+
+const unread = (why: string): WiringRead => ({
+	state: "unknown",
+	entry: null,
+	marketplace: null,
+	detail: detail(why),
+});
+
+/** What the bytes say about whether a session in this repo loads fabrika's skills. */
+export const wiringOf = (source: WiringSource): WiringRead => {
+	if (source._tag === "Unreadable") {
+		return unread(`could not read ${SETTINGS_PATH}: ${source.reason}`);
+	}
+	if (source._tag === "Absent") {
+		return off(null, null, `no ${SETTINGS_PATH} — no fabrika skill can load in a session here`);
+	}
+	const parsed = parseJsonOrReason(source.text);
+	if (parsed._tag === "Failed") {
+		return unread(`${SETTINGS_PATH} is not JSON: ${parsed.reason}`);
+	}
+	if (!isRecord(parsed.value)) {
+		return unread(`${SETTINGS_PATH} is not a JSON object, so its plugin block is unread`);
+	}
+	const enabled = parsed.value.enabledPlugins;
+	if (enabled === undefined) {
+		return off(null, null, `${SETTINGS_PATH} declares no enabledPlugins block`);
+	}
+	if (!isRecord(enabled)) {
+		return unread(`${SETTINGS_PATH} declares an enabledPlugins that is not an object`);
+	}
+	const named = entriesNamingFabrika(enabled);
+	if (named.length === 0) {
+		const others = Object.keys(enabled).length;
+		return off(
+			null,
+			null,
+			`enabledPlugins names no ${PLUGIN} entry (${others} other plugin(s)) — the CLI answers, the skills do not exist`,
+		);
+	}
+	const on = named.find((one) => one.value === true);
+	if (on === undefined) {
+		const first = named[0] as PluginEntry;
+		return first.value === false
+			? off(first.key, first.marketplace, `enabledPlugins carries ${first.key} switched off`)
+			: unread(
+					`enabledPlugins carries ${first.key} set to ${JSON.stringify(first.value)} — neither true nor false, so whether the plugin loads is unread`,
+				);
+	}
+	// A key with no `@` half names no marketplace, and Claude Code resolves an `enabledPlugins` key
+	// as `plugin@marketplace` — so it enables nothing however it is spelled.
+	if (on.marketplace === null || on.marketplace === "") {
+		return off(
+			on.key,
+			null,
+			`enabledPlugins carries a bare ${on.key} naming no marketplace source — a key resolves as ${PLUGIN}@<marketplace>`,
+		);
+	}
+	return {
+		state: "wired",
+		entry: on.key,
+		marketplace: on.marketplace,
+		detail: detail(`${on.key} is enabled — sessions in this repo load fabrika's skills`),
+	};
+};
+
+/** How the file itself was found, for the scope line the answer is derived from. */
+const sourceNote = (source: WiringSource): string => {
+	switch (source._tag) {
+		case "Absent":
+			return `no ${SETTINGS_PATH}`;
+		case "Text":
+			return `read ${SETTINGS_PATH}`;
+		case "Unreadable":
+			return `could not read ${SETTINGS_PATH}: ${source.reason}`;
+	}
+};
+
+export interface WiringInput {
+	readonly source: WiringSource;
+	readonly read: WiringRead;
+	/** This invocation's own read of the file — the one fact the answer's freshness comes from. */
+	readonly asOf: AsOf;
+	readonly json: boolean;
+}
+
+/**
+ * **`unwired` is an answer at exit `0`, `unknown` is a refusal.** A proven-off plugin is a fact the
+ * caller acts on — the same seat `status board`'s proven `0` and `status readout`'s `absent` take —
+ * while a probe that could not be performed has no answer to seat, so it refuses on the group's
+ * UNKNOWN code rather than printing a state it did not establish.
+ */
+export const runWiring = ({source, read, asOf, json}: WiringInput): VerbOutcome => {
+	const scope = `${VERB}: ${sourceNote(source)}; plugin ${PLUGIN} is ${read.state}.`;
+	if (read.state === "unknown") {
+		return refuse(
+			PRECONDITION_UNKNOWN,
+			`${VERB}: ${read.detail} — whether a session here loads fabrika's skills is UNKNOWN, never unwired and never green.`,
+			[scope],
+		);
+	}
+	const body = json
+		? JSON.stringify({
+				outcome: read.state,
+				path: SETTINGS_PATH,
+				entry: read.entry,
+				marketplace: read.marketplace,
+				detail: read.detail,
+				asOf: asOf.at,
+				asOfKind: asOf.kind,
+			})
+		: row(
+				"wiring",
+				read.state,
+				read.entry ?? EMPTY_CELL,
+				read.marketplace ?? EMPTY_CELL,
+				read.detail,
+				asOfToken(asOf),
+			);
+	return answer(`${body}\n`, [scope]);
+};

--- a/packages/fabrika-cli/src/status/wiring-verb.unit.test.ts
+++ b/packages/fabrika-cli/src/status/wiring-verb.unit.test.ts
@@ -1,0 +1,207 @@
+/**
+ * `status wiring` in-process: the three states, and that a probe nobody could perform never renders
+ * as the proven negative it did not establish.
+ *
+ * The case that matters is the middle one — a repo where the CLI answers and no skill loads was
+ * green on every other status surface for two days (#6443).
+ */
+import {Effect} from "effect";
+import {describe, expect, it} from "vitest";
+import {fakeFs} from "../fakes.test-support.ts";
+import {ANSWER} from "../verb.ts";
+import {PRECONDITION_UNKNOWN} from "./codes.ts";
+import {readNow} from "./fields.ts";
+import {wiringField} from "./open-verb.ts";
+import {
+	readWiringSource,
+	repoWiringSource,
+	runWiring,
+	SETTINGS_PATH,
+	type WiringSource,
+	wiringOf,
+} from "./wiring-verb.ts";
+
+const AS_OF = readNow("2026-08-20T00:00:00Z");
+const ROOT = "/repo";
+const TARGET = `${ROOT}/${SETTINGS_PATH}`;
+
+const text = (settings: unknown): WiringSource => ({
+	_tag: "Text",
+	text: JSON.stringify(settings),
+});
+
+const run = (source: WiringSource, json = false) =>
+	runWiring({source, read: wiringOf(source), asOf: AS_OF, json});
+
+describe("wiringOf", () => {
+	it("reads a repo whose settings enable fabrika as wired, naming the marketplace source", () => {
+		const read = wiringOf(text({enabledPlugins: {"fabrika@kampus": true, "other@kampus": false}}));
+		expect(read.state).toBe("wired");
+		expect(read.entry).toBe("fabrika@kampus");
+		expect(read.marketplace).toBe("kampus");
+	});
+
+	it("reads an absent settings.json as unwired, not as unknown", () => {
+		const read = wiringOf({_tag: "Absent"});
+		expect(read.state).toBe("unwired");
+		expect(read.detail).toContain("no fabrika skill can load");
+	});
+
+	it("reads a settings.json that enables other plugins but not fabrika as unwired", () => {
+		const read = wiringOf(text({enabledPlugins: {"kampus-pipeline@kampus": true}}));
+		expect(read.state).toBe("unwired");
+		expect(read.entry).toBeNull();
+		expect(read.detail).toContain("1 other plugin(s)");
+	});
+
+	it("reads a fabrika entry switched off as unwired, carrying the key that says so", () => {
+		const read = wiringOf(text({enabledPlugins: {"fabrika@kampus": false}}));
+		expect(read.state).toBe("unwired");
+		expect(read.entry).toBe("fabrika@kampus");
+		expect(read.detail).toContain("switched off");
+	});
+
+	it("reads a settings.json with no enabledPlugins block at all as unwired", () => {
+		const read = wiringOf(text({env: {}}));
+		expect(read.state).toBe("unwired");
+		expect(read.detail).toContain("no enabledPlugins block");
+	});
+
+	/**
+	 * The demlik shape's near miss: an entry naming no marketplace resolves to no plugin, so calling
+	 * it wired would green a session that loads nothing.
+	 */
+	it("reads a bare `fabrika` key naming no marketplace as unwired", () => {
+		const read = wiringOf(text({enabledPlugins: {fabrika: true}}));
+		expect(read.state).toBe("unwired");
+		expect(read.entry).toBe("fabrika");
+		expect(read.marketplace).toBeNull();
+		expect(read.detail).toContain("no marketplace source");
+	});
+
+	it("reads a file it could not open as unknown, carrying the reason", () => {
+		const read = wiringOf({_tag: "Unreadable", reason: "EACCES: permission denied"});
+		expect(read.state).toBe("unknown");
+		expect(read.detail).toContain("EACCES");
+	});
+
+	it("reads bytes that are not JSON as unknown, never unwired", () => {
+		const read = wiringOf({_tag: "Text", text: "{ not json"});
+		expect(read.state).toBe("unknown");
+		expect(read.entry).toBeNull();
+	});
+
+	it("reads a settings.json that is not a JSON object as unknown", () => {
+		expect(wiringOf({_tag: "Text", text: "[]"}).state).toBe("unknown");
+	});
+
+	it("reads a non-object enabledPlugins as unknown", () => {
+		expect(wiringOf(text({enabledPlugins: "fabrika"})).state).toBe("unknown");
+	});
+
+	it("reads a fabrika entry that is neither true nor false as unknown", () => {
+		const read = wiringOf(text({enabledPlugins: {"fabrika@kampus": "yes"}}));
+		expect(read.state).toBe("unknown");
+		expect(read.detail).toContain("neither true nor false");
+	});
+});
+
+describe("runWiring", () => {
+	it("answers the wired state on one line at exit 0", () => {
+		const outcome = run(text({enabledPlugins: {"fabrika@kampus": true}}));
+		expect(outcome.code).toBe(ANSWER);
+		expect(outcome.stdout.split("\t").slice(0, 4)).toEqual([
+			"wiring",
+			"wired",
+			"fabrika@kampus",
+			"kampus",
+		]);
+		expect(outcome.stdout).toContain("2026-08-20T00:00:00Z");
+	});
+
+	it("answers the proven negative at exit 0 with `unwired` on stdout", () => {
+		const outcome = run({_tag: "Absent"});
+		expect(outcome.code).toBe(ANSWER);
+		expect(outcome.stdout.startsWith("wiring\tunwired\t-\t-\t")).toBe(true);
+		expect(outcome.stderr.join(" ")).toContain("is unwired");
+	});
+
+	it("refuses an unperformable probe on 11 with NOTHING on stdout", () => {
+		const outcome = run({_tag: "Unreadable", reason: "EISDIR"});
+		expect(outcome.code).toBe(PRECONDITION_UNKNOWN);
+		expect(outcome.stdout).toBe("");
+		expect(outcome.stderr.join(" ")).toContain("UNKNOWN, never unwired and never green");
+	});
+
+	it("emits the result object under --json", () => {
+		const outcome = run(text({enabledPlugins: {"fabrika@kampus": true}}), true);
+		expect(JSON.parse(outcome.stdout)).toMatchObject({
+			outcome: "wired",
+			path: SETTINGS_PATH,
+			entry: "fabrika@kampus",
+			marketplace: "kampus",
+		});
+	});
+});
+
+describe("the wiring field inside status open", () => {
+	it("carries a proven-off plugin as `unwired`, not as the composite's `unknown`", () => {
+		const field = wiringField(wiringOf({_tag: "Absent"}), AS_OF);
+		expect(field.state).toBe("unwired");
+		expect(field.source).toBe(SETTINGS_PATH);
+		expect(field.asOf.at).toBe(AS_OF.at);
+	});
+
+	it("drops the freshness token when the probe could not be performed", () => {
+		const field = wiringField(wiringOf({_tag: "Unreadable", reason: "EACCES"}), AS_OF);
+		expect(field.state).toBe("unknown");
+		expect(field.asOf.at).toBeNull();
+	});
+});
+
+describe("the read itself", () => {
+	const open = (options: Parameters<typeof fakeFs>[0], root = ROOT) => {
+		const fs = fakeFs(options);
+		return Effect.runPromise(Effect.provide(readWiringSource(root), fs.layer)).then((found) => ({
+			found,
+			written: fs.written,
+		}));
+	};
+
+	it("reads the file under the named root and writes nothing", async () => {
+		const {found, written} = await open({
+			files: {[TARGET]: '{"enabledPlugins":{"fabrika@kampus":true}}'},
+		});
+		expect(wiringOf(found).state).toBe("wired");
+		expect(written.size).toBe(0);
+	});
+
+	it("reports an absent file as Absent and writes nothing", async () => {
+		const {found, written} = await open({directories: [ROOT]});
+		expect(found._tag).toBe("Absent");
+		expect(written.size).toBe(0);
+	});
+
+	it("reports a file it could not open as Unreadable, never as Absent", async () => {
+		const {found} = await open({files: {[TARGET]: "{}"}, unreadable: [TARGET]});
+		expect(found._tag).toBe("Unreadable");
+	});
+
+	it("reports a probe that itself failed as Unreadable", async () => {
+		const {found} = await open({unprobeable: [TARGET]});
+		expect(found._tag).toBe("Unreadable");
+	});
+
+	/**
+	 * A repo root nobody could locate must not fall back to the cwd: finding no file there would
+	 * answer "this repo enables nothing" about a repo that was never opened.
+	 */
+	it("reports an unresolvable repo root as Unreadable, never as an absent settings.json", async () => {
+		const fs = fakeFs({unprobeable: ["/nowhere/deep/package.json"]});
+		const found = await Effect.runPromise(
+			Effect.provide(repoWiringSource("/nowhere/deep"), fs.layer),
+		);
+		expect(found._tag).toBe("Unreadable");
+		expect(wiringOf(found).state).toBe("unknown");
+	});
+});


### PR DESCRIPTION
`fabrika status` grows a `wiring` verb and a sixth `status open` field that answer one question no
other status surface covers: does `.claude/settings.json` actually enable the fabrika plugin here?

Every other verb in the group answers about something the CLI reads, and the CLI reads fine in a
repo where no fabrika skill can load in a session. That is the demlik shape (kamp-us/demlik#26) —
two days of green status surfaces over a repo whose skill half did not exist.

**What it reads.** The `enabledPlugins` key naming fabrika. A Claude Code key is
`plugin@marketplace`, so that one entry carries both the plugin and the marketplace source. It does
not read `extraKnownMarketplaces`: ADR 0273's 2026-08-16 amendment records that Claude Code never
registers a project-scope block (verified live on #5705), so treating one as evidence would green a
session that loads nothing.

**What it answers.** `wired` when a `fabrika@<marketplace>` key is `true`. `unwired` — at exit 0, a
fact the caller acts on — when the file is absent, declares no `enabledPlugins`, names no fabrika
entry, carries one switched off, or carries a bare `fabrika` key naming no marketplace. `unknown`
(exit 11, nothing on stdout) when the probe could not be performed: an unresolvable repo root, an
unreadable file, bytes that are not a JSON object, a non-object `enabledPlugins`, or an entry that
is neither `true` nor `false`.

It detects only. Creating the file stays #5979's `BUILDABLE_SURFACES` work, and this probe is its
companion: a repo that never runs bootstrap still needs the answer.

Reviewer's first stop: `packages/fabrika-cli/src/status/wiring-verb.ts` — the state table in
`wiringOf` is where the proven-negative/unread line is drawn, and `wiring-verb.unit.test.ts` walks
every arm of it.

## Deviations

- **Out-of-scope change** — **Said:** #6443 names the probe, its states, and its unit coverage.
  **Did:** also corrected two `status open` sample transcripts in
  `claude-plugins/fabrika/guide/getting-started.md` and the front-door contract that were already
  stale before this change — the guide still printed a retired `config` field and both showed a
  four/five-field readout. **Why:** the field count is what this change moves, so those blocks had
  to be rewritten anyway, and leaving a known-wrong row inside a block I was editing would ship a
  transcript no run produces. **Disposition:** stated here.
- **Out-of-scope change** — **Said:** the issue's pointers name `status config` and
  `packages/fabrika-cli/src/status/config-verb.ts` / `required-files.ts` as the landing site.
  **Did:** landed a new `status wiring` verb plus a `wiring` field on `status open` instead. **Why:**
  those files no longer exist — the `## Required repo files` declaration surface and its reader
  retired in #6301 (ADR 0273's 2026-08-19 amendment) and moved to `.fabrika.jsonc`'s
  `surfaceDispositions`. The issue names the sub-verb as the sanctioned alternative landing.
  **Disposition:** stated here.

Fixes #6443
