### PR TITLE
chore: skill-conventions §7 names an .out-of-scope/ directory that does not exist

### DIFF
--- a/claude-plugins/fabrika/docs/skill-conventions.md
+++ b/claude-plugins/fabrika/docs/skill-conventions.md
@@ -213,19 +213,27 @@ A criterion carries two independent properties, and conflating them costs one of
 > Source: [#4644](https://github.com/kamp-us/phoenix/issues/4644) adopt-list item 2 (the
 > completion-criterion lever from the reference's glossary at `2ab9580`).
 
-## 7. The scope law — `.out-of-scope/`
+## 7. The scope law — recording a rejection
 
-**A rejected proposal is recorded, with its reasoning, so it stops being re-proposed.** fabrika
-keeps an `.out-of-scope/` directory at the plugin root: one file per rejected proposal, named for
-the proposal, stating what is out of scope, **why**, and what prior requests asked for it.
+**A rejected proposal is recorded, with its reasoning, so it stops being re-proposed.** One entry
+per rejected proposal, named for the proposal, stating what is out of scope, **why**, and what prior
+requests asked for it.
 
 This is a first-class scope law rather than a courtesy. An unrecorded rejection is one the next
 session re-derives from zero and may re-decide differently; a recorded one is a decision that holds
 without anyone remembering it. It is the same instinct as `.decisions/` — the repo's ADRs record
-what *was* decided, and `.out-of-scope/` records what was decided **against** at the skill layer.
+what *was* decided, and this records what was decided **against** at the skill layer.
 
 A rejection belongs here when it is a real proposal someone could plausibly make again — not every
 idea that was passed over in an authoring session.
+
+**An entry lives in its skill's own [`contract.md`](../skills/report/contract.md), under a
+*Considered and deliberately not derived* section.** The adoption source below names a plugin-root
+`.out-of-scope/` directory instead — one file per rejection — and that directory does not exist:
+the corpus-wide build was declined once
+([#5667](https://github.com/kamp-us/phoenix/issues/5667), closed not-planned), so the contract
+sections are the home until a founder re-opens it. What a build would move is where an entry lives,
+never whether one is written.
 
 > Source: [#4644](https://github.com/kamp-us/phoenix/issues/4644) adopt-list item 4, grounded in
 > the reference's `.out-of-scope/` at `2ab9580`.


### PR DESCRIPTION
Fixes #6561

Section 7 of `claude-plugins/fabrika/docs/skill-conventions.md` claimed in present tense that fabrika keeps an `.out-of-scope/` directory at the plugin root. It does not — `ls claude-plugins/fabrika/.out-of-scope` fails, and nothing in the tree matches the name.

This takes the default resolution the issue names: amend §7 so it reads true. **It does not build the directory** — that corpus-wide build was #5667's scope, and the founder declined it there (closed not-planned, 2026-08-19).

What changed:

- The heading no longer names a directory that does not exist.
- §7 now states where a rejection actually goes today: the skill's own `contract.md`, under a *Considered and deliberately not derived* section, linked to `report/contract.md` as the worked example. Eighteen files in the corpus already carry that section, and three contracts (`triage`, `review-ui`, `plan-epic`) already describe `.out-of-scope/` as unbootstrapped — §7 was the one surface out of step.
- The `.out-of-scope/` shape is kept as the adoption source's proposal with #5667's declined status attached, so the law still binds and a future build has its context.

The map-level out-of-scope section in `wayfinding` is real (`fabrika map descope` writes it) and is untouched.

## Deviations

None.
