### PR TITLE
chore: agent-shells.md lists an effort: field no shell carries

### DIFF
--- a/.decisions/0280-review-shell-carries-the-spawn-tool.md
+++ b/.decisions/0280-review-shell-carries-the-spawn-tool.md
@@ -1,7 +1,7 @@
 ---
 id: 0280
 title: The review agent shell carries the spawn tool; the driver plans no governance stage
-status: accepted
+status: amended-in-part by [0311](0311-every-agent-shell-carries-the-spawn-tool.md)
 date: 2026-08-14
 tags: [pipeline, fabrika, governance, review, agents]
 ---

--- a/.decisions/0310-no-agent-shell-pins-effort.md
+++ b/.decisions/0310-no-agent-shell-pins-effort.md
@@ -1,0 +1,97 @@
+---
+id: 0310
+title: No agent shell pins effort, and no caller passes one either
+status: accepted
+date: 2026-08-20
+tags: [pipeline, fabrika, agents]
+---
+
+# 0310 — No agent shell pins effort, and no caller passes one either
+
+**What this decides:** the fabrika agent shells leave the `effort:` field off their frontmatter, and
+a driver spawning one does not pass an effort of its own. A spawn runs at whatever effort the
+spawning session is set to.
+
+## Context
+
+`effort: high` sat in the frontmatter of `builder`, `reviewer` and `shipper` with no surface arguing
+for the value, and `claude-plugins/fabrika/docs/agent-shells.md` listed `effort:` as one of the four
+things a shell holds without ever saying what value or why. That is the exact thing the same doc
+bans one paragraph later: *"a shell that grows opinions is a defect."*
+
+[#5669](https://github.com/kamp-us/phoenix/issues/5669) opened on that mismatch and the founder ruled
+the field comes off, verbatim on 2026-08-15:
+
+> reviewer is fine but i wanna drop from builder as well. i find more than medium to be diminishing
+> returns + being able to dynamically set effort levels are better
+
+The first reading of that was "unpin it so a driver sets it per call", and the driving session
+started passing an explicit `effort` on the builder and shipper stages of a driver script. The
+founder corrected that immediately, verbatim:
+
+> dont set it dont. setting these type of values comes with a price of silent changes in the llm
+> pipeline.
+
+So the ruling is *omit the field*, not *relocate it*. Then the reviewer carve-out — a gate should not
+think less because whoever spawned it was in a hurry — was proposed and the founder extended the
+ruling instead of taking it, verbatim: *"yeah, remove from reviewer as well."* The 2026-08-16
+restatement that PR [#5693](https://github.com/kamp-us/phoenix/pull/5693) implemented covers both
+halves at once: *remove effort levels + allow Agent tool in all agents* (the second half is ADR
+[0311](0311-every-agent-shell-carries-the-spawn-tool.md)).
+
+The premise the ruling rests on was checked against the platform rather than assumed, and the finding
+is on #5669: on Claude Code 2.1.233 an omitted `effort:` **inherits the spawning session's** effort.
+It is a documented frontmatter field taking `low | medium | high | xhigh | max`, the session value has
+four entry points (`/effort`, `--effort`, the `effortLevel` setting, `CLAUDE_CODE_EFFORT_LEVEL`), and
+the session default is `high`. So dropping the pin does not swap one fixed value for a different fixed
+value; it moves the value from three files nobody reads to one place the operator sets.
+
+PR #5693 dropped all three pins on 2026-08-16 and nothing recorded the rule. The doc kept listing the
+field for four days, which is what [#6558](https://github.com/kamp-us/phoenix/issues/6558) is fixing —
+and an inventory naming the pin is exactly how the next shell author re-adds it.
+
+## Decision
+
+**No agent shell under [`claude-plugins/fabrika/agents/`](../claude-plugins/fabrika/agents/) declares
+`effort:`, and no driver passes an explicit effort when spawning one.**
+
+The reason is invisibility, not the value. A pinned effort changes model behaviour with nothing
+surfacing the change: no gate reds, no output looks different, and the person reading the result
+cannot tell the setting was in play. That argument does not weaken for a gate shell, which is why the
+reviewer carve-out was refused rather than kept. An unset field inherits the session, which is at
+least one value the operator can see and set, instead of two disagreeing ones.
+
+**Binding constraints.**
+- Every shell's frontmatter omits `effort:` entirely. An absent field is the correct state, not a
+  gap waiting to be filled.
+- A driver spawning a shell passes no effort argument. The session's own setting is the only input.
+- `agent-shells.md`'s field inventory lists what a shell actually holds, so the doc cannot reintroduce
+  the pin by describing it.
+
+**Banned.**
+- Re-adding `effort:` to any shell, including a "just this one is different" carve-out for a gate.
+- A driver, script or spawn brief that sets effort per call — the relocation the founder refused.
+- Setting `effort:` on a fabrika `SKILL.md`, which takes the same field with the same inheritance and
+  would pin the value one layer down instead.
+
+## Consequences
+
+1. Effort becomes one operator-visible setting rather than three frontmatter lines. A run left at the
+   session default behaves exactly as the pinned shells did, so nothing changed at ruling time except
+   who can see the value.
+2. A shell reading "high" no longer contradicts a session running "medium". The pin is not overridable
+   from the caller, so the two-disagreeing-values state is gone rather than resolved.
+3. A shell author who wants a different effort for one stage has no in-repo lever. That is the point;
+   the lever is the session, and wanting a per-stage one is the case this ADR refuses.
+
+## Records
+
+- Records the founder rulings of 2026-08-15 and 2026-08-16 on
+  [#5669](https://github.com/kamp-us/phoenix/issues/5669), verbatim above.
+- Implemented by PR [#5693](https://github.com/kamp-us/phoenix/pull/5693); recorded here four days
+  late, on [#6558](https://github.com/kamp-us/phoenix/issues/6558).
+- Its sibling half is ADR [0311](0311-every-agent-shell-carries-the-spawn-tool.md); the two rulings
+  arrived together and landed on one PR.
+- No vocabulary impact. *Agent shell* is defined in
+  [`claude-plugins/fabrika/docs/agent-shells.md`](../claude-plugins/fabrika/docs/agent-shells.md) and
+  is not coined here.

--- a/.decisions/0311-every-agent-shell-carries-the-spawn-tool.md
+++ b/.decisions/0311-every-agent-shell-carries-the-spawn-tool.md
@@ -1,0 +1,90 @@
+---
+id: 0311
+title: Every agent shell carries the spawn tool, not the reviewer alone
+status: accepted
+date: 2026-08-20
+tags: [pipeline, fabrika, agents, governance]
+---
+
+# 0311 — Every agent shell carries the spawn tool, not the reviewer alone
+
+**What this decides:** every fabrika agent shell declares `Agent` in its `tools:` set, so any of them
+can spawn a subagent. ADR [0280](0280-review-shell-carries-the-spawn-tool.md)'s grant to the reviewer
+still stands and still has its own reason; it is no longer the only grant.
+
+## Context
+
+ADR [0280](0280-review-shell-carries-the-spawn-tool.md) gave the spawn tool to the review shell for
+one named reason: `review`'s own SKILL.md §6 makes the `governance` namespace derived-required on a
+governed diff — fire `governance` and wait — and spike
+[#5554](https://github.com/kamp-us/phoenix/issues/5554) dead-ended at `ns governance absent` because
+its shell could not obey that instruction. The grant there is "the ability to obey what the skill
+already says", and that argument reached exactly one shell because at the time exactly one shell had
+a named need.
+
+**0280 grants; it does not prohibit.** Nothing in `.decisions/` banned a spawn tool on the others —
+the narrow builder and shipper tool sets came from
+[#5586](https://github.com/kamp-us/phoenix/issues/5586)'s rule that each shell declares an explicit
+scoped set, and a scoped set is scoped to need, not to a prohibition.
+
+[#5686](https://github.com/kamp-us/phoenix/issues/5686) filed the widening on 2026-08-16 against a
+read of `main`: `builder` carried no `Agent`, `shipper` carried neither `Agent` nor `Skill`, and
+`reviewer` and the then-in-flight `operator` both carried `Agent`. The founder ruled the same night,
+in one sentence covering two changes: *remove effort levels + allow Agent tool in all agents* (the
+first half is ADR [0310](0310-no-agent-shell-pins-effort.md)). PR
+[#5693](https://github.com/kamp-us/phoenix/pull/5693) landed it. The `triager` shell, added after,
+carries `Agent` from birth.
+
+Neither ruling was recorded. A reader landing on 0280 first therefore infers "reviewer only" is the
+standing law, which was true for two days and is not true now —
+[#6558](https://github.com/kamp-us/phoenix/issues/6558) is the re-file that closes that gap.
+
+## Decision
+
+**Every agent shell under [`claude-plugins/fabrika/agents/`](../claude-plugins/fabrika/agents/)
+declares the harness spawn tool, `Agent`, in its `tools:` set.**
+
+The grant is a tool and nothing more, on exactly 0280's terms: no judgement moves into the shell, no
+pipeline step, no rubric, no opinion. A shell's body still says only that it is a seat for one skill.
+What a shell may spawn, and when, stays written in the skill it loads.
+
+0280's reason for the reviewer's grant is **not** replaced by this one. The governance
+derived-required rule is still why review specifically cannot function without a spawn tool; this ADR
+adds a second, weaker reason that covers the rest — a role shell that cannot delegate has to do every
+sub-question in its own context, and none of the skills is written on the premise that it must.
+
+**Binding constraints.**
+- A new shell declares `Agent` at creation. It is part of the baseline set, not a grant to argue for.
+- The widening is tools only. A shell that grows an instruction telling it *when* to spawn is the
+  defect `agent-shells.md` names, whatever its tool set.
+- `agent-shells.md`'s spawn-tool section names what the shells at head actually carry, and keeps
+  0280's reviewer reason rather than flattening it into "everyone has it".
+
+**Banned.**
+- Reading 0280 as a prohibition on the other shells. It never was one, and this ADR amends it in part
+  so the file itself says so.
+- Removing `Agent` from a shell on the argument that its skill does not spawn today.
+
+## Consequences
+
+1. A shell's tool set stops encoding "has a named need to spawn". The signal moves to the skill text,
+   which is where the eval bar can see it.
+2. The widening is real: every shell can now reach anything a subagent can reach. That trade was
+   already accepted for the reviewer in 0280 — a spawn tool widens what a shell can reach, contained
+   by the fact that no matching instruction ships with it — and it is accepted on the same terms here.
+3. 0280 stays live and cited for the governance route. Its status line becomes `amended-in-part` so a
+   reader landing there is sent here for the shell inventory.
+
+## Records
+
+- Records the founder ruling of 2026-08-16 on
+  [#5686](https://github.com/kamp-us/phoenix/issues/5686), relayed on
+  [#5669](https://github.com/kamp-us/phoenix/issues/5669#issuecomment-5309803937), verbatim: *remove
+  effort levels + allow Agent tool in all agents*.
+- Amends in part ADR [0280](0280-review-shell-carries-the-spawn-tool.md), which decided the reviewer's
+  grant and the no-conditional-governance-stage routing. Only the "review shell alone" scope is
+  amended; the governance routing and the reviewer's own reason stand.
+- Its sibling half is ADR [0310](0310-no-agent-shell-pins-effort.md); the two rulings arrived together
+  and landed on one PR.
+- No vocabulary impact. *Agent shell* and *spawn tool* are both defined in
+  [`claude-plugins/fabrika/docs/agent-shells.md`](../claude-plugins/fabrika/docs/agent-shells.md).

--- a/claude-plugins/fabrika/docs/agent-shells.md
+++ b/claude-plugins/fabrika/docs/agent-shells.md
@@ -5,11 +5,17 @@ An **agent shell** is a behaviour-free agent definition under
 loaded. It is not the phoenix UI `Shell` (`SubnavShell` / `PageShell`, ADR 0182) — that word is
 taken in phoenix prose, so this surface is always written **agent shell** in full.
 
-A shell holds four things and nothing else: a `skills:` preload naming the one plugin-namespaced
-skill it exists to run, a `tools:` set scoped to what that skill actually calls, an `effort:`
-setting, and a `description:` saying when to spawn it. All judgement — every step, rubric,
-acceptance test and terminal token — lives in the preloaded skill, which is the surface the eval
-bar gates.
+A shell holds three things and nothing else, over the `name:` that is its address: a `skills:`
+preload naming the one plugin-namespaced skill it exists to run, a `tools:` set scoped to what that
+skill actually calls, and a `description:` saying when to spawn it. `model:` is the one optional
+field, governed by the allowlist below. All judgement — every step, rubric, acceptance test and
+terminal token — lives in the preloaded skill, which is the surface the eval bar gates.
+
+**No shell pins `effort:`, and no driver passes one when spawning a shell** — ADR
+[0310](../../../.decisions/0310-no-agent-shell-pins-effort.md), founder ruling of 2026-08-15
+extended 2026-08-16. A pinned effort changes model behaviour with nothing surfacing the change: no
+gate reds, no output looks different, and a reader cannot tell the setting was in play. An omitted
+field inherits the spawning session's effort, so the value stays in one place the operator can see.
 
 **A shell that grows opinions is a defect.** An instruction in a shell body is behaviour that never
 faces the evals, and it silently forks from the skill the moment the skill changes. Anything you
@@ -87,28 +93,35 @@ caller's own model whenever the pin is sane.
 
 ## Which shells carry a spawn tool
 
-`reviewer` and `operator` carry the harness spawn tool, `Agent`. For the operator the spawn tool
-is the skill itself: every route in the `operate` loop
-([`../skills/operate/SKILL.md`](../skills/operate/SKILL.md)) is a spawn of one of the other
-shells, so a spawn-less operator drives nothing.
-[#5686](https://github.com/kamp-us/phoenix/issues/5686) records the founder's 2026-08-16
-direction that every role shell should be able to spawn subagents — the retired pipeline-crew's
-over-restricted tool sets are the named failure mode — but builder and shipper keep their current
-sets until that filing is triaged and built.
+Every shell does. `builder`, `reviewer`, `shipper`, `operator` and `triager` each declare the
+harness spawn tool, `Agent`, in `tools:` — founder ruling of 2026-08-16 on
+[#5686](https://github.com/kamp-us/phoenix/issues/5686), that every role shell should be able to
+spawn subagents, with the retired pipeline-crew's over-restricted tool sets as the named failure
+mode. ADR [0311](../../../.decisions/0311-every-agent-shell-carries-the-spawn-tool.md) records it.
+The grant is baseline, so a new shell declares `Agent` at creation rather than arguing for it.
 
-For the reviewer the grant is a tool grant and nothing more: the behaviour stays in
+**Read `tools:` in [`../agents/`](../agents/) for what a shell carries, not this paragraph.** The
+definitions are the statement; a doc is a summary of them, and it is a summary that has already
+drifted once.
+
+The reviewer's grant came first and rests on its own reason, which is why ADR
+[0280](../../../.decisions/0280-review-shell-carries-the-spawn-tool.md) still stands and is only
+amended in part. For the reviewer the grant is a tool grant and nothing more: the behaviour stays in
 [`../skills/review/SKILL.md`](../skills/review/SKILL.md) §6, which makes the `governance` namespace
 **derived-required** on a `governance: required` diff — fire the `governance` skill, wait for it, and never
 emit that namespace yourself. Without a spawn tool the shell derives that requirement mid-run and
 dead-ends, leaving the PR with a governance check nothing in the run can clear. The grant only lets
 the shell obey an instruction it already carried. Founder ruling of 2026-08-14 on
 [#5558](https://github.com/kamp-us/phoenix/issues/5558), verbatim *"yeah, review shell carries the
-spawn tool"*. Its decision record is ADR
-[0280](../../../.decisions/0280-review-shell-carries-the-spawn-tool.md), which predates the noun
-rename and calls this shell `review`.
+spawn tool"*. 0280 predates the noun rename and calls this shell `review`; 0311 widens who holds the
+tool and nothing else.
 
-`builder` and `shipper` get no spawn tool: neither skill invokes another agent. The `ship` skill
-routes by writing a `ship note` and stopping, so `shipper` holds no `Skill` grant either.
+For the operator the spawn tool is the skill itself: every route in the `operate` loop
+([`../skills/operate/SKILL.md`](../skills/operate/SKILL.md)) is a spawn of one of the other shells,
+so a spawn-less operator drives nothing.
+
+A spawn tool is not a `Skill` grant. `shipper` holds none: the `ship` skill routes by writing a
+`ship note` and stopping.
 
 Write the tool's canonical name, `Agent` — the `name` on the spawn tool in the Claude Code 2.1.233
 bundle, which also carries `aliases: ["Task"]`. Both strings grant the tool (a shell built with


### PR DESCRIPTION
Fixes #6558

`claude-plugins/fabrika/docs/agent-shells.md` described the shells as they were before PR #5693.
Two claims were false at head: the field inventory listed an `effort:` setting no shell carries, and
the spawn-tool section said only `reviewer` and `operator` hold `Agent` while `builder` and `shipper`
hold none. All five shells carry `Agent` today. This re-grounds both against
`claude-plugins/fabrika/agents/*.md` and records the two rulings that were never written down.

**The rulings land as two new ADRs, not as an amendment on 0280.** They are two separate decisions —
what a shell may pin, and who holds the spawn tool — and the `adr` skill is one decision per file.
0280 also decides a second thing this issue does not touch (the driver plans no conditional
governance stage), so folding a tool-set widening into it would have buried that.

- ADR 0310 — no shell pins `effort:` and no driver passes one, from the #5669 rulings and the
  platform check on that issue (an omitted `effort:` inherits the spawning session's, Claude Code
  2.1.233).
- ADR 0311 — every shell carries `Agent`, from the #5686 ruling. It amends 0280 **in part**, via
  `fabrika adr amend-in-part`, so 0280's status line now points here and a reader landing there first
  is not left with "reviewer only". 0280's own reason for the reviewer's grant — review's SKILL.md §6
  makes `governance` derived-required, so a spawn-less reviewer dead-ends — survives in both the ADR
  and the doc.

## Deviations

- **Known defect left unfixed** — **Said:** the criteria cover the field inventory and the
  spawn-tool section. **Did:** left `## Why exactly four`, "Fabrika's four shells", "every adopting
  repo inherits all four", "Pick a fifth for…" and "All four shells today leave it unset" as they
  are, so the doc now names five shells in one section and argues four in the others. **Why:** the
  count turns on a founder call that #6437 is already open and awaiting a human on — whether
  `triager` is a legitimate fifth shell or was landed against the standing ruling. A builder cannot
  settle that. **Disposition:** noted on #6437
  (https://github.com/kamp-us/phoenix/issues/6437#issuecomment-5360172674) so whoever rules sees what
  this PR changed.
- **Out-of-scope change** — **Said:** #6558 names the two drifted sections. **Did:** the inventory
  paragraph also gained the *reason* effort is unpinned, and a line telling the reader to read
  `tools:` in `../agents/` rather than trust the paragraph. **Why:** a bare deletion is what let the
  field come back — the doc's job is to stop the next shell author re-adding the pin, and a summary
  that has already drifted once should say it is a summary. **Disposition:** stated here.
- **Pre-existing defect left unfixed** — **Said:** every reference added must resolve. **Did:** the
  doc's existing citation of ADR 0195 ("The address is the bare noun") is untouched, and 0195 is
  `superseded by 0279` per `fabrika adr resolve`. **Why:** not a reference this PR adds, and
  re-homing that claim means finding where the bare-`name:` platform fact now lives, which is its own
  read. **Disposition:** noted here, not filed — it sits inside the same doc #6437 is already
  queued to rewrite.
