### PR TITLE
chore: governed-roots.ts docblocks still promise threading that #6296 already landed

### DIFF
--- a/packages/fabrika-cli/src/config/keys/governed-roots.ts
+++ b/packages/fabrika-cli/src/config/keys/governed-roots.ts
@@ -11,8 +11,9 @@
  * at all refuses it too, since an unusable root list un-governs the config just as effectively
  * (#6314).
  *
- * This module ships the key, its default and that refusal. Threading it into `review/classes.ts` and
- * `governance scope`, and the rest of the path surface, is #6296's.
+ * This module ships the key, its default and that refusal, and every path surface that derives the
+ * namespace reads it from here through `config/paths.ts`'s `governedRootsOr` — `review scope`,
+ * `governance scope` and `post`, the three `ship` verbs, `heal-ci`, `lane prove`.
  */
 
 import {CONFIG_PATH} from "../document.ts";
@@ -22,9 +23,9 @@ import type {Decoded, KeyGroup} from "../key-group.ts";
 export const GOVERNED_ROOTS = "governedRoots";
 
 /**
- * Phoenix's four roots, plus the config file. Kept in step with
- * `packages/fabrika-cli/src/review/classes.ts`'s `GOVERNANCE_ROOTS` until #6296 threads that site
- * onto this key and the literal goes away.
+ * Phoenix's four roots, plus the config file — the one copy of the list.
+ * `packages/fabrika-cli/src/review/classes.ts` re-exports this binding rather than holding a second
+ * literal, so a caller with no config load in reach still lands on this value.
  */
 export const SHIPPED_GOVERNED_ROOTS: ReadonlyArray<string> = [
 	".decisions/",


### PR DESCRIPTION
Fixes #6455

Two docblocks in `packages/fabrika-cli/src/config/keys/governed-roots.ts` were written in the future tense about threading that already landed. They pointed a reader at a `GOVERNANCE_ROOTS` literal in `review/classes.ts` that no longer exists — the only `GOVERNANCE_ROOTS` name left in the tree is a test-local import alias.

Rewritten in the present tense. The module docblock now names where the key is actually read (`config/paths.ts`'s `governedRootsOr`, feeding `review scope`, `governance scope`/`post`, the three `ship` verbs, `heal-ci`, `lane prove`), and the `SHIPPED_GOVERNED_ROOTS` docblock says `review/classes.ts` re-exports this binding instead of holding a second literal.

Comment-only. No production source outside the two docblocks changed; the tests keep their alias untouched.

Verified in this tree: `pnpm typecheck` and `pnpm lint:worktree` green via `build check --surface code` with nothing unvalidated, and `pnpm --filter @kampus/fabrika-cli test` at 425 files / 7149 tests passing.

## Deviations

None.
