### PR TITLE
fix: A boot/session divergence leaves the topbar with no sign-in affordance at all

### DIFF
--- a/apps/web/src/App.test.tsx
+++ b/apps/web/src/App.test.tsx
@@ -247,6 +247,23 @@ describe("signed-in cluster seeded from __BOOT__.user (ADR 0185)", () => {
 		expect(screen.getByText("Elif")).toBeTruthy();
 	});
 
+	// #6577: the edge resolved a user the settled session denies. The account slot collapses (no
+	// pill, no placeholder), so the CTA must come back — otherwise the shell offers no sign-in
+	// path at all and the viewer reads it as broken rather than signed out.
+	it("__BOOT__ present but the session settles signed-out: giriş-yap returns and the account slot is empty", () => {
+		flags.signedIn = true;
+		renderApp(FATE_FREE_ROUTE);
+		expect(screen.queryByRole("button", {name: "giriş yap"})).toBeNull();
+
+		act(() => {
+			setSession({data: null, isPending: false});
+		});
+
+		expect(screen.getByRole("button", {name: "giriş yap"})).toBeTruthy();
+		expect(screen.queryByText("Elif")).toBeNull();
+		expect(screen.queryByTestId("topbar-user-placeholder")).toBeNull();
+	});
+
 	it("__BOOT__ absent (readBootUser null): the shell is exactly as today — giriş-yap, no account cluster (AC-3)", () => {
 		renderApp();
 		expect(screen.getByRole("button", {name: "giriş yap"})).toBeTruthy();

--- a/apps/web/src/App.tsx
+++ b/apps/web/src/App.tsx
@@ -127,11 +127,15 @@ function Layout() {
 	// `__BOOT__` this is null and the session-gated `isSignedIn` governs.
 	const bootUser = readBootUser();
 	const bootSignedIn = bootUser != null;
-	const signedInAtFirstPaint = bootSignedIn || isSignedIn;
 	// Reserve the account slot only while the edge said signed-in AND we haven't settled to a
 	// definitively signed-out session — so an absent `__BOOT__` never reserves (today's render)
 	// and a boot/session divergence collapses cleanly rather than stranding a phantom slot.
 	const reserveSignedInSlots = bootSignedIn && (session.isPending || isSignedIn);
+	// Both halves of the account side hang off that one condition, so they can never collapse in
+	// opposite directions: the CTA is suppressed exactly while the slot is filled or reserved.
+	// Keying it off `__BOOT__` alone left a boot/session divergence showing neither the pill nor
+	// the CTA, a shell with no way to sign in (#6577).
+	const showSignInCta = !isSignedIn && !reserveSignedInSlots;
 	const bootUserProps = bootUser
 		? {
 				user: {
@@ -180,7 +184,7 @@ function Layout() {
 							actions={
 								// Suppressed from the first frame for a signed-in user so the CTA never flashes
 								// then swaps out (#2933) — see ADR 0185.
-								!signedInAtFirstPaint ? (
+								showSignInCta ? (
 									<Button
 										type="button"
 										variant="secondary"


### PR DESCRIPTION
On a boot/session divergence — the edge-resolved `window.__BOOT__.user` says signed-in, but the settled BetterAuth client session says signed-out — the topbar rendered neither the account pill nor the `giriş yap` CTA. The shell offered no sign-in path at all.

The two conditions in `apps/web/src/App.tsx` collapsed in opposite directions. `reserveSignedInSlots` went false once the session settled signed-out, so the account slot emptied; `signedInAtFirstPaint = bootSignedIn || isSignedIn` stayed true forever, because `readBootUser()` reads a payload that never changes after load, so the CTA stayed suppressed forever.

The fix derives the CTA from the same condition that governs the slot:

```ts
const reserveSignedInSlots = bootSignedIn && (session.isPending || isSignedIn);
const showSignInCta = !isSignedIn && !reserveSignedInSlots;
```

Now the two halves cannot disagree — the CTA is suppressed exactly while the account slot is filled or reserved. The ADR 0185 / #2933 no-flash guarantee is unchanged: while `session.isPending` with a boot user present, `reserveSignedInSlots` is true, so the CTA still does not flash.

`apps/web/src/App.test.tsx` gains a regression test that renders with `__BOOT__.user` present, settles the session signed-out, and asserts the CTA returns with no pill and no placeholder. It fails against the old predicate.

Fixes #6577

## Deviations

None.
