### PR TITLE
chore: A clean PR still in the merge queue at ship's horizon parks its lane on a human, then merges itself

### DIFF
--- a/.decisions/0313-a-queue-dwell-is-a-wait-not-a-park.md
+++ b/.decisions/0313-a-queue-dwell-is-a-wait-not-a-park.md
@@ -40,7 +40,7 @@ and a driver re-folds it. The coder machine's `ship` had no equivalent.
 
 **`ship:queued` is the wait cell.** It is reachable from `ship` on `WIP`, re-enters itself on a
 further wait, reaches `shipped` on a landing, routes an ejection back into `build`, and escalates to
-`human:cp-approval` when its own budget is spent. It is not a park: the name carries no `human:`
+`human:queue-stall` when its own budget is spent. It is not a park: the name carries no `human:`
 prefix, so `recipe/parks.ts`'s `isPark` reads it as ordinary work and no park sweep touches it.
 
 **Both queue terminals record `WIP`.** `UNRESOLVED` no longer maps to `BLOCKED`, and `QUEUED` no
@@ -58,6 +58,18 @@ spends `waits` (`WAIT_BUDGET`, 3). Riding one counter would have let a PR that d
 arrive at its first real FAIL with no repair rounds left — a repair budget spent on the queue's clock
 rather than on the work. The recognition stays structural, off the event's own polarity: no guard or
 action name is dereferenced, which is the property `lane/machine.ts` has held since #5673.
+
+**A founder's cleared round buys a repair round and never a longer wait.** ADR
+[0312](0312-event-anchored-retry-budget.md) anchors the repair budget to a recorded
+`CLEARED` event, and that event raises `maxRetries` alone. `maxWaits` is a declared constant no
+recorded event moves — which is the same separation from the other side: the founder is clearing a
+review round, and handing the merge queue three more turns of the crank is not what they granted.
+
+Splitting the counters also narrows what a *state* being guarded means. `guardedStates` — the set
+0312's resume refusal reads, where the state comes back and the budget does not — now holds only the
+states whose guarded route out spends `retries`. A wait-guarded cell is no resume hazard: its spent
+fallthrough is a park that names the stall, not a fall back into the error final the resume just
+left.
 
 **The shipper's horizon does not move.** `ship reconcile` polls exactly as far as it did. The waiting
 moved out to the driver, one read per pass — `ship reconcile <pr> --polls 1`, whose answer the driver

--- a/.decisions/0313-a-queue-dwell-is-a-wait-not-a-park.md
+++ b/.decisions/0313-a-queue-dwell-is-a-wait-not-a-park.md
@@ -30,8 +30,8 @@ Twice, measurably:
 - [#6178](https://github.com/kamp-us/phoenix/pull/6178) sat ~13m45s in the queue against the ~480s
   horizon and merged ~1.7x past it, long before anyone would have read the park.
 - Lane 6462's PR merged 29 seconds before its `BLOCKED` was written. The follow-up `LANDED` was then
-  refused: `human:cp-approval` held no `DONE` cell, so `NoCellError` left a merged PR's lane stuck in
-  a park with no route out.
+  refused with `NoCellError`, because a park is not a state a landing is recorded from. The lane was
+  cleared by hand with `UNBLOCKED` — the right route, taken late, on a park that was never owed.
 
 The chore machine already drew this line — `recipe route` folds a not-yet-clear known park to `WIP`
 and a driver re-folds it. The coder machine's `ship` had no equivalent.
@@ -65,10 +65,37 @@ relays rather than derives (ADR [0228](0228-scripts-relay-never-derive.md)): `la
 `unresolved` → `UNRESOLVED`, `ejected` → `EJECTED`, `parked` → `UNKNOWN`. The driver never counts
 re-folds and never decides the wait is over; the cell's own budget does that.
 
-**`human:cp-approval` gains a `DONE` cell.** A lane parked there whose PR then merged can record
-`LANDED` and fold to `shipped`. That is lane 6462's named route out, and it weakens nothing: the only
-tokens that reach `DONE` are the two that read a merge back, and a merged control-plane PR is one
-whose approval happened.
+**A park keeps its one exit.** `human:cp-approval` gains nothing here. An already-parked lane whose
+PR then merged leaves the way every park is left — a recorded `UNBLOCKED` back to the state it came
+from, and the landing recorded from there. That is lane 6462's route out, it is the one that lane
+actually took on 2026-08-20, and it is the only one ADR
+[0302](0302-known-parks-clear-novel-routes-human.md) permits: a park is cleared by a registered
+recipe proven by a re-fold, or by a human's `UNBLOCKED`, and never by a second exit cell that skips
+both. A `DONE` cell would have been that second exit, reachable by any driver relaying a `ship`
+token, so what looked like a convenience was a widening of the rule 0302 states — and 0302 says
+widening it needs a table row and a proving read, not an analogy.
+
+**The wait's own escalation gets its own park, `human:queue-stall`.** It could not be
+`human:cp-approval`. The escalation is driven by a `WIP`, and `report.ts` refuses a park cause on any
+non-`BLOCKED` event, so a spent queue wait structurally cannot carry one — which is exactly the key
+`recipe/parks.ts`'s control-plane row matches (`cause: null`). A stall landing there would be swept
+as a §CP park and cleared by reading an approval nobody was waiting on, the failure that table's
+cause key exists to prevent. Its own leaf carries no row, so `classifyPark` reads it as novel and
+routes it to a human, which is what a spent wait needs. A human clears it with `UNBLOCKED` like any
+other park; the lane resumes at `ship:queued` and a re-read decides it from there.
+
+**Lanes already booted are migrated, not left behind.** `lane open` places a byte-identical copy of
+the template into each lane and refuses to overwrite one afterwards, so a template edit reaches lanes
+booted after it and no lane already on disk — while `report.ts`'s token map is code and reaches all
+of them at once. Left alone, that combination is worse than the bug: every booted lane's shipper
+would report `QUEUED`, now mapped to `WIP`, against a frozen `ship` state holding no `WIP` cell, and
+the ordinary success path would refuse. So this change ships with `lane migrate`, which replaces a
+booted lane's `workflow.json` with the committed template **only** where the swap is provably inert:
+state is the event log replayed from scratch with no snapshot, so the swap is safe exactly when the
+existing log folds to the same per-task leaf state through both machines. Anything else — a log that
+will not replay, or one that folds somewhere new — is named and left untouched for a human, because
+relocating a lane is not migrating it. `lane migrate --check` is the same judgement with the write
+withheld.
 
 ## What this costs
 

--- a/.decisions/0313-a-queue-dwell-is-a-wait-not-a-park.md
+++ b/.decisions/0313-a-queue-dwell-is-a-wait-not-a-park.md
@@ -1,0 +1,84 @@
+---
+id: 0313
+title: A clean PR still in the merge queue is a wait the driver re-folds, not a human park
+status: accepted
+date: 2026-08-20
+tags: [fabrika, lane, pipeline, ship, state-machine]
+---
+
+# 0313 — A clean PR still in the merge queue is a wait the driver re-folds, not a human park
+
+**What this decides:** the coder machine gains a non-human wait cell out of `ship`. A shipper that
+ends with the PR still in the merge queue records `WIP`, the lane folds to `ship:queued`, and the
+driver re-reads the queue on a later pass. A human is spent only when the PR leaves the queue
+un-merged or the wait's own bounded re-folds run out.
+
+Founder ruling, [2026-08-20](https://github.com/kamp-us/phoenix/issues/6189#issuecomment-5360244073),
+restating [2026-08-19](https://github.com/kamp-us/phoenix/issues/6189#issuecomment-5346739403). This
+ADR transcribes that ruling; the choice is the founder's, not this record's.
+
+## The problem
+
+`ship reconcile` watches an enqueued PR for a bounded ~480s and answers `unresolved` when the PR is
+still in the queue at that horizon — an honest answer that its own contract calls "neither a landing
+nor a failure". The lane machine had nowhere to put it. `UNRESOLVED` mapped to `BLOCKED`, `BLOCKED`
+out of `ship` folds to `human:cp-approval`, so every clean lane that dwelt past the horizon parked on
+a human for a merge that was going to land on its own.
+
+Twice, measurably:
+
+- [#6178](https://github.com/kamp-us/phoenix/pull/6178) sat ~13m45s in the queue against the ~480s
+  horizon and merged ~1.7x past it, long before anyone would have read the park.
+- Lane 6462's PR merged 29 seconds before its `BLOCKED` was written. The follow-up `LANDED` was then
+  refused: `human:cp-approval` held no `DONE` cell, so `NoCellError` left a merged PR's lane stuck in
+  a park with no route out.
+
+The chore machine already drew this line — `recipe route` folds a not-yet-clear known park to `WIP`
+and a driver re-folds it. The coder machine's `ship` had no equivalent.
+
+## The decision
+
+**`ship:queued` is the wait cell.** It is reachable from `ship` on `WIP`, re-enters itself on a
+further wait, reaches `shipped` on a landing, routes an ejection back into `build`, and escalates to
+`human:cp-approval` when its own budget is spent. It is not a park: the name carries no `human:`
+prefix, so `recipe/parks.ts`'s `isPark` reads it as ordinary work and no park sweep touches it.
+
+**Both queue terminals record `WIP`.** `UNRESOLVED` no longer maps to `BLOCKED`, and `QUEUED` no
+longer maps to `DONE`. Only `LANDED` and `ALREADY-MERGED` are `DONE`, because those are the two
+terminals that read a merge back — `QUEUED` folding a lane to `shipped` over a merge nobody observed
+was the same lie as `UNRESOLVED` parking one over a merge that was fine. Every genuine shipper block
+still maps to `BLOCKED` and still folds to `human:cp-approval`, so
+[#5820](https://github.com/kamp-us/phoenix/issues/5820)'s separate question — which park cell a real
+block lands in — is untouched.
+
+**The wait spends its own budget.** A guarded two-arm array in a lane machine used to mean one thing:
+retry while `retries < maxRetries`. It now means "loop while a budget remains", and *which* budget is
+read off the event: `FAIL` is a repair round and spends `retries`, every other event is a wait and
+spends `waits` (`WAIT_BUDGET`, 3). Riding one counter would have let a PR that dwelt in the queue
+arrive at its first real FAIL with no repair rounds left — a repair budget spent on the queue's clock
+rather than on the work. The recognition stays structural, off the event's own polarity: no guard or
+action name is dereferenced, which is the property `lane/machine.ts` has held since #5673.
+
+**The shipper's horizon does not move.** `ship reconcile` polls exactly as far as it did. The waiting
+moved out to the driver, one read per pass — `ship reconcile <pr> --polls 1`, whose answer the driver
+relays rather than derives (ADR [0228](0228-scripts-relay-never-derive.md)): `landed` → `LANDED`,
+`unresolved` → `UNRESOLVED`, `ejected` → `EJECTED`, `parked` → `UNKNOWN`. The driver never counts
+re-folds and never decides the wait is over; the cell's own budget does that.
+
+**`human:cp-approval` gains a `DONE` cell.** A lane parked there whose PR then merged can record
+`LANDED` and fold to `shipped`. That is lane 6462's named route out, and it weakens nothing: the only
+tokens that reach `DONE` are the two that read a merge back, and a merged control-plane PR is one
+whose approval happened.
+
+## What this costs
+
+An ejection out of the wait cell routes to `build` (spending a retry), not to a human park. The
+ruling named "the PR left the queue un-merged" as an escalation condition; #5807 had already decided
+an ejection is repair work this lane retries, and that answer survives here — a human is spent only
+when the repair budget itself runs out. A genuine block observed on a re-fold pass (`REFUSED`,
+`AWAITING-CP-APPROVAL`, `UNKNOWN`) still parks, which is the ordinary block route rather than a third
+escalation path out of the wait.
+
+An epic run's tail gets the same cell for the same reason: the tail is where an epic meets the merge
+queue. A child region has no `ship` and reaches no queue, so it needs none (ADR
+[0285](0285-epic-machine-ends-in-review.md)).

--- a/claude-plugins/fabrika/skills/operate/SKILL.md
+++ b/claude-plugins/fabrika/skills/operate/SKILL.md
@@ -19,7 +19,8 @@ through `lane report`'s closed in-code map, a recipe exit folds through `recipe 
 `lane prove`'s read — the artifact behind an event — is what lets any event reach the machine at
 all, run by `lane report` on the shell's path and by you on yours.
 **Capability set:** shell in the checkout you were spawned in, repo-scoped token, subagent spawns.
-Writes used — lane-ledger appends, comments on the driven issue, whatever a recipe verb writes on
+Writes used — lane-ledger appends, a booted lane's own machine document brought up to the committed
+template through `lane migrate`, comments on the driven issue, whatever a recipe verb writes on
 its own account (step 3's chore row), and, **on an epic lane only**, that run's assembly branch: you
 merge a passing child into it, push it, and open the one draft PR (step 2's `integrate`). Never a
 branch a spawned shell owns, never a verdict of your own, and never the merge into the default
@@ -343,7 +344,7 @@ Relay its answer, never your own reading of the PR:
 | `reconcile` says | Record |
 | --- | --- |
 | `landed` | `--token LANDED --pr <pr-url>` — the machine folds the lane to `shipped` |
-| `unresolved` | `--token UNRESOLVED` — still queued; the cell re-enters itself, and after its bounded re-folds escalates to `human:cp-approval` on its own |
+| `unresolved` | `--token UNRESOLVED` — still queued; the cell re-enters itself, and after its bounded re-folds escalates to `human:queue-stall` on its own |
 | `ejected` | `--token EJECTED` — the PR left the queue un-merged, which is repair work: the machine spends a retry back into `build` |
 | `parked` | `--token UNKNOWN` — the timeline shows a PR neither queued, ejected nor merged, and an unread queue state is UNKNOWN, never a wait to keep sitting in |
 

--- a/claude-plugins/fabrika/skills/operate/SKILL.md
+++ b/claude-plugins/fabrika/skills/operate/SKILL.md
@@ -366,7 +366,7 @@ node <fabrika> lane migrate           # migrate the ones the swap provably does 
 ```
 
 It writes only where the lane's own event log folds to the same state through both machines. Exit
-`36` names the lanes it would have moved and leaves them alone — that is a human's call, not a
+`37` names the lanes it would have moved and leaves them alone — that is a human's call, not a
 re-run's.
 
 **A chore state routes to a verb, not to a shell**, and the routing is a verb's answer too:

--- a/claude-plugins/fabrika/skills/operate/SKILL.md
+++ b/claude-plugins/fabrika/skills/operate/SKILL.md
@@ -349,9 +349,24 @@ Relay its answer, never your own reading of the PR:
 
 The escalation bound is the machine's, not yours: **you never count re-folds and never decide the
 wait is over**. Record what the read said and re-fold; the cell escalates when its own budget is
-spent, and that budget is separate from the lane's build/review retries, so a long dwell cannot cost
-a later repair round. A non-zero exit from `reconcile` is UNKNOWN — end `STOPPED` naming the code,
-record nothing.
+spent — to `human:queue-stall`, a park of its own that no recipe clears, so a spent queue wait is
+never swept as a control-plane approval. That budget is separate from the lane's build/review
+retries, so a long dwell cannot cost a later repair round. A non-zero exit from `reconcile` is
+UNKNOWN — end `STOPPED` naming the code, record nothing.
+
+**A lane booted before this cell existed cannot reach it, and will refuse the shipper's ordinary
+`QUEUED` instead.** `lane open` copies the template in at boot and never overwrites it, so a machine
+change reaches new lanes only — while the token map that feeds it is code and reaches every lane at
+once. Bring the lanes on disk up to the committed machine before driving them:
+
+```bash
+node <fabrika> lane migrate --check   # judge every lane, write nothing
+node <fabrika> lane migrate           # migrate the ones the swap provably does not move
+```
+
+It writes only where the lane's own event log folds to the same state through both machines. Exit
+`36` names the lanes it would have moved and leaves them alone — that is a human's call, not a
+re-run's.
 
 **A chore state routes to a verb, not to a shell**, and the routing is a verb's answer too:
 

--- a/claude-plugins/fabrika/skills/operate/SKILL.md
+++ b/claude-plugins/fabrika/skills/operate/SKILL.md
@@ -168,6 +168,7 @@ active phase** (future phases read `waiting`; leave them alone), route on the le
 | --- | --- |
 | `queued` | record `WIP` — the task enters build |
 | `build` / `review` / `ship` | dispatch through `lane brief` — below |
+| `ship:queued` | the PR is in the merge queue and nothing is wrong — re-read the queue yourself, below. Never a park, and never a shell |
 | `integrate` | land the child on the assembly branch yourself — the epic run, below |
 | a state `recipe route` names | apply that recipe verb — the chore drive, below |
 | a task's own final — `landed`, `shipped` | nothing to route and no event to record: that task is finished, and its phase advances when every task in it is final |
@@ -322,6 +323,35 @@ gh pr ready <pr>
 ```
 
 That is the last thing you do to the branch: the merge itself is the shipper's, once.
+
+## `ship:queued` — re-read the queue, relay the answer
+
+A PR sitting in the merge queue with every guard clear is a **wait**, not a block: the queue lands it
+on its own clock, and #6178 took ~1.7x the shipper's ~480s horizon to do it. So the shipper's horizon
+stays exactly where it is and the waiting happens out here, one re-read per driver pass, in
+`ship:queued` (ADR [0313](../../../../.decisions/0313-a-queue-dwell-is-a-wait-not-a-park.md)).
+
+You spawn nothing. One read answers the whole cell — `--polls 1` makes it a single look rather than
+another watch, so this costs a driver pass, not a horizon:
+
+```bash
+node <fabrika> ship reconcile <pr> --polls 1
+```
+
+Relay its answer, never your own reading of the PR:
+
+| `reconcile` says | Record |
+| --- | --- |
+| `landed` | `--token LANDED --pr <pr-url>` — the machine folds the lane to `shipped` |
+| `unresolved` | `--token UNRESOLVED` — still queued; the cell re-enters itself, and after its bounded re-folds escalates to `human:cp-approval` on its own |
+| `ejected` | `--token EJECTED` — the PR left the queue un-merged, which is repair work: the machine spends a retry back into `build` |
+| `parked` | `--token UNKNOWN` — the timeline shows a PR neither queued, ejected nor merged, and an unread queue state is UNKNOWN, never a wait to keep sitting in |
+
+The escalation bound is the machine's, not yours: **you never count re-folds and never decide the
+wait is over**. Record what the read said and re-fold; the cell escalates when its own budget is
+spent, and that budget is separate from the lane's build/review retries, so a long dwell cannot cost
+a later repair round. A non-zero exit from `reconcile` is UNKNOWN — end `STOPPED` naming the code,
+record nothing.
 
 **A chore state routes to a verb, not to a shell**, and the routing is a verb's answer too:
 

--- a/claude-plugins/fabrika/skills/ship/SKILL.md
+++ b/claude-plugins/fabrika/skills/ship/SKILL.md
@@ -9,8 +9,10 @@ argument-hint: "[pr-number] — the verified pull request to merge"
 
 You are the merge authority: one PR in, one terminal token out. The checkout you stand in is not
 this PR — **read-only, no local git, ever**. Where a merge queue governs the base, success is
-**enqueued + green** — the queue owns the async merge, so "QUEUED" is your victory condition and
-"merged" is something you *confirm*, never assert. Where no queue governs it, you land the PR
+**enqueued + green** — the queue owns the async merge, so "QUEUED" is where your run ends and
+"merged" is something you *confirm*, never assert. It is the end of *your* run and not of the lane:
+a PR still in the queue is a wait the driver re-reads on a later pass, never a park and never a
+landing (ADR [0313](../../../../.decisions/0313-a-queue-dwell-is-a-wait-not-a-park.md)). Where no queue governs it, you land the PR
 yourself with `ship merge` and success is the **proven** landing. Which of the two you are on is a
 fact `ship scope` prints; it is never a guess.
 
@@ -208,7 +210,9 @@ mergeability is unknown, so stop and say so; nothing was armed. `reconcile`'s te
 the run's terminals: `landed` → step 8. `ejected` → `disarm --site ejected`, note, route to
 repair; re-entry is rebase → re-review → fresh gate pass, never a re-enqueue on old verdicts.
 `unresolved` → report it in those words with the horizon; still-queued at the horizon is
-neither a landing nor a failure, and **"auto-merges on green" is not a thing you say**. `parked` →
+neither a landing nor a failure, and **"auto-merges on green" is not a thing you say**. Your horizon
+is fixed: you never poll past it, and a lane that needs longer gets it from the driver's re-reads at
+`ship:queued`, not from a wider watch in here. `parked` →
 the enqueue never took effect: run `fabrika ship disarm $pr_number --site post-enqueue` (reconcile is a
 read and disarms nothing), note, and stop. The `mergeable_state` assertion and each terminal's proof
 are the verbs' sections
@@ -236,12 +240,15 @@ close→reopen nudge, one label (`status:awaiting-release`), and one append to t
 ledger through `lane report` at the `--root` your brief carries, a path outside this checkout. No
 push, no local git mutation, no
 implementation, no review verdict, no flag flip. Every run ends as exactly one of:
-**already-merged (idempotent success)** · **QUEUED — enqueued, awaiting the queue** (success
-without a merge observed, the queue route's victory) · **landed** (the direct route's, and
+**already-merged (idempotent success)** · **QUEUED — enqueued, awaiting the queue** and
+**UNRESOLVED at horizon — still queued, still clean** (the two queue waits: your run ends, the lane
+does not. Neither is a landing — no merge was observed — and neither is a park: both record `WIP`,
+which folds the lane to `ship:queued` for the driver to re-read, ADR 0313) ·
+**landed** (the direct route's, and
 `reconcile`'s — either way it is a landing you *read back*, never one you infer) ·
 **refused — <reason>** (a successful decline: disarmed,
 noted, nothing mutated beyond the note) · **awaiting control-plane approval** · **routed to
-repair** · **routed to heal-ci** · **routed to review** · **UNRESOLVED at horizon** ·
+repair** · **routed to heal-ci** · **routed to review** ·
 **EJECTED — routed to repair** ·
 **UNKNOWN — a read failed** (never rendered as any of the above). The three routings are three
 terminals, not one: repair is work this lane retries, heal-ci and review are waits it cannot, and

--- a/claude-plugins/fabrika/skills/ship/contract.md
+++ b/claude-plugins/fabrika/skills/ship/contract.md
@@ -49,7 +49,7 @@ Named because a spec that leaves the substrate open makes the implementer guess 
 | `ship resolve` | the sanctioned thread-resolution write: rationale reply, resolve mutation, read-back — refusing any thread not positively bot-classed | the protocol and the bot-only structural anchor are mechanical; deciding a bot thread is a nit is the skill's |
 | `ship enqueue` | arm the queue's auto-merge at a pinned head, method-flag-free by construction, and prove the arm landed | the arm, its error discrimination, and the entry read are mechanical; whether the PR should ship was settled by the gates |
 | `ship merge` | the second landing path: land directly on a base branch no merge queue governs, with the method read off the repository, and prove the landing | reading the regime, picking a permitted method and proving `merged` + the merge commit are mechanical; whether the PR should ship was settled by the gates |
-| `ship reconcile` | the bounded post-enqueue watch: `landed` / `ejected` / `unresolved` / `parked`, each a proven answer at exit 0 | multi-signal terminal classification against timeline + base-branch evidence is mechanical; what ejection means for the lane is judgment |
+| `ship reconcile` | the bounded post-enqueue watch: `landed` / `ejected` / `unresolved` / `parked`, each a proven answer at exit 0 — and, at `--polls 1`, the one read the driver's `ship:queued` wait cell relays | multi-signal terminal classification against timeline + base-branch evidence is mechanical; what ejection means for the lane is judgment |
 | `ship disarm` | the four-site merge-intent lifecycle (ADR 0198): `kept` / `disarmed`, read-back-verified | the site policy table and the verified write are mechanical |
 | `ship nudge` | the at-most-once dropped-trigger remedy: re-derive the zero-runs state, close→reopen, verify both legs | the precondition re-derivation and the guarded PATCH pair are mechanical; the verb refuses rather than trusting its dispatch (#4816) |
 | `ship note` | the durable stop-path comment: stdin body, leak-scanned, read back | posting with the sibling groups' write protocol is mechanical; what the note says is the skill's |
@@ -1609,7 +1609,10 @@ pages joined.
 
 **The horizon is stated, not defended:** default 16×30s ≈ 7.5 minutes of dwell against a
 measured queue dwell of 5–10 minutes; `unresolved` at the horizon is the expected outcome of
-a healthy long dwell, and the caller's report says so in those words. The verb never disarms
+a healthy long dwell, and the caller's report says so in those words. It stays there: a lane
+that needs longer waits in the driver's `ship:queued` cell, which re-reads this verb at
+`--polls 1` once a pass, rather than in a wider watch inside one shipper run (ADR
+[0313](../../../../.decisions/0313-a-queue-dwell-is-a-wait-not-a-park.md)). The verb never disarms
 — it is a read; the skill fires `ship disarm --site ejected` / `--site post-enqueue` on the
 `ejected` / `parked` answers (the sites exist precisely for these two answers, and the skill
 text carries the pairing).

--- a/packages/fabrika-cli/src/lane/__fixtures__/epic-4300.workflow.golden.txt
+++ b/packages/fabrika-cli/src/lane/__fixtures__/epic-4300.workflow.golden.txt
@@ -274,7 +274,34 @@
 							"ship": {
 								"on": {
 									"EPIC_4300.DONE": "shipped",
+									"EPIC_4300.WIP": "ship:queued",
 									"EPIC_4300.BLOCKED": "human:cp-approval",
+									"EPIC_4300.FAIL": [
+										{
+											"target": "review",
+											"guard": "retriesRemaining",
+											"actions": "incrementRetries"
+										},
+										{
+											"target": "human:epic-review"
+										}
+									]
+								}
+							},
+							"ship:queued": {
+								"on": {
+									"EPIC_4300.DONE": "shipped",
+									"EPIC_4300.BLOCKED": "human:cp-approval",
+									"EPIC_4300.WIP": [
+										{
+											"target": "ship:queued",
+											"guard": "waitsRemaining",
+											"actions": "incrementWaits"
+										},
+										{
+											"target": "human:cp-approval"
+										}
+									],
 									"EPIC_4300.FAIL": [
 										{
 											"target": "review",
@@ -294,6 +321,7 @@
 							},
 							"human:cp-approval": {
 								"on": {
+									"EPIC_4300.DONE": "shipped",
 									"EPIC_4300.UNBLOCKED": "hist"
 								}
 							},

--- a/packages/fabrika-cli/src/lane/__fixtures__/epic-4300.workflow.golden.txt
+++ b/packages/fabrika-cli/src/lane/__fixtures__/epic-4300.workflow.golden.txt
@@ -299,7 +299,7 @@
 											"actions": "incrementWaits"
 										},
 										{
-											"target": "human:cp-approval"
+											"target": "human:queue-stall"
 										}
 									],
 									"EPIC_4300.FAIL": [
@@ -321,7 +321,11 @@
 							},
 							"human:cp-approval": {
 								"on": {
-									"EPIC_4300.DONE": "shipped",
+									"EPIC_4300.UNBLOCKED": "hist"
+								}
+							},
+							"human:queue-stall": {
+								"on": {
 									"EPIC_4300.UNBLOCKED": "hist"
 								}
 							},

--- a/packages/fabrika-cli/src/lane/codes.ts
+++ b/packages/fabrika-cli/src/lane/codes.ts
@@ -246,3 +246,15 @@ export const CAUSE_UNRECOGNISED = 35;
  * only the code must not be told to retype the transition (ADR 0312).
  */
 export const RESUME_UNBUDGETED = 36;
+
+/**
+ * A booted lane's machine cannot be replaced by the committed template without moving the lane: the
+ * log will not replay through the candidate, or it replays to a different leaf state. Nothing was
+ * written on either arm.
+ *
+ * Its own seat rather than {@link MALFORMED_RECORD}'s: that one says a record on disk is not the
+ * shape and the remedy is fixing the record, while this one says both records are fine and
+ * *disagree* — the remedy is a human deciding what that lane's state should be, never a rewrite the
+ * sweep picks (ADR 0313).
+ */
+export const MIGRATION_UNSAFE = 37;

--- a/packages/fabrika-cli/src/lane/command.ts
+++ b/packages/fabrika-cli/src/lane/command.ts
@@ -504,10 +504,14 @@ const migrate = leafCommand(
 			yield* runMigrate({
 				roots: Option.match(root, {
 					onNone: () => [
-						{root: DEFAULT_LANES_ROOT, templatePath: templatePath("Issue")},
-						{root: DEFAULT_CHORES_ROOT, templatePath: templatePath("Chore")},
+						{root: DEFAULT_LANES_ROOT, templatePaths: [templatePath("Issue")]},
+						{root: DEFAULT_CHORES_ROOT, templatePaths: [templatePath("Chore")]},
 					],
-					onSome: (only) => [{root: only, templatePath: templatePath("Issue")}],
+					// A relocated root holds whatever was opened into it, so both templates are
+					// candidates and the lane's own machine id picks — never the root's position.
+					onSome: (only) => [
+						{root: only, templatePaths: [templatePath("Issue"), templatePath("Chore")]},
+					],
 				}),
 				check,
 			}),
@@ -516,7 +520,7 @@ const migrate = leafCommand(
 ).pipe(
 	Command.withShortDescription("Bring every booted lane's machine up to the committed template."),
 	Command.withDescription(
-		'Bring each booted lane\'s workflow.json up to the committed template its root selects, but only where the swap provably moves nothing. `lane open` places a byte-identical copy at boot and refuses to overwrite one afterwards, so a template edit reaches lanes booted after it and no lane already on disk — safe until a token→event map in code changes with it, at which point every booted lane is asked for a cell its frozen machine does not have (ADR 0313). Two things are kept: the lane\'s own `machine.context`, which is per-lane DATA (the task\'s maxRetries, and whatever else a lane declares) and would be erased by a verbatim copy, and any lane whose machine was GENERATED rather than booted — an emitted epic document has no committed template to be brought up to, and is reported, never touched. State is the event log replayed from scratch with no snapshot, so the swap is safe exactly when the existing events.jsonl folds to the same per-task leaf state through both machines; anything else is a rewritten history, not a migration. Each lane carries one verdict: "current" (already what this verb would write), "migrated" (judged safe and written), "stale" (judged safe, --check withheld the write), "generated" (not booted from this template), "unsafe" (the log will not replay through one of the two machines, or it folds to a different state — named, never written) or "unreadable". stdout is {check, scanned, summary, lanes}. Both default roots are swept unless --root names one, which is read as a relocated lanes root and takes the coder template; an absent root holds no lanes and is not a fault. Exits 11 (a template could not be read, or a root is there and could not be listed — the lane set is UNKNOWN, never empty), 37 (at least one lane cannot take the template without moving; those lanes are named on stderr and none of them was written, and so are the ones that were). Examples: fabrika lane migrate --check · fabrika lane migrate',
+		'Bring each booted lane\'s workflow.json up to the committed template its root selects, but only where the swap provably moves nothing. `lane open` places a byte-identical copy at boot and refuses to overwrite one afterwards, so a template edit reaches lanes booted after it and no lane already on disk — safe until a token→event map in code changes with it, at which point every booted lane is asked for a cell its frozen machine does not have (ADR 0313). Two things are kept: the lane\'s own `machine.context`, which is per-lane DATA (the task\'s maxRetries, and whatever else a lane declares) and would be erased by a verbatim copy, and any lane whose machine was GENERATED rather than booted — an emitted epic document has no committed template to be brought up to, and is reported, never touched. State is the event log replayed from scratch with no snapshot, so the swap is safe exactly when the existing events.jsonl folds to the same per-task leaf state through both machines; anything else is a rewritten history, not a migration. Each lane carries one verdict: "current" (already the machine this verb would write, read past formatting), "migrated" (judged safe and written), "stale" (judged safe, --check withheld the write), "generated" (not booted from this template), "unsafe" (the log will not replay through one of the two machines, or it folds to a different state — named, never written) or "unreadable". stdout is {check, scanned, summary, lanes}. Both default roots are swept unless --root names one, which is read as a relocated root whose lanes may have booted from either committed template — the lane\'s own machine id picks, never the root\'s position; an absent root holds no lanes and is not a fault. Exits 11 (a template could not be read, or a root is there and could not be listed — the lane set is UNKNOWN, never empty), 37 (at least one lane cannot take the template without moving; those lanes are named on stderr and none of them was written, and so are the ones that were). Examples: fabrika lane migrate --check · fabrika lane migrate',
 	),
 );
 

--- a/packages/fabrika-cli/src/lane/command.ts
+++ b/packages/fabrika-cli/src/lane/command.ts
@@ -19,6 +19,7 @@ import {runLaneClaim, runLaneRelease} from "./claim-verb.ts";
 import {runEmit} from "./emit-verb.ts";
 import {runHistory} from "./history-verb.ts";
 import {type LaneKey, laneRef, parseKey, templateFile} from "./key.ts";
+import {runMigrate} from "./migrate-verb.ts";
 import {runOpen} from "./open-verb.ts";
 import {runPrint} from "./print-verb.ts";
 import {runProve} from "./prove-verb.ts";
@@ -249,15 +250,17 @@ const print = leafCommand(
 	),
 );
 
-const templatePath = (key: LaneKey): string =>
-	fileURLToPath(new URL(`./templates/${templateFile(key)}`, import.meta.url));
+const templatePath = (kind: LaneKey["_tag"]): string =>
+	fileURLToPath(new URL(`./templates/${templateFile(kind)}`, import.meta.url));
 
 const open = leafCommand(
 	"open",
 	{lane: laneArgument, root: rootFlag},
 	Effect.fn(function* ({lane, root}) {
 		yield* emit(
-			yield* onKey(lane, root, (key, ref) => runOpen({...ref, templatePath: templatePath(key)})),
+			yield* onKey(lane, root, (key, ref) =>
+				runOpen({...ref, templatePath: templatePath(key._tag)}),
+			),
 		);
 	}),
 ).pipe(
@@ -488,6 +491,35 @@ const stale = leafCommand(
 	),
 );
 
+const migrate = leafCommand(
+	"migrate",
+	{
+		root: rootFlag,
+		check: Flag.boolean("check").pipe(
+			Flag.withDescription("judge every lane and report, writing nothing"),
+		),
+	},
+	Effect.fn(function* ({root, check}) {
+		yield* emit(
+			yield* runMigrate({
+				roots: Option.match(root, {
+					onNone: () => [
+						{root: DEFAULT_LANES_ROOT, templatePath: templatePath("Issue")},
+						{root: DEFAULT_CHORES_ROOT, templatePath: templatePath("Chore")},
+					],
+					onSome: (only) => [{root: only, templatePath: templatePath("Issue")}],
+				}),
+				check,
+			}),
+		);
+	}),
+).pipe(
+	Command.withShortDescription("Bring every booted lane's machine up to the committed template."),
+	Command.withDescription(
+		'Bring each booted lane\'s workflow.json up to the committed template its root selects, but only where the swap provably moves nothing. `lane open` places a byte-identical copy at boot and refuses to overwrite one afterwards, so a template edit reaches lanes booted after it and no lane already on disk — safe until a token→event map in code changes with it, at which point every booted lane is asked for a cell its frozen machine does not have (ADR 0313). Two things are kept: the lane\'s own `machine.context`, which is per-lane DATA (the task\'s maxRetries, and whatever else a lane declares) and would be erased by a verbatim copy, and any lane whose machine was GENERATED rather than booted — an emitted epic document has no committed template to be brought up to, and is reported, never touched. State is the event log replayed from scratch with no snapshot, so the swap is safe exactly when the existing events.jsonl folds to the same per-task leaf state through both machines; anything else is a rewritten history, not a migration. Each lane carries one verdict: "current" (already what this verb would write), "migrated" (judged safe and written), "stale" (judged safe, --check withheld the write), "generated" (not booted from this template), "unsafe" (the log will not replay through one of the two machines, or it folds to a different state — named, never written) or "unreadable". stdout is {check, scanned, summary, lanes}. Both default roots are swept unless --root names one, which is read as a relocated lanes root and takes the coder template; an absent root holds no lanes and is not a fault. Exits 11 (a template could not be read, or a root is there and could not be listed — the lane set is UNKNOWN, never empty), 37 (at least one lane cannot take the template without moving; those lanes are named on stderr and none of them was written, and so are the ones that were). Examples: fabrika lane migrate --check · fabrika lane migrate',
+	),
+);
+
 const view = leafCommand(
 	"view",
 	{
@@ -530,6 +562,7 @@ export const laneCommand = Command.make("lane").pipe(
 		assembly,
 		pushLane,
 		stale,
+		migrate,
 		claim,
 		release,
 		view,

--- a/packages/fabrika-cli/src/lane/emit.ts
+++ b/packages/fabrika-cli/src/lane/emit.ts
@@ -117,7 +117,11 @@ const region = (ns: string, initial: "queued" | "landed" | "frozen"): Record<str
  * `ship:queued` is the tail's wait cell (ADR 0313): the tail is the one place an epic run meets a
  * merge queue, so it is the one region that needs it — a child region has no `ship` and reaches no
  * queue at all. The `WIP` out of it is a guarded array like the FAIL above, but it spends `waits`
- * rather than `retries`, so a queue dwell cannot eat the epic review's repair rounds.
+ * rather than `retries`, so a queue dwell cannot eat the epic review's repair rounds. Its spent-
+ * budget fallthrough is `human:queue-stall` and not `human:cp-approval` because a `WIP` carries no
+ * park cause, and `recipe/parks.ts`'s §CP row keys on `cause: null` — a stall landing there would be
+ * cleared by reading an approval nobody was waiting on. Its own leaf carries no row, so the table
+ * reads it as novel and routes it to a human, which is what a spent wait actually needs.
  *
  * `review` FAIL is a two-arm guarded array so the fallthrough final is an *error* final by the
  * compiler's own structural read; a plain target would leave a failed epic review folding to
@@ -156,7 +160,7 @@ const epicRegion = (ns: string): Record<string, unknown> => ({
 				[`${ns}.BLOCKED`]: "human:cp-approval",
 				[`${ns}.WIP`]: [
 					{target: "ship:queued", guard: "waitsRemaining", actions: "incrementWaits"},
-					{target: "human:cp-approval"},
+					{target: "human:queue-stall"},
 				],
 				[`${ns}.FAIL`]: [
 					{target: "review", guard: "retriesRemaining", actions: "incrementRetries"},
@@ -165,7 +169,8 @@ const epicRegion = (ns: string): Record<string, unknown> => ({
 			},
 		},
 		blocked: {on: {[`${ns}.UNBLOCKED`]: "hist"}},
-		"human:cp-approval": {on: {[`${ns}.DONE`]: "shipped", [`${ns}.UNBLOCKED`]: "hist"}},
+		"human:cp-approval": {on: {[`${ns}.UNBLOCKED`]: "hist"}},
+		"human:queue-stall": {on: {[`${ns}.UNBLOCKED`]: "hist"}},
 		hist: {type: "history"},
 		shipped: {type: "final"},
 		"human:epic-review": {type: "final"},

--- a/packages/fabrika-cli/src/lane/emit.ts
+++ b/packages/fabrika-cli/src/lane/emit.ts
@@ -114,6 +114,11 @@ const region = (ns: string, initial: "queued" | "landed" | "frozen"): Record<str
  * the same reason the review edge's is: the repair round happens outside the machine, so the next
  * thing the lane can record is another verdict.
  *
+ * `ship:queued` is the tail's wait cell (ADR 0313): the tail is the one place an epic run meets a
+ * merge queue, so it is the one region that needs it — a child region has no `ship` and reaches no
+ * queue at all. The `WIP` out of it is a guarded array like the FAIL above, but it spends `waits`
+ * rather than `retries`, so a queue dwell cannot eat the epic review's repair rounds.
+ *
  * `review` FAIL is a two-arm guarded array so the fallthrough final is an *error* final by the
  * compiler's own structural read; a plain target would leave a failed epic review folding to
  * `complete`. The retry arm is `review` itself: a repair round happens outside the machine and the
@@ -137,6 +142,7 @@ const epicRegion = (ns: string): Record<string, unknown> => ({
 		ship: {
 			on: {
 				[`${ns}.DONE`]: "shipped",
+				[`${ns}.WIP`]: "ship:queued",
 				[`${ns}.BLOCKED`]: "human:cp-approval",
 				[`${ns}.FAIL`]: [
 					{target: "review", guard: "retriesRemaining", actions: "incrementRetries"},
@@ -144,8 +150,22 @@ const epicRegion = (ns: string): Record<string, unknown> => ({
 				],
 			},
 		},
+		"ship:queued": {
+			on: {
+				[`${ns}.DONE`]: "shipped",
+				[`${ns}.BLOCKED`]: "human:cp-approval",
+				[`${ns}.WIP`]: [
+					{target: "ship:queued", guard: "waitsRemaining", actions: "incrementWaits"},
+					{target: "human:cp-approval"},
+				],
+				[`${ns}.FAIL`]: [
+					{target: "review", guard: "retriesRemaining", actions: "incrementRetries"},
+					{target: "human:epic-review"},
+				],
+			},
+		},
 		blocked: {on: {[`${ns}.UNBLOCKED`]: "hist"}},
-		"human:cp-approval": {on: {[`${ns}.UNBLOCKED`]: "hist"}},
+		"human:cp-approval": {on: {[`${ns}.DONE`]: "shipped", [`${ns}.UNBLOCKED`]: "hist"}},
 		hist: {type: "history"},
 		shipped: {type: "final"},
 		"human:epic-review": {type: "final"},

--- a/packages/fabrika-cli/src/lane/fold.ts
+++ b/packages/fabrika-cli/src/lane/fold.ts
@@ -215,6 +215,8 @@ export const deriveStatus = (
 			retries: state.retries,
 			maxRetries: state.maxRetries,
 			...(state.cleared.length === 0 ? {} : {clearedRounds: state.cleared}),
+			waits: state.waits,
+			maxWaits: state.maxWaits,
 			...taskIn(lane, taskId).extras,
 			...(cause === undefined ? {} : {cause}),
 		};

--- a/packages/fabrika-cli/src/lane/fold.unit.test.ts
+++ b/packages/fabrika-cli/src/lane/fold.unit.test.ts
@@ -4,6 +4,7 @@
  */
 import {describe, expect, it} from "vitest";
 import {CAP_ROUND, RETRY_BUDGET} from "../retry-budget.ts";
+import {WAIT_BUDGET} from "../wait-budget.ts";
 import {coderWorkflow, twoPhaseWorkflow} from "./fixtures.test-support.ts";
 import {
 	applyClearance,
@@ -77,9 +78,9 @@ describe("run 1 — a fresh lane's status shape", () => {
 			},
 			status: "active",
 			context: {
-				task_a: {retries: 0, maxRetries: 2, code: true},
-				task_b: {retries: 0, maxRetries: 3, code: false},
-				task_c: {retries: 0, maxRetries: 3, code: true},
+				task_a: {retries: 0, maxRetries: 2, waits: 0, maxWaits: WAIT_BUDGET, code: true},
+				task_b: {retries: 0, maxRetries: 3, waits: 0, maxWaits: WAIT_BUDGET, code: false},
+				task_c: {retries: 0, maxRetries: 3, waits: 0, maxWaits: WAIT_BUDGET, code: true},
 				errors: [],
 			},
 		});

--- a/packages/fabrika-cli/src/lane/key.ts
+++ b/packages/fabrika-cli/src/lane/key.ts
@@ -62,6 +62,11 @@ export const laneRef = (key: LaneKey, root: string | null): LaneRef => ({
 	lane: key._tag === "Chore" ? key.name : key.lane,
 });
 
-/** The committed template a key boots from, by file name under `./templates/`. */
-export const templateFile = (key: LaneKey): string =>
-	key._tag === "Chore" ? "chore.workflow.json" : "coder.workflow.json";
+/**
+ * The committed template a lane of this kind boots from, by file name under `./templates/`.
+ *
+ * Keyed on the kind rather than a whole key because `lane migrate` sweeps a *root*, which selects a
+ * kind and names no lane — asking it for a key would mean inventing one nobody addressed.
+ */
+export const templateFile = (kind: LaneKey["_tag"]): string =>
+	kind === "Chore" ? "chore.workflow.json" : "coder.workflow.json";

--- a/packages/fabrika-cli/src/lane/key.unit.test.ts
+++ b/packages/fabrika-cli/src/lane/key.unit.test.ts
@@ -35,8 +35,8 @@ describe("the lane key", () => {
 	});
 
 	it("selects the boot template by kind, never by root", () => {
-		expect(templateFile(key("5673"))).toBe("coder.workflow.json");
-		expect(templateFile(key("chore:park-sweep"))).toBe("chore.workflow.json");
+		expect(templateFile(key("5673")._tag)).toBe("coder.workflow.json");
+		expect(templateFile(key("chore:park-sweep")._tag)).toBe("chore.workflow.json");
 	});
 
 	it("refuses a chore name that is not lowercase kebab", () => {

--- a/packages/fabrika-cli/src/lane/machine.ts
+++ b/packages/fabrika-cli/src/lane/machine.ts
@@ -6,9 +6,12 @@
  * Three structural recognitions replace every name-driven mechanism, and **no guard or action name
  * is ever dereferenced** — a `guard`/`actions` string in the document is inert data:
  *
- *   - An **array on an event** means guarded-FAIL: `[retry-while-retries-remain, else-fallthrough]`.
- *     The guard is the one inline `retries < maxRetries` in the compiled cell; the fallthrough
- *     target, when final, is the task's error final (`frozen`, `tripped`).
+ *   - An **array on an event** means guarded-loop: `[loop-while-budget-remains, else-fallthrough]`.
+ *     The guard is one inline counter comparison in the compiled cell; the fallthrough target, when
+ *     final, is the task's error final (`frozen`, `tripped`). **Which counter it spends is the
+ *     event's own polarity**: `FAIL` is a repair round and spends `retries`, every other event is a
+ *     wait and spends `waits`. A queue dwell must not eat the budget a later repair draws on, and
+ *     reading that off the event keeps it structural — no guard name is consulted (ADR 0313).
  *   - A transition **targeting a `history` node** resumes the state the task left, carried as the
  *     `was` field in {@link TaskState} — history-state semantics as data, no pseudo-state.
  *   - A phase's **`onDone` pair** `[{target, guard}, {target}]` names the two workflow terminals
@@ -30,6 +33,7 @@ import type {Machine} from "@demlik/tea";
 import {defineMachine} from "@demlik/tea";
 import {budgetWith} from "../cap-clearance.ts";
 import {RETRY_BUDGET} from "../retry-budget.ts";
+import {WAIT_BUDGET} from "../wait-budget.ts";
 
 /** The operator's whole event vocabulary — the six, closed (#5570 founder session, 2026-08-15). */
 export const OPERATOR_EVENTS = ["DONE", "PASS", "FAIL", "BLOCKED", "WIP", "UNBLOCKED"] as const;
@@ -47,7 +51,7 @@ export const isOperatorEvent = (event: string): event is OperatorEvent =>
 export const CLEARED_EVENT = "CLEARED";
 
 /**
- * One task's folded state: the leaf, the retry budget, the state it left (`was`), and the grants
+ * One task's folded state: the leaf, its two budgets, the state it left (`was`), and the grants
  * applied so far — `cleared` is the fold's own tally of {@link CLEARED_EVENT} rounds, which is what
  * makes `maxRetries` a function of the log's prefix rather than of a document anyone can edit.
  */
@@ -56,6 +60,9 @@ export interface TaskState {
 	readonly retries: number;
 	readonly maxRetries: number;
 	readonly cleared: ReadonlyArray<number>;
+	/** Re-folds spent waiting on something outside the lane — never the repair budget above. */
+	readonly waits: number;
+	readonly maxWaits: number;
 	readonly was?: string;
 }
 
@@ -77,9 +84,11 @@ export interface CompiledTask {
 	/** The finals that hold a cell for some event — parks the lane trips on and resumes from. */
 	readonly openFinals: ReadonlySet<string>;
 	/**
-	 * The states holding a guarded cell — the ones whose only non-`PASS` route out is gated on
-	 * `retries < maxRetries`. Read at resume time, where landing in one with the budget spent means
-	 * the state was restored and the budget was not (#6570).
+	 * The states holding a **retries**-guarded cell — the ones whose only non-`PASS` route out is
+	 * gated on `retries < maxRetries`. Read at resume time, where landing in one with the budget
+	 * spent means the state was restored and the budget was not (#6570). A wait-guarded cell is not
+	 * one of these: its spent fallthrough is a human park that names the stall, not a fall back into
+	 * the error final the resume just left (ADR 0313).
 	 */
 	readonly guardedStates: ReadonlySet<string>;
 	/**
@@ -88,7 +97,7 @@ export interface CompiledTask {
 	 * rather than leaving an operator staring at a grant that silently buys nothing.
 	 */
 	readonly staleGrants: ReadonlyArray<number>;
-	/** The task's `context` entry minus the retry bookkeeping — passed through to status. */
+	/** The task's `context` entry minus the two budgets' bookkeeping — passed through to status. */
 	readonly extras: Readonly<Record<string, unknown>>;
 }
 
@@ -184,7 +193,7 @@ const compileRegion = (taskId: string, region: unknown, context: unknown): Regio
 				const [retry, fallthrough] = targets;
 				if (transition.length !== 2 || retry === undefined || fallthrough === undefined) {
 					defects.push(
-						`task "${taskId}": guarded "${eventName}" must be a two-arm array of \`{target}\` — [retry-while-retries-remain, else-fallthrough]`,
+						`task "${taskId}": guarded "${eventName}" must be a two-arm array of \`{target}\` — [loop-while-budget-remains, else-fallthrough]`,
 					);
 					continue;
 				}
@@ -194,11 +203,17 @@ const compileRegion = (taskId: string, region: unknown, context: unknown): Regio
 					}
 				}
 				if (finals.has(fallthrough)) errorFinals.add(fallthrough);
-				guardedStates.add(stateName);
-				cells[msg] = (s) =>
-					s.retries < s.maxRetries
-						? [{...s, type: retry, retries: s.retries + 1, was: s.type}, []]
-						: [{...s, type: fallthrough, was: s.type}, []];
+				if (msg === "FAIL") guardedStates.add(stateName);
+				cells[msg] =
+					msg === "FAIL"
+						? (s) =>
+								s.retries < s.maxRetries
+									? [{...s, type: retry, retries: s.retries + 1, was: s.type}, []]
+									: [{...s, type: fallthrough, was: s.type}, []]
+						: (s) =>
+								s.waits < s.maxWaits
+									? [{...s, type: retry, waits: s.waits + 1, was: s.type}, []]
+									: [{...s, type: fallthrough, was: s.type}, []];
 				continue;
 			}
 			if (typeof transition !== "string") {
@@ -241,8 +256,25 @@ const compileRegion = (taskId: string, region: unknown, context: unknown): Regio
 	const staleGrants = Array.isArray(ctx.clearedRounds)
 		? ctx.clearedRounds.filter((round): round is number => typeof round === "number")
 		: [];
-	const {maxRetries: _max, retries: _retries, clearedRounds: _cleared, ...extras} = ctx;
-	const initial: TaskState = {type: initialState, retries: 0, maxRetries: declared, cleared: []};
+	// A cap clearance buys a repair round and never a longer wait: `clearedCell` raises `maxRetries`
+	// alone, so the wait budget is a declared constant no recorded event moves (ADRs 0312, 0313).
+	const maxWaits = typeof ctx.maxWaits === "number" ? ctx.maxWaits : WAIT_BUDGET;
+	const {
+		maxRetries: _max,
+		retries: _retries,
+		clearedRounds: _cleared,
+		maxWaits: _maxWaits,
+		waits: _waits,
+		...extras
+	} = ctx;
+	const initial: TaskState = {
+		type: initialState,
+		retries: 0,
+		maxRetries: declared,
+		cleared: [],
+		waits: 0,
+		maxWaits,
+	};
 	// The Transitions mapped type demands a cell for every (state × msg) pair; a lane machine is
 	// compiled from data and deliberately partial — the absent cells ARE the refusal contract
 	// (`applyCell` throws `NoCellError` on them). One cast at the construction boundary.
@@ -372,6 +404,7 @@ export interface LaneTopology {
 			{
 				readonly initial: string;
 				readonly maxRetries: number;
+				readonly maxWaits: number;
 				/** Per state, the events it holds a cell for — everything else refuses. */
 				readonly states: Readonly<Record<string, ReadonlyArray<string>>>;
 			}
@@ -394,6 +427,7 @@ export const topology = (lane: CompiledLane): LaneTopology => ({
 			{
 				initial: task.initial.type,
 				maxRetries: task.initial.maxRetries,
+				maxWaits: task.initial.maxWaits,
 				states: Object.fromEntries(
 					Object.entries(task.machine.update as Record<string, Record<string, unknown>>).map(
 						([state, cells]) => [state, Object.keys(cells)],

--- a/packages/fabrika-cli/src/lane/machine.unit.test.ts
+++ b/packages/fabrika-cli/src/lane/machine.unit.test.ts
@@ -1,4 +1,5 @@
 import {describe, expect, it} from "vitest";
+import {classifyPark, isPark} from "../recipe/parks.ts";
 import {WAIT_BUDGET} from "../wait-budget.ts";
 import {
 	choreWorkflow,
@@ -294,14 +295,34 @@ describe("`ship:queued` — a proven-clean enqueue is a wait, not a park (ADR 03
 		]);
 	});
 
-	it("re-enters itself for WAIT_BUDGET re-folds, then escalates to the human park", () => {
+	it("re-enters itself for WAIT_BUDGET re-folds, then escalates to its own human park", () => {
 		const waiting = Array.from({length: WAIT_BUDGET + 2}, () => "WIP");
 
 		expect(leaves(compiled(coderWorkflow()), "issue", [...toShip, ...waiting])).toEqual([
 			...reached,
 			...Array.from({length: WAIT_BUDGET + 1}, () => "ship:queued"),
-			"human:cp-approval",
+			"human:queue-stall",
 		]);
+	});
+
+	// A spent wait carries no park cause — `report.ts` refuses one on any non-BLOCKED event — so
+	// landing it in `human:cp-approval` would key `parks.ts`'s `cause: null` §CP row and clear it by
+	// reading an approval nobody was waiting on. Its own leaf is what makes the sweep read it novel.
+	it("escalates to a park the recipe table reads as novel, never as the §CP row", () => {
+		const stalled = [...toShip, ...Array.from({length: WAIT_BUDGET + 2}, () => "WIP")];
+		const leaf = defined(leaves(compiled(coderWorkflow()), "issue", stalled).at(-1));
+
+		expect(isPark(leaf)).toBe(true);
+		expect(classifyPark(leaf, null)._tag).toBe("Novel");
+		expect(classifyPark("human:cp-approval", null)._tag).toBe("Known");
+	});
+
+	it("lets a human clear the stall back into the wait cell", () => {
+		const stalled = [...toShip, ...Array.from({length: WAIT_BUDGET + 2}, () => "WIP")];
+
+		expect(leaves(compiled(coderWorkflow()), "issue", [...stalled, "UNBLOCKED"]).at(-1)).toBe(
+			"ship:queued",
+		);
 	});
 
 	it("spends `waits`, leaving the repair budget a later FAIL draws on untouched", () => {
@@ -329,11 +350,18 @@ describe("`ship:queued` — a proven-clean enqueue is a wait, not a park (ADR 03
 		]);
 	});
 
-	it("gives an already-parked lane over a merged PR a route out", () => {
-		expect(leaves(compiled(coderWorkflow()), "issue", [...toShip, "BLOCKED", "DONE"])).toEqual([
-			...reached,
-			"human:cp-approval",
-			"shipped",
-		]);
+	// Lane 6462's real route out, and the only one ADR 0302 permits: a park is left by a recorded
+	// `UNBLOCKED` and never by a second exit cell, so the landing is recorded from the state the lane
+	// resumes into rather than from inside the park.
+	it("leaves a park over a merged PR by UNBLOCKED, then records the landing", () => {
+		expect(
+			leaves(compiled(coderWorkflow()), "issue", [...toShip, "BLOCKED", "UNBLOCKED", "DONE"]),
+		).toEqual([...reached, "human:cp-approval", "ship", "shipped"]);
+	});
+
+	it("refuses a DONE inside the park rather than opening a second exit from it", () => {
+		expect(() =>
+			leaves(compiled(coderWorkflow()), "issue", [...toShip, "BLOCKED", "DONE"]),
+		).toThrow(/DONE/);
 	});
 });

--- a/packages/fabrika-cli/src/lane/machine.unit.test.ts
+++ b/packages/fabrika-cli/src/lane/machine.unit.test.ts
@@ -1,4 +1,5 @@
 import {describe, expect, it} from "vitest";
+import {WAIT_BUDGET} from "../wait-budget.ts";
 import {
 	choreWorkflow,
 	coderWorkflow,
@@ -62,6 +63,8 @@ describe("the compiler — structural recognition", () => {
 			retries: 0,
 			maxRetries: 2,
 			cleared: [],
+			waits: 0,
+			maxWaits: WAIT_BUDGET,
 		});
 		expect([...defined(lane.tasks.issue).finals].sort()).toEqual(["frozen", "shipped"]);
 		expect([...defined(lane.tasks.issue).errorFinals]).toEqual(["frozen"]);
@@ -111,10 +114,19 @@ describe("the compiler — structural recognition", () => {
 		]);
 		expect(defined(summary.tasks.issue).states.ship).toEqual([
 			"DONE",
+			"WIP",
 			"BLOCKED",
 			"FAIL",
 			CLEARED_EVENT,
 		]);
+		expect(defined(summary.tasks.issue).states["ship:queued"]).toEqual([
+			"DONE",
+			"BLOCKED",
+			"WIP",
+			"FAIL",
+			CLEARED_EVENT,
+		]);
+		expect(defined(summary.tasks.issue).states.shipped).toEqual([CLEARED_EVENT]);
 		// `frozen` is a final that carries a door: a park the lane trips on, not an end (ADR 0297).
 		expect(defined(summary.tasks.issue).states.frozen).toEqual(["UNBLOCKED", CLEARED_EVENT]);
 		expect(summary.trigger).toBeUndefined();
@@ -150,6 +162,8 @@ describe("the compiler — structural recognition", () => {
 			retries: 0,
 			maxRetries: 2,
 			cleared: [],
+			waits: 0,
+			maxWaits: WAIT_BUDGET,
 		});
 		expect([...defined(lane.tasks.park_sweep).errorFinals]).toEqual(["frozen"]);
 		expect([...defined(lane.tasks.park_sweep).openFinals]).toEqual(["frozen"]);
@@ -242,5 +256,84 @@ describe("the compiler — refusals", () => {
 	it("refuses a document that is not machine-shaped at all", () => {
 		expect(defectsOf(null)).toContain("machine.states");
 		expect(defectsOf({})).toContain("machine.states");
+	});
+});
+
+describe("`ship:queued` — a proven-clean enqueue is a wait, not a park (ADR 0313)", () => {
+	const toShip = ["WIP", "DONE", "PASS"] as const;
+	const reached = ["build", "review", "ship"] as const;
+
+	/** Drive the same events as {@link leaves}, but answer with the task's folded budgets. */
+	const budgets = (lane: CompiledLane, task: string, events: ReadonlyArray<string>) => {
+		const log: LogEntry[] = [];
+		const statesOf = () => {
+			const fold = foldLog(lane, log);
+			if (fold._tag !== "Folded") throw new Error(fold.defects.join("; "));
+			return fold.states;
+		};
+		for (const event of events) {
+			const applied = applyEvent(lane, statesOf(), task, event, "2026-08-20T00:00:00.000Z");
+			if (applied._tag !== "Applied") throw new Error(`${task} ${event}: ${applied.reason}`);
+			log.push(applied.entry);
+		}
+		return defined(statesOf()[task]);
+	};
+
+	it("takes a still-queued shipper out of `ship` into the wait cell", () => {
+		expect(leaves(compiled(coderWorkflow()), "issue", [...toShip, "WIP"])).toEqual([
+			...reached,
+			"ship:queued",
+		]);
+	});
+
+	it("absorbs the late landing lane 6462 could not record — WIP then DONE folds to `shipped`", () => {
+		expect(leaves(compiled(coderWorkflow()), "issue", [...toShip, "WIP", "DONE"])).toEqual([
+			...reached,
+			"ship:queued",
+			"shipped",
+		]);
+	});
+
+	it("re-enters itself for WAIT_BUDGET re-folds, then escalates to the human park", () => {
+		const waiting = Array.from({length: WAIT_BUDGET + 2}, () => "WIP");
+
+		expect(leaves(compiled(coderWorkflow()), "issue", [...toShip, ...waiting])).toEqual([
+			...reached,
+			...Array.from({length: WAIT_BUDGET + 1}, () => "ship:queued"),
+			"human:cp-approval",
+		]);
+	});
+
+	it("spends `waits`, leaving the repair budget a later FAIL draws on untouched", () => {
+		const waiting = Array.from({length: WAIT_BUDGET + 1}, () => "WIP");
+
+		expect(budgets(compiled(coderWorkflow()), "issue", [...toShip, ...waiting])).toMatchObject({
+			type: "ship:queued",
+			waits: WAIT_BUDGET,
+			retries: 0,
+		});
+	});
+
+	it("routes an ejection out of the wait cell to repair with a full retry budget", () => {
+		const lane = compiled(coderWorkflow());
+		const ejected = [...toShip, "WIP", "FAIL"];
+
+		expect(leaves(lane, "issue", ejected)).toEqual([...reached, "ship:queued", "build"]);
+		expect(budgets(lane, "issue", ejected)).toMatchObject({retries: 1, waits: 0});
+	});
+
+	it("still parks a genuine block out of `ship` on `human:cp-approval` (#5820 untouched)", () => {
+		expect(leaves(compiled(coderWorkflow()), "issue", [...toShip, "BLOCKED"])).toEqual([
+			...reached,
+			"human:cp-approval",
+		]);
+	});
+
+	it("gives an already-parked lane over a merged PR a route out", () => {
+		expect(leaves(compiled(coderWorkflow()), "issue", [...toShip, "BLOCKED", "DONE"])).toEqual([
+			...reached,
+			"human:cp-approval",
+			"shipped",
+		]);
 	});
 });

--- a/packages/fabrika-cli/src/lane/machine.unit.test.ts
+++ b/packages/fabrika-cli/src/lane/machine.unit.test.ts
@@ -70,7 +70,25 @@ describe("the compiler — structural recognition", () => {
 		expect([...defined(lane.tasks.issue).finals].sort()).toEqual(["frozen", "shipped"]);
 		expect([...defined(lane.tasks.issue).errorFinals]).toEqual(["frozen"]);
 		expect([...defined(lane.tasks.issue).openFinals]).toEqual(["frozen"]);
-		expect([...defined(lane.tasks.issue).guardedStates].sort()).toEqual(["review", "ship"]);
+		expect([...defined(lane.tasks.issue).guardedStates].sort()).toEqual([
+			"review",
+			"ship",
+			"ship:queued",
+		]);
+	});
+
+	it("counts a state as guarded only for the retry budget, never for the wait budget", () => {
+		const workflow = twoPhaseWorkflow();
+		// A WIP-guarded array spends `waits`, and its spent fallthrough is a park that names the stall
+		// — not a fall back into the error final a resume just left, so it is no resume hazard (#6570).
+		stateNode(workflow, "task_a", "doing").on["TASK_A.WIP"] = [
+			{target: "doing"},
+			{target: "tripped"},
+		];
+
+		const lane = compiled(workflow);
+
+		expect([...defined(lane.tasks.task_a).guardedStates]).toEqual(["checking"]);
 	});
 
 	it("leaves every final an end but `frozen`, though all of them take a clearance", () => {

--- a/packages/fabrika-cli/src/lane/migrate-verb.ts
+++ b/packages/fabrika-cli/src/lane/migrate-verb.ts
@@ -1,0 +1,201 @@
+/**
+ * `lane migrate` — bring every booted lane's machine up to the committed template, or say why not.
+ *
+ * The second verb in the group that reads across lanes rather than into one, and for the same reason
+ * `lane stale` does: the question is a sweep. A machine change ships in one commit and the lanes
+ * carrying the old copy are all of them, so migrating them one key at a time is a loop nobody would
+ * run to the end.
+ *
+ * Every lane is judged before anything is written to it, and each is judged on its own: a lane that
+ * cannot be migrated is a row, never the end of the sweep, because refusing the whole answer over
+ * one lane would leave every other lane on a machine its driver is about to break. The write is the
+ * last thing that happens on a lane and only on a `Preserved` verdict ({@link judgeMigration}).
+ *
+ * `--check` is the same sweep with the write withheld — what a driver runs to find out whether a
+ * lane it is about to drive is stale, and what a release runs before merging a machine change.
+ */
+import {Effect, type FileSystem, Path, Result} from "effect";
+import {exists, readDir, readFile, writeFile} from "../io/fs.ts";
+import {answer, refuse, type VerbOutcome} from "../verb.ts";
+import {LANE_UNREADABLE, MIGRATION_UNSAFE} from "./codes.ts";
+import {CHORE_PREFIX} from "./key.ts";
+import {compileText} from "./machine.ts";
+import {type Drift, graftContext, judgeMigration} from "./migrate.ts";
+import {DEFAULT_CHORES_ROOT, loadLane} from "./store.ts";
+
+const VERB = "fabrika lane migrate";
+
+/** One root to sweep, bound to the committed template its lanes boot from. */
+export interface MigrateRoot {
+	readonly root: string;
+	/** The template's on-disk path — resolved by the adapter, so this verb joins no paths of its own. */
+	readonly templatePath: string;
+}
+
+export interface MigrateOptions {
+	readonly roots: ReadonlyArray<MigrateRoot>;
+	/** Judge and report, write nothing. */
+	readonly check: boolean;
+}
+
+type Verdict = "current" | "migrated" | "stale" | "generated" | "unsafe" | "unreadable";
+
+const VERDICTS: ReadonlyArray<Verdict> = [
+	"current",
+	"migrated",
+	"stale",
+	"generated",
+	"unsafe",
+	"unreadable",
+];
+
+interface LaneRow {
+	readonly key: string;
+	readonly root: string;
+	readonly verdict: Verdict;
+	/** Why the sweep could not migrate this lane; absent on every lane it could act on. */
+	readonly reason?: string;
+	readonly drifts?: ReadonlyArray<Drift>;
+}
+
+/** How a caller addresses this lane: a chore root's entries are keyed `chore:<name>` (`key.ts`). */
+const keyOf = (root: string, name: string): string =>
+	root === DEFAULT_CHORES_ROOT ? `${CHORE_PREFIX}${name}` : name;
+
+const migrateLane = (
+	root: string,
+	name: string,
+	templateText: string,
+	check: boolean,
+): Effect.Effect<LaneRow | null, never, FileSystem.FileSystem | Path.Path> =>
+	Effect.gen(function* () {
+		const path = yield* Path.Path;
+		const key = keyOf(root, name);
+		const unreadable = (reason: string): LaneRow => ({key, root, verdict: "unreadable", reason});
+		const loaded = yield* loadLane({root, lane: name});
+		// An entry with no workflow.json is not a lane — a scratch directory under the root is not a
+		// migration to report, and calling it one would put noise in front of every real one.
+		if (loaded._tag === "Absent") return null;
+		if (loaded._tag === "Unreadable") {
+			return unreadable(`cannot read ${loaded.path}: ${loaded.reason}`);
+		}
+		if (loaded._tag === "Malformed") {
+			return unreadable(`${loaded.path} is not the shape: ${loaded.defects.join("; ")}`);
+		}
+
+		const workflowPath = path.join(loaded.dir, "workflow.json");
+		const onDisk = yield* Effect.result(readFile(workflowPath));
+		if (Result.isFailure(onDisk)) {
+			return unreadable(`cannot re-read ${workflowPath}: ${onDisk.failure.reason}`);
+		}
+		const graft = graftContext(templateText, onDisk.success);
+		if (graft._tag === "Ungraftable") return unreadable(graft.reason);
+		if (graft._tag === "Foreign") {
+			return {key, root, verdict: "generated", reason: `machine "${graft.id}" was generated`};
+		}
+		if (onDisk.success === graft.text) return {key, root, verdict: "current"};
+
+		const candidate = compileText(graft.text);
+		if (candidate._tag === "Malformed") {
+			return unreadable(`the committed template does not compile: ${candidate.defects.join("; ")}`);
+		}
+		const judged = judgeMigration(loaded.lane, candidate.lane, loaded.entries);
+		if (judged._tag === "Unreplayable") {
+			return {
+				key,
+				root,
+				verdict: "unsafe",
+				reason:
+					judged.through === "current"
+						? `${loaded.logPath} already does not replay through this lane's own machine: ${judged.defects.join("; ")}`
+						: `${loaded.logPath} does not replay through the committed template: ${judged.defects.join("; ")}`,
+			};
+		}
+		if (judged._tag === "Drifts") {
+			return {
+				key,
+				root,
+				verdict: "unsafe",
+				reason: `the committed template would fold this lane's log to a different state: ${judged.drifts
+					.map((drift) => `${drift.task} ${drift.from} → ${drift.to}`)
+					.join("; ")}`,
+				drifts: judged.drifts,
+			};
+		}
+		if (check) return {key, root, verdict: "stale"};
+
+		const wrote = yield* Effect.result(writeFile(workflowPath, graft.text));
+		return Result.isFailure(wrote)
+			? unreadable(`the write to ${workflowPath} did not land: ${wrote.failure.reason}`)
+			: {key, root, verdict: "migrated"};
+	});
+
+export const runMigrate = (
+	options: MigrateOptions,
+): Effect.Effect<VerbOutcome, never, FileSystem.FileSystem | Path.Path> =>
+	Effect.gen(function* () {
+		const lanes: LaneRow[] = [];
+		const scanned: Array<{root: string; present: boolean; lanes: number}> = [];
+		for (const {root, templatePath} of options.roots) {
+			const template = yield* Effect.result(readFile(templatePath));
+			if (Result.isFailure(template)) {
+				return refuse(
+					LANE_UNREADABLE,
+					`${VERB}: cannot read the committed template at ${templatePath}: ${template.failure.reason} — nothing was migrated.`,
+				);
+			}
+			const probe = yield* Effect.result(exists(root));
+			if (Result.isFailure(probe)) {
+				return refuse(
+					LANE_UNREADABLE,
+					`${VERB}: cannot establish whether ${root} is there: ${probe.failure.reason} — the lane set is UNKNOWN, never empty.`,
+				);
+			}
+			if (!probe.success) {
+				scanned.push({root, present: false, lanes: 0});
+				continue;
+			}
+			const names = yield* Effect.result(readDir(root));
+			if (Result.isFailure(names)) {
+				return refuse(
+					LANE_UNREADABLE,
+					`${VERB}: cannot list ${root}: ${names.failure.reason} — the lane set is UNKNOWN, never empty.`,
+				);
+			}
+			let found = 0;
+			for (const name of [...names.success].sort()) {
+				const row = yield* migrateLane(root, name, template.success, options.check);
+				if (row === null) continue;
+				found += 1;
+				lanes.push(row);
+			}
+			scanned.push({root, present: true, lanes: found});
+		}
+
+		const summary = Object.fromEntries(
+			VERDICTS.map((verdict) => [verdict, lanes.filter((row) => row.verdict === verdict).length]),
+		);
+		const unsafe = lanes.filter((row) => row.verdict === "unsafe");
+		const acted = lanes.filter((row) => row.verdict === (options.check ? "stale" : "migrated"));
+		const stderr = [
+			`${VERB}: swept ${scanned.map((entry) => `${entry.root} (${entry.present ? `${entry.lanes} lane(s)` : "absent"})`).join(", ")}${options.check ? " — check only, nothing written" : ""}.`,
+			...unsafe.map((row) => `${VERB}: ${row.key}: ${row.reason ?? "unsafe"}`),
+		];
+		if (unsafe.length === 0) {
+			return answer(
+				JSON.stringify({check: options.check, scanned, summary, lanes}, null, 2),
+				stderr,
+			);
+		}
+		// The refusal's stdout is empty by contract, so the keys that DID move have to reach the
+		// operator on stderr — otherwise a partly-applied sweep is a write nobody can enumerate.
+		return refuse(
+			MIGRATION_UNSAFE,
+			`${VERB}: ${unsafe.length} lane(s) cannot take the committed template without moving, and none of those was written: ${unsafe.map((row) => row.key).join(", ")}. ${
+				options.check
+					? `${acted.length} other lane(s) are stale and safe to migrate.`
+					: `${acted.length} other lane(s) were migrated: ${acted.map((row) => row.key).join(", ") || "none"}.`
+			} Decide each unsafe lane's state by hand — re-run to sweep the rest.`,
+			stderr,
+		);
+	});

--- a/packages/fabrika-cli/src/lane/migrate-verb.ts
+++ b/packages/fabrika-cli/src/lane/migrate-verb.ts
@@ -20,16 +20,23 @@ import {answer, refuse, type VerbOutcome} from "../verb.ts";
 import {LANE_UNREADABLE, MIGRATION_UNSAFE} from "./codes.ts";
 import {CHORE_PREFIX} from "./key.ts";
 import {compileText} from "./machine.ts";
-import {type Drift, graftContext, judgeMigration} from "./migrate.ts";
+import {type Drift, graftContext, judgeMigration, sameMachine} from "./migrate.ts";
 import {DEFAULT_CHORES_ROOT, loadLane} from "./store.ts";
 
 const VERB = "fabrika lane migrate";
 
-/** One root to sweep, bound to the committed template its lanes boot from. */
+/**
+ * One root to sweep, bound to the committed templates its lanes may have booted from.
+ *
+ * A *list* rather than one path, and the lane's own document `id` picks among them: a relocated root
+ * holds whatever lanes were opened into it, so binding a root to a single template made every chore
+ * lane under a `--root` read as `generated` — a lying row, since it was booted from the other
+ * committed template.
+ */
 export interface MigrateRoot {
 	readonly root: string;
-	/** The template's on-disk path — resolved by the adapter, so this verb joins no paths of its own. */
-	readonly templatePath: string;
+	/** The templates' on-disk paths — resolved by the adapter, so this verb joins no paths of its own. */
+	readonly templatePaths: ReadonlyArray<string>;
 }
 
 export interface MigrateOptions {
@@ -65,7 +72,7 @@ const keyOf = (root: string, name: string): string =>
 const migrateLane = (
 	root: string,
 	name: string,
-	templateText: string,
+	templateTexts: ReadonlyArray<string>,
 	check: boolean,
 ): Effect.Effect<LaneRow | null, never, FileSystem.FileSystem | Path.Path> =>
 	Effect.gen(function* () {
@@ -88,12 +95,16 @@ const migrateLane = (
 		if (Result.isFailure(onDisk)) {
 			return unreadable(`cannot re-read ${workflowPath}: ${onDisk.failure.reason}`);
 		}
-		const graft = graftContext(templateText, onDisk.success);
-		if (graft._tag === "Ungraftable") return unreadable(graft.reason);
-		if (graft._tag === "Foreign") {
-			return {key, root, verdict: "generated", reason: `machine "${graft.id}" was generated`};
+		const grafts = templateTexts.map((text) => graftContext(text, onDisk.success));
+		const ungraftable = grafts.find((candidate) => candidate._tag === "Ungraftable");
+		if (ungraftable !== undefined) return unreadable(ungraftable.reason);
+		const graft = grafts.find((candidate) => candidate._tag === "Grafted");
+		if (graft === undefined) {
+			const foreign = grafts.find((candidate) => candidate._tag === "Foreign");
+			const id = foreign === undefined ? name : foreign.id;
+			return {key, root, verdict: "generated", reason: `machine "${id}" was generated`};
 		}
-		if (onDisk.success === graft.text) return {key, root, verdict: "current"};
+		if (sameMachine(onDisk.success, graft.text)) return {key, root, verdict: "current"};
 
 		const candidate = compileText(graft.text);
 		if (candidate._tag === "Malformed") {
@@ -136,13 +147,17 @@ export const runMigrate = (
 	Effect.gen(function* () {
 		const lanes: LaneRow[] = [];
 		const scanned: Array<{root: string; present: boolean; lanes: number}> = [];
-		for (const {root, templatePath} of options.roots) {
-			const template = yield* Effect.result(readFile(templatePath));
-			if (Result.isFailure(template)) {
-				return refuse(
-					LANE_UNREADABLE,
-					`${VERB}: cannot read the committed template at ${templatePath}: ${template.failure.reason} — nothing was migrated.`,
-				);
+		for (const {root, templatePaths} of options.roots) {
+			const templateTexts: string[] = [];
+			for (const templatePath of templatePaths) {
+				const template = yield* Effect.result(readFile(templatePath));
+				if (Result.isFailure(template)) {
+					return refuse(
+						LANE_UNREADABLE,
+						`${VERB}: cannot read the committed template at ${templatePath}: ${template.failure.reason} — nothing was migrated.`,
+					);
+				}
+				templateTexts.push(template.success);
 			}
 			const probe = yield* Effect.result(exists(root));
 			if (Result.isFailure(probe)) {
@@ -164,7 +179,7 @@ export const runMigrate = (
 			}
 			let found = 0;
 			for (const name of [...names.success].sort()) {
-				const row = yield* migrateLane(root, name, template.success, options.check);
+				const row = yield* migrateLane(root, name, templateTexts, options.check);
 				if (row === null) continue;
 				found += 1;
 				lanes.push(row);

--- a/packages/fabrika-cli/src/lane/migrate.ts
+++ b/packages/fabrika-cli/src/lane/migrate.ts
@@ -1,0 +1,133 @@
+/**
+ * The migration judgement — may this lane's `workflow.json` be replaced by the committed template?
+ *
+ * `lane open` places a byte-identical copy of the committed template into each lane at boot and
+ * refuses to overwrite one afterwards, so a template edit reaches lanes booted after it and no lane
+ * already on disk. That is safe while an edit touches the *template* only. It stops being safe the
+ * moment a token→event map in code changes with it: `report.ts` is code, so a remap lands on every
+ * booted lane at once and asks their frozen machines for a cell they do not have (ADR 0313, and the
+ * `QUEUED`→`WIP` remap that named this).
+ *
+ * The fold is what makes a swap provable rather than hoped: state is `events.jsonl` replayed from
+ * scratch every run, with no snapshot anywhere. So a replacement is safe exactly when the existing
+ * log replays through the new machine to the same per-task leaf state it replays to through the old
+ * one. This module decides that and nothing else — it reads no disk and writes none.
+ *
+ * The check is deliberately stricter than "the log replays": a machine that re-routes an event the
+ * log already carries would replay fine and land the lane somewhere it never was, which is a
+ * rewritten history rather than a migration. Drift is refused with each task named.
+ *
+ * What gets written is not the template's bytes but {@link graftContext}'s — see there for why the
+ * lane's own `machine.context` survives the swap and why a generated machine is left alone.
+ */
+import {isRecord, parseJson} from "../io/json.ts";
+import {foldLog, type LogEntry} from "./fold.ts";
+import type {CompiledLane, TaskState} from "./machine.ts";
+
+/**
+ * The template's shape carrying the lane's own `machine.context`, as the text to write.
+ *
+ * The context is the one part of a booted lane's document that is **data, not shape**: a task's
+ * `maxRetries` is read from it, and a lane may carry per-task extras beside it that the fold passes
+ * through to status untouched. Copying the template over a lane verbatim would reset every one of
+ * them to the template's own numbers — a silent loss no fold could catch, because the log still
+ * replays. So the swap replaces the states and keeps the context.
+ *
+ * A founder's cleared round is *not* among the things being kept here, and deliberately: since
+ * ADR 0312 a grant is a `CLEARED` line in `events.jsonl`, never a context field, so it survives the
+ * swap for free — the log is what the new machine replays.
+ *
+ * `Foreign` is the other half of the same care: a lane whose machine was *generated* rather than
+ * booted (`lane emit`'s per-epic document) has no committed template to be brought up to, so it is
+ * not this sweep's business at all. The document `id` is the recognition — an emitted machine is
+ * `epic-<n>` and a booted one carries its template's id.
+ */
+export type Graft =
+	| {readonly _tag: "Grafted"; readonly text: string}
+	| {readonly _tag: "Foreign"; readonly id: string}
+	| {readonly _tag: "Ungraftable"; readonly reason: string};
+
+const documentId = (document: unknown): string | null =>
+	isRecord(document) && typeof document.id === "string" ? document.id : null;
+
+const contextOf = (document: unknown): Record<string, unknown> | null => {
+	if (!isRecord(document)) return null;
+	const machine = document.machine;
+	return isRecord(machine) && isRecord(machine.context) ? {...machine.context} : null;
+};
+
+/** Build the text a migration would write, or say why this lane is not one to write it to. */
+export const graftContext = (templateText: string, laneText: string): Graft => {
+	const template = parseJson(templateText);
+	const lane = parseJson(laneText);
+	const templateId = documentId(template);
+	const laneId = documentId(lane);
+	if (templateId === null)
+		return {_tag: "Ungraftable", reason: "the committed template has no `id`"};
+	if (laneId === null) return {_tag: "Ungraftable", reason: "this lane's document has no `id`"};
+	if (laneId !== templateId) return {_tag: "Foreign", id: laneId};
+
+	const templateContext = contextOf(template);
+	const laneContext = contextOf(lane);
+	if (templateContext === null || laneContext === null) {
+		return {_tag: "Ungraftable", reason: "one of the two documents carries no `machine.context`"};
+	}
+	const grafted = Object.fromEntries(
+		Object.keys(templateContext).map((task) => [task, laneContext[task] ?? templateContext[task]]),
+	);
+	const machine = (template as {machine: Record<string, unknown>}).machine;
+	return {
+		_tag: "Grafted",
+		text: `${JSON.stringify({...(template as object), machine: {...machine, context: grafted}}, null, "\t")}\n`,
+	};
+};
+
+/** One task whose folded state would move if the machine were swapped under it. */
+export interface Drift {
+	readonly task: string;
+	readonly from: string;
+	readonly to: string;
+}
+
+export type MigrationVerdict =
+	/** The log replays through both machines to the same states — the swap changes no lane state. */
+	| {readonly _tag: "Preserved"; readonly states: Readonly<Record<string, TaskState>>}
+	/** The log does not replay through one of the machines, and which one decides the remedy. */
+	| {
+			readonly _tag: "Unreplayable";
+			readonly through: "current" | "candidate";
+			readonly defects: ReadonlyArray<string>;
+	  }
+	/** Both replay and disagree — the candidate would relocate the lane, not migrate it. */
+	| {readonly _tag: "Drifts"; readonly drifts: ReadonlyArray<Drift>};
+
+/**
+ * Judge one swap. The candidate's task set may be a superset of the current one — a new task region
+ * is a machine the log has nothing to say about yet, and it folds to its own initial state — but a
+ * task the current machine folds and the candidate does not carry is a drift, because that lane's
+ * state would simply stop being represented.
+ */
+export const judgeMigration = (
+	current: CompiledLane,
+	candidate: CompiledLane,
+	entries: ReadonlyArray<LogEntry>,
+): MigrationVerdict => {
+	const before = foldLog(current, entries);
+	if (before._tag !== "Folded") {
+		return {_tag: "Unreplayable", through: "current", defects: before.defects};
+	}
+	const after = foldLog(candidate, entries);
+	if (after._tag !== "Folded") {
+		return {_tag: "Unreplayable", through: "candidate", defects: after.defects};
+	}
+	const drifts: Drift[] = [];
+	for (const [task, state] of Object.entries(before.states)) {
+		const next = after.states[task];
+		if (next === undefined) {
+			drifts.push({task, from: state.type, to: "(no such task)"});
+			continue;
+		}
+		if (next.type !== state.type) drifts.push({task, from: state.type, to: next.type});
+	}
+	return drifts.length > 0 ? {_tag: "Drifts", drifts} : {_tag: "Preserved", states: after.states};
+};

--- a/packages/fabrika-cli/src/lane/migrate.ts
+++ b/packages/fabrika-cli/src/lane/migrate.ts
@@ -82,6 +82,22 @@ export const graftContext = (templateText: string, laneText: string): Graft => {
 	};
 };
 
+/**
+ * Whether two documents are the same machine once formatting is read past.
+ *
+ * `lane open` copies the committed template's biome-formatted bytes, with inline objects a tab
+ * indent expands, so comparing text calls every un-booted-since lane stale whatever machine it
+ * carries — the opposite of the question `--check` is asked. The comparison is order-sensitive on
+ * purpose: a grafted document is built from the template, so a key order that differs is a template
+ * that differs.
+ */
+export const sameMachine = (a: string, b: string): boolean => {
+	const left = parseJson(a);
+	const right = parseJson(b);
+	if (left === null || right === null) return false;
+	return JSON.stringify(left) === JSON.stringify(right);
+};
+
 /** One task whose folded state would move if the machine were swapped under it. */
 export interface Drift {
 	readonly task: string;

--- a/packages/fabrika-cli/src/lane/migrate.unit.test.ts
+++ b/packages/fabrika-cli/src/lane/migrate.unit.test.ts
@@ -1,0 +1,228 @@
+/** The migration judgement and the sweep verb over it. */
+import {Effect} from "effect";
+import {describe, expect, it} from "vitest";
+import {fakeFs} from "../fakes.test-support.ts";
+import {MIGRATION_UNSAFE} from "./codes.ts";
+import {coderTemplateText} from "./fixtures.test-support.ts";
+import type {LogEntry} from "./fold.ts";
+import {type CompiledLane, compileText} from "./machine.ts";
+import {graftContext, judgeMigration} from "./migrate.ts";
+import {runMigrate} from "./migrate-verb.ts";
+
+const ROOT = ".fabrika/lanes";
+const TEMPLATE = "/repo/templates/coder.workflow.json";
+
+const compiled = (text: string): CompiledLane => {
+	const result = compileText(text);
+	if (result._tag === "Malformed") throw new Error(result.defects.join("; "));
+	return result.lane;
+};
+
+const log = (...events: ReadonlyArray<string>): ReadonlyArray<LogEntry> =>
+	events.map((event) => ({task: "issue", event: `ISSUE.${event}`, at: "2026-08-20T00:00:00.000Z"}));
+
+const logText = (...events: ReadonlyArray<string>): string =>
+	`${log(...events)
+		.map((entry) => JSON.stringify(entry))
+		.join("\n")}\n`;
+
+/** The machine every booted lane carries today: no `ship:queued`, no `WIP` cell on `ship`. */
+const preWaitCellTemplate = (): string => {
+	const document = JSON.parse(coderTemplateText());
+	const states = document.machine.states.pipeline.states.issue.states;
+	delete states["ship:queued"];
+	delete states["human:queue-stall"];
+	delete states.ship.on["ISSUE.WIP"];
+	return JSON.stringify(document, null, "\t");
+};
+
+describe("graftContext", () => {
+	it("keeps the lane's own context, so a per-lane budget survives the swap", () => {
+		const lane = JSON.parse(preWaitCellTemplate());
+		lane.machine.context.issue = {retries: 0, maxRetries: 5, code: true};
+
+		const grafted = graftContext(coderTemplateText(), JSON.stringify(lane));
+
+		expect(grafted._tag).toBe("Grafted");
+		if (grafted._tag !== "Grafted") return;
+		const written = JSON.parse(grafted.text);
+		expect(written.machine.context.issue).toEqual({retries: 0, maxRetries: 5, code: true});
+		expect(written.machine.states.pipeline.states.issue.states["ship:queued"]).toBeDefined();
+	});
+
+	it("leaves a generated machine alone rather than calling it stale", () => {
+		const emitted = JSON.parse(coderTemplateText());
+		emitted.id = "epic-5817";
+
+		expect(graftContext(coderTemplateText(), JSON.stringify(emitted))).toEqual({
+			_tag: "Foreign",
+			id: "epic-5817",
+		});
+	});
+
+	it("is idempotent — what it writes is what it next reads as current", () => {
+		const first = graftContext(coderTemplateText(), preWaitCellTemplate());
+		if (first._tag !== "Grafted") throw new Error(first._tag);
+
+		expect(graftContext(coderTemplateText(), first.text)).toEqual(first);
+	});
+});
+
+describe("judgeMigration", () => {
+	it("preserves a swap that adds states the log never visits", () => {
+		const verdict = judgeMigration(
+			compiled(preWaitCellTemplate()),
+			compiled(coderTemplateText()),
+			log("WIP", "DONE", "PASS"),
+		);
+
+		expect(verdict._tag).toBe("Preserved");
+	});
+
+	it("refuses a candidate the existing log cannot replay through", () => {
+		const verdict = judgeMigration(
+			compiled(coderTemplateText()),
+			compiled(preWaitCellTemplate()),
+			log("WIP", "DONE", "PASS", "WIP"),
+		);
+
+		expect(verdict).toMatchObject({_tag: "Unreplayable", through: "candidate"});
+	});
+
+	it("refuses a candidate that folds the same log to a different leaf", () => {
+		const document = JSON.parse(coderTemplateText());
+		document.machine.states.pipeline.states.issue.states.ship.on["ISSUE.WIP"] = "blocked";
+
+		const verdict = judgeMigration(
+			compiled(coderTemplateText()),
+			compiled(JSON.stringify(document)),
+			log("WIP", "DONE", "PASS", "WIP"),
+		);
+
+		expect(verdict).toMatchObject({
+			_tag: "Drifts",
+			drifts: [{task: "issue", from: "ship:queued", to: "blocked"}],
+		});
+	});
+
+	it("names the lane's own machine when the log never replayed through that either", () => {
+		const verdict = judgeMigration(
+			compiled(preWaitCellTemplate()),
+			compiled(coderTemplateText()),
+			log("WIP", "DONE", "PASS", "WIP"),
+		);
+
+		expect(verdict).toMatchObject({_tag: "Unreplayable", through: "current"});
+	});
+});
+
+/** What the verb would write for a lane whose context is the template's — its `current` shape. */
+const migratedText = (): string => {
+	const grafted = graftContext(coderTemplateText(), coderTemplateText());
+	if (grafted._tag !== "Grafted") throw new Error(grafted._tag);
+	return grafted.text;
+};
+
+describe("lane migrate", () => {
+	const sweep = (
+		files: Record<string, string | null>,
+		options: {check?: boolean; dirs?: Record<string, ReadonlyArray<string> | null>} = {},
+	) => {
+		const fs = fakeFs({
+			files: {[TEMPLATE]: coderTemplateText(), ...files},
+			dirs: options.dirs ?? {[ROOT]: ["42", "43"]},
+			directories: [ROOT],
+		});
+		return Effect.runPromise(
+			Effect.provide(
+				runMigrate({roots: [{root: ROOT, templatePath: TEMPLATE}], check: options.check ?? false}),
+				fs.layer,
+			),
+		).then((outcome) => ({outcome, written: fs.written}));
+	};
+
+	it("writes the template over a stale lane whose log replays unchanged", async () => {
+		const {outcome, written} = await sweep({
+			[`${ROOT}/42/workflow.json`]: preWaitCellTemplate(),
+			[`${ROOT}/42/events.jsonl`]: logText("WIP", "DONE"),
+			[`${ROOT}/43/workflow.json`]: migratedText(),
+		});
+
+		expect(outcome.code).toBe(0);
+		expect(JSON.parse(outcome.stdout).summary).toMatchObject({migrated: 1, current: 1, unsafe: 0});
+		expect(written.get(`${ROOT}/42/workflow.json`)).toBe(migratedText());
+	});
+
+	it("withholds every write under --check and still names the stale lanes", async () => {
+		const {outcome, written} = await sweep(
+			{
+				[`${ROOT}/42/workflow.json`]: preWaitCellTemplate(),
+				[`${ROOT}/42/events.jsonl`]: logText("WIP", "DONE"),
+				[`${ROOT}/43/workflow.json`]: migratedText(),
+			},
+			{check: true},
+		);
+
+		expect(outcome.code).toBe(0);
+		expect(JSON.parse(outcome.stdout).summary).toMatchObject({stale: 1, migrated: 0});
+		expect(written.size).toBe(0);
+	});
+
+	it("refuses on an unsafe lane, writes none of it, and migrates the rest", async () => {
+		const drifting = JSON.parse(coderTemplateText());
+		drifting.machine.states.pipeline.states.issue.states.ship.on["ISSUE.WIP"] = "blocked";
+
+		const {outcome, written} = await sweep({
+			[`${ROOT}/42/workflow.json`]: JSON.stringify(drifting, null, "\t"),
+			[`${ROOT}/42/events.jsonl`]: logText("WIP", "DONE", "PASS", "WIP"),
+			[`${ROOT}/43/workflow.json`]: preWaitCellTemplate(),
+			[`${ROOT}/43/events.jsonl`]: logText("WIP", "DONE"),
+		});
+
+		expect(outcome.code).toBe(MIGRATION_UNSAFE);
+		expect(outcome.stdout).toBe("");
+		expect(outcome.stderr.join("\n")).toContain("different state");
+		expect(written.has(`${ROOT}/42/workflow.json`)).toBe(false);
+		expect(written.get(`${ROOT}/43/workflow.json`)).toBe(migratedText());
+	});
+
+	it("reports an unreadable lane as a row rather than ending the sweep", async () => {
+		const {outcome} = await sweep({
+			[`${ROOT}/42/workflow.json`]: "{",
+			[`${ROOT}/43/workflow.json`]: migratedText(),
+		});
+
+		expect(outcome.code).toBe(0);
+		expect(JSON.parse(outcome.stdout).summary).toMatchObject({unreadable: 1, current: 1});
+	});
+
+	it("reports a generated machine without touching it", async () => {
+		const emitted = JSON.parse(preWaitCellTemplate());
+		emitted.id = "epic-5817";
+
+		const {outcome, written} = await sweep({
+			[`${ROOT}/42/workflow.json`]: JSON.stringify(emitted, null, "\t"),
+			[`${ROOT}/43/workflow.json`]: migratedText(),
+		});
+
+		expect(outcome.code).toBe(0);
+		expect(JSON.parse(outcome.stdout).summary).toMatchObject({generated: 1, current: 1});
+		expect(written.size).toBe(0);
+	});
+
+	it("skips an entry that holds no lane at all", async () => {
+		const {outcome} = await sweep({[`${ROOT}/43/workflow.json`]: coderTemplateText()});
+
+		expect(JSON.parse(outcome.stdout).scanned).toEqual([{root: ROOT, present: true, lanes: 1}]);
+	});
+
+	it("refuses the whole sweep when a root is there and cannot be listed", async () => {
+		const {outcome} = await sweep(
+			{[`${ROOT}/43/workflow.json`]: coderTemplateText()},
+			{dirs: {[ROOT]: null}},
+		);
+
+		expect(outcome.code).not.toBe(0);
+		expect(outcome.stderr.join("\n")).toContain("UNKNOWN, never empty");
+	});
+});

--- a/packages/fabrika-cli/src/lane/migrate.unit.test.ts
+++ b/packages/fabrika-cli/src/lane/migrate.unit.test.ts
@@ -3,7 +3,7 @@ import {Effect} from "effect";
 import {describe, expect, it} from "vitest";
 import {fakeFs} from "../fakes.test-support.ts";
 import {MIGRATION_UNSAFE} from "./codes.ts";
-import {coderTemplateText} from "./fixtures.test-support.ts";
+import {choreTemplateText, coderTemplateText} from "./fixtures.test-support.ts";
 import type {LogEntry} from "./fold.ts";
 import {type CompiledLane, compileText} from "./machine.ts";
 import {graftContext, judgeMigration} from "./migrate.ts";
@@ -11,6 +11,7 @@ import {runMigrate} from "./migrate-verb.ts";
 
 const ROOT = ".fabrika/lanes";
 const TEMPLATE = "/repo/templates/coder.workflow.json";
+const CHORE_TEMPLATE = "/repo/templates/chore.workflow.json";
 
 const compiled = (text: string): CompiledLane => {
 	const result = compileText(text);
@@ -126,16 +127,23 @@ const migratedText = (): string => {
 describe("lane migrate", () => {
 	const sweep = (
 		files: Record<string, string | null>,
-		options: {check?: boolean; dirs?: Record<string, ReadonlyArray<string> | null>} = {},
+		options: {
+			check?: boolean;
+			dirs?: Record<string, ReadonlyArray<string> | null>;
+			templatePaths?: ReadonlyArray<string>;
+		} = {},
 	) => {
 		const fs = fakeFs({
-			files: {[TEMPLATE]: coderTemplateText(), ...files},
+			files: {[TEMPLATE]: coderTemplateText(), [CHORE_TEMPLATE]: choreTemplateText(), ...files},
 			dirs: options.dirs ?? {[ROOT]: ["42", "43"]},
 			directories: [ROOT],
 		});
 		return Effect.runPromise(
 			Effect.provide(
-				runMigrate({roots: [{root: ROOT, templatePath: TEMPLATE}], check: options.check ?? false}),
+				runMigrate({
+					roots: [{root: ROOT, templatePaths: options.templatePaths ?? [TEMPLATE]}],
+					check: options.check ?? false,
+				}),
 				fs.layer,
 			),
 		).then((outcome) => ({outcome, written: fs.written}));
@@ -151,6 +159,28 @@ describe("lane migrate", () => {
 		expect(outcome.code).toBe(0);
 		expect(JSON.parse(outcome.stdout).summary).toMatchObject({migrated: 1, current: 1, unsafe: 0});
 		expect(written.get(`${ROOT}/42/workflow.json`)).toBe(migratedText());
+	});
+
+	it("reads a booted lane as current past the formatting `lane open` copied in", async () => {
+		// `lane open` places the template's biome-formatted bytes and a graft re-serializes with a tab
+		// indent, so comparing text called every un-migrated lane stale whatever machine it carried.
+		const {outcome, written} = await sweep({
+			[`${ROOT}/42/workflow.json`]: coderTemplateText(),
+			[`${ROOT}/43/workflow.json`]: migratedText(),
+		});
+
+		expect(coderTemplateText()).not.toBe(migratedText());
+		expect(JSON.parse(outcome.stdout).summary).toMatchObject({current: 2, stale: 0, migrated: 0});
+		expect(written.size).toBe(0);
+	});
+
+	it("picks a lane's template by its own machine id, not by the root it sits under", async () => {
+		const {outcome} = await sweep(
+			{[`${ROOT}/42/workflow.json`]: choreTemplateText()},
+			{dirs: {[ROOT]: ["42"]}, templatePaths: [TEMPLATE, CHORE_TEMPLATE]},
+		);
+
+		expect(JSON.parse(outcome.stdout).summary).toMatchObject({generated: 0, current: 1});
 	});
 
 	it("withholds every write under --check and still names the stale lanes", async () => {

--- a/packages/fabrika-cli/src/lane/report.ts
+++ b/packages/fabrika-cli/src/lane/report.ts
@@ -38,7 +38,14 @@ export const SHELL_VOCABULARIES = {
 	},
 	shipper: {
 		"ALREADY-MERGED": "DONE",
-		QUEUED: "DONE",
+		// The two queue terminals are waits, not landings (ADR 0313). Only a merge this pipeline read
+		// back is `DONE`, and neither of these is one: `QUEUED` means the arm took and the shipper did
+		// not watch it to an outcome, `UNRESOLVED` means it watched to its horizon and the PR is still
+		// in the queue. Both used to fold the lane out of the loop — `QUEUED` to `shipped` over a merge
+		// nobody observed, `UNRESOLVED` to a human park over a merge that was always going to land
+		// (#6178, #6462) — and both now route to the machine's wait cell, which a driver re-folds.
+		QUEUED: "WIP",
+		UNRESOLVED: "WIP",
 		LANDED: "DONE",
 		REFUSED: "BLOCKED",
 		"AWAITING-CP-APPROVAL": "BLOCKED",
@@ -49,7 +56,6 @@ export const SHELL_VOCABULARIES = {
 		"ROUTED-REPAIR": "FAIL",
 		"ROUTED-HEAL-CI": "BLOCKED",
 		"ROUTED-REVIEW": "BLOCKED",
-		UNRESOLVED: "BLOCKED",
 		// An ejection is always "routed to repair", so it feeds the machine's `ship` FAIL edge and
 		// spends a retry rather than parking the lane (#5807).
 		EJECTED: "FAIL",

--- a/packages/fabrika-cli/src/lane/report.unit.test.ts
+++ b/packages/fabrika-cli/src/lane/report.unit.test.ts
@@ -46,6 +46,31 @@ describe("the shipper's routing arms are three answers, not one", () => {
 	});
 });
 
+describe("the shipper's two queue terminals are waits, not landings (ADR 0313)", () => {
+	it("routes a still-queued-at-horizon shipper to WIP, so the lane waits instead of parking", () => {
+		expect(eventForToken("UNRESOLVED")).toEqual({
+			_tag: "Mapped",
+			token: "UNRESOLVED",
+			event: "WIP",
+		});
+	});
+
+	it("routes a bare enqueue to WIP too — a merge nobody read back is not `shipped`", () => {
+		expect(eventForToken("QUEUED")).toEqual({_tag: "Mapped", token: "QUEUED", event: "WIP"});
+	});
+
+	it("keeps DONE for the two terminals that read a merge back", () => {
+		expect(eventForToken("LANDED")).toMatchObject({event: "DONE"});
+		expect(eventForToken("ALREADY-MERGED")).toMatchObject({event: "DONE"});
+	});
+
+	it("still folds every genuine shipper block to BLOCKED", () => {
+		expect(eventForToken("REFUSED")).toMatchObject({event: "BLOCKED"});
+		expect(eventForToken("AWAITING-CP-APPROVAL")).toMatchObject({event: "BLOCKED"});
+		expect(eventForToken("UNKNOWN")).toMatchObject({event: "BLOCKED"});
+	});
+});
+
 describe("flattening the per-shell vocabularies", () => {
 	it("flattens the real vocabularies with nothing overwritten", () => {
 		const flat = flattenVocabularies(SHELL_VOCABULARIES);

--- a/packages/fabrika-cli/src/lane/templates/coder.workflow.json
+++ b/packages/fabrika-cli/src/lane/templates/coder.workflow.json
@@ -43,7 +43,30 @@
 							"ship": {
 								"on": {
 									"ISSUE.DONE": "shipped",
+									"ISSUE.WIP": "ship:queued",
 									"ISSUE.BLOCKED": "human:cp-approval",
+									"ISSUE.FAIL": [
+										{
+											"target": "build",
+											"guard": "retriesRemaining",
+											"actions": "incrementRetries"
+										},
+										{ "target": "frozen" }
+									]
+								}
+							},
+							"ship:queued": {
+								"on": {
+									"ISSUE.DONE": "shipped",
+									"ISSUE.BLOCKED": "human:cp-approval",
+									"ISSUE.WIP": [
+										{
+											"target": "ship:queued",
+											"guard": "waitsRemaining",
+											"actions": "incrementWaits"
+										},
+										{ "target": "human:cp-approval" }
+									],
 									"ISSUE.FAIL": [
 										{
 											"target": "build",
@@ -61,6 +84,7 @@
 							},
 							"human:cp-approval": {
 								"on": {
+									"ISSUE.DONE": "shipped",
 									"ISSUE.UNBLOCKED": "hist"
 								}
 							},

--- a/packages/fabrika-cli/src/lane/templates/coder.workflow.json
+++ b/packages/fabrika-cli/src/lane/templates/coder.workflow.json
@@ -65,7 +65,7 @@
 											"guard": "waitsRemaining",
 											"actions": "incrementWaits"
 										},
-										{ "target": "human:cp-approval" }
+										{ "target": "human:queue-stall" }
 									],
 									"ISSUE.FAIL": [
 										{
@@ -84,7 +84,11 @@
 							},
 							"human:cp-approval": {
 								"on": {
-									"ISSUE.DONE": "shipped",
+									"ISSUE.UNBLOCKED": "hist"
+								}
+							},
+							"human:queue-stall": {
+								"on": {
 									"ISSUE.UNBLOCKED": "hist"
 								}
 							},

--- a/packages/fabrika-cli/src/lane/verbs.unit.test.ts
+++ b/packages/fabrika-cli/src/lane/verbs.unit.test.ts
@@ -2,6 +2,7 @@
 import {Effect} from "effect";
 import {describe, expect, it} from "vitest";
 import {fakeFs} from "../fakes.test-support.ts";
+import {WAIT_BUDGET} from "../wait-budget.ts";
 import {LANE_ABSENT, LANE_UNREADABLE, MALFORMED_RECORD} from "./codes.ts";
 import {coderTemplateText} from "./fixtures.test-support.ts";
 import {runHistory} from "./history-verb.ts";
@@ -31,7 +32,10 @@ describe("lane status", () => {
 		expect(JSON.parse(out.stdout)).toEqual({
 			stateValue: {pipeline: {issue: "queued"}},
 			status: "active",
-			context: {issue: {retries: 0, maxRetries: 2}, errors: []},
+			context: {
+				issue: {retries: 0, maxRetries: 2, waits: 0, maxWaits: WAIT_BUDGET},
+				errors: [],
+			},
 		});
 	});
 
@@ -78,7 +82,7 @@ describe("lane print", () => {
 		expect(JSON.parse(out.stdout)).toMatchObject({
 			phases: [{name: "pipeline", tasks: ["issue"]}],
 			terminals: {complete: "complete", tripped: "tripped"},
-			tasks: {issue: {initial: "queued", maxRetries: 2}},
+			tasks: {issue: {initial: "queued", maxRetries: 2, maxWaits: WAIT_BUDGET}},
 		});
 	});
 });

--- a/packages/fabrika-cli/src/wait-budget.ts
+++ b/packages/fabrika-cli/src/wait-budget.ts
@@ -1,0 +1,17 @@
+/**
+ * How many times a driver may re-fold a lane that is waiting on something outside it, before the
+ * wait escalates to a human.
+ *
+ * It is deliberately NOT [`RETRY_BUDGET`](retry-budget.ts). A retry is a repair round — the lane failed and is
+ * spending a chance to fix itself — and a wait is a lane that did nothing wrong sitting behind a
+ * merge queue. Riding one counter would make a PR that dwelt in the queue arrive at its first real
+ * FAIL with no repair rounds left, which is a budget spent on a queue's clock rather than on the
+ * work (ADR 0313).
+ *
+ * The value is four observations of the same wait: the shipper's own bounded watch, then three
+ * driver re-folds. #6178 sat ~13m45s against the shipper's ~480s horizon, so a bound of three
+ * covers roughly four horizons without ever letting the wait run open-ended.
+ */
+
+/** The re-folds a waiting task gets before its wait escalates to a human park. */
+export const WAIT_BUDGET = 3;


### PR DESCRIPTION
A PR sitting clean in the merge queue past `ship reconcile`'s ~480s horizon used to park the lane on a human. It is a wait, not a block — the queue lands it on its own clock (#6178 took ~1.7x the horizon; lane 6462's PR merged 29s before its `BLOCKED` was even written).

Founder ruled option 2 on https://github.com/kamp-us/phoenix/issues/6189#issuecomment-5360244073 (restating https://github.com/kamp-us/phoenix/issues/6189#issuecomment-5346739403): the machine gains a non-human wait cell out of `ship`. ADR 0313 transcribes the ruling; both comment URLs are cited in its text.

What changed:

- **`ship:queued`** in `coder.workflow.json` and in `emit.ts`'s epic tail — reachable from `ship` on `WIP`, re-enters itself, reaches `shipped` on a landing, routes an ejection back into `build`, escalates when its own budget runs out. Not a `human:*` name, so `parks.ts` reads it as ordinary work.
- **Both queue terminals record `WIP`** in `report.ts`. `UNRESOLVED` no longer maps to `BLOCKED`; `QUEUED` no longer maps to `DONE` (it folded a lane to `shipped` over a merge nobody read back). Only `LANDED` and `ALREADY-MERGED` stay `DONE`. Every genuine block still maps to `BLOCKED` and still folds to `human:cp-approval`, so #5820's question is untouched.
- **A second counter.** A guarded two-arm array now means "loop while a budget remains", and which budget it spends is read off the event: `FAIL` spends `retries`, anything else spends `waits` (`WAIT_BUDGET` = 3, `src/wait-budget.ts`). A queue dwell can no longer eat the repair rounds a later FAIL draws on. No guard or action name is dereferenced — the recognition stays structural. A founder's cleared round (ADR 0312) raises `maxRetries` alone and never `maxWaits`.
- **`human:queue-stall`** is where a spent wait escalates, not `human:cp-approval`. The fallthrough rides a `WIP`, which carries no park cause, and `parks.ts`'s §CP row keys on exactly `cause: null` — so a stall in that park would be cleared by reading an approval nobody was waiting on. Its own leaf carries no row, so the table reads it novel and routes it to a human.
- **`fabrika lane migrate`** brings lanes already on disk up to the committed machine. `lane open` copies the template in at boot and never overwrites it, while `report.ts`'s token map is code and reaches every lane at once — so without this, every booted lane's shipper would report `QUEUED`, now `WIP`, against a frozen `ship` state holding no `WIP` cell. The verb writes only where the swap is provably inert: the lane's `events.jsonl` must fold to the same per-task leaf state through both machines. It keeps the lane's own `machine.context`, which is per-lane data, and it skips a machine `lane emit` generated rather than one booted from a template. `--check` withholds every write.
- `ship reconcile`'s horizon is unchanged. The waiting moved to the driver: `operate/SKILL.md` gains a `ship:queued` row and a section that runs `ship reconcile <pr> --polls 1` and relays its four answers, plus the migration step. `ship/SKILL.md` and `contract.md` re-cut the two queue terminals.
- Unit coverage in `machine.unit.test.ts`, `report.unit.test.ts` and `migrate.unit.test.ts`: the token-to-event rows, the wait cell's cells, lane 6462's real sequence, the escalation firing exactly at the bound and landing in a park the recipe table reads novel, and the migration's verdicts.

This head is rebased onto `main`, which had taken exit code `36` (`RESUME_UNBUDGETED`, ADR 0312) and retired the `clearedRounds` context field. `MIGRATION_UNSAFE` moved to `37`, and the number was followed into `command.ts` and `operate/SKILL.md`; `graftContext`'s docblock, the `migrate` description and the first migration test are re-grounded on 0312's event-anchored clearance.

Run against the live lanes root at this head, `lane migrate --check` reads 132 lanes stale and safe to migrate, and 5 unsafe. Those five carry a `DONE` recorded while in `frozen`, so their logs already do not replay through their **own** machines — `lane status` refuses on them too, so it is a pre-existing defect this verb surfaces rather than causes. Filed as #6711; none of the five is written.

Fixes #6189

## Deviations

- **Declined guidance** — **Said:** the ruling names "the PR left the queue un-merged (`removed_from_merge_queue`)" as a condition that escalates to a human park. **Did:** an ejection out of `ship:queued` records `EJECTED`, which maps to `FAIL` and routes the lane back into `build`, spending a retry; a human is reached only when the repair budget itself is spent. **Why:** #5807 already decided an ejection is repair work this lane retries, and re-routing it to a human park would have reversed that decision as a side effect of this one. **Disposition:** stated here and in ADR 0313's "What this costs".
- **Out-of-scope change** — **Said:** #6189's criteria name `UNRESOLVED` only. **Did:** also re-cut `QUEUED` from `DONE` to `WIP`. **Why:** the founder's own wording was "give ship a `QUEUED` token that folds to a non-human wait cell", and `QUEUED` mapping to `DONE` folded a lane to `shipped` over a merge nobody observed — the same fabrication as the park this PR removes, in the other direction. Criterion 2's second arm covers it, and `ship/SKILL.md`'s terminal row is rewritten to match. **Disposition:** stated here.
- **Out-of-scope change** — **Said:** #6189 asks for a wait cell and says nothing about a migration verb. **Did:** added `fabrika lane migrate`, its judgement module, its `MIGRATION_UNSAFE` seat and its tests, and re-keyed `templateFile` from a whole `LaneKey` to the kind, since a root selects a kind and names no lane. **Why:** without it this PR breaks the shipper's ordinary success path on every lane already on disk — the `review-code` FAIL at `e32aab46` named exactly that, and a migration is the positive answer it asked for. **Disposition:** stated here and in ADR 0313.
- **Out-of-scope change** — **Said:** the last review round called findings 4 and 5 on `lane migrate` my call, one line each. **Did:** fixed both in code instead. `current` now compares the two documents past their formatting (`sameMachine`), because `lane open`'s biome-formatted bytes and a graft's tab indent made `current` unreachable for every un-migrated lane whatever machine it carried; and a root is now bound to a *list* of candidate templates that the lane's own machine `id` picks among, so a chore lane under a `--root` is no longer labelled `generated`. **Why:** `--check` is what a driver runs to learn whether a lane it is about to drive is stale, and both defects made its answer say something other than what it means. Each is covered by a new test. **Disposition:** stated here.
- **Out-of-scope change** — **Said:** nothing about #6570's `guardedStates` set, which landed on `main` after this branch's base. **Did:** narrowed it to the states whose guarded route out spends `retries`, so a wait-guarded cell is not one. **Why:** the resume refusal that reads it keys on `next.retries >= next.maxRetries`, so leaving a wait-guarded state in the set would refuse a resume whose actual route out still has waits left. A spent wait is no resume hazard either way — its fallthrough is a park that names the stall, not a fall back into the error final the resume just left. **Disposition:** stated here and in ADR 0313; a test pins that a `WIP`-guarded array does not join the set.
- **Known defect left unfixed** — **Said:** criterion 10 asks that epic-child lanes not be left behind. **Did:** `emit.ts` generates the wait cell, so every epic lane emitted from now on has it, but the 5 epic lanes already on disk do not and `lane migrate` skips them by design — their machines were generated from their epics' board state, not booted from a committed template, so rewriting one from a template it never came from would be a fabrication. Their tail `ship` states hold no `WIP` cell, so an epic tail shipper reporting `QUEUED` on one of them will refuse. **Why:** regenerating them needs the epic board state the verb reads nothing of, and inventing that read inside this lane would be a second design decision taken without a ruling. **Disposition:** stated here and filed as #6683.
- **Known defect left unfixed** — **Said:** criterion 6 asks for no third escalation path out of the wait. **Did:** `ship:queued` keeps an `ISSUE.BLOCKED` edge to `human:cp-approval`, so a genuine block observed on a re-fold pass (a `REFUSED`, an `AWAITING-CP-APPROVAL`, an `UNKNOWN` read) still parks. **Why:** without it, a lane whose §CP approval is withdrawn mid-queue would have no route out of the wait cell at all. It is the ordinary block route, bounded by the shipper, not an open-ended wait. **Disposition:** stated here and in ADR 0313.
- **Governing-ADR departure** — **Said:** an earlier head of this PR gave `human:cp-approval` a `DONE` cell, taking criterion 5's first arm. **Did:** removed it, taking the second arm instead — the PR now states why an already-parked lane leaves only by `UNBLOCKED`, and lane 6462's named route out is that edge, which its own machine carries and which its `events.jsonl` shows it took. **Why:** ADR 0302 holds that every park other than a table-registered, re-fold-proven clear is reachable only by a recorded `UNBLOCKED`, and a `DONE` cell was a second exit that skipped both. The `governance` FAIL at `e32aab46` named it. **Disposition:** stated here; no `amended-in-part` marker is owed on 0302 or 0297, because nothing narrows them now.
- **Pre-existing test or fixture changed** — **Said:** nothing about the existing fixtures. **Did:** regenerated `epic-4300.workflow.golden.txt`, added `waits`/`maxWaits` to the budget assertions in `fold.unit.test.ts`, `verbs.unit.test.ts` and `machine.unit.test.ts`, re-pointed `key.unit.test.ts`'s two `templateFile` calls at the new signature, and re-grounded `migrate.unit.test.ts`'s first case off the retired `clearedRounds` field onto a per-lane `maxRetries`. **Why:** the golden bytes now carry the tail's wait cell and its own park, `lane status`'s per-task context now reports both budgets, `templateFile` takes a kind, and ADR 0312 retired the field the old assertion pinned. **Disposition:** stated here; no assertion was weakened.
