### PR TITLE
fix: fate-live: narrow entity broadcasts to changed fields (kill the myVote/isSaved leak)

### DIFF
--- a/apps/web/worker/features/fate-live/live-publisher.ts
+++ b/apps/web/worker/features/fate-live/live-publisher.ts
@@ -49,12 +49,44 @@ export interface LivePublisherOptions {
 	readonly waitUntil: (promise: Promise<unknown>) => void;
 }
 
-/** fate's `livePayload` shape. */
-const entityFrame = (
-	type: "update" | "delete",
-	id: string | number,
-	options?: {readonly data?: unknown},
-): EntityFrame => (type === "delete" ? {delete: true, id} : {data: options?.data});
+const isRecord = (value: unknown): value is Record<string, unknown> =>
+	typeof value === "object" && value !== null && !Array.isArray(value);
+
+/**
+ * fate's `livePayload` update frame, narrowed to the keys the mutation changed (#6585).
+ *
+ * Trimming `data` is the leak fix, not an optimisation: fate's `writeEntity` copies every
+ * scalar key PRESENT ON the payload over each subscriber's cached record, gated by
+ * `hasOwnProperty` and never by `select` — so an untrimmed node, re-resolved against the
+ * MUTATOR's viewer, overwrites everyone else's `myVote`/`isSaved` until they refetch.
+ *
+ * `select` must then name exactly the keys the trimmed payload carries: the client reads
+ * it ahead of the payload and refetches the record whenever the payload cannot cover the
+ * selection (`canUseLivePayloadData`), so a `changed` key the node omits would cost every
+ * subscriber a round trip. `id` joins the selection because fate's own `changed`→select
+ * derivation adds it and `writeEntity` resolves the cache key through it.
+ *
+ * No `changed` leaves the old whole-node frame standing — an unnarrowed publish stays as
+ * loud as it was, rather than silently becoming a no-op.
+ */
+const updateFrame = (options?: {
+	readonly changed?: ReadonlyArray<string>;
+	readonly data?: unknown;
+}): EntityFrame => {
+	const changed = options?.changed?.filter((key) => key.length > 0);
+	const data = options?.data;
+	if (!changed || changed.length === 0) return {data};
+	const select = [...new Set(["id", ...changed])];
+	if (!isRecord(data)) return {data, select};
+	// A payload with no cache key cannot be merged, so it is dropped rather than trimmed:
+	// the subscriber refetches the narrowed `select` instead of receiving a keyless record.
+	if (!("id" in data)) return {data: undefined, select};
+	const trimmed: Record<string, unknown> = {};
+	for (const key of select) {
+		if (key in data) trimmed[key] = data[key];
+	}
+	return {data: trimmed, select: Object.keys(trimmed)};
+};
 
 const nodeFrame = (
 	type: "appendNode" | "prependNode",
@@ -100,7 +132,7 @@ export function livePublisherFor(options: LivePublisherOptions): typeof LivePubl
 				publish({
 					kind: "entity",
 					match: {type, entityId: String(id)},
-					frame: entityFrame("update", id, opts),
+					frame: updateFrame(opts),
 					...(opts?.eventId !== undefined ? {eventId: opts.eventId} : {}),
 				}),
 			),
@@ -109,7 +141,7 @@ export function livePublisherFor(options: LivePublisherOptions): typeof LivePubl
 				publish({
 					kind: "entity",
 					match: {type, entityId: String(id)},
-					frame: entityFrame("delete", id),
+					frame: {delete: true, id},
 					...(opts?.eventId !== undefined ? {eventId: opts.eventId} : {}),
 				}),
 			),

--- a/apps/web/worker/features/fate-live/live-publisher.unit.test.ts
+++ b/apps/web/worker/features/fate-live/live-publisher.unit.test.ts
@@ -1,6 +1,6 @@
 /** Unit tier (ADR 0082): stubs at the topic seam, zero storage, no platform fake. */
 
-import {assert, it} from "@effect/vitest";
+import {assert, describe, it} from "@effect/vitest";
 import type {LivePublisher} from "@kampus/fate-effect";
 import {liveConnectionTopic, liveEntityTopic, liveGlobalConnectionTopic} from "@nkzw/fate/server";
 import {Effect, Exit} from "effect";
@@ -61,13 +61,12 @@ it.effect("publishes the bridge's exact wire frames (literal fixtures)", () =>
 	Effect.gen(function* () {
 		const {live, recorded, flush} = makeHarness();
 
-		// `changed` is accepted but does NOT reach the wire.
 		yield* live.update("Definition", "d1", {
 			data: {id: "d1", body: "updated"},
 			changed: ["body"],
 			eventId: "e1",
 		});
-		// An update with no `data` still carries the `data` key on the wire.
+		// An update with no `changed` and no `data` still carries the `data` key on the wire.
 		yield* live.update("Definition", "d9", {eventId: "e9"});
 		yield* live.delete("Post", 7, {eventId: "e2"});
 		const definitions = live.topic("Term.definitions", {slug: "effect"});
@@ -92,7 +91,7 @@ it.effect("publishes the bridge's exact wire frames (literal fixtures)", () =>
 				message: {
 					kind: "entity",
 					match: {type: "Definition", entityId: "d1"},
-					frame: {data: {id: "d1", body: "updated"}},
+					frame: {data: {id: "d1", body: "updated"}, select: ["id", "body"]},
 					eventId: "e1",
 				},
 			},
@@ -164,6 +163,81 @@ it.effect("publishes the bridge's exact wire frames (literal fixtures)", () =>
 		]);
 	}),
 );
+
+/**
+ * The #6585 leak: fate merges a live payload key-by-key over every subscriber's cached
+ * record, so a whole re-resolved node resolved against the mutator's viewer overwrites
+ * everyone else's viewer scalars. `changed` is what narrows it.
+ */
+describe("entity update frames narrow to the changed keys", () => {
+	const frameOf = async (options: Parameters<(typeof LivePublisher.Service)["update"]>[2]) => {
+		const {live, recorded, flush} = makeHarness();
+		await Effect.runPromise(live.update("Post", "p1", options));
+		await flush();
+		const message = recorded[0]?.message;
+		if (message?.kind !== "entity") {
+			throw new Error(`expected one entity publish, recorded ${JSON.stringify(recorded)}`);
+		}
+		return message.frame;
+	};
+
+	it("trims the payload to the changed keys and selects exactly what it kept", async () => {
+		assert.deepStrictEqual(
+			await frameOf({
+				changed: ["score"],
+				data: {id: "p1", score: 8, myVote: true, isSaved: true, title: "t"},
+			}),
+			{data: {id: "p1", score: 8}, select: ["id", "score"]},
+			"the mutator's `myVote`/`isSaved` never ride a vote broadcast",
+		);
+	});
+
+	it("keeps a viewer scalar only when it IS the changed field", async () => {
+		assert.deepStrictEqual(
+			await frameOf({changed: ["isSaved"], data: {id: "p1", isSaved: true, myVote: true}}),
+			{data: {id: "p1", isSaved: true}, select: ["id", "isSaved"]},
+		);
+	});
+
+	it("carries every changed key, de-duplicated, with `id` first", async () => {
+		assert.deepStrictEqual(
+			await frameOf({
+				changed: ["title", "body", "id", "title"],
+				data: {id: "p1", title: "t", body: "b", myVote: false},
+			}),
+			{data: {id: "p1", title: "t", body: "b"}, select: ["id", "title", "body"]},
+		);
+	});
+
+	it("drops a changed key the payload does not carry, so `select` stays coverable", async () => {
+		assert.deepStrictEqual(
+			await frameOf({changed: ["title", "body"], data: {id: "p1", title: "t"}}),
+			{data: {id: "p1", title: "t"}, select: ["id", "title"]},
+			"a select fate's payload cannot cover forces every subscriber to refetch",
+		);
+	});
+
+	it("sends `select` alone when the payload carries no cache key", async () => {
+		assert.deepStrictEqual(await frameOf({changed: ["score"], data: {score: 8}}), {
+			data: undefined,
+			select: ["id", "score"],
+		});
+	});
+
+	it("narrows a data-less signal so the subscriber's refetch is narrow too", async () => {
+		assert.deepStrictEqual(await frameOf({changed: ["score"]}), {
+			data: undefined,
+			select: ["id", "score"],
+		});
+	});
+
+	it("leaves an unnarrowed publish whole rather than silently emptying it", async () => {
+		const whole = {id: "p1", score: 8, myVote: true};
+		assert.deepStrictEqual(await frameOf({data: whole}), {data: whole});
+		assert.deepStrictEqual(await frameOf({changed: [], data: whole}), {data: whole});
+		assert.deepStrictEqual(await frameOf({changed: [""], data: whole}), {data: whole});
+	});
+});
 
 it.effect("a rejecting topic publish cannot fail the calling effect", () => {
 	// Silence the publisher's Warn failure log so the run stays quiet.

--- a/apps/web/worker/features/kunye/sandbox.ts
+++ b/apps/web/worker/features/kunye/sandbox.ts
@@ -154,18 +154,19 @@ export const broadcastIf = (
  * Drop the reader-facing çaylak marker from an entity-update payload (#6462).
  *
  * `decidePublish` guards the NODE broadcasts, but an entity `live.update` carries the
- * whole re-resolved wire node and is ungated — and phoenix's `entityFrame` puts no
- * `select` on the frame, so fate merges that node shallowly over every subscriber's
- * cached record (`{...previous, ...partial}`) and the published `changed` narrows
- * nothing. `sandboxedInPlace` is resolved against the MUTATOR's `SandboxViewer` (#6425),
- * so on that path an opted-in yazar's vote broadcasts `true` to viewers holding no
- * entitlement, and every other voter's `false` erases the badge a subscriber correctly
- * read. Both directions are the #4313 failure mode on the newer field.
+ * whole re-resolved wire node and is ungated. `sandboxedInPlace` is resolved against the
+ * MUTATOR's `SandboxViewer` (#6425), so an opted-in yazar's vote broadcasts `true` to
+ * viewers holding no entitlement, and every other voter's `false` erases the badge a
+ * subscriber correctly read. Both directions are the #4313 failure mode on the newer field.
  *
  * Omitting the key beats stamping `false`, because fate copies only the keys the payload
  * carries: an absent one leaves each subscriber's own read-derived value standing. The
  * owner-scoped `sandboxed` rides the same hazard and is deliberately left alone — #4313
  * owns that half.
+ *
+ * Since #6585 the publisher also trims the payload to the mutation's `changed` keys, which
+ * drops the marker on every narrowed publish. This stays because it is the belt to that
+ * brace: it covers the frames that carry no `changed`, where the whole node still rides.
  */
 export const withoutInPlaceMarker = <T extends {readonly sandboxedInPlace?: boolean | undefined}>(
 	node: T,

--- a/apps/web/worker/features/pano/mutations.ts
+++ b/apps/web/worker/features/pano/mutations.ts
@@ -226,7 +226,12 @@ export const mutations = {
 			});
 			const post = shapePost({...r, myVote: null});
 			// A draft is private: re-resolve for the author, never prepend to the public topic.
-			yield* live.post.update(post.id, {changed: ["isDraft"], data: post});
+			// A save rewrites the whole draft, so `changed` names every intrinsic field it can
+			// touch — the author's other tab reads them all off this frame.
+			yield* live.post.update(post.id, {
+				changed: ["slug", "title", "url", "host", "body", "tags", "isDraft", "updatedAt"],
+				data: post,
+			});
 			return post;
 		}),
 	),
@@ -417,7 +422,7 @@ export const mutations = {
 			// `myVote` (edit doesn't touch vote state).
 			const [fresh] = yield* pano.getPostsByIds([r.postId], {viewerId: user.id});
 			const post = shapePost({...r, myVote: fresh?.myVote ?? null});
-			yield* live.post.update(post.id, {changed: ["title", "body"], data: post});
+			yield* live.post.update(post.id, {changed: ["title", "body", "updatedAt"], data: post});
 			return post;
 		}),
 	),
@@ -641,9 +646,11 @@ export const mutations = {
 				sandboxed: fresh?.sandboxed ?? false,
 			});
 			// The thread topic is viewer-blind, so the broadcast payload drops the owner-scoped
-			// `sandboxed` flag while the author's own returned node keeps it (#4282).
+			// `sandboxed` flag while the author's own returned node keeps it (#4282). Since
+			// #6585 `changed` trims it off the frame anyway; the explicit `false` stays as the
+			// belt to that brace.
 			yield* live.comment.update(comment.id, {
-				changed: ["body"],
+				changed: ["body", "updatedAt"],
 				data: {...comment, sandboxed: false},
 			});
 			return comment;

--- a/apps/web/worker/features/pano/vote-preserves-saved-state.unit.test.ts
+++ b/apps/web/worker/features/pano/vote-preserves-saved-state.unit.test.ts
@@ -1,11 +1,15 @@
 /**
  * Regression coverage for #2213: voting an already-saved post must not clobber its
- * saved state or author identity, in the client cache or the fanned live frame.
+ * saved state or author identity.
  *
  * The defect was that both resolvers shaped their return from the write result, which
  * carries neither `isSaved` nor resolved author identity, so the client cache-merge
  * overwrote the real values with nulls. The fix re-resolves the post through the same
  * batched read `post.save`/`post.unsave` use.
+ *
+ * The fanned frame used to be checked for the same whole projection. Since #6585 it
+ * is narrowed to the vote's `score`, so the frame assertions pin THAT — carrying the
+ * mutator's `isSaved` to every other subscriber was the leak, not the fix.
  */
 import {assert, describe, it} from "@effect/vitest";
 import {CurrentUser, LivePublisher} from "@kampus/fate-effect";
@@ -98,10 +102,13 @@ const recordingLive = (frames: PublishMessage[]): Layer.Layer<LivePublisher> =>
 		}),
 	);
 
-const publishedData = (frames: PublishMessage[]): Record<string, unknown> | undefined => {
+const publishedFrame = (frames: PublishMessage[]) => {
 	const entity = frames.find((m) => m.kind === "entity");
 	if (!entity || entity.kind !== "entity" || "delete" in entity.frame) return undefined;
-	return entity.frame.data as Record<string, unknown> | undefined;
+	return {
+		data: entity.frame.data as Record<string, unknown> | undefined,
+		select: entity.frame.select,
+	};
 };
 
 // The vote path fires the flag-gated `notifyContentVote` emitter and re-resolves the
@@ -168,30 +175,31 @@ describe("post.vote — voting a saved post preserves isSaved + author identity 
 		}),
 	);
 
-	it.effect(
-		"the published /fate/live frame carries the same resolved projection (no null leak)",
-		() =>
-			Effect.gen(function* () {
-				const frames: PublishMessage[] = [];
-				yield* drive(
-					mutations["post.vote"],
-					panoStub({
-						voteOnPost: () => Effect.succeed(writeResult()),
-						getPostsByIds: () => Effect.succeed([savedRow()]),
-					}),
-					frames,
-				);
-				const data = publishedData(frames);
-				assert.isDefined(data, "an entity update frame was published");
-				assert.strictEqual(data?.isSaved, true, "the fanned frame keeps isSaved, not null");
-				assert.strictEqual(data?.authorUsername, "elif", "the fanned frame keeps author identity");
-				assert.strictEqual(data?.authorDisplayName, "Elif Yılmaz");
-			}),
+	it.effect("the published /fate/live frame narrows to the re-resolved score (#6585)", () =>
+		Effect.gen(function* () {
+			const frames: PublishMessage[] = [];
+			yield* drive(
+				mutations["post.vote"],
+				panoStub({
+					voteOnPost: () => Effect.succeed(writeResult()),
+					getPostsByIds: () => Effect.succeed([savedRow()]),
+				}),
+				frames,
+			);
+			const frame = publishedFrame(frames);
+			assert.isDefined(frame, "an entity update frame was published");
+			assert.deepStrictEqual(
+				frame?.data,
+				{id: "post_1", score: 1},
+				"a vote fans its score and nothing else",
+			);
+			assert.deepStrictEqual(frame?.select, ["id", "score"]);
+		}),
 	);
 });
 
 describe("post.retractVote — shares the fix (#2213)", () => {
-	it.effect("returned + published projection both keep isSaved:true and identity", () =>
+	it.effect("the returned projection keeps isSaved + identity; the frame narrows", () =>
 		Effect.gen(function* () {
 			const frames: PublishMessage[] = [];
 			const post = (yield* drive(
@@ -204,9 +212,12 @@ describe("post.retractVote — shares the fix (#2213)", () => {
 			)) as Record<string, unknown>;
 			assert.strictEqual(post.isSaved, true, "retractVote also preserves isSaved");
 			assert.strictEqual(post.authorUsername, "elif");
-			const data = publishedData(frames);
-			assert.strictEqual(data?.isSaved, true, "the fanned retract frame keeps isSaved too");
-			assert.strictEqual(data?.authorDisplayName, "Elif Yılmaz");
+			const frame = publishedFrame(frames);
+			assert.deepStrictEqual(
+				frame?.data,
+				{id: "post_1", score: 0},
+				"the fanned retract frame narrows to the re-resolved score (#6585)",
+			);
 		}),
 	);
 });

--- a/apps/web/worker/features/sozluk/mutations.ts
+++ b/apps/web/worker/features/sozluk/mutations.ts
@@ -229,7 +229,10 @@ export const mutations = {
 			// Re-read the viewer's vote so the edit doesn't blank `myVote`.
 			const [fresh] = yield* sozluk.getDefinitionsByIds([result.definitionId], {viewerId: user.id});
 			const definition = shapeDefinition({...result, myVote: fresh?.myVote ?? null});
-			yield* live.definition.update(definition.id, {changed: ["body"], data: definition});
+			yield* live.definition.update(definition.id, {
+				changed: ["body", "updatedAt"],
+				data: definition,
+			});
 			return definition;
 		}),
 	),


### PR DESCRIPTION
A live entity `update` used to ship the whole re-resolved node, resolved against the mutator's
viewer, and fate merged it key-by-key into every subscriber's cache. One person's vote overwrote
everyone else's `myVote` and `isSaved` until they refetched. The `changed: [...]` array written at
~20 call sites read as if it stopped that; the frame builder dropped it, so it never did.

`updateFrame` in `apps/web/worker/features/fate-live/live-publisher.ts` now threads `changed`
through: the payload is trimmed to those keys and `select` names exactly what survived the trim.

Two things are worth knowing about why it is shaped that way, both read off fate's own source
(`@nkzw/fate/lib/index.mjs`):

- **The trim is the fix, not the `select`.** fate's `writeEntity` copies every scalar key *present
  on the payload* over the cached record, gated by `hasOwnProperty` and never by `select`. A key
  that is not on the payload leaves each subscriber's own read-derived value standing.
- **`select` has to match the trim exactly.** `subscribeById` reads `event.data.select` ahead of the
  payload and refetches the record whenever `canUseLivePayloadData` says the payload cannot cover
  the selection. A `changed` key the node happens to omit would cost every subscriber a round trip,
  so `select` is derived from the trimmed payload rather than from `changed` directly.

A publish carrying no `changed` keeps the old whole-node frame, so nothing silently becomes a no-op.

The call-site sweep widened four `changed` arrays that were incomplete and became staleness bugs
once they started being applied: `post.saveDraft` (a save rewrites the whole draft), and the three
edit paths, which all bump `updatedAt`.

Reviewer's first stop: the `entity update frames narrow to the changed keys` block in
`live-publisher.unit.test.ts`, then the two rewritten frame assertions in
`vote-preserves-saved-state.unit.test.ts` — that file used to pin the leak as the fix.

Follow-up filed: #6656 — https://github.com/kamp-us/phoenix/issues/6656

Fixes #6585

## Deviations

- **Pre-existing test or fixture changed** — **Said:** #6585 names the publisher and the mutation
  call sites. **Did:** rewrote two assertions in
  `apps/web/worker/features/pano/vote-preserves-saved-state.unit.test.ts` that asserted the fanned
  vote frame keeps `isSaved: true` and the author identity. **Why:** that is the leak #6585 kills,
  so the test pinned the defect; the assertions now pin the narrowed frame (`{id, score}` with
  `select: ["id", "score"]`), and #2213's actual invariant — the *returned* projection keeps
  `isSaved` and identity rather than nulls from the write result — is untouched and still asserted.
  **Disposition:** stated here.
- **Scope narrowing** — **Said:** criterion 1 asks for `select` equal to the changed keys.
  **Did:** `select` is the changed keys plus `id`. **Why:** fate's own `changed`→select derivation
  (`filterLiveSelection`) adds `id`, and `writeEntity` resolves the cache key through
  `config.getId(record)`, so a payload without it cannot be merged at all. **Disposition:** stated
  here.
- **Known defect left unfixed** — **Said:** kill the `myVote`/`isSaved` leak. **Did:** `post.save`
  and `post.unsave` still broadcast the mutator's `isSaved`, because on those paths it IS the
  changed field. **Why:** #6585's criterion 1 sanctions it in so many words ("never ride unless they
  are the changed field"), and the real fix is a design question — a per-viewer topic, or dropping
  the publish and leaning on the client's `savedReconcile` — not a line in this diff.
  **Disposition:** filed as #6656.
- **Known defect left unfixed** — **Said:** criterion 3 asks for a two-session check that an idle
  reader's vote arrow and bookmark do not flip. **Did:** proved it at the frame instead — the vote
  frame carries `{id, score}` and nothing else, and fate writes only the keys a payload carries.
  **Why:** this lane has no way to drive two browser sessions against a deployed worker.
  **Disposition:** stated here; the manual two-session check is still worth running before merge.
