### PR TITLE
chore: Seventeen flag-gated pages repeat the same dark-gate docblock with no .patterns/ home

### DIFF
--- a/.patterns/feature-flags.md
+++ b/.patterns/feature-flags.md
@@ -151,6 +151,10 @@ import {FlagGate} from "../flags/FlagGate";
 `FlagGate` defaults to `false`, so the gated path stays dark through loading, fetch errors, and an
 undeclared flag — the same safe-default contract as the server, end to end.
 
+Gating a **whole page** on a flag has its own shape, because the off answer there is a 404 and a
+404 rendered before the flag settles reads as a broken link:
+[flag-dark-page-gate.md](./flag-dark-page-gate.md).
+
 ## 4. Flip a flag (and kill-switch)
 
 Flipping is the **release** — a deliberate act, separate from the merge. Two paths:

--- a/.patterns/flag-dark-page-gate.md
+++ b/.patterns/flag-dark-page-gate.md
@@ -1,7 +1,7 @@
 # The flag-dark page gate
 
-**How to gate a whole page dark**: the route ships behind a default-off flag, self-404s while the
-flag is off, and never decides 404-vs-page until the flag has actually resolved. Reach for this doc
+**The shape a flag-dark page gate takes**: the route ships behind a default-off flag, self-404s while
+the flag is off, and never decides 404-vs-page until the flag has actually resolved. Reach for this doc
 before adding a page-level `useFlag` gate; the flag system itself (declaring, flipping, reading
 server-side) is [feature-flags.md](./feature-flags.md), and where the route mounts is
 [frontend-routing.md](./frontend-routing.md).
@@ -68,8 +68,9 @@ A key listed in `SHELL_FLAG_KEYS` ([`apps/web/src/flags/shell-keys.ts`](../apps/
 is injected into `window.__BOOT__` by the worker's shell render, and `useFlag` resolves it
 synchronously in its `useState` initializer — so the very first render already carries
 `{value, loading: false}` and the placeholder branch never paints. `MECMUA_PUBLIC_READ` and
-`MECMUA_FEED` are the members today; the mecmua pages get the fast path, every other gated page
-takes the `/api/flags/evaluate` round trip.
+`MECMUA_FEED` are the members today, so `MecmuaIndexPage`, `MecmuaPostPage` and `MecmuaFeedPage` get
+the fast path; every other gated page — including the `MECMUA_WRITE` pages `MecmuaDraftsPage` and
+`MecmuaEditorPage` — takes the `/api/flags/evaluate` round trip and does paint the placeholder.
 
 That does not make the placeholder branch dead code: `__BOOT__` is absent whenever the shell was not
 injected, and membership is a deliberate, guarded decision — only a flag whose wrong value moves

--- a/.patterns/flag-dark-page-gate.md
+++ b/.patterns/flag-dark-page-gate.md
@@ -1,0 +1,94 @@
+# The flag-dark page gate
+
+**How to gate a whole page dark**: the route ships behind a default-off flag, self-404s while the
+flag is off, and never decides 404-vs-page until the flag has actually resolved. Reach for this doc
+before adding a page-level `useFlag` gate; the flag system itself (declaring, flipping, reading
+server-side) is [feature-flags.md](./feature-flags.md), and where the route mounts is
+[frontend-routing.md](./frontend-routing.md).
+
+## The three rules
+
+1. **Dark by default.** The gate reads `useFlag(KEY, false)`. The flag's declared default is `off`,
+   so the page is unreachable the moment it merges and a human flips it on later (ADR
+   [0083](../.decisions/0083-agents-deploy-humans-release.md)).
+2. **Off ⇒ 404, from the page itself.** With the flag off the component returns `<NotFoundPage />`.
+   The route stays mounted in `App.tsx` either way — the page owns its own visibility, so there is
+   no conditional route tree to keep in sync.
+3. **Defer the decision while the flag is loading.** Render a neutral placeholder until `loading` is
+   false. Deciding on the default value would show a 404 for one paint to a user who is entitled to
+   the page, then swap it for the page — which reads as a broken link, not as loading.
+
+## The shape
+
+```tsx
+export function MutesPage() {
+	const {value: flagOn, loading: flagLoading} = useFlag(MEMBER_MUTE, false);
+	const session = useSession();
+
+	// The deferred-404 gate — see `.patterns/flag-dark-page-gate.md`.
+	if (flagLoading || session.isPending) {
+		return (
+			<div className="kp-mutes">
+				<div className="kp-mutes__inner">
+					<p className="kp-mutes__loading">yükleniyor…</p>
+				</div>
+			</div>
+		);
+	}
+
+	if (!flagOn) return <NotFoundPage />;
+	// …the page
+}
+```
+
+Every asynchronous input the 404 decision depends on joins the same first branch —
+`session.isPending` above, because a signed-out visitor is redirected rather than 404'd and that
+answer is not known yet either. The placeholder wears the page's own frame (its container classes,
+its `yükleniyor…` line), so releasing the page is not a layout jump; see
+[fate-async-react.md](./fate-async-react.md) for the height-matching discipline.
+
+Once the gate needs more than two conditions, lift the state choice into a pure function beside the
+page and test it there — `caylakVisibilityGating.ts` returns one of six states (`loading`, `404`,
+`auth`, …) and `CaylakVisibilityPage` only renders what it names.
+
+## The `useFlag(key, default)` contract the gate reads
+
+`useFlag` returns `{value, loading}` ([`apps/web/src/flags/useFlag.ts`](../apps/web/src/flags/useFlag.ts)):
+
+- `value` is `default` until the server resolves a genuine boolean. The read **never throws** — an
+  unreachable Flagship, a typo'd key and a non-2xx response all hold the default, so a flag outage
+  leaves every dark page 404ing rather than breaking.
+- `loading` is the only thing that distinguishes "resolved to `false`" from "still `false` because
+  nothing answered yet". Both look identical in `value`, which is exactly why the gate branches on
+  `loading` first.
+
+## The `__BOOT__` fast path
+
+A key listed in `SHELL_FLAG_KEYS` ([`apps/web/src/flags/shell-keys.ts`](../apps/web/src/flags/shell-keys.ts))
+is injected into `window.__BOOT__` by the worker's shell render, and `useFlag` resolves it
+synchronously in its `useState` initializer — so the very first render already carries
+`{value, loading: false}` and the placeholder branch never paints. `MECMUA_PUBLIC_READ` and
+`MECMUA_FEED` are the members today; the mecmua pages get the fast path, every other gated page
+takes the `/api/flags/evaluate` round trip.
+
+That does not make the placeholder branch dead code: `__BOOT__` is absent whenever the shell was not
+injected, and membership is a deliberate, guarded decision — only a flag whose wrong value moves
+geometry at first paint belongs there, and both sides derive the key set from the one manifest (ADR
+[0179](../.decisions/0179-edge-resolved-shell-state-boot-contract.md)). Write the gate the same way
+regardless of membership.
+
+## When this is not the gate you want
+
+- **Access that the server already decides.** `/divan` and `/funnel` carry no flag and no
+  client-side role check: the fate root denies a non-reviewer `UNAUTHORIZED` and `<Screen>` renders
+  "yetkin yok". A client gate over a server-authoritative answer is a second source of truth.
+- **A flag that toggles something inside a live page.** `PanoFeed` reads `MEMBER_MUTE` for the mute
+  affordance and `ProfilePage` reads `PHOENIX_CAYLAK_VISIBILITY` for a marker; neither blocks the
+  page, so both read `value` alone and let the default hold through loading. Use `<FlagGate>` for
+  the declarative version.
+
+## Pages carrying the gate today
+
+`BildirimlerPage`, `CaylakVisibilityPage`, `MecmuaDraftsPage`, `MecmuaEditorPage`,
+`MecmuaFeedPage`, `MecmuaIndexPage`, `MecmuaPostPage`, `MutesPage` — all under
+`apps/web/src/pages/`.

--- a/.patterns/frontend-routing.md
+++ b/.patterns/frontend-routing.md
@@ -16,10 +16,15 @@ and lowercase kebab-case even where the product noun they serve is Turkish
 Routes fall into two visibility classes:
 
 - **Public product routes** — mounted plainly, live for everyone (`/pano`, `/sozluk`,
-  `/search`, `/u/:username`).
-- **Dark feature routes** — mounted behind a flag the page self-gates on (off ⇒ 404):
-  `/divan`, `/funnel`, `/bildirimler`. These ship dark by default and a human flips
-  the flag to release them (the agents-deploy / humans-release contract, ADR 0083).
+  `/search`, `/u/:username`). `/divan` and `/funnel` belong here too: they carry no flag and no
+  client-side role check, because their fate roots deny an unentitled reader `UNAUTHORIZED` and
+  `<Screen>` renders that as "yetkin yok".
+- **Dark feature routes** — mounted plainly, but the page self-gates on a default-off flag
+  (off ⇒ 404): `/bildirimler`, `/susturduklarim`, `/caylak-gorunurlugu`, and the `/mecmua/*`
+  routes. These ship dark by default and a human flips the flag to release them (the
+  agents-deploy / humans-release contract, ADR 0083). The gate's shape — the self-404 and the
+  placeholder that keeps the 404 from flashing before the flag settles — is
+  [flag-dark-page-gate.md](./flag-dark-page-gate.md).
 
 `/lab/*` is a third, deliberately-public class — see below.
 

--- a/.patterns/index.md
+++ b/.patterns/index.md
@@ -89,6 +89,7 @@ The SPA's route tree (`apps/web/src/App.tsx`) and the visibility classes a route
 | Doc | Topic | Read when |
 |---|---|---|
 | [frontend-routing.md](./frontend-routing.md) | The react-router `<Routes>`/`<Route>` tree (one shared `<Layout />`, pages in `apps/web/src/pages/`); the two visibility classes (public vs dark flag-gated); the `/lab/*` PUBLIC-prototype convention + graduate-or-cull lifecycle | Adding a route, mounting a prototype under `/lab/*`, or deciding a route's production visibility |
+| [flag-dark-page-gate.md](./flag-dark-page-gate.md) | The dark-route gate's shape: `useFlag(KEY, false)` → self-404 when off → the deferred-404 placeholder so the 404 never flashes; the `value`/`loading` contract; the `__BOOT__` fast path; when a server-authoritative denial or an in-page toggle is the right gate instead | Gating a whole page behind a flag, or touching an existing gated page's gate ([#6459](https://github.com/kamp-us/phoenix/issues/6459)) |
 
 ## Index — alchemy infra layer
 

--- a/apps/web/src/pages/BildirimlerPage.tsx
+++ b/apps/web/src/pages/BildirimlerPage.tsx
@@ -1,3 +1,7 @@
+/**
+ * `/bildirimler` — ships dark behind the default-off `phoenix-bildirim` flag. The gate's shape is
+ * `.patterns/flag-dark-page-gate.md`.
+ */
 import {Navigate} from "react-router";
 import {useSession} from "../auth/client";
 import {BildirimList} from "../components/bildirim/BildirimList";
@@ -14,7 +18,6 @@ export function BildirimlerPage() {
 	const {value: flagOn, loading: flagLoading} = useFlag(PHOENIX_BILDIRIM, false);
 	const session = useSession();
 
-	// Don't decide 404-vs-page until the flag resolves, or the 404 flashes first.
 	if (flagLoading || session.isPending) {
 		return (
 			<div className="kp-bildirim">

--- a/apps/web/src/pages/CaylakVisibilityPage.tsx
+++ b/apps/web/src/pages/CaylakVisibilityPage.tsx
@@ -2,11 +2,10 @@
  * `CaylakVisibilityPage` — the `/caylak-gorunurlugu` route (#6426, epic #4306): the yazar's
  * "çaylak katkılarını yerinde göster" setting, and the only surface that flips the #6422
  * preference. Same shape as `MutesPage` (`/susturduklarim`, #3117): a signed-in per-user
- * preference route that self-404s behind a default-off flag, shows a neutral placeholder while
- * the flag resolves so the 404 never flashes, and redirects a signed-out visitor to auth with a
- * `returnTo`.
+ * preference route that redirects a signed-out visitor to auth with a `returnTo`.
  *
- * Ships dark behind `phoenix-caylak-visibility` (ADR 0083). Yazar-only: a signed-in çaylak gets
+ * Ships dark behind `phoenix-caylak-visibility` (default-off;
+ * `.patterns/flag-dark-page-gate.md`). Yazar-only: a signed-in çaylak gets
  * a plain explanation, never a switch they cannot flip — the server refuses them anyway (#6422),
  * so a disabled control would only be a dead end wearing a control's clothes. Which of the six
  * states renders is the pure {@link caylakVisibilityGate}.

--- a/apps/web/src/pages/MecmuaDraftsPage.tsx
+++ b/apps/web/src/pages/MecmuaDraftsPage.tsx
@@ -1,7 +1,8 @@
 /**
  * `/mecmua/yazilarim` — the author's own drafts + published posts, off the `CurrentUser`-scoped
- * `mecmuaMyPosts` root. Ships dark behind `MECMUA_WRITE` (default-off; ADR 0083); that root
- * serves empty while the flag is off, so a signed-out or gated read just renders empty.
+ * `mecmuaMyPosts` root. Ships dark behind `MECMUA_WRITE` (default-off;
+ * `.patterns/flag-dark-page-gate.md`); that root serves empty while the flag is off, so a
+ * signed-out or gated read just renders empty.
  */
 import {NotebookPen} from "lucide-react";
 import {useListView, useRequest, useView, type ViewRef, view} from "react-fate";
@@ -35,7 +36,6 @@ export function MecmuaDraftsPage() {
 	const {value: flagOn, loading: flagLoading} = useFlag(MECMUA_WRITE, false);
 	// No in-page write CTA on purpose: mecmua's single one lives in the Subnav (#2603).
 
-	// Don't decide 404-vs-page until the flag resolves, or the 404 flashes first.
 	if (flagLoading) {
 		return (
 			<div className="kp-page">

--- a/apps/web/src/pages/MecmuaEditorPage.tsx
+++ b/apps/web/src/pages/MecmuaEditorPage.tsx
@@ -3,7 +3,8 @@
  * user may save a private draft, but yayımla is offered only to a yazar (read off the fate
  * `me` view, never the session field) — `PublishMecmua` gates it server-side regardless.
  * Every save mints a FRESH draft row; there is no edit-in-place (#2463). Nothing here
- * imports tiptap directly. Ships dark behind `MECMUA_WRITE` (default-off; ADR 0083).
+ * imports tiptap directly. Ships dark behind `MECMUA_WRITE` (default-off;
+ * `.patterns/flag-dark-page-gate.md`).
  */
 import {Composer, useComposerEditor} from "@kampus/composer";
 import {useState} from "react";
@@ -34,7 +35,6 @@ const MecmuaEditorView = view<MecmuaPost>()({
 export function MecmuaEditorPage() {
 	const {value: flagOn, loading: flagLoading} = useFlag(MECMUA_WRITE, false);
 
-	// Don't decide 404-vs-page until the flag resolves, or the 404 flashes first.
 	if (flagLoading) {
 		return (
 			<div className="kp-page">

--- a/apps/web/src/pages/MecmuaFeedPage.tsx
+++ b/apps/web/src/pages/MecmuaFeedPage.tsx
@@ -1,7 +1,8 @@
 /**
  * `/mecmua/akis` — the feed of published posts from authors the reader follows. On-site
  * reading only: there is no email/bülten path here by design. Ships dark behind
- * `MECMUA_FEED` (default-off; ADR 0083), and the `mecmuaFeed` root serves empty while it is.
+ * `MECMUA_FEED` (default-off; `.patterns/flag-dark-page-gate.md`), and the `mecmuaFeed` root
+ * serves empty while it is.
  */
 import {Newspaper} from "lucide-react";
 import {useListView, useRequest, useView, type ViewRef, view} from "react-fate";
@@ -40,7 +41,6 @@ const feedRequest = {
 export function MecmuaFeedPage() {
 	const {value: flagOn, loading: flagLoading} = useFlag(MECMUA_FEED, false);
 
-	// Don't decide 404-vs-page until the flag resolves, or the 404 flashes first.
 	if (flagLoading) {
 		return (
 			<div className="kp-page">

--- a/apps/web/src/pages/MecmuaIndexPage.tsx
+++ b/apps/web/src/pages/MecmuaIndexPage.tsx
@@ -1,7 +1,8 @@
 /**
  * `/mecmua` — the public index of published posts, distinct from the personalized
  * subscribed-author feed (`/mecmua/akis`). Ships dark behind `MECMUA_PUBLIC_READ`
- * (default-off; ADR 0083) — the route 404s server-side too, this gate just saves a fetch.
+ * (default-off; `.patterns/flag-dark-page-gate.md`) — the route 404s server-side too, this gate
+ * just saves a fetch.
  */
 import {BookOpenText} from "lucide-react";
 import {useEffect, useState} from "react";
@@ -32,7 +33,6 @@ type FetchState =
 export function MecmuaIndexPage() {
 	const {value: flagOn, loading: flagLoading} = useFlag(MECMUA_PUBLIC_READ, false);
 
-	// Don't decide 404-vs-page until the flag resolves, or the 404 flashes first.
 	if (flagLoading) {
 		return (
 			<div className="kp-page">

--- a/apps/web/src/pages/MecmuaPostPage.tsx
+++ b/apps/web/src/pages/MecmuaPostPage.tsx
@@ -2,7 +2,7 @@
  * `/mecmua/:slug` — the public reader for one published post. The body renders through
  * `@kampus/composer` in read-only mode, so write and read share one tiptap render path and
  * can't re-diverge (the raw-markdown bug #2578). Client-only; SEO/prerender is deferred.
- * Ships dark behind `MECMUA_PUBLIC_READ` (default-off; ADR 0083).
+ * Ships dark behind `MECMUA_PUBLIC_READ` (default-off; `.patterns/flag-dark-page-gate.md`).
  */
 import {lazy, Suspense, useEffect, useState} from "react";
 import {useParams} from "react-router";
@@ -33,7 +33,6 @@ export function MecmuaPostPage() {
 	const {value: flagOn, loading: flagLoading} = useFlag(MECMUA_PUBLIC_READ, false);
 	const {slug} = useParams<{slug: string}>();
 
-	// Don't decide 404-vs-page until the flag resolves, or the 404 flashes first.
 	if (flagLoading) {
 		return (
 			<div className="kp-page">

--- a/apps/web/src/pages/MutesPage.tsx
+++ b/apps/web/src/pages/MutesPage.tsx
@@ -1,4 +1,7 @@
-/** `/susturduklarim` — ships dark behind the default-off `member-mute` flag (ADR 0083). */
+/**
+ * `/susturduklarim` — ships dark behind the default-off `member-mute` flag. The gate's shape is
+ * `.patterns/flag-dark-page-gate.md`.
+ */
 import {Navigate} from "react-router";
 import {useSession} from "../auth/client";
 import {MutedMembersList} from "../components/mute/MutedMembersList";
@@ -14,7 +17,6 @@ export function MutesPage() {
 	const {value: flagOn, loading: flagLoading} = useFlag(MEMBER_MUTE, false);
 	const session = useSession();
 
-	// Don't decide 404-vs-page until the flag resolves, or the 404 flashes first.
 	if (flagLoading || session.isPending) {
 		return (
 			<div className="kp-mutes">

--- a/apps/web/src/pages/caylakVisibilityGating.ts
+++ b/apps/web/src/pages/caylakVisibilityGating.ts
@@ -3,9 +3,9 @@
  * reads (#6426, epic #4306). Extracted DOM-free — the `landingGating` / `mecmua-write-gate`
  * idiom — so the order of the gates is pinned without a render.
  *
- * The order is load-bearing. `loading` outranks everything so the 404 never flashes before
- * the flag resolves; `not-found` outranks the session so a dark feature leaks nothing to a
- * signed-out visitor either; and an unread tier is `loading`, never `caylak` — telling a
+ * The order is load-bearing. `loading` outranks everything — the deferred-404 gate,
+ * `.patterns/flag-dark-page-gate.md`; `not-found` outranks the session so a dark feature leaks
+ * nothing to a signed-out visitor either; and an unread tier is `loading`, never `caylak` — telling a
  * yazar they are a çaylak because their `me` read had not landed yet would be a lie.
  */
 import type {Tier} from "../../worker/features/kunye/standing";

--- a/apps/web/src/pages/caylakVisibilityGating.ts
+++ b/apps/web/src/pages/caylakVisibilityGating.ts
@@ -5,8 +5,8 @@
  *
  * The order is load-bearing. `loading` outranks everything — the deferred-404 gate,
  * `.patterns/flag-dark-page-gate.md`; `not-found` outranks the session so a dark feature leaks
- * nothing to a signed-out visitor either; and an unread tier is `loading`, never `caylak` — telling a
- * yazar they are a çaylak because their `me` read had not landed yet would be a lie.
+ * nothing to a signed-out visitor either; and an unread tier is `loading`, never `caylak` —
+ * telling a yazar they are a çaylak because their `me` read had not landed yet would be a lie.
  */
 import type {Tier} from "../../worker/features/kunye/standing";
 


### PR DESCRIPTION
The flag-dark page gate now has one home: `.patterns/flag-dark-page-gate.md`.

The rule was real and load-bearing but lived nowhere — eight gated pages each restated
"don't decide 404-vs-page until the flag resolves" in their own words, and the collapsed
one-liners from #6458 pointed at ADR 0083, which is the deploy/release decision, not the
gate's shape.

The new doc is a reference page: the three rules (dark by default, self-404 when off, defer
the decision while `loading`), the worked shape off `MutesPage`, the `useFlag(key, default)`
`value`/`loading` contract and why the gate branches on `loading` rather than `value`, the
`__BOOT__` fast path (`MECMUA_PUBLIC_READ` / `MECMUA_FEED` are the shell members today, so
`MecmuaIndexPage`, `MecmuaPostPage` and `MecmuaFeedPage` skip the placeholder while the
`MECMUA_WRITE` pages still take the round trip) and why the placeholder branch is still not
dead code, and the two cases where this is the wrong gate — a server-authoritative denial
(`/divan`, `/funnel`) and an in-page toggle (`PanoFeed`, `ProfilePage`).

Then the pages: each gate docblock now cites the doc instead of ADR 0083, and the eight
copies of the inline restatement are gone. `.patterns/index.md` carries the row;
`frontend-routing.md` and `feature-flags.md` §3 point at it from the two places a builder
lands first.

Both surfaces are green in-tree — `--surface code` (typecheck + lint) over the pages and
`--surface prose` (link + leak scan) over the docs, together covering all 13 changed files.

Fixes #6459

## Deviations

- **Out-of-scope change** — **Said:** #6459 names the pattern doc and repointing the gated
  pages' one-liners. **Did:** also corrected `frontend-routing.md`'s dark-route list, which
  named `/divan` and `/funnel` as flag-gated. **Why:** neither carries a flag — both are
  server-authoritative (`divan.roster` / `funnel.summary` deny `UNAUTHORIZED`, `<Screen>`
  renders "yetkin yok") — and that stale sentence is the exact line the new doc is linked
  from, so leaving it would have pointed a reader at a wrong example of the shape.
  **Disposition:** stated here; the corrected list names `/bildirimler`,
  `/susturduklarim`, `/caylak-gorunurlugu` and `/mecmua/*`, verified against
  `apps/web/src/pages/`.
- **Out-of-scope change** — **Said:** the criteria name the gated pages' docblocks.
  **Did:** also repointed one clause in `pages/caylakVisibilityGating.ts`, the pure
  six-state gate function behind `CaylakVisibilityPage`. **Why:** it restated the same
  no-404-flash rule while justifying its own ordering; the ordering note stays (it is a
  local invariant at its enforcement site), the restated rule became a pointer.
  **Disposition:** stated here.
