### PR TITLE
fix: fate-live: thread the resolved sandbox viewer through every masking mutation re-read

### DIFF
--- a/.patterns/caylak-content-containment.md
+++ b/.patterns/caylak-content-containment.md
@@ -90,12 +90,19 @@ content table owns its lifecycle, and mask through that.
 
 ## A gated read still has to say who it is
 
-Passing no viewer is not neutral. `resolveSandboxViewer({})` returns `anonymousViewer`, so a
-read with no options is a read *as the public* — the strictest mask there is. That is the
-right default for an unauthenticated path and the wrong one everywhere else, and it fails
-silently: the row is simply absent, and the caller renders whatever it renders for "missing".
+Passing no viewer is not neutral, and every masked Pano/Sözlük read now refuses to let you:
+their options carry `MaskedReadOptions` (`apps/web/worker/features/lifecycle/SandboxVisibility.ts`),
+a **required** resolved `sandboxViewer`, so omitting it is a compile error rather than a
+silent read *as the public*. Anonymity is still available — you write
+`sandboxViewer: anonymousViewer`, which is the RSS feed's and the landing feed's deliberate
+answer — but you have to say it.
 
-The trap is a read that already sits behind an authority gate. Being inside a
+That refusal exists because the omission's failure mode is invisible: the row is simply
+absent, and the caller renders whatever it renders for "missing". A write's own re-read is
+where that hurt most — the mutation committed at D1, then its masked re-read dropped the row
+and the handler answered `null` or `*NotFound` (#6473, #6424, #6586).
+
+The trap the type cannot close is a read that already sits behind an authority gate. Being inside a
 `Moderate`-gated resolver does nothing for the mask; the SQL only widens for a viewer that
 carries `canSeeSandboxed`. The moderation report queue spent six reads this way (#6472): the
 `Moderate` grant was discharged, the reads passed no viewer, and every reported çaylak item —

--- a/.patterns/effect-testing.md
+++ b/.patterns/effect-testing.md
@@ -80,7 +80,10 @@ sits above it; a captured argument is the wiring itself.
 Bundle the services the derivation reads as one layer per axis so a shape is one or two lines, not
 seven stubs — [`kunye/sandbox.testing.ts`](../apps/web/worker/features/kunye/sandbox.testing.ts) is
 the worked example (`inPlaceVisibilityLayer` / `moderatorAxisLayer` / `sandboxViewerLayer`), with
-every store dying on contact so a short-circuit shape proves the read never happened. Consumers:
+every store dying on contact so a short-circuit shape proves the read never happened. Its
+`memberSandboxViewer` is the other half: a test that calls a masked read *directly* has to hand it a
+viewer (they are required — see [caylak-content-containment.md](./caylak-content-containment.md)), and
+that constructor names the plain-member one instead of leaving it inline. Consumers:
 [`pano/mutation-rehydrate-viewer.unit.test.ts`](../apps/web/worker/features/pano/mutation-rehydrate-viewer.unit.test.ts),
 [`pano/saved-posts-viewer.unit.test.ts`](../apps/web/worker/features/pano/saved-posts-viewer.unit.test.ts),
 [`search/search-not-widened.unit.test.ts`](../apps/web/worker/features/search/search-not-widened.unit.test.ts).

--- a/apps/web/worker/features/flagship/sandbox-restore-escape.invariant.test.ts
+++ b/apps/web/worker/features/flagship/sandbox-restore-escape.invariant.test.ts
@@ -17,6 +17,7 @@ import * as Schema from "effect/Schema";
 import {DefinitionId} from "../../lib/ids.ts";
 import {noopPanoFeedCache} from "../fate/resolve-wire.testing.ts";
 import {livePublisherFor} from "../fate-live/live-publisher.ts";
+import {sandboxViewerLayer} from "../kunye/sandbox.testing.ts";
 import type {CommentRow} from "../pano/comment-fields.ts";
 import {CommentId, PostId} from "../pano/ids.ts";
 import {mutations as panoMutations} from "../pano/mutations.ts";
@@ -28,6 +29,11 @@ import {Sozluk, type TermPage} from "../sozluk/Sozluk.ts";
 
 const AUTHOR = {id: "caylak-1", email: "caylak@example.com", name: "çaylak"};
 const AT = new Date("2026-07-03T00:00:00.000Z");
+
+// The three restore handlers re-read their parent page through the resolved sandbox
+// viewer (#6586), so the axes it probes have to be on the context. Flag off + not a
+// moderator is this file's world: what it proves is the publish gate, not the mask.
+const viewerAxes = sandboxViewerLayer({flagOn: false, viewerId: AUTHOR.id, isModerator: false});
 
 // The gated `appendNode` publishes NOTHING when `decidePublish` suppresses it, so a
 // suppressed restore leaves the topic absent from `recorded` — the assertion itself.
@@ -155,7 +161,7 @@ describe("çaylak sandbox-escape via delete→restore is structurally prevented 
 			yield* panoMutations["post.restore"]
 				.handler({input: {id: PostId.make("post-1")}, select: ["id"]})
 				.pipe(
-					Effect.provide(Layer.mergeAll(pano, layer)),
+					Effect.provide(Layer.mergeAll(pano, layer, viewerAxes)),
 					Effect.provideService(CurrentUser, {user: AUTHOR}),
 				);
 			yield* drain(scheduled);
@@ -204,7 +210,7 @@ describe("çaylak sandbox-escape via delete→restore is structurally prevented 
 			yield* panoMutations["comment.restore"]
 				.handler({input: {id: CommentId.make("comment-1")}, select: ["id"]})
 				.pipe(
-					Effect.provide(Layer.mergeAll(pano, layer)),
+					Effect.provide(Layer.mergeAll(pano, layer, viewerAxes)),
 					Effect.provideService(CurrentUser, {user: AUTHOR}),
 				);
 			yield* drain(scheduled);
@@ -243,7 +249,7 @@ describe("çaylak sandbox-escape via delete→restore is structurally prevented 
 			yield* sozlukMutations["definition.restore"]
 				.handler({input: {id: DefinitionId.make("def-1")}, select: ["id"]})
 				.pipe(
-					Effect.provide(Layer.mergeAll(sozluk, layer)),
+					Effect.provide(Layer.mergeAll(sozluk, layer, viewerAxes)),
 					Effect.provideService(CurrentUser, {user: AUTHOR}),
 				);
 			yield* drain(scheduled);

--- a/apps/web/worker/features/kunye/sandbox.testing.ts
+++ b/apps/web/worker/features/kunye/sandbox.testing.ts
@@ -18,8 +18,22 @@ import {
 } from "../caylak-visibility/CaylakVisibility.ts";
 import {Flags} from "../flagship/Flags.ts";
 import {RequestFlagOverrides} from "../flagship/FlagsContext.ts";
+import type {SandboxViewer} from "../lifecycle/EntityLifecycle.ts";
 import {Kunye} from "./Kunye.ts";
 import type {Tier} from "./standing.ts";
+
+/**
+ * The plain signed-in viewer — neither moderator nor #6423 in-place reader, so the
+ * sandbox mask admits their own rows and nothing else. Test-only: production reads take
+ * the viewer `currentSandboxViewer` resolved, and a constructor that hands back an
+ * unelevated viewer without probing is exactly the degradation `MaskedReadOptions` exists
+ * to keep out of the call sites (#6586).
+ */
+export const memberSandboxViewer = (viewerId: string): SandboxViewer => ({
+	viewerId,
+	canSeeSandboxed: false,
+	seesSandboxedInPlace: false,
+});
 
 const runtimeContextStub: BaseRuntimeContext = {
 	Type: "sandbox-viewer-test",

--- a/apps/web/worker/features/lifecycle/SandboxVisibility.ts
+++ b/apps/web/worker/features/lifecycle/SandboxVisibility.ts
@@ -14,6 +14,22 @@ import {
 } from "./EntityLifecycle.ts";
 
 /**
+ * The viewer axis of a sandbox-masked read: a RESOLVED {@link SandboxViewer}, required.
+ * Every masked Pano/Sözlük read's options carry this, so a call site cannot reach the
+ * mask without first resolving who is asking — the omission is a compile error rather
+ * than something a reviewer has to grep for (#6586).
+ *
+ * That mattered because omitting it was silent and wrong in one direction only: the
+ * degraded viewer {@link resolveSandboxViewer} used to synthesize reads `false` on both
+ * elevated axes, so a write's re-read masked out the very row the write had just
+ * committed — `null` back from a landed mutation (#6473 for the author arm, #6424 for
+ * the moderator/in-place arms).
+ */
+export interface MaskedReadOptions {
+	readonly sandboxViewer: SandboxViewer;
+}
+
+/**
  * Resolve the {@link SandboxViewer} a domain read applies from its options. A read
  * that was handed a fully-resolved `sandboxViewer` (the resolver probed moderator
  * authority) uses it; otherwise it degrades to a non-moderator viewer keyed by the
@@ -23,6 +39,11 @@ import {
  * The degraded path claims neither elevated class: `seesSandboxedInPlace` (#6423) is
  * resolved from the flag + the opt-in preference, which a bare `{viewerId}` cannot
  * witness, so it degrades `false` exactly as `canSeeSandboxed` does.
+ *
+ * The Pano/Sözlük content reads no longer reach this: their viewer is
+ * {@link MaskedReadOptions}-required, so there is nothing to degrade FROM. It survives
+ * for `Pasaport`'s profile reads, whose options are shaped by the profile being viewed
+ * rather than by a resolved reader.
  */
 export const resolveSandboxViewer = (opts: {
 	readonly viewerId?: string | null | undefined;

--- a/apps/web/worker/features/pano/Pano.connection.unit.test.ts
+++ b/apps/web/worker/features/pano/Pano.connection.unit.test.ts
@@ -11,6 +11,8 @@ import {drizzle} from "drizzle-orm/d1";
 import {Effect, Layer} from "effect";
 import {Drizzle, type DrizzleAccess, type DrizzleDb, relations} from "../../db/Drizzle.ts";
 import type * as schema from "../../db/drizzle/schema.ts";
+import {memberSandboxViewer} from "../kunye/sandbox.testing.ts";
+import {anonymousViewer} from "../lifecycle/EntityLifecycle.ts";
 import {makePasaportStub, PasaportIdentityStub} from "../pasaport/Pasaport.testing.ts";
 import type {Pasaport, ProfileIdentityRow} from "../pasaport/Pasaport.ts";
 import {ReactionStub} from "../reaction/Reaction.testing.ts";
@@ -104,7 +106,11 @@ describe("Pano.listPostsConnection — `first` clamp [1,100] (no SQL engine boot
 			const {access, queries} = scriptedAccess([0 /* count */, [] /* fetch */]);
 			return Effect.gen(function* () {
 				const pano = yield* Pano;
-				yield* pano.listPostsConnection(input === undefined ? {} : {first: input});
+				yield* pano.listPostsConnection(
+					input === undefined
+						? {sandboxViewer: anonymousViewer}
+						: {first: input, sandboxViewer: anonymousViewer},
+				);
 				const {params} = fetchQuery(queries);
 				assert.strictEqual(
 					params.at(-1),
@@ -128,7 +134,12 @@ describe("Pano.listPostsConnection — single-direction keyset, lead column by s
 	const sqlOf = (sort: "hot" | "new" | "top" | "discuss") =>
 		Effect.gen(function* () {
 			const pano = yield* Pano;
-			yield* pano.listPostsConnection({sort, first: 10, after: "p9"});
+			yield* pano.listPostsConnection({
+				sort,
+				first: 10,
+				after: "p9",
+				sandboxViewer: anonymousViewer,
+			});
 		});
 
 	const run = (sort: "hot" | "new" | "top" | "discuss") => {
@@ -199,7 +210,11 @@ describe("Pano.listPostsConnection — cursor-miss → empty page, NO second DB 
 		};
 		return Effect.gen(function* () {
 			const pano = yield* Pano;
-			const page = yield* pano.listPostsConnection({first: 10, after: "ghost"});
+			const page = yield* pano.listPostsConnection({
+				first: 10,
+				after: "ghost",
+				sandboxViewer: anonymousViewer,
+			});
 			assert.deepStrictEqual(page.rows, [], "miss → no rows");
 			assert.strictEqual(page.hasNextPage, false, "miss → no next page");
 			assert.strictEqual(page.endCursor, null, "miss → no cursor");
@@ -221,7 +236,7 @@ describe("Pano.listPostsConnection — cursor-miss → empty page, NO second DB 
 		};
 		return Effect.gen(function* () {
 			const pano = yield* Pano;
-			const page = yield* pano.listPostsConnection({first: 10});
+			const page = yield* pano.listPostsConnection({first: 10, sandboxViewer: anonymousViewer});
 			assert.strictEqual(page.totalCount, 0);
 		}).pipe(Effect.provide(panoLayer(access)));
 	});
@@ -267,7 +282,11 @@ describe("Pano.listPostsConnection — stamps the LIVE author identity on the pa
 			const {access} = scriptedAccess([1 /* count */, [fetchRow] /* fetch */]);
 			return Effect.gen(function* () {
 				const pano = yield* Pano;
-				const page = yield* pano.listPostsConnection({sort: "new", first: 10});
+				const page = yield* pano.listPostsConnection({
+					sort: "new",
+					first: 10,
+					sandboxViewer: anonymousViewer,
+				});
 				assert.strictEqual(page.rows.length, 1, "head page returns the one row");
 				const row = page.rows[0];
 				assert.isDefined(row, "head page returns the one row");
@@ -303,7 +322,11 @@ describe("Pano.listPostsConnection — stamps the LIVE author identity on the pa
 		const {access} = scriptedAccess([3 /* count */, rows /* fetch */]);
 		return Effect.gen(function* () {
 			const pano = yield* Pano;
-			yield* pano.listPostsConnection({sort: "new", first: 10});
+			yield* pano.listPostsConnection({
+				sort: "new",
+				first: 10,
+				sandboxViewer: anonymousViewer,
+			});
 			assert.deepStrictEqual(
 				[...(readSpy.ids ?? [])].sort(),
 				["user-1", "user-2"],
@@ -404,12 +427,19 @@ describe("Pano — authed feed: parallelized listPostsConnection composes with t
 			]);
 			return Effect.gen(function* () {
 				const pano = yield* Pano;
-				const page = yield* pano.listPostsConnection({sort: "new", first: 10});
+				const page = yield* pano.listPostsConnection({
+					sort: "new",
+					first: 10,
+					sandboxViewer: anonymousViewer,
+				});
 				assert.strictEqual(page.totalCount, 1, "parallelized count still lands on the page");
 				const ids = page.rows.map((row) => row.id);
 				assert.deepStrictEqual(ids, ["post-1"], "the keyset page carries the id to re-hydrate");
 
-				const hydrated = yield* pano.getPostsByIds(ids, {viewerId: VIEWER});
+				const hydrated = yield* pano.getPostsByIds(ids, {
+					viewerId: VIEWER,
+					sandboxViewer: memberSandboxViewer(VIEWER),
+				});
 				const row = hydrated[0];
 				assert.isDefined(row, "the re-hydrate returns the viewer-scoped row");
 				assert.strictEqual(row.myVote, true, "the viewer's vote survives the re-hydrate stamp");
@@ -431,7 +461,12 @@ describe("Pano feed + thread — mute read-mask (author_id NOT IN …)", () => {
 		const {access, queries} = scriptedAccess([1 /* count */, [] /* fetch */]);
 		return Effect.gen(function* () {
 			const pano = yield* Pano;
-			yield* pano.listPostsConnection({sort: "new", first: 10, mutedIds: new Set(["u-muted"])});
+			yield* pano.listPostsConnection({
+				sort: "new",
+				first: 10,
+				mutedIds: new Set(["u-muted"]),
+				sandboxViewer: anonymousViewer,
+			});
 			const {sql, params} = fetchQuery(queries);
 			assert.match(sql, /"post_record"\."author_id" not in \(\?\)/, "muted author excluded");
 			assert.include(params, "u-muted");
@@ -442,7 +477,11 @@ describe("Pano feed + thread — mute read-mask (author_id NOT IN …)", () => {
 		const {access, queries} = scriptedAccess([1 /* count */, [] /* fetch */]);
 		return Effect.gen(function* () {
 			const pano = yield* Pano;
-			yield* pano.listPostsConnection({sort: "new", first: 10});
+			yield* pano.listPostsConnection({
+				sort: "new",
+				first: 10,
+				sandboxViewer: anonymousViewer,
+			});
 			assert.notMatch(fetchQuery(queries).sql, /not in/, "no mask ⇒ byte-for-byte today's feed");
 		}).pipe(Effect.provide(panoLayer(access)));
 	});
@@ -451,7 +490,11 @@ describe("Pano feed + thread — mute read-mask (author_id NOT IN …)", () => {
 		const {access, queries} = scriptedAccess([0 /* count */, [] /* fetch */]);
 		return Effect.gen(function* () {
 			const pano = yield* Pano;
-			yield* pano.listCommentsKeyset("post-1", {first: 10, mutedIds: new Set(["u-muted"])});
+			yield* pano.listCommentsKeyset("post-1", {
+				first: 10,
+				mutedIds: new Set(["u-muted"]),
+				sandboxViewer: anonymousViewer,
+			});
 			const {sql, params} = fetchQuery(queries);
 			assert.match(sql, /"comment_record"\."author_id" not in \(\?\)/, "muted author excluded");
 			assert.include(params, "u-muted");
@@ -462,7 +505,7 @@ describe("Pano feed + thread — mute read-mask (author_id NOT IN …)", () => {
 		const {access, queries} = scriptedAccess([0 /* count */, [] /* fetch */]);
 		return Effect.gen(function* () {
 			const pano = yield* Pano;
-			yield* pano.listCommentsKeyset("post-1", {first: 10});
+			yield* pano.listCommentsKeyset("post-1", {first: 10, sandboxViewer: anonymousViewer});
 			assert.notMatch(fetchQuery(queries).sql, /not in/, "no mask ⇒ byte-for-byte today's thread");
 		}).pipe(Effect.provide(panoLayer(access)));
 	});

--- a/apps/web/worker/features/pano/Pano.ts
+++ b/apps/web/worker/features/pano/Pano.ts
@@ -10,8 +10,8 @@ import {Context, Effect, Layer} from "effect";
 import type {PostSort} from "../../../src/lib/panoFeedSort.ts";
 import {POST_TAG_KINDS, type PostTagKind, tagLabel} from "../../../src/lib/panoTags.ts";
 import {Drizzle, orDieAccess} from "../../db/Drizzle.ts";
-import type {SandboxViewer} from "../lifecycle/EntityLifecycle.ts";
 import type * as Removal from "../lifecycle/removal.ts";
+import type {MaskedReadOptions} from "../lifecycle/SandboxVisibility.ts";
 import {Pasaport} from "../pasaport/Pasaport.ts";
 import {Reaction} from "../reaction/Reaction.ts";
 import type {ReportId} from "../report/ids.ts";
@@ -121,31 +121,30 @@ export class Pano extends Context.Service<
 	{
 		readonly getPost: (
 			postId: string,
-			opts?: {
+			opts: MaskedReadOptions & {
 				viewerId?: string | null | undefined;
-				sandboxViewer?: SandboxViewer | undefined;
 				/** Mute read-mask (#3113): a muted author's post reads as not-found. */
 				mutedIds?: ReadonlySet<string> | undefined;
 			},
 		) => Effect.Effect<PostPage | null>;
 
-		readonly listPostsConnection: (opts?: {
-			sort?: PostSort;
-			first?: number;
-			after?: string | null;
-			host?: string | null;
-			sandboxViewer?: SandboxViewer | undefined;
-			mutedIds?: ReadonlySet<string> | undefined;
-		}) => Effect.Effect<PostConnectionPage>;
+		readonly listPostsConnection: (
+			opts: MaskedReadOptions & {
+				sort?: PostSort;
+				first?: number;
+				after?: string | null;
+				host?: string | null;
+				mutedIds?: ReadonlySet<string> | undefined;
+			},
+		) => Effect.Effect<PostConnectionPage>;
 
 		/** Keyset page over a post's comments, `(created_at asc, id asc)` (ADR 0019). */
 		readonly listCommentsKeyset: (
 			postId: string,
-			opts?: {
+			opts: MaskedReadOptions & {
 				first?: number | undefined;
 				after?: string | null | undefined;
 				viewerId?: string | null | undefined;
-				sandboxViewer?: SandboxViewer | undefined;
 				mutedIds?: ReadonlySet<string> | undefined;
 				/** Collapse the finalize stamps into one concurrent wave (#2710). Default off. */
 				parallelStamps?: boolean | undefined;
@@ -155,9 +154,8 @@ export class Pano extends Context.Service<
 		/** Post source `byIds` — batched read avoiding the relation N+1. */
 		readonly getPostsByIds: (
 			ids: ReadonlyArray<string>,
-			opts?: {
+			opts: MaskedReadOptions & {
 				viewerId?: string | null | undefined;
-				sandboxViewer?: SandboxViewer | undefined;
 				mutedIds?: ReadonlySet<string> | undefined;
 			},
 		) => Effect.Effect<ReadonlyArray<PostSummaryRow>>;
@@ -176,9 +174,8 @@ export class Pano extends Context.Service<
 		/** Comment source `byIds` — batched read avoiding the relation N+1. */
 		readonly getCommentsByIds: (
 			ids: ReadonlyArray<string>,
-			opts?: {
+			opts: MaskedReadOptions & {
 				viewerId?: string | null | undefined;
-				sandboxViewer?: SandboxViewer | undefined;
 				mutedIds?: ReadonlySet<string> | undefined;
 				/** Collapse the finalize stamps into one concurrent wave (#2710). Default off. */
 				parallelStamps?: boolean | undefined;

--- a/apps/web/worker/features/pano/comment-operations.ts
+++ b/apps/web/worker/features/pano/comment-operations.ts
@@ -22,8 +22,8 @@ import {applyRemovalTransition} from "../lifecycle/apply-removal-transition.ts";
 import {anonymousViewer, type SandboxViewer} from "../lifecycle/EntityLifecycle.ts";
 import * as Removal from "../lifecycle/removal.ts";
 import {
+	type MaskedReadOptions,
 	ownSandboxed,
-	resolveSandboxViewer,
 	sandboxBacklogWhere,
 	sandboxedInPlace,
 	sandboxVisibleWhere,
@@ -101,7 +101,7 @@ export interface VoteOnCommentResult {
 	changed: boolean;
 }
 
-export interface ReactToCommentInput {
+export interface ReactToCommentInput extends MaskedReadOptions {
 	commentId: CommentId;
 	userId: UserId;
 	// `null` retracts (toggle off). Already decoded against `ReactionEmojiSchema` at the
@@ -285,21 +285,20 @@ export const makeCommentOperations = (deps: CommentOperationsDeps) => {
 
 	const listCommentsKeyset = Effect.fn("Pano.listCommentsKeyset")(function* (
 		postId: string,
-		opts: {
+		opts: MaskedReadOptions & {
 			first?: number | undefined;
 			after?: string | null | undefined;
 			viewerId?: string | null | undefined;
-			sandboxViewer?: SandboxViewer | undefined;
 			mutedIds?: ReadonlySet<string> | undefined;
 			// Off ⇒ the wave runs at `concurrency: 1`, byte-for-byte today. Resolved from the
 			// default-off `phoenix-pano-stamp-wave` flag.
 			parallelStamps?: boolean | undefined;
-		} = {},
+		},
 	) {
 		const first = Math.max(1, Math.min(opts.first ?? 50, 200));
 		const after = opts.after ?? null;
 		const viewerId = opts.viewerId ?? null;
-		const viewer = resolveSandboxViewer(opts);
+		const viewer = opts.sandboxViewer;
 
 		// A removed comment stays in the thread ONLY to preserve reply structure (ADR 0096
 		// §5): keep it when it still has a live child, otherwise omit it.
@@ -370,17 +369,16 @@ export const makeCommentOperations = (deps: CommentOperationsDeps) => {
 
 	const getCommentsByIds = Effect.fn("Pano.getCommentsByIds")(function* (
 		ids: ReadonlyArray<string>,
-		opts: {
+		opts: MaskedReadOptions & {
 			viewerId?: string | null | undefined;
-			sandboxViewer?: SandboxViewer | undefined;
 			mutedIds?: ReadonlySet<string> | undefined;
 			/** See `listCommentsKeyset`'s `parallelStamps` (#2710). */
 			parallelStamps?: boolean | undefined;
-		} = {},
+		},
 	) {
 		if (ids.length === 0) return [];
 		const viewerId = opts.viewerId ?? null;
-		const viewer = resolveSandboxViewer(opts);
+		const viewer = opts.sandboxViewer;
 		const fetched = yield* run((db) =>
 			db
 				.select()
@@ -852,7 +850,10 @@ export const makeCommentOperations = (deps: CommentOperationsDeps) => {
 			);
 
 		// A missing row here is a raced removal — surface it as `CommentNotFound`.
-		const [row] = yield* getCommentsByIds([input.commentId], {viewerId: input.userId});
+		const [row] = yield* getCommentsByIds([input.commentId], {
+			viewerId: input.userId,
+			sandboxViewer: input.sandboxViewer,
+		});
 		if (!row) {
 			return yield* new CommentNotFound({
 				commentId: input.commentId,

--- a/apps/web/worker/features/pano/comment-stamp-wave.unit.test.ts
+++ b/apps/web/worker/features/pano/comment-stamp-wave.unit.test.ts
@@ -9,6 +9,7 @@ import {Effect} from "effect";
 import type {Concurrency} from "effect/Types";
 import type {DrizzleAccessOrDie} from "../../db/Drizzle.ts";
 import type {ReactionEmoji} from "../../db/reaction-emoji.ts";
+import {memberSandboxViewer} from "../kunye/sandbox.testing.ts";
 import type {Reaction, ReactionAggregate} from "../reaction/Reaction.ts";
 import type {Vote} from "../vote/Vote.ts";
 import {type CommentOperationsDeps, makeCommentOperations} from "./comment-operations.ts";
@@ -92,12 +93,14 @@ describe("Pano.getCommentsByIds — stamp-wave behavior equivalence (#2710)", ()
 			const serialOps = makeCommentOperations(deps(byIdRun(), serialCalls));
 			const serial = yield* serialOps.getCommentsByIds(["comment_1", "comment_2"], {
 				viewerId: "viewer-1",
+				sandboxViewer: memberSandboxViewer("viewer-1"),
 				parallelStamps: false,
 			});
 
 			const parallelOps = makeCommentOperations(deps(byIdRun(), parallelCalls));
 			const parallel = yield* parallelOps.getCommentsByIds(["comment_1", "comment_2"], {
 				viewerId: "viewer-1",
+				sandboxViewer: memberSandboxViewer("viewer-1"),
 				parallelStamps: true,
 			});
 
@@ -126,15 +129,18 @@ describe("Pano.getCommentsByIds — stamp-wave behavior equivalence (#2710)", ()
 		return Effect.gen(function* () {
 			yield* makeCommentOperations(deps(byIdRun(), onCalls)).getCommentsByIds(["comment_1"], {
 				viewerId: "v",
+				sandboxViewer: memberSandboxViewer("v"),
 				parallelStamps: true,
 			});
 			yield* makeCommentOperations(deps(byIdRun(), offCalls)).getCommentsByIds(["comment_1"], {
 				viewerId: "v",
+				sandboxViewer: memberSandboxViewer("v"),
 				parallelStamps: false,
 			});
 			// No `parallelStamps` at all → the default-off path.
 			yield* makeCommentOperations(deps(byIdRun(), offCalls)).getCommentsByIds(["comment_1"], {
 				viewerId: "v",
+				sandboxViewer: memberSandboxViewer("v"),
 			});
 
 			assert.deepStrictEqual(onCalls, [{concurrency: "unbounded"}], "flag on → unbounded");
@@ -165,6 +171,7 @@ describe("Pano.listCommentsKeyset — stamp-wave behavior equivalence (#2710)", 
 				const serial = yield* serialOps.listCommentsKeyset("post_1", {
 					first: 10,
 					viewerId: "viewer-1",
+					sandboxViewer: memberSandboxViewer("viewer-1"),
 					parallelStamps: false,
 				});
 
@@ -172,6 +179,7 @@ describe("Pano.listCommentsKeyset — stamp-wave behavior equivalence (#2710)", 
 				const parallel = yield* parallelOps.listCommentsKeyset("post_1", {
 					first: 10,
 					viewerId: "viewer-1",
+					sandboxViewer: memberSandboxViewer("viewer-1"),
 					parallelStamps: true,
 				});
 

--- a/apps/web/worker/features/pano/mutation-parent-reread-viewer.unit.test.ts
+++ b/apps/web/worker/features/pano/mutation-parent-reread-viewer.unit.test.ts
@@ -1,15 +1,17 @@
 /**
  * The parent-page re-read in `post.restore`, `comment.delete` and `comment.restore` carries
- * the acting author's identity (#6473).
+ * the viewer the request resolved — the acting author (#6473) and the opted-in in-place
+ * yazar (#6586).
  *
  * Each handler commits its write, re-reads the parent post through `Pano.getPost` — a read
  * masked on the sandbox dimension — and answers `null` when the row comes back masked. Handed
- * no viewer at all, that read resolved anonymously, so a çaylak restoring their OWN still-
- * sandboxed post got `null` back from a mutation that had already landed at D1.
+ * a degraded viewer, that read resolves neither elevated class, so a çaylak restoring their
+ * OWN still-sandboxed post, and an opted-in yazar acting on somebody else's, both got `null`
+ * back from a mutation that had already landed at D1.
  *
- * The stub does not mimic the mask: it resolves the options through the real
- * `resolveSandboxViewer` and asks the real `lifecycleVisibilityRule`, so the test moves with
- * the visibility rule instead of restating it.
+ * The stub does not mimic the mask: it asks the real `lifecycleVisibilityRule` about the
+ * viewer it was handed, so the test moves with the visibility rule instead of restating it,
+ * and that viewer arrives through the real resolver rather than a hand-built one.
  */
 import {assert, describe, it} from "@effect/vitest";
 import {CurrentUser, LivePublisher} from "@kampus/fate-effect";
@@ -17,12 +19,12 @@ import {type BaseRuntimeContext, RuntimeContext} from "alchemy";
 import {Effect, Layer} from "effect";
 import {resolveWire} from "../fate/resolve-wire.testing.ts";
 import {livePublisherFor} from "../fate-live/live-publisher.ts";
+import {sandboxViewerLayer} from "../kunye/sandbox.testing.ts";
 import {
 	lifecycleVisibilityRule,
 	ruleVisibleTo,
 	type SandboxViewer,
 } from "../lifecycle/EntityLifecycle.ts";
-import {resolveSandboxViewer} from "../lifecycle/SandboxVisibility.ts";
 import {mutations} from "./mutations.ts";
 import {Pano} from "./Pano.ts";
 import type {PostPage} from "./post-fields.ts";
@@ -31,6 +33,7 @@ const AUTHOR = {id: "u-caylak", email: "caylak@kamp.us", name: "çaylak"};
 const OTHER_MEMBER = {id: "u-yazar", email: "yazar@kamp.us", name: "yazar"};
 const POST_ID = "post_sb1";
 const COMMENT_ID = "comment_sb1";
+const OPTED_IN_AT = new Date("2026-08-19T00:00:00.000Z");
 
 const runtimeContextStub: BaseRuntimeContext = {
 	Type: "mutation-parent-reread-viewer",
@@ -75,11 +78,29 @@ const commentRow = {
 	myVote: null,
 };
 
+type Axes = Parameters<typeof sandboxViewerLayer>[0];
+
+/** A signed-in member with the çaylak-visibility flag off: no in-place widening exists yet. */
+const plainMember = (user: typeof AUTHOR): Axes => ({
+	flagOn: false,
+	viewerId: user.id,
+	isModerator: false,
+});
+
+/** The #6423 third class: a yazar who opted in to reading çaylak work in place. */
+const optedInYazar = (user: typeof AUTHOR): Axes => ({
+	flagOn: true,
+	tier: "yazar",
+	preference: {optedIn: true, setAt: OPTED_IN_AT},
+	viewerId: user.id,
+	isModerator: false,
+});
+
 /**
  * Every service the three handlers reach. `getPost` applies the REAL sandbox rule to the
- * viewer the call site resolved, so a call that omits the viewer masks exactly as D1 does.
+ * viewer it was handed, so a handler that hands it a degraded one masks exactly as D1 does.
  */
-const contextFor = (user: typeof AUTHOR) =>
+const contextFor = (user: typeof AUTHOR, axes: Axes) =>
 	Layer.mergeAll(
 		// biome-ignore lint/plugin: a service double — the writes are scripted and only the parent re-read is under test.
 		Layer.succeed(Pano, {
@@ -100,12 +121,12 @@ const contextFor = (user: typeof AUTHOR) =>
 					placeholder: null,
 					sandboxedAt: new Date(),
 				}),
-			getPost: (_id: string, opts?: {viewerId?: string | null; sandboxViewer?: SandboxViewer}) =>
+			getPost: (_id: string, opts: {sandboxViewer: SandboxViewer}) =>
 				Effect.sync(() =>
 					ruleVisibleTo(
 						lifecycleVisibilityRule.Sandboxed,
 						sandboxedPage.authorId,
-						resolveSandboxViewer(opts ?? {}),
+						opts.sandboxViewer,
 					)
 						? sandboxedPage
 						: null,
@@ -114,6 +135,7 @@ const contextFor = (user: typeof AUTHOR) =>
 			getCommentsByIds: () => Effect.succeed([commentRow]),
 		} as unknown as typeof Pano.Service),
 		noopLive,
+		sandboxViewerLayer(axes),
 		Layer.succeed(CurrentUser, {user}),
 		Layer.succeed(RuntimeContext, runtimeContextStub),
 	);
@@ -144,11 +166,11 @@ const HANDLERS = [
 	},
 ] as const;
 
-describe("the pano parent-page re-reads carry the acting author (#6473)", () => {
+describe("the pano parent-page re-reads carry the resolved viewer (#6473, #6586)", () => {
 	for (const handler of HANDLERS) {
 		it.effect(`${handler.name} returns the still-sandboxed page to its own author`, () =>
 			Effect.gen(function* () {
-				const result = yield* handler.run(contextFor(AUTHOR));
+				const result = yield* handler.run(contextFor(AUTHOR, plainMember(AUTHOR)));
 				assert.isNotNull(result, `${handler.name} answered null on a write that landed`);
 				assert.strictEqual(result?.id, POST_ID);
 			}),
@@ -156,7 +178,15 @@ describe("the pano parent-page re-reads carry the acting author (#6473)", () => 
 
 		it.effect(`${handler.name} still masks the sandboxed page from another member`, () =>
 			Effect.gen(function* () {
-				assert.isNull(yield* handler.run(contextFor(OTHER_MEMBER)));
+				assert.isNull(yield* handler.run(contextFor(OTHER_MEMBER, plainMember(OTHER_MEMBER))));
+			}),
+		);
+
+		it.effect(`${handler.name} returns the page to an opted-in in-place yazar`, () =>
+			Effect.gen(function* () {
+				const result = yield* handler.run(contextFor(OTHER_MEMBER, optedInYazar(OTHER_MEMBER)));
+				assert.isNotNull(result, `${handler.name} answered null on a write that landed`);
+				assert.strictEqual(result?.id, POST_ID);
 			}),
 		);
 	}

--- a/apps/web/worker/features/pano/mutations.ts
+++ b/apps/web/worker/features/pano/mutations.ts
@@ -322,12 +322,12 @@ export const mutations = {
 		Effect.fn("post.react")(function* ({input}) {
 			const user = yield* CurrentUser.required;
 			const pano = yield* Pano;
+			const sandboxViewer = yield* currentSandboxViewer;
 			// Dark-ship gate (ADR 0083). Off ⇒ the react never lands; re-resolve unchanged so
 			// the caller's cache stays consistent. A Flagship outage reads `false` = dark.
 			const flags = yield* Flags;
 			const on = yield* flags.getBoolean(PHOENIX_REACTIONS, false).pipe(provideRequestFlags);
 			if (!on) {
-				const sandboxViewer = yield* currentSandboxViewer;
 				const [current] = yield* pano.getPostsByIds([input.id], {
 					viewerId: user.id,
 					sandboxViewer,
@@ -342,6 +342,7 @@ export const mutations = {
 				postId: input.id,
 				userId: UserId.make(user.id),
 				emoji: input.emoji,
+				sandboxViewer,
 			});
 			const post = toPost(r.post);
 			yield* live.post.update(post.id, {changed: ["reactions"], data: post});
@@ -415,7 +416,8 @@ export const mutations = {
 			});
 			// Re-read the viewer's vote so the edited entity carries an accurate
 			// `myVote` (edit doesn't touch vote state).
-			const [fresh] = yield* pano.getPostsByIds([r.postId], {viewerId: user.id});
+			const sandboxViewer = yield* currentSandboxViewer;
+			const [fresh] = yield* pano.getPostsByIds([r.postId], {viewerId: user.id, sandboxViewer});
 			const post = shapePost({...r, myVote: fresh?.myVote ?? null});
 			yield* live.post.update(post.id, {changed: ["title", "body"], data: post});
 			return post;
@@ -458,9 +460,10 @@ export const mutations = {
 			const pano = yield* Pano;
 			const live = panoLive(yield* WorkerLivePublisher, yield* PanoFeedCache);
 			const restored = yield* pano.restorePost({postId: input.id, actorId: UserId.make(user.id)});
-			const page = yield* pano.getPost(input.id, {viewerId: user.id});
+			const sandboxViewer = yield* currentSandboxViewer;
+			const page = yield* pano.getPost(input.id, {viewerId: user.id, sandboxViewer});
 			if (!page) return null;
-			const [stamped] = yield* pano.getPostsByIds([page.id], {viewerId: user.id});
+			const [stamped] = yield* pano.getPostsByIds([page.id], {viewerId: user.id, sandboxViewer});
 			const post = toPostFromPage(
 				page,
 				stamped?.myVote ?? null,
@@ -585,12 +588,12 @@ export const mutations = {
 		Effect.fn("comment.react")(function* ({input}) {
 			const user = yield* CurrentUser.required;
 			const pano = yield* Pano;
+			const sandboxViewer = yield* currentSandboxViewer;
 			// Dark-ship gate (ADR 0083). Off ⇒ the react never lands; re-resolve unchanged so
 			// the caller's cache stays consistent. A Flagship outage reads `false` = dark.
 			const flags = yield* Flags;
 			const on = yield* flags.getBoolean(PHOENIX_REACTIONS, false).pipe(provideRequestFlags);
 			if (!on) {
-				const sandboxViewer = yield* currentSandboxViewer;
 				const [current] = yield* pano.getCommentsByIds([input.id], {
 					viewerId: user.id,
 					sandboxViewer,
@@ -608,6 +611,7 @@ export const mutations = {
 				commentId: input.id,
 				userId: UserId.make(user.id),
 				emoji: input.emoji,
+				sandboxViewer,
 			});
 			const comment = toComment(r.comment);
 			yield* live.comment.update(comment.id, {changed: ["reactions"], data: comment});
@@ -634,7 +638,11 @@ export const mutations = {
 				actorId: UserId.make(user.id),
 				body: input.body,
 			});
-			const [fresh] = yield* pano.getCommentsByIds([r.commentId], {viewerId: user.id});
+			const sandboxViewer = yield* currentSandboxViewer;
+			const [fresh] = yield* pano.getCommentsByIds([r.commentId], {
+				viewerId: user.id,
+				sandboxViewer,
+			});
 			const comment = shapeComment({
 				...r,
 				myVote: fresh?.myVote ?? null,
@@ -666,9 +674,10 @@ export const mutations = {
 				actorId: UserId.make(user.id),
 			});
 			if (!postId) return null;
-			const page = yield* pano.getPost(postId, {viewerId: user.id});
+			const sandboxViewer = yield* currentSandboxViewer;
+			const page = yield* pano.getPost(postId, {viewerId: user.id, sandboxViewer});
 			if (!page) return null;
-			const [stamped] = yield* pano.getPostsByIds([page.id], {viewerId: user.id});
+			const [stamped] = yield* pano.getPostsByIds([page.id], {viewerId: user.id, sandboxViewer});
 			const post = toPostFromPage(
 				page,
 				stamped?.myVote ?? null,
@@ -712,7 +721,11 @@ export const mutations = {
 				actorId: UserId.make(user.id),
 			});
 			if (!postId) return null;
-			const [comment] = yield* pano.getCommentsByIds([input.id], {viewerId: user.id});
+			const sandboxViewer = yield* currentSandboxViewer;
+			const [comment] = yield* pano.getCommentsByIds([input.id], {
+				viewerId: user.id,
+				sandboxViewer,
+			});
 			if (comment) {
 				const node = toComment(comment);
 				// Sandbox-faithful restore (#1811): route the thread broadcast through the
@@ -721,9 +734,9 @@ export const mutations = {
 					.thread(postId)
 					.appendNode(node.id, {node}, decidePublish(restored.sandboxedAt ?? null));
 			}
-			const page = yield* pano.getPost(postId, {viewerId: user.id});
+			const page = yield* pano.getPost(postId, {viewerId: user.id, sandboxViewer});
 			if (!page) return null;
-			const [stamped] = yield* pano.getPostsByIds([page.id], {viewerId: user.id});
+			const [stamped] = yield* pano.getPostsByIds([page.id], {viewerId: user.id, sandboxViewer});
 			const post = toPostFromPage(
 				page,
 				stamped?.myVote ?? null,

--- a/apps/web/worker/features/pano/post-by-id-draft-visibility.unit.test.ts
+++ b/apps/web/worker/features/pano/post-by-id-draft-visibility.unit.test.ts
@@ -11,6 +11,8 @@ import {drizzle} from "drizzle-orm/d1";
 import {Effect, Layer} from "effect";
 import {Drizzle, type DrizzleAccess, type DrizzleDb, relations} from "../../db/Drizzle.ts";
 import type * as schema from "../../db/drizzle/schema.ts";
+import {memberSandboxViewer} from "../kunye/sandbox.testing.ts";
+import {anonymousViewer} from "../lifecycle/EntityLifecycle.ts";
 import {PasaportIdentityStub} from "../pasaport/Pasaport.testing.ts";
 import {ReactionStub} from "../reaction/Reaction.testing.ts";
 import {Vote} from "../vote/Vote.ts";
@@ -119,7 +121,10 @@ describe("Pano.getPost — draft is author-only (the by-id leak gate, #1405)", (
 	it.effect("a non-owner by-id read of a draft resolves not-found (the leak case)", () =>
 		Effect.gen(function* () {
 			const pano = yield* Pano;
-			const got = yield* pano.getPost(draftRow.id, {viewerId: OTHER});
+			const got = yield* pano.getPost(draftRow.id, {
+				viewerId: OTHER,
+				sandboxViewer: memberSandboxViewer(OTHER),
+			});
 			assert.isNull(got, "another author's draft must not disclose to a viewer holding its id");
 		}).pipe(Effect.provide(panoLayer(scriptedAccess([draftRow]).access))),
 	);
@@ -127,7 +132,10 @@ describe("Pano.getPost — draft is author-only (the by-id leak gate, #1405)", (
 	it.effect("the author reads their OWN draft by id (read-your-writes)", () =>
 		Effect.gen(function* () {
 			const pano = yield* Pano;
-			const got = yield* pano.getPost(draftRow.id, {viewerId: AUTHOR});
+			const got = yield* pano.getPost(draftRow.id, {
+				viewerId: AUTHOR,
+				sandboxViewer: memberSandboxViewer(AUTHOR),
+			});
 			assert.isNotNull(got, "the author must read their own draft back");
 			assert.strictEqual(got?.id, draftRow.id);
 		}).pipe(Effect.provide(panoLayer(scriptedAccess([draftRow]).access))),
@@ -136,7 +144,7 @@ describe("Pano.getPost — draft is author-only (the by-id leak gate, #1405)", (
 	it.effect("an anonymous by-id read of a draft resolves not-found", () =>
 		Effect.gen(function* () {
 			const pano = yield* Pano;
-			const got = yield* pano.getPost(draftRow.id, {});
+			const got = yield* pano.getPost(draftRow.id, {sandboxViewer: anonymousViewer});
 			assert.isNull(got);
 		}).pipe(Effect.provide(panoLayer(scriptedAccess([draftRow]).access))),
 	);
@@ -149,7 +157,10 @@ describe("Pano.getPostsByIds — batch routes through the seam's draft arm (#140
 			const {access, queries} = scriptedAccess([[] /* fetched */]);
 			return Effect.gen(function* () {
 				const pano = yield* Pano;
-				yield* pano.getPostsByIds([draftRow.id], {viewerId: OTHER});
+				yield* pano.getPostsByIds([draftRow.id], {
+					viewerId: OTHER,
+					sandboxViewer: memberSandboxViewer(OTHER),
+				});
 				const {sql, params} = queries[0]!;
 				assert.match(sql, /"post_record"\."is_draft" is not 1/, "draft arm from the seam");
 				assert.match(
@@ -166,7 +177,7 @@ describe("Pano.getPostsByIds — batch routes through the seam's draft arm (#140
 		const {access, queries} = scriptedAccess([[] /* fetched */]);
 		return Effect.gen(function* () {
 			const pano = yield* Pano;
-			yield* pano.getPostsByIds([draftRow.id], {});
+			yield* pano.getPostsByIds([draftRow.id], {sandboxViewer: anonymousViewer});
 			const {sql} = queries[0]!;
 			assert.match(
 				sql,

--- a/apps/web/worker/features/pano/post-operations.ts
+++ b/apps/web/worker/features/pano/post-operations.ts
@@ -19,11 +19,10 @@ import {type ReadProfileIdentities, stampAuthorIdentity} from "../fate/author-id
 import {stampReactionAggregate} from "../fate/reaction-aggregate.ts";
 import {stampViewerScalars} from "../fate/viewer-scalars.ts";
 import {applyRemovalTransition, swallowRefresh} from "../lifecycle/apply-removal-transition.ts";
-import type {SandboxViewer} from "../lifecycle/EntityLifecycle.ts";
 import * as Removal from "../lifecycle/removal.ts";
 import {
+	type MaskedReadOptions,
 	ownSandboxed,
-	resolveSandboxViewer,
 	sandboxBacklogWhere,
 	sandboxedInPlace,
 	sandboxVisibleWhere,
@@ -138,7 +137,7 @@ export interface VoteOnPostResult {
 	changed: boolean;
 }
 
-export interface ReactToPostInput {
+export interface ReactToPostInput extends MaskedReadOptions {
 	postId: PostId;
 	userId: UserId;
 	/** Sets/changes the user's single reaction; `null` retracts it. */
@@ -444,11 +443,10 @@ export const makePostOperations = (deps: PostOperationsDeps) => {
 
 	const getPost = Effect.fn("Pano.getPost")(function* (
 		postId: string,
-		opts: {
+		opts: MaskedReadOptions & {
 			viewerId?: string | null | undefined;
-			sandboxViewer?: SandboxViewer | undefined;
 			mutedIds?: ReadonlySet<string> | undefined;
-		} = {},
+		},
 	) {
 		const meta = yield* run((db) =>
 			db.query.postRecord.findFirst({
@@ -464,7 +462,7 @@ export const makePostOperations = (deps: PostOperationsDeps) => {
 				Removal.fromColumns(meta),
 				Boolean(meta.isDraft),
 				meta.authorId,
-				resolveSandboxViewer(opts),
+				opts.sandboxViewer,
 			)
 		) {
 			return null;
@@ -473,14 +471,13 @@ export const makePostOperations = (deps: PostOperationsDeps) => {
 	});
 
 	const listPostsConnection = Effect.fn("Pano.listPostsConnection")(function* (
-		opts: {
+		opts: MaskedReadOptions & {
 			sort?: PostSort;
 			first?: number;
 			after?: string | null;
 			host?: string | null;
-			sandboxViewer?: SandboxViewer | undefined;
 			mutedIds?: ReadonlySet<string> | undefined;
-		} = {},
+		},
 	) {
 		const sort = opts.sort ?? "hot";
 		const first = Math.max(1, Math.min(opts.first ?? 20, 100));
@@ -496,7 +493,7 @@ export const makePostOperations = (deps: PostOperationsDeps) => {
 		if (host) baseConditions.push(eq(schema.postRecord.host, host));
 		const sandboxClause = sandboxVisibleWhere(
 			{sandboxedAt: schema.postRecord.sandboxedAt, authorId: schema.postRecord.authorId},
-			resolveSandboxViewer(opts),
+			opts.sandboxViewer,
 		);
 		if (sandboxClause) baseConditions.push(sandboxClause);
 		const muteClause = mutedAuthorsWhere(schema.postRecord.authorId, opts.mutedIds);
@@ -608,15 +605,14 @@ export const makePostOperations = (deps: PostOperationsDeps) => {
 
 	const getPostsByIds = Effect.fn("Pano.getPostsByIds")(function* (
 		ids: ReadonlyArray<string>,
-		opts: {
+		opts: MaskedReadOptions & {
 			viewerId?: string | null | undefined;
-			sandboxViewer?: SandboxViewer | undefined;
 			mutedIds?: ReadonlySet<string> | undefined;
-		} = {},
+		},
 	) {
 		if (ids.length === 0) return [];
 		const viewerId = opts.viewerId ?? null;
-		const viewer = resolveSandboxViewer(opts);
+		const viewer = opts.sandboxViewer;
 		const fetched = yield* run((db) =>
 			db
 				.select()
@@ -1140,7 +1136,10 @@ export const makePostOperations = (deps: PostOperationsDeps) => {
 
 		// The react write already asserted the target is live, so a missing row here is a
 		// raced removal, not a bad input.
-		const [row] = yield* getPostsByIds([input.postId], {viewerId: input.userId});
+		const [row] = yield* getPostsByIds([input.postId], {
+			viewerId: input.userId,
+			sandboxViewer: input.sandboxViewer,
+		});
 		if (!row) {
 			return yield* new PostNotFound({
 				postId: input.postId,

--- a/apps/web/worker/features/pano/reaction-comment-mutation.unit.test.ts
+++ b/apps/web/worker/features/pano/reaction-comment-mutation.unit.test.ts
@@ -12,7 +12,11 @@ import {UserId} from "../../lib/ids.ts";
 import {resolveWire} from "../fate/resolve-wire.testing.ts";
 import {livePublisherFor} from "../fate-live/live-publisher.ts";
 import {Flags} from "../flagship/Flags.ts";
-import {inPlaceVisibilityStores, moderatorAxisLayer} from "../kunye/sandbox.testing.ts";
+import {
+	inPlaceVisibilityStores,
+	memberSandboxViewer,
+	moderatorAxisLayer,
+} from "../kunye/sandbox.testing.ts";
 import {EMPTY_REACTION_AGGREGATE, type ReactionAggregate} from "../reaction/Reaction.ts";
 import type {CommentRow} from "./comment-fields.ts";
 import type {ReactToCommentInput, ReactToCommentResult} from "./comment-operations.ts";
@@ -87,12 +91,13 @@ const react = (
 				pano,
 				flagsStub(on),
 				liveStub,
-				// The inert (flag-off) branch re-resolves the comment through the real sandbox
-				// viewer (#6424), so the moderator axis it probes has to be on the context.
+				// Both branches now re-resolve the comment through the real sandbox viewer
+				// (#6424 for the inert one, #6586 for the write's own re-read), so both axes
+				// it probes have to be on the context. `flagsStub` answers every key with
+				// `on`, so the çaylak tier is what keeps the in-place axis `false` when this
+				// file's own flag is ON.
 				moderatorAxisLayer({viewerId: user?.id ?? "anon", isModerator: false}),
-				// Both stores die on contact: the caylak-visibility flag is off on the only
-				// branch that resolves a viewer, so neither may be read.
-				inPlaceVisibilityStores({}),
+				inPlaceVisibilityStores({tier: "çaylak"}),
 			),
 		),
 		Effect.provideService(CurrentUser, {user}),
@@ -118,7 +123,14 @@ describe("comment.react — (1) flag ON delegates and echoes the aggregate", () 
 				{id: "comment_1", emoji: "👍"},
 			);
 			assert.deepStrictEqual(calls, [
-				{commentId: CommentId.make("comment_1"), userId: UserId.make(CAYLAK.id), emoji: "👍"},
+				{
+					commentId: CommentId.make("comment_1"),
+					userId: UserId.make(CAYLAK.id),
+					emoji: "👍",
+					// The write's own re-read masks on the sandbox dimension, so the handler
+					// hands the service the viewer it resolved rather than a degraded one (#6586).
+					sandboxViewer: memberSandboxViewer(CAYLAK.id),
+				},
 			]);
 			assert.deepStrictEqual((comment as {reactions?: unknown}).reactions, {
 				counts: [{emoji: "👍", count: 1}],

--- a/apps/web/worker/features/pano/reaction-mutation.unit.test.ts
+++ b/apps/web/worker/features/pano/reaction-mutation.unit.test.ts
@@ -90,12 +90,12 @@ const react = (
 				pano,
 				flags,
 				liveStub,
-				// The inert (flag-off) branch re-resolves the post through the real sandbox viewer
-				// (#6424), so the moderator axis it probes has to be on the context.
+				// Both branches now re-resolve the post through the real sandbox viewer (#6424
+				// for the inert one, #6586 for the write's own re-read), so both axes it probes
+				// have to be on the context. `flagsStub` answers every key alike, so the çaylak
+				// tier is what keeps the in-place axis `false` when this file's own flag is ON.
 				moderatorAxisLayer({viewerId: user?.id ?? "anon", isModerator: false}),
-				// Both stores die on contact: the caylak-visibility flag is off on the only
-				// branch that resolves a viewer, so neither may be read.
-				inPlaceVisibilityStores({}),
+				inPlaceVisibilityStores({tier: "çaylak"}),
 			),
 		),
 		Effect.provideService(CurrentUser, {user}),

--- a/apps/web/worker/features/sozluk/Sozluk.connection.unit.test.ts
+++ b/apps/web/worker/features/sozluk/Sozluk.connection.unit.test.ts
@@ -9,6 +9,7 @@ import {assert, describe, it} from "@effect/vitest";
 import {drizzle} from "drizzle-orm/d1";
 import {Effect, Layer} from "effect";
 import {Drizzle, type DrizzleAccess, type DrizzleDb, relations} from "../../db/Drizzle.ts";
+import {anonymousViewer} from "../lifecycle/EntityLifecycle.ts";
 import {PasaportIdentityStub} from "../pasaport/Pasaport.testing.ts";
 import {ReactionStub} from "../reaction/Reaction.testing.ts";
 import {Vote} from "../vote/Vote.ts";
@@ -85,7 +86,10 @@ describe("Sozluk.listDefinitionsKeyset — `first` clamp [1,200] (no SQL engine 
 			const {access, queries} = scriptedAccess([0 /* count */, [] /* fetch */]);
 			return Effect.gen(function* () {
 				const sozluk = yield* Sozluk;
-				yield* sozluk.listDefinitionsKeyset("a-term", {first: input});
+				yield* sozluk.listDefinitionsKeyset("a-term", {
+					first: input,
+					sandboxViewer: anonymousViewer,
+				});
 				assert.strictEqual(fetchQuery(queries).params.at(-1), expectedLimit);
 			}).pipe(Effect.provide(sozlukLayer(access)));
 		});
@@ -103,7 +107,11 @@ describe("Sozluk.listTermSummariesConnection — `first` clamp [1,100] (no SQL e
 			const {access, queries} = scriptedAccess([0 /* count */, [] /* fetch */]);
 			return Effect.gen(function* () {
 				const sozluk = yield* Sozluk;
-				yield* sozluk.listTermSummariesConnection(input === undefined ? {} : {first: input});
+				yield* sozluk.listTermSummariesConnection(
+					input === undefined
+						? {sandboxViewer: anonymousViewer}
+						: {first: input, sandboxViewer: anonymousViewer},
+				);
 				assert.strictEqual(fetchQuery(queries).params.at(-1), expectedLimit);
 			}).pipe(Effect.provide(sozlukLayer(access)));
 		});
@@ -125,7 +133,11 @@ describe("Sozluk.listDefinitionsKeyset — MIXED-direction keyset (score desc, c
 				const {access, queries} = scriptedAccess([1, {score: 5, createdAt: created}, []]);
 				yield* Effect.gen(function* () {
 					const sozluk = yield* Sozluk;
-					yield* sozluk.listDefinitionsKeyset("a-term", {first: 10, after: "d7"});
+					yield* sozluk.listDefinitionsKeyset("a-term", {
+						first: 10,
+						after: "d7",
+						sandboxViewer: anonymousViewer,
+					});
 				}).pipe(Effect.provide(sozlukLayer(access)));
 				const {sql, params} = fetchQuery(queries);
 				// desc lead → `<`, asc tiebreak → `>`. Per-arm equalities precede each strict cmp.
@@ -169,7 +181,11 @@ describe("Sozluk.listDefinitionsKeyset — cursor-miss → empty page, NO furthe
 		};
 		return Effect.gen(function* () {
 			const sozluk = yield* Sozluk;
-			const page = yield* sozluk.listDefinitionsKeyset("a-term", {first: 10, after: "ghost"});
+			const page = yield* sozluk.listDefinitionsKeyset("a-term", {
+				first: 10,
+				after: "ghost",
+				sandboxViewer: anonymousViewer,
+			});
 			assert.deepStrictEqual(page.rows, [], "miss → no rows");
 			assert.strictEqual(page.hasNextPage, false);
 			assert.strictEqual(page.endCursor, null);
@@ -183,7 +199,11 @@ describe("Sozluk.listDefinitionsKeyset — mute read-mask (author_id NOT IN …)
 		const {access, queries} = scriptedAccess([1 /* count */, [] /* fetch */]);
 		return Effect.gen(function* () {
 			const sozluk = yield* Sozluk;
-			yield* sozluk.listDefinitionsKeyset("a-term", {first: 10, mutedIds: new Set(["u-muted"])});
+			yield* sozluk.listDefinitionsKeyset("a-term", {
+				first: 10,
+				mutedIds: new Set(["u-muted"]),
+				sandboxViewer: anonymousViewer,
+			});
 			const {sql, params} = fetchQuery(queries);
 			assert.match(sql, /"definition_record"\."author_id" not in \(\?\)/, "muted author excluded");
 			assert.include(params, "u-muted");
@@ -194,7 +214,7 @@ describe("Sozluk.listDefinitionsKeyset — mute read-mask (author_id NOT IN …)
 		const {access, queries} = scriptedAccess([1 /* count */, [] /* fetch */]);
 		return Effect.gen(function* () {
 			const sozluk = yield* Sozluk;
-			yield* sozluk.listDefinitionsKeyset("a-term", {first: 10});
+			yield* sozluk.listDefinitionsKeyset("a-term", {first: 10, sandboxViewer: anonymousViewer});
 			assert.notMatch(fetchQuery(queries).sql, /not in/, "no mask ⇒ today's definition read");
 		}).pipe(Effect.provide(sozlukLayer(access)));
 	});

--- a/apps/web/worker/features/sozluk/Sozluk.ts
+++ b/apps/web/worker/features/sozluk/Sozluk.ts
@@ -16,12 +16,12 @@ import {stampReactionAggregate} from "../fate/reaction-aggregate.ts";
 import {parallelStampWave} from "../fate/stamp-wave.ts";
 import {stampViewerScalars} from "../fate/viewer-scalars.ts";
 import {applyRemovalTransition, swallowRefresh} from "../lifecycle/apply-removal-transition.ts";
-import {anonymousViewer, type SandboxViewer} from "../lifecycle/EntityLifecycle.ts";
+import {anonymousViewer} from "../lifecycle/EntityLifecycle.ts";
 import * as Removal from "../lifecycle/removal.ts";
 import {
+	type MaskedReadOptions,
 	ownSandboxed,
 	publicLiveWhere,
-	resolveSandboxViewer,
 	sandboxBacklogWhere,
 	sandboxedInPlace,
 	sandboxVisibleWhere,
@@ -280,7 +280,7 @@ export class Sozluk extends Context.Service<
 	{
 		readonly getTerm: (
 			slug: string,
-			opts?: {viewerId?: string | null | undefined; sandboxViewer?: SandboxViewer | undefined},
+			opts: MaskedReadOptions & {viewerId?: string | null | undefined},
 		) => Effect.Effect<TermPage | null>;
 
 		/**
@@ -289,11 +289,10 @@ export class Sozluk extends Context.Service<
 		 */
 		readonly listDefinitionsKeyset: (
 			slug: string,
-			opts?: {
+			opts: MaskedReadOptions & {
 				first?: number | undefined;
 				after?: string | null | undefined;
 				viewerId?: string | null | undefined;
-				sandboxViewer?: SandboxViewer | undefined;
 				/** Mute read-mask (#3113): muted authors' definitions hidden from the muter. */
 				mutedIds?: ReadonlySet<string> | undefined;
 				/**
@@ -310,9 +309,8 @@ export class Sozluk extends Context.Service<
 		 */
 		readonly getDefinitionsByIds: (
 			ids: ReadonlyArray<string>,
-			opts?: {
+			opts: MaskedReadOptions & {
 				viewerId?: string | null | undefined;
-				sandboxViewer?: SandboxViewer | undefined;
 				/** Mute read-mask (#3113): muted authors' definitions dropped from the batch. */
 				mutedIds?: ReadonlySet<string> | undefined;
 				/** See {@link listDefinitionsKeyset}'s `parallelStamps` (#2709). */
@@ -343,13 +341,14 @@ export class Sozluk extends Context.Service<
 		 * Viewer-masked: a term surfaces only when the viewer can read at least one of its
 		 * definitions (#3724), so a sandbox-only term is never a dead-end page.
 		 */
-		readonly listTermSummariesConnection: (opts?: {
-			sort?: ListSort;
-			first?: number;
-			after?: string | null;
-			viewerId?: string | null | undefined;
-			sandboxViewer?: SandboxViewer | undefined;
-		}) => Effect.Effect<TermConnectionPage>;
+		readonly listTermSummariesConnection: (
+			opts: MaskedReadOptions & {
+				sort?: ListSort;
+				first?: number;
+				after?: string | null;
+				viewerId?: string | null | undefined;
+			},
+		) => Effect.Effect<TermConnectionPage>;
 
 		/**
 		 * Public landing terms (#1424), scoped to LIVE content: a term surfaces only via a
@@ -605,12 +604,12 @@ export const SozlukLive = Layer.effect(Sozluk)(
 
 		const getTerm = Effect.fn("Sozluk.getTerm")(function* (
 			slug: string,
-			opts: {viewerId?: string | null | undefined; sandboxViewer?: SandboxViewer | undefined} = {},
+			opts: MaskedReadOptions & {viewerId?: string | null | undefined},
 		) {
 			const meta = yield* run((db) => db.query.termRecord.findFirst({where: {slug}}));
 			if (!meta) return null;
 
-			const viewer = resolveSandboxViewer(opts);
+			const viewer = opts.sandboxViewer;
 			const defs = yield* run((db) =>
 				db
 					.select()
@@ -648,19 +647,18 @@ export const SozlukLive = Layer.effect(Sozluk)(
 
 		const listDefinitionsKeyset = Effect.fn("Sozluk.listDefinitionsKeyset")(function* (
 			slug: string,
-			opts: {
+			opts: MaskedReadOptions & {
 				first?: number | undefined;
 				after?: string | null | undefined;
 				viewerId?: string | null | undefined;
-				sandboxViewer?: SandboxViewer | undefined;
 				mutedIds?: ReadonlySet<string> | undefined;
 				parallelStamps?: boolean | undefined;
-			} = {},
+			},
 		) {
 			const first = Math.max(1, Math.min(opts.first ?? 50, 200));
 			const after = opts.after ?? null;
 			const viewerId = opts.viewerId ?? null;
-			const viewer = resolveSandboxViewer(opts);
+			const viewer = opts.sandboxViewer;
 
 			const baseWhere = and(
 				eq(schema.definitionRecord.termSlug, slug),
@@ -742,16 +740,15 @@ export const SozlukLive = Layer.effect(Sozluk)(
 
 		const getDefinitionsByIds = Effect.fn("Sozluk.getDefinitionsByIds")(function* (
 			ids: ReadonlyArray<string>,
-			opts: {
+			opts: MaskedReadOptions & {
 				viewerId?: string | null | undefined;
-				sandboxViewer?: SandboxViewer | undefined;
 				mutedIds?: ReadonlySet<string> | undefined;
 				parallelStamps?: boolean | undefined;
-			} = {},
+			},
 		) {
 			if (ids.length === 0) return [];
 			const viewerId = opts.viewerId ?? null;
-			const viewer = resolveSandboxViewer(opts);
+			const viewer = opts.sandboxViewer;
 			const fetched = yield* run((db) =>
 				db
 					.select()
@@ -837,18 +834,17 @@ export const SozlukLive = Layer.effect(Sozluk)(
 		});
 
 		const listTermSummariesConnection = Effect.fn("Sozluk.listTermSummariesConnection")(function* (
-			opts: {
+			opts: MaskedReadOptions & {
 				sort?: ListSort;
 				first?: number;
 				after?: string | null;
 				viewerId?: string | null | undefined;
-				sandboxViewer?: SandboxViewer | undefined;
-			} = {},
+			},
 		) {
 			const sort = opts.sort ?? "recent";
 			const first = Math.max(1, Math.min(opts.first ?? 20, 100));
 			const after = opts.after ?? null;
-			const viewer = resolveSandboxViewer(opts);
+			const viewer = opts.sandboxViewer;
 
 			// The count carries the SAME mask as the page below: an unmasked `count(*)`
 			// would report terms the page can never yield, so the connection would claim

--- a/apps/web/worker/features/sozluk/definition-reaction-mutation.unit.test.ts
+++ b/apps/web/worker/features/sozluk/definition-reaction-mutation.unit.test.ts
@@ -13,6 +13,7 @@ import {DefinitionId, UserId} from "../../lib/ids.ts";
 import {resolveWire} from "../fate/resolve-wire.testing.ts";
 import {livePublisherFor} from "../fate-live/live-publisher.ts";
 import {Flags} from "../flagship/Flags.ts";
+import {inPlaceVisibilityStores, moderatorAxisLayer} from "../kunye/sandbox.testing.ts";
 import {EMPTY_REACTION_AGGREGATE} from "../reaction/Reaction.ts";
 import {mutations} from "./mutations.ts";
 import type {DefinitionRow, ReactDefinitionInput} from "./Sozluk.ts";
@@ -82,6 +83,12 @@ const requestCtx = (
 		sozluk,
 		flagsStub(on),
 		liveStub,
+		// The inert (flag-off) branch re-resolves the definition through the real sandbox
+		// viewer (#6586), so both axes it probes have to be on the context. `flagsStub`
+		// answers every key with `on`, so the çaylak tier is what keeps the in-place axis
+		// `false` when this file's own flag is ON.
+		moderatorAxisLayer({viewerId: user?.id ?? "anon", isModerator: false}),
+		inPlaceVisibilityStores({tier: "çaylak"}),
 		Layer.succeed(CurrentUser, {user}),
 		Layer.succeed(RuntimeContext, runtimeContextStub),
 	);

--- a/apps/web/worker/features/sozluk/definition-stamp-wave.unit.test.ts
+++ b/apps/web/worker/features/sozluk/definition-stamp-wave.unit.test.ts
@@ -8,6 +8,7 @@ import {Effect, Layer} from "effect";
 import type {Concurrency} from "effect/Types";
 import {Drizzle, type DrizzleAccess, type DrizzleDb} from "../../db/Drizzle.ts";
 import type {ReactionEmoji} from "../../db/reaction-emoji.ts";
+import {memberSandboxViewer} from "../kunye/sandbox.testing.ts";
 import {makePasaportStub} from "../pasaport/Pasaport.testing.ts";
 import {Reaction, type ReactionAggregate} from "../reaction/Reaction.ts";
 import {Vote} from "../vote/Vote.ts";
@@ -96,6 +97,7 @@ describe("Sozluk.getDefinitionsByIds — stamp-wave behavior equivalence (#2709)
 				const sozluk = yield* Sozluk;
 				return yield* sozluk.getDefinitionsByIds(["d1", "d2"], {
 					viewerId: "viewer-1",
+					sandboxViewer: memberSandboxViewer("viewer-1"),
 					parallelStamps: false,
 				});
 			}).pipe(Effect.provide(sozlukLayer(byIdAccess(), serialCalls)));
@@ -104,6 +106,7 @@ describe("Sozluk.getDefinitionsByIds — stamp-wave behavior equivalence (#2709)
 				const sozluk = yield* Sozluk;
 				return yield* sozluk.getDefinitionsByIds(["d1", "d2"], {
 					viewerId: "viewer-1",
+					sandboxViewer: memberSandboxViewer("viewer-1"),
 					parallelStamps: true,
 				});
 			}).pipe(Effect.provide(sozlukLayer(byIdAccess(), parallelCalls)));
@@ -129,16 +132,27 @@ describe("Sozluk.getDefinitionsByIds — stamp-wave behavior equivalence (#2709)
 		return Effect.gen(function* () {
 			yield* Effect.gen(function* () {
 				const sozluk = yield* Sozluk;
-				yield* sozluk.getDefinitionsByIds(["d1"], {viewerId: "v", parallelStamps: true});
+				yield* sozluk.getDefinitionsByIds(["d1"], {
+					viewerId: "v",
+					sandboxViewer: memberSandboxViewer("v"),
+					parallelStamps: true,
+				});
 			}).pipe(Effect.provide(sozlukLayer(byIdAccess(), onCalls)));
 			yield* Effect.gen(function* () {
 				const sozluk = yield* Sozluk;
-				yield* sozluk.getDefinitionsByIds(["d1"], {viewerId: "v", parallelStamps: false});
+				yield* sozluk.getDefinitionsByIds(["d1"], {
+					viewerId: "v",
+					sandboxViewer: memberSandboxViewer("v"),
+					parallelStamps: false,
+				});
 			}).pipe(Effect.provide(sozlukLayer(byIdAccess(), offCalls)));
 			yield* Effect.gen(function* () {
 				const sozluk = yield* Sozluk;
 				// No `parallelStamps` → the default-off path (today's behavior).
-				yield* sozluk.getDefinitionsByIds(["d1"], {viewerId: "v"});
+				yield* sozluk.getDefinitionsByIds(["d1"], {
+					viewerId: "v",
+					sandboxViewer: memberSandboxViewer("v"),
+				});
 			}).pipe(Effect.provide(sozlukLayer(byIdAccess(), offCalls)));
 
 			assert.deepStrictEqual(onCalls, [{concurrency: "unbounded"}], "flag on → unbounded");
@@ -167,6 +181,7 @@ describe("Sozluk.listDefinitionsKeyset — stamp-wave behavior equivalence (#270
 					return yield* sozluk.listDefinitionsKeyset("a-term", {
 						first: 10,
 						viewerId: "viewer-1",
+						sandboxViewer: memberSandboxViewer("viewer-1"),
 						parallelStamps: false,
 					});
 				}).pipe(Effect.provide(sozlukLayer(keysetAccess(), serialCalls)));
@@ -176,6 +191,7 @@ describe("Sozluk.listDefinitionsKeyset — stamp-wave behavior equivalence (#270
 					return yield* sozluk.listDefinitionsKeyset("a-term", {
 						first: 10,
 						viewerId: "viewer-1",
+						sandboxViewer: memberSandboxViewer("viewer-1"),
 						parallelStamps: true,
 					});
 				}).pipe(Effect.provide(sozlukLayer(keysetAccess(), parallelCalls)));

--- a/apps/web/worker/features/sozluk/mutation-definition-reread-viewer.unit.test.ts
+++ b/apps/web/worker/features/sozluk/mutation-definition-reread-viewer.unit.test.ts
@@ -1,0 +1,168 @@
+/**
+ * The two sözlük by-id definition re-reads carry the resolved `SandboxViewer` (#6586) —
+ * `definition.react`'s flag-off inert re-read and `definition.edit`'s stamp read.
+ *
+ * `Sozluk.getDefinitionsByIds` masks on the sandbox dimension, so a degraded
+ * `{viewerId}`-only viewer drops another author's still-sandboxed row and
+ * `definition.react` answers `DefinitionNotFound` for an opted-in in-place yazar reading a
+ * row their own term page shows them. `definition.edit` is author-only, so no viewer class
+ * beyond the author can reach it — what is asserted there is the threading itself, the way
+ * the pano twins were widened in #6424.
+ *
+ * The two flags are answered per key rather than alike: this file needs
+ * `phoenix-reactions` OFF (to reach the inert branch) while `phoenix-caylak-visibility` is
+ * ON (to resolve the in-place viewer), which one shared answer cannot express.
+ */
+import {assert, describe, it} from "@effect/vitest";
+import {CurrentUser, LivePublisher} from "@kampus/fate-effect";
+import {type BaseRuntimeContext, RuntimeContext} from "alchemy";
+import {Effect, Layer} from "effect";
+import {PHOENIX_CAYLAK_VISIBILITY} from "../../../src/flags/keys.ts";
+import {resolveWire} from "../fate/resolve-wire.testing.ts";
+import {livePublisherFor} from "../fate-live/live-publisher.ts";
+import {Flags} from "../flagship/Flags.ts";
+import {RequestFlagOverrides} from "../flagship/FlagsContext.ts";
+import {inPlaceVisibilityStores, moderatorAxisLayer} from "../kunye/sandbox.testing.ts";
+import {
+	lifecycleVisibilityRule,
+	ruleVisibleTo,
+	type SandboxViewer,
+} from "../lifecycle/EntityLifecycle.ts";
+import type {DefinitionRow} from "./definition-fields.ts";
+import {mutations} from "./mutations.ts";
+import {Sozluk} from "./Sozluk.ts";
+
+const AUTHOR_ID = "u-caylak";
+const VIEWER = {id: "u-yazar", email: "yazar@kamp.us", name: "yazar"};
+const DEFINITION_ID = "def_sb1";
+const OPTED_IN_AT = new Date("2026-08-19T00:00:00.000Z");
+
+const runtimeContextStub: BaseRuntimeContext = {
+	Type: "mutation-definition-reread-viewer",
+	id: "mutation-definition-reread-viewer",
+	env: {},
+	get: () => Effect.succeed(undefined),
+	set: (id) => Effect.succeed(id),
+};
+
+/** Another author's still-sandboxed definition: only the in-place axis reaches it. */
+const sandboxedDefinition: DefinitionRow = {
+	id: DEFINITION_ID,
+	body: "tanım",
+	score: 3,
+	author: "çaylak",
+	authorId: AUTHOR_ID,
+	createdAt: new Date("2026-01-01T00:00:00Z"),
+	updatedAt: new Date("2026-01-01T00:00:00Z"),
+	myVote: true,
+};
+
+const noopLive = Layer.succeed(LivePublisher)(
+	livePublisherFor({publish: () => Effect.void, waitUntil: () => {}}),
+);
+
+// `phoenix-reactions` stays off (the inert branch); `phoenix-caylak-visibility` follows
+// the case under test.
+const flagsFor = (caylakVisibility: boolean): Layer.Layer<Flags | RequestFlagOverrides> =>
+	Layer.mergeAll(
+		Layer.succeed(Flags, {
+			getBoolean: (key: string) =>
+				Effect.succeed(key === PHOENIX_CAYLAK_VISIBILITY && caylakVisibility),
+			getString: () => Effect.die("getString not exercised"),
+			getNumber: () => Effect.die("getNumber not exercised"),
+			getObject: () => Effect.die("getObject not exercised"),
+		} as typeof Flags.Service),
+		Layer.succeed(RequestFlagOverrides, {cookieHeader: null, overridesAllowed: false}),
+	);
+
+/**
+ * `getDefinitionsByIds` applies the REAL sandbox rule to the viewer it was handed and
+ * records it, so one context serves both the behavioural and the threading assertion.
+ */
+const contextFor = (optedIn: boolean, seen: SandboxViewer[]) =>
+	Layer.mergeAll(
+		// biome-ignore lint/plugin: a service double — the write is scripted and only the by-id re-read is under test.
+		Layer.succeed(Sozluk, {
+			editDefinition: () =>
+				Effect.succeed({
+					definitionId: DEFINITION_ID,
+					score: sandboxedDefinition.score,
+					body: sandboxedDefinition.body,
+					authorId: AUTHOR_ID,
+					authorName: "çaylak",
+					createdAt: sandboxedDefinition.createdAt,
+					updatedAt: sandboxedDefinition.updatedAt,
+				}),
+			getDefinitionsByIds: (_ids: ReadonlyArray<string>, opts: {sandboxViewer: SandboxViewer}) =>
+				Effect.sync(() => {
+					seen.push(opts.sandboxViewer);
+					return ruleVisibleTo(
+						lifecycleVisibilityRule.Sandboxed,
+						sandboxedDefinition.authorId,
+						opts.sandboxViewer,
+					)
+						? [sandboxedDefinition]
+						: [];
+				}),
+		} as unknown as typeof Sozluk.Service),
+		noopLive,
+		flagsFor(optedIn),
+		moderatorAxisLayer({viewerId: VIEWER.id, isModerator: false}),
+		inPlaceVisibilityStores(
+			optedIn ? {tier: "yazar", preference: {optedIn: true, setAt: OPTED_IN_AT}} : {},
+		),
+		Layer.succeed(CurrentUser, {user: VIEWER}),
+		Layer.succeed(RuntimeContext, runtimeContextStub),
+	);
+
+const react = (optedIn: boolean, seen: SandboxViewer[]) =>
+	resolveWire(mutations["definition.react"], {
+		input: {id: DEFINITION_ID, emoji: null},
+		select: ["id"],
+	}).pipe(Effect.provide(contextFor(optedIn, seen)));
+
+const edit = (optedIn: boolean, seen: SandboxViewer[]) =>
+	resolveWire(mutations["definition.edit"], {
+		input: {id: DEFINITION_ID, body: "yeni tanım"},
+		select: ["id"],
+	}).pipe(Effect.provide(contextFor(optedIn, seen)));
+
+describe("the sözlük by-id definition re-reads carry the resolved viewer (#6586)", () => {
+	it.effect("definition.react's inert re-read returns the row to an opted-in in-place yazar", () =>
+		Effect.gen(function* () {
+			const seen: SandboxViewer[] = [];
+			const definition = yield* react(true, seen);
+			assert.strictEqual(definition?.id, DEFINITION_ID);
+			assert.deepStrictEqual(seen[0], {
+				viewerId: VIEWER.id,
+				canSeeSandboxed: false,
+				seesSandboxedInPlace: true,
+			});
+		}),
+	);
+
+	it.effect("definition.react's inert re-read still masks the row from a plain yazar", () =>
+		Effect.gen(function* () {
+			const seen: SandboxViewer[] = [];
+			const exit = yield* react(false, seen).pipe(Effect.exit);
+			assert.isTrue(exit._tag === "Failure", "a masked row is DEFINITION_NOT_FOUND");
+			assert.deepStrictEqual(seen[0], {
+				viewerId: VIEWER.id,
+				canSeeSandboxed: false,
+				seesSandboxedInPlace: false,
+			});
+		}),
+	);
+
+	it.effect("definition.edit's stamp read is handed the resolved viewer, not a degraded one", () =>
+		Effect.gen(function* () {
+			const seen: SandboxViewer[] = [];
+			yield* edit(true, seen);
+			assert.deepStrictEqual(seen[0], {
+				viewerId: VIEWER.id,
+				canSeeSandboxed: false,
+				seesSandboxedInPlace: true,
+			});
+		}),
+	);
+});

--- a/apps/web/worker/features/sozluk/mutation-term-reread-viewer.unit.test.ts
+++ b/apps/web/worker/features/sozluk/mutation-term-reread-viewer.unit.test.ts
@@ -1,15 +1,18 @@
 /**
- * The parent-term re-read in `definition.delete` and `definition.restore` carries the acting
- * author's identity (#6473).
+ * The parent-term re-read in `definition.delete` and `definition.restore` carries the
+ * viewer the request resolved — the author (#6473) and the opted-in in-place yazar (#6586).
  *
  * `Sozluk.getTerm` masks the term's definitions on the sandbox dimension, so a re-read handed
- * no viewer resolved anonymously and dropped the author's own still-sandboxed rows: the
- * returned `Term` under-counted them, and `definition.restore`'s `page.definitions.find` then
- * missed the row it had just restored, skipping the term-topic re-append.
+ * a degraded viewer dropped every sandboxed row it should have kept: the author's own
+ * (`{viewerId}` alone still resolved that arm) and, for the #6423 in-place class, another
+ * author's — the returned `Term` under-counted them, and `definition.restore`'s
+ * `page.definitions.find` then missed the row it had just restored, skipping the term-topic
+ * re-append.
  *
  * The term row itself is never sandboxed, so — unlike the pano handlers this shares an issue
  * with — the page comes back non-null either way; what moves is which definitions it carries.
- * The stub filters through the real `lifecycleVisibilityRule` rather than restating the mask.
+ * The stub filters through the real `lifecycleVisibilityRule` rather than restating the mask,
+ * and the viewer reaches it through the real resolver rather than a hand-built one.
  */
 import {assert, describe, it} from "@effect/vitest";
 import {CurrentUser, LivePublisher} from "@kampus/fate-effect";
@@ -17,12 +20,12 @@ import {type BaseRuntimeContext, RuntimeContext} from "alchemy";
 import {Effect, Layer} from "effect";
 import {resolveWire} from "../fate/resolve-wire.testing.ts";
 import {livePublisherFor} from "../fate-live/live-publisher.ts";
+import {sandboxViewerLayer} from "../kunye/sandbox.testing.ts";
 import {
 	lifecycleVisibilityRule,
 	ruleVisibleTo,
 	type SandboxViewer,
 } from "../lifecycle/EntityLifecycle.ts";
-import {resolveSandboxViewer} from "../lifecycle/SandboxVisibility.ts";
 import type {DefinitionRow, TermPage} from "./definition-fields.ts";
 import {mutations} from "./mutations.ts";
 import {Sozluk} from "./Sozluk.ts";
@@ -31,6 +34,7 @@ const AUTHOR = {id: "u-caylak", email: "caylak@kamp.us", name: "çaylak"};
 const OTHER_MEMBER = {id: "u-yazar", email: "yazar@kamp.us", name: "yazar"};
 const SLUG = "kamp-us";
 const DEFINITION_ID = "def_sb1";
+const OPTED_IN_AT = new Date("2026-08-19T00:00:00.000Z");
 
 const runtimeContextStub: BaseRuntimeContext = {
 	Type: "mutation-term-reread-viewer",
@@ -66,11 +70,29 @@ const noopLive = Layer.succeed(LivePublisher)(
 	livePublisherFor({publish: () => Effect.void, waitUntil: () => {}}),
 );
 
+type Axes = Parameters<typeof sandboxViewerLayer>[0];
+
+/** A signed-in member with the çaylak-visibility flag off: no in-place widening exists yet. */
+const plainMember = (user: typeof AUTHOR): Axes => ({
+	flagOn: false,
+	viewerId: user.id,
+	isModerator: false,
+});
+
+/** The #6423 third class: a yazar who opted in to reading çaylak work in place. */
+const optedInYazar = (user: typeof AUTHOR): Axes => ({
+	flagOn: true,
+	tier: "yazar",
+	preference: {optedIn: true, setAt: OPTED_IN_AT},
+	viewerId: user.id,
+	isModerator: false,
+});
+
 /**
  * Every service the two handlers reach. `getTerm` applies the REAL sandbox rule to the viewer
- * the call site resolved, so a call that omits the viewer masks exactly as D1 does.
+ * it was handed, so a handler that hands it a degraded one masks exactly as D1 does.
  */
-const contextFor = (user: typeof AUTHOR) =>
+const contextFor = (user: typeof AUTHOR, axes: Axes) =>
 	Layer.mergeAll(
 		// biome-ignore lint/plugin: a service double — the writes are scripted and only the term re-read is under test.
 		Layer.succeed(Sozluk, {
@@ -78,17 +100,17 @@ const contextFor = (user: typeof AUTHOR) =>
 			deleteDefinition: () => Effect.succeed({definitionId: DEFINITION_ID, deleted: true}),
 			restoreDefinition: () =>
 				Effect.succeed({definitionId: DEFINITION_ID, deleted: false, sandboxedAt: new Date()}),
-			getTerm: (_slug: string, opts?: {viewerId?: string | null; sandboxViewer?: SandboxViewer}) =>
-				Effect.sync(() => {
-					const viewer = resolveSandboxViewer(opts ?? {});
-					return termPageFor(
+			getTerm: (_slug: string, opts: {sandboxViewer: SandboxViewer}) =>
+				Effect.sync(() =>
+					termPageFor(
 						[sandboxedDefinition].filter((d) =>
-							ruleVisibleTo(lifecycleVisibilityRule.Sandboxed, d.authorId, viewer),
+							ruleVisibleTo(lifecycleVisibilityRule.Sandboxed, d.authorId, opts.sandboxViewer),
 						),
-					);
-				}),
+					),
+				),
 		} as unknown as typeof Sozluk.Service),
 		noopLive,
+		sandboxViewerLayer(axes),
 		Layer.succeed(CurrentUser, {user}),
 		Layer.succeed(RuntimeContext, runtimeContextStub),
 	);
@@ -114,11 +136,11 @@ const HANDLERS = [
 	},
 ] as const;
 
-describe("the sözlük term re-reads carry the acting author (#6473)", () => {
+describe("the sözlük term re-reads carry the resolved viewer (#6473, #6586)", () => {
 	for (const handler of HANDLERS) {
 		it.effect(`${handler.name} returns a term page carrying the author's own sandboxed row`, () =>
 			Effect.gen(function* () {
-				const term = yield* handler.run(contextFor(AUTHOR));
+				const term = yield* handler.run(contextFor(AUTHOR, plainMember(AUTHOR)));
 				assert.isNotNull(term, `${handler.name} answered null on a write that landed`);
 				assert.strictEqual(term?.count, 1);
 			}),
@@ -126,7 +148,17 @@ describe("the sözlük term re-reads carry the acting author (#6473)", () => {
 
 		it.effect(`${handler.name} still masks the sandboxed row from another member`, () =>
 			Effect.gen(function* () {
-				assert.strictEqual((yield* handler.run(contextFor(OTHER_MEMBER)))?.count, 0);
+				const term = yield* handler.run(contextFor(OTHER_MEMBER, plainMember(OTHER_MEMBER)));
+				assert.strictEqual(term?.count, 0);
+			}),
+		);
+
+		// The count is computed off the masked list, so a degraded viewer here answers a
+		// count that excludes rows the same viewer's ordinary term page shows them.
+		it.effect(`${handler.name} counts the sandboxed row for an opted-in in-place yazar`, () =>
+			Effect.gen(function* () {
+				const term = yield* handler.run(contextFor(OTHER_MEMBER, optedInYazar(OTHER_MEMBER)));
+				assert.strictEqual(term?.count, 1);
 			}),
 		);
 	}

--- a/apps/web/worker/features/sozluk/mutations.ts
+++ b/apps/web/worker/features/sozluk/mutations.ts
@@ -20,7 +20,7 @@ import {Flags} from "../flagship/Flags.ts";
 import {provideRequestFlags} from "../flagship/FlagsContext.ts";
 import {InsufficientKarma} from "../kunye/errors.ts";
 import {gateContentOnKarma} from "../kunye/privilege.ts";
-import {decidePublish, sandboxedAtForAuthor} from "../kunye/sandbox.ts";
+import {currentSandboxViewer, decidePublish, sandboxedAtForAuthor} from "../kunye/sandbox.ts";
 import {authorDisplayLabel} from "../pasaport/author-label.ts";
 import {SelfVoteNotAllowed, VoterNotEligible} from "../vote/errors.ts";
 import {
@@ -183,7 +183,11 @@ export const mutations = {
 			const flags = yield* Flags;
 			const on = yield* flags.getBoolean(PHOENIX_REACTIONS, false).pipe(provideRequestFlags);
 			if (!on) {
-				const [current] = yield* sozluk.getDefinitionsByIds([input.id], {viewerId: user.id});
+				const sandboxViewer = yield* currentSandboxViewer;
+				const [current] = yield* sozluk.getDefinitionsByIds([input.id], {
+					viewerId: user.id,
+					sandboxViewer,
+				});
 				if (!current) {
 					return yield* new DefinitionNotFound({
 						definitionId: input.id,
@@ -227,7 +231,11 @@ export const mutations = {
 				body: input.body,
 			});
 			// Re-read the viewer's vote so the edit doesn't blank `myVote`.
-			const [fresh] = yield* sozluk.getDefinitionsByIds([result.definitionId], {viewerId: user.id});
+			const sandboxViewer = yield* currentSandboxViewer;
+			const [fresh] = yield* sozluk.getDefinitionsByIds([result.definitionId], {
+				viewerId: user.id,
+				sandboxViewer,
+			});
 			const definition = shapeDefinition({...result, myVote: fresh?.myVote ?? null});
 			yield* live.definition.update(definition.id, {changed: ["body"], data: definition});
 			return definition;
@@ -252,7 +260,8 @@ export const mutations = {
 				yield* live.definition.term(slug).deleteEdge(input.id);
 			}
 			if (!slug) return null;
-			const page = yield* sozluk.getTerm(slug, {viewerId: user.id});
+			const sandboxViewer = yield* currentSandboxViewer;
+			const page = yield* sozluk.getTerm(slug, {viewerId: user.id, sandboxViewer});
 			if (!page) return null;
 			return toTermFromPage(page);
 		}),
@@ -275,7 +284,8 @@ export const mutations = {
 			});
 			const slug = yield* sozluk.lookupDefinitionTermSlug(input.id);
 			if (!slug) return null;
-			const page = yield* sozluk.getTerm(slug, {viewerId: user.id});
+			const sandboxViewer = yield* currentSandboxViewer;
+			const page = yield* sozluk.getTerm(slug, {viewerId: user.id, sandboxViewer});
 			if (!page) return null;
 			const restored = page.definitions.find((d) => d.id === input.id);
 			if (restored) {

--- a/apps/web/worker/features/sozluk/term-list-sandbox.unit.test.ts
+++ b/apps/web/worker/features/sozluk/term-list-sandbox.unit.test.ts
@@ -12,6 +12,7 @@ import {drizzle} from "drizzle-orm/d1";
 import {Effect, Layer} from "effect";
 import {Drizzle, type DrizzleAccess, type DrizzleDb, relations} from "../../db/Drizzle.ts";
 import type {SandboxViewer} from "../lifecycle/EntityLifecycle.ts";
+import {resolveSandboxViewer} from "../lifecycle/SandboxVisibility.ts";
 import {PasaportIdentityStub} from "../pasaport/Pasaport.testing.ts";
 import {ReactionStub} from "../reaction/Reaction.testing.ts";
 import {Vote} from "../vote/Vote.ts";
@@ -106,7 +107,10 @@ const runList = (opts: {
 		);
 		yield* Effect.gen(function* () {
 			const sozluk = yield* Sozluk;
-			yield* sozluk.listTermSummariesConnection(opts);
+			yield* sozluk.listTermSummariesConnection({
+				...opts,
+				sandboxViewer: resolveSandboxViewer(opts),
+			});
 		}).pipe(Effect.provide(sozlukLayer(access)));
 
 		const count = prepared[0];


### PR DESCRIPTION
Fixes #6586

A mutation's masked re-read that was handed a `{viewerId}`-only viewer degraded to
"neither moderator nor in-place reader", so it dropped the very row the write had just
committed. Seven such reads still did that: the five parent-page re-reads in
`post.restore` / `comment.delete` / `comment.restore` / `definition.delete` /
`definition.restore`, plus `definition.react`'s inert re-read and `definition.edit`'s stamp
read. Each now threads the resolved `sandboxViewer` the way its siblings already did.

Rather than leave the omission greppable, the masked Pano and Sözlük reads now take the
viewer as a **required** field — `MaskedReadOptions` in
`apps/web/worker/features/lifecycle/SandboxVisibility.ts`. Omitting it is a compile error;
anonymity is still available, but you write `sandboxViewer: anonymousViewer` and mean it.
That is what pulled the other call sites into the diff: every production read already passed
a resolved viewer, so the change there is the type, not the behaviour. `resolveSandboxViewer`
survives for `Pasaport`'s profile reads, which are shaped by the profile being viewed rather
than by a resolved reader.

Inert until `PHOENIX_CAYLAK_VISIBILITY` is on, as the issue says.

Tests: `mutation-parent-reread-viewer` and `mutation-term-reread-viewer` gain the in-place
arm (an opted-in yazar acting on another author's still-sandboxed row gets the entity, and a
count including it, instead of `null` / `0`), and a new
`sozluk/mutation-definition-reread-viewer.unit.test.ts` covers the two by-id sözlük reads.
1742 worker unit tests pass.

Reviewer's first stop: the two `.patterns/` edits and the `MaskedReadOptions` docblock — the
containment doc's "a gated read still has to say who it is" section described a world where
you *could* pass no viewer, which is no longer true.

## Deviations

- **Out-of-scope change** — **Said:** #6586 names seven reads across `pano/mutations.ts`
  and `sozluk/mutations.ts`. **Did:** also widened `post.edit`'s and `comment.edit`'s
  `myVote` re-reads, and `comment.restore`'s `getCommentsByIds`. **Why:** making the viewer
  required means every remaining call site had to state one, and for these the honest
  statement is the resolved viewer their handler already had — passing an explicitly
  degraded one instead would have re-introduced the defect under a longer name. The edit
  paths are author-only, so no behaviour moves there; `comment.restore`'s comment read is
  the same in-place defect as the parent-post read beside it. **Disposition:** stated here.
- **Out-of-scope change** — **Said:** the issue lists resolver-level reads. **Did:**
  `Pano.reactToPost` / `reactToComment` now take a `sandboxViewer` on their input and hand
  it to their own post-write re-read (`post-operations.ts:1143`,
  `comment-operations.ts:855`). **Why:** those two service-internal reads are the same
  degraded shape and the required type surfaced them. #6424 widened `post.react`'s inert
  branch but not the live branch, which lands in this read — so an in-place yazar reacting
  to a sandboxed post still got `PostNotFound` on a react that committed. **Disposition:** stated here.
- **Scope narrowing** — **Said:** "make the masked read take a resolved viewer".
  **Did:** applied it to the Pano and Sözlük read surfaces only. **Why:** `Pasaport`'s
  contribution/profile reads take their viewer from a different derivation and are not in
  the write-then-re-read defect class; folding them in would have doubled the diff without
  closing anything this issue names. **Disposition:** stated here; `resolveSandboxViewer`'s
  docblock names the remaining caller so it is not silent.
- **Pre-existing test or fixture changed** — **Said:** nothing about the SQL-golden and
  stamp-wave tests. **Did:** added an explicit `sandboxViewer` to ~35 call sites across nine
  test files, and put the sandbox-viewer layers on four resolver tests that now resolve a
  viewer. **Why:** the required field forces it. The value passed is the one
  `resolveSandboxViewer` used to synthesize for that call (`anonymousViewer`, or
  `memberSandboxViewer(viewerId)`), so every golden SQL assertion is unchanged. **Disposition:** stated here.
